### PR TITLE
serverutils: improve the initialization of TestServer

### DIFF
--- a/docs/RFCS/20210723_metrics_update.md
+++ b/docs/RFCS/20210723_metrics_update.md
@@ -527,7 +527,7 @@ func (ts *TestServer) MustGetMetricRule(name string) metric.Rule {
 // Within a unit test.
 func UnitTestMetricRule() {
 	params, _ := tests.CreateTestServerParams()
-	s, _, _ := serverutils.StartServer(t, params)
+	s := serverutils.StartServerOnly(t, params)
 	defer s.Stopper().Stop(context.Background())
 	rule = s.MustGetMetricRule("rule_name")
 	require.NotNil(rule)

--- a/pkg/bench/pgbench_test.go
+++ b/pkg/bench/pgbench_test.go
@@ -109,7 +109,7 @@ func execPgbench(b *testing.B, pgURL url.URL) {
 func BenchmarkPgbenchExec(b *testing.B) {
 	defer log.Scope(b).Close(b)
 	b.Run("Cockroach", func(b *testing.B) {
-		s, _, _ := serverutils.StartServer(b, base.TestServerArgs{Insecure: true})
+		s := serverutils.StartServerOnly(b, base.TestServerArgs{Insecure: true})
 		defer s.Stopper().Stop(context.Background())
 
 		pgURL, cleanupFn := sqlutils.PGUrl(

--- a/pkg/ccl/backupccl/restore_progress_test.go
+++ b/pkg/ccl/backupccl/restore_progress_test.go
@@ -33,7 +33,7 @@ import (
 func TestProgressTracker(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	ctx := context.Background()
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
 
 	execCfg := s.ExecutorConfig().(sql.ExecutorConfig)

--- a/pkg/ccl/backupccl/restore_span_covering_test.go
+++ b/pkg/ccl/backupccl/restore_span_covering_test.go
@@ -585,7 +585,7 @@ func TestRestoreEntryCoverExample(t *testing.T) {
 func TestFileSpanStartKeyIterator(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	ctx := context.Background()
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
 
 	execCfg := s.ExecutorConfig().(sql.ExecutorConfig)
@@ -698,7 +698,7 @@ func TestFileSpanStartKeyIterator(t *testing.T) {
 func TestCheckpointFilter(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	ctx := context.Background()
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
 
 	execCfg := s.ExecutorConfig().(sql.ExecutorConfig)

--- a/pkg/ccl/importerccl/ccl_test.go
+++ b/pkg/ccl/importerccl/ccl_test.go
@@ -387,7 +387,7 @@ func TestExportInsideTenant(t *testing.T) {
 	dir, cleanupDir := testutils.TempDir(t)
 	defer cleanupDir()
 
-	srv, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+	srv := serverutils.StartServerOnly(t, base.TestServerArgs{
 		DefaultTestTenant: base.TestTenantProbabilistic,
 		ExternalIODir:     dir,
 	})

--- a/pkg/ccl/jwtauthccl/authentication_jwt_test.go
+++ b/pkg/ccl/jwtauthccl/authentication_jwt_test.go
@@ -123,7 +123,7 @@ func TestJWTEnabledCheck(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
 	identMapString := ""
 	identMap, err := identmap.From(strings.NewReader(identMapString))
@@ -149,7 +149,7 @@ func TestJWTSingleKey(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
 	identMapString := ""
 	identMap, err := identmap.From(strings.NewReader(identMapString))
@@ -180,7 +180,7 @@ func TestJWTSingleKeyWithoutKeyAlgorithm(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
 	identMapString := ""
 	identMap, err := identmap.From(strings.NewReader(identMapString))
@@ -213,7 +213,7 @@ func TestJWTMultiKey(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
 	identMapString := ""
 	identMap, err := identmap.From(strings.NewReader(identMapString))
@@ -248,7 +248,7 @@ func TestExpiredToken(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
 	identMapString := ""
 	identMap, err := identmap.From(strings.NewReader(identMapString))
@@ -270,7 +270,7 @@ func TestKeyIdMismatch(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
 	identMapString := ""
 	identMap, err := identmap.From(strings.NewReader(identMapString))
@@ -301,7 +301,7 @@ func TestIssuerCheck(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
 	identMapString := ""
 	identMap, err := identmap.From(strings.NewReader(identMapString))
@@ -344,7 +344,7 @@ func TestSubjectCheck(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
 	identMapString := ""
 	identMap, err := identmap.From(strings.NewReader(identMapString))
@@ -374,7 +374,7 @@ func TestClaimMissing(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
 	identMapString := ""
 	identMap, err := identmap.From(strings.NewReader(identMapString))
@@ -399,7 +399,7 @@ func TestIntegerClaimValue(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
 	// map the value 1 to a valid user
 	identMapString := issuer2 + "     1    " + username1
@@ -425,7 +425,7 @@ func TestSingleClaim(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
 	identMapString := ""
 	identMap, err := identmap.From(strings.NewReader(identMapString))
@@ -456,7 +456,7 @@ func TestMultipleClaim(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
 	identMapString := ""
 	identMap, err := identmap.From(strings.NewReader(identMapString))
@@ -489,7 +489,7 @@ func TestSubjectMappingCheck(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
 	// Create a map for issuer2 from username1 to username2 (note not the reverse).
 	identMapString := issuer2 + "    " + username1 + "    " + username2
@@ -524,7 +524,7 @@ func TestSubjectReservedUser(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
 	// Create a map for issuer2 from username1 to username2 (note not the reverse).
 	identMapString := issuer2 + "    " + username1 + "    root"
@@ -553,7 +553,7 @@ func TestAudienceCheck(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
 	identMapString := ""
 	identMap, err := identmap.From(strings.NewReader(identMapString))

--- a/pkg/ccl/multitenantccl/tenantcostclient/tenant_side_test.go
+++ b/pkg/ccl/multitenantccl/tenantcostclient/tenant_side_test.go
@@ -870,7 +870,7 @@ func TestConsumption(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	hostServer, _, _ := serverutils.StartServer(t, base.TestServerArgs{DefaultTestTenant: base.TestControlsTenantsExplicitly})
+	hostServer := serverutils.StartServerOnly(t, base.TestServerArgs{DefaultTestTenant: base.TestControlsTenantsExplicitly})
 	defer hostServer.Stopper().Stop(context.Background())
 
 	const targetPeriod = time.Millisecond
@@ -1020,7 +1020,7 @@ func TestScheduledJobsConsumption(t *testing.T) {
 	stats.AutomaticStatisticsOnSystemTables.Override(ctx, &st.SV, false)
 	tenantcostclient.TargetPeriodSetting.Override(ctx, &st.SV, time.Millisecond*20)
 
-	hostServer, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+	hostServer := serverutils.StartServerOnly(t, base.TestServerArgs{
 		DefaultTestTenant: base.TestControlsTenantsExplicitly,
 		Settings:          st,
 	})

--- a/pkg/ccl/oidcccl/authentication_oidc_test.go
+++ b/pkg/ccl/oidcccl/authentication_oidc_test.go
@@ -48,7 +48,7 @@ func TestOIDCBadRequestIfDisabled(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
 
 	newRPCContext := func(cfg *base.Config) *rpc.Context {

--- a/pkg/ccl/serverccl/admin_test.go
+++ b/pkg/ccl/serverccl/admin_test.go
@@ -172,7 +172,7 @@ func TestListTenants(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{
 		DefaultTestTenant: base.TestControlsTenantsExplicitly,
 	})
 	defer s.Stopper().Stop(ctx)

--- a/pkg/ccl/serverccl/server_controller_test.go
+++ b/pkg/ccl/serverccl/server_controller_test.go
@@ -134,7 +134,7 @@ func TestSharedProcessServerInheritsTempStorageLimit(t *testing.T) {
 	// Start a server with a custom temp storage limit.
 	ctx := context.Background()
 	st := cluster.MakeClusterSettings()
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{
 		Settings:          st,
 		TempStorageConfig: base.DefaultTestTempStorageConfigWithSize(st, specialSize),
 		DefaultTestTenant: base.TestControlsTenantsExplicitly,
@@ -335,7 +335,7 @@ func TestServerControllerDefaultHTTPTenant(t *testing.T) {
 
 	ctx := context.Background()
 
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{
 		DefaultTestTenant: base.TestControlsTenantsExplicitly,
 	})
 	defer s.Stopper().Stop(ctx)
@@ -379,7 +379,7 @@ func TestServerControllerBadHTTPCookies(t *testing.T) {
 
 	ctx := context.Background()
 
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
 
 	client, err := s.GetUnauthenticatedHTTPClient()
@@ -562,7 +562,7 @@ func TestServerControllerLoginLogout(t *testing.T) {
 
 	ctx := context.Background()
 
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
 
 	client, err := s.GetAuthenticatedHTTPClient(false, serverutils.SingleTenantSession)
@@ -583,7 +583,7 @@ func TestServerControllerLoginLogout(t *testing.T) {
 	require.ElementsMatch(t, []string{"", ""}, cookieValues)
 
 	// Need a new server because the HTTP Client is memoized.
-	s2, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s2 := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s2.Stopper().Stop(ctx)
 
 	clientMT, err := s2.GetAuthenticatedHTTPClient(false, serverutils.MultiTenantSession)

--- a/pkg/ccl/serverccl/server_sql_test.go
+++ b/pkg/ccl/serverccl/server_sql_test.go
@@ -102,7 +102,7 @@ func TestTenantCanUseEnterpriseFeatures(t *testing.T) {
 	defer ccl.TestingDisableEnterprise()()
 	defer envutil.TestSetEnv(t, "COCKROACH_TENANT_LICENSE", license)()
 
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{
 		// Note: we can't use `TestTenantAlwaysEnabled` here because
 		// (currently) that requires the enterprise license to be set at
 		// the storage layer, which we just disabled above (because we
@@ -125,7 +125,7 @@ func TestTenantUnauthenticatedAccess(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
 
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{
 		DefaultTestTenant: base.TestControlsTenantsExplicitly,
 	})
 	defer s.Stopper().Stop(ctx)
@@ -150,7 +150,7 @@ func TestTenantHTTP(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
 
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{
 		// This test is specific to secondary tenants; no need to run it
 		// using the system tenant.
 		DefaultTestTenant: base.TestTenantAlwaysEnabled,
@@ -319,7 +319,7 @@ func TestNonExistentTenant(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
 
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{
 		DefaultTestTenant: base.TestControlsTenantsExplicitly,
 	})
 	defer s.Stopper().Stop(ctx)
@@ -382,7 +382,7 @@ func TestTenantInstanceIDReclaimLoop(t *testing.T) {
 	ctx := context.Background()
 
 	clusterSettings := cluster.MakeTestingClusterSettings()
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{
 		Settings:          clusterSettings,
 		DefaultTestTenant: base.TestControlsTenantsExplicitly,
 	})

--- a/pkg/ccl/serverccl/server_startup_guardrails_test.go
+++ b/pkg/ccl/serverccl/server_startup_guardrails_test.go
@@ -83,7 +83,7 @@ func TestServerStartupGuardrails(t *testing.T) {
 				false, /* initializeVersion */
 			)
 
-			s, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+			s := serverutils.StartServerOnly(t, base.TestServerArgs{
 				DefaultTestTenant: base.TestControlsTenantsExplicitly,
 				Settings:          storageSettings,
 				Knobs: base.TestingKnobs{

--- a/pkg/ccl/serverccl/tenant_migration_test.go
+++ b/pkg/ccl/serverccl/tenant_migration_test.go
@@ -83,7 +83,7 @@ func TestValidateTargetTenantClusterVersion(t *testing.T) {
 				false, /* initializeVersion */
 			)
 
-			s, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+			s := serverutils.StartServerOnly(t, base.TestServerArgs{
 				DefaultTestTenant: base.TestControlsTenantsExplicitly,
 				Settings:          st,
 				Knobs: base.TestingKnobs{
@@ -193,7 +193,7 @@ func TestBumpTenantClusterVersion(t *testing.T) {
 				false, /* initializeVersion */
 			)
 
-			s, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+			s := serverutils.StartServerOnly(t, base.TestServerArgs{
 				DefaultTestTenant: base.TestControlsTenantsExplicitly,
 				Settings:          st,
 				Knobs: base.TestingKnobs{

--- a/pkg/ccl/serverccl/tenant_vars_test.go
+++ b/pkg/ccl/serverccl/tenant_vars_test.go
@@ -35,7 +35,7 @@ func TestTenantVars(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	srv, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+	srv := serverutils.StartServerOnly(t, base.TestServerArgs{
 		DefaultTestTenant: base.TestControlsTenantsExplicitly,
 	})
 	defer srv.Stopper().Stop(ctx)

--- a/pkg/ccl/spanconfigccl/spanconfigkvaccessorccl/kvaccessor_test.go
+++ b/pkg/ccl/spanconfigccl/spanconfigkvaccessorccl/kvaccessor_test.go
@@ -37,7 +37,7 @@ func TestCommitTSIntervals(t *testing.T) {
 	manual := hlc.NewHybridManualClock()
 
 	var i interceptor
-	ts, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+	ts := serverutils.StartServerOnly(t, base.TestServerArgs{
 		DefaultTestTenant: base.TestControlsTenantsExplicitly,
 		Knobs: base.TestingKnobs{
 			Server: &server.TestingKnobs{

--- a/pkg/ccl/sqlproxyccl/backend_dialer_test.go
+++ b/pkg/ccl/sqlproxyccl/backend_dialer_test.go
@@ -38,7 +38,7 @@ func TestBackendDialTLSInsecure(t *testing.T) {
 	ctx := context.Background()
 	startupMsg := &pgproto3.StartupMessage{ProtocolVersion: pgproto3.ProtocolVersionNumber}
 
-	sql, _, _ := serverutils.StartServer(t, base.TestServerArgs{Insecure: true})
+	sql := serverutils.StartServerOnly(t, base.TestServerArgs{Insecure: true})
 	defer sql.Stopper().Stop(ctx)
 
 	conn, err := BackendDial(context.Background(), startupMsg, sql.ApplicationLayer().AdvSQLAddr(), &tls.Config{})
@@ -89,7 +89,7 @@ func TestBackendDialTLS(t *testing.T) {
 
 	ctx := context.Background()
 
-	storageServer, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+	storageServer := serverutils.StartServerOnly(t, base.TestServerArgs{
 		Insecure:          false,
 		DefaultTestTenant: base.TestControlsTenantsExplicitly,
 	})

--- a/pkg/ccl/sqlproxyccl/proxy_handler_test.go
+++ b/pkg/ccl/sqlproxyccl/proxy_handler_test.go
@@ -1273,7 +1273,7 @@ func TestDirectoryConnect(t *testing.T) {
 	defer te.Close()
 
 	// Start KV server.
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{
 		DefaultTestTenant: base.TestControlsTenantsExplicitly,
 	})
 	defer s.Stopper().Stop(ctx)
@@ -2315,7 +2315,7 @@ func TestAcceptedConnCountMetric(t *testing.T) {
 	ctx := context.Background()
 
 	// Start KV server.
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{
 		DefaultTestTenant: base.TestControlsTenantsExplicitly,
 	})
 	defer s.Stopper().Stop(ctx)
@@ -2406,7 +2406,7 @@ func TestCurConnCountMetric(t *testing.T) {
 	ctx := context.Background()
 
 	// Start KV server.
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{
 		DefaultTestTenant: base.TestControlsTenantsExplicitly,
 	})
 	defer s.Stopper().Stop(ctx)

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor_test.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor_test.go
@@ -611,7 +611,7 @@ func TestRandomClientGeneration(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	srv, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	srv := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer srv.Stopper().Stop(ctx)
 	registry := srv.JobRegistry().(*jobs.Registry)
 

--- a/pkg/ccl/testccl/sqlccl/tenant_gc_test.go
+++ b/pkg/ccl/testccl/sqlccl/tenant_gc_test.go
@@ -48,7 +48,7 @@ func TestGCTenantRemovesSpanConfigs(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	ts, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+	ts := serverutils.StartServerOnly(t, base.TestServerArgs{
 		DefaultTestTenant: base.TestTenantProbabilistic,
 		Knobs: base.TestingKnobs{
 			SpanConfig: &spanconfig.TestingKnobs{

--- a/pkg/cli/testutils.go
+++ b/pkg/cli/testutils.go
@@ -146,6 +146,8 @@ func newCLITestWithArgs(params TestCLIParams, argsFn func(args *base.TestServerA
 		}
 
 		args := base.TestServerArgs{
+			DefaultTestTenant: base.TestControlsTenantsExplicitly,
+
 			Insecure:      params.Insecure,
 			SSLCertsDir:   c.certsDir,
 			StoreSpecs:    params.StoreSpecs,
@@ -187,11 +189,17 @@ func newCLITestWithArgs(params TestCLIParams, argsFn func(args *base.TestServerA
 		if c.Insecure() {
 			params.TenantArgs.ForceInsecure = true
 		}
-		c.tenant, _ = serverutils.StartTenant(c.t, c.TestServer, *params.TenantArgs)
+		c.tenant, err = c.TestServer.StartTenant(context.Background(), *params.TenantArgs)
+		if err != nil {
+			c.fail(err)
+		}
 	}
 
 	if params.SharedProcessTenantArgs != nil {
-		c.tenant, _ = serverutils.StartSharedProcessTenant(c.t, c.TestServer, *params.SharedProcessTenantArgs)
+		c.tenant, _, err = c.TestServer.StartSharedProcessTenant(context.Background(), *params.SharedProcessTenantArgs)
+		if err != nil {
+			c.fail(err)
+		}
 		c.useSystemTenant = params.UseSystemTenant
 	}
 

--- a/pkg/cli/testutils.go
+++ b/pkg/cli/testutils.go
@@ -165,7 +165,7 @@ func newCLITestWithArgs(params TestCLIParams, argsFn func(args *base.TestServerA
 		if params.NoNodelocal {
 			args.ExternalIODir = ""
 		}
-		s, err := serverutils.StartServerRaw(params.T, args)
+		s, err := serverutils.StartServerOnlyE(params.T, args)
 		if err != nil {
 			c.fail(err)
 		}
@@ -240,7 +240,7 @@ func (c *TestCLI) stopServer() {
 func (c *TestCLI) RestartServer(params TestCLIParams) {
 	c.stopServer()
 	log.Info(context.Background(), "restarting server")
-	s, err := serverutils.StartServerRaw(params.T, base.TestServerArgs{
+	s, err := serverutils.StartServerOnlyE(params.T, base.TestServerArgs{
 		Insecure:    params.Insecure,
 		SSLCertsDir: c.certsDir,
 		StoreSpecs:  params.StoreSpecs,

--- a/pkg/cli/zip_test.go
+++ b/pkg/cli/zip_test.go
@@ -534,7 +534,7 @@ func TestZipRetries(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{Insecure: true})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{Insecure: true})
 	defer s.Stopper().Stop(context.Background())
 
 	dir, cleanupFn := testutils.TempDir(t)

--- a/pkg/cloud/userfile/file_table_storage_test.go
+++ b/pkg/cloud/userfile/file_table_storage_test.go
@@ -41,7 +41,7 @@ func TestPutUserFileTable(t *testing.T) {
 	filename := "path/to/file"
 
 	ctx := context.Background()
-	srv, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	srv := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer srv.Stopper().Stop(ctx)
 	s := srv.ApplicationLayer()
 	testSettings := s.ClusterSettings()

--- a/pkg/cmd/reduce/reduce/reducesql/BUILD.bazel
+++ b/pkg/cmd/reduce/reduce/reducesql/BUILD.bazel
@@ -27,11 +27,8 @@ go_test(
         ":reducesql",
         "//pkg/base",
         "//pkg/cmd/reduce/reduce",
-        "//pkg/security/username",
         "//pkg/server",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/skip",
-        "@com_github_jackc_pgx_v4//:pgx",
-        "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/cmd/reduce/reduce/reducesql/reducesql_test.go
+++ b/pkg/cmd/reduce/reduce/reducesql/reducesql_test.go
@@ -13,18 +13,14 @@ package reducesql_test
 import (
 	"context"
 	"flag"
-	"net/url"
 	"strings"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/cmd/reduce/reduce"
 	"github.com/cockroachdb/cockroach/pkg/cmd/reduce/reduce/reducesql"
-	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
-	"github.com/jackc/pgx/v4"
-	"github.com/stretchr/testify/require"
 )
 
 var printUnknown = flag.Bool("unknown", false, "print unknown types during walk")
@@ -48,22 +44,12 @@ func isInterestingSQL(t *testing.T, contains string) reduce.InterestingFn {
 			Insecure: true,
 		}
 
-		serv, err := serverutils.StartServerRaw(t, args)
-		require.NoError(t, err)
+		serv := serverutils.StartServerOnly(t, args)
 		defer serv.Stopper().Stop(ctx)
 
-		options := url.Values{}
-		options.Add("sslmode", "disable")
-		url := url.URL{
-			Scheme:   "postgres",
-			User:     url.User(username.RootUser),
-			Host:     serv.AdvSQLAddr(),
-			RawQuery: options.Encode(),
-		}
+		db := serv.ApplicationLayer().SQLConn(t, "")
 
-		db, err := pgx.Connect(ctx, url.String())
-		require.NoError(t, err)
-		_, err = db.Exec(ctx, f)
+		_, err := db.Exec(f)
 		if err == nil {
 			return false, nil
 		}

--- a/pkg/configprofiles/datadriven_test.go
+++ b/pkg/configprofiles/datadriven_test.go
@@ -65,7 +65,7 @@ func TestDataDriven(t *testing.T) {
 
 				numExpectedTasks := len(configprofiles.TestingGetProfiles()[setter.String()])
 
-				s, _, _ = serverutils.StartServer(t, base.TestServerArgs{
+				s = serverutils.StartServerOnly(t, base.TestServerArgs{
 					DefaultTestTenant: base.TestControlsTenantsExplicitly,
 
 					AutoConfigProvider: provider,

--- a/pkg/jobs/job_info_storage_test.go
+++ b/pkg/jobs/job_info_storage_test.go
@@ -41,7 +41,7 @@ import (
 func TestJobInfoAccessors(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	ctx := context.Background()
 	defer s.Stopper().Stop(ctx)
 
@@ -243,7 +243,7 @@ func TestAccessorsWithWrongSQLLivenessSession(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	s, _, _ := serverutils.StartServer(t, args)
+	s := serverutils.StartServerOnly(t, args)
 	defer s.Stopper().Stop(ctx)
 	ief := s.InternalDB().(isql.DB)
 

--- a/pkg/jobs/job_scheduler_test.go
+++ b/pkg/jobs/job_scheduler_test.go
@@ -809,7 +809,7 @@ func TestDisablingSchedulerCancelsSchedules(t *testing.T) {
 	knobs := base.TestingKnobs{
 		JobsTestingKnobs: fastDaemonKnobs(overridePaceSetting(10 * time.Millisecond)),
 	}
-	ts, _, _ := serverutils.StartServer(t, base.TestServerArgs{Knobs: knobs})
+	ts := serverutils.StartServerOnly(t, base.TestServerArgs{Knobs: knobs})
 	defer ts.Stopper().Stop(context.Background())
 
 	schedules := ScheduledJobDB(ts.InternalDB().(isql.DB))
@@ -845,7 +845,7 @@ func TestSchedulePlanningRespectsTimeout(t *testing.T) {
 	knobs := base.TestingKnobs{
 		JobsTestingKnobs: fastDaemonKnobs(overridePaceSetting(10 * time.Millisecond)),
 	}
-	ts, _, _ := serverutils.StartServer(t, base.TestServerArgs{Knobs: knobs})
+	ts := serverutils.StartServerOnly(t, base.TestServerArgs{Knobs: knobs})
 	defer ts.Stopper().Stop(context.Background())
 	schedules := ScheduledJobDB(ts.InternalDB().(isql.DB))
 

--- a/pkg/jobs/jobs_test.go
+++ b/pkg/jobs/jobs_test.go
@@ -2558,7 +2558,7 @@ func TestStartableJob(t *testing.T) {
 	defer jobs.ResetConstructors()()
 
 	ctx := context.Background()
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
 	jr := s.JobRegistry().(*jobs.Registry)
 	var resumeFunc atomic.Value
@@ -2753,7 +2753,7 @@ func TestStartableJobTxnRetry(t *testing.T) {
 	params.Knobs.Store = &kvserver.StoreTestingKnobs{
 		TestingRequestFilter: requestFilter,
 	}
-	s, _, _ := serverutils.StartServer(t, params)
+	s := serverutils.StartServerOnly(t, params)
 	defer s.Stopper().Stop(ctx)
 	jr := s.JobRegistry().(*jobs.Registry)
 	jobs.RegisterConstructor(jobspb.TypeRestore, func(job *jobs.Job, settings *cluster.Settings) jobs.Resumer {
@@ -2783,7 +2783,7 @@ func TestRegistryTestingNudgeAdoptionQueue(t *testing.T) {
 
 	ctx := context.Background()
 
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
 	registry := s.JobRegistry().(*jobs.Registry)
 
@@ -3103,7 +3103,7 @@ func TestLoseLeaseDuringExecution(t *testing.T) {
 
 	ctx := context.Background()
 
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{Knobs: knobs})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{Knobs: knobs})
 	defer s.Stopper().Stop(ctx)
 	registry := s.JobRegistry().(*jobs.Registry)
 

--- a/pkg/jobs/jobsprofiler/profiler_test.go
+++ b/pkg/jobs/jobsprofiler/profiler_test.go
@@ -114,7 +114,7 @@ func TestStorePerNodeProcessorProgressFraction(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{
 		Knobs: base.TestingKnobs{
 			JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
 		},

--- a/pkg/jobs/registry_external_test.go
+++ b/pkg/jobs/registry_external_test.go
@@ -51,7 +51,7 @@ func TestRoundtripJob(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	registry := s.JobRegistry().(*jobs.Registry)
 	defer s.Stopper().Stop(ctx)
 

--- a/pkg/jobs/registry_test.go
+++ b/pkg/jobs/registry_test.go
@@ -337,7 +337,7 @@ func TestCreateJobWritesToJobInfo(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	s, _, _ := serverutils.StartServer(t, args)
+	s := serverutils.StartServerOnly(t, args)
 	ief := s.InternalDB().(isql.DB)
 	defer s.Stopper().Stop(ctx)
 	r := s.JobRegistry().(*Registry)
@@ -1196,7 +1196,7 @@ func TestRunWithoutLoop(t *testing.T) {
 	ctx := context.Background()
 	settings := cluster.MakeTestingClusterSettings()
 	intervalBaseSetting.Override(ctx, &settings.SV, 1e6)
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{
 		Settings: settings,
 	})
 
@@ -1418,7 +1418,7 @@ func TestDisablingJobAdoptionClearsClaimSessionID(t *testing.T) {
 func TestJobRecordMissingUsername(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	ctx := context.Background()
 	defer s.Stopper().Stop(ctx)
 

--- a/pkg/jobs/update_test.go
+++ b/pkg/jobs/update_test.go
@@ -58,7 +58,7 @@ func TestUpdaterUpdatesJobInfo(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	s, _, _ := serverutils.StartServer(t, args)
+	s := serverutils.StartServerOnly(t, args)
 	defer s.Stopper().Stop(ctx)
 	ief := s.InternalDB().(isql.DB)
 
@@ -201,7 +201,7 @@ func TestUpdateDoesNotReadPayloadFromJobsTable(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	s, _, _ := serverutils.StartServer(t, args)
+	s := serverutils.StartServerOnly(t, args)
 	defer s.Stopper().Stop(ctx)
 	ief := s.InternalDB().(isql.DB)
 	nullOutPayloadAndProgressInSystemJobs := func() {

--- a/pkg/kv/client_test.go
+++ b/pkg/kv/client_test.go
@@ -124,7 +124,7 @@ func TestClientRetryNonTxn(t *testing.T) {
 			},
 		},
 	}
-	s, _, _ := serverutils.StartServer(t, args)
+	s := serverutils.StartServerOnly(t, args)
 	defer s.Stopper().Stop(context.Background())
 
 	testCases := []struct {
@@ -240,7 +240,7 @@ func TestClientRetryNonTxn(t *testing.T) {
 func TestClientRunTransaction(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(context.Background())
 	db := createTestClient(t, s)
 
@@ -298,7 +298,7 @@ func TestClientRunTransaction(t *testing.T) {
 func TestClientGetAndPutProto(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(context.Background())
 	db := createTestClient(t, s)
 
@@ -328,7 +328,7 @@ func TestClientGetAndPutProto(t *testing.T) {
 func TestClientGetAndPut(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(context.Background())
 	db := createTestClient(t, s)
 
@@ -351,7 +351,7 @@ func TestClientGetAndPut(t *testing.T) {
 func TestClientPutInline(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(context.Background())
 	db := createTestClient(t, s)
 
@@ -375,7 +375,7 @@ func TestClientCPutInline(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
 	db := createTestClient(t, s)
 	key := testUser + "/key"
@@ -444,7 +444,7 @@ func TestClientCPutInline(t *testing.T) {
 func TestClientEmptyValues(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(context.Background())
 	db := createTestClient(t, s)
 
@@ -474,7 +474,7 @@ func TestClientEmptyValues(t *testing.T) {
 func TestClientBatch(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(context.Background())
 	db := createTestClient(t, s)
 	ctx := context.Background()
@@ -731,7 +731,7 @@ func concurrentIncrements(db *kv.DB, t *testing.T) {
 func TestConcurrentIncrements(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(context.Background())
 	db := createTestClient(t, s)
 
@@ -818,7 +818,7 @@ func TestReadConsistencyTypes(t *testing.T) {
 func TestTxn_ReverseScan(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(context.Background())
 	db := createTestClient(t, s)
 

--- a/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
@@ -1811,7 +1811,7 @@ func TestPropagateTxnOnError(t *testing.T) {
 			return nil
 		}
 
-	s, _, _ := serverutils.StartServer(t,
+	s := serverutils.StartServerOnly(t,
 		base.TestServerArgs{Knobs: base.TestingKnobs{Store: &storeKnobs}})
 	ctx := context.Background()
 	defer s.Stopper().Stop(ctx)
@@ -1883,7 +1883,7 @@ func TestPropagateTxnOnError(t *testing.T) {
 func TestTxnStarvation(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	ctx := context.Background()
 	defer s.Stopper().Stop(ctx)
 
@@ -2011,7 +2011,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 		}
 
 	var refreshSpansCondenseFilter atomic.Value
-	s, _, _ := serverutils.StartServer(t,
+	s := serverutils.StartServerOnly(t,
 		base.TestServerArgs{Knobs: base.TestingKnobs{
 			Store: &storeKnobs,
 			KVClient: &kvcoord.ClientTestingKnobs{

--- a/pkg/kv/kvclient/kvstreamer/streamer_test.go
+++ b/pkg/kv/kvclient/kvstreamer/streamer_test.go
@@ -64,7 +64,7 @@ func TestStreamerLimitations(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
 
 	getStreamer := func() *Streamer {

--- a/pkg/kv/kvclient/rangefeed/rangefeedcache/watcher_test.go
+++ b/pkg/kv/kvclient/rangefeed/rangefeedcache/watcher_test.go
@@ -32,7 +32,7 @@ func TestWatchAuthErr(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	host, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+	host := serverutils.StartServerOnly(t, base.TestServerArgs{
 		DefaultTestTenant: base.TestControlsTenantsExplicitly,
 	})
 	defer host.Stopper().Stop(ctx)

--- a/pkg/kv/kvserver/batcheval/cmd_delete_range_gchint_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_delete_range_gchint_test.go
@@ -31,7 +31,7 @@ func TestDeleteRangeTombstoneSetsGCHint(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	serv, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+	serv := serverutils.StartServerOnly(t, base.TestServerArgs{
 		Knobs: base.TestingKnobs{
 			Store: &kvserver.StoreTestingKnobs{
 				DisableMergeQueue: true,

--- a/pkg/kv/kvserver/client_merge_test.go
+++ b/pkg/kv/kvserver/client_merge_test.go
@@ -293,7 +293,7 @@ func mergeWithData(t *testing.T, retries int64) {
 		return nil
 	}
 
-	serv, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+	serv := serverutils.StartServerOnly(t, base.TestServerArgs{
 		Knobs: base.TestingKnobs{
 			Store: &kvserver.StoreTestingKnobs{
 				DisableMergeQueue:    true,
@@ -1234,7 +1234,7 @@ func TestStoreRangeSplitMergeGeneration(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	testutils.RunTrueAndFalse(t, "rhsHasHigherGen", func(t *testing.T, rhsHasHigherGen bool) {
-		s, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+		s := serverutils.StartServerOnly(t, base.TestServerArgs{
 			Knobs: base.TestingKnobs{
 				Store: &kvserver.StoreTestingKnobs{
 					// Disable both splits and merges so that we're in full
@@ -2290,7 +2290,7 @@ func TestStoreRangeMergeConcurrentRequests(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	serv, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+	serv := serverutils.StartServerOnly(t, base.TestServerArgs{
 		Knobs: base.TestingKnobs{
 			Store: &kvserver.StoreTestingKnobs{
 				DisableMergeQueue:     true,
@@ -4147,7 +4147,7 @@ func TestStoreRangeMergeDuringShutdown(t *testing.T) {
 	}
 
 	manualClock := hlc.NewHybridManualClock()
-	serv, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+	serv := serverutils.StartServerOnly(t, base.TestServerArgs{
 		Knobs: base.TestingKnobs{
 			Store: &kvserver.StoreTestingKnobs{
 				DisableMergeQueue:      true,
@@ -5293,7 +5293,7 @@ func TestStoreMergeGCHint(t *testing.T) {
 	} {
 		t.Run(d.name, func(t *testing.T) {
 			ctx := context.Background()
-			serv, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+			serv := serverutils.StartServerOnly(t, base.TestServerArgs{
 				Knobs: base.TestingKnobs{
 					Store: &kvserver.StoreTestingKnobs{
 						DisableMergeQueue: true,

--- a/pkg/kv/kvserver/client_metrics_test.go
+++ b/pkg/kv/kvserver/client_metrics_test.go
@@ -186,7 +186,7 @@ func TestStoreResolveMetrics(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	serv, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	serv := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	s := serv.(*server.TestServer)
 	defer s.Stopper().Stop(ctx)
 	store, err := s.Stores().GetStore(s.GetFirstStoreID())

--- a/pkg/kv/kvserver/client_mvcc_gc_test.go
+++ b/pkg/kv/kvserver/client_mvcc_gc_test.go
@@ -35,7 +35,7 @@ func TestMVCCGCCorrectStats(t *testing.T) {
 	ctx := context.Background()
 	var args base.TestServerArgs
 	args.Knobs.Store = &kvserver.StoreTestingKnobs{DisableCanAckBeforeApplication: true}
-	serv, _, _ := serverutils.StartServer(t, args)
+	serv := serverutils.StartServerOnly(t, args)
 	s := serv.(*server.TestServer)
 	defer s.Stopper().Stop(ctx)
 

--- a/pkg/kv/kvserver/client_replica_test.go
+++ b/pkg/kv/kvserver/client_replica_test.go
@@ -162,7 +162,7 @@ func TestLeaseholdersRejectClockUpdateWithJump(t *testing.T) {
 
 	manual := hlc.NewHybridManualClock()
 	ctx := context.Background()
-	serv, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+	serv := serverutils.StartServerOnly(t, base.TestServerArgs{
 		Knobs: base.TestingKnobs{
 			Server: &server.TestingKnobs{
 				WallClock: manual,
@@ -271,7 +271,7 @@ func TestTxnPutOutOfOrder(t *testing.T) {
 	}
 	manual := hlc.NewHybridManualClock()
 	ctx := context.Background()
-	serv, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+	serv := serverutils.StartServerOnly(t, base.TestServerArgs{
 		Knobs: base.TestingKnobs{
 			Server: &server.TestingKnobs{
 				WallClock: manual,
@@ -453,7 +453,7 @@ func TestTxnReadWithinUncertaintyInterval(t *testing.T) {
 func testTxnReadWithinUncertaintyInterval(t *testing.T, observedTS bool, readOp string) {
 	ctx := context.Background()
 	manual := hlc.NewHybridManualClock()
-	srv, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+	srv := serverutils.StartServerOnly(t, base.TestServerArgs{
 		Knobs: base.TestingKnobs{
 			Server: &server.TestingKnobs{
 				WallClock: manual,
@@ -1248,7 +1248,7 @@ func TestRangeLookupUseReverse(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	serv, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+	serv := serverutils.StartServerOnly(t, base.TestServerArgs{
 		Knobs: base.TestingKnobs{
 			Store: &kvserver.StoreTestingKnobs{
 				DisableMergeQueue: true,
@@ -2264,7 +2264,7 @@ func TestLeaseExtensionNotBlockedByRead(t *testing.T) {
 		}
 		return nil
 	}
-	srv, _, _ := serverutils.StartServer(t,
+	srv := serverutils.StartServerOnly(t,
 		base.TestServerArgs{
 			Knobs: base.TestingKnobs{
 				Store: &kvserver.StoreTestingKnobs{
@@ -2519,7 +2519,7 @@ func TestErrorHandlingForNonKVCommand(t *testing.T) {
 		}
 		return nil
 	}
-	srv, _, _ := serverutils.StartServer(t,
+	srv := serverutils.StartServerOnly(t,
 		base.TestServerArgs{
 			Knobs: base.TestingKnobs{
 				Store: &kvserver.StoreTestingKnobs{
@@ -2558,7 +2558,7 @@ func TestRangeInfoAfterSplit(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
 
 	store, err := s.GetStores().(*kvserver.Stores).GetStore(s.GetFirstStoreID())
@@ -2693,7 +2693,7 @@ func TestClearRange(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	serv, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+	serv := serverutils.StartServerOnly(t, base.TestServerArgs{
 		Knobs: base.TestingKnobs{Store: &kvserver.StoreTestingKnobs{
 			// This makes sure that our writes are visible when we go
 			// straight to the engine to check them.

--- a/pkg/kv/kvserver/client_spanconfigs_test.go
+++ b/pkg/kv/kvserver/client_spanconfigs_test.go
@@ -61,7 +61,7 @@ func TestSpanConfigUpdateAppliedToReplica(t *testing.T) {
 			},
 		},
 	}
-	s, _, _ := serverutils.StartServer(t, args)
+	s := serverutils.StartServerOnly(t, args)
 	defer s.Stopper().Stop(context.Background())
 
 	_, err := s.InternalExecutor().(isql.Executor).ExecEx(ctx, "inline-exec", nil,
@@ -130,7 +130,7 @@ func TestFallbackSpanConfigOverride(t *testing.T) {
 			},
 		},
 	}
-	s, _, _ := serverutils.StartServer(t, args)
+	s := serverutils.StartServerOnly(t, args)
 	defer s.Stopper().Stop(context.Background())
 
 	_, err := s.InternalDB().(isql.DB).Executor().ExecEx(ctx, "inline-exec", nil,

--- a/pkg/kv/kvserver/client_split_test.go
+++ b/pkg/kv/kvserver/client_split_test.go
@@ -90,7 +90,7 @@ func TestStoreRangeSplitAtIllegalKeys(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{
 		Knobs: base.TestingKnobs{
 			Store: &kvserver.StoreTestingKnobs{
 				DisableMergeQueue: true,
@@ -122,7 +122,7 @@ func TestStoreSplitAbortSpan(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	serv, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+	serv := serverutils.StartServerOnly(t, base.TestServerArgs{
 		Knobs: base.TestingKnobs{
 			Store: &kvserver.StoreTestingKnobs{
 				DisableMergeQueue: true,
@@ -264,7 +264,7 @@ func TestStoreRangeSplitInsideRow(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	serv, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+	serv := serverutils.StartServerOnly(t, base.TestServerArgs{
 		Knobs: base.TestingKnobs{
 			Store: &kvserver.StoreTestingKnobs{
 				DisableMergeQueue: true,
@@ -333,7 +333,7 @@ func TestStoreRangeSplitIntents(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	serv, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+	serv := serverutils.StartServerOnly(t, base.TestServerArgs{
 		Knobs: base.TestingKnobs{
 			Store: &kvserver.StoreTestingKnobs{
 				DisableMergeQueue: true,
@@ -543,7 +543,7 @@ func TestStoreRangeSplitAtRangeBounds(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	serv, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+	serv := serverutils.StartServerOnly(t, base.TestServerArgs{
 		Knobs: base.TestingKnobs{
 			Store: &kvserver.StoreTestingKnobs{
 				DisableMergeQueue: true,
@@ -602,7 +602,7 @@ func TestStoreRangeSplitIdempotency(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	serv, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+	serv := serverutils.StartServerOnly(t, base.TestServerArgs{
 		Knobs: base.TestingKnobs{
 			Store: &kvserver.StoreTestingKnobs{
 				DisableMergeQueue:              true,
@@ -764,7 +764,7 @@ func TestStoreRangeSplitMergeStats(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	serv, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+	serv := serverutils.StartServerOnly(t, base.TestServerArgs{
 		Knobs: base.TestingKnobs{
 			Store: &kvserver.StoreTestingKnobs{
 				DisableMergeQueue:              true,
@@ -970,7 +970,7 @@ func TestStoreRangeSplitStatsWithMerges(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	serv, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+	serv := serverutils.StartServerOnly(t, base.TestServerArgs{
 		Knobs: base.TestingKnobs{
 			Store: &kvserver.StoreTestingKnobs{
 				DisableSplitQueue: true,
@@ -1253,7 +1253,7 @@ func TestStoreRangeSplitBackpressureWrites(t *testing.T) {
 				}
 
 			ctx := context.Background()
-			serv, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+			serv := serverutils.StartServerOnly(t, base.TestServerArgs{
 				Knobs: base.TestingKnobs{
 					Server: &server.TestingKnobs{
 						DefaultZoneConfigOverride: &zoneConfig,
@@ -1905,7 +1905,7 @@ func TestStoreSplitGCThreshold(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	serv, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+	serv := serverutils.StartServerOnly(t, base.TestServerArgs{
 		Knobs: base.TestingKnobs{
 			Store: &kvserver.StoreTestingKnobs{
 				DisableMergeQueue: true,
@@ -1966,7 +1966,7 @@ func TestStoreSplitGCHint(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	serv, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+	serv := serverutils.StartServerOnly(t, base.TestServerArgs{
 		Knobs: base.TestingKnobs{
 			Store: &kvserver.StoreTestingKnobs{
 				DisableMergeQueue: true,
@@ -2237,7 +2237,7 @@ func TestLeaderAfterSplit(t *testing.T) {
 
 func BenchmarkStoreRangeSplit(b *testing.B) {
 	ctx := context.Background()
-	serv, _, _ := serverutils.StartServer(b, base.TestServerArgs{})
+	serv := serverutils.StartServerOnly(b, base.TestServerArgs{})
 	s := serv.(*server.TestServer)
 	defer s.Stopper().Stop(ctx)
 	store, err := s.Stores().GetStore(s.GetFirstStoreID())
@@ -2341,7 +2341,7 @@ func TestStoreRangeGossipOnSplits(t *testing.T) {
 	overrideCapacityFraction := 0.5
 
 	ctx := context.Background()
-	serv, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+	serv := serverutils.StartServerOnly(t, base.TestServerArgs{
 		Knobs: base.TestingKnobs{
 			Store: &kvserver.StoreTestingKnobs{
 				DisableMergeQueue: true,
@@ -2435,7 +2435,7 @@ func TestStoreTxnWaitQueueEnabledOnSplit(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	serv, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+	serv := serverutils.StartServerOnly(t, base.TestServerArgs{
 		Knobs: base.TestingKnobs{
 			Store: &kvserver.StoreTestingKnobs{
 				DisableMergeQueue: true,
@@ -2467,7 +2467,7 @@ func TestDistributedTxnCleanup(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	serv, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+	serv := serverutils.StartServerOnly(t, base.TestServerArgs{
 		Knobs: base.TestingKnobs{
 			Store: &kvserver.StoreTestingKnobs{
 				DisableMergeQueue: true,
@@ -2591,7 +2591,7 @@ func TestUnsplittableRange(t *testing.T) {
 	}
 	splitQueuePurgatoryChan := make(chan time.Time, 1)
 
-	serv, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+	serv := serverutils.StartServerOnly(t, base.TestServerArgs{
 		Knobs: base.TestingKnobs{
 			Store: &kvserver.StoreTestingKnobs{
 				DisableMergeQueue:       true,
@@ -2695,7 +2695,7 @@ func TestTxnWaitQueueDependencyCycleWithRangeSplit(t *testing.T) {
 				return nil
 			}
 		ctx := context.Background()
-		serv, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+		serv := serverutils.StartServerOnly(t, base.TestServerArgs{
 			Knobs: base.TestingKnobs{
 				Store: &kvserver.StoreTestingKnobs{
 					DisableMergeQueue: true,
@@ -2952,7 +2952,7 @@ func TestRangeLookupAfterMeta2Split(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	srv, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+	srv := serverutils.StartServerOnly(t, base.TestServerArgs{
 		Knobs: base.TestingKnobs{
 			Store: &kvserver.StoreTestingKnobs{
 				DisableMergeQueue: true,
@@ -3083,7 +3083,7 @@ func TestStoreSplitRangeLookupRace(t *testing.T) {
 		return nil
 	}
 
-	srv, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+	srv := serverutils.StartServerOnly(t, base.TestServerArgs{
 		Knobs: base.TestingKnobs{
 			Store: &kvserver.StoreTestingKnobs{
 				DisableSplitQueue:     true,
@@ -3179,7 +3179,7 @@ func TestRangeLookupAsyncResolveIntent(t *testing.T) {
 			return nil
 		}
 	ctx := context.Background()
-	srv, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+	srv := serverutils.StartServerOnly(t, base.TestServerArgs{
 		Knobs: base.TestingKnobs{
 			Store: &kvserver.StoreTestingKnobs{
 				// Disable async tasks in the intent resolver. All tasks will be synchronous.
@@ -3262,7 +3262,7 @@ func TestStoreSplitDisappearingReplicas(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	serv, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+	serv := serverutils.StartServerOnly(t, base.TestServerArgs{
 		Knobs: base.TestingKnobs{
 			Store: &kvserver.StoreTestingKnobs{
 				DisableMergeQueue: true,
@@ -3509,7 +3509,7 @@ func TestSplitBlocksReadsToRHS(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	serv, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+	serv := serverutils.StartServerOnly(t, base.TestServerArgs{
 		Knobs: base.TestingKnobs{
 			Store: &kvserver.StoreTestingKnobs{
 				DisableMergeQueue:     true,

--- a/pkg/kv/kvserver/client_tenant_test.go
+++ b/pkg/kv/kvserver/client_tenant_test.go
@@ -326,7 +326,7 @@ func TestTenantCtx(t *testing.T) {
 	testutils.RunTrueAndFalse(t, "shared-process tenant", func(t *testing.T, sharedProcess bool) {
 		getErr := make(chan error)
 		pushErr := make(chan error)
-		s, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+		s := serverutils.StartServerOnly(t, base.TestServerArgs{
 			// Disable the default test tenant since we're going to create our own.
 			DefaultTestTenant: base.TestControlsTenantsExplicitly,
 			Knobs: base.TestingKnobs{

--- a/pkg/kv/kvserver/node_liveness_test.go
+++ b/pkg/kv/kvserver/node_liveness_test.go
@@ -212,7 +212,7 @@ func TestRedundantNodeLivenessHeartbeatsAvoided(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	serv, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	serv := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	s := serv.(*server.TestServer)
 	store, err := s.Stores().GetStore(s.GetFirstStoreID())
 	require.NoError(t, err)
@@ -555,7 +555,7 @@ func TestNodeLivenessSelf(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
-	serv, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	serv := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	s := serv.(*server.TestServer)
 	defer s.Stopper().Stop(ctx)
 	g := s.Gossip()
@@ -748,7 +748,7 @@ func TestNodeLivenessConcurrentHeartbeats(t *testing.T) {
 
 	ctx := context.Background()
 	manualClock := hlc.NewHybridManualClock()
-	serv, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+	serv := serverutils.StartServerOnly(t, base.TestServerArgs{
 		Knobs: base.TestingKnobs{
 			Server: &server.TestingKnobs{
 				WallClock: manualClock,
@@ -980,7 +980,7 @@ func TestNodeLivenessRetryAmbiguousResultError(t *testing.T) {
 		return nil
 	}
 	ctx := context.Background()
-	serv, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+	serv := serverutils.StartServerOnly(t, base.TestServerArgs{
 		Knobs: base.TestingKnobs{
 			Store: &kvserver.StoreTestingKnobs{
 				EvalKnobs: kvserverbase.BatchEvalTestingKnobs{
@@ -1107,7 +1107,7 @@ func TestNodeLivenessNoRetryOnAmbiguousResultCausedByCancellation(t *testing.T) 
 		<-sem
 		return nil
 	}
-	serv, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+	serv := serverutils.StartServerOnly(t, base.TestServerArgs{
 		Knobs: base.TestingKnobs{
 			Store: &kvserver.StoreTestingKnobs{
 				EvalKnobs: kvserverbase.BatchEvalTestingKnobs{

--- a/pkg/kv/kvserver/protectedts/ptcache/cache_test.go
+++ b/pkg/kv/kvserver/protectedts/ptcache/cache_test.go
@@ -77,7 +77,7 @@ func (idb *internalDBWithLastCommit) Txn(
 func TestCacheBasic(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	ctx := context.Background()
-	s, _, _ := serverutils.StartServer(t,
+	s := serverutils.StartServerOnly(t,
 		base.TestServerArgs{
 			Knobs: base.TestingKnobs{
 				ProtectedTS: &protectedts.TestingKnobs{
@@ -150,7 +150,7 @@ func TestRefresh(t *testing.T) {
 	ptsKnobs := &protectedts.TestingKnobs{
 		DisableProtectedTimestampForMultiTenant: true,
 	}
-	s, _, _ := serverutils.StartServer(t,
+	s := serverutils.StartServerOnly(t,
 		base.TestServerArgs{
 			// Disable span configs to avoid measuring protected timestamp lookups
 			// performed by the AUTO SPAN CONFIG RECONCILIATION job.
@@ -270,7 +270,7 @@ func TestStart(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	ctx := context.Background()
 	setup := func() (serverutils.TestServerInterface, *ptcache.Cache) {
-		s, _, _ := serverutils.StartServer(t,
+		s := serverutils.StartServerOnly(t,
 			base.TestServerArgs{
 				Knobs: base.TestingKnobs{
 					ProtectedTS: &protectedts.TestingKnobs{
@@ -308,7 +308,7 @@ func TestStart(t *testing.T) {
 func TestQueryRecord(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	ctx := context.Background()
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
 	db := s.InternalDB().(isql.DB)
 	storage := ptstorage.New(s.ClusterSettings(), &protectedts.TestingKnobs{
@@ -367,7 +367,7 @@ func TestQueryRecord(t *testing.T) {
 
 func TestIterate(t *testing.T) {
 	ctx := context.Background()
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
 	db := s.InternalDB().(isql.DB)
 	m := ptstorage.New(s.ClusterSettings(), &protectedts.TestingKnobs{
@@ -434,7 +434,7 @@ func (recs *records) sorted() []*ptpb.Record {
 
 func TestGetProtectionTimestamps(t *testing.T) {
 	ctx := context.Background()
-	s, _, _ := serverutils.StartServer(t,
+	s := serverutils.StartServerOnly(t,
 		base.TestServerArgs{
 			Knobs: base.TestingKnobs{
 				ProtectedTS: &protectedts.TestingKnobs{
@@ -537,7 +537,7 @@ func TestGetProtectionTimestamps(t *testing.T) {
 
 func TestSettingChangedLeadsToFetch(t *testing.T) {
 	ctx := context.Background()
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
 	db := s.InternalDB().(isql.DB)
 	m := ptstorage.New(s.ClusterSettings(), &protectedts.TestingKnobs{

--- a/pkg/kv/kvserver/protectedts/ptstorage/storage_test.go
+++ b/pkg/kv/kvserver/protectedts/ptstorage/storage_test.go
@@ -759,7 +759,7 @@ func TestErrorsFromSQL(t *testing.T) {
 	defer ccl.TestingEnableEnterprise()()
 
 	ctx := context.Background()
-	srv, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	srv := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer srv.Stopper().Stop(ctx)
 	s := srv.ApplicationLayer()
 

--- a/pkg/kv/kvserver/replica_closedts_test.go
+++ b/pkg/kv/kvserver/replica_closedts_test.go
@@ -698,7 +698,7 @@ func BenchmarkBumpSideTransportClosed(b *testing.B) {
 
 	ctx := context.Background()
 	manual := hlc.NewHybridManualClock()
-	s, _, _ := serverutils.StartServer(b, base.TestServerArgs{
+	s := serverutils.StartServerOnly(b, base.TestServerArgs{
 		Knobs: base.TestingKnobs{
 			Server: &server.TestingKnobs{
 				WallClock: manual,

--- a/pkg/kv/kvserver/replicate_test.go
+++ b/pkg/kv/kvserver/replicate_test.go
@@ -31,7 +31,7 @@ func TestEagerReplication(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	serv, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+	serv := serverutils.StartServerOnly(t, base.TestServerArgs{
 		// Need to trick the server to think it's part of a cluster, otherwise it
 		// will set the default zone config to require 1 replica and the split
 		// bellow will not trigger a replication attempt.

--- a/pkg/kv/kvserver/scheduler_test.go
+++ b/pkg/kv/kvserver/scheduler_test.go
@@ -480,7 +480,7 @@ func TestSchedulerPrioritizesLivenessAndMeta(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
 
 	store, err := s.GetStores().(*Stores).GetStore(s.GetFirstStoreID())

--- a/pkg/kv/kvserver/ts_maintenance_queue_test.go
+++ b/pkg/kv/kvserver/ts_maintenance_queue_test.go
@@ -106,7 +106,7 @@ func TestTimeSeriesMaintenanceQueue(t *testing.T) {
 	manual := hlc.NewHybridManualClock()
 
 	ctx := context.Background()
-	serv, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+	serv := serverutils.StartServerOnly(t, base.TestServerArgs{
 		Knobs: base.TestingKnobs{
 			Server: &server.TestingKnobs{
 				WallClock: manual,

--- a/pkg/security/certs_rotation_test.go
+++ b/pkg/security/certs_rotation_test.go
@@ -68,7 +68,7 @@ func TestRotateCerts(t *testing.T) {
 		SSLCertsDir:       certsDir,
 		InsecureWebAccess: true,
 	}
-	s, _, _ := serverutils.StartServer(t, params)
+	s := serverutils.StartServerOnly(t, params)
 	defer s.Stopper().Stop(context.Background())
 
 	// Client test function.

--- a/pkg/server/api_v2_sql_test.go
+++ b/pkg/server/api_v2_sql_test.go
@@ -37,7 +37,7 @@ func TestExecSQL(t *testing.T) {
 		SQLAPIClock = timeutil.DefaultTimeSource{}
 	}()
 
-	server, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	server := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	ctx := context.Background()
 	defer server.Stopper().Stop(ctx)
 

--- a/pkg/server/application_api/dbconsole_test.go
+++ b/pkg/server/application_api/dbconsole_test.go
@@ -31,7 +31,7 @@ import (
 func TestAdminAPIUIData(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{
 		// Disable the default test tenant for now as this tests fails
 		// with it enabled. Tracked with #81590.
 		DefaultTestTenant: base.TODOTestTenantDisabled,
@@ -142,7 +142,7 @@ func TestAdminAPIUIData(t *testing.T) {
 func TestAdminAPIUISeparateData(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{
 		// Disable the default test tenant for now as this tests fails
 		// with it enabled. Tracked with #81590.
 		DefaultTestTenant: base.TODOTestTenantDisabled,

--- a/pkg/server/application_api/jobs_test.go
+++ b/pkg/server/application_api/jobs_test.go
@@ -417,7 +417,7 @@ func TestAdminAPIJobsDetails(t *testing.T) {
 func TestJobStatusResponse(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	ts, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	ts := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer ts.Stopper().Stop(context.Background())
 
 	rootConfig := testutils.NewTestBaseContext(username.RootUserName())

--- a/pkg/server/application_api/metrics_test.go
+++ b/pkg/server/application_api/metrics_test.go
@@ -31,7 +31,7 @@ import (
 func TestMetricsMetadata(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	srv, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	srv := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer srv.Stopper().Stop(context.Background())
 
 	s := srv.(*server.TestServer)
@@ -63,7 +63,7 @@ func TestMetricsMetadata(t *testing.T) {
 func TestStatusVars(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(context.Background())
 
 	if body, err := srvtestutils.GetText(s, s.AdminURL().WithPath(apiconstants.StatusPrefix+"vars").String()); err != nil {
@@ -119,7 +119,7 @@ func TestStatusVarsTxnMetrics(t *testing.T) {
 func TestSpanStatsResponse(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	ts, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	ts := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer ts.Stopper().Stop(context.Background())
 
 	httpClient, err := ts.GetAdminHTTPClient()

--- a/pkg/server/application_api/schema_inspection_test.go
+++ b/pkg/server/application_api/schema_inspection_test.go
@@ -195,7 +195,7 @@ func TestAdminAPIDatabaseDoesNotExist(t *testing.T) {
 	// Until this can be put in main_test.go.
 	defer ccl.TestingEnableEnterprise()()
 
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(context.Background())
 	ts := s.ApplicationLayer()
 
@@ -212,7 +212,7 @@ func TestAdminAPIDatabaseSQLInjection(t *testing.T) {
 	// Until this can be put in main_test.go.
 	defer ccl.TestingEnableEnterprise()()
 
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(context.Background())
 	ts := s.ApplicationLayer()
 
@@ -231,7 +231,7 @@ func TestAdminAPITableDoesNotExist(t *testing.T) {
 	// Until this can be put in main_test.go.
 	defer ccl.TestingEnableEnterprise()()
 
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(context.Background())
 	ts := s.ApplicationLayer()
 
@@ -256,7 +256,7 @@ func TestAdminAPITableSQLInjection(t *testing.T) {
 	// Until this can be put in main_test.go.
 	defer ccl.TestingEnableEnterprise()()
 
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(context.Background())
 	ts := s.ApplicationLayer()
 
@@ -286,7 +286,7 @@ func TestAdminAPITableDetails(t *testing.T) {
 		{name: "upper", dbName: "TEST", tblName: `"TBL"`, pkName: "TBL_pkey"}, // Regression test for issue #14056
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+			s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 			defer s.Stopper().Stop(context.Background())
 			ts := s.ApplicationLayer()
 

--- a/pkg/server/application_api/schema_inspection_test.go
+++ b/pkg/server/application_api/schema_inspection_test.go
@@ -22,9 +22,9 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/ccl"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
-	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/server/apiconstants"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/server/srvtestutils"
@@ -44,13 +44,13 @@ import (
 func TestAdminAPIDatabases(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{
-		// Disable the default test tenant for now as this tests fails with
-		// it enabled. Tracked with #81590.
-		DefaultTestTenant: base.TODOTestTenantDisabled,
-	})
+
+	// Until this can be put in main_test.go.
+	defer ccl.TestingEnableEnterprise()()
+
+	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(context.Background())
-	ts := s.(*server.TestServer)
+	ts := s.ApplicationLayer()
 
 	ac := ts.AmbientCtx()
 	ctx, span := ac.AnnotateCtxWithSpan(context.Background(), "test")
@@ -110,7 +110,7 @@ func TestAdminAPIDatabases(t *testing.T) {
 			// Test databases endpoint.
 			var resp serverpb.DatabasesResponse
 			if err := srvtestutils.GetAdminJSONProtoWithAdminOption(
-				s,
+				ts,
 				"databases",
 				&resp,
 				tc.isAdmin,
@@ -135,7 +135,7 @@ func TestAdminAPIDatabases(t *testing.T) {
 			urlEscapeDbName := url.PathEscape(testDbName)
 
 			if err := srvtestutils.GetAdminJSONProtoWithAdminOption(
-				s,
+				ts,
 				"databases/"+urlEscapeDbName,
 				&details,
 				tc.isAdmin,
@@ -191,15 +191,16 @@ func TestAdminAPIDatabases(t *testing.T) {
 func TestAdminAPIDatabaseDoesNotExist(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{
-		// Disable the default test tenant for now as this tests fails with
-		// it enabled. Tracked with #81590.
-		DefaultTestTenant: base.TODOTestTenantDisabled,
-	})
+
+	// Until this can be put in main_test.go.
+	defer ccl.TestingEnableEnterprise()()
+
+	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(context.Background())
+	ts := s.ApplicationLayer()
 
 	const errPattern = "database.+does not exist"
-	if err := srvtestutils.GetAdminJSONProto(s, "databases/i_do_not_exist", nil); !testutils.IsError(err, errPattern) {
+	if err := srvtestutils.GetAdminJSONProto(ts, "databases/i_do_not_exist", nil); !testutils.IsError(err, errPattern) {
 		t.Fatalf("unexpected error: %v\nexpected: %s", err, errPattern)
 	}
 }
@@ -207,17 +208,18 @@ func TestAdminAPIDatabaseDoesNotExist(t *testing.T) {
 func TestAdminAPIDatabaseSQLInjection(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{
-		// Disable the default test tenant for now as this tests fails with
-		// it enabled. Tracked with #81590.
-		DefaultTestTenant: base.TODOTestTenantDisabled,
-	})
+
+	// Until this can be put in main_test.go.
+	defer ccl.TestingEnableEnterprise()()
+
+	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(context.Background())
+	ts := s.ApplicationLayer()
 
 	const fakedb = "system;DROP DATABASE system;"
 	const path = "databases/" + fakedb
 	const errPattern = `target database or schema does not exist`
-	if err := srvtestutils.GetAdminJSONProto(s, path, nil); !testutils.IsError(err, errPattern) {
+	if err := srvtestutils.GetAdminJSONProto(ts, path, nil); !testutils.IsError(err, errPattern) {
 		t.Fatalf("unexpected error: %v\nexpected: %s", err, errPattern)
 	}
 }
@@ -225,23 +227,24 @@ func TestAdminAPIDatabaseSQLInjection(t *testing.T) {
 func TestAdminAPITableDoesNotExist(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{
-		// Disable the default test tenant for now as this tests fails with
-		// it enabled. Tracked with #81590.
-		DefaultTestTenant: base.TODOTestTenantDisabled,
-	})
+
+	// Until this can be put in main_test.go.
+	defer ccl.TestingEnableEnterprise()()
+
+	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(context.Background())
+	ts := s.ApplicationLayer()
 
 	const fakename = "i_do_not_exist"
 	const badDBPath = "databases/" + fakename + "/tables/foo"
 	const dbErrPattern = `relation \\"` + fakename + `.foo\\" does not exist`
-	if err := srvtestutils.GetAdminJSONProto(s, badDBPath, nil); !testutils.IsError(err, dbErrPattern) {
+	if err := srvtestutils.GetAdminJSONProto(ts, badDBPath, nil); !testutils.IsError(err, dbErrPattern) {
 		t.Fatalf("unexpected error: %v\nexpected: %s", err, dbErrPattern)
 	}
 
 	const badTablePath = "databases/system/tables/" + fakename
 	const tableErrPattern = `relation \\"system.` + fakename + `\\" does not exist`
-	if err := srvtestutils.GetAdminJSONProto(s, badTablePath, nil); !testutils.IsError(err, tableErrPattern) {
+	if err := srvtestutils.GetAdminJSONProto(ts, badTablePath, nil); !testutils.IsError(err, tableErrPattern) {
 		t.Fatalf("unexpected error: %v\nexpected: %s", err, tableErrPattern)
 	}
 }
@@ -249,17 +252,18 @@ func TestAdminAPITableDoesNotExist(t *testing.T) {
 func TestAdminAPITableSQLInjection(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{
-		// Disable the default test tenant for now as this tests fails with
-		// it enabled. Tracked with #81590.
-		DefaultTestTenant: base.TODOTestTenantDisabled,
-	})
+
+	// Until this can be put in main_test.go.
+	defer ccl.TestingEnableEnterprise()()
+
+	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(context.Background())
+	ts := s.ApplicationLayer()
 
 	const fakeTable = "users;DROP DATABASE system;"
 	const path = "databases/system/tables/" + fakeTable
 	const errPattern = `relation \"system.` + fakeTable + `\" does not exist`
-	if err := srvtestutils.GetAdminJSONProto(s, path, nil); !testutils.IsError(err, regexp.QuoteMeta(errPattern)) {
+	if err := srvtestutils.GetAdminJSONProto(ts, path, nil); !testutils.IsError(err, regexp.QuoteMeta(errPattern)) {
 		t.Fatalf("unexpected error: %v\nexpected: %s", err, errPattern)
 	}
 }
@@ -267,6 +271,11 @@ func TestAdminAPITableSQLInjection(t *testing.T) {
 func TestAdminAPITableDetails(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
+	// Until this can be put in main_test.go.
+	defer ccl.TestingEnableEnterprise()()
+
+	const schemaName = "testschema"
 
 	for _, tc := range []struct {
 		name, dbName, tblName, pkName string
@@ -277,17 +286,12 @@ func TestAdminAPITableDetails(t *testing.T) {
 		{name: "upper", dbName: "TEST", tblName: `"TBL"`, pkName: "TBL_pkey"}, // Regression test for issue #14056
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			s, _, _ := serverutils.StartServer(t, base.TestServerArgs{
-				// Disable the default test tenant for now as this tests fails
-				// with it enabled. Tracked with #81590.
-				DefaultTestTenant: base.TODOTestTenantDisabled,
-			})
+			s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
 			defer s.Stopper().Stop(context.Background())
-			ts := s.(*server.TestServer)
+			ts := s.ApplicationLayer()
 
 			escDBName := tree.NameStringP(&tc.dbName)
 			tblName := tc.tblName
-			schemaName := "testschema"
 
 			ac := ts.AmbientCtx()
 			ctx, span := ac.AnnotateCtxWithSpan(context.Background(), "test")
@@ -320,7 +324,7 @@ func TestAdminAPITableDetails(t *testing.T) {
 			// Perform API call.
 			var resp serverpb.TableDetailsResponse
 			url := fmt.Sprintf("databases/%s/tables/%s", tc.dbName, tblName)
-			if err := srvtestutils.GetAdminJSONProto(s, url, &resp); err != nil {
+			if err := srvtestutils.GetAdminJSONProto(ts, url, &resp); err != nil {
 				t.Fatal(err)
 			}
 
@@ -439,11 +443,14 @@ func TestAdminAPIDatabaseDetails(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	// Until this can be put in main_test.go.
+	defer ccl.TestingEnableEnterprise()()
+
 	const numServers = 3
 	tc := testcluster.StartTestCluster(t, numServers, base.TestClusterArgs{})
 	defer tc.Stopper().Stop(context.Background())
 
-	db := tc.ServerConn(0)
+	db := tc.ApplicationLayer(0).SQLConn(t, "")
 
 	_, err := db.Exec("CREATE DATABASE test")
 	require.NoError(t, err)
@@ -458,14 +465,14 @@ func TestAdminAPIDatabaseDetails(t *testing.T) {
 
 	// Flush all stores here so that we can read the ApproximateDiskBytes field without waiting for a flush.
 	for i := 0; i < numServers; i++ {
-		s := tc.Server(i)
+		s := tc.Server(i).StorageLayer()
 		err = s.GetStores().(*kvserver.Stores).VisitStores(func(store *kvserver.Store) error {
 			return store.TODOEngine().Flush()
 		})
 		require.NoError(t, err)
 	}
 
-	s := tc.Server(0)
+	s := tc.Server(0).ApplicationLayer()
 
 	var resp serverpb.DatabaseDetailsResponse
 	require.NoError(t, serverutils.GetJSONProto(s, "/_admin/v1/databases/test", &resp))
@@ -498,6 +505,9 @@ func TestAdminAPITableStats(t *testing.T) {
 	skip.UnderStress(t, "flaky under stress #107156")
 	skip.UnderRace(t, "flaky under race #107156")
 
+	// Until this can be put in main_test.go.
+	defer ccl.TestingEnableEnterprise()()
+
 	const nodeCount = 3
 	tc := testcluster.StartTestCluster(t, nodeCount, base.TestClusterArgs{
 		ReplicationMode: base.ReplicationAuto,
@@ -508,10 +518,11 @@ func TestAdminAPITableStats(t *testing.T) {
 		},
 	})
 	defer tc.Stopper().Stop(context.Background())
-	server0 := tc.Server(0)
+
+	server0 := tc.Server(0).ApplicationLayer()
 
 	// Create clients (SQL, HTTP) connected to server 0.
-	db := tc.ServerConn(0)
+	db := server0.SQLConn(t, "")
 
 	client, err := server0.GetAdminHTTPClient()
 	if err != nil {

--- a/pkg/server/application_api/sessions_test.go
+++ b/pkg/server/application_api/sessions_test.go
@@ -42,7 +42,7 @@ import (
 func TestListSessionsSecurity(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	ts := s.(*server.TestServer)
 	defer ts.Stopper().Stop(context.Background())
 

--- a/pkg/server/application_api/stmtdiag_test.go
+++ b/pkg/server/application_api/stmtdiag_test.go
@@ -82,7 +82,7 @@ func TestCreateStatementDiagnosticsReport(t *testing.T) {
 	// all tests.
 	defer ccl.TestingEnableEnterprise()()
 
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(context.Background())
 
 	ts := s.ApplicationLayer()

--- a/pkg/server/application_api/storage_inspection_test.go
+++ b/pkg/server/application_api/storage_inspection_test.go
@@ -453,7 +453,7 @@ func TestSpanStatsGRPCResponse(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
 	ts := s.(*server.TestServer)
 

--- a/pkg/server/application_api/telemetry_test.go
+++ b/pkg/server/application_api/telemetry_test.go
@@ -103,7 +103,7 @@ func TestDiagnosticsResponse(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(context.Background())
 
 	var resp diagnosticspb.DiagnosticReport

--- a/pkg/server/authserver/authentication_test.go
+++ b/pkg/server/authserver/authentication_test.go
@@ -90,7 +90,7 @@ func TestSSLEnforcement(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{
 		// This test is verifying the (unimplemented) authentication of SSL
 		// client certificates over HTTP endpoints. Web session authentication
 		// is disabled in order to avoid the need to authenticate the individual
@@ -416,7 +416,7 @@ WHERE id = $1`
 func TestVerifySession(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(context.Background())
 	ts := s.ApplicationLayer()
 
@@ -588,7 +588,7 @@ func TestAuthenticationAPIUserLogin(t *testing.T) {
 func TestLogoutClearsCookies(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{
 		DefaultTestTenant: base.TestControlsTenantsExplicitly,
 	})
 	defer s.Stopper().Stop(context.Background())
@@ -714,7 +714,7 @@ func TestLogout(t *testing.T) {
 func TestAuthenticationMux(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(context.Background())
 	tsrv := s.ApplicationLayer()
 
@@ -800,7 +800,7 @@ func TestGRPCAuthentication(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
 
 	ts := s.ApplicationLayer()

--- a/pkg/server/debug/debug_test.go
+++ b/pkg/server/debug/debug_test.go
@@ -36,7 +36,7 @@ func debugURL(s serverutils.ApplicationLayerInterface) string {
 func TestAdminDebugExpVar(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(context.Background())
 
 	ts := s.ApplicationLayer()
@@ -59,7 +59,7 @@ func TestAdminDebugExpVar(t *testing.T) {
 func TestAdminDebugMetrics(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(context.Background())
 
 	ts := s.ApplicationLayer()
@@ -82,7 +82,7 @@ func TestAdminDebugMetrics(t *testing.T) {
 func TestAdminDebugPprof(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(context.Background())
 
 	ts := s.ApplicationLayer()
@@ -101,7 +101,7 @@ func TestAdminDebugPprof(t *testing.T) {
 func TestAdminDebugTrace(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(context.Background())
 
 	ts := s.ApplicationLayer()
@@ -128,7 +128,7 @@ func TestAdminDebugAuth(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(context.Background())
 	ts := s.ApplicationLayer()
 
@@ -182,7 +182,7 @@ func TestAdminDebugAuth(t *testing.T) {
 func TestAdminDebugRedirect(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(context.Background())
 	ts := s.ApplicationLayer()
 

--- a/pkg/server/diagnostics/update_checker_test.go
+++ b/pkg/server/diagnostics/update_checker_test.go
@@ -39,7 +39,7 @@ func TestCheckVersion(t *testing.T) {
 		defer r.Close()
 
 		url := r.URL()
-		s, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+		s := serverutils.StartServerOnly(t, base.TestServerArgs{
 			Knobs: base.TestingKnobs{
 				Server: &server.TestingKnobs{
 					DiagnosticsTestingKnobs: diagnostics.TestingKnobs{
@@ -66,7 +66,7 @@ func TestCheckVersion(t *testing.T) {
 		// Ensure nil, which happens when an empty env override URL is used, does not
 		// cause a crash.
 		var nilURL *url.URL
-		s, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+		s := serverutils.StartServerOnly(t, base.TestServerArgs{
 			Knobs: base.TestingKnobs{
 				Server: &server.TestingKnobs{
 					DiagnosticsTestingKnobs: diagnostics.TestingKnobs{

--- a/pkg/server/drain_test.go
+++ b/pkg/server/drain_test.go
@@ -314,7 +314,7 @@ func TestServerShutdownReleasesSession(t *testing.T) {
 
 	ctx := context.Background()
 
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{
 		DefaultTestTenant: base.TestControlsTenantsExplicitly,
 	})
 	defer s.Stopper().Stop(ctx)

--- a/pkg/server/grpc_gateway_test.go
+++ b/pkg/server/grpc_gateway_test.go
@@ -31,7 +31,7 @@ func TestEndpointTelemetryBasic(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{
 		// Disable the default test tenant for now as this tests fails
 		// with it enabled. Tracked with #81590.
 		DefaultTestTenant: base.TODOTestTenantDisabled,

--- a/pkg/server/migration_test.go
+++ b/pkg/server/migration_test.go
@@ -85,7 +85,7 @@ func TestValidateTargetClusterVersion(t *testing.T) {
 			false, /* initializeVersion */
 		)
 
-		s, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+		s := serverutils.StartServerOnly(t, base.TestServerArgs{
 			Settings: st,
 			Knobs: base.TestingKnobs{
 				Server: &TestingKnobs{
@@ -156,7 +156,7 @@ func TestBumpClusterVersion(t *testing.T) {
 				false, /* initializeVersion */
 			)
 
-			s, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+			s := serverutils.StartServerOnly(t, base.TestServerArgs{
 				Settings: st,
 				Knobs: base.TestingKnobs{
 					Server: &TestingKnobs{
@@ -218,7 +218,7 @@ func TestMigrationPurgeOutdatedReplicas(t *testing.T) {
 	}
 
 	intercepted := 0
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{
 		StoreSpecs: storeSpecs,
 		Knobs: base.TestingKnobs{
 			Store: &kvserver.StoreTestingKnobs{

--- a/pkg/server/node_test.go
+++ b/pkg/server/node_test.go
@@ -139,7 +139,7 @@ func TestBootstrapNewStore(t *testing.T) {
 
 	// Start server with persisted store so that it gets bootstrapped.
 	{
-		s, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+		s := serverutils.StartServerOnly(t, base.TestServerArgs{
 			StoreSpecs: []base.StoreSpec{
 				{Path: path},
 			},
@@ -152,7 +152,7 @@ func TestBootstrapNewStore(t *testing.T) {
 		{InMemory: true},
 		{InMemory: true},
 	}
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{
 		StoreSpecs: specs,
 	})
 	defer s.Stopper().Stop(ctx)
@@ -595,7 +595,7 @@ func TestStartNodeWithLocality(t *testing.T) {
 		args := base.TestServerArgs{
 			Locality: locality,
 		}
-		s, _, _ := serverutils.StartServer(t, args)
+		s := serverutils.StartServerOnly(t, args)
 		defer s.Stopper().Stop(ctx)
 
 		// Check that the locality is present both on the Node and was also
@@ -669,7 +669,7 @@ func TestNodeBatchRequestPProfLabels(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	observedProfileLabels := make(map[string]string)
-	srv, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+	srv := serverutils.StartServerOnly(t, base.TestServerArgs{
 		Knobs: base.TestingKnobs{
 			Store: &kvserver.StoreTestingKnobs{
 				TestingResponseFilter: func(ctx context.Context, ba *kvpb.BatchRequest, _ *kvpb.BatchResponse) *kvpb.Error {
@@ -732,7 +732,7 @@ func TestNodeBatchRequestMetricsInc(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	srv, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	srv := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer srv.Stopper().Stop(context.Background())
 	ts := srv.(*TestServer)
 
@@ -840,7 +840,7 @@ func TestGetTenantWeights(t *testing.T) {
 		{InMemory: true},
 		{InMemory: true},
 	}
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{
 		StoreSpecs: specs,
 	})
 	defer s.Stopper().Stop(ctx)

--- a/pkg/server/rangetestutils/rangetestutils.go
+++ b/pkg/server/rangetestutils/rangetestutils.go
@@ -41,7 +41,7 @@ func InitRangeTestServerFactory(impl TestServerFactory) {
 // caller is responsible for stopping the server.
 func StartServer(t testing.TB) serverutils.TestServerInterface {
 	params := srvFactoryImpl.MakeRangeTestServerArgs()
-	s, _, _ := serverutils.StartServer(t, params)
+	s := serverutils.StartServerOnly(t, params)
 	if err := srvFactoryImpl.PrepareRangeTestServer(s); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/server/server_controller_test.go
+++ b/pkg/server/server_controller_test.go
@@ -69,7 +69,7 @@ func TestSQLErrorUponInvalidTenant(t *testing.T) {
 
 	ctx := context.Background()
 
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{
 		DefaultTestTenant: base.TestControlsTenantsExplicitly,
 	})
 	defer s.Stopper().Stop(ctx)

--- a/pkg/server/server_internal_executor_factory_test.go
+++ b/pkg/server/server_internal_executor_factory_test.go
@@ -28,7 +28,7 @@ func TestInternalExecutorClearsMonitorMemory(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
 
 	mon := s.(*TestServer).sqlServer.internalDBMemMonitor

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -75,10 +75,8 @@ import (
 func TestSelfBootstrap(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	s, err := serverutils.StartServerRaw(t, base.TestServerArgs{})
-	if err != nil {
-		t.Fatal(err)
-	}
+
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(context.Background())
 
 	if s.RPCContext().StorageClusterID.Get() == uuid.Nil {
@@ -88,10 +86,9 @@ func TestSelfBootstrap(t *testing.T) {
 
 func TestPanicRecovery(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
+	defer log.ScopeWithoutShowLogs(t).Close(t)
 
-	s, err := serverutils.StartServerRaw(t, base.TestServerArgs{})
-	require.NoError(t, err)
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(context.Background())
 	ts := s.(*TestServer)
 
@@ -131,16 +128,13 @@ func TestHealthCheck(t *testing.T) {
 
 	cfg := zonepb.DefaultZoneConfig()
 	cfg.NumReplicas = proto.Int32(1)
-	s, err := serverutils.StartServerRaw(t, base.TestServerArgs{
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{
 		Knobs: base.TestingKnobs{
 			Server: &TestingKnobs{
 				DefaultZoneConfigOverride: &cfg,
 			},
 		},
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
 	defer s.Stopper().Stop(context.Background())
 
 	ctx := context.Background()
@@ -421,14 +415,11 @@ func TestListenerFileCreation(t *testing.T) {
 	dir, cleanupFn := testutils.TempDir(t)
 	defer cleanupFn()
 
-	s, err := serverutils.StartServerRaw(t, base.TestServerArgs{
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{
 		StoreSpecs: []base.StoreSpec{{
 			Path: dir,
 		}},
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
 	defer s.Stopper().Stop(context.Background())
 
 	files, err := filepath.Glob(filepath.Join(dir, "cockroach.*"))

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -212,7 +212,7 @@ func TestServerStartClock(t *testing.T) {
 			},
 		},
 	}
-	s, _, _ := serverutils.StartServer(t, params)
+	s := serverutils.StartServerOnly(t, params)
 	defer s.Stopper().Stop(context.Background())
 
 	// Run a command so that we are sure to touch the timestamp cache. This is
@@ -240,7 +240,7 @@ func TestServerStartClock(t *testing.T) {
 func TestPlainHTTPServer(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{
 		// The default context uses embedded certs.
 		Insecure: true,
 	})
@@ -286,7 +286,7 @@ func TestPlainHTTPServer(t *testing.T) {
 func TestSecureHTTPRedirect(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(context.Background())
 	ts := s.(*TestServer)
 
@@ -337,7 +337,7 @@ func TestSecureHTTPRedirect(t *testing.T) {
 func TestAcceptEncoding(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(context.Background())
 	client, err := s.GetAdminHTTPClient()
 	if err != nil {
@@ -747,7 +747,7 @@ func TestServeIndexHTML(t *testing.T) {
 	}
 
 	t.Run("Insecure mode", func(t *testing.T) {
-		s, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+		s := serverutils.StartServerOnly(t, base.TestServerArgs{
 			Insecure: true,
 		})
 		defer s.Stopper().Stop(ctx)
@@ -814,7 +814,7 @@ Binary built without web UI.
 	t.Run("Secure mode", func(t *testing.T) {
 		linkInFakeUI()
 		defer unlinkFakeUI()
-		s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+		s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 		defer s.Stopper().Stop(ctx)
 		tsrv := s.(*TestServer)
 
@@ -897,7 +897,7 @@ Binary built without web UI.
 			ui.Assets = nil
 		}()
 
-		s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+		s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 		defer s.Stopper().Stop(ctx)
 		tsrv := s.(*TestServer)
 
@@ -1198,7 +1198,7 @@ func TestSocketAutoNumbering(t *testing.T) {
 		Insecure:   true,
 		SocketFile: socketFile,
 	}
-	s, _, _ := serverutils.StartServer(t, params)
+	s := serverutils.StartServerOnly(t, params)
 	defer s.Stopper().Stop(ctx)
 
 	_, expectedPort, err := addr.SplitHostPort(s.SQLAddr(), "")
@@ -1214,7 +1214,7 @@ func TestInternalSQL(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
 
 	conf, err := pgx.ParseConfig("")

--- a/pkg/server/settings_cache_test.go
+++ b/pkg/server/settings_cache_test.go
@@ -78,7 +78,7 @@ func TestCachedSettingsServerRestart(t *testing.T) {
 		},
 	}
 	var settingsCache []roachpb.KeyValue
-	testServer, _, _ := serverutils.StartServer(t, serverArgs)
+	testServer := serverutils.StartServerOnly(t, serverArgs)
 	closedts.TargetDuration.Override(ctx, &testServer.ClusterSettings().SV, 10*time.Millisecond)
 	closedts.SideTransportCloseInterval.Override(ctx, &testServer.ClusterSettings().SV, 10*time.Millisecond)
 	testutils.SucceedsSoon(t, func() error {

--- a/pkg/server/status/runtime_stats_test.go
+++ b/pkg/server/status/runtime_stats_test.go
@@ -35,7 +35,7 @@ func TestStructuredEventLogging(t *testing.T) {
 	defer log.ScopeWithoutShowLogs(t).Close(t)
 
 	ctx := context.Background()
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
 
 	testStartTs := timeutil.Now()

--- a/pkg/server/storage_api/certs_test.go
+++ b/pkg/server/storage_api/certs_test.go
@@ -25,7 +25,7 @@ import (
 func TestCertificatesResponse(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	ts, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	ts := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer ts.Stopper().Stop(context.Background())
 
 	var response serverpb.CertificatesResponse

--- a/pkg/server/storage_api/engine_test.go
+++ b/pkg/server/storage_api/engine_test.go
@@ -34,14 +34,11 @@ func TestStatusEngineStatsJson(t *testing.T) {
 	dir, cleanupFn := testutils.TempDir(t)
 	defer cleanupFn()
 
-	s, err := serverutils.StartServerRaw(t, base.TestServerArgs{
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{
 		StoreSpecs: []base.StoreSpec{{
 			Path: dir,
 		}},
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
 	defer s.Stopper().Stop(context.Background())
 
 	t.Logf("using admin URL %s", s.AdminURL())

--- a/pkg/server/storage_api/files_test.go
+++ b/pkg/server/storage_api/files_test.go
@@ -40,7 +40,7 @@ func TestStatusGetFiles(t *testing.T) {
 
 	storeSpec := base.StoreSpec{Path: tempDir}
 
-	tsI, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+	tsI := serverutils.StartServerOnly(t, base.TestServerArgs{
 		StoreSpecs: []base.StoreSpec{
 			storeSpec,
 		},

--- a/pkg/server/storage_api/gossip_test.go
+++ b/pkg/server/storage_api/gossip_test.go
@@ -28,7 +28,7 @@ func TestStatusGossipJson(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(context.Background())
 
 	var data gossip.InfoStatus

--- a/pkg/server/storage_api/health_test.go
+++ b/pkg/server/storage_api/health_test.go
@@ -36,7 +36,7 @@ func TestHealthAPI(t *testing.T) {
 
 	ctx := context.Background()
 
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{
 		// Disable the default test tenant for now as this tests fails
 		// with it enabled. Tracked with #81590.
 		DefaultTestTenant: base.TODOTestTenantDisabled,

--- a/pkg/server/storage_api/logfiles_test.go
+++ b/pkg/server/storage_api/logfiles_test.go
@@ -50,7 +50,7 @@ func TestStatusLocalLogs(t *testing.T) {
 	// there's just one.
 	defer s.SetupSingleFileLogging()()
 
-	ts, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	ts := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer ts.Stopper().Stop(context.Background())
 
 	// Log an error of each main type which we expect to be able to retrieve.
@@ -205,7 +205,7 @@ func TestStatusLocalLogsTenantFilter(t *testing.T) {
 	// there's just one.
 	defer s.SetupSingleFileLogging()()
 
-	srv, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	srv := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer srv.Stopper().Stop(context.Background())
 
 	ts := srv.(*server.TestServer)
@@ -338,7 +338,7 @@ func TestStatusLogRedaction(t *testing.T) {
 			// Apply the redactable log boolean for this test.
 			defer log.TestingSetRedactable(redactableLogs)()
 
-			ts, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+			ts := serverutils.StartServerOnly(t, base.TestServerArgs{})
 			defer ts.Stopper().Stop(context.Background())
 
 			// Log something.

--- a/pkg/server/storage_api/nodes_test.go
+++ b/pkg/server/storage_api/nodes_test.go
@@ -38,7 +38,7 @@ import (
 func TestStatusJson(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(context.Background())
 	ts := s.(*server.TestServer)
 
@@ -92,7 +92,7 @@ func TestStatusJson(t *testing.T) {
 func TestNodeStatusResponse(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	srv, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	srv := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer srv.Stopper().Stop(context.Background())
 	s := srv.(*server.TestServer)
 	node := s.Node().(*server.Node)
@@ -174,7 +174,7 @@ func TestMetricsRecording(t *testing.T) {
 func TestMetricsEndpoint(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	srv, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	srv := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer srv.Stopper().Stop(context.Background())
 
 	s := srv.(*server.TestServer)
@@ -187,7 +187,7 @@ func TestMetricsEndpoint(t *testing.T) {
 func TestNodesGRPCResponse(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(context.Background())
 	ts := s.(*server.TestServer)
 

--- a/pkg/server/storage_api/raft_test.go
+++ b/pkg/server/storage_api/raft_test.go
@@ -27,7 +27,7 @@ import (
 func TestRaftDebug(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(context.Background())
 
 	var resp serverpb.RaftDebugResponse

--- a/pkg/server/storage_api/ranges_test.go
+++ b/pkg/server/storage_api/ranges_test.go
@@ -33,7 +33,7 @@ func TestRangesResponse(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	defer kvserver.EnableLeaseHistoryForTesting(100)()
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(context.Background())
 
 	ts := s.(*server.TestServer)
@@ -111,7 +111,7 @@ func TestTenantRangesResponse(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
 	ts := s.(*server.TestServer)
 
@@ -134,7 +134,7 @@ func TestRangeResponse(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	defer kvserver.EnableLeaseHistoryForTesting(100)()
-	ts, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	ts := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer ts.Stopper().Stop(context.Background())
 
 	// Perform a scan to ensure that all the raft groups are initialized.

--- a/pkg/server/structlogging/hot_ranges_log_test.go
+++ b/pkg/server/structlogging/hot_ranges_log_test.go
@@ -46,7 +46,7 @@ func TestHotRangesStats(t *testing.T) {
 	cleanup := logtestutils.InstallLogFileSink(sc, t, logpb.Channel_TELEMETRY)
 	defer cleanup()
 
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{
 		DefaultTestTenant: base.TestControlsTenantsExplicitly,
 		StoreSpecs: []base.StoreSpec{
 			base.DefaultTestStoreSpec,

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -20,7 +20,6 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
-	"testing"
 	"time"
 
 	"github.com/cenkalti/backoff"
@@ -489,12 +488,14 @@ func (ts *TestServer) TsDB() *ts.DB {
 }
 
 // SQLConn is part of the serverutils.ApplicationLayerInterface.
-func (ts *TestServer) SQLConn(test testing.TB, dbName string) *gosql.DB {
+func (ts *TestServer) SQLConn(test serverutils.TestFataler, dbName string) *gosql.DB {
 	return ts.SQLConnForUser(test, username.RootUser, dbName)
 }
 
 // SQLConnForUser is part of the serverutils.ApplicationLayerInterface.
-func (ts *TestServer) SQLConnForUser(test testing.TB, userName, dbName string) *gosql.DB {
+func (ts *TestServer) SQLConnForUser(
+	test serverutils.TestFataler, userName, dbName string,
+) *gosql.DB {
 	db, err := ts.SQLConnForUserE(userName, dbName)
 	if err != nil {
 		test.Fatal(err)
@@ -758,12 +759,14 @@ func (t *TestTenant) RPCAddr() string {
 }
 
 // SQLConn is part of the serverutils.ApplicationLayerInterface.
-func (t *TestTenant) SQLConn(test testing.TB, dbName string) *gosql.DB {
+func (t *TestTenant) SQLConn(test serverutils.TestFataler, dbName string) *gosql.DB {
 	return t.SQLConnForUser(test, username.RootUser, dbName)
 }
 
 // SQLConnForUser is part of the serverutils.ApplicationLayerInterface.
-func (t *TestTenant) SQLConnForUser(test testing.TB, userName, dbName string) *gosql.DB {
+func (t *TestTenant) SQLConnForUser(
+	test serverutils.TestFataler, userName, dbName string,
+) *gosql.DB {
 	db, err := t.SQLConnForUserE(userName, dbName)
 	if err != nil {
 		test.Fatal(err)

--- a/pkg/server/testserver_test.go
+++ b/pkg/server/testserver_test.go
@@ -23,6 +23,6 @@ import (
 func TestServerTest(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(context.Background())
 }

--- a/pkg/server/tracedumper/tracedumper_test.go
+++ b/pkg/server/tracedumper/tracedumper_test.go
@@ -46,7 +46,7 @@ func TestTraceDumperZipCreation(t *testing.T) {
 	}
 	ctx := context.Background()
 	params, _ := tests.CreateTestServerParams()
-	s, _, _ := serverutils.StartServer(t, params)
+	s := serverutils.StartServerOnly(t, params)
 	defer s.Stopper().Stop(ctx)
 
 	filename := "foo"

--- a/pkg/sql/authorization_test.go
+++ b/pkg/sql/authorization_test.go
@@ -29,7 +29,7 @@ func TestCheckAnyPrivilegeForNodeUser(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 
 	defer s.Stopper().Stop(ctx)
 

--- a/pkg/sql/catalog/descs/txn_external_test.go
+++ b/pkg/sql/catalog/descs/txn_external_test.go
@@ -41,7 +41,7 @@ func TestTxnWithStepping(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
 
 	db := s.InternalDB().(descs.DB)

--- a/pkg/sql/catalog/descs/txn_with_executor_datadriven_test.go
+++ b/pkg/sql/catalog/descs/txn_with_executor_datadriven_test.go
@@ -47,7 +47,7 @@ func TestTxnWithExecutorDataDriven(t *testing.T) {
 
 	ctx := context.Background()
 	datadriven.Walk(t, datapathutils.TestDataPath(t, ""), func(t *testing.T, path string) {
-		s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+		s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 		defer s.Stopper().Stop(ctx)
 		datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {
 			stmts, err := parser.Parse(d.Input)

--- a/pkg/sql/conn_executor_internal_test.go
+++ b/pkg/sql/conn_executor_internal_test.go
@@ -396,7 +396,7 @@ func TestSessionCloseWithPendingTempTableInTxn(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
 
 	srv := s.SQLServer().(*Server)

--- a/pkg/sql/conn_executor_test.go
+++ b/pkg/sql/conn_executor_test.go
@@ -474,7 +474,7 @@ func TestAppNameStatisticsInitialization(t *testing.T) {
 	params, _ := tests.CreateTestServerParams()
 	params.Insecure = true
 
-	s, _, _ := serverutils.StartServer(t, params)
+	s := serverutils.StartServerOnly(t, params)
 	defer s.Stopper().Stop(context.Background())
 
 	// Prepare a session with a custom application name.
@@ -973,7 +973,7 @@ func TestUnqualifiedIntSizeRace(t *testing.T) {
 
 	ctx := context.Background()
 
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{
 		Insecure: true,
 	})
 	defer s.Stopper().Stop(ctx)
@@ -1013,7 +1013,7 @@ func TestTrimSuspendedPortals(t *testing.T) {
 	ctx := context.Background()
 
 	var stmtBuff *sql.StmtBuf
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{
 		Knobs: base.TestingKnobs{
 			SQLExecutor: &sql.ExecutorTestingKnobs{
 				// get a handle to the statement buffer during the Bind phase
@@ -1192,7 +1192,7 @@ func TestTransactionDeadline(t *testing.T) {
 			SessionOverride: sessionOverrideKnob,
 		},
 	}
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{
 		DefaultTestTenant: base.TestTenantAlwaysEnabled,
 		Knobs:             knobs,
 	})

--- a/pkg/sql/copy/copy_in_test.go
+++ b/pkg/sql/copy/copy_in_test.go
@@ -721,7 +721,7 @@ func TestMessageSizeTooBig(t *testing.T) {
 
 	ctx := context.Background()
 	params, _ := tests.CreateTestServerParams()
-	s, _, _ := serverutils.StartServer(t, params)
+	s := serverutils.StartServerOnly(t, params)
 	defer s.Stopper().Stop(ctx)
 
 	url, cleanup := sqlutils.PGUrl(t, s.AdvSQLAddr(), "copytest", url.User(username.RootUser))
@@ -766,7 +766,7 @@ func TestCopyExceedsSQLMemory(t *testing.T) {
 					params := base.TestServerArgs{
 						SQLMemoryPoolSize: 10 << 20,
 					}
-					s, _, _ := serverutils.StartServer(t, params)
+					s := serverutils.StartServerOnly(t, params)
 					defer s.Stopper().Stop(ctx)
 
 					url, cleanup := sqlutils.PGUrl(t, s.AdvSQLAddr(), "copytest", url.User(username.RootUser))

--- a/pkg/sql/copy/copy_test.go
+++ b/pkg/sql/copy/copy_test.go
@@ -97,7 +97,7 @@ func TestDataDriven(t *testing.T) {
 		for _, atomic := range []string{"on", "off"} {
 			for _, fastPath := range []string{"on", "off"} {
 				datadriven.Walk(t, datapathutils.TestDataPath(t), func(t *testing.T, path string) {
-					s, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+					s := serverutils.StartServerOnly(t, base.TestServerArgs{
 						Settings: cluster.MakeTestingClusterSettings(),
 					})
 					defer s.Stopper().Stop(ctx)
@@ -249,7 +249,7 @@ func TestCopyFromTransaction(t *testing.T) {
 	ctx := context.Background()
 
 	testutils.RunTrueAndFalse(t, "disableAutoCommitDuringExec", func(t *testing.T, b bool) {
-		s, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+		s := serverutils.StartServerOnly(t, base.TestServerArgs{
 			Settings: cluster.MakeTestingClusterSettings(),
 			Knobs: base.TestingKnobs{
 				SQLExecutor: &sql.ExecutorTestingKnobs{
@@ -401,7 +401,7 @@ func TestCopyFromTimeout(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
 
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
 
 	pgURL, cleanup := sqlutils.PGUrl(
@@ -467,7 +467,7 @@ func TestShowQueriesIncludesCopy(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
 
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
 
 	pgURL, cleanup := sqlutils.PGUrl(
@@ -566,7 +566,7 @@ func TestLargeDynamicRows(t *testing.T) {
 			return nil
 		},
 	}
-	s, _, _ := serverutils.StartServer(t, params)
+	s := serverutils.StartServerOnly(t, params)
 	defer s.Stopper().Stop(ctx)
 
 	url, cleanup := sqlutils.PGUrl(t, s.AdvSQLAddr(), "copytest", url.User(username.RootUser))
@@ -620,7 +620,7 @@ func TestTinyRows(t *testing.T) {
 	ctx := context.Background()
 
 	params, _ := tests.CreateTestServerParams()
-	s, _, _ := serverutils.StartServer(t, params)
+	s := serverutils.StartServerOnly(t, params)
 	defer s.Stopper().Stop(ctx)
 
 	url, cleanup := sqlutils.PGUrl(t, s.AdvSQLAddr(), "copytest", url.User(username.RootUser))

--- a/pkg/sql/crdb_internal_test.go
+++ b/pkg/sql/crdb_internal_test.go
@@ -169,7 +169,7 @@ func TestGossipAlertsTable(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	params, _ := tests.CreateTestServerParams()
-	s, _, _ := serverutils.StartServer(t, params)
+	s := serverutils.StartServerOnly(t, params)
 	defer s.Stopper().Stop(context.Background())
 	ctx := context.Background()
 

--- a/pkg/sql/create_test.go
+++ b/pkg/sql/create_test.go
@@ -312,7 +312,7 @@ SELECT * FROM t.kv%d
 func TestCreateStatementType(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	ctx := context.Background()
 	defer s.Stopper().Stop(ctx)
 

--- a/pkg/sql/database_test.go
+++ b/pkg/sql/database_test.go
@@ -29,7 +29,7 @@ func TestDatabaseAccessors(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(context.Background())
 
 	if err := TestingDescsTxn(context.Background(), s, func(ctx context.Context, txn isql.Txn, col *descs.Collection) error {

--- a/pkg/sql/distsql/setup_flow_after_drain_test.go
+++ b/pkg/sql/distsql/setup_flow_after_drain_test.go
@@ -35,7 +35,7 @@ func TestSetupFlowAfterDrain(t *testing.T) {
 	// We'll create a server just so that we can extract its distsql ServerConfig,
 	// so we can use it for a manually-built DistSQL Server below. Otherwise, too
 	// much work to create that ServerConfig by hand.
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
 	cfg := s.DistSQLServer().(*ServerImpl).ServerConfig
 

--- a/pkg/sql/drop_test.go
+++ b/pkg/sql/drop_test.go
@@ -1141,7 +1141,7 @@ func TestDropIndexOnHashShardedIndexWithStoredShardColumn(t *testing.T) {
 	// Start a test server and connect to it with notice handler (so we can get and check notices from running queries).
 	ctx := context.Background()
 	params, _ := tests.CreateTestServerParams()
-	s, _, _ := serverutils.StartServer(t, params)
+	s := serverutils.StartServerOnly(t, params)
 	defer s.Stopper().Stop(ctx)
 	url, cleanup := sqlutils.PGUrl(t, s.AdvSQLAddr(), t.Name(), url.User(username.RootUser))
 	defer cleanup()

--- a/pkg/sql/flowinfra/server_test.go
+++ b/pkg/sql/flowinfra/server_test.go
@@ -147,7 +147,7 @@ func TestDistSQLServerGossipsVersion(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(context.Background())
 
 	var v execinfrapb.DistSQLVersionGossipInfo

--- a/pkg/sql/gcjob/gc_protected_timestamp_test.go
+++ b/pkg/sql/gcjob/gc_protected_timestamp_test.go
@@ -40,7 +40,7 @@ func TestProtectedTimestampsPreventGC(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	srv, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+	srv := serverutils.StartServerOnly(t, base.TestServerArgs{
 		Knobs: base.TestingKnobs{
 			JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
 		},

--- a/pkg/sql/internal_test.go
+++ b/pkg/sql/internal_test.go
@@ -375,7 +375,7 @@ func TestInternalExecAppNameInitialization(t *testing.T) {
 	}
 
 	t.Run("root internal exec", func(t *testing.T) {
-		s, _, _ := serverutils.StartServer(t, params)
+		s := serverutils.StartServerOnly(t, params)
 		defer s.Stopper().Stop(context.Background())
 
 		testInternalExecutorAppNameInitialization(
@@ -387,7 +387,7 @@ func TestInternalExecAppNameInitialization(t *testing.T) {
 	// We are running the second test with a new server so
 	// as to reset the statement statistics properly.
 	t.Run("session bound exec", func(t *testing.T) {
-		s, _, _ := serverutils.StartServer(t, params)
+		s := serverutils.StartServerOnly(t, params)
 		defer s.Stopper().Stop(context.Background())
 
 		mon := sql.MakeInternalExecutorMemMonitor(sql.MemoryMetrics{}, s.ClusterSettings())
@@ -613,7 +613,7 @@ func TestInternalExecutorWithDefinedQoSOverrideDoesNotPanic(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
 
 	ie := s.InternalExecutor().(*sql.InternalExecutor)
@@ -631,7 +631,7 @@ func TestInternalExecutorWithUndefinedQoSOverridePanics(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
 
 	ie := s.InternalExecutor().(*sql.InternalExecutor)
@@ -654,7 +654,7 @@ func TestInternalDBWithOverrides(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
 
 	idb1 := s.InternalDB().(*sql.InternalDB)

--- a/pkg/sql/logictest/testdata/logic_test/event_log
+++ b/pkg/sql/logictest/testdata/logic_test/event_log
@@ -478,7 +478,7 @@ AND info NOT LIKE '%sql.stats%'
 ORDER BY "timestamp", info
 ----
 1  {"ApplicationName": "$ internal-optInToDiagnosticsStatReporting", "EventType": "set_cluster_setting", "SettingName": "diagnostics.reporting.enabled", "Statement": "SET CLUSTER SETTING \"diagnostics.reporting.enabled\" = true", "Tag": "SET CLUSTER SETTING", "User": "root", "Value": "true"}
-1  {"EventType": "set_cluster_setting", "SettingName": "kv.range_merge.queue_enabled", "Statement": "SET CLUSTER SETTING \"kv.range_merge.queue_enabled\" = false", "Tag": "SET CLUSTER SETTING", "User": "root", "Value": "false"}
+1  {"ApplicationName": "$ internal-enable-merge-queue", "EventType": "set_cluster_setting", "SettingName": "kv.range_merge.queue_enabled", "Statement": "SET CLUSTER SETTING \"kv.range_merge.queue_enabled\" = false", "Tag": "SET CLUSTER SETTING", "User": "root", "Value": "false"}
 1  {"EventType": "set_cluster_setting", "SettingName": "sql.crdb_internal.table_row_statistics.as_of_time", "Statement": "SET CLUSTER SETTING \"sql.crdb_internal.table_row_statistics.as_of_time\" = e'-1\\u00B5s'", "Tag": "SET CLUSTER SETTING", "User": "root", "Value": "-00:00:00.000001"}
 1  {"EventType": "set_cluster_setting", "SettingName": "kv.allocator.load_based_lease_rebalancing.enabled", "Statement": "SET CLUSTER SETTING \"kv.allocator.load_based_lease_rebalancing.enabled\" = false", "Tag": "SET CLUSTER SETTING", "User": "root", "Value": "false"}
 1  {"EventType": "set_cluster_setting", "SettingName": "kv.allocator.load_based_lease_rebalancing.enabled", "Statement": "SET CLUSTER SETTING \"kv.allocator.load_based_lease_rebalancing.enabled\" = DEFAULT", "Tag": "SET CLUSTER SETTING", "User": "root", "Value": "DEFAULT"}

--- a/pkg/sql/pgwire/conn_test.go
+++ b/pkg/sql/pgwire/conn_test.go
@@ -80,7 +80,7 @@ func TestConn(t *testing.T) {
 	// server that the client will connect to; we just use it on the side to
 	// execute some metadata queries that pgx sends whenever it opens a
 	// connection.
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{Insecure: true, UseDatabase: "system"})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{Insecure: true, UseDatabase: "system"})
 	defer s.Stopper().Stop(context.Background())
 
 	// Start a pgwire "server".
@@ -917,7 +917,7 @@ func TestConnCloseReleasesLocks(t *testing.T) {
 	// We're going to test closing the connection in both the Open and Aborted
 	// state.
 	testutils.RunTrueAndFalse(t, "open state", func(t *testing.T, open bool) {
-		s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+		s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 		ctx := context.Background()
 		defer s.Stopper().Stop(ctx)
 
@@ -1275,7 +1275,7 @@ func TestConnCloseCancelsAuth(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	authBlocked := make(chan struct{})
-	s, _, _ := serverutils.StartServer(t,
+	s := serverutils.StartServerOnly(t,
 		base.TestServerArgs{
 			Insecure: true,
 			Knobs: base.TestingKnobs{
@@ -1989,7 +1989,7 @@ func TestPGWireRejectsNewConnIfTooManyConns(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	testServer, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	testServer := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer testServer.Stopper().Stop(ctx)
 
 	// Users.
@@ -2204,7 +2204,7 @@ func TestPGWireRejectsNewConnIfTooManyConns(t *testing.T) {
 func TestConnCloseReleasesReservedMem(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	ctx := context.Background()
 	defer s.Stopper().Stop(ctx)
 

--- a/pkg/sql/pgwire/pgwire_test.go
+++ b/pkg/sql/pgwire/pgwire_test.go
@@ -72,7 +72,7 @@ func TestPGWireDrainClient(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	srv, _, _ := serverutils.StartServer(t, base.TestServerArgs{Insecure: true})
+	srv := serverutils.StartServerOnly(t, base.TestServerArgs{Insecure: true})
 	ctx := context.Background()
 	defer srv.Stopper().Stop(ctx)
 	tt := srv.ApplicationLayer()
@@ -144,7 +144,7 @@ func TestPGWireDrainOngoingTxns(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{Insecure: true})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{Insecure: true})
 	ctx := context.Background()
 	defer s.Stopper().Stop(ctx)
 
@@ -1550,7 +1550,7 @@ func TestSQLNetworkMetrics(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	defer ccl.TestingEnableEnterprise()()
 
-	srv, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	srv := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer srv.Stopper().Stop(context.Background())
 
 	// Setup pgwire client.
@@ -1649,7 +1649,7 @@ func TestPGWireOverUnixSocket(t *testing.T) {
 		Insecure:   true,
 		SocketFile: socketFile,
 	}
-	s, _, _ := serverutils.StartServer(t, params)
+	s := serverutils.StartServerOnly(t, params)
 	defer s.Stopper().Stop(context.Background())
 
 	// We can't pass socket paths as url.Host to libpq, use ?host=/... instead.
@@ -1729,7 +1729,7 @@ func TestSessionParameters(t *testing.T) {
 
 	ctx := context.Background()
 	params := base.TestServerArgs{Insecure: true}
-	srv, _, _ := serverutils.StartServer(t, params)
+	srv := serverutils.StartServerOnly(t, params)
 	defer srv.Stopper().Stop(ctx)
 	s := srv.ApplicationLayer()
 
@@ -1846,7 +1846,7 @@ func TestCancelRequest(t *testing.T) {
 	testutils.RunTrueAndFalse(t, "insecure", func(t *testing.T, insecure bool) {
 		ctx := context.Background()
 		params := base.TestServerArgs{Insecure: insecure}
-		srv, _, _ := serverutils.StartServer(t, params)
+		srv := serverutils.StartServerOnly(t, params)
 		defer srv.Stopper().Stop(ctx)
 		s := srv.ApplicationLayer()
 
@@ -1884,7 +1884,7 @@ func TestUnsupportedGSSEnc(t *testing.T) {
 	testutils.RunTrueAndFalse(t, "insecure", func(t *testing.T, insecure bool) {
 		ctx := context.Background()
 		params := base.TestServerArgs{Insecure: insecure}
-		srv, _, _ := serverutils.StartServer(t, params)
+		srv := serverutils.StartServerOnly(t, params)
 		defer srv.Stopper().Stop(ctx)
 		s := srv.ApplicationLayer()
 

--- a/pkg/sql/pgwire/pgwirecancel/cancel_test.go
+++ b/pkg/sql/pgwire/pgwirecancel/cancel_test.go
@@ -174,7 +174,7 @@ func TestCancelCopyTo(t *testing.T) {
 	ctx := context.Background()
 	skip.UnderStress(t, "flaky")
 
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
 
 	pgURL, cleanup := sqlutils.PGUrl(

--- a/pkg/sql/rowexec/inverted_filterer_test.go
+++ b/pkg/sql/rowexec/inverted_filterer_test.go
@@ -123,7 +123,7 @@ func TestInvertedFilterer(t *testing.T) {
 	}
 	// Setup test environment.
 	ctx := context.Background()
-	server, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	server := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer server.Stopper().Stop(ctx)
 	testConfig := DefaultProcessorTestConfig()
 	diskMonitor := execinfra.NewTestDiskMonitor(ctx, testConfig.FlowCtx.Cfg.Settings)

--- a/pkg/sql/schemachanger/scbackup/job_test.go
+++ b/pkg/sql/schemachanger/scbackup/job_test.go
@@ -49,7 +49,7 @@ func TestCreateDeclarativeSchemaChangeJobs(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(context.Background())
 
 	t.Run("all-targets-reached-their-target-status", func(t *testing.T) {

--- a/pkg/sql/show_test.go
+++ b/pkg/sql/show_test.go
@@ -667,7 +667,7 @@ func TestShowQueriesDelegatesInternal(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
 
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
 
 	pgURL, cleanup := sqlutils.PGUrl(

--- a/pkg/sql/sqlinstance/instancestorage/instancecache_test.go
+++ b/pkg/sql/sqlinstance/instancestorage/instancecache_test.go
@@ -70,7 +70,7 @@ func TestRangeFeed(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	host, _, _ := serverutils.StartServer(t, base.TestServerArgs{DefaultTestTenant: base.TODOTestTenantDisabled})
+	host := serverutils.StartServerOnly(t, base.TestServerArgs{DefaultTestTenant: base.TODOTestTenantDisabled})
 	defer host.Stopper().Stop(ctx)
 
 	tenant, tenantSQL := serverutils.StartTenant(t, host, base.TestTenantArgs{

--- a/pkg/sql/sqlstats/persistedsqlstats/compaction_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/compaction_test.go
@@ -51,7 +51,7 @@ func TestSQLStatsCompactorNilTestingKnobCheck(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	srv, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	srv := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer srv.Stopper().Stop(ctx)
 
 	server := srv.ApplicationLayer()

--- a/pkg/sql/sqlstats/persistedsqlstats/flush_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/flush_test.go
@@ -210,7 +210,7 @@ func TestSQLStatsInitialDelay(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	params, _ := tests.CreateTestServerParams()
-	srv, _, _ := serverutils.StartServer(t, params)
+	srv := serverutils.StartServerOnly(t, params)
 	defer srv.Stopper().Stop(context.Background())
 	s := srv.ApplicationLayer()
 

--- a/pkg/sql/sqlstats/sslocal/sql_stats_test.go
+++ b/pkg/sql/sqlstats/sslocal/sql_stats_test.go
@@ -876,7 +876,7 @@ func TestTransactionServiceLatencyOnExtendedProtocol(t *testing.T) {
 			}
 		},
 	}
-	s, _, _ := serverutils.StartServer(t, params)
+	s := serverutils.StartServerOnly(t, params)
 	defer s.Stopper().Stop(ctx)
 
 	pgURL, cleanupGoDB := sqlutils.PGUrl(

--- a/pkg/sql/stats/automatic_stats_test.go
+++ b/pkg/sql/stats/automatic_stats_test.go
@@ -672,7 +672,7 @@ func TestNoRetryOnFailure(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
 
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
 
 	st := cluster.MakeTestingClusterSettings()

--- a/pkg/sql/stats/delete_stats_test.go
+++ b/pkg/sql/stats/delete_stats_test.go
@@ -40,7 +40,7 @@ func TestDeleteOldStatsForColumns(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
 	db := s.InternalDB().(descs.DB)
 	cache := NewTableStatisticsCache(
@@ -335,7 +335,7 @@ func TestDeleteOldStatsForOtherColumns(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
 	db := s.InternalDB().(isql.DB)
 	cache := NewTableStatisticsCache(

--- a/pkg/sql/stats/stats_cache_test.go
+++ b/pkg/sql/stats/stats_cache_test.go
@@ -217,7 +217,7 @@ func TestCacheBasic(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
 	db := s.InternalDB().(descs.DB)
 	expectedStats, err := initTestData(ctx, db.Executor())
@@ -373,7 +373,7 @@ func TestCacheWait(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
 	db := s.InternalDB().(descs.DB)
 

--- a/pkg/sql/tests/empty_query_test.go
+++ b/pkg/sql/tests/empty_query_test.go
@@ -31,7 +31,7 @@ func TestEmptyQuery(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{Insecure: false, UseDatabase: "defaultdb"})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{Insecure: false, UseDatabase: "defaultdb"})
 	defer s.Stopper().Stop(context.Background())
 
 	pgURL, cleanupFunc := sqlutils.PGUrl(

--- a/pkg/sql/tests/search_path_test.go
+++ b/pkg/sql/tests/search_path_test.go
@@ -29,7 +29,7 @@ func TestSearchPathEndToEnd(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	ctx := context.Background()
 	defer s.Stopper().Stop(ctx)
 

--- a/pkg/testutils/dir.go
+++ b/pkg/testutils/dir.go
@@ -12,7 +12,6 @@ package testutils
 
 import (
 	"os"
-	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/build/bazel"
 	"github.com/cockroachdb/cockroach/pkg/util/fileutil"
@@ -20,7 +19,7 @@ import (
 
 // TempDir creates a directory and a function to clean it up at the end of the
 // test.
-func TempDir(t testing.TB) (string, func()) {
+func TempDir(t TestNamedFatalerLogger) (string, func()) {
 	tmpDir := ""
 	if bazel.BuiltWithBazel() {
 		// Bazel sets up private temp directories for each test.

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -2263,7 +2263,6 @@ func TestLint(t *testing.T) {
 			":!server/application_api/insights_test.go",
 			":!server/application_api/jobs_test.go",
 			":!server/application_api/query_plan_test.go",
-			":!server/application_api/schema_inspection_test.go",
 			":!server/application_api/security_test.go",
 			":!server/application_api/zcfg_test.go",
 			":!server/grpc_gateway_test.go",

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -585,6 +585,38 @@ func TestLint(t *testing.T) {
 		}
 	})
 
+	t.Run("TestStartServer", func(t *testing.T) {
+		t.Parallel()
+		cmd, stderr, filter, err := dirCmd(
+			pkgDir,
+			"git",
+			"grep",
+			"-nE",
+			`, _, _ :?= serverutils\.StartServer\(`,
+			"--",
+			"*_test.go",
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := cmd.Start(); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := stream.ForEach(filter, func(s string) {
+			t.Errorf("\n%s <- forbidden; use 'serverutils.StartServerOnly' instead", s)
+		}); err != nil {
+			t.Error(err)
+		}
+
+		if err := cmd.Wait(); err != nil {
+			if out := stderr.String(); len(out) > 0 {
+				t.Fatalf("err=%s, stderr=%s", err, out)
+			}
+		}
+	})
+
 	t.Run("TestSQLTelemetryDirectCount", func(t *testing.T) {
 		t.Parallel()
 		cmd, stderr, filter, err := dirCmd(

--- a/pkg/testutils/pprof.go
+++ b/pkg/testutils/pprof.go
@@ -14,12 +14,11 @@ import (
 	"os"
 	"runtime"
 	"runtime/pprof"
-	"testing"
 )
 
 // WriteProfile serialized the pprof profile with the given name to a file at
 // the given path.
-func WriteProfile(t testing.TB, name string, path string) {
+func WriteProfile(t TestFataler, name string, path string) {
 	f, err := os.Create(path)
 	if err != nil {
 		t.Fatal(err)
@@ -45,7 +44,7 @@ func WriteProfile(t testing.TB, name string, path string) {
 // The resulting profiles are then diffed via:
 //
 //	go tool pprof -base mem.before mem.after
-func AllocProfileDiff(t testing.TB, beforePath, afterPath string, fn func()) {
+func AllocProfileDiff(t TestFatalerLogger, beforePath, afterPath string, fn func()) {
 	// Use "allocs" instead of "heap" to match what -memprofile does. Also run
 	// runtime.GC immediately before grabbing the profile because the allocs
 	// profile is materialized on gc, so this makes sure we have the latest data.

--- a/pkg/testutils/serverutils/BUILD.bazel
+++ b/pkg/testutils/serverutils/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
         "//pkg/settings/cluster",
         "//pkg/sql/catalog",
         "//pkg/sql/catalog/descpb",
+        "//pkg/sql/isql",
         "//pkg/storage",
         "//pkg/testutils",
         "//pkg/testutils/skip",

--- a/pkg/testutils/serverutils/api.go
+++ b/pkg/testutils/serverutils/api.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	gosql "database/sql"
 	"net/http"
-	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/config"
@@ -105,14 +104,14 @@ type ApplicationLayerInterface interface {
 	// For the second argument use catalogkeys.DefaultDatabaseName or
 	// catconstants.SystemDatabaseName when in doubt. An empty
 	// string results in DefaultDatabaseName being used.
-	SQLConn(t testing.TB, dbName string) *gosql.DB
+	SQLConn(t TestFataler, dbName string) *gosql.DB
 
 	// SQLConnE is like SQLConn but it allows the test to check the error.
 	SQLConnE(dbName string) (*gosql.DB, error)
 
 	// SQLConnForUser is like SQLConn but allows the test to specify a
 	// username.
-	SQLConnForUser(t testing.TB, userName, dbName string) *gosql.DB
+	SQLConnForUser(t TestFataler, userName, dbName string) *gosql.DB
 
 	// SQLConnForUserE is like SQLConnForUser but it allows the test to
 	// check the error.

--- a/pkg/testutils/serverutils/test_cluster_utils.go
+++ b/pkg/testutils/serverutils/test_cluster_utils.go
@@ -14,13 +14,11 @@ import (
 	"context"
 	"fmt"
 	"strconv"
-
-	"github.com/cockroachdb/cockroach/pkg/testutils"
 )
 
 // SetClusterSetting executes set cluster settings statement, and then ensures that
 // all nodes in the test cluster see that setting update.
-func SetClusterSetting(t testutils.TB, c TestClusterInterface, name string, value interface{}) {
+func SetClusterSetting(t TestFataler, c TestClusterInterface, name string, value interface{}) {
 	t.Helper()
 	strVal := func() string {
 		switch v := value.(type) {

--- a/pkg/testutils/serverutils/test_server_shim.go
+++ b/pkg/testutils/serverutils/test_server_shim.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
+	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
@@ -94,7 +95,7 @@ func ShouldStartDefaultTestTenant(t testing.TB, serverArgs base.TestServerArgs) 
 	// of an "enable" value, because it probabilistically returns its default value
 	// more often than not and that is what we want.
 	enabled := !util.ConstantWithMetamorphicTestBoolWithoutLogging("disable-test-tenant", false)
-	if enabled {
+	if enabled && t != nil {
 		t.Log(DefaultTestTenantMessage)
 	}
 	return enabled
@@ -109,15 +110,9 @@ func InitTestServerFactory(impl TestServerFactory) {
 	srvFactoryImpl = impl
 }
 
-// StartServer creates and starts a test server.
-// The returned server should be stopped by calling
-// server.Stopper().Stop().
-// The second and third return values are equivalent to
-// .ApplicationLayer().SQLConn() and .ApplicationLayer().DB(),
-// respectively.
-func StartServer(
-	t testing.TB, params base.TestServerArgs,
-) (TestServerInterface, *gosql.DB, *kv.DB) {
+// StartServerOnlyE is like StartServerOnly() but it lets
+// the test decide what to do with the error.
+func StartServerOnlyE(t testing.TB, params base.TestServerArgs) (TestServerInterface, error) {
 	allowAdditionalTenants := params.DefaultTestTenant.AllowAdditionalTenants()
 	// Determine if we should probabilistically start a test tenant
 	// for this server.
@@ -133,11 +128,14 @@ func StartServer(
 
 	s, err := NewServer(params)
 	if err != nil {
-		t.Fatalf("%+v", err)
+		return nil, err
 	}
 
-	if err := s.Start(context.Background()); err != nil {
-		t.Fatalf("%+v", err)
+	ctx := context.Background()
+
+	if err := s.Start(ctx); err != nil {
+		s.Stopper().Stop(ctx)
+		return nil, err
 	}
 
 	if s.StartedDefaultTestTenant() {
@@ -148,17 +146,48 @@ func StartServer(
 		s.DisableStartTenant(PreventStartTenantError)
 	}
 
-	goDB := s.ApplicationLayer().SQLConn(t, params.UseDatabase)
-
 	// Now that we have started the server on the bootstrap version, let us run
 	// the migrations up to the overridden BinaryVersion.
 	if v := s.BinaryVersionOverride(); v != (roachpb.Version{}) {
-		if _, err := goDB.Exec(`SET CLUSTER SETTING version = $1`, v.String()); err != nil {
-			t.Fatal(err)
+		for _, layer := range []ApplicationLayerInterface{s.SystemLayer(), s.ApplicationLayer()} {
+			ie := layer.InternalExecutor().(isql.Executor)
+			if _, err := ie.Exec(ctx, "set-version", nil, /* kv.Txn */
+				`SET CLUSTER SETTING version = $1`, v.String()); err != nil {
+				s.Stopper().Stop(ctx)
+				return nil, err
+			}
 		}
 	}
 
-	return s, goDB, s.DB()
+	return s, nil
+}
+
+// StartServerOnly creates and starts a test server.
+// The returned server should be stopped by calling
+// server.Stopper().Stop().
+func StartServerOnly(t testing.TB, params base.TestServerArgs) TestServerInterface {
+	s, err := StartServerOnlyE(t, params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return s
+}
+
+// StartServer creates and starts a test server.
+// The returned server should be stopped by calling
+// server.Stopper().Stop().
+//
+// The second and third return values are equivalent to
+// .ApplicationLayer().SQLConn() and .ApplicationLayer().DB(),
+// respectively. If your test does not need them, consider
+// using StartServerOnly() instead.
+func StartServer(
+	t testing.TB, params base.TestServerArgs,
+) (TestServerInterface, *gosql.DB, *kv.DB) {
+	s := StartServerOnly(t, params)
+	goDB := s.ApplicationLayer().SQLConn(t, params.UseDatabase)
+	kvDB := s.ApplicationLayer().DB()
+	return s, goDB, kvDB
 }
 
 // NewServer creates a test server.
@@ -213,23 +242,6 @@ func OpenDBConn(
 		t.Fatal(err)
 	}
 	return conn
-}
-
-// StartServerRaw creates and starts a TestServer.
-// Generally StartServer() should be used. However, this function can be used
-// directly when opening a connection to the server is not desired.
-func StartServerRaw(t testing.TB, args base.TestServerArgs) (TestServerInterface, error) {
-	server, err := NewServer(args)
-	if err != nil {
-		return nil, err
-	}
-	if err := server.Start(context.Background()); err != nil {
-		return nil, err
-	}
-	if server.StartedDefaultTestTenant() {
-		t.Log(DefaultTestTenantMessage)
-	}
-	return server, nil
 }
 
 // StartTenant starts a tenant SQL server connecting to the supplied test

--- a/pkg/testutils/soon.go
+++ b/pkg/testutils/soon.go
@@ -37,7 +37,7 @@ const (
 // immediately at first and then successively with an exponential backoff
 // starting at 1ns and ending at DefaultSucceedsSoonDuration (or
 // RaceSucceedsSoonDuration if race is enabled).
-func SucceedsSoon(t TB, fn func() error) {
+func SucceedsSoon(t TestFataler, fn func() error) {
 	t.Helper()
 	SucceedsWithin(t, fn, succeedsSoonDuration())
 }
@@ -55,7 +55,7 @@ func SucceedsSoonError(fn func() error) error {
 // function runs without error within the given duration. The function
 // is invoked immediately at first and then successively with an
 // exponential backoff starting at 1ns and ending at duration.
-func SucceedsWithin(t TB, fn func() error, duration time.Duration) {
+func SucceedsWithin(t TestFataler, fn func() error, duration time.Duration) {
 	t.Helper()
 	if err := SucceedsWithinError(fn, duration); err != nil {
 		if f, l, _, ok := errors.GetOneLineSource(err); ok {

--- a/pkg/testutils/tb.go
+++ b/pkg/testutils/tb.go
@@ -10,12 +10,29 @@
 
 package testutils
 
-// TB is a slimmed down version of testing.TB for use in helper functions
+// TestFataler is a slimmed down version of testing.TB for use in helper functions
 // by testing contexts which do not come from the stdlib testing package.
-type TB interface {
+type TestFataler interface {
 	Fatal(args ...interface{})
 	Fatalf(format string, args ...interface{})
-	Errorf(format string, args ...interface{})
-	FailNow()
 	Helper()
+}
+
+// TestErrorer is like Fataler but it only needs a Error method.
+type TestErrorer interface {
+	Error(args ...interface{})
+	Errorf(format string, args ...interface{})
+	Helper()
+}
+
+// TestFatalerLogger is like Fataler but it also needs a Log method.
+type TestFatalerLogger interface {
+	TestFataler
+	Logf(format string, args ...interface{})
+}
+
+// TestNamedFatalerLogger is like Fataler but it also needs a Name method.
+type TestNamedFatalerLogger interface {
+	TestFatalerLogger
+	Name() string
 }

--- a/pkg/testutils/testcluster/BUILD.bazel
+++ b/pkg/testutils/testcluster/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "//pkg/server/serverpb",
         "//pkg/spanconfig",
         "//pkg/sql/catalog",
+        "//pkg/sql/isql",
         "//pkg/sql/randgen",
         "//pkg/storage",
         "//pkg/testutils",

--- a/pkg/testutils/txn_restart.go
+++ b/pkg/testutils/txn_restart.go
@@ -13,7 +13,6 @@ package testutils
 import (
 	"context"
 	"strings"
-	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
@@ -35,7 +34,7 @@ import (
 //		},
 //	}
 func TestingRequestFilterRetryTxnWithPrefix(
-	t testing.TB, prefix string, maxCount int,
+	t TestErrorer, prefix string, maxCount int,
 ) (func(ctx context.Context, r *kvpb.BatchRequest) *kvpb.Error, func()) {
 	txnTracker := struct {
 		syncutil.Mutex

--- a/pkg/ts/server_test.go
+++ b/pkg/ts/server_test.go
@@ -41,7 +41,7 @@ func TestServerQuery(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{
 		Knobs: base.TestingKnobs{
 			Store: &kvserver.StoreTestingKnobs{
 				DisableTimeSeriesMaintenanceQueue: true,
@@ -266,7 +266,7 @@ func TestServerQueryStarvation(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	workerCount := 20
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{
 		TimeSeriesQueryWorkerMax: workerCount,
 	})
 	defer s.Stopper().Stop(context.Background())
@@ -304,7 +304,7 @@ func TestServerQueryTenant(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{
 		DefaultTestTenant: base.TODOTestTenantDisabled,
 		Knobs: base.TestingKnobs{
 			Store: &kvserver.StoreTestingKnobs{
@@ -543,7 +543,7 @@ func TestServerQueryMemoryManagement(t *testing.T) {
 	sizeOfSlab := int64(unsafe.Sizeof(roachpb.InternalTimeSeriesData{})) + (int64(unsafe.Sizeof(roachpb.InternalTimeSeriesSample{})) * samplesPerSlab)
 	budget := 3 * sizeOfSlab * int64(sourceCount) * int64(workerCount)
 
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{
 		TimeSeriesQueryWorkerMax:    workerCount,
 		TimeSeriesQueryMemoryBudget: budget,
 	})
@@ -614,7 +614,7 @@ func TestServerDump(t *testing.T) {
 
 	expTotalMsgCount := seriesCount * sourceCount * (endSlab - startSlab)
 
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{
 		Knobs: base.TestingKnobs{
 			Store: &kvserver.StoreTestingKnobs{
 				DisableTimeSeriesMaintenanceQueue: true,
@@ -709,7 +709,7 @@ func TestServerDump(t *testing.T) {
 	s.Stopper().Stop(ctx)
 
 	// Start a new server, into which to write the raw dump.
-	s, _, _ = serverutils.StartServer(t, base.TestServerArgs{
+	s = serverutils.StartServerOnly(t, base.TestServerArgs{
 		Knobs: base.TestingKnobs{
 			Store: &kvserver.StoreTestingKnobs{
 				DisableTimeSeriesMaintenanceQueue: true,
@@ -754,7 +754,7 @@ func TestServerDump(t *testing.T) {
 func BenchmarkServerQuery(b *testing.B) {
 	defer log.Scope(b).Close(b)
 
-	s, _, _ := serverutils.StartServer(b, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(b, base.TestServerArgs{})
 	defer s.Stopper().Stop(context.Background())
 	tsrv := s.(*server.TestServer)
 

--- a/pkg/util/log/logcrash/crash_reporting_packet_test.go
+++ b/pkg/util/log/logcrash/crash_reporting_packet_test.go
@@ -98,7 +98,7 @@ func TestCrashReportingPacket(t *testing.T) {
 	func() {
 		defer expectPanic("after server start")
 		defer logcrash.RecoverAndReportPanic(ctx, &st.SV)
-		s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+		s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 		s.Stopper().Stop(ctx)
 		panic(redact.Safe(panicPost))
 	}()

--- a/pkg/util/tracing/tracer_external_test.go
+++ b/pkg/util/tracing/tracer_external_test.go
@@ -109,7 +109,7 @@ func TestTraceForTenantWithLocalKVServer(t *testing.T) {
 	st := cluster.MakeTestingClusterSettings()
 	server.RedactServerTracesForSecondaryTenants.Override(ctx, &st.SV, false)
 	args := base.TestServerArgs{Settings: st}
-	s, _, _ := serverutils.StartServer(t, args)
+	s := serverutils.StartServerOnly(t, args)
 	defer s.Stopper().Stop(ctx)
 
 	// Create our own test tenant with a known name.


### PR DESCRIPTION
The primary purpose of this patch is to tease out a `StartServerOnly()` function that doesn't return a `*gosql.DB` and `*kv.DB`, to improve readability in those tests that don't need them.

In doing so however, this patch also fixes two bugs:

- the advertised behavior of  `StartServer()` was to return `.ApplicationLayer().DB()` in the second return value. However, the code was effectively returning `.SystemLayer().DB()` instead. This patch fixes it.

- in case a binary version override was set in the parameters, the expectation is to upgrade both the storage layer and the application layer to the specified version. The code was only upgrading the application layer. This patch fixes it.

Release note: None
Epic: CRDB-28893