### PR TITLE
db-console: delete unused vars and enforce eslint rule

### DIFF
--- a/pkg/ui/workspaces/db-console/.eslintrc.json
+++ b/pkg/ui/workspaces/db-console/.eslintrc.json
@@ -8,7 +8,7 @@
     "react/jsx-key": "off",
     "@typescript-eslint/ban-types": "off",
     "react/no-unescaped-entities": "off",
-    "@typescript-eslint/no-unused-vars": "off",
+    "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_" }],
     "@typescript-eslint/explicit-module-boundary-types": "off",
     "@typescript-eslint/no-explicit-any": "off",
     "no-restricted-imports": ["error", {

--- a/pkg/ui/workspaces/db-console/src/redux/cachedDataReducer.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/cachedDataReducer.ts
@@ -52,6 +52,9 @@ export class CachedDataReducerState<TResponseMessage> {
 
 // KeyedCachedDataReducerState is used to track the state of the cached data
 // that is associated with a key.
+// This error is a false positive because we do use 'TResponseMessage' to type
+// CachedDataReducerState. We'll suppress the error to make the linter happy.
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export class KeyedCachedDataReducerState<TResponseMessage> {
   [id: string]: CachedDataReducerState<TResponseMessage>;
 }

--- a/pkg/ui/workspaces/db-console/src/redux/nodes.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/nodes.ts
@@ -71,7 +71,10 @@ const partialNodeStatusesSelector = createSelector(
   nodeStatusesSelector,
   (nodeStatuses: INodeStatus[]) => {
     return nodeStatuses?.map((ns: INodeStatus) => {
-      const { metrics, store_statuses, updated_at, activity, ...rest } = ns;
+      // We need to extract the fields that constantly change below, so
+      // suppress the eslint rule.
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { metrics, updated_at, activity, store_statuses, ...rest } = ns;
       return {
         ...rest,
         store_statuses: store_statuses?.map(ss => ({ desc: ss.desc })),

--- a/pkg/ui/workspaces/db-console/src/util/analytics/trackTableSort.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/util/analytics/trackTableSort.spec.ts
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-import _, { get, isString } from "lodash";
+import { get, isString } from "lodash";
 import { track } from "./trackTableSort";
 
 describe("trackTableSort", () => {

--- a/pkg/ui/workspaces/db-console/src/util/api.ts
+++ b/pkg/ui/workspaces/db-console/src/util/api.ts
@@ -25,8 +25,6 @@ export type LocationsResponseMessage =
   protos.cockroach.server.serverpb.LocationsResponse;
 
 export type NodesRequestMessage = protos.cockroach.server.serverpb.NodesRequest;
-export type NodesResponseMessage =
-  protos.cockroach.server.serverpb.NodesResponse;
 export type NodesResponseExternalMessage =
   protos.cockroach.server.serverpb.NodesResponseExternal;
 
@@ -62,8 +60,6 @@ export type ClusterResponseMessage =
 
 export type TableStatsRequestMessage =
   protos.cockroach.server.serverpb.TableStatsRequest;
-export type TableStatsResponseMessage =
-  protos.cockroach.server.serverpb.TableStatsResponse;
 
 export type IndexStatsRequestMessage =
   protos.cockroach.server.serverpb.TableIndexStatsRequest;
@@ -202,11 +198,6 @@ export type KeyVisualizerSamplesRequestMessage =
   protos.cockroach.server.serverpb.KeyVisSamplesRequest;
 export type KeyVisualizerSamplesResponseMessage =
   protos.cockroach.server.serverpb.KeyVisSamplesResponse;
-
-export type ListTracingSnapshotsRequestMessage =
-  protos.cockroach.server.serverpb.ListTracingSnapshotsRequest;
-export type ListTracingSnapshotsResponseMessage =
-  protos.cockroach.server.serverpb.ListTracingSnapshotsResponse;
 
 export type ListTenantsRequestMessage =
   protos.cockroach.server.serverpb.ListTenantsRequest;
@@ -496,26 +487,6 @@ export function getCluster(
   return timeoutFetch(
     serverpb.ClusterResponse,
     `${API_PREFIX}/cluster`,
-    null,
-    timeout,
-  );
-}
-
-// getTableStats gets detailed stats about the current table
-export function getTableStats(
-  req: TableStatsRequestMessage,
-  timeout?: moment.Duration,
-): Promise<TableStatsResponseMessage> {
-  const promiseErr = IsValidateUriName(req.database, req.table);
-  if (promiseErr) {
-    return promiseErr;
-  }
-
-  return timeoutFetch(
-    serverpb.TableStatsResponse,
-    `${API_PREFIX}/databases/${EncodeUriName(
-      req.database,
-    )}/tables/${EncodeUriName(req.table)}/stats`,
     null,
     timeout,
   );

--- a/pkg/ui/workspaces/db-console/src/util/eventTypes.ts
+++ b/pkg/ui/workspaces/db-console/src/util/eventTypes.ts
@@ -10,8 +10,6 @@
 
 // NOTE: This file is kept in sync manually with sql/event_log.go
 
-import _ from "lodash";
-
 // Recorded when a database is created.
 export const CREATE_DATABASE = "create_database";
 // Recorded when a database is dropped.

--- a/pkg/ui/workspaces/db-console/src/views/shared/containers/alerts/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/shared/containers/alerts/index.tsx
@@ -35,6 +35,8 @@ class AlertSection extends React.Component<AlertSectionProps, {}> {
     return (
       <div>
         {_.map(alerts, (a, i) => {
+          // Extract values we don't want.
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
           const { dismiss, ...alertProps } = a;
           const boundDismiss = bindActionCreators(() => a.dismiss, dispatch);
           return <AlertBox key={i} dismiss={boundDismiss} {...alertProps} />;

--- a/pkg/ui/workspaces/db-console/src/views/shared/containers/alerts/overviewListAlerts.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/shared/containers/alerts/overviewListAlerts.tsx
@@ -38,6 +38,8 @@ class OverviewAlertListSection extends React.Component<AlertSectionProps, {}> {
     return (
       <section className="section">
         {_.map(alerts, (a, i) => {
+          // Extract values we don't want.
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
           const { dismiss, ...alertProps } = a;
           const boundDismiss = bindActionCreators(() => a.dismiss, dispatch);
           return <AlertBox key={i} dismiss={boundDismiss} {...alertProps} />;


### PR DESCRIPTION
This commit turns the eslint rule no-unused-vars to errors. It removes all unused vars in the db-console application.

Epic: none

Release note: None