### PR TITLE
server: prevent deadlocks in server orchestration

### DIFF
--- a/pkg/server/server_controller_orchestration.go
+++ b/pkg/server/server_controller_orchestration.go
@@ -96,8 +96,11 @@ func (c *serverController) startInitialSecondaryTenantServers(
 func (c *serverController) scanTenantsForRunnableServices(
 	ctx context.Context, ie isql.Executor,
 ) error {
-	c.mu.Lock()
-	defer c.mu.Unlock()
+	// Gather the list of servers currently running.
+	// We capture this early so that we don't accidentally look
+	// at entries created after the call to `getExpectedRunningTenants()`
+	// by concurrent calls to `createServerEntryLocked()`.
+	curEntries := c.getAllEntries()
 
 	// The list of tenants that should have a running server.
 	reqTenants, err := c.getExpectedRunningTenants(ctx, ie)
@@ -113,7 +116,7 @@ func (c *serverController) scanTenantsForRunnableServices(
 
 	// First check if there are any servers that shouldn't be running
 	// right now.
-	for name, srv := range c.mu.servers {
+	for name, srv := range curEntries {
 		if _, ok := nameLookup[name]; !ok {
 			log.Infof(ctx, "tenant %q has changed service mode, should now stop", name)
 			// Mark the server for async shutdown.
@@ -122,6 +125,8 @@ func (c *serverController) scanTenantsForRunnableServices(
 	}
 
 	// Now add all the missing servers.
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	for _, name := range reqTenants {
 		if _, ok := c.mu.servers[name]; !ok {
 			log.Infof(ctx, "tenant %q has changed service mode, should now start", name)
@@ -297,12 +302,12 @@ func (c *serverController) drain(ctx context.Context) (stillRunning int) {
 	return notStopped
 }
 
-func (c *serverController) getAllEntries() (res []serverState) {
+func (c *serverController) getAllEntries() (res map[roachpb.TenantName]serverState) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	res = make([]serverState, 0, len(c.mu.servers))
-	for _, e := range c.mu.servers {
-		res = append(res, e)
+	res = make(map[roachpb.TenantName]serverState, len(c.mu.servers))
+	for name, e := range c.mu.servers {
+		res[name] = e
 	}
 	return res
 }


### PR DESCRIPTION
Fixes #107564.
Informs #107791.
Supersedes #107666.

The previous fix in this
area (5ca5703489862051e4efbe3b220e2df1c658a2dc) correctly identified the case where `createServerEntryLocked()` was called concurrently with `scanTenantsForRunnableServices()`, in which case we ran the risk of immediately tearing down the new server because it hadn't be picked up by `getExpectedRunningTenants()`.

However, the fix was incorrect: it was causing the controller mutex to be held through `getExpectedRunningTenants()`, which itself can hang. In that case, a cascading failure could result.

This patch changes the fix (and thus continues to solve the original problem) by ensuring we only look at entries to remove that existed prior to the call to `getExpectedRunningTenants()`. No mutex needs to be held here.

Release note: None
Epic: CRDB-28893