### PR TITLE
ui: fix check for config

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.selectors.ts
@@ -75,6 +75,6 @@ export const selectStatementDetails = createSelector(
 );
 
 export const selectStatementDetailsUiConfig = createSelector(
-  (state: AppState) => state.adminUI?.uiConfig.pages.statementDetails,
+  (state: AppState) => state.adminUI?.uiConfig?.pages.statementDetails,
   statementDetailsUiConfig => statementDetailsUiConfig,
 );

--- a/pkg/ui/workspaces/cluster-ui/src/store/sessions/sessions.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/sessions/sessions.selectors.ts
@@ -33,6 +33,6 @@ export const selectSession = createSelector(
 );
 
 export const selectSessionDetailsUiConfig = createSelector(
-  (state: AppState) => state.adminUI?.uiConfig.pages.sessionDetails,
+  (state: AppState) => state.adminUI?.uiConfig?.pages.sessionDetails,
   statementDetailsUiConfig => statementDetailsUiConfig,
 );

--- a/pkg/ui/workspaces/cluster-ui/src/store/uiConfig/uiConfig.selector.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/uiConfig/uiConfig.selector.ts
@@ -18,14 +18,14 @@ export const selectUIConfig = createSelector(
 
 export const selectIsTenant = createSelector(
   selectUIConfig,
-  uiConfig => uiConfig.isTenant,
+  uiConfig => uiConfig?.isTenant,
 );
 
 export const selectHasViewActivityRedactedRole = createSelector(
   selectUIConfig,
-  uiConfig => uiConfig.userSQLRoles.includes("VIEWACTIVITYREDACTED"),
+  uiConfig => uiConfig?.userSQLRoles.includes("VIEWACTIVITYREDACTED"),
 );
 
 export const selectHasAdminRole = createSelector(selectUIConfig, uiConfig =>
-  uiConfig.userSQLRoles.includes("ADMIN"),
+  uiConfig?.userSQLRoles.includes("ADMIN"),
 );


### PR DESCRIPTION
Add check of UIConfig used on CC Console, which could be undefinied initially and cause a crash.

Epic: none

Release note: None