### PR TITLE
build,ui: make webpack copy plugin more resilient, and emit typescript declarations with `dev ui watch`

### DIFF
--- a/dev
+++ b/dev
@@ -8,7 +8,7 @@ fi
 set -euo pipefail
 
 # Bump this counter to force rebuilding `dev` on all machines.
-DEV_VERSION=83
+DEV_VERSION=84
 
 THIS_DIR=$(cd "$(dirname "$0")" && pwd)
 BINARY_DIR=$THIS_DIR/bin/dev-versions

--- a/pkg/cmd/dev/testdata/datadriven/ui
+++ b/pkg/cmd/dev/testdata/datadriven/ui
@@ -13,6 +13,7 @@ cp sandbox/pkg/ui/workspaces/db-console/ccl/src/js/protos.d.ts crdb-checkout/pkg
 rm -rf crdb-checkout/pkg/ui/workspaces/cluster-ui/dist
 cp -r sandbox/pkg/ui/workspaces/cluster-ui/dist crdb-checkout/pkg/ui/workspaces/cluster-ui/dist
 pnpm --dir crdb-checkout/pkg/ui/workspaces/cluster-ui run build:watch
+pnpm --dir crdb-checkout/pkg/ui/workspaces/cluster-ui run tsc:watch
 pnpm --dir crdb-checkout/pkg/ui/workspaces/db-console exec webpack-dev-server --config webpack.config.js --mode development --env.WEBPACK_SERVE --env.dist=ccl --env.target=http://localhost:8080 --port 3000
 
 exec
@@ -28,6 +29,7 @@ cp sandbox/pkg/ui/workspaces/db-console/src/js/protos.d.ts crdb-checkout/pkg/ui/
 rm -rf crdb-checkout/pkg/ui/workspaces/cluster-ui/dist
 cp -r sandbox/pkg/ui/workspaces/cluster-ui/dist crdb-checkout/pkg/ui/workspaces/cluster-ui/dist
 pnpm --dir crdb-checkout/pkg/ui/workspaces/cluster-ui run build:watch
+pnpm --dir crdb-checkout/pkg/ui/workspaces/cluster-ui run tsc:watch
 pnpm --dir crdb-checkout/pkg/ui/workspaces/db-console exec webpack-dev-server --config webpack.config.js --mode development --env.WEBPACK_SERVE --env.dist=oss --env.target=http://localhost:8080 --port 3000
 
 exec
@@ -45,6 +47,7 @@ cp sandbox/pkg/ui/workspaces/db-console/ccl/src/js/protos.d.ts crdb-checkout/pkg
 rm -rf crdb-checkout/pkg/ui/workspaces/cluster-ui/dist
 cp -r sandbox/pkg/ui/workspaces/cluster-ui/dist crdb-checkout/pkg/ui/workspaces/cluster-ui/dist
 pnpm --dir crdb-checkout/pkg/ui/workspaces/cluster-ui run build:watch
+pnpm --dir crdb-checkout/pkg/ui/workspaces/cluster-ui run tsc:watch
 pnpm --dir crdb-checkout/pkg/ui/workspaces/db-console exec webpack-dev-server --config webpack.config.js --mode development --env.WEBPACK_SERVE --env.dist=ccl --env.target=http://localhost:8080 --port 3000 --https
 
 exec
@@ -62,6 +65,7 @@ cp sandbox/pkg/ui/workspaces/db-console/ccl/src/js/protos.d.ts crdb-checkout/pkg
 rm -rf crdb-checkout/pkg/ui/workspaces/cluster-ui/dist
 cp -r sandbox/pkg/ui/workspaces/cluster-ui/dist crdb-checkout/pkg/ui/workspaces/cluster-ui/dist
 pnpm --dir crdb-checkout/pkg/ui/workspaces/cluster-ui run build:watch
+pnpm --dir crdb-checkout/pkg/ui/workspaces/cluster-ui run tsc:watch
 pnpm --dir crdb-checkout/pkg/ui/workspaces/db-console exec webpack-dev-server --config webpack.config.js --mode development --env.WEBPACK_SERVE --env.dist=ccl --env.target=http://example.crdb.io:4848 --port 3000
 
 exec
@@ -79,6 +83,7 @@ cp sandbox/pkg/ui/workspaces/db-console/ccl/src/js/protos.d.ts crdb-checkout/pkg
 rm -rf crdb-checkout/pkg/ui/workspaces/cluster-ui/dist
 cp -r sandbox/pkg/ui/workspaces/cluster-ui/dist crdb-checkout/pkg/ui/workspaces/cluster-ui/dist
 pnpm --dir crdb-checkout/pkg/ui/workspaces/cluster-ui run build:watch
+pnpm --dir crdb-checkout/pkg/ui/workspaces/cluster-ui run tsc:watch
 pnpm --dir crdb-checkout/pkg/ui/workspaces/db-console exec webpack-dev-server --config webpack.config.js --mode development --env.WEBPACK_SERVE --env.dist=ccl --env.target=http://localhost:8080 --port 12345
 
 exec
@@ -96,6 +101,7 @@ cp sandbox/pkg/ui/workspaces/db-console/ccl/src/js/protos.d.ts crdb-checkout/pkg
 rm -rf crdb-checkout/pkg/ui/workspaces/cluster-ui/dist
 cp -r sandbox/pkg/ui/workspaces/cluster-ui/dist crdb-checkout/pkg/ui/workspaces/cluster-ui/dist
 pnpm --dir crdb-checkout/pkg/ui/workspaces/cluster-ui run build:watch --env.copy-to=/path/to/foo --env.copy-to=/path/to/bar
+pnpm --dir crdb-checkout/pkg/ui/workspaces/cluster-ui run tsc:watch --copy-to=/path/to/foo --copy-to=/path/to/bar
 pnpm --dir crdb-checkout/pkg/ui/workspaces/db-console exec webpack-dev-server --config webpack.config.js --mode development --env.WEBPACK_SERVE --env.dist=ccl --env.target=http://localhost:8080 --port 3000
 
 exec

--- a/pkg/ui/workspaces/cluster-ui/build/typescript/watchWithMultipleDests.js
+++ b/pkg/ui/workspaces/cluster-ui/build/typescript/watchWithMultipleDests.js
@@ -20,15 +20,16 @@ const { cleanDestinationPaths, tildeify } = require("../util");
  * A minimal wrapper around tsc --watch, implemented using the typescript JS API
  * to support writing emitted files to multiple directories.
  * This function never returns, as it hosts a filesystem 'watcher'.
- * @params {Object} options - a bag of options
- * @params {string[]} options.destinations - an array of directories to emit declarations to.
- *                                           The default from tsconfig.json will be automatically
- *                                           prepended to this list.
+ * @param {Object} opts - a bag of options
+ * @param {boolean} opts.interactive - whether to show compiler errors as they occur.
+ * @param {string[]} opts.destinations - an array of directories to emit declarations to.
+ *                                       The default from tsconfig.json will be automatically
+ *                                       prepended to this list.
  * @returns never
  * @see https://github.com/microsoft/TypeScript/wiki/Using-the-Compiler-API/167d197d290bec04b626b91b6f453123ef309e58#writing-an-incremental-program-watcher
  */
-function watch(options) {
-  const destinations = options.destinations;
+function watch(opts) {
+  const destinations = opts.destinations;
 
   // Find a tsconfig.json.
   const configPath = ts.findConfigFile(
@@ -58,6 +59,10 @@ function watch(options) {
     }
   }
 
+  const reportWatchStatus = opts.interactive
+    ? undefined // default output
+    : () => {}; // nop output
+
   // Create a watching compiler host that we'll pass to ts.createWatchProgram
   // later.
   const host = ts.createWatchCompilerHost(
@@ -65,29 +70,37 @@ function watch(options) {
     /* optionsToExtend */ {},
     {
       ...ts.sys,
+      // Never clear the screen, to simulate tsc --watch --preserveWatchOutput.
+      clearScreen: undefined,
       writeFile,
     },
     ts.createEmitAndSemanticDiagnosticsBuilderProgram,
+    // Use the default diagnostic reporter.
+    /* reportDiagnostic */ undefined,
+    reportWatchStatus,
   );
 
   // Create a wrapper around the default createProgram hook (called whenever a
-  // compilation pass starts) to log a helpful message. Note that in TS 4.2,
-  // there's no way to suppress typescript's default terminal-clearing behavior
-  // when a program is created. To keep anyone from forgetting, print this
-  // message every time.
+  // compilation pass starts) to log a helpful message every time in interactive
+  // mode and just once otherwise.
   const origCreateProgram = host.createProgram;
+  let createProgramHasRun = false;
   host.createProgram = (rootNames, options, host, oldProgram, configFileParsingDiagnostics, projectReferences) => {
-    const compilerOptions = options || {};
-    const currentDir = host.getCurrentDirectory();
-    // Compute the declaration directory relative to the project root.
-    const relDeclarationDir = path.relative(
-      currentDir,
-      compilerOptions.declarationDir || compilerOptions.outDir || ""
-    );
+    if (opts.interactive || !createProgramHasRun) {
+      createProgramHasRun = true;
 
-    console.log("Declarations will be written to:")
-    for (const dst of ["./"].concat(destinations)) {
-      console.log(`  ${tildeify(path.join(dst, relDeclarationDir))}`);
+      const compilerOptions = options || {};
+      const currentDir = host.getCurrentDirectory();
+      // Compute the declaration directory relative to the project root.
+      const relDeclarationDir = path.relative(
+        currentDir,
+        compilerOptions.declarationDir || compilerOptions.outDir || ""
+      );
+
+      console.log("TypeScript declarations will be silently written to:")
+      for (const dst of ["./"].concat(destinations)) {
+        console.log(`  ${tildeify(path.join(dst, relDeclarationDir))}`);
+      }
     }
 
     return origCreateProgram(rootNames, options, host, oldProgram, configFileParsingDiagnostics, projectReferences);
@@ -101,17 +114,19 @@ function watch(options) {
 const isHelp = argv.h || argv.help;
 const hasPositionalArgs = argv._.length !== 0;
 if (isHelp || hasPositionalArgs) {
-  const argv1 = path.relative(path.join(__dirname, "../../"), argv[1]);
+  const argv1 = path.relative(path.join(__dirname, "../../"), process.argv[1]);
   const help = `
 ${argv1} - a minimal replacement for 'tsc --watch' that copies generated files to extra directories.
 
 Usage:
-  ${argv1} [--copy-to DIR]...
+  ${argv1} [--no-interactive] [--copy-to DIR]...
 
 Flags:
-  --copy-to DIR path to copy emitted files to, in addition to the default in
-                tsconfig.json. Can be specified multiple times.
-  -h, --help    prints this message
+  --no-interactive print TS compiler errors if they occur and clear the terminal
+                   between compilations.
+  --copy-to DIR    path to copy emitted files to, in addition to the default in
+                   tsconfig.json. Can be specified multiple times.
+  -h, --help       prints this message
   `;
 
   if (hasPositionalArgs) {
@@ -128,5 +143,6 @@ const destinations = typeof copyToArgs === "string"
   : (copyToArgs || []);
 
 watch({
+  interactive: argv.interactive ?? true,
   destinations: cleanDestinationPaths(destinations),
 });

--- a/pkg/ui/workspaces/cluster-ui/package.json
+++ b/pkg/ui/workspaces/cluster-ui/package.json
@@ -17,7 +17,7 @@
     "build:bundle": "NODE_ENV=production webpack --display-error-details --mode=production",
     "build:typescript": "tsc",
     "build:watch": "webpack --watch --mode=development --env.WEBPACK_WATCH",
-    "tsc:watch": "node build/typescript/watchWithMultipleDests.js",
+    "tsc:watch": "node build/typescript/watchWithMultipleDests.js --no-interactive",
     "ci": "jest --ci -i",
     "clean": "rm -rf  ./dist/*",
     "lint": "eslint './src/**/*.{tsx,ts,js}' --format=codeframe",


### PR DESCRIPTION
When determining how to prepare destinations for copied cluster-ui builds, we'd previously made some incorrect assumptions around file existence and removing symlinks. Use fs.unlink and fs.lstat to properly clear symlinked directories, and add an extra existence check for safety.

Also, `dev ui watch` used to only produce .js files, and instead relied on a separate run of `tsc` to produce .d.ts files for consumption by other packages. Now that produced files are pushed into external directories, have `dev ui watch` also run a TypeScript watcher to produce those .d.ts files.

Release note: None
Epic: none

-----

Note: you may remember the first commit from https://github.com/cockroachdb/cockroach/pull/107809 ! It's basically unchanged.