### PR TITLE
sql: add bitwise operation for varbit with variable length

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -2685,6 +2685,30 @@ The swap_ordinate_string parameter is a 2-character string naming the ordinates 
 </span></td><td>Immutable</td></tr>
 <tr><td><a name="bit_length"></a><code>bit_length(val: varbit) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Calculates the number of bits used to represent <code>val</code>.</p>
 </span></td><td>Immutable</td></tr>
+<tr><td><a name="bitmask_and"></a><code>bitmask_and(a: <a href="string.html">string</a>, b: <a href="string.html">string</a>) &rarr; varbit</code></td><td><span class="funcdesc"><p>Calculates bitwise AND value of unsigned bit arrays ‘a’ and ‘b’ that may have different lengths.</p>
+</span></td><td>Immutable</td></tr>
+<tr><td><a name="bitmask_and"></a><code>bitmask_and(a: <a href="string.html">string</a>, b: varbit) &rarr; varbit</code></td><td><span class="funcdesc"><p>Calculates bitwise AND value of unsigned bit arrays ‘a’ and ‘b’ that may have different lengths.</p>
+</span></td><td>Immutable</td></tr>
+<tr><td><a name="bitmask_and"></a><code>bitmask_and(a: varbit, b: <a href="string.html">string</a>) &rarr; varbit</code></td><td><span class="funcdesc"><p>Calculates bitwise AND value of unsigned bit arrays ‘a’ and ‘b’ that may have different lengths.</p>
+</span></td><td>Immutable</td></tr>
+<tr><td><a name="bitmask_and"></a><code>bitmask_and(a: varbit, b: varbit) &rarr; varbit</code></td><td><span class="funcdesc"><p>Calculates bitwise AND value of unsigned bit arrays ‘a’ and ‘b’ that may have different lengths.</p>
+</span></td><td>Immutable</td></tr>
+<tr><td><a name="bitmask_or"></a><code>bitmask_or(a: <a href="string.html">string</a>, b: <a href="string.html">string</a>) &rarr; varbit</code></td><td><span class="funcdesc"><p>Calculates bitwise OR value of unsigned bit arrays ‘a’ and ‘b’ that may have different lengths.</p>
+</span></td><td>Immutable</td></tr>
+<tr><td><a name="bitmask_or"></a><code>bitmask_or(a: <a href="string.html">string</a>, b: varbit) &rarr; varbit</code></td><td><span class="funcdesc"><p>Calculates bitwise OR value of unsigned bit arrays ‘a’ and ‘b’ that may have different lengths.</p>
+</span></td><td>Immutable</td></tr>
+<tr><td><a name="bitmask_or"></a><code>bitmask_or(a: varbit, b: <a href="string.html">string</a>) &rarr; varbit</code></td><td><span class="funcdesc"><p>Calculates bitwise OR value of unsigned bit arrays ‘a’ and ‘b’ that may have different lengths.</p>
+</span></td><td>Immutable</td></tr>
+<tr><td><a name="bitmask_or"></a><code>bitmask_or(a: varbit, b: varbit) &rarr; varbit</code></td><td><span class="funcdesc"><p>Calculates bitwise OR value of unsigned bit arrays ‘a’ and ‘b’ that may have different lengths.</p>
+</span></td><td>Immutable</td></tr>
+<tr><td><a name="bitmask_xor"></a><code>bitmask_xor(a: <a href="string.html">string</a>, b: <a href="string.html">string</a>) &rarr; varbit</code></td><td><span class="funcdesc"><p>Calculates bitwise XOR value of unsigned bit arrays ‘a’ and ‘b’ that may have different lengths.</p>
+</span></td><td>Immutable</td></tr>
+<tr><td><a name="bitmask_xor"></a><code>bitmask_xor(a: <a href="string.html">string</a>, b: varbit) &rarr; varbit</code></td><td><span class="funcdesc"><p>Calculates bitwise XOR value of unsigned bit arrays ‘a’ and ‘b’ that may have different lengths.</p>
+</span></td><td>Immutable</td></tr>
+<tr><td><a name="bitmask_xor"></a><code>bitmask_xor(a: varbit, b: <a href="string.html">string</a>) &rarr; varbit</code></td><td><span class="funcdesc"><p>Calculates bitwise XOR value of unsigned bit arrays ‘a’ and ‘b’ that may have different lengths.</p>
+</span></td><td>Immutable</td></tr>
+<tr><td><a name="bitmask_xor"></a><code>bitmask_xor(a: varbit, b: varbit) &rarr; varbit</code></td><td><span class="funcdesc"><p>Calculates bitwise XOR value of unsigned bit arrays ‘a’ and ‘b’ that may have different lengths.</p>
+</span></td><td>Immutable</td></tr>
 <tr><td><a name="btrim"></a><code>btrim(input: <a href="string.html">string</a>, trim_chars: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Removes any characters included in <code>trim_chars</code> from the beginning or end of <code>input</code> (applies recursively).</p>
 <p>For example, <code>btrim('doggie', 'eod')</code> returns <code>ggi</code>.</p>
 </span></td><td>Immutable</td></tr>

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -4037,3 +4037,132 @@ SELECT crdb_internal.merge_aggregated_stmt_metadata(ARRAY[ '{"aMalformedMetadaOb
 {"appNames": [], "db": [], "distSQLCount": 0, "failedCount": 0, "fingerprintID": "", "formattedQuery": "", "fullScanCount": 0, "implicitTxn": false, "query": "", "querySummary": "", "stmtType": "", "totalCount": 0, "vecCount": 0}
 
 subtest end
+
+# Test bitmask_or function for string and varbit data
+query T
+SELECT bitmask_or('1010010', '0101');
+----
+1010111
+
+query T
+SELECT bitmask_or('1010010'::bit(7), '0101'::bit(4));
+----
+1010111
+
+query T
+SELECT bitmask_or('1010010'::bit(7), '0101');
+----
+1010111
+
+query T
+SELECT bitmask_or('1010010', '0101'::bit(4));
+----
+1010111
+
+query T
+SELECT bitmask_or('1010010'::varbit, '0101'::varbit);
+----
+1010111
+
+# Test bitmask_and function for string and varbit data
+query T
+SELECT bitmask_and('1010010', '0101');
+----
+0000000
+
+query T
+SELECT bitmask_and('1010010'::bit(7), '0101'::bit(4));
+----
+0000000
+
+query T
+SELECT bitmask_and('1010010'::bit(7), '0101');
+----
+0000000
+
+query T
+SELECT bitmask_and('1010010', '0101'::bit(4));
+----
+0000000
+
+query T
+SELECT bitmask_and('1010010'::varbit, '0101'::varbit);
+----
+0000000
+
+# Test bitmask_xor function for string and varbit data
+query T
+SELECT bitmask_xor('1010010', '0101');
+----
+1010111
+
+query T
+SELECT bitmask_xor('1010010'::bit(7), '0101'::bit(4));
+----
+1010111
+
+query T
+SELECT bitmask_xor('1010010'::bit(7), '0101');
+----
+1010111
+
+query T
+SELECT bitmask_xor('1010010', '0101'::bit(4));
+----
+1010111
+
+query T
+SELECT bitmask_xor('1010010'::varbit, '0101'::varbit);
+----
+1010111
+
+# Test for invalid inputs.
+statement error pgcode 22P02 could not parse string as bit array: "n" is not a valid binary digit
+SELECT bitmask_or('not binary', '111')
+
+statement error pgcode 22P02 could not parse string as bit array: "n" is not a valid binary digit
+SELECT bitmask_or('111', 'not binary')
+
+statement error pgcode 22P02 could not parse string as bit array: "n" is not a valid binary digit
+SELECT bitmask_and('not binary', '111')
+
+statement error pgcode 22P02 could not parse string as bit array: "n" is not a valid binary digit
+SELECT bitmask_and('111', 'not binary')
+
+statement error pgcode 22P02 could not parse string as bit array: "n" is not a valid binary digit
+SELECT bitmask_xor('not binary', '111')
+
+statement error pgcode 22P02 could not parse string as bit array: "n" is not a valid binary digit
+SELECT bitmask_xor('111', 'not binary')
+
+# Accept hex as well as binary inputs.
+query T
+SELECT bitmask_or('xfe8c', '1111');
+----
+1111111010001111
+
+query T
+SELECT bitmask_and('1111', 'xfe8c');
+----
+0000000000001100
+
+query T
+SELECT bitmask_xor('xfe8c', '1111');
+----
+1111111010000011
+
+# Test on a large (>64 bit) input.
+query T
+SELECT bitmask_or('xffffffffffffffffff', '010');
+----
+111111111111111111111111111111111111111111111111111111111111111111111111
+
+query T
+SELECT bitmask_and('xffffffffffffffffff', '010');
+----
+000000000000000000000000000000000000000000000000000000000000000000000010
+
+query T
+SELECT bitmask_xor('xffffffffffffffffff', '010');
+----
+111111111111111111111111111111111111111111111111111111111111111111111101

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -77,6 +77,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/cockroach/pkg/util/bitarray"
 	"github.com/cockroachdb/cockroach/pkg/util/duration"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
@@ -8154,6 +8155,195 @@ specified store on the node it's run from. One of 'mvccGC', 'merge', 'split',
 			CalledOnNullInput: true,
 		},
 	),
+	"bitmask_or": makeBuiltin(tree.FunctionProperties{Category: builtinconstants.CategoryString},
+		stringOverload2(
+			"a",
+			"b",
+			func(_ context.Context, _ *eval.Context, a, b string) (tree.Datum, error) {
+				aBitArray, err := bitarray.Parse(a)
+				if err != nil {
+					return nil, err
+				}
+
+				bBitArray, err := bitarray.Parse(b)
+				if err != nil {
+					return nil, err
+				}
+
+				return bitmaskOr(aBitArray.String(), bBitArray.String())
+			},
+			types.VarBit,
+			"Calculates bitwise OR value of unsigned bit arrays 'a' and 'b' that may have different lengths.",
+			volatility.Immutable),
+		bitsOverload2("a", "b",
+			func(_ context.Context, _ *eval.Context, a, b *tree.DBitArray) (tree.Datum, error) {
+				return bitmaskOr(a.BitArray.String(), b.BitArray.String())
+			},
+			types.VarBit,
+			"Calculates bitwise OR value of unsigned bit arrays 'a' and 'b' that may have different lengths.",
+			volatility.Immutable,
+		),
+		tree.Overload{
+			Types: tree.ParamTypes{
+				{Name: "a", Typ: types.VarBit},
+				{Name: "b", Typ: types.String},
+			},
+			ReturnType: tree.FixedReturnType(types.VarBit),
+			Fn: func(_ context.Context, _ *eval.Context, a *tree.DBitArray, b string) (tree.Datum, error) {
+				bBitArray, err := bitarray.Parse(b)
+				if err != nil {
+					return nil, err
+				}
+
+				return bitmaskOr(a.BitArray.String(), bBitArray.String())
+			},
+			Info:       "Calculates bitwise OR value of unsigned bit arrays 'a' and 'b' that may have different lengths.",
+			Volatility: volatility.Immutable,
+		},
+		tree.Overload{
+			Types: tree.ParamTypes{
+				{Name: "a", Typ: types.String},
+				{Name: "b", Typ: types.VarBit},
+			},
+			ReturnType: tree.FixedReturnType(types.VarBit),
+			Fn: func(_ context.Context, _ *eval.Context, a string, b *tree.DBitArray) (tree.Datum, error) {
+				aBitArray, err := bitarray.Parse(a)
+				if err != nil {
+					return nil, err
+				}
+
+				return bitmaskOr(aBitArray.String(), b.BitArray.String())
+			},
+			Info:       "Calculates bitwise OR value of unsigned bit arrays 'a' and 'b' that may have different lengths.",
+			Volatility: volatility.Immutable,
+		},
+	),
+	"bitmask_and": makeBuiltin(tree.FunctionProperties{Category: builtinconstants.CategoryString},
+		stringOverload2(
+			"a",
+			"b",
+			func(_ context.Context, _ *eval.Context, a, b string) (tree.Datum, error) {
+				aBitArray, err := bitarray.Parse(a)
+				if err != nil {
+					return nil, err
+				}
+
+				bBitArray, err := bitarray.Parse(b)
+				if err != nil {
+					return nil, err
+				}
+
+				return bitmaskAnd(aBitArray.String(), bBitArray.String())
+			},
+			types.VarBit,
+			"Calculates bitwise AND value of unsigned bit arrays 'a' and 'b' that may have different lengths.",
+			volatility.Immutable),
+		bitsOverload2("a", "b",
+			func(_ context.Context, _ *eval.Context, a, b *tree.DBitArray) (tree.Datum, error) {
+				return bitmaskAnd(a.BitArray.String(), b.BitArray.String())
+			},
+			types.VarBit,
+			"Calculates bitwise AND value of unsigned bit arrays 'a' and 'b' that may have different lengths.",
+			volatility.Immutable,
+		),
+		tree.Overload{
+			Types: tree.ParamTypes{
+				{Name: "a", Typ: types.VarBit},
+				{Name: "b", Typ: types.String},
+			},
+			ReturnType: tree.FixedReturnType(types.VarBit),
+			Fn: func(_ context.Context, _ *eval.Context, a *tree.DBitArray, b string) (tree.Datum, error) {
+				bBitArray, err := bitarray.Parse(b)
+				if err != nil {
+					return nil, err
+				}
+
+				return bitmaskAnd(a.BitArray.String(), bBitArray.String())
+			},
+			Info:       "Calculates bitwise AND value of unsigned bit arrays 'a' and 'b' that may have different lengths.",
+			Volatility: volatility.Immutable,
+		},
+		tree.Overload{
+			Types: tree.ParamTypes{
+				{Name: "a", Typ: types.String},
+				{Name: "b", Typ: types.VarBit},
+			},
+			ReturnType: tree.FixedReturnType(types.VarBit),
+			Fn: func(_ context.Context, _ *eval.Context, a string, b *tree.DBitArray) (tree.Datum, error) {
+				aBitArray, err := bitarray.Parse(a)
+				if err != nil {
+					return nil, err
+				}
+
+				return bitmaskAnd(aBitArray.String(), b.BitArray.String())
+			},
+			Info:       "Calculates bitwise AND value of unsigned bit arrays 'a' and 'b' that may have different lengths.",
+			Volatility: volatility.Immutable,
+		},
+	),
+	"bitmask_xor": makeBuiltin(tree.FunctionProperties{Category: builtinconstants.CategoryString},
+		stringOverload2(
+			"a",
+			"b",
+			func(_ context.Context, _ *eval.Context, a, b string) (tree.Datum, error) {
+				aBitArray, err := bitarray.Parse(a)
+				if err != nil {
+					return nil, err
+				}
+
+				bBitArray, err := bitarray.Parse(b)
+				if err != nil {
+					return nil, err
+				}
+
+				return bitmaskXor(aBitArray.String(), bBitArray.String())
+			},
+			types.VarBit,
+			"Calculates bitwise XOR value of unsigned bit arrays 'a' and 'b' that may have different lengths.",
+			volatility.Immutable),
+		bitsOverload2("a", "b",
+			func(_ context.Context, _ *eval.Context, a, b *tree.DBitArray) (tree.Datum, error) {
+				return bitmaskXor(a.BitArray.String(), b.BitArray.String())
+			},
+			types.VarBit,
+			"Calculates bitwise XOR value of unsigned bit arrays 'a' and 'b' that may have different lengths.",
+			volatility.Immutable,
+		),
+		tree.Overload{
+			Types: tree.ParamTypes{
+				{Name: "a", Typ: types.VarBit},
+				{Name: "b", Typ: types.String},
+			},
+			ReturnType: tree.FixedReturnType(types.VarBit),
+			Fn: func(_ context.Context, _ *eval.Context, a *tree.DBitArray, b string) (tree.Datum, error) {
+				bBitArray, err := bitarray.Parse(b)
+				if err != nil {
+					return nil, err
+				}
+
+				return bitmaskXor(a.BitArray.String(), bBitArray.String())
+			},
+			Info:       "Calculates bitwise XOR value of unsigned bit arrays 'a' and 'b' that may have different lengths.",
+			Volatility: volatility.Immutable,
+		},
+		tree.Overload{
+			Types: tree.ParamTypes{
+				{Name: "a", Typ: types.String},
+				{Name: "b", Typ: types.VarBit},
+			},
+			ReturnType: tree.FixedReturnType(types.VarBit),
+			Fn: func(_ context.Context, _ *eval.Context, a string, b *tree.DBitArray) (tree.Datum, error) {
+				aBitArray, err := bitarray.Parse(a)
+				if err != nil {
+					return nil, err
+				}
+
+				return bitmaskXor(aBitArray.String(), b.BitArray.String())
+			},
+			Info:       "Calculates bitwise XOR value of unsigned bit arrays 'a' and 'b' that may have different lengths.",
+			Volatility: volatility.Immutable,
+		},
+	),
 }
 
 var lengthImpls = func(incBitOverload bool) builtinDefinition {
@@ -11025,4 +11215,44 @@ true, then any plan other then the specified gist will be used`
 		Volatility: volatility.Volatile,
 		Info:       info,
 	}
+}
+
+func bitmaskAnd(aStr, bStr string) (*tree.DBitArray, error) {
+	return bitmaskOp(aStr, bStr, func(a, b byte) byte { return a & b })
+}
+
+func bitmaskOr(aStr, bStr string) (*tree.DBitArray, error) {
+	return bitmaskOp(aStr, bStr, func(a, b byte) byte { return a | b })
+}
+
+func bitmaskXor(aStr, bStr string) (*tree.DBitArray, error) {
+	return bitmaskOp(aStr, bStr, func(a, b byte) byte { return (a ^ b) + '0' })
+}
+
+// Perform bitwise operation on the 2 bit strings that may have different
+// lengths. The function applies left padding implicitly with 0s. The function
+// also assumes both input strings are only comprised of charactor '0' and '1'.
+func bitmaskOp(aStr, bStr string, op func(byte, byte) byte) (*tree.DBitArray, error) {
+	aLen, bLen := len(aStr), len(bStr)
+	bufLen := max(aLen, bLen)
+	buf := make([]byte, bufLen)
+	for i := 0; i < bufLen; i++ {
+		var a, b byte
+
+		if i >= aLen {
+			a = '0'
+		} else {
+			a = aStr[aLen-i-1]
+		}
+
+		if i >= bLen {
+			b = '0'
+		} else {
+			b = bStr[bLen-i-1]
+		}
+
+		buf[bufLen-i-1] = op(a, b)
+	}
+
+	return tree.ParseDBitArray(string(buf))
 }

--- a/pkg/sql/sem/builtins/builtins_test.go
+++ b/pkg/sql/sem/builtins/builtins_test.go
@@ -920,3 +920,48 @@ func TestPGBuiltinsCalledOnNull(t *testing.T) {
 		require.Equalf(t, [][]string{{"NULL"}}, res, "failed test case %d", i+1)
 	}
 }
+
+func TestBitmaskOrAndXor(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	testCases := []struct {
+		bitFn    func(string, string) (*tree.DBitArray, error)
+		a        string
+		b        string
+		expected string
+	}{
+		{bitmaskOr, "010", "0", "010"},
+		{bitmaskOr, "010", "101", "111"},
+		{bitmaskOr, "010", "101", "111"},
+		{bitmaskOr, "010", "1010", "1010"},
+		{bitmaskOr, "0100010", "1010", "0101010"},
+		{bitmaskOr, "001010010000", "0101010100", "001111010100"},
+		{bitmaskOr, "001010010111", "", "001010010111"},
+		{bitmaskOr, "", "1000100", "1000100"},
+		{bitmaskAnd, "010", "101", "000"},
+		{bitmaskAnd, "010", "01", "000"},
+		{bitmaskAnd, "111", "000", "000"},
+		{bitmaskAnd, "110", "101", "100"},
+		{bitmaskAnd, "0100010", "1010", "0000010"},
+		{bitmaskAnd, "001010010000", "0101010100", "000000010000"},
+		{bitmaskAnd, "001010010000", "", "000000000000"},
+		{bitmaskAnd, "", "01000100", "00000000"},
+		{bitmaskXor, "010", "101", "111"},
+		{bitmaskXor, "010", "01", "011"},
+		{bitmaskXor, "101", "100", "001"},
+		{bitmaskXor, "110", "001", "111"},
+		{bitmaskXor, "0101010", "1011", "0100001"},
+		{bitmaskXor, "001010010000", "0101010100", "001111000100"},
+		{bitmaskXor, "001010010000", "", "001010010000"},
+		{bitmaskXor, "", "01000100", "01000100"},
+	}
+	for _, tc := range testCases {
+		bitArray, err := tc.bitFn(tc.a, tc.b)
+		if err != nil {
+			t.Fatal(err)
+		}
+		resultStr := bitArray.BitArray.String()
+		if resultStr != tc.expected {
+			t.Errorf("expected %s, found %s", tc.expected, resultStr)
+		}
+	}
+}

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -2440,6 +2440,18 @@ var builtinOidsArray = []string{
 	2469: `crdb_internal.is_system_table_key(raw_key: bytes) -> bool`,
 	2470: `crdb_internal.scan_storage_internal_keys(node_id: int, store_id: int, start_key: bytes, end_key: bytes) -> tuple{int AS level, int AS node_id, int AS store_id, int AS snapshot_pinned_keys, int AS snapshot_pinned_keys_bytes, int AS point_key_delete_count, int AS point_key_set_count, int AS range_delete_count, int AS range_key_set_count, int AS range_key_delete_count}`,
 	2471: `crdb_internal.scan_storage_internal_keys(node_id: int, store_id: int, start_key: bytes, end_key: bytes, mb_per_second: int4) -> tuple{int AS level, int AS node_id, int AS store_id, int AS snapshot_pinned_keys, int AS snapshot_pinned_keys_bytes, int AS point_key_delete_count, int AS point_key_set_count, int AS range_delete_count, int AS range_key_set_count, int AS range_key_delete_count}`,
+	2472: `bitmask_or(a: varbit, b: varbit) -> varbit`,
+	2473: `bitmask_or(a: string, b: string) -> varbit`,
+	2474: `bitmask_or(a: varbit, b: string) -> varbit`,
+	2475: `bitmask_or(a: string, b: varbit) -> varbit`,
+	2476: `bitmask_and(a: varbit, b: varbit) -> varbit`,
+	2477: `bitmask_and(a: string, b: string) -> varbit`,
+	2478: `bitmask_and(a: varbit, b: string) -> varbit`,
+	2479: `bitmask_and(a: string, b: varbit) -> varbit`,
+	2480: `bitmask_xor(a: varbit, b: varbit) -> varbit`,
+	2481: `bitmask_xor(a: string, b: string) -> varbit`,
+	2482: `bitmask_xor(a: varbit, b: string) -> varbit`,
+	2483: `bitmask_xor(a: string, b: varbit) -> varbit`,
 }
 
 var builtinOidsBySignature map[string]oid.Oid


### PR DESCRIPTION
As raised in #107821, the existing bitwise operations in CRDB follow the same standard as Postgresql that require the two operands of varbit type to have the same length. The restriction makes it easier for the implementation but harder for users. As of today, we need to apply casting and left padding to make sure the operands have the same length. Instead, it might be useful to have CRDB built-in functions that can handle this. Here I have implemented 2 basic bitwise operation functions that are tailored for varbit typed data of arbitrary length.