### PR TITLE
sql: fix TestSQLStatsCompactor flaky test

### DIFF
--- a/pkg/sql/sqlstats/persistedsqlstats/compaction_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/compaction_test.go
@@ -141,7 +141,8 @@ func TestSQLStatsCompactor(t *testing.T) {
 							},
 						},
 						Store: &kvserver.StoreTestingKnobs{
-							TestingRequestFilter: kvInterceptor.intercept,
+							TestingRequestFilter:      kvInterceptor.intercept,
+							DisableLoadBasedSplitting: true,
 						},
 					},
 				},


### PR DESCRIPTION
This patch disables auto split and merge of ranges for the test because it causes extra wide scan to be counted by `kvInterceptor`.
Also, it is defined to run test on system tenant only to have an access to `kv` specific cluster setting and because it should have an access to store level.

Release note: None

Resolves: #107067