### PR TITLE
release-23.1: internal/issues: remove dependency from roachprod/logger

### DIFF
--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -119,6 +119,7 @@ ALL_TESTS = [
     "//pkg/clusterversion:clusterversion_test",
     "//pkg/cmd/bazci/githubpost:githubpost_test",
     "//pkg/cmd/bazci/testfilter:testfilter_test",
+    "//pkg/cmd/bazci:bazci_lib_disallowed_imports_test",
     "//pkg/cmd/cmpconn:cmpconn_test",
     "//pkg/cmd/cockroach-oss:cockroach-oss_disallowed_imports_test",
     "//pkg/cmd/cockroach:cockroach_lib_disallowed_imports_test",

--- a/pkg/cmd/bazci/BUILD.bazel
+++ b/pkg/cmd/bazci/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("//pkg/testutils/buildutil:buildutil.bzl", "disallowed_imports_test")
 
 go_library(
     name = "bazci_lib",
@@ -26,4 +27,12 @@ go_binary(
     name = "bazci",
     embed = [":bazci_lib"],
     visibility = ["//visibility:public"],
+)
+
+disallowed_imports_test(
+    "bazci_lib",
+    disallowed_list = [
+        "//pkg/roachprod/logger",
+        "//pkg/util/log",
+    ],
 )

--- a/pkg/cmd/bazci/githubpost/BUILD.bazel
+++ b/pkg/cmd/bazci/githubpost/BUILD.bazel
@@ -10,7 +10,6 @@ go_library(
         "//pkg/cmd/internal/issues",
         "//pkg/internal/codeowners",
         "//pkg/internal/team",
-        "//pkg/roachprod/logger",
         "@com_github_cockroachdb_errors//:errors",
     ],
 )

--- a/pkg/cmd/bazci/githubpost/githubpost.go
+++ b/pkg/cmd/bazci/githubpost/githubpost.go
@@ -38,7 +38,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/internal/issues"
 	"github.com/cockroachdb/cockroach/pkg/internal/codeowners"
 	"github.com/cockroachdb/cockroach/pkg/internal/team"
-	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/errors"
 )
 
@@ -101,11 +100,7 @@ func getIssueFilerForFormatter(formatterName string) func(ctx context.Context, f
 
 	return func(ctx context.Context, f failure) error {
 		fmter, req := reqFromFailure(ctx, f)
-		l, err := logger.RootLogger("", false)
-		if err != nil {
-			return err
-		}
-		return issues.Post(ctx, l, fmter, req)
+		return issues.Post(ctx, log.Default(), fmter, req)
 	}
 }
 

--- a/pkg/cmd/internal/issues/BUILD.bazel
+++ b/pkg/cmd/internal/issues/BUILD.bazel
@@ -11,7 +11,6 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/cmd/internal/issues",
     visibility = ["//pkg/cmd:__subpackages__"],
     deps = [
-        "//pkg/roachprod/logger",
         "//pkg/util/version",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_google_go_github//github",
@@ -31,7 +30,6 @@ go_test(
     data = glob(["testdata/**"]),
     embed = [":issues"],
     deps = [
-        "//pkg/roachprod/logger",
         "//pkg/testutils/datapathutils",
         "//pkg/testutils/skip",
         "@com_github_cockroachdb_datadriven//:datadriven",

--- a/pkg/cmd/internal/issues/issues.go
+++ b/pkg/cmd/internal/issues/issues.go
@@ -20,7 +20,6 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/cockroach/pkg/util/version"
 	"github.com/cockroachdb/errors"
 	"github.com/google/go-github/github"
@@ -114,7 +113,7 @@ func (p *poster) getProbableMilestone(ctx *postCtx) *int {
 type poster struct {
 	*Options
 
-	l *logger.Logger
+	l Logger
 
 	createIssue func(ctx context.Context, owner string, repo string,
 		issue *github.IssueRequest) (*github.Issue, *github.Response, error)
@@ -130,7 +129,7 @@ type poster struct {
 		opt *github.ProjectCardOptions) (*github.ProjectCard, *github.Response, error)
 }
 
-func newPoster(l *logger.Logger, client *github.Client, opts *Options) *poster {
+func newPoster(l Logger, client *github.Client, opts *Options) *poster {
 	return &poster{
 		Options:           opts,
 		l:                 l,
@@ -452,11 +451,20 @@ type PostRequest struct {
 	ProjectColumnID int
 }
 
+// Logger is an interface that allows callers to plug their own log
+// implementation when they post GitHub issues. It avoids us having to
+// link against heavy dependencies in certain cases (such as in
+// `bazci`) while still allowing other callers (such as `roachtest`)
+// to use other logger implementations.
+type Logger interface {
+	Printf(format string, args ...interface{})
+}
+
 // Post either creates a new issue for a failed test, or posts a comment to an
 // existing open issue. GITHUB_API_TOKEN must be set to a valid GitHub token
 // that has permissions to search and create issues and comments or an error
 // will be returned.
-func Post(ctx context.Context, l *logger.Logger, formatter IssueFormatter, req PostRequest) error {
+func Post(ctx context.Context, l Logger, formatter IssueFormatter, req PostRequest) error {
 	opts := DefaultOptionsFromEnv()
 	if !opts.CanPost() {
 		return errors.Newf("GITHUB_API_TOKEN env variable is not set; cannot post issue")

--- a/pkg/cmd/internal/issues/issues_test.go
+++ b/pkg/cmd/internal/issues/issues_test.go
@@ -13,6 +13,7 @@ package issues
 import (
 	"context"
 	"fmt"
+	"log"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -20,7 +21,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/cockroach/pkg/testutils/datapathutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/datadriven"
@@ -273,11 +273,9 @@ test logs left over in: /go/src/github.com/cockroachdb/cockroach/artifacts/logTe
 				return tag, nil
 			}
 
-			l, err := logger.RootLogger("", false)
-			require.NoError(t, err)
 			p := &poster{
 				Options: &opts,
-				l:       l,
+				l:       log.Default(),
 			}
 
 			createdIssue := false
@@ -419,10 +417,7 @@ func TestPostEndToEnd(t *testing.T) {
 		HelpCommand: UnitTestHelpCommand(""),
 	}
 
-	l, err := logger.RootLogger("", false)
-	require.NoError(t, err)
-
-	require.NoError(t, Post(context.Background(), l, UnitTestFormatter, req))
+	require.NoError(t, Post(context.Background(), log.Default(), UnitTestFormatter, req))
 }
 
 // setEnv overrides the env variables corresponding to the input map. The

--- a/pkg/cmd/roachtest/github.go
+++ b/pkg/cmd/roachtest/github.go
@@ -28,7 +28,7 @@ type githubIssues struct {
 	disable      bool
 	cluster      *clusterImpl
 	vmCreateOpts *vm.CreateOpts
-	issuePoster  func(context.Context, *logger.Logger, issues.IssueFormatter, issues.PostRequest) error
+	issuePoster  func(context.Context, issues.Logger, issues.IssueFormatter, issues.PostRequest) error
 	teamLoader   func() (team.Map, error)
 }
 


### PR DESCRIPTION
Backport 1/1 commits from #106447.

/cc @cockroachdb/release

---

`roachprod/logger` is a heavy dependency (depending on `pkg/util/log`), so it doesn't make sense to use it in `bazci`. In addition, the log bridge also causes this warning to be printed every time other parts of the code print to stdout from outside the `log` package:

```
util/log/log_bridge.go:81  [-] 1  bad log format: [...]
```

This commit changes the signature of the `issues.Post` function so that a `Logger` interface is expected instead (with a simple dependency on an implementation of `Printf`). This allows us to continue to use `roachprod/logger` in roachtest, while using the default stdlib `Logger` instance in `bazci`.

It also adds a `disallowed_imports_test` test to `bazci` to stop these logger dependencies from being accidentally added again.

Epic: none

Release note: None

Release justification: infrastructure-only changes.