### PR TITLE
workflow: Remove `yarn.lock` as it no longer exists

### DIFF
--- a/.github/workflows/cluster-ui-release-next.yml
+++ b/.github/workflows/cluster-ui-release-next.yml
@@ -6,7 +6,6 @@ on:
       - master
     paths:
       - 'pkg/ui/workspaces/cluster-ui/**/*.tsx?'
-      - 'pkg/ui/workspaces/cluster-ui/yarn.lock'
       - 'pkg/ui/workspaces/cluster-ui/package.json'
 
 jobs:

--- a/pkg/ui/workspaces/cluster-ui/.yarnrc
+++ b/pkg/ui/workspaces/cluster-ui/.yarnrc
@@ -1,1 +1,0 @@
-version-tag-prefix "@cockroachlabs/cluster-ui@"


### PR DESCRIPTION
Removed the `yarn.lock` file path from cluster release next action, as it has been removed since we swithed to pnpm.

Epic: none

Release note: None