### PR TITLE
storage: use correct context for logging

### DIFF
--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -1140,7 +1140,7 @@ func NewPebble(ctx context.Context, cfg PebbleConfig) (p *Pebble, err error) {
 		p.async(func() { oldDiskSlow(info) })
 	}
 	el := pebble.TeeEventListener(
-		p.makeMetricEtcEventListener(ctx),
+		p.makeMetricEtcEventListener(logCtx),
 		lel,
 	)
 


### PR DESCRIPTION
The context given to makeMetricEtcEventListener is later used for logging, so it should be using the logCtx.

Epic: none

Release note: None