### PR TITLE
sql: fix exec+audit logs for BEGIN, COMMIT, SET stmts

### DIFF
--- a/pkg/ccl/auditloggingccl/audit_logging_test.go
+++ b/pkg/ccl/auditloggingccl/audit_logging_test.go
@@ -156,6 +156,22 @@ func TestSingleRoleAuditLogging(t *testing.T) {
 		`GRANT SELECT ON TABLE u TO root`,
 		// DML statement
 		`SELECT * FROM u`,
+		// The following statements are all executed specially by the conn_executor.
+		`SET application_name = 'test'`,
+		`SET CLUSTER SETTING sql.defaults.vectorize = 'on'`,
+		`BEGIN`,
+		`SHOW application_name`,
+		`SAVEPOINT s`,
+		`RELEASE SAVEPOINT s`,
+		`SAVEPOINT t`,
+		`ROLLBACK TO SAVEPOINT t`,
+		`COMMIT`,
+		`SHOW COMMIT TIMESTAMP`,
+		`BEGIN TRANSACTION PRIORITY LOW`,
+		`ROLLBACK`,
+		`PREPARE q AS SELECT 1`,
+		`EXECUTE q`,
+		`DEALLOCATE q`,
 	}
 	testData := []struct {
 		name            string
@@ -167,7 +183,7 @@ func TestSingleRoleAuditLogging(t *testing.T) {
 			name:            "test-all-stmt-types",
 			role:            allStmtTypesRole,
 			queries:         testQueries,
-			expectedNumLogs: 3,
+			expectedNumLogs: len(testQueries),
 		},
 		{
 			name:            "test-no-stmt-types",
@@ -181,7 +197,7 @@ func TestSingleRoleAuditLogging(t *testing.T) {
 			role:    "testuser",
 			queries: testQueries,
 			// One for each test query.
-			expectedNumLogs: 3,
+			expectedNumLogs: len(testQueries),
 		},
 	}
 

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -955,6 +955,9 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 		SessionInitCache: sessioninit.NewCache(
 			serverCacheMemoryMonitor.MakeBoundAccount(), cfg.stopper,
 		),
+		AuditConfig: &auditlogging.AuditConfigLock{
+			Config: auditlogging.EmptyAuditConfig(),
+		},
 		ClientCertExpirationCache: security.NewClientCertExpirationCache(
 			ctx, cfg.Settings, cfg.stopper, &timeutil.DefaultTimeSource{}, rootSQLMemoryMonitor,
 		),
@@ -1351,7 +1354,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 	vmoduleSetting.SetOnChange(&cfg.Settings.SV, fn)
 	fn(ctx)
 
-	auditlogging.ConfigureRoleBasedAuditClusterSettings(ctx, execCfg.SessionInitCache.AuditConfig, execCfg.Settings, &execCfg.Settings.SV)
+	auditlogging.ConfigureRoleBasedAuditClusterSettings(ctx, execCfg.AuditConfig, execCfg.Settings, &execCfg.Settings.SV)
 
 	return &SQLServer{
 		ambientCtx:                     cfg.BaseConfig.AmbientCtx,

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -2789,7 +2789,6 @@ func (ex *connExecutor) execCopyOut(
 		ex.planner.maybeLogStatement(
 			ctx,
 			ex.executorType,
-			true, /* isCopy */
 			int(ex.state.mu.autoRetryCounter),
 			ex.extraTxnState.txnCounter,
 			numOutputRows,
@@ -3041,7 +3040,7 @@ func (ex *connExecutor) execCopyIn(
 			ex.planner.CurrentDatabase(),
 		)
 		var stats topLevelQueryStats
-		ex.planner.maybeLogStatement(ctx, ex.executorType, true,
+		ex.planner.maybeLogStatement(ctx, ex.executorType,
 			int(ex.state.mu.autoRetryCounter), ex.extraTxnState.txnCounter,
 			numInsertedRows, ex.state.mu.stmtCount,
 			0, /* bulkJobId */

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -803,7 +803,6 @@ func (ex *connExecutor) execStmtInOpenState(
 		p.maybeLogStatement(
 			ctx,
 			ex.executorType,
-			false, /* isCopy */
 			int(ex.state.mu.autoRetryCounter),
 			ex.extraTxnState.txnCounter,
 			0, /* rowsAffected */
@@ -1577,7 +1576,6 @@ func (ex *connExecutor) dispatchToExecutionEngine(
 					planner.maybeLogStatement(
 						ctx,
 						ex.executorType,
-						false, /* isCopy */
 						int(ex.state.mu.autoRetryCounter),
 						ex.extraTxnState.txnCounter,
 						ppInfo.dispatchToExecutionEngine.rowsAffected,
@@ -1605,7 +1603,6 @@ func (ex *connExecutor) dispatchToExecutionEngine(
 			planner.maybeLogStatement(
 				ctx,
 				ex.executorType,
-				false, /* isCopy */
 				int(ex.state.mu.autoRetryCounter),
 				ex.extraTxnState.txnCounter,
 				nonBulkJobNumRows,
@@ -2279,7 +2276,6 @@ func (ex *connExecutor) execStmtInNoTxnState(
 		p.maybeLogStatement(
 			ctx,
 			ex.executorType,
-			false, /* isCopy */
 			int(ex.state.mu.autoRetryCounter),
 			ex.extraTxnState.txnCounter,
 			0, /* rowsAffected */

--- a/pkg/sql/event_log.go
+++ b/pkg/sql/event_log.go
@@ -166,9 +166,6 @@ type eventLogOptions struct {
 
 	// Additional redaction options, if necessary.
 	rOpts redactionOptions
-
-	// isCopy notes whether the current event is related to COPY.
-	isCopy bool
 }
 
 // redactionOptions contains instructions on how to redact the SQL
@@ -281,8 +278,8 @@ func logEventInternalForSQLStatements(
 ) error {
 	// Inject the common fields into the payload provided by the caller.
 	injectCommonFields := func(event logpb.EventPayload) error {
-		if opts.isCopy {
-			// No txn is set for COPY, so use now instead.
+		if txn == nil {
+			// No txn is set (e.g. for COPY or BEGIN), so use now instead.
 			event.CommonDetails().Timestamp = timeutil.Now().UnixNano()
 		} else {
 			event.CommonDetails().Timestamp = txn.KV().ReadTimestamp().WallTime

--- a/pkg/sql/exec_log.go
+++ b/pkg/sql/exec_log.go
@@ -120,7 +120,6 @@ func (s executorType) logLabel() string { return logLabels[s] }
 func (p *planner) maybeLogStatement(
 	ctx context.Context,
 	execType executorType,
-	isCopy bool,
 	numRetries, txnCounter, rows, stmtCount int,
 	bulkJobId uint64,
 	err error,
@@ -132,7 +131,7 @@ func (p *planner) maybeLogStatement(
 	statsCollector sqlstats.StatsCollector,
 ) {
 	p.maybeAuditRoleBasedAuditEvent(ctx, execType)
-	p.maybeLogStatementInternal(ctx, execType, isCopy, numRetries, txnCounter,
+	p.maybeLogStatementInternal(ctx, execType, numRetries, txnCounter,
 		rows, stmtCount, bulkJobId, err, queryReceived, hasAdminRoleCache,
 		telemetryLoggingMetrics, stmtFingerprintID, queryStats, statsCollector,
 	)
@@ -141,7 +140,6 @@ func (p *planner) maybeLogStatement(
 func (p *planner) maybeLogStatementInternal(
 	ctx context.Context,
 	execType executorType,
-	isCopy bool,
 	numRetries, txnCounter, rows, stmtCount int,
 	bulkJobId uint64,
 	err error,
@@ -235,7 +233,7 @@ func (p *planner) maybeLogStatementInternal(
 			auditEvent := builder.BuildAuditEvent(ctx, p, eventpb.CommonSQLEventDetails{}, execDetails)
 			entries[idx] = auditEvent
 		}
-		p.logEventsOnlyExternally(ctx, isCopy, entries...)
+		p.logEventsOnlyExternally(ctx, entries...)
 	}
 
 	if slowQueryLogEnabled && (
@@ -247,12 +245,12 @@ func (p *planner) maybeLogStatementInternal(
 		switch {
 		case execType == executorTypeExec:
 			// Non-internal queries are always logged to the slow query log.
-			p.logEventsOnlyExternally(ctx, isCopy, &eventpb.SlowQuery{CommonSQLExecDetails: execDetails})
+			p.logEventsOnlyExternally(ctx, &eventpb.SlowQuery{CommonSQLExecDetails: execDetails})
 
 		case execType == executorTypeInternal && slowInternalQueryLogEnabled:
 			// Internal queries that surpass the slow query log threshold should only
 			// be logged to the slow-internal-only log if the cluster setting dictates.
-			p.logEventsOnlyExternally(ctx, isCopy, &eventpb.SlowQueryInternal{CommonSQLExecDetails: execDetails})
+			p.logEventsOnlyExternally(ctx, &eventpb.SlowQueryInternal{CommonSQLExecDetails: execDetails})
 		}
 	}
 
@@ -267,13 +265,12 @@ func (p *planner) maybeLogStatementInternal(
 				// see a copy of the execution on the DEV Channel.
 				dst:               LogExternally | LogToDevChannelIfVerbose,
 				verboseTraceLevel: execType.vLevel(),
-				isCopy:            isCopy,
 			},
 			&eventpb.QueryExecute{CommonSQLExecDetails: execDetails})
 	}
 
 	if shouldLogToAdminAuditLog {
-		p.logEventsOnlyExternally(ctx, isCopy, &eventpb.AdminQuery{CommonSQLExecDetails: execDetails})
+		p.logEventsOnlyExternally(ctx, &eventpb.AdminQuery{CommonSQLExecDetails: execDetails})
 	}
 
 	if telemetryLoggingEnabled && !p.SessionData().TroubleshootingMode {
@@ -412,21 +409,19 @@ func (p *planner) maybeLogStatementInternal(
 				SchemaChangerMode:                     p.curPlan.instrumentation.schemaChangerMode.String(),
 			}
 
-			p.logOperationalEventsOnlyExternally(ctx, isCopy, &sampledQuery)
+			p.logOperationalEventsOnlyExternally(ctx, &sampledQuery)
 		} else {
 			telemetryMetrics.incSkippedQueryCount()
 		}
 	}
 }
 
-func (p *planner) logEventsOnlyExternally(
-	ctx context.Context, isCopy bool, entries ...logpb.EventPayload,
-) {
+func (p *planner) logEventsOnlyExternally(ctx context.Context, entries ...logpb.EventPayload) {
 	// The API contract for logEventsWithOptions() is that it returns
 	// no error when system.eventlog is not written to.
 	_ = p.logEventsWithOptions(ctx,
 		2, /* depth: we want to use the caller location */
-		eventLogOptions{dst: LogExternally, isCopy: isCopy},
+		eventLogOptions{dst: LogExternally},
 		entries...)
 }
 
@@ -434,12 +429,12 @@ func (p *planner) logEventsOnlyExternally(
 // options to omit SQL Name redaction. This is used when logging to
 // the telemetry channel when we want additional metadata available.
 func (p *planner) logOperationalEventsOnlyExternally(
-	ctx context.Context, isCopy bool, entries ...logpb.EventPayload,
+	ctx context.Context, entries ...logpb.EventPayload,
 ) {
 	// The API contract for logEventsWithOptions() is that it returns
 	// no error when system.eventlog is not written to.
 	_ = p.logEventsWithOptions(ctx,
 		2, /* depth: we want to use the caller location */
-		eventLogOptions{dst: LogExternally, isCopy: isCopy, rOpts: redactionOptions{omitSQLNameRedaction: true}},
+		eventLogOptions{dst: LogExternally, rOpts: redactionOptions{omitSQLNameRedaction: true}},
 		entries...)
 }

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -61,6 +61,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/cockroach/pkg/sql/appstatspb"
+	"github.com/cockroachdb/cockroach/pkg/sql/auditlogging"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/lease"
@@ -1319,6 +1320,10 @@ type ExecutorConfig struct {
 	// SessionInitCache cache; contains information used during authentication
 	// and per-role default settings.
 	SessionInitCache *sessioninit.Cache
+
+	// AuditConfig is the cluster's audit configuration. See the
+	// 'sql.log.user_audit' cluster setting to see how this is configured.
+	AuditConfig *auditlogging.AuditConfigLock
 
 	// ProtectedTimestampProvider encapsulates the protected timestamp subsystem.
 	ProtectedTimestampProvider protectedts.Provider

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -624,7 +624,7 @@ func (p *planner) LeaseMgr() *lease.Manager {
 }
 
 func (p *planner) AuditConfig() *auditlogging.AuditConfigLock {
-	return p.execCfg.SessionInitCache.AuditConfig
+	return p.execCfg.AuditConfig
 }
 
 func (p *planner) Txn() *kv.Txn {

--- a/pkg/sql/sessioninit/BUILD.bazel
+++ b/pkg/sql/sessioninit/BUILD.bazel
@@ -13,7 +13,6 @@ go_library(
         "//pkg/security/username",
         "//pkg/settings",
         "//pkg/settings/cluster",
-        "//pkg/sql/auditlogging",
         "//pkg/sql/catalog",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/descs",

--- a/pkg/sql/sessioninit/cache.go
+++ b/pkg/sql/sessioninit/cache.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
-	"github.com/cockroachdb/cockroach/pkg/sql/auditlogging"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
@@ -58,10 +57,6 @@ type Cache struct {
 	settingsCache map[SettingsCacheKey][]string
 	// populateCacheGroup is used to ensure that there is at most one in-flight
 	// request for populating each cache entry.
-
-	// AuditConfig is the cluster's audit configuration. See the 'sql.log.user_audit'
-	// cluster setting to see how this is configured.
-	AuditConfig *auditlogging.AuditConfigLock
 
 	populateCacheGroup *singleflight.Group
 	stopper            *stop.Stopper
@@ -102,9 +97,6 @@ func NewCache(account mon.BoundAccount, stopper *stop.Stopper) *Cache {
 		boundAccount:       account,
 		populateCacheGroup: singleflight.NewGroup("load-value", "key"),
 		stopper:            stopper,
-		AuditConfig: &auditlogging.AuditConfigLock{
-			Config: auditlogging.EmptyAuditConfig(),
-		},
 	}
 }
 


### PR DESCRIPTION
Epic: None
Release note (bug fix): Fixed a bug where BEGIN, COMMIT, SET, ROLLBACK, and SAVEPOINT statements would not be written to the execution or audit logs.