### PR TITLE
release: update predecessor map for 23.1.7

### DIFF
--- a/pkg/testutils/release/cockroach_releases.yaml
+++ b/pkg/testutils/release/cockroach_releases.yaml
@@ -14,7 +14,7 @@
   - 22.2.8
   predecessor: "22.1"
 "23.1":
-  latest: 23.1.6
+  latest: 23.1.7
   withdrawn:
   - 23.1.0
   predecessor: "22.2"


### PR DESCRIPTION
Release note: None
Epic: None