### PR TITLE
server,storage: changes to ease rollout for corruption bug fix

### DIFF
--- a/pkg/base/config.go
+++ b/pkg/base/config.go
@@ -774,6 +774,8 @@ type StorageConfig struct {
 	// through to C CCL code to set up encryption-at-rest.  Must be set if and
 	// only if encryption is enabled, otherwise left empty.
 	EncryptionOptions []byte
+
+	StatsLoadedFunc func()
 }
 
 // IsEncrypted returns whether the StorageConfig has encryption enabled.

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -2166,6 +2166,10 @@ func (s *systemAdminServer) checkReadinessForHealthCheck(ctx context.Context) er
 		return grpcstatus.Errorf(codes.Unavailable, "node is not accepting SQL clients")
 	}
 
+	if s.server != nil && !s.server.statsLoaded.Load() {
+		return grpcstatus.Errorf(codes.Unavailable, "store stats are not yet loaded")
+	}
+
 	return nil
 }
 

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -689,7 +689,7 @@ func (e *Engines) Close() {
 
 // CreateEngines creates Engines based on the specs in cfg.Stores.
 func (cfg *Config) CreateEngines(
-	ctx context.Context, nodeIDContainer *base.NodeIDContainer,
+	ctx context.Context, nodeIDContainer *base.NodeIDContainer, statsLoaded *atomic.Bool,
 ) (Engines, error) {
 	var engines Engines
 	defer engines.Close()
@@ -759,6 +759,7 @@ func (cfg *Config) CreateEngines(
 					time.Sleep(time.Second)
 				}
 				log.Infof(ctx, "finished loading table stats for all stores")
+				statsLoaded.Store(true)
 			}()
 		}
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -280,7 +280,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		admissionOptions.Override(opts)
 	}
 
-	engines, err := cfg.CreateEngines(ctx)
+	engines, err := cfg.CreateEngines(ctx, nodeIDContainer)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create engines")
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -19,6 +19,7 @@ import (
 	"reflect"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -219,6 +220,8 @@ type Server struct {
 
 	// The following fields are populated at start time, i.e. in `(*Server).Start`.
 	startTime time.Time
+
+	statsLoaded *atomic.Bool
 }
 
 // NewServer creates a Server from a server.Config.
@@ -280,7 +283,8 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		admissionOptions.Override(opts)
 	}
 
-	engines, err := cfg.CreateEngines(ctx, nodeIDContainer)
+	var statsLoaded atomic.Bool
+	engines, err := cfg.CreateEngines(ctx, nodeIDContainer, &statsLoaded)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create engines")
 	}
@@ -1313,6 +1317,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		kvMemoryMonitor:           kvMemoryMonitor,
 		keyVisualizerServer:       keyVisualizerServer,
 		inspectzServer:            inspectzServer,
+		statsLoaded:               &statsLoaded,
 	}
 
 	return lateBoundServer, err

--- a/pkg/storage/open.go
+++ b/pkg/storage/open.go
@@ -245,6 +245,13 @@ func If(enable bool, opt ConfigOption) ConfigOption {
 	return func(cfg *engineConfig) error { return nil }
 }
 
+func StatsLoadedFunc(statsLoadedFunc func()) ConfigOption {
+	return func(cfg *engineConfig) error {
+		cfg.StatsLoadedFunc = statsLoadedFunc
+		return nil
+	}
+}
+
 // A Location describes where the storage engine's data will be written. A
 // Location may be in-memory or on the filesystem.
 type Location struct {

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -1138,7 +1138,7 @@ func NewPebble(ctx context.Context, cfg PebbleConfig) (p *Pebble, err error) {
 		p.async(func() { oldDiskSlow(info) })
 	}
 	el := pebble.TeeEventListener(
-		p.makeMetricEtcEventListener(ctx),
+		p.makeMetricEtcEventListener(logCtx),
 		lel,
 	)
 


### PR DESCRIPTION
storage,server: log when all configured stores have loaded stats
The log line is output after the NodeID is known.

server: return error from checkReadinessForHealthCheck if stats of all stores are not loaded

Epic: none

Release note: None