### PR TITLE
plpgsql: add support for sql exec and INTO statements

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/udf_plpgsql
+++ b/pkg/sql/logictest/testdata/logic_test/udf_plpgsql
@@ -3,6 +3,10 @@ CREATE TABLE xy (x INT, y INT);
 INSERT INTO xy VALUES (1, 2), (3, 4);
 
 statement ok
+CREATE TABLE kv (k INT PRIMARY KEY, v INT);
+INSERT INTO kv VALUES (1, 2), (3, 4);
+
+statement ok
 CREATE OR REPLACE FUNCTION f(a INT, b INT) RETURNS INT AS $$
   BEGIN
     RETURN a;
@@ -1436,3 +1440,405 @@ $$ LANGUAGE PLpgSQL;
 
 statement error pgcode 22012 pq: Oh no, division by zero!
 SELECT f();
+
+# Testing SQL statement execution.
+statement ok
+CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$
+  BEGIN
+    SELECT 1 + 1;
+    SELECT random();
+    SELECT * FROM xy;
+    INSERT INTO xy VALUES (1000, 1000);
+    DELETE FROM xy WHERE x = 1000;
+    RETURN 0;
+  END
+$$ LANGUAGE PLpgSQL;
+
+query I
+SELECT f();
+----
+0
+
+query II rowsort
+SELECT * FROM xy;
+----
+1  2
+3  4
+
+statement ok
+CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$
+  BEGIN
+    INSERT INTO kv VALUES (100, 100);
+    DELETE FROM kv WHERE k = 100;
+    INSERT INTO kv VALUES (100, 100);
+    RETURN (SELECT v FROM kv WHERE k = 100);
+  END
+$$ LANGUAGE PLpgSQL;
+
+query I
+SELECT f();
+----
+100
+
+query II rowsort
+SELECT * FROM kv;
+----
+1    2
+3    4
+100  100
+
+statement ok
+DELETE FROM kv WHERE k = 100;
+
+statement ok
+CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$
+  BEGIN
+    INSERT INTO kv VALUES (100, 100);
+    INSERT INTO kv VALUES (100, 100);
+    RETURN (SELECT v FROM kv WHERE k = 100);
+  END
+$$ LANGUAGE PLpgSQL;
+
+statement error pgcode 23505 pq: duplicate key value violates unique constraint \"kv_pkey\"
+SELECT f();
+
+query II rowsort
+SELECT * FROM kv;
+----
+1  2
+3  4
+
+statement error pgcode 0A000 pq: unimplemented: EXPLAIN usage inside a function definition
+CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$
+  BEGIN
+    EXPLAIN SELECT * FROM xy;
+    RETURN 0;
+  END
+$$ LANGUAGE PLpgSQL;
+
+statement error pgcode 0A000 pq: unimplemented: CTE usage inside a function definition
+CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$
+  BEGIN
+    WITH foo AS MATERIALIZED (SELECT * FROM xy) SELECT * FROM foo;
+    RETURN 0;
+  END
+$$ LANGUAGE PLpgSQL;
+
+statement error pgcode 0A000 pq: unimplemented: SHOW DATABASES usage inside a function definition
+CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$
+  BEGIN
+    SHOW databases;
+    RETURN 0;
+  END
+$$ LANGUAGE PLpgSQL;
+
+statement error pgcode 0A000 pq: unimplemented: statement source \(square bracket syntax\) within user-defined function
+CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$
+  BEGIN
+    SELECT * FROM [SHOW databases];
+    RETURN 0;
+  END
+$$ LANGUAGE PLpgSQL;
+
+
+statement error pgcode 0A000 pq: unimplemented: CREATE TABLE usage inside a function definition
+CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$
+  BEGIN
+    CREATE TABLE ab (a INT, b INT);
+    RETURN 0;
+  END
+$$ LANGUAGE PLpgSQL;
+
+
+statement error pgcode 0A000 pq: unimplemented: ALTER TABLE usage inside a function definition
+CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$
+  BEGIN
+    ALTER TABLE xy ADD COLUMN z INT;
+    RETURN 0;
+  END
+$$ LANGUAGE PLpgSQL;
+
+
+statement error pgcode 0A000 pq: unimplemented: PREPARE usage inside a function definition
+CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$
+  BEGIN
+    PREPARE foo AS SELECT * FROM xy WHERE x = $1;
+    RETURN 0;
+  END
+$$ LANGUAGE PLpgSQL;
+
+# Testing SQL statements with INTO.
+statement ok
+CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$
+  DECLARE
+    i INT;
+  BEGIN
+    SELECT 1 INTO i;
+    RETURN i;
+  END
+$$ LANGUAGE PLpgSQL;
+
+query I
+SELECT f();
+----
+1
+
+statement ok
+CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$
+  DECLARE
+    i INT;
+  BEGIN
+    SELECT x INTO i FROM xy ORDER BY x DESC LIMIT 1;
+    RETURN i;
+  END
+$$ LANGUAGE PLpgSQL;
+
+query I
+SELECT f();
+----
+3
+
+# If the INTO query returns more than one row, only the first is used.
+statement ok
+CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$
+  DECLARE
+    i INT;
+  BEGIN
+    SELECT x INTO i FROM xy ORDER BY x DESC;
+    RETURN i;
+  END
+$$ LANGUAGE PLpgSQL;
+
+query I
+SELECT f();
+----
+3
+
+# If the INTO query returns no rows, the target variables are set to NULL.
+statement ok
+DELETE FROM xy WHERE true;
+
+statement ok
+CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$
+  DECLARE
+    i INT;
+  BEGIN
+    SELECT x INTO i FROM xy ORDER BY x DESC;
+    RETURN i;
+  END
+$$ LANGUAGE PLpgSQL;
+
+query I
+SELECT f();
+----
+NULL
+
+statement ok
+INSERT INTO xy VALUES (1, 2), (3, 4);
+
+query I
+SELECT f();
+----
+3
+
+statement ok
+CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$
+  DECLARE
+    i INT;
+  BEGIN
+    INSERT INTO xy VALUES (100, 100) RETURNING x INTO i;
+    RETURN i;
+  END
+$$ LANGUAGE PLpgSQL;
+
+query I
+SELECT f();
+----
+100
+
+query II rowsort
+SELECT * FROM xy;
+----
+1    2
+3    4
+100  100
+
+statement ok
+CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$
+  DECLARE
+    i INT;
+  BEGIN
+    UPDATE xy SET y = y * 2 WHERE x = 100 RETURNING x INTO i;
+    RETURN i;
+  END
+$$ LANGUAGE PLpgSQL;
+
+query I
+SELECT f();
+----
+100
+
+query II rowsort
+SELECT * FROM xy;
+----
+1    2
+3    4
+100  200
+
+statement ok
+CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$
+  DECLARE
+    i INT;
+  BEGIN
+    DELETE FROM xy WHERE x = 100 RETURNING x INTO i;
+    RETURN i;
+  END
+$$ LANGUAGE PLpgSQL;
+
+query I
+SELECT f();
+----
+100
+
+query II rowsort
+SELECT * FROM xy;
+----
+1  2
+3  4
+
+statement ok
+DROP FUNCTION f(INT);
+CREATE OR REPLACE FUNCTION f(n INT) RETURNS INT AS $$
+  DECLARE
+    foo INT;
+    bar INT;
+    i INT := 0;
+  BEGIN
+    LOOP IF i >= n THEN EXIT; END IF;
+      INSERT INTO xy VALUES (100+i, 200+i) RETURNING y INTO bar;
+      SELECT x INTO foo FROM xy ORDER BY x DESC LIMIT 1;
+      RAISE NOTICE 'foo: %, bar: %', foo, bar;
+      i := i + 1;
+    END LOOP;
+    RETURN 0;
+  END
+$$ LANGUAGE PLpgSQL;
+
+query T noticetrace
+SELECT f(5);
+----
+NOTICE: foo: 100, bar: 200
+NOTICE: foo: 101, bar: 201
+NOTICE: foo: 102, bar: 202
+NOTICE: foo: 103, bar: 203
+NOTICE: foo: 104, bar: 204
+
+query II rowsort
+SELECT * FROM xy;
+----
+1    2
+3    4
+100  200
+101  201
+102  202
+103  203
+104  204
+
+# If there are more INTO targets than output columns, the left over variables
+# are set to NULL.
+statement ok
+CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$
+  DECLARE
+    i INT;
+    j INT;
+  BEGIN
+    SELECT x INTO i, j FROM xy ORDER BY x DESC;
+    RAISE NOTICE 'i = %', i;
+    IF j IS NULL THEN
+      RAISE NOTICE 'j is null!';
+    END IF;
+    RETURN 0;
+  END
+$$ LANGUAGE PLpgSQL;
+
+query T noticetrace
+SELECT f();
+----
+NOTICE: i = 104
+NOTICE: j is null!
+
+# If there are less INTO targets than output columns, the left over columns
+# are ignored.
+statement ok
+CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$
+  DECLARE
+    i INT;
+  BEGIN
+    SELECT x, y INTO i FROM xy ORDER BY x DESC;
+    RETURN i;
+  END
+$$ LANGUAGE PLpgSQL;
+
+query I
+SELECT f();
+----
+104
+
+query II rowsort
+SELECT * FROM xy;
+----
+1    2
+3    4
+100  200
+101  201
+102  202
+103  203
+104  204
+
+# It is possible to SELECT INTO multiple targets.
+statement ok
+CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$
+  DECLARE
+    i INT;
+    j INT;
+  BEGIN
+    SELECT x, y INTO i, j FROM xy ORDER BY x DESC;
+    RETURN i + j;
+  END
+$$ LANGUAGE PLpgSQL;
+
+query I
+SELECT f();
+----
+308
+
+# It is possible to reference a previous value of a target variable in a
+# SELECT INTO statement.
+statement ok
+CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$
+  DECLARE
+    i INT;
+  BEGIN
+    SELECT x INTO i FROM xy ORDER BY x DESC;
+    RAISE NOTICE 'i = %', i;
+    SELECT x INTO i FROM xy WHERE x < i ORDER BY x DESC;
+    RAISE NOTICE 'i = %', i;
+    RETURN 0;
+  END
+$$ LANGUAGE PLpgSQL;
+
+query T noticetrace
+SELECT f();
+----
+NOTICE: i = 104
+NOTICE: i = 103
+
+statement error pgcode 0A000 pq: unimplemented: assigning to a variable more than once in the same INTO statement is not supported
+CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$
+  DECLARE
+    i INT;
+  BEGIN
+    SELECT x, y INTO i, i FROM xy ORDER BY x DESC;
+    RETURN i;
+  END
+$$ LANGUAGE PLpgSQL;

--- a/pkg/sql/logictest/testdata/logic_test/udf_plpgsql
+++ b/pkg/sql/logictest/testdata/logic_test/udf_plpgsql
@@ -328,13 +328,16 @@ SELECT f(1, 5), f(-5, 5), f(0, 1)
 # TODO(drewk): add back the dijkstra test once UDFs calling other UDFs is
 # allowed.
 
-statement error pgcode 2F005 control reached end of function without RETURN
+statement ok
 CREATE OR REPLACE FUNCTION f(a INT, b INT) RETURNS INT AS $$
   BEGIN
   END
 $$ LANGUAGE PLpgSQL;
 
 statement error pgcode 2F005 control reached end of function without RETURN
+SELECT f(1, 2);
+
+statement ok
 CREATE OR REPLACE FUNCTION f(a INT, b INT) RETURNS INT AS $$
   DECLARE
     i INT;
@@ -344,6 +347,9 @@ CREATE OR REPLACE FUNCTION f(a INT, b INT) RETURNS INT AS $$
 $$ LANGUAGE PLpgSQL;
 
 statement error pgcode 2F005 control reached end of function without RETURN
+SELECT f(1, 2);
+
+statement ok
 CREATE OR REPLACE FUNCTION f(a INT, b INT) RETURNS INT AS $$
   BEGIN
     IF a < b THEN
@@ -352,7 +358,15 @@ CREATE OR REPLACE FUNCTION f(a INT, b INT) RETURNS INT AS $$
   END
 $$ LANGUAGE PLpgSQL;
 
+query I
+SELECT f(1, 2);
+----
+1
+
 statement error pgcode 2F005 control reached end of function without RETURN
+SELECT f(2, 1);
+
+statement ok
 CREATE OR REPLACE FUNCTION f(a INT, b INT) RETURNS INT AS $$
   DECLARE
     i INT;
@@ -366,6 +380,14 @@ CREATE OR REPLACE FUNCTION f(a INT, b INT) RETURNS INT AS $$
 $$ LANGUAGE PLpgSQL;
 
 statement error pgcode 2F005 control reached end of function without RETURN
+SELECT f(1, 2);
+
+query I
+SELECT f(2, 1);
+----
+0
+
+statement ok
 CREATE OR REPLACE FUNCTION f(a INT, b INT) RETURNS INT AS $$
   DECLARE
     i INT;
@@ -380,7 +402,15 @@ CREATE OR REPLACE FUNCTION f(a INT, b INT) RETURNS INT AS $$
   END
 $$ LANGUAGE PLpgSQL;
 
+query II
+SELECT f(1, 2), f(2, 1);
+----
+-1  1
+
 statement error pgcode 2F005 control reached end of function without RETURN
+SELECT f(1, 1);
+
+statement ok
 CREATE OR REPLACE FUNCTION f(a INT, b INT) RETURNS INT AS $$
   BEGIN
     LOOP
@@ -390,6 +420,9 @@ CREATE OR REPLACE FUNCTION f(a INT, b INT) RETURNS INT AS $$
 $$ LANGUAGE PLpgSQL;
 
 statement error pgcode 2F005 control reached end of function without RETURN
+SELECT f(1, 2);
+
+statement ok
 CREATE OR REPLACE FUNCTION f(a INT, b INT) RETURNS INT AS $$
   BEGIN
     LOOP
@@ -400,6 +433,29 @@ CREATE OR REPLACE FUNCTION f(a INT, b INT) RETURNS INT AS $$
     END IF;
   END
 $$ LANGUAGE PLpgSQL;
+
+query I
+SELECT f(1, 2);
+----
+0
+
+statement error pgcode 2F005 control reached end of function without RETURN
+SELECT f(2, 1);
+
+statement ok
+CREATE OR REPLACE FUNCTION f(a INT, b INT) RETURNS INT AS $$
+  BEGIN
+    IF a < b THEN
+      RAISE 'foo % %', a, b;
+    END IF;
+  END
+$$ LANGUAGE PLpgSQL;
+
+statement error pgcode P0001 foo 1 2
+SELECT f(1, 2);
+
+statement error pgcode 2F005 control reached end of function without RETURN
+SELECT f(2, 1);
 
 statement error pgcode 0A000 PL/pgSQL functions with RECORD input arguments are not yet supported
 CREATE FUNCTION f_err(p1 RECORD) RETURNS RECORD AS $$

--- a/pkg/sql/opt/optbuilder/plpgsql.go
+++ b/pkg/sql/opt/optbuilder/plpgsql.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
-	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/builtins/builtinsregistry"
@@ -208,24 +207,11 @@ func (b *plpgsqlBuilder) build(block *plpgsqltree.PLpgSQLStmtBlock, s *scope) *s
 		// are caught. Note that errors thrown during variable elimination are
 		// intentionally not caught.
 		catchCon := b.makeContinuation("exception_block")
-		b.finishContinuation(block.Body, &catchCon, false /* recursive */)
+		b.appendPlpgSQLStmts(&catchCon, block.Body)
 		s = b.callContinuation(&catchCon, s)
 	} else {
 		// No exception block, so no need to wrap the body statements.
 		s = b.buildPLpgSQLStatements(block.Body, s)
-	}
-	if s == nil {
-		// At least one path in the control flow does not terminate with a RETURN
-		// statement.
-		//
-		// Postgres throws this error at runtime, so it's possible to define a
-		// function that runs correctly for some inputs, but returns this error for
-		// others. We are compiling rather than interpreting, so it seems better to
-		// eagerly return the error if there is an execution path with no RETURN.
-		panic(pgerror.New(
-			pgcode.RoutineExceptionFunctionExecutedNoReturnStatement,
-			"control reached end of function without RETURN",
-		))
 	}
 	return s
 }
@@ -265,7 +251,7 @@ func (b *plpgsqlBuilder) buildPLpgSQLStatements(
 				// will be the correct values for the variables, and can be passed to
 				// the exception handler routines.
 				catchCon := b.makeContinuation("assign_exception_block")
-				b.finishContinuation(stmts[i+1:], &catchCon, false /* recursive */)
+				b.appendPlpgSQLStmts(&catchCon, stmts[i+1:])
 				return b.callContinuation(&catchCon, s)
 			}
 		case *plpgsqltree.PLpgSQLStmtIf:
@@ -280,7 +266,7 @@ func (b *plpgsqlBuilder) buildPLpgSQLStatements(
 			//   IF (...) THEN ... END IF;
 			//   RETURN (...); <-- This is used to build the continuation function.
 			con := b.makeContinuation("stmt_if")
-			b.finishContinuation(stmts[i+1:], &con, false /* recursive */)
+			b.appendPlpgSQLStmts(&con, stmts[i+1:])
 			b.pushContinuation(con)
 			// Build each branch of the IF statement, calling the continuation
 			// function at the end of construction in order to resume execution after
@@ -346,12 +332,11 @@ func (b *plpgsqlBuilder) buildPLpgSQLStatements(
 			// statement, the exit continuation is called to model returning control
 			// flow to the statements outside the loop.
 			exitCon := b.makeContinuation("loop_exit")
-			b.finishContinuation(stmts[i+1:], &exitCon, false /* recursive */)
+			b.appendPlpgSQLStmts(&exitCon, stmts[i+1:])
 			b.pushExitContinuation(exitCon)
-			loopContinuation := b.makeContinuation("stmt_loop")
-			loopContinuation.isLoopContinuation = true
+			loopContinuation := b.makeRecursiveContinuation("stmt_loop")
 			b.pushContinuation(loopContinuation)
-			b.finishContinuation(t.Body, &loopContinuation, true /* recursive */)
+			b.appendPlpgSQLStmts(&loopContinuation, t.Body)
 			b.popContinuation()
 			b.popExitContinuation()
 			return b.callContinuation(&loopContinuation, s)
@@ -394,32 +379,10 @@ func (b *plpgsqlBuilder) buildPLpgSQLStatements(
 			// statement, which returns the actual result of evaluation.
 			//
 			// The synchronous notice sending behavior is implemented in the
-			// crdb_internal.plpgsql_raise builtin function. The side-effecting body
-			// statement just makes a call into crdb_internal.plpgsql_raise using the
-			// RAISE statement options as parameters.
+			// crdb_internal.plpgsql_raise builtin function.
 			con := b.makeContinuation("_stmt_raise")
-			const raiseFnName = "crdb_internal.plpgsql_raise"
-			props, overloads := builtinsregistry.GetBuiltinProperties(raiseFnName)
-			if len(overloads) != 1 {
-				panic(errors.AssertionFailedf("expected one overload for %s", raiseFnName))
-			}
-			raiseCall := b.ob.factory.ConstructFunction(
-				b.getRaiseArgs(con.s, t),
-				&memo.FunctionPrivate{
-					Name:       raiseFnName,
-					Typ:        types.Int,
-					Properties: props,
-					Overload:   &overloads[0],
-				},
-			)
-			raiseColName := scopeColName("").WithMetadataName(b.makeIdentifier("stmt_raise"))
-			raiseScope := con.s.push()
-			b.ensureScopeHasExpr(raiseScope)
-			b.ob.synthesizeColumn(raiseScope, raiseColName, types.Int, nil /* expr */, raiseCall)
-			b.ob.constructProjectForScope(con.s, raiseScope)
-			con.def.Body = []memo.RelExpr{raiseScope.expr}
-			con.def.BodyProps = []*physical.Required{raiseScope.makePhysicalProps()}
-			b.finishContinuation(stmts[i+1:], &con, false /* recursive */)
+			b.appendBodyStmt(&con, b.buildPLpgSQLRaise(con.s, b.getRaiseArgs(con.s, t)))
+			b.appendPlpgSQLStmts(&con, stmts[i+1:])
 			return b.callContinuation(&con, s)
 		default:
 			panic(unimplemented.New(
@@ -466,6 +429,30 @@ func (b *plpgsqlBuilder) addPLpgSQLAssign(
 	b.ob.synthesizeColumn(assignScope, colName, typ, nil, scalar)
 	b.ob.constructProjectForScope(inScope, assignScope)
 	return assignScope
+}
+
+// buildPLpgSQLRaise builds a call to the crdb_internal.plpgsql_raise builtin
+// function, which implements the notice-sending behavior of RAISE statements.
+func (b *plpgsqlBuilder) buildPLpgSQLRaise(inScope *scope, args memo.ScalarListExpr) *scope {
+	const raiseFnName = "crdb_internal.plpgsql_raise"
+	props, overloads := builtinsregistry.GetBuiltinProperties(raiseFnName)
+	if len(overloads) != 1 {
+		panic(errors.AssertionFailedf("expected one overload for %s", raiseFnName))
+	}
+	raiseCall := b.ob.factory.ConstructFunction(
+		args,
+		&memo.FunctionPrivate{
+			Name:       raiseFnName,
+			Typ:        types.Int,
+			Properties: props,
+			Overload:   &overloads[0],
+		},
+	)
+	raiseColName := scopeColName("").WithMetadataName(b.makeIdentifier("stmt_raise"))
+	raiseScope := inScope.push()
+	b.ob.synthesizeColumn(raiseScope, raiseColName, types.Int, nil /* expr */, raiseCall)
+	b.ob.constructProjectForScope(inScope, raiseScope)
+	return raiseScope
 }
 
 // getRaiseArgs validates the options attached to the given PLpgSQL RAISE
@@ -687,7 +674,7 @@ func (b *plpgsqlBuilder) buildExceptions(block *plpgsqltree.PLpgSQLStmtBlock) {
 	handlers := make([]*memo.UDFDefinition, 0, len(block.Exceptions))
 	for _, e := range block.Exceptions {
 		handlerCon := b.makeContinuation("exception_handler")
-		b.finishContinuation(e.Action, &handlerCon, false /* recursive */)
+		b.appendPlpgSQLStmts(&handlerCon, e.Action)
 		handlerCon.def.Volatility = volatility.Volatile
 		for _, cond := range e.Conditions {
 			if cond.SqlErrState != "" {
@@ -715,6 +702,31 @@ func (b *plpgsqlBuilder) buildExceptions(block *plpgsqltree.PLpgSQLStmtBlock) {
 		Codes:   codes,
 		Actions: handlers,
 	}
+}
+
+// buildEndOfFunctionRaise builds a RAISE statement that throws an error when
+// control reaches the end of a PLpgSQL routine without reaching a RETURN
+// statement.
+func (b *plpgsqlBuilder) buildEndOfFunctionRaise(inScope *scope) *scope {
+	makeConstStr := func(str string) opt.ScalarExpr {
+		return b.ob.factory.ConstructConstVal(tree.NewDString(str), types.String)
+	}
+	args := memo.ScalarListExpr{
+		makeConstStr("ERROR"), /* severity */
+		makeConstStr("control reached end of function without RETURN"), /* message */
+		makeConstStr(""), /* detail */
+		makeConstStr(""), /* hint */
+		makeConstStr(pgcode.RoutineExceptionFunctionExecutedNoReturnStatement.String()), /* code */
+	}
+	con := b.makeContinuation("_end_of_function")
+	b.appendBodyStmt(&con, b.buildPLpgSQLRaise(con.s, args))
+	// Build a dummy statement that returns NULL. It won't be executed, but
+	// ensures that the continuation routine's return type is correct.
+	eofColName := scopeColName("").WithMetadataName(b.makeIdentifier("end_of_function"))
+	eofScope := inScope.push()
+	b.ob.synthesizeColumn(eofScope, eofColName, b.returnType, nil /* expr */, memo.NullSingleton)
+	b.ob.constructProjectForScope(inScope, eofScope)
+	return b.callContinuation(&con, inScope)
 }
 
 // makeContinuation allocates a new continuation function with an uninitialized
@@ -749,51 +761,51 @@ func (b *plpgsqlBuilder) makeContinuation(name string) continuation {
 	}
 }
 
-// finishContinuation adds the final body statement to the definition of a
-// continuation function. This statement returns the result of executing the
-// given PLpgSQL statements. There may be other statements that are executed
-// before this final statement for their side effects (e.g. RAISE statement).
+// makeRecursiveContinuation allocates a new continuation routine that can
+// recursively invoke itself.
+func (b *plpgsqlBuilder) makeRecursiveContinuation(name string) continuation {
+	con := b.makeContinuation(name)
+	con.def.IsRecursive = true
+	return con
+}
+
+// appendBodyStmt adds a body statement to the definition of a continuation
+// function. Only the last body statement will return results; all others will
+// only be executed for their side effects (e.g. RAISE statement).
 //
-// finishContinuation is separate from makeContinuation to allow recursive
-// function definitions, which need to push the continuation before it is
-// finished.
-func (b *plpgsqlBuilder) finishContinuation(
-	stmts []plpgsqltree.PLpgSQLStatement, con *continuation, recursive bool,
+// appendBodyStmt is separate from makeContinuation to allow recursive routine
+// definitions, which need to push the continuation before it is finished. The
+// separation also allows for appending multiple body statements.
+func (b *plpgsqlBuilder) appendBodyStmt(con *continuation, bodyScope *scope) {
+	// Set the volatility of the continuation routine to the least restrictive
+	// volatility level in the Relational properties of the body statements.
+	vol := bodyScope.expr.Relational().VolatilitySet.ToVolatility()
+	if con.def.Volatility < vol {
+		con.def.Volatility = vol
+	}
+	con.def.Body = append(con.def.Body, bodyScope.expr)
+	con.def.BodyProps = append(con.def.BodyProps, bodyScope.makePhysicalProps())
+}
+
+// appendPlpgSQLStmts builds the given PLpgSQL statements into a relational
+// expression and appends it to the given continuation routine's body statements
+// list.
+func (b *plpgsqlBuilder) appendPlpgSQLStmts(
+	con *continuation, stmts []plpgsqltree.PLpgSQLStatement,
 ) {
 	// Make sure to push s before constructing the continuation scope to ensure
 	// that the parameter columns are not projected.
 	continuationScope := b.buildPLpgSQLStatements(stmts, con.s.push())
-	if continuationScope == nil {
-		// One or more branches did not terminate with a RETURN statement.
-		con.reachedEndOfFunction = true
-		return
-	}
-	// Append to the body statements because some PLpgSQL statements will make a
-	// continuation routine with more than one body statement in order to handle
-	// side effects (see the RAISE case in buildPLpgSQLStatements).
-	con.def.Body = append(con.def.Body, continuationScope.expr)
-	con.def.BodyProps = append(con.def.BodyProps, continuationScope.makePhysicalProps())
-	con.def.IsRecursive = recursive
-	// Set the volatility of the continuation routine to the least restrictive
-	// volatility level in the expression's Relational properties.
-	vol := continuationScope.expr.Relational().VolatilitySet
-	if vol.HasVolatile() {
-		con.def.Volatility = volatility.Volatile
-	} else if vol.HasStable() {
-		con.def.Volatility = volatility.Stable
-	} else if vol.IsLeakproof() {
-		con.def.Volatility = volatility.Leakproof
-	} else {
-		con.def.Volatility = volatility.Immutable
-	}
+	b.appendBodyStmt(con, continuationScope)
 }
 
 // callContinuation adds a column that projects the result of calling the
 // given continuation function.
 func (b *plpgsqlBuilder) callContinuation(con *continuation, s *scope) *scope {
-	if con == nil || con.reachedEndOfFunction {
-		// Return nil to signify "control reached end of function without RETURN".
-		return nil
+	if con == nil {
+		// There is no continuation. If the control flow reaches this point, we need
+		// to throw a runtime error.
+		return b.buildEndOfFunctionRaise(s)
 	}
 	args := make(memo.ScalarListExpr, 0, len(b.decls)+len(b.params))
 	addArg := func(name tree.Name, typ *types.T) {
@@ -858,16 +870,6 @@ type continuation struct {
 	// s is a scope initialized with the parameters of the routine. It should be
 	// used to construct the routine body statement.
 	s *scope
-
-	// isLoopContinuation indicates that this continuation was constructed for the
-	// body statements of a loop.
-	isLoopContinuation bool
-
-	// reachedEndOfFunction indicates that the statements used to define this
-	// continuation did not return from at least one path in the control flow.
-	// If this continuation is reachable from the root, we return a
-	// "control reached end of function without RETURN" error.
-	reachedEndOfFunction bool
 }
 
 func (b *plpgsqlBuilder) pushContinuation(con continuation) {
@@ -906,7 +908,7 @@ func (b *plpgsqlBuilder) getExitContinuation() *continuation {
 
 func (b *plpgsqlBuilder) getLoopContinuation() *continuation {
 	for i := len(b.continuations) - 1; i >= 0; i-- {
-		if b.continuations[i].isLoopContinuation {
+		if b.continuations[i].def.IsRecursive {
 			return &b.continuations[i]
 		}
 	}

--- a/pkg/sql/opt/optbuilder/plpgsql.go
+++ b/pkg/sql/opt/optbuilder/plpgsql.go
@@ -384,6 +384,78 @@ func (b *plpgsqlBuilder) buildPLpgSQLStatements(
 			b.appendBodyStmt(&con, b.buildPLpgSQLRaise(con.s, b.getRaiseArgs(con.s, t)))
 			b.appendPlpgSQLStmts(&con, stmts[i+1:])
 			return b.callContinuation(&con, s)
+		case *plpgsqltree.PLpgSQLStmtExecSql:
+			if t.Strict {
+				panic(unimplemented.NewWithIssuef(107854,
+					"INTO STRICT statements are not yet implemented",
+				))
+			}
+			// Create a new continuation routine to handle executing a SQL statement.
+			execCon := b.makeContinuation("_stmt_exec")
+			stmtScope := b.ob.buildStmtAtRootWithScope(t.SqlStmt, nil /* desiredTypes */, execCon.s)
+			if t.Target == nil {
+				// When there is not INTO target, build the SQL statement into a body
+				// statement that is only executed for its side effects.
+				b.appendBodyStmt(&execCon, stmtScope)
+				b.appendPlpgSQLStmts(&execCon, stmts[i+1:])
+				return b.callContinuation(&execCon, s)
+			}
+			// This statement has an INTO target. Unlike the above case, we need the
+			// result of executing the SQL statement, since its result is assigned to
+			// the target variables. We handle this using the following steps:
+			//   1. Build the PLpgSQL statements following this one into a
+			//      continuation routine.
+			//   2. Build the INTO statement into a continuation routine that calls
+			//      the continuation from Step 1 using its output as parameters.
+			//   3. Call the INTO continuation from the parent scope.
+			//
+			// Step 1: build a continuation for the remaining PLpgSQL statements.
+			retCon := b.makeContinuation("_stmt_exec_ret")
+			b.appendPlpgSQLStmts(&retCon, stmts[i+1:])
+
+			// We only need the first row from the SQL statement.
+			stmtScope.expr = b.ob.factory.ConstructLimit(
+				stmtScope.expr,
+				b.ob.factory.ConstructConst(tree.NewDInt(tree.DInt(1)), types.Int),
+				stmtScope.makeOrderingChoice(),
+			)
+
+			// Step 2: build the INTO statement into a continuation routine that calls
+			// the previously built continuation.
+			//
+			// For each target variable, project an output column that aliases the
+			// corresponding column from the SQL statement. Previous values for the
+			// variables will naturally be "overwritten" by the projection, since
+			// input columns are always considered before outer columns when resolving
+			// a column reference.
+			intoScope := stmtScope.push()
+			for j := range t.Target {
+				typ := b.resolveVariableForAssign(t.Target[j])
+				colName := scopeColName(t.Target[j])
+				var scalar opt.ScalarExpr
+				if j < len(stmtScope.cols) {
+					scalar = b.ob.factory.ConstructVariable(stmtScope.cols[j].id)
+				} else {
+					// If there are less output columns than target variables, NULL is
+					// assigned to any remaining targets.
+					scalar = b.ob.factory.ConstructConstVal(tree.DNull, typ)
+				}
+				for i := range intoScope.cols {
+					if intoScope.cols[i].name.MatchesReferenceName(t.Target[j]) {
+						panic(unimplemented.New(
+							"duplicate INTO target",
+							"assigning to a variable more than once in the same INTO statement is not supported",
+						))
+					}
+				}
+				b.ob.synthesizeColumn(intoScope, colName, typ, nil /* expr */, scalar)
+			}
+			b.ob.constructProjectForScope(stmtScope, intoScope)
+			intoScope = b.callContinuation(&retCon, intoScope)
+
+			// Step 3: call the INTO continuation from the parent scope.
+			b.appendBodyStmt(&execCon, intoScope)
+			return b.callContinuation(&execCon, s)
 		default:
 			panic(unimplemented.New(
 				"unimplemented PL/pgSQL statement",
@@ -402,15 +474,7 @@ func (b *plpgsqlBuilder) buildPLpgSQLStatements(
 func (b *plpgsqlBuilder) addPLpgSQLAssign(
 	inScope *scope, ident plpgsqltree.PLpgSQLVariable, val plpgsqltree.PLpgSQLExpr,
 ) *scope {
-	if b.constants != nil {
-		if _, ok := b.constants[ident]; ok {
-			panic(pgerror.Newf(pgcode.ErrorInAssignment, "variable \"%s\" is declared CONSTANT", ident))
-		}
-	}
-	typ, ok := b.varTypes[ident]
-	if !ok {
-		panic(pgerror.Newf(pgcode.Syntax, "\"%s\" is not a known variable", ident))
-	}
+	typ := b.resolveVariableForAssign(ident)
 	assignScope := inScope.push()
 	b.ensureScopeHasExpr(assignScope)
 	for i := range inScope.cols {
@@ -729,7 +793,7 @@ func (b *plpgsqlBuilder) buildEndOfFunctionRaise(inScope *scope) *scope {
 	return b.callContinuation(&con, inScope)
 }
 
-// makeContinuation allocates a new continuation function with an uninitialized
+// makeContinuation allocates a new continuation routine with an uninitialized
 // definition.
 func (b *plpgsqlBuilder) makeContinuation(name string) continuation {
 	s := b.ob.allocScope()
@@ -809,7 +873,10 @@ func (b *plpgsqlBuilder) callContinuation(con *continuation, s *scope) *scope {
 	}
 	args := make(memo.ScalarListExpr, 0, len(b.decls)+len(b.params))
 	addArg := func(name tree.Name, typ *types.T) {
-		_, source, _, _ := s.FindSourceProvidingColumn(b.ob.ctx, name)
+		_, source, _, err := s.FindSourceProvidingColumn(b.ob.ctx, name)
+		if err != nil {
+			panic(err)
+		}
 		if source != nil {
 			args = append(args, b.ob.factory.ConstructVariable(source.(*scopeColumn).id))
 		} else {
@@ -844,6 +911,21 @@ func (b *plpgsqlBuilder) buildPLpgSQLExpr(
 		panic(err)
 	}
 	return b.ob.buildScalar(typedExpr, s, nil, nil, b.colRefs)
+}
+
+// resolveVariableForAssign attempts to retrieve the type of the variable with
+// the given name, throwing an error if no such variable exists.
+func (b *plpgsqlBuilder) resolveVariableForAssign(name tree.Name) *types.T {
+	typ, ok := b.varTypes[name]
+	if !ok {
+		panic(pgerror.Newf(pgcode.Syntax, "\"%s\" is not a known variable", name))
+	}
+	if b.constants != nil {
+		if _, ok := b.constants[name]; ok {
+			panic(pgerror.Newf(pgcode.ErrorInAssignment, "variable \"%s\" is declared CONSTANT", name))
+		}
+	}
+	return typ
 }
 
 func (b *plpgsqlBuilder) ensureScopeHasExpr(s *scope) {

--- a/pkg/sql/opt/optbuilder/testdata/udf_plpgsql
+++ b/pkg/sql/opt/optbuilder/testdata/udf_plpgsql
@@ -3,6 +3,10 @@ CREATE TABLE xy (x INT, y INT);
 ----
 
 exec-ddl
+CREATE TABLE kv (k INT PRIMARY KEY, v INT);
+----
+
+exec-ddl
 CREATE OR REPLACE FUNCTION f(a INT, b INT) RETURNS INT AS $$
   BEGIN
     RETURN a;
@@ -4101,4 +4105,341 @@ project
                      │                             │    └── tuple
                      │                             └── projections
                      │                                  └── variable: i:6 [as=stmt_return_2:9]
+                     └── const: 1
+
+# Testing SQL statement execution.
+exec-ddl
+CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$
+  BEGIN
+    INSERT INTO kv VALUES (100, 100);
+    DELETE FROM kv WHERE k = 100;
+    INSERT INTO kv VALUES (100, 100);
+    RETURN (SELECT v FROM kv WHERE k = 100);
+  END
+$$ LANGUAGE PLpgSQL;
+----
+
+# TODO(drewk): add norm rule to fold the non-output body statements of nested
+# routines.
+build format=show-scalars
+SELECT f();
+----
+project
+ ├── columns: f:29
+ ├── values
+ │    └── tuple
+ └── projections
+      └── udf: f [as=f:29]
+           └── body
+                └── limit
+                     ├── columns: "_stmt_exec_1":28
+                     ├── project
+                     │    ├── columns: "_stmt_exec_1":28
+                     │    ├── values
+                     │    │    └── tuple
+                     │    └── projections
+                     │         └── udf: _stmt_exec_1 [as="_stmt_exec_1":28]
+                     │              └── body
+                     │                   ├── insert kv
+                     │                   │    ├── columns: <none>
+                     │                   │    ├── insert-mapping:
+                     │                   │    │    ├── column1:5 => k:1
+                     │                   │    │    └── column2:6 => v:2
+                     │                   │    └── values
+                     │                   │         ├── columns: column1:5!null column2:6!null
+                     │                   │         └── tuple
+                     │                   │              ├── const: 100
+                     │                   │              └── const: 100
+                     │                   └── project
+                     │                        ├── columns: "_stmt_exec_2":27
+                     │                        ├── values
+                     │                        │    └── tuple
+                     │                        └── projections
+                     │                             └── udf: _stmt_exec_2 [as="_stmt_exec_2":27]
+                     │                                  └── body
+                     │                                       ├── delete kv
+                     │                                       │    ├── columns: <none>
+                     │                                       │    ├── fetch columns: k:11 v:12
+                     │                                       │    └── select
+                     │                                       │         ├── columns: k:11!null v:12 crdb_internal_mvcc_timestamp:13 tableoid:14
+                     │                                       │         ├── scan kv
+                     │                                       │         │    └── columns: k:11!null v:12 crdb_internal_mvcc_timestamp:13 tableoid:14
+                     │                                       │         └── filters
+                     │                                       │              └── eq
+                     │                                       │                   ├── variable: k:11
+                     │                                       │                   └── const: 100
+                     │                                       └── project
+                     │                                            ├── columns: "_stmt_exec_3":26
+                     │                                            ├── values
+                     │                                            │    └── tuple
+                     │                                            └── projections
+                     │                                                 └── udf: _stmt_exec_3 [as="_stmt_exec_3":26]
+                     │                                                      └── body
+                     │                                                           ├── insert kv
+                     │                                                           │    ├── columns: <none>
+                     │                                                           │    ├── insert-mapping:
+                     │                                                           │    │    ├── column1:19 => k:15
+                     │                                                           │    │    └── column2:20 => v:16
+                     │                                                           │    └── values
+                     │                                                           │         ├── columns: column1:19!null column2:20!null
+                     │                                                           │         └── tuple
+                     │                                                           │              ├── const: 100
+                     │                                                           │              └── const: 100
+                     │                                                           └── project
+                     │                                                                ├── columns: stmt_return_4:25
+                     │                                                                ├── values
+                     │                                                                │    └── tuple
+                     │                                                                └── projections
+                     │                                                                     └── subquery [as=stmt_return_4:25]
+                     │                                                                          └── max1-row
+                     │                                                                               ├── columns: v:22
+                     │                                                                               └── project
+                     │                                                                                    ├── columns: v:22
+                     │                                                                                    └── select
+                     │                                                                                         ├── columns: k:21!null v:22 crdb_internal_mvcc_timestamp:23 tableoid:24
+                     │                                                                                         ├── scan kv
+                     │                                                                                         │    └── columns: k:21!null v:22 crdb_internal_mvcc_timestamp:23 tableoid:24
+                     │                                                                                         └── filters
+                     │                                                                                              └── eq
+                     │                                                                                                   ├── variable: k:21
+                     │                                                                                                   └── const: 100
+                     └── const: 1
+
+# Testing SELECT INTO.
+exec-ddl
+CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$
+  DECLARE
+    i INT;
+    j INT;
+  BEGIN
+    SELECT x, y INTO i, j FROM xy ORDER BY x DESC;
+    RETURN i + j;
+  END
+$$ LANGUAGE PLpgSQL;
+----
+
+build format=show-scalars
+SELECT f();
+----
+project
+ ├── columns: f:17
+ ├── values
+ │    └── tuple
+ └── projections
+      └── udf: f [as=f:17]
+           └── body
+                └── limit
+                     ├── columns: "_stmt_exec_1":16
+                     ├── project
+                     │    ├── columns: "_stmt_exec_1":16
+                     │    ├── project
+                     │    │    ├── columns: j:2 i:1
+                     │    │    ├── project
+                     │    │    │    ├── columns: i:1
+                     │    │    │    ├── values
+                     │    │    │    │    └── tuple
+                     │    │    │    └── projections
+                     │    │    │         └── cast: INT8 [as=i:1]
+                     │    │    │              └── null
+                     │    │    └── projections
+                     │    │         └── cast: INT8 [as=j:2]
+                     │    │              └── null
+                     │    └── projections
+                     │         └── udf: _stmt_exec_1 [as="_stmt_exec_1":16]
+                     │              ├── args
+                     │              │    ├── variable: i:1
+                     │              │    └── variable: j:2
+                     │              ├── params: i:3 j:4
+                     │              └── body
+                     │                   └── project
+                     │                        ├── columns: "_stmt_exec_ret_2":15
+                     │                        ├── project
+                     │                        │    ├── columns: i:13 j:14
+                     │                        │    ├── limit
+                     │                        │    │    ├── columns: x:5 y:6
+                     │                        │    │    ├── internal-ordering: -5
+                     │                        │    │    ├── project
+                     │                        │    │    │    ├── columns: x:5 y:6
+                     │                        │    │    │    └── scan xy
+                     │                        │    │    │         └── columns: x:5 y:6 rowid:7!null crdb_internal_mvcc_timestamp:8 tableoid:9
+                     │                        │    │    └── const: 1
+                     │                        │    └── projections
+                     │                        │         ├── variable: x:5 [as=i:13]
+                     │                        │         └── variable: y:6 [as=j:14]
+                     │                        └── projections
+                     │                             └── udf: _stmt_exec_ret_2 [as="_stmt_exec_ret_2":15]
+                     │                                  ├── args
+                     │                                  │    ├── variable: i:13
+                     │                                  │    └── variable: j:14
+                     │                                  ├── params: i:10 j:11
+                     │                                  └── body
+                     │                                       └── project
+                     │                                            ├── columns: stmt_return_3:12
+                     │                                            ├── values
+                     │                                            │    └── tuple
+                     │                                            └── projections
+                     │                                                 └── plus [as=stmt_return_3:12]
+                     │                                                      ├── variable: i:10
+                     │                                                      └── variable: j:11
+                     └── const: 1
+
+# It is possible to reference a previous value of a target variable in a
+# SELECT INTO statement (note the "x < i" filter).
+exec-ddl
+CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$
+  DECLARE
+    i INT;
+  BEGIN
+    SELECT x INTO i FROM xy ORDER BY x DESC;
+    RAISE NOTICE 'i = %', i;
+    SELECT x INTO i FROM xy WHERE x < i ORDER BY x DESC;
+    RAISE NOTICE 'i = %', i;
+    RETURN 0;
+  END
+$$ LANGUAGE PLpgSQL;
+----
+
+build format=show-scalars
+SELECT f();
+----
+project
+ ├── columns: f:29
+ ├── values
+ │    └── tuple
+ └── projections
+      └── udf: f [as=f:29]
+           └── body
+                └── limit
+                     ├── columns: "_stmt_exec_1":28
+                     ├── project
+                     │    ├── columns: "_stmt_exec_1":28
+                     │    ├── project
+                     │    │    ├── columns: i:1
+                     │    │    ├── values
+                     │    │    │    └── tuple
+                     │    │    └── projections
+                     │    │         └── cast: INT8 [as=i:1]
+                     │    │              └── null
+                     │    └── projections
+                     │         └── udf: _stmt_exec_1 [as="_stmt_exec_1":28]
+                     │              ├── args
+                     │              │    └── variable: i:1
+                     │              ├── params: i:2
+                     │              └── body
+                     │                   └── project
+                     │                        ├── columns: "_stmt_exec_ret_2":27
+                     │                        ├── project
+                     │                        │    ├── columns: i:26
+                     │                        │    ├── limit
+                     │                        │    │    ├── columns: x:3
+                     │                        │    │    ├── internal-ordering: -3
+                     │                        │    │    ├── project
+                     │                        │    │    │    ├── columns: x:3
+                     │                        │    │    │    └── scan xy
+                     │                        │    │    │         └── columns: x:3 y:4 rowid:5!null crdb_internal_mvcc_timestamp:6 tableoid:7
+                     │                        │    │    └── const: 1
+                     │                        │    └── projections
+                     │                        │         └── variable: x:3 [as=i:26]
+                     │                        └── projections
+                     │                             └── udf: _stmt_exec_ret_2 [as="_stmt_exec_ret_2":27]
+                     │                                  ├── args
+                     │                                  │    └── variable: i:26
+                     │                                  ├── params: i:8
+                     │                                  └── body
+                     │                                       └── project
+                     │                                            ├── columns: "_stmt_raise_3":25
+                     │                                            ├── values
+                     │                                            │    └── tuple
+                     │                                            └── projections
+                     │                                                 └── udf: _stmt_raise_3 [as="_stmt_raise_3":25]
+                     │                                                      ├── args
+                     │                                                      │    └── variable: i:8
+                     │                                                      ├── params: i:9
+                     │                                                      └── body
+                     │                                                           ├── project
+                     │                                                           │    ├── columns: stmt_raise_4:10
+                     │                                                           │    ├── values
+                     │                                                           │    │    └── tuple
+                     │                                                           │    └── projections
+                     │                                                           │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_4:10]
+                     │                                                           │              ├── const: 'NOTICE'
+                     │                                                           │              ├── concat
+                     │                                                           │              │    ├── concat
+                     │                                                           │              │    │    ├── const: 'i = '
+                     │                                                           │              │    │    └── coalesce
+                     │                                                           │              │    │         ├── variable: i:9
+                     │                                                           │              │    │         └── const: '<NULL>'
+                     │                                                           │              │    └── const: ''
+                     │                                                           │              ├── const: ''
+                     │                                                           │              ├── const: ''
+                     │                                                           │              └── const: '00000'
+                     │                                                           └── project
+                     │                                                                ├── columns: "_stmt_exec_5":24
+                     │                                                                ├── values
+                     │                                                                │    └── tuple
+                     │                                                                └── projections
+                     │                                                                     └── udf: _stmt_exec_5 [as="_stmt_exec_5":24]
+                     │                                                                          ├── args
+                     │                                                                          │    └── variable: i:9
+                     │                                                                          ├── params: i:11
+                     │                                                                          └── body
+                     │                                                                               └── project
+                     │                                                                                    ├── columns: "_stmt_exec_ret_6":23
+                     │                                                                                    ├── project
+                     │                                                                                    │    ├── columns: i:22!null
+                     │                                                                                    │    ├── limit
+                     │                                                                                    │    │    ├── columns: x:12!null
+                     │                                                                                    │    │    ├── internal-ordering: -12
+                     │                                                                                    │    │    ├── project
+                     │                                                                                    │    │    │    ├── columns: x:12!null
+                     │                                                                                    │    │    │    └── select
+                     │                                                                                    │    │    │         ├── columns: x:12!null y:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
+                     │                                                                                    │    │    │         ├── scan xy
+                     │                                                                                    │    │    │         │    └── columns: x:12 y:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
+                     │                                                                                    │    │    │         └── filters
+                     │                                                                                    │    │    │              └── lt
+                     │                                                                                    │    │    │                   ├── variable: x:12
+                     │                                                                                    │    │    │                   └── variable: i:11
+                     │                                                                                    │    │    └── const: 1
+                     │                                                                                    │    └── projections
+                     │                                                                                    │         └── variable: x:12 [as=i:22]
+                     │                                                                                    └── projections
+                     │                                                                                         └── udf: _stmt_exec_ret_6 [as="_stmt_exec_ret_6":23]
+                     │                                                                                              ├── args
+                     │                                                                                              │    └── variable: i:22
+                     │                                                                                              ├── params: i:17
+                     │                                                                                              └── body
+                     │                                                                                                   └── project
+                     │                                                                                                        ├── columns: "_stmt_raise_7":21
+                     │                                                                                                        ├── values
+                     │                                                                                                        │    └── tuple
+                     │                                                                                                        └── projections
+                     │                                                                                                             └── udf: _stmt_raise_7 [as="_stmt_raise_7":21]
+                     │                                                                                                                  ├── args
+                     │                                                                                                                  │    └── variable: i:17
+                     │                                                                                                                  ├── params: i:18
+                     │                                                                                                                  └── body
+                     │                                                                                                                       ├── project
+                     │                                                                                                                       │    ├── columns: stmt_raise_8:19
+                     │                                                                                                                       │    ├── values
+                     │                                                                                                                       │    │    └── tuple
+                     │                                                                                                                       │    └── projections
+                     │                                                                                                                       │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_8:19]
+                     │                                                                                                                       │              ├── const: 'NOTICE'
+                     │                                                                                                                       │              ├── concat
+                     │                                                                                                                       │              │    ├── concat
+                     │                                                                                                                       │              │    │    ├── const: 'i = '
+                     │                                                                                                                       │              │    │    └── coalesce
+                     │                                                                                                                       │              │    │         ├── variable: i:18
+                     │                                                                                                                       │              │    │         └── const: '<NULL>'
+                     │                                                                                                                       │              │    └── const: ''
+                     │                                                                                                                       │              ├── const: ''
+                     │                                                                                                                       │              ├── const: ''
+                     │                                                                                                                       │              └── const: '00000'
+                     │                                                                                                                       └── project
+                     │                                                                                                                            ├── columns: stmt_return_9:20!null
+                     │                                                                                                                            ├── values
+                     │                                                                                                                            │    └── tuple
+                     │                                                                                                                            └── projections
+                     │                                                                                                                                 └── const: 0 [as=stmt_return_9:20]
                      └── const: 1

--- a/pkg/sql/opt/optbuilder/testdata/udf_plpgsql
+++ b/pkg/sql/opt/optbuilder/testdata/udf_plpgsql
@@ -549,20 +549,20 @@ build format=show-scalars
 SELECT f(1, 2);
 ----
 project
- ├── columns: f:10
+ ├── columns: f:16
  ├── values
  │    └── tuple
  └── projections
-      └── udf: f [as=f:10]
+      └── udf: f [as=f:16]
            ├── args
            │    ├── const: 1
            │    └── const: 2
            ├── params: a:1 b:2
            └── body
                 └── limit
-                     ├── columns: stmt_if_4:9
+                     ├── columns: stmt_if_7:15
                      ├── project
-                     │    ├── columns: stmt_if_4:9
+                     │    ├── columns: stmt_if_7:15
                      │    ├── project
                      │    │    ├── columns: c:3
                      │    │    ├── values
@@ -571,7 +571,7 @@ project
                      │    │         └── cast: INT8 [as=c:3]
                      │    │              └── null
                      │    └── projections
-                     │         └── case [as=stmt_if_4:9]
+                     │         └── case [as=stmt_if_7:15]
                      │              ├── true
                      │              ├── when
                      │              │    ├── lt
@@ -579,18 +579,18 @@ project
                      │              │    │    └── variable: b:2
                      │              │    └── subquery
                      │              │         └── project
-                     │              │              ├── columns: stmt_return_2:7!null
+                     │              │              ├── columns: stmt_return_5:13!null
                      │              │              ├── values
                      │              │              │    └── tuple
                      │              │              └── projections
-                     │              │                   └── const: 100 [as=stmt_return_2:7]
+                     │              │                   └── const: 100 [as=stmt_return_5:13]
                      │              └── subquery
                      │                   └── project
-                     │                        ├── columns: stmt_return_3:8!null
+                     │                        ├── columns: stmt_return_6:14!null
                      │                        ├── values
                      │                        │    └── tuple
                      │                        └── projections
-                     │                             └── const: 0 [as=stmt_return_3:8]
+                     │                             └── const: 0 [as=stmt_return_6:14]
                      └── const: 1
 
 exec-ddl
@@ -599,61 +599,6 @@ CREATE OR REPLACE FUNCTION f(a INT, b INT) RETURNS INT AS $$
     i INT := a;
   BEGIN
     LOOP
-      RETURN 100;
-    END LOOP;
-  END
-$$ LANGUAGE PLpgSQL;
-----
-
-build format=show-scalars
-SELECT f(1, 2);
-----
-project
- ├── columns: f:12
- ├── values
- │    └── tuple
- └── projections
-      └── udf: f [as=f:12]
-           ├── args
-           │    ├── const: 1
-           │    └── const: 2
-           ├── params: a:1 b:2
-           └── body
-                └── limit
-                     ├── columns: stmt_loop_2:11
-                     ├── project
-                     │    ├── columns: stmt_loop_2:11
-                     │    ├── project
-                     │    │    ├── columns: i:3
-                     │    │    ├── values
-                     │    │    │    └── tuple
-                     │    │    └── projections
-                     │    │         └── variable: a:1 [as=i:3]
-                     │    └── projections
-                     │         └── udf: stmt_loop_2 [as=stmt_loop_2:11]
-                     │              ├── args
-                     │              │    ├── variable: i:3
-                     │              │    ├── variable: a:1
-                     │              │    └── variable: b:2
-                     │              ├── params: i:7 a:8 b:9
-                     │              └── body
-                     │                   └── project
-                     │                        ├── columns: stmt_return_3:10!null
-                     │                        ├── values
-                     │                        │    └── tuple
-                     │                        └── projections
-                     │                             └── const: 100 [as=stmt_return_3:10]
-                     └── const: 1
-
-exec-ddl
-CREATE OR REPLACE FUNCTION f(a INT, b INT) RETURNS INT AS $$
-  DECLARE
-    i INT := a;
-  BEGIN
-    LOOP
-      IF a < b THEN
-        RETURN 0;
-      END IF;
       RETURN 100;
     END LOOP;
   END
@@ -675,9 +620,9 @@ project
            ├── params: a:1 b:2
            └── body
                 └── limit
-                     ├── columns: stmt_loop_2:17
+                     ├── columns: stmt_loop_5:17
                      ├── project
-                     │    ├── columns: stmt_loop_2:17
+                     │    ├── columns: stmt_loop_5:17
                      │    ├── project
                      │    │    ├── columns: i:3
                      │    │    ├── values
@@ -685,50 +630,105 @@ project
                      │    │    └── projections
                      │    │         └── variable: a:1 [as=i:3]
                      │    └── projections
-                     │         └── udf: stmt_loop_2 [as=stmt_loop_2:17]
+                     │         └── udf: stmt_loop_5 [as=stmt_loop_5:17]
                      │              ├── args
                      │              │    ├── variable: i:3
                      │              │    ├── variable: a:1
                      │              │    └── variable: b:2
-                     │              ├── params: i:7 a:8 b:9
+                     │              ├── params: i:13 a:14 b:15
                      │              └── body
                      │                   └── project
-                     │                        ├── columns: stmt_if_6:16
+                     │                        ├── columns: stmt_return_6:16!null
                      │                        ├── values
                      │                        │    └── tuple
                      │                        └── projections
-                     │                             └── case [as=stmt_if_6:16]
+                     │                             └── const: 100 [as=stmt_return_6:16]
+                     └── const: 1
+
+exec-ddl
+CREATE OR REPLACE FUNCTION f(a INT, b INT) RETURNS INT AS $$
+  DECLARE
+    i INT := a;
+  BEGIN
+    LOOP
+      IF a < b THEN
+        RETURN 0;
+      END IF;
+      RETURN 100;
+    END LOOP;
+  END
+$$ LANGUAGE PLpgSQL;
+----
+
+build format=show-scalars
+SELECT f(1, 2);
+----
+project
+ ├── columns: f:24
+ ├── values
+ │    └── tuple
+ └── projections
+      └── udf: f [as=f:24]
+           ├── args
+           │    ├── const: 1
+           │    └── const: 2
+           ├── params: a:1 b:2
+           └── body
+                └── limit
+                     ├── columns: stmt_loop_5:23
+                     ├── project
+                     │    ├── columns: stmt_loop_5:23
+                     │    ├── project
+                     │    │    ├── columns: i:3
+                     │    │    ├── values
+                     │    │    │    └── tuple
+                     │    │    └── projections
+                     │    │         └── variable: a:1 [as=i:3]
+                     │    └── projections
+                     │         └── udf: stmt_loop_5 [as=stmt_loop_5:23]
+                     │              ├── args
+                     │              │    ├── variable: i:3
+                     │              │    ├── variable: a:1
+                     │              │    └── variable: b:2
+                     │              ├── params: i:13 a:14 b:15
+                     │              └── body
+                     │                   └── project
+                     │                        ├── columns: stmt_if_9:22
+                     │                        ├── values
+                     │                        │    └── tuple
+                     │                        └── projections
+                     │                             └── case [as=stmt_if_9:22]
                      │                                  ├── true
                      │                                  ├── when
                      │                                  │    ├── lt
-                     │                                  │    │    ├── variable: a:8
-                     │                                  │    │    └── variable: b:9
+                     │                                  │    │    ├── variable: a:14
+                     │                                  │    │    └── variable: b:15
                      │                                  │    └── subquery
                      │                                  │         └── project
-                     │                                  │              ├── columns: stmt_return_5:14!null
+                     │                                  │              ├── columns: stmt_return_8:20!null
                      │                                  │              ├── values
                      │                                  │              │    └── tuple
                      │                                  │              └── projections
-                     │                                  │                   └── const: 0 [as=stmt_return_5:14]
+                     │                                  │                   └── const: 0 [as=stmt_return_8:20]
                      │                                  └── subquery
                      │                                       └── project
-                     │                                            ├── columns: stmt_if_3:15
+                     │                                            ├── columns: stmt_if_6:21
                      │                                            ├── values
                      │                                            │    └── tuple
                      │                                            └── projections
-                     │                                                 └── udf: stmt_if_3 [as=stmt_if_3:15]
+                     │                                                 └── udf: stmt_if_6 [as=stmt_if_6:21]
                      │                                                      ├── args
-                     │                                                      │    ├── variable: i:7
-                     │                                                      │    ├── variable: a:8
-                     │                                                      │    └── variable: b:9
-                     │                                                      ├── params: i:10 a:11 b:12
+                     │                                                      │    ├── variable: i:13
+                     │                                                      │    ├── variable: a:14
+                     │                                                      │    └── variable: b:15
+                     │                                                      ├── params: i:16 a:17 b:18
                      │                                                      └── body
                      │                                                           └── project
-                     │                                                                ├── columns: stmt_return_4:13!null
+                     │                                                                ├── columns: stmt_return_7:19!null
                      │                                                                ├── values
                      │                                                                │    └── tuple
                      │                                                                └── projections
-                     │                                                                     └── const: 100 [as=stmt_return_4:13]
+                     │                                                                     └── const: 100 [as=stmt_return_7:19]
                      └── const: 1
 
 exec-ddl
@@ -3319,33 +3319,33 @@ build format=show-scalars
 SELECT f(0);
 ----
 project
- ├── columns: f:10
+ ├── columns: f:14
  ├── values
  │    └── tuple
  └── projections
-      └── udf: f [as=f:10]
+      └── udf: f [as=f:14]
            ├── args
            │    └── const: 0
            ├── params: i:1
            └── body
                 └── limit
-                     ├── columns: exception_block_3:9
+                     ├── columns: exception_block_3:13
                      ├── project
-                     │    ├── columns: exception_block_3:9
+                     │    ├── columns: exception_block_3:13
                      │    ├── values
                      │    │    └── tuple
                      │    └── projections
-                     │         └── udf: exception_block_3 [as=exception_block_3:9]
+                     │         └── udf: exception_block_3 [as=exception_block_3:13]
                      │              ├── args
                      │              │    └── variable: i:1
                      │              ├── params: i:4
                      │              ├── body
                      │              │    └── project
-                     │              │         ├── columns: stmt_if_7:8
+                     │              │         ├── columns: stmt_if_10:12
                      │              │         ├── values
                      │              │         │    └── tuple
                      │              │         └── projections
-                     │              │              └── case [as=stmt_if_7:8]
+                     │              │              └── case [as=stmt_if_10:12]
                      │              │                   ├── true
                      │              │                   ├── when
                      │              │                   │    ├── gt
@@ -3353,20 +3353,20 @@ project
                      │              │                   │    │    └── const: 0
                      │              │                   │    └── subquery
                      │              │                   │         └── project
-                     │              │                   │              ├── columns: stmt_return_5:6!null
+                     │              │                   │              ├── columns: stmt_return_8:10!null
                      │              │                   │              ├── values
                      │              │                   │              │    └── tuple
                      │              │                   │              └── projections
-                     │              │                   │                   └── floor-div [as=stmt_return_5:6]
+                     │              │                   │                   └── floor-div [as=stmt_return_8:10]
                      │              │                   │                        ├── const: 1
                      │              │                   │                        └── const: 0
                      │              │                   └── subquery
                      │              │                        └── project
-                     │              │                             ├── columns: stmt_return_6:7
+                     │              │                             ├── columns: stmt_return_9:11
                      │              │                             ├── values
                      │              │                             │    └── tuple
                      │              │                             └── projections
-                     │              │                                  └── cast: INT8 [as=stmt_return_6:7]
+                     │              │                                  └── cast: INT8 [as=stmt_return_9:11]
                      │              │                                       └── function: sqrt
                      │              │                                            └── cast: FLOAT8
                      │              │                                                 └── variable: i:4
@@ -3408,33 +3408,33 @@ build format=show-scalars
 SELECT f(0);
 ----
 project
- ├── columns: f:12
+ ├── columns: f:16
  ├── values
  │    └── tuple
  └── projections
-      └── udf: f [as=f:12]
+      └── udf: f [as=f:16]
            ├── args
            │    └── const: 0
            ├── params: i:1
            └── body
                 └── limit
-                     ├── columns: exception_block_5:11
+                     ├── columns: exception_block_5:15
                      ├── project
-                     │    ├── columns: exception_block_5:11
+                     │    ├── columns: exception_block_5:15
                      │    ├── values
                      │    │    └── tuple
                      │    └── projections
-                     │         └── udf: exception_block_5 [as=exception_block_5:11]
+                     │         └── udf: exception_block_5 [as=exception_block_5:15]
                      │              ├── args
                      │              │    └── variable: i:1
                      │              ├── params: i:6
                      │              ├── body
                      │              │    └── project
-                     │              │         ├── columns: stmt_if_9:10
+                     │              │         ├── columns: stmt_if_12:14
                      │              │         ├── values
                      │              │         │    └── tuple
                      │              │         └── projections
-                     │              │              └── case [as=stmt_if_9:10]
+                     │              │              └── case [as=stmt_if_12:14]
                      │              │                   ├── true
                      │              │                   ├── when
                      │              │                   │    ├── gt
@@ -3442,20 +3442,20 @@ project
                      │              │                   │    │    └── const: 0
                      │              │                   │    └── subquery
                      │              │                   │         └── project
-                     │              │                   │              ├── columns: stmt_return_7:8!null
+                     │              │                   │              ├── columns: stmt_return_10:12!null
                      │              │                   │              ├── values
                      │              │                   │              │    └── tuple
                      │              │                   │              └── projections
-                     │              │                   │                   └── floor-div [as=stmt_return_7:8]
+                     │              │                   │                   └── floor-div [as=stmt_return_10:12]
                      │              │                   │                        ├── const: 1
                      │              │                   │                        └── const: 0
                      │              │                   └── subquery
                      │              │                        └── project
-                     │              │                             ├── columns: stmt_return_8:9
+                     │              │                             ├── columns: stmt_return_11:13
                      │              │                             ├── values
                      │              │                             │    └── tuple
                      │              │                             └── projections
-                     │              │                                  └── cast: INT8 [as=stmt_return_8:9]
+                     │              │                                  └── cast: INT8 [as=stmt_return_11:13]
                      │              │                                       └── function: sqrt
                      │              │                                            └── cast: FLOAT8
                      │              │                                                 └── variable: i:6

--- a/pkg/sql/opt/props/volatility.go
+++ b/pkg/sql/opt/props/volatility.go
@@ -117,6 +117,11 @@ func (vs VolatilitySet) IsLeakproof() bool {
 	return vs == 0 || vs == volatilityBit(volatility.Leakproof)
 }
 
+// HasImmutable returns true if the set contains Immutable.
+func (vs VolatilitySet) HasImmutable() bool {
+	return (vs & volatilityBit(volatility.Immutable)) != 0
+}
+
 // HasStable returns true if the set contains Stable.
 func (vs VolatilitySet) HasStable() bool {
 	return (vs & volatilityBit(volatility.Stable)) != 0
@@ -125,6 +130,18 @@ func (vs VolatilitySet) HasStable() bool {
 // HasVolatile returns true if the set contains Volatile.
 func (vs VolatilitySet) HasVolatile() bool {
 	return (vs & volatilityBit(volatility.Volatile)) != 0
+}
+
+// ToVolatility returns the least restrictive volatility value in the set.
+func (vs VolatilitySet) ToVolatility() volatility.V {
+	if vs.HasVolatile() {
+		return volatility.Volatile
+	} else if vs.HasStable() {
+		return volatility.Stable
+	} else if vs.HasImmutable() {
+		return volatility.Immutable
+	}
+	return volatility.Leakproof
 }
 
 func (vs VolatilitySet) String() string {

--- a/pkg/sql/plpgsql/parser/lexer.go
+++ b/pkg/sql/plpgsql/parser/lexer.go
@@ -121,57 +121,83 @@ func (l *lexer) Lex(lval *plpgsqlSymType) int {
 }
 
 // MakeExecSqlStmt makes a PLpgSQLStmtExecSql from current token position.
-// TODO(chengxiong): we need to fill in variables as well.
-func (l *lexer) MakeExecSqlStmt(startTokenID int) *plpgsqltree.PLpgSQLStmtExecSql {
-	sqlToks := make([]string, 0)
-	if startTokenID == 0 || startTokenID == ';' {
-		l.setErr(errors.AssertionFailedf("plpgsql_execsql: invalid start token"))
+func (l *lexer) MakeExecSqlStmt() (*plpgsqltree.PLpgSQLStmtExecSql, error) {
+	if l.parser.Lookahead() != -1 {
+		// Push back the lookahead token so that it can be included.
+		l.PushBack(1)
 	}
-	if int(l.lastToken().id) != startTokenID {
-		l.setErr(errors.AssertionFailedf("plpgsql_execsql: given start token does not match current pos of lexer"))
+	// Push back the first token so that it's included in the SQL string.
+	l.PushBack(1)
+	startPos, endPos, _ := l.readSQLConstruct(';')
+	if endPos <= startPos || startPos <= 0 {
+		return nil, errors.New("expected SQL statement")
+	}
+	// Move past the semicolon.
+	l.lastPos++
+
+	var haveInto, haveStrict bool
+	var intoStartPos, intoEndPos int
+	var target []plpgsqltree.PLpgSQLVariable
+	firstTok := l.tokens[startPos]
+	tok := firstTok
+	for pos := startPos; pos < endPos; pos++ {
+		prevTok := tok
+		tok = l.tokens[pos]
+		if tok.id == INTO {
+			if prevTok.id == INSERT || prevTok.id == MERGE || firstTok.id == IMPORT {
+				// INSERT INTO, MERGE INTO, and IMPORT ... INTO are not INTO-targets.
+				continue
+			}
+			if haveInto {
+				return nil, errors.New("INTO specified more than once")
+			}
+			haveInto = true
+			intoStartPos = pos
+			pos++
+			if pos+1 < endPos && l.tokens[pos].id == STRICT {
+				haveStrict = true
+				pos++
+			}
+			// Read in one or more comma-separated variables as the INTO target.
+			for ; pos < endPos; pos += 2 {
+				tok = l.tokens[pos]
+				if tok.id != IDENT {
+					return nil, errors.Newf("\"%s\" is not a scalar variable", tok.str)
+				}
+				variable := plpgsqltree.PLpgSQLVariable(strings.TrimSpace(l.getStr(pos, pos+1)))
+				target = append(target, variable)
+				if pos+1 == endPos || l.tokens[pos+1].id != ',' {
+					// This is the end of the target list.
+					break
+				}
+			}
+			intoEndPos = pos + 1
+		}
 	}
 
-	var hasInto bool
-	var hasStrict bool
-	var preTok plpgsqlSymType
-	tok := l.lastToken()
-	for {
-		if !hasInto {
-			sqlToks = append(sqlToks, tok.Str())
-		}
-		preTok = tok
-		l.Lex(&tok)
-		if tok.id == ';' {
-			break
-		}
-		if tok.id == 0 {
-			l.setErr(errors.AssertionFailedf("unexpected end of function definition"))
-		}
-		if hasInto && tok.id == STRICT {
-			hasStrict = true
-			continue
-		}
-		if tok.id == INTO {
-			if preTok.id == INSERT {
-				continue
-			}
-			if preTok.id == MERGE {
-				continue
-			}
-			if startTokenID == IMPORT {
-				continue
-			}
-			if hasInto {
-				l.setErr(errors.AssertionFailedf("plpgsql_execsql: INTO specified more than once"))
-			}
-			hasInto = true
-		}
+	var sql string
+	if haveInto {
+		sql = l.getStr(startPos, intoStartPos) + l.getStr(intoEndPos, endPos)
+	} else {
+		sql = l.getStr(startPos, endPos)
+	}
+	sqlStmt, err := parser.ParseOne(sql)
+	if err != nil {
+		return nil, err
+	}
+
+	// Note: PG disallows directly writing SQL statements that return rows, like
+	// a SELECT or a mutation with RETURNING. It is difficult to determine this
+	// for all possible statements, and execution is able to handle it, so we
+	// allow SQL statements that return rows.
+	if target != nil && sqlStmt.AST.StatementReturnType() != tree.Rows {
+		return nil, pgerror.New(pgcode.Syntax, "INTO used with a command that cannot return data")
 	}
 	return &plpgsqltree.PLpgSQLStmtExecSql{
-		SqlStmt: strings.Join(sqlToks, " "),
-		Into:    hasInto,
-		Strict:  hasStrict,
-	}
+		SqlStmt: sqlStmt.AST,
+		Strict:  haveStrict,
+		Target:  target,
+	}, nil
 }
 
 func (l *lexer) MakeDynamicExecuteStmt() *plpgsqltree.PLpgSQLStmtDynamicExecute {
@@ -286,15 +312,15 @@ func (l *lexer) ReadSqlExpressionStr2(
 	return l.ReadSqlConstruct(terminator1, terminator2, 0)
 }
 
-func (l *lexer) ReadSqlConstruct(
+func (l *lexer) readSQLConstruct(
 	terminator1 int, terminators ...int,
-) (sqlStr string, terminatorMet int) {
+) (startPos, endPos, terminatorMet int) {
 	if l.parser.Lookahead() != -1 {
-		// Push back the lookahead token so that it can be included in the string.
+		// Push back the lookahead token so that it can be included.
 		l.PushBack(1)
 	}
 	parenLevel := 0
-	startPos := l.lastPos + 1
+	startPos = l.lastPos + 1
 	for l.lastPos < len(l.tokens) {
 		tok := l.Peek()
 		if int(tok.id) == terminator1 && parenLevel == 0 {
@@ -325,13 +351,33 @@ func (l *lexer) ReadSqlConstruct(
 	if startPos > l.lastPos {
 		//TODO(jane): show the terminator in the panic message.
 		l.setErr(errors.New("missing SQL expression"))
+		return 0, 0, 0
+	}
+	endPos = l.lastPos + 1
+	if endPos > len(l.tokens) {
+		endPos = len(l.tokens)
+	}
+	return startPos, endPos, terminatorMet
+}
+
+func (l *lexer) ReadSqlConstruct(
+	terminator1 int, terminators ...int,
+) (sqlStr string, terminatorMet int) {
+	var startPos, endPos int
+	startPos, endPos, terminatorMet = l.readSQLConstruct(terminator1, terminators...)
+	return l.getStr(startPos, endPos), terminatorMet
+}
+
+func (l *lexer) getStr(startPos, endPos int) string {
+	if endPos <= startPos {
+		return ""
 	}
 	end := len(l.in)
-	if l.lastPos+1 < len(l.tokens) {
-		end = int(l.tokens[l.lastPos+1].Pos())
+	if endPos < len(l.tokens) {
+		end = int(l.tokens[endPos].Pos())
 	}
 	start := int(l.tokens[startPos].Pos())
-	return l.in[start:end], terminatorMet
+	return l.in[start:end]
 }
 
 func (l *lexer) ProcessQueryForCursorWithoutExplicitExpr(openStmt *plpgsqltree.PLpgSQLStmtOpen) {

--- a/pkg/sql/plpgsql/parser/parser_test.go
+++ b/pkg/sql/plpgsql/parser/parser_test.go
@@ -11,8 +11,6 @@
 package parser_test
 
 import (
-	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/plpgsql/parser"
@@ -31,11 +29,7 @@ func TestParseDataDriver(t *testing.T) {
 				// Check parse.
 				fn, err := parser.Parse(d.Input)
 				if err != nil {
-					if strings.Contains(err.Error(), "unimplemented") {
-						return fmt.Sprintf("expected parse error: %v", err)
-					}
-
-					d.Fatalf(t, "unexpected parse error: %v", err)
+					return err.Error()
 				}
 				// TODO(chengxiong): add pretty print round trip test.
 				return fn.String()

--- a/pkg/sql/plpgsql/parser/plpgsql.y
+++ b/pkg/sql/plpgsql/parser/plpgsql.y
@@ -644,7 +644,9 @@ proc_stmt:pl_block ';'
     $$.val = $1.plpgsqlStatement()
   }
 | stmt_loop
-  { }
+  {
+    $$.val = $1.plpgsqlStatement()
+  }
 | stmt_while
   { }
 | stmt_for
@@ -1215,23 +1217,21 @@ loop_body: proc_sect END LOOP
   }
 ;
 
-// MakeExecSqlStmt read until a ';'
-stmt_execsql: IMPORT
+stmt_execsql: stmt_execsql_start
   {
-    $$.val = plpgsqllex.(*lexer).MakeExecSqlStmt(IMPORT)
+    stmt, err := plpgsqllex.(*lexer).MakeExecSqlStmt()
+    if err != nil {
+      return setErr(plpgsqllex, err)
+    }
+    $$.val = stmt
   }
+;
+
+stmt_execsql_start:
+  IMPORT
 | INSERT
-  {
-    $$.val = plpgsqllex.(*lexer).MakeExecSqlStmt(INSERT)
-  }
 | MERGE
-  {
-    $$.val = plpgsqllex.(*lexer).MakeExecSqlStmt(MERGE)
-  }
 | IDENT
-  {
-    $$.val = plpgsqllex.(*lexer).MakeExecSqlStmt(IDENT)
-  }
 ;
 
 stmt_dynexecute: EXECUTE

--- a/pkg/sql/plpgsql/parser/testdata/decl_header
+++ b/pkg/sql/plpgsql/parser/testdata/decl_header
@@ -38,7 +38,7 @@ DECLARE
 BEGIN
 END
 ----
-expected parse error: at or near ";": syntax error: unimplemented: this syntax
+at or near ";": syntax error: unimplemented: this syntax
 
 parse
 DECLARE
@@ -46,4 +46,4 @@ DECLARE
 BEGIN
 END
 ----
-expected parse error: at or near "scroll": syntax error: unimplemented: this syntax
+at or near "scroll": syntax error: unimplemented: this syntax

--- a/pkg/sql/plpgsql/parser/testdata/stmt_commit_rollback
+++ b/pkg/sql/plpgsql/parser/testdata/stmt_commit_rollback
@@ -6,7 +6,7 @@ IF x THEN
 END IF;
 END
 ----
-expected parse error: at or near ";": syntax error: unimplemented: this syntax
+at or near ";": syntax error: unimplemented: this syntax
 
 parse
 DECLARE
@@ -16,7 +16,7 @@ IF x THEN
 END IF;
 END
 ----
-expected parse error: at or near ";": syntax error: unimplemented: this syntax
+at or near ";": syntax error: unimplemented: this syntax
 
 parse
 DECLARE
@@ -28,7 +28,7 @@ ELSIF y THEN
 END IF;
 END
 ----
-expected parse error: at or near ";": syntax error: unimplemented: this syntax
+at or near ";": syntax error: unimplemented: this syntax
 
 
 parse
@@ -38,4 +38,4 @@ BEGIN
   COMMIT;
 END
 ----
-expected parse error: at or near ";": syntax error: unimplemented: this syntax
+at or near ";": syntax error: unimplemented: this syntax

--- a/pkg/sql/plpgsql/parser/testdata/stmt_exec_sql
+++ b/pkg/sql/plpgsql/parser/testdata/stmt_exec_sql
@@ -1,14 +1,14 @@
 parse
 DECLARE
 BEGIN
-  IMPORT TABLE employees
-  FROM PGDUMP 's3://{BUCKET NAME}/{employees-full.sql}?AWS_ACCESS_KEY_ID={ACCESS KEY}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}'
-  WITH skip_foreign_keys WITH ignore_unsupported_statements;
+  IMPORT TABLE foo
+  FROM PGDUMP 'userfile://defaultdb.public.userfiles_root/db.sql'
+  WITH max_row_size='524288';
 END
 ----
 DECLARE
 BEGIN
-EXECUTE bare sql query
+IMPORT TABLE foo FROM PGDUMP 'userfile://defaultdb.public.userfiles_root/db.sql' WITH OPTIONS (max_row_size = '524288');
 END
 
 parse
@@ -19,7 +19,7 @@ END
 ----
 DECLARE
 BEGIN
-EXECUTE bare sql query
+INSERT INTO t1 VALUES (1, 2);
 END
 
 parse
@@ -30,7 +30,7 @@ END
 ----
 DECLARE
 BEGIN
-EXECUTE bare sql query WITH INTO
+INSERT INTO t1 VALUES (1, 2) RETURNING x INTO y;
 END
 
 parse
@@ -41,27 +41,93 @@ END
 ----
 DECLARE
 BEGIN
-EXECUTE bare sql query WITH INTO STRICT
+INSERT INTO t1 VALUES (1, 2) RETURNING x INTO STRICT y;
 END
 
 parse
 DECLARE
 BEGIN
-  MERGE INTO whatever;
+  INSERT INTO t1 VALUES (1,2) INTO y;
+END
+----
+at or near ";": syntax error: INTO used with a command that cannot return data
+
+parse
+DECLARE
+BEGIN
+  IMPORT INTO foo (k, v) CSV DATA ($1, $2);
 END
 ----
 DECLARE
 BEGIN
-EXECUTE bare sql query
+IMPORT INTO foo(k, v) CSV DATA ($1, $2);
 END
 
 parse
 DECLARE
 BEGIN
-  IMPORT xxxx INTO whatever;
+  SELECT x, y FROM xy;
 END
 ----
 DECLARE
 BEGIN
-EXECUTE bare sql query
+SELECT x, y FROM xy;
+END
+
+parse
+DECLARE
+BEGIN
+  SELECT x, y INTO a, b FROM xy;
+END
+----
+DECLARE
+BEGIN
+SELECT x, y FROM xy INTO a, b;
+END
+
+parse
+DECLARE
+BEGIN
+  SELECT x, y FROM xy INTO a, b;
+END
+----
+DECLARE
+BEGIN
+SELECT x, y FROM xy INTO a, b;
+END
+
+parse
+DECLARE
+BEGIN
+  SET testing_optimizer_disable_rule_probability = 0;
+END
+----
+DECLARE
+BEGIN
+SET testing_optimizer_disable_rule_probability = 0;
+END
+
+parse
+DECLARE
+  i INT;
+BEGIN
+  SET testing_optimizer_disable_rule_probability = 0;
+  INSERT INTO xy VALUES (1, 2);
+  SELECT 1 + 1;
+  SELECT 100 INTO i;
+  SELECT max(x) INTO i FROM xy;
+  INSERT INTO xy VALUES (10, 10) RETURNING x INTO i;
+  RETURN i;
+END
+----
+DECLARE
+i INT8;
+BEGIN
+SET testing_optimizer_disable_rule_probability = 0;
+INSERT INTO xy VALUES (1, 2);
+SELECT 1 + 1;
+SELECT 100 INTO i;
+SELECT max(x) FROM xy INTO i;
+INSERT INTO xy VALUES (10, 10) RETURNING x INTO i;
+RETURN i;
 END

--- a/pkg/sql/plpgsql/parser/testdata/stmt_fetch_move
+++ b/pkg/sql/plpgsql/parser/testdata/stmt_fetch_move
@@ -4,7 +4,7 @@ BEGIN
 MOVE NEXT FROM emp_cur;
 END
 ----
-expected parse error: at or near "move": syntax error: unimplemented: this syntax
+at or near "move": syntax error: unimplemented: this syntax
 
 parse
 DECLARE
@@ -12,7 +12,7 @@ BEGIN
 MOVE PRIOR FROM var;
 END
 ----
-expected parse error: at or near "move": syntax error: unimplemented: this syntax
+at or near "move": syntax error: unimplemented: this syntax
 
 parse
 DECLARE
@@ -20,7 +20,7 @@ BEGIN
 FETCH NEXT FROM emp_cur INTO x,y;
 END
 ----
-expected parse error: at or near "fetch": syntax error: unimplemented: this syntax
+at or near "fetch": syntax error: unimplemented: this syntax
 
 parse
 DECLARE
@@ -28,7 +28,7 @@ BEGIN
 FETCH emp_cur INTO x,y;
 END
 ----
-expected parse error: at or near "fetch": syntax error: unimplemented: this syntax
+at or near "fetch": syntax error: unimplemented: this syntax
 
 parse
 DECLARE
@@ -36,4 +36,4 @@ BEGIN
 FETCH ABSOLUTE 2 FROM emp_cur INTO x,y;
 END
 ----
-expected parse error: at or near "fetch": syntax error: unimplemented: this syntax
+at or near "fetch": syntax error: unimplemented: this syntax

--- a/pkg/sql/plpgsql/parser/testdata/stmt_for
+++ b/pkg/sql/plpgsql/parser/testdata/stmt_for
@@ -6,7 +6,7 @@ FOR counter IN 1..5 LOOP
 END LOOP;
 END
 ----
-expected parse error: at or near "counter": syntax error: unimplemented: this syntax
+at or near "counter": syntax error: unimplemented: this syntax
 
 
 parse
@@ -18,7 +18,7 @@ FOR counter IN 1..5 LOOP
 END LOOP for_loop;
 END
 ----
-expected parse error: at or near "counter": syntax error: unimplemented: this syntax
+at or near "counter": syntax error: unimplemented: this syntax
 
 parse
 DECLARE
@@ -28,7 +28,7 @@ FOR counter IN 1..5 LOOP
 END LOOP;
 END
 ----
-expected parse error: at or near "counter": syntax error: unimplemented: this syntax
+at or near "counter": syntax error: unimplemented: this syntax
 
 parse
 DECLARE
@@ -39,4 +39,4 @@ LOOP
 END LOOP;
 RETURN;
 ----
-expected parse error: at or near "yr": syntax error: unimplemented: this syntax
+at or near "yr": syntax error: unimplemented: this syntax

--- a/pkg/sql/plpgsql/parser/testdata/stmt_foreach_a
+++ b/pkg/sql/plpgsql/parser/testdata/stmt_foreach_a
@@ -10,4 +10,4 @@ BEGIN
   RETURN s;
 END
 ----
-expected parse error: at or near "x": syntax error: unimplemented: this syntax
+at or near "x": syntax error: unimplemented: this syntax

--- a/pkg/sql/plpgsql/parser/testdata/stmt_perform
+++ b/pkg/sql/plpgsql/parser/testdata/stmt_perform
@@ -4,7 +4,7 @@ BEGIN
   PERFORM 1+1;
 END
 ----
-expected parse error: at or near ";": syntax error: unimplemented: this syntax
+at or near ";": syntax error: unimplemented: this syntax
 
 parse
 DECLARE
@@ -12,4 +12,4 @@ BEGIN
   PERFORM SELECT * FROM generate_series(1,10,1) AS y_(y);
 END
 ----
-expected parse error: at or near ";": syntax error: unimplemented: this syntax
+at or near ";": syntax error: unimplemented: this syntax

--- a/pkg/sql/plpgsql/parser/testdata/stmt_raise
+++ b/pkg/sql/plpgsql/parser/testdata/stmt_raise
@@ -4,7 +4,7 @@ BEGIN
   RAISE;
 END
 ----
-expected parse error: at or near ";": syntax error: unimplemented: this syntax
+at or near ";": syntax error: unimplemented: this syntax
 
 parse
 DECLARE

--- a/pkg/sql/plpgsql/parser/testdata/stmt_return
+++ b/pkg/sql/plpgsql/parser/testdata/stmt_return
@@ -42,7 +42,7 @@ BEGIN
   RETURN QUERY SELECT 1 + 1;
 END
 ----
-expected parse error: at or near ";": syntax error: unimplemented: this syntax
+at or near ";": syntax error: unimplemented: this syntax
 
 
 parse
@@ -51,4 +51,4 @@ BEGIN
   RETURN QUERY EXECUTE a dynamic command;
 END
 ----
-expected parse error: at or near "query": syntax error: unimplemented: this syntax
+at or near ";": syntax error: unimplemented: this syntax

--- a/pkg/sql/plpgsql/parser/testdata/stmt_while
+++ b/pkg/sql/plpgsql/parser/testdata/stmt_while
@@ -7,7 +7,7 @@ WHILE x > 0 LOOP
 END LOOP;
 END
 ----
-expected parse error: at or near "while": syntax error: unimplemented: this syntax
+at or near "while": syntax error: unimplemented: this syntax
 
 
 
@@ -21,4 +21,4 @@ WHILE x > 0 LOOP
 END LOOP labeled;
 END
 ----
-expected parse error: at or near "while": syntax error: unimplemented: this syntax
+at or near "while": syntax error: unimplemented: this syntax

--- a/pkg/sql/sem/plpgsqltree/statements.go
+++ b/pkg/sql/sem/plpgsqltree/statements.go
@@ -687,21 +687,26 @@ func (s *PLpgSQLStmtAssert) WalkStmt(visitor PLpgSQLStmtVisitor) {
 // stmt_execsql
 type PLpgSQLStmtExecSql struct {
 	PLpgSQLStatementImpl
-	SqlStmt string
-	Into    bool // INTO provided?
+	SqlStmt tree.Statement
 	Strict  bool // INTO STRICT flag
+	Target  []PLpgSQLVariable
 }
 
 func (s *PLpgSQLStmtExecSql) Format(ctx *tree.FmtCtx) {
-	// TODO(drewk): Pretty print the sql statement
-	ctx.WriteString("EXECUTE bare sql query")
-	if s.Into {
-		ctx.WriteString(" WITH INTO")
+	s.SqlStmt.Format(ctx)
+	if s.Target != nil {
+		ctx.WriteString(" INTO ")
+		if s.Strict {
+			ctx.WriteString("STRICT ")
+		}
+		for i := range s.Target {
+			if i > 0 {
+				ctx.WriteString(", ")
+			}
+			s.Target[i].Format(ctx)
+		}
 	}
-	if s.Strict {
-		ctx.WriteString(" STRICT")
-	}
-	ctx.WriteString("\n")
+	ctx.WriteString(";\n")
 }
 
 func (s *PLpgSQLStmtExecSql) PlpgSQLStatementTag() string {


### PR DESCRIPTION
#### plpgsql: add parser support for sql exec statements

This patch adds support in the parser for directly executing SQL statements
in a PLpgSQL routine. Note that postgres disallows this syntax for statements
that return rows, but we allow it because execution can handle row-returning
statements and it allows running statements like `IMPORT`, which returns rows.

SQL statements with an `INTO` clause are also supported; `INTO` allows for
the result of a SQL statement to be assigned to one or more PLpgSQL
variables. It cannot be used with a statement that does not return rows.

Example:
```
CREATE FUNCTION f() RETURNS INT AS $$
  DECLARE
    i INT;
  BEGIN
    SET testing_optimizer_disable_rule_probability = 0;
    INSERT INTO xy VALUES (1, 2);
    SELECT 1 + 1;
    SELECT 100 INTO i;
    SELECT max(x) INTO i FROM xy;
    INSERT INTO xy VALUES (10, 10) RETURNING x INTO i;
    RETURN i;
  END
$$ LANGUAGE PLpgSQL;
```

Informs #105252

Release note: None

#### plpgsql: raise end-of-function error during runtime

This commit moves the end-of-function error from compile-time to
run-time, using a RAISE statement to throw the error. This more
closely mirrors postgres behavior, where it's possible to define
a function that is not guaranteed to terminate. Example:
```
CREATE OR REPLACE FUNCTION f(a INT, b INT) RETURNS INT AS $$
  BEGIN
    IF a < b THEN
      RETURN a;
    END IF;
  END
$$ LANGUAGE PLpgSQL;

root@localhost:26257/defaultdb> SELECT f(1, 2);
  f
-----
  1
(1 row)

Time: 25ms total (execution 24ms / network 0ms)

root@localhost:26257/defaultdb> SELECT f(2, 1);
ERROR: control reached end of function without RETURN
SQLSTATE: 2F005
```

This commit also refactors some of the PLpgSQL routine-building logic
to simplify building multiple body statements.

Epic: CRDB-799

Release note: None

#### plpgsql: add support for sql exec and INTO statements

This patch adds execution support for executing SQL statements within
PLpgSQL routines, both for the case when the result is discarded and when
`INTO` syntax is used to assign the result to a set of target variables.
The former case is handled by building the SQL statement into one of the
first body statements of a routine; this captures the result-discarding
behavior, but ensures any side effects still occur. The latter case is
handled by aliasing the output columns of the SQL statement to the target
variable names; this is done in the last body statement of the routine,
since the result of the query is needed.

Examples:
```
CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$
  BEGIN
    INSERT INTO xy VALUES (1000, 1000);
    DELETE FROM xy WHERE x = 1000;
    RETURN 0;
  END
$$ LANGUAGE PLpgSQL;

CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$
  DECLARE
    i INT;
  BEGIN
    SELECT x INTO i FROM xy ORDER BY x DESC;
    RETURN i;
  END
$$ LANGUAGE PLpgSQL;
```

Fixes #105252

Release note (sql change): Added support for executing SQL statements
directly within PLpgSQL routines. Note that this currently only applies
to the subset of statements that can be executed within SQL UDFs, so
`CREATE TABLE` is not supported, for example. INTO syntax is also
supported, e.g. `SELECT * INTO a, b FROM xy;`.