### PR TITLE
server: export distsender metrics from SQL pods

### DIFF
--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -1089,6 +1089,7 @@ func makeTenantSQLServerArgs(
 		TestingKnobs:      dsKnobs,
 	}
 	ds := kvcoord.NewDistSender(dsCfg)
+	registry.AddMetricStruct(ds.Metrics())
 
 	var clientKnobs kvcoord.ClientTestingKnobs
 	if p, ok := baseCfg.TestingKnobs.KVClient.(*kvcoord.ClientTestingKnobs); ok {


### PR DESCRIPTION
This commit exports the DistSender timeseries metrics from SQL pods.

```
distsender.batches
distsender.batches.partial
distsender.batch_requests.replica_addressed.bytes
distsender.batch_responses.replica_addressed.bytes
distsender.batch_requests.cross_region.bytes
distsender.batch_responses.cross_region.bytes
distsender.batch_requests.cross_zone.bytes
distsender.batch_responses.cross_zone.bytes
distsender.batches.async.sent
distsender.batches.async.throttled
distsender.rpc.sent
distsender.rpc.sent.local
distsender.rpc.sent.nextreplicaerror
distsender.errors.notleaseholder
distsender.errors.inleasetransferbackoffs
distsender.rangelookups
requests.slow.distsender
distsender.rpc.%s.sent # rpc name
distsender.rpc.err.%s  # error name
distsender.rangefeed.total_ranges
distsender.rangefeed.catchup_ranges
distsender.rangefeed.error_catchup_ranges
distsender.rangefeed.restart_ranges
distsender.rangefeed.restart_stuck
```

Epic: None
Release note: None