### PR TITLE
release-23.1: roachtest: ignore some ORM tests

### DIFF
--- a/pkg/cmd/roachtest/tests/hibernate_blocklist.go
+++ b/pkg/cmd/roachtest/tests/hibernate_blocklist.go
@@ -37,9 +37,11 @@ var hibernateBlockList = blocklist{
 var hibernateSpatialIgnoreList = blocklist{
 	"org.hibernate.serialization.SessionFactorySerializationTest.testUnNamedSessionFactorySerialization": "flaky",
 	"org.hibernate.serialization.SessionFactorySerializationTest.testNamedSessionFactorySerialization":   "flaky",
+	"org.hibernate.test.batch.BatchTest.testBatchInsertUpdate":                                           "flaky",
 }
 
 var hibernateIgnoreList = blocklist{
 	"org.hibernate.serialization.SessionFactorySerializationTest.testUnNamedSessionFactorySerialization": "flaky",
 	"org.hibernate.serialization.SessionFactorySerializationTest.testNamedSessionFactorySerialization":   "flaky",
+	"org.hibernate.test.batch.BatchTest.testBatchInsertUpdate":                                           "flaky",
 }

--- a/pkg/cmd/roachtest/tests/npgsql_blocklist.go
+++ b/pkg/cmd/roachtest/tests/npgsql_blocklist.go
@@ -751,6 +751,7 @@ var npgsqlBlocklist = blocklist{
 }
 
 var npgsqlIgnoreList = blocklist{
+	`Npgsql.Tests.CommandTests(Multiplexing).Statement_mapped_output_parameters(Default)`:                  "flaky",
 	`Npgsql.Tests.CommandTests(NonMultiplexing).Statement_mapped_output_parameters(SequentialAccess)`:      "flaky",
 	`Npgsql.Tests.ConnectionTests(NonMultiplexing).PostgreSqlVersion_ServerVersion`:                        "flaky",
 	`Npgsql.Tests.ConnectionTests(NonMultiplexing).Connector_not_initialized_exception`:                    "flaky",
@@ -792,7 +793,10 @@ var npgsqlIgnoreList = blocklist{
 	`Npgsql.Tests.CopyTests(NonMultiplexing).Wrong_format_binary_import`:                                   "flaky",
 	`Npgsql.Tests.CopyTests(NonMultiplexing).Wrong_format_raw_binary_copy`:                                 "flaky",
 	`Npgsql.Tests.CopyTests(NonMultiplexing).Wrong_format_text_import`:                                     "flaky",
+	`Npgsql.Tests.NotificationTests.WaitAsync_with_timeout`:                                                "flaky",
+	`Npgsql.Tests.ReaderTests(Multiplexing,Default).Cleans_up_ok_with_dispose_calls(NotPrepared)`:          "flaky",
 	`Npgsql.Tests.ReaderTests(Multiplexing,SequentialAccess).Cleans_up_ok_with_dispose_calls(NotPrepared)`: "flaky",
+	`Npgsql.Tests.TransactionTests(Multiplexing).Failed_transaction_on_close_with_custom_timeout`:          "flaky",
 	`Npgsql.Tests.TransactionTests(NonMultiplexing).CommitAsync(Prepared)`:                                 "flaky",
 	`Npgsql.Tests.NotificationTests.Wait_with_timeout`:                                                     "flaky",
 }

--- a/pkg/cmd/roachtest/tests/pgjdbc_blocklist.go
+++ b/pkg/cmd/roachtest/tests/pgjdbc_blocklist.go
@@ -926,6 +926,7 @@ var pgjdbcIgnoreList = blocklist{
 	"org.postgresql.test.jdbc2.BatchedInsertReWriteEnabledTest.testReWriteDisabledForPlainBatch[2: autoCommit=NO, binary=REGULAR]":                  "54477",
 	"org.postgresql.test.jdbc2.BatchedInsertReWriteEnabledTest.testReWriteDisabledForPlainBatch[3: autoCommit=NO, binary=FORCE]":                    "54477",
 	"org.postgresql.test.jdbc2.CursorFetchTest.testBasicFetch[binary = FORCE]":                                                                      "flaky",
+	"org.postgresql.test.jdbc2.CursorFetchTest.testBasicFetch[binary = REGULAR]":                                                                    "flaky",
 	"org.postgresql.test.jdbc2.DatabaseEncodingTest.testBadUTF8Decode":                                                                              "54477",
 	"org.postgresql.test.jdbc2.DatabaseEncodingTest.testTruncatedUTF8Decode":                                                                        "54477",
 	"org.postgresql.test.jdbc2.DatabaseEncodingTest.testUTF8Decode":                                                                                 "54477",


### PR DESCRIPTION
Backport 1/1 commits from #107927.

/cc @cockroachdb/release

---

fixes https://github.com/cockroachdb/cockroach/issues/107698
fixes https://github.com/cockroachdb/cockroach/issues/107849
fixes https://github.com/cockroachdb/cockroach/issues/107861
fixes https://github.com/cockroachdb/cockroach/issues/107869

Release justification: test only change
Release note: None
