### PR TITLE
release-22.2: roachtest: ignore some ORM tests

### DIFF
--- a/pkg/cmd/roachtest/tests/hibernate_blocklist.go
+++ b/pkg/cmd/roachtest/tests/hibernate_blocklist.go
@@ -248,4 +248,5 @@ var hibernateIgnoreList21_1 = blocklist{
 	"org.hibernate.userguide.pc.WhereTest.testLifecycle":                                                 "unknown",
 	"org.hibernate.serialization.SessionFactorySerializationTest.testUnNamedSessionFactorySerialization": "flaky",
 	"org.hibernate.serialization.SessionFactorySerializationTest.testNamedSessionFactorySerialization":   "flaky",
+	"org.hibernate.test.batch.BatchTest.testBatchInsertUpdate":                                           "flaky",
 }

--- a/pkg/cmd/roachtest/tests/pgjdbc_blocklist.go
+++ b/pkg/cmd/roachtest/tests/pgjdbc_blocklist.go
@@ -942,6 +942,7 @@ var pgjdbcIgnoreList = blocklist{
 	"org.postgresql.test.jdbc2.BatchedInsertReWriteEnabledTest.testReWriteDisabledForPlainBatch[2: autoCommit=NO, binary=REGULAR]":                  "54477",
 	"org.postgresql.test.jdbc2.BatchedInsertReWriteEnabledTest.testReWriteDisabledForPlainBatch[3: autoCommit=NO, binary=FORCE]":                    "54477",
 	"org.postgresql.test.jdbc2.CursorFetchTest.testBasicFetch[binary = FORCE]":                                                                      "flaky",
+	"org.postgresql.test.jdbc2.CursorFetchTest.testBasicFetch[binary = REGULAR]":                                                                    "flaky",
 	"org.postgresql.test.jdbc2.DatabaseEncodingTest.testBadUTF8Decode":                                                                              "54477",
 	"org.postgresql.test.jdbc2.DatabaseEncodingTest.testTruncatedUTF8Decode":                                                                        "54477",
 	"org.postgresql.test.jdbc2.DatabaseEncodingTest.testUTF8Decode":                                                                                 "54477",


### PR DESCRIPTION
Backport 1/1 commits from #107927.

/cc @cockroachdb/release

---

fixes https://github.com/cockroachdb/cockroach/issues/107698
fixes https://github.com/cockroachdb/cockroach/issues/107849
fixes https://github.com/cockroachdb/cockroach/issues/107861
fixes https://github.com/cockroachdb/cockroach/issues/107869

Release justification: test only change
Release note: None
