### PR TITLE
changefeedccl: remove two usages of disableDeclarativeSchemaChangesForTest

### DIFF
--- a/pkg/ccl/changefeedccl/alter_changefeed_test.go
+++ b/pkg/ccl/changefeedccl/alter_changefeed_test.go
@@ -1103,11 +1103,19 @@ func TestAlterChangefeedAddTargetsDuringSchemaChangeError(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	rnd, _ := randutil.NewPseudoRand()
+	rnd, seed := randutil.NewPseudoRand()
+	t.Logf("random seed: %d", seed)
 
 	testFn := func(t *testing.T, s TestServerWithSystem, f cdctest.TestFeedFactory) {
 		sqlDB := sqlutils.MakeSQLRunner(s.DB)
-		disableDeclarativeSchemaChangesForTest(t, sqlDB)
+		usingLegacySchemaChanger := maybeDisableDeclarativeSchemaChangesForTest(t, sqlDB, rnd)
+		// NB: For the `ALTER TABLE foo ADD COLUMN ... DEFAULT` schema change,
+		// the expected boundary is different depending on if we are using the
+		// legacy schema changer or not.
+		expectedBoundaryType := jobspb.ResolvedSpan_RESTART
+		if usingLegacySchemaChanger {
+			expectedBoundaryType = jobspb.ResolvedSpan_BACKFILL
+		}
 
 		knobs := s.TestingKnobs.
 			DistSQL.(*execinfra.TestingKnobs).
@@ -1182,10 +1190,9 @@ func TestAlterChangefeedAddTargetsDuringSchemaChangeError(t *testing.T) {
 				return true, nil
 			}
 
-			// A backfill begins when the backfill resolved event arrives, which has a
-			// timestamp such that all backfill spans have a timestamp of
-			// timestamp.Next()
-			if r.BoundaryType == jobspb.ResolvedSpan_BACKFILL {
+			// A backfill begins when the associated resolved event arrives, which has a
+			// timestamp such that all backfill spans have a timestamp of timestamp.Next().
+			if r.BoundaryType == expectedBoundaryType {
 				backfillTimestamp = r.Timestamp
 				return false, nil
 			}

--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -58,6 +58,21 @@ import (
 
 var testSinkFlushFrequency = 100 * time.Millisecond
 
+// disableDeclarativeSchemaChangesForTest will disable the declarative schema
+// changer with a probability of 10% using the provided SQL DB connection. This
+// returns true if the declarative schema changer is disabled.
+func maybeDisableDeclarativeSchemaChangesForTest(
+	t testing.TB, sqlDB *sqlutils.SQLRunner, rnd *rand.Rand,
+) bool {
+	disable := rnd.Float32() < 0.1
+	if disable {
+		t.Log("using legacy schema changer")
+		sqlDB.Exec(t, "SET use_declarative_schema_changer='off'")
+		sqlDB.Exec(t, "SET CLUSTER SETTING  sql.defaults.use_declarative_schema_changer='off'")
+	}
+	return disable
+}
+
 // disableDeclarativeSchemaChangesForTest tests that are disabled due to differences
 // in changefeed behaviour and are tracked by issue #80545.
 func disableDeclarativeSchemaChangesForTest(t testing.TB, sqlDB *sqlutils.SQLRunner) {


### PR DESCRIPTION
This change removes two usages of `disableDeclarativeSchemaChangesForTest` from tests and replaces them with `maybeDisableDeclarativeSchemaChangesForTest` which will use the legacy schema changer 10% of the time.

Release note: None
Informs: #106906
Epic: None