### PR TITLE
asim: add zone ctor to improve default StoresPerNode handling

### DIFF
--- a/pkg/kv/kvserver/asim/state/new_state.go
+++ b/pkg/kv/kvserver/asim/state/new_state.go
@@ -244,7 +244,7 @@ func ClusterInfoWithDistribution(
 		availableNodes -= allocatedNodes
 		ret.Regions[i] = Region{
 			Name:  name,
-			Zones: []Zone{{Name: name + "_1", NodeCount: allocatedNodes, StoresPerNode: storesPerNode}},
+			Zones: []Zone{NewZone(name+"_1", allocatedNodes, storesPerNode)},
 		}
 	}
 

--- a/pkg/kv/kvserver/asim/tests/testdata/rand/rand_cluster
+++ b/pkg/kv/kvserver/asim/tests/testdata/rand/rand_cluster
@@ -21,7 +21,7 @@ sample1: pass
 sample2: start running
 configurations generated using seed 1926012586526624009
 	loaded cluster with
- 		region:US [zone=US_1(nodes=5,stores=0), zone=US_2(nodes=5,stores=0), zone=US_3(nodes=5,stores=0)]
+ 		region:US [zone=US_1(nodes=5,stores=1), zone=US_2(nodes=5,stores=1), zone=US_3(nodes=5,stores=1)]
 	basic ranges with placement_type=even, ranges=10, key_space=200000, replication_factor=3, bytes=0
 	basic load with rw_ratio=0.00, rate=0.00, skewed_access=false, min_block_size=1, max_block_size=1, min_key=1, max_key=200000
 	number of mutation events=0, number of assertion events=0
@@ -60,9 +60,9 @@ generating settings configurations using static option
 sample1: start running
 configurations generated using seed 608747136543856411
 	loaded cluster with
- 		region:US_East [zone=US_East_1(nodes=1,stores=0), zone=US_East_2(nodes=2,stores=0), zone=US_East_3(nodes=3,stores=0), zone=US_East_3(nodes=10,stores=0)]
-		region:US_West [zone=US_West_1(nodes=2,stores=0)]
-		region:EU [zone=EU_1(nodes=3,stores=0), zone=EU_2(nodes=3,stores=0), zone=EU_3(nodes=4,stores=0)]
+ 		region:US_East [zone=US_East_1(nodes=1,stores=1), zone=US_East_2(nodes=2,stores=1), zone=US_East_3(nodes=3,stores=1), zone=US_East_3(nodes=10,stores=1)]
+		region:US_West [zone=US_West_1(nodes=2,stores=1)]
+		region:EU [zone=EU_1(nodes=3,stores=1), zone=EU_2(nodes=3,stores=1), zone=EU_3(nodes=4,stores=1)]
 	basic ranges with placement_type=even, ranges=10, key_space=200000, replication_factor=3, bytes=0
 	basic load with rw_ratio=0.00, rate=0.00, skewed_access=false, min_block_size=1, max_block_size=1, min_key=1, max_key=200000
 	number of mutation events=0, number of assertion events=0
@@ -92,9 +92,9 @@ sample1: pass
 sample2: start running
 configurations generated using seed 1926012586526624009
 	loaded cluster with
- 		region:US_East [zone=US_East_1(nodes=4,stores=0), zone=US_East_2(nodes=4,stores=0), zone=US_East_3(nodes=4,stores=0)]
-		region:US_West [zone=US_West_1(nodes=4,stores=0), zone=US_West_2(nodes=4,stores=0), zone=US_West_3(nodes=4,stores=0)]
-		region:EU [zone=EU_1(nodes=4,stores=0), zone=EU_2(nodes=4,stores=0), zone=EU_3(nodes=4,stores=0)]
+ 		region:US_East [zone=US_East_1(nodes=4,stores=1), zone=US_East_2(nodes=4,stores=1), zone=US_East_3(nodes=4,stores=1)]
+		region:US_West [zone=US_West_1(nodes=4,stores=1), zone=US_West_2(nodes=4,stores=1), zone=US_West_3(nodes=4,stores=1)]
+		region:EU [zone=EU_1(nodes=4,stores=1), zone=EU_2(nodes=4,stores=1), zone=EU_3(nodes=4,stores=1)]
 	basic ranges with placement_type=even, ranges=10, key_space=200000, replication_factor=3, bytes=0
 	basic load with rw_ratio=0.00, rate=0.00, skewed_access=false, min_block_size=1, max_block_size=1, min_key=1, max_key=200000
 	number of mutation events=0, number of assertion events=0
@@ -128,9 +128,9 @@ sample2: pass
 sample3: start running
 configurations generated using seed 3534334367214237261
 	loaded cluster with
- 		region:US_East [zone=US_East_1(nodes=1,stores=0), zone=US_East_2(nodes=2,stores=0), zone=US_East_3(nodes=3,stores=0), zone=US_East_3(nodes=10,stores=0)]
-		region:US_West [zone=US_West_1(nodes=2,stores=0)]
-		region:EU [zone=EU_1(nodes=3,stores=0), zone=EU_2(nodes=3,stores=0), zone=EU_3(nodes=4,stores=0)]
+ 		region:US_East [zone=US_East_1(nodes=1,stores=1), zone=US_East_2(nodes=2,stores=1), zone=US_East_3(nodes=3,stores=1), zone=US_East_3(nodes=10,stores=1)]
+		region:US_West [zone=US_West_1(nodes=2,stores=1)]
+		region:EU [zone=EU_1(nodes=3,stores=1), zone=EU_2(nodes=3,stores=1), zone=EU_3(nodes=4,stores=1)]
 	basic ranges with placement_type=even, ranges=10, key_space=200000, replication_factor=3, bytes=0
 	basic load with rw_ratio=0.00, rate=0.00, skewed_access=false, min_block_size=1, max_block_size=1, min_key=1, max_key=200000
 	number of mutation events=0, number of assertion events=0
@@ -179,7 +179,7 @@ sample1: pass
 sample2: start running
 configurations generated using seed 1926012586526624009
 	loaded cluster with
- 		region:US [zone=US_1(nodes=5,stores=0), zone=US_2(nodes=5,stores=0), zone=US_3(nodes=5,stores=0)]
+ 		region:US [zone=US_1(nodes=5,stores=1), zone=US_2(nodes=5,stores=1), zone=US_3(nodes=5,stores=1)]
 	basic ranges with placement_type=even, ranges=10, key_space=200000, replication_factor=3, bytes=0
 	basic load with rw_ratio=0.00, rate=0.00, skewed_access=false, min_block_size=1, max_block_size=1, min_key=1, max_key=200000
 	number of mutation events=0, number of assertion events=0
@@ -188,9 +188,9 @@ sample2: pass
 sample3: start running
 configurations generated using seed 3534334367214237261
 	loaded cluster with
- 		region:US_East [zone=US_East_1(nodes=1,stores=0), zone=US_East_2(nodes=2,stores=0), zone=US_East_3(nodes=3,stores=0), zone=US_East_3(nodes=10,stores=0)]
-		region:US_West [zone=US_West_1(nodes=2,stores=0)]
-		region:EU [zone=EU_1(nodes=3,stores=0), zone=EU_2(nodes=3,stores=0), zone=EU_3(nodes=4,stores=0)]
+ 		region:US_East [zone=US_East_1(nodes=1,stores=1), zone=US_East_2(nodes=2,stores=1), zone=US_East_3(nodes=3,stores=1), zone=US_East_3(nodes=10,stores=1)]
+		region:US_West [zone=US_West_1(nodes=2,stores=1)]
+		region:EU [zone=EU_1(nodes=3,stores=1), zone=EU_2(nodes=3,stores=1), zone=EU_3(nodes=4,stores=1)]
 	basic ranges with placement_type=even, ranges=10, key_space=200000, replication_factor=3, bytes=0
 	basic load with rw_ratio=0.00, rate=0.00, skewed_access=false, min_block_size=1, max_block_size=1, min_key=1, max_key=200000
 	number of mutation events=0, number of assertion events=0

--- a/pkg/kv/kvserver/asim/tests/testdata/rand/rand_event
+++ b/pkg/kv/kvserver/asim/tests/testdata/rand/rand_event
@@ -25,9 +25,9 @@ generating settings configurations using static option
 sample1: start running
 configurations generated using seed 7894140303635748408
 	loaded cluster with
- 		region:US_East [zone=US_East_1(nodes=1,stores=0), zone=US_East_2(nodes=2,stores=0), zone=US_East_3(nodes=3,stores=0), zone=US_East_3(nodes=10,stores=0)]
-		region:US_West [zone=US_West_1(nodes=2,stores=0)]
-		region:EU [zone=EU_1(nodes=3,stores=0), zone=EU_2(nodes=3,stores=0), zone=EU_3(nodes=4,stores=0)]
+ 		region:US_East [zone=US_East_1(nodes=1,stores=1), zone=US_East_2(nodes=2,stores=1), zone=US_East_3(nodes=3,stores=1), zone=US_East_3(nodes=10,stores=1)]
+		region:US_West [zone=US_West_1(nodes=2,stores=1)]
+		region:EU [zone=EU_1(nodes=3,stores=1), zone=EU_2(nodes=3,stores=1), zone=EU_3(nodes=4,stores=1)]
 	basic ranges with placement_type=even, ranges=1, key_space=200000, replication_factor=3, bytes=0
 	basic load with rw_ratio=0.00, rate=0.00, skewed_access=false, min_block_size=1, max_block_size=1, min_key=1, max_key=200000
 	number of mutation events=12, number of assertion events=12

--- a/pkg/kv/kvserver/asim/tests/testdata/rand/rand_ranges
+++ b/pkg/kv/kvserver/asim/tests/testdata/rand/rand_ranges
@@ -49,7 +49,7 @@ sample1: pass
 sample2: start running
 configurations generated using seed 2643318057788968173
 	loaded cluster with
- 		region:US [zone=US_1(nodes=5,stores=0), zone=US_2(nodes=5,stores=0), zone=US_3(nodes=5,stores=0)]
+ 		region:US [zone=US_1(nodes=5,stores=1), zone=US_2(nodes=5,stores=1), zone=US_3(nodes=5,stores=1)]
 	randomized ranges with placement_type=random, ranges=944, key_space=1357, replication_factor=3, bytes=0
 	basic load with rw_ratio=0.00, rate=0.00, skewed_access=false, min_block_size=1, max_block_size=1, min_key=1, max_key=200000
 	number of mutation events=0, number of assertion events=0
@@ -58,7 +58,7 @@ sample2: pass
 sample3: start running
 configurations generated using seed 6972490225919430754
 	loaded cluster with
- 		region:US [zone=US_1(nodes=5,stores=0), zone=US_2(nodes=5,stores=0), zone=US_3(nodes=5,stores=0)]
+ 		region:US [zone=US_1(nodes=5,stores=1), zone=US_2(nodes=5,stores=1), zone=US_3(nodes=5,stores=1)]
 	randomized ranges with placement_type=random, ranges=479, key_space=1003, replication_factor=3, bytes=0
 	basic load with rw_ratio=0.00, rate=0.00, skewed_access=false, min_block_size=1, max_block_size=1, min_key=1, max_key=200000
 	number of mutation events=0, number of assertion events=0
@@ -173,7 +173,7 @@ sample1: pass
 sample2: start running
 configurations generated using seed 2643318057788968173
 	loaded cluster with
- 		region:US [zone=US_1(nodes=5,stores=0), zone=US_2(nodes=5,stores=0), zone=US_3(nodes=5,stores=0)]
+ 		region:US [zone=US_1(nodes=5,stores=1), zone=US_2(nodes=5,stores=1), zone=US_3(nodes=5,stores=1)]
 	randomized ranges with placement_type=random, ranges=944, key_space=150098, replication_factor=1, bytes=0
 	basic load with rw_ratio=0.00, rate=0.00, skewed_access=false, min_block_size=1, max_block_size=1, min_key=1, max_key=200000
 	number of mutation events=0, number of assertion events=0
@@ -205,7 +205,7 @@ over replicated:
 sample3: start running
 configurations generated using seed 6972490225919430754
 	loaded cluster with
- 		region:US [zone=US_1(nodes=5,stores=0), zone=US_2(nodes=5,stores=0), zone=US_3(nodes=5,stores=0)]
+ 		region:US [zone=US_1(nodes=5,stores=1), zone=US_2(nodes=5,stores=1), zone=US_3(nodes=5,stores=1)]
 	randomized ranges with placement_type=random, ranges=479, key_space=199954, replication_factor=1, bytes=0
 	basic load with rw_ratio=0.00, rate=0.00, skewed_access=false, min_block_size=1, max_block_size=1, min_key=1, max_key=200000
 	number of mutation events=0, number of assertion events=0


### PR DESCRIPTION
Previously, simulated availability zones were initialized with struct literals.
If `StoresPerNode` was left uninitialized, a default value of 1 is set before its
use in functions. This was less ideal and seemed more error-prone. To improve
this, this patch adds two constructors for simulated availability zones: one
with a default of one store per node and one with custom stores per node.

Release Note: None

Epic: None