### PR TITLE
roachtest: bugfix testeng grafana link missing cluster name

### DIFF
--- a/pkg/cmd/roachtest/github.go
+++ b/pkg/cmd/roachtest/github.go
@@ -60,10 +60,13 @@ func generateHelpCommand(
 			"How To Investigate (internal)",
 			"https://cockroachlabs.atlassian.net/l/c/SSSBr8c7",
 		)(renderer)
-		issues.HelpCommandAsLink(
-			"Grafana",
-			fmt.Sprintf("https://go.crdb.dev/p/roachfana/%s/%d/%d", clusterName, start.UnixMilli(), end.UnixMilli()),
-		)(renderer)
+		// An empty clusterName corresponds to a cluster creation failure
+		if clusterName != "" {
+			issues.HelpCommandAsLink(
+				"Grafana",
+				fmt.Sprintf("https://go.crdb.dev/p/roachfana/%s/%d/%d", clusterName, start.UnixMilli(), end.UnixMilli()),
+			)(renderer)
+		}
 	}
 }
 
@@ -131,6 +134,7 @@ func (g *githubIssues) createPostRequest(
 
 	issueOwner := spec.Owner
 	issueName := testName
+	issueClusterName := ""
 
 	messagePrefix := ""
 	var infraFlake bool
@@ -202,6 +206,7 @@ func (g *githubIssues) createPostRequest(
 			// Hence, we only emit when arch was unspecified.
 			clusterParams[roachtestPrefix("arch")] = string(g.cluster.arch)
 		}
+		issueClusterName = g.cluster.name
 	}
 
 	issueMessage := messagePrefix + message
@@ -218,7 +223,7 @@ func (g *githubIssues) createPostRequest(
 		Artifacts:       artifacts,
 		ExtraLabels:     labels,
 		ExtraParams:     clusterParams,
-		HelpCommand:     generateHelpCommand(clusterName, start, end),
+		HelpCommand:     generateHelpCommand(issueClusterName, start, end),
 	}, nil
 }
 

--- a/pkg/cmd/roachtest/github_test.go
+++ b/pkg/cmd/roachtest/github_test.go
@@ -184,11 +184,13 @@ func TestCreatePostRequest(t *testing.T) {
 			}
 
 			ti := &testImpl{
-				spec: testSpec,
-				l:    nilLogger(),
+				spec:  testSpec,
+				l:     nilLogger(),
+				start: time.Date(2023, time.July, 21, 16, 34, 3, 817, time.UTC),
+				end:   time.Date(2023, time.July, 21, 16, 42, 13, 137, time.UTC),
 			}
 
-			testClusterImpl := &clusterImpl{spec: clusterSpec, arch: vm.ArchAMD64}
+			testClusterImpl := &clusterImpl{spec: clusterSpec, arch: vm.ArchAMD64, name: "foo"}
 			vo := vm.DefaultCreateOpts()
 			vmOpts := &vo
 
@@ -219,6 +221,11 @@ func TestCreatePostRequest(t *testing.T) {
 			} else {
 				req, err := github.createPostRequest("github_test", ti.start, ti.end, testSpec, c.failure, "message")
 				assert.NoError(t, err, "Expected no error in createPostRequest")
+
+				r := &issues.Renderer{}
+				req.HelpCommand(r)
+				file := fmt.Sprintf("help_command_createpost_%d.txt", idx+1)
+				echotest.Require(t, r.String(), filepath.Join("testdata", file))
 
 				if c.expectedParams != nil {
 					require.Equal(t, c.expectedParams, req.ExtraParams)

--- a/pkg/cmd/roachtest/testdata/help_command_createpost_1.txt
+++ b/pkg/cmd/roachtest/testdata/help_command_createpost_1.txt
@@ -1,0 +1,17 @@
+echo
+----
+----
+
+
+See: [roachtest README](https://github.com/cockroachdb/cockroach/blob/master/pkg/cmd/roachtest/README.md)
+
+
+
+See: [How To Investigate \(internal\)](https://cockroachlabs.atlassian.net/l/c/SSSBr8c7)
+
+
+
+See: [Grafana](https://go.crdb.dev/p/roachfana/foo/1689957243000/1689957733000)
+
+----
+----

--- a/pkg/cmd/roachtest/testdata/help_command_createpost_2.txt
+++ b/pkg/cmd/roachtest/testdata/help_command_createpost_2.txt
@@ -1,0 +1,17 @@
+echo
+----
+----
+
+
+See: [roachtest README](https://github.com/cockroachdb/cockroach/blob/master/pkg/cmd/roachtest/README.md)
+
+
+
+See: [How To Investigate \(internal\)](https://cockroachlabs.atlassian.net/l/c/SSSBr8c7)
+
+
+
+See: [Grafana](https://go.crdb.dev/p/roachfana/foo/1689957243000/1689957733000)
+
+----
+----

--- a/pkg/cmd/roachtest/testdata/help_command_createpost_3.txt
+++ b/pkg/cmd/roachtest/testdata/help_command_createpost_3.txt
@@ -1,0 +1,13 @@
+echo
+----
+----
+
+
+See: [roachtest README](https://github.com/cockroachdb/cockroach/blob/master/pkg/cmd/roachtest/README.md)
+
+
+
+See: [How To Investigate \(internal\)](https://cockroachlabs.atlassian.net/l/c/SSSBr8c7)
+
+----
+----

--- a/pkg/cmd/roachtest/testdata/help_command_createpost_5.txt
+++ b/pkg/cmd/roachtest/testdata/help_command_createpost_5.txt
@@ -1,0 +1,17 @@
+echo
+----
+----
+
+
+See: [roachtest README](https://github.com/cockroachdb/cockroach/blob/master/pkg/cmd/roachtest/README.md)
+
+
+
+See: [How To Investigate \(internal\)](https://cockroachlabs.atlassian.net/l/c/SSSBr8c7)
+
+
+
+See: [Grafana](https://go.crdb.dev/p/roachfana/foo/1689957243000/1689957733000)
+
+----
+----


### PR DESCRIPTION
Previously, the testeng grafana link generated after a roachtest failure directed the user to cockroachlabs.com due to a missing cluster name from the link. This patch should fix this issue by getting the cluster name from a `*githubIssues.cluster.name` instead of the `clusterName` from roachtest/cluster.go.

Fixes: #107894

Release note (bug fix): The link to testeng grafana that is generated on a roachtest failure should now properly direct to grafana.