### PR TITLE
tests: remove direct uses of *TestCluster

### DIFF
--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -1544,6 +1544,7 @@ GO_TARGETS = [
     "//pkg/server/profiler:profiler",
     "//pkg/server/profiler:profiler_test",
     "//pkg/server/rangetestutils:rangetestutils",
+    "//pkg/server/serverctl:serverctl",
     "//pkg/server/serverpb:serverpb",
     "//pkg/server/serverpb:serverpb_test",
     "//pkg/server/serverrules:serverrules",

--- a/pkg/bench/bench_test.go
+++ b/pkg/bench/bench_test.go
@@ -506,7 +506,7 @@ func BenchmarkTracing(b *testing.B) {
 							Tracer:      tr,
 						},
 					})
-				sqlRunner := sqlutils.MakeRoundRobinSQLRunner(tc.Conns[0], tc.Conns[1], tc.Conns[2])
+				sqlRunner := sqlutils.MakeRoundRobinSQLRunner(tc.ServerConn(0), tc.ServerConn(1), tc.ServerConn(2))
 				return sqlRunner, tc.Stopper()
 			},
 		},

--- a/pkg/bench/foreachdb.go
+++ b/pkg/bench/foreachdb.go
@@ -145,12 +145,12 @@ func benchmarkMultinodeCockroach(b *testing.B, f BenchmarkFn) {
 				DefaultTestTenant: base.TestIsForStuffThatShouldWorkWithSecondaryTenantsButDoesntYet(83461),
 			},
 		})
-	if _, err := tc.Conns[0].Exec(`CREATE DATABASE bench`); err != nil {
+	if _, err := tc.ServerConn(0).Exec(`CREATE DATABASE bench`); err != nil {
 		b.Fatal(err)
 	}
 	defer tc.Stopper().Stop(context.TODO())
 
-	f(b, sqlutils.MakeRoundRobinSQLRunner(tc.Conns[0], tc.Conns[1], tc.Conns[2]))
+	f(b, sqlutils.MakeRoundRobinSQLRunner(tc.ServerConn(0), tc.ServerConn(1), tc.ServerConn(2)))
 }
 
 func benchmarkPostgres(b *testing.B, f BenchmarkFn) {

--- a/pkg/ccl/backupccl/backup_tenant_test.go
+++ b/pkg/ccl/backupccl/backup_tenant_test.go
@@ -45,7 +45,7 @@ func TestBackupTenantImportingTable(t *testing.T) {
 			},
 		})
 	defer tc.Stopper().Stop(ctx)
-	sqlDB := sqlutils.MakeSQLRunner(tc.Conns[0])
+	sqlDB := sqlutils.MakeSQLRunner(tc.ServerConn(0))
 
 	tenantID := roachpb.MustMakeTenantID(10)
 	tSrv, tSQL := serverutils.StartTenant(t, tc.Server(0), base.TestTenantArgs{

--- a/pkg/ccl/backupccl/backupinfo/backup_metadata_test.go
+++ b/pkg/ccl/backupccl/backupinfo/backup_metadata_test.go
@@ -77,7 +77,7 @@ func TestMetadataSST(t *testing.T) {
 
 	// Check for correct backup metadata on tenant backups.
 	userfile2 := "userfile:///2"
-	_, err := tc.Servers[0].StartTenant(ctx, base.TestTenantArgs{TenantID: roachpb.MustMakeTenantID(10)})
+	_, err := tc.Server(0).StartTenant(ctx, base.TestTenantArgs{TenantID: roachpb.MustMakeTenantID(10)})
 	require.NoError(t, err)
 	sqlDB.Exec(t, `BACKUP TENANT 10 TO $1`, userfile2)
 	checkMetadata(ctx, t, tc, userfile2)
@@ -90,10 +90,10 @@ func checkMetadata(
 		ctx,
 		backupLoc,
 		base.ExternalIODirConfig{},
-		tc.Servers[0].ClusterSettings(),
+		tc.Server(0).ClusterSettings(),
 		blobs.TestEmptyBlobClientFactory,
 		username.RootUserName(),
-		tc.Servers[0].InternalDB().(isql.DB),
+		tc.Server(0).InternalDB().(isql.DB),
 		nil, /* limiters */
 		cloud.NilMetrics,
 	)
@@ -105,7 +105,7 @@ func checkMetadata(
 		t.Fatal(err)
 	}
 
-	srv := tc.Servers[0]
+	srv := tc.Server(0)
 	execCfg := srv.ExecutorConfig().(sql.ExecutorConfig)
 	kmsEnv := backupencryption.MakeBackupKMSEnv(srv.ClusterSettings(), &base.ExternalIODirConfig{},
 		execCfg.InternalDB, username.RootUserName())

--- a/pkg/ccl/backupccl/backuptestutils/testutils.go
+++ b/pkg/ccl/backupccl/backuptestutils/testutils.go
@@ -122,7 +122,7 @@ func StartBackupRestoreTestCluster(
 	tc := testcluster.StartTestCluster(t, clusterSize, opts.testClusterArgs)
 	opts.initFunc(tc)
 
-	sqlDB := sqlutils.MakeSQLRunner(tc.Conns[0])
+	sqlDB := sqlutils.MakeSQLRunner(tc.ServerConn(0))
 
 	if opts.bankArgs != nil {
 		const payloadSize = 100
@@ -157,7 +157,7 @@ func StartBackupRestoreTestCluster(
 	}
 
 	return tc, sqlDB, opts.dataDir, func() {
-		CheckForInvalidDescriptors(t, tc.Conns[0])
+		CheckForInvalidDescriptors(t, tc.ServerConn(0))
 		tc.Stopper().Stop(ctx) // cleans up in memory storage's auxiliary dirs
 		dirCleanupFunc()
 	}

--- a/pkg/ccl/backupccl/bench_test.go
+++ b/pkg/ccl/backupccl/bench_test.go
@@ -127,10 +127,10 @@ func BenchmarkIteratorMemory(b *testing.B) {
 			ctx,
 			storeURI,
 			base.ExternalIODirConfig{},
-			tc.Servers[0].ClusterSettings(),
+			tc.Server(0).ClusterSettings(),
 			blobs.TestEmptyBlobClientFactory,
 			username.RootUserName(),
-			tc.Servers[0].InternalDB().(isql.DB),
+			tc.Server(0).InternalDB().(isql.DB),
 			nil, /* limiters */
 			cloud.NilMetrics,
 		)

--- a/pkg/ccl/backupccl/file_sst_sink_test.go
+++ b/pkg/ccl/backupccl/file_sst_sink_test.go
@@ -860,10 +860,10 @@ func fileSSTSinkTestSetUp(
 ) (*fileSSTSink, cloud.ExternalStorage) {
 	store, err := cloud.ExternalStorageFromURI(ctx, "userfile:///0",
 		base.ExternalIODirConfig{},
-		tc.Servers[0].ClusterSettings(),
+		tc.Server(0).ClusterSettings(),
 		blobs.TestEmptyBlobClientFactory,
 		username.RootUserName(),
-		tc.Servers[0].InternalDB().(isql.DB),
+		tc.Server(0).InternalDB().(isql.DB),
 		nil, /* limiters */
 		cloud.NilMetrics,
 	)
@@ -876,7 +876,7 @@ func fileSSTSinkTestSetUp(
 		id:       1,
 		enc:      nil,
 		progCh:   progCh,
-		settings: &tc.Servers[0].ClusterSettings().SV,
+		settings: &tc.Server(0).ClusterSettings().SV,
 	}
 
 	sink := makeFileSSTSink(sinkConf, store)

--- a/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
+++ b/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
@@ -87,7 +87,8 @@ func TestFullClusterBackup(t *testing.T) {
 	allowProgressAfterPreRestore := make(chan struct{})
 	// Closed to signal the zones have been restored.
 	restoredZones := make(chan struct{})
-	for _, server := range tcRestore.Servers {
+	for i := 0; i < tcRestore.NumServers(); i++ {
+		server := tcRestore.Server(i)
 		registry := server.JobRegistry().(*jobs.Registry)
 		registry.TestingWrapResumerConstructor(jobspb.TypeRestore,
 			func(raw jobs.Resumer) jobs.Resumer {
@@ -495,7 +496,8 @@ func TestClusterRestoreSystemTableOrdering(t *testing.T) {
 	defer cleanupEmptyCluster()
 
 	restoredSystemTables := make([]string, 0)
-	for _, server := range tcRestore.Servers {
+	for i := 0; i < tcRestore.NumServers(); i++ {
+		server := tcRestore.Server(i)
 		registry := server.JobRegistry().(*jobs.Registry)
 		registry.TestingWrapResumerConstructor(jobspb.TypeRestore,
 			func(raw jobs.Resumer) jobs.Resumer {
@@ -712,7 +714,8 @@ func TestClusterRestoreFailCleanup(t *testing.T) {
 
 				// Inject a retry error, that returns once.
 				alreadyErrored := false
-				for _, server := range tcRestore.Servers {
+				for i := 0; i < tcRestore.NumServers(); i++ {
+					server := tcRestore.Server(i)
 					registry := server.JobRegistry().(*jobs.Registry)
 					registry.TestingWrapResumerConstructor(jobspb.TypeRestore,
 						func(raw jobs.Resumer) jobs.Resumer {
@@ -744,7 +747,8 @@ func TestClusterRestoreFailCleanup(t *testing.T) {
 		defer cleanupEmptyCluster()
 
 		// Bugger the backup by injecting a failure while restoring the system data.
-		for _, server := range tcRestore.Servers {
+		for i := 0; i < tcRestore.NumServers(); i++ {
+			server := tcRestore.Server(i)
 			registry := server.JobRegistry().(*jobs.Registry)
 			registry.TestingWrapResumerConstructor(jobspb.TypeRestore,
 				func(raw jobs.Resumer) jobs.Resumer {
@@ -787,7 +791,8 @@ func TestClusterRestoreFailCleanup(t *testing.T) {
 		defer cleanupEmptyCluster()
 
 		// Bugger the backup by injecting a failure while restoring the system data.
-		for _, server := range tcRestore.Servers {
+		for i := 0; i < tcRestore.NumServers(); i++ {
+			server := tcRestore.Server(i)
 			registry := server.JobRegistry().(*jobs.Registry)
 			registry.TestingWrapResumerConstructor(jobspb.TypeRestore,
 				func(raw jobs.Resumer) jobs.Resumer {
@@ -1065,7 +1070,7 @@ func TestClusterRevisionDoesNotBackupOptOutSystemTables(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	tc, _, _, cleanup := backupRestoreTestSetup(t, singleNode, 10, InitManualReplication)
-	conn := tc.Conns[0]
+	conn := tc.ServerConn(0)
 	sqlDB := sqlutils.MakeSQLRunner(conn)
 	defer cleanup()
 

--- a/pkg/ccl/backupccl/generative_split_and_scatter_processor_test.go
+++ b/pkg/ccl/backupccl/generative_split_and_scatter_processor_test.go
@@ -87,7 +87,7 @@ func TestRunGenerativeSplitAndScatterContextCancel(t *testing.T) {
 	uri := localFoo + "/" + backups[0][0]
 
 	codec := keys.MakeSQLCodec(s0.RPCContext().TenantID)
-	backupTableDesc := desctestutils.TestingGetPublicTableDescriptor(tc.Servers[0].DB(), codec, "data", "bank")
+	backupTableDesc := desctestutils.TestingGetPublicTableDescriptor(tc.Server(0).DB(), codec, "data", "bank")
 	backupStartKey := backupTableDesc.PrimaryIndexSpan(codec).Key
 
 	spec := makeTestingGenerativeSplitAndScatterSpec(
@@ -171,7 +171,7 @@ func TestRunGenerativeSplitAndScatterRandomizedDestOnFailScatter(t *testing.T) {
 	uri := localFoo + "/" + backups[0][0]
 
 	codec := keys.MakeSQLCodec(s0.RPCContext().TenantID)
-	backupTableDesc := desctestutils.TestingGetPublicTableDescriptor(tc.Servers[0].DB(), codec, "data", "bank")
+	backupTableDesc := desctestutils.TestingGetPublicTableDescriptor(tc.Server(0).DB(), codec, "data", "bank")
 	backupStartKey := backupTableDesc.PrimaryIndexSpan(codec).Key
 
 	spec := makeTestingGenerativeSplitAndScatterSpec(

--- a/pkg/ccl/backupccl/restore_mid_schema_change_test.go
+++ b/pkg/ccl/backupccl/restore_mid_schema_change_test.go
@@ -220,7 +220,7 @@ func restoreMidSchemaChange(
 			tc.Stopper().Stop(ctx)
 			dirCleanupFn()
 		}()
-		sqlDB := sqlutils.MakeSQLRunner(tc.Conns[0])
+		sqlDB := sqlutils.MakeSQLRunner(tc.ServerConn(0))
 
 		symlink := filepath.Join(dir, "foo")
 		err := os.Symlink(backupDir, symlink)

--- a/pkg/ccl/backupccl/restore_old_versions_test.go
+++ b/pkg/ccl/backupccl/restore_old_versions_test.go
@@ -148,7 +148,7 @@ func restoreOldVersionClusterTest(exportDir string) func(t *testing.T) {
 				ExternalIODir:     externalDir,
 			},
 		})
-		sqlDB := sqlutils.MakeSQLRunner(tc.Conns[0])
+		sqlDB := sqlutils.MakeSQLRunner(tc.ServerConn(0))
 		defer func() {
 			tc.Stopper().Stop(ctx)
 			dirCleanup()

--- a/pkg/ccl/backupccl/system_schema_test.go
+++ b/pkg/ccl/backupccl/system_schema_test.go
@@ -35,7 +35,7 @@ func TestAllSystemTablesHaveBackupConfig(t *testing.T) {
 				DefaultTestTenant: base.TestControlsTenantsExplicitly,
 			}})
 	defer tc.Stopper().Stop(ctx)
-	systemSQL := sqlutils.MakeSQLRunner(tc.Conns[0])
+	systemSQL := sqlutils.MakeSQLRunner(tc.ServerConn(0))
 
 	_, tSQL := serverutils.StartTenant(t, tc.Server(0), base.TestTenantArgs{
 		TenantID:     roachpb.MustMakeTenantID(10),

--- a/pkg/ccl/backupccl/tenant_backup_nemesis_test.go
+++ b/pkg/ccl/backupccl/tenant_backup_nemesis_test.go
@@ -73,7 +73,7 @@ func TestTenantBackupWithCanceledImport(t *testing.T) {
 	hostSQLDB.Exec(t, "SET CLUSTER SETTING storage.mvcc.range_tombstones.enabled = true")
 	hostSQLDB.Exec(t, "ALTER TENANT ALL SET CLUSTER SETTING storage.mvcc.range_tombstones.enabled = true")
 
-	tenant10, err := tc.Servers[0].StartTenant(ctx, base.TestTenantArgs{
+	tenant10, err := tc.Server(0).StartTenant(ctx, base.TestTenantArgs{
 		TenantID: roachpb.MustMakeTenantID(10),
 		TestingKnobs: base.TestingKnobs{
 			JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
@@ -102,7 +102,7 @@ func TestTenantBackupWithCanceledImport(t *testing.T) {
 	hostSQLDB.Exec(t, "BACKUP TENANT 10 INTO LATEST IN 'nodelocal://1/tenant-backup'")
 	hostSQLDB.Exec(t, "RESTORE TENANT 10 FROM LATEST IN 'nodelocal://1/tenant-backup' WITH virtual_cluster_name = 'tenant-11'")
 
-	tenant11, err := tc.Servers[0].StartTenant(ctx, base.TestTenantArgs{
+	tenant11, err := tc.Server(0).StartTenant(ctx, base.TestTenantArgs{
 		TenantName:          "tenant-11",
 		DisableCreateTenant: true,
 	})
@@ -147,7 +147,7 @@ func TestTenantBackupNemesis(t *testing.T) {
 	hostSQLDB.Exec(t, "SET CLUSTER SETTING storage.mvcc.range_tombstones.enabled = true")
 	hostSQLDB.Exec(t, "ALTER TENANT ALL SET CLUSTER SETTING storage.mvcc.range_tombstones.enabled = true")
 
-	tenant10, err := tc.Servers[0].StartTenant(ctx, base.TestTenantArgs{
+	tenant10, err := tc.Server(0).StartTenant(ctx, base.TestTenantArgs{
 		TenantID: roachpb.MustMakeTenantID(10),
 		TestingKnobs: base.TestingKnobs{
 			JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
@@ -248,7 +248,7 @@ func TestTenantBackupNemesis(t *testing.T) {
 	//
 	// We check bank.bank which has had the workload running against it
 	// and any table from a completed nemesis.
-	tenant11, err := tc.Servers[0].StartTenant(ctx, base.TestTenantArgs{
+	tenant11, err := tc.Server(0).StartTenant(ctx, base.TestTenantArgs{
 		TenantName:          "tenant-11",
 		DisableCreateTenant: true,
 	})

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -8000,7 +8000,7 @@ func TestChangefeedExecLocality(t *testing.T) {
 	defer tc.Stopper().Stop(ctx)
 	tc.ToggleReplicateQueues(false)
 
-	n2 := sqlutils.MakeSQLRunner(tc.Conns[1])
+	n2 := sqlutils.MakeSQLRunner(tc.ServerConn(1))
 
 	// Setup a table with at least one range on each node to be sure we will see a
 	// file from that node if it isn't excluded by filter. Relocate can fail with

--- a/pkg/ccl/cloudccl/amazon/s3_connection_test.go
+++ b/pkg/ccl/cloudccl/amazon/s3_connection_test.go
@@ -45,7 +45,7 @@ func TestS3ExternalConnection(t *testing.T) {
 	defer tc.Stopper().Stop(context.Background())
 
 	tc.WaitForNodeLiveness(t)
-	sqlDB := sqlutils.MakeSQLRunner(tc.Conns[0])
+	sqlDB := sqlutils.MakeSQLRunner(tc.ServerConn(0))
 
 	// Setup some dummy data.
 	sqlDB.Exec(t, `CREATE DATABASE foo`)
@@ -198,7 +198,7 @@ func TestAWSKMSExternalConnection(t *testing.T) {
 	defer tc.Stopper().Stop(context.Background())
 
 	tc.WaitForNodeLiveness(t)
-	sqlDB := sqlutils.MakeSQLRunner(tc.Conns[0])
+	sqlDB := sqlutils.MakeSQLRunner(tc.ServerConn(0))
 
 	// Setup some dummy data.
 	sqlDB.Exec(t, `CREATE DATABASE foo`)
@@ -307,7 +307,7 @@ func TestAWSKMSExternalConnectionAssumeRole(t *testing.T) {
 	defer tc.Stopper().Stop(context.Background())
 
 	tc.WaitForNodeLiveness(t)
-	sqlDB := sqlutils.MakeSQLRunner(tc.Conns[0])
+	sqlDB := sqlutils.MakeSQLRunner(tc.ServerConn(0))
 
 	// Setup some dummy data.
 	sqlDB.Exec(t, `CREATE DATABASE foo`)

--- a/pkg/ccl/cloudccl/azure/azure_connection_test.go
+++ b/pkg/ccl/cloudccl/azure/azure_connection_test.go
@@ -71,7 +71,7 @@ func TestExternalConnections(t *testing.T) {
 	defer tc.Stopper().Stop(context.Background())
 
 	tc.WaitForNodeLiveness(t)
-	sqlDB := sqlutils.MakeSQLRunner(tc.Conns[0])
+	sqlDB := sqlutils.MakeSQLRunner(tc.ServerConn(0))
 
 	// Setup some dummy data.
 	sqlDB.Exec(t, `CREATE DATABASE foo`)

--- a/pkg/ccl/cloudccl/gcp/gcp_connection_test.go
+++ b/pkg/ccl/cloudccl/gcp/gcp_connection_test.go
@@ -50,7 +50,7 @@ func TestGCPKMSExternalConnection(t *testing.T) {
 	defer tc.Stopper().Stop(context.Background())
 
 	tc.WaitForNodeLiveness(t)
-	sqlDB := sqlutils.MakeSQLRunner(tc.Conns[0])
+	sqlDB := sqlutils.MakeSQLRunner(tc.ServerConn(0))
 
 	// Setup some dummy data.
 	sqlDB.Exec(t, `CREATE DATABASE foo`)
@@ -178,7 +178,7 @@ func TestGCPKMSExternalConnectionAssumeRole(t *testing.T) {
 	defer tc.Stopper().Stop(context.Background())
 
 	tc.WaitForNodeLiveness(t)
-	sqlDB := sqlutils.MakeSQLRunner(tc.Conns[0])
+	sqlDB := sqlutils.MakeSQLRunner(tc.ServerConn(0))
 
 	// Setup some dummy data.
 	sqlDB.Exec(t, `CREATE DATABASE foo`)
@@ -305,7 +305,7 @@ func TestGCPAssumeRoleExternalConnection(t *testing.T) {
 	defer tc.Stopper().Stop(context.Background())
 
 	tc.WaitForNodeLiveness(t)
-	sqlDB := sqlutils.MakeSQLRunner(tc.Conns[0])
+	sqlDB := sqlutils.MakeSQLRunner(tc.ServerConn(0))
 
 	// Setup some dummy data.
 	sqlDB.Exec(t, `CREATE DATABASE foo`)
@@ -452,7 +452,7 @@ func TestGCPExternalConnection(t *testing.T) {
 	defer tc.Stopper().Stop(context.Background())
 
 	tc.WaitForNodeLiveness(t)
-	sqlDB := sqlutils.MakeSQLRunner(tc.Conns[0])
+	sqlDB := sqlutils.MakeSQLRunner(tc.ServerConn(0))
 
 	// Setup some dummy data.
 	sqlDB.Exec(t, `CREATE DATABASE foo`)

--- a/pkg/ccl/importerccl/ccl_test.go
+++ b/pkg/ccl/importerccl/ccl_test.go
@@ -424,7 +424,7 @@ func TestImportInTenant(t *testing.T) {
 	}
 	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{ServerArgs: args})
 	defer tc.Stopper().Stop(ctx)
-	conn := tc.Conns[0]
+	conn := tc.ServerConn(0)
 	sqlDB := sqlutils.MakeSQLRunner(conn)
 
 	// Setup a few tenants, each with a different table.

--- a/pkg/ccl/kvccl/kvfollowerreadsccl/boundedstaleness_test.go
+++ b/pkg/ccl/kvccl/kvfollowerreadsccl/boundedstaleness_test.go
@@ -80,7 +80,7 @@ func TestBoundedStalenessEnterpriseLicense(t *testing.T) {
 	t.Run("disabled", func(t *testing.T) {
 		for _, testCase := range testCases {
 			t.Run(testCase.query, func(t *testing.T) {
-				_, err := tc.Conns[0].QueryContext(ctx, testCase.query, testCase.args...)
+				_, err := tc.ServerConn(0).QueryContext(ctx, testCase.query, testCase.args...)
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "use of bounded staleness requires an enterprise license")
 			})
@@ -91,7 +91,7 @@ func TestBoundedStalenessEnterpriseLicense(t *testing.T) {
 		defer ccl.TestingEnableEnterprise()()
 		for _, testCase := range testCases {
 			t.Run(testCase.query, func(t *testing.T) {
-				r, err := tc.Conns[0].QueryContext(ctx, testCase.query, testCase.args...)
+				r, err := tc.ServerConn(0).QueryContext(ctx, testCase.query, testCase.args...)
 				require.NoError(t, err)
 				require.NoError(t, r.Close())
 			})

--- a/pkg/ccl/multiregionccl/cold_start_latency_test.go
+++ b/pkg/ccl/multiregionccl/cold_start_latency_test.go
@@ -288,8 +288,9 @@ SELECT checkpoint > extract(epoch from after)
 
 	// Wait for the configs to be applied.
 	testutils.SucceedsWithin(t, func() error {
-		for _, server := range tc.Servers {
-			reporter := server.SpanConfigReporter().(spanconfig.Reporter)
+		for i := 0; i < tc.NumServers(); i++ {
+			s := tc.Server(i)
+			reporter := s.SpanConfigReporter().(spanconfig.Reporter)
 			report, err := reporter.SpanConfigConformance(ctx, []roachpb.Span{
 				{Key: keys.TableDataMin, EndKey: keys.TenantTableDataMax},
 			})

--- a/pkg/ccl/multiregionccl/multiregion_system_table_test.go
+++ b/pkg/ccl/multiregionccl/multiregion_system_table_test.go
@@ -55,9 +55,9 @@ func TestMrSystemDatabase(t *testing.T) {
 	tenantArgs := base.TestTenantArgs{
 		Settings: cs,
 		TenantID: id,
-		Locality: *cluster.Servers[0].Locality(),
+		Locality: *cluster.Server(0).Locality(),
 	}
-	_, tenantSQL := serverutils.StartTenant(t, cluster.Servers[0], tenantArgs)
+	_, tenantSQL := serverutils.StartTenant(t, cluster.Server(0), tenantArgs)
 
 	tDB := sqlutils.MakeSQLRunner(tenantSQL)
 

--- a/pkg/ccl/multiregionccl/regional_by_row_test.go
+++ b/pkg/ccl/multiregionccl/regional_by_row_test.go
@@ -922,7 +922,7 @@ func TestIndexDescriptorUpdateForImplicitColumns(t *testing.T) {
 	tdb.Exec(t, `CREATE DATABASE test PRIMARY REGION "us-east1" REGIONS "us-east2"`)
 
 	fetchIndexes := func(tableName string) []catalog.Index {
-		kvDB := c.Servers[0].DB()
+		kvDB := c.Server(0).DB()
 		desc := desctestutils.TestingGetPublicTableDescriptor(kvDB, keys.SystemSQLCodec, "test", tableName)
 		return desc.NonDropIndexes()
 	}

--- a/pkg/ccl/partitionccl/partition_test.go
+++ b/pkg/ccl/partitionccl/partition_test.go
@@ -1191,14 +1191,14 @@ func setupPartitioningTestCluster(
 	}}
 	tc := testcluster.StartTestCluster(t, 3, tcArgs)
 
-	sqlDB := sqlutils.MakeSQLRunner(tc.Conns[0])
+	sqlDB := sqlutils.MakeSQLRunner(tc.ServerConn(0))
 	sqlDB.Exec(t, `CREATE DATABASE data`)
 
 	// Disabling store throttling vastly speeds up rebalancing.
 	sqlDB.Exec(t, `SET CLUSTER SETTING server.declined_reservation_timeout = '0s'`)
 	sqlDB.Exec(t, `SET CLUSTER SETTING server.failed_reservation_timeout = '0s'`)
 
-	return tc.Conns[0], sqlDB, func() {
+	return tc.ServerConn(0), sqlDB, func() {
 		tc.Stopper().Stop(context.Background())
 	}
 }

--- a/pkg/ccl/storageccl/external_sst_reader_test.go
+++ b/pkg/ccl/storageccl/external_sst_reader_test.go
@@ -122,7 +122,7 @@ func TestNewExternalSSTReader(t *testing.T) {
 			clusterSettings,
 			blobs.TestBlobServiceClient(tempDir),
 			username.RootUserName(),
-			tc.Servers[0].InternalDB().(isql.DB),
+			tc.Server(0).InternalDB().(isql.DB),
 			nil, /* limiters */
 			cloud.NilMetrics,
 		)

--- a/pkg/ccl/streamingccl/streamingest/replication_random_client_test.go
+++ b/pkg/ccl/streamingccl/streamingest/replication_random_client_test.go
@@ -204,7 +204,7 @@ func TestStreamIngestionJobWithRandomClient(t *testing.T) {
 	tc := testcluster.StartTestCluster(t, numNodes, params)
 	defer tc.Stopper().Stop(ctx)
 	sqlDB := sqlutils.MakeSQLRunner(tc.ServerConn(0))
-	conn := tc.Conns[0]
+	conn := tc.ServerConn(0)
 
 	allowResponse = make(chan struct{})
 	receivedRevertRequest = make(chan struct{})

--- a/pkg/ccl/testccl/sqlstatsccl/sql_stats_test.go
+++ b/pkg/ccl/testccl/sqlstatsccl/sql_stats_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
-	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/stretchr/testify/assert"
@@ -80,11 +79,11 @@ func TestSQLStatsRegions(t *testing.T) {
 		serverArgs[i] = args
 	}
 
-	host := testcluster.StartTestCluster(t, numServers, base.TestClusterArgs{
+	tc := serverutils.StartNewTestCluster(t, numServers, base.TestClusterArgs{
 		ServerArgsPerNode: serverArgs,
 		ParallelStart:     true,
 	})
-	defer host.Stopper().Stop(ctx)
+	defer tc.Stopper().Stop(ctx)
 
 	go func() {
 		for _, c := range signalAfter {
@@ -92,7 +91,7 @@ func TestSQLStatsRegions(t *testing.T) {
 		}
 	}()
 
-	tdb := sqlutils.MakeSQLRunner(host.ServerConn(1))
+	tdb := sqlutils.MakeSQLRunner(tc.ServerConn(1))
 
 	// Shorten the closed timestamp target duration so that span configs
 	// propagate more rapidly.
@@ -116,7 +115,8 @@ func TestSQLStatsRegions(t *testing.T) {
 
 	// Create secondary tenants
 	var tenantDbs []*gosql.DB
-	for _, server := range host.Servers {
+	for i := 0; i < numServers; i++ {
+		server := tc.Server(i)
 		_, tenantDb := serverutils.StartTenant(t, server, base.TestTenantArgs{
 			Settings: st,
 			TenantID: roachpb.MustMakeTenantID(11),
@@ -131,19 +131,19 @@ func TestSQLStatsRegions(t *testing.T) {
 	tenantDbName := "testDbTenant"
 	createMultiRegionDbAndTable(t, tenantRunner, regionNames, tenantDbName)
 
-	require.NoError(t, host.WaitForFullReplication())
+	require.NoError(t, tc.WaitForFullReplication())
 
 	testCases := []struct {
 		name   string
 		dbName string
-		db     func(t *testing.T, host *testcluster.TestCluster, st *cluster.Settings) *sqlutils.SQLRunner
+		db     func(t *testing.T, tc serverutils.TestClusterInterface, st *cluster.Settings) *sqlutils.SQLRunner
 	}{{
 		// This test runs against the system tenant, opening a database
 		// connection to the first node in the cluster.
 		name:   "system tenant",
 		dbName: systemDbName,
-		db: func(t *testing.T, host *testcluster.TestCluster, _ *cluster.Settings) *sqlutils.SQLRunner {
-			return sqlutils.MakeSQLRunner(host.ServerConn(0))
+		db: func(t *testing.T, tc serverutils.TestClusterInterface, _ *cluster.Settings) *sqlutils.SQLRunner {
+			return sqlutils.MakeSQLRunner(tc.ServerConn(0))
 		},
 	}, {
 		// This test runs against a secondary tenant, launching a SQL instance
@@ -151,13 +151,13 @@ func TestSQLStatsRegions(t *testing.T) {
 		// connection to the first one.
 		name:   "secondary tenant",
 		dbName: tenantDbName,
-		db: func(t *testing.T, host *testcluster.TestCluster, st *cluster.Settings) *sqlutils.SQLRunner {
+		db: func(t *testing.T, tc serverutils.TestClusterInterface, st *cluster.Settings) *sqlutils.SQLRunner {
 			return tenantRunner
 		},
 	}}
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			db := tc.db(t, host, st)
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			db := testCase.db(t, tc, st)
 
 			db.Exec(t, `SET CLUSTER SETTING sql.txn_stats.sample_rate = 1;`)
 
@@ -165,7 +165,7 @@ func TestSQLStatsRegions(t *testing.T) {
 			testutils.SucceedsWithin(t, func() error {
 				var expectedNodes []int64
 				var expectedRegions []string
-				_, err := db.DB.ExecContext(ctx, fmt.Sprintf(`USE %s`, tc.dbName))
+				_, err := db.DB.ExecContext(ctx, fmt.Sprintf(`USE %s`, testCase.dbName))
 				if err != nil {
 					return err
 				}

--- a/pkg/ccl/workloadccl/fixture_test.go
+++ b/pkg/ccl/workloadccl/fixture_test.go
@@ -267,7 +267,7 @@ func TestImportFixtureNodeCount(t *testing.T) {
 	tc := testcluster.StartTestCluster(t, nodes, base.TestClusterArgs{})
 	defer tc.Stopper().Stop(ctx)
 
-	db := tc.Conns[0]
+	db := tc.ServerConn(0)
 	sqlDB := sqlutils.MakeSQLRunner(db)
 
 	gen := makeTestWorkload()

--- a/pkg/cli/BUILD.bazel
+++ b/pkg/cli/BUILD.bazel
@@ -148,6 +148,7 @@ go_library(
         "//pkg/server/autoconfig/acprovider",
         "//pkg/server/pgurl",
         "//pkg/server/profiler",
+        "//pkg/server/serverctl",
         "//pkg/server/serverpb",
         "//pkg/server/status",
         "//pkg/server/status/statuspb",

--- a/pkg/cli/mt_start_sql.go
+++ b/pkg/cli/mt_start_sql.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cli/clierrorplus"
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/server/serverctl"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/redact"
 	"github.com/spf13/cobra"
@@ -78,7 +79,7 @@ func runStartSQL(cmd *cobra.Command, args []string) error {
 		)
 	}
 
-	newServerFn := func(ctx context.Context, serverCfg server.Config, stopper *stop.Stopper) (serverStartupInterface, error) {
+	newServerFn := func(ctx context.Context, serverCfg server.Config, stopper *stop.Stopper) (serverctl.ServerStartupInterface, error) {
 		// Beware of not writing simply 'return server.NewServer()'. This is
 		// because it would cause the serverStartupInterface reference to
 		// always be non-nil, even if NewServer returns a nil pointer (and

--- a/pkg/kv/kvserver/batcheval/cmd_export_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_export_test.go
@@ -172,7 +172,7 @@ func TestExportCmd(t *testing.T) {
 			"unexpected ResumeReason in latest export")
 	}
 
-	sqlDB := sqlutils.MakeSQLRunner(tc.Conns[0])
+	sqlDB := sqlutils.MakeSQLRunner(tc.ServerConn(0))
 	sqlDB.Exec(t, `CREATE DATABASE mvcclatest`)
 	sqlDB.Exec(t, `CREATE TABLE mvcclatest.export (id INT PRIMARY KEY, value INT)`)
 	tableID := descpb.ID(sqlutils.QueryTableID(
@@ -455,7 +455,7 @@ func TestExportRequestWithCPULimitResumeSpans(t *testing.T) {
 	defer tc.Stopper().Stop(context.Background())
 
 	s := tc.ApplicationLayer(0)
-	sqlDB := tc.Conns[0]
+	sqlDB := tc.ServerConn(0)
 	db := sqlutils.MakeSQLRunner(sqlDB)
 	execCfg := s.ExecutorConfig().(sql.ExecutorConfig)
 	kvDB := s.DB()

--- a/pkg/kv/kvserver/client_atomic_membership_change_test.go
+++ b/pkg/kv/kvserver/client_atomic_membership_change_test.go
@@ -59,7 +59,7 @@ func TestAtomicReplicationChange(t *testing.T) {
 
 	runChange := func(expDesc roachpb.RangeDescriptor, chgs []kvpb.ReplicationChange) roachpb.RangeDescriptor {
 		t.Helper()
-		desc, err := tc.Servers[0].DB().AdminChangeReplicas(ctx, k, expDesc, chgs)
+		desc, err := tc.Server(0).DB().AdminChangeReplicas(ctx, k, expDesc, chgs)
 		require.NoError(t, err)
 
 		return *desc
@@ -68,7 +68,8 @@ func TestAtomicReplicationChange(t *testing.T) {
 	checkDesc := func(desc roachpb.RangeDescriptor, expStores ...roachpb.StoreID) {
 		testutils.SucceedsSoon(t, func() error {
 			var sawStores []roachpb.StoreID
-			for _, s := range tc.Servers {
+			for serverIdx := 0; serverIdx < tc.NumServers(); serverIdx++ {
+				s := tc.Server(serverIdx)
 				r, _, _ := s.GetStores().(*kvserver.Stores).GetReplicaForRangeID(ctx, desc.RangeID)
 				if r == nil {
 					continue

--- a/pkg/kv/kvserver/client_decommission_test.go
+++ b/pkg/kv/kvserver/client_decommission_test.go
@@ -71,7 +71,7 @@ func TestDecommission(t *testing.T) {
 			attempt++
 			desc := tc.LookupRangeOrFatal(t, k)
 			for _, rDesc := range desc.Replicas().VoterDescriptors() {
-				store, err := tc.Servers[int(rDesc.NodeID-1)].GetStores().(*kvserver.Stores).GetStore(rDesc.StoreID)
+				store, err := tc.Server(int(rDesc.NodeID-1)).GetStores().(*kvserver.Stores).GetStore(rDesc.StoreID)
 				require.NoError(t, err)
 				if err := store.ForceReplicationScanAndProcess(); err != nil {
 					return err

--- a/pkg/kv/kvserver/client_metrics_test.go
+++ b/pkg/kv/kvserver/client_metrics_test.go
@@ -303,7 +303,7 @@ func TestStoreMetrics(t *testing.T) {
 	// Flush Pebble memtables, so that Pebble begins using block-based tables.
 	// This is useful, because most of the stats we track don't apply to
 	// memtables.
-	for i := range tc.Servers {
+	for i := 0; i < tc.NumServers(); i++ {
 		if err := tc.GetFirstStoreFromServer(t, i).TODOEngine().Flush(); err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/kv/kvserver/client_migration_test.go
+++ b/pkg/kv/kvserver/client_migration_test.go
@@ -85,7 +85,7 @@ func TestStorePurgeOutdatedReplicas(t *testing.T) {
 			require.NoError(t, tc.WaitForVoters(k, tc.Target(n2), tc.Target(n3)))
 
 			for _, node := range []int{n2, n3} {
-				ts := tc.Servers[node]
+				ts := tc.Server(node)
 				store, pErr := ts.GetStores().(*kvserver.Stores).GetStore(ts.GetFirstStoreID())
 				if pErr != nil {
 					t.Fatal(pErr)
@@ -107,7 +107,7 @@ func TestStorePurgeOutdatedReplicas(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			ts := tc.Servers[n2]
+			ts := tc.Server(n2)
 			store, pErr := ts.GetStores().(*kvserver.Stores).GetStore(ts.GetFirstStoreID())
 			if pErr != nil {
 				t.Fatal(pErr)
@@ -219,7 +219,7 @@ func TestMigrateWithInflightSnapshot(t *testing.T) {
 	}
 
 	for _, node := range []int{n1, n2} {
-		ts := tc.Servers[node]
+		ts := tc.Server(node)
 		store, pErr := ts.GetStores().(*kvserver.Stores).GetStore(ts.GetFirstStoreID())
 		if pErr != nil {
 			t.Fatal(pErr)
@@ -273,7 +273,7 @@ func TestMigrateWaitsForApplication(t *testing.T) {
 	require.NoError(t, tc.WaitForVoters(k, tc.Target(n2), tc.Target(n3)))
 
 	for _, node := range []int{n1, n2, n3} {
-		ts := tc.Servers[node]
+		ts := tc.Server(node)
 		store, pErr := ts.GetStores().(*kvserver.Stores).GetStore(ts.GetFirstStoreID())
 		if pErr != nil {
 			t.Fatal(pErr)
@@ -306,7 +306,7 @@ func TestMigrateWaitsForApplication(t *testing.T) {
 	}
 
 	for _, node := range []int{n1, n2, n3} {
-		ts := tc.Servers[node]
+		ts := tc.Server(node)
 		store, pErr := ts.GetStores().(*kvserver.Stores).GetStore(ts.GetFirstStoreID())
 		if pErr != nil {
 			t.Fatal(pErr)

--- a/pkg/kv/kvserver/client_raft_log_queue_test.go
+++ b/pkg/kv/kvserver/client_raft_log_queue_test.go
@@ -91,7 +91,7 @@ func TestRaftLogQueue(t *testing.T) {
 	var afterTruncationIndex kvpb.RaftIndex
 	testutils.SucceedsSoon(t, func() error {
 		// Force a truncation check.
-		for i := range tc.Servers {
+		for i := 0; i < tc.NumServers(); i++ {
 			tc.GetFirstStoreFromServer(t, i).MustForceRaftLogScanAndProcess()
 		}
 		// Flush the engine to advance durability, which triggers truncation.
@@ -113,7 +113,7 @@ func TestRaftLogQueue(t *testing.T) {
 	// GetFirstIndex, giving a false negative. Fixing this requires additional
 	// instrumentation of the queues, which was deemed to require too much work
 	// at the time of this writing.
-	for i := range tc.Servers {
+	for i := 0; i < tc.NumServers(); i++ {
 		tc.GetFirstStoreFromServer(t, i).MustForceRaftLogScanAndProcess()
 	}
 

--- a/pkg/kv/kvserver/client_replica_circuit_breaker_test.go
+++ b/pkg/kv/kvserver/client_replica_circuit_breaker_test.go
@@ -610,7 +610,7 @@ func TestReplicaCircuitBreaker_ExemptRequests(t *testing.T) {
 			return addReq
 		},
 		func() kvpb.Request {
-			return &kvpb.RevertRangeRequest{TargetTime: tc.Servers[0].Clock().Now()}
+			return &kvpb.RevertRangeRequest{TargetTime: tc.Server(0).Clock().Now()}
 		},
 		func() kvpb.Request {
 			return &kvpb.GCRequest{}
@@ -830,7 +830,7 @@ func setupCircuitBreakerTest(t *testing.T) *circuitBreakerTest {
 	require.NoError(t, tc.WaitForVoters(k, tc.Target(n2)))
 
 	var repls []replWithKnob
-	for i := range tc.Servers {
+	for i := 0; i < tc.NumServers(); i++ {
 		repl := tc.GetFirstStoreFromServer(t, i).LookupReplica(keys.MustAddr(k))
 		enableProbe := makeBreakerToggleable(repl.Breaker())
 		repls = append(repls, replWithKnob{repl, enableProbe})

--- a/pkg/kv/kvserver/client_replica_gc_test.go
+++ b/pkg/kv/kvserver/client_replica_gc_test.go
@@ -90,7 +90,7 @@ func TestReplicaGCQueueDropReplicaDirect(t *testing.T) {
 	tc.AddVotersOrFatal(t, k, tc.Target(1), tc.Target(2))
 	require.NoError(t, tc.WaitForVoters(k, tc.Target(1), tc.Target(2)))
 
-	ts := tc.Servers[1]
+	ts := tc.Server(1)
 	store, pErr := ts.GetStores().(*kvserver.Stores).GetStore(ts.GetFirstStoreID())
 	if pErr != nil {
 		t.Fatal(pErr)
@@ -170,7 +170,7 @@ func TestReplicaGCQueueDropReplicaGCOnScan(t *testing.T) {
 	)
 	defer tc.Stopper().Stop(context.Background())
 
-	ts := tc.Servers[1]
+	ts := tc.Server(1)
 	store, pErr := ts.GetStores().(*kvserver.Stores).GetStore(ts.GetFirstStoreID())
 	if pErr != nil {
 		t.Fatal(pErr)

--- a/pkg/kv/kvserver/client_replica_raft_overload_test.go
+++ b/pkg/kv/kvserver/client_replica_raft_overload_test.go
@@ -81,7 +81,7 @@ func TestReplicaRaftOverload(t *testing.T) {
 		// so it may or may not contribute here (depending on when it quiesces).
 		//
 		// See: https://github.com/cockroachdb/cockroach/issues/84252
-		require.NoError(t, tc.Servers[0].DB().Put(ctx, tc.ScratchRange(t), "foo"))
+		require.NoError(t, tc.Server(0).DB().Put(ctx, tc.ScratchRange(t), "foo"))
 		s1 := tc.GetFirstStoreFromServer(t, 0)
 		require.NoError(t, s1.ComputeMetrics(ctx))
 		if n := s1.Metrics().RaftPausedFollowerCount.Value(); n == 0 {

--- a/pkg/kv/kvserver/client_store_test.go
+++ b/pkg/kv/kvserver/client_store_test.go
@@ -54,7 +54,7 @@ func TestStoreSetRangesMaxBytes(t *testing.T) {
 	)
 	defer tc.Stopper().Stop(ctx)
 	store := tc.GetFirstStoreFromServer(t, 0)
-	tdb := sqlutils.MakeSQLRunner(tc.Conns[0])
+	tdb := sqlutils.MakeSQLRunner(tc.ServerConn(0))
 
 	tdb.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.target_duration = '100ms'`) // speeds up the test
 

--- a/pkg/kv/kvserver/consistency_queue_test.go
+++ b/pkg/kv/kvserver/consistency_queue_test.go
@@ -501,7 +501,7 @@ func testConsistencyQueueRecomputeStatsImpl(t *testing.T, hadEstimates bool) {
 		tc := testcluster.StartTestCluster(t, 1, clusterArgs)
 		defer tc.Stopper().Stop(context.Background())
 
-		db0 := tc.Servers[0].DB()
+		db0 := tc.Server(0).DB()
 
 		// Split off a range so that we get away from the timeseries writes, which
 		// pollute the stats with ContainsEstimates=true. Note that the split clears
@@ -561,7 +561,7 @@ func testConsistencyQueueRecomputeStatsImpl(t *testing.T, hadEstimates bool) {
 	tc := testcluster.StartTestCluster(t, numNodes, clusterArgs)
 	defer tc.Stopper().Stop(ctx)
 
-	srv0 := tc.Servers[0]
+	srv0 := tc.Server(0)
 	db0 := srv0.DB()
 
 	// Run a goroutine that writes to the range in a tight loop. This tests that
@@ -611,7 +611,7 @@ func testConsistencyQueueRecomputeStatsImpl(t *testing.T, hadEstimates bool) {
 
 	// The stats should magically repair themselves. We'll first do a quick check
 	// and then a full recomputation.
-	repl, _, err := tc.Servers[0].GetStores().(*kvserver.Stores).GetReplicaForRangeID(ctx, rangeID)
+	repl, _, err := tc.Server(0).GetStores().(*kvserver.Stores).GetReplicaForRangeID(ctx, rangeID)
 	require.NoError(t, err)
 	ms := repl.GetMVCCStats()
 	if ms.SysCount >= sysCountGarbage {

--- a/pkg/kv/kvserver/gossip_test.go
+++ b/pkg/kv/kvserver/gossip_test.go
@@ -42,7 +42,7 @@ func TestGossipFirstRange(t *testing.T) {
 
 	errors := make(chan error, 1)
 	descs := make(chan *roachpb.RangeDescriptor)
-	unregister := tc.Servers[0].GossipI().(*gossip.Gossip).
+	unregister := tc.Server(0).GossipI().(*gossip.Gossip).
 		RegisterCallback(gossip.KeyFirstRangeDescriptor,
 			func(_ string, content roachpb.Value) {
 				var desc roachpb.RangeDescriptor
@@ -172,10 +172,10 @@ func TestGossipHandlesReplacedNode(t *testing.T) {
 	// Take down the first node and replace it with a new one.
 	oldNodeIdx := 0
 	newServerArgs := serverArgs
-	newServerArgs.Addr = tc.Servers[oldNodeIdx].AdvRPCAddr()
-	newServerArgs.SQLAddr = tc.Servers[oldNodeIdx].AdvSQLAddr()
+	newServerArgs.Addr = tc.Server(oldNodeIdx).AdvRPCAddr()
+	newServerArgs.SQLAddr = tc.Server(oldNodeIdx).AdvSQLAddr()
 	newServerArgs.PartOfCluster = true
-	newServerArgs.JoinAddr = tc.Servers[1].AdvRPCAddr()
+	newServerArgs.JoinAddr = tc.Server(1).AdvRPCAddr()
 	log.Infof(ctx, "stopping server %d", oldNodeIdx)
 	tc.StopServer(oldNodeIdx)
 	// We are re-using a hard-coded port. Other processes on the system may by now
@@ -195,7 +195,8 @@ func TestGossipHandlesReplacedNode(t *testing.T) {
 	// Ensure that all servers still running are responsive. If the two remaining
 	// original nodes don't refresh their connection to the address of the first
 	// node, they can get stuck here.
-	for i, server := range tc.Servers {
+	for i := 0; i < tc.NumServers(); i++ {
+		server := tc.Server(i)
 		if i == oldNodeIdx {
 			continue
 		}

--- a/pkg/kv/kvserver/intentresolver/intent_resolver_integration_test.go
+++ b/pkg/kv/kvserver/intentresolver/intent_resolver_integration_test.go
@@ -189,7 +189,7 @@ func TestAsyncIntentResolution_ByteSizePagination(t *testing.T) {
 	}
 
 	// Set the max raft command size to 5MB.
-	st := tc.Servers[0].ClusterSettings()
+	st := tc.Server(0).ClusterSettings()
 	st.Manual.Store(true)
 	kvserverbase.MaxCommandSize.Override(ctx, &st.SV, 5<<20)
 
@@ -284,7 +284,7 @@ func TestSyncIntentResolution_ByteSizePagination(t *testing.T) {
 	}
 
 	// Set the max raft command size to 5MB.
-	st := tc.Servers[0].ClusterSettings()
+	st := tc.Server(0).ClusterSettings()
 	st.Manual.Store(true)
 	kvserverbase.MaxCommandSize.Override(ctx, &st.SV, 5<<20)
 
@@ -334,7 +334,8 @@ func TestSyncIntentResolution_ByteSizePagination(t *testing.T) {
 }
 
 func forceScanOnAllReplicationQueues(tc *testcluster.TestCluster) (err error) {
-	for _, s := range tc.Servers {
+	for i := 0; i < tc.NumServers(); i++ {
+		s := tc.Server(i)
 		err = s.GetStores().(*kvserver.Stores).VisitStores(func(store *kvserver.Store) error {
 			return store.ForceReplicationScanAndProcess()
 		})

--- a/pkg/kv/kvserver/liveness/client_test.go
+++ b/pkg/kv/kvserver/liveness/client_test.go
@@ -162,7 +162,7 @@ func TestNodeLivenessStatusMap(t *testing.T) {
 	ctx = logtags.AddTag(ctx, "in test", nil)
 
 	log.Infof(ctx, "setting zone config to disable replication")
-	if _, err := tc.Conns[0].Exec(`ALTER RANGE meta CONFIGURE ZONE using num_replicas = 1`); err != nil {
+	if _, err := tc.ServerConn(0).Exec(`ALTER RANGE meta CONFIGURE ZONE using num_replicas = 1`); err != nil {
 		t.Fatal(err)
 	}
 
@@ -284,7 +284,7 @@ func TestNodeLivenessDecommissionedCallback(t *testing.T) {
 	tc.Start(t)
 	defer tc.Stopper().Stop(ctx)
 
-	nl1 := tc.Servers[0].NodeLiveness().(*liveness.NodeLiveness)
+	nl1 := tc.Server(0).NodeLiveness().(*liveness.NodeLiveness)
 
 	// Make sure the callback doesn't fire willy-nilly...
 	func() {
@@ -340,7 +340,7 @@ func TestGetActiveNodes(t *testing.T) {
 	defer tc.Stopper().Stop(ctx)
 
 	// At this point StartTestCluster has waited for all nodes to become live.
-	nl1 := tc.Servers[0].NodeLiveness().(*liveness.NodeLiveness)
+	nl1 := tc.Server(0).NodeLiveness().(*liveness.NodeLiveness)
 	require.Equal(t, []roachpb.NodeID{1, 2, 3, 4, 5}, getActiveNodes(nl1))
 
 	// Mark n5 as decommissioning, which should reduce node count.

--- a/pkg/kv/kvserver/loqrecovery/collect_raft_log_test.go
+++ b/pkg/kv/kvserver/loqrecovery/collect_raft_log_test.go
@@ -64,7 +64,7 @@ func TestFindUpdateDescriptor(t *testing.T) {
 			lHSBefore, rHS, err = tc.SplitRange(splitKey)
 			require.NoError(t, err, "failed to split scratch range")
 
-			lHSAfter, err = tc.Servers[0].MergeRanges(scratchKey)
+			lHSAfter, err = tc.Server(0).MergeRanges(scratchKey)
 			require.NoError(t, err, "failed to merge scratch range")
 
 			require.NoError(t,

--- a/pkg/kv/kvserver/replica_closedts_test.go
+++ b/pkg/kv/kvserver/replica_closedts_test.go
@@ -565,7 +565,7 @@ func TestRejectedLeaseDoesntDictateClosedTimestamp(t *testing.T) {
 
 	manual.Pause()
 	// Upreplicate a range.
-	n1, n2 := tc.Servers[0], tc.Servers[1]
+	n1, n2 := tc.Server(0), tc.Server(1)
 	// One of the filters hardcodes a node id.
 	require.Equal(t, roachpb.NodeID(2), n2.NodeID())
 	key := tc.ScratchRangeWithExpirationLease(t)
@@ -919,7 +919,8 @@ func testNonBlockingReadsWithReaderFn(
 	}
 
 	// Reader goroutines: run one reader per store.
-	for _, s := range tc.Servers {
+	for serverIdx := 0; serverIdx < tc.NumServers(); serverIdx++ {
+		s := tc.Server(serverIdx)
 		store, err := s.GetStores().(*kvserver.Stores).GetStore(s.GetFirstStoreID())
 		require.NoError(t, err)
 		g.Go(func() error {

--- a/pkg/kv/kvserver/replica_rangefeed_test.go
+++ b/pkg/kv/kvserver/replica_rangefeed_test.go
@@ -115,7 +115,7 @@ func TestReplicaRangefeed(t *testing.T) {
 	tc := testcluster.StartTestCluster(t, numNodes, args)
 	defer tc.Stopper().Stop(ctx)
 
-	ts := tc.Servers[0]
+	ts := tc.Server(0)
 	firstStore, pErr := ts.GetStores().(*kvserver.Stores).GetStore(ts.GetFirstStoreID())
 	if pErr != nil {
 		t.Fatal(pErr)
@@ -148,7 +148,7 @@ func TestReplicaRangefeed(t *testing.T) {
 	for i := 0; i < numNodes; i++ {
 		stream := newTestStream()
 		streams[i] = stream
-		srv := tc.Servers[i]
+		srv := tc.Server(i)
 		store, err := srv.GetStores().(*kvserver.Stores).GetStore(srv.GetFirstStoreID())
 		if err != nil {
 			t.Fatal(err)
@@ -297,7 +297,7 @@ func TestReplicaRangefeed(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	server1 := tc.Servers[1]
+	server1 := tc.Server(1)
 	store1, pErr := server1.GetStores().(*kvserver.Stores).GetStore(server1.GetFirstStoreID())
 	if pErr != nil {
 		t.Fatal(pErr)
@@ -469,7 +469,7 @@ func TestReplicaRangefeed(t *testing.T) {
 
 	testutils.SucceedsSoon(t, func() error {
 		for i := 0; i < numNodes; i++ {
-			ts := tc.Servers[i]
+			ts := tc.Server(i)
 			store, pErr := ts.GetStores().(*kvserver.Stores).GetStore(ts.GetFirstStoreID())
 			if pErr != nil {
 				t.Fatal(pErr)
@@ -528,7 +528,7 @@ func TestReplicaRangefeedErrors(t *testing.T) {
 			},
 		)
 
-		ts := tc.Servers[0]
+		ts := tc.Server(0)
 		store, pErr := ts.GetStores().(*kvserver.Stores).GetStore(ts.GetFirstStoreID())
 		if pErr != nil {
 			t.Fatal(pErr)
@@ -621,7 +621,7 @@ func TestReplicaRangefeedErrors(t *testing.T) {
 		stream := newTestStream()
 		streamErrC := make(chan error, 1)
 		rangefeedSpan := mkSpan("a", "z")
-		ts := tc.Servers[removeStore]
+		ts := tc.Server(removeStore)
 		store, err := ts.GetStores().(*kvserver.Stores).GetStore(ts.GetFirstStoreID())
 		if err != nil {
 			t.Fatal(err)
@@ -656,7 +656,7 @@ func TestReplicaRangefeedErrors(t *testing.T) {
 		stream := newTestStream()
 		streamErrC := make(chan error, 1)
 		rangefeedSpan := mkSpan("a", "z")
-		ts := tc.Servers[0]
+		ts := tc.Server(0)
 		store, err := ts.GetStores().(*kvserver.Stores).GetStore(ts.GetFirstStoreID())
 		if err != nil {
 			t.Fatal(err)
@@ -687,7 +687,7 @@ func TestReplicaRangefeedErrors(t *testing.T) {
 		tc, rangeID := setup(t, base.TestingKnobs{})
 		defer tc.Stopper().Stop(ctx)
 
-		ts := tc.Servers[0]
+		ts := tc.Server(0)
 		store, err := ts.GetStores().(*kvserver.Stores).GetStore(ts.GetFirstStoreID())
 		if err != nil {
 			t.Fatal(err)
@@ -753,22 +753,23 @@ func TestReplicaRangefeedErrors(t *testing.T) {
 		tc, rangeID := setup(t, base.TestingKnobs{})
 		defer tc.Stopper().Stop(ctx)
 
-		ts2 := tc.Servers[2]
+		ts2 := tc.Server(2)
 		partitionStore, err := ts2.GetStores().(*kvserver.Stores).GetStore(ts2.GetFirstStoreID())
 		if err != nil {
 			t.Fatal(err)
 		}
-		ts := tc.Servers[0]
+		ts := tc.Server(0)
 		firstStore, err := ts.GetStores().(*kvserver.Stores).GetStore(ts.GetFirstStoreID())
 		if err != nil {
 			t.Fatal(err)
 		}
-		secondStore, err := tc.Servers[1].GetStores().(*kvserver.Stores).GetStore(tc.Servers[1].GetFirstStoreID())
+		secondStore, err := tc.Server(1).GetStores().(*kvserver.Stores).GetStore(tc.Server(1).GetFirstStoreID())
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		for _, server := range tc.Servers {
+		for serverIdx := 0; serverIdx < tc.NumServers(); serverIdx++ {
+			server := tc.Server(serverIdx)
 			store, err := server.GetStores().(*kvserver.Stores).GetStore(server.GetFirstStoreID())
 			if err != nil {
 				t.Fatal(err)
@@ -890,7 +891,7 @@ func TestReplicaRangefeedErrors(t *testing.T) {
 		tc, _ := setup(t, knobs)
 		defer tc.Stopper().Stop(ctx)
 
-		ts := tc.Servers[0]
+		ts := tc.Server(0)
 		store, err := ts.GetStores().(*kvserver.Stores).GetStore(ts.GetFirstStoreID())
 		if err != nil {
 			t.Fatal(err)
@@ -959,7 +960,7 @@ func TestReplicaRangefeedErrors(t *testing.T) {
 		tc, _ := setup(t, knobs)
 		defer tc.Stopper().Stop(ctx)
 
-		ts := tc.Servers[0]
+		ts := tc.Server(0)
 		store, err := ts.GetStores().(*kvserver.Stores).GetStore(ts.GetFirstStoreID())
 		if err != nil {
 			t.Fatal(err)
@@ -1033,7 +1034,7 @@ func TestReplicaRangefeedMVCCHistoryMutationError(t *testing.T) {
 		ReplicationMode: base.ReplicationManual,
 	})
 	defer tc.Stopper().Stop(ctx)
-	ts := tc.Servers[0]
+	ts := tc.Server(0)
 	store, err := ts.GetStores().(*kvserver.Stores).GetStore(ts.GetFirstStoreID())
 	require.NoError(t, err)
 	tc.SplitRangeOrFatal(t, splitKey)

--- a/pkg/kv/kvserver/reset_quorum_test.go
+++ b/pkg/kv/kvserver/reset_quorum_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
-	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
@@ -66,7 +65,7 @@ func TestResetQuorum(t *testing.T) {
 	// range on n2, n3, and n4 with n5 as a non-voting replica.
 	setup := func(
 		t *testing.T,
-	) (tc *testcluster.TestCluster, k roachpb.Key, id roachpb.RangeID) {
+	) (tc serverutils.TestClusterInterface, k roachpb.Key, id roachpb.RangeID) {
 		clusterArgs := base.TestClusterArgs{
 			ReplicationMode: base.ReplicationManual,
 			ServerArgs: base.TestServerArgs{
@@ -78,7 +77,7 @@ func TestResetQuorum(t *testing.T) {
 				},
 			},
 		}
-		tc = testcluster.StartTestCluster(t, 5, clusterArgs)
+		tc = serverutils.StartNewTestCluster(t, 5, clusterArgs)
 
 		n1, n2, n3, n4, n5 := 0, 1, 2, 3, 4
 

--- a/pkg/kv/kvserver/scatter_test.go
+++ b/pkg/kv/kvserver/scatter_test.go
@@ -64,7 +64,7 @@ func TestAdminScatterWithDrainingNodes(t *testing.T) {
 	drainingStore := tc.GetFirstStoreFromServer(t, drainingServerIdx)
 
 	// Wait until the non-draining node is aware of the draining node.
-	testutils.SucceedsSoon(t, tc.Servers[drainingServerIdx].HeartbeatNodeLiveness)
+	testutils.SucceedsSoon(t, tc.Server(drainingServerIdx).HeartbeatNodeLiveness)
 	testutils.SucceedsSoon(t, func() error {
 		isDraining, err := nonDrainingStore.GetStoreConfig().StorePool.IsDraining(drainingStore.StoreID())
 		if err != nil {

--- a/pkg/kv/kvserver/single_key_test.go
+++ b/pkg/kv/kvserver/single_key_test.go
@@ -45,7 +45,7 @@ func TestSingleKey(t *testing.T) {
 
 	// Initialize the value for our test key to zero.
 	const key = "test-key"
-	initDB := tc.Servers[0].DB()
+	initDB := tc.Server(0).DB()
 	if err := initDB.Put(ctx, key, 0); err != nil {
 		t.Fatal(err)
 	}
@@ -63,7 +63,7 @@ func TestSingleKey(t *testing.T) {
 	// key. Each worker is configured to talk to a different node in the
 	// cluster.
 	for i := 0; i < num; i++ {
-		db := tc.Servers[i].DB()
+		db := tc.Server(i).DB()
 		go func() {
 			var r result
 			for timeutil.Now().Before(deadline) {

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -186,6 +186,7 @@ go_library(
         "//pkg/server/pgurl",
         "//pkg/server/privchecker",
         "//pkg/server/profiler",
+        "//pkg/server/serverctl",
         "//pkg/server/serverpb",
         "//pkg/server/serverrules",
         "//pkg/server/settingswatcher",

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -130,7 +130,7 @@ type systemAdminServer struct {
 	*adminServer
 
 	nodeLiveness *liveness.NodeLiveness
-	server       *Server
+	server       *topLevelServer
 }
 
 // noteworthyAdminMemoryUsageBytes is the minimum size tracked by the
@@ -161,7 +161,7 @@ func newSystemAdminServer(
 	distSender *kvcoord.DistSender,
 	grpc *grpcServer,
 	drainServer *drainServer,
-	s *Server,
+	s *topLevelServer,
 ) *systemAdminServer {
 	adminServer := newAdminServer(
 		sqlServer,

--- a/pkg/server/auto_upgrade.go
+++ b/pkg/server/auto_upgrade.go
@@ -24,7 +24,7 @@ import (
 )
 
 // startAttemptUpgrade attempts to upgrade cluster version.
-func (s *Server) startAttemptUpgrade(ctx context.Context) error {
+func (s *topLevelServer) startAttemptUpgrade(ctx context.Context) error {
 	return s.stopper.RunAsyncTask(ctx, "auto-upgrade", func(ctx context.Context) {
 		ctx, cancel := s.stopper.WithCancelOnQuiesce(ctx)
 		defer cancel()
@@ -120,7 +120,7 @@ const (
 
 // upgradeStatus lets the main checking loop know if we should do upgrade,
 // keep checking upgrade status, or stop attempting upgrade.
-func (s *Server) upgradeStatus(
+func (s *topLevelServer) upgradeStatus(
 	ctx context.Context, clusterVersion string,
 ) (st upgradeStatus, err error) {
 	nodes, err := s.status.ListNodesInternal(ctx, nil)
@@ -205,7 +205,7 @@ func (s *Server) upgradeStatus(
 // clusterVersion returns the current cluster version from the SQL subsystem
 // (which returns the version from the KV store as opposed to the possibly
 // lagging settings subsystem).
-func (s *Server) clusterVersion(ctx context.Context) (string, error) {
+func (s *topLevelServer) clusterVersion(ctx context.Context) (string, error) {
 	row, err := s.sqlServer.internalExecutor.QueryRowEx(
 		ctx, "show-version", nil, /* txn */
 		sessiondata.RootUserSessionDataOverride,

--- a/pkg/server/clock_monotonicity.go
+++ b/pkg/server/clock_monotonicity.go
@@ -45,7 +45,7 @@ var (
 
 // startMonitoringForwardClockJumps starts a background task to monitor forward
 // clock jumps based on a cluster setting.
-func (s *Server) startMonitoringForwardClockJumps(ctx context.Context) error {
+func (s *topLevelServer) startMonitoringForwardClockJumps(ctx context.Context) error {
 	forwardJumpCheckEnabled := make(chan bool, 1)
 	s.stopper.AddCloser(stop.CloserFn(func() { close(forwardJumpCheckEnabled) }))
 
@@ -69,7 +69,7 @@ func (s *Server) startMonitoringForwardClockJumps(ctx context.Context) error {
 // checkHLCUpperBoundExists determines whether there's an HLC
 // upper bound that will need to refreshed/persisted after
 // the server has initialized.
-func (s *Server) checkHLCUpperBoundExistsAndEnsureMonotonicity(
+func (s *topLevelServer) checkHLCUpperBoundExistsAndEnsureMonotonicity(
 	ctx context.Context, initialStart bool,
 ) (hlcUpperBoundExists bool, err error) {
 	if initialStart {
@@ -238,7 +238,9 @@ func periodicallyPersistHLCUpperBound(
 //
 // tickCallback is called whenever persistHLCUpperBoundCh or a ticker tick is
 // processed
-func (s *Server) startPersistingHLCUpperBound(ctx context.Context, hlcUpperBoundExists bool) error {
+func (s *topLevelServer) startPersistingHLCUpperBound(
+	ctx context.Context, hlcUpperBoundExists bool,
+) error {
 	tickerFn := time.NewTicker
 	persistHLCUpperBoundFn := func(t int64) error { /* function to persist upper bound of HLC to all stores */
 		return s.node.SetHLCUpperBound(context.Background(), t)

--- a/pkg/server/connectivity_test.go
+++ b/pkg/server/connectivity_test.go
@@ -337,7 +337,7 @@ func TestJoinVersionGate(t *testing.T) {
 
 	oldVersionServerArgs := commonArg
 	oldVersionServerArgs.Knobs = knobs
-	oldVersionServerArgs.JoinAddr = tc.Servers[0].AdvRPCAddr()
+	oldVersionServerArgs.JoinAddr = tc.Server(0).AdvRPCAddr()
 
 	serv, err := tc.AddServer(oldVersionServerArgs)
 	if err != nil {
@@ -374,7 +374,7 @@ func TestDecommissionedNodeCannotConnect(t *testing.T) {
 	for _, status := range []livenesspb.MembershipStatus{
 		livenesspb.MembershipStatus_DECOMMISSIONING, livenesspb.MembershipStatus_DECOMMISSIONED,
 	} {
-		require.NoError(t, tc.Servers[0].Decommission(ctx, status, []roachpb.NodeID{decomSrv.NodeID()}))
+		require.NoError(t, tc.Server(0).Decommission(ctx, status, []roachpb.NodeID{decomSrv.NodeID()}))
 	}
 
 	testutils.SucceedsSoon(t, func() error {

--- a/pkg/server/decommission.go
+++ b/pkg/server/decommission.go
@@ -141,7 +141,7 @@ func getPingCheckDecommissionFn(
 // or remove actions. If maxErrors >0, range checks will stop once maxError is
 // reached.
 // The error returned is a gRPC error.
-func (s *Server) DecommissionPreCheck(
+func (s *topLevelServer) DecommissionPreCheck(
 	ctx context.Context,
 	nodeIDs []roachpb.NodeID,
 	strictReadiness bool,
@@ -314,7 +314,7 @@ func evaluateRangeCheckResult(
 
 // Decommission idempotently sets the decommissioning flag for specified nodes.
 // The error return is a gRPC error.
-func (s *Server) Decommission(
+func (s *topLevelServer) Decommission(
 	ctx context.Context, targetStatus livenesspb.MembershipStatus, nodeIDs []roachpb.NodeID,
 ) error {
 	// If we're asked to decommission ourself we may lose access to cluster RPC,
@@ -396,7 +396,7 @@ func (s *Server) Decommission(
 
 // DecommissioningNodeMap returns the set of node IDs that are decommissioning
 // from the perspective of the server.
-func (s *Server) DecommissioningNodeMap() map[roachpb.NodeID]interface{} {
+func (s *topLevelServer) DecommissioningNodeMap() map[roachpb.NodeID]interface{} {
 	s.decomNodeMap.RLock()
 	defer s.decomNodeMap.RUnlock()
 	nodes := make(map[roachpb.NodeID]interface{})

--- a/pkg/server/drain.go
+++ b/pkg/server/drain.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/server/serverctl"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/server/srverrors"
 	"github.com/cockroachdb/cockroach/pkg/settings"
@@ -197,7 +198,7 @@ func (s *drainServer) maybeShutdownAfterDrain(
 		// away (and who knows whether gRPC-goroutines are tied up in some
 		// stopper task somewhere).
 		s.grpc.Stop()
-		s.stopTrigger.signalStop(ctx, MakeShutdownRequest(ShutdownReasonDrainRPC, nil /* err */))
+		s.stopTrigger.signalStop(ctx, serverctl.MakeShutdownRequest(serverctl.ShutdownReasonDrainRPC, nil /* err */))
 	}()
 
 	select {

--- a/pkg/server/drain_test.go
+++ b/pkg/server/drain_test.go
@@ -166,7 +166,7 @@ INSERT INTO t.test VALUES (3);
 
 type testDrainContext struct {
 	*testing.T
-	tc         *testcluster.TestCluster
+	tc         serverutils.TestClusterInterface
 	c          serverpb.AdminClient
 	connCloser func()
 }

--- a/pkg/server/import_ts.go
+++ b/pkg/server/import_ts.go
@@ -38,7 +38,7 @@ import (
 // to be written to the DB.
 const maxBatchSize = 10000
 
-func maybeImportTS(ctx context.Context, s *Server) (returnErr error) {
+func maybeImportTS(ctx context.Context, s *topLevelServer) (returnErr error) {
 	// We don't want to do startup retries as this is not meant to be run in
 	// production.
 	ctx = startup.WithoutChecks(ctx)

--- a/pkg/server/initial_sql.go
+++ b/pkg/server/initial_sql.go
@@ -29,7 +29,7 @@ import (
 // and `cockroach demo` with 2 nodes or fewer.
 // If adminUser is non-empty, an admin user with that name is
 // created upon initialization. Its password is then also returned.
-func (s *Server) RunInitialSQL(
+func (s *topLevelServer) RunInitialSQL(
 	ctx context.Context, startSingleNode bool, adminUser, adminPassword string,
 ) error {
 	if s.cfg.ObsServiceAddr == base.ObsServiceEmbedFlagValue {
@@ -75,7 +75,9 @@ func (s *SQLServerWrapper) RunInitialSQL(context.Context, bool, string, string) 
 }
 
 // createAdminUser creates an admin user with the given name.
-func (s *Server) createAdminUser(ctx context.Context, adminUser, adminPassword string) error {
+func (s *topLevelServer) createAdminUser(
+	ctx context.Context, adminUser, adminPassword string,
+) error {
 	ie := s.sqlServer.internalExecutor
 	_, err := ie.Exec(
 		ctx, "admin-user", nil,
@@ -97,7 +99,7 @@ func (s *Server) createAdminUser(ctx context.Context, adminUser, adminPassword s
 //
 // The change is effected using the internal SQL interface of the
 // given server object.
-func (s *Server) disableReplication(ctx context.Context) (retErr error) {
+func (s *topLevelServer) disableReplication(ctx context.Context) (retErr error) {
 	ie := s.sqlServer.internalExecutor
 
 	it, err := ie.QueryIterator(ctx, "get-zones", nil,

--- a/pkg/server/loss_of_quorum.go
+++ b/pkg/server/loss_of_quorum.go
@@ -93,7 +93,7 @@ func maybeRunLossOfQuorumRecoveryCleanup(
 	ctx context.Context,
 	ie isql.Executor,
 	stores *kvserver.Stores,
-	server *Server,
+	server *topLevelServer,
 	stopper *stop.Stopper,
 ) {
 	publishCtx, publishCancel := stopper.WithCancelOnQuiesce(ctx)

--- a/pkg/server/migration.go
+++ b/pkg/server/migration.go
@@ -29,7 +29,7 @@ import (
 // migrationServer is an implementation of the Migration service. The RPCs here
 // are used to power the upgrades infrastructure in pkg/upgrades.
 type migrationServer struct {
-	server *Server
+	server *topLevelServer
 
 	// We use this mutex to serialize attempts to bump the cluster version.
 	syncutil.Mutex

--- a/pkg/server/multi_store_test.go
+++ b/pkg/server/multi_store_test.go
@@ -99,7 +99,8 @@ func TestAddNewStoresToExistingNodes(t *testing.T) {
 
 	// Sanity check that we're testing what we wanted to test and didn't accidentally
 	// bootstrap three single-node clusters (who knows).
-	for _, srv := range tc.Servers {
+	for serverIdx := 0; serverIdx < tc.NumServers(); serverIdx++ {
+		srv := tc.Server(serverIdx)
 		require.Equal(t, clusterID, srv.StorageClusterID())
 	}
 
@@ -107,7 +108,8 @@ func TestAddNewStoresToExistingNodes(t *testing.T) {
 	// store ID.
 	testutils.SucceedsSoon(t, func() error {
 		var storeIDs []roachpb.StoreID
-		for _, server := range tc.Servers {
+		for serverIdx := 0; serverIdx < tc.NumServers(); serverIdx++ {
+			server := tc.Server(serverIdx)
 			var storeCount = 0
 			if err := server.GetStores().(*kvserver.Stores).VisitStores(
 				func(s *kvserver.Store) error {
@@ -169,7 +171,8 @@ func TestMultiStoreIDAlloc(t *testing.T) {
 	// Sanity check that we're testing what we wanted to test and didn't accidentally
 	// bootstrap three single-node clusters (who knows).
 	clusterID := tc.Server(0).StorageClusterID()
-	for _, srv := range tc.Servers {
+	for serverIdx := 0; serverIdx < tc.NumServers(); serverIdx++ {
+		srv := tc.Server(serverIdx)
 		require.Equal(t, clusterID, srv.StorageClusterID())
 	}
 
@@ -177,7 +180,8 @@ func TestMultiStoreIDAlloc(t *testing.T) {
 	// store ID.
 	testutils.SucceedsSoon(t, func() error {
 		var storeIDs []roachpb.StoreID
-		for _, server := range tc.Servers {
+		for serverIdx := 0; serverIdx < tc.NumServers(); serverIdx++ {
+			server := tc.Server(serverIdx)
 			var storeCount = 0
 			if err := server.GetStores().(*kvserver.Stores).VisitStores(
 				func(s *kvserver.Store) error {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -72,6 +72,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server/debug"
 	"github.com/cockroachdb/cockroach/pkg/server/diagnostics"
 	"github.com/cockroachdb/cockroach/pkg/server/privchecker"
+	"github.com/cockroachdb/cockroach/pkg/server/serverctl"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/server/serverrules"
 	"github.com/cockroachdb/cockroach/pkg/server/status"
@@ -130,8 +131,8 @@ import (
 	"google.golang.org/grpc/codes"
 )
 
-// Server is the cockroach server node.
-type Server struct {
+// topLevelServer is the cockroach server node.
+type topLevelServer struct {
 	// The following fields are populated in NewServer.
 
 	nodeIDContainer *base.NodeIDContainer
@@ -225,7 +226,7 @@ type Server struct {
 //
 // The caller is responsible for listening on the server's ShutdownRequested()
 // channel and calling stopper.Stop().
-func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
+func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterface, error) {
 	ctx := cfg.AmbientCtx.AnnotateCtx(context.Background())
 
 	if err := cfg.ValidateAddrs(ctx); err != nil {
@@ -946,7 +947,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		db, node.stores, storePool, st, nodeLiveness, internalExecutor, systemConfigWatcher,
 	)
 
-	lateBoundServer := &Server{}
+	lateBoundServer := &topLevelServer{}
 
 	// The following initialization is mirrored in NewTenantServer().
 	// Please keep them in sync.
@@ -1261,7 +1262,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		},
 	)
 
-	*lateBoundServer = Server{
+	*lateBoundServer = topLevelServer{
 		nodeIDContainer:           nodeIDContainer,
 		cfg:                       cfg,
 		st:                        st,
@@ -1319,36 +1320,36 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 }
 
 // ClusterSettings returns the cluster settings.
-func (s *Server) ClusterSettings() *cluster.Settings {
+func (s *topLevelServer) ClusterSettings() *cluster.Settings {
 	return s.st
 }
 
 // AnnotateCtx is a convenience wrapper; see AmbientContext.
-func (s *Server) AnnotateCtx(ctx context.Context) context.Context {
+func (s *topLevelServer) AnnotateCtx(ctx context.Context) context.Context {
 	return s.cfg.AmbientCtx.AnnotateCtx(ctx)
 }
 
 // AnnotateCtxWithSpan is a convenience wrapper; see AmbientContext.
-func (s *Server) AnnotateCtxWithSpan(
+func (s *topLevelServer) AnnotateCtxWithSpan(
 	ctx context.Context, opName string,
 ) (context.Context, *tracing.Span) {
 	return s.cfg.AmbientCtx.AnnotateCtxWithSpan(ctx, opName)
 }
 
 // StorageClusterID returns the ID of the storage cluster this server is a part of.
-func (s *Server) StorageClusterID() uuid.UUID {
+func (s *topLevelServer) StorageClusterID() uuid.UUID {
 	return s.rpcContext.StorageClusterID.Get()
 }
 
 // NodeID returns the ID of this node within its cluster.
-func (s *Server) NodeID() roachpb.NodeID {
+func (s *topLevelServer) NodeID() roachpb.NodeID {
 	return s.node.Descriptor.NodeID
 }
 
 // InitialStart returns whether this is the first time the node has started (as
 // opposed to being restarted). Only intended to help print debugging info
 // during server startup.
-func (s *Server) InitialStart() bool {
+func (s *topLevelServer) InitialStart() bool {
 	return s.node.initialStart
 }
 
@@ -1401,7 +1402,7 @@ func (li listenerInfo) Iter() map[string]string {
 //
 // The passed context can be used to trace the server startup. The context
 // should represent the general startup operation.
-func (s *Server) PreStart(ctx context.Context) error {
+func (s *topLevelServer) PreStart(ctx context.Context) error {
 	ctx = s.AnnotateCtx(ctx)
 	done := startup.Begin(ctx)
 	defer done()
@@ -2173,7 +2174,7 @@ func (s *Server) PreStart(ctx context.Context) error {
 // AcceptClients starts listening for incoming SQL clients over the network.
 // This mirrors the implementation of (*SQLServerWrapper).AcceptClients.
 // TODO(knz): Find a way to implement this method only once for both.
-func (s *Server) AcceptClients(ctx context.Context) error {
+func (s *topLevelServer) AcceptClients(ctx context.Context) error {
 	workersCtx := s.AnnotateCtx(context.Background())
 
 	if err := startServeSQL(
@@ -2205,7 +2206,7 @@ func (s *Server) AcceptClients(ctx context.Context) error {
 
 // AcceptInternalClients starts listening for incoming SQL connections on the
 // internal loopback interface.
-func (s *Server) AcceptInternalClients(ctx context.Context) error {
+func (s *topLevelServer) AcceptInternalClients(ctx context.Context) error {
 	connManager := netutil.MakeTCPServer(ctx, s.stopper)
 
 	return s.stopper.RunAsyncTaskEx(ctx,
@@ -2231,34 +2232,34 @@ func (s *Server) AcceptInternalClients(ctx context.Context) error {
 
 // ShutdownRequested returns a channel that is signaled when a subsystem wants
 // the server to be shut down.
-func (s *Server) ShutdownRequested() <-chan ShutdownRequest {
+func (s *topLevelServer) ShutdownRequested() <-chan serverctl.ShutdownRequest {
 	return s.stopTrigger.C()
 }
 
 // TempDir returns the filepath of the temporary directory used for temp storage.
 // It is empty for an in-memory temp storage.
-func (s *Server) TempDir() string {
+func (s *topLevelServer) TempDir() string {
 	return s.cfg.TempStorageConfig.Path
 }
 
 // PGServer exports the pgwire server. Used by tests.
-func (s *Server) PGServer() *pgwire.Server {
+func (s *topLevelServer) PGServer() *pgwire.Server {
 	return s.sqlServer.pgServer
 }
 
 // SpanConfigReporter returns the spanconfig.Reporter. Used by tests.
-func (s *Server) SpanConfigReporter() spanconfig.Reporter {
+func (s *topLevelServer) SpanConfigReporter() spanconfig.Reporter {
 	return s.spanConfigReporter
 }
 
 // LogicalClusterID implements cli.serverStartupInterface. This
 // implementation exports the logical cluster ID of the system tenant.
-func (s *Server) LogicalClusterID() uuid.UUID {
+func (s *topLevelServer) LogicalClusterID() uuid.UUID {
 	return s.sqlServer.LogicalClusterID()
 }
 
 // startDiagnostics starts periodic diagnostics reporting and update checking.
-func (s *Server) startDiagnostics(ctx context.Context) {
+func (s *topLevelServer) startDiagnostics(ctx context.Context) {
 	s.updates.PeriodicallyCheckForUpdates(ctx, s.stopper)
 	s.sqlServer.StartDiagnostics(ctx)
 }
@@ -2268,12 +2269,12 @@ func init() {
 }
 
 // Insecure returns true iff the server has security disabled.
-func (s *Server) Insecure() bool {
+func (s *topLevelServer) Insecure() bool {
 	return s.cfg.Insecure
 }
 
 // TenantCapabilitiesReader returns the Server's tenantcapabilities.Reader.
-func (s *Server) TenantCapabilitiesReader() tenantcapabilities.Reader {
+func (s *topLevelServer) TenantCapabilitiesReader() tenantcapabilities.Reader {
 	return s.tenantCapabilitiesWatcher
 }
 
@@ -2292,7 +2293,7 @@ func (s *Server) TenantCapabilitiesReader() tenantcapabilities.Reader {
 // TODO(knz): This method is currently exported for use by the
 // shutdown code in cli/start.go; however, this is a mis-design. The
 // start code should use the Drain() RPC like quit does.
-func (s *Server) Drain(
+func (s *topLevelServer) Drain(
 	ctx context.Context, verbose bool,
 ) (remaining uint64, info redact.RedactableString, err error) {
 	return s.drain.runDrain(ctx, verbose)

--- a/pkg/server/server_controller.go
+++ b/pkg/server/server_controller.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/server/serverctl"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgwirecancel"
@@ -175,7 +176,7 @@ func (s *tenantServerWrapper) getInstanceID() base.SQLInstanceID {
 	return s.server.sqlServer.sqlIDContainer.SQLInstanceID()
 }
 
-func (s *tenantServerWrapper) shutdownRequested() <-chan ShutdownRequest {
+func (s *tenantServerWrapper) shutdownRequested() <-chan serverctl.ShutdownRequest {
 	return s.server.sqlServer.ShutdownRequested()
 }
 
@@ -196,7 +197,7 @@ func (s *tenantServerWrapper) gracefulDrain(
 // We do not implement the onDemandServer interface methods on *Server
 // directly so as to not add noise to its go documentation.
 type systemServerWrapper struct {
-	server *Server
+	server *topLevelServer
 }
 
 var _ onDemandServer = (*systemServerWrapper)(nil)
@@ -236,7 +237,7 @@ func (s *systemServerWrapper) getInstanceID() base.SQLInstanceID {
 	return base.SQLInstanceID(s.server.nodeIDContainer.Get())
 }
 
-func (s *systemServerWrapper) shutdownRequested() <-chan ShutdownRequest {
+func (s *systemServerWrapper) shutdownRequested() <-chan serverctl.ShutdownRequest {
 	return nil
 }
 

--- a/pkg/server/server_controller_new_server.go
+++ b/pkg/server/server_controller_new_server.go
@@ -61,10 +61,10 @@ type tenantServerCreator interface {
 	) (onDemandServer, error)
 }
 
-var _ tenantServerCreator = &Server{}
+var _ tenantServerCreator = &topLevelServer{}
 
 // newTenantServer implements the tenantServerCreator interface.
-func (s *Server) newTenantServer(
+func (s *topLevelServer) newTenantServer(
 	ctx context.Context,
 	tenantNameContainer *roachpb.TenantNameContainer,
 	tenantStopper *stop.Stopper,
@@ -103,7 +103,7 @@ func (errInvalidTenantMarker) Error() string { return "invalid tenant" }
 // is not shared.
 var ErrInvalidTenant error = errInvalidTenantMarker{}
 
-func (s *Server) getTenantID(
+func (s *topLevelServer) getTenantID(
 	ctx context.Context, tenantName roachpb.TenantName,
 ) (roachpb.TenantID, error) {
 	var rec *mtinfopb.TenantInfo
@@ -149,7 +149,7 @@ func newTenantServerInternal(
 	return newSharedProcessTenantServer(newCtx, stopper, baseCfg, sqlCfg, tenantNameContainer)
 }
 
-func (s *Server) makeSharedProcessTenantConfig(
+func (s *topLevelServer) makeSharedProcessTenantConfig(
 	ctx context.Context, tenantID roachpb.TenantID, index int, stopper *stop.Stopper,
 ) (BaseConfig, SQLConfig, error) {
 	// Create a configuration for the new tenant.

--- a/pkg/server/server_controller_orchestration_method.go
+++ b/pkg/server/server_controller_orchestration_method.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/server/serverctl"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/redact"
 )
@@ -90,7 +91,7 @@ type orchestratedServer interface {
 	// shutdownRequested returns the shutdown request channel,
 	// which is triggered when the server encounters an internal
 	// condition or receives an external RPC that requires it to shut down.
-	shutdownRequested() <-chan ShutdownRequest
+	shutdownRequested() <-chan serverctl.ShutdownRequest
 
 	// gracefulDrain drains the server. It should be called repeatedly
 	// until the first value reaches zero.

--- a/pkg/server/server_controller_test.go
+++ b/pkg/server/server_controller_test.go
@@ -37,7 +37,7 @@ func TestServerController(t *testing.T) {
 
 	d, err := ts.serverController.getServer(ctx, "system")
 	require.NoError(t, err)
-	if d.(*systemServerWrapper).server != ts.Server {
+	if d.(*systemServerWrapper).server != ts.topLevelServer {
 		t.Fatal("expected wrapped system server")
 	}
 

--- a/pkg/server/server_obs_service.go
+++ b/pkg/server/server_obs_service.go
@@ -31,7 +31,7 @@ import (
 // startEmbeddedObsService creates the schema for the Observability Service (if
 // it doesn't exist already), starts the internal RPC service for event
 // ingestion and hooks up the event exporter to talk to the local service.
-func (s *Server) startEmbeddedObsService(
+func (s *topLevelServer) startEmbeddedObsService(
 	ctx context.Context, knobs *obs.EventExporterTestingKnobs,
 ) error {
 	// Create the Obs Service schema.

--- a/pkg/server/server_special_test.go
+++ b/pkg/server/server_special_test.go
@@ -127,7 +127,7 @@ func TestInternalSQL(t *testing.T) {
 	conf.User = "root"
 	// Configure pgx to connect on the loopback listener.
 	conf.DialFunc = func(ctx context.Context, network, addr string) (net.Conn, error) {
-		return s.(*testServer).Server.loopbackPgL.Connect(ctx)
+		return s.(*testServer).topLevelServer.loopbackPgL.Connect(ctx)
 	}
 	conn, err := pgx.ConnectConfig(ctx, conf)
 	require.NoError(t, err)

--- a/pkg/server/serverctl/BUILD.bazel
+++ b/pkg/server/serverctl/BUILD.bazel
@@ -1,0 +1,17 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "serverctl",
+    srcs = [
+        "api.go",
+        "shutdown.go",
+    ],
+    importpath = "github.com/cockroachdb/cockroach/pkg/server/serverctl",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/settings/cluster",
+        "//pkg/util/uuid",
+        "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
+    ],
+)

--- a/pkg/server/serverctl/api.go
+++ b/pkg/server/serverctl/api.go
@@ -1,0 +1,89 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package serverctl
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+	"github.com/cockroachdb/redact"
+)
+
+type ServerStartupInterface interface {
+	ServerShutdownInterface
+
+	// ClusterSettings retrieves this server's settings.
+	ClusterSettings() *cluster.Settings
+
+	// LogicalClusterID retrieves this server's logical cluster ID.
+	LogicalClusterID() uuid.UUID
+
+	// PreStart starts the server on the specified port(s) and
+	// initializes subsystems.
+	// It does not activate the pgwire listener over the network / unix
+	// socket, which is done by the AcceptClients() method. The separation
+	// between the two exists so that SQL initialization can take place
+	// before the first client is accepted.
+	PreStart(ctx context.Context) error
+
+	// AcceptClients starts listening for incoming SQL clients over the network.
+	AcceptClients(ctx context.Context) error
+	// AcceptInternalClients starts listening for incoming internal SQL clients over the
+	// loopback interface.
+	AcceptInternalClients(ctx context.Context) error
+
+	// InitialStart returns whether this node is starting for the first time.
+	// This is (currently) used when displaying the server status report
+	// on the terminal & in logs. We know that some folk have automation
+	// that depend on certain strings displayed from this when orchestrating
+	// KV-only nodes.
+	InitialStart() bool
+
+	// RunInitialSQL runs the SQL initialization for brand new clusters,
+	// if the cluster is being started for the first time.
+	// The arguments are:
+	// - startSingleNode is used by 'demo' and 'start-single-node'.
+	// - adminUser/adminPassword is used for 'demo'.
+	RunInitialSQL(ctx context.Context, startSingleNode bool, adminUser, adminPassword string) error
+}
+
+// serverShutdownInterface is the subset of the APIs on a server
+// object that's sufficient to run a server shutdown.
+type ServerShutdownInterface interface {
+	AnnotateCtx(context.Context) context.Context
+	Drain(ctx context.Context, verbose bool) (uint64, redact.RedactableString, error)
+	ShutdownRequested() <-chan ShutdownRequest
+}
+
+// ShutdownRequest is used to signal a request to shutdown the server through
+// stopTrigger. It carries the reason for the shutdown.
+type ShutdownRequest struct {
+	// Reason identifies the cause of the shutdown.
+	Reason ShutdownReason
+	// Err is populated for reason ServerStartupError and FatalError.
+	Err error
+}
+
+// ShutdownReason identifies the reason for a ShutdownRequest.
+type ShutdownReason int
+
+const (
+	// ShutdownReasonDrainRPC represents a drain RPC with the shutdown flag set.
+	ShutdownReasonDrainRPC ShutdownReason = iota
+	// ShutdownReasonServerStartupError means that the server startup process
+	// failed.
+	ShutdownReasonServerStartupError
+	// ShutdownReasonFatalError identifies an error that requires the server be
+	// terminated. Compared to a panic or log.Fatal(), the termination can be more
+	// graceful, though.
+	ShutdownReasonFatalError
+)

--- a/pkg/server/serverctl/shutdown.go
+++ b/pkg/server/serverctl/shutdown.go
@@ -1,0 +1,39 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package serverctl
+
+import "github.com/cockroachdb/errors"
+
+// ShutdownCause returns the reason for the shutdown request, as an error.
+func (r ShutdownRequest) ShutdownCause() error {
+	switch r.Reason {
+	case ShutdownReasonDrainRPC:
+		return errors.Newf("shutdown requested by drain RPC")
+	default:
+		return r.Err
+	}
+}
+
+// Empty returns true if the receiver is the zero value.
+func (r ShutdownRequest) Empty() bool {
+	return r == (ShutdownRequest{})
+}
+
+// MakeShutdownRequest constructs a serverctl.ShutdownRequest.
+func MakeShutdownRequest(reason ShutdownReason, err error) ShutdownRequest {
+	if reason == ShutdownReasonDrainRPC && err != nil {
+		panic(errors.NewAssertionErrorWithWrappedErrf(err, "programming error: unexpected err for ShutdownReasonDrainRPC"))
+	}
+	return ShutdownRequest{
+		Reason: reason,
+		Err:    err,
+	}
+}

--- a/pkg/server/settings_cache_test.go
+++ b/pkg/server/settings_cache_test.go
@@ -109,7 +109,7 @@ func TestCachedSettingsServerRestart(t *testing.T) {
 	{
 		getDialOpts := s.RPCContext().GRPCDialOptions
 
-		initConfig := newInitServerConfig(ctx, s.(*testServer).Server.cfg, getDialOpts)
+		initConfig := newInitServerConfig(ctx, s.(*testServer).topLevelServer.cfg, getDialOpts)
 		inspectState, err := inspectEngines(
 			context.Background(),
 			s.Engines(),

--- a/pkg/server/stop_trigger.go
+++ b/pkg/server/stop_trigger.go
@@ -13,9 +13,9 @@ package server
 import (
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/server/serverctl"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
-	"github.com/cockroachdb/errors"
 )
 
 // stopTrigger is used by modules to signal the desire to stop the server. When
@@ -23,22 +23,22 @@ import (
 type stopTrigger struct {
 	mu struct {
 		syncutil.Mutex
-		shutdownRequest ShutdownRequest
+		shutdownRequest serverctl.ShutdownRequest
 	}
-	c chan ShutdownRequest
+	c chan serverctl.ShutdownRequest
 }
 
 func newStopTrigger() *stopTrigger {
 	return &stopTrigger{
 		// The channel is buffered so that there's no requirement that anyone ever
 		// calls C() and reads from this channel.
-		c: make(chan ShutdownRequest, 1),
+		c: make(chan serverctl.ShutdownRequest, 1),
 	}
 }
 
 // signalStop is used to signal that the server should shut down. The shutdown
 // is asynchronous.
-func (s *stopTrigger) signalStop(ctx context.Context, r ShutdownRequest) {
+func (s *stopTrigger) signalStop(ctx context.Context, r serverctl.ShutdownRequest) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if !s.mu.shutdownRequest.Empty() {
@@ -52,60 +52,10 @@ func (s *stopTrigger) signalStop(ctx context.Context, r ShutdownRequest) {
 	s.c <- r
 }
 
-// ShutdownRequest is used to signal a request to shutdown the server through
-// stopTrigger. It carries the reason for the shutdown.
-type ShutdownRequest struct {
-	// Reason identifies the cause of the shutdown.
-	Reason ShutdownReason
-	// Err is populated for reason ServerStartupError and FatalError.
-	Err error
-}
-
-// MakeShutdownRequest constructs a ShutdownRequest.
-func MakeShutdownRequest(reason ShutdownReason, err error) ShutdownRequest {
-	if reason == ShutdownReasonDrainRPC && err != nil {
-		panic(errors.NewAssertionErrorWithWrappedErrf(err, "programming error: unexpected err for ShutdownReasonDrainRPC"))
-	}
-	return ShutdownRequest{
-		Reason: reason,
-		Err:    err,
-	}
-}
-
-// ShutdownReason identifies the reason for a ShutdownRequest.
-type ShutdownReason int
-
-const (
-	// ShutdownReasonDrainRPC represents a drain RPC with the shutdown flag set.
-	ShutdownReasonDrainRPC ShutdownReason = iota
-	// ShutdownReasonServerStartupError means that the server startup process
-	// failed.
-	ShutdownReasonServerStartupError
-	// ShutdownReasonFatalError identifies an error that requires the server be
-	// terminated. Compared to a panic or log.Fatal(), the termination can be more
-	// graceful, though.
-	ShutdownReasonFatalError
-)
-
-// ShutdownCause returns the reason for the shutdown request, as an error.
-func (r ShutdownRequest) ShutdownCause() error {
-	switch r.Reason {
-	case ShutdownReasonDrainRPC:
-		return errors.Newf("shutdown requested by drain RPC")
-	default:
-		return r.Err
-	}
-}
-
 // C returns the channel that is signaled by signaledStop().
 //
 // Generally, there should be only one caller to C(); shutdown requests are
 // delivered once, not broadcast.
-func (s *stopTrigger) C() <-chan ShutdownRequest {
+func (s *stopTrigger) C() <-chan serverctl.ShutdownRequest {
 	return s.c
-}
-
-// Empty returns true if the receiver is the zero value.
-func (r ShutdownRequest) Empty() bool {
-	return r == (ShutdownRequest{})
 }

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -51,6 +51,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server/authserver"
 	"github.com/cockroachdb/cockroach/pkg/server/debug"
 	"github.com/cockroachdb/cockroach/pkg/server/privchecker"
+	"github.com/cockroachdb/cockroach/pkg/server/serverctl"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/server/status"
 	"github.com/cockroachdb/cockroach/pkg/server/structlogging"
@@ -958,7 +959,7 @@ func (s *SQLServerWrapper) InitialStart() bool {
 
 // ShutdownRequested returns a channel that is signaled when a subsystem wants
 // the server to be shut down.
-func (s *SQLServerWrapper) ShutdownRequested() <-chan ShutdownRequest {
+func (s *SQLServerWrapper) ShutdownRequested() <-chan serverctl.ShutdownRequest {
 	return s.sqlServer.ShutdownRequested()
 }
 

--- a/pkg/spanconfig/spanconfigtestutils/spanconfigtestcluster/BUILD.bazel
+++ b/pkg/spanconfig/spanconfigtestutils/spanconfigtestcluster/BUILD.bazel
@@ -32,7 +32,6 @@ go_library(
         "//pkg/testutils",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/sqlutils",
-        "//pkg/testutils/testcluster",
         "//pkg/util/hlc",
         "//pkg/util/syncutil",
         "//pkg/util/uuid",

--- a/pkg/spanconfig/spanconfigtestutils/spanconfigtestcluster/cluster.go
+++ b/pkg/spanconfig/spanconfigtestutils/spanconfigtestcluster/cluster.go
@@ -22,8 +22,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/spanconfig/spanconfigtestutils"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
-	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
@@ -33,14 +33,14 @@ import (
 // span config primitives. It's not safe for concurrent use.
 type Handle struct {
 	t       *testing.T
-	tc      *testcluster.TestCluster
+	tc      serverutils.TestClusterInterface
 	ts      map[roachpb.TenantID]*Tenant
 	scKnobs *spanconfig.TestingKnobs
 }
 
 // NewHandle returns a new Handle.
 func NewHandle(
-	t *testing.T, tc *testcluster.TestCluster, scKnobs *spanconfig.TestingKnobs,
+	t *testing.T, tc serverutils.TestClusterInterface, scKnobs *spanconfig.TestingKnobs,
 ) *Handle {
 	return &Handle{
 		t:       t,

--- a/pkg/sql/ambiguous_commit_test.go
+++ b/pkg/sql/ambiguous_commit_test.go
@@ -154,13 +154,14 @@ func TestAmbiguousCommit(t *testing.T) {
 
 		// Avoid distSQL so we can reliably hydrate the intended dist
 		// sender's cache below.
-		for _, server := range tc.Servers {
+		for serverIdx := 0; serverIdx < tc.NumServers(); serverIdx++ {
+			server := tc.Server(serverIdx)
 			st := server.ClusterSettings()
 			st.Manual.Store(true)
 			sql.DistSQLClusterExecMode.Override(ctx, &st.SV, int64(sessiondatapb.DistSQLOff))
 		}
 
-		sqlDB := tc.Conns[0]
+		sqlDB := tc.ServerConn(0)
 
 		if _, err := sqlDB.Exec(`CREATE DATABASE test`); err != nil {
 			t.Fatal(err)

--- a/pkg/sql/catalog/lease/lease_test.go
+++ b/pkg/sql/catalog/lease/lease_test.go
@@ -2514,14 +2514,14 @@ func TestOutstandingLeasesMetric(t *testing.T) {
 	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{})
 	ctx := context.Background()
 	defer tc.Stopper().Stop(ctx)
-	_, err := tc.Conns[0].ExecContext(ctx, "CREATE TABLE a (a INT PRIMARY KEY)")
+	_, err := tc.ServerConn(0).ExecContext(ctx, "CREATE TABLE a (a INT PRIMARY KEY)")
 	assert.NoError(t, err)
-	_, err = tc.Conns[0].ExecContext(ctx, "CREATE TABLE b (a INT PRIMARY KEY)")
+	_, err = tc.ServerConn(0).ExecContext(ctx, "CREATE TABLE b (a INT PRIMARY KEY)")
 	assert.NoError(t, err)
-	gauge := tc.Servers[0].LeaseManager().(*lease.Manager).TestingOutstandingLeasesGauge()
+	gauge := tc.Server(0).LeaseManager().(*lease.Manager).TestingOutstandingLeasesGauge()
 	outstandingLeases := gauge.Value()
 
-	_, err = tc.Conns[0].ExecContext(ctx, "SELECT * FROM a")
+	_, err = tc.ServerConn(0).ExecContext(ctx, "SELECT * FROM a")
 	assert.NoError(t, err)
 
 	afterQuery := gauge.Value()
@@ -2535,7 +2535,7 @@ func TestOutstandingLeasesMetric(t *testing.T) {
 	}
 
 	// Expect at least 3 leases: one for a, one for the default database, and one for b.
-	_, err = tc.Conns[0].ExecContext(ctx, "SELECT * FROM b")
+	_, err = tc.ServerConn(0).ExecContext(ctx, "SELECT * FROM b")
 	assert.NoError(t, err)
 
 	afterQuery = gauge.Value()
@@ -3145,7 +3145,7 @@ ALTER TABLE t1 SPLIT AT VALUES (1);
 	require.NoError(t, err)
 	// Get the lease manager and table ID for acquiring a lease on.
 	beforeExecute.Lock()
-	leaseManager = tc.Servers[0].LeaseManager().(*lease.Manager)
+	leaseManager = tc.Server(0).LeaseManager().(*lease.Manager)
 	beforeExecute.Unlock()
 	tempTableID := uint64(0)
 	err = conn.QueryRow("SELECT table_id FROM crdb_internal.tables WHERE name = $1 AND database_name = current_database()",

--- a/pkg/sql/colfetcher/bytes_read_test.go
+++ b/pkg/sql/colfetcher/bytes_read_test.go
@@ -34,7 +34,7 @@ func TestBytesRead(t *testing.T) {
 	ctx := context.Background()
 	defer tc.Stopper().Stop(ctx)
 
-	conn := tc.Conns[0]
+	conn := tc.ServerConn(0)
 
 	// Create the table with disabled automatic table stats collection. The
 	// stats collection is disabled so that the ColBatchScan would read the

--- a/pkg/sql/colfetcher/vectorized_batch_size_test.go
+++ b/pkg/sql/colfetcher/vectorized_batch_size_test.go
@@ -88,7 +88,7 @@ func TestScanBatchSize(t *testing.T) {
 	ctx := context.Background()
 	defer tc.Stopper().Stop(ctx)
 
-	conn := tc.Conns[0]
+	conn := tc.ServerConn(0)
 	sqlDB := sqlutils.MakeSQLRunner(conn)
 
 	// Until we propagate the estimated row count hint in the KV projection
@@ -160,7 +160,7 @@ func TestCFetcherLimitsOutputBatch(t *testing.T) {
 	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{ReplicationMode: base.ReplicationAuto})
 	ctx := context.Background()
 	defer tc.Stopper().Stop(ctx)
-	conn := tc.Conns[0]
+	conn := tc.ServerConn(0)
 
 	// Until we propagate the estimated row count hint in the KV projection
 	// pushdown case, this test is expected to fail if the direct scans are

--- a/pkg/sql/colflow/vectorized_flow_deadlock_test.go
+++ b/pkg/sql/colflow/vectorized_flow_deadlock_test.go
@@ -50,7 +50,7 @@ func TestVectorizedFlowDeadlocksWhenSpilling(t *testing.T) {
 	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{ServerArgs: serverArgs})
 	ctx := context.Background()
 	defer tc.Stopper().Stop(ctx)
-	conn := tc.Conns[0]
+	conn := tc.ServerConn(0)
 
 	_, err := conn.ExecContext(ctx, "CREATE TABLE t (a, b) AS SELECT i, i FROM generate_series(1, 10000) AS g(i)")
 	require.NoError(t, err)

--- a/pkg/sql/colflow/vectorized_flow_planning_test.go
+++ b/pkg/sql/colflow/vectorized_flow_planning_test.go
@@ -31,7 +31,7 @@ func TestVectorizedPlanning(t *testing.T) {
 	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{ReplicationMode: base.ReplicationAuto})
 	ctx := context.Background()
 	defer tc.Stopper().Stop(ctx)
-	conn := tc.Conns[0]
+	conn := tc.ServerConn(0)
 
 	t.Run("no columnarizer-materializer", func(t *testing.T) {
 		if !buildutil.CrdbTestBuild {

--- a/pkg/sql/crdb_internal_test.go
+++ b/pkg/sql/crdb_internal_test.go
@@ -129,10 +129,10 @@ func TestRangeLocalityBasedOnNodeIDs(t *testing.T) {
 		},
 	)
 	defer tc.Stopper().Stop(ctx)
-	assert.EqualValues(t, 1, tc.Servers[len(tc.Servers)-1].GetFirstStoreID())
+	assert.EqualValues(t, 1, tc.Server(tc.NumServers()-1).GetFirstStoreID())
 
 	// Set to 2 so the next store id will be 3.
-	assert.NoError(t, tc.Servers[0].DB().Put(ctx, keys.StoreIDGenerator, 2))
+	assert.NoError(t, tc.Server(0).DB().Put(ctx, keys.StoreIDGenerator, 2))
 
 	// NodeID=2, StoreID=3
 	tc.AddAndStartServer(t,
@@ -140,10 +140,10 @@ func TestRangeLocalityBasedOnNodeIDs(t *testing.T) {
 			Locality: roachpb.Locality{Tiers: []roachpb.Tier{{Key: "node", Value: "2"}}},
 		},
 	)
-	assert.EqualValues(t, 3, tc.Servers[len(tc.Servers)-1].GetFirstStoreID())
+	assert.EqualValues(t, 3, tc.Server(tc.NumServers()-1).GetFirstStoreID())
 
 	// Set to 1 so the next store id will be 2.
-	assert.NoError(t, tc.Servers[0].DB().Put(ctx, keys.StoreIDGenerator, 1))
+	assert.NoError(t, tc.Server(0).DB().Put(ctx, keys.StoreIDGenerator, 1))
 
 	// NodeID=3, StoreID=2
 	tc.AddAndStartServer(t,
@@ -151,10 +151,10 @@ func TestRangeLocalityBasedOnNodeIDs(t *testing.T) {
 			Locality: roachpb.Locality{Tiers: []roachpb.Tier{{Key: "node", Value: "3"}}},
 		},
 	)
-	assert.EqualValues(t, 2, tc.Servers[len(tc.Servers)-1].GetFirstStoreID())
+	assert.EqualValues(t, 2, tc.Server(tc.NumServers()-1).GetFirstStoreID())
 	assert.NoError(t, tc.WaitForFullReplication())
 
-	sqlDB := sqlutils.MakeSQLRunner(tc.Conns[0])
+	sqlDB := sqlutils.MakeSQLRunner(tc.ServerConn(0))
 	var replicas, localities string
 	sqlDB.QueryRow(t, `select replicas, replica_localities from crdb_internal.ranges limit 1`).
 		Scan(&replicas, &localities)

--- a/pkg/sql/create_test.go
+++ b/pkg/sql/create_test.go
@@ -44,7 +44,6 @@ import (
 // it successful or not) it signals a done on the end waitgroup.
 func createTestTable(
 	t *testing.T,
-	tc *testcluster.TestCluster,
 	id int,
 	db *gosql.DB,
 	wgStart *sync.WaitGroup,
@@ -157,7 +156,7 @@ func TestParallelCreateTables(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Get the id descriptor generator count.
-	s := tc.Servers[0].ApplicationLayer()
+	s := tc.Server(0).ApplicationLayer()
 	idgen := descidgen.NewGenerator(s.ClusterSettings(), s.Codec(), s.DB())
 	descIDStart, err := idgen.PeekNextUniqueDescID(context.Background())
 	if err != nil {
@@ -172,7 +171,7 @@ func TestParallelCreateTables(t *testing.T) {
 	completed := make(chan int, numberOfTables)
 	for i := 0; i < numberOfTables; i++ {
 		db := tc.ServerConn(i % numberOfNodes)
-		go createTestTable(t, tc, i, db, &wgStart, &wgEnd, signal, completed)
+		go createTestTable(t, i, db, &wgStart, &wgEnd, signal, completed)
 	}
 
 	// Wait until all goroutines are ready.
@@ -212,7 +211,7 @@ func TestParallelCreateConflictingTables(t *testing.T) {
 	}
 
 	// Get the id descriptor generator count.
-	s := tc.Servers[0].ApplicationLayer()
+	s := tc.Server(0).ApplicationLayer()
 	idgen := descidgen.NewGenerator(s.ClusterSettings(), s.Codec(), s.DB())
 	descIDStart, err := idgen.PeekNextUniqueDescID(context.Background())
 	if err != nil {
@@ -227,7 +226,7 @@ func TestParallelCreateConflictingTables(t *testing.T) {
 	completed := make(chan int, numberOfTables)
 	for i := 0; i < numberOfTables; i++ {
 		db := tc.ServerConn(i % numberOfNodes)
-		go createTestTable(t, tc, 0, db, &wgStart, &wgEnd, signal, completed)
+		go createTestTable(t, 0, db, &wgStart, &wgEnd, signal, completed)
 	}
 
 	// Wait until all goroutines are ready.

--- a/pkg/sql/flowinfra/cluster_test.go
+++ b/pkg/sql/flowinfra/cluster_test.go
@@ -42,7 +42,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
-	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -263,8 +262,7 @@ func TestClusterFlow(t *testing.T) {
 	const numNodes = 3
 
 	args := base.TestClusterArgs{ReplicationMode: base.ReplicationManual}
-	tci := serverutils.StartNewTestCluster(t, numNodes, args)
-	tc := tci.(*testcluster.TestCluster)
+	tc := serverutils.StartNewTestCluster(t, numNodes, args)
 	defer tc.Stopper().Stop(context.Background())
 
 	servers := make([]serverutils.ApplicationLayerInterface, numNodes)
@@ -289,8 +287,7 @@ func TestTenantClusterFlow(t *testing.T) {
 
 	serverParams, _ := tests.CreateTestServerParams()
 	args := base.TestClusterArgs{ReplicationMode: base.ReplicationManual, ServerArgs: serverParams}
-	tci := serverutils.StartNewTestCluster(t, 1, args)
-	tc := tci.(*testcluster.TestCluster)
+	tc := serverutils.StartNewTestCluster(t, 1, args)
 	defer tc.Stopper().Stop(context.Background())
 
 	testingKnobs := base.TestingKnobs{

--- a/pkg/sql/importer/exportcsv_test.go
+++ b/pkg/sql/importer/exportcsv_test.go
@@ -160,7 +160,7 @@ func TestExportNullWithEmptyNullAs(t *testing.T) {
 		t, 1, base.TestClusterArgs{ServerArgs: base.TestServerArgs{ExternalIODir: dir}})
 	defer tc.Stopper().Stop(ctx)
 
-	conn := tc.Conns[0]
+	conn := tc.ServerConn(0)
 	db := sqlutils.MakeSQLRunner(conn)
 
 	// Set up dummy accounts table with NULL value
@@ -327,7 +327,7 @@ func TestExportUserDefinedTypes(t *testing.T) {
 		t, 1, base.TestClusterArgs{ServerArgs: base.TestServerArgs{ExternalIODir: dir}})
 	defer tc.Stopper().Stop(ctx)
 
-	conn := tc.Conns[0]
+	conn := tc.ServerConn(0)
 	sqlDB := sqlutils.MakeSQLRunner(conn)
 
 	// Set up some initial state for the tests.
@@ -516,7 +516,7 @@ func TestExportTargetFileSizeSetting(t *testing.T) {
 		t, 1, base.TestClusterArgs{ServerArgs: base.TestServerArgs{ExternalIODir: dir}})
 	defer tc.Stopper().Stop(ctx)
 
-	conn := tc.Conns[0]
+	conn := tc.ServerConn(0)
 	sqlDB := sqlutils.MakeSQLRunner(conn)
 
 	sqlDB.Exec(t, `EXPORT INTO CSV 'nodelocal://1/foo' WITH chunk_size='10KB' FROM select i, gen_random_uuid() from generate_series(1, 4000) as i;`)

--- a/pkg/sql/opt/exec/explain/output_test.go
+++ b/pkg/sql/opt/exec/explain/output_test.go
@@ -132,7 +132,7 @@ func TestMaxDiskSpillUsage(t *testing.T) {
 	ctx := context.Background()
 	defer tc.Stopper().Stop(ctx)
 
-	conn := tc.Conns[0]
+	conn := tc.ServerConn(0)
 
 	_, err := conn.ExecContext(ctx, `
 CREATE TABLE t (a PRIMARY KEY, b) AS SELECT i, i FROM generate_series(1, 10) AS g(i)
@@ -183,7 +183,7 @@ func TestCPUTimeEndToEnd(t *testing.T) {
 	ctx := context.Background()
 	defer tc.Stopper().Stop(ctx)
 
-	db := sqlutils.MakeSQLRunner(tc.Conns[0])
+	db := sqlutils.MakeSQLRunner(tc.ServerConn(0))
 
 	runQuery := func(query string, hideCPU bool) {
 		rows := db.QueryStr(t, "EXPLAIN ANALYZE "+query)
@@ -247,7 +247,7 @@ func TestContentionTimeOnWrites(t *testing.T) {
 	ctx := context.Background()
 	defer tc.Stopper().Stop(ctx)
 
-	runner := sqlutils.MakeSQLRunner(tc.Conns[0])
+	runner := sqlutils.MakeSQLRunner(tc.ServerConn(0))
 	runner.Exec(t, "CREATE TABLE t (k INT PRIMARY KEY, v INT)")
 
 	// The test involves three goroutines:
@@ -276,7 +276,7 @@ func TestContentionTimeOnWrites(t *testing.T) {
 				close(sem)
 			}
 		}()
-		txn, err := tc.Conns[0].Begin()
+		txn, err := tc.ServerConn(0).Begin()
 		if err != nil {
 			errCh <- err
 			return

--- a/pkg/sql/revert_test.go
+++ b/pkg/sql/revert_test.go
@@ -190,7 +190,7 @@ func TestRevertSpansFanout(t *testing.T) {
 	})
 	defer tc.Stopper().Stop(context.Background())
 	s := tc.ApplicationLayer(0)
-	sqlDB := tc.Conns[0]
+	sqlDB := tc.ServerConn(0)
 
 	execCfg := s.ExecutorConfig().(sql.ExecutorConfig)
 

--- a/pkg/sql/show_ranges_test.go
+++ b/pkg/sql/show_ranges_test.go
@@ -39,7 +39,7 @@ func TestShowRangesWithLocality(t *testing.T) {
 	tc := testcluster.StartTestCluster(t, numNodes, base.TestClusterArgs{})
 	defer tc.Stopper().Stop(ctx)
 
-	sqlDB := sqlutils.MakeSQLRunner(tc.Conns[0])
+	sqlDB := sqlutils.MakeSQLRunner(tc.ServerConn(0))
 	sqlDB.Exec(t, `CREATE TABLE t (x INT PRIMARY KEY)`)
 	sqlDB.Exec(t, `ALTER TABLE t SPLIT AT SELECT i FROM generate_series(0, 20) AS g(i)`)
 
@@ -124,7 +124,7 @@ func TestShowRangesMultipleStores(t *testing.T) {
 	assert.NoError(t, tc.WaitForFullReplication())
 
 	// Scatter a system table so that the lease is unlike to be on node 1.
-	sqlDB := sqlutils.MakeSQLRunner(tc.Conns[0])
+	sqlDB := sqlutils.MakeSQLRunner(tc.ServerConn(0))
 	sqlDB.Exec(t, "ALTER TABLE system.jobs SCATTER")
 	// Ensure that the localities line up.
 	for _, q := range []string{
@@ -184,7 +184,7 @@ func TestShowRangesWithDetails(t *testing.T) {
 	tc := testcluster.StartTestCluster(t, 3, base.TestClusterArgs{})
 	defer tc.Stopper().Stop(ctx)
 
-	sqlDB := sqlutils.MakeSQLRunner(tc.Conns[0])
+	sqlDB := sqlutils.MakeSQLRunner(tc.ServerConn(0))
 	sqlDB.Exec(t, "CREATE DATABASE test")
 	sqlDB.Exec(t, "USE test")
 	sqlDB.Exec(t, `

--- a/pkg/sql/show_trace_replica_test.go
+++ b/pkg/sql/show_trace_replica_test.go
@@ -65,7 +65,7 @@ func TestShowTraceReplica(t *testing.T) {
 	tc := testcluster.StartTestCluster(t, numNodes, tcArgs)
 	defer tc.Stopper().Stop(ctx)
 
-	sqlDB := sqlutils.MakeSQLRunner(tc.Conns[0])
+	sqlDB := sqlutils.MakeSQLRunner(tc.ServerConn(0))
 	sqlDB.Exec(t, `ALTER RANGE "default" CONFIGURE ZONE USING constraints = '[+n4]'`)
 	sqlDB.Exec(t, `ALTER DATABASE system CONFIGURE ZONE USING constraints = '[+n4]'`)
 	sqlDB.Exec(t, `CREATE DATABASE d`)

--- a/pkg/sql/sqlstats/persistedsqlstats/bench_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/bench_test.go
@@ -143,8 +143,8 @@ func BenchmarkSqlStatsPersisted(b *testing.B) {
 							SQLMemoryPoolSize: 512 << 20,
 						},
 					})
-				sqlRunner := sqlutils.MakeRoundRobinSQLRunner(tc.Conns[0],
-					tc.Conns[1], tc.Conns[2])
+				sqlRunner := sqlutils.MakeRoundRobinSQLRunner(tc.ServerConn(0),
+					tc.ServerConn(1), tc.ServerConn(2))
 				return sqlRunner, tc
 			},
 		},
@@ -159,9 +159,9 @@ func BenchmarkSqlStatsPersisted(b *testing.B) {
 							SQLMemoryPoolSize: 512 << 20,
 						},
 					})
-				sqlRunner := sqlutils.MakeRoundRobinSQLRunner(tc.Conns[0],
-					tc.Conns[1], tc.Conns[2], tc.Conns[3],
-					tc.Conns[4], tc.Conns[5])
+				sqlRunner := sqlutils.MakeRoundRobinSQLRunner(tc.ServerConn(0),
+					tc.ServerConn(1), tc.ServerConn(2), tc.ServerConn(3),
+					tc.ServerConn(4), tc.ServerConn(5))
 				return sqlRunner, tc
 			},
 		},

--- a/pkg/sql/stats/create_stats_job_test.go
+++ b/pkg/sql/stats/create_stats_job_test.go
@@ -67,7 +67,7 @@ func TestCreateStatsControlJob(t *testing.T) {
 	ctx := context.Background()
 	tc := testcluster.StartTestCluster(t, nodes, params)
 	defer tc.Stopper().Stop(ctx)
-	sqlDB := sqlutils.MakeSQLRunner(tc.Conns[0])
+	sqlDB := sqlutils.MakeSQLRunner(tc.ServerConn(0))
 	sqlDB.Exec(t, `CREATE DATABASE d`)
 	sqlDB.Exec(t, `CREATE TABLE d.t (x INT PRIMARY KEY)`)
 	var tID descpb.ID
@@ -140,7 +140,7 @@ func TestAtMostOneRunningCreateStats(t *testing.T) {
 	const nodes = 1
 	tc := testcluster.StartTestCluster(t, nodes, params)
 	defer tc.Stopper().Stop(ctx)
-	conn := tc.Conns[0]
+	conn := tc.ServerConn(0)
 	sqlDB := sqlutils.MakeSQLRunner(conn)
 
 	sqlDB.Exec(t, `CREATE DATABASE d`)
@@ -235,7 +235,7 @@ func TestDeleteFailedJob(t *testing.T) {
 	serverArgs := base.TestServerArgs{Knobs: base.TestingKnobs{JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals()}}
 	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{ServerArgs: serverArgs})
 	defer tc.Stopper().Stop(ctx)
-	conn := tc.Conns[0]
+	conn := tc.ServerConn(0)
 	sqlDB := sqlutils.MakeSQLRunner(conn)
 
 	sqlDB.Exec(t, `SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false`)
@@ -309,7 +309,7 @@ func TestCreateStatsProgress(t *testing.T) {
 	const nodes = 1
 	tc := testcluster.StartTestCluster(t, nodes, params)
 	defer tc.Stopper().Stop(ctx)
-	conn := tc.Conns[0]
+	conn := tc.ServerConn(0)
 	sqlDB := sqlutils.MakeSQLRunner(conn)
 
 	sqlDB.Exec(t, `SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false`)
@@ -387,7 +387,7 @@ func TestCreateStatsProgress(t *testing.T) {
 	// Invalidate the stats cache so that we can be sure to get the latest stats.
 	var tableID descpb.ID
 	sqlDB.QueryRow(t, `SELECT id FROM system.namespace WHERE name = 't'`).Scan(&tableID)
-	tc.Servers[0].ExecutorConfig().(sql.ExecutorConfig).TableStatsCache.InvalidateTableStats(
+	tc.Server(0).ExecutorConfig().(sql.ExecutorConfig).TableStatsCache.InvalidateTableStats(
 		ctx, tableID,
 	)
 
@@ -448,7 +448,7 @@ func TestCreateStatsAsOfTime(t *testing.T) {
 	ctx := context.Background()
 	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{})
 	defer tc.Stopper().Stop(ctx)
-	sqlDB := sqlutils.MakeSQLRunner(tc.Conns[0])
+	sqlDB := sqlutils.MakeSQLRunner(tc.ServerConn(0))
 	sqlDB.Exec(t, `CREATE DATABASE d`)
 	sqlDB.Exec(t, `CREATE TABLE d.t (x INT PRIMARY KEY)`)
 

--- a/pkg/sql/tests/system_table_test.go
+++ b/pkg/sql/tests/system_table_test.go
@@ -181,7 +181,7 @@ func TestSystemTableLiterals(t *testing.T) {
 	})
 	defer tc.Stopper().Stop(ctx)
 
-	s := tc.Servers[0]
+	s := tc.Server(0)
 
 	testcases := make(map[string]testcase)
 	for _, table := range systemschema.MakeSystemTables() {

--- a/pkg/upgrade/upgrades/database_role_settings_table_user_id_migration_test.go
+++ b/pkg/upgrade/upgrades/database_role_settings_table_user_id_migration_test.go
@@ -81,10 +81,10 @@ func runTestDatabaseRoleSettingsUserIDMigration(t *testing.T, numUsers int) {
 	tdb.CheckQueryResults(t, "SELECT count(*) FROM system.database_role_settings", [][]string{{strconv.Itoa(numUsers + 1)}})
 
 	// Run migrations.
-	_, err := tc.Conns[0].ExecContext(ctx, `SET CLUSTER SETTING version = $1`,
+	_, err := tc.ServerConn(0).ExecContext(ctx, `SET CLUSTER SETTING version = $1`,
 		clusterversion.ByKey(clusterversion.V23_1DatabaseRoleSettingsHasRoleIDColumn).String())
 	require.NoError(t, err)
-	_, err = tc.Conns[0].ExecContext(ctx, `SET CLUSTER SETTING version = $1`,
+	_, err = tc.ServerConn(0).ExecContext(ctx, `SET CLUSTER SETTING version = $1`,
 		clusterversion.ByKey(clusterversion.V23_1DatabaseRoleSettingsRoleIDColumnBackfilled).String())
 	require.NoError(t, err)
 

--- a/pkg/upgrade/upgrades/external_connections_table_user_id_migration_test.go
+++ b/pkg/upgrade/upgrades/external_connections_table_user_id_migration_test.go
@@ -84,10 +84,10 @@ func runTestExternalConnectionsUserIDMigration(t *testing.T, numUsers int) {
 	tdb.CheckQueryResults(t, "SELECT count(*) FROM system.external_connections", [][]string{{strconv.Itoa(numUsers)}})
 
 	// Run migrations.
-	_, err := tc.Conns[0].ExecContext(ctx, `SET CLUSTER SETTING version = $1`,
+	_, err := tc.ServerConn(0).ExecContext(ctx, `SET CLUSTER SETTING version = $1`,
 		clusterversion.ByKey(clusterversion.V23_1ExternalConnectionsTableHasOwnerIDColumn).String())
 	require.NoError(t, err)
-	_, err = tc.Conns[0].ExecContext(ctx, `SET CLUSTER SETTING version = $1`,
+	_, err = tc.ServerConn(0).ExecContext(ctx, `SET CLUSTER SETTING version = $1`,
 		clusterversion.ByKey(clusterversion.V23_1ExternalConnectionsTableOwnerIDColumnBackfilled).String())
 	require.NoError(t, err)
 

--- a/pkg/upgrade/upgrades/json_forward_indexes_test.go
+++ b/pkg/upgrade/upgrades/json_forward_indexes_test.go
@@ -54,7 +54,7 @@ func TestJSONForwardingIndexes(t *testing.T) {
 
 	// Set the cluster version to 22.2 to test that with the legacy schema changer
 	// we cannot create forward indexes on JSON columns.
-	_, err = tc.Conns[0].ExecContext(ctx, `SET CLUSTER SETTING version = $1`,
+	_, err = tc.ServerConn(0).ExecContext(ctx, `SET CLUSTER SETTING version = $1`,
 		clusterversion.ByKey(clusterversion.V22_2).String())
 	require.NoError(t, err)
 
@@ -100,7 +100,7 @@ func TestJSONForwardingIndexes(t *testing.T) {
 
 	// Set the cluster version to 23.1 to test that with the declarative schema
 	// changer we cannot create forward indexes on JSON columns.
-	_, err = tc.Conns[0].ExecContext(ctx, `SET CLUSTER SETTING version = $1`,
+	_, err = tc.ServerConn(0).ExecContext(ctx, `SET CLUSTER SETTING version = $1`,
 		clusterversion.ByKey(clusterversion.V23_1).String())
 	require.NoError(t, err)
 
@@ -142,7 +142,7 @@ func TestJSONForwardingIndexes(t *testing.T) {
 
 	// Setting a cluster version that supports forward indexes on JSON
 	// columns and expecting success when creating forward indexes.
-	_, err = tc.Conns[0].ExecContext(ctx, `SET CLUSTER SETTING version = $1`,
+	_, err = tc.ServerConn(0).ExecContext(ctx, `SET CLUSTER SETTING version = $1`,
 		clusterversion.ByKey(clusterversion.V23_2).String())
 	require.NoError(t, err)
 

--- a/pkg/upgrade/upgrades/role_members_ids_migration_test.go
+++ b/pkg/upgrade/upgrades/role_members_ids_migration_test.go
@@ -99,10 +99,10 @@ func runTestRoleMembersIDMigration(t *testing.T, numUsers int) {
 	})
 
 	// Run migrations.
-	_, err := tc.Conns[0].ExecContext(ctx, `SET CLUSTER SETTING version = $1`,
+	_, err := tc.ServerConn(0).ExecContext(ctx, `SET CLUSTER SETTING version = $1`,
 		clusterversion.ByKey(clusterversion.V23_1RoleMembersTableHasIDColumns).String())
 	require.NoError(t, err)
-	_, err = tc.Conns[0].ExecContext(ctx, `SET CLUSTER SETTING version = $1`,
+	_, err = tc.ServerConn(0).ExecContext(ctx, `SET CLUSTER SETTING version = $1`,
 		clusterversion.ByKey(clusterversion.V23_1RoleMembersIDColumnsBackfilled).String())
 	require.NoError(t, err)
 
@@ -133,7 +133,7 @@ func runTestRoleMembersIDMigration(t *testing.T, numUsers int) {
 	FAMILY fam_4_role_id (role_id),
 	FAMILY fam_5_member_id (member_id)
 )`
-	r := tc.Conns[0].QueryRow("SELECT create_statement FROM [SHOW CREATE TABLE system.role_members]")
+	r := tc.ServerConn(0).QueryRow("SELECT create_statement FROM [SHOW CREATE TABLE system.role_members]")
 	var actualSchema string
 	require.NoError(t, r.Scan(&actualSchema))
 	require.Equal(t, expectedSchema, actualSchema)

--- a/pkg/upgrade/upgrades/system_privileges_index_migration_test.go
+++ b/pkg/upgrade/upgrades/system_privileges_index_migration_test.go
@@ -45,7 +45,7 @@ func TestSystemPrivilegesIndexMigration(t *testing.T) {
 	tdb := sqlutils.MakeSQLRunner(db)
 
 	// Run migration.
-	_, err := tc.Conns[0].ExecContext(
+	_, err := tc.ServerConn(0).ExecContext(
 		ctx,
 		`SET CLUSTER SETTING version = $1`,
 		clusterversion.ByKey(clusterversion.V23_1AlterSystemPrivilegesAddIndexOnPathAndUsername).String(),

--- a/pkg/upgrade/upgrades/system_privileges_user_id_migration_test.go
+++ b/pkg/upgrade/upgrades/system_privileges_user_id_migration_test.go
@@ -81,10 +81,10 @@ func runTestSystemPrivilegesUserIDMigration(t *testing.T, numUsers int) {
 	tdb.CheckQueryResults(t, "SELECT count(*) FROM system.privileges", [][]string{{strconv.Itoa(numUsers + 1)}})
 
 	// Run migrations.
-	_, err := tc.Conns[0].ExecContext(ctx, `SET CLUSTER SETTING version = $1`,
+	_, err := tc.ServerConn(0).ExecContext(ctx, `SET CLUSTER SETTING version = $1`,
 		clusterversion.ByKey(clusterversion.V23_1SystemPrivilegesTableHasUserIDColumn).String())
 	require.NoError(t, err)
-	_, err = tc.Conns[0].ExecContext(ctx, `SET CLUSTER SETTING version = $1`,
+	_, err = tc.ServerConn(0).ExecContext(ctx, `SET CLUSTER SETTING version = $1`,
 		clusterversion.ByKey(clusterversion.V23_1SystemPrivilegesTableUserIDColumnBackfilled).String())
 	require.NoError(t, err)
 

--- a/pkg/upgrade/upgrades/web_sessions_table_user_id_migration_test.go
+++ b/pkg/upgrade/upgrades/web_sessions_table_user_id_migration_test.go
@@ -92,10 +92,10 @@ VALUES (
 	}
 
 	// Run migrations.
-	_, err := tc.Conns[0].ExecContext(ctx, `SET CLUSTER SETTING version = $1`,
+	_, err := tc.ServerConn(0).ExecContext(ctx, `SET CLUSTER SETTING version = $1`,
 		clusterversion.ByKey(clusterversion.V23_1WebSessionsTableHasUserIDColumn).String())
 	require.NoError(t, err)
-	_, err = tc.Conns[0].ExecContext(ctx, `SET CLUSTER SETTING version = $1`,
+	_, err = tc.ServerConn(0).ExecContext(ctx, `SET CLUSTER SETTING version = $1`,
 		clusterversion.ByKey(clusterversion.V23_1WebSessionsTableUserIDColumnBackfilled).String())
 	require.NoError(t, err)
 


### PR DESCRIPTION
All commits except the last are from #107866 and prior.


Epic: CRDB-18499
