### PR TITLE
release-23.1: sql/schemachanger: fix incorrect errors dropping primary key columns

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -3263,3 +3263,19 @@ t_99764  CREATE TABLE public.t_99764 (
              i INT8 NOT NULL,
              CONSTRAINT t_99764_pkey PRIMARY KEY (i ASC)
          )
+
+# Validate that DROP COLUMN CASCADE generates the proper error if we attempt
+# to drop a key column
+subtest alter_table_drop_cascade_with_key
+
+statement ok
+create table t_drop_cascade_with_key(n int primary key, k int);
+
+statement ok
+alter table t_drop_cascade_with_key add column j int as (n) stored null;
+
+statement ok
+set sql_safe_updates=false
+
+statement error pgcode 42P10 column "n" is referenced by.*
+alter table t_drop_cascade_with_key drop column n cascade;

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_drop_column.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_drop_column.go
@@ -186,6 +186,25 @@ func dropColumn(
 ) {
 	_, _, cn := scpb.FindColumnName(colElts)
 	var undroppedSeqBackrefsToCheck catalog.DescriptorIDSet
+	// First validate that the column references here is not a primary key,
+	// we not do this first since any cascaded drops would clean up the primary
+	// key *during* the iteration below.
+	var pkIDs catid.IndexSet
+	tableElts := b.QueryByID(col.TableID).Filter(notAbsentOrTransientTargetFilter)
+	tableElts.ForEachElementStatus(func(current scpb.Status, target scpb.TargetStatus, e scpb.Element) {
+		if pk, ok := e.(*scpb.PrimaryIndex); ok {
+			pkIDs.Add(pk.IndexID)
+		}
+	})
+
+	tableElts.ForEachElementStatus(func(current scpb.Status, target scpb.TargetStatus, e scpb.Element) {
+		if ic, ok := e.(*scpb.IndexColumn); ok {
+			if ic.Kind == scpb.IndexColumn_KEY && ic.ColumnID == col.ColumnID && pkIDs.Contains(ic.IndexID) {
+				panic(sqlerrors.NewColumnReferencedByPrimaryKeyError(cn.Name))
+			}
+		}
+	})
+	// Next walk through and actually clean up the column references.
 	walkDropColumnDependencies(b, col, func(e scpb.Element) {
 		switch e := e.(type) {
 		case *scpb.Column:
@@ -200,14 +219,7 @@ func dropColumn(
 			}
 			dropColumn(b, tn, tbl, n, e, elts, behavior)
 		case *scpb.PrimaryIndex:
-			tableElts := b.QueryByID(e.TableID).Filter(publicTargetFilter)
-			scpb.ForEachIndexColumn(tableElts, func(_ scpb.Status, _ scpb.TargetStatus, ic *scpb.IndexColumn) {
-				if ic.ColumnID == col.ColumnID &&
-					e.IndexID == ic.IndexID &&
-					ic.Kind == scpb.IndexColumn_KEY {
-					panic(sqlerrors.NewColumnReferencedByPrimaryKeyError(cn.Name))
-				}
-			})
+			// Nothing needs to be done.
 		case *scpb.SecondaryIndex:
 			indexElts := b.QueryByID(e.TableID).Filter(hasIndexIDAttrFilter(e.IndexID))
 			_, indexTargetStatus, indexName := scpb.FindIndexName(indexElts)

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/helpers.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/helpers.go
@@ -407,6 +407,12 @@ func notAbsentTargetFilter(_ scpb.Status, target scpb.TargetStatus, _ scpb.Eleme
 	return target != scpb.ToAbsent
 }
 
+func notAbsentOrTransientTargetFilter(
+	_ scpb.Status, target scpb.TargetStatus, _ scpb.Element,
+) bool {
+	return target != scpb.ToAbsent && target != scpb.Transient
+}
+
 func statusAbsentOrBackfillOnlyFilter(
 	status scpb.Status, _ scpb.TargetStatus, _ scpb.Element,
 ) bool {


### PR DESCRIPTION
Backport 1/1 commits from #106634.

/cc @cockroachdb/release

---

Previously, the declarative schema changer in DROP COLUMN CASCADE scenarios would either hang (23.1) or generate incorrect errors (master) when dropping a primary key column. This was because the primary index would be replaced during a DROP CASCADE scenario when cleaning up the cascade column. The check to see if the target column was a key could look for the original index, which will no longer be public. To address this bug, this patch checks if the target dropped column is a key column first.

Fixes: #105953

Release note (bug fix) : DROP COLUMN cascade involving a primary key column could end up hanging

Release justification: low risk and fixes a bug in the declarative schema changer
