### PR TITLE
concurrency: do not rely on Strength enum ordering in a few places

### DIFF
--- a/pkg/kv/kvserver/concurrency/BUILD.bazel
+++ b/pkg/kv/kvserver/concurrency/BUILD.bazel
@@ -32,6 +32,7 @@ go_library(
         "//pkg/util/buildutil",
         "//pkg/util/hlc",
         "//pkg/util/humanizeutil",
+        "//pkg/util/iterutil",
         "//pkg/util/log",
         "//pkg/util/metric",
         "//pkg/util/stop",

--- a/pkg/kv/kvserver/concurrency/lock/BUILD.bazel
+++ b/pkg/kv/kvserver/concurrency/lock/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "//pkg/kv/kvserver/concurrency/isolation",
         "//pkg/settings",
         "//pkg/util/hlc",
+        "//pkg/util/iterutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_redact//:redact",
     ],


### PR DESCRIPTION
Previously, a few places in the code relied on the ordering of lock strengths. This was mostly places where we looped over all lock strengths in descending order or performed <= comparisons. This patch hides such usages behind functions, in preparation for #107947.

Informs https://github.com/cockroachdb/cockroach/issues/107947

Release note: None
