### PR TITLE
sql: save planTop by reference instead of by value

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -3608,6 +3608,7 @@ func (ex *connExecutor) implicitTxn() bool {
 // query in the context of this session.
 func (ex *connExecutor) initPlanner(ctx context.Context, p *planner) {
 	p.cancelChecker.Reset(ctx)
+	p.curPlan = &planTop{}
 
 	ex.initEvalCtx(ctx, &p.extendedEvalCtx, p)
 

--- a/pkg/sql/distsql_plan_changefeed.go
+++ b/pkg/sql/distsql_plan_changefeed.go
@@ -120,7 +120,7 @@ func PlanCDCExpression(
 
 	const allowAutoCommit = false
 	if err := opc.runExecBuilder(
-		ctx, &p.curPlan, &p.stmt, newExecFactory(ctx, p), memo, p.EvalContext(), allowAutoCommit,
+		ctx, p.curPlan, &p.stmt, newExecFactory(ctx, p), memo, p.EvalContext(), allowAutoCommit,
 	); err != nil {
 		return cdcPlan, err
 	}

--- a/pkg/sql/instrumentation.go
+++ b/pkg/sql/instrumentation.go
@@ -425,7 +425,7 @@ func (ih *instrumentationHelper) Finish(
 				payloadErr = pwe.errorCause()
 			}
 			bundle = buildStatementBundle(
-				ctx, ih.explainFlags, cfg.DB, ie.(*InternalExecutor), stmtRawSQL, &p.curPlan,
+				ctx, ih.explainFlags, cfg.DB, ie.(*InternalExecutor), stmtRawSQL, p.curPlan,
 				ob.BuildString(), trace, placeholders, res.Err(), payloadErr, retErr,
 				&p.extendedEvalCtx.Settings.SV,
 			)

--- a/pkg/sql/plan_opt.go
+++ b/pkg/sql/plan_opt.go
@@ -253,7 +253,7 @@ func (p *planner) makeOptimizerPlan(ctx context.Context) error {
 		}
 		err := opc.runExecBuilder(
 			ctx,
-			&p.curPlan,
+			p.curPlan,
 			&p.stmt,
 			newDistSQLSpecExecFactory(ctx, p, planningMode),
 			execMemo,
@@ -288,7 +288,7 @@ func (p *planner) makeOptimizerPlan(ctx context.Context) error {
 				// execFactory.
 				err = opc.runExecBuilder(
 					ctx,
-					&p.curPlan,
+					p.curPlan,
 					&p.stmt,
 					newDistSQLSpecExecFactory(ctx, p, distSQLLocalOnlyPlanning),
 					execMemo,
@@ -309,7 +309,7 @@ func (p *planner) makeOptimizerPlan(ctx context.Context) error {
 	// If we got here, we did not create a plan above.
 	return opc.runExecBuilder(
 		ctx,
-		&p.curPlan,
+		p.curPlan,
 		&p.stmt,
 		newExecFactory(ctx, p),
 		execMemo,

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -250,7 +250,7 @@ type planner struct {
 	// curPlan collects the properties of the current plan being prepared. This state
 	// is undefined at the beginning of the planning of each new statement, and cannot
 	// be reused for an old prepared statement after a new statement has been prepared.
-	curPlan planTop
+	curPlan *planTop
 
 	// Avoid allocations by embedding commonly used objects and visitors.
 	txCtx                 transform.ExprTransformContext
@@ -399,6 +399,7 @@ func newInternalPlanner(
 	p.txn = txn
 	p.stmt = Statement{}
 	p.cancelChecker.Reset(ctx)
+	p.curPlan = &planTop{}
 	p.isInternalPlanner = true
 
 	p.semaCtx = tree.MakeSemaContext()

--- a/pkg/sql/prepared_stmt.go
+++ b/pkg/sql/prepared_stmt.go
@@ -369,7 +369,7 @@ type portalPauseInfo struct {
 		// We reuse it when re-executing the portal.
 		// TODO(yuzefovich): consider refactoring distSQLFlowInfos from planTop to
 		// avoid storing the planTop here.
-		planTop planTop
+		planTop *planTop
 		// queryStats stores statistics on query execution. It is incremented for
 		// each execution of the portal.
 		queryStats *topLevelQueryStats


### PR DESCRIPTION
In `dispatchToExecutionEngine` we were saving the planTop to the portalPauseInfo by value, but after this we mutate the planTop several times (e.g. setting flags). We need to save the planTop by reference in order to not lose these mutations.

Release note: None