### PR TITLE
c2c: reduce TestStreamingAutoReplan runtime

### DIFF
--- a/pkg/ccl/streamingccl/streamingest/replication_stream_e2e_test.go
+++ b/pkg/ccl/streamingccl/streamingest/replication_stream_e2e_test.go
@@ -729,6 +729,7 @@ func TestStreamingAutoReplan(t *testing.T) {
 	defer cleanup()
 	// Don't allow for replanning until the new nodes and scattered table have been created.
 	serverutils.SetClusterSetting(t, c.DestCluster, "stream_replication.replan_flow_threshold", 0)
+	serverutils.SetClusterSetting(t, c.DestCluster, "stream_replication.replan_flow_frequency", time.Millisecond*500)
 
 	// Begin the job on a single source node.
 	producerJobID, ingestionJobID := c.StartStreamReplication(ctx)
@@ -746,7 +747,6 @@ func TestStreamingAutoReplan(t *testing.T) {
 
 	// Configure the ingestion job to replan eagerly.
 	serverutils.SetClusterSetting(t, c.DestCluster, "stream_replication.replan_flow_threshold", 0.1)
-	serverutils.SetClusterSetting(t, c.DestCluster, "stream_replication.replan_flow_frequency", time.Millisecond*500)
 
 	// The ingestion job should eventually retry because it detects new nodes to add to the plan.
 	require.Error(t, <-retryErrorChan, sql.ErrPlanChanged)


### PR DESCRIPTION
In a suprising twist, #106853 deflaked this test, but also increased the runtime to 10 minutes. To understand why, consider that the default value of the stream_replication.replan_flow_frequency setting is 10 minutes, and if the user changes the cluster setting, the frequency will only take effect on the next replanning check. So, if a stream begins at t0, and the user changes the setting at t1, the replanning frequency will actually change 10 minutes after t0.

In #105853  patch reduced stream_replication.replan_flow_frequency setting to 500 ms _after_ the stream began, which caused the next replanninng check to occur a full 10 minutes after the stream started! This patch changes this cluster setting _before_ the stream begins, reducing the runtime of this test to a speedy 10 seconds.

Epic: none

Release note: none