### PR TITLE
sql: fix TestSQLStatsRegions flaky test

### DIFF
--- a/pkg/ccl/testccl/sqlstatsccl/BUILD.bazel
+++ b/pkg/ccl/testccl/sqlstatsccl/BUILD.bazel
@@ -2,6 +2,8 @@ load("@io_bazel_rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "sqlstatsccl_test",
+    # Explicitly indicate timeout as some of the tests (ie TestSQLStatsRegions) might take up to 3 min to run.
+    timeout = "moderate",
     srcs = [
         "main_test.go",
         "sql_stats_test.go",

--- a/pkg/ccl/testccl/sqlstatsccl/sql_stats_test.go
+++ b/pkg/ccl/testccl/sqlstatsccl/sql_stats_test.go
@@ -106,8 +106,8 @@ func TestSQLStatsRegions(t *testing.T) {
 	// change, the test sometimes is flakey because the latency budget allocated
 	// to closed timestamp propagation proves to be insufficient. This value is
 	// very cautious, and makes this already slow test even slower.
-	tdb.Exec(t, "SET CLUSTER SETTING kv.closed_timestamp.side_transport_interval = '50 ms'")
-	tdb.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.lead_for_global_reads_override = '1500ms'`)
+	tdb.Exec(t, "SET CLUSTER SETTING kv.closed_timestamp.side_transport_interval = '10ms'")
+	tdb.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.lead_for_global_reads_override = '500ms'`)
 	tdb.Exec(t, `ALTER TENANT ALL SET CLUSTER SETTING spanconfig.reconciliation_job.checkpoint_interval = '500ms'`)
 
 	tdb.Exec(t, "ALTER TENANT ALL SET CLUSTER SETTING sql.zone_configs.allow_for_secondary_tenant.enabled = true")


### PR DESCRIPTION
This patch updates cluster settings that improves test stability and time of execution.
Settings values were chosen based on multiple test runs with different values that have lower average time execution and don't cause flaky failures.

Resolves: #107582

Release note: None