### PR TITLE
changefeedccl: wrap common errors before displaying or logging

### DIFF
--- a/pkg/ccl/changefeedccl/changefeedbase/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/changefeedbase/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//pkg/util",
         "//pkg/util/iterutil",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_shopify_sarama//:sarama",
     ],
 )
 
@@ -48,6 +49,7 @@ go_test(
         "//pkg/util/log",
         "//pkg/util/randutil",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_shopify_sarama//:sarama",
         "@com_github_stretchr_testify//require",
     ],
 )


### PR DESCRIPTION
"context canceled" and "run out of available brokers" are both extremely generic errors that look like they could be specific, which can be misleading. Any time they're visible to users is technical debt, but we can at least make it clearer how little we know.

Informs: https://cockroachlabs.atlassian.net/browse/CRDB-302686

Release note: None