### PR TITLE
sqlproxyccl: fix non-auth error causing throttle

### DIFF
--- a/pkg/ccl/sqlproxyccl/BUILD.bazel
+++ b/pkg/ccl/sqlproxyccl/BUILD.bazel
@@ -53,6 +53,7 @@ go_library(
         "@org_golang_google_grpc//codes",
         "@org_golang_google_grpc//credentials/insecure",
         "@org_golang_google_grpc//status",
+        "@org_golang_x_exp//slices",
     ],
 )
 
@@ -93,6 +94,7 @@ go_test(
         "//pkg/sql",
         "//pkg/sql/catalog/descs",
         "//pkg/sql/pgwire",
+        "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/pgwire/pgwirebase",
         "//pkg/sql/tests",

--- a/pkg/sql/pgwire/conn.go
+++ b/pkg/sql/pgwire/conn.go
@@ -210,6 +210,9 @@ func (c *conn) processCommands(
 
 	var decrementConnectionCount func()
 	if decrementConnectionCount, retErr = sqlServer.IncrementConnectionCount(c.sessionArgs); retErr != nil {
+		// This will return pgcode.TooManyConnections which is used by the sql proxy
+		// to skip failed auth throttle (as in this case the auth was fine but the
+		// error occurred before sending back auth ok msg)
 		_ = c.sendError(ctx, retErr)
 		return
 	}


### PR DESCRIPTION
Currently an error that occurs after a successful authentication but before the SQL server is ready to serve queries is considered an authentication failure and causes a throttle. In the cases where the connections are limited (due to usage limits) this causes blocks and prevents the clients to connect. This PR fixes the issue by not considering errors that came after the authentication was successful as conditions to throttle.

Fixes: https://cockroachlabs.atlassian.net/browse/CC-25314

Release note: None