### PR TITLE
changefeedccl: add metamorphic testing for different schema changers

### DIFF
--- a/pkg/ccl/changefeedccl/alter_changefeed_test.go
+++ b/pkg/ccl/changefeedccl/alter_changefeed_test.go
@@ -1107,7 +1107,7 @@ func TestAlterChangefeedAddTargetsDuringSchemaChangeError(t *testing.T) {
 
 	testFn := func(t *testing.T, s TestServerWithSystem, f cdctest.TestFeedFactory) {
 		sqlDB := sqlutils.MakeSQLRunner(s.DB)
-		usingLegacySchemaChanger := maybeDisableDeclarativeSchemaChangesForTest(t, sqlDB, rnd)
+		usingLegacySchemaChanger := maybeDisableDeclarativeSchemaChangesForTest(t, sqlDB)
 		// NB: For the `ALTER TABLE foo ADD COLUMN ... DEFAULT` schema change,
 		// the expected boundary is different depending on if we are using the
 		// legacy schema changer or not.

--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -58,13 +58,11 @@ import (
 
 var testSinkFlushFrequency = 100 * time.Millisecond
 
-// disableDeclarativeSchemaChangesForTest will disable the declarative schema
-// changer with a probability of 10% using the provided SQL DB connection. This
-// returns true if the declarative schema changer is disabled.
-func maybeDisableDeclarativeSchemaChangesForTest(
-	t testing.TB, sqlDB *sqlutils.SQLRunner, rnd *rand.Rand,
-) bool {
-	disable := rnd.Float32() < 0.1
+// maybeDisableDeclarativeSchemaChangesForTest will disable the declarative
+// schema changer with a probability of 10% using the provided SQL DB
+// connection. This returns true if the declarative schema changer is disabled.
+func maybeDisableDeclarativeSchemaChangesForTest(t testing.TB, sqlDB *sqlutils.SQLRunner) bool {
+	disable := rand.Float32() < 0.1
 	if disable {
 		t.Log("using legacy schema changer")
 		sqlDB.Exec(t, "SET use_declarative_schema_changer='off'")

--- a/pkg/ccl/changefeedccl/nemeses_test.go
+++ b/pkg/ccl/changefeedccl/nemeses_test.go
@@ -32,7 +32,7 @@ func TestChangefeedNemeses(t *testing.T) {
 		t.Logf("random seed: %d", seed)
 
 		sqlDB := sqlutils.MakeSQLRunner(s.DB)
-		withLegacySchemaChanger := maybeDisableDeclarativeSchemaChangesForTest(t, sqlDB, rng)
+		withLegacySchemaChanger := maybeDisableDeclarativeSchemaChangesForTest(t, sqlDB)
 		// TODO(dan): Ugly hack to disable `eventPause` in sinkless feeds. See comment in
 		// `RunNemesis` for details.
 		isSinkless := strings.Contains(t.Name(), "sinkless")


### PR DESCRIPTION
This change updates some tests to use `maybeDisableDeclarativeSchemaChangesForTest()`
for metamorphic testing of behavior under both schema changers.

This change adds a test called `TestChangefeedSchemaChangeAllowBackfill_Legacy`
which is a carbon copy of `TestChangefeedSchemaChangeAllowBackfill` prior to
https://github.com/cockroachdb/cockroach/pull/107184. This legacy test only asserts behavior under the legacy schema changer.

This change also updates `maybeDisableDeclarativeSchemaChangesForTest()` to
not take a `rand.Rand` as a paramter. This is uncessessary as the global
`rand` pkg is sufficient for deterministic RNG during tests.

Closes: https://github.com/cockroachdb/cockroach/issues/107532
Closes: https://github.com/cockroachdb/cockroach/issues/106906
Epic: None
Release note: None