### PR TITLE
roachtest: enable cpu profiler on restore tests

### DIFF
--- a/pkg/cmd/roachtest/tests/restore.go
+++ b/pkg/cmd/roachtest/tests/restore.go
@@ -815,7 +815,11 @@ func (rd *restoreDriver) prepareCluster(ctx context.Context) {
 		rd.t.Skipf("test configured to run on %s", rd.sp.backup.cloud)
 	}
 	rd.c.Put(ctx, rd.t.Cockroach(), "./cockroach")
-	rd.c.Start(ctx, rd.t.L(), option.DefaultStartOptsNoBackups(), install.MakeClusterSettings())
+	// TODO(kvoli): Once CPU profiling is enabled by default across roachtests,
+	// remove this cluster setting change #97699.
+	settings := install.MakeClusterSettings()
+	settings.ClusterSettings["server.cpu_profile.cpu_usage_combined_threshold"] = "70"
+	rd.c.Start(ctx, rd.t.L(), option.DefaultStartOptsNoBackups(), settings)
 	rd.getAOST(ctx)
 }
 


### PR DESCRIPTION
`restore/tpce/400GB/aws/nodes=8/cpus=8` recently failed with high CPU usage on one node #106140. The high CPU usage was attributed within replication, however we were unable to determine where exactly.

Enable the automatic CPU profiler on `restore/*` roachtests, which will collect profiles once normalized CPU utilization exceeds 70%.

Note this is supposed to be a temporary addition, which will be subsumed by #97699.

Informs: #106140

Release note: None