### PR TITLE
ui: fix infinite cluster setting refresh

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePage.tsx
@@ -246,6 +246,9 @@ export class DatabaseTablePage extends React.Component<
 
   componentDidMount(): void {
     this.refresh();
+    if (this.props.refreshSettings != null) {
+      this.props.refreshSettings();
+    }
   }
 
   componentDidUpdate(prevProp: Readonly<DatabaseTablePageProps>): void {
@@ -283,10 +286,6 @@ export class DatabaseTablePage extends React.Component<
         this.props.databaseName,
         this.props.name,
       );
-    }
-
-    if (this.props.refreshSettings != null) {
-      this.props.refreshSettings();
     }
   }
 


### PR DESCRIPTION
The DatabaseTablePage was unconditionally refreshing cluster settings causing a flood of network requests.

Epic: none
Release note (bux fix): A bug has been fixed that caused a flood of requests to refresh cluster settings on the Table Detail page.

If a user would like to see the effect of a modified cluster setting in DB Console, a page-reload is required.