### PR TITLE
kvserver: always log store rebalancer transfers and relocates

### DIFF
--- a/pkg/kv/kvserver/store_rebalancer.go
+++ b/pkg/kv/kvserver/store_rebalancer.go
@@ -655,9 +655,8 @@ func (sr *StoreRebalancer) applyRangeRebalance(
 	voterTargets, nonVoterTargets []roachpb.ReplicationTarget,
 ) bool {
 	descBeforeRebalance, _ := candidateReplica.DescAndSpanConfig()
-	log.KvDistribution.VEventf(
+	log.KvDistribution.Infof(
 		ctx,
-		1,
 		"rebalancing r%d (%s load) to better balance load: voters from %v to %v; non-voters from %v to %v",
 		candidateReplica.GetRangeID(),
 		candidateReplica.RangeUsageInfo().Load(),
@@ -800,9 +799,8 @@ func (sr *StoreRebalancer) chooseLeaseToTransfer(
 			continue
 		}
 		if targetStore, ok := rctx.allStoresList.FindStoreByID(candidate.StoreID); ok {
-			log.KvDistribution.VEventf(
+			log.KvDistribution.Infof(
 				ctx,
-				1,
 				"transferring lease for r%d load=%s to store s%d load=%s from local store s%d load=%s",
 				desc.RangeID,
 				candidateReplica.RangeUsageInfo().TransferImpact(),


### PR DESCRIPTION
Previously, the store rebalancer would not default log range lease transfers or replica relocations, nor their estimated load impact. This made debugging imbalance related issues difficult.

Bump the range relocation and range lease transfer log lines from `v(1)` to `Info`, so that they are always logged.

Resolves: #107702

Release note: None