### PR TITLE
release-23.1: sql: fix TestSQLStatsCompactor flaky test

### DIFF
--- a/pkg/sql/sqlstats/persistedsqlstats/compaction_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/compaction_test.go
@@ -154,6 +154,8 @@ func TestSQLStatsCompactor(t *testing.T) {
 			// Change the automatic compaction job to avoid it running during the test.
 			// Test creates a new compactor and calls it directly.
 			sqlConn.Exec(t, "SET CLUSTER SETTING sql.stats.cleanup.recurrence = '@yearly';")
+			// Disable auto split by load as it affects the number of wide scans.
+			sqlConn.Exec(t, "SET CLUSTER SETTING kv.range_split.by_load_enabled = false")
 
 			_, err := internalExecutor.ExecEx(
 				ctx,


### PR DESCRIPTION
Backport 1/1 commits from #107870 on behalf of @koorosh.

/cc @cockroachdb/release

----

This patch disables auto split and merge of ranges for the test because it causes extra wide scan to be counted by `kvInterceptor`.

Release note: None

Resolves: #108041

----

Release justification: non-production code changes