### PR TITLE
sql: fix SHOW COMPLETIONS slice bounds out of range

### DIFF
--- a/pkg/sql/delegate/BUILD.bazel
+++ b/pkg/sql/delegate/BUILD.bazel
@@ -74,6 +74,7 @@ go_test(
     srcs = ["show_completions_test.go"],
     args = ["-test.timeout=295s"],
     embed = [":delegate"],
+    deps = ["@com_github_stretchr_testify//require"],
 )
 
 get_x_data(name = "get_x_data")

--- a/pkg/sql/delegate/show_completions.go
+++ b/pkg/sql/delegate/show_completions.go
@@ -56,8 +56,8 @@ func (d *delegator) delegateShowCompletions(n *tree.ShowCompletions) (tree.State
 // RunShowCompletions returns a list of completion keywords for the given
 // statement and offset.
 func RunShowCompletions(stmt string, offset int) ([]string, error) {
-	byteStmt := []byte(stmt)
-	if offset <= 0 || offset > len(byteStmt) {
+	stmtRunes := []rune(stmt)
+	if offset <= 0 || offset > len(stmtRunes) {
 		return nil, nil
 	}
 
@@ -67,10 +67,10 @@ func RunShowCompletions(stmt string, offset int) ([]string, error) {
 	// Ie "SELECT ", will only return one token being "SELECT".
 	// If we're at the whitespace, we do not want to return completion
 	// recommendations for "SELECT".
-	if unicode.IsSpace(rune(byteStmt[offset-1])) {
+	if unicode.IsSpace(stmtRunes[offset-1]) {
 		return nil, nil
 	}
-	sqlTokens := parser.TokensIgnoreErrors(string([]rune(stmt)[:offset]))
+	sqlTokens := parser.TokensIgnoreErrors(string(stmtRunes[:offset]))
 	if len(sqlTokens) == 0 {
 		return nil, nil
 	}
@@ -118,6 +118,11 @@ func min(a int, b int) int {
 
 func getCompletionsForWord(w string, words []string) []string {
 	left, right := binarySearch(strings.ToLower(w), words)
+	length := right - left
+	// Consistent with other branches returning nil instead of []string{}.
+	if length == 0 {
+		return nil
+	}
 	completions := make([]string, right-left)
 
 	for i, word := range words[left:right] {

--- a/pkg/sql/delegate/show_completions_test.go
+++ b/pkg/sql/delegate/show_completions_test.go
@@ -11,8 +11,9 @@
 package delegate
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestCompletions(t *testing.T) {
@@ -31,7 +32,7 @@ func TestCompletions(t *testing.T) {
 		},
 		{
 			stmt:                "creat ",
-			expectedCompletions: []string{},
+			expectedCompletions: nil,
 		},
 		{
 			stmt:                "SHOW CREAT",
@@ -59,57 +60,61 @@ func TestCompletions(t *testing.T) {
 		},
 		{
 			stmt:                "create ta",
-			expectedCompletions: []string{"CREATE"},
 			offset:              3,
+			expectedCompletions: []string{"CREATE"},
 		},
 		{
 			stmt:                "select",
-			expectedCompletions: []string{"SELECT"},
 			offset:              2,
+			expectedCompletions: []string{"SELECT"},
 		},
 		{
 			stmt:                "select ",
-			expectedCompletions: []string{},
 			offset:              7,
+			expectedCompletions: nil,
 		},
 		{
 			stmt:                "你好，我的名字是鲍勃 SELECT",
-			expectedCompletions: []string{"你好，我的名字是鲍勃"},
 			offset:              2,
+			expectedCompletions: []string{"你好，我的名字是鲍勃"},
 		},
 		{
 			stmt:                "你好，我的名字是鲍勃 SELECT",
-			expectedCompletions: []string{},
 			offset:              11,
+			expectedCompletions: nil,
 		},
 		{
 			stmt:                "你好，我的名字是鲍勃 SELECT",
-			expectedCompletions: []string{"SELECT"},
 			offset:              12,
+			expectedCompletions: []string{"SELECT"},
 		},
 		{
 			stmt:                "😋😋😋 😋😋😋",
-			expectedCompletions: []string{},
 			offset:              25,
+			expectedCompletions: nil,
 		},
 		{
 			stmt:                "Jalapeño",
-			expectedCompletions: []string{},
 			offset:              9,
+			expectedCompletions: nil,
+		},
+		// Test an offset greater than the number of runes in the string, but less
+		// than or equal to the number of bytes in the string.
+		// 🦹 has 1 rune and 4 bytes.
+		{
+			stmt:   "🦹",
+			offset: 2,
 		},
 	}
 	for _, tc := range tests {
-		offset := tc.offset
-		if tc.offset == 0 {
-			offset = len(tc.stmt)
-		}
-		completions, err := RunShowCompletions(tc.stmt, offset)
-		if err != nil {
-			t.Error(err)
-		}
-		if !(len(completions) == 0 && len(tc.expectedCompletions) == 0) &&
-			!reflect.DeepEqual(completions, tc.expectedCompletions) {
-			t.Errorf("expected %v, got %v", tc.expectedCompletions, completions)
-		}
+		t.Run(tc.stmt, func(t *testing.T) {
+			offset := tc.offset
+			if tc.offset == 0 {
+				offset = len([]rune(tc.stmt))
+			}
+			actualCompletions, err := RunShowCompletions(tc.stmt, offset)
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedCompletions, actualCompletions)
+		})
 	}
 }


### PR DESCRIPTION
Fixes #96708

Previously SHOW COMPLETIONS could error on input where the offset is greater than the number of runes, but less than or equal to the number of bytes.

This PR fixes the issue by comparing the offset to the number of runes instead of number of bytes.

Release note (bug fix): Fix SHOW COMPLETIONS slice bounds out of range.