### PR TITLE
release-23.1: ci,ui: always install dependencies with pnpm

### DIFF
--- a/.github/workflows/cluster-ui-release-next.yml
+++ b/.github/workflows/cluster-ui-release-next.yml
@@ -42,6 +42,16 @@ jobs:
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      # Always install node dependencies. It seems silly to do if we're not
+      # going to actually use them, but setup-node's post-run action attempts
+      # to save dependencies to a cache shared between GitHub actions. If the
+      # pnpm store directory doesn't exist (e.g. during a cache miss), that
+      # cache-saving step will fail and the entire job will be marked "failed"
+      # as a result. Installing dependencies is the canonical way to seed the
+      # pnpm store from-scratch.
+    - name: Install dependencies
+      run: pnpm install --frozen-lockfile
+
     - name: Check if version is published
       id: version-check
       shell: bash
@@ -62,7 +72,6 @@ jobs:
     - name: Build Cluster UI
       if: steps.version-check.outputs.published == 'no'
       run: |
-        pnpm install --frozen-lockfile
         bazel build //pkg/ui/workspaces/db-console/src/js:crdb-protobuf-client
         cp ../../../../_bazel/bin/pkg/ui/workspaces/db-console/src/js/protos.* ../db-console/src/js/
         pnpm build

--- a/.github/workflows/cluster-ui-release.yml
+++ b/.github/workflows/cluster-ui-release.yml
@@ -42,6 +42,16 @@ jobs:
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      # Always install node dependencies. It seems silly to do if we're not
+      # going to actually use them, but setup-node's post-run action attempts
+      # to save dependencies to a cache shared between GitHub actions. If the
+      # pnpm store directory doesn't exist (e.g. during a cache miss), that
+      # cache-saving step will fail and the entire job will be marked "failed"
+      # as a result. Installing dependencies is the canonical way to seed the
+      # pnpm store from-scratch.
+    - name: Install dependencies
+      run: pnpm install --frozen-lockfile
+
     - name: Check if version is published
       id: version-check
       shell: bash
@@ -67,7 +77,6 @@ jobs:
     - name: Build Cluster UI
       if: steps.version-check.outputs.published == 'no'
       run: |
-        pnpm install --frozen-lockfile
         bazel build //pkg/ui/workspaces/db-console/src/js:crdb-protobuf-client
         cp ../../../../_bazel/bin/pkg/ui/workspaces/db-console/src/js/protos.* ../db-console/src/js/
         pnpm build


### PR DESCRIPTION
Backport 1/1 commits from #107840.

/cc @cockroachdb/release

---

Previously, the 'cluster-ui-release' and 'cluster-ui-release-next' GitHub Actions workflows would fail when no new version needed to be published. When setup-node performs its post-run actions, it attempts to cache the global pnpm store. Unfortunately, that caching step fails when no global pnpm store exists, like during a cache-miss when `pnpm install` never ran. This caused the entire workflow to be marked as failed, adding needless noise to anyone who changed a file in `pkg/ui/workspaces/cluster-ui` without bumping the package version. Always run `pnpm install`, so that the global pnpm store is always populated and cacheable.

Release note: None
Epic: none

---
Release justification: build-only change
