### PR TITLE
acceptance, ccl, cli, cmd, config, gossip, internal, jobs: cleanup lock usages

### DIFF
--- a/pkg/acceptance/localcluster/cluster.go
+++ b/pkg/acceptance/localcluster/cluster.go
@@ -715,15 +715,19 @@ func (n *Node) waitUntilLive(dur time.Duration) error {
 		}
 
 		if n.Cfg.RPCPort == 0 {
-			n.Lock()
-			n.rpcPort = pgURL.Port()
-			n.Unlock()
+			func() {
+				n.Lock()
+				defer n.Unlock()
+				n.rpcPort = pgURL.Port()
+			}()
 		}
 
 		pgURL.Path = n.Cfg.DB
-		n.Lock()
-		n.pgURL = pgURL.String()
-		n.Unlock()
+		func() {
+			n.Lock()
+			defer n.Unlock()
+			n.pgURL = pgURL.String()
+		}()
 
 		var uiURL *url.URL
 
@@ -737,9 +741,11 @@ func (n *Node) waitUntilLive(dur time.Duration) error {
 		//
 		// This can be improved by making the below code run opportunistically whenever the
 		// http port is required but isn't initialized yet.
-		n.Lock()
-		n.db = makeDB(n.pgURL, n.Cfg.NumWorkers, n.Cfg.DB)
-		n.Unlock()
+		func() {
+			n.Lock()
+			defer n.Unlock()
+			n.db = makeDB(n.pgURL, n.Cfg.NumWorkers, n.Cfg.DB)
+		}()
 
 		{
 			var uiStr string

--- a/pkg/ccl/backupccl/backupinfo/manifest_handling.go
+++ b/pkg/ccl/backupccl/backupinfo/manifest_handling.go
@@ -1534,6 +1534,7 @@ func GetBackupManifests(
 			}
 
 			memMu.Lock()
+			defer memMu.Unlock()
 			err = memMu.mem.Grow(ctx, size)
 
 			if err == nil {
@@ -1541,7 +1542,6 @@ func GetBackupManifests(
 				manifests[i] = desc
 			}
 			subMem.Shrink(ctx, size)
-			memMu.Unlock()
 
 			return err
 		})

--- a/pkg/ccl/backupccl/restore_progress.go
+++ b/pkg/ccl/backupccl/restore_progress.go
@@ -176,18 +176,20 @@ func (pt *progressTracker) updateJobCallback(
 ) {
 	switch d := progressDetails.(type) {
 	case *jobspb.Progress_Restore:
-		pt.mu.Lock()
-		if pt.useFrontier {
-			// TODO (msbutler): this requires iterating over every span in the frontier,
-			// and rewriting every completed required span to disk.
-			// We may want to be more intelligent about this.
-			d.Restore.Checkpoint = persistFrontier(pt.mu.checkpointFrontier, pt.maxBytes)
-		} else {
-			if pt.mu.highWaterMark >= 0 {
-				d.Restore.HighWater = pt.mu.inFlightImportSpans[pt.mu.highWaterMark].Key
+		func() {
+			pt.mu.Lock()
+			defer pt.mu.Unlock()
+			if pt.useFrontier {
+				// TODO (msbutler): this requires iterating over every span in the frontier,
+				// and rewriting every completed required span to disk.
+				// We may want to be more intelligent about this.
+				d.Restore.Checkpoint = persistFrontier(pt.mu.checkpointFrontier, pt.maxBytes)
+			} else {
+				if pt.mu.highWaterMark >= 0 {
+					d.Restore.HighWater = pt.mu.inFlightImportSpans[pt.mu.highWaterMark].Key
+				}
 			}
-		}
-		pt.mu.Unlock()
+		}()
 	default:
 		log.Errorf(progressedCtx, "job payload had unexpected type %T", d)
 	}

--- a/pkg/ccl/changefeedccl/cdctest/mock_webhook_sink.go
+++ b/pkg/ccl/changefeedccl/cdctest/mock_webhook_sink.go
@@ -188,6 +188,7 @@ func (s *MockWebhookSink) publish(hw http.ResponseWriter, hr *http.Request) erro
 		return err
 	}
 	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.mu.numCalls++
 	if s.mu.statusCodes[s.mu.statusCodesIndex] >= http.StatusOK && s.mu.statusCodes[s.mu.statusCodesIndex] < http.StatusMultipleChoices {
 		s.mu.rows = append(s.mu.rows, string(row))
@@ -199,6 +200,5 @@ func (s *MockWebhookSink) publish(hw http.ResponseWriter, hr *http.Request) erro
 
 	hw.WriteHeader(s.mu.statusCodes[s.mu.statusCodesIndex])
 	s.mu.statusCodesIndex = (s.mu.statusCodesIndex + 1) % len(s.mu.statusCodes)
-	s.mu.Unlock()
 	return nil
 }

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -1183,11 +1183,13 @@ func (cf *changeFrontier) Start(ctx context.Context) {
 		}
 	}
 
-	cf.metrics.mu.Lock()
-	cf.metricsID = cf.metrics.mu.id
-	cf.metrics.mu.id++
-	sli.RunningCount.Inc(1)
-	cf.metrics.mu.Unlock()
+	func() {
+		cf.metrics.mu.Lock()
+		defer cf.metrics.mu.Unlock()
+		cf.metricsID = cf.metrics.mu.id
+		cf.metrics.mu.id++
+		sli.RunningCount.Inc(1)
+	}()
 
 	cf.sliMetricsID = cf.sliMetrics.claimId()
 
@@ -1223,13 +1225,15 @@ func (cf *changeFrontier) close() {
 func (cf *changeFrontier) closeMetrics() {
 	// Delete this feed from the MaxBehindNanos metric so it's no longer
 	// considered by the gauge.
-	cf.metrics.mu.Lock()
-	if cf.metricsID > 0 {
-		cf.sliMetrics.RunningCount.Dec(1)
-	}
-	delete(cf.metrics.mu.resolved, cf.metricsID)
-	cf.metricsID = -1
-	cf.metrics.mu.Unlock()
+	func() {
+		cf.metrics.mu.Lock()
+		defer cf.metrics.mu.Unlock()
+		if cf.metricsID > 0 {
+			cf.sliMetrics.RunningCount.Dec(1)
+		}
+		delete(cf.metrics.mu.resolved, cf.metricsID)
+		cf.metricsID = -1
+	}()
 
 	cf.sliMetrics.closeId(cf.sliMetricsID)
 }
@@ -1377,11 +1381,13 @@ func (cf *changeFrontier) forwardFrontier(resolved jobspb.ResolvedSpan) error {
 		cf.sliMetrics.setCheckpoint(cf.sliMetricsID, newResolved)
 
 		// This backs max_behind_nanos which is deprecated in favor of checkpoint_progress
-		cf.metrics.mu.Lock()
-		if cf.metricsID != -1 {
-			cf.metrics.mu.resolved[cf.metricsID] = newResolved
-		}
-		cf.metrics.mu.Unlock()
+		func() {
+			cf.metrics.mu.Lock()
+			defer cf.metrics.mu.Unlock()
+			if cf.metricsID != -1 {
+				cf.metrics.mu.resolved[cf.metricsID] = newResolved
+			}
+		}()
 
 		return cf.maybeEmitResolved(newResolved)
 	}

--- a/pkg/ccl/changefeedccl/event_processing.go
+++ b/pkg/ccl/changefeedccl/event_processing.go
@@ -644,9 +644,9 @@ func (c *parallelEventConsumer) workerLoop(
 
 func (c *parallelEventConsumer) incInFlight() {
 	c.mu.Lock()
+	defer c.mu.Unlock()
 	c.mu.inFlight++
 	c.metrics.ParallelConsumerInFlightEvents.Update(int64(c.mu.inFlight))
-	c.mu.Unlock()
 }
 
 func (c *parallelEventConsumer) decInFlight() {
@@ -704,9 +704,9 @@ func (c *parallelEventConsumer) Flush(ctx context.Context) error {
 		return c.mu.termErr
 	case <-c.flushCh:
 		c.mu.Lock()
+		defer c.mu.Unlock()
 		c.mu.waiting = false
 		c.mu.flushFrontier = c.spanFrontier.Frontier()
-		c.mu.Unlock()
 		return nil
 	}
 }

--- a/pkg/ccl/changefeedccl/kvevent/blocking_buffer.go
+++ b/pkg/ccl/changefeedccl/kvevent/blocking_buffer.go
@@ -164,8 +164,8 @@ func (b *blockingBuffer) notifyOutOfQuota(canFlush bool) {
 // that producer is blocked.
 func (b *blockingBuffer) producerBlocked() {
 	b.mu.Lock()
+	defer b.mu.Unlock()
 	b.mu.numBlocked++
-	b.mu.Unlock()
 }
 
 // quotaAcquiredAfterWait is invoked by quota pool to notify blocking buffer
@@ -173,6 +173,7 @@ func (b *blockingBuffer) producerBlocked() {
 // NB: always called after producerBlocked
 func (b *blockingBuffer) quotaAcquiredAfterWait() {
 	b.mu.Lock()
+	defer b.mu.Unlock()
 	if b.mu.numBlocked > 0 {
 		b.mu.numBlocked--
 	} else {
@@ -183,7 +184,6 @@ func (b *blockingBuffer) quotaAcquiredAfterWait() {
 		// Clear out canFlush since we know that producers no longer blocked.
 		b.mu.canFlush = false
 	}
-	b.mu.Unlock()
 }
 
 // Get implements kvevent.Reader interface.

--- a/pkg/ccl/changefeedccl/metrics.go
+++ b/pkg/ccl/changefeedccl/metrics.go
@@ -843,12 +843,12 @@ func MakeMetrics(histogramWindow time.Duration) metric.Struct {
 		now := timeutil.Now()
 		var maxBehind time.Duration
 		m.mu.Lock()
+		defer m.mu.Unlock()
 		for _, resolved := range m.mu.resolved {
 			if behind := now.Sub(resolved.GoTime()); behind > maxBehind {
 				maxBehind = behind
 			}
 		}
-		m.mu.Unlock()
 		return maxBehind.Nanoseconds()
 	})
 	return m

--- a/pkg/ccl/changefeedccl/sink_kafka.go
+++ b/pkg/ccl/changefeedccl/sink_kafka.go
@@ -412,16 +412,20 @@ func (s *kafkaSink) Flush(ctx context.Context) error {
 	defer s.metrics.recordFlushRequestCallback()()
 
 	flushCh := make(chan struct{}, 1)
-
-	s.mu.Lock()
-	inflight := s.mu.inflight
-	flushErr := s.mu.flushErr
-	s.mu.flushErr = nil
-	immediateFlush := inflight == 0 || flushErr != nil
-	if !immediateFlush {
-		s.mu.flushCh = flushCh
-	}
-	s.mu.Unlock()
+	var inflight int64
+	var flushErr error
+	var immediateFlush bool
+	func() {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		inflight = s.mu.inflight
+		flushErr = s.mu.flushErr
+		s.mu.flushErr = nil
+		immediateFlush = inflight == 0 || flushErr != nil
+		if !immediateFlush {
+			s.mu.flushCh = flushCh
+		}
+	}()
 
 	if immediateFlush {
 		return flushErr
@@ -435,9 +439,9 @@ func (s *kafkaSink) Flush(ctx context.Context) error {
 		return ctx.Err()
 	case <-flushCh:
 		s.mu.Lock()
+		defer s.mu.Unlock()
 		flushErr := s.mu.flushErr
 		s.mu.flushErr = nil
-		s.mu.Unlock()
 		return flushErr
 	}
 }

--- a/pkg/ccl/sqlproxyccl/acl/watcher.go
+++ b/pkg/ccl/sqlproxyccl/acl/watcher.go
@@ -214,10 +214,13 @@ func NewWatcher(ctx context.Context, opts ...Option) (*Watcher, error) {
 func (w *Watcher) addAccessController(
 	ctx context.Context, controller AccessController, next chan AccessController,
 ) {
-	w.mu.Lock()
-	index := len(w.controllers)
-	w.controllers = append(w.controllers, controller)
-	w.mu.Unlock()
+	var index int
+	func() {
+		w.mu.Lock()
+		defer w.mu.Unlock()
+		index = len(w.controllers)
+		w.controllers = append(w.controllers, controller)
+	}()
 
 	if next != nil {
 		go func() {
@@ -235,11 +238,15 @@ func (w *Watcher) addAccessController(
 func (w *Watcher) updateAccessController(
 	ctx context.Context, index int, controller AccessController,
 ) {
-	w.mu.Lock()
-	copy := w.listeners.Clone()
-	w.controllers[index] = controller
-	controllers := append([]AccessController(nil), w.controllers...)
-	w.mu.Unlock()
+	var copy *btree.BTree
+	var controllers []AccessController
+	func() {
+		w.mu.Lock()
+		defer w.mu.Unlock()
+		copy = w.listeners.Clone()
+		w.controllers[index] = controller
+		controllers = append([]AccessController(nil), w.controllers...)
+	}()
 
 	checkListeners(ctx, copy, controllers)
 }

--- a/pkg/ccl/sqlproxyccl/tenantdirsvr/test_directory_svr.go
+++ b/pkg/ccl/sqlproxyccl/tenantdirsvr/test_directory_svr.go
@@ -174,9 +174,12 @@ func (s *TestDirectoryServer) WatchPods(
 	// Make the channel with a small buffer to allow for a burst of notifications
 	// and a slow receiver.
 	c := make(chan *tenant.WatchPodsResponse, 10)
-	s.mu.Lock()
-	elem := s.mu.eventListeners.PushBack(c)
-	s.mu.Unlock()
+
+	elem := func() *list.Element {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		return s.mu.eventListeners.PushBack(c)
+	}()
 	err := s.stopper.RunTask(context.Background(), "watch-pods-server",
 		func(ctx context.Context) {
 		out:
@@ -187,17 +190,11 @@ func (s *TestDirectoryServer) WatchPods(
 						break out
 					}
 					if err := server.Send(e); err != nil {
-						s.mu.Lock()
-						s.mu.eventListeners.Remove(elem)
-						close(c)
-						s.mu.Unlock()
+						s.removeEventListenerAndCloseChan(elem, c)
 						break out
 					}
 				case <-s.stopper.ShouldQuiesce():
-					s.mu.Lock()
-					s.mu.eventListeners.Remove(elem)
-					close(c)
-					s.mu.Unlock()
+					s.removeEventListenerAndCloseChan(elem, c)
 					break out
 				}
 			}
@@ -367,4 +364,13 @@ func (s *TestDirectoryServer) deregisterInstance(tenantID uint64, sqlAddr string
 	} else {
 		s.mu.processByAddrByTenantID[tenantID] = remaining
 	}
+}
+
+func (s *TestDirectoryServer) removeEventListenerAndCloseChan(
+	elem *list.Element, c chan *tenant.WatchPodsResponse,
+) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.mu.eventListeners.Remove(elem)
+	close(c)
 }

--- a/pkg/ccl/streamingccl/streamclient/random_stream_client.go
+++ b/pkg/ccl/streamingccl/streamclient/random_stream_client.go
@@ -494,9 +494,11 @@ func (m *RandomStreamClient) Subscribe(
 
 	// rand is not thread safe, so create a random source for each partition.
 	rng, _ := randutil.NewPseudoRand()
-	m.mu.Lock()
-	reg, err := newRandomEventGenerator(rng, partitionURL, config, m.mu.sstMaker)
-	m.mu.Unlock()
+	reg, err := func() (*randomEventGenerator, error) {
+		m.mu.Lock()
+		defer m.mu.Unlock()
+		return newRandomEventGenerator(rng, partitionURL, config, m.mu.sstMaker)
+	}()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/config/system.go
+++ b/pkg/config/system.go
@@ -139,9 +139,12 @@ func (s *SystemConfig) getSystemTenantDesc(key roachpb.Key) *roachpb.Value {
 		panic(err)
 	}
 
-	testingLock.Lock()
-	_, ok := testingZoneConfig[ObjectID(id)]
-	testingLock.Unlock()
+	_, ok := func() (zonepb.ZoneConfig, bool) {
+		testingLock.Lock()
+		defer testingLock.Unlock()
+		zc, ok := testingZoneConfig[ObjectID(id)]
+		return zc, ok
+	}()
 
 	if ok {
 		// A test installed a zone config for this ID, but no descriptor.

--- a/pkg/gossip/client.go
+++ b/pkg/gossip/client.go
@@ -124,13 +124,16 @@ func (c *client) startLocked(
 		log.Infof(ctx, "started gossip client to n%d (%s)", c.peerID, c.addr)
 		if err := c.gossip(ctx, g, stream, stopper, &wg); err != nil {
 			if !grpcutil.IsClosedConnection(err) {
-				g.mu.RLock()
+				peerID, addr := func() (roachpb.NodeID, net.Addr) {
+					g.mu.RLock()
+					defer g.mu.RUnlock()
+					return c.peerID, c.addr
+				}()
 				if c.peerID != 0 {
-					log.Infof(ctx, "closing client to n%d (%s): %s", c.peerID, c.addr, err)
+					log.Infof(ctx, "closing client to n%d (%s): %s", peerID, addr, err)
 				} else {
-					log.Infof(ctx, "closing client to %s: %s", c.addr, err)
+					log.Infof(ctx, "closing client to %s: %s", addr, err)
 				}
-				g.mu.RUnlock()
 			}
 		}
 	}); err != nil {
@@ -151,14 +154,17 @@ func (c *client) close() {
 // supplying a map of this node's knowledge of other nodes' high water
 // timestamps.
 func (c *client) requestGossip(g *Gossip, stream Gossip_GossipClient) error {
-	g.mu.RLock()
+	nodeAddr, highWaterStamps := func() (util.UnresolvedAddr, map[roachpb.NodeID]int64) {
+		g.mu.RLock()
+		defer g.mu.RUnlock()
+		return g.mu.is.NodeAddr, g.mu.is.getHighWaterStamps()
+	}()
 	args := &Request{
 		NodeID:          g.NodeID.Get(),
-		Addr:            g.mu.is.NodeAddr,
-		HighWaterStamps: g.mu.is.getHighWaterStamps(),
+		Addr:            nodeAddr,
+		HighWaterStamps: highWaterStamps,
 		ClusterID:       g.clusterID.Get(),
 	}
-	g.mu.RUnlock()
 
 	bytesSent := int64(args.Size())
 	c.clientMetrics.BytesSent.Inc(bytesSent)
@@ -206,7 +212,6 @@ func (c *client) sendGossip(g *Gossip, stream Gossip_GossipClient, firstReq bool
 				log.Infof(ctx, "sending %s to %s", extractKeys(args.Delta), c.addr)
 			}
 		}
-
 		g.mu.Unlock()
 		return stream.Send(&args)
 	}

--- a/pkg/gossip/gossip.go
+++ b/pkg/gossip/gossip.go
@@ -306,12 +306,12 @@ func New(
 	registry.AddMetric(g.outgoing.gauge)
 
 	g.mu.Lock()
+	defer g.mu.Unlock()
 	// Add ourselves as a SystemConfig watcher.
 	g.mu.is.registerCallback(KeyDeprecatedSystemConfig, g.updateSystemConfig)
 	// Add ourselves as a node descriptor watcher.
 	g.mu.is.registerCallback(MakePrefixPattern(KeyNodeDescPrefix), g.updateNodeAddress)
 	g.mu.is.registerCallback(MakePrefixPattern(KeyStoreDescPrefix), g.updateStoreMap)
-	g.mu.Unlock()
 
 	return g
 }
@@ -541,18 +541,20 @@ func (g *Gossip) GetStoreDescriptor(storeID roachpb.StoreID) (*roachpb.StoreDesc
 // LogStatus logs the current status of gossip such as the incoming and
 // outgoing connections.
 func (g *Gossip) LogStatus() {
-	g.mu.RLock()
-	var n int
-	g.nodeDescs.Range(func(_ int64, _ unsafe.Pointer) bool {
-		n++
-		return true
-	})
-	status := redact.SafeString("ok")
-	if g.mu.is.getInfo(KeySentinel) == nil {
-		status = redact.SafeString("stalled")
-	}
-	g.mu.RUnlock()
-
+	n, status := func() (int, redact.SafeString) {
+		var inc int
+		g.mu.RLock()
+		defer g.mu.RUnlock()
+		g.nodeDescs.Range(func(_ int64, _ unsafe.Pointer) bool {
+			inc++
+			return true
+		})
+		s := redact.SafeString("ok")
+		if g.mu.is.getInfo(KeySentinel) == nil {
+			s = redact.SafeString("stalled")
+		}
+		return inc, s
+	}()
 	ctx := g.AnnotateCtx(context.TODO())
 	log.Health.Infof(ctx, "gossip status (%s, %d node%s)\n%s%s",
 		status, n, util.Pluralize(int64(n)),
@@ -943,9 +945,11 @@ func (g *Gossip) GetClusterID() (uuid.UUID, error) {
 // GetInfo returns an info value by key or an KeyNotPresentError if specified
 // key does not exist or has expired.
 func (g *Gossip) GetInfo(key string) ([]byte, error) {
-	g.mu.RLock()
-	i := g.mu.is.getInfo(key)
-	g.mu.RUnlock()
+	i := func() *Info {
+		g.mu.RLock()
+		defer g.mu.RUnlock()
+		return g.mu.is.getInfo(key)
+	}()
 
 	if i != nil {
 		if err := i.Value.Verify([]byte(key)); err != nil {
@@ -1008,8 +1012,8 @@ func (g *Gossip) tryClearInfoWithTTL(key string, ttl time.Duration) (bool, error
 // is regossiped as soon as possible when its lease changes hands.
 func (g *Gossip) InfoOriginatedHere(key string) bool {
 	g.mu.RLock()
+	defer g.mu.RUnlock()
 	info := g.mu.is.getInfo(key)
-	g.mu.RUnlock()
 	return info != nil && info.NodeID == g.NodeID.Get()
 }
 
@@ -1070,13 +1074,15 @@ var Redundant redundantCallbacks
 // received. The callback method is invoked with the info key which
 // matched pattern. Returns a function to unregister the callback.
 func (g *Gossip) RegisterCallback(pattern string, method Callback, opts ...CallbackOption) func() {
-	g.mu.Lock()
-	unregister := g.mu.is.registerCallback(pattern, method, opts...)
-	g.mu.Unlock()
+	unregister := func() func() {
+		g.mu.Lock()
+		defer g.mu.Unlock()
+		return g.mu.is.registerCallback(pattern, method, opts...)
+	}()
 	return func() {
 		g.mu.Lock()
+		defer g.mu.Unlock()
 		unregister()
-		g.mu.Unlock()
 	}
 }
 
@@ -1314,9 +1320,11 @@ func (g *Gossip) manage(rpcContext *rpc.Context) {
 							}()
 						} else {
 							if log.V(1) {
-								g.clientsMu.Lock()
-								log.Dev.Infof(ctx, "couldn't find least useful client among %+v", g.clientsMu.clients)
-								g.clientsMu.Unlock()
+								func() {
+									g.clientsMu.Lock()
+									defer g.clientsMu.Unlock()
+									log.Dev.Infof(ctx, "couldn't find least useful client among %+v", g.clientsMu.clients)
+								}()
 							}
 						}
 					}
@@ -1325,10 +1333,11 @@ func (g *Gossip) manage(rpcContext *rpc.Context) {
 			case <-stallTimer.C:
 				stallTimer.Read = true
 				stallTimer.Reset(jitteredInterval(g.stallInterval))
-
-				g.mu.Lock()
-				g.maybeSignalStatusChangeLocked()
-				g.mu.Unlock()
+				func() {
+					g.mu.Lock()
+					defer g.mu.Unlock()
+					g.maybeSignalStatusChangeLocked()
+				}()
 			}
 		}
 	})

--- a/pkg/gossip/server.go
+++ b/pkg/gossip/server.go
@@ -387,9 +387,11 @@ func (s *server) start(addr net.Addr) {
 	waitQuiesce := func(context.Context) {
 		<-s.stopper.ShouldQuiesce()
 
-		s.mu.Lock()
-		unregister()
-		s.mu.Unlock()
+		func() {
+			s.mu.Lock()
+			defer s.mu.Unlock()
+			unregister()
+		}()
 
 		broadcast()
 	}

--- a/pkg/jobs/adopt.go
+++ b/pkg/jobs/adopt.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/multitenant"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
@@ -426,14 +427,15 @@ func (r *Registry) runJob(
 		return errors.Newf("refusing to start %q; job registry is draining", taskName)
 	}
 
-	job.mu.Lock()
 	var finalResumeError error
-	if job.mu.payload.FinalResumeError != nil {
-		finalResumeError = errors.DecodeError(ctx, *job.mu.payload.FinalResumeError)
-	}
-	username := job.mu.payload.UsernameProto.Decode()
-	typ := job.mu.payload.Type()
-	job.mu.Unlock()
+	username, typ := func() (username.SQLUsername, jobspb.Type) {
+		job.mu.Lock()
+		defer job.mu.Unlock()
+		if job.mu.payload.FinalResumeError != nil {
+			finalResumeError = errors.DecodeError(ctx, *job.mu.payload.FinalResumeError)
+		}
+		return job.mu.payload.UsernameProto.Decode(), job.mu.payload.Type()
+	}()
 
 	// Make sure that we remove the job from the running set when this returns.
 	defer r.unregister(job.ID())

--- a/pkg/jobs/job_scheduler.go
+++ b/pkg/jobs/job_scheduler.go
@@ -362,10 +362,10 @@ func newCancelWhenDisabled(sv *settings.Values) *syncCancelFunc {
 	schedulerEnabledSetting.SetOnChange(sv, func(ctx context.Context) {
 		if !schedulerEnabledSetting.Get(sv) {
 			sf.Lock()
+			defer sf.Unlock()
 			if sf.CancelFunc != nil {
 				sf.CancelFunc()
 			}
-			sf.Unlock()
 		}
 	})
 	return sf

--- a/pkg/jobs/progress.go
+++ b/pkg/jobs/progress.go
@@ -140,18 +140,19 @@ type ProgressUpdateBatcher struct {
 // change in the completed progress (and enough time has passed) to report the
 // new progress amount.
 func (p *ProgressUpdateBatcher) Add(ctx context.Context, delta float32) error {
-	p.Lock()
-	p.completed += delta
-	completed := p.completed
-	shouldReport := p.completed-p.reported > progressFractionThreshold
-	shouldReport = shouldReport || (p.completed > p.reported && p.lastReported.Add(progressTimeThreshold).Before(timeutil.Now()))
-
-	if shouldReport {
-		p.reported = p.completed
-		p.lastReported = timeutil.Now()
-	}
-	p.Unlock()
-
+	shouldReport, completed := func() (bool, float32) {
+		p.Lock()
+		defer p.Unlock()
+		p.completed += delta
+		c := p.completed
+		sReport := p.completed-p.reported > progressFractionThreshold
+		sReport = sReport || (p.completed > p.reported && p.lastReported.Add(progressTimeThreshold).Before(timeutil.Now()))
+		if sReport {
+			p.reported = p.completed
+			p.lastReported = timeutil.Now()
+		}
+		return sReport, c
+	}()
 	if shouldReport {
 		return p.Report(ctx, completed)
 	}
@@ -165,7 +166,6 @@ func (p *ProgressUpdateBatcher) Done(ctx context.Context) error {
 	completed := p.completed
 	shouldReport := completed-p.reported > progressFractionThreshold
 	p.Unlock()
-
 	if shouldReport {
 		return p.Report(ctx, completed)
 	}


### PR DESCRIPTION
This PR updates unsafe/unnecessary manual unlocks to defer unlocks.
The criteria for leaving some unlocks as is:
 - will not cause a leak
 - releases the resources much earlier
 - deferring will cause a deadlock without significant refactor

Part of #107946

Release note: None

Signoffs
- [x] acceptance
- [x] backupccl
- [x] changefeedccl
- [x] multitenantccl
- [x] sqlproxyccl
- [x] cli
- [x] cmd
- [x] config
- [x] gossip
- [x] internal
- [x] jobs