### PR TITLE
kv: cleanup lock usages

### DIFF
--- a/pkg/kv/kvclient/rangecache/range_cache.go
+++ b/pkg/kv/kvclient/rangecache/range_cache.go
@@ -763,6 +763,7 @@ func (rc *RangeCache) tryLookup(
 ) (EvictionToken, error) {
 	rc.rangeCache.RLock()
 	if entry, _ := rc.getCachedRLocked(ctx, key, useReverseScan); entry != nil {
+		// nolint:deferunlock
 		rc.rangeCache.RUnlock()
 		returnToken := rc.makeEvictionToken(entry, nil /* nextDesc */)
 		return returnToken, nil
@@ -842,6 +843,7 @@ func (rc *RangeCache) tryLookup(
 	// We must use DoChan above so that we can always unlock this mutex. This must
 	// be done *after* the request has been added to the lookupRequests group, or
 	// we risk it racing with an inflight request.
+	// nolint:deferunlock
 	rc.rangeCache.RUnlock()
 
 	if !leader {

--- a/pkg/kv/kvserver/allocator/allocatorimpl/allocator_scorer.go
+++ b/pkg/kv/kvserver/allocator/allocatorimpl/allocator_scorer.go
@@ -1013,9 +1013,12 @@ func (cl candidateList) selectBest(randGen allocatorRand) *candidate {
 	if len(cl) == 1 {
 		return &cl[0]
 	}
-	randGen.Lock()
-	order := randGen.Perm(len(cl))
-	randGen.Unlock()
+
+	order := func() []int {
+		randGen.Lock()
+		defer randGen.Unlock()
+		return randGen.Perm(len(cl))
+	}()
 	best := &cl[order[0]]
 	for i := 1; i < allocatorRandomCount; i++ {
 		if best.less(cl[order[i]]) {
@@ -1035,9 +1038,11 @@ func (cl candidateList) selectGood(randGen allocatorRand) *candidate {
 	if len(cl) == 1 {
 		return &cl[0]
 	}
-	randGen.Lock()
-	r := randGen.Intn(len(cl))
-	randGen.Unlock()
+	r := func() int {
+		randGen.Lock()
+		defer randGen.Unlock()
+		return randGen.Intn(len(cl))
+	}()
 	c := &cl[r]
 	return c
 }
@@ -1052,9 +1057,11 @@ func (cl candidateList) selectWorst(randGen allocatorRand) *candidate {
 	if len(cl) == 1 {
 		return &cl[0]
 	}
-	randGen.Lock()
-	order := randGen.Perm(len(cl))
-	randGen.Unlock()
+	order := func() []int {
+		randGen.Lock()
+		defer randGen.Unlock()
+		return randGen.Perm(len(cl))
+	}()
 	worst := &cl[order[0]]
 	for i := 1; i < allocatorRandomCount; i++ {
 		if cl[order[i]].less(*worst) {

--- a/pkg/kv/kvserver/concurrency/lock_table_waiter.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_waiter.go
@@ -1095,11 +1095,12 @@ func newContentionEventTracer(sp *tracing.Span, clock *hlc.Clock) *contentionEve
 		oldContentionTag.mu.Lock()
 		waiting := oldContentionTag.mu.waiting
 		if waiting {
-			oldContentionTag.mu.Unlock()
+			defer oldContentionTag.mu.Unlock()
 			panic("span already contains contention tag in the waiting state")
 		}
 		t.tag.mu.numLocks = oldContentionTag.mu.numLocks
 		t.tag.mu.lockWait = oldContentionTag.mu.lockWait
+		// nolint:deferunlock
 		oldContentionTag.mu.Unlock()
 	}
 

--- a/pkg/kv/kvserver/kvflowcontrol/kvflowcontroller/kvflowcontroller.go
+++ b/pkg/kv/kvserver/kvflowcontrol/kvflowcontroller/kvflowcontroller.go
@@ -142,10 +142,12 @@ func (c *Controller) Admit(
 	logged := false
 	tstart := c.clock.PhysicalTime()
 	for {
-		c.mu.Lock()
-		b := c.getBucketLocked(connection.Stream())
-		tokens := b.tokens[class]
-		c.mu.Unlock()
+		b, tokens := func() (bucket, kvflowcontrol.Tokens) {
+			c.mu.Lock()
+			defer c.mu.Unlock()
+			bt := c.getBucketLocked(connection.Stream())
+			return bt, bt.tokens[class]
+		}()
 
 		if tokens > 0 ||
 			// In addition to letting requests through when there are tokens

--- a/pkg/kv/kvserver/liveness/cache.go
+++ b/pkg/kv/kvserver/liveness/cache.go
@@ -123,13 +123,13 @@ func (c *cache) storeGossipUpdate(_ string, content roachpb.Value) {
 		return
 	}
 	c.mu.Lock()
+	defer c.mu.Unlock()
 	previousRec, found := c.mu.lastNodeUpdate[nodeID]
 	if !found {
 		previousRec = UpdateInfo{}
 	}
 	previousRec.lastUpdateTime = c.clock.Now()
 	c.mu.lastNodeUpdate[nodeID] = previousRec
-	c.mu.Unlock()
 }
 
 // maybeUpdate replaces the liveness (if it appears newer) and invokes the
@@ -157,6 +157,7 @@ func (c *cache) maybeUpdate(ctx context.Context, newLivenessRec Record) {
 	if shouldReplace {
 		c.mu.nodes[newLivenessRec.NodeID] = newLivenessRec
 	}
+	// nolint:deferunlock
 	c.mu.Unlock()
 
 	if shouldReplace {

--- a/pkg/kv/kvserver/rangefeed/budget.go
+++ b/pkg/kv/kvserver/rangefeed/budget.go
@@ -210,15 +210,16 @@ func (f *FeedBudget) WaitAndGet(
 
 // Return returns amount to budget.
 func (f *FeedBudget) returnAllocation(ctx context.Context, amount int64) {
-	f.mu.Lock()
-	if f.mu.closed {
-		f.mu.Unlock()
-		return
-	}
-	if amount > 0 {
-		f.mu.memBudget.Shrink(ctx, amount)
-	}
-	f.mu.Unlock()
+	func() {
+		f.mu.Lock()
+		defer f.mu.Unlock()
+		if f.mu.closed {
+			return
+		}
+		if amount > 0 {
+			f.mu.memBudget.Shrink(ctx, amount)
+		}
+	}()
 	select {
 	case f.replenishC <- struct{}{}:
 	default:
@@ -233,10 +234,10 @@ func (f *FeedBudget) Close(ctx context.Context) {
 	}
 	f.closed.Do(func() {
 		f.mu.Lock()
+		defer f.mu.Unlock()
 		f.mu.closed = true
 		f.mu.memBudget.Close(ctx)
 		close(f.stopC)
-		f.mu.Unlock()
 	})
 }
 

--- a/pkg/kv/kvserver/replica_rangefeed.go
+++ b/pkg/kv/kvserver/replica_rangefeed.go
@@ -230,6 +230,7 @@ func (r *Replica) RangeFeed(
 	// the registration doesn't miss any events.
 	r.raftMu.Lock()
 	if err := r.checkExecutionCanProceedForRangeFeed(ctx, rSpan, checkTS); err != nil {
+		// nolint:deferunlock
 		r.raftMu.Unlock()
 		iterSemRelease()
 		return future.MakeCompletedErrorFuture(err)
@@ -253,6 +254,7 @@ func (r *Replica) RangeFeed(
 	p := r.registerWithRangefeedRaftMuLocked(
 		ctx, rSpan, args.Timestamp, catchUpIterFunc, args.WithDiff, lockedStream, &done,
 	)
+	// nolint:deferunlock
 	r.raftMu.Unlock()
 
 	// This call is a no-op if we have successfully registered; but in case we
@@ -359,6 +361,7 @@ func (r *Replica) registerWithRangefeedRaftMuLocked(
 			// Update the rangefeed filter to avoid filtering ops
 			// that this new registration might be interested in.
 			r.setRangefeedFilterLocked(filter)
+			// nolint:deferunlock
 			r.rangefeedMu.Unlock()
 			return p
 		}
@@ -368,6 +371,7 @@ func (r *Replica) registerWithRangefeedRaftMuLocked(
 		r.unsetRangefeedProcessorLocked(p)
 		p = nil
 	}
+	// nolint:deferunlock
 	r.rangefeedMu.Unlock()
 
 	feedBudget := r.store.GetStoreConfig().RangefeedBudgetFactory.CreateBudget(r.startKey)
@@ -435,9 +439,11 @@ func (r *Replica) registerWithRangefeedRaftMuLocked(
 
 	// Set the rangefeed processor and filter reference.
 	r.setRangefeedProcessor(p)
-	r.rangefeedMu.Lock()
-	r.setRangefeedFilterLocked(filter)
-	r.rangefeedMu.Unlock()
+	func() {
+		r.rangefeedMu.Lock()
+		defer r.rangefeedMu.Unlock()
+		r.setRangefeedFilterLocked(filter)
+	}()
 
 	// Check for an initial closed timestamp update immediately to help
 	// initialize the rangefeed's resolved timestamp as soon as possible.

--- a/pkg/kv/kvserver/replica_send.go
+++ b/pkg/kv/kvserver/replica_send.go
@@ -1114,10 +1114,14 @@ func (r *Replica) collectSpans(
 	_ error,
 ) {
 	latchSpans, lockSpans = spanset.New(), lockspanset.New()
-	r.mu.RLock()
-	desc := r.descRLocked()
-	liveCount := r.mu.state.Stats.LiveCount
-	r.mu.RUnlock()
+	var desc *roachpb.RangeDescriptor
+	var liveCount int64
+	func() {
+		r.mu.RLock()
+		defer r.mu.RUnlock()
+		desc = r.descRLocked()
+		liveCount = r.mu.state.Stats.LiveCount
+	}()
 	// TODO(bdarnell): need to make this less global when local
 	// latches are used more heavily. For example, a split will
 	// have a large read-only span but also a write (see #10084).

--- a/pkg/kv/kvserver/replica_write.go
+++ b/pkg/kv/kvserver/replica_write.go
@@ -101,6 +101,7 @@ func (r *Replica) executeWriteBatch(
 	readOnlyCmdMu.RLock()
 	defer func() {
 		if readOnlyCmdMu != nil {
+			// nolint:deferunlock
 			readOnlyCmdMu.RUnlock()
 		}
 	}()
@@ -180,6 +181,7 @@ func (r *Replica) executeWriteBatch(
 	if pErr != nil {
 		if cErr, ok := pErr.GetDetail().(*kvpb.ReplicaCorruptionError); ok {
 			// Need to unlock here because setCorruptRaftMuLock needs readOnlyCmdMu not held.
+			// nolint:deferunlock
 			readOnlyCmdMu.RUnlock()
 			readOnlyCmdMu = nil
 
@@ -194,6 +196,7 @@ func (r *Replica) executeWriteBatch(
 
 	// We are done with pre-Raft evaluation at this point, and have to release the
 	// read-only command lock to avoid deadlocks during Raft evaluation.
+	// nolint:deferunlock
 	readOnlyCmdMu.RUnlock()
 	readOnlyCmdMu = nil
 

--- a/pkg/kv/kvserver/split_delay_helper.go
+++ b/pkg/kv/kvserver/split_delay_helper.go
@@ -35,6 +35,7 @@ type splitDelayHelper Replica
 func (sdh *splitDelayHelper) RaftStatus(ctx context.Context) (roachpb.RangeID, *raft.Status) {
 	r := (*Replica)(sdh)
 	r.mu.RLock()
+	defer r.mu.RUnlock()
 	raftStatus := r.raftStatusRLocked()
 	if raftStatus != nil {
 		updateRaftProgressFromActivity(
@@ -44,7 +45,6 @@ func (sdh *splitDelayHelper) RaftStatus(ctx context.Context) (roachpb.RangeID, *
 			},
 		)
 	}
-	r.mu.RUnlock()
 	return r.RangeID, raftStatus
 }
 

--- a/pkg/kv/kvserver/split_trigger_helper.go
+++ b/pkg/kv/kvserver/split_trigger_helper.go
@@ -27,10 +27,13 @@ type replicaMsgAppDropper Replica
 
 func (rd *replicaMsgAppDropper) Args() (initialized bool, age time.Duration) {
 	r := (*Replica)(rd)
-	r.mu.RLock()
-	initialized = r.IsInitialized()
-	creationTime := r.creationTime
-	r.mu.RUnlock()
+	var creationTime time.Time
+	func() {
+		r.mu.RLock()
+		defer r.mu.RUnlock()
+		initialized = r.IsInitialized()
+		creationTime = r.creationTime
+	}()
 	age = timeutil.Since(creationTime)
 	return initialized, age
 }

--- a/pkg/kv/kvserver/store_remove_replica.go
+++ b/pkg/kv/kvserver/store_remove_replica.go
@@ -161,6 +161,7 @@ func (s *Store) removeInitializedReplicaRaftMuLocked(
 		// This is a fatal error because uninitialized replicas shouldn't make it
 		// this far. This method will need some changes when we introduce GC of
 		// uninitialized replicas.
+		// nolint:deferunlock
 		s.mu.Unlock()
 		log.Fatalf(ctx, "replica %+v unexpectedly overlapped by %+v", rep, it.item)
 	}
@@ -170,6 +171,7 @@ func (s *Store) removeInitializedReplicaRaftMuLocked(
 
 	s.metrics.subtractMVCCStats(ctx, rep.tenantMetricsRef, rep.GetMVCCStats())
 	s.metrics.ReplicaCount.Dec(1)
+	// nolint:deferunlock
 	s.mu.Unlock()
 
 	// The replica will no longer exist, so cancel any rangefeed registrations.
@@ -252,13 +254,17 @@ func (s *Store) removeUninitializedReplicaRaftMuLocked(
 		// because we should have already checked this under the raftMu
 		// before calling this method.
 		if rep.mu.destroyStatus.Removed() {
+			// nolint:deferunlock
 			rep.mu.Unlock()
+			// nolint:deferunlock
 			rep.readOnlyCmdMu.Unlock()
 			log.Fatalf(ctx, "uninitialized replica unexpectedly already removed")
 		}
 
 		if rep.IsInitialized() {
+			// nolint:deferunlock
 			rep.mu.Unlock()
+			// nolint:deferunlock
 			rep.readOnlyCmdMu.Unlock()
 			log.Fatalf(ctx, "cannot remove initialized replica in removeUninitializedReplica: %v", rep)
 		}
@@ -266,8 +272,9 @@ func (s *Store) removeUninitializedReplicaRaftMuLocked(
 		// Mark the replica as removed before deleting data.
 		rep.mu.destroyStatus.Set(kvpb.NewRangeNotFoundError(rep.RangeID, rep.StoreID()),
 			destroyReasonRemoved)
-
+		// nolint:deferunlock
 		rep.mu.Unlock()
+		// nolint:deferunlock
 		rep.readOnlyCmdMu.Unlock()
 	}
 
@@ -302,9 +309,11 @@ func (s *Store) removeUninitializedReplicaRaftMuLocked(
 // store.mu must be held.
 func (s *Store) unlinkReplicaByRangeIDLocked(ctx context.Context, rangeID roachpb.RangeID) {
 	s.mu.AssertHeld()
-	s.unquiescedReplicas.Lock()
-	delete(s.unquiescedReplicas.m, rangeID)
-	s.unquiescedReplicas.Unlock()
+	func() {
+		s.unquiescedReplicas.Lock()
+		defer s.unquiescedReplicas.Unlock()
+		delete(s.unquiescedReplicas.m, rangeID)
+	}()
 	delete(s.mu.uninitReplicas, rangeID)
 	s.mu.replicasByRangeID.Delete(rangeID)
 	s.unregisterLeaseholderByID(ctx, rangeID)

--- a/pkg/kv/kvserver/store_snapshot.go
+++ b/pkg/kv/kvserver/store_snapshot.go
@@ -879,6 +879,7 @@ func (s *Store) canAcceptSnapshotLocked(
 	existingDesc := existingRepl.mu.state.Desc
 	existingIsInitialized := existingDesc.IsInitialized()
 	existingDestroyStatus := existingRepl.mu.destroyStatus
+	// nolint:deferunlock
 	existingRepl.mu.RUnlock()
 
 	if existingIsInitialized {


### PR DESCRIPTION
This PR updates unsafe/unnecessary manual unlocks to defer unlocks. Usages that were good as is
added the `nolint:deferunlock` comment to pass
the incoming defer unlock linter. The criteria for leaving some unlocks as is:
 - will not cause a leak
 - releases the resources much earlier
 - deferring will cause a deadlock without significant refactor

Part of #107946

Release note: None