### PR TITLE
dev: set `COCKROACH_DEV_LICENSE` for `compose`

### DIFF
--- a/pkg/cmd/dev/compose.go
+++ b/pkg/cmd/dev/compose.go
@@ -78,6 +78,7 @@ func (d *dev) compose(cmd *cobra.Command, _ []string) error {
 
 	args = append(args, "--test_arg", "-cockroach", "--test_arg", cockroachBin)
 	args = append(args, "--test_arg", "-compare", "--test_arg", compareBin)
+	args = append(args, "--test_env", "COCKROACH_DEV_LICENSE")
 
 	logCommand("bazel", args...)
 	return d.exec.CommandContextInheritingStdStreams(ctx, "bazel", args...)


### PR DESCRIPTION
This test won't run without the license key set.

Epic: CRDB-17171
Release note: None