### PR TITLE
asim: rename uniform placement type to even placement type

### DIFF
--- a/pkg/kv/kvserver/asim/gen/generator.go
+++ b/pkg/kv/kvserver/asim/gen/generator.go
@@ -190,7 +190,7 @@ func (lr LoadedRanges) Generate(
 type PlacementType int
 
 const (
-	Uniform PlacementType = iota
+	Even PlacementType = iota
 	Skewed
 )
 
@@ -209,7 +209,7 @@ type BaseRanges struct {
 // PlacementType while using other BaseRanges fields for range configuration.
 func (b BaseRanges) getRangesInfo(pType PlacementType, numOfStores int) state.RangesInfo {
 	switch pType {
-	case Uniform:
+	case Even:
 		return state.RangesInfoEvenDistribution(numOfStores, b.Ranges, b.KeySpace, b.ReplicationFactor, b.Bytes)
 	case Skewed:
 		return state.RangesInfoSkewedDistribution(numOfStores, b.Ranges, b.KeySpace, b.ReplicationFactor, b.Bytes)
@@ -227,7 +227,7 @@ func (b BaseRanges) loadRangeInfo(s state.State, rangesInfo state.RangesInfo) {
 }
 
 // BasicRanges implements the RangeGen interface, supporting basic range info
-// distribution, including uniform and skewed distributions.
+// distribution, including even and skewed distributions.
 type BasicRanges struct {
 	BaseRanges
 	PlacementType PlacementType

--- a/pkg/kv/kvserver/asim/tests/datadriven_simulation_test.go
+++ b/pkg/kv/kvserver/asim/tests/datadriven_simulation_test.go
@@ -209,7 +209,7 @@ func TestDataDriven(t *testing.T) {
 				if placementSkew {
 					placementType = gen.Skewed
 				} else {
-					placementType = gen.Uniform
+					placementType = gen.Even
 				}
 				rangeGen = gen.BasicRanges{
 					BaseRanges: gen.BaseRanges{

--- a/pkg/kv/kvserver/asim/tests/default_settings.go
+++ b/pkg/kv/kvserver/asim/tests/default_settings.go
@@ -63,7 +63,7 @@ func defaultLoadGen() gen.BasicLoad {
 
 const (
 	defaultRanges            = 1
-	defaultPlacementType     = gen.Uniform
+	defaultPlacementType     = gen.Even
 	defaultReplicationFactor = 1
 	defaultBytes             = 0
 )


### PR DESCRIPTION
Previously, we use uniform as a placement type when describing equal and
deterministic allocation of ranges among stores. This leads to confusion as the
term uniform is associated with probability distribution where all outcomes are
equally likely for ranges and key space generators. In our context, the
allocation of ranges is deterministic and even, not probabilistic. This patch
renames uniform to even to be clearer.

Release Note: none
Epic: none