### PR TITLE
ccl/sqlproxyccl: avoid holding onto the lock in ListenForDenied

### DIFF
--- a/pkg/ccl/sqlproxyccl/acl/cidr_ranges.go
+++ b/pkg/ccl/sqlproxyccl/acl/cidr_ranges.go
@@ -28,14 +28,14 @@ var _ AccessController = &CIDRRanges{}
 
 // CheckConnection implements the AccessController interface.
 func (p *CIDRRanges) CheckConnection(ctx context.Context, conn ConnectionTags) error {
-	tenantObj, err := p.LookupTenantFn(ctx, conn.TenantID)
-	if err != nil {
-		return err
-	}
-
 	// Private connections. This ACL is only responsible for public CIDR ranges.
 	if conn.EndpointID != "" {
 		return nil
+	}
+
+	tenantObj, err := p.LookupTenantFn(ctx, conn.TenantID)
+	if err != nil {
+		return err
 	}
 
 	// Cluster allows public connections, so we'll check allowed CIDR ranges.

--- a/pkg/ccl/sqlproxyccl/acl/private_endpoints.go
+++ b/pkg/ccl/sqlproxyccl/acl/private_endpoints.go
@@ -37,14 +37,14 @@ var _ AccessController = &PrivateEndpoints{}
 
 // CheckConnection implements the AccessController interface.
 func (p *PrivateEndpoints) CheckConnection(ctx context.Context, conn ConnectionTags) error {
-	tenantObj, err := p.LookupTenantFn(ctx, conn.TenantID)
-	if err != nil {
-		return err
-	}
-
 	// Public connections. This ACL is only responsible for private endpoints.
 	if conn.EndpointID == "" {
 		return nil
+	}
+
+	tenantObj, err := p.LookupTenantFn(ctx, conn.TenantID)
+	if err != nil {
+		return err
 	}
 
 	// Cluster allows private connections, so we'll check allowed endpoints.

--- a/pkg/ccl/sqlproxyccl/acl/private_endpoints_test.go
+++ b/pkg/ccl/sqlproxyccl/acl/private_endpoints_test.go
@@ -41,7 +41,7 @@ func TestPrivateEndpoints(t *testing.T) {
 				return nil, errors.New("foo")
 			},
 		}
-		err := p.CheckConnection(ctx, makeConn(""))
+		err := p.CheckConnection(ctx, makeConn("foo"))
 		require.EqualError(t, err, "foo")
 	})
 


### PR DESCRIPTION
#### ccl/sqlproxyccl: avoid holding onto the lock in ListenForDenied 

Previously, ListenForDenied would grab the watcher's lock (which is tied to
the scope of the proxy) before calling checkConnection. As part of the updated
ACL work, checkConnection now will grab a lock when it calls Initialize on a
given tenant. Given that checkConnection can be blocking, grabbing onto the
global watcher lock isn't ideal as it could hold up new connections, leading
to timeout issues.

This commit updates ListenForDenied such that the watcher's lock gets released
before invoking checkConnection.

#### ccl/sqlproxyccl: avoid tenant lookups if we know the type of connection 

Previously, we were performing a tenant lookup call before checking on the
type of connection. This can be unnecessary (e.g. doing a lookup call for the
private endpoints ACL, even if we knew that the connection was a public one).
This commit addresses that.

Release note: None

Epic: none