### PR TITLE
asim: enforce len(weighted_rand) == number of stores

### DIFF
--- a/pkg/kv/kvserver/asim/tests/datadriven_simulation_test.go
+++ b/pkg/kv/kvserver/asim/tests/datadriven_simulation_test.go
@@ -161,7 +161,13 @@ func TestDataDriven(t *testing.T) {
 		const defaultKeyspace = 10000
 		loadGen := gen.BasicLoad{}
 		var clusterGen gen.ClusterGen
-		rangeGen := defaultBasicRangesGen()
+		var rangeGen gen.RangeGen = gen.BasicRanges{
+			BaseRanges: gen.BaseRanges{
+				Ranges:            1,
+				ReplicationFactor: 1,
+				KeySpace:          defaultKeyspace,
+			},
+		}
 		settingsGen := gen.StaticSettings{Settings: config.DefaultSimulationSettings()}
 		eventGen := gen.StaticEvents{DelayedEvents: event.DelayedEventList{}}
 		assertions := []SimulationAssertion{}

--- a/pkg/kv/kvserver/asim/tests/default_settings.go
+++ b/pkg/kv/kvserver/asim/tests/default_settings.go
@@ -24,21 +24,6 @@ const (
 	defaultStoresPerNode = 1
 )
 
-func defaultBasicClusterGen() gen.BasicCluster {
-	return gen.BasicCluster{
-		Nodes:         defaultNodes,
-		StoresPerNode: defaultStoresPerNode,
-	}
-}
-
-func defaultStaticSettingsGen() gen.StaticSettings {
-	return gen.StaticSettings{Settings: config.DefaultSimulationSettings()}
-}
-
-func defaultStaticEventsGen() gen.StaticEvents {
-	return gen.StaticEvents{DelayedEvents: event.DelayedEventList{}}
-}
-
 const defaultKeyspace = 200000
 
 const (
@@ -48,34 +33,96 @@ const (
 	defaultSkewedAccess              = false
 )
 
-func defaultLoadGen() gen.BasicLoad {
-	return gen.BasicLoad{
-		RWRatio:      defaultRwRatio,
-		Rate:         defaultRate,
-		SkewedAccess: defaultSkewedAccess,
-		MinBlockSize: defaultMinBlock,
-		MaxBlockSize: defaultMaxBlock,
-		MinKey:       defaultMinKey,
-		MaxKey:       defaultMaxKey,
-	}
-}
-
 const (
 	defaultRanges            = 10
 	defaultPlacementType     = gen.Even
 	defaultReplicationFactor = 3
-	defaultBytes             = 0
+	defaultBytes             = int64(0)
 )
 
-func defaultBasicRangesGen() gen.BasicRanges {
+const (
+	defaultStat                 = "replicas"
+	defaultHeight, defaultWidth = 15, 80
+)
+
+type staticOptionSettings struct {
+	nodes             int
+	storesPerNode     int
+	rwRatio           float64
+	rate              float64
+	minBlock          int
+	maxBlock          int
+	minKey            int64
+	maxKey            int64
+	skewedAccess      bool
+	ranges            int
+	keySpace          int
+	placementType     gen.PlacementType
+	replicationFactor int
+	bytes             int64
+	stat              string
+	height            int
+	width             int
+}
+
+func getDefaultStaticOptionSettings() staticOptionSettings {
+	return staticOptionSettings{
+		nodes:             defaultNodes,
+		storesPerNode:     defaultStoresPerNode,
+		rwRatio:           defaultRwRatio,
+		rate:              defaultRate,
+		minBlock:          defaultMinBlock,
+		maxBlock:          defaultMaxBlock,
+		minKey:            defaultMinKey,
+		maxKey:            defaultMaxKey,
+		skewedAccess:      defaultSkewedAccess,
+		ranges:            defaultRanges,
+		keySpace:          defaultKeyspace,
+		placementType:     defaultPlacementType,
+		replicationFactor: defaultReplicationFactor,
+		bytes:             defaultBytes,
+		stat:              defaultStat,
+		height:            defaultHeight,
+		width:             defaultWidth,
+	}
+}
+
+func (f randTestingFramework) defaultBasicClusterGen() gen.BasicCluster {
+	return gen.BasicCluster{
+		Nodes:         f.defaultStaticSettings.nodes,
+		StoresPerNode: f.defaultStaticSettings.storesPerNode,
+	}
+}
+
+func (f randTestingFramework) defaultStaticSettingsGen() gen.StaticSettings {
+	return gen.StaticSettings{Settings: config.DefaultSimulationSettings()}
+}
+
+func (f randTestingFramework) defaultStaticEventsGen() gen.StaticEvents {
+	return gen.StaticEvents{DelayedEvents: event.DelayedEventList{}}
+}
+
+func (f randTestingFramework) defaultLoadGen() gen.BasicLoad {
+	return gen.BasicLoad{
+		RWRatio:      f.defaultStaticSettings.rwRatio,
+		Rate:         f.defaultStaticSettings.rate,
+		SkewedAccess: f.defaultStaticSettings.skewedAccess,
+		MinBlockSize: f.defaultStaticSettings.minBlock,
+		MaxBlockSize: f.defaultStaticSettings.maxBlock,
+		MinKey:       f.defaultStaticSettings.minKey,
+		MaxKey:       f.defaultStaticSettings.maxKey,
+	}
+}
+
+func (f randTestingFramework) defaultBasicRangesGen() gen.BasicRanges {
 	return gen.BasicRanges{
 		BaseRanges: gen.BaseRanges{
-			Ranges:            defaultRanges,
-			KeySpace:          defaultKeyspace,
-			ReplicationFactor: defaultReplicationFactor,
-			Bytes:             defaultBytes,
+			Ranges:            f.defaultStaticSettings.ranges,
+			KeySpace:          f.defaultStaticSettings.keySpace,
+			ReplicationFactor: f.defaultStaticSettings.replicationFactor,
+			Bytes:             f.defaultStaticSettings.bytes,
 		},
-		PlacementType: defaultPlacementType,
+		PlacementType: f.defaultStaticSettings.placementType,
 	}
 }
 

--- a/pkg/kv/kvserver/asim/tests/rand_framework.go
+++ b/pkg/kv/kvserver/asim/tests/rand_framework.go
@@ -237,6 +237,12 @@ func (f randTestingFramework) randomBasicRangesGen() gen.RangeGen {
 		if len(f.s.rangeGen.weightedRand) == 0 {
 			panic("set weightedRand array for stores properly to use weighted random placement for stores")
 		}
+		if f.s.randOptions.cluster {
+			panic("randomized cluster with weighted rand stores is not supported")
+		}
+		if stores, length := f.defaultStaticSettings.storesPerNode*f.defaultStaticSettings.nodes, len(f.s.rangeGen.weightedRand); stores != length {
+			panic(fmt.Sprintf("number of stores %d does not match length of weighted_rand %d: ", stores, length))
+		}
 		return WeightedRandomizedBasicRanges{
 			BaseRanges: gen.BaseRanges{
 				Ranges:            convertInt64ToInt(f.rangeGenerator.key()),

--- a/pkg/kv/kvserver/asim/tests/rand_gen.go
+++ b/pkg/kv/kvserver/asim/tests/rand_gen.go
@@ -85,6 +85,9 @@ func (wr WeightedRandomizedBasicRanges) Generate(
 	if wr.placementType != gen.WeightedRandom || len(wr.weightedRand) == 0 {
 		panic("RandomizedBasicRanges generate only weighted randomized distributions with non-empty weightedRand")
 	}
+	if len(s.Stores()) != len(wr.weightedRand) {
+		panic("mismatch: len(weighted_rand) != stores count")
+	}
 	rangesInfo := wr.GetRangesInfo(wr.placementType, len(s.Stores()), wr.randSource, wr.weightedRand)
 	wr.LoadRangeInfo(s, rangesInfo)
 	return s

--- a/pkg/kv/kvserver/asim/tests/rand_test.go
+++ b/pkg/kv/kvserver/asim/tests/rand_test.go
@@ -79,7 +79,7 @@ const (
 //    number of stores 4. sum of weights in the array should be equal to 1
 
 // 3. "eval" [seed=<int64>] [num_iterations=<int>] [duration=<time.Duration>]
-// [verbose=(<[]("result_only","test_settings","initial_state","config_gen","topology","all")>)]
+//  [verbose=(<[]("result_only","test_settings","initial_state","config_gen","topology","all")>)]
 // e.g. eval seed=20 duration=30m2s verbose=(test_settings,initial_state)
 //  - eval: generates a simulation based on the configuration set with the given
 //    commands.
@@ -100,6 +100,38 @@ const (
 //    - topology: displays the topology of cluster configurations
 //    - all: display everything above
 
+// 4. “change_static_option”[nodes=<int>][stores_per_node=<int>]
+// [rw_ratio=<float64>] [rate=<float64>] [min_block=<int>] [max_block=<int>]
+// [min_key=<int64>] [max_key=<int64>] [skewed_access=<bool>] [ranges=<int>]
+// [placement_type=<gen.PlacementType>] [key_space=<int>]
+// [replication_factor=<int>] [bytes=<int64>] [stat=<string>] [height=<int>]
+// [width=<int>]
+// e.g. change_static_option nodes=2 stores_per_node=3 placement_type=skewed
+//	- Change_static_option: modifies the settings for the static mode where no
+//	  randomization is involved. Note that this does not change the default
+//	  settings for any randomized generation.
+//	- nodes (default value is 3): number of nodes in the generated cluster
+//	- storesPerNode (default value is 1): number of store per nodes in the
+// 	  generated cluster
+//	- rwRatio (default value is 0.0): read-write ratio of the generated load
+//	- rate (default value is 0.0): rate at which the load is generated
+//	- minBlock (default value is 1): min size of each load event
+//	- maxBlock (default value is 1): max size of each load event
+//	- minKey (default value is int64(1)): min key of the generated load
+//	- maxKey (default value is int64(200000)): max key of the generated load
+//	- skewedAccess (default value is false): is true, workload key generator is
+// 	  skewed (zipf)
+//	- ranges (default value is 1): number of generated ranges
+//	- keySpace (default value is 200000): keyspace for the generated range
+//	- placementType (default value is gen.Even): type of distribution for how
+// 	  ranges are distributed across stores
+//	- replicationFactor (default value is 3): number of replica for each range
+//	- bytes (default value is int64(0)): size of each range in bytes
+//	- stat (default value is “replicas”): specifies the output to be plotted
+//	  for the verbose option
+//	- height (default value is 15): height of the plot
+//	- width (default value is 80): width of the plot
+
 // RandTestingFramework is initialized with specified testSetting and maintains
 // its state across all iterations. It repeats the test with different random
 // configurations. Each iteration in RandTestingFramework executes the following
@@ -114,12 +146,14 @@ func TestRandomized(t *testing.T) {
 		randOptions := testRandOptions{}
 		var rGenSettings rangeGenSettings
 		var cGenSettings clusterGenSettings
+		staticOptionSettings := getDefaultStaticOptionSettings()
 		datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {
 			switch d.Cmd {
 			case "clear":
 				randOptions = testRandOptions{}
 				rGenSettings = rangeGenSettings{}
 				cGenSettings = clusterGenSettings{}
+				staticOptionSettings = getDefaultStaticOptionSettings()
 				return ""
 			case "rand_cluster":
 				randOptions.cluster = true
@@ -128,6 +162,25 @@ func TestRandomized(t *testing.T) {
 				cGenSettings = clusterGenSettings{
 					clusterGenType: clusterGenType,
 				}
+				return ""
+			case "change_static_option":
+				scanIfExists(t, d, "nodes", &staticOptionSettings.nodes)
+				scanIfExists(t, d, "stores_per_node", &staticOptionSettings.storesPerNode)
+				scanIfExists(t, d, "rw_ratio", &staticOptionSettings.rwRatio)
+				scanIfExists(t, d, "rate", &staticOptionSettings.rate)
+				scanIfExists(t, d, "min_block", &staticOptionSettings.minBlock)
+				scanIfExists(t, d, "max_block", &staticOptionSettings.maxBlock)
+				scanIfExists(t, d, "min_key", &staticOptionSettings.minKey)
+				scanIfExists(t, d, "max_key", &staticOptionSettings.maxKey)
+				scanIfExists(t, d, "skewed_access", &staticOptionSettings.skewedAccess)
+				scanIfExists(t, d, "ranges", &staticOptionSettings.ranges)
+				scanIfExists(t, d, "key_space", &staticOptionSettings.keySpace)
+				scanIfExists(t, d, "placement_type", &staticOptionSettings.placementType)
+				scanIfExists(t, d, "replication_factor", &staticOptionSettings.replicationFactor)
+				scanIfExists(t, d, "bytes", &staticOptionSettings.bytes)
+				scanIfExists(t, d, "stat", &staticOptionSettings.stat)
+				scanIfExists(t, d, "height", &staticOptionSettings.height)
+				scanIfExists(t, d, "width", &staticOptionSettings.width)
 				return ""
 			case "rand_ranges":
 				randOptions.ranges = true
@@ -161,7 +214,7 @@ func TestRandomized(t *testing.T) {
 				scanIfExists(t, d, "num_iterations", &numIterations)
 				scanIfExists(t, d, "duration", &duration)
 				scanIfExists(t, d, "verbose", &verbose)
-				settings := testSettings{
+				s := testSettings{
 					numIterations: numIterations,
 					duration:      duration,
 					randSource:    rand.New(rand.NewSource(seed)),
@@ -171,7 +224,7 @@ func TestRandomized(t *testing.T) {
 					rangeGen:      rGenSettings,
 					clusterGen:    cGenSettings,
 				}
-				f := newRandTestingFramework(settings)
+				f := newRandTestingFramework(s, staticOptionSettings)
 				outputs := f.runRandTestRepeated()
 				return outputs.String()
 			default:

--- a/pkg/kv/kvserver/asim/tests/rand_test.go
+++ b/pkg/kv/kvserver/asim/tests/rand_test.go
@@ -72,11 +72,15 @@ const (
 //    keyspace parameter as ranges are generated across iterations
 //    (keyspace ∈[1000,200000]).
 //	- weighted_rand: specifies the weighted random distribution among stores.
-//	  Requirements (will panic otherwise): 1. weighted_rand should only be
-//    used with placement_type=weighted_rand and vice versa. 2. Must specify a
-//    weight between [0.0, 1.0] for each element in the array, with each element
-//    corresponding to a store 3. len(weighted_rand) cannot be greater than
-//    number of stores 4. sum of weights in the array should be equal to 1
+//	  Requirements (will panic otherwise): 1. use static option for cluster
+//	  generation, specify nodes(default:3) and stores_per_node(default:1)
+//	  through change_static_option, and ensure len(weighted_rand) == number of
+//	  stores == nodes * stores_per_node
+//	  2. weighted_rand should only be used with placement_type=weighted_rand and
+//	  vice versa.
+//	  3. must specify a weight between [0.0, 1.0] for each element in the array,
+//	  with each element corresponding to a store
+//	  4. sum of weights in the array should be equal to 1
 
 // 3. "eval" [seed=<int64>] [num_iterations=<int>] [duration=<time.Duration>]
 //  [verbose=(<[]("result_only","test_settings","initial_state","config_gen","topology","all")>)]

--- a/pkg/kv/kvserver/asim/tests/testdata/rand/default_settings
+++ b/pkg/kv/kvserver/asim/tests/testdata/rand/default_settings
@@ -45,8 +45,11 @@ test settings
 	num_iterations=3 duration=10m0s
 ----------------------------------
 generating cluster configurations using static option
+	nodes=3, stores_per_node=1
 generating ranges configurations using static option
+	placement_type=even, ranges=10, key_space=200000, replication_factor=3, bytes=0
 generating load configurations using static option
+	rw_ratio=0.00, rate=0.00, min_block=1, max_block=1, min_key=1, max_key=200000, skewed_access=false
 generating events configurations using static option
 generating settings configurations using static option
 ----------------------------------
@@ -158,8 +161,11 @@ test settings
 	num_iterations=3 duration=10m0s
 ----------------------------------
 generating cluster configurations using static option
+	nodes=3, stores_per_node=1
 generating ranges configurations using static option
+	placement_type=even, ranges=10, key_space=200000, replication_factor=3, bytes=0
 generating load configurations using static option
+	rw_ratio=0.00, rate=0.00, min_block=1, max_block=1, min_key=1, max_key=200000, skewed_access=false
 generating events configurations using static option
 generating settings configurations using static option
 ----------------------------------
@@ -194,6 +200,9 @@ initial state at 2022-03-21 11:00:00 +0000 UTC:
 sample3: pass
 ----------------------------------
 
+clear
+----
+
 # all flag: we expect that the output to include test settings, generated
 # configurations, initial state, and topology.
 eval verbose=(all)
@@ -202,8 +211,11 @@ test settings
 	num_iterations=3 duration=10m0s
 ----------------------------------
 generating cluster configurations using static option
+	nodes=3, stores_per_node=1
 generating ranges configurations using static option
+	placement_type=even, ranges=10, key_space=200000, replication_factor=3, bytes=0
 generating load configurations using static option
+	rw_ratio=0.00, rate=0.00, min_block=1, max_block=1, min_key=1, max_key=200000, skewed_access=false
 generating events configurations using static option
 generating settings configurations using static option
 ----------------------------------
@@ -247,5 +259,37 @@ topology:
 AU_EAST
   AU_EAST_1
     └── [1 2 3]
+sample3: pass
+----------------------------------
+
+clear
+----
+
+# This test checks whether change_static_option correctly modifies the settings
+# for the static options where no randomization is involved.
+change_static_option nodes=5 stores_per_node=5 key_space=30000 rw_ratio=0.2 rate=0.01 min_block=2 max_block=3 min_key=2 max_key=10000 skewed_access=true ranges=2 placement_type=skewed replication_factor=5 bytes=2 stat=leases height=20 width=150
+----
+
+eval verbose=(test_settings) duration=20m
+----
+test settings
+	num_iterations=3 duration=20m0s
+----------------------------------
+generating cluster configurations using static option
+	nodes=5, stores_per_node=5
+generating ranges configurations using static option
+	placement_type=skewed, ranges=2, key_space=30000, replication_factor=5, bytes=2
+generating load configurations using static option
+	rw_ratio=0.20, rate=0.01, min_block=2, max_block=3, min_key=2, max_key=10000, skewed_access=true
+generating events configurations using static option
+generating settings configurations using static option
+----------------------------------
+sample1: start running
+sample1: pass
+----------------------------------
+sample2: start running
+sample2: pass
+----------------------------------
+sample3: start running
 sample3: pass
 ----------------------------------

--- a/pkg/kv/kvserver/asim/tests/testdata/rand/rand_cluster
+++ b/pkg/kv/kvserver/asim/tests/testdata/rand/rand_cluster
@@ -51,7 +51,9 @@ test settings
 generating cluster configurations using randomized option
 	cluster_gen_type=multi_region
 generating ranges configurations using static option
+	placement_type=even, ranges=10, key_space=200000, replication_factor=3, bytes=0
 generating load configurations using static option
+	rw_ratio=0.00, rate=0.00, min_block=1, max_block=1, min_key=1, max_key=200000, skewed_access=false
 generating events configurations using static option
 generating settings configurations using static option
 ----------------------------------

--- a/pkg/kv/kvserver/asim/tests/testdata/rand/rand_ranges
+++ b/pkg/kv/kvserver/asim/tests/testdata/rand/rand_ranges
@@ -33,6 +33,7 @@ generating cluster configurations using randomized option
 generating ranges configurations using randomized option
 	placement_type=random, range_gen_type=uniform, key_space=zipf, replication_factor=3, weightedRand=[]
 generating load configurations using static option
+	rw_ratio=0.00, rate=0.00, min_block=1, max_block=1, min_key=1, max_key=200000, skewed_access=false
 generating events configurations using static option
 generating settings configurations using static option
 ----------------------------------
@@ -155,6 +156,7 @@ generating cluster configurations using randomized option
 generating ranges configurations using randomized option
 	placement_type=random, range_gen_type=uniform, key_space=uniform, replication_factor=1, weightedRand=[]
 generating load configurations using static option
+	rw_ratio=0.00, rate=0.00, min_block=1, max_block=1, min_key=1, max_key=200000, skewed_access=false
 generating events configurations using static option
 generating settings configurations using static option
 ----------------------------------

--- a/pkg/kv/kvserver/asim/tests/testdata/rand/weighted_rand
+++ b/pkg/kv/kvserver/asim/tests/testdata/rand/weighted_rand
@@ -1,63 +1,98 @@
-rand_cluster cluster_gen_type=multi_region
+# In this test, we run the randomized testing framework with the weighted_rand
+# option.  Note that due to the limited sample size, these may not be observed
+# accurately. But we expect the distribution of ranges across stores should be
+# roughly proportional to the weight.
+change_static_option stores_per_node=3 nodes=1
 ----
 
-# We expect ranges distributed to the third and fourth stores to be larger than
-# the first two stores. Ranges on other stores are significantly smaller, but
-# they are not zero due to the best-effort nature of the range information
-# distribution.
-rand_ranges replication_factor=3 placement_type=weighted_rand weighted_rand=(0.01, 0.04, 0.2, 0.75)
+# Due to replication factor of 3, it is impossible to satisfy the weighted rand
+# distribution. So number of ranges across the stores remains the same.
+rand_ranges replication_factor=3 placement_type=weighted_rand weighted_rand=(0.1, 0.2, 0.7)
 ----
 
-eval duration=5m num_iterations=3 verbose=(test_settings,config_gen,initial_state)
+eval duration=5m num_iterations=3 verbose=(test_settings,initial_state)
 ----
 test settings
 	num_iterations=3 duration=5m0s
 ----------------------------------
-generating cluster configurations using randomized option
-	cluster_gen_type=multi_region
+generating cluster configurations using static option
+	nodes=1, stores_per_node=3
 generating ranges configurations using randomized option
-	placement_type=weighted_rand, range_gen_type=uniform, key_space=uniform, replication_factor=3, weightedRand=[0.01 0.04 0.2 0.75]
+	placement_type=weighted_rand, range_gen_type=uniform, key_space=uniform, replication_factor=3, weightedRand=[0.1 0.2 0.7]
 generating load configurations using static option
 	rw_ratio=0.00, rate=0.00, min_block=1, max_block=1, min_key=1, max_key=200000, skewed_access=false
 generating events configurations using static option
 generating settings configurations using static option
 ----------------------------------
 sample1: start running
-configurations generated using seed 1926012586526624009
-	loaded cluster with
- 		region:US_East [zone=US_East_1(nodes=1,stores=0), zone=US_East_2(nodes=2,stores=0), zone=US_East_3(nodes=3,stores=0), zone=US_East_3(nodes=10,stores=0)]
-		region:US_West [zone=US_West_1(nodes=2,stores=0)]
-		region:EU [zone=EU_1(nodes=3,stores=0), zone=EU_2(nodes=3,stores=0), zone=EU_3(nodes=4,stores=0)]
-	weighted randomized ranges with placement_type=weighted_rand, weighted_rand=[0.01 0.04 0.2 0.75], ranges=305, key_space=96760, replication_factor=3, bytes=0
-	basic load with rw_ratio=0.00, rate=0.00, skewed_access=false, min_block_size=1, max_block_size=1, min_key=1, max_key=200000
-	number of static events generated=0
 initial state at 2022-03-21 11:00:00 +0000 UTC:
-	stores(28)=[s1n1=(replicas(59)),s2n2=(replicas(74)),s3n3=(replicas(75)),s4n4=(replicas(77)),s5n5=(replicas(25)),s6n6=(replicas(27)),s7n7=(replicas(26)),s8n8=(replicas(28)),s9n9=(replicas(27)),s10n10=(replicas(26)),s11n11=(replicas(27)),s12n12=(replicas(25)),s13n13=(replicas(25)),s14n14=(replicas(27)),s15n15=(replicas(26)),s16n16=(replicas(26)),s17n17=(replicas(25)),s18n18=(replicas(26)),s19n19=(replicas(25)),s20n20=(replicas(28)),s21n21=(replicas(25)),s22n22=(replicas(26)),s23n23=(replicas(27)),s24n24=(replicas(27)),s25n25=(replicas(27)),s26n26=(replicas(27)),s27n27=(replicas(26)),s28n28=(replicas(26))]
+	stores(3)=[s1n1=(replicas(563)),s2n1=(replicas(563)),s3n1=(replicas(563))]
 sample1: pass
 ----------------------------------
 sample2: start running
-configurations generated using seed 6603068123710785442
-	loaded cluster with
- 		region:US_East [zone=US_East_1(nodes=4,stores=0), zone=US_East_2(nodes=4,stores=0), zone=US_East_3(nodes=4,stores=0)]
-		region:US_West [zone=US_West_1(nodes=4,stores=0), zone=US_West_2(nodes=4,stores=0), zone=US_West_3(nodes=4,stores=0)]
-		region:EU [zone=EU_1(nodes=4,stores=0), zone=EU_2(nodes=4,stores=0), zone=EU_3(nodes=4,stores=0)]
-	weighted randomized ranges with placement_type=weighted_rand, weighted_rand=[0.01 0.04 0.2 0.75], ranges=603, key_space=99075, replication_factor=3, bytes=0
-	basic load with rw_ratio=0.00, rate=0.00, skewed_access=false, min_block_size=1, max_block_size=1, min_key=1, max_key=200000
-	number of static events generated=0
 initial state at 2022-03-21 11:00:00 +0000 UTC:
-	stores(36)=[s1n1=(replicas(159)),s2n2=(replicas(306)),s3n3=(replicas(372)),s4n4=(replicas(374)),s5n5=(replicas(19)),s6n6=(replicas(20)),s7n7=(replicas(18)),s8n8=(replicas(17)),s9n9=(replicas(18)),s10n10=(replicas(18)),s11n11=(replicas(19)),s12n12=(replicas(18)),s13n13=(replicas(18)),s14n14=(replicas(20)),s15n15=(replicas(19)),s16n16=(replicas(19)),s17n17=(replicas(18)),s18n18=(replicas(17)),s19n19=(replicas(19)),s20n20=(replicas(21)),s21n21=(replicas(21)),s22n22=(replicas(19)),s23n23=(replicas(20)),s24n24=(replicas(19)),s25n25=(replicas(18)),s26n26=(replicas(18)),s27n27=(replicas(18)),s28n28=(replicas(17)),s29n29=(replicas(19)),s30n30=(replicas(18)),s31n31=(replicas(20)),s32n32=(replicas(18)),s33n33=(replicas(19)),s34n34=(replicas(18)),s35n35=(replicas(18)),s36n36=(replicas(20))]
+	stores(3)=[s1n1=(replicas(299)),s2n1=(replicas(299)),s3n1=(replicas(299))]
 sample2: pass
 ----------------------------------
 sample3: start running
-configurations generated using seed 6656619927997724782
-	loaded cluster with
- 		region:US_East [zone=US_East_1(nodes=1,stores=0), zone=US_East_2(nodes=2,stores=0), zone=US_East_3(nodes=3,stores=0), zone=US_East_3(nodes=10,stores=0)]
-		region:US_West [zone=US_West_1(nodes=2,stores=0)]
-		region:EU [zone=EU_1(nodes=3,stores=0), zone=EU_2(nodes=3,stores=0), zone=EU_3(nodes=4,stores=0)]
-	weighted randomized ranges with placement_type=weighted_rand, weighted_rand=[0.01 0.04 0.2 0.75], ranges=394, key_space=89281, replication_factor=3, bytes=0
+initial state at 2022-03-21 11:00:00 +0000 UTC:
+	stores(3)=[s1n1=(replicas(521)),s2n1=(replicas(521)),s3n1=(replicas(521))]
+sample3: pass
+----------------------------------
+
+clear
+----
+
+change_static_option stores_per_node=2 nodes=3
+----
+
+# We expect ranges distributed to the last three stores to be larger than the
+# first few stores. The ratio is not exact due to the best-effort nature of the
+# range information distribution.
+rand_ranges replication_factor=3 placement_type=weighted_rand weighted_rand=(0,0,0,0.3,0.3,0.4)
+----
+
+eval duration=5m num_iterations=3 verbose=(test_settings,initial_state,config_gen)
+----
+test settings
+	num_iterations=3 duration=5m0s
+----------------------------------
+generating cluster configurations using static option
+	nodes=3, stores_per_node=2
+generating ranges configurations using randomized option
+	placement_type=weighted_rand, range_gen_type=uniform, key_space=uniform, replication_factor=3, weightedRand=[0 0 0 0.3 0.3 0.4]
+generating load configurations using static option
+	rw_ratio=0.00, rate=0.00, min_block=1, max_block=1, min_key=1, max_key=200000, skewed_access=false
+generating events configurations using static option
+generating settings configurations using static option
+----------------------------------
+sample1: start running
+configurations generated using seed 5571782338101878760
+	basic cluster with nodes=3, stores_per_node=2
+	weighted randomized ranges with placement_type=weighted_rand, weighted_rand=[0 0 0 0.3 0.3 0.4], ranges=563, key_space=160411, replication_factor=3, bytes=0
 	basic load with rw_ratio=0.00, rate=0.00, skewed_access=false, min_block_size=1, max_block_size=1, min_key=1, max_key=200000
 	number of static events generated=0
 initial state at 2022-03-21 11:00:00 +0000 UTC:
-	stores(28)=[s1n1=(replicas(116)),s2n2=(replicas(117)),s3n3=(replicas(156)),s4n4=(replicas(162)),s5n5=(replicas(26)),s6n6=(replicas(28)),s7n7=(replicas(26)),s8n8=(replicas(26)),s9n9=(replicas(26)),s10n10=(replicas(26)),s11n11=(replicas(26)),s12n12=(replicas(27)),s13n13=(replicas(25)),s14n14=(replicas(27)),s15n15=(replicas(25)),s16n16=(replicas(26)),s17n17=(replicas(28)),s18n18=(replicas(26)),s19n19=(replicas(27)),s20n20=(replicas(26)),s21n21=(replicas(26)),s22n22=(replicas(26)),s23n23=(replicas(26)),s24n24=(replicas(25)),s25n25=(replicas(28)),s26n26=(replicas(26)),s27n27=(replicas(26)),s28n28=(replicas(27))]
+	stores(6)=[s1n1=(replicas(132)),s2n1=(replicas(130)),s3n2=(replicas(131)),s4n2=(replicas(437)),s5n3=(replicas(428)),s6n3=(replicas(431))]
+sample1: pass
+----------------------------------
+sample2: start running
+configurations generated using seed 4299969443970870044
+	basic cluster with nodes=3, stores_per_node=2
+	weighted randomized ranges with placement_type=weighted_rand, weighted_rand=[0 0 0 0.3 0.3 0.4], ranges=299, key_space=9542, replication_factor=3, bytes=0
+	basic load with rw_ratio=0.00, rate=0.00, skewed_access=false, min_block_size=1, max_block_size=1, min_key=1, max_key=200000
+	number of static events generated=0
+initial state at 2022-03-21 11:00:00 +0000 UTC:
+	stores(6)=[s1n1=(replicas(140)),s2n1=(replicas(136)),s3n2=(replicas(139)),s4n2=(replicas(169)),s5n3=(replicas(142)),s6n3=(replicas(171))]
+sample2: pass
+----------------------------------
+sample3: start running
+configurations generated using seed 4157513341729910236
+	basic cluster with nodes=3, stores_per_node=2
+	weighted randomized ranges with placement_type=weighted_rand, weighted_rand=[0 0 0 0.3 0.3 0.4], ranges=521, key_space=82660, replication_factor=3, bytes=0
+	basic load with rw_ratio=0.00, rate=0.00, skewed_access=false, min_block_size=1, max_block_size=1, min_key=1, max_key=200000
+	number of static events generated=0
+initial state at 2022-03-21 11:00:00 +0000 UTC:
+	stores(6)=[s1n1=(replicas(180)),s2n1=(replicas(181)),s3n2=(replicas(183)),s4n2=(replicas(386)),s5n3=(replicas(247)),s6n3=(replicas(386))]
 sample3: pass
 ----------------------------------

--- a/pkg/kv/kvserver/asim/tests/testdata/rand/weighted_rand
+++ b/pkg/kv/kvserver/asim/tests/testdata/rand/weighted_rand
@@ -18,6 +18,7 @@ generating cluster configurations using randomized option
 generating ranges configurations using randomized option
 	placement_type=weighted_rand, range_gen_type=uniform, key_space=uniform, replication_factor=3, weightedRand=[0.01 0.04 0.2 0.75]
 generating load configurations using static option
+	rw_ratio=0.00, rate=0.00, min_block=1, max_block=1, min_key=1, max_key=200000, skewed_access=false
 generating events configurations using static option
 generating settings configurations using static option
 ----------------------------------


### PR DESCRIPTION
**asim: enable option to change static option settings**

This patch allows users to modify the settings for the static mode within the
randomized testing framework. The following command is now supported:
```
4. “change_static_option”[nodes=<int>][stores_per_node=<int>]
[rw_ratio=<float64>] [rate=<float64>] [min_block=<int>] [max_block=<int>]
[min_key=<int64>] [max_key=<int64>] [skewed_access=<bool>] [ranges=<int>]
[placement_type=<gen.PlacementType>] [key_space=<int>]
[replication_factor=<int>] [bytes=<int64>] [stat=<string>] [height=<int>]
[width=<int>]
e.g. change_static_option nodes=2 stores_per_node=3 placement_type=skewed
	- Change_static_option: modifies the settings for the static mode where no
	  randomization is involved. Note that this does not change the default
	  settings for any randomized generation.
	- nodes (default value is 3): number of nodes in the generated cluster
	- storesPerNode (default value is 1): number of store per nodes in the
	  generated cluster
	- rwRatio (default value is 0.0): read-write ratio of the generated load
	- rate (default value is 0.0): rate at which the load is generated
	- minBlock (default value is 1): min size of each load event
	- maxBlock (default value is 1): max size of each load event
	- minKey (default value is int64(1)): min key of the generated load
	- maxKey (default value is int64(200000)): max key of the generated load
	- skewedAccess (default value is false): is true, workload key generator is
	  skewed (zipf)
	- ranges (default value is 1): number of generated ranges
	- keySpace (default value is 200000): keyspace for the generated range
	- placementType (default value is gen.Even): type of distribution for how
	  ranges are distributed across stores
	- replicationFactor (default value is 3): number of replica for each range
	- bytes (default value is int64(0)): size of each range in bytes
	- stat (default value is “replicas”): specifies the output to be plotted
	  for the verbose option
	- height (default value is 15): height of the plot
	- width (default value is 80): width of the plot

In addition, verbose=(static_settings) can now be used to display settings used
for static options where no randomization is involved.
```

Part of: https://github.com/cockroachdb/cockroach/issues/106311
Release note: None

----

**asim: enforce len(weighted_rand) == number of stores**

Previously, we enforce that the length of a given `weighted_rand` cannot exceed
the number of stores. This was challenging for users as they might not know the
cluster configuration that would be generated and thus do not know the number of
stores. In addition, if the length of `weighted_rand` was less than total number
of stores, any stores outside of the `weighted_rand` range would simply have
zero replicas. This could lead to confusion.

To improve user control, this patch disables the use of weighted_rand with
randomized cluster generation. Requirements to use weighted_rand:
1. use static option for cluster generation
2. specify nodes(default:3) and stores_per_node(default:1) through
change_static_option
3. ensure len(weighted_rand) == number of stores == nodes * stores_per_node

In addition to these new rules, the following existing requirements remain in
place:
1. weighted_rand should only be used with placement_type=weighted_rand and vice
versa.
2. must specify a weight between [0.0, 1.0] for each element in the array, with
each element corresponding to a store
3. sum of weights in the array should be equal to 1

Resolves: https://github.com/cockroachdb/cockroach/issues/106311
Release note: None