### PR TITLE
server: init secondary tenant servers with proper clock parameters

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -239,21 +239,9 @@ func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterf
 		panic(errors.New("no tracer set in AmbientCtx"))
 	}
 
-	maxOffset := time.Duration(cfg.MaxOffset)
-	toleratedOffset := cfg.ToleratedOffset()
-	var clock *hlc.Clock
-	if cfg.ClockDevicePath != "" {
-		ptpClock, err := ptp.MakeClock(ctx, cfg.ClockDevicePath)
-		if err != nil {
-			return nil, errors.Wrap(err, "instantiating clock source")
-		}
-		clock = hlc.NewClock(ptpClock, maxOffset, toleratedOffset)
-	} else if cfg.TestingKnobs.Server != nil &&
-		cfg.TestingKnobs.Server.(*TestingKnobs).WallClock != nil {
-		clock = hlc.NewClock(cfg.TestingKnobs.Server.(*TestingKnobs).WallClock,
-			maxOffset, toleratedOffset)
-	} else {
-		clock = hlc.NewClockWithSystemTimeSource(maxOffset, toleratedOffset)
+	clock, err := newClockFromConfig(ctx, cfg.BaseConfig)
+	if err != nil {
+		return nil, err
 	}
 	registry := metric.NewRegistry()
 	ruleRegistry := metric.NewRuleRegistry()
@@ -1317,6 +1305,27 @@ func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterf
 	}
 
 	return lateBoundServer, err
+}
+
+// newClockFromConfig creates a HLC clock from the server configuration.
+func newClockFromConfig(ctx context.Context, cfg BaseConfig) (*hlc.Clock, error) {
+	maxOffset := time.Duration(cfg.MaxOffset)
+	toleratedOffset := cfg.ToleratedOffset()
+	var clock *hlc.Clock
+	if cfg.ClockDevicePath != "" {
+		ptpClock, err := ptp.MakeClock(ctx, cfg.ClockDevicePath)
+		if err != nil {
+			return nil, errors.Wrap(err, "instantiating clock source")
+		}
+		clock = hlc.NewClock(ptpClock, maxOffset, toleratedOffset)
+	} else if cfg.TestingKnobs.Server != nil &&
+		cfg.TestingKnobs.Server.(*TestingKnobs).WallClock != nil {
+		clock = hlc.NewClock(cfg.TestingKnobs.Server.(*TestingKnobs).WallClock,
+			maxOffset, toleratedOffset)
+	} else {
+		clock = hlc.NewClockWithSystemTimeSource(maxOffset, toleratedOffset)
+	}
+	return clock, nil
 }
 
 // ClusterSettings returns the cluster settings.

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -978,9 +978,10 @@ func makeTenantSQLServerArgs(
 	// the instance ID (once known) as a tag.
 	startupCtx = baseCfg.AmbientCtx.AnnotateCtx(startupCtx)
 
-	maxOffset := time.Duration(baseCfg.MaxOffset)
-	toleratedOffset := baseCfg.ToleratedOffset()
-	clock := hlc.NewClockWithSystemTimeSource(maxOffset, toleratedOffset)
+	clock, err := newClockFromConfig(startupCtx, baseCfg)
+	if err != nil {
+		return sqlServerArgs{}, err
+	}
 
 	registry := metric.NewRegistry()
 	ruleRegistry := metric.NewRuleRegistry()


### PR DESCRIPTION
We need to share the code path to initialize the HLC clock between all types of servers.

Fixes #108098.
Epic: CRDB-26687
