### PR TITLE
release-23.1: sql: unskip TestSchemaChangePurgeFailure

### DIFF
--- a/pkg/sql/schemachanger/scexec/testing_knobs.go
+++ b/pkg/sql/schemachanger/scexec/testing_knobs.go
@@ -41,6 +41,10 @@ type TestingKnobs struct {
 
 	// RunBeforeBackfill is called just before starting the backfill.
 	RunBeforeBackfill func() error
+
+	// RunBeforeMakingPostCommitPlan is called just before making the post commit
+	// plan.
+	RunBeforeMakingPostCommitPlan func(inRollback bool) error
 }
 
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.

--- a/pkg/sql/schemachanger/scrun/scrun.go
+++ b/pkg/sql/schemachanger/scrun/scrun.go
@@ -118,6 +118,11 @@ func RunSchemaChangesInJob(
 	descriptorIDs []descpb.ID,
 	rollbackCause error,
 ) error {
+	if knobs != nil && knobs.RunBeforeMakingPostCommitPlan != nil {
+		if err := knobs.RunBeforeMakingPostCommitPlan(rollbackCause != nil); err != nil {
+			return err
+		}
+	}
 	p, err := makePostCommitPlan(ctx, deps, jobID, descriptorIDs, rollbackCause)
 	if err != nil {
 		if knobs != nil && knobs.OnPostCommitPlanError != nil {


### PR DESCRIPTION
Backport 1/1 commits from #108053.

/cc @cockroachdb/release

---

Informs #51796

There has been a lot of changes since the test was first written and looks some of integer variables are not used to control the schema changer flow at all. Specifically the concept of "Async Schema Changer" was misleading. This commit changes the test to test the purging behavior by comparing the key counts before and after rollback. We don't need to test how many attempts.

Release note: None
Release justification: test only change
