### PR TITLE
kvprober: remove unnecessary checks to avoid flakes

### DIFF
--- a/pkg/kv/kvprober/kvprober_integration_test.go
+++ b/pkg/kv/kvprober/kvprober_integration_test.go
@@ -171,8 +171,6 @@ func TestProberDoesReadsAndWrites(t *testing.T) {
 			p.WriteProbe(ctx, s.DB())
 		}
 
-		// Expect all read probes to fail but write probes & planning to succeed.
-		require.Equal(t, p.Metrics().ReadProbeAttempts.Count(), p.Metrics().ReadProbeFailures.Count())
 		// kvprober is running in background, so more than ten probes may be run.
 		require.GreaterOrEqual(t, p.Metrics().ReadProbeFailures.Count(), int64(10))
 
@@ -220,8 +218,6 @@ func TestProberDoesReadsAndWrites(t *testing.T) {
 			p.WriteProbe(ctx, s.DB())
 		}
 
-		// Expect all write probes to fail but read probes & planning to succeed.
-		require.Equal(t, p.Metrics().WriteProbeAttempts.Count(), p.Metrics().WriteProbeFailures.Count())
 		// kvprober is running in background, so more than ten probes may be run.
 		require.GreaterOrEqual(t, p.Metrics().WriteProbeFailures.Count(), int64(10))
 


### PR DESCRIPTION
Fixes https://github.com/cockroachdb/cockroach/issues/107873.

**kvprober: remove unnecessary checks to avoid flakes**

This commit removes two unnecessary checks, to avoid flakes. The removed checks can cause flakes, since they require all probes (of a certain type) to fail, even tho the test server is not configured to fail probes until after server startup. That is, there is a race condition. The checks are also unnecessary. What we really care about is the checks that follow the deleted ones: That the ten probes run within test all fail, since those happen after the test server is configured to fail probes.

Release note: None.
Epic: None.