### PR TITLE
sql: rewind txn sequence number in internal executor

### DIFF
--- a/pkg/sql/conn_executor_test.go
+++ b/pkg/sql/conn_executor_test.go
@@ -450,6 +450,8 @@ SELECT IF(x::INT::FLOAT = x,
              'NOOPE', 'insert saw its own writes: ' || x::STRING || ' (it is halloween today)')::FLOAT)
        + 0.1
   FROM t.test
+  -- the function used here is implemented by using the internal executor.
+  WHERE has_table_privilege('root', ((x+.1)/(x+1) + 1)::int::oid, 'INSERT') IS NULL
 `); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
If the internal executor is used by a user-initiated query, then it shares the same transaction as the user's query. In that case, it's important to step back the sequence number so that a single statement does not read its own writes.

fixes https://github.com/cockroachdb/cockroach/issues/86162
Release note: None