### PR TITLE
sql: check for resultWriter error in runPlanInsidePlan

### DIFF
--- a/pkg/sql/apply_join.go
+++ b/pkg/sql/apply_join.go
@@ -347,6 +347,9 @@ func runPlanInsidePlan(
 	if recv.commErr != nil {
 		return recv.commErr
 	}
+	if resultWriter.Err() != nil {
+		return resultWriter.Err()
+	}
 
 	evalCtxFactory2 := func(usedConcurrently bool) *extendedEvalContext {
 		return evalCtxFactory()


### PR DESCRIPTION
In https://github.com/cockroachdb/cockroach/pull/104553, we modified `runPlanInsidePlan` to plan and run checks after planning and running the inside plan. Although we check for comm errors after the initial call to `PlanAndRun` to see if we should exit early, we neglected to also check the result writer for errors. Since not all result writer errors may be copied into the comm errors, we fix that here.

Epic: None
Informs: #87289

Release note: None