### PR TITLE
storage: introduce indirection between lock table keys and lock strength

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_query_resolved_timestamp_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_query_resolved_timestamp_test.go
@@ -228,7 +228,7 @@ func TestQueryResolvedTimestampErrors(t *testing.T) {
 
 	lockTableKey := storage.LockTableKey{
 		Key:      roachpb.Key("a"),
-		Strength: lock.Exclusive,
+		Strength: lock.Intent,
 		TxnUUID:  txnUUID,
 	}
 	engineKey, buf := lockTableKey.ToEngineKey(nil)

--- a/pkg/kv/kvserver/rditer/replica_data_iter_test.go
+++ b/pkg/kv/kvserver/rditer/replica_data_iter_test.go
@@ -110,11 +110,11 @@ func createRangeData(
 	locks := []storage.LockTableKey{
 		{
 			Key:      keys.RangeDescriptorKey(desc.StartKey), // mark [1] above as intent
-			Strength: lock.Exclusive,
+			Strength: lock.Intent,
 			TxnUUID:  testTxnID,
 		}, {
 			Key:      desc.StartKey.AsRawKey(), // mark [2] above as intent
-			Strength: lock.Exclusive,
+			Strength: lock.Intent,
 			TxnUUID:  testTxnID,
 		},
 	}

--- a/pkg/storage/intent_interleaving_iter.go
+++ b/pkg/storage/intent_interleaving_iter.go
@@ -609,7 +609,7 @@ func (i *intentInterleavingIter) SeekIntentGE(key roachpb.Key, txnUUID uuid.UUID
 	var engineKey EngineKey
 	engineKey, i.intentKeyBuf = LockTableKey{
 		Key:      key,
-		Strength: lock.Exclusive,
+		Strength: lock.Intent,
 		TxnUUID:  txnUUID,
 	}.ToEngineKey(i.intentKeyBuf)
 	var limitKey roachpb.Key

--- a/pkg/storage/intent_interleaving_iter_test.go
+++ b/pkg/storage/intent_interleaving_iter_test.go
@@ -294,7 +294,7 @@ func TestIntentInterleavingIter(t *testing.T) {
 								return err.Error()
 							}
 						} else {
-							ltKey := LockTableKey{Key: key, Strength: lock.Exclusive, TxnUUID: txnUUID}
+							ltKey := LockTableKey{Key: key, Strength: lock.Intent, TxnUUID: txnUUID}
 							eKey, _ := ltKey.ToEngineKey(nil)
 							if err := batch.PutEngineKey(eKey, val); err != nil {
 								return err.Error()
@@ -561,7 +561,7 @@ func generateRandomData(
 			}
 			val, err := protoutil.Marshal(&meta)
 			require.NoError(t, err)
-			ltKey := LockTableKey{Key: key, Strength: lock.Exclusive, TxnUUID: txnUUID}
+			ltKey := LockTableKey{Key: key, Strength: lock.Intent, TxnUUID: txnUUID}
 			lkv = append(lkv, lockKeyValue{
 				key: ltKey, val: val, liveIntent: hasIntent && i == 0})
 			mvcckv = append(mvcckv, MVCCKeyValue{
@@ -823,7 +823,7 @@ func writeBenchData(
 			require.NoError(b, err)
 			if separated {
 				eKey, _ :=
-					LockTableKey{Key: key, Strength: lock.Exclusive, TxnUUID: txnUUID}.ToEngineKey(nil)
+					LockTableKey{Key: key, Strength: lock.Intent, TxnUUID: txnUUID}.ToEngineKey(nil)
 				require.NoError(b, batch.PutEngineKey(eKey, val))
 			} else {
 				require.NoError(b, batch.PutUnversioned(key, val))

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -1475,7 +1475,7 @@ func (b *putBuffer) putIntentMeta(
 		return 0, 0, errors.AssertionFailedf(
 			"meta.Timestamp != meta.Txn.WriteTimestamp: %s != %s", meta.Timestamp, meta.Txn.WriteTimestamp)
 	}
-	lockTableKey := b.lockTableKey(key.Key, lock.Exclusive, meta.Txn.ID)
+	lockTableKey := b.lockTableKey(key.Key, lock.Intent, meta.Txn.ID)
 	if alreadyExists {
 		// Absence represents false.
 		meta.TxnDidNotUpdateMeta = nil
@@ -1504,7 +1504,7 @@ func (b *putBuffer) putIntentMeta(
 func (b *putBuffer) clearIntentMeta(
 	writer Writer, key MVCCKey, txnDidNotUpdateMeta bool, txnUUID uuid.UUID, opts ClearOptions,
 ) (keyBytes, valBytes int64, err error) {
-	lockTableKey := b.lockTableKey(key.Key, lock.Exclusive, txnUUID)
+	lockTableKey := b.lockTableKey(key.Key, lock.Intent, txnUUID)
 	if txnDidNotUpdateMeta {
 		err = writer.SingleClearEngineKey(lockTableKey)
 	} else {

--- a/pkg/storage/pebble_mvcc_scanner_test.go
+++ b/pkg/storage/pebble_mvcc_scanner_test.go
@@ -73,7 +73,7 @@ func TestMVCCScanWithManyVersionsAndSeparatedIntents(t *testing.T) {
 	for _, k := range keys {
 		lockTableKey, _ := LockTableKey{
 			Key:      k,
-			Strength: lock.Exclusive,
+			Strength: lock.Intent,
 			TxnUUID:  uuid,
 		}.ToEngineKey(nil)
 		err = eng.PutEngineKey(lockTableKey, metaBytes)

--- a/pkg/storage/pebble_test.go
+++ b/pkg/storage/pebble_test.go
@@ -601,7 +601,7 @@ func TestPebbleMVCCTimeIntervalCollector(t *testing.T) {
 	// Nothing added.
 	finishAndCheck(0, 0)
 	uuid := uuid.Must(uuid.FromString("6ba7b810-9dad-11d1-80b4-00c04fd430c8"))
-	ek, _ := LockTableKey{aKey, lock.Exclusive, uuid}.ToEngineKey(nil)
+	ek, _ := LockTableKey{aKey, lock.Intent, uuid}.ToEngineKey(nil)
 	require.NoError(t, collector.Add(pebble.InternalKey{UserKey: ek.Encode()}, []byte("foo")))
 	// The added key was not an MVCCKey.
 	finishAndCheck(0, 0)
@@ -1241,7 +1241,7 @@ func TestShortAttributeExtractor(t *testing.T) {
 
 	var txnUUID [uuid.Size]byte
 	lockKey, _ := LockTableKey{
-		Key: roachpb.Key("a"), Strength: lock.Exclusive, TxnUUID: txnUUID}.ToEngineKey(nil)
+		Key: roachpb.Key("a"), Strength: lock.Intent, TxnUUID: txnUUID}.ToEngineKey(nil)
 	v := MVCCValue{}
 	tombstoneVal, err := EncodeMVCCValue(v)
 	require.NoError(t, err)


### PR DESCRIPTION
Lock table keys include a single byte that denotes the lock's strength. Prior to this patch, that byte was directly derived from the lock strength. Versions <= 23.1 considered intents to have Exclusive lock strength; versions > 23.1 treat intents as having a new (stronger) lock strength -- lock.Intent.

This requires us to change how lock table keys are serialized and deserialized -- otherwise, we'd have a incompatibility issue between intents written across these versions. To that end, this patch introduces a layer of indirection between a lock's strength and the strength byte that's persisted in lock table keys. We then ensure the byte itself doesn't change between versions -- i.e, all versions use 3 (the enum value of `lock.Exclusive`) as the byte written by an intent.

Closes #107947

Release note: None