### PR TITLE
release-23.1: sql: fix rare flake in TestDistSQLFlowsVirtualTables

### DIFF
--- a/pkg/sql/crdb_internal_test.go
+++ b/pkg/sql/crdb_internal_test.go
@@ -639,15 +639,14 @@ func TestDistSQLFlowsVirtualTables(t *testing.T) {
 		queuedStatus  = "queued"
 	)
 	getNum := func(db *sqlutils.SQLRunner, scope, status string) int {
-		querySuffix := fmt.Sprintf("FROM crdb_internal.%s_distsql_flows WHERE status = '%s'", scope, status)
-		// Check that all remote flows (if any) correspond to the expected
-		// statement.
-		stmts := db.QueryStr(t, "SELECT stmt "+querySuffix)
-		for _, stmt := range stmts {
-			require.Equal(t, query, stmt[0])
-		}
+		// Count the number of flows matching our target query. Note that there
+		// could be other flows in the table for the internal operations.
+		countQuery := fmt.Sprintf(`
+SELECT count(*) FROM crdb_internal.%s_distsql_flows WHERE stmt = '%s' AND status = '%s'`,
+			scope, query, status,
+		)
 		var num int
-		db.QueryRow(t, "SELECT count(*) "+querySuffix).Scan(&num)
+		db.QueryRow(t, countQuery).Scan(&num)
 		return num
 	}
 	for nodeID := 0; nodeID < numNodes; nodeID++ {


### PR DESCRIPTION
This commit fixes a rare flake in `TestDistSQLFlowsVirtualTables`. The test previously asserted that only the target query was present in `*_distsql_flows` virtual tables, but we just saw a case where an internal query showed up in there (related to table stats cache). This assertion was too strict and unnecessary - the test really cares whether the target query is present or not, so this commit removes the assertion.

Epic: None

Release note: None

Release justification: test-only change.