### PR TITLE
sql: fix logic to collect stats on system.jobs

### DIFF
--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -233,12 +233,6 @@ func (n *createStatsNode) makeJobRecord(ctx context.Context) (*jobs.Record, erro
 		)
 	}
 
-	if tableDesc.GetID() == keys.JobsTableID {
-		return nil, pgerror.New(
-			pgcode.WrongObjectType, "cannot create statistics on system.jobs",
-		)
-	}
-
 	if tableDesc.GetID() == keys.ScheduledJobsTableID {
 		return nil, pgerror.New(
 			pgcode.WrongObjectType, "cannot create statistics on system.scheduled_jobs",

--- a/pkg/sql/logictest/testdata/logic_test/distsql_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_stats
@@ -1657,8 +1657,8 @@ ANALYZE system.lease
 statement error pq: cannot create statistics on system.table_statistics
 ANALYZE system.table_statistics
 
-# Collecting stats on system.jobs is disallowed.
-statement error pq: cannot create statistics on system.jobs
+# Collecting stats on system.jobs is allowed.
+statement ok
 ANALYZE system.jobs
 
 # Collecting stats on system.scheduled_jobs is disallowed.


### PR DESCRIPTION
This commit fixes an oversight in #102637 which intended to enable stats collection on the jobs table, but was not successful.

I've manually confirmed that stats are now collected on the jobs table in a local cluster:
```
  888074673664065537 | AUTO CREATE STATS               | Table statistics refresh for system.public.jobs                         | CREATE STATISTICS __auto__ FROM [15] WITH OPTIONS THROTTLING 0.9 AS OF SYSTEM TIME '-30s'  | root      | succeeded | NULL           | 2023-08-03 19:01:22.343
```

Informs #107405

Release note (performance improvement): We now automatically collect table statistics on the `system.jobs` table, which will enable the optimizer to produce better query plans for internal queries that access the `system.jobs` table. This may result in better performance of the system. Note: a previous attempt to enable stats on `system.jobs` starting in 23.1.0 was unsuccessful, but we have now fixed the oversight.