### PR TITLE
ui: upgrade typescript from v4 to v5

### DIFF
--- a/pkg/ui/pnpm-lock.yaml
+++ b/pkg/ui/pnpm-lock.yaml
@@ -142,7 +142,7 @@ importers:
         version: 7.8.0(@babel/core@7.8.3)
       '@bazel/typescript':
         specifier: 5.5.0
-        version: 5.5.0(typescript@4.2.4)
+        version: 5.5.0(typescript@5.1.6)
       '@bazel/worker':
         specifier: 5.5.0
         version: 5.5.0
@@ -154,7 +154,7 @@ importers:
         version: 0.4.5
       '@cockroachlabs/eslint-config':
         specifier: ^0.1.11
-        version: 0.1.11(@typescript-eslint/eslint-plugin@4.29.1)(eslint-plugin-prettier@3.4.1)(eslint-plugin-react-hooks@2.3.0)(eslint-plugin-react@7.21.5)(eslint@6.8.0)(typescript@4.2.4)
+        version: 0.1.11(@typescript-eslint/eslint-plugin@4.29.1)(eslint-plugin-prettier@3.4.1)(eslint-plugin-react-hooks@2.3.0)(eslint-plugin-react@7.21.5)(eslint@6.8.0)(typescript@5.1.6)
       '@cockroachlabs/eslint-plugin-crdb':
         specifier: workspace:../eslint-plugin-crdb
         version: link:../eslint-plugin-crdb
@@ -181,7 +181,7 @@ importers:
         version: 6.3.1(react-dom@16.12.0)(react@16.12.0)
       '@storybook/react':
         specifier: ^6.3.1
-        version: 6.3.1(@babel/core@7.8.3)(@types/react@16.14.8)(eslint@6.8.0)(react-dom@16.12.0)(react@16.12.0)(typescript@4.2.4)(webpack-cli@3.3.10)
+        version: 6.3.1(@babel/core@7.8.3)(@types/react@16.14.8)(eslint@6.8.0)(react-dom@16.12.0)(react@16.12.0)(typescript@5.1.6)(webpack-cli@3.3.10)
       '@testing-library/dom':
         specifier: ^8.11.1
         version: 8.11.1
@@ -256,13 +256,13 @@ importers:
         version: 9.0.4
       '@typescript-eslint/eslint-plugin':
         specifier: 4.29.1
-        version: 4.29.1(@typescript-eslint/parser@4.29.1)(eslint@6.8.0)(typescript@4.2.4)
+        version: 4.29.1(@typescript-eslint/parser@4.29.1)(eslint@6.8.0)(typescript@5.1.6)
       '@typescript-eslint/parser':
         specifier: 4.29.1
-        version: 4.29.1(eslint@6.8.0)(typescript@4.2.4)
+        version: 4.29.1(eslint@6.8.0)(typescript@5.1.6)
       '@typescript-eslint/utils':
         specifier: 5.26.0
-        version: 5.26.0(eslint@6.8.0)(typescript@4.2.4)
+        version: 5.26.0(eslint@6.8.0)(typescript@5.1.6)
       antd:
         specifier: 3.26.20
         version: 3.26.20(@babel/runtime@7.12.13)(identity-obj-proxy@3.0.0)(react-dom@16.12.0)(react@16.12.0)
@@ -439,10 +439,10 @@ importers:
         version: 1.1.3(webpack@4.41.5)
       ts-jest:
         specifier: ^27.1.3
-        version: 27.1.3(@babel/core@7.8.3)(@types/jest@27.4.1)(babel-jest@27.5.1)(esbuild@0.14.43)(jest@27.5.1)(typescript@4.2.4)
+        version: 27.1.3(@babel/core@7.8.3)(@types/jest@27.4.1)(babel-jest@27.5.1)(esbuild@0.14.43)(jest@27.5.1)(typescript@5.1.6)
       typescript:
-        specifier: 4.2.4
-        version: 4.2.4
+        specifier: 5.1.6
+        version: 5.1.6
       uplot:
         specifier: ^1.6.19
         version: 1.6.19
@@ -502,7 +502,7 @@ importers:
         version: 5.1.15
       '@typescript-eslint/utils':
         specifier: ^5.26.0
-        version: 5.26.0(eslint@7.16.0)(typescript@4.2.4)
+        version: 5.26.0(eslint@7.16.0)(typescript@5.1.6)
       analytics-node:
         specifier: ^3.5.0
         version: 3.5.0
@@ -642,13 +642,13 @@ importers:
         version: 7.10.4(@babel/core@7.8.3)
       '@cockroachlabs/eslint-config':
         specifier: ^0.1.11
-        version: 0.1.11(@typescript-eslint/eslint-plugin@4.29.1)(eslint-plugin-prettier@3.4.1)(eslint-plugin-react-hooks@4.2.0)(eslint-plugin-react@7.21.5)(eslint@7.16.0)(typescript@4.2.4)
+        version: 0.1.11(@typescript-eslint/eslint-plugin@4.29.1)(eslint-plugin-prettier@3.4.1)(eslint-plugin-react-hooks@4.2.0)(eslint-plugin-react@7.21.5)(eslint@7.16.0)(typescript@5.1.6)
       '@reduxjs/toolkit':
         specifier: 1.6.0
         version: 1.6.0(react-redux@7.2.4)(react@16.12.0)
       '@storybook/react':
         specifier: ^6.3.1
-        version: 6.3.1(@babel/core@7.8.3)(@types/react@16.14.8)(eslint@7.16.0)(react-dom@16.12.0)(react@16.12.0)(typescript@4.2.4)(webpack-cli@3.3.10)(webpack-dev-server@3.10.1)
+        version: 6.3.1(@babel/core@7.8.3)(@types/react@16.14.8)(eslint@7.16.0)(react-dom@16.12.0)(react@16.12.0)(typescript@5.1.6)(webpack-cli@3.3.10)(webpack-dev-server@3.10.1)
       '@testing-library/dom':
         specifier: ^8.11.1
         version: 8.11.1
@@ -756,10 +756,10 @@ importers:
         version: 4.0.2
       '@typescript-eslint/eslint-plugin':
         specifier: 4.29.1
-        version: 4.29.1(@typescript-eslint/parser@4.29.1)(eslint@7.16.0)(typescript@4.2.4)
+        version: 4.29.1(@typescript-eslint/parser@4.29.1)(eslint@7.16.0)(typescript@5.1.6)
       '@typescript-eslint/parser':
         specifier: 4.29.1
-        version: 4.29.1(eslint@7.16.0)(typescript@4.2.4)
+        version: 4.29.1(eslint@7.16.0)(typescript@5.1.6)
       babel-jest:
         specifier: 27.5.1
         version: 27.5.1(@babel/core@7.8.3)
@@ -837,7 +837,7 @@ importers:
         version: 5.0.2(webpack@4.41.5)
       fork-ts-checker-webpack-plugin:
         specifier: ^1.0.0
-        version: 1.0.0(eslint@7.16.0)(typescript@4.2.4)(webpack@4.41.5)
+        version: 1.0.0(eslint@7.16.0)(typescript@5.1.6)(webpack@4.41.5)
       glob:
         specifier: ^7.1.1
         version: 7.1.1
@@ -942,13 +942,13 @@ importers:
         version: 3.0.2(patch_hash=wpfs36vhb2v7nm6ekzrirgbci4)
       ts-jest:
         specifier: 27.1.3
-        version: 27.1.3(@babel/core@7.8.3)(@types/jest@27.5.2)(babel-jest@27.5.1)(jest@27.5.1)(typescript@4.2.4)
+        version: 27.1.3(@babel/core@7.8.3)(@types/jest@27.5.2)(babel-jest@27.5.1)(jest@27.5.1)(typescript@5.1.6)
       ts-loader:
         specifier: ^6.2.1
-        version: 6.2.1(typescript@4.2.4)
+        version: 6.2.1(typescript@5.1.6)
       typescript:
-        specifier: 4.2.4
-        version: 4.2.4
+        specifier: 5.1.6
+        version: 5.1.6
       uglify-js:
         specifier: ^2.8.15
         version: 2.8.15
@@ -1058,11 +1058,11 @@ importers:
     dependencies:
       '@typescript-eslint/eslint-plugin':
         specifier: 4.29.1
-        version: 4.29.1(@typescript-eslint/parser@4.29.1)(eslint@7.29.0)(typescript@4.7.2)
+        version: 4.29.1(@typescript-eslint/parser@4.29.1)(eslint@7.29.0)(typescript@5.1.6)
     devDependencies:
       '@cockroachlabs/eslint-config':
         specifier: 0.1.11
-        version: 0.1.11(@typescript-eslint/eslint-plugin@4.29.1)(eslint-plugin-prettier@3.4.1)(eslint-plugin-react-hooks@4.2.0)(eslint-plugin-react@7.24.0)(eslint@7.29.0)(typescript@4.7.2)
+        version: 0.1.11(@typescript-eslint/eslint-plugin@4.29.1)(eslint-plugin-prettier@3.4.1)(eslint-plugin-react-hooks@4.2.0)(eslint-plugin-react@7.24.0)(eslint@7.29.0)(typescript@5.1.6)
       '@testing-library/cypress':
         specifier: ^8.0.2
         version: 8.0.2(cypress@10.3.0)
@@ -1071,7 +1071,7 @@ importers:
         version: 16.0.0
       '@typescript-eslint/parser':
         specifier: 4.29.1
-        version: 4.29.1(eslint@7.29.0)(typescript@4.7.2)
+        version: 4.29.1(eslint@7.29.0)(typescript@5.1.6)
       cypress:
         specifier: ^10.3.0
         version: 10.3.0
@@ -1094,21 +1094,21 @@ importers:
         specifier: 2.6.2
         version: 2.6.2
       typescript:
-        specifier: ^4.6.3
-        version: 4.7.2
+        specifier: 5.1.6
+        version: 5.1.6
 
   workspaces/eslint-plugin-crdb:
     dependencies:
       '@typescript-eslint/parser':
         specifier: ^5.0.0
-        version: 5.0.0(eslint@8.16.0)(typescript@4.7.2)
+        version: 5.0.0(eslint@8.16.0)(typescript@5.1.6)
       '@typescript-eslint/utils':
         specifier: ^5.26.0
-        version: 5.26.0(eslint@8.16.0)(typescript@4.7.2)
+        version: 5.26.0(eslint@8.16.0)(typescript@5.1.6)
     devDependencies:
       '@bazel/typescript':
         specifier: 5.5.0
-        version: 5.5.0(typescript@4.7.2)
+        version: 5.5.0(typescript@5.1.6)
       '@bazel/worker':
         specifier: 5.5.0
         version: 5.5.0
@@ -1123,10 +1123,10 @@ importers:
         version: 28.1.0
       ts-jest:
         specifier: ^28.0.3
-        version: 28.0.3(@babel/core@7.22.8)(jest@28.1.0)(typescript@4.7.2)
+        version: 28.0.3(@babel/core@7.22.8)(jest@28.1.0)(typescript@5.1.6)
       typescript:
-        specifier: ^4.7.2
-        version: 4.7.2
+        specifier: 5.1.6
+        version: 5.1.6
 
 packages:
 
@@ -5125,7 +5125,7 @@ packages:
       '@babel/helper-validator-identifier': 7.22.5
       to-fast-properties: 2.0.0
 
-  /@bazel/typescript@5.5.0(typescript@4.2.4):
+  /@bazel/typescript@5.5.0(typescript@5.1.6):
     resolution: {integrity: sha512-Ord0+nCj+B1M4NDbe0uqZf2FyOCzaDAlc4DAsr5UKJrArCipIbMTEAxlsEk+WAYBNAFGO/FS9/zlDtLceqpHqw==}
     deprecated: No longer maintained, https://github.com/aspect-build/rules_ts is the recommended replacement
     hasBin: true
@@ -5137,24 +5137,8 @@ packages:
       protobufjs: 6.8.6
       semver: 5.6.0
       source-map-support: 0.5.9
-      tsutils: 3.21.0(typescript@4.2.4)
-      typescript: 4.2.4
-    dev: true
-
-  /@bazel/typescript@5.5.0(typescript@4.7.2):
-    resolution: {integrity: sha512-Ord0+nCj+B1M4NDbe0uqZf2FyOCzaDAlc4DAsr5UKJrArCipIbMTEAxlsEk+WAYBNAFGO/FS9/zlDtLceqpHqw==}
-    deprecated: No longer maintained, https://github.com/aspect-build/rules_ts is the recommended replacement
-    hasBin: true
-    requiresBuild: true
-    peerDependencies:
-      typescript: '>=3.0.0'
-    dependencies:
-      '@bazel/worker': 5.5.0
-      protobufjs: 6.8.6
-      semver: 5.6.0
-      source-map-support: 0.5.9
-      tsutils: 3.21.0(typescript@4.7.2)
-      typescript: 4.7.2
+      tsutils: 3.21.0(typescript@5.1.6)
+      typescript: 5.1.6
     dev: true
 
   /@bazel/worker@5.5.0:
@@ -5170,7 +5154,7 @@ packages:
   /@cockroachlabs/design-tokens@0.4.5:
     resolution: {integrity: sha512-az2aIuGjnD0UBN5igLmaKvVWnZJ9r7v2jQ9C4fNR6bxxiF5DkOcD1DXf8EXHIbgwJtorpB74zaic7MQhhMY45w==}
 
-  /@cockroachlabs/eslint-config@0.1.11(@typescript-eslint/eslint-plugin@4.29.1)(eslint-plugin-prettier@3.4.1)(eslint-plugin-react-hooks@2.3.0)(eslint-plugin-react@7.21.5)(eslint@6.8.0)(typescript@4.2.4):
+  /@cockroachlabs/eslint-config@0.1.11(@typescript-eslint/eslint-plugin@4.29.1)(eslint-plugin-prettier@3.4.1)(eslint-plugin-react-hooks@2.3.0)(eslint-plugin-react@7.21.5)(eslint@6.8.0)(typescript@5.1.6):
     resolution: {integrity: sha512-lXeEfweDMg/g2a9KroNaLfa20cKFxUO5zWFlLty7ZHrGwSG7ndP9CYmXjokqBymhPa25NSOlWc4CetDFR0DXMQ==}
     peerDependencies:
       '@typescript-eslint/eslint-plugin': ^2.6.1
@@ -5180,19 +5164,19 @@ packages:
       eslint-plugin-react-hooks: ^2.3.0
       typescript: '>=2.8.0'
     dependencies:
-      '@typescript-eslint/eslint-plugin': 4.29.1(@typescript-eslint/parser@4.29.1)(eslint@6.8.0)(typescript@4.2.4)
-      '@typescript-eslint/parser': 4.29.1(eslint@6.8.0)(typescript@4.2.4)
+      '@typescript-eslint/eslint-plugin': 4.29.1(@typescript-eslint/parser@4.29.1)(eslint@6.8.0)(typescript@5.1.6)
+      '@typescript-eslint/parser': 4.29.1(eslint@6.8.0)(typescript@5.1.6)
       eslint: 6.8.0
       eslint-config-prettier: 6.11.0(eslint@6.8.0)
       eslint-plugin-prettier: 3.4.1(eslint-config-prettier@6.11.0)(eslint@6.8.0)(prettier@2.6.2)
       eslint-plugin-react: 7.21.5(eslint@6.8.0)
       eslint-plugin-react-hooks: 2.3.0(eslint@6.8.0)
-      typescript: 4.2.4
+      typescript: 5.1.6
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@cockroachlabs/eslint-config@0.1.11(@typescript-eslint/eslint-plugin@4.29.1)(eslint-plugin-prettier@3.4.1)(eslint-plugin-react-hooks@4.2.0)(eslint-plugin-react@7.21.5)(eslint@7.16.0)(typescript@4.2.4):
+  /@cockroachlabs/eslint-config@0.1.11(@typescript-eslint/eslint-plugin@4.29.1)(eslint-plugin-prettier@3.4.1)(eslint-plugin-react-hooks@4.2.0)(eslint-plugin-react@7.21.5)(eslint@7.16.0)(typescript@5.1.6):
     resolution: {integrity: sha512-lXeEfweDMg/g2a9KroNaLfa20cKFxUO5zWFlLty7ZHrGwSG7ndP9CYmXjokqBymhPa25NSOlWc4CetDFR0DXMQ==}
     peerDependencies:
       '@typescript-eslint/eslint-plugin': ^2.6.1
@@ -5202,19 +5186,19 @@ packages:
       eslint-plugin-react-hooks: ^2.3.0
       typescript: '>=2.8.0'
     dependencies:
-      '@typescript-eslint/eslint-plugin': 4.29.1(@typescript-eslint/parser@4.29.1)(eslint@7.16.0)(typescript@4.2.4)
-      '@typescript-eslint/parser': 4.29.1(eslint@7.16.0)(typescript@4.2.4)
+      '@typescript-eslint/eslint-plugin': 4.29.1(@typescript-eslint/parser@4.29.1)(eslint@7.16.0)(typescript@5.1.6)
+      '@typescript-eslint/parser': 4.29.1(eslint@7.16.0)(typescript@5.1.6)
       eslint: 7.16.0
       eslint-config-prettier: 6.11.0(eslint@7.16.0)
       eslint-plugin-prettier: 3.4.1(eslint-config-prettier@6.11.0)(eslint@7.16.0)(prettier@2.6.2)
       eslint-plugin-react: 7.21.5(eslint@7.16.0)
       eslint-plugin-react-hooks: 4.2.0(eslint@7.16.0)
-      typescript: 4.2.4
+      typescript: 5.1.6
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@cockroachlabs/eslint-config@0.1.11(@typescript-eslint/eslint-plugin@4.29.1)(eslint-plugin-prettier@3.4.1)(eslint-plugin-react-hooks@4.2.0)(eslint-plugin-react@7.24.0)(eslint@7.29.0)(typescript@4.7.2):
+  /@cockroachlabs/eslint-config@0.1.11(@typescript-eslint/eslint-plugin@4.29.1)(eslint-plugin-prettier@3.4.1)(eslint-plugin-react-hooks@4.2.0)(eslint-plugin-react@7.24.0)(eslint@7.29.0)(typescript@5.1.6):
     resolution: {integrity: sha512-lXeEfweDMg/g2a9KroNaLfa20cKFxUO5zWFlLty7ZHrGwSG7ndP9CYmXjokqBymhPa25NSOlWc4CetDFR0DXMQ==}
     peerDependencies:
       '@typescript-eslint/eslint-plugin': ^2.6.1
@@ -5224,14 +5208,14 @@ packages:
       eslint-plugin-react-hooks: ^2.3.0
       typescript: '>=2.8.0'
     dependencies:
-      '@typescript-eslint/eslint-plugin': 4.29.1(@typescript-eslint/parser@4.29.1)(eslint@7.29.0)(typescript@4.7.2)
-      '@typescript-eslint/parser': 4.29.1(eslint@7.29.0)(typescript@4.7.2)
+      '@typescript-eslint/eslint-plugin': 4.29.1(@typescript-eslint/parser@4.29.1)(eslint@7.29.0)(typescript@5.1.6)
+      '@typescript-eslint/parser': 4.29.1(eslint@7.29.0)(typescript@5.1.6)
       eslint: 7.29.0
       eslint-config-prettier: 6.11.0(eslint@7.29.0)
       eslint-plugin-prettier: 3.4.1(eslint-config-prettier@8.8.0)(eslint@7.29.0)(prettier@2.6.2)
       eslint-plugin-react: 7.24.0(eslint@7.29.0)
       eslint-plugin-react-hooks: 4.2.0(eslint@7.29.0)
-      typescript: 4.7.2
+      typescript: 5.1.6
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -6499,7 +6483,7 @@ packages:
       util-deprecate: 1.0.2
     dev: true
 
-  /@storybook/builder-webpack4@6.3.1(@types/react@16.14.8)(eslint@6.8.0)(react-dom@16.12.0)(react@16.12.0)(typescript@4.2.4)(webpack-cli@3.3.10):
+  /@storybook/builder-webpack4@6.3.1(@types/react@16.14.8)(eslint@6.8.0)(react-dom@16.12.0)(react@16.12.0)(typescript@5.1.6)(webpack-cli@3.3.10):
     resolution: {integrity: sha512-G0McjY59svyarwCTaS1T2O00s4iFollm/85z62IrM5+HcshJLkMZ4gNcgo3EiHpYkiAvBIJXAHXlDxkf8E9V0w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -6537,7 +6521,7 @@ packages:
       '@storybook/client-api': 6.3.1(react-dom@16.12.0)(react@16.12.0)
       '@storybook/client-logger': 6.3.1
       '@storybook/components': 6.3.1(@types/react@16.14.8)(react-dom@16.12.0)(react@16.12.0)
-      '@storybook/core-common': 6.3.1(eslint@6.8.0)(react-dom@16.12.0)(react@16.12.0)(typescript@4.2.4)(webpack-cli@3.3.10)
+      '@storybook/core-common': 6.3.1(eslint@6.8.0)(react-dom@16.12.0)(react@16.12.0)(typescript@5.1.6)(webpack-cli@3.3.10)
       '@storybook/core-events': 6.3.1
       '@storybook/node-logger': 6.3.1
       '@storybook/router': 6.3.1(react-dom@16.12.0)(react@16.12.0)
@@ -6556,25 +6540,25 @@ packages:
       dotenv-webpack: 1.8.0(webpack@4.46.0)
       file-loader: 6.2.0(webpack@4.46.0)
       find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 4.1.6(eslint@6.8.0)(typescript@4.2.4)(webpack@4.46.0)
+      fork-ts-checker-webpack-plugin: 4.1.6(eslint@6.8.0)(typescript@5.1.6)(webpack@4.46.0)
       fs-extra: 9.1.0
       glob: 7.2.3
       glob-promise: 3.4.0(glob@7.2.3)
       global: 4.4.0
       html-webpack-plugin: 4.5.2(webpack@4.46.0)
-      pnp-webpack-plugin: 1.6.4(typescript@4.2.4)
+      pnp-webpack-plugin: 1.6.4(typescript@5.1.6)
       postcss: 7.0.39
       postcss-flexbugs-fixes: 4.2.1
       postcss-loader: 4.3.0(postcss@7.0.39)(webpack@4.46.0)
       raw-loader: 4.0.2(webpack@4.46.0)
       react: 16.12.0
-      react-dev-utils: 11.0.4(eslint@6.8.0)(typescript@4.2.4)(webpack@4.46.0)
+      react-dev-utils: 11.0.4(eslint@6.8.0)(typescript@5.1.6)(webpack@4.46.0)
       react-dom: 16.12.0(react@16.12.0)
       stable: 0.1.8
       style-loader: 1.3.0(webpack@4.46.0)
       terser-webpack-plugin: 4.2.3(webpack@4.46.0)
       ts-dedent: 2.2.0
-      typescript: 4.2.4
+      typescript: 5.1.6
       url-loader: 4.1.1(file-loader@6.2.0)(webpack@4.46.0)
       util-deprecate: 1.0.2
       webpack: 4.46.0(webpack-cli@3.3.10)
@@ -6592,7 +6576,7 @@ packages:
       - webpack-command
     dev: true
 
-  /@storybook/builder-webpack4@6.3.1(@types/react@16.14.8)(eslint@7.16.0)(react-dom@16.12.0)(react@16.12.0)(typescript@4.2.4)(webpack-cli@3.3.10):
+  /@storybook/builder-webpack4@6.3.1(@types/react@16.14.8)(eslint@7.16.0)(react-dom@16.12.0)(react@16.12.0)(typescript@5.1.6)(webpack-cli@3.3.10):
     resolution: {integrity: sha512-G0McjY59svyarwCTaS1T2O00s4iFollm/85z62IrM5+HcshJLkMZ4gNcgo3EiHpYkiAvBIJXAHXlDxkf8E9V0w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -6630,7 +6614,7 @@ packages:
       '@storybook/client-api': 6.3.1(react-dom@16.12.0)(react@16.12.0)
       '@storybook/client-logger': 6.3.1
       '@storybook/components': 6.3.1(@types/react@16.14.8)(react-dom@16.12.0)(react@16.12.0)
-      '@storybook/core-common': 6.3.1(eslint@7.16.0)(react-dom@16.12.0)(react@16.12.0)(typescript@4.2.4)(webpack-cli@3.3.10)
+      '@storybook/core-common': 6.3.1(eslint@7.16.0)(react-dom@16.12.0)(react@16.12.0)(typescript@5.1.6)(webpack-cli@3.3.10)
       '@storybook/core-events': 6.3.1
       '@storybook/node-logger': 6.3.1
       '@storybook/router': 6.3.1(react-dom@16.12.0)(react@16.12.0)
@@ -6649,25 +6633,25 @@ packages:
       dotenv-webpack: 1.8.0(webpack@4.46.0)
       file-loader: 6.2.0(webpack@4.46.0)
       find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 4.1.6(eslint@7.16.0)(typescript@4.2.4)(webpack@4.46.0)
+      fork-ts-checker-webpack-plugin: 4.1.6(eslint@7.16.0)(typescript@5.1.6)(webpack@4.46.0)
       fs-extra: 9.1.0
       glob: 7.2.3
       glob-promise: 3.4.0(glob@7.2.3)
       global: 4.4.0
       html-webpack-plugin: 4.5.2(webpack@4.46.0)
-      pnp-webpack-plugin: 1.6.4(typescript@4.2.4)
+      pnp-webpack-plugin: 1.6.4(typescript@5.1.6)
       postcss: 7.0.39
       postcss-flexbugs-fixes: 4.2.1
       postcss-loader: 4.3.0(postcss@7.0.39)(webpack@4.46.0)
       raw-loader: 4.0.2(webpack@4.46.0)
       react: 16.12.0
-      react-dev-utils: 11.0.4(eslint@7.16.0)(typescript@4.2.4)(webpack@4.46.0)
+      react-dev-utils: 11.0.4(eslint@7.16.0)(typescript@5.1.6)(webpack@4.46.0)
       react-dom: 16.12.0(react@16.12.0)
       stable: 0.1.8
       style-loader: 1.3.0(webpack@4.46.0)
       terser-webpack-plugin: 4.2.3(webpack@4.46.0)
       ts-dedent: 2.2.0
-      typescript: 4.2.4
+      typescript: 5.1.6
       url-loader: 4.1.1(file-loader@6.2.0)(webpack@4.46.0)
       util-deprecate: 1.0.2
       webpack: 4.46.0(webpack-cli@3.3.10)
@@ -6809,7 +6793,7 @@ packages:
       util-deprecate: 1.0.2
     dev: true
 
-  /@storybook/core-client@6.3.1(@types/react@16.14.8)(react-dom@16.12.0)(react@16.12.0)(typescript@4.2.4)(webpack@4.46.0):
+  /@storybook/core-client@6.3.1(@types/react@16.14.8)(react-dom@16.12.0)(react@16.12.0)(typescript@5.1.6)(webpack@4.46.0):
     resolution: {integrity: sha512-CQWSMhmxqNYS10zvyaCYbwgaznKr30kus1Ri/wEjf5NTvX8+6vj3oo9fx2ZlVHwmKrXcFVMDp5+zJEZ6PtoLNg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -6837,7 +6821,7 @@ packages:
       react-dom: 16.12.0(react@16.12.0)
       regenerator-runtime: 0.13.11
       ts-dedent: 2.2.0
-      typescript: 4.2.4
+      typescript: 5.1.6
       unfetch: 4.2.0
       util-deprecate: 1.0.2
       webpack: 4.46.0(webpack-cli@3.3.10)
@@ -6845,7 +6829,7 @@ packages:
       - '@types/react'
     dev: true
 
-  /@storybook/core-common@6.3.1(eslint@6.8.0)(react-dom@16.12.0)(react@16.12.0)(typescript@4.2.4)(webpack-cli@3.3.10):
+  /@storybook/core-common@6.3.1(eslint@6.8.0)(react-dom@16.12.0)(react@16.12.0)(typescript@5.1.6)(webpack-cli@3.3.10):
     resolution: {integrity: sha512-c0ZvZo52SwzL3xI+C7ux+wCpq0uDIXiau4S9LoeKHjRUc1vFyrQKgkQ0UeKXk43DhhlpVYdxw88ZyFHkeNCaEg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -6890,7 +6874,7 @@ packages:
       express: 4.18.2(supports-color@6.1.0)
       file-system-cache: 1.1.0
       find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 6.5.3(eslint@6.8.0)(typescript@4.2.4)(webpack@4.46.0)
+      fork-ts-checker-webpack-plugin: 6.5.3(eslint@6.8.0)(typescript@5.1.6)(webpack@4.46.0)
       glob: 7.2.3
       glob-base: 0.3.0
       interpret: 2.2.0
@@ -6903,7 +6887,7 @@ packages:
       react-dom: 16.12.0(react@16.12.0)
       resolve-from: 5.0.0
       ts-dedent: 2.2.0
-      typescript: 4.2.4
+      typescript: 5.1.6
       util-deprecate: 1.0.2
       webpack: 4.46.0(webpack-cli@3.3.10)
     transitivePeerDependencies:
@@ -6914,7 +6898,7 @@ packages:
       - webpack-command
     dev: true
 
-  /@storybook/core-common@6.3.1(eslint@7.16.0)(react-dom@16.12.0)(react@16.12.0)(typescript@4.2.4)(webpack-cli@3.3.10):
+  /@storybook/core-common@6.3.1(eslint@7.16.0)(react-dom@16.12.0)(react@16.12.0)(typescript@5.1.6)(webpack-cli@3.3.10):
     resolution: {integrity: sha512-c0ZvZo52SwzL3xI+C7ux+wCpq0uDIXiau4S9LoeKHjRUc1vFyrQKgkQ0UeKXk43DhhlpVYdxw88ZyFHkeNCaEg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -6959,7 +6943,7 @@ packages:
       express: 4.18.2(supports-color@6.1.0)
       file-system-cache: 1.1.0
       find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 6.5.3(eslint@7.16.0)(typescript@4.2.4)(webpack@4.46.0)
+      fork-ts-checker-webpack-plugin: 6.5.3(eslint@7.16.0)(typescript@5.1.6)(webpack@4.46.0)
       glob: 7.2.3
       glob-base: 0.3.0
       interpret: 2.2.0
@@ -6972,7 +6956,7 @@ packages:
       react-dom: 16.12.0(react@16.12.0)
       resolve-from: 5.0.0
       ts-dedent: 2.2.0
-      typescript: 4.2.4
+      typescript: 5.1.6
       util-deprecate: 1.0.2
       webpack: 4.46.0(webpack-cli@3.3.10)
     transitivePeerDependencies:
@@ -6995,7 +6979,7 @@ packages:
       core-js: 3.31.1
     dev: true
 
-  /@storybook/core-server@6.3.1(@babel/core@7.8.3)(@types/react@16.14.8)(eslint@6.8.0)(react-dom@16.12.0)(react@16.12.0)(typescript@4.2.4)(webpack-cli@3.3.10):
+  /@storybook/core-server@6.3.1(@babel/core@7.8.3)(@types/react@16.14.8)(eslint@6.8.0)(react-dom@16.12.0)(react@16.12.0)(typescript@5.1.6)(webpack-cli@3.3.10):
     resolution: {integrity: sha512-MlDGjo3DFUMTva6d+T7YuQRqZ2YxziiEdQAH9Na3TRuuhNoIrl6g04y7ys0W3MjYaoKjVXQMYBKYXayot939Cw==}
     peerDependencies:
       '@storybook/builder-webpack5': 6.3.1
@@ -7011,11 +6995,11 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@storybook/builder-webpack4': 6.3.1(@types/react@16.14.8)(eslint@6.8.0)(react-dom@16.12.0)(react@16.12.0)(typescript@4.2.4)(webpack-cli@3.3.10)
-      '@storybook/core-client': 6.3.1(@types/react@16.14.8)(react-dom@16.12.0)(react@16.12.0)(typescript@4.2.4)(webpack@4.46.0)
-      '@storybook/core-common': 6.3.1(eslint@6.8.0)(react-dom@16.12.0)(react@16.12.0)(typescript@4.2.4)(webpack-cli@3.3.10)
+      '@storybook/builder-webpack4': 6.3.1(@types/react@16.14.8)(eslint@6.8.0)(react-dom@16.12.0)(react@16.12.0)(typescript@5.1.6)(webpack-cli@3.3.10)
+      '@storybook/core-client': 6.3.1(@types/react@16.14.8)(react-dom@16.12.0)(react@16.12.0)(typescript@5.1.6)(webpack@4.46.0)
+      '@storybook/core-common': 6.3.1(eslint@6.8.0)(react-dom@16.12.0)(react@16.12.0)(typescript@5.1.6)(webpack-cli@3.3.10)
       '@storybook/csf-tools': 6.3.1(@babel/core@7.8.3)
-      '@storybook/manager-webpack4': 6.3.1(@types/react@16.14.8)(eslint@6.8.0)(react-dom@16.12.0)(react@16.12.0)(typescript@4.2.4)(webpack-cli@3.3.10)
+      '@storybook/manager-webpack4': 6.3.1(@types/react@16.14.8)(eslint@6.8.0)(react-dom@16.12.0)(react@16.12.0)(typescript@5.1.6)(webpack-cli@3.3.10)
       '@storybook/node-logger': 6.3.1
       '@storybook/semver': 7.3.2
       '@types/node': 14.18.53
@@ -7044,7 +7028,7 @@ packages:
       regenerator-runtime: 0.13.11
       serve-favicon: 2.5.0
       ts-dedent: 2.2.0
-      typescript: 4.2.4
+      typescript: 5.1.6
       util-deprecate: 1.0.2
       webpack: 4.46.0(webpack-cli@3.3.10)
     transitivePeerDependencies:
@@ -7059,7 +7043,7 @@ packages:
       - webpack-command
     dev: true
 
-  /@storybook/core-server@6.3.1(@babel/core@7.8.3)(@types/react@16.14.8)(eslint@7.16.0)(react-dom@16.12.0)(react@16.12.0)(typescript@4.2.4)(webpack-cli@3.3.10):
+  /@storybook/core-server@6.3.1(@babel/core@7.8.3)(@types/react@16.14.8)(eslint@7.16.0)(react-dom@16.12.0)(react@16.12.0)(typescript@5.1.6)(webpack-cli@3.3.10):
     resolution: {integrity: sha512-MlDGjo3DFUMTva6d+T7YuQRqZ2YxziiEdQAH9Na3TRuuhNoIrl6g04y7ys0W3MjYaoKjVXQMYBKYXayot939Cw==}
     peerDependencies:
       '@storybook/builder-webpack5': 6.3.1
@@ -7075,11 +7059,11 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@storybook/builder-webpack4': 6.3.1(@types/react@16.14.8)(eslint@7.16.0)(react-dom@16.12.0)(react@16.12.0)(typescript@4.2.4)(webpack-cli@3.3.10)
-      '@storybook/core-client': 6.3.1(@types/react@16.14.8)(react-dom@16.12.0)(react@16.12.0)(typescript@4.2.4)(webpack@4.46.0)
-      '@storybook/core-common': 6.3.1(eslint@7.16.0)(react-dom@16.12.0)(react@16.12.0)(typescript@4.2.4)(webpack-cli@3.3.10)
+      '@storybook/builder-webpack4': 6.3.1(@types/react@16.14.8)(eslint@7.16.0)(react-dom@16.12.0)(react@16.12.0)(typescript@5.1.6)(webpack-cli@3.3.10)
+      '@storybook/core-client': 6.3.1(@types/react@16.14.8)(react-dom@16.12.0)(react@16.12.0)(typescript@5.1.6)(webpack@4.46.0)
+      '@storybook/core-common': 6.3.1(eslint@7.16.0)(react-dom@16.12.0)(react@16.12.0)(typescript@5.1.6)(webpack-cli@3.3.10)
       '@storybook/csf-tools': 6.3.1(@babel/core@7.8.3)
-      '@storybook/manager-webpack4': 6.3.1(@types/react@16.14.8)(eslint@7.16.0)(react-dom@16.12.0)(react@16.12.0)(typescript@4.2.4)(webpack-cli@3.3.10)
+      '@storybook/manager-webpack4': 6.3.1(@types/react@16.14.8)(eslint@7.16.0)(react-dom@16.12.0)(react@16.12.0)(typescript@5.1.6)(webpack-cli@3.3.10)
       '@storybook/node-logger': 6.3.1
       '@storybook/semver': 7.3.2
       '@types/node': 14.18.53
@@ -7108,7 +7092,7 @@ packages:
       regenerator-runtime: 0.13.11
       serve-favicon: 2.5.0
       ts-dedent: 2.2.0
-      typescript: 4.2.4
+      typescript: 5.1.6
       util-deprecate: 1.0.2
       webpack: 4.46.0(webpack-cli@3.3.10)
     transitivePeerDependencies:
@@ -7123,7 +7107,7 @@ packages:
       - webpack-command
     dev: true
 
-  /@storybook/core@6.3.1(@babel/core@7.8.3)(@types/react@16.14.8)(eslint@6.8.0)(react-dom@16.12.0)(react@16.12.0)(typescript@4.2.4)(webpack-cli@3.3.10)(webpack@4.46.0):
+  /@storybook/core@6.3.1(@babel/core@7.8.3)(@types/react@16.14.8)(eslint@6.8.0)(react-dom@16.12.0)(react@16.12.0)(typescript@5.1.6)(webpack-cli@3.3.10)(webpack@4.46.0):
     resolution: {integrity: sha512-H1CMPwiFJlJNEKqQ9+PxNCiUcuwzRKCE3Ecg29d9KoW0r8lnfHRsW4XUL8JavFAWvlg5CBjMOc/E7obmStsOIA==}
     peerDependencies:
       '@storybook/builder-webpack5': 6.3.1
@@ -7136,11 +7120,11 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@storybook/core-client': 6.3.1(@types/react@16.14.8)(react-dom@16.12.0)(react@16.12.0)(typescript@4.2.4)(webpack@4.46.0)
-      '@storybook/core-server': 6.3.1(@babel/core@7.8.3)(@types/react@16.14.8)(eslint@6.8.0)(react-dom@16.12.0)(react@16.12.0)(typescript@4.2.4)(webpack-cli@3.3.10)
+      '@storybook/core-client': 6.3.1(@types/react@16.14.8)(react-dom@16.12.0)(react@16.12.0)(typescript@5.1.6)(webpack@4.46.0)
+      '@storybook/core-server': 6.3.1(@babel/core@7.8.3)(@types/react@16.14.8)(eslint@6.8.0)(react-dom@16.12.0)(react@16.12.0)(typescript@5.1.6)(webpack-cli@3.3.10)
       react: 16.12.0
       react-dom: 16.12.0(react@16.12.0)
-      typescript: 4.2.4
+      typescript: 5.1.6
     transitivePeerDependencies:
       - '@babel/core'
       - '@storybook/manager-webpack5'
@@ -7155,7 +7139,7 @@ packages:
       - webpack-command
     dev: true
 
-  /@storybook/core@6.3.1(@babel/core@7.8.3)(@types/react@16.14.8)(eslint@7.16.0)(react-dom@16.12.0)(react@16.12.0)(typescript@4.2.4)(webpack-cli@3.3.10)(webpack@4.46.0):
+  /@storybook/core@6.3.1(@babel/core@7.8.3)(@types/react@16.14.8)(eslint@7.16.0)(react-dom@16.12.0)(react@16.12.0)(typescript@5.1.6)(webpack-cli@3.3.10)(webpack@4.46.0):
     resolution: {integrity: sha512-H1CMPwiFJlJNEKqQ9+PxNCiUcuwzRKCE3Ecg29d9KoW0r8lnfHRsW4XUL8JavFAWvlg5CBjMOc/E7obmStsOIA==}
     peerDependencies:
       '@storybook/builder-webpack5': 6.3.1
@@ -7168,11 +7152,11 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@storybook/core-client': 6.3.1(@types/react@16.14.8)(react-dom@16.12.0)(react@16.12.0)(typescript@4.2.4)(webpack@4.46.0)
-      '@storybook/core-server': 6.3.1(@babel/core@7.8.3)(@types/react@16.14.8)(eslint@7.16.0)(react-dom@16.12.0)(react@16.12.0)(typescript@4.2.4)(webpack-cli@3.3.10)
+      '@storybook/core-client': 6.3.1(@types/react@16.14.8)(react-dom@16.12.0)(react@16.12.0)(typescript@5.1.6)(webpack@4.46.0)
+      '@storybook/core-server': 6.3.1(@babel/core@7.8.3)(@types/react@16.14.8)(eslint@7.16.0)(react-dom@16.12.0)(react@16.12.0)(typescript@5.1.6)(webpack-cli@3.3.10)
       react: 16.12.0
       react-dom: 16.12.0(react@16.12.0)
-      typescript: 4.2.4
+      typescript: 5.1.6
     transitivePeerDependencies:
       - '@babel/core'
       - '@storybook/manager-webpack5'
@@ -7221,7 +7205,7 @@ packages:
       lodash: 4.17.20
     dev: true
 
-  /@storybook/manager-webpack4@6.3.1(@types/react@16.14.8)(eslint@6.8.0)(react-dom@16.12.0)(react@16.12.0)(typescript@4.2.4)(webpack-cli@3.3.10):
+  /@storybook/manager-webpack4@6.3.1(@types/react@16.14.8)(eslint@6.8.0)(react-dom@16.12.0)(react@16.12.0)(typescript@5.1.6)(webpack-cli@3.3.10):
     resolution: {integrity: sha512-KMFSp2gWdGhIH4sKPeJNcju9w3nfyhCBtNv9bugLoUapv7eAix6zwk2x91SeswhBQT6NBPUusNtT5CpkgEcDAw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -7235,8 +7219,8 @@ packages:
       '@babel/plugin-transform-template-literals': 7.22.5(@babel/core@7.22.8)
       '@babel/preset-react': 7.22.5(@babel/core@7.22.8)
       '@storybook/addons': 6.3.1(react-dom@16.12.0)(react@16.12.0)
-      '@storybook/core-client': 6.3.1(@types/react@16.14.8)(react-dom@16.12.0)(react@16.12.0)(typescript@4.2.4)(webpack@4.46.0)
-      '@storybook/core-common': 6.3.1(eslint@6.8.0)(react-dom@16.12.0)(react@16.12.0)(typescript@4.2.4)(webpack-cli@3.3.10)
+      '@storybook/core-client': 6.3.1(@types/react@16.14.8)(react-dom@16.12.0)(react@16.12.0)(typescript@5.1.6)(webpack@4.46.0)
+      '@storybook/core-common': 6.3.1(eslint@6.8.0)(react-dom@16.12.0)(react@16.12.0)(typescript@5.1.6)(webpack-cli@3.3.10)
       '@storybook/node-logger': 6.3.1
       '@storybook/theming': 6.3.1(react-dom@16.12.0)(react@16.12.0)
       '@storybook/ui': 6.3.1(@types/react@16.14.8)(react-dom@16.12.0)(react@16.12.0)
@@ -7255,7 +7239,7 @@ packages:
       fs-extra: 9.1.0
       html-webpack-plugin: 4.5.2(webpack@4.46.0)
       node-fetch: 2.6.7
-      pnp-webpack-plugin: 1.6.4(typescript@4.2.4)
+      pnp-webpack-plugin: 1.6.4(typescript@5.1.6)
       react: 16.12.0
       react-dom: 16.12.0(react@16.12.0)
       read-pkg-up: 7.0.1
@@ -7265,7 +7249,7 @@ packages:
       telejson: 5.3.3
       terser-webpack-plugin: 4.2.3(webpack@4.46.0)
       ts-dedent: 2.2.0
-      typescript: 4.2.4
+      typescript: 5.1.6
       url-loader: 4.1.1(file-loader@6.2.0)(webpack@4.46.0)
       util-deprecate: 1.0.2
       webpack: 4.46.0(webpack-cli@3.3.10)
@@ -7282,7 +7266,7 @@ packages:
       - webpack-command
     dev: true
 
-  /@storybook/manager-webpack4@6.3.1(@types/react@16.14.8)(eslint@7.16.0)(react-dom@16.12.0)(react@16.12.0)(typescript@4.2.4)(webpack-cli@3.3.10):
+  /@storybook/manager-webpack4@6.3.1(@types/react@16.14.8)(eslint@7.16.0)(react-dom@16.12.0)(react@16.12.0)(typescript@5.1.6)(webpack-cli@3.3.10):
     resolution: {integrity: sha512-KMFSp2gWdGhIH4sKPeJNcju9w3nfyhCBtNv9bugLoUapv7eAix6zwk2x91SeswhBQT6NBPUusNtT5CpkgEcDAw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -7296,8 +7280,8 @@ packages:
       '@babel/plugin-transform-template-literals': 7.22.5(@babel/core@7.22.8)
       '@babel/preset-react': 7.22.5(@babel/core@7.22.8)
       '@storybook/addons': 6.3.1(react-dom@16.12.0)(react@16.12.0)
-      '@storybook/core-client': 6.3.1(@types/react@16.14.8)(react-dom@16.12.0)(react@16.12.0)(typescript@4.2.4)(webpack@4.46.0)
-      '@storybook/core-common': 6.3.1(eslint@7.16.0)(react-dom@16.12.0)(react@16.12.0)(typescript@4.2.4)(webpack-cli@3.3.10)
+      '@storybook/core-client': 6.3.1(@types/react@16.14.8)(react-dom@16.12.0)(react@16.12.0)(typescript@5.1.6)(webpack@4.46.0)
+      '@storybook/core-common': 6.3.1(eslint@7.16.0)(react-dom@16.12.0)(react@16.12.0)(typescript@5.1.6)(webpack-cli@3.3.10)
       '@storybook/node-logger': 6.3.1
       '@storybook/theming': 6.3.1(react-dom@16.12.0)(react@16.12.0)
       '@storybook/ui': 6.3.1(@types/react@16.14.8)(react-dom@16.12.0)(react@16.12.0)
@@ -7316,7 +7300,7 @@ packages:
       fs-extra: 9.1.0
       html-webpack-plugin: 4.5.2(webpack@4.46.0)
       node-fetch: 2.6.7
-      pnp-webpack-plugin: 1.6.4(typescript@4.2.4)
+      pnp-webpack-plugin: 1.6.4(typescript@5.1.6)
       react: 16.12.0
       react-dom: 16.12.0(react@16.12.0)
       read-pkg-up: 7.0.1
@@ -7326,7 +7310,7 @@ packages:
       telejson: 5.3.3
       terser-webpack-plugin: 4.2.3(webpack@4.46.0)
       ts-dedent: 2.2.0
-      typescript: 4.2.4
+      typescript: 5.1.6
       url-loader: 4.1.1(file-loader@6.2.0)(webpack@4.46.0)
       util-deprecate: 1.0.2
       webpack: 4.46.0(webpack-cli@3.3.10)
@@ -7353,7 +7337,7 @@ packages:
       pretty-hrtime: 1.0.3
     dev: true
 
-  /@storybook/react-docgen-typescript-plugin@1.0.2-canary.3c70e01.0(typescript@4.2.4)(webpack@4.46.0):
+  /@storybook/react-docgen-typescript-plugin@1.0.2-canary.3c70e01.0(typescript@5.1.6)(webpack@4.46.0):
     resolution: {integrity: sha512-go1LO+iM6qLGhgqvEoEpw339/kf2YBX86aG2JewWwlHCO0YyyYdlsdZd3KkB5MVtudyK7mtrcNDq0k/EIaB2JA==}
     peerDependencies:
       typescript: '>= 3.x'
@@ -7364,15 +7348,15 @@ packages:
       find-cache-dir: 3.3.2
       flat-cache: 3.0.4
       micromatch: 4.0.5
-      react-docgen-typescript: 2.2.2(typescript@4.2.4)
+      react-docgen-typescript: 2.2.2(typescript@5.1.6)
       tslib: 2.6.0
-      typescript: 4.2.4
+      typescript: 5.1.6
       webpack: 4.46.0(webpack-cli@3.3.10)
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@storybook/react@6.3.1(@babel/core@7.8.3)(@types/react@16.14.8)(eslint@6.8.0)(react-dom@16.12.0)(react@16.12.0)(typescript@4.2.4)(webpack-cli@3.3.10):
+  /@storybook/react@6.3.1(@babel/core@7.8.3)(@types/react@16.14.8)(eslint@6.8.0)(react-dom@16.12.0)(react@16.12.0)(typescript@5.1.6)(webpack-cli@3.3.10):
     resolution: {integrity: sha512-P3neN04YWpIyJ0kLq5UWo390wwM9HG6hVOJUi1uw9lMFbZoy/oVM77ot+77Mtfq3S58Rv51iohFF9DAkxPFNzA==}
     engines: {node: '>=10.13.0'}
     hasBin: true
@@ -7392,10 +7376,10 @@ packages:
       '@babel/preset-react': 7.22.5(@babel/core@7.8.3)
       '@pmmmwh/react-refresh-webpack-plugin': 0.4.3(react-refresh@0.8.3)(webpack-dev-server@3.10.1)(webpack@4.46.0)
       '@storybook/addons': 6.3.1(react-dom@16.12.0)(react@16.12.0)
-      '@storybook/core': 6.3.1(@babel/core@7.8.3)(@types/react@16.14.8)(eslint@6.8.0)(react-dom@16.12.0)(react@16.12.0)(typescript@4.2.4)(webpack-cli@3.3.10)(webpack@4.46.0)
-      '@storybook/core-common': 6.3.1(eslint@6.8.0)(react-dom@16.12.0)(react@16.12.0)(typescript@4.2.4)(webpack-cli@3.3.10)
+      '@storybook/core': 6.3.1(@babel/core@7.8.3)(@types/react@16.14.8)(eslint@6.8.0)(react-dom@16.12.0)(react@16.12.0)(typescript@5.1.6)(webpack-cli@3.3.10)(webpack@4.46.0)
+      '@storybook/core-common': 6.3.1(eslint@6.8.0)(react-dom@16.12.0)(react@16.12.0)(typescript@5.1.6)(webpack-cli@3.3.10)
       '@storybook/node-logger': 6.3.1
-      '@storybook/react-docgen-typescript-plugin': 1.0.2-canary.3c70e01.0(typescript@4.2.4)(webpack@4.46.0)
+      '@storybook/react-docgen-typescript-plugin': 1.0.2-canary.3c70e01.0(typescript@5.1.6)(webpack@4.46.0)
       '@storybook/semver': 7.3.2
       '@types/webpack-env': 1.18.1
       babel-plugin-add-react-displayname: 0.0.5
@@ -7406,13 +7390,13 @@ packages:
       lodash: 4.17.20
       prop-types: 15.8.1
       react: 16.12.0
-      react-dev-utils: 11.0.4(eslint@6.8.0)(typescript@4.2.4)(webpack@4.46.0)
+      react-dev-utils: 11.0.4(eslint@6.8.0)(typescript@5.1.6)(webpack@4.46.0)
       react-dom: 16.12.0(react@16.12.0)
       react-refresh: 0.8.3
       read-pkg-up: 7.0.1
       regenerator-runtime: 0.13.11
       ts-dedent: 2.2.0
-      typescript: 4.2.4
+      typescript: 5.1.6
       webpack: 4.46.0(webpack-cli@3.3.10)
     transitivePeerDependencies:
       - '@storybook/builder-webpack5'
@@ -7433,7 +7417,7 @@ packages:
       - webpack-plugin-serve
     dev: true
 
-  /@storybook/react@6.3.1(@babel/core@7.8.3)(@types/react@16.14.8)(eslint@7.16.0)(react-dom@16.12.0)(react@16.12.0)(typescript@4.2.4)(webpack-cli@3.3.10)(webpack-dev-server@3.10.1):
+  /@storybook/react@6.3.1(@babel/core@7.8.3)(@types/react@16.14.8)(eslint@7.16.0)(react-dom@16.12.0)(react@16.12.0)(typescript@5.1.6)(webpack-cli@3.3.10)(webpack-dev-server@3.10.1):
     resolution: {integrity: sha512-P3neN04YWpIyJ0kLq5UWo390wwM9HG6hVOJUi1uw9lMFbZoy/oVM77ot+77Mtfq3S58Rv51iohFF9DAkxPFNzA==}
     engines: {node: '>=10.13.0'}
     hasBin: true
@@ -7453,10 +7437,10 @@ packages:
       '@babel/preset-react': 7.22.5(@babel/core@7.8.3)
       '@pmmmwh/react-refresh-webpack-plugin': 0.4.3(react-refresh@0.8.3)(webpack-dev-server@3.10.1)(webpack@4.46.0)
       '@storybook/addons': 6.3.1(react-dom@16.12.0)(react@16.12.0)
-      '@storybook/core': 6.3.1(@babel/core@7.8.3)(@types/react@16.14.8)(eslint@7.16.0)(react-dom@16.12.0)(react@16.12.0)(typescript@4.2.4)(webpack-cli@3.3.10)(webpack@4.46.0)
-      '@storybook/core-common': 6.3.1(eslint@7.16.0)(react-dom@16.12.0)(react@16.12.0)(typescript@4.2.4)(webpack-cli@3.3.10)
+      '@storybook/core': 6.3.1(@babel/core@7.8.3)(@types/react@16.14.8)(eslint@7.16.0)(react-dom@16.12.0)(react@16.12.0)(typescript@5.1.6)(webpack-cli@3.3.10)(webpack@4.46.0)
+      '@storybook/core-common': 6.3.1(eslint@7.16.0)(react-dom@16.12.0)(react@16.12.0)(typescript@5.1.6)(webpack-cli@3.3.10)
       '@storybook/node-logger': 6.3.1
-      '@storybook/react-docgen-typescript-plugin': 1.0.2-canary.3c70e01.0(typescript@4.2.4)(webpack@4.46.0)
+      '@storybook/react-docgen-typescript-plugin': 1.0.2-canary.3c70e01.0(typescript@5.1.6)(webpack@4.46.0)
       '@storybook/semver': 7.3.2
       '@types/webpack-env': 1.18.1
       babel-plugin-add-react-displayname: 0.0.5
@@ -7467,13 +7451,13 @@ packages:
       lodash: 4.17.20
       prop-types: 15.8.1
       react: 16.12.0
-      react-dev-utils: 11.0.4(eslint@7.16.0)(typescript@4.2.4)(webpack@4.46.0)
+      react-dev-utils: 11.0.4(eslint@7.16.0)(typescript@5.1.6)(webpack@4.46.0)
       react-dom: 16.12.0(react@16.12.0)
       react-refresh: 0.8.3
       read-pkg-up: 7.0.1
       regenerator-runtime: 0.13.11
       ts-dedent: 2.2.0
-      typescript: 4.2.4
+      typescript: 5.1.6
       webpack: 4.46.0(webpack-cli@3.3.10)
     transitivePeerDependencies:
       - '@storybook/builder-webpack5'
@@ -8307,7 +8291,7 @@ packages:
     dev: true
     optional: true
 
-  /@typescript-eslint/eslint-plugin@4.29.1(@typescript-eslint/parser@4.29.1)(eslint@6.8.0)(typescript@4.2.4):
+  /@typescript-eslint/eslint-plugin@4.29.1(@typescript-eslint/parser@4.29.1)(eslint@6.8.0)(typescript@5.1.6):
     resolution: {integrity: sha512-AHqIU+SqZZgBEiWOrtN94ldR3ZUABV5dUG94j8Nms9rQnHFc8fvDOue/58K4CFz6r8OtDDc35Pw9NQPWo0Ayrw==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
@@ -8318,21 +8302,21 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/experimental-utils': 4.29.1(eslint@6.8.0)(typescript@4.2.4)
-      '@typescript-eslint/parser': 4.29.1(eslint@6.8.0)(typescript@4.2.4)
+      '@typescript-eslint/experimental-utils': 4.29.1(eslint@6.8.0)(typescript@5.1.6)
+      '@typescript-eslint/parser': 4.29.1(eslint@6.8.0)(typescript@5.1.6)
       '@typescript-eslint/scope-manager': 4.29.1
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 6.8.0
       functional-red-black-tree: 1.0.1
       regexpp: 3.2.0
       semver: 7.5.3
-      tsutils: 3.21.0(typescript@4.2.4)
-      typescript: 4.2.4
+      tsutils: 3.21.0(typescript@5.1.6)
+      typescript: 5.1.6
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/eslint-plugin@4.29.1(@typescript-eslint/parser@4.29.1)(eslint@7.16.0)(typescript@4.2.4):
+  /@typescript-eslint/eslint-plugin@4.29.1(@typescript-eslint/parser@4.29.1)(eslint@7.16.0)(typescript@5.1.6):
     resolution: {integrity: sha512-AHqIU+SqZZgBEiWOrtN94ldR3ZUABV5dUG94j8Nms9rQnHFc8fvDOue/58K4CFz6r8OtDDc35Pw9NQPWo0Ayrw==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
@@ -8343,21 +8327,21 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/experimental-utils': 4.29.1(eslint@7.16.0)(typescript@4.2.4)
-      '@typescript-eslint/parser': 4.29.1(eslint@7.16.0)(typescript@4.2.4)
+      '@typescript-eslint/experimental-utils': 4.29.1(eslint@7.16.0)(typescript@5.1.6)
+      '@typescript-eslint/parser': 4.29.1(eslint@7.16.0)(typescript@5.1.6)
       '@typescript-eslint/scope-manager': 4.29.1
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 7.16.0
       functional-red-black-tree: 1.0.1
       regexpp: 3.2.0
       semver: 7.5.3
-      tsutils: 3.21.0(typescript@4.2.4)
-      typescript: 4.2.4
+      tsutils: 3.21.0(typescript@5.1.6)
+      typescript: 5.1.6
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/eslint-plugin@4.29.1(@typescript-eslint/parser@4.29.1)(eslint@7.29.0)(typescript@4.7.2):
+  /@typescript-eslint/eslint-plugin@4.29.1(@typescript-eslint/parser@4.29.1)(eslint@7.29.0)(typescript@5.1.6):
     resolution: {integrity: sha512-AHqIU+SqZZgBEiWOrtN94ldR3ZUABV5dUG94j8Nms9rQnHFc8fvDOue/58K4CFz6r8OtDDc35Pw9NQPWo0Ayrw==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
@@ -8368,20 +8352,20 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/experimental-utils': 4.29.1(eslint@7.29.0)(typescript@4.7.2)
-      '@typescript-eslint/parser': 4.29.1(eslint@7.29.0)(typescript@4.7.2)
+      '@typescript-eslint/experimental-utils': 4.29.1(eslint@7.29.0)(typescript@5.1.6)
+      '@typescript-eslint/parser': 4.29.1(eslint@7.29.0)(typescript@5.1.6)
       '@typescript-eslint/scope-manager': 4.29.1
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 7.29.0
       functional-red-black-tree: 1.0.1
       regexpp: 3.2.0
       semver: 7.5.3
-      tsutils: 3.21.0(typescript@4.7.2)
-      typescript: 4.7.2
+      tsutils: 3.21.0(typescript@5.1.6)
+      typescript: 5.1.6
     transitivePeerDependencies:
       - supports-color
 
-  /@typescript-eslint/experimental-utils@4.29.1(eslint@6.8.0)(typescript@4.2.4):
+  /@typescript-eslint/experimental-utils@4.29.1(eslint@6.8.0)(typescript@5.1.6):
     resolution: {integrity: sha512-kl6QG6qpzZthfd2bzPNSJB2YcZpNOrP6r9jueXupcZHnL74WiuSjaft7WSu17J9+ae9zTlk0KJMXPUj0daBxMw==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
@@ -8390,7 +8374,7 @@ packages:
       '@types/json-schema': 7.0.12
       '@typescript-eslint/scope-manager': 4.29.1
       '@typescript-eslint/types': 4.29.1
-      '@typescript-eslint/typescript-estree': 4.29.1(typescript@4.2.4)
+      '@typescript-eslint/typescript-estree': 4.29.1(typescript@5.1.6)
       eslint: 6.8.0
       eslint-scope: 5.1.1
       eslint-utils: 3.0.0(eslint@6.8.0)
@@ -8399,7 +8383,7 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/experimental-utils@4.29.1(eslint@7.16.0)(typescript@4.2.4):
+  /@typescript-eslint/experimental-utils@4.29.1(eslint@7.16.0)(typescript@5.1.6):
     resolution: {integrity: sha512-kl6QG6qpzZthfd2bzPNSJB2YcZpNOrP6r9jueXupcZHnL74WiuSjaft7WSu17J9+ae9zTlk0KJMXPUj0daBxMw==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
@@ -8408,7 +8392,7 @@ packages:
       '@types/json-schema': 7.0.12
       '@typescript-eslint/scope-manager': 4.29.1
       '@typescript-eslint/types': 4.29.1
-      '@typescript-eslint/typescript-estree': 4.29.1(typescript@4.2.4)
+      '@typescript-eslint/typescript-estree': 4.29.1(typescript@5.1.6)
       eslint: 7.16.0
       eslint-scope: 5.1.1
       eslint-utils: 3.0.0(eslint@7.16.0)
@@ -8417,7 +8401,7 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/experimental-utils@4.29.1(eslint@7.29.0)(typescript@4.7.2):
+  /@typescript-eslint/experimental-utils@4.29.1(eslint@7.29.0)(typescript@5.1.6):
     resolution: {integrity: sha512-kl6QG6qpzZthfd2bzPNSJB2YcZpNOrP6r9jueXupcZHnL74WiuSjaft7WSu17J9+ae9zTlk0KJMXPUj0daBxMw==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
@@ -8426,7 +8410,7 @@ packages:
       '@types/json-schema': 7.0.12
       '@typescript-eslint/scope-manager': 4.29.1
       '@typescript-eslint/types': 4.29.1
-      '@typescript-eslint/typescript-estree': 4.29.1(typescript@4.7.2)
+      '@typescript-eslint/typescript-estree': 4.29.1(typescript@5.1.6)
       eslint: 7.29.0
       eslint-scope: 5.1.1
       eslint-utils: 3.0.0(eslint@7.29.0)
@@ -8434,7 +8418,7 @@ packages:
       - supports-color
       - typescript
 
-  /@typescript-eslint/parser@4.29.1(eslint@6.8.0)(typescript@4.2.4):
+  /@typescript-eslint/parser@4.29.1(eslint@6.8.0)(typescript@5.1.6):
     resolution: {integrity: sha512-3fL5iN20hzX3Q4OkG7QEPFjZV2qsVGiDhEwwh+EkmE/w7oteiOvUNzmpu5eSwGJX/anCryONltJ3WDmAzAoCMg==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
@@ -8446,15 +8430,15 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 4.29.1
       '@typescript-eslint/types': 4.29.1
-      '@typescript-eslint/typescript-estree': 4.29.1(typescript@4.2.4)
+      '@typescript-eslint/typescript-estree': 4.29.1(typescript@5.1.6)
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 6.8.0
-      typescript: 4.2.4
+      typescript: 5.1.6
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser@4.29.1(eslint@7.16.0)(typescript@4.2.4):
+  /@typescript-eslint/parser@4.29.1(eslint@7.16.0)(typescript@5.1.6):
     resolution: {integrity: sha512-3fL5iN20hzX3Q4OkG7QEPFjZV2qsVGiDhEwwh+EkmE/w7oteiOvUNzmpu5eSwGJX/anCryONltJ3WDmAzAoCMg==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
@@ -8466,15 +8450,15 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 4.29.1
       '@typescript-eslint/types': 4.29.1
-      '@typescript-eslint/typescript-estree': 4.29.1(typescript@4.2.4)
+      '@typescript-eslint/typescript-estree': 4.29.1(typescript@5.1.6)
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 7.16.0
-      typescript: 4.2.4
+      typescript: 5.1.6
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser@4.29.1(eslint@7.29.0)(typescript@4.7.2):
+  /@typescript-eslint/parser@4.29.1(eslint@7.29.0)(typescript@5.1.6):
     resolution: {integrity: sha512-3fL5iN20hzX3Q4OkG7QEPFjZV2qsVGiDhEwwh+EkmE/w7oteiOvUNzmpu5eSwGJX/anCryONltJ3WDmAzAoCMg==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
@@ -8486,14 +8470,14 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 4.29.1
       '@typescript-eslint/types': 4.29.1
-      '@typescript-eslint/typescript-estree': 4.29.1(typescript@4.7.2)
+      '@typescript-eslint/typescript-estree': 4.29.1(typescript@5.1.6)
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 7.29.0
-      typescript: 4.7.2
+      typescript: 5.1.6
     transitivePeerDependencies:
       - supports-color
 
-  /@typescript-eslint/parser@5.0.0(eslint@8.16.0)(typescript@4.7.2):
+  /@typescript-eslint/parser@5.0.0(eslint@8.16.0)(typescript@5.1.6):
     resolution: {integrity: sha512-B6D5rmmQ14I1fdzs71eL3DAuvnPHTY/t7rQABrL9BLnx/H51Un8ox1xqYAchs0/V2trcoyxB1lMJLlrwrJCDgw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -8505,10 +8489,10 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 5.0.0
       '@typescript-eslint/types': 5.0.0
-      '@typescript-eslint/typescript-estree': 5.0.0(typescript@4.7.2)
+      '@typescript-eslint/typescript-estree': 5.0.0(typescript@5.1.6)
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.16.0
-      typescript: 4.7.2
+      typescript: 5.1.6
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -8548,7 +8532,7 @@ packages:
     resolution: {integrity: sha512-8794JZFE1RN4XaExLWLI2oSXsVImNkl79PzTOOWt9h0UHROwJedNOD2IJyfL0NbddFllcktGIO2aOu10avQQyA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
-  /@typescript-eslint/typescript-estree@4.29.1(typescript@4.2.4):
+  /@typescript-eslint/typescript-estree@4.29.1(typescript@5.1.6):
     resolution: {integrity: sha512-lIkkrR9E4lwZkzPiRDNq0xdC3f2iVCUjw/7WPJ4S2Sl6C3nRWkeE1YXCQ0+KsiaQRbpY16jNaokdWnm9aUIsfw==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
@@ -8563,33 +8547,12 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.3
-      tsutils: 3.21.0(typescript@4.2.4)
-      typescript: 4.2.4
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@typescript-eslint/typescript-estree@4.29.1(typescript@4.7.2):
-    resolution: {integrity: sha512-lIkkrR9E4lwZkzPiRDNq0xdC3f2iVCUjw/7WPJ4S2Sl6C3nRWkeE1YXCQ0+KsiaQRbpY16jNaokdWnm9aUIsfw==}
-    engines: {node: ^10.12.0 || >=12.0.0}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/types': 4.29.1
-      '@typescript-eslint/visitor-keys': 4.29.1
-      debug: 4.3.4(supports-color@8.1.1)
-      globby: 11.1.0
-      is-glob: 4.0.3
-      semver: 7.5.3
-      tsutils: 3.21.0(typescript@4.7.2)
-      typescript: 4.7.2
+      tsutils: 3.21.0(typescript@5.1.6)
+      typescript: 5.1.6
     transitivePeerDependencies:
       - supports-color
 
-  /@typescript-eslint/typescript-estree@5.0.0(typescript@4.7.2):
+  /@typescript-eslint/typescript-estree@5.0.0(typescript@5.1.6):
     resolution: {integrity: sha512-V/6w+PPQMhinWKSn+fCiX5jwvd1vRBm7AX7SJQXEGQtwtBvjMPjaU3YTQ1ik2UF1u96X7tsB96HMnulG3eLi9Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -8604,13 +8567,13 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.3
-      tsutils: 3.21.0(typescript@4.7.2)
-      typescript: 4.7.2
+      tsutils: 3.21.0(typescript@5.1.6)
+      typescript: 5.1.6
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@typescript-eslint/typescript-estree@5.26.0(typescript@4.2.4):
+  /@typescript-eslint/typescript-estree@5.26.0(typescript@5.1.6):
     resolution: {integrity: sha512-EyGpw6eQDsfD6jIqmXP3rU5oHScZ51tL/cZgFbFBvWuCwrIptl+oueUZzSmLtxFuSOQ9vDcJIs+279gnJkfd1w==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -8625,33 +8588,12 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.3
-      tsutils: 3.21.0(typescript@4.2.4)
-      typescript: 4.2.4
+      tsutils: 3.21.0(typescript@5.1.6)
+      typescript: 5.1.6
     transitivePeerDependencies:
       - supports-color
 
-  /@typescript-eslint/typescript-estree@5.26.0(typescript@4.7.2):
-    resolution: {integrity: sha512-EyGpw6eQDsfD6jIqmXP3rU5oHScZ51tL/cZgFbFBvWuCwrIptl+oueUZzSmLtxFuSOQ9vDcJIs+279gnJkfd1w==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/types': 5.26.0
-      '@typescript-eslint/visitor-keys': 5.26.0
-      debug: 4.3.4(supports-color@8.1.1)
-      globby: 11.1.0
-      is-glob: 4.0.3
-      semver: 7.5.3
-      tsutils: 3.21.0(typescript@4.7.2)
-      typescript: 4.7.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /@typescript-eslint/utils@5.26.0(eslint@6.8.0)(typescript@4.2.4):
+  /@typescript-eslint/utils@5.26.0(eslint@6.8.0)(typescript@5.1.6):
     resolution: {integrity: sha512-PJFwcTq2Pt4AMOKfe3zQOdez6InIDOjUJJD3v3LyEtxHGVVRK3Vo7Dd923t/4M9hSH2q2CLvcTdxlLPjcIk3eg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -8660,7 +8602,7 @@ packages:
       '@types/json-schema': 7.0.12
       '@typescript-eslint/scope-manager': 5.26.0
       '@typescript-eslint/types': 5.26.0
-      '@typescript-eslint/typescript-estree': 5.26.0(typescript@4.2.4)
+      '@typescript-eslint/typescript-estree': 5.26.0(typescript@5.1.6)
       eslint: 6.8.0
       eslint-scope: 5.1.1
       eslint-utils: 3.0.0(eslint@6.8.0)
@@ -8669,7 +8611,7 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/utils@5.26.0(eslint@7.16.0)(typescript@4.2.4):
+  /@typescript-eslint/utils@5.26.0(eslint@7.16.0)(typescript@5.1.6):
     resolution: {integrity: sha512-PJFwcTq2Pt4AMOKfe3zQOdez6InIDOjUJJD3v3LyEtxHGVVRK3Vo7Dd923t/4M9hSH2q2CLvcTdxlLPjcIk3eg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -8678,7 +8620,7 @@ packages:
       '@types/json-schema': 7.0.12
       '@typescript-eslint/scope-manager': 5.26.0
       '@typescript-eslint/types': 5.26.0
-      '@typescript-eslint/typescript-estree': 5.26.0(typescript@4.2.4)
+      '@typescript-eslint/typescript-estree': 5.26.0(typescript@5.1.6)
       eslint: 7.16.0
       eslint-scope: 5.1.1
       eslint-utils: 3.0.0(eslint@7.16.0)
@@ -8687,7 +8629,7 @@ packages:
       - typescript
     dev: false
 
-  /@typescript-eslint/utils@5.26.0(eslint@8.16.0)(typescript@4.7.2):
+  /@typescript-eslint/utils@5.26.0(eslint@8.16.0)(typescript@5.1.6):
     resolution: {integrity: sha512-PJFwcTq2Pt4AMOKfe3zQOdez6InIDOjUJJD3v3LyEtxHGVVRK3Vo7Dd923t/4M9hSH2q2CLvcTdxlLPjcIk3eg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -8696,7 +8638,7 @@ packages:
       '@types/json-schema': 7.0.12
       '@typescript-eslint/scope-manager': 5.26.0
       '@typescript-eslint/types': 5.26.0
-      '@typescript-eslint/typescript-estree': 5.26.0(typescript@4.7.2)
+      '@typescript-eslint/typescript-estree': 5.26.0(typescript@5.1.6)
       eslint: 8.16.0
       eslint-scope: 5.1.1
       eslint-utils: 3.0.0(eslint@8.16.0)
@@ -14065,7 +14007,7 @@ packages:
     resolution: {integrity: sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==}
     dev: true
 
-  /fork-ts-checker-webpack-plugin@1.0.0(eslint@7.16.0)(typescript@4.2.4)(webpack@4.41.5):
+  /fork-ts-checker-webpack-plugin@1.0.0(eslint@7.16.0)(typescript@5.1.6)(webpack@4.41.5):
     resolution: {integrity: sha512-Kc7LI0OlnWB0FRbDQO+nnDCfZr+LhFSJIP8kZppDXvuXI/opeMg3IrlMedBX/EGgOUK0ma5Hafgkdp3DuxgYdg==}
     engines: {node: '>=6.11.5'}
     peerDependencies:
@@ -14087,13 +14029,13 @@ packages:
       minimatch: 3.1.2
       semver: 5.7.1
       tapable: 1.1.3
-      typescript: 4.2.4
+      typescript: 5.1.6
       webpack: 4.41.5(webpack-cli@3.3.10)
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /fork-ts-checker-webpack-plugin@4.1.6(eslint@6.8.0)(typescript@4.2.4)(webpack@4.46.0):
+  /fork-ts-checker-webpack-plugin@4.1.6(eslint@6.8.0)(typescript@5.1.6)(webpack@4.46.0):
     resolution: {integrity: sha512-DUxuQaKoqfNne8iikd14SAkh5uw4+8vNifp6gmA73yYNS6ywLIWSLD/n/mBzHQRpW3J7rbATEakmiA8JvkTyZw==}
     engines: {node: '>=6.11.5', yarn: '>=1.0.0'}
     peerDependencies:
@@ -14114,14 +14056,14 @@ packages:
       minimatch: 3.1.2
       semver: 5.7.1
       tapable: 1.1.3
-      typescript: 4.2.4
+      typescript: 5.1.6
       webpack: 4.46.0(webpack-cli@3.3.10)
       worker-rpc: 0.1.1
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /fork-ts-checker-webpack-plugin@4.1.6(eslint@7.16.0)(typescript@4.2.4)(webpack@4.46.0):
+  /fork-ts-checker-webpack-plugin@4.1.6(eslint@7.16.0)(typescript@5.1.6)(webpack@4.46.0):
     resolution: {integrity: sha512-DUxuQaKoqfNne8iikd14SAkh5uw4+8vNifp6gmA73yYNS6ywLIWSLD/n/mBzHQRpW3J7rbATEakmiA8JvkTyZw==}
     engines: {node: '>=6.11.5', yarn: '>=1.0.0'}
     peerDependencies:
@@ -14142,14 +14084,14 @@ packages:
       minimatch: 3.1.2
       semver: 5.7.1
       tapable: 1.1.3
-      typescript: 4.2.4
+      typescript: 5.1.6
       webpack: 4.46.0(webpack-cli@3.3.10)
       worker-rpc: 0.1.1
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /fork-ts-checker-webpack-plugin@6.5.3(eslint@6.8.0)(typescript@4.2.4)(webpack@4.46.0):
+  /fork-ts-checker-webpack-plugin@6.5.3(eslint@6.8.0)(typescript@5.1.6)(webpack@4.46.0):
     resolution: {integrity: sha512-SbH/l9ikmMWycd5puHJKTkZJKddF4iRLyW3DeZ08HTI7NGyLS38MXd/KGgeWumQO7YNQbW2u/NtPT2YowbPaGQ==}
     engines: {node: '>=10', yarn: '>=1.0.0'}
     peerDependencies:
@@ -14177,11 +14119,11 @@ packages:
       schema-utils: 2.7.0
       semver: 7.5.3
       tapable: 1.1.3
-      typescript: 4.2.4
+      typescript: 5.1.6
       webpack: 4.46.0(webpack-cli@3.3.10)
     dev: true
 
-  /fork-ts-checker-webpack-plugin@6.5.3(eslint@7.16.0)(typescript@4.2.4)(webpack@4.46.0):
+  /fork-ts-checker-webpack-plugin@6.5.3(eslint@7.16.0)(typescript@5.1.6)(webpack@4.46.0):
     resolution: {integrity: sha512-SbH/l9ikmMWycd5puHJKTkZJKddF4iRLyW3DeZ08HTI7NGyLS38MXd/KGgeWumQO7YNQbW2u/NtPT2YowbPaGQ==}
     engines: {node: '>=10', yarn: '>=1.0.0'}
     peerDependencies:
@@ -14209,7 +14151,7 @@ packages:
       schema-utils: 2.7.0
       semver: 7.5.3
       tapable: 1.1.3
-      typescript: 4.2.4
+      typescript: 5.1.6
       webpack: 4.46.0(webpack-cli@3.3.10)
     dev: true
 
@@ -19096,11 +19038,11 @@ packages:
       find-up: 3.0.0
     dev: true
 
-  /pnp-webpack-plugin@1.6.4(typescript@4.2.4):
+  /pnp-webpack-plugin@1.6.4(typescript@5.1.6):
     resolution: {integrity: sha512-7Wjy+9E3WwLOEL30D+m8TSTF7qJJUJLONBnwQp0518siuMxUQUbgZwssaFX+QKlZkjHZcw/IpZCt/H0srrntSg==}
     engines: {node: '>=6'}
     dependencies:
-      ts-pnp: 1.2.0(typescript@4.2.4)
+      ts-pnp: 1.2.0(typescript@5.1.6)
     transitivePeerDependencies:
       - typescript
     dev: true
@@ -19481,6 +19423,7 @@ packages:
 
   /prr@1.0.1:
     resolution: {integrity: sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==}
+    requiresBuild: true
 
   /pseudomap@1.0.2:
     resolution: {integrity: sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==}
@@ -20287,7 +20230,7 @@ packages:
       - encoding
     dev: false
 
-  /react-dev-utils@11.0.4(eslint@6.8.0)(typescript@4.2.4)(webpack@4.46.0):
+  /react-dev-utils@11.0.4(eslint@6.8.0)(typescript@5.1.6)(webpack@4.46.0):
     resolution: {integrity: sha512-dx0LvIGHcOPtKbeiSUM4jqpBl3TcY7CDjZdfOIcKeznE7BWr9dg0iPG90G5yfVQ+p/rGNMXdbfStvzQZEVEi4A==}
     engines: {node: '>=10'}
     peerDependencies:
@@ -20306,7 +20249,7 @@ packages:
       escape-string-regexp: 2.0.0
       filesize: 6.1.0
       find-up: 4.1.0
-      fork-ts-checker-webpack-plugin: 4.1.6(eslint@6.8.0)(typescript@4.2.4)(webpack@4.46.0)
+      fork-ts-checker-webpack-plugin: 4.1.6(eslint@6.8.0)(typescript@5.1.6)(webpack@4.46.0)
       global-modules: 2.0.0
       globby: 11.0.1
       gzip-size: 5.1.1
@@ -20321,7 +20264,7 @@ packages:
       shell-quote: 1.7.2
       strip-ansi: 6.0.0
       text-table: 0.2.0
-      typescript: 4.2.4
+      typescript: 5.1.6
       webpack: 4.46.0(webpack-cli@3.3.10)
     transitivePeerDependencies:
       - eslint
@@ -20329,7 +20272,7 @@ packages:
       - vue-template-compiler
     dev: true
 
-  /react-dev-utils@11.0.4(eslint@7.16.0)(typescript@4.2.4)(webpack@4.46.0):
+  /react-dev-utils@11.0.4(eslint@7.16.0)(typescript@5.1.6)(webpack@4.46.0):
     resolution: {integrity: sha512-dx0LvIGHcOPtKbeiSUM4jqpBl3TcY7CDjZdfOIcKeznE7BWr9dg0iPG90G5yfVQ+p/rGNMXdbfStvzQZEVEi4A==}
     engines: {node: '>=10'}
     peerDependencies:
@@ -20348,7 +20291,7 @@ packages:
       escape-string-regexp: 2.0.0
       filesize: 6.1.0
       find-up: 4.1.0
-      fork-ts-checker-webpack-plugin: 4.1.6(eslint@7.16.0)(typescript@4.2.4)(webpack@4.46.0)
+      fork-ts-checker-webpack-plugin: 4.1.6(eslint@7.16.0)(typescript@5.1.6)(webpack@4.46.0)
       global-modules: 2.0.0
       globby: 11.0.1
       gzip-size: 5.1.1
@@ -20363,7 +20306,7 @@ packages:
       shell-quote: 1.7.2
       strip-ansi: 6.0.0
       text-table: 0.2.0
-      typescript: 4.2.4
+      typescript: 5.1.6
       webpack: 4.46.0(webpack-cli@3.3.10)
     transitivePeerDependencies:
       - eslint
@@ -20371,12 +20314,12 @@ packages:
       - vue-template-compiler
     dev: true
 
-  /react-docgen-typescript@2.2.2(typescript@4.2.4):
+  /react-docgen-typescript@2.2.2(typescript@5.1.6):
     resolution: {integrity: sha512-tvg2ZtOpOi6QDwsb3GZhOjDkkX0h8Z2gipvTg6OVMUyoYoURhEiRNePT8NZItTVCDh39JJHnLdfCOkzoLbFnTg==}
     peerDependencies:
       typescript: '>= 4.3.x'
     dependencies:
-      typescript: 4.2.4
+      typescript: 5.1.6
     dev: true
 
   /react-docgen@5.4.3:
@@ -22797,7 +22740,7 @@ packages:
     engines: {node: '>=6.10'}
     dev: true
 
-  /ts-jest@27.1.3(@babel/core@7.8.3)(@types/jest@27.4.1)(babel-jest@27.5.1)(esbuild@0.14.43)(jest@27.5.1)(typescript@4.2.4):
+  /ts-jest@27.1.3(@babel/core@7.8.3)(@types/jest@27.4.1)(babel-jest@27.5.1)(esbuild@0.14.43)(jest@27.5.1)(typescript@5.1.6):
     resolution: {integrity: sha512-6Nlura7s6uM9BVUAoqLH7JHyMXjz8gluryjpPXxr3IxZdAXnU6FhjvVLHFtfd1vsE1p8zD1OJfskkc0jhTSnkA==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     hasBin: true
@@ -22830,11 +22773,11 @@ packages:
       lodash.memoize: 4.1.2
       make-error: 1.3.6
       semver: 7.5.3
-      typescript: 4.2.4
+      typescript: 5.1.6
       yargs-parser: 20.2.9
     dev: true
 
-  /ts-jest@27.1.3(@babel/core@7.8.3)(@types/jest@27.5.2)(babel-jest@27.5.1)(jest@27.5.1)(typescript@4.2.4):
+  /ts-jest@27.1.3(@babel/core@7.8.3)(@types/jest@27.5.2)(babel-jest@27.5.1)(jest@27.5.1)(typescript@5.1.6):
     resolution: {integrity: sha512-6Nlura7s6uM9BVUAoqLH7JHyMXjz8gluryjpPXxr3IxZdAXnU6FhjvVLHFtfd1vsE1p8zD1OJfskkc0jhTSnkA==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     hasBin: true
@@ -22866,11 +22809,11 @@ packages:
       lodash.memoize: 4.1.2
       make-error: 1.3.6
       semver: 7.5.3
-      typescript: 4.2.4
+      typescript: 5.1.6
       yargs-parser: 20.2.9
     dev: true
 
-  /ts-jest@28.0.3(@babel/core@7.22.8)(jest@28.1.0)(typescript@4.7.2):
+  /ts-jest@28.0.3(@babel/core@7.22.8)(jest@28.1.0)(typescript@5.1.6):
     resolution: {integrity: sha512-HzgbEDQ2KgVtDmpXToqAcKTyGHdHsG23i/iUjfxji92G5eT09S1m9UHZd7csF0Bfgh9txM4JzwHnv7r1waFPlw==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     hasBin: true
@@ -22900,11 +22843,11 @@ packages:
       lodash.memoize: 4.1.2
       make-error: 1.3.6
       semver: 7.5.3
-      typescript: 4.7.2
+      typescript: 5.1.6
       yargs-parser: 20.2.9
     dev: true
 
-  /ts-loader@6.2.1(typescript@4.2.4):
+  /ts-loader@6.2.1(typescript@5.1.6):
     resolution: {integrity: sha512-Dd9FekWuABGgjE1g0TlQJ+4dFUfYGbYcs52/HQObE0ZmUNjQlmLAS7xXsSzy23AMaMwipsx5sNHvoEpT2CZq1g==}
     engines: {node: '>=8.6'}
     peerDependencies:
@@ -22915,10 +22858,10 @@ packages:
       loader-utils: 1.4.2
       micromatch: 4.0.5
       semver: 6.3.0
-      typescript: 4.2.4
+      typescript: 5.1.6
     dev: true
 
-  /ts-pnp@1.2.0(typescript@4.2.4):
+  /ts-pnp@1.2.0(typescript@5.1.6):
     resolution: {integrity: sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==}
     engines: {node: '>=6'}
     peerDependencies:
@@ -22927,7 +22870,7 @@ packages:
       typescript:
         optional: true
     dependencies:
-      typescript: 4.2.4
+      typescript: 5.1.6
     dev: true
 
   /tslib@1.14.1:
@@ -22937,23 +22880,14 @@ packages:
     resolution: {integrity: sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==}
     dev: true
 
-  /tsutils@3.21.0(typescript@4.2.4):
+  /tsutils@3.21.0(typescript@5.1.6):
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
     dependencies:
       tslib: 1.14.1
-      typescript: 4.2.4
-
-  /tsutils@3.21.0(typescript@4.7.2):
-    resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
-    engines: {node: '>= 6'}
-    peerDependencies:
-      typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
-    dependencies:
-      tslib: 1.14.1
-      typescript: 4.7.2
+      typescript: 5.1.6
 
   /tty-browserify@0.0.0:
     resolution: {integrity: sha512-JVa5ijo+j/sOoHGjw0sxw734b1LhBkQ3bvUGNdxnVXDCX81Yx7TFgnZygxrIIWn23hbfTaMYLwRmAxFyDuFmIw==}
@@ -23033,14 +22967,9 @@ packages:
     dependencies:
       typescript-compare: 0.0.2
 
-  /typescript@4.2.4:
-    resolution: {integrity: sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==}
-    engines: {node: '>=4.2.0'}
-    hasBin: true
-
-  /typescript@4.7.2:
-    resolution: {integrity: sha512-Mamb1iX2FDUpcTRzltPxgWMKy3fhg0TN378ylbktPGPK/99KbDtMQ4W1hwgsbPAsG3a0xKa1vmw4VKZQbkvz5A==}
-    engines: {node: '>=4.2.0'}
+  /typescript@5.1.6:
+    resolution: {integrity: sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==}
+    engines: {node: '>=14.17'}
     hasBin: true
 
   /ua-parser-js@0.7.24:

--- a/pkg/ui/workspaces/cluster-ui/package.json
+++ b/pkg/ui/workspaces/cluster-ui/package.json
@@ -155,7 +155,7 @@
     "source-map-loader": "^0.2.4",
     "style-loader": "^1.1.3",
     "ts-jest": "^27.1.3",
-    "typescript": "4.2.4",
+    "typescript": "5.1.6",
     "uplot": "^1.6.19",
     "url-loader": "^4.1.0",
     "webpack": "^4.41.5",

--- a/pkg/ui/workspaces/cluster-ui/src/jobs/util/duration.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/jobs/util/duration.tsx
@@ -17,7 +17,7 @@ import { JOB_STATUS_SUCCEEDED, isRunning } from "./jobOptions";
 type Job = cockroach.server.serverpb.IJobResponse;
 
 export const formatDuration = (d: moment.Duration): string =>
-  [Math.floor(d.asHours()).toFixed(0), d.minutes(), d.seconds()]
+  [Number(Math.floor(d.asHours()).toFixed(0)), d.minutes(), d.seconds()]
     .map(c => (c < 10 ? ("0" + c).slice(-2) : c))
     .join(":");
 

--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsPage.tsx
@@ -321,7 +321,7 @@ export class SessionsPage extends React.Component<
           TimestampToMoment(s.session.start),
           "seconds",
         );
-        return sessionTime >= timeValue || timeValue === "empty";
+        return timeValue === "empty" || sessionTime >= Number(timeValue);
       })
       .filter((s: SessionInfo) => {
         if (filters.username && filters.username != "All") {

--- a/pkg/ui/workspaces/cluster-ui/src/sqlActivity/util.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sqlActivity/util.tsx
@@ -100,7 +100,8 @@ export function filterStatementsData(
     .filter(statement => (filters.fullScan ? statement.fullScan : true))
     .filter(
       statement =>
-        statement.stats.service_lat.mean >= timeValue || timeValue === "empty",
+        timeValue === "empty" ||
+        statement.stats.service_lat.mean >= Number(timeValue),
     )
     .filter(
       statement =>

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/utils.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/utils.ts
@@ -199,8 +199,8 @@ export const filterTransactions = (
     })
     .filter(
       (t: Transaction) =>
-        t.stats_data.stats.service_lat.mean >= timeValue ||
-        timeValue === "empty",
+        timeValue === "empty" ||
+        t.stats_data.stats.service_lat.mean >= Number(timeValue),
     )
     .filter((t: Transaction) => {
       // The transaction must contain at least one value of the regions list

--- a/pkg/ui/workspaces/db-console/package.json
+++ b/pkg/ui/workspaces/db-console/package.json
@@ -173,7 +173,7 @@
     "topojson": "^3.0.2",
     "ts-jest": "27.1.3",
     "ts-loader": "^6.2.1",
-    "typescript": "4.2.4",
+    "typescript": "5.1.6",
     "uglify-js": "^2.8.15",
     "uplot": "^1.6.8",
     "url-loader": "4.1.1",

--- a/pkg/ui/workspaces/db-console/src/redux/nodes.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/nodes.ts
@@ -588,11 +588,11 @@ export const partitionedStatuses = createSelector(
   nodesSummarySelector,
   summary => {
     return _.groupBy(summary.nodeStatuses, ns => {
-      switch (summary.livenessByNodeID[ns.desc.node_id]) {
-        case MembershipStatus.ACTIVE:
-        case MembershipStatus.DECOMMISSIONING:
+      switch (summary.livenessStatusByNodeID[ns.desc.node_id]) {
+        case LivenessStatus.NODE_STATUS_LIVE:
+        case LivenessStatus.NODE_STATUS_DECOMMISSIONING:
           return "live";
-        case MembershipStatus.DECOMMISSIONED:
+        case LivenessStatus.NODE_STATUS_DECOMMISSIONED:
           return "decommissioned";
         default:
           // TODO (koorosh): "live" has to be renamed to some partition which

--- a/pkg/ui/workspaces/e2e-tests/package.json
+++ b/pkg/ui/workspaces/e2e-tests/package.json
@@ -24,7 +24,7 @@
     "eslint-plugin-react": "7.24.0",
     "eslint-plugin-react-hooks": "4.2.0",
     "prettier": "2.6.2",
-    "typescript": "^4.6.3"
+    "typescript": "5.1.6"
   },
   "dependencies": {
     "@typescript-eslint/eslint-plugin": "4.29.1"

--- a/pkg/ui/workspaces/eslint-plugin-crdb/package.json
+++ b/pkg/ui/workspaces/eslint-plugin-crdb/package.json
@@ -19,7 +19,7 @@
     "eslint": "^8.16.0",
     "jest": "^28.1.0",
     "ts-jest": "^28.0.3",
-    "typescript": "^4.7.2"
+    "typescript": "5.1.6"
   },
   "peerDependencies": {
     "@typescript-eslint/parser": "^5.0.0",


### PR DESCRIPTION
Upgrade Typescript from v4 to v5, that has a smaller size, is faster and adds new features.

This commit make some updates that were causing errors
on the new Typescript version, such as type mismatch error. [1]

[1] https://devblogs.microsoft.com/typescript/announcing-typescript-5-0/#forbidden-implicit-coercions-in-relational-operators
Epic: none

Release note: None