### PR TITLE
roachtest/awsdms: run once a week instead

### DIFF
--- a/pkg/cmd/roachtest/tests/awsdms.go
+++ b/pkg/cmd/roachtest/tests/awsdms.go
@@ -192,7 +192,7 @@ func registerAWSDMS(r registry.Registry) {
 		Owner:   registry.OwnerMigrations,
 		Cluster: r.MakeClusterSpec(1),
 		Leases:  registry.MetamorphicLeases,
-		Tags:    registry.Tags(`default`, `awsdms`, `aws`),
+		Tags:    registry.Tags(`weekly`, `aws-weekly`),
 		Run:     runAWSDMS,
 	})
 }


### PR DESCRIPTION
Save a bit of mad dosh by running awsdms once a weekly instead of daily. We don't need this tested every week.

Epic: None

Release note: None