### PR TITLE
sql: fix insight integration test for contention

### DIFF
--- a/pkg/sql/sqlstats/insights/integration/insights_test.go
+++ b/pkg/sql/sqlstats/insights/integration/insights_test.go
@@ -523,7 +523,7 @@ func TestInsightsIntegrationForContention(t *testing.T) {
 	require.NoError(t, err)
 
 	// Enable detection by setting a latencyThreshold > 0.
-	latencyThreshold := 100 * time.Millisecond
+	latencyThreshold := 30 * time.Millisecond
 	insights.LatencyThreshold.Override(ctx, &settings.SV, latencyThreshold)
 
 	// Create a new connection, and then in a go routine have it start a transaction, update a row,


### PR DESCRIPTION
This change lowers the latency threshold for which statement is considered slow to make sure it detects contention.
Previous value was set to 100ms which is default. New value is set to 30ms to be the same as overridden
value in other tests.

Release note: None

Resolves: #108020