### PR TITLE
spanconfig: remove ability to disable span configs

### DIFF
--- a/pkg/base/test_server_args.go
+++ b/pkg/base/test_server_args.go
@@ -144,15 +144,6 @@ type TestServerArgs struct {
 	// If set, a TraceDir is initialized at the provided path.
 	TraceDir string
 
-	// DisableSpanConfigs disables the use of the span configs infrastructure
-	// (in favor of the gossiped system config span). It's equivalent to setting
-	// COCKROACH_DISABLE_SPAN_CONFIGS, and is only intended for tests written
-	// with the system config span in mind.
-	//
-	// TODO(irfansharif): Remove all uses of this when we rip out the system
-	// config span.
-	DisableSpanConfigs bool
-
 	// TestServer will probabilistically start a single test tenant on each node
 	// for multi-tenant testing, and default all connections through that tenant.
 	// Use this flag to change this behavior. You might want/need to alter this

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -9641,7 +9641,9 @@ func TestExcludeDataFromBackupDoesNotHoldupGC(t *testing.T) {
 		if !r.ExcludeDataFromBackup() {
 			return false, errors.New("waiting for exclude_data_from_backup to be applied")
 		}
-		conf := r.SpanConfig()
+		conf, err := r.SpanConfig()
+		require.NoError(t, err)
+
 		if conf.TTL() != 1*time.Second {
 			return false, errors.New("waiting for gc.ttlseconds to be applied")
 		}
@@ -9666,7 +9668,12 @@ func TestExcludeDataFromBackupDoesNotHoldupGC(t *testing.T) {
 
 	// Ensure that the replica sees the ProtectionPolicies.
 	waitForReplicaFieldToBeSet(t, tc, conn, "foo", "test", func(r *kvserver.Replica) (bool, error) {
-		if len(r.SpanConfig().GCPolicy.ProtectionPolicies) == 0 {
+		conf, err := r.SpanConfig()
+		if err != nil {
+			return false, err
+		}
+
+		if len(conf.GCPolicy.ProtectionPolicies) == 0 {
 			return false, errors.New("no protection policy applied to replica")
 		}
 		return true, nil

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -6385,7 +6385,6 @@ func TestRestoreErrorPropagates(t *testing.T) {
 	params.ServerArgs.Knobs.JobsTestingKnobs = jobs.NewTestingKnobsWithShortIntervals()
 	params.ServerArgs.Knobs.KeyVisualizer = &keyvisualizer.TestingKnobs{SkipJobBootstrap: true}
 	params.ServerArgs.Knobs.SQLStatsKnobs = &sqlstats.TestingKnobs{SkipZoneConfigBootstrap: true}
-	params.ServerArgs.DisableSpanConfigs = true
 	tc := testcluster.StartTestCluster(t, 3, params)
 	defer tc.Stopper().Stop(ctx)
 	db := tc.ServerConn(0)

--- a/pkg/jobs/job_info_storage_test.go
+++ b/pkg/jobs/job_info_storage_test.go
@@ -239,7 +239,6 @@ func TestAccessorsWithWrongSQLLivenessSession(t *testing.T) {
 				SkipJobBootstrap: true,
 			},
 		},
-		DisableSpanConfigs: true,
 	}
 
 	ctx := context.Background()

--- a/pkg/jobs/registry_test.go
+++ b/pkg/jobs/registry_test.go
@@ -333,7 +333,6 @@ func TestCreateJobWritesToJobInfo(t *testing.T) {
 				SkipJobBootstrap: true,
 			},
 		},
-		DisableSpanConfigs: true,
 	}
 
 	ctx := context.Background()
@@ -520,7 +519,6 @@ func TestBatchJobsCreation(t *testing.T) {
 							SkipJobBootstrap: true,
 						},
 					},
-					DisableSpanConfigs: true,
 				}
 
 				ctx := context.Background()

--- a/pkg/jobs/update_test.go
+++ b/pkg/jobs/update_test.go
@@ -54,7 +54,6 @@ func TestUpdaterUpdatesJobInfo(t *testing.T) {
 				SkipJobBootstrap: true,
 			},
 		},
-		DisableSpanConfigs: true,
 	}
 
 	ctx := context.Background()
@@ -197,7 +196,6 @@ func TestUpdateDoesNotReadPayloadFromJobsTable(t *testing.T) {
 				SkipJobBootstrap: true,
 			},
 		},
-		DisableSpanConfigs: true,
 	}
 
 	ctx := context.Background()

--- a/pkg/kv/kvclient/rangefeed/rangefeed_external_test.go
+++ b/pkg/kv/kvclient/rangefeed/rangefeed_external_test.go
@@ -883,7 +883,11 @@ func TestUnrecoverableErrors(t *testing.T) {
 
 	testutils.SucceedsSoon(t, func() error {
 		repl := tc.GetFirstStoreFromServer(t, 0).LookupReplica(roachpb.RKey(scratchKey))
-		if repl.SpanConfig().GCPolicy.IgnoreStrictEnforcement {
+		conf, err := repl.SpanConfig()
+		if err != nil {
+			return err
+		}
+		if conf.GCPolicy.IgnoreStrictEnforcement {
 			return errors.New("waiting for span config to apply")
 		}
 		require.NoError(t, repl.ReadProtectedTimestampsForTesting(ctx))

--- a/pkg/kv/kvserver/allocator/allocatorimpl/allocator_test.go
+++ b/pkg/kv/kvserver/allocator/allocatorimpl/allocator_test.go
@@ -1967,6 +1967,7 @@ func TestAllocatorTransferLeaseTarget(t *testing.T) {
 			target := a.TransferLeaseTarget(
 				ctx,
 				sp,
+				&roachpb.RangeDescriptor{},
 				emptySpanConfig(),
 				c.existing,
 				&mockRepl{
@@ -2096,6 +2097,7 @@ func TestAllocatorTransferLeaseTargetIOOverloadCheck(t *testing.T) {
 			target := a.TransferLeaseTarget(
 				ctx,
 				sp,
+				&roachpb.RangeDescriptor{},
 				emptySpanConfig(),
 				existing,
 				&mockRepl{
@@ -2211,6 +2213,7 @@ func TestAllocatorTransferLeaseToReplicasNeedingSnapshot(t *testing.T) {
 			target := a.TransferLeaseTarget(
 				ctx,
 				sp,
+				&roachpb.RangeDescriptor{},
 				emptySpanConfig(),
 				c.existing,
 				repl,
@@ -2303,6 +2306,7 @@ func TestAllocatorTransferLeaseTargetConstraints(t *testing.T) {
 			target := a.TransferLeaseTarget(
 				context.Background(),
 				sp,
+				&roachpb.RangeDescriptor{},
 				c.conf,
 				c.existing,
 				&mockRepl{
@@ -2415,6 +2419,7 @@ func TestAllocatorTransferLeaseTargetDraining(t *testing.T) {
 			target := a.TransferLeaseTarget(
 				ctx,
 				storePool,
+				&roachpb.RangeDescriptor{},
 				c.conf,
 				c.existing,
 				&mockRepl{
@@ -2699,6 +2704,7 @@ func TestAllocatorShouldTransferLease(t *testing.T) {
 			result := a.ShouldTransferLease(
 				ctx,
 				sp,
+				&roachpb.RangeDescriptor{},
 				emptySpanConfig(),
 				c.existing,
 				&mockRepl{
@@ -2767,6 +2773,7 @@ func TestAllocatorShouldTransferLeaseDraining(t *testing.T) {
 			result := a.ShouldTransferLease(
 				ctx,
 				storePool,
+				&roachpb.RangeDescriptor{},
 				emptySpanConfig(),
 				c.existing,
 				&mockRepl{
@@ -2814,6 +2821,7 @@ func TestAllocatorShouldTransferSuspected(t *testing.T) {
 		result := a.ShouldTransferLease(
 			ctx,
 			storePool,
+			&roachpb.RangeDescriptor{},
 			emptySpanConfig(),
 			replicas(1, 2, 3),
 			&mockRepl{storeID: 2, replicationFactor: 3},
@@ -2955,6 +2963,7 @@ func TestAllocatorLeasePreferences(t *testing.T) {
 			result := a.ShouldTransferLease(
 				ctx,
 				sp,
+				&roachpb.RangeDescriptor{},
 				conf,
 				c.existing,
 				&mockRepl{
@@ -2970,6 +2979,7 @@ func TestAllocatorLeasePreferences(t *testing.T) {
 			target := a.TransferLeaseTarget(
 				ctx,
 				sp,
+				&roachpb.RangeDescriptor{},
 				conf,
 				c.existing,
 				&mockRepl{
@@ -2989,6 +2999,7 @@ func TestAllocatorLeasePreferences(t *testing.T) {
 			target = a.TransferLeaseTarget(
 				ctx,
 				sp,
+				&roachpb.RangeDescriptor{},
 				conf,
 				c.existing,
 				&mockRepl{
@@ -3082,6 +3093,7 @@ func TestAllocatorLeasePreferencesMultipleStoresPerLocality(t *testing.T) {
 			target := a.TransferLeaseTarget(
 				ctx,
 				sp,
+				&roachpb.RangeDescriptor{},
 				conf,
 				c.existing,
 				&mockRepl{
@@ -3102,6 +3114,7 @@ func TestAllocatorLeasePreferencesMultipleStoresPerLocality(t *testing.T) {
 			target = a.TransferLeaseTarget(
 				ctx,
 				sp,
+				&roachpb.RangeDescriptor{},
 				conf,
 				c.existing,
 				&mockRepl{
@@ -5732,6 +5745,7 @@ func TestAllocatorTransferLeaseTargetLoadBased(t *testing.T) {
 			target := a.TransferLeaseTarget(
 				ctx,
 				storePool,
+				&roachpb.RangeDescriptor{},
 				emptySpanConfig(),
 				existing,
 				&mockRepl{

--- a/pkg/kv/kvserver/allocator/base.go
+++ b/pkg/kv/kvserver/allocator/base.go
@@ -91,10 +91,10 @@ type TestingKnobs struct {
 	// targets produced by the Allocator to include replicas that may be waiting
 	// for snapshots.
 	AllowLeaseTransfersToReplicasNeedingSnapshots bool
-	RaftStatusFn                                  func(r interface {
-		Desc() *roachpb.RangeDescriptor
-		StoreID() roachpb.StoreID
-	}) *raft.Status
+	RaftStatusFn                                  func(
+		desc *roachpb.RangeDescriptor,
+		storeID roachpb.StoreID,
+	) *raft.Status
 	// BlockTransferTarget can be used to block returning any transfer targets
 	// from TransferLeaseTarget.
 	BlockTransferTarget func() bool

--- a/pkg/kv/kvserver/allocator/plan/replicate.go
+++ b/pkg/kv/kvserver/allocator/plan/replicate.go
@@ -60,6 +60,8 @@ type ReplicationPlanner interface {
 		ctx context.Context,
 		now hlc.ClockTimestamp,
 		repl AllocatorReplica,
+		desc *roachpb.RangeDescriptor,
+		conf roachpb.SpanConfig,
 		canTransferLeaseFrom CanTransferLeaseFrom,
 	) (bool, float64)
 	// PlanOneChange calls the allocator to determine an action to be taken upon a
@@ -68,6 +70,8 @@ type ReplicationPlanner interface {
 	PlanOneChange(
 		ctx context.Context,
 		repl AllocatorReplica,
+		desc *roachpb.RangeDescriptor,
+		conf roachpb.SpanConfig,
 		canTransferLeaseFrom CanTransferLeaseFrom,
 		scatter bool,
 	) (ReplicateChange, error)
@@ -78,6 +82,7 @@ type ReplicationPlanner interface {
 type CanTransferLeaseFrom func(
 	ctx context.Context,
 	repl LeaseCheckReplica,
+	conf roachpb.SpanConfig,
 ) bool
 
 // LeaseCheckReplica contains methods that may be used to check a replica's
@@ -85,7 +90,7 @@ type CanTransferLeaseFrom func(
 type LeaseCheckReplica interface {
 	HasCorrectLeaseType(lease roachpb.Lease) bool
 	LeaseStatusAt(ctx context.Context, now hlc.ClockTimestamp) kvserverpb.LeaseStatus
-	LeaseViolatesPreferences(context.Context) bool
+	LeaseViolatesPreferences(context.Context, roachpb.SpanConfig) bool
 	OwnsValidLease(context.Context, hlc.ClockTimestamp) bool
 }
 
@@ -98,8 +103,6 @@ type AllocatorReplica interface {
 	GetFirstIndex() kvpb.RaftIndex
 	LastReplicaAdded() (roachpb.ReplicaID, time.Time)
 	StoreID() roachpb.StoreID
-	DescAndSpanConfig() (*roachpb.RangeDescriptor, roachpb.SpanConfig)
-	Desc() *roachpb.RangeDescriptor
 	GetRangeID() roachpb.RangeID
 }
 
@@ -141,9 +144,10 @@ func (rp ReplicaPlanner) ShouldPlanChange(
 	ctx context.Context,
 	now hlc.ClockTimestamp,
 	repl AllocatorReplica,
+	desc *roachpb.RangeDescriptor,
+	conf roachpb.SpanConfig,
 	canTransferLeaseFrom CanTransferLeaseFrom,
 ) (shouldPlanChange bool, priority float64) {
-	desc, conf := repl.DescAndSpanConfig()
 
 	log.KvDistribution.VEventf(ctx, 6,
 		"computing range action desc=%s config=%s",
@@ -197,10 +201,11 @@ func (rp ReplicaPlanner) ShouldPlanChange(
 	}
 
 	// If the lease is valid, check to see if we should transfer it.
-	if canTransferLeaseFrom(ctx, repl) &&
+	if canTransferLeaseFrom(ctx, repl, conf) &&
 		rp.allocator.ShouldTransferLease(
 			ctx,
 			rp.storePool,
+			desc,
 			conf,
 			voterReplicas,
 			repl,
@@ -235,6 +240,8 @@ func (rp ReplicaPlanner) ShouldPlanChange(
 func (rp ReplicaPlanner) PlanOneChange(
 	ctx context.Context,
 	repl AllocatorReplica,
+	desc *roachpb.RangeDescriptor,
+	conf roachpb.SpanConfig,
 	canTransferLeaseFrom CanTransferLeaseFrom,
 	scatter bool,
 ) (change ReplicateChange, _ error) {
@@ -245,14 +252,6 @@ func (rp ReplicaPlanner) PlanOneChange(
 		Op:      AllocationNoop{},
 		Replica: repl,
 	}
-	// TODO(aayush): The fact that we're calling `repl.DescAndZone()` here once to
-	// pass to `ComputeAction()` to use for deciding which action to take to
-	// repair a range, and then calling it again inside methods like
-	// `addOrReplace{Non}Voters()` or `remove{Dead,Decommissioning}` to execute
-	// upon that decision is a bit unfortunate. It means that we could
-	// successfully execute a decision that was based on the state of a stale
-	// range descriptor.
-	desc, conf := repl.DescAndSpanConfig()
 	log.KvDistribution.VEventf(ctx, 6,
 		"planning range change desc=%s config=%s",
 		desc, conf.String())
@@ -299,12 +298,12 @@ func (rp ReplicaPlanner) PlanOneChange(
 		switch action.TargetReplicaType() {
 		case allocatorimpl.VoterTarget:
 			op, stats, err = rp.addOrReplaceVoters(
-				ctx, repl, existing, remainingLiveVoters, remainingLiveNonVoters,
+				ctx, repl, desc, conf, existing, remainingLiveVoters, remainingLiveNonVoters,
 				removeIdx, action.ReplicaStatus(), allocatorPrio,
 			)
 		case allocatorimpl.NonVoterTarget:
 			op, stats, err = rp.addOrReplaceNonVoters(
-				ctx, repl, existing, remainingLiveVoters, remainingLiveNonVoters,
+				ctx, repl, desc, conf, existing, remainingLiveVoters, remainingLiveNonVoters,
 				removeIdx, action.ReplicaStatus(), allocatorPrio,
 			)
 		default:
@@ -313,9 +312,9 @@ func (rp ReplicaPlanner) PlanOneChange(
 
 	// Remove replicas.
 	case allocatorimpl.AllocatorRemoveVoter:
-		op, stats, err = rp.removeVoter(ctx, repl, voterReplicas, nonVoterReplicas)
+		op, stats, err = rp.removeVoter(ctx, repl, desc, conf, voterReplicas, nonVoterReplicas)
 	case allocatorimpl.AllocatorRemoveNonVoter:
-		op, stats, err = rp.removeNonVoter(ctx, repl, voterReplicas, nonVoterReplicas)
+		op, stats, err = rp.removeNonVoter(ctx, repl, desc, conf, voterReplicas, nonVoterReplicas)
 
 	// Remove decommissioning replicas.
 	//
@@ -323,9 +322,9 @@ func (rp ReplicaPlanner) PlanOneChange(
 	// has decommissioning replicas; in the common case we'll hit
 	// AllocatorReplaceDecommissioning{Non}Voter above.
 	case allocatorimpl.AllocatorRemoveDecommissioningVoter:
-		op, stats, err = rp.removeDecommissioning(ctx, repl, allocatorimpl.VoterTarget)
+		op, stats, err = rp.removeDecommissioning(ctx, repl, desc, conf, allocatorimpl.VoterTarget)
 	case allocatorimpl.AllocatorRemoveDecommissioningNonVoter:
-		op, stats, err = rp.removeDecommissioning(ctx, repl, allocatorimpl.NonVoterTarget)
+		op, stats, err = rp.removeDecommissioning(ctx, repl, desc, conf, allocatorimpl.NonVoterTarget)
 
 	// Remove dead replicas.
 	//
@@ -348,6 +347,8 @@ func (rp ReplicaPlanner) PlanOneChange(
 		op, stats, err = rp.considerRebalance(
 			ctx,
 			repl,
+			desc,
+			conf,
 			voterReplicas,
 			nonVoterReplicas,
 			allocatorPrio,
@@ -385,13 +386,14 @@ func (rp ReplicaPlanner) PlanOneChange(
 func (rp ReplicaPlanner) addOrReplaceVoters(
 	ctx context.Context,
 	repl AllocatorReplica,
+	desc *roachpb.RangeDescriptor,
+	conf roachpb.SpanConfig,
 	existingVoters []roachpb.ReplicaDescriptor,
 	remainingLiveVoters, remainingLiveNonVoters []roachpb.ReplicaDescriptor,
 	removeIdx int,
 	replicaStatus allocatorimpl.ReplicaStatus,
 	allocatorPriority float64,
 ) (op AllocationOp, stats ReplicateStats, _ error) {
-	desc, conf := repl.DescAndSpanConfig()
 	var replacing *roachpb.ReplicaDescriptor
 	if removeIdx >= 0 {
 		replacing = &existingVoters[removeIdx]
@@ -481,13 +483,14 @@ func (rp ReplicaPlanner) addOrReplaceVoters(
 func (rp ReplicaPlanner) addOrReplaceNonVoters(
 	ctx context.Context,
 	repl AllocatorReplica,
+	_ *roachpb.RangeDescriptor,
+	conf roachpb.SpanConfig,
 	existingNonVoters []roachpb.ReplicaDescriptor,
 	liveVoterReplicas, liveNonVoterReplicas []roachpb.ReplicaDescriptor,
 	removeIdx int,
 	replicaStatus allocatorimpl.ReplicaStatus,
 	allocatorPrio float64,
 ) (op AllocationOp, stats ReplicateStats, _ error) {
-	_, conf := repl.DescAndSpanConfig()
 	var replacing *roachpb.ReplicaDescriptor
 	if removeIdx >= 0 {
 		replacing = &existingNonVoters[removeIdx]
@@ -538,13 +541,12 @@ func (rp ReplicaPlanner) addOrReplaceNonVoters(
 func (rp ReplicaPlanner) findRemoveVoter(
 	ctx context.Context,
 	repl interface {
-		DescAndSpanConfig() (*roachpb.RangeDescriptor, roachpb.SpanConfig)
 		LastReplicaAdded() (roachpb.ReplicaID, time.Time)
 		RaftStatus() *raft.Status
 	},
+	conf roachpb.SpanConfig,
 	existingVoters, existingNonVoters []roachpb.ReplicaDescriptor,
 ) (roachpb.ReplicationTarget, string, error) {
-	_, zone := repl.DescAndSpanConfig()
 	// This retry loop involves quick operations on local state, so a
 	// small MaxBackoff is good (but those local variables change on
 	// network time scales as raft receives responses).
@@ -612,7 +614,7 @@ func (rp ReplicaPlanner) findRemoveVoter(
 	return rp.allocator.RemoveVoter(
 		ctx,
 		rp.storePool,
-		zone,
+		conf,
 		candidates,
 		existingVoters,
 		existingNonVoters,
@@ -623,15 +625,17 @@ func (rp ReplicaPlanner) findRemoveVoter(
 func (rp ReplicaPlanner) removeVoter(
 	ctx context.Context,
 	repl AllocatorReplica,
+	desc *roachpb.RangeDescriptor,
+	conf roachpb.SpanConfig,
 	existingVoters, existingNonVoters []roachpb.ReplicaDescriptor,
 ) (op AllocationOp, stats ReplicateStats, _ error) {
-	removeVoter, details, err := rp.findRemoveVoter(ctx, repl, existingVoters, existingNonVoters)
+	removeVoter, details, err := rp.findRemoveVoter(ctx, repl, conf, existingVoters, existingNonVoters)
 	if err != nil {
 		return nil, stats, err
 	}
 
 	transferOp, err := rp.maybeTransferLeaseAwayTarget(
-		ctx, repl, removeVoter.StoreID, nil /* canTransferLeaseFrom */)
+		ctx, repl, desc, conf, removeVoter.StoreID, nil /* canTransferLeaseFrom */)
 	if err != nil {
 		return nil, stats, err
 	}
@@ -664,9 +668,10 @@ func (rp ReplicaPlanner) removeVoter(
 func (rp ReplicaPlanner) removeNonVoter(
 	ctx context.Context,
 	repl AllocatorReplica,
+	_ *roachpb.RangeDescriptor,
+	conf roachpb.SpanConfig,
 	existingVoters, existingNonVoters []roachpb.ReplicaDescriptor,
 ) (op AllocationOp, stats ReplicateStats, _ error) {
-	_, conf := repl.DescAndSpanConfig()
 	removeNonVoter, details, err := rp.allocator.RemoveNonVoter(
 		ctx,
 		rp.storePool,
@@ -701,9 +706,12 @@ func (rp ReplicaPlanner) removeNonVoter(
 }
 
 func (rp ReplicaPlanner) removeDecommissioning(
-	ctx context.Context, repl AllocatorReplica, targetType allocatorimpl.TargetReplicaType,
+	ctx context.Context,
+	repl AllocatorReplica,
+	desc *roachpb.RangeDescriptor,
+	conf roachpb.SpanConfig,
+	targetType allocatorimpl.TargetReplicaType,
 ) (op AllocationOp, stats ReplicateStats, _ error) {
-	desc, _ := repl.DescAndSpanConfig()
 	var decommissioningReplicas []roachpb.ReplicaDescriptor
 	switch targetType {
 	case allocatorimpl.VoterTarget:
@@ -725,7 +733,7 @@ func (rp ReplicaPlanner) removeDecommissioning(
 	decommissioningReplica := decommissioningReplicas[0]
 
 	transferOp, err := rp.maybeTransferLeaseAwayTarget(
-		ctx, repl, decommissioningReplica.StoreID, nil /* canTransferLeaseFrom */)
+		ctx, repl, desc, conf, decommissioningReplica.StoreID, nil /* canTransferLeaseFrom */)
 	if err != nil {
 		return nil, stats, err
 	}
@@ -796,6 +804,8 @@ func (rp ReplicaPlanner) removeDead(
 func (rp ReplicaPlanner) considerRebalance(
 	ctx context.Context,
 	repl AllocatorReplica,
+	desc *roachpb.RangeDescriptor,
+	conf roachpb.SpanConfig,
 	existingVoters, existingNonVoters []roachpb.ReplicaDescriptor,
 	allocatorPrio float64,
 	canTransferLeaseFrom CanTransferLeaseFrom,
@@ -806,7 +816,6 @@ func (rp ReplicaPlanner) considerRebalance(
 		return nil, stats, nil
 	}
 
-	desc, conf := repl.DescAndSpanConfig()
 	rebalanceTargetType := allocatorimpl.VoterTarget
 
 	scorerOpts := allocatorimpl.ScorerOptions(rp.allocator.ScorerOptions(ctx))
@@ -851,7 +860,7 @@ func (rp ReplicaPlanner) considerRebalance(
 		log.KvDistribution.VInfof(ctx, 2, "no suitable rebalance target for non-voters")
 	} else if !lhRemovalAllowed {
 		if transferOp, err := rp.maybeTransferLeaseAwayTarget(
-			ctx, repl, removeTarget.StoreID, canTransferLeaseFrom,
+			ctx, repl, desc, conf, removeTarget.StoreID, canTransferLeaseFrom,
 		); err != nil {
 			// No transfer possible.
 			ok = false
@@ -865,7 +874,7 @@ func (rp ReplicaPlanner) considerRebalance(
 	// No rebalance target was found, check whether we are able and should
 	// transfer the lease away to another store.
 	if !ok {
-		if !canTransferLeaseFrom(ctx, repl) {
+		if !canTransferLeaseFrom(ctx, repl, conf) {
 			return nil, stats, nil
 		}
 		var err error
@@ -945,6 +954,7 @@ func (rp ReplicaPlanner) shedLeaseTarget(
 	target := rp.allocator.TransferLeaseTarget(
 		ctx,
 		rp.storePool,
+		desc,
 		conf,
 		existingVoters,
 		repl,
@@ -964,7 +974,7 @@ func (rp ReplicaPlanner) shedLeaseTarget(
 			existingVoters, false /* includeSuspectAndDrainingStores */)
 		preferred := rp.allocator.PreferredLeaseholders(rp.storePool, conf, liveVoters)
 		if len(preferred) > 0 &&
-			repl.LeaseViolatesPreferences(ctx) {
+			repl.LeaseViolatesPreferences(ctx, conf) {
 			return nil, CantTransferLeaseViolatingPreferencesError{RangeID: desc.RangeID}
 		}
 		return nil, nil
@@ -991,16 +1001,17 @@ func (rp ReplicaPlanner) shedLeaseTarget(
 func (rp ReplicaPlanner) maybeTransferLeaseAwayTarget(
 	ctx context.Context,
 	repl AllocatorReplica,
+	desc *roachpb.RangeDescriptor,
+	conf roachpb.SpanConfig,
 	removeStoreID roachpb.StoreID,
 	canTransferLeaseFrom CanTransferLeaseFrom,
 ) (op AllocationOp, _ error) {
 	if removeStoreID != repl.StoreID() {
 		return nil, nil
 	}
-	if canTransferLeaseFrom != nil && !canTransferLeaseFrom(ctx, repl) {
+	if canTransferLeaseFrom != nil && !canTransferLeaseFrom(ctx, repl, conf) {
 		return nil, errors.Errorf("cannot transfer lease")
 	}
-	desc, conf := repl.DescAndSpanConfig()
 	usageInfo := repl.RangeUsageInfo()
 	// The local replica was selected as the removal target, but that replica
 	// is the leaseholder, so transfer the lease instead. We don't check that
@@ -1015,6 +1026,7 @@ func (rp ReplicaPlanner) maybeTransferLeaseAwayTarget(
 	target := rp.allocator.TransferLeaseTarget(
 		ctx,
 		rp.storePool,
+		desc,
 		conf,
 		desc.Replicas().VoterDescriptors(),
 		repl,

--- a/pkg/kv/kvserver/asim/queue/allocator_replica.go
+++ b/pkg/kv/kvserver/asim/queue/allocator_replica.go
@@ -84,13 +84,14 @@ func (sr *SimulatorReplica) LeaseStatusAt(
 // violates the lease preferences defined in the span config. If there is an
 // error or no preferences defined then it will return false and consider that
 // to be in-conformance.
-func (sr *SimulatorReplica) LeaseViolatesPreferences(context.Context) bool {
+func (sr *SimulatorReplica) LeaseViolatesPreferences(
+	_ context.Context, conf roachpb.SpanConfig,
+) bool {
 	descs := sr.state.StoreDescriptors(true /* useCached */, sr.repl.StoreID())
 	if len(descs) != 1 {
 		panic(fmt.Sprintf("programming error: cannot get  store descriptor for store %d", sr.repl.StoreID()))
 	}
 	storeDesc := descs[0]
-	_, conf := sr.DescAndSpanConfig()
 
 	if len(conf.LeasePreferences) == 0 {
 		return false
@@ -146,10 +147,8 @@ func (sr *SimulatorReplica) GetFirstIndex() kvpb.RaftIndex {
 	return 2
 }
 
-// DescAndSpanConfig returns the authoritative range descriptor as well
-// as the span config for the replica.
-func (sr *SimulatorReplica) DescAndSpanConfig() (*roachpb.RangeDescriptor, roachpb.SpanConfig) {
-	return sr.rng.Descriptor(), sr.rng.SpanConfig()
+func (sr *SimulatorReplica) SpanConfig() (roachpb.SpanConfig, error) {
+	return sr.rng.SpanConfig(), nil
 }
 
 // Desc returns the authoritative range descriptor, acquiring a replica lock in

--- a/pkg/kv/kvserver/asim/storerebalancer/candidate_replica.go
+++ b/pkg/kv/kvserver/asim/storerebalancer/candidate_replica.go
@@ -77,10 +77,10 @@ func (sr *simulatorReplica) GetFirstIndex() kvpb.RaftIndex {
 	return 2
 }
 
-// DescAndSpanConfig returns the authoritative range descriptor as well
+// SpanConfig returns the authoritative range descriptor as well
 // as the span config for the replica.
-func (sr *simulatorReplica) DescAndSpanConfig() (*roachpb.RangeDescriptor, roachpb.SpanConfig) {
-	return sr.rng.Descriptor(), sr.rng.SpanConfig()
+func (sr *simulatorReplica) SpanConfig() (roachpb.SpanConfig, error) {
+	return sr.rng.SpanConfig(), nil
 }
 
 // Desc returns the authoritative range descriptor, acquiring a replica lock in

--- a/pkg/kv/kvserver/client_merge_test.go
+++ b/pkg/kv/kvserver/client_merge_test.go
@@ -4297,19 +4297,22 @@ func TestMergeQueue(t *testing.T) {
 
 	// setThresholds simulates a zone config update that updates the ranges'
 	// minimum and maximum sizes.
-	setSpanConfigs := func(t *testing.T, conf roachpb.SpanConfig) {
-		t.Helper()
-		if l := lhs(); l == nil {
-			t.Fatal("left-hand side range not found")
-		} else {
-			l.SetSpanConfig(conf)
+	// FIXME: These need to be in the store conf
+	/*
+		setSpanConfigs := func(t *testing.T, conf roachpb.SpanConfig) {
+			t.Helper()
+			if l := lhs(); l == nil {
+				t.Fatal("left-hand side range not found")
+			} else {
+				l.SetSpanConfig(conf)
+			}
+			if r := rhs(); r == nil {
+				t.Fatal("right-hand side range not found")
+			} else {
+				r.SetSpanConfig(conf)
+			}
 		}
-		if r := rhs(); r == nil {
-			t.Fatal("right-hand side range not found")
-		} else {
-			r.SetSpanConfig(conf)
-		}
-	}
+	*/
 
 	reset := func(t *testing.T) {
 		t.Helper()
@@ -4319,7 +4322,7 @@ func TestMergeQueue(t *testing.T) {
 				t.Fatal(err)
 			}
 		}
-		setSpanConfigs(t, conf)
+		//setSpanConfigs(t, conf)
 		// Disable load-based splitting, so that the absence of sufficient QPS
 		// measurements do not prevent ranges from merging. Certain subtests
 		// re-enable the functionality.
@@ -4346,7 +4349,7 @@ func TestMergeQueue(t *testing.T) {
 		reset(t)
 		conf := conf
 		conf.RangeMinBytes *= 2
-		lhs().SetSpanConfig(conf)
+		//lhs().SetSpanConfig(conf)
 		verifyMergedSoon(t, store, lhsStartKey, rhsStartKey)
 	})
 
@@ -4358,12 +4361,12 @@ func TestMergeQueue(t *testing.T) {
 		conf := conf
 		conf.RangeMinBytes = rhs().GetMVCCStats().Total() + 1
 		conf.RangeMaxBytes = lhs().GetMVCCStats().Total() + rhs().GetMVCCStats().Total() - 1
-		setSpanConfigs(t, conf)
+		//setSpanConfigs(t, conf)
 		verifyUnmergedSoon(t, store, lhsStartKey, rhsStartKey)
 
 		// Once the maximum size threshold is increased, the merge can occur.
 		conf.RangeMaxBytes += 1
-		setSpanConfigs(t, conf)
+		//setSpanConfigs(t, conf)
 		verifyMergedSoon(t, store, lhsStartKey, rhsStartKey)
 	})
 

--- a/pkg/kv/kvserver/client_rangefeed_test.go
+++ b/pkg/kv/kvserver/client_rangefeed_test.go
@@ -129,7 +129,11 @@ func TestRangefeedWorksOnSystemRangesUnconditionally(t *testing.T) {
 				if repl == nil {
 					return fmt.Errorf("replica not found on n%d", i)
 				}
-				if repl.SpanConfig().RangefeedEnabled {
+				conf, err := repl.SpanConfig()
+				if err != nil {
+					return err
+				}
+				if conf.RangefeedEnabled {
 					return errors.New("waiting for span configs")
 				}
 			}

--- a/pkg/kv/kvserver/client_replica_backpressure_test.go
+++ b/pkg/kv/kvserver/client_replica_backpressure_test.go
@@ -138,7 +138,10 @@ func TestBackpressureNotAppliedWhenReducingRangeSize(t *testing.T) {
 			for i := 0; i < tc.NumServers(); i++ {
 				s := tc.Server(i)
 				_, r := getFirstStoreReplica(t, s, tablePrefix)
-				conf := r.SpanConfig()
+				conf, err := r.SpanConfig()
+				if err != nil {
+					return err
+				}
 				if conf.RangeMaxBytes != exp {
 					return fmt.Errorf("expected %d, got %d", exp, conf.RangeMaxBytes)
 				}
@@ -277,7 +280,10 @@ func TestBackpressureNotAppliedWhenReducingRangeSize(t *testing.T) {
 		// Ensure that the new replica has applied the same config.
 		testutils.SucceedsSoon(t, func() error {
 			_, r := getFirstStoreReplica(t, tc.Server(1), tablePrefix)
-			conf := r.SpanConfig()
+			conf, err := r.SpanConfig()
+			if err != nil {
+				return err
+			}
 			if conf.RangeMaxBytes != newMax {
 				return fmt.Errorf("expected %d, got %d", newMax, conf.RangeMaxBytes)
 			}

--- a/pkg/kv/kvserver/client_replica_test.go
+++ b/pkg/kv/kvserver/client_replica_test.go
@@ -4142,7 +4142,11 @@ func TestStrictGCEnforcement(t *testing.T) {
 				for i := 0; i < tc.NumServers(); i++ {
 					s := tc.Server(i)
 					_, r := getFirstStoreReplica(t, s, tableKey)
-					if c := r.SpanConfig(); c.TTL().Seconds() != (time.Duration(exp) * time.Second).Seconds() {
+					c, err := r.SpanConfig()
+					if err != nil {
+						return err
+					}
+					if c.TTL().Seconds() != (time.Duration(exp) * time.Second).Seconds() {
 						return errors.Errorf("expected %d, got %f", exp, c.TTL().Seconds())
 					}
 				}
@@ -4476,7 +4480,11 @@ func TestProposalOverhead(t *testing.T) {
 			if repl == nil {
 				return errors.New("scratch range replica not found")
 			}
-			if repl.SpanConfig().RangefeedEnabled {
+			conf, err := repl.SpanConfig()
+			if err != nil {
+				return err
+			}
+			if conf.RangefeedEnabled {
 				return errors.New("waiting for span configs to apply")
 			}
 			return nil

--- a/pkg/kv/kvserver/client_spanconfigs_test.go
+++ b/pkg/kv/kvserver/client_spanconfigs_test.go
@@ -94,7 +94,10 @@ func TestSpanConfigUpdateAppliedToReplica(t *testing.T) {
 	mockSubscriber.callback(ctx, span) // invoke the callback
 	testutils.SucceedsSoon(t, func() error {
 		repl := store.LookupReplica(keys.MustAddr(key))
-		gotConfig := repl.SpanConfig()
+		gotConfig, err := repl.SpanConfig()
+		if err != nil {
+			return err
+		}
 		if !gotConfig.Equal(conf) {
 			return errors.Newf("expected config=%s, got config=%s", conf.String(), gotConfig.String())
 		}
@@ -152,7 +155,10 @@ func TestFallbackSpanConfigOverride(t *testing.T) {
 	mockSubscriber.callback(ctx, span) // invoke the callback
 	testutils.SucceedsSoon(t, func() error {
 		repl := store.LookupReplica(keys.MustAddr(key))
-		gotConfig := repl.SpanConfig()
+		gotConfig, err := repl.SpanConfig()
+		if err != nil {
+			return err
+		}
 		if !gotConfig.Equal(conf) {
 			return errors.Newf("expected config=%s, got config=%s", conf.String(), gotConfig.String())
 		}

--- a/pkg/kv/kvserver/client_split_test.go
+++ b/pkg/kv/kvserver/client_split_test.go
@@ -3627,7 +3627,6 @@ func TestStoreRangeSplitAndMergeWithGlobalReads(t *testing.T) {
 
 	ctx := context.Background()
 	s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{
-		DisableSpanConfigs: true,
 		Knobs: base.TestingKnobs{
 			Store: &kvserver.StoreTestingKnobs{
 				DisableMergeQueue:     true,
@@ -3870,7 +3869,6 @@ func TestLBSplitUnsafeKeys(t *testing.T) {
 			}
 
 			s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{
-				DisableSpanConfigs: true,
 				Knobs: base.TestingKnobs{
 					Store: &kvserver.StoreTestingKnobs{
 						LoadBasedSplittingOverrideKey: overrideLBSplitFn,

--- a/pkg/kv/kvserver/consistency_queue.go
+++ b/pkg/kv/kvserver/consistency_queue.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness/livenesspb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
-	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/grpcutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -109,7 +108,7 @@ func newConsistencyQueue(store *Store) *consistencyQueue {
 }
 
 func (q *consistencyQueue) shouldQueue(
-	ctx context.Context, now hlc.ClockTimestamp, repl *Replica, _ spanconfig.StoreReader,
+	ctx context.Context, now hlc.ClockTimestamp, repl *Replica,
 ) (bool, float64) {
 	return consistencyQueueShouldQueueImpl(ctx, now,
 		consistencyShouldQueueData{
@@ -158,9 +157,7 @@ func consistencyQueueShouldQueueImpl(
 }
 
 // process() is called on every range for which this node is a lease holder.
-func (q *consistencyQueue) process(
-	ctx context.Context, repl *Replica, _ spanconfig.StoreReader,
-) (bool, error) {
+func (q *consistencyQueue) process(ctx context.Context, repl *Replica) (bool, error) {
 	if q.interval() <= 0 {
 		return false, nil
 	}

--- a/pkg/kv/kvserver/helpers_test.go
+++ b/pkg/kv/kvserver/helpers_test.go
@@ -17,7 +17,6 @@ package kvserver
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -194,12 +193,8 @@ func (s *Store) EnqueueRaftUpdateCheck(rangeID roachpb.RangeID) {
 }
 
 func manualQueue(s *Store, q queueImpl, repl *Replica) error {
-	cfg := s.cfg.SystemConfigProvider.GetSystemConfig()
-	if cfg == nil {
-		return fmt.Errorf("%s: system config not yet available", s)
-	}
 	ctx := repl.AnnotateCtx(context.Background())
-	_, err := q.process(ctx, repl, cfg)
+	_, err := q.process(ctx, repl)
 	return err
 }
 

--- a/pkg/kv/kvserver/merge_queue_test.go
+++ b/pkg/kv/kvserver/merge_queue_test.go
@@ -156,8 +156,8 @@ func TestMergeQueueShouldQueue(t *testing.T) {
 			repl.mu.state.Stats = &enginepb.MVCCStats{KeyBytes: tc.bytes}
 			zoneConfig := zonepb.DefaultZoneConfigRef()
 			zoneConfig.RangeMinBytes = proto.Int64(tc.minBytes)
-			repl.SetSpanConfig(zoneConfig.AsSpanConfig())
-			shouldQ, priority := mq.shouldQueue(ctx, hlc.ClockTimestamp{}, repl, config.NewSystemConfig(zoneConfig))
+			testCtx.store.cfg.DefaultSpanConfig = zoneConfig.AsSpanConfig()
+			shouldQ, priority := mq.shouldQueue(ctx, hlc.ClockTimestamp{}, repl)
 			if tc.expShouldQ != shouldQ {
 				t.Errorf("incorrect shouldQ: expected %v but got %v", tc.expShouldQ, shouldQ)
 			}

--- a/pkg/kv/kvserver/merge_queue_test.go
+++ b/pkg/kv/kvserver/merge_queue_test.go
@@ -37,7 +37,6 @@ func TestMergeQueueShouldQueue(t *testing.T) {
 	stopper := stop.NewStopper()
 	defer stopper.Stop(ctx)
 	tsc := TestStoreConfig(nil)
-	tsc.SpanConfigsDisabled = true
 	testCtx.StartWithStoreConfig(ctx, t, stopper, tsc)
 
 	mq := newMergeQueue(testCtx.store, testCtx.store.DB())

--- a/pkg/kv/kvserver/mvcc_gc_queue_test.go
+++ b/pkg/kv/kvserver/mvcc_gc_queue_test.go
@@ -908,7 +908,7 @@ func TestMVCCGCQueueProcess(t *testing.T) {
 
 	// Process through a scan queue.
 	mgcq := newMVCCGCQueue(tc.store)
-	processed, err := mgcq.process(ctx, tc.repl, cfg)
+	processed, err := mgcq.process(ctx, tc.repl)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1143,12 +1143,7 @@ func TestMVCCGCQueueTransactionTable(t *testing.T) {
 
 	// Run GC.
 	mgcq := newMVCCGCQueue(tc.store)
-	cfg, err := tc.store.GetConfReader(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	processed, err := mgcq.process(ctx, tc.repl, cfg)
+	processed, err := mgcq.process(ctx, tc.repl)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1277,12 +1272,8 @@ func TestMVCCGCQueueIntentResolution(t *testing.T) {
 	}
 
 	// Process through GC queue.
-	confReader, err := tc.store.GetConfReader(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
 	mgcq := newMVCCGCQueue(tc.store)
-	processed, err := mgcq.process(ctx, tc.repl, confReader)
+	processed, err := mgcq.process(ctx, tc.repl)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1340,14 +1331,9 @@ func TestMVCCGCQueueLastProcessedTimestamps(t *testing.T) {
 		}
 	}
 
-	confReader, err := tc.store.GetConfReader(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	// Process through a scan queue.
 	mgcq := newMVCCGCQueue(tc.store)
-	processed, err := mgcq.process(ctx, tc.repl, confReader)
+	processed, err := mgcq.process(ctx, tc.repl)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1445,17 +1431,13 @@ func TestMVCCGCQueueChunkRequests(t *testing.T) {
 	}
 
 	// Forward the clock past the default GC time.
-	confReader, err := tc.store.GetConfReader(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
-	conf, err := confReader.GetSpanConfigForKey(ctx, roachpb.RKey("key"))
+	conf, err := tc.store.GetSpanConfigForKey(ctx, roachpb.RKey("key"))
 	if err != nil {
 		t.Fatalf("could not find span config for range %s", err)
 	}
 	tc.manualClock.Advance(conf.TTL() + 1)
 	mgcq := newMVCCGCQueue(tc.store)
-	processed, err := mgcq.process(ctx, tc.repl, confReader)
+	processed, err := mgcq.process(ctx, tc.repl)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1503,7 +1485,8 @@ func TestMVCCGCQueueGroupsRangeDeletions(t *testing.T) {
 	require.NoError(t, store.AddReplica(r2))
 	r2.RaftStatus()
 	r2.handleGCHintResult(ctx, &roachpb.GCHint{LatestRangeDeleteTimestamp: hlc.Timestamp{WallTime: 1}})
-	r2.SetSpanConfig(roachpb.SpanConfig{GCPolicy: roachpb.GCPolicy{TTLSeconds: 100}})
+	// FIXME
+	//	r2.SetSpanConfig(roachpb.SpanConfig{GCPolicy: roachpb.GCPolicy{TTLSeconds: 100}})
 
 	gcQueue := newMVCCGCQueue(store)
 

--- a/pkg/kv/kvserver/protectedts/ptcache/cache_test.go
+++ b/pkg/kv/kvserver/protectedts/ptcache/cache_test.go
@@ -154,7 +154,6 @@ func TestRefresh(t *testing.T) {
 		base.TestServerArgs{
 			// Disable span configs to avoid measuring protected timestamp lookups
 			// performed by the AUTO SPAN CONFIG RECONCILIATION job.
-			DisableSpanConfigs: true,
 			Knobs: base.TestingKnobs{
 				Store: &kvserver.StoreTestingKnobs{
 					TestingRequestFilter: st.requestFilter,

--- a/pkg/kv/kvserver/raft_snapshot_queue.go
+++ b/pkg/kv/kvserver/raft_snapshot_queue.go
@@ -17,7 +17,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
@@ -65,7 +64,7 @@ func newRaftSnapshotQueue(store *Store) *raftSnapshotQueue {
 }
 
 func (rq *raftSnapshotQueue) shouldQueue(
-	ctx context.Context, now hlc.ClockTimestamp, repl *Replica, _ spanconfig.StoreReader,
+	ctx context.Context, now hlc.ClockTimestamp, repl *Replica,
 ) (shouldQueue bool, priority float64) {
 	// If a follower needs a snapshot, enqueue at the highest priority.
 	if status := repl.RaftStatus(); status != nil {
@@ -83,7 +82,7 @@ func (rq *raftSnapshotQueue) shouldQueue(
 }
 
 func (rq *raftSnapshotQueue) process(
-	ctx context.Context, repl *Replica, _ spanconfig.StoreReader,
+	ctx context.Context, repl *Replica,
 ) (anyProcessed bool, _ error) {
 	// If a follower requires a Raft snapshot, perform it.
 	if status := repl.RaftStatus(); status != nil {

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -1039,10 +1039,8 @@ func (r *Replica) DescAndSpanConfig() (*roachpb.RangeDescriptor, roachpb.SpanCon
 }
 
 // SpanConfig returns the authoritative span config for the replica.
-func (r *Replica) SpanConfig() roachpb.SpanConfig {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	return r.mu.conf
+func (r *Replica) SpanConfig() (roachpb.SpanConfig, error) {
+	return r.store.GetSpanConfigForKey(context.TODO(), r.startKey)
 }
 
 // Desc returns the authoritative range descriptor, acquiring a replica lock in

--- a/pkg/kv/kvserver/replica_backpressure.go
+++ b/pkg/kv/kvserver/replica_backpressure.go
@@ -136,9 +136,15 @@ func (r *Replica) shouldBackpressureWrites() bool {
 		return false
 	}
 
+	// TODO: Optimize somehow...
+	conf, err := r.SpanConfig()
+	if err != nil {
+		return false
+	}
+
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	exceeded, bytesOver := r.exceedsMultipleOfSplitSizeRLocked(mult)
+	exceeded, bytesOver := r.exceedsMultipleOfSplitSizeRLocked(conf, mult)
 	if !exceeded {
 		return false
 	}

--- a/pkg/kv/kvserver/replica_gc_queue.go
+++ b/pkg/kv/kvserver/replica_gc_queue.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/log/logcrash"
@@ -120,7 +119,7 @@ func newReplicaGCQueue(store *Store, db *kv.DB) *replicaGCQueue {
 // check must have occurred more than ReplicaGCQueueInactivityThreshold
 // in the past.
 func (rgcq *replicaGCQueue) shouldQueue(
-	ctx context.Context, now hlc.ClockTimestamp, repl *Replica, _ spanconfig.StoreReader,
+	ctx context.Context, now hlc.ClockTimestamp, repl *Replica,
 ) (shouldQueue bool, priority float64) {
 	if _, currentMember := repl.Desc().GetReplicaDescriptor(repl.store.StoreID()); !currentMember {
 		return true, replicaGCPriorityRemoved
@@ -220,7 +219,7 @@ func replicaGCShouldQueueImpl(now, lastCheck hlc.Timestamp, isSuspect bool) (boo
 // process performs a consistent lookup on the range descriptor to see if we are
 // still a member of the range.
 func (rgcq *replicaGCQueue) process(
-	ctx context.Context, repl *Replica, _ spanconfig.StoreReader,
+	ctx context.Context, repl *Replica,
 ) (processed bool, err error) {
 	// Note that the Replicas field of desc is probably out of date, so
 	// we should only use `desc` for its static fields like RangeID and

--- a/pkg/kv/kvserver/replica_init.go
+++ b/pkg/kv/kvserver/replica_init.go
@@ -125,7 +125,6 @@ func newUninitializedReplicaWithoutRaftGroup(
 	r.mu.pendingLeaseRequest = makePendingLeaseRequest(r)
 	r.mu.stateLoader = stateloader.Make(rangeID)
 	r.mu.quiescent = true
-	r.mu.conf = store.cfg.DefaultSpanConfig
 
 	r.mu.proposals = map[kvserverbase.CmdIDKey]*ProposalData{}
 	r.mu.checksums = map[uuid.UUID]*replicaChecksum{}
@@ -169,7 +168,6 @@ func newUninitializedReplicaWithoutRaftGroup(
 	)
 
 	r.splitQueueThrottle = util.Every(splitQueueThrottleDuration)
-	r.mergeQueueThrottle = util.Every(mergeQueueThrottleDuration)
 
 	onTrip := func() {
 		telemetry.Inc(telemetryTripAsync)

--- a/pkg/kv/kvserver/replica_proposal.go
+++ b/pkg/kv/kvserver/replica_proposal.go
@@ -524,20 +524,26 @@ func (r *Replica) leasePostApplyLocked(
 	// lease is valid and owned by the replica before processing.
 	if iAmTheLeaseHolder && leaseChangingHands &&
 		LeaseCheckPreferencesOnAcquisitionEnabled.Get(&r.store.cfg.Settings.SV) {
-		preferenceStatus := checkStoreAgainstLeasePreferences(r.store.StoreID(), r.store.Attrs(),
-			r.store.nodeDesc.Attrs, r.store.nodeDesc.Locality, r.mu.conf.LeasePreferences)
-		switch preferenceStatus {
-		case leasePreferencesOK, leasePreferencesLessPreferred:
-			// We could also enqueue the lease when we are a less preferred
-			// leaseholder, however the replicate queue will eventually get to it and
-			// we already satisfy _some_ preference.
-		case leasePreferencesViolating:
-			log.VEventf(ctx, 2,
-				"acquired lease violates lease preferences, enqueuing for transfer [lease=%v preferences=%v]",
-				newLease, r.mu.conf.LeasePreferences)
-			r.store.replicateQueue.AddAsync(ctx, r, replicateQueueLeasePreferencePriority)
-		default:
-			log.Fatalf(ctx, "unknown lease preferences status: %v", preferenceStatus)
+		conf, err := r.SpanConfig()
+		// If there is an error we can't check this now. This can happen during
+		// startup, but normally it would be rare for us to acquire a non-preference
+		// lease until later.
+		if err != nil {
+			preferenceStatus := checkStoreAgainstLeasePreferences(r.store.StoreID(), r.store.Attrs(),
+				r.store.nodeDesc.Attrs, r.store.nodeDesc.Locality, conf.LeasePreferences)
+			switch preferenceStatus {
+			case leasePreferencesOK, leasePreferencesLessPreferred:
+				// We could also enqueue the lease when we are a less preferred
+				// leaseholder, however the replicate queue will eventually get to it and
+				// we already satisfy _some_ preference.
+			case leasePreferencesViolating:
+				log.VEventf(ctx, 2,
+					"acquired lease violates lease preferences, enqueuing for transfer [lease=%v preferences=%v]",
+					newLease, conf.LeasePreferences)
+				r.store.replicateQueue.AddAsync(ctx, r, replicateQueueLeasePreferencePriority)
+			default:
+				log.Fatalf(ctx, "unknown lease preferences status: %v", preferenceStatus)
+			}
 		}
 	}
 

--- a/pkg/kv/kvserver/replica_range_lease.go
+++ b/pkg/kv/kvserver/replica_range_lease.go
@@ -1571,13 +1571,10 @@ const (
 // LeaseViolatesPreferences checks if this replica owns the lease and if it
 // violates the lease preferences defined in the span config. If no preferences
 // are defined then it will return false and consider it to be in conformance.
-func (r *Replica) LeaseViolatesPreferences(ctx context.Context) bool {
+func (r *Replica) LeaseViolatesPreferences(ctx context.Context, conf roachpb.SpanConfig) bool {
 	storeID := r.store.StoreID()
-	now := r.Clock().NowAsClockTimestamp()
-	r.mu.RLock()
-	preferences := r.mu.conf.LeasePreferences
-	leaseStatus := r.leaseStatusAtRLocked(ctx, now)
-	r.mu.RUnlock()
+	preferences := conf.LeasePreferences
+	leaseStatus := r.CurrentLeaseStatus(ctx)
 
 	if !leaseStatus.IsValid() || !leaseStatus.Lease.OwnedBy(storeID) {
 		// We can't determine if the lease preferences are being conformed to or

--- a/pkg/kv/kvserver/replica_rankings.go
+++ b/pkg/kv/kvserver/replica_rankings.go
@@ -45,9 +45,9 @@ type CandidateReplica interface {
 	// GetFirstIndex returns the index of the first entry in the replica's Raft
 	// log.
 	GetFirstIndex() kvpb.RaftIndex
-	// DescAndSpanConfig returns the authoritative range descriptor as well
-	// as the span config for the replica.
-	DescAndSpanConfig() (*roachpb.RangeDescriptor, roachpb.SpanConfig)
+	// SpanConfig returns the span config for the replica or an error if it can't
+	// be determined.
+	SpanConfig() (roachpb.SpanConfig, error)
 	// Desc returns the authoritative range descriptor.
 	Desc() *roachpb.RangeDescriptor
 	// RangeUsageInfo returns usage information (sizes and traffic) needed by

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -13433,7 +13433,9 @@ func TestReplicateQueueProcessOne(t *testing.T) {
 	requeue, err := tc.store.replicateQueue.processOneChange(
 		ctx,
 		tc.repl,
-		func(ctx context.Context, repl plan.LeaseCheckReplica) bool { return false },
+		tc.repl.Desc(),
+		tc.repl.SpanConfig(),
+		func(ctx context.Context, repl plan.LeaseCheckReplica, conf roachpb.SpanConfig) bool { return false },
 		false, /* scatter */
 		true,  /* dryRun */
 	)

--- a/pkg/kv/kvserver/split_queue_test.go
+++ b/pkg/kv/kvserver/split_queue_test.go
@@ -75,11 +75,6 @@ func TestSplitQueueShouldQueue(t *testing.T) {
 		{roachpb.RKey(keys.SystemSQLCodec.TablePrefix(2001)), roachpb.RKeyMax, 32<<20 + 1, 64 << 20, true, 1},
 	}
 
-	cfg, err := tc.store.GetConfReader(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	{
 		// This test plays fast and loose and if there are raft commands ongoing then
 		// we'll hit internal assertions in the tests below. Sending a write through
@@ -108,15 +103,14 @@ func TestSplitQueueShouldQueue(t *testing.T) {
 		repl.mu.Lock()
 		repl.mu.state.Stats = &enginepb.MVCCStats{KeyBytes: test.bytes}
 		repl.mu.Unlock()
-		conf := roachpb.TestingDefaultSpanConfig()
-		conf.RangeMaxBytes = test.maxBytes
-		repl.SetSpanConfig(conf)
+		conf := zonepb.DefaultZoneConfigRef()
+		conf.RangeMaxBytes = proto.Int64(test.maxBytes)
 
 		// Testing using shouldSplitRange instead of shouldQueue to avoid using the splitFinder
 		// This tests the merge queue behavior too as a result. For splitFinder tests,
 		// see split/split_test.go.
 		shouldQ, priority := shouldSplitRange(ctx, repl.Desc(), repl.GetMVCCStats(),
-			repl.GetMaxBytes(), repl.ShouldBackpressureWrites(), cfg)
+			repl.GetMaxBytes(), repl.ShouldBackpressureWrites(), config.NewSystemConfig(conf))
 		if shouldQ != test.shouldQ {
 			t.Errorf("%d: should queue expected %t; got %t", i, test.shouldQ, shouldQ)
 		}

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -1189,14 +1189,8 @@ type StoreConfig struct {
 	KVMemoryMonitor        *mon.BytesMonitor
 	RangefeedBudgetFactory *rangefeed.BudgetFactory
 
-	// SpanConfigsDisabled determines whether we're able to use the span configs
-	// infrastructure or not.
-	//
-	// TODO(irfansharif): We can remove this.
-	SpanConfigsDisabled bool
 	// Used to subscribe to span configuration changes, keeping up-to-date a
-	// data structure useful for retrieving span configs. Only available if
-	// SpanConfigsDisabled is unset.
+	// data structure useful for retrieving span configs.
 	SpanConfigSubscriber spanconfig.KVSubscriber
 
 	// KVAdmissionController is used for admission control.
@@ -2153,30 +2147,14 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 		})
 	}
 
-	if !s.cfg.SpanConfigsDisabled {
-		s.cfg.SpanConfigSubscriber.Subscribe(func(ctx context.Context, update roachpb.Span) {
-			s.onSpanConfigUpdate(ctx, update)
-		})
+	s.cfg.SpanConfigSubscriber.Subscribe(func(ctx context.Context, update roachpb.Span) {
+		s.onSpanConfigUpdate(ctx, update)
+	})
 
-		// When toggling between the system config span and the span
-		// configs infrastructure, we want to re-apply configs on all
-		// replicas from whatever the new source is.
-		spanconfigstore.EnabledSetting.SetOnChange(&s.ClusterSettings().SV, func(ctx context.Context) {
-			enabled := spanconfigstore.EnabledSetting.Get(&s.ClusterSettings().SV)
-			if enabled {
-				s.applyAllFromSpanConfigStore(ctx)
-			} else if scp := s.cfg.SystemConfigProvider; scp != nil {
-				if sc := scp.GetSystemConfig(); sc != nil {
-					s.systemGossipUpdate(sc)
-				}
-			}
-		})
-
-		// We also want to do it when the fallback config setting is changed.
-		spanconfigstore.FallbackConfigOverride.SetOnChange(&s.ClusterSettings().SV, func(ctx context.Context) {
-			s.applyAllFromSpanConfigStore(ctx)
-		})
-	}
+	// We also want to do it when the fallback config setting is changed.
+	spanconfigstore.FallbackConfigOverride.SetOnChange(&s.ClusterSettings().SV, func(ctx context.Context) {
+		s.applyAllFromSpanConfigStore(ctx)
+	})
 
 	// Connect rangefeeds to closed timestamp updates.
 	s.startRangefeedUpdater(ctx)
@@ -2210,10 +2188,7 @@ func (s *Store) GetConfReader(ctx context.Context) (spanconfig.StoreReader, erro
 		return s.cfg.TestingKnobs.ConfReaderInterceptor(), nil
 	}
 
-	if s.cfg.SpanConfigsDisabled ||
-		!spanconfigstore.EnabledSetting.Get(&s.ClusterSettings().SV) ||
-		s.TestingKnobs().UseSystemConfigSpanForQueues {
-
+	if s.TestingKnobs().UseSystemConfigSpanForQueues {
 		sysCfg := s.cfg.SystemConfigProvider.GetSystemConfig()
 		if sysCfg == nil {
 			return nil, errSpanConfigsUnavailable
@@ -2373,10 +2348,6 @@ func (s *Store) removeReplicaWithRangefeed(rangeID roachpb.RangeID) {
 // onSpanConfigUpdate is the callback invoked whenever this store learns of a
 // span config update.
 func (s *Store) onSpanConfigUpdate(ctx context.Context, updated roachpb.Span) {
-	if !spanconfigstore.EnabledSetting.Get(&s.ClusterSettings().SV) {
-		return
-	}
-
 	sp, err := keys.SpanAddr(updated)
 	if err != nil {
 		log.Errorf(ctx, "skipped applying update (%s), unexpected error resolving span address: %v",
@@ -3662,10 +3633,6 @@ func (s *Store) PurgeOutdatedReplicas(ctx context.Context, version roachpb.Versi
 // WaitForSpanConfigSubscription waits until the store is wholly subscribed to
 // the global span configurations state.
 func (s *Store) WaitForSpanConfigSubscription(ctx context.Context) error {
-	if s.cfg.SpanConfigsDisabled {
-		return nil // nothing to do here
-	}
-
 	for r := retry.StartWithCtx(ctx, base.DefaultRetryOptions()); r.Next(); {
 		if !s.cfg.SpanConfigSubscriber.LastUpdated().IsEmpty() {
 			return nil

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -3410,11 +3410,13 @@ func (s *Store) ReplicateQueueDryRun(
 		s.cfg.AmbientCtx.Tracer, "replicate queue dry run",
 	)
 	defer collectAndFinish()
-	canTransferLease := func(ctx context.Context, repl plan.LeaseCheckReplica) bool {
+	canTransferLease := func(ctx context.Context, repl plan.LeaseCheckReplica, conf roachpb.SpanConfig) bool {
 		return true
 	}
+	desc := repl.Desc()
+	conf := repl.SpanConfig()
 	_, err := s.replicateQueue.processOneChange(
-		ctx, repl, canTransferLease, false /* scatter */, true, /* dryRun */
+		ctx, repl, desc, conf, canTransferLease, false /* scatter */, true, /* dryRun */
 	)
 	if err != nil {
 		log.Eventf(ctx, "error simulating allocator on replica %s: %s", repl, err)

--- a/pkg/kv/kvserver/store_gossip.go
+++ b/pkg/kv/kvserver/store_gossip.go
@@ -157,6 +157,8 @@ func (s *Store) startGossip() {
 
 var errSpanConfigsUnavailable = errors.New("span configs not available")
 
+var errSpanConfigsNotConfigured = errors.New("span configs not configured")
+
 // systemGossipUpdate is a callback for gossip updates to
 // the system config which affect range split boundaries.
 //

--- a/pkg/kv/kvserver/store_rebalancer.go
+++ b/pkg/kv/kvserver/store_rebalancer.go
@@ -758,6 +758,7 @@ func (sr *StoreRebalancer) chooseLeaseToTransfer(
 		candidate := sr.allocator.TransferLeaseTarget(
 			ctx,
 			sr.storePool,
+			desc,
 			conf,
 			candidates,
 			candidateReplica,
@@ -960,6 +961,7 @@ func (sr *StoreRebalancer) chooseRangeToRebalance(
 		validTargets := sr.allocator.ValidLeaseTargets(
 			ctx,
 			sr.storePool,
+			rebalanceCtx.rangeDesc,
 			rebalanceCtx.conf,
 			targetVoterRepls,
 			rebalanceCtx.candidateReplica,

--- a/pkg/kv/kvserver/store_rebalancer_test.go
+++ b/pkg/kv/kvserver/store_rebalancer_test.go
@@ -509,7 +509,6 @@ func loadRanges(rr *ReplicaRankings, s *Store, ranges []testRange) {
 		rangeID := roachpb.RangeID(i + 1)
 		repl := &Replica{store: s, RangeID: rangeID}
 		repl.mu.state.Desc = &roachpb.RangeDescriptor{RangeID: rangeID}
-		repl.mu.conf = s.cfg.DefaultSpanConfig
 		for _, storeID := range r.voters {
 			repl.mu.state.Desc.InternalReplicas = append(repl.mu.state.Desc.InternalReplicas, roachpb.ReplicaDescriptor{
 				NodeID:    roachpb.NodeID(storeID),

--- a/pkg/kv/kvserver/store_rebalancer_test.go
+++ b/pkg/kv/kvserver/store_rebalancer_test.go
@@ -610,7 +610,7 @@ func TestChooseLeaseToTransfer(t *testing.T) {
 	// order to pass replicaIsBehind checks, fake out the function for getting
 	// raft status with one that always returns all replicas as up to date.
 	sr.getRaftStatusFn = func(r CandidateReplica) *raft.Status {
-		return TestingRaftStatusFn(r)
+		return TestingRaftStatusFn(r.Desc(), r.StoreID())
 	}
 
 	testCases := []struct {
@@ -907,7 +907,7 @@ func TestChooseRangeToRebalanceRandom(t *testing.T) {
 			// order to pass replicaIsBehind checks, fake out the function for getting
 			// raft status with one that always returns all replicas as up to date.
 			sr.getRaftStatusFn = func(r CandidateReplica) *raft.Status {
-				return TestingRaftStatusFn(r)
+				return TestingRaftStatusFn(r.Desc(), r.StoreID())
 			}
 			sp.OverrideIsStoreReadyForRoutineReplicaTransferFn = func(_ context.Context, this roachpb.StoreID) bool {
 				for _, deadStore := range deadStores {
@@ -1261,7 +1261,7 @@ func TestChooseRangeToRebalanceAcrossHeterogeneousZones(t *testing.T) {
 			// order to pass replicaIsBehind checks, fake out the function for getting
 			// raft status with one that always returns all replicas as up to date.
 			sr.getRaftStatusFn = func(r CandidateReplica) *raft.Status {
-				return TestingRaftStatusFn(r)
+				return TestingRaftStatusFn(r.Desc(), r.StoreID())
 			}
 			s.cfg.DefaultSpanConfig.NumVoters = int32(len(tc.voters))
 			s.cfg.DefaultSpanConfig.NumReplicas = int32(len(tc.voters) + len(tc.nonVoters))
@@ -1526,7 +1526,7 @@ func TestChooseRangeToRebalanceOffHotNodes(t *testing.T) {
 			// order to pass replicaIsBehind checks, fake out the function for getting
 			// raft status with one that always returns all replicas as up to date.
 			sr.getRaftStatusFn = func(r CandidateReplica) *raft.Status {
-				return TestingRaftStatusFn(r)
+				return TestingRaftStatusFn(r.Desc(), r.StoreID())
 			}
 
 			s.cfg.DefaultSpanConfig.NumReplicas = int32(len(tc.voters))
@@ -1563,21 +1563,19 @@ func TestNoLeaseTransferToBehindReplicas(t *testing.T) {
 	// Set up a fake RaftStatus that indicates s5 is behind (but all other stores
 	// are caught up). We thus shouldn't transfer a lease to s5.
 	behindTestingRaftStatusFn := func(
-		r interface {
-			Desc() *roachpb.RangeDescriptor
-			StoreID() roachpb.StoreID
-		},
+		desc *roachpb.RangeDescriptor,
+		storeID roachpb.StoreID,
 	) *raft.Status {
 		status := &raft.Status{
 			Progress: make(map[uint64]tracker.Progress),
 		}
-		replDesc, ok := r.Desc().GetReplicaDescriptor(r.StoreID())
-		require.True(t, ok, "Could not find replica descriptor for replica on store with id %d", r.StoreID())
+		replDesc, ok := desc.GetReplicaDescriptor(storeID)
+		require.True(t, ok, "Could not find replica descriptor for replica on store with id %d", storeID)
 
 		status.Lead = uint64(replDesc.ReplicaID)
 		status.RaftState = raft.StateLeader
 		status.Commit = 2
-		for _, replica := range r.Desc().InternalReplicas {
+		for _, replica := range desc.InternalReplicas {
 			match := uint64(2)
 			if replica.StoreID == roachpb.StoreID(5) {
 				match = 0
@@ -1618,7 +1616,7 @@ func TestNoLeaseTransferToBehindReplicas(t *testing.T) {
 
 		sr := NewStoreRebalancer(cfg.AmbientCtx, cfg.Settings, rq, rr, objectiveProvider)
 		sr.getRaftStatusFn = func(r CandidateReplica) *raft.Status {
-			return behindTestingRaftStatusFn(r)
+			return behindTestingRaftStatusFn(r.Desc(), r.StoreID())
 		}
 		lbRebalanceDimension := sr.RebalanceObjective().ToDimension()
 
@@ -1821,16 +1819,11 @@ func TestStoreRebalancerIOOverloadCheck(t *testing.T) {
 // TestingRaftStatusFn returns a raft status where all replicas are up to date and
 // the replica on the store with ID StoreID is the leader. It may be used for
 // testing.
-func TestingRaftStatusFn(
-	r interface {
-		Desc() *roachpb.RangeDescriptor
-		StoreID() roachpb.StoreID
-	},
-) *raft.Status {
+func TestingRaftStatusFn(desc *roachpb.RangeDescriptor, storeID roachpb.StoreID) *raft.Status {
 	status := &raft.Status{
 		Progress: make(map[uint64]tracker.Progress),
 	}
-	replDesc, ok := r.Desc().GetReplicaDescriptor(r.StoreID())
+	replDesc, ok := desc.GetReplicaDescriptor(storeID)
 	if !ok {
 		return status
 	}
@@ -1838,7 +1831,7 @@ func TestingRaftStatusFn(
 	status.Lead = uint64(replDesc.ReplicaID)
 	status.RaftState = raft.StateLeader
 	status.Commit = 2
-	for _, replica := range r.Desc().InternalReplicas {
+	for _, replica := range desc.InternalReplicas {
 		status.Progress[uint64(replica.ReplicaID)] = tracker.Progress{
 			Match: 2,
 			State: tracker.StateReplicate,

--- a/pkg/kv/kvserver/store_split.go
+++ b/pkg/kv/kvserver/store_split.go
@@ -329,13 +329,6 @@ func (s *Store) SplitRange(
 	// distribution across all tracked load stats is identical.
 	leftRepl.loadStats.Split(rightRepl.loadStats)
 
-	// Update the replica's cached byte thresholds. This is a no-op if the system
-	// config is not available, in which case we rely on the next gossip update to
-	// perform the update.
-	if err := rightRepl.updateRangeInfo(ctx, rightDesc); err != nil {
-		return err
-	}
-
 	rightRepl.mu.Lock()
 	defer rightRepl.mu.Unlock()
 	return s.markReplicaInitializedLockedReplLocked(ctx, rightRepl)

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -220,7 +220,9 @@ func createTestStoreWithoutStart(
 	// dependency reasons. Tests using this harness can probably be refactored
 	// to do the same (with some effort). That's unlikely to happen soon, so
 	// let's continue to use the system config span.
-	cfg.SpanConfigsDisabled = true
+	cfg.SystemConfigProvider = config.NewConstantSystemConfigProvider(
+		config.NewSystemConfig(zonepb.DefaultZoneConfigRef()),
+	)
 	eng := storage.NewDefaultInMemForTesting()
 	stopper.AddCloser(eng)
 	require.Nil(t, cfg.Transport)

--- a/pkg/kv/kvserver/testing_knobs.go
+++ b/pkg/kv/kvserver/testing_knobs.go
@@ -391,6 +391,7 @@ type StoreTestingKnobs struct {
 	SpanConfigUpdateInterceptor func(spanconfig.Update)
 	// SetSpanConfigInterceptor is called before updating a replica's embedded
 	// SpanConfig. The returned SpanConfig is used instead.
+	// FIXME
 	SetSpanConfigInterceptor func(*roachpb.RangeDescriptor, roachpb.SpanConfig) roachpb.SpanConfig
 	// If set, use the given version as the initial replica version when
 	// bootstrapping ranges. This is used for testing the migration
@@ -414,13 +415,6 @@ type StoreTestingKnobs struct {
 	// MakeSystemConfigSpanUnavailableToQueues makes the system config span
 	// unavailable to queues that ask for it.
 	MakeSystemConfigSpanUnavailableToQueues bool
-	// UseSystemConfigSpanForQueues uses the system config span infrastructure
-	// for internal queues (as opposed to the span configs infrastructure). This
-	// is used only for (old) tests written with the system config span in mind.
-	//
-	// TODO(irfansharif): Get rid of this knob, maybe by first moving
-	// DisableSpanConfigs into a testing knob instead of a server arg.
-	UseSystemConfigSpanForQueues bool
 	// ConfReaderInterceptor intercepts calls to get a span config reader.
 	ConfReaderInterceptor func() spanconfig.StoreReader
 	// IgnoreStrictGCEnforcement is used by tests to op out of strict GC

--- a/pkg/kv/kvserver/ts_maintenance_queue.go
+++ b/pkg/kv/kvserver/ts_maintenance_queue.go
@@ -17,7 +17,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -127,7 +126,7 @@ func newTimeSeriesMaintenanceQueue(
 }
 
 func (q *timeSeriesMaintenanceQueue) shouldQueue(
-	ctx context.Context, now hlc.ClockTimestamp, repl *Replica, _ spanconfig.StoreReader,
+	ctx context.Context, now hlc.ClockTimestamp, repl *Replica,
 ) (shouldQ bool, priority float64) {
 	if !repl.store.cfg.TestingKnobs.DisableLastProcessedCheck {
 		lpTS, err := repl.getQueueLastProcessed(ctx, q.name)
@@ -147,7 +146,7 @@ func (q *timeSeriesMaintenanceQueue) shouldQueue(
 }
 
 func (q *timeSeriesMaintenanceQueue) process(
-	ctx context.Context, repl *Replica, _ spanconfig.StoreReader,
+	ctx context.Context, repl *Replica,
 ) (processed bool, err error) {
 	desc := repl.Desc()
 	eng := repl.store.StateEngine()

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -199,11 +199,6 @@ type BaseConfig struct {
 	// instantiate stores.
 	StorageEngine enginepb.EngineType
 
-	// SpanConfigsDisabled disables the use of the span configs infrastructure.
-	//
-	// Environment Variable: COCKROACH_DISABLE_SPAN_CONFIGS
-	SpanConfigsDisabled bool
-
 	// Disables the default test tenant.
 	DisableDefaultTestTenant bool
 
@@ -648,9 +643,6 @@ func (cfg *Config) String() string {
 	if cfg.Linearizable {
 		fmt.Fprintln(w, "linearizable\t", cfg.Linearizable)
 	}
-	if !cfg.SpanConfigsDisabled {
-		fmt.Fprintln(w, "span configs enabled\t", !cfg.SpanConfigsDisabled)
-	}
 	_ = w.Flush()
 
 	return buf.String()
@@ -936,7 +928,6 @@ func (cfg *BaseConfig) InsecureWebAccess() bool {
 }
 
 func (cfg *Config) readSQLEnvironmentVariables() {
-	cfg.SpanConfigsDisabled = envutil.EnvOrDefaultBool("COCKROACH_DISABLE_SPAN_CONFIGS", cfg.SpanConfigsDisabled)
 	cfg.Linearizable = envutil.EnvOrDefaultBool("COCKROACH_EXPERIMENTAL_LINEARIZABLE", cfg.Linearizable)
 }
 

--- a/pkg/server/config_test.go
+++ b/pkg/server/config_test.go
@@ -99,9 +99,6 @@ func TestReadEnvironmentVariables(t *testing.T) {
 		if err := os.Unsetenv("COCKROACH_EXPERIMENTAL_LINEARIZABLE"); err != nil {
 			t.Fatal(err)
 		}
-		if err := os.Unsetenv("COCKROACH_DISABLE_SPAN_CONFIGS"); err != nil {
-			t.Fatal(err)
-		}
 		if err := os.Unsetenv("COCKROACH_SCAN_INTERVAL"); err != nil {
 			t.Fatal(err)
 		}
@@ -139,10 +136,6 @@ func TestReadEnvironmentVariables(t *testing.T) {
 
 	// Set all the environment variables to valid values and ensure they are set
 	// correctly.
-	if err := os.Setenv("COCKROACH_DISABLE_SPAN_CONFIGS", "true"); err != nil {
-		t.Fatal(err)
-	}
-	cfgExpected.SpanConfigsDisabled = true
 	if err := os.Setenv("COCKROACH_EXPERIMENTAL_LINEARIZABLE", "true"); err != nil {
 		t.Fatal(err)
 	}
@@ -167,7 +160,6 @@ func TestReadEnvironmentVariables(t *testing.T) {
 	}
 
 	for _, envVar := range []string{
-		"COCKROACH_DISABLE_SPAN_CONFIGS",
 		"COCKROACH_EXPERIMENTAL_LINEARIZABLE",
 		"COCKROACH_SCAN_INTERVAL",
 		"COCKROACH_SCAN_MIN_IDLE_TIME",

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -723,74 +723,58 @@ func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterf
 		// tenant records.
 		kvAccessorForTenantRecords spanconfig.KVAccessor
 	}
-	if !cfg.SpanConfigsDisabled {
-		spanConfigKnobs, _ := cfg.TestingKnobs.SpanConfig.(*spanconfig.TestingKnobs)
-		if spanConfigKnobs != nil && spanConfigKnobs.StoreKVSubscriberOverride != nil {
-			spanConfig.subscriber = spanConfigKnobs.StoreKVSubscriberOverride
-		} else {
-			// We use the span configs infra to control whether rangefeeds are
-			// enabled on a given range. At the moment this only applies to
-			// system tables (on both host and secondary tenants). We need to
-			// consider two things:
-			// - The sql-side reconciliation process runs asynchronously. When
-			//   the config for a given range is requested, we might not yet have
-			//   it, thus falling back to the static config below.
-			// - Various internal subsystems rely on rangefeeds to function.
-			//
-			// Consequently, we configure our static fallback config to actually
-			// allow rangefeeds. As the sql-side reconciliation process kicks
-			// off, it'll install the actual configs that we'll later consult.
-			// For system table ranges we install configs that allow for
-			// rangefeeds. Until then, we simply allow rangefeeds when a more
-			// targeted config is not found.
-			fallbackConf := cfg.DefaultZoneConfig.AsSpanConfig()
-			fallbackConf.RangefeedEnabled = true
-			// We do the same for opting out of strict GC enforcement; it
-			// really only applies to user table ranges
-			fallbackConf.GCPolicy.IgnoreStrictEnforcement = true
-
-			spanConfig.subscriber = spanconfigkvsubscriber.New(
-				clock,
-				rangeFeedFactory,
-				keys.SpanConfigurationsTableID,
-				1<<20, /* 1 MB */
-				fallbackConf,
-				cfg.Settings,
-				spanconfigstore.NewBoundsReader(tenantCapabilitiesWatcher),
-				spanConfigKnobs,
-				registry,
-			)
-		}
-
-		scKVAccessor := spanconfigkvaccessor.New(
-			db, internalExecutor, cfg.Settings, clock,
-			systemschema.SpanConfigurationsTableName.FQString(),
-			spanConfigKnobs,
-		)
-		spanConfig.kvAccessor, spanConfig.kvAccessorForTenantRecords = scKVAccessor, scKVAccessor
-		spanConfig.reporter = spanconfigreporter.New(
-			nodeLiveness,
-			storePool,
-			spanConfig.subscriber,
-			rangedesc.NewScanner(db),
-			cfg.Settings,
-			spanConfigKnobs,
-		)
+	spanConfigKnobs, _ := cfg.TestingKnobs.SpanConfig.(*spanconfig.TestingKnobs)
+	if spanConfigKnobs != nil && spanConfigKnobs.StoreKVSubscriberOverride != nil {
+		spanConfig.subscriber = spanConfigKnobs.StoreKVSubscriberOverride
 	} else {
-		// If the spanconfigs infrastructure is disabled, there should be no
-		// reconciliation jobs or RPCs issued against the infrastructure. Plug
-		// in a disabled spanconfig.KVAccessor that would error out for
-		// unexpected use.
-		spanConfig.kvAccessor = spanconfigkvaccessor.DisabledKVAccessor
+		// We use the span configs infra to control whether rangefeeds are
+		// enabled on a given range. At the moment this only applies to
+		// system tables (on both host and secondary tenants). We need to
+		// consider two things:
+		// - The sql-side reconciliation process runs asynchronously. When
+		//   the config for a given range is requested, we might not yet have
+		//   it, thus falling back to the static config below.
+		// - Various internal subsystems rely on rangefeeds to function.
+		//
+		// Consequently, we configure our static fallback config to actually
+		// allow rangefeeds. As the sql-side reconciliation process kicks
+		// off, it'll install the actual configs that we'll later consult.
+		// For system table ranges we install configs that allow for
+		// rangefeeds. Until then, we simply allow rangefeeds when a more
+		// targeted config is not found.
+		fallbackConf := cfg.DefaultZoneConfig.AsSpanConfig()
+		fallbackConf.RangefeedEnabled = true
+		// We do the same for opting out of strict GC enforcement; it
+		// really only applies to user table ranges
+		fallbackConf.GCPolicy.IgnoreStrictEnforcement = true
 
-		// Ditto for the spanconfig.Reporter.
-		spanConfig.reporter = spanconfigreporter.DisabledReporter
-
-		// Use a no-op accessor where tenant records are created/destroyed.
-		spanConfig.kvAccessorForTenantRecords = spanconfigkvaccessor.NoopKVAccessor
-
-		spanConfig.subscriber = spanconfigkvsubscriber.NewNoopSubscriber(clock)
+		spanConfig.subscriber = spanconfigkvsubscriber.New(
+			clock,
+			rangeFeedFactory,
+			keys.SpanConfigurationsTableID,
+			1<<20, /* 1 MB */
+			fallbackConf,
+			cfg.Settings,
+			spanconfigstore.NewBoundsReader(tenantCapabilitiesWatcher),
+			spanConfigKnobs,
+			registry,
+		)
 	}
+
+	scKVAccessor := spanconfigkvaccessor.New(
+		db, internalExecutor, cfg.Settings, clock,
+		systemschema.SpanConfigurationsTableName.FQString(),
+		spanConfigKnobs,
+	)
+	spanConfig.kvAccessor, spanConfig.kvAccessorForTenantRecords = scKVAccessor, scKVAccessor
+	spanConfig.reporter = spanconfigreporter.New(
+		nodeLiveness,
+		storePool,
+		spanConfig.subscriber,
+		rangedesc.NewScanner(db),
+		cfg.Settings,
+		spanConfigKnobs,
+	)
 
 	var protectedTSReader spanconfig.ProtectedTSReader
 	if cfg.TestingKnobs.SpanConfig != nil &&
@@ -844,7 +828,6 @@ func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterf
 		RangefeedBudgetFactory:       rangeReedBudgetFactory,
 		SystemConfigProvider:         systemConfigWatcher,
 		SpanConfigSubscriber:         spanConfig.subscriber,
-		SpanConfigsDisabled:          cfg.SpanConfigsDisabled,
 		SnapshotApplyLimit:           cfg.SnapshotApplyLimit,
 		SnapshotSendLimit:            cfg.SnapshotSendLimit,
 		RangeLogWriter:               rangeLogWriter,
@@ -1981,11 +1964,9 @@ func (s *topLevelServer) PreStart(ctx context.Context) error {
 		return err
 	}
 
-	if !s.cfg.SpanConfigsDisabled && s.spanConfigSubscriber != nil {
-		if subscriber, ok := s.spanConfigSubscriber.(*spanconfigkvsubscriber.KVSubscriber); ok {
-			if err := subscriber.Start(workersCtx, s.stopper); err != nil {
-				return err
-			}
+	if subscriber, ok := s.spanConfigSubscriber.(*spanconfigkvsubscriber.KVSubscriber); ok {
+		if err := subscriber.Start(workersCtx, s.stopper); err != nil {
+			return err
 		}
 	}
 	// Start garbage collecting system events.

--- a/pkg/server/server_controller_new_server.go
+++ b/pkg/server/server_controller_new_server.go
@@ -243,7 +243,6 @@ func makeSharedProcessTenantServerConfig(
 	baseCfg.StorageEngine = kvServerCfg.BaseConfig.StorageEngine
 	baseCfg.TestingInsecureWebAccess = kvServerCfg.BaseConfig.TestingInsecureWebAccess
 	baseCfg.Locality = kvServerCfg.BaseConfig.Locality
-	baseCfg.SpanConfigsDisabled = kvServerCfg.BaseConfig.SpanConfigsDisabled
 	baseCfg.EnableDemoLoginEndpoint = kvServerCfg.BaseConfig.EnableDemoLoginEndpoint
 
 	// TODO(knz): use a single network interface for all tenant servers.

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -1245,44 +1245,40 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 		execCfg.UpgradeTestingKnobs = knobs
 	}
 
-	if !codec.ForSystemTenant() || !cfg.SpanConfigsDisabled {
-		// Instantiate a span config manager. If we're the host tenant we'll
-		// only do it unless COCKROACH_DISABLE_SPAN_CONFIGS is set.
-		spanConfigKnobs, _ := cfg.TestingKnobs.SpanConfig.(*spanconfig.TestingKnobs)
-		spanConfig.sqlTranslatorFactory = spanconfigsqltranslator.NewFactory(
-			execCfg.ProtectedTimestampProvider, codec, spanConfigKnobs,
-		)
-		spanConfig.sqlWatcher = spanconfigsqlwatcher.New(
-			codec,
-			cfg.Settings,
-			cfg.rangeFeedFactory,
-			1<<20, /* 1 MB bufferMemLimit */
-			cfg.stopper,
-			// TODO(irfansharif): What should this no-op cadence be?
-			30*time.Second, /* checkpointNoopsEvery */
-			spanConfigKnobs,
-		)
-		spanConfigReconciler := spanconfigreconciler.New(
-			spanConfig.sqlWatcher,
-			spanConfig.sqlTranslatorFactory,
-			cfg.spanConfigAccessor,
-			execCfg,
-			codec,
-			cfg.TenantID,
-			cfg.Settings,
-			spanConfigKnobs,
-		)
-		spanConfig.manager = spanconfigmanager.New(
-			cfg.internalDB,
-			jobRegistry,
-			cfg.stopper,
-			cfg.Settings,
-			spanConfigReconciler,
-			spanConfigKnobs,
-		)
+	// Instantiate a span config manager.
+	spanConfig.sqlTranslatorFactory = spanconfigsqltranslator.NewFactory(
+		execCfg.ProtectedTimestampProvider, codec, spanConfigKnobs,
+	)
+	spanConfig.sqlWatcher = spanconfigsqlwatcher.New(
+		codec,
+		cfg.Settings,
+		cfg.rangeFeedFactory,
+		1<<20, /* 1 MB bufferMemLimit */
+		cfg.stopper,
+		// TODO(irfansharif): What should this no-op cadence be?
+		30*time.Second, /* checkpointNoopsEvery */
+		spanConfigKnobs,
+	)
+	spanConfigReconciler := spanconfigreconciler.New(
+		spanConfig.sqlWatcher,
+		spanConfig.sqlTranslatorFactory,
+		cfg.spanConfigAccessor,
+		execCfg,
+		codec,
+		cfg.TenantID,
+		cfg.Settings,
+		spanConfigKnobs,
+	)
+	spanConfig.manager = spanconfigmanager.New(
+		cfg.internalDB,
+		jobRegistry,
+		cfg.stopper,
+		cfg.Settings,
+		spanConfigReconciler,
+		spanConfigKnobs,
+	)
 
-		execCfg.SpanConfigReconciler = spanConfigReconciler
-	}
+	execCfg.SpanConfigReconciler = spanConfigReconciler
 	execCfg.SpanConfigKVAccessor = cfg.spanConfigAccessor
 	execCfg.SpanConfigLimiter = spanConfig.limiter
 	execCfg.SpanConfigSplitter = spanConfig.splitter

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -254,9 +254,6 @@ func makeTestConfigFromParams(params base.TestServerArgs) Config {
 	if params.EnableDemoLoginEndpoint {
 		cfg.EnableDemoLoginEndpoint = true
 	}
-	if params.DisableSpanConfigs {
-		cfg.SpanConfigsDisabled = true
-	}
 	if params.SnapshotApplyLimit != 0 {
 		cfg.SnapshotApplyLimit = params.SnapshotApplyLimit
 	}

--- a/pkg/spanconfig/spanconfigmanager/manager.go
+++ b/pkg/spanconfig/spanconfigmanager/manager.go
@@ -30,8 +30,7 @@ import (
 // checkReconciliationJobInterval is a cluster setting to control how often we
 // check if the span config reconciliation job exists. If it's not found, it
 // will be started. It has no effect unless
-// spanconfig.reconciliation_job.enabled is configured. For host
-// tenants, COCKROACH_DISABLE_SPAN_CONFIGS must not be set.
+// spanconfig.reconciliation_job.enabled is configured.
 var checkReconciliationJobInterval = settings.RegisterDurationSetting(
 	settings.TenantWritable,
 	"spanconfig.reconciliation_job.check_interval",
@@ -41,8 +40,6 @@ var checkReconciliationJobInterval = settings.RegisterDurationSetting(
 )
 
 // jobEnabledSetting gates the activation of the span config reconciliation job.
-// For the host tenant it has no effect if COCKROACH_DISABLE_SPAN_CONFIGS is
-// set.
 //
 // TODO(irfansharif): This should be a tenant read-only setting once the work
 // for #73349 is completed.

--- a/pkg/spanconfig/spanconfigstore/store.go
+++ b/pkg/spanconfig/spanconfigstore/store.go
@@ -25,20 +25,6 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-// EnabledSetting is a hidden cluster setting to enable the use of the span
-// configs infrastructure in KV. It switches each store in the cluster from
-// using the gossip backed system config span to instead using the span configs
-// infrastructure. It has no effect if COCKROACH_DISABLE_SPAN_CONFIGS
-// is set.
-//
-// TODO(irfansharif): We should remove this.
-var EnabledSetting = settings.RegisterBoolSetting(
-	settings.SystemOnly,
-	"spanconfig.store.enabled",
-	`use the span config infrastructure in KV instead of the system config span`,
-	true,
-)
-
 // FallbackConfigOverride is a hidden cluster setting to override the fallback
 // config used for ranges with no explicit span configs set.
 var FallbackConfigOverride = settings.RegisterProtobufSetting(

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -1925,17 +1925,6 @@ type clusterOpt interface {
 	apply(args *base.TestServerArgs)
 }
 
-// clusterOptDisableSpanConfigs corresponds to the disable-span-configs
-// directive.
-type clusterOptDisableSpanConfigs struct{}
-
-var _ clusterOpt = clusterOptDisableSpanConfigs{}
-
-// apply implements the clusterOpt interface.
-func (c clusterOptDisableSpanConfigs) apply(args *base.TestServerArgs) {
-	args.DisableSpanConfigs = true
-}
-
 // clusterOptTracingOff corresponds to the tracing-off directive.
 type clusterOptTracingOff struct{}
 
@@ -2122,8 +2111,6 @@ func readClusterOptions(t *testing.T, path string) []clusterOpt {
 	var res []clusterOpt
 	parseDirectiveOptions(t, path, clusterDirective, func(opt string) {
 		switch opt {
-		case "disable-span-configs":
-			res = append(res, clusterOptDisableSpanConfigs{})
 		case "tracing-off":
 			res = append(res, clusterOptTracingOff{})
 		case "ignore-tenant-strict-gc-enforcement":

--- a/pkg/sql/tests/split_test.go
+++ b/pkg/sql/tests/split_test.go
@@ -72,10 +72,9 @@ func TestSplitOnTableBoundaries(t *testing.T) {
 		// The test needs to be refactored to work with the secondary tenants.
 		DefaultTestTenant: base.TestDoesNotWorkWithSecondaryTenantsButWeDontKnowWhyYet(107289),
 		// We want fast scan.
-		ScanInterval:       time.Millisecond,
-		ScanMinIdleTime:    time.Millisecond,
-		ScanMaxIdleTime:    time.Millisecond,
-		DisableSpanConfigs: true,
+		ScanInterval:    time.Millisecond,
+		ScanMinIdleTime: time.Millisecond,
+		ScanMaxIdleTime: time.Millisecond,
 	})
 	defer s.Stopper().Stop(context.Background())
 

--- a/pkg/upgrade/upgrades/backfill_job_info_table_migration_test.go
+++ b/pkg/upgrade/upgrades/backfill_job_info_table_migration_test.go
@@ -45,7 +45,6 @@ func TestBackfillJobsInfoTable(t *testing.T) {
 	clusterArgs := base.TestClusterArgs{
 		// Disable all automatic jobs creation and adoption.
 		ServerArgs: base.TestServerArgs{
-			DisableSpanConfigs: true,
 			Knobs: base.TestingKnobs{
 				Server: &server.TestingKnobs{
 					DisableAutomaticVersionUpgrade: make(chan struct{}),


### PR DESCRIPTION
Span configs are integral to correct operation of queues and the ability to disable this infrastructure is no longer necessary.

Epic: none

Release note: None