### PR TITLE
ccl/sqlproxyccl: fixes a data race in the ACL's watcher

### DIFF
--- a/pkg/ccl/sqlproxyccl/acl/watcher.go
+++ b/pkg/ccl/sqlproxyccl/acl/watcher.go
@@ -276,7 +276,9 @@ func (w *Watcher) ListenForDenied(
 
 		w.listeners.ReplaceOrInsert(l)
 
-		return l, w.controllers
+		// We need a new copy of w.controllers so that it doesn't race with the
+		// add and update operations.
+		return l, append([]AccessController(nil), w.controllers...)
 	}()
 	if err := checkConnection(ctx, connection, controllers); err != nil {
 		w.removeListener(lst)


### PR DESCRIPTION
Fixes https://github.com/cockroachdb/cockroach/issues/108156. Regression from https://github.com/cockroachdb/cockroach/pull/108097.

Previously, we updated the code to return w.controllers after releasing the
lock because checkConnection may be long running, and we did not want to block
new connections. We had forgotten the contract where fields on the Watcher
object needs `mu` as they may be updated, so that approach had data races.
This commit address that by ensuring that a copy of w.controllers is returned
instead.

Release note: None

Epic: none