### PR TITLE
parser: add SHOW BACKUP...NOWAIT hidden alias for SKIP SIZE

### DIFF
--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -7665,6 +7665,11 @@ show_backup_options:
  {
  $$.val = &tree.ShowBackupOptions{SkipSize: true}
  }
+ | NOWAIT
+ {
+ /* SKIP DOC */
+ $$.val = &tree.ShowBackupOptions{SkipSize: true}
+ }
  | DEBUG_IDS
  {
  $$.val = &tree.ShowBackupOptions{DebugIDs: true}

--- a/pkg/sql/parser/testdata/show
+++ b/pkg/sql/parser/testdata/show
@@ -2059,3 +2059,19 @@ SHOW BACKUP 'family' IN ('string', 'placeholder', 'placeholder', 'placeholder', 
 SHOW BACKUP ('family') IN (('string'), ('placeholder'), ('placeholder'), ('placeholder'), ('string'), ('placeholder'), ('string'), ('placeholder')) WITH incremental_location = ('nullif'), privileges, debug_dump_metadata_sst -- fully parenthesized
 SHOW BACKUP '_' IN ('_', '_', '_', '_', '_', '_', '_', '_') WITH incremental_location = '_', privileges, debug_dump_metadata_sst -- literals removed
 SHOW BACKUP 'family' IN ('string', 'placeholder', 'placeholder', 'placeholder', 'string', 'placeholder', 'string', 'placeholder') WITH incremental_location = 'nullif', privileges, debug_dump_metadata_sst -- identifiers removed
+
+parse
+SHOW BACKUP 'abc' WITH SKIP SIZE
+----
+SHOW BACKUP 'abc' WITH skip size -- normalized!
+SHOW BACKUP ('abc') WITH skip size -- fully parenthesized
+SHOW BACKUP '_' WITH skip size -- literals removed
+SHOW BACKUP 'abc' WITH skip size -- identifiers removed
+
+parse
+SHOW BACKUP 'abc' WITH NOWAIT
+----
+SHOW BACKUP 'abc' WITH skip size -- normalized!
+SHOW BACKUP ('abc') WITH skip size -- fully parenthesized
+SHOW BACKUP '_' WITH skip size -- literals removed
+SHOW BACKUP 'abc' WITH skip size -- identifiers removed


### PR DESCRIPTION
SKIP SIZE cannot backport to 22.2 due to 22.2 using string k/v options, rather than first class syntax. NOWAIT is added as a hidden alias that will be able to be used in both 23.1 backports and a 22.2 backport, as the single keyword will also be usable as a string k/v in in the old option parsing.

Release note: none.
Epic: none.