### PR TITLE
release-23.1: sql: add enums to statement bundles

### DIFF
--- a/pkg/cli/testdata/explain-bundle/bundle/schema.sql
+++ b/pkg/cli/testdata/explain-bundle/bundle/schema.sql
@@ -1,10 +1,12 @@
-CREATE TABLE public.a (
-	a INT8 NOT NULL,
-	b INT8 NULL,
-	CONSTRAINT "primary" PRIMARY KEY (a ASC),
-	FAMILY "primary" (a, b)
+CREATE TABLE public.a
+(
+  a      INT8 NOT NULL,
+  b      INT8 NULL,
+  CONSTRAINT "primary" PRIMARY KEY (a ASC),
+  FAMILY "primary" (a, b)
 );
 
-CREATE TABLE public."order" (
-    id INT8 PRIMARY KEY
+CREATE TABLE public."order"
+(
+  id INT8 PRIMARY KEY
 );

--- a/pkg/sql/sem/tree/create.go
+++ b/pkg/sql/sem/tree/create.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/collatedstring"
 	"github.com/cockroachdb/cockroach/pkg/util/pretty"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 	"golang.org/x/text/language"
 )
 
@@ -328,6 +329,10 @@ func (n *EnumValue) Format(ctx *FmtCtx) {
 	f := ctx.flags
 	if f.HasFlags(FmtAnonymize) {
 		ctx.WriteByte('_')
+	} else if f.HasFlags(FmtMarkRedactionNode) {
+		ctx.WriteString(string(redact.StartMarker()))
+		lexbase.EncodeSQLString(&ctx.Buffer, string(*n))
+		ctx.WriteString(string(redact.EndMarker()))
 	} else {
 		lexbase.EncodeSQLString(&ctx.Buffer, string(*n))
 	}


### PR DESCRIPTION
Backport 1/1 commits from #101953.

/cc @cockroachdb/release

---

Statement bundles now include the `CREATE` statements for enums in `schema.sql`.

Epic: None
Fixes: #100377

Release note: None

Release justification: low-risk debugging improvement.