### PR TITLE
changefeedccl: fix row count in nemeses test

### DIFF
--- a/pkg/ccl/changefeedccl/cdctest/nemeses.go
+++ b/pkg/ccl/changefeedccl/cdctest/nemeses.go
@@ -30,7 +30,7 @@ import (
 // real output of a changefeed. The output rows and resolved timestamps of the
 // tested feed are fed into them to check for anomalies.
 func RunNemesis(
-	f TestFeedFactory, db *gosql.DB, isSinkless bool, rng *rand.Rand,
+	f TestFeedFactory, db *gosql.DB, isSinkless bool, withLegacySchemaChanger bool, rng *rand.Rand,
 ) (Validator, error) {
 	// possible additional nemeses:
 	// - schema changes
@@ -54,9 +54,10 @@ func RunNemesis(
 		eventPauseCount = 0
 	}
 	ns := &nemeses{
-		maxTestColumnCount: 10,
-		rowCount:           4,
-		db:                 db,
+		withLegacySchemaChanger: withLegacySchemaChanger,
+		maxTestColumnCount:      10,
+		rowCount:                4,
+		db:                      db,
 		// eventMix does not have to add to 100
 		eventMix: map[fsm.Event]int{
 			// We don't want `eventFinished` to ever be returned by `nextEvent` so we set
@@ -262,6 +263,8 @@ type addColumnPayload struct {
 }
 
 type nemeses struct {
+	withLegacySchemaChanger bool
+
 	rowCount           int
 	maxTestColumnCount int
 	eventMix           map[fsm.Event]int
@@ -692,9 +695,14 @@ func addColumn(a fsm.Args) error {
 	if err := ns.db.QueryRow(`SELECT count(*) FROM foo`).Scan(&rows); err != nil {
 		return err
 	}
-	// We expect one table scan that corresponds to the schema change backfill, and one
-	// scan that corresponds to the changefeed level backfill.
-	ns.availableRows += 2 * rows
+	if ns.withLegacySchemaChanger {
+		// We expect one table scan that corresponds to the schema change backfill, and one
+		// scan that corresponds to the changefeed level backfill.
+		ns.availableRows += 2 * rows
+	} else {
+		// We expect to see a backfill
+		ns.availableRows += rows
+	}
 	return nil
 }
 
@@ -715,9 +723,14 @@ func removeColumn(a fsm.Args) error {
 	if err := ns.db.QueryRow(`SELECT count(*) FROM foo`).Scan(&rows); err != nil {
 		return err
 	}
-	// We expect one table scan that corresponds to the schema change backfill, and one
-	// scan that corresponds to the changefeed level backfill.
-	ns.availableRows += 2 * rows
+	if ns.withLegacySchemaChanger {
+		// We expect one table scan that corresponds to the schema change backfill, and one
+		// scan that corresponds to the changefeed level backfill.
+		ns.availableRows += 2 * rows
+	} else {
+		// We expect to see a backfill
+		ns.availableRows += rows
+	}
 	return nil
 }
 

--- a/pkg/ccl/changefeedccl/nemeses_test.go
+++ b/pkg/ccl/changefeedccl/nemeses_test.go
@@ -32,11 +32,11 @@ func TestChangefeedNemeses(t *testing.T) {
 		t.Logf("random seed: %d", seed)
 
 		sqlDB := sqlutils.MakeSQLRunner(s.DB)
-		_ = maybeDisableDeclarativeSchemaChangesForTest(t, sqlDB, rng)
+		withLegacySchemaChanger := maybeDisableDeclarativeSchemaChangesForTest(t, sqlDB, rng)
 		// TODO(dan): Ugly hack to disable `eventPause` in sinkless feeds. See comment in
 		// `RunNemesis` for details.
 		isSinkless := strings.Contains(t.Name(), "sinkless")
-		v, err := cdctest.RunNemesis(f, s.DB, isSinkless, rng)
+		v, err := cdctest.RunNemesis(f, s.DB, isSinkless, withLegacySchemaChanger, rng)
 		if err != nil {
 			t.Fatalf("%+v", err)
 		}


### PR DESCRIPTION
There was a bug in this test where, when using the declarative schema changer, we would increment the running row count by a factor of 3 when doing addColumn/dropColumn operations. This behavior aligns with the legacy schema changer where we expect to see two backfills. For the declarative schema changer, we should only double the row count because we see one backfill.

In #108155, this bug was caused the rowcount would be incorrectly nonzero which would cause test would get stuck waiting for rows to be emitted.

Fixes: https://github.com/cockroachdb/cockroach/issues/108155
Release note: None
Epic: None