### PR TITLE
metric: Ensure correct metrics registry usage

### DIFF
--- a/pkg/jobs/jobs_test.go
+++ b/pkg/jobs/jobs_test.go
@@ -2850,14 +2850,14 @@ func TestStatusSafeFormatter(t *testing.T) {
 }
 
 type fakeMetrics struct {
-	n *metric.Counter
+	N *metric.Counter
 }
 
 func (fm fakeMetrics) MetricStruct() {}
 
 func makeFakeMetrics() fakeMetrics {
 	return fakeMetrics{
-		n: metric.NewCounter(metric.Metadata{
+		N: metric.NewCounter(metric.Metadata{
 			Name:        "fake.count",
 			Help:        "utterly fake metric",
 			Measurement: "N",
@@ -2901,7 +2901,7 @@ func TestMetrics(t *testing.T) {
 		func(j *jobs.Job, _ *cluster.Settings) jobs.Resumer {
 			return jobs.FakeResumer{
 				OnResume: func(ctx context.Context) error {
-					defer fakeBackupMetrics.n.Inc(1)
+					defer fakeBackupMetrics.N.Inc(1)
 					return waitForErr(ctx)
 				},
 				FailOrCancel: func(ctx context.Context) error {
@@ -2954,7 +2954,7 @@ func TestMetrics(t *testing.T) {
 		require.Equal(t, int64(1), backupMetrics.CurrentlyRunning.Value())
 		errCh <- nil
 		int64EqSoon(t, backupMetrics.ResumeCompleted.Count, 1)
-		int64EqSoon(t, registry.MetricsStruct().JobSpecificMetrics[jobspb.TypeBackup].(fakeMetrics).n.Count, 1)
+		int64EqSoon(t, registry.MetricsStruct().JobSpecificMetrics[jobspb.TypeBackup].(fakeMetrics).N.Count, 1)
 
 	})
 	t.Run("restart, pause, resume, then success", func(t *testing.T) {

--- a/pkg/sql/mem_metrics.go
+++ b/pkg/sql/mem_metrics.go
@@ -23,6 +23,9 @@ type BaseMemoryMetrics struct {
 	CurBytesCount *metric.Gauge
 }
 
+// MetricStruct implements the metrics.Struct interface.
+func (BaseMemoryMetrics) MetricStruct() {}
+
 // MemoryMetrics contains pointers to the metrics object
 // for one of the SQL endpoints:
 // - "client" for connections received via pgwire.

--- a/pkg/sql/sql_activity_update_job.go
+++ b/pkg/sql/sql_activity_update_job.go
@@ -105,7 +105,7 @@ func (j *sqlActivityUpdateJob) Resume(ctx context.Context, execCtxI interface{})
 				updater := newSqlActivityUpdater(settings, execCtx.ExecCfg().InternalDB, nil)
 				if err := updater.TransferStatsToActivity(ctx); err != nil {
 					log.Warningf(ctx, "error running sql activity updater job: %v", err)
-					metrics.numErrors.Inc(1)
+					metrics.NumErrors.Inc(1)
 				}
 			}
 		case <-ctx.Done():
@@ -119,14 +119,14 @@ func (j *sqlActivityUpdateJob) Resume(ctx context.Context, execCtxI interface{})
 // ActivityUpdaterMetrics must be public for metrics to get
 // registered
 type ActivityUpdaterMetrics struct {
-	numErrors *metric.Counter
+	NumErrors *metric.Counter
 }
 
 func (m ActivityUpdaterMetrics) MetricStruct() {}
 
 func newActivityUpdaterMetrics() metric.Struct {
 	return ActivityUpdaterMetrics{
-		numErrors: metric.NewCounter(metric.Metadata{
+		NumErrors: metric.NewCounter(metric.Metadata{
 			Name:        "jobs.metrics.task_failed",
 			Help:        "Number of metrics sql activity updater tasks that failed",
 			Measurement: "errors",

--- a/pkg/util/metric/BUILD.bazel
+++ b/pkg/util/metric/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/util",
+        "//pkg/util/buildutil",
         "//pkg/util/envutil",
         "//pkg/util/log",
         "//pkg/util/syncutil",
@@ -58,6 +59,7 @@ go_test(
     deps = [
         "//pkg/testutils/datapathutils",
         "//pkg/testutils/echotest",
+        "//pkg/util/buildutil",
         "//pkg/util/log",
         "@com_github_kr_pretty//:pretty",
         "@com_github_prometheus_client_golang//prometheus",

--- a/pkg/util/metric/registry.go
+++ b/pkg/util/metric/registry.go
@@ -17,6 +17,7 @@ import (
 	"reflect"
 	"regexp"
 
+	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/gogo/protobuf/proto"
@@ -104,12 +105,12 @@ func (r *Registry) AddMetricStruct(metricStruct interface{}) {
 	for i := 0; i < v.NumField(); i++ {
 		vfield, tfield := v.Field(i), t.Field(i)
 		tname := tfield.Name
+
 		if !vfield.CanInterface() {
-			if log.V(2) {
-				log.Infof(ctx, "skipping unexported field %s", tname)
-			}
+			checkFieldCanBeSkipped("unexported", tname, tfield.Type, t)
 			continue
 		}
+
 		switch vfield.Kind() {
 		case reflect.Array:
 			for i := 0; i < vfield.Len(); i++ {
@@ -117,18 +118,18 @@ func (r *Registry) AddMetricStruct(metricStruct interface{}) {
 				telemName := fmt.Sprintf("%s[%d]", tname, i)
 				// Permit elements in the array to be nil.
 				const skipNil = true
-				r.addMetricValue(ctx, velem, telemName, skipNil)
+				r.addMetricValue(ctx, velem, telemName, skipNil, t)
 			}
 		default:
 			// No metric fields should be nil.
 			const skipNil = false
-			r.addMetricValue(ctx, vfield, tname, skipNil)
+			r.addMetricValue(ctx, vfield, tname, skipNil, t)
 		}
 	}
 }
 
 func (r *Registry) addMetricValue(
-	ctx context.Context, val reflect.Value, name string, skipNil bool,
+	ctx context.Context, val reflect.Value, name string, skipNil bool, parentType reflect.Type,
 ) {
 	if val.Kind() == reflect.Ptr && val.IsNil() {
 		if skipNil {
@@ -146,9 +147,7 @@ func (r *Registry) addMetricValue(
 	case Struct:
 		r.AddMetricStruct(typ)
 	default:
-		if log.V(2) {
-			log.Infof(ctx, "skipping non-metric field %s", name)
-		}
+		checkFieldCanBeSkipped("non-metric", name, val.Type(), parentType)
 	}
 }
 
@@ -216,4 +215,102 @@ func exportedName(name string) string {
 // exportedLabel takes a metric name and generates a valid prometheus name.
 func exportedLabel(name string) string {
 	return prometheusLabelReplaceRE.ReplaceAllString(name, "_")
+}
+
+var panicHandler = log.Fatalf
+
+func testingSetPanicHandler(h func(ctx context.Context, msg string, args ...interface{})) func() {
+	panicHandler = h
+	return func() { panicHandler = log.Fatalf }
+}
+
+// checkFieldCanBeSkipped detects common mis-use patterns with metrics registry
+// when running under test.
+func checkFieldCanBeSkipped(
+	skipReason, fieldName string, fieldType reflect.Type, parentType reflect.Type,
+) {
+	if !buildutil.CrdbTestBuild {
+		if log.V(2) {
+			log.Infof(context.Background(), "skipping %s field %s", skipReason, fieldName)
+		}
+		return
+	}
+
+	qualifiedFieldName := func() string {
+		if parentType == nil {
+			return fieldName
+		}
+		parentName := parentType.Name()
+		if parentName == "" {
+			parentName = "<unnamed>"
+		}
+		return fmt.Sprintf("%s.%s", parentName, fieldName)
+	}()
+
+	if isMetricType(fieldType) {
+		panicHandler(context.Background(),
+			"metric field %s (or any of embedded metrics) must be exported", qualifiedFieldName)
+	}
+
+	switch fieldType.Kind() {
+	case reflect.Slice:
+		if isMetricType(fieldType.Elem()) {
+			panicHandler(context.Background(),
+				"expected array, found slice instead for field %s (%s)", qualifiedFieldName, fieldType)
+		}
+	case reflect.Array:
+		checkFieldCanBeSkipped(skipReason, fieldName, fieldType.Elem(), parentType)
+	case reflect.Struct:
+		containsMetrics := false
+		for i := 0; i < fieldType.NumField() && !containsMetrics; i++ {
+			containsMetrics = containsMetricType(fieldType.Field(i).Type)
+		}
+
+		if containsMetrics {
+			// Embedded struct contains metrics.  Make sure the struct implements
+			// metric.Struct interface.
+			_, isStruct := reflect.New(fieldType).Interface().(Struct)
+			if !isStruct {
+				panicHandler(context.Background(),
+					"embedded struct field %s (%s) does not implement metric.Struct interface", qualifiedFieldName, fieldType)
+			}
+		}
+	}
+}
+
+// isMetricType returns true if the type is one of the metric type interfaces.
+func isMetricType(ft reflect.Type) bool {
+	v := reflect.Zero(ft)
+	if !v.CanInterface() {
+		return false
+	}
+
+	switch v.Interface().(type) {
+	case Iterable, Struct:
+		return true
+	default:
+		return false
+	}
+}
+
+// containsMetricTypes returns true if the type or any types inside aggregate
+// type (array, struct, etc) is metric type.
+func containsMetricType(ft reflect.Type) bool {
+	if isMetricType(ft) {
+		return true
+	}
+
+	switch ft.Kind() {
+	case reflect.Slice, reflect.Array:
+		return containsMetricType(ft.Elem())
+	case reflect.Struct:
+		for i := 0; i < ft.NumField(); i++ {
+			if containsMetricType(ft.Field(i).Type) {
+				return true
+			}
+		}
+		return false
+	default:
+		return false
+	}
 }

--- a/pkg/util/metric/registry_test.go
+++ b/pkg/util/metric/registry_test.go
@@ -11,8 +11,13 @@
 package metric
 
 import (
+	"context"
+	"fmt"
 	"testing"
 	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
+	"github.com/stretchr/testify/require"
 )
 
 func (r *Registry) findMetricByName(name string) Iterable {
@@ -94,12 +99,7 @@ func TestRegistry(t *testing.T) {
 		// Ensure that nil struct values in arrays are safe.
 		NestedStructArray [2]*NestedStruct
 		// A few extra ones: either not exported, or not metric objects.
-		privateStructGauge            *Gauge
-		privateStructGauge64          *GaugeFloat64
-		privateStructCounter          *Counter
-		privateStructHistogram        IHistogram
-		privateNestedStructGauge      NestedStruct
-		privateArrayStructCounters    [2]*Counter
+		privateInt                    int
 		NotAMetric                    int
 		AlsoNotAMetric                string
 		ReallyNotAMetric              *Registry
@@ -128,22 +128,6 @@ func TestRegistry(t *testing.T) {
 			1: {
 				NestedStructGauge: NewGauge(Metadata{Name: "nested.struct.array.1.gauge"}),
 			},
-		},
-		privateStructGauge:   NewGauge(Metadata{Name: "private.struct.gauge"}),
-		privateStructGauge64: NewGaugeFloat64(Metadata{Name: "private.struct.gauge64"}),
-		privateStructCounter: NewCounter(Metadata{Name: "private.struct.counter"}),
-		privateStructHistogram: NewHistogram(HistogramOptions{
-			Mode:         HistogramModePrometheus,
-			Metadata:     Metadata{Name: "private.struct.histogram"},
-			Duration:     time.Minute,
-			BucketConfig: Count1KBuckets,
-		}),
-		privateNestedStructGauge: NestedStruct{
-			NestedStructGauge: NewGauge(Metadata{Name: "private.nested.struct.gauge"}),
-		},
-		privateArrayStructCounters: [...]*Counter{
-			NewCounter(Metadata{Name: "private.array.struct.counter.0"}),
-			NewCounter(Metadata{Name: "private.array.struct.counter.1"}),
 		},
 		NotAMetric:                    0,
 		AlsoNotAMetric:                "foo",
@@ -218,4 +202,108 @@ func TestRegistry(t *testing.T) {
 	if c := r.getCounter("top.histogram"); c != nil {
 		t.Errorf("getCounter returned non-nil %v of type %T when requesting non-counter, expected nil", c, c)
 	}
+}
+
+type embedMetricStruct struct {
+	ExportedCounter *Counter
+}
+
+func (embedMetricStruct) MetricStruct() {}
+
+func TestRegistryPanicsWhenAddingUnexportedMetrics(t *testing.T) {
+	if !buildutil.CrdbTestBuild {
+		t.Logf("skipping test; crdb_test build tag must be set for this test")
+		return
+	}
+
+	defer testingSetPanicHandler(func(ctx context.Context, msg string, args ...interface{}) {
+		panic(fmt.Sprintf(msg, args...))
+	})()
+
+	r := NewRegistry()
+
+	// empty struct -- strange, but okay.
+	r.AddMetricStruct(struct{}{})
+
+	// Unexported, non-metrics fields are fine.
+	r.AddMetricStruct(struct{ unexportedInt int }{0})
+
+	g := NewGauge(Metadata{Name: "private.struct.gauge"})
+	c := NewCounter(Metadata{Name: "private.struct.counter"})
+
+	const unnamedStructName = "<unnamed>"
+	unexportedErr := func(parentName, fieldName string) string {
+
+		return fmt.Sprintf("metric field %s.%s (or any of embedded metrics) must be exported", parentName, fieldName)
+	}
+
+	// Panics when struct has unexported gauge.
+	require.PanicsWithValue(t,
+		unexportedErr(unnamedStructName, "unexportedGauge"),
+		func() {
+			r.AddMetricStruct(struct{ unexportedGauge *Gauge }{g})
+		},
+	)
+
+	// Panics when we have a mix of exported and unexported metrics.
+	require.PanicsWithValue(t,
+		unexportedErr(unnamedStructName, "unexportedCounter"),
+		func() {
+			r.AddMetricStruct(struct {
+				ExportedGauge     *Gauge
+				unexportedCounter *Counter
+			}{g, c})
+		},
+	)
+
+	// Metric slice is a bug since registry only supports arrays.
+	require.PanicsWithValue(t,
+		"expected array, found slice instead for field <unnamed>.unexportedGaugeSlice ([]*metric.Gauge)",
+		func() {
+			r.AddMetricStruct(struct {
+				ExportedArray        [1]*Counter
+				unexportedGaugeSlice []*Gauge
+			}{[1]*Counter{c}, []*Gauge{g}})
+		},
+	)
+
+	// Panics when embedded struct is unexported.
+	require.PanicsWithValue(t,
+		unexportedErr(unnamedStructName, "embedMetricStruct"),
+		func() {
+			r.AddMetricStruct(struct {
+				ExportedArray [1]*Counter
+				embedMetricStruct
+			}{
+				ExportedArray: [1]*Counter{c},
+				embedMetricStruct: embedMetricStruct{
+					ExportedCounter: c,
+				},
+			})
+		},
+	)
+
+	// Even though we can't directly embed embedMetricStruct (since it's unexported), we can
+	// still use it as exported field since struct implements metric.Struct.
+	r.AddMetricStruct(struct{ Embed embedMetricStruct }{Embed: embedMetricStruct{ExportedCounter: c}})
+
+	type EmbedBroken struct {
+		ExportedCounter *Counter
+	}
+
+	// Panics when embedded struct with metrics did not implement metric.Struct.
+	require.PanicsWithValue(t,
+		"embedded struct field <unnamed>.EmbedBroken (metric.EmbedBroken) does not implement metric.Struct interface",
+		func() {
+			r.AddMetricStruct(struct {
+				ExportedArray [1]*Counter
+				EmbedBroken
+			}{
+				ExportedArray: [1]*Counter{c},
+				EmbedBroken: EmbedBroken{
+					ExportedCounter: c,
+				},
+			})
+		},
+	)
 }


### PR DESCRIPTION
Every exported metric must be registered with metrics registry.

It is very easy to make silly mistakes when doing so (for example, by having an unexported field in the struct, or forgetting to implement `metric.Struct` interface).

See #107384 where the newly introduced struct
`DistsenderRangeFeedMetrics` did not implement `metric.Struct` interface.

In addition, the recently deprecated `chart_catalog_test.go` removed the only remaining sanity check.  Thus, mistakes in metrics registration are easy to make and very easy to remain undetected.

This PR ensures that registered metrics are sane.  The sanity checking happens only when running under test, and if any violations are detected, the process panics.

Epic: None
Issue: None

Release note: None