### PR TITLE
kvserver: pass Desc and SpanConf through allocator

### DIFF
--- a/pkg/kv/kvserver/allocator/allocatorimpl/allocator_test.go
+++ b/pkg/kv/kvserver/allocator/allocatorimpl/allocator_test.go
@@ -1967,6 +1967,7 @@ func TestAllocatorTransferLeaseTarget(t *testing.T) {
 			target := a.TransferLeaseTarget(
 				ctx,
 				sp,
+				&roachpb.RangeDescriptor{},
 				emptySpanConfig(),
 				c.existing,
 				&mockRepl{
@@ -2096,6 +2097,7 @@ func TestAllocatorTransferLeaseTargetIOOverloadCheck(t *testing.T) {
 			target := a.TransferLeaseTarget(
 				ctx,
 				sp,
+				&roachpb.RangeDescriptor{},
 				emptySpanConfig(),
 				existing,
 				&mockRepl{
@@ -2211,6 +2213,7 @@ func TestAllocatorTransferLeaseToReplicasNeedingSnapshot(t *testing.T) {
 			target := a.TransferLeaseTarget(
 				ctx,
 				sp,
+				&roachpb.RangeDescriptor{},
 				emptySpanConfig(),
 				c.existing,
 				repl,
@@ -2303,6 +2306,7 @@ func TestAllocatorTransferLeaseTargetConstraints(t *testing.T) {
 			target := a.TransferLeaseTarget(
 				context.Background(),
 				sp,
+				&roachpb.RangeDescriptor{},
 				c.conf,
 				c.existing,
 				&mockRepl{
@@ -2415,6 +2419,7 @@ func TestAllocatorTransferLeaseTargetDraining(t *testing.T) {
 			target := a.TransferLeaseTarget(
 				ctx,
 				storePool,
+				&roachpb.RangeDescriptor{},
 				c.conf,
 				c.existing,
 				&mockRepl{
@@ -2699,6 +2704,7 @@ func TestAllocatorShouldTransferLease(t *testing.T) {
 			result := a.ShouldTransferLease(
 				ctx,
 				sp,
+				&roachpb.RangeDescriptor{},
 				emptySpanConfig(),
 				c.existing,
 				&mockRepl{
@@ -2767,6 +2773,7 @@ func TestAllocatorShouldTransferLeaseDraining(t *testing.T) {
 			result := a.ShouldTransferLease(
 				ctx,
 				storePool,
+				&roachpb.RangeDescriptor{},
 				emptySpanConfig(),
 				c.existing,
 				&mockRepl{
@@ -2814,6 +2821,7 @@ func TestAllocatorShouldTransferSuspected(t *testing.T) {
 		result := a.ShouldTransferLease(
 			ctx,
 			storePool,
+			&roachpb.RangeDescriptor{},
 			emptySpanConfig(),
 			replicas(1, 2, 3),
 			&mockRepl{storeID: 2, replicationFactor: 3},
@@ -2955,6 +2963,7 @@ func TestAllocatorLeasePreferences(t *testing.T) {
 			result := a.ShouldTransferLease(
 				ctx,
 				sp,
+				&roachpb.RangeDescriptor{},
 				conf,
 				c.existing,
 				&mockRepl{
@@ -2970,6 +2979,7 @@ func TestAllocatorLeasePreferences(t *testing.T) {
 			target := a.TransferLeaseTarget(
 				ctx,
 				sp,
+				&roachpb.RangeDescriptor{},
 				conf,
 				c.existing,
 				&mockRepl{
@@ -2989,6 +2999,7 @@ func TestAllocatorLeasePreferences(t *testing.T) {
 			target = a.TransferLeaseTarget(
 				ctx,
 				sp,
+				&roachpb.RangeDescriptor{},
 				conf,
 				c.existing,
 				&mockRepl{
@@ -3082,6 +3093,7 @@ func TestAllocatorLeasePreferencesMultipleStoresPerLocality(t *testing.T) {
 			target := a.TransferLeaseTarget(
 				ctx,
 				sp,
+				&roachpb.RangeDescriptor{},
 				conf,
 				c.existing,
 				&mockRepl{
@@ -3102,6 +3114,7 @@ func TestAllocatorLeasePreferencesMultipleStoresPerLocality(t *testing.T) {
 			target = a.TransferLeaseTarget(
 				ctx,
 				sp,
+				&roachpb.RangeDescriptor{},
 				conf,
 				c.existing,
 				&mockRepl{
@@ -5732,6 +5745,7 @@ func TestAllocatorTransferLeaseTargetLoadBased(t *testing.T) {
 			target := a.TransferLeaseTarget(
 				ctx,
 				storePool,
+				&roachpb.RangeDescriptor{},
 				emptySpanConfig(),
 				existing,
 				&mockRepl{

--- a/pkg/kv/kvserver/allocator/base.go
+++ b/pkg/kv/kvserver/allocator/base.go
@@ -91,10 +91,10 @@ type TestingKnobs struct {
 	// targets produced by the Allocator to include replicas that may be waiting
 	// for snapshots.
 	AllowLeaseTransfersToReplicasNeedingSnapshots bool
-	RaftStatusFn                                  func(r interface {
-		Desc() *roachpb.RangeDescriptor
-		StoreID() roachpb.StoreID
-	}) *raft.Status
+	RaftStatusFn                                  func(
+		desc *roachpb.RangeDescriptor,
+		storeID roachpb.StoreID,
+	) *raft.Status
 	// BlockTransferTarget can be used to block returning any transfer targets
 	// from TransferLeaseTarget.
 	BlockTransferTarget func() bool

--- a/pkg/kv/kvserver/allocator/plan/replicate.go
+++ b/pkg/kv/kvserver/allocator/plan/replicate.go
@@ -60,6 +60,8 @@ type ReplicationPlanner interface {
 		ctx context.Context,
 		now hlc.ClockTimestamp,
 		repl AllocatorReplica,
+		desc *roachpb.RangeDescriptor,
+		conf roachpb.SpanConfig,
 		canTransferLeaseFrom CanTransferLeaseFrom,
 	) (bool, float64)
 	// PlanOneChange calls the allocator to determine an action to be taken upon a
@@ -68,6 +70,8 @@ type ReplicationPlanner interface {
 	PlanOneChange(
 		ctx context.Context,
 		repl AllocatorReplica,
+		desc *roachpb.RangeDescriptor,
+		conf roachpb.SpanConfig,
 		canTransferLeaseFrom CanTransferLeaseFrom,
 		scatter bool,
 	) (ReplicateChange, error)
@@ -78,6 +82,7 @@ type ReplicationPlanner interface {
 type CanTransferLeaseFrom func(
 	ctx context.Context,
 	repl LeaseCheckReplica,
+	conf roachpb.SpanConfig,
 ) bool
 
 // LeaseCheckReplica contains methods that may be used to check a replica's
@@ -85,7 +90,7 @@ type CanTransferLeaseFrom func(
 type LeaseCheckReplica interface {
 	HasCorrectLeaseType(lease roachpb.Lease) bool
 	LeaseStatusAt(ctx context.Context, now hlc.ClockTimestamp) kvserverpb.LeaseStatus
-	LeaseViolatesPreferences(context.Context) bool
+	LeaseViolatesPreferences(context.Context, roachpb.SpanConfig) bool
 	OwnsValidLease(context.Context, hlc.ClockTimestamp) bool
 }
 
@@ -98,8 +103,6 @@ type AllocatorReplica interface {
 	GetFirstIndex() kvpb.RaftIndex
 	LastReplicaAdded() (roachpb.ReplicaID, time.Time)
 	StoreID() roachpb.StoreID
-	DescAndSpanConfig() (*roachpb.RangeDescriptor, roachpb.SpanConfig)
-	Desc() *roachpb.RangeDescriptor
 	GetRangeID() roachpb.RangeID
 }
 
@@ -141,9 +144,10 @@ func (rp ReplicaPlanner) ShouldPlanChange(
 	ctx context.Context,
 	now hlc.ClockTimestamp,
 	repl AllocatorReplica,
+	desc *roachpb.RangeDescriptor,
+	conf roachpb.SpanConfig,
 	canTransferLeaseFrom CanTransferLeaseFrom,
 ) (shouldPlanChange bool, priority float64) {
-	desc, conf := repl.DescAndSpanConfig()
 
 	log.KvDistribution.VEventf(ctx, 6,
 		"computing range action desc=%s config=%s",
@@ -197,10 +201,11 @@ func (rp ReplicaPlanner) ShouldPlanChange(
 	}
 
 	// If the lease is valid, check to see if we should transfer it.
-	if canTransferLeaseFrom(ctx, repl) &&
+	if canTransferLeaseFrom(ctx, repl, conf) &&
 		rp.allocator.ShouldTransferLease(
 			ctx,
 			rp.storePool,
+			desc,
 			conf,
 			voterReplicas,
 			repl,
@@ -235,6 +240,8 @@ func (rp ReplicaPlanner) ShouldPlanChange(
 func (rp ReplicaPlanner) PlanOneChange(
 	ctx context.Context,
 	repl AllocatorReplica,
+	desc *roachpb.RangeDescriptor,
+	conf roachpb.SpanConfig,
 	canTransferLeaseFrom CanTransferLeaseFrom,
 	scatter bool,
 ) (change ReplicateChange, _ error) {
@@ -245,14 +252,6 @@ func (rp ReplicaPlanner) PlanOneChange(
 		Op:      AllocationNoop{},
 		Replica: repl,
 	}
-	// TODO(aayush): The fact that we're calling `repl.DescAndZone()` here once to
-	// pass to `ComputeAction()` to use for deciding which action to take to
-	// repair a range, and then calling it again inside methods like
-	// `addOrReplace{Non}Voters()` or `remove{Dead,Decommissioning}` to execute
-	// upon that decision is a bit unfortunate. It means that we could
-	// successfully execute a decision that was based on the state of a stale
-	// range descriptor.
-	desc, conf := repl.DescAndSpanConfig()
 	log.KvDistribution.VEventf(ctx, 6,
 		"planning range change desc=%s config=%s",
 		desc, conf.String())
@@ -299,12 +298,12 @@ func (rp ReplicaPlanner) PlanOneChange(
 		switch action.TargetReplicaType() {
 		case allocatorimpl.VoterTarget:
 			op, stats, err = rp.addOrReplaceVoters(
-				ctx, repl, existing, remainingLiveVoters, remainingLiveNonVoters,
+				ctx, repl, desc, conf, existing, remainingLiveVoters, remainingLiveNonVoters,
 				removeIdx, action.ReplicaStatus(), allocatorPrio,
 			)
 		case allocatorimpl.NonVoterTarget:
 			op, stats, err = rp.addOrReplaceNonVoters(
-				ctx, repl, existing, remainingLiveVoters, remainingLiveNonVoters,
+				ctx, repl, desc, conf, existing, remainingLiveVoters, remainingLiveNonVoters,
 				removeIdx, action.ReplicaStatus(), allocatorPrio,
 			)
 		default:
@@ -313,9 +312,9 @@ func (rp ReplicaPlanner) PlanOneChange(
 
 	// Remove replicas.
 	case allocatorimpl.AllocatorRemoveVoter:
-		op, stats, err = rp.removeVoter(ctx, repl, voterReplicas, nonVoterReplicas)
+		op, stats, err = rp.removeVoter(ctx, repl, desc, conf, voterReplicas, nonVoterReplicas)
 	case allocatorimpl.AllocatorRemoveNonVoter:
-		op, stats, err = rp.removeNonVoter(ctx, repl, voterReplicas, nonVoterReplicas)
+		op, stats, err = rp.removeNonVoter(ctx, repl, desc, conf, voterReplicas, nonVoterReplicas)
 
 	// Remove decommissioning replicas.
 	//
@@ -323,9 +322,9 @@ func (rp ReplicaPlanner) PlanOneChange(
 	// has decommissioning replicas; in the common case we'll hit
 	// AllocatorReplaceDecommissioning{Non}Voter above.
 	case allocatorimpl.AllocatorRemoveDecommissioningVoter:
-		op, stats, err = rp.removeDecommissioning(ctx, repl, allocatorimpl.VoterTarget)
+		op, stats, err = rp.removeDecommissioning(ctx, repl, desc, conf, allocatorimpl.VoterTarget)
 	case allocatorimpl.AllocatorRemoveDecommissioningNonVoter:
-		op, stats, err = rp.removeDecommissioning(ctx, repl, allocatorimpl.NonVoterTarget)
+		op, stats, err = rp.removeDecommissioning(ctx, repl, desc, conf, allocatorimpl.NonVoterTarget)
 
 	// Remove dead replicas.
 	//
@@ -348,6 +347,8 @@ func (rp ReplicaPlanner) PlanOneChange(
 		op, stats, err = rp.considerRebalance(
 			ctx,
 			repl,
+			desc,
+			conf,
 			voterReplicas,
 			nonVoterReplicas,
 			allocatorPrio,
@@ -385,13 +386,14 @@ func (rp ReplicaPlanner) PlanOneChange(
 func (rp ReplicaPlanner) addOrReplaceVoters(
 	ctx context.Context,
 	repl AllocatorReplica,
+	desc *roachpb.RangeDescriptor,
+	conf roachpb.SpanConfig,
 	existingVoters []roachpb.ReplicaDescriptor,
 	remainingLiveVoters, remainingLiveNonVoters []roachpb.ReplicaDescriptor,
 	removeIdx int,
 	replicaStatus allocatorimpl.ReplicaStatus,
 	allocatorPriority float64,
 ) (op AllocationOp, stats ReplicateStats, _ error) {
-	desc, conf := repl.DescAndSpanConfig()
 	var replacing *roachpb.ReplicaDescriptor
 	if removeIdx >= 0 {
 		replacing = &existingVoters[removeIdx]
@@ -481,13 +483,14 @@ func (rp ReplicaPlanner) addOrReplaceVoters(
 func (rp ReplicaPlanner) addOrReplaceNonVoters(
 	ctx context.Context,
 	repl AllocatorReplica,
+	_ *roachpb.RangeDescriptor,
+	conf roachpb.SpanConfig,
 	existingNonVoters []roachpb.ReplicaDescriptor,
 	liveVoterReplicas, liveNonVoterReplicas []roachpb.ReplicaDescriptor,
 	removeIdx int,
 	replicaStatus allocatorimpl.ReplicaStatus,
 	allocatorPrio float64,
 ) (op AllocationOp, stats ReplicateStats, _ error) {
-	_, conf := repl.DescAndSpanConfig()
 	var replacing *roachpb.ReplicaDescriptor
 	if removeIdx >= 0 {
 		replacing = &existingNonVoters[removeIdx]
@@ -538,13 +541,12 @@ func (rp ReplicaPlanner) addOrReplaceNonVoters(
 func (rp ReplicaPlanner) findRemoveVoter(
 	ctx context.Context,
 	repl interface {
-		DescAndSpanConfig() (*roachpb.RangeDescriptor, roachpb.SpanConfig)
 		LastReplicaAdded() (roachpb.ReplicaID, time.Time)
 		RaftStatus() *raft.Status
 	},
+	conf roachpb.SpanConfig,
 	existingVoters, existingNonVoters []roachpb.ReplicaDescriptor,
 ) (roachpb.ReplicationTarget, string, error) {
-	_, zone := repl.DescAndSpanConfig()
 	// This retry loop involves quick operations on local state, so a
 	// small MaxBackoff is good (but those local variables change on
 	// network time scales as raft receives responses).
@@ -612,7 +614,7 @@ func (rp ReplicaPlanner) findRemoveVoter(
 	return rp.allocator.RemoveVoter(
 		ctx,
 		rp.storePool,
-		zone,
+		conf,
 		candidates,
 		existingVoters,
 		existingNonVoters,
@@ -623,15 +625,17 @@ func (rp ReplicaPlanner) findRemoveVoter(
 func (rp ReplicaPlanner) removeVoter(
 	ctx context.Context,
 	repl AllocatorReplica,
+	desc *roachpb.RangeDescriptor,
+	conf roachpb.SpanConfig,
 	existingVoters, existingNonVoters []roachpb.ReplicaDescriptor,
 ) (op AllocationOp, stats ReplicateStats, _ error) {
-	removeVoter, details, err := rp.findRemoveVoter(ctx, repl, existingVoters, existingNonVoters)
+	removeVoter, details, err := rp.findRemoveVoter(ctx, repl, conf, existingVoters, existingNonVoters)
 	if err != nil {
 		return nil, stats, err
 	}
 
 	transferOp, err := rp.maybeTransferLeaseAwayTarget(
-		ctx, repl, removeVoter.StoreID, nil /* canTransferLeaseFrom */)
+		ctx, repl, desc, conf, removeVoter.StoreID, nil /* canTransferLeaseFrom */)
 	if err != nil {
 		return nil, stats, err
 	}
@@ -664,9 +668,10 @@ func (rp ReplicaPlanner) removeVoter(
 func (rp ReplicaPlanner) removeNonVoter(
 	ctx context.Context,
 	repl AllocatorReplica,
+	_ *roachpb.RangeDescriptor,
+	conf roachpb.SpanConfig,
 	existingVoters, existingNonVoters []roachpb.ReplicaDescriptor,
 ) (op AllocationOp, stats ReplicateStats, _ error) {
-	_, conf := repl.DescAndSpanConfig()
 	removeNonVoter, details, err := rp.allocator.RemoveNonVoter(
 		ctx,
 		rp.storePool,
@@ -701,9 +706,12 @@ func (rp ReplicaPlanner) removeNonVoter(
 }
 
 func (rp ReplicaPlanner) removeDecommissioning(
-	ctx context.Context, repl AllocatorReplica, targetType allocatorimpl.TargetReplicaType,
+	ctx context.Context,
+	repl AllocatorReplica,
+	desc *roachpb.RangeDescriptor,
+	conf roachpb.SpanConfig,
+	targetType allocatorimpl.TargetReplicaType,
 ) (op AllocationOp, stats ReplicateStats, _ error) {
-	desc, _ := repl.DescAndSpanConfig()
 	var decommissioningReplicas []roachpb.ReplicaDescriptor
 	switch targetType {
 	case allocatorimpl.VoterTarget:
@@ -725,7 +733,7 @@ func (rp ReplicaPlanner) removeDecommissioning(
 	decommissioningReplica := decommissioningReplicas[0]
 
 	transferOp, err := rp.maybeTransferLeaseAwayTarget(
-		ctx, repl, decommissioningReplica.StoreID, nil /* canTransferLeaseFrom */)
+		ctx, repl, desc, conf, decommissioningReplica.StoreID, nil /* canTransferLeaseFrom */)
 	if err != nil {
 		return nil, stats, err
 	}
@@ -796,6 +804,8 @@ func (rp ReplicaPlanner) removeDead(
 func (rp ReplicaPlanner) considerRebalance(
 	ctx context.Context,
 	repl AllocatorReplica,
+	desc *roachpb.RangeDescriptor,
+	conf roachpb.SpanConfig,
 	existingVoters, existingNonVoters []roachpb.ReplicaDescriptor,
 	allocatorPrio float64,
 	canTransferLeaseFrom CanTransferLeaseFrom,
@@ -806,7 +816,6 @@ func (rp ReplicaPlanner) considerRebalance(
 		return nil, stats, nil
 	}
 
-	desc, conf := repl.DescAndSpanConfig()
 	rebalanceTargetType := allocatorimpl.VoterTarget
 
 	scorerOpts := allocatorimpl.ScorerOptions(rp.allocator.ScorerOptions(ctx))
@@ -851,7 +860,7 @@ func (rp ReplicaPlanner) considerRebalance(
 		log.KvDistribution.VInfof(ctx, 2, "no suitable rebalance target for non-voters")
 	} else if !lhRemovalAllowed {
 		if transferOp, err := rp.maybeTransferLeaseAwayTarget(
-			ctx, repl, removeTarget.StoreID, canTransferLeaseFrom,
+			ctx, repl, desc, conf, removeTarget.StoreID, canTransferLeaseFrom,
 		); err != nil {
 			// No transfer possible.
 			ok = false
@@ -865,7 +874,7 @@ func (rp ReplicaPlanner) considerRebalance(
 	// No rebalance target was found, check whether we are able and should
 	// transfer the lease away to another store.
 	if !ok {
-		if !canTransferLeaseFrom(ctx, repl) {
+		if !canTransferLeaseFrom(ctx, repl, conf) {
 			return nil, stats, nil
 		}
 		var err error
@@ -945,6 +954,7 @@ func (rp ReplicaPlanner) shedLeaseTarget(
 	target := rp.allocator.TransferLeaseTarget(
 		ctx,
 		rp.storePool,
+		desc,
 		conf,
 		existingVoters,
 		repl,
@@ -964,7 +974,7 @@ func (rp ReplicaPlanner) shedLeaseTarget(
 			existingVoters, false /* includeSuspectAndDrainingStores */)
 		preferred := rp.allocator.PreferredLeaseholders(rp.storePool, conf, liveVoters)
 		if len(preferred) > 0 &&
-			repl.LeaseViolatesPreferences(ctx) {
+			repl.LeaseViolatesPreferences(ctx, conf) {
 			return nil, CantTransferLeaseViolatingPreferencesError{RangeID: desc.RangeID}
 		}
 		return nil, nil
@@ -991,16 +1001,17 @@ func (rp ReplicaPlanner) shedLeaseTarget(
 func (rp ReplicaPlanner) maybeTransferLeaseAwayTarget(
 	ctx context.Context,
 	repl AllocatorReplica,
+	desc *roachpb.RangeDescriptor,
+	conf roachpb.SpanConfig,
 	removeStoreID roachpb.StoreID,
 	canTransferLeaseFrom CanTransferLeaseFrom,
 ) (op AllocationOp, _ error) {
 	if removeStoreID != repl.StoreID() {
 		return nil, nil
 	}
-	if canTransferLeaseFrom != nil && !canTransferLeaseFrom(ctx, repl) {
+	if canTransferLeaseFrom != nil && !canTransferLeaseFrom(ctx, repl, conf) {
 		return nil, errors.Errorf("cannot transfer lease")
 	}
-	desc, conf := repl.DescAndSpanConfig()
 	usageInfo := repl.RangeUsageInfo()
 	// The local replica was selected as the removal target, but that replica
 	// is the leaseholder, so transfer the lease instead. We don't check that
@@ -1015,6 +1026,7 @@ func (rp ReplicaPlanner) maybeTransferLeaseAwayTarget(
 	target := rp.allocator.TransferLeaseTarget(
 		ctx,
 		rp.storePool,
+		desc,
 		conf,
 		desc.Replicas().VoterDescriptors(),
 		repl,

--- a/pkg/kv/kvserver/asim/queue/allocator_replica.go
+++ b/pkg/kv/kvserver/asim/queue/allocator_replica.go
@@ -84,13 +84,14 @@ func (sr *SimulatorReplica) LeaseStatusAt(
 // violates the lease preferences defined in the span config. If there is an
 // error or no preferences defined then it will return false and consider that
 // to be in-conformance.
-func (sr *SimulatorReplica) LeaseViolatesPreferences(context.Context) bool {
+func (sr *SimulatorReplica) LeaseViolatesPreferences(
+	_ context.Context, conf roachpb.SpanConfig,
+) bool {
 	descs := sr.state.StoreDescriptors(true /* useCached */, sr.repl.StoreID())
 	if len(descs) != 1 {
 		panic(fmt.Sprintf("programming error: cannot get  store descriptor for store %d", sr.repl.StoreID()))
 	}
 	storeDesc := descs[0]
-	_, conf := sr.DescAndSpanConfig()
 
 	if len(conf.LeasePreferences) == 0 {
 		return false
@@ -146,10 +147,8 @@ func (sr *SimulatorReplica) GetFirstIndex() kvpb.RaftIndex {
 	return 2
 }
 
-// DescAndSpanConfig returns the authoritative range descriptor as well
-// as the span config for the replica.
-func (sr *SimulatorReplica) DescAndSpanConfig() (*roachpb.RangeDescriptor, roachpb.SpanConfig) {
-	return sr.rng.Descriptor(), sr.rng.SpanConfig()
+func (sr *SimulatorReplica) SpanConfig() (roachpb.SpanConfig, error) {
+	return sr.rng.SpanConfig(), nil
 }
 
 // Desc returns the authoritative range descriptor, acquiring a replica lock in

--- a/pkg/kv/kvserver/replica_range_lease.go
+++ b/pkg/kv/kvserver/replica_range_lease.go
@@ -1571,13 +1571,10 @@ const (
 // LeaseViolatesPreferences checks if this replica owns the lease and if it
 // violates the lease preferences defined in the span config. If no preferences
 // are defined then it will return false and consider it to be in conformance.
-func (r *Replica) LeaseViolatesPreferences(ctx context.Context) bool {
+func (r *Replica) LeaseViolatesPreferences(ctx context.Context, conf roachpb.SpanConfig) bool {
 	storeID := r.store.StoreID()
-	now := r.Clock().NowAsClockTimestamp()
-	r.mu.RLock()
-	preferences := r.mu.conf.LeasePreferences
-	leaseStatus := r.leaseStatusAtRLocked(ctx, now)
-	r.mu.RUnlock()
+	preferences := conf.LeasePreferences
+	leaseStatus := r.CurrentLeaseStatus(ctx)
 
 	if !leaseStatus.IsValid() || !leaseStatus.Lease.OwnedBy(storeID) {
 		// We can't determine if the lease preferences are being conformed to or

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -13433,7 +13433,9 @@ func TestReplicateQueueProcessOne(t *testing.T) {
 	requeue, err := tc.store.replicateQueue.processOneChange(
 		ctx,
 		tc.repl,
-		func(ctx context.Context, repl plan.LeaseCheckReplica) bool { return false },
+		tc.repl.Desc(),
+		tc.repl.SpanConfig(),
+		func(ctx context.Context, repl plan.LeaseCheckReplica, conf roachpb.SpanConfig) bool { return false },
 		false, /* scatter */
 		true,  /* dryRun */
 	)

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -3410,11 +3410,13 @@ func (s *Store) ReplicateQueueDryRun(
 		s.cfg.AmbientCtx.Tracer, "replicate queue dry run",
 	)
 	defer collectAndFinish()
-	canTransferLease := func(ctx context.Context, repl plan.LeaseCheckReplica) bool {
+	canTransferLease := func(ctx context.Context, repl plan.LeaseCheckReplica, conf roachpb.SpanConfig) bool {
 		return true
 	}
+	desc := repl.Desc()
+	conf := repl.SpanConfig()
 	_, err := s.replicateQueue.processOneChange(
-		ctx, repl, canTransferLease, false /* scatter */, true, /* dryRun */
+		ctx, repl, desc, conf, canTransferLease, false /* scatter */, true, /* dryRun */
 	)
 	if err != nil {
 		log.Eventf(ctx, "error simulating allocator on replica %s: %s", repl, err)

--- a/pkg/kv/kvserver/store_rebalancer.go
+++ b/pkg/kv/kvserver/store_rebalancer.go
@@ -758,6 +758,7 @@ func (sr *StoreRebalancer) chooseLeaseToTransfer(
 		candidate := sr.allocator.TransferLeaseTarget(
 			ctx,
 			sr.storePool,
+			desc,
 			conf,
 			candidates,
 			candidateReplica,
@@ -960,6 +961,7 @@ func (sr *StoreRebalancer) chooseRangeToRebalance(
 		validTargets := sr.allocator.ValidLeaseTargets(
 			ctx,
 			sr.storePool,
+			rebalanceCtx.rangeDesc,
 			rebalanceCtx.conf,
 			targetVoterRepls,
 			rebalanceCtx.candidateReplica,

--- a/pkg/kv/kvserver/store_rebalancer_test.go
+++ b/pkg/kv/kvserver/store_rebalancer_test.go
@@ -610,7 +610,7 @@ func TestChooseLeaseToTransfer(t *testing.T) {
 	// order to pass replicaIsBehind checks, fake out the function for getting
 	// raft status with one that always returns all replicas as up to date.
 	sr.getRaftStatusFn = func(r CandidateReplica) *raft.Status {
-		return TestingRaftStatusFn(r)
+		return TestingRaftStatusFn(r.Desc(), r.StoreID())
 	}
 
 	testCases := []struct {
@@ -907,7 +907,7 @@ func TestChooseRangeToRebalanceRandom(t *testing.T) {
 			// order to pass replicaIsBehind checks, fake out the function for getting
 			// raft status with one that always returns all replicas as up to date.
 			sr.getRaftStatusFn = func(r CandidateReplica) *raft.Status {
-				return TestingRaftStatusFn(r)
+				return TestingRaftStatusFn(r.Desc(), r.StoreID())
 			}
 			sp.OverrideIsStoreReadyForRoutineReplicaTransferFn = func(_ context.Context, this roachpb.StoreID) bool {
 				for _, deadStore := range deadStores {
@@ -1261,7 +1261,7 @@ func TestChooseRangeToRebalanceAcrossHeterogeneousZones(t *testing.T) {
 			// order to pass replicaIsBehind checks, fake out the function for getting
 			// raft status with one that always returns all replicas as up to date.
 			sr.getRaftStatusFn = func(r CandidateReplica) *raft.Status {
-				return TestingRaftStatusFn(r)
+				return TestingRaftStatusFn(r.Desc(), r.StoreID())
 			}
 			s.cfg.DefaultSpanConfig.NumVoters = int32(len(tc.voters))
 			s.cfg.DefaultSpanConfig.NumReplicas = int32(len(tc.voters) + len(tc.nonVoters))
@@ -1526,7 +1526,7 @@ func TestChooseRangeToRebalanceOffHotNodes(t *testing.T) {
 			// order to pass replicaIsBehind checks, fake out the function for getting
 			// raft status with one that always returns all replicas as up to date.
 			sr.getRaftStatusFn = func(r CandidateReplica) *raft.Status {
-				return TestingRaftStatusFn(r)
+				return TestingRaftStatusFn(r.Desc(), r.StoreID())
 			}
 
 			s.cfg.DefaultSpanConfig.NumReplicas = int32(len(tc.voters))
@@ -1563,21 +1563,19 @@ func TestNoLeaseTransferToBehindReplicas(t *testing.T) {
 	// Set up a fake RaftStatus that indicates s5 is behind (but all other stores
 	// are caught up). We thus shouldn't transfer a lease to s5.
 	behindTestingRaftStatusFn := func(
-		r interface {
-			Desc() *roachpb.RangeDescriptor
-			StoreID() roachpb.StoreID
-		},
+		desc *roachpb.RangeDescriptor,
+		storeID roachpb.StoreID,
 	) *raft.Status {
 		status := &raft.Status{
 			Progress: make(map[uint64]tracker.Progress),
 		}
-		replDesc, ok := r.Desc().GetReplicaDescriptor(r.StoreID())
-		require.True(t, ok, "Could not find replica descriptor for replica on store with id %d", r.StoreID())
+		replDesc, ok := desc.GetReplicaDescriptor(storeID)
+		require.True(t, ok, "Could not find replica descriptor for replica on store with id %d", storeID)
 
 		status.Lead = uint64(replDesc.ReplicaID)
 		status.RaftState = raft.StateLeader
 		status.Commit = 2
-		for _, replica := range r.Desc().InternalReplicas {
+		for _, replica := range desc.InternalReplicas {
 			match := uint64(2)
 			if replica.StoreID == roachpb.StoreID(5) {
 				match = 0
@@ -1618,7 +1616,7 @@ func TestNoLeaseTransferToBehindReplicas(t *testing.T) {
 
 		sr := NewStoreRebalancer(cfg.AmbientCtx, cfg.Settings, rq, rr, objectiveProvider)
 		sr.getRaftStatusFn = func(r CandidateReplica) *raft.Status {
-			return behindTestingRaftStatusFn(r)
+			return behindTestingRaftStatusFn(r.Desc(), r.StoreID())
 		}
 		lbRebalanceDimension := sr.RebalanceObjective().ToDimension()
 
@@ -1821,16 +1819,11 @@ func TestStoreRebalancerIOOverloadCheck(t *testing.T) {
 // TestingRaftStatusFn returns a raft status where all replicas are up to date and
 // the replica on the store with ID StoreID is the leader. It may be used for
 // testing.
-func TestingRaftStatusFn(
-	r interface {
-		Desc() *roachpb.RangeDescriptor
-		StoreID() roachpb.StoreID
-	},
-) *raft.Status {
+func TestingRaftStatusFn(desc *roachpb.RangeDescriptor, storeID roachpb.StoreID) *raft.Status {
 	status := &raft.Status{
 		Progress: make(map[uint64]tracker.Progress),
 	}
-	replDesc, ok := r.Desc().GetReplicaDescriptor(r.StoreID())
+	replDesc, ok := desc.GetReplicaDescriptor(storeID)
 	if !ok {
 		return status
 	}
@@ -1838,7 +1831,7 @@ func TestingRaftStatusFn(
 	status.Lead = uint64(replDesc.ReplicaID)
 	status.RaftState = raft.StateLeader
 	status.Commit = 2
-	for _, replica := range r.Desc().InternalReplicas {
+	for _, replica := range desc.InternalReplicas {
 		status.Progress[uint64(replica.ReplicaID)] = tracker.Progress{
 			Match: 2,
 			State: tracker.StateReplicate,


### PR DESCRIPTION
Previously the different layers of the allocator would load the Desc and
SpanConf as needed, this had a risk of them changing between various
loads and could cause strange and hard to track down races. Now they are
loaded once and passed through all the layers.

Epic: none

Release note: None