### PR TITLE
plpgsql: add support for ELSIF branches

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/udf_plpgsql
+++ b/pkg/sql/logictest/testdata/logic_test/udf_plpgsql
@@ -367,6 +367,21 @@ $$ LANGUAGE PLpgSQL;
 
 statement error pgcode 2F005 control reached end of function without RETURN
 CREATE OR REPLACE FUNCTION f(a INT, b INT) RETURNS INT AS $$
+  DECLARE
+    i INT;
+  BEGIN
+    IF a < b THEN
+      RETURN -1;
+    ELSIF a = b THEN
+      i := 0;
+    ELSE
+      RETURN 1;
+    END IF;
+  END
+$$ LANGUAGE PLpgSQL;
+
+statement error pgcode 2F005 control reached end of function without RETURN
+CREATE OR REPLACE FUNCTION f(a INT, b INT) RETURNS INT AS $$
   BEGIN
     LOOP
       EXIT;
@@ -709,6 +724,7 @@ CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$
   END
 $$ LANGUAGE PLpgSQL;
 
+# Testing CONSTANT variable declarations.
 statement ok
 CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$
   DECLARE
@@ -808,3 +824,147 @@ CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$
     RETURN i;
   END
 $$ LANGUAGE PLpgSQL;
+
+# Testing IF statements with ELSIF branches.
+statement ok
+CREATE OR REPLACE FUNCTION f(n INT) RETURNS INT AS $$
+  DECLARE
+    i INT := -1;
+  BEGIN
+    IF n = 0 THEN
+      RETURN 0;
+    ELSIF n = 1 THEN
+      i := 100;
+    ELSIF n = 2 THEN
+      i := 200;
+      RETURN i;
+    END IF;
+    RETURN i;
+  END
+$$ LANGUAGE PLpgSQL;
+
+query IIII
+SELECT f(0), f(1), f(2), f(100);
+----
+0  100  200  -1
+
+statement ok
+CREATE OR REPLACE FUNCTION f(a INT, b INT) RETURNS INT AS $$
+  DECLARE
+    i INT := 0;
+    foo INT := 0;
+  BEGIN
+    LOOP IF i >= a THEN EXIT; END IF;
+      IF b = 0 THEN
+        RETURN NULL;
+      ELSIF b = 1 THEN
+        foo := foo + 1;
+      ELSIF b = 2 THEN
+        RETURN 100;
+      ELSE
+        foo := foo + b;
+      END IF;
+      i := i + 1;
+    END LOOP;
+    RETURN foo;
+  END
+$$ LANGUAGE PLpgSQL;
+
+query IIIII
+SELECT f(0, 0), f(1, 0), f(1, 1), f(1, 2), f(1, 3);
+----
+0  NULL  1  100  3
+
+query IIII
+SELECT f(5, 0), f(5, 1), f(5, 2), f(5, 3);
+----
+NULL  5  100  15
+
+# Branches should only be executed if the previous ones fail.
+statement ok
+CREATE OR REPLACE FUNCTION f(n INT) RETURNS INT AS $$
+  BEGIN
+    IF n <= 0 THEN
+      RAISE NOTICE 'foo';
+    ELSIF n <= 1 THEN
+      RAISE NOTICE 'bar';
+    ELSIF n <= 2 THEN
+      RAISE NOTICE 'baz';
+    END IF;
+    RETURN 0;
+  END
+$$ LANGUAGE PLpgSQL;
+
+query T noticetrace
+SELECT f(0);
+----
+NOTICE: foo
+
+query T noticetrace
+SELECT f(1);
+----
+NOTICE: bar
+
+query T noticetrace
+SELECT f(2);
+----
+NOTICE: baz
+
+query I
+SELECT f(100);
+----
+0
+
+# Test nested IF/ELSIF/ELSE.
+statement ok
+CREATE OR REPLACE FUNCTION f(a INT, b INT) RETURNS INT AS $$
+  BEGIN
+    IF a > 1 THEN
+      IF b > 1 THEN
+        RETURN 0;
+      ELSIF b = 1 THEN
+        RETURN 1;
+      ELSIF b = 0 THEN
+        RETURN 2;
+      ELSE
+        RETURN 3;
+      END IF;
+    ELSIF a = 1 THEN
+      IF b > 1 THEN
+        RETURN 4;
+      ELSIF b = 1 THEN
+        RETURN 5;
+      ELSIF b = 0 THEN
+        RETURN 6;
+      ELSE
+        RETURN 7;
+      END IF;
+    ELSIF a = 0 THEN
+      IF b > 1 THEN
+        RETURN 8;
+      ELSIF b = 1 THEN
+        RETURN 9;
+      ELSIF b = 0 THEN
+        RETURN 10;
+      ELSE
+        RETURN 11;
+      END IF;
+    ELSE
+      IF b > 1 THEN
+        RETURN 12;
+      ELSIF b = 1 THEN
+        RETURN 13;
+      ELSIF b = 0 THEN
+        RETURN 14;
+      ELSE
+        RETURN 15;
+      END IF;
+    END IF;
+  END
+$$ LANGUAGE PLpgSQL;
+
+query IIIIIIIIIIIIIIII
+SELECT f(-1, -1), f(-1, 0), f(-1, 1), f(-1, 10), f(0, -1), f(0, 0), f(0, 1), f(0, 10),
+  f(1, -1), f(1, 0), f(1, 1), f(1, 10), f(10, -1), f(10, 0), f(10, 1), f(10, 10);
+----
+15  14  13  12  11  10  9  8  7  6  5  4  3  2  1  0

--- a/pkg/sql/opt/optbuilder/testdata/udf_plpgsql
+++ b/pkg/sql/opt/optbuilder/testdata/udf_plpgsql
@@ -3079,3 +3079,120 @@ project
                      │                        └── projections
                      │                             └── const: 0 [as=stmt_return_3:2]
                      └── const: 1
+
+# Testing IF statements with ELSIF branches.
+exec-ddl
+CREATE OR REPLACE FUNCTION f(n INT) RETURNS INT AS $$
+  DECLARE
+    i INT := -1;
+  BEGIN
+    IF n = 0 THEN
+      RETURN 0;
+    ELSIF n = 1 THEN
+      i := 100;
+    ELSIF n = 2 THEN
+      i := 200;
+      RETURN i;
+    END IF;
+    RETURN i;
+  END
+$$ LANGUAGE PLpgSQL;
+----
+
+build format=show-scalars
+SELECT f(0);
+----
+project
+ ├── columns: f:13
+ ├── values
+ │    └── tuple
+ └── projections
+      └── udf: f [as=f:13]
+           ├── args
+           │    └── const: 0
+           ├── params: n:1
+           └── body
+                └── limit
+                     ├── columns: stmt_if_5:12
+                     ├── project
+                     │    ├── columns: stmt_if_5:12
+                     │    ├── project
+                     │    │    ├── columns: i:2!null
+                     │    │    ├── values
+                     │    │    │    └── tuple
+                     │    │    └── projections
+                     │    │         └── const: -1 [as=i:2]
+                     │    └── projections
+                     │         └── case [as=stmt_if_5:12]
+                     │              ├── true
+                     │              ├── when
+                     │              │    ├── eq
+                     │              │    │    ├── variable: n:1
+                     │              │    │    └── const: 0
+                     │              │    └── subquery
+                     │              │         └── project
+                     │              │              ├── columns: stmt_return_3:6!null
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── const: 0 [as=stmt_return_3:6]
+                     │              ├── when
+                     │              │    ├── eq
+                     │              │    │    ├── variable: n:1
+                     │              │    │    └── const: 1
+                     │              │    └── subquery
+                     │              │         └── project
+                     │              │              ├── columns: stmt_if_1:8
+                     │              │              ├── project
+                     │              │              │    ├── columns: i:7!null
+                     │              │              │    ├── values
+                     │              │              │    │    └── tuple
+                     │              │              │    └── projections
+                     │              │              │         └── const: 100 [as=i:7]
+                     │              │              └── projections
+                     │              │                   └── udf: stmt_if_1 [as=stmt_if_1:8]
+                     │              │                        ├── args
+                     │              │                        │    ├── variable: i:7
+                     │              │                        │    └── variable: n:1
+                     │              │                        ├── params: i:3 n:4
+                     │              │                        └── body
+                     │              │                             └── project
+                     │              │                                  ├── columns: stmt_return_2:5
+                     │              │                                  ├── values
+                     │              │                                  │    └── tuple
+                     │              │                                  └── projections
+                     │              │                                       └── variable: i:3 [as=stmt_return_2:5]
+                     │              ├── when
+                     │              │    ├── eq
+                     │              │    │    ├── variable: n:1
+                     │              │    │    └── const: 2
+                     │              │    └── subquery
+                     │              │         └── project
+                     │              │              ├── columns: stmt_return_4:10!null
+                     │              │              ├── project
+                     │              │              │    ├── columns: i:9!null
+                     │              │              │    ├── values
+                     │              │              │    │    └── tuple
+                     │              │              │    └── projections
+                     │              │              │         └── const: 200 [as=i:9]
+                     │              │              └── projections
+                     │              │                   └── variable: i:9 [as=stmt_return_4:10]
+                     │              └── subquery
+                     │                   └── project
+                     │                        ├── columns: stmt_if_1:11
+                     │                        ├── values
+                     │                        │    └── tuple
+                     │                        └── projections
+                     │                             └── udf: stmt_if_1 [as=stmt_if_1:11]
+                     │                                  ├── args
+                     │                                  │    ├── variable: i:2
+                     │                                  │    └── variable: n:1
+                     │                                  ├── params: i:3 n:4
+                     │                                  └── body
+                     │                                       └── project
+                     │                                            ├── columns: stmt_return_2:5
+                     │                                            ├── values
+                     │                                            │    └── tuple
+                     │                                            └── projections
+                     │                                                 └── variable: i:3 [as=stmt_return_2:5]
+                     └── const: 1

--- a/pkg/sql/plpgsql/parser/plpgsql.y
+++ b/pkg/sql/plpgsql/parser/plpgsql.y
@@ -114,8 +114,8 @@ func (u *plpgsqlSymUnion) pLpgSQLStmtGetDiagItemList() plpgsqltree.PLpgSQLStmtGe
     return u.val.(plpgsqltree.PLpgSQLStmtGetDiagItemList)
 }
 
-func (u *plpgsqlSymUnion) pLpgSQLStmtIfElseIfArmList() []*plpgsqltree.PLpgSQLStmtIfElseIfArm {
-    return u.val.([]*plpgsqltree.PLpgSQLStmtIfElseIfArm)
+func (u *plpgsqlSymUnion) pLpgSQLStmtIfElseIfArmList() []plpgsqltree.PLpgSQLStmtIfElseIfArm {
+    return u.val.([]plpgsqltree.PLpgSQLStmtIfElseIfArm)
 }
 
 func (u *plpgsqlSymUnion) pLpgSQLStmtOpen() *plpgsqltree.PLpgSQLStmtOpen {
@@ -315,7 +315,7 @@ func (u *plpgsqlSymUnion) plpgsqlOptionExprs() []plpgsqltree.PLpgSQLStmtRaiseOpt
 %type <str> opt_error_level option_type
 
 %type <[]plpgsqltree.PLpgSQLStatement> proc_sect
-%type <[]*plpgsqltree.PLpgSQLStmtIfElseIfArm> stmt_elsifs
+%type <[]plpgsqltree.PLpgSQLStmtIfElseIfArm> stmt_elsifs
 %type <[]plpgsqltree.PLpgSQLStatement> stmt_else loop_body // TODO is this a list of statement?
 %type <plpgsqltree.PLpgSQLStatement>  pl_block
 %type <plpgsqltree.PLpgSQLStatement>	proc_stmt
@@ -822,7 +822,7 @@ stmt_if: IF expr_until_then THEN proc_sect stmt_elsifs stmt_else END_IF IF ';'
 
 stmt_elsifs:
   {
-    $$.val = []*plpgsqltree.PLpgSQLStmtIfElseIfArm{};
+    $$.val = []plpgsqltree.PLpgSQLStmtIfElseIfArm{};
   }
 | stmt_elsifs ELSIF expr_until_then THEN proc_sect
   {
@@ -830,7 +830,7 @@ stmt_elsifs:
     if err != nil {
       return setErr(plpgsqllex, err)
     }
-    newStmt := &plpgsqltree.PLpgSQLStmtIfElseIfArm{
+    newStmt := plpgsqltree.PLpgSQLStmtIfElseIfArm{
       Condition: cond,
       Stmts: $5.plpgsqlStatements(),
     }

--- a/pkg/sql/sem/plpgsqltree/statements.go
+++ b/pkg/sql/sem/plpgsqltree/statements.go
@@ -152,7 +152,7 @@ type PLpgSQLStmtIf struct {
 	PLpgSQLStatementImpl
 	Condition  PLpgSQLExpr
 	ThenBody   []PLpgSQLStatement
-	ElseIfList []*PLpgSQLStmtIfElseIfArm
+	ElseIfList []PLpgSQLStmtIfElseIfArm
 	ElseBody   []PLpgSQLStatement
 }
 
@@ -201,7 +201,6 @@ func (s *PLpgSQLStmtIf) WalkStmt(visitor PLpgSQLStmtVisitor) {
 
 type PLpgSQLStmtIfElseIfArm struct {
 	PLpgSQLStatementImpl
-	LineNo    int
 	Condition PLpgSQLExpr
 	Stmts     []PLpgSQLStatement
 }


### PR DESCRIPTION
This patch adds support for executing PLpgSQL `IF` statements with `ELSIF` branches (else if). `IF` statements were already executed as CASE statements under the hood, so this change only requires building the `ELSIF` branches and appending them to the `whens` list.

Informs #105254

Release note (sql change): Added support for specifying PLpgSQL `IF` statements with `ELSIF` branches.