### PR TITLE
storage: add fuzz test for engine key invariants

### DIFF
--- a/pkg/storage/engine_key.go
+++ b/pkg/storage/engine_key.go
@@ -205,7 +205,7 @@ func DecodeEngineKey(b []byte) (key EngineKey, ok bool) {
 	versionLen := int(b[len(b)-1])
 	// keyPartEnd points to the sentinel byte.
 	keyPartEnd := len(b) - 1 - versionLen
-	if keyPartEnd < 0 {
+	if keyPartEnd < 0 || b[keyPartEnd] != 0x00 {
 		return EngineKey{}, false
 	}
 	// Key excludes the sentinel byte.
@@ -229,7 +229,7 @@ func GetKeyPartFromEngineKey(engineKey []byte) (key []byte, ok bool) {
 	versionLen := int(engineKey[len(engineKey)-1])
 	// keyPartEnd points to the sentinel byte.
 	keyPartEnd := len(engineKey) - 1 - versionLen
-	if keyPartEnd < 0 {
+	if keyPartEnd < 0 || engineKey[keyPartEnd] != 0x00 {
 		return nil, false
 	}
 	// Key excludes the sentinel byte.

--- a/pkg/storage/engine_key_test.go
+++ b/pkg/storage/engine_key_test.go
@@ -11,6 +11,7 @@
 package storage
 
 import (
+	"bytes"
 	"encoding/hex"
 	"fmt"
 	"math"
@@ -251,6 +252,137 @@ func TestEngineKeyValidate(t *testing.T) {
 			}
 		})
 	})
+}
+
+// interestingEngineKeys is a slice of byte slices that may be used in tests as
+// engine keys. Not all the keys are valid keys.
+var interestingEngineKeys = [][]byte{
+	{0x00, 0x00},
+	{0x01, 0x11, 0x01},
+	EncodeMVCCKey(MVCCKey{Key: roachpb.Key("a"), Timestamp: hlc.Timestamp{WallTime: math.MaxInt64}}),
+	EncodeMVCCKey(MVCCKey{Key: roachpb.Key("foo"), Timestamp: hlc.Timestamp{WallTime: 1691183078362053000}}),
+	EncodeMVCCKey(MVCCKey{Key: roachpb.Key("bar")}),
+	EncodeMVCCKey(MVCCKey{Key: roachpb.Key("bar"), Timestamp: hlc.Timestamp{WallTime: 1643550788737652545}}),
+	EncodeMVCCKey(MVCCKey{Key: roachpb.Key("bar"), Timestamp: hlc.Timestamp{WallTime: 1643550788737652545, Logical: 1}}),
+	EncodeMVCCKey(MVCCKey{Key: roachpb.Key("bar"), Timestamp: hlc.Timestamp{WallTime: 1643550788737652545, Logical: 1, Synthetic: true}}),
+	encodeLockTableKey(LockTableKey{
+		Key:      roachpb.Key("foo"),
+		Strength: lock.Exclusive,
+		TxnUUID:  uuid.Must(uuid.FromString("6ba7b810-9dad-11d1-80b4-00c04fd430c8")),
+	}),
+	encodeLockTableKey(LockTableKey{
+		Key:      keys.RangeDescriptorKey(roachpb.RKey("baz")),
+		Strength: lock.Exclusive,
+		TxnUUID:  uuid.Must(uuid.FromString("6ba7b810-9dad-11d1-80b4-00c04fd430c8")),
+	}),
+}
+
+// FuzzEngineKeysInvariants fuzz tests various functions over engine keys,
+// ensuring that invariants over engine keys hold.
+func FuzzEngineKeysInvariants(f *testing.F) {
+	for i := 0; i < len(interestingEngineKeys); i++ {
+		for j := 0; j < len(interestingEngineKeys); j++ {
+			f.Add(interestingEngineKeys[i], interestingEngineKeys[j])
+		}
+	}
+
+	compareEngineKeys := func(t *testing.T, a, b []byte) int {
+		cmp := EngineKeyCompare(a, b)
+		eq := EngineKeyEqual(a, b)
+		// Invariant: Iff EngineKeyCompare(a, b) == 0, EngineKeyEqual(a, b)
+		if eq != (cmp == 0) {
+			t.Errorf("EngineKeyEqual(0x%x, 0x%x) = %t; EngineKeyCompare(0x%x, 0x%x) = %d",
+				a, b, eq, a, b, cmp)
+		}
+		return cmp
+	}
+	computeImmediateSuccessor := func(t *testing.T, a []byte) []byte {
+		succ := EngineComparer.ImmediateSuccessor(nil, a)
+		// Invariant: ImmediateSuccessor(a) > a
+		if cmp := compareEngineKeys(t, a, succ); cmp >= 0 {
+			t.Errorf("ImmediateSuccessor(0x%x) = 0x%x, but EngineKeyCompare(0x%x, 0x%x) = %d",
+				a, succ, a, succ, cmp)
+		}
+		return succ
+	}
+	decodeEngineKey := func(t *testing.T, a []byte) (EngineKey, bool) {
+		// Invariant: DecodeEngineKey(a) ok iff GetKeyPartFromEngineKey(a) ok
+		// Invariant: DecodeEngineKey(a).Key == GetKeyPartFromEngineKey(a)
+		ek, ok1 := DecodeEngineKey(a)
+		kp, ok2 := GetKeyPartFromEngineKey(a)
+		if ok1 != ok2 || ok1 && !bytes.Equal(ek.Key, kp) {
+			t.Errorf("DecodeEngineKey(0x%x) = (%s, %t); but GetKeyPartFromEngineKey(0x%x) = (0x%x, %t)",
+				a, ek, ok1, a, kp, ok2)
+		}
+
+		return ek, ok1
+	}
+
+	f.Fuzz(func(t *testing.T, a, b []byte) {
+		t.Logf("a = 0x%x; b = 0x%x", a, b)
+		cmp := compareEngineKeys(t, a, b)
+		if cmp == 0 {
+			return
+		}
+		if len(a) == 0 || len(b) == 0 {
+			return
+		}
+
+		// Make a < b.
+		if cmp > 0 {
+			a, b = b, a
+			t.Logf("Swapped: a = 0x%x; b = 0x%x", a, b)
+		}
+		// Invariant: Separator(a, b) >= a
+		// Invariant: Separator(a, b) < b
+		sep := EngineComparer.Separator(nil, a, b)
+		if cmp = compareEngineKeys(t, a, b); cmp > 0 {
+			t.Errorf("Separator(0x%x, 0x%x) = 0x%x; but EngineKeyCompare(0x%x, 0x%x) = %d",
+				a, b, sep, a, sep, cmp)
+		}
+		if cmp = compareEngineKeys(t, sep, b); cmp >= 0 {
+			t.Errorf("Separator(0x%x, 0x%x) = 0x%x; but EngineKeyCompare(0x%x, 0x%x) = %d",
+				a, b, sep, sep, b, cmp)
+		}
+		ekA, okA := decodeEngineKey(t, a)
+		ekB, okB := decodeEngineKey(t, b)
+		if !okA || !okB {
+			return
+		}
+		errA := ekA.Validate()
+		errB := ekB.Validate()
+		// The below invariants only apply for valid keys.
+		if errA != nil || errB != nil {
+			return
+		}
+		t.Logf("ekA = %s (Key: 0x%x, Version: 0x%x); ekB = %s (Key: 0x%x, Version: 0x%x)",
+			ekA, ekA.Key, ekA.Version, ekB, ekB.Key, ekB.Version)
+
+		splitA := EngineComparer.Split(a)
+		splitB := EngineComparer.Split(b)
+		aIsSuffixless := splitA == len(a)
+		bIsSuffixless := splitB == len(b)
+		// ImmediateSuccessor is only defined on prefix keys.
+		var immediateSuccessorA, immediateSuccessorB []byte
+		if aIsSuffixless {
+			immediateSuccessorA = computeImmediateSuccessor(t, a)
+		}
+		if bIsSuffixless {
+			immediateSuccessorB = computeImmediateSuccessor(t, b)
+		}
+		if aIsSuffixless && bIsSuffixless {
+			// Invariant: ImmediateSuccessor(a) < ImmediateSuccessor(b)
+			if cmp = compareEngineKeys(t, immediateSuccessorA, immediateSuccessorB); cmp >= 0 {
+				t.Errorf("ImmediateSuccessor(0x%x) = 0x%x, ImmediateSuccessor(0x%x) = 0x%x; but EngineKeyCompare(0x%x, 0x%x) = %d",
+					a, immediateSuccessorA, b, immediateSuccessorB, immediateSuccessorA, immediateSuccessorB, cmp)
+			}
+		}
+	})
+}
+
+func encodeLockTableKey(ltk LockTableKey) []byte {
+	ek, _ := ltk.ToEngineKey(nil)
+	return ek.Encode()
 }
 
 func randomMVCCKey(r *rand.Rand) MVCCKey {


### PR DESCRIPTION
Add a Go Fuzz test that checks various invariants that should apply to
EngineKeys. The set of invariants checked is relatively small, but we can
extend it to cover all the invariants required by pebble.Comparer.

Epic: none
Release note: none