### PR TITLE
plpgsql: handle NULL values correctly for RAISE statements

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/udf_plpgsql
+++ b/pkg/sql/logictest/testdata/logic_test/udf_plpgsql
@@ -685,6 +685,42 @@ CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$
   END
 $$ LANGUAGE PLpgSQL;
 
+# NULL formatting arguments are printed as "<NULL>".
+statement ok
+CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$
+  BEGIN
+    RAISE 'foo % bar %', NULL::TEXT, NULL::INT;
+    return 0;
+  END
+$$ LANGUAGE PLpgSQL;
+
+statement error pgcode P0001 pq: foo <NULL> bar <NULL>
+SELECT f();
+
+# NULL values cannot be supplied as RAISE options.
+statement ok
+CREATE OR REPLACE FUNCTION f(n INT) RETURNS INT AS $$
+  BEGIN
+    IF n = 0 THEN
+      RAISE division_by_zero USING message = NULL::TEXT;
+    END IF;
+    IF n = 1 THEN
+      RAISE division_by_zero USING detail = NULL::TEXT;
+    END IF;
+    RAISE division_by_zero USING hint = (SELECT 'foo' FROM xy WHERE False);
+    return 0;
+  END
+$$ LANGUAGE PLpgSQL;
+
+statement error pgcode 22004 pq: RAISE statement option cannot be null
+SELECT f(0);
+
+statement error pgcode 22004 pq: RAISE statement option cannot be null
+SELECT f(1);
+
+statement error pgcode 22004 pq: RAISE statement option cannot be null
+SELECT f(2);
+
 statement error pgcode 42601 pq: \"i\" is not a known variable
 CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$
   BEGIN

--- a/pkg/sql/opt/optbuilder/plpgsql.go
+++ b/pkg/sql/opt/optbuilder/plpgsql.go
@@ -545,7 +545,10 @@ func (b *plpgsqlBuilder) makeRaiseFormatMessage(
 				if argIdx >= len(args) {
 					panic(pgerror.Newf(pgcode.Syntax, "too few parameters specified for RAISE"))
 				}
-				addToResult(b.buildPLpgSQLExpr(args[argIdx], types.String, s))
+				// If the argument is NULL, postgres prints "<NULL>".
+				arg := b.buildPLpgSQLExpr(args[argIdx], types.String, s)
+				arg = b.ob.factory.ConstructCoalesce(memo.ScalarListExpr{arg, makeConstStr("<NULL>")})
+				addToResult(arg)
 				argIdx++
 			}
 			addToResult(makeConstStr(paramSubstr))

--- a/pkg/sql/opt/optbuilder/testdata/udf_plpgsql
+++ b/pkg/sql/opt/optbuilder/testdata/udf_plpgsql
@@ -1710,7 +1710,9 @@ project
                      │                   │              ├── concat
                      │                   │              │    ├── concat
                      │                   │              │    │    ├── const: ''
-                     │                   │              │    │    └── const: 1
+                     │                   │              │    │    └── coalesce
+                     │                   │              │    │         ├── const: 1
+                     │                   │              │    │         └── const: '<NULL>'
                      │                   │              │    └── const: ''
                      │                   │              ├── const: ''
                      │                   │              ├── const: ''
@@ -1736,11 +1738,17 @@ project
                      │                                       │              │    │    │    │    ├── concat
                      │                                       │              │    │    │    │    │    ├── concat
                      │                                       │              │    │    │    │    │    │    ├── const: 'foo: '
-                     │                                       │              │    │    │    │    │    │    └── const: 1
+                     │                                       │              │    │    │    │    │    │    └── coalesce
+                     │                                       │              │    │    │    │    │    │         ├── const: 1
+                     │                                       │              │    │    │    │    │    │         └── const: '<NULL>'
                      │                                       │              │    │    │    │    │    └── const: ', '
-                     │                                       │              │    │    │    │    └── const: 2
+                     │                                       │              │    │    │    │    └── coalesce
+                     │                                       │              │    │    │    │         ├── const: 2
+                     │                                       │              │    │    │    │         └── const: '<NULL>'
                      │                                       │              │    │    │    └── const: ', '
-                     │                                       │              │    │    └── const: 3
+                     │                                       │              │    │    └── coalesce
+                     │                                       │              │    │         ├── const: 3
+                     │                                       │              │    │         └── const: '<NULL>'
                      │                                       │              │    └── const: ''
                      │                                       │              ├── const: ''
                      │                                       │              ├── const: ''
@@ -1788,7 +1796,9 @@ project
                      │                                                                               │              │    │    │    │    ├── const: ''
                      │                                                                               │              │    │    │    │    └── const: '%'
                      │                                                                               │              │    │    │    └── const: ''
-                     │                                                                               │              │    │    └── const: 1
+                     │                                                                               │              │    │    └── coalesce
+                     │                                                                               │              │    │         ├── const: 1
+                     │                                                                               │              │    │         └── const: '<NULL>'
                      │                                                                               │              │    └── const: ''
                      │                                                                               │              ├── const: ''
                      │                                                                               │              ├── const: ''
@@ -1830,7 +1840,9 @@ project
                      │                                                                                                   │              │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    ├── const: ''
                      │                                                                                                   │              │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    └── const: '%'
                      │                                                                                                   │              │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    └── const: ''
-                     │                                                                                                   │              │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    └── const: 1
+                     │                                                                                                   │              │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    └── coalesce
+                     │                                                                                                   │              │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │         ├── const: 1
+                     │                                                                                                   │              │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │         └── const: '<NULL>'
                      │                                                                                                   │              │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    └── const: 'foo'
                      │                                                                                                   │              │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    └── const: '%'
                      │                                                                                                   │              │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    └── const: ' bar'
@@ -1844,9 +1856,13 @@ project
                      │                                                                                                   │              │    │    │    │    │    │    │    └── const: ''
                      │                                                                                                   │              │    │    │    │    │    │    └── const: '%'
                      │                                                                                                   │              │    │    │    │    │    └── const: ' ba'
-                     │                                                                                                   │              │    │    │    │    └── const: 2
+                     │                                                                                                   │              │    │    │    │    └── coalesce
+                     │                                                                                                   │              │    │    │    │         ├── const: 2
+                     │                                                                                                   │              │    │    │    │         └── const: '<NULL>'
                      │                                                                                                   │              │    │    │    └── const: 'z'
-                     │                                                                                                   │              │    │    └── const: 3
+                     │                                                                                                   │              │    │    └── coalesce
+                     │                                                                                                   │              │    │         ├── const: 3
+                     │                                                                                                   │              │    │         └── const: '<NULL>'
                      │                                                                                                   │              │    └── const: ''
                      │                                                                                                   │              ├── const: ''
                      │                                                                                                   │              ├── const: ''
@@ -2237,7 +2253,9 @@ project
                      │                   │              ├── concat
                      │                   │              │    ├── concat
                      │                   │              │    │    ├── const: '1: i = '
-                     │                   │              │    │    └── variable: i:2
+                     │                   │              │    │    └── coalesce
+                     │                   │              │    │         ├── variable: i:2
+                     │                   │              │    │         └── const: '<NULL>'
                      │                   │              │    └── const: ''
                      │                   │              ├── const: ''
                      │                   │              ├── const: ''
@@ -2266,7 +2284,9 @@ project
                      │                                       │              ├── concat
                      │                                       │              │    ├── concat
                      │                                       │              │    │    ├── const: '2: i = '
-                     │                                       │              │    │    └── variable: i:5
+                     │                                       │              │    │    └── coalesce
+                     │                                       │              │    │         ├── variable: i:5
+                     │                                       │              │    │         └── const: '<NULL>'
                      │                                       │              │    └── const: ''
                      │                                       │              ├── const: ''
                      │                                       │              ├── const: ''
@@ -2304,7 +2324,9 @@ project
                      │                                                           │              ├── concat
                      │                                                           │              │    ├── concat
                      │                                                           │              │    │    ├── const: '3: i = '
-                     │                                                           │              │    │    └── variable: i:14
+                     │                                                           │              │    │    └── coalesce
+                     │                                                           │              │    │         ├── variable: i:14
+                     │                                                           │              │    │         └── const: '<NULL>'
                      │                                                           │              │    └── const: ''
                      │                                                           │              ├── const: ''
                      │                                                           │              ├── const: ''
@@ -2329,18 +2351,20 @@ project
                      │                                                                               │              ├── concat
                      │                                                                               │              │    ├── concat
                      │                                                                               │              │    │    ├── const: 'max_x: '
-                     │                                                                               │              │    │    └── subquery
-                     │                                                                               │              │    │         └── max1-row
-                     │                                                                               │              │    │              ├── columns: max:22
-                     │                                                                               │              │    │              └── scalar-group-by
-                     │                                                                               │              │    │                   ├── columns: max:22
-                     │                                                                               │              │    │                   ├── project
-                     │                                                                               │              │    │                   │    ├── columns: x:17
-                     │                                                                               │              │    │                   │    └── scan xy
-                     │                                                                               │              │    │                   │         └── columns: x:17 y:18 rowid:19!null crdb_internal_mvcc_timestamp:20 tableoid:21
-                     │                                                                               │              │    │                   └── aggregations
-                     │                                                                               │              │    │                        └── max [as=max:22]
-                     │                                                                               │              │    │                             └── variable: x:17
+                     │                                                                               │              │    │    └── coalesce
+                     │                                                                               │              │    │         ├── subquery
+                     │                                                                               │              │    │         │    └── max1-row
+                     │                                                                               │              │    │         │         ├── columns: max:22
+                     │                                                                               │              │    │         │         └── scalar-group-by
+                     │                                                                               │              │    │         │              ├── columns: max:22
+                     │                                                                               │              │    │         │              ├── project
+                     │                                                                               │              │    │         │              │    ├── columns: x:17
+                     │                                                                               │              │    │         │              │    └── scan xy
+                     │                                                                               │              │    │         │              │         └── columns: x:17 y:18 rowid:19!null crdb_internal_mvcc_timestamp:20 tableoid:21
+                     │                                                                               │              │    │         │              └── aggregations
+                     │                                                                               │              │    │         │                   └── max [as=max:22]
+                     │                                                                               │              │    │         │                        └── variable: x:17
+                     │                                                                               │              │    │         └── const: '<NULL>'
                      │                                                                               │              │    └── const: ''
                      │                                                                               │              ├── const: ''
                      │                                                                               │              ├── const: ''
@@ -2437,7 +2461,9 @@ project
                      │                                  │                                                 │              ├── concat
                      │                                  │                                                 │              │    ├── concat
                      │                                  │                                                 │              │    │    ├── const: 'finished with i = '
-                     │                                  │                                                 │              │    │    └── variable: i:3
+                     │                                  │                                                 │              │    │    └── coalesce
+                     │                                  │                                                 │              │    │         ├── variable: i:3
+                     │                                  │                                                 │              │    │         └── const: '<NULL>'
                      │                                  │                                                 │              │    └── const: ''
                      │                                  │                                                 │              ├── const: ''
                      │                                  │                                                 │              ├── const: ''
@@ -2479,7 +2505,9 @@ project
                      │                                                                               │              ├── concat
                      │                                                                               │              │    ├── concat
                      │                                                                               │              │    │    ├── const: 'i = '
-                     │                                                                               │              │    │    └── variable: i:9
+                     │                                                                               │              │    │    └── coalesce
+                     │                                                                               │              │    │         ├── variable: i:9
+                     │                                                                               │              │    │         └── const: '<NULL>'
                      │                                                                               │              │    └── const: ''
                      │                                                                               │              ├── const: ''
                      │                                                                               │              ├── const: ''
@@ -2730,7 +2758,9 @@ project
                      │                                  │                                                 │              ├── concat
                      │                                  │                                                 │              │    ├── concat
                      │                                  │                                                 │              │    │    ├── const: 'finished with i = '
-                     │                                  │                                                 │              │    │    └── variable: i:3
+                     │                                  │                                                 │              │    │    └── coalesce
+                     │                                  │                                                 │              │    │         ├── variable: i:3
+                     │                                  │                                                 │              │    │         └── const: '<NULL>'
                      │                                  │                                                 │              │    └── const: ''
                      │                                  │                                                 │              ├── const: ''
                      │                                  │                                                 │              ├── const: ''
@@ -2784,7 +2814,9 @@ project
                      │                                                                          │                             │              ├── concat
                      │                                                                          │                             │              │    ├── concat
                      │                                                                          │                             │              │    │    ├── const: 'i = '
-                     │                                                                          │                             │              │    │    └── variable: i:15
+                     │                                                                          │                             │              │    │    └── coalesce
+                     │                                                                          │                             │              │    │         ├── variable: i:15
+                     │                                                                          │                             │              │    │         └── const: '<NULL>'
                      │                                                                          │                             │              │    └── const: ''
                      │                                                                          │                             │              ├── const: ''
                      │                                                                          │                             │              ├── const: ''
@@ -2819,7 +2851,9 @@ project
                      │                                                                          │                                                                     │              ├── concat
                      │                                                                          │                                                                     │              │    ├── concat
                      │                                                                          │                                                                     │              │    │    ├── const: 'i = '
-                     │                                                                          │                                                                     │              │    │    └── variable: i:10
+                     │                                                                          │                                                                     │              │    │    └── coalesce
+                     │                                                                          │                                                                     │              │    │         ├── variable: i:10
+                     │                                                                          │                                                                     │              │    │         └── const: '<NULL>'
                      │                                                                          │                                                                     │              │    └── const: ''
                      │                                                                          │                                                                     │              ├── const: ''
                      │                                                                          │                                                                     │              ├── const: ''
@@ -2870,7 +2904,9 @@ project
                      │                                                                                                                       │              ├── concat
                      │                                                                                                                       │              │    ├── concat
                      │                                                                                                                       │              │    │    ├── const: 'i = '
-                     │                                                                                                                       │              │    │    └── variable: i:10
+                     │                                                                                                                       │              │    │    └── coalesce
+                     │                                                                                                                       │              │    │         ├── variable: i:10
+                     │                                                                                                                       │              │    │         └── const: '<NULL>'
                      │                                                                                                                       │              │    └── const: ''
                      │                                                                                                                       │              ├── const: ''
                      │                                                                                                                       │              ├── const: ''

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -8117,6 +8117,11 @@ expires until the statement bundle is collected`,
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				argStrings := make([]string, len(args))
 				for i := range args {
+					if args[i] == tree.DNull {
+						return nil, pgerror.New(
+							pgcode.NullValueNotAllowed, "RAISE statement option cannot be null",
+						)
+					}
 					s, ok := tree.AsDString(args[i])
 					if !ok {
 						return nil, errors.Newf("expected string value, got %T", args[i])
@@ -8168,8 +8173,9 @@ expires until the statement bundle is collected`,
 				}
 				return tree.DNull, nil
 			},
-			Info:       "This function is used internally to implement the PLpgSQL RAISE statement.",
-			Volatility: volatility.Volatile,
+			Info:              "This function is used internally to implement the PLpgSQL RAISE statement.",
+			Volatility:        volatility.Volatile,
+			CalledOnNullInput: true,
 		},
 	),
 }


### PR DESCRIPTION
This patch fixes two behaviors related to RAISE statements handling NULL values:
1. When a NULL value is passed as a formatting argument, it is printed as `<NULL>` in the result string.
2. When a NULL value is passed as a RAISE option (message, detail, etc.) a runtime `RAISE statement option cannot be null` error results.

Informs #105254

Release note: None