### PR TITLE
util, workload: cleanup lock usages

### DIFF
--- a/pkg/util/admission/work_queue.go
+++ b/pkg/util/admission/work_queue.go
@@ -468,10 +468,12 @@ func (q *WorkQueue) startClosingEpochs() {
 		const minTimerDur = time.Millisecond
 		var timer *time.Timer
 		for {
-			q.mu.Lock()
-			q.sampleEpochLIFOSettingsLocked()
-			nextCloseTime := q.nextEpochCloseTimeLocked()
-			q.mu.Unlock()
+			nextCloseTime := func() time.Time {
+				q.mu.Lock()
+				defer q.mu.Unlock()
+				q.sampleEpochLIFOSettingsLocked()
+				return q.nextEpochCloseTimeLocked()
+			}()
 			timeNow := q.timeNow()
 			timerDur := nextCloseTime.Sub(timeNow)
 			if timerDur > 0 {
@@ -1055,20 +1057,27 @@ func (q *WorkQueue) SetTenantWeights(tenantWeights map[uint64]uint32) {
 		}
 		q.mu.tenantWeights.inactive[k] = w
 	}
-	q.mu.Lock()
 	// Establish the new active map.
-	q.mu.tenantWeights.active, q.mu.tenantWeights.inactive =
-		q.mu.tenantWeights.inactive, q.mu.tenantWeights.active
+	func() {
+		q.mu.Lock()
+		defer q.mu.Unlock()
+		q.mu.tenantWeights.active, q.mu.tenantWeights.inactive =
+			q.mu.tenantWeights.inactive, q.mu.tenantWeights.active
+	}()
 	// Create a slice for storing all the tenantIDs. We use this to split the
 	// update to the data-structures that require holding q.mu, in case there
 	// are 1000s of tenants (we don't want to hold q.mu for long durations).
-	tenantIDs := make([]uint64, len(q.mu.tenants))
-	i := 0
-	for k := range q.mu.tenants {
-		tenantIDs[i] = k
-		i++
-	}
-	q.mu.Unlock()
+	tenantIDs := func() []uint64 {
+		q.mu.Lock()
+		defer q.mu.Unlock()
+		tIDs := make([]uint64, len(q.mu.tenants))
+		i := 0
+		for k := range q.mu.tenants {
+			tIDs[i] = k
+			i++
+		}
+		return tIDs
+	}()
 	// Any tenants not in tenantIDs will see the latest weight when their
 	// tenantInfo is created. The existing ones need their weights to be
 	// updated.
@@ -1873,9 +1882,11 @@ func (q *StoreWorkQueue) Admit(
 		//
 		// [1]: This happens asynchronously -- i.e. we may have already returned
 		//      from StoreWorkQueue.Admit().
-		q.mu.RLock()
-		info.RequestedCount = q.mu.estimates.writeTokens
-		q.mu.RUnlock()
+		info.RequestedCount = func() int64 {
+			q.mu.RLock()
+			defer q.mu.RUnlock()
+			return q.mu.estimates.writeTokens
+		}()
 	}
 	if info.ReplicatedWorkInfo.Enabled {
 		info.CreateTime = q.sequenceReplicatedWork(info.CreateTime, info.ReplicatedWorkInfo)
@@ -2056,15 +2067,16 @@ func (q *StoreWorkQueue) BypassedWorkDone(workCount int64, doneInfo StoreWorkDon
 // storeAdmissionStats.
 func (q *StoreWorkQueue) StatsToIgnore(ingestStats pebble.IngestOperationStats) {
 	q.mu.Lock()
+	defer q.mu.Unlock()
 	q.mu.stats.statsToIgnore.Bytes += ingestStats.Bytes
 	q.mu.stats.statsToIgnore.ApproxIngestedIntoL0Bytes += ingestStats.ApproxIngestedIntoL0Bytes
-	q.mu.Unlock()
 }
 
 func (q *StoreWorkQueue) updateStoreStatsAfterWorkDone(
 	workCount uint64, doneInfo StoreWorkDoneInfo, bypassed bool,
 ) {
 	q.mu.Lock()
+	defer q.mu.Unlock()
 	q.mu.stats.workCount += workCount
 	q.mu.stats.writeAccountedBytes += uint64(doneInfo.WriteBytes)
 	q.mu.stats.ingestedAccountedBytes += uint64(doneInfo.IngestedBytes)
@@ -2073,7 +2085,6 @@ func (q *StoreWorkQueue) updateStoreStatsAfterWorkDone(
 		q.mu.stats.aux.writeBypassedAccountedBytes += uint64(doneInfo.WriteBytes)
 		q.mu.stats.aux.ingestedBypassedAccountedBytes += uint64(doneInfo.IngestedBytes)
 	}
-	q.mu.Unlock()
 }
 
 // SetTenantWeights passes through to WorkQueue.SetTenantWeights.
@@ -2107,8 +2118,8 @@ func (q *StoreWorkQueue) getStoreAdmissionStats() storeAdmissionStats {
 
 func (q *StoreWorkQueue) setStoreRequestEstimates(estimates storeRequestEstimates) {
 	q.mu.Lock()
+	defer q.mu.Unlock()
 	q.mu.estimates = estimates
-	q.mu.Unlock()
 }
 
 func makeStoreWorkQueue(
@@ -2178,13 +2189,16 @@ func (q *StoreWorkQueue) gcSequencers() {
 }
 
 func (q *StoreWorkQueue) sequenceReplicatedWork(createTime int64, info ReplicatedWorkInfo) int64 {
-	q.sequencersMu.Lock()
-	seq, ok := q.sequencersMu.s[info.RangeID]
-	if !ok {
-		seq = &sequencer{}
-		q.sequencersMu.s[info.RangeID] = seq
-	}
-	q.sequencersMu.Unlock()
+	seq := func() *sequencer {
+		q.sequencersMu.Lock()
+		defer q.sequencersMu.Unlock()
+		sqr, ok := q.sequencersMu.s[info.RangeID]
+		if !ok {
+			sqr = &sequencer{}
+			q.sequencersMu.s[info.RangeID] = sqr
+		}
+		return sqr
+	}()
 	// We're assuming sequenceReplicatedWork is never invoked concurrently for a
 	// given RangeID.
 	return seq.sequence(createTime)

--- a/pkg/util/log/channels.go
+++ b/pkg/util/log/channels.go
@@ -59,12 +59,15 @@ func logfDepthInternal(
 	if sev == severity.FATAL {
 		// Timeout logic should stay at the top of this call to capture all
 		// writes that happen afterwards.
-		logging.mu.Lock()
-		exitFunc := func(x exit.Code, _ error) { exit.WithCode(x) }
-		if logging.mu.exitOverride.f != nil {
-			exitFunc = logging.mu.exitOverride.f
-		}
-		logging.mu.Unlock()
+		exitFunc := func() (exitFunc func(exit.Code, error)) {
+			exitFunc = func(x exit.Code, _ error) { exit.WithCode(x) }
+			logging.mu.Lock()
+			defer logging.mu.Unlock()
+			if logging.mu.exitOverride.f != nil {
+				exitFunc = logging.mu.exitOverride.f
+			}
+			return exitFunc
+		}()
 
 		// Fatal error handling later already tries to exit even if I/O should
 		// block, but crash reporting might also be in the way.

--- a/pkg/util/log/trace.go
+++ b/pkg/util/log/trace.go
@@ -34,11 +34,11 @@ type ctxEventLog struct {
 
 func (el *ctxEventLog) finish() {
 	el.Lock()
+	defer el.Unlock()
 	if el.eventLog != nil {
 		el.eventLog.Finish()
 		el.eventLog = nil
 	}
-	el.Unlock()
 }
 
 func embedCtxEventLog(ctx context.Context, el *ctxEventLog) context.Context {

--- a/pkg/util/log/vmodule.go
+++ b/pkg/util/log/vmodule.go
@@ -102,12 +102,15 @@ func (c *vmoduleConfig) vDepth(l Level, depth int) bool {
 			c.pcsPool.Put(poolObj)
 			return false
 		}
-		c.mu.Lock()
-		v, ok := c.mu.vmap[pcs[0]]
-		if !ok {
-			v = c.setV(pcs)
-		}
-		c.mu.Unlock()
+		v := func() Level {
+			c.mu.Lock()
+			defer c.mu.Unlock()
+			lvl, ok := c.mu.vmap[pcs[0]]
+			if !ok {
+				lvl = c.setV(pcs)
+			}
+			return lvl
+		}()
 		c.pcsPool.Put(poolObj)
 		return v >= l
 	}

--- a/pkg/util/randutil/rand.go
+++ b/pkg/util/randutil/rand.go
@@ -40,22 +40,22 @@ func NewLockedSource(seed int64) rand.Source {
 
 func (rng *lockedSource) Int63() (n int64) {
 	rng.mu.Lock()
+	defer rng.mu.Unlock()
 	n = rng.src.Int63()
-	rng.mu.Unlock()
 	return
 }
 
 func (rng *lockedSource) Uint64() (n uint64) {
 	rng.mu.Lock()
+	defer rng.mu.Unlock()
 	n = rng.src.Uint64()
-	rng.mu.Unlock()
 	return
 }
 
 func (rng *lockedSource) Seed(seed int64) {
 	rng.mu.Lock()
+	defer rng.mu.Unlock()
 	rng.src.Seed(seed)
-	rng.mu.Unlock()
 }
 
 // globalSeed contains a pseudo random seed that should only be used in tests.

--- a/pkg/util/tracing/span.go
+++ b/pkg/util/tracing/span.go
@@ -703,41 +703,42 @@ func (sp *Span) reset(
 		// Nobody is supposed to have a reference to the span at this point, but let's
 		// take the lock anyway to protect against buggy clients accessing the span
 		// after Finish().
-		c.mu.Lock()
-		if len(c.mu.openChildren) != 0 {
-			panic(errors.AssertionFailedf("unexpected children in span being reset: %v", c.mu.openChildren))
-		}
-		if len(c.mu.tags) != 0 {
-			panic(errors.AssertionFailedf("unexpected tags in span being reset: %v", c.mu.tags))
-		}
-		if !c.mu.recording.finishedChildren.Empty() {
-			panic(errors.AssertionFailedf("unexpected finished children in span being reset: %v", c.mu.recording.finishedChildren))
-		}
-		if c.mu.recording.structured.Len() != 0 {
-			panic(errors.AssertionFailedf("unexpected structured recording in span being reset"))
-		}
-		if c.mu.recording.logs.Len() != 0 {
-			panic(errors.AssertionFailedf("unexpected logs in span being reset"))
-		}
+		func() {
+			c.mu.Lock()
+			defer c.mu.Unlock()
+			if len(c.mu.openChildren) != 0 {
+				panic(errors.AssertionFailedf("unexpected children in span being reset: %v", c.mu.openChildren))
+			}
+			if len(c.mu.tags) != 0 {
+				panic(errors.AssertionFailedf("unexpected tags in span being reset: %v", c.mu.tags))
+			}
+			if !c.mu.recording.finishedChildren.Empty() {
+				panic(errors.AssertionFailedf("unexpected finished children in span being reset: %v", c.mu.recording.finishedChildren))
+			}
+			if c.mu.recording.structured.Len() != 0 {
+				panic(errors.AssertionFailedf("unexpected structured recording in span being reset"))
+			}
+			if c.mu.recording.logs.Len() != 0 {
+				panic(errors.AssertionFailedf("unexpected logs in span being reset"))
+			}
+			h := sp.helper
+			c.mu.crdbSpanMu = crdbSpanMu{
+				duration:     -1, // unfinished
+				openChildren: h.childrenAlloc[:0],
+				goroutineID:  goroutineID,
+				recording: recordingState{
+					logs:             makeSizeLimitedBuffer[*tracingpb.LogRecord](maxLogBytesPerSpan, nil /* scratch */),
+					structured:       makeSizeLimitedBuffer[*tracingpb.StructuredRecord](maxStructuredBytesPerSpan, h.structuredEventsAlloc[:]),
+					childrenMetadata: h.childrenMetadataAlloc,
+					finishedChildren: MakeTrace(tracingpb.RecordedSpan{}),
+				},
+				tags: h.tagsAlloc[:0],
+			}
 
-		h := sp.helper
-		c.mu.crdbSpanMu = crdbSpanMu{
-			duration:     -1, // unfinished
-			openChildren: h.childrenAlloc[:0],
-			goroutineID:  goroutineID,
-			recording: recordingState{
-				logs:             makeSizeLimitedBuffer[*tracingpb.LogRecord](maxLogBytesPerSpan, nil /* scratch */),
-				structured:       makeSizeLimitedBuffer[*tracingpb.StructuredRecord](maxStructuredBytesPerSpan, h.structuredEventsAlloc[:]),
-				childrenMetadata: h.childrenMetadataAlloc,
-				finishedChildren: MakeTrace(tracingpb.RecordedSpan{}),
-			},
-			tags: h.tagsAlloc[:0],
-		}
-
-		if kind != oteltrace.SpanKindUnspecified {
-			c.setTagLocked(SpanKindTagKey, attribute.StringValue(kind.String()))
-		}
-		c.mu.Unlock()
+			if kind != oteltrace.SpanKindUnspecified {
+				c.setTagLocked(SpanKindTagKey, attribute.StringValue(kind.String()))
+			}
+		}()
 	}
 
 	// We only mark the span as not finished at the end so that accesses to the

--- a/pkg/workload/histogram/histogram.go
+++ b/pkg/workload/histogram/histogram.go
@@ -96,9 +96,9 @@ func (w *NamedHistogram) RecordValue(value int64) {
 	w.prometheusHistogram.Observe(float64(value))
 
 	w.mu.Lock()
+	defer w.mu.Unlock()
 	// This value may be outside the range, in which case it will be dropped.
 	_ = w.mu.current.RecordValue(value)
-	w.mu.Unlock()
 }
 
 // tick resets the current histogram to a new "period". The old one's data
@@ -293,13 +293,15 @@ type Histograms struct {
 // if necessary. The result is cached, so no need to cache it in the workload.
 func (w *Histograms) Get(name string) *NamedHistogram {
 	// Fast path for existing histograms, which is the common case by far.
-	w.mu.RLock()
-	hist, ok := w.mu.hists[name]
+	hist, ok := func() (*NamedHistogram, bool) {
+		w.mu.RLock()
+		defer w.mu.RUnlock()
+		h, ok := w.mu.hists[name]
+		return h, ok
+	}()
 	if ok {
-		w.mu.RUnlock()
 		return hist
 	}
-	w.mu.RUnlock()
 
 	w.mu.Lock()
 	defer w.mu.Unlock()

--- a/pkg/workload/schemachange/deck.go
+++ b/pkg/workload/schemachange/deck.go
@@ -55,6 +55,7 @@ func newDeck(rng *rand.Rand, weights ...int) *deck {
 // probability of i is weights(i)/sum(weights).
 func (d *deck) Int() int {
 	d.mu.Lock()
+	defer d.mu.Unlock()
 	if d.mu.index == len(d.mu.vals) {
 		d.rng.Shuffle(len(d.mu.vals), func(i, j int) {
 			d.mu.vals[i], d.mu.vals[j] = d.mu.vals[j], d.mu.vals[i]
@@ -63,6 +64,5 @@ func (d *deck) Int() int {
 	}
 	result := d.mu.vals[d.mu.index]
 	d.mu.index++
-	d.mu.Unlock()
 	return result
 }

--- a/pkg/workload/schemachange/schemachange.go
+++ b/pkg/workload/schemachange/schemachange.go
@@ -675,7 +675,7 @@ func (l *logger) flushLogWithError(tx pgx.Tx, err error) {
 	}()
 
 	l.flushLogAndLock(tx, err.Error(), true)
-	l.currentLogEntry.mu.Unlock()
+	defer l.currentLogEntry.mu.Unlock()
 }
 
 // flushLog outputs the currentLogEntry of the schemaChangeWorker.
@@ -685,7 +685,7 @@ func (l *logger) flushLog(tx pgx.Tx, message string) {
 		return
 	}
 	l.flushLogAndLock(tx, message, true)
-	l.currentLogEntry.mu.Unlock()
+	defer l.currentLogEntry.mu.Unlock()
 }
 
 // flushLogAndLock prints the currentLogEntry of the schemaChangeWorker and does not release


### PR DESCRIPTION
This PR updates unsafe/unnecessary manual unlocks to defer unlocks.
The criteria for leaving some unlocks as is:
- will not cause a leak
- releases the resources much earlier
- deferring will cause a deadlock without significant refactor

Part of #107946

Release note: None

Signoffs

- [x] admission
- [x] circuitbreaker
- [x] log
- [x] metric
- [x] mon
- [x] randutil
- [x] schedulerlatency
- [x] stop
- [x] syncutil
- [x] singleflight
- [x] tracing
- [x] workload