### PR TITLE
release-22.2: roachtest: fix knex nightly test

### DIFF
--- a/pkg/cmd/roachtest/tests/knex.go
+++ b/pkg/cmd/roachtest/tests/knex.go
@@ -12,6 +12,9 @@ package tests
 
 import (
 	"context"
+	"regexp"
+	"strconv"
+	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
@@ -111,6 +114,33 @@ func registerKnex(r registry.Registry) {
 		)
 		rawResultsStr := result.Stdout + result.Stderr
 		t.L().Printf("Test Results: %s", rawResultsStr)
+		if err != nil {
+			// We don't have a good way of parsing test results from javascript, so we
+			// do substring matching instead.
+			numFailingRegex := regexp.MustCompile(`There were (\d+) failures`)
+			matches := numFailingRegex.FindStringSubmatch(rawResultsStr)
+			numFailing, convErr := strconv.Atoi(matches[1])
+			if convErr != nil {
+				t.Fatal(convErr)
+			}
+			// These tests fail because the port in the connection string is
+			// returned as '0000' instead of '0'.
+			for _, testName := range []string{
+				"#852, ssl param with PG query string",
+				"support postgresql connection protocol",
+				"it should parse the connection string",
+				"it should allow to use proprietary dialect",
+				"it should use knex supported dialect",
+			} {
+				// Each failing test name gets logged twice in the output.
+				if strings.Count(rawResultsStr, testName) == 2 {
+					numFailing -= 1
+				}
+			}
+			if numFailing == 0 {
+				err = nil
+			}
+		}
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
We recently upgraded the knex version under test, which introduced new tests that do not work on v22.2.

fixes https://github.com/cockroachdb/cockroach/issues/108091
Release justification: test only change
Release note: None