### PR TITLE
acceptance: unskip test_missing_log_output with fix

### DIFF
--- a/pkg/acceptance/generated_cli_test.go
+++ b/pkg/acceptance/generated_cli_test.go
@@ -298,6 +298,13 @@ func TestDockerCLI_test_log_flags(t *testing.T) {
 	runTestDockerCLI(t, "test_log_flags", "../cli/interactive_tests/test_log_flags.tcl")
 }
 
+func TestDockerCLI_test_missing_log_output(t *testing.T) {
+	s := log.Scope(t)
+	defer s.Close(t)
+
+	runTestDockerCLI(t, "test_missing_log_output", "../cli/interactive_tests/test_missing_log_output.tcl")
+}
+
 func TestDockerCLI_test_multiline_statements(t *testing.T) {
 	s := log.Scope(t)
 	defer s.Close(t)

--- a/pkg/cli/interactive_tests/test_missing_log_output.tcl
+++ b/pkg/cli/interactive_tests/test_missing_log_output.tcl
@@ -1,7 +1,5 @@
 #! /usr/bin/env expect -f
 
-# disabled until #107122 is resolved.
-
 source [file join [file dirname $argv0] common.tcl]
 
 spawn /bin/bash
@@ -71,6 +69,7 @@ end_test
 
 # Stop it.
 interrupt
+interrupt
 eexpect ":/# "
 
 start_test "Check that --logtostderr can override the threshold but no error is printed on startup"
@@ -79,6 +78,7 @@ eexpect "marker\r\nCockroachDB node starting"
 end_test
 
 # Stop it.
+interrupt
 interrupt
 eexpect ":/# "
 


### PR DESCRIPTION
Previously, this test would pass infrequently due to a failed interrupt in the script. This change adds a second interrupt to ensure that the cockroach process has shut down.

The second interrupt is necessary in order to force the override of graceful shutdown and terminate the node. Other parts of the test using `start_server` and `stop_server` have their own shutdown code.

Resolves: #107122
Epic: None
Release note: None