### PR TITLE
release-23.1: logictest: increase lease transfer timeout for cockroach-go/testserver

### DIFF
--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -1286,6 +1286,12 @@ func (t *logicTest) newTestServerCluster(bootstrapBinaryPath string, upgradeBina
 	t.clusterCleanupFuncs = append(t.clusterCleanupFuncs, ts.Stop)
 
 	t.setUser(username.RootUser, 0 /* nodeIdx */)
+
+	// These tests involve stopping and starting nodes, so to reduce flakiness,
+	// we increase the lease Transfer timeout.
+	if _, err := t.db.Exec("SET CLUSTER SETTING server.shutdown.lease_transfer_wait = '40s'"); err != nil {
+		t.Fatal(err)
+	}
 }
 
 // newCluster creates a new cluster. It should be called after the logic tests's


### PR DESCRIPTION
Backport 1/1 commits from #108205.

/cc @cockroachdb/release

---

Since the test stops and starts nodes, giving more time to transfer leases during shutdown should make it less flaky.

fixes https://github.com/cockroachdb/cockroach/issues/107778
fixes https://github.com/cockroachdb/cockroach/issues/108294
Release justification: test only change
Release note: None
