### PR TITLE
schemachanger: Skip some reported timeout backup tests

### DIFF
--- a/pkg/sql/schemachanger/sctest/backup.go
+++ b/pkg/sql/schemachanger/sctest/backup.go
@@ -35,12 +35,23 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TODO (xiang): Fix and unskip those flaky backup tests.
+func skipFlakyBackupTests(t *testing.T, path string) {
+	if strings.Contains(path, "alter_table_multiple_commands") ||
+		strings.Contains(path, "alter_table_alter_primary_key_drop_rowid") ||
+		strings.Contains(path, "drop_column_basic") {
+		skip.WithIssue(t, 108221, "skipping flaky tests")
+	}
+}
+
 // BackupSuccess tests that the schema changer can handle being backed up
 // any time during a successful schema change.
 func BackupSuccess(t *testing.T, path string, factory TestServerFactory) {
 	// These tests are expensive.
 	skip.UnderStress(t)
 	skip.UnderRace(t)
+
+	skipFlakyBackupTests(t, path)
 
 	cumulativeTestForEachPostCommitStage(t, path, factory, func(t *testing.T, cs CumulativeTestCaseSpec) {
 		backupSuccess(t, factory, cs)
@@ -57,6 +68,8 @@ func BackupRollbacks(t *testing.T, path string, factory TestServerFactory) {
 	// and at least as expensive to run.
 	skip.UnderShort(t)
 
+	skipFlakyBackupTests(t, path)
+
 	cumulativeTestForEachPostCommitStage(t, path, factory, func(t *testing.T, cs CumulativeTestCaseSpec) {
 		backupRollbacks(t, factory, cs)
 	})
@@ -71,6 +84,8 @@ func BackupSuccessMixedVersion(t *testing.T, path string, factory TestServerFact
 	// These tests are only marginally more useful than BackupSuccess
 	// and at least as expensive to run.
 	skip.UnderShort(t)
+
+	skipFlakyBackupTests(t, path)
 
 	factory = factory.WithMixedVersion()
 	cumulativeTestForEachPostCommitStage(t, path, factory, func(t *testing.T, cs CumulativeTestCaseSpec) {
@@ -87,6 +102,8 @@ func BackupRollbacksMixedVersion(t *testing.T, path string, factory TestServerFa
 	// These tests are only marginally more useful than BackupSuccess
 	// and at least as expensive to run.
 	skip.UnderShort(t)
+
+	skipFlakyBackupTests(t, path)
 
 	factory = factory.WithMixedVersion()
 	cumulativeTestForEachPostCommitStage(t, path, factory, func(t *testing.T, cs CumulativeTestCaseSpec) {


### PR DESCRIPTION
There has been a few timeout failures from the BACKUP/RESTORE testing suites so let's skip
them for now until we know more of the issue.

Informs #https://github.com/cockroachdb/cockroach/issues/108238
Informs https://github.com/cockroachdb/cockroach/issues/108221
Epic: None
Release note: None