### PR TITLE
backupccl: make SHOW BACKUP timestamps timestampTZ

### DIFF
--- a/pkg/ccl/backupccl/show.go
+++ b/pkg/ccl/backupccl/show.go
@@ -732,8 +732,8 @@ func backupShowerHeaders(showSchemas bool, opts tree.ShowBackupOptions) colinfo.
 		{Name: "object_name", Typ: types.String},
 		{Name: "object_type", Typ: types.String},
 		{Name: "backup_type", Typ: types.String},
-		{Name: "start_time", Typ: types.Timestamp},
-		{Name: "end_time", Typ: types.Timestamp},
+		{Name: "start_time", Typ: types.TimestampTZ},
+		{Name: "end_time", Typ: types.TimestampTZ},
 		{Name: "size_bytes", Typ: types.Int},
 		{Name: "rows", Typ: types.Int},
 		{Name: "is_full_cluster", Typ: types.Bool},
@@ -844,12 +844,12 @@ func backupShowerDefault(
 					backupType = tree.NewDString("incremental")
 				}
 				start := tree.DNull
-				end, err := tree.MakeDTimestamp(timeutil.Unix(0, manifest.EndTime.WallTime), time.Nanosecond)
+				end, err := tree.MakeDTimestampTZ(timeutil.Unix(0, manifest.EndTime.WallTime), time.Nanosecond)
 				if err != nil {
 					return nil, err
 				}
 				if manifest.StartTime.WallTime != 0 {
-					start, err = tree.MakeDTimestamp(timeutil.Unix(0, manifest.StartTime.WallTime), time.Nanosecond)
+					start, err = tree.MakeDTimestampTZ(timeutil.Unix(0, manifest.StartTime.WallTime), time.Nanosecond)
 					if err != nil {
 						return nil, err
 					}

--- a/pkg/ccl/backupccl/testdata/backup-restore/show_backup
+++ b/pkg/ccl/backupccl/testdata/backup-restore/show_backup
@@ -26,6 +26,28 @@ SELECT sum(size_bytes) FROM [SHOW BACKUP 'valid-22.2' IN 'nodelocal://1/' WITH s
 ----
 0
 
+query-sql
+SET TIME ZONE 'UTC';
+----
+
+query-sql
+SELECT end_time, end_time AT TIME ZONE 'MST' FROM [SHOW BACKUP 'valid-22.2' IN 'nodelocal://1/' WITH skip size] limit 1;
+----
+2022-08-03 16:00:28.984252 +0000 UTC 2022-08-03 09:00:28.984252 +0000 +0000
+
+query-sql
+SET TIME ZONE 'MST';
+----
+
+query-sql
+SELECT end_time, end_time AT TIME ZONE 'MST' FROM [SHOW BACKUP 'valid-22.2' IN 'nodelocal://1/' WITH skip size] limit 1;
+----
+2022-08-03 09:00:28.984252 -0700 MST 2022-08-03 09:00:28.984252 +0000 +0000
+
+query-sql
+SET TIME ZONE 'UTC';
+----
+
 # This backup is completely valid, but has no jobs.
 query-sql regex=No\sproblems\sfound!
 SELECT * FROM [SHOW BACKUP VALIDATE FROM 'valid-22.2' IN 'nodelocal://1/'];


### PR DESCRIPTION
Release note (backwards-incompatible change): SHOW BACKUP's timestamp columns are now TIMESTAMPTZ, meaning they render in the session offset.
Epic: CRDB-24406.