### PR TITLE
roachtest: increase timeout for network_logging to 60s

### DIFF
--- a/pkg/cmd/roachtest/tests/network_logging.go
+++ b/pkg/cmd/roachtest/tests/network_logging.go
@@ -90,7 +90,8 @@ func registerNetworkLogging(r registry.Registry) {
 			// URLs already are wrapped in '', but we need to add a timeout flag.
 			// Trim the trailing ' and re-add with the flag.
 			trimmed := strings.TrimSuffix(url, "'")
-			workloadPGURLs[i] = fmt.Sprintf("%s&statement_timeout=10s'", trimmed)
+			// Define a 60s client statement timeout.
+			workloadPGURLs[i] = fmt.Sprintf("%s&statement_timeout=60000'", trimmed)
 		}
 
 		// Init & run a workload on the workload node.


### PR DESCRIPTION
Fixes: https://github.com/cockroachdb/cockroach/issues/108088

The new network_logging roachtest sets a pgclient timeout of 10s to attempt detecting deadlocks. This timeout was hit fairly easily during the nightly runs. This is an indication that our 10s timeout is too aggressive.

This PR changes the timeout from 10s to 60s which still achieves the original aim without being so aggressive.

Release note: none