### PR TITLE
schemachanger: Unskip some backup tests

### DIFF
--- a/pkg/sql/schemachanger/sctest/framework.go
+++ b/pkg/sql/schemachanger/sctest/framework.go
@@ -713,7 +713,6 @@ func cumulativeTestForEachPostCommitStage(
 			var hasFailed bool
 			for _, tc := range testCases {
 				fn := func(t *testing.T) {
-					t.Parallel() // SAFE FOR TESTING
 					tf(t, tc)
 				}
 				if hasFailed {


### PR DESCRIPTION
Randomly skip subtests in the BACKUP/RESTORE suites before parallelizing them.

Epic: None
Release note: None