### PR TITLE
release-23.1: release: update latest field in predecessor map

### DIFF
--- a/pkg/testutils/release/cockroach_releases.yaml
+++ b/pkg/testutils/release/cockroach_releases.yaml
@@ -14,7 +14,7 @@
   - 22.2.8
   predecessor: "22.1"
 "23.1":
-  latest: 23.1.6
+  latest: 23.1.8
   withdrawn:
   - 23.1.0
   predecessor: "22.2"


### PR DESCRIPTION
Epic: None
Release justification: normal release adjustment
Release note: None