### PR TITLE
build: use typescript@5.1.6 via Bazel

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -237,7 +237,9 @@ ts_http_archive(
     name = "npm_typescript",
     build_file = "@aspect_rules_ts//ts:BUILD.typescript",
     urls = ["https://storage.googleapis.com/cockroach-npm-deps/typescript/-/typescript-{}.tgz"],
-    version = "4.2.4",
+    version = "5.1.6",
+    # v5.1.6 isn't known to rules_ts 1.4.0 (nor to any published rules_ts version as-of 7 Aug 2023).
+    integrity = "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
 )
 # NOTE: The version is expected to match up to what version we use in db-console.
 # TODO(ricky): We should add a lint check to ensure it does match.


### PR DESCRIPTION
Commit f7a8aa2ec57 (ui: upgrade typescript from v4 to v5, 2023-08-03) recently upgraded to TypeScript 5.1.6. Keep the version used by rules_ts in-sync.

Epic: none
Release note: None