### PR TITLE
kvserver: deflake lease preferences during outage

### DIFF
--- a/pkg/kv/kvserver/client_lease_test.go
+++ b/pkg/kv/kvserver/client_lease_test.go
@@ -947,6 +947,13 @@ func TestLeasePreferencesDuringOutage(t *testing.T) {
 		locality("us", "mi"),
 		locality("us", "mi"),
 	}
+	// Disable expiration based lease transfers. It is possible that a (pseudo)
+	// dead node acquires the lease and we are forced to wait out the expiration
+	// timer, if this were not set.
+	settings := cluster.MakeTestingClusterSettings()
+	sv := &settings.SV
+	kvserver.TransferExpirationLeasesFirstEnabled.Override(ctx, sv, false)
+	kvserver.ExpirationLeasesOnly.Override(ctx, sv, false)
 	for i := 0; i < numNodes; i++ {
 		serverArgs[i] = base.TestServerArgs{
 			Locality: localities[i],


### PR DESCRIPTION
*This PR is intended to be backported to `release-22.2`.
 `TestLeasePreferencesDuringOutage` is currently skipped on master.
Stressed for 30 mins without failure on release-22.2.*

Previously, it was possible for a soon-to-be dead replica, to acquire the range lease in the `TestLeasePreferencesDuringOutage` test. The acquired lease would be expiration based, disallowing the intended leaseholder from acquiring the lease.

This patch disables expiration based lease transfers, deflaking the test.

Resolves: #105101
Epic: none

Release note: None