### PR TITLE
kv: fix Replica stringer and SafeFormatter implementations

### DIFF
--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -922,7 +922,7 @@ func (r *Replica) String() string {
 // SafeFormat implements the redact.SafeFormatter interface.
 func (r *Replica) SafeFormat(w redact.SafePrinter, _ rune) {
 	w.Printf("[n%d,s%d,r%s]",
-		r.store.Ident.NodeID, r.store.Ident.StoreID, r.rangeStr.get())
+		r.store.Ident.NodeID, r.store.Ident.StoreID, &r.rangeStr)
 }
 
 // ReplicaID returns the ID for the Replica. This value is fixed for the

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -72,6 +72,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
+	"github.com/cockroachdb/redact"
 	"github.com/kr/pretty"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -469,6 +470,29 @@ func TestIsOnePhaseCommit(t *testing.T) {
 				}
 			})
 	}
+}
+
+func TestReplicaStringAndSafeFormat(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	// This test really only needs a hollow shell of a Store and Replica.
+	s := &Store{}
+	s.Ident = &roachpb.StoreIdent{NodeID: 1, StoreID: 2}
+	r := &Replica{}
+	r.store = s
+	r.rangeStr.store(4, &roachpb.RangeDescriptor{
+		RangeID:  3,
+		StartKey: roachpb.RKey("a"),
+		EndKey:   roachpb.RKey("b"),
+	})
+
+	// String.
+	assert.Equal(t, "[n1,s2,r3/4:{a-b}]", r.String())
+	// Redactable string.
+	assert.EqualValues(t, "[n1,s2,r3/4:‹{a-b}›]", redact.Sprint(r))
+	// Redacted string.
+	assert.EqualValues(t, "[n1,s2,r3/4:‹×›]", redact.Sprint(r).Redact())
 }
 
 // TestReplicaContains verifies that the range uses Key.Address() in


### PR DESCRIPTION
This commit fixes the Replica stringer and SafeFormatter implementations so that they correctly include the range descriptor string. This was unintentionally broken by 897d6e, which changed the return value of `atomicDescString.get`.

Before this change, the stringer implementation looked something like:
```
[n1,s2,r&{3/4:{a-b} 3/4:{a-b} 3/4}]
```
The confusing `&{...}` portion was the internal structure `atomicDescInfo`.

After, it looks like:
```
[n1,s2,r3/4:{a-b}]
```

Epic: None
Release note: None