### PR TITLE
release-23.1: sqlproxyccl: fix non-auth error causing throttle

### DIFF
--- a/pkg/ccl/sqlproxyccl/BUILD.bazel
+++ b/pkg/ccl/sqlproxyccl/BUILD.bazel
@@ -93,6 +93,7 @@ go_test(
         "//pkg/sql",
         "//pkg/sql/catalog/descs",
         "//pkg/sql/pgwire",
+        "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/pgwire/pgwirebase",
         "//pkg/sql/tests",

--- a/pkg/ccl/sqlproxyccl/authentication.go
+++ b/pkg/ccl/sqlproxyccl/authentication.go
@@ -13,9 +13,16 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/interceptor"
 	"github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/throttler"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/errors"
 	pgproto3 "github.com/jackc/pgproto3/v2"
 )
+
+// These errors occur after successful auth but are sent back as a result of
+// the auth request. Receiving such error shouldn't trigger throttle.
+var pgPostAuthErrorCodes = []string{
+	pgcode.TooManyConnections.String(),
+}
 
 // authenticate handles the startup of the pgwire protocol to the point where
 // the connections is considered authenticated. If that doesn't happen, it
@@ -111,13 +118,28 @@ var authenticate = func(
 		// Server has rejected the authentication response from the client and
 		// has closed the connection.
 		case *pgproto3.ErrorResponse:
-			throttleError := throttleHook(throttler.AttemptInvalidCredentials)
+			// The error may be in response of auth message but may not indicate
+			// unsuccessful authentication. Clear throttle if this is the case.
+			var inPostAuthErrorCodes bool
+			for i := range pgPostAuthErrorCodes {
+				if tp.Code == pgPostAuthErrorCodes[i] {
+					inPostAuthErrorCodes = true
+					break
+				}
+			}
+			var throttleError error
+			if inPostAuthErrorCodes {
+				throttleError = throttleHook(throttler.AttemptOK)
+			} else {
+				throttleError = throttleHook(throttler.AttemptInvalidCredentials)
+			}
 			if throttleError != nil {
 				if err = feSend(toPgError(throttleError)); err != nil {
 					return nil, err
 				}
 				return nil, throttleError
 			}
+
 			if err = feSend(backendMsg); err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
Backport 1/1 commits from #108039.

/cc @cockroachdb/release

---

Currently an error that occurs after a successful authentication but before the SQL server is ready to serve queries is considered an authentication failure and causes a throttle. In the cases where the connections are limited (due to usage limits) this causes blocks and prevents the clients to connect. This PR fixes the issue by not considering errors that came after the authentication was successful as conditions to throttle.

Fixes: https://cockroachlabs.atlassian.net/browse/CC-25314

Release note: None

Release justification: bug fix
