### PR TITLE
rttanalysis: relax expected range for drop_3_roles

### DIFF
--- a/pkg/bench/rttanalysis/testdata/benchmark_expectations
+++ b/pkg/bench/rttanalysis/testdata/benchmark_expectations
@@ -41,7 +41,7 @@ exp,benchmark
 17,DropDatabase/drop_database_3_tables
 26,DropRole/drop_1_role
 36,DropRole/drop_2_roles
-45,DropRole/drop_3_roles
+42-45,DropRole/drop_3_roles
 15,DropSequence/drop_1_sequence
 17,DropSequence/drop_2_sequences
 19,DropSequence/drop_3_sequences


### PR DESCRIPTION
This test is mostly meant to assert an uppser bound, so a lower number is better. Some runs of the test in CI take 43 round trips.

fixes https://github.com/cockroachdb/cockroach/issues/108322
backport fixes https://github.com/cockroachdb/cockroach/issues/108292
Release note: None