### PR TITLE
roachtest: double machine size for 8TB restore test

### DIFF
--- a/pkg/cmd/roachtest/tests/restore.go
+++ b/pkg/cmd/roachtest/tests/restore.go
@@ -323,7 +323,12 @@ func registerRestore(r registry.Registry) {
 		},
 		{
 			// The nightly 8TB Restore test.
-			hardware: makeHardwareSpecs(hardwareSpecs{nodes: 10, volumeSize: 2000}),
+			// TODO(pavelkalinnikov): using high memory machines due to the risk of
+			// hitting raft OOM issues. Reduce machine size when OOM issues are fixed:
+			// - https://github.com/cockroachdb/cockroach/issues/73376
+			// - https://github.com/cockroachdb/cockroach/issues/102840
+			// - https://github.com/cockroachdb/cockroach/issues/105338
+			hardware: makeHardwareSpecs(hardwareSpecs{nodes: 10, mem: spec.High, volumeSize: 2000}),
 			backup: makeRestoringBackupSpecs(backupSpecs{
 				version:  "v22.2.1",
 				workload: tpceRestore{customers: 500000}}),


### PR DESCRIPTION
The test occasionally OOMs in the raft stack. Reduce the noise until we fix the
underlying causes of such OOMs.

Similar tests in GCP use n2 machines with 4 GB per CPU, and the AWS test before
this changes used a 2 GB/CPU machine:

```
$ roachtest list restore | grep TB
restore/tpce/32TB/aws/nodes=15/cpus=16 [disaster-recovery]
restore/tpce/32TB/inc-count=400/aws/nodes=15/cpus=16 [disaster-recovery]
restore/tpce/32TB/inc-count=400/gce/nodes=15/cpus=16 [disaster-recovery]
restore/tpce/8TB/aws/nodes=10/cpus=8 [disaster-recovery]
```

After this commit, all O(TB) restore tests use machines with at least 32 GB of
memory.

Touches #106496
Epic: none
Release note: none