### PR TITLE
sqlstats: fix fullScan determination and add test coverage

### DIFF
--- a/pkg/server/combined_statement_stats.go
+++ b/pkg/server/combined_statement_stats.go
@@ -688,16 +688,28 @@ FROM (SELECT fingerprint_id,
 
 		aggregatedTs := tree.MustBeDTimestampTZ(row[3]).Time
 
-		var metadata appstatspb.CollectedStatementStatistics
-		metadataJSON := tree.MustBeDJSON(row[4]).JSON
-		if err = sqlstatsutil.DecodeStmtStatsMetadataJSON(metadataJSON, &metadata); err != nil {
+		// The metadata is aggregated across all the statements with the same fingerprint.
+		aggregateMetadataJSON := tree.MustBeDJSON(row[4]).JSON
+		var aggregateMetadata appstatspb.AggregatedStatementMetadata
+		if err = sqlstatsutil.DecodeAggregatedMetadataJSON(aggregateMetadataJSON, &aggregateMetadata); err != nil {
 			return nil, srverrors.ServerError(ctx, err)
 		}
 
-		metadata.Key.App = app
+		metadata := appstatspb.CollectedStatementStatistics{
+			Key: appstatspb.StatementStatisticsKey{
+				App:          app,
+				DistSQL:      aggregateMetadata.DistSQLCount > 0,
+				FullScan:     aggregateMetadata.FullScanCount > 0,
+				Failed:       aggregateMetadata.FailedCount > 0,
+				Query:        aggregateMetadata.Query,
+				QuerySummary: aggregateMetadata.QuerySummary,
+				Database:     strings.Join(aggregateMetadata.Databases, ","),
+			},
+		}
 
+		var stats appstatspb.StatementStatistics
 		statsJSON := tree.MustBeDJSON(row[5]).JSON
-		if err = sqlstatsutil.DecodeStmtStatsStatisticsJSON(statsJSON, &metadata.Stats); err != nil {
+		if err = sqlstatsutil.DecodeStmtStatsStatisticsJSON(statsJSON, &stats); err != nil {
 			return nil, srverrors.ServerError(ctx, err)
 		}
 
@@ -707,12 +719,11 @@ FROM (SELECT fingerprint_id,
 				AggregatedTs: aggregatedTs,
 			},
 			ID:                appstatspb.StmtFingerprintID(statementFingerprintID),
-			Stats:             metadata.Stats,
+			Stats:             stats,
 			TxnFingerprintIDs: txnFingerprintIDs,
 		}
 
 		statements = append(statements, stmt)
-
 	}
 
 	if err != nil {


### PR DESCRIPTION
Fixes: #107945.

A recent escalation revealed an issue with the "full scan" filter in the
UI, where the filter was not returning any results. Investigation found
that the "full scan" determination was always evaluating to false due to
an incorrect mapping between statements and their expected full scan
property.

This bug fix addresses the problem by ensuring that when reading data
from the SQL stats table to form a response, the "full scan" is marked
as true if there was at least one full scan count in the aggregate data.

Release note (bug fix): fixes the `fullScan` attribute when reading from
sqlstats to be true when there is at least one fullScanCount in the
metadata.