### PR TITLE
sctest: loop var capture fix

### DIFF
--- a/pkg/sql/schemachanger/sctest/framework.go
+++ b/pkg/sql/schemachanger/sctest/framework.go
@@ -712,6 +712,7 @@ func cumulativeTestForEachPostCommitStage(
 			}
 			var hasFailed bool
 			for _, tc := range testCases {
+				tc := tc // capture loop variable
 				fn := func(t *testing.T) {
 					t.Parallel() // SAFE FOR TESTING
 					tf(t, tc)


### PR DESCRIPTION
`tc` variable will be captured by reference in a loop and used by a parallel test, resulting in only the last case being tested. This change captures `tc`.

Release note: None
Epic: None