### PR TITLE
kv: deflake TestFollowerReadsWithStaleDescriptor

### DIFF
--- a/pkg/base/test_server_args.go
+++ b/pkg/base/test_server_args.go
@@ -153,6 +153,9 @@ type TestServerArgs struct {
 	// config span.
 	DisableSpanConfigs bool
 
+	// DisableKVProber disables the use of the kvprober infrastructure.
+	DisableKVProber bool
+
 	// TestServer will probabilistically start a single test tenant on each node
 	// for multi-tenant testing, and default all connections through that tenant.
 	// Use this flag to change this behavior. You might want/need to alter this

--- a/pkg/ccl/kvccl/kvfollowerreadsccl/followerreads_test.go
+++ b/pkg/ccl/kvccl/kvfollowerreadsccl/followerreads_test.go
@@ -716,6 +716,9 @@ func TestFollowerReadsWithStaleDescriptor(t *testing.T) {
 				3: {
 					DefaultTestTenant: base.TODOTestTenantDisabled,
 					UseDatabase:       "t",
+					// Disable kvprober to prevent it from interfering with the test.
+					// kvprober can cause unexpected updates to the range cache.
+					DisableKVProber: true,
 					Knobs: base.TestingKnobs{
 						KVClient: &kvcoord.ClientTestingKnobs{
 							// Inhibit the checking of connection health done by the

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -204,6 +204,9 @@ type BaseConfig struct {
 	// Environment Variable: COCKROACH_DISABLE_SPAN_CONFIGS
 	SpanConfigsDisabled bool
 
+	// DisableKVProber disables the use of the kvprober infrastructure.
+	DisableKVProber bool
+
 	// Disables the default test tenant.
 	DisableDefaultTestTenant bool
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -2148,8 +2148,11 @@ func (s *topLevelServer) PreStart(ctx context.Context) error {
 	// global tenant capabilities state.
 	s.rpcContext.TenantRPCAuthorizer.BindReader(s.tenantCapabilitiesWatcher)
 
-	if err := s.kvProber.Start(workersCtx, s.stopper); err != nil {
-		return errors.Wrapf(err, "failed to start KV prober")
+	// If enabled, start kvprober.
+	if !s.cfg.DisableKVProber {
+		if err := s.kvProber.Start(workersCtx, s.stopper); err != nil {
+			return errors.Wrapf(err, "failed to start KV prober")
+		}
 	}
 
 	// Perform loss of quorum recovery cleanup if any actions were scheduled.

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -257,6 +257,9 @@ func makeTestConfigFromParams(params base.TestServerArgs) Config {
 	if params.DisableSpanConfigs {
 		cfg.SpanConfigsDisabled = true
 	}
+	if params.DisableKVProber {
+		cfg.DisableKVProber = true
+	}
 	if params.SnapshotApplyLimit != 0 {
 		cfg.SnapshotApplyLimit = params.SnapshotApplyLimit
 	}


### PR DESCRIPTION
Fixes #108349.

This commit deflakes TestFollowerReadsWithStaleDescriptor by disabling kvprober. As of 769ba1c4, kvprober is now metaphorically enabled in all tests. When enabled, it can cause unexpected updates to the range cache, which trip up the test's assertion that a given query is not served on a newly added follower replica.

The failure was easy to reproduce if I added a sleep after the non-voter addition. This change deflakes the test (even with this sleep) by disabling kvprober.

Release note: None