### PR TITLE
release-23.1: rttanalysis: relax expected range for drop_3_roles

### DIFF
--- a/pkg/bench/rttanalysis/testdata/benchmark_expectations
+++ b/pkg/bench/rttanalysis/testdata/benchmark_expectations
@@ -41,7 +41,7 @@ exp,benchmark
 17,DropDatabase/drop_database_3_tables
 26,DropRole/drop_1_role
 34,DropRole/drop_2_roles
-42,DropRole/drop_3_roles
+39-42,DropRole/drop_3_roles
 15,DropSequence/drop_1_sequence
 17,DropSequence/drop_2_sequences
 19,DropSequence/drop_3_sequences


### PR DESCRIPTION
Backport 1/1 commits from #108346.

/cc @cockroachdb/release

---

This test is mostly meant to assert an upper bound, so a lower number is better. Some runs of the test in CI take 40 round trips.

fixes https://github.com/cockroachdb/cockroach/issues/108322
backport fixes https://github.com/cockroachdb/cockroach/issues/108292
Release justification: test only change
Release note: None
