### PR TITLE
server: fix a race when reading `server` object

### DIFF
--- a/pkg/server/server_controller_channel_orchestrator.go
+++ b/pkg/server/server_controller_channel_orchestrator.go
@@ -106,7 +106,10 @@ var _ serverState = (*serverStateUsingChannels)(nil)
 
 // getServer is part of the serverState interface.
 func (s *serverStateUsingChannels) getServer() (orchestratedServer, bool) {
-	return s.server, s.started.Get()
+	if s.started.Get() {
+		return s.server, true
+	}
+	return nil, false
 }
 
 // nameContainer is part of the serverState interface.


### PR DESCRIPTION
Avoid returning `server` when it's not ready - we shouldn't read it when `started` is false (that's a race).

Testing: this test (sometimes) fails without this pr and succeeds with it:
`./dev test pkg/ccl/streamingccl/streamingest:streamingest_test -f TestDataDriven --race -- --runs_per_test=10`

Epic: none
Informs: #107930

Release note: None