### PR TITLE
changefeedccl: Increase test utility timeout

### DIFF
--- a/pkg/ccl/changefeedccl/cdctest/row.go
+++ b/pkg/ccl/changefeedccl/cdctest/row.go
@@ -53,7 +53,7 @@ func MakeRangeFeedValueReader(
 	)
 	require.NoError(t, err)
 
-	var timeout = 5 * time.Second
+	var timeout = 10 * time.Second
 	if util.RaceEnabled {
 		timeout = 3 * timeout
 	}


### PR DESCRIPTION
As observed in #108348, a test failed because
it timed out reading a row.  Yet, this flake
could not be reproduced in over 50k runs.
Bump timeout period to make this flake even
less likely.

Fixes #108348

Release note: None