### PR TITLE
build: update ci timeout for enormous targets

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -51,7 +51,7 @@ test:test --test_env=TZ=
 test:race --test_timeout=1200,6000,18000,72000
 
 # CI uses a custom timeout for enormous targets.
-test:use_ci_timeouts --test_timeout=60,300,900,900 --define=use_ci_timeouts=true
+test:use_ci_timeouts --test_timeout=60,300,900,1500 --define=use_ci_timeouts=true
 # CI should always run with `--config=ci`.
 build:ci --lintonbuild
 # Set `-test.v` in Go tests.

--- a/pkg/ccl/backupccl/BUILD.bazel
+++ b/pkg/ccl/backupccl/BUILD.bazel
@@ -200,7 +200,7 @@ go_test(
         "utils_test.go",
     ],
     args = select({
-        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=1495s"],
         "//conditions:default": ["-test.timeout=3595s"],
     }),
     data = glob(["testdata/**"]) + ["//c-deps:libgeos"],

--- a/pkg/ccl/benchccl/rttanalysisccl/BUILD.bazel
+++ b/pkg/ccl/benchccl/rttanalysisccl/BUILD.bazel
@@ -8,7 +8,7 @@ go_test(
         "multi_region_bench_test.go",
     ],
     args = select({
-        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=1495s"],
         "//conditions:default": ["-test.timeout=3595s"],
     }),
     data = glob(["testdata/**"]),

--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -202,7 +202,7 @@ go_test(
         "validations_test.go",
     ],
     args = select({
-        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=1495s"],
         "//conditions:default": ["-test.timeout=3595s"],
     }),
     embed = [":changefeedccl"],

--- a/pkg/ccl/kvccl/kvtenantccl/upgradeinterlockccl/BUILD.bazel
+++ b/pkg/ccl/kvccl/kvtenantccl/upgradeinterlockccl/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
         "main_test.go",
     ],
     args = select({
-        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=1495s"],
         "//conditions:default": ["-test.timeout=3595s"],
     }),
     shard_count = 14,

--- a/pkg/ccl/logictestccl/tests/3node-tenant-multiregion/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/3node-tenant-multiregion/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "enormous",
     srcs = ["generated_test.go"],
     args = select({
-        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=1495s"],
         "//conditions:default": ["-test.timeout=3595s"],
     }),
     data = [

--- a/pkg/ccl/logictestccl/tests/3node-tenant/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/3node-tenant/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "enormous",
     srcs = ["generated_test.go"],
     args = select({
-        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=1495s"],
         "//conditions:default": ["-test.timeout=3595s"],
     }),
     data = [

--- a/pkg/ccl/logictestccl/tests/5node/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/5node/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "enormous",
     srcs = ["generated_test.go"],
     args = select({
-        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=1495s"],
         "//conditions:default": ["-test.timeout=3595s"],
     }),
     data = [

--- a/pkg/ccl/logictestccl/tests/fakedist-disk/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/fakedist-disk/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "enormous",
     srcs = ["generated_test.go"],
     args = select({
-        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=1495s"],
         "//conditions:default": ["-test.timeout=3595s"],
     }),
     data = [

--- a/pkg/ccl/logictestccl/tests/fakedist-vec-off/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/fakedist-vec-off/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "enormous",
     srcs = ["generated_test.go"],
     args = select({
-        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=1495s"],
         "//conditions:default": ["-test.timeout=3595s"],
     }),
     data = [

--- a/pkg/ccl/logictestccl/tests/fakedist/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/fakedist/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "enormous",
     srcs = ["generated_test.go"],
     args = select({
-        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=1495s"],
         "//conditions:default": ["-test.timeout=3595s"],
     }),
     data = [

--- a/pkg/ccl/logictestccl/tests/local-legacy-schema-changer/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/local-legacy-schema-changer/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "enormous",
     srcs = ["generated_test.go"],
     args = select({
-        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=1495s"],
         "//conditions:default": ["-test.timeout=3595s"],
     }),
     data = [

--- a/pkg/ccl/logictestccl/tests/local-mixed-22.2-23.1/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/local-mixed-22.2-23.1/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "enormous",
     srcs = ["generated_test.go"],
     args = select({
-        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=1495s"],
         "//conditions:default": ["-test.timeout=3595s"],
     }),
     data = [

--- a/pkg/ccl/logictestccl/tests/local-vec-off/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/local-vec-off/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "enormous",
     srcs = ["generated_test.go"],
     args = select({
-        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=1495s"],
         "//conditions:default": ["-test.timeout=3595s"],
     }),
     data = [

--- a/pkg/ccl/logictestccl/tests/local/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/local/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "enormous",
     srcs = ["generated_test.go"],
     args = select({
-        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=1495s"],
         "//conditions:default": ["-test.timeout=3595s"],
     }),
     data = [

--- a/pkg/ccl/logictestccl/tests/multiregion-15node-5region-3azs/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/multiregion-15node-5region-3azs/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "enormous",
     srcs = ["generated_test.go"],
     args = select({
-        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=1495s"],
         "//conditions:default": ["-test.timeout=3595s"],
     }),
     data = [

--- a/pkg/ccl/logictestccl/tests/multiregion-3node-3superlongregions/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/multiregion-3node-3superlongregions/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "enormous",
     srcs = ["generated_test.go"],
     args = select({
-        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=1495s"],
         "//conditions:default": ["-test.timeout=3595s"],
     }),
     data = [

--- a/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs-no-los/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs-no-los/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "enormous",
     srcs = ["generated_test.go"],
     args = select({
-        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=1495s"],
         "//conditions:default": ["-test.timeout=3595s"],
     }),
     data = [

--- a/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs-tenant/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs-tenant/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "enormous",
     srcs = ["generated_test.go"],
     args = select({
-        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=1495s"],
         "//conditions:default": ["-test.timeout=3595s"],
     }),
     data = [

--- a/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs-vec-off/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs-vec-off/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "enormous",
     srcs = ["generated_test.go"],
     args = select({
-        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=1495s"],
         "//conditions:default": ["-test.timeout=3595s"],
     }),
     data = [

--- a/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "enormous",
     srcs = ["generated_test.go"],
     args = select({
-        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=1495s"],
         "//conditions:default": ["-test.timeout=3595s"],
     }),
     data = [

--- a/pkg/ccl/multiregionccl/BUILD.bazel
+++ b/pkg/ccl/multiregionccl/BUILD.bazel
@@ -39,7 +39,7 @@ go_test(
         "unique_test.go",
     ],
     args = select({
-        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=1495s"],
         "//conditions:default": ["-test.timeout=3595s"],
     }),
     data = glob(["testdata/**"]),

--- a/pkg/ccl/schemachangerccl/BUILD.bazel
+++ b/pkg/ccl/schemachangerccl/BUILD.bazel
@@ -24,7 +24,7 @@ go_test(
         ":test_gen_ccl",  # keep
     ],
     args = select({
-        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=1495s"],
         "//conditions:default": ["-test.timeout=3595s"],
     }),
     data = glob(["testdata/**"]) + [

--- a/pkg/ccl/serverccl/BUILD.bazel
+++ b/pkg/ccl/serverccl/BUILD.bazel
@@ -42,7 +42,7 @@ go_test(
         "tenant_vars_test.go",
     ],
     args = select({
-        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=1495s"],
         "//conditions:default": ["-test.timeout=3595s"],
     }),
     data = glob(["testdata/**"]),

--- a/pkg/cmd/generate-bazel-extra/main.go
+++ b/pkg/cmd/generate-bazel-extra/main.go
@@ -36,7 +36,7 @@ var (
 		"small":    60,
 		"medium":   300,
 		"large":    900,
-		"enormous": 900,
+		"enormous": 1500,
 	}
 )
 

--- a/pkg/cmd/generate-logictest/templates.go
+++ b/pkg/cmd/generate-logictest/templates.go
@@ -257,7 +257,7 @@ go_test(
     srcs = ["generated_test.go"],{{ if .SqliteLogicTest }}
     args = ["-test.timeout=7195s"],{{ else }}
     args = select({
-        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=1495s"],
         "//conditions:default": ["-test.timeout=3595s"],
     }),{{ end }}
     data = [

--- a/pkg/compose/BUILD.bazel
+++ b/pkg/compose/BUILD.bazel
@@ -12,7 +12,7 @@ go_test(
     size = "enormous",
     srcs = ["compose_test.go"],
     args = select({
-        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=1495s"],
         "//conditions:default": ["-test.timeout=3595s"],
     }),
     data = [

--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -355,7 +355,7 @@ go_test(
         "txn_wait_queue_test.go",
     ],
     args = select({
-        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=1495s"],
         "//conditions:default": ["-test.timeout=3595s"],
     }),
     data = glob(["testdata/**"]),

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -465,7 +465,7 @@ go_test(
         "version_cluster_test.go",
     ],
     args = select({
-        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=1495s"],
         "//conditions:default": ["-test.timeout=3595s"],
     }),
     data = glob(["testdata/**"]),

--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -721,7 +721,7 @@ go_test(
         "zone_test.go",
     ],
     args = select({
-        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=1495s"],
         "//conditions:default": ["-test.timeout=3595s"],
     }),
     data = glob(["testdata/**"]) + [

--- a/pkg/sql/logictest/tests/5node-disk/BUILD.bazel
+++ b/pkg/sql/logictest/tests/5node-disk/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "enormous",
     srcs = ["generated_test.go"],
     args = select({
-        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=1495s"],
         "//conditions:default": ["-test.timeout=3595s"],
     }),
     data = [

--- a/pkg/sql/logictest/tests/5node/BUILD.bazel
+++ b/pkg/sql/logictest/tests/5node/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "enormous",
     srcs = ["generated_test.go"],
     args = select({
-        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=1495s"],
         "//conditions:default": ["-test.timeout=3595s"],
     }),
     data = [

--- a/pkg/sql/logictest/tests/cockroach-go-testserver-upgrade-to-master/BUILD.bazel
+++ b/pkg/sql/logictest/tests/cockroach-go-testserver-upgrade-to-master/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "enormous",
     srcs = ["generated_test.go"],
     args = select({
-        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=1495s"],
         "//conditions:default": ["-test.timeout=3595s"],
     }),
     data = [

--- a/pkg/sql/logictest/tests/fakedist-disk/BUILD.bazel
+++ b/pkg/sql/logictest/tests/fakedist-disk/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "enormous",
     srcs = ["generated_test.go"],
     args = select({
-        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=1495s"],
         "//conditions:default": ["-test.timeout=3595s"],
     }),
     data = [

--- a/pkg/sql/logictest/tests/fakedist-vec-off/BUILD.bazel
+++ b/pkg/sql/logictest/tests/fakedist-vec-off/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "enormous",
     srcs = ["generated_test.go"],
     args = select({
-        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=1495s"],
         "//conditions:default": ["-test.timeout=3595s"],
     }),
     data = [

--- a/pkg/sql/logictest/tests/fakedist/BUILD.bazel
+++ b/pkg/sql/logictest/tests/fakedist/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "enormous",
     srcs = ["generated_test.go"],
     args = select({
-        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=1495s"],
         "//conditions:default": ["-test.timeout=3595s"],
     }),
     data = [

--- a/pkg/sql/logictest/tests/local-legacy-schema-changer/BUILD.bazel
+++ b/pkg/sql/logictest/tests/local-legacy-schema-changer/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "enormous",
     srcs = ["generated_test.go"],
     args = select({
-        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=1495s"],
         "//conditions:default": ["-test.timeout=3595s"],
     }),
     data = [

--- a/pkg/sql/logictest/tests/local-mixed-22.2-23.1/BUILD.bazel
+++ b/pkg/sql/logictest/tests/local-mixed-22.2-23.1/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "enormous",
     srcs = ["generated_test.go"],
     args = select({
-        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=1495s"],
         "//conditions:default": ["-test.timeout=3595s"],
     }),
     data = [

--- a/pkg/sql/logictest/tests/local-vec-off/BUILD.bazel
+++ b/pkg/sql/logictest/tests/local-vec-off/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "enormous",
     srcs = ["generated_test.go"],
     args = select({
-        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=1495s"],
         "//conditions:default": ["-test.timeout=3595s"],
     }),
     data = [

--- a/pkg/sql/logictest/tests/local/BUILD.bazel
+++ b/pkg/sql/logictest/tests/local/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "enormous",
     srcs = ["generated_test.go"],
     args = select({
-        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=1495s"],
         "//conditions:default": ["-test.timeout=3595s"],
     }),
     data = [

--- a/pkg/sql/logictest/tests/multiregion-9node-3region-3azs/BUILD.bazel
+++ b/pkg/sql/logictest/tests/multiregion-9node-3region-3azs/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "enormous",
     srcs = ["generated_test.go"],
     args = select({
-        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=1495s"],
         "//conditions:default": ["-test.timeout=3595s"],
     }),
     data = [

--- a/pkg/sql/logictest/tests/multiregion-invalid-locality/BUILD.bazel
+++ b/pkg/sql/logictest/tests/multiregion-invalid-locality/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "enormous",
     srcs = ["generated_test.go"],
     args = select({
-        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=1495s"],
         "//conditions:default": ["-test.timeout=3595s"],
     }),
     data = [

--- a/pkg/sql/opt/exec/execbuilder/tests/5node/BUILD.bazel
+++ b/pkg/sql/opt/exec/execbuilder/tests/5node/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "enormous",
     srcs = ["generated_test.go"],
     args = select({
-        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=1495s"],
         "//conditions:default": ["-test.timeout=3595s"],
     }),
     data = [

--- a/pkg/sql/opt/exec/execbuilder/tests/fakedist-disk/BUILD.bazel
+++ b/pkg/sql/opt/exec/execbuilder/tests/fakedist-disk/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "enormous",
     srcs = ["generated_test.go"],
     args = select({
-        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=1495s"],
         "//conditions:default": ["-test.timeout=3595s"],
     }),
     data = [

--- a/pkg/sql/opt/exec/execbuilder/tests/fakedist-vec-off/BUILD.bazel
+++ b/pkg/sql/opt/exec/execbuilder/tests/fakedist-vec-off/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "enormous",
     srcs = ["generated_test.go"],
     args = select({
-        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=1495s"],
         "//conditions:default": ["-test.timeout=3595s"],
     }),
     data = [

--- a/pkg/sql/opt/exec/execbuilder/tests/fakedist/BUILD.bazel
+++ b/pkg/sql/opt/exec/execbuilder/tests/fakedist/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "enormous",
     srcs = ["generated_test.go"],
     args = select({
-        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=1495s"],
         "//conditions:default": ["-test.timeout=3595s"],
     }),
     data = [

--- a/pkg/sql/opt/exec/execbuilder/tests/local-legacy-schema-changer/BUILD.bazel
+++ b/pkg/sql/opt/exec/execbuilder/tests/local-legacy-schema-changer/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "enormous",
     srcs = ["generated_test.go"],
     args = select({
-        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=1495s"],
         "//conditions:default": ["-test.timeout=3595s"],
     }),
     data = [

--- a/pkg/sql/opt/exec/execbuilder/tests/local-mixed-22.2-23.1/BUILD.bazel
+++ b/pkg/sql/opt/exec/execbuilder/tests/local-mixed-22.2-23.1/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "enormous",
     srcs = ["generated_test.go"],
     args = select({
-        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=1495s"],
         "//conditions:default": ["-test.timeout=3595s"],
     }),
     data = [

--- a/pkg/sql/opt/exec/execbuilder/tests/local-vec-off/BUILD.bazel
+++ b/pkg/sql/opt/exec/execbuilder/tests/local-vec-off/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "enormous",
     srcs = ["generated_test.go"],
     args = select({
-        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=1495s"],
         "//conditions:default": ["-test.timeout=3595s"],
     }),
     data = [

--- a/pkg/sql/opt/exec/execbuilder/tests/local/BUILD.bazel
+++ b/pkg/sql/opt/exec/execbuilder/tests/local/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "enormous",
     srcs = ["generated_test.go"],
     args = select({
-        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=1495s"],
         "//conditions:default": ["-test.timeout=3595s"],
     }),
     data = [

--- a/pkg/sql/schemachanger/BUILD.bazel
+++ b/pkg/sql/schemachanger/BUILD.bazel
@@ -29,7 +29,7 @@ go_test(
         ":test_gen",  # keep
     ],
     args = select({
-        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=1495s"],
         "//conditions:default": ["-test.timeout=3595s"],
     }),
     data = glob(["testdata/**"]),

--- a/pkg/storage/metamorphic/BUILD.bazel
+++ b/pkg/storage/metamorphic/BUILD.bazel
@@ -42,7 +42,7 @@ go_test(
         "parser_test.go",
     ],
     args = select({
-        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=1495s"],
         "//conditions:default": ["-test.timeout=3595s"],
     }),
     data = glob(["testdata/**"]),


### PR DESCRIPTION
This change updates the timeout for enormous targets in CI from 15 minutes to 25 minutes.

Release note: None
Epic: none