### PR TITLE
sql: fix typing of CASE statements to match Postgres

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/order_by
+++ b/pkg/sql/logictest/testdata/logic_test/order_by
@@ -166,7 +166,7 @@ query I
 query error pgcode 42601 multiple ORDER BY clauses not allowed
 ((SELECT a FROM t ORDER BY a)) ORDER BY a
 
-query error expected c to be of type int, found type bool
+query error expected b to be of type bool, found type int
 SELECT CASE a WHEN 1 THEN b ELSE c END as val FROM t ORDER BY val
 
 query error pgcode 42P10 ORDER BY position 0 is not in select list

--- a/pkg/sql/logictest/testdata/logic_test/tuple
+++ b/pkg/sql/logictest/testdata/logic_test/tuple
@@ -1196,10 +1196,16 @@ CREATE TABLE t78159 (b BOOL)
 statement ok
 INSERT INTO t78159 VALUES (false)
 
-query B
-SELECT (CASE WHEN b THEN ((ROW(1) AS a)) ELSE NULL END).a from t78159
+query I
+SELECT (CASE WHEN b THEN NULL ELSE ((ROW(1) AS a)) END).a from t78159
 ----
-NULL
+1
+
+# TODO(rytaft): Uncomment this case once #109105 is fixed.
+# query B
+# SELECT (CASE WHEN b THEN ((ROW(1) AS a)) ELSE NULL END).a from t78159
+# ----
+# NULL
 
 # Regression test for #78515. Propagate tuple labels when type-checking
 # expressions with multiple matching tuple types.
@@ -1208,14 +1214,12 @@ subtest 78515
 statement ok
 SELECT (CASE WHEN false THEN (ROW(1) AS a) ELSE (ROW(2) AS a) END).a;
 
-# The label of the first tuple is used in the type of the CASE expression. This
-# is similar to Postgres, but not exactly the same - Postgres uses the labels of
-# the last tuple. This difference should be addressed in the future when we try
-# to adhere more closely to Postgres's type conversion behavior (see #75101).
-statement ok
+# The label of the last tuple is used in the type of the CASE expression. This
+# matches Postgres behavior.
+statement error could not identify column \"a\" in tuple{int AS b}
 SELECT (CASE WHEN false THEN (ROW(1) AS a) ELSE (ROW(2) AS b) END).a;
 
-statement error could not identify column \"b\" in tuple{int AS a}
+statement ok
 SELECT (CASE WHEN false THEN (ROW(1) AS a) ELSE (ROW(2) AS b) END).b;
 
 subtest end

--- a/pkg/sql/logictest/testdata/logic_test/typing
+++ b/pkg/sql/logictest/testdata/logic_test/typing
@@ -273,3 +273,43 @@ SELECT ARRAY[]::TIMESTAMPTZ[] >
 query error pq: cannot determine type of empty array\. Consider casting to the desired type, for example ARRAY\[\]::int\[\]
 SELECT ARRAY[]::TIMESTAMPTZ[] <
        SOME (ARRAY[TIMESTAMPTZ '1969-12-29T21:20:13+01'], ARRAY[NULL]);
+
+# Regression test for #102110. Ensure CASE is typed correctly.
+statement ok
+CREATE TABLE t102110_1 (t TEXT);
+INSERT INTO t102110_1 VALUES ('tt');
+
+statement ok
+CREATE TABLE t102110_2 (c CHAR);
+INSERT INTO t102110_2 VALUES ('c');
+
+query T
+SELECT t102110_1.t FROM t102110_1, t102110_2
+WHERE t102110_1.t NOT BETWEEN t102110_1.t AND
+  (CASE WHEN NULL THEN t102110_2.c ELSE t102110_1.t END);
+----
+
+# IF is typed differently (Postgres does not support IF).
+query T
+SELECT t102110_1.t FROM t102110_1, t102110_2
+WHERE t102110_1.t NOT BETWEEN t102110_1.t AND
+  IF(NULL, t102110_2.c, t102110_1.t);
+----
+tt
+
+# TODO(#108360): implicit casts from STRING to CHAR should use bpchar.
+statement ok
+CREATE TABLE t108360_1 (t TEXT);
+INSERT INTO t108360_1 VALUES ('tt');
+
+statement ok
+CREATE TABLE t108360_2 (c CHAR);
+INSERT INTO t108360_2 VALUES ('c');
+
+# This returns one row with 'tt' in Postgres. The results are different because
+# Postgres casts t108360_1.t to bpchar rather than char.
+query T
+SELECT (CASE WHEN t108360_1.t > t108360_2.c THEN t108360_1.t ELSE t108360_2.c END)
+FROM t108360_1, t108360_2
+WHERE t108360_1.t = (CASE WHEN t108360_1.t > t108360_2.c THEN t108360_1.t ELSE t108360_2.c END);
+----

--- a/pkg/sql/opt/exec/execbuilder/testdata/scalar
+++ b/pkg/sql/opt/exec/execbuilder/testdata/scalar
@@ -1285,8 +1285,13 @@ vectorized: true
 
 # Regression test for #57959. This should not cause an error due to
 # "comparison overload not found".
-query T
+query error pq: incompatible value type: cannot determine type of empty array. Consider casting to the desired type, for example ARRAY[]::int[]
 EXPLAIN (VERBOSE) SELECT * FROM t0 WHERE (CASE WHEN (t0.c0) IN (t0.c0) THEN ARRAY[NULL] ELSE ARRAY[] END) IS NULL
+
+# TODO(rytaft): On Postgres this case returns ERROR: cannot determine type of
+# empty array.
+query T
+EXPLAIN (VERBOSE) SELECT * FROM t0 WHERE (CASE WHEN (t0.c0) IN (t0.c0) THEN ARRAY[] ELSE ARRAY[NULL] END) IS NULL
 ----
 distribution: local
 vectorized: true
@@ -1294,7 +1299,7 @@ vectorized: true
 • filter
 │ columns: (c0)
 │ estimated row count: 333 (missing stats)
-│ filter: CASE WHEN (c0 IS DISTINCT FROM CAST(NULL AS DECIMAL)) OR CAST(NULL AS BOOL) THEN ARRAY[NULL] ELSE ARRAY[] END IS NULL
+│ filter: CASE WHEN (c0 IS DISTINCT FROM CAST(NULL AS DECIMAL)) OR CAST(NULL AS BOOL) THEN ARRAY[] ELSE ARRAY[NULL] END IS NULL
 │
 └── • scan
       columns: (c0)

--- a/pkg/sql/opt/optbuilder/testdata/orderby
+++ b/pkg/sql/opt/optbuilder/testdata/orderby
@@ -364,7 +364,7 @@ error (42601): multiple ORDER BY clauses not allowed
 build
 SELECT CASE a WHEN 1 THEN b ELSE c END as val FROM t ORDER BY val
 ----
-error (22023): incompatible value type: expected c to be of type int, found type bool
+error (22023): incompatible value type: expected b to be of type bool, found type int
 
 build
 SELECT * FROM t ORDER BY 0

--- a/pkg/sql/opt/optbuilder/testdata/scalar
+++ b/pkg/sql/opt/optbuilder/testdata/scalar
@@ -1343,10 +1343,9 @@ case [type=oid]
  ├── when [type=oid]
  │    ├── true [type=bool]
  │    └── const: 1234 [type=oid]
- └── coalesce [type=oid]
-      ├── cast: OID [type=oid]
-      │    └── null [type=unknown]
-      └── cast: OID [type=oid]
+ └── cast: OID [type=oid]
+      └── coalesce [type=unknown]
+           ├── null [type=unknown]
            └── null [type=unknown]
 
 # Make sure NULL arguments for AND/OR/NOT are typed as boolean.
@@ -1470,7 +1469,7 @@ error: unsupported comparison operator: <geometry[]> && <geometry>
 # Regression test for #57959. Ensure that the CASE statement is typed as
 # string[].
 build-scalar vars=(a varbit)
-(CASE WHEN (a) IN (a) THEN ARRAY[NULL] ELSE ARRAY[] END) IS NULL
+(CASE WHEN (a) IN (a) THEN ARRAY[] ELSE ARRAY[NULL] END) IS NULL
 ----
 is [type=bool]
  ├── case [type=string[]]
@@ -1481,24 +1480,57 @@ is [type=bool]
  │    │    │    └── tuple [type=tuple{varbit}]
  │    │    │         └── variable: a:1 [type=varbit]
  │    │    └── array: [type=string[]]
- │    │         └── null [type=unknown]
  │    └── array: [type=string[]]
+ │         └── null [type=unknown]
  └── null [type=unknown]
+
+build-scalar vars=(a varbit)
+(CASE WHEN (a) IN (a) THEN ARRAY[NULL] ELSE ARRAY[] END) IS NULL
+----
+error: incompatible value type: cannot determine type of empty array. Consider casting to the desired type, for example ARRAY[]::int[]
 
 # Regression test for #75365. Do not create invalid casts when building CASE
 # expressions. We build a Select expressions here instead of a scalar so that
 # logical properties are generated, which is required to reproduce the bug.
-# TODO(#75103): We should be more permissive with casts of arrays of tuples.
-# These tests should be successful, not user-facing errors.
+build
+SELECT CASE WHEN false THEN ARRAY[]::RECORD[] ELSE ARRAY[('', 0)] END
+----
+project
+ ├── columns: array:1!null
+ ├── values
+ │    └── ()
+ └── projections
+      └── CASE WHEN false THEN ARRAY[] ELSE ARRAY[('', 0)]::RECORD[] END [as=array:1]
+
+build
+SELECT CASE WHEN false THEN ARRAY[('', 0)] WHEN true THEN ARRAY[('', 0)] ELSE ARRAY[]::RECORD[] END
+----
+project
+ ├── columns: array:1!null
+ ├── values
+ │    └── ()
+ └── projections
+      └── CASE WHEN false THEN ARRAY[('', 0)]::RECORD[] WHEN true THEN ARRAY[('', 0)]::RECORD[] ELSE ARRAY[] END [as=array:1]
+
 build
 SELECT CASE WHEN false THEN ARRAY[('', 0)] ELSE ARRAY[]::RECORD[] END
 ----
-error (42804): CASE ELSE type tuple[] cannot be matched to WHEN type tuple{string, int}[]
+project
+ ├── columns: array:1!null
+ ├── values
+ │    └── ()
+ └── projections
+      └── CASE WHEN false THEN ARRAY[('', 0)]::RECORD[] ELSE ARRAY[] END [as=array:1]
 
 build
 SELECT CASE WHEN false THEN ARRAY[('', 0)] WHEN true THEN ARRAY[]::RECORD[] ELSE ARRAY[('', 0)] END
 ----
-error (42804): CASE WHEN types tuple[] and tuple{string, int}[] cannot be matched
+project
+ ├── columns: array:1!null
+ ├── values
+ │    └── ()
+ └── projections
+      └── CASE WHEN false THEN ARRAY[('', 0)]::RECORD[] WHEN true THEN ARRAY[] ELSE ARRAY[('', 0)]::RECORD[] END [as=array:1]
 
 # Regression test for #76807. Do not create invalid casts when building COALESCE
 # and IF expressions.
@@ -1506,7 +1538,13 @@ build
 SELECT COALESCE(t.v, ARRAY[]:::RECORD[])
 FROM (VALUES (ARRAY[(1, 'foo')])) AS t(v)
 ----
-error (42804): COALESCE types tuple[] and tuple{int, string}[] cannot be matched
+project
+ ├── columns: coalesce:2
+ ├── values
+ │    ├── columns: column1:1
+ │    └── (ARRAY[(1, 'foo')],)
+ └── projections
+      └── COALESCE(column1:1::RECORD[], ARRAY[]) [as=coalesce:2]
 
 build
 SELECT COALESCE(ARRAY[]:::RECORD[], t.v)
@@ -1524,7 +1562,13 @@ build
 SELECT IF(true, t.v, ARRAY[]:::RECORD[])
 FROM (VALUES (ARRAY[(1, 'foo')])) AS t(v)
 ----
-error (42804): IF types tuple[] and tuple{int, string}[] cannot be matched
+project
+ ├── columns: if:2
+ ├── values
+ │    ├── columns: column1:1
+ │    └── (ARRAY[(1, 'foo')],)
+ └── projections
+      └── CASE WHEN true THEN column1:1::RECORD[] ELSE ARRAY[] END [as=if:2]
 
 build
 SELECT IF(true, ARRAY[]:::RECORD[], t.v)
@@ -1537,3 +1581,101 @@ project
  │    └── (ARRAY[(1, 'foo')],)
  └── projections
       └── CASE WHEN true THEN ARRAY[] ELSE column1:1::RECORD[] END [as=if:2]
+
+# Regression test for #102110. Ensure that CASE is typed correctly when
+# different types are used in different branches.
+exec-ddl
+CREATE TABLE t102110_1 (t TEXT);
+----
+
+exec-ddl
+CREATE TABLE t102110_2 (c CHAR);
+----
+
+build
+SELECT t102110_1.t FROM t102110_1, t102110_2
+WHERE t102110_1.t NOT BETWEEN t102110_1.t AND
+  (CASE WHEN NULL THEN t102110_2.c ELSE t102110_1.t END);
+----
+project
+ ├── columns: t:1
+ └── select
+      ├── columns: t:1 t102110_1.rowid:2!null t102110_1.crdb_internal_mvcc_timestamp:3 t102110_1.tableoid:4 c:5 t102110_2.rowid:6!null t102110_2.crdb_internal_mvcc_timestamp:7 t102110_2.tableoid:8
+      ├── inner-join (cross)
+      │    ├── columns: t:1 t102110_1.rowid:2!null t102110_1.crdb_internal_mvcc_timestamp:3 t102110_1.tableoid:4 c:5 t102110_2.rowid:6!null t102110_2.crdb_internal_mvcc_timestamp:7 t102110_2.tableoid:8
+      │    ├── scan t102110_1
+      │    │    └── columns: t:1 t102110_1.rowid:2!null t102110_1.crdb_internal_mvcc_timestamp:3 t102110_1.tableoid:4
+      │    ├── scan t102110_2
+      │    │    └── columns: c:5 t102110_2.rowid:6!null t102110_2.crdb_internal_mvcc_timestamp:7 t102110_2.tableoid:8
+      │    └── filters (true)
+      └── filters
+           └── NOT ((t:1 >= t:1) AND (t:1 <= CASE WHEN NULL THEN c:5::STRING ELSE t:1 END))
+
+build
+SELECT t102110_1.t FROM t102110_1, t102110_2
+WHERE t102110_1.t NOT BETWEEN t102110_1.t AND
+  (CASE WHEN NULL THEN t102110_1.t ELSE t102110_2.c END);
+----
+project
+ ├── columns: t:1
+ └── select
+      ├── columns: t:1 t102110_1.rowid:2!null t102110_1.crdb_internal_mvcc_timestamp:3 t102110_1.tableoid:4 c:5 t102110_2.rowid:6!null t102110_2.crdb_internal_mvcc_timestamp:7 t102110_2.tableoid:8
+      ├── inner-join (cross)
+      │    ├── columns: t:1 t102110_1.rowid:2!null t102110_1.crdb_internal_mvcc_timestamp:3 t102110_1.tableoid:4 c:5 t102110_2.rowid:6!null t102110_2.crdb_internal_mvcc_timestamp:7 t102110_2.tableoid:8
+      │    ├── scan t102110_1
+      │    │    └── columns: t:1 t102110_1.rowid:2!null t102110_1.crdb_internal_mvcc_timestamp:3 t102110_1.tableoid:4
+      │    ├── scan t102110_2
+      │    │    └── columns: c:5 t102110_2.rowid:6!null t102110_2.crdb_internal_mvcc_timestamp:7 t102110_2.tableoid:8
+      │    └── filters (true)
+      └── filters
+           └── NOT ((t:1 >= t:1) AND (t:1 <= CASE WHEN NULL THEN t:1::CHAR ELSE c:5 END))
+
+# IF is typed differently (Postgres does not support IF).
+build
+SELECT t102110_1.t FROM t102110_1, t102110_2
+WHERE t102110_1.t NOT BETWEEN t102110_1.t AND
+  IF(NULL, t102110_2.c, t102110_1.t);
+----
+project
+ ├── columns: t:1
+ └── select
+      ├── columns: t:1 t102110_1.rowid:2!null t102110_1.crdb_internal_mvcc_timestamp:3 t102110_1.tableoid:4 c:5 t102110_2.rowid:6!null t102110_2.crdb_internal_mvcc_timestamp:7 t102110_2.tableoid:8
+      ├── inner-join (cross)
+      │    ├── columns: t:1 t102110_1.rowid:2!null t102110_1.crdb_internal_mvcc_timestamp:3 t102110_1.tableoid:4 c:5 t102110_2.rowid:6!null t102110_2.crdb_internal_mvcc_timestamp:7 t102110_2.tableoid:8
+      │    ├── scan t102110_1
+      │    │    └── columns: t:1 t102110_1.rowid:2!null t102110_1.crdb_internal_mvcc_timestamp:3 t102110_1.tableoid:4
+      │    ├── scan t102110_2
+      │    │    └── columns: c:5 t102110_2.rowid:6!null t102110_2.crdb_internal_mvcc_timestamp:7 t102110_2.tableoid:8
+      │    └── filters (true)
+      └── filters
+           └── NOT ((t:1 >= t:1) AND (t:1 <= CASE NULL WHEN true THEN c:5 ELSE t:1::CHAR END))
+
+# TODO(#108360): implicit casts from STRING to CHAR should use bpchar.
+exec-ddl
+CREATE TABLE t108360_1 (t TEXT)
+----
+
+exec-ddl
+CREATE TABLE t108360_2 (c CHAR)
+----
+
+build
+SELECT (CASE WHEN t108360_1.t > t108360_2.c THEN t108360_1.t ELSE t108360_2.c END)
+FROM t108360_1, t108360_2
+WHERE t108360_1.t = (CASE WHEN t108360_1.t > t108360_2.c THEN t108360_1.t ELSE t108360_2.c END);
+----
+project
+ ├── columns: c:9
+ ├── select
+ │    ├── columns: t:1!null t108360_1.rowid:2!null t108360_1.crdb_internal_mvcc_timestamp:3 t108360_1.tableoid:4 t108360_2.c:5 t108360_2.rowid:6!null t108360_2.crdb_internal_mvcc_timestamp:7 t108360_2.tableoid:8
+ │    ├── inner-join (cross)
+ │    │    ├── columns: t:1 t108360_1.rowid:2!null t108360_1.crdb_internal_mvcc_timestamp:3 t108360_1.tableoid:4 t108360_2.c:5 t108360_2.rowid:6!null t108360_2.crdb_internal_mvcc_timestamp:7 t108360_2.tableoid:8
+ │    │    ├── scan t108360_1
+ │    │    │    └── columns: t:1 t108360_1.rowid:2!null t108360_1.crdb_internal_mvcc_timestamp:3 t108360_1.tableoid:4
+ │    │    ├── scan t108360_2
+ │    │    │    └── columns: t108360_2.c:5 t108360_2.rowid:6!null t108360_2.crdb_internal_mvcc_timestamp:7 t108360_2.tableoid:8
+ │    │    └── filters (true)
+ │    └── filters
+ │         └── t:1 = CASE WHEN t:1 > t108360_2.c:5 THEN t:1::CHAR ELSE t108360_2.c:5 END
+ └── projections
+      └── CASE WHEN t:1 > t108360_2.c:5 THEN t:1::CHAR ELSE t108360_2.c:5 END [as=c:9]

--- a/pkg/sql/opt/xform/testdata/external/tpcc
+++ b/pkg/sql/opt/xform/testdata/external/tpcc
@@ -576,11 +576,11 @@ RETURNING
   CASE c_credit WHEN 'BC' THEN "left"(c_data, 200) ELSE '' END
 ----
 project
- ├── columns: c_first:4 c_middle:5 c_last:6 c_street_1:7 c_street_2:8 c_city:9 c_state:10 c_zip:11 c_phone:12 c_since:13 c_credit:14 c_credit_lim:15 c_discount:16 c_balance:17 case:54
+ ├── columns: c_first:4 c_middle:5 c_last:6 c_street_1:7 c_street_2:8 c_city:9 c_state:10 c_zip:11 c_phone:12 c_since:13 c_credit:14 c_credit_lim:15 c_discount:16 c_balance:17 case:53
  ├── cardinality: [0 - 1]
  ├── volatile, mutations
  ├── key: ()
- ├── fd: ()-->(4-17,54)
+ ├── fd: ()-->(4-17,53)
  ├── update customer
  │    ├── columns: c_id:1!null c_d_id:2!null c_w_id:3!null c_first:4 c_middle:5 c_last:6 c_street_1:7 c_street_2:8 c_city:9 c_state:10 c_zip:11 c_phone:12 c_since:13 c_credit:14 c_credit_lim:15 c_discount:16 c_balance:17 c_data:21
  │    ├── fetch columns: c_id:24 c_d_id:25 c_w_id:26 c_first:27 c_middle:28 c_last:29 c_street_1:30 c_street_2:31 c_city:32 c_state:33 c_zip:34 c_phone:35 c_since:36 c_credit:37 c_credit_lim:38 c_discount:39 c_balance:40 c_ytd_payment:41 c_payment_cnt:42 c_delivery_cnt:43 c_data:44
@@ -588,7 +588,7 @@ project
  │    │    ├── c_balance_cast:51 => c_balance:17
  │    │    ├── c_ytd_payment_cast:52 => c_ytd_payment:18
  │    │    ├── c_payment_cnt_new:49 => c_payment_cnt:19
- │    │    └── c_data_cast:53 => c_data:21
+ │    │    └── c_data_new:50 => c_data:21
  │    ├── return-mapping:
  │    │    ├── c_id:24 => c_id:1
  │    │    ├── c_d_id:25 => c_d_id:2
@@ -607,17 +607,17 @@ project
  │    │    ├── c_credit_lim:38 => c_credit_lim:15
  │    │    ├── c_discount:39 => c_discount:16
  │    │    ├── c_balance_cast:51 => c_balance:17
- │    │    └── c_data_cast:53 => c_data:21
+ │    │    └── c_data_new:50 => c_data:21
  │    ├── cardinality: [0 - 1]
  │    ├── volatile, mutations
  │    ├── key: ()
  │    ├── fd: ()-->(1-17,21)
  │    └── project
- │         ├── columns: c_balance_cast:51 c_ytd_payment_cast:52 c_data_cast:53 c_payment_cnt_new:49 c_id:24!null c_d_id:25!null c_w_id:26!null c_first:27 c_middle:28 c_last:29 c_street_1:30 c_street_2:31 c_city:32 c_state:33 c_zip:34 c_phone:35 c_since:36 c_credit:37 c_credit_lim:38 c_discount:39 c_balance:40 c_ytd_payment:41 c_payment_cnt:42 c_delivery_cnt:43 c_data:44
+ │         ├── columns: c_balance_cast:51 c_ytd_payment_cast:52 c_payment_cnt_new:49 c_data_new:50 c_id:24!null c_d_id:25!null c_w_id:26!null c_first:27 c_middle:28 c_last:29 c_street_1:30 c_street_2:31 c_city:32 c_state:33 c_zip:34 c_phone:35 c_since:36 c_credit:37 c_credit_lim:38 c_discount:39 c_balance:40 c_ytd_payment:41 c_payment_cnt:42 c_delivery_cnt:43 c_data:44
  │         ├── cardinality: [0 - 1]
  │         ├── immutable
  │         ├── key: ()
- │         ├── fd: ()-->(24-44,49,51-53)
+ │         ├── fd: ()-->(24-44,49-52)
  │         ├── scan customer
  │         │    ├── columns: c_id:24!null c_d_id:25!null c_w_id:26!null c_first:27 c_middle:28 c_last:29 c_street_1:30 c_street_2:31 c_city:32 c_state:33 c_zip:34 c_phone:35 c_since:36 c_credit:37 c_credit_lim:38 c_discount:39 c_balance:40 c_ytd_payment:41 c_payment_cnt:42 c_delivery_cnt:43 c_data:44
  │         │    ├── constraint: /26/25/24: [/10/5/1343 - /10/5/1343]
@@ -629,11 +629,10 @@ project
  │              │    └── c_balance:40 - 3860.61
  │              ├── assignment-cast: DECIMAL(12,2) [as=c_ytd_payment_cast:52, outer=(41), immutable]
  │              │    └── c_ytd_payment:41 + 3860.61
- │              ├── assignment-cast: VARCHAR(500) [as=c_data_cast:53, outer=(24-26,37,44), immutable]
- │              │    └── CASE c_credit:37 WHEN 'BC' THEN left((((((c_id:24::STRING || c_d_id:25::STRING) || c_w_id:26::STRING) || '5') || '10') || '3860.61') || c_data:44, 500) ELSE c_data:44::STRING END
- │              └── c_payment_cnt:42 + 1 [as=c_payment_cnt_new:49, outer=(42), immutable]
+ │              ├── c_payment_cnt:42 + 1 [as=c_payment_cnt_new:49, outer=(42), immutable]
+ │              └── CASE c_credit:37 WHEN 'BC' THEN left((((((c_id:24::STRING || c_d_id:25::STRING) || c_w_id:26::STRING) || '5') || '10') || '3860.61') || c_data:44, 500)::VARCHAR(500) ELSE c_data:44 END [as=c_data_new:50, outer=(24-26,37,44), immutable]
  └── projections
-      └── CASE c_credit:14 WHEN 'BC' THEN left(c_data:21, 200) ELSE '' END [as=case:54, outer=(14,21), immutable]
+      └── CASE c_credit:14 WHEN 'BC' THEN left(c_data:21, 200) ELSE '' END [as=case:53, outer=(14,21), immutable]
 
 opt format=hide-qual
 INSERT INTO history

--- a/pkg/sql/opt/xform/testdata/external/tpcc-later-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpcc-later-stats
@@ -579,11 +579,11 @@ RETURNING
   CASE c_credit WHEN 'BC' THEN "left"(c_data, 200) ELSE '' END
 ----
 project
- ├── columns: c_first:4 c_middle:5 c_last:6 c_street_1:7 c_street_2:8 c_city:9 c_state:10 c_zip:11 c_phone:12 c_since:13 c_credit:14 c_credit_lim:15 c_discount:16 c_balance:17 case:54
+ ├── columns: c_first:4 c_middle:5 c_last:6 c_street_1:7 c_street_2:8 c_city:9 c_state:10 c_zip:11 c_phone:12 c_since:13 c_credit:14 c_credit_lim:15 c_discount:16 c_balance:17 case:53
  ├── cardinality: [0 - 1]
  ├── volatile, mutations
  ├── key: ()
- ├── fd: ()-->(4-17,54)
+ ├── fd: ()-->(4-17,53)
  ├── update customer
  │    ├── columns: c_id:1!null c_d_id:2!null c_w_id:3!null c_first:4 c_middle:5 c_last:6 c_street_1:7 c_street_2:8 c_city:9 c_state:10 c_zip:11 c_phone:12 c_since:13 c_credit:14 c_credit_lim:15 c_discount:16 c_balance:17 c_data:21
  │    ├── fetch columns: c_id:24 c_d_id:25 c_w_id:26 c_first:27 c_middle:28 c_last:29 c_street_1:30 c_street_2:31 c_city:32 c_state:33 c_zip:34 c_phone:35 c_since:36 c_credit:37 c_credit_lim:38 c_discount:39 c_balance:40 c_ytd_payment:41 c_payment_cnt:42 c_delivery_cnt:43 c_data:44
@@ -591,7 +591,7 @@ project
  │    │    ├── c_balance_cast:51 => c_balance:17
  │    │    ├── c_ytd_payment_cast:52 => c_ytd_payment:18
  │    │    ├── c_payment_cnt_new:49 => c_payment_cnt:19
- │    │    └── c_data_cast:53 => c_data:21
+ │    │    └── c_data_new:50 => c_data:21
  │    ├── return-mapping:
  │    │    ├── c_id:24 => c_id:1
  │    │    ├── c_d_id:25 => c_d_id:2
@@ -610,17 +610,17 @@ project
  │    │    ├── c_credit_lim:38 => c_credit_lim:15
  │    │    ├── c_discount:39 => c_discount:16
  │    │    ├── c_balance_cast:51 => c_balance:17
- │    │    └── c_data_cast:53 => c_data:21
+ │    │    └── c_data_new:50 => c_data:21
  │    ├── cardinality: [0 - 1]
  │    ├── volatile, mutations
  │    ├── key: ()
  │    ├── fd: ()-->(1-17,21)
  │    └── project
- │         ├── columns: c_balance_cast:51 c_ytd_payment_cast:52 c_data_cast:53 c_payment_cnt_new:49 c_id:24!null c_d_id:25!null c_w_id:26!null c_first:27 c_middle:28 c_last:29 c_street_1:30 c_street_2:31 c_city:32 c_state:33 c_zip:34 c_phone:35 c_since:36 c_credit:37 c_credit_lim:38 c_discount:39 c_balance:40 c_ytd_payment:41 c_payment_cnt:42 c_delivery_cnt:43 c_data:44
+ │         ├── columns: c_balance_cast:51 c_ytd_payment_cast:52 c_payment_cnt_new:49 c_data_new:50 c_id:24!null c_d_id:25!null c_w_id:26!null c_first:27 c_middle:28 c_last:29 c_street_1:30 c_street_2:31 c_city:32 c_state:33 c_zip:34 c_phone:35 c_since:36 c_credit:37 c_credit_lim:38 c_discount:39 c_balance:40 c_ytd_payment:41 c_payment_cnt:42 c_delivery_cnt:43 c_data:44
  │         ├── cardinality: [0 - 1]
  │         ├── immutable
  │         ├── key: ()
- │         ├── fd: ()-->(24-44,49,51-53)
+ │         ├── fd: ()-->(24-44,49-52)
  │         ├── scan customer
  │         │    ├── columns: c_id:24!null c_d_id:25!null c_w_id:26!null c_first:27 c_middle:28 c_last:29 c_street_1:30 c_street_2:31 c_city:32 c_state:33 c_zip:34 c_phone:35 c_since:36 c_credit:37 c_credit_lim:38 c_discount:39 c_balance:40 c_ytd_payment:41 c_payment_cnt:42 c_delivery_cnt:43 c_data:44
  │         │    ├── constraint: /26/25/24: [/10/5/1343 - /10/5/1343]
@@ -632,11 +632,10 @@ project
  │              │    └── c_balance:40 - 3860.61
  │              ├── assignment-cast: DECIMAL(12,2) [as=c_ytd_payment_cast:52, outer=(41), immutable]
  │              │    └── c_ytd_payment:41 + 3860.61
- │              ├── assignment-cast: VARCHAR(500) [as=c_data_cast:53, outer=(24-26,37,44), immutable]
- │              │    └── CASE c_credit:37 WHEN 'BC' THEN left((((((c_id:24::STRING || c_d_id:25::STRING) || c_w_id:26::STRING) || '5') || '10') || '3860.61') || c_data:44, 500) ELSE c_data:44::STRING END
- │              └── c_payment_cnt:42 + 1 [as=c_payment_cnt_new:49, outer=(42), immutable]
+ │              ├── c_payment_cnt:42 + 1 [as=c_payment_cnt_new:49, outer=(42), immutable]
+ │              └── CASE c_credit:37 WHEN 'BC' THEN left((((((c_id:24::STRING || c_d_id:25::STRING) || c_w_id:26::STRING) || '5') || '10') || '3860.61') || c_data:44, 500)::VARCHAR(500) ELSE c_data:44 END [as=c_data_new:50, outer=(24-26,37,44), immutable]
  └── projections
-      └── CASE c_credit:14 WHEN 'BC' THEN left(c_data:21, 200) ELSE '' END [as=case:54, outer=(14,21), immutable]
+      └── CASE c_credit:14 WHEN 'BC' THEN left(c_data:21, 200) ELSE '' END [as=case:53, outer=(14,21), immutable]
 
 opt format=hide-qual
 INSERT INTO history

--- a/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
@@ -573,11 +573,11 @@ RETURNING
   CASE c_credit WHEN 'BC' THEN "left"(c_data, 200) ELSE '' END
 ----
 project
- ├── columns: c_first:4 c_middle:5 c_last:6 c_street_1:7 c_street_2:8 c_city:9 c_state:10 c_zip:11 c_phone:12 c_since:13 c_credit:14 c_credit_lim:15 c_discount:16 c_balance:17 case:54
+ ├── columns: c_first:4 c_middle:5 c_last:6 c_street_1:7 c_street_2:8 c_city:9 c_state:10 c_zip:11 c_phone:12 c_since:13 c_credit:14 c_credit_lim:15 c_discount:16 c_balance:17 case:53
  ├── cardinality: [0 - 1]
  ├── volatile, mutations
  ├── key: ()
- ├── fd: ()-->(4-17,54)
+ ├── fd: ()-->(4-17,53)
  ├── update customer
  │    ├── columns: c_id:1!null c_d_id:2!null c_w_id:3!null c_first:4 c_middle:5 c_last:6 c_street_1:7 c_street_2:8 c_city:9 c_state:10 c_zip:11 c_phone:12 c_since:13 c_credit:14 c_credit_lim:15 c_discount:16 c_balance:17 c_data:21
  │    ├── fetch columns: c_id:24 c_d_id:25 c_w_id:26 c_first:27 c_middle:28 c_last:29 c_street_1:30 c_street_2:31 c_city:32 c_state:33 c_zip:34 c_phone:35 c_since:36 c_credit:37 c_credit_lim:38 c_discount:39 c_balance:40 c_ytd_payment:41 c_payment_cnt:42 c_delivery_cnt:43 c_data:44
@@ -585,7 +585,7 @@ project
  │    │    ├── c_balance_cast:51 => c_balance:17
  │    │    ├── c_ytd_payment_cast:52 => c_ytd_payment:18
  │    │    ├── c_payment_cnt_new:49 => c_payment_cnt:19
- │    │    └── c_data_cast:53 => c_data:21
+ │    │    └── c_data_new:50 => c_data:21
  │    ├── return-mapping:
  │    │    ├── c_id:24 => c_id:1
  │    │    ├── c_d_id:25 => c_d_id:2
@@ -604,17 +604,17 @@ project
  │    │    ├── c_credit_lim:38 => c_credit_lim:15
  │    │    ├── c_discount:39 => c_discount:16
  │    │    ├── c_balance_cast:51 => c_balance:17
- │    │    └── c_data_cast:53 => c_data:21
+ │    │    └── c_data_new:50 => c_data:21
  │    ├── cardinality: [0 - 1]
  │    ├── volatile, mutations
  │    ├── key: ()
  │    ├── fd: ()-->(1-17,21)
  │    └── project
- │         ├── columns: c_balance_cast:51 c_ytd_payment_cast:52 c_data_cast:53 c_payment_cnt_new:49 c_id:24!null c_d_id:25!null c_w_id:26!null c_first:27 c_middle:28 c_last:29 c_street_1:30 c_street_2:31 c_city:32 c_state:33 c_zip:34 c_phone:35 c_since:36 c_credit:37 c_credit_lim:38 c_discount:39 c_balance:40 c_ytd_payment:41 c_payment_cnt:42 c_delivery_cnt:43 c_data:44
+ │         ├── columns: c_balance_cast:51 c_ytd_payment_cast:52 c_payment_cnt_new:49 c_data_new:50 c_id:24!null c_d_id:25!null c_w_id:26!null c_first:27 c_middle:28 c_last:29 c_street_1:30 c_street_2:31 c_city:32 c_state:33 c_zip:34 c_phone:35 c_since:36 c_credit:37 c_credit_lim:38 c_discount:39 c_balance:40 c_ytd_payment:41 c_payment_cnt:42 c_delivery_cnt:43 c_data:44
  │         ├── cardinality: [0 - 1]
  │         ├── immutable
  │         ├── key: ()
- │         ├── fd: ()-->(24-44,49,51-53)
+ │         ├── fd: ()-->(24-44,49-52)
  │         ├── scan customer
  │         │    ├── columns: c_id:24!null c_d_id:25!null c_w_id:26!null c_first:27 c_middle:28 c_last:29 c_street_1:30 c_street_2:31 c_city:32 c_state:33 c_zip:34 c_phone:35 c_since:36 c_credit:37 c_credit_lim:38 c_discount:39 c_balance:40 c_ytd_payment:41 c_payment_cnt:42 c_delivery_cnt:43 c_data:44
  │         │    ├── constraint: /26/25/24: [/10/5/1343 - /10/5/1343]
@@ -626,11 +626,10 @@ project
  │              │    └── c_balance:40 - 3860.61
  │              ├── assignment-cast: DECIMAL(12,2) [as=c_ytd_payment_cast:52, outer=(41), immutable]
  │              │    └── c_ytd_payment:41 + 3860.61
- │              ├── assignment-cast: VARCHAR(500) [as=c_data_cast:53, outer=(24-26,37,44), immutable]
- │              │    └── CASE c_credit:37 WHEN 'BC' THEN left((((((c_id:24::STRING || c_d_id:25::STRING) || c_w_id:26::STRING) || '5') || '10') || '3860.61') || c_data:44, 500) ELSE c_data:44::STRING END
- │              └── c_payment_cnt:42 + 1 [as=c_payment_cnt_new:49, outer=(42), immutable]
+ │              ├── c_payment_cnt:42 + 1 [as=c_payment_cnt_new:49, outer=(42), immutable]
+ │              └── CASE c_credit:37 WHEN 'BC' THEN left((((((c_id:24::STRING || c_d_id:25::STRING) || c_w_id:26::STRING) || '5') || '10') || '3860.61') || c_data:44, 500)::VARCHAR(500) ELSE c_data:44 END [as=c_data_new:50, outer=(24-26,37,44), immutable]
  └── projections
-      └── CASE c_credit:14 WHEN 'BC' THEN left(c_data:21, 200) ELSE '' END [as=case:54, outer=(14,21), immutable]
+      └── CASE c_credit:14 WHEN 'BC' THEN left(c_data:21, 200) ELSE '' END [as=case:53, outer=(14,21), immutable]
 
 opt format=hide-qual
 INSERT INTO history

--- a/pkg/sql/pgwire/pgwire_test.go
+++ b/pkg/sql/pgwire/pgwire_test.go
@@ -295,7 +295,7 @@ func TestPGPrepareFail(t *testing.T) {
 		"SELECT $1":                                 "pq: could not determine data type of placeholder $1",
 		"SELECT $1 + $1":                            "pq: could not determine data type of placeholder $1",
 		"SELECT CASE WHEN TRUE THEN $1 END":         "pq: could not determine data type of placeholder $1",
-		"SELECT CASE WHEN TRUE THEN $1 ELSE $2 END": "pq: could not determine data type of placeholder $1",
+		"SELECT CASE WHEN TRUE THEN $1 ELSE $2 END": "pq: could not determine data type of placeholder $2",
 		"SELECT $1 > 0 AND NOT $1":                  "pq: placeholder $1 already has type int, cannot assign bool",
 		"CREATE TABLE $1 (id INT)":                  "pq: at or near \"1\": syntax error",
 		"UPDATE d.t SET s = i + $1":                 "pq: unsupported binary operator: <int> + <anyelement> (desired <string>)",


### PR DESCRIPTION
Fixes #102110
Informs #75103
Informs #108360

Release note (bug fix): Fixed the type resolution logic for `CASE` statements to more closely match Postgres' logic. In particular, we now adhere to rule 5 listed in https://www.postgresql.org/docs/current/typeconv-union-case.html, which requires that we select the first non-unknown input type as the candidate type, then consider each other non-unknown input type, left to right (`CASE` treats its `ELSE` clause (if any) as the "first" input, with the `THEN` clauses(s) considered after that). If the candidate type can be implicitly converted to the other type, but not vice-versa, select the other type as the new candidate type. Then continue considering the remaining inputs. If, at any stage of this process, a preferred type is selected, stop considering additional inputs (note that CockroachDB does not yet support the concept of a "preferred type").