### PR TITLE
upgradeccl: deflake and unskip `TestTenantUpgradeFailure`

### DIFF
--- a/pkg/ccl/kvccl/kvtenantccl/upgradeccl/BUILD.bazel
+++ b/pkg/ccl/kvccl/kvtenantccl/upgradeccl/BUILD.bazel
@@ -22,7 +22,6 @@ go_test(
         "//pkg/sql/sqlinstance/instancestorage",
         "//pkg/sql/sqlliveness/slinstance",
         "//pkg/testutils/serverutils",
-        "//pkg/testutils/skip",
         "//pkg/testutils/sqlutils",
         "//pkg/upgrade",
         "//pkg/upgrade/upgradebase",

--- a/pkg/testutils/sqlutils/sql_runner.go
+++ b/pkg/testutils/sqlutils/sql_runner.go
@@ -151,6 +151,15 @@ func (sr *SQLRunner) ExpectErr(t Fataler, errRE string, query string, args ...in
 	sr.expectErr(t, query, err, errRE)
 }
 
+// ExpectNonNilErr runs the given statement and verifies that it returns an error.
+func (sr *SQLRunner) ExpectNonNilErr(t Fataler, query string, args ...interface{}) {
+	helperOrNoop(t)()
+	_, err := sr.DB.ExecContext(context.Background(), query, args...)
+	if err == nil {
+		t.Fatalf("expected query '%s' to return a non-nil error", query)
+	}
+}
+
 func (sr *SQLRunner) expectErr(t Fataler, query string, err error, errRE string) {
 	helperOrNoop(t)()
 	if !testutils.IsError(err, errRE) {


### PR DESCRIPTION
This code changes deflakes `TestTenantUpgradeFailure` by
expanding the list of expected errors to any non-nil error
when the tenant is is stopped in the middle of an upgrade.
It also unskips the test.

Closes https://github.com/cockroachdb/cockroach/issues/106279
Release note: None
Epic: none