### PR TITLE
github-pull-request-make: stress all directly tests in CI

### DIFF
--- a/pkg/cmd/github-pull-request-make/main_test.go
+++ b/pkg/cmd/github-pull-request-make/main_test.go
@@ -20,21 +20,36 @@ import (
 
 func TestPkgsFromDiff(t *testing.T) {
 	for filename, expPkgs := range map[string]map[string]pkg{
-		datapathutils.TestDataPath(t, "10305.diff"): {
-			"pkg/roachpb": {tests: []string{"TestLeaseEquivalence"}},
-			"pkg/storage": {tests: []string{"TestStoreRangeLease", "TestStoreRangeLeaseSwitcheroo"}},
-		},
 		datapathutils.TestDataPath(t, "skip.diff"): {
-			"pkg/ccl/storageccl": {tests: []string{"TestPutS3"}},
+			"pkg/ccl/storageccl": makePkg([]string{"TestPutS3"}),
 		},
-		// This PR had some churn and renamed packages. This was formerly problematic
-		// because nonexistent packages would be emitted.
-		datapathutils.TestDataPath(t, "27595.diff"): {
-			"pkg/storage/closedts/transport": {tests: []string{"TestTransportConnectOnRequest", "TestTransportClientReceivesEntries"}},
-			"pkg/storage/closedts/container": {tests: []string{"TestTwoNodes"}},
-			"pkg/storage/closedts/storage":   {tests: []string{"TestConcurrent"}},
+		datapathutils.TestDataPath(t, "modified.diff"): {
+			"pkg/ccl/streamingccl/streamingest": makePkg([]string{"TestStreamingAutoReplan"}),
 		},
 		datapathutils.TestDataPath(t, "removed.diff"): {},
+		datapathutils.TestDataPath(t, "not_go.diff"):  {},
+		datapathutils.TestDataPath(t, "new_test.diff"): {
+			"pkg/ccl/streamingccl/streamclient": makePkg([]string{
+				"TestExternalConnectionClient",
+				"TestGetFirstActiveClientEmpty",
+			}),
+		},
+		datapathutils.TestDataPath(t, "dont_stress.diff"): {},
+		datapathutils.TestDataPath(t, "27595.diff"): {
+			"pkg/storage/closedts/container": makePkg([]string{
+				"TestTwoNodes",
+			}),
+			"pkg/storage/closedts/minprop": makePkg([]string{
+				"TestTrackerConcurrentUse",
+			}),
+			"pkg/storage/closedts/storage": makePkg([]string{
+				"TestConcurrent",
+			}),
+			"pkg/storage/closedts/transport": makePkg([]string{
+				"TestTransportConnectOnRequest",
+				"TestTransportClientReceivesEntries",
+			}),
+		},
 	} {
 		t.Run(filename, func(t *testing.T) {
 			f, err := os.Open(filename)

--- a/pkg/cmd/github-pull-request-make/testdata/dont_stress.diff
+++ b/pkg/cmd/github-pull-request-make/testdata/dont_stress.diff
@@ -1,0 +1,24 @@
+diff --git a/pkg/ccl/logictestccl/tests/5node/generated_test.go b/pkg/ccl/logictestccl/tests/5node/generated_test.go
+index 1b993b58790..4ffc2bcc1b3 100644
+--- a/pkg/ccl/logictestccl/tests/5node/generated_test.go
++++ b/pkg/ccl/logictestccl/tests/5node/generated_test.go
+@@ -69,6 +69,7 @@ func TestLogic_tmp(t *testing.T) {
+        defer leaktest.AfterTest(t)()
+        var glob string
+        glob = filepath.Join(cclLogicTestDir, "_*")
++       print("im a diff too! dont stress me!")
+        logictest.RunLogicTests(t, logictest.TestServerArgs{}, configIdx, glob)
+ }
+
+diff --git a/pkg/spanconfig/spanconfigstore/store_test.go b/pkg/spanconfig/spanconfigstore/store_test.go
+index 9ef7c9f0893..fbed4ab1fc4 100644
+--- a/pkg/spanconfig/spanconfigstore/store_test.go
++++ b/pkg/spanconfig/spanconfigstore/store_test.go
+@@ -119,6 +119,7 @@ func (s *spanConfigStore) TestingSplitKeys(
+ // spanconfigtestutils.Parse{Target,Config,SpanConfigRecord} for more details.
+ func TestDataDriven(t *testing.T) {
+        defer leaktest.AfterTest(t)()
++       fmt.Printf("im a diff!")
+
+        ctx := context.Background()
+        boundsReader := newMockBoundsReader()

--- a/pkg/cmd/github-pull-request-make/testdata/modified.diff
+++ b/pkg/cmd/github-pull-request-make/testdata/modified.diff
@@ -1,0 +1,20 @@
+diff --git a/pkg/ccl/streamingccl/streamingest/replication_stream_e2e_test.go b/pkg/ccl/streamingccl/streamingest/replication_stream_e2e_test.go
+index b92047e8651..a76b862ea8c 100644
+--- a/pkg/ccl/streamingccl/streamingest/replication_stream_e2e_test.go
++++ b/pkg/ccl/streamingccl/streamingest/replication_stream_e2e_test.go
+@@ -729,6 +729,7 @@ func TestStreamingAutoReplan(t *testing.T) {
+        defer cleanup()
+        // Don't allow for replanning until the new nodes and scattered table have been created.
+        serverutils.SetClusterSetting(t, c.DestCluster, "stream_replication.replan_flow_threshold", 0)
++       serverutils.SetClusterSetting(t, c.DestCluster, "stream_replication.replan_flow_frequency", time.Millisecond*500)
+
+        // Begin the job on a single source node.
+        producerJobID, ingestionJobID := c.StartStreamReplication(ctx)
+@@ -746,7 +747,6 @@ func TestStreamingAutoReplan(t *testing.T) {
+
+        // Configure the ingestion job to replan eagerly.
+        serverutils.SetClusterSetting(t, c.DestCluster, "stream_replication.replan_flow_threshold", 0.1)
+-       serverutils.SetClusterSetting(t, c.DestCluster, "stream_replication.replan_flow_frequency", time.Millisecond*500)
+
+        // The ingestion job should eventually retry because it detects new nodes to add to the plan.
+        require.Error(t, <-retryErrorChan, sql.ErrPlanChanged)

--- a/pkg/cmd/github-pull-request-make/testdata/new_test.diff
+++ b/pkg/cmd/github-pull-request-make/testdata/new_test.diff
@@ -1,0 +1,55 @@
+index 6c20afaef23..879494bdadd 100644
+--- a/pkg/ccl/streamingccl/streamclient/client_test.go
++++ b/pkg/ccl/streamingccl/streamclient/client_test.go
+@@ -15,13 +15,19 @@ import (
+        "testing"
+        "time"
+
++       "github.com/cockroachdb/cockroach/pkg/base"
+        "github.com/cockroachdb/cockroach/pkg/ccl/streamingccl"
+        "github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+        "github.com/cockroachdb/cockroach/pkg/repstream/streampb"
+        "github.com/cockroachdb/cockroach/pkg/roachpb"
++       "github.com/cockroachdb/cockroach/pkg/security/username"
++       "github.com/cockroachdb/cockroach/pkg/sql/isql"
++       "github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
++       "github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+        "github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
+        "github.com/cockroachdb/cockroach/pkg/util/hlc"
+        "github.com/cockroachdb/cockroach/pkg/util/leaktest"
++       "github.com/cockroachdb/cockroach/pkg/util/log"
+        "github.com/cockroachdb/cockroach/pkg/util/syncutil"
+        "github.com/cockroachdb/cockroach/pkg/util/timeutil"
+        "github.com/cockroachdb/errors"
+@@ -138,8 +144,47 @@ func TestGetFirstActiveClientEmpty(t *testing.T) {
+
+ }
+
++func TestExternalConnectionClient(t *testing.T) {
++       defer leaktest.AfterTest(t)()
++       defer log.Scope(t).Close(t)
++
++       ctx := context.Background()
++
++       srv, db, _ := serverutils.StartServer(t, base.TestServerArgs{DefaultTestTenant: base.TODOTestTenantDis
+abled})
++       defer srv.Stopper().Stop(ctx)
++
++       sql := sqlutils.MakeSQLRunner(db)
++       pgURL, cleanupSinkCert := sqlutils.PGUrl(t, srv.AdvSQLAddr(), t.Name(), url.User(username.RootUser))
++       defer cleanupSinkCert()
++
++       externalConnection := "replication-source-addr"
++       sql.Exec(t, fmt.Sprintf(`CREATE EXTERNAL CONNECTION "%s" AS "%s"`,
++               externalConnection, pgURL.String()))
++       nonExistentConnection := "i-dont-exist"
++       address := streamingccl.StreamAddress(fmt.Sprintf("external://%s", externalConnection))
++       dontExistAddress := streamingccl.StreamAddress(fmt.Sprintf("external://%s", nonExistentConnection))
++
++       isqlDB := srv.InternalDB().(isql.DB)
++       client, err := NewStreamClient(ctx, address, isqlDB)
++       require.NoError(t, err)
++       require.NoError(t, client.Dial(ctx))
++       _, err = NewStreamClient(ctx, dontExistAddress, isqlDB)
++       require.Contains(t, err.Error(), "failed to load external connection object")
++ }

--- a/pkg/cmd/github-pull-request-make/testdata/not_go.diff
+++ b/pkg/cmd/github-pull-request-make/testdata/not_go.diff
@@ -1,0 +1,30 @@
+diff --git a/pkg/cmd/github-pull-request-make/testdata/dont_stress.diff b/pkg/cmd/github-pull-request-make/testdata/dont_stress.diff
+new file mode 100644
+index 00000000000..5a235303c65
+--- /dev/null
++++ b/pkg/cmd/github-pull-request-make/testdata/dont_stress.diff
+@@ -0,0 +1,24 @@
++diff --git a/pkg/ccl/logictestccl/tests/5node/generated_test.go b/pkg/ccl/logictestccl/tests/5node/generated_test.go
++index 1b993b58790..4ffc2bcc1b3 100644
++--- a/pkg/ccl/logictestccl/tests/5node/generated_test.go
+++++ b/pkg/ccl/logictestccl/tests/5node/generated_test.go
++@@ -69,6 +69,7 @@ func TestLogic_tmp(t *testing.T) {
++        defer leaktest.AfterTest(t)()
++        var glob string
++        glob = filepath.Join(cclLogicTestDir, "_*")
+++       print("im a diff too! dont stress me!")
++        logictest.RunLogicTests(t, logictest.TestServerArgs{}, configIdx, glob)
++ }
++
++diff --git a/pkg/spanconfig/spanconfigstore/store_test.go b/pkg/spanconfig/spanconfigstore/store_test.go
++index 9ef7c9f0893..fbed4ab1fc4 100644
++--- a/pkg/spanconfig/spanconfigstore/store_test.go
+++++ b/pkg/spanconfig/spanconfigstore/store_test.go
++@@ -119,6 +119,7 @@ func (s *spanConfigStore) TestingSplitKeys(
++ // spanconfigtestutils.Parse{Target,Config,SpanConfigRecord} for more details.
++ func TestDataDriven(t *testing.T) {
++        defer leaktest.AfterTest(t)()
+++       fmt.Printf("im a diff!")
++
++        ctx := context.Background()
++        boundsReader := newMockBoundsReader()


### PR DESCRIPTION
Previously, we only stressed new and unskipped tests in CI. With this patch, all directly modified tests will be stressed in CI, except for tests that match the following regex's: "^TestDataDriven$","^TestLogic_".

Fixes #108046

Release note: None