### PR TITLE
backup: add env var to discard data

### DIFF
--- a/pkg/ccl/backupccl/backup_processor.go
+++ b/pkg/ccl/backupccl/backup_processor.go
@@ -34,6 +34,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb"
 	"github.com/cockroachdb/cockroach/pkg/util/bulk"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
+	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
@@ -91,6 +92,7 @@ var (
 		"send each export request with a verbose tracing span",
 		util.ConstantWithMetamorphicTestBool("export_request_verbose_tracing", false),
 	)
+	testingDiscardBackupData = envutil.EnvOrDefaultBool("COCKROACH_BACKUP_TESTING_DISCARD_DATA", false)
 )
 
 const (
@@ -336,6 +338,9 @@ func runBackupProcessor(
 			}
 			log.Infof(ctx, "backing up %d spans to default locality because backup localities %s have no match in node's localities %s", totalSpans, backupLocalities, nodeLocalities)
 		}
+	}
+	if testingDiscardBackupData {
+		destURI = "null:///discard"
 	}
 	dest, err := cloud.ExternalStorageConfFromURI(destURI, spec.User())
 	if err != nil {


### PR DESCRIPTION
The env var COCKROACH_BACKUP_TESTING_DISCARD_DATA can be set to tell the backup process to discard all data during a backup, rather than writing it to the backup destination. Metadata is still tracked and written, but the row data SST files are discarded.

Release note: none.
Epic: none.