### PR TITLE
telemetry: log all querys used by internal-console

### DIFF
--- a/pkg/sql/telemetry_logging.go
+++ b/pkg/sql/telemetry_logging.go
@@ -42,6 +42,14 @@ var telemetryInternalQueriesEnabled = settings.RegisterBoolSetting(
 	false,
 ).WithPublic()
 
+var telemetryInternalConsoleQueriesEnabled = settings.RegisterBoolSetting(
+	settings.TenantWritable,
+	"sql.telemetry.query_sampling.internal_console.enabled",
+	"when set to true, all internal queries used to populated the UI Console"+
+		"will be logged into telemetry",
+	true,
+)
+
 // TelemetryLoggingMetrics keeps track of the last time at which an event
 // was logged to the telemetry channel, and the number of skipped queries
 // since the last logged event.

--- a/pkg/sql/telemetry_logging_test.go
+++ b/pkg/sql/telemetry_logging_test.go
@@ -792,6 +792,105 @@ func TestTelemetryLoggingInternalEnabled(t *testing.T) {
 	}
 }
 
+// TestTelemetryLoggingInternalConsoleEnabled verifies that setting the cluster setting to send
+// internal console queries to telemetry works as intended.
+func TestTelemetryLoggingInternalConsoleEnabled(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	sc := log.ScopeWithoutShowLogs(t)
+	defer sc.Close(t)
+
+	cleanup := logtestutils.InstallLogFileSink(sc, t, logpb.Channel_TELEMETRY)
+	defer cleanup()
+
+	st := logtestutils.StubTime{}
+	sts := logtestutils.StubTracingStatus{}
+
+	s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{
+		Knobs: base.TestingKnobs{
+			EventLog: &EventLogTestingKnobs{
+				// The sampling checks below need to have a deterministic
+				// number of statements run by internal executor.
+				SyncWrites: true,
+			},
+			TelemetryLoggingKnobs: &TelemetryLoggingTestingKnobs{
+				getTimeNow:       st.TimeNow,
+				getTracingStatus: sts.TracingStatus,
+			},
+		},
+	})
+	stubTime := timeutil.FromUnixMicros(int64(1e6))
+	st.SetTime(stubTime)
+	defer s.Stopper().Stop(context.Background())
+
+	db := sqlutils.MakeSQLRunner(sqlDB)
+	db.Exec(t, `SET CLUSTER SETTING sql.telemetry.query_sampling.enabled = true;`)
+	// Set query internal to `false` to guarantee that if an entry qith `internal-console` is showing
+	// is because of the setting `sql.telemetry.query_sampling.internal_console.enabled` and not
+	// being sampled as a regular internal.
+	db.Exec(t, `SET CLUSTER SETTING sql.telemetry.query_sampling.internal.enabled = false;`)
+
+	testData := []struct {
+		appName            string
+		logInternalConsole bool
+		errorMessage       string
+	}{
+		{
+			"$ internal-console",
+			false,
+			"query from internal-console found on logs with internal_console cluster setting disabled",
+		},
+		{
+			"$ internal-console-extra-name",
+			false,
+			"query from internal-console-extra-name found on logs with internal_console cluster setting disabled",
+		},
+		{
+			"$ internal-console",
+			true,
+			"query from internal-console not found on logs with internal_console cluster setting enabled",
+		},
+		{
+			"$ internal-console-extra-name",
+			true,
+			"query from internal-console-extra-name not found on logs with internal_console cluster setting enabled",
+		},
+	}
+
+	query := `SELECT count(*) FROM crdb_internal.statement_statistics`
+	for _, tc := range testData {
+		db.Exec(t, `SET application_name = $1`, tc.appName)
+		db.Exec(t, `SET CLUSTER SETTING sql.telemetry.query_sampling.internal_console.enabled = $1;`, tc.logInternalConsole)
+		db.Exec(t, query)
+		log.Flush()
+
+		entries, err := log.FetchEntriesFromFiles(
+			0,
+			math.MaxInt64,
+			10000,
+			regexp.MustCompile(`"EventType":"sampled_query"`),
+			log.WithMarkedSensitiveData,
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(entries) == 0 {
+			t.Fatal(errors.Newf("no entries found"))
+		}
+
+		found := false
+		for _, e := range entries {
+			if strings.Contains(e.Message, tc.appName) && strings.Contains(e.Message, query) {
+				found = true
+				break
+			}
+		}
+
+		if found != tc.logInternalConsole {
+			t.Errorf(tc.errorMessage)
+		}
+	}
+}
+
 func TestNoTelemetryLogOnTroubleshootMode(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	sc := log.ScopeWithoutShowLogs(t)

--- a/pkg/ui/workspaces/cluster-ui/src/api/sqlApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/sqlApi.ts
@@ -107,7 +107,7 @@ export const FALLBACK_DB = "system";
 export function executeInternalSql<RowType>(
   req: SqlExecutionRequest,
 ): Promise<SqlExecutionResponse<RowType>> {
-  if (!req.application_name) {
+  if (!req.application_name || req.application_name === INTERNAL_SQL_API_APP) {
     req.application_name = INTERNAL_SQL_API_APP;
   } else {
     req.application_name = `$ internal-${req.application_name}`;


### PR DESCRIPTION
Add a cluster setting to make it possible to log
all queries used by our console (application name
starts with `$ internal-console`).
The console emits just a couple of them, so there
should be no concern with performance.

This commit also updates querys used by our console to include de `internal-console` on the application name.

Fixes #94250

Release note: None