### PR TITLE
sql: refactor PLpgSQL-related types to be more ergonomic

### DIFF
--- a/pkg/sql/opt/optbuilder/plpgsql.go
+++ b/pkg/sql/opt/optbuilder/plpgsql.go
@@ -115,7 +115,7 @@ type plpgsqlBuilder struct {
 	params []tree.ParamType
 
 	// decls is the set of variable declarations for a PL/pgSQL function.
-	decls []plpgsqltree.PLpgSQLDecl
+	decls []plpgsqltree.Declaration
 
 	// varTypes maps from the name of each variable to its type.
 	varTypes map[tree.Name]*types.T
@@ -150,7 +150,7 @@ func (b *plpgsqlBuilder) init(
 	ob *Builder,
 	colRefs *opt.ColSet,
 	params []tree.ParamType,
-	block *plpgsqltree.PLpgSQLStmtBlock,
+	block *plpgsqltree.Block,
 	returnType *types.T,
 ) {
 	b.ob = ob
@@ -182,7 +182,7 @@ func (b *plpgsqlBuilder) init(
 
 // build constructs an expression that returns the result of executing a
 // PL/pgSQL function. See buildPLpgSQLStatements for more details.
-func (b *plpgsqlBuilder) build(block *plpgsqltree.PLpgSQLStmtBlock, s *scope) *scope {
+func (b *plpgsqlBuilder) build(block *plpgsqltree.Block, s *scope) *scope {
 	s = s.push()
 	b.ensureScopeHasExpr(s)
 
@@ -224,13 +224,11 @@ func (b *plpgsqlBuilder) build(block *plpgsqltree.PLpgSQLStmtBlock, s *scope) *s
 //
 // buildPLpgSQLStatements returns nil if one or more branches in the given
 // statements do not eventually terminate with a RETURN statement.
-func (b *plpgsqlBuilder) buildPLpgSQLStatements(
-	stmts []plpgsqltree.PLpgSQLStatement, s *scope,
-) *scope {
+func (b *plpgsqlBuilder) buildPLpgSQLStatements(stmts []plpgsqltree.Statement, s *scope) *scope {
 	b.ensureScopeHasExpr(s)
 	for i, stmt := range stmts {
 		switch t := stmt.(type) {
-		case *plpgsqltree.PLpgSQLStmtReturn:
+		case *plpgsqltree.Return:
 			// RETURN is handled by projecting a single column with the expression
 			// that is being returned.
 			returnScalar := b.buildPLpgSQLExpr(t.Expr, b.returnType, s)
@@ -240,7 +238,7 @@ func (b *plpgsqlBuilder) buildPLpgSQLStatements(
 			b.ob.synthesizeColumn(returnScope, returnColName, b.returnType, nil /* expr */, returnScalar)
 			b.ob.constructProjectForScope(s, returnScope)
 			return returnScope
-		case *plpgsqltree.PLpgSQLStmtAssign:
+		case *plpgsqltree.Assignment:
 			// Assignment (:=) is handled by projecting a new column with the same
 			// name as the variable being assigned.
 			s = b.addPLpgSQLAssign(s, t.Var, t.Value)
@@ -254,7 +252,7 @@ func (b *plpgsqlBuilder) buildPLpgSQLStatements(
 				b.appendPlpgSQLStmts(&catchCon, stmts[i+1:])
 				return b.callContinuation(&catchCon, s)
 			}
-		case *plpgsqltree.PLpgSQLStmtIf:
+		case *plpgsqltree.If:
 			// IF statement control flow is handled by calling a "continuation"
 			// function in each branch that executes all the statements that logically
 			// follow the IF statement block.
@@ -314,7 +312,7 @@ func (b *plpgsqlBuilder) buildPLpgSQLStatements(
 			b.ob.synthesizeColumn(returnScope, returnColName, b.returnType, nil /* expr */, scalar)
 			b.ob.constructProjectForScope(s, returnScope)
 			return returnScope
-		case *plpgsqltree.PLpgSQLStmtSimpleLoop:
+		case *plpgsqltree.Loop:
 			if t.Label != "" {
 				panic(unimplemented.New(
 					"LOOP label",
@@ -340,7 +338,7 @@ func (b *plpgsqlBuilder) buildPLpgSQLStatements(
 			b.popContinuation()
 			b.popExitContinuation()
 			return b.callContinuation(&loopContinuation, s)
-		case *plpgsqltree.PLpgSQLStmtExit:
+		case *plpgsqltree.Exit:
 			if t.Label != "" {
 				panic(unimplemented.New(
 					"EXIT label",
@@ -357,7 +355,7 @@ func (b *plpgsqlBuilder) buildPLpgSQLStatements(
 					"EXIT cannot be used outside a loop, unless it has a label",
 				))
 			}
-		case *plpgsqltree.PLpgSQLStmtContinue:
+		case *plpgsqltree.Continue:
 			if t.Label != "" {
 				panic(unimplemented.New(
 					"CONTINUE label",
@@ -371,7 +369,7 @@ func (b *plpgsqlBuilder) buildPLpgSQLStatements(
 			} else {
 				panic(pgerror.New(pgcode.Syntax, "CONTINUE cannot be used outside a loop"))
 			}
-		case *plpgsqltree.PLpgSQLStmtRaise:
+		case *plpgsqltree.Raise:
 			// RAISE statements allow the PLpgSQL function to send an error or a
 			// notice to the client. We handle these side effects by building them
 			// into a separate body statement that is only executed for its side
@@ -384,7 +382,7 @@ func (b *plpgsqlBuilder) buildPLpgSQLStatements(
 			b.appendBodyStmt(&con, b.buildPLpgSQLRaise(con.s, b.getRaiseArgs(con.s, t)))
 			b.appendPlpgSQLStmts(&con, stmts[i+1:])
 			return b.callContinuation(&con, s)
-		case *plpgsqltree.PLpgSQLStmtExecSql:
+		case *plpgsqltree.Execute:
 			if t.Strict {
 				panic(unimplemented.NewWithIssuef(107854,
 					"INTO STRICT statements are not yet implemented",
@@ -472,7 +470,7 @@ func (b *plpgsqlBuilder) buildPLpgSQLStatements(
 // If there is a column with the same name in the previous scope, it will be
 // replaced. This allows the plpgsqlBuilder to model variable mutations.
 func (b *plpgsqlBuilder) addPLpgSQLAssign(
-	inScope *scope, ident plpgsqltree.PLpgSQLVariable, val plpgsqltree.PLpgSQLExpr,
+	inScope *scope, ident plpgsqltree.Variable, val plpgsqltree.Expr,
 ) *scope {
 	typ := b.resolveVariableForAssign(ident)
 	assignScope := inScope.push()
@@ -522,9 +520,7 @@ func (b *plpgsqlBuilder) buildPLpgSQLRaise(inScope *scope, args memo.ScalarListE
 // getRaiseArgs validates the options attached to the given PLpgSQL RAISE
 // statement and returns the arguments to be used for a call to the
 // crdb_internal.plpgsql_raise builtin function.
-func (b *plpgsqlBuilder) getRaiseArgs(
-	s *scope, raise *plpgsqltree.PLpgSQLStmtRaise,
-) memo.ScalarListExpr {
+func (b *plpgsqlBuilder) getRaiseArgs(s *scope, raise *plpgsqltree.Raise) memo.ScalarListExpr {
 	var severity, message, detail, hint, code opt.ScalarExpr
 	makeConstStr := func(str string) opt.ScalarExpr {
 		return b.ob.factory.ConstructConstVal(tree.NewDString(str), types.String)
@@ -565,7 +561,7 @@ func (b *plpgsqlBuilder) getRaiseArgs(
 		code = makeConstStr(raise.CodeName)
 	}
 	// Retrieve the RAISE options, if any.
-	buildOptionExpr := func(name string, expr plpgsqltree.PLpgSQLExpr, isDup bool) opt.ScalarExpr {
+	buildOptionExpr := func(name string, expr plpgsqltree.Expr, isDup bool) opt.ScalarExpr {
 		if isDup {
 			panic(pgerror.Newf(pgcode.Syntax, "RAISE option already specified: %s", name))
 		}
@@ -614,7 +610,7 @@ func (b *plpgsqlBuilder) getRaiseArgs(
 // is specified by doubling it: '%%'. The formatting arguments can be arbitrary
 // SQL expressions.
 func (b *plpgsqlBuilder) makeRaiseFormatMessage(
-	s *scope, format string, args []plpgsqltree.PLpgSQLExpr,
+	s *scope, format string, args []plpgsqltree.Expr,
 ) (result opt.ScalarExpr) {
 	makeConstStr := func(str string) opt.ScalarExpr {
 		return b.ob.factory.ConstructConstVal(tree.NewDString(str), types.String)
@@ -730,7 +726,7 @@ func (b *plpgsqlBuilder) makeRaiseFormatMessage(
 // TODO(drewk): We could make a special case for exception handling, since the
 // exception handler is the same across all PLpgSQL routines. This would allow
 // us to only set the exception handler for the two cases above.
-func (b *plpgsqlBuilder) buildExceptions(block *plpgsqltree.PLpgSQLStmtBlock) {
+func (b *plpgsqlBuilder) buildExceptions(block *plpgsqltree.Block) {
 	if len(block.Exceptions) == 0 {
 		return
 	}
@@ -854,9 +850,7 @@ func (b *plpgsqlBuilder) appendBodyStmt(con *continuation, bodyScope *scope) {
 // appendPlpgSQLStmts builds the given PLpgSQL statements into a relational
 // expression and appends it to the given continuation routine's body statements
 // list.
-func (b *plpgsqlBuilder) appendPlpgSQLStmts(
-	con *continuation, stmts []plpgsqltree.PLpgSQLStatement,
-) {
+func (b *plpgsqlBuilder) appendPlpgSQLStmts(con *continuation, stmts []plpgsqltree.Statement) {
 	// Make sure to push s before constructing the continuation scope to ensure
 	// that the parameter columns are not projected.
 	continuationScope := b.buildPLpgSQLStatements(stmts, con.s.push())
@@ -903,7 +897,7 @@ func (b *plpgsqlBuilder) callContinuation(con *continuation, s *scope) *scope {
 // buildPLpgSQLExpr parses and builds the given SQL expression into a ScalarExpr
 // within the given scope.
 func (b *plpgsqlBuilder) buildPLpgSQLExpr(
-	expr plpgsqltree.PLpgSQLExpr, typ *types.T, s *scope,
+	expr plpgsqltree.Expr, typ *types.T, s *scope,
 ) opt.ScalarExpr {
 	expr, _ = tree.WalkExpr(s, expr)
 	typedExpr, err := expr.TypeCheck(b.ob.ctx, b.ob.semaCtx, typ)

--- a/pkg/sql/opt/optbuilder/plpgsql.go
+++ b/pkg/sql/opt/optbuilder/plpgsql.go
@@ -19,7 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/builtins/builtinsregistry"
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/plpgsqltree"
+	ast "github.com/cockroachdb/cockroach/pkg/sql/sem/plpgsqltree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/volatility"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
@@ -115,7 +115,7 @@ type plpgsqlBuilder struct {
 	params []tree.ParamType
 
 	// decls is the set of variable declarations for a PL/pgSQL function.
-	decls []plpgsqltree.Declaration
+	decls []ast.Declaration
 
 	// varTypes maps from the name of each variable to its type.
 	varTypes map[tree.Name]*types.T
@@ -147,11 +147,7 @@ type plpgsqlBuilder struct {
 }
 
 func (b *plpgsqlBuilder) init(
-	ob *Builder,
-	colRefs *opt.ColSet,
-	params []tree.ParamType,
-	block *plpgsqltree.Block,
-	returnType *types.T,
+	ob *Builder, colRefs *opt.ColSet, params []tree.ParamType, block *ast.Block, returnType *types.T,
 ) {
 	b.ob = ob
 	b.colRefs = colRefs
@@ -182,7 +178,7 @@ func (b *plpgsqlBuilder) init(
 
 // build constructs an expression that returns the result of executing a
 // PL/pgSQL function. See buildPLpgSQLStatements for more details.
-func (b *plpgsqlBuilder) build(block *plpgsqltree.Block, s *scope) *scope {
+func (b *plpgsqlBuilder) build(block *ast.Block, s *scope) *scope {
 	s = s.push()
 	b.ensureScopeHasExpr(s)
 
@@ -224,11 +220,11 @@ func (b *plpgsqlBuilder) build(block *plpgsqltree.Block, s *scope) *scope {
 //
 // buildPLpgSQLStatements returns nil if one or more branches in the given
 // statements do not eventually terminate with a RETURN statement.
-func (b *plpgsqlBuilder) buildPLpgSQLStatements(stmts []plpgsqltree.Statement, s *scope) *scope {
+func (b *plpgsqlBuilder) buildPLpgSQLStatements(stmts []ast.Statement, s *scope) *scope {
 	b.ensureScopeHasExpr(s)
 	for i, stmt := range stmts {
 		switch t := stmt.(type) {
-		case *plpgsqltree.Return:
+		case *ast.Return:
 			// RETURN is handled by projecting a single column with the expression
 			// that is being returned.
 			returnScalar := b.buildPLpgSQLExpr(t.Expr, b.returnType, s)
@@ -238,7 +234,7 @@ func (b *plpgsqlBuilder) buildPLpgSQLStatements(stmts []plpgsqltree.Statement, s
 			b.ob.synthesizeColumn(returnScope, returnColName, b.returnType, nil /* expr */, returnScalar)
 			b.ob.constructProjectForScope(s, returnScope)
 			return returnScope
-		case *plpgsqltree.Assignment:
+		case *ast.Assignment:
 			// Assignment (:=) is handled by projecting a new column with the same
 			// name as the variable being assigned.
 			s = b.addPLpgSQLAssign(s, t.Var, t.Value)
@@ -252,7 +248,7 @@ func (b *plpgsqlBuilder) buildPLpgSQLStatements(stmts []plpgsqltree.Statement, s
 				b.appendPlpgSQLStmts(&catchCon, stmts[i+1:])
 				return b.callContinuation(&catchCon, s)
 			}
-		case *plpgsqltree.If:
+		case *ast.If:
 			// IF statement control flow is handled by calling a "continuation"
 			// function in each branch that executes all the statements that logically
 			// follow the IF statement block.
@@ -312,7 +308,7 @@ func (b *plpgsqlBuilder) buildPLpgSQLStatements(stmts []plpgsqltree.Statement, s
 			b.ob.synthesizeColumn(returnScope, returnColName, b.returnType, nil /* expr */, scalar)
 			b.ob.constructProjectForScope(s, returnScope)
 			return returnScope
-		case *plpgsqltree.Loop:
+		case *ast.Loop:
 			if t.Label != "" {
 				panic(unimplemented.New(
 					"LOOP label",
@@ -338,7 +334,7 @@ func (b *plpgsqlBuilder) buildPLpgSQLStatements(stmts []plpgsqltree.Statement, s
 			b.popContinuation()
 			b.popExitContinuation()
 			return b.callContinuation(&loopContinuation, s)
-		case *plpgsqltree.Exit:
+		case *ast.Exit:
 			if t.Label != "" {
 				panic(unimplemented.New(
 					"EXIT label",
@@ -355,7 +351,7 @@ func (b *plpgsqlBuilder) buildPLpgSQLStatements(stmts []plpgsqltree.Statement, s
 					"EXIT cannot be used outside a loop, unless it has a label",
 				))
 			}
-		case *plpgsqltree.Continue:
+		case *ast.Continue:
 			if t.Label != "" {
 				panic(unimplemented.New(
 					"CONTINUE label",
@@ -369,7 +365,7 @@ func (b *plpgsqlBuilder) buildPLpgSQLStatements(stmts []plpgsqltree.Statement, s
 			} else {
 				panic(pgerror.New(pgcode.Syntax, "CONTINUE cannot be used outside a loop"))
 			}
-		case *plpgsqltree.Raise:
+		case *ast.Raise:
 			// RAISE statements allow the PLpgSQL function to send an error or a
 			// notice to the client. We handle these side effects by building them
 			// into a separate body statement that is only executed for its side
@@ -382,7 +378,7 @@ func (b *plpgsqlBuilder) buildPLpgSQLStatements(stmts []plpgsqltree.Statement, s
 			b.appendBodyStmt(&con, b.buildPLpgSQLRaise(con.s, b.getRaiseArgs(con.s, t)))
 			b.appendPlpgSQLStmts(&con, stmts[i+1:])
 			return b.callContinuation(&con, s)
-		case *plpgsqltree.Execute:
+		case *ast.Execute:
 			if t.Strict {
 				panic(unimplemented.NewWithIssuef(107854,
 					"INTO STRICT statements are not yet implemented",
@@ -469,9 +465,7 @@ func (b *plpgsqlBuilder) buildPLpgSQLStatements(stmts []plpgsqltree.Statement, s
 // new column with the variable name that projects the assigned expression.
 // If there is a column with the same name in the previous scope, it will be
 // replaced. This allows the plpgsqlBuilder to model variable mutations.
-func (b *plpgsqlBuilder) addPLpgSQLAssign(
-	inScope *scope, ident plpgsqltree.Variable, val plpgsqltree.Expr,
-) *scope {
+func (b *plpgsqlBuilder) addPLpgSQLAssign(inScope *scope, ident ast.Variable, val ast.Expr) *scope {
 	typ := b.resolveVariableForAssign(ident)
 	assignScope := inScope.push()
 	b.ensureScopeHasExpr(assignScope)
@@ -520,7 +514,7 @@ func (b *plpgsqlBuilder) buildPLpgSQLRaise(inScope *scope, args memo.ScalarListE
 // getRaiseArgs validates the options attached to the given PLpgSQL RAISE
 // statement and returns the arguments to be used for a call to the
 // crdb_internal.plpgsql_raise builtin function.
-func (b *plpgsqlBuilder) getRaiseArgs(s *scope, raise *plpgsqltree.Raise) memo.ScalarListExpr {
+func (b *plpgsqlBuilder) getRaiseArgs(s *scope, raise *ast.Raise) memo.ScalarListExpr {
 	var severity, message, detail, hint, code opt.ScalarExpr
 	makeConstStr := func(str string) opt.ScalarExpr {
 		return b.ob.factory.ConstructConstVal(tree.NewDString(str), types.String)
@@ -561,7 +555,7 @@ func (b *plpgsqlBuilder) getRaiseArgs(s *scope, raise *plpgsqltree.Raise) memo.S
 		code = makeConstStr(raise.CodeName)
 	}
 	// Retrieve the RAISE options, if any.
-	buildOptionExpr := func(name string, expr plpgsqltree.Expr, isDup bool) opt.ScalarExpr {
+	buildOptionExpr := func(name string, expr ast.Expr, isDup bool) opt.ScalarExpr {
 		if isDup {
 			panic(pgerror.Newf(pgcode.Syntax, "RAISE option already specified: %s", name))
 		}
@@ -610,7 +604,7 @@ func (b *plpgsqlBuilder) getRaiseArgs(s *scope, raise *plpgsqltree.Raise) memo.S
 // is specified by doubling it: '%%'. The formatting arguments can be arbitrary
 // SQL expressions.
 func (b *plpgsqlBuilder) makeRaiseFormatMessage(
-	s *scope, format string, args []plpgsqltree.Expr,
+	s *scope, format string, args []ast.Expr,
 ) (result opt.ScalarExpr) {
 	makeConstStr := func(str string) opt.ScalarExpr {
 		return b.ob.factory.ConstructConstVal(tree.NewDString(str), types.String)
@@ -726,7 +720,7 @@ func (b *plpgsqlBuilder) makeRaiseFormatMessage(
 // TODO(drewk): We could make a special case for exception handling, since the
 // exception handler is the same across all PLpgSQL routines. This would allow
 // us to only set the exception handler for the two cases above.
-func (b *plpgsqlBuilder) buildExceptions(block *plpgsqltree.Block) {
+func (b *plpgsqlBuilder) buildExceptions(block *ast.Block) {
 	if len(block.Exceptions) == 0 {
 		return
 	}
@@ -850,7 +844,7 @@ func (b *plpgsqlBuilder) appendBodyStmt(con *continuation, bodyScope *scope) {
 // appendPlpgSQLStmts builds the given PLpgSQL statements into a relational
 // expression and appends it to the given continuation routine's body statements
 // list.
-func (b *plpgsqlBuilder) appendPlpgSQLStmts(con *continuation, stmts []plpgsqltree.Statement) {
+func (b *plpgsqlBuilder) appendPlpgSQLStmts(con *continuation, stmts []ast.Statement) {
 	// Make sure to push s before constructing the continuation scope to ensure
 	// that the parameter columns are not projected.
 	continuationScope := b.buildPLpgSQLStatements(stmts, con.s.push())
@@ -896,9 +890,7 @@ func (b *plpgsqlBuilder) callContinuation(con *continuation, s *scope) *scope {
 
 // buildPLpgSQLExpr parses and builds the given SQL expression into a ScalarExpr
 // within the given scope.
-func (b *plpgsqlBuilder) buildPLpgSQLExpr(
-	expr plpgsqltree.Expr, typ *types.T, s *scope,
-) opt.ScalarExpr {
+func (b *plpgsqlBuilder) buildPLpgSQLExpr(expr ast.Expr, typ *types.T, s *scope) opt.ScalarExpr {
 	expr, _ = tree.WalkExpr(s, expr)
 	typedExpr, err := expr.TypeCheck(b.ob.ctx, b.ob.semaCtx, typ)
 	if err != nil {

--- a/pkg/sql/parser/statements/statement.go
+++ b/pkg/sql/parser/statements/statement.go
@@ -66,7 +66,7 @@ func IsANSIDML(stmt tree.Statement) bool {
 // Statements is a list of parsed statements.
 type Statements []Statement[tree.Statement]
 
-type PLpgStatement Statement[*plpgsqltree.PLpgSQLStmtBlock]
+type PLpgStatement Statement[*plpgsqltree.Block]
 
 // String returns the AST formatted as a string.
 func (stmts Statements) String() string {

--- a/pkg/sql/plpgsql/parser/plpgsql.y
+++ b/pkg/sql/plpgsql/parser/plpgsql.y
@@ -314,15 +314,12 @@ func (u *plpgsqlSymUnion) conditions() []plpgsqltree.Condition {
 %type <plpgsqltree.Expr>	decl_defval decl_cursor_query
 %type <tree.ResolvableTypeReference>	decl_datatype
 %type <str>		decl_collate
-%type <plpgsqltree.PLpgSQLDatum>	decl_cursor_args
 
 %type <*plpgsqltree.Open> open_stmt_processor
 %type <str>	expr_until_semi expr_until_paren
 %type <str>	expr_until_then expr_until_loop opt_expr_until_when
 %type <plpgsqltree.Expr>	opt_exitcond
 
-%type <plpgsqltree.PLpgSQLScalarVar>		cursor_variable
-%type <plpgsqltree.PLpgSQLDatum>	decl_cursor_arg
 %type <forvariable>	for_variable
 %type <plpgsqltree.Expr>	return_variable
 %type <*tree.NumVal>	foreach_slice

--- a/pkg/sql/plpgsql/parser/plpgsql.y
+++ b/pkg/sql/plpgsql/parser/plpgsql.y
@@ -62,24 +62,24 @@ type plpgsqlSymUnion struct {
     val interface{}
 }
 
-func (u *plpgsqlSymUnion) plpgsqlStmtBlock() *plpgsqltree.PLpgSQLStmtBlock {
-    return u.val.(*plpgsqltree.PLpgSQLStmtBlock)
+func (u *plpgsqlSymUnion) block() *plpgsqltree.Block {
+    return u.val.(*plpgsqltree.Block)
 }
 
-func (u *plpgsqlSymUnion) plpgsqlStmtCaseWhenArm() *plpgsqltree.PLpgSQLStmtCaseWhenArm {
-    return u.val.(*plpgsqltree.PLpgSQLStmtCaseWhenArm)
+func (u *plpgsqlSymUnion) caseWhen() *plpgsqltree.CaseWhen {
+    return u.val.(*plpgsqltree.CaseWhen)
 }
 
-func (u *plpgsqlSymUnion) plpgsqlStmtCaseWhenArms() []*plpgsqltree.PLpgSQLStmtCaseWhenArm {
-    return u.val.([]*plpgsqltree.PLpgSQLStmtCaseWhenArm)
+func (u *plpgsqlSymUnion) caseWhens() []*plpgsqltree.CaseWhen {
+    return u.val.([]*plpgsqltree.CaseWhen)
 }
 
-func (u *plpgsqlSymUnion) plpgsqlStatement() plpgsqltree.PLpgSQLStatement {
-    return u.val.(plpgsqltree.PLpgSQLStatement)
+func (u *plpgsqlSymUnion) statement() plpgsqltree.Statement {
+    return u.val.(plpgsqltree.Statement)
 }
 
-func (u *plpgsqlSymUnion) plpgsqlStatements() []plpgsqltree.PLpgSQLStatement {
-    return u.val.([]plpgsqltree.PLpgSQLStatement)
+func (u *plpgsqlSymUnion) statements() []plpgsqltree.Statement {
+    return u.val.([]plpgsqltree.Statement)
 }
 
 func (u *plpgsqlSymUnion) int32() int32 {
@@ -102,68 +102,68 @@ func (u *plpgsqlSymUnion) typ() tree.ResolvableTypeReference {
     return u.val.(tree.ResolvableTypeReference)
 }
 
-func (u *plpgsqlSymUnion) pLpgSQLGetDiagKind() plpgsqltree.PLpgSQLGetDiagKind {
-    return u.val.(plpgsqltree.PLpgSQLGetDiagKind)
+func (u *plpgsqlSymUnion) getDiagnosticsKind() plpgsqltree.GetDiagnosticsKind {
+    return u.val.(plpgsqltree.GetDiagnosticsKind)
 }
 
-func (u *plpgsqlSymUnion) pLpgSQLStmtGetDiagItem() *plpgsqltree.PLpgSQLStmtGetDiagItem {
-    return u.val.(*plpgsqltree.PLpgSQLStmtGetDiagItem)
+func (u *plpgsqlSymUnion) getDiagnosticsItem() *plpgsqltree.GetDiagnosticsItem {
+    return u.val.(*plpgsqltree.GetDiagnosticsItem)
 }
 
-func (u *plpgsqlSymUnion) pLpgSQLStmtGetDiagItemList() plpgsqltree.PLpgSQLStmtGetDiagItemList {
-    return u.val.(plpgsqltree.PLpgSQLStmtGetDiagItemList)
+func (u *plpgsqlSymUnion) getDiagnosticsItemList() plpgsqltree.GetDiagnosticsItemList {
+    return u.val.(plpgsqltree.GetDiagnosticsItemList)
 }
 
-func (u *plpgsqlSymUnion) pLpgSQLStmtIfElseIfArmList() []plpgsqltree.PLpgSQLStmtIfElseIfArm {
-    return u.val.([]plpgsqltree.PLpgSQLStmtIfElseIfArm)
+func (u *plpgsqlSymUnion) elseIf() []plpgsqltree.ElseIf {
+    return u.val.([]plpgsqltree.ElseIf)
 }
 
-func (u *plpgsqlSymUnion) pLpgSQLStmtOpen() *plpgsqltree.PLpgSQLStmtOpen {
-    return u.val.(*plpgsqltree.PLpgSQLStmtOpen)
+func (u *plpgsqlSymUnion) open() *plpgsqltree.Open {
+    return u.val.(*plpgsqltree.Open)
 }
 
-func (u *plpgsqlSymUnion) plpgsqlExpr() plpgsqltree.PLpgSQLExpr {
+func (u *plpgsqlSymUnion) expr() plpgsqltree.Expr {
     if u.val == nil {
       return nil
     }
-    return u.val.(plpgsqltree.PLpgSQLExpr)
+    return u.val.(plpgsqltree.Expr)
 }
 
-func (u *plpgsqlSymUnion) plpgsqlExprs() []plpgsqltree.PLpgSQLExpr {
-    return u.val.([]plpgsqltree.PLpgSQLExpr)
+func (u *plpgsqlSymUnion) exprs() []plpgsqltree.Expr {
+    return u.val.([]plpgsqltree.Expr)
 }
 
-func (u *plpgsqlSymUnion) plpgsqlDecl() *plpgsqltree.PLpgSQLDecl {
-    return u.val.(*plpgsqltree.PLpgSQLDecl)
+func (u *plpgsqlSymUnion) declaration() *plpgsqltree.Declaration {
+    return u.val.(*plpgsqltree.Declaration)
 }
 
-func (u *plpgsqlSymUnion) plpgsqlDecls() []plpgsqltree.PLpgSQLDecl {
-    return u.val.([]plpgsqltree.PLpgSQLDecl)
+func (u *plpgsqlSymUnion) declarations() []plpgsqltree.Declaration {
+    return u.val.([]plpgsqltree.Declaration)
 }
 
-func (u *plpgsqlSymUnion) plpgsqlOptionExpr() *plpgsqltree.PLpgSQLStmtRaiseOption {
-    return u.val.(*plpgsqltree.PLpgSQLStmtRaiseOption)
+func (u *plpgsqlSymUnion) raiseOption() *plpgsqltree.RaiseOption {
+    return u.val.(*plpgsqltree.RaiseOption)
 }
 
-func (u *plpgsqlSymUnion) plpgsqlOptionExprs() []plpgsqltree.PLpgSQLStmtRaiseOption {
-    return u.val.([]plpgsqltree.PLpgSQLStmtRaiseOption)
+func (u *plpgsqlSymUnion) raiseOptions() []plpgsqltree.RaiseOption {
+    return u.val.([]plpgsqltree.RaiseOption)
 }
 
 
-func (u *plpgsqlSymUnion) plpgsqlException() *plpgsqltree.PLpgSQLException {
-    return u.val.(*plpgsqltree.PLpgSQLException)
+func (u *plpgsqlSymUnion) exception() *plpgsqltree.Exception {
+    return u.val.(*plpgsqltree.Exception)
 }
 
-func (u *plpgsqlSymUnion) plpgsqlExceptions() []plpgsqltree.PLpgSQLException {
-    return u.val.([]plpgsqltree.PLpgSQLException)
+func (u *plpgsqlSymUnion) exceptions() []plpgsqltree.Exception {
+    return u.val.([]plpgsqltree.Exception)
 }
 
-func (u *plpgsqlSymUnion) plpgsqlCondition() *plpgsqltree.PLpgSQLCondition {
-    return u.val.(*plpgsqltree.PLpgSQLCondition)
+func (u *plpgsqlSymUnion) condition() *plpgsqltree.Condition {
+    return u.val.(*plpgsqltree.Condition)
 }
 
-func (u *plpgsqlSymUnion) plpgsqlConditions() []plpgsqltree.PLpgSQLCondition {
-    return u.val.([]plpgsqltree.PLpgSQLCondition)
+func (u *plpgsqlSymUnion) conditions() []plpgsqltree.Condition {
+    return u.val.([]plpgsqltree.Condition)
 }
 
 %}
@@ -311,63 +311,63 @@ func (u *plpgsqlSymUnion) plpgsqlConditions() []plpgsqltree.PLpgSQLCondition {
 
 %type <str> decl_varname decl_defkey
 %type <bool>	decl_const decl_notnull
-%type <plpgsqltree.PLpgSQLExpr>	decl_defval decl_cursor_query
+%type <plpgsqltree.Expr>	decl_defval decl_cursor_query
 %type <tree.ResolvableTypeReference>	decl_datatype
 %type <str>		decl_collate
 %type <plpgsqltree.PLpgSQLDatum>	decl_cursor_args
 
-%type <*plpgsqltree.PLpgSQLStmtOpen> open_stmt_processor
+%type <*plpgsqltree.Open> open_stmt_processor
 %type <str>	expr_until_semi expr_until_paren
 %type <str>	expr_until_then expr_until_loop opt_expr_until_when
-%type <plpgsqltree.PLpgSQLExpr>	opt_exitcond
+%type <plpgsqltree.Expr>	opt_exitcond
 
 %type <plpgsqltree.PLpgSQLScalarVar>		cursor_variable
 %type <plpgsqltree.PLpgSQLDatum>	decl_cursor_arg
 %type <forvariable>	for_variable
-%type <plpgsqltree.PLpgSQLExpr>	return_variable
+%type <plpgsqltree.Expr>	return_variable
 %type <*tree.NumVal>	foreach_slice
-%type <plpgsqltree.PLpgSQLStatement>	for_control
+%type <plpgsqltree.Statement>	for_control
 
 %type <str> any_identifier opt_block_label opt_loop_label opt_label query_options
 %type <str> opt_error_level option_type
 
-%type <[]plpgsqltree.PLpgSQLStatement> proc_sect
-%type <[]plpgsqltree.PLpgSQLStmtIfElseIfArm> stmt_elsifs
-%type <[]plpgsqltree.PLpgSQLStatement> stmt_else loop_body // TODO is this a list of statement?
-%type <plpgsqltree.PLpgSQLStatement>  pl_block
-%type <plpgsqltree.PLpgSQLStatement>	proc_stmt
-%type <plpgsqltree.PLpgSQLStatement>	stmt_assign stmt_if stmt_loop stmt_while stmt_exit stmt_continue
-%type <plpgsqltree.PLpgSQLStatement>	stmt_return stmt_raise stmt_assert stmt_execsql
-%type <plpgsqltree.PLpgSQLStatement>	stmt_dynexecute stmt_for stmt_perform stmt_call stmt_getdiag
-%type <plpgsqltree.PLpgSQLStatement>	stmt_open stmt_fetch stmt_move stmt_close stmt_null
-%type <plpgsqltree.PLpgSQLStatement>	stmt_commit stmt_rollback
-%type <plpgsqltree.PLpgSQLStatement>	stmt_case stmt_foreach_a
+%type <[]plpgsqltree.Statement> proc_sect
+%type <[]plpgsqltree.ElseIf> stmt_elsifs
+%type <[]plpgsqltree.Statement> stmt_else loop_body // TODO is this a list of statement?
+%type <plpgsqltree.Statement>  pl_block
+%type <plpgsqltree.Statement>	proc_stmt
+%type <plpgsqltree.Statement>	stmt_assign stmt_if stmt_loop stmt_while stmt_exit stmt_continue
+%type <plpgsqltree.Statement>	stmt_return stmt_raise stmt_assert stmt_execsql
+%type <plpgsqltree.Statement>	stmt_dynexecute stmt_for stmt_perform stmt_call stmt_getdiag
+%type <plpgsqltree.Statement>	stmt_open stmt_fetch stmt_move stmt_close stmt_null
+%type <plpgsqltree.Statement>	stmt_commit stmt_rollback
+%type <plpgsqltree.Statement>	stmt_case stmt_foreach_a
 
-%type <*plpgsqltree.PLpgSQLDecl> decl_stmt decl_statement
-%type <[]plpgsqltree.PLpgSQLDecl> decl_sect opt_decl_stmts decl_stmts
+%type <*plpgsqltree.Declaration> decl_stmt decl_statement
+%type <[]plpgsqltree.Declaration> decl_sect opt_decl_stmts decl_stmts
 
-%type <[]plpgsqltree.PLpgSQLException> exception_sect proc_exceptions
-%type <*plpgsqltree.PLpgSQLException>	proc_exception
-%type <[]plpgsqltree.PLpgSQLCondition> proc_conditions
-%type <*plpgsqltree.PLpgSQLCondition> proc_condition
+%type <[]plpgsqltree.Exception> exception_sect proc_exceptions
+%type <*plpgsqltree.Exception>	proc_exception
+%type <[]plpgsqltree.Condition> proc_conditions
+%type <*plpgsqltree.Condition> proc_condition
 
-%type <*plpgsqltree.PLpgSQLStmtCaseWhenArm>	case_when
-%type <[]*plpgsqltree.PLpgSQLStmtCaseWhenArm>	case_when_list
-%type <[]plpgsqltree.PLpgSQLStatement> opt_case_else
+%type <*plpgsqltree.CaseWhen>	case_when
+%type <[]*plpgsqltree.CaseWhen>	case_when_list
+%type <[]plpgsqltree.Statement> opt_case_else
 
 %type <bool>	getdiag_area_opt
-%type <plpgsqltree.PLpgSQLStmtGetDiagItemList>	getdiag_list // TODO don't know what this is
-%type <*plpgsqltree.PLpgSQLStmtGetDiagItem> getdiag_list_item // TODO don't know what this is
+%type <plpgsqltree.GetDiagnosticsItemList>	getdiag_list // TODO don't know what this is
+%type <*plpgsqltree.GetDiagnosticsItem> getdiag_list_item // TODO don't know what this is
 %type <int32> getdiag_item
 
-%type <*plpgsqltree.PLpgSQLStmtRaiseOption> option_expr
-%type <[]plpgsqltree.PLpgSQLStmtRaiseOption> option_exprs opt_option_exprs
-%type <plpgsqltree.PLpgSQLExpr> format_expr
-%type <[]plpgsqltree.PLpgSQLExpr> opt_format_exprs format_exprs
+%type <*plpgsqltree.RaiseOption> option_expr
+%type <[]plpgsqltree.RaiseOption> option_exprs opt_option_exprs
+%type <plpgsqltree.Expr> format_expr
+%type <[]plpgsqltree.Expr> opt_format_exprs format_exprs
 
 %type <uint32>	opt_scrollable
 
-%type <*plpgsqltree.PLpgSQLStmtFetch>	opt_fetch_direction
+%type <*plpgsqltree.Fetch>	opt_fetch_direction
 
 %type <*tree.NumVal>	opt_transaction_chain
 
@@ -377,7 +377,7 @@ func (u *plpgsqlSymUnion) plpgsqlConditions() []plpgsqltree.PLpgSQLCondition {
 pl_function:
   pl_block opt_semi
   {
-    plpgsqllex.(*lexer).SetStmt($1.plpgsqlStatement())
+    plpgsqllex.(*lexer).SetStmt($1.statement())
   }
 
 opt_semi:
@@ -386,40 +386,40 @@ opt_semi:
 
 pl_block: opt_block_label decl_sect BEGIN proc_sect exception_sect END opt_label
   {
-    $$.val = &plpgsqltree.PLpgSQLStmtBlock{
+    $$.val = &plpgsqltree.Block{
       Label: $1,
-      Decls: $2.plpgsqlDecls(),
-      Body: $4.plpgsqlStatements(),
-      Exceptions: $5.plpgsqlExceptions(),
+      Decls: $2.declarations(),
+      Body: $4.statements(),
+      Exceptions: $5.exceptions(),
     }
   }
 ;
 
 decl_sect: DECLARE opt_decl_stmts
   {
-    $$.val = $2.plpgsqlDecls()
+    $$.val = $2.declarations()
   }
 | /* EMPTY */
   {
     // Use a nil slice to indicate DECLARE was not used.
-    $$.val = []plpgsqltree.PLpgSQLDecl(nil)
+    $$.val = []plpgsqltree.Declaration(nil)
   }
 ;
 
 opt_decl_stmts: decl_stmts
   {
-    $$.val = $1.plpgsqlDecls()
+    $$.val = $1.declarations()
   }
 | /* EMPTY */
   {
-    $$.val = []plpgsqltree.PLpgSQLDecl{}
+    $$.val = []plpgsqltree.Declaration{}
   }
 ;
 
 decl_stmts: decl_stmts decl_stmt
   {
-    decs := $1.plpgsqlDecls()
-    dec := $2.plpgsqlDecl()
+    decs := $1.declarations()
+    dec := $2.declaration()
     if dec == nil {
       $$.val = decs
     } else {
@@ -428,23 +428,23 @@ decl_stmts: decl_stmts decl_stmt
   }
 | decl_stmt
   {
-    dec := $1.plpgsqlDecl()
+    dec := $1.declaration()
     if dec == nil {
-      $$.val = []plpgsqltree.PLpgSQLDecl{}
+      $$.val = []plpgsqltree.Declaration{}
     } else {
-      $$.val = []plpgsqltree.PLpgSQLDecl{*dec}
+      $$.val = []plpgsqltree.Declaration{*dec}
     }
 	}
 ;
 
 decl_stmt	: decl_statement
   {
-    $$.val = $1.plpgsqlDecl()
+    $$.val = $1.declaration()
   }
 | DECLARE
   {
     // This is to allow useless extra "DECLARE" keywords in the declare section.
-    $$.val = (*plpgsqltree.PLpgSQLDecl)(nil)
+    $$.val = (*plpgsqltree.Declaration)(nil)
   }
 // TODO(chengxiong): turn this block on and throw useful error if user
 // tries to put the block label just before BEGIN instead of before
@@ -456,13 +456,13 @@ decl_stmt	: decl_statement
 
 decl_statement: decl_varname decl_const decl_datatype decl_collate decl_notnull decl_defval
   {
-    $$.val = &plpgsqltree.PLpgSQLDecl{
-      Var: plpgsqltree.PLpgSQLVariable($1),
+    $$.val = &plpgsqltree.Declaration{
+      Var: plpgsqltree.Variable($1),
       Constant: $2.bool(),
       Typ: $3.typ(),
       Collate: $4,
       NotNull: $5.bool(),
-      Expr: $6.plpgsqlExpr(),
+      Expr: $6.expr(),
     }
   }
 | decl_varname ALIAS FOR decl_aliasitem ';'
@@ -584,7 +584,7 @@ decl_notnull:
 
 decl_defval: ';'
   {
-    $$.val = (plpgsqltree.PLpgSQLExpr)(nil)
+    $$.val = (plpgsqltree.Expr)(nil)
   }
 | decl_defkey ';'
   {
@@ -617,35 +617,35 @@ assign_operator: '='
 
 proc_sect:
   {
-    $$.val = []plpgsqltree.PLpgSQLStatement{}
+    $$.val = []plpgsqltree.Statement{}
   }
 | proc_sect proc_stmt
   {
-    stmts := $1.plpgsqlStatements()
-    stmts = append(stmts, $2.plpgsqlStatement())
+    stmts := $1.statements()
+    stmts = append(stmts, $2.statement())
     $$.val = stmts
   }
 ;
 
 proc_stmt:pl_block ';'
   {
-    $$.val = $1.plpgsqlStmtBlock()
+    $$.val = $1.block()
   }
 | stmt_assign
   {
-    $$.val = $1.plpgsqlStatement()
+    $$.val = $1.statement()
   }
 | stmt_if
   {
-    $$.val = $1.plpgsqlStatement()
+    $$.val = $1.statement()
   }
 | stmt_case
   {
-    $$.val = $1.plpgsqlStatement()
+    $$.val = $1.statement()
   }
 | stmt_loop
   {
-    $$.val = $1.plpgsqlStatement()
+    $$.val = $1.statement()
   }
 | stmt_while
   { }
@@ -655,37 +655,37 @@ proc_stmt:pl_block ';'
   { }
 | stmt_exit
   {
-    $$.val = $1.plpgsqlStatement()
+    $$.val = $1.statement()
   }
 | stmt_continue
   {
-    $$.val = $1.plpgsqlStatement()
+    $$.val = $1.statement()
   }
 | stmt_return
   {
-    $$.val = $1.plpgsqlStatement()
+    $$.val = $1.statement()
   }
 | stmt_raise
   {
-    $$.val = $1.plpgsqlStatement()
+    $$.val = $1.statement()
   }
 | stmt_assert
   {
-    $$.val = $1.plpgsqlStatement()
+    $$.val = $1.statement()
   }
 | stmt_execsql
   {
-    $$.val = $1.plpgsqlStatement()
+    $$.val = $1.statement()
   }
 | stmt_dynexecute
   {
-    $$.val = $1.plpgsqlStatement()
+    $$.val = $1.statement()
   }
 | stmt_perform
   { }
 | stmt_call
   {
-    $$.val = $1.plpgsqlStatement()
+    $$.val = $1.statement()
   }
 | stmt_getdiag
   { }
@@ -697,7 +697,7 @@ proc_stmt:pl_block ';'
   { }
 | stmt_close
   {
-    $$.val = $1.plpgsqlStatement()
+    $$.val = $1.statement()
   }
 | stmt_null
   { }
@@ -715,11 +715,11 @@ stmt_perform: PERFORM expr_until_semi ';'
 
 stmt_call: CALL call_cmd ';'
   {
-    $$.val = &plpgsqltree.PLpgSQLStmtCall{IsCall: true}
+    $$.val = &plpgsqltree.Call{IsCall: true}
   }
 | DO call_cmd ';'
   {
-    $$.val = &plpgsqltree.PLpgSQLStmtCall{IsCall: false}
+    $$.val = &plpgsqltree.Call{IsCall: false}
   }
 ;
 
@@ -735,8 +735,8 @@ stmt_assign: IDENT assign_operator expr_until_semi ';'
     if err != nil {
       return setErr(plpgsqllex, err)
     }
-    $$.val = &plpgsqltree.PLpgSQLStmtAssign{
-      Var: plpgsqltree.PLpgSQLVariable($1),
+    $$.val = &plpgsqltree.Assignment{
+      Var: plpgsqltree.Variable($1),
       Value: expr,
     }
   }
@@ -744,9 +744,9 @@ stmt_assign: IDENT assign_operator expr_until_semi ';'
 
 stmt_getdiag: GET getdiag_area_opt DIAGNOSTICS getdiag_list ';'
   {
-  $$.val = &plpgsqltree.PLpgSQLStmtGetDiag{
+  $$.val = &plpgsqltree.GetDiagnostics{
     IsStacked: $2.bool(),
-    DiagItems: $4.pLpgSQLStmtGetDiagItemList(),
+    DiagItems: $4.getDiagnosticsItemList(),
   }
   // TODO(jane): Check information items are valid for area option.
   }
@@ -768,18 +768,18 @@ getdiag_area_opt:
 
 getdiag_list: getdiag_list ',' getdiag_list_item
   {
-    $$.val = append($1.pLpgSQLStmtGetDiagItemList(), $3.pLpgSQLStmtGetDiagItem())
+    $$.val = append($1.getDiagnosticsItemList(), $3.getDiagnosticsItem())
   }
 | getdiag_list_item
   {
-    $$.val = plpgsqltree.PLpgSQLStmtGetDiagItemList{$1.pLpgSQLStmtGetDiagItem()}
+    $$.val = plpgsqltree.GetDiagnosticsItemList{$1.getDiagnosticsItem()}
   }
 ;
 
 getdiag_list_item: IDENT assign_operator getdiag_item
   {
-    $$.val = &plpgsqltree.PLpgSQLStmtGetDiagItem{
-      Kind : $3.pLpgSQLGetDiagKind(),
+    $$.val = &plpgsqltree.GetDiagnosticsItem{
+      Kind : $3.getDiagnosticsKind(),
       TargetName: $1,
       // TODO(jane): set the target from $1.
     }
@@ -789,29 +789,29 @@ getdiag_list_item: IDENT assign_operator getdiag_item
 getdiag_item: unreserved_keyword {
   switch $1 {
     case "row_count":
-      $$.val = plpgsqltree.PlpgsqlGetdiagRowCount;
+      $$.val = plpgsqltree.GetDiagnosticsRowCount;
     case "pg_context":
-      $$.val = plpgsqltree.PlpgsqlGetdiagContext;
+      $$.val = plpgsqltree.GetDiagnosticsContext;
     case "pg_exception_detail":
-      $$.val = plpgsqltree.PlpgsqlGetdiagErrorDetail;
+      $$.val = plpgsqltree.GetDiagnosticsErrorDetail;
     case "pg_exception_hint":
-      $$.val = plpgsqltree.PlpgsqlGetdiagErrorHint;
+      $$.val = plpgsqltree.GetDiagnosticsErrorHint;
     case "pg_exception_context":
-      $$.val = plpgsqltree.PlpgsqlGetdiagErrorContext;
+      $$.val = plpgsqltree.GetDiagnosticsErrorContext;
     case "column_name":
-      $$.val = plpgsqltree.PlpgsqlGetdiagColumnName;
+      $$.val = plpgsqltree.GetDiagnosticsColumnName;
     case "constraint_name":
-      $$.val = plpgsqltree.PlpgsqlGetdiagConstraintName;
+      $$.val = plpgsqltree.GetDiagnosticsConstraintName;
     case "pg_datatype_name":
-      $$.val = plpgsqltree.PlpgsqlGetdiagDatatypeName;
+      $$.val = plpgsqltree.GetDiagnosticsDatatypeName;
     case "message_text":
-      $$.val = plpgsqltree.PlpgsqlGetdiagMessageText;
+      $$.val = plpgsqltree.GetDiagnosticsMessageText;
     case "table_name":
-      $$.val = plpgsqltree.PlpgsqlGetdiagTableName;
+      $$.val = plpgsqltree.GetDiagnosticsTableName;
     case "schema_name":
-      $$.val = plpgsqltree.PlpgsqlGetdiagSchemaName;
+      $$.val = plpgsqltree.GetDiagnosticsSchemaName;
     case "returned_sqlstate":
-      $$.val = plpgsqltree.PlpgsqlGetdiagReturnedSqlstate;
+      $$.val = plpgsqltree.GetDiagnosticsReturnedSQLState;
     default:
       // TODO(jane): Should this use an unimplemented error instead?
       setErr(plpgsqllex, errors.Newf("unrecognized GET DIAGNOSTICS item: %s", redact.Safe($1)))
@@ -832,18 +832,18 @@ stmt_if: IF expr_until_then THEN proc_sect stmt_elsifs stmt_else END_IF IF ';'
     if err != nil {
       return setErr(plpgsqllex, err)
     }
-    $$.val = &plpgsqltree.PLpgSQLStmtIf{
+    $$.val = &plpgsqltree.If{
       Condition: cond,
-      ThenBody: $4.plpgsqlStatements(),
-      ElseIfList: $5.pLpgSQLStmtIfElseIfArmList(),
-      ElseBody: $6.plpgsqlStatements(),
+      ThenBody: $4.statements(),
+      ElseIfList: $5.elseIf(),
+      ElseBody: $6.statements(),
     }
   }
 ;
 
 stmt_elsifs:
   {
-    $$.val = []plpgsqltree.PLpgSQLStmtIfElseIfArm{};
+    $$.val = []plpgsqltree.ElseIf{};
   }
 | stmt_elsifs ELSIF expr_until_then THEN proc_sect
   {
@@ -851,33 +851,33 @@ stmt_elsifs:
     if err != nil {
       return setErr(plpgsqllex, err)
     }
-    newStmt := plpgsqltree.PLpgSQLStmtIfElseIfArm{
+    newStmt := plpgsqltree.ElseIf{
       Condition: cond,
-      Stmts: $5.plpgsqlStatements(),
+      Stmts: $5.statements(),
     }
-    $$.val = append($1.pLpgSQLStmtIfElseIfArmList() , newStmt)
+    $$.val = append($1.elseIf() , newStmt)
   }
 ;
 
 stmt_else:
   {
-    $$.val = []plpgsqltree.PLpgSQLStatement{};
+    $$.val = []plpgsqltree.Statement{};
   }
 | ELSE proc_sect
   {
-    $$.val = $2.plpgsqlStatements();
+    $$.val = $2.statements();
   }
 ;
 
 stmt_case: CASE opt_expr_until_when case_when_list opt_case_else END_CASE CASE ';'
   {
-    expr := &plpgsqltree.PLpgSQLStmtCase {
+    expr := &plpgsqltree.Case {
       TestExpr: $2,
-      CaseWhenList: $3.plpgsqlStmtCaseWhenArms(),
+      CaseWhenList: $3.caseWhens(),
     }
     if $4.val != nil {
        expr.HaveElse = true
-       expr.ElseStmts = $4.plpgsqlStatements()
+       expr.ElseStmts = $4.statements()
     }
     $$.val = expr
   }
@@ -896,23 +896,23 @@ opt_expr_until_when:
 
 case_when_list: case_when_list case_when
   {
-    stmts := $1.plpgsqlStmtCaseWhenArms()
-    stmts = append(stmts, $2.plpgsqlStmtCaseWhenArm())
+    stmts := $1.caseWhens()
+    stmts = append(stmts, $2.caseWhen())
     $$.val = stmts
   }
 | case_when
   {
-    stmts := []*plpgsqltree.PLpgSQLStmtCaseWhenArm{}
-    stmts = append(stmts, $1.plpgsqlStmtCaseWhenArm())
+    stmts := []*plpgsqltree.CaseWhen{}
+    stmts = append(stmts, $1.caseWhen())
     $$.val = stmts
   }
 ;
 
 case_when: WHEN expr_until_then THEN proc_sect
   {
-     expr := &plpgsqltree.PLpgSQLStmtCaseWhenArm{
+     expr := &plpgsqltree.CaseWhen{
        Expr: $2,
-       Stmts: $4.plpgsqlStatements(),
+       Stmts: $4.statements(),
      }
      $$.val = expr
   }
@@ -924,7 +924,7 @@ opt_case_else:
   }
 | ELSE proc_sect
   {
-    $$.val = $2.plpgsqlStatements()
+    $$.val = $2.statements()
   }
 ;
 
@@ -932,9 +932,9 @@ stmt_loop: opt_loop_label LOOP loop_body opt_label ';'
   {
     // TODO(drewk): does the second usage of the label actually
     // do anything?
-    $$.val = &plpgsqltree.PLpgSQLStmtSimpleLoop{
+    $$.val = &plpgsqltree.Loop{
       Label: $1,
-      Body: $3.plpgsqlStatements(),
+      Body: $3.statements(),
     }
   }
 ;
@@ -998,18 +998,18 @@ foreach_slice:
 
 stmt_exit: EXIT opt_label opt_exitcond
   {
-    $$.val = &plpgsqltree.PLpgSQLStmtExit{
+    $$.val = &plpgsqltree.Exit{
       Label: $2,
-      Condition: $3.plpgsqlExpr(),
+      Condition: $3.expr(),
     }
   }
 ;
 
 stmt_continue: CONTINUE opt_label opt_exitcond
   {
-    $$.val = &plpgsqltree.PLpgSQLStmtContinue{
+    $$.val = &plpgsqltree.Continue{
       Label: $2,
-      Condition: $3.plpgsqlExpr(),
+      Condition: $3.expr(),
     }
   }
 ;
@@ -1022,8 +1022,8 @@ stmt_continue: CONTINUE opt_label opt_exitcond
 
 stmt_return: RETURN return_variable ';'
   {
-    $$.val = &plpgsqltree.PLpgSQLStmtReturn{
-      Expr: $2.plpgsqlExpr(),
+    $$.val = &plpgsqltree.Return{
+      Expr: $2.expr(),
     }
   }
 | RETURN_NEXT NEXT return_variable ';'
@@ -1065,34 +1065,34 @@ stmt_raise:
   }
 | RAISE opt_error_level SCONST opt_format_exprs opt_option_exprs ';'
   {
-    $$.val = &plpgsqltree.PLpgSQLStmtRaise{
+    $$.val = &plpgsqltree.Raise{
       LogLevel: $2,
       Message: $3,
-      Params: $4.plpgsqlExprs(),
-      Options: $5.plpgsqlOptionExprs(),
+      Params: $4.exprs(),
+      Options: $5.raiseOptions(),
     }
   }
 | RAISE opt_error_level IDENT opt_option_exprs ';'
   {
-    $$.val = &plpgsqltree.PLpgSQLStmtRaise{
+    $$.val = &plpgsqltree.Raise{
       LogLevel: $2,
       CodeName: $3,
-      Options: $4.plpgsqlOptionExprs(),
+      Options: $4.raiseOptions(),
     }
   }
 | RAISE opt_error_level SQLSTATE SCONST opt_option_exprs ';'
   {
-    $$.val = &plpgsqltree.PLpgSQLStmtRaise{
+    $$.val = &plpgsqltree.Raise{
       LogLevel: $2,
       Code: $4,
-      Options: $5.plpgsqlOptionExprs(),
+      Options: $5.raiseOptions(),
     }
   }
 | RAISE opt_error_level USING option_exprs ';'
   {
-    $$.val = &plpgsqltree.PLpgSQLStmtRaise{
+    $$.val = &plpgsqltree.Raise{
       LogLevel: $2,
-      Options: $4.plpgsqlOptionExprs(),
+      Options: $4.raiseOptions(),
     }
   }
 ;
@@ -1113,24 +1113,24 @@ opt_error_level:
 opt_option_exprs:
   USING option_exprs
   {
-    $$.val = $2.plpgsqlOptionExprs()
+    $$.val = $2.raiseOptions()
   }
 | /* EMPTY */
   {
-    $$.val = []plpgsqltree.PLpgSQLStmtRaiseOption{}
+    $$.val = []plpgsqltree.RaiseOption{}
   }
 ;
 
 option_exprs:
   option_exprs ',' option_expr
   {
-    option := $3.plpgsqlOptionExpr()
-    $$.val = append($1.plpgsqlOptionExprs(), *option)
+    option := $3.raiseOption()
+    $$.val = append($1.raiseOptions(), *option)
   }
 | option_expr
   {
-    option := $1.plpgsqlOptionExpr()
-    $$.val = []plpgsqltree.PLpgSQLStmtRaiseOption{*option}
+    option := $1.raiseOption()
+    $$.val = []plpgsqltree.RaiseOption{*option}
   }
 ;
 
@@ -1143,7 +1143,7 @@ option_expr:
     if err != nil {
       return setErr(plpgsqllex, err)
     }
-    $$.val = &plpgsqltree.PLpgSQLStmtRaiseOption{
+    $$.val = &plpgsqltree.RaiseOption{
       OptType: $1,
       Expr: optionExpr,
     }
@@ -1165,22 +1165,22 @@ option_type:
 opt_format_exprs:
   format_exprs
   {
-    $$.val = $1.plpgsqlExprs()
+    $$.val = $1.exprs()
   }
  | /* EMPTY */
   {
-    $$.val = []plpgsqltree.PLpgSQLExpr{}
+    $$.val = []plpgsqltree.Expr{}
   }
 ;
 
 format_exprs:
   format_expr
   {
-    $$.val = []plpgsqltree.PLpgSQLExpr{$1.plpgsqlExpr()}
+    $$.val = []plpgsqltree.Expr{$1.expr()}
   }
 | format_exprs format_expr
   {
-    $$.val = append($1.plpgsqlExprs(), $2.plpgsqlExpr())
+    $$.val = append($1.exprs(), $2.expr())
   }
 ;
 
@@ -1198,7 +1198,7 @@ format_expr: ','
 
 stmt_assert: ASSERT assert_cond ';'
   {
-    $$.val = &plpgsqltree.PLpgSQLStmtAssert{}
+    $$.val = &plpgsqltree.Assert{}
   }
 ;
 
@@ -1213,7 +1213,7 @@ assert_cond:
 
 loop_body: proc_sect END LOOP
   {
-    $$.val = $1.plpgsqlStatements()
+    $$.val = $1.statements()
   }
 ;
 
@@ -1243,7 +1243,7 @@ stmt_dynexecute: EXECUTE
 // TODO: change expr_until_semi to process_cursor_before_semi
 stmt_open: OPEN IDENT open_stmt_processor ';'
   {
-    openCursorStmt := $3.pLpgSQLStmtOpen()
+    openCursorStmt := $3.open()
     openCursorStmt.CursorName = $2
     $$.val = openCursorStmt
   }
@@ -1268,13 +1268,13 @@ opt_fetch_direction:
 
 stmt_close: CLOSE cursor_variable ';'
   {
-    $$.val = &plpgsqltree.PLpgSQLStmtClose{}
+    $$.val = &plpgsqltree.Close{}
   }
 ;
 
 stmt_null: NULL ';'
   {
-  $$.val = &plpgsqltree.PLpgSQLStmtNull{};
+  $$.val = &plpgsqltree.Null{};
   }
 ;
 
@@ -1306,54 +1306,54 @@ cursor_variable: IDENT
 
 exception_sect: /* EMPTY */
   {
-    $$.val = []plpgsqltree.PLpgSQLException(nil)
+    $$.val = []plpgsqltree.Exception(nil)
   }
 | EXCEPTION proc_exceptions
   {
-    $$.val = $2.plpgsqlExceptions()
+    $$.val = $2.exceptions()
   }
 ;
 
 proc_exceptions: proc_exceptions proc_exception
   {
-    e := $2.plpgsqlException()
-    $$.val = append($1.plpgsqlExceptions(), *e)
+    e := $2.exception()
+    $$.val = append($1.exceptions(), *e)
   }
 | proc_exception
   {
-    e := $1.plpgsqlException()
-    $$.val = []plpgsqltree.PLpgSQLException{*e}
+    e := $1.exception()
+    $$.val = []plpgsqltree.Exception{*e}
   }
 ;
 
 proc_exception: WHEN proc_conditions THEN proc_sect
   {
-    $$.val = &plpgsqltree.PLpgSQLException{
-      Conditions: $2.plpgsqlConditions(),
-      Action: $4.plpgsqlStatements(),
+    $$.val = &plpgsqltree.Exception{
+      Conditions: $2.conditions(),
+      Action: $4.statements(),
     }
   }
 ;
 
 proc_conditions: proc_conditions OR proc_condition
   {
-    c := $3.plpgsqlCondition()
-    $$.val = append($1.plpgsqlConditions(), *c)
+    c := $3.condition()
+    $$.val = append($1.conditions(), *c)
   }
 | proc_condition
   {
-    c := $1.plpgsqlCondition()
-    $$.val = []plpgsqltree.PLpgSQLCondition{*c}
+    c := $1.condition()
+    $$.val = []plpgsqltree.Condition{*c}
   }
 ;
 
 proc_condition: any_identifier
   {
-    $$.val = &plpgsqltree.PLpgSQLCondition{SqlErrName: $1}
+    $$.val = &plpgsqltree.Condition{SqlErrName: $1}
   }
 | SQLSTATE SCONST
   {
-    $$.val = &plpgsqltree.PLpgSQLCondition{SqlErrState: $2}
+    $$.val = &plpgsqltree.Condition{SqlErrState: $2}
   }
 ;
 

--- a/pkg/sql/sem/plpgsqltree/constants.go
+++ b/pkg/sql/sem/plpgsqltree/constants.go
@@ -12,124 +12,122 @@ package plpgsqltree
 
 import "github.com/cockroachdb/errors"
 
-// PLpgSQLGetDiagKind represents the type of error diagnostic
+// GetDiagnosticsKind represents the type of error diagnostic
 // item in stmt_getdiag.
-type PLpgSQLGetDiagKind int
+type GetDiagnosticsKind int
 
-// PlpgsqlGetdiagRowCount is an option for diagnostic items that can be
-// present in stmt_getdiag.
 const (
-	// PlpgsqlGetdiagRowCount returns the number of rows processed by the recent
+	// GetDiagnosticsRowCount returns the number of rows processed by the recent
 	// SQL command.
-	PlpgsqlGetdiagRowCount PLpgSQLGetDiagKind = iota
-	// PlpgsqlGetdiagContext returns text describing the current call stack.
-	PlpgsqlGetdiagContext
-	// PlpgsqlGetdiagErrorContext returns text describing the exception's callstack.
-	PlpgsqlGetdiagErrorContext
-	// PlpgsqlGetdiagErrorDetail returns the exceptions detail message.
-	PlpgsqlGetdiagErrorDetail
-	// PlpgsqlGetdiagErrorHint returns the exceptions hint message.
-	PlpgsqlGetdiagErrorHint
-	// PlpgsqlGetdiagReturnedSqlstate returns the SQLSTATE error code related to
+	GetDiagnosticsRowCount GetDiagnosticsKind = iota
+	// GetDiagnosticsContext returns text describing the current call stack.
+	GetDiagnosticsContext
+	// GetDiagnosticsErrorContext returns text describing the exception's
+	// callstack.
+	GetDiagnosticsErrorContext
+	// GetDiagnosticsErrorDetail returns the exceptions detail message.
+	GetDiagnosticsErrorDetail
+	// GetDiagnosticsErrorHint returns the exceptions hint message.
+	GetDiagnosticsErrorHint
+	// GetDiagnosticsReturnedSQLState returns the SQLSTATE error code related to
 	// the exception.
-	PlpgsqlGetdiagReturnedSqlstate
-	// PlpgsqlGetdiagColumnName returns the column name related to the exception.
-	PlpgsqlGetdiagColumnName
-	// PlpgsqlGetdiagConstraintName returns the constraint name related to
+	GetDiagnosticsReturnedSQLState
+	// GetDiagnosticsColumnName returns the column name related to the exception.
+	GetDiagnosticsColumnName
+	// GetDiagnosticsConstraintName returns the constraint name related to
 	// the exception.
-	PlpgsqlGetdiagConstraintName
-	// PlpgsqlGetdiagDatatypeName returns the data type name related to
-	// the exception.
-	PlpgsqlGetdiagDatatypeName
-	// PlpgsqlGetdiagMessageText returns the exceptions primary message.
-	PlpgsqlGetdiagMessageText
-	// PlpgsqlGetdiagTableName returns the name of the table related to
-	// the exception.
-	PlpgsqlGetdiagTableName
-	// PlpgsqlGetdiagSchemaName returns the name of the schema related to
-	//	// the exception.
-	PlpgsqlGetdiagSchemaName
+	GetDiagnosticsConstraintName
+	// GetDiagnosticsDatatypeName returns the data type name related to the
+	// exception.
+	GetDiagnosticsDatatypeName
+	// GetDiagnosticsMessageText returns the exceptions primary message.
+	GetDiagnosticsMessageText
+	// GetDiagnosticsTableName returns the name of the table related to the
+	// exception.
+	GetDiagnosticsTableName
+	// GetDiagnosticsSchemaName returns the name of the schema related to the
+	// exception.
+	GetDiagnosticsSchemaName
 )
 
 // String implements the fmt.Stringer interface.
-func (k PLpgSQLGetDiagKind) String() string {
+func (k GetDiagnosticsKind) String() string {
 	switch k {
-	case PlpgsqlGetdiagRowCount:
+	case GetDiagnosticsRowCount:
 		return "ROW_COUNT"
-	case PlpgsqlGetdiagContext:
+	case GetDiagnosticsContext:
 		return "PG_CONTEXT"
-	case PlpgsqlGetdiagErrorContext:
+	case GetDiagnosticsErrorContext:
 		return "PG_EXCEPTION_CONTEXT"
-	case PlpgsqlGetdiagErrorDetail:
+	case GetDiagnosticsErrorDetail:
 		return "PG_EXCEPTION_DETAIL"
-	case PlpgsqlGetdiagErrorHint:
+	case GetDiagnosticsErrorHint:
 		return "PG_EXCEPTION_HINT"
-	case PlpgsqlGetdiagReturnedSqlstate:
+	case GetDiagnosticsReturnedSQLState:
 		return "RETURNED_SQLSTATE"
-	case PlpgsqlGetdiagColumnName:
+	case GetDiagnosticsColumnName:
 		return "COLUMN_NAME"
-	case PlpgsqlGetdiagConstraintName:
+	case GetDiagnosticsConstraintName:
 		return "CONSTRAINT_NAME"
-	case PlpgsqlGetdiagDatatypeName:
+	case GetDiagnosticsDatatypeName:
 		return "PG_DATATYPE_NAME"
-	case PlpgsqlGetdiagMessageText:
+	case GetDiagnosticsMessageText:
 		return "MESSAGE_TEXT"
-	case PlpgsqlGetdiagTableName:
+	case GetDiagnosticsTableName:
 		return "TABLE_NAME"
-	case PlpgsqlGetdiagSchemaName:
+	case GetDiagnosticsSchemaName:
 		return "SCHEMA_NAME"
 	}
-	panic(errors.AssertionFailedf("no Annotations unknown getDiagnistics kind"))
+	panic(errors.AssertionFailedf("unknown diagnostics kind"))
 
 }
 
-// PLpgSQLFetchDirection represents the direction clause passed into a
-// fetch statement.
-type PLpgSQLFetchDirection int
+// FetchDirection represents the direction clause passed into a fetch statement.
+type FetchDirection int
 
-// PLpgSQLCursorOpt represents a cursor option, which describes
-// how a cursor will behave.
-type PLpgSQLCursorOpt uint32
+// CursorOption represents a cursor option, which describes how a cursor will
+// behave.
+type CursorOption uint32
 
 const (
-	// PLpgSQLCursorOptNone
-	PLpgSQLCursorOptNone PLpgSQLCursorOpt = iota
-	// PLpgSQLCursorOptBinary describes cursors that return data in binary form.
-	PLpgSQLCursorOptBinary
-	// PLpgSQLCursorOptScroll describes cursors that can retrieve rows in
+	// CursorOptionNone
+	CursorOptionNone CursorOption = iota
+	// CursorOptionBinary describes cursors that return data in binary form.
+	CursorOptionBinary
+	// CursorOptionScroll describes cursors that can retrieve rows in
 	// non-sequential fashion.
-	PLpgSQLCursorOptScroll
-	// PLpgSQLCursorOptNoScroll describes cursors that can not retrieve rows in
+	CursorOptionScroll
+	// CursorOptionNoScroll describes cursors that can not retrieve rows in
 	// non-sequential fashion.
-	PLpgSQLCursorOptNoScroll
-	// PLpgSQLCursorOptInsensitive describes cursors that can't see changes to
+	CursorOptionNoScroll
+	// CursorOptionInsensitive describes cursors that can't see changes to
 	// done to data in same txn.
-	PLpgSQLCursorOptInsensitive
-	// PLpgSQLCursorOptAsensitive describes cursors that may be able to see
+	CursorOptionInsensitive
+	// CursorOPtionAsensitive describes cursors that may be able to see
 	// changes to done to data in same txn.
-	PLpgSQLCursorOptAsensitive
-	// PLpgSQLCursorOptHold describes cursors that can be used after a txn that it
+	CursorOPtionAsensitive
+	// CursorOptionHold describes cursors that can be used after a txn that it
 	// was created in commits.
-	PLpgSQLCursorOptHold
-	// PLpgSQLCursorOptFastPlan describes cursors that can not be used after a txn
+	CursorOptionHold
+	// CursorOptionFastPlan describes cursors that can not be used after a txn
 	// that it was created in commits.
-	PLpgSQLCursorOptFastPlan
-	// PLpgSQLCursorOptGenericPlan describes cursors that uses a generic plan.
-	PLpgSQLCursorOptGenericPlan
-	// PLpgSQLCursorOptCustomPlan describes cursors that uses a custom plan.
-	PLpgSQLCursorOptCustomPlan
-	// PLpgSQLCursorOptParallelOK describes cursors that allows parallel queries.
-	PLpgSQLCursorOptParallelOK
+	CursorOptionFastPlan
+	// CursorOptionGenericPlan describes cursors that uses a generic plan.
+	CursorOptionGenericPlan
+	// CursorOptionCustomPlan describes cursors that uses a custom plan.
+	CursorOptionCustomPlan
+	// CursorOptionParallelOK describes cursors that allows parallel queries.
+	CursorOptionParallelOK
 )
 
 // String implements the fmt.Stringer interface.
-func (o PLpgSQLCursorOpt) String() string {
+func (o CursorOption) String() string {
 	switch o {
-	case PLpgSQLCursorOptNoScroll:
+	case CursorOptionNoScroll:
 		return "NO SCROLL"
-	case PLpgSQLCursorOptScroll:
+	case CursorOptionScroll:
 		return "SCROLL"
-	case PLpgSQLCursorOptFastPlan:
+	case CursorOptionFastPlan:
 		return ""
 	// TODO(jane): implement string representation for other opts.
 	default:
@@ -138,19 +136,19 @@ func (o PLpgSQLCursorOpt) String() string {
 }
 
 // Mask returns the bitmask for a given cursor option.
-func (o PLpgSQLCursorOpt) Mask() uint32 {
+func (o CursorOption) Mask() uint32 {
 	return 1 << o
 }
 
 // IsSetIn returns true if this cursor option is set in the supplied bitfield.
-func (o PLpgSQLCursorOpt) IsSetIn(bits uint32) bool {
+func (o CursorOption) IsSetIn(bits uint32) bool {
 	return bits&o.Mask() != 0
 }
 
-type plpgSQLCursorOptList []PLpgSQLCursorOpt
+type cursorOptionList []CursorOption
 
 // ToBitField returns the bitfield representation of a list of cursor options.
-func (ol plpgSQLCursorOptList) ToBitField() uint32 {
+func (ol cursorOptionList) ToBitField() uint32 {
 	var ret uint32
 	for _, o := range ol {
 		ret |= o.Mask()
@@ -159,19 +157,19 @@ func (ol plpgSQLCursorOptList) ToBitField() uint32 {
 }
 
 // OptListFromBitField returns a list of cursor option to be printed.
-func OptListFromBitField(m uint32) plpgSQLCursorOptList {
-	ret := plpgSQLCursorOptList{}
-	opts := []PLpgSQLCursorOpt{
-		PLpgSQLCursorOptBinary,
-		PLpgSQLCursorOptScroll,
-		PLpgSQLCursorOptNoScroll,
-		PLpgSQLCursorOptInsensitive,
-		PLpgSQLCursorOptAsensitive,
-		PLpgSQLCursorOptHold,
-		PLpgSQLCursorOptFastPlan,
-		PLpgSQLCursorOptGenericPlan,
-		PLpgSQLCursorOptCustomPlan,
-		PLpgSQLCursorOptParallelOK,
+func OptListFromBitField(m uint32) cursorOptionList {
+	ret := cursorOptionList{}
+	opts := []CursorOption{
+		CursorOptionBinary,
+		CursorOptionScroll,
+		CursorOptionNoScroll,
+		CursorOptionInsensitive,
+		CursorOPtionAsensitive,
+		CursorOptionHold,
+		CursorOptionFastPlan,
+		CursorOptionGenericPlan,
+		CursorOptionCustomPlan,
+		CursorOptionParallelOK,
 	}
 	for _, opt := range opts {
 		if opt.IsSetIn(m) {

--- a/pkg/sql/sem/plpgsqltree/exception.go
+++ b/pkg/sql/sem/plpgsqltree/exception.go
@@ -16,13 +16,13 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
 
-type PLpgSQLException struct {
-	PLpgSQLStatementImpl
-	Conditions []PLpgSQLCondition
-	Action     []PLpgSQLStatement
+type Exception struct {
+	StatementImpl
+	Conditions []Condition
+	Action     []Statement
 }
 
-func (s *PLpgSQLException) Format(ctx *tree.FmtCtx) {
+func (s *Exception) Format(ctx *tree.FmtCtx) {
 	ctx.WriteString("WHEN ")
 	for i, cond := range s.Conditions {
 		if i > 0 {
@@ -40,18 +40,18 @@ func (s *PLpgSQLException) Format(ctx *tree.FmtCtx) {
 	}
 }
 
-func (s *PLpgSQLException) PlpgSQLStatementTag() string {
+func (s *Exception) PlpgSQLStatementTag() string {
 	return "proc_exception"
 }
 
-func (s *PLpgSQLException) WalkStmt(visitor PLpgSQLStmtVisitor) {
+func (s *Exception) WalkStmt(visitor StatementVisitor) {
 	visitor.Visit(s)
 	for _, stmt := range s.Action {
 		stmt.WalkStmt(visitor)
 	}
 }
 
-type PLpgSQLCondition struct {
+type Condition struct {
 	SqlErrState string
 	SqlErrName  string
 }

--- a/pkg/sql/sem/plpgsqltree/statements.go
+++ b/pkg/sql/sem/plpgsqltree/statements.go
@@ -17,21 +17,21 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
 
-type PLpgSQLExpr = tree.Expr
+type Expr = tree.Expr
 
-type PLpgSQLStatement interface {
+type Statement interface {
 	tree.NodeFormatter
 	GetLineNo() int
 	GetStmtID() uint
 	plpgsqlStmt()
-	WalkStmt(PLpgSQLStmtVisitor)
+	WalkStmt(StatementVisitor)
 }
 
-type TaggedPLpgSQLStatement interface {
+type TaggedStatement interface {
 	PlpgSQLStatementTag() string
 }
 
-type PLpgSQLStatementImpl struct {
+type StatementImpl struct {
 	// TODO(Chengxiong): figure out how to get line number from scanner.
 	LineNo int
 	/*
@@ -43,27 +43,27 @@ type PLpgSQLStatementImpl struct {
 	StmtID uint
 }
 
-func (s *PLpgSQLStatementImpl) GetLineNo() int {
+func (s *StatementImpl) GetLineNo() int {
 	return s.LineNo
 }
 
-func (s *PLpgSQLStatementImpl) GetStmtID() uint {
+func (s *StatementImpl) GetStmtID() uint {
 	return s.StmtID
 }
 
-func (s *PLpgSQLStatementImpl) plpgsqlStmt() {}
+func (s *StatementImpl) plpgsqlStmt() {}
 
 // pl_block
-type PLpgSQLStmtBlock struct {
-	PLpgSQLStatementImpl
+type Block struct {
+	StatementImpl
 	Label      string
-	Decls      []PLpgSQLDecl
-	Body       []PLpgSQLStatement
-	Exceptions []PLpgSQLException
+	Decls      []Declaration
+	Body       []Statement
+	Exceptions []Exception
 }
 
 // TODO(drewk): format Label and Exceptions fields.
-func (s *PLpgSQLStmtBlock) Format(ctx *tree.FmtCtx) {
+func (s *Block) Format(ctx *tree.FmtCtx) {
 	if s.Decls != nil {
 		ctx.WriteString("DECLARE\n")
 		for _, dec := range s.Decls {
@@ -85,11 +85,11 @@ func (s *PLpgSQLStmtBlock) Format(ctx *tree.FmtCtx) {
 	ctx.WriteString("END\n")
 }
 
-func (s *PLpgSQLStmtBlock) PlpgSQLStatementTag() string {
+func (s *Block) PlpgSQLStatementTag() string {
 	return "stmt_block"
 }
 
-func (s *PLpgSQLStmtBlock) WalkStmt(visitor PLpgSQLStmtVisitor) {
+func (s *Block) WalkStmt(visitor StatementVisitor) {
 	visitor.Visit(s)
 	for _, stmt := range s.Body {
 		stmt.WalkStmt(visitor)
@@ -97,17 +97,17 @@ func (s *PLpgSQLStmtBlock) WalkStmt(visitor PLpgSQLStmtVisitor) {
 }
 
 // decl_stmt
-type PLpgSQLDecl struct {
-	PLpgSQLStatementImpl
-	Var      PLpgSQLVariable
+type Declaration struct {
+	StatementImpl
+	Var      Variable
 	Constant bool
 	Typ      tree.ResolvableTypeReference
 	Collate  string
 	NotNull  bool
-	Expr     PLpgSQLExpr
+	Expr     Expr
 }
 
-func (s *PLpgSQLDecl) Format(ctx *tree.FmtCtx) {
+func (s *Declaration) Format(ctx *tree.FmtCtx) {
 	ctx.WriteString(string(s.Var))
 	if s.Constant {
 		ctx.WriteString(" CONSTANT")
@@ -126,43 +126,43 @@ func (s *PLpgSQLDecl) Format(ctx *tree.FmtCtx) {
 	ctx.WriteString(";\n")
 }
 
-func (s *PLpgSQLDecl) PlpgSQLStatementTag() string {
+func (s *Declaration) PlpgSQLStatementTag() string {
 	return "decl_stmt"
 }
 
-func (s *PLpgSQLDecl) WalkStmt(visitor PLpgSQLStmtVisitor) {
+func (s *Declaration) WalkStmt(visitor StatementVisitor) {
 	visitor.Visit(s)
 }
 
 // stmt_assign
-type PLpgSQLStmtAssign struct {
-	PLpgSQLStatement
-	Var   PLpgSQLVariable
-	Value PLpgSQLExpr
+type Assignment struct {
+	Statement
+	Var   Variable
+	Value Expr
 }
 
-func (s *PLpgSQLStmtAssign) PlpgSQLStatementTag() string {
+func (s *Assignment) PlpgSQLStatementTag() string {
 	return "stmt_assign"
 }
 
-func (s *PLpgSQLStmtAssign) Format(ctx *tree.FmtCtx) {
+func (s *Assignment) Format(ctx *tree.FmtCtx) {
 	ctx.WriteString(fmt.Sprintf("%s := %s;\n", s.Var, s.Value))
 }
 
-func (s *PLpgSQLStmtAssign) WalkStmt(visitor PLpgSQLStmtVisitor) {
+func (s *Assignment) WalkStmt(visitor StatementVisitor) {
 	visitor.Visit(s)
 }
 
 // stmt_if
-type PLpgSQLStmtIf struct {
-	PLpgSQLStatementImpl
-	Condition  PLpgSQLExpr
-	ThenBody   []PLpgSQLStatement
-	ElseIfList []PLpgSQLStmtIfElseIfArm
-	ElseBody   []PLpgSQLStatement
+type If struct {
+	StatementImpl
+	Condition  Expr
+	ThenBody   []Statement
+	ElseIfList []ElseIf
+	ElseBody   []Statement
 }
 
-func (s *PLpgSQLStmtIf) Format(ctx *tree.FmtCtx) {
+func (s *If) Format(ctx *tree.FmtCtx) {
 	ctx.WriteString("IF ")
 	s.Condition.Format(ctx)
 	ctx.WriteString(" THEN\n")
@@ -184,11 +184,11 @@ func (s *PLpgSQLStmtIf) Format(ctx *tree.FmtCtx) {
 	ctx.WriteString("END IF;\n")
 }
 
-func (s *PLpgSQLStmtIf) PlpgSQLStatementTag() string {
+func (s *If) PlpgSQLStatementTag() string {
 	return "stmt_if"
 }
 
-func (s *PLpgSQLStmtIf) WalkStmt(visitor PLpgSQLStmtVisitor) {
+func (s *If) WalkStmt(visitor StatementVisitor) {
 	visitor.Visit(s)
 
 	for _, thenStmt := range s.ThenBody {
@@ -205,13 +205,13 @@ func (s *PLpgSQLStmtIf) WalkStmt(visitor PLpgSQLStmtVisitor) {
 
 }
 
-type PLpgSQLStmtIfElseIfArm struct {
-	PLpgSQLStatementImpl
-	Condition PLpgSQLExpr
-	Stmts     []PLpgSQLStatement
+type ElseIf struct {
+	StatementImpl
+	Condition Expr
+	Stmts     []Statement
 }
 
-func (s *PLpgSQLStmtIfElseIfArm) Format(ctx *tree.FmtCtx) {
+func (s *ElseIf) Format(ctx *tree.FmtCtx) {
 	ctx.WriteString("ELSIF ")
 	s.Condition.Format(ctx)
 	ctx.WriteString(" THEN\n")
@@ -221,11 +221,11 @@ func (s *PLpgSQLStmtIfElseIfArm) Format(ctx *tree.FmtCtx) {
 	}
 }
 
-func (s *PLpgSQLStmtIfElseIfArm) PlpgSQLStatementTag() string {
+func (s *ElseIf) PlpgSQLStatementTag() string {
 	return "stmt_if_else_if"
 }
 
-func (s *PLpgSQLStmtIfElseIfArm) WalkStmt(visitor PLpgSQLStmtVisitor) {
+func (s *ElseIf) WalkStmt(visitor StatementVisitor) {
 	visitor.Visit(s)
 
 	for _, stmt := range s.Stmts {
@@ -234,19 +234,19 @@ func (s *PLpgSQLStmtIfElseIfArm) WalkStmt(visitor PLpgSQLStmtVisitor) {
 }
 
 // stmt_case
-type PLpgSQLStmtCase struct {
-	PLpgSQLStatementImpl
-	// TODO(drewk): Change to PLpgSQLExpr
+type Case struct {
+	StatementImpl
+	// TODO(drewk): Change to Expr
 	TestExpr     string
-	Var          PLpgSQLVariable
-	CaseWhenList []*PLpgSQLStmtCaseWhenArm
+	Var          Variable
+	CaseWhenList []*CaseWhen
 	HaveElse     bool
-	ElseStmts    []PLpgSQLStatement
+	ElseStmts    []Statement
 }
 
 // TODO(drewk): fix the whitespace/newline formatting for CASE (see the
 // stmt_case test file).
-func (s *PLpgSQLStmtCase) Format(ctx *tree.FmtCtx) {
+func (s *Case) Format(ctx *tree.FmtCtx) {
 	ctx.WriteString("CASE")
 	if len(s.TestExpr) > 0 {
 		ctx.WriteString(fmt.Sprintf(" %s", s.TestExpr))
@@ -265,11 +265,11 @@ func (s *PLpgSQLStmtCase) Format(ctx *tree.FmtCtx) {
 	ctx.WriteString("END CASE\n")
 }
 
-func (s *PLpgSQLStmtCase) PlpgSQLStatementTag() string {
+func (s *Case) PlpgSQLStatementTag() string {
 	return "stmt_case"
 }
 
-func (s *PLpgSQLStmtCase) WalkStmt(visitor PLpgSQLStmtVisitor) {
+func (s *Case) WalkStmt(visitor StatementVisitor) {
 	visitor.Visit(s)
 
 	for _, when := range s.CaseWhenList {
@@ -283,14 +283,14 @@ func (s *PLpgSQLStmtCase) WalkStmt(visitor PLpgSQLStmtVisitor) {
 	}
 }
 
-type PLpgSQLStmtCaseWhenArm struct {
-	PLpgSQLStatementImpl
-	// TODO(drewk): Change to PLpgSQLExpr
+type CaseWhen struct {
+	StatementImpl
+	// TODO(drewk): Change to Expr
 	Expr  string
-	Stmts []PLpgSQLStatement
+	Stmts []Statement
 }
 
-func (s *PLpgSQLStmtCaseWhenArm) Format(ctx *tree.FmtCtx) {
+func (s *CaseWhen) Format(ctx *tree.FmtCtx) {
 	ctx.WriteString(fmt.Sprintf("WHEN %s THEN\n", s.Expr))
 	for i, stmt := range s.Stmts {
 		ctx.WriteString("  ")
@@ -301,11 +301,11 @@ func (s *PLpgSQLStmtCaseWhenArm) Format(ctx *tree.FmtCtx) {
 	}
 }
 
-func (s *PLpgSQLStmtCaseWhenArm) PlpgSQLStatementTag() string {
+func (s *CaseWhen) PlpgSQLStatementTag() string {
 	return "stmt_when"
 }
 
-func (s *PLpgSQLStmtCaseWhenArm) WalkStmt(visitor PLpgSQLStmtVisitor) {
+func (s *CaseWhen) WalkStmt(visitor StatementVisitor) {
 	visitor.Visit(s)
 
 	for _, stmt := range s.Stmts {
@@ -314,17 +314,17 @@ func (s *PLpgSQLStmtCaseWhenArm) WalkStmt(visitor PLpgSQLStmtVisitor) {
 }
 
 // stmt_loop
-type PLpgSQLStmtSimpleLoop struct {
-	PLpgSQLStatementImpl
+type Loop struct {
+	StatementImpl
 	Label string
-	Body  []PLpgSQLStatement
+	Body  []Statement
 }
 
-func (s *PLpgSQLStmtSimpleLoop) PlpgSQLStatementTag() string {
+func (s *Loop) PlpgSQLStatementTag() string {
 	return "stmt_simple_loop"
 }
 
-func (s *PLpgSQLStmtSimpleLoop) Format(ctx *tree.FmtCtx) {
+func (s *Loop) Format(ctx *tree.FmtCtx) {
 	ctx.WriteString("LOOP\n")
 	for _, stmt := range s.Body {
 		stmt.Format(ctx)
@@ -336,7 +336,7 @@ func (s *PLpgSQLStmtSimpleLoop) Format(ctx *tree.FmtCtx) {
 	ctx.WriteString(";\n")
 }
 
-func (s *PLpgSQLStmtSimpleLoop) WalkStmt(visitor PLpgSQLStmtVisitor) {
+func (s *Loop) WalkStmt(visitor StatementVisitor) {
 	visitor.Visit(s)
 	for _, stmt := range s.Body {
 		stmt.WalkStmt(visitor)
@@ -344,21 +344,21 @@ func (s *PLpgSQLStmtSimpleLoop) WalkStmt(visitor PLpgSQLStmtVisitor) {
 }
 
 // stmt_while
-type PLpgSQLStmtWhileLoop struct {
-	PLpgSQLStatementImpl
+type While struct {
+	StatementImpl
 	Label     string
-	Condition PLpgSQLExpr
-	Body      []PLpgSQLStatement
+	Condition Expr
+	Body      []Statement
 }
 
-func (s *PLpgSQLStmtWhileLoop) Format(ctx *tree.FmtCtx) {
+func (s *While) Format(ctx *tree.FmtCtx) {
 }
 
-func (s *PLpgSQLStmtWhileLoop) PlpgSQLStatementTag() string {
+func (s *While) PlpgSQLStatementTag() string {
 	return "stmt_while"
 }
 
-func (s *PLpgSQLStmtWhileLoop) WalkStmt(visitor PLpgSQLStmtVisitor) {
+func (s *While) WalkStmt(visitor StatementVisitor) {
 	visitor.Visit(s)
 	for _, stmt := range s.Body {
 		stmt.WalkStmt(visitor)
@@ -366,123 +366,123 @@ func (s *PLpgSQLStmtWhileLoop) WalkStmt(visitor PLpgSQLStmtVisitor) {
 }
 
 // stmt_for
-type PLpgSQLStmtForIntLoop struct {
-	PLpgSQLStatementImpl
+type ForInt struct {
+	StatementImpl
 	Label   string
-	Var     PLpgSQLVariable
-	Lower   PLpgSQLExpr
-	Upper   PLpgSQLExpr
-	Step    PLpgSQLExpr
+	Var     Variable
+	Lower   Expr
+	Upper   Expr
+	Step    Expr
 	Reverse int
-	Body    []PLpgSQLStatement
+	Body    []Statement
 }
 
-func (s *PLpgSQLStmtForIntLoop) Format(ctx *tree.FmtCtx) {
+func (s *ForInt) Format(ctx *tree.FmtCtx) {
 }
 
-func (s *PLpgSQLStmtForIntLoop) PlpgSQLStatementTag() string {
+func (s *ForInt) PlpgSQLStatementTag() string {
 	return "stmt_for_int_loop"
 }
 
-func (s *PLpgSQLStmtForIntLoop) WalkStmt(visitor PLpgSQLStmtVisitor) {
+func (s *ForInt) WalkStmt(visitor StatementVisitor) {
 	visitor.Visit(s)
 	for _, stmt := range s.Body {
 		stmt.WalkStmt(visitor)
 	}
 }
 
-type PLpgSQLStmtForQueryLoop struct {
-	PLpgSQLStatementImpl
+type ForQuery struct {
+	StatementImpl
 	Label string
-	Var   PLpgSQLVariable
-	Body  []PLpgSQLStatement
+	Var   Variable
+	Body  []Statement
 }
 
-func (s *PLpgSQLStmtForQueryLoop) Format(ctx *tree.FmtCtx) {
+func (s *ForQuery) Format(ctx *tree.FmtCtx) {
 }
 
-func (s *PLpgSQLStmtForQueryLoop) PlpgSQLStatementTag() string {
+func (s *ForQuery) PlpgSQLStatementTag() string {
 	return "stmt_for_query_loop"
 }
 
-func (s *PLpgSQLStmtForQueryLoop) WalkStmt(visitor PLpgSQLStmtVisitor) {
+func (s *ForQuery) WalkStmt(visitor StatementVisitor) {
 	visitor.Visit(s)
 	for _, stmt := range s.Body {
 		stmt.WalkStmt(visitor)
 	}
 }
 
-type PLpgSQLStmtForQuerySelectLoop struct {
-	PLpgSQLStmtForQueryLoop
-	Query PLpgSQLExpr
+type ForSelect struct {
+	ForQuery
+	Query Expr
 }
 
-func (s *PLpgSQLStmtForQuerySelectLoop) Format(ctx *tree.FmtCtx) {
+func (s *ForSelect) Format(ctx *tree.FmtCtx) {
 }
 
-func (s *PLpgSQLStmtForQuerySelectLoop) PlpgSQLStatementTag() string {
+func (s *ForSelect) PlpgSQLStatementTag() string {
 	return "stmt_query_select_loop"
 }
 
-func (s *PLpgSQLStmtForQuerySelectLoop) WalkStmt(visitor PLpgSQLStmtVisitor) {
+func (s *ForSelect) WalkStmt(visitor StatementVisitor) {
 	visitor.Visit(s)
-	s.PLpgSQLStmtForQueryLoop.WalkStmt(visitor)
+	s.ForQuery.WalkStmt(visitor)
 }
 
-type PLpgSQLStmtForQueryCursorLoop struct {
-	PLpgSQLStmtForQueryLoop
+type ForCursor struct {
+	ForQuery
 	CurVar   int // TODO(drewk): is this CursorVariable?
-	ArgQuery PLpgSQLExpr
+	ArgQuery Expr
 }
 
-func (s *PLpgSQLStmtForQueryCursorLoop) Format(ctx *tree.FmtCtx) {
+func (s *ForCursor) Format(ctx *tree.FmtCtx) {
 }
 
-func (s *PLpgSQLStmtForQueryCursorLoop) PlpgSQLStatementTag() string {
+func (s *ForCursor) PlpgSQLStatementTag() string {
 	return "stmt_for_query_cursor_loop"
 }
 
-func (s *PLpgSQLStmtForQueryCursorLoop) WalkStmt(visitor PLpgSQLStmtVisitor) {
+func (s *ForCursor) WalkStmt(visitor StatementVisitor) {
 	visitor.Visit(s)
-	s.PLpgSQLStmtForQueryLoop.WalkStmt(visitor)
+	s.ForQuery.WalkStmt(visitor)
 }
 
-type PLpgSQLStmtForDynamicLoop struct {
-	PLpgSQLStmtForQueryLoop
-	Query  PLpgSQLExpr
-	Params []PLpgSQLExpr
+type ForDynamic struct {
+	ForQuery
+	Query  Expr
+	Params []Expr
 }
 
-func (s *PLpgSQLStmtForDynamicLoop) Format(ctx *tree.FmtCtx) {
+func (s *ForDynamic) Format(ctx *tree.FmtCtx) {
 }
 
-func (s *PLpgSQLStmtForDynamicLoop) PlpgSQLStatementTag() string {
+func (s *ForDynamic) PlpgSQLStatementTag() string {
 	return "stmt_for_dyn_loop"
 }
 
-func (s *PLpgSQLStmtForDynamicLoop) WalkStmt(visitor PLpgSQLStmtVisitor) {
+func (s *ForDynamic) WalkStmt(visitor StatementVisitor) {
 	visitor.Visit(s)
-	s.PLpgSQLStmtForQueryLoop.WalkStmt(visitor)
+	s.ForQuery.WalkStmt(visitor)
 }
 
 // stmt_foreach_a
-type PLpgSQLStmtForEachALoop struct {
-	PLpgSQLStatementImpl
+type ForEachArray struct {
+	StatementImpl
 	Label string
-	Var   *PLpgSQLVariable
+	Var   *Variable
 	Slice int // TODO(drewk): not sure what this is
-	Expr  PLpgSQLExpr
-	Body  []PLpgSQLStatement
+	Expr  Expr
+	Body  []Statement
 }
 
-func (s *PLpgSQLStmtForEachALoop) Format(ctx *tree.FmtCtx) {
+func (s *ForEachArray) Format(ctx *tree.FmtCtx) {
 }
 
-func (s *PLpgSQLStmtForEachALoop) PlpgSQLStatementTag() string {
+func (s *ForEachArray) PlpgSQLStatementTag() string {
 	return "stmt_for_each_a"
 }
 
-func (s *PLpgSQLStmtForEachALoop) WalkStmt(visitor PLpgSQLStmtVisitor) {
+func (s *ForEachArray) WalkStmt(visitor StatementVisitor) {
 	visitor.Visit(s)
 
 	for _, stmt := range s.Body {
@@ -491,13 +491,13 @@ func (s *PLpgSQLStmtForEachALoop) WalkStmt(visitor PLpgSQLStmtVisitor) {
 }
 
 // stmt_exit
-type PLpgSQLStmtExit struct {
-	PLpgSQLStatementImpl
+type Exit struct {
+	StatementImpl
 	Label     string
-	Condition PLpgSQLExpr
+	Condition Expr
 }
 
-func (s *PLpgSQLStmtExit) Format(ctx *tree.FmtCtx) {
+func (s *Exit) Format(ctx *tree.FmtCtx) {
 	ctx.WriteString("EXIT")
 	if s.Label != "" {
 		ctx.WriteString(fmt.Sprintf(" %s", s.Label))
@@ -510,22 +510,22 @@ func (s *PLpgSQLStmtExit) Format(ctx *tree.FmtCtx) {
 
 }
 
-func (s *PLpgSQLStmtExit) PlpgSQLStatementTag() string {
+func (s *Exit) PlpgSQLStatementTag() string {
 	return "stmt_exit"
 }
 
-func (s *PLpgSQLStmtExit) WalkStmt(visitor PLpgSQLStmtVisitor) {
+func (s *Exit) WalkStmt(visitor StatementVisitor) {
 	visitor.Visit(s)
 }
 
 // stmt_continue
-type PLpgSQLStmtContinue struct {
-	PLpgSQLStatementImpl
+type Continue struct {
+	StatementImpl
 	Label     string
-	Condition PLpgSQLExpr
+	Condition Expr
 }
 
-func (s *PLpgSQLStmtContinue) Format(ctx *tree.FmtCtx) {
+func (s *Continue) Format(ctx *tree.FmtCtx) {
 	ctx.WriteString("CONTINUE")
 	if s.Label != "" {
 		ctx.WriteString(fmt.Sprintf(" %s", s.Label))
@@ -537,22 +537,22 @@ func (s *PLpgSQLStmtContinue) Format(ctx *tree.FmtCtx) {
 	ctx.WriteString(";\n")
 }
 
-func (s *PLpgSQLStmtContinue) PlpgSQLStatementTag() string {
+func (s *Continue) PlpgSQLStatementTag() string {
 	return "stmt_continue"
 }
 
-func (s *PLpgSQLStmtContinue) WalkStmt(visitor PLpgSQLStmtVisitor) {
+func (s *Continue) WalkStmt(visitor StatementVisitor) {
 	visitor.Visit(s)
 }
 
 // stmt_return
-type PLpgSQLStmtReturn struct {
-	PLpgSQLStatementImpl
-	Expr   PLpgSQLExpr
-	RetVar PLpgSQLVariable
+type Return struct {
+	StatementImpl
+	Expr   Expr
+	RetVar Variable
 }
 
-func (s *PLpgSQLStmtReturn) Format(ctx *tree.FmtCtx) {
+func (s *Return) Format(ctx *tree.FmtCtx) {
 	ctx.WriteString("RETURN ")
 	if s.Expr == nil {
 		s.RetVar.Format(ctx)
@@ -562,61 +562,61 @@ func (s *PLpgSQLStmtReturn) Format(ctx *tree.FmtCtx) {
 	ctx.WriteString(";\n")
 }
 
-func (s *PLpgSQLStmtReturn) PlpgSQLStatementTag() string {
+func (s *Return) PlpgSQLStatementTag() string {
 	return "stmt_return"
 }
 
-func (s *PLpgSQLStmtReturn) WalkStmt(visitor PLpgSQLStmtVisitor) {
+func (s *Return) WalkStmt(visitor StatementVisitor) {
 	visitor.Visit(s)
 }
 
-type PLpgSQLStmtReturnNext struct {
-	PLpgSQLStatementImpl
-	Expr   PLpgSQLExpr
-	RetVar PLpgSQLVariable
+type ReturnNext struct {
+	StatementImpl
+	Expr   Expr
+	RetVar Variable
 }
 
-func (s *PLpgSQLStmtReturnNext) Format(ctx *tree.FmtCtx) {
+func (s *ReturnNext) Format(ctx *tree.FmtCtx) {
 }
 
-func (s *PLpgSQLStmtReturnNext) PlpgSQLStatementTag() string {
+func (s *ReturnNext) PlpgSQLStatementTag() string {
 	return "stmt_return_next"
 }
 
-func (s *PLpgSQLStmtReturnNext) WalkStmt(visitor PLpgSQLStmtVisitor) {
+func (s *ReturnNext) WalkStmt(visitor StatementVisitor) {
 	visitor.Visit(s)
 }
 
-type PLpgSQLStmtReturnQuery struct {
-	PLpgSQLStatementImpl
-	Query        PLpgSQLExpr
-	DynamicQuery PLpgSQLExpr
-	Params       []PLpgSQLExpr
+type ReturnQuery struct {
+	StatementImpl
+	Query        Expr
+	DynamicQuery Expr
+	Params       []Expr
 }
 
-func (s *PLpgSQLStmtReturnQuery) Format(ctx *tree.FmtCtx) {
+func (s *ReturnQuery) Format(ctx *tree.FmtCtx) {
 }
 
-func (s *PLpgSQLStmtReturnQuery) PlpgSQLStatementTag() string {
+func (s *ReturnQuery) PlpgSQLStatementTag() string {
 	return "stmt_return_query"
 }
 
-func (s *PLpgSQLStmtReturnQuery) WalkStmt(visitor PLpgSQLStmtVisitor) {
+func (s *ReturnQuery) WalkStmt(visitor StatementVisitor) {
 	visitor.Visit(s)
 }
 
 // stmt_raise
-type PLpgSQLStmtRaise struct {
-	PLpgSQLStatementImpl
+type Raise struct {
+	StatementImpl
 	LogLevel string
 	Code     string
 	CodeName string
 	Message  string
-	Params   []PLpgSQLExpr
-	Options  []PLpgSQLStmtRaiseOption
+	Params   []Expr
+	Options  []RaiseOption
 }
 
-func (s *PLpgSQLStmtRaise) Format(ctx *tree.FmtCtx) {
+func (s *Raise) Format(ctx *tree.FmtCtx) {
 	ctx.WriteString("RAISE")
 	if s.LogLevel != "" {
 		ctx.WriteString(" ")
@@ -646,53 +646,53 @@ func (s *PLpgSQLStmtRaise) Format(ctx *tree.FmtCtx) {
 	ctx.WriteString(";\n")
 }
 
-type PLpgSQLStmtRaiseOption struct {
+type RaiseOption struct {
 	OptType string
-	Expr    PLpgSQLExpr
+	Expr    Expr
 }
 
-func (s *PLpgSQLStmtRaiseOption) Format(ctx *tree.FmtCtx) {
+func (s *RaiseOption) Format(ctx *tree.FmtCtx) {
 	ctx.WriteString(fmt.Sprintf("%s = ", strings.ToUpper(s.OptType)))
 	s.Expr.Format(ctx)
 }
 
-func (s *PLpgSQLStmtRaise) PlpgSQLStatementTag() string {
+func (s *Raise) PlpgSQLStatementTag() string {
 	return "stmt_raise"
 }
 
-func (s *PLpgSQLStmtRaise) WalkStmt(visitor PLpgSQLStmtVisitor) {
+func (s *Raise) WalkStmt(visitor StatementVisitor) {
 	visitor.Visit(s)
 }
 
 // stmt_assert
-type PLpgSQLStmtAssert struct {
-	PLpgSQLStatementImpl
-	Condition PLpgSQLExpr
-	Message   PLpgSQLExpr
+type Assert struct {
+	StatementImpl
+	Condition Expr
+	Message   Expr
 }
 
-func (s *PLpgSQLStmtAssert) Format(ctx *tree.FmtCtx) {
+func (s *Assert) Format(ctx *tree.FmtCtx) {
 	// TODO(drewk): Pretty print the assert condition and message
 	ctx.WriteString("ASSERT\n")
 }
 
-func (s *PLpgSQLStmtAssert) PlpgSQLStatementTag() string {
+func (s *Assert) PlpgSQLStatementTag() string {
 	return "stmt_assert"
 }
 
-func (s *PLpgSQLStmtAssert) WalkStmt(visitor PLpgSQLStmtVisitor) {
+func (s *Assert) WalkStmt(visitor StatementVisitor) {
 	visitor.Visit(s)
 }
 
 // stmt_execsql
-type PLpgSQLStmtExecSql struct {
-	PLpgSQLStatementImpl
+type Execute struct {
+	StatementImpl
 	SqlStmt tree.Statement
 	Strict  bool // INTO STRICT flag
-	Target  []PLpgSQLVariable
+	Target  []Variable
 }
 
-func (s *PLpgSQLStmtExecSql) Format(ctx *tree.FmtCtx) {
+func (s *Execute) Format(ctx *tree.FmtCtx) {
 	s.SqlStmt.Format(ctx)
 	if s.Target != nil {
 		ctx.WriteString(" INTO ")
@@ -709,26 +709,26 @@ func (s *PLpgSQLStmtExecSql) Format(ctx *tree.FmtCtx) {
 	ctx.WriteString(";\n")
 }
 
-func (s *PLpgSQLStmtExecSql) PlpgSQLStatementTag() string {
+func (s *Execute) PlpgSQLStatementTag() string {
 	return "stmt_exec_sql"
 }
 
-func (s *PLpgSQLStmtExecSql) WalkStmt(visitor PLpgSQLStmtVisitor) {
+func (s *Execute) WalkStmt(visitor StatementVisitor) {
 	visitor.Visit(s)
 }
 
 // stmt_dynexecute
 // TODO(chengxiong): query should be a better expression type.
-type PLpgSQLStmtDynamicExecute struct {
-	PLpgSQLStatementImpl
+type DynamicExecute struct {
+	StatementImpl
 	Query  string
 	Into   bool
 	Strict bool
-	Target PLpgSQLVariable
-	Params []PLpgSQLExpr
+	Target Variable
+	Params []Expr
 }
 
-func (s *PLpgSQLStmtDynamicExecute) Format(ctx *tree.FmtCtx) {
+func (s *DynamicExecute) Format(ctx *tree.FmtCtx) {
 	// TODO(drewk): Pretty print the original command
 	ctx.WriteString("EXECUTE a dynamic command")
 	if s.Into {
@@ -743,40 +743,40 @@ func (s *PLpgSQLStmtDynamicExecute) Format(ctx *tree.FmtCtx) {
 	ctx.WriteString("\n")
 }
 
-func (s *PLpgSQLStmtDynamicExecute) PlpgSQLStatementTag() string {
+func (s *DynamicExecute) PlpgSQLStatementTag() string {
 	return "stmt_dyn_exec"
 }
 
-func (s *PLpgSQLStmtDynamicExecute) WalkStmt(visitor PLpgSQLStmtVisitor) {
+func (s *DynamicExecute) WalkStmt(visitor StatementVisitor) {
 	visitor.Visit(s)
 }
 
 // stmt_perform
-type PLpgSQLStmtPerform struct {
-	PLpgSQLStatementImpl
-	Expr PLpgSQLExpr
+type Perform struct {
+	StatementImpl
+	Expr Expr
 }
 
-func (s *PLpgSQLStmtPerform) Format(ctx *tree.FmtCtx) {
+func (s *Perform) Format(ctx *tree.FmtCtx) {
 }
 
-func (s *PLpgSQLStmtPerform) PlpgSQLStatementTag() string {
+func (s *Perform) PlpgSQLStatementTag() string {
 	return "stmt_perform"
 }
 
-func (s *PLpgSQLStmtPerform) WalkStmt(visitor PLpgSQLStmtVisitor) {
+func (s *Perform) WalkStmt(visitor StatementVisitor) {
 	visitor.Visit(s)
 }
 
 // stmt_call
-type PLpgSQLStmtCall struct {
-	PLpgSQLStatementImpl
-	Expr   PLpgSQLExpr
+type Call struct {
+	StatementImpl
+	Expr   Expr
 	IsCall bool
-	Target PLpgSQLVariable
+	Target Variable
 }
 
-func (s *PLpgSQLStmtCall) Format(ctx *tree.FmtCtx) {
+func (s *Call) Format(ctx *tree.FmtCtx) {
 	// TODO(drewk): Correct the Call field and print the Expr and Target.
 	if s.IsCall {
 		ctx.WriteString("CALL a function/procedure\n")
@@ -785,22 +785,22 @@ func (s *PLpgSQLStmtCall) Format(ctx *tree.FmtCtx) {
 	}
 }
 
-func (s *PLpgSQLStmtCall) PlpgSQLStatementTag() string {
+func (s *Call) PlpgSQLStatementTag() string {
 	return "stmt_call"
 }
 
-func (s *PLpgSQLStmtCall) WalkStmt(visitor PLpgSQLStmtVisitor) {
+func (s *Call) WalkStmt(visitor StatementVisitor) {
 	visitor.Visit(s)
 }
 
 // stmt_getdiag
-type PLpgSQLStmtGetDiag struct {
-	PLpgSQLStatementImpl
+type GetDiagnostics struct {
+	StatementImpl
 	IsStacked bool
-	DiagItems PLpgSQLStmtGetDiagItemList // TODO(drewk): what is this?
+	DiagItems GetDiagnosticsItemList // TODO(drewk): what is this?
 }
 
-func (s *PLpgSQLStmtGetDiag) Format(ctx *tree.FmtCtx) {
+func (s *GetDiagnostics) Format(ctx *tree.FmtCtx) {
 	if s.IsStacked {
 		ctx.WriteString("GET STACKED DIAGNOSTICS ")
 	} else {
@@ -815,46 +815,46 @@ func (s *PLpgSQLStmtGetDiag) Format(ctx *tree.FmtCtx) {
 	ctx.WriteString("\n")
 }
 
-type PLpgSQLStmtGetDiagItem struct {
-	Kind PLpgSQLGetDiagKind
+type GetDiagnosticsItem struct {
+	Kind GetDiagnosticsKind
 	// TODO(jane): TargetName is temporary -- should be removed and use Target.
 	TargetName string
 	Target     int // where to assign it?
 }
 
-func (s *PLpgSQLStmtGetDiagItem) Format(ctx *tree.FmtCtx) {
+func (s *GetDiagnosticsItem) Format(ctx *tree.FmtCtx) {
 	ctx.WriteString(fmt.Sprintf("%s := %s", s.TargetName, s.Kind.String()))
 }
 
-type PLpgSQLStmtGetDiagItemList []*PLpgSQLStmtGetDiagItem
+type GetDiagnosticsItemList []*GetDiagnosticsItem
 
-func (s *PLpgSQLStmtGetDiag) PlpgSQLStatementTag() string {
+func (s *GetDiagnostics) PlpgSQLStatementTag() string {
 	return "stmt_get_diag"
 }
 
-func (s *PLpgSQLStmtGetDiag) WalkStmt(visitor PLpgSQLStmtVisitor) {
+func (s *GetDiagnostics) WalkStmt(visitor StatementVisitor) {
 	visitor.Visit(s)
 }
 
 // stmt_open
-type PLpgSQLStmtOpen struct {
-	PLpgSQLStatementImpl
-	CurVar        int // TODO(drewk): this could just a PLpgSQLVariable
+type Open struct {
+	StatementImpl
+	CurVar        int // TODO(drewk): this could just a Variable
 	CursorOptions uint32
 	// TODO(jane): This is temporary and we should remove it and use CurVar.
 	CursorName       string
 	WithExplicitExpr bool
-	// TODO(jane): Should be PLpgSQLExpr
+	// TODO(jane): Should be Expr
 	ArgQuery string
-	// TODO(jane): Should be PLpgSQLExpr
+	// TODO(jane): Should be Expr
 	Query string
-	// TODO(jane): Should be PLpgSQLExpr
+	// TODO(jane): Should be Expr
 	DynamicQuery string
-	// TODO(jane): Should be []PLpgSQLExpr
+	// TODO(jane): Should be []Expr
 	Params []string
 }
 
-func (s *PLpgSQLStmtOpen) Format(ctx *tree.FmtCtx) {
+func (s *Open) Format(ctx *tree.FmtCtx) {
 	ctx.WriteString(
 		fmt.Sprintf(
 			"OPEN %s ",
@@ -885,108 +885,108 @@ func (s *PLpgSQLStmtOpen) Format(ctx *tree.FmtCtx) {
 	ctx.WriteString("\n")
 }
 
-func (s *PLpgSQLStmtOpen) PlpgSQLStatementTag() string {
+func (s *Open) PlpgSQLStatementTag() string {
 	return "stmt_open"
 }
 
-func (s *PLpgSQLStmtOpen) WalkStmt(visitor PLpgSQLStmtVisitor) {
+func (s *Open) WalkStmt(visitor StatementVisitor) {
 	visitor.Visit(s)
 }
 
 // stmt_fetch
 // stmt_move (where IsMove = true)
-type PLpgSQLStmtFetch struct {
-	PLpgSQLStatementImpl
-	Target           PLpgSQLVariable
-	CurVar           int // TODO(drewk): this could just a PLpgSQLVariable
-	Direction        PLpgSQLFetchDirection
+type Fetch struct {
+	StatementImpl
+	Target           Variable
+	CurVar           int // TODO(drewk): this could just a Variable
+	Direction        FetchDirection
 	HowMany          int64
-	Expr             PLpgSQLExpr
+	Expr             Expr
 	IsMove           bool
 	ReturnsMultiRows bool
 }
 
-func (s *PLpgSQLStmtFetch) Format(ctx *tree.FmtCtx) {
+func (s *Fetch) Format(ctx *tree.FmtCtx) {
 }
 
-func (s *PLpgSQLStmtFetch) PlpgSQLStatementTag() string {
+func (s *Fetch) PlpgSQLStatementTag() string {
 	if s.IsMove {
 		return "stmt_move"
 	}
 	return "stmt_fetch"
 }
 
-func (s *PLpgSQLStmtFetch) WalkStmt(visitor PLpgSQLStmtVisitor) {
+func (s *Fetch) WalkStmt(visitor StatementVisitor) {
 	visitor.Visit(s)
 }
 
 // stmt_close
-type PLpgSQLStmtClose struct {
-	PLpgSQLStatementImpl
-	CurVar int // TODO(drewk): this could just a PLpgSQLVariable
+type Close struct {
+	StatementImpl
+	CurVar int // TODO(drewk): this could just a Variable
 }
 
-func (s *PLpgSQLStmtClose) Format(ctx *tree.FmtCtx) {
+func (s *Close) Format(ctx *tree.FmtCtx) {
 	// TODO(drewk): Pretty- Print the cursor identifier
 	ctx.WriteString("CLOSE a cursor\n")
 
 }
 
-func (s *PLpgSQLStmtClose) PlpgSQLStatementTag() string {
+func (s *Close) PlpgSQLStatementTag() string {
 	return "stmt_close"
 }
 
-func (s *PLpgSQLStmtClose) WalkStmt(visitor PLpgSQLStmtVisitor) {
+func (s *Close) WalkStmt(visitor StatementVisitor) {
 	visitor.Visit(s)
 }
 
 // stmt_commit
-type PLpgSQLStmtCommit struct {
-	PLpgSQLStatementImpl
+type Commit struct {
+	StatementImpl
 	Chain bool
 }
 
-func (s *PLpgSQLStmtCommit) Format(ctx *tree.FmtCtx) {
+func (s *Commit) Format(ctx *tree.FmtCtx) {
 }
 
-func (s *PLpgSQLStmtCommit) PlpgSQLStatementTag() string {
+func (s *Commit) PlpgSQLStatementTag() string {
 	return "stmt_commit"
 }
 
-func (s *PLpgSQLStmtCommit) WalkStmt(visitor PLpgSQLStmtVisitor) {
+func (s *Commit) WalkStmt(visitor StatementVisitor) {
 	visitor.Visit(s)
 }
 
 // stmt_rollback
-type PLpgSQLStmtRollback struct {
-	PLpgSQLStatementImpl
+type Rollback struct {
+	StatementImpl
 	Chain bool
 }
 
-func (s *PLpgSQLStmtRollback) Format(ctx *tree.FmtCtx) {
+func (s *Rollback) Format(ctx *tree.FmtCtx) {
 }
 
-func (s *PLpgSQLStmtRollback) PlpgSQLStatementTag() string {
+func (s *Rollback) PlpgSQLStatementTag() string {
 	return "stmt_rollback"
 }
 
-func (s *PLpgSQLStmtRollback) WalkStmt(visitor PLpgSQLStmtVisitor) {
+func (s *Rollback) WalkStmt(visitor StatementVisitor) {
 	visitor.Visit(s)
 }
 
 // stmt_null
-type PLpgSQLStmtNull struct {
-	PLpgSQLStatementImpl
+type Null struct {
+	StatementImpl
 }
 
-func (s *PLpgSQLStmtNull) Format(ctx *tree.FmtCtx) {
+func (s *Null) Format(ctx *tree.FmtCtx) {
 	ctx.WriteString("NULL\n")
 }
 
-func (s *PLpgSQLStmtNull) PlpgSQLStatementTag() string {
+func (s *Null) PlpgSQLStatementTag() string {
 	return "stmt_null"
 }
 
-func (s *PLpgSQLStmtNull) WalkStmt(visitor PLpgSQLStmtVisitor) {
+func (s *Null) WalkStmt(visitor StatementVisitor) {
 	visitor.Visit(s)
 }

--- a/pkg/sql/sem/plpgsqltree/telemetry_visitor.go
+++ b/pkg/sql/sem/plpgsqltree/telemetry_visitor.go
@@ -10,14 +10,14 @@
 
 package plpgsqltree
 
-// PLpgSQLStmtVisitor defines methods that are called plpgsql statements during
+// StatementVisitor defines methods that are called plpgsql statements during
 // a statement walk.
-type PLpgSQLStmtVisitor interface {
+type StatementVisitor interface {
 	// Visit is called during a statement walk.
-	Visit(stmt PLpgSQLStatement)
+	Visit(stmt Statement)
 }
 
 // Walk traverses the plpgsql statement.
-func Walk(v PLpgSQLStmtVisitor, stmt PLpgSQLStatement) {
+func Walk(v StatementVisitor, stmt Statement) {
 	stmt.WalkStmt(v)
 }

--- a/pkg/sql/sem/plpgsqltree/utils/plpg_visitor.go
+++ b/pkg/sql/sem/plpgsqltree/utils/plpg_visitor.go
@@ -55,11 +55,11 @@ type telemetryVisitor struct {
 	Err     error
 }
 
-var _ plpgsqltree.PLpgSQLStmtVisitor = &telemetryVisitor{}
+var _ plpgsqltree.StatementVisitor = &telemetryVisitor{}
 
-// Visit implements the PLpgSQLStmtVisitor interface
-func (v *telemetryVisitor) Visit(stmt plpgsqltree.PLpgSQLStatement) {
-	taggedStmt, ok := stmt.(plpgsqltree.TaggedPLpgSQLStatement)
+// Visit implements the StatementVisitor interface
+func (v *telemetryVisitor) Visit(stmt plpgsqltree.Statement) {
+	taggedStmt, ok := stmt.(plpgsqltree.TaggedStatement)
 	if !ok {
 		v.Err = errors.AssertionFailedf("no tag found for stmt %q", stmt)
 	}

--- a/pkg/sql/sem/plpgsqltree/variable.go
+++ b/pkg/sql/sem/plpgsqltree/variable.go
@@ -12,4 +12,4 @@ package plpgsqltree
 
 import "github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 
-type PLpgSQLVariable = tree.Name
+type Variable = tree.Name


### PR DESCRIPTION
#### plpgsqltree: remove redundant prefix of AST type names

Epic: None

Release note: None

#### plpgsql/parser: remove references to non-existant types

The types `PLpgSQLDatum` and `PLpgSQLScalarVar` do not exist. References
to them in `plpgsql.y` have been removed.

Release note: None

#### opt/optbuilder: alias plpgsqltree as ast

Release note: None
