### PR TITLE
workload: use sync/atomic's native types to ensure proper alignment

### DIFF
--- a/pkg/workload/cli/run.go
+++ b/pkg/workload/cli/run.go
@@ -246,7 +246,7 @@ func SetCmdDefaults(cmd *cobra.Command) *cobra.Command {
 
 // numOps keeps a global count of successful operations (if countErrors is
 // false) or of all operations (if countErrors is true).
-var numOps uint64
+var numOps atomic.Uint64
 
 // workerRun is an infinite loop in which the worker continuously attempts to
 // read / write blocks of random data into a table in cockroach DB. The function
@@ -289,7 +289,7 @@ func workerRun(
 			}
 		}
 
-		v := atomic.AddUint64(&numOps, 1)
+		v := numOps.Add(1)
 		if *maxOps > 0 && v >= *maxOps {
 			return
 		}

--- a/pkg/workload/driver.go
+++ b/pkg/workload/driver.go
@@ -28,12 +28,12 @@ import (
 // simplistic setups where nodes in the cluster are stable and do not go up and
 // down.
 type cockroachDriver struct {
-	idx uint32
+	idx atomic.Uint32
 }
 
 func (d *cockroachDriver) Open(name string) (driver.Conn, error) {
 	urls := strings.Split(name, " ")
-	i := atomic.AddUint32(&d.idx, 1) - 1
+	i := d.idx.Add(1) - 1
 	return pq.Open(urls[i%uint32(len(urls))])
 }
 

--- a/pkg/workload/insights/insights.go
+++ b/pkg/workload/insights/insights.go
@@ -61,7 +61,7 @@ type insights struct {
 	payloadBytes, ranges int
 	totalTableCount      int
 	scaleStats           bool
-	appCount             uint64
+	appCount             atomic.Uint64
 }
 
 func init() {
@@ -324,7 +324,7 @@ func (b *insights) incrementAppName(db *gosql.DB) error {
 	if !b.scaleStats {
 		return nil
 	}
-	appNum := atomic.AddUint64(&b.appCount, 1)
+	appNum := b.appCount.Add(1)
 	appName := fmt.Sprintf("%s %d", "insightsapp", appNum)
 	_, err := db.Exec("SET application_name = $1;", appName)
 	return err

--- a/pkg/workload/pgx_helpers.go
+++ b/pkg/workload/pgx_helpers.go
@@ -29,7 +29,7 @@ import (
 type MultiConnPool struct {
 	Pools []*pgxpool.Pool
 	// Atomic counter used by Get().
-	counter uint32
+	counter atomic.Uint32
 
 	mu struct {
 		syncutil.RWMutex
@@ -276,7 +276,7 @@ func (m *MultiConnPool) Get() *pgxpool.Pool {
 	if numPools == 1 {
 		return m.Pools[0]
 	}
-	i := atomic.AddUint32(&m.counter, 1) - 1
+	i := m.counter.Add(1) - 1
 
 	return m.Pools[i%numPools]
 }

--- a/pkg/workload/queue/queue.go
+++ b/pkg/workload/queue/queue.go
@@ -165,8 +165,8 @@ func (o *queueOp) run(ctx context.Context) error {
 }
 
 func makeSequenceFunc() func() int {
-	i := int64(0)
+	var i atomic.Int64
 	return func() int {
-		return int(atomic.AddInt64(&i, 1))
+		return int(i.Add(1))
 	}
 }

--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -42,7 +42,7 @@ import (
 // seqNum may be shared across multiple instances of this, so it should only
 // be change atomically.
 type operationGeneratorParams struct {
-	seqNum             *int64
+	seqNum             *atomic.Int64
 	errorRate          int
 	enumPct            int
 	rng                *rand.Rand
@@ -3825,7 +3825,7 @@ func (og *operationGenerator) randIntn(topBound int) int {
 }
 
 func (og *operationGenerator) newUniqueSeqNum() int64 {
-	return atomic.AddInt64(og.params.seqNum, 1)
+	return og.params.seqNum.Add(1)
 }
 
 // typeFromTypeName resolves a type string to a types.T struct so that it can be

--- a/pkg/workload/schemachange/schemachange.go
+++ b/pkg/workload/schemachange/schemachange.go
@@ -264,8 +264,8 @@ func (s *schemaChange) Ops(
 // cluster.
 func (s *schemaChange) initSeqNum(
 	ctx context.Context, pool *workload.MultiConnPool,
-) (*int64, error) {
-	seqNum := new(int64)
+) (*atomic.Int64, error) {
+	var seqNum atomic.Int64
 
 	const q = `
 SELECT max(regexp_extract(name, '[0-9]+$')::INT8)
@@ -288,10 +288,10 @@ SELECT max(regexp_extract(name, '[0-9]+$')::INT8)
 		return nil, err
 	}
 	if max.Valid {
-		*seqNum = max.Int64 + 1
+		seqNum.Store(max.Int64 + 1)
 	}
 
-	return seqNum, nil
+	return &seqNum, nil
 }
 
 type schemaChangeWorker struct {

--- a/pkg/workload/tpcc/order_status.go
+++ b/pkg/workload/tpcc/order_status.go
@@ -12,7 +12,6 @@ package tpcc
 
 import (
 	"context"
-	"sync/atomic"
 	"time"
 
 	crdbpgx "github.com/cockroachdb/cockroach-go/v2/crdb/crdbpgxv5"
@@ -117,7 +116,7 @@ func createOrderStatus(
 }
 
 func (o *orderStatus) run(ctx context.Context, wID int) (interface{}, error) {
-	atomic.AddUint64(&o.config.auditor.orderStatusTransactions, 1)
+	o.config.auditor.orderStatusTransactions.Add(1)
 
 	rng := rand.New(rand.NewSource(uint64(timeutil.Now().UnixNano())))
 
@@ -129,7 +128,7 @@ func (o *orderStatus) run(ctx context.Context, wID int) (interface{}, error) {
 	// and 40% by number.
 	if rng.Intn(100) < 60 {
 		d.cLast = string(o.config.randCLast(rng, &o.a))
-		atomic.AddUint64(&o.config.auditor.orderStatusByLastName, 1)
+		o.config.auditor.orderStatusByLastName.Add(1)
 	} else {
 		d.cID = o.config.randCustomerID(rng)
 	}

--- a/pkg/workload/tpcc/payment.go
+++ b/pkg/workload/tpcc/payment.go
@@ -13,7 +13,6 @@ package tpcc
 import (
 	"context"
 	"fmt"
-	"sync/atomic"
 	"time"
 
 	crdbpgx "github.com/cockroachdb/cockroach-go/v2/crdb/crdbpgxv5"
@@ -150,7 +149,7 @@ func createPayment(ctx context.Context, config *tpcc, mcp *workload.MultiConnPoo
 }
 
 func (p *payment) run(ctx context.Context, wID int) (interface{}, error) {
-	atomic.AddUint64(&p.config.auditor.paymentTransactions, 1)
+	p.config.auditor.paymentTransactions.Add(1)
 
 	rng := rand.New(rand.NewSource(uint64(timeutil.Now().UnixNano())))
 
@@ -185,7 +184,7 @@ func (p *payment) run(ctx context.Context, wID int) (interface{}, error) {
 	// and 40% by number.
 	if rng.Intn(100) < 60 {
 		d.cLast = string(p.config.randCLast(rng, &p.a))
-		atomic.AddUint64(&p.config.auditor.paymentsByLastName, 1)
+		p.config.auditor.paymentsByLastName.Add(1)
 	} else {
 		d.cID = p.config.randCustomerID(rng)
 	}

--- a/pkg/workload/ttlbench/ttlbench.go
+++ b/pkg/workload/ttlbench/ttlbench.go
@@ -378,7 +378,7 @@ func (t *ttlBench) Tables() []workload.Table {
 	if ttlBatchSize < 0 {
 		panic(fmt.Sprintf("invalid ttl-batch-size %d", ttlBatchSize))
 	}
-	rowCount := int64(0)
+	var rowCount atomic.Int64
 	return []workload.Table{
 		{
 			Name: ttlTableName,
@@ -391,7 +391,7 @@ func (t *ttlBench) Tables() []workload.Table {
 			InitialRows: workload.Tuples(
 				initialRowCount,
 				func(i int) []interface{} {
-					newRowCount := atomic.AddInt64(&rowCount, 1)
+					newRowCount := rowCount.Add(1)
 					const printRowCount = 100_000
 					if newRowCount%printRowCount == 0 {
 						log.Infof(context.Background(), "inserted %d rows", newRowCount)


### PR DESCRIPTION
From Go's atomic/sync's BUG section[1]:

> On ARM, 386, and 32-bit MIPS, it is the caller's responsibility to
> arrange for 64-bit alignment of 64-bit words accessed atomically via
> the primitive atomic functions (types Int64 and Uint64 are
> automatically aligned). The first word in an allocated struct, array,
> or slice; in a global variable; or in a local variable (because the
> subject of all atomic operations will escape to the heap) can be
> relied upon to be 64-bit aligned.

[1]: https://pkg.go.dev/sync/atomic#pkg-note-BUG

Epic: none
Release note: None