### PR TITLE
serverutils: remove ad-hoc code from StartNewTestCluster

### DIFF
--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -1494,6 +1494,7 @@ func (t *logicTest) newCluster(
 	stats.DefaultRefreshInterval = time.Millisecond
 
 	t.cluster = serverutils.StartNewTestCluster(t.rootT, cfg.NumNodes, params)
+	t.purgeZoneConfig()
 	if cfg.UseFakeSpanResolver {
 		// We need to update the DistSQL span resolver with the fake resolver.
 		// Note that DistSQL was disabled in makeClusterSetting above, so we

--- a/pkg/testutils/serverutils/test_cluster_shim.go
+++ b/pkg/testutils/serverutils/test_cluster_shim.go
@@ -284,13 +284,9 @@ func StartNewTestCluster(
 ) TestClusterInterface {
 	cluster := NewTestCluster(t, numNodes, args)
 	cluster.Start(t)
-	for i := 0; i < cluster.NumServers(); i++ {
-		sysconfigProvider := cluster.Server(i).SystemConfigProvider()
-		sysconfig := sysconfigProvider.GetSystemConfig()
-		if sysconfig != nil {
-			sysconfig.PurgeZoneConfigCache()
-		}
-	}
+	// Note: do not add logic here. To customize cluster configuration,
+	// add testing knobs and check them in testcluster.NewTestCluster.
+	// Not all tests use StartNewTestCluster.
 	return cluster
 }
 


### PR DESCRIPTION
This function is a convenience alias for NewTestCluster+Start. This should not contain custom logic specific to certain tests. Any custom logic should be conditional on testing knobs and put inside `(*testcluster.TestCluster).Start()` instead.

(The code removed here was mistakenly added in the wrong place in 70f85cd5671382a6c3843427b6deb870b3ee176f).

Release note: None
Needed for #107986.
Epic: CRDB-18499