### PR TITLE
server,testutils: remove complexity

### DIFF
--- a/pkg/base/test_server_args.go
+++ b/pkg/base/test_server_args.go
@@ -281,9 +281,6 @@ var (
 
 	// InternalNonDefaultDecision is a sentinel value used inside a
 	// mechanism in serverutils. Should not be used by tests directly.
-	//
-	// TODO(#76378): Investigate how we can remove the need for this
-	// sentinel value.
 	InternalNonDefaultDecision = DefaultTestTenantOptions{testBehavior: ttDisabled, allowAdditionalTenants: true}
 )
 

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -337,9 +337,11 @@ func TestBackupRestorePartitioned(t *testing.T) {
 
 	// Disabled to run within tenant as certain MR features are not available to tenants.
 	args := base.TestClusterArgs{
+		ServerArgs: base.TestServerArgs{
+			DefaultTestTenant: base.TODOTestTenantDisabled,
+		},
 		ServerArgsPerNode: map[int]base.TestServerArgs{
 			0: {
-				DefaultTestTenant: base.TODOTestTenantDisabled,
 				Locality: roachpb.Locality{Tiers: []roachpb.Tier{
 					{Key: "region", Value: "west"},
 					// NB: This has the same value as an az in the east region
@@ -349,7 +351,6 @@ func TestBackupRestorePartitioned(t *testing.T) {
 				}},
 			},
 			1: {
-				DefaultTestTenant: base.TODOTestTenantDisabled,
 				Locality: roachpb.Locality{Tiers: []roachpb.Tier{
 					{Key: "region", Value: "east"},
 					// NB: This has the same value as an az in the west region
@@ -359,7 +360,6 @@ func TestBackupRestorePartitioned(t *testing.T) {
 				}},
 			},
 			2: {
-				DefaultTestTenant: base.TODOTestTenantDisabled,
 				Locality: roachpb.Locality{Tiers: []roachpb.Tier{
 					{Key: "region", Value: "east"},
 					{Key: "az", Value: "az2"},
@@ -490,34 +490,33 @@ func TestBackupRestoreExecLocality(t *testing.T) {
 
 	// Disabled to run within tenant as certain MR features are not available to tenants.
 	args := base.TestClusterArgs{
+		ServerArgs: base.TestServerArgs{
+			DefaultTestTenant: base.TODOTestTenantDisabled,
+		},
 		ServerArgsPerNode: map[int]base.TestServerArgs{
 			0: {
-				ExternalIODir:     "/west0",
-				DefaultTestTenant: base.TODOTestTenantDisabled,
+				ExternalIODir: "/west0",
 				Locality: roachpb.Locality{Tiers: []roachpb.Tier{
 					{Key: "tier", Value: "0"},
 					{Key: "region", Value: "west"},
 				}},
 			},
 			1: {
-				ExternalIODir:     "/west1",
-				DefaultTestTenant: base.TODOTestTenantDisabled,
+				ExternalIODir: "/west1",
 				Locality: roachpb.Locality{Tiers: []roachpb.Tier{
 					{Key: "tier", Value: "1"},
 					{Key: "region", Value: "west"},
 				}},
 			},
 			2: {
-				ExternalIODir:     "/east0",
-				DefaultTestTenant: base.TODOTestTenantDisabled,
+				ExternalIODir: "/east0",
 				Locality: roachpb.Locality{Tiers: []roachpb.Tier{
 					{Key: "tier", Value: "0"},
 					{Key: "region", Value: "east"},
 				}},
 			},
 			3: {
-				ExternalIODir:     "/east1",
-				DefaultTestTenant: base.TODOTestTenantDisabled,
+				ExternalIODir: "/east1",
 				Locality: roachpb.Locality{Tiers: []roachpb.Tier{
 					{Key: "tier", Value: "1"},
 					{Key: "region", Value: "east"},

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -5689,10 +5689,7 @@ func TestChangefeedHandlesRollingRestart(t *testing.T) {
 		nodeDrainChannels[n].Store(make(chan struct{}))
 
 		return base.TestServerArgs{
-			// Test uses SPLIT AT, which isn't currently supported for
-			// secondary tenants. Tracked with #76378.
-			DefaultTestTenant: base.TODOTestTenantDisabled,
-			UseDatabase:       "test",
+			UseDatabase: "test",
 			Knobs: base.TestingKnobs{
 				DistSQL: &execinfra.TestingKnobs{
 					DrainFast: true,
@@ -5770,6 +5767,11 @@ func TestChangefeedHandlesRollingRestart(t *testing.T) {
 			}
 			return perNode
 		}(),
+		ServerArgs: base.TestServerArgs{
+			// Test uses SPLIT AT, which isn't currently supported for
+			// secondary tenants. Tracked with #76378.
+			DefaultTestTenant: base.TODOTestTenantDisabled,
+		},
 	})
 	defer tc.Stopper().Stop(context.Background())
 
@@ -5882,9 +5884,6 @@ func TestChangefeedPropagatesTerminalError(t *testing.T) {
 	perServerKnobs := make(map[int]base.TestServerArgs, numNodes)
 	for i := 0; i < numNodes; i++ {
 		perServerKnobs[i] = base.TestServerArgs{
-			// Test uses SPLIT AT, which isn't currently supported for
-			// secondary tenants. Tracked with #76378.
-			DefaultTestTenant: base.TODOTestTenantDisabled,
 			Knobs: base.TestingKnobs{
 				DistSQL: &execinfra.TestingKnobs{
 					DrainFast:  true,
@@ -5901,6 +5900,11 @@ func TestChangefeedPropagatesTerminalError(t *testing.T) {
 		base.TestClusterArgs{
 			ServerArgsPerNode: perServerKnobs,
 			ReplicationMode:   base.ReplicationManual,
+			ServerArgs: base.TestServerArgs{
+				// Test uses SPLIT AT, which isn't currently supported for
+				// secondary tenants. Tracked with #76378.
+				DefaultTestTenant: base.TODOTestTenantDisabled,
+			},
 		})
 	defer tc.Stopper().Stop(context.Background())
 
@@ -8241,13 +8245,17 @@ func TestChangefeedExecLocality(t *testing.T) {
 	str := strconv.Itoa
 
 	const nodes = 4
-	args := base.TestClusterArgs{ServerArgsPerNode: map[int]base.TestServerArgs{}}
+	args := base.TestClusterArgs{
+		ServerArgs: base.TestServerArgs{
+			DefaultTestTenant: base.TODOTestTenantDisabled, // need nodelocal and splits.
+		},
+		ServerArgsPerNode: map[int]base.TestServerArgs{},
+	}
 	for i := 0; i < nodes; i++ {
 		args.ServerArgsPerNode[i] = base.TestServerArgs{
 			ExternalIODir: path.Join(dir, str(i)),
 			Locality: roachpb.Locality{
 				Tiers: []roachpb.Tier{{Key: "x", Value: str(i / 2)}, {Key: "y", Value: str(i % 2)}}},
-			DefaultTestTenant: base.TODOTestTenantDisabled, // need nodelocal and splits.
 		}
 	}
 

--- a/pkg/ccl/kvccl/kvfollowerreadsccl/boundedstaleness_test.go
+++ b/pkg/ccl/kvccl/kvfollowerreadsccl/boundedstaleness_test.go
@@ -268,6 +268,9 @@ func TestBoundedStalenessDataDriven(t *testing.T) {
 	ctx := context.Background()
 
 	clusterArgs := base.TestClusterArgs{
+		ServerArgs: base.TestServerArgs{
+			DefaultTestTenant: base.TODOTestTenantDisabled,
+		},
 		ServerArgsPerNode: map[int]base.TestServerArgs{},
 	}
 	const numNodes = 3
@@ -275,7 +278,6 @@ func TestBoundedStalenessDataDriven(t *testing.T) {
 	for i := 0; i < numNodes; i++ {
 		i := i
 		clusterArgs.ServerArgsPerNode[i] = base.TestServerArgs{
-			DefaultTestTenant: base.TODOTestTenantDisabled,
 			Knobs: base.TestingKnobs{
 				SQLExecutor: &sql.ExecutorTestingKnobs{
 					WithStatementTrace: func(trace tracingpb.Recording, stmt string) {

--- a/pkg/ccl/kvccl/kvfollowerreadsccl/followerreads_test.go
+++ b/pkg/ccl/kvccl/kvfollowerreadsccl/followerreads_test.go
@@ -714,8 +714,7 @@ func TestFollowerReadsWithStaleDescriptor(t *testing.T) {
 			// Also, we're going to collect a trace of the test's final query.
 			ServerArgsPerNode: map[int]base.TestServerArgs{
 				3: {
-					DefaultTestTenant: base.TODOTestTenantDisabled,
-					UseDatabase:       "t",
+					UseDatabase: "t",
 					Knobs: base.TestingKnobs{
 						KVClient: &kvcoord.ClientTestingKnobs{
 							// Inhibit the checking of connection health done by the
@@ -901,13 +900,15 @@ func TestSecondaryTenantFollowerReadsRouting(t *testing.T) {
 			}
 			localities[i] = locality
 			serverArgs[i] = base.TestServerArgs{
-				Locality:          localities[i],
-				DefaultTestTenant: base.TODOTestTenantDisabled, // we'll create one ourselves below.
+				Locality: localities[i],
 			}
 		}
 		tc := testcluster.StartTestCluster(t, numNodes, base.TestClusterArgs{
 			ReplicationMode:   base.ReplicationManual,
 			ServerArgsPerNode: serverArgs,
+			ServerArgs: base.TestServerArgs{
+				DefaultTestTenant: base.TODOTestTenantDisabled, // we'll create one ourselves below.
+			},
 		})
 		ctx := context.Background()
 		defer tc.Stopper().Stop(ctx)

--- a/pkg/ccl/multiregionccl/cold_start_latency_test.go
+++ b/pkg/ccl/multiregionccl/cold_start_latency_test.go
@@ -79,8 +79,7 @@ func TestColdStartLatency(t *testing.T) {
 	for i := 0; i < numNodes; i++ {
 		i := i
 		args := base.TestServerArgs{
-			DefaultTestTenant: base.TODOTestTenantDisabled,
-			Locality:          localities[i],
+			Locality: localities[i],
 		}
 		signalAfter[i] = make(chan struct{})
 		serverKnobs := &server.TestingKnobs{
@@ -120,6 +119,9 @@ func TestColdStartLatency(t *testing.T) {
 	tc := testcluster.NewTestCluster(t, numNodes, base.TestClusterArgs{
 		ParallelStart:     true,
 		ServerArgsPerNode: perServerArgs,
+		ServerArgs: base.TestServerArgs{
+			DefaultTestTenant: base.TODOTestTenantDisabled,
+		},
 	})
 	go func() {
 		for _, c := range signalAfter {

--- a/pkg/ccl/multiregionccl/datadriven_test.go
+++ b/pkg/ccl/multiregionccl/datadriven_test.go
@@ -153,12 +153,6 @@ func TestMultiRegionDataDriven(t *testing.T) {
 					}
 					serverArgs[i] = base.TestServerArgs{
 						Locality: localityCfg,
-						// We need to disable the default test tenant here
-						// because it appears as though operations like
-						// "wait-for-zone-config-changes" only work correctly
-						// when called from the system tenant. More
-						// investigation is required (tracked with #76378).
-						DefaultTestTenant: base.TODOTestTenantDisabled,
 						Knobs: base.TestingKnobs{
 							SQLExecutor: &sql.ExecutorTestingKnobs{
 								WithStatementTrace: func(trace tracingpb.Recording, stmt string) {
@@ -175,6 +169,14 @@ func TestMultiRegionDataDriven(t *testing.T) {
 				numServers := len(localityNames)
 				tc := testcluster.StartTestCluster(t, numServers, base.TestClusterArgs{
 					ServerArgsPerNode: serverArgs,
+					ServerArgs: base.TestServerArgs{
+						// We need to disable the default test tenant here
+						// because it appears as though operations like
+						// "wait-for-zone-config-changes" only work correctly
+						// when called from the system tenant. More
+						// investigation is required (tracked with #76378).
+						DefaultTestTenant: base.TODOTestTenantDisabled,
+					},
 				})
 				ds.tc = tc
 

--- a/pkg/ccl/multiregionccl/multiregionccltestutils/testutils.go
+++ b/pkg/ccl/multiregionccl/multiregionccltestutils/testutils.go
@@ -110,13 +110,6 @@ func TestingCreateMultiRegionClusterWithRegionList(
 				Knobs:         knobs,
 				ExternalIODir: params.baseDir,
 				UseDatabase:   params.useDatabase,
-				// Disabling this due to failures in the rtt_analysis tests. Ideally
-				// we could disable multi-tenancy just for those tests, but this function
-				// is used to create the MR cluster for all test cases. For
-				// bonus points, the code to re-enable this should also provide more
-				// flexibility in disabling the default test tenant by callers of this
-				// function. Re-enablement is tracked with #76378.
-				DefaultTestTenant: base.TODOTestTenantDisabled,
 				Locality: roachpb.Locality{
 					Tiers: []roachpb.Tier{{Key: "region", Value: region}},
 				},
@@ -128,6 +121,15 @@ func TestingCreateMultiRegionClusterWithRegionList(
 	tc := testcluster.StartTestCluster(t, totalServerCount, base.TestClusterArgs{
 		ReplicationMode:   params.replicationMode,
 		ServerArgsPerNode: serverArgs,
+		ServerArgs: base.TestServerArgs{
+			// Disabling this due to failures in the rtt_analysis tests. Ideally
+			// we could disable multi-tenancy just for those tests, but this function
+			// is used to create the MR cluster for all test cases. For
+			// bonus points, the code to re-enable this should also provide more
+			// flexibility in disabling the default test tenant by callers of this
+			// function. Re-enablement is tracked with #76378.
+			DefaultTestTenant: base.TODOTestTenantDisabled,
+		},
 	})
 
 	ctx := context.Background()

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -204,9 +204,6 @@ type BaseConfig struct {
 	// Environment Variable: COCKROACH_DISABLE_SPAN_CONFIGS
 	SpanConfigsDisabled bool
 
-	// Disables the default test tenant.
-	DisableDefaultTestTenant bool
-
 	// TestingKnobs is used for internal test controls only.
 	TestingKnobs base.TestingKnobs
 

--- a/pkg/server/multi_store_test.go
+++ b/pkg/server/multi_store_test.go
@@ -62,11 +62,12 @@ func TestAddNewStoresToExistingNodes(t *testing.T) {
 			// again explicitly.
 			ReplicationMode:   base.ReplicationAuto,
 			ServerArgsPerNode: map[int]base.TestServerArgs{},
+			ServerArgs: base.TestServerArgs{
+				DefaultTestTenant: base.TODOTestTenantDisabled,
+			},
 		}
 		for srvIdx := 0; srvIdx < numNodes; srvIdx++ {
-			serverArgs := base.TestServerArgs{
-				DefaultTestTenant: base.TODOTestTenantDisabled,
-			}
+			serverArgs := base.TestServerArgs{}
 			serverArgs.Knobs.Server = &server.TestingKnobs{StickyVFSRegistry: ser}
 			for storeIdx := 0; storeIdx < numStoresPerNode; storeIdx++ {
 				id := fmt.Sprintf("s%d.%d", srvIdx+1, storeIdx+1)

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -308,9 +308,6 @@ func makeTestConfigFromParams(params base.TestServerArgs) Config {
 		cfg.TempStorageConfig.Settings = st
 	}
 
-	// TODO(#76378): Review this assignment to ensure it does not interfere with randomization.
-	cfg.DisableDefaultTestTenant = params.DefaultTestTenant.TestTenantAlwaysDisabled()
-
 	if cfg.TestingKnobs.Store == nil {
 		cfg.TestingKnobs.Store = &kvserver.StoreTestingKnobs{}
 	}
@@ -569,16 +566,6 @@ func (ts *testServer) TestTenants() []serverutils.ApplicationLayerInterface {
 	return ts.testTenants
 }
 
-// DefaultTestTenantDisabled is part of the serverutils.TenantControlInterface.
-func (ts *testServer) DefaultTestTenantDisabled() bool {
-	return ts.cfg.DisableDefaultTestTenant
-}
-
-// DisableDefaultTestTenant is part of the serverutils.TenantControlInterface.
-func (ts *testServer) DisableDefaultTestTenant() {
-	ts.cfg.DisableDefaultTestTenant = true
-}
-
 // maybeStartDefaultTestTenant might start a test tenant. This can then be used
 // for multi-tenant testing, where the default SQL connection will be made to
 // this tenant instead of to the system tenant. Note that we will
@@ -586,9 +573,16 @@ func (ts *testServer) DisableDefaultTestTenant() {
 // enterprise enabled build. This is due to licensing restrictions on the MT
 // capabilities.
 func (ts *testServer) maybeStartDefaultTestTenant(ctx context.Context) error {
+	if !(ts.params.DefaultTestTenant.TestTenantAlwaysDisabled() ||
+		ts.params.DefaultTestTenant.TestTenantAlwaysEnabled()) {
+		return errors.WithHint(
+			errors.AssertionFailedf("programming error: no decision taken about the default test tenant"),
+			"Maybe add the missing call to serverutils.ShouldStartDefaultTestTenant()?")
+	}
+
 	// If the flag has been set to disable the default test tenant, don't start
 	// it here.
-	if ts.params.DefaultTestTenant.TestTenantAlwaysDisabled() || ts.cfg.DisableDefaultTestTenant {
+	if ts.params.DefaultTestTenant.TestTenantAlwaysDisabled() {
 		return nil
 	}
 
@@ -597,7 +591,10 @@ func (ts *testServer) maybeStartDefaultTestTenant(ctx context.Context) error {
 		log.Shoutf(ctx, severity.WARNING, "test tenant requested by configuration, but code organization prevents start!\n%v", err)
 		// If not enterprise enabled, we won't be able to use SQL Servers so eat
 		// the error and return without creating/starting a SQL server.
-		ts.cfg.DisableDefaultTestTenant = true
+		//
+		// TODO(knz/yahor): Remove this - as we discussed this ought to work
+		// now even when not enterprise enabled.
+		ts.params.DefaultTestTenant = base.TODOTestTenantDisabled
 		return nil // nolint:returnerrcheck
 	}
 
@@ -668,7 +665,15 @@ func (ts *testServer) maybeStartDefaultTestTenant(ctx context.Context) error {
 // testServer.AdvRPCAddr() after Start() for client connections.
 // Use testServer.Stopper().Stop() to shutdown the server after the test
 // completes.
-func (ts *testServer) Start(ctx context.Context) error {
+func (ts *testServer) Start(ctx context.Context) (retErr error) {
+	defer func() {
+		if retErr != nil {
+			// Use a separate context to avoid using an already-cancelled
+			// context in closers.
+			ts.Stopper().Stop(context.Background())
+		}
+	}()
+
 	if err := ts.topLevelServer.PreStart(ctx); err != nil {
 		return err
 	}
@@ -681,16 +686,16 @@ func (ts *testServer) Start(ctx context.Context) error {
 	); err != nil {
 		return err
 	}
+
+	// Let clients connect.
 	if err := ts.topLevelServer.AcceptClients(ctx); err != nil {
 		return err
 	}
 
 	if err := ts.maybeStartDefaultTestTenant(ctx); err != nil {
-		// We're failing the call to this function but we've already started
-		// the testServer above. Stop it here to avoid leaking the server.
-		ts.Stopper().Stop(context.Background())
 		return err
 	}
+
 	go func() {
 		// If the server requests a shutdown, do that simply by stopping the
 		// stopper.

--- a/pkg/sql/sqltestutils/telemetry.go
+++ b/pkg/sql/sqltestutils/telemetry.go
@@ -147,7 +147,6 @@ func (tt *telemetryTest) Start(t *testing.T, serverArgs []base.TestServerArgs) {
 	diagSrvURL := tt.diagSrv.URL()
 	mapServerArgs := make(map[int]base.TestServerArgs, len(serverArgs))
 	for i, v := range serverArgs {
-		v.DefaultTestTenant = base.TestControlsTenantsExplicitly
 		v.Knobs.Server = &server.TestingKnobs{
 			DiagnosticsTestingKnobs: diagnostics.TestingKnobs{
 				OverrideReportingURL: &diagSrvURL,
@@ -159,7 +158,12 @@ func (tt *telemetryTest) Start(t *testing.T, serverArgs []base.TestServerArgs) {
 	tt.cluster = serverutils.StartNewTestCluster(
 		tt.t,
 		len(serverArgs),
-		base.TestClusterArgs{ServerArgsPerNode: mapServerArgs},
+		base.TestClusterArgs{
+			ServerArgs: base.TestServerArgs{
+				DefaultTestTenant: base.TestControlsTenantsExplicitly,
+			},
+			ServerArgsPerNode: mapServerArgs,
+		},
 	)
 	tt.server = tt.cluster.Server(0)
 	tt.serverDB = tt.cluster.ServerConn(0)

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -2337,6 +2337,7 @@ func TestLint(t *testing.T) {
 			":!server/storage_api/decommission_test.go",
 			":!server/storage_api/health_test.go",
 			":!server/storage_api/rangelog_test.go",
+			":!server/testserver.go",
 			":!sql/catalog/internal/catkv/catalog_reader_test.go",
 			":!sql/importer/import_processor_test.go",
 			":!sql/importer/import_stmt_test.go",

--- a/pkg/testutils/serverutils/api.go
+++ b/pkg/testutils/serverutils/api.go
@@ -53,6 +53,9 @@ type TestServerInterface interface {
 	// Start runs the server. This is pre-called by StartServer().
 	// It is provided for tests that use the TestServerFactory directly
 	// (mostly 'cockroach demo').
+	//
+	// For convenience, the caller can assume that Stop() has been called
+	// already if Start() fails with an error.
 	Start(context.Context) error
 
 	// Stop stops the server. This must be called at the end of a test
@@ -438,18 +441,6 @@ type TenantControlInterface interface {
 	// StartedDefaultTestTenant returns true if the server has started
 	// the service for the default test tenant.
 	StartedDefaultTestTenant() bool
-
-	// DefaultTestTenantDisabled returns true if the server has disabled
-	// the service for the default test tenant.
-	// TODO(knz): Verify whether this accessor is needed. This should
-	// be simplified.
-	DefaultTestTenantDisabled() bool
-
-	// DisableDefaultTestTenant prevents the server from starting the
-	// service for the default test tenant.
-	// TODO(knz): Verify whether this accessor is needed. This should
-	// be simplified.
-	DisableDefaultTestTenant()
 }
 
 // StorageLayerInterface defines accessors to the storage layer of a

--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -73,6 +73,8 @@ type TestCluster struct {
 	serverArgs  []base.TestServerArgs
 	clusterArgs base.TestClusterArgs
 
+	defaultTestTenantOptions base.DefaultTestTenantOptions
+
 	t serverutils.TestFataler
 }
 
@@ -276,6 +278,23 @@ func NewTestCluster(
 		noLocalities = false
 	}
 
+	// Find out how to do the default test tenant.
+	// The choice should be made by the top-level ServerArgs.
+	defaultTestTenantOptions := tc.clusterArgs.ServerArgs.DefaultTestTenant
+	// API check: verify that no non-default choice was made via per-server args,
+	// and inform the user otherwise.
+	for i := 0; i < nodes; i++ {
+		if args, ok := tc.clusterArgs.ServerArgsPerNode[i]; ok &&
+			args.DefaultTestTenant != (base.DefaultTestTenantOptions{}) &&
+			args.DefaultTestTenant != defaultTestTenantOptions {
+			tc.Stopper().Stop(context.Background())
+			t.Fatalf("improper use of DefaultTestTenantOptions in per-server args: %v vs %v\n"+
+				"Tip: use the top-level ServerArgs to set the default test tenant options.",
+				args.DefaultTestTenant, defaultTestTenantOptions)
+		}
+	}
+	tc.defaultTestTenantOptions = serverutils.ShouldStartDefaultTestTenant(t, defaultTestTenantOptions)
+
 	var firstListener net.Listener
 	for i := 0; i < nodes; i++ {
 		var serverArgs base.TestServerArgs
@@ -359,42 +378,25 @@ func NewTestCluster(
 // in a separate thread and with ParallelStart enabled (otherwise it'll block
 // on waiting for init for the first server).
 func (tc *TestCluster) Start(t serverutils.TestFataler) {
+	defer func() {
+		if r := recover(); r != nil {
+			// Avoid a stopper leak.
+			tc.Stopper().Stop(context.Background())
+			panic(r)
+		}
+	}()
+
 	nodes := len(tc.Servers)
 	var errCh chan error
 	if tc.clusterArgs.ParallelStart {
 		errCh = make(chan error, nodes)
 	}
 
-	// Determine if we should probabilistically start a test tenant for the
-	// cluster. We key off of the DisableDefaultTestTenant flag of the first
-	// server in the cluster since they should all be set to the same value
-	// (validated below).
-	probabilisticallyStartTestTenant := false
-	if !tc.Servers[0].DefaultTestTenantDisabled() {
-		probabilisticallyStartTestTenant = serverutils.ShouldStartDefaultTestTenant(t, tc.serverArgs[0])
-	}
-
-	startedTestTenant := true
 	disableLBS := false
 	for i := 0; i < nodes; i++ {
 		// Disable LBS if any server has a very low scan interval.
 		if tc.serverArgs[i].ScanInterval > 0 && tc.serverArgs[i].ScanInterval <= 100*time.Millisecond {
 			disableLBS = true
-		}
-
-		// If we're not probabilistically starting the test tenant, disable
-		// its start and set the "started" flag accordingly. We need to do this
-		// with two separate if checks because the DisableDefaultTestTenant flag
-		// could have been set coming into this function by the caller.
-		if !probabilisticallyStartTestTenant {
-			tc.Servers[i].DisableDefaultTestTenant()
-		}
-		if tc.Servers[i].DefaultTestTenantDisabled() {
-			if startedTestTenant && i > 0 {
-				t.Fatal(errors.Newf("starting only some nodes with a test tenant is not"+
-					"currently supported - attempted to disable SQL sever on node %d", i))
-			}
-			startedTestTenant = false
 		}
 
 		if tc.clusterArgs.ParallelStart {
@@ -403,6 +405,7 @@ func (tc *TestCluster) Start(t serverutils.TestFataler) {
 			}(i)
 		} else {
 			if err := tc.startServer(i, tc.serverArgs[i]); err != nil {
+				tc.Stopper().Stop(context.Background())
 				t.Fatal(err)
 			}
 			// We want to wait for stores for each server in order to have predictable
@@ -412,15 +415,16 @@ func (tc *TestCluster) Start(t serverutils.TestFataler) {
 		}
 	}
 
-	if tc.StartedDefaultTestTenant() {
-		t.Log(serverutils.DefaultTestTenantMessage)
-	}
-
 	if tc.clusterArgs.ParallelStart {
+		var cerr error
 		for i := 0; i < nodes; i++ {
 			if err := <-errCh; err != nil {
-				t.Fatal(err)
+				cerr = errors.CombineErrors(cerr, err)
 			}
+		}
+		if cerr != nil {
+			tc.Stopper().Stop(context.Background())
+			t.Fatal(cerr)
 		}
 
 		tc.WaitForNStores(t, tc.NumServers(), tc.Servers[0].GossipI().(*gossip.Gossip))
@@ -434,15 +438,13 @@ func (tc *TestCluster) Start(t serverutils.TestFataler) {
 			ie := layer.InternalExecutor().(isql.Executor)
 			if _, err := ie.Exec(context.Background(), "set-cluster-version", nil, /* txn */
 				`SET CLUSTER SETTING version = $1`, v.String()); err != nil {
+				tc.Stopper().Stop(context.Background())
 				t.Fatal(err)
 			}
 		}
 	}
 
-	// No need to disable the merge queue for SQL servers, as they don't have
-	// access to that cluster setting (and ALTER TABLE ... SPLIT AT is not
-	// supported in SQL servers either).
-	if !startedTestTenant && tc.clusterArgs.ReplicationMode == base.ReplicationManual {
+	if tc.clusterArgs.ReplicationMode == base.ReplicationManual {
 		// We've already disabled the merge queue via testing knobs above, but ALTER
 		// TABLE ... SPLIT AT will throw an error unless we also disable merges via
 		// the cluster setting.
@@ -453,6 +455,7 @@ func (tc *TestCluster) Start(t serverutils.TestFataler) {
 			InternalExecutor().(isql.Executor).
 			Exec(context.Background(), "enable-merge-queue", nil, /* txn */
 				`SET CLUSTER SETTING kv.range_merge.queue_enabled = false`); err != nil {
+			tc.Stopper().Stop(context.Background())
 			t.Fatal(err)
 		}
 	}
@@ -462,6 +465,7 @@ func (tc *TestCluster) Start(t serverutils.TestFataler) {
 			InternalExecutor().(isql.Executor).
 			Exec(context.Background(), "enable-split-by-load", nil, /*txn */
 				`SET CLUSTER SETTING kv.range_split.by_load_enabled = false`); err != nil {
+			tc.Stopper().Stop(context.Background())
 			t.Fatal(err)
 		}
 	}
@@ -472,6 +476,7 @@ func (tc *TestCluster) Start(t serverutils.TestFataler) {
 
 	if tc.clusterArgs.ReplicationMode == base.ReplicationAuto {
 		if err := tc.WaitForFullReplication(); err != nil {
+			tc.Stopper().Stop(context.Background())
 			t.Fatal(err)
 		}
 	}
@@ -602,15 +607,13 @@ func (tc *TestCluster) AddServer(
 		serverArgs.Addr = serverArgs.Listener.Addr().String()
 	}
 
+	// Inject the decision that was made about whether or not to start a
+	// test tenant server, into this new server's configuration.
+	serverArgs.DefaultTestTenant = tc.defaultTestTenantOptions
+
 	s, err := serverutils.NewServer(serverArgs)
 	if err != nil {
 		return nil, err
-	}
-
-	// If we only allowed probabilistic starting of the test tenant, we disable
-	// starting additional tenants, even if we didn't start the test tenant.
-	if serverArgs.DefaultTestTenant == base.TestTenantProbabilisticOnly {
-		s.DisableStartTenant(serverutils.PreventStartTenantError)
 	}
 
 	tc.Servers = append(tc.Servers, s)

--- a/pkg/upgrade/upgrademanager/manager_external_test.go
+++ b/pkg/upgrade/upgrademanager/manager_external_test.go
@@ -612,8 +612,6 @@ func TestPrecondition(t *testing.T) {
 	ctx := context.Background()
 	args := func() base.TestServerArgs {
 		return base.TestServerArgs{
-			DefaultTestTenant: base.TestIsForStuffThatShouldWorkWithSecondaryTenantsButDoesntYet(107397),
-
 			Knobs: knobs,
 			Settings: cluster.MakeTestingClusterSettingsWithVersions(
 				v2,    // binaryVersion
@@ -623,6 +621,9 @@ func TestPrecondition(t *testing.T) {
 		}
 	}
 	tc := testcluster.StartTestCluster(t, 3, base.TestClusterArgs{
+		ServerArgs: base.TestServerArgs{
+			DefaultTestTenant: base.TestIsForStuffThatShouldWorkWithSecondaryTenantsButDoesntYet(107397),
+		},
 		ServerArgsPerNode: map[int]base.TestServerArgs{
 			0: args(),
 			1: args(),


### PR DESCRIPTION
There is a saying (paraphrasing) that it always takes more work removing unwanted complexity than it takes to add it. This is an example of that.

Prior to this commit, there was an "interesting" propagation of the flag that decides whether or not to define a test tenant for test servers and clusters. In a nutshell, we had:

- an "input" flag in `base.TestServerArgs`, which remained mostly immutable
- a boolean decided once by `ShouldStartDefaultTestTenant()` either in:
  - `serverutils.StartServerOnlyE`
  - or `testcluster.Start`
- that boolean choice was then propagated to `server.testServer` via _another_ boolean config flag in `server.BaseConfig`
- both the 2nd boolean and the original input flag were then again checked when the time came to do the work (in `maybeStartDefaultTestTenant`).

Additional complexity was then incurred by the need of `TestCluster` to make the determination just once (and not once per server).

This commit cuts through all the layers of complexity by simply propagating the choice of `ShouldStartDefaultTestTenant()` back into the `TestServerArgs` and only ever reading from that subsequently.

Release note: None
Epic: CRDB-18499