### PR TITLE
server: process version overrides in `(*testServer).Start()`

### DIFF
--- a/pkg/testutils/serverutils/BUILD.bazel
+++ b/pkg/testutils/serverutils/BUILD.bazel
@@ -30,7 +30,6 @@ go_library(
         "//pkg/settings/cluster",
         "//pkg/sql/catalog",
         "//pkg/sql/catalog/descpb",
-        "//pkg/sql/isql",
         "//pkg/storage",
         "//pkg/testutils",
         "//pkg/testutils/skip",

--- a/pkg/testutils/serverutils/api.go
+++ b/pkg/testutils/serverutils/api.go
@@ -56,7 +56,17 @@ type TestServerInterface interface {
 	//
 	// For convenience, the caller can assume that Stop() has been called
 	// already if Start() fails with an error.
+	//
+	// Start is an alias for PreStart() followed by Activate(). This
+	// distinction exists mainly for the benefit of the TestCluster
+	// boostrap logic.
 	Start(context.Context) error
+
+	// PreStart is the bootstrap/init phase of Start().
+	PreStart(context.Context) error
+
+	// Activate is the service activation phase of Start().
+	Activate(context.Context) error
 
 	// Stop stops the server. This must be called at the end of a test
 	// to avoid leaking resources.

--- a/pkg/testutils/serverutils/test_server_shim.go
+++ b/pkg/testutils/serverutils/test_server_shim.go
@@ -30,7 +30,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
-	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
@@ -171,19 +170,6 @@ func StartServerOnlyE(t TestLogger, params base.TestServerArgs) (TestServerInter
 
 	if !allowAdditionalTenants {
 		s.DisableStartTenant(PreventStartTenantError)
-	}
-
-	// Now that we have started the server on the bootstrap version, let us run
-	// the migrations up to the overridden BinaryVersion.
-	if v := s.BinaryVersionOverride(); v != (roachpb.Version{}) {
-		for _, layer := range []ApplicationLayerInterface{s.SystemLayer(), s.ApplicationLayer()} {
-			ie := layer.InternalExecutor().(isql.Executor)
-			if _, err := ie.Exec(ctx, "set-version", nil, /* kv.Txn */
-				`SET CLUSTER SETTING version = $1`, v.String()); err != nil {
-				s.Stopper().Stop(ctx)
-				return nil, err
-			}
-		}
 	}
 
 	return s, nil


### PR DESCRIPTION
Prior to this patch, unit tests that exercised a binary version override were dependent on the upgrade logic encoded in `serverutils.StartServer*` and `(*TestCluster).Start()`.

This was defective in two ways:

- the logic was implemented twice, in different places, increasing the chance that future changes would cause a divergence.
- it was creating brittleness, where a future test that would call `NewServer` and `Start` separately would not get the proper binary version override applied.

This change makes the configuration more robust by concentrating the version override logic inside `(*testServer).Start()`.

Release note: None
Epic: CRDB-18499