### PR TITLE
roachtest: deflake npgsql test

### DIFF
--- a/pkg/cmd/roachtest/tests/npgsql_blocklist.go
+++ b/pkg/cmd/roachtest/tests/npgsql_blocklist.go
@@ -745,8 +745,14 @@ var npgsqlBlocklist = blocklist{
 }
 
 var npgsqlIgnoreList = blocklist{
+	`Npgsql.Tests.CommandTests(Multiplexing).QueryNonQuery`:                                           "flaky",
+	`Npgsql.Tests.CommandTests(Multiplexing).SingleNonQuery`:                                          "flaky",
 	`Npgsql.Tests.CommandTests(Multiplexing).Statement_mapped_output_parameters(Default)`:             "flaky",
+	`Npgsql.Tests.CommandTests(NonMultiplexing).Cached_command_clears_parameters_placeholder_type`:    "flaky",
+	`Npgsql.Tests.CommandTests(NonMultiplexing).CloseConnection_with_exception`:                       "flaky",
+	`Npgsql.Tests.CommandTests(NonMultiplexing).Cursor_move_RecordsAffected `:                         "flaky",
 	`Npgsql.Tests.CommandTests(NonMultiplexing).Statement_mapped_output_parameters(SequentialAccess)`: "flaky",
+	`Npgsql.Tests.CommandTests(NonMultiplexing).Use_across_connection_change(Prepared)`:               "flaky",
 	`Npgsql.Tests.ConnectionTests(NonMultiplexing).PostgreSqlVersion_ServerVersion`:                   "flaky",
 	`Npgsql.Tests.ConnectionTests(NonMultiplexing).Connector_not_initialized_exception`:               "flaky",
 	`Npgsql.Tests.ConnectionTests(NonMultiplexing).Many_open_close_with_transaction`:                  "flaky",


### PR DESCRIPTION
These upstream tests are flaky, so we ignore them.

informs https://github.com/cockroachdb/cockroach/issues/108414
fixes https://github.com/cockroachdb/cockroach/issues/108044
fixes https://github.com/cockroachdb/cockroach/issues/108504
Release note: None