### PR TITLE
do-not-merge. sql: fix TestSQLStatsRegions test

### DIFF
--- a/pkg/ccl/testccl/sqlstatsccl/BUILD.bazel
+++ b/pkg/ccl/testccl/sqlstatsccl/BUILD.bazel
@@ -13,6 +13,8 @@ go_test(
     deps = [
         "//pkg/base",
         "//pkg/ccl",
+        "//pkg/kv/kvserver",
+        "//pkg/kv/kvserver/closedts",
         "//pkg/roachpb",
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",


### PR DESCRIPTION
It is another attempt to make TestSQLStatsRegions test stable.
It is assumed that cluster settings that were set before with `SET CLUSTER SETTING ...` were applied to system tenant only. Now these settings overridden globally.

Also reduced number of regions to make sure there's enough time to replicate to all of them.

Release note: None

Related to: #107582

---

UPD ⚠️ : this change makes test even more fragile.

```bash
=== RUN   TestSQLStatsRegions
    test_log_scope.go:167: test logs captured to: /Users/avor/go/src/github.com/cockroachdb/cockroach/artifacts/tmp/_tmp/84a758507a1b5fcfe96c9edcebc7a240/logTestSQLStatsRegions4189634080
    test_log_scope.go:81: use -show-logs to present logs inline
=== RUN   TestSQLStatsRegions/system_tenant
=== RUN   TestSQLStatsRegions/secondary_tenant
    sql_stats_test.go:166: condition failed to evaluate within 3m0s: rows are not replicated to all regions [1]
=== CONT  TestSQLStatsRegions
    sql_stats_test.go:244: -- test log scope end --
test logs left over in: /Users/avor/go/src/github.com/cockroachdb/cockroach/artifacts/tmp/_tmp/84a758507a1b5fcfe96c9edcebc7a240/logTestSQLStatsRegions4189634080
--- FAIL: TestSQLStatsRegions (192.01s)
    --- PASS: TestSQLStatsRegions/system_tenant (0.11s)
    --- FAIL: TestSQLStatsRegions/secondary_tenant (181.01s)
FAIL
I230809 08:34:02.025616 1 (gostd) testmain.go:85  [-] 1  Test //pkg/ccl/testccl/sqlstatsccl:sqlstatsccl_test exited with error code 1
================================================================================
Target //pkg/ccl/testccl/sqlstatsccl:sqlstatsccl_test up-to-date:
  _bazel/bin/pkg/ccl/testccl/sqlstatsccl/sqlstatsccl_test_/sqlstatsccl_test
INFO: Elapsed time: 600.366s, Critical Path: 599.86s
INFO: 55 processes: 65 darwin-sandbox.
INFO: Build completed successfully, 55 total actions
//pkg/ccl/testccl/sqlstatsccl:sqlstatsccl_test                            FLAKY, failed in 11 out of 61 in 200.3s
  Stats over 61 runs: max = 200.3s, min = 4.8s, avg = 58.5s, dev = 73.5s
```


