### PR TITLE
testserver,testtenant: fix `SQLConn()`

### DIFF
--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -491,6 +491,7 @@ go_test(
         "//pkg/kv/kvserver/kvserverpb",
         "//pkg/kv/kvserver/kvstorage",
         "//pkg/kv/kvserver/liveness/livenesspb",
+        "//pkg/multitenant",
         "//pkg/roachpb",
         "//pkg/rpc",
         "//pkg/security",


### PR DESCRIPTION
Fixes #107859.
Epic: CRDB-18499

Prior to this patch, the (recently introduced) `SQLConn()` method was blind to the concept of a shared SQL port where connections get redirected to a secondary tenant based on the `cluster` URL option.

Because of this, two bad things were happening:

- `.SQLConn()` on the `ApplicationLayerInterface` of a secondary tenant with a shared SQL port would fail to connect to the right tenant.

- `.SystemLayer().SQLConn()` would fail if the cluster setting `server.controller.default_tenant` was set.

This patch fixes it.

Release note: None