### PR TITLE
ui: Fix "Backfill Pending Ranges" graph

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/changefeeds.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/changefeeds.tsx
@@ -165,7 +165,6 @@ export default function (props: GraphDashboardProps) {
         <Metric
           name="cr.node.changefeed.backfill_pending_ranges"
           title="Backfill Pending Ranges"
-          nonNegativeRate
         />
       </Axis>
     </LineGraph>,


### PR DESCRIPTION
Fix "Backfill Pending Ranges" changefeed graph:
the graph should be a counter graph, not a rate.

Epic: None

Release note: None