### PR TITLE
plpgsql: add support for WHILE loops

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/udf_plpgsql
+++ b/pkg/sql/logictest/testdata/logic_test/udf_plpgsql
@@ -282,7 +282,7 @@ CREATE OR REPLACE FUNCTION f(a INT, b INT) RETURNS INT AS $$
   BEGIN
     LOOP
       IF i >= b THEN EXIT; END IF;
-      IF i = 2 THEN 
+      IF i = 2 THEN
         i := i + 1;
         CONTINUE;
       END IF;
@@ -331,6 +331,78 @@ SELECT f(1, 5), f(-5, 5), f(0, 1)
 
 # TODO(drewk): add back the dijkstra test once UDFs calling other UDFs is
 # allowed.
+
+# --------------------------------------------------
+# Tests for WHILE LOOP
+# --------------------------------------------------
+
+subtest while
+
+statement ok
+CREATE OR REPLACE FUNCTION f(n INT) RETURNS INT AS $$
+  DECLARE
+    i INT := 0;
+    sum INT := 0;
+  BEGIN
+    WHILE i <= n LOOP
+      sum := sum + i;
+      i := i + 1;
+    END LOOP;
+    RETURN sum;
+  END
+$$ LANGUAGE PLpgSQL;
+
+query IIII
+SELECT f(0), f(1), f(2), f(10);
+----
+0  1  3  55
+
+statement ok
+CREATE OR REPLACE FUNCTION f(n INT) RETURNS INT AS $$
+  DECLARE
+    i INT := 0;
+    sum INT := 0;
+  BEGIN
+    WHILE i <= n LOOP
+      IF i > 10 THEN
+        EXIT;
+      END IF;
+      sum := sum + i;
+      i := i + 1;
+    END LOOP;
+    RETURN sum;
+  END
+$$ LANGUAGE PLpgSQL;
+
+query II
+SELECT f(5), f(20)
+----
+15  55
+
+statement ok
+CREATE OR REPLACE FUNCTION f(n INT) RETURNS INT AS $$
+  DECLARE
+    i INT := 0;
+    sum INT := 0;
+  BEGIN
+    WHILE i <= n LOOP
+      IF i % 2 = 0 THEN
+        i := i + 1;
+        CONTINUE;
+      END IF;
+      sum := sum + i;
+      i := i + 1;
+    END LOOP;
+    RETURN sum;
+  END
+$$ LANGUAGE PLpgSQL;
+
+query IIII
+SELECT f(0), f(1), f(2), f(5)
+----
+0  1  1  9
+
+subtest end
 
 statement ok
 CREATE OR REPLACE FUNCTION f(a INT, b INT) RETURNS INT AS $$

--- a/pkg/sql/opt/optbuilder/plpgsql.go
+++ b/pkg/sql/opt/optbuilder/plpgsql.go
@@ -374,6 +374,12 @@ func (b *plpgsqlBuilder) buildPLpgSQLStatements(stmts []ast.Statement, s *scope)
 					"EXIT statement labels are not yet supported",
 				))
 			}
+			if t.Condition != nil {
+				panic(unimplemented.New(
+					"EXIT WHEN",
+					"conditional EXIT statements are not yet supported",
+				))
+			}
 			// EXIT statements are handled by calling the function that executes the
 			// statements after a loop. Errors if used outside a loop.
 			if con := b.getExitContinuation(); con != nil {
@@ -390,6 +396,12 @@ func (b *plpgsqlBuilder) buildPLpgSQLStatements(stmts []ast.Statement, s *scope)
 				panic(unimplemented.New(
 					"CONTINUE label",
 					"CONTINUE statement labels are not yet supported",
+				))
+			}
+			if t.Condition != nil {
+				panic(unimplemented.New(
+					"CONTINUE WHEN",
+					"conditional CONTINUE statements are not yet supported",
 				))
 			}
 			// CONTINUE statements are handled by calling the function that executes

--- a/pkg/sql/opt/optbuilder/testdata/udf_plpgsql
+++ b/pkg/sql/opt/optbuilder/testdata/udf_plpgsql
@@ -1166,7 +1166,7 @@ CREATE OR REPLACE FUNCTION f(a INT, b INT) RETURNS INT AS $$
   BEGIN
     LOOP
       IF i >= b THEN EXIT; END IF;
-      IF i = 2 THEN 
+      IF i = 2 THEN
         i := i + 1;
         CONTINUE;
       END IF;
@@ -1545,6 +1545,124 @@ project
                      │                                                                                                                                      │    ├── variable: a:38
                      │                                                                                                                                      │    └── variable: b:39
                      │                                                                                                                                      └── recursive-call
+                     └── const: 1
+
+exec-ddl
+CREATE OR REPLACE FUNCTION f(n INT) RETURNS INT AS $$
+  DECLARE
+    sum INT := 0;
+    i INT := 0;
+  BEGIN
+    WHILE i < n LOOP
+      sum := sum + i;
+      i := i + 1;
+    END LOOP;
+    RETURN sum;
+  END
+$$ LANGUAGE PLpgSQL;
+----
+
+build format=show-scalars
+SELECT f(5)
+----
+project
+ ├── columns: f:21
+ ├── values
+ │    └── tuple
+ └── projections
+      └── udf: f [as=f:21]
+           ├── args
+           │    └── const: 5
+           ├── params: n:1
+           └── body
+                └── limit
+                     ├── columns: stmt_loop_3:20
+                     ├── project
+                     │    ├── columns: stmt_loop_3:20
+                     │    ├── project
+                     │    │    ├── columns: i:3!null sum:2!null
+                     │    │    ├── project
+                     │    │    │    ├── columns: sum:2!null
+                     │    │    │    ├── values
+                     │    │    │    │    └── tuple
+                     │    │    │    └── projections
+                     │    │    │         └── const: 0 [as=sum:2]
+                     │    │    └── projections
+                     │    │         └── const: 0 [as=i:3]
+                     │    └── projections
+                     │         └── udf: stmt_loop_3 [as=stmt_loop_3:20]
+                     │              ├── args
+                     │              │    ├── variable: sum:2
+                     │              │    ├── variable: i:3
+                     │              │    └── variable: n:1
+                     │              ├── params: sum:8 i:9 n:10
+                     │              └── body
+                     │                   └── project
+                     │                        ├── columns: stmt_if_5:19
+                     │                        ├── values
+                     │                        │    └── tuple
+                     │                        └── projections
+                     │                             └── case [as=stmt_if_5:19]
+                     │                                  ├── true
+                     │                                  ├── when
+                     │                                  │    ├── lt
+                     │                                  │    │    ├── variable: i:9
+                     │                                  │    │    └── variable: n:10
+                     │                                  │    └── subquery
+                     │                                  │         └── project
+                     │                                  │              ├── columns: stmt_if_4:17
+                     │                                  │              ├── project
+                     │                                  │              │    ├── columns: i:16 sum:15
+                     │                                  │              │    ├── project
+                     │                                  │              │    │    ├── columns: sum:15
+                     │                                  │              │    │    ├── values
+                     │                                  │              │    │    │    └── tuple
+                     │                                  │              │    │    └── projections
+                     │                                  │              │    │         └── plus [as=sum:15]
+                     │                                  │              │    │              ├── variable: sum:8
+                     │                                  │              │    │              └── variable: i:9
+                     │                                  │              │    └── projections
+                     │                                  │              │         └── plus [as=i:16]
+                     │                                  │              │              ├── variable: i:9
+                     │                                  │              │              └── const: 1
+                     │                                  │              └── projections
+                     │                                  │                   └── udf: stmt_if_4 [as=stmt_if_4:17]
+                     │                                  │                        ├── args
+                     │                                  │                        │    ├── variable: sum:15
+                     │                                  │                        │    ├── variable: i:16
+                     │                                  │                        │    └── variable: n:10
+                     │                                  │                        ├── params: sum:11 i:12 n:13
+                     │                                  │                        └── body
+                     │                                  │                             └── project
+                     │                                  │                                  ├── columns: stmt_loop_3:14
+                     │                                  │                                  ├── values
+                     │                                  │                                  │    └── tuple
+                     │                                  │                                  └── projections
+                     │                                  │                                       └── udf: stmt_loop_3 [as=stmt_loop_3:14]
+                     │                                  │                                            ├── args
+                     │                                  │                                            │    ├── variable: sum:11
+                     │                                  │                                            │    ├── variable: i:12
+                     │                                  │                                            │    └── variable: n:13
+                     │                                  │                                            └── recursive-call
+                     │                                  └── subquery
+                     │                                       └── project
+                     │                                            ├── columns: loop_exit_1:18
+                     │                                            ├── values
+                     │                                            │    └── tuple
+                     │                                            └── projections
+                     │                                                 └── udf: loop_exit_1 [as=loop_exit_1:18]
+                     │                                                      ├── args
+                     │                                                      │    ├── variable: sum:8
+                     │                                                      │    ├── variable: i:9
+                     │                                                      │    └── variable: n:10
+                     │                                                      ├── params: sum:4 i:5 n:6
+                     │                                                      └── body
+                     │                                                           └── project
+                     │                                                                ├── columns: stmt_return_2:7
+                     │                                                                ├── values
+                     │                                                                │    └── tuple
+                     │                                                                └── projections
+                     │                                                                     └── variable: sum:4 [as=stmt_return_2:7]
                      └── const: 1
 
 # TODO(drewk): consider adding a norm rules to fold nested UDFs.

--- a/pkg/sql/opt/optbuilder/testdata/udf_plpgsql
+++ b/pkg/sql/opt/optbuilder/testdata/udf_plpgsql
@@ -1665,6 +1665,48 @@ project
                      │                                                                     └── variable: sum:4 [as=stmt_return_2:7]
                      └── const: 1
 
+exec-ddl
+CREATE OR REPLACE FUNCTION f(n INT) RETURNS INT AS $$
+  DECLARE
+    sum INT := 0;
+    i INT := 0;
+  BEGIN
+    LOOP
+      EXIT WHEN i > n;
+      sum := sum + i;
+      i := i + 1;
+    END LOOP;
+    RETURN sum;
+  END
+$$ LANGUAGE PLpgSQL;
+----
+
+build format=show-scalars
+SELECT f(5)
+----
+error (0A000): unimplemented: conditional EXIT statements are not yet supported
+
+exec-ddl
+CREATE OR REPLACE FUNCTION f(n INT) RETURNS INT AS $$
+  DECLARE
+    sum INT := 0;
+    i INT := 0;
+  BEGIN
+    LOOP
+      CONTINUE WHEN i % 2 = 0;
+      sum := sum + i;
+      i := i + 1;
+    END LOOP;
+    RETURN sum;
+  END
+$$ LANGUAGE PLpgSQL;
+----
+
+build format=show-scalars
+SELECT f(5)
+----
+error (0A000): unimplemented: conditional CONTINUE statements are not yet supported
+
 # TODO(drewk): consider adding a norm rules to fold nested UDFs.
 # Testing RAISE statements.
 exec-ddl

--- a/pkg/sql/plpgsql/parser/parser_test.go
+++ b/pkg/sql/plpgsql/parser/parser_test.go
@@ -21,7 +21,7 @@ import (
 
 // TODO: Define(if possible) a data driven test framework so that sql and
 // plpgsql share a parse test
-func TestParseDataDriver(t *testing.T) {
+func TestParseDataDriven(t *testing.T) {
 	datadriven.Walk(t, datapathutils.TestDataPath(t), func(t *testing.T, path string) {
 		datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {
 			switch d.Cmd {

--- a/pkg/sql/plpgsql/parser/plpgsql.y
+++ b/pkg/sql/plpgsql/parser/plpgsql.y
@@ -936,9 +936,19 @@ stmt_loop: opt_loop_label LOOP loop_body opt_label ';'
   }
 ;
 
-stmt_while: opt_loop_label WHILE expr_until_loop loop_body
+stmt_while: opt_loop_label WHILE expr_until_loop LOOP loop_body opt_label ';'
   {
-    return unimplemented(plpgsqllex, "while loop")
+    // TODO(drewk): does the second usage of the label actually
+    // do anything?
+    cond, err := plpgsqllex.(*lexer).ParseExpr($3)
+    if err != nil {
+      return setErr(plpgsqllex, err)
+    }
+    $$.val = &plpgsqltree.While{
+      Label: $1,
+      Condition: cond,
+      Body: $5.statements(),
+    }
   }
 ;
 
@@ -1373,7 +1383,7 @@ expr_until_then:
 
 expr_until_loop:
   {
-    return unimplemented(plpgsqllex, "loop expr")
+    $$ = plpgsqllex.(*lexer).ReadSqlExpressionStr(LOOP)
   }
 ;
 

--- a/pkg/sql/plpgsql/parser/testdata/stmt_while
+++ b/pkg/sql/plpgsql/parser/testdata/stmt_while
@@ -7,9 +7,32 @@ WHILE x > 0 LOOP
 END LOOP;
 END
 ----
-at or near "while": syntax error: unimplemented: this syntax
+DECLARE
+BEGIN
+x := 10;
+WHILE x > 0 LOOP
+x := x - 1;
+END LOOP;
+END
 
-
+parse
+DECLARE
+BEGIN
+x := 10;
+WHILE x > 0 AND x < 100 LOOP
+  x := x - 1;
+  x := x - 2;
+END LOOP;
+END
+----
+DECLARE
+BEGIN
+x := 10;
+WHILE (x > 0) AND (x < 100) LOOP
+x := x - 1;
+x := x - 2;
+END LOOP;
+END
 
 parse
 DECLARE
@@ -21,4 +44,10 @@ WHILE x > 0 LOOP
 END LOOP labeled;
 END
 ----
-at or near "while": syntax error: unimplemented: this syntax
+DECLARE
+BEGIN
+x := 10;
+WHILE x > 0 LOOP
+x := x - 1;
+END LOOP labeled;
+END

--- a/pkg/sql/sem/plpgsqltree/statements.go
+++ b/pkg/sql/sem/plpgsqltree/statements.go
@@ -352,6 +352,17 @@ type While struct {
 }
 
 func (s *While) Format(ctx *tree.FmtCtx) {
+	ctx.WriteString("WHILE ")
+	s.Condition.Format(ctx)
+	ctx.WriteString(" LOOP\n")
+	for _, stmt := range s.Body {
+		stmt.Format(ctx)
+	}
+	ctx.WriteString("END LOOP")
+	if s.Label != "" {
+		ctx.WriteString(fmt.Sprintf(" %s", s.Label))
+	}
+	ctx.WriteString(";\n")
 }
 
 func (s *While) PlpgSQLStatementTag() string {


### PR DESCRIPTION
#### plpgsql/parser: parse WHILE loops

Release note: None

#### opt: support PL/pgSQL WHILE loops

This commit adds support for PL/pgSQL `WHILE` loops. A `WHILE` loop is
syntactic sugar for a `LOOP` with that exits conditionally, so we build
a `WHILE` loop with a simple transformation:

    WHILE [cond] LOOP
      [body];
    END LOOP;
    =>
    LOOP
      IF [cond] THEN
        [body];
      ELSE
        EXIT;
      END IF;
    END LOOP;

This transformation allows us to avoid adding complicated logic
specifically for `WHILE` loops and instead rely on the existing
implementations for `LOOP` and `IF/ELSE` statements.

Epic: CRDB-799

Release note: None

#### opt: add unimplemented errors for EXIT/CONTINUE WHEN

Release note: None
