### PR TITLE
server: support separate transactions on sql api

### DIFF
--- a/pkg/ccl/serverccl/testdata/api_v2_sql
+++ b/pkg/ccl/serverccl/testdata/api_v2_sql
@@ -13,6 +13,7 @@ sql admin
   "database": "system",
   "execute": false,
   "max_result_size": 10000,
+  "separate_txns": false,
   "statements": [
    {
     "arguments": [
@@ -21,6 +22,7 @@ sql admin
     "sql": "SELECT username FROM users WHERE username = $1"
    }
   ],
+  "stop_on_error": false,
   "timeout": "5s"
  }
 }

--- a/pkg/server/api_v2_sql.go
+++ b/pkg/server/api_v2_sql.go
@@ -196,6 +196,7 @@ var SQLAPIClock timeutil.TimeSource = timeutil.DefaultTimeSource{}
 //	                  type: array
 //	                  description: The result rows.
 //	                  items: {}
+
 func (a *apiV2Server) execSQL(w http.ResponseWriter, r *http.Request) {
 	// Type for the request.
 	type requestType struct {
@@ -204,12 +205,15 @@ func (a *apiV2Server) execSQL(w http.ResponseWriter, r *http.Request) {
 		Database        string `json:"database"`
 		ApplicationName string `json:"application_name"`
 		Execute         bool   `json:"execute"`
+		SeparateTxns    bool   `json:"separate_txns"`
+		StopOnError     bool   `json:"stop_on_error"`
 		Statements      []struct {
 			SQL       string                               `json:"sql"`
 			stmt      statements.Statement[tree.Statement] `json:"-"`
 			Arguments []interface{}                        `json:"arguments,omitempty"`
 		} `json:"statements"`
 	}
+
 	// Type for the result.
 	type txnResult struct {
 		Statement    int               `json:"statement"` // index of statement in request.
@@ -364,25 +368,68 @@ func (a *apiV2Server) execSQL(w http.ResponseWriter, r *http.Request) {
 	options := []isql.TxnOption{
 		isql.WithPriority(admissionpb.NormalPri),
 	}
+
+	// execResultRunner is the function that runs the entirety of the request.
+	var execResultRunner func(context.Context, func(context.Context, isql.Txn) error, ...isql.TxnOption) error
+	// stmtRunner is the function that runs each statement in turn.
+	var stmtRunner func(ctx context.Context, outerTxn isql.Txn, queryFn func(ctx context.Context, innerTxn isql.Txn) error, opts ...isql.TxnOption) error
+	var handleStmtErr func(outerErr, stmtErr error) (err error, terminate bool)
+
+	// Select which runners to use depending on the transaction mode.
+	if !requestPayload.SeparateTxns {
+		execResultRunner = a.sqlServer.internalDB.Txn
+		handleStmtErr = func(_, stmtErr error) (error, bool) {
+			// In a single txn, any stmt err ends the txn
+			return stmtErr, stmtErr != nil
+		}
+		stmtRunner = func(ctx context.Context, outerTxn isql.Txn, queryFn func(ctx context.Context, innerTxn isql.Txn) error, _ ...isql.TxnOption) error {
+			return queryFn(ctx, outerTxn)
+		}
+	} else {
+		execResultRunner = func(ctx context.Context, queryFn func(ctx context.Context, txn isql.Txn) error, _ ...isql.TxnOption) error {
+			return queryFn(ctx, nil /* txn */)
+		}
+		handleStmtErr = func(outerErr, stmtErr error) (error, bool) {
+			// If we encounter a stmt error with separate txns, set the outer error
+			if stmtErr != nil {
+				if outerErr == nil {
+					outerErr = errors.New("separate transaction payload encountered transaction error(s)")
+				}
+				// If StopOnError is specified, return the outerErr and terminate
+				if requestPayload.StopOnError {
+					return outerErr, true
+				}
+			}
+			// Return outerErr without terminating
+			return outerErr, false
+		}
+		stmtRunner = func(ctx context.Context, _ isql.Txn, queryFn func(ctx context.Context, innerTxn isql.Txn) error, opts ...isql.TxnOption) error {
+			return a.sqlServer.internalDB.Txn(ctx, queryFn, opts...)
+		}
+	}
+
 	result.Execution = &execResult{}
 	result.Execution.TxnResults = make([]txnResult, 0, len(requestPayload.Statements))
 
 	err = timeutil.RunWithTimeout(ctx, "run-sql-via-api", timeout, func(ctx context.Context) error {
 		retryNum := 0
-
-		return a.sqlServer.internalDB.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
+		return execResultRunner(ctx, func(ctx context.Context, txn isql.Txn) error {
 			result.Execution.TxnResults = result.Execution.TxnResults[:0]
 			result.Execution.Retries = retryNum
 			retryNum++
 			curSize := uintptr(0)
+			var outerErr error
+			checkSize := func(size uintptr) error {
+				if size > uintptr(requestPayload.MaxResultSize) {
+					return errors.New("max result size exceeded")
+				}
+				return nil
+			}
 			addSize := func(row tree.Datums) error {
 				for _, c := range row {
 					curSize += c.Size()
 				}
-				if curSize > uintptr(requestPayload.MaxResultSize) {
-					return errors.New("max result size exceeded")
-				}
-				return nil
+				return checkSize(curSize)
 			}
 
 			for stmtIdx, stmt := range requestPayload.Statements {
@@ -395,7 +442,7 @@ func (a *apiV2Server) execSQL(w http.ResponseWriter, r *http.Request) {
 				txnRes := &result.Execution.TxnResults[stmtIdx]
 
 				returnType := stmt.stmt.AST.StatementReturnType()
-				stmtErr := func() (retErr error) {
+				stmtErr := stmtRunner(ctx, txn, func(ctx context.Context, txn isql.Txn) (retErr error) {
 					txnRes.Start = jsonTime(SQLAPIClock.Now())
 					txnRes.Statement = stmtIdx + 1
 					txnRes.Tag = stmt.stmt.AST.StatementTag()
@@ -406,6 +453,13 @@ func (a *apiV2Server) execSQL(w http.ResponseWriter, r *http.Request) {
 							txnRes.Error = &jsonError{retErr}
 						}
 					}()
+
+					// If the max size has been exceeded by previous statements/transactions
+					// avoid executing, return immediately.
+					err := checkSize(curSize)
+					if err != nil {
+						return err
+					}
 
 					it, err := txn.QueryIteratorEx(ctx, "run-query-via-api", txn.KV(),
 						sessiondata.InternalExecutorOverride{
@@ -442,12 +496,14 @@ func (a *apiV2Server) execSQL(w http.ResponseWriter, r *http.Request) {
 						}
 					}
 					return err
-				}()
-				if stmtErr != nil {
-					return stmtErr
+				}, options...)
+				handledErr, terminate := handleStmtErr(outerErr, stmtErr)
+				outerErr = handledErr
+				if terminate {
+					return outerErr
 				}
 			}
-			return nil
+			return outerErr
 		}, options...)
 	})
 	if err != nil {

--- a/pkg/server/api_v2_sql_test.go
+++ b/pkg/server/api_v2_sql_test.go
@@ -85,12 +85,44 @@ func TestExecSQL(t *testing.T) {
 				require.NoError(t, err)
 				return fmt.Sprintf("%s|%s", er.Error.Code, er.Error.Message)
 			}
-			var u interface{}
-			err = json.Unmarshal(r, &u)
-			require.NoError(t, err)
-			s, err := json.MarshalIndent(u, "", " ")
-			require.NoError(t, err)
-			return string(s)
+			return getMarshalledResponse(t, r)
 		},
 	)
+}
+
+func getMarshalledResponse(t *testing.T, r []byte) string {
+	type marshallJsonError struct {
+		Code     string `json:"code"`
+		Message  string `json:"message"`
+		Severity string `json:"severity"`
+	}
+	// Type for the result.
+	type marshalledTxnResult struct {
+		Columns      interface{}        `json:"columns,omitempty"`
+		End          interface{}        `json:"end"` // end timestamp.
+		Error        *marshallJsonError `json:"error,omitempty"`
+		Rows         interface{}        `json:"rows,omitempty"`
+		RowsAffected int                `json:"rows_affected"`
+		Start        interface{}        `json:"start"`     // start timestamp.
+		Statement    int                `json:"statement"` // index of statement in request.
+		Tag          string             `json:"tag"`       // SQL statement tag.
+	}
+	type marshalledExecResult struct {
+		Retries    int                   `json:"retries,omitempty"`
+		TxnResults []marshalledTxnResult `json:"txn_results"`
+	}
+
+	type marshalledResponse struct {
+		Error         *marshallJsonError    `json:"error,omitempty"`
+		Execution     *marshalledExecResult `json:"execution,omitempty"`
+		NumStatements int                   `json:"num_statements,omitempty"`
+		Request       interface{}           `json:"request,omitempty"`
+	}
+
+	var u = &marshalledResponse{}
+	err := json.Unmarshal(r, u)
+	require.NoError(t, err)
+	s, err := json.MarshalIndent(u, "", " ")
+	require.NoError(t, err)
+	return string(s)
 }

--- a/pkg/server/testdata/api_v2_sql
+++ b/pkg/server/testdata/api_v2_sql
@@ -11,6 +11,7 @@ sql admin
   "database": "system",
   "execute": false,
   "max_result_size": 10000,
+  "separate_txns": false,
   "statements": [
    {
     "arguments": [
@@ -19,6 +20,7 @@ sql admin
     "sql": "SELECT username FROM users WHERE username = $1"
    }
   ],
+  "stop_on_error": false,
   "timeout": "5s"
  }
 }
@@ -545,4 +547,361 @@ sql admin
   ]
  },
  "num_statements": 1
+}
+
+# Test that running queries in separate transactions returns expected results
+# for each transaction.
+sql admin
+{
+  "database": "testdb",
+  "execute": true,
+  "separate_txns": true,
+  "statements": [
+        {"sql": "CREATE database testdb"},
+        {"sql": "CREATE table testdb.test (id int)"},
+        {"sql": "INSERT INTO testdb.test VALUES (1)"}
+  ]
+}
+----
+{
+ "execution": {
+  "txn_results": [
+   {
+    "columns": [
+     {
+      "name": "rows_affected",
+      "oid": 20,
+      "type": "INT8"
+     }
+    ],
+    "end": "1970-01-01T00:00:00Z",
+    "rows_affected": 0,
+    "start": "1970-01-01T00:00:00Z",
+    "statement": 1,
+    "tag": "CREATE DATABASE"
+   },
+   {
+    "columns": [
+     {
+      "name": "rows_affected",
+      "oid": 20,
+      "type": "INT8"
+     }
+    ],
+    "end": "1970-01-01T00:00:00Z",
+    "rows_affected": 0,
+    "start": "1970-01-01T00:00:00Z",
+    "statement": 2,
+    "tag": "CREATE TABLE"
+   },
+   {
+    "columns": [
+     {
+      "name": "rows_affected",
+      "oid": 20,
+      "type": "INT8"
+     }
+    ],
+    "end": "1970-01-01T00:00:00Z",
+    "rows_affected": 1,
+    "start": "1970-01-01T00:00:00Z",
+    "statement": 3,
+    "tag": "INSERT"
+   }
+  ]
+ },
+ "num_statements": 3
+}
+
+# Test that errors are localized to their respective transaction
+# (i.e. an error on transaction 2 should not affect transaction 1 and 3).
+# Ensure that the response level error is populated.
+sql non-admin
+{
+  "database": "system",
+  "execute": true,
+  "separate_txns": true,
+  "statements": [
+    {"sql": "SELECT username FROM users where username = 'admin'"},
+    {"sql": "SELECT 1"},
+    {"sql": "SELECT 1"}
+  ]
+}
+----
+{
+ "error": {
+  "code": "XXUUU",
+  "message": "separate transaction payload encountered transaction error(s)",
+  "severity": "ERROR"
+ },
+ "execution": {
+  "txn_results": [
+   {
+    "end": "1970-01-01T00:00:00Z",
+    "error": {
+     "code": "42501",
+     "message": "executing stmt 1: run-query-via-api: user authentic_user_noadmin does not have SELECT privilege on relation users",
+     "severity": "ERROR"
+    },
+    "rows_affected": 0,
+    "start": "1970-01-01T00:00:00Z",
+    "statement": 1,
+    "tag": "SELECT"
+   },
+   {
+    "columns": [
+     {
+      "name": "?column?",
+      "oid": 20,
+      "type": "INT8"
+     }
+    ],
+    "end": "1970-01-01T00:00:00Z",
+    "rows": [
+     {
+      "?column?": 1
+     }
+    ],
+    "rows_affected": 0,
+    "start": "1970-01-01T00:00:00Z",
+    "statement": 2,
+    "tag": "SELECT"
+   },
+   {
+    "columns": [
+     {
+      "name": "?column?",
+      "oid": 20,
+      "type": "INT8"
+     }
+    ],
+    "end": "1970-01-01T00:00:00Z",
+    "rows": [
+     {
+      "?column?": 1
+     }
+    ],
+    "rows_affected": 0,
+    "start": "1970-01-01T00:00:00Z",
+    "statement": 3,
+    "tag": "SELECT"
+   }
+  ]
+ },
+ "num_statements": 3
+}
+
+# Test that stop_on_error stops execution of subsequent txns/stmts
+# when separate_txns is true
+sql non-admin
+{
+  "database": "system",
+  "execute": true,
+  "separate_txns": true,
+  "stop_on_error": true,
+  "statements": [
+    {"sql": "SELECT username FROM users where username = 'admin'"},
+    {"sql": "SELECT 1"},
+    {"sql": "SELECT 1"}
+  ]
+}
+----
+{
+ "error": {
+  "code": "XXUUU",
+  "message": "separate transaction payload encountered transaction error(s)",
+  "severity": "ERROR"
+ },
+ "execution": {
+  "txn_results": [
+   {
+    "end": "1970-01-01T00:00:00Z",
+    "error": {
+     "code": "42501",
+     "message": "executing stmt 1: run-query-via-api: user authentic_user_noadmin does not have SELECT privilege on relation users",
+     "severity": "ERROR"
+    },
+    "rows_affected": 0,
+    "start": "1970-01-01T00:00:00Z",
+    "statement": 1,
+    "tag": "SELECT"
+   }
+  ]
+ },
+ "num_statements": 3
+}
+
+# Test multiple localized transaction errors.
+sql non-admin
+{
+  "database": "system",
+  "execute": true,
+  "separate_txns": true,
+  "statements": [
+    {"sql": "SELECT username FROM users where username = 'admin'"},
+    {"sql": "SELECT 1"},
+    {"sql": "SELECT field FROM not_exist"}
+  ]
+}
+----
+{
+ "error": {
+  "code": "XXUUU",
+  "message": "separate transaction payload encountered transaction error(s)",
+  "severity": "ERROR"
+ },
+ "execution": {
+  "txn_results": [
+   {
+    "end": "1970-01-01T00:00:00Z",
+    "error": {
+     "code": "42501",
+     "message": "executing stmt 1: run-query-via-api: user authentic_user_noadmin does not have SELECT privilege on relation users",
+     "severity": "ERROR"
+    },
+    "rows_affected": 0,
+    "start": "1970-01-01T00:00:00Z",
+    "statement": 1,
+    "tag": "SELECT"
+   },
+   {
+    "columns": [
+     {
+      "name": "?column?",
+      "oid": 20,
+      "type": "INT8"
+     }
+    ],
+    "end": "1970-01-01T00:00:00Z",
+    "rows": [
+     {
+      "?column?": 1
+     }
+    ],
+    "rows_affected": 0,
+    "start": "1970-01-01T00:00:00Z",
+    "statement": 2,
+    "tag": "SELECT"
+   },
+   {
+    "end": "1970-01-01T00:00:00Z",
+    "error": {
+     "code": "42P01",
+     "message": "executing stmt 3: run-query-via-api: relation \"not_exist\" does not exist",
+     "severity": "ERROR"
+    },
+    "rows_affected": 0,
+    "start": "1970-01-01T00:00:00Z",
+    "statement": 3,
+    "tag": "SELECT"
+   }
+  ]
+ },
+ "num_statements": 3
+}
+
+# Test that total size is being tracked correctly across multiple transactions
+# "SELECT 1" has a row size of 8. We set the max result size for the request
+# to 23 and request execution of 4 "SELECT 1" statements, totalling a size of 32.
+# We check that we receive a 'max size result exceeded' error on the expected statements (3 & 4)
+# We check that query 4 does not execute as the max size limit is exceeded by query 3, prior to its execution.
+sql admin
+{
+  "database": "system",
+  "execute": true,
+  "max_result_size": 23,
+  "separate_txns": true,
+  "statements": [
+        {"sql": "SELECT 1"},
+        {"sql": "SELECT 1"},
+        {"sql": "SELECT 1"},
+        {"sql": "SELECT 1"}
+  ]
+}
+----
+{
+ "error": {
+  "code": "XXUUU",
+  "message": "separate transaction payload encountered transaction error(s)",
+  "severity": "ERROR"
+ },
+ "execution": {
+  "txn_results": [
+   {
+    "columns": [
+     {
+      "name": "?column?",
+      "oid": 20,
+      "type": "INT8"
+     }
+    ],
+    "end": "1970-01-01T00:00:00Z",
+    "rows": [
+     {
+      "?column?": 1
+     }
+    ],
+    "rows_affected": 0,
+    "start": "1970-01-01T00:00:00Z",
+    "statement": 1,
+    "tag": "SELECT"
+   },
+   {
+    "columns": [
+     {
+      "name": "?column?",
+      "oid": 20,
+      "type": "INT8"
+     }
+    ],
+    "end": "1970-01-01T00:00:00Z",
+    "rows": [
+     {
+      "?column?": 1
+     }
+    ],
+    "rows_affected": 0,
+    "start": "1970-01-01T00:00:00Z",
+    "statement": 2,
+    "tag": "SELECT"
+   },
+   {
+    "columns": [
+     {
+      "name": "?column?",
+      "oid": 20,
+      "type": "INT8"
+     }
+    ],
+    "end": "1970-01-01T00:00:00Z",
+    "error": {
+     "code": "XXUUU",
+     "message": "executing stmt 3: max result size exceeded",
+     "severity": "ERROR"
+    },
+    "rows": [
+     {
+      "?column?": 1
+     }
+    ],
+    "rows_affected": 0,
+    "start": "1970-01-01T00:00:00Z",
+    "statement": 3,
+    "tag": "SELECT"
+   },
+   {
+    "end": "1970-01-01T00:00:00Z",
+    "error": {
+     "code": "XXUUU",
+     "message": "executing stmt 4: max result size exceeded",
+     "severity": "ERROR"
+    },
+    "rows_affected": 0,
+    "start": "1970-01-01T00:00:00Z",
+    "statement": 4,
+    "tag": "SELECT"
+   }
+  ]
+ },
+ "num_statements": 4
 }


### PR DESCRIPTION
Part of: https://github.com/cockroachdb/cockroach/issues/102386

This change introduces a `separate_txns` field to the sql api endpoint.
This field allows callers to run provided statements in separate
transactions. Failures in separate transactions are scoped to their
respective transaction and do not interfere with the execution of
subsequent transactions. The exception to this case is if the max
response size is exceeded. If the response size is exceeded in an
earlier transaction, it will still exceed the limit in subsequent
transactions.  The response-level error using `separate_txns` is a
generic message: `separate transaction payload encountered transaction
error(s)`, indicating that an error has occurred in at least one of the
transactions.

We additionally add a `stop_on_error` field to allow callers to stop
execution of subsequent txns (i.e. in the case where `separate_txns` is
true).

Release note: None