### PR TITLE
kvserver: [dnm] eagerly enqueue replicas-in-need of repair every 10s

### DIFF
--- a/pkg/kv/kvserver/replicate_queue.go
+++ b/pkg/kv/kvserver/replicate_queue.go
@@ -102,6 +102,15 @@ var MinLeaseTransferInterval = settings.RegisterDurationSetting(
 	settings.NonNegativeDuration,
 )
 
+var EagerlyMaybeAddRangesNeedingRepair = settings.RegisterBoolSetting(
+	settings.SystemOnly,
+	"kv.eagerly_enqueue_ranges_needing_repair",
+	"controls whether ranges are eagerly enqueued into the replicate queue "+
+		"for repair, when under-replicated, over-replicated, or violating lease "+
+		" preferences.",
+	true,
+)
+
 var (
 	metaReplicateQueueAddReplicaCount = metric.Metadata{
 		Name:        "queue.replicate.addreplica",


### PR DESCRIPTION
Previously, it was up to the replica scanner to enqueue replicas in need of repair into the replicate queue. On average, this occurred every 10 minutes.

We check whether a range is under-replicated, over-replicated, or violating lease preferneces when updating the replication gauages every 10s. Piggyback an eager `MaybeAddAsync` into the replicate queue, when any of these conditions are true, indicating the range might need repair.

This eager enqueue can be controlled by the cluster setting `kv.eagerly_enqueue_ranges_needing_repair`.

Epic: none
Fixes: #108425
Release note: None