### PR TITLE
ui: fix crash when adminUI is not yet initialized

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/databaseDetailsConnected.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/databaseDetailsConnected.ts
@@ -45,7 +45,7 @@ const mapStateToProps = (
   props: RouteComponentProps,
 ): DatabaseDetailsPageData => {
   const database = getMatchParamByName(props.match, databaseNameCCAttr);
-  const databaseDetails = state.adminUI.databaseDetails;
+  const databaseDetails = state.adminUI?.databaseDetails;
   const dbTables =
     databaseDetails[database]?.data?.results.tablesResp.tables || [];
   const nodeRegions = nodeRegionsByIDSelector(state);

--- a/pkg/ui/workspaces/cluster-ui/src/store/statementDiagnostics/statementDiagnostics.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/statementDiagnostics/statementDiagnostics.selectors.ts
@@ -16,7 +16,7 @@ import moment from "moment-timezone";
 
 export const statementDiagnostics = createSelector(
   (state: AppState) => state.adminUI,
-  state => state.statementDiagnostics,
+  state => state?.statementDiagnostics,
 );
 
 export const selectStatementDiagnosticsReports = createSelector(


### PR DESCRIPTION
When it's the first time a cluster is open, the value for adminUI might not yet be initialized.
We should check before using it. This commit adds
the check to a few missing places.

Epic: none

Release note: None