### PR TITLE
sql: fix recently introduced minor bug around PREPARE

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -903,16 +903,18 @@ func (ex *connExecutor) execStmtInOpenState(
 		// PREPARE statement itself.
 		oldPlaceholders := p.extendedEvalCtx.Placeholders
 		p.extendedEvalCtx.Placeholders = nil
+		defer func() {
+			// The call to addPreparedStmt changed the planner stmt to the
+			// statement being prepared. Set it back to the PREPARE statement,
+			// so that it's logged correctly.
+			p.stmt = stmt
+			p.extendedEvalCtx.Placeholders = oldPlaceholders
+		}()
 		if _, err := ex.addPreparedStmt(
 			ctx, name, prepStmt, typeHints, rawTypeHints, PreparedStatementOriginSQL,
 		); err != nil {
 			return makeErrEvent(err)
 		}
-		// The call to addPreparedStmt changed the planner stmt to the statement
-		// being prepared. Set it back to the PREPARE statement, so that it's
-		// logged correctly.
-		p.stmt = stmt
-		p.extendedEvalCtx.Placeholders = oldPlaceholders
 		return nil, nil, nil
 	}
 


### PR DESCRIPTION
In just merged 4a3e78753b9c043c51d2a483b8b591f3abc1457e, we had a minor bug that in case `addPreparedStmt` call fails, we don't restore the original placeholders, which can then lead to panics.

Fixes: #108421.

Release note: None