### PR TITLE
kvserver: remove cached SpanConfig from Replica

### DIFF
--- a/pkg/kv/kvserver/asim/op/relocate_range.go
+++ b/pkg/kv/kvserver/asim/op/relocate_range.go
@@ -69,8 +69,8 @@ func (s *SimRelocateOneOptions) StorePool() storepool.AllocatorStorePool {
 	return s.storePool
 }
 
-// SpanConfig returns the span configuration for the range with start key.
-func (s *SimRelocateOneOptions) SpanConfig(
+// LoadSpanConfig returns the span configuration for the range with start key.
+func (s *SimRelocateOneOptions) LoadSpanConfig(
 	ctx context.Context, startKey roachpb.RKey,
 ) (*roachpb.SpanConfig, error) {
 	return s.state.RangeFor(state.ToKey(startKey.AsRawKey())).SpanConfig(), nil

--- a/pkg/kv/kvserver/asim/storerebalancer/candidate_replica.go
+++ b/pkg/kv/kvserver/asim/storerebalancer/candidate_replica.go
@@ -77,10 +77,10 @@ func (sr *simulatorReplica) GetFirstIndex() kvpb.RaftIndex {
 	return 2
 }
 
-// DescAndSpanConfig returns the authoritative range descriptor as well
+// LoadSpanConfig returns the authoritative range descriptor as well
 // as the span config for the replica.
-func (sr *simulatorReplica) DescAndSpanConfig() (*roachpb.RangeDescriptor, *roachpb.SpanConfig) {
-	return sr.rng.Descriptor(), sr.rng.SpanConfig()
+func (sr *simulatorReplica) LoadSpanConfig(ctx context.Context) (*roachpb.SpanConfig, error) {
+	return sr.rng.SpanConfig(), nil
 }
 
 // Desc returns the authoritative range descriptor, acquiring a replica lock in

--- a/pkg/kv/kvserver/asim/tests/rand_gen.go
+++ b/pkg/kv/kvserver/asim/tests/rand_gen.go
@@ -342,7 +342,7 @@ func constructSetZoneConfigEventWithConformanceAssertion(
 // The first mutation event starts at the beginning, followed by an assertion
 // event after some time (durationToAssert). Right after that, the second
 // MutationWithAssertionEvent happens. Both of these mutation events are
-// SetSpanConfig events which use two hardcoded zone configurations.
+// onSpanConfigChange events which use two hardcoded zone configurations.
 func generateHardcodedSurvivalGoalsEvents(
 	regions []state.Region, startTime time.Time, durationToAssert time.Duration,
 ) gen.StaticEvents {
@@ -400,7 +400,7 @@ func randomlySelectDataPlacement(randSource *rand.Rand) descpb.DataPlacement {
 	}
 }
 
-// generateRandomSurvivalGoalsEvents generates SetSpanConfig events spaced at
+// generateRandomSurvivalGoalsEvents generates onSpanConfigChange events spaced at
 // intervals defined by durationToAssert from the start time. These events apply
 // a randomly generated zone configuration followed by an assertion event. Note
 // that these random configurations might be unsatisfiable under the cluster

--- a/pkg/kv/kvserver/client_merge_test.go
+++ b/pkg/kv/kvserver/client_merge_test.go
@@ -46,6 +46,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/rpc/nodedialer"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/storage/fs"
@@ -4230,6 +4231,60 @@ func verifyUnmergedSoon(
 	})
 }
 
+// Utility to allow manually setting a span config that is used for all ranges.
+type spanConfigInterceptor struct {
+	syncutil.Mutex
+	spanConfig roachpb.SpanConfig
+	clock      *hlc.Clock
+}
+
+func (s *spanConfigInterceptor) NeedsSplit(
+	ctx context.Context, start, end roachpb.RKey,
+) (bool, error) {
+	// Never require a span config based split. Splits and merges can still
+	// happen for size based reasons.
+	return false, nil
+}
+
+func (s *spanConfigInterceptor) ComputeSplitKey(
+	ctx context.Context, start, end roachpb.RKey,
+) (roachpb.RKey, error) {
+	panic("test should not be computing a split key")
+}
+
+func (s *spanConfigInterceptor) GetSpanConfigForKey(
+	ctx context.Context, key roachpb.RKey,
+) (roachpb.SpanConfig, error) {
+	s.Lock()
+	defer s.Unlock()
+	return s.spanConfig, nil
+}
+
+func (s *spanConfigInterceptor) GetProtectionTimestamps(
+	ctx context.Context, sp roachpb.Span,
+) (protectionTimestamps []hlc.Timestamp, asOf hlc.Timestamp, _ error) {
+	return []hlc.Timestamp{}, s.clock.Now(), nil
+}
+
+func (s *spanConfigInterceptor) LastUpdated() hlc.Timestamp {
+	// Return a non-zero timestamp. This is typically used in the context of "has at least one update".
+	return hlc.Timestamp{
+		WallTime:  1,
+		Logical:   1,
+		Synthetic: false,
+	}
+}
+
+func (s *spanConfigInterceptor) Subscribe(f func(ctx context.Context, updated roachpb.Span)) {
+	// ignore
+}
+
+func (s *spanConfigInterceptor) set(config roachpb.SpanConfig) {
+	s.Lock()
+	defer s.Unlock()
+	s.spanConfig = config
+}
+
 func TestMergeQueue(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -4241,6 +4296,9 @@ func TestMergeQueue(t *testing.T) {
 
 	zoneConfig := zonepb.DefaultZoneConfig()
 	zoneConfig.RangeMinBytes = proto.Int64(1 << 10) // 1KB
+	conf := zoneConfig.AsSpanConfig()
+	interceptor := spanConfigInterceptor{spanConfig: conf, clock: hlc.NewClockForTesting(manualClock)}
+
 	tc := testcluster.StartTestCluster(t, 2,
 		base.TestClusterArgs{
 			ReplicationMode: base.ReplicationManual,
@@ -4248,24 +4306,20 @@ func TestMergeQueue(t *testing.T) {
 				Settings: settings,
 				Knobs: base.TestingKnobs{
 					Server: &server.TestingKnobs{
-						WallClock:                 manualClock,
-						DefaultZoneConfigOverride: &zoneConfig,
+						WallClock: manualClock,
 					},
-					Store: &kvserver.StoreTestingKnobs{
-						DisableScanner: true,
+					SpanConfig: &spanconfig.TestingKnobs{
+						StoreKVSubscriberOverride: &interceptor,
 					},
 				},
+				DisableSQLServer: true,
 			},
 		})
 	defer tc.Stopper().Stop(ctx)
 
-	conf := zoneConfig.AsSpanConfig()
 	store := tc.GetFirstStoreFromServer(t, 0)
-	// The cluster with manual replication disables the merge queue,
-	// so we need to re-enable.
-	_, err := tc.ServerConn(0).Exec(`SET CLUSTER SETTING kv.range_merge.queue.enabled = true`)
-	require.NoError(t, err)
 	store.SetMergeQueueActive(true)
+	kvserverbase.MergeQueueEnabled.Override(ctx, sv, true)
 
 	split := func(t *testing.T, key roachpb.Key, expirationTime hlc.Timestamp) {
 		t.Helper()
@@ -4277,11 +4331,9 @@ func TestMergeQueue(t *testing.T) {
 	}
 
 	clearRange := func(t *testing.T, start, end roachpb.RKey) {
-		if _, pErr := kv.SendWrapped(ctx, store.DB().NonTransactionalSender(), &kvpb.ClearRangeRequest{
-			RequestHeader: kvpb.RequestHeader{Key: start.AsRawKey(), EndKey: end.AsRawKey()},
-		}); pErr != nil {
-			t.Fatal(pErr)
-		}
+		_, pErr := kv.SendWrapped(ctx, store.DB().NonTransactionalSender(), &kvpb.ClearRangeRequest{
+			RequestHeader: kvpb.RequestHeader{Key: start.AsRawKey(), EndKey: end.AsRawKey()}})
+		require.Nil(t, pErr)
 	}
 	rng, _ := randutil.NewTestRand()
 	randBytes := randutil.RandBytes(rng, int(conf.RangeMinBytes))
@@ -4296,31 +4348,13 @@ func TestMergeQueue(t *testing.T) {
 	lhs := func() *kvserver.Replica { return store.LookupReplica(lhsStartKey) }
 	rhs := func() *kvserver.Replica { return store.LookupReplica(rhsStartKey) }
 
-	// setThresholds simulates a zone config update that updates the ranges'
-	// minimum and maximum sizes.
-	setSpanConfigs := func(t *testing.T, conf roachpb.SpanConfig) {
-		t.Helper()
-		if l := lhs(); l == nil {
-			t.Fatal("left-hand side range not found")
-		} else {
-			l.SetSpanConfig(conf)
-		}
-		if r := rhs(); r == nil {
-			t.Fatal("right-hand side range not found")
-		} else {
-			r.SetSpanConfig(conf)
-		}
-	}
-
 	reset := func(t *testing.T) {
 		t.Helper()
 		clearRange(t, lhsStartKey, rhsEndKey)
 		for _, k := range []roachpb.RKey{lhsStartKey, rhsStartKey} {
-			if err := store.DB().Put(ctx, k, randBytes); err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, store.DB().Put(ctx, k, randBytes))
 		}
-		setSpanConfigs(t, conf)
+		interceptor.set(conf)
 		for _, s := range tc.Servers {
 			// Disable load-based splitting, so that the absence of sufficient QPS
 			// measurements do not prevent ranges from merging. Certain subtests
@@ -4348,9 +4382,9 @@ func TestMergeQueue(t *testing.T) {
 
 	t.Run("lhs-undersize", func(t *testing.T) {
 		reset(t)
-		conf := conf
-		conf.RangeMinBytes *= 2
-		lhs().SetSpanConfig(conf)
+		testConf := conf
+		testConf.RangeMinBytes *= 2
+		interceptor.set(testConf)
 		verifyMergedSoon(t, store, lhsStartKey, rhsStartKey)
 	})
 
@@ -4359,15 +4393,15 @@ func TestMergeQueue(t *testing.T) {
 
 		// The ranges are individually beneath the minimum size threshold, but
 		// together they'll exceed the maximum size threshold.
-		conf := conf
-		conf.RangeMinBytes = rhs().GetMVCCStats().Total() + 1
-		conf.RangeMaxBytes = lhs().GetMVCCStats().Total() + rhs().GetMVCCStats().Total() - 1
-		setSpanConfigs(t, conf)
+		testConf := conf
+		testConf.RangeMinBytes = rhs().GetMVCCStats().Total() + 1
+		testConf.RangeMaxBytes = lhs().GetMVCCStats().Total() + rhs().GetMVCCStats().Total() - 1
+		interceptor.set(testConf)
 		verifyUnmergedSoon(t, store, lhsStartKey, rhsStartKey)
 
 		// Once the maximum size threshold is increased, the merge can occur.
-		conf.RangeMaxBytes += 1
-		setSpanConfigs(t, conf)
+		testConf.RangeMaxBytes += 1
+		interceptor.set(testConf)
 		verifyMergedSoon(t, store, lhsStartKey, rhsStartKey)
 	})
 

--- a/pkg/kv/kvserver/client_spanconfigs_test.go
+++ b/pkg/kv/kvserver/client_spanconfigs_test.go
@@ -89,7 +89,9 @@ func TestSpanConfigUpdateAppliedToReplica(t *testing.T) {
 	testutils.SucceedsSoon(t, func() error {
 		repl := store.LookupReplica(keys.MustAddr(key))
 		gotConfig, err := repl.LoadSpanConfig(ctx)
-		require.NoError(t, err)
+		if err != nil {
+			return err
+		}
 		if !gotConfig.Equal(conf) {
 			return errors.Newf("expected config=%s, got config=%s", conf.String(), gotConfig.String())
 		}

--- a/pkg/kv/kvserver/client_spanconfigs_test.go
+++ b/pkg/kv/kvserver/client_spanconfigs_test.go
@@ -58,6 +58,7 @@ func TestSpanConfigUpdateAppliedToReplica(t *testing.T) {
 				StoreKVSubscriberOverride: mockSubscriber,
 			},
 		},
+		DisableSQLServer: true,
 	}
 	s := serverutils.StartServerOnly(t, args)
 	defer s.Stopper().Stop(context.Background())
@@ -82,60 +83,6 @@ func TestSpanConfigUpdateAppliedToReplica(t *testing.T) {
 	require.True(t, added[0].GetTarget().GetSpan().Equal(span))
 	addedCfg := added[0].GetConfig()
 	require.True(t, addedCfg.Equal(conf))
-
-	require.NotNil(t, mockSubscriber.callback)
-	mockSubscriber.callback(ctx, span) // invoke the callback
-	testutils.SucceedsSoon(t, func() error {
-		repl := store.LookupReplica(keys.MustAddr(key))
-		gotConfig, err := repl.LoadSpanConfig(ctx)
-		require.NoError(t, err)
-		if !gotConfig.Equal(conf) {
-			return errors.Newf("expected config=%s, got config=%s", conf.String(), gotConfig.String())
-		}
-		return nil
-	})
-}
-
-// TestFallbackSpanConfigOverride ensures that
-// spanconfig.store.fallback_config_override works as expected.
-func TestFallbackSpanConfigOverride(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-
-	st := cluster.MakeTestingClusterSettings()
-	spanConfigStore := spanconfigstore.New(
-		roachpb.TestingDefaultSpanConfig(),
-		st,
-		spanconfigstore.NewEmptyBoundsReader(),
-		nil,
-	)
-	var t0 = time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC)
-	mockSubscriber := newMockSpanConfigSubscriber(t0, spanConfigStore)
-
-	ctx := context.Background()
-	args := base.TestServerArgs{
-		Knobs: base.TestingKnobs{
-			Store: &kvserver.StoreTestingKnobs{
-				DisableMergeQueue: true,
-				DisableSplitQueue: true,
-				DisableGCQueue:    true,
-			},
-			SpanConfig: &spanconfig.TestingKnobs{
-				StoreKVSubscriberOverride: mockSubscriber,
-			},
-		},
-	}
-	s := serverutils.StartServerOnly(t, args)
-	defer s.Stopper().Stop(context.Background())
-
-	key, err := s.ScratchRange()
-	require.NoError(t, err)
-	store, err := s.GetStores().(*kvserver.Stores).GetStore(s.GetFirstStoreID())
-	require.NoError(t, err)
-	repl := store.LookupReplica(keys.MustAddr(key))
-	span := repl.Desc().RSpan().AsRawSpanWithNoLocals()
-
-	conf := roachpb.SpanConfig{NumReplicas: 5, NumVoters: 3}
-	spanconfigstore.FallbackConfigOverride.Override(ctx, &st.SV, &conf)
 
 	require.NotNil(t, mockSubscriber.callback)
 	mockSubscriber.callback(ctx, span) // invoke the callback

--- a/pkg/kv/kvserver/client_split_test.go
+++ b/pkg/kv/kvserver/client_split_test.go
@@ -1131,7 +1131,8 @@ func TestStoreZoneUpdateAndRangeSplit(t *testing.T) {
 		rngDesc := repl.Desc()
 		rngStart, rngEnd := rngDesc.StartKey, rngDesc.EndKey
 		if rngStart.Equal(tableBoundary) || !rngEnd.Equal(roachpb.RKeyMax) {
-			return errors.Errorf("range %s has not yet split", repl)
+			_, _, _ = store.Enqueue(ctx, "split", repl, false, false)
+			return errors.Errorf("range %s has not yet split expected %s-Max", repl, tableBoundary)
 		}
 		return nil
 	})
@@ -3634,8 +3635,11 @@ func TestStoreRangeSplitAndMergeWithGlobalReads(t *testing.T) {
 	zoneConfig := zonepb.DefaultZoneConfig()
 	zoneConfig.GlobalReads = proto.Bool(true)
 
+	st := cluster.MakeTestingClusterSettings()
+
 	ctx := context.Background()
 	s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{
+		Settings: st,
 		Knobs: base.TestingKnobs{
 			Server: &server.TestingKnobs{
 				DefaultZoneConfigOverride: &zoneConfig,
@@ -3658,7 +3662,6 @@ func TestStoreRangeSplitAndMergeWithGlobalReads(t *testing.T) {
 	clock.Store(s.Clock())
 	store, err := s.GetStores().(*kvserver.Stores).GetStore(s.GetFirstStoreID())
 	require.NoError(t, err)
-	config.TestingSetupZoneConfigHook(s.Stopper())
 
 	// Split off the range for the test.
 	descID := bootstrap.TestingUserDescID(0)

--- a/pkg/kv/kvserver/consistency_queue.go
+++ b/pkg/kv/kvserver/consistency_queue.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness/livenesspb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
-	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/grpcutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -110,7 +109,7 @@ func newConsistencyQueue(store *Store) *consistencyQueue {
 }
 
 func (q *consistencyQueue) shouldQueue(
-	ctx context.Context, now hlc.ClockTimestamp, repl *Replica, _ spanconfig.StoreReader,
+	ctx context.Context, now hlc.ClockTimestamp, repl *Replica, _ *roachpb.SpanConfig,
 ) (bool, float64) {
 	return consistencyQueueShouldQueueImpl(ctx, now,
 		consistencyShouldQueueData{
@@ -160,7 +159,7 @@ func consistencyQueueShouldQueueImpl(
 
 // process() is called on every range for which this node is a lease holder.
 func (q *consistencyQueue) process(
-	ctx context.Context, repl *Replica, _ spanconfig.StoreReader,
+	ctx context.Context, repl *Replica, _ *roachpb.SpanConfig,
 ) (bool, error) {
 	if q.interval() <= 0 {
 		return false, nil
@@ -208,7 +207,7 @@ func (q *consistencyQueue) process(
 }
 
 func (*consistencyQueue) postProcessScheduled(
-	ctx context.Context, replica replicaInQueue, priority float64,
+	ctx context.Context, replica replicaInQueue, _ *roachpb.SpanConfig, priority float64,
 ) {
 }
 

--- a/pkg/kv/kvserver/helpers_test.go
+++ b/pkg/kv/kvserver/helpers_test.go
@@ -425,7 +425,11 @@ func (r *Replica) GetTSCacheHighWater() hlc.Timestamp {
 // ShouldBackpressureWrites returns whether writes to the range should be
 // subject to backpressure.
 func (r *Replica) ShouldBackpressureWrites(ctx context.Context) bool {
-	return r.shouldBackpressureWrites()
+	conf, err := r.LoadSpanConfig(ctx)
+	if err != nil {
+		return false
+	}
+	return r.shouldBackpressureWrites(conf)
 }
 
 // GetRaftLogSize returns the approximate raft log size and whether it is

--- a/pkg/kv/kvserver/helpers_test.go
+++ b/pkg/kv/kvserver/helpers_test.go
@@ -17,7 +17,6 @@ package kvserver
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -194,12 +193,12 @@ func (s *Store) EnqueueRaftUpdateCheck(rangeID roachpb.RangeID) {
 }
 
 func manualQueue(s *Store, q queueImpl, repl *Replica) error {
-	cfg := s.cfg.SystemConfigProvider.GetSystemConfig()
-	if cfg == nil {
-		return fmt.Errorf("%s: system config not yet available", s)
-	}
 	ctx := repl.AnnotateCtx(context.Background())
-	_, err := q.process(ctx, repl, cfg)
+	conf, err := repl.LoadSpanConfig(ctx)
+	if err != nil {
+		return err
+	}
+	_, err = q.process(ctx, repl, conf)
 	return err
 }
 
@@ -425,7 +424,7 @@ func (r *Replica) GetTSCacheHighWater() hlc.Timestamp {
 
 // ShouldBackpressureWrites returns whether writes to the range should be
 // subject to backpressure.
-func (r *Replica) ShouldBackpressureWrites(_ context.Context) bool {
+func (r *Replica) ShouldBackpressureWrites(ctx context.Context) bool {
 	return r.shouldBackpressureWrites()
 }
 

--- a/pkg/kv/kvserver/merge_queue.go
+++ b/pkg/kv/kvserver/merge_queue.go
@@ -295,7 +295,7 @@ func (mq *mergeQueue) process(
 	}
 
 	shouldSplit, _ := shouldSplitRange(ctx, mergedDesc, mergedStats,
-		conf.RangeMaxBytes, lhsRepl.shouldBackpressureWrites(), confReader)
+		conf.RangeMaxBytes, lhsRepl.shouldBackpressureWrites(conf), confReader)
 	if shouldSplit {
 		log.VEventf(ctx, 2,
 			"skipping merge to avoid thrashing: merged range %s may split "+

--- a/pkg/kv/kvserver/merge_queue_test.go
+++ b/pkg/kv/kvserver/merge_queue_test.go
@@ -156,8 +156,8 @@ func TestMergeQueueShouldQueue(t *testing.T) {
 			repl.mu.state.Stats = &enginepb.MVCCStats{KeyBytes: tc.bytes}
 			zoneConfig := zonepb.DefaultZoneConfigRef()
 			zoneConfig.RangeMinBytes = proto.Int64(tc.minBytes)
-			repl.SetSpanConfig(zoneConfig.AsSpanConfig())
-			shouldQ, priority := mq.shouldQueue(ctx, hlc.ClockTimestamp{}, repl, config.NewSystemConfig(zoneConfig))
+			conf := zoneConfig.AsSpanConfig()
+			shouldQ, priority := mq.shouldQueue(ctx, hlc.ClockTimestamp{}, repl, &conf)
 			if tc.expShouldQ != shouldQ {
 				t.Errorf("incorrect shouldQ: expected %v but got %v", tc.expShouldQ, shouldQ)
 			}

--- a/pkg/kv/kvserver/queue.go
+++ b/pkg/kv/kvserver/queue.go
@@ -971,6 +971,7 @@ func (bq *baseQueue) processReplica(
 // where the lease can't be acquired.
 var errMarkNotAcquirableLease = errors.New("lease can't be acquired")
 
+
 // replicaCanBeProcessed validates that all the conditions for running this
 // queue are satisfied according to the queue configuration and the status of
 // the replica and its span config. This normalizes the logic for deciding
@@ -1016,11 +1017,6 @@ func (bq *baseQueue) replicaCanBeProcessed(
 			log.Infof(ctx, "unable to retrieve conf reader, skipping: %v", err)
 			return nil, err
 		}
-
-		// TODO(baptist): Remove setting the span config once the cached span
-		// config is removed from the replica.
-		realRepl, _ := repl.(*Replica)
-		realRepl.SetSpanConfig(*conf)
 
 		if !bq.acceptsUnsplitRanges {
 			// Queue does not accept unsplit ranges. Check to see if the range needs to

--- a/pkg/kv/kvserver/queue_concurrency_test.go
+++ b/pkg/kv/kvserver/queue_concurrency_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
-	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -85,7 +84,7 @@ func TestBaseQueueConcurrent(t *testing.T) {
 
 	// Set up a queue impl that will return random results from processing.
 	impl := fakeQueueImpl{
-		pr: func(context.Context, *Replica, spanconfig.StoreReader) (bool, error) {
+		pr: func(context.Context, *Replica) (bool, error) {
 			n := rand.Intn(4)
 			if n == 0 {
 				return true, nil
@@ -135,25 +134,25 @@ func TestBaseQueueConcurrent(t *testing.T) {
 }
 
 type fakeQueueImpl struct {
-	pr func(context.Context, *Replica, spanconfig.StoreReader) (processed bool, err error)
+	pr func(context.Context, *Replica) (processed bool, err error)
 }
 
 var _ queueImpl = &fakeQueueImpl{}
 
 func (fakeQueueImpl) shouldQueue(
-	context.Context, hlc.ClockTimestamp, *Replica, spanconfig.StoreReader,
+	context.Context, hlc.ClockTimestamp, *Replica, *roachpb.SpanConfig,
 ) (shouldQueue bool, priority float64) {
 	return rand.Intn(5) != 0, 1.0
 }
 
 func (fq fakeQueueImpl) process(
-	ctx context.Context, repl *Replica, confReader spanconfig.StoreReader,
+	ctx context.Context, repl *Replica, config *roachpb.SpanConfig,
 ) (bool, error) {
-	return fq.pr(ctx, repl, confReader)
+	return fq.pr(ctx, repl)
 }
 
 func (fakeQueueImpl) postProcessScheduled(
-	ctx context.Context, replica replicaInQueue, priority float64,
+	ctx context.Context, replica replicaInQueue, config *roachpb.SpanConfig, priority float64,
 ) {
 }
 

--- a/pkg/kv/kvserver/queue_test.go
+++ b/pkg/kv/kvserver/queue_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
-	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/bootstrap"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -57,13 +56,13 @@ type testQueueImpl struct {
 var _ queueImpl = &testQueueImpl{}
 
 func (tq *testQueueImpl) shouldQueue(
-	_ context.Context, now hlc.ClockTimestamp, r *Replica, _ spanconfig.StoreReader,
+	_ context.Context, now hlc.ClockTimestamp, r *Replica, _ *roachpb.SpanConfig,
 ) (bool, float64) {
 	return tq.shouldQueueFn(now, r)
 }
 
 func (tq *testQueueImpl) process(
-	_ context.Context, _ *Replica, _ spanconfig.StoreReader,
+	_ context.Context, _ *Replica, _ *roachpb.SpanConfig,
 ) (bool, error) {
 	defer atomic.AddInt32(&tq.processed, 1)
 	if tq.err != nil {
@@ -77,7 +76,7 @@ func (tq *testQueueImpl) getProcessed() int {
 }
 
 func (*testQueueImpl) postProcessScheduled(
-	ctx context.Context, replica replicaInQueue, priority float64,
+	ctx context.Context, replica replicaInQueue, _ *roachpb.SpanConfig, priority float64,
 ) {
 }
 
@@ -989,7 +988,7 @@ type processTimeoutQueueImpl struct {
 var _ queueImpl = &processTimeoutQueueImpl{}
 
 func (pq *processTimeoutQueueImpl) process(
-	ctx context.Context, r *Replica, _ spanconfig.StoreReader,
+	ctx context.Context, r *Replica, conf *roachpb.SpanConfig,
 ) (processed bool, err error) {
 	<-ctx.Done()
 	atomic.AddInt32(&pq.processed, 1)
@@ -1119,7 +1118,7 @@ type processTimeQueueImpl struct {
 var _ queueImpl = &processTimeQueueImpl{}
 
 func (pq *processTimeQueueImpl) process(
-	_ context.Context, _ *Replica, _ spanconfig.StoreReader,
+	context.Context, *Replica, *roachpb.SpanConfig,
 ) (processed bool, err error) {
 	time.Sleep(5 * time.Millisecond)
 	return true, nil
@@ -1343,13 +1342,13 @@ type parallelQueueImpl struct {
 var _ queueImpl = &parallelQueueImpl{}
 
 func (pq *parallelQueueImpl) process(
-	ctx context.Context, repl *Replica, confReader spanconfig.StoreReader,
+	ctx context.Context, repl *Replica, spanConfig *roachpb.SpanConfig,
 ) (processed bool, err error) {
 	atomic.AddInt32(&pq.processing, 1)
 	if pq.processBlocker != nil {
 		<-pq.processBlocker
 	}
-	processed, err = pq.testQueueImpl.process(ctx, repl, confReader)
+	processed, err = pq.testQueueImpl.process(ctx, repl, spanConfig)
 	atomic.AddInt32(&pq.processing, -1)
 	return processed, err
 }

--- a/pkg/kv/kvserver/queue_test.go
+++ b/pkg/kv/kvserver/queue_test.go
@@ -62,7 +62,7 @@ func (tq *testQueueImpl) shouldQueue(
 }
 
 func (tq *testQueueImpl) process(
-	_ context.Context, _ *Replica, _ *roachpb.SpanConfig,
+	ctx context.Context, r *Replica, _ *roachpb.SpanConfig,
 ) (bool, error) {
 	defer atomic.AddInt32(&tq.processed, 1)
 	if tq.err != nil {
@@ -723,7 +723,7 @@ func TestAcceptsUnsplitRanges(t *testing.T) {
 		},
 	}
 
-	bq := makeTestBaseQueue("test", testQueue, s, queueConfig{maxSize: 2})
+	bq := makeTestBaseQueue("test", testQueue, s, queueConfig{maxSize: 2, acceptsUnsplitRanges: false, needsSpanConfigs: true})
 	bq.Start(stopper)
 
 	// Check our config.

--- a/pkg/kv/kvserver/raft_log_queue_test.go
+++ b/pkg/kv/kvserver/raft_log_queue_test.go
@@ -204,7 +204,7 @@ func TestComputeTruncateDecision(t *testing.T) {
 			// we'll just see the decision play out as before.
 			// The real tests for this are in TestRaftLogQueueShouldQueue, but this is
 			// some nice extra coverage.
-			should, recompute, prio := (*raftLogQueue)(nil).shouldQueueImpl(ctx, decision)
+			should, recompute, prio := (*raftLogQueue)(nil).shouldQueueImpl(ctx, decision, nil)
 			assert.Equal(t, decision.ShouldTruncate(), should)
 			assert.False(t, recompute)
 			assert.Equal(t, decision.ShouldTruncate(), prio != 0)
@@ -214,7 +214,7 @@ func TestComputeTruncateDecision(t *testing.T) {
 				input.LastIndex = input.FirstIndex + 1
 			}
 			decision = computeTruncateDecision(input)
-			should, recompute, prio = (*raftLogQueue)(nil).shouldQueueImpl(ctx, decision)
+			should, recompute, prio = (*raftLogQueue)(nil).shouldQueueImpl(ctx, decision, nil)
 			assert.True(t, should)
 			assert.True(t, prio > 0)
 			assert.True(t, recompute)
@@ -433,7 +433,7 @@ func TestNewTruncateDecisionMaxSize(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	td, err := newTruncateDecision(ctx, repl)
+	td, err := newTruncateDecision(ctx, repl, &cfg.DefaultSpanConfig)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -469,7 +469,7 @@ func TestNewTruncateDecision(t *testing.T) {
 	}
 
 	getIndexes := func() (kvpb.RaftIndex, int, kvpb.RaftIndex, error) {
-		d, err := newTruncateDecision(ctx, r)
+		d, err := newTruncateDecision(ctx, r, &cfg.DefaultSpanConfig)
 		if err != nil {
 			return 0, 0, 0, err
 		}
@@ -820,7 +820,7 @@ func TestRaftLogQueueShouldQueueRecompute(t *testing.T) {
 
 	verify := func(shouldQ bool, recompute bool, prio float64) {
 		t.Helper()
-		isQ, isR, isP := rlq.shouldQueueImpl(ctx, decision)
+		isQ, isR, isP := rlq.shouldQueueImpl(ctx, decision, nil)
 		assert.Equal(t, shouldQ, isQ)
 		assert.Equal(t, recompute, isR)
 		assert.Equal(t, prio, isP)
@@ -883,7 +883,7 @@ func TestTruncateLogRecompute(t *testing.T) {
 
 	put()
 
-	decision, err := newTruncateDecision(ctx, repl)
+	decision, err := newTruncateDecision(ctx, repl, &cfg.DefaultSpanConfig)
 	assert.NoError(t, err)
 	assert.True(t, decision.ShouldTruncate())
 	// Should never trust initially, until recomputed at least once.

--- a/pkg/kv/kvserver/raft_snapshot_queue.go
+++ b/pkg/kv/kvserver/raft_snapshot_queue.go
@@ -17,7 +17,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
@@ -66,7 +65,7 @@ func newRaftSnapshotQueue(store *Store) *raftSnapshotQueue {
 }
 
 func (rq *raftSnapshotQueue) shouldQueue(
-	ctx context.Context, now hlc.ClockTimestamp, repl *Replica, _ spanconfig.StoreReader,
+	ctx context.Context, now hlc.ClockTimestamp, repl *Replica, _ *roachpb.SpanConfig,
 ) (shouldQueue bool, priority float64) {
 	// If a follower needs a snapshot, enqueue at the highest priority.
 	if status := repl.RaftStatus(); status != nil {
@@ -84,7 +83,7 @@ func (rq *raftSnapshotQueue) shouldQueue(
 }
 
 func (rq *raftSnapshotQueue) process(
-	ctx context.Context, repl *Replica, _ spanconfig.StoreReader,
+	ctx context.Context, repl *Replica, _ *roachpb.SpanConfig,
 ) (anyProcessed bool, _ error) {
 	// If a follower requires a Raft snapshot, perform it.
 	if status := repl.RaftStatus(); status != nil {
@@ -171,7 +170,7 @@ func (rq *raftSnapshotQueue) processRaftSnapshot(
 }
 
 func (*raftSnapshotQueue) postProcessScheduled(
-	ctx context.Context, replica replicaInQueue, priority float64,
+	ctx context.Context, replica replicaInQueue, _ *roachpb.SpanConfig, priority float64,
 ) {
 }
 

--- a/pkg/kv/kvserver/replica_gc_queue.go
+++ b/pkg/kv/kvserver/replica_gc_queue.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/log/logcrash"
@@ -121,7 +120,7 @@ func newReplicaGCQueue(store *Store, db *kv.DB) *replicaGCQueue {
 // check must have occurred more than ReplicaGCQueueInactivityThreshold
 // in the past.
 func (rgcq *replicaGCQueue) shouldQueue(
-	ctx context.Context, now hlc.ClockTimestamp, repl *Replica, _ spanconfig.StoreReader,
+	ctx context.Context, now hlc.ClockTimestamp, repl *Replica, _ *roachpb.SpanConfig,
 ) (shouldQueue bool, priority float64) {
 	if _, currentMember := repl.Desc().GetReplicaDescriptor(repl.store.StoreID()); !currentMember {
 		return true, replicaGCPriorityRemoved
@@ -221,7 +220,7 @@ func replicaGCShouldQueueImpl(now, lastCheck hlc.Timestamp, isSuspect bool) (boo
 // process performs a consistent lookup on the range descriptor to see if we are
 // still a member of the range.
 func (rgcq *replicaGCQueue) process(
-	ctx context.Context, repl *Replica, _ spanconfig.StoreReader,
+	ctx context.Context, repl *Replica, _ *roachpb.SpanConfig,
 ) (processed bool, err error) {
 	// Note that the Replicas field of desc is probably out of date, so
 	// we should only use `desc` for its static fields like RangeID and
@@ -375,7 +374,7 @@ func (rgcq *replicaGCQueue) process(
 }
 
 func (*replicaGCQueue) postProcessScheduled(
-	ctx context.Context, replica replicaInQueue, priority float64,
+	ctx context.Context, replica replicaInQueue, _ *roachpb.SpanConfig, priority float64,
 ) {
 }
 

--- a/pkg/kv/kvserver/replica_init.go
+++ b/pkg/kv/kvserver/replica_init.go
@@ -125,7 +125,6 @@ func newUninitializedReplicaWithoutRaftGroup(
 	r.mu.pendingLeaseRequest = makePendingLeaseRequest(r)
 	r.mu.stateLoader = stateloader.Make(rangeID)
 	r.mu.quiescent = true
-	r.mu.conf = store.cfg.DefaultSpanConfig
 
 	r.mu.proposals = map[kvserverbase.CmdIDKey]*ProposalData{}
 	r.mu.checksums = map[uuid.UUID]*replicaChecksum{}
@@ -169,7 +168,6 @@ func newUninitializedReplicaWithoutRaftGroup(
 	)
 
 	r.splitQueueThrottle = util.Every(splitQueueThrottleDuration)
-	r.mergeQueueThrottle = util.Every(mergeQueueThrottleDuration)
 
 	onTrip := func() {
 		telemetry.Inc(telemetryTripAsync)

--- a/pkg/kv/kvserver/replica_metrics.go
+++ b/pkg/kv/kvserver/replica_metrics.go
@@ -80,6 +80,11 @@ func (r *Replica) Metrics(
 	nodeAttrs := r.store.nodeDesc.Attrs
 	nodeLocality := r.store.nodeDesc.Locality
 
+	conf, err := r.LoadSpanConfig(ctx)
+	if err != nil {
+		return ReplicaMetrics{}
+	}
+
 	r.mu.RLock()
 
 	var qpUsed, qpCap int64
@@ -88,10 +93,9 @@ func (r *Replica) Metrics(
 		qpCap = int64(q.Capacity()) // NB: max capacity is MaxInt64, see NewIntPool
 		qpUsed = qpCap - qpAvail
 	}
-
 	input := calcReplicaMetricsInput{
 		raftCfg:               &r.store.cfg.RaftConfig,
-		conf:                  r.mu.conf,
+		conf:                  conf,
 		vitalityMap:           vitalityMap,
 		clusterNodes:          clusterNodes,
 		desc:                  r.mu.state.Desc,
@@ -120,7 +124,7 @@ func (r *Replica) Metrics(
 
 type calcReplicaMetricsInput struct {
 	raftCfg               *base.RaftConfig
-	conf                  roachpb.SpanConfig
+	conf                  *roachpb.SpanConfig
 	vitalityMap           livenesspb.NodeVitalityMap
 	clusterNodes          int
 	desc                  *roachpb.RangeDescriptor
@@ -321,13 +325,9 @@ func (r *Replica) LoadStats() load.ReplicaLoadStats {
 	return r.loadStats.Stats()
 }
 
-func (r *Replica) needsSplitBySizeRLocked() bool {
-	exceeded, _ := r.exceedsMultipleOfSplitSizeRLocked(1)
+func (r *Replica) needsSplitBySizeRLocked(conf *roachpb.SpanConfig) bool {
+	exceeded, _ := r.exceedsMultipleOfSplitSizeRLocked(conf, 1)
 	return exceeded
-}
-
-func (r *Replica) needsMergeBySizeRLocked() bool {
-	return r.mu.state.Stats.Total() < r.mu.conf.RangeMinBytes
 }
 
 func (r *Replica) needsRaftLogTruncationLocked() bool {
@@ -352,8 +352,10 @@ func (r *Replica) needsRaftLogTruncationLocked() bool {
 // size as dictated by the span config or a previous max size indicating that
 // the max size has changed relatively recently and thus we should not
 // backpressure for being over.
-func (r *Replica) exceedsMultipleOfSplitSizeRLocked(mult float64) (exceeded bool, bytesOver int64) {
-	maxBytes := r.mu.conf.RangeMaxBytes
+func (r *Replica) exceedsMultipleOfSplitSizeRLocked(
+	conf *roachpb.SpanConfig, mult float64,
+) (exceeded bool, bytesOver int64) {
+	maxBytes := conf.RangeMaxBytes
 	if r.mu.largestPreviousMaxRangeSizeBytes > maxBytes {
 		maxBytes = r.mu.largestPreviousMaxRangeSizeBytes
 	}

--- a/pkg/kv/kvserver/replica_raftstorage.go
+++ b/pkg/kv/kvserver/replica_raftstorage.go
@@ -458,7 +458,7 @@ func (r *Replica) updateRangeInfo(ctx context.Context, desc *roachpb.RangeDescri
 	// the original range wont work as the original and new ranges might belong
 	// to different zones.
 	// Load the system config.
-	confReader, err := r.store.GetConfReader(ctx)
+	conf, err := r.LoadSpanConfig(ctx)
 	if errors.Is(err, errSpanConfigsUnavailable) {
 		// This could be before the span config subscription was ever
 		// established.
@@ -466,17 +466,10 @@ func (r *Replica) updateRangeInfo(ctx context.Context, desc *roachpb.RangeDescri
 		return nil
 	}
 	if err != nil {
-		return err
-	}
-
-	// Find span config for this range.
-	conf, err := confReader.GetSpanConfigForKey(ctx, desc.StartKey)
-	if err != nil {
 		return errors.Wrapf(err, "%s: failed to lookup span config", r)
 	}
 
-	changed := r.SetSpanConfig(conf)
-	if changed {
+	if r.onSpanConfigUpdate(*conf) {
 		r.MaybeQueue(ctx, r.store.cfg.Clock.NowAsClockTimestamp())
 	}
 

--- a/pkg/kv/kvserver/replica_range_lease.go
+++ b/pkg/kv/kvserver/replica_range_lease.go
@@ -1577,6 +1577,7 @@ const (
 // LeaseViolatesPreferences checks if this replica owns the lease and if it
 // violates the lease preferences defined in the span config. If no preferences
 // are defined then it will return false and consider it to be in conformance.
+// TODO(baptist): Change to pass preferences instead of conf.
 func (r *Replica) LeaseViolatesPreferences(ctx context.Context, conf *roachpb.SpanConfig) bool {
 	storeID := r.store.StoreID()
 	preferences := conf.LeasePreferences

--- a/pkg/kv/kvserver/replica_rankings.go
+++ b/pkg/kv/kvserver/replica_rankings.go
@@ -45,9 +45,9 @@ type CandidateReplica interface {
 	// GetFirstIndex returns the index of the first entry in the replica's Raft
 	// log.
 	GetFirstIndex() kvpb.RaftIndex
-	// DescAndSpanConfig returns the authoritative range descriptor as well
-	// as the span config for the replica.
-	DescAndSpanConfig() (*roachpb.RangeDescriptor, *roachpb.SpanConfig)
+	// LoadSpanConfig returns the span config for the replica or an error if it can't
+	// be determined.
+	LoadSpanConfig(context.Context) (*roachpb.SpanConfig, error)
 	// Desc returns the authoritative range descriptor.
 	Desc() *roachpb.RangeDescriptor
 	// RangeUsageInfo returns usage information (sizes and traffic) needed by
@@ -77,7 +77,7 @@ func (cr candidateReplica) RangeUsageInfo() allocator.RangeUsageInfo {
 	return cr.usage
 }
 
-// Replica returns the underlying replica for this CandidateReplica. It is
+// Repl returns the underlying replica for this CandidateReplica. It is
 // only used for determining timeouts in production code and not the
 // simulator.
 func (cr candidateReplica) Repl() *Replica {

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -10373,13 +10373,11 @@ func TestConsistenctQueueErrorFromCheckConsistency(t *testing.T) {
 	tc := testContext{}
 	tc.StartWithStoreConfig(ctx, t, stopper, cfg)
 
-	confReader, err := tc.store.GetConfReader(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
+	conf, err := tc.repl.LoadSpanConfig(ctx)
+	require.NoError(t, err)
 	for i := 0; i < 2; i++ {
 		// Do this twice because it used to deadlock. See #25456.
-		processed, err := tc.store.consistencyQueue.process(ctx, tc.repl, confReader)
+		processed, err := tc.store.consistencyQueue.process(ctx, tc.repl, conf)
 		if !testutils.IsError(err, "boom") {
 			t.Fatal(err)
 		}

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -9162,7 +9162,7 @@ func TestReplicaMetrics(t *testing.T) {
 			c.expected.Ticking = !c.expected.Quiescent
 			metrics := calcReplicaMetrics(calcReplicaMetricsInput{
 				raftCfg:            &cfg.RaftConfig,
-				conf:               spanConfig,
+				conf:               &spanConfig,
 				vitalityMap:        c.liveness.ScanNodeVitalityFromCache(),
 				desc:               &c.desc,
 				raftStatus:         c.raftStatus,

--- a/pkg/kv/kvserver/replicate_queue.go
+++ b/pkg/kv/kvserver/replicate_queue.go
@@ -27,7 +27,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness/livenesspb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
-	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
@@ -626,27 +625,21 @@ func newReplicateQueue(store *Store, allocator allocatorimpl.Allocator) *replica
 }
 
 func (rq *replicateQueue) shouldQueue(
-	ctx context.Context, now hlc.ClockTimestamp, repl *Replica, confReader spanconfig.StoreReader,
+	ctx context.Context, now hlc.ClockTimestamp, repl *Replica, conf *roachpb.SpanConfig,
 ) (shouldQueue bool, priority float64) {
-	// TODO(baptist): Change to Replica.SpanConfig() once the refactor is done to
-	// have that use the confReader.
-	conf, err := confReader.GetSpanConfigForKey(ctx, repl.startKey)
-	if err != nil {
-		return false, 0
-	}
 	desc := repl.Desc()
 	return rq.planner.ShouldPlanChange(
 		ctx,
 		now,
 		repl,
 		desc,
-		&conf,
+		conf,
 		rq.canTransferLeaseFrom,
 	)
 }
 
 func (rq *replicateQueue) process(
-	ctx context.Context, repl *Replica, confReader spanconfig.StoreReader,
+	ctx context.Context, repl *Replica, conf *roachpb.SpanConfig,
 ) (processed bool, err error) {
 	retryOpts := retry.Options{
 		InitialBackoff: 50 * time.Millisecond,
@@ -654,18 +647,12 @@ func (rq *replicateQueue) process(
 		Multiplier:     2,
 		MaxRetries:     5,
 	}
-	// TODO(baptist): Change to Replica.SpanConfig() once the refactor is done to
-	// have that use the confReader.
-	conf, err := confReader.GetSpanConfigForKey(ctx, repl.startKey)
-	if err != nil {
-		return false, err
-	}
 	desc := repl.Desc()
 	// Use a retry loop in order to backoff in the case of snapshot errors,
 	// usually signaling that a rebalancing reservation could not be made with the
 	// selected target.
 	for r := retry.StartWithCtx(ctx, retryOpts); r.Next(); {
-		requeue, err := rq.processOneChangeWithTracing(ctx, repl, desc, &conf)
+		requeue, err := rq.processOneChangeWithTracing(ctx, repl, desc, conf)
 		if isSnapshotError(err) {
 			// If ChangeReplicas failed because the snapshot failed, we attempt to
 			// retry the operation. The most likely causes of the snapshot failing
@@ -690,7 +677,7 @@ func (rq *replicateQueue) process(
 		}
 
 		if testingAggressiveConsistencyChecks {
-			if _, err := rq.store.consistencyQueue.process(ctx, repl, confReader); err != nil {
+			if _, err := rq.store.consistencyQueue.process(ctx, repl, conf); err != nil {
 				log.KvDistribution.Warningf(ctx, "%v", err)
 			}
 		}
@@ -1143,7 +1130,7 @@ func (rq *replicateQueue) canTransferLeaseFrom(
 }
 
 func (*replicateQueue) postProcessScheduled(
-	ctx context.Context, replica replicaInQueue, priority float64,
+	ctx context.Context, replica replicaInQueue, conf *roachpb.SpanConfig, priority float64,
 ) {
 }
 

--- a/pkg/kv/kvserver/replicate_queue_test.go
+++ b/pkg/kv/kvserver/replicate_queue_test.go
@@ -778,7 +778,10 @@ func TestReplicateQueueDecommissioningNonVoters(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			_, conf := repl.DescAndSpanConfig()
+			conf, err := repl.LoadSpanConfig(ctx)
+			if err != nil {
+				return false
+			}
 			return conf.GetNumNonVoters() == 0
 		}, testutils.DefaultSucceedsSoonDuration, 100*time.Millisecond)
 
@@ -1205,7 +1208,10 @@ func TestReplicateQueueDeadNonVoters(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			_, conf := repl.DescAndSpanConfig()
+			conf, err := repl.LoadSpanConfig(ctx)
+			if err != nil {
+				return false
+			}
 			return conf.GetNumNonVoters() == 0
 		}, testutils.DefaultSucceedsSoonDuration, 100*time.Millisecond)
 
@@ -2033,23 +2039,26 @@ func TestTransferLeaseToLaggingNode(t *testing.T) {
 		time.Sleep(13 * time.Millisecond)
 	}
 
-	// Set the zone preference for the replica to show that it has to be moved
-	// to the remote node.
-	desc, conf := leaseHolderRepl.DescAndSpanConfig()
-	newConf := conf
-	newConf.LeasePreferences = []roachpb.LeasePreference{
-		{
-			Constraints: []roachpb.Constraint{
-				{
-					Type:  roachpb.Constraint_REQUIRED,
-					Value: fmt.Sprintf("n%d", remoteNodeID),
-				},
-			},
-		},
-	}
-
 	// By now the lease holder may have changed.
 	testutils.SucceedsSoon(t, func() error {
+		conf, err := leaseHolderRepl.LoadSpanConfig(ctx)
+		if err != nil {
+			return err
+		}
+		newConf := conf
+
+		// Set the zone preference for the replica to show that it has to be moved
+		// to the remote node.
+		newConf.LeasePreferences = []roachpb.LeasePreference{
+			{
+				Constraints: []roachpb.Constraint{
+					{
+						Type:  roachpb.Constraint_REQUIRED,
+						Value: fmt.Sprintf("n%d", remoteNodeID),
+					},
+				},
+			},
+		}
 		leaseBefore, _ := leaseHolderRepl.GetLease()
 		log.Infof(ctx, "Lease before transfer %+v\n", leaseBefore)
 
@@ -2071,7 +2080,7 @@ func TestTransferLeaseToLaggingNode(t *testing.T) {
 			return err
 		}
 		transferred, err := leaseStore.FindTargetAndTransferLease(
-			ctx, leaseRepl, desc, newConf)
+			ctx, leaseRepl, leaseHolderRepl.Desc(), newConf)
 		if err != nil {
 			return err
 		}

--- a/pkg/kv/kvserver/split_queue.go
+++ b/pkg/kv/kvserver/split_queue.go
@@ -190,7 +190,7 @@ func (sq *splitQueue) shouldQueue(
 		return false, 0
 	}
 	shouldQ, priority = shouldSplitRange(ctx, repl.Desc(), repl.GetMVCCStats(),
-		conf.RangeMaxBytes, repl.shouldBackpressureWrites(), confReader)
+		conf.RangeMaxBytes, repl.shouldBackpressureWrites(conf), confReader)
 
 	if !shouldQ && repl.SplitByLoadEnabled() {
 		if splitKey := repl.loadSplitKey(ctx, repl.Clock().PhysicalTime()); splitKey != nil {

--- a/pkg/kv/kvserver/split_queue.go
+++ b/pkg/kv/kvserver/split_queue.go
@@ -183,10 +183,14 @@ func shouldSplitRange(
 // prefix or if the range's size in bytes exceeds the limit for the zone,
 // or if the range has too much load on it.
 func (sq *splitQueue) shouldQueue(
-	ctx context.Context, now hlc.ClockTimestamp, repl *Replica, confReader spanconfig.StoreReader,
+	ctx context.Context, now hlc.ClockTimestamp, repl *Replica, conf *roachpb.SpanConfig,
 ) (shouldQ bool, priority float64) {
+	confReader, err := repl.store.GetConfReader(ctx)
+	if err != nil {
+		return false, 0
+	}
 	shouldQ, priority = shouldSplitRange(ctx, repl.Desc(), repl.GetMVCCStats(),
-		repl.GetMaxBytes(ctx), repl.shouldBackpressureWrites(), confReader)
+		conf.RangeMaxBytes, repl.shouldBackpressureWrites(), confReader)
 
 	if !shouldQ && repl.SplitByLoadEnabled() {
 		if splitKey := repl.loadSplitKey(ctx, repl.Clock().PhysicalTime()); splitKey != nil {
@@ -208,9 +212,9 @@ var _ PurgatoryError = unsplittableRangeError{}
 
 // process synchronously invokes admin split for each proposed split key.
 func (sq *splitQueue) process(
-	ctx context.Context, r *Replica, confReader spanconfig.StoreReader,
+	ctx context.Context, r *Replica, conf *roachpb.SpanConfig,
 ) (processed bool, err error) {
-	processed, err = sq.processAttempt(ctx, r, confReader)
+	processed, err = sq.processAttempt(ctx, r, conf)
 	if errors.HasType(err, (*kvpb.ConditionFailedError)(nil)) {
 		// ConditionFailedErrors are an expected outcome for range split
 		// attempts because splits can race with other descriptor modifications.
@@ -225,9 +229,13 @@ func (sq *splitQueue) process(
 }
 
 func (sq *splitQueue) processAttempt(
-	ctx context.Context, r *Replica, confReader spanconfig.StoreReader,
+	ctx context.Context, r *Replica, conf *roachpb.SpanConfig,
 ) (processed bool, err error) {
 	desc := r.Desc()
+	confReader, err := r.store.GetConfReader(ctx)
+	if err != nil {
+		return false, errors.Wrapf(err, "unable to load conf reader")
+	}
 	// First handle the case of splitting due to span config maps.
 	splitKey, err := confReader.ComputeSplitKey(ctx, desc.StartKey, desc.EndKey)
 	if err != nil {
@@ -244,6 +252,7 @@ func (sq *splitQueue) processAttempt(
 				ExpirationTime: hlc.Timestamp{},
 			},
 			desc,
+			conf,
 			false, /* delayable */
 			"span config",
 			false, /* findFirstSafeSplitKey */
@@ -258,7 +267,7 @@ func (sq *splitQueue) processAttempt(
 	// size-based splitting if maxBytes is 0 (happens in certain test
 	// situations).
 	size := r.GetMVCCStats().Total()
-	maxBytes := r.GetMaxBytes(ctx)
+	maxBytes := conf.RangeMaxBytes
 	if maxBytes > 0 && size > maxBytes {
 		reason := redact.Sprintf(
 			"%s above threshold size %s",
@@ -269,6 +278,7 @@ func (sq *splitQueue) processAttempt(
 			ctx,
 			kvpb.AdminSplitRequest{},
 			desc,
+			conf,
 			false, /* delayable */
 			reason,
 			false, /* findFirstSafeSplitKey */
@@ -321,6 +331,7 @@ func (sq *splitQueue) processAttempt(
 				ExpirationTime: expTime,
 			},
 			desc,
+			conf,
 			false, /* delayable */
 			reason,
 			true, /* findFirstSafeSplitKey */
@@ -340,7 +351,7 @@ func (sq *splitQueue) processAttempt(
 }
 
 func (*splitQueue) postProcessScheduled(
-	ctx context.Context, replica replicaInQueue, priority float64,
+	ctx context.Context, replica replicaInQueue, config *roachpb.SpanConfig, priority float64,
 ) {
 }
 

--- a/pkg/kv/kvserver/store_rebalancer.go
+++ b/pkg/kv/kvserver/store_rebalancer.go
@@ -654,7 +654,7 @@ func (sr *StoreRebalancer) applyRangeRebalance(
 	candidateReplica CandidateReplica,
 	voterTargets, nonVoterTargets []roachpb.ReplicationTarget,
 ) bool {
-	descBeforeRebalance, _ := candidateReplica.DescAndSpanConfig()
+	descBeforeRebalance := candidateReplica.Desc()
 	log.KvDistribution.Infof(
 		ctx,
 		"rebalancing r%d (%s load) to better balance load: voters from %v to %v; non-voters from %v to %v",
@@ -740,7 +740,12 @@ func (sr *StoreRebalancer) chooseLeaseToTransfer(
 			continue
 		}
 
-		desc, conf := candidateReplica.DescAndSpanConfig()
+		desc := candidateReplica.Desc()
+		conf, err := candidateReplica.LoadSpanConfig(ctx)
+		if err != nil {
+			log.KvDistribution.VEventf(ctx, 2, "unable to load span config: %v", err)
+			continue
+		}
 		log.KvDistribution.VEventf(ctx, 3, "considering lease transfer for r%d with %s load",
 			desc.RangeID, candidateReplica.RangeUsageInfo().TransferImpact())
 
@@ -867,7 +872,12 @@ func (sr *StoreRebalancer) chooseRangeToRebalance(
 			continue
 		}
 
-		rangeDesc, conf := candidateReplica.DescAndSpanConfig()
+		rangeDesc := candidateReplica.Desc()
+		conf, err := candidateReplica.LoadSpanConfig(ctx)
+		if err != nil {
+			log.KvDistribution.VEventf(ctx, 2, "unable to load span config: %v", err)
+			continue
+		}
 		clusterNodes := sr.storePool.ClusterNodeCount()
 		numDesiredVoters := allocatorimpl.GetNeededVoters(conf.GetNumVoters(), clusterNodes)
 		numDesiredNonVoters := allocatorimpl.GetNeededNonVoters(numDesiredVoters, int(conf.GetNumNonVoters()), clusterNodes)

--- a/pkg/kv/kvserver/store_rebalancer_test.go
+++ b/pkg/kv/kvserver/store_rebalancer_test.go
@@ -1278,12 +1278,6 @@ func TestChooseRangeToRebalanceAcrossHeterogeneousZones(t *testing.T) {
 			)
 
 			hottestRanges := sr.replicaRankings.TopLoad(lbRebalanceDimension)
-			// TODO(baptist): Remove this once the cached span conf is removed
-			// from the replica. The DefaultSpanConfig can be removed also once
-			// this change is made.
-			for _, replica := range hottestRanges {
-				replica.Repl().SetSpanConfig(s.cfg.DefaultSpanConfig)
-			}
 			options := sr.scorerOptions(ctx, lbRebalanceDimension)
 			rctx := sr.NewRebalanceContext(ctx, options, hottestRanges, LBRebalancingLeasesAndReplicas)
 			rctx.options.IOOverloadOptions = allocatorimpl.IOOverloadOptions{
@@ -1540,12 +1534,6 @@ func TestChooseRangeToRebalanceOffHotNodes(t *testing.T) {
 			)
 
 			hottestRanges := sr.replicaRankings.TopLoad(lbRebalanceDimension)
-			// TODO(baptist): Remove this once the cached span conf is removed
-			// from the replica. The DefaultSpanConfig can be removed also once
-			// this change is made.
-			for _, replica := range hottestRanges {
-				replica.Repl().SetSpanConfig(s.cfg.DefaultSpanConfig)
-			}
 			options := sr.scorerOptions(ctx, lbRebalanceDimension)
 			rctx := sr.NewRebalanceContext(ctx, options, hottestRanges, sr.RebalanceMode())
 			rctx.options.IOOverloadOptions = allocatorimpl.IOOverloadOptions{
@@ -1813,12 +1801,6 @@ func TestStoreRebalancerIOOverloadCheck(t *testing.T) {
 			loadRanges(rr, s, []testRange{{voters: []roachpb.StoreID{1, 3, 5}, qps: 100, reqCPU: 100 * float64(time.Millisecond)}})
 
 			hottestRanges := sr.replicaRankings.TopLoad(lbRebalanceDimension)
-			// TODO(baptist): Remove this once the cached span conf is removed
-			// from the replica. The DefaultSpanConfig can be removed also once
-			// this change is made.
-			for _, replica := range hottestRanges {
-				replica.Repl().SetSpanConfig(s.cfg.DefaultSpanConfig)
-			}
 			options := sr.scorerOptions(ctx, lbRebalanceDimension)
 			rctx := sr.NewRebalanceContext(ctx, options, hottestRanges, sr.RebalanceMode())
 			require.Greater(t, len(rctx.hottestRanges), 0)

--- a/pkg/kv/kvserver/store_rebalancer_test.go
+++ b/pkg/kv/kvserver/store_rebalancer_test.go
@@ -509,7 +509,6 @@ func loadRanges(rr *ReplicaRankings, s *Store, ranges []testRange) {
 		rangeID := roachpb.RangeID(i + 1)
 		repl := &Replica{store: s, RangeID: rangeID}
 		repl.mu.state.Desc = &roachpb.RangeDescriptor{RangeID: rangeID}
-		repl.mu.conf = s.cfg.DefaultSpanConfig
 		for _, storeID := range r.voters {
 			repl.mu.state.Desc.InternalReplicas = append(repl.mu.state.Desc.InternalReplicas, roachpb.ReplicaDescriptor{
 				NodeID:    roachpb.NodeID(storeID),
@@ -1279,6 +1278,12 @@ func TestChooseRangeToRebalanceAcrossHeterogeneousZones(t *testing.T) {
 			)
 
 			hottestRanges := sr.replicaRankings.TopLoad(lbRebalanceDimension)
+			// TODO(baptist): Remove this once the cached span conf is removed
+			// from the replica. The DefaultSpanConfig can be removed also once
+			// this change is made.
+			for _, replica := range hottestRanges {
+				replica.Repl().SetSpanConfig(s.cfg.DefaultSpanConfig)
+			}
 			options := sr.scorerOptions(ctx, lbRebalanceDimension)
 			rctx := sr.NewRebalanceContext(ctx, options, hottestRanges, LBRebalancingLeasesAndReplicas)
 			rctx.options.IOOverloadOptions = allocatorimpl.IOOverloadOptions{
@@ -1535,6 +1540,12 @@ func TestChooseRangeToRebalanceOffHotNodes(t *testing.T) {
 			)
 
 			hottestRanges := sr.replicaRankings.TopLoad(lbRebalanceDimension)
+			// TODO(baptist): Remove this once the cached span conf is removed
+			// from the replica. The DefaultSpanConfig can be removed also once
+			// this change is made.
+			for _, replica := range hottestRanges {
+				replica.Repl().SetSpanConfig(s.cfg.DefaultSpanConfig)
+			}
 			options := sr.scorerOptions(ctx, lbRebalanceDimension)
 			rctx := sr.NewRebalanceContext(ctx, options, hottestRanges, sr.RebalanceMode())
 			rctx.options.IOOverloadOptions = allocatorimpl.IOOverloadOptions{
@@ -1802,6 +1813,12 @@ func TestStoreRebalancerIOOverloadCheck(t *testing.T) {
 			loadRanges(rr, s, []testRange{{voters: []roachpb.StoreID{1, 3, 5}, qps: 100, reqCPU: 100 * float64(time.Millisecond)}})
 
 			hottestRanges := sr.replicaRankings.TopLoad(lbRebalanceDimension)
+			// TODO(baptist): Remove this once the cached span conf is removed
+			// from the replica. The DefaultSpanConfig can be removed also once
+			// this change is made.
+			for _, replica := range hottestRanges {
+				replica.Repl().SetSpanConfig(s.cfg.DefaultSpanConfig)
+			}
 			options := sr.scorerOptions(ctx, lbRebalanceDimension)
 			rctx := sr.NewRebalanceContext(ctx, options, hottestRanges, sr.RebalanceMode())
 			require.Greater(t, len(rctx.hottestRanges), 0)

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -52,7 +52,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/rpc/nodedialer"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
-	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/bootstrap"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
@@ -3505,34 +3504,6 @@ func TestSnapshotRateLimit(t *testing.T) {
 	require.Equal(t, int64(32<<20), limit)
 }
 
-type mockSpanConfigReader struct {
-	real      spanconfig.StoreReader
-	overrides map[string]roachpb.SpanConfig
-}
-
-func (m *mockSpanConfigReader) NeedsSplit(
-	ctx context.Context, start, end roachpb.RKey,
-) (bool, error) {
-	panic("unimplemented")
-}
-
-func (m *mockSpanConfigReader) ComputeSplitKey(
-	ctx context.Context, start, end roachpb.RKey,
-) (roachpb.RKey, error) {
-	panic("unimplemented")
-}
-
-func (m *mockSpanConfigReader) GetSpanConfigForKey(
-	ctx context.Context, key roachpb.RKey,
-) (roachpb.SpanConfig, error) {
-	if conf, ok := m.overrides[string(key)]; ok {
-		return conf, nil
-	}
-	return m.GetSpanConfigForKey(ctx, key)
-}
-
-var _ spanconfig.StoreReader = &mockSpanConfigReader{}
-
 // TestAllocatorCheckRangeUnconfigured tests evaluating the allocation decisions
 // for a range with a single replica using the default system configuration and
 // no other available allocation targets.
@@ -3684,7 +3655,6 @@ func TestAllocatorCheckRange(t *testing.T) {
 				{NodeID: 4, StoreID: 4, ReplicaID: 4},
 				{NodeID: 5, StoreID: 5, ReplicaID: 5},
 			},
-			spanConfig: &defaultSystemSpanConfig,
 			livenessOverrides: map[roachpb.NodeID]livenesspb.NodeLivenessStatus{
 				3: livenesspb.NodeLivenessStatus_DECOMMISSIONING,
 			},
@@ -3702,7 +3672,6 @@ func TestAllocatorCheckRange(t *testing.T) {
 				{NodeID: 4, StoreID: 4, ReplicaID: 4},
 				{NodeID: 5, StoreID: 5, ReplicaID: 5},
 			},
-			spanConfig: &defaultSystemSpanConfig,
 			livenessOverrides: map[roachpb.NodeID]livenesspb.NodeLivenessStatus{
 				3: livenesspb.NodeLivenessStatus_DECOMMISSIONING,
 				4: livenesspb.NodeLivenessStatus_DECOMMISSIONING,
@@ -3726,7 +3695,6 @@ func TestAllocatorCheckRange(t *testing.T) {
 				// Region "c"
 				{NodeID: 7, StoreID: 7, ReplicaID: 5},
 			},
-			spanConfig: &defaultSystemSpanConfig,
 			livenessOverrides: map[roachpb.NodeID]livenesspb.NodeLivenessStatus{
 				// Downsize to one node per region: 3,6,9.
 				1: livenesspb.NodeLivenessStatus_DECOMMISSIONING,
@@ -3979,16 +3947,8 @@ func TestAllocatorCheckRange(t *testing.T) {
 			cfg.Gossip = g
 			cfg.StorePool = sp
 			if tc.spanConfig != nil {
-				mockSr := &mockSpanConfigReader{
-					real: cfg.SystemConfigProvider.GetSystemConfig(),
-					overrides: map[string]roachpb.SpanConfig{
-						"a": *tc.spanConfig,
-					},
-				}
-
-				cfg.TestingKnobs.ConfReaderInterceptor = func() spanconfig.StoreReader {
-					return mockSr
-				}
+				cfg.SpanConfigsDisabled = true
+				cfg.DefaultSpanConfig = *tc.spanConfig
 			}
 
 			s := createTestStoreWithoutStart(ctx, t, stopper, testStoreOpts{createSystemRanges: true}, &cfg)

--- a/pkg/kv/kvserver/ts_maintenance_queue.go
+++ b/pkg/kv/kvserver/ts_maintenance_queue.go
@@ -17,7 +17,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -128,7 +127,7 @@ func newTimeSeriesMaintenanceQueue(
 }
 
 func (q *timeSeriesMaintenanceQueue) shouldQueue(
-	ctx context.Context, now hlc.ClockTimestamp, repl *Replica, _ spanconfig.StoreReader,
+	ctx context.Context, now hlc.ClockTimestamp, repl *Replica, conf *roachpb.SpanConfig,
 ) (shouldQ bool, priority float64) {
 	if !repl.store.cfg.TestingKnobs.DisableLastProcessedCheck {
 		lpTS, err := repl.getQueueLastProcessed(ctx, q.name)
@@ -148,7 +147,7 @@ func (q *timeSeriesMaintenanceQueue) shouldQueue(
 }
 
 func (q *timeSeriesMaintenanceQueue) process(
-	ctx context.Context, repl *Replica, _ spanconfig.StoreReader,
+	ctx context.Context, repl *Replica, conf *roachpb.SpanConfig,
 ) (processed bool, err error) {
 	desc := repl.Desc()
 	eng := repl.store.StateEngine()
@@ -166,7 +165,7 @@ func (q *timeSeriesMaintenanceQueue) process(
 }
 
 func (*timeSeriesMaintenanceQueue) postProcessScheduled(
-	ctx context.Context, replica replicaInQueue, priority float64,
+	ctx context.Context, replica replicaInQueue, conf *roachpb.SpanConfig, priority float64,
 ) {
 }
 

--- a/pkg/spanconfig/spanconfigkvsubscriber/kvsubscriber.go
+++ b/pkg/spanconfig/spanconfigkvsubscriber/kvsubscriber.go
@@ -430,6 +430,12 @@ func (s *KVSubscriber) handleCompleteUpdate(
 	}
 }
 
+func (s *KVSubscriber) SetLastUpdatedTest() {
+	s.mu.Lock()
+	s.setLastUpdatedLocked(s.clock.Now())
+	defer s.mu.Unlock()
+}
+
 func (s *KVSubscriber) setLastUpdatedLocked(ts hlc.Timestamp) {
 	s.mu.lastUpdated = ts
 	nanos := timeutil.Since(s.mu.lastUpdated.GoTime()).Nanoseconds()

--- a/pkg/testutils/localtestcluster/local_test_cluster.go
+++ b/pkg/testutils/localtestcluster/local_test_cluster.go
@@ -240,17 +240,21 @@ func (ltc *LocalTestCluster) Start(t testing.TB, initFactory InitFactoryFn) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	cfg.SpanConfigSubscriber = spanconfigkvsubscriber.New(
-		clock,
-		rangeFeedFactory,
-		keys.SpanConfigurationsTableID,
-		1<<20, /* 1 MB */
-		cfg.DefaultSpanConfig,
-		cfg.Settings,
-		spanconfigstore.NewEmptyBoundsReader(),
-		nil, /* knobs */
-		nil, /* registry */
-	)
+
+	spanConfigSubscriber :=
+		spanconfigkvsubscriber.New(
+			clock,
+			rangeFeedFactory,
+			keys.SpanConfigurationsTableID,
+			1<<20, /* 1 MB */
+			cfg.DefaultSpanConfig,
+			cfg.Settings,
+			spanconfigstore.NewEmptyBoundsReader(),
+			nil, /* knobs */
+			nil, /* registry */
+		)
+	spanConfigSubscriber.SetLastUpdatedTest()
+	cfg.SpanConfigSubscriber = spanConfigSubscriber
 	cfg.SystemConfigProvider = systemconfigwatcher.New(
 		keys.SystemSQLCodec,
 		cfg.Clock,


### PR DESCRIPTION
This commit removes the cached span config from the replica.
This prevents lost updates from causing problems such as invalid
span configs.

As a result of this change, a number of span config testing knobs
are no longer necessary or have better replacements so they are also
removed

Fixes: https://github.com/cockroachdb/cockroach/issues/104195
Fixes: https://github.com/cockroachdb/cockroach/issues/108123

Epic: none

Release note: None