### PR TITLE
sql/sem/builtins: add TestGenerateUniqueUnorderedIDOrder

### DIFF
--- a/pkg/sql/sem/builtins/BUILD.bazel
+++ b/pkg/sql/sem/builtins/BUILD.bazel
@@ -220,6 +220,7 @@ go_test(
         "@com_github_lib_pq//oid",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
+        "@org_golang_x_exp//constraints",
     ],
 )
 


### PR DESCRIPTION
This patch adds a new TestGenerateUniqueUnorderedIDOrder test to verify that IDs produced by GenerateUniqueUnorderedID are indeed unordered.

Epic: None

Release note: None