### PR TITLE
plpgsql/parser: do not parse RAISE ... IDENT

### DIFF
--- a/pkg/sql/plpgsql/parser/BUILD.bazel
+++ b/pkg/sql/plpgsql/parser/BUILD.bazel
@@ -64,6 +64,7 @@ go_test(
     data = glob(["testdata/**"]),
     deps = [
         ":plpgparser",
+        "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/sem/plpgsqltree/utils",
         "//pkg/testutils/datapathutils",
         "@com_github_cockroachdb_datadriven//:datadriven",

--- a/pkg/sql/plpgsql/parser/plpgsql.y
+++ b/pkg/sql/plpgsql/parser/plpgsql.y
@@ -1051,14 +1051,6 @@ stmt_raise:
       Options: $5.plpgsqlOptionExprs(),
     }
   }
-| RAISE opt_error_level IDENT opt_option_exprs ';'
-  {
-    $$.val = &plpgsqltree.PLpgSQLStmtRaise{
-      LogLevel: $2,
-      CodeName: $3,
-      Options: $4.plpgsqlOptionExprs(),
-    }
-  }
 | RAISE opt_error_level SQLSTATE SCONST opt_option_exprs ';'
   {
     $$.val = &plpgsqltree.PLpgSQLStmtRaise{

--- a/pkg/sql/plpgsql/parser/testdata/stmt_raise
+++ b/pkg/sql/plpgsql/parser/testdata/stmt_raise
@@ -116,18 +116,20 @@ RAISE SQLSTATE '222222'
 USING HINT = hm;
 END
 
-parse
+error
 DECLARE
 BEGIN
   RAISE internal_screaming;
 END
 ----
+at or near "internal_screaming": syntax error
+DETAIL: source SQL:
 DECLARE
 BEGIN
-RAISE internal_screaming;
-END
+  RAISE internal_screaming;
+        ^
 
-parse
+error
 DECLARE
 BEGIN
   RAISE internal_screaming
@@ -135,9 +137,9 @@ BEGIN
         COLUMN = 'foo';
 END
 ----
+at or near "internal_screaming": syntax error
+DETAIL: source SQL:
 DECLARE
 BEGIN
-RAISE internal_screaming
-USING MESSAGE = 'blah blah blah',
-COLUMN = 'foo';
-END
+  RAISE internal_screaming
+        ^


### PR DESCRIPTION
#### plpgsql/parser: add error test directive

Release note: None

#### plpgsql/parser: do not parse RAISE ... IDENT

This commit removes support for `RAISE ... IDENT` PL/pgSQL statements.
These are not supported by Postgres - they cause syntax errors.

Epic: CRDB-799

Release note: None
