### PR TITLE
roachtest: wait smaller duration before timining out lease prefs

### DIFF
--- a/pkg/cmd/roachtest/tests/lease_preferences.go
+++ b/pkg/cmd/roachtest/tests/lease_preferences.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -48,11 +49,12 @@ import (
 type leasePreferencesEventFn func(context.Context, test.Test, cluster.Cluster)
 
 type leasePreferencesSpec struct {
-	preferences          string
-	ranges, replFactor   int
-	eventFn              leasePreferencesEventFn
-	checkNodes           []int
-	waitForLessPreferred bool
+	preferences           string
+	ranges, replFactor    int
+	eventFn               leasePreferencesEventFn
+	checkNodes            []int
+	waitForLessPreferred  bool
+	postEventWaitDuration time.Duration
 }
 
 // makeStopNodesEventFn returns a leasePreferencesEventFn which stops the
@@ -103,12 +105,13 @@ func registerLeasePreferences(r registry.Registry) {
 		Cluster:             r.MakeClusterSpec(5, spec.CPU(4)),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runLeasePreferences(ctx, t, c, leasePreferencesSpec{
-				preferences:          `[+dc=1],[+dc=2]`,
-				ranges:               1000,
-				replFactor:           5,
-				checkNodes:           []int{1, 3, 4, 5},
-				eventFn:              makeStopNodesEventFn(2 /* targets */),
-				waitForLessPreferred: false,
+				preferences:           `[+dc=1],[+dc=2]`,
+				ranges:                1000,
+				replFactor:            5,
+				checkNodes:            []int{1, 3, 4, 5},
+				eventFn:               makeStopNodesEventFn(2 /* targets */),
+				waitForLessPreferred:  false,
+				postEventWaitDuration: 10 * time.Minute,
 			})
 		},
 	})
@@ -126,12 +129,13 @@ func registerLeasePreferences(r registry.Registry) {
 		Cluster:             r.MakeClusterSpec(5, spec.CPU(4)),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runLeasePreferences(ctx, t, c, leasePreferencesSpec{
-				preferences:          `[+dc=1],[+dc=2]`,
-				ranges:               1000,
-				replFactor:           5,
-				eventFn:              makeStopNodesEventFn(1, 2 /* targets */),
-				checkNodes:           []int{3, 4, 5},
-				waitForLessPreferred: false,
+				preferences:           `[+dc=1],[+dc=2]`,
+				ranges:                1000,
+				replFactor:            5,
+				eventFn:               makeStopNodesEventFn(1, 2 /* targets */),
+				checkNodes:            []int{3, 4, 5},
+				waitForLessPreferred:  false,
+				postEventWaitDuration: 10 * time.Minute,
 			})
 		},
 	})
@@ -150,8 +154,9 @@ func registerLeasePreferences(r registry.Registry) {
 				replFactor:  5,
 				eventFn: makeTransferLeasesEventFn(
 					5 /* gateway */, 5 /* target */),
-				checkNodes:           []int{1, 2, 3, 4, 5},
-				waitForLessPreferred: false,
+				checkNodes:            []int{1, 2, 3, 4, 5},
+				waitForLessPreferred:  false,
+				postEventWaitDuration: 10 * time.Minute,
 			})
 		},
 	})
@@ -223,7 +228,7 @@ func runLeasePreferences(
 
 	checkLeasePreferenceConformance := func(ctx context.Context) {
 		result, err := waitForLeasePreferences(
-			ctx, t, c, spec.checkNodes, spec.waitForLessPreferred, stableDuration)
+			ctx, t, c, spec.checkNodes, spec.waitForLessPreferred, stableDuration, spec.postEventWaitDuration)
 		require.NoError(t, err, result)
 		require.Truef(t, !result.violating(), "violating lease preferences %s", result)
 		if spec.waitForLessPreferred {
@@ -329,7 +334,7 @@ func waitForLeasePreferences(
 	c cluster.Cluster,
 	nodes []int,
 	waitForLessPreferred bool,
-	stableDuration time.Duration,
+	stableDuration, maxWaitDuration time.Duration,
 ) (leasePreferencesResult, error) {
 	// NB: We are querying metrics, expect these to be populated approximately
 	// every 10s.
@@ -361,6 +366,8 @@ func waitForLeasePreferences(
 		select {
 		case <-ctx.Done():
 			return ret, ctx.Err()
+		case <-time.After(maxWaitDuration):
+			return ret, errors.Errorf("timed out before lease preferences satisfied")
 		case <-checkTimer.C:
 			checkTimer.Read = true
 			violating, lessPreferred := preferenceMetrics(ctx)


### PR DESCRIPTION
Previously, the `lease-preferences` roachtests would fail on the test
tiemout, despite the test actually failing much earlier. 5 minutes
stopping a node, the node is considered dead, and up-replication will
begin. If the cluster doesn't satisfy lease preferences within that 5
minute window, the test will reliably fail -- making the remainder of
the test timeout (30 or 60 minutes), wasted time.

Fail earlier, by adhering to a post event timeout. This timeout set to
10 minutes.

Informs: https://github.com/cockroachdb/cockroach/issues/108425
Epic: none
Release note: None