### PR TITLE
roachtest: better failure message for c2c roachtests

### DIFF
--- a/pkg/cmd/roachtest/tests/cluster_to_cluster.go
+++ b/pkg/cmd/roachtest/tests/cluster_to_cluster.go
@@ -749,6 +749,8 @@ func (rd *replicationDriver) main(ctx context.Context) {
 	rd.checkParticipatingNodes(ingestionJobID)
 
 	retainedTime := rd.getReplicationRetainedTime()
+	require.GreaterOrEqual(rd.t, cutoverTime, retainedTime,
+		"cannot cutover to a time below the retained time (did the test already fail?)")
 
 	rd.metrics.cutoverTo = newMetricSnapshot(metricSnapper, cutoverTime)
 	rd.metrics.cutoverStart = newMetricSnapshot(metricSnapper, timeutil.Now())


### PR DESCRIPTION
In some failures cases the c2c roachtests may try to cutover even though the replication did not start successfully. This patch makes sure we fail with a more clear error in those cases.

Epic: none
Fixes: #107935

Release note: None