### PR TITLE
kv: unimplement MockTransactionalSender.ManualRestart

### DIFF
--- a/pkg/kv/mock_transactional_sender.go
+++ b/pkg/kv/mock_transactional_sender.go
@@ -145,10 +145,9 @@ func (m *MockTransactionalSender) RequiredFrontier() hlc.Timestamp {
 
 // ManualRestart is part of the TxnSender interface.
 func (m *MockTransactionalSender) ManualRestart(
-	ctx context.Context, pri roachpb.UserPriority, ts hlc.Timestamp, msg redact.RedactableString,
+	context.Context, roachpb.UserPriority, hlc.Timestamp, redact.RedactableString,
 ) error {
-	m.txn.Restart(pri, 0 /* upgradePriority */, ts)
-	return kvpb.NewTransactionRetryWithProtoRefreshError(msg, m.txn.ID, m.txn)
+	panic("unimplemented")
 }
 
 // IsSerializablePushAndRefreshNotPossible is part of the TxnSender interface.


### PR DESCRIPTION
The code is dead, so remove it.

Epic: None
Release note: None