### PR TITLE
sql: don't start default test tenant in MT admin function tests

### DIFF
--- a/pkg/sql/create_as_test.go
+++ b/pkg/sql/create_as_test.go
@@ -325,6 +325,7 @@ AND status != 'succeeded'`
 
 func TestFormat(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
 
 	testCases := []struct {
 		sql            string

--- a/pkg/sql/create_function_test.go
+++ b/pkg/sql/create_function_test.go
@@ -151,6 +151,7 @@ SELECT nextval(105:::REGCLASS);`,
 
 func TestVersionGatingUDFInCheckConstraints(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
 
 	t.Run("new_schema_changer_version_enabled", func(t *testing.T) {
 		params, _ := createTestServerParams()

--- a/pkg/sql/multitenant_admin_function_test.go
+++ b/pkg/sql/multitenant_admin_function_test.go
@@ -246,7 +246,7 @@ func (tc testCase) runTest(
 	if numNodes == 0 {
 		numNodes = 1
 	}
-	cfg.ServerArgs.DefaultTestTenant = base.TestTenantProbabilistic
+	cfg.ServerArgs.DefaultTestTenant = base.TestControlsTenantsExplicitly
 	testCluster := serverutils.StartNewTestCluster(t, numNodes, cfg.TestClusterArgs)
 	defer testCluster.Stopper().Stop(ctx)
 

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -7586,6 +7586,7 @@ CREATE TABLE t.test (pk INT PRIMARY KEY, v INT);
 // to conclude. If the locks were not dropped, a deadlock could occur.
 func TestConcurrentSchemaChangesDoNotDeadlock(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
 	s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{})

--- a/pkg/sql/sequence_test.go
+++ b/pkg/sql/sequence_test.go
@@ -115,6 +115,7 @@ func BenchmarkUniqueRowID(b *testing.B) {
 // - ownership removal
 func TestSequenceOwnershipDependencies(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
 	params := base.TestServerArgs{}


### PR DESCRIPTION
These tests themselves start multiple tenants, so there is no need to create a default test tenant (doing that also makes it a bit more confusing because the default tenant as well as the first test tenant share the same TenantID effectively making it two SQL pod config, which is confusing). Starting the default test tenant was enabled recently in c8996612ac823b1e65028a8b4eb8e3f8d778138e when we enabled the CCL license, and we have seen at least one confusing failure that is possibly related to this.

Starting the default test tenant was originally added in cfa437560c93dd07fae2ac804c757842eca5d369, but I don't see a good reason for it.

This PR is opportunistic fix of #108081.

Fixes: #108081.

Release note: None