### PR TITLE
kvstreamer: add more assertions to RequestsProvider.enqueue

### DIFF
--- a/pkg/kv/kvclient/kvstreamer/requests_provider.go
+++ b/pkg/kv/kvclient/kvstreamer/requests_provider.go
@@ -264,6 +264,9 @@ func (p *outOfOrderRequestsProvider) enqueue(requests []singleRangeBatch) {
 	if len(p.requests) > 0 {
 		panic(errors.AssertionFailedf("outOfOrderRequestsProvider has old requests in enqueue"))
 	}
+	if len(requests) == 0 {
+		panic(errors.AssertionFailedf("outOfOrderRequestsProvider enqueuing zero requests"))
+	}
 	p.requests = requests
 	p.hasWork.Signal()
 }
@@ -387,6 +390,9 @@ func (p *inOrderRequestsProvider) enqueue(requests []singleRangeBatch) {
 	defer p.Unlock()
 	if len(p.requests) > 0 {
 		panic(errors.AssertionFailedf("inOrderRequestsProvider has old requests in enqueue"))
+	}
+	if len(requests) == 0 {
+		panic(errors.AssertionFailedf("inOrderRequestsProvider enqueuing zero requests"))
 	}
 	p.requests = requests
 	p.heapInit()


### PR DESCRIPTION
If we ever enqueue zero-length requests, it could cause a deadlock where the `workerCoordinator` is waiting for more requests and the enqueuer is waiting for results. Add assertions that we never do this.

Informs: #101823
Release note: None