### PR TITLE
sql: do not evaluate AOST timestamp in session migrations

### DIFF
--- a/pkg/sql/testdata/session_migration/prepared_statements
+++ b/pkg/sql/testdata/session_migration/prepared_statements
@@ -33,6 +33,11 @@ wire_prepare s4
 INSERT INTO t2 VALUES($1, $2)
 ----
 
+# Regression test for transferring statements with AOST.
+wire_prepare s5
+SELECT a, b FROM t2 AS OF SYSTEM TIME '-2us'
+----
+
 wire_prepare s_empty
 ;
 ----
@@ -99,6 +104,15 @@ wire_exec s4 1 cat
 
 query
 SELECT * FROM t2
+----
+1 cat
+
+query
+SELECT pg_sleep(0.1)
+----
+true
+
+wire_query s5
 ----
 1 cat
 


### PR DESCRIPTION
fixes https://github.com/cockroachlabs/support/issues/2510
refs https://github.com/cockroachdb/cockroach/pull/108305
Release note (bug fix): Fixed a bug where a session migration performed by SHOW TRANSFER STATE would not handle prepared statements that used the AS OF SYSTEM TIME clause. Users who encountered this bug would see errors such as `expected 1 or 0 for number of format codes, got N`. This bug was present since v22.2.0.