### PR TITLE
backupccl: remove spurious print line in test

### DIFF
--- a/pkg/ccl/backupccl/datadriven_test.go
+++ b/pkg/ccl/backupccl/datadriven_test.go
@@ -848,7 +848,6 @@ func runTestDataDriven(t *testing.T, testFilePathFromWorkspace string) {
 			err = ds.getSQLDB(t, cluster, user).QueryRow(filePathQuery).Scan(&filePath)
 			require.NoError(t, err)
 			fullPath := filepath.Join(ds.getIODir(t, cluster), parsedURI.Path, filePath)
-			print(fullPath)
 			data, err := os.ReadFile(fullPath)
 			require.NoError(t, err)
 			data[20] ^= 1


### PR DESCRIPTION
Print statements should not be in commited code

Epic: none

Release note: none