### PR TITLE
roachtest: Abort monitor wait when no tasks exist

### DIFF
--- a/pkg/cmd/roachtest/monitor.go
+++ b/pkg/cmd/roachtest/monitor.go
@@ -188,6 +188,10 @@ func (m *monitorImpl) wait() error {
 			}()
 			setErr(errors.Wrap(m.g.Wait(), "function passed to monitor.Go failed"))
 		}()
+	} else {
+		// If we have no tasks running with this monitor, ensure the
+		// goroutine below terminates.
+		m.cancel()
 	}
 
 	// 2. The second goroutine reads from the monitoring channel, watching for any


### PR DESCRIPTION
PR #107548 introduced a bug where monitor context
is not cancelled if the monitor has no tasks running. In this case, the goroutine waiting for cluster events never terminates (if the cluster is healthy) and the roachtest times out waiting for shutdown.

Fixes #108507
Epic: None

Release note: None