### PR TITLE
roachtest: Ensure tpcc workloads runs for a bit

### DIFF
--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -1327,7 +1327,10 @@ func registerCDC(r registry.Registry) {
 			ct := newCDCTester(ctx, t, c)
 			defer ct.Close()
 
-			ct.runTPCCWorkload(tpccArgs{warehouses: 1})
+			// Run tpcc workload for tiny bit.  Roachtest monitor does not
+			// like when there are no tasks that were started with the monitor
+			// (This can be removed once #108530 resolved).
+			ct.runTPCCWorkload(tpccArgs{warehouses: 1, duration: "30s"})
 
 			kafkaNode := ct.kafkaSinkNode()
 			kafka := kafkaManager{


### PR DESCRIPTION
An issue in roachtest #108530 prevents clean test
termination when calling Wait() on a test monitor
that did not have at least 1 task started.

This cause `cdc/kafka-oauth` test to hang.
Add a '30s' duration to the tpcc task to go around this problem.

Fixes #108507

Release note: None