### PR TITLE
roachtest: remove rangeTs variants of import-cancellation test

### DIFF
--- a/pkg/cmd/roachtest/tests/import_cancellation.go
+++ b/pkg/cmd/roachtest/tests/import_cancellation.go
@@ -29,27 +29,23 @@ import (
 )
 
 func registerImportCancellation(r registry.Registry) {
-	for _, rangeTombstones := range []bool{true, false} {
-		r.Add(registry.TestSpec{
-			Name:      fmt.Sprintf(`import-cancellation/rangeTs=%t`, rangeTombstones),
-			Owner:     registry.OwnerDisasterRecovery,
-			Benchmark: true,
-			Timeout:   4 * time.Hour,
-			Cluster:   r.MakeClusterSpec(6, spec.CPU(32)),
-			Leases:    registry.MetamorphicLeases,
-			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-				if c.Spec().Cloud != spec.GCE {
-					t.Skip("uses gs://cockroach-fixtures; see https://github.com/cockroachdb/cockroach/issues/105968")
-				}
-				runImportCancellation(ctx, t, c, rangeTombstones)
-			},
-		})
-	}
+	r.Add(registry.TestSpec{
+		Name:      `import-cancellation`,
+		Owner:     registry.OwnerDisasterRecovery,
+		Benchmark: true,
+		Timeout:   4 * time.Hour,
+		Cluster:   r.MakeClusterSpec(6, spec.CPU(32)),
+		Leases:    registry.MetamorphicLeases,
+		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			if c.Spec().Cloud != spec.GCE {
+				t.Skip("uses gs://cockroach-fixtures; see https://github.com/cockroachdb/cockroach/issues/105968")
+			}
+			runImportCancellation(ctx, t, c)
+		},
+	})
 }
 
-func runImportCancellation(
-	ctx context.Context, t test.Test, c cluster.Cluster, rangeTombstones bool,
-) {
+func runImportCancellation(ctx context.Context, t test.Test, c cluster.Cluster) {
 	c.Put(ctx, t.Cockroach(), "./cockroach")
 	c.Put(ctx, t.DeprecatedWorkload(), "./workload") // required for tpch
 	c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings())
@@ -79,15 +75,6 @@ func runImportCancellation(
 		t.Fatal(err)
 	}
 	if _, err := conn.Exec(`SET CLUSTER SETTING kv.bulk_ingest.max_index_buffer_size = '2gb'`); err != nil {
-		t.Fatal(err)
-	}
-	// Enable MVCC Range tombstones, if required.
-	rtEnable := "f"
-	if rangeTombstones {
-		rtEnable = "t"
-	}
-	stmt := fmt.Sprintf(`SET CLUSTER SETTING storage.mvcc.range_tombstones.enabled = '%s'`, rtEnable)
-	if _, err := conn.Exec(stmt); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
Previously the import-cancellation roachtest was split into two variants: one with MVCC range tombstones enabled and one without. MVCC range tombstones are always enabled now, so the two variants were effectively identical. This commit consolidates the two tests into a single `import-cancellation` roachtest.

Informs #97869.
Epic: None
Release note: None