### PR TITLE
roachtest: pass artifacts-literal flag to local roachtests

### DIFF
--- a/build/teamcity/cockroach/ci/tests/local_roachtest.sh
+++ b/build/teamcity/cockroach/ci/tests/local_roachtest.sh
@@ -8,6 +8,6 @@ source "$dir/teamcity-support.sh"  # For $root
 source "$dir/teamcity-bazel-support.sh"  # For run_bazel
 
 tc_start_block "Run local roachtests"
-BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="-e COCKROACH_DEV_LICENSE -e BUILD_VCS_NUMBER -e TC_BUILD_ID -e TC_BUILD_BRANCH" \
+BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="-e LITERAL_ARTIFACTS_DIR=$root/artifacts -e COCKROACH_DEV_LICENSE -e BUILD_VCS_NUMBER -e TC_BUILD_ID -e TC_BUILD_BRANCH" \
   run_bazel build/teamcity/cockroach/ci/tests/local_roachtest_impl.sh
 tc_end_block "Run local roachtests"

--- a/build/teamcity/cockroach/ci/tests/local_roachtest_fips.sh
+++ b/build/teamcity/cockroach/ci/tests/local_roachtest_fips.sh
@@ -8,6 +8,6 @@ source "$dir/teamcity-support.sh"  # For $root
 source "$dir/teamcity-bazel-support.sh"  # For run_bazel
 
 tc_start_block "Run local roachtests"
-BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="-e COCKROACH_DEV_LICENSE -e BUILD_VCS_NUMBER -e TC_BUILD_ID -e TC_BUILD_BRANCH" \
+BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="-e LITERAL_ARTIFACTS_DIR=$root/artifacts -e COCKROACH_DEV_LICENSE -e BUILD_VCS_NUMBER -e TC_BUILD_ID -e TC_BUILD_BRANCH" \
   run_bazel_fips build/teamcity/cockroach/ci/tests/local_roachtest_fips_impl.sh
 tc_end_block "Run local roachtests"

--- a/build/teamcity/cockroach/ci/tests/local_roachtest_impl.sh
+++ b/build/teamcity/cockroach/ci/tests/local_roachtest_impl.sh
@@ -27,4 +27,5 @@ $BAZEL_BIN/pkg/cmd/roachtest/roachtest_/roachtest run acceptance kv/splits cdc/b
   --cockroach "$BAZEL_BIN/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short" \
   --workload "$BAZEL_BIN/pkg/cmd/workload/workload_/workload" \
   --artifacts /artifacts \
+  --artifacts-literal="${LITERAL_ARTIFACTS_DIR:-}" \
   --teamcity


### PR DESCRIPTION
Previously, the --artifacts-literal flag was not passed in for local roachtests. In the event of a test failure, roachtest should immediately publish artifacts so they are available to the TeamCity UI before the entire build finishes. Without explicitly passing in the artifacts directory, roachtest is unable to tell TeamCity where to collect a test's artifacts and the immediate publish fails. To address this, an artifacts-literal flag is now passed for local roachtests.

Fixes: #103778

Epic: None

Release note: None