### PR TITLE
internal/sqlsmith: don't generate UDFs with collated strings

### DIFF
--- a/pkg/internal/sqlsmith/relational.go
+++ b/pkg/internal/sqlsmith/relational.go
@@ -1043,7 +1043,7 @@ func (s *Smither) makeCreateFunc() (cf *tree.CreateRoutine, ok bool) {
 				// If the rtype isn't a RECORD, change it to rrefs or RECORD depending
 				// how many columns there are to avoid return type mismatch errors.
 				if rtyp != types.AnyTuple {
-					if len(rrefs) == 1 && s.coin() {
+					if len(rrefs) == 1 && s.coin() && rrefs[0].typ.Family() != types.CollatedStringFamily {
 						rtyp = rrefs[0].typ
 					} else {
 						rtyp = types.AnyTuple


### PR DESCRIPTION
Collated strings are not a valid return type for UDFs in Postgres, so they are disallowed. We already had the check in most places, and the only exception was if we created a mutation with a single RETURNING column of collated string type. This omission is now fixed.

Fixes: #108006.

Release note: None