### PR TITLE
concurrency: refactor LockStateInfo to display shared locks correctly with lock strength

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/cluster_locks_tenant
+++ b/pkg/ccl/logictestccl/testdata/logic_test/cluster_locks_tenant
@@ -79,13 +79,13 @@ SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, d
 FROM crdb_internal.cluster_locks WHERE table_name='t' AND txn_id='$txn1'
 ----
 database_name schema_name table_name  lock_key_pretty     lock_strength   durability   isolation_level   granted  contended
-test          public      t           /Table/106/1/"b"/0  Exclusive       Replicated   SERIALIZABLE      true     true
-test          public      t           /Table/106/1/"c"/0  Exclusive       Replicated   SERIALIZABLE      true     false
-test          public      t           /Table/106/1/"l"/0  Exclusive       Replicated   SERIALIZABLE      true     false
-test          public      t           /Table/106/1/"m"/0  Exclusive       Replicated   SERIALIZABLE      true     false
-test          public      t           /Table/106/1/"p"/0  Exclusive       Replicated   SERIALIZABLE      true     false
-test          public      t           /Table/106/1/"s"/0  Exclusive       Replicated   SERIALIZABLE      true     false
-test          public      t           /Table/106/1/"t"/0  Exclusive       Replicated   SERIALIZABLE      true     false
+test          public      t           /Table/106/1/"b"/0  Intent          Replicated   SERIALIZABLE      true     true
+test          public      t           /Table/106/1/"c"/0  Intent          Replicated   SERIALIZABLE      true     false
+test          public      t           /Table/106/1/"l"/0  Intent          Replicated   SERIALIZABLE      true     false
+test          public      t           /Table/106/1/"m"/0  Intent          Replicated   SERIALIZABLE      true     false
+test          public      t           /Table/106/1/"p"/0  Intent          Replicated   SERIALIZABLE      true     false
+test          public      t           /Table/106/1/"s"/0  Intent          Replicated   SERIALIZABLE      true     false
+test          public      t           /Table/106/1/"t"/0  Intent          Replicated   SERIALIZABLE      true     false
 
 query TTTTTTTBB colnames
 SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, isolation_level, granted, contended
@@ -102,13 +102,13 @@ SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, d
 FROM crdb_internal.cluster_locks WHERE table_name='t' AND txn_id='$txn1'
 ----
 database_name schema_name table_name  lock_key_pretty     lock_strength   durability   isolation_level   granted  contended
-test          public      t           ·                   Exclusive       Replicated   SERIALIZABLE      true    true
-test          public      t           ·                   Exclusive       Replicated   SERIALIZABLE      true    false
-test          public      t           ·                   Exclusive       Replicated   SERIALIZABLE      true    false
-test          public      t           ·                   Exclusive       Replicated   SERIALIZABLE      true    false
-test          public      t           ·                   Exclusive       Replicated   SERIALIZABLE      true    false
-test          public      t           ·                   Exclusive       Replicated   SERIALIZABLE      true    false
-test          public      t           ·                   Exclusive       Replicated   SERIALIZABLE      true    false
+test          public      t           ·                   Intent          Replicated   SERIALIZABLE      true    true
+test          public      t           ·                   Intent          Replicated   SERIALIZABLE      true    false
+test          public      t           ·                   Intent          Replicated   SERIALIZABLE      true    false
+test          public      t           ·                   Intent          Replicated   SERIALIZABLE      true    false
+test          public      t           ·                   Intent          Replicated   SERIALIZABLE      true    false
+test          public      t           ·                   Intent          Replicated   SERIALIZABLE      true    false
+test          public      t           ·                   Intent          Replicated   SERIALIZABLE      true    false
 
 user root
 

--- a/pkg/kv/kvserver/concurrency/lock_table.go
+++ b/pkg/kv/kvserver/concurrency/lock_table.go
@@ -1870,14 +1870,14 @@ func (kl *keyLocks) safeFormat(sb *redact.StringBuilder, txnStatusCache *txnStat
 // includeUncontended is false).
 func (kl *keyLocks) collectLockStateInfo(
 	includeUncontended bool, now time.Time,
-) (bool, roachpb.LockStateInfo) {
+) (bool, []roachpb.LockStateInfo) {
 	kl.mu.Lock()
 	defer kl.mu.Unlock()
 
 	// Don't include locks that have neither lock holders, nor claims, nor
 	// waiting readers/locking requests.
 	if kl.isEmptyLock() {
-		return false, roachpb.LockStateInfo{}
+		return false, []roachpb.LockStateInfo{}
 	}
 
 	// Filter out locks without waiting readers/locking requests unless explicitly
@@ -1890,7 +1890,7 @@ func (kl *keyLocks) collectLockStateInfo(
 	if !includeUncontended && kl.waitingReaders.Len() == 0 &&
 		(kl.queuedLockingRequests.Len() == 0 ||
 			(kl.queuedLockingRequests.Len() == 1 && !kl.queuedLockingRequests.Front().Value.active)) {
-		return false, roachpb.LockStateInfo{}
+		return false, []roachpb.LockStateInfo{}
 	}
 
 	return true, kl.lockStateInfo(now)
@@ -1898,20 +1898,7 @@ func (kl *keyLocks) collectLockStateInfo(
 
 // lockStateInfo converts receiver to the roachpb.LockStateInfo structure.
 // REQUIRES: kl.mu is locked.
-func (kl *keyLocks) lockStateInfo(now time.Time) roachpb.LockStateInfo {
-	var txnHolder *enginepb.TxnMeta
-
-	durability := lock.Unreplicated
-	if kl.isLocked() {
-		// This doesn't work with multiple lock holders. See
-		// https://github.com/cockroachdb/cockroach/issues/109081.
-		tl := kl.holders.Front().Value
-		txnHolder = tl.txn
-		if tl.isHeldReplicated() {
-			durability = lock.Replicated
-		}
-	}
-
+func (kl *keyLocks) lockStateInfo(now time.Time) []roachpb.LockStateInfo {
 	waiterCount := kl.waitingReaders.Len() + kl.queuedLockingRequests.Len()
 	lockWaiters := make([]lock.Waiter, 0, waiterCount)
 
@@ -1942,13 +1929,37 @@ func (kl *keyLocks) lockStateInfo(now time.Time) roachpb.LockStateInfo {
 		g.mu.Unlock()
 	}
 
-	return roachpb.LockStateInfo{
-		Key:          kl.key,
-		LockHolder:   txnHolder,
-		Durability:   durability,
-		HoldDuration: kl.lockHeldDuration(now),
-		Waiters:      lockWaiters,
+	if !kl.isLocked() {
+		return []roachpb.LockStateInfo{
+			{
+				Key:          kl.key,
+				LockHolder:   nil,
+				Durability:   lock.Unreplicated,
+				HoldDuration: kl.lockHeldDuration(now),
+				Waiters:      lockWaiters,
+				LockStrength: lock.None,
+			},
+		}
 	}
+
+	var lockStateInfos []roachpb.LockStateInfo
+	for e := kl.holders.Front(); e != nil; e = e.Next() {
+		tl := e.Value
+		durability := lock.Unreplicated
+		if tl.isHeldReplicated() {
+			durability = lock.Replicated
+		}
+		lsi := roachpb.LockStateInfo{
+			Key:          kl.key,
+			LockHolder:   tl.txn,
+			Durability:   durability,
+			HoldDuration: now.Sub(tl.startTime),
+			Waiters:      lockWaiters,
+			LockStrength: tl.getLockMode().Strength,
+		}
+		lockStateInfos = append(lockStateInfos, lsi)
+	}
+	return lockStateInfos
 }
 
 // addToMetrics adds the receiver's state to the provided metrics struct.
@@ -4359,24 +4370,26 @@ func (t *lockTableImpl) QueryLockTableState(
 	for iter.FirstOverlap(ltRange); iter.Valid(); iter.NextOverlap(ltRange) {
 		l := iter.Cur()
 
-		if ok, lInfo := l.collectLockStateInfo(opts.IncludeUncontended, now); ok {
-			nextKey = l.key
-			nextByteSize = int64(lInfo.Size())
-			lInfo.RangeID = t.rID
+		if ok, lInfos := l.collectLockStateInfo(opts.IncludeUncontended, now); ok {
+			for _, lInfo := range lInfos {
+				nextKey = l.key
+				nextByteSize = int64(lInfo.Size())
+				lInfo.RangeID = t.rID
 
-			// Check if adding the lock would exceed our byte or count limits,
-			// though we must ensure we return at least one lock.
-			if len(lockTableState) > 0 && opts.TargetBytes > 0 && (numBytes+nextByteSize) > opts.TargetBytes {
-				resumeState.ResumeReason = kvpb.RESUME_BYTE_LIMIT
-				break
-			} else if len(lockTableState) > 0 && opts.MaxLocks > 0 && numLocks >= opts.MaxLocks {
-				resumeState.ResumeReason = kvpb.RESUME_KEY_LIMIT
-				break
+				// Check if adding the lock would exceed our byte or count limits,
+				// though we must ensure we return at least one lock.
+				if len(lockTableState) > 0 && opts.TargetBytes > 0 && (numBytes+nextByteSize) > opts.TargetBytes {
+					resumeState.ResumeReason = kvpb.RESUME_BYTE_LIMIT
+					break
+				} else if len(lockTableState) > 0 && opts.MaxLocks > 0 && numLocks >= opts.MaxLocks {
+					resumeState.ResumeReason = kvpb.RESUME_KEY_LIMIT
+					break
+				}
+
+				lockTableState = append(lockTableState, lInfo)
+				numLocks++
+				numBytes += nextByteSize
 			}
-
-			lockTableState = append(lockTableState, lInfo)
-			numLocks++
-			numBytes += nextByteSize
 		}
 	}
 

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/basic
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/basic
@@ -270,7 +270,7 @@ num=5
 
 query
 ----
-num locks: 1, bytes returned: 83, resume reason: RESUME_UNKNOWN, resume span: <nil>
+num locks: 1, bytes returned: 85, resume reason: RESUME_UNKNOWN, resume span: <nil>
  locks:
   range_id=3 key="a" holder=00000000-0000-0000-0000-000000000003 durability=Replicated duration=2s
    waiters:
@@ -712,7 +712,7 @@ topklocksbywaitduration:
 
 query
 ----
-num locks: 3, bytes returned: 286, resume reason: RESUME_UNKNOWN, resume span: <nil>
+num locks: 3, bytes returned: 288, resume reason: RESUME_UNKNOWN, resume span: <nil>
  locks:
   range_id=3 key="a" holder=00000000-0000-0000-0000-000000000003 durability=Replicated duration=2.65s
    waiters:
@@ -883,7 +883,7 @@ topklocksbywaitduration:
 
 query
 ----
-num locks: 3, bytes returned: 266, resume reason: RESUME_UNKNOWN, resume span: <nil>
+num locks: 3, bytes returned: 268, resume reason: RESUME_UNKNOWN, resume span: <nil>
  locks:
   range_id=3 key="b" holder=<nil> durability=Unreplicated duration=0s
    waiters:

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/query
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/query
@@ -45,7 +45,7 @@ num locks: 0, bytes returned: 0, resume reason: RESUME_UNKNOWN, resume span: <ni
 
 query span=a,d uncontended
 ----
-num locks: 1, bytes returned: 39, resume reason: RESUME_UNKNOWN, resume span: <nil>
+num locks: 1, bytes returned: 41, resume reason: RESUME_UNKNOWN, resume span: <nil>
  locks:
   range_id=3 key="c" holder=00000000-0000-0000-0000-000000000001 durability=Unreplicated duration=0s
 
@@ -82,14 +82,14 @@ num=3
 
 query span=a,f max-locks=2 uncontended
 ----
-num locks: 2, bytes returned: 78, resume reason: RESUME_KEY_LIMIT, resume span: {e-f}
+num locks: 2, bytes returned: 82, resume reason: RESUME_KEY_LIMIT, resume span: {e-f}
  locks:
   range_id=3 key="b" holder=00000000-0000-0000-0000-000000000001 durability=Unreplicated duration=0s
   range_id=3 key="c" holder=00000000-0000-0000-0000-000000000001 durability=Unreplicated duration=0s
 
 query span=a,f max-bytes=50 uncontended
 ----
-num locks: 1, bytes returned: 39, resume reason: RESUME_BYTE_LIMIT, resume span: {c-f}
+num locks: 1, bytes returned: 41, resume reason: RESUME_BYTE_LIMIT, resume span: {e-f}
  locks:
   range_id=3 key="b" holder=00000000-0000-0000-0000-000000000001 durability=Unreplicated duration=0s
 
@@ -97,7 +97,7 @@ num locks: 1, bytes returned: 39, resume reason: RESUME_BYTE_LIMIT, resume span:
 
 query span=a,f max-bytes=10 uncontended
 ----
-num locks: 1, bytes returned: 39, resume reason: RESUME_BYTE_LIMIT, resume span: {c-f}
+num locks: 1, bytes returned: 41, resume reason: RESUME_BYTE_LIMIT, resume span: {e-f}
  locks:
   range_id=3 key="b" holder=00000000-0000-0000-0000-000000000001 durability=Unreplicated duration=0s
 
@@ -149,7 +149,7 @@ num=3
 
 query span=a,/Max max-bytes=100
 ----
-num locks: 1, bytes returned: 89, resume reason: RESUME_BYTE_LIMIT, resume span: {e-/Max}
+num locks: 1, bytes returned: 91, resume reason: RESUME_BYTE_LIMIT, resume span: {e-/Max}
  locks:
   range_id=3 key="b" holder=00000000-0000-0000-0000-000000000001 durability=Unreplicated duration=200ms
    waiters:
@@ -157,7 +157,7 @@ num locks: 1, bytes returned: 89, resume reason: RESUME_BYTE_LIMIT, resume span:
 
 query span=b max-bytes=100
 ----
-num locks: 1, bytes returned: 89, resume reason: RESUME_UNKNOWN, resume span: <nil>
+num locks: 1, bytes returned: 91, resume reason: RESUME_UNKNOWN, resume span: <nil>
  locks:
   range_id=3 key="b" holder=00000000-0000-0000-0000-000000000001 durability=Unreplicated duration=200ms
    waiters:
@@ -165,7 +165,7 @@ num locks: 1, bytes returned: 89, resume reason: RESUME_UNKNOWN, resume span: <n
 
 query span=e,/Max max-bytes=100
 ----
-num locks: 1, bytes returned: 89, resume reason: RESUME_UNKNOWN, resume span: <nil>
+num locks: 1, bytes returned: 91, resume reason: RESUME_UNKNOWN, resume span: <nil>
  locks:
   range_id=3 key="e" holder=00000000-0000-0000-0000-000000000001 durability=Unreplicated duration=200ms
    waiters:

--- a/pkg/roachpb/data.proto
+++ b/pkg/roachpb/data.proto
@@ -611,6 +611,8 @@ message LockStateInfo {
   // The readers and writers currently waiting on the lock.  Stable ordering
   // is not guaranteed.
   repeated kv.kvserver.concurrency.lock.Waiter waiters = 6 [(gogoproto.nullable) = false];
+  // The strength of the lock is being held at.
+  kv.kvserver.concurrency.lock.Strength lock_strength = 7;
 }
 
 // A SequencedWrite is a point write to a key with a certain sequence number.

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -34,7 +34,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/lock"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvflowcontrol/kvflowinspectpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness/livenesspb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/protectedts/ptpb"
@@ -7940,6 +7939,8 @@ func genClusterLocksGenerator(
 		}
 
 		var curLock *roachpb.LockStateInfo
+		// Used to deduplicate waiter information from shared locks.
+		var prevLock *roachpb.LockStateInfo
 		var fErr error
 		waiterIdx := -1
 		// Flatten response such that both lock holders and lock waiters are each
@@ -7948,8 +7949,14 @@ func genClusterLocksGenerator(
 		// each waiter, prior to moving onto the next lock (or fetching additional
 		// results as necessary).
 		return func() (tree.Datums, error) {
+			lockHasWaitersDeduped := false
 			if curLock == nil || waiterIdx >= len(curLock.Waiters) {
+				prevLock = curLock
 				curLock, fErr = getNextLock()
+				if prevLock != nil && curLock != nil && prevLock.Key.Equal(curLock.Key) {
+					lockHasWaitersDeduped = len(curLock.Waiters) > 0
+					curLock.Waiters = curLock.Waiters[:0]
+				}
 				waiterIdx = -1
 			}
 
@@ -7958,7 +7965,6 @@ func genClusterLocksGenerator(
 			if curLock == nil || fErr != nil {
 				return nil, fErr
 			}
-
 			strengthDatum := tree.DNull
 			txnIDDatum := tree.DNull
 			tsDatum := tree.DNull
@@ -7969,7 +7975,7 @@ func genClusterLocksGenerator(
 				if curLock.LockHolder != nil {
 					txnIDDatum = tree.NewDUuid(tree.DUuid{UUID: curLock.LockHolder.ID})
 					tsDatum = eval.TimestampToInexactDTimestamp(curLock.LockHolder.WriteTimestamp)
-					strengthDatum = tree.NewDString(lock.Exclusive.String())
+					strengthDatum = tree.NewDString(curLock.LockStrength.String())
 					durationDatum = tree.NewDInterval(
 						duration.MakeDuration(curLock.HoldDuration.Nanoseconds(), 0 /* days */, 0 /* months */),
 						types.DefaultIntervalTypeMetadata,
@@ -8002,7 +8008,7 @@ func genClusterLocksGenerator(
 				keyOrRedacted, _, _ = keys.DecodeTenantPrefix(curLock.Key)
 				prettyKeyOrRedacted = keys.PrettyPrint(nil /* valDirs */, keyOrRedacted)
 			}
-
+			contented := lockHasWaitersDeduped || len(curLock.Waiters) > 0
 			return tree.Datums{
 				tree.NewDInt(tree.DInt(curLock.RangeID)),     /* range_id */
 				tree.NewDInt(tree.DInt(tableID)),             /* table_id */
@@ -8017,7 +8023,7 @@ func genClusterLocksGenerator(
 				strengthDatum,                                /* lock_strength */
 				tree.NewDString(curLock.Durability.String()), /* durability */
 				tree.MakeDBool(tree.DBool(granted)),          /* granted */
-				tree.MakeDBool(len(curLock.Waiters) > 0),     /* contended */
+				tree.MakeDBool(tree.DBool(contented)),        /* contended */
 				durationDatum,                                /* duration */
 				tree.NewDString(tree.IsolationLevelFromKVTxnIsolationLevel(curLock.LockHolder.IsoLevel).String()), /* isolation_level */
 			}, nil

--- a/pkg/sql/logictest/testdata/logic_test/cluster_locks
+++ b/pkg/sql/logictest/testdata/logic_test/cluster_locks
@@ -102,8 +102,8 @@ query TTTTTTTBB colnames,retry,rowsort
 SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, isolation_level, granted, contended FROM crdb_internal.cluster_locks WHERE range_id=$r1 AND txn_id='$txn1'
 ----
 database_name schema_name table_name  lock_key_pretty     lock_strength   durability   isolation_level   granted contended
-test          public      t           /Table/106/1/"b"/0  Exclusive       Replicated   SERIALIZABLE      true    true
-test          public      t           /Table/106/1/"c"/0  Exclusive       Replicated   SERIALIZABLE      true    false
+test          public      t           /Table/106/1/"b"/0  Intent          Replicated   SERIALIZABLE      true    true
+test          public      t           /Table/106/1/"c"/0  Intent          Replicated   SERIALIZABLE      true    false
 
 query TTTTTTTBB colnames
 SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, isolation_level, granted, contended FROM crdb_internal.cluster_locks WHERE range_id=$r1 AND txn_id='$txn2'
@@ -140,8 +140,8 @@ query TTTTTTTBB colnames,rowsort
 SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, isolation_level, granted, contended FROM crdb_internal.cluster_locks WHERE range_id=$r1 AND txn_id='$txn1'
 ----
 database_name schema_name table_name  lock_key_pretty     lock_strength   durability   isolation_level   granted contended
-test          public      t           ·                   Exclusive       Replicated   SERIALIZABLE      true    true
-test          public      t           ·                   Exclusive       Replicated   SERIALIZABLE      true    false
+test          public      t           ·                   Intent          Replicated   SERIALIZABLE      true    true
+test          public      t           ·                   Intent          Replicated   SERIALIZABLE      true    false
 
 user root
 
@@ -149,30 +149,30 @@ query TTTTTTTBB colnames,retry,rowsort
 SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, isolation_level, granted, contended FROM crdb_internal.cluster_locks WHERE database_name='test'
 ----
 database_name schema_name table_name  lock_key_pretty     lock_strength   durability   isolation_level   granted contended
-test          public      t           /Table/106/1/"b"/0  Exclusive       Replicated   SERIALIZABLE      true    true
+test          public      t           /Table/106/1/"b"/0  Intent          Replicated   SERIALIZABLE      true    true
 test          public      t           /Table/106/1/"b"/0  None            Replicated   SERIALIZABLE      false   true
-test          public      t           /Table/106/1/"c"/0  Exclusive       Replicated   SERIALIZABLE      true    false
+test          public      t           /Table/106/1/"c"/0  Intent          Replicated   SERIALIZABLE      true    false
 
 query TTTTTTTBB colnames,retry,rowsort
 SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, isolation_level, granted, contended FROM crdb_internal.cluster_locks WHERE table_id='t'::regclass::oid::int
 ----
 database_name schema_name table_name  lock_key_pretty     lock_strength   durability   isolation_level   granted contended
-test          public      t           /Table/106/1/"b"/0  Exclusive       Replicated   SERIALIZABLE      true    true
+test          public      t           /Table/106/1/"b"/0  Intent          Replicated   SERIALIZABLE      true    true
 test          public      t           /Table/106/1/"b"/0  None            Replicated   SERIALIZABLE      false   true
-test          public      t           /Table/106/1/"c"/0  Exclusive       Replicated   SERIALIZABLE      true    false
+test          public      t           /Table/106/1/"c"/0  Intent          Replicated   SERIALIZABLE      true    false
 
 query TTTTTTTBB colnames,retry,rowsort
 SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, isolation_level, granted, contended FROM crdb_internal.cluster_locks WHERE contended=true AND lock_key_pretty LIKE '/Table/106%'
 ----
 database_name schema_name table_name  lock_key_pretty     lock_strength   durability   isolation_level   granted contended
-test          public      t           /Table/106/1/"b"/0  Exclusive       Replicated   SERIALIZABLE      true    true
+test          public      t           /Table/106/1/"b"/0  Intent          Replicated   SERIALIZABLE      true    true
 test          public      t           /Table/106/1/"b"/0  None            Replicated   SERIALIZABLE      false   true
 
 query TTTTTTTBB colnames,retry
 SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, isolation_level, granted, contended FROM crdb_internal.cluster_locks WHERE contended=false AND lock_key_pretty LIKE '/Table/106%'
 ----
 database_name schema_name table_name  lock_key_pretty     lock_strength   durability   isolation_level   granted contended
-test          public      t           /Table/106/1/"c"/0  Exclusive       Replicated   SERIALIZABLE      true    false
+test          public      t           /Table/106/1/"c"/0  Intent          Replicated   SERIALIZABLE      true    false
 
 query I
 SELECT count(*) FROM crdb_internal.cluster_locks WHERE table_name = 't'

--- a/pkg/sql/logictest/testdata/logic_test/select_for_share
+++ b/pkg/sql/logictest/testdata/logic_test/select_for_share
@@ -42,19 +42,13 @@ user testuser2
 statement async writeReq count 1
 UPDATE t SET a = 2 WHERE a = 1
 
-# TODO(arul): Until https://github.com/cockroachdb/cockroach/issues/107766 is
-# addressed, we'll incorrectly report shared locks as having "Exclusive" lock
-# strength; We'll also only report a single holder (the other row in there is
-# the waiting UPDATE request, not the second shared lock holder). However,
-# having this query in here is useful to make sure there are locks and waiters
-# on our key, meaning setting the cluster setting above actually did something;
-# otherwise, had we used non-locking reads, we'd have failed here.
 query TTTTTTTBB colnames,retry,rowsort
 SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, isolation_level, granted, contended FROM crdb_internal.cluster_locks
 ----
 database_name  schema_name  table_name  lock_key_pretty   lock_strength  durability    isolation_level  granted  contended
-test           public       t           /Table/106/1/1/0  Exclusive      Unreplicated  SERIALIZABLE     true     true
+test           public       t           /Table/106/1/1/0  Shared         Unreplicated  SERIALIZABLE     true     true
 test           public       t           /Table/106/1/1/0  Exclusive      Unreplicated  SERIALIZABLE     false    true
+test           public       t           /Table/106/1/1/0  Shared         Unreplicated  SERIALIZABLE     true     true
 
 # Commit the first transaction and rollback the second.
 


### PR DESCRIPTION
Fixes: https://github.com/cockroachdb/cockroach/issues/107766
This pr decouples the LockStateInfo to keyLocks struct as many to one relationship to better reflect shared locks. crdb_internal.cluster_locks
will be reflecting the correct lock holders and lock strengthes.

Release note: None.