### PR TITLE
release-23.1: sql: do not evaluate AOST timestamp in session migrations

### DIFF
--- a/pkg/ccl/testccl/sqlccl/BUILD.bazel
+++ b/pkg/ccl/testccl/sqlccl/BUILD.bazel
@@ -62,6 +62,7 @@ go_test(
         "@com_github_cockroachdb_redact//:redact",
         "@com_github_gogo_protobuf//types",
         "@com_github_jackc_pgx_v4//:pgx",
+        "@com_github_jackc_pgx_v5//:pgx",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/ccl/testccl/sqlccl/show_transfer_state_test.go
+++ b/pkg/ccl/testccl/sqlccl/show_transfer_state_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/jackc/pgx/v5"
 	"github.com/stretchr/testify/require"
 )
 
@@ -37,6 +38,8 @@ func TestShowTransferState(t *testing.T) {
 	_, err := tenantDB.Exec("CREATE USER testuser WITH PASSWORD 'hunter2'")
 	require.NoError(t, err)
 	_, err = mainDB.Exec("ALTER TENANT ALL SET CLUSTER SETTING server.user_login.session_revival_token.enabled = true")
+	require.NoError(t, err)
+	_, err = tenantDB.Exec("CREATE TYPE typ AS ENUM ('foo', 'bar')")
 	require.NoError(t, err)
 
 	t.Run("without_transfer_key", func(t *testing.T) {
@@ -89,24 +92,30 @@ func TestShowTransferState(t *testing.T) {
 		q := pgURL.Query()
 		q.Add("application_name", "carl")
 		pgURL.RawQuery = q.Encode()
-		conn, err := gosql.Open("postgres", pgURL.String())
+		conn, err := pgx.Connect(ctx, pgURL.String())
 		require.NoError(t, err)
-		defer conn.Close()
+		defer func() { _ = conn.Close(ctx) }()
 
 		// Add a prepared statement to make sure SHOW TRANSFER STATE handles it.
-		// Since lib/pq doesn't tell us the name of the prepared statement, we won't
-		// be able to test that we can use it after deserializing the session, but
-		// there are other tests for that.
-		stmt, err := conn.Prepare("SELECT 1 WHERE 1 = 1")
+		_, err = conn.Prepare(ctx, "prepared_stmt", "SELECT $1::INT4, 'foo'::typ WHERE 1 = 1")
 		require.NoError(t, err)
-		defer stmt.Close()
 
-		rows, err := conn.Query(`SHOW TRANSFER STATE WITH 'foobar'`)
+		var intResult int
+		var enumResult string
+		err = conn.QueryRow(ctx, "prepared_stmt", 1).Scan(&intResult, &enumResult)
+		require.NoError(t, err)
+		require.Equal(t, 1, intResult)
+		require.Equal(t, "foo", enumResult)
+
+		rows, err := conn.Query(ctx, `SHOW TRANSFER STATE WITH 'foobar'`, pgx.QueryExecModeSimpleProtocol)
 		require.NoError(t, err, "show transfer state failed")
 		defer rows.Close()
 
-		resultColumns, err := rows.Columns()
-		require.NoError(t, err)
+		fieldDescriptions := rows.FieldDescriptions()
+		var resultColumns []string
+		for _, f := range fieldDescriptions {
+			resultColumns = append(resultColumns, f.Name)
+		}
 
 		require.Equal(t, []string{
 			"error",
@@ -143,26 +152,40 @@ func TestShowTransferState(t *testing.T) {
 		q.Add("application_name", "someotherapp")
 		q.Add("crdb:session_revival_token_base64", token)
 		pgURL.RawQuery = q.Encode()
-		conn, err := gosql.Open("postgres", pgURL.String())
+		conn, err := pgx.Connect(ctx, pgURL.String())
 		require.NoError(t, err)
-		defer conn.Close()
+		defer func() { _ = conn.Close(ctx) }()
 
 		var appName string
-		err = conn.QueryRow("SHOW application_name").Scan(&appName)
+		err = conn.QueryRow(ctx, "SHOW application_name").Scan(&appName)
 		require.NoError(t, err)
 		require.Equal(t, "someotherapp", appName)
 
 		var b bool
 		err = conn.QueryRow(
+			ctx,
 			"SELECT crdb_internal.deserialize_session(decode($1, 'base64'))",
 			state,
 		).Scan(&b)
 		require.NoError(t, err)
 		require.True(t, b)
 
-		err = conn.QueryRow("SHOW application_name").Scan(&appName)
+		err = conn.QueryRow(ctx, "SHOW application_name").Scan(&appName)
 		require.NoError(t, err)
 		require.Equal(t, "carl", appName)
+
+		// Confirm that the prepared statement can be used after deserializing the
+		// session.
+		result := conn.PgConn().ExecPrepared(
+			ctx,
+			"prepared_stmt",
+			[][]byte{{0, 0, 0, 2}}, // binary representation of 2
+			[]int16{1},             // paramFormats - 1 means binary
+			[]int16{1},             // resultFormats - 1 means binary
+		).Read()
+		require.Equal(t, [][][]byte{{
+			{0, 0, 0, 2}, {0x66, 0x6f, 0x6f}, // binary representation of 2, 'foo'
+		}}, result.Rows)
 	})
 
 	// Errors should be displayed as a SQL value.

--- a/pkg/ccl/testccl/sqlccl/show_transfer_state_test.go
+++ b/pkg/ccl/testccl/sqlccl/show_transfer_state_test.go
@@ -41,6 +41,12 @@ func TestShowTransferState(t *testing.T) {
 	require.NoError(t, err)
 	_, err = tenantDB.Exec("CREATE TYPE typ AS ENUM ('foo', 'bar')")
 	require.NoError(t, err)
+	_, err = tenantDB.Exec("CREATE TABLE tab (a INT4, b typ)")
+	require.NoError(t, err)
+	_, err = tenantDB.Exec("INSERT INTO tab VALUES (1, 'foo')")
+	require.NoError(t, err)
+	_, err = tenantDB.Exec("GRANT SELECT ON tab TO testuser")
+	require.NoError(t, err)
 
 	t.Run("without_transfer_key", func(t *testing.T) {
 		pgURL, cleanup := sqlutils.PGUrl(
@@ -97,12 +103,18 @@ func TestShowTransferState(t *testing.T) {
 		defer func() { _ = conn.Close(ctx) }()
 
 		// Add a prepared statement to make sure SHOW TRANSFER STATE handles it.
-		_, err = conn.Prepare(ctx, "prepared_stmt", "SELECT $1::INT4, 'foo'::typ WHERE 1 = 1")
+		_, err = conn.Prepare(ctx, "prepared_stmt_const", "SELECT $1::INT4, 'foo'::typ WHERE 1 = 1")
+		require.NoError(t, err)
+		_, err = conn.Prepare(ctx, "prepared_stmt_aost", "SELECT a, b FROM tab AS OF SYSTEM TIME '-1us'")
 		require.NoError(t, err)
 
 		var intResult int
 		var enumResult string
-		err = conn.QueryRow(ctx, "prepared_stmt", 1).Scan(&intResult, &enumResult)
+		err = conn.QueryRow(ctx, "prepared_stmt_const", 1).Scan(&intResult, &enumResult)
+		require.NoError(t, err)
+		require.Equal(t, 1, intResult)
+		require.Equal(t, "foo", enumResult)
+		err = conn.QueryRow(ctx, "prepared_stmt_aost").Scan(&intResult, &enumResult)
 		require.NoError(t, err)
 		require.Equal(t, 1, intResult)
 		require.Equal(t, "foo", enumResult)
@@ -178,13 +190,25 @@ func TestShowTransferState(t *testing.T) {
 		// session.
 		result := conn.PgConn().ExecPrepared(
 			ctx,
-			"prepared_stmt",
+			"prepared_stmt_const",
 			[][]byte{{0, 0, 0, 2}}, // binary representation of 2
 			[]int16{1},             // paramFormats - 1 means binary
-			[]int16{1},             // resultFormats - 1 means binary
+			[]int16{1, 1},          // resultFormats - 1 means binary
 		).Read()
+		require.NoError(t, result.Err)
 		require.Equal(t, [][][]byte{{
 			{0, 0, 0, 2}, {0x66, 0x6f, 0x6f}, // binary representation of 2, 'foo'
+		}}, result.Rows)
+		result = conn.PgConn().ExecPrepared(
+			ctx,
+			"prepared_stmt_aost",
+			[][]byte{},    // paramValues
+			[]int16{},     // paramFormats
+			[]int16{1, 1}, // resultFormats - 1 means binary
+		).Read()
+		require.NoError(t, result.Err)
+		require.Equal(t, [][][]byte{{
+			{0, 0, 0, 1}, {0x66, 0x6f, 0x6f}, // binary representation of 1, 'foo'
 		}}, result.Rows)
 	})
 

--- a/pkg/sql/conn_executor_prepare.go
+++ b/pkg/sql/conn_executor_prepare.go
@@ -273,8 +273,12 @@ func (ex *connExecutor) prepare(
 	}
 
 	// Use the existing transaction.
-	if err := prepare(ctx, ex.state.mu.txn); err != nil && origin != PreparedStatementOriginSessionMigration {
-		return nil, err
+	if err := prepare(ctx, ex.state.mu.txn); err != nil {
+		if origin != PreparedStatementOriginSessionMigration {
+			return nil, err
+		} else {
+			log.Warningf(ctx, "could not prepare statement during session migration: %v", err)
+		}
 	}
 
 	// Account for the memory used by this prepared statement.
@@ -305,8 +309,15 @@ func (ex *connExecutor) populatePrepared(
 		return 0, err
 	}
 	p.extendedEvalCtx.PrepareOnly = true
-	if err := ex.handleAOST(ctx, p.stmt.AST); err != nil {
-		return 0, err
+	// If the statement is being prepared by a session migration, then we should
+	// not evaluate the AS OF SYSTEM TIME timestamp. During session migration,
+	// there is no way for the statement being prepared to be executed in this
+	// transaction, so there's no need to fix the timestamp, unlike how we must
+	// for pgwire- or SQL-level prepared statements.
+	if origin != PreparedStatementOriginSessionMigration {
+		if err := ex.handleAOST(ctx, p.stmt.AST); err != nil {
+			return 0, err
+		}
 	}
 
 	// PREPARE has a limited subset of statements it can be run with. Postgres

--- a/pkg/sql/testdata/session_migration/prepared_statements
+++ b/pkg/sql/testdata/session_migration/prepared_statements
@@ -33,6 +33,11 @@ wire_prepare s4
 INSERT INTO t2 VALUES($1, $2)
 ----
 
+# Regression test for transferring statements with AOST.
+wire_prepare s5
+SELECT a, b FROM t2 AS OF SYSTEM TIME '-2us'
+----
+
 wire_prepare s_empty
 ;
 ----
@@ -99,6 +104,15 @@ wire_exec s4 1 cat
 
 query
 SELECT * FROM t2
+----
+1 cat
+
+query
+SELECT pg_sleep(0.1)
+----
+true
+
+wire_query s5
 ----
 1 cat
 


### PR DESCRIPTION
Backport:
  * 1/1 commits from "sqlccl: test prepared statement in session migration test" (#108305)
  * 1/1 commits from "sql: do not evaluate AOST timestamp in session migrations" (#108503)

Please see individual PRs for details.

fixes https://github.com/cockroachlabs/support/issues/2510
Release justification: high priority bug fix
Release note (bug fix): Fixed a bug where a session migration performed
by SHOW TRANSFER STATE would not handle prepared statements that used
the AS OF SYSTEM TIME clause. Users who encountered this bug would see
errors such as `expected 1 or 0 for number of format codes, got N`. This
bug was present since v22.2.0.

/cc @cockroachdb/release
