### PR TITLE
kv: add error return from Txn.PrepareForRetry

### DIFF
--- a/pkg/kv/db_test.go
+++ b/pkg/kv/db_test.go
@@ -872,7 +872,7 @@ func TestPreservingSteppingOnSenderReplacement(t *testing.T) {
 		require.NotEqual(t, pErr.TxnID, pErr.Transaction.ID)
 
 		// Reset the handle in order to get a new sender.
-		txn.PrepareForRetry(ctx)
+		require.NoError(t, txn.PrepareForRetry(ctx))
 
 		// Make sure we have a new txn ID.
 		require.NotEqual(t, pErr.TxnID, txn.ID())

--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender_savepoints_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender_savepoints_test.go
@@ -127,7 +127,9 @@ func TestSavepoints(t *testing.T) {
 
 			case "reset":
 				prevID := txn.ID()
-				txn.PrepareForRetry(ctx)
+				if err := txn.PrepareForRetry(ctx); err != nil {
+					t.Fatal(err)
+				}
 				changed := "changed"
 				if prevID == txn.ID() {
 					changed = "not changed"

--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender_test.go
@@ -912,7 +912,9 @@ func TestTxnCoordSenderTxnUpdatedOnError(t *testing.T) {
 			stopper.Stop(ctx)
 
 			if test.callPrepareForRetry {
-				txn.PrepareForRetry(ctx)
+				if err := txn.PrepareForRetry(ctx); err != nil {
+					t.Fatal(err)
+				}
 			}
 			if test.name != "nil" && err == nil {
 				t.Fatalf("expected an error")


### PR DESCRIPTION
Instead of using `log.Fatal`, return assertion errors.

Epic: None
Release note: None