### PR TITLE
experiment for 102839

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -3281,7 +3281,8 @@ func errIsRetriable(err error) bool {
 		// client in implicit transactions. This is not great; it should
 		// be marked as a client visible retry error.
 		errors.Is(err, descidgen.ErrDescIDSequenceMigrationInProgress) ||
-		descs.IsTwoVersionInvariantViolationError(err)
+		descs.IsTwoVersionInvariantViolationError(err) ||
+		pgerror.IsSQLRetryableError(err)
 }
 
 // convertRetriableErrorIntoUserVisibleError converts internal retriable

--- a/pkg/sql/importer/import_stmt_test.go
+++ b/pkg/sql/importer/import_stmt_test.go
@@ -5417,10 +5417,6 @@ func TestImportWorkerFailure(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	skip.UnderStressWithIssue(t, 102839, "flaky test")
-	skip.UnderDeadlockWithIssue(t, 102839, "flaky test")
-	skip.UnderRaceWithIssue(t, 102839, "flaky test")
-
 	allowResponse := make(chan struct{})
 	params := base.TestClusterArgs{}
 	params.ServerArgs.Knobs.JobsTestingKnobs = jobs.NewTestingKnobsWithShortIntervals()


### PR DESCRIPTION
**importer: completely unskip TestImportWorkerFailure**

Informs: #102839
Release note: None

---

**sql: autoretry transactions on IsSQLRetryableErrors**

Informs: #102839
Release note: None