### PR TITLE
roachtest: start monitoring after `NewMonitor`

### DIFF
--- a/pkg/cmd/roachtest/cluster/monitor_interface.go
+++ b/pkg/cmd/roachtest/cluster/monitor_interface.go
@@ -30,6 +30,7 @@ type Monitor interface {
 	// Wait() or WaitE() before returning.
 	Go(fn func(context.Context) error)
 	GoWithCancel(fn func(context.Context) error) func()
+	WaitForNodeDeath() error
 	WaitE() error
 	Wait()
 }

--- a/pkg/cmd/roachtest/roachtestutil/clusterupgrade/clusterupgrade.go
+++ b/pkg/cmd/roachtest/roachtestutil/clusterupgrade/clusterupgrade.go
@@ -264,7 +264,8 @@ func WaitForClusterUpgrade(
 	// expected cluster version within the given timeout.
 	waitForUpgrade := func(node int, timeout time.Duration) error {
 		var latestVersion roachpb.Version
-		err := retry.ForDuration(timeout, func() error {
+		var opts retry.Options
+		err := opts.Do(ctx, func(ctx context.Context) error {
 			currentVersion, err := ClusterVersion(ctx, dbFunc(node))
 			if err != nil {
 				return err


### PR DESCRIPTION
Epic: none

Release note: None