### PR TITLE
kvstreamer: fix up some comments

### DIFF
--- a/pkg/kv/kvclient/kvstreamer/requests_provider.go
+++ b/pkg/kv/kvclient/kvstreamer/requests_provider.go
@@ -244,8 +244,7 @@ func (b *requestsProviderBase) close() {
 }
 
 // outOfOrderRequestsProvider is a requestProvider that returns requests in an
-// arbitrary order (namely in the same order as the requests are enqueued and
-// added).
+// arbitrary order (namely in the LIFO order of requests being enqueued).
 type outOfOrderRequestsProvider struct {
 	*requestsProviderBase
 }
@@ -283,6 +282,8 @@ func (p *outOfOrderRequestsProvider) nextLocked() singleRangeBatch {
 	if len(p.requests) == 0 {
 		panic(errors.AssertionFailedf("nextLocked called when requestsProvider is empty"))
 	}
+	// Use the last request so that we could reuse its slot if resume request is
+	// added.
 	return p.requests[len(p.requests)-1]
 }
 
@@ -291,6 +292,8 @@ func (p *outOfOrderRequestsProvider) removeNextLocked() {
 	if len(p.requests) == 0 {
 		panic(errors.AssertionFailedf("removeNextLocked called when requestsProvider is empty"))
 	}
+	// Use the last request so that we could reuse its slot if resume request is
+	// added.
 	p.requests = p.requests[:len(p.requests)-1]
 }
 


### PR DESCRIPTION
As of d564a0c11287eb8f46b6e08a5fa5d7cf98d2e829 we no longer use FIFO order in the OutOfOrder requests provider, so this commit adjusts the comments accordingly.

Epic: None

Release note: None