### PR TITLE
release-22.1: acceptance: deflake test_demo_node_cmds

### DIFF
--- a/pkg/cli/interactive_tests/test_demo_node_cmds.tcl
+++ b/pkg/cli/interactive_tests/test_demo_node_cmds.tcl
@@ -64,31 +64,27 @@ send "\\demo restart 3\r"
 eexpect "node 3 has been restarted"
 eexpect "movr>"
 
-# NB: this is flaky, sometimes n3 is still marked as draining due to
-# gossip propagation delays. See:
-# https://github.com/cockroachdb/cockroach/issues/76391
-# send "select node_id, draining, decommissioning, membership from crdb_internal.gossip_liveness ORDER BY node_id;\r"
-# eexpect "1 |  false   |      false      | active"
-# eexpect "2 |  false   |      false      | active"
-# eexpect "3 |  false   |      false      | active"
-# eexpect "4 |  false   |      false      | active"
-# eexpect "5 |  false   |      false      | active"
-# eexpect "movr>"
+send "select node_id, draining, decommissioning, membership from crdb_internal.gossip_liveness ORDER BY node_id;\r"
+eexpect "1 |  false   |      false      | active"
+eexpect "2 |  false   |      false      | active"
+eexpect "3 |  false   |      false      | active"
+eexpect "4 |  false   |      false      | active"
+eexpect "5 |  false   |      false      | active"
+eexpect "movr>"
 
-# Try commissioning commands
+# Try decommissioning commands
 send "\\demo decommission 4\r"
 eexpect "node 4 has been decommissioned"
 eexpect "movr>"
 
-# NB: skipping this out of an abundance of caution, see:
-# https://github.com/cockroachdb/cockroach/issues/76391
-# send "select node_id, draining, decommissioning, membership from crdb_internal.gossip_liveness ORDER BY node_id;\r"
-# eexpect "1 |  false   |      false      | active"
-# eexpect "2 |  false   |      false      | active"
-# eexpect "3 |  false   |      false      | active"
-# eexpect "4 |  false   |      true       | decommissioned"
-# eexpect "5 |  false   |      false      | active"
-# eexpect "movr>"
+send "select node_id, draining, membership from crdb_internal.kv_node_liveness ORDER BY node_id;\r"
+eexpect "1 |  false   | active"
+eexpect "2 |  false   | active"
+eexpect "3 |  false   | active"
+eexpect "4 |  false   | decommissioned"
+eexpect "5 |  false   | active"
+eexpect "movr>"
+
 
 send "\\demo recommission 4\r"
 eexpect "can only recommission a decommissioning node"
@@ -123,17 +119,16 @@ send "\\demo shutdown 6\r"
 eexpect "node 6 has been shutdown"
 eexpect "movr>"
 
-# By now the node should have stabilized in gossip which allows us to query the more detailed information there.
-# NB: skip this to avoid flakes, see:
-# https://github.com/cockroachdb/cockroach/issues/76391
-# send "select node_id, draining, decommissioning, membership from crdb_internal.gossip_liveness ORDER BY node_id;\r"
-# eexpect "1 |  false   |      false      | active"
-# eexpect "2 |  false   |      false      | active"
-# eexpect "3 |  false   |      false      | active"
-# eexpect "4 |  false   |      true       | decommissioned"
-# eexpect "5 |  false   |      false      | active"
-# eexpect "6 |   true   |      false      | active"
-# eexpect "movr>"
+# NB: use kv_node_liveness to avoid flakes due to gossip delays.
+# See https://github.com/cockroachdb/cockroach/issues/76391
+send "select node_id, draining, membership from crdb_internal.kv_node_liveness ORDER BY node_id;\r"
+eexpect "1 |  false   | active"
+eexpect "2 |  false   | active"
+eexpect "3 |  false   | active"
+eexpect "4 |  false   | decommissioned"
+eexpect "5 |  false   | active"
+eexpect "6 |   true   | active"
+eexpect "movr>"
 
 send_eof
 eexpect eof


### PR DESCRIPTION
Backport 1/1 commits from #107140.

/cc @cockroachdb/release

---

Previously the acceptance test `test_demo_node_cmds`, which attempts to shutdown and decommission some nodes using the `cockroach demo` CLI, would sometimes be flaky due to delays in propagating information via gossip. This change fixes these flakes by utilizing the virtual table `crdb_internal.kv_node_liveness` rather than the gossip-based `gossip_liveness` virtual table.

Fixes: #76391

Release note: None

---

Release justification: Test fix.