### PR TITLE
release-23.1: roachtest/awsdms: run once a week instead

### DIFF
--- a/pkg/cmd/roachtest/tests/awsdms.go
+++ b/pkg/cmd/roachtest/tests/awsdms.go
@@ -191,7 +191,7 @@ func registerAWSDMS(r registry.Registry) {
 		Name:    "awsdms",
 		Owner:   registry.OwnerMigrations,
 		Cluster: r.MakeClusterSpec(1),
-		Tags:    []string{`default`, `awsdms`},
+		Tags:    []string{`weekly`, `aws-weekly`},
 		Leases:  registry.MetamorphicLeases,
 		Run:     runAWSDMS,
 	})


### PR DESCRIPTION
Backport 1/1 commits from #108160.

/cc @cockroachdb/release

---

Save a bit of mad dosh by running awsdms once a weekly instead of daily. We don't need this tested every week.

Epic: None

Release note: None

Release justification: test change
