### PR TITLE
kv: introduce `isolation.RunEachLevel` test utility

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
@@ -3938,11 +3938,9 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			for _, isoLevel := range isolation.Levels() {
-				t.Run(isoLevel.String(), func(t *testing.T) {
-					run(t, tc, isoLevel)
-				})
-			}
+			isolation.RunEachLevel(t, func(t *testing.T, isoLevel isolation.Level) {
+				run(t, tc, isoLevel)
+			})
 		})
 	}
 }

--- a/pkg/kv/kvserver/concurrency/isolation/levels.go
+++ b/pkg/kv/kvserver/concurrency/isolation/levels.go
@@ -69,3 +69,16 @@ func (Level) SafeValue() {}
 // Levels returns a list of all isolation levels, ordered from strongest to
 // weakest.
 func Levels() []Level { return []Level{Serializable, Snapshot, ReadCommitted} }
+
+// RunEachLevel calls f in a subtest for each isolation level.
+func RunEachLevel[T testingTB[T]](t T, f func(T, Level)) {
+	for _, l := range Levels() {
+		t.Run(l.String(), func(t T) { f(t, l) })
+	}
+}
+
+// testingTB is an interface that matches *testing.T and *testing.B, without
+// incurring the package dependency.
+type testingTB[T any] interface {
+	Run(name string, f func(t T)) bool
+}


### PR DESCRIPTION
This commit introduces a new `isolation.RunEachLevel` test utility, which runs a subtest for each isolation level. This is similar to the `testutils.RunTrueAndFalse` test utility, but for isolation levels. It avoids some boiler plate code and an indentation for tests that can use the helper.

The commit also uses the new utility in a few places. While doing so, it fixes a few tests that were incorrectly handling subtests by failing to plumb the `t` parameter through to the subtest.

Epic: None
Release note: None