### PR TITLE
release-23.1: sql: fix VIEWACTIVITY privilege for ListSessions

### DIFF
--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -569,5 +569,6 @@ go_test(
         "@org_golang_google_grpc//metadata",
         "@org_golang_google_grpc//status",
         "@org_golang_x_crypto//bcrypt",
+        "@org_golang_x_sync//errgroup",
     ],
 )

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -3915,14 +3915,11 @@ func (c *adminPrivilegeChecker) requireViewActivityPermission(ctx context.Contex
 	if isAdmin {
 		return nil
 	}
-	if hasView, err := c.hasGlobalPrivilege(ctx, userName, privilege.VIEWACTIVITY); err != nil {
+	hasView, err := c.HasPrivilegeOrRoleOption(ctx, userName, privilege.VIEWACTIVITY)
+	if err != nil {
 		return serverError(ctx, err)
-	} else if hasView {
-		return nil
 	}
-	if hasView, err := c.hasRoleOption(ctx, userName, roleoption.VIEWACTIVITY); err != nil {
-		return serverError(ctx, err)
-	} else if hasView {
+	if hasView {
 		return nil
 	}
 	return grpcstatus.Errorf(
@@ -3941,24 +3938,18 @@ func (c *adminPrivilegeChecker) requireViewActivityOrViewActivityRedactedPermiss
 	if isAdmin {
 		return nil
 	}
-	if hasView, err := c.hasGlobalPrivilege(ctx, userName, privilege.VIEWACTIVITY); err != nil {
+	hasView, err := c.HasPrivilegeOrRoleOption(ctx, userName, privilege.VIEWACTIVITY)
+	if err != nil {
 		return serverError(ctx, err)
-	} else if hasView {
+	}
+	if hasView {
 		return nil
 	}
-	if hasViewRedacted, err := c.hasGlobalPrivilege(ctx, userName, privilege.VIEWACTIVITYREDACTED); err != nil {
+	hasViewRedacted, err := c.HasPrivilegeOrRoleOption(ctx, userName, privilege.VIEWACTIVITYREDACTED)
+	if err != nil {
 		return serverError(ctx, err)
-	} else if hasViewRedacted {
-		return nil
 	}
-	if hasView, err := c.hasRoleOption(ctx, userName, roleoption.VIEWACTIVITY); err != nil {
-		return serverError(ctx, err)
-	} else if hasView {
-		return nil
-	}
-	if hasViewRedacted, err := c.hasRoleOption(ctx, userName, roleoption.VIEWACTIVITYREDACTED); err != nil {
-		return serverError(ctx, err)
-	} else if hasViewRedacted {
+	if hasViewRedacted {
 		return nil
 	}
 	return grpcstatus.Errorf(
@@ -3977,24 +3968,18 @@ func (c *adminPrivilegeChecker) requireViewClusterSettingOrModifyClusterSettingP
 	if isAdmin {
 		return nil
 	}
-	if hasView, err := c.hasGlobalPrivilege(ctx, userName, privilege.VIEWCLUSTERSETTING); err != nil {
+	hasView, err := c.HasPrivilegeOrRoleOption(ctx, userName, privilege.VIEWCLUSTERSETTING)
+	if err != nil {
 		return serverError(ctx, err)
-	} else if hasView {
+	}
+	if hasView {
 		return nil
 	}
-	if hasModify, err := c.hasGlobalPrivilege(ctx, userName, privilege.MODIFYCLUSTERSETTING); err != nil {
+	hasModify, err := c.HasPrivilegeOrRoleOption(ctx, userName, privilege.MODIFYCLUSTERSETTING)
+	if err != nil {
 		return serverError(ctx, err)
-	} else if hasModify {
-		return nil
 	}
-	if hasView, err := c.hasRoleOption(ctx, userName, roleoption.VIEWCLUSTERSETTING); err != nil {
-		return serverError(ctx, err)
-	} else if hasView {
-		return nil
-	}
-	if hasModify, err := c.hasRoleOption(ctx, userName, roleoption.MODIFYCLUSTERSETTING); err != nil {
-		return serverError(ctx, err)
-	} else if hasModify {
+	if hasModify {
 		return nil
 	}
 	return grpcstatus.Errorf(
@@ -4149,6 +4134,28 @@ func (c *adminPrivilegeChecker) hasRoleOption(
 		return false, errors.AssertionFailedf("hasRoleOption: expected bool, got %T", row[0])
 	}
 	return bool(dbDatum), nil
+}
+
+// HasPrivilegeOrRoleOption is a helper function which calls both HasGlobalPrivilege and HasRoleOption.
+func (c *adminPrivilegeChecker) HasPrivilegeOrRoleOption(
+	ctx context.Context, username username.SQLUsername, privilege privilege.Kind,
+) (bool, error) {
+	if privilegeName, err := c.hasGlobalPrivilege(ctx, username, privilege); err != nil {
+		return false, err
+	} else if privilegeName {
+		return true, nil
+	}
+	privName := privilege.String()
+	roleOption, ok := roleoption.ByName[privName]
+	if !ok {
+		return false, nil
+	}
+	if hasRoleOption, err := c.hasRoleOption(ctx, username, roleOption); err != nil {
+		return false, err
+	} else if hasRoleOption {
+		return true, nil
+	}
+	return false, nil
 }
 
 // hasGlobalPrivilege is a helper function which calls

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -173,12 +173,12 @@ func (b *baseStatusServer) getLocalSessions(
 		return nil, serverError(ctx, err)
 	}
 
-	hasViewActivityRedacted, err := b.privilegeChecker.hasRoleOption(ctx, sessionUser, roleoption.VIEWACTIVITYREDACTED)
+	hasViewActivityRedacted, err := b.privilegeChecker.HasPrivilegeOrRoleOption(ctx, sessionUser, privilege.VIEWACTIVITYREDACTED)
 	if err != nil {
 		return nil, serverError(ctx, err)
 	}
 
-	hasViewActivity, err := b.privilegeChecker.hasRoleOption(ctx, sessionUser, roleoption.VIEWACTIVITY)
+	hasViewActivity, err := b.privilegeChecker.HasPrivilegeOrRoleOption(ctx, sessionUser, privilege.VIEWACTIVITY)
 	if err != nil {
 		return nil, serverError(ctx, err)
 	}
@@ -219,6 +219,11 @@ func (b *baseStatusServer) getLocalSessions(
 		}
 	}
 
+	// At this point, we have decided if we are going to show all sessions so we
+	// can set the username to the session user if it is undefined.
+	if reqUsername.Undefined() {
+		reqUsername = sessionUser
+	}
 	reqUserNameNormalized := reqUsername.Normalized()
 
 	userSessions := make([]serverpb.Session, 0, len(sessions)+len(closedSessions))

--- a/pkg/server/status_test.go
+++ b/pkg/server/status_test.go
@@ -75,6 +75,7 @@ import (
 	"github.com/kr/pretty"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
 )
 
 func getStatusJSONProto(
@@ -2515,6 +2516,128 @@ func TestListSessionsSecurity(t *testing.T) {
 				user, err, resp.Errors)
 		}
 	}
+}
+
+// TestListSessionsPrivileges tests that the VIEWACTIVITY and VIEWACTIVITYREDACTED privileges
+// are respected when listing sessions, particularly for other users' sessions.
+func TestListSessionsPrivileges(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	// Skip under stress race as the sleep query might finish before the stress race can finish.
+	skip.UnderStressRace(t, "list sessions privileges")
+
+	ts, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer ts.Stopper().Stop(context.Background())
+	endpoint := "sessions"
+	appName := "test_sessions_privileges"
+	user := authenticatedUserNameNoAdmin().Normalized()
+	sleepQuery := "SELECT pg_sleep(3000)"
+	sleepQueryRedacted := "SELECT pg_sleep(_)"
+
+	serverSQL := sqlutils.MakeSQLRunner(sqlDB)
+	serverSQL.Exec(t, fmt.Sprintf(`SET application_name = "%s"`, appName))
+	queryCtx, cancel := context.WithCancel(context.Background())
+
+	// Run a sleep query as root in another goroutine to make sure that root's session has one
+	// active query while we list sessions. This sleep query will be cancelled at the end of the
+	// test.
+	var g errgroup.Group
+	g.Go(func() error {
+		_, err := serverSQL.DB.ExecContext(queryCtx, sleepQuery)
+		if strings.Contains(err.Error(), "canceled") && strings.Contains(queryCtx.Err().Error(), "canceled") {
+			// Both errors contain the "canceled" substring, this means the query was
+			// canceled as expected.
+			return nil
+		}
+		t.Errorf("unexpected error: %v", err)
+		return err
+	})
+
+	// We test all combinations of VIEWACTIVITY and VIEWACTIVITYREDACTED. We could also start
+	// by granting all privileges and then revoking them one by one, but we want to keep the
+	// tests as isolated as possible. If a non-admin user has neither privilege, they should
+	// not see root's session. If a non-admin user has VIEWACTIVITY, they should see root's
+	// session with the full query. If a non-admin user has VIEWACTIVITYREDACTED, they should
+	// see root's session with the redacted query. If a non-admin user has both privileges,
+	// VIEWACTIVITYREDACTED should take precedence.
+	testCases := []struct {
+		grantViewActivity         bool
+		grantViewActivityRedacted bool
+		expectedQuery             string
+	}{
+		{false, false, ""},
+		{false, true, sleepQueryRedacted},
+		{true, false, sleepQuery},
+		{true, true, sleepQueryRedacted},
+	}
+
+	// Filters sessions by appName.
+	filterSessions := func(sessions []serverpb.Session) []serverpb.Session {
+		var filteredSessions []serverpb.Session
+		for _, s := range sessions {
+			if s.ApplicationName == appName {
+				filteredSessions = append(filteredSessions, s)
+			}
+		}
+		return filteredSessions
+	}
+
+	for _, tc := range testCases {
+		if tc.grantViewActivity {
+			serverSQL.Exec(t, fmt.Sprintf(`GRANT SYSTEM VIEWACTIVITY TO %s`, user))
+		}
+		if tc.grantViewActivityRedacted {
+			serverSQL.Exec(t, fmt.Sprintf(`GRANT SYSTEM VIEWACTIVITYREDACTED TO %s`, user))
+		}
+
+		var response serverpb.ListSessionsResponse
+		err := getStatusJSONProtoWithAdminOption(ts, endpoint, &response, false)
+
+		if err != nil {
+			t.Errorf("unexpected failure listing sessions from %s; error: %v; response errors: %v",
+				endpoint, err, response.Errors)
+		}
+
+		filteredSessions := filterSessions(response.Sessions)
+		numberOfSessions := len(filteredSessions)
+
+		// A non-admin user with no privileges should not see any other users' sessions.
+		if !tc.grantViewActivity && !tc.grantViewActivityRedacted {
+			if numberOfSessions != 0 {
+				t.Errorf("expected 0 sessions, but got %d", numberOfSessions)
+			}
+			continue
+		}
+
+		// A non-admin user with at least one of the privileges should see other users' sessions.
+		if numberOfSessions != 1 {
+			t.Errorf("expected 1 session, but got %d", numberOfSessions)
+		} else {
+			session := filteredSessions[0]
+			numberOfActiveQueries := len(session.ActiveQueries)
+			if numberOfActiveQueries != 1 {
+				t.Errorf("expected 1 active query, but got %d", numberOfActiveQueries)
+			} else {
+				activeQuery := session.ActiveQueries[0].Sql
+				if activeQuery != tc.expectedQuery {
+					t.Errorf("expected active query to be %s, but got %s", tc.expectedQuery, activeQuery)
+				}
+			}
+		}
+
+		// Only revoke the privilege if we granted it in this test case.
+		if tc.grantViewActivity {
+			serverSQL.Exec(t, fmt.Sprintf(`REVOKE SYSTEM VIEWACTIVITY FROM %s`, user))
+		}
+		if tc.grantViewActivityRedacted {
+			serverSQL.Exec(t, fmt.Sprintf(`REVOKE SYSTEM VIEWACTIVITYREDACTED FROM %s`, user))
+		}
+	}
+
+	// Cancel the query so that the test can finish.
+	cancel()
+	_ = g.Wait()
 }
 
 func TestListActivitySecurity(t *testing.T) {


### PR DESCRIPTION
Backport 1/1 commits from #106590.

/cc @cockroachdb/release

---

Fixes #104354.
Partially addresses #106588.

Previously, when a non-admin user was given the `VIEWACTIVITY`
privilege, they were able to see other users' sessions from the SQL
shell but not from the UI.

This commit fixes the ListSessions endpoint to check for the
`VIEWACTIVITY` privilege in addition to the `VIEWACTIVITY` role when
returning a response for the ListSessions endpoint.

loom: https://www.loom.com/share/8224628f7e7e4af298306c83f158d593

Release note (bug fix): users with the `VIEWACTIVITY` privilege should
be able to see other users' sessions from both the CLI and the DB
Console.

----

Release justification: bug fix
