### PR TITLE
rangefeed: deflake `TestBudgetReleaseOnOneStreamError`

### DIFF
--- a/pkg/kv/kvserver/rangefeed/processor_test.go
+++ b/pkg/kv/kvserver/rangefeed/processor_test.go
@@ -1301,7 +1301,7 @@ func TestBudgetReleaseOnOneStreamError(t *testing.T) {
 		PushTxnsInterval: pushTxnInterval,
 		PushTxnsAge:      pushTxnAge,
 		EventChanCap:     channelCapacity,
-		EventChanTimeout: time.Millisecond,
+		EventChanTimeout: 100 * time.Millisecond, // enough time for registration to process events
 		MemBudget:        fb,
 		Metrics:          NewMetrics(),
 	})


### PR DESCRIPTION
The test could fail with `REASON_SLOW_CONSUMER` if the registration goroutine did not drain the queue in time (1 ms). Increase the timeout.

Resolves #108555.

Epic: none
Release note: None