### PR TITLE
roachtest: allow callers to listen for node events in monitor

### DIFF
--- a/pkg/cmd/roachtest/cluster/monitor_interface.go
+++ b/pkg/cmd/roachtest/cluster/monitor_interface.go
@@ -30,6 +30,7 @@ type Monitor interface {
 	// Wait() or WaitE() before returning.
 	Go(fn func(context.Context) error)
 	GoWithCancel(fn func(context.Context) error) func()
+	WaitForNodeDeath() error
 	WaitE() error
 	Wait()
 }

--- a/pkg/cmd/roachtest/roachtestutil/clusterupgrade/clusterupgrade.go
+++ b/pkg/cmd/roachtest/roachtestutil/clusterupgrade/clusterupgrade.go
@@ -264,7 +264,10 @@ func WaitForClusterUpgrade(
 	// expected cluster version within the given timeout.
 	waitForUpgrade := func(node int, timeout time.Duration) error {
 		var latestVersion roachpb.Version
-		err := retry.ForDuration(timeout, func() error {
+		var opts retry.Options
+		retryCtx, cancel := context.WithTimeout(ctx, timeout)
+		defer cancel()
+		err := opts.Do(retryCtx, func(ctx context.Context) error {
 			currentVersion, err := ClusterVersion(ctx, dbFunc(node))
 			if err != nil {
 				return err

--- a/pkg/cmd/roachtest/tests/sstable_corruption.go
+++ b/pkg/cmd/roachtest/tests/sstable_corruption.go
@@ -23,7 +23,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
-	"github.com/cockroachdb/errors"
 )
 
 func runSSTableCorruption(ctx context.Context, t test.Test, c cluster.Cluster) {
@@ -132,44 +131,44 @@ func runSSTableCorruption(ctx context.Context, t test.Test, c cluster.Cluster) {
 	}
 
 	{
+		workloadErr := make(chan error, 1)
+		const timeout = 10 * time.Minute
 		m := c.NewMonitor(ctx)
 		// Run a workload to try to get the node to notice corruption and crash.
 		m.Go(func(ctx context.Context) error {
-			const timeout = 10 * time.Minute
-			ctx, cancel := context.WithTimeout(ctx, timeout)
-			defer cancel()
-			for {
-				err := errors.CombineErrors(
-					c.RunE(
-						ctx, workloadNode,
-						"./cockroach workload run tpcc --warehouses=100 --tolerate-errors",
-					),
-					errors.New("workload unexpectedly returned nil"),
-				)
-				// NOTE: the workload is fallible, however, we don't want to return the
-				// error to the caller of WaitE (below), as we want it to see any error
-				// caused due to a node death. The workload is just a means of surfacing
-				// the corruption. The workload could also return early with a nil
-				// error, which is unexpected. In both cases, simply log the error and
-				// determine whether to continue based on the context (timeout, or other
-				// context cancellation).
-				if err != nil {
-					t.L().Printf("workload failed: %s", err)
-				}
-				select {
-				case <-ctx.Done():
-					return ctx.Err()
-				case <-time.After(time.Second):
-					// Loop.
-				}
+			err := c.RunE(
+				ctx, workloadNode,
+				fmt.Sprintf(
+					"./cockroach workload run tpcc --warehouses=100 --tolerate-errors --duration %s",
+					timeout,
+				),
+			)
+
+			// If the workload returned because of context cancelation, it
+			// means the node died as expected.
+			if ctx.Err() == nil {
+				workloadErr <- err
 			}
+			return nil
 		})
 
-		t.L().Printf("waiting for monitor to observe error ...")
-		err := m.WaitE()
-		t.L().Printf("monitor observed error: %s", err)
-		if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
-			t.Fatal(err)
+		t.L().Printf("waiting for monitor to observe error...")
+		deathChan := make(chan error, 1)
+		go func() {
+			// Errors here can only come from node deaths, as the workload
+			// function never returns an error.
+			deathChan <- m.WaitE()
+		}()
+
+		select {
+		case err := <-deathChan:
+			t.L().Printf("monitor observed: %v", err)
+			// success
+		case <-workloadErr:
+			if workloadErr != nil {
+				t.Fatalf("workload returned error: %v", workloadErr)
+			}
+			t.Fatalf("workload ran for %s without observing node crash", timeout)
 		}
 	}
 


### PR DESCRIPTION
In #107548, the `(*monitorImpl).wait()` function was modified such that, if the caller provided no functions (via the `Go` method), then `wait()` would block while listening for node events. However, that was a change in the semantics of the function: previously, a monitor without goroutines would return immediately after a call to `wait()` is made. This behaviour is preferred as it's familiar: it's how `errgroup` and our own `ctxgroup` work.

That said, we still need some way to support the use-case where callers are only interested in listening for unexpected node deaths without having to pass a function to `Go()`. To support that scenario, a new function is added to the `Monitor` interface: `WaitForNodeDeath`. This function is like `WaitE`, except that only errors related to unexpected node deaths are returned. When callers wish to terminate the monitoring goroutine, they call call `Wait{,E}()` as before.

The internal implementation of the `monitorImpl` is also simplified by making use of two `errgroup`s to achieve this behaviour, replacing the previous, harder to understand, logic.

Fixes: #108530.

Release note: None