### PR TITLE
dev,bazelrc: new flag `--test-build-only`

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -30,6 +30,7 @@ build:nolintonbuild --nolintonbuild
 # Note: nonogo is classically the name of the nolintonbuild configuration.
 build:nonogo --nolintonbuild
 build:test --crdb_test
+build:testbuildonly --crdb_test --@io_bazel_rules_go//go/config:testbuildonly
 
 # Basic settings.
 build --define gotags=bazel,gss


### PR DESCRIPTION
When specified, only the dependencies of test targets (including the test sources) are compiled; the test executables themselves are not linked.

This change depends on https://github.com/cockroachdb/rules_go/pull/16.

Release note: None
Fixes  #108584.
Epic: CRDB-28893