### PR TITLE
metrics: assign histogram metric type on histogram construction

### DIFF
--- a/pkg/util/metric/metric.go
+++ b/pkg/util/metric/metric.go
@@ -255,6 +255,7 @@ type HistogramOptions struct {
 }
 
 func NewHistogram(opt HistogramOptions) IHistogram {
+	opt.Metadata.MetricType = prometheusgo.MetricType_HISTOGRAM
 	if hdrEnabled && opt.Mode != HistogramModePrometheus {
 		if opt.Mode == HistogramModePreferHdrLatency {
 			return NewHdrLatency(opt.Metadata, opt.Duration)
@@ -492,6 +493,7 @@ func NewManualWindowHistogram(
 		panic(err.Error())
 	}
 
+	meta.MetricType = prometheusgo.MetricType_HISTOGRAM
 	h := &ManualWindowHistogram{
 		Metadata: meta,
 	}

--- a/pkg/util/schedulerlatency/histogram.go
+++ b/pkg/util/schedulerlatency/histogram.go
@@ -51,6 +51,7 @@ func newRuntimeHistogram(metadata metric.Metadata, buckets []float64) *runtimeHi
 	if buckets[0] == math.Inf(-1) {
 		buckets = buckets[1:]
 	}
+	metadata.MetricType = prometheusgo.MetricType_HISTOGRAM
 	h := &runtimeHistogram{
 		Metadata: metadata,
 		// Go runtime histograms as of go1.19 are always in seconds whereas


### PR DESCRIPTION
This commit assigns prometheusgo.MetricType_HISTOGRAM to the
Metadata.MetricType on histogram construction.

Before this change, GetMetadata() was returning the
Metadata.MetricType zero value (prometheusgo.MetricType_COUNTER)
for all histograms that did not explicitly specify the
prometheusgo.MetricType_HISTOGRAM for Metadata.MetricType in
their Metadata definitions. This prevented checks on histogram
Metadata.MetricType from properly evaluating the metrics as
histograms.

Fixes https://github.com/cockroachdb/cockroach/issues/106448.
Fixes https://github.com/cockroachdb/cockroach/issues/107701.

Releaes note: None