### PR TITLE
cli,server: distinguish graceful vs non-graceful shutdown requests

### DIFF
--- a/pkg/server/serverctl/api.go
+++ b/pkg/server/serverctl/api.go
@@ -83,7 +83,6 @@ const (
 	// failed.
 	ShutdownReasonServerStartupError
 	// ShutdownReasonFatalError identifies an error that requires the server be
-	// terminated. Compared to a panic or log.Fatal(), the termination can be more
-	// graceful, though.
+	// terminated immediately.
 	ShutdownReasonFatalError
 )

--- a/pkg/server/serverctl/shutdown.go
+++ b/pkg/server/serverctl/shutdown.go
@@ -22,6 +22,14 @@ func (r ShutdownRequest) ShutdownCause() error {
 	}
 }
 
+// Graceful determines whether the shutdown should be effected via a
+// graceful drain first.
+func (r ShutdownRequest) TerminateUsingGracefulDrain() bool {
+	// As of this patch, none of the existing reasons for shutdown
+	// can be correctly followed by a graceful drain.
+	return false
+}
+
 // Empty returns true if the receiver is the zero value.
 func (r ShutdownRequest) Empty() bool {
 	return r == (ShutdownRequest{})

--- a/pkg/server/stop_trigger.go
+++ b/pkg/server/stop_trigger.go
@@ -18,8 +18,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 )
 
-// stopTrigger is used by modules to signal the desire to stop the server. When
-// signaled, the stopTrigger notifies listeners on a channel.
+// stopTrigger is used by modules to signal the desire to stop the
+// server. When signaled, the stopTrigger notifies listeners on a
+// channel.
 type stopTrigger struct {
 	mu struct {
 		syncutil.Mutex
@@ -32,7 +33,7 @@ func newStopTrigger() *stopTrigger {
 	return &stopTrigger{
 		// The channel is buffered so that there's no requirement that anyone ever
 		// calls C() and reads from this channel.
-		c: make(chan serverctl.ShutdownRequest, 1),
+		c: make(chan serverctl.ShutdownRequest, 2),
 	}
 }
 
@@ -44,11 +45,24 @@ func (s *stopTrigger) signalStop(ctx context.Context, r serverctl.ShutdownReques
 	if !s.mu.shutdownRequest.Empty() {
 		// Someone else already triggered the shutdown.
 		log.Infof(ctx, "received a second shutdown request: %s", r.ShutdownCause())
-		return
+		// We want to ensure that non-graceful shutdowns are always queued.
+		// We have three possible situations:
+		// - the first shutdown request was graceful, and the second one
+		//   is not, in which case we want to ensure that the second one
+		//   is queued.
+		// - the first shutdown request was non-graceful, in which case we can
+		//   ignore the second one.
+		// - the first shutdown request was graceful, and the second one is
+		//   too, in which case we can ignore the second one too.
+		if !s.mu.shutdownRequest.TerminateUsingGracefulDrain() || r.TerminateUsingGracefulDrain() {
+			return
+		}
+		// Other cases: we replace the previous one (which was graceful)
+		// with the new one (which isn't graceful).
 	}
 	s.mu.shutdownRequest = r
-	// Writing to s.c is done under the lock, so there can ever only be one value
-	// written and the writer does not block.
+	// Writing to s.c is done under the lock, so there can ever only be
+	// one or two values written and the writer does not block.
 	s.c <- r
 }
 

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -703,6 +703,9 @@ func (ts *testServer) Start(ctx context.Context) (retErr error) {
 		case req := <-ts.topLevelServer.ShutdownRequested():
 			shutdownCtx := ts.topLevelServer.AnnotateCtx(context.Background())
 			log.Infof(shutdownCtx, "server requesting spontaneous shutdown: %v", req.ShutdownCause())
+			// TODO(knz): evaluate whether there is value in shutting down
+			// test servers using a graceful drain when
+			// req.TerminateUsingGracefulDrain() is true.
 			ts.Stopper().Stop(shutdownCtx)
 		case <-ts.Stopper().ShouldQuiesce():
 		}


### PR DESCRIPTION
Needed to fix #107856.

TLDR: this patch fixes a bug whereby the top-level shutdown logic in `cli/start.go` mistakenly attempted a graceful drain when that, in fact, was impossible. This would show up as a storm of errors in logs and, sometimes, block server shutdown until a non-graceful shutdown was initiated by other means.

A more detailed explanation follows.

*For context*, we have a notification mechanism (called "stop trigger") through which internal components in a server can request a shutdown of the overall server. As of this writing, this mechanism is used for example:

- when an error is encountered very early during server startup.
- at the tail end of the `Drain` RPC, when the `Shutdown` request flag is true, to indicate the process can now exit.
- when a SQL liveness record is found to have been deleted or expired without heartbeat.

The way this works is that the internal component, given a reference to `*server.stopTrigger`, when it needs a server shutdown calls `signalStop()` and passes a "shutdown
request" (`serverctl.MakeShutdownRequest`).

At the very outer orchestration layer, a loop monitor a channel from the `stopTrigger` and processes shutdown requests. As of this writing, we have at least the following orchestration points:

1. the top-level shutdown logic in `cli/start.go`.
2. the top-level `testServer` shutdown monitor task (initiated from `(*server.testServer).Start()`)
3. the tenant server orchestration logic in `(*server.channelOrchestrator) startControlledServer()`.

Prior to this patch, a bug existed in `cli/start.go` as follows:

- the shutdown logic considered that any "shutdown reason" other than `ShutdownReasonServerStartupError` could be processed by performing a graceful drain on the server.
- meanwhile, in fact *none* of the current shutdown reasons can be correctly processed via a graceful drain (they all signal conditions that make the current server unhealthy and unable to shut down gracefully).
- as a result, if a shutdown request other than "server startup error" was received in `cli/start.go`, it would attempt a graceful drain and the graceful drain process would generally fail with all kinds of error messages in logs. It would also sometime hang, blocking the overall shutdown.

This patch fixes this by avoiding the graceful drain unless the shutdown request is for a graceful drain.

Through this, care is taken to ensure that if a hard shutdown is triggered after a graceful shutdown, the hard shutdown is also "delivered" to the orchestration. That allows hard shutdown to "catch up" with and shortcut graceful drains initiated earlier.

Release note (bug fix): A bug was fixed whereby `cockroach start` would sometimes incorrectly hang upon shutting down a server after encountering an internal error. This bug had been introduced some time in v22.x.

Fixes #108611.
Epic: CRDB-28893