### PR TITLE
server,cli/start: gracefully drain tenant servers upon service disable

### DIFF
--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -1708,14 +1708,14 @@ func (s *SQLServer) startCheckService(ctx context.Context, stopper *stop.Stopper
 
 	var entry tenantcapabilities.Entry
 	var updateCh <-chan struct{}
-	check := func() error {
+	check := func() (useGracefulDrain bool, err error) {
 		entry, updateCh = s.tenantConnect.TenantInfo()
 		return checkServerModeMatchesEntry(s.serviceMode, entry)
 	}
 
 	// Do a synchronous check, to prevent starting the SQL service
 	// outright if the service mode is initially incorrect.
-	if err := check(); err != nil {
+	if _, err := check(); err != nil {
 		return err
 	}
 
@@ -1727,9 +1727,14 @@ func (s *SQLServer) startCheckService(ctx context.Context, stopper *stop.Stopper
 			case <-ctx.Done():
 				return
 			case <-updateCh:
-				if err := check(); err != nil {
-					s.stopTrigger.signalStop(ctx,
-						serverctl.MakeShutdownRequest(serverctl.ShutdownReasonFatalError, err))
+				if useGracefulDrain, err := check(); err != nil {
+					var req serverctl.ShutdownRequest
+					if useGracefulDrain {
+						req = serverctl.MakeShutdownRequest(serverctl.ShutdownReasonGracefulStopRequestedByOrchestration, err)
+					} else {
+						req = serverctl.MakeShutdownRequest(serverctl.ShutdownReasonFatalError, err)
+					}
+					s.stopTrigger.signalStop(ctx, req)
 				}
 			}
 		}
@@ -1738,7 +1743,7 @@ func (s *SQLServer) startCheckService(ctx context.Context, stopper *stop.Stopper
 
 func checkServerModeMatchesEntry(
 	expectedMode mtinfopb.TenantServiceMode, entry tenantcapabilities.Entry,
-) error {
+) (useGracefulDrain bool, err error) {
 	if !entry.Ready() {
 		// At the version this check was introduced, the server was
 		// already modified to provide metadata during the initial
@@ -1746,19 +1751,24 @@ func checkServerModeMatchesEntry(
 		//
 		// If we don't have the metadata here, this means that the
 		// connector is talking to an older-version server.
-		return errors.AssertionFailedf("storage layer did not communicate metadata, is it running an older binary version than the client?")
+		return false, errors.AssertionFailedf("storage layer did not communicate metadata, is it running an older binary version than the client?")
 	}
 
 	if actualMode := entry.ServiceMode; expectedMode != actualMode {
-		return errors.Newf("service check failed: expected service mode %v, record says %v", expectedMode, actualMode)
+		// We can only use a graceful drain if the data state is still ready.
+		useGracefulDrain = entry.DataState == mtinfopb.DataStateReady
+		return useGracefulDrain, errors.Newf("service check failed: expected service mode %v, record says %v", expectedMode, actualMode)
 	}
 	// Extra sanity check. This should never happen (we should enforce
 	// a valid data state when the service mode is not NONE) but it's
 	// cheap to check.
 	if expected, actual := mtinfopb.DataStateReady, entry.DataState; expected != actual {
-		return errors.AssertionFailedf("service check failed: expected data state %v, record says %v", expected, actual)
+		return false, errors.AssertionFailedf("service check failed: expected data state %v, record says %v", expected, actual)
 	}
-	return nil
+
+	// Note: the caller only looks at the first return value if the
+	// error return is non-nil. So any value is fine.
+	return true, nil
 }
 
 // SQLInstanceID returns the ephemeral ID assigned to each SQL instance. The ID

--- a/pkg/server/serverctl/api.go
+++ b/pkg/server/serverctl/api.go
@@ -85,4 +85,7 @@ const (
 	// ShutdownReasonFatalError identifies an error that requires the server be
 	// terminated immediately.
 	ShutdownReasonFatalError
+	// ShutdownReasonGracefulStopRequestedByOrchestration is used when a graceful shutdown
+	// was requested by orchestration.
+	ShutdownReasonGracefulStopRequestedByOrchestration
 )

--- a/pkg/server/serverctl/shutdown.go
+++ b/pkg/server/serverctl/shutdown.go
@@ -25,9 +25,10 @@ func (r ShutdownRequest) ShutdownCause() error {
 // Graceful determines whether the shutdown should be effected via a
 // graceful drain first.
 func (r ShutdownRequest) TerminateUsingGracefulDrain() bool {
-	// As of this patch, none of the existing reasons for shutdown
-	// can be correctly followed by a graceful drain.
-	return false
+	// Note: ShutdownReasonDrainRPC despite its name cannot be effected
+	// via a graceful drain, because at the time it is generated
+	// the RPC subsystem is shut down already.
+	return r.Reason == ShutdownReasonGracefulStopRequestedByOrchestration
 }
 
 // Empty returns true if the receiver is the zero value.


### PR DESCRIPTION
First commit from #108612.
Thanks to @stevendanna for brainstorming solutions.

TLDR: when the service mode of a secondary tenant is changed to NONE,
but the data state is still READY, the tenant servers will now shut
down gracefully. This applies both to tenant servers run as separate
processes (via `cockroach mt start-sql`) and those started via the
internal server controller.

More details follow.

For context, the reader is invited to first refer to the commit
immediately prior.

Prior to this patch, all internal shutdown requests were considered to
be non-graceful. This included the request that was triggered as a
result of a change in the service mode.

This caused two separate bugs:

- it created a race condition between the server controller (for
  shared-process servers) and the service mode checker task inside the
  SQL server (`startCheckService`). When the service mode was flipped to
  'NONE', the server controller initiated a graceful drain but then that
  was caught up by the service mode checker and converted to a
  hard shutdown. This particular bug was a regression caused by #96144
  and had been identified through flakes in `TestServiceShutdownUsesGracefulDrain`.

- it was generally causing shutdowns upon changes in service mode to
  always be run as hard shutdowns (both for external-process and shared-process
  ervers). This is generally undesirable when the data state is still
  READY, as it prevents cleaning up the SQL liveness record and can
  cause delays during subsequent server startups.

This patch fixes it by using a graceful shutdown request whenever
the service mode changes and the data state is still READY.
Since the tenant server now handles graceful drains, the patch
also removes this responsibility from the server controller.

Release note: None
Fixes #107856
Epic: CRDB-26691