### PR TITLE
changefeedccl: Reject subquery in alter changefeed

### DIFF
--- a/pkg/ccl/changefeedccl/alter_changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/alter_changefeed_stmt.go
@@ -84,11 +84,20 @@ func alterChangefeedPlanHook(
 	}
 
 	fn := func(ctx context.Context, _ []sql.PlanNode, resultsCh chan<- tree.Datums) error {
-		typedExpr, err := tree.TypeCheckAndRequire(ctx, alterChangefeedStmt.Jobs, p.SemaCtx(), types.Int, "get-job-id")
+		jobID, err := func() (jobspb.JobID, error) {
+			origProps := p.SemaCtx().Properties
+			p.SemaCtx().Properties.Require("cdc", tree.RejectSubqueries)
+			defer p.SemaCtx().Properties.Restore(origProps)
+
+			id, err := p.ExprEvaluator("ALTER CHANGEFEED").Int(ctx, alterChangefeedStmt.Jobs)
+			if err != nil {
+				return jobspb.JobID(0), err
+			}
+			return jobspb.JobID(id), nil
+		}()
 		if err != nil {
-			return err
+			return pgerror.Wrap(err, pgcode.DatatypeMismatch, "changefeed ID must be an INT value")
 		}
-		jobID := jobspb.JobID(tree.MustBeDInt(typedExpr))
 
 		job, err := p.ExecCfg().JobRegistry.LoadJobWithTxn(ctx, jobID, p.InternalSQLTxn())
 		if err != nil {

--- a/pkg/ccl/changefeedccl/alter_changefeed_test.go
+++ b/pkg/ccl/changefeedccl/alter_changefeed_test.go
@@ -560,6 +560,11 @@ func TestAlterChangefeedErrors(t *testing.T) {
 			`pq: cannot specify both "initial_scan" and "no_initial_scan"`,
 			fmt.Sprintf(`ALTER CHANGEFEED %d ADD bar WITH initial_scan, no_initial_scan`, feed.JobID()),
 		)
+
+		sqlDB.ExpectErr(t, "pq: changefeed ID must be an INT value: subqueries are not allowed in cdc",
+			"ALTER CHANGEFEED (SELECT 1) ADD bar")
+		sqlDB.ExpectErr(t, "pq: changefeed ID must be an INT value: could not parse \"two\" as type int",
+			"ALTER CHANGEFEED 'two' ADD bar")
 	}
 
 	cdcTest(t, testFn, feedTestEnterpriseSinks, feedTestNoExternalConnection)


### PR DESCRIPTION
Disallow subquery as the changefeed ID argument.

Fixes #108500

Release note: None