### PR TITLE
release-23.1: cli,server: distinguish graceful vs non-graceful shutdown requests

### DIFF
--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -970,8 +970,7 @@ func waitForShutdown(
 	select {
 	case shutdownRequest := <-shutdownC:
 		returnErr = shutdownRequest.ShutdownCause()
-		// There's no point in draining if the server didn't even fully start.
-		drain := shutdownRequest.Reason != server.ShutdownReasonServerStartupError
+		drain := shutdownRequest.TerminateUsingGracefulDrain()
 		startShutdownAsync(serverStatusMu, stopWithoutDrain, drain)
 
 	case sig := <-signalCh:
@@ -1075,6 +1074,23 @@ func waitForShutdown(
 				redact.Safe(sig), redact.Safe(hardShutdownHint))
 			handleSignalDuringShutdown(sig)
 			panic("unreachable")
+
+		case shutdownRequest := <-shutdownC:
+			if shutdownRequest.TerminateUsingGracefulDrain() {
+				// Internal graceful drain request during graceful shutdown:
+				// continue the graceful shutdown.
+				log.Ops.Infof(shutdownCtx, "received additional shutdown request '%s'; continuing graceful shutdown", shutdownRequest.ShutdownCause())
+				continue
+			} else {
+				// A non-graceful shutdown request: we're done.
+				const msgDone = "internal error during drain; used hard shutdown instead"
+				returnErr = shutdownRequest.ShutdownCause()
+				log.Ops.Infof(shutdownCtx, "received additional shutdown request '%s'; initiating hard shutdown%s",
+					shutdownRequest.ShutdownCause(), redact.Safe(hardShutdownHint))
+				if !startCtx.inBackground {
+					fmt.Fprintln(os.Stdout, msgDone)
+				}
+			}
 
 		case <-stopper.IsStopped():
 			const msgDone = "server drained and shutdown completed"

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -643,6 +643,9 @@ func (ts *TestServer) Start(ctx context.Context) error {
 		case req := <-ts.Server.ShutdownRequested():
 			shutdownCtx := ts.Server.AnnotateCtx(context.Background())
 			log.Infof(shutdownCtx, "server requesting spontaneous shutdown: %v", req.ShutdownCause())
+			// TODO(knz): evaluate whether there is value in shutting down
+			// test servers using a graceful drain when
+			// req.TerminateUsingGracefulDrain() is true.
 			ts.Stopper().Stop(shutdownCtx)
 		case <-ts.Stopper().ShouldQuiesce():
 		}


### PR DESCRIPTION
Backport 1/1 commits from #108612.

/cc @cockroachdb/release

---

Fixes #108611.
Epic: CRDB-28893

---
Release justification: smoother behavior on SQL pod shutdown in Serverless