### PR TITLE
colexec: allow timestamp + / - interval

### DIFF
--- a/pkg/sql/colexec/colbuilder/BUILD.bazel
+++ b/pkg/sql/colexec/colbuilder/BUILD.bazel
@@ -43,6 +43,7 @@ go_library(
         "//pkg/sql/sessiondatapb",
         "//pkg/sql/types",
         "//pkg/util/buildutil",
+        "//pkg/util/errorutil/unimplemented",
         "//pkg/util/intsets",
         "//pkg/util/log",
         "//pkg/util/mon",

--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -49,6 +49,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
+	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/cockroach/pkg/util/intsets"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
@@ -533,7 +534,7 @@ func (r opResult) createAndWrapRowSource(
 	causeToWrap error,
 ) error {
 	if args.ProcessorConstructor == nil {
-		return errors.New("processorConstructor is nil")
+		return errors.Wrap(causeToWrap, "processorConstructor is nil")
 	}
 	log.VEventf(ctx, 1, "planning a row-execution processor in the vectorized flow: %v", causeToWrap)
 	if err := canWrap(flowCtx.EvalCtx.SessionData().VectorizeMode, core); err != nil {
@@ -2457,6 +2458,9 @@ func planProjectionOperators(
 		}
 		return planProjectionOperators(ctx, evalCtx, caseExpr, columnTypes, input, acc, factory, releasables)
 	case *tree.ComparisonExpr:
+		if err = checkSupportedComparisonExpr(t.TypedLeft(), t.TypedRight()); err != nil {
+			return op, resultIdx, typs, err
+		}
 		return planProjectionExpr(
 			ctx, evalCtx, t.Operator, t.ResolvedType(), t.TypedLeft(), t.TypedRight(),
 			columnTypes, input, acc, factory, nil /* binFn */, t, releasables, t.Op.CalledOnNullInput,
@@ -2581,38 +2585,92 @@ func planProjectionOperators(
 	}
 }
 
-var errMixedTypeUnsupported = errors.New("dates and timestamp(tz) not supported in mixed-type expressions in the vectorized engine")
-
-func checkSupportedProjectionExpr(left, right tree.TypedExpr) error {
-	leftTyp := left.ResolvedType()
-	rightTyp := right.ResolvedType()
-	if leftTyp.Equivalent(rightTyp) || leftTyp.Family() == types.UnknownFamily || rightTyp.Family() == types.UnknownFamily {
+// safeTypesForBinOrCmpExpr returns true if the given type pair is definitely
+// safe for Binary or Comparison expressions (in other words, this type pair
+// will definitely not result in problematic mixed-type expressions that we want
+// to avoid (see a few errors below for examples)).
+func safeTypesForBinOrCmpExpr(leftTyp, rightTyp *types.T) bool {
+	if leftTyp.Equivalent(rightTyp) {
+		// All same type expressions are safe.
+		return true
+	}
+	if leftTyp.Family() == types.UnknownFamily || rightTyp.Family() == types.UnknownFamily {
 		// If either type is of an Unknown family, then the corresponding vector
 		// will only contain NULL values, so we won't run into the mixed-type
 		// issues.
-		return nil
+		//
+		// Note that in the general case the optimizer should constant-fold such
+		// expressions, but we are constructing some expressions manually during
+		// the vectorized planning (e.g. handling of COALESCE expression
+		// involves the creation of IS DISTINCT FROM comparison expression)
+		// which don't go through the optimizer, so we have this check.
+		return true
 	}
-
-	// The types are not equivalent. Check if either is a type we'd like to
-	// avoid.
-	for _, t := range []*types.T{leftTyp, rightTyp} {
-		switch t.Family() {
-		case types.DateFamily, types.TimestampFamily, types.TimestampTZFamily:
-			return errMixedTypeUnsupported
-		}
-	}
-	return nil
+	return false
 }
 
-var errBinaryExprWithDatums = errors.New("datum-backed arguments on both sides and not datum-backed output of a binary expression is currently not supported")
+var errBinaryExprWithDatums = unimplemented.NewWithIssue(
+	49780, "datum-backed arguments on both sides and not datum-backed "+
+		"output of a binary expression is currently not supported",
+)
+var errMixedTypeBinaryUnsupported = unimplemented.NewWithIssue(
+	46198, "dates and timestamptz not supported in mixed-type binary "+
+		"expressions in the vectorized engine",
+)
 
 func checkSupportedBinaryExpr(left, right tree.TypedExpr, outputType *types.T) error {
-	leftDatumBacked := typeconv.TypeFamilyToCanonicalTypeFamily(left.ResolvedType().Family()) == typeconv.DatumVecCanonicalTypeFamily
-	rightDatumBacked := typeconv.TypeFamilyToCanonicalTypeFamily(right.ResolvedType().Family()) == typeconv.DatumVecCanonicalTypeFamily
+	leftTyp := left.ResolvedType()
+	rightTyp := right.ResolvedType()
+
+	leftDatumBacked := typeconv.TypeFamilyToCanonicalTypeFamily(leftTyp.Family()) == typeconv.DatumVecCanonicalTypeFamily
+	rightDatumBacked := typeconv.TypeFamilyToCanonicalTypeFamily(rightTyp.Family()) == typeconv.DatumVecCanonicalTypeFamily
 	outputDatumBacked := typeconv.TypeFamilyToCanonicalTypeFamily(outputType.Family()) == typeconv.DatumVecCanonicalTypeFamily
 	if (leftDatumBacked && rightDatumBacked) && !outputDatumBacked {
 		return errBinaryExprWithDatums
 	}
+
+	if safeTypesForBinOrCmpExpr(leftTyp, rightTyp) {
+		return nil
+	}
+
+	// Check whether we have a mixed type expression with one of the types we
+	// want to avoid.
+	for _, t := range []*types.T{leftTyp, rightTyp} {
+		switch t.Family() {
+		case types.DateFamily, types.TimestampTZFamily:
+			// Note that the Timestamp type is ok because the current
+			// implementation of binary expressions that use TimestampTZ
+			// canonical type family on one side hard-codes the choice of
+			// Timestamp (as opposed to TimestampTZ).
+			return errMixedTypeBinaryUnsupported
+		}
+	}
+
+	return nil
+}
+
+var errMixedTypeComparisonUnsupported = unimplemented.NewWithIssue(
+	44770, "dates and timestamp(tz) not supported in mixed-type "+
+		"comparison expressions in the vectorized engine",
+)
+
+func checkSupportedComparisonExpr(left, right tree.TypedExpr) error {
+	leftTyp := left.ResolvedType()
+	rightTyp := right.ResolvedType()
+
+	if safeTypesForBinOrCmpExpr(leftTyp, rightTyp) {
+		return nil
+	}
+
+	// Check whether we have a mixed type expression with one of the types we
+	// want to avoid.
+	for _, t := range []*types.T{leftTyp, rightTyp} {
+		switch t.Family() {
+		case types.DateFamily, types.TimestampFamily, types.TimestampTZFamily:
+			return errMixedTypeComparisonUnsupported
+		}
+	}
+
 	return nil
 }
 
@@ -2631,9 +2689,6 @@ func planProjectionExpr(
 	releasables *[]execreleasable.Releasable,
 	calledOnNullInput bool,
 ) (op colexecop.Operator, resultIdx int, typs []*types.T, err error) {
-	if err := checkSupportedProjectionExpr(left, right); err != nil {
-		return nil, resultIdx, typs, err
-	}
 	allocator := colmem.NewAllocator(ctx, acc, factory)
 	resultIdx = -1
 

--- a/pkg/sql/logictest/testdata/logic_test/vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize
@@ -1142,10 +1142,10 @@ SELECT b > now() - interval '1 day'  FROM mixed_type_a
 ----
 false
 
-statement error .* dates and timestamp\(tz\) not supported in mixed-type expressions in the vectorized engine
+statement error .* dates and timestamptz not supported in mixed-type binary expressions
 SELECT * FROM mixed_type_a AS a INNER MERGE JOIN mixed_type_b AS b ON a.a = b.a AND a.b < (now() - b.b)
 
-statement error .* dates and timestamp\(tz\) not supported in mixed-type expressions in the vectorized engine
+statement error .* dates and timestamptz not supported in mixed-type binary expressions
 SELECT * FROM mixed_type_a AS a JOIN mixed_type_b AS b ON a.a = b.a AND a.b < (now() - b.b)
 
 # Regression for #46183.

--- a/pkg/sql/logictest/testdata/logic_test/vectorize_overloads
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize_overloads
@@ -487,3 +487,9 @@ NULL
 statement ok
 RESET testing_optimizer_random_seed;
 RESET testing_optimizer_disable_rule_probability;
+
+query T rowsort
+SELECT _interval + _timestamp FROM many_types WHERE _timestamp - _interval IS NOT NULL
+----
+2018-01-01 13:34:56.124456 +0000 +0000
+2018-01-01 02:23:45.468345 +0000 +0000

--- a/pkg/sql/opt/exec/execbuilder/testdata/vectorize_overloads
+++ b/pkg/sql/opt/exec/execbuilder/testdata/vectorize_overloads
@@ -430,3 +430,13 @@ EXPLAIN (VEC) SELECT _int4 // _int FROM many_types WHERE _int <> 0
   └ *colexecproj.projFloorDivInt32Int64Op
     └ *colexecsel.selNEInt64Int64ConstOp
       └ *colfetcher.ColBatchScan
+
+query T
+EXPLAIN (VEC) SELECT _interval + _timestamp FROM many_types WHERE _timestamp - _interval IS NOT NULL
+----
+│
+└ Node 1
+  └ *colexecproj.projPlusIntervalTimestampOp
+    └ *colexec.isNullSelOp
+      └ *colexecproj.projMinusTimestampIntervalOp
+        └ *colfetcher.ColBatchScan

--- a/pkg/sql/sem/eval/eval_test/BUILD.bazel
+++ b/pkg/sql/sem/eval/eval_test/BUILD.bazel
@@ -33,6 +33,7 @@ go_test(
         "//pkg/testutils/serverutils",
         "//pkg/testutils/testcluster",
         "//pkg/util/leaktest",
+        "//pkg/util/log",
         "//pkg/util/randutil",
         "@com_github_cockroachdb_datadriven//:datadriven",
         "@com_github_stretchr_testify//require",

--- a/pkg/sql/sem/eval/eval_test/eval_test.go
+++ b/pkg/sql/sem/eval/eval_test/eval_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/datadriven"
 	"github.com/stretchr/testify/require"
 )
@@ -71,6 +72,8 @@ func TestEval(t *testing.T) {
 	// we have to also figure out what the expected output type is so we
 	// can correctly format the datum.
 	t.Run("sql", func(t *testing.T) {
+		defer log.Scope(t).Close(t)
+
 		s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{})
 		defer s.Stopper().Stop(ctx)
 


### PR DESCRIPTION
This commit allows the usage of existing native operators for evaluation of `timestamp` + / - `interval` and `interval` + `timestamp` expressions. Previously, this was disallowed out of caution but unnecessarily. The context is that we represent `timestamp` and `timestamptz` as the same type in the vectorized engine, and we currently have no way to distinguish between the two and make or omit the time zone adjustment. Thus, long time ago we prohibited mixed-type expressions with these types completely. However, we have existing correct implementation of some mixed-type expressions that use `timestamp` type, so it's actually safe to plan those, which this commit enables.

Additionally, it clarifies what limitations are for binary vs comparison expressions as well as which issue tracks addressing a particular limitation.

Epic: None

Release note: None