### PR TITLE
roachtest: use SI for ranges in cdc/workload

### DIFF
--- a/pkg/cmd/roachtest/tests/cdc_bench.go
+++ b/pkg/cmd/roachtest/tests/cdc_bench.go
@@ -123,8 +123,8 @@ func registerCDCBench(r registry.Registry) {
 			// Control run that only runs the workload, with no changefeed.
 			r.Add(registry.TestSpec{
 				Name: fmt.Sprintf(
-					"cdc/workload/kv%d/nodes=%d/cpu=%d/ranges=%d/control",
-					readPercent, nodes, cpus, ranges),
+					"cdc/workload/kv%d/nodes=%d/cpu=%d/ranges=%s/control",
+					readPercent, nodes, cpus, formatSI(ranges)),
 				Owner:           registry.OwnerCDC,
 				Benchmark:       true,
 				Cluster:         r.MakeClusterSpec(nodes+2, spec.CPU(cpus)),
@@ -141,8 +141,8 @@ func registerCDCBench(r registry.Registry) {
 					server, protocol := server, protocol // pin loop variables
 					r.Add(registry.TestSpec{
 						Name: fmt.Sprintf(
-							"cdc/workload/kv%d/nodes=%d/cpu=%d/ranges=%d/server=%s/protocol=%s/format=%s/sink=null",
-							readPercent, nodes, cpus, ranges, server, protocol, format),
+							"cdc/workload/kv%d/nodes=%d/cpu=%d/ranges=%s/server=%s/protocol=%s/format=%s/sink=null",
+							readPercent, nodes, cpus, formatSI(ranges), server, protocol, format),
 						Owner:           registry.OwnerCDC,
 						Benchmark:       true,
 						Cluster:         r.MakeClusterSpec(nodes+2, spec.CPU(cpus)),


### PR DESCRIPTION
I.e. format `ranges=100k` instead of `ranges=100000`, like we already do for `cdc/scan`.

Epic: none
Release note: None