### PR TITLE
kv: don't step read timestamp for read committed AOST txns

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
@@ -1836,7 +1836,8 @@ func TestPropagateTxnOnError(t *testing.T) {
 	epoch := 0
 	if err := db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
 		// Observe the commit timestamp to prevent refreshes.
-		_ = txn.CommitTimestamp()
+		_, err := txn.CommitTimestamp()
+		require.NoError(t, err)
 
 		epoch++
 		proto := txn.TestingCloneTxn()
@@ -1858,7 +1859,7 @@ func TestPropagateTxnOnError(t *testing.T) {
 		b.Put(keyA, "val")
 		b.CPut(keyB, "new_val", origBytes)
 		b.Put(keyC, "val2")
-		err := txn.CommitInBatch(ctx, b)
+		err = txn.CommitInBatch(ctx, b)
 		if epoch == 1 {
 			if retErr := (*kvpb.TransactionRetryWithProtoRefreshError)(nil); errors.As(err, &retErr) {
 				if !testutils.IsError(retErr, "ReadWithinUncertaintyIntervalError") {
@@ -3892,7 +3893,8 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 				}
 				// Read the commit timestamp so the expectation is that
 				// this transaction cannot be restarted internally.
-				_ = txn.CommitTimestamp()
+				_, err := txn.CommitTimestamp()
+				require.NoError(t, err)
 			}
 
 			if tc.priorReads {

--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
@@ -1086,30 +1086,33 @@ func (tc *TxnCoordSender) ProvisionalCommitTimestamp() hlc.Timestamp {
 }
 
 // CommitTimestamp is part of the kv.TxnSender interface.
-func (tc *TxnCoordSender) CommitTimestamp() hlc.Timestamp {
+func (tc *TxnCoordSender) CommitTimestamp() (hlc.Timestamp, error) {
 	tc.mu.Lock()
 	defer tc.mu.Unlock()
 	txn := &tc.mu.txn
-	if txn.Status == roachpb.COMMITTED {
-		return txn.ReadTimestamp
+	switch txn.Status {
+	case roachpb.COMMITTED:
+		return txn.ReadTimestamp, nil
+	case roachpb.ABORTED:
+		return hlc.Timestamp{}, errors.Errorf("CommitTimestamp called on aborted transaction")
+	default:
+		// If the transaction is not yet committed, configure the ReadTimestampFixed
+		// flag to ensure that the transaction's read timestamp is not pushed before
+		// it commits.
+		//
+		// This operates by disabling the transaction refresh mechanism. For
+		// isolation levels that can tolerate write skew, this is not enough to
+		// prevent the transaction from committing with a later timestamp. In fact,
+		// it's not even clear what timestamp to consider the "commit timestamp" for
+		// these transactions, given that they can read at one or more different
+		// timestamps than the one they eventually write at. For this reason, we
+		// disable the CommitTimestamp method for these isolation levels.
+		if txn.IsoLevel.ToleratesWriteSkew() {
+			return hlc.Timestamp{}, errors.Errorf("CommitTimestamp called on weak isolation transaction")
+		}
+		tc.mu.txn.ReadTimestampFixed = true
+		return txn.ReadTimestamp, nil
 	}
-	// If the transaction is not yet committed, configure the ReadTimestampFixed
-	// flag to ensure that the transaction's read timestamp is not pushed before
-	// it commits.
-	//
-	// This operates by disabling the transaction refresh mechanism. For isolation
-	// levels that can tolerate write skew, this is not enough to prevent the
-	// transaction from committing with a later timestamp. In fact, it's not even
-	// clear what timestamp to consider the "commit timestamp" for these
-	// transactions. For this reason, we currently disable the CommitTimestamp
-	// method for these isolation levels.
-	// TODO(nvanbenschoten): figure out something better to do here. At least
-	// return an error. Tracked in #103245.
-	if txn.IsoLevel.ToleratesWriteSkew() {
-		panic("unsupported")
-	}
-	tc.mu.txn.ReadTimestampFixed = true
-	return txn.ReadTimestamp
 }
 
 // SetFixedTimestamp is part of the kv.TxnSender interface.

--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
@@ -514,7 +514,7 @@ func (tc *TxnCoordSender) Send(
 		return nil, nil
 	}
 
-	if tc.mu.txn.IsoLevel.PerStatementReadSnapshot() {
+	if tc.shouldStepReadTimestampLocked() {
 		tc.maybeAutoStepReadTimestampLocked()
 	}
 
@@ -1375,7 +1375,7 @@ func (tc *TxnCoordSender) Step(ctx context.Context) error {
 	//}
 	tc.mu.Lock()
 	defer tc.mu.Unlock()
-	if tc.mu.txn.IsoLevel.PerStatementReadSnapshot() {
+	if tc.shouldStepReadTimestampLocked() {
 		tc.manualStepReadTimestampLocked()
 	}
 	return tc.interceptorAlloc.txnSeqNumAllocator.manualStepReadSeqLocked(ctx)
@@ -1489,6 +1489,16 @@ func (tc *TxnCoordSender) stepReadTimestampLocked() {
 	now := tc.clock.Now()
 	tc.mu.txn.BumpReadTimestamp(now)
 	tc.interceptorAlloc.txnSpanRefresher.resetRefreshSpansLocked()
+}
+
+// shouldStepReadTimestampLocked returns true if the transaction's read
+// timestamp should be advanced on each step, based on the transaction's
+// isolation level and whether its read timestamp has been fixed.
+//
+// The specific approach to stepping (manual vs. automatic) depends on the
+// configured the stepping mode.
+func (tc *TxnCoordSender) shouldStepReadTimestampLocked() bool {
+	return tc.mu.txn.IsoLevel.PerStatementReadSnapshot() && !tc.mu.txn.ReadTimestampFixed
 }
 
 // DeferCommitWait is part of the TxnSender interface.

--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender_test.go
@@ -2808,11 +2808,11 @@ func TestTxnCoordSenderSetFixedTimestamp(t *testing.T) {
 			if test.expErr != "" {
 				require.Error(t, err)
 				require.Regexp(t, test.expErr, err)
-				require.False(t, txn.CommitTimestampFixed())
+				require.False(t, txn.ReadTimestampFixed())
 			} else {
 				require.NoError(t, err)
-				require.True(t, txn.CommitTimestampFixed())
-				require.Equal(t, ts, txn.CommitTimestamp())
+				require.True(t, txn.ReadTimestampFixed())
+				require.Equal(t, ts, txn.ReadTimestamp())
 			}
 		})
 	}

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_span_refresher.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_span_refresher.go
@@ -645,7 +645,7 @@ func (sr *txnSpanRefresher) resetRefreshSpansLocked() {
 // It also requires that the txnSpanRefresher has been configured to allow
 // auto-retries.
 func (sr *txnSpanRefresher) canForwardReadTimestamp(txn *roachpb.Transaction) bool {
-	return sr.canAutoRetry && !txn.CommitTimestampFixed
+	return sr.canAutoRetry && !txn.ReadTimestampFixed
 }
 
 // canForwardReadTimestampWithoutRefresh returns whether the transaction can

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_span_refresher_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_span_refresher_test.go
@@ -1235,10 +1235,10 @@ func TestTxnSpanRefresherAssignsCanForwardReadTimestamp(t *testing.T) {
 	require.Equal(t, int64(0), tsr.metrics.ClientRefreshAutoRetries.Count())
 	require.Equal(t, int64(1), tsr.metrics.ServerRefreshSuccess.Count())
 
-	// Send a Put request for a transaction with a fixed commit timestamp.
+	// Send a Put request for a transaction with a fixed read timestamp.
 	// Should NOT set CanForwardReadTimestamp flag.
 	txnFixed := txn.Clone()
-	txnFixed.CommitTimestampFixed = true
+	txnFixed.ReadTimestampFixed = true
 	baFixed := &kvpb.BatchRequest{}
 	baFixed.Header = kvpb.Header{Txn: txnFixed}
 	baFixed.Add(&kvpb.PutRequest{RequestHeader: kvpb.RequestHeader{Key: keyA}})

--- a/pkg/kv/kvclient/rangefeed/rangefeedcache/cache_test.go
+++ b/pkg/kv/kvclient/rangefeed/rangefeedcache/cache_test.go
@@ -88,14 +88,18 @@ func TestCache(t *testing.T) {
 		}))
 		testutils.SucceedsSoon(t, func() error {
 			_, ts, ok := c.GetSnapshot()
-			if !ok || ts.Less(copied.CommitTimestamp()) {
+			commitTs, err := copied.CommitTimestamp()
+			require.NoError(t, err)
+			if !ok || ts.Less(commitTs) {
 				return errors.Errorf("cache not yet up to date")
 			}
 			return nil
 		})
 		resp := readRowsAt(t, s.Clock().Now())
 		got, _, _ := c.GetSnapshot()
-		require.Equalf(t, resp, got, "%v", copied.CommitTimestamp())
+		commitTs, err := copied.CommitTimestamp()
+		require.NoError(t, err)
+		require.Equalf(t, resp, got, "%v", commitTs)
 	}
 
 	// Initialize an empty cache.

--- a/pkg/kv/kvpb/data.go
+++ b/pkg/kv/kvpb/data.go
@@ -86,8 +86,8 @@ func PrepareTransactionForRetry(
 		if tErr.Reason == RETRY_SERIALIZABLE {
 			// For RETRY_SERIALIZABLE case, we want to bump timestamp further than
 			// timestamp cache.
-			// This helps transactions that had their commit timestamp fixed (See
-			// roachpb.Transaction.CommitTimestampFixed for details on when it happens)
+			// This helps transactions that had their read timestamp fixed (See
+			// roachpb.Transaction.ReadTimestampFixed for details on when it happens)
 			// or transactions that hit read-write contention and can't bump
 			// read timestamp because of later writes.
 			// Upon retry, we want those transactions to restart on now() instead of

--- a/pkg/kv/kvserver/batcheval/cmd_add_sstable_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_add_sstable_test.go
@@ -1879,7 +1879,8 @@ func TestAddSSTableSSTTimestampToRequestTimestampRespectsTSCache(t *testing.T) {
 	txn := db.NewTxn(ctx, "txn")
 	require.NoError(t, txn.Put(ctx, "key", "txn"))
 	require.NoError(t, txn.Commit(ctx))
-	txnTS := txn.CommitTimestamp()
+	txnTS, err := txn.CommitTimestamp()
+	require.NoError(t, err)
 
 	// Add an SST writing below the previous write.
 	sst, start, end := storageutils.MakeSST(t, s.ClusterSettings(), kvs{pointKV("key", 1, "sst")})

--- a/pkg/kv/kvserver/protectedts/ptcache/cache_test.go
+++ b/pkg/kv/kvserver/protectedts/ptcache/cache_test.go
@@ -68,7 +68,7 @@ func (idb *internalDBWithLastCommit) Txn(
 		return f(ctx, txn)
 	})
 	if err == nil {
-		idb.lastCommit = kvTxn.CommitTimestamp()
+		idb.lastCommit, err = kvTxn.CommitTimestamp()
 	}
 	return err
 }

--- a/pkg/kv/mock_transactional_sender.go
+++ b/pkg/kv/mock_transactional_sender.go
@@ -124,8 +124,8 @@ func (m *MockTransactionalSender) ProvisionalCommitTimestamp() hlc.Timestamp {
 }
 
 // CommitTimestamp is part of the TxnSender interface.
-func (m *MockTransactionalSender) CommitTimestamp() hlc.Timestamp {
-	return m.txn.ReadTimestamp
+func (m *MockTransactionalSender) CommitTimestamp() (hlc.Timestamp, error) {
+	return m.txn.ReadTimestamp, nil
 }
 
 // SetFixedTimestamp is part of the TxnSender interface.

--- a/pkg/kv/mock_transactional_sender.go
+++ b/pkg/kv/mock_transactional_sender.go
@@ -113,6 +113,11 @@ func (m *MockTransactionalSender) ReadTimestamp() hlc.Timestamp {
 	return m.txn.ReadTimestamp
 }
 
+// ReadTimestampFixed is part of the TxnSender interface.
+func (m *MockTransactionalSender) ReadTimestampFixed() bool {
+	return m.txn.ReadTimestampFixed
+}
+
 // ProvisionalCommitTimestamp is part of the TxnSender interface.
 func (m *MockTransactionalSender) ProvisionalCommitTimestamp() hlc.Timestamp {
 	return m.txn.WriteTimestamp
@@ -123,17 +128,12 @@ func (m *MockTransactionalSender) CommitTimestamp() hlc.Timestamp {
 	return m.txn.ReadTimestamp
 }
 
-// CommitTimestampFixed is part of the TxnSender interface.
-func (m *MockTransactionalSender) CommitTimestampFixed() bool {
-	return m.txn.CommitTimestampFixed
-}
-
 // SetFixedTimestamp is part of the TxnSender interface.
 func (m *MockTransactionalSender) SetFixedTimestamp(_ context.Context, ts hlc.Timestamp) error {
 	m.txn.WriteTimestamp = ts
 	m.txn.ReadTimestamp = ts
+	m.txn.ReadTimestampFixed = true
 	m.txn.GlobalUncertaintyLimit = ts
-	m.txn.CommitTimestampFixed = true
 
 	// Set the MinTimestamp to the minimum of the existing MinTimestamp and the fixed
 	// timestamp. This ensures that the MinTimestamp is always <= the other timestamps.

--- a/pkg/kv/sender.go
+++ b/pkg/kv/sender.go
@@ -220,6 +220,10 @@ type TxnSender interface {
 	// timestamp. Use CommitTimestamp() when needed.
 	ReadTimestamp() hlc.Timestamp
 
+	// ReadTimestampFixed returns true if the read timestamp has been fixed
+	// and cannot be pushed forward.
+	ReadTimestampFixed() bool
+
 	// CommitTimestamp returns the transaction's start timestamp.
 	//
 	// This method is guaranteed to always return the same value while
@@ -231,12 +235,8 @@ type TxnSender interface {
 	// In other words, using this method just once increases the
 	// likelihood that a retry error will bubble up to a client.
 	//
-	// See CommitTimestampFixed() below.
+	// See ReadTimestampFixed() above.
 	CommitTimestamp() hlc.Timestamp
-
-	// CommitTimestampFixed returns true if the commit timestamp has
-	// been fixed to the start timestamp and cannot be pushed forward.
-	CommitTimestampFixed() bool
 
 	// ProvisionalCommitTimestamp returns the transaction's provisional
 	// commit timestamp. This can move forward throughout the txn's

--- a/pkg/kv/sender.go
+++ b/pkg/kv/sender.go
@@ -224,19 +224,25 @@ type TxnSender interface {
 	// and cannot be pushed forward.
 	ReadTimestampFixed() bool
 
-	// CommitTimestamp returns the transaction's start timestamp.
+	// CommitTimestamp returns the transaction's commit timestamp.
 	//
-	// This method is guaranteed to always return the same value while
-	// the transaction is open. To achieve this, the first call to this
-	// method also anchors the start timestamp and prevents the sender
-	// from automatically pushing transactions forward (i.e. handling
-	// certain forms of contention / txn conflicts automatically).
+	// If the transaction is committed, the method returns the timestamp at
+	// which the transaction performed all of its writes.
 	//
-	// In other words, using this method just once increases the
-	// likelihood that a retry error will bubble up to a client.
+	// If the transaction is aborted, the method returns an error.
 	//
-	// See ReadTimestampFixed() above.
-	CommitTimestamp() hlc.Timestamp
+	// If the transaction is pending and running under serializable isolation,
+	// the method returns the transaction's current provisional commit
+	// timestamp. It also fixes the transaction's read timestamp to ensure
+	// that the transaction cannot be pushed to a later timestamp and still
+	// commit. It does so by disabling read refreshes. As a result, using this
+	// method just once increases the likelihood that a retry error will
+	// bubble up to a client.
+	//
+	// If the transaction is pending and running under a weak isolation level,
+	// the method returns an error. Fixing the commit timestamp early is not
+	// supported for transactions running under weak isolation levels.
+	CommitTimestamp() (hlc.Timestamp, error)
 
 	// ProvisionalCommitTimestamp returns the transaction's provisional
 	// commit timestamp. This can move forward throughout the txn's

--- a/pkg/kv/txn.go
+++ b/pkg/kv/txn.go
@@ -397,12 +397,25 @@ func (txn *Txn) ReadTimestampFixed() bool {
 	return txn.mu.sender.ReadTimestampFixed()
 }
 
-// CommitTimestamp returns the transaction's start timestamp.
-// The start timestamp can get pushed but the use of this
-// method will guarantee that if a timestamp push is needed
-// the commit will fail with a retryable error.
-// TODO(nvanbenschoten): clean up this comment.
-func (txn *Txn) CommitTimestamp() hlc.Timestamp {
+// CommitTimestamp returns the transaction's commit timestamp.
+//
+// If the transaction is committed, the method returns the timestamp at
+// which the transaction performed all of its writes.
+//
+// If the transaction is aborted, the method returns an error.
+//
+// If the transaction is pending and running under serializable isolation,
+// the method returns the transaction's current provisional commit
+// timestamp. It also fixes the transaction's read timestamp to ensure
+// that the transaction cannot be pushed to a later timestamp and still
+// commit. It does so by disabling read refreshes. As a result, using this
+// method just once increases the likelihood that a retry error will
+// bubble up to a client.
+//
+// If the transaction is pending and running under a weak isolation level,
+// the method returns an error. Fixing the commit timestamp prematurely is
+// not supported for transactions running under weak isolation levels.
+func (txn *Txn) CommitTimestamp() (hlc.Timestamp, error) {
 	txn.mu.Lock()
 	defer txn.mu.Unlock()
 	return txn.mu.sender.CommitTimestamp()

--- a/pkg/kv/txn_external_test.go
+++ b/pkg/kv/txn_external_test.go
@@ -462,14 +462,14 @@ func testTxnNegotiateAndSendDoesNotBlock(t *testing.T, multiRange, strict, route
 						return pErr.GoError()
 					}
 
-					// Validate that the transaction timestamp is now fixed and set to the
-					// request timestamp.
-					if !txn.CommitTimestampFixed() {
-						return errors.Errorf("transaction timestamp not fixed")
+					// Validate that the transaction's read timestamp is now fixed and set
+					// to the request timestamp.
+					if !txn.ReadTimestampFixed() {
+						return errors.Errorf("transaction's read timestamp not fixed")
 					}
-					txnTS := txn.CommitTimestamp()
+					txnTS := txn.ReadTimestamp()
 					if txnTS != br.Timestamp {
-						return errors.Errorf("transaction timestamp (%s) does not equal request timestamp (%s)", txnTS, br.Timestamp)
+						return errors.Errorf("transaction's read timestamp (%s) does not equal request timestamp (%s)", txnTS, br.Timestamp)
 					}
 
 					// Validate that the transaction timestamp increases monotonically

--- a/pkg/kv/txn_external_test.go
+++ b/pkg/kv/txn_external_test.go
@@ -796,7 +796,7 @@ func TestUpdateRootWithLeafFinalStateReadsBelowRefreshTimestamp(t *testing.T) {
 		if err := conflictTxn.Commit(ctx); err != nil {
 			return hlc.Timestamp{}, err
 		}
-		return conflictTxn.CommitTimestamp(), nil
+		return conflictTxn.CommitTimestamp()
 	}
 	err := db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
 		// Perform a read to set the timestamp.

--- a/pkg/kv/txn_test.go
+++ b/pkg/kv/txn_test.go
@@ -580,13 +580,13 @@ func TestTxnNegotiateAndSend(t *testing.T) {
 			require.Nil(t, pErr)
 			require.NotNil(t, br)
 			require.Equal(t, ts20, br.Timestamp)
-			require.True(t, txn.CommitTimestampFixed())
-			require.Equal(t, ts20, txn.CommitTimestamp())
+			require.True(t, txn.ReadTimestampFixed())
+			require.Equal(t, ts20, txn.ReadTimestamp())
 		} else {
 			require.Nil(t, br)
 			require.NotNil(t, pErr)
 			require.Regexp(t, "unimplemented: cross-range bounded staleness reads not yet implemented", pErr)
-			require.False(t, txn.CommitTimestampFixed())
+			require.False(t, txn.ReadTimestampFixed())
 		}
 	})
 }
@@ -691,13 +691,13 @@ func TestTxnNegotiateAndSendWithDeadline(t *testing.T) {
 				require.Nil(t, pErr)
 				require.NotNil(t, br)
 				require.Equal(t, minTSBound, br.Timestamp)
-				require.True(t, txn.CommitTimestampFixed())
-				require.Equal(t, minTSBound, txn.CommitTimestamp())
+				require.True(t, txn.ReadTimestampFixed())
+				require.Equal(t, minTSBound, txn.ReadTimestamp())
 			} else {
 				require.Nil(t, br)
 				require.NotNil(t, pErr)
 				require.Regexp(t, test.expErr, pErr)
-				require.False(t, txn.CommitTimestampFixed())
+				require.False(t, txn.ReadTimestampFixed())
 			}
 		})
 	}
@@ -762,8 +762,8 @@ func TestTxnNegotiateAndSendWithResumeSpan(t *testing.T) {
 			require.NotNil(t, br)
 			// The negotiated timestamp should be returned and fixed.
 			require.Equal(t, ts20, br.Timestamp)
-			require.True(t, txn.CommitTimestampFixed())
-			require.Equal(t, ts20, txn.CommitTimestamp())
+			require.True(t, txn.ReadTimestampFixed())
+			require.Equal(t, ts20, txn.ReadTimestamp())
 			// Even though the response is paginated and carries a resume span.
 			require.Len(t, br.Responses, 1)
 			scanResp := br.Responses[0].GetScan()
@@ -776,7 +776,7 @@ func TestTxnNegotiateAndSendWithResumeSpan(t *testing.T) {
 			require.Nil(t, br)
 			require.NotNil(t, pErr)
 			require.Regexp(t, "unimplemented: cross-range bounded staleness reads not yet implemented", pErr)
-			require.False(t, txn.CommitTimestampFixed())
+			require.False(t, txn.ReadTimestampFixed())
 		}
 	})
 }

--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -1168,7 +1168,7 @@ func (t *Transaction) Restart(
 	// Reset all epoch-scoped state.
 	t.Sequence = 0
 	t.WriteTooOld = false
-	t.CommitTimestampFixed = false
+	t.ReadTimestampFixed = false
 	t.LockSpans = nil
 	t.InFlightWrites = nil
 	t.IgnoredSeqNums = nil
@@ -1238,7 +1238,7 @@ func (t *Transaction) Update(o *Transaction) {
 		t.Epoch = o.Epoch
 		t.Status = o.Status
 		t.WriteTooOld = o.WriteTooOld
-		t.CommitTimestampFixed = o.CommitTimestampFixed
+		t.ReadTimestampFixed = o.ReadTimestampFixed
 		t.Sequence = o.Sequence
 		t.LockSpans = o.LockSpans
 		t.InFlightWrites = o.InFlightWrites
@@ -1264,7 +1264,7 @@ func (t *Transaction) Update(o *Transaction) {
 			// If neither of the transactions has a bumped ReadTimestamp, then the
 			// WriteTooOld flag is cumulative.
 			t.WriteTooOld = t.WriteTooOld || o.WriteTooOld
-			t.CommitTimestampFixed = t.CommitTimestampFixed || o.CommitTimestampFixed
+			t.ReadTimestampFixed = t.ReadTimestampFixed || o.ReadTimestampFixed
 		} else if t.ReadTimestamp.Less(o.ReadTimestamp) {
 			// If `o` has a higher ReadTimestamp (i.e. it's the result of a refresh,
 			// which refresh generally clears the WriteTooOld field), then it dictates
@@ -1272,7 +1272,7 @@ func (t *Transaction) Update(o *Transaction) {
 			// concurrently with any requests whose response's WriteTooOld field
 			// matters.
 			t.WriteTooOld = o.WriteTooOld
-			t.CommitTimestampFixed = o.CommitTimestampFixed
+			t.ReadTimestampFixed = o.ReadTimestampFixed
 		}
 		// If t has a higher ReadTimestamp, than it gets to dictate the
 		// WriteTooOld field - so there's nothing to update.

--- a/pkg/roachpb/data.proto
+++ b/pkg/roachpb/data.proto
@@ -390,7 +390,6 @@ message Transaction {
   // be modified. If true, this prevents the transaction's timestamp from being
   // adjusted by a read refresh or, for read committed transactions, by a read
   // timestamp step.
-  // TODO(nvanbenschoten): implement this second limitation.
   //
   // For serializable transactions (who do not tolerate write skew), this flag
   // also has the effect of fixing the transaction's commit timestamp. This

--- a/pkg/roachpb/data.proto
+++ b/pkg/roachpb/data.proto
@@ -369,12 +369,6 @@ message Transaction {
   // large diff that doesn't seem worth it, given that we never feed this
   // timestamp back into a clock.
   util.hlc.Timestamp last_heartbeat = 5 [(gogoproto.nullable) = false];
-  // This flag is set if the transaction's timestamp was "leaked" beyond the
-  // transaction (e.g. via cluster_logical_timestamp()). If true, this prevents
-  // the transaction's timestamp from being pushed, which means that the txn
-  // can't commit at a higher timestamp without resorting to a client-side
-  // retry.
-  bool commit_timestamp_fixed = 16;
   // The transaction's read timestamp. All reads are performed at this
   // timestamp, ensuring that the transaction runs on top of a consistent
   // snapshot of the database.
@@ -392,6 +386,19 @@ message Transaction {
   // successful refresh or, if the refresh is unsuccessful, after a transaction
   // restart.
   util.hlc.Timestamp read_timestamp = 15 [(gogoproto.nullable) = false];
+  // This flag is set if the transaction's read timestamp is fixed and can not
+  // be modified. If true, this prevents the transaction's timestamp from being
+  // adjusted by a read refresh or, for read committed transactions, by a read
+  // timestamp step.
+  // TODO(nvanbenschoten): implement this second limitation.
+  //
+  // For serializable transactions (who do not tolerate write skew), this flag
+  // also has the effect of fixing the transaction's commit timestamp. This
+  // means that the txn can not commit at a higher timestamp than its read
+  // timestamp without resorting to a client-side retry. For this reason, the
+  // flag is set if the transaction's timestamp was "leaked" beyond the
+  // transaction (e.g. via cluster_logical_timestamp()).
+  bool read_timestamp_fixed = 16;
   // The transaction's global uncertainty limit is its initial timestamp +
   // maximum cluster-wide clock skew. This value defines the inclusive upper
   // bound of the transaction's uncertainty interval.

--- a/pkg/roachpb/data_test.go
+++ b/pkg/roachpb/data_test.go
@@ -563,11 +563,11 @@ var nonZeroTxn = Transaction{
 			Synthetic: true, // normally not set, but needed for zerofields.NoZeroField
 		},
 	}},
-	WriteTooOld:          true,
-	LockSpans:            []Span{{Key: []byte("a"), EndKey: []byte("b")}},
-	InFlightWrites:       []SequencedWrite{{Key: []byte("c"), Sequence: 1}},
-	CommitTimestampFixed: true,
-	IgnoredSeqNums:       []enginepb.IgnoredSeqNumRange{{Start: 888, End: 999}},
+	WriteTooOld:        true,
+	LockSpans:          []Span{{Key: []byte("a"), EndKey: []byte("b")}},
+	InFlightWrites:     []SequencedWrite{{Key: []byte("c"), Sequence: 1}},
+	ReadTimestampFixed: true,
+	IgnoredSeqNums:     []enginepb.IgnoredSeqNumRange{{Start: 888, End: 999}},
 }
 
 func TestTransactionUpdate(t *testing.T) {
@@ -657,7 +657,7 @@ func TestTransactionUpdate(t *testing.T) {
 	expTxn5.InFlightWrites = nil
 	expTxn5.IgnoredSeqNums = nil
 	expTxn5.WriteTooOld = false
-	expTxn5.CommitTimestampFixed = false
+	expTxn5.ReadTimestampFixed = false
 	require.Equal(t, expTxn5, txn5)
 
 	// Updating a different transaction fatals.
@@ -788,7 +788,7 @@ func TestTransactionRestart(t *testing.T) {
 	expTxn.WriteTimestamp = makeTS(25, 1)
 	expTxn.ReadTimestamp = makeTS(25, 1)
 	expTxn.WriteTooOld = false
-	expTxn.CommitTimestampFixed = false
+	expTxn.ReadTimestampFixed = false
 	expTxn.LockSpans = nil
 	expTxn.InFlightWrites = nil
 	expTxn.IgnoredSeqNums = nil

--- a/pkg/spanconfig/spanconfigreconciler/reconciler.go
+++ b/pkg/spanconfig/spanconfigreconciler/reconciler.go
@@ -242,7 +242,10 @@ func (f *fullReconciler) reconcile(
 	}); err != nil {
 		return nil, hlc.Timestamp{}, err
 	}
-	readTimestamp := kvTxn.CommitTimestamp()
+	readTimestamp, err := kvTxn.CommitTimestamp()
+	if err != nil {
+		return nil, hlc.Timestamp{}, err
+	}
 
 	updates := make([]spanconfig.Update, len(records))
 	for i, record := range records {

--- a/pkg/sql/backfill/mvcc_index_merger.go
+++ b/pkg/sql/backfill/mvcc_index_merger.go
@@ -353,11 +353,12 @@ func (ibm *IndexBackfillMerger) merge(
 	) error {
 		var deletedCount int
 		txn.KV().AddCommitTrigger(func(ctx context.Context) {
+			commitTs, _ := txn.KV().CommitTimestamp()
 			log.VInfof(ctx, 2, "merged batch of %d keys (%d deletes) (span: %s) (commit timestamp: %s)",
 				len(sourceKeys),
 				deletedCount,
 				sourceSpan,
-				txn.KV().CommitTimestamp(),
+				commitTs,
 			)
 		})
 		if len(sourceKeys) == 0 {

--- a/pkg/sql/conn_executor_show_commit_timestamp.go
+++ b/pkg/sql/conn_executor_show_commit_timestamp.go
@@ -58,9 +58,11 @@ func (ex *connExecutor) execShowCommitTimestampInOpenState(
 	err := ex.commitSQLTransactionInternal(ctx)
 	if err == nil {
 
-		if err := writeShowCommitTimestampRow(
-			ctx, res, ex.state.mu.txn.CommitTimestamp(),
-		); err != nil {
+		ts, err := ex.state.mu.txn.CommitTimestamp()
+		if err != nil {
+			return ex.makeErrEvent(err, s)
+		}
+		if err := writeShowCommitTimestampRow(ctx, res, ts); err != nil {
 			return ex.makeErrEvent(err, s)
 		}
 
@@ -108,9 +110,11 @@ func (ex *connExecutor) execShowCommitTimestampInOpenState(
 func (ex *connExecutor) execShowCommitTimestampInCommitWaitState(
 	ctx context.Context, s *tree.ShowCommitTimestamp, res RestrictedCommandResult,
 ) (fsm.Event, fsm.EventPayload) {
-	if err := writeShowCommitTimestampRow(
-		ctx, res, ex.state.mu.txn.CommitTimestamp(),
-	); err != nil {
+	ts, err := ex.state.mu.txn.CommitTimestamp()
+	if err != nil {
+		return ex.makeErrEvent(err, s)
+	}
+	if err := writeShowCommitTimestampRow(ctx, res, ts); err != nil {
 		return ex.makeErrEvent(err, s)
 	}
 	return nil, nil

--- a/pkg/sql/drop_test.go
+++ b/pkg/sql/drop_test.go
@@ -780,7 +780,11 @@ func TestDropTableDeleteData(t *testing.T) {
 
 func writeTableDesc(ctx context.Context, db *kv.DB, tableDesc *tabledesc.Mutable) error {
 	return db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
-		tableDesc.ModificationTime = txn.CommitTimestamp()
+		var err error
+		tableDesc.ModificationTime, err = txn.CommitTimestamp()
+		if err != nil {
+			return err
+		}
 		return txn.Put(ctx, catalogkeys.MakeDescMetadataKey(keys.SystemSQLCodec, tableDesc.ID), tableDesc.DescriptorProto())
 	})
 }

--- a/pkg/sql/internal_test.go
+++ b/pkg/sql/internal_test.go
@@ -558,7 +558,8 @@ func TestInternalExecutorPushDetectionInTxn(t *testing.T) {
 			}
 			if tt.serializable && !tt.refreshable {
 				// Fix the txn's timestamp to prevent refreshes.
-				txn.CommitTimestamp()
+				_, err := txn.CommitTimestamp()
+				require.NoError(t, err)
 			}
 
 			// Are txn.IsSerializablePushAndRefreshNotPossible() and the connExecutor

--- a/pkg/sql/sem/eval/context.go
+++ b/pkg/sql/sem/eval/context.go
@@ -557,7 +557,10 @@ func (ec *Context) GetClusterTimestamp() (*tree.DDecimal, error) {
 		return nil, pgerror.Newf(pgcode.FeatureNotSupported, "unsupported in %s isolation", treeIso.String())
 	}
 
-	ts := ec.Txn.CommitTimestamp()
+	ts, err := ec.Txn.CommitTimestamp()
+	if err != nil {
+		return nil, err
+	}
 	if ts.IsEmpty() {
 		return nil, errors.AssertionFailedf("zero cluster timestamp in txn")
 	}

--- a/pkg/sql/txn_state.go
+++ b/pkg/sql/txn_state.go
@@ -290,7 +290,11 @@ func (ts *txnState) finishSQLTxn() (txnID uuid.UUID, commitTimestamp hlc.Timesta
 		defer ts.mu.Unlock()
 		txnID = ts.mu.txn.ID()
 		if ts.mu.txn.IsCommitted() {
-			timestamp = ts.mu.txn.CommitTimestamp()
+			var err error
+			timestamp, err = ts.mu.txn.CommitTimestamp()
+			if err != nil {
+				panic(errors.Wrapf(err, "failed to get commit timestamp of committed txn"))
+			}
 		}
 		ts.mu.txn = nil
 		ts.mu.txnStart = time.Time{}


### PR DESCRIPTION
Fixes #100154.

The first two commits here are predominantly refactors. The third addresses the issue.

This commit updates the stepping logic in the TxnCoordSender to not step a read committed transaction's read timestamp if the transaction's read timestamp has been fixed. This fixes AS OF SYSTEM TIME transactions and, in particular, follower reads in read committed transactions.

Once this lands, I'd like to follow it up with an enhancement to the `follower-reads` roachtest suite to run follower reads under weak isolation transactions. This is tracked in #108671.

Release note: None