### PR TITLE
kvclient/kvcoord: respect rangefeed closedts interval in stuck watcher

### DIFF
--- a/pkg/kv/kvclient/kvcoord/BUILD.bazel
+++ b/pkg/kv/kvclient/kvcoord/BUILD.bazel
@@ -50,6 +50,7 @@ go_library(
         "//pkg/kv/kvserver/closedts",
         "//pkg/kv/kvserver/concurrency/isolation",
         "//pkg/kv/kvserver/concurrency/lock",
+        "//pkg/kv/kvserver/kvserverbase",
         "//pkg/kv/kvserver/txnwait",
         "//pkg/multitenant",
         "//pkg/multitenant/tenantcostmodel",

--- a/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/rangecache"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/closedts"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
@@ -675,13 +676,17 @@ func makeRangeFeedRequest(
 func defaultStuckRangeThreshold(st *cluster.Settings) func() time.Duration {
 	return func() time.Duration {
 		// Before the introduction of kv.rangefeed.range_stuck_threshold = 1m,
-		// clusters may already have kv.closed_timestamp.side_transport_interval set
-		// to >1m. This would cause rangefeeds to continually restart. We therefore
-		// conservatively use the highest value.
+		// clusters may already have kv.closed_timestamp.side_transport_interval or
+		// kv.rangefeed.closed_timestamp_refresh_interval set to >1m. This would
+		// cause rangefeeds to continually restart. We therefore conservatively use
+		// the highest value, with a 1.2 safety factor.
 		threshold := rangefeedRangeStuckThreshold.Get(&st.SV)
 		if threshold > 0 {
-			if t := time.Duration(math.Round(
-				1.2 * float64(closedts.SideTransportCloseInterval.Get(&st.SV)))); t > threshold {
+			interval := kvserverbase.RangeFeedRefreshInterval.Get(&st.SV)
+			if i := closedts.SideTransportCloseInterval.Get(&st.SV); i > interval {
+				interval = i
+			}
+			if t := time.Duration(math.Round(1.2 * float64(interval))); t > threshold {
 				threshold = t
 			}
 		}

--- a/pkg/kv/kvserver/kvserverbase/base.go
+++ b/pkg/kv/kvserver/kvserverbase/base.go
@@ -108,6 +108,10 @@ var MVCCGCQueueEnabled = settings.RegisterBoolSetting(
 	true,
 )
 
+// RangeFeedRefreshInterval is injected from kvserver to avoid import cycles
+// when accessed from kvcoord.
+var RangeFeedRefreshInterval *settings.DurationSetting
+
 // CmdIDKey is a Raft command id. This will be logged unredacted - keep it random.
 type CmdIDKey string
 

--- a/pkg/kv/kvserver/replica_rangefeed.go
+++ b/pkg/kv/kvserver/replica_rangefeed.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/closedts"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/intentresolver"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/rangefeed"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -73,6 +74,11 @@ var RangeFeedSmearInterval = settings.RegisterDurationSetting(
 	1*time.Millisecond,
 	settings.NonNegativeDuration,
 )
+
+func init() {
+	// Inject into kvserverbase to allow usage from kvcoord.
+	kvserverbase.RangeFeedRefreshInterval = RangeFeedRefreshInterval
+}
 
 // defaultEventChanCap is the channel capacity of the rangefeed processor and
 // each registration.


### PR DESCRIPTION
The threshold for the DistSender stuck rangefeed watcher is configured by `kv.rangefeed.range_stuck_threshold`. However, if `kv.closed_timestamp.side_transport_interval` was greater, it took precedence. `kv.rangefeed.closed_timestamp_refresh_interval` wasn't checked though, it should.

Resolves #108666.

Epic: none
Release note: None