### PR TITLE
sql/resolver: rename AvoidLeased to AssertNotLeased

### DIFF
--- a/pkg/sql/catalog/descs/descriptor.go
+++ b/pkg/sql/catalog/descs/descriptor.go
@@ -481,7 +481,7 @@ func (tc *Collection) getVirtualDescriptorByName(
 // getNonVirtualDescriptorID looks up a non-virtual descriptor ID by name by
 // going through layers in sequence.
 //
-// All flags except AvoidLeased, RequireMutable and AvoidSynthetic are ignored.
+// All flags except AssertNotLeased, RequireMutable and AvoidSynthetic are ignored.
 func (tc *Collection) getNonVirtualDescriptorID(
 	ctx context.Context,
 	txn *kv.Txn,

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -1214,7 +1214,7 @@ func (p *planner) ResolveExistingObjectEx(
 ) (res catalog.TableDescriptor, err error) {
 	lookupFlags := tree.ObjectLookupFlags{
 		Required:             required,
-		AvoidLeased:          p.skipDescriptorCache,
+		AssertNotLeased:      p.skipDescriptorCache,
 		DesiredObjectKind:    tree.TableObject,
 		DesiredTableDescKind: requiredType,
 	}

--- a/pkg/sql/schema_resolver.go
+++ b/pkg/sql/schema_resolver.go
@@ -153,6 +153,14 @@ func (sr *schemaResolver) LookupObject(
 
 	b := sr.descCollection.ByName(sr.txn)
 	if !sr.skipDescriptorCache && !flags.RequireMutable {
+		// The caller requires this descriptor to *not* be leased,
+		// so lets assert this here. Normally the planner / resolver
+		// will propagate flags so we don' need to check on a
+		// look up level.
+		if flags.AssertNotLeased {
+			return false, prefix, nil,
+				errors.AssertionFailedf("unable to get leased descriptor for (%q), resolver was not configured properly", obName)
+		}
 		b = sr.descCollection.ByNameWithLeased(sr.txn)
 	}
 	if flags.IncludeOffline {

--- a/pkg/sql/schemachanger/scdeps/build_deps.go
+++ b/pkg/sql/schemachanger/scdeps/build_deps.go
@@ -179,7 +179,7 @@ func (d *buildDeps) MayResolveTable(
 	ctx context.Context, name tree.UnresolvedObjectName,
 ) (catalog.ResolvedObjectPrefix, catalog.TableDescriptor) {
 	desc, prefix, err := resolver.ResolveExistingObject(ctx, d.schemaResolver, &name, tree.ObjectLookupFlags{
-		AvoidLeased:       true,
+		AssertNotLeased:   true,
 		DesiredObjectKind: tree.TableObject,
 	})
 	if err != nil {
@@ -196,7 +196,7 @@ func (d *buildDeps) MayResolveType(
 	ctx context.Context, name tree.UnresolvedObjectName,
 ) (catalog.ResolvedObjectPrefix, catalog.TypeDescriptor) {
 	desc, prefix, err := resolver.ResolveExistingObject(ctx, d.schemaResolver, &name, tree.ObjectLookupFlags{
-		AvoidLeased:       true,
+		AssertNotLeased:   true,
 		DesiredObjectKind: tree.TypeObject,
 	})
 	if err != nil {

--- a/pkg/sql/sem/tree/name_resolution.go
+++ b/pkg/sql/sem/tree/name_resolution.go
@@ -190,9 +190,9 @@ type ObjectLookupFlags struct {
 	Required bool
 	// RequireMutable specifies whether to return a mutable descriptor.
 	RequireMutable bool
-	// AvoidLeased, if set, avoid the leased (possibly stale) version of the
+	// AssertNotLeased, if set, avoid the leased (possibly stale) version of the
 	// descriptor. It must be set when callers want consistent reads.
-	AvoidLeased bool
+	AssertNotLeased bool
 	// IncludeOffline specifies if offline descriptors should be visible.
 	IncludeOffline bool
 	// AllowWithoutPrimaryKey specifies if tables without PKs can be resolved.


### PR DESCRIPTION
Previously, we had a flag to avoid leased descriptors, which did not do anything within look-up contexts. This was because this flag was never really used since skipping leased descriptors happens at a higher level with flags on the resolver. To address this, this
the patch will make this flag more useful by making it an assertion that no leased descriptor is being used in these contexts.

Release note: None