### PR TITLE
release-23.1: kvclient/kvcoord: respect rangefeed closedts interval in stuck watcher

### DIFF
--- a/pkg/kv/kvclient/kvcoord/BUILD.bazel
+++ b/pkg/kv/kvclient/kvcoord/BUILD.bazel
@@ -49,6 +49,7 @@ go_library(
         "//pkg/kv/kvpb",
         "//pkg/kv/kvserver/closedts",
         "//pkg/kv/kvserver/concurrency/lock",
+        "//pkg/kv/kvserver/kvserverbase",
         "//pkg/kv/kvserver/txnwait",
         "//pkg/multitenant",
         "//pkg/multitenant/tenantcostmodel",

--- a/pkg/kv/kvserver/kvserverbase/base.go
+++ b/pkg/kv/kvserver/kvserverbase/base.go
@@ -63,6 +63,10 @@ var MVCCGCQueueEnabled = settings.RegisterBoolSetting(
 	true,
 )
 
+// RangeFeedRefreshInterval is injected from kvserver to avoid import cycles
+// when accessed from kvcoord.
+var RangeFeedRefreshInterval *settings.DurationSetting
+
 // CmdIDKey is a Raft command id. This will be logged unredacted - keep it random.
 type CmdIDKey string
 

--- a/pkg/kv/kvserver/replica_rangefeed.go
+++ b/pkg/kv/kvserver/replica_rangefeed.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/closedts"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/intentresolver"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/rangefeed"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -73,6 +74,11 @@ var RangeFeedSmearInterval = settings.RegisterDurationSetting(
 	0,
 	settings.NonNegativeDuration,
 )
+
+func init() {
+	// Inject into kvserverbase to allow usage from kvcoord.
+	kvserverbase.RangeFeedRefreshInterval = RangeFeedRefreshInterval
+}
 
 // lockedRangefeedStream is an implementation of rangefeed.Stream which provides
 // support for concurrent calls to Send. Note that the default implementation of


### PR DESCRIPTION
Backport 1/1 commits from #108679.

/cc @cockroachdb/release

---

The threshold for the DistSender stuck rangefeed watcher is configured by `kv.rangefeed.range_stuck_threshold`. However, if `kv.closed_timestamp.side_transport_interval` was greater, it took precedence. `kv.rangefeed.closed_timestamp_refresh_interval` wasn't checked though, it should.

Resolves #108666.

Epic: none
Release note: None
