### PR TITLE
release-23.1: changefeedccl: Reject subquery in alter changefeed

### DIFF
--- a/pkg/ccl/changefeedccl/alter_changefeed_test.go
+++ b/pkg/ccl/changefeedccl/alter_changefeed_test.go
@@ -563,6 +563,11 @@ func TestAlterChangefeedErrors(t *testing.T) {
 			`pq: cannot specify both "initial_scan" and "no_initial_scan"`,
 			fmt.Sprintf(`ALTER CHANGEFEED %d ADD bar WITH initial_scan, no_initial_scan`, feed.JobID()),
 		)
+
+		sqlDB.ExpectErr(t, "pq: changefeed ID must be an INT value: subqueries are not allowed in cdc",
+			"ALTER CHANGEFEED (SELECT 1) ADD bar")
+		sqlDB.ExpectErr(t, "pq: changefeed ID must be an INT value: could not parse \"two\" as type int",
+			"ALTER CHANGEFEED 'two' ADD bar")
 	}
 
 	cdcTest(t, testFn, feedTestEnterpriseSinks, feedTestNoExternalConnection)


### PR DESCRIPTION
Backport 1/1 commits from #108615.

/cc @cockroachdb/release

---

Disallow subquery as the changefeed ID argument.

Fixes #108500

Release note: None
Release justification: bug fix -- do not panic when incorrect input provided to alter changefeed.
