### PR TITLE
release-22.2: changefeedccl: Reject subquery in alter changefeed

### DIFF
--- a/pkg/ccl/changefeedccl/alter_changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/alter_changefeed_stmt.go
@@ -88,12 +88,20 @@ func alterChangefeedPlanHook(
 		if err := validateSettings(ctx, p); err != nil {
 			return err
 		}
+		jobID, err := func() (jobspb.JobID, error) {
+			origProps := p.SemaCtx().Properties
+			p.SemaCtx().Properties.Require("cdc", tree.RejectSubqueries)
+			defer p.SemaCtx().Properties.Restore(origProps)
 
-		typedExpr, err := alterChangefeedStmt.Jobs.TypeCheck(ctx, p.SemaCtx(), types.Int)
+			id, err := p.ExprEvaluator("ALTER CHANGEFEED").Int(ctx, alterChangefeedStmt.Jobs)
+			if err != nil {
+				return jobspb.JobID(0), err
+			}
+			return jobspb.JobID(id), nil
+		}()
 		if err != nil {
-			return err
+			return pgerror.Wrap(err, pgcode.DatatypeMismatch, "changefeed ID must be an INT value")
 		}
-		jobID := jobspb.JobID(tree.MustBeDInt(typedExpr))
 
 		job, err := p.ExecCfg().JobRegistry.LoadJobWithTxn(ctx, jobID, p.Txn())
 		if err != nil {

--- a/pkg/ccl/changefeedccl/alter_changefeed_test.go
+++ b/pkg/ccl/changefeedccl/alter_changefeed_test.go
@@ -405,6 +405,11 @@ func TestAlterChangefeedErrors(t *testing.T) {
 			`pq: cannot specify both "initial_scan" and "no_initial_scan"`,
 			fmt.Sprintf(`ALTER CHANGEFEED %d ADD bar WITH initial_scan, no_initial_scan`, feed.JobID()),
 		)
+
+		sqlDB.ExpectErr(t, "pq: changefeed ID must be an INT value: subqueries are not allowed in cdc",
+			"ALTER CHANGEFEED (SELECT 1) ADD bar")
+		sqlDB.ExpectErr(t, "pq: changefeed ID must be an INT value: could not parse \"two\" as type int",
+			"ALTER CHANGEFEED 'two' ADD bar")
 	}
 
 	cdcTest(t, testFn, feedTestEnterpriseSinks)

--- a/pkg/sql/exprutil/evaluator.go
+++ b/pkg/sql/exprutil/evaluator.go
@@ -44,6 +44,15 @@ func (e Evaluator) StringArray(ctx context.Context, exprs tree.Exprs) ([]string,
 	return strs, nil
 }
 
+// Int evaluates expr to an int.
+func (e Evaluator) Int(ctx context.Context, expr tree.Expr) (int64, error) {
+	d, err := e.evalScalar(ctx, expr, types.Int)
+	if err != nil {
+		return 0, err
+	}
+	return int64(tree.MustBeDInt(d)), nil
+}
+
 // String evaluates expr to a string.
 func (e Evaluator) String(ctx context.Context, expr tree.Expr) (string, error) {
 	d, err := e.evalScalar(ctx, expr, types.String)


### PR DESCRIPTION
Backport 1/1 commits from #108615.

/cc @cockroachdb/release

---

Disallow subquery as the changefeed ID argument.

Fixes #108500

Release note: None
Release justification: fix a panic when incorrect input provided to alter changefeed.