### PR TITLE
kvserver: deflake TestReplicateQueueLeasePreferencePurgatoryError

### DIFF
--- a/pkg/kv/kvserver/replicate_queue_test.go
+++ b/pkg/kv/kvserver/replicate_queue_test.go
@@ -2575,18 +2575,21 @@ func TestReplicateQueueLeasePreferencePurgatoryError(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, tc.WaitForFullReplication())
 
-	store := tc.GetFirstStoreFromServer(t, 0)
 	// Set a preference on the initial node, then wait until all the leases for
 	// the test table are on that node.
 	setLeasePreferences(initialPreferredNode)
 	testutils.SucceedsSoon(t, func() error {
-		require.NoError(t, store.ForceReplicationScanAndProcess())
+		for serverIdx := 0; serverIdx < numNodes; serverIdx++ {
+			require.NoError(t, tc.GetFirstStoreFromServer(t, serverIdx).
+				ForceReplicationScanAndProcess())
+		}
 		return checkLeaseCount(initialPreferredNode, numRanges)
 	})
 
 	// Block returning transfer targets from the allocator, then update the
 	// preferred node. We expect that every range for the test table will end up
 	// in purgatory on the initially preferred node.
+	store := tc.GetFirstStoreFromServer(t, 0)
 	blockTransferTarget.Store(true)
 	setLeasePreferences(nextPreferredNode)
 	testutils.SucceedsSoon(t, func() error {


### PR DESCRIPTION
`TestReplicateQueueLeasePreferencePurgatoryError` waits for every lease to be on one store, before changing the lease preference, and asserting the leaseholders end up in purgatory.

The test could occasionally time out before every lease was on the initial store. The test forced replicate queue processing to speed this up, however only on one store, when all stores may need to transfer lease(s).

Force replication scan and process on every store, instead of just the initially preferred node. This speeds up this stage of the test.

Fixes: #108624
Release note: None