### PR TITLE
sql: fix tests overwritten with WITH OPTIONS

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -806,7 +806,7 @@ func TestBackupAndRestoreJobDescription(t *testing.T) {
 	sqlDB.Exec(t, "BACKUP TO ($1,$2,$3) INCREMENTAL FROM $4", append(incrementals, backups[0])...)
 	sqlDB.Exec(t, "BACKUP INTO ($1, $2, $3)", collections...)
 	sqlDB.Exec(t, "BACKUP INTO LATEST IN ($1, $2, $3)", collections...)
-	sqlDB.Exec(t, "BACKUP INTO LATEST IN ($1, $2, $3) WITH OPTIONS (incremental_location = ($4, $5, $6))",
+	sqlDB.Exec(t, "BACKUP INTO LATEST IN ($1, $2, $3) WITH incremental_location = ($4, $5, $6)",
 		append(collections, incrementals...)...)
 
 	sqlDB.ExpectErr(t, "the incremental_location option must contain the same number of locality",

--- a/pkg/sql/importer/import_csv_mark_redaction_test.go
+++ b/pkg/sql/importer/import_csv_mark_redaction_test.go
@@ -30,7 +30,7 @@ func TestMarkRedactionCCLStatement(t *testing.T) {
 		expected string
 	}{
 		{
-			"IMPORT CSV 'file' WITH OPTIONS (delimiter = 'foo')",
+			"IMPORT CSV 'file' WITH delimiter = 'foo'",
 			"IMPORT CSV ‹'file'› WITH OPTIONS (delimiter = ‹'foo'›)",
 		},
 	}

--- a/pkg/sql/parser/testdata/backup_restore
+++ b/pkg/sql/parser/testdata/backup_restore
@@ -1,7 +1,1030 @@
 parse
+BACKUP TABLE foo TO 'bar'
+----
+BACKUP TABLE foo TO 'bar'
+BACKUP TABLE (foo) TO ('bar') -- fully parenthesized
+BACKUP TABLE foo TO '_' -- literals removed
+BACKUP TABLE _ TO 'bar' -- identifiers removed
+
+parse
+BACKUP foo TO 'bar'
+----
+BACKUP TABLE foo TO 'bar' -- normalized!
+BACKUP TABLE (foo) TO ('bar') -- fully parenthesized
+BACKUP TABLE foo TO '_' -- literals removed
+BACKUP TABLE _ TO 'bar' -- identifiers removed
+
+parse
+BACKUP TO 'bar'
+----
+BACKUP TO 'bar'
+BACKUP TO ('bar') -- fully parenthesized
+BACKUP TO '_' -- literals removed
+BACKUP TO 'bar' -- identifiers removed
+
+parse
+BACKUP role TO 'bar'
+----
+BACKUP TABLE "role" TO 'bar' -- normalized!
+BACKUP TABLE ("role") TO ('bar') -- fully parenthesized
+BACKUP TABLE "role" TO '_' -- literals removed
+BACKUP TABLE _ TO 'bar' -- identifiers removed
+
+parse
+BACKUP TABLE foo INTO 'bar'
+----
+BACKUP TABLE foo INTO 'bar'
+BACKUP TABLE (foo) INTO ('bar') -- fully parenthesized
+BACKUP TABLE foo INTO '_' -- literals removed
+BACKUP TABLE _ INTO 'bar' -- identifiers removed
+
+parse
+BACKUP TABLE foo INTO LATEST IN 'bar'
+----
+BACKUP TABLE foo INTO LATEST IN 'bar'
+BACKUP TABLE (foo) INTO LATEST IN ('bar') -- fully parenthesized
+BACKUP TABLE foo INTO LATEST IN '_' -- literals removed
+BACKUP TABLE _ INTO LATEST IN 'bar' -- identifiers removed
+
+parse
+BACKUP TABLE foo INTO LATEST IN 'bar' WITH incremental_location = 'baz'
+----
+BACKUP TABLE foo INTO LATEST IN 'bar' WITH OPTIONS (incremental_location = 'baz') -- normalized!
+BACKUP TABLE (foo) INTO LATEST IN ('bar') WITH OPTIONS (incremental_location = ('baz')) -- fully parenthesized
+BACKUP TABLE foo INTO LATEST IN '_' WITH OPTIONS (incremental_location = '_') -- literals removed
+BACKUP TABLE _ INTO LATEST IN 'bar' WITH OPTIONS (incremental_location = 'baz') -- identifiers removed
+
+parse
+BACKUP TABLE foo INTO 'subdir' IN 'bar'
+----
+BACKUP TABLE foo INTO 'subdir' IN 'bar'
+BACKUP TABLE (foo) INTO ('subdir') IN ('bar') -- fully parenthesized
+BACKUP TABLE foo INTO '_' IN '_' -- literals removed
+BACKUP TABLE _ INTO 'subdir' IN 'bar' -- identifiers removed
+
+parse
+BACKUP TABLE foo INTO $1 IN $2
+----
+BACKUP TABLE foo INTO $1 IN $2
+BACKUP TABLE (foo) INTO ($1) IN ($2) -- fully parenthesized
+BACKUP TABLE foo INTO $1 IN $1 -- literals removed
+BACKUP TABLE _ INTO $1 IN $2 -- identifiers removed
+
+parse
+EXPLAIN BACKUP TABLE foo TO 'bar'
+----
+EXPLAIN BACKUP TABLE foo TO 'bar'
+EXPLAIN BACKUP TABLE (foo) TO ('bar') -- fully parenthesized
+EXPLAIN BACKUP TABLE foo TO '_' -- literals removed
+EXPLAIN BACKUP TABLE _ TO 'bar' -- identifiers removed
+
+parse
+BACKUP TABLE foo.foo, baz.baz TO 'bar'
+----
+BACKUP TABLE foo.foo, baz.baz TO 'bar'
+BACKUP TABLE (foo.foo), (baz.baz) TO ('bar') -- fully parenthesized
+BACKUP TABLE foo.foo, baz.baz TO '_' -- literals removed
+BACKUP TABLE _._, _._ TO 'bar' -- identifiers removed
+
+parse
+BACKUP foo.foo, baz.baz TO 'bar'
+----
+BACKUP TABLE foo.foo, baz.baz TO 'bar' -- normalized!
+BACKUP TABLE (foo.foo), (baz.baz) TO ('bar') -- fully parenthesized
+BACKUP TABLE foo.foo, baz.baz TO '_' -- literals removed
+BACKUP TABLE _._, _._ TO 'bar' -- identifiers removed
+
+parse
+SHOW BACKUP 'bar'
+----
+SHOW BACKUP 'bar'
+SHOW BACKUP ('bar') -- fully parenthesized
+SHOW BACKUP '_' -- literals removed
+SHOW BACKUP 'bar' -- identifiers removed
+
+parse
+SHOW BACKUP 'bar' WITH ENCRYPTION_PASSPHRASE = 'secret', CHECK_FILES
+----
+SHOW BACKUP 'bar' WITH check_files, encryption_passphrase = '*****' -- normalized!
+SHOW BACKUP ('bar') WITH check_files, encryption_passphrase = '*****' -- fully parenthesized
+SHOW BACKUP '_' WITH check_files, encryption_passphrase = '*****' -- literals removed
+SHOW BACKUP 'bar' WITH check_files, encryption_passphrase = '*****' -- identifiers removed
+SHOW BACKUP 'bar' WITH check_files, encryption_passphrase = 'secret' -- passwords exposed
+
+parse
+SHOW BACKUP FROM LATEST IN 'bar' WITH incremental_location = 'baz', skip size
+----
+SHOW BACKUP FROM 'latest' IN 'bar' WITH incremental_location = 'baz', skip size -- normalized!
+SHOW BACKUP FROM ('latest') IN ('bar') WITH incremental_location = ('baz'), skip size -- fully parenthesized
+SHOW BACKUP FROM '_' IN '_' WITH incremental_location = '_', skip size -- literals removed
+SHOW BACKUP FROM 'latest' IN 'bar' WITH incremental_location = 'baz', skip size -- identifiers removed
+
+parse
+SHOW BACKUP FROM LATEST IN ('bar','bar1') WITH KMS = ('foo', 'bar'), incremental_location=('hi','hello')
+----
+SHOW BACKUP FROM 'latest' IN ('bar', 'bar1') WITH incremental_location = ('hi', 'hello'), kms = ('foo', 'bar') -- normalized!
+SHOW BACKUP FROM ('latest') IN (('bar'), ('bar1')) WITH incremental_location = (('hi'), ('hello')), kms = (('foo'), ('bar')) -- fully parenthesized
+SHOW BACKUP FROM '_' IN ('_', '_') WITH incremental_location = ('_', '_'), kms = ('_', '_') -- literals removed
+SHOW BACKUP FROM 'latest' IN ('bar', 'bar1') WITH incremental_location = ('hi', 'hello'), kms = ('foo', 'bar') -- identifiers removed
+
+
+parse
+EXPLAIN SHOW BACKUP 'bar'
+----
+EXPLAIN SHOW BACKUP 'bar'
+EXPLAIN SHOW BACKUP ('bar') -- fully parenthesized
+EXPLAIN SHOW BACKUP '_' -- literals removed
+EXPLAIN SHOW BACKUP 'bar' -- identifiers removed
+
+parse
+SHOW BACKUP RANGES 'bar'
+----
+SHOW BACKUP RANGES 'bar'
+SHOW BACKUP RANGES ('bar') -- fully parenthesized
+SHOW BACKUP RANGES '_' -- literals removed
+SHOW BACKUP RANGES 'bar' -- identifiers removed
+
+parse
+SHOW BACKUP FILES 'bar'
+----
+SHOW BACKUP FILES 'bar'
+SHOW BACKUP FILES ('bar') -- fully parenthesized
+SHOW BACKUP FILES '_' -- literals removed
+SHOW BACKUP FILES 'bar' -- identifiers removed
+
+parse
+SHOW BACKUP CONNECTION 'bar'
+----
+SHOW BACKUP CONNECTION 'bar'
+SHOW BACKUP CONNECTION ('bar') -- fully parenthesized
+SHOW BACKUP CONNECTION '_' -- literals removed
+SHOW BACKUP CONNECTION 'bar' -- identifiers removed
+
+parse
+SHOW BACKUP CONNECTION 'bar' WITH TRANSFER = '1KiB', TIME = '1h', CONCURRENTLY = 3
+----
+SHOW BACKUP CONNECTION 'bar' WITH CONCURRENTLY = 3, TRANSFER = '1KiB', TIME = '1h' -- normalized!
+SHOW BACKUP CONNECTION ('bar') WITH CONCURRENTLY = (3), TRANSFER = ('1KiB'), TIME = ('1h') -- fully parenthesized
+SHOW BACKUP CONNECTION '_' WITH CONCURRENTLY = _, TRANSFER = '_', TIME = '_' -- literals removed
+SHOW BACKUP CONNECTION 'bar' WITH CONCURRENTLY = 3, TRANSFER = '1KiB', TIME = '1h' -- identifiers removed
+
+parse
+SHOW BACKUP CONNECTION 'bar' WITH TRANSFER = $1, CONCURRENTLY = $2, TIME = $3
+----
+SHOW BACKUP CONNECTION 'bar' WITH CONCURRENTLY = $2, TRANSFER = $1, TIME = $3 -- normalized!
+SHOW BACKUP CONNECTION ('bar') WITH CONCURRENTLY = ($2), TRANSFER = ($1), TIME = ($3) -- fully parenthesized
+SHOW BACKUP CONNECTION '_' WITH CONCURRENTLY = $1, TRANSFER = $1, TIME = $1 -- literals removed
+SHOW BACKUP CONNECTION 'bar' WITH CONCURRENTLY = $2, TRANSFER = $1, TIME = $3 -- identifiers removed
+
+parse
+SHOW BACKUPS IN 'bar'
+----
+SHOW BACKUPS IN 'bar'
+SHOW BACKUPS IN ('bar') -- fully parenthesized
+SHOW BACKUPS IN '_' -- literals removed
+SHOW BACKUPS IN 'bar' -- identifiers removed
+
+parse
+SHOW BACKUPS IN $1
+----
+SHOW BACKUPS IN $1
+SHOW BACKUPS IN ($1) -- fully parenthesized
+SHOW BACKUPS IN $1 -- literals removed
+SHOW BACKUPS IN $1 -- identifiers removed
+
+parse
+SHOW BACKUP 'foo' IN 'bar'
+----
+SHOW BACKUP 'foo' IN 'bar'
+SHOW BACKUP ('foo') IN ('bar') -- fully parenthesized
+SHOW BACKUP '_' IN '_' -- literals removed
+SHOW BACKUP 'foo' IN 'bar' -- identifiers removed
+
+parse
+SHOW BACKUP FROM $1 IN $2 WITH privileges
+----
+SHOW BACKUP FROM $1 IN $2 WITH privileges
+SHOW BACKUP FROM ($1) IN ($2) WITH privileges -- fully parenthesized
+SHOW BACKUP FROM $1 IN $1 WITH privileges -- literals removed
+SHOW BACKUP FROM $1 IN $2 WITH privileges -- identifiers removed
+
+parse
+SHOW BACKUP FILES FROM 'foo' IN 'bar'
+----
+SHOW BACKUP FILES FROM 'foo' IN 'bar'
+SHOW BACKUP FILES FROM ('foo') IN ('bar') -- fully parenthesized
+SHOW BACKUP FILES FROM '_' IN '_' -- literals removed
+SHOW BACKUP FILES FROM 'foo' IN 'bar' -- identifiers removed
+
+parse
+SHOW BACKUP RANGES FROM 'foo' IN 'bar'
+----
+SHOW BACKUP RANGES FROM 'foo' IN 'bar'
+SHOW BACKUP RANGES FROM ('foo') IN ('bar') -- fully parenthesized
+SHOW BACKUP RANGES FROM '_' IN '_' -- literals removed
+SHOW BACKUP RANGES FROM 'foo' IN 'bar' -- identifiers removed
+
+parse
+SHOW BACKUP SCHEMAS FROM 'foo' IN 'bar'
+----
+SHOW BACKUP SCHEMAS FROM 'foo' IN 'bar'
+SHOW BACKUP SCHEMAS FROM ('foo') IN ('bar') -- fully parenthesized
+SHOW BACKUP SCHEMAS FROM '_' IN '_' -- literals removed
+SHOW BACKUP SCHEMAS FROM 'foo' IN 'bar' -- identifiers removed
+
+parse
+SHOW BACKUP $1 IN $2 WITH ENCRYPTION_PASSPHRASE = 'secret', ENCRYPTION_INFO_DIR = 'long_live_backupper'
+----
+SHOW BACKUP $1 IN $2 WITH encryption_passphrase = '*****', encryption_info_dir = 'long_live_backupper' -- normalized!
+SHOW BACKUP ($1) IN ($2) WITH encryption_passphrase = '*****', encryption_info_dir = ('long_live_backupper') -- fully parenthesized
+SHOW BACKUP $1 IN $1 WITH encryption_passphrase = '*****', encryption_info_dir = '_' -- literals removed
+SHOW BACKUP $1 IN $2 WITH encryption_passphrase = '*****', encryption_info_dir = 'long_live_backupper' -- identifiers removed
+SHOW BACKUP $1 IN $2 WITH encryption_passphrase = 'secret', encryption_info_dir = 'long_live_backupper' -- passwords exposed
+
+parse
+BACKUP TABLE foo TO 'bar' AS OF SYSTEM TIME '1' INCREMENTAL FROM 'baz'
+----
+BACKUP TABLE foo TO 'bar' AS OF SYSTEM TIME '1' INCREMENTAL FROM 'baz'
+BACKUP TABLE (foo) TO ('bar') AS OF SYSTEM TIME ('1') INCREMENTAL FROM ('baz') -- fully parenthesized
+BACKUP TABLE foo TO '_' AS OF SYSTEM TIME '_' INCREMENTAL FROM '_' -- literals removed
+BACKUP TABLE _ TO 'bar' AS OF SYSTEM TIME '1' INCREMENTAL FROM 'baz' -- identifiers removed
+
+parse
+BACKUP foo TO 'bar' AS OF SYSTEM TIME '1' INCREMENTAL FROM 'baz'
+----
+BACKUP TABLE foo TO 'bar' AS OF SYSTEM TIME '1' INCREMENTAL FROM 'baz' -- normalized!
+BACKUP TABLE (foo) TO ('bar') AS OF SYSTEM TIME ('1') INCREMENTAL FROM ('baz') -- fully parenthesized
+BACKUP TABLE foo TO '_' AS OF SYSTEM TIME '_' INCREMENTAL FROM '_' -- literals removed
+BACKUP TABLE _ TO 'bar' AS OF SYSTEM TIME '1' INCREMENTAL FROM 'baz' -- identifiers removed
+
+parse
+BACKUP TABLE foo TO $1 INCREMENTAL FROM 'bar', $2, 'baz'
+----
+BACKUP TABLE foo TO $1 INCREMENTAL FROM 'bar', $2, 'baz'
+BACKUP TABLE (foo) TO ($1) INCREMENTAL FROM ('bar'), ($2), ('baz') -- fully parenthesized
+BACKUP TABLE foo TO $1 INCREMENTAL FROM '_', $1, '_' -- literals removed
+BACKUP TABLE _ TO $1 INCREMENTAL FROM 'bar', $2, 'baz' -- identifiers removed
+
+parse
+BACKUP foo TO $1 INCREMENTAL FROM 'bar', $2, 'baz'
+----
+BACKUP TABLE foo TO $1 INCREMENTAL FROM 'bar', $2, 'baz' -- normalized!
+BACKUP TABLE (foo) TO ($1) INCREMENTAL FROM ('bar'), ($2), ('baz') -- fully parenthesized
+BACKUP TABLE foo TO $1 INCREMENTAL FROM '_', $1, '_' -- literals removed
+BACKUP TABLE _ TO $1 INCREMENTAL FROM 'bar', $2, 'baz' -- identifiers removed
+
+parse
+BACKUP DATABASE foo TO 'bar'
+----
+BACKUP DATABASE foo TO 'bar'
+BACKUP DATABASE foo TO ('bar') -- fully parenthesized
+BACKUP DATABASE foo TO '_' -- literals removed
+BACKUP DATABASE _ TO 'bar' -- identifiers removed
+
+parse
+BACKUP DATABASE foo TO ($1)
+----
+BACKUP DATABASE foo TO $1 -- normalized!
+BACKUP DATABASE foo TO ($1) -- fully parenthesized
+BACKUP DATABASE foo TO $1 -- literals removed
+BACKUP DATABASE _ TO $1 -- identifiers removed
+
+parse
+EXPLAIN BACKUP DATABASE foo TO 'bar'
+----
+EXPLAIN BACKUP DATABASE foo TO 'bar'
+EXPLAIN BACKUP DATABASE foo TO ('bar') -- fully parenthesized
+EXPLAIN BACKUP DATABASE foo TO '_' -- literals removed
+EXPLAIN BACKUP DATABASE _ TO 'bar' -- identifiers removed
+
+parse
+BACKUP DATABASE foo TO bar
+----
+BACKUP DATABASE foo TO 'bar' -- normalized!
+BACKUP DATABASE foo TO ('bar') -- fully parenthesized
+BACKUP DATABASE foo TO '_' -- literals removed
+BACKUP DATABASE _ TO 'bar' -- identifiers removed
+
+
+parse
+BACKUP DATABASE foo, baz TO 'bar'
+----
+BACKUP DATABASE foo, baz TO 'bar'
+BACKUP DATABASE foo, baz TO ('bar') -- fully parenthesized
+BACKUP DATABASE foo, baz TO '_' -- literals removed
+BACKUP DATABASE _, _ TO 'bar' -- identifiers removed
+
+parse
+BACKUP DATABASE foo TO "bar.12" INCREMENTAL FROM "baz.34"
+----
+BACKUP DATABASE foo TO 'bar.12' INCREMENTAL FROM 'baz.34' -- normalized!
+BACKUP DATABASE foo TO ('bar.12') INCREMENTAL FROM ('baz.34') -- fully parenthesized
+BACKUP DATABASE foo TO '_' INCREMENTAL FROM '_' -- literals removed
+BACKUP DATABASE _ TO 'bar.12' INCREMENTAL FROM 'baz.34' -- identifiers removed
+
+
+parse
+BACKUP DATABASE foo TO 'bar' AS OF SYSTEM TIME '1' INCREMENTAL FROM 'baz'
+----
+BACKUP DATABASE foo TO 'bar' AS OF SYSTEM TIME '1' INCREMENTAL FROM 'baz'
+BACKUP DATABASE foo TO ('bar') AS OF SYSTEM TIME ('1') INCREMENTAL FROM ('baz') -- fully parenthesized
+BACKUP DATABASE foo TO '_' AS OF SYSTEM TIME '_' INCREMENTAL FROM '_' -- literals removed
+BACKUP DATABASE _ TO 'bar' AS OF SYSTEM TIME '1' INCREMENTAL FROM 'baz' -- identifiers removed
+
+parse
+BACKUP DATABASE foo TO ($1, $2)
+----
+BACKUP DATABASE foo TO ($1, $2)
+BACKUP DATABASE foo TO (($1), ($2)) -- fully parenthesized
+BACKUP DATABASE foo TO ($1, $1) -- literals removed
+BACKUP DATABASE _ TO ($1, $2) -- identifiers removed
+
+parse
+BACKUP DATABASE foo TO ($1, $2) INCREMENTAL FROM 'baz'
+----
+BACKUP DATABASE foo TO ($1, $2) INCREMENTAL FROM 'baz'
+BACKUP DATABASE foo TO (($1), ($2)) INCREMENTAL FROM ('baz') -- fully parenthesized
+BACKUP DATABASE foo TO ($1, $1) INCREMENTAL FROM '_' -- literals removed
+BACKUP DATABASE _ TO ($1, $2) INCREMENTAL FROM 'baz' -- identifiers removed
+
+parse
+BACKUP foo TO 'bar' WITH ENCRYPTION_PASSPHRASE = 'secret', revision_history, execution locality = 'a=b'
+----
+BACKUP TABLE foo TO 'bar' WITH OPTIONS (revision_history = true, encryption_passphrase = '*****', execution locality = 'a=b') -- normalized!
+BACKUP TABLE (foo) TO ('bar') WITH OPTIONS (revision_history = (true), encryption_passphrase = '*****', execution locality = ('a=b')) -- fully parenthesized
+BACKUP TABLE foo TO '_' WITH OPTIONS (revision_history = _, encryption_passphrase = '*****', execution locality = '_') -- literals removed
+BACKUP TABLE _ TO 'bar' WITH OPTIONS (revision_history = true, encryption_passphrase = '*****', execution locality = 'a=b') -- identifiers removed
+BACKUP TABLE foo TO 'bar' WITH OPTIONS (revision_history = true, encryption_passphrase = 'secret', execution locality = 'a=b') -- passwords exposed
+
+parse
+BACKUP foo TO 'bar' WITH KMS = ('foo', 'bar'), revision_history
+----
+BACKUP TABLE foo TO 'bar' WITH OPTIONS (revision_history = true, kms = ('foo', 'bar')) -- normalized!
+BACKUP TABLE (foo) TO ('bar') WITH OPTIONS (revision_history = (true), kms = (('foo'), ('bar'))) -- fully parenthesized
+BACKUP TABLE foo TO '_' WITH OPTIONS (revision_history = _, kms = ('_', '_')) -- literals removed
+BACKUP TABLE _ TO 'bar' WITH OPTIONS (revision_history = true, kms = ('foo', 'bar')) -- identifiers removed
+
+parse
+BACKUP foo TO 'bar' WITH OPTIONS (detached, ENCRYPTION_PASSPHRASE = 'secret', revision_history)
+----
+BACKUP TABLE foo TO 'bar' WITH OPTIONS (revision_history = true, encryption_passphrase = '*****', detached) -- normalized!
+BACKUP TABLE (foo) TO ('bar') WITH OPTIONS (revision_history = (true), encryption_passphrase = '*****', detached) -- fully parenthesized
+BACKUP TABLE foo TO '_' WITH OPTIONS (revision_history = _, encryption_passphrase = '*****', detached) -- literals removed
+BACKUP TABLE _ TO 'bar' WITH OPTIONS (revision_history = true, encryption_passphrase = '*****', detached) -- identifiers removed
+BACKUP TABLE foo TO 'bar' WITH OPTIONS (revision_history = true, encryption_passphrase = 'secret', detached) -- passwords exposed
+
+parse
+BACKUP foo TO 'bar' WITH OPTIONS (detached, KMS = ('foo', 'bar'), revision_history)
+----
+BACKUP TABLE foo TO 'bar' WITH OPTIONS (revision_history = true, detached, kms = ('foo', 'bar')) -- normalized!
+BACKUP TABLE (foo) TO ('bar') WITH OPTIONS (revision_history = (true), detached, kms = (('foo'), ('bar'))) -- fully parenthesized
+BACKUP TABLE foo TO '_' WITH OPTIONS (revision_history = _, detached, kms = ('_', '_')) -- literals removed
+BACKUP TABLE _ TO 'bar' WITH OPTIONS (revision_history = true, detached, kms = ('foo', 'bar')) -- identifiers removed
+
+
+# Regression test for #95235.
+parse
+BACKUP foo TO 'bar' WITH OPTIONS (detached = false)
+----
+BACKUP TABLE foo TO 'bar' WITH OPTIONS (detached = FALSE) -- normalized!
+BACKUP TABLE (foo) TO ('bar') WITH OPTIONS (detached = FALSE) -- fully parenthesized
+BACKUP TABLE foo TO '_' WITH OPTIONS (detached = FALSE) -- literals removed
+BACKUP TABLE _ TO 'bar' WITH OPTIONS (detached = FALSE) -- identifiers removed
+
+parse
+BACKUP VIRTUAL CLUSTER 36 TO 'bar'
+----
+BACKUP VIRTUAL CLUSTER 36 TO 'bar'
+BACKUP VIRTUAL CLUSTER 36 TO ('bar') -- fully parenthesized
+BACKUP VIRTUAL CLUSTER _ TO '_' -- literals removed
+BACKUP VIRTUAL CLUSTER 36 TO 'bar' -- identifiers removed
+
+parse
+BACKUP TENANT 36 TO 'bar'
+----
+BACKUP VIRTUAL CLUSTER 36 TO 'bar' -- normalized!
+BACKUP VIRTUAL CLUSTER 36 TO ('bar') -- fully parenthesized
+BACKUP VIRTUAL CLUSTER _ TO '_' -- literals removed
+BACKUP VIRTUAL CLUSTER 36 TO 'bar' -- identifiers removed
+
+parse
+RESTORE TABLE foo FROM 'bar'
+----
+RESTORE TABLE foo FROM 'bar'
+RESTORE TABLE (foo) FROM ('bar') -- fully parenthesized
+RESTORE TABLE foo FROM '_' -- literals removed
+RESTORE TABLE _ FROM 'bar' -- identifiers removed
+
+parse
+EXPLAIN RESTORE TABLE foo FROM 'bar'
+----
+EXPLAIN RESTORE TABLE foo FROM 'bar'
+EXPLAIN RESTORE TABLE (foo) FROM ('bar') -- fully parenthesized
+EXPLAIN RESTORE TABLE foo FROM '_' -- literals removed
+EXPLAIN RESTORE TABLE _ FROM 'bar' -- identifiers removed
+
+parse
+RESTORE foo FROM 'bar'
+----
+RESTORE TABLE foo FROM 'bar' -- normalized!
+RESTORE TABLE (foo) FROM ('bar') -- fully parenthesized
+RESTORE TABLE foo FROM '_' -- literals removed
+RESTORE TABLE _ FROM 'bar' -- identifiers removed
+
+parse
+RESTORE TABLE foo FROM $1
+----
+RESTORE TABLE foo FROM $1
+RESTORE TABLE (foo) FROM ($1) -- fully parenthesized
+RESTORE TABLE foo FROM $1 -- literals removed
+RESTORE TABLE _ FROM $1 -- identifiers removed
+
+
+parse
+RESTORE foo FROM $1
+----
+RESTORE TABLE foo FROM $1 -- normalized!
+RESTORE TABLE (foo) FROM ($1) -- fully parenthesized
+RESTORE TABLE foo FROM $1 -- literals removed
+RESTORE TABLE _ FROM $1 -- identifiers removed
+
+parse
+RESTORE TABLE foo FROM $2 IN $1
+----
+RESTORE TABLE foo FROM $2 IN $1
+RESTORE TABLE (foo) FROM ($2) IN ($1) -- fully parenthesized
+RESTORE TABLE foo FROM $1 IN $1 -- literals removed
+RESTORE TABLE _ FROM $2 IN $1 -- identifiers removed
+
+parse
+RESTORE TABLE foo FROM $1, $2, 'bar'
+----
+RESTORE TABLE foo FROM $1, $2, 'bar'
+RESTORE TABLE (foo) FROM ($1), ($2), ('bar') -- fully parenthesized
+RESTORE TABLE foo FROM $1, $1, '_' -- literals removed
+RESTORE TABLE _ FROM $1, $2, 'bar' -- identifiers removed
+
+parse
+RESTORE foo FROM $1, $2, 'bar'
+----
+RESTORE TABLE foo FROM $1, $2, 'bar' -- normalized!
+RESTORE TABLE (foo) FROM ($1), ($2), ('bar') -- fully parenthesized
+RESTORE TABLE foo FROM $1, $1, '_' -- literals removed
+RESTORE TABLE _ FROM $1, $2, 'bar' -- identifiers removed
+
+parse
+RESTORE TABLE foo FROM 'abc' IN $1, $2, 'bar'
+----
+RESTORE TABLE foo FROM 'abc' IN $1, $2, 'bar'
+RESTORE TABLE (foo) FROM ('abc') IN ($1), ($2), ('bar') -- fully parenthesized
+RESTORE TABLE foo FROM '_' IN $1, $1, '_' -- literals removed
+RESTORE TABLE _ FROM 'abc' IN $1, $2, 'bar' -- identifiers removed
+
+parse
+RESTORE TABLE foo FROM $4 IN $1, $2, 'bar'
+----
+RESTORE TABLE foo FROM $4 IN $1, $2, 'bar'
+RESTORE TABLE (foo) FROM ($4) IN ($1), ($2), ('bar') -- fully parenthesized
+RESTORE TABLE foo FROM $1 IN $1, $1, '_' -- literals removed
+RESTORE TABLE _ FROM $4 IN $1, $2, 'bar' -- identifiers removed
+
+parse
+RESTORE TABLE foo, baz FROM 'bar'
+----
+RESTORE TABLE foo, baz FROM 'bar'
+RESTORE TABLE (foo), (baz) FROM ('bar') -- fully parenthesized
+RESTORE TABLE foo, baz FROM '_' -- literals removed
+RESTORE TABLE _, _ FROM 'bar' -- identifiers removed
+
+
+parse
+RESTORE foo, baz FROM 'bar'
+----
+RESTORE TABLE foo, baz FROM 'bar' -- normalized!
+RESTORE TABLE (foo), (baz) FROM ('bar') -- fully parenthesized
+RESTORE TABLE foo, baz FROM '_' -- literals removed
+RESTORE TABLE _, _ FROM 'bar' -- identifiers removed
+
+parse
+RESTORE TABLE foo, baz FROM 'bar' AS OF SYSTEM TIME '1'
+----
+RESTORE TABLE foo, baz FROM 'bar' AS OF SYSTEM TIME '1'
+RESTORE TABLE (foo), (baz) FROM ('bar') AS OF SYSTEM TIME ('1') -- fully parenthesized
+RESTORE TABLE foo, baz FROM '_' AS OF SYSTEM TIME '_' -- literals removed
+RESTORE TABLE _, _ FROM 'bar' AS OF SYSTEM TIME '1' -- identifiers removed
+
+
+parse
+RESTORE foo, baz FROM 'bar' AS OF SYSTEM TIME '1'
+----
+RESTORE TABLE foo, baz FROM 'bar' AS OF SYSTEM TIME '1' -- normalized!
+RESTORE TABLE (foo), (baz) FROM ('bar') AS OF SYSTEM TIME ('1') -- fully parenthesized
+RESTORE TABLE foo, baz FROM '_' AS OF SYSTEM TIME '_' -- literals removed
+RESTORE TABLE _, _ FROM 'bar' AS OF SYSTEM TIME '1' -- identifiers removed
+
+parse
+RESTORE DATABASE foo FROM 'bar'
+----
+RESTORE DATABASE foo FROM 'bar'
+RESTORE DATABASE foo FROM ('bar') -- fully parenthesized
+RESTORE DATABASE foo FROM '_' -- literals removed
+RESTORE DATABASE _ FROM 'bar' -- identifiers removed
+
+parse
+RESTORE DATABASE foo FROM ($1)
+----
+RESTORE DATABASE foo FROM $1 -- normalized!
+RESTORE DATABASE foo FROM ($1) -- fully parenthesized
+RESTORE DATABASE foo FROM $1 -- literals removed
+RESTORE DATABASE _ FROM $1 -- identifiers removed
+
+parse
+EXPLAIN RESTORE DATABASE foo FROM 'bar'
+----
+EXPLAIN RESTORE DATABASE foo FROM 'bar'
+EXPLAIN RESTORE DATABASE foo FROM ('bar') -- fully parenthesized
+EXPLAIN RESTORE DATABASE foo FROM '_' -- literals removed
+EXPLAIN RESTORE DATABASE _ FROM 'bar' -- identifiers removed
+
+parse
+RESTORE DATABASE foo FROM bar
+----
+RESTORE DATABASE foo FROM 'bar' -- normalized!
+RESTORE DATABASE foo FROM ('bar') -- fully parenthesized
+RESTORE DATABASE foo FROM '_' -- literals removed
+RESTORE DATABASE _ FROM 'bar' -- identifiers removed
+
+
+parse
+RESTORE DATABASE foo, baz FROM 'bar'
+----
+RESTORE DATABASE foo, baz FROM 'bar'
+RESTORE DATABASE foo, baz FROM ('bar') -- fully parenthesized
+RESTORE DATABASE foo, baz FROM '_' -- literals removed
+RESTORE DATABASE _, _ FROM 'bar' -- identifiers removed
+
+parse
+RESTORE DATABASE foo FROM 'bar' WITH new_db_name = 'baz'
+----
+RESTORE DATABASE foo FROM 'bar' WITH OPTIONS (new_db_name = 'baz') -- normalized!
+RESTORE DATABASE foo FROM ('bar') WITH OPTIONS (new_db_name = ('baz')) -- fully parenthesized
+RESTORE DATABASE foo FROM '_' WITH OPTIONS (new_db_name = '_') -- literals removed
+RESTORE DATABASE _ FROM 'bar' WITH OPTIONS (new_db_name = 'baz') -- identifiers removed
+
+parse
+RESTORE DATABASE foo FROM 'bar' WITH schema_only
+----
+RESTORE DATABASE foo FROM 'bar' WITH OPTIONS (schema_only) -- normalized!
+RESTORE DATABASE foo FROM ('bar') WITH OPTIONS (schema_only) -- fully parenthesized
+RESTORE DATABASE foo FROM '_' WITH OPTIONS (schema_only) -- literals removed
+RESTORE DATABASE _ FROM 'bar' WITH OPTIONS (schema_only) -- identifiers removed
+
+parse
+RESTORE DATABASE foo FROM 'bar' IN LATEST WITH incremental_location = 'baz'
+----
+RESTORE DATABASE foo FROM 'bar' IN 'latest' WITH OPTIONS (incremental_location = 'baz') -- normalized!
+RESTORE DATABASE foo FROM ('bar') IN ('latest') WITH OPTIONS (incremental_location = ('baz')) -- fully parenthesized
+RESTORE DATABASE foo FROM '_' IN '_' WITH OPTIONS (incremental_location = '_') -- literals removed
+RESTORE DATABASE _ FROM 'bar' IN 'latest' WITH OPTIONS (incremental_location = 'baz') -- identifiers removed
+
+parse
+RESTORE DATABASE foo, baz FROM 'bar' AS OF SYSTEM TIME '1'
+----
+RESTORE DATABASE foo, baz FROM 'bar' AS OF SYSTEM TIME '1'
+RESTORE DATABASE foo, baz FROM ('bar') AS OF SYSTEM TIME ('1') -- fully parenthesized
+RESTORE DATABASE foo, baz FROM '_' AS OF SYSTEM TIME '_' -- literals removed
+RESTORE DATABASE _, _ FROM 'bar' AS OF SYSTEM TIME '1' -- identifiers removed
+
+parse
+RESTORE DATABASE foo FROM ($1, $2)
+----
+RESTORE DATABASE foo FROM ($1, $2)
+RESTORE DATABASE foo FROM (($1), ($2)) -- fully parenthesized
+RESTORE DATABASE foo FROM ($1, $1) -- literals removed
+RESTORE DATABASE _ FROM ($1, $2) -- identifiers removed
+
+parse
+RESTORE DATABASE foo FROM ($1), ($2)
+----
+RESTORE DATABASE foo FROM $1, $2 -- normalized!
+RESTORE DATABASE foo FROM ($1), ($2) -- fully parenthesized
+RESTORE DATABASE foo FROM $1, $1 -- literals removed
+RESTORE DATABASE _ FROM $1, $2 -- identifiers removed
+
+parse
+RESTORE DATABASE foo FROM ($1), ($2, $3)
+----
+RESTORE DATABASE foo FROM $1, ($2, $3) -- normalized!
+RESTORE DATABASE foo FROM ($1), (($2), ($3)) -- fully parenthesized
+RESTORE DATABASE foo FROM $1, ($1, $1) -- literals removed
+RESTORE DATABASE _ FROM $1, ($2, $3) -- identifiers removed
+
+parse
+RESTORE DATABASE foo FROM ($1, $2), $3
+----
+RESTORE DATABASE foo FROM ($1, $2), $3
+RESTORE DATABASE foo FROM (($1), ($2)), ($3) -- fully parenthesized
+RESTORE DATABASE foo FROM ($1, $1), $1 -- literals removed
+RESTORE DATABASE _ FROM ($1, $2), $3 -- identifiers removed
+
+parse
+RESTORE DATABASE foo FROM $1, ($2, $3)
+----
+RESTORE DATABASE foo FROM $1, ($2, $3)
+RESTORE DATABASE foo FROM ($1), (($2), ($3)) -- fully parenthesized
+RESTORE DATABASE foo FROM $1, ($1, $1) -- literals removed
+RESTORE DATABASE _ FROM $1, ($2, $3) -- identifiers removed
+
+parse
+RESTORE DATABASE foo FROM ($1, $2), ($3, $4)
+----
+RESTORE DATABASE foo FROM ($1, $2), ($3, $4)
+RESTORE DATABASE foo FROM (($1), ($2)), (($3), ($4)) -- fully parenthesized
+RESTORE DATABASE foo FROM ($1, $1), ($1, $1) -- literals removed
+RESTORE DATABASE _ FROM ($1, $2), ($3, $4) -- identifiers removed
+
+parse
+RESTORE DATABASE foo FROM ($1, $2), ($3, $4) AS OF SYSTEM TIME '1'
+----
+RESTORE DATABASE foo FROM ($1, $2), ($3, $4) AS OF SYSTEM TIME '1'
+RESTORE DATABASE foo FROM (($1), ($2)), (($3), ($4)) AS OF SYSTEM TIME ('1') -- fully parenthesized
+RESTORE DATABASE foo FROM ($1, $1), ($1, $1) AS OF SYSTEM TIME '_' -- literals removed
+RESTORE DATABASE _ FROM ($1, $2), ($3, $4) AS OF SYSTEM TIME '1' -- identifiers removed
+
+parse
+RESTORE FROM ($1, $2)
+----
+RESTORE FROM ($1, $2)
+RESTORE FROM (($1), ($2)) -- fully parenthesized
+RESTORE FROM ($1, $1) -- literals removed
+RESTORE FROM ($1, $2) -- identifiers removed
+
+parse
+RESTORE FROM ($1, $2), $3
+----
+RESTORE FROM ($1, $2), $3
+RESTORE FROM (($1), ($2)), ($3) -- fully parenthesized
+RESTORE FROM ($1, $1), $1 -- literals removed
+RESTORE FROM ($1, $2), $3 -- identifiers removed
+
+parse
+RESTORE FROM $1, ($2, $3)
+----
+RESTORE FROM $1, ($2, $3)
+RESTORE FROM ($1), (($2), ($3)) -- fully parenthesized
+RESTORE FROM $1, ($1, $1) -- literals removed
+RESTORE FROM $1, ($2, $3) -- identifiers removed
+
+parse
+RESTORE FROM ($1, $2), ($3, $4)
+----
+RESTORE FROM ($1, $2), ($3, $4)
+RESTORE FROM (($1), ($2)), (($3), ($4)) -- fully parenthesized
+RESTORE FROM ($1, $1), ($1, $1) -- literals removed
+RESTORE FROM ($1, $2), ($3, $4) -- identifiers removed
+
+parse
+RESTORE FROM ($1, $2), ($3, $4) AS OF SYSTEM TIME '1'
+----
+RESTORE FROM ($1, $2), ($3, $4) AS OF SYSTEM TIME '1'
+RESTORE FROM (($1), ($2)), (($3), ($4)) AS OF SYSTEM TIME ('1') -- fully parenthesized
+RESTORE FROM ($1, $1), ($1, $1) AS OF SYSTEM TIME '_' -- literals removed
+RESTORE FROM ($1, $2), ($3, $4) AS OF SYSTEM TIME '1' -- identifiers removed
+
+parse
+RESTORE FROM $1, $2, 'bar'
+----
+RESTORE FROM $1, $2, 'bar'
+RESTORE FROM ($1), ($2), ('bar') -- fully parenthesized
+RESTORE FROM $1, $1, '_' -- literals removed
+RESTORE FROM $1, $2, 'bar' -- identifiers removed
+
+parse
+RESTORE FROM $4 IN $1, $2, 'bar'
+----
+RESTORE FROM $4 IN $1, $2, 'bar'
+RESTORE FROM ($4) IN ($1), ($2), ('bar') -- fully parenthesized
+RESTORE FROM $1 IN $1, $1, '_' -- literals removed
+RESTORE FROM $4 IN $1, $2, 'bar' -- identifiers removed
+
+parse
+RESTORE FROM $4 IN $1, $2, 'bar' AS OF SYSTEM TIME '1' WITH skip_missing_foreign_keys
+----
+RESTORE FROM $4 IN $1, $2, 'bar' AS OF SYSTEM TIME '1' WITH OPTIONS (skip_missing_foreign_keys) -- normalized!
+RESTORE FROM ($4) IN ($1), ($2), ('bar') AS OF SYSTEM TIME ('1') WITH OPTIONS (skip_missing_foreign_keys) -- fully parenthesized
+RESTORE FROM $1 IN $1, $1, '_' AS OF SYSTEM TIME '_' WITH OPTIONS (skip_missing_foreign_keys) -- literals removed
+RESTORE FROM $4 IN $1, $2, 'bar' AS OF SYSTEM TIME '1' WITH OPTIONS (skip_missing_foreign_keys) -- identifiers removed
+
+parse
+RESTORE abc.xzy FROM 'a' WITH into_db = 'foo', skip_missing_foreign_keys
+----
+RESTORE TABLE abc.xzy FROM 'a' WITH OPTIONS (into_db = 'foo', skip_missing_foreign_keys) -- normalized!
+RESTORE TABLE (abc.xzy) FROM ('a') WITH OPTIONS (into_db = ('foo'), skip_missing_foreign_keys) -- fully parenthesized
+RESTORE TABLE abc.xzy FROM '_' WITH OPTIONS (into_db = '_', skip_missing_foreign_keys) -- literals removed
+RESTORE TABLE _._ FROM 'a' WITH OPTIONS (into_db = 'foo', skip_missing_foreign_keys) -- identifiers removed
+
+parse
+RESTORE FROM 'a' WITH into_db = 'foo', skip_missing_foreign_keys, skip_localities_check
+----
+RESTORE FROM 'a' WITH OPTIONS (into_db = 'foo', skip_missing_foreign_keys, skip_localities_check) -- normalized!
+RESTORE FROM ('a') WITH OPTIONS (into_db = ('foo'), skip_missing_foreign_keys, skip_localities_check) -- fully parenthesized
+RESTORE FROM '_' WITH OPTIONS (into_db = '_', skip_missing_foreign_keys, skip_localities_check) -- literals removed
+RESTORE FROM 'a' WITH OPTIONS (into_db = 'foo', skip_missing_foreign_keys, skip_localities_check) -- identifiers removed
+
+parse
+RESTORE foo FROM 'bar' WITH OPTIONS (encryption_passphrase='secret', into_db='baz', debug_pause_on='error',
+skip_missing_foreign_keys, skip_missing_sequences, skip_missing_sequence_owners, skip_missing_views, skip_missing_udfs, detached, skip_localities_check)
+----
+RESTORE TABLE foo FROM 'bar' WITH OPTIONS (encryption_passphrase = '*****', into_db = 'baz', debug_pause_on = 'error', skip_missing_foreign_keys, skip_missing_sequence_owners, skip_missing_sequences, skip_missing_views, skip_missing_udfs, detached, skip_localities_check) -- normalized!
+RESTORE TABLE (foo) FROM ('bar') WITH OPTIONS (encryption_passphrase = '*****', into_db = ('baz'), debug_pause_on = ('error'), skip_missing_foreign_keys, skip_missing_sequence_owners, skip_missing_sequences, skip_missing_views, skip_missing_udfs, detached, skip_localities_check) -- fully parenthesized
+RESTORE TABLE foo FROM '_' WITH OPTIONS (encryption_passphrase = '*****', into_db = '_', debug_pause_on = '_', skip_missing_foreign_keys, skip_missing_sequence_owners, skip_missing_sequences, skip_missing_views, skip_missing_udfs, detached, skip_localities_check) -- literals removed
+RESTORE TABLE _ FROM 'bar' WITH OPTIONS (encryption_passphrase = '*****', into_db = 'baz', debug_pause_on = 'error', skip_missing_foreign_keys, skip_missing_sequence_owners, skip_missing_sequences, skip_missing_views, skip_missing_udfs, detached, skip_localities_check) -- identifiers removed
+RESTORE TABLE foo FROM 'bar' WITH OPTIONS (encryption_passphrase = 'secret', into_db = 'baz', debug_pause_on = 'error', skip_missing_foreign_keys, skip_missing_sequence_owners, skip_missing_sequences, skip_missing_views, skip_missing_udfs, detached, skip_localities_check) -- passwords exposed
+
+parse
+RESTORE foo FROM 'bar' WITH ENCRYPTION_PASSPHRASE = 'secret', INTO_DB=baz, DEBUG_PAUSE_ON='error',
+SKIP_MISSING_FOREIGN_KEYS, SKIP_MISSING_SEQUENCES, SKIP_MISSING_SEQUENCE_OWNERS, SKIP_MISSING_VIEWS, SKIP_LOCALITIES_CHECK, SKIP_MISSING_UDFS
+----
+RESTORE TABLE foo FROM 'bar' WITH OPTIONS (encryption_passphrase = '*****', into_db = 'baz', debug_pause_on = 'error', skip_missing_foreign_keys, skip_missing_sequence_owners, skip_missing_sequences, skip_missing_views, skip_missing_udfs, skip_localities_check) -- normalized!
+RESTORE TABLE (foo) FROM ('bar') WITH OPTIONS (encryption_passphrase = '*****', into_db = ('baz'), debug_pause_on = ('error'), skip_missing_foreign_keys, skip_missing_sequence_owners, skip_missing_sequences, skip_missing_views, skip_missing_udfs, skip_localities_check) -- fully parenthesized
+RESTORE TABLE foo FROM '_' WITH OPTIONS (encryption_passphrase = '*****', into_db = '_', debug_pause_on = '_', skip_missing_foreign_keys, skip_missing_sequence_owners, skip_missing_sequences, skip_missing_views, skip_missing_udfs, skip_localities_check) -- literals removed
+RESTORE TABLE _ FROM 'bar' WITH OPTIONS (encryption_passphrase = '*****', into_db = 'baz', debug_pause_on = 'error', skip_missing_foreign_keys, skip_missing_sequence_owners, skip_missing_sequences, skip_missing_views, skip_missing_udfs, skip_localities_check) -- identifiers removed
+RESTORE TABLE foo FROM 'bar' WITH OPTIONS (encryption_passphrase = 'secret', into_db = 'baz', debug_pause_on = 'error', skip_missing_foreign_keys, skip_missing_sequence_owners, skip_missing_sequences, skip_missing_views, skip_missing_udfs, skip_localities_check) -- passwords exposed
+
+parse
+RESTORE TENANT 36 FROM ($1, $2) AS OF SYSTEM TIME '1'
+----
+RESTORE VIRTUAL CLUSTER 36 FROM ($1, $2) AS OF SYSTEM TIME '1' -- normalized!
+RESTORE VIRTUAL CLUSTER 36 FROM (($1), ($2)) AS OF SYSTEM TIME ('1') -- fully parenthesized
+RESTORE VIRTUAL CLUSTER _ FROM ($1, $1) AS OF SYSTEM TIME '_' -- literals removed
+RESTORE VIRTUAL CLUSTER 36 FROM ($1, $2) AS OF SYSTEM TIME '1' -- identifiers removed
+
+parse
+RESTORE TENANT 36 FROM ($1, $2) WITH virtual_cluster_name = 'tenant-5'
+----
+RESTORE VIRTUAL CLUSTER 36 FROM ($1, $2) WITH OPTIONS (virtual_cluster_name = 'tenant-5') -- normalized!
+RESTORE VIRTUAL CLUSTER 36 FROM (($1), ($2)) WITH OPTIONS (virtual_cluster_name = ('tenant-5')) -- fully parenthesized
+RESTORE VIRTUAL CLUSTER _ FROM ($1, $1) WITH OPTIONS (virtual_cluster_name = '_') -- literals removed
+RESTORE VIRTUAL CLUSTER 36 FROM ($1, $2) WITH OPTIONS (virtual_cluster_name = 'tenant-5') -- identifiers removed
+
+parse
+RESTORE TENANT 36 FROM ($1, $2) WITH tenant_name = 'tenant-5'
+----
+RESTORE VIRTUAL CLUSTER 36 FROM ($1, $2) WITH OPTIONS (virtual_cluster_name = 'tenant-5') -- normalized!
+RESTORE VIRTUAL CLUSTER 36 FROM (($1), ($2)) WITH OPTIONS (virtual_cluster_name = ('tenant-5')) -- fully parenthesized
+RESTORE VIRTUAL CLUSTER _ FROM ($1, $1) WITH OPTIONS (virtual_cluster_name = '_') -- literals removed
+RESTORE VIRTUAL CLUSTER 36 FROM ($1, $2) WITH OPTIONS (virtual_cluster_name = 'tenant-5') -- identifiers removed
+
+parse
+RESTORE TENANT 36 FROM ($1, $2) WITH virtual_cluster = '5'
+----
+RESTORE VIRTUAL CLUSTER 36 FROM ($1, $2) WITH OPTIONS (virtual_cluster = '5') -- normalized!
+RESTORE VIRTUAL CLUSTER 36 FROM (($1), ($2)) WITH OPTIONS (virtual_cluster = ('5')) -- fully parenthesized
+RESTORE VIRTUAL CLUSTER _ FROM ($1, $1) WITH OPTIONS (virtual_cluster = '_') -- literals removed
+RESTORE VIRTUAL CLUSTER 36 FROM ($1, $2) WITH OPTIONS (virtual_cluster = '5') -- identifiers removed
+
+parse
+RESTORE TENANT 36 FROM ($1, $2) WITH tenant = '5'
+----
+RESTORE VIRTUAL CLUSTER 36 FROM ($1, $2) WITH OPTIONS (virtual_cluster = '5') -- normalized!
+RESTORE VIRTUAL CLUSTER 36 FROM (($1), ($2)) WITH OPTIONS (virtual_cluster = ('5')) -- fully parenthesized
+RESTORE VIRTUAL CLUSTER _ FROM ($1, $1) WITH OPTIONS (virtual_cluster = '_') -- literals removed
+RESTORE VIRTUAL CLUSTER 36 FROM ($1, $2) WITH OPTIONS (virtual_cluster = '5') -- identifiers removed
+
+parse
+BACKUP TABLE foo TO 'bar' WITH revision_history, detached
+----
+BACKUP TABLE foo TO 'bar' WITH OPTIONS (revision_history = true, detached) -- normalized!
+BACKUP TABLE (foo) TO ('bar') WITH OPTIONS (revision_history = (true), detached) -- fully parenthesized
+BACKUP TABLE foo TO '_' WITH OPTIONS (revision_history = _, detached) -- literals removed
+BACKUP TABLE _ TO 'bar' WITH OPTIONS (revision_history = true, detached) -- identifiers removed
+
+parse
+BACKUP TABLE foo TO 'bar' WITH revision_history = $1, detached, execution locality = $2
+----
+BACKUP TABLE foo TO 'bar' WITH OPTIONS (revision_history = $1, detached, execution locality = $2) -- normalized!
+BACKUP TABLE (foo) TO ('bar') WITH OPTIONS (revision_history = ($1), detached, execution locality = ($2)) -- fully parenthesized
+BACKUP TABLE foo TO '_' WITH OPTIONS (revision_history = $1, detached, execution locality = $1) -- literals removed
+BACKUP TABLE _ TO 'bar' WITH OPTIONS (revision_history = $1, detached, execution locality = $2) -- identifiers removed
+
+parse
+RESTORE TABLE foo FROM 'bar' WITH skip_missing_foreign_keys, skip_missing_sequences, detached
+----
+RESTORE TABLE foo FROM 'bar' WITH OPTIONS (skip_missing_foreign_keys, skip_missing_sequences, detached) -- normalized!
+RESTORE TABLE (foo) FROM ('bar') WITH OPTIONS (skip_missing_foreign_keys, skip_missing_sequences, detached) -- fully parenthesized
+RESTORE TABLE foo FROM '_' WITH OPTIONS (skip_missing_foreign_keys, skip_missing_sequences, detached) -- literals removed
+RESTORE TABLE _ FROM 'bar' WITH OPTIONS (skip_missing_foreign_keys, skip_missing_sequences, detached) -- identifiers removed
+
+parse
+BACKUP INTO 'bar' WITH include_all_virtual_clusters = $1, detached
+----
+BACKUP INTO 'bar' WITH OPTIONS (detached, include_all_virtual_clusters = $1) -- normalized!
+BACKUP INTO ('bar') WITH OPTIONS (detached, include_all_virtual_clusters = ($1)) -- fully parenthesized
+BACKUP INTO '_' WITH OPTIONS (detached, include_all_virtual_clusters = $1) -- literals removed
+BACKUP INTO 'bar' WITH OPTIONS (detached, include_all_virtual_clusters = $1) -- identifiers removed
+
+parse
+BACKUP INTO 'bar' WITH include_all_secondary_tenants = $1, detached
+----
+BACKUP INTO 'bar' WITH OPTIONS (detached, include_all_virtual_clusters = $1) -- normalized!
+BACKUP INTO ('bar') WITH OPTIONS (detached, include_all_virtual_clusters = ($1)) -- fully parenthesized
+BACKUP INTO '_' WITH OPTIONS (detached, include_all_virtual_clusters = $1) -- literals removed
+BACKUP INTO 'bar' WITH OPTIONS (detached, include_all_virtual_clusters = $1) -- identifiers removed
+
+parse
+BACKUP INTO 'bar' WITH include_all_virtual_clusters, detached
+----
+BACKUP INTO 'bar' WITH OPTIONS (detached, include_all_virtual_clusters = true) -- normalized!
+BACKUP INTO ('bar') WITH OPTIONS (detached, include_all_virtual_clusters = (true)) -- fully parenthesized
+BACKUP INTO '_' WITH OPTIONS (detached, include_all_virtual_clusters = _) -- literals removed
+BACKUP INTO 'bar' WITH OPTIONS (detached, include_all_virtual_clusters = true) -- identifiers removed
+
+parse
+BACKUP INTO 'bar' WITH include_all_secondary_tenants, detached
+----
+BACKUP INTO 'bar' WITH OPTIONS (detached, include_all_virtual_clusters = true) -- normalized!
+BACKUP INTO ('bar') WITH OPTIONS (detached, include_all_virtual_clusters = (true)) -- fully parenthesized
+BACKUP INTO '_' WITH OPTIONS (detached, include_all_virtual_clusters = _) -- literals removed
+BACKUP INTO 'bar' WITH OPTIONS (detached, include_all_virtual_clusters = true) -- identifiers removed
+
+parse
+RESTORE FROM LATEST IN 'bar' WITH include_all_virtual_clusters = $1, detached
+----
+RESTORE FROM 'latest' IN 'bar' WITH OPTIONS (detached, include_all_virtual_clusters = $1) -- normalized!
+RESTORE FROM ('latest') IN ('bar') WITH OPTIONS (detached, include_all_virtual_clusters = ($1)) -- fully parenthesized
+RESTORE FROM '_' IN '_' WITH OPTIONS (detached, include_all_virtual_clusters = $1) -- literals removed
+RESTORE FROM 'latest' IN 'bar' WITH OPTIONS (detached, include_all_virtual_clusters = $1) -- identifiers removed
+
+parse
 RESTORE FROM LATEST IN 'bar' WITH include_all_virtual_clusters = $1, execution locality = $2, detached
 ----
 RESTORE FROM 'latest' IN 'bar' WITH OPTIONS (detached, include_all_virtual_clusters = $1, execution locality = $2) -- normalized!
 RESTORE FROM ('latest') IN ('bar') WITH OPTIONS (detached, include_all_virtual_clusters = ($1), execution locality = ($2)) -- fully parenthesized
 RESTORE FROM '_' IN '_' WITH OPTIONS (detached, include_all_virtual_clusters = $1, execution locality = $1) -- literals removed
 RESTORE FROM 'latest' IN 'bar' WITH OPTIONS (detached, include_all_virtual_clusters = $1, execution locality = $2) -- identifiers removed
+
+parse
+RESTORE FROM LATEST IN 'bar' WITH include_all_virtual_clusters, detached
+----
+RESTORE FROM 'latest' IN 'bar' WITH OPTIONS (detached, include_all_virtual_clusters = true) -- normalized!
+RESTORE FROM ('latest') IN ('bar') WITH OPTIONS (detached, include_all_virtual_clusters = (true)) -- fully parenthesized
+RESTORE FROM '_' IN '_' WITH OPTIONS (detached, include_all_virtual_clusters = _) -- literals removed
+RESTORE FROM 'latest' IN 'bar' WITH OPTIONS (detached, include_all_virtual_clusters = true) -- identifiers removed
+
+parse
+RESTORE FROM LATEST IN 'bar' WITH include_all_secondary_tenants, detached
+----
+RESTORE FROM 'latest' IN 'bar' WITH OPTIONS (detached, include_all_virtual_clusters = true) -- normalized!
+RESTORE FROM ('latest') IN ('bar') WITH OPTIONS (detached, include_all_virtual_clusters = (true)) -- fully parenthesized
+RESTORE FROM '_' IN '_' WITH OPTIONS (detached, include_all_virtual_clusters = _) -- literals removed
+RESTORE FROM 'latest' IN 'bar' WITH OPTIONS (detached, include_all_virtual_clusters = true) -- identifiers removed
+
+parse
+RESTORE FROM LATEST IN 'bar' WITH unsafe_restore_incompatible_version, execution locality = 'abc', detached
+----
+RESTORE FROM 'latest' IN 'bar' WITH OPTIONS (detached, unsafe_restore_incompatible_version, execution locality = 'abc') -- normalized!
+RESTORE FROM ('latest') IN ('bar') WITH OPTIONS (detached, unsafe_restore_incompatible_version, execution locality = ('abc')) -- fully parenthesized
+RESTORE FROM '_' IN '_' WITH OPTIONS (detached, unsafe_restore_incompatible_version, execution locality = '_') -- literals removed
+RESTORE FROM 'latest' IN 'bar' WITH OPTIONS (detached, unsafe_restore_incompatible_version, execution locality = 'abc') -- identifiers removed
+
+error
+BACKUP foo TO 'bar' WITH key1, key2 = 'value'
+----
+at or near "key1": syntax error
+DETAIL: source SQL:
+BACKUP foo TO 'bar' WITH key1, key2 = 'value'
+                         ^
+HINT: try \h BACKUP
+
+error
+BACKUP foo TO 'bar' WITH revision_history, revision_history
+----
+at or near "EOF": syntax error: revision_history option specified multiple times
+DETAIL: source SQL:
+BACKUP foo TO 'bar' WITH revision_history, revision_history
+                                                           ^
+
+error
+BACKUP foo TO 'bar' WITH detached, revision_history, detached
+----
+at or near "EOF": syntax error: detached option specified multiple times
+DETAIL: source SQL:
+BACKUP foo TO 'bar' WITH detached, revision_history, detached
+                                                             ^
+
+error
+BACKUP foo TO 'bar' WITH revision_history=false, revision_history, detached
+----
+at or near ",": syntax error: revision_history option specified multiple times
+DETAIL: source SQL:
+BACKUP foo TO 'bar' WITH revision_history=false, revision_history, detached
+                                                                 ^
+
+error
+BACKUP foo TO 'bar' WITH detached=true, revision_history, detached=true
+----
+at or near "true": syntax error: detached option specified multiple times
+DETAIL: source SQL:
+BACKUP foo TO 'bar' WITH detached=true, revision_history, detached=true
+                                                                   ^
+
+error
+BACKUP TO 'bar' WITH include_all_virtual_clusters=false, include_all_secondary_tenants
+----
+at or near "EOF": syntax error: include_all_virtual_clusters specified multiple times
+DETAIL: source SQL:
+BACKUP TO 'bar' WITH include_all_virtual_clusters=false, include_all_secondary_tenants
+                                                                                      ^
+
+error
+BACKUP foo TO 'bar' WITH detached=$1, revision_history
+----
+at or near "1": syntax error
+DETAIL: source SQL:
+BACKUP foo TO 'bar' WITH detached=$1, revision_history
+                                  ^
+HINT: try \h BACKUP
+
+error
+RESTORE foo FROM 'bar' WITH key1, key2 = 'value'
+----
+at or near "key1": syntax error
+DETAIL: source SQL:
+RESTORE foo FROM 'bar' WITH key1, key2 = 'value'
+                            ^
+HINT: try \h RESTORE
+
+error
+RESTORE foo FROM 'bar' WITH skip_missing_foreign_keys, skip_missing_foreign_keys
+----
+at or near "skip_missing_foreign_keys": syntax error: skip_missing_foreign_keys specified multiple times
+DETAIL: source SQL:
+RESTORE foo FROM 'bar' WITH skip_missing_foreign_keys, skip_missing_foreign_keys
+                                                       ^
+
+error
+RESTORE foo FROM 'bar' WITH skip_missing_sequences, skip_missing_views, skip_missing_sequences
+----
+at or near "skip_missing_sequences": syntax error: skip_missing_sequences specified multiple times
+DETAIL: source SQL:
+RESTORE foo FROM 'bar' WITH skip_missing_sequences, skip_missing_views, skip_missing_sequences
+                                                                        ^
+
+error
+RESTORE foo FROM 'bar' WITH detached, skip_missing_views, detached
+----
+at or near "detached": syntax error: detached option specified multiple times
+DETAIL: source SQL:
+RESTORE foo FROM 'bar' WITH detached, skip_missing_views, detached
+                                                          ^
+
+error
+RESTORE foo FROM 'bar' WITH skip_missing_udfs, skip_missing_views, skip_missing_udfs
+----
+at or near "skip_missing_udfs": syntax error: skip_missing_udfs specified multiple times
+DETAIL: source SQL:
+RESTORE foo FROM 'bar' WITH skip_missing_udfs, skip_missing_views, skip_missing_udfs
+                                                                   ^
+
+error
+RESTORE FROM 'bar' WITH include_all_virtual_clusters=false, include_all_secondary_tenants
+----
+at or near "EOF": syntax error: include_all_virtual_clusters specified multiple times
+DETAIL: source SQL:
+RESTORE FROM 'bar' WITH include_all_virtual_clusters=false, include_all_secondary_tenants
+                                                                                         ^
+
+error
+RESTORE FROM 'bar' WITH unsafe_restore_incompatible_version, unsafe_restore_incompatible_version
+----
+at or near "unsafe_restore_incompatible_version": syntax error: unsafe_restore_incompatible_version specified multiple times
+DETAIL: source SQL:
+RESTORE FROM 'bar' WITH unsafe_restore_incompatible_version, unsafe_restore_incompatible_version
+                                                             ^
+
+error
+BACKUP ROLE foo, bar TO 'baz'
+----
+at or near "foo": syntax error
+DETAIL: source SQL:
+BACKUP ROLE foo, bar TO 'baz'
+            ^
+HINT: try \h BACKUP
+
+error
+RESTORE ROLE foo, bar FROM 'baz'
+----
+at or near "foo": syntax error
+DETAIL: source SQL:
+RESTORE ROLE foo, bar FROM 'baz'
+             ^
+HINT: try \h RESTORE
+
+# Regression test for #95612
+parse
+BACKUP INTO LATEST IN UNLOGGED WITH OPTIONS ( DETACHED = FALSE )
+----
+BACKUP INTO LATEST IN 'unlogged' WITH OPTIONS (detached = FALSE) -- normalized!
+BACKUP INTO LATEST IN ('unlogged') WITH OPTIONS (detached = FALSE) -- fully parenthesized
+BACKUP INTO LATEST IN '_' WITH OPTIONS (detached = FALSE) -- literals removed
+BACKUP INTO LATEST IN 'unlogged' WITH OPTIONS (detached = FALSE) -- identifiers removed


### PR DESCRIPTION
In #107892, there were some tests that accidentally overwrote the "WITH" syntax to "WITH OPTIONS".

Release note: none
Epic: none