### PR TITLE
changefeedccl: add test to assert monotonic highwater during retries

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_dist.go
+++ b/pkg/ccl/changefeedccl/changefeed_dist.go
@@ -122,6 +122,11 @@ func distChangefeedFlow(
 		}
 	}
 
+	if knobs, ok := execCtx.ExecCfg().DistSQLSrv.TestingKnobs.Changefeed.(*TestingKnobs); ok {
+		if knobs != nil && knobs.StartDistChangefeedInitialHighwater != nil {
+			knobs.StartDistChangefeedInitialHighwater(ctx, initialHighWater)
+		}
+	}
 	return startDistChangefeed(
 		ctx, execCtx, jobID, schemaTS, details, initialHighWater, localState, resultsCh)
 }

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -1363,6 +1363,12 @@ func reconcileJobStateWithLocalState(
 			`job should be retried later`, jobID, reloadErr)
 		return reloadErr
 	}
+	knobs, _ := execCfg.DistSQLSrv.TestingKnobs.Changefeed.(*TestingKnobs)
+	if knobs != nil && knobs.LoadJobErr != nil {
+		if err := knobs.LoadJobErr(); err != nil {
+			return err
+		}
+	}
 
 	localState.progress = reloadedJob.Progress()
 

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -8354,3 +8354,146 @@ func TestChangefeedTopicNames(t *testing.T) {
 
 	cdcTest(t, testFn, feedTestForceSink("pubsub"))
 }
+
+// Regression test for #108450. When a changefeed hits a retryable error
+// and retries, it should start with the most up-to-date highwater (ie. the
+// highwater in the job record). If there is an error reading the highwater
+// from the job record, there should be retries until we are able to get the
+// highwater.
+func TestHighwaterDoesNotRegressOnRetry(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
+		defer changefeedbase.TestingSetDefaultMinCheckpointFrequency(10 * time.Millisecond)()
+		knobs := s.TestingKnobs.
+			DistSQL.(*execinfra.TestingKnobs).
+			Changefeed.(*TestingKnobs)
+
+		// NB: We call this in a testing knob which runs in a separate goroutine, so we prefer
+		// not to use `require.NoError` because that may panic.
+		loadProgressErr := func(jobID jobspb.JobID, jobRegistry *jobs.Registry) (jobspb.Progress, error) {
+			job, err := jobRegistry.LoadJob(context.Background(), jobID)
+			if err != nil {
+				return jobspb.Progress{}, err
+			}
+			return job.Progress(), nil
+		}
+
+		sqlDB := sqlutils.MakeSQLRunner(s.DB)
+		sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY)`)
+		foo := feed(t, f, `CREATE CHANGEFEED FOR foo WITH resolved = '10ms'`)
+		defer closeFeed(t, foo)
+
+		// Rough estimate of the statement time. The test only asserts that
+		// things happen after the statement time. Asserting things happen after
+		// this is good enough.
+		initialHighwater := s.Server.Clock().Now()
+
+		jobFeed := foo.(cdctest.EnterpriseTestFeed)
+		jobRegistry := s.Server.JobRegistry().(*jobs.Registry)
+
+		// Pause the changefeed to configure testing knobs which need the job ID.
+		require.NoError(t, jobFeed.Pause())
+
+		// A flag we toggle on to put the changefeed in a retrying state.
+		var changefeedIsRetrying atomic.Bool
+		knobs.RaiseRetryableError = func() error {
+			if changefeedIsRetrying.Load() {
+				return errors.New("test retryable error")
+			}
+			return nil
+		}
+
+		// NB: We use the errCh to return errors in testing knobs because they run in separate goroutines.
+		// Avoid using `require` because it can panic and the goroutines may `recover()` the panic.
+		doneCh := make(chan struct{}, 1)
+		errCh := make(chan error, 1)
+		sendErrWithCtx := func(ctx context.Context, err error) {
+			t.Errorf("sending error: %s", err)
+			select {
+			case <-ctx.Done():
+				return
+			case errCh <- err:
+				return
+			}
+		}
+
+		knobs.StartDistChangefeedInitialHighwater = func(ctx context.Context, retryHighwater hlc.Timestamp) {
+			if changefeedIsRetrying.Load() {
+				progress, err := loadProgressErr(jobFeed.JobID(), jobRegistry)
+				if err != nil {
+					sendErrWithCtx(ctx, err)
+					return
+				}
+				progressHighwater := progress.GetHighWater()
+				// Sanity check that the highwater is not nil, meaning that a
+				// highwater timestamp was written to the job record.
+				if progressHighwater == nil {
+					sendErrWithCtx(ctx, errors.AssertionFailedf("job highwater is nil"))
+					return
+				}
+				// Assert that the retry highwater is equal to the one in the job
+				// record.
+				if !progressHighwater.Equal(retryHighwater) {
+					sendErrWithCtx(ctx, errors.AssertionFailedf("highwater %s does not match job highwater %s",
+						retryHighwater, progressHighwater))
+					return
+				}
+				// Terminate the test.
+				t.Log("signalling for test completion")
+				select {
+				case <-ctx.Done():
+					return
+				case doneCh <- struct{}{}:
+					return
+				}
+			}
+		}
+
+		loadJobErrCount := 2
+		knobs.LoadJobErr = func() error {
+			if loadJobErrCount > 0 {
+				loadJobErrCount -= 1
+				return errors.New("test error")
+			}
+			return nil
+		}
+
+		require.NoError(t, jobFeed.Resume())
+
+		// Step 1: Wait for the highwater to advance. This guarantees that there is some highwater
+		//         in the changefeed job record to use when retrying.
+		testutils.SucceedsSoon(t, func() error {
+			progress, err := loadProgressErr(jobFeed.JobID(), jobRegistry)
+			if err != nil {
+				return err
+			}
+			progressHighwater := progress.GetHighWater()
+			if progressHighwater != nil && initialHighwater.Less(*progressHighwater) {
+				changefeedIsRetrying.Store(true)
+				return nil
+			}
+			return errors.Newf("waiting for highwater %s to advance ahead of initial highwater %s",
+				progressHighwater, initialHighwater)
+		})
+
+		// Check that the following happens soon.
+		//
+		// Step 2: Since `changefeedIsRetrying` is true, the changefeed will now attempt retries in
+		//         via `knobs.RaiseRetryableError`.
+		// Step 3: `knobs.LoadJobErr` will result an in error when reading the job record a couple of times, causing
+		//          more retries.
+		// Step 4: Eventually, a dist changefeed is started at a certain highwater timestamp.
+		//         `knobs.StartDistChangefeedInitialHighwater`. should see this stimetsamp and assert that it's the one
+		//         from the job record.
+		select {
+		case <-time.After(30 * time.Second):
+			t.Fatal("test timed out")
+		case err := <-errCh:
+			t.Fatal(err)
+		case <-doneCh:
+		}
+	}
+	cdcTest(t, testFn, feedTestEnterpriseSinks)
+}

--- a/pkg/ccl/changefeedccl/testing_knobs.go
+++ b/pkg/ccl/changefeedccl/testing_knobs.go
@@ -52,7 +52,12 @@ type TestingKnobs struct {
 	OnDistflowSpec func(aggregatorSpecs []*execinfrapb.ChangeAggregatorSpec, frontierSpec *execinfrapb.ChangeFrontierSpec)
 	// RaiseRetryableError is a knob used to possibly return an error.
 	RaiseRetryableError func() error
-
+	// StartDistChangefeedInitialHighwater is called when starting the dist changefeed with the initial highwater
+	// of the changefeed. Note that this will be called when the changefeed starts and subsequently when the changefeed
+	// is retried.
+	StartDistChangefeedInitialHighwater func(ctx context.Context, initialHighwater hlc.Timestamp)
+	// LoadJobErr is called when the changefeed loads the job record during a retry to check for progress updates.
+	LoadJobErr func() error
 	// This is currently used to test negative timestamp in cursor i.e of the form
 	// "-3us". Check TestChangefeedCursor for more info. This function needs to be in the
 	// knobs as current statement time will only be available once the create changefeed statement


### PR DESCRIPTION
In https://github.com/cockroachdb/cockroach/issues/108450, it was discovered that there is a bug where a changefeed
may retry using an out of date highwater. This bug is only in versions
22.2 and earlier. This commit adds a test which asserts that a changefeed
does not retry with an out of date highwater.

Informs: https://github.com/cockroachdb/cockroach/issues/108450
Epic: None
Release note: None