### PR TITLE
upgrades: deflake TestRoleMembersIDMigration1500Users

### DIFF
--- a/pkg/upgrade/upgrades/role_members_ids_migration_test.go
+++ b/pkg/upgrade/upgrades/role_members_ids_migration_test.go
@@ -36,10 +36,12 @@ func TestRoleMembersIDMigration10Users(t *testing.T) {
 	runTestRoleMembersIDMigration(t, 10)
 }
 
-func TestRoleMembersIDMigration1500Users(t *testing.T) {
+func TestRoleMembersIDMigration1200Users(t *testing.T) {
 	skip.UnderRace(t)
 	skip.UnderStress(t)
-	runTestRoleMembersIDMigration(t, 1500)
+	// Choosing a number larger than 1000 tests that the batching logic in
+	// this upgrade works correctly.
+	runTestRoleMembersIDMigration(t, 1200)
 }
 
 func runTestRoleMembersIDMigration(t *testing.T, numUsers int) {


### PR DESCRIPTION
TeamCity has a new machine type where this test has started to time out more, so this change will make it take less time.

fixes https://github.com/cockroachdb/cockroach/issues/108539
Release note: None