### PR TITLE
release-23.1: persistedsqlstats: fix flakey TestPersistedSQLStatsRead

### DIFF
--- a/pkg/sql/sqlstats/persistedsqlstats/flush_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/flush_test.go
@@ -42,24 +42,24 @@ import (
 
 type testCase struct {
 	query       string
-	fingerprint string
+	stmtNoConst string
 	count       int64
 }
 
 var testQueries = []testCase{
 	{
 		query:       "SELECT 1",
-		fingerprint: "SELECT _",
+		stmtNoConst: "SELECT _",
 		count:       3,
 	},
 	{
 		query:       "SELECT 1, 2, 3",
-		fingerprint: "SELECT _, _, _",
+		stmtNoConst: "SELECT _, _, _",
 		count:       10,
 	},
 	{
 		query:       "SELECT 1, 1 WHERE 1 < 10",
-		fingerprint: "SELECT _, _ WHERE _ < _",
+		stmtNoConst: "SELECT _, _ WHERE _ < _",
 		count:       7,
 	},
 }
@@ -141,8 +141,8 @@ func TestSQLStatsFlush(t *testing.T) {
 		// For each test case, we verify that it's being properly inserted exactly
 		// once and it is exactly executed tc.count number of times.
 		for _, tc := range testQueries {
-			verifyNumOfInsertedEntries(t, secondSQLConn, tc.fingerprint, firstServer.NodeID(), 1 /* expectedStmtEntryCnt */, 1 /* expectedTxnEntryCtn */)
-			verifyInsertedFingerprintExecCount(t, secondSQLConn, tc.fingerprint, fakeTime.getAggTimeTs(), firstServer.NodeID(), tc.count)
+			verifyNumOfInsertedEntries(t, secondSQLConn, tc.stmtNoConst, firstServer.NodeID(), 1 /* expectedStmtEntryCnt */, 1 /* expectedTxnEntryCtn */)
+			verifyInsertedFingerprintExecCount(t, secondSQLConn, tc.stmtNoConst, fakeTime.getAggTimeTs(), firstServer.NodeID(), tc.count)
 		}
 	}
 
@@ -166,10 +166,10 @@ func TestSQLStatsFlush(t *testing.T) {
 		verifyInMemoryStatsEmpty(t, testQueries, secondServerSQLStats)
 
 		for _, tc := range testQueries {
-			verifyNumOfInsertedEntries(t, secondSQLConn, tc.fingerprint, firstServer.NodeID(), 1 /* expectedStmtEntryCnt */, 1 /* expectedTxnEntryCtn */)
+			verifyNumOfInsertedEntries(t, secondSQLConn, tc.stmtNoConst, firstServer.NodeID(), 1 /* expectedStmtEntryCnt */, 1 /* expectedTxnEntryCtn */)
 			// The execution count is doubled here because we execute all of the
 			// statements here in the same aggregation interval.
-			verifyInsertedFingerprintExecCount(t, secondSQLConn, tc.fingerprint, fakeTime.getAggTimeTs(), firstServer.NodeID(), tc.count+tc.count-1 /* expectedCount */)
+			verifyInsertedFingerprintExecCount(t, secondSQLConn, tc.stmtNoConst, fakeTime.getAggTimeTs(), firstServer.NodeID(), tc.count+tc.count-1 /* expectedCount */)
 		}
 	}
 
@@ -193,8 +193,8 @@ func TestSQLStatsFlush(t *testing.T) {
 
 		for _, tc := range testQueries {
 			// We expect exactly 2 entries since we are in a different aggregation window.
-			verifyNumOfInsertedEntries(t, secondSQLConn, tc.fingerprint, firstServer.NodeID(), 2 /* expectedStmtEntryCnt */, 2 /* expectedTxnEntryCtn */)
-			verifyInsertedFingerprintExecCount(t, secondSQLConn, tc.fingerprint, fakeTime.getAggTimeTs(), firstServer.NodeID(), tc.count)
+			verifyNumOfInsertedEntries(t, secondSQLConn, tc.stmtNoConst, firstServer.NodeID(), 2 /* expectedStmtEntryCnt */, 2 /* expectedTxnEntryCtn */)
+			verifyInsertedFingerprintExecCount(t, secondSQLConn, tc.stmtNoConst, fakeTime.getAggTimeTs(), firstServer.NodeID(), tc.count)
 		}
 	}
 
@@ -218,10 +218,10 @@ func TestSQLStatsFlush(t *testing.T) {
 		// Ensure that we encode the correct node_id for the new entry and did not
 		// accidentally tamper the entries written by another server.
 		for _, tc := range testQueries {
-			verifyNumOfInsertedEntries(t, firstSQLConn, tc.fingerprint, secondServer.NodeID(), 1 /* expectedStmtEntryCnt */, 1 /* expectedTxnEntryCtn */)
-			verifyInsertedFingerprintExecCount(t, firstSQLConn, tc.fingerprint, fakeTime.getAggTimeTs(), secondServer.NodeID(), tc.count)
-			verifyNumOfInsertedEntries(t, secondSQLConn, tc.fingerprint, firstServer.NodeID(), 2 /* expectedStmtEntryCnt */, 2 /* expectedTxnEntryCtn */)
-			verifyInsertedFingerprintExecCount(t, secondSQLConn, tc.fingerprint, fakeTime.getAggTimeTs(), firstServer.NodeID(), tc.count)
+			verifyNumOfInsertedEntries(t, firstSQLConn, tc.stmtNoConst, secondServer.NodeID(), 1 /* expectedStmtEntryCnt */, 1 /* expectedTxnEntryCtn */)
+			verifyInsertedFingerprintExecCount(t, firstSQLConn, tc.stmtNoConst, fakeTime.getAggTimeTs(), secondServer.NodeID(), tc.count)
+			verifyNumOfInsertedEntries(t, secondSQLConn, tc.stmtNoConst, firstServer.NodeID(), 2 /* expectedStmtEntryCnt */, 2 /* expectedTxnEntryCtn */)
+			verifyInsertedFingerprintExecCount(t, secondSQLConn, tc.stmtNoConst, fakeTime.getAggTimeTs(), firstServer.NodeID(), tc.count)
 		}
 	}
 }
@@ -814,8 +814,8 @@ func verifyInMemoryStatsCorrectness(
 ) {
 	for _, tc := range tcs {
 		err := statsProvider.SQLStats.IterateStatementStats(context.Background(), &sqlstats.IteratorOptions{}, func(ctx context.Context, statistics *appstatspb.CollectedStatementStatistics) error {
-			if tc.fingerprint == statistics.Key.Query {
-				require.Equal(t, tc.count, statistics.Stats.Count, "fingerprint: %s", tc.fingerprint)
+			if tc.stmtNoConst == statistics.Key.Query {
+				require.Equal(t, tc.count, statistics.Stats.Count, "fingerprint: %s", tc.stmtNoConst)
 			}
 
 			// All the queries should be under 1 minute
@@ -841,8 +841,8 @@ func verifyInMemoryStatsEmpty(
 ) {
 	for _, tc := range tcs {
 		err := statsProvider.SQLStats.IterateStatementStats(context.Background(), &sqlstats.IteratorOptions{}, func(ctx context.Context, statistics *appstatspb.CollectedStatementStatistics) error {
-			if tc.fingerprint == statistics.Key.Query {
-				require.Equal(t, 0 /* expected */, statistics.Stats.Count, "fingerprint: %s", tc.fingerprint)
+			if tc.stmtNoConst == statistics.Key.Query {
+				require.Equal(t, 0 /* expected */, statistics.Stats.Count, "fingerprint: %s", tc.stmtNoConst)
 			}
 			return nil
 		})

--- a/pkg/sql/sqlstats/persistedsqlstats/reader_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/reader_test.go
@@ -15,6 +15,8 @@ package persistedsqlstats_test
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -32,10 +34,129 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestPersistedSQLStatsRead(t *testing.T) {
+func TestPersistedSQLStatsReadMemory(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	skip.UnderStress(t, "the test is too slow to run under stress")
 
+	testCluster, ctx := createCluster(t)
+	defer testCluster.Stopper().Stop(ctx)
+	_, sqlStats, expectedStmtsNoConst := insertData(t, testCluster)
+
+	verifyInMemoryStmtFingerprints(t, expectedStmtsNoConst, "TestPersistedSQLStatsRead", sqlStats)
+	verifyStoredStmtFingerprints(t, expectedStmtsNoConst, sqlStats)
+}
+
+func TestPersistedSQLStatsReadDisk(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	skip.UnderStress(t, "the test is too slow to run under stress")
+
+	testCluster, ctx := createCluster(t)
+	defer testCluster.Stopper().Stop(ctx)
+	sqlConn, sqlStats, expectedStmtsNoConst := insertData(t, testCluster)
+
+	sqlStats.Flush(ctx)
+	verifyDiskStmtFingerprints(t, sqlConn, expectedStmtsNoConst)
+	verifyStoredStmtFingerprints(t, expectedStmtsNoConst, sqlStats)
+}
+
+func TestPersistedSQLStatsReadHybrid(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	skip.UnderStress(t, "the test is too slow to run under stress")
+
+	testCluster, ctx := createCluster(t)
+	defer testCluster.Stopper().Stop(ctx)
+
+	sqlConn, sqlStats, expectedStmtsNoConst := insertData(t, testCluster)
+	sqlStats.Flush(ctx)
+	// We execute each test queries one more time without flushing the stats.
+	// This means that we should see the exact same result as previous subtest
+	// except the execution count field will be incremented. We should not
+	// be seeing duplicated fields.
+	for _, tc := range testQueries {
+		sqlConn.Exec(t, tc.query)
+		tc.count++
+		expectedStmtsNoConst[tc.stmtNoConst]++
+	}
+
+	foundQueries := make(map[string]struct{})
+	foundTxns := make(map[string]struct{})
+	stmtFingerprintIDToQueries := make(map[appstatspb.StmtFingerprintID]string)
+
+	require.NoError(t,
+		sqlStats.IterateStatementStats(
+			context.Background(),
+			&sqlstats.IteratorOptions{
+				SortedKey:      true,
+				SortedAppNames: true,
+			},
+			func(ctx context.Context, statistics *appstatspb.CollectedStatementStatistics) error {
+				if expectedExecCount, ok := expectedStmtsNoConst[statistics.Key.Query]; ok {
+					_, ok = foundQueries[statistics.Key.Query]
+					require.False(
+						t,
+						ok,
+						"should only found one stats entry for %s, but found more than one", statistics.Key.Query,
+					)
+					foundQueries[statistics.Key.Query] = struct{}{}
+					stmtFingerprintIDToQueries[statistics.ID] = statistics.Key.Query
+					require.Equal(t, expectedExecCount, statistics.Stats.Count, "query: %s", statistics.Key.Query)
+				}
+				return nil
+			}))
+
+	require.NoError(t,
+		sqlStats.IterateTransactionStats(
+			context.Background(),
+			&sqlstats.IteratorOptions{},
+			func(
+				ctx context.Context,
+				statistics *appstatspb.CollectedTransactionStatistics,
+			) error {
+				if len(statistics.StatementFingerprintIDs) == 1 {
+					if query, ok := stmtFingerprintIDToQueries[statistics.StatementFingerprintIDs[0]]; ok {
+						if expectedExecCount, ok := expectedStmtsNoConst[query]; ok {
+							_, ok = foundTxns[query]
+							require.False(
+								t,
+								ok,
+								"should only found one txn stats entry for %s, but found more than one", query,
+							)
+							foundTxns[query] = struct{}{}
+							require.Equal(t, expectedExecCount, statistics.Stats.Count)
+						}
+					}
+				}
+				return nil
+			}))
+
+	for expectedStmtFingerprint := range expectedStmtsNoConst {
+		_, ok := foundQueries[expectedStmtFingerprint]
+		require.True(t, ok, "expected %s to be returned, but it didn't", expectedStmtFingerprint)
+	}
+}
+
+func insertData(
+	t *testing.T, testCluster serverutils.TestClusterInterface,
+) (*sqlutils.SQLRunner, *persistedsqlstats.PersistedSQLStats, map[string]int64) {
+	server1 := testCluster.Server(0 /* idx */)
+	sqlConn := sqlutils.MakeSQLRunner(testCluster.ServerConn(0))
+	sqlStats := server1.SQLServer().(*sql.Server).GetSQLStatsProvider().(*persistedsqlstats.PersistedSQLStats)
+
+	sqlConn.Exec(t, `SET application_name = 'TestPersistedSQLStatsRead'`)
+	expectedStmtsNoConst := make(map[string]int64)
+	for _, tc := range testQueries {
+		expectedStmtsNoConst[tc.stmtNoConst] = tc.count
+		for i := int64(0); i < tc.count; i++ {
+			sqlConn.Exec(t, tc.query)
+		}
+	}
+	return sqlConn, sqlStats, expectedStmtsNoConst
+}
+
+func createCluster(t *testing.T) (serverutils.TestClusterInterface, context.Context) {
 	fakeTime := stubTime{
 		aggInterval: time.Hour,
 	}
@@ -52,96 +173,7 @@ func TestPersistedSQLStatsRead(t *testing.T) {
 		},
 	})
 	ctx := context.Background()
-	defer testCluster.Stopper().Stop(ctx)
-
-	server1 := testCluster.Server(0 /* idx */)
-	sqlConn := sqlutils.MakeSQLRunner(testCluster.ServerConn(0 /* idx */))
-	sqlStats := server1.SQLServer().(*sql.Server).GetSQLStatsProvider().(*persistedsqlstats.PersistedSQLStats)
-
-	expectedStmtFingerprints := make(map[string]int64)
-	for _, tc := range testQueries {
-		expectedStmtFingerprints[tc.fingerprint] = tc.count
-		for i := int64(0); i < tc.count; i++ {
-			sqlConn.Exec(t, tc.query)
-		}
-	}
-
-	t.Run("in-memory only read", func(t *testing.T) {
-		verifyStoredStmtFingerprints(t, expectedStmtFingerprints, sqlStats)
-	})
-
-	t.Run("disk only read", func(t *testing.T) {
-		sqlStats.Flush(ctx)
-		verifyStoredStmtFingerprints(t, expectedStmtFingerprints, sqlStats)
-	})
-
-	t.Run("hybrid read", func(t *testing.T) {
-		// We execute each test queries one more time without flushing the stats.
-		// This means that we should see the exact same result as previous subtest
-		// except the execution count field will be incremented. We should not
-		// be seeing duplicated fields.
-		for _, tc := range testQueries {
-			sqlConn.Exec(t, tc.query)
-			tc.count++
-			expectedStmtFingerprints[tc.fingerprint]++
-		}
-
-		foundQueries := make(map[string]struct{})
-		foundTxns := make(map[string]struct{})
-		stmtFingerprintIDToQueries := make(map[appstatspb.StmtFingerprintID]string)
-
-		require.NoError(t,
-			sqlStats.IterateStatementStats(
-				context.Background(),
-				&sqlstats.IteratorOptions{
-					SortedKey:      true,
-					SortedAppNames: true,
-				},
-				func(ctx context.Context, statistics *appstatspb.CollectedStatementStatistics) error {
-					if expectedExecCount, ok := expectedStmtFingerprints[statistics.Key.Query]; ok {
-						_, ok = foundQueries[statistics.Key.Query]
-						require.False(
-							t,
-							ok,
-							"should only found one stats entry for %s, but found more than one", statistics.Key.Query,
-						)
-						foundQueries[statistics.Key.Query] = struct{}{}
-						stmtFingerprintIDToQueries[statistics.ID] = statistics.Key.Query
-						require.Equal(t, expectedExecCount, statistics.Stats.Count, "query: %s", statistics.Key.Query)
-					}
-					return nil
-				}))
-
-		require.NoError(t,
-			sqlStats.IterateTransactionStats(
-				context.Background(),
-				&sqlstats.IteratorOptions{},
-				func(
-					ctx context.Context,
-					statistics *appstatspb.CollectedTransactionStatistics,
-				) error {
-					if len(statistics.StatementFingerprintIDs) == 1 {
-						if query, ok := stmtFingerprintIDToQueries[statistics.StatementFingerprintIDs[0]]; ok {
-							if expectedExecCount, ok := expectedStmtFingerprints[query]; ok {
-								_, ok = foundTxns[query]
-								require.False(
-									t,
-									ok,
-									"should only found one txn stats entry for %s, but found more than one", query,
-								)
-								foundTxns[query] = struct{}{}
-								require.Equal(t, expectedExecCount, statistics.Stats.Count)
-							}
-						}
-					}
-					return nil
-				}))
-
-		for expectedStmtFingerprint := range expectedStmtFingerprints {
-			_, ok := foundQueries[expectedStmtFingerprint]
-			require.True(t, ok, "expected %s to be returned, but it didn't", expectedStmtFingerprint)
-		}
-	})
+	return testCluster, ctx
 }
 
 // Testing same fingerprint having more than one index recommendation and
@@ -202,6 +234,91 @@ func TestSQLStatsWithMultipleIdxRec(t *testing.T) {
 	sqlConn.QueryRow(t, combinedSelect).Scan(&cnt, &recs)
 	require.Equal(t, int64(6), cnt)
 	require.Equal(t, int64(2), recs)
+}
+
+func verifyInMemoryStmtFingerprints(
+	t *testing.T,
+	expectedStmtFingerprints map[string]int64,
+	appName string,
+	sqlStats *persistedsqlstats.PersistedSQLStats,
+) {
+	foundQueries := make(map[string]struct{})
+	foundTxns := make(map[string]struct{})
+	stmtFingerprintIDToQueries := make(map[appstatspb.StmtFingerprintID]string)
+	require.NoError(t,
+		sqlStats.GetApplicationStats(appName, false).IterateStatementStats(
+			context.Background(),
+			&sqlstats.IteratorOptions{},
+			func(ctx context.Context, statistics *appstatspb.CollectedStatementStatistics) error {
+				if expectedExecCount, ok := expectedStmtFingerprints[statistics.Key.Query]; ok {
+					foundQueries[statistics.Key.Query] = struct{}{}
+					stmtFingerprintIDToQueries[statistics.ID] = statistics.Key.Query
+					require.Equal(t, expectedExecCount, statistics.Stats.Count)
+				}
+				return nil
+			}))
+
+	require.NoError(t,
+		sqlStats.IterateTransactionStats(
+			context.Background(),
+			&sqlstats.IteratorOptions{},
+			func(
+				ctx context.Context,
+				statistics *appstatspb.CollectedTransactionStatistics,
+			) error {
+				if len(statistics.StatementFingerprintIDs) == 1 {
+					if query, ok := stmtFingerprintIDToQueries[statistics.StatementFingerprintIDs[0]]; ok {
+						if expectedExecCount, ok := expectedStmtFingerprints[query]; ok {
+							foundTxns[query] = struct{}{}
+							require.Equal(t, expectedExecCount, statistics.Stats.Count)
+						}
+					}
+				}
+				return nil
+			}))
+
+	for expectedStmtFingerprint := range expectedStmtFingerprints {
+		_, ok := foundQueries[expectedStmtFingerprint]
+		require.True(t, ok, "expected %s to be returned, but it didn't", expectedStmtFingerprint)
+		_, ok = foundTxns[expectedStmtFingerprint]
+		require.True(t, ok, "expected %s to be returned, but it didn't", expectedStmtFingerprint)
+	}
+}
+
+func verifyDiskStmtFingerprints(
+	t *testing.T, sqlRunner *sqlutils.SQLRunner, expectedStmtsNoConst map[string]int64,
+) {
+	require.NotEmpty(t, expectedStmtsNoConst)
+	expectedStmtsNoConstCopy := make(map[string]int64, len(expectedStmtsNoConst))
+	stmtQuery := `SELECT ss.metadata->>'query' as query,
+       ss.statistics->'statistics'->>'cnt' as count,
+       ts.execution_count
+FROM system.statement_statistics ss
+    LEFT JOIN system.transaction_statistics ts ON ss.transaction_fingerprint_id = ts.fingerprint_id
+WHERE ss.metadata->>'query' in ( `
+
+	for fingerprint, cnt := range expectedStmtsNoConst {
+		stmtQuery += fmt.Sprintf(` '%s' ,`, fingerprint)
+		expectedStmtsNoConstCopy[fingerprint] = cnt
+	}
+	stmtQuery = strings.TrimRight(stmtQuery, ",")
+	stmtQuery += " ) "
+	rows := sqlRunner.Query(t, stmtQuery)
+	defer rows.Close()
+
+	for rows.Next() {
+		require.NoError(t, rows.Err())
+		var actualStmtNoConst string
+		var actualStmtCount, actualTxnCount int64
+		require.NoError(t, rows.Scan(&actualStmtNoConst, &actualStmtCount, &actualTxnCount))
+		expectedCount, ok := expectedStmtsNoConstCopy[actualStmtNoConst]
+		require.True(t, ok, "Fingerprint %s not found in expected", actualStmtNoConst)
+		require.Equal(t, expectedCount, actualStmtCount, "statement no const: %s, expected stmt count: %d, actual count: %d", actualStmtNoConst, expectedCount, actualStmtCount)
+		require.Equal(t, expectedCount, actualTxnCount, "stmt no const: %s, expected txn count: %d, actual count: %d", actualStmtNoConst, expectedCount, actualTxnCount)
+		delete(expectedStmtsNoConstCopy, actualStmtNoConst)
+	}
+
+	require.Empty(t, expectedStmtsNoConstCopy)
 }
 
 func verifyStoredStmtFingerprints(


### PR DESCRIPTION
Backport 1/1 commits from #108131.

/cc @cockroachdb/release

---

1. Test always failed on secondary tenant, because it was always connecting to system tenant.
2. Test was not properly validating in memory vs system table. The `IterateStatementStats` iterates both in memory and stats from the system table. New functions are added to verify it's actually in memory vs system table. The original check was added to verify the stats `IterateStatementStats` logic.

Fixes: #107804

Release note: None

Release Justification: Test fix