### PR TITLE
build: add basic infrastructure for remote execution with EngFlow

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -53,14 +53,15 @@ test:race --test_timeout=1200,6000,18000,72000
 # CI uses a custom timeout for enormous targets.
 test:use_ci_timeouts --test_timeout=60,300,900,900 --define=use_ci_timeouts=true
 # CI should always run with `--config=ci`.
-build:ci --lintonbuild
+build:cibase --lintonbuild
 # Set `-test.v` in Go tests.
 # Ref: https://github.com/bazelbuild/rules_go/pull/2456
-test:ci --test_env=GO_TEST_WRAP_TESTV=1
+test:cibase --test_env=GO_TEST_WRAP_TESTV=1
 # Dump all output for failed tests to the build log.
-test:ci --test_output=errors
+test:cibase --test_output=errors
 # Put all tmp artifacts in /artifacts/tmp.
-build:ci --test_tmpdir=/artifacts/tmp
+test:ci --test_tmpdir=/artifacts/tmp
+build:ci --config=cibase
 
 build:cross --stamp
 
@@ -110,6 +111,23 @@ build:macos --host_action_env=PATH=/opt/homebrew/bin:/opt/local/bin:/usr/local/b
 # All `dev` builds will use this configuration; all `cross` builds will use a
 # more precise --workspace_status_command option.
 build:simplestamp --stamp --workspace_status_command=./build/bazelutil/stamp.sh
+
+build:engflow --define=EXECUTOR=remote
+build:engflow --disk_cache=
+build:engflow --experimental_inmemory_dotd_files
+build:engflow --experimental_inmemory_jdeps_files
+build:engflow --incompatible_strict_action_env=true
+build:engflow --remote_timeout=600
+build:engflow --nolegacy_important_outputs
+build:engflow --grpc_keepalive_time=30s
+build:engflow --experimental_remote_cache_compression=true
+build:engflow --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
+build:engflow --remote_cache=grpcs://tanzanite.cluster.engflow.com
+build:engflow --remote_executor=grpcs://tanzanite.cluster.engflow.com
+build:engflow --bes_backend=grpcs://tanzanite.cluster.engflow.com
+build:engflow --bes_results_url=https://tanzanite.cluster.engflow.com/invocation/
+build:engflow --extra_execution_platforms=//build/toolchains:cross_linux
+test:engflow --test_env=REMOTE_EXEC=1
 
 try-import %workspace%/.bazelrc.user
 

--- a/build/toolchains/BUILD.bazel
+++ b/build/toolchains/BUILD.bazel
@@ -31,6 +31,11 @@ platform(
         "@platforms//os:linux",
         "@platforms//cpu:x86_64",
     ],
+    exec_properties = {
+        "container-image": "docker://cockroachdb/bazel@sha256:2fdff6a4a2c66bf01d6ad4c6973eb4b38acdb812d07a431a0471f2b6449bb653",
+        "dockerReuse": "True",
+        "Pool": "default",
+    },
 )
 
 toolchain(
@@ -131,6 +136,11 @@ platform(
         "@platforms//os:linux",
         "@platforms//cpu:arm64",
     ],
+    exec_properties = {
+        "container-image": "docker://cockroachdb/bazel@sha256:6acc131994de3e9adcdf05ddd0956a047cb7a7e07a939a76fa9cad11af3a1a8a",
+        "dockerReuse": "True",
+        "Pool": "default",
+    },
 )
 
 platform(

--- a/pkg/acceptance/BUILD.bazel
+++ b/pkg/acceptance/BUILD.bazel
@@ -53,6 +53,7 @@ go_test(
         "//pkg/cli:interactive_tests",
     ],
     embed = [":acceptance"],
+    exec_properties = {"Pool": "large"},
     gotags = ["acceptance"],
     shard_count = 16,
     tags = ["integration"],

--- a/pkg/ccl/backupccl/BUILD.bazel
+++ b/pkg/ccl/backupccl/BUILD.bazel
@@ -205,6 +205,7 @@ go_test(
     }),
     data = glob(["testdata/**"]) + ["//c-deps:libgeos"],
     embed = [":backupccl"],
+    exec_properties = {"Pool": "large"},
     shard_count = 48,
     tags = ["ccl_test"],
     deps = [

--- a/pkg/ccl/benchccl/rttanalysisccl/BUILD.bazel
+++ b/pkg/ccl/benchccl/rttanalysisccl/BUILD.bazel
@@ -12,6 +12,7 @@ go_test(
         "//conditions:default": ["-test.timeout=3595s"],
     }),
     data = glob(["testdata/**"]),
+    exec_properties = {"Pool": "large"},
     shard_count = 16,
     tags = ["ccl_test"],
     deps = [

--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -206,6 +206,7 @@ go_test(
         "//conditions:default": ["-test.timeout=3595s"],
     }),
     embed = [":changefeedccl"],
+    exec_properties = {"Pool": "large"},
     shard_count = 16,
     tags = ["ccl_test"],
     deps = [

--- a/pkg/ccl/kvccl/kvtenantccl/upgradeinterlockccl/BUILD.bazel
+++ b/pkg/ccl/kvccl/kvtenantccl/upgradeinterlockccl/BUILD.bazel
@@ -12,6 +12,7 @@ go_test(
         "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
         "//conditions:default": ["-test.timeout=3595s"],
     }),
+    exec_properties = {"Pool": "large"},
     shard_count = 14,
     tags = ["ccl_test"],
     deps = [

--- a/pkg/ccl/logictestccl/tests/3node-tenant-multiregion/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/3node-tenant-multiregion/BUILD.bazel
@@ -14,6 +14,7 @@ go_test(
         "//pkg/sql/logictest:testdata",  # keep
         "//pkg/sql/opt/exec/execbuilder:testdata",  # keep
     ],
+    exec_properties = {"Pool": "large"},
     shard_count = 5,
     tags = [
         "ccl_test",

--- a/pkg/ccl/logictestccl/tests/3node-tenant/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/3node-tenant/BUILD.bazel
@@ -14,6 +14,7 @@ go_test(
         "//pkg/sql/logictest:testdata",  # keep
         "//pkg/sql/opt/exec/execbuilder:testdata",  # keep
     ],
+    exec_properties = {"Pool": "large"},
     shard_count = 48,
     tags = [
         "ccl_test",

--- a/pkg/ccl/logictestccl/tests/5node/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/5node/BUILD.bazel
@@ -12,6 +12,7 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
+    exec_properties = {"Pool": "large"},
     shard_count = 5,
     tags = [
         "ccl_test",

--- a/pkg/ccl/logictestccl/tests/fakedist-disk/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/fakedist-disk/BUILD.bazel
@@ -12,6 +12,7 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
+    exec_properties = {"Pool": "large"},
     shard_count = 5,
     tags = [
         "ccl_test",

--- a/pkg/ccl/logictestccl/tests/fakedist-vec-off/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/fakedist-vec-off/BUILD.bazel
@@ -12,6 +12,7 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
+    exec_properties = {"Pool": "large"},
     shard_count = 5,
     tags = [
         "ccl_test",

--- a/pkg/ccl/logictestccl/tests/fakedist/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/fakedist/BUILD.bazel
@@ -12,6 +12,7 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
+    exec_properties = {"Pool": "large"},
     shard_count = 6,
     tags = [
         "ccl_test",

--- a/pkg/ccl/logictestccl/tests/local-legacy-schema-changer/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/local-legacy-schema-changer/BUILD.bazel
@@ -12,6 +12,7 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
+    exec_properties = {"Pool": "large"},
     shard_count = 5,
     tags = [
         "ccl_test",

--- a/pkg/ccl/logictestccl/tests/local-mixed-22.2-23.1/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/local-mixed-22.2-23.1/BUILD.bazel
@@ -12,6 +12,7 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
+    exec_properties = {"Pool": "large"},
     shard_count = 6,
     tags = [
         "ccl_test",

--- a/pkg/ccl/logictestccl/tests/local-vec-off/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/local-vec-off/BUILD.bazel
@@ -12,6 +12,7 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
+    exec_properties = {"Pool": "large"},
     shard_count = 5,
     tags = [
         "ccl_test",

--- a/pkg/ccl/logictestccl/tests/local/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/local/BUILD.bazel
@@ -12,6 +12,7 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
+    exec_properties = {"Pool": "large"},
     shard_count = 19,
     tags = [
         "ccl_test",

--- a/pkg/ccl/logictestccl/tests/multiregion-15node-5region-3azs/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/multiregion-15node-5region-3azs/BUILD.bazel
@@ -12,6 +12,7 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
+    exec_properties = {"Pool": "large"},
     shard_count = 4,
     tags = [
         "ccl_test",

--- a/pkg/ccl/logictestccl/tests/multiregion-3node-3superlongregions/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/multiregion-3node-3superlongregions/BUILD.bazel
@@ -12,6 +12,7 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
+    exec_properties = {"Pool": "large"},
     shard_count = 1,
     tags = [
         "ccl_test",

--- a/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs-no-los/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs-no-los/BUILD.bazel
@@ -12,6 +12,7 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
+    exec_properties = {"Pool": "large"},
     shard_count = 19,
     tags = [
         "ccl_test",

--- a/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs-tenant/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs-tenant/BUILD.bazel
@@ -12,6 +12,7 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
+    exec_properties = {"Pool": "large"},
     shard_count = 15,
     tags = [
         "ccl_test",

--- a/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs-vec-off/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs-vec-off/BUILD.bazel
@@ -12,6 +12,7 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
+    exec_properties = {"Pool": "large"},
     shard_count = 8,
     tags = [
         "ccl_test",

--- a/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs/BUILD.bazel
@@ -12,6 +12,7 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
+    exec_properties = {"Pool": "large"},
     shard_count = 26,
     tags = [
         "ccl_test",

--- a/pkg/ccl/multiregionccl/BUILD.bazel
+++ b/pkg/ccl/multiregionccl/BUILD.bazel
@@ -44,6 +44,7 @@ go_test(
     }),
     data = glob(["testdata/**"]),
     embed = [":multiregionccl"],
+    exec_properties = {"Pool": "large"},
     shard_count = 16,
     tags = ["ccl_test"],
     deps = [

--- a/pkg/ccl/schemachangerccl/BUILD.bazel
+++ b/pkg/ccl/schemachangerccl/BUILD.bazel
@@ -31,6 +31,7 @@ go_test(
         "//pkg/sql/schemachanger:end_to_end_testdata",
     ],
     embed = [":schemachangerccl"],
+    exec_properties = {"Pool": "large"},
     shard_count = 48,
     tags = [
         "ccl_test",

--- a/pkg/ccl/serverccl/BUILD.bazel
+++ b/pkg/ccl/serverccl/BUILD.bazel
@@ -47,6 +47,7 @@ go_test(
     }),
     data = glob(["testdata/**"]),
     embed = [":serverccl"],
+    exec_properties = {"Pool": "large"},
     tags = ["ccl_test"],
     deps = [
         "//pkg/base",

--- a/pkg/ccl/sqlitelogictestccl/tests/3node-tenant/BUILD.bazel
+++ b/pkg/ccl/sqlitelogictestccl/tests/3node-tenant/BUILD.bazel
@@ -9,6 +9,7 @@ go_test(
         "//c-deps:libgeos",  # keep
         "@com_github_cockroachdb_sqllogictest//:testfiles",  # keep
     ],
+    exec_properties = {"Pool": "large"},
     shard_count = 48,
     tags = [
         "ccl_test",

--- a/pkg/ccl/sqlproxyccl/BUILD.bazel
+++ b/pkg/ccl/sqlproxyccl/BUILD.bazel
@@ -59,7 +59,7 @@ go_library(
 
 go_test(
     name = "sqlproxyccl_test",
-    size = "medium",
+    size = "large",
     srcs = [
         "authentication_test.go",
         "backend_dialer_test.go",
@@ -73,9 +73,10 @@ go_test(
         "proxy_handler_test.go",
         "server_test.go",
     ],
-    args = ["-test.timeout=295s"],
+    args = ["-test.timeout=895s"],
     data = glob(["testdata/**"]),
     embed = [":sqlproxyccl"],
+    shard_count = 8,
     tags = ["ccl_test"],
     deps = [
         "//pkg/base",

--- a/pkg/ccl/streamingccl/streamclient/BUILD.bazel
+++ b/pkg/ccl/streamingccl/streamclient/BUILD.bazel
@@ -50,7 +50,10 @@ go_test(
     ],
     args = ["-test.timeout=55s"],
     embed = [":streamclient"],
-    tags = ["ccl_test"],
+    tags = [
+        "ccl_test",
+        "no-remote-exec",
+    ],
     deps = [
         "//pkg/base",
         "//pkg/ccl",

--- a/pkg/ccl/streamingccl/streamingest/BUILD.bazel
+++ b/pkg/ccl/streamingccl/streamingest/BUILD.bazel
@@ -97,7 +97,10 @@ go_test(
     data = glob(["testdata/**"]),
     embed = [":streamingest"],
     shard_count = 16,
-    tags = ["ccl_test"],
+    tags = [
+        "ccl_test",
+        "no-remote-exec",
+    ],
     deps = [
         "//pkg/base",
         "//pkg/ccl",

--- a/pkg/cmd/generate-bazel-extra/main.go
+++ b/pkg/cmd/generate-bazel-extra/main.go
@@ -252,13 +252,13 @@ func excludeReallyEnormousTargets(targets []string) []string {
 		// Answer the following questions before adding a test target to this list:
 		//  1. Does this target run in Bazel Essential CI? If it does and you need
 		//     timeout to be > 1 hour then you need to talk to dev-inf. This is not
-		//	   expected.
+		//     expected.
 		//  2. Are you increasing the timeout for stress-testing purposes in CI? Make
-		// 	   your change in `pkg/cmd/teamcity-trigger` by updating `customTimeouts`.
-		//	3. You should only add a test target here if it's for stand-alone testing.
-		//	   For example: `/pkg/sql/sqlitelogictest` is only tested in a nightly in
-		//	   `build/teamcity/cockroach/nightlies/sqlite_logic_test_impl.sh`. If this is
-		//	   the case, you should tag your test as `integration`.
+		//     your change in `pkg/cmd/teamcity-trigger` by updating `customTimeouts`.
+		//  3. You should only add a test target here if it's for stand-alone testing.
+		//     For example: `/pkg/sql/sqlitelogictest` is only tested in a nightly in
+		//     `build/teamcity/cockroach/nightlies/sqlite_logic_test_impl.sh`. If this is
+		//     the case, you should tag your test as `integration`.
 		//  4. If you are not sure, please ask the dev-inf team for help.
 		for _, toExclude := range []string{
 			"//pkg/ccl/sqlitelogictestccl",
@@ -288,6 +288,7 @@ func generateTestsTimeouts() {
 	}
 	for size, defaultTimeout := range testSizeToDefaultTimeout {
 		if size == "enormous" {
+			runBuildozer(append([]string{`dict_set exec_properties Pool:large`}, targets[size]...))
 			// Exclude really enormous targets since they have a custom timeout that
 			// exceeds the default 1h.
 			targets[size] = excludeReallyEnormousTargets(targets[size])

--- a/pkg/cmd/generate-logictest/templates.go
+++ b/pkg/cmd/generate-logictest/templates.go
@@ -268,6 +268,7 @@ go_test(
         "//pkg/sql/logictest:testdata",  # keep{{ end }}{{ if .ExecBuildLogicTest }}
         "//pkg/sql/opt/exec/execbuilder:testdata",  # keep{{ end }}
     ],
+    exec_properties = {"Pool": "large"},
     shard_count = {{ if gt .TestCount 48 }}48{{ else }}{{ .TestCount }}{{end}},
     tags = [{{ if .Ccl }}
         "ccl_test",{{ end }}

--- a/pkg/compose/BUILD.bazel
+++ b/pkg/compose/BUILD.bazel
@@ -20,6 +20,7 @@ go_test(
         "//pkg/compose:compare/docker-compose.yml",
     ],
     embed = [":compose"],
+    exec_properties = {"Pool": "large"},
     gotags = ["compose"],
     tags = ["integration"],
     deps = [

--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -360,6 +360,7 @@ go_test(
     }),
     data = glob(["testdata/**"]),
     embed = [":kvserver"],
+    exec_properties = {"Pool": "large"},
     shard_count = 48,
     tags = ["cpu:2"],
     deps = [

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -471,6 +471,7 @@ go_test(
     }),
     data = glob(["testdata/**"]),
     embed = [":server"],
+    exec_properties = {"Pool": "large"},
     shard_count = 16,
     deps = [
         "//pkg/base",

--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -734,7 +734,9 @@ go_test(
         "//pkg/sql/vtable:pg_catalog.go",
     ],
     embed = [":sql"],
+    exec_properties = {"Pool": "large"},
     shard_count = 16,
+    tags = ["no-remote-exec"],
     deps = [
         "//pkg/base",
         "//pkg/build/bazel",

--- a/pkg/sql/gcjob_test/BUILD.bazel
+++ b/pkg/sql/gcjob_test/BUILD.bazel
@@ -8,6 +8,7 @@ go_test(
         "main_test.go",
     ],
     args = ["-test.timeout=295s"],
+    shard_count = 2,
     deps = [
         "//pkg/base",
         "//pkg/clusterversion",

--- a/pkg/sql/logictest/tests/5node-disk/BUILD.bazel
+++ b/pkg/sql/logictest/tests/5node-disk/BUILD.bazel
@@ -12,6 +12,7 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/sql/logictest:testdata",  # keep
     ],
+    exec_properties = {"Pool": "large"},
     shard_count = 14,
     tags = [
         "cpu:3",

--- a/pkg/sql/logictest/tests/5node/BUILD.bazel
+++ b/pkg/sql/logictest/tests/5node/BUILD.bazel
@@ -12,6 +12,7 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/sql/logictest:testdata",  # keep
     ],
+    exec_properties = {"Pool": "large"},
     shard_count = 20,
     tags = [
         "cpu:3",

--- a/pkg/sql/logictest/tests/cockroach-go-testserver-upgrade-to-master/BUILD.bazel
+++ b/pkg/sql/logictest/tests/cockroach-go-testserver-upgrade-to-master/BUILD.bazel
@@ -13,6 +13,7 @@ go_test(
         "//pkg/cmd/cockroach-short",  # keep
         "//pkg/sql/logictest:testdata",  # keep
     ],
+    exec_properties = {"Pool": "large"},
     shard_count = 9,
     tags = [
         "cpu:2",

--- a/pkg/sql/logictest/tests/fakedist-disk/BUILD.bazel
+++ b/pkg/sql/logictest/tests/fakedist-disk/BUILD.bazel
@@ -12,6 +12,7 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/sql/logictest:testdata",  # keep
     ],
+    exec_properties = {"Pool": "large"},
     shard_count = 48,
     tags = [
         "cpu:2",

--- a/pkg/sql/logictest/tests/fakedist-vec-off/BUILD.bazel
+++ b/pkg/sql/logictest/tests/fakedist-vec-off/BUILD.bazel
@@ -12,6 +12,7 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/sql/logictest:testdata",  # keep
     ],
+    exec_properties = {"Pool": "large"},
     shard_count = 48,
     tags = [
         "cpu:2",

--- a/pkg/sql/logictest/tests/fakedist/BUILD.bazel
+++ b/pkg/sql/logictest/tests/fakedist/BUILD.bazel
@@ -12,6 +12,7 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/sql/logictest:testdata",  # keep
     ],
+    exec_properties = {"Pool": "large"},
     shard_count = 48,
     tags = [
         "cpu:2",

--- a/pkg/sql/logictest/tests/local-legacy-schema-changer/BUILD.bazel
+++ b/pkg/sql/logictest/tests/local-legacy-schema-changer/BUILD.bazel
@@ -12,6 +12,7 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/sql/logictest:testdata",  # keep
     ],
+    exec_properties = {"Pool": "large"},
     shard_count = 48,
     tags = [
         "cpu:1",

--- a/pkg/sql/logictest/tests/local-mixed-22.2-23.1/BUILD.bazel
+++ b/pkg/sql/logictest/tests/local-mixed-22.2-23.1/BUILD.bazel
@@ -12,6 +12,7 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/sql/logictest:testdata",  # keep
     ],
+    exec_properties = {"Pool": "large"},
     shard_count = 48,
     tags = [
         "cpu:1",

--- a/pkg/sql/logictest/tests/local-vec-off/BUILD.bazel
+++ b/pkg/sql/logictest/tests/local-vec-off/BUILD.bazel
@@ -12,6 +12,7 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/sql/logictest:testdata",  # keep
     ],
+    exec_properties = {"Pool": "large"},
     shard_count = 48,
     tags = [
         "cpu:1",

--- a/pkg/sql/logictest/tests/local/BUILD.bazel
+++ b/pkg/sql/logictest/tests/local/BUILD.bazel
@@ -12,6 +12,7 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/sql/logictest:testdata",  # keep
     ],
+    exec_properties = {"Pool": "large"},
     shard_count = 48,
     tags = [
         "cpu:1",

--- a/pkg/sql/logictest/tests/multiregion-9node-3region-3azs/BUILD.bazel
+++ b/pkg/sql/logictest/tests/multiregion-9node-3region-3azs/BUILD.bazel
@@ -12,6 +12,7 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/sql/logictest:testdata",  # keep
     ],
+    exec_properties = {"Pool": "large"},
     shard_count = 1,
     tags = [
         "cpu:4",

--- a/pkg/sql/logictest/tests/multiregion-invalid-locality/BUILD.bazel
+++ b/pkg/sql/logictest/tests/multiregion-invalid-locality/BUILD.bazel
@@ -12,6 +12,7 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/sql/logictest:testdata",  # keep
     ],
+    exec_properties = {"Pool": "large"},
     shard_count = 1,
     tags = [
         "cpu:2",

--- a/pkg/sql/opt/exec/execbuilder/tests/5node/BUILD.bazel
+++ b/pkg/sql/opt/exec/execbuilder/tests/5node/BUILD.bazel
@@ -12,6 +12,7 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/sql/opt/exec/execbuilder:testdata",  # keep
     ],
+    exec_properties = {"Pool": "large"},
     shard_count = 29,
     tags = [
         "cpu:3",

--- a/pkg/sql/opt/exec/execbuilder/tests/fakedist-disk/BUILD.bazel
+++ b/pkg/sql/opt/exec/execbuilder/tests/fakedist-disk/BUILD.bazel
@@ -12,6 +12,7 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/sql/opt/exec/execbuilder:testdata",  # keep
     ],
+    exec_properties = {"Pool": "large"},
     shard_count = 1,
     tags = [
         "cpu:2",

--- a/pkg/sql/opt/exec/execbuilder/tests/fakedist-vec-off/BUILD.bazel
+++ b/pkg/sql/opt/exec/execbuilder/tests/fakedist-vec-off/BUILD.bazel
@@ -12,6 +12,7 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/sql/opt/exec/execbuilder:testdata",  # keep
     ],
+    exec_properties = {"Pool": "large"},
     shard_count = 1,
     tags = [
         "cpu:2",

--- a/pkg/sql/opt/exec/execbuilder/tests/fakedist/BUILD.bazel
+++ b/pkg/sql/opt/exec/execbuilder/tests/fakedist/BUILD.bazel
@@ -12,6 +12,7 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/sql/opt/exec/execbuilder:testdata",  # keep
     ],
+    exec_properties = {"Pool": "large"},
     shard_count = 1,
     tags = [
         "cpu:2",

--- a/pkg/sql/opt/exec/execbuilder/tests/local-legacy-schema-changer/BUILD.bazel
+++ b/pkg/sql/opt/exec/execbuilder/tests/local-legacy-schema-changer/BUILD.bazel
@@ -12,6 +12,7 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/sql/opt/exec/execbuilder:testdata",  # keep
     ],
+    exec_properties = {"Pool": "large"},
     shard_count = 1,
     tags = [
         "cpu:1",

--- a/pkg/sql/opt/exec/execbuilder/tests/local-mixed-22.2-23.1/BUILD.bazel
+++ b/pkg/sql/opt/exec/execbuilder/tests/local-mixed-22.2-23.1/BUILD.bazel
@@ -12,6 +12,7 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/sql/opt/exec/execbuilder:testdata",  # keep
     ],
+    exec_properties = {"Pool": "large"},
     shard_count = 1,
     tags = [
         "cpu:1",

--- a/pkg/sql/opt/exec/execbuilder/tests/local-vec-off/BUILD.bazel
+++ b/pkg/sql/opt/exec/execbuilder/tests/local-vec-off/BUILD.bazel
@@ -12,6 +12,7 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/sql/opt/exec/execbuilder:testdata",  # keep
     ],
+    exec_properties = {"Pool": "large"},
     shard_count = 1,
     tags = [
         "cpu:1",

--- a/pkg/sql/opt/exec/execbuilder/tests/local/BUILD.bazel
+++ b/pkg/sql/opt/exec/execbuilder/tests/local/BUILD.bazel
@@ -12,6 +12,7 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/sql/opt/exec/execbuilder:testdata",  # keep
     ],
+    exec_properties = {"Pool": "large"},
     shard_count = 48,
     tags = [
         "cpu:1",

--- a/pkg/sql/schemachanger/BUILD.bazel
+++ b/pkg/sql/schemachanger/BUILD.bazel
@@ -33,6 +33,7 @@ go_test(
         "//conditions:default": ["-test.timeout=3595s"],
     }),
     data = glob(["testdata/**"]),
+    exec_properties = {"Pool": "large"},
     shard_count = 16,
     deps = [
         "//pkg/base",

--- a/pkg/sql/sqlitelogictest/tests/fakedist-disk/BUILD.bazel
+++ b/pkg/sql/sqlitelogictest/tests/fakedist-disk/BUILD.bazel
@@ -9,6 +9,7 @@ go_test(
         "//c-deps:libgeos",  # keep
         "@com_github_cockroachdb_sqllogictest//:testfiles",  # keep
     ],
+    exec_properties = {"Pool": "large"},
     shard_count = 48,
     tags = [
         "cpu:2",

--- a/pkg/sql/sqlitelogictest/tests/fakedist-vec-off/BUILD.bazel
+++ b/pkg/sql/sqlitelogictest/tests/fakedist-vec-off/BUILD.bazel
@@ -9,6 +9,7 @@ go_test(
         "//c-deps:libgeos",  # keep
         "@com_github_cockroachdb_sqllogictest//:testfiles",  # keep
     ],
+    exec_properties = {"Pool": "large"},
     shard_count = 48,
     tags = [
         "cpu:2",

--- a/pkg/sql/sqlitelogictest/tests/fakedist/BUILD.bazel
+++ b/pkg/sql/sqlitelogictest/tests/fakedist/BUILD.bazel
@@ -9,6 +9,7 @@ go_test(
         "//c-deps:libgeos",  # keep
         "@com_github_cockroachdb_sqllogictest//:testfiles",  # keep
     ],
+    exec_properties = {"Pool": "large"},
     shard_count = 48,
     tags = [
         "cpu:2",

--- a/pkg/sql/sqlitelogictest/tests/local-legacy-schema-changer/BUILD.bazel
+++ b/pkg/sql/sqlitelogictest/tests/local-legacy-schema-changer/BUILD.bazel
@@ -9,6 +9,7 @@ go_test(
         "//c-deps:libgeos",  # keep
         "@com_github_cockroachdb_sqllogictest//:testfiles",  # keep
     ],
+    exec_properties = {"Pool": "large"},
     shard_count = 48,
     tags = [
         "cpu:1",

--- a/pkg/sql/sqlitelogictest/tests/local-mixed-22.2-23.1/BUILD.bazel
+++ b/pkg/sql/sqlitelogictest/tests/local-mixed-22.2-23.1/BUILD.bazel
@@ -9,6 +9,7 @@ go_test(
         "//c-deps:libgeos",  # keep
         "@com_github_cockroachdb_sqllogictest//:testfiles",  # keep
     ],
+    exec_properties = {"Pool": "large"},
     shard_count = 48,
     tags = [
         "cpu:1",

--- a/pkg/sql/sqlitelogictest/tests/local-vec-off/BUILD.bazel
+++ b/pkg/sql/sqlitelogictest/tests/local-vec-off/BUILD.bazel
@@ -9,6 +9,7 @@ go_test(
         "//c-deps:libgeos",  # keep
         "@com_github_cockroachdb_sqllogictest//:testfiles",  # keep
     ],
+    exec_properties = {"Pool": "large"},
     shard_count = 48,
     tags = [
         "cpu:1",

--- a/pkg/sql/sqlitelogictest/tests/local/BUILD.bazel
+++ b/pkg/sql/sqlitelogictest/tests/local/BUILD.bazel
@@ -9,6 +9,7 @@ go_test(
         "//c-deps:libgeos",  # keep
         "@com_github_cockroachdb_sqllogictest//:testfiles",  # keep
     ],
+    exec_properties = {"Pool": "large"},
     shard_count = 48,
     tags = [
         "cpu:1",

--- a/pkg/sql/tests/BUILD.bazel
+++ b/pkg/sql/tests/BUILD.bazel
@@ -28,7 +28,7 @@ go_library(
 
 go_test(
     name = "tests_test",
-    size = "large",
+    size = "enormous",
     srcs = [
         "allow_role_memberships_to_change_during_transaction_test.go",
         "autocommit_extended_protocol_test.go",
@@ -57,9 +57,13 @@ go_test(
         "truncate_test.go",
         "virtual_table_test.go",
     ],
-    args = ["-test.timeout=895s"],
+    args = select({
+        "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
+        "//conditions:default": ["-test.timeout=3595s"],
+    }),
     data = glob(["testdata/**"]),
     embed = [":tests"],
+    exec_properties = {"Pool": "large"},
     shard_count = 16,
     deps = [
         "//pkg/base",

--- a/pkg/storage/BUILD.bazel
+++ b/pkg/storage/BUILD.bazel
@@ -142,6 +142,8 @@ go_test(
     args = ["-test.timeout=295s"],
     data = glob(["testdata/**"]),
     embed = [":storage"],
+    shard_count = 2,
+    tags = ["no-remote-exec"],
     deps = [
         "//pkg/base",
         "//pkg/clusterversion",

--- a/pkg/storage/metamorphic/BUILD.bazel
+++ b/pkg/storage/metamorphic/BUILD.bazel
@@ -47,6 +47,7 @@ go_test(
     }),
     data = glob(["testdata/**"]),
     embed = [":metamorphic"],
+    exec_properties = {"Pool": "large"},
     shard_count = 8,
     deps = [
         "//pkg/settings/cluster",


### PR DESCRIPTION
Add the `--config engflow` which sets some appropriate configurations
for building against our engflow cluster, and set some other metadata.
Also bump some test sizes and shard counts to get everything working.

Epic: [CRDB-8308](https://cockroachlabs.atlassian.net/browse/CRDB-8308)
Release note: None