### PR TITLE
ui: fix occurrence of x.toNumber is not a function

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionDetails.tsx
@@ -57,6 +57,7 @@ import { CircleFilled } from "../icon";
 import { createTimeScaleFromDateRange, TimeScale } from "src/timeScaleDropdown";
 import moment from "moment-timezone";
 import { Timestamp } from "../timestamp";
+import { FixLong } from "../util";
 
 const cx = classNames.bind(styles);
 const statementsPageCx = classNames.bind(statementsPageStyles);
@@ -93,7 +94,9 @@ export const MemoryUsageItem: React.FC<{
   <SummaryCardItem
     label={"Memory Usage"}
     value={
-      Bytes(alloc_bytes?.toNumber()) + "/" + Bytes(max_alloc_bytes?.toNumber())
+      Bytes(FixLong(alloc_bytes ?? 0).toNumber()) +
+      "/" +
+      Bytes(FixLong(max_alloc_bytes ?? 0).toNumber())
     }
   />
 );

--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsTable.tsx
@@ -44,7 +44,7 @@ import {
 } from "src/dropdown/dropdown";
 import { Button } from "src/button/button";
 import { Tooltip } from "@cockroachlabs/ui-components";
-import { computeOrUseStmtSummary } from "../util";
+import { computeOrUseStmtSummary, FixLong } from "../util";
 import {
   statisticsTableTitles,
   StatisticType,
@@ -235,10 +235,16 @@ export function makeSessionsColumns(
       title: statisticsTableTitles.memUsage(statType),
       className: cx("cl-table__col-session"),
       cell: session =>
-        BytesWithPrecision(session.session.alloc_bytes?.toNumber(), 0) +
+        BytesWithPrecision(
+          FixLong(session.session.alloc_bytes ?? 0).toNumber(),
+          0,
+        ) +
         "/" +
-        BytesWithPrecision(session.session.max_alloc_bytes?.toNumber(), 0),
-      sort: session => session.session.alloc_bytes?.toNumber(),
+        BytesWithPrecision(
+          FixLong(session.session.max_alloc_bytes ?? 0).toNumber(),
+          0,
+        ),
+      sort: session => FixLong(session.session.alloc_bytes ?? 0).toNumber(),
     },
     {
       name: "clientAddress",

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/utils.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/utils.ts
@@ -94,7 +94,7 @@ export const aggregateStatements = (
     if (!(key in statsKey)) {
       statsKey[key] = {
         aggregatedFingerprintID: s.statement_fingerprint_id?.toString(),
-        aggregatedFingerprintHexID: s.statement_fingerprint_id.toString(16),
+        aggregatedFingerprintHexID: s.statement_fingerprint_id?.toString(16),
         label: s.statement,
         summary: s.statement_summary,
         aggregatedTs: s.aggregated_ts,


### PR DESCRIPTION
backport 1/1 commits from https://github.com/cockroachdb/cockroach/pull/108595

----

protobuf.js sets the default value of Long types to 0, instead of Long.fromInt(0).

This is a workaround until we have a more comprehensive solution.

See https://github.com/cockroachdb/cockroach/blob/165960a9e0588e7046da44a4a4a45b78b9d4541f/pkg/ui/workspaces/cluster-ui/src/util/fixLong.ts#L13

Resolves #107905
Release note (bug fix): Fixes errors on the Sessions page UI when a session's memory usage is zero bytes.