### PR TITLE
ui: fix filter font size

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/queryFilter/filter.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/queryFilter/filter.module.scss
@@ -4,6 +4,7 @@ $dropdown-hover-color: darken($colors--background, 2.5%);
 
 .dropdown-btn {
   font-family: $font-family--semi-bold;
+  font-size: $font-size--medium;
   padding: 8px 0 8px 17px;
   vertical-align: middle;
   border: 1px solid $colors--neutral-4;


### PR DESCRIPTION
On CC Console, the font size of the filter was
using a wrong value inherited from another class.
This commit makes the value explicit to be consistent.

Before
<img width="623" alt="Screenshot 2023-08-14 at 3 08 24 PM" src="https://github.com/cockroachdb/cockroach/assets/1017486/59bc6306-642e-4fbb-947f-500dd335ec10">


After
<img width="1187" alt="Screenshot 2023-08-14 at 3 07 39 PM" src="https://github.com/cockroachdb/cockroach/assets/1017486/27034065-97a5-40a5-863d-231debc6faad">


Epic: none
Release note: None