### PR TITLE
sql: don't bump external read timestamp for RC internal executor txns

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
@@ -2289,7 +2289,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 				if err := txn.Put(ctx, "a", "put"); err != nil {
 					return err
 				}
-				if err := txn.Step(ctx); err != nil {
+				if err := txn.Step(ctx, true /* allowReadTimestampStep */); err != nil {
 					return err
 				}
 				_, err := txn.Get(ctx, "a2")
@@ -2321,7 +2321,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 				if err := txn.Put(ctx, "a", "put"); err != nil {
 					return err
 				}
-				if err := txn.Step(ctx); err != nil {
+				if err := txn.Step(ctx, true /* allowReadTimestampStep */); err != nil {
 					return err
 				}
 				_, err := txn.Scan(ctx, "a2", "a3", 0)
@@ -2353,7 +2353,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 				if err := txn.Put(ctx, "a", "put"); err != nil {
 					return err
 				}
-				if err := txn.Step(ctx); err != nil {
+				if err := txn.Step(ctx, true /* allowReadTimestampStep */); err != nil {
 					return err
 				}
 				b := txn.NewBatch()
@@ -2386,7 +2386,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 				if err := txn.Put(ctx, "a", "put"); err != nil {
 					return err
 				}
-				if err := txn.Step(ctx); err != nil {
+				if err := txn.Step(ctx, true /* allowReadTimestampStep */); err != nil {
 					return err
 				}
 				b := txn.NewBatch()
@@ -2504,7 +2504,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 				if err := txn.Put(ctx, "a", "put"); err != nil {
 					return err
 				}
-				if err := txn.Step(ctx); err != nil {
+				if err := txn.Step(ctx, true /* allowReadTimestampStep */); err != nil {
 					return err
 				}
 				// Make the final batch large enough such that if we accounted
@@ -2556,7 +2556,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 				if _, err := txn.DelRange(ctx, "a", "b", false /* returnKeys */); err != nil {
 					return err
 				}
-				if err := txn.Step(ctx); err != nil {
+				if err := txn.Step(ctx, true /* allowReadTimestampStep */); err != nil {
 					return err
 				}
 				// Make the final batch large enough such that if we accounted
@@ -2669,7 +2669,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 				if err := txn.Put(ctx, "a", "put"); err != nil {
 					return err
 				}
-				if err := txn.Step(ctx); err != nil {
+				if err := txn.Step(ctx, true /* allowReadTimestampStep */); err != nil {
 					return err
 				}
 				// Get from "b" to establish a read span. It is important that we
@@ -2678,7 +2678,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 				if _, err := txn.Get(ctx, "b"); err != nil {
 					return err
 				}
-				if err := txn.Step(ctx); err != nil {
+				if err := txn.Step(ctx, true /* allowReadTimestampStep */); err != nil {
 					return err
 				}
 				// Now, Put to "b", which would have thrown a write-too-old error had
@@ -2722,7 +2722,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 				if err := txn.Put(ctx, "a", "txn-value1"); err != nil {
 					return err
 				}
-				if err := txn.Step(ctx); err != nil {
+				if err := txn.Step(ctx, true /* allowReadTimestampStep */); err != nil {
 					return err
 				}
 				// Write again to make sure the timestamp of the second intent
@@ -3892,7 +3892,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 				} else if !bytes.Equal(b, []byte("newval")) {
 					return fmt.Errorf("expected \"newval\", got: %v", b)
 				}
-				if err := txn.Step(ctx); err != nil {
+				if err := txn.Step(ctx, true /* allowReadTimestampStep */); err != nil {
 					return err
 				}
 				return txn.Commit(ctx)
@@ -3989,7 +3989,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 				if err := txn.Put(ctx, "a", "put"); err != nil {
 					return err
 				}
-				if err := txn.Step(ctx); err != nil {
+				if err := txn.Step(ctx, true /* allowReadTimestampStep */); err != nil {
 					return err
 				}
 				b := txn.NewBatch()
@@ -4212,7 +4212,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 			if tc.priorReads {
 				_, err := txn.Get(ctx, "prior read")
 				require.NoError(t, err, "prior read")
-				require.NoError(t, txn.Step(ctx))
+				require.NoError(t, txn.Step(ctx, true /* allowReadTimestampStep */))
 			}
 
 			if tc.afterTxnStart != nil {
@@ -4226,7 +4226,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 
 			// If the transaction is still open, step one more time before the commit.
 			if txn.IsOpen() {
-				require.NoError(t, txn.Step(ctx))
+				require.NoError(t, txn.Step(ctx, true /* allowReadTimestampStep */))
 			}
 
 			return nil

--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
@@ -1414,7 +1414,7 @@ func (tc *TxnCoordSender) TestingCloneTxn() *roachpb.Transaction {
 }
 
 // Step is part of the TxnSender interface.
-func (tc *TxnCoordSender) Step(ctx context.Context) error {
+func (tc *TxnCoordSender) Step(ctx context.Context, allowReadTimestampStep bool) error {
 	// TODO(nvanbenschoten): it should be possible to make this assertion, but
 	// the API is currently misused by the connExecutor. See #86162.
 	// if tc.typ != kv.RootTxn {
@@ -1422,7 +1422,7 @@ func (tc *TxnCoordSender) Step(ctx context.Context) error {
 	// }
 	tc.mu.Lock()
 	defer tc.mu.Unlock()
-	if tc.shouldStepReadTimestampLocked() {
+	if allowReadTimestampStep && tc.shouldStepReadTimestampLocked() {
 		tc.manualStepReadTimestampLocked()
 	}
 	return tc.interceptorAlloc.txnSeqNumAllocator.manualStepReadSeqLocked(ctx)

--- a/pkg/kv/kvclient/kvcoord/txn_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_test.go
@@ -422,7 +422,7 @@ func TestTxnReadCommittedPerStatementReadSnapshot(t *testing.T) {
 			incrementKey()
 
 			if step {
-				require.NoError(t, txn1.Step(ctx))
+				require.NoError(t, txn1.Step(ctx, true /* allowReadTimestampStep */))
 			}
 
 			// Read the key twice in the same batch, to demonstrate that regardless of

--- a/pkg/kv/mock_transactional_sender.go
+++ b/pkg/kv/mock_transactional_sender.go
@@ -226,7 +226,7 @@ func (m *MockTransactionalSender) Active() bool {
 func (m *MockTransactionalSender) DisablePipelining() error { return nil }
 
 // Step is part of the TxnSender interface.
-func (m *MockTransactionalSender) Step(_ context.Context) error {
+func (m *MockTransactionalSender) Step(context.Context, bool) error {
 	// At least one test (e.g sql/TestPortalsDestroyedOnTxnFinish) requires
 	// the ability to run simple statements that do not access storage,
 	// and that requires a non-panicky Step().

--- a/pkg/kv/sender.go
+++ b/pkg/kv/sender.go
@@ -304,17 +304,17 @@ type TxnSender interface {
 	// the time the snapshot was established and ignore writes performed by the
 	// transaction since.
 	//
-	// Additionally, for Read Committed transactions, Step also advances the
-	// transaction's external read snapshot (i.e. ReadTimestamp) to a timestamp
-	// captured from the local HLC clock. This ensures that subsequent read-only
-	// operations observe the writes of other transactions that were committed
-	// before the time the new snapshot was established. For more detail on the
-	// interaction between transaction isolation levels and Step, see
-	// (isolation.Level).PerStatementReadSnapshot.
+	// Additionally, for Read Committed transactions, if allowReadTimestampStep is
+	// set, Step also advances the transaction's external read snapshot (i.e.
+	// ReadTimestamp) to a timestamp captured from the local HLC clock. This
+	// ensures that subsequent read-only operations observe the writes of other
+	// transactions that were committed before the time the new snapshot was
+	// established. For more detail on the interaction between transaction
+	// isolation levels and Step, see (isolation.Level).PerStatementReadSnapshot.
 	//
 	// Step() can only be called after stepping mode has been enabled
 	// using ConfigureStepping(SteppingEnabled).
-	Step(context.Context) error
+	Step(ctx context.Context, allowReadTimestampStep bool) error
 
 	// GetReadSeqNum gets the read sequence point for the current transaction.
 	GetReadSeqNum() enginepb.TxnSeq

--- a/pkg/kv/txn.go
+++ b/pkg/kv/txn.go
@@ -1612,10 +1612,10 @@ func (txn *Txn) Active() bool {
 //
 // In step-wise execution, reads operate at a snapshot established at
 // the last step, instead of the latest write if not yet enabled.
-func (txn *Txn) Step(ctx context.Context) error {
+func (txn *Txn) Step(ctx context.Context, allowReadTimestampStep bool) error {
 	txn.mu.Lock()
 	defer txn.mu.Unlock()
-	return txn.mu.sender.Step(ctx)
+	return txn.mu.sender.Step(ctx, allowReadTimestampStep)
 }
 
 // GetReadSeqNum gets the read sequence number for this transaction.

--- a/pkg/kv/txn_external_test.go
+++ b/pkg/kv/txn_external_test.go
@@ -747,7 +747,7 @@ func testPrepareForRetry(t *testing.T, isoLevel isolation.Level) {
 	require.NoError(t, txn.SetIsoLevel(isoLevel))
 	// Write to "a" in the first epoch.
 	require.NoError(t, txn.Put(ctx, keyA, 1))
-	require.NoError(t, txn.Step(ctx))
+	require.NoError(t, txn.Step(ctx, true /* allowReadTimestampStep */))
 	// Read from "b" to establish a refresh span.
 	res, err := txn.Get(ctx, keyB)
 	require.NoError(t, err)
@@ -824,7 +824,7 @@ func TestPrepareForPartialRetry(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, txn.Put(ctx, keyA, 1))
 	require.NoError(t, txn.ReleaseSavepoint(ctx, stmt1))
-	require.NoError(t, txn.Step(ctx))
+	require.NoError(t, txn.Step(ctx, true /* allowReadTimestampStep */))
 	// Perform a series of reads and writes in the second "statement".
 	stmt2, err := txn.CreateSavepoint(ctx)
 	require.NoError(t, err)

--- a/pkg/sql/catalog/descs/txn_external_test.go
+++ b/pkg/sql/catalog/descs/txn_external_test.go
@@ -69,7 +69,7 @@ func TestTxnWithStepping(t *testing.T) {
 				return errors.AssertionFailedf("expected no value, got %v", got)
 			}
 		}
-		if err := txn.KV().Step(ctx); err != nil {
+		if err := txn.KV().Step(ctx, true /* allowReadTimestampStep */); err != nil {
 			return err
 		}
 		{

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -2064,10 +2064,11 @@ func (dsp *DistSQLPlanner) PlanAndRunCascadesAndChecks(
 
 		log.VEventf(ctx, 2, "executing cascade for constraint %s", plan.cascades[i].FKName)
 
-		// We place a sequence point before every cascade, so
-		// that each subsequent cascade can observe the writes
-		// by the previous step.
-		if err := planner.Txn().Step(ctx); err != nil {
+		// We place a sequence point before every cascade, so that each subsequent
+		// cascade can observe the writes by the previous step. However, The
+		// external read timestamp is not allowed to advance, since the checks are
+		// run as part of the same statement as the corresponding mutations.
+		if err := planner.Txn().Step(ctx, false /* allowReadTimestampStep */); err != nil {
 			recv.SetError(err)
 			return false
 		}
@@ -2136,8 +2137,10 @@ func (dsp *DistSQLPlanner) PlanAndRunCascadesAndChecks(
 	}
 
 	// We place a sequence point before the checks, so that they observe the
-	// writes of the main query and/or any cascades.
-	if err := planner.Txn().Step(ctx); err != nil {
+	// writes of the main query and/or any cascades. However, The external read
+	// timestamp is not allowed to advance, since the checks are run as part of
+	// the same statement as the corresponding mutations.
+	if err := planner.Txn().Step(ctx, false /* allowReadTimestampStep */); err != nil {
 		recv.SetError(err)
 		return false
 	}

--- a/pkg/sql/routine.go
+++ b/pkg/sql/routine.go
@@ -262,10 +262,12 @@ func (g *routineGenerator) startInternal(ctx context.Context, txn *kv.Txn) (err 
 			w = &droppingResultWriter{}
 		}
 
-		// Place a sequence point before each statement in the routine for
-		// volatile functions.
+		// Place a sequence point before each statement in the routine for volatile
+		// functions. Unlike Postgres, we don't allow the txn's external read
+		// snapshot to advance, because we do not support restoring the txn's prior
+		// external read snapshot after returning from the volatile function.
 		if g.expr.EnableStepping {
-			if err := txn.Step(ctx); err != nil {
+			if err := txn.Step(ctx, false /* allowReadTimestampStep */); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
The internal executor can be used to implement some SQL expressions that
are sent by the user. If it is, then the internal executor should not
ever advance the external read timestamp.

Normally, READ COMMITTED txns would bump the read snapshot whenever the
txn is stepped. Now, when stepping, we check if we are in an internal
executor running on behalf of an outer txn. If so, we avoid changing the
read timestamp.

A test assertion was added that reveals the pre-existing problem.

No release note is added since this is new in v23.2.

fixes https://github.com/cockroachdb/cockroach/issues/86162
fixes https://github.com/cockroachdb/cockroach/issues/104847
Release note: None