### PR TITLE
sql/gcjob_test: mitigate testserver build up

### DIFF
--- a/pkg/sql/gcjob_test/gc_job_test.go
+++ b/pkg/sql/gcjob_test/gc_job_test.go
@@ -53,218 +53,228 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type DropItem int
+
+const (
+	INDEX = iota
+	TABLE
+	DATABASE
+)
+
+type TTLTime int
+
+const (
+	PAST   = iota // An item was supposed to be GC already.
+	SOON          // An item will be GC'd soon.
+	FUTURE        // An item should not be GC'd during this test.
+)
+
 // TODO(pbardea): Add more testing around the timer calculations.
 func TestSchemaChangeGCJob(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-
-	type DropItem int
-	const (
-		INDEX = iota
-		TABLE
-		DATABASE
-	)
-
-	type TTLTime int
-	const (
-		PAST   = iota // An item was supposed to be GC already.
-		SOON          // An item will be GC'd soon.
-		FUTURE        // An item should not be GC'd during this test.
-	)
+	defer log.Scope(t).Close(t)
 
 	for _, dropItem := range []DropItem{INDEX, TABLE, DATABASE} {
 		for _, ttlTime := range []TTLTime{PAST, SOON, FUTURE} {
-			blockGC := make(chan struct{}, 1)
-			params := base.TestServerArgs{}
-			params.ScanMaxIdleTime = time.Millisecond
-			params.Knobs.JobsTestingKnobs = jobs.NewTestingKnobsWithShortIntervals()
-			params.Knobs.GCJob = &sql.GCJobTestingKnobs{
-				RunBeforePerformGC: func(_ jobspb.JobID) error {
-					<-blockGC
-					return nil
-				},
-			}
-			s, db, kvDB := serverutils.StartServer(t, params)
-			ctx := context.Background()
-			defer s.Stopper().Stop(ctx)
-			sqlDB := sqlutils.MakeSQLRunner(db)
-
-			sqlDB.Exec(t, `SET CLUSTER SETTING sql.gc_job.wait_for_gc.interval = '1s';`)
-			// Refresh protected timestamp cache immediately to make MVCC GC queue to
-			// process GC immediately.
-			sqlDB.Exec(t, `SET CLUSTER SETTING kv.protectedts.poll_interval = '1s';`)
-
-			jobRegistry := s.JobRegistry().(*jobs.Registry)
-
-			sqlDB.Exec(t, "CREATE DATABASE my_db")
-			sqlDB.Exec(t, "USE my_db")
-			sqlDB.Exec(t, "CREATE TABLE my_table (a int primary key, b int, index (b))")
-			sqlDB.Exec(t, "CREATE TABLE my_other_table (a int primary key, b int, index (b))")
-			if ttlTime == SOON {
-				sqlDB.Exec(t, "ALTER TABLE my_table CONFIGURE ZONE USING gc.ttlseconds = 1")
-				sqlDB.Exec(t, "ALTER TABLE my_other_table CONFIGURE ZONE USING gc.ttlseconds = 1")
-			}
-
-			myDBID := descpb.ID(bootstrap.TestingUserDescID(4))
-			myTableID := descpb.ID(bootstrap.TestingUserDescID(6))
-			myOtherTableID := descpb.ID(bootstrap.TestingUserDescID(7))
-
-			var myTableDesc *tabledesc.Mutable
-			var myOtherTableDesc *tabledesc.Mutable
-			if err := sql.TestingDescsTxn(ctx, s, func(ctx context.Context, txn isql.Txn, col *descs.Collection) error {
-				myImm, err := col.ByID(txn.KV()).Get().Table(ctx, myTableID)
-				if err != nil {
-					return err
-				}
-				myTableDesc = tabledesc.NewBuilder(myImm.TableDesc()).BuildExistingMutableTable()
-				myOtherImm, err := col.ByID(txn.KV()).Get().Table(ctx, myOtherTableID)
-				if err != nil {
-					return err
-				}
-				myOtherTableDesc = tabledesc.NewBuilder(myOtherImm.TableDesc()).BuildExistingMutableTable()
-				return nil
-			}); err != nil {
-				t.Fatal(err)
-			}
-
-			// Start the job that drops an index.
-			dropTime := timeutil.Now().UnixNano()
-			if ttlTime == PAST {
-				dropTime = 1
-			}
-			var details jobspb.SchemaChangeGCDetails
-			var expectedRunningStatus string
-			switch dropItem {
-			case INDEX:
-				details = jobspb.SchemaChangeGCDetails{
-					Indexes: []jobspb.SchemaChangeGCDetails_DroppedIndex{
-						{
-							IndexID:  descpb.IndexID(2),
-							DropTime: dropTime,
-						},
-					},
-					ParentID: myTableID,
-				}
-				myTableDesc.SetPublicNonPrimaryIndexes([]descpb.IndexDescriptor{})
-				expectedRunningStatus = "deleting data"
-			case TABLE:
-				details = jobspb.SchemaChangeGCDetails{
-					Tables: []jobspb.SchemaChangeGCDetails_DroppedID{
-						{
-							ID:       myTableID,
-							DropTime: dropTime,
-						},
-					},
-				}
-				myTableDesc.State = descpb.DescriptorState_DROP
-				myTableDesc.DropTime = dropTime
-				expectedRunningStatus = "deleting data"
-			case DATABASE:
-				details = jobspb.SchemaChangeGCDetails{
-					Tables: []jobspb.SchemaChangeGCDetails_DroppedID{
-						{
-							ID:       myTableID,
-							DropTime: dropTime,
-						},
-						{
-							ID:       myOtherTableID,
-							DropTime: dropTime,
-						},
-					},
-					ParentID: myDBID,
-				}
-				myTableDesc.State = descpb.DescriptorState_DROP
-				myTableDesc.DropTime = dropTime
-				myOtherTableDesc.State = descpb.DescriptorState_DROP
-				myOtherTableDesc.DropTime = dropTime
-				expectedRunningStatus = "deleting data"
-			}
-
-			if err := kvDB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
-				b := txn.NewBatch()
-				descKey := catalogkeys.MakeDescMetadataKey(keys.SystemSQLCodec, myTableID)
-				descDesc := myTableDesc.DescriptorProto()
-				b.Put(descKey, descDesc)
-				descKey2 := catalogkeys.MakeDescMetadataKey(keys.SystemSQLCodec, myOtherTableID)
-				descDesc2 := myOtherTableDesc.DescriptorProto()
-				b.Put(descKey2, descDesc2)
-				return txn.Run(ctx, b)
-			}); err != nil {
-				t.Fatal(err)
-			}
-
-			jobRecord := jobs.Record{
-				Description:   "GC test",
-				Username:      username.TestUserName(),
-				DescriptorIDs: descpb.IDs{myTableID},
-				Details:       details,
-				Progress:      jobspb.SchemaChangeGCProgress{},
-				RunningStatus: sql.RunningStatusWaitingGC,
-				NonCancelable: true,
-			}
-
-			// The job record that will be used to lookup this job.
-			lookupJR := jobs.Record{
-				Description:   "GC test",
-				Username:      username.TestUserName(),
-				DescriptorIDs: descpb.IDs{myTableID},
-				Details:       details,
-			}
-
-			job, err := jobs.TestingCreateAndStartJob(ctx, jobRegistry, s.InternalDB().(isql.DB), jobRecord)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			// Check that the job started.
-			jobIDStr := strconv.Itoa(int(job.ID()))
-			if err := jobutils.VerifyRunningSystemJob(t, sqlDB, 0, jobspb.TypeSchemaChangeGC, sql.RunningStatusWaitingGC, lookupJR); err != nil {
-				t.Fatal(err)
-			}
-
-			if ttlTime != FUTURE {
-				// Check that the job eventually blocks right before performing GC, due to the testing knob.
-				sqlDB.CheckQueryResultsRetry(
-					t,
-					fmt.Sprintf("SELECT status, running_status FROM [SHOW JOBS] WHERE job_id = %s", jobIDStr),
-					[][]string{{"running", expectedRunningStatus}})
-			}
-			blockGC <- struct{}{}
-
-			if ttlTime == FUTURE {
-				time.Sleep(500 * time.Millisecond)
-			} else {
-				sqlDB.CheckQueryResultsRetry(t, fmt.Sprintf("SELECT status FROM [SHOW JOBS] WHERE job_id = %s", jobIDStr), [][]string{{"succeeded"}})
-				if err := jobutils.VerifySystemJob(t, sqlDB, 0, jobspb.TypeSchemaChangeGC, jobs.StatusSucceeded, lookupJR); err != nil {
-					t.Fatal(err)
-				}
-			}
-
-			if err := sql.TestingDescsTxn(ctx, s, func(ctx context.Context, txn isql.Txn, col *descs.Collection) error {
-				myImm, err := col.ByID(txn.KV()).Get().Table(ctx, myTableID)
-				if err != nil {
-					if ttlTime != FUTURE && (dropItem == TABLE || dropItem == DATABASE) {
-						// We dropped the table, so expect it to not be found.
-						require.EqualError(t, err, fmt.Sprintf(`relation "[%d]" does not exist`, myTableID))
-						return nil
-					}
-					return err
-				}
-				myTableDesc = tabledesc.NewBuilder(myImm.TableDesc()).BuildExistingMutableTable()
-				myOtherImm, err := col.ByID(txn.KV()).Get().Table(ctx, myOtherTableID)
-				if err != nil {
-					if ttlTime != FUTURE && dropItem == DATABASE {
-						// We dropped the entire database, so expect none of the tables to be found.
-						require.EqualError(t, err, fmt.Sprintf(`relation "[%d]" does not exist`, myOtherTableID))
-						return nil
-					}
-					return err
-				}
-				myOtherTableDesc = tabledesc.NewBuilder(myOtherImm.TableDesc()).BuildExistingMutableTable()
-				return nil
-			}); err != nil {
-				t.Fatal(err)
-			}
+			// NB: The inner body of this loop has been extracted into a function to
+			// ensure defer statements (namely testserver.Stop) is executed at the
+			// end of each loop rather than the end of each test.
+			doTestSchemaChangeGCJob(t, dropItem, ttlTime)
 		}
+	}
+}
+
+func doTestSchemaChangeGCJob(t *testing.T, dropItem DropItem, ttlTime TTLTime) {
+	blockGC := make(chan struct{}, 1)
+	params := base.TestServerArgs{}
+	params.ScanMaxIdleTime = time.Millisecond
+	params.Knobs.JobsTestingKnobs = jobs.NewTestingKnobsWithShortIntervals()
+	params.Knobs.GCJob = &sql.GCJobTestingKnobs{
+		RunBeforePerformGC: func(_ jobspb.JobID) error {
+			<-blockGC
+			return nil
+		},
+	}
+	s, db, kvDB := serverutils.StartServer(t, params)
+	ctx := context.Background()
+	defer s.Stopper().Stop(ctx)
+	sqlDB := sqlutils.MakeSQLRunner(db)
+
+	sqlDB.Exec(t, `SET CLUSTER SETTING sql.gc_job.wait_for_gc.interval = '1s';`)
+	// Refresh protected timestamp cache immediately to make MVCC GC queue to
+	// process GC immediately.
+	sqlDB.Exec(t, `SET CLUSTER SETTING kv.protectedts.poll_interval = '1s';`)
+
+	jobRegistry := s.JobRegistry().(*jobs.Registry)
+
+	sqlDB.Exec(t, "CREATE DATABASE my_db")
+	sqlDB.Exec(t, "USE my_db")
+	sqlDB.Exec(t, "CREATE TABLE my_table (a int primary key, b int, index (b))")
+	sqlDB.Exec(t, "CREATE TABLE my_other_table (a int primary key, b int, index (b))")
+	if ttlTime == SOON {
+		sqlDB.Exec(t, "ALTER TABLE my_table CONFIGURE ZONE USING gc.ttlseconds = 1")
+		sqlDB.Exec(t, "ALTER TABLE my_other_table CONFIGURE ZONE USING gc.ttlseconds = 1")
+	}
+
+	myDBID := descpb.ID(bootstrap.TestingUserDescID(4))
+	myTableID := descpb.ID(bootstrap.TestingUserDescID(6))
+	myOtherTableID := descpb.ID(bootstrap.TestingUserDescID(7))
+
+	var myTableDesc *tabledesc.Mutable
+	var myOtherTableDesc *tabledesc.Mutable
+	if err := sql.TestingDescsTxn(ctx, s, func(ctx context.Context, txn isql.Txn, col *descs.Collection) error {
+		myImm, err := col.ByID(txn.KV()).Get().Table(ctx, myTableID)
+		if err != nil {
+			return err
+		}
+		myTableDesc = tabledesc.NewBuilder(myImm.TableDesc()).BuildExistingMutableTable()
+		myOtherImm, err := col.ByID(txn.KV()).Get().Table(ctx, myOtherTableID)
+		if err != nil {
+			return err
+		}
+		myOtherTableDesc = tabledesc.NewBuilder(myOtherImm.TableDesc()).BuildExistingMutableTable()
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Start the job that drops an index.
+	dropTime := timeutil.Now().UnixNano()
+	if ttlTime == PAST {
+		dropTime = 1
+	}
+	var details jobspb.SchemaChangeGCDetails
+	var expectedRunningStatus string
+	switch dropItem {
+	case INDEX:
+		details = jobspb.SchemaChangeGCDetails{
+			Indexes: []jobspb.SchemaChangeGCDetails_DroppedIndex{
+				{
+					IndexID:  descpb.IndexID(2),
+					DropTime: dropTime,
+				},
+			},
+			ParentID: myTableID,
+		}
+		myTableDesc.SetPublicNonPrimaryIndexes([]descpb.IndexDescriptor{})
+		expectedRunningStatus = "deleting data"
+	case TABLE:
+		details = jobspb.SchemaChangeGCDetails{
+			Tables: []jobspb.SchemaChangeGCDetails_DroppedID{
+				{
+					ID:       myTableID,
+					DropTime: dropTime,
+				},
+			},
+		}
+		myTableDesc.State = descpb.DescriptorState_DROP
+		myTableDesc.DropTime = dropTime
+		expectedRunningStatus = "deleting data"
+	case DATABASE:
+		details = jobspb.SchemaChangeGCDetails{
+			Tables: []jobspb.SchemaChangeGCDetails_DroppedID{
+				{
+					ID:       myTableID,
+					DropTime: dropTime,
+				},
+				{
+					ID:       myOtherTableID,
+					DropTime: dropTime,
+				},
+			},
+			ParentID: myDBID,
+		}
+		myTableDesc.State = descpb.DescriptorState_DROP
+		myTableDesc.DropTime = dropTime
+		myOtherTableDesc.State = descpb.DescriptorState_DROP
+		myOtherTableDesc.DropTime = dropTime
+		expectedRunningStatus = "deleting data"
+	}
+
+	if err := kvDB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+		b := txn.NewBatch()
+		descKey := catalogkeys.MakeDescMetadataKey(keys.SystemSQLCodec, myTableID)
+		descDesc := myTableDesc.DescriptorProto()
+		b.Put(descKey, descDesc)
+		descKey2 := catalogkeys.MakeDescMetadataKey(keys.SystemSQLCodec, myOtherTableID)
+		descDesc2 := myOtherTableDesc.DescriptorProto()
+		b.Put(descKey2, descDesc2)
+		return txn.Run(ctx, b)
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	jobRecord := jobs.Record{
+		Description:   "GC test",
+		Username:      username.TestUserName(),
+		DescriptorIDs: descpb.IDs{myTableID},
+		Details:       details,
+		Progress:      jobspb.SchemaChangeGCProgress{},
+		RunningStatus: sql.RunningStatusWaitingGC,
+		NonCancelable: true,
+	}
+
+	// The job record that will be used to lookup this job.
+	lookupJR := jobs.Record{
+		Description:   "GC test",
+		Username:      username.TestUserName(),
+		DescriptorIDs: descpb.IDs{myTableID},
+		Details:       details,
+	}
+
+	job, err := jobs.TestingCreateAndStartJob(ctx, jobRegistry, s.InternalDB().(isql.DB), jobRecord)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Check that the job started.
+	jobIDStr := strconv.Itoa(int(job.ID()))
+	if err := jobutils.VerifyRunningSystemJob(t, sqlDB, 0, jobspb.TypeSchemaChangeGC, sql.RunningStatusWaitingGC, lookupJR); err != nil {
+		t.Fatal(err)
+	}
+
+	if ttlTime != FUTURE {
+		// Check that the job eventually blocks right before performing GC, due to the testing knob.
+		sqlDB.CheckQueryResultsRetry(
+			t,
+			fmt.Sprintf("SELECT status, running_status FROM [SHOW JOBS] WHERE job_id = %s", jobIDStr),
+			[][]string{{"running", expectedRunningStatus}})
+	}
+	blockGC <- struct{}{}
+
+	if ttlTime == FUTURE {
+		time.Sleep(500 * time.Millisecond)
+	} else {
+		sqlDB.CheckQueryResultsRetry(t, fmt.Sprintf("SELECT status FROM [SHOW JOBS] WHERE job_id = %s", jobIDStr), [][]string{{"succeeded"}})
+		if err := jobutils.VerifySystemJob(t, sqlDB, 0, jobspb.TypeSchemaChangeGC, jobs.StatusSucceeded, lookupJR); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := sql.TestingDescsTxn(ctx, s, func(ctx context.Context, txn isql.Txn, col *descs.Collection) error {
+		myImm, err := col.ByID(txn.KV()).Get().Table(ctx, myTableID)
+		if err != nil {
+			if ttlTime != FUTURE && (dropItem == TABLE || dropItem == DATABASE) {
+				// We dropped the table, so expect it to not be found.
+				require.EqualError(t, err, fmt.Sprintf(`relation "[%d]" does not exist`, myTableID))
+				return nil
+			}
+			return err
+		}
+		myTableDesc = tabledesc.NewBuilder(myImm.TableDesc()).BuildExistingMutableTable()
+		myOtherImm, err := col.ByID(txn.KV()).Get().Table(ctx, myOtherTableID)
+		if err != nil {
+			if ttlTime != FUTURE && dropItem == DATABASE {
+				// We dropped the entire database, so expect none of the tables to be found.
+				require.EqualError(t, err, fmt.Sprintf(`relation "[%d]" does not exist`, myOtherTableID))
+				return nil
+			}
+			return err
+		}
+		myOtherTableDesc = tabledesc.NewBuilder(myOtherImm.TableDesc()).BuildExistingMutableTable()
+		return nil
+	}); err != nil {
+		t.Fatal(err)
 	}
 }
 


### PR DESCRIPTION
`TestSchemaChangeGCJob` was prone to resource exhaustion timeouts due to an accrual of testservers. This was due to the use of `defer Stop()` within the body of a nested for loop.

This commit extracts the loop body into its own function to ensure that testservers are shutdown between each subtest.

The author of this commit believes the recently reported flake of this test is due to resource exhaustion as the TC logs do not contain any indication as to _why_ the test failed.

The substantial improvement of
`dev test ./pkg/sql/gcjob_test --race --timeout 30m` indicates that the aforementioned flake(s) will likely be solved by this commit.

```
Before:
//pkg/sql/gcjob_test:gcjob_test_test             PASSED in 305.1s

After:
//pkg/sql/gcjob_test:gcjob_test_test             PASSED in 143.2s
```

Fixes: #108526
Release note: None