### PR TITLE
pkg/cmd/dev: show case how to pass envvars to tests

### DIFF
--- a/pkg/cmd/dev/test.go
+++ b/pkg/cmd/dev/test.go
@@ -88,6 +88,10 @@ pkg/kv/kvserver:kvserver_test) instead.`,
         Run a test repeatedly until at least N seconds have passed (useful if "dev test --stress" ends too quickly and you want to keep the test running for a while)
 
     dev test pkg/server -f=TestSpanStatsResponse -v --count=5 --vmodule='raft=1'
+        Run a specific test, multiple times, with increased logging verbosity
+
+    dev test pkg/server -- --test_env=COCKROACH_RANDOM_SEED=1234
+        Run a test with a specified seed by passing the --test_env flag directly to bazel
 `,
 		Args: cobra.MinimumNArgs(0),
 		RunE: runE,


### PR DESCRIPTION
Previously, it was difficult to track down the recommended way to pass environment variables, such as `COCKROACH_RANDOM_SEED`, to tests. A developer would have had to notice that `dev` passes arguments after `--` directly to bazel and that bazel supports a `--test_env` flag for `bazel test`. Additionally, grepping the codebase environment test specific environment variables would yield no relevant results.

This commit adds an intentionally repetitive example to `dev test` showcasing how to override `COCKROACH_RANDOM_SEED`. This example and presence of `COCKROACH_RANDOM_SEED` will hopefully enhance the discoverability of `dev`'s bazel pass through capabilities and the `--test_env` bazel flag.

Epic: none
Release note: None