### PR TITLE
import: bring TestImportWorkerFailure back online

### DIFF
--- a/pkg/sql/importer/import_stmt_test.go
+++ b/pkg/sql/importer/import_stmt_test.go
@@ -5417,10 +5417,6 @@ func TestImportWorkerFailure(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	skip.UnderStressWithIssue(t, 108547, "flaky test")
-	skip.UnderDeadlockWithIssue(t, 108547, "flaky test")
-	skip.UnderRaceWithIssue(t, 108547, "flaky test")
-
 	allowResponse := make(chan struct{})
 	params := base.TestClusterArgs{}
 	params.ServerArgs.Knobs.JobsTestingKnobs = jobs.NewTestingKnobsWithShortIntervals()

--- a/pkg/testutils/jobutils/jobs_verification.go
+++ b/pkg/testutils/jobutils/jobs_verification.go
@@ -68,6 +68,28 @@ func WaitForJobReverting(t testing.TB, db *sqlutils.SQLRunner, jobID jobspb.JobI
 	waitForJobToHaveStatus(t, db, jobID, jobs.StatusReverting)
 }
 
+func WaitForJobToSucceedOrFail(
+	t testing.TB, db *sqlutils.SQLRunner, jobID jobspb.JobID,
+) (status jobs.Status) {
+	t.Helper()
+	testutils.SucceedsWithin(t, func() error {
+		var statusStr string
+		query := fmt.Sprintf("SELECT status FROM (%s)", InternalSystemJobsBaseQuery)
+		if err := db.DB.QueryRowContext(context.Background(), query, jobID).Scan(&statusStr); err != nil {
+			if testutils.IsError(err, "sql: no rows in result set") {
+				return errors.Newf("job %d not found", jobID)
+			}
+			return err
+		}
+		status = jobs.Status(statusStr)
+		if status != jobs.StatusFailed && status != jobs.StatusSucceeded {
+			return errors.Errorf("expected success or failure but got %s", statusStr)
+		}
+		return nil
+	}, 2*time.Minute)
+	return status
+}
+
 // InternalSystemJobsBaseQuery runs the query against an empty database string.
 // Since crdb_internal.system_jobs is a virtual table, by default, the query
 // will take a lease on the current database the SQL session is connected to. If


### PR DESCRIPTION
## jobs: fix waitForJobToHaveStatus flakey error

Sometimes we flake with the error:

```
 jobs_verification.go:88: error scanning '&{<nil> 0xc032ce2300}': sql: no rows in result set
```

We need this error to be returned and not fail the test in order for the
SucceedsSoon to work. Now if the job fails to be created after 2m the
error will be:

```
import_stmt_test.go:5482: condition failed to evaluate within 2m0s: from jobs_verification.go:90: job 891470100285554693 not found
```

Informs: #107456
Epic: none
Release note: none

## import: allow import worker failure to fail

This commit flushes out work done in #108626 to allow import to succeed
or fail and still have it count as passing.  This covers the case
where the import statement succeeds but the import fails later.

We also handle the case where the import statement reports an error
but actually just puts job in the background.  This is the
"node liveness error: restarting in background" error.

Informs: #107456
Release note: none
Epic: none

## import: unskip TestImportWorkerFailure for stress/race/deadlock

Now that we allow this to fail as long as it fails atomically and it
seems to pass reliably under stress race and deadlock.

Epic: none
Release note: none


