### PR TITLE
asim: fix simulator non-deterministic behavior 

### DIFF
--- a/pkg/kv/kvserver/asim/BUILD.bazel
+++ b/pkg/kv/kvserver/asim/BUILD.bazel
@@ -29,7 +29,6 @@ go_test(
         "//pkg/kv/kvserver/asim/metrics",
         "//pkg/kv/kvserver/asim/state",
         "//pkg/kv/kvserver/asim/workload",
-        "//pkg/testutils/skip",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/kv/kvserver/asim/asim_test.go
+++ b/pkg/kv/kvserver/asim/asim_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/asim/metrics"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/asim/state"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/asim/workload"
-	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/stretchr/testify/require"
 )
 
@@ -40,7 +39,6 @@ func TestRunAllocatorSimulator(t *testing.T) {
 }
 
 func TestAsimDeterministic(t *testing.T) {
-	skip.WithIssue(t, 105904, "asim is non-deterministic")
 	settings := config.DefaultSimulationSettings()
 
 	runs := 3

--- a/pkg/kv/kvserver/asim/state/BUILD.bazel
+++ b/pkg/kv/kvserver/asim/state/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
         "config_loader.go",
         "helpers.go",
         "impl.go",
+        "liveness.go",
         "load.go",
         "new_state.go",
         "split_decider.go",
@@ -49,6 +50,7 @@ go_test(
     srcs = [
         "change_test.go",
         "config_loader_test.go",
+        "liveness_test.go",
         "split_decider_test.go",
         "state_test.go",
     ],
@@ -61,6 +63,7 @@ go_test(
         "//pkg/kv/kvserver/liveness/livenesspb",
         "//pkg/kv/kvserver/load",
         "//pkg/roachpb",
+        "//pkg/util/hlc",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/kv/kvserver/asim/state/impl.go
+++ b/pkg/kv/kvserver/asim/state/impl.go
@@ -42,7 +42,7 @@ type state struct {
 	stores                  map[StoreID]*store
 	load                    map[RangeID]ReplicaLoad
 	loadsplits              map[StoreID]LoadSplitter
-	quickLivenessMap        livenesspb.TestNodeVitality
+	nodeLiveness            MockNodeLiveness
 	capacityChangeListeners []CapacityChangeListener
 	newCapacityListeners    []NewCapacityListener
 	configChangeListeners   []ConfigChangeListener
@@ -71,13 +71,17 @@ func newState(settings *config.SimulationSettings) *state {
 		nodes:             make(map[NodeID]*node),
 		stores:            make(map[StoreID]*store),
 		loadsplits:        make(map[StoreID]LoadSplitter),
-		quickLivenessMap:  livenesspb.TestNodeVitality{},
 		capacityOverrides: make(map[StoreID]CapacityOverride),
 		clock:             &ManualSimClock{nanos: settings.StartTime.UnixNano()},
 		ranges:            newRMap(),
 		usageInfo:         newClusterUsageInfo(),
 		settings:          settings,
 	}
+	s.nodeLiveness = MockNodeLiveness{
+		clock:     hlc.NewClockForTesting(s.clock),
+		statusMap: map[NodeID]livenesspb.NodeLivenessStatus{},
+	}
+
 	s.load = map[RangeID]ReplicaLoad{FirstRangeID: NewReplicaLoadCounter(s.clock)}
 	return s
 }
@@ -377,7 +381,7 @@ func (s *state) AddNode() Node {
 		stores: []StoreID{},
 	}
 	s.nodes[nodeID] = node
-	s.quickLivenessMap.AddNode(roachpb.NodeID(nodeID))
+	s.SetNodeLiveness(nodeID, livenesspb.NodeLivenessStatus_LIVE)
 	return node
 }
 func (s *state) SetNodeLocality(nodeID NodeID, locality roachpb.Locality) {
@@ -1054,18 +1058,7 @@ func (s *state) NextReplicasFn(storeID StoreID) func() []Replica {
 // SetNodeLiveness sets the liveness status of the node with ID NodeID to be
 // the status given.
 func (s *state) SetNodeLiveness(nodeID NodeID, status livenesspb.NodeLivenessStatus) {
-	switch status {
-	case livenesspb.NodeLivenessStatus_DRAINING:
-		s.quickLivenessMap.Draining(roachpb.NodeID(nodeID), true)
-	case livenesspb.NodeLivenessStatus_DECOMMISSIONED:
-		s.quickLivenessMap.Decommissioned(roachpb.NodeID(nodeID), false)
-	case livenesspb.NodeLivenessStatus_DECOMMISSIONING:
-		s.quickLivenessMap.Decommissioning(roachpb.NodeID(nodeID), true)
-	case livenesspb.NodeLivenessStatus_LIVE:
-		s.quickLivenessMap.RestartNode(roachpb.NodeID(nodeID))
-	case livenesspb.NodeLivenessStatus_DEAD:
-		s.quickLivenessMap.DownNode(roachpb.NodeID(nodeID))
-	}
+	s.nodeLiveness.statusMap[nodeID] = status
 }
 
 // NodeLivenessFn returns a function, that when called will return the
@@ -1073,18 +1066,23 @@ func (s *state) SetNodeLiveness(nodeID NodeID, status livenesspb.NodeLivenessSta
 // TODO(kvoli): Find a better home for this method, required by the storepool.
 func (s *state) NodeLivenessFn() storepool.NodeLivenessFunc {
 	return func(nid roachpb.NodeID) livenesspb.NodeLivenessStatus {
-		return s.quickLivenessMap[nid].Convert().LivenessStatus()
+		return s.nodeLiveness.statusMap[NodeID(nid)]
 	}
 }
 
 // NodeCountFn returns a function, that when called will return the current
 // number of nodes that exist in this state.
 // TODO(kvoli): Find a better home for this method, required by the storepool.
+// TODO(wenyihu6): introduce the concept of membership separated from the
+// liveness map.
 func (s *state) NodeCountFn() storepool.NodeCountFunc {
 	return func() int {
 		count := 0
-		for _, entry := range s.quickLivenessMap {
-			if entry.Convert().IsLive(livenesspb.Rebalance) {
+		for _, status := range s.nodeLiveness.statusMap {
+			// Nodes with a liveness status other than decommissioned or
+			// decommissioning are considered active members (see
+			// liveness.MembershipStatus).
+			if status != livenesspb.NodeLivenessStatus_DECOMMISSIONED && status != livenesspb.NodeLivenessStatus_DECOMMISSIONING {
 				count++
 			}
 		}
@@ -1241,7 +1239,7 @@ func (s *state) Scan(
 // state of ranges.
 func (s *state) Report() roachpb.SpanConfigConformanceReport {
 	reporter := spanconfigreporter.New(
-		s.quickLivenessMap, s, s, s,
+		s.nodeLiveness, s, s, s,
 		cluster.MakeClusterSettings(), &spanconfig.TestingKnobs{})
 	report, err := reporter.SpanConfigConformance(context.Background(), []roachpb.Span{{}})
 	if err != nil {

--- a/pkg/kv/kvserver/asim/state/liveness.go
+++ b/pkg/kv/kvserver/asim/state/liveness.go
@@ -1,0 +1,116 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package state
+
+import (
+	"context"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness/livenesspb"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+)
+
+// MockNodeLiveness is responsible for tracking the liveness status of nodes
+// without the need for real heartbeating. Instead, this mock implementation
+// manages the statuses of all nodes by manually updating and accessing the
+// internal map. It implements the NodeVitalityInterface to enable the
+// SpanConfigConformance reporter to call it. Thus, we only expect calls to the
+// ScanNodeVitalityFromCache function.
+type MockNodeLiveness struct {
+	clock     *hlc.Clock
+	statusMap map[NodeID]livenesspb.NodeLivenessStatus
+}
+
+var _ livenesspb.NodeVitalityInterface = &MockNodeLiveness{}
+
+func (m MockNodeLiveness) GetNodeVitalityFromCache(roachpb.NodeID) livenesspb.NodeVitality {
+	panic("GetNodeVitalityFromCache is not expected to be called on MockNodeLiveness")
+}
+
+func (m MockNodeLiveness) ScanNodeVitalityFromKV(
+	context.Context,
+) (livenesspb.NodeVitalityMap, error) {
+	panic("ScanNodeVitalityFromKV is not expected to be called on MockNodeLiveness")
+}
+
+// convertNodeStatusToNodeVitality constructs a node vitality in a manner that
+// respects all node liveness status properties. The node vitality record for
+// nodes in different states are set as follows:
+// timeUntilNodeDead = time.Minute
+// - unknown: invalid NodeVitality
+// - live, decommissioning: expirationWallTime = MaxTimeStamp - timeUntilNodeDead
+// - unavailable: expirationWallTime = now - time.Second
+// - dead, decommissioned: expirationWallTime = 0
+//
+// Explanation: refer to liveness.LivenessStatus for an overview of the states a
+// liveness record goes through.
+//
+// - live, decommissioning: set liveness expiration to be in the
+// future(MaxTimestamp) and minus timeUntilNodeDead to avoid overflow in
+// liveness status check tExp+timeUntilNodeDead.
+// - unavailable: set liveness expiration to be just recently expired. This
+// needs to be within now - timeUntilNodeDead <= expirationWallTime < now so
+// that the status is not dead nor alive.
+// - dead, decommissioned: set liveness expiration to be in the
+// past(MinTimestamp).
+func convertNodeStatusToNodeVitality(
+	nid roachpb.NodeID, status livenesspb.NodeLivenessStatus, now hlc.Timestamp,
+) livenesspb.NodeVitality {
+	const timeUntilNodeDead = time.Minute
+	var liveTs = hlc.MaxTimestamp.AddDuration(-timeUntilNodeDead).ToLegacyTimestamp()
+	var deadTs = hlc.MinTimestamp.ToLegacyTimestamp()
+	var unavailableTs = now.AddDuration(-time.Second).ToLegacyTimestamp()
+	l := livenesspb.Liveness{
+		NodeID:     nid,
+		Draining:   false,
+		Epoch:      1,
+		Membership: livenesspb.MembershipStatus_ACTIVE,
+	}
+	switch status {
+	case livenesspb.NodeLivenessStatus_UNKNOWN:
+		return livenesspb.NodeVitality{}
+	case livenesspb.NodeLivenessStatus_DEAD:
+		l.Expiration = deadTs
+	case livenesspb.NodeLivenessStatus_UNAVAILABLE:
+		l.Expiration = unavailableTs
+	case livenesspb.NodeLivenessStatus_LIVE:
+		l.Expiration = liveTs
+	case livenesspb.NodeLivenessStatus_DECOMMISSIONING:
+		l.Expiration = liveTs
+		l.Membership = livenesspb.MembershipStatus_DECOMMISSIONING
+	case livenesspb.NodeLivenessStatus_DECOMMISSIONED:
+		l.Expiration = deadTs
+		l.Membership = livenesspb.MembershipStatus_DECOMMISSIONED
+	case livenesspb.NodeLivenessStatus_DRAINING:
+		l.Expiration = liveTs
+		l.Draining = true
+	}
+	entry := l.CreateNodeVitality(
+		now,               /* now */
+		hlc.Timestamp{},   /* descUpdateTime */
+		hlc.Timestamp{},   /* descUnavailableTime */
+		true,              /* connected */
+		timeUntilNodeDead, /* timeUntilNodeDead */
+		0,                 /* timeAfterNodeSuspect */
+	)
+	return entry
+}
+
+func (m MockNodeLiveness) ScanNodeVitalityFromCache() livenesspb.NodeVitalityMap {
+	isLiveMap := livenesspb.NodeVitalityMap{}
+	for nodeID, status := range m.statusMap {
+		nid := roachpb.NodeID(nodeID)
+		now := m.clock.Now()
+		isLiveMap[nid] = convertNodeStatusToNodeVitality(nid, status, now)
+	}
+	return isLiveMap
+}

--- a/pkg/kv/kvserver/asim/state/liveness_test.go
+++ b/pkg/kv/kvserver/asim/state/liveness_test.go
@@ -1,0 +1,75 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package state
+
+import (
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness/livenesspb"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMockLiveness(t *testing.T) {
+	clock := &ManualSimClock{nanos: time.Date(2022, 03, 21, 11, 0, 0, 0, time.UTC).UnixNano()}
+	now := hlc.NewClockForTesting(clock).Now()
+	testCases := []struct {
+		status           livenesspb.NodeLivenessStatus
+		IsAlive          bool
+		MembershipStatus livenesspb.MembershipStatus
+	}{
+		{
+			status:           livenesspb.NodeLivenessStatus_UNKNOWN,
+			IsAlive:          false,
+			MembershipStatus: livenesspb.MembershipStatus_ACTIVE,
+		},
+		{
+			status:           livenesspb.NodeLivenessStatus_DEAD,
+			IsAlive:          false,
+			MembershipStatus: livenesspb.MembershipStatus_ACTIVE,
+		},
+		{
+			status:           livenesspb.NodeLivenessStatus_UNAVAILABLE,
+			IsAlive:          false,
+			MembershipStatus: livenesspb.MembershipStatus_ACTIVE,
+		},
+		{
+			status:           livenesspb.NodeLivenessStatus_DECOMMISSIONED,
+			IsAlive:          false,
+			MembershipStatus: livenesspb.MembershipStatus_DECOMMISSIONED,
+		},
+		{
+			status:           livenesspb.NodeLivenessStatus_DECOMMISSIONING,
+			IsAlive:          true,
+			MembershipStatus: livenesspb.MembershipStatus_DECOMMISSIONING,
+		},
+		{
+			status:           livenesspb.NodeLivenessStatus_LIVE,
+			IsAlive:          true,
+			MembershipStatus: livenesspb.MembershipStatus_ACTIVE,
+		},
+		{
+			status:           livenesspb.NodeLivenessStatus_DRAINING,
+			IsAlive:          true,
+			MembershipStatus: livenesspb.MembershipStatus_ACTIVE,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.status.String(), func(t *testing.T) {
+			nv := convertNodeStatusToNodeVitality(roachpb.NodeID(1), tc.status, now)
+			require.Equal(t, tc.IsAlive, nv.IsLive(livenesspb.Rebalance))
+			require.Equal(t, tc.MembershipStatus, nv.MembershipStatus())
+			require.Equal(t, tc.status, nv.LivenessStatus())
+		})
+	}
+}

--- a/pkg/kv/kvserver/asim/state/state_test.go
+++ b/pkg/kv/kvserver/asim/state/state_test.go
@@ -625,7 +625,7 @@ func TestSetNodeLiveness(t *testing.T) {
 		for i := 6; i <= 10; i++ {
 			s.SetNodeLiveness(NodeID(i), livenesspb.NodeLivenessStatus_DEAD)
 		}
-		require.Equal(t, 0, countFn())
+		require.Equal(t, 5, countFn())
 	})
 }
 

--- a/pkg/kv/kvserver/asim/tests/BUILD.bazel
+++ b/pkg/kv/kvserver/asim/tests/BUILD.bazel
@@ -22,7 +22,6 @@ go_test(
         "//pkg/roachpb",
         "//pkg/spanconfig/spanconfigtestutils",
         "//pkg/testutils/datapathutils",
-        "//pkg/testutils/skip",
         "//pkg/util/log",
         "@com_github_cockroachdb_datadriven//:datadriven",
         "@com_github_guptarohit_asciigraph//:asciigraph",

--- a/pkg/kv/kvserver/asim/tests/datadriven_simulation_test.go
+++ b/pkg/kv/kvserver/asim/tests/datadriven_simulation_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/spanconfig/spanconfigtestutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/datapathutils"
-	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/datadriven"
 	"github.com/guptarohit/asciigraph"
@@ -159,9 +158,6 @@ func TestDataDriven(t *testing.T) {
 	ctx := context.Background()
 	dir := datapathutils.TestDataPath(t, ".")
 	datadriven.Walk(t, dir, func(t *testing.T, path string) {
-		if strings.Contains(path, "example_fulldisk") {
-			skip.WithIssue(t, 105904, "asim is non-deterministic")
-		}
 		const defaultKeyspace = 10000
 		loadGen := gen.BasicLoad{}
 		var clusterGen gen.ClusterGen


### PR DESCRIPTION
Previously, the allocator simulator exhibits non-deterministic behavior
because it set the liveness expiration record using the real system time
plus one minute. In addition, the liveness record was not updated between
ticks. While this was typically acceptable, it could lead to dead nodes in
deadlock test scenarios where tests took longer.

To address this, the following changes were made in this patch:
1. Remove the usage of TestNodeVitality as the simulator uses a simulated clock
rather than a real-time clock.
2. Replace the existing TestNodeVitality mapping with an enum map for Liveness
Status. The majority of the code changes just revert to the state before this
[commit](4a52da5).
3. To hook the liveness component with the liveness status mapping, this patch
also introduces a conversion method which constructs node vitality in a manner
that respects all node liveness status properties.

Fixes: #105904, #108092
Release Note: None