### PR TITLE
kvserver: fix double span Finish on reproposals

### DIFF
--- a/pkg/kv/kvserver/replica_application_result.go
+++ b/pkg/kv/kvserver/replica_application_result.go
@@ -320,11 +320,15 @@ func (r *Replica) tryReproposeWithNewLeaseIndex(ctx context.Context, origCmd *re
 		// for (some reincarnation of) the command to eventually apply, its trace
 		// will reflect the reproposal as well.
 		ctx:             origP.ctx,
-		sp:              origP.sp, // NB: special handling below
 		idKey:           raftlog.MakeCmdIDKey(),
 		proposedAtTicks: 0, // set in registerProposalLocked
 		createdAtTicks:  0, // set in registerProposalLocked
 		command:         &newCommand,
+
+		// Next comes the block of fields that are "moved" to the new proposal. See
+		// the deferred function call below which, correspondingly, clears these
+		// fields in the original proposal.
+		sp: origP.sp,
 		// NB: quotaAlloc is always nil here, because we already released the quota
 		// unconditionally in retrieveLocalProposals. So the below is a no-op.
 		//
@@ -333,8 +337,10 @@ func (r *Replica) tryReproposeWithNewLeaseIndex(ctx context.Context, origCmd *re
 		// releasing it here.
 		quotaAlloc: origP.quotaAlloc,
 		ec:         origP.ec,
-		applied:    false,
 		doneCh:     origP.doneCh,
+
+		applied: false,
+
 		// Local is copied over. It won't be used on the old proposal (since that
 		// proposal got rejected), but since it's still "local" we don't want to put
 		// it into  an undefined state by removing its response. The same goes for

--- a/pkg/kv/kvserver/replica_application_result.go
+++ b/pkg/kv/kvserver/replica_application_result.go
@@ -288,20 +288,6 @@ func (r *Replica) tryReproposeWithNewLeaseIndex(ctx context.Context, origCmd *re
 	// goal is that the old proposal remains a local proposal (switching it to
 	// non-local now invites logic bugs) but not bound to the caller.
 
-	// NB: quotaAlloc is always nil here, because we already
-	// released the quota unconditionally in retrieveLocalProposals.
-	// So the below is a no-op.
-	//
-	// TODO(tbg): if we shifted the release of proposal quota to *after*
-	// successful application, we could move the quota over
-	// prematurely releasing it here.
-	newQuotaAlloc := origP.quotaAlloc
-	defer func() {
-		if success {
-			origP.quotaAlloc = nil
-		}
-	}()
-
 	newCommand := kvserverpb.RaftCommand{
 		ProposerLeaseSequence: origP.command.ProposerLeaseSequence,
 		ReplicatedEvalResult:  origP.command.ReplicatedEvalResult,
@@ -316,25 +302,10 @@ func (r *Replica) tryReproposeWithNewLeaseIndex(ctx context.Context, origCmd *re
 		AdmissionOriginNode: 0,   // assigned on flush
 	}
 
-	// Now we construct the remainder of the ProposalData. First, the pieces
-	// that actively "move over", i.e. those that have to do with the latches
-	// held and the caller waiting to be signaled.
-
-	// `ec` (latches, etc) transfers to the new proposal.
-	newEC := origP.ec
-	defer func() {
-		if success {
-			origP.ec = makeEmptyEndCmds()
-		}
-	}()
-
-	// Ditto doneCh (signal to proposer).
-	newDoneCh := origP.doneCh
-	defer func() {
-		if success {
-			origP.doneCh = nil
-		}
-	}()
+	// Now we construct the remainder of the ProposalData. The pieces that
+	// actively "move over", are removed from the original proposal in the
+	// deferred func below. For example, those fields that have to do with the
+	// latches held and the caller waiting to be signaled.
 
 	// TODO(tbg): work on the lifecycle of ProposalData. This struct (and the
 	// surrounding replicatedCmd) are populated in an overly ad-hoc manner.
@@ -354,10 +325,16 @@ func (r *Replica) tryReproposeWithNewLeaseIndex(ctx context.Context, origCmd *re
 		proposedAtTicks: 0, // set in registerProposalLocked
 		createdAtTicks:  0, // set in registerProposalLocked
 		command:         &newCommand,
-		quotaAlloc:      newQuotaAlloc,
-		ec:              newEC,
-		applied:         false,
-		doneCh:          newDoneCh,
+		// NB: quotaAlloc is always nil here, because we already released the quota
+		// unconditionally in retrieveLocalProposals. So the below is a no-op.
+		//
+		// TODO(tbg): if we shifted the release of proposal quota to *after*
+		// successful application, we could move the quota over prematurely
+		// releasing it here.
+		quotaAlloc: origP.quotaAlloc,
+		ec:         origP.ec,
+		applied:    false,
+		doneCh:     origP.doneCh,
 		// Local is copied over. It won't be used on the old proposal (since that
 		// proposal got rejected), but since it's still "local" we don't want to put
 		// it into  an undefined state by removing its response. The same goes for
@@ -372,23 +349,23 @@ func (r *Replica) tryReproposeWithNewLeaseIndex(ctx context.Context, origCmd *re
 
 		seedProposal: seedP,
 	}
-	// If the original proposal had an explicit span, it's an async consensus
-	// proposal and the span would be finished momentarily (when we return to
-	// the caller) if we didn't unlink it here, but we want it to continue
-	// tracking newProposal. We leave it in `origP.ctx` though, since that
-	// context will become unused once the application of this (soft-failed)
-	// proposal concludes, i.e. soon after this method returns, in case there
-	// is anything left to log into it.
-	defer func() {
-		if success {
-			origP.sp = nil
-		}
-	}()
 
 	defer func() {
 		if !success {
 			return
 		}
+		// If the original proposal had an explicit span, it's an async consensus
+		// proposal and the span would be finished momentarily (when we return to
+		// the caller) if we didn't unlink it here, but we want it to continue
+		// tracking newProposal. We leave it in `origP.ctx` though, since that
+		// context will become unused once the application of this (soft-failed)
+		// proposal concludes, i.e. soon after this method returns, in case there is
+		// anything left to log into it.
+		origP.sp = nil
+		origP.quotaAlloc = nil
+		origP.ec = makeEmptyEndCmds()
+		origP.doneCh = nil
+
 		// If the proposal is synchronous, the client is waiting on the seed
 		// proposal. By the time it has to act on the result, a bunch of reproposals
 		// can have happened, and some may still be running and using the

--- a/pkg/kv/kvserver/replica_application_result_test.go
+++ b/pkg/kv/kvserver/replica_application_result_test.go
@@ -28,10 +28,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestProposalDataAndRaftCommandAreConsideredWhenAddingFields(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
-
+func makeProposalData() *ProposalData {
 	raftCommand := &kvserverpb.RaftCommand{
 		ProposerLeaseSequence: 1,
 		MaxLeaseIndex:         1,
@@ -45,8 +42,8 @@ func TestProposalDataAndRaftCommandAreConsideredWhenAddingFields(t *testing.T) {
 		AdmissionOriginNode:   1,
 	}
 
-	prop := &ProposalData{
-		ctx:                     context.Background(),
+	return &ProposalData{
+		ctx:                     context.WithValue(context.Background(), struct{}{}, "nonempty-ctx"),
 		sp:                      &tracing.Span{},
 		idKey:                   "deadbeef",
 		proposedAtTicks:         1,
@@ -66,7 +63,13 @@ func TestProposalDataAndRaftCommandAreConsideredWhenAddingFields(t *testing.T) {
 		seedProposal:            nil,
 		lastReproposal:          nil,
 	}
+}
 
+func TestProposalDataAndRaftCommandAreConsideredWhenAddingFields(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	prop := makeProposalData()
 	// If you are adding a field to ProposalData or RaftCommand, please consider the
 	// desired semantics of that field in `tryReproposeWithNewLeaseIndex{,v2}`. Once
 	// this has been done, adjust the expected number of fields below, and populate
@@ -75,6 +78,49 @@ func TestProposalDataAndRaftCommandAreConsideredWhenAddingFields(t *testing.T) {
 	// NB: we can't use zerofields for two reasons: First, we have unexported fields
 	// here, and second, we don't want to check for recursively populated structs (but
 	// only for the top level fields).
-	require.Equal(t, 10, reflect.TypeOf(*raftCommand).NumField())
+	require.Equal(t, 10, reflect.TypeOf(*prop.command).NumField())
 	require.Equal(t, 19, reflect.TypeOf(*prop).NumField())
+}
+
+func TestReplicaMakeReproposalChaininig(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	var r Replica
+	proposals := make([]*ProposalData, 1, 4)
+	proposals[0] = makeProposalData()
+	sharedCtx := proposals[0].ctx
+
+	verify := func() {
+		seed := proposals[0]
+		require.Nil(t, seed.seedProposal)
+		// The seed proposal must know the latest reproposal.
+		if len(proposals) > 1 {
+			require.Equal(t, proposals[len(proposals)-1], seed.lastReproposal)
+		} else {
+			require.Nil(t, seed.lastReproposal)
+		}
+		// All reproposals must point at the seed proposal.
+		for _, reproposal := range proposals[1:] {
+			require.Equal(t, seed, reproposal.seedProposal)
+			require.Nil(t, reproposal.lastReproposal)
+		}
+		// Only the latest reproposal must use the seed context.
+		for _, prop := range proposals[:len(proposals)-1] {
+			require.NotEqual(t, sharedCtx, prop.ctx)
+		}
+		require.Equal(t, sharedCtx, proposals[len(proposals)-1].ctx)
+	}
+
+	verify()
+	for i := 1; i < cap(proposals); i++ {
+		reproposal, onSuccess := r.makeReproposal(proposals[i-1])
+		proposals = append(proposals, reproposal)
+		onSuccess()
+		verify()
+	}
+
+	reproposal, onSuccess := r.makeReproposal(proposals[len(proposals)-1])
+	_, _ = reproposal, onSuccess // No onSuccess call, assume the proposal failed.
+	verify()
 }

--- a/pkg/kv/kvserver/replica_application_result_test.go
+++ b/pkg/kv/kvserver/replica_application_result_test.go
@@ -63,6 +63,8 @@ func TestProposalDataAndRaftCommandAreConsideredWhenAddingFields(t *testing.T) {
 		tok:                     TrackedRequestToken{done: true},
 		raftAdmissionMeta:       &kvflowcontrolpb.RaftAdmissionMeta{},
 		v2SeenDuringApplication: true,
+		seedProposal:            nil,
+		lastReproposal:          nil,
 	}
 
 	// If you are adding a field to ProposalData or RaftCommand, please consider the
@@ -74,5 +76,5 @@ func TestProposalDataAndRaftCommandAreConsideredWhenAddingFields(t *testing.T) {
 	// here, and second, we don't want to check for recursively populated structs (but
 	// only for the top level fields).
 	require.Equal(t, 10, reflect.TypeOf(*raftCommand).NumField())
-	require.Equal(t, 17, reflect.TypeOf(*prop).NumField())
+	require.Equal(t, 19, reflect.TypeOf(*prop).NumField())
 }

--- a/pkg/kv/kvserver/replica_proposal.go
+++ b/pkg/kv/kvserver/replica_proposal.go
@@ -198,6 +198,23 @@ type ProposalData struct {
 	// application is). This flag makes sure that the proposal buffer won't
 	// accidentally reinsert a finished proposal into the map.
 	v2SeenDuringApplication bool
+
+	// seedProposal points at the seed proposal in the chain of (re-)proposals, if
+	// this ProposalData is a reproposal. The field is nil for the seed proposal.
+	seedProposal *ProposalData
+	// lastReproposal is the last proposal that superseded the seed proposal.
+	// Superseding proposals form a chain starting from the seed proposal. This
+	// field is set only on the seed proposal, and is updated every time a new
+	// reproposal is cast.
+	//
+	// See Replica.mu.proposals comment for more details.
+	//
+	// TODO(pavelkalinnikov): We are referencing only the last reproposal in the
+	// chain, so that the intermediate ones can be GCed in case the chain is very
+	// long. This chain reasoning is subtle, we should decompose ProposalData in
+	// such a way that the "common" parts of the (re-)proposals are shared and
+	// chaining isn't necessary.
+	lastReproposal *ProposalData
 }
 
 // useReplicationAdmissionControl indicates whether this raft command should


### PR DESCRIPTION
Since #106750, `ProposalData` is being copied on superseding reproposals. The caller only knows about the original proposal, and only detaches its context / tracing span when abandoning the request (e.g. on timeout). By the time of abandoning the request, there might have been a few superseding reproposals, and the context / tracing span is being used by multiple `ProposalData` objects.

In addition to rewriting the original `proposal.ctx`, we should do the same for all the `ProposalData` objects corresponding to the same request. This commit unbinds the context for older proposals when reproposing them, and unbinds the latest reproposal context when cleaning up / abandoning the request.

Fixes #107521
Fixes #108534
Fixes #108241
Fixes #108663
Fixes #108696
Fixes #108837

Epic: CRDB-25287
Release note: none