### PR TITLE
metricspoller: avoid forever-growing context chain

### DIFF
--- a/pkg/jobs/metricspoller/poller.go
+++ b/pkg/jobs/metricspoller/poller.go
@@ -60,8 +60,7 @@ func (mp *metricsPoller) Resume(ctx context.Context, execCtx interface{}) error 
 	defer t.Stop()
 
 	runTask := func(name string, task func(ctx context.Context, execCtx sql.JobExecContext) error) error {
-		ctx = logtags.AddTag(ctx, "task", name)
-		return task(ctx, exec)
+		return task(logtags.AddTag(ctx, "task", name), exec)
 	}
 
 	for {


### PR DESCRIPTION
logtags.AddTag calls context.WithValue which creates a new context. Further, here we were re-assigning this new context to the original context passed to the Resume function. As a result, I believe that we were ending up with a constantly growing chain of contexts.

We believe this is the cause of slowly growing CPU usage.

Epic: None

Release note (bug fix): Fix bug that could cause CPU usage to increase over time.