### PR TITLE
release-23.1: server: allow users with VIEWACTIVITY to get console settings

### DIFF
--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -347,6 +347,7 @@ go_library(
         "@org_golang_google_grpc//codes",
         "@org_golang_google_grpc//metadata",
         "@org_golang_google_grpc//status",
+        "@org_golang_x_exp//slices",
     ] + select({
         "@io_bazel_rules_go//go/platform:aix": [
             "@org_golang_x_sys//unix",

--- a/pkg/settings/registry.go
+++ b/pkg/settings/registry.go
@@ -282,6 +282,29 @@ func Keys(forSystemTenant bool) (res []string) {
 	return res
 }
 
+// ConsoleKeys return an array with all cluster settings keys
+// used by the UI Console.
+// This list should only contain settings that have no sensitive
+// information, because it will be returned on `settings` endpoint for
+// users without VIEWCLUSTERSETTING or MODIFYCLUSTERSETTING permission,
+// but that have VIEWACTIVITY or VIEWACTIVITYREDACTED permissions.
+func ConsoleKeys() (res []string) {
+	return []string{
+		"cross_cluster_replication.enabled",
+		"keyvisualizer.enabled",
+		"keyvisualizer.sample_interval",
+		"sql.index_recommendation.drop_unused_duration",
+		"sql.insights.anomaly_detection.latency_threshold",
+		"sql.insights.high_retry_count.threshold",
+		"sql.insights.latency_threshold",
+		"sql.stats.automatic_collection.enabled",
+		"timeseries.storage.resolution_10s.ttl",
+		"timeseries.storage.resolution_30m.ttl",
+		"ui.display_timezone",
+		"version",
+	}
+}
+
 // LookupForLocalAccess returns a NonMaskedSetting by name. Used when a setting
 // is being retrieved for local processing within the cluster and not for
 // reporting; sensitive values are accessible.


### PR DESCRIPTION
Backport 1/1 commits from #108486.

/cc @cockroachdb/release

---

Previously, only users with `ADMIN`, `VIEWCLUSTERSETTING` or `MODIFYCLUSTERSETTING` could get the settings on the `_admin/v1/settings`. This API was used by the Console and then a few places retrieved that information.
Users without those permissions would not be able to see the values and some functionalities where not working as expected, for example timezone was showing as UTC even when the cluster setting `ui.display_timezone` was set to other value.

This commits modifies that endpoint (and that endpoint only) to return just the cluster settings that are not sensitive and that are required by the console to have all functionalities working.

The list of cluster settings:
"cross_cluster_replication.enabled",
"keyvisualizer.enabled",
"keyvisualizer.sample_interval",
"sql.index_recommendation.drop_unused_duration",
"sql.insights.anomaly_detection.latency_threshold", "sql.insights.high_retry_count.threshold",
"sql.insights.latency_threshold",
"sql.stats.automatic_collection.enabled",
"timeseries.storage.resolution_10s.ttl",
"timeseries.storage.resolution_30m.ttl",
"ui.display_timezone",
"version"

Part Of #108373
Fixes #108117

Release note (bug fix): Users with VIEWACTIVITY can now view correct values for timezone.

---

Release justification: Bug fix
