### PR TITLE
issues: auto-file issues for skipped tests

### DIFF
--- a/pkg/cmd/bazci/githubpost/githubpost_test.go
+++ b/pkg/cmd/bazci/githubpost/githubpost_test.go
@@ -334,7 +334,7 @@ TestXXA - 1.00s
 			defer file.Close()
 			curIssue := 0
 
-			f := func(ctx context.Context, f failure) error {
+			f := func(ctx context.Context, f failureOrSkip) error {
 				if t.Failed() {
 					return nil
 				}
@@ -421,7 +421,7 @@ func TestListFailuresFromTestXML(t *testing.T) {
 			defer file.Close()
 			curIssue := 0
 
-			f := func(ctx context.Context, f failure) error {
+			f := func(ctx context.Context, f failureOrSkip) error {
 				if t.Failed() {
 					return nil
 				}
@@ -481,7 +481,7 @@ func TestPostGeneralFailure(t *testing.T) {
 				issue.message = string(b)
 			}
 
-			f := func(ctx context.Context, f failure) error {
+			f := func(ctx context.Context, f failureOrSkip) error {
 				if t.Failed() {
 					return nil
 				}

--- a/pkg/cmd/internal/issues/issues.go
+++ b/pkg/cmd/internal/issues/issues.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/version"
 	"github.com/cockroachdb/errors"
 	"github.com/google/go-github/github"
+	"golang.org/x/exp/slices"
 	"golang.org/x/oauth2"
 )
 
@@ -387,7 +388,9 @@ func (p *poster) post(origCtx context.Context, formatter IssueFormatter, req Pos
 				p.l.Printf("could not create GitHub project card: %v", err)
 			}
 		}
-	} else {
+	} else if !slices.Contains(req.ExtraLabels, "skipped-test") {
+		// For failures, but not for skipped tests, add a comment to an existing
+		// issue.
 		comment := github.IssueComment{Body: github.String(body)}
 		if _, _, err := p.createComment(
 			ctx, p.Org, p.Repo, *foundIssue, &comment); err != nil {


### PR DESCRIPTION
All skipped tests will result in an issue being filed if one does not exist already. Currently, this includes tests that are "allowed" to be skipped (with skip.IgnoreLint) as well as skips that we want to block releases.

Release note: None