### PR TITLE
testutils/sqlutils/tsql: add SQL builder helper modules

### DIFF
--- a/pkg/testutils/sqlutils/BUILD.bazel
+++ b/pkg/testutils/sqlutils/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "sqlutils",
     srcs = [
+        "descriptor_corruption.go",
         "inject.go",
         "pg_url.go",
         "pretty.go",
@@ -27,6 +28,7 @@ go_library(
         "//pkg/sql/sem/catconstants",
         "//pkg/sql/sem/tree",
         "//pkg/testutils",
+        "//pkg/testutils/sqlutils/tsql",
         "//pkg/util/fileutil",
         "//pkg/util/protoutil",
         "@com_github_cockroachdb_cockroach_go_v2//crdb",

--- a/pkg/testutils/sqlutils/descriptor_corruption.go
+++ b/pkg/testutils/sqlutils/descriptor_corruption.go
@@ -1,0 +1,153 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sqlutils
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils/tsql"
+)
+
+const (
+	descPB = "cockroach.sql.sqlbase.Descriptor"
+)
+
+// DescriptorCorruption defines and showcases a specific "class" of descriptor
+// corruption.
+// It exists as a test utility to help enumerate, document, and reproduce
+// corruptions that occur in the wild.
+type DescriptorCorruption struct {
+	// Corruptor returns a tree.Expr that applies this "class" of corruption to
+	// the provided descriptor.
+	// For example, outbound foreign key references may be removed by wrapping
+	// the provided tree.Expr in json_remove_path(expr, 'table', 'outboundFKs').
+	Corruptor func(descJSON tree.Expr) tree.Expr
+	// Where return a tree.Expr that will be AND'd into a WHERE clause. The
+	// returned expression should limit system.descriptor rows to those that can
+	// be corrupted by this class.
+	// For example, if removing outboundFKs, the returned tree.Expr should
+	// exclude non-table descriptors and table descriptors without outboundFKs.
+	Where func(descJSON tree.Expr) tree.Expr
+}
+
+var (
+	// MissingInboundFKsCorruption is a DescriptorCorruption where a Table
+	// descriptor is missing some, or all, inbound foreign key references.
+	MissingInboundFKsCorruption = DescriptorCorruption{
+		Corruptor: func(descJSON tree.Expr) tree.Expr {
+			return tsql.JSONRemovePath(descJSON, "table", "inboundFKs")
+		},
+		Where: func(descJSON tree.Expr) tree.Expr {
+			// descriptor_json ? 'table' AND json_array_length(descriptor_json -> table -> inboundFKs) > 0
+			return tsql.And(
+				// Only apply to tables.,
+				tsql.JSONExists(descJSON, "table"),
+				// Only select descriptors that have inbound FKs.
+				tsql.Cmp(
+					tsql.JSONArrayLength(tsql.JSONExtractPath(descJSON, "table", "inboundFKs")),
+					tsql.GT,
+					tree.NewDInt(0),
+				),
+			)
+		},
+	}
+
+	// MissingInboundFKsCorruption is a DescriptorCorruption where a Table
+	// descriptor is missing some, or all, outbound foreign key references.
+	MissingOutboundFKsCorruption = DescriptorCorruption{
+		Corruptor: func(descJSON tree.Expr) tree.Expr {
+			return tsql.JSONRemovePath(descJSON, "table", "outboundFKs")
+		},
+		Where: func(descJSON tree.Expr) tree.Expr {
+			// descriptor_json ? 'table' AND json_array_length(descriptor_json -> table -> inboundFKs) > 0
+			return tsql.And(
+				// Only apply to tables.
+				tsql.JSONExists(descJSON, "table"),
+				// Only select descriptors that have outbound FKs.
+				tsql.Cmp(
+					tsql.JSONArrayLength(tsql.JSONExtractPath(descJSON, "table", "outboundFKs")),
+					tsql.GT,
+					tree.NewDInt(0),
+				),
+			)
+		},
+	}
+
+	// TODO InvalidMutationJobCorruption can apply to any descriptor type. It
+	// only applies to tables for now as the query is a bit more involved.
+	InvalidMutationJobCorruption = DescriptorCorruption{
+		Corruptor: func(descJSON tree.Expr) tree.Expr {
+			return tsql.JSONSet(
+				descJSON,
+				[]string{"table", "mutations"},
+				tsql.JSONBuildArray(
+					tsql.JSONBuildObject(map[string]any{
+						"mutation_id": 1,
+					}),
+				),
+			)
+		},
+		Where: func(descJSON tree.Expr) tree.Expr {
+			return tsql.JSONExists(descJSON, "table")
+		},
+	}
+
+	InvalidMutationCorruption = DescriptorCorruption{
+	}
+)
+
+type DescriptorTarget interface {
+
+}
+
+func MustCorrupt(t Fataler, sr *SQLRunner, target DescriptorTarget, corruptions ...DescriptorCorruption) {
+}
+
+// MustCorruptOne applies the given DescriptorCorruption and asserts that
+// exactly one descriptor was corrupted. It will call t.Fatal, if no
+// descriptors are susceptible by the provided corruption class.
+func MustCorruptOne(t Fataler, sr *SQLRunner, c DescriptorCorruption, where ...tree.Expr) {
+	idCol := tree.NewUnresolvedName("id")
+	descCol := tree.NewUnresolvedName("descriptor")
+	descJSON := tsql.PBToJSON(descPB, descCol)
+	descTbl := tree.MakeTableNameFromPrefix(tree.ObjectNamePrefix{SchemaName: "system", ExplicitSchema: true}, "descriptor")
+
+	where = append(where,
+		// Filter out system descriptors.
+		tsql.Cmp(idCol, tsql.GT, tree.NewDInt(105)),
+		c.Where(descCol),
+	)
+
+	stmt := tree.Select{
+		Select: &tree.SelectClause{
+			Exprs: []tree.SelectExpr{
+				{
+					Expr: descJSON,
+					// Expr: tsql.UnsafeUpsertDescriptor(
+					// 	idCol,
+					// 	tsql.JSONToPB(descPB, c.Corruptor(descJSON)),
+					// 	true,
+					// ),
+				},
+			},
+			From: tree.From{
+				Tables: []tree.TableExpr{&descTbl},
+			},
+			Where: &tree.Where{
+				Type: tree.AstWhere,
+				Expr: tsql.And(where...),
+			},
+		},
+		// Limit one so we only corrupt at most 1 descriptor.
+		Limit: &tree.Limit{Count: tree.NewDInt(1)},
+	}
+
+	sr.ExecRowsAffected(t, 1, tsql.ToString(&stmt))
+}

--- a/pkg/testutils/sqlutils/tsql/BUILD.bazel
+++ b/pkg/testutils/sqlutils/tsql/BUILD.bazel
@@ -1,0 +1,29 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "tsql",
+    srcs = [
+        "crdb_internal.go",
+        "json.go",
+        "tsql.go",
+    ],
+    importpath = "github.com/cockroachdb/cockroach/pkg/testutils/sqlutils/tsql",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/sql/sem/builtins",
+        "//pkg/sql/sem/tree",
+        "//pkg/sql/sem/tree/treecmp",
+        "@com_github_cockroachdb_errors//:errors",
+    ],
+)
+
+go_test(
+    name = "tsql_test",
+    srcs = ["tsql_test.go"],
+    args = ["-test.timeout=295s"],
+    deps = [
+        ":tsql",
+        "//pkg/sql/sem/tree",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/pkg/testutils/sqlutils/tsql/crdb_internal.go
+++ b/pkg/testutils/sqlutils/tsql/crdb_internal.go
@@ -1,0 +1,25 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package tsql
+
+import "github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+
+func PBToJSON(message string, e tree.Expr) tree.Expr {
+	return Func("crdb_internal.pb_to_json", message, e)
+}
+
+func JSONToPB(message string, e tree.Expr, defaults bool) tree.Expr {
+	return Func("crdb_internal.json_to_pb", message, e, defaults)
+}
+
+func UnsafeUpsertDescriptor(id, desc tree.Expr, force bool) tree.Expr {
+	return Func("crdb_internal.unsafe_upsert_descriptor", id, desc, force)
+}

--- a/pkg/testutils/sqlutils/tsql/json.go
+++ b/pkg/testutils/sqlutils/tsql/json.go
@@ -1,0 +1,77 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package tsql
+
+import (
+	"sort"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree/treecmp"
+)
+
+func JSONArrayLength(e tree.Expr) tree.Expr {
+	return Func("json_array_length", e)
+}
+
+func JSONExtractPath(e tree.Expr, path ...string) tree.Expr {
+	exprs := make([]any, len(path)+1)
+	exprs[0] = e
+	for i, segment := range path {
+		exprs[i+1] = segment
+	}
+	return Func("json_array_length", exprs...)
+}
+
+func JSONRemovePath(e tree.Expr, path ...string) tree.Expr {
+	exprs := make([]any, len(path)+1)
+	exprs[0] = e
+	for i, segment := range path {
+		exprs[i+1] = segment
+	}
+	return Func("json_array_length", exprs...)
+}
+
+func JSONExists(e tree.Expr, path ...string) tree.Expr {
+	op := treecmp.MakeComparisonOperator(treecmp.JSONExists)
+	e = JSONExtractPath(e, path[:len(path)-1]...)
+	return Cmp(e, op, toExpr(path[len(path)-1]))
+}
+
+func JSONSet(obj tree.Expr, path []string, value tree.Expr) tree.Expr {
+	anys := make([]any, len(path))
+	for i := range path {
+		anys[i] = path[i]
+	}
+	return Func("json_set", obj, Array(anys...), value)
+}
+
+func JSONBuildArray(items ...any) tree.Expr {
+	return Func("jsonb_build_array", items...)
+}
+
+func JSONBuildObject(obj map[string]any) tree.Expr {
+	keys := make([]string, len(obj))
+	i := 0
+	for k := range obj {
+		keys[i] = k
+		i++
+	}
+
+	sort.Strings(keys)
+
+	exprs := make([]any, len(obj)*2)
+	for i, k := range keys {
+		exprs[i*2] = toExpr(k)
+		exprs[(i*2)+1] = toExpr(obj[k])
+	}
+
+	return Func("jsonb_build_object", exprs...)
+}

--- a/pkg/testutils/sqlutils/tsql/tsql.go
+++ b/pkg/testutils/sqlutils/tsql/tsql.go
@@ -1,0 +1,111 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// Package tsql (tree SQL) is a collection of helper functions to build SQL
+// queries using the tree package.
+//
+// It is intended to aid in making legible and composable query generators. It
+// should only be utilized within tests as it will panic to create a more
+// pleasant UX.
+package tsql
+
+import (
+	_ "github.com/cockroachdb/cockroach/pkg/sql/sem/builtins" // Registers builtin functions.
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree/treecmp"
+	"github.com/cockroachdb/errors"
+)
+
+var (
+	GT = treecmp.MakeComparisonOperator(treecmp.GT)
+	GE = treecmp.MakeComparisonOperator(treecmp.GE)
+	LT = treecmp.MakeComparisonOperator(treecmp.LT)
+	LE = treecmp.MakeComparisonOperator(treecmp.LE)
+)
+
+// ToString is a convenience method to convert a tree.NodeFormatter to a
+// string.
+func ToString(e tree.NodeFormatter) string {
+	fmtCtx := tree.NewFmtCtx(tree.FmtSimple)
+	e.Format(fmtCtx)
+	return fmtCtx.CloseAndGetString()
+}
+
+// Func returns a *tree.FuncExpr representing a the given function and
+// arguments. Usage:
+//
+//	Func("levenshtein", "str1", "str2")
+func Func(name string, args ...any) *tree.FuncExpr {
+	exprs := make([]tree.Expr, len(args))
+	for i, arg := range args {
+		exprs[i] = toExpr(arg)
+	}
+	return &tree.FuncExpr{
+		Func:  tree.WrapFunction(name),
+		Exprs: exprs,
+	}
+}
+
+// Cmp is a convenience method to generate *tree.ComparisonExprs.
+func Cmp(left tree.Expr, op treecmp.ComparisonOperator, right tree.Expr) *tree.ComparisonExpr {
+	return &tree.ComparisonExpr{
+		Operator: op,
+		Left:     left,
+		Right:    right,
+	}
+}
+
+// And foldl's the given expressions by combining them with tree.AndExpr's. If
+// exprs is empty, nil is returned. If exprs has a single element, it will be
+// returned unmodified.
+func And(exprs ...tree.Expr) tree.Expr {
+	if len(exprs) == 0 {
+		return nil
+	}
+
+	acc := exprs[0]
+	for i := range exprs[1:] {
+		acc = &tree.AndExpr{
+			Left:  acc,
+			Right: exprs[i+1],
+		}
+	}
+	return acc
+}
+
+func Array(values ...any) tree.Expr {
+	exprs := make([]tree.Expr, len(values))
+	for i := range values {
+		exprs[i] = toExpr(values[i])
+	}
+	return &tree.Array{Exprs: exprs}
+}
+
+func toExpr(val any) tree.Expr {
+	switch e := val.(type) {
+	case tree.Expr:
+		return e
+
+	case string:
+		return tree.NewDString(e)
+
+	case int:
+		return tree.NewDInt(tree.DInt(e))
+
+	case bool:
+		if e {
+			return tree.DBoolTrue
+		}
+		return tree.DBoolFalse
+
+	default:
+		panic(errors.AssertionFailedf("unhandled type: %T", val))
+	}
+}

--- a/pkg/testutils/sqlutils/tsql/tsql_test.go
+++ b/pkg/testutils/sqlutils/tsql/tsql_test.go
@@ -1,0 +1,42 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package tsql_test
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils/tsql"
+	"github.com/stretchr/testify/require"
+)
+
+func TestToString(t *testing.T) {
+	testCases := []struct {
+		In  tree.NodeFormatter
+		Out string
+	}{
+		{
+			In:  tsql.PBToJSON("cockroach.sql.sqlbase.Descriptor", tree.NewUnresolvedName("some_col")),
+			Out: `crdb_internal.pb_to_json('cockroach.sql.sqlbase.Descriptor', some_col)`,
+		},
+		{
+			In: tsql.And(
+				tsql.Func("levenshtein", "str1", "str2"),
+				tsql.Cmp(tree.NewDInt(1), tsql.LT, tree.NewDInt(2)),
+			),
+			Out: `levenshtein('str1', 'str2') AND (1 < 2)`,
+		},
+	}
+
+	for _, tc := range testCases {
+		require.Equal(t, tc.Out, tsql.ToString(tc.In))
+	}
+}


### PR DESCRIPTION
Previously SQL queries within test cases would be generated by `fmt.Sprint`, string concatenation, or manual construction of `tree.Expr`s. While these methods work quite well for small queries, they begin to fray as queries increase or additional flexibility is needed.

In particular, the queries required to generate descriptor corruption for the purpose of test cases are unpleasant to work with. This commit does not generate these queries but it was inspired by one that will.

To provide a better UX within tests and ease any frictions around query composition, this commit adds the `tsql` package. `tsql` (tree SQL) contains a minimally useful set of helper functions to legibly construct `tree.Expr`s and translate them into strings to be executed.

Epic: None
Release note: None