### PR TITLE
release-22:2: changefeedccl: add test to assert monotonic highwater during retries

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_dist.go
+++ b/pkg/ccl/changefeedccl/changefeed_dist.go
@@ -126,6 +126,11 @@ func distChangefeedFlow(
 		checkpoint = *cf.Checkpoint
 	}
 
+	if knobs, ok := execCtx.ExecCfg().DistSQLSrv.TestingKnobs.Changefeed.(*TestingKnobs); ok {
+		if knobs != nil && knobs.StartDistChangefeedInitialHighwater != nil {
+			knobs.StartDistChangefeedInitialHighwater(ctx, initialHighWater)
+		}
+	}
 	return startDistChangefeed(
 		ctx, execCtx, jobID, schemaTS, details, initialHighWater, checkpoint, resultsCh)
 }

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -1047,13 +1047,20 @@ func (b *changefeedResumer) resumeWithRetries(
 		// Re-load the job in order to update our progress object, which may have
 		// been updated by the changeFrontier processor since the flow started.
 		reloadedJob, reloadErr := execCfg.JobRegistry.LoadClaimedJob(ctx, jobID)
+		knobs, _ := execCfg.DistSQLSrv.TestingKnobs.Changefeed.(*TestingKnobs)
+		// NB: We don't want the knob to overwrite a non-nil reloadErr
+		// with a nil one. If we do that, we will panic trying to read
+		// the nil reloadedJob later.
+		if knobs != nil && knobs.LoadJobErr != nil && reloadErr == nil {
+			reloadErr = knobs.LoadJobErr()
+		}
 		if reloadErr != nil {
 			if ctx.Err() != nil {
 				return ctx.Err()
 			}
-			log.Warningf(ctx, `CHANGEFEED job %d could not reload job progress; `+
-				`continuing from last known high-water of %s: %v`,
-				jobID, progress.GetHighWater(), reloadErr)
+			log.Errorf(ctx, `CHANGEFEED job %d could not reload job progress;
+				marking error as job-level retry error`, jobID)
+			return jobs.MarkAsRetryJobError(err)
 		} else {
 			progress = reloadedJob.Progress()
 		}

--- a/pkg/ccl/changefeedccl/testing_knobs.go
+++ b/pkg/ccl/changefeedccl/testing_knobs.go
@@ -48,7 +48,17 @@ type TestingKnobs struct {
 	ShouldReplan func(ctx context.Context, oldPlan, newPlan *sql.PhysicalPlan) bool
 	// RaiseRetryableError is a knob used to possibly return an error.
 	RaiseRetryableError func() error
-	OverrideCursor      func(currentTime *hlc.Timestamp) string
+	// StartDistChangefeedInitialHighwater is called when starting the dist changefeed with the initial highwater
+	// of the changefeed. Note that this will be called when the changefeed starts and subsequently when the changefeed
+	// is retried.
+	StartDistChangefeedInitialHighwater func(ctx context.Context, initialHighwater hlc.Timestamp)
+	// LoadJobErr is called when the changefeed loads the job record during a retry to check for progress updates.
+	LoadJobErr func() error
+	// This is currently used to test negative timestamp in cursor i.e of the form
+	// "-3us". Check TestChangefeedCursor for more info. This function needs to be in the
+	// knobs as current statement time will only be available once the create changefeed statement
+	// starts executing.
+	OverrideCursor func(currentTime *hlc.Timestamp) string
 }
 
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.


### PR DESCRIPTION
Backport 1/1 commits from https://github.com/cockroachdb/cockroach/pull/108710

--- 

In #108450, it was discovered that there is a bug where a changefeed may retry using an out of date highwater. This bug is only in versions 23.1 and earlier. This commit adds a fix where the changefeed does not proceed if the highwater cannot be loaded from the job record. Instead, the changefeed returns an error which can be retried by the jobs system. This change also adds a regression test.

Closes: #108450
Epic: None
Release note: None

Release justification: Small bug fix.