### PR TITLE
server,log: report tenant names in logging output

### DIFF
--- a/docs/generated/logformats.md
+++ b/docs/generated/logformats.md
@@ -325,8 +325,9 @@ Additionally, the following fields are conditionally present:
 |-------|-------|-------------|
 | `N` | `node_id` | The node ID where the event was generated, once known. Only reported for single-tenant or KV servers. |
 | `x` | `cluster_id` | The cluster ID where the event was generated, once known. Only reported for single-tenant of KV servers. |
-| `q` | `instance_id` | The SQL instance ID where the event was generated, once known. Only reported for multi-tenant SQL servers. |
-| `T` | `tenant_id` | The SQL tenant ID where the event was generated, once known. Only reported for multi-tenant SQL servers. |
+| `q` | `instance_id` | The SQL instance ID where the event was generated, once known. |
+| `T` | `tenant_id` | The SQL tenant ID where the event was generated, once known. |
+| `V` | `tenant_name` | The SQL virtual cluster where the event was generated, once known. |
 | `tags` | `tags` | The logging context tags for the entry, if there were context tags. |
 | `message` | `message` | For unstructured events, the flat text payload. |
 | `event`   | `event`   | The logging event, if structured (see below for details). |

--- a/pkg/base/serverident/server_ident.go
+++ b/pkg/base/serverident/server_ident.go
@@ -69,7 +69,7 @@ type IDPayload struct {
 	// the correlation of panic reports with self-reported log files.
 	ClusterID string
 	// the node ID is reported like the cluster ID, for the same reasons.
-	// We avoid using roahcpb.NodeID to avoid a circular reference.
+	// We avoid using roachpb.NodeID to avoid a circular reference.
 	NodeID string
 	// ditto for the tenant ID.
 	TenantID string

--- a/pkg/base/serverident/server_ident.go
+++ b/pkg/base/serverident/server_ident.go
@@ -47,16 +47,6 @@ type ServerIdentificationPayload interface {
 	// given retrieval key. If there is no value known for a given key,
 	// the method can return the empty string.
 	ServerIdentityString(key ServerIdentificationKey) string
-
-	// TenantID returns the roachpb.TenantID identifying the server. It's returned
-	// as an interface{} because the log pkg cannot depend on roachpb (and the log pkg
-	// is the one putting the ServerIdentificationPayload into the ctx, so it makes
-	// sense for this interface to live in log).
-	//
-	// Note that this tenant ID should not be confused with the one put in the
-	// context by roachpb.ContextWithClientTenant(): that one is used by a server
-	// handling an RPC call, referring to the tenant that's the client of the RPC.
-	TenantID() interface{}
 }
 
 // ServerIdentificationKey represents a possible parameter to the

--- a/pkg/base/serverident/server_ident.go
+++ b/pkg/base/serverident/server_ident.go
@@ -62,6 +62,8 @@ const (
 	IdentifyInstanceID
 	// IdentifyTenantID retrieves the tenant ID of the server.
 	IdentifyTenantID
+	// IdentifyTenantLabel retrieves the tenant name of the server.
+	IdentifyTenantName
 )
 
 type IDPayload struct {
@@ -73,6 +75,8 @@ type IDPayload struct {
 	NodeID string
 	// ditto for the tenant ID.
 	TenantID string
+	// ditto for tenant name.
+	TenantName string
 	// ditto for the SQL instance ID.
 	SQLInstanceID string
 }
@@ -87,6 +91,7 @@ func GetIdentificationPayload(ctx context.Context) IDPayload {
 		NodeID:        si.ServerIdentityString(IdentifyKVNodeID),
 		SQLInstanceID: si.ServerIdentityString(IdentifyInstanceID),
 		TenantID:      si.ServerIdentityString(IdentifyTenantID),
+		TenantName:    si.ServerIdentityString(IdentifyTenantName),
 	}
 }
 

--- a/pkg/base/serverident/server_ident.go
+++ b/pkg/base/serverident/server_ident.go
@@ -72,10 +72,7 @@ type IDPayload struct {
 	// We avoid using roahcpb.NodeID to avoid a circular reference.
 	NodeID string
 	// ditto for the tenant ID.
-	//
-	// NB: Use TenantID() to access/read this value to take advantage
-	// of default behaviors.
-	TenantIDInternal string
+	TenantID string
 	// ditto for the SQL instance ID.
 	SQLInstanceID string
 }
@@ -86,16 +83,11 @@ func GetIdentificationPayload(ctx context.Context) IDPayload {
 		return IDPayload{}
 	}
 	return IDPayload{
-		ClusterID:        si.ServerIdentityString(IdentifyClusterID),
-		NodeID:           si.ServerIdentityString(IdentifyKVNodeID),
-		SQLInstanceID:    si.ServerIdentityString(IdentifyInstanceID),
-		TenantIDInternal: si.ServerIdentityString(IdentifyTenantID),
+		ClusterID:     si.ServerIdentityString(IdentifyClusterID),
+		NodeID:        si.ServerIdentityString(IdentifyKVNodeID),
+		SQLInstanceID: si.ServerIdentityString(IdentifyInstanceID),
+		TenantID:      si.ServerIdentityString(IdentifyTenantID),
 	}
-}
-
-// TenantID returns the tenant ID associated with this idPayload.
-func (ip IDPayload) TenantID() string {
-	return ip.TenantIDInternal
 }
 
 // SetSystemTenantID is used to set the string representation of

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -1048,16 +1048,7 @@ func (s *idProvider) ServerIdentityString(key serverident.ServerIdentificationKe
 		return cs
 
 	case serverident.IdentifyTenantID:
-		t := s.tenantStr.Load()
-		ts, ok := t.(string)
-		if !ok {
-			tid := s.tenantID
-			if tid.IsSet() {
-				ts = strconv.FormatUint(tid.ToUint64(), 10)
-				s.tenantStr.Store(ts)
-			}
-		}
-		return ts
+		return s.maybeMemoizeTenantID()
 
 	case serverident.IdentifyInstanceID:
 		// If tenantID is not set, this is a KV node and it has no SQL
@@ -1108,4 +1099,19 @@ func (s *idProvider) maybeMemoizeServerID() string {
 		}
 	}
 	return sis
+}
+
+// maybeMemoizeTenantID saves the representation of tenantID to
+// tenantStr if the former is initialized.
+func (s *idProvider) maybeMemoizeTenantID() string {
+	t := s.tenantStr.Load()
+	ts, ok := t.(string)
+	if !ok {
+		tid := s.tenantID
+		if tid.IsSet() {
+			ts = strconv.FormatUint(tid.ToUint64(), 10)
+			s.tenantStr.Store(ts)
+		}
+	}
+	return ts
 }

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -36,6 +36,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server/autoconfig/acprovider"
 	"github.com/cockroachdb/cockroach/pkg/server/status"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/catconstants"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/ts"
@@ -284,8 +285,9 @@ func (cfg *BaseConfig) SetDefaults(
 	cfg.Tracer = tr
 	cfg.Settings = st
 	idsProvider := &idProvider{
-		clusterID: &base.ClusterIDContainer{},
-		serverID:  &base.NodeIDContainer{},
+		clusterID:  &base.ClusterIDContainer{},
+		serverID:   &base.NodeIDContainer{},
+		tenantName: roachpb.NewTenantNameContainer(""),
 	}
 	disableWebLogin := envutil.EnvOrDefaultBool("COCKROACH_DISABLE_WEB_LOGIN", false)
 	cfg.idProvider = idsProvider
@@ -896,7 +898,8 @@ func (cfg *Config) InitNode(ctx context.Context) error {
 		cfg.GossipBootstrapAddresses = addresses
 	}
 
-	cfg.BaseConfig.idProvider.SetTenant(roachpb.SystemTenantID)
+	cfg.BaseConfig.idProvider.SetTenantID(roachpb.SystemTenantID)
+	cfg.BaseConfig.idProvider.SetTenantName(catconstants.SystemTenantName)
 
 	return nil
 }
@@ -1022,6 +1025,9 @@ type idProvider struct {
 	// tenantStr is the memoized representation of tenantID.
 	tenantStr atomic.Value
 
+	// tenantName is the tenant name container for this server.
+	tenantName *roachpb.TenantNameContainer
+
 	// serverID contains the node ID for KV nodes (when tenantID.IsSet() ==
 	// false), or the SQL instance ID for SQL-only servers (when
 	// tenantID.IsSet() == true).
@@ -1065,6 +1071,9 @@ func (s *idProvider) ServerIdentityString(key serverident.ServerIdentificationKe
 			return ""
 		}
 		return s.maybeMemoizeServerID()
+
+	case serverident.IdentifyTenantName:
+		return string(s.tenantName.Get())
 	}
 
 	return ""
@@ -1076,7 +1085,7 @@ func (s *idProvider) ServerIdentityString(key serverident.ServerIdentificationKe
 // Note: this should not be called concurrently with logging which may
 // invoke the method from the serverident.ServerIdentificationPayload
 // interface.
-func (s *idProvider) SetTenant(tenantID roachpb.TenantID) {
+func (s *idProvider) SetTenantID(tenantID roachpb.TenantID) {
 	if !tenantID.IsSet() {
 		panic("programming error: invalid tenant ID")
 	}
@@ -1084,6 +1093,13 @@ func (s *idProvider) SetTenant(tenantID roachpb.TenantID) {
 		panic("programming error: provider already set for tenant server")
 	}
 	s.tenantID = tenantID
+}
+
+func (s *idProvider) SetTenantName(tenantName roachpb.TenantName) {
+	if s.tenantName.Get() != "" {
+		panic("programming error: tenant name already set")
+	}
+	s.tenantName.Set(tenantName)
 }
 
 // maybeMemoizeServerID saves the representation of serverID to

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -1032,11 +1032,6 @@ type idProvider struct {
 
 var _ serverident.ServerIdentificationPayload = (*idProvider)(nil)
 
-// TenantID is part of the serverident.ServerIdentificationPayload interface.
-func (s *idProvider) TenantID() interface{} {
-	return s.tenantID
-}
-
 // ServerIdentityString implements the serverident.ServerIdentificationPayload interface.
 func (s *idProvider) ServerIdentityString(key serverident.ServerIdentificationKey) string {
 	switch key {

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -1410,6 +1410,19 @@ func (s *SQLServer) preStart(
 		if err := s.tenantConnect.Start(ctx); err != nil {
 			return err
 		}
+		// Propagate the tenant name to the logging context, so the name
+		// appears in logging output.
+		//
+		// Note: we only need to do this once here, because the tenant name
+		// cannot change while the service mode is active.
+		//
+		// TODO(#77336): Instead of initializing a tenant server from the ID,
+		// and only then receiving the name from KV, prefer starting from the name,
+		// configuring that early on in the context bits, then look up the ID
+		// from KV (or elsewhere).
+		if entry, _ := s.tenantConnect.TenantInfo(); entry.Name != "" {
+			s.cfg.idProvider.SetTenantName(entry.Name)
+		}
 		if err := s.startCheckService(ctx, stopper); err != nil {
 			return err
 		}

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -256,7 +256,17 @@ func newTenantServer(
 
 	// Inform the server identity provider that we're operating
 	// for a tenant server.
-	baseCfg.idProvider.SetTenant(sqlCfg.TenantID)
+	//
+	// TODO(#77336): we would like to set the tenant name here too.
+	// Unfortunately, this is not possible for now because the name is
+	// only known after the SQL server has initialized the connector (in
+	// preStart), which cannot be called yet.
+	// Instead, the tenant name is currently added to the idProvider
+	// inside preStart().
+	// The better approach would be to have the CLI flag use a name,
+	// then rely on some mechanism to retrieve the ID from the name to
+	// initialize the rest of the server.
+	baseCfg.idProvider.SetTenantID(sqlCfg.TenantID)
 	args, err := makeTenantSQLServerArgs(ctx, stopper, baseCfg, sqlCfg, tenantNameContainer, deps, serviceMode)
 	if err != nil {
 		return nil, err

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -2350,15 +2350,17 @@ func TestingMakeLoggingContexts(
 ) (sysContext, appContext context.Context) {
 	ctxSysTenant := context.Background()
 	ctxSysTenant = context.WithValue(ctxSysTenant, serverident.ServerIdentificationContextKey{}, &idProvider{
-		tenantID:  roachpb.SystemTenantID,
-		clusterID: &base.ClusterIDContainer{},
-		serverID:  &base.NodeIDContainer{},
+		tenantID:   roachpb.SystemTenantID,
+		clusterID:  &base.ClusterIDContainer{},
+		serverID:   &base.NodeIDContainer{},
+		tenantName: roachpb.NewTenantNameContainer("system"),
 	})
 	ctxAppTenant := context.Background()
 	ctxAppTenant = context.WithValue(ctxAppTenant, serverident.ServerIdentificationContextKey{}, &idProvider{
-		tenantID:  appTenantID,
-		clusterID: &base.ClusterIDContainer{},
-		serverID:  &base.NodeIDContainer{},
+		tenantID:   appTenantID,
+		clusterID:  &base.ClusterIDContainer{},
+		serverID:   &base.NodeIDContainer{},
+		tenantName: roachpb.NewTenantNameContainer(""),
 	})
 	return ctxSysTenant, ctxAppTenant
 }

--- a/pkg/sql/tenant_update.go
+++ b/pkg/sql/tenant_update.go
@@ -264,6 +264,10 @@ func (p *planner) renameTenant(
 	}
 
 	if info.ServiceMode != mtinfopb.ServiceModeNone {
+		// No name changes while there is a service mode.
+		//
+		// If this is ever allowed, the logic to update the tenant name in
+		// logging output for tenant servers must be updated as well.
 		return errors.WithHint(pgerror.Newf(pgcode.ObjectNotInPrerequisiteState,
 			"cannot rename tenant in service mode %v", info.ServiceMode),
 			"Use ALTER VIRTUAL CLUSTER STOP SERVICE before renaming a tenant.")

--- a/pkg/util/log/clog_test.go
+++ b/pkg/util/log/clog_test.go
@@ -776,10 +776,10 @@ func BenchmarkLogEntry_String(b *testing.B) {
 	ctxtags := logtags.AddTag(context.Background(), "foo", "bar")
 	entry := &logEntry{
 		IDPayload: serverident.IDPayload{
-			ClusterID:        "fooo",
-			NodeID:           "10",
-			TenantIDInternal: "12",
-			SQLInstanceID:    "9",
+			ClusterID:     "fooo",
+			NodeID:        "10",
+			TenantID:      "12",
+			SQLInstanceID: "9",
 		},
 		ts:         timeutil.Now().UnixNano(),
 		header:     false,

--- a/pkg/util/log/clog_test.go
+++ b/pkg/util/log/clog_test.go
@@ -779,6 +779,7 @@ func BenchmarkLogEntry_String(b *testing.B) {
 			ClusterID:     "fooo",
 			NodeID:        "10",
 			TenantID:      "12",
+			TenantName:    "vc42",
 			SQLInstanceID: "9",
 		},
 		ts:         timeutil.Now().UnixNano(),

--- a/pkg/util/log/format_crdb.go
+++ b/pkg/util/log/format_crdb.go
@@ -19,9 +19,13 @@ import (
 	"github.com/cockroachdb/ttycolor"
 )
 
-// TenantIDLogTagKey is the log tag key used when tagging
+// tenantIDLogTagKey is the log tag key used when tagging
 // log entries with a tenant ID.
-const TenantIDLogTagKey = 'T'
+const tenantIDLogTagKey = 'T'
+
+// tenantNameLogTagKey is the log tag key used when tagging
+// log entries with a tenant name.
+const tenantNameLogTagKey = 'V'
 
 const severityChar = "IWEF"
 

--- a/pkg/util/log/format_crdb_v2.go
+++ b/pkg/util/log/format_crdb_v2.go
@@ -247,6 +247,8 @@ Additional options recognized via ` + "`format-options`" + `:
 	return buf.String()
 }
 
+const emptyTagMarker = "-"
+
 func (f formatCrdbV2) formatEntry(entry logEntry) *buffer {
 	// Note: the prefix up to and including the logging tags
 	// needs to remain the same as in crdb-v1, so as to
@@ -256,28 +258,34 @@ func (f formatCrdbV2) formatEntry(entry logEntry) *buffer {
 	cp := f.colorProfile
 	writeCrdbHeader(buf, cp, entry.sev, entry.ch, entry.file, entry.line, entry.ts, f.loc, int(entry.gid), entry.payload.redactable)
 
+	hasTenantLabel, tenantLabelLength := checkTenantLabel(entry.TenantID, entry.TenantName)
+	hasTags := len(entry.payload.tags) > 0
+
 	// The remainder is variable-length and could exceed
 	// the static size of tmp. But we do have a best-case upper bound.
-	buf.Grow(20 + len(entry.payload.message))
+	//
+	// We optimistically count 3 times the size of entry.Tags to have
+	// one character for the key, one character for the value and one
+	// for the comma.
+	buf.Grow(len(entry.payload.tags)*3 + 20 + tenantLabelLength + len(entry.payload.message))
 
 	// Display the tags if set.
 	buf.Write(cp[ttycolor.Blue])
 	// We must always tag with tenant ID if present.
-	tID := entry.TenantID
-	if tID != "" || entry.payload.tags != nil {
+	if hasTenantLabel || hasTags {
 		buf.WriteByte('[')
-		if tID != "" {
-			writeTagToBuffer(buf, tenantIDLogTagBytePrefix, []byte(entry.TenantID))
-			if entry.payload.tags != nil {
+		if hasTenantLabel {
+			writeTenantLabel(buf, entry.TenantID, entry.TenantName)
+			if hasTags {
 				buf.WriteByte(',')
 			}
 		}
-		if entry.payload.tags != nil {
+		if hasTags {
 			entry.payload.tags.formatToBuffer(buf)
 		}
 		buf.WriteByte(']')
 	} else {
-		buf.WriteString("[-]")
+		buf.WriteString("[" + emptyTagMarker + "]")
 	}
 	buf.Write(cp[ttycolor.Reset])
 	buf.WriteByte(' ')
@@ -480,9 +488,11 @@ var (
 	v2CounterIdx               = entryREV2.SubexpIndex("counter")
 	v2ContinuationIdx          = entryREV2.SubexpIndex("continuation")
 	v2MsgIdx                   = entryREV2.SubexpIndex("msg")
-	tenantIDLogTagStringPrefix = string(TenantIDLogTagKey)
-	tenantIDLogTagBytePrefix   = []byte{TenantIDLogTagKey}
+	tenantIDLogTagBytePrefix   = []byte{tenantIDLogTagKey}
+	tenantNameLogTagBytePrefix = []byte{tenantNameLogTagKey}
 )
+
+const tenantDetailsTags = string(tenantIDLogTagKey) + string(tenantNameLogTagKey)
 
 type entryDecoderV2 struct {
 	lines           int // number of lines read from reader
@@ -602,6 +612,7 @@ func (d *entryDecoderV2) initEntryFromFirstLine(
 	entry *logpb.Entry, m entryDecoderV2Fragment,
 ) (err error) {
 	// Erase all the fields, to be sure.
+	tenantID, tenantName := m.getTenantDetails()
 	*entry = logpb.Entry{
 		Severity:   m.getSeverity(),
 		Time:       m.getTimestamp(),
@@ -611,7 +622,8 @@ func (d *entryDecoderV2) initEntryFromFirstLine(
 		Line:       m.getLine(),
 		Redactable: m.isRedactable(),
 		Tags:       m.getTags(d.sensitiveEditor),
-		TenantID:   m.getTenantID(),
+		TenantID:   tenantID,
+		TenantName: tenantName,
 		Counter:    m.getCounter(),
 	}
 	if m.isStructured() {
@@ -678,40 +690,47 @@ func (f entryDecoderV2Fragment) isRedactable() bool {
 }
 
 func (f entryDecoderV2Fragment) getTags(editor redactEditor) string {
-	tagsStr := string(f[v2TagsIdx])
-	if strings.HasPrefix(tagsStr, tenantIDLogTagStringPrefix) {
-		firstCommaIndex := strings.IndexByte(tagsStr, ',')
-		if firstCommaIndex >= 0 {
-			tagsStr = tagsStr[firstCommaIndex+1:]
-		} else {
-			tagsStr = tagsStr[len(tagsStr):]
-		}
-	}
-	switch tagsStr {
-	case "":
-		fallthrough
-	case "-":
+	origTags := f[v2TagsIdx]
+	remainingTags := skipTags(origTags, tenantDetailsTags)
+	if len(remainingTags) == 0 || bytes.Equal(origTags, []byte(emptyTagMarker)) {
 		return ""
-	default:
-		r := editor(redactablePackage{
-			msg:        []byte(tagsStr),
-			redactable: f.isRedactable(),
-		})
-		return string(r.msg)
+	}
+
+	r := editor(redactablePackage{
+		msg:        remainingTags,
+		redactable: f.isRedactable(),
+	})
+	return string(r.msg)
+}
+
+// skipTags advances tags to skip over the one-character tags
+// in skip.
+func skipTags(tags []byte, skip string) []byte {
+	for {
+		if len(tags) == 0 || len(skip) == 0 {
+			return tags
+		}
+		if tags[0] != skip[0] {
+			return tags
+		}
+		tags = tags[1:]
+		skip = skip[1:]
+		indexComma := bytes.IndexByte(tags, ',')
+		if indexComma < 0 {
+			return nil
+		}
+		tags = tags[indexComma+1:]
 	}
 }
 
-func (f entryDecoderV2Fragment) getTenantID() string {
-	out := serverident.SystemTenantID
-	switch tagsStr := string(f[v2TagsIdx]); tagsStr {
-	case "-":
-	default:
-		tags := string(f[v2TagsIdx])
-		if strings.HasPrefix(tags, tenantIDLogTagStringPrefix) {
-			out = strings.Split(tags, ",")[0][1:]
-		}
+func (f entryDecoderV2Fragment) getTenantDetails() (tenantID, tenantName string) {
+	tags := f[v2TagsIdx]
+	if bytes.Equal(tags, []byte(emptyTagMarker)) {
+		return serverident.SystemTenantID, ""
 	}
-	return out
+
+	tenantID, tenantName, _ = maybeReadTenantDetails(tags)
+	return tenantID, tenantName
 }
 
 func (f entryDecoderV2Fragment) getCounter() uint64 {

--- a/pkg/util/log/format_crdb_v2.go
+++ b/pkg/util/log/format_crdb_v2.go
@@ -263,11 +263,11 @@ func (f formatCrdbV2) formatEntry(entry logEntry) *buffer {
 	// Display the tags if set.
 	buf.Write(cp[ttycolor.Blue])
 	// We must always tag with tenant ID if present.
-	tID := entry.TenantID()
+	tID := entry.TenantID
 	if tID != "" || entry.payload.tags != nil {
 		buf.WriteByte('[')
 		if tID != "" {
-			writeTagToBuffer(buf, tenantIDLogTagBytePrefix, []byte(entry.TenantID()))
+			writeTagToBuffer(buf, tenantIDLogTagBytePrefix, []byte(entry.TenantID))
 			if entry.payload.tags != nil {
 				buf.WriteByte(',')
 			}

--- a/pkg/util/log/format_crdb_v2_test.go
+++ b/pkg/util/log/format_crdb_v2_test.go
@@ -30,13 +30,16 @@ import (
 )
 
 type testIDPayload struct {
-	tenantID string
+	tenantID   string
+	tenantName string
 }
 
 func (t testIDPayload) ServerIdentityString(key serverident.ServerIdentificationKey) string {
 	switch key {
 	case serverident.IdentifyTenantID:
 		return t.tenantID
+	case serverident.IdentifyTenantName:
+		return t.tenantName
 	default:
 		return ""
 	}
@@ -74,6 +77,10 @@ func TestFormatCrdbV2(t *testing.T) {
 	tenantCtx = logtags.AddTag(tenantCtx, "noval", nil)
 	tenantCtx = logtags.AddTag(tenantCtx, "p", "3")
 	tenantCtx = logtags.AddTag(tenantCtx, "longKey", "456")
+
+	namedTenantIDPayload := tenantIDPayload
+	namedTenantIDPayload.tenantName = "abc"
+	namedTenantCtx := context.WithValue(tenantCtx, serverident.ServerIdentificationContextKey{}, namedTenantIDPayload)
 
 	defer func(prev int) { crdbV2LongLineLen.set(prev) }(int(crdbV2LongLineLen))
 	crdbV2LongLineLen.set(1024)
@@ -148,9 +155,11 @@ func TestFormatCrdbV2(t *testing.T) {
 		}),
 		// Unstructured with long stack trace.
 		withBigStack(makeUnstructuredEntry(sysCtx, severity.ERROR, channel.HEALTH, 0, true, "hello %s", "stack")),
-		// Secondary tenant entries
+		// Secondary tenant entries.
 		makeStructuredEntry(tenantCtx, severity.INFO, channel.DEV, 0, ev),
 		makeUnstructuredEntry(tenantCtx, severity.WARNING, channel.OPS, 0, false, "hello %s", "world"),
+		makeStructuredEntry(namedTenantCtx, severity.INFO, channel.DEV, 0, ev),
+		makeUnstructuredEntry(namedTenantCtx, severity.WARNING, channel.OPS, 0, false, "hello %s", "world"),
 		// Entries with empty ctx
 		makeStructuredEntry(emptyCtx, severity.INFO, channel.DEV, 0, ev),
 		makeUnstructuredEntry(emptyCtx, severity.WARNING, channel.OPS, 0, false, "hello %s", "world"),

--- a/pkg/util/log/format_crdb_v2_test.go
+++ b/pkg/util/log/format_crdb_v2_test.go
@@ -42,10 +42,6 @@ func (t testIDPayload) ServerIdentityString(key serverident.ServerIdentification
 	}
 }
 
-func (t testIDPayload) TenantID() interface{} {
-	return nil
-}
-
 var _ serverident.ServerIdentificationPayload = (*testIDPayload)(nil)
 
 func TestFormatCrdbV2(t *testing.T) {
@@ -207,7 +203,7 @@ func TestFormatCrdbV2LongLineBreaks(t *testing.T) {
 
 		entry := logEntry{
 			IDPayload: serverident.IDPayload{
-				TenantIDInternal: "1",
+				TenantID: "1",
 			},
 			payload: entryPayload{
 				redactable: redactable,

--- a/pkg/util/log/format_json.go
+++ b/pkg/util/log/format_json.go
@@ -372,11 +372,11 @@ func (f formatJSONFull) formatEntry(entry logEntry) *buffer {
 		buf.WriteString(`":`)
 		buf.WriteString(entry.NodeID)
 	}
-	if entry.TenantID() != "" {
+	if entry.TenantID != "" {
 		buf.WriteString(`,"`)
 		buf.WriteString(jtags['T'].tags[f.tags])
 		buf.WriteString(`":`)
-		buf.WriteString(entry.TenantID())
+		buf.WriteString(entry.TenantID)
 	}
 	if entry.SQLInstanceID != "" {
 		buf.WriteString(`,"`)

--- a/pkg/util/log/format_json.go
+++ b/pkg/util/log/format_json.go
@@ -250,19 +250,22 @@ var jsonTags = map[byte]struct {
 		"The binary version with which the event was generated.", true},
 	// SQL servers in multi-tenant deployments.
 	'q': {[2]string{"q", "instance_id"},
-		"The SQL instance ID where the event was generated, once known. Only reported for multi-tenant SQL servers.", true},
-	'T': {[2]string{tenantIDLogTagStringPrefix, TenantIDLogTagKeyJSON},
-		"The SQL tenant ID where the event was generated, once known. Only reported for multi-tenant SQL servers.", true},
+		"The SQL instance ID where the event was generated, once known.", true},
+	'T': {[2]string{string(tenantIDLogTagKey), tenantIDLogTagKeyJSON},
+		"The SQL tenant ID where the event was generated, once known.", true},
+	'V': {[2]string{string(tenantNameLogTagKey), tenantNameLogTagKeyJSON},
+		"The SQL virtual cluster where the event was generated, once known.", true},
 }
 
-const serverIdentifierFields = "NxqT"
+const serverIdentifierFields = "NxqTV"
 
 type tagChoice int
 
 const (
-	tagCompact            tagChoice = 0
-	tagVerbose            tagChoice = 1
-	TenantIDLogTagKeyJSON string    = "tenant_id"
+	tagCompact              tagChoice = 0
+	tagVerbose              tagChoice = 1
+	tenantIDLogTagKeyJSON   string    = "tenant_id"
+	tenantNameLogTagKeyJSON string    = "tenant_name"
 )
 
 func (t tagChoice) String() string {
@@ -377,6 +380,13 @@ func (f formatJSONFull) formatEntry(entry logEntry) *buffer {
 		buf.WriteString(jtags['T'].tags[f.tags])
 		buf.WriteString(`":`)
 		buf.WriteString(entry.TenantID)
+	}
+	if entry.TenantName != "" {
+		buf.WriteString(`,"`)
+		buf.WriteString(jtags['V'].tags[f.tags])
+		buf.WriteString(`":"`)
+		escapeString(buf, entry.TenantName)
+		buf.WriteByte('"')
 	}
 	if entry.SQLInstanceID != "" {
 		buf.WriteString(`,"`)
@@ -528,6 +538,7 @@ type JSONEntry struct {
 	Version         string `json:"version,omitempty"`
 	InstanceID      int64  `json:"instance_id,omitempty"`
 	TenantID        int64  `json:"tenant_id,omitempty"`
+	TenantName      string `json:"tenant_name,omitempty"`
 }
 
 // JSONCompactEntry represents a JSON log entry in the compact format.
@@ -549,6 +560,7 @@ type JSONCompactEntry struct {
 	Version         string `json:"v,omitempty"`
 	InstanceID      int64  `json:"q,omitempty"`
 	TenantID        int64  `json:"T,omitempty"`
+	TenantName      string `json:"V,omitempty"`
 }
 
 // populate is a method that populates fields from the source JSONEntry
@@ -571,6 +583,7 @@ func (e *JSONEntry) populate(entry *logpb.Entry, d *entryDecoderJSON) (*redactab
 	if e.TenantID != 0 {
 		entry.TenantID = fmt.Sprint(e.TenantID)
 	}
+	entry.TenantName = e.TenantName
 
 	if e.Header == 0 {
 		entry.Severity = Severity(e.SeverityNumeric)
@@ -635,6 +648,7 @@ func (e *JSONCompactEntry) toEntry(entry *JSONEntry) {
 	entry.Version = e.Version
 	entry.InstanceID = e.InstanceID
 	entry.TenantID = e.TenantID
+	entry.TenantName = e.TenantName
 }
 
 // Decode decodes the next log entry into the provided protobuf message.

--- a/pkg/util/log/format_json_test.go
+++ b/pkg/util/log/format_json_test.go
@@ -56,8 +56,8 @@ func TestJSONFormats(t *testing.T) {
 		}(),
 		// Normal (non-header) entries.
 		{},
-		{IDPayload: serverident.IDPayload{TenantIDInternal: "1", ClusterID: "abc", NodeID: "123"}},
-		{IDPayload: serverident.IDPayload{TenantIDInternal: "456", SQLInstanceID: "123"}},
+		{IDPayload: serverident.IDPayload{TenantID: "1", ClusterID: "abc", NodeID: "123"}},
+		{IDPayload: serverident.IDPayload{TenantID: "456", SQLInstanceID: "123"}},
 		makeStructuredEntry(ctx, severity.INFO, channel.DEV, 0, &logpb.TestingStructuredLogEvent{
 			CommonEventDetails: logpb.CommonEventDetails{
 				Timestamp: 123,

--- a/pkg/util/log/format_json_test.go
+++ b/pkg/util/log/format_json_test.go
@@ -56,8 +56,8 @@ func TestJSONFormats(t *testing.T) {
 		}(),
 		// Normal (non-header) entries.
 		{},
-		{IDPayload: serverident.IDPayload{TenantID: "1", ClusterID: "abc", NodeID: "123"}},
-		{IDPayload: serverident.IDPayload{TenantID: "456", SQLInstanceID: "123"}},
+		{IDPayload: serverident.IDPayload{TenantID: "1", TenantName: "system", ClusterID: "abc", NodeID: "123"}},
+		{IDPayload: serverident.IDPayload{TenantID: "456", TenantName: "vc42", SQLInstanceID: "123"}},
 		makeStructuredEntry(ctx, severity.INFO, channel.DEV, 0, &logpb.TestingStructuredLogEvent{
 			CommonEventDetails: logpb.CommonEventDetails{
 				Timestamp: 123,

--- a/pkg/util/log/log_entry.go
+++ b/pkg/util/log/log_entry.go
@@ -327,6 +327,7 @@ func (e logEntry) convertToLegacy() (res logpb.Entry) {
 		Redactable: e.payload.redactable,
 		Message:    e.payload.message,
 		TenantID:   e.TenantID,
+		TenantName: e.TenantName,
 	}
 
 	if e.payload.tags != nil {

--- a/pkg/util/log/log_entry.go
+++ b/pkg/util/log/log_entry.go
@@ -326,7 +326,7 @@ func (e logEntry) convertToLegacy() (res logpb.Entry) {
 		Counter:    e.counter,
 		Redactable: e.payload.redactable,
 		Message:    e.payload.message,
-		TenantID:   e.TenantID(),
+		TenantID:   e.TenantID,
 	}
 
 	if e.payload.tags != nil {

--- a/pkg/util/log/logpb/log.proto
+++ b/pkg/util/log/logpb/log.proto
@@ -266,6 +266,11 @@ message Entry {
   // log entry was not found to contain any tenant ID, we default to the system
   // tenant ID.
   string tenant_id = 14 [(gogoproto.customname) = "TenantID"];
+
+  // TenantName is the tenant name that the log entry originated from. NB: if a
+  // log entry was not found to contain any tenant name, we default to the empty
+  // string.
+  string tenant_name = 15 [(gogoproto.customname) = "TenantName"];
 }
 
 // A FileDetails holds all of the particulars that can be parsed by the name of

--- a/pkg/util/log/testdata/crdb_v1
+++ b/pkg/util/log/testdata/crdb_v1
@@ -9,8 +9,8 @@ entries
 I000101 00:00:12.300000 456 somefile.go:136  2 
 I000101 00:00:12.300000 456 somefile.go:136  3 info
 # after parse:
-logpb.Entry{Severity:1, Time:946684812300000000, Goroutine:456, File:"somefile.go", Line:136, Message:"‹›", Tags:"", Counter:0x2, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1"}
-logpb.Entry{Severity:1, Time:946684812300000000, Goroutine:456, File:"somefile.go", Line:136, Message:"‹info›", Tags:"", Counter:0x3, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1"}
+logpb.Entry{Severity:1, Time:946684812300000000, Goroutine:456, File:"somefile.go", Line:136, Message:"‹›", Tags:"", Counter:0x2, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
+logpb.Entry{Severity:1, Time:946684812300000000, Goroutine:456, File:"somefile.go", Line:136, Message:"‹info›", Tags:"", Counter:0x3, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
 
 entries
 {"counter": 2, "message": "hello ‹world›", "tags": "sometags"}
@@ -19,8 +19,8 @@ entries
 I000101 00:00:12.300000 456 somefile.go:136  [sometags] 2 hello ‹world›
 I000101 00:00:12.300000 456 somefile.go:136 ⋮ 3 hello ‹world›
 # after parse:
-logpb.Entry{Severity:1, Time:946684812300000000, Goroutine:456, File:"somefile.go", Line:136, Message:"‹hello ?world?›", Tags:"‹sometags›", Counter:0x2, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1"}
-logpb.Entry{Severity:1, Time:946684812300000000, Goroutine:456, File:"somefile.go", Line:136, Message:"hello ‹world›", Tags:"", Counter:0x3, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1"}
+logpb.Entry{Severity:1, Time:946684812300000000, Goroutine:456, File:"somefile.go", Line:136, Message:"‹hello ?world?›", Tags:"‹sometags›", Counter:0x2, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
+logpb.Entry{Severity:1, Time:946684812300000000, Goroutine:456, File:"somefile.go", Line:136, Message:"hello ‹world›", Tags:"", Counter:0x3, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
 
 
 entries
@@ -32,8 +32,8 @@ line
 I000101 00:00:12.300000 456 somefile.go:136 ⋮ 3 multi-
 line
 # after parse:
-logpb.Entry{Severity:1, Time:946684812300000000, Goroutine:456, File:"somefile.go", Line:136, Message:"‹multi-›\n‹line›", Tags:"", Counter:0x2, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1"}
-logpb.Entry{Severity:1, Time:946684812300000000, Goroutine:456, File:"somefile.go", Line:136, Message:"multi-\nline", Tags:"", Counter:0x3, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1"}
+logpb.Entry{Severity:1, Time:946684812300000000, Goroutine:456, File:"somefile.go", Line:136, Message:"‹multi-›\n‹line›", Tags:"", Counter:0x2, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
+logpb.Entry{Severity:1, Time:946684812300000000, Goroutine:456, File:"somefile.go", Line:136, Message:"multi-\nline", Tags:"", Counter:0x3, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
 
 
 entries
@@ -45,9 +45,9 @@ W000101 00:00:12.300000 456 somefile.go:136  [T1234,nsql?,othertag=somevalue] 2 
 E000101 00:00:12.300000 456 somefile.go:136  [T1234,nsql?,othertag=somevalue] 3 error
 F000101 00:00:12.300000 456 somefile.go:136  [T1234,nsql?,othertag=somevalue] 4 fatal
 # after parse:
-logpb.Entry{Severity:2, Time:946684812300000000, Goroutine:456, File:"somefile.go", Line:136, Message:"‹warning›", Tags:"‹nsql?,othertag=somevalue›", Counter:0x2, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1234"}
-logpb.Entry{Severity:3, Time:946684812300000000, Goroutine:456, File:"somefile.go", Line:136, Message:"‹error›", Tags:"‹nsql?,othertag=somevalue›", Counter:0x3, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1234"}
-logpb.Entry{Severity:4, Time:946684812300000000, Goroutine:456, File:"somefile.go", Line:136, Message:"‹fatal›", Tags:"‹nsql?,othertag=somevalue›", Counter:0x4, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1234"}
+logpb.Entry{Severity:2, Time:946684812300000000, Goroutine:456, File:"somefile.go", Line:136, Message:"‹warning›", Tags:"‹nsql?,othertag=somevalue›", Counter:0x2, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1234", TenantName:""}
+logpb.Entry{Severity:3, Time:946684812300000000, Goroutine:456, File:"somefile.go", Line:136, Message:"‹error›", Tags:"‹nsql?,othertag=somevalue›", Counter:0x3, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1234", TenantName:""}
+logpb.Entry{Severity:4, Time:946684812300000000, Goroutine:456, File:"somefile.go", Line:136, Message:"‹fatal›", Tags:"‹nsql?,othertag=somevalue›", Counter:0x4, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1234", TenantName:""}
 
 subtest regression_56873
 
@@ -58,8 +58,8 @@ entries
 I000101 00:00:12.300000 456 somefile.go:136  [sometags,someothertags,nsql?] 2 foo
 I000101 00:00:12.300000 456 somefile.go:136  3 foo
 # after parse:
-logpb.Entry{Severity:1, Time:946684812300000000, Goroutine:456, File:"somefile.go", Line:136, Message:"‹foo›", Tags:"‹sometags,someothertags,nsql?›", Counter:0x2, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1"}
-logpb.Entry{Severity:1, Time:946684812300000000, Goroutine:456, File:"somefile.go", Line:136, Message:"‹foo›", Tags:"", Counter:0x3, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1"}
+logpb.Entry{Severity:1, Time:946684812300000000, Goroutine:456, File:"somefile.go", Line:136, Message:"‹foo›", Tags:"‹sometags,someothertags,nsql?›", Counter:0x2, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
+logpb.Entry{Severity:1, Time:946684812300000000, Goroutine:456, File:"somefile.go", Line:136, Message:"‹foo›", Tags:"", Counter:0x3, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
 
 subtest end
 
@@ -70,7 +70,7 @@ entries
 ----
 I000101 00:00:12.300000 456 2@somefile.go:136  2 foo
 # after parse:
-logpb.Entry{Severity:1, Time:946684812300000000, Goroutine:456, File:"somefile.go", Line:136, Message:"‹foo›", Tags:"", Counter:0x2, Redactable:true, Channel:2, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1"}
+logpb.Entry{Severity:1, Time:946684812300000000, Goroutine:456, File:"somefile.go", Line:136, Message:"‹foo›", Tags:"", Counter:0x2, Redactable:true, Channel:2, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
 
 subtest end
 
@@ -81,7 +81,7 @@ entries
 ----
 I000101 00:00:12.300000 456 somefile.go:136  [client=[1::]:2] 2 foo
 # after parse:
-logpb.Entry{Severity:1, Time:946684812300000000, Goroutine:456, File:"somefile.go", Line:136, Message:"‹foo›", Tags:"‹client=[1::]:2›", Counter:0x2, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1"}
+logpb.Entry{Severity:1, Time:946684812300000000, Goroutine:456, File:"somefile.go", Line:136, Message:"‹foo›", Tags:"‹client=[1::]:2›", Counter:0x2, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
 
 subtest end
 
@@ -96,9 +96,9 @@ I000101 00:00:12.300000 456 somefile.go:136 ⋮ 2 Structured entry: {"hello":123
 stack trace:
 foo
 # after parse:
-logpb.Entry{Severity:1, Time:946684812300000000, Goroutine:456, File:"somefile.go", Line:136, Message:"Structured entry: {\"hello\":123}", Tags:"", Counter:0x2, Redactable:true, Channel:0, StructuredEnd:0x1f, StructuredStart:0x12, StackTraceStart:0x0, TenantID:"1"}
+logpb.Entry{Severity:1, Time:946684812300000000, Goroutine:456, File:"somefile.go", Line:136, Message:"Structured entry: {\"hello\":123}", Tags:"", Counter:0x2, Redactable:true, Channel:0, StructuredEnd:0x1f, StructuredStart:0x12, StackTraceStart:0x0, TenantID:"1", TenantName:""}
 JSON payload in previous entry: map[hello:123]
-logpb.Entry{Severity:1, Time:946684812300000000, Goroutine:456, File:"somefile.go", Line:136, Message:"Structured entry: {\"hello\":123}\nstack trace:\nfoo", Tags:"", Counter:0x2, Redactable:true, Channel:0, StructuredEnd:0x1f, StructuredStart:0x12, StackTraceStart:0x20, TenantID:"1"}
+logpb.Entry{Severity:1, Time:946684812300000000, Goroutine:456, File:"somefile.go", Line:136, Message:"Structured entry: {\"hello\":123}\nstack trace:\nfoo", Tags:"", Counter:0x2, Redactable:true, Channel:0, StructuredEnd:0x1f, StructuredStart:0x12, StackTraceStart:0x20, TenantID:"1", TenantName:""}
 JSON payload in previous entry: map[hello:123]
 
 # v2 entries are not treated specially in the v1 parser.
@@ -111,8 +111,34 @@ I000101 00:00:12.300000 456 somefile.go:136 ⋮ 2  ={"hello":123}
 stack trace:
 foo
 # after parse:
-logpb.Entry{Severity:1, Time:946684812300000000, Goroutine:456, File:"somefile.go", Line:136, Message:" ={\"hello\":123}", Tags:"", Counter:0x2, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1"}
-logpb.Entry{Severity:1, Time:946684812300000000, Goroutine:456, File:"somefile.go", Line:136, Message:" ={\"hello\":123}\nstack trace:\nfoo", Tags:"", Counter:0x2, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1"}
+logpb.Entry{Severity:1, Time:946684812300000000, Goroutine:456, File:"somefile.go", Line:136, Message:" ={\"hello\":123}", Tags:"", Counter:0x2, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
+logpb.Entry{Severity:1, Time:946684812300000000, Goroutine:456, File:"somefile.go", Line:136, Message:" ={\"hello\":123}\nstack trace:\nfoo", Tags:"", Counter:0x2, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
+
+subtest end
+
+subtest tenant_details
+
+entries
+{"counter": 2, "message": "woo", "tenant_id": "123"}
+{"counter": 2, "message": "waa", "tenant_name": "abc"}
+{"counter": 2, "message": "woo", "tenant_id": "123", "tenant_name": "abc"}
+{"counter": 2, "message": "woo", "tenant_id": "123", "tags": "sometags"}
+{"counter": 2, "message": "waa", "tenant_name": "abc", "tags": "sometags"}
+{"counter": 2, "message": "woo", "tenant_id": "123", "tenant_name": "abc", "tags": "sometags"}
+----
+I000101 00:00:12.300000 456 somefile.go:136  [T123] 2 woo
+I000101 00:00:12.300000 456 somefile.go:136  2 waa
+I000101 00:00:12.300000 456 somefile.go:136  [T123,Vabc] 2 woo
+I000101 00:00:12.300000 456 somefile.go:136  [T123,sometags] 2 woo
+I000101 00:00:12.300000 456 somefile.go:136  [sometags] 2 waa
+I000101 00:00:12.300000 456 somefile.go:136  [T123,Vabc,sometags] 2 woo
+# after parse:
+logpb.Entry{Severity:1, Time:946684812300000000, Goroutine:456, File:"somefile.go", Line:136, Message:"‹woo›", Tags:"", Counter:0x2, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"123", TenantName:""}
+logpb.Entry{Severity:1, Time:946684812300000000, Goroutine:456, File:"somefile.go", Line:136, Message:"‹waa›", Tags:"", Counter:0x2, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
+logpb.Entry{Severity:1, Time:946684812300000000, Goroutine:456, File:"somefile.go", Line:136, Message:"‹woo›", Tags:"", Counter:0x2, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"123", TenantName:"abc"}
+logpb.Entry{Severity:1, Time:946684812300000000, Goroutine:456, File:"somefile.go", Line:136, Message:"‹woo›", Tags:"‹sometags›", Counter:0x2, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"123", TenantName:""}
+logpb.Entry{Severity:1, Time:946684812300000000, Goroutine:456, File:"somefile.go", Line:136, Message:"‹waa›", Tags:"‹sometags›", Counter:0x2, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
+logpb.Entry{Severity:1, Time:946684812300000000, Goroutine:456, File:"somefile.go", Line:136, Message:"‹woo›", Tags:"‹sometags›", Counter:0x2, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"123", TenantName:"abc"}
 
 subtest end
 
@@ -127,20 +153,20 @@ entries tz=america/new_york
 ----
 I691231 19:00:12.300000-050000 456 somefile.go:136  3 info
 # after parse:
-logpb.Entry{Severity:1, Time:12300000000, Goroutine:456, File:"somefile.go", Line:136, Message:"‹info›", Tags:"", Counter:0x3, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1"}
+logpb.Entry{Severity:1, Time:12300000000, Goroutine:456, File:"somefile.go", Line:136, Message:"‹info›", Tags:"", Counter:0x3, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
 
 entries tz=europe/amsterdam
 {"counter": 3, "message": "info"}
 ----
 I700101 01:00:12.300000+010000 456 somefile.go:136  3 info
 # after parse:
-logpb.Entry{Severity:1, Time:12300000000, Goroutine:456, File:"somefile.go", Line:136, Message:"‹info›", Tags:"", Counter:0x3, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1"}
+logpb.Entry{Severity:1, Time:12300000000, Goroutine:456, File:"somefile.go", Line:136, Message:"‹info›", Tags:"", Counter:0x3, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
 
 entries tz=utc
 {"counter": 3, "message": "info"}
 ----
 I700101 00:00:12.300000+000000 456 somefile.go:136  3 info
 # after parse:
-logpb.Entry{Severity:1, Time:12300000000, Goroutine:456, File:"somefile.go", Line:136, Message:"‹info›", Tags:"", Counter:0x3, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1"}
+logpb.Entry{Severity:1, Time:12300000000, Goroutine:456, File:"somefile.go", Line:136, Message:"‹info›", Tags:"", Counter:0x3, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
 
 subtest end

--- a/pkg/util/log/testdata/crdb_v2
+++ b/pkg/util/log/testdata/crdb_v2
@@ -43,6 +43,10 @@ I060102 15:04:05.654321 11 util/log/format_crdb_v2_test.go:123 ⋮ [T2,noval,p�
 #
 W060102 15:04:05.654321 11 1@util/log/format_crdb_v2_test.go:123  [T2,noval,p3,longKey=456]   hello world
 #
+I060102 15:04:05.654321 11 util/log/format_crdb_v2_test.go:123 ⋮ [T2,Vabc,noval,p‹3›,longKey=‹456›]  ={"Timestamp":123,"EventType":"rename_database","Event":"‹rename from `hello` to `world`›"}
+#
+W060102 15:04:05.654321 11 1@util/log/format_crdb_v2_test.go:123  [T2,Vabc,noval,p3,longKey=456]   hello world
+#
 I060102 15:04:05.654321 11 util/log/format_crdb_v2_test.go:123 ⋮ [-]  ={"Timestamp":123,"EventType":"rename_database","Event":"‹rename from `hello` to `world`›"}
 #
 W060102 15:04:05.654321 11 1@util/log/format_crdb_v2_test.go:123  [-]   hello world
@@ -91,6 +95,10 @@ E060102 10:04:05.654321-050000 11 2@util/log/format_crdb_v2_test.go:123 ⋮ [T1,
 I060102 10:04:05.654321-050000 11 util/log/format_crdb_v2_test.go:123 ⋮ [T2,noval,p‹3›,longKey=‹456›]  ={"Timestamp":123,"EventType":"rename_database","Event":"‹rename from `hello` to `world`›"}
 #
 W060102 10:04:05.654321-050000 11 1@util/log/format_crdb_v2_test.go:123  [T2,noval,p3,longKey=456]   hello world
+#
+I060102 10:04:05.654321-050000 11 util/log/format_crdb_v2_test.go:123 ⋮ [T2,Vabc,noval,p‹3›,longKey=‹456›]  ={"Timestamp":123,"EventType":"rename_database","Event":"‹rename from `hello` to `world`›"}
+#
+W060102 10:04:05.654321-050000 11 1@util/log/format_crdb_v2_test.go:123  [T2,Vabc,noval,p3,longKey=456]   hello world
 #
 I060102 10:04:05.654321-050000 11 util/log/format_crdb_v2_test.go:123 ⋮ [-]  ={"Timestamp":123,"EventType":"rename_database","Event":"‹rename from `hello` to `world`›"}
 #

--- a/pkg/util/log/testdata/json
+++ b/pkg/util/log/testdata/json
@@ -13,17 +13,17 @@ json-fluent-compact: {"tag":"logtest.dev","c":0,"t":"1136214245.654321000","s":0
        json-compact: {"c":0,"t":"1136214245.654321000","s":0,"g":11,"f":"","l":123,"n":0,"r":0,"message":""}
        json-compact: {"c":0,"t":"1136214245.654321000","d":"2006-01-02 xx 10:04:05+07","s":0,"g":11,"f":"","l":123,"n":0,"r":0,"message":""}
 #
-json-fluent-compact: {"tag":"logtest.dev","c":0,"t":"1136214245.654321000","x":"abc","N":123,"T":1,"s":0,"g":11,"f":"","l":123,"n":0,"r":0,"message":""}
-        json-fluent: {"tag":"logtest.dev","channel_numeric":0,"channel":"DEV","timestamp":"1136214245.654321000","cluster_id":"abc","node_id":123,"tenant_id":1,"severity_numeric":0,"severity":"UNKNOWN","goroutine":11,"file":"","line":123,"entry_counter":0,"redactable":0,"message":""}
-       json-compact: {"c":0,"t":"1136214245.654321000","x":"abc","N":123,"T":1,"s":0,"g":11,"f":"","l":123,"n":0,"r":0,"message":""}
-       json-compact: {"c":0,"t":"1136214245.654321000","x":"abc","N":123,"T":1,"s":0,"g":11,"f":"","l":123,"n":0,"r":0,"message":""}
-       json-compact: {"c":0,"t":"1136214245.654321000","d":"2006-01-02 xx 10:04:05+07","x":"abc","N":123,"T":1,"s":0,"g":11,"f":"","l":123,"n":0,"r":0,"message":""}
+json-fluent-compact: {"tag":"logtest.dev","c":0,"t":"1136214245.654321000","x":"abc","N":123,"T":1,"V":"system","s":0,"g":11,"f":"","l":123,"n":0,"r":0,"message":""}
+        json-fluent: {"tag":"logtest.dev","channel_numeric":0,"channel":"DEV","timestamp":"1136214245.654321000","cluster_id":"abc","node_id":123,"tenant_id":1,"tenant_name":"system","severity_numeric":0,"severity":"UNKNOWN","goroutine":11,"file":"","line":123,"entry_counter":0,"redactable":0,"message":""}
+       json-compact: {"c":0,"t":"1136214245.654321000","x":"abc","N":123,"T":1,"V":"system","s":0,"g":11,"f":"","l":123,"n":0,"r":0,"message":""}
+       json-compact: {"c":0,"t":"1136214245.654321000","x":"abc","N":123,"T":1,"V":"system","s":0,"g":11,"f":"","l":123,"n":0,"r":0,"message":""}
+       json-compact: {"c":0,"t":"1136214245.654321000","d":"2006-01-02 xx 10:04:05+07","x":"abc","N":123,"T":1,"V":"system","s":0,"g":11,"f":"","l":123,"n":0,"r":0,"message":""}
 #
-json-fluent-compact: {"tag":"logtest.dev","c":0,"t":"1136214245.654321000","T":456,"q":123,"s":0,"g":11,"f":"","l":123,"n":0,"r":0,"message":""}
-        json-fluent: {"tag":"logtest.dev","channel_numeric":0,"channel":"DEV","timestamp":"1136214245.654321000","tenant_id":456,"instance_id":123,"severity_numeric":0,"severity":"UNKNOWN","goroutine":11,"file":"","line":123,"entry_counter":0,"redactable":0,"message":""}
-       json-compact: {"c":0,"t":"1136214245.654321000","T":456,"q":123,"s":0,"g":11,"f":"","l":123,"n":0,"r":0,"message":""}
-       json-compact: {"c":0,"t":"1136214245.654321000","T":456,"q":123,"s":0,"g":11,"f":"","l":123,"n":0,"r":0,"message":""}
-       json-compact: {"c":0,"t":"1136214245.654321000","d":"2006-01-02 xx 10:04:05+07","T":456,"q":123,"s":0,"g":11,"f":"","l":123,"n":0,"r":0,"message":""}
+json-fluent-compact: {"tag":"logtest.dev","c":0,"t":"1136214245.654321000","T":456,"V":"vc42","q":123,"s":0,"g":11,"f":"","l":123,"n":0,"r":0,"message":""}
+        json-fluent: {"tag":"logtest.dev","channel_numeric":0,"channel":"DEV","timestamp":"1136214245.654321000","tenant_id":456,"tenant_name":"vc42","instance_id":123,"severity_numeric":0,"severity":"UNKNOWN","goroutine":11,"file":"","line":123,"entry_counter":0,"redactable":0,"message":""}
+       json-compact: {"c":0,"t":"1136214245.654321000","T":456,"V":"vc42","q":123,"s":0,"g":11,"f":"","l":123,"n":0,"r":0,"message":""}
+       json-compact: {"c":0,"t":"1136214245.654321000","T":456,"V":"vc42","q":123,"s":0,"g":11,"f":"","l":123,"n":0,"r":0,"message":""}
+       json-compact: {"c":0,"t":"1136214245.654321000","d":"2006-01-02 xx 10:04:05+07","T":456,"V":"vc42","q":123,"s":0,"g":11,"f":"","l":123,"n":0,"r":0,"message":""}
 #
 json-fluent-compact: {"tag":"logtest.dev","c":0,"t":"1136214245.654321000","T":1,"v":"v999.0.0","s":1,"sev":"I","g":11,"f":"util/log/format_json_test.go","l":123,"n":0,"r":1,"tags":{"noval":"","s":"‹1›","long":"‹2›"},"event":{"Timestamp":123,"EventType":"rename_database","Event":"‹rename from `hello` to `world`›"}}
         json-fluent: {"tag":"logtest.dev","channel_numeric":0,"channel":"DEV","timestamp":"1136214245.654321000","tenant_id":1,"version":"v999.0.0","severity_numeric":1,"severity":"INFO","goroutine":11,"file":"util/log/format_json_test.go","line":123,"entry_counter":0,"redactable":1,"tags":{"noval":"","s":"‹1›","long":"‹2›"},"event":{"Timestamp":123,"EventType":"rename_database","Event":"‹rename from `hello` to `world`›"}}

--- a/pkg/util/log/testdata/parse
+++ b/pkg/util/log/testdata/parse
@@ -3,17 +3,32 @@ subtest single_line_no_tenant_tag
 log
 I210116 21:49:17.073282 14 server/node.go:464 ⋮ [-] 23  started with engine type ‹2›
 ----
-logpb.Entry{Severity:1, Time:1610833757073282000, Goroutine:14, File:"server/node.go", Line:464, Message:"started with engine type ‹2›", Tags:"", Counter:0x17, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1"}
+logpb.Entry{Severity:1, Time:1610833757073282000, Goroutine:14, File:"server/node.go", Line:464, Message:"started with engine type ‹2›", Tags:"", Counter:0x17, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
+
+log
+I210116 21:49:17.073282 14 server/node.go:464 ⋮ [unrelated] 23  started with engine type ‹2›
+----
+logpb.Entry{Severity:1, Time:1610833757073282000, Goroutine:14, File:"server/node.go", Line:464, Message:"started with engine type ‹2›", Tags:"unrelated", Counter:0x17, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
 
 log
 I210116 21:49:17.073282 14 server/node.go:464 ⋮ [T1] 23  started with engine type ‹2›
 ----
-logpb.Entry{Severity:1, Time:1610833757073282000, Goroutine:14, File:"server/node.go", Line:464, Message:"started with engine type ‹2›", Tags:"", Counter:0x17, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1"}
+logpb.Entry{Severity:1, Time:1610833757073282000, Goroutine:14, File:"server/node.go", Line:464, Message:"started with engine type ‹2›", Tags:"", Counter:0x17, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
 
 log
 I210116 21:49:17.073282 14 server/node.go:464 ⋮ [T12345] 23  started with engine type ‹2›
 ----
-logpb.Entry{Severity:1, Time:1610833757073282000, Goroutine:14, File:"server/node.go", Line:464, Message:"started with engine type ‹2›", Tags:"", Counter:0x17, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"12345"}
+logpb.Entry{Severity:1, Time:1610833757073282000, Goroutine:14, File:"server/node.go", Line:464, Message:"started with engine type ‹2›", Tags:"", Counter:0x17, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"12345", TenantName:""}
+
+log
+I210116 21:49:17.073282 14 server/node.go:464 ⋮ [Vabc] 23  started with engine type ‹2›
+----
+logpb.Entry{Severity:1, Time:1610833757073282000, Goroutine:14, File:"server/node.go", Line:464, Message:"started with engine type ‹2›", Tags:"Vabc", Counter:0x17, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
+
+log
+I210116 21:49:17.073282 14 server/node.go:464 ⋮ [T123,Vabc] 23  started with engine type ‹2›
+----
+logpb.Entry{Severity:1, Time:1610833757073282000, Goroutine:14, File:"server/node.go", Line:464, Message:"started with engine type ‹2›", Tags:"", Counter:0x17, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"123", TenantName:"abc"}
 
 subtest end
 
@@ -22,12 +37,12 @@ subtest single_line_unstructured_entry
 log
 I210116 21:49:17.073282 14 server/node.go:464 ⋮ [T1] 23  started with engine type ‹2›
 ----
-logpb.Entry{Severity:1, Time:1610833757073282000, Goroutine:14, File:"server/node.go", Line:464, Message:"started with engine type ‹2›", Tags:"", Counter:0x17, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1"}
+logpb.Entry{Severity:1, Time:1610833757073282000, Goroutine:14, File:"server/node.go", Line:464, Message:"started with engine type ‹2›", Tags:"", Counter:0x17, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
 
 log
 I210116 21:49:17.073282 14 (gostd) server/node.go:464 ⋮ [T1] 23  started with engine type ‹2›
 ----
-logpb.Entry{Severity:1, Time:1610833757073282000, Goroutine:14, File:"server/node.go", Line:464, Message:"started with engine type ‹2›", Tags:"", Counter:0x17, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1"}
+logpb.Entry{Severity:1, Time:1610833757073282000, Goroutine:14, File:"server/node.go", Line:464, Message:"started with engine type ‹2›", Tags:"", Counter:0x17, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
 
 subtest end
 
@@ -37,14 +52,14 @@ log
 I210116 21:49:17.083093 14 1@cli/start.go:690 ⋮ [T1] 40  node startup completed:
 I210116 21:49:17.083093 14 1@cli/start.go:690 ⋮ [T1] 40 +CockroachDB node starting at 2021-01-16 21:49 (took 0.0s)
 ----
-logpb.Entry{Severity:1, Time:1610833757083093000, Goroutine:14, File:"cli/start.go", Line:690, Message:"node startup completed:\nCockroachDB node starting at 2021-01-16 21:49 (took 0.0s)", Tags:"", Counter:0x28, Redactable:true, Channel:1, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1"}
+logpb.Entry{Severity:1, Time:1610833757083093000, Goroutine:14, File:"cli/start.go", Line:690, Message:"node startup completed:\nCockroachDB node starting at 2021-01-16 21:49 (took 0.0s)", Tags:"", Counter:0x28, Redactable:true, Channel:1, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
 
 log
 I210116 21:49:17.083093 14 1@cli/start.go:690 ⋮ [T1] 40  node startup completed:
 I210116 21:49:17.083093 14 1@cli/start.go:690 ⋮ [T1] 40 +CockroachDB node starting at 2021-01-16 21:49 (took 0.0s)
 I210116 21:49:17.083093 14 1@cli/start.go:690 ⋮ [T1] 40 +build:               CCL v21.1.1 @ 2021/5/24 11:00:26 (go1.15.5) (go1.12.6)
 ----
-logpb.Entry{Severity:1, Time:1610833757083093000, Goroutine:14, File:"cli/start.go", Line:690, Message:"node startup completed:\nCockroachDB node starting at 2021-01-16 21:49 (took 0.0s)\nbuild:               CCL v21.1.1 @ 2021/5/24 11:00:26 (go1.15.5) (go1.12.6)", Tags:"", Counter:0x28, Redactable:true, Channel:1, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1"}
+logpb.Entry{Severity:1, Time:1610833757083093000, Goroutine:14, File:"cli/start.go", Line:690, Message:"node startup completed:\nCockroachDB node starting at 2021-01-16 21:49 (took 0.0s)\nbuild:               CCL v21.1.1 @ 2021/5/24 11:00:26 (go1.15.5) (go1.12.6)", Tags:"", Counter:0x28, Redactable:true, Channel:1, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
 
 subtest end
 
@@ -53,7 +68,7 @@ subtest structured_entry
 log
 I210116 21:49:17.080713 14 1@util/log/event_log.go:32 ⋮ [T1] 32 ={"Timestamp":1610833757080706620,"EventType":"node_restart"}
 ----
-logpb.Entry{Severity:1, Time:1610833757080713000, Goroutine:14, File:"util/log/event_log.go", Line:32, Message:"{\"Timestamp\":1610833757080706620,\"EventType\":\"node_restart\"}", Tags:"", Counter:0x20, Redactable:true, Channel:1, StructuredEnd:0x3c, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1"}
+logpb.Entry{Severity:1, Time:1610833757080713000, Goroutine:14, File:"util/log/event_log.go", Line:32, Message:"{\"Timestamp\":1610833757080706620,\"EventType\":\"node_restart\"}", Tags:"", Counter:0x20, Redactable:true, Channel:1, StructuredEnd:0x3c, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
 
 subtest end
 
@@ -63,14 +78,14 @@ log
 I210116 21:49:17.073282 14 server/node.go:464 ⋮ [T1] 23  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 I210116 21:49:17.073282 14 server/node.go:464 ⋮ [T1] 23 |aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 ----
-logpb.Entry{Severity:1, Time:1610833757073282000, Goroutine:14, File:"server/node.go", Line:464, Message:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", Tags:"", Counter:0x17, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1"}
+logpb.Entry{Severity:1, Time:1610833757073282000, Goroutine:14, File:"server/node.go", Line:464, Message:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", Tags:"", Counter:0x17, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
 
 log
 I210116 21:49:17.073282 14 server/node.go:464 ⋮ [T1] 23  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 I210116 21:49:17.073282 14 server/node.go:464 ⋮ [T1] 23 |aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 I210116 21:49:17.073282 14 server/node.go:464 ⋮ [T1] 23 |aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 ----
-logpb.Entry{Severity:1, Time:1610833757073282000, Goroutine:14, File:"server/node.go", Line:464, Message:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", Tags:"", Counter:0x17, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1"}
+logpb.Entry{Severity:1, Time:1610833757073282000, Goroutine:14, File:"server/node.go", Line:464, Message:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", Tags:"", Counter:0x17, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
 
 log
 I210116 21:49:17.083093 14 1@cli/start.go:690 ⋮ [T1] 40  node startup
@@ -78,13 +93,13 @@ I210116 21:49:17.083093 14 1@cli/start.go:690 ⋮ [T1] 40 | completed:
 I210116 21:49:17.083093 14 1@cli/start.go:690 ⋮ [T1] 40 +CockroachDB node starting at
 I210116 21:49:17.083093 14 1@cli/start.go:690 ⋮ [T1] 40 | 2021-01-16 21:49 (took 0.0s)
 ----
-logpb.Entry{Severity:1, Time:1610833757083093000, Goroutine:14, File:"cli/start.go", Line:690, Message:"node startup completed:\nCockroachDB node starting at 2021-01-16 21:49 (took 0.0s)", Tags:"", Counter:0x28, Redactable:true, Channel:1, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1"}
+logpb.Entry{Severity:1, Time:1610833757083093000, Goroutine:14, File:"cli/start.go", Line:690, Message:"node startup completed:\nCockroachDB node starting at 2021-01-16 21:49 (took 0.0s)", Tags:"", Counter:0x28, Redactable:true, Channel:1, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
 
 log
 I210116 21:49:17.080713 14 1@util/log/event_log.go:32 ⋮ [T1] 32 ={"Timestamp":1610833757080706620,"EventTy
 I210116 21:49:17.080713 14 1@util/log/event_log.go:32 ⋮ [T1] 32 |pe":"node_restart"}
 ----
-logpb.Entry{Severity:1, Time:1610833757080713000, Goroutine:14, File:"util/log/event_log.go", Line:32, Message:"{\"Timestamp\":1610833757080706620,\"EventType\":\"node_restart\"}", Tags:"", Counter:0x20, Redactable:true, Channel:1, StructuredEnd:0x3c, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1"}
+logpb.Entry{Severity:1, Time:1610833757080713000, Goroutine:14, File:"util/log/event_log.go", Line:32, Message:"{\"Timestamp\":1610833757080706620,\"EventType\":\"node_restart\"}", Tags:"", Counter:0x20, Redactable:true, Channel:1, StructuredEnd:0x3c, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
 
 subtest end
 
@@ -94,34 +109,34 @@ log
 E060102 15:04:05.654321 11 2@util/log/format_crdb_v2_test.go:123 ⋮ [T1,noval,s‹1›,long=‹2›] 23  hello ‹stack›
 E060102 15:04:05.654321 11 2@util/log/format_crdb_v2_test.go:123 ⋮ [T1,noval,s‹1›,long=‹2›] 23 !this is a fake stack
 ----
-logpb.Entry{Severity:3, Time:1136214245654321000, Goroutine:11, File:"util/log/format_crdb_v2_test.go", Line:123, Message:"hello ‹stack›\nstack trace:\nthis is a fake stack", Tags:"noval,s‹1›,long=‹2›", Counter:0x17, Redactable:true, Channel:2, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x12, TenantID:"1"}
+logpb.Entry{Severity:3, Time:1136214245654321000, Goroutine:11, File:"util/log/format_crdb_v2_test.go", Line:123, Message:"hello ‹stack›\nstack trace:\nthis is a fake stack", Tags:"noval,s‹1›,long=‹2›", Counter:0x17, Redactable:true, Channel:2, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x12, TenantID:"1", TenantName:""}
 
 log
 E060102 15:04:05.654321 11 2@util/log/format_crdb_v2_test.go:123 ⋮ [T1,noval,s‹1›,long=‹2›] 23  hello ‹stack›
 E060102 15:04:05.654321 11 2@util/log/format_crdb_v2_test.go:123 ⋮ [T1,noval,s‹1›,long=‹2›] 23 !this is a longer
 E060102 15:04:05.654321 11 2@util/log/format_crdb_v2_test.go:123 ⋮ [T1,noval,s‹1›,long=‹2›] 23 !fake stack
 ----
-logpb.Entry{Severity:3, Time:1136214245654321000, Goroutine:11, File:"util/log/format_crdb_v2_test.go", Line:123, Message:"hello ‹stack›\nstack trace:\nthis is a longer\nfake stack", Tags:"noval,s‹1›,long=‹2›", Counter:0x17, Redactable:true, Channel:2, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x12, TenantID:"1"}
+logpb.Entry{Severity:3, Time:1136214245654321000, Goroutine:11, File:"util/log/format_crdb_v2_test.go", Line:123, Message:"hello ‹stack›\nstack trace:\nthis is a longer\nfake stack", Tags:"noval,s‹1›,long=‹2›", Counter:0x17, Redactable:true, Channel:2, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x12, TenantID:"1", TenantName:""}
 
 log
 I210116 21:49:17.080713 14 1@util/log/event_log.go:32 ⋮ [T1] 32 ={"Timestamp":1610833757080706620,"EventType":"node_restart"}
 I210116 21:49:17.080713 14 1@util/log/event_log.go:32 ⋮ [T1] 32 !this is a fake stack
 ----
-logpb.Entry{Severity:1, Time:1610833757080713000, Goroutine:14, File:"util/log/event_log.go", Line:32, Message:"{\"Timestamp\":1610833757080706620,\"EventType\":\"node_restart\"}\nstack trace:\nthis is a fake stack", Tags:"", Counter:0x20, Redactable:true, Channel:1, StructuredEnd:0x3c, StructuredStart:0x0, StackTraceStart:0x3d, TenantID:"1"}
+logpb.Entry{Severity:1, Time:1610833757080713000, Goroutine:14, File:"util/log/event_log.go", Line:32, Message:"{\"Timestamp\":1610833757080706620,\"EventType\":\"node_restart\"}\nstack trace:\nthis is a fake stack", Tags:"", Counter:0x20, Redactable:true, Channel:1, StructuredEnd:0x3c, StructuredStart:0x0, StackTraceStart:0x3d, TenantID:"1", TenantName:""}
 
 log
 I060102 15:04:05.654321 11 util/log/format_crdb_v2_test.go:123 ⋮ [T1,noval,s‹1›,long=‹2›] 23  maybe ‹multi›
 I060102 15:04:05.654321 11 util/log/format_crdb_v2_test.go:123 ⋮ [T1,noval,s‹1›,long=‹2›] 23 +‹line with stack›
 I060102 15:04:05.654321 11 util/log/format_crdb_v2_test.go:123 ⋮ [T1,noval,s‹1›,long=‹2›] 23 !this is a fake stack
 ----
-logpb.Entry{Severity:1, Time:1136214245654321000, Goroutine:11, File:"util/log/format_crdb_v2_test.go", Line:123, Message:"maybe ‹multi›\n‹line with stack›\nstack trace:\nthis is a fake stack", Tags:"noval,s‹1›,long=‹2›", Counter:0x17, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x28, TenantID:"1"}
+logpb.Entry{Severity:1, Time:1136214245654321000, Goroutine:11, File:"util/log/format_crdb_v2_test.go", Line:123, Message:"maybe ‹multi›\n‹line with stack›\nstack trace:\nthis is a fake stack", Tags:"noval,s‹1›,long=‹2›", Counter:0x17, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x28, TenantID:"1", TenantName:""}
 
 log
 E060102 15:04:05.654321 11 2@util/log/format_crdb_v2_test.go:123 ⋮ [T1,noval,s‹1›,long=‹2›] 23  hello ‹stack›
 E060102 15:04:05.654321 11 2@util/log/format_crdb_v2_test.go:123 ⋮ [T1,noval,s‹1›,long=‹2›] 23 !this is aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 E060102 15:04:05.654321 11 2@util/log/format_crdb_v2_test.go:123 ⋮ [T1,noval,s‹1›,long=‹2›] 23 |aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa fake stack
 ----
-logpb.Entry{Severity:3, Time:1136214245654321000, Goroutine:11, File:"util/log/format_crdb_v2_test.go", Line:123, Message:"hello ‹stack›\nstack trace:\nthis is aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa fake stack", Tags:"noval,s‹1›,long=‹2›", Counter:0x17, Redactable:true, Channel:2, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x12, TenantID:"1"}
+logpb.Entry{Severity:3, Time:1136214245654321000, Goroutine:11, File:"util/log/format_crdb_v2_test.go", Line:123, Message:"hello ‹stack›\nstack trace:\nthis is aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa fake stack", Tags:"noval,s‹1›,long=‹2›", Counter:0x17, Redactable:true, Channel:2, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x12, TenantID:"1", TenantName:""}
 
 subtest end
 
@@ -130,52 +145,52 @@ subtest empty_fields
 log
 E060102 15:04:05.654321 11 2@util/log/format_crdb_v2_test.go:123 ⋮ [T1,noval,s‹1›,long=‹2›]   hello ‹world›
 ----
-logpb.Entry{Severity:3, Time:1136214245654321000, Goroutine:11, File:"util/log/format_crdb_v2_test.go", Line:123, Message:"hello ‹world›", Tags:"noval,s‹1›,long=‹2›", Counter:0x0, Redactable:true, Channel:2, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1"}
+logpb.Entry{Severity:3, Time:1136214245654321000, Goroutine:11, File:"util/log/format_crdb_v2_test.go", Line:123, Message:"hello ‹world›", Tags:"noval,s‹1›,long=‹2›", Counter:0x0, Redactable:true, Channel:2, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
 
 log
 I060102 15:04:05.654321 11 util/log/format_crdb_v2_test.go:123 ⋮ [T1,noval,s‹1›,long=‹2›]   hello ‹world›
 ----
-logpb.Entry{Severity:1, Time:1136214245654321000, Goroutine:11, File:"util/log/format_crdb_v2_test.go", Line:123, Message:"hello ‹world›", Tags:"noval,s‹1›,long=‹2›", Counter:0x0, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1"}
+logpb.Entry{Severity:1, Time:1136214245654321000, Goroutine:11, File:"util/log/format_crdb_v2_test.go", Line:123, Message:"hello ‹world›", Tags:"noval,s‹1›,long=‹2›", Counter:0x0, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
 
 log
 I060102 15:04:05.654321 11 util/log/format_crdb_v2_test.go:123 ⋮ [T1,noval,s‹1›,long=‹2›]   maybe ‹multi›
 I060102 15:04:05.654321 11 util/log/format_crdb_v2_test.go:123 ⋮ [T1,noval,s‹1›,long=‹2›]  +‹line›
 ----
-logpb.Entry{Severity:1, Time:1136214245654321000, Goroutine:11, File:"util/log/format_crdb_v2_test.go", Line:123, Message:"maybe ‹multi›\n‹line›", Tags:"noval,s‹1›,long=‹2›", Counter:0x0, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1"}
+logpb.Entry{Severity:1, Time:1136214245654321000, Goroutine:11, File:"util/log/format_crdb_v2_test.go", Line:123, Message:"maybe ‹multi›\n‹line›", Tags:"noval,s‹1›,long=‹2›", Counter:0x0, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
 
 log
 I060102 15:04:05.654321 11 util/log/format_crdb_v2_test.go:123 ⋮ [T1,noval,s‹1›,long=‹2›]  ={"Timestamp":123,"EventType":"rename_database","DatabaseName":"‹hello›","NewDatabaseName":"‹world›"}
 ----
-logpb.Entry{Severity:1, Time:1136214245654321000, Goroutine:11, File:"util/log/format_crdb_v2_test.go", Line:123, Message:"{\"Timestamp\":123,\"EventType\":\"rename_database\",\"DatabaseName\":\"‹hello›\",\"NewDatabaseName\":\"‹world›\"}", Tags:"noval,s‹1›,long=‹2›", Counter:0x0, Redactable:true, Channel:0, StructuredEnd:0x6c, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1"}
+logpb.Entry{Severity:1, Time:1136214245654321000, Goroutine:11, File:"util/log/format_crdb_v2_test.go", Line:123, Message:"{\"Timestamp\":123,\"EventType\":\"rename_database\",\"DatabaseName\":\"‹hello›\",\"NewDatabaseName\":\"‹world›\"}", Tags:"noval,s‹1›,long=‹2›", Counter:0x0, Redactable:true, Channel:0, StructuredEnd:0x6c, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
 
 log
 I060102 15:04:05.654321 11 util/log/format_crdb_v2_test.go:123 ⋮ [T1,noval,s‹1›,long=‹2›]  ={"Timestamp":123,"EventType":"rename_database","DatabaseName":"‹aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa›
 I060102 15:04:05.654321 11 util/log/format_crdb_v2_test.go:123 ⋮ [T1,noval,s‹1›,long=‹2›]  |‹aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa›"}
 ----
-logpb.Entry{Severity:1, Time:1136214245654321000, Goroutine:11, File:"util/log/format_crdb_v2_test.go", Line:123, Message:"{\"Timestamp\":123,\"EventType\":\"rename_database\",\"DatabaseName\":\"‹aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa›‹aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa›\"}", Tags:"noval,s‹1›,long=‹2›", Counter:0x0, Redactable:true, Channel:0, StructuredEnd:0x91, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1"}
+logpb.Entry{Severity:1, Time:1136214245654321000, Goroutine:11, File:"util/log/format_crdb_v2_test.go", Line:123, Message:"{\"Timestamp\":123,\"EventType\":\"rename_database\",\"DatabaseName\":\"‹aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa›‹aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa›\"}", Tags:"noval,s‹1›,long=‹2›", Counter:0x0, Redactable:true, Channel:0, StructuredEnd:0x91, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
 
 log
 I060102 15:04:05.654321 11 util/log/format_crdb_v2_test.go:123 ⋮ [T1,noval,s‹1›,long=‹2›]  ={"Timestamp":123,"EventType":"rename_database","DatabaseName":"‹hello›","NewDatabaseName":"‹world›"}
 I060102 15:04:05.654321 11 util/log/format_crdb_v2_test.go:123 ⋮ [T1,noval,s‹1›,long=‹2›]  !this is a fake stack
 ----
-logpb.Entry{Severity:1, Time:1136214245654321000, Goroutine:11, File:"util/log/format_crdb_v2_test.go", Line:123, Message:"{\"Timestamp\":123,\"EventType\":\"rename_database\",\"DatabaseName\":\"‹hello›\",\"NewDatabaseName\":\"‹world›\"}\nstack trace:\nthis is a fake stack", Tags:"noval,s‹1›,long=‹2›", Counter:0x0, Redactable:true, Channel:0, StructuredEnd:0x6c, StructuredStart:0x0, StackTraceStart:0x6d, TenantID:"1"}
+logpb.Entry{Severity:1, Time:1136214245654321000, Goroutine:11, File:"util/log/format_crdb_v2_test.go", Line:123, Message:"{\"Timestamp\":123,\"EventType\":\"rename_database\",\"DatabaseName\":\"‹hello›\",\"NewDatabaseName\":\"‹world›\"}\nstack trace:\nthis is a fake stack", Tags:"noval,s‹1›,long=‹2›", Counter:0x0, Redactable:true, Channel:0, StructuredEnd:0x6c, StructuredStart:0x0, StackTraceStart:0x6d, TenantID:"1", TenantName:""}
 
 log
 W060102 15:04:05.654321 11 1@util/log/format_crdb_v2_test.go:123  [T1,noval,s1,long=2]   hello world
 ----
-logpb.Entry{Severity:2, Time:1136214245654321000, Goroutine:11, File:"util/log/format_crdb_v2_test.go", Line:123, Message:"‹hello world›", Tags:"‹noval,s1,long=2›", Counter:0x0, Redactable:true, Channel:1, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1"}
+logpb.Entry{Severity:2, Time:1136214245654321000, Goroutine:11, File:"util/log/format_crdb_v2_test.go", Line:123, Message:"‹hello world›", Tags:"‹noval,s1,long=2›", Counter:0x0, Redactable:true, Channel:1, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
 
 log
 I060102 15:04:05.654321 11 util/log/format_crdb_v2_test.go:123  [T1,noval,s1,long=2]   maybe multi
 I060102 15:04:05.654321 11 util/log/format_crdb_v2_test.go:123  [T1,noval,s1,long=2]  +line
 ----
-logpb.Entry{Severity:1, Time:1136214245654321000, Goroutine:11, File:"util/log/format_crdb_v2_test.go", Line:123, Message:"‹maybe multi›\n‹line›", Tags:"‹noval,s1,long=2›", Counter:0x0, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1"}
+logpb.Entry{Severity:1, Time:1136214245654321000, Goroutine:11, File:"util/log/format_crdb_v2_test.go", Line:123, Message:"‹maybe multi›\n‹line›", Tags:"‹noval,s1,long=2›", Counter:0x0, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
 
 log
 I060102 15:04:05.654321 11 util/log/format_crdb_v2_test.go:123  [T1,noval,s1,long=2]   aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 I060102 15:04:05.654321 11 util/log/format_crdb_v2_test.go:123  [T1,noval,s1,long=2]  |aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 ----
-logpb.Entry{Severity:1, Time:1136214245654321000, Goroutine:11, File:"util/log/format_crdb_v2_test.go", Line:123, Message:"‹aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa›", Tags:"‹noval,s1,long=2›", Counter:0x0, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1"}
+logpb.Entry{Severity:1, Time:1136214245654321000, Goroutine:11, File:"util/log/format_crdb_v2_test.go", Line:123, Message:"‹aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa›", Tags:"‹noval,s1,long=2›", Counter:0x0, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
 
 subtest end
 
@@ -185,16 +200,16 @@ log
 E060102 15:04:05.654321 11 2@util/log/format_crdb_v2_test.go:123 ⋮ [T1,noval,s‹1›,long=‹2›] 23  hello ‹world›
 I060102 15:04:05.654321 11 util/log/format_crdb_v2_test.go:123 ⋮ [T1,noval,s‹1›,long=‹2›] 24 ={"Timestamp":123,"EventType":"rename_database","DatabaseName":"‹hello›","NewDatabaseName":"‹world›"}
 ----
-logpb.Entry{Severity:3, Time:1136214245654321000, Goroutine:11, File:"util/log/format_crdb_v2_test.go", Line:123, Message:"hello ‹world›", Tags:"noval,s‹1›,long=‹2›", Counter:0x17, Redactable:true, Channel:2, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1"}
-logpb.Entry{Severity:1, Time:1136214245654321000, Goroutine:11, File:"util/log/format_crdb_v2_test.go", Line:123, Message:"{\"Timestamp\":123,\"EventType\":\"rename_database\",\"DatabaseName\":\"‹hello›\",\"NewDatabaseName\":\"‹world›\"}", Tags:"noval,s‹1›,long=‹2›", Counter:0x18, Redactable:true, Channel:0, StructuredEnd:0x6c, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1"}
+logpb.Entry{Severity:3, Time:1136214245654321000, Goroutine:11, File:"util/log/format_crdb_v2_test.go", Line:123, Message:"hello ‹world›", Tags:"noval,s‹1›,long=‹2›", Counter:0x17, Redactable:true, Channel:2, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
+logpb.Entry{Severity:1, Time:1136214245654321000, Goroutine:11, File:"util/log/format_crdb_v2_test.go", Line:123, Message:"{\"Timestamp\":123,\"EventType\":\"rename_database\",\"DatabaseName\":\"‹hello›\",\"NewDatabaseName\":\"‹world›\"}", Tags:"noval,s‹1›,long=‹2›", Counter:0x18, Redactable:true, Channel:0, StructuredEnd:0x6c, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
 
 log
 I060102 15:04:05.654321 11 util/log/format_crdb_v2_test.go:123 ⋮ [T1,noval,s‹1›,long=‹2›] 23  maybe ‹multi›
 I060102 15:04:05.654321 11 util/log/format_crdb_v2_test.go:123 ⋮ [T1,noval,s‹1›,long=‹2›] 23 +‹line›
 E060102 15:04:05.654321 11 2@util/log/format_crdb_v2_test.go:123 ⋮ [T1,noval,s‹1›,long=‹2›] 24  hello ‹world›
 ----
-logpb.Entry{Severity:1, Time:1136214245654321000, Goroutine:11, File:"util/log/format_crdb_v2_test.go", Line:123, Message:"maybe ‹multi›\n‹line›", Tags:"noval,s‹1›,long=‹2›", Counter:0x17, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1"}
-logpb.Entry{Severity:3, Time:1136214245654321000, Goroutine:11, File:"util/log/format_crdb_v2_test.go", Line:123, Message:"hello ‹world›", Tags:"noval,s‹1›,long=‹2›", Counter:0x18, Redactable:true, Channel:2, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1"}
+logpb.Entry{Severity:1, Time:1136214245654321000, Goroutine:11, File:"util/log/format_crdb_v2_test.go", Line:123, Message:"maybe ‹multi›\n‹line›", Tags:"noval,s‹1›,long=‹2›", Counter:0x17, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
+logpb.Entry{Severity:3, Time:1136214245654321000, Goroutine:11, File:"util/log/format_crdb_v2_test.go", Line:123, Message:"hello ‹world›", Tags:"noval,s‹1›,long=‹2›", Counter:0x18, Redactable:true, Channel:2, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
 
 log
 I060102 15:04:05.654321 11 util/log/format_crdb_v2_test.go:123 ⋮ [T1,noval,s‹1›,long=‹2›] 23  maybe ‹multi›
@@ -202,16 +217,16 @@ I060102 15:04:05.654321 11 util/log/format_crdb_v2_test.go:123 ⋮ [T1,noval,s�
 I060102 15:04:05.654321 11 util/log/format_crdb_v2_test.go:123 ⋮ [T1,noval,s‹1›,long=‹2›] 24 ={"Timestamp":123,"EventType":"rename_database","DatabaseName":"‹aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa›
 I060102 15:04:05.654321 11 util/log/format_crdb_v2_test.go:123 ⋮ [T1,noval,s‹1›,long=‹2›] 24 |‹aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa›"}
 ----
-logpb.Entry{Severity:1, Time:1136214245654321000, Goroutine:11, File:"util/log/format_crdb_v2_test.go", Line:123, Message:"maybe ‹multi›\n‹line›", Tags:"noval,s‹1›,long=‹2›", Counter:0x17, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1"}
-logpb.Entry{Severity:1, Time:1136214245654321000, Goroutine:11, File:"util/log/format_crdb_v2_test.go", Line:123, Message:"{\"Timestamp\":123,\"EventType\":\"rename_database\",\"DatabaseName\":\"‹aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa›‹aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa›\"}", Tags:"noval,s‹1›,long=‹2›", Counter:0x18, Redactable:true, Channel:0, StructuredEnd:0x91, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1"}
+logpb.Entry{Severity:1, Time:1136214245654321000, Goroutine:11, File:"util/log/format_crdb_v2_test.go", Line:123, Message:"maybe ‹multi›\n‹line›", Tags:"noval,s‹1›,long=‹2›", Counter:0x17, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
+logpb.Entry{Severity:1, Time:1136214245654321000, Goroutine:11, File:"util/log/format_crdb_v2_test.go", Line:123, Message:"{\"Timestamp\":123,\"EventType\":\"rename_database\",\"DatabaseName\":\"‹aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa›‹aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa›\"}", Tags:"noval,s‹1›,long=‹2›", Counter:0x18, Redactable:true, Channel:0, StructuredEnd:0x91, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
 
 log
 I060102 15:04:05.654321 11 util/log/format_crdb_v2_test.go:123 ⋮ [T1,noval,s‹1›,long=‹2›] 23 ={"Timestamp":123,"EventType":"rename_database","DatabaseName":"‹aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa›
 I060102 15:04:05.654321 11 util/log/format_crdb_v2_test.go:123 ⋮ [T1,noval,s‹1›,long=‹2›] 23 |‹aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa›"}
 E060102 15:04:05.654321 11 2@util/log/format_crdb_v2_test.go:123 ⋮ [T1,noval,s‹1›,long=‹2›] 24  hello ‹world›
 ----
-logpb.Entry{Severity:1, Time:1136214245654321000, Goroutine:11, File:"util/log/format_crdb_v2_test.go", Line:123, Message:"{\"Timestamp\":123,\"EventType\":\"rename_database\",\"DatabaseName\":\"‹aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa›‹aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa›\"}", Tags:"noval,s‹1›,long=‹2›", Counter:0x17, Redactable:true, Channel:0, StructuredEnd:0x91, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1"}
-logpb.Entry{Severity:3, Time:1136214245654321000, Goroutine:11, File:"util/log/format_crdb_v2_test.go", Line:123, Message:"hello ‹world›", Tags:"noval,s‹1›,long=‹2›", Counter:0x18, Redactable:true, Channel:2, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1"}
+logpb.Entry{Severity:1, Time:1136214245654321000, Goroutine:11, File:"util/log/format_crdb_v2_test.go", Line:123, Message:"{\"Timestamp\":123,\"EventType\":\"rename_database\",\"DatabaseName\":\"‹aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa›‹aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa›\"}", Tags:"noval,s‹1›,long=‹2›", Counter:0x17, Redactable:true, Channel:0, StructuredEnd:0x91, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
+logpb.Entry{Severity:3, Time:1136214245654321000, Goroutine:11, File:"util/log/format_crdb_v2_test.go", Line:123, Message:"hello ‹world›", Tags:"noval,s‹1›,long=‹2›", Counter:0x18, Redactable:true, Channel:2, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
 
 log
 I060102 15:04:05.654321 11 util/log/format_crdb_v2_test.go:123 ⋮ [T1,noval,s‹1›,long=‹2›] 23 ={"Timestamp":123,"EventType":"rename_database","DatabaseName":"‹aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa›
@@ -219,8 +234,8 @@ I060102 15:04:05.654321 11 util/log/format_crdb_v2_test.go:123 ⋮ [T1,noval,s�
 I060102 15:04:05.654321 11 util/log/format_crdb_v2_test.go:123 ⋮ [T1,noval,s‹1›,long=‹2›] 24  maybe ‹multi›
 I060102 15:04:05.654321 11 util/log/format_crdb_v2_test.go:123 ⋮ [T1,noval,s‹1›,long=‹2›] 24 +‹line›
 ----
-logpb.Entry{Severity:1, Time:1136214245654321000, Goroutine:11, File:"util/log/format_crdb_v2_test.go", Line:123, Message:"{\"Timestamp\":123,\"EventType\":\"rename_database\",\"DatabaseName\":\"‹aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa›‹aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa›\"}", Tags:"noval,s‹1›,long=‹2›", Counter:0x17, Redactable:true, Channel:0, StructuredEnd:0x91, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1"}
-logpb.Entry{Severity:1, Time:1136214245654321000, Goroutine:11, File:"util/log/format_crdb_v2_test.go", Line:123, Message:"maybe ‹multi›\n‹line›", Tags:"noval,s‹1›,long=‹2›", Counter:0x18, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1"}
+logpb.Entry{Severity:1, Time:1136214245654321000, Goroutine:11, File:"util/log/format_crdb_v2_test.go", Line:123, Message:"{\"Timestamp\":123,\"EventType\":\"rename_database\",\"DatabaseName\":\"‹aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa›‹aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa›\"}", Tags:"noval,s‹1›,long=‹2›", Counter:0x17, Redactable:true, Channel:0, StructuredEnd:0x91, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
+logpb.Entry{Severity:1, Time:1136214245654321000, Goroutine:11, File:"util/log/format_crdb_v2_test.go", Line:123, Message:"maybe ‹multi›\n‹line›", Tags:"noval,s‹1›,long=‹2›", Counter:0x18, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
 
 log
 I060102 15:04:05.654321 11 util/log/format_crdb_v2_test.go:123 ⋮ [T1,noval,s‹1›,long=‹2›] 23 ={"Timestamp":123,"EventType":"rename_database","DatabaseName":"‹aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa›
@@ -228,8 +243,8 @@ I060102 15:04:05.654321 11 util/log/format_crdb_v2_test.go:123 ⋮ [T1,noval,s�
 I060102 15:04:05.654321 11 util/log/format_crdb_v2_test.go:123 ⋮ [T1,noval,s‹1›,long=‹2›] 23 !this is a fake stack
 E060102 15:04:05.654321 11 2@util/log/format_crdb_v2_test.go:123 ⋮ [T1,noval,s‹1›,long=‹2›] 24  hello ‹world›
 ----
-logpb.Entry{Severity:1, Time:1136214245654321000, Goroutine:11, File:"util/log/format_crdb_v2_test.go", Line:123, Message:"{\"Timestamp\":123,\"EventType\":\"rename_database\",\"DatabaseName\":\"‹aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa›‹aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa›\"}\nstack trace:\nthis is a fake stack", Tags:"noval,s‹1›,long=‹2›", Counter:0x17, Redactable:true, Channel:0, StructuredEnd:0x91, StructuredStart:0x0, StackTraceStart:0x92, TenantID:"1"}
-logpb.Entry{Severity:3, Time:1136214245654321000, Goroutine:11, File:"util/log/format_crdb_v2_test.go", Line:123, Message:"hello ‹world›", Tags:"noval,s‹1›,long=‹2›", Counter:0x18, Redactable:true, Channel:2, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1"}
+logpb.Entry{Severity:1, Time:1136214245654321000, Goroutine:11, File:"util/log/format_crdb_v2_test.go", Line:123, Message:"{\"Timestamp\":123,\"EventType\":\"rename_database\",\"DatabaseName\":\"‹aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa›‹aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa›\"}\nstack trace:\nthis is a fake stack", Tags:"noval,s‹1›,long=‹2›", Counter:0x17, Redactable:true, Channel:0, StructuredEnd:0x91, StructuredStart:0x0, StackTraceStart:0x92, TenantID:"1", TenantName:""}
+logpb.Entry{Severity:3, Time:1136214245654321000, Goroutine:11, File:"util/log/format_crdb_v2_test.go", Line:123, Message:"hello ‹world›", Tags:"noval,s‹1›,long=‹2›", Counter:0x18, Redactable:true, Channel:2, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
 
 log
 I060102 15:04:05.654321 11 util/log/format_crdb_v2_test.go:123 ⋮ [T1,noval,s‹1›,long=‹2›] 23 ={"Timestamp":123,"EventType":"rename_database","DatabaseName":"‹aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa›
@@ -238,8 +253,8 @@ I060102 15:04:05.654321 11 util/log/format_crdb_v2_test.go:123 ⋮ [T1,noval,s�
 I060102 15:04:05.654321 11 util/log/format_crdb_v2_test.go:123 ⋮ [T1,noval,s‹1›,long=‹2›] 24  maybe ‹multi›
 I060102 15:04:05.654321 11 util/log/format_crdb_v2_test.go:123 ⋮ [T1,noval,s‹1›,long=‹2›] 24 +‹line›
 ----
-logpb.Entry{Severity:1, Time:1136214245654321000, Goroutine:11, File:"util/log/format_crdb_v2_test.go", Line:123, Message:"{\"Timestamp\":123,\"EventType\":\"rename_database\",\"DatabaseName\":\"‹aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa›‹aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa›\"}\nstack trace:\nthis is a fake stack", Tags:"noval,s‹1›,long=‹2›", Counter:0x17, Redactable:true, Channel:0, StructuredEnd:0x91, StructuredStart:0x0, StackTraceStart:0x92, TenantID:"1"}
-logpb.Entry{Severity:1, Time:1136214245654321000, Goroutine:11, File:"util/log/format_crdb_v2_test.go", Line:123, Message:"maybe ‹multi›\n‹line›", Tags:"noval,s‹1›,long=‹2›", Counter:0x18, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1"}
+logpb.Entry{Severity:1, Time:1136214245654321000, Goroutine:11, File:"util/log/format_crdb_v2_test.go", Line:123, Message:"{\"Timestamp\":123,\"EventType\":\"rename_database\",\"DatabaseName\":\"‹aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa›‹aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa›\"}\nstack trace:\nthis is a fake stack", Tags:"noval,s‹1›,long=‹2›", Counter:0x17, Redactable:true, Channel:0, StructuredEnd:0x91, StructuredStart:0x0, StackTraceStart:0x92, TenantID:"1", TenantName:""}
+logpb.Entry{Severity:1, Time:1136214245654321000, Goroutine:11, File:"util/log/format_crdb_v2_test.go", Line:123, Message:"maybe ‹multi›\n‹line›", Tags:"noval,s‹1›,long=‹2›", Counter:0x18, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
 
 subtest end
 
@@ -252,10 +267,10 @@ I210116 21:49:17.073282+020000 14 server/node.go:464 ⋮ [-] 23  started with en
 I210116 19:49:17.073282+000000 14 server/node.go:464 ⋮ [-] 23  started with engine type ‹2›
 I210116 19:49:17.073282 14 server/node.go:464 ⋮ [-] 23  started with engine type ‹2›
 ----
-logpb.Entry{Severity:1, Time:1610826557073282000, Goroutine:14, File:"server/node.go", Line:464, Message:"started with engine type ‹2›", Tags:"", Counter:0x17, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1"}
-logpb.Entry{Severity:1, Time:1610826557073282000, Goroutine:14, File:"server/node.go", Line:464, Message:"started with engine type ‹2›", Tags:"", Counter:0x17, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1"}
-logpb.Entry{Severity:1, Time:1610826557073282000, Goroutine:14, File:"server/node.go", Line:464, Message:"started with engine type ‹2›", Tags:"", Counter:0x17, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1"}
-logpb.Entry{Severity:1, Time:1610826557073282000, Goroutine:14, File:"server/node.go", Line:464, Message:"started with engine type ‹2›", Tags:"", Counter:0x17, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1"}
+logpb.Entry{Severity:1, Time:1610826557073282000, Goroutine:14, File:"server/node.go", Line:464, Message:"started with engine type ‹2›", Tags:"", Counter:0x17, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
+logpb.Entry{Severity:1, Time:1610826557073282000, Goroutine:14, File:"server/node.go", Line:464, Message:"started with engine type ‹2›", Tags:"", Counter:0x17, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
+logpb.Entry{Severity:1, Time:1610826557073282000, Goroutine:14, File:"server/node.go", Line:464, Message:"started with engine type ‹2›", Tags:"", Counter:0x17, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
+logpb.Entry{Severity:1, Time:1610826557073282000, Goroutine:14, File:"server/node.go", Line:464, Message:"started with engine type ‹2›", Tags:"", Counter:0x17, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
 
 
 subtest end

--- a/pkg/util/log/testdata/parse_json
+++ b/pkg/util/log/testdata/parse_json
@@ -3,37 +3,37 @@ subtest json_fluent
 log format=json-fluent
 {"tag":"logtest.unknown","header":1,"timestamp":"1136214245.654321000","version":"v999.0.0","goroutine":11,"file":"util/log/format_json_test.go","line":123,"redactable":1,"tags":{"noval":"","s":"‹1›","long":"‹2›"},"message":"hello ‹world›"}
 ----
-logpb.Entry{Severity:0, Time:1136214245654321000, Goroutine:11, File:"util/log/format_json_test.go", Line:123, Message:"hello ‹world›", Tags:"long=‹2›,noval,s‹1›", Counter:0x0, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1"}
+logpb.Entry{Severity:0, Time:1136214245654321000, Goroutine:11, File:"util/log/format_json_test.go", Line:123, Message:"hello ‹world›", Tags:"long=‹2›,noval,s‹1›", Counter:0x0, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
 
 log format=json-fluent
 {"tag":"logtest.dev","channel_numeric":0,"channel":"DEV","timestamp":"1136214245.654321000","severity_numeric":0,"severity":"UNKNOWN","goroutine":11,"file":"","line":123,"entry_counter":0,"redactable":0,"message":""}
 ----
-logpb.Entry{Severity:0, Time:1136214245654321000, Goroutine:11, File:"", Line:123, Message:"‹›", Tags:"", Counter:0x0, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1"}
+logpb.Entry{Severity:0, Time:1136214245654321000, Goroutine:11, File:"", Line:123, Message:"‹›", Tags:"", Counter:0x0, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
 
 log format=json-fluent
 {"tag":"logtest.dev","channel_numeric":0,"channel":"DEV","timestamp":"1136214245.654321000","cluster_id":"abc","node_id":123,"severity_numeric":0,"severity":"UNKNOWN","goroutine":11,"file":"","line":123,"entry_counter":0,"redactable":0,"message":""}
 ----
-logpb.Entry{Severity:0, Time:1136214245654321000, Goroutine:11, File:"", Line:123, Message:"‹›", Tags:"", Counter:0x0, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1"}
+logpb.Entry{Severity:0, Time:1136214245654321000, Goroutine:11, File:"", Line:123, Message:"‹›", Tags:"", Counter:0x0, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
 
 log format=json-fluent
 {"tag":"logtest.dev","channel_numeric":0,"channel":"DEV","timestamp":"1136214245.654321000","tenant_id":456,"instance_id":123,"severity_numeric":0,"severity":"UNKNOWN","goroutine":11,"file":"","line":123,"entry_counter":0,"redactable":0,"message":""}
 ----
-logpb.Entry{Severity:0, Time:1136214245654321000, Goroutine:11, File:"", Line:123, Message:"‹›", Tags:"", Counter:0x0, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"456"}
+logpb.Entry{Severity:0, Time:1136214245654321000, Goroutine:11, File:"", Line:123, Message:"‹›", Tags:"", Counter:0x0, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"456", TenantName:""}
 
 log format=json-fluent
 {"tag":"logtest.dev","channel_numeric":0,"channel":"DEV","timestamp":"1136214245.654321000","version":"v999.0.0","severity_numeric":1,"severity":"INFO","goroutine":11,"file":"util/log/format_json_test.go","line":123,"entry_counter":0,"redactable":1,"tags":{"noval":"","s":"‹1›","long":"‹2›"},"event":{"Timestamp":123,"EventType":"rename_database","DatabaseName":"‹hello›","NewDatabaseName":"‹world›"}}
 ----
-logpb.Entry{Severity:1, Time:1136214245654321000, Goroutine:11, File:"util/log/format_json_test.go", Line:123, Message:"{\"DatabaseName\":\"‹hello›\",\"EventType\":\"rename_database\",\"NewDatabaseName\":\"‹world›\",\"Timestamp\":123}", Tags:"long=‹2›,noval,s‹1›", Counter:0x0, Redactable:true, Channel:0, StructuredEnd:0x6c, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1"}
+logpb.Entry{Severity:1, Time:1136214245654321000, Goroutine:11, File:"util/log/format_json_test.go", Line:123, Message:"{\"DatabaseName\":\"‹hello›\",\"EventType\":\"rename_database\",\"NewDatabaseName\":\"‹world›\",\"Timestamp\":123}", Tags:"long=‹2›,noval,s‹1›", Counter:0x0, Redactable:true, Channel:0, StructuredEnd:0x6c, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
 
 log format=json-fluent
 {"tag":"logtest.ops","channel_numeric":1,"channel":"OPS","timestamp":"1136214245.654321000","version":"v999.0.0","severity_numeric":2,"severity":"WARNING","goroutine":11,"file":"util/log/format_json_test.go","line":123,"entry_counter":0,"redactable":0,"tags":{"noval":"","s":"1","long":"2"},"message":"hello world"}
 ----
-logpb.Entry{Severity:2, Time:1136214245654321000, Goroutine:11, File:"util/log/format_json_test.go", Line:123, Message:"‹hello world›", Tags:"‹long=2,noval,s1›", Counter:0x0, Redactable:true, Channel:1, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1"}
+logpb.Entry{Severity:2, Time:1136214245654321000, Goroutine:11, File:"util/log/format_json_test.go", Line:123, Message:"‹hello world›", Tags:"‹long=2,noval,s1›", Counter:0x0, Redactable:true, Channel:1, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
 
 log format=json-fluent
 {"tag":"logtest.health","channel_numeric":2,"channel":"HEALTH","timestamp":"1136214245.654321000","version":"v999.0.0","severity_numeric":3,"severity":"ERROR","goroutine":11,"file":"util/log/format_json_test.go","line":123,"entry_counter":0,"redactable":1,"tags":{"noval":"","s":"‹1›","long":"‹2›"},"message":"hello ‹world›"}
 ----
-logpb.Entry{Severity:3, Time:1136214245654321000, Goroutine:11, File:"util/log/format_json_test.go", Line:123, Message:"hello ‹world›", Tags:"long=‹2›,noval,s‹1›", Counter:0x0, Redactable:true, Channel:2, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1"}
+logpb.Entry{Severity:3, Time:1136214245654321000, Goroutine:11, File:"util/log/format_json_test.go", Line:123, Message:"hello ‹world›", Tags:"long=‹2›,noval,s‹1›", Counter:0x0, Redactable:true, Channel:2, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
 
 subtest end
 
@@ -42,37 +42,42 @@ subtest json
 log format=json
 {"header":1,"timestamp":"1136214245.654321000","version":"v999.0.0","goroutine":11,"file":"util/log/format_json_test.go","line":123,"redactable":1,"tags":{"noval":"","s":"‹1›","long":"‹2›"},"message":"hello ‹world›"}
 ----
-logpb.Entry{Severity:0, Time:1136214245654321000, Goroutine:11, File:"util/log/format_json_test.go", Line:123, Message:"hello ‹world›", Tags:"long=‹2›,noval,s‹1›", Counter:0x0, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1"}
+logpb.Entry{Severity:0, Time:1136214245654321000, Goroutine:11, File:"util/log/format_json_test.go", Line:123, Message:"hello ‹world›", Tags:"long=‹2›,noval,s‹1›", Counter:0x0, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
 
 log format=json
 {"channel_numeric":0,"channel":"DEV","timestamp":"1136214245.654321000","severity_numeric":0,"severity":"UNKNOWN","goroutine":11,"file":"","line":123,"entry_counter":0,"redactable":0,"message":""}
 ----
-logpb.Entry{Severity:0, Time:1136214245654321000, Goroutine:11, File:"", Line:123, Message:"‹›", Tags:"", Counter:0x0, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1"}
+logpb.Entry{Severity:0, Time:1136214245654321000, Goroutine:11, File:"", Line:123, Message:"‹›", Tags:"", Counter:0x0, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
 
 log format=json
 {"channel_numeric":0,"channel":"DEV","timestamp":"1136214245.654321000","cluster_id":"abc","node_id":123,"severity_numeric":0,"severity":"UNKNOWN","goroutine":11,"file":"","line":123,"entry_counter":0,"redactable":0,"message":""}
 ----
-logpb.Entry{Severity:0, Time:1136214245654321000, Goroutine:11, File:"", Line:123, Message:"‹›", Tags:"", Counter:0x0, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1"}
+logpb.Entry{Severity:0, Time:1136214245654321000, Goroutine:11, File:"", Line:123, Message:"‹›", Tags:"", Counter:0x0, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
 
 log format=json
 {"channel_numeric":0,"channel":"DEV","timestamp":"1136214245.654321000","tenant_id":456,"instance_id":123,"severity_numeric":0,"severity":"UNKNOWN","goroutine":11,"file":"","line":123,"entry_counter":0,"redactable":0,"message":""}
 ----
-logpb.Entry{Severity:0, Time:1136214245654321000, Goroutine:11, File:"", Line:123, Message:"‹›", Tags:"", Counter:0x0, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"456"}
+logpb.Entry{Severity:0, Time:1136214245654321000, Goroutine:11, File:"", Line:123, Message:"‹›", Tags:"", Counter:0x0, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"456", TenantName:""}
+
+log format=json
+{"channel_numeric":0,"channel":"DEV","timestamp":"1136214245.654321000","tenant_id":456,"tenant_name":"abc","instance_id":123,"severity_numeric":0,"severity":"UNKNOWN","goroutine":11,"file":"","line":123,"entry_counter":0,"redactable":0,"message":""}
+----
+logpb.Entry{Severity:0, Time:1136214245654321000, Goroutine:11, File:"", Line:123, Message:"‹›", Tags:"", Counter:0x0, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"456", TenantName:"abc"}
 
 log format=json
 {"channel_numeric":0,"channel":"DEV","timestamp":"1136214245.654321000","version":"v999.0.0","severity_numeric":1,"severity":"INFO","goroutine":11,"file":"util/log/format_json_test.go","line":123,"entry_counter":0,"redactable":1,"tags":{"noval":"","s":"‹1›","long":"‹2›"},"event":{"Timestamp":123,"EventType":"rename_database","DatabaseName":"‹hello›","NewDatabaseName":"‹world›"}}
 ----
-logpb.Entry{Severity:1, Time:1136214245654321000, Goroutine:11, File:"util/log/format_json_test.go", Line:123, Message:"{\"DatabaseName\":\"‹hello›\",\"EventType\":\"rename_database\",\"NewDatabaseName\":\"‹world›\",\"Timestamp\":123}", Tags:"long=‹2›,noval,s‹1›", Counter:0x0, Redactable:true, Channel:0, StructuredEnd:0x6c, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1"}
+logpb.Entry{Severity:1, Time:1136214245654321000, Goroutine:11, File:"util/log/format_json_test.go", Line:123, Message:"{\"DatabaseName\":\"‹hello›\",\"EventType\":\"rename_database\",\"NewDatabaseName\":\"‹world›\",\"Timestamp\":123}", Tags:"long=‹2›,noval,s‹1›", Counter:0x0, Redactable:true, Channel:0, StructuredEnd:0x6c, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
 
 log format=json
 {"channel_numeric":1,"channel":"OPS","timestamp":"1136214245.654321000","version":"v999.0.0","severity_numeric":2,"severity":"WARNING","goroutine":11,"file":"util/log/format_json_test.go","line":123,"entry_counter":0,"redactable":0,"tags":{"noval":"","s":"1","long":"2"},"message":"hello world"}
 ----
-logpb.Entry{Severity:2, Time:1136214245654321000, Goroutine:11, File:"util/log/format_json_test.go", Line:123, Message:"‹hello world›", Tags:"‹long=2,noval,s1›", Counter:0x0, Redactable:true, Channel:1, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1"}
+logpb.Entry{Severity:2, Time:1136214245654321000, Goroutine:11, File:"util/log/format_json_test.go", Line:123, Message:"‹hello world›", Tags:"‹long=2,noval,s1›", Counter:0x0, Redactable:true, Channel:1, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
 
 log format=json
 {"channel_numeric":2,"channel":"HEALTH","timestamp":"1136214245.654321000","version":"v999.0.0","severity_numeric":3,"severity":"ERROR","goroutine":11,"file":"util/log/format_json_test.go","line":123,"entry_counter":0,"redactable":1,"tags":{"noval":"","s":"‹1›","long":"‹2›"},"message":"hello ‹world›"}
 ----
-logpb.Entry{Severity:3, Time:1136214245654321000, Goroutine:11, File:"util/log/format_json_test.go", Line:123, Message:"hello ‹world›", Tags:"long=‹2›,noval,s‹1›", Counter:0x0, Redactable:true, Channel:2, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1"}
+logpb.Entry{Severity:3, Time:1136214245654321000, Goroutine:11, File:"util/log/format_json_test.go", Line:123, Message:"hello ‹world›", Tags:"long=‹2›,noval,s‹1›", Counter:0x0, Redactable:true, Channel:2, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
 
 subtest end
 
@@ -82,37 +87,42 @@ subtest json_fluent_compact
 log format=json-fluent-compact
 {"tag":"logtest.unknown","header":1,"t":"1136214245.654321000","v":"v999.0.0","g":11,"f":"util/log/format_json_test.go","l":123,"r":1,"tags":{"noval":"","s":"‹1›","long":"‹2›"},"message":"hello ‹world›"}
 ----
-logpb.Entry{Severity:0, Time:1136214245654321000, Goroutine:11, File:"util/log/format_json_test.go", Line:123, Message:"hello ‹world›", Tags:"long=‹2›,noval,s‹1›", Counter:0x0, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1"}
+logpb.Entry{Severity:0, Time:1136214245654321000, Goroutine:11, File:"util/log/format_json_test.go", Line:123, Message:"hello ‹world›", Tags:"long=‹2›,noval,s‹1›", Counter:0x0, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
 
 log format=json-fluent-compact
 {"tag":"logtest.dev","c":0,"t":"1136214245.654321000","s":0,"g":11,"f":"","l":123,"n":0,"r":0,"message":""}
 ----
-logpb.Entry{Severity:0, Time:1136214245654321000, Goroutine:11, File:"", Line:123, Message:"‹›", Tags:"", Counter:0x0, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1"}
+logpb.Entry{Severity:0, Time:1136214245654321000, Goroutine:11, File:"", Line:123, Message:"‹›", Tags:"", Counter:0x0, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
 
 log format=json-fluent-compact
 {"tag":"logtest.dev","c":0,"t":"1136214245.654321000","x":"abc","N":123,"s":0,"g":11,"f":"","l":123,"n":0,"r":0,"message":""}
 ----
-logpb.Entry{Severity:0, Time:1136214245654321000, Goroutine:11, File:"", Line:123, Message:"‹›", Tags:"", Counter:0x0, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1"}
+logpb.Entry{Severity:0, Time:1136214245654321000, Goroutine:11, File:"", Line:123, Message:"‹›", Tags:"", Counter:0x0, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
 
 log format=json-fluent-compact
 {"tag":"logtest.dev","c":0,"t":"1136214245.654321000","T":456,"q":123,"s":0,"g":11,"f":"","l":123,"n":0,"r":0,"message":""}
 ----
-logpb.Entry{Severity:0, Time:1136214245654321000, Goroutine:11, File:"", Line:123, Message:"‹›", Tags:"", Counter:0x0, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"456"}
+logpb.Entry{Severity:0, Time:1136214245654321000, Goroutine:11, File:"", Line:123, Message:"‹›", Tags:"", Counter:0x0, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"456", TenantName:""}
+
+log format=json-fluent-compact
+{"tag":"logtest.dev","c":0,"t":"1136214245.654321000","T":456,"V":"abc","q":123,"s":0,"g":11,"f":"","l":123,"n":0,"r":0,"message":""}
+----
+logpb.Entry{Severity:0, Time:1136214245654321000, Goroutine:11, File:"", Line:123, Message:"‹›", Tags:"", Counter:0x0, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"456", TenantName:"abc"}
 
 log format=json-fluent-compact
 {"tag":"logtest.dev","c":0,"t":"1136214245.654321000","v":"v999.0.0","s":1,"sev":"I","g":11,"f":"util/log/format_json_test.go","l":123,"n":0,"r":1,"tags":{"noval":"","s":"‹1›","long":"‹2›"},"event":{"Timestamp":123,"EventType":"rename_database","DatabaseName":"‹hello›","NewDatabaseName":"‹world›"}}
 ----
-logpb.Entry{Severity:1, Time:1136214245654321000, Goroutine:11, File:"util/log/format_json_test.go", Line:123, Message:"{\"DatabaseName\":\"‹hello›\",\"EventType\":\"rename_database\",\"NewDatabaseName\":\"‹world›\",\"Timestamp\":123}", Tags:"long=‹2›,noval,s‹1›", Counter:0x0, Redactable:true, Channel:0, StructuredEnd:0x6c, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1"}
+logpb.Entry{Severity:1, Time:1136214245654321000, Goroutine:11, File:"util/log/format_json_test.go", Line:123, Message:"{\"DatabaseName\":\"‹hello›\",\"EventType\":\"rename_database\",\"NewDatabaseName\":\"‹world›\",\"Timestamp\":123}", Tags:"long=‹2›,noval,s‹1›", Counter:0x0, Redactable:true, Channel:0, StructuredEnd:0x6c, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
 
 log format=json-fluent-compact
 {"tag":"logtest.ops","c":1,"t":"1136214245.654321000","v":"v999.0.0","s":2,"sev":"W","g":11,"f":"util/log/format_json_test.go","l":123,"n":0,"r":0,"tags":{"noval":"","s":"1","long":"2"},"message":"hello world"}
 ----
-logpb.Entry{Severity:2, Time:1136214245654321000, Goroutine:11, File:"util/log/format_json_test.go", Line:123, Message:"‹hello world›", Tags:"‹long=2,noval,s1›", Counter:0x0, Redactable:true, Channel:1, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1"}
+logpb.Entry{Severity:2, Time:1136214245654321000, Goroutine:11, File:"util/log/format_json_test.go", Line:123, Message:"‹hello world›", Tags:"‹long=2,noval,s1›", Counter:0x0, Redactable:true, Channel:1, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
 
 log format=json-fluent-compact
 {"tag":"logtest.health","c":2,"t":"1136214245.654321000","v":"v999.0.0","s":3,"sev":"E","g":11,"f":"util/log/format_json_test.go","l":123,"n":0,"r":1,"tags":{"noval":"","s":"‹1›","long":"‹2›"},"message":"hello ‹world›"}
 ----
-logpb.Entry{Severity:3, Time:1136214245654321000, Goroutine:11, File:"util/log/format_json_test.go", Line:123, Message:"hello ‹world›", Tags:"long=‹2›,noval,s‹1›", Counter:0x0, Redactable:true, Channel:2, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1"}
+logpb.Entry{Severity:3, Time:1136214245654321000, Goroutine:11, File:"util/log/format_json_test.go", Line:123, Message:"hello ‹world›", Tags:"long=‹2›,noval,s‹1›", Counter:0x0, Redactable:true, Channel:2, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
 
 subtest end
 
@@ -121,36 +131,36 @@ subtest json_compact
 log format=json-fluent-compact
 {"header":1,"t":"1136214245.654321000","v":"v999.0.0","g":11,"f":"util/log/format_json_test.go","l":123,"r":1,"tags":{"noval":"","s":"‹1›","long":"‹2›"},"message":"hello ‹world›"}
 ----
-logpb.Entry{Severity:0, Time:1136214245654321000, Goroutine:11, File:"util/log/format_json_test.go", Line:123, Message:"hello ‹world›", Tags:"long=‹2›,noval,s‹1›", Counter:0x0, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1"}
+logpb.Entry{Severity:0, Time:1136214245654321000, Goroutine:11, File:"util/log/format_json_test.go", Line:123, Message:"hello ‹world›", Tags:"long=‹2›,noval,s‹1›", Counter:0x0, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
 
 log format=json-compact
 {"c":0,"t":"1136214245.654321000","s":0,"g":11,"f":"","l":123,"n":0,"r":0,"message":""}
 ----
-logpb.Entry{Severity:0, Time:1136214245654321000, Goroutine:11, File:"", Line:123, Message:"‹›", Tags:"", Counter:0x0, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1"}
+logpb.Entry{Severity:0, Time:1136214245654321000, Goroutine:11, File:"", Line:123, Message:"‹›", Tags:"", Counter:0x0, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
 
 log format=json-compact
 {"c":0,"t":"1136214245.654321000","x":"abc","N":123,"s":0,"g":11,"f":"","l":123,"n":0,"r":0,"message":""}
 ----
-logpb.Entry{Severity:0, Time:1136214245654321000, Goroutine:11, File:"", Line:123, Message:"‹›", Tags:"", Counter:0x0, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1"}
+logpb.Entry{Severity:0, Time:1136214245654321000, Goroutine:11, File:"", Line:123, Message:"‹›", Tags:"", Counter:0x0, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
 
 log format=json-compact
 {"c":0,"t":"1136214245.654321000","T":456,"q":123,"s":0,"g":11,"f":"","l":123,"n":0,"r":0,"message":""}
 ----
-logpb.Entry{Severity:0, Time:1136214245654321000, Goroutine:11, File:"", Line:123, Message:"‹›", Tags:"", Counter:0x0, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"456"}
+logpb.Entry{Severity:0, Time:1136214245654321000, Goroutine:11, File:"", Line:123, Message:"‹›", Tags:"", Counter:0x0, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"456", TenantName:""}
 
 log format=json-compact
 {"c":0,"t":"1136214245.654321000","v":"v999.0.0","s":1,"sev":"I","g":11,"f":"util/log/format_json_test.go","l":123,"n":0,"r":1,"tags":{"noval":"","s":"‹1›","long":"‹2›"},"event":{"Timestamp":123,"EventType":"rename_database","DatabaseName":"‹hello›","NewDatabaseName":"‹world›"}}
 ----
-logpb.Entry{Severity:1, Time:1136214245654321000, Goroutine:11, File:"util/log/format_json_test.go", Line:123, Message:"{\"DatabaseName\":\"‹hello›\",\"EventType\":\"rename_database\",\"NewDatabaseName\":\"‹world›\",\"Timestamp\":123}", Tags:"long=‹2›,noval,s‹1›", Counter:0x0, Redactable:true, Channel:0, StructuredEnd:0x6c, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1"}
+logpb.Entry{Severity:1, Time:1136214245654321000, Goroutine:11, File:"util/log/format_json_test.go", Line:123, Message:"{\"DatabaseName\":\"‹hello›\",\"EventType\":\"rename_database\",\"NewDatabaseName\":\"‹world›\",\"Timestamp\":123}", Tags:"long=‹2›,noval,s‹1›", Counter:0x0, Redactable:true, Channel:0, StructuredEnd:0x6c, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
 
 log format=json-compact
 {"c":1,"t":"1136214245.654321000","v":"v999.0.0","s":2,"sev":"W","g":11,"f":"util/log/format_json_test.go","l":123,"n":0,"r":0,"tags":{"noval":"","s":"1","long":"2"},"message":"hello world"}
 ----
-logpb.Entry{Severity:2, Time:1136214245654321000, Goroutine:11, File:"util/log/format_json_test.go", Line:123, Message:"‹hello world›", Tags:"‹long=2,noval,s1›", Counter:0x0, Redactable:true, Channel:1, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1"}
+logpb.Entry{Severity:2, Time:1136214245654321000, Goroutine:11, File:"util/log/format_json_test.go", Line:123, Message:"‹hello world›", Tags:"‹long=2,noval,s1›", Counter:0x0, Redactable:true, Channel:1, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
 
 log format=json-compact
 {"c":2,"t":"1136214245.654321000","v":"v999.0.0","s":3,"sev":"E","g":11,"f":"util/log/format_json_test.go","l":123,"n":0,"r":1,"tags":{"noval":"","s":"‹1›","long":"‹2›"},"message":"hello ‹world›"}
 ----
-logpb.Entry{Severity:3, Time:1136214245654321000, Goroutine:11, File:"util/log/format_json_test.go", Line:123, Message:"hello ‹world›", Tags:"long=‹2›,noval,s‹1›", Counter:0x0, Redactable:true, Channel:2, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1"}
+logpb.Entry{Severity:3, Time:1136214245654321000, Goroutine:11, File:"util/log/format_json_test.go", Line:123, Message:"hello ‹world›", Tags:"long=‹2›,noval,s‹1›", Counter:0x0, Redactable:true, Channel:2, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
 
 subtest end


### PR DESCRIPTION
Epic: CRDB-27982
Fixes #103406.

Prior to this change, the tenant details reported in logging output
were limited to just the tenant ID. This is because the original
tenant server initialization code only had access to the tenant
ID (provided as CLI argument).

Since recently, the tenant name is also becoming known during tenant
server initialization. This is currently done via the tenant
connector.

This commit expands on this foundation by injecting the tenant name
into the logging output as soon as it is available.

For example:

```
I230815 19:31:07.290757 922 sql/temporary_schema.go:554 ⋮ [T4,Vblah,n1] 148  found 0 temporary schemas
                                                              ^^^^^ here
```

or using JSON:
```
{"channel_numeric":0,"channel":"DEV",...,"tenant_id":4,"tenant_name":"blah",...}
                                                       ^^^^^^^^^^^^^^^^^^^^ here
```


Note: we are choosing to report the tenant name *in addition* to the
tenant ID to preserve compatibilit with automation (eg. logspy) which
needs to filter entries based on ID.


Release note (cluster virtualization): The name of the virtual
cluster (tenant), when known, is now reported in logging events.
Refer to the documentation of individual logging format for details.