### PR TITLE
kvserver: queue replicas on significant span config changes

### DIFF
--- a/pkg/kv/kvserver/mvcc_gc_queue.go
+++ b/pkg/kv/kvserver/mvcc_gc_queue.go
@@ -118,6 +118,19 @@ var mvccGCQueueHighPriInterval = settings.RegisterDurationSetting(
 	settings.NonNegativeDuration,
 )
 
+// EnqueueInMvccGCQueueOnSpanConfigUpdateEnabled controls whether replicas
+// are enqueued into the mvcc queue, following a span config update which
+// affects the replica.
+// TODO(baptist): Enable this once we have better AC control and have verified
+// this doesn't cause any overload problems.
+var EnqueueInMvccGCQueueOnSpanConfigUpdateEnabled = settings.RegisterBoolSetting(
+	settings.SystemOnly,
+	"kv.enqueue_in_mvcc_gc_queue_on_span_config_update.enabled",
+	"controls whether replicas are enqueued into the mvcc gc queue for "+
+		"processing, when a span config update occurs which affects the replica",
+	false,
+)
+
 func largeAbortSpan(ms enginepb.MVCCStats) bool {
 	// Checks if the size of the abort span exceeds the given threshold.
 	// The abort span is not supposed to become that large, but it does

--- a/pkg/kv/kvserver/replica_raftstorage.go
+++ b/pkg/kv/kvserver/replica_raftstorage.go
@@ -432,7 +432,11 @@ func (r *Replica) updateRangeInfo(ctx context.Context, desc *roachpb.RangeDescri
 		return errors.Wrapf(err, "%s: failed to lookup span config", r)
 	}
 
-	r.SetSpanConfig(conf)
+	changed := r.SetSpanConfig(conf)
+	if changed {
+		r.MaybeQueue(ctx, r.store.cfg.Clock.NowAsClockTimestamp())
+	}
+
 	return nil
 }
 

--- a/pkg/kv/kvserver/replicate_queue.go
+++ b/pkg/kv/kvserver/replicate_queue.go
@@ -110,7 +110,7 @@ var EnqueueInReplicateQueueOnSpanConfigUpdateEnabled = settings.RegisterBoolSett
 	"kv.enqueue_in_replicate_queue_on_span_config_update.enabled",
 	"controls whether replicas are enqueued into the replicate queue for "+
 		"processing, when a span config update occurs, which affects the replica",
-	false,
+	true,
 )
 
 var (

--- a/pkg/roachpb/BUILD.bazel
+++ b/pkg/roachpb/BUILD.bazel
@@ -64,6 +64,7 @@ go_test(
         "metadata_replicas_test.go",
         "metadata_test.go",
         "span_config_conformance_report_test.go",
+        "span_config_test.go",
         "span_group_test.go",
         "string_test.go",
         "tenant_test.go",

--- a/pkg/roachpb/span_config.go
+++ b/pkg/roachpb/span_config.go
@@ -47,6 +47,17 @@ func (s *SpanConfig) IsEmpty() bool {
 	return s.Equal(emptySpanConfig)
 }
 
+// HasConfigurationChange is true if there is a change to this SpanConfig that
+// is initiated by the end user (directly or indirectly) rather than by a
+// background system process (like a PTS update).
+func (s *SpanConfig) HasConfigurationChange(other SpanConfig) bool {
+	this := *s
+	// Clear out the protection policies from both SpanConfigs.
+	this.GCPolicy.ProtectionPolicies = nil
+	other.GCPolicy.ProtectionPolicies = nil
+	return !this.Equal(other)
+}
+
 // TTL returns the implies TTL as a time.Duration.
 func (s *SpanConfig) TTL() time.Duration {
 	return time.Duration(s.GCPolicy.TTLSeconds) * time.Second


### PR DESCRIPTION
Previously we would queue replicas for split, merge and replicate
changes on every change to the span configs including PTS changes. This
was inefficient and now we check if the change to the SpanConfig is
significant.

Informs: https://github.com/cockroachdb/cockroach/issues/107977
Fixes: https://github.com/cockroachdb/cockroach/issues/108795

Epic: none

Release note: None