### PR TITLE
sqlsmith: disable NAME type in postgres mode

### DIFF
--- a/pkg/internal/sqlsmith/type.go
+++ b/pkg/internal/sqlsmith/type.go
@@ -105,6 +105,11 @@ func (s *Smither) randType() *types.T {
 			(s.disableOIDs && typ.Family() == types.OidFamily) {
 			continue
 		}
+		if s.postgres && typ == types.Name {
+			// Name type in CRDB doesn't match Postgres behavior. Exclude for tests
+			// which compare CRDB behavior to Postgres.
+			continue
+		}
 		break
 	}
 	return typ


### PR DESCRIPTION
The NAME type is known to have different behavior in CRDB than in postgres, in that casting to name truncates a string to 63 characters in postgres, but not in CRDB, causing sqlsmith test failures. For backwards compatibility, CRDB behavior is not being changed to match postgres, at least for now.

The fix is to prevent sqlsmith tests which use postgres mode (which implies it is comparing CRDB results with postgres) from generating NAME as a random type for testing.

Fixes: #107895

Release note: None