### PR TITLE
sql: fix pg_statistic_ext behavior for dropped tables

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -4057,6 +4057,8 @@ WHERE indexrelid IN (SELECT crdb_oid FROM pg_catalog.pg_indexes WHERE indexname 
 indoption
 1
 
+subtest end
+
 # Regression #59561.
 # database_name would not be populated even when the SELECT does not use the virtual index.
 query TTI
@@ -4407,6 +4409,28 @@ JOIN pg_class ON pg_statistic_ext.stxrelid = pg_class.oid
 relname  stxname  stxnamespace  stxowner  stxstattarget  stxkeys  stxkind
 stxtbl   stxobj   105           NULL      -1             {2,3}    {d}
 stxtbl2  stxobj2  191           NULL      -1             {1,3}    {d}
+stx      NULL     105           NULL      -1             {2}      {d}
+stx      NULL     105           NULL      -1             {1}      {d}
+
+# Regression test for https://github.com/cockroachdb/cockroach/issues/108813:
+# pg_statistic_ext should still work after dropping the table.
+statement ok
+DROP TABLE test.stxtbl2
+
+query TTOOITT colnames,rowsort
+SELECT
+  relname,
+  stxname,
+  stxnamespace,
+  stxowner,
+  stxstattarget,
+  stxkeys,
+  stxkind
+FROM pg_statistic_ext
+JOIN pg_class ON pg_statistic_ext.stxrelid = pg_class.oid
+----
+relname  stxname  stxnamespace  stxowner  stxstattarget  stxkeys  stxkind
+stxtbl   stxobj   105           NULL      -1             {2,3}    {d}
 stx      NULL     105           NULL      -1             {2}      {d}
 stx      NULL     105           NULL      -1             {1}      {d}
 

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -3604,7 +3604,22 @@ https://www.postgresql.org/docs/13/catalog-pg-statistic-ext.html`,
 			h.writeUInt64(uint64(statisticsID))
 			statisticsOID := h.getOid()
 
-			tbl, err := p.Descriptors().ByIDWithLeased(p.Txn()).WithoutNonPublic().Get().Table(ctx, descpb.ID(tableID))
+			tbl, err := p.Descriptors().ByIDWithLeased(p.Txn()).Get().Table(ctx, descpb.ID(tableID))
+			if err != nil {
+				if pgerror.GetPGCode(err) == pgcode.UndefinedTable {
+					// The system.table_statistics could contain stale rows that
+					// reference a descriptor that no longer exists.
+					continue
+				}
+				return err
+			}
+			canSeeDescriptor, err := userCanSeeDescriptor(ctx, p, tbl, db, false /* allowAdding */)
+			if err != nil {
+				return err
+			}
+			if !canSeeDescriptor {
+				continue
+			}
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/108813
fixes https://github.com/cockroachdb/cockroach/issues/108482

Release note (bug fix): Fixed a bug present since v23.1.0 that would cause queries on the pg_catalog.pg_statistic_ext table to fail if a table was dropped recently. This bug also caused the `\d` CLI shortcut to encounter errors.