### PR TITLE
sql: fix recent regression around EXPLAIN ANALYZE in some tools

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -868,6 +868,16 @@ func (ex *connExecutor) execStmtInOpenState(
 			)
 			return makeErrEvent(err)
 		}
+		if _, ok := s.Statement.(*tree.ExplainAnalyze); ok {
+			// Prohibit the explicit PREPARE ... AS EXPLAIN ANALYZE since we
+			// won't be able to execute the prepared statement. This is also in
+			// line with Postgres.
+			err := pgerror.Newf(
+				pgcode.Syntax,
+				"EXPLAIN ANALYZE can only be used as a top-level statement",
+			)
+			return makeErrEvent(err)
+		}
 		var typeHints tree.PlaceholderTypes
 		// We take max(len(s.Types), stmt.NumPlaceHolders) as the length of types.
 		numParams := len(s.Types)

--- a/pkg/sql/conn_executor_prepare.go
+++ b/pkg/sql/conn_executor_prepare.go
@@ -195,21 +195,6 @@ func (ex *connExecutor) prepare(
 		return prepared, nil
 	}
 
-	// Prohibit preparing of EXPLAIN ANALYZE since we won't be able to execute
-	// it anyway.
-	var isExplainAnalyze bool
-	switch s := stmt.AST.(type) {
-	case *tree.ExplainAnalyze:
-		isExplainAnalyze = true
-	case *tree.Prepare:
-		if _, ok := s.Statement.(*tree.ExplainAnalyze); ok {
-			isExplainAnalyze = true
-		}
-	}
-	if isExplainAnalyze {
-		return nil, pgerror.Newf(pgcode.Syntax, "EXPLAIN ANALYZE can only be used as a top-level statement")
-	}
-
 	origNumPlaceholders := stmt.NumPlaceholders
 	switch stmt.AST.(type) {
 	case *tree.Prepare, *tree.CopyTo:

--- a/pkg/sql/explain_test.go
+++ b/pkg/sql/explain_test.go
@@ -240,6 +240,7 @@ func TestPrepareExplain(t *testing.T) {
 		"EXPLAIN (TYPES) SELECT * FROM abc WHERE c=1",
 		"EXPLAIN (DISTSQL) SELECT * FROM abc WHERE c=1",
 		"EXPLAIN (VEC) SELECT * FROM abc WHERE c=1",
+		"EXPLAIN ANALYZE SELECT * FROM abc WHERE c=1",
 	}
 
 	for _, sql := range statements {

--- a/pkg/sql/logictest/testdata/logic_test/prepare
+++ b/pkg/sql/logictest/testdata/logic_test/prepare
@@ -1664,3 +1664,6 @@ DEALLOCATE ALL
 
 statement ok
 RESET prepared_statements_cache_size
+
+statement error EXPLAIN ANALYZE can only be used as a top-level statement
+PREPARE p AS EXPLAIN ANALYZE SELECT 1

--- a/pkg/sql/pgwire/conn.go
+++ b/pkg/sql/pgwire/conn.go
@@ -857,7 +857,7 @@ func cookTag(
 		tag = strconv.AppendInt(tag, int64(rowsAffected), 10)
 
 	case tree.Rows:
-		if tagStr != "SHOW" {
+		if tagStr != "SHOW" && tagStr != "EXPLAIN" {
 			tag = append(tag, ' ')
 			tag = strconv.AppendUint(tag, uint64(rowsAffected), 10)
 		}

--- a/pkg/sql/pgwire/testdata/pgtest/prepare
+++ b/pkg/sql/pgwire/testdata/pgtest/prepare
@@ -82,7 +82,6 @@ Execute {"Portal": "p"}
 Sync
 ----
 
-
 until
 ErrorResponse
 ReadyForQuery
@@ -92,13 +91,31 @@ ReadyForQuery
 {"Type":"ReadyForQuery","TxStatus":"I"}
 
 send
-Parse {"Query": "EXPLAIN ANALYZE SELECT 1;"}
+Parse {"Name": "e", "Query": "EXPLAIN SELECT generate_series(1,10);"}
+Bind {"DestinationPortal": "pe", "PreparedStatement": "e"}
+Execute {"Portal": "pe"}
 Sync
 ----
 
-until crdb_only keepErrMessage
-ErrorResponse
+until ignore=DataRow
 ReadyForQuery
 ----
-{"Type":"ErrorResponse","Code":"42601","Message":"EXPLAIN ANALYZE can only be used as a top-level statement"}
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"CommandComplete","CommandTag":"EXPLAIN"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send
+Parse {"Name": "ea", "Query": "EXPLAIN ANALYZE SELECT generate_series(1,10);"}
+Bind {"DestinationPortal": "pea", "PreparedStatement": "ea"}
+Execute {"Portal": "pea"}
+Sync
+----
+
+until ignore=DataRow
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"CommandComplete","CommandTag":"EXPLAIN"}
 {"Type":"ReadyForQuery","TxStatus":"I"}

--- a/pkg/sql/sem/tree/stmt.go
+++ b/pkg/sql/sem/tree/stmt.go
@@ -1145,7 +1145,7 @@ func (*ExplainAnalyze) StatementReturnType() StatementReturnType { return Rows }
 func (*ExplainAnalyze) StatementType() StatementType { return TypeDML }
 
 // StatementTag returns a short string identifying the type of statement.
-func (*ExplainAnalyze) StatementTag() string { return "EXPLAIN ANALYZE" }
+func (*ExplainAnalyze) StatementTag() string { return "EXPLAIN" }
 
 // StatementReturnType implements the Statement interface.
 func (*Export) StatementReturnType() StatementReturnType { return Rows }

--- a/pkg/sql/sql_prepare_test.go
+++ b/pkg/sql/sql_prepare_test.go
@@ -35,10 +35,6 @@ func TestPreparePrepareExecute(t *testing.T) {
 	_, err := db.Prepare("EXECUTE x(3)")
 	require.Contains(t, err.Error(), "no such prepared statement")
 
-	// Test that creating a prepared EXPLAIN ANALYZE statement is prohibited.
-	_, err = db.Prepare("PREPARE p AS EXPLAIN ANALYZE SELECT 1")
-	require.Contains(t, err.Error(), "EXPLAIN ANALYZE can only be used as a top-level statement")
-
 	// Test that we can prepare and execute a PREPARE.
 	s, err := db.Prepare("PREPARE x AS SELECT $1::int")
 	require.NoError(t, err)


### PR DESCRIPTION
In feb9c43eff5cdd16b5e4a50a1ecac3fffaf5a436 we prohibited PREPARE'ing EXPLAIN ANALYZE statements; however, that broke DataGrip (namely, the tool - when using the extended pgwire protocol - can no longer execute EXPLAIN ANALYZE statements). This is due to an oversight in that commit: there are two ways create a prepared statement:
- via SQL-level PREPARE keyword
- via pgwire-level Parse command (that will be followed by Bind/Execute)

In that commit we disallowed both, but only the first should be disallowed, so this commit addresses that. (DataGrip happens to use the latter which postgres supports.)

Additionally, this work exposed some minor differences in the "CommandTag" between us and postgres which are also fixed.

Fixes: #107898.

Release note: None