### PR TITLE
row: remove no longer nil txn check

### DIFF
--- a/pkg/sql/row/kv_fetcher.go
+++ b/pkg/sql/row/kv_fetcher.go
@@ -87,8 +87,7 @@ func newTxnKVFetcher(
 			return br, nil
 		}
 	}
-
-	fetcherArgs := newTxnKVFetcherArgs{
+	return newTxnKVFetcherInternal(newTxnKVFetcherArgs{
 		sendFn:                     sendFn,
 		reverse:                    reverse,
 		lockStrength:               lockStrength,
@@ -98,15 +97,9 @@ func newTxnKVFetcher(
 		forceProductionKVBatchSize: forceProductionKVBatchSize,
 		kvPairsRead:                new(int64),
 		batchRequestsIssued:        &batchRequestsIssued,
-	}
-	if txn != nil {
-		// In most cases, the txn is non-nil; however, in some code paths (e.g.
-		// when executing EXPLAIN (VEC)) it might be nil, so we need to have
-		// this check.
-		fetcherArgs.requestAdmissionHeader = txn.AdmissionHeader()
-		fetcherArgs.responseAdmissionQ = txn.DB().SQLKVResponseAdmissionQ
-	}
-	return newTxnKVFetcherInternal(fetcherArgs)
+		requestAdmissionHeader:     txn.AdmissionHeader(),
+		responseAdmissionQ:         txn.DB().SQLKVResponseAdmissionQ,
+	})
 }
 
 // NewDirectKVBatchFetcher creates a new KVBatchFetcher that uses the


### PR DESCRIPTION
I believe this non-nil txn check is no longer needed as of 8f7f2f405d4989d1cb22d1ab50fc0e20aadebcec (which fixed the only known place where we forgot to set the txn field on the FlowCtx).

Epic: None

Release note: None