### PR TITLE
sql: implement datetime builtins

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -559,6 +559,11 @@ significant than <code>element</code> to zero (or one, for day and month)</p>
 <p>Compatible elements: millennium, century, decade, year, quarter, month,
 week, day, hour, minute, second, millisecond, microsecond.</p>
 </span></td><td>Stable</td></tr>
+<tr><td><a name="date_trunc"></a><code>date_trunc(element: <a href="string.html">string</a>, input: <a href="timestamp.html">timestamptz</a>, timezone: <a href="string.html">string</a>) &rarr; <a href="timestamp.html">timestamptz</a></code></td><td><span class="funcdesc"><p>Truncates <code>input</code> to precision <code>element</code> in the specified <code>timezone</code>.  Sets all fields that are less
+significant than <code>element</code> to zero (or one, for day and month)</p>
+<p>Compatible elements: millennium, century, decade, year, quarter, month,
+week, day, hour, minute, second, millisecond, microsecond.</p>
+</span></td><td>Stable</td></tr>
 <tr><td><a name="experimental_follower_read_timestamp"></a><code>experimental_follower_read_timestamp() &rarr; <a href="timestamp.html">timestamptz</a></code></td><td><span class="funcdesc"><p>Same as follower_read_timestamp. This name is deprecated.</p>
 </span></td><td>Volatile</td></tr>
 <tr><td><a name="experimental_strftime"></a><code>experimental_strftime(input: <a href="date.html">date</a>, extract_format: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>From <code>input</code>, extracts and formats the time as identified in <code>extract_format</code> using standard <code>strftime</code> notation (though not all formatting is supported).</p>
@@ -642,6 +647,14 @@ has no relationship with the commit order of concurrent transactions.</p>
 <p>The value is based on a timestamp picked when the transaction starts
 and which stays constant throughout the transaction. This timestamp
 has no relationship with the commit order of concurrent transactions.</p>
+</span></td><td>Stable</td></tr>
+<tr><td><a name="make_date"></a><code>make_date(year: <a href="int.html">int</a>, month: <a href="int.html">int</a>, day: <a href="int.html">int</a>) &rarr; <a href="date.html">date</a></code></td><td><span class="funcdesc"><p>Create date (formatted according to ISO 8601) from year, month, and day fields (negative years signify BC).</p>
+</span></td><td>Immutable</td></tr>
+<tr><td><a name="make_timestamp"></a><code>make_timestamp(year: <a href="int.html">int</a>, month: <a href="int.html">int</a>, day: <a href="int.html">int</a>, hour: <a href="int.html">int</a>, min: <a href="int.html">int</a>, sec: <a href="float.html">float</a>) &rarr; <a href="timestamp.html">timestamp</a></code></td><td><span class="funcdesc"><p>Create timestamp (formatted according to ISO 8601) from year, month, day, hour, minute, and seconds fields (negative years signify BC).</p>
+</span></td><td>Immutable</td></tr>
+<tr><td><a name="make_timestamptz"></a><code>make_timestamptz(year: <a href="int.html">int</a>, month: <a href="int.html">int</a>, day: <a href="int.html">int</a>, hour: <a href="int.html">int</a>, min: <a href="int.html">int</a>, sec: <a href="float.html">float</a>) &rarr; <a href="timestamp.html">timestamptz</a></code></td><td><span class="funcdesc"><p>Create timestamp (formatted according to ISO 8601) with time zone from year, month, day, hour, minute and seconds fields (negative years signify BC). If timezone is not specified, the current time zone is used.</p>
+</span></td><td>Stable</td></tr>
+<tr><td><a name="make_timestamptz"></a><code>make_timestamptz(year: <a href="int.html">int</a>, month: <a href="int.html">int</a>, day: <a href="int.html">int</a>, hour: <a href="int.html">int</a>, min: <a href="int.html">int</a>, sec: <a href="float.html">float</a>, timezone: <a href="string.html">string</a>) &rarr; <a href="timestamp.html">timestamptz</a></code></td><td><span class="funcdesc"><p>Create timestamp (formatted according to ISO 8601) with time zone from year, month, day, hour, minute and seconds fields (negative years signify BC). If timezone is not specified, the current time zone is used.</p>
 </span></td><td>Stable</td></tr>
 <tr><td><a name="now"></a><code>now() &rarr; <a href="date.html">date</a></code></td><td><span class="funcdesc"><p>Returns the time of the current transaction.</p>
 <p>The value is based on a timestamp picked when the transaction starts

--- a/pkg/sql/logictest/testdata/logic_test/datetime
+++ b/pkg/sql/logictest/testdata/logic_test/datetime
@@ -2014,3 +2014,102 @@ SELECT * FROM ex WHERE ROW('1970-01-02 00:00:01.000001-04'::TIMESTAMPTZ) < '1970
 query TTTTT
 SELECT * FROM ex WHERE ROW('1970-01-03 00:00:01.000001-04'::TIMESTAMPTZ) < ROW('1970-01-02 00:00:01.000001-04');
 ----
+
+subtest make_date
+
+query T colnames,rowsort
+SELECT make_date(2013, 7, 15)::string
+----
+make_date
+2013-07-15
+
+query T colnames,rowsort
+SELECT make_date(-2013, 7, 15)
+----
+make_date
+-2013-07-15 00:00:00 +0000 +0000
+
+statement error pgcode 22008 pq: make_date\(\): year value of 0 is not valid
+SELECT make_date(0, 11, 11)
+
+subtest end
+
+subtest make_timestamp
+
+query T colnames,rowsort
+SELECT make_timestamp(2013, 7, 15, 8, 15, 23.5)::string
+----
+make_timestamp
+2013-07-15 08:15:23.5
+
+query T colnames,rowsort
+SELECT make_timestamp(-2013, 7, 15, 8, 15, 23.5)
+----
+make_timestamp
+-2013-07-15 08:15:23.5 +0000 +0000
+
+query T colnames,rowsort
+SELECT make_timestamp(2013, 7, 15, 8, 15, 23.5231231244234)::string
+----
+make_timestamp
+2013-07-15 08:15:23.523123
+
+statement error pgcode 22008 pq: make_timestamp\(\): year value of 0 is not valid
+SELECT make_timestamp(0, 7, 15, 8, 15, 23.5);
+
+subtest end
+
+subtest make_timestamptz
+
+statement ok
+SET TIME ZONE 'EST';
+
+query T colnames,rowsort
+SELECT make_timestamptz(2013, 7, 15, 8, 15, 23.5)
+----
+make_timestamptz
+2013-07-15 08:15:23.5 -0500 EST
+
+query T colnames,rowsort
+SELECT make_timestamptz(-2013, 7, 15, 8, 15, 23.5)
+----
+make_timestamptz
+-2013-07-15 08:15:23.5 -0500 EST
+
+query T colnames,rowsort
+SELECT make_timestamptz(2013, 7, 15, 8, 15, 23.5231231244234)
+----
+make_timestamptz
+2013-07-15 08:15:23.523123 -0500 EST
+
+query T colnames,rowsort
+SELECT make_timestamptz(2013, 7, 15, 8, 15, 23.5, 'America/New_York')
+----
+make_timestamptz
+2013-07-15 07:15:23.5 -0500 EST
+
+statement error pgcode 22008 pq: make_timestamptz\(\): year value of 0 is not valid
+SELECT make_timestamptz(0, 7, 15, 8, 15, 23.5);
+
+statement error pgcode 22008 pq: make_timestamptz\(\): year value of 0 is not valid
+SELECT make_timestamptz(0, 7, 15, 8, 15, 23.5, 'America/New_York');
+
+statement error pgcode 22023 pq: make_timestamptz\(\): could not parse "No" as time zone
+SELECT make_timestamptz(0, 7, 15, 8, 15, 23.5, 'No');
+
+subtest end
+
+subtest date_trunc_withtz
+
+query T
+SELECT date_trunc('day', '2001-02-16 20:38:40+00'::timestamptz, 'Australia/Sydney')
+----
+2001-02-16 08:00:00 -0500 EST
+
+statement error pgcode 22008 pq: date_trunc\(\): parsing as type timestamp: field month value 0 is out of range
+SELECT date_trunc('day', '0-02-16 20:38:40+00'::timestamptz, 'Australia/Sydney');
+
+statement error pgcode 22023 pq: date_trunc\(\): could not parse "No" as time zone
+SELECT date_trunc('day', '4-02-16 20:38:40+00'::timestamptz, 'No');
+
+subtest end

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -2458,6 +2458,11 @@ var builtinOidsArray = []string{
 	2487: `decrypt(data: bytes, key: bytes, type: string) -> bytes`,
 	2488: `decrypt_iv(data: bytes, key: bytes, iv: bytes, type: string) -> bytes`,
 	2489: `gen_random_bytes(count: int) -> bytes`,
+	2490: `make_timestamp(year: int, month: int, day: int, hour: int, min: int, sec: float) -> timestamp`,
+	2491: `make_timestamptz(year: int, month: int, day: int, hour: int, min: int, sec: float) -> timestamptz`,
+	2492: `make_timestamptz(year: int, month: int, day: int, hour: int, min: int, sec: float, timezone: string) -> timestamptz`,
+	2493: `date_trunc(element: string, input: timestamptz, timezone: string) -> timestamptz`,
+	2494: `make_date(year: int, month: int, day: int) -> date`,
 }
 
 var builtinOidsBySignature map[string]oid.Oid

--- a/pkg/util/timeutil/pgdate/pgdate.go
+++ b/pkg/util/timeutil/pgdate/pgdate.go
@@ -176,6 +176,8 @@ func (d Date) Format(buf *bytes.Buffer) {
 		year, month, day := t.Date()
 		bc := year <= 0
 		if bc {
+			// For the ISO 8601 standard, the conversion from a negative year to BC changes the year value (ex. -2013 == 2014 BC).
+			// https://en.wikipedia.org/wiki/ISO_8601#Years
 			year = -year + 1
 		}
 		fmt.Fprintf(buf, "%04d-%02d-%02d", year, month, day)


### PR DESCRIPTION
Previously, `make_date`, `make_timestamp`, and `make_timestamptz`
built-ins were not implemented. In addition, a new signature for
`date_trunc` was not implemented. This was inadequate because it caused
an incompatibility issue for tools that needed these datetime functions.
To address this, this patch adds said datetime built-ins. Note that behaviors
do not align with postgres when negative years are inpits, as we adhere
to ISO 8601 standard.

Epic: none
Fixes: #108448

Release note (sql change): Datetime built-ins (make_date,
make_timestamp, and make_timestamptz) are implemented - allowing for
the creation of timestamps, timestamps with time zones, and dates. In
addition, date_trunc now allows for a timestamp to be truncated in a
provided timezone (to a provided precision).