### PR TITLE
sql: add `crdb_internal.update_row_level_ttl_for_obs_tables` builtin

### DIFF
--- a/pkg/sql/faketreeeval/evalctx.go
+++ b/pkg/sql/faketreeeval/evalctx.go
@@ -317,6 +317,11 @@ func (*DummyEvalPlanner) RepairTTLScheduledJobForTable(ctx context.Context, tabl
 	return errors.WithStack(errEvalPlanner)
 }
 
+// UpdateRowLevelTTLForObsTables is part of the Planner interface.
+func (*DummyEvalPlanner) UpdateRowLevelTTLForObsTables(ctx context.Context, interval string) error {
+	return errors.WithStack(errEvalPlanner)
+}
+
 // Mon is part of the eval.Planner interface.
 func (ep *DummyEvalPlanner) Mon() *mon.BytesMonitor {
 	return ep.Monitor

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -7317,6 +7317,32 @@ table's zone configuration this will return NULL.`,
 		},
 	),
 
+	"crdb_internal.update_row_level_ttl_for_obs_tables": makeBuiltin(
+		tree.FunctionProperties{
+			Category: builtinconstants.CategorySystemInfo,
+		},
+		tree.Overload{
+			Types:      tree.ParamTypes{{Name: "interval", Typ: types.String}},
+			ReturnType: tree.FixedReturnType(types.Void),
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				isAdmin, err := evalCtx.SessionAccessor.HasAdminRole(ctx)
+				if err != nil {
+					return nil, err
+				}
+				if !isAdmin {
+					return nil, errInsufficientPriv
+				}
+				interval := tree.MustBeDString(args[0])
+				if err := evalCtx.Planner.UpdateRowLevelTTLForObsTables(ctx, interval.String()); err != nil {
+					return nil, err
+				}
+				return tree.DVoidDatum, nil
+			},
+			Info:       `Updates row level TTL for system tables that store SQL statement statistics.`,
+			Volatility: volatility.Volatile,
+		},
+	),
+
 	"crdb_internal.check_password_hash_format": makeBuiltin(
 		tree.FunctionProperties{
 			Category: builtinconstants.CategorySystemInfo,

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -2440,6 +2440,7 @@ var builtinOidsArray = []string{
 	2469: `crdb_internal.is_system_table_key(raw_key: bytes) -> bool`,
 	2470: `crdb_internal.scan_storage_internal_keys(node_id: int, store_id: int, start_key: bytes, end_key: bytes) -> tuple{int AS level, int AS node_id, int AS store_id, int AS snapshot_pinned_keys, int AS snapshot_pinned_keys_bytes, int AS point_key_delete_count, int AS point_key_set_count, int AS range_delete_count, int AS range_key_set_count, int AS range_key_delete_count}`,
 	2471: `crdb_internal.scan_storage_internal_keys(node_id: int, store_id: int, start_key: bytes, end_key: bytes, mb_per_second: int4) -> tuple{int AS level, int AS node_id, int AS store_id, int AS snapshot_pinned_keys, int AS snapshot_pinned_keys_bytes, int AS point_key_delete_count, int AS point_key_set_count, int AS range_delete_count, int AS range_key_set_count, int AS range_key_delete_count}`,
+	2472: `crdb_internal.update_row_level_ttl_for_obs_tables(interval: string) -> void`,
 }
 
 var builtinOidsBySignature map[string]oid.Oid

--- a/pkg/sql/sem/eval/deps.go
+++ b/pkg/sql/sem/eval/deps.go
@@ -348,6 +348,13 @@ type Planner interface {
 	// it is invalid.
 	RepairTTLScheduledJobForTable(ctx context.Context, tableID int64) error
 
+	// UpdateRowLevelTTLForObsTables updates row level TTL for a set of system
+	// tables that store statement stats and insights. It is a way to alter
+	// system tables schema without migrations.
+	// interval can be expressed as a string that complies to INTERVAL type
+	// (see: https://www.cockroachlabs.com/docs/stable/interval#syntax).
+	UpdateRowLevelTTLForObsTables(ctx context.Context, interval string) error
+
 	// QueryRowEx executes the supplied SQL statement and returns a single row, or
 	// nil if no row is found, or an error if more that one row is returned.
 	//


### PR DESCRIPTION
This change is aimed to provide a flexible way to change row level TTL intervals on specific system tables
that used to store SQL statement stats and insights. Due to the limitation that it is not possible to change 
system tables after creation (with `ALTER` statement), `crdb_internal.update_row_level_ttl_for_obs_tables` builtin
function is defined that does update TTL values for specific set of tables (`system.txn_exec_insights` and 
`system.stmt_exec_insights` that will be added with https://github.com/cockroachdb/cockroach/pull/104714 change).

In future, it might be extended to update more tables like `system.statement_statistics`, `system.transaction_statistics`,
`system.transaction_activity`, etc.

`UpdateRowLevelTTLForObsTables` function 
- updates `RowLevelTTL` for predefined list of tables, then runs 
- validates TTL scheduled jobs (borrowed part of code from `RepairTTLScheduledJobForTable` function.

TODO:
- [ ] find proper place for `UpdateRowLevelTTLForObsTables` func. `pkg/sql/check.go` doesn't look like a good one.
- [ ] should `UpdateRowLevelTTLForObsTables` func accept another one param to alter `ttl_job_cron` param?
- [ ] what roles required to run this builtin function?
- [ ] `UpdateRowLevelTTLForObsTables` func might be more generic to accept list of tables to update.

Depends on: https://github.com/cockroachdb/cockroach/pull/104714

Related to: https://github.com/cockroachdb/cockroach/issues/104582

Epic: None

Release note (sql): added new builtin function that allows change row level TTL interval for system tables that store SQL statement stats and insights.