### PR TITLE
cli: Increase `debug doctor` scanner limit from 50MiB to 200MiB

### DIFF
--- a/pkg/cli/doctor.go
+++ b/pkg/cli/doctor.go
@@ -650,8 +650,8 @@ func slurp(zipDirPath string, fileName string, tableMapFn func(row string) error
 func tableMap(in io.Reader, fn func(string) error) error {
 	firstLine := true
 	sc := bufio.NewScanner(in)
-	// Read lines up to 50 MB in size.
-	sc.Buffer(make([]byte, 64*1024), 50*1024*1024)
+	// Read lines up to 200 MB in size.
+	sc.Buffer(make([]byte, 64*1024), 200*1024*1024)
 	for sc.Scan() {
 		if firstLine {
 			firstLine = false


### PR DESCRIPTION
We encountered a debug zip where its `system.jobs.txt` file contain extrememly long line (>50MiB for that line), and cause commands within `debug doctor` (e.g. `examine zipdir`) to fail with
```
ERROR: bufio.Scanner: token too long
Failed running "debug doctor examine zipdir"
```
This commit increases the scanner buffer limit from 50MiB to 200MiB to handle those cases.

Epic: None
Release note: None