### PR TITLE
changefeedccl: assert increasing resolved message timestamps in validators

### DIFF
--- a/pkg/ccl/changefeedccl/cdctest/validator.go
+++ b/pkg/ccl/changefeedccl/cdctest/validator.go
@@ -176,6 +176,9 @@ func (v *orderValidator) NoteResolved(partition string, resolved hlc.Timestamp) 
 	prev := v.resolved[partition]
 	if prev.Less(resolved) {
 		v.resolved[partition] = resolved
+	} else {
+		v.failures = append(v.failures, fmt.Sprintf("new resolved timestamp %s is lower than existing resolved timestamp %s for"+
+			" partition %s", resolved.String(), prev.String(), partition))
 	}
 	return nil
 }

--- a/pkg/ccl/changefeedccl/cdctest/validator.go
+++ b/pkg/ccl/changefeedccl/cdctest/validator.go
@@ -26,7 +26,8 @@ import (
 type Validator interface {
 	// NoteRow accepts a changed row entry.
 	NoteRow(partition string, key, value string, updated hlc.Timestamp) error
-	// NoteResolved accepts a resolved timestamp entry.
+	// NoteResolved accepts a resolved timestamp entry. NB: This resolved
+	// timestamp should apply for all spans tracked by the validator.
 	NoteResolved(partition string, resolved hlc.Timestamp) error
 	// Failures returns any violations seen so far.
 	Failures() []string

--- a/pkg/ccl/changefeedccl/cdctest/validator_test.go
+++ b/pkg/ccl/changefeedccl/cdctest/validator_test.go
@@ -96,6 +96,15 @@ func TestOrderValidator(t *testing.T) {
 				`: saw new row timestamp 2.0000000000 after 3.0000000000 was resolved`,
 		)
 	})
+	t.Run(`regression in resolved timestamp`, func(t *testing.T) {
+		v := NewOrderValidator(`t1`)
+		noteResolved(t, v, `p2`, ts(2))
+		noteResolved(t, v, `p2`, ts(1))
+		assertValidatorFailures(t, v,
+			`new resolved timestamp 0.000000001,0 is lower than existing resolved timestamp`+
+				` 0.000000002,0 for partition p2`,
+		)
+	})
 }
 
 func TestBeforeAfterValidator(t *testing.T) {


### PR DESCRIPTION
streamingccl: fix incorrect usages of cdctest.Validator

The `NoteResolved` API on the `cdctest.Validator` requires that the passed
resolved timestamp is the resolved timetsamp / frontier for the whole set
of spans being tracked by the validator. Previously, tests would submit resolved
timestamps for subsets of spans at a time, which is incorrect. This would
not cause tests to fail because the order validator does not
assert that resolved timetsamps monotonically increase (tracked by https://github.com/cockroachdb/cockroach/issues/108872).
This change updates these tests to submit resolved timestamps for the
overall set of spans being tracked. After this change, fixing the
ordering validator in (https://github.com/cockroachdb/cockroach/issues/108872) will not cause these tests to fail.

Release note: None
Epic: None

--- 

changefeedccl: assert increasing resolved message timestamps in validators #108861

Previously, no validator in the `cdctest` package would assert that resolved messages increase monotonically. This is an important ordering guarantee that changefeeds provide.

This change updates the `orderValidator` to assert this.

Release note: None
Epic: None
Fixes: https://github.com/cockroachdb/cockroach/issues/108872
