### PR TITLE
changefeedccl: revert "do not merge: force parquet cloud storage tests"

### DIFF
--- a/pkg/ccl/changefeedccl/cdctest/nemeses.go
+++ b/pkg/ccl/changefeedccl/cdctest/nemeses.go
@@ -30,7 +30,12 @@ import (
 // real output of a changefeed. The output rows and resolved timestamps of the
 // tested feed are fed into them to check for anomalies.
 func RunNemesis(
-	f TestFeedFactory, db *gosql.DB, isSinkless bool, withLegacySchemaChanger bool, rng *rand.Rand,
+	f TestFeedFactory,
+	db *gosql.DB,
+	isSinkless bool,
+	isCloudstorage bool,
+	withLegacySchemaChanger bool,
+	rng *rand.Rand,
 ) (Validator, error) {
 	// possible additional nemeses:
 	// - schema changes
@@ -156,7 +161,7 @@ func RunNemesis(
 	}
 
 	withFormatParquet := ""
-	if rand.Intn(2) < 2 {
+	if isCloudstorage && rand.Intn(2) < 1 {
 		withFormatParquet = ", format=parquet"
 	}
 	foo, err := f.Feed(fmt.Sprintf(`CREATE CHANGEFEED FOR foo WITH updated, resolved, diff %s`, withFormatParquet))

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -196,7 +196,7 @@ func TestChangefeedBasicQueryWrapped(t *testing.T) {
 		// Currently, parquet format (which may be injected by feed() call),  doesn't
 		// know how to handle tuple types (cdc_prev); so, force JSON format.
 		foo := feed(t, f, `
-CREATE CHANGEFEED WITH envelope='wrapped', format='parquet', diff
+CREATE CHANGEFEED WITH envelope='wrapped', format='json', diff
 AS SELECT b||a AS ba, event_op() AS op  FROM foo`)
 		defer closeFeed(t, foo)
 
@@ -225,7 +225,7 @@ AS SELECT b||a AS ba, event_op() AS op  FROM foo`)
 		})
 	}
 
-	cdcTest(t, testFn, feedTestForceSink("cloudstorage"))
+	cdcTest(t, testFn, feedTestForceSink("webhook"))
 }
 
 // Same test as TestChangefeedBasicQueryWrapped, but this time using AVRO.
@@ -459,7 +459,7 @@ func TestChangefeedDiff(t *testing.T) {
 		sqlDB.Exec(t, `INSERT INTO foo VALUES (0, 'initial')`)
 		sqlDB.Exec(t, `UPSERT INTO foo VALUES (0, 'updated')`)
 
-		foo := feed(t, f, `CREATE CHANGEFEED FOR foo WITH diff, format=parquet`)
+		foo := feed(t, f, `CREATE CHANGEFEED FOR foo WITH diff`)
 		defer closeFeed(t, foo)
 
 		// 'initial' is skipped because only the latest value ('updated') is
@@ -491,7 +491,7 @@ func TestChangefeedDiff(t *testing.T) {
 		})
 	}
 
-	cdcTest(t, testFn, feedTestForceSink("cloudstorage"))
+	cdcTest(t, testFn)
 }
 
 func TestChangefeedTenants(t *testing.T) {
@@ -6822,7 +6822,7 @@ func TestChangefeedEndTime(t *testing.T) {
 		sqlDB.Exec(t, "INSERT INTO foo VALUES (1), (2), (3)")
 
 		fakeEndTime := s.Server.Clock().Now().Add(int64(time.Hour), 0).AsOfSystemTime()
-		feed := feed(t, f, "CREATE CHANGEFEED FOR foo WITH end_time = $1, format=parquet", fakeEndTime)
+		feed := feed(t, f, "CREATE CHANGEFEED FOR foo WITH end_time = $1", fakeEndTime)
 		defer closeFeed(t, feed)
 
 		assertPayloads(t, feed, []string{
@@ -6839,7 +6839,7 @@ func TestChangefeedEndTime(t *testing.T) {
 		}))
 	}
 
-	cdcTest(t, testFn, feedTestForceSink("cloudstorage"))
+	cdcTest(t, testFn, feedTestEnterpriseSinks)
 }
 
 func TestChangefeedEndTimeWithCursor(t *testing.T) {

--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -885,9 +885,6 @@ func randomSinkTypeWithOptions(options feedTestOptions) string {
 			sinkWeights[sinkType] = 0
 		}
 	}
-	if weight, ok := sinkWeights["cloudstorage"]; ok && weight != 0 {
-		sinkWeights = map[string]int{"cloudstorage": 1}
-	}
 	weightTotal := 0
 	for _, weight := range sinkWeights {
 		weightTotal += weight

--- a/pkg/ccl/changefeedccl/nemeses_test.go
+++ b/pkg/ccl/changefeedccl/nemeses_test.go
@@ -36,7 +36,9 @@ func TestChangefeedNemeses(t *testing.T) {
 		// TODO(dan): Ugly hack to disable `eventPause` in sinkless feeds. See comment in
 		// `RunNemesis` for details.
 		isSinkless := strings.Contains(t.Name(), "sinkless")
-		v, err := cdctest.RunNemesis(f, s.DB, isSinkless, withLegacySchemaChanger, rng)
+		isCloudstorage := strings.Contains(t.Name(), "cloudstorage")
+
+		v, err := cdctest.RunNemesis(f, s.DB, isSinkless, isCloudstorage, withLegacySchemaChanger, rng)
 		if err != nil {
 			t.Fatalf("%+v", err)
 		}

--- a/pkg/ccl/changefeedccl/testfeed_test.go
+++ b/pkg/ccl/changefeedccl/testfeed_test.go
@@ -1081,7 +1081,7 @@ func (f *cloudFeedFactory) Feed(
 			}
 		}
 		randNum := rand.Intn(5)
-		if randNum < 0 {
+		if randNum < 3 {
 			parquetPossible = false
 		}
 		if parquetPossible {


### PR DESCRIPTION
This reverts commit d5d1c88aa851398582f5fdf9e30653f8d4123883.

This commit was in a PR to force parquet when possible instead of randomly
choosing a format. This change had the purpose of helping check that all
test pass when using parquet in the essential CI of the original PR.
Now, we should revert it to go back to randomized testing.

Release note: None
Epic: None