### PR TITLE
sql: fix sequence reporting of smallint type

### DIFF
--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -1256,14 +1256,24 @@ https://www.postgresql.org/docs/9.5/infoschema-sequences.html`,
 				if !table.IsSequence() {
 					return nil
 				}
+				typ := "INT8"
+				precision := 64
+				switch table.GetSequenceOpts().AsIntegerType {
+				case "INT2":
+					precision = 16
+					typ = "INT2"
+				case "INT4":
+					precision = 32
+					typ = "INT4"
+				}
 				return addRow(
-					tree.NewDString(db.GetName()),    // catalog
-					tree.NewDString(sc.GetName()),    // schema
-					tree.NewDString(table.GetName()), // name
-					tree.NewDString("bigint"),        // type
-					tree.NewDInt(64),                 // numeric precision
-					tree.NewDInt(2),                  // numeric precision radix
-					tree.NewDInt(0),                  // numeric scale
+					tree.NewDString(db.GetName()),      // catalog
+					tree.NewDString(sc.GetName()),      // schema
+					tree.NewDString(table.GetName()),   // name
+					tree.NewDString(typ),               // integer type, one of ["INT2", "INT4", "INT8"]
+					tree.NewDInt(tree.DInt(precision)), // numeric precision
+					tree.NewDInt(2),                    // numeric precision radix
+					tree.NewDInt(0),                    // numeric scale
 					tree.NewDString(strconv.FormatInt(table.GetSequenceOpts().Start, 10)),     // start value
 					tree.NewDString(strconv.FormatInt(table.GetSequenceOpts().MinValue, 10)),  // min value
 					tree.NewDString(strconv.FormatInt(table.GetSequenceOpts().MaxValue, 10)),  // max value

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -4655,8 +4655,8 @@ SET DATABASE = test
 query TTTTIIITTTTT rowsort
 SELECT * FROM information_schema.sequences
 ----
-test  public  generated_as_identity_b_seq  bigint  64  2  0  1  1  9223372036854775807  1  NO
-test  public  generated_as_identity_c_seq  bigint  64  2  0  1  1  9223372036854775807  1  NO
+test  public  generated_as_identity_b_seq  INT8  64  2  0  1  1  9223372036854775807  1  NO
+test  public  generated_as_identity_c_seq  INT8  64  2  0  1  1  9223372036854775807  1  NO
 
 statement ok
 CREATE SEQUENCE test_seq
@@ -4664,15 +4664,38 @@ CREATE SEQUENCE test_seq
 statement ok
 CREATE SEQUENCE test_seq_2 INCREMENT -1 MINVALUE 5 MAXVALUE 1000 START WITH 15
 
+statement ok
+CREATE SEQUENCE test_seq_3 AS smallint
+
+statement ok
+CREATE SEQUENCE test_seq_4 AS integer 
+
+statement ok
+CREATE SEQUENCE test_seq_5 AS bigint
+
+statement ok
+CREATE SEQUENCE test_seq_6 AS INT2 
+
+statement ok
+CREATE SEQUENCE test_seq_7 AS INT4
+
+statement ok
+CREATE SEQUENCE test_seq_8 AS INT8 
 
 query TTTTIIITTTTT colnames,rowsort
 SELECT * FROM information_schema.sequences
 ----
 sequence_catalog  sequence_schema  sequence_name                data_type  numeric_precision  numeric_precision_radix  numeric_scale  start_value  minimum_value  maximum_value        increment  cycle_option
-test              public           generated_as_identity_b_seq  bigint     64                 2                        0              1            1              9223372036854775807  1          NO
-test              public           generated_as_identity_c_seq  bigint     64                 2                        0              1            1              9223372036854775807  1          NO
-test              public           test_seq                     bigint     64                 2                        0              1            1              9223372036854775807  1          NO
-test              public           test_seq_2                   bigint     64                 2                        0              15           5              1000                 -1         NO
+test              public           generated_as_identity_b_seq  INT8       64                 2                        0              1            1              9223372036854775807  1          NO
+test              public           generated_as_identity_c_seq  INT8       64                 2                        0              1            1              9223372036854775807  1          NO
+test              public           test_seq                     INT8       64                 2                        0              1            1              9223372036854775807  1          NO
+test              public           test_seq_2                   INT8       64                 2                        0              15           5              1000                 -1         NO
+test              public           test_seq_3                   INT2       16                 2                        0              1            1              32767                1          NO
+test              public           test_seq_4                   INT8       64                 2                        0              1            1              9223372036854775807  1          NO
+test              public           test_seq_5                   INT8       64                 2                        0              1            1              9223372036854775807  1          NO
+test              public           test_seq_6                   INT2       16                 2                        0              1            1              32767                1          NO
+test              public           test_seq_7                   INT4       32                 2                        0              1            1              2147483647           1          NO
+test              public           test_seq_8                   INT8       64                 2                        0              1            1              9223372036854775807  1          NO
 
 statement ok
 CREATE DATABASE other_db


### PR DESCRIPTION
Previously the type sequence descriptor was hardcoded to be 'bigint' even when the type is created as INT2. This causes confusion in the 'information_schema' table as reported on cockroach#108847.

In this PR 2 fields are updated:

1. `data_type` field will report `INT2` if it is created as `smallint`(int2), `INtT4`, or `INT8` if it is created as `bigint`(int8).

2. `numeric_precision` for `smallint` will be reported as 16, as smallint only has 16 bits. https://www.postgresql.org/docs/current/infoschema-sequences.html 

fixes https://github.com/cockroachdb/cockroach/issues/108847