### PR TITLE
kvstreamer: Revert "kvstreamer: resolve a deadlock in an edge case"

### DIFF
--- a/pkg/kv/kvclient/kvstreamer/results_buffer.go
+++ b/pkg/kv/kvclient/kvstreamer/results_buffer.go
@@ -52,8 +52,8 @@ type resultsBuffer interface {
 	get(context.Context) (_ []Result, allComplete bool, _ error)
 
 	// wait blocks until there is at least one Result available to be returned
-	// to the client or the passed-in context is canceled.
-	wait(context.Context) error
+	// to the client.
+	wait()
 
 	// releaseOne decrements the number of unreleased Results by one.
 	releaseOne()
@@ -227,13 +227,8 @@ func (b *resultsBufferBase) signal() {
 	}
 }
 
-func (b *resultsBufferBase) wait(ctx context.Context) error {
-	select {
-	case <-b.hasResults:
-		return b.error()
-	case <-ctx.Done():
-		return ctx.Err()
-	}
+func (b *resultsBufferBase) wait() {
+	<-b.hasResults
 }
 
 func (b *resultsBufferBase) numUnreleased() int {

--- a/pkg/kv/kvclient/kvstreamer/streamer.go
+++ b/pkg/kv/kvclient/kvstreamer/streamer.go
@@ -728,7 +728,10 @@ func (s *Streamer) GetResults(ctx context.Context) ([]Result, error) {
 		if len(results) > 0 || allComplete || err != nil {
 			return results, err
 		}
-		if err = s.results.wait(ctx); err != nil {
+		s.results.wait()
+		// Check whether the Streamer has been canceled or closed while we were
+		// waiting for the results.
+		if err = ctx.Err(); err != nil {
 			s.results.setError(err)
 			return nil, err
 		}


### PR DESCRIPTION
This reverts commit ee761a1cbd144b1a47cb96713bba2523a11ec687. Let's do this on master branch in hopes of getting another reproduction of #101823. We'll un-revert it during 23.2 stability (tracked by #108884).

Epic: None