### PR TITLE
tree: don't resolve expressions with wildcard types

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/typing
+++ b/pkg/sql/logictest/testdata/logic_test/typing
@@ -313,3 +313,18 @@ SELECT (CASE WHEN t108360_1.t > t108360_2.c THEN t108360_1.t ELSE t108360_2.c EN
 FROM t108360_1, t108360_2
 WHERE t108360_1.t = (CASE WHEN t108360_1.t > t108360_2.c THEN t108360_1.t ELSE t108360_2.c END);
 ----
+
+# Static analysis types should never make it to execution.
+statement ok
+CREATE TABLE t83496 (
+  a STRING,
+  b STRING
+);
+CREATE TYPE typ83496 AS ENUM ('foo', 'bar');
+
+statement ok
+SELECT * FROM t83496
+WHERE (
+  (SELECT 'bar':::typ83496 FROM t83496 WHERE false)
+  IS NOT DISTINCT FROM CASE WHEN NULL THEN NULL ELSE NULL END
+);

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -1817,7 +1817,7 @@ func (expr *Array) TypeCheck(
 	}
 
 	if len(expr.Exprs) == 0 {
-		if desiredParam.Family() == types.AnyFamily {
+		if desiredParam == types.Any {
 			return nil, errAmbiguousArrayType
 		}
 		expr.typ = types.MakeArray(desiredParam)
@@ -2696,7 +2696,7 @@ func typeCheckSameTypedExprs(
 			return nil, nil, err
 		}
 		typ := typedExpr.ResolvedType()
-		if typ == types.Unknown && desired != types.Any {
+		if typ == types.Unknown && !desired.IsWildcardType() {
 			// The expression had a NULL type, so we can return the desired type as
 			// the expression type.
 			typ = desired
@@ -2779,7 +2779,7 @@ func typeCheckSameTypedExprs(
 				}
 				return typedExprs, typ, nil
 			default:
-				if desired != types.Any {
+				if !desired.IsWildcardType() {
 					return typedExprs, desired, nil
 				}
 				return typedExprs, types.Unknown, nil
@@ -2874,7 +2874,7 @@ func typeCheckSameTypedConsts(
 	}
 
 	// If typ is not a wildcard, all consts try to become typ.
-	if typ.Family() != types.AnyFamily {
+	if !typ.IsWildcardType() {
 		all := true
 		for i, ok := s.constIdxs.Next(0); ok; i, ok = s.constIdxs.Next(i + 1) {
 			if !canConstantBecome(s.exprs[i].(Constant), typ) {
@@ -2913,7 +2913,7 @@ func typeCheckSameTypedConsts(
 		if typ := typedExpr.ResolvedType(); !typ.Equivalent(reqTyp) {
 			return nil, unexpectedTypeError(s.exprs[i], reqTyp, typ)
 		}
-		if reqTyp.Family() == types.AnyFamily {
+		if reqTyp.IsWildcardType() {
 			reqTyp = typedExpr.ResolvedType()
 		}
 	}

--- a/pkg/sql/types/types.go
+++ b/pkg/sql/types/types.go
@@ -2132,6 +2132,16 @@ func (t *T) Equal(other *T) bool {
 	return t.Identical(other)
 }
 
+// IsWildcardType returns true if the type is only used as a wildcard during
+// static analysis, and cannot be used during execution.
+func (t *T) IsWildcardType() bool {
+	switch t {
+	case Any, AnyArray, AnyCollatedString, AnyEnum, AnyEnumArray, AnyTuple, AnyTupleArray:
+		return true
+	}
+	return false
+}
+
 // Size returns the size, in bytes, of this type once it has been marshaled to
 // a byte buffer. This is typically called to determine the size of the buffer
 // that needs to be allocated before calling Marshal.


### PR DESCRIPTION
There are various wildcard types that are used during type-checking, but which are not valid during execution. Previously, we only checked for `types.Any` in several places, but there are other wildcard types like `types.AnyEnum` with similar properties. This could lead to an internal panic during execution when this invalid type was resolved. This patch adds a new method `types.T.IsWildcardType()` that checks for all wildcard types, to be used during type-checking.

Fixes #83496

Release note (bug fix): Fixed a bug that has existed since before v22.2 which could cause an internal error during distributed execution for an expression like `CASE` that requires its inputs to be the same type with all `NULL` inputs.