### PR TITLE
cli: use reusable listeners in TestStageVersionCheck

### DIFF
--- a/pkg/cli/debug_recover_loss_of_quorum_test.go
+++ b/pkg/cli/debug_recover_loss_of_quorum_test.go
@@ -328,6 +328,9 @@ func TestStageVersionCheck(t *testing.T) {
 	})
 	defer c.Cleanup()
 
+	listenerReg := listenerutil.NewListenerRegistry()
+	defer listenerReg.Close()
+
 	storeReg := server.NewStickyVFSRegistry()
 	tc := testcluster.NewTestCluster(t, 4, base.TestClusterArgs{
 		ReplicationMode: base.ReplicationManual,
@@ -343,6 +346,7 @@ func TestStageVersionCheck(t *testing.T) {
 				},
 			},
 		},
+		ReusableListenerReg: listenerReg,
 	})
 	tc.Start(t)
 	defer tc.Stopper().Stop(ctx)


### PR DESCRIPTION
The test stops a node. If another CRDB test (or entirely different process) binds to the released port, the remaining nodes can be attempting to exchange messages with that process. This causes arbitrary errors and test flakes.

This commit makes `TestStageVersionCheck` retain the port despite the node is stopped, to prevent the port reuse by others, and the resulting errors.

Fixes #108803
Epic: none
Release note: none