### PR TITLE
release-23.1: cli: use reusable listeners in TestStageVersionCheck

### DIFF
--- a/pkg/cli/debug_recover_loss_of_quorum_test.go
+++ b/pkg/cli/debug_recover_loss_of_quorum_test.go
@@ -332,6 +332,9 @@ func TestStageVersionCheck(t *testing.T) {
 	})
 	defer c.Cleanup()
 
+	listenerReg := listenerutil.NewListenerRegistry()
+	defer listenerReg.Close()
+
 	storeReg := server.NewStickyInMemEnginesRegistry()
 	defer storeReg.CloseAllStickyInMemEngines()
 	tc := testcluster.NewTestCluster(t, 4, base.TestClusterArgs{
@@ -348,6 +351,7 @@ func TestStageVersionCheck(t *testing.T) {
 				},
 			},
 		},
+		ReusableListenerReg: listenerReg,
 	})
 	tc.Start(t)
 	defer tc.Stopper().Stop(ctx)


### PR DESCRIPTION
Backport 1/1 commits from #108897.

/cc @cockroachdb/release

---

The test stops a node. If another CRDB test (or entirely different process) binds to the released port, the remaining nodes can be attempting to exchange messages with that process. This causes arbitrary errors and test flakes.

This commit makes `TestStageVersionCheck` retain the port despite the node is stopped, to prevent the port reuse by others, and the resulting errors.

Epic: none
Release note: none
Release justification: flaky test fix
