### PR TITLE
spanconfig: exclude non table data from span used for BACKUP 

### DIFF
--- a/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/testdata/multitenant/protectedts
+++ b/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/testdata/multitenant/protectedts
@@ -56,7 +56,7 @@ reconcile tenant=10
 # We should see protected timestamp record mutations as the host tenant.
 mutations
 ----
-upsert {entire-keyspace}                   protection_policies=[{ts: 1}]
+upsert {cluster-backup-keyspace}           protection_policies=[{ts: 1}]
 upsert {source=1,target=1}                 protection_policies=[{ts: 2}]
 upsert {source=1,target=10}                protection_policies=[{ts: 2}]
 
@@ -138,7 +138,7 @@ upsert {source=10,target=10}               protection_policies=[{ts: 3}]
 
 state limit=4
 ----
-{entire-keyspace}                          protection_policies=[{ts: 1}]
+{cluster-backup-keyspace}                  protection_policies=[{ts: 1}]
 {source=1,target=1}                        protection_policies=[{ts: 2}]
 {source=1,target=10}                       protection_policies=[{ts: 2}]
 {source=10,target=10}                      protection_policies=[{ts: 3}]
@@ -157,7 +157,7 @@ mutations tenant=10
 
 mutations
 ----
-delete {entire-keyspace}
+delete {cluster-backup-keyspace}
 delete {source=1,target=1}
 delete {source=1,target=10}
 

--- a/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/testdata/protectedts
+++ b/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/testdata/protectedts
@@ -17,7 +17,7 @@ tenants 1,2
 
 mutations
 ----
-upsert {entire-keyspace}                   protection_policies=[{ts: 1}]
+upsert {cluster-backup-keyspace}           protection_policies=[{ts: 1}]
 upsert {source=1,target=1}                 protection_policies=[{ts: 2}]
 upsert {source=1,target=2}                 protection_policies=[{ts: 2}]
 
@@ -64,12 +64,12 @@ cluster
 
 mutations
 ----
-delete {entire-keyspace}
-upsert {entire-keyspace}                   protection_policies=[{ts: 1} {ts: 5}]
+delete {cluster-backup-keyspace}
+upsert {cluster-backup-keyspace}           protection_policies=[{ts: 1} {ts: 5}]
 
 state limit=3
 ----
-{entire-keyspace}                          protection_policies=[{ts: 1} {ts: 5}]
+{cluster-backup-keyspace}                  protection_policies=[{ts: 1} {ts: 5}]
 {source=1,target=1}                        protection_policies=[{ts: 2}]
 {source=1,target=2}                        protection_policies=[{ts: 2}]
 ...
@@ -101,8 +101,8 @@ release record-id=5
 
 mutations
 ----
-delete {entire-keyspace}
-upsert {entire-keyspace}                   protection_policies=[{ts: 1}]
+delete {cluster-backup-keyspace}
+upsert {cluster-backup-keyspace}           protection_policies=[{ts: 1}]
 
 release record-id=1
 ----
@@ -111,7 +111,7 @@ release record-id=1
 # a delete entry.
 mutations
 ----
-delete {entire-keyspace}
+delete {cluster-backup-keyspace}
 
 state limit=2
 ----

--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/protectedts
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/protectedts
@@ -83,7 +83,7 @@ tenants 111,112
 
 translate system-span-configurations
 ----
-{entire-keyspace}                          protection_policies=[{ts: 3}]
+{cluster-backup-keyspace}                  protection_policies=[{ts: 3}]
 {source=1,target=111}                      protection_policies=[{ts: 3} {ts: 4}]
 {source=1,target=112}                      protection_policies=[{ts: 3} {ts: 4}]
 {source=1,target=113}                      protection_policies=[{ts: 4}]
@@ -99,7 +99,7 @@ release record-id=1
 
 translate system-span-configurations
 ----
-{entire-keyspace}                          protection_policies=[{ts: 3}]
+{cluster-backup-keyspace}                  protection_policies=[{ts: 3}]
 {source=1,target=111}                      protection_policies=[{ts: 3} {ts: 4}]
 {source=1,target=112}                      protection_policies=[{ts: 3} {ts: 4}]
 {source=1,target=113}                      protection_policies=[{ts: 4}]
@@ -115,7 +115,7 @@ release record-id=2
 
 translate system-span-configurations
 ----
-{entire-keyspace}                          protection_policies=[{ts: 3}]
+{cluster-backup-keyspace}                  protection_policies=[{ts: 3}]
 {source=1,target=111}                      protection_policies=[{ts: 3} {ts: 4}]
 {source=1,target=112}                      protection_policies=[{ts: 3} {ts: 4}]
 {source=1,target=113}                      protection_policies=[{ts: 4}]

--- a/pkg/keys/spans.go
+++ b/pkg/keys/spans.go
@@ -16,6 +16,11 @@ var (
 	// EverythingSpan is a span that covers everything.
 	EverythingSpan = roachpb.Span{Key: roachpb.KeyMin, EndKey: roachpb.KeyMax}
 
+	// ClusterBackupSpan is a span that covers all System and Tenant tables. It is
+	// a subset of EverythingSpan and skips certain keyspaces that are not used in
+	// full cluster backups (i.e. NodeLiveness, Timeseries, etc.)
+	ClusterBackupSpan = roachpb.Span{Key: TableDataMin, EndKey: roachpb.KeyMax}
+
 	// Meta1Span holds all first level addressing records.
 	Meta1Span = roachpb.Span{Key: roachpb.KeyMin, EndKey: Meta2Prefix}
 

--- a/pkg/spanconfig/spanconfigkvaccessor/kvaccessor.go
+++ b/pkg/spanconfig/spanconfigkvaccessor/kvaccessor.go
@@ -107,7 +107,7 @@ func (k *KVAccessor) GetAllSystemSpanConfigsThatApply(
 	// 2. The system span config set by the host over just the tenant's keyspace.
 	// 3. The system span config set by the tenant over its own keyspace.
 	targets := []spanconfig.Target{
-		spanconfig.MakeTargetFromSystemTarget(spanconfig.MakeEntireKeyspaceTarget()),
+		spanconfig.MakeTargetFromSystemTarget(spanconfig.MakeClusterBackupKeyspaceTarget()),
 		spanconfig.MakeTargetFromSystemTarget(hostSetOnTenant),
 	}
 

--- a/pkg/spanconfig/spanconfigkvaccessor/testdata/get_all_system_span_configs_that_apply
+++ b/pkg/spanconfig/spanconfigkvaccessor/testdata/get_all_system_span_configs_that_apply
@@ -20,7 +20,7 @@ kvaccessor-get-all-system-span-configs-that-apply tenant-id=20
 ----
 
 kvaccessor-update
-upsert {entire-keyspace}:B
+upsert {cluster-backup-keyspace}:B
 upsert {source=10,target=10}:C
 upsert {source=1,target=1}:D
 ----
@@ -43,7 +43,7 @@ B
 
 # Remove a system span config and update another; make sure it's reflected.
 kvaccessor-update
-delete {entire-keyspace}
+delete {cluster-backup-keyspace}
 upsert {source=1,target=10}:E
 ----
 ok

--- a/pkg/spanconfig/spanconfigkvaccessor/testdata/system_span_configs
+++ b/pkg/spanconfig/spanconfigkvaccessor/testdata/system_span_configs
@@ -2,7 +2,7 @@
 
 # Test with an empty slate.
 kvaccessor-get
-system-target {entire-keyspace}
+system-target {cluster-backup-keyspace}
 system-target {source=1,target=1}
 system-target {source=1,target=10}
 system-target {source=20,target=20}
@@ -10,13 +10,13 @@ system-target {source=20,target=20}
 
 # Try deleting a system span configuration that doesn't exist.
 kvaccessor-update
-delete {entire-keyspace}
+delete {cluster-backup-keyspace}
 ----
 err: expected to delete 1 row(s), deleted 0
 
 # Basic tests that set all possible combinations of system targets.
 kvaccessor-update
-upsert {entire-keyspace}:A
+upsert {cluster-backup-keyspace}:A
 upsert {source=1,target=1}:B
 upsert {source=1,target=10}:C
 upsert {source=20,target=20}:D
@@ -24,19 +24,19 @@ upsert {source=20,target=20}:D
 ok
 
 kvaccessor-get
-system-target {entire-keyspace}
+system-target {cluster-backup-keyspace}
 system-target {source=1,target=1}
 system-target {source=1,target=10}
 system-target {source=20,target=20}
 ----
-{entire-keyspace}:A
+{cluster-backup-keyspace}:A
 {source=1,target=1}:B
 {source=1,target=10}:C
 {source=20,target=20}:D
 
 # Update some of the span configurations that we added and ensure that works.
 kvaccessor-update
-upsert {entire-keyspace}:F
+upsert {cluster-backup-keyspace}:F
 upsert {source=1,target=1}:G
 upsert {source=1,target=10}:H
 upsert {source=20,target=20}:I
@@ -44,12 +44,12 @@ upsert {source=20,target=20}:I
 ok
 
 kvaccessor-get
-system-target {entire-keyspace}
+system-target {cluster-backup-keyspace}
 system-target {source=1,target=1}
 system-target {source=1,target=10}
 system-target {source=20,target=20}
 ----
-{entire-keyspace}:F
+{cluster-backup-keyspace}:F
 {source=1,target=1}:G
 {source=1,target=10}:H
 {source=20,target=20}:I
@@ -64,7 +64,7 @@ system-target {source=1,all-tenant-keyspace-targets-set}
 # Delete all the system span configurations that we just added and ensure
 # they take effect.
 kvaccessor-update
-delete {entire-keyspace}
+delete {cluster-backup-keyspace}
 delete {source=1,target=1}
 delete {source=1,target=10}
 delete {source=20,target=20}
@@ -72,7 +72,7 @@ delete {source=20,target=20}
 ok
 
 kvaccessor-get
-system-target {entire-keyspace}
+system-target {cluster-backup-keyspace}
 system-target {source=1,target=1}
 system-target {source=1,target=10}
 system-target {source=20,target=20}
@@ -86,7 +86,7 @@ system-target {source=1,all-tenant-keyspace-targets-set}
 # to distinct secondary tenants. We also add a system span configuration set by
 # one of these secondary tenant's on itself for kicks.
 kvaccessor-update
-upsert {entire-keyspace}:Z
+upsert {cluster-backup-keyspace}:Z
 upsert {source=1,target=10}:A
 upsert {source=1,target=20}:B
 upsert {source=1,target=30}:C
@@ -95,13 +95,13 @@ upsert {source=10,target=10}:G
 ok
 
 kvaccessor-get
-system-target {entire-keyspace}
+system-target {cluster-backup-keyspace}
 system-target {source=1,target=10}
 system-target {source=1,target=20}
 system-target {source=1,target=30}
 system-target {source=10,target=10}
 ----
-{entire-keyspace}:Z
+{cluster-backup-keyspace}:Z
 {source=1,target=10}:A
 {source=1,target=20}:B
 {source=1,target=30}:C

--- a/pkg/spanconfig/spanconfigkvaccessor/validation_test.go
+++ b/pkg/spanconfig/spanconfigkvaccessor/validation_test.go
@@ -26,7 +26,7 @@ func TestValidateUpdateArgs(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	entireKeyspaceTarget := spanconfig.MakeTargetFromSystemTarget(
-		spanconfig.MakeEntireKeyspaceTarget(),
+		spanconfig.MakeClusterBackupKeyspaceTarget(),
 	)
 
 	makeTenantTarget := func(id uint64) spanconfig.Target {

--- a/pkg/spanconfig/spanconfigkvsubscriber/datadriven_test.go
+++ b/pkg/spanconfig/spanconfigkvsubscriber/datadriven_test.go
@@ -47,7 +47,7 @@ import (
 //		delete [c,e)
 //		upsert [c,d):C
 //		upsert [d,e):D
-//		upsert {entire-keyspace}:X
+//		upsert {cluster-backup-keyspace}:X
 //		delete {source=1,target=20}
 //		----
 //

--- a/pkg/spanconfig/spanconfigkvsubscriber/spanconfigdecoder_test.go
+++ b/pkg/spanconfig/spanconfigkvsubscriber/spanconfigdecoder_test.go
@@ -108,7 +108,7 @@ func TestDecodeSystemTargets(t *testing.T) {
 			t, roachpb.SystemTenantID, roachpb.MustMakeTenantID(10),
 		),
 		// System tenant targeting the entire keyspace.
-		spanconfig.MakeEntireKeyspaceTarget(),
+		spanconfig.MakeClusterBackupKeyspaceTarget(),
 	} {
 		// We start with a fresh table for each run.
 		tdb.Exec(t, fmt.Sprintf("DROP TABLE IF EXISTS %s", dummyTableName))

--- a/pkg/spanconfig/spanconfigkvsubscriber/testdata/system_span_configs
+++ b/pkg/spanconfig/spanconfigkvsubscriber/testdata/system_span_configs
@@ -26,12 +26,12 @@ store-reader key=g
 conf=FALLBACK
 
 update
-upsert {entire-keyspace}:X
+upsert {cluster-backup-keyspace}:X
 ----
 
 updates
 ----
-[/Min,/Max)
+[/Table/0,/Max)
 
 store-reader key=a
 ----
@@ -69,12 +69,12 @@ conf=D+X+Y
 # Delete the system span config over the entire keyspace and ensure handlers are
 # invoked correctly + configs for various keys are correctly hydrated.
 update
-delete {entire-keyspace}
+delete {cluster-backup-keyspace}
 ----
 
 updates
 ----
-[/Min,/Max)
+[/Table/0,/Max)
 
 store-reader key=a
 ----

--- a/pkg/spanconfig/spanconfigreconciler/reconciler.go
+++ b/pkg/spanconfig/spanconfigreconciler/reconciler.go
@@ -368,7 +368,7 @@ func (f *fullReconciler) fetchExistingSpanConfigs(
 		// keyspace (including secondary tenants), on its tenant keyspace, and on
 		// other secondary tenant keyspaces.
 		targets = append(targets,
-			spanconfig.MakeTargetFromSystemTarget(spanconfig.MakeEntireKeyspaceTarget()))
+			spanconfig.MakeTargetFromSystemTarget(spanconfig.MakeClusterBackupKeyspaceTarget()))
 		targets = append(targets,
 			spanconfig.MakeTargetFromSystemTarget(spanconfig.MakeAllTenantKeyspaceTargetsSet(f.tenID)))
 		if f.knobs.ConfigureScratchRange {
@@ -628,7 +628,7 @@ func (r *incrementalReconciler) filterForMissingProtectedTimestampSystemTargets(
 			// For the host tenant a Cluster ProtectedTimestampUpdate corresponds
 			// to the entire keyspace (including secondary tenants).
 			if r.codec.ForSystemTenant() {
-				missingSystemTarget = spanconfig.MakeEntireKeyspaceTarget()
+				missingSystemTarget = spanconfig.MakeClusterBackupKeyspaceTarget()
 			} else {
 				// For a secondary tenant a Cluster ProtectedTimestampUpdate
 				// corresponds to the tenants keyspace.

--- a/pkg/spanconfig/spanconfigsqltranslator/sqltranslator.go
+++ b/pkg/spanconfig/spanconfigsqltranslator/sqltranslator.go
@@ -161,7 +161,7 @@ func (s *SQLTranslator) generateSystemSpanConfigRecords(
 		var systemTarget spanconfig.SystemTarget
 		var err error
 		if sourceTenantID == roachpb.SystemTenantID {
-			systemTarget = spanconfig.MakeEntireKeyspaceTarget()
+			systemTarget = spanconfig.MakeClusterBackupKeyspaceTarget()
 		} else {
 			systemTarget, err = spanconfig.MakeTenantKeyspaceTarget(sourceTenantID, sourceTenantID)
 			if err != nil {

--- a/pkg/spanconfig/spanconfigstore/store_test.go
+++ b/pkg/spanconfig/spanconfigstore/store_test.go
@@ -73,13 +73,13 @@ func (s *spanConfigStore) TestingSplitKeys(
 //	apply
 //	delete [a,c)
 //	set [c,h):X
-//	set {entire-keyspace}:X
+//	set {cluster-backup-keyspace}:X
 //	set {source=1,target=1}:Y
 //	----
 //	deleted [b,d)
 //	deleted [e,g)
 //	added [c,h):X
-//	added {entire-keyspace}:X
+//	added {cluster-backup-keyspace}:X
 //	added {source=1,target=1}:Y
 //
 //	get key=b
@@ -114,7 +114,7 @@ func (s *spanConfigStore) TestingSplitKeys(
 // delete /Tenant/10
 // ----
 //
-// Text of the form [a,b), {entire-keyspace}, {source=1,target=20}, and [a,b):C
+// Text of the form [a,b), {cluster-backup-keyspace}, {source=1,target=20}, and [a,b):C
 // correspond to targets {spans, system targets} and span config records; see
 // spanconfigtestutils.Parse{Target,Config,SpanConfigRecord} for more details.
 func TestDataDriven(t *testing.T) {
@@ -286,7 +286,7 @@ func TestStoreClone(t *testing.T) {
 			spanconfigtestutils.ParseConfig(t, "E"),
 		),
 		makeSpanConfigAddition(
-			spanconfig.MakeTargetFromSystemTarget(spanconfig.MakeEntireKeyspaceTarget()),
+			spanconfig.MakeTargetFromSystemTarget(spanconfig.MakeClusterBackupKeyspaceTarget()),
 			spanconfigtestutils.ParseConfig(t, "G"),
 		),
 		makeSpanConfigAddition(

--- a/pkg/spanconfig/spanconfigstore/system_store.go
+++ b/pkg/spanconfig/spanconfigstore/system_store.go
@@ -95,7 +95,7 @@ func (s *systemSpanConfigStore) combine(
 	// 2. The system span config set by the host over the tenant's keyspace.
 	// 3. The system span config set by the tenant itself over its own keyspace.
 	targets := []spanconfig.SystemTarget{
-		spanconfig.MakeEntireKeyspaceTarget(),
+		spanconfig.MakeClusterBackupKeyspaceTarget(),
 		hostSetOnTenant,
 	}
 

--- a/pkg/spanconfig/spanconfigstore/system_store_test.go
+++ b/pkg/spanconfig/spanconfigstore/system_store_test.go
@@ -62,7 +62,7 @@ func TestSystemSpanConfigStoreCombine(t *testing.T) {
 
 	updates := []spanconfig.Update{
 		makeSpanConfigAddition(
-			spanconfig.MakeTargetFromSystemTarget(spanconfig.MakeEntireKeyspaceTarget()),
+			spanconfig.MakeTargetFromSystemTarget(spanconfig.MakeClusterBackupKeyspaceTarget()),
 			makeSystemSpanConfig(100),
 		),
 		makeSpanConfigAddition(spanconfig.MakeTargetFromSystemTarget(

--- a/pkg/spanconfig/spanconfigstore/testdata/batched/system_span_configs
+++ b/pkg/spanconfig/spanconfigstore/testdata/batched/system_span_configs
@@ -4,11 +4,11 @@
 # apply a batch of system span configs + regular configs.
 apply
 set [a,f):A
-set {entire-keyspace}:X
+set {cluster-backup-keyspace}:X
 set {source=1,target=1}:Y
 set {source=10,target=10}:Z
 ----
-added {entire-keyspace}:X
+added {cluster-backup-keyspace}:X
 added {source=1,target=1}:Y
 added {source=10,target=10}:Z
 added [a,f):A
@@ -22,13 +22,13 @@ conf=A+X+Y
 # delete.
 apply
 set [c,d):B
-set {entire-keyspace}:W
+set {cluster-backup-keyspace}:W
 delete {source=1,target=1}
 ----
-deleted {entire-keyspace}
+deleted {cluster-backup-keyspace}
 deleted {source=1,target=1}
 deleted [a,f)
-added {entire-keyspace}:W
+added {cluster-backup-keyspace}:W
 added [a,c):A
 added [c,d):B
 added [d,f):A
@@ -46,10 +46,10 @@ conf=B+W
 
 apply
 delete [c,d)
-delete {entire-keyspace}
+delete {cluster-backup-keyspace}
 set {source=10,target=10}:V
 ----
-deleted {entire-keyspace}
+deleted {cluster-backup-keyspace}
 deleted {source=10,target=10}
 deleted [c,d)
 added {source=10,target=10}:V

--- a/pkg/spanconfig/spanconfigstore/testdata/batched/system_span_configs_overlap
+++ b/pkg/spanconfig/spanconfigstore/testdata/batched/system_span_configs_overlap
@@ -1,9 +1,9 @@
 apply
 set [b,d):A
-set {entire-keyspace}:X
+set {cluster-backup-keyspace}:X
 set [e,g):B
 ----
-added {entire-keyspace}:X
+added {cluster-backup-keyspace}:X
 added [b,d):A
 added [e,g):B
 

--- a/pkg/spanconfig/spanconfigstore/testdata/single/system_span_configs
+++ b/pkg/spanconfig/spanconfigstore/testdata/single/system_span_configs
@@ -6,9 +6,9 @@ set [a,c):A
 added [a,c):A
 
 apply
-set {entire-keyspace}:X
+set {cluster-backup-keyspace}:X
 ----
-added {entire-keyspace}:X
+added {cluster-backup-keyspace}:X
 
 # Check that keys are hydrated correctly.
 get key=b
@@ -21,7 +21,7 @@ conf=FALLBACK+X
 
 # Ensure no-ops appear as such.
 apply
-set {entire-keyspace}:X
+set {cluster-backup-keyspace}:X
 ----
 
 # Ensure combining system span configs that target a tenant and the entire
@@ -42,10 +42,10 @@ conf=FALLBACK+X+Y
 
 # Ensure updates take affect as you'd expect.
 apply
-set {entire-keyspace}:Z
+set {cluster-backup-keyspace}:Z
 ----
-deleted {entire-keyspace}
-added {entire-keyspace}:Z
+deleted {cluster-backup-keyspace}
+added {cluster-backup-keyspace}:Z
 
 get key=c
 ----
@@ -57,9 +57,9 @@ conf=A+Z+Y
 
 # Ensure deletion works properly.
 apply
-delete {entire-keyspace}
+delete {cluster-backup-keyspace}
 ----
-deleted {entire-keyspace}
+deleted {cluster-backup-keyspace}
 
 get key=c
 ----
@@ -71,7 +71,7 @@ conf=A+Y
 
 # Ensure deletion no-ops appear as such.
 apply
-delete {entire-keyspace}
+delete {cluster-backup-keyspace}
 ----
 
 # Ensure updates/deletes to the system span configuration that applies to tenant

--- a/pkg/spanconfig/spanconfigtestutils/utils.go
+++ b/pkg/spanconfig/spanconfigtestutils/utils.go
@@ -38,9 +38,9 @@ import (
 var spanRe = regexp.MustCompile(`^\[((/Tenant/\d*/)?\w+),\s??((/Tenant/\d*/)?\w+)\)$`)
 
 // systemTargetRe matches strings of the form
-// "{entire-keyspace|source=<id>,(target=<id>|all-tenant-keyspace-targets-set)}".
+// "{cluster-backup-keyspace|source=<id>,(target=<id>|all-tenant-keyspace-targets-set)}".
 var systemTargetRe = regexp.MustCompile(
-	`^{(entire-keyspace)|(source=(\d*),\s??((target=(\d*))|all-tenant-keyspace-targets-set))}$`,
+	`^{(cluster-backup-keyspace)|(source=(\d*),\s??((target=(\d*))|all-tenant-keyspace-targets-set))}$`,
 )
 
 // configRe matches either FALLBACK (for readability), a single letter, or a
@@ -211,8 +211,8 @@ func parseSystemTarget(t testing.TB, systemTarget string) spanconfig.SystemTarge
 	}
 	matches := systemTargetRe.FindStringSubmatch(systemTarget)
 
-	if matches[1] == "entire-keyspace" {
-		return spanconfig.MakeEntireKeyspaceTarget()
+	if matches[1] == "cluster-backup-keyspace" {
+		return spanconfig.MakeClusterBackupKeyspaceTarget()
 	}
 
 	sourceID, err := strconv.Atoi(matches[3])

--- a/pkg/spanconfig/target_test.go
+++ b/pkg/spanconfig/target_test.go
@@ -35,7 +35,7 @@ func TestEncodeDecodeSystemTarget(t *testing.T) {
 		// System tenant targeting a secondary tenant.
 		TestingMakeTenantKeyspaceTargetOrFatal(t, roachpb.SystemTenantID, roachpb.MustMakeTenantID(10)),
 		// System tenant targeting the entire keyspace.
-		MakeEntireKeyspaceTarget(),
+		MakeClusterBackupKeyspaceTarget(),
 	} {
 		systemTarget, err := decodeSystemTarget(testTarget.encode())
 		require.NoError(t, err)
@@ -61,7 +61,7 @@ func TestTargetToFromProto(t *testing.T) {
 		// System tenant targeting a secondary tenant.
 		TestingMakeTenantKeyspaceTargetOrFatal(t, roachpb.SystemTenantID, roachpb.MustMakeTenantID(10)),
 		// System tenant targeting the entire keyspace.
-		MakeEntireKeyspaceTarget(),
+		MakeClusterBackupKeyspaceTarget(),
 		// System tenant's read-only target to fetch all system span configurations
 		// it has set over secondary tenant keyspaces.
 		MakeAllTenantKeyspaceTargetsSet(roachpb.SystemTenantID),
@@ -93,8 +93,8 @@ func TestKeyspaceTargeted(t *testing.T) {
 		expSpan roachpb.Span
 	}{
 		{
-			target:  MakeTargetFromSystemTarget(MakeEntireKeyspaceTarget()),
-			expSpan: keys.EverythingSpan,
+			target:  MakeTargetFromSystemTarget(MakeClusterBackupKeyspaceTarget()),
+			expSpan: keys.ClusterBackupSpan,
 		},
 		{
 			target: MakeTargetFromSystemTarget(TestingMakeTenantKeyspaceTargetOrFatal(t, ten10, ten10)),
@@ -202,7 +202,7 @@ func TestSystemTargetValidation(t *testing.T) {
 			// Secondary tenants cannot target the entire keyspace.
 			sourceTenantID: tenant10,
 			targetTenantID: roachpb.TenantID{},
-			targetType:     SystemTargetTypeEntireKeyspace,
+			targetType:     SystemTargetTypeClusterBackupKeyspace,
 			expErr:         "only the host tenant is allowed to target the entire keyspace",
 		},
 		{
@@ -210,7 +210,7 @@ func TestSystemTargetValidation(t *testing.T) {
 			// set targetTenantID to themselves.
 			sourceTenantID: tenant10,
 			targetTenantID: tenant10,
-			targetType:     SystemTargetTypeEntireKeyspace,
+			targetType:     SystemTargetTypeClusterBackupKeyspace,
 			expErr:         "only the host tenant is allowed to target the entire keyspace",
 		},
 		{
@@ -234,7 +234,7 @@ func TestSystemTargetValidation(t *testing.T) {
 			// keyspace.
 			sourceTenantID: roachpb.SystemTenantID,
 			targetTenantID: tenant10,
-			targetType:     SystemTargetTypeEntireKeyspace,
+			targetType:     SystemTargetTypeClusterBackupKeyspace,
 			expErr:         "malformed system target for entire keyspace; targetTenantID set",
 		},
 		{
@@ -256,7 +256,7 @@ func TestSystemTargetValidation(t *testing.T) {
 			// System tenant targeting the entire keyspace is allowed.
 			sourceTenantID: roachpb.SystemTenantID,
 			targetTenantID: roachpb.TenantID{},
-			targetType:     SystemTargetTypeEntireKeyspace,
+			targetType:     SystemTargetTypeClusterBackupKeyspace,
 		},
 		{
 			// System tenant targeting itself is allowed.
@@ -309,7 +309,7 @@ func TestTargetSortingRandomized(t *testing.T) {
 	sortedTargets := Targets{
 		MakeTargetFromSystemTarget(MakeAllTenantKeyspaceTargetsSet(roachpb.SystemTenantID)),
 		MakeTargetFromSystemTarget(MakeAllTenantKeyspaceTargetsSet(roachpb.MustMakeTenantID(10))),
-		MakeTargetFromSystemTarget(MakeEntireKeyspaceTarget()),
+		MakeTargetFromSystemTarget(MakeClusterBackupKeyspaceTarget()),
 		MakeTargetFromSystemTarget(
 			TestingMakeTenantKeyspaceTargetOrFatal(t, roachpb.SystemTenantID, roachpb.SystemTenantID),
 		),
@@ -350,7 +350,7 @@ func TestSpanTargetsConstructedInSystemSpanConfigKeyspace(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	for _, tc := range []roachpb.Span{
-		MakeEntireKeyspaceTarget().encode(),
+		MakeClusterBackupKeyspaceTarget().encode(),
 		TestingMakeTenantKeyspaceTargetOrFatal(t, roachpb.MustMakeTenantID(10), roachpb.MustMakeTenantID(10)).encode(),
 		TestingMakeTenantKeyspaceTargetOrFatal(t, roachpb.SystemTenantID, roachpb.SystemTenantID).encode(),
 		TestingMakeTenantKeyspaceTargetOrFatal(t, roachpb.SystemTenantID, roachpb.MustMakeTenantID(10)).encode(),


### PR DESCRIPTION
Previously, we were returning the `EverythingSpan` when targetting the
entire keyspace for a cluster backup. This would place a protected
timestamp on the entire keyspace. This was non-ideal because not all
spans are used for BACKUP. This is especially problematic for the case
of `Nodeliveness` since it would violate its GC TTL while the BACKUP is
taking place.

This patch introducees a more limited span for this use case and only
includes table data for system tables and tenant tables since this is
the only data used in a BACKUP.

Fixes: https://github.com/cockroachdb/cockroach/issues/102338

Release note: None