### PR TITLE
release-22.2: roachtest: better handling of infrastructure flakes

### DIFF
--- a/pkg/cmd/internal/issues/issues.go
+++ b/pkg/cmd/internal/issues/issues.go
@@ -44,18 +44,37 @@ func enforceMaxLength(s string) string {
 	return s
 }
 
-var (
-	// Set of labels attached to created issues.
-	issueLabels = []string{"O-robot", "C-test-failure"}
-	// Label we expect when checking existing issues. Sometimes users open
-	// issues about flakes and don't assign all the labels. We want to at
-	// least require the test-failure label to avoid pathological situations
-	// in which a test name is so generic that it matches lots of random issues.
-	// Note that we'll only post a comment into an existing label if the labels
-	// match 100%, but we also cross-link issues whose labels differ. But we
-	// require that they all have searchLabel as a baseline.
-	searchLabel = issueLabels[1]
+const (
+	robotLabel       = "O-robot"
+	testFailureLabel = "C-test-failure"
 )
+
+// Label we expect when checking existing issues. Sometimes users open
+// issues about flakes and don't assign all the labels. We want to at
+// least require the one label to avoid pathological situations in
+// which a test name is so generic that it matches lots of random
+// issues.  Note that we'll only post a comment into an existing label
+// if the labels match 100%, but we also cross-link issues whose
+// labels differ. But we require that they all have searchLabel as a
+// baseline.
+func searchLabel(req PostRequest) string {
+	if req.SkipLabelTestFailure {
+		return robotLabel
+	}
+
+	return testFailureLabel
+}
+
+// issueLabels returns the set of labels attached by default to
+// created issues.
+func issueLabels(req PostRequest) []string {
+	labels := []string{robotLabel}
+	if req.SkipLabelTestFailure {
+		return labels
+	}
+
+	return append(labels, testFailureLabel)
+}
 
 // context augments context.Context with a logger.
 type postCtx struct {
@@ -298,7 +317,7 @@ func (p *poster) post(origCtx context.Context, formatter IssueFormatter, req Pos
 	// that would match if it weren't for their branch label.
 	qBase := fmt.Sprintf(
 		`repo:%q user:%q is:issue is:open in:title label:%q sort:created-desc %q`,
-		p.Repo, p.Org, searchLabel, title)
+		p.Repo, p.Org, searchLabel(req), title)
 
 	releaseLabel := fmt.Sprintf("branch-%s", p.Branch)
 	qExisting := qBase + " label:" + releaseLabel
@@ -351,7 +370,7 @@ func (p *poster) post(origCtx context.Context, formatter IssueFormatter, req Pos
 
 	body := enforceMaxLength(r.buf.String())
 
-	createLabels := append(issueLabels, releaseLabel)
+	createLabels := append(issueLabels(req), releaseLabel)
 	createLabels = append(createLabels, req.ExtraLabels...)
 	if foundIssue == nil {
 		issueRequest := github.IssueRequest{
@@ -421,6 +440,8 @@ type PostRequest struct {
 	PackageName string
 	// The name of the failing test.
 	TestName string
+	// If set, the C-test-failure label will not be applied.
+	SkipLabelTestFailure bool
 	// The test output.
 	Message string
 	// ExtraParams contains the parameters to be included in a failure

--- a/pkg/cmd/internal/issues/issues_test.go
+++ b/pkg/cmd/internal/issues/issues_test.go
@@ -56,6 +56,7 @@ func TestPost(t *testing.T) {
 		message              string
 		artifacts            string
 		reproCmd             string
+		skipTestFailure      bool
 		reproTitle, reproURL string
 	}
 
@@ -149,6 +150,13 @@ test logs left over in: /go/src/github.com/cockroachdb/cockroach/artifacts/logTe
 			message:     "boom",
 			reproURL:    "https://github.com/cockroachdb/cockroach",
 			reproTitle:  "FooBar README",
+		},
+		{
+			name:            "infrastructure-flake",
+			packageName:     "roachtest",
+			testName:        "TestCDC",
+			message:         "Something went wrong",
+			skipTestFailure: true,
 		},
 	}
 
@@ -302,14 +310,15 @@ test logs left over in: /go/src/github.com/cockroachdb/cockroach/artifacts/logTe
 				repro = HelpCommandAsLink(c.reproTitle, c.reproURL)
 			}
 			req := PostRequest{
-				PackageName:     c.packageName,
-				TestName:        c.testName,
-				Message:         c.message,
-				Artifacts:       c.artifacts,
-				MentionOnCreate: []string{"@cockroachdb/idonotexistbecausethisisatest"},
-				HelpCommand:     repro,
-				ExtraLabels:     []string{"release-blocker"},
-				ExtraParams:     map[string]string{"ROACHTEST_cloud": "gce"},
+				PackageName:          c.packageName,
+				TestName:             c.testName,
+				Message:              c.message,
+				SkipLabelTestFailure: c.skipTestFailure,
+				Artifacts:            c.artifacts,
+				MentionOnCreate:      []string{"@cockroachdb/idonotexistbecausethisisatest"},
+				HelpCommand:          repro,
+				ExtraLabels:          []string{"release-blocker"},
+				ExtraParams:          map[string]string{"ROACHTEST_cloud": "gce"},
 			}
 			require.NoError(t, p.post(context.Background(), UnitTestFormatter, req))
 

--- a/pkg/cmd/internal/issues/testdata/post/infrastructure-flake-matching-and-related-issue.txt
+++ b/pkg/cmd/internal/issues/testdata/post/infrastructure-flake-matching-and-related-issue.txt
@@ -1,0 +1,38 @@
+post
+----
+----
+searchIssue repo:"cockroach" user:"cockroachdb" is:issue is:open in:title label:"O-robot" sort:created-desc "roachtest: TestCDC failed" label:branch-release-0.1: [github.Issue{Number:30, Title:"boom", Labels:[github.Label{URL:"fake", Name:"C-test-failure"} github.Label{URL:"fake", Name:"O-robot"} github.Label{URL:"fake", Name:"release-0.1"}]}]
+searchIssue repo:"cockroach" user:"cockroachdb" is:issue is:open in:title label:"O-robot" sort:created-desc "roachtest: TestCDC failed" -label:branch-release-0.1: [github.Issue{Number:31, Title:"boom related", Labels:[github.Label{URL:"fake", Name:"C-test-failure"} github.Label{URL:"fake", Name:"O-robot"} github.Label{URL:"fake", Name:"release-0.2"}]}]
+createComment owner=cockroachdb repo=cockroach issue=30:
+
+roachtest.TestCDC [failed](https://teamcity.example.com/buildConfiguration/nightly123/8008135?buildTab=log) on release-0.1 @ [abcd123](https://github.com/cockroachdb/cockroach/commits/abcd123):
+
+
+```
+Something went wrong
+```
+<p>Parameters: <code>GOFLAGS=race</code>
+, <code>ROACHTEST_cloud=gce</code>
+, <code>TAGS=deadlock</code>
+</p>
+<details><summary>Help</summary>
+<p>
+
+See also: [How To Investigate a Go Test Failure \(internal\)](https://cockroachlabs.atlassian.net/l/c/HgfXfJgM)
+</p>
+</details>
+<details><summary>Same failure on other branches</summary>
+<p>
+
+- #31 boom related [C-test-failure O-robot release-0.2]
+</p>
+</details>
+<sub>
+
+[This test on roachdash](https://roachdash.crdb.dev/?filter=status:open%20t:.*TestCDC.*&sort=title+created&display=lastcommented+project) | [Improve this report!](https://github.com/cockroachdb/cockroach/tree/master/pkg/cmd/internal/issues)
+</sub>
+
+
+Rendered: https://github.com/cockroachdb/cockroach/issues/new?body=roachtest.TestCDC+%5Bfailed%5D%28https%3A%2F%2Fteamcity.example.com%2FbuildConfiguration%2Fnightly123%2F8008135%3FbuildTab%3Dlog%29+on+release-0.1+%40+%5Babcd123%5D%28https%3A%2F%2Fgithub.com%2Fcockroachdb%2Fcockroach%2Fcommits%2Fabcd123%29%3A%0A%0A%0A%60%60%60%0ASomething+went+wrong%0A%60%60%60%0A%3Cp%3EParameters%3A+%3Ccode%3EGOFLAGS%3Drace%3C%2Fcode%3E%0A%2C+%3Ccode%3EROACHTEST_cloud%3Dgce%3C%2Fcode%3E%0A%2C+%3Ccode%3ETAGS%3Ddeadlock%3C%2Fcode%3E%0A%3C%2Fp%3E%0A%3Cdetails%3E%3Csummary%3EHelp%3C%2Fsummary%3E%0A%3Cp%3E%0A%0ASee+also%3A+%5BHow+To+Investigate+a+Go+Test+Failure+%5C%28internal%5C%29%5D%28https%3A%2F%2Fcockroachlabs.atlassian.net%2Fl%2Fc%2FHgfXfJgM%29%0A%3C%2Fp%3E%0A%3C%2Fdetails%3E%0A%3Cdetails%3E%3Csummary%3ESame+failure+on+other+branches%3C%2Fsummary%3E%0A%3Cp%3E%0A%0A-+%2331+boom+related+%5BC-test-failure+O-robot+release-0.2%5D%0A%3C%2Fp%3E%0A%3C%2Fdetails%3E%0A%3Csub%3E%0A%0A%5BThis+test+on+roachdash%5D%28https%3A%2F%2Froachdash.crdb.dev%2F%3Ffilter%3Dstatus%3Aopen%2520t%3A.%2ATestCDC.%2A%26sort%3Dtitle%2Bcreated%26display%3Dlastcommented%2Bproject%29+%7C+%5BImprove+this+report%21%5D%28https%3A%2F%2Fgithub.com%2Fcockroachdb%2Fcockroach%2Ftree%2Fmaster%2Fpkg%2Fcmd%2Finternal%2Fissues%29%0A%3C%2Fsub%3E%0A&title=%3Ccomment%3E
+----
+----

--- a/pkg/cmd/internal/issues/testdata/post/infrastructure-flake-matching-issue.txt
+++ b/pkg/cmd/internal/issues/testdata/post/infrastructure-flake-matching-issue.txt
@@ -1,0 +1,32 @@
+post
+----
+----
+searchIssue repo:"cockroach" user:"cockroachdb" is:issue is:open in:title label:"O-robot" sort:created-desc "roachtest: TestCDC failed" label:branch-release-0.1: [github.Issue{Number:30, Title:"boom", Labels:[github.Label{URL:"fake", Name:"C-test-failure"} github.Label{URL:"fake", Name:"O-robot"} github.Label{URL:"fake", Name:"release-0.1"}]}]
+searchIssue repo:"cockroach" user:"cockroachdb" is:issue is:open in:title label:"O-robot" sort:created-desc "roachtest: TestCDC failed" -label:branch-release-0.1: []
+createComment owner=cockroachdb repo=cockroach issue=30:
+
+roachtest.TestCDC [failed](https://teamcity.example.com/buildConfiguration/nightly123/8008135?buildTab=log) on release-0.1 @ [abcd123](https://github.com/cockroachdb/cockroach/commits/abcd123):
+
+
+```
+Something went wrong
+```
+<p>Parameters: <code>GOFLAGS=race</code>
+, <code>ROACHTEST_cloud=gce</code>
+, <code>TAGS=deadlock</code>
+</p>
+<details><summary>Help</summary>
+<p>
+
+See also: [How To Investigate a Go Test Failure \(internal\)](https://cockroachlabs.atlassian.net/l/c/HgfXfJgM)
+</p>
+</details>
+<sub>
+
+[This test on roachdash](https://roachdash.crdb.dev/?filter=status:open%20t:.*TestCDC.*&sort=title+created&display=lastcommented+project) | [Improve this report!](https://github.com/cockroachdb/cockroach/tree/master/pkg/cmd/internal/issues)
+</sub>
+
+
+Rendered: https://github.com/cockroachdb/cockroach/issues/new?body=roachtest.TestCDC+%5Bfailed%5D%28https%3A%2F%2Fteamcity.example.com%2FbuildConfiguration%2Fnightly123%2F8008135%3FbuildTab%3Dlog%29+on+release-0.1+%40+%5Babcd123%5D%28https%3A%2F%2Fgithub.com%2Fcockroachdb%2Fcockroach%2Fcommits%2Fabcd123%29%3A%0A%0A%0A%60%60%60%0ASomething+went+wrong%0A%60%60%60%0A%3Cp%3EParameters%3A+%3Ccode%3EGOFLAGS%3Drace%3C%2Fcode%3E%0A%2C+%3Ccode%3EROACHTEST_cloud%3Dgce%3C%2Fcode%3E%0A%2C+%3Ccode%3ETAGS%3Ddeadlock%3C%2Fcode%3E%0A%3C%2Fp%3E%0A%3Cdetails%3E%3Csummary%3EHelp%3C%2Fsummary%3E%0A%3Cp%3E%0A%0ASee+also%3A+%5BHow+To+Investigate+a+Go+Test+Failure+%5C%28internal%5C%29%5D%28https%3A%2F%2Fcockroachlabs.atlassian.net%2Fl%2Fc%2FHgfXfJgM%29%0A%3C%2Fp%3E%0A%3C%2Fdetails%3E%0A%3Csub%3E%0A%0A%5BThis+test+on+roachdash%5D%28https%3A%2F%2Froachdash.crdb.dev%2F%3Ffilter%3Dstatus%3Aopen%2520t%3A.%2ATestCDC.%2A%26sort%3Dtitle%2Bcreated%26display%3Dlastcommented%2Bproject%29+%7C+%5BImprove+this+report%21%5D%28https%3A%2F%2Fgithub.com%2Fcockroachdb%2Fcockroach%2Ftree%2Fmaster%2Fpkg%2Fcmd%2Finternal%2Fissues%29%0A%3C%2Fsub%3E%0A&title=%3Ccomment%3E
+----
+----

--- a/pkg/cmd/internal/issues/testdata/post/infrastructure-flake-no-issue.txt
+++ b/pkg/cmd/internal/issues/testdata/post/infrastructure-flake-no-issue.txt
@@ -1,0 +1,38 @@
+post
+----
+----
+searchIssue repo:"cockroach" user:"cockroachdb" is:issue is:open in:title label:"O-robot" sort:created-desc "roachtest: TestCDC failed" label:branch-release-0.1: []
+searchIssue repo:"cockroach" user:"cockroachdb" is:issue is:open in:title label:"O-robot" sort:created-desc "roachtest: TestCDC failed" -label:branch-release-0.1: []
+getLatestTag: result v3.3.0
+listMilestones owner=cockroachdb repo=cockroach: result [github.Milestone{Number:2, Title:"3.3"} github.Milestone{Number:1, Title:"3.2"}]
+createIssue owner=cockroachdb repo=cockroach:
+github.IssueRequest{Labels:["O-robot" "branch-release-0.1" "release-blocker"], Milestone:2}
+
+roachtest: TestCDC failed
+
+roachtest.TestCDC [failed](https://teamcity.example.com/buildConfiguration/nightly123/8008135?buildTab=log) on release-0.1 @ [abcd123](https://github.com/cockroachdb/cockroach/commits/abcd123):
+
+
+```
+Something went wrong
+```
+<p>Parameters: <code>GOFLAGS=race</code>
+, <code>ROACHTEST_cloud=gce</code>
+, <code>TAGS=deadlock</code>
+</p>
+<details><summary>Help</summary>
+<p>
+
+See also: [How To Investigate a Go Test Failure \(internal\)](https://cockroachlabs.atlassian.net/l/c/HgfXfJgM)
+</p>
+</details>
+/cc @cockroachdb/idonotexistbecausethisisatest
+<sub>
+
+[This test on roachdash](https://roachdash.crdb.dev/?filter=status:open%20t:.*TestCDC.*&sort=title+created&display=lastcommented+project) | [Improve this report!](https://github.com/cockroachdb/cockroach/tree/master/pkg/cmd/internal/issues)
+</sub>
+
+
+Rendered: https://github.com/cockroachdb/cockroach/issues/new?body=roachtest.TestCDC+%5Bfailed%5D%28https%3A%2F%2Fteamcity.example.com%2FbuildConfiguration%2Fnightly123%2F8008135%3FbuildTab%3Dlog%29+on+release-0.1+%40+%5Babcd123%5D%28https%3A%2F%2Fgithub.com%2Fcockroachdb%2Fcockroach%2Fcommits%2Fabcd123%29%3A%0A%0A%0A%60%60%60%0ASomething+went+wrong%0A%60%60%60%0A%3Cp%3EParameters%3A+%3Ccode%3EGOFLAGS%3Drace%3C%2Fcode%3E%0A%2C+%3Ccode%3EROACHTEST_cloud%3Dgce%3C%2Fcode%3E%0A%2C+%3Ccode%3ETAGS%3Ddeadlock%3C%2Fcode%3E%0A%3C%2Fp%3E%0A%3Cdetails%3E%3Csummary%3EHelp%3C%2Fsummary%3E%0A%3Cp%3E%0A%0ASee+also%3A+%5BHow+To+Investigate+a+Go+Test+Failure+%5C%28internal%5C%29%5D%28https%3A%2F%2Fcockroachlabs.atlassian.net%2Fl%2Fc%2FHgfXfJgM%29%0A%3C%2Fp%3E%0A%3C%2Fdetails%3E%0A%2Fcc+%40cockroachdb%2Fidonotexistbecausethisisatest%0A%3Csub%3E%0A%0A%5BThis+test+on+roachdash%5D%28https%3A%2F%2Froachdash.crdb.dev%2F%3Ffilter%3Dstatus%3Aopen%2520t%3A.%2ATestCDC.%2A%26sort%3Dtitle%2Bcreated%26display%3Dlastcommented%2Bproject%29+%7C+%5BImprove+this+report%21%5D%28https%3A%2F%2Fgithub.com%2Fcockroachdb%2Fcockroach%2Ftree%2Fmaster%2Fpkg%2Fcmd%2Finternal%2Fissues%29%0A%3C%2Fsub%3E%0A&title=roachtest%3A+TestCDC+failed
+----
+----

--- a/pkg/cmd/internal/issues/testdata/post/infrastructure-flake-related-issue.txt
+++ b/pkg/cmd/internal/issues/testdata/post/infrastructure-flake-related-issue.txt
@@ -1,0 +1,44 @@
+post
+----
+----
+searchIssue repo:"cockroach" user:"cockroachdb" is:issue is:open in:title label:"O-robot" sort:created-desc "roachtest: TestCDC failed" label:branch-release-0.1: []
+searchIssue repo:"cockroach" user:"cockroachdb" is:issue is:open in:title label:"O-robot" sort:created-desc "roachtest: TestCDC failed" -label:branch-release-0.1: [github.Issue{Number:31, Title:"boom related", Labels:[github.Label{URL:"fake", Name:"C-test-failure"} github.Label{URL:"fake", Name:"O-robot"} github.Label{URL:"fake", Name:"release-0.2"}]}]
+getLatestTag: result v3.3.0
+listMilestones owner=cockroachdb repo=cockroach: result [github.Milestone{Number:2, Title:"3.3"} github.Milestone{Number:1, Title:"3.2"}]
+createIssue owner=cockroachdb repo=cockroach:
+github.IssueRequest{Labels:["O-robot" "branch-release-0.1" "release-blocker"], Milestone:2}
+
+roachtest: TestCDC failed
+
+roachtest.TestCDC [failed](https://teamcity.example.com/buildConfiguration/nightly123/8008135?buildTab=log) on release-0.1 @ [abcd123](https://github.com/cockroachdb/cockroach/commits/abcd123):
+
+
+```
+Something went wrong
+```
+<p>Parameters: <code>GOFLAGS=race</code>
+, <code>ROACHTEST_cloud=gce</code>
+, <code>TAGS=deadlock</code>
+</p>
+<details><summary>Help</summary>
+<p>
+
+See also: [How To Investigate a Go Test Failure \(internal\)](https://cockroachlabs.atlassian.net/l/c/HgfXfJgM)
+</p>
+</details>
+<details><summary>Same failure on other branches</summary>
+<p>
+
+- #31 boom related [C-test-failure O-robot release-0.2]
+</p>
+</details>
+/cc @cockroachdb/idonotexistbecausethisisatest
+<sub>
+
+[This test on roachdash](https://roachdash.crdb.dev/?filter=status:open%20t:.*TestCDC.*&sort=title+created&display=lastcommented+project) | [Improve this report!](https://github.com/cockroachdb/cockroach/tree/master/pkg/cmd/internal/issues)
+</sub>
+
+
+Rendered: https://github.com/cockroachdb/cockroach/issues/new?body=roachtest.TestCDC+%5Bfailed%5D%28https%3A%2F%2Fteamcity.example.com%2FbuildConfiguration%2Fnightly123%2F8008135%3FbuildTab%3Dlog%29+on+release-0.1+%40+%5Babcd123%5D%28https%3A%2F%2Fgithub.com%2Fcockroachdb%2Fcockroach%2Fcommits%2Fabcd123%29%3A%0A%0A%0A%60%60%60%0ASomething+went+wrong%0A%60%60%60%0A%3Cp%3EParameters%3A+%3Ccode%3EGOFLAGS%3Drace%3C%2Fcode%3E%0A%2C+%3Ccode%3EROACHTEST_cloud%3Dgce%3C%2Fcode%3E%0A%2C+%3Ccode%3ETAGS%3Ddeadlock%3C%2Fcode%3E%0A%3C%2Fp%3E%0A%3Cdetails%3E%3Csummary%3EHelp%3C%2Fsummary%3E%0A%3Cp%3E%0A%0ASee+also%3A+%5BHow+To+Investigate+a+Go+Test+Failure+%5C%28internal%5C%29%5D%28https%3A%2F%2Fcockroachlabs.atlassian.net%2Fl%2Fc%2FHgfXfJgM%29%0A%3C%2Fp%3E%0A%3C%2Fdetails%3E%0A%3Cdetails%3E%3Csummary%3ESame+failure+on+other+branches%3C%2Fsummary%3E%0A%3Cp%3E%0A%0A-+%2331+boom+related+%5BC-test-failure+O-robot+release-0.2%5D%0A%3C%2Fp%3E%0A%3C%2Fdetails%3E%0A%2Fcc+%40cockroachdb%2Fidonotexistbecausethisisatest%0A%3Csub%3E%0A%0A%5BThis+test+on+roachdash%5D%28https%3A%2F%2Froachdash.crdb.dev%2F%3Ffilter%3Dstatus%3Aopen%2520t%3A.%2ATestCDC.%2A%26sort%3Dtitle%2Bcreated%26display%3Dlastcommented%2Bproject%29+%7C+%5BImprove+this+report%21%5D%28https%3A%2F%2Fgithub.com%2Fcockroachdb%2Fcockroach%2Ftree%2Fmaster%2Fpkg%2Fcmd%2Finternal%2Fissues%29%0A%3C%2Fsub%3E%0A&title=roachtest%3A+TestCDC+failed
+----
+----

--- a/pkg/cmd/roachtest/github.go
+++ b/pkg/cmd/roachtest/github.go
@@ -149,14 +149,15 @@ func (g *githubIssues) createPostRequest(
 	}
 
 	return issues.PostRequest{
-		MentionOnCreate: mention,
-		ProjectColumnID: projColID,
-		PackageName:     "roachtest",
-		TestName:        issueName,
-		Message:         messagePrefix + message,
-		Artifacts:       artifacts,
-		ExtraLabels:     labels,
-		ExtraParams:     clusterParams,
+		MentionOnCreate:      mention,
+		ProjectColumnID:      projColID,
+		PackageName:          "roachtest",
+		TestName:             issueName,
+		Message:              messagePrefix + message,
+		SkipLabelTestFailure: infraFlake, // infra-flakes are not marked as C-test-failure
+		Artifacts:            artifacts,
+		ExtraLabels:          labels,
+		ExtraParams:          clusterParams,
 		HelpCommand: func(renderer *issues.Renderer) {
 			issues.HelpCommandAsLink(
 				"roachtest README",


### PR DESCRIPTION
Backports #101754 and #108644.

Epic: none

Release notes: None.

Release justification: test-only changes.