### PR TITLE
sqlproxyccl: do not report BackendDown metrics on throttle and routing errors

### DIFF
--- a/pkg/ccl/sqlproxyccl/backend_dialer_test.go
+++ b/pkg/ccl/sqlproxyccl/backend_dialer_test.go
@@ -120,22 +120,22 @@ func TestBackendDialTLS(t *testing.T) {
 		name:     "tenant10To11",
 		addr:     sql11.SQLAddr(),
 		tenantID: 10,
-		errCode:  codeBackendDown,
+		errCode:  codeBackendDialFailed,
 	}, {
 		name:     "tenant11To10",
 		addr:     sql10.SQLAddr(),
 		tenantID: 11,
-		errCode:  codeBackendDown,
+		errCode:  codeBackendDialFailed,
 	}, {
 		name:     "tenant10ToStorage",
 		addr:     storageServer.SystemLayer().AdvSQLAddr(),
 		tenantID: 10,
-		errCode:  codeBackendDown,
+		errCode:  codeBackendDialFailed,
 	}, {
 		name:     "tenantWithNodeIDToStoage",
 		addr:     storageServer.SystemLayer().AdvSQLAddr(),
 		tenantID: uint64(storageServer.NodeID()),
-		errCode:  codeBackendDown,
+		errCode:  codeBackendDialFailed,
 	}}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/ccl/sqlproxyccl/connector.go
+++ b/pkg/ccl/sqlproxyccl/connector.go
@@ -374,7 +374,7 @@ func (c *connector) dialSQLServer(
 		return err
 	})
 	if err != nil {
-		if getErrorCode(err) == codeBackendDown {
+		if getErrorCode(err) == codeBackendDialFailed {
 			return nil, markAsRetriableConnectorError(err)
 		}
 		return nil, err

--- a/pkg/ccl/sqlproxyccl/connector_test.go
+++ b/pkg/ccl/sqlproxyccl/connector_test.go
@@ -888,14 +888,14 @@ func TestConnector_dialSQLServer(t *testing.T) {
 				require.Equal(t, c.StartupMsg, msg)
 				require.Equal(t, "127.0.0.2:4567", serverAddress)
 				require.Nil(t, tlsConfig)
-				return nil, withCode(errors.New("bar"), codeBackendDown)
+				return nil, withCode(errors.New("bar"), codeBackendDialFailed)
 			},
 		)()
 		sa := balancer.NewServerAssignment(tenantID, tracker, nil, "127.0.0.2:4567")
 		defer sa.Close()
 
 		conn, err := c.dialSQLServer(ctx, sa)
-		require.EqualError(t, err, "codeBackendDown: bar")
+		require.EqualError(t, err, "codeBackendDialFailed: bar")
 		require.True(t, isRetriableConnectorError(err))
 		require.Nil(t, conn)
 	})

--- a/pkg/ccl/sqlproxyccl/error.go
+++ b/pkg/ccl/sqlproxyccl/error.go
@@ -50,13 +50,9 @@ const (
 	// on the client's session parameters.
 	codeParamsRoutingFailed
 
-	// codeBackendDown indicates an error establishing or maintaining a connection
-	// to the backend SQL server.
-	codeBackendDown
-
-	// codeBackendRefusedTLS indicates that the backend SQL server refused a TLS-
-	// enabled SQL connection.
-	codeBackendRefusedTLS
+	// codeBackendDialFailed indicates an error establishing a connection
+	// between the proxy and the backend SQL server.
+	codeBackendDialFailed
 
 	// codeBackendDisconnected indicates that the backend disconnected (with a
 	// connection error) while serving client traffic.

--- a/pkg/ccl/sqlproxyccl/errorcode_string.go
+++ b/pkg/ccl/sqlproxyccl/errorcode_string.go
@@ -17,13 +17,12 @@ func _() {
 	_ = x[codeUnexpectedInsecureStartupMessage-6]
 	_ = x[codeUnexpectedStartupMessage-7]
 	_ = x[codeParamsRoutingFailed-8]
-	_ = x[codeBackendDown-9]
-	_ = x[codeBackendRefusedTLS-10]
-	_ = x[codeBackendDisconnected-11]
-	_ = x[codeClientDisconnected-12]
-	_ = x[codeProxyRefusedConnection-13]
-	_ = x[codeExpiredClientConnection-14]
-	_ = x[codeUnavailable-15]
+	_ = x[codeBackendDialFailed-9]
+	_ = x[codeBackendDisconnected-10]
+	_ = x[codeClientDisconnected-11]
+	_ = x[codeProxyRefusedConnection-12]
+	_ = x[codeExpiredClientConnection-13]
+	_ = x[codeUnavailable-14]
 }
 
 func (i errorCode) String() string {
@@ -46,10 +45,8 @@ func (i errorCode) String() string {
 		return "codeUnexpectedStartupMessage"
 	case codeParamsRoutingFailed:
 		return "codeParamsRoutingFailed"
-	case codeBackendDown:
-		return "codeBackendDown"
-	case codeBackendRefusedTLS:
-		return "codeBackendRefusedTLS"
+	case codeBackendDialFailed:
+		return "codeBackendDialFailed"
 	case codeBackendDisconnected:
 		return "codeBackendDisconnected"
 	case codeClientDisconnected:

--- a/pkg/ccl/sqlproxyccl/metrics.go
+++ b/pkg/ccl/sqlproxyccl/metrics.go
@@ -292,10 +292,8 @@ func (metrics *metrics) updateForError(err error) {
 		metrics.ClientDisconnectCount.Inc(1)
 	case codeProxyRefusedConnection:
 		metrics.RefusedConnCount.Inc(1)
-		metrics.BackendDownCount.Inc(1)
 	case codeParamsRoutingFailed, codeUnavailable:
 		metrics.RoutingErrCount.Inc(1)
-		metrics.BackendDownCount.Inc(1)
 	case codeBackendDown:
 		metrics.BackendDownCount.Inc(1)
 	case codeAuthFailed:

--- a/pkg/ccl/sqlproxyccl/metrics.go
+++ b/pkg/ccl/sqlproxyccl/metrics.go
@@ -294,7 +294,11 @@ func (metrics *metrics) updateForError(err error) {
 		metrics.RefusedConnCount.Inc(1)
 	case codeParamsRoutingFailed, codeUnavailable:
 		metrics.RoutingErrCount.Inc(1)
-	case codeBackendDown:
+	case codeBackendDialFailed:
+		// NOTE: Historically, we had the code named codeBackendDown instead of
+		// codeBackendDialFailed. This has been renamed to codeBackendDialFailed
+		// for accuracy, and to prevent confusion by developers. We don't rename
+		// the metrics here as that may break downstream consumers.
 		metrics.BackendDownCount.Inc(1)
 	case codeAuthFailed:
 		metrics.AuthFailedCount.Inc(1)

--- a/pkg/ccl/sqlproxyccl/metrics_test.go
+++ b/pkg/ccl/sqlproxyccl/metrics_test.go
@@ -35,10 +35,10 @@ func TestMetricsUpdateForError(t *testing.T) {
 
 		{codeExpiredClientConnection, []*metric.Counter{m.ExpiredClientConnCount}},
 
-		{codeProxyRefusedConnection, []*metric.Counter{m.RefusedConnCount, m.BackendDownCount}},
+		{codeProxyRefusedConnection, []*metric.Counter{m.RefusedConnCount}},
 
-		{codeParamsRoutingFailed, []*metric.Counter{m.RoutingErrCount, m.BackendDownCount}},
-		{codeUnavailable, []*metric.Counter{m.RoutingErrCount, m.BackendDownCount}},
+		{codeParamsRoutingFailed, []*metric.Counter{m.RoutingErrCount}},
+		{codeUnavailable, []*metric.Counter{m.RoutingErrCount}},
 
 		{codeBackendDown, []*metric.Counter{m.BackendDownCount}},
 

--- a/pkg/ccl/sqlproxyccl/metrics_test.go
+++ b/pkg/ccl/sqlproxyccl/metrics_test.go
@@ -40,7 +40,7 @@ func TestMetricsUpdateForError(t *testing.T) {
 		{codeParamsRoutingFailed, []*metric.Counter{m.RoutingErrCount}},
 		{codeUnavailable, []*metric.Counter{m.RoutingErrCount}},
 
-		{codeBackendDown, []*metric.Counter{m.BackendDownCount}},
+		{codeBackendDialFailed, []*metric.Counter{m.BackendDownCount}},
 
 		{codeAuthFailed, []*metric.Counter{m.AuthFailedCount}},
 	}

--- a/pkg/ccl/sqlproxyccl/proxy.go
+++ b/pkg/ccl/sqlproxyccl/proxy.go
@@ -35,7 +35,7 @@ func toPgError(err error) *pgproto3.ErrorResponse {
 		switch getErrorCode(err) {
 		// These are send as is.
 		case codeExpiredClientConnection,
-			codeBackendDown,
+			codeBackendDialFailed,
 			codeParamsRoutingFailed,
 			codeClientDisconnected,
 			codeBackendDisconnected,

--- a/pkg/ccl/sqlproxyccl/proxy_handler_test.go
+++ b/pkg/ccl/sqlproxyccl/proxy_handler_test.go
@@ -571,7 +571,7 @@ func TestBackendDownRetry(t *testing.T) {
 		if callCount >= 3 {
 			directoryServer.DeleteTenant(roachpb.MustMakeTenantID(28))
 		}
-		return nil, withCode(errors.New("SQL pod is down"), codeBackendDown)
+		return nil, withCode(errors.New("SQL pod is down"), codeBackendDialFailed)
 	})()
 
 	// Valid connection, but no backend server running.
@@ -1307,7 +1307,7 @@ func TestDirectoryConnect(t *testing.T) {
 			if countFailures >= 3 {
 				return nil, withCode(errors.New("backend disconnected"), codeBackendDisconnected)
 			}
-			return nil, withCode(errors.New("backend down"), codeBackendDown)
+			return nil, withCode(errors.New("backend down"), codeBackendDialFailed)
 		})()
 
 		// Ensure that Directory.ReportFailure is being called correctly.


### PR DESCRIPTION
#### sqlproxyccl: do not report BackendDown metrics on throttle and routing errors

Previously, we were reporting the backend_down metric on the following errors:
- codeProxyRefusedConnection
- codeParamsRoutingFailed
- codeUnavailable

These errors do not imply that the backend is down. We originally introduced
this in #57431, but looking at the PR, it appears unintentional. This commit
fixes that by not reporting the backend_down metric when the proxy returns
such errors.

Release note: None

Epic: none

#### sqlproxyccl: rename codeBackendDown to codeBackendDialFailed

This commit renames codeBackendDown to codeBackendDialFailed to prevent
confusions by developers. Note that we don't rename the metric here to avoid
breaking downstream consumers. At the same time, we will remove the old
codeBackendRefusedTLS code as it does not serve any purpose, and there wasn't
a metric for it as well.

Release note: None

Epic: none



Release justification: This fixes accuracy issues with SQL Proxy metrics.