### PR TITLE
backupccl: skip TestBackupRestoreAppend under race

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -602,7 +602,8 @@ func TestBackupRestoreAppend(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	skip.UnderStressRace(t, "test is too large to run under stress race")
+	skip.UnderStress(t, "test is too large to run under stress")
+	skip.UnderRace(t, "test is too large to run under race")
 
 	const numAccounts = 1000
 	ctx := context.Background()


### PR DESCRIPTION
This is a large test that starts 3 nodes, loads a bank workload and then issues a number of SQL statements. Under race we've seen this hang but we don't currently belive that this represent a problem with BACKUP/RESTORE.

Fixes #108800

Epic: none

Release note: None