### PR TITLE
concurrency: use lock modes to detect conflicts in SKIP LOCKED

### DIFF
--- a/pkg/kv/kvserver/concurrency/concurrency_control.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_control.go
@@ -787,7 +787,7 @@ type lockTableGuard interface {
 	// for conflicts. This helps prevent a stream of locking SKIP LOCKED requests
 	// from starving out regular locking requests. In such cases, true is
 	// returned, but so is nil.
-	IsKeyLockedByConflictingTxn(roachpb.Key, lock.Strength) (bool, *enginepb.TxnMeta)
+	IsKeyLockedByConflictingTxn(roachpb.Key, lock.Strength) (bool, *enginepb.TxnMeta, error)
 }
 
 // lockTableWaiter is concerned with waiting in lock wait-queues for locks held

--- a/pkg/kv/kvserver/concurrency/concurrency_control.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_control.go
@@ -773,22 +773,20 @@ type lockTableGuard interface {
 	// that conflict.
 	CheckOptimisticNoConflicts(*lockspanset.LockSpanSet) (ok bool)
 
-	// IsKeyLockedByConflictingTxn returns whether the specified key is claimed
-	// (see claimantTxn()) by a conflicting transaction in the lockTableGuard's
-	// snapshot of the lock table, given the caller's own desired locking
-	// strength. If so, true is returned. If the key is locked, the lock holder is
-	// also returned. Otherwise, if the key was claimed by a concurrent request
-	// still sequencing through the lock table, but the lock isn't held (yet), nil
-	// is also returned.
+	// IsKeyLockedByConflictingTxn returns whether the specified key is locked by
+	// a conflicting transaction in the lockTableGuard's snapshot of the lock
+	// table, given the caller's own desired locking strength. If so, true is
+	// returned and so is the lock holder. If the lock is held by the transaction
+	// itself, there's no conflict to speak of, so false is returned.
 	//
-	// If the lock has been claimed (held or otherwise) by the transaction itself,
-	// there's no conflict to speak of, so false is returned. In cases where the
-	// lock isn't held, but the lock has been claimed by the transaction itself,
-	// we do not make a distinction about which request claimed the key -- it
-	// could either be the request itself, or a different concurrent request from
-	// the same transaction; The specifics do not affect the caller.
 	// This method is used by requests in conjunction with the SkipLocked wait
 	// policy to determine which keys they should skip over during evaluation.
+	//
+	// If the supplied lock strength is locking (!= lock.None), then any queued
+	// locking requests that came before the lockTableGuard will also be checked
+	// for conflicts. This helps prevent a stream of locking SKIP LOCKED requests
+	// from starving out regular locking requests. In such cases, true is
+	// returned, but so is nil.
 	IsKeyLockedByConflictingTxn(roachpb.Key, lock.Strength) (bool, *enginepb.TxnMeta)
 }
 

--- a/pkg/kv/kvserver/concurrency/concurrency_manager.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager.go
@@ -767,22 +767,20 @@ func (g *Guard) CheckOptimisticNoLatchConflicts() (ok bool) {
 	return g.lm.CheckOptimisticNoConflicts(g.lg, g.Req.LatchSpans)
 }
 
-// IsKeyLockedByConflictingTxn returns whether the specified key is claimed
-// (see claimantTxn()) by a conflicting transaction in the lockTableGuard's
-// snapshot of the lock table, given the caller's own desired locking
-// strength. If so, true is returned. If the key is locked, the lock holder is
-// also returned. Otherwise, if the key was claimed by a concurrent request
-// still sequencing through the lock table, but the lock isn't held (yet), nil
-// is also returned.
+// IsKeyLockedByConflictingTxn returns whether the specified key is locked by
+// a conflicting transaction in the lockTableGuard's snapshot of the lock
+// table, given the caller's own desired locking strength. If so, true is
+// returned and so is the lock holder. If the lock is held by the transaction
+// itself, there's no conflict to speak of, so false is returned.
 //
-// If the lock has been claimed (held or otherwise) by the transaction itself,
-// there's no conflict to speak of, so false is returned. In cases where the
-// lock isn't held, but the lock has been claimed by the transaction itself,
-// we do not make a distinction about which request claimed the key -- it
-// could either be the request itself, or a different concurrent request from
-// the same transaction; The specifics do not affect the caller.
 // This method is used by requests in conjunction with the SkipLocked wait
 // policy to determine which keys they should skip over during evaluation.
+//
+// If the supplied lock strength is locking (!= lock.None), then any queued
+// locking requests that came before the lockTableGuard will also be checked
+// for conflicts. This helps prevent a stream of locking SKIP LOCKED requests
+// from starving out regular locking requests. In such cases, true is
+// returned, but so is nil.
 func (g *Guard) IsKeyLockedByConflictingTxn(
 	key roachpb.Key, strength lock.Strength,
 ) (bool, *enginepb.TxnMeta) {

--- a/pkg/kv/kvserver/concurrency/concurrency_manager.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager.go
@@ -783,7 +783,7 @@ func (g *Guard) CheckOptimisticNoLatchConflicts() (ok bool) {
 // returned, but so is nil.
 func (g *Guard) IsKeyLockedByConflictingTxn(
 	key roachpb.Key, strength lock.Strength,
-) (bool, *enginepb.TxnMeta) {
+) (bool, *enginepb.TxnMeta, error) {
 	return g.ltg.IsKeyLockedByConflictingTxn(key, strength)
 }
 

--- a/pkg/kv/kvserver/concurrency/concurrency_manager_test.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager_test.go
@@ -372,7 +372,11 @@ func TestConcurrencyManagerBasic(t *testing.T) {
 				var key string
 				d.ScanArgs(t, "key", &key)
 				strength := concurrency.ScanLockStrength(t, d)
-				if ok, txn := g.IsKeyLockedByConflictingTxn(roachpb.Key(key), strength); ok {
+				ok, txn, err := g.IsKeyLockedByConflictingTxn(roachpb.Key(key), strength)
+				if err != nil {
+					return err.Error()
+				}
+				if ok {
 					holder := "<nil>"
 					if txn != nil {
 						holder = txn.ID.String()

--- a/pkg/kv/kvserver/concurrency/lock_table_test.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_test.go
@@ -497,7 +497,11 @@ func TestLockTableBasic(t *testing.T) {
 				var key string
 				d.ScanArgs(t, "k", &key)
 				strength := ScanLockStrength(t, d)
-				if ok, txn := g.IsKeyLockedByConflictingTxn(roachpb.Key(key), strength); ok {
+				ok, txn, err := g.IsKeyLockedByConflictingTxn(roachpb.Key(key), strength)
+				if err != nil {
+					return err.Error()
+				}
+				if ok {
 					holder := "<nil>"
 					if txn != nil {
 						holder = txn.ID.String()

--- a/pkg/kv/kvserver/concurrency/lock_table_waiter_test.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_waiter_test.go
@@ -89,7 +89,7 @@ func (g *mockLockTableGuard) CheckOptimisticNoConflicts(*lockspanset.LockSpanSet
 }
 func (g *mockLockTableGuard) IsKeyLockedByConflictingTxn(
 	roachpb.Key, lock.Strength,
-) (bool, *enginepb.TxnMeta) {
+) (bool, *enginepb.TxnMeta, error) {
 	panic("unimplemented")
 }
 func (g *mockLockTableGuard) notify() { g.signal <- struct{}{} }

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/skip_locked
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/skip_locked
@@ -14,6 +14,9 @@ new-txn txn=txn2 ts=9,1 epoch=0
 #  d: locked by txn1
 #  e: unlocked
 #  f: reservation by txn1
+#  g: locked by txn1 (shared)
+#  h: locked by txn2 (shared)
+#  i: locked by txn2 (shared), (exclusive) request from txn1 actively waiting
 
 new-request r=req1 txn=txn1 ts=10,1 spans=exclusive@b,d
 ----
@@ -117,13 +120,7 @@ num=4
    queued writers:
     active: false req: 3, txn: 00000000-0000-0000-0000-000000000001
 
-# ---------------------------------------------------------------------------------
-# req4 will scan the lock table with a Skip wait policy. It will not need to wait.
-# Once it begins evaluating, it will probe into the lock table to determine which
-# keys to skip.
-# ---------------------------------------------------------------------------------
-
-new-request r=req4 txn=txn2 ts=9,1 spans=none@a,g skip-locked
+new-request r=req4 txn=txn1 ts=10,1 spans=shared@g
 ----
 
 scan r=req4
@@ -134,57 +131,9 @@ should-wait r=req4
 ----
 false
 
-is-key-locked-by-conflicting-txn r=req4 k=a strength=none
+acquire r=req4 k=g durability=u strength=shared
 ----
-locked: false
-
-is-key-locked-by-conflicting-txn r=req4 k=b strength=none
-----
-locked: false
-
-is-key-locked-by-conflicting-txn r=req4 k=c strength=none
-----
-locked: false
-
-is-key-locked-by-conflicting-txn r=req4 k=d strength=none
-----
-locked: false
-
-is-key-locked-by-conflicting-txn r=req4 k=e strength=none
-----
-locked: false
-
-is-key-locked-by-conflicting-txn r=req4 k=f strength=none
-----
-locked: false
-
-is-key-locked-by-conflicting-txn r=req4 k=a strength=exclusive
-----
-locked: false
-
-is-key-locked-by-conflicting-txn r=req4 k=b strength=exclusive
-----
-locked: true, holder: 00000000-0000-0000-0000-000000000001
-
-is-key-locked-by-conflicting-txn r=req4 k=c strength=exclusive
-----
-locked: false
-
-is-key-locked-by-conflicting-txn r=req4 k=d strength=exclusive
-----
-locked: true, holder: 00000000-0000-0000-0000-000000000001
-
-is-key-locked-by-conflicting-txn r=req4 k=e strength=exclusive
-----
-locked: false
-
-is-key-locked-by-conflicting-txn r=req4 k=f strength=exclusive
-----
-locked: true, holder: <nil>
-
-dequeue r=req4
-----
-num=4
+num=5
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
  lock: "c"
@@ -194,13 +143,10 @@ num=4
  lock: "f"
    queued writers:
     active: false req: 3, txn: 00000000-0000-0000-0000-000000000001
+ lock: "g"
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Shared seq: 0)]
 
-# ---------------------------------------------------------------------------------
-# req5 is the same as req4, except is has a timestamp equal to txn1's to
-# exercise the strength=none cases again.
-# ---------------------------------------------------------------------------------
-
-new-request r=req5 txn=txn2 ts=10,1 spans=none@a,g skip-locked
+new-request r=req5 txn=txn2 ts=9,1 spans=shared@h
 ----
 
 scan r=req5
@@ -211,33 +157,9 @@ should-wait r=req5
 ----
 false
 
-is-key-locked-by-conflicting-txn r=req5 k=a strength=none
+acquire r=req5 k=h durability=u strength=shared
 ----
-locked: false
-
-is-key-locked-by-conflicting-txn r=req5 k=b strength=none
-----
-locked: true, holder: 00000000-0000-0000-0000-000000000001
-
-is-key-locked-by-conflicting-txn r=req5 k=c strength=none
-----
-locked: false
-
-is-key-locked-by-conflicting-txn r=req5 k=d strength=none
-----
-locked: true, holder: 00000000-0000-0000-0000-000000000001
-
-is-key-locked-by-conflicting-txn r=req5 k=e strength=none
-----
-locked: false
-
-is-key-locked-by-conflicting-txn r=req5 k=f strength=none
-----
-locked: false
-
-dequeue r=req5
-----
-num=4
+num=6
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
  lock: "c"
@@ -247,3 +169,291 @@ num=4
  lock: "f"
    queued writers:
     active: false req: 3, txn: 00000000-0000-0000-0000-000000000001
+ lock: "g"
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Shared seq: 0)]
+ lock: "h"
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 9.000000000,1, info: unrepl [(str: Shared seq: 0)]
+
+new-request r=req6 txn=txn2 ts=9,1 spans=shared@i
+----
+
+scan r=req6
+----
+start-waiting: false
+
+should-wait r=req6
+----
+false
+
+acquire r=req6 k=i durability=u strength=shared
+----
+num=7
+ lock: "b"
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
+ lock: "c"
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 9.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
+ lock: "d"
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
+ lock: "f"
+   queued writers:
+    active: false req: 3, txn: 00000000-0000-0000-0000-000000000001
+ lock: "g"
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Shared seq: 0)]
+ lock: "h"
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 9.000000000,1, info: unrepl [(str: Shared seq: 0)]
+ lock: "i"
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 9.000000000,1, info: unrepl [(str: Shared seq: 0)]
+
+new-request r=req7 txn=txn1 ts=10,1 spans=exclusive@i
+----
+
+scan r=req7
+----
+start-waiting: true
+
+should-wait r=req7
+----
+true
+
+dequeue r=req6
+----
+num=7
+ lock: "b"
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
+ lock: "c"
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 9.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
+ lock: "d"
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
+ lock: "f"
+   queued writers:
+    active: false req: 3, txn: 00000000-0000-0000-0000-000000000001
+ lock: "g"
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Shared seq: 0)]
+ lock: "h"
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 9.000000000,1, info: unrepl [(str: Shared seq: 0)]
+ lock: "i"
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 9.000000000,1, info: unrepl [(str: Shared seq: 0)]
+   queued writers:
+    active: true req: 7, txn: 00000000-0000-0000-0000-000000000001
+   distinguished req: 7
+
+# ---------------------------------------------------------------------------------
+# req8 will scan the lock table with a Skip wait policy. It will not need to wait.
+# Once it begins evaluating, it will probe into the lock table to determine which
+# keys to skip.
+# ---------------------------------------------------------------------------------
+
+new-request r=req8 txn=txn2 ts=9,1 spans=none@a,j skip-locked
+----
+
+scan r=req8
+----
+start-waiting: false
+
+should-wait r=req8
+----
+false
+
+is-key-locked-by-conflicting-txn r=req8 k=a strength=none
+----
+locked: false
+
+is-key-locked-by-conflicting-txn r=req8 k=b strength=none
+----
+locked: false
+
+is-key-locked-by-conflicting-txn r=req8 k=c strength=none
+----
+locked: false
+
+is-key-locked-by-conflicting-txn r=req8 k=d strength=none
+----
+locked: false
+
+is-key-locked-by-conflicting-txn r=req8 k=e strength=none
+----
+locked: false
+
+is-key-locked-by-conflicting-txn r=req8 k=f strength=none
+----
+locked: false
+
+is-key-locked-by-conflicting-txn r=req8 k=g strength=none
+----
+locked: false
+
+is-key-locked-by-conflicting-txn r=req8 k=h strength=none
+----
+locked: false
+
+is-key-locked-by-conflicting-txn r=req8 k=i strength=none
+----
+locked: false
+
+is-key-locked-by-conflicting-txn r=req8 k=a strength=shared
+----
+locked: false
+
+is-key-locked-by-conflicting-txn r=req8 k=b strength=shared
+----
+locked: true, holder: 00000000-0000-0000-0000-000000000001
+
+is-key-locked-by-conflicting-txn r=req8 k=c strength=shared
+----
+locked: false
+
+is-key-locked-by-conflicting-txn r=req8 k=d strength=shared
+----
+locked: true, holder: 00000000-0000-0000-0000-000000000001
+
+is-key-locked-by-conflicting-txn r=req8 k=e strength=shared
+----
+locked: false
+
+is-key-locked-by-conflicting-txn r=req8 k=f strength=shared
+----
+locked: true, holder: <nil>
+
+is-key-locked-by-conflicting-txn r=req8 k=g strength=shared
+----
+locked: false
+
+is-key-locked-by-conflicting-txn r=req8 k=h strength=shared
+----
+locked: false
+
+is-key-locked-by-conflicting-txn r=req8 k=i strength=shared
+----
+locked: false
+
+is-key-locked-by-conflicting-txn r=req8 k=a strength=exclusive
+----
+locked: false
+
+is-key-locked-by-conflicting-txn r=req8 k=b strength=exclusive
+----
+locked: true, holder: 00000000-0000-0000-0000-000000000001
+
+is-key-locked-by-conflicting-txn r=req8 k=c strength=exclusive
+----
+locked: false
+
+is-key-locked-by-conflicting-txn r=req8 k=d strength=exclusive
+----
+locked: true, holder: 00000000-0000-0000-0000-000000000001
+
+is-key-locked-by-conflicting-txn r=req8 k=e strength=exclusive
+----
+locked: false
+
+is-key-locked-by-conflicting-txn r=req8 k=f strength=exclusive
+----
+locked: true, holder: <nil>
+
+is-key-locked-by-conflicting-txn r=req8 k=g strength=exclusive
+----
+locked: true, holder: 00000000-0000-0000-0000-000000000001
+
+is-key-locked-by-conflicting-txn r=req8 k=h strength=exclusive
+----
+locked: false
+
+is-key-locked-by-conflicting-txn r=req8 k=i strength=exclusive
+----
+locked: true, holder: <nil>
+
+dequeue r=req8
+----
+num=7
+ lock: "b"
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
+ lock: "c"
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 9.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
+ lock: "d"
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
+ lock: "f"
+   queued writers:
+    active: false req: 3, txn: 00000000-0000-0000-0000-000000000001
+ lock: "g"
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Shared seq: 0)]
+ lock: "h"
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 9.000000000,1, info: unrepl [(str: Shared seq: 0)]
+ lock: "i"
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 9.000000000,1, info: unrepl [(str: Shared seq: 0)]
+   queued writers:
+    active: true req: 7, txn: 00000000-0000-0000-0000-000000000001
+   distinguished req: 7
+
+# ---------------------------------------------------------------------------------
+# req9 is the same as req8, except is has a timestamp equal to txn1's to
+# exercise the strength=none cases again.
+# ---------------------------------------------------------------------------------
+
+new-request r=req9 txn=txn2 ts=10,1 spans=none@a,j skip-locked
+----
+
+scan r=req9
+----
+start-waiting: false
+
+should-wait r=req9
+----
+false
+
+is-key-locked-by-conflicting-txn r=req9 k=a strength=none
+----
+locked: false
+
+is-key-locked-by-conflicting-txn r=req9 k=b strength=none
+----
+locked: true, holder: 00000000-0000-0000-0000-000000000001
+
+is-key-locked-by-conflicting-txn r=req9 k=c strength=none
+----
+locked: false
+
+is-key-locked-by-conflicting-txn r=req9 k=d strength=none
+----
+locked: true, holder: 00000000-0000-0000-0000-000000000001
+
+is-key-locked-by-conflicting-txn r=req9 k=e strength=none
+----
+locked: false
+
+is-key-locked-by-conflicting-txn r=req9 k=f strength=none
+----
+locked: false
+
+is-key-locked-by-conflicting-txn r=req9 k=g strength=none
+----
+locked: false
+
+is-key-locked-by-conflicting-txn r=req9 k=h strength=none
+----
+locked: false
+
+is-key-locked-by-conflicting-txn r=req9 k=i strength=none
+----
+locked: false
+
+dequeue r=req9
+----
+num=7
+ lock: "b"
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
+ lock: "c"
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 9.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
+ lock: "d"
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
+ lock: "f"
+   queued writers:
+    active: false req: 3, txn: 00000000-0000-0000-0000-000000000001
+ lock: "g"
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Shared seq: 0)]
+ lock: "h"
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 9.000000000,1, info: unrepl [(str: Shared seq: 0)]
+ lock: "i"
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 9.000000000,1, info: unrepl [(str: Shared seq: 0)]
+   queued writers:
+    active: true req: 7, txn: 00000000-0000-0000-0000-000000000001
+   distinguished req: 7

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/skip_locked
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/skip_locked
@@ -457,3 +457,23 @@ num=7
    queued writers:
     active: true req: 7, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 7
+
+# ---------------------------------------------------------------------------------
+# Ensure the case where a locking skip locked request finds another request from
+# its own transaction correctly returns an error.
+# ---------------------------------------------------------------------------------
+
+new-request r=req10 txn=txn1 ts=10,1 spans=exclusive@f skip-locked
+----
+
+scan r=req10
+----
+start-waiting: false
+
+should-wait r=req10
+----
+false
+
+is-key-locked-by-conflicting-txn r=req10 k=f strength=exclusive
+----
+SKIP LOCKED request should not find another waiting request from the same transaction

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -919,22 +919,20 @@ func MVCCBlindPutInlineWithPrev(
 // table (i.e. unreplicated locks) and locks only stored in the persistent lock
 // table keyspace (i.e. replicated locks that have yet to be "discovered").
 type LockTableView interface {
-	// IsKeyLockedByConflictingTxn returns whether the specified key is claimed
-	// (see claimantTxn()) by a conflicting transaction in the lockTableGuard's
-	// snapshot of the lock table, given the caller's own desired locking
-	// strength. If so, true is returned. If the key is locked, the lock holder is
-	// also returned. Otherwise, if the key was claimed by a concurrent request
-	// still sequencing through the lock table, but the lock isn't held (yet), nil
-	// is also returned.
+	// IsKeyLockedByConflictingTxn returns whether the specified key is locked by
+	// a conflicting transaction in the lockTableGuard's snapshot of the lock
+	// table, given the caller's own desired locking strength. If so, true is
+	// returned and so is the lock holder. If the lock is held by the transaction
+	// itself, there's no conflict to speak of, so false is returned.
 	//
-	// If the lock has been claimed (held or otherwise) by the transaction itself,
-	// there's no conflict to speak of, so false is returned. In cases where the
-	// lock isn't held, but the lock has been claimed by the transaction itself,
-	// we do not make a distinction about which request claimed the key -- it
-	// could either be the request itself, or a different concurrent request from
-	// the same transaction; The specifics do not affect the caller.
 	// This method is used by requests in conjunction with the SkipLocked wait
 	// policy to determine which keys they should skip over during evaluation.
+	//
+	// If the supplied lock strength is locking (!= lock.None), then any queued
+	// locking requests that came before the lockTableGuard will also be checked
+	// for conflicts. This helps prevent a stream of locking SKIP LOCKED requests
+	// from starving out regular locking requests. In such cases, true is
+	// returned, but so is nil.
 	IsKeyLockedByConflictingTxn(roachpb.Key, lock.Strength) (bool, *enginepb.TxnMeta)
 }
 

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -933,7 +933,7 @@ type LockTableView interface {
 	// for conflicts. This helps prevent a stream of locking SKIP LOCKED requests
 	// from starving out regular locking requests. In such cases, true is
 	// returned, but so is nil.
-	IsKeyLockedByConflictingTxn(roachpb.Key, lock.Strength) (bool, *enginepb.TxnMeta)
+	IsKeyLockedByConflictingTxn(roachpb.Key, lock.Strength) (bool, *enginepb.TxnMeta, error)
 }
 
 // MVCCGetOptions bundles options for the MVCCGet family of functions.

--- a/pkg/storage/mvcc_history_test.go
+++ b/pkg/storage/mvcc_history_test.go
@@ -2475,18 +2475,18 @@ type mockLockTableView struct {
 
 func (lt *mockLockTableView) IsKeyLockedByConflictingTxn(
 	k roachpb.Key, s lock.Strength,
-) (bool, *enginepb.TxnMeta) {
+) (bool, *enginepb.TxnMeta, error) {
 	holder, ok := lt.locks[string(k)]
 	if !ok {
-		return false, nil
+		return false, nil, nil
 	}
 	if lt.txn != nil && lt.txn.ID == holder.ID {
-		return false, nil
+		return false, nil, nil
 	}
 	if s == lock.None && lt.ts.Less(holder.WriteTimestamp) {
-		return false, nil
+		return false, nil, nil
 	}
-	return true, &holder.TxnMeta
+	return true, &holder.TxnMeta, nil
 }
 
 func (e *evalCtx) visitWrappedIters(fn func(it storage.SimpleMVCCIterator) (done bool)) {

--- a/pkg/storage/pebble_mvcc_scanner.go
+++ b/pkg/storage/pebble_mvcc_scanner.go
@@ -1809,7 +1809,12 @@ func (p *pebbleMVCCScanner) isKeyLockedByConflictingTxn(
 	if p.failOnMoreRecent {
 		strength = lock.Exclusive
 	}
-	if ok, txn := p.lockTable.IsKeyLockedByConflictingTxn(key, strength); ok {
+	ok, txn, err := p.lockTable.IsKeyLockedByConflictingTxn(key, strength)
+	if err != nil {
+		p.err = err
+		return false, false
+	}
+	if ok {
 		// The key is locked or reserved, so ignore it.
 		if txn != nil && (p.maxIntents == 0 || int64(p.intents.Count()) < p.maxIntents) {
 			// However, if the key is locked, we return the lock holder separately


### PR DESCRIPTION
This patch switches isKeyLockedByConflictingTxn to make use of lock modes to detect conflicts. As a result, SKIP LOCKED requests correctly interact with shared locks. We add a few tests to demonstrate this.

Fixes #108715

Release note: None