### PR TITLE
release-23.1: TEAMS: use workflow for SQL Queries issue triage

### DIFF
--- a/TEAMS.yaml
+++ b/TEAMS.yaml
@@ -29,11 +29,13 @@ cockroachdb/sql-foundations:
   triage_column_id: 19467489
   label: T-sql-foundations
 cockroachdb/sql-queries:
+  # SQL Queries team uses GH projects v2, which doesn't have a REST API, so
+  # there is no triage column ID.
+  # See .github/workflows/add-issues-to-project.yml.
   aliases:
     cockroachdb/sql-queries-prs: other
     cockroachdb/sql-optimizer: other
     cockroachdb/sql-opt-prs: other
-  triage_column_id: 13549252
 cockroachdb/cluster-observability:
   triage_column_id: 12618343
 cockroachdb/kv:


### PR DESCRIPTION
Backport 1/1 commits from #107498.

/cc @cockroachdb/release

---

The SQL Queries team now uses Github Projects v2. This commit updates
`TEAMS.yaml` so that roachtest doesn't try to assign it a project.

Epic: None
Release note: None
Release justification: test only