### PR TITLE
util/log: add custom crash tags to sentry

### DIFF
--- a/pkg/util/log/logcrash/crash_reporting.go
+++ b/pkg/util/log/logcrash/crash_reporting.go
@@ -255,6 +255,7 @@ func SetupCrashReporter(ctx context.Context, cmd string) {
 	crashReportingActive = true
 
 	sentry.ConfigureScope(func(scope *sentry.Scope) {
+		scope.SetTags(getTagsFromEnvironment())
 		scope.SetTags(map[string]string{
 			"cmd":          cmd,
 			"platform":     info.Platform,


### PR DESCRIPTION
In #106786 we added the ability to provide an environment variable that was meant to add custom tags to sentry crash reports. That change added the function that would create the map of crash report tags / values, but it was never actually used. This change ensures that tags from that environment variable will actually show up in the sentry reports.

Release note: None

Epic: None