### PR TITLE
compose/compare: Add PG compat session variables

### DIFF
--- a/pkg/compose/compare/compare/compare_test.go
+++ b/pkg/compose/compare/compare/compare_test.go
@@ -65,6 +65,8 @@ func TestCompare(t *testing.T) {
 			addr: "postgresql://root@cockroach1:26257/postgres?sslmode=disable",
 			init: []string{
 				"SET CLUSTER SETTING cluster.organization = 'Cockroach Labs - Production Testing'",
+				"SET extra_float_digits = 0",   // For Postgres Compat when casting floats to strings.
+				"SET null_ordered_last = true", // For Postgres Compat, see https://www.cockroachlabs.com/docs/stable/order-by#parameters
 				fmt.Sprintf("SET CLUSTER SETTING enterprise.license = '%s'", license),
 				"drop database if exists postgres",
 				"create database postgres",
@@ -74,6 +76,8 @@ func TestCompare(t *testing.T) {
 			addr: "postgresql://root@cockroach2:26257/postgres?sslmode=disable",
 			init: []string{
 				"SET CLUSTER SETTING cluster.organization = 'Cockroach Labs - Production Testing'",
+				"SET extra_float_digits = 0",   // For Postgres Compat when casting floats to strings.
+				"SET null_ordered_last = true", // For Postgres Compat https://www.cockroachlabs.com/docs/stable/order-by#parameters
 				fmt.Sprintf("SET CLUSTER SETTING enterprise.license = '%s'", license),
 				"drop database if exists postgres",
 				"create database postgres",


### PR DESCRIPTION
Previously, `TestComposeCompare` would fail due to differences in how floats were cast to strings and the default behavior of NULL ordering. This commit sets PG compatibility session variables for the CockroachDB instances used in this test.

This commit only fixes failures when:
1. A float is being cast to a string (`SELECT 1234567::FLOAT8::STRING`)
2. A `SELECT` contains an `ORDER BY` _without_ specifying how `NULLS` should be handled.

There are still other known and unknown failures.

Epic: None
Informs: #99181