### PR TITLE
logictest: avoid FATAL during cleanup

### DIFF
--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -3804,10 +3804,10 @@ func (t *logicTest) validateAfterTestCompletion() error {
 		if user == username.RootUser {
 			continue
 		}
-		for i, c := range userClients {
-			if err := c.Close(); err != nil {
-				t.Fatalf("failed to close connection to node %d for user %s: %v", i, user, err)
-			}
+		for _, c := range userClients {
+			// Ignore the error from closing the connection. This may not succeed if,
+			// for example, CANCEL SESSION was called on one of the sessions.
+			_ = c.Close()
 		}
 		delete(t.clients, user)
 	}


### PR DESCRIPTION
This prevents the test from failing if there is an error closing a connection at the end of the test. There is no strong need for us to assert that closing the connection worked.

fixes https://github.com/cockroachdb/cockroach/issues/108833
Release note: None