### PR TITLE
streamingest: speed-up c2c cutover

### DIFF
--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor.go
@@ -84,7 +84,7 @@ var cutoverSignalPollInterval = settings.RegisterDurationSetting(
 	settings.TenantWritable,
 	"bulkio.stream_ingestion.cutover_signal_poll_interval",
 	"the interval at which the stream ingestion job checks if it has been signaled to cutover",
-	30*time.Second,
+	10*time.Second,
 	settings.NonNegativeDuration,
 )
 


### PR DESCRIPTION
Each c2c processor checks the job info table every 30 seconds to see whether a cutover has started. Normally a cutover should take about 10 seconds. This pr changes the default to 10 seconds, to reduce the total time for cutting over.

Epic: none

Release note: None