### PR TITLE
pkg/util/log: alter bufferedSink to handle writes during sync flush

### DIFF
--- a/pkg/util/log/buffered_sink.go
+++ b/pkg/util/log/buffered_sink.go
@@ -271,8 +271,8 @@ func (bs *bufferedSink) output(b []byte, opts sinkOutputOptions) error {
 			if bs.mu.timer == nil && bs.maxStaleness > 0 {
 				bs.mu.timer = time.AfterFunc(bs.maxStaleness, func() {
 					bs.mu.Lock()
+					defer bs.mu.Unlock()
 					bs.flushAsyncLocked()
-					bs.mu.Unlock()
 				})
 			}
 		}
@@ -330,9 +330,11 @@ func (bs *bufferedSink) runFlusher(stopC <-chan struct{}) {
 			// We'll return after flushing everything.
 			done = true
 		}
-		bs.mu.Lock()
-		msg, errC := buf.flush(bs.format.prefix, bs.format.suffix, bs.format.delimiter)
-		bs.mu.Unlock()
+		msg, errC := func() (*buffer, chan<- error) {
+			bs.mu.Lock()
+			defer bs.mu.Unlock()
+			return buf.flush(bs.format.prefix, bs.format.suffix, bs.format.delimiter)
+		}()
 		if msg == nil {
 			// Nothing to flush.
 			// NOTE: This can happen in the done case, or if we get two flushC signals
@@ -350,9 +352,11 @@ func (bs *bufferedSink) runFlusher(stopC <-chan struct{}) {
 		} else if err != nil {
 			Ops.Errorf(context.Background(), "logging error from %T: %v", bs.child, err)
 			if bs.crashOnAsyncFlushFailure {
-				logging.mu.Lock()
-				f := logging.mu.exitOverride.f
-				logging.mu.Unlock()
+				f := func() func(exit.Code, error) {
+					logging.mu.Lock()
+					defer logging.mu.Unlock()
+					return logging.mu.exitOverride.f
+				}()
 				code := bs.exitCode()
 				if f != nil {
 					f(code, err)

--- a/pkg/util/log/buffered_sink.go
+++ b/pkg/util/log/buffered_sink.go
@@ -12,6 +12,7 @@ package log
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/cli/exit"
@@ -23,16 +24,19 @@ import (
 // bufferedSink wraps a child sink to add buffering. Messages are accumulated
 // and passed to the child sink in bulk when the buffer is flushed. The buffer
 // is flushed periodically, and also when it reaches a configured size. Flushes
-// can also be requested manually through the extraFlush and forceSync output()
+// can also be requested manually through the extraFlush and tryForceSync output()
 // options.
 //
 // bufferedSink's output() method never blocks on the child (except when the
-// forceSync option is used). Instead, old messages are dropped if the buffer is
+// tryForceSync option is used). Instead, old messages are dropped if the buffer is
 // overflowing a configured limit.
 //
 // Should an error occur in the child sink, it's forwarded to the provided
-// onAsyncFlushErr (unless forceSync is requested, in which case the error is
+// onAsyncFlushErr (unless tryForceSync is requested, in which case the error is
 // returned synchronously, as it would for any other sink).
+//
+// Note that tryForceSync is best-effort, but there are scenarios where it can't
+// be honored. See output() documentation for additional details.
 type bufferedSink struct {
 	// child is the wrapped logSink.
 	child logSink
@@ -104,7 +108,7 @@ func newBufferFmtConfig(bufferFmt *logconfig.BufferFormat) *bufferFmtConfig {
 // automatically flushes its contents to the child sink. Zero values disable
 // these flush triggers. If all triggers are disabled, the buffer is only ever
 // flushed when a flush is explicitly requested through the extraFlush or
-// forceSync options passed to output().
+// tryForceSync options passed to output().
 //
 // maxBufferSize, if not zero, limits the size of the buffer. When a new message
 // is causing the buffer to overflow, old messages are dropped. The caller must
@@ -193,10 +197,17 @@ func (bs *bufferedSink) attachHints(b []byte) []byte {
 // sinks must not recursively call into logging when implementing
 // this method.
 //
-// If forceSync is set, the output() call blocks on the child sink flush and
-// returns the child sink's error (which is otherwise handled via the
-// bufferedSink's onAsyncFlushErr). If the bufferedSink drops this message instead of
-// passing it to the child sink, errSyncMsgDropped is returned.
+// If tryForceSync is set, the output() call attempts to block on the
+// child sink flush and returns the child sink's error (which is otherwise
+// handled via the bufferedSink's onAsyncFlushErr). However, if a previous
+// tryForceSync is already scheduled on flushC, we do not block. In this case,
+// the msg provided to this output() call will be included in the already
+// scheduled tryForceSync's flush, which is imminent. This is an edge case
+// that should rarely happen, but it's possible.
+//
+// If the bufferedSink drops this message instead of passing it to the child
+// sink, errSyncMsgDropped is returned. This is generally due to buffer size
+// limitations.
 func (bs *bufferedSink) output(b []byte, opts sinkOutputOptions) error {
 	// Make a copy to live in the async buffer.
 	// We can't take ownership of the slice we're passed --
@@ -206,36 +217,70 @@ func (bs *bufferedSink) output(b []byte, opts sinkOutputOptions) error {
 	_, _ = msg.Write(b)
 
 	var errC chan error
-	if opts.forceSync {
-		// We'll ask to be notified on errC when the flush is complete.
-		errC = make(chan error)
-	}
 
-	bs.mu.Lock()
-	// Append the message to the buffer.
-	if err := bs.mu.buf.appendMsg(msg, errC); err != nil {
-		bs.mu.Unlock()
+	err := func() error {
+		bs.mu.Lock()
+		defer bs.mu.Unlock()
+		// Append the message to the buffer.
+		err := bs.mu.buf.appendMsg(msg)
+		if err != nil {
+			// Release the msg buffer, since our append failed.
+			putBuffer(msg)
+			return err
+		}
+
+		// If the errC on the buffer is already set, then a synchronous
+		// flush must already be scheduled & waiting on flushC to be executed.
+		// We only support scheduling one single synchronous flush at a time
+		// in the bufferedSink, triggered via the tryForceSync option.
+		//
+		// Since b.errC is already set by the currently scheduled synchronous flush,
+		// we can't honor the tryForceSync option for this output() call. However,
+		// this output() call's msg will be picked up in the imminent flush anyway,
+		// since it's already been buffered.
+		//
+		// WARNING: Attempting to use the buffer's errC when a tryForceSync flush
+		// is already scheduled, such as overwriting the reference here with a new
+		// errC, will cause the goroutine already waiting on errC to deadlock!
+		// Don't do this!
+		syncFlushAlreadyScheduled := bs.mu.buf.errC != nil
+		if !syncFlushAlreadyScheduled && opts.tryForceSync {
+			// We'll ask to be notified on errC when the flush is complete.
+			errC = make(chan error)
+			bs.mu.buf.errC = errC
+		}
+		if syncFlushAlreadyScheduled && opts.tryForceSync {
+			fmt.Printf(
+				"tryForceSync called on %T while one already scheduled. Msg will be included in imminent flush instead.\n",
+				bs.child)
+		}
+
+		// If a synchronous flush is already scheduled, then a flush is imminent, so don't bother
+		// scheduling another. Our msg will be included in the upcoming flush.
+		flush := !syncFlushAlreadyScheduled &&
+			(opts.extraFlush || opts.tryForceSync || (bs.triggerSize > 0 && bs.mu.buf.size() >= bs.triggerSize))
+		if flush {
+			// Trigger a flush. The flush will take effect asynchronously (and can be
+			// arbitrarily delayed if there's another flush in progress). In the
+			// meantime, the current buffer continues accumulating messages until it
+			// hits its limit.
+			bs.flushAsyncLocked()
+		} else {
+			// Schedule a flush for the future based on maxStaleness, unless
+			// one is scheduled already.
+			if bs.mu.timer == nil && bs.maxStaleness > 0 {
+				bs.mu.timer = time.AfterFunc(bs.maxStaleness, func() {
+					bs.mu.Lock()
+					bs.flushAsyncLocked()
+					bs.mu.Unlock()
+				})
+			}
+		}
+		return nil
+	}()
+	if err != nil {
 		return err
 	}
-
-	flush := opts.extraFlush || opts.forceSync || (bs.triggerSize > 0 && bs.mu.buf.size() >= bs.triggerSize)
-	if flush {
-		// Trigger a flush. The flush will take effect asynchronously (and can be
-		// arbitrarily delayed if there's another flush in progress). In the
-		// meantime, the current buffer continues accumulating messages until it
-		// hits its limit.
-		bs.flushAsyncLocked()
-	} else {
-		// Schedule a flush unless one is scheduled already.
-		if bs.mu.timer == nil && bs.maxStaleness > 0 {
-			bs.mu.timer = time.AfterFunc(bs.maxStaleness, func() {
-				bs.mu.Lock()
-				bs.flushAsyncLocked()
-				bs.mu.Unlock()
-			})
-		}
-	}
-	bs.mu.Unlock()
 
 	// If this is a synchronous flush, wait for its completion.
 	if errC != nil {
@@ -299,7 +344,7 @@ func (bs *bufferedSink) runFlusher(stopC <-chan struct{}) {
 			continue
 		}
 
-		err := bs.child.output(msg.Bytes(), sinkOutputOptions{extraFlush: true, forceSync: errC != nil})
+		err := bs.child.output(msg.Bytes(), sinkOutputOptions{extraFlush: true, tryForceSync: errC != nil})
 		if errC != nil {
 			errC <- err
 		} else if err != nil {
@@ -347,9 +392,12 @@ func (b *msgBuf) size() uint64 {
 
 var errMsgTooLarge = errors.New("message dropped because it is too large")
 
-// appendMsg appends msg to the buffer. If errC is not nil, then this channel
-// will be signaled when the buffer is flushed.
-func (b *msgBuf) appendMsg(msg *buffer, errC chan<- error) error {
+// appendMsg appends msg to the buffer. If msg can't fit in the buffer,
+// errMsgTooLarge is returned.
+//
+// If the buffer is full, then we drop older messages in the buffer
+// until we have space for the new message.
+func (b *msgBuf) appendMsg(msg *buffer) error {
 	msgLen := uint64(msg.Len())
 
 	// Make room for the new message, potentially by dropping the oldest messages
@@ -368,18 +416,6 @@ func (b *msgBuf) appendMsg(msg *buffer, errC chan<- error) error {
 
 	b.messages = append(b.messages, msg)
 	b.sizeBytes += msgLen
-
-	// Assert that b.errC is not already set. It shouldn't be set
-	// because, if there was a previous message with errC set, that
-	// message must have had the forceSync flag set and thus acts as a barrier:
-	// no more messages are sent until the flush of that message completes.
-	//
-	// If b.errorCh were to be set, we wouldn't know what to do about it
-	// since we can't overwrite it in case m.errorCh is also set.
-	if b.errC != nil {
-		panic(errors.AssertionFailedf("unexpected errC already set"))
-	}
-	b.errC = errC
 	return nil
 }
 

--- a/pkg/util/log/clog.go
+++ b/pkg/util/log/clog.go
@@ -370,7 +370,7 @@ func (l *loggerT) outputLogEntry(entry logEntry) {
 				// The sink was not accepting entries at this level. Nothing to do.
 				continue
 			}
-			if err := s.sink.output(bufs.b[i].Bytes(), sinkOutputOptions{extraFlush: extraFlush, forceSync: isFatal}); err != nil {
+			if err := s.sink.output(bufs.b[i].Bytes(), sinkOutputOptions{extraFlush: extraFlush, tryForceSync: isFatal}); err != nil {
 				if !s.criticality {
 					// An error on this sink is not critical. Just report
 					// the error and move on.

--- a/pkg/util/log/sinks.go
+++ b/pkg/util/log/sinks.go
@@ -28,9 +28,19 @@ type sinkOutputOptions struct {
 	extraFlush bool
 	// ignoreErrors disables internal error handling (i.e. fail fast).
 	ignoreErrors bool
-	// forceSync forces synchronous operation of this output operation.
-	// That is, it will block until the output has been handled.
-	forceSync bool
+	// tryForceSync attempts to force a synchronous operation of this
+	// output operation. That is, it will block until the output has been
+	// handled, so long as the underlying sink can support the operation at
+	// that moment.
+	//
+	// This isn't an ironclad guarantee, but in the vast majority of
+	// scenarios, this option will be honored.
+	//
+	// If a sink can't support a synchronous flush, it should do its
+	// best to ensure a flush is imminent which will include the log
+	// message that accompanies the tryForceSync option. It should also
+	// give some indication that it was unable to do so.
+	tryForceSync bool
 }
 
 // logSink abstracts the destination of logging events, after all


### PR DESCRIPTION
Previously, if the bufferedSink had a synchronous flush scheduled, and an additional write (via the `output()` function) was sent to the bufferedSink, the bufferedSink would panic.

After some investigation & analysis of the code, this approach was found to be unnecessary. We can gracefully handle this scenario without panicking. Instead, we can buffer the message to be included in the upcoming flush.

In this scenario, if an additional forceSync output() call is sent to the bufferedSink, when one is already scheduled, we cannot make the call synchronous. Instead, we can buffer the message in the imminent flush, and return.

Because of this, we change the name of the forceSync option to tryForceSync, to indicate that it's best-effort and not an ironclad guarantee.

Release note: none

Fixes: https://github.com/cockroachdb/cockroach/issues/106345

NB: A follow up PR will reintroduce the flush trigger into the crash reporter / process shutdown procedure (similar to https://github.com/cockroachdb/cockroach/pull/101562, which was reverted). This PR focuses on the bufferedSink changes themselves, to keep discussion focused.