### PR TITLE
[DNM] kv: generalize optimistic eval checks to work on the rw path

### DIFF
--- a/pkg/kv/kvserver/replica_proposal.go
+++ b/pkg/kv/kvserver/replica_proposal.go
@@ -896,6 +896,11 @@ func (r *Replica) evaluateProposal(
 	// in the call stack as well.
 	batch, ms, br, res, pErr := r.evaluateWriteBatch(ctx, idKey, ba, g, st, ui)
 
+	optEvalErr := r.maybeCheckOptimisticEvalSuccess(g, pErr, ba, br, st)
+	if optEvalErr != nil {
+		pErr = optEvalErr
+	}
+
 	// Note: reusing the proposer's batch when applying the command on the
 	// proposer was explored as an optimization but resulted in no performance
 	// benefit.


### PR DESCRIPTION
Prior to this patch, optimistic evaluation and checking if it was successful happened only on the read-only path. However, with the imminent introduction of replicated locks, we'll have some Get/Scan/RevScan requests taking the read-write path as well. To enable optmistic eval possibilities for such requests, this patch generalizes optimistic eval checks to happen on both the read-only and read-write paths.

Epic: none

Release note: None