### PR TITLE
release: submit post publishing phase PRs

### DIFF
--- a/build/teamcity/internal/cockroach/release/process/update_versions_impl.sh
+++ b/build/teamcity/internal/cockroach/release/process/update_versions_impl.sh
@@ -15,8 +15,8 @@ fi
 git fetch --tags -q origin
 
 # install gh
-wget -O /tmp/gh.tar.gz https://github.com/cli/cli/releases/download/v2.13.0/gh_2.13.0_linux_amd64.tar.gz
-echo "9e833e02428cd49e0af73bc7dc4cafa329fe3ecba1bfe92f0859bf5b11916401  /tmp/gh.tar.gz" | sha256sum -c -
+wget -O /tmp/gh.tar.gz https://github.com/cli/cli/releases/download/v2.32.1/gh_2.32.1_linux_amd64.tar.gz
+echo "5c9a70b6411cc9774f5f4e68f9227d5d55ca0bfbd00dfc6353081c9b705c8939  /tmp/gh.tar.gz" | sha256sum -c -
 tar --strip-components 1 -xf /tmp/gh.tar.gz
 export PATH=$PWD/bin:$PATH
 

--- a/pkg/cmd/release/BUILD.bazel
+++ b/pkg/cmd/release/BUILD.bazel
@@ -15,6 +15,9 @@ go_library(
         "sentry.go",
         "set_cockroach_version.go",
         "templates.go",
+        "update_brew.go",
+        "update_helm.go",
+        "update_orchestration.go",
         "update_releases.go",
         "update_versions.go",
     ],
@@ -47,6 +50,7 @@ go_test(
     name = "release_test",
     srcs = [
         "blockers_test.go",
+        "git_test.go",
         "sender_test.go",
         "update_releases_test.go",
         "update_versions_test.go",

--- a/pkg/cmd/release/git_test.go
+++ b/pkg/cmd/release/git_test.go
@@ -1,0 +1,129 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package main
+
+import "testing"
+
+func TestBumpVersion(t *testing.T) {
+	tests := []struct {
+		version     string
+		nextVersion string
+		wantErr     bool
+	}{
+		{
+			version:     "v23.1.0",
+			nextVersion: "v23.1.1",
+			wantErr:     false,
+		},
+		{
+			version:     "v23.1.1",
+			nextVersion: "v23.1.2",
+			wantErr:     false,
+		},
+		{
+			version:     "v23.1.9",
+			nextVersion: "v23.1.10",
+			wantErr:     false,
+		},
+		{
+			version:     "v23.2.0",
+			nextVersion: "v23.2.1",
+			wantErr:     false,
+		},
+		{
+			version:     "v23.2.1",
+			nextVersion: "v23.2.2",
+			wantErr:     false,
+		},
+		{
+			version:     "v23.2.9",
+			nextVersion: "v23.2.10",
+			wantErr:     false,
+		},
+		{
+			version:     "v23.2.0-alpha.00000000",
+			nextVersion: "v23.2.0-alpha.1",
+			wantErr:     false,
+		},
+		{
+			version:     "v23.1.0-alpha.0",
+			nextVersion: "v23.1.0-alpha.1",
+			wantErr:     false,
+		},
+		{
+			version:     "v23.1.0-alpha.1",
+			nextVersion: "v23.1.0-alpha.2",
+			wantErr:     false,
+		},
+		{
+			version:     "v23.1.0-alpha.9",
+			nextVersion: "v23.1.0-alpha.10",
+			wantErr:     false,
+		},
+		{
+			version:     "v23.1.0-beta.0",
+			nextVersion: "v23.1.0-beta.1",
+			wantErr:     false,
+		},
+		{
+			version:     "v23.1.0-beta.1",
+			nextVersion: "v23.1.0-beta.2",
+			wantErr:     false,
+		},
+		{
+			version:     "v23.1.0-beta.9",
+			nextVersion: "v23.1.0-beta.10",
+			wantErr:     false,
+		},
+		{
+			version:     "v23.1.0-rc.0",
+			nextVersion: "v23.1.0-rc.1",
+			wantErr:     false,
+		},
+		{
+			version:     "v23.1.0-rc.1",
+			nextVersion: "v23.1.0-rc.2",
+			wantErr:     false,
+		},
+		{
+			version:     "v23.1.0-rc.9",
+			nextVersion: "v23.1.0-rc.10",
+			wantErr:     false,
+		},
+		{
+			version:     "v23.1.0-rc9",
+			nextVersion: "",
+			wantErr:     true,
+		},
+		{
+			version:     "v23.1.0-beta",
+			nextVersion: "",
+			wantErr:     true,
+		},
+		{
+			version:     "v23.1.0-alpha-3",
+			nextVersion: "",
+			wantErr:     true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.version, func(t *testing.T) {
+			got, err := bumpVersion(tt.version)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("bumpVersion() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.nextVersion {
+				t.Errorf("bumpVersion() got = %v, nextVersion %v", got, tt.nextVersion)
+			}
+		})
+	}
+}

--- a/pkg/cmd/release/sender.go
+++ b/pkg/cmd/release/sender.go
@@ -13,6 +13,7 @@ package main
 import (
 	"fmt"
 	htmltemplate "html/template"
+	"log"
 	"net/smtp"
 	"net/textproto"
 	"path/filepath"
@@ -215,7 +216,7 @@ func sendMailPickSHA(args messageDataPickSHA, opts sendOpts) error {
 	return sendmail(msg, opts)
 }
 
-func sendMailUpdateVersions(args messageDataUpdateVersions, opts sendOpts, dryRun bool) error {
+func sendMailUpdateVersions(args messageDataUpdateVersions, opts sendOpts) error {
 	template := messageTemplates{
 		SubjectPrefix: templatePrefixUpdateVersions,
 		BodyPrefixes:  []string{templatePrefixUpdateVersions},
@@ -224,14 +225,8 @@ func sendMailUpdateVersions(args messageDataUpdateVersions, opts sendOpts, dryRu
 	if err != nil {
 		return fmt.Errorf("newMessage: %w", err)
 	}
-
-	if dryRun {
-		email := fmt.Sprintf("Subject: %s\n\n%s\n", msg.Subject, msg.TextBody)
-		fmt.Printf("dry-run: sendMailUpdateVersions:\n%s", email)
-		// We proceed to actually sending the mail in dry-runs because the
-		// TeamCity script sets the destination email address to the
-		// release-dev team's email.
-	}
+	log.Printf("dry-run: sendMailUpdateVersions:\n")
+	log.Printf("Subject: %s\n\n%s\n", msg.Subject, msg.TextBody)
 	return sendmail(msg, opts)
 }
 
@@ -239,7 +234,6 @@ func sendMailUpdateVersions(args messageDataUpdateVersions, opts sendOpts, dryRu
 // sendmail is specified as a function closure to allow for testing
 // of sendMail* methods.
 var sendmail = func(content *message, smtpOpts sendOpts) error {
-
 	e := &email.Email{
 		To:      smtpOpts.to,
 		From:    smtpOpts.from,

--- a/pkg/cmd/release/sentry.go
+++ b/pkg/cmd/release/sentry.go
@@ -22,7 +22,7 @@ func generatePanic(tag string) error {
 	// TODO: do not hardcode the URL
 	script := fmt.Sprintf(`
 set -exuo pipefail
-curl --fail --silent --show-error --output /dev/stdout --url https://storage.googleapis.com/cockroach-builds-artifacts-prod/cockroach-%s.linux-amd64.tgz | tar -xz
+curl --retry-connrefused --retry 5 --fail --silent --show-error --output /dev/stdout --url https://storage.googleapis.com/cockroach-builds-artifacts-prod/cockroach-%s.linux-amd64.tgz | tar -xz
 ./cockroach-%s.linux-amd64/cockroach demo --insecure -e "select crdb_internal.force_panic('testing')" || true
 `, tag, tag)
 	cmd := exec.Command("bash", "-c", script)

--- a/pkg/cmd/release/set_cockroach_version.go
+++ b/pkg/cmd/release/set_cockroach_version.go
@@ -42,9 +42,12 @@ func setCockroachVersion(_ *cobra.Command, _ []string) error {
 	if err != nil {
 		return fmt.Errorf("cannot parse version %s: %w", setCockroachVersionFlags.versionStr, err)
 	}
-	version := []byte(setCockroachVersionFlags.versionStr + "\n")
-	err = os.WriteFile(versionFile, version, 0644)
-	if err != nil {
+	return updateVersionFile(versionFile, setCockroachVersionFlags.versionStr)
+}
+
+func updateVersionFile(dest string, version string) error {
+	contents := []byte(version + "\n")
+	if err := os.WriteFile(dest, contents, 0644); err != nil {
 		return fmt.Errorf("cannot write version.txt: %w", err)
 	}
 	return nil

--- a/pkg/cmd/release/update_brew.go
+++ b/pkg/cmd/release/update_brew.go
@@ -1,0 +1,41 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"os/exec"
+
+	"github.com/Masterminds/semver/v3"
+)
+
+// updateBrew runs commands in the homebrew-tap repo in order to update the cockroachdb version.
+func updateBrew(workDir string, version *semver.Version, latestMajor bool) error {
+	// cockroach@major.minor is supported for all releases
+	commands := []*exec.Cmd{
+		exec.Command("make", fmt.Sprintf("VERSION=%s", version.String()), fmt.Sprintf("PRODUCT=cockroach@%d.%d", version.Major(), version.Minor())),
+	}
+	// limited to the latest release only
+	if latestMajor {
+		commands = append(commands, exec.Command("make", fmt.Sprintf("VERSION=%s", version.String()), "PRODUCT=cockroach"))
+		commands = append(commands, exec.Command("make", fmt.Sprintf("VERSION=%s", version.String()), "PRODUCT=cockroach-sql"))
+	}
+	for _, cmd := range commands {
+		cmd.Dir = workDir
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("failed running '%s' with message '%s': %w", cmd.String(), string(out), err)
+		}
+		log.Printf("ran '%s': %s\n", cmd.String(), string(out))
+	}
+	return nil
+}

--- a/pkg/cmd/release/update_helm.go
+++ b/pkg/cmd/release/update_helm.go
@@ -1,0 +1,35 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"os/exec"
+)
+
+// updateHelm runs commands in the helm-charts repo in order to update the cockroachdb version.
+func updateHelm(workDir string, version string) error {
+	commands := []*exec.Cmd{
+		exec.Command("bazel", "build", "//build"),
+		// Helm charts use the version without the "v" prefix, but the bumper trims it if present.
+		exec.Command("sh", "-c", fmt.Sprintf("$(bazel info bazel-bin)/build/build_/build bump %s", version)),
+	}
+	for _, cmd := range commands {
+		cmd.Dir = workDir
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("failed running '%s' with message '%s': %w", cmd.String(), string(out), err)
+		}
+		log.Printf("ran '%s': %s\n", cmd.String(), string(out))
+	}
+	return nil
+}

--- a/pkg/cmd/release/update_orchestration.go
+++ b/pkg/cmd/release/update_orchestration.go
@@ -1,0 +1,69 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+)
+
+// updateOrchestration updates the kubernetes manifests in the cockroach repo using templates.
+func updateOrchestration(gitDir string, version string) error {
+	// make sure we have the leading "v" in the version
+	version = "v" + strings.TrimPrefix(version, "v")
+	templatesDir := path.Join(gitDir, "cloud/kubernetes/templates")
+	outputDir := path.Join(gitDir, "cloud/kubernetes")
+	dirInfo, err := os.Stat(templatesDir)
+	if err != nil {
+		return fmt.Errorf("cannot stat templates directory: %w", err)
+	}
+	if !dirInfo.IsDir() {
+		return fmt.Errorf("%s is not a directory", templatesDir)
+	}
+	return filepath.Walk(templatesDir, func(filePath string, fileInfo os.FileInfo, e error) error {
+		if e != nil {
+			return e
+		}
+		// Skip directories
+		if !fileInfo.Mode().IsRegular() {
+			return nil
+		}
+		// calculate file directory relative to the given root directory.
+		dir := path.Dir(filePath)
+		relDir, err := filepath.Rel(templatesDir, dir)
+		if err != nil {
+			return err
+		}
+		destDir := filepath.Join(outputDir, relDir)
+		destFile := filepath.Join(destDir, fileInfo.Name())
+		if err := os.MkdirAll(destDir, 0755); err != nil && !errors.Is(err, os.ErrExist) {
+			return err
+		}
+		contents, err := os.ReadFile(filePath)
+		if err != nil {
+			return err
+		}
+		// Go templates cannot be used here, because some files are templates already.
+		generatedContents := strings.ReplaceAll(string(contents), "@VERSION@", version)
+		if strings.HasSuffix(destFile, ".yaml") {
+			generatedContents = fmt.Sprintf("# Generated file, DO NOT EDIT. Source: %s\n", filePath) + generatedContents
+		}
+		err = os.WriteFile(destFile, []byte(generatedContents), fileInfo.Mode().Perm())
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+}


### PR DESCRIPTION
Previously, the post publishing automation was not up to date, so we couldn't use it.

* Update `gh` version.
* `bumpVersion` now supports pre-release versions.
* Add `bumpVersion` tests.
* Simplify orchestration CLI args.
* Use a function instead of commands for repo manipulation for better flexibility.
* Added logic to handle version bump on "dot-zero" branches.

Part of: RE-54
Release note: None