### PR TITLE
cloud/azure: allow all tests in TestAzure to be run in parallel

### DIFF
--- a/pkg/cloud/azure/azure_storage_test.go
+++ b/pkg/cloud/azure/azure_storage_test.go
@@ -126,24 +126,24 @@ func TestAzure(t *testing.T) {
 	)
 
 	// Client Secret auth
-	cloudtestutils.CheckExportStore(t, cfg.filePathClientAuth("backup-test"),
+	cloudtestutils.CheckExportStore(t, cfg.filePathClientAuth(testPath),
 		false, username.RootUserName(),
 		nil, /* db */
 		testSettings,
 	)
-	cloudtestutils.CheckListFiles(t, cfg.filePathClientAuth("listing-test"),
+	cloudtestutils.CheckListFiles(t, cfg.filePathClientAuth(testListPath),
 		username.RootUserName(),
 		nil, /* db */
 		testSettings,
 	)
 
 	// Implicit auth
-	cloudtestutils.CheckExportStore(t, cfg.filePathImplicitAuth("backup-test"),
+	cloudtestutils.CheckExportStore(t, cfg.filePathImplicitAuth(testPath),
 		false, username.RootUserName(),
 		nil, /* db */
 		testSettings,
 	)
-	cloudtestutils.CheckListFiles(t, cfg.filePathImplicitAuth("listing-test"),
+	cloudtestutils.CheckListFiles(t, cfg.filePathImplicitAuth(testListPath),
 		username.RootUserName(),
 		nil, /* db */
 		testSettings,


### PR DESCRIPTION
Add a random int64 to all storage prefixes used in TestAzure so the tests can be ran in parallel.

Fixes: #108877

Release note: None