### PR TITLE
batcheval: make Get and {,Rev}Scan cmds read write

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_scan.go
+++ b/pkg/kv/kvserver/batcheval/cmd_scan.go
@@ -21,7 +21,7 @@ import (
 )
 
 func init() {
-	RegisterReadOnlyCommand(kvpb.Scan, DefaultDeclareIsolatedKeys, Scan)
+	RegisterReadWriteCommand(kvpb.Scan, DefaultDeclareIsolatedKeys, Scan)
 }
 
 // Scan scans the key range specified by start key through end key
@@ -29,7 +29,7 @@ func init() {
 // stores the number of scan results remaining for this batch
 // (MaxInt64 for no limit).
 func Scan(
-	ctx context.Context, reader storage.Reader, cArgs CommandArgs, resp kvpb.Response,
+	ctx context.Context, readWriter storage.ReadWriter, cArgs CommandArgs, resp kvpb.Response,
 ) (result.Result, error) {
 	args := cArgs.Args.(*kvpb.ScanRequest)
 	h := cArgs.Header
@@ -60,14 +60,14 @@ func Scan(
 	switch args.ScanFormat {
 	case kvpb.BATCH_RESPONSE:
 		scanRes, err = storage.MVCCScanToBytes(
-			ctx, reader, args.Key, args.EndKey, h.Timestamp, opts)
+			ctx, readWriter, args.Key, args.EndKey, h.Timestamp, opts)
 		if err != nil {
 			return result.Result{}, err
 		}
 		reply.BatchResponses = scanRes.KVData
 	case kvpb.COL_BATCH_RESPONSE:
 		scanRes, err = storage.MVCCScanToCols(
-			ctx, reader, cArgs.Header.IndexFetchSpec, args.Key, args.EndKey,
+			ctx, readWriter, cArgs.Header.IndexFetchSpec, args.Key, args.EndKey,
 			h.Timestamp, opts, cArgs.EvalCtx.ClusterSettings(),
 		)
 		if err != nil {
@@ -80,7 +80,7 @@ func Scan(
 		}
 	case kvpb.KEY_VALUES:
 		scanRes, err = storage.MVCCScan(
-			ctx, reader, args.Key, args.EndKey, h.Timestamp, opts)
+			ctx, readWriter, args.Key, args.EndKey, h.Timestamp, opts)
 		if err != nil {
 			return result.Result{}, err
 		}
@@ -103,7 +103,7 @@ func Scan(
 		// one in CollectIntentRows either so that we're guaranteed to use the
 		// same cached iterator and observe a consistent snapshot of the engine.
 		const usePrefixIter = false
-		reply.IntentRows, err = CollectIntentRows(ctx, reader, usePrefixIter, scanRes.Intents)
+		reply.IntentRows, err = CollectIntentRows(ctx, readWriter, usePrefixIter, scanRes.Intents)
 		if err != nil {
 			return result.Result{}, err
 		}


### PR DESCRIPTION
Previously, Get, Scan, and RevScan commands were registered as read only commands. This meant they only had access to a storage.Reader. With the imminent introduction of replicated locks, Get/Scan/RevScan requests that acquire replicated locks will need access to a storage.ReadWriter. In preperation, we now register them as read write commands.

Note that non-replicated lock acquiring Get/Scan/RevScan commands will continue to go through the read-only execution path. This patch doesn't affect that behavior, as that distinction is made based on the request's flags.

We're losing some of the type safety on the read-only path for these requests that was added in 5e6e11c. We could bring it back in the future, but it'll likely not be in the current structure of how commands are registered. The current mechanism wasn't designed to have both a read-only and read-write variant for a single request type. For now, this patch shall do.

Epic: none

Release note: None