### PR TITLE
colexec: support CAST and COALESCE when used as selection op

### DIFF
--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -2088,7 +2088,7 @@ func planSelectionOperators(
 			ctx, evalCtx, t.TypedRight(), typs, leftOp, acc, factory, releasables,
 		)
 		return rightOp, resultIdx, typs, err
-	case *tree.CaseExpr:
+	case *tree.CaseExpr, *tree.CastExpr, *tree.CoalesceExpr:
 		op, resultIdx, typs, err = planProjectionOperators(
 			ctx, evalCtx, expr, columnTypes, input, acc, factory, releasables,
 		)

--- a/pkg/sql/opt/exec/execbuilder/testdata/vectorize_local
+++ b/pkg/sql/opt/exec/execbuilder/testdata/vectorize_local
@@ -253,7 +253,7 @@ querying next range at /Table/109/1/0/0
 === SPAN START: kv.DistSender: sending partial batch ===
 querying next range at /Table/109/1/10/0
 
-# Regression test for #46123 (rowexec.TableReader not implementing
+# Used to be a regression test for #46123 (rowexec.TableReader not implementing
 # execopnode.OpNode interface).
 statement ok
 CREATE TABLE t46123(c0 INT)
@@ -265,8 +265,9 @@ EXPLAIN (VEC) SELECT stddev(0) FROM t46123 WHERE ('' COLLATE en)::BOOL
 └ Node 1
   └ *colexec.orderedAggregator
     └ *colexecbase.constInt64Op
-      └ *rowexec.filtererProcessor
-        └ *colfetcher.ColBatchScan
+      └ *colexecbase.castDatumBoolOp
+        └ *colexecbase.constDatumOp
+          └ *colfetcher.ColBatchScan
 
 # Regression test for #46122.
 statement ok

--- a/pkg/sql/opt/exec/execbuilder/testdata/vectorize_overloads
+++ b/pkg/sql/opt/exec/execbuilder/testdata/vectorize_overloads
@@ -440,3 +440,31 @@ EXPLAIN (VEC) SELECT _interval + _timestamp FROM many_types WHERE _timestamp - _
     └ *colexec.isNullSelOp
       └ *colexecproj.projMinusTimestampIntervalOp
         └ *colfetcher.ColBatchScan
+
+query T
+EXPLAIN (VEC) SELECT 1 FROM many_types WHERE _string::BOOL
+----
+│
+└ Node 1
+  └ *colexecbase.constInt64Op
+    └ *colexecbase.castStringBoolOp
+      └ *colfetcher.ColBatchScan
+
+query T
+EXPLAIN (VEC) SELECT 1 FROM many_types WHERE COALESCE(_string::BOOL, _bool)
+----
+│
+└ Node 1
+  └ *colexecbase.constInt64Op
+    └ *colexec.caseOp
+      ├ *colexec.bufferOp
+      │ └ *colfetcher.ColBatchScan
+      ├ *colexecbase.castStringBoolOp
+      │ └ *colexec.isNullProjOp
+      │   └ *colexecbase.castStringBoolOp
+      │     └ *colexec.bufferOp
+      ├ *colexec.isNullProjOp
+      │ └ *colexec.bufferOp
+      └ *colexecbase.castOpNullAny
+        └ *colexecbase.constNullOp
+          └ *colexec.bufferOp


### PR DESCRIPTION
Previously we would fall back to the row-by-row engine for CAST and COALESCE expressions when used in filters (i.e. as "selection" operators) even though we have support for projecting those expressions. Fix is simple - just plan it as the projection operator and then add `selBoolOp` on top it. Found this when debugging another issue.

Epic: None

Release note: None