### PR TITLE
internal/sqlsmith: pre-split and scatter ranges

### DIFF
--- a/pkg/internal/sqlsmith/BUILD.bazel
+++ b/pkg/internal/sqlsmith/BUILD.bazel
@@ -48,6 +48,7 @@ go_test(
     size = "medium",
     srcs = [
         "main_test.go",
+        "setup_test.go",
         "sqlsmith_test.go",
     ],
     args = ["-test.timeout=295s"],
@@ -59,6 +60,7 @@ go_test(
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",
         "//pkg/server",
+        "//pkg/sql",
         "//pkg/sql/parser",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/sqlutils",

--- a/pkg/internal/sqlsmith/setup_test.go
+++ b/pkg/internal/sqlsmith/setup_test.go
@@ -1,0 +1,139 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sqlsmith_test
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/ccl"
+	"github.com/cockroachdb/cockroach/pkg/internal/sqlsmith"
+	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+)
+
+var (
+	flagExec    = flag.Bool("ex", false, "execute (instead of just parse) generated statements")
+	flagNum     = flag.Int("num", 100, "number of statements to generate")
+	flagSetup   = flag.String("setup", "", "setup for TestGenerateParse, empty for random")
+	flagSetting = flag.String("setting", "", "setting for TestGenerateParse, empty for random")
+)
+
+// TestSetups verifies that all setups generate executable SQL.
+func TestSetups(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	defer ccl.TestingEnableEnterprise()()
+
+	for name, setup := range sqlsmith.Setups {
+		t.Run(name, func(t *testing.T) {
+			ctx := context.Background()
+			srv, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{})
+			defer srv.Stopper().Stop(ctx)
+			sql.SecondaryTenantSplitAtEnabled.Override(ctx, &srv.ApplicationLayer().ClusterSettings().SV, true)
+			sql.SecondaryTenantScatterEnabled.Override(ctx, &srv.ApplicationLayer().ClusterSettings().SV, true)
+
+			rnd, _ := randutil.NewTestRand()
+
+			stmts := setup(rnd)
+			for _, stmt := range stmts {
+				if _, err := sqlDB.Exec(stmt); err != nil {
+					t.Log(stmt)
+					t.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// TestGenerateParse verifies that statements produced by Generate can be
+// parsed. This is useful because since we make AST nodes directly we can
+// sometimes put them into bad states that the parser would never do.
+func TestGenerateParse(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	defer ccl.TestingEnableEnterprise()()
+
+	ctx := context.Background()
+	srv, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer srv.Stopper().Stop(ctx)
+	sql.SecondaryTenantSplitAtEnabled.Override(ctx, &srv.ApplicationLayer().ClusterSettings().SV, true)
+	sql.SecondaryTenantScatterEnabled.Override(ctx, &srv.ApplicationLayer().ClusterSettings().SV, true)
+
+	rnd, seed := randutil.NewTestRand()
+	t.Log("seed:", seed)
+
+	db := sqlutils.MakeSQLRunner(sqlDB)
+
+	setupName := *flagSetup
+	if setupName == "" {
+		setupName = sqlsmith.RandSetup(rnd)
+	}
+	setup, ok := sqlsmith.Setups[setupName]
+	if !ok {
+		t.Fatalf("unknown setup %s", setupName)
+	}
+	t.Log("setup:", setupName)
+	settingName := *flagSetting
+	if settingName == "" {
+		settingName = sqlsmith.RandSetting(rnd)
+	}
+	setting, ok := sqlsmith.Settings[settingName]
+	if !ok {
+		t.Fatalf("unknown setting %s", settingName)
+	}
+	settings := setting(rnd)
+	t.Log("setting:", settingName, settings.Options)
+	setupSQL := setup(rnd)
+	t.Log(strings.Join(setupSQL, "\n"))
+	for _, stmt := range setupSQL {
+		db.Exec(t, stmt)
+	}
+
+	smither, err := sqlsmith.NewSmither(sqlDB, rnd, settings.Options...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer smither.Close()
+
+	seen := map[string]bool{}
+	for i := 0; i < *flagNum; i++ {
+		stmt := smither.Generate()
+		if err != nil {
+			t.Fatalf("%v: %v", stmt, err)
+		}
+		parsed, err := parser.ParseOne(stmt)
+		if err != nil {
+			t.Fatalf("%v: %v", stmt, err)
+		}
+		stmt = sqlsmith.TestingPrettyCfg.Pretty(parsed.AST)
+		fmt.Print("STMT: ", i, "\n", stmt, ";\n\n")
+		if *flagExec {
+			db.Exec(t, `SET statement_timeout = '9s'`)
+			if _, err := sqlDB.Exec(stmt); err != nil {
+				es := err.Error()
+				if !seen[es] {
+					seen[es] = true
+					fmt.Printf("ERR (%d): %v\n", i, err)
+				}
+			}
+		}
+	}
+}

--- a/pkg/internal/sqlsmith/sqlsmith.go
+++ b/pkg/internal/sqlsmith/sqlsmith.go
@@ -174,6 +174,9 @@ var prettyCfg = func() tree.PrettyCfg {
 	return cfg
 }()
 
+// TestingPrettyCfg is only exposed to be used in tests.
+var TestingPrettyCfg = prettyCfg
+
 // Generate returns a random SQL string.
 func (s *Smither) Generate() string {
 	i := 0

--- a/pkg/sql/explain_test.go
+++ b/pkg/sql/explain_test.go
@@ -521,9 +521,10 @@ func TestExplainRedact(t *testing.T) {
 	t.Log("seed:", seed)
 
 	params, _ := createTestServerParams()
-	s, sqlDB, _ := serverutils.StartServer(t, params)
-	defer s.Stopper().Stop(ctx)
-	defer sqlDB.Close()
+	srv, sqlDB, _ := serverutils.StartServer(t, params)
+	defer srv.Stopper().Stop(ctx)
+	sql.SecondaryTenantSplitAtEnabled.Override(ctx, &srv.ApplicationLayer().ClusterSettings().SV, true)
+	sql.SecondaryTenantScatterEnabled.Override(ctx, &srv.ApplicationLayer().ClusterSettings().SV, true)
 
 	query := func(sql string) (*gosql.Rows, error) {
 		return sqlDB.QueryContext(ctx, sql)

--- a/pkg/sql/tests/rsg_test.go
+++ b/pkg/sql/tests/rsg_test.go
@@ -798,8 +798,10 @@ func testRandomSyntax(
 	params.Knobs.PGWireTestingKnobs = &sql.PGWireTestingKnobs{
 		CatchPanics: true,
 	}
-	s, rawDB, _ := serverutils.StartServer(t, params)
-	defer s.Stopper().Stop(ctx)
+	srv, rawDB, _ := serverutils.StartServer(t, params)
+	defer srv.Stopper().Stop(ctx)
+	sql.SecondaryTenantSplitAtEnabled.Override(ctx, &srv.ApplicationLayer().ClusterSettings().SV, true)
+	sql.SecondaryTenantScatterEnabled.Override(ctx, &srv.ApplicationLayer().ClusterSettings().SV, true)
 	db := &verifyFormatDB{db: rawDB}
 	err := db.exec(t, ctx, "SET CLUSTER SETTING schemachanger.job.max_retry_backoff='1s'")
 	require.NoError(t, err)


### PR DESCRIPTION
This commit modifies `seed` and `seed-multi-region` sqlsmith setups to manually split the seed table and then scatter the ranges. This should make the setups more interesting.

This required allowing secondary tenants to run these commands in some tests that use these setups.

Epic: None

Release note: None