### PR TITLE
streamingccl: add pprof label to event stream

### DIFF
--- a/pkg/ccl/streamingccl/streamproducer/BUILD.bazel
+++ b/pkg/ccl/streamingccl/streamproducer/BUILD.bazel
@@ -56,6 +56,7 @@ go_library(
         "//pkg/util/tracing",
         "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_logtags//:logtags",
     ],
 )
 


### PR DESCRIPTION
The producer side "job"doesn't do very much at all. Most of the work happens on inbound connections from the destination cluster.

The new "Advanced Debugging" page gives us the ability to look at Cluster Wide CPU profiles filtered by JobID easily. It would be nice if the actual producer-side work showed up in this profile, even though it isn't _technically_ part of the job.

This makes that happen by adding the relevant pprof labels to the rangefeed client library goroutines and the event stream goroutines. This won't capture CPU usage used in the SQL execution layer, but its a start.

Epic: none

Release note: None