### PR TITLE
release-23.1: ui: fix app = empty string filter on stmts page

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/testUtils.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/api/testUtils.tsx
@@ -1,0 +1,221 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { cockroach, google } from "@cockroachlabs/crdb-protobuf-client";
+import Long from "long";
+
+export type Stmt =
+  cockroach.server.serverpb.StatementsResponse.ICollectedStatementStatistics;
+type Txn =
+  cockroach.server.serverpb.StatementsResponse.IExtendedCollectedTransactionStatistics;
+type ILatencyInfo = cockroach.sql.ILatencyInfo;
+
+const latencyInfo: Required<ILatencyInfo> = {
+  min: 0.00008,
+  max: 0.00028,
+  p50: 0.00015,
+  p90: 0.00016,
+  p99: 0.00018,
+};
+
+const baseStmt: Partial<Stmt> = {
+  id: Long.fromInt(11871906682067483964),
+  key: {
+    key_data: {
+      query: "SELECT node_id FROM system.statement_statistics",
+      app: "$ cockroach sql",
+      distSQL: true,
+      failed: false,
+      implicit_txn: true,
+      vec: true,
+      full_scan: true,
+      database: "defaultdb",
+      query_summary: "SELECT node_id FROM system.statement_statistics",
+      transaction_fingerprint_id: Long.fromInt(1),
+    },
+    node_id: 0,
+  },
+  stats: {
+    count: Long.fromInt(1),
+    first_attempt_count: Long.fromInt(1),
+    max_retries: Long.fromInt(0),
+    num_rows: {
+      mean: 1576,
+      squared_diffs: 0,
+    },
+    parse_lat: {
+      mean: 0.000044584,
+      squared_diffs: 0,
+    },
+    plan_lat: {
+      mean: 0.037206708,
+      squared_diffs: 0,
+    },
+    run_lat: {
+      mean: 0.003240459,
+      squared_diffs: 0,
+    },
+    service_lat: {
+      mean: 0.040506917,
+      squared_diffs: 0,
+    },
+    overhead_lat: {
+      mean: 0.000015166000000003954,
+      squared_diffs: 0,
+    },
+    sensitive_info: {
+      last_err: "",
+      most_recent_plan_description: {
+        name: "",
+        attrs: [],
+        children: [],
+      },
+      most_recent_plan_timestamp: new google.protobuf.Timestamp(),
+    },
+    bytes_read: {
+      mean: 162109,
+      squared_diffs: 0,
+    },
+    rows_read: {
+      mean: 1576,
+      squared_diffs: 0,
+    },
+    rows_written: {
+      mean: 0,
+      squared_diffs: 0,
+    },
+    latency_info: latencyInfo,
+    exec_stats: {
+      count: Long.fromInt(1),
+      network_bytes: {
+        mean: 0,
+        squared_diffs: 0,
+      },
+      max_mem_usage: {
+        mean: 184320,
+        squared_diffs: 0,
+      },
+      contention_time: {
+        mean: 0,
+        squared_diffs: 0,
+      },
+      network_messages: {
+        mean: 0,
+        squared_diffs: 0,
+      },
+      max_disk_usage: {
+        mean: 0,
+        squared_diffs: 0,
+      },
+    },
+    sql_type: "TypeDML",
+    last_exec_timestamp: new google.protobuf.Timestamp(),
+    plan_gists: ["AgFUBAAgAAAABgI="],
+    indexes: ["123@456"],
+    index_recommendations: [],
+  },
+};
+
+const baseTxn: Partial<Txn> = {
+  stats_data: {
+    statement_fingerprint_ids: [Long.fromInt(18262870370352730905)],
+    app: "$ cockroach sql",
+    stats: {
+      count: Long.fromInt(8),
+      max_retries: Long.fromInt(0),
+      num_rows: {
+        mean: 0,
+        squared_diffs: 0,
+      },
+      service_lat: {
+        mean: 0.00013457312500000002,
+        squared_diffs: 5.992246806875002e-9,
+      },
+      retry_lat: {
+        mean: 0,
+        squared_diffs: 0,
+      },
+      commit_lat: {
+        mean: 0.0000031143749999999997,
+        squared_diffs: 1.1728737874999997e-11,
+      },
+      bytes_read: {
+        mean: 0,
+        squared_diffs: 0,
+      },
+      rows_read: {
+        mean: 0,
+        squared_diffs: 0,
+      },
+      exec_stats: {
+        count: Long.fromInt(8),
+        network_bytes: {
+          mean: 0,
+          squared_diffs: 0,
+        },
+        max_mem_usage: {
+          mean: 10240,
+          squared_diffs: 0,
+        },
+        contention_time: {
+          mean: 0,
+          squared_diffs: 0,
+        },
+        network_messages: {
+          mean: 0,
+          squared_diffs: 0,
+        },
+        max_disk_usage: {
+          mean: 0,
+          squared_diffs: 0,
+        },
+      },
+      rows_written: {
+        mean: 0,
+        squared_diffs: 0,
+      },
+    },
+    aggregated_ts: new google.protobuf.Timestamp(),
+    transaction_fingerprint_id: Long.fromInt(5913510653911377094),
+  },
+  node_id: 0,
+};
+
+const assignObjectPropsIfExists = <T extends { [key: string]: unknown }>(
+  baseObj: T,
+  overrides: Partial<T>,
+): T => {
+  const copiedObj: T = { ...baseObj };
+  for (const prop in baseObj) {
+    if (overrides[prop] === undefined) {
+      continue;
+    }
+
+    const val = copiedObj[prop];
+    if (typeof val === "object") {
+      copiedObj[prop] = assignObjectPropsIfExists(
+        val as Record<string, unknown>,
+        overrides[prop] as Record<string, unknown>,
+      ) as typeof val;
+    } else {
+      copiedObj[prop] = overrides[prop];
+    }
+  }
+
+  return copiedObj;
+};
+
+export const mockStmtStats = (partialStmt: Partial<Stmt> = {}): Stmt => {
+  return assignObjectPropsIfExists(baseStmt, partialStmt);
+};
+
+export const mockTxnStats = (partialTxn: Partial<Txn> = {}): Txn => {
+  return assignObjectPropsIfExists(baseTxn, partialTxn);
+};

--- a/pkg/ui/workspaces/cluster-ui/src/queryFilter/filter.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/queryFilter/filter.tsx
@@ -283,7 +283,7 @@ export const calculateActiveFilters = (filters: Filters): number => {
 };
 
 export const getTimeValueInSeconds = (filters: Filters): number | "empty" => {
-  if (filters.timeNumber === "0") return "empty";
+  if (filters?.timeNumber == null || filters.timeNumber === "0") return "empty";
   switch (filters.timeUnit) {
     case "seconds":
       return Number(filters.timeNumber);

--- a/pkg/ui/workspaces/cluster-ui/src/sqlActivity/util.spec.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sqlActivity/util.spec.tsx
@@ -1,0 +1,385 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import {
+  convertRawStmtsToAggregateStatistics,
+  filteredStatementsData,
+} from "src/sqlActivity/util";
+import { mockStmtStats, Stmt } from "src/api/testUtils";
+import { Filters } from "src/queryFilter/filter";
+import Long from "long";
+import { unset } from "../util";
+
+describe("filteredStatementsData", () => {
+  function filterAndCheckStmts(
+    stmtsRaw: Stmt[],
+    filters: Filters,
+    searchString: string | null,
+    expectedStmtIDs: number[],
+  ) {
+    const statements = convertRawStmtsToAggregateStatistics(stmtsRaw);
+
+    const filteredStmts = filteredStatementsData(
+      filters,
+      searchString,
+      statements,
+      null,
+      false,
+    );
+
+    expect(filteredStmts.length).toEqual(expectedStmtIDs.length);
+
+    expect(
+      filteredStmts.map(stmt => Number(stmt.aggregatedFingerprintID)).sort(),
+    ).toEqual(expectedStmtIDs);
+  }
+
+  it("should filter out statements not matching search string", () => {
+    const stmtsRaw = [
+      {
+        id: 1,
+        query: "rhinos",
+      },
+      {
+        id: 2,
+        query: "giraffes", // Should match.
+      },
+      {
+        id: 3,
+        query: "giraffes are cool", // Should match.
+      },
+      {
+        id: 4,
+        query: "elephants cannot jump",
+      },
+    ].map(stmt =>
+      mockStmtStats({
+        id: Long.fromInt(stmt.id),
+        key: { key_data: { query: stmt.query, query_summary: stmt.query } },
+      }),
+    );
+
+    const expectedIDs = [2, 3];
+    filterAndCheckStmts(stmtsRaw, {}, "giraffe", expectedIDs);
+  });
+
+  it.each([
+    {
+      stmts: [
+        {
+          id: 1,
+          app: "hello world",
+        },
+        {
+          id: 2,
+          app: "giraffe", // Should match.
+        },
+        {
+          id: 3,
+          app: "giraffes are cool", // Should NOT match. App names must match exactly.
+        },
+        {
+          id: 4,
+          app: "elephants cannot jump",
+        },
+        {
+          id: 5,
+          app: "gira",
+        },
+      ],
+      appName: "giraffe",
+      expectedIDs: [2],
+    },
+    {
+      stmts: [
+        {
+          id: 1,
+          app: "",
+        },
+        {
+          id: 2,
+          app: "",
+        },
+        {
+          id: 3,
+          app: "hello",
+        },
+        {
+          id: 4,
+          app: "",
+        },
+        {
+          id: 5,
+          app: "",
+        },
+      ],
+      appName: unset,
+      expectedIDs: [1, 2, 4, 5],
+    },
+    {
+      stmts: [
+        {
+          id: 1,
+          app: "hello world",
+        },
+        {
+          id: 2,
+          app: "giraffes", // Should NOT match.
+        },
+        {
+          id: 3,
+          app: "giraffe", // Should match.
+        },
+        {
+          id: 4,
+          app: "elephant", // Should match.
+        },
+        {
+          id: 5,
+          app: "gira", // Should NOT match. Exact matches only.
+        },
+        {
+          id: 6,
+          app: "giraffe", // Should match.
+        },
+        {
+          id: 7,
+          app: "elephants cannot jump", // Should not match.
+        },
+      ],
+      appName: "giraffe, elephant",
+      expectedIDs: [3, 4, 6],
+    },
+    {
+      stmts: [
+        {
+          id: 1,
+          app: "hello world",
+        },
+        {
+          id: 2,
+          app: "giraffes", // Should NOT match.
+        },
+        {
+          id: 3,
+          app: "giraffe", // Should match.
+        },
+        {
+          id: 4,
+          app: "elephant", // Should match.
+        },
+        {
+          id: 5,
+          app: "gira", // Should NOT match. Exact matches only.
+        },
+        {
+          id: 6,
+          app: "giraffe", // Should match.
+        },
+        {
+          id: 7,
+          app: "elephants cannot jump", // Should not match.
+        },
+      ],
+      appName: "aaaaaaaaaaaaaaaaaaaaaaaa",
+      expectedIDs: [],
+    },
+  ])("should filter out statements not matching filter apps", tc => {
+    const stmtsRaw = tc.stmts.map(stmt =>
+      mockStmtStats({
+        id: Long.fromInt(stmt.id),
+        key: { key_data: { app: stmt.app } },
+      }),
+    );
+
+    const filters: Filters = {
+      app: tc.appName,
+    };
+    filterAndCheckStmts(stmtsRaw, filters, null, tc.expectedIDs);
+  });
+
+  it("should filter out statements not matching sql type", () => {
+    const filters: Filters = {
+      sqlType: "DDL, DML",
+    };
+
+    const stmtsRaw = [
+      {
+        id: 1,
+        type: "TypeDML",
+      },
+      {
+        id: 2,
+        type: "TypeDDL",
+      },
+      {
+        id: 3,
+        type: "TypeDCL",
+      },
+      {
+        id: 4,
+        type: "TypeDCL",
+      },
+      {
+        id: 5,
+        type: "TypeTCL",
+      },
+      {
+        id: 6,
+        type: "TypeDDL",
+      },
+    ].map(stmt =>
+      mockStmtStats({
+        id: Long.fromInt(stmt.id),
+        stats: { sql_type: stmt.type },
+      }),
+    );
+
+    const expectedIDs = [1, 2, 6];
+    filterAndCheckStmts(stmtsRaw, filters, null, expectedIDs);
+  });
+
+  it("should filter out statements not matching database (exact match)", () => {
+    const filters: Filters = {
+      database: "cockroach, coolDB",
+    };
+
+    const stmtsRaw = [
+      {
+        id: 1,
+        db: "roachie",
+      },
+      {
+        id: 2,
+        db: "uncoolDB",
+      },
+      {
+        id: 3,
+        db: "coolDB",
+      },
+      {
+        id: 4,
+        db: "cockroach",
+      },
+      {
+        id: 5,
+        db: "cockroach",
+      },
+      {
+        id: 6,
+        db: "myDB",
+      },
+    ].map(stmt =>
+      mockStmtStats({
+        id: Long.fromInt(stmt.id),
+        key: { key_data: { database: stmt.db } },
+      }),
+    );
+
+    const expectedIDs = [3, 4, 5];
+    filterAndCheckStmts(stmtsRaw, filters, null, expectedIDs);
+  });
+
+  it("should filter out statements with svc_lat less than filter time value", () => {
+    // Create stmts with ids matching service_lat in seconds.
+    // We will filter out the first half of these stmts.
+    const stmtsRaw = [1, 2, 3, 4, 5, 6].map(stmtID =>
+      mockStmtStats({
+        id: Long.fromInt(stmtID),
+        stats: { service_lat: { mean: stmtID, squared_diffs: 0 } },
+      }),
+    );
+
+    const expectedIDs = [4, 5, 6];
+
+    [
+      {
+        timeNumber: "4",
+        timeUnit: "seconds",
+      },
+      {
+        timeNumber: "0.06",
+        timeUnit: "minutes",
+      },
+      {
+        timeNumber: "4000",
+        timeUnit: "milliseconds",
+      },
+    ].forEach(filter => {
+      filterAndCheckStmts(stmtsRaw, filter, null, expectedIDs);
+    });
+  });
+
+  it("should filter out statements not matching ALL filters", () => {
+    const filters: Filters = {
+      database: "coolestDB",
+      app: "coolestApp",
+      timeNumber: "1",
+      timeUnit: "seconds",
+    };
+
+    const searchTerm = "coolestQuery";
+
+    const stmtsRaw = [
+      {
+        id: 1,
+        db: "lameDB",
+        app: "coolestApp",
+        svcLatSecs: 1,
+        query: "coolestQuery",
+      },
+      {
+        id: 2,
+        db: "coolestDb",
+        app: "lameApp",
+        svcLatSecs: 1,
+        query: "coolestQuery",
+      },
+      {
+        id: 3,
+        db: "coolestDb",
+        app: "coolestApp",
+        svcLatSecs: 0.5,
+        query: "coolestQuery",
+      },
+      {
+        id: 4,
+        db: "coolestDb",
+        app: "coolestApp",
+        svcLatSecs: 1,
+        query: "select lame, query",
+      },
+      {
+        id: 5,
+        db: "coolestDB",
+        app: "coolestApp",
+        svcLatSecs: 1,
+        query: `select ${searchTerm}`,
+      },
+    ].map(stmt =>
+      mockStmtStats({
+        id: Long.fromInt(stmt.id),
+        key: {
+          key_data: {
+            app: stmt.app,
+            database: stmt.db,
+            query: stmt.query,
+            query_summary: stmt.query,
+          },
+        },
+        stats: { service_lat: { mean: stmt.svcLatSecs, squared_diffs: 0 } },
+      }),
+    );
+
+    const expectedIDs = [5];
+
+    filterAndCheckStmts(stmtsRaw, filters, searchTerm, expectedIDs);
+  });
+});


### PR DESCRIPTION
Backport 1/1 commits from #107750
cc @cockroachdb/release 

------------------------
The filter on app name = empty string was not working on the stmts page. This was due to the fact that we use (unset) as the option in the filter to represent selecting the empty string app name. However when filtering statements, the empty string app name on the stmt was not changed accordingly. this commit fixes this and also adds testing for the unset case.

Epic: none
Fixes: #107748

Release note (bug fix): Filter on stmts page works for app name = empty string (represented as 'unset').

Release justification: bug fix