### PR TITLE
release-22.2: sql: deflake TestDropTableWhileUpgradingFormat

### DIFF
--- a/pkg/sql/drop_test.go
+++ b/pkg/sql/drop_test.go
@@ -860,7 +860,12 @@ func TestDropTableWhileUpgradingFormat(t *testing.T) {
 	}
 
 	tableSpan := tableDesc.TableSpan(keys.SystemSQLCodec)
-	tests.CheckKeyCount(t, kvDB, tableSpan, numRows)
+	testutils.SucceedsSoon(t, func() error {
+		if err := tests.CheckKeyCountE(t, kvDB, tableSpan, numRows); err != nil {
+			return errors.Wrap(err, "failed to verify expected amount of keys")
+		}
+		return nil
+	})
 
 	sqlDB.Exec(t, `DROP TABLE test.t`)
 

--- a/pkg/sql/tests/data.go
+++ b/pkg/sql/tests/data.go
@@ -31,7 +31,7 @@ func CheckKeyCount(t *testing.T, kvDB *kv.DB, span roachpb.Span, numKeys int) {
 	}
 }
 
-// CheckKeyCountE returns an error if the the number of keys in the
+// CheckKeyCountE returns an error if the number of keys in the
 // provided span does not match numKeys.
 func CheckKeyCountE(t *testing.T, kvDB *kv.DB, span roachpb.Span, numKeys int) error {
 	t.Helper()


### PR DESCRIPTION
Backport 1/1 commits from #108880.

/cc @cockroachdb/release

---

Previously, the `CheckKeyCountIncludingTombstoned` call in TestDropTableWhileUpgradingFormat flaked with a key count mismatch error (expected: 100, actual: 0). This was odd because this key counting failure was directly after rows were committed. To address this, this patch adds a retry for the `CheckKeyCountIncludingTombstoned` logic in case this is due to a race condition.

Epic: none
Fixes: https://github.com/cockroachdb/cockroach/issues/108340

Release note: none

Release justification: test only change