### PR TITLE
kv: don't log trace of cancelled requests if not Export

### DIFF
--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -1238,7 +1238,9 @@ func (n *Node) batchInternal(
 	// replica to notice the cancellation and return a response. For this reason,
 	// we log the server-side trace of the cancelled request to help debug what
 	// the request was doing at the time it noticed the cancellation.
-	if pErr != nil && ctx.Err() != nil {
+	// NOTE: we only log on Export requests to avoid this causing log spam in this
+	// backported version of the code.
+	if pErr != nil && ctx.Err() != nil && args.IsSingleExportRequest() {
 		if sp := tracing.SpanFromContext(ctx); sp != nil && !sp.IsNoop() {
 			recording := sp.GetConfiguredRecording()
 			if recording.Len() != 0 {


### PR DESCRIPTION
This commit limits the logging added in #106611 to only apply to Export requests. The logging has been observed to be noisy and we'd like to avoid any perceived regression in a v23.1 patch release.

Epic: None
Release note: None