### PR TITLE
roachprod: better determination if scp -R flag can be used

### DIFF
--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -22,7 +22,6 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"sync"
 	"syscall"
@@ -1750,9 +1749,12 @@ func (c *SyncedCluster) Put(
 	// not tested.
 	const treeDistFanout = 10
 
+	// If scp does not support the -R flag, treedist mode is slower as it ends up
+	// transferring everything through this machine anyway.
+	useTreeDist := c.UseTreeDist && sshVersion3()
 	var detail string
 	if !c.IsLocal() {
-		if c.UseTreeDist {
+		if useTreeDist {
 			detail = " (dist)"
 		} else {
 			detail = " (scp)"
@@ -1783,7 +1785,7 @@ func (c *SyncedCluster) Put(
 		}
 	}
 
-	if c.UseTreeDist {
+	if useTreeDist {
 		// In treedist mode, only add the local source initially.
 		pushSource(-1)
 	} else {
@@ -2452,6 +2454,24 @@ func (c *SyncedCluster) SSH(ctx context.Context, l *logger.Logger, sshArgs, args
 	return syscall.Exec(sshPath, allArgs, os.Environ())
 }
 
+var sshVersion3Internal struct {
+	value bool
+	once  sync.Once
+}
+
+// sshVersion3 returns true if ssh uses an SSL library at major version 3.
+func sshVersion3() bool {
+	sshVersion3Internal.once.Do(func() {
+		cmd := exec.Command("ssh", "-V")
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			panic(fmt.Sprintf("error running ssh -V: %v\nOutput:\n%s", err, string(out)))
+		}
+		sshVersion3Internal.value = strings.Contains(string(out), "SSL 3.")
+	})
+	return sshVersion3Internal.value
+}
+
 // scp return type conforms to what runWithMaybeRetry expects. A nil error
 // is always returned here since the only error that can happen is an scp error
 // which we do want to be able to retry.
@@ -2462,12 +2482,9 @@ func scp(l *logger.Logger, src, dest string) (*RunResultDetails, error) {
 		"-o", "StrictHostKeyChecking=no",
 		"-o", "ConnectTimeout=10",
 	}
-	if runtime.GOOS == "darwin" {
-		// SSH to src node and excute SCP there using agent-forwarding,
-		// as these are not the defaults on MacOS.
-		// TODO(sarkesian): Rather than checking Darwin, it would be preferable
-		// to check the output of `ssh-V` and check the version to see what flags
-		// are supported.
+	if sshVersion3() {
+		// Have scp do a direct transfer between two remote hosts (SSH to src node
+		// and execute SCP there using agent-forwarding).
 		args = append(args, "-R", "-A")
 	}
 	args = append(args, sshAuthArgs()...)


### PR DESCRIPTION
When uploading a file to a cluster, we use the "tree dist" algorithm by default. This uploads the file to a single node, then we copy the file from that node to the other nodes (up to 10).

This only makes sense if the remote-to-remote transfers can happen directly, which only happens if we pass the `-R -A` flags to `scp`. Unfortunately older versions don't support these flags. Currently the flags are only passed if the OS is `darwin`.

This commits improves the determination - we run `ssh -V` (once) and check if the `SSL` major version is three. For reference, some examples of what `ssh -V` returns:
 - recent MacOSX: `OpenSSH_9.0p1, LibreSSL 3.3.6`
 - Ubuntu 22.04: `OpenSSH_8.9p1 Ubuntu-3ubuntu0.3, OpenSSL 3.0.2 15 Mar 2022`

In addition, if the version is not 3, we disable the use of "tree dist".

Epic: none
Release note: None