### PR TITLE
roachprod: don't show progress when downloading grafana

### DIFF
--- a/pkg/roachprod/prometheus/prometheus.go
+++ b/pkg/roachprod/prometheus/prometheus.go
@@ -341,12 +341,13 @@ sudo systemd-run --unit prometheus --same-dir \
 			l.Stderr, cfg.PrometheusNode, "install grafana",
 			fmt.Sprintf(`
 sudo apt-get install -qqy apt-transport-https &&
-sudo apt-get install -qqy software-properties-common wget &&
+sudo apt-get install -qqy software-properties-common &&
 sudo apt-get install -y adduser libfontconfig1 &&
-wget https://dl.grafana.com/enterprise/release/grafana-enterprise_9.2.3_%s.deb -O grafana-enterprise_9.2.3_%s.deb &&
-sudo dpkg -i grafana-enterprise_9.2.3_%s.deb &&
+echo "Downloading https://dl.grafana.com/enterprise/release/grafana-enterprise_9.2.3_%[1]s.deb" &&
+curl https://dl.grafana.com/enterprise/release/grafana-enterprise_9.2.3_%[1]s.deb -sS -o grafana-enterprise_9.2.3_%[1]s.deb &&
+sudo dpkg -i grafana-enterprise_9.2.3_%[1]s.deb &&
 sudo mkdir -p /var/lib/grafana/dashboards`,
-				binArch, binArch, binArch)); err != nil {
+				binArch)); err != nil {
 			return nil, err
 		}
 


### PR DESCRIPTION
When a roachtest downloads Grafana, `wget` logs a lot of spammy lines
with progress reports. In this commit, we switch to `curl` (which is
typically used in roachprod) and pass the `-sS` flags to only show errors.

Epic: none
Release note: None
