### PR TITLE
builtins: fix recently introduced bitmask fns with mixed type arguments

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -4166,3 +4166,34 @@ query T
 SELECT bitmask_xor('xffffffffffffffffff', '010');
 ----
 111111111111111111111111111111111111111111111111111111111111111111111101
+
+# Regression test for mixed-type arguments (#108976).
+query T
+SELECT bitmask_or('101'::STRING, B'001'::VARBIT);
+----
+101
+
+query T
+SELECT bitmask_or(B'001'::VARBIT, '101'::STRING);
+----
+101
+
+query T
+SELECT bitmask_and('101'::STRING, B'001'::VARBIT);
+----
+001
+
+query T
+SELECT bitmask_and(B'001'::VARBIT, '101'::STRING);
+----
+001
+
+query T
+SELECT bitmask_xor('101'::STRING, B'001'::VARBIT);
+----
+100
+
+query T
+SELECT bitmask_xor(B'001'::VARBIT, '101'::STRING);
+----
+100

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -8187,13 +8187,14 @@ specified store on the node it's run from. One of 'mvccGC', 'merge', 'split',
 				{Name: "b", Typ: types.String},
 			},
 			ReturnType: tree.FixedReturnType(types.VarBit),
-			Fn: func(_ context.Context, _ *eval.Context, a *tree.DBitArray, b string) (tree.Datum, error) {
-				bBitArray, err := bitarray.Parse(b)
+			Fn: func(_ context.Context, _ *eval.Context, datums tree.Datums) (tree.Datum, error) {
+				a, b := datums[0], datums[1]
+				bBitArray, err := bitarray.Parse(string(tree.MustBeDString(b)))
 				if err != nil {
 					return nil, err
 				}
 
-				return bitmaskOr(a.BitArray.String(), bBitArray.String())
+				return bitmaskOr(a.(*tree.DBitArray).BitArray.String(), bBitArray.String())
 			},
 			Info:       "Calculates bitwise OR value of unsigned bit arrays 'a' and 'b' that may have different lengths.",
 			Volatility: volatility.Immutable,
@@ -8204,13 +8205,14 @@ specified store on the node it's run from. One of 'mvccGC', 'merge', 'split',
 				{Name: "b", Typ: types.VarBit},
 			},
 			ReturnType: tree.FixedReturnType(types.VarBit),
-			Fn: func(_ context.Context, _ *eval.Context, a string, b *tree.DBitArray) (tree.Datum, error) {
-				aBitArray, err := bitarray.Parse(a)
+			Fn: func(_ context.Context, _ *eval.Context, datums tree.Datums) (tree.Datum, error) {
+				a, b := datums[0], datums[1]
+				aBitArray, err := bitarray.Parse(string(tree.MustBeDString(a)))
 				if err != nil {
 					return nil, err
 				}
 
-				return bitmaskOr(aBitArray.String(), b.BitArray.String())
+				return bitmaskOr(aBitArray.String(), b.(*tree.DBitArray).BitArray.String())
 			},
 			Info:       "Calculates bitwise OR value of unsigned bit arrays 'a' and 'b' that may have different lengths.",
 			Volatility: volatility.Immutable,
@@ -8250,13 +8252,14 @@ specified store on the node it's run from. One of 'mvccGC', 'merge', 'split',
 				{Name: "b", Typ: types.String},
 			},
 			ReturnType: tree.FixedReturnType(types.VarBit),
-			Fn: func(_ context.Context, _ *eval.Context, a *tree.DBitArray, b string) (tree.Datum, error) {
-				bBitArray, err := bitarray.Parse(b)
+			Fn: func(_ context.Context, _ *eval.Context, datums tree.Datums) (tree.Datum, error) {
+				a, b := datums[0], datums[1]
+				bBitArray, err := bitarray.Parse(string(tree.MustBeDString(b)))
 				if err != nil {
 					return nil, err
 				}
 
-				return bitmaskAnd(a.BitArray.String(), bBitArray.String())
+				return bitmaskAnd(a.(*tree.DBitArray).BitArray.String(), bBitArray.String())
 			},
 			Info:       "Calculates bitwise AND value of unsigned bit arrays 'a' and 'b' that may have different lengths.",
 			Volatility: volatility.Immutable,
@@ -8267,13 +8270,14 @@ specified store on the node it's run from. One of 'mvccGC', 'merge', 'split',
 				{Name: "b", Typ: types.VarBit},
 			},
 			ReturnType: tree.FixedReturnType(types.VarBit),
-			Fn: func(_ context.Context, _ *eval.Context, a string, b *tree.DBitArray) (tree.Datum, error) {
-				aBitArray, err := bitarray.Parse(a)
+			Fn: func(_ context.Context, _ *eval.Context, datums tree.Datums) (tree.Datum, error) {
+				a, b := datums[0], datums[1]
+				aBitArray, err := bitarray.Parse(string(tree.MustBeDString(a)))
 				if err != nil {
 					return nil, err
 				}
 
-				return bitmaskAnd(aBitArray.String(), b.BitArray.String())
+				return bitmaskAnd(aBitArray.String(), b.(*tree.DBitArray).BitArray.String())
 			},
 			Info:       "Calculates bitwise AND value of unsigned bit arrays 'a' and 'b' that may have different lengths.",
 			Volatility: volatility.Immutable,
@@ -8313,13 +8317,14 @@ specified store on the node it's run from. One of 'mvccGC', 'merge', 'split',
 				{Name: "b", Typ: types.String},
 			},
 			ReturnType: tree.FixedReturnType(types.VarBit),
-			Fn: func(_ context.Context, _ *eval.Context, a *tree.DBitArray, b string) (tree.Datum, error) {
-				bBitArray, err := bitarray.Parse(b)
+			Fn: func(_ context.Context, _ *eval.Context, datums tree.Datums) (tree.Datum, error) {
+				a, b := datums[0], datums[1]
+				bBitArray, err := bitarray.Parse(string(tree.MustBeDString(b)))
 				if err != nil {
 					return nil, err
 				}
 
-				return bitmaskXor(a.BitArray.String(), bBitArray.String())
+				return bitmaskXor(a.(*tree.DBitArray).BitArray.String(), bBitArray.String())
 			},
 			Info:       "Calculates bitwise XOR value of unsigned bit arrays 'a' and 'b' that may have different lengths.",
 			Volatility: volatility.Immutable,
@@ -8330,13 +8335,14 @@ specified store on the node it's run from. One of 'mvccGC', 'merge', 'split',
 				{Name: "b", Typ: types.VarBit},
 			},
 			ReturnType: tree.FixedReturnType(types.VarBit),
-			Fn: func(_ context.Context, _ *eval.Context, a string, b *tree.DBitArray) (tree.Datum, error) {
-				aBitArray, err := bitarray.Parse(a)
+			Fn: func(_ context.Context, _ *eval.Context, datums tree.Datums) (tree.Datum, error) {
+				a, b := datums[0], datums[1]
+				aBitArray, err := bitarray.Parse(string(tree.MustBeDString(a)))
 				if err != nil {
 					return nil, err
 				}
 
-				return bitmaskXor(aBitArray.String(), b.BitArray.String())
+				return bitmaskXor(aBitArray.String(), b.(*tree.DBitArray).BitArray.String())
 			},
 			Info:       "Calculates bitwise XOR value of unsigned bit arrays 'a' and 'b' that may have different lengths.",
 			Volatility: volatility.Immutable,


### PR DESCRIPTION
`FnOverload` is a function that takes in three arguments, and we incorrectly had functions that take four leading to an internal error in case of mixed-type arguments.

Fixes: #108976.

Release note: None