### PR TITLE
sqlstats: ignore EXPLAIN stmts on insights

### DIFF
--- a/pkg/sql/sqlstats/insights/detector.go
+++ b/pkg/sql/sqlstats/insights/detector.go
@@ -174,7 +174,7 @@ func isFailed(s *Statement) bool {
 	return s.Status == Statement_Failed
 }
 
-var prefixesToIgnore = []string{"SET "}
+var prefixesToIgnore = []string{"SET ", "EXPLAIN "}
 
 // shouldIgnoreStatement returns true if we don't want to analyze the statement.
 func shouldIgnoreStatement(s *Statement) bool {


### PR DESCRIPTION
Previously, it was possible to get Insights for a `EXPLAIN` statement, which didn't make sense.
This commit adds `EXPLAIN` to the list of statement types to be ignored during insights detection.

Fixes #88366

Release note: None