### PR TITLE
concurrency: allow multiple transactions to hold locks on a single key 

### DIFF
--- a/pkg/kv/kvserver/concurrency/lock_table.go
+++ b/pkg/kv/kvserver/concurrency/lock_table.go
@@ -1466,7 +1466,7 @@ func (l *lockState) lockStateInfo(now time.Time) roachpb.LockStateInfo {
 	var txnHolder *enginepb.TxnMeta
 
 	durability := lock.Unreplicated
-	if l.isHeld() {
+	if l.isLocked() {
 		txnHolder = l.holder.txn
 		if l.isHeldReplicated() {
 			durability = lock.Replicated
@@ -1522,7 +1522,7 @@ func (l *lockState) addToMetrics(m *LockTableMetrics, now time.Time) {
 	totalWaitDuration, maxWaitDuration := l.totalAndMaxWaitDuration(now)
 	lm := LockMetrics{
 		Key:                  l.key,
-		Held:                 l.isHeld(),
+		Held:                 l.isLocked(),
 		HoldDurationNanos:    l.lockHeldDuration(now).Nanoseconds(),
 		WaitingReaders:       int64(l.waitingReaders.Len()),
 		WaitingWriters:       int64(l.queuedWriters.Len()),
@@ -1575,7 +1575,7 @@ func (l *lockState) informActiveWaiters() {
 		// all waiters on the lock are waiting on the (old) distinguished waiter,
 		// the lock is not held.
 		assert(
-			l.distinguishedWaiter == nil || !l.isHeld(), fmt.Sprintf(
+			l.distinguishedWaiter == nil || !l.isLocked(), fmt.Sprintf(
 				"distinguished waiter waiting from txn %s waiting on itself with un-held lock",
 				waitForState.txn,
 			))
@@ -1730,7 +1730,7 @@ func (l *lockState) tryMakeNewDistinguished() {
 //
 // REQUIRES: l.mu is locked.
 func (l *lockState) isEmptyLock() bool {
-	if l.isHeld() {
+	if l.isLocked() {
 		return false // lock is held
 	}
 	// The lock isn't held. Sanity check the lock state is sane:
@@ -1763,19 +1763,11 @@ func (l *lockState) assertEmptyLockUnlocked() {
 	l.assertEmptyLock()
 }
 
-// isHeld returns true if the receiver is held. If held, it may be held durably,
-// non-durably, or both.
-//
-// REQUIRES: l.mu is locked.
-func (l *lockState) isHeld() bool {
-	return l.holder.txn != nil
-}
-
 // isHeldReplicated returns true if the receiver is held as a replicated lock.
 //
 // REQUIRES: l.mu is locked.
 func (l *lockState) isHeldReplicated() bool {
-	return l.isHeld() && !l.holder.replicatedInfo.ts.IsEmpty()
+	return l.isLocked() && !l.holder.replicatedInfo.ts.IsEmpty()
 }
 
 // isheldUnreplicated returns true if the receiver is held as a unreplicated
@@ -1783,13 +1775,13 @@ func (l *lockState) isHeldReplicated() bool {
 //
 // REQUIRES: l.mu is locked.
 func (l *lockState) isHeldUnreplicated() bool {
-	return l.isHeld() && !l.holder.unreplicatedInfo.ts.IsEmpty()
+	return l.isLocked() && !l.holder.unreplicatedInfo.ts.IsEmpty()
 }
 
 // Returns the duration of time the lock has been tracked as held in the lock table.
 // REQUIRES: l.mu is locked.
 func (l *lockState) lockHeldDuration(now time.Time) time.Duration {
-	if !l.isHeld() {
+	if !l.isLocked() {
 		return time.Duration(0)
 	}
 
@@ -1830,18 +1822,27 @@ func (l *lockState) totalAndMaxWaitDuration(now time.Time) (time.Duration, time.
 // given id.
 // REQUIRES: l.mu is locked.
 func (l *lockState) isLockedBy(id uuid.UUID) bool {
-	if l.isHeld() {
+	if l.isLocked() {
 		holderTxn, _ := l.getLockHolder()
 		return id == holderTxn.ID
 	}
 	return false
 }
 
+// isLocked returns true if key is locked. If locked, the key be locked by one
+// or more transactions. Each transaction's locks may be held durably,
+// non-durably, or both.
+//
+// REQUIRES: l.mu is locked.
+func (l *lockState) isLocked() bool {
+	return l.holder.txn != nil
+}
+
 // Returns information about the current lock holder if the lock is held, else
 // returns nil.
 // REQUIRES: l.mu is locked.
 func (l *lockState) getLockHolder() (*enginepb.TxnMeta, hlc.Timestamp) {
-	if !l.isHeld() {
+	if !l.isLocked() {
 		return nil, hlc.Timestamp{}
 	}
 
@@ -2393,7 +2394,7 @@ func (l *lockState) isNonConflictingLock(g *lockTableGuardImpl) bool {
 		return true
 	}
 	// Lock is not empty.
-	if !l.isHeld() {
+	if !l.isLocked() {
 		// If the lock is neither empty nor held it must be the case that another
 		// transaction has claimed the lock. Locks that have been claimed, but have
 		// not been acquired yet, are considered non-conflicting. Optimistic
@@ -2453,7 +2454,7 @@ func (l *lockState) isNonConflictingLock(g *lockTableGuardImpl) bool {
 func (l *lockState) acquireLock(acq *roachpb.LockAcquisition, clock *hlc.Clock) error {
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	if l.isHeld() {
+	if l.isLocked() {
 		// Already held.
 		beforeTxn, beforeTs := l.getLockHolder()
 		if acq.Txn.ID != beforeTxn.ID {
@@ -2681,7 +2682,7 @@ func (l *lockState) discoveredLock(
 	if notRemovable {
 		l.notRemovable++
 	}
-	if l.isHeld() {
+	if l.isLocked() {
 		if !l.isLockedBy(txn.ID) {
 			return errors.AssertionFailedf(
 				"discovered lock by different transaction (%s) than existing lock (see issue #63592): %s",
@@ -3043,7 +3044,7 @@ func (l *lockState) requestDone(g *lockTableGuardImpl) (gc bool) {
 		}
 	}
 
-	if !l.isHeld() && doneRemoval {
+	if !l.isLocked() && doneRemoval {
 		// The head of the list of waiting writers should always be an inactive,
 		// transactional writer if the lock isn't held. That may no longer be true
 		// if the guy we removed above was serving this purpose; the call to
@@ -3096,7 +3097,7 @@ func (l *lockState) tryFreeLockOnReplicatedAcquire() bool {
 	defer l.mu.Unlock()
 
 	// Bail if not locked with only the Unreplicated durability.
-	if !l.isHeld() || l.isHeldReplicated() {
+	if !l.isLocked() || l.isHeldReplicated() {
 		return false
 	}
 
@@ -3121,7 +3122,7 @@ func (l *lockState) tryFreeLockOnReplicatedAcquire() bool {
 //
 // REQUIRES: l.mu is locked.
 func (l *lockState) releaseWaitersOnKeyUnlocked() (gc bool) {
-	assert(!l.isHeld(), "releaseWaitersOnKeyUnlocked should only be called on unheld locks")
+	assert(!l.isLocked(), "releaseWaitersOnKeyUnlocked should only be called on unheld locks")
 
 	// All waiting readers don't need to wait here anymore.
 	// NB: all waiting readers are by definition active waiters.
@@ -3160,7 +3161,7 @@ func (l *lockState) releaseWaitersOnKeyUnlocked() (gc bool) {
 // REQUIRES: the (receiver) lock must not be held.
 // REQUIRES: there should not be any waitingReaders in the lock's wait queues.
 func (l *lockState) maybeReleaseFirstTransactionalWriter() {
-	if l.isHeld() {
+	if l.isLocked() {
 		panic("maybeReleaseFirstTransactionalWriter called when lock is held")
 	}
 	if l.waitingReaders.Len() != 0 {

--- a/pkg/kv/kvserver/concurrency/lock_table_test.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_test.go
@@ -1895,12 +1895,14 @@ func TestLockStateSafeFormat(t *testing.T) {
 		key:    []byte("KEY"),
 		endKey: []byte("END"),
 	}
-	l.holder.txn = &enginepb.TxnMeta{ID: uuid.NamespaceDNS}
+	holder := &txnLock{}
+	l.holders.PushFront(holder)
+	holder.txn = &enginepb.TxnMeta{ID: uuid.NamespaceDNS}
 	// TODO(arul): add something about replicated locks here too.
-	l.holder.unreplicatedInfo.init()
-	l.holder.unreplicatedInfo.ts = hlc.Timestamp{WallTime: 123, Logical: 7}
-	require.NoError(t, l.holder.unreplicatedInfo.acquire(lock.Exclusive, 1))
-	require.NoError(t, l.holder.unreplicatedInfo.acquire(lock.Shared, 3))
+	holder.unreplicatedInfo.init()
+	holder.unreplicatedInfo.ts = hlc.Timestamp{WallTime: 123, Logical: 7}
+	require.NoError(t, holder.unreplicatedInfo.acquire(lock.Exclusive, 1))
+	require.NoError(t, holder.unreplicatedInfo.acquire(lock.Shared, 3))
 	require.EqualValues(t,
 		" lock: ‹\"KEY\"›\n  holder: txn: 6ba7b810-9dad-11d1-80b4-00c04fd430c8 epoch: 0, iso: Serializable, ts: 0.000000123,7, info: unrepl [(str: Exclusive seq: 1), (str: Shared seq: 3)]\n",
 		redact.Sprint(l))


### PR DESCRIPTION
Locks on a single key are stored in the `lockState` struct. Prior to
this patch, the lock table only expected a single transaction to hold
a lock on a given key at any point in time. This restriction needs to
be lifted for shared locks, whose semantics allow multiple transactions
to hold locks on a single key.

This patch changes the `lockState` datastructure so that it can be
generalized in the future. We don't actually allow multiple transactions
to acquire locks on a single key just yet -- that'll come in a subsequent
patch.

Informs https://github.com/cockroachdb/cockroach/issues/91545

Release note: None