### PR TITLE
ccl/multiregionccl: make multi-region dd less flaky

### DIFF
--- a/pkg/ccl/multiregionccl/datadriven_test.go
+++ b/pkg/ccl/multiregionccl/datadriven_test.go
@@ -190,7 +190,9 @@ func TestMultiRegionDataDriven(t *testing.T) {
 				for _, stmt := range strings.Split(`
 SET CLUSTER SETTING kv.closed_timestamp.target_duration = '0.4s';
 SET CLUSTER SETTING kv.closed_timestamp.side_transport_interval = '0.1s';
-SET CLUSTER SETTING kv.closed_timestamp.propagation_slack = '0.5s'
+SET CLUSTER SETTING kv.closed_timestamp.propagation_slack = '0.5s';
+SET CLUSTER SETTING kv.allocator.load_based_rebalancing = 'off';
+SET CLUSTER SETTING kv.allocator.load_based_lease_rebalancing.enabled = false
 `,
 					";") {
 					_, err = sqlConn.Exec(stmt)


### PR DESCRIPTION
Previously, it was possible for lease transfers to be initiated in-between assertions which relied on a steady leaseholder.

This commit reduces the likelihood of lease transfers which would break assumptions the `TestMultiRegionDataDriven` test makes, by stopping load based rebalancing, and follow-the-workload lease transfers.

Informs: #108759

Release note: None