### PR TITLE
ui: add total value on stmt details page

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
@@ -38,6 +38,10 @@ import {
   TimestampToMoment,
   unique,
   batchStatements,
+  formatNumberForDisplay,
+  Duration,
+  Count,
+  longToInt,
 } from "src/util";
 import { getValidErrorsList, Loading } from "src/loading";
 import { Button } from "src/button";
@@ -694,6 +698,8 @@ export class StatementDetails extends React.Component<
       });
     }
 
+    const duration = (v: number) => Duration(v * 1e9);
+
     return (
       <>
         <PageConfig>
@@ -773,6 +779,68 @@ export class StatementDetails extends React.Component<
                   value={renderTransactionType(implicit_txn)}
                 />
                 <SummaryCardItem label="Last execution time" value={lastExec} />
+              </SummaryCard>
+            </Col>
+          </Row>
+          <Row gutter={24} className={cx("margin-left-neg")}>
+            <Col className="gutter-row" span={12}>
+              <SummaryCard className={cx("summary-card")}>
+                <SummaryCardItem
+                  label="Statement Time"
+                  value={`${formatNumberForDisplay(
+                    stats?.service_lat.mean,
+                    duration,
+                  )}`}
+                />
+                <span className={summaryCardStylesCx("summary-small-info")}>
+                  {`Execution: ${formatNumberForDisplay(
+                    stats?.run_lat.mean,
+                    duration,
+                  )} /
+                  Planning: 
+                  ${formatNumberForDisplay(stats?.plan_lat.mean, duration)}`}
+                </span>
+                <SummaryCardItem
+                  label="Rows Processed"
+                  value={`${Count(
+                    Number(stats?.rows_read?.mean),
+                  )} Reads / ${Count(
+                    Number(stats?.rows_written?.mean),
+                  )} Writes`}
+                />
+                <SummaryCardItem
+                  label="Execution Retries"
+                  value={Count(
+                    longToInt(stats?.count) -
+                      longToInt(stats?.first_attempt_count),
+                  )}
+                />
+                <SummaryCardItem
+                  label="Execution Count"
+                  value={Count(longToInt(stats?.count))}
+                />
+              </SummaryCard>
+            </Col>
+            <Col className="gutter-row" span={12}>
+              <SummaryCard className={cx("summary-card")}>
+                <SummaryCardItem
+                  label="Contention Time"
+                  value={formatNumberForDisplay(
+                    stats?.exec_stats?.contention_time.mean,
+                    duration,
+                  )}
+                />
+                <SummaryCardItem
+                  label="CPU Time"
+                  value={formatNumberForDisplay(
+                    stats?.exec_stats?.cpu_sql_nanos.mean,
+                    Duration,
+                  )}
+                />
+                <SummaryCardItem
+                  label="Client Wait Time"
+                  value={formatNumberForDisplay(stats?.idle_lat.mean, duration)}
+                />
               </SummaryCard>
             </Col>
           </Row>

--- a/pkg/ui/workspaces/cluster-ui/src/summaryCard/summaryCard.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/summaryCard/summaryCard.module.scss
@@ -96,4 +96,13 @@
       }
     }
   }
+
+  .summary-small-info {
+    color: $colors--neutral-7;
+    display: flex;
+    font-size: 13px;
+    font-weight: $font-weight--light;
+    justify-content: right;
+    margin-top: -13px;
+  }
 }


### PR DESCRIPTION
Previously, we remove the summary cards that
had the total/avg values for the selected period
on the Statement Details page and replaced them
with charts.
We received feedback that user still want to see
the total values, plus the charts.
This commit adds back the summary cards.

Fixes #87192

<img width="1653" alt="Screenshot 2023-08-18 at 6 45 01 PM" src="https://github.com/cockroachdb/cockroach/assets/1017486/31a70173-f2a8-44ec-b657-93aac9c5edc8">

https://www.loom.com/share/97d32facf8234f40becba63cf4f9146e

Release note (ui change): Add summary cards with total/avg values for statistics on Statement Details page.