### PR TITLE
builtins: unify and expand sanity checks of builtins

### DIFF
--- a/pkg/sql/sem/builtins/aggregate_builtins.go
+++ b/pkg/sql/sem/builtins/aggregate_builtins.go
@@ -38,24 +38,9 @@ import (
 )
 
 func init() {
-	// Add all aggregates to the builtins map after a few sanity checks.
 	for k, v := range aggregates {
-		for _, a := range v.overloads {
-			if a.Class != tree.AggregateClass {
-				panic(errors.AssertionFailedf("%s: aggregate functions should be marked with the tree.AggregateClass "+
-					"function class, found %v", k, v))
-			}
-			if a.AggregateFunc == nil {
-				panic(errors.AssertionFailedf("%s: aggregate functions should have eval.AggregateFunc constructors, "+
-					"found %v", k, a))
-			}
-			if a.WindowFunc == nil {
-				panic(errors.AssertionFailedf("%s: aggregate functions should have tree.WindowFunc constructors, "+
-					"found %v", k, a))
-			}
-		}
-
-		registerBuiltin(k, v)
+		const enforceClass = true
+		registerBuiltin(k, v, tree.AggregateClass, enforceClass)
 	}
 }
 
@@ -712,8 +697,6 @@ func makeAggOverloadWithReturnType(
 	}
 
 	return tree.Overload{
-		// See the comment about aggregate functions in the definitions
-		// of the Builtins array above.
 		Types:         paramTypes,
 		ReturnType:    retType,
 		AggregateFunc: f,

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -197,7 +197,8 @@ func mustBeDIntInTenantRange(e tree.Expr) (tree.DInt, error) {
 
 func init() {
 	for k, v := range regularBuiltins {
-		registerBuiltin(k, v)
+		const enforceClass = true
+		registerBuiltin(k, v, tree.NormalClass, enforceClass)
 	}
 }
 

--- a/pkg/sql/sem/builtins/generator_builtins.go
+++ b/pkg/sql/sem/builtins/generator_builtins.go
@@ -56,15 +56,9 @@ var _ eval.ValueGenerator = &seriesValueGenerator{}
 var _ eval.ValueGenerator = &arrayValueGenerator{}
 
 func init() {
-	// Add all windows to the builtins map after a few sanity checks.
 	for k, v := range generators {
-		for _, g := range v.overloads {
-			if g.Class != tree.GeneratorClass {
-				panic(errors.AssertionFailedf("generator functions should be marked with the tree.GeneratorClass "+
-					"function class, found %v", v))
-			}
-		}
-		registerBuiltin(k, v)
+		const enforceClass = true
+		registerBuiltin(k, v, tree.GeneratorClass, enforceClass)
 	}
 }
 

--- a/pkg/sql/sem/builtins/generator_probe_ranges.go
+++ b/pkg/sql/sem/builtins/generator_probe_ranges.go
@@ -34,15 +34,9 @@ import (
 )
 
 func init() {
-	// Add all windows to the Builtins map after a few sanity checks.
 	for k, v := range probeRangesGenerators {
-		for _, g := range v.overloads {
-			if g.Class != tree.GeneratorClass {
-				panic(errors.AssertionFailedf("generator functions should be marked with the tree.GeneratorClass "+
-					"function class, found %v", v))
-			}
-		}
-		registerBuiltin(k, v)
+		const enforceClass = true
+		registerBuiltin(k, v, tree.GeneratorClass, enforceClass)
 	}
 }
 

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -7474,7 +7474,10 @@ func init() {
 	for k, v := range geoBuiltins {
 		v.props.Category = builtinconstants.CategorySpatial
 		v.props.AvailableOnPublicSchema = true
-		registerBuiltin(k, v)
+		// Most builtins in geoBuiltins are of the Normal class, but there are a
+		// few of the Generator or SQL classes.
+		const enforceClass = false
+		registerBuiltin(k, v, tree.NormalClass, enforceClass)
 	}
 }
 

--- a/pkg/sql/sem/builtins/math_builtins.go
+++ b/pkg/sql/sem/builtins/math_builtins.go
@@ -27,9 +27,9 @@ import (
 )
 
 func init() {
-	// Add all mathBuiltins to the builtins map after a sanity check.
 	for k, v := range mathBuiltins {
-		registerBuiltin(k, v)
+		const enforceClass = true
+		registerBuiltin(k, v, tree.NormalClass, enforceClass)
 	}
 }
 

--- a/pkg/sql/sem/builtins/overlaps_builtins.go
+++ b/pkg/sql/sem/builtins/overlaps_builtins.go
@@ -47,9 +47,9 @@ var (
 )
 
 func init() {
-	// Add all overlapsBuiltins to the builtins map after a sanity check.
 	for k, v := range overlapsBuiltins {
-		registerBuiltin(k, v)
+		const enforceClass = true
+		registerBuiltin(k, v, tree.NormalClass, enforceClass)
 	}
 }
 

--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -102,9 +102,10 @@ func PGIOBuiltinPrefix(typ *types.T) string {
 
 // initPGBuiltins adds all of the postgres builtins to the builtins map.
 func init() {
+	const enforceClass = true
 	for k, v := range pgBuiltins {
 		v.props.Category = builtinconstants.CategoryCompatibility
-		registerBuiltin(k, v)
+		registerBuiltin(k, v, tree.NormalClass, enforceClass)
 	}
 
 	// Make non-array type i/o builtins.
@@ -119,19 +120,19 @@ func init() {
 		}
 		builtinPrefix := PGIOBuiltinPrefix(typ)
 		for name, builtin := range makeTypeIOBuiltins(builtinPrefix, typ) {
-			registerBuiltin(name, builtin)
+			registerBuiltin(name, builtin, tree.NormalClass, enforceClass)
 		}
 	}
 	// Make array type i/o builtins.
 	for name, builtin := range makeTypeIOBuiltins("array_", types.AnyArray) {
-		registerBuiltin(name, builtin)
+		registerBuiltin(name, builtin, tree.NormalClass, enforceClass)
 	}
 	for name, builtin := range makeTypeIOBuiltins("anyarray_", types.AnyArray) {
-		registerBuiltin(name, builtin)
+		registerBuiltin(name, builtin, tree.NormalClass, enforceClass)
 	}
 	// Make enum type i/o builtins.
 	for name, builtin := range makeTypeIOBuiltins("enum_", types.AnyEnum) {
-		registerBuiltin(name, builtin)
+		registerBuiltin(name, builtin, tree.NormalClass, enforceClass)
 	}
 
 	// Make type cast builtins.
@@ -203,7 +204,7 @@ func init() {
 	for toOID, def := range castBuiltins {
 		n := cast.CastTypeName(types.OidToType[toOID])
 		CastBuiltinNames[n] = struct{}{}
-		registerBuiltin(n, *def)
+		registerBuiltin(n, *def, tree.NormalClass, enforceClass)
 	}
 
 	// Make crdb_internal.create_regfoo and to_regfoo builtins.
@@ -219,8 +220,8 @@ func init() {
 		{"Translates a textual type name to its OID", types.RegType},
 	} {
 		typName := b.typ.SQLStandardName()
-		registerBuiltin("crdb_internal.create_"+typName, makeCreateRegDef(b.typ))
-		registerBuiltin("to_"+typName, makeToRegOverload(b.typ, b.toRegOverloadHelpText))
+		registerBuiltin("crdb_internal.create_"+typName, makeCreateRegDef(b.typ), tree.NormalClass, enforceClass)
+		registerBuiltin("to_"+typName, makeToRegOverload(b.typ, b.toRegOverloadHelpText), tree.NormalClass, enforceClass)
 	}
 }
 

--- a/pkg/sql/sem/builtins/pgcrypto_builtins.go
+++ b/pkg/sql/sem/builtins/pgcrypto_builtins.go
@@ -36,9 +36,9 @@ import (
 )
 
 func init() {
-	// Add all pgcryptoBuiltins to the builtins map after a sanity check.
 	for k, v := range pgcryptoBuiltins {
-		registerBuiltin(k, v)
+		const enforceClass = true
+		registerBuiltin(k, v, tree.NormalClass, enforceClass)
 	}
 }
 

--- a/pkg/sql/sem/builtins/replication_builtins.go
+++ b/pkg/sql/sem/builtins/replication_builtins.go
@@ -27,9 +27,11 @@ import (
 )
 
 func init() {
-	// Add all replicationBuiltins to the builtins map after a sanity check.
 	for k, v := range replicationBuiltins {
-		registerBuiltin(k, v)
+		// Most builtins in this file are of the Normal class, but there are a
+		// couple of the Generator class.
+		const enforceClass = false
+		registerBuiltin(k, v, tree.NormalClass, enforceClass)
 	}
 }
 

--- a/pkg/sql/sem/builtins/trigram_builtins.go
+++ b/pkg/sql/sem/builtins/trigram_builtins.go
@@ -25,7 +25,8 @@ func init() {
 	for k, v := range trigramBuiltins {
 		v.props.Category = builtinconstants.CategoryTrigram
 		v.props.AvailableOnPublicSchema = true
-		registerBuiltin(k, v)
+		const enforceClass = true
+		registerBuiltin(k, v, tree.NormalClass, enforceClass)
 	}
 }
 

--- a/pkg/sql/sem/builtins/tsearch_builtins.go
+++ b/pkg/sql/sem/builtins/tsearch_builtins.go
@@ -28,7 +28,10 @@ func init() {
 	for k, v := range tsearchBuiltins {
 		v.props.Category = builtinconstants.CategoryFullTextSearch
 		v.props.AvailableOnPublicSchema = true
-		registerBuiltin(k, v)
+		// Most builtins in this file are of the Normal class, but there is one
+		// (at the time of writing) of the Generator class.
+		const enforceClass = false
+		registerBuiltin(k, v, tree.NormalClass, enforceClass)
 	}
 }
 

--- a/pkg/sql/sem/builtins/window_builtins.go
+++ b/pkg/sql/sem/builtins/window_builtins.go
@@ -19,23 +19,12 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/volatility"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
-	"github.com/cockroachdb/errors"
 )
 
 func init() {
-	// Add all windows to the builtins map after a few sanity checks.
 	for k, v := range windows {
-		for _, w := range v.overloads {
-			if w.Class != tree.WindowClass {
-				panic(errors.AssertionFailedf("%s: window functions should be marked with the tree.WindowClass "+
-					"function class, found %v", k, v))
-			}
-			if w.WindowFunc == nil {
-				panic(errors.AssertionFailedf("%s: window functions should have eval.WindowFunc constructors, "+
-					"found %v", k, w))
-			}
-		}
-		registerBuiltin(k, v)
+		const enforceClass = true
+		registerBuiltin(k, v, tree.WindowClass, enforceClass)
 	}
 }
 

--- a/pkg/sql/sem/eval/BUILD.bazel
+++ b/pkg/sql/sem/eval/BUILD.bazel
@@ -63,6 +63,7 @@ go_library(
         "//pkg/sql/pgwire/pgwirecancel",
         "//pkg/sql/privilege",
         "//pkg/sql/roleoption",
+        "//pkg/sql/sem/builtins/builtinsregistry",
         "//pkg/sql/sem/cast",
         "//pkg/sql/sem/catid",
         "//pkg/sql/sem/tree",

--- a/pkg/sql/sem/tree/overload.go
+++ b/pkg/sql/sem/tree/overload.go
@@ -112,6 +112,24 @@ const (
 	SQLClass
 )
 
+// String returns the string representation of the function class.
+func (c FunctionClass) String() string {
+	switch c {
+	case NormalClass:
+		return "normal"
+	case AggregateClass:
+		return "aggregate"
+	case WindowClass:
+		return "window"
+	case GeneratorClass:
+		return "generator"
+	case SQLClass:
+		return "SQL"
+	default:
+		panic(errors.AssertionFailedf("unexpected class %d", c))
+	}
+}
+
 // Overload is one of the overloads of a built-in function.
 // Each FunctionDefinition may contain one or more overloads.
 type Overload struct {


### PR DESCRIPTION
This commit unifies all sanity checks performed on the builtin overloads to be in a single place. These checks verify that the correct "function" fields are set based on the class of the overload.

It additionally introduces an extra check that `Fn` field has the correct signature (all other fields are verified at compile time via marker interfaces, but there are just too many `Fn` usages, so it's easier to have init time check). This check would have prevented #108976 from slipping in.

Epic: None

Release note: None