### PR TITLE
cloud: redact passwords in URLs

### DIFF
--- a/pkg/cloud/BUILD.bazel
+++ b/pkg/cloud/BUILD.bazel
@@ -38,7 +38,10 @@ go_library(
 
 go_test(
     name = "cloud_test",
-    srcs = ["cloud_io_test.go"],
+    srcs = [
+        "cloud_io_test.go",
+        "uris_test.go",
+    ],
     args = ["-test.timeout=295s"],
     embed = [":cloud"],
     deps = [

--- a/pkg/cloud/impl_registry.go
+++ b/pkg/cloud/impl_registry.go
@@ -163,40 +163,6 @@ func ExternalStorageFromURI(
 		db, limiters, metrics, opts...)
 }
 
-// SanitizeExternalStorageURI returns the external storage URI with with some
-// secrets redacted, for use when showing these URIs in the UI, to provide some
-// protection from shoulder-surfing. The param is still present -- just
-// redacted -- to make it clearer that that value is indeed persisted interally.
-// extraParams which should be scrubbed -- for params beyond those that the
-// various cloud-storage URIs supported by this package know about -- can be
-// passed allowing this function to be used to scrub other URIs too (such as
-// non-cloudstorage changefeed sinks).
-func SanitizeExternalStorageURI(path string, extraParams []string) (string, error) {
-	uri, err := url.Parse(path)
-	if err != nil {
-		return "", err
-	}
-	if uri.Scheme == "experimental-workload" || uri.Scheme == "workload" || uri.Scheme == "null" {
-		return path, nil
-	}
-
-	params := uri.Query()
-	for param := range params {
-		if _, ok := redactedQueryParams[param]; ok {
-			params.Set(param, "redacted")
-		} else {
-			for _, p := range extraParams {
-				if param == p {
-					params.Set(param, "redacted")
-				}
-			}
-		}
-	}
-
-	uri.RawQuery = params.Encode()
-	return uri.String(), nil
-}
-
 // MakeExternalStorage creates an ExternalStorage from the given config.
 func MakeExternalStorage(
 	ctx context.Context,

--- a/pkg/cloud/uris_test.go
+++ b/pkg/cloud/uris_test.go
@@ -1,0 +1,61 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package cloud_test
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/cloud"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSanitizeExternalStorageURI(t *testing.T) {
+	// Register a scheme to test scheme-specific redaction.
+	cloud.RegisterExternalStorageProvider(0, nil, nil,
+		cloud.RedactedParams("TEST_PARAM"),
+		"test-scheme",
+	)
+	testCases := []struct {
+		name             string
+		inputURI         string
+		inputExtraParams []string
+		expected         string
+	}{
+		{
+			name:     "redacts password",
+			inputURI: "http://username:password@foo.com/something",
+			expected: "http://username:redacted@foo.com/something",
+		},
+		{
+			name:             "redacts given parameters",
+			inputURI:         "http://foo.com/something?secret_key=uhoh",
+			inputExtraParams: []string{"secret_key"},
+			expected:         "http://foo.com/something?secret_key=redacted",
+		},
+		{
+			name:     "redacts registered parameters",
+			inputURI: "test-scheme://somehost/somepath?TEST_PARAM=uhoh",
+			expected: "test-scheme://somehost/somepath?TEST_PARAM=redacted",
+		},
+		{
+			name:     "preserves username",
+			inputURI: "http://username@foo.com/something",
+			expected: "http://username@foo.com/something",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actualOutput, err := cloud.SanitizeExternalStorageURI(tc.inputURI, tc.inputExtraParams)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, actualOutput)
+		})
+	}
+}


### PR DESCRIPTION
URIs contain an optional userinfo before the host:

   http://username@example.com/
   http://username:password@example.com/

Previously SanitizeExternalStorageURI left this untouched. Now, we redact the password portion if present.

Epic: none

Release note: None