### PR TITLE
pgwire: avoid mentioning "tenants" in pre-serve metric descriptions

### DIFF
--- a/pkg/sql/pgwire/pre_serve.go
+++ b/pkg/sql/pgwire/pre_serve.go
@@ -39,37 +39,37 @@ import (
 var (
 	MetaPreServeNewConns = metric.Metadata{
 		Name:        "sql.pre_serve.new_conns",
-		Help:        "Counter of the number of SQL connections created prior to routine the connection a specific tenant",
+		Help:        "Number of SQL connections created prior to routing the connection to the target SQL server",
 		Measurement: "Connections",
 		Unit:        metric.Unit_COUNT,
 	}
 	MetaPreServeBytesIn = metric.Metadata{
 		Name:        "sql.pre_serve.bytesin",
-		Help:        "Number of SQL bytes received prior to routing the connection to a specific tenant",
+		Help:        "Number of SQL bytes received prior to routing the connection to the target SQL server",
 		Measurement: "SQL Bytes",
 		Unit:        metric.Unit_BYTES,
 	}
 	MetaPreServeBytesOut = metric.Metadata{
 		Name:        "sql.pre_serve.bytesout",
-		Help:        "Number of SQL bytes sent prior to routing the connection to a specific tenant",
+		Help:        "Number of SQL bytes sent prior to routing the connection to the target SQL server",
 		Measurement: "SQL Bytes",
 		Unit:        metric.Unit_BYTES,
 	}
 	MetaPreServeConnFailures = metric.Metadata{
 		Name:        "sql.pre_serve.conn.failures",
-		Help:        "Number of SQL connection failures prior to routing the connection to a specific tenant",
+		Help:        "Number of SQL connection failures prior to routing the connection to the target SQL server",
 		Measurement: "Connections",
 		Unit:        metric.Unit_COUNT,
 	}
 	MetaPreServeMaxBytes = metric.Metadata{
 		Name:        "sql.pre_serve.mem.max",
-		Help:        "Memory usage for SQL connections prior to routing the connection to a specific tenant",
+		Help:        "Memory usage for SQL connections prior to routing the connection to the target SQL server",
 		Measurement: "Memory",
 		Unit:        metric.Unit_BYTES,
 	}
 	MetaPreServeCurBytes = metric.Metadata{
 		Name:        "sql.pre_serve.mem.cur",
-		Help:        "Current memory usage for SQL connections prior to routing the connection to a specific tenant",
+		Help:        "Current memory usage for SQL connections prior to routing the connection to the target SQL server",
 		Measurement: "Memory",
 		Unit:        metric.Unit_BYTES,
 	}

--- a/pkg/sql/pgwire/server.go
+++ b/pkg/sql/pgwire/server.go
@@ -113,7 +113,7 @@ var (
 	}
 	MetaNewConns = metric.Metadata{
 		Name:        "sql.new_conns",
-		Help:        "Counter of the number of SQL connections created",
+		Help:        "Number of SQL connections created",
 		Measurement: "Connections",
 		Unit:        metric.Unit_COUNT,
 	}
@@ -149,19 +149,19 @@ var (
 	}
 	MetaPGWireCancelTotal = metric.Metadata{
 		Name:        "sql.pgwire_cancel.total",
-		Help:        "Counter of the number of pgwire query cancel requests",
+		Help:        "Number of pgwire query cancel requests",
 		Measurement: "Requests",
 		Unit:        metric.Unit_COUNT,
 	}
 	MetaPGWireCancelIgnored = metric.Metadata{
 		Name:        "sql.pgwire_cancel.ignored",
-		Help:        "Counter of the number of pgwire query cancel requests that were ignored due to rate limiting",
+		Help:        "Number of pgwire query cancel requests that were ignored due to rate limiting",
 		Measurement: "Requests",
 		Unit:        metric.Unit_COUNT,
 	}
 	MetaPGWireCancelSuccessful = metric.Metadata{
 		Name:        "sql.pgwire_cancel.successful",
-		Help:        "Counter of the number of pgwire query cancel requests that were successful",
+		Help:        "Number of pgwire query cancel requests that were successful",
 		Measurement: "Requests",
 		Unit:        metric.Unit_COUNT,
 	}


### PR DESCRIPTION
Found via #109042.
Epic: CRDB-29380
Release note: None