### PR TITLE
streamingccl: add application name to partition client conns

### DIFF
--- a/pkg/ccl/streamingccl/streamclient/BUILD.bazel
+++ b/pkg/ccl/streamingccl/streamclient/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
         "client.go",
         "client_helpers.go",
         "partitioned_stream_client.go",
+        "pgconn.go",
         "random_stream_client.go",
         "span_config_stream_client.go",
     ],

--- a/pkg/ccl/streamingccl/streamclient/client_helpers.go
+++ b/pkg/ccl/streamingccl/streamclient/client_helpers.go
@@ -10,17 +10,10 @@ package streamclient
 
 import (
 	"context"
-	"crypto/tls"
-	"crypto/x509"
-	"encoding/pem"
-	"net"
-	"net/url"
-	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/streamingccl"
 	"github.com/cockroachdb/cockroach/pkg/repstream/streampb"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
-	"github.com/cockroachdb/errors"
 	"github.com/jackc/pgx/v4"
 )
 
@@ -106,121 +99,4 @@ func parseEvent(streamEvent *streampb.StreamEvent) streamingccl.Event {
 		}
 	}
 	return event
-}
-
-type tlsCerts struct {
-	certs        []tls.Certificate
-	rootCertPool *x509.CertPool
-}
-
-const (
-	// sslInlineURLParam is a non-standard connection URL
-	// parameter. When true, we assume that sslcert, sslkey, and
-	// sslrootcert contain URL-encoded data rather than paths.
-	sslInlineURLParam = "sslinline"
-
-	sslModeURLParam     = "sslmode"
-	sslCertURLParam     = "sslcert"
-	sslKeyURLParam      = "sslkey"
-	sslRootCertURLParam = "sslrootcert"
-)
-
-var RedactableURLParameters = []string{
-	sslCertURLParam,
-	sslKeyURLParam,
-	sslRootCertURLParam,
-}
-
-func setupPGXConfig(remote *url.URL) (*pgx.ConnConfig, error) {
-	noInlineCertURI, tlsInfo, err := uriWithInlineTLSCertsRemoved(remote)
-	if err != nil {
-		return nil, err
-	}
-	config, err := pgx.ParseConfig(noInlineCertURI.String())
-	if err != nil {
-		return nil, err
-	}
-	tlsInfo.addTLSCertsToConfig(config.TLSConfig)
-
-	// The default pgx dialer uses a KeepAlive of 5 minutes. Set a lower KeepAlive
-	// threshold, so if two nodes disconnect, we eagerly replan the job with
-	// potentially new node pairings.
-	dialer := &net.Dialer{KeepAlive: time.Second * 15}
-	config.DialFunc = dialer.DialContext
-	return config, nil
-}
-
-// uriWithInlineTLSCertsRemoved handles the non-standard sslinline
-// option. The returned URL can be passed to pgx. The returned
-// tlsCerts struct can be used to apply the certificate data to the
-// tls.Config produced by pgx.
-func uriWithInlineTLSCertsRemoved(remote *url.URL) (*url.URL, *tlsCerts, error) {
-	if remote.Query().Get(sslInlineURLParam) != "true" {
-		return remote, nil, nil
-	}
-
-	retURL := *remote
-	v := retURL.Query()
-	cert := v.Get(sslCertURLParam)
-	key := v.Get(sslKeyURLParam)
-	rootcert := v.Get(sslRootCertURLParam)
-
-	if (cert != "" && key == "") || (cert == "" && key != "") {
-		return nil, nil, errors.New(`both "sslcert" and "sslkey" are required`)
-	}
-
-	tlsInfo := &tlsCerts{}
-	if rootcert != "" {
-		caCertPool := x509.NewCertPool()
-		if !caCertPool.AppendCertsFromPEM([]byte(rootcert)) {
-			return nil, nil, errors.New("unable to add CA to cert pool")
-		}
-		tlsInfo.rootCertPool = caCertPool
-	}
-	if cert != "" && key != "" {
-		// TODO(ssd): pgx supports sslpassword here. But, it
-		// only supports PKCS#1 and relies on functions that
-		// are deprecated in the stdlib. For now, I've skipped
-		// it.
-		block, _ := pem.Decode([]byte(key))
-		pemKey := pem.EncodeToMemory(block)
-		keyPair, err := tls.X509KeyPair([]byte(cert), pemKey)
-		if err != nil {
-			return nil, nil, errors.Wrap(err, "unable to construct x509 key pair")
-		}
-		tlsInfo.certs = []tls.Certificate{keyPair}
-	}
-
-	// lib/pq, pgx, and the C libpq implement this backwards
-	// compatibility quirk. Since we are removing sslrootcert, we
-	// have to re-implement it here.
-	//
-	// TODO(ssd): This may be a sign that we should implement the
-	// entire configTLS function from pgx and remove all tls
-	// options.
-	if v.Get(sslModeURLParam) == "require" && rootcert != "" {
-		v.Set(sslModeURLParam, "verify-ca")
-	}
-
-	v.Del(sslCertURLParam)
-	v.Del(sslKeyURLParam)
-	v.Del(sslRootCertURLParam)
-	v.Del(sslInlineURLParam)
-	retURL.RawQuery = v.Encode()
-	return &retURL, tlsInfo, nil
-}
-
-func (c *tlsCerts) addTLSCertsToConfig(tlsConfig *tls.Config) {
-	if c == nil {
-		return
-	}
-
-	if c.rootCertPool != nil {
-		tlsConfig.RootCAs = c.rootCertPool
-		tlsConfig.ClientCAs = c.rootCertPool
-	}
-
-	if len(c.certs) > 0 {
-		tlsConfig.Certificates = c.certs
-	}
 }

--- a/pkg/ccl/streamingccl/streamclient/partitioned_stream_client.go
+++ b/pkg/ccl/streamingccl/streamclient/partitioned_stream_client.go
@@ -38,9 +38,11 @@ type partitionedStreamClient struct {
 	}
 }
 
-func NewPartitionedStreamClient(ctx context.Context, remote *url.URL) (Client, error) {
-
-	config, err := setupPGXConfig(remote)
+func NewPartitionedStreamClient(
+	ctx context.Context, remote *url.URL, opts ...Option,
+) (Client, error) {
+	options := processOptions(opts)
+	config, err := setupPGXConfig(remote, options)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ccl/streamingccl/streamclient/pgconn.go
+++ b/pkg/ccl/streamingccl/streamclient/pgconn.go
@@ -1,0 +1,144 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package streamclient
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"net"
+	"net/url"
+	"time"
+
+	"github.com/cockroachdb/errors"
+	"github.com/jackc/pgx/v4"
+)
+
+const (
+	// sslInlineURLParam is a non-standard connection URL
+	// parameter. When true, we assume that sslcert, sslkey, and
+	// sslrootcert contain URL-encoded data rather than paths.
+	sslInlineURLParam = "sslinline"
+
+	sslModeURLParam     = "sslmode"
+	sslCertURLParam     = "sslcert"
+	sslKeyURLParam      = "sslkey"
+	sslRootCertURLParam = "sslrootcert"
+)
+
+var RedactableURLParameters = []string{
+	sslCertURLParam,
+	sslKeyURLParam,
+	sslRootCertURLParam,
+}
+
+func setupPGXConfig(remote *url.URL, options *options) (*pgx.ConnConfig, error) {
+	noInlineCertURI, tlsInfo, err := uriWithInlineTLSCertsRemoved(remote)
+	if err != nil {
+		return nil, err
+	}
+	config, err := pgx.ParseConfig(noInlineCertURI.String())
+	if err != nil {
+		return nil, err
+	}
+	tlsInfo.addTLSCertsToConfig(config.TLSConfig)
+
+	// The default pgx dialer uses a KeepAlive of 5 minutes. Set a lower KeepAlive
+	// threshold, so if two nodes disconnect, we eagerly replan the job with
+	// potentially new node pairings.
+	dialer := &net.Dialer{KeepAlive: time.Second * 15}
+	config.DialFunc = dialer.DialContext
+
+	// If the user hasn't given us an application name.
+	if _, ok := config.RuntimeParams["application_name"]; !ok {
+		config.RuntimeParams["application_name"] = options.appName()
+	}
+
+	return config, nil
+}
+
+type tlsCerts struct {
+	certs        []tls.Certificate
+	rootCertPool *x509.CertPool
+}
+
+// uriWithInlineTLSCertsRemoved handles the non-standard sslinline
+// option. The returned URL can be passed to pgx. The returned
+// tlsCerts struct can be used to apply the certificate data to the
+// tls.Config produced by pgx.
+func uriWithInlineTLSCertsRemoved(remote *url.URL) (*url.URL, *tlsCerts, error) {
+	if remote.Query().Get(sslInlineURLParam) != "true" {
+		return remote, nil, nil
+	}
+
+	retURL := *remote
+	v := retURL.Query()
+	cert := v.Get(sslCertURLParam)
+	key := v.Get(sslKeyURLParam)
+	rootcert := v.Get(sslRootCertURLParam)
+
+	if (cert != "" && key == "") || (cert == "" && key != "") {
+		return nil, nil, errors.New(`both "sslcert" and "sslkey" are required`)
+	}
+
+	tlsInfo := &tlsCerts{}
+	if rootcert != "" {
+		caCertPool := x509.NewCertPool()
+		if !caCertPool.AppendCertsFromPEM([]byte(rootcert)) {
+			return nil, nil, errors.New("unable to add CA to cert pool")
+		}
+		tlsInfo.rootCertPool = caCertPool
+	}
+	if cert != "" && key != "" {
+		// TODO(ssd): pgx supports sslpassword here. But, it
+		// only supports PKCS#1 and relies on functions that
+		// are deprecated in the stdlib. For now, I've skipped
+		// it.
+		block, _ := pem.Decode([]byte(key))
+		pemKey := pem.EncodeToMemory(block)
+		keyPair, err := tls.X509KeyPair([]byte(cert), pemKey)
+		if err != nil {
+			return nil, nil, errors.Wrap(err, "unable to construct x509 key pair")
+		}
+		tlsInfo.certs = []tls.Certificate{keyPair}
+	}
+
+	// lib/pq, pgx, and the C libpq implement this backwards
+	// compatibility quirk. Since we are removing sslrootcert, we
+	// have to re-implement it here.
+	//
+	// TODO(ssd): This may be a sign that we should implement the
+	// entire configTLS function from pgx and remove all tls
+	// options.
+	if v.Get(sslModeURLParam) == "require" && rootcert != "" {
+		v.Set(sslModeURLParam, "verify-ca")
+	}
+
+	v.Del(sslCertURLParam)
+	v.Del(sslKeyURLParam)
+	v.Del(sslRootCertURLParam)
+	v.Del(sslInlineURLParam)
+	retURL.RawQuery = v.Encode()
+	return &retURL, tlsInfo, nil
+}
+
+func (c *tlsCerts) addTLSCertsToConfig(tlsConfig *tls.Config) {
+	if c == nil {
+		return
+	}
+
+	if c.rootCertPool != nil {
+		tlsConfig.RootCAs = c.rootCertPool
+		tlsConfig.ClientCAs = c.rootCertPool
+	}
+
+	if len(c.certs) > 0 {
+		tlsConfig.Certificates = c.certs
+	}
+}

--- a/pkg/ccl/streamingccl/streamclient/span_config_stream_client.go
+++ b/pkg/ccl/streamingccl/streamclient/span_config_stream_client.go
@@ -32,8 +32,12 @@ type spanConfigStreamClient struct {
 // side, consider implementing a different interface for the spanConfig client.
 var _ Client = &spanConfigStreamClient{}
 
-func NewSpanConfigStreamClient(ctx context.Context, remote *url.URL) (Client, error) {
-	config, err := setupPGXConfig(remote)
+func NewSpanConfigStreamClient(
+	ctx context.Context, remote *url.URL, opts ...Option,
+) (Client, error) {
+	options := processOptions(opts)
+
+	config, err := setupPGXConfig(remote, options)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_dist.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_dist.go
@@ -81,7 +81,8 @@ func startDistIngestion(
 	msg := redact.Sprintf("resuming stream (producer job %d) from %s", streamID, heartbeatTimestamp)
 	updateRunningStatus(ctx, ingestionJob, jobspb.InitializingReplication, msg)
 
-	client, err := connectToActiveClient(ctx, ingestionJob, execCtx.ExecCfg().InternalDB)
+	client, err := connectToActiveClient(ctx, ingestionJob, execCtx.ExecCfg().InternalDB,
+		streamclient.WithStreamID(streamID))
 	if err != nil {
 		return err
 	}

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_frontier_processor.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_frontier_processor.go
@@ -171,13 +171,15 @@ type heartbeatSender struct {
 func newHeartbeatSender(
 	ctx context.Context, flowCtx *execinfra.FlowCtx, spec execinfrapb.StreamIngestionFrontierSpec,
 ) (*heartbeatSender, error) {
-	streamClient, err := streamclient.GetFirstActiveClient(ctx, spec.StreamAddresses)
+
+	streamID := streampb.StreamID(spec.StreamID)
+	streamClient, err := streamclient.GetFirstActiveClient(ctx, spec.StreamAddresses, streamclient.WithStreamID(streamID))
 	if err != nil {
 		return nil, err
 	}
 	return &heartbeatSender{
 		client:          streamClient,
-		streamID:        streampb.StreamID(spec.StreamID),
+		streamID:        streamID,
 		sv:              &flowCtx.EvalCtx.Settings.SV,
 		frontierUpdates: make(chan hlc.Timestamp),
 		cancel:          func() {},

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor.go
@@ -394,7 +394,8 @@ func (sip *streamIngestionProcessor) Start(ctx context.Context) {
 			streamClient = sip.forceClientForTests
 			log.Infof(ctx, "using testing client")
 		} else {
-			streamClient, err = streamclient.NewStreamClient(ctx, streamingccl.StreamAddress(addr), db)
+			streamClient, err = streamclient.NewStreamClient(ctx, streamingccl.StreamAddress(addr), db,
+				streamclient.WithStreamID(streampb.StreamID(sip.spec.StreamID)))
 			if err != nil {
 				sip.MoveToDraining(errors.Wrapf(err, "creating client for partition spec %q from %q", token, addr))
 				return

--- a/pkg/ccl/streamingccl/streamingest/testdata/simple
+++ b/pkg/ccl/streamingccl/streamingest/testdata/simple
@@ -30,6 +30,13 @@ SELECT strip_host(source_cluster_uri) FROM [SHOW TENANT destination WITH REPLICA
 ----
 postgres://root@?sslcert=redacted&sslkey=redacted&sslmode=verify-full&sslrootcert=redacted
 
+# The session on the source should have an app name set.
+query-sql as=source-system
+SELECT application_name FROM [SHOW SESSIONS] WHERE application_name LIKE '%repstream%' LIMIT 1
+----
+repstream job id=$_producerJobID
+
+
 query-sql as=source-system
 SHOW TENANT source WITH REPLICATION STATUS
 ----


### PR DESCRIPTION
This makes it easier to quickly identify replication stream related sessions in the output of SHOW SESSIONS.

Also by including the word "job" and the streamID in the app name, we get a nice side-effect: SQL attaches the app name to the pprof labels and thus these connections show up in the Advanced Debug CPU profile for the producer side job.

<img width="1559" alt="Screenshot 2023-08-20 at 01 06 23" src="https://github.com/cockroachdb/cockroach/assets/852371/ffccb77a-456d-4980-a1dc-de960e2e78d8">


Epic: none

Release note: None