### PR TITLE
sql/execinfrapb: add summaries for physical replication processors

### DIFF
--- a/pkg/sql/execinfrapb/BUILD.bazel
+++ b/pkg/sql/execinfrapb/BUILD.bazel
@@ -79,6 +79,7 @@ go_test(
     deps = [
         "//pkg/base",
         "//pkg/keys",
+        "//pkg/roachpb",
         "//pkg/security/username",
         "//pkg/settings/cluster",
         "//pkg/sql",

--- a/pkg/sql/execinfrapb/flow_diagram.go
+++ b/pkg/sql/execinfrapb/flow_diagram.go
@@ -525,12 +525,49 @@ func (c *ReadImportDataSpec) summary() (string, []string) {
 
 // summary implements the diagramCellType interface.
 func (s *StreamIngestionDataSpec) summary() (string, []string) {
-	return "StreamIngestionData", []string{}
+	const (
+		specLimit = 3
+		spanLimit = 3
+	)
+
+	annotations := []string{
+		"Partitions",
+	}
+
+	// Sort partitions by ID for stable output.
+	srcIDs := make([]string, 0, len(s.PartitionSpecs))
+	for k := range s.PartitionSpecs {
+		srcIDs = append(srcIDs, k)
+	}
+	sort.Strings(srcIDs)
+
+	specCount := 0
+	for _, srcID := range srcIDs {
+		specCount++
+		if specCount > specLimit {
+			annotations = append(annotations, fmt.Sprintf("and %d more partitions", len(s.PartitionSpecs)-specLimit))
+			break
+		}
+		p := s.PartitionSpecs[srcID]
+		var spanDesc string
+		if len(p.Spans) <= spanLimit {
+			spanDesc = fmt.Sprintf("n%s: %v", srcID, p.Spans)
+		} else {
+			spanDesc = fmt.Sprintf("n%s: %v and %d more spans",
+				srcID, p.Spans[:spanLimit], len(p.Spans)-spanLimit)
+		}
+		annotations = append(annotations, spanDesc)
+	}
+
+	return "StreamIngestionData", annotations
 }
 
 // summary implements the diagramCellType interface.
 func (s *StreamIngestionFrontierSpec) summary() (string, []string) {
-	return "StreamIngestionFrontier", []string{}
+	annotations := []string{
+		fmt.Sprintf("streamID: %d", s.StreamID),
+	}
+	return "StreamIngestionFrontier", annotations
 }
 
 // summary implements the diagramCellType interface.


### PR DESCRIPTION
This adds some basic information to distsqlplan nodes for the physical replication processors that lists what source nodes and spans each ingestion processor cares about.

<img width="1111" alt="Screenshot 2023-08-20 at 02 28 31" src="https://github.com/cockroachdb/cockroach/assets/852371/27725f86-687b-4188-93e8-845ea8566fbc">


Epic: none

Release note: None