### PR TITLE
storage: use `uuid.UUID` for `LockTableKey.TxnUUID`

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_query_resolved_timestamp_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_query_resolved_timestamp_test.go
@@ -229,7 +229,7 @@ func TestQueryResolvedTimestampErrors(t *testing.T) {
 	lockTableKey := storage.LockTableKey{
 		Key:      roachpb.Key("a"),
 		Strength: lock.Exclusive,
-		TxnUUID:  txnUUID.GetBytes(),
+		TxnUUID:  txnUUID,
 	}
 	engineKey, buf := lockTableKey.ToEngineKey(nil)
 

--- a/pkg/kv/kvserver/rditer/replica_data_iter_test.go
+++ b/pkg/kv/kvserver/rditer/replica_data_iter_test.go
@@ -111,11 +111,11 @@ func createRangeData(
 		{
 			Key:      keys.RangeDescriptorKey(desc.StartKey), // mark [1] above as intent
 			Strength: lock.Exclusive,
-			TxnUUID:  testTxnID.GetBytes(),
+			TxnUUID:  testTxnID,
 		}, {
 			Key:      desc.StartKey.AsRawKey(), // mark [2] above as intent
 			Strength: lock.Exclusive,
-			TxnUUID:  testTxnID.GetBytes(),
+			TxnUUID:  testTxnID,
 		},
 	}
 

--- a/pkg/storage/engine_key_test.go
+++ b/pkg/storage/engine_key_test.go
@@ -36,13 +36,13 @@ func TestLockTableKeyEncodeDecode(t *testing.T) {
 	testCases := []struct {
 		key LockTableKey
 	}{
-		{key: LockTableKey{Key: roachpb.Key("foo"), Strength: lock.Exclusive, TxnUUID: uuid1[:]}},
-		{key: LockTableKey{Key: roachpb.Key("a"), Strength: lock.Exclusive, TxnUUID: uuid2[:]}},
+		{key: LockTableKey{Key: roachpb.Key("foo"), Strength: lock.Exclusive, TxnUUID: uuid1}},
+		{key: LockTableKey{Key: roachpb.Key("a"), Strength: lock.Exclusive, TxnUUID: uuid2}},
 		// Causes a doubly-local range local key.
 		{key: LockTableKey{
 			Key:      keys.RangeDescriptorKey(roachpb.RKey("baz")),
 			Strength: lock.Exclusive,
-			TxnUUID:  uuid1[:]}},
+			TxnUUID:  uuid1}},
 	}
 	buf := make([]byte, 100)
 	for i, test := range testCases {
@@ -177,14 +177,14 @@ func TestEngineKeyValidate(t *testing.T) {
 			key: LockTableKey{
 				Key:      roachpb.Key("foo"),
 				Strength: lock.Exclusive,
-				TxnUUID:  uuid1[:],
+				TxnUUID:  uuid1,
 			},
 		},
 		{
 			key: LockTableKey{
 				Key:      keys.RangeDescriptorKey(roachpb.RKey("bar")),
 				Strength: lock.Exclusive,
-				TxnUUID:  uuid1[:],
+				TxnUUID:  uuid1,
 			},
 		},
 
@@ -272,7 +272,7 @@ func randomLockTableKey(r *rand.Rand) LockTableKey {
 	}
 	var txnID uuid.UUID
 	txnID.DeterministicV4(r.Uint64(), math.MaxUint64)
-	k.TxnUUID = txnID[:]
+	k.TxnUUID = txnID
 	return k
 }
 

--- a/pkg/storage/intent_interleaving_iter.go
+++ b/pkg/storage/intent_interleaving_iter.go
@@ -543,7 +543,7 @@ func (i *intentInterleavingIter) SeekIntentGE(key roachpb.Key, txnUUID uuid.UUID
 	engineKey, i.intentKeyBuf = LockTableKey{
 		Key:      key,
 		Strength: lock.Exclusive,
-		TxnUUID:  txnUUID[:],
+		TxnUUID:  txnUUID,
 	}.ToEngineKey(i.intentKeyBuf)
 	var limitKey roachpb.Key
 	if i.iterValid && !i.prefix {

--- a/pkg/storage/intent_interleaving_iter_test.go
+++ b/pkg/storage/intent_interleaving_iter_test.go
@@ -294,7 +294,7 @@ func TestIntentInterleavingIter(t *testing.T) {
 								return err.Error()
 							}
 						} else {
-							ltKey := LockTableKey{Key: key, Strength: lock.Exclusive, TxnUUID: txnUUID[:]}
+							ltKey := LockTableKey{Key: key, Strength: lock.Exclusive, TxnUUID: txnUUID}
 							eKey, _ := ltKey.ToEngineKey(nil)
 							if err := batch.PutEngineKey(eKey, val); err != nil {
 								return err.Error()
@@ -521,7 +521,7 @@ func generateRandomData(
 			}
 			val, err := protoutil.Marshal(&meta)
 			require.NoError(t, err)
-			ltKey := LockTableKey{Key: key, Strength: lock.Exclusive, TxnUUID: txnUUID[:]}
+			ltKey := LockTableKey{Key: key, Strength: lock.Exclusive, TxnUUID: txnUUID}
 			lkv = append(lkv, lockKeyValue{
 				key: ltKey, val: val, liveIntent: hasIntent && i == 0})
 			mvcckv = append(mvcckv, MVCCKeyValue{
@@ -781,7 +781,7 @@ func writeBenchData(
 			require.NoError(b, err)
 			if separated {
 				eKey, _ :=
-					LockTableKey{Key: key, Strength: lock.Exclusive, TxnUUID: txnUUID[:]}.ToEngineKey(nil)
+					LockTableKey{Key: key, Strength: lock.Exclusive, TxnUUID: txnUUID}.ToEngineKey(nil)
 				require.NoError(b, batch.PutEngineKey(eKey, val))
 			} else {
 				require.NoError(b, batch.PutUnversioned(key, val))

--- a/pkg/storage/intent_reader_writer.go
+++ b/pkg/storage/intent_reader_writer.go
@@ -43,7 +43,7 @@ func (idw intentDemuxWriter) ClearIntent(
 	engineKey, buf = LockTableKey{
 		Key:      key,
 		Strength: lock.Exclusive,
-		TxnUUID:  txnUUID[:],
+		TxnUUID:  txnUUID,
 	}.ToEngineKey(buf)
 	if txnDidNotUpdateMeta {
 		return buf, idw.w.SingleClearEngineKey(engineKey)
@@ -61,7 +61,7 @@ func (idw intentDemuxWriter) PutIntent(
 	engineKey, buf = LockTableKey{
 		Key:      key,
 		Strength: lock.Exclusive,
-		TxnUUID:  txnUUID[:],
+		TxnUUID:  txnUUID,
 	}.ToEngineKey(buf)
 	return buf, idw.w.PutEngineKey(engineKey, value)
 }

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -6378,6 +6378,16 @@ func computeStatsForIterWithVisitors(
 	return ms, nil
 }
 
+// MVCCIsSpanEmptyOptions configures the MVCCIsSpanEmpty function.
+type MVCCIsSpanEmptyOptions struct {
+	// StartKey determines start of the checked span.
+	StartKey roachpb.Key
+	// EndKey determines the end of exported interval (exclusive).
+	EndKey roachpb.Key
+	// StartTS and EndTS determine the scanned time range as (startTS, endTS].
+	StartTS, EndTS hlc.Timestamp
+}
+
 // MVCCIsSpanEmpty returns true if there are no MVCC keys whatsoever in the key
 // span in the requested time interval. If a time interval is given and any
 // inline values are encountered, an error may be returned.
@@ -6954,16 +6964,6 @@ type MVCCExportFingerprintOptions struct {
 	StripIndexPrefixAndTimestamp bool
 }
 
-// MVCCIsSpanEmptyOptions configures the MVCCIsSpanEmpty function.
-type MVCCIsSpanEmptyOptions struct {
-	// StartKey determines start of the checked span.
-	StartKey roachpb.Key
-	// EndKey determines the end of exported interval (exclusive).
-	EndKey roachpb.Key
-	// StartTS and EndTS determine the scanned time range as (startTS, endTS].
-	StartTS, EndTS hlc.Timestamp
-}
-
 // PeekRangeKeysLeft peeks for any range keys to the left of the given key.
 // It returns the relative position of any range keys to the peek key, along
 // with the (unsafe) range key stack:
@@ -7161,7 +7161,7 @@ func ReplacePointTombstonesWithRangeTombstones(
 
 // In order to test the correctness of range deletion tombstones, we added a
 // testing knob to replace point deletions with range deletion tombstones in
-// some tests. Unfortuantely, doing so affects the correctness of rangefeeds.
+// some tests. Unfortunately, doing so affects the correctness of rangefeeds.
 // The tests in question do not use rangefeeds, but some system functionality
 // does use rangefeeds internally. The primary impact is that catch-up scans
 // will miss deletes. That makes these issues rare and hard to detect. In order

--- a/pkg/storage/pebble_test.go
+++ b/pkg/storage/pebble_test.go
@@ -586,7 +586,7 @@ func TestPebbleMVCCTimeIntervalCollector(t *testing.T) {
 	// Nothing added.
 	finishAndCheck(0, 0)
 	uuid := uuid.Must(uuid.FromString("6ba7b810-9dad-11d1-80b4-00c04fd430c8"))
-	ek, _ := LockTableKey{aKey, lock.Exclusive, uuid[:]}.ToEngineKey(nil)
+	ek, _ := LockTableKey{aKey, lock.Exclusive, uuid}.ToEngineKey(nil)
 	require.NoError(t, collector.Add(pebble.InternalKey{UserKey: ek.Encode()}, []byte("foo")))
 	// The added key was not an MVCCKey.
 	finishAndCheck(0, 0)
@@ -1204,7 +1204,7 @@ func TestShortAttributeExtractor(t *testing.T) {
 
 	var txnUUID [uuid.Size]byte
 	lockKey, _ := LockTableKey{
-		Key: roachpb.Key("a"), Strength: lock.Exclusive, TxnUUID: txnUUID[:]}.ToEngineKey(nil)
+		Key: roachpb.Key("a"), Strength: lock.Exclusive, TxnUUID: txnUUID}.ToEngineKey(nil)
 	v := MVCCValue{}
 	tombstoneVal, err := EncodeMVCCValue(v)
 	require.NoError(t, err)


### PR DESCRIPTION
This commit changes `LockTableKey.TxnUUID` from a `[]byte` to a `uuid.UUID`.

The field was a byte slice "to avoid copying a slice when decoding". This reasoning did not make much sense though, because the uuid slice was only 16 bytes in size. A slice header is 24 bytes, so using a uuid results in less copying. This is all presumably negligible though, so we make this change to make LockTableKey easier to work with.

Epic: None
Release note: None