### PR TITLE
sql: fix a leftover bug

### DIFF
--- a/pkg/sql/tenant_settings.go
+++ b/pkg/sql/tenant_settings.go
@@ -121,7 +121,7 @@ func (n *alterTenantSetClusterSettingNode) startExec(params runParams) error {
 		if _, err := params.p.InternalSQLTxn().ExecEx(
 			params.ctx, "reset-tenant-setting", params.p.Txn(),
 			sessiondata.RootUserSessionDataOverride,
-			"DELETE FROM system.tenant_settings WHERE tenant_id = $1 AND name = $2", tenantID, n.name,
+			"DELETE FROM system.tenant_settings WHERE tenant_id = $1 AND name = $2", tenantID, n.setting.InternalKey(),
 		); err != nil {
 			return err
 		}
@@ -139,7 +139,7 @@ func (n *alterTenantSetClusterSettingNode) startExec(params runParams) error {
 			params.ctx, "update-tenant-setting", params.p.Txn(),
 			sessiondata.RootUserSessionDataOverride,
 			`UPSERT INTO system.tenant_settings (tenant_id, name, value, last_updated, value_type) VALUES ($1, $2, $3, now(), $4)`,
-			tenantID, n.name, encoded, n.setting.Typ(),
+			tenantID, n.setting.InternalKey(), encoded, n.setting.Typ(),
 		); err != nil {
 			return err
 		}


### PR DESCRIPTION
This (hidden) bug was left over from #108902.
There is no visible negative effect to this bug being present until setting aliases are effectively introduced, which hasn't happened yet.

No tests included here -- this is exercised by #109077 and #109074 and the CI in those PRs readily fail without this fix.

 Epic: CRDB-27642