### PR TITLE
roachprod: use correct ($os-$arch) suffix for staging arm64 workload …

### DIFF
--- a/pkg/roachprod/install/staging.go
+++ b/pkg/roachprod/install/staging.go
@@ -212,9 +212,14 @@ func StageApplication(
 		}
 		return nil
 	case "workload":
-		// N.B. workload binary is only available for linux amd64: https://github.com/cockroachdb/cockroach/issues/103563
+		// N.B. After https://github.com/cockroachdb/cockroach/issues/103563, only arm64 build uses the $os-$arch suffix.
+		// E.g., workload.LATEST is for linux-amd64, workload.linux-gnu-arm64.LATEST is for linux-arm64.
+		archSuffix := ""
+		if arch == vm.ArchARM64 {
+			archSuffix = archInfo.DebugArchitecture
+		}
 		err := stageRemoteBinary(
-			ctx, l, c, applicationName, "cockroach/workload", version, "" /* arch */, destDir,
+			ctx, l, c, applicationName, "cockroach/workload", version, archSuffix, destDir,
 		)
 		return err
 	case "release":
@@ -256,8 +261,13 @@ func URLsForApplication(
 		}
 		return urls, nil
 	case "workload":
-		// N.B. workload binary is only available for linux amd64: https://github.com/cockroachdb/cockroach/issues/103563
-		u, err := getEdgeURL("cockroach/workload", version, "" /* arch */, "" /* extension */)
+		// N.B. After https://github.com/cockroachdb/cockroach/issues/103563, only arm64 build uses the $os-$arch suffix.
+		// E.g., workload.LATEST is for linux-amd64, workload.linux-gnu-arm64.LATEST is for linux-arm64.
+		archSuffix := ""
+		if arch == vm.ArchARM64 {
+			archSuffix = archInfo.DebugArchitecture
+		}
+		u, err := getEdgeURL("cockroach/workload", version, archSuffix, "" /* extension */)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/roachprod/install/staging_test.go
+++ b/pkg/roachprod/install/staging_test.go
@@ -109,6 +109,18 @@ func TestURLsForApplication(t *testing.T) {
 			},
 		},
 		{
+			name: "workload",
+			args: args{
+				application: "workload",
+				version:     "563ea3967c98c67d47ede30d895c82315e4b1a77",
+				os:          "linux",
+				arch:        "arm64",
+			},
+			want: []string{
+				"https://storage.googleapis.com/cockroach-edge-artifacts-prod/cockroach/workload.linux-gnu-arm64.563ea3967c98c67d47ede30d895c82315e4b1a77",
+			},
+		},
+		{
 			name: "cockroach linux latest",
 			args: args{
 				application: "cockroach",


### PR DESCRIPTION
…binary

Prior to [1], workload binaries didn't have $os-$arch suffix. Now, only arm64 workload binaries have the suffix. E.g.,
```
workload.LATEST
workload.linux-gnu-arm64.LATEST
```
Update roachprod stage and stageurl accordingly.

Epic: none
Release note: None

[1] https://github.com/cockroachdb/cockroach/issues/103563