### PR TITLE
kv: rename `WriteIntentError` to `LockConflictError`

### DIFF
--- a/pkg/ccl/backupccl/backup_processor.go
+++ b/pkg/ccl/backupccl/backup_processor.go
@@ -401,7 +401,7 @@ func runBackupProcessor(
 	defer logClose(ctx, storage, "external storage")
 
 	// Start start a group of goroutines which each pull spans off of `todo` and
-	// send export requests. Any spans that encounter write intent errors during
+	// send export requests. Any spans that encounter lock conflict errors during
 	// Export are put back on the todo queue for later processing.
 	numSenders, release, err := reserveWorkerMemory(ctx, clusterSettings, memAcc)
 	if err != nil {
@@ -527,13 +527,13 @@ func runBackupProcessor(
 							return nil
 						})
 					if exportRequestErr != nil {
-						if intentErr, ok := pErr.GetDetail().(*kvpb.WriteIntentError); ok {
+						if lockErr, ok := pErr.GetDetail().(*kvpb.LockConflictError); ok {
 							span.lastTried = timeutil.Now()
 							span.attempts++
 							todo <- span
 							// TODO(dt): send a progress update to update job progress to note
 							// the intents being hit.
-							log.VEventf(ctx, 1, "retrying ExportRequest for span %s; encountered WriteIntentError: %s", span.span, intentErr.Error())
+							log.VEventf(ctx, 1, "retrying ExportRequest for span %s; encountered LockConflictError: %s", span.span, lockErr.Error())
 							span = spanAndTime{}
 							continue
 						}

--- a/pkg/kv/kvclient/kvcoord/dist_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_test.go
@@ -3661,7 +3661,7 @@ func TestMultipleErrorsMerged(t *testing.T) {
 	retryErr := kvpb.NewTransactionRetryError(kvpb.RETRY_SERIALIZABLE, "test err")
 	abortErr := kvpb.NewTransactionAbortedError(kvpb.ABORT_REASON_ABORTED_RECORD_FOUND)
 	conditionFailedErr := &kvpb.ConditionFailedError{}
-	writeIntentErr := &kvpb.WriteIntentError{}
+	lockConflictErr := &kvpb.LockConflictError{}
 	sendErr := &sendError{}
 	ambiguousErr := &kvpb.AmbiguousResultError{}
 	randomErr := &kvpb.IntegerOverflowError{}
@@ -3732,19 +3732,19 @@ func TestMultipleErrorsMerged(t *testing.T) {
 			err2:   randomErr,
 			expErr: "results in overflow",
 		},
-		// WriteIntentError also has a low score since it's "not ambiguous".
+		// LockConflictError also has a low score since it's "not ambiguous".
 		{
-			err1:   writeIntentErr,
+			err1:   lockConflictErr,
 			err2:   ambiguousErr,
 			expErr: "result is ambiguous",
 		},
 		{
-			err1:   writeIntentErr,
+			err1:   lockConflictErr,
 			err2:   sendErr,
 			expErr: "failed to send RPC",
 		},
 		{
-			err1:   writeIntentErr,
+			err1:   lockConflictErr,
 			err2:   randomErr,
 			expErr: "results in overflow",
 		},

--- a/pkg/kv/kvclient/kvcoord/testdata/savepoints
+++ b/pkg/kv/kvclient/kvcoord/testdata/savepoints
@@ -396,7 +396,7 @@ savepoint x
 
 get conflict-key locking nowait
 ----
-(*kvpb.LockConflictError) conflicting intents on "conflict-key" [reason=wait_policy]
+(*kvpb.LockConflictError) conflicting locks on "conflict-key" [reason=wait_policy]
 
 rollback x
 ----
@@ -404,7 +404,7 @@ rollback x
 
 put conflict-key b nowait
 ----
-(*kvpb.LockConflictError) conflicting intents on "conflict-key" [reason=wait_policy]
+(*kvpb.LockConflictError) conflicting locks on "conflict-key" [reason=wait_policy]
 
 rollback x
 ----
@@ -437,7 +437,7 @@ savepoint x
 
 get conflict-key-2 lock-timeout
 ----
-(*kvpb.LockConflictError) conflicting intents on "conflict-key-2" [reason=lock_timeout]
+(*kvpb.LockConflictError) conflicting locks on "conflict-key-2" [reason=lock_timeout]
 
 rollback x
 ----
@@ -445,7 +445,7 @@ rollback x
 
 put conflict-key-2 b lock-timeout
 ----
-(*kvpb.LockConflictError) conflicting intents on "conflict-key-2" [reason=lock_timeout]
+(*kvpb.LockConflictError) conflicting locks on "conflict-key-2" [reason=lock_timeout]
 
 rollback x
 ----

--- a/pkg/kv/kvclient/kvcoord/testdata/savepoints
+++ b/pkg/kv/kvclient/kvcoord/testdata/savepoints
@@ -396,7 +396,7 @@ savepoint x
 
 get conflict-key locking nowait
 ----
-(*kvpb.WriteIntentError) conflicting intents on "conflict-key" [reason=wait_policy]
+(*kvpb.LockConflictError) conflicting intents on "conflict-key" [reason=wait_policy]
 
 rollback x
 ----
@@ -404,7 +404,7 @@ rollback x
 
 put conflict-key b nowait
 ----
-(*kvpb.WriteIntentError) conflicting intents on "conflict-key" [reason=wait_policy]
+(*kvpb.LockConflictError) conflicting intents on "conflict-key" [reason=wait_policy]
 
 rollback x
 ----
@@ -437,7 +437,7 @@ savepoint x
 
 get conflict-key-2 lock-timeout
 ----
-(*kvpb.WriteIntentError) conflicting intents on "conflict-key-2" [reason=lock_timeout]
+(*kvpb.LockConflictError) conflicting intents on "conflict-key-2" [reason=lock_timeout]
 
 rollback x
 ----
@@ -445,7 +445,7 @@ rollback x
 
 put conflict-key-2 b lock-timeout
 ----
-(*kvpb.WriteIntentError) conflicting intents on "conflict-key-2" [reason=lock_timeout]
+(*kvpb.LockConflictError) conflicting intents on "conflict-key-2" [reason=lock_timeout]
 
 rollback x
 ----

--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender_savepoints.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender_savepoints.go
@@ -107,7 +107,7 @@ func (tc *TxnCoordSender) RollbackToSavepoint(ctx context.Context, s kv.Savepoin
 	}
 
 	// We don't allow rollback to savepoint after errors (except after
-	// ConditionFailedError and WriteIntentError, which are special-cased
+	// ConditionFailedError and LockConflictError, which are special-cased
 	// elsewhere and don't move the txn to the txnError state). In particular, we
 	// cannot allow rollbacks to savepoint after ambiguous errors where it's
 	// possible for a previously-successfully written intent to have been pushed

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_pipeliner.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_pipeliner.go
@@ -658,8 +658,8 @@ func (tp *txnPipeliner) updateLockTrackingInner(
 		// locks, we ignore that request for the purposes of accounting for lock
 		// spans. This is important for transactions that only perform a single
 		// request and hit an unambiguous error like a ConditionFailedError, as it
-		// can allow them to avoid sending a rollback. It it also important for
-		// transactions that throw a WriteIntentError due to heavy contention on a
+		// can allow them to avoid sending a rollback. It is also important for
+		// transactions that throw a LockConflictError due to heavy contention on a
 		// certain key after either passing a Error wait policy or hitting a lock
 		// timeout / queue depth limit. In such cases, this optimization prevents
 		// these transactions from adding even more load to the contended key by

--- a/pkg/kv/kvclient/kvcoord/txn_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_test.go
@@ -1043,9 +1043,9 @@ func TestTxnContinueAfterCputError(t *testing.T) {
 }
 
 // Test that a transaction can be used after a locking request returns a
-// WriteIntentError. This is not generally allowed for other errors, but
-// WriteIntentError is special.
-func TestTxnContinueAfterWriteIntentError(t *testing.T) {
+// LockConflictError. This is not generally allowed for other errors, but
+// a LockConflictError is special.
+func TestTxnContinueAfterLockConflictError(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
@@ -1061,7 +1061,7 @@ func TestTxnContinueAfterWriteIntentError(t *testing.T) {
 	b.Header.WaitPolicy = lock.WaitPolicy_Error
 	b.Put("a", "c")
 	err := txn.Run(ctx, b)
-	require.IsType(t, &kvpb.WriteIntentError{}, err)
+	require.IsType(t, &kvpb.LockConflictError{}, err)
 
 	require.NoError(t, txn.Put(ctx, "a'", "c"))
 	require.NoError(t, txn.Commit(ctx))
@@ -1122,9 +1122,9 @@ func TestTxnWaitPolicies(t *testing.T) {
 		// Priority does not matter.
 		err := <-errorC
 		require.NotNil(t, err)
-		wiErr := new(kvpb.WriteIntentError)
-		require.True(t, errors.As(err, &wiErr))
-		require.Equal(t, kvpb.WriteIntentError_REASON_WAIT_POLICY, wiErr.Reason)
+		lcErr := new(kvpb.LockConflictError)
+		require.True(t, errors.As(err, &lcErr))
+		require.Equal(t, kvpb.LockConflictError_REASON_WAIT_POLICY, lcErr.Reason)
 
 		// SkipLocked wait policy.
 		type skipRes struct {
@@ -1174,9 +1174,9 @@ func TestTxnLockTimeout(t *testing.T) {
 	b.Get(key)
 	err := s.DB.Run(ctx, &b)
 	require.NotNil(t, err)
-	wiErr := new(kvpb.WriteIntentError)
-	require.True(t, errors.As(err, &wiErr))
-	require.Equal(t, kvpb.WriteIntentError_REASON_LOCK_TIMEOUT, wiErr.Reason)
+	lcErr := new(kvpb.LockConflictError)
+	require.True(t, errors.As(err, &lcErr))
+	require.Equal(t, kvpb.LockConflictError_REASON_LOCK_TIMEOUT, lcErr.Reason)
 }
 
 // TestTxnReturnsWriteTooOldErrorOnConflictingDeleteRange tests that if two

--- a/pkg/kv/kvpb/api.proto
+++ b/pkg/kv/kvpb/api.proto
@@ -83,7 +83,7 @@ enum ResumeReason {
   // NB: 21.2 and below will return RESUME_KEY_LIMIT instead.
   RESUME_BYTE_LIMIT = 2;
   // An intent limit was exceeded. This is currently never returned to clients,
-  // since MVCCScan converts the result into a WriteIntentError.
+  // since MVCCScan converts the result into a LockConflictError.
   // NB: 21.2 and below will return RESUME_KEY_LIMIT instead.
   RESUME_INTENT_LIMIT = 3;
   // The DistSender encountered a range boundary and returned a partial result,
@@ -2525,7 +2525,7 @@ message Header {
   // encounters a conflicting lock held by another active transaction.
   //
   // If an Error wait policy is set and a conflicting lock held by an active
-  // transaction is encountered, a WriteIntentError will be returned.
+  // transaction is encountered, a LockConflictError will be returned.
   //
   // If a SkipLocked wait policy is set and a conflicting lock held by an active
   // transaction is encountered, the corresponding key is not included in the
@@ -2539,7 +2539,7 @@ message Header {
   // will wait while attempting to acquire a lock on a key or while blocking on
   // an existing lock in order to perform a non-locking read on a key. The time
   // limit applies separately to each lock acquisition attempt. If the timeout
-  // elapses when waiting for a lock, a WriteIntentError will be returned.
+  // elapses when waiting for a lock, a LockConflictError will be returned.
   //
   // Unlike in some other systems like PostgreSQL, where non-locking reads do
   // not wait on conflicting locks, in CockroachDB, non-locking reads do wait

--- a/pkg/kv/kvpb/batch_generated.go
+++ b/pkg/kv/kvpb/batch_generated.go
@@ -28,8 +28,8 @@ func (ru ErrorDetail) GetInner() error {
 		return t.TransactionRetry
 	case *ErrorDetail_TransactionStatus:
 		return t.TransactionStatus
-	case *ErrorDetail_WriteIntent:
-		return t.WriteIntent
+	case *ErrorDetail_LockConflict:
+		return t.LockConflict
 	case *ErrorDetail_WriteTooOld:
 		return t.WriteTooOld
 	case *ErrorDetail_OpRequiresTxn:
@@ -310,8 +310,8 @@ func (ru *ErrorDetail) MustSetInner(r error) {
 		union = &ErrorDetail_TransactionRetry{t}
 	case *TransactionStatusError:
 		union = &ErrorDetail_TransactionStatus{t}
-	case *WriteIntentError:
-		union = &ErrorDetail_WriteIntent{t}
+	case *LockConflictError:
+		union = &ErrorDetail_LockConflict{t}
 	case *WriteTooOldError:
 		union = &ErrorDetail_WriteTooOld{t}
 	case *OpRequiresTxnError:

--- a/pkg/kv/kvpb/errordetailtype_string.go
+++ b/pkg/kv/kvpb/errordetailtype_string.go
@@ -16,7 +16,7 @@ func _() {
 	_ = x[TransactionPushErrType-6]
 	_ = x[TransactionRetryErrType-7]
 	_ = x[TransactionStatusErrType-8]
-	_ = x[WriteIntentErrType-9]
+	_ = x[LockConflictErrType-9]
 	_ = x[WriteTooOldErrType-10]
 	_ = x[OpRequiresTxnErrType-11]
 	_ = x[ConditionFailedErrType-12]
@@ -63,8 +63,8 @@ func (i ErrorDetailType) String() string {
 		return "TransactionRetryErrType"
 	case TransactionStatusErrType:
 		return "TransactionStatusErrType"
-	case WriteIntentErrType:
-		return "WriteIntentErrType"
+	case LockConflictErrType:
+		return "LockConflictErrType"
 	case WriteTooOldErrType:
 		return "WriteTooOldErrType"
 	case OpRequiresTxnErrType:

--- a/pkg/kv/kvpb/errors.go
+++ b/pkg/kv/kvpb/errors.go
@@ -922,17 +922,18 @@ func (e *LockConflictError) SafeFormatError(p errors.Printer) (next error) {
 }
 
 func (e *LockConflictError) printError(buf Printer) {
+	// TODO(nvanbenschoten): s/intent/lock/ below.
 	buf.Printf("conflicting intents on ")
 
-	// If we have a lot of intents, we only want to show the first and the last.
+	// If we have a lot of locks, we only want to show the first and the last.
 	const maxBegin = 5
 	const maxEnd = 5
 	var begin, end []roachpb.Intent
-	if len(e.Intents) <= maxBegin+maxEnd {
-		begin = e.Intents
+	if len(e.Locks) <= maxBegin+maxEnd {
+		begin = e.Locks
 	} else {
-		begin = e.Intents[0:maxBegin]
-		end = e.Intents[len(e.Intents)-maxEnd : len(e.Intents)]
+		begin = e.Locks[0:maxBegin]
+		end = e.Locks[len(e.Locks)-maxEnd : len(e.Locks)]
 	}
 
 	for i := range begin {

--- a/pkg/kv/kvpb/errors.go
+++ b/pkg/kv/kvpb/errors.go
@@ -922,8 +922,7 @@ func (e *LockConflictError) SafeFormatError(p errors.Printer) (next error) {
 }
 
 func (e *LockConflictError) printError(buf Printer) {
-	// TODO(nvanbenschoten): s/intent/lock/ below.
-	buf.Printf("conflicting intents on ")
+	buf.Printf("conflicting locks on ")
 
 	// If we have a lot of locks, we only want to show the first and the last.
 	const maxBegin = 5

--- a/pkg/kv/kvpb/errors.go
+++ b/pkg/kv/kvpb/errors.go
@@ -100,7 +100,7 @@ const (
 	// written. We allow the transaction to continue after such errors; we also
 	// allow RollbackToSavepoint() to be called after such errors. In particular,
 	// this is useful for SQL which wants to allow rolling back to a savepoint
-	// after ConditionFailedErrors (uniqueness violations) and WriteIntentError
+	// after ConditionFailedErrors (uniqueness violations) and LockConflictError
 	// (lock not available errors). With continuing after errors it's important
 	// for the coordinator to track the timestamp at which intents might have been
 	// written.
@@ -152,10 +152,10 @@ func ErrPriority(err error) ErrorPriority {
 			return ErrorScoreTxnAbort
 		}
 		return ErrorScoreTxnRestart
-	case *ConditionFailedError, *WriteIntentError:
+	case *ConditionFailedError, *LockConflictError:
 		// We particularly care about returning the low ErrorScoreUnambiguousError
 		// because we don't want to transition a transaction that encounters a
-		// ConditionFailedError or a WriteIntentError to an error state. More
+		// ConditionFailedError or a LockConflictError to an error state. More
 		// specifically, we want to allow rollbacks to savepoint after one of these
 		// errors.
 		return ErrorScoreUnambiguousError
@@ -272,7 +272,7 @@ const (
 	TransactionPushErrType                  ErrorDetailType = 6
 	TransactionRetryErrType                 ErrorDetailType = 7
 	TransactionStatusErrType                ErrorDetailType = 8
-	WriteIntentErrType                      ErrorDetailType = 9
+	LockConflictErrType                     ErrorDetailType = 9
 	WriteTooOldErrType                      ErrorDetailType = 10
 	OpRequiresTxnErrType                    ErrorDetailType = 11
 	ConditionFailedErrType                  ErrorDetailType = 12
@@ -323,7 +323,7 @@ func init() {
 	errors.RegisterTypeMigration(roachpbPath, "*roachpb.TransactionPushError", &TransactionPushError{})
 	errors.RegisterTypeMigration(roachpbPath, "*roachpb.TransactionRetryError", &TransactionRetryError{})
 	errors.RegisterTypeMigration(roachpbPath, "*roachpb.TransactionStatusError", &TransactionStatusError{})
-	errors.RegisterTypeMigration(roachpbPath, "*roachpb.WriteIntentError", &WriteIntentError{})
+	errors.RegisterTypeMigration(roachpbPath, "*roachpb.WriteIntentError", &LockConflictError{})
 	errors.RegisterTypeMigration(roachpbPath, "*roachpb.WriteTooOldError", &WriteTooOldError{})
 	errors.RegisterTypeMigration(roachpbPath, "*roachpb.OpRequiresTxnError", &OpRequiresTxnError{})
 	errors.RegisterTypeMigration(roachpbPath, "*roachpb.ConditionFailedError", &ConditionFailedError{})
@@ -912,16 +912,16 @@ func (e *TransactionStatusError) SafeFormatError(p errors.Printer) (next error) 
 
 var _ ErrorDetailInterface = &TransactionStatusError{}
 
-func (e *WriteIntentError) Error() string {
+func (e *LockConflictError) Error() string {
 	return redact.Sprint(e).StripMarkers()
 }
 
-func (e *WriteIntentError) SafeFormatError(p errors.Printer) (next error) {
+func (e *LockConflictError) SafeFormatError(p errors.Printer) (next error) {
 	e.printError(p)
 	return nil
 }
 
-func (e *WriteIntentError) printError(buf Printer) {
+func (e *LockConflictError) printError(buf Printer) {
 	buf.Printf("conflicting intents on ")
 
 	// If we have a lot of intents, we only want to show the first and the last.
@@ -952,13 +952,13 @@ func (e *WriteIntentError) printError(buf Printer) {
 	}
 
 	switch e.Reason {
-	case WriteIntentError_REASON_UNSPECIFIED:
+	case LockConflictError_REASON_UNSPECIFIED:
 		// Nothing to say.
-	case WriteIntentError_REASON_WAIT_POLICY:
+	case LockConflictError_REASON_WAIT_POLICY:
 		buf.Printf(" [reason=wait_policy]")
-	case WriteIntentError_REASON_LOCK_TIMEOUT:
+	case LockConflictError_REASON_LOCK_TIMEOUT:
 		buf.Printf(" [reason=lock_timeout]")
-	case WriteIntentError_REASON_LOCK_WAIT_QUEUE_MAX_LENGTH_EXCEEDED:
+	case LockConflictError_REASON_LOCK_WAIT_QUEUE_MAX_LENGTH_EXCEEDED:
 		buf.Printf(" [reason=lock_wait_queue_max_length_exceeded]")
 	default:
 		// Could panic, better to silently ignore in case new reasons are added.
@@ -966,11 +966,11 @@ func (e *WriteIntentError) printError(buf Printer) {
 }
 
 // Type is part of the ErrorDetailInterface.
-func (e *WriteIntentError) Type() ErrorDetailType {
-	return WriteIntentErrType
+func (e *LockConflictError) Type() ErrorDetailType {
+	return LockConflictErrType
 }
 
-var _ ErrorDetailInterface = &WriteIntentError{}
+var _ ErrorDetailInterface = &LockConflictError{}
 
 // NewWriteTooOldError creates a new write too old error. The function accepts
 // the timestamp of the operation that hit the error, along with the timestamp
@@ -1642,7 +1642,7 @@ var _ errors.SafeFormatter = &TransactionAbortedError{}
 var _ errors.SafeFormatter = &TransactionPushError{}
 var _ errors.SafeFormatter = &TransactionRetryError{}
 var _ errors.SafeFormatter = &TransactionStatusError{}
-var _ errors.SafeFormatter = &WriteIntentError{}
+var _ errors.SafeFormatter = &LockConflictError{}
 var _ errors.SafeFormatter = &WriteTooOldError{}
 var _ errors.SafeFormatter = &OpRequiresTxnError{}
 var _ errors.SafeFormatter = &ConditionFailedError{}

--- a/pkg/kv/kvpb/errors.proto
+++ b/pkg/kv/kvpb/errors.proto
@@ -331,7 +331,9 @@ message TransactionStatusError {
 // there's no ambiguity; the error carries a WriteTimestamp that's the
 // upper bound of the timestamps intents were written at.
 message LockConflictError {
-  repeated roachpb.Intent intents = 1 [(gogoproto.nullable) = false];
+  // TODO(nvanbenschoten): rename roachpb.Intent to roachpb.Lock and add a
+  // lock.Strength field.
+  repeated roachpb.Intent locks = 1 [(gogoproto.nullable) = false];
   reserved 2;
   // The sequence of the lease that the operation which hit this error was
   // operating under. Used on the server to avoid adding discovered locks

--- a/pkg/kv/kvpb/errors.proto
+++ b/pkg/kv/kvpb/errors.proto
@@ -297,25 +297,25 @@ message TransactionStatusError {
   optional string msg_redactable = 3 [(gogoproto.nullable) = false, (gogoproto.customtype) = "github.com/cockroachdb/redact.RedactableString"];
 }
 
-// A WriteIntentError indicates that one or more write intents belonging
+// A LockConflictError indicates that one or more locks belonging
 // to another transaction were encountered, leading to a read/write or
-// write/write conflict. The keys at which the intents were encountered
-// are set, as are the txn metas for the intents' transactions.
+// write/write conflict. The keys at which the locks were encountered
+// are set, as are the txn metas for the locks' transactions.
 //
-// WriteIntentErrors are used at two different levels of the system. In
+// LockConflictErrors are used at two different levels of the system. In
 // both cases, they have the same meaning — that an intent or lock (an
 // intent is a form of replicated lock) is preventing an operation from
 // completing.
 //
 // First, they are returned from MVCC during request evaluation when a
-// request finds a conflicting intent. A WriteIntentError is propagated
+// request finds a conflicting lock. A LockConflictError is propagated
 // up through the Replica to the corresponding lock table and passed to
 // its AddDiscoveredLock method. This informs the lock table about the
-// intent(s) and allows the request to handle the conflicts through a
+// lock(s) and allows the request to handle the conflicts through a
 // combination of waiting and pushing in the concurrency manager. See
 // concurrency_control.go for an explanation and diagram of the flow.
 //
-// Second, WriteIntentErrors are returned from the concurrency manager
+// Second, LockConflictErrors are returned from the concurrency manager
 // for intents/locks that conflict with a request and are not handled.
 // This is typically because the request was configured with an Error
 // wait policy instead of a Block wait policy, so it is opting to fail
@@ -324,13 +324,13 @@ message TransactionStatusError {
 // they are converted to a LockNotAvailable error.
 //
 // Note that the KV client is free to send more requests after a
-// WriteIntentError. This is not generally allowed after other errors
+// LockConflictError. This is not generally allowed after other errors
 // because of fears over the ambiguity of the side-effects of failed
 // requests (in particular, the timestamps at which intents might have
-// been written). WriteIntentError is a special case as we ensure
+// been written). LockConflictError is a special case as we ensure
 // there's no ambiguity; the error carries a WriteTimestamp that's the
 // upper bound of the timestamps intents were written at.
-message WriteIntentError {
+message LockConflictError {
   repeated roachpb.Intent intents = 1 [(gogoproto.nullable) = false];
   reserved 2;
   // The sequence of the lease that the operation which hit this error was
@@ -339,7 +339,7 @@ message WriteIntentError {
   optional int64 lease_sequence = 3 [(gogoproto.nullable) = false,
     (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/roachpb.LeaseSequence"];
   enum Reason {
-    // The reason for the WriteIntentError is unspecified. This will
+    // The reason for the LockConflictError is unspecified. This will
     // always be the case for errors returned from MVCC.
     REASON_UNSPECIFIED = 0;
     // The request used an Error wait policy because it did not want to
@@ -352,7 +352,7 @@ message WriteIntentError {
     // already equal to or exceeding the configured maximum.
     REASON_LOCK_WAIT_QUEUE_MAX_LENGTH_EXCEEDED = 3;
   }
-  // The reason for the error. Applies to WriteIntentErrors that are
+  // The reason for the error. Applies to LockConflictErrors that are
   // returned from the concurrency manager (the second use described
   // above).
   optional Reason reason = 4 [(gogoproto.nullable) = false];
@@ -684,7 +684,7 @@ message ErrorDetail {
     TransactionPushError transaction_push = 6;
     TransactionRetryError transaction_retry = 7;
     TransactionStatusError transaction_status = 8;
-    WriteIntentError write_intent = 9;
+    LockConflictError lock_conflict = 9;
     WriteTooOldError write_too_old = 10;
     OpRequiresTxnError op_requires_txn = 11;
     ConditionFailedError condition_failed = 12;

--- a/pkg/kv/kvpb/errors_test.go
+++ b/pkg/kv/kvpb/errors_test.go
@@ -229,7 +229,7 @@ func TestErrorRedaction(t *testing.T) {
 		},
 		{
 			err:    &LockConflictError{},
-			expect: "conflicting intents on ",
+			expect: "conflicting locks on ",
 		},
 		{
 			err:    &WriteTooOldError{},

--- a/pkg/kv/kvpb/errors_test.go
+++ b/pkg/kv/kvpb/errors_test.go
@@ -228,7 +228,7 @@ func TestErrorRedaction(t *testing.T) {
 			expect: "TransactionStatusError:  (REASON_UNKNOWN)",
 		},
 		{
-			err:    &WriteIntentError{},
+			err:    &LockConflictError{},
 			expect: "conflicting intents on ",
 		},
 		{

--- a/pkg/kv/kvserver/addressing_test.go
+++ b/pkg/kv/kvserver/addressing_test.go
@@ -173,7 +173,7 @@ func TestUpdateRangeAddressing(t *testing.T) {
 				hlc.MaxTimestamp, storage.MVCCScanOptions{})
 			if err != nil {
 				// Wait for the intent to be resolved.
-				if errors.HasType(err, (*kvpb.WriteIntentError)(nil)) {
+				if errors.HasType(err, (*kvpb.LockConflictError)(nil)) {
 					return err
 				}
 				t.Fatal(err)

--- a/pkg/kv/kvserver/batcheval/cmd_add_sstable.go
+++ b/pkg/kv/kvserver/batcheval/cmd_add_sstable.go
@@ -228,7 +228,7 @@ func EvalAddSSTable(
 	if checkConflicts {
 		// If requested, check for MVCC conflicts with existing keys. This enforces
 		// all MVCC invariants by returning WriteTooOldError for any existing
-		// values at or above the SST timestamp, returning WriteIntentError to
+		// values at or above the SST timestamp, returning LockConflictError to
 		// resolve any encountered intents, and accurately updating MVCC stats.
 		//
 		// Additionally, if DisallowShadowing or DisallowShadowingBelow is set, it
@@ -273,7 +273,7 @@ func EvalAddSSTable(
 		if err != nil {
 			return result.Result{}, errors.Wrap(err, "scanning intents")
 		} else if len(intents) > 0 {
-			return result.Result{}, &kvpb.WriteIntentError{Intents: intents}
+			return result.Result{}, &kvpb.LockConflictError{Intents: intents}
 		}
 	}
 

--- a/pkg/kv/kvserver/batcheval/cmd_add_sstable.go
+++ b/pkg/kv/kvserver/batcheval/cmd_add_sstable.go
@@ -273,7 +273,7 @@ func EvalAddSSTable(
 		if err != nil {
 			return result.Result{}, errors.Wrap(err, "scanning intents")
 		} else if len(intents) > 0 {
-			return result.Result{}, &kvpb.LockConflictError{Intents: intents}
+			return result.Result{}, &kvpb.LockConflictError{Locks: intents}
 		}
 	}
 

--- a/pkg/kv/kvserver/batcheval/cmd_add_sstable.go
+++ b/pkg/kv/kvserver/batcheval/cmd_add_sstable.go
@@ -222,7 +222,7 @@ func EvalAddSSTable(
 	}
 
 	var statsDelta enginepb.MVCCStats
-	maxIntents := storage.MaxIntentsPerWriteIntentError.Get(&cArgs.EvalCtx.ClusterSettings().SV)
+	maxIntents := storage.MaxIntentsPerLockConflictError.Get(&cArgs.EvalCtx.ClusterSettings().SV)
 	checkConflicts := args.DisallowConflicts || args.DisallowShadowing ||
 		!args.DisallowShadowingBelow.IsEmpty()
 	if checkConflicts {

--- a/pkg/kv/kvserver/batcheval/cmd_clear_range.go
+++ b/pkg/kv/kvserver/batcheval/cmd_clear_range.go
@@ -117,7 +117,7 @@ func ClearRange(
 	if err != nil {
 		return result.Result{}, err
 	} else if len(intents) > 0 {
-		return result.Result{}, &kvpb.WriteIntentError{Intents: intents}
+		return result.Result{}, &kvpb.LockConflictError{Intents: intents}
 	}
 
 	// Before clearing, compute the delta in MVCCStats.

--- a/pkg/kv/kvserver/batcheval/cmd_clear_range.go
+++ b/pkg/kv/kvserver/batcheval/cmd_clear_range.go
@@ -112,7 +112,7 @@ func ClearRange(
 	// txns. Otherwise, txn recovery would fail to find these intents and
 	// consider the txn incomplete, uncommitting it and its writes (even those
 	// outside of the cleared range).
-	maxIntents := storage.MaxIntentsPerWriteIntentError.Get(&cArgs.EvalCtx.ClusterSettings().SV)
+	maxIntents := storage.MaxIntentsPerLockConflictError.Get(&cArgs.EvalCtx.ClusterSettings().SV)
 	intents, err := storage.ScanIntents(ctx, readWriter, from, to, maxIntents, 0)
 	if err != nil {
 		return result.Result{}, err

--- a/pkg/kv/kvserver/batcheval/cmd_clear_range.go
+++ b/pkg/kv/kvserver/batcheval/cmd_clear_range.go
@@ -117,7 +117,7 @@ func ClearRange(
 	if err != nil {
 		return result.Result{}, err
 	} else if len(intents) > 0 {
-		return result.Result{}, &kvpb.LockConflictError{Intents: intents}
+		return result.Result{}, &kvpb.LockConflictError{Locks: intents}
 	}
 
 	// Before clearing, compute the delta in MVCCStats.

--- a/pkg/kv/kvserver/batcheval/cmd_delete_range.go
+++ b/pkg/kv/kvserver/batcheval/cmd_delete_range.go
@@ -149,7 +149,7 @@ func DeleteRange(
 
 		leftPeekBound, rightPeekBound := rangeTombstonePeekBounds(
 			args.Key, args.EndKey, desc.StartKey.AsRawKey(), desc.EndKey.AsRawKey())
-		maxIntents := storage.MaxIntentsPerWriteIntentError.Get(&cArgs.EvalCtx.ClusterSettings().SV)
+		maxIntents := storage.MaxIntentsPerLockConflictError.Get(&cArgs.EvalCtx.ClusterSettings().SV)
 
 		// If no predicate parameters are passed, use the fast path. If we're
 		// deleting the entire Raft range, use an even faster path that avoids a

--- a/pkg/kv/kvserver/batcheval/cmd_delete_range_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_delete_range_test.go
@@ -145,11 +145,11 @@ func TestDeleteRangeTombstone(t *testing.T) {
 			returnKeys: true,
 			expectErr:  "ReturnKeys can't be used with range tombstones",
 		},
-		"intent errors with WriteIntentError": {
+		"intent errors with LockConflictError": {
 			start:     "i",
 			end:       "j",
 			ts:        10e9,
-			expectErr: &kvpb.WriteIntentError{},
+			expectErr: &kvpb.LockConflictError{},
 		},
 		"below point errors with WriteTooOldError": {
 			start:     "a",

--- a/pkg/kv/kvserver/batcheval/cmd_export.go
+++ b/pkg/kv/kvserver/batcheval/cmd_export.go
@@ -155,7 +155,7 @@ func evalExport(
 	}
 
 	var maxIntents uint64
-	if m := storage.MaxIntentsPerWriteIntentError.Get(&cArgs.EvalCtx.ClusterSettings().SV); m > 0 {
+	if m := storage.MaxIntentsPerLockConflictError.Get(&cArgs.EvalCtx.ClusterSettings().SV); m > 0 {
 		maxIntents = uint64(m)
 	}
 

--- a/pkg/kv/kvserver/batcheval/cmd_export_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_export_test.go
@@ -539,7 +539,7 @@ func exportUsingGoIterator(
 	for iter.SeekGE(storage.MakeMVCCMetadataKey(startKey)); ; iterFn(iter) {
 		ok, err := iter.Valid()
 		if err != nil {
-			// The error may be a WriteIntentError. In which case, returning it will
+			// The error may be a LockConflictError. In which case, returning it will
 			// cause this command to be retried.
 			return nil, err
 		}

--- a/pkg/kv/kvserver/batcheval/cmd_reverse_scan.go
+++ b/pkg/kv/kvserver/batcheval/cmd_reverse_scan.go
@@ -46,7 +46,7 @@ func ReverseScan(
 		ScanStats:             cArgs.ScanStats,
 		Uncertainty:           cArgs.Uncertainty,
 		MaxKeys:               h.MaxSpanRequestKeys,
-		MaxIntents:            storage.MaxIntentsPerWriteIntentError.Get(&cArgs.EvalCtx.ClusterSettings().SV),
+		MaxIntents:            storage.MaxIntentsPerLockConflictError.Get(&cArgs.EvalCtx.ClusterSettings().SV),
 		TargetBytes:           h.TargetBytes,
 		AllowEmpty:            h.AllowEmpty,
 		WholeRowsOfSize:       h.WholeRowsOfSize,

--- a/pkg/kv/kvserver/batcheval/cmd_revert_range_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_revert_range_test.go
@@ -231,7 +231,7 @@ func TestCmdRevertRange(t *testing.T) {
 
 			if tc.expectErr {
 				if !testutils.IsError(err, "intents") {
-					t.Fatalf("expected write intent error; got: %T %+v", err, err)
+					t.Fatalf("expected lock conflict error; got: %T %+v", err, err)
 				}
 			} else {
 				if err != nil {

--- a/pkg/kv/kvserver/batcheval/cmd_revert_range_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_revert_range_test.go
@@ -230,7 +230,7 @@ func TestCmdRevertRange(t *testing.T) {
 			}
 
 			if tc.expectErr {
-				if !testutils.IsError(err, "intents") {
+				if !testutils.IsError(err, "conflicting locks") {
 					t.Fatalf("expected lock conflict error; got: %T %+v", err, err)
 				}
 			} else {

--- a/pkg/kv/kvserver/batcheval/cmd_scan.go
+++ b/pkg/kv/kvserver/batcheval/cmd_scan.go
@@ -46,7 +46,7 @@ func Scan(
 		ScanStats:             cArgs.ScanStats,
 		Uncertainty:           cArgs.Uncertainty,
 		MaxKeys:               h.MaxSpanRequestKeys,
-		MaxIntents:            storage.MaxIntentsPerWriteIntentError.Get(&cArgs.EvalCtx.ClusterSettings().SV),
+		MaxIntents:            storage.MaxIntentsPerLockConflictError.Get(&cArgs.EvalCtx.ClusterSettings().SV),
 		TargetBytes:           h.TargetBytes,
 		AllowEmpty:            h.AllowEmpty,
 		WholeRowsOfSize:       h.WholeRowsOfSize,

--- a/pkg/kv/kvserver/batcheval/intent.go
+++ b/pkg/kv/kvserver/batcheval/intent.go
@@ -55,7 +55,7 @@ func CollectIntentRows(
 	for i := range intents {
 		kv, err := readProvisionalVal(ctx, reader, usePrefixIter, &intents[i])
 		if err != nil {
-			if errors.HasType(err, (*kvpb.WriteIntentError)(nil)) ||
+			if errors.HasType(err, (*kvpb.LockConflictError)(nil)) ||
 				errors.HasType(err, (*kvpb.ReadWithinUncertaintyIntervalError)(nil)) {
 				log.Fatalf(ctx, "unexpected %T in CollectIntentRows: %+v", err, err)
 			}

--- a/pkg/kv/kvserver/client_replica_test.go
+++ b/pkg/kv/kvserver/client_replica_test.go
@@ -4536,8 +4536,8 @@ func TestDiscoverIntentAcrossLeaseTransferAwayAndBack(t *testing.T) {
 				TestingConcurrencyRetryFilter: func(ctx context.Context, ba *kvpb.BatchRequest, pErr *kvpb.Error) {
 					if txn := ba.Txn; txn != nil && txn.ID == txn2ID.Load() {
 						txn2BBlockOnce.Do(func() {
-							if !errors.HasType(pErr.GoError(), (*kvpb.WriteIntentError)(nil)) {
-								t.Errorf("expected WriteIntentError; got %v", pErr)
+							if !errors.HasType(pErr.GoError(), (*kvpb.LockConflictError)(nil)) {
+								t.Errorf("expected LockConflictError; got %v", pErr)
 							}
 
 							unblockCh := make(chan struct{})

--- a/pkg/kv/kvserver/client_split_test.go
+++ b/pkg/kv/kvserver/client_split_test.go
@@ -3243,7 +3243,7 @@ func TestRangeLookupAsyncResolveIntent(t *testing.T) {
 	store.DB().NonTransactionalSender().(*kv.CrossRangeTxnWrapperSender).Wrapped().(*kvcoord.DistSender).RangeDescriptorCache().Clear()
 
 	// Now send a request, forcing the RangeLookup. Since the lookup is
-	// inconsistent, there's no WriteIntentError, but we'll try to resolve any
+	// inconsistent, there's no LockConflictError, but we'll try to resolve any
 	// intents that are found. If the RangeLookup op attempts to resolve the
 	// intents synchronously, the operation will block forever.
 	//

--- a/pkg/kv/kvserver/concurrency/concurrency_control.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_control.go
@@ -54,7 +54,7 @@ import (
 // Specifically, write intents (replicated, exclusive locks) are stored inline
 // in the MVCC keyspace, so they are not detectable until request evaluation
 // time. To accommodate this form of lock storage, the manager exposes a
-// HandleWriterIntentError method, which can be used in conjunction with a retry
+// HandleLockConflictError method, which can be used in conjunction with a retry
 // loop around evaluation to integrate external locks with the concurrency
 // manager structure. In the future, we intend to pull all locks, including
 // those associated with write intents, into the concurrency manager directly
@@ -92,7 +92,7 @@ import (
 //	|         | [    key4   ]  \  - txn  meta | |  (no latches) |-->-^  |         |
 //	|         | [    key5   ]    -------------+-|---------------+ |     |         |
 //	|         | [    ...    ]                   v                 |     |         ^
-//	|         +---------------------------------|-----------------+     |         | if lock found, HandleWriterIntentError()
+//	|         +---------------------------------|-----------------+     |         | if lock found, HandleLockConflictError()
 //	|                 |                         |                       |         |  - enter lockWaitQueue
 //	|                 |       +- may be remote -+--+                    |         |  - drop latches
 //	|                 |       |                    |                    |         |  - wait for lock update / release
@@ -212,7 +212,7 @@ type RequestSequencer interface {
 // typically involves preparing the request to be queued upon a retry. It is one
 // of the roles of Manager.
 type ContentionHandler interface {
-	// HandleWriterIntentError consumes a LockConflictError by informing the
+	// HandleLockConflictError consumes a LockConflictError by informing the
 	// concurrency manager about the replicated write intent that was missing
 	// from its lock table which was found during request evaluation (while
 	// holding latches) under the provided lease sequence. After doing so, it
@@ -229,7 +229,7 @@ type ContentionHandler interface {
 	// method before txn A retries its scan. During the retry, txn A scans the
 	// lock table and observes the lock on key K, so it enters the lock's
 	// wait-queue and waits for it to be resolved.
-	HandleWriterIntentError(
+	HandleLockConflictError(
 		context.Context, *Guard, roachpb.LeaseSequence, *kvpb.LockConflictError,
 	) (*Guard, *Error)
 

--- a/pkg/kv/kvserver/concurrency/concurrency_control.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_control.go
@@ -212,7 +212,7 @@ type RequestSequencer interface {
 // typically involves preparing the request to be queued upon a retry. It is one
 // of the roles of Manager.
 type ContentionHandler interface {
-	// HandleWriterIntentError consumes a WriteIntentError by informing the
+	// HandleWriterIntentError consumes a LockConflictError by informing the
 	// concurrency manager about the replicated write intent that was missing
 	// from its lock table which was found during request evaluation (while
 	// holding latches) under the provided lease sequence. After doing so, it
@@ -225,12 +225,12 @@ type ContentionHandler interface {
 	// Example usage: Txn A scans the lock table and does not see an intent on
 	// key K from txn B because the intent is not being tracked in the lock
 	// table. Txn A moves on to evaluation. While scanning, it notices the
-	// intent on key K. It throws a WriteIntentError which is consumed by this
+	// intent on key K. It throws a LockConflictError which is consumed by this
 	// method before txn A retries its scan. During the retry, txn A scans the
 	// lock table and observes the lock on key K, so it enters the lock's
 	// wait-queue and waits for it to be resolved.
 	HandleWriterIntentError(
-		context.Context, *Guard, roachpb.LeaseSequence, *kvpb.WriteIntentError,
+		context.Context, *Guard, roachpb.LeaseSequence, *kvpb.LockConflictError,
 	) (*Guard, *Error)
 
 	// HandleTransactionPushError consumes a TransactionPushError thrown by a
@@ -402,7 +402,7 @@ type Request struct {
 	// level of quality-of-service under severe per-key contention. If set
 	// to a non-zero value and an existing lock wait-queue is already equal
 	// to or exceeding this length, the request will be rejected eagerly
-	// with a WriteIntentError instead of entering the queue and waiting.
+	// with a LockConflictError instead of entering the queue and waiting.
 	MaxLockWaitQueueLength int
 
 	// The poison.Policy to use for this Request.

--- a/pkg/kv/kvserver/concurrency/concurrency_manager.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager.go
@@ -480,9 +480,9 @@ func (m *managerImpl) HandleLockConflictError(
 	// Either way, there is no possibility of the request entering an infinite
 	// loop without making progress.
 	consultTxnStatusCache :=
-		int64(len(t.Intents)) > DiscoveredLocksThresholdToConsultTxnStatusCache.Get(&m.st.SV)
-	for i := range t.Intents {
-		intent := &t.Intents[i]
+		int64(len(t.Locks)) > DiscoveredLocksThresholdToConsultTxnStatusCache.Get(&m.st.SV)
+	for i := range t.Locks {
+		intent := &t.Locks[i]
 		added, err := m.lt.AddDiscoveredLock(intent, seq, consultTxnStatusCache, g.ltg)
 		if err != nil {
 			log.Fatalf(ctx, "%v", err)

--- a/pkg/kv/kvserver/concurrency/concurrency_manager.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager.go
@@ -450,8 +450,8 @@ func (m *managerImpl) FinishReq(g *Guard) {
 	releaseGuard(g)
 }
 
-// HandleWriterIntentError implements the ContentionHandler interface.
-func (m *managerImpl) HandleWriterIntentError(
+// HandleLockConflictError implements the ContentionHandler interface.
+func (m *managerImpl) HandleLockConflictError(
 	ctx context.Context, g *Guard, seq roachpb.LeaseSequence, t *kvpb.LockConflictError,
 ) (*Guard, *Error) {
 	if g.ltg == nil {
@@ -612,7 +612,7 @@ func (m *managerImpl) OnReplicaSnapshotApplied() {
 	// through LockManager listener methods. If there's a chance it missed a
 	// state transition, it is safer to simply clear the lockTable and rebuild
 	// it from persistent intent state by allowing requests to discover locks
-	// and inform the manager through calls to HandleWriterIntentError.
+	// and inform the manager through calls to HandleLockConflictError.
 	//
 	// A range only maintains locks in the lockTable of its leaseholder replica
 	// even thought it runs a concurrency manager on all replicas. Because of

--- a/pkg/kv/kvserver/concurrency/concurrency_manager.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager.go
@@ -452,10 +452,10 @@ func (m *managerImpl) FinishReq(g *Guard) {
 
 // HandleWriterIntentError implements the ContentionHandler interface.
 func (m *managerImpl) HandleWriterIntentError(
-	ctx context.Context, g *Guard, seq roachpb.LeaseSequence, t *kvpb.WriteIntentError,
+	ctx context.Context, g *Guard, seq roachpb.LeaseSequence, t *kvpb.LockConflictError,
 ) (*Guard, *Error) {
 	if g.ltg == nil {
-		log.Fatalf(ctx, "cannot handle WriteIntentError %v for request without "+
+		log.Fatalf(ctx, "cannot handle LockConflictError %v for request without "+
 			"lockTableGuard; were lock spans declared for this request?", t)
 	}
 
@@ -472,7 +472,7 @@ func (m *managerImpl) HandleWriterIntentError(
 	//    wait in the new leaseholder's lock table.
 	// 2) if the request can be served on this follower replica according to the
 	//    closed timestamp then it will likely re-encounter the same intent on its
-	//    next evaluation attempt. The WriteIntentError will then be mapped to an
+	//    next evaluation attempt. The LockConflictError will then be mapped to an
 	//    InvalidLeaseError in maybeAttachLease, which will indicate that the
 	//    request cannot be served as a follower read after all and cause the
 	//    request to be redirected to the leaseholder.

--- a/pkg/kv/kvserver/concurrency/concurrency_manager_test.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager_test.go
@@ -335,15 +335,15 @@ func TestConcurrencyManagerBasic(t *testing.T) {
 				opName := fmt.Sprintf("handle write intent error %s", reqName)
 				mon.runAsync(opName, func(ctx context.Context) {
 					seq := roachpb.LeaseSequence(leaseSeq)
-					wiErr := &kvpb.WriteIntentError{Intents: intents}
-					guard, err := m.HandleWriterIntentError(ctx, prev, seq, wiErr)
+					lcErr := &kvpb.LockConflictError{Intents: intents}
+					guard, err := m.HandleWriterIntentError(ctx, prev, seq, lcErr)
 					if err != nil {
-						log.Eventf(ctx, "handled %v, returned error: %v", wiErr, err)
+						log.Eventf(ctx, "handled %v, returned error: %v", lcErr, err)
 						c.mu.Lock()
 						delete(c.guardsByReqName, reqName)
 						c.mu.Unlock()
 					} else {
-						log.Eventf(ctx, "handled %v, released latches", wiErr)
+						log.Eventf(ctx, "handled %v, released latches", lcErr)
 						c.mu.Lock()
 						c.guardsByReqName[reqName] = guard
 						c.mu.Unlock()

--- a/pkg/kv/kvserver/concurrency/concurrency_manager_test.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager_test.go
@@ -69,8 +69,8 @@ import (
 // poison       req=<req-name>
 // finish       req=<req-name>
 //
-// handle-write-intent-error  req=<req-name> txn=<txn-name> key=<key> lease-seq=<seq>
-// handle-txn-push-error      req=<req-name> txn=<txn-name> key=<key>  TODO(nvanbenschoten): implement this
+// handle-lock-conflict-error  req=<req-name> txn=<txn-name> key=<key> lease-seq=<seq>
+// handle-txn-push-error       req=<req-name> txn=<txn-name> key=<key>  TODO(nvanbenschoten): implement this
 //
 // check-opt-no-conflicts            req=<req-name>
 // is-key-locked-by-conflicting-txn  req=<req-name> key=<key> strength=<strength>
@@ -295,7 +295,7 @@ func TestConcurrencyManagerBasic(t *testing.T) {
 				})
 				return c.waitAndCollect(t, mon)
 
-			case "handle-write-intent-error":
+			case "handle-lock-conflict-error":
 				var reqName string
 				d.ScanArgs(t, "req", &reqName)
 				prev, ok := c.guardsByReqName[reqName]
@@ -313,10 +313,10 @@ func TestConcurrencyManagerBasic(t *testing.T) {
 					var err error
 					d.Cmd, d.CmdArgs, err = datadriven.ParseLine(line)
 					if err != nil {
-						d.Fatalf(t, "error parsing single intent: %v", err)
+						d.Fatalf(t, "error parsing single lock: %v", err)
 					}
-					if d.Cmd != "intent" {
-						d.Fatalf(t, "expected \"intent\", found %s", d.Cmd)
+					if d.Cmd != "lock" {
+						d.Fatalf(t, "expected \"lock\", found %s", d.Cmd)
 					}
 
 					var txnName string
@@ -332,11 +332,11 @@ func TestConcurrencyManagerBasic(t *testing.T) {
 					intents = append(intents, roachpb.MakeIntent(&txn.TxnMeta, roachpb.Key(key)))
 				}
 
-				opName := fmt.Sprintf("handle write intent error %s", reqName)
+				opName := fmt.Sprintf("handle lock conflict error %s", reqName)
 				mon.runAsync(opName, func(ctx context.Context) {
 					seq := roachpb.LeaseSequence(leaseSeq)
 					lcErr := &kvpb.LockConflictError{Intents: intents}
-					guard, err := m.HandleWriterIntentError(ctx, prev, seq, lcErr)
+					guard, err := m.HandleLockConflictError(ctx, prev, seq, lcErr)
 					if err != nil {
 						log.Eventf(ctx, "handled %v, returned error: %v", lcErr, err)
 						c.mu.Lock()

--- a/pkg/kv/kvserver/concurrency/concurrency_manager_test.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager_test.go
@@ -335,7 +335,7 @@ func TestConcurrencyManagerBasic(t *testing.T) {
 				opName := fmt.Sprintf("handle lock conflict error %s", reqName)
 				mon.runAsync(opName, func(ctx context.Context) {
 					seq := roachpb.LeaseSequence(leaseSeq)
-					lcErr := &kvpb.LockConflictError{Intents: intents}
+					lcErr := &kvpb.LockConflictError{Locks: intents}
 					guard, err := m.HandleLockConflictError(ctx, prev, seq, lcErr)
 					if err != nil {
 						log.Eventf(ctx, "handled %v, returned error: %v", lcErr, err)

--- a/pkg/kv/kvserver/concurrency/lock_table_waiter.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_waiter.go
@@ -107,7 +107,7 @@ type lockTableWaiterImpl struct {
 	ir       IntentResolver
 	lt       lockTable
 
-	// When set, WriteIntentError are propagated instead of pushing
+	// When set, LockConflictError are propagated instead of pushing
 	// conflicting transactions.
 	disableTxnPushing bool
 	// When set, called just before each push timer event is processed.
@@ -458,7 +458,7 @@ func (w *lockTableWaiterImpl) WaitOn(
 // lock to trigger a state transition in the lockTable that will free up the
 // request to proceed. If the method returns successfully then the caller can
 // expect to have an updated waitingState. Otherwise, the method returns with a
-// WriteIntentError and without blocking on the lock holder transaction.
+// LockConflictError and without blocking on the lock holder transaction.
 func (w *lockTableWaiterImpl) pushLockTxn(
 	ctx context.Context, req Request, ws waitingState,
 ) *Error {
@@ -520,7 +520,7 @@ func (w *lockTableWaiterImpl) pushLockTxn(
 	pusheeTxn, err := w.ir.PushTransaction(ctx, ws.txn, h, pushType)
 	if err != nil {
 		// If pushing with an Error WaitPolicy and the push fails, then the lock
-		// holder is still active. Transform the error into a WriteIntentError.
+		// holder is still active. Transform the error into a LockConflictError.
 		if _, ok := err.GetDetail().(*kvpb.TransactionPushError); ok && req.WaitPolicy == lock.WaitPolicy_Error {
 			err = newWriteIntentErr(req, ws, reasonWaitPolicy)
 		}
@@ -658,14 +658,14 @@ func (w *lockTableWaiterImpl) pushLockTxn(
 // pushLockTxnAfterTimeout is like pushLockTxn, but it sets the Error wait
 // policy on its request so that the request will not block on the lock holder
 // if it is still active. It is meant to be used after a lock timeout has been
-// elapsed, and returns a WriteIntentErrors with a LOCK_TIMEOUT reason if the
+// elapsed, and returns a LockConflictErrors with a LOCK_TIMEOUT reason if the
 // lock holder is not abandoned.
 func (w *lockTableWaiterImpl) pushLockTxnAfterTimeout(
 	ctx context.Context, req Request, ws waitingState,
 ) *Error {
 	req.WaitPolicy = lock.WaitPolicy_Error
 	err := w.pushLockTxn(ctx, req, ws)
-	if _, ok := err.GetDetail().(*kvpb.WriteIntentError); ok {
+	if _, ok := err.GetDetail().(*kvpb.LockConflictError); ok {
 		err = newWriteIntentErr(req, ws, reasonLockTimeout)
 	}
 	return err
@@ -858,7 +858,7 @@ func (w *lockTableWaiterImpl) ResolveDeferredIntents(
 // proving that the pushee was active and began waiting in its txnwait.Queue.
 // The push may have timed out before this point due to a slow network, slow
 // CPU, or for some other reason. But just like with WaitPolicy_Error, we don't
-// want to throw a WriteIntentError on abandoned locks. So on timeout, we issue
+// want to throw a LockConflictError on abandoned locks. So on timeout, we issue
 // a PUSH_TOUCH request (like we do for WaitPolicy_Error) that is not subject to
 // the lock_timeout to check with certainty whether the conflict is active or
 // not, but without blocking if it happens to be active.
@@ -1252,13 +1252,13 @@ func (tag *contentionTag) Render() []attribute.KeyValue {
 }
 
 const (
-	reasonWaitPolicy                 = kvpb.WriteIntentError_REASON_WAIT_POLICY
-	reasonLockTimeout                = kvpb.WriteIntentError_REASON_LOCK_TIMEOUT
-	reasonWaitQueueMaxLengthExceeded = kvpb.WriteIntentError_REASON_LOCK_WAIT_QUEUE_MAX_LENGTH_EXCEEDED
+	reasonWaitPolicy                 = kvpb.LockConflictError_REASON_WAIT_POLICY
+	reasonLockTimeout                = kvpb.LockConflictError_REASON_LOCK_TIMEOUT
+	reasonWaitQueueMaxLengthExceeded = kvpb.LockConflictError_REASON_LOCK_WAIT_QUEUE_MAX_LENGTH_EXCEEDED
 )
 
-func newWriteIntentErr(req Request, ws waitingState, reason kvpb.WriteIntentError_Reason) *Error {
-	err := kvpb.NewError(&kvpb.WriteIntentError{
+func newWriteIntentErr(req Request, ws waitingState, reason kvpb.LockConflictError_Reason) *Error {
+	err := kvpb.NewError(&kvpb.LockConflictError{
 		Intents: []roachpb.Intent{roachpb.MakeIntent(ws.txn, ws.key)},
 		Reason:  reason,
 	})

--- a/pkg/kv/kvserver/concurrency/lock_table_waiter.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_waiter.go
@@ -1259,8 +1259,8 @@ const (
 
 func newLockConflictErr(req Request, ws waitingState, reason kvpb.LockConflictError_Reason) *Error {
 	err := kvpb.NewError(&kvpb.LockConflictError{
-		Intents: []roachpb.Intent{roachpb.MakeIntent(ws.txn, ws.key)},
-		Reason:  reason,
+		Locks:  []roachpb.Intent{roachpb.MakeIntent(ws.txn, ws.key)},
+		Reason: reason,
 	})
 	// TODO(nvanbenschoten): setting an error index can assist the KV client in
 	// understanding which request hit an error. This is not necessary, but can

--- a/pkg/kv/kvserver/concurrency/lock_table_waiter_test.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_waiter_test.go
@@ -492,7 +492,7 @@ func testErrorWaitPush(
 	k waitKind,
 	makeReq func() Request,
 	expPushTS hlc.Timestamp,
-	errReason kvpb.WriteIntentError_Reason,
+	errReason kvpb.LockConflictError_Reason,
 ) {
 	ctx := context.Background()
 	keyA := roachpb.Key("keyA")
@@ -527,9 +527,9 @@ func testErrorWaitPush(
 					require.Nil(t, err)
 				} else {
 					require.NotNil(t, err)
-					wiErr := new(kvpb.WriteIntentError)
-					require.True(t, errors.As(err.GoError(), &wiErr))
-					require.Equal(t, errReason, wiErr.Reason)
+					lcErr := new(kvpb.LockConflictError)
+					require.True(t, errors.As(err.GoError(), &lcErr))
+					require.Equal(t, errReason, lcErr.Reason)
 				}
 				return
 			}
@@ -576,9 +576,9 @@ func testErrorWaitPush(
 			err := w.WaitOn(ctx, req, g)
 			if pusheeActive {
 				require.NotNil(t, err)
-				wiErr := new(kvpb.WriteIntentError)
-				require.True(t, errors.As(err.GoError(), &wiErr))
-				require.Equal(t, errReason, wiErr.Reason)
+				lcErr := new(kvpb.LockConflictError)
+				require.True(t, errors.As(err.GoError(), &lcErr))
+				require.Equal(t, errReason, lcErr.Reason)
 			} else {
 				require.Nil(t, err)
 			}
@@ -699,9 +699,9 @@ func testWaitPushWithTimeout(t *testing.T, k waitKind, makeReq func() Request) {
 				if !lockHeld && timeoutBeforePush {
 					err := w.WaitOn(ctx, req, g)
 					require.NotNil(t, err)
-					wiErr := new(kvpb.WriteIntentError)
-					require.True(t, errors.As(err.GoError(), &wiErr))
-					require.Equal(t, reasonLockTimeout, wiErr.Reason)
+					lcErr := new(kvpb.LockConflictError)
+					require.True(t, errors.As(err.GoError(), &lcErr))
+					require.Equal(t, reasonLockTimeout, lcErr.Reason)
 					return
 				}
 
@@ -765,9 +765,9 @@ func testWaitPushWithTimeout(t *testing.T, k waitKind, makeReq func() Request) {
 				err := w.WaitOn(ctx, req, g)
 				if pusheeActive {
 					require.NotNil(t, err)
-					wiErr := new(kvpb.WriteIntentError)
-					require.True(t, errors.As(err.GoError(), &wiErr))
-					require.Equal(t, reasonLockTimeout, wiErr.Reason)
+					lcErr := new(kvpb.LockConflictError)
+					require.True(t, errors.As(err.GoError(), &lcErr))
+					require.Equal(t, reasonLockTimeout, lcErr.Reason)
 				} else {
 					require.Nil(t, err)
 				}

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/clear_abandoned_intents
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/clear_abandoned_intents
@@ -31,7 +31,7 @@ handle-lock-conflict-error req=req1 lease-seq=1
   lock txn=txn2 key=i
   lock txn=txn2 key=j
 ----
-[2] handle lock conflict error req1: handled conflicting intents on ‹"a"›, ‹"b"›, ‹"c"›, ‹"d"›, ‹"e"›, ‹"f"›, ‹"g"›, ‹"h"›, ‹"i"›, ‹"j"›, released latches
+[2] handle lock conflict error req1: handled conflicting locks on ‹"a"›, ‹"b"›, ‹"c"›, ‹"d"›, ‹"e"›, ‹"f"›, ‹"g"›, ‹"h"›, ‹"i"›, ‹"j"›, released latches
 
 debug-lock-table
 ----
@@ -158,7 +158,7 @@ sequence req=req1
 handle-lock-conflict-error req=req1 lease-seq=1
   lock txn=txn2 key=a
 ----
-[2] handle lock conflict error req1: handled conflicting intents on ‹"a"›, released latches
+[2] handle lock conflict error req1: handled conflicting locks on ‹"a"›, released latches
 
 debug-lock-table
 ----
@@ -195,7 +195,7 @@ on-txn-updated txn=txn2 status=committed
 handle-lock-conflict-error req=req1 lease-seq=1
   lock txn=txn2 key=b
 ----
-[4] handle lock conflict error req1: handled conflicting intents on ‹"b"›, released latches
+[4] handle lock conflict error req1: handled conflicting locks on ‹"b"›, released latches
 
 debug-lock-table
 ----
@@ -224,7 +224,7 @@ sequence req=req1
 handle-lock-conflict-error req=req1 lease-seq=1
   lock txn=txn2 key=c
 ----
-[6] handle lock conflict error req1: handled conflicting intents on ‹"c"›, released latches
+[6] handle lock conflict error req1: handled conflicting locks on ‹"c"›, released latches
 
 debug-lock-table
 ----
@@ -300,7 +300,7 @@ handle-lock-conflict-error req=req1 lease-seq=1
   lock txn=txn2 key=a
   lock txn=txn2 key=b
 ----
-[2] handle lock conflict error req1: handled conflicting intents on ‹"a"›, ‹"b"›, released latches
+[2] handle lock conflict error req1: handled conflicting locks on ‹"a"›, ‹"b"›, released latches
 
 debug-lock-table
 ----
@@ -443,7 +443,7 @@ handle-lock-conflict-error req=req1 lease-seq=1
   lock txn=txn3 key=d
   lock txn=txn5 key=e
 ----
-[2] handle lock conflict error req1: handled conflicting intents on ‹"c"›, ‹"d"›, ‹"e"›, released latches
+[2] handle lock conflict error req1: handled conflicting locks on ‹"c"›, ‹"d"›, ‹"e"›, released latches
 
 debug-lock-table
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/clear_abandoned_intents
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/clear_abandoned_intents
@@ -19,19 +19,19 @@ sequence req=req1
 [1] sequence req1: scanning lock table for conflicting locks
 [1] sequence req1: sequencing complete, returned guard
 
-handle-write-intent-error req=req1 lease-seq=1
-  intent txn=txn2 key=a
-  intent txn=txn2 key=b
-  intent txn=txn2 key=c
-  intent txn=txn2 key=d
-  intent txn=txn2 key=e
-  intent txn=txn2 key=f
-  intent txn=txn2 key=g
-  intent txn=txn2 key=h
-  intent txn=txn2 key=i
-  intent txn=txn2 key=j
+handle-lock-conflict-error req=req1 lease-seq=1
+  lock txn=txn2 key=a
+  lock txn=txn2 key=b
+  lock txn=txn2 key=c
+  lock txn=txn2 key=d
+  lock txn=txn2 key=e
+  lock txn=txn2 key=f
+  lock txn=txn2 key=g
+  lock txn=txn2 key=h
+  lock txn=txn2 key=i
+  lock txn=txn2 key=j
 ----
-[2] handle write intent error req1: handled conflicting intents on ‹"a"›, ‹"b"›, ‹"c"›, ‹"d"›, ‹"e"›, ‹"f"›, ‹"g"›, ‹"h"›, ‹"i"›, ‹"j"›, released latches
+[2] handle lock conflict error req1: handled conflicting intents on ‹"a"›, ‹"b"›, ‹"c"›, ‹"d"›, ‹"e"›, ‹"f"›, ‹"g"›, ‹"h"›, ‹"i"›, ‹"j"›, released latches
 
 debug-lock-table
 ----
@@ -155,10 +155,10 @@ sequence req=req1
 [1] sequence req1: scanning lock table for conflicting locks
 [1] sequence req1: sequencing complete, returned guard
 
-handle-write-intent-error req=req1 lease-seq=1
-  intent txn=txn2 key=a
+handle-lock-conflict-error req=req1 lease-seq=1
+  lock txn=txn2 key=a
 ----
-[2] handle write intent error req1: handled conflicting intents on ‹"a"›, released latches
+[2] handle lock conflict error req1: handled conflicting intents on ‹"a"›, released latches
 
 debug-lock-table
 ----
@@ -192,10 +192,10 @@ on-txn-updated txn=txn2 status=committed
 [3] sequence req1: scanning lock table for conflicting locks
 [3] sequence req1: sequencing complete, returned guard
 
-handle-write-intent-error req=req1 lease-seq=1
-  intent txn=txn2 key=b
+handle-lock-conflict-error req=req1 lease-seq=1
+  lock txn=txn2 key=b
 ----
-[4] handle write intent error req1: handled conflicting intents on ‹"b"›, released latches
+[4] handle lock conflict error req1: handled conflicting intents on ‹"b"›, released latches
 
 debug-lock-table
 ----
@@ -221,10 +221,10 @@ sequence req=req1
 [5] sequence req1: scanning lock table for conflicting locks
 [5] sequence req1: sequencing complete, returned guard
 
-handle-write-intent-error req=req1 lease-seq=1
-  intent txn=txn2 key=c
+handle-lock-conflict-error req=req1 lease-seq=1
+  lock txn=txn2 key=c
 ----
-[6] handle write intent error req1: handled conflicting intents on ‹"c"›, released latches
+[6] handle lock conflict error req1: handled conflicting intents on ‹"c"›, released latches
 
 debug-lock-table
 ----
@@ -296,11 +296,11 @@ sequence req=req1
 [1] sequence req1: scanning lock table for conflicting locks
 [1] sequence req1: sequencing complete, returned guard
 
-handle-write-intent-error req=req1 lease-seq=1
-  intent txn=txn2 key=a
-  intent txn=txn2 key=b
+handle-lock-conflict-error req=req1 lease-seq=1
+  lock txn=txn2 key=a
+  lock txn=txn2 key=b
 ----
-[2] handle write intent error req1: handled conflicting intents on ‹"a"›, ‹"b"›, released latches
+[2] handle lock conflict error req1: handled conflicting intents on ‹"a"›, ‹"b"›, released latches
 
 debug-lock-table
 ----
@@ -434,16 +434,16 @@ sequence req=req1
 [1] sequence req1: scanning lock table for conflicting locks
 [1] sequence req1: sequencing complete, returned guard
 
-# Normally req1 will not discover write intents for c, d, e in one shot, since
-# it consists of multiple requests, and we only discover intents a request at
-# a time (though a single request can discover multiple intents), but we do
-# this for shortening the test.
-handle-write-intent-error req=req1 lease-seq=1
-  intent txn=txn3 key=c
-  intent txn=txn3 key=d
-  intent txn=txn5 key=e
+# Normally req1 will not discover locks for c, d, e in one shot, since it
+# consists of multiple requests, and we only discover locks a request at a time
+# (though a single request can discover multiple locks), but we do this for
+# shortening the test.
+handle-lock-conflict-error req=req1 lease-seq=1
+  lock txn=txn3 key=c
+  lock txn=txn3 key=d
+  lock txn=txn5 key=e
 ----
-[2] handle write intent error req1: handled conflicting intents on ‹"c"›, ‹"d"›, ‹"e"›, released latches
+[2] handle lock conflict error req1: handled conflicting intents on ‹"c"›, ‹"d"›, ‹"e"›, released latches
 
 debug-lock-table
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/clear_abandoned_intents_without_adding_to_lock_table
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/clear_abandoned_intents_without_adding_to_lock_table
@@ -28,7 +28,7 @@ sequence req=req1
 handle-lock-conflict-error req=req1 lease-seq=1
   lock txn=txn2 key=a
 ----
-[2] handle lock conflict error req1: handled conflicting intents on ‹"a"›, released latches
+[2] handle lock conflict error req1: handled conflicting locks on ‹"a"›, released latches
 
 debug-lock-table
 ----
@@ -112,7 +112,7 @@ handle-lock-conflict-error req=req2 lease-seq=1
 [5] handle lock conflict error req2: resolving intent ‹"h"› for txn 00000002 with ABORTED status
 [5] handle lock conflict error req2: resolving intent ‹"i"› for txn 00000002 with ABORTED status
 [5] handle lock conflict error req2: resolving intent ‹"j"› for txn 00000002 with ABORTED status
-[5] handle lock conflict error req2: handled conflicting intents on ‹"b"›, ‹"c"›, ‹"d"›, ‹"e"›, ‹"f"›, ‹"g"›, ‹"h"›, ‹"i"›, ‹"j"›, released latches
+[5] handle lock conflict error req2: handled conflicting locks on ‹"b"›, ‹"c"›, ‹"d"›, ‹"e"›, ‹"f"›, ‹"g"›, ‹"h"›, ‹"i"›, ‹"j"›, released latches
 
 debug-lock-table
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/clear_abandoned_intents_without_adding_to_lock_table
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/clear_abandoned_intents_without_adding_to_lock_table
@@ -25,10 +25,10 @@ sequence req=req1
 [1] sequence req1: scanning lock table for conflicting locks
 [1] sequence req1: sequencing complete, returned guard
 
-handle-write-intent-error req=req1 lease-seq=1
-  intent txn=txn2 key=a
+handle-lock-conflict-error req=req1 lease-seq=1
+  lock txn=txn2 key=a
 ----
-[2] handle write intent error req1: handled conflicting intents on ‹"a"›, released latches
+[2] handle lock conflict error req1: handled conflicting intents on ‹"a"›, released latches
 
 debug-lock-table
 ----
@@ -90,29 +90,29 @@ sequence req=req2
 [4] sequence req2: scanning lock table for conflicting locks
 [4] sequence req2: sequencing complete, returned guard
 
-# The intents get resolved instead of being added to the lock table.
-handle-write-intent-error req=req2 lease-seq=1
-  intent txn=txn2 key=b
-  intent txn=txn2 key=c
-  intent txn=txn2 key=d
-  intent txn=txn2 key=e
-  intent txn=txn2 key=f
-  intent txn=txn2 key=g
-  intent txn=txn2 key=h
-  intent txn=txn2 key=i
-  intent txn=txn2 key=j
+# The locks get resolved instead of being added to the lock table.
+handle-lock-conflict-error req=req2 lease-seq=1
+  lock txn=txn2 key=b
+  lock txn=txn2 key=c
+  lock txn=txn2 key=d
+  lock txn=txn2 key=e
+  lock txn=txn2 key=f
+  lock txn=txn2 key=g
+  lock txn=txn2 key=h
+  lock txn=txn2 key=i
+  lock txn=txn2 key=j
 ----
-[5] handle write intent error req2: resolving a batch of 9 intent(s)
-[5] handle write intent error req2: resolving intent ‹"b"› for txn 00000002 with ABORTED status
-[5] handle write intent error req2: resolving intent ‹"c"› for txn 00000002 with ABORTED status
-[5] handle write intent error req2: resolving intent ‹"d"› for txn 00000002 with ABORTED status
-[5] handle write intent error req2: resolving intent ‹"e"› for txn 00000002 with ABORTED status
-[5] handle write intent error req2: resolving intent ‹"f"› for txn 00000002 with ABORTED status
-[5] handle write intent error req2: resolving intent ‹"g"› for txn 00000002 with ABORTED status
-[5] handle write intent error req2: resolving intent ‹"h"› for txn 00000002 with ABORTED status
-[5] handle write intent error req2: resolving intent ‹"i"› for txn 00000002 with ABORTED status
-[5] handle write intent error req2: resolving intent ‹"j"› for txn 00000002 with ABORTED status
-[5] handle write intent error req2: handled conflicting intents on ‹"b"›, ‹"c"›, ‹"d"›, ‹"e"›, ‹"f"›, ‹"g"›, ‹"h"›, ‹"i"›, ‹"j"›, released latches
+[5] handle lock conflict error req2: resolving a batch of 9 intent(s)
+[5] handle lock conflict error req2: resolving intent ‹"b"› for txn 00000002 with ABORTED status
+[5] handle lock conflict error req2: resolving intent ‹"c"› for txn 00000002 with ABORTED status
+[5] handle lock conflict error req2: resolving intent ‹"d"› for txn 00000002 with ABORTED status
+[5] handle lock conflict error req2: resolving intent ‹"e"› for txn 00000002 with ABORTED status
+[5] handle lock conflict error req2: resolving intent ‹"f"› for txn 00000002 with ABORTED status
+[5] handle lock conflict error req2: resolving intent ‹"g"› for txn 00000002 with ABORTED status
+[5] handle lock conflict error req2: resolving intent ‹"h"› for txn 00000002 with ABORTED status
+[5] handle lock conflict error req2: resolving intent ‹"i"› for txn 00000002 with ABORTED status
+[5] handle lock conflict error req2: resolving intent ‹"j"› for txn 00000002 with ABORTED status
+[5] handle lock conflict error req2: handled conflicting intents on ‹"b"›, ‹"c"›, ‹"d"›, ‹"e"›, ‹"f"›, ‹"g"›, ‹"h"›, ‹"i"›, ‹"j"›, released latches
 
 debug-lock-table
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/discover_lock_after_lease_race
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/discover_lock_after_lease_race
@@ -132,7 +132,7 @@ sequence req=req4
 handle-lock-conflict-error req=req4 lease-seq=3
   lock txn=txn3 key=k
 ----
-[4] handle lock conflict error req4: handled conflicting intents on ‹"k"›, released latches
+[4] handle lock conflict error req4: handled conflicting locks on ‹"k"›, released latches
 
 debug-lock-table
 ----
@@ -155,7 +155,7 @@ handle-lock-conflict-error req=req2 lease-seq=1
   lock txn=txn1 key=k
 ----
 [6] handle lock conflict error req2: intent on ‹"k"› discovered but not added to disabled lock table
-[6] handle lock conflict error req2: handled conflicting intents on ‹"k"›, released latches
+[6] handle lock conflict error req2: handled conflicting locks on ‹"k"›, released latches
 
 debug-lock-table
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/discover_lock_after_lease_race
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/discover_lock_after_lease_race
@@ -85,7 +85,7 @@ num=0
 # --------------------------------
 
 # req2 begins evaluating and hits the replicated intent. However, before
-# handle-write-intent-error, it pauses.
+# handle-lock-conflict-error, it pauses.
 sequence req=req2
 ----
 [2] sequence req2: sequencing request
@@ -129,10 +129,10 @@ sequence req=req4
 [3] sequence req4: scanning lock table for conflicting locks
 [3] sequence req4: sequencing complete, returned guard
 
-handle-write-intent-error req=req4 lease-seq=3
-  intent txn=txn3 key=k
+handle-lock-conflict-error req=req4 lease-seq=3
+  lock txn=txn3 key=k
 ----
-[4] handle write intent error req4: handled conflicting intents on ‹"k"›, released latches
+[4] handle lock conflict error req4: handled conflicting intents on ‹"k"›, released latches
 
 debug-lock-table
 ----
@@ -151,11 +151,11 @@ sequence req=req4
 [5] sequence req4: pushing timestamp of txn 00000003 above 10.000000000,0
 [5] sequence req4: blocked on select in concurrency_test.(*cluster).PushTransaction
 
-handle-write-intent-error req=req2 lease-seq=1
-  intent txn=txn1 key=k
+handle-lock-conflict-error req=req2 lease-seq=1
+  lock txn=txn1 key=k
 ----
-[6] handle write intent error req2: intent on ‹"k"› discovered but not added to disabled lock table
-[6] handle write intent error req2: handled conflicting intents on ‹"k"›, released latches
+[6] handle lock conflict error req2: intent on ‹"k"› discovered but not added to disabled lock table
+[6] handle lock conflict error req2: handled conflicting intents on ‹"k"›, released latches
 
 debug-lock-table
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/discovered_lock
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/discovered_lock
@@ -23,7 +23,7 @@ sequence req=req1
 handle-lock-conflict-error req=req1 lease-seq=1
   lock txn=txn1 key=k
 ----
-[2] handle lock conflict error req1: handled conflicting intents on ‹"k"›, released latches
+[2] handle lock conflict error req1: handled conflicting locks on ‹"k"›, released latches
 
 debug-lock-table
 ----
@@ -91,7 +91,7 @@ handle-lock-conflict-error req=req1 lease-seq=2
   lock txn=txn1 key=k
 ----
 [2] handle lock conflict error req1: intent on ‹"k"› discovered but not added to disabled lock table
-[2] handle lock conflict error req1: handled conflicting intents on ‹"k"›, released latches
+[2] handle lock conflict error req1: handled conflicting locks on ‹"k"›, released latches
 
 sequence req=req1
 ----
@@ -140,7 +140,7 @@ handle-lock-conflict-error req=req1 lease-seq=2
   lock txn=txn1 key=k
 ----
 [2] handle lock conflict error req1: intent on ‹"k"› discovered but not added to disabled lock table
-[2] handle lock conflict error req1: handled conflicting intents on ‹"k"›, released latches
+[2] handle lock conflict error req1: handled conflicting locks on ‹"k"›, released latches
 
 sequence req=req1
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/discovered_lock
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/discovered_lock
@@ -20,10 +20,10 @@ sequence req=req1
 [1] sequence req1: scanning lock table for conflicting locks
 [1] sequence req1: sequencing complete, returned guard
 
-handle-write-intent-error req=req1 lease-seq=1
-  intent txn=txn1 key=k
+handle-lock-conflict-error req=req1 lease-seq=1
+  lock txn=txn1 key=k
 ----
-[2] handle write intent error req1: handled conflicting intents on ‹"k"›, released latches
+[2] handle lock conflict error req1: handled conflicting intents on ‹"k"›, released latches
 
 debug-lock-table
 ----
@@ -87,11 +87,11 @@ sequence req=req1
 [1] sequence req1: scanning lock table for conflicting locks
 [1] sequence req1: sequencing complete, returned guard
 
-handle-write-intent-error req=req1 lease-seq=2
-  intent txn=txn1 key=k
+handle-lock-conflict-error req=req1 lease-seq=2
+  lock txn=txn1 key=k
 ----
-[2] handle write intent error req1: intent on ‹"k"› discovered but not added to disabled lock table
-[2] handle write intent error req1: handled conflicting intents on ‹"k"›, released latches
+[2] handle lock conflict error req1: intent on ‹"k"› discovered but not added to disabled lock table
+[2] handle lock conflict error req1: handled conflicting intents on ‹"k"›, released latches
 
 sequence req=req1
 ----
@@ -136,11 +136,11 @@ sequence req=req1
 [1] sequence req1: scanning lock table for conflicting locks
 [1] sequence req1: sequencing complete, returned guard
 
-handle-write-intent-error req=req1 lease-seq=2
-  intent txn=txn1 key=k
+handle-lock-conflict-error req=req1 lease-seq=2
+  lock txn=txn1 key=k
 ----
-[2] handle write intent error req1: intent on ‹"k"› discovered but not added to disabled lock table
-[2] handle write intent error req1: handled conflicting intents on ‹"k"›, released latches
+[2] handle lock conflict error req1: intent on ‹"k"› discovered but not added to disabled lock table
+[2] handle lock conflict error req1: handled conflicting intents on ‹"k"›, released latches
 
 sequence req=req1
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/isolation_level
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/isolation_level
@@ -191,25 +191,25 @@ sequence req=reqDiscoverInitial
 [5] sequence reqDiscoverInitial: scanning lock table for conflicting locks
 [5] sequence reqDiscoverInitial: sequencing complete, returned guard
 
-handle-write-intent-error req=reqDiscoverInitial lease-seq=1
-  intent txn=txnRCHighPushee key=kRCHigh1
-  intent txn=txnRCHighPushee key=kRCHigh2
-  intent txn=txnRCHighPushee key=kRCHigh3
-  intent txn=txnRCHighPushee key=kRCHigh4
-  intent txn=txnRCNormalPushee key=kRCNormal1
-  intent txn=txnRCNormalPushee key=kRCNormal2
-  intent txn=txnRCNormalPushee key=kRCNormal3
-  intent txn=txnRCNormalPushee key=kRCNormal4
-  intent txn=txnSSIHighPushee key=kSSIHigh1
-  intent txn=txnSSIHighPushee key=kSSIHigh2
-  intent txn=txnSSIHighPushee key=kSSIHigh3
-  intent txn=txnSSIHighPushee key=kSSIHigh4
-  intent txn=txnSSINormalPushee  key=kSSINormal1
-  intent txn=txnSSINormalPushee  key=kSSINormal2
-  intent txn=txnSSINormalPushee  key=kSSINormal3
-  intent txn=txnSSINormalPushee  key=kSSINormal4
+handle-lock-conflict-error req=reqDiscoverInitial lease-seq=1
+  lock txn=txnRCHighPushee key=kRCHigh1
+  lock txn=txnRCHighPushee key=kRCHigh2
+  lock txn=txnRCHighPushee key=kRCHigh3
+  lock txn=txnRCHighPushee key=kRCHigh4
+  lock txn=txnRCNormalPushee key=kRCNormal1
+  lock txn=txnRCNormalPushee key=kRCNormal2
+  lock txn=txnRCNormalPushee key=kRCNormal3
+  lock txn=txnRCNormalPushee key=kRCNormal4
+  lock txn=txnSSIHighPushee key=kSSIHigh1
+  lock txn=txnSSIHighPushee key=kSSIHigh2
+  lock txn=txnSSIHighPushee key=kSSIHigh3
+  lock txn=txnSSIHighPushee key=kSSIHigh4
+  lock txn=txnSSINormalPushee  key=kSSINormal1
+  lock txn=txnSSINormalPushee  key=kSSINormal2
+  lock txn=txnSSINormalPushee  key=kSSINormal3
+  lock txn=txnSSINormalPushee  key=kSSINormal4
 ----
-[6] handle write intent error reqDiscoverInitial: handled conflicting intents on ‹"kRCHigh1"›, ‹"kRCHigh2"›, ‹"kRCHigh3"›, ‹"kRCHigh4"›, ‹"kRCNormal1"› ... ‹"kSSIHigh4"›, ‹"kSSINormal1"›, ‹"kSSINormal2"›, ‹"kSSINormal3"›, ‹"kSSINormal4"›, released latches
+[6] handle lock conflict error reqDiscoverInitial: handled conflicting intents on ‹"kRCHigh1"›, ‹"kRCHigh2"›, ‹"kRCHigh3"›, ‹"kRCHigh4"›, ‹"kRCNormal1"› ... ‹"kSSIHigh4"›, ‹"kSSINormal1"›, ‹"kSSINormal2"›, ‹"kSSINormal3"›, ‹"kSSINormal4"›, released latches
 
 finish req=reqDiscoverInitial
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/isolation_level
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/isolation_level
@@ -209,7 +209,7 @@ handle-lock-conflict-error req=reqDiscoverInitial lease-seq=1
   lock txn=txnSSINormalPushee  key=kSSINormal3
   lock txn=txnSSINormalPushee  key=kSSINormal4
 ----
-[6] handle lock conflict error reqDiscoverInitial: handled conflicting intents on ‹"kRCHigh1"›, ‹"kRCHigh2"›, ‹"kRCHigh3"›, ‹"kRCHigh4"›, ‹"kRCNormal1"› ... ‹"kSSIHigh4"›, ‹"kSSINormal1"›, ‹"kSSINormal2"›, ‹"kSSINormal3"›, ‹"kSSINormal4"›, released latches
+[6] handle lock conflict error reqDiscoverInitial: handled conflicting locks on ‹"kRCHigh1"›, ‹"kRCHigh2"›, ‹"kRCHigh3"›, ‹"kRCHigh4"›, ‹"kRCNormal1"› ... ‹"kSSIHigh4"›, ‹"kSSINormal1"›, ‹"kSSINormal2"›, ‹"kSSINormal3"›, ‹"kSSINormal4"›, released latches
 
 finish req=reqDiscoverInitial
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/lock_timeout
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/lock_timeout
@@ -185,10 +185,10 @@ sequence req=reqTimeout3
 [7] sequence reqTimeout3: scanning lock table for conflicting locks
 [7] sequence reqTimeout3: sequencing complete, returned guard
 
-handle-write-intent-error req=reqTimeout3 lease-seq=1
-  intent txn=txn2 key=k4
+handle-lock-conflict-error req=reqTimeout3 lease-seq=1
+  lock txn=txn2 key=k4
 ----
-[8] handle write intent error reqTimeout3: handled conflicting intents on ‹"k4"›, released latches
+[8] handle lock conflict error reqTimeout3: handled conflicting intents on ‹"k4"›, released latches
 
 sequence req=reqTimeout3
 ----
@@ -243,10 +243,10 @@ sequence req=reqTimeout4
 [10] sequence reqTimeout4: scanning lock table for conflicting locks
 [10] sequence reqTimeout4: sequencing complete, returned guard
 
-handle-write-intent-error req=reqTimeout4 lease-seq=1
-  intent txn=txn2 key=k5
+handle-lock-conflict-error req=reqTimeout4 lease-seq=1
+  lock txn=txn2 key=k5
 ----
-[11] handle write intent error reqTimeout4: handled conflicting intents on ‹"k5"›, released latches
+[11] handle lock conflict error reqTimeout4: handled conflicting intents on ‹"k5"›, released latches
 
 sequence req=reqTimeout4
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/lock_timeout
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/lock_timeout
@@ -108,7 +108,7 @@ sequence req=reqTimeout1
 [4] sequence reqTimeout1: pushing txn 00000001 to check if abandoned
 [4] sequence reqTimeout1: pushee not abandoned
 [4] sequence reqTimeout1: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"k"› for 0.000s
-[4] sequence reqTimeout1: sequencing complete, returned error: conflicting intents on ‹"k"› [reason=lock_timeout]
+[4] sequence reqTimeout1: sequencing complete, returned error: conflicting locks on ‹"k"› [reason=lock_timeout]
 
 # -------------------------------------------------------------
 # Read-only request with lock timeout hits abandoned lock.
@@ -167,7 +167,7 @@ sequence req=reqTimeout2
 [6] sequence reqTimeout2: lock wait-queue event: wait for (distinguished) txn 00000003 running request @ key ‹"k2"› (queuedWriters: 2, queuedReaders: 0)
 [6] sequence reqTimeout2: pushing after 0s for: liveness detection = false, deadlock detection = true, timeout enforcement = true, priority enforcement = false
 [6] sequence reqTimeout2: conflicted with ‹00000003-0000-0000-0000-000000000000› on ‹"k2"› for 0.000s
-[6] sequence reqTimeout2: sequencing complete, returned error: conflicting intents on ‹"k2"› [reason=lock_timeout]
+[6] sequence reqTimeout2: sequencing complete, returned error: conflicting locks on ‹"k2"› [reason=lock_timeout]
 
 # -------------------------------------------------------------
 # Read-only request with lock timeout discovers lock. The
@@ -188,7 +188,7 @@ sequence req=reqTimeout3
 handle-lock-conflict-error req=reqTimeout3 lease-seq=1
   lock txn=txn2 key=k4
 ----
-[8] handle lock conflict error reqTimeout3: handled conflicting intents on ‹"k4"›, released latches
+[8] handle lock conflict error reqTimeout3: handled conflicting locks on ‹"k4"›, released latches
 
 sequence req=reqTimeout3
 ----
@@ -201,7 +201,7 @@ sequence req=reqTimeout3
 [9] sequence reqTimeout3: pushing txn 00000002 to check if abandoned
 [9] sequence reqTimeout3: pushee not abandoned
 [9] sequence reqTimeout3: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"k4"› for 0.000s
-[9] sequence reqTimeout3: sequencing complete, returned error: conflicting intents on ‹"k4"› [reason=lock_timeout]
+[9] sequence reqTimeout3: sequencing complete, returned error: conflicting locks on ‹"k4"› [reason=lock_timeout]
 
 debug-lock-table
 ----
@@ -246,7 +246,7 @@ sequence req=reqTimeout4
 handle-lock-conflict-error req=reqTimeout4 lease-seq=1
   lock txn=txn2 key=k5
 ----
-[11] handle lock conflict error reqTimeout4: handled conflicting intents on ‹"k5"›, released latches
+[11] handle lock conflict error reqTimeout4: handled conflicting locks on ‹"k5"›, released latches
 
 sequence req=reqTimeout4
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/queue_length_exceeded
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/queue_length_exceeded
@@ -191,7 +191,7 @@ sequence req=req5w
 [6] sequence req5w: scanning lock table for conflicting locks
 [6] sequence req5w: waiting in lock wait-queues
 [6] sequence req5w: lock wait-queue event: wait-queue maximum length exceeded @ key ‹"k"› with length 2
-[6] sequence req5w: sequencing complete, returned error: conflicting intents on ‹"k"› [reason=lock_wait_queue_max_length_exceeded]
+[6] sequence req5w: sequencing complete, returned error: conflicting locks on ‹"k"› [reason=lock_wait_queue_max_length_exceeded]
 
 # -------------------------------------------------------------
 # Cleanup.

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/range_state_listener
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/range_state_listener
@@ -126,7 +126,7 @@ handle-lock-conflict-error req=req2 lease-seq=1
   lock txn=txn1 key=k
 ----
 [3] handle lock conflict error req2: intent on ‹"k"› discovered but not added to disabled lock table
-[3] handle lock conflict error req2: handled conflicting intents on ‹"k"›, released latches
+[3] handle lock conflict error req2: handled conflicting locks on ‹"k"›, released latches
 
 debug-lock-table
 ----
@@ -158,7 +158,7 @@ sequence req=req2
 handle-lock-conflict-error req=req2 lease-seq=2
   lock txn=txn1 key=k
 ----
-[6] handle lock conflict error req2: handled conflicting intents on ‹"k"›, released latches
+[6] handle lock conflict error req2: handled conflicting locks on ‹"k"›, released latches
 
 debug-lock-table
 ----
@@ -257,7 +257,7 @@ handle-lock-conflict-error req=req3 lease-seq=2
   lock txn=txn1 key=k
 ----
 [10] handle lock conflict error req3: intent on ‹"k"› discovered but not added to disabled lock table
-[10] handle lock conflict error req3: handled conflicting intents on ‹"k"›, released latches
+[10] handle lock conflict error req3: handled conflicting locks on ‹"k"›, released latches
 
 debug-lock-table
 ----
@@ -273,7 +273,7 @@ sequence req=req3
 handle-lock-conflict-error req=req3 lease-seq=4
   lock txn=txn2 key=k
 ----
-[12] handle lock conflict error req3: handled conflicting intents on ‹"k"›, released latches
+[12] handle lock conflict error req3: handled conflicting locks on ‹"k"›, released latches
 
 debug-lock-table
 ----
@@ -431,7 +431,7 @@ num=0
 handle-lock-conflict-error req=req2 lease-seq=1
   lock txn=txn1 key=k
 ----
-[3] handle lock conflict error req2: handled conflicting intents on ‹"k"›, released latches
+[3] handle lock conflict error req2: handled conflicting locks on ‹"k"›, released latches
 
 debug-lock-table
 ----
@@ -623,7 +623,7 @@ handle-lock-conflict-error req=req2 lease-seq=1
   lock txn=txn1 key=k
 ----
 [4] handle lock conflict error req2: intent on ‹"k"› discovered but not added to disabled lock table
-[4] handle lock conflict error req2: handled conflicting intents on ‹"k"›, released latches
+[4] handle lock conflict error req2: handled conflicting locks on ‹"k"›, released latches
 
 sequence req=req2
 ----
@@ -651,7 +651,7 @@ sequence req=req2
 handle-lock-conflict-error req=req2 lease-seq=2
   lock txn=txn1 key=k
 ----
-[7] handle lock conflict error req2: handled conflicting intents on ‹"k"›, released latches
+[7] handle lock conflict error req2: handled conflicting locks on ‹"k"›, released latches
 
 debug-lock-table
 ----
@@ -809,7 +809,7 @@ num=0
 handle-lock-conflict-error req=req2 lease-seq=1
   lock txn=txn1 key=k
 ----
-[3] handle lock conflict error req2: handled conflicting intents on ‹"k"›, released latches
+[3] handle lock conflict error req2: handled conflicting locks on ‹"k"›, released latches
 
 debug-lock-table
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/range_state_listener
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/range_state_listener
@@ -122,11 +122,11 @@ debug-lock-table
 ----
 num=0
 
-handle-write-intent-error req=req2 lease-seq=1
-  intent txn=txn1 key=k
+handle-lock-conflict-error req=req2 lease-seq=1
+  lock txn=txn1 key=k
 ----
-[3] handle write intent error req2: intent on ‹"k"› discovered but not added to disabled lock table
-[3] handle write intent error req2: handled conflicting intents on ‹"k"›, released latches
+[3] handle lock conflict error req2: intent on ‹"k"› discovered but not added to disabled lock table
+[3] handle lock conflict error req2: handled conflicting intents on ‹"k"›, released latches
 
 debug-lock-table
 ----
@@ -155,10 +155,10 @@ sequence req=req2
 [5] sequence req2: scanning lock table for conflicting locks
 [5] sequence req2: sequencing complete, returned guard
 
-handle-write-intent-error req=req2 lease-seq=2
-  intent txn=txn1 key=k
+handle-lock-conflict-error req=req2 lease-seq=2
+  lock txn=txn1 key=k
 ----
-[6] handle write intent error req2: handled conflicting intents on ‹"k"›, released latches
+[6] handle lock conflict error req2: handled conflicting intents on ‹"k"›, released latches
 
 debug-lock-table
 ----
@@ -253,11 +253,11 @@ sequence req=req3
 # this entire time. This isn't quite realistic, given the setup of this
 # test, but it is possible (see discover_lock_after_lease_race) and the
 # discovery should be ignored.
-handle-write-intent-error req=req3 lease-seq=2
-  intent txn=txn1 key=k
+handle-lock-conflict-error req=req3 lease-seq=2
+  lock txn=txn1 key=k
 ----
-[10] handle write intent error req3: intent on ‹"k"› discovered but not added to disabled lock table
-[10] handle write intent error req3: handled conflicting intents on ‹"k"›, released latches
+[10] handle lock conflict error req3: intent on ‹"k"› discovered but not added to disabled lock table
+[10] handle lock conflict error req3: handled conflicting intents on ‹"k"›, released latches
 
 debug-lock-table
 ----
@@ -270,10 +270,10 @@ sequence req=req3
 [11] sequence req3: scanning lock table for conflicting locks
 [11] sequence req3: sequencing complete, returned guard
 
-handle-write-intent-error req=req3 lease-seq=4
-  intent txn=txn2 key=k
+handle-lock-conflict-error req=req3 lease-seq=4
+  lock txn=txn2 key=k
 ----
-[12] handle write intent error req3: handled conflicting intents on ‹"k"›, released latches
+[12] handle lock conflict error req3: handled conflicting intents on ‹"k"›, released latches
 
 debug-lock-table
 ----
@@ -428,10 +428,10 @@ debug-lock-table
 ----
 num=0
 
-handle-write-intent-error req=req2 lease-seq=1
-  intent txn=txn1 key=k
+handle-lock-conflict-error req=req2 lease-seq=1
+  lock txn=txn1 key=k
 ----
-[3] handle write intent error req2: handled conflicting intents on ‹"k"›, released latches
+[3] handle lock conflict error req2: handled conflicting intents on ‹"k"›, released latches
 
 debug-lock-table
 ----
@@ -619,11 +619,11 @@ finish req=req3
 ----
 [-] finish req3: finishing request
 
-handle-write-intent-error req=req2 lease-seq=1
-  intent txn=txn1 key=k
+handle-lock-conflict-error req=req2 lease-seq=1
+  lock txn=txn1 key=k
 ----
-[4] handle write intent error req2: intent on ‹"k"› discovered but not added to disabled lock table
-[4] handle write intent error req2: handled conflicting intents on ‹"k"›, released latches
+[4] handle lock conflict error req2: intent on ‹"k"› discovered but not added to disabled lock table
+[4] handle lock conflict error req2: handled conflicting intents on ‹"k"›, released latches
 
 sequence req=req2
 ----
@@ -648,10 +648,10 @@ sequence req=req2
 [6] sequence req2: scanning lock table for conflicting locks
 [6] sequence req2: sequencing complete, returned guard
 
-handle-write-intent-error req=req2 lease-seq=2
-  intent txn=txn1 key=k
+handle-lock-conflict-error req=req2 lease-seq=2
+  lock txn=txn1 key=k
 ----
-[7] handle write intent error req2: handled conflicting intents on ‹"k"›, released latches
+[7] handle lock conflict error req2: handled conflicting intents on ‹"k"›, released latches
 
 debug-lock-table
 ----
@@ -806,10 +806,10 @@ debug-lock-table
 ----
 num=0
 
-handle-write-intent-error req=req2 lease-seq=1
-  intent txn=txn1 key=k
+handle-lock-conflict-error req=req2 lease-seq=1
+  lock txn=txn1 key=k
 ----
-[3] handle write intent error req2: handled conflicting intents on ‹"k"›, released latches
+[3] handle lock conflict error req2: handled conflicting intents on ‹"k"›, released latches
 
 debug-lock-table
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/resolve_pushed_intents
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/resolve_pushed_intents
@@ -34,7 +34,7 @@ handle-lock-conflict-error req=req1 lease-seq=1
   lock txn=txn2 key=i
   lock txn=txn2 key=j
 ----
-[2] handle lock conflict error req1: handled conflicting intents on ‹"a"›, ‹"b"›, ‹"c"›, ‹"d"›, ‹"e"›, ‹"f"›, ‹"g"›, ‹"h"›, ‹"i"›, ‹"j"›, released latches
+[2] handle lock conflict error req1: handled conflicting locks on ‹"a"›, ‹"b"›, ‹"c"›, ‹"d"›, ‹"e"›, ‹"f"›, ‹"g"›, ‹"h"›, ‹"i"›, ‹"j"›, released latches
 
 debug-lock-table
 ----
@@ -162,7 +162,7 @@ handle-lock-conflict-error req=req1 lease-seq=1
   lock txn=txn2 key=a
   lock txn=txn2 key=b
 ----
-[2] handle lock conflict error req1: handled conflicting intents on ‹"a"›, ‹"b"›, released latches
+[2] handle lock conflict error req1: handled conflicting locks on ‹"a"›, ‹"b"›, released latches
 
 debug-lock-table
 ----
@@ -270,7 +270,7 @@ handle-lock-conflict-error req=req1 lease-seq=1
   lock txn=txn2 key=b
   lock txn=txn2 key=c
 ----
-[2] handle lock conflict error req1: handled conflicting intents on ‹"a"›, ‹"b"›, ‹"c"›, released latches
+[2] handle lock conflict error req1: handled conflicting locks on ‹"a"›, ‹"b"›, ‹"c"›, released latches
 
 debug-lock-table
 ----
@@ -360,7 +360,7 @@ handle-lock-conflict-error req=req1 lease-seq=1
   lock txn=txn2 key=i
   lock txn=txn2 key=j
 ----
-[2] handle lock conflict error req1: handled conflicting intents on ‹"a"›, ‹"b"›, ‹"c"›, ‹"d"›, ‹"e"›, ‹"f"›, ‹"g"›, ‹"h"›, ‹"i"›, ‹"j"›, released latches
+[2] handle lock conflict error req1: handled conflicting locks on ‹"a"›, ‹"b"›, ‹"c"›, ‹"d"›, ‹"e"›, ‹"f"›, ‹"g"›, ‹"h"›, ‹"i"›, ‹"j"›, released latches
 
 debug-lock-table
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/resolve_pushed_intents
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/resolve_pushed_intents
@@ -22,19 +22,19 @@ sequence req=req1
 [1] sequence req1: scanning lock table for conflicting locks
 [1] sequence req1: sequencing complete, returned guard
 
-handle-write-intent-error req=req1 lease-seq=1
-  intent txn=txn2 key=a
-  intent txn=txn2 key=b
-  intent txn=txn2 key=c
-  intent txn=txn2 key=d
-  intent txn=txn2 key=e
-  intent txn=txn2 key=f
-  intent txn=txn2 key=g
-  intent txn=txn2 key=h
-  intent txn=txn2 key=i
-  intent txn=txn2 key=j
+handle-lock-conflict-error req=req1 lease-seq=1
+  lock txn=txn2 key=a
+  lock txn=txn2 key=b
+  lock txn=txn2 key=c
+  lock txn=txn2 key=d
+  lock txn=txn2 key=e
+  lock txn=txn2 key=f
+  lock txn=txn2 key=g
+  lock txn=txn2 key=h
+  lock txn=txn2 key=i
+  lock txn=txn2 key=j
 ----
-[2] handle write intent error req1: handled conflicting intents on ‹"a"›, ‹"b"›, ‹"c"›, ‹"d"›, ‹"e"›, ‹"f"›, ‹"g"›, ‹"h"›, ‹"i"›, ‹"j"›, released latches
+[2] handle lock conflict error req1: handled conflicting intents on ‹"a"›, ‹"b"›, ‹"c"›, ‹"d"›, ‹"e"›, ‹"f"›, ‹"g"›, ‹"h"›, ‹"i"›, ‹"j"›, released latches
 
 debug-lock-table
 ----
@@ -158,11 +158,11 @@ sequence req=req1
 [1] sequence req1: scanning lock table for conflicting locks
 [1] sequence req1: sequencing complete, returned guard
 
-handle-write-intent-error req=req1 lease-seq=1
-  intent txn=txn2 key=a
-  intent txn=txn2 key=b
+handle-lock-conflict-error req=req1 lease-seq=1
+  lock txn=txn2 key=a
+  lock txn=txn2 key=b
 ----
-[2] handle write intent error req1: handled conflicting intents on ‹"a"›, ‹"b"›, released latches
+[2] handle lock conflict error req1: handled conflicting intents on ‹"a"›, ‹"b"›, released latches
 
 debug-lock-table
 ----
@@ -265,12 +265,12 @@ sequence req=req1
 [1] sequence req1: scanning lock table for conflicting locks
 [1] sequence req1: sequencing complete, returned guard
 
-handle-write-intent-error req=req1 lease-seq=1
-  intent txn=txn2 key=a
-  intent txn=txn2 key=b
-  intent txn=txn2 key=c
+handle-lock-conflict-error req=req1 lease-seq=1
+  lock txn=txn2 key=a
+  lock txn=txn2 key=b
+  lock txn=txn2 key=c
 ----
-[2] handle write intent error req1: handled conflicting intents on ‹"a"›, ‹"b"›, ‹"c"›, released latches
+[2] handle lock conflict error req1: handled conflicting intents on ‹"a"›, ‹"b"›, ‹"c"›, released latches
 
 debug-lock-table
 ----
@@ -348,19 +348,19 @@ sequence req=req1
 [1] sequence req1: scanning lock table for conflicting locks
 [1] sequence req1: sequencing complete, returned guard
 
-handle-write-intent-error req=req1 lease-seq=1
-  intent txn=txn2 key=a
-  intent txn=txn2 key=b
-  intent txn=txn2 key=c
-  intent txn=txn2 key=d
-  intent txn=txn2 key=e
-  intent txn=txn2 key=f
-  intent txn=txn2 key=g
-  intent txn=txn2 key=h
-  intent txn=txn2 key=i
-  intent txn=txn2 key=j
+handle-lock-conflict-error req=req1 lease-seq=1
+  lock txn=txn2 key=a
+  lock txn=txn2 key=b
+  lock txn=txn2 key=c
+  lock txn=txn2 key=d
+  lock txn=txn2 key=e
+  lock txn=txn2 key=f
+  lock txn=txn2 key=g
+  lock txn=txn2 key=h
+  lock txn=txn2 key=i
+  lock txn=txn2 key=j
 ----
-[2] handle write intent error req1: handled conflicting intents on ‹"a"›, ‹"b"›, ‹"c"›, ‹"d"›, ‹"e"›, ‹"f"›, ‹"g"›, ‹"h"›, ‹"i"›, ‹"j"›, released latches
+[2] handle lock conflict error req1: handled conflicting intents on ‹"a"›, ‹"b"›, ‹"c"›, ‹"d"›, ‹"e"›, ‹"f"›, ‹"g"›, ‹"h"›, ‹"i"›, ‹"j"›, released latches
 
 debug-lock-table
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/resolve_pushed_intents_without_adding_to_lock_table
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/resolve_pushed_intents_without_adding_to_lock_table
@@ -28,7 +28,7 @@ sequence req=req1
 handle-lock-conflict-error req=req1 lease-seq=1
   lock txn=txn2 key=a
 ----
-[2] handle lock conflict error req1: handled conflicting intents on ‹"a"›, released latches
+[2] handle lock conflict error req1: handled conflicting locks on ‹"a"›, released latches
 
 debug-lock-table
 ----
@@ -94,7 +94,7 @@ handle-lock-conflict-error req=req2 lease-seq=1
 [5] handle lock conflict error req2: resolving intent ‹"h"› for txn 00000002 with PENDING status
 [5] handle lock conflict error req2: resolving intent ‹"i"› for txn 00000002 with PENDING status
 [5] handle lock conflict error req2: resolving intent ‹"j"› for txn 00000002 with PENDING status
-[5] handle lock conflict error req2: handled conflicting intents on ‹"b"›, ‹"c"›, ‹"d"›, ‹"e"›, ‹"f"›, ‹"g"›, ‹"h"›, ‹"i"›, ‹"j"›, released latches
+[5] handle lock conflict error req2: handled conflicting locks on ‹"b"›, ‹"c"›, ‹"d"›, ‹"e"›, ‹"f"›, ‹"g"›, ‹"h"›, ‹"i"›, ‹"j"›, released latches
 
 debug-lock-table
 ----
@@ -140,7 +140,7 @@ sequence req=req1
 handle-lock-conflict-error req=req1 lease-seq=1
   lock txn=txn2 key=a
 ----
-[2] handle lock conflict error req1: handled conflicting intents on ‹"a"›, released latches
+[2] handle lock conflict error req1: handled conflicting locks on ‹"a"›, released latches
 
 debug-lock-table
 ----
@@ -196,7 +196,7 @@ handle-lock-conflict-error req=req2 lease-seq=1
   lock txn=txn2 key=i
   lock txn=txn2 key=j
 ----
-[5] handle lock conflict error req2: handled conflicting intents on ‹"b"›, ‹"c"›, ‹"d"›, ‹"e"›, ‹"f"›, ‹"g"›, ‹"h"›, ‹"i"›, ‹"j"›, released latches
+[5] handle lock conflict error req2: handled conflicting locks on ‹"b"›, ‹"c"›, ‹"d"›, ‹"e"›, ‹"f"›, ‹"g"›, ‹"h"›, ‹"i"›, ‹"j"›, released latches
 
 debug-lock-table
 ----
@@ -311,7 +311,7 @@ sequence req=req1
 handle-lock-conflict-error req=req1 lease-seq=1
   lock txn=txn2 key=a
 ----
-[2] handle lock conflict error req1: handled conflicting intents on ‹"a"›, released latches
+[2] handle lock conflict error req1: handled conflicting locks on ‹"a"›, released latches
 
 debug-lock-table
 ----
@@ -367,7 +367,7 @@ handle-lock-conflict-error req=req2 lease-seq=1
   lock txn=txn2 key=i
   lock txn=txn2 key=j
 ----
-[5] handle lock conflict error req2: handled conflicting intents on ‹"b"›, ‹"c"›, ‹"d"›, ‹"e"›, ‹"f"›, ‹"g"›, ‹"h"›, ‹"i"›, ‹"j"›, released latches
+[5] handle lock conflict error req2: handled conflicting locks on ‹"b"›, ‹"c"›, ‹"d"›, ‹"e"›, ‹"f"›, ‹"g"›, ‹"h"›, ‹"i"›, ‹"j"›, released latches
 
 debug-lock-table
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/resolve_pushed_intents_without_adding_to_lock_table
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/resolve_pushed_intents_without_adding_to_lock_table
@@ -25,10 +25,10 @@ sequence req=req1
 [1] sequence req1: scanning lock table for conflicting locks
 [1] sequence req1: sequencing complete, returned guard
 
-handle-write-intent-error req=req1 lease-seq=1
-  intent txn=txn2 key=a
+handle-lock-conflict-error req=req1 lease-seq=1
+  lock txn=txn2 key=a
 ----
-[2] handle write intent error req1: handled conflicting intents on ‹"a"›, released latches
+[2] handle lock conflict error req1: handled conflicting intents on ‹"a"›, released latches
 
 debug-lock-table
 ----
@@ -72,29 +72,29 @@ sequence req=req2
 [4] sequence req2: scanning lock table for conflicting locks
 [4] sequence req2: sequencing complete, returned guard
 
-# The intents get resolved instead of being added to the lock table.
-handle-write-intent-error req=req2 lease-seq=1
-  intent txn=txn2 key=b
-  intent txn=txn2 key=c
-  intent txn=txn2 key=d
-  intent txn=txn2 key=e
-  intent txn=txn2 key=f
-  intent txn=txn2 key=g
-  intent txn=txn2 key=h
-  intent txn=txn2 key=i
-  intent txn=txn2 key=j
+# The locks get resolved instead of being added to the lock table.
+handle-lock-conflict-error req=req2 lease-seq=1
+  lock txn=txn2 key=b
+  lock txn=txn2 key=c
+  lock txn=txn2 key=d
+  lock txn=txn2 key=e
+  lock txn=txn2 key=f
+  lock txn=txn2 key=g
+  lock txn=txn2 key=h
+  lock txn=txn2 key=i
+  lock txn=txn2 key=j
 ----
-[5] handle write intent error req2: resolving a batch of 9 intent(s)
-[5] handle write intent error req2: resolving intent ‹"b"› for txn 00000002 with PENDING status
-[5] handle write intent error req2: resolving intent ‹"c"› for txn 00000002 with PENDING status
-[5] handle write intent error req2: resolving intent ‹"d"› for txn 00000002 with PENDING status
-[5] handle write intent error req2: resolving intent ‹"e"› for txn 00000002 with PENDING status
-[5] handle write intent error req2: resolving intent ‹"f"› for txn 00000002 with PENDING status
-[5] handle write intent error req2: resolving intent ‹"g"› for txn 00000002 with PENDING status
-[5] handle write intent error req2: resolving intent ‹"h"› for txn 00000002 with PENDING status
-[5] handle write intent error req2: resolving intent ‹"i"› for txn 00000002 with PENDING status
-[5] handle write intent error req2: resolving intent ‹"j"› for txn 00000002 with PENDING status
-[5] handle write intent error req2: handled conflicting intents on ‹"b"›, ‹"c"›, ‹"d"›, ‹"e"›, ‹"f"›, ‹"g"›, ‹"h"›, ‹"i"›, ‹"j"›, released latches
+[5] handle lock conflict error req2: resolving a batch of 9 intent(s)
+[5] handle lock conflict error req2: resolving intent ‹"b"› for txn 00000002 with PENDING status
+[5] handle lock conflict error req2: resolving intent ‹"c"› for txn 00000002 with PENDING status
+[5] handle lock conflict error req2: resolving intent ‹"d"› for txn 00000002 with PENDING status
+[5] handle lock conflict error req2: resolving intent ‹"e"› for txn 00000002 with PENDING status
+[5] handle lock conflict error req2: resolving intent ‹"f"› for txn 00000002 with PENDING status
+[5] handle lock conflict error req2: resolving intent ‹"g"› for txn 00000002 with PENDING status
+[5] handle lock conflict error req2: resolving intent ‹"h"› for txn 00000002 with PENDING status
+[5] handle lock conflict error req2: resolving intent ‹"i"› for txn 00000002 with PENDING status
+[5] handle lock conflict error req2: resolving intent ‹"j"› for txn 00000002 with PENDING status
+[5] handle lock conflict error req2: handled conflicting intents on ‹"b"›, ‹"c"›, ‹"d"›, ‹"e"›, ‹"f"›, ‹"g"›, ‹"h"›, ‹"i"›, ‹"j"›, released latches
 
 debug-lock-table
 ----
@@ -137,10 +137,10 @@ sequence req=req1
 [1] sequence req1: scanning lock table for conflicting locks
 [1] sequence req1: sequencing complete, returned guard
 
-handle-write-intent-error req=req1 lease-seq=1
-  intent txn=txn2 key=a
+handle-lock-conflict-error req=req1 lease-seq=1
+  lock txn=txn2 key=a
 ----
-[2] handle write intent error req1: handled conflicting intents on ‹"a"›, released latches
+[2] handle lock conflict error req1: handled conflicting intents on ‹"a"›, released latches
 
 debug-lock-table
 ----
@@ -184,19 +184,19 @@ sequence req=req2
 [4] sequence req2: scanning lock table for conflicting locks
 [4] sequence req2: sequencing complete, returned guard
 
-# The intents get resolved instead of being added to the lock table.
-handle-write-intent-error req=req2 lease-seq=1
-  intent txn=txn2 key=b
-  intent txn=txn2 key=c
-  intent txn=txn2 key=d
-  intent txn=txn2 key=e
-  intent txn=txn2 key=f
-  intent txn=txn2 key=g
-  intent txn=txn2 key=h
-  intent txn=txn2 key=i
-  intent txn=txn2 key=j
+# The locks get resolved instead of being added to the lock table.
+handle-lock-conflict-error req=req2 lease-seq=1
+  lock txn=txn2 key=b
+  lock txn=txn2 key=c
+  lock txn=txn2 key=d
+  lock txn=txn2 key=e
+  lock txn=txn2 key=f
+  lock txn=txn2 key=g
+  lock txn=txn2 key=h
+  lock txn=txn2 key=i
+  lock txn=txn2 key=j
 ----
-[5] handle write intent error req2: handled conflicting intents on ‹"b"›, ‹"c"›, ‹"d"›, ‹"e"›, ‹"f"›, ‹"g"›, ‹"h"›, ‹"i"›, ‹"j"›, released latches
+[5] handle lock conflict error req2: handled conflicting intents on ‹"b"›, ‹"c"›, ‹"d"›, ‹"e"›, ‹"f"›, ‹"g"›, ‹"h"›, ‹"i"›, ‹"j"›, released latches
 
 debug-lock-table
 ----
@@ -308,10 +308,10 @@ sequence req=req1
 [1] sequence req1: scanning lock table for conflicting locks
 [1] sequence req1: sequencing complete, returned guard
 
-handle-write-intent-error req=req1 lease-seq=1
-  intent txn=txn2 key=a
+handle-lock-conflict-error req=req1 lease-seq=1
+  lock txn=txn2 key=a
 ----
-[2] handle write intent error req1: handled conflicting intents on ‹"a"›, released latches
+[2] handle lock conflict error req1: handled conflicting intents on ‹"a"›, released latches
 
 debug-lock-table
 ----
@@ -355,19 +355,19 @@ sequence req=req2
 [4] sequence req2: scanning lock table for conflicting locks
 [4] sequence req2: sequencing complete, returned guard
 
-# The intents get resolved instead of being added to the lock table.
-handle-write-intent-error req=req2 lease-seq=1
-  intent txn=txn2 key=b
-  intent txn=txn2 key=c
-  intent txn=txn2 key=d
-  intent txn=txn2 key=e
-  intent txn=txn2 key=f
-  intent txn=txn2 key=g
-  intent txn=txn2 key=h
-  intent txn=txn2 key=i
-  intent txn=txn2 key=j
+# The locks get resolved instead of being added to the lock table.
+handle-lock-conflict-error req=req2 lease-seq=1
+  lock txn=txn2 key=b
+  lock txn=txn2 key=c
+  lock txn=txn2 key=d
+  lock txn=txn2 key=e
+  lock txn=txn2 key=f
+  lock txn=txn2 key=g
+  lock txn=txn2 key=h
+  lock txn=txn2 key=i
+  lock txn=txn2 key=j
 ----
-[5] handle write intent error req2: handled conflicting intents on ‹"b"›, ‹"c"›, ‹"d"›, ‹"e"›, ‹"f"›, ‹"g"›, ‹"h"›, ‹"i"›, ‹"j"›, released latches
+[5] handle lock conflict error req2: handled conflicting intents on ‹"b"›, ‹"c"›, ‹"d"›, ‹"e"›, ‹"f"›, ‹"g"›, ‹"h"›, ‹"i"›, ‹"j"›, released latches
 
 debug-lock-table
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/uncertainty
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/uncertainty
@@ -25,7 +25,7 @@ sequence req=req1
 handle-lock-conflict-error req=req1 lease-seq=1
   lock txn=txn1 key=k
 ----
-[2] handle lock conflict error req1: handled conflicting intents on ‹"k"›, released latches
+[2] handle lock conflict error req1: handled conflicting locks on ‹"k"›, released latches
 
 debug-lock-table
 ----
@@ -91,7 +91,7 @@ sequence req=req1
 handle-lock-conflict-error req=req1 lease-seq=1
   lock txn=txn1 key=k
 ----
-[2] handle lock conflict error req1: handled conflicting intents on ‹"k"›, released latches
+[2] handle lock conflict error req1: handled conflicting locks on ‹"k"›, released latches
 
 debug-lock-table
 ----
@@ -160,7 +160,7 @@ sequence req=req1
 handle-lock-conflict-error req=req1 lease-seq=1
   lock txn=txn1 key=k
 ----
-[2] handle lock conflict error req1: handled conflicting intents on ‹"k"›, released latches
+[2] handle lock conflict error req1: handled conflicting locks on ‹"k"›, released latches
 
 debug-lock-table
 ----
@@ -235,7 +235,7 @@ sequence req=req1
 handle-lock-conflict-error req=req1 lease-seq=1
   lock txn=txn1 key=k
 ----
-[2] handle lock conflict error req1: handled conflicting intents on ‹"k"›, released latches
+[2] handle lock conflict error req1: handled conflicting locks on ‹"k"›, released latches
 
 debug-lock-table
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/uncertainty
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/uncertainty
@@ -22,10 +22,10 @@ sequence req=req1
 [1] sequence req1: scanning lock table for conflicting locks
 [1] sequence req1: sequencing complete, returned guard
 
-handle-write-intent-error req=req1 lease-seq=1
-  intent txn=txn1 key=k
+handle-lock-conflict-error req=req1 lease-seq=1
+  lock txn=txn1 key=k
 ----
-[2] handle write intent error req1: handled conflicting intents on ‹"k"›, released latches
+[2] handle lock conflict error req1: handled conflicting intents on ‹"k"›, released latches
 
 debug-lock-table
 ----
@@ -88,10 +88,10 @@ sequence req=req1
 [1] sequence req1: scanning lock table for conflicting locks
 [1] sequence req1: sequencing complete, returned guard
 
-handle-write-intent-error req=req1 lease-seq=1
-  intent txn=txn1 key=k
+handle-lock-conflict-error req=req1 lease-seq=1
+  lock txn=txn1 key=k
 ----
-[2] handle write intent error req1: handled conflicting intents on ‹"k"›, released latches
+[2] handle lock conflict error req1: handled conflicting intents on ‹"k"›, released latches
 
 debug-lock-table
 ----
@@ -157,10 +157,10 @@ sequence req=req1
 [1] sequence req1: scanning lock table for conflicting locks
 [1] sequence req1: sequencing complete, returned guard
 
-handle-write-intent-error req=req1 lease-seq=1
-  intent txn=txn1 key=k
+handle-lock-conflict-error req=req1 lease-seq=1
+  lock txn=txn1 key=k
 ----
-[2] handle write intent error req1: handled conflicting intents on ‹"k"›, released latches
+[2] handle lock conflict error req1: handled conflicting intents on ‹"k"›, released latches
 
 debug-lock-table
 ----
@@ -232,10 +232,10 @@ sequence req=req1
 [1] sequence req1: scanning lock table for conflicting locks
 [1] sequence req1: sequencing complete, returned guard
 
-handle-write-intent-error req=req1 lease-seq=1
-  intent txn=txn1 key=k
+handle-lock-conflict-error req=req1 lease-seq=1
+  lock txn=txn1 key=k
 ----
-[2] handle write intent error req1: handled conflicting intents on ‹"k"›, released latches
+[2] handle lock conflict error req1: handled conflicting intents on ‹"k"›, released latches
 
 debug-lock-table
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_elsewhere
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_elsewhere
@@ -49,10 +49,10 @@ sequence req=reqWaiter
 
 # Simulate that the replicated lock was discovered, so it's added to the lock
 # table.
-handle-write-intent-error req=reqWaiter lease-seq=1
- intent txn=txnWriter key=k
+handle-lock-conflict-error req=reqWaiter lease-seq=1
+  lock txn=txnWriter key=k
 ----
-[3] handle write intent error reqWaiter: handled conflicting intents on ‹"k"›, released latches
+[3] handle lock conflict error reqWaiter: handled conflicting intents on ‹"k"›, released latches
 
 sequence req=reqWaiter
 ----
@@ -190,11 +190,11 @@ sequence req=reqThreeKeyWaiter
 
 # Simulate that the replicated locks were discovered, so they are added to the
 # lock table.
-handle-write-intent-error req=reqTwoKeyWaiter lease-seq=1
- intent txn=txnThreeKeyWriter key=k1
- intent txn=txnThreeKeyWriter key=k2
+handle-lock-conflict-error req=reqTwoKeyWaiter lease-seq=1
+  lock txn=txnThreeKeyWriter key=k1
+  lock txn=txnThreeKeyWriter key=k2
 ----
-[9] handle write intent error reqTwoKeyWaiter: handled conflicting intents on ‹"k1"›, ‹"k2"›, released latches
+[9] handle lock conflict error reqTwoKeyWaiter: handled conflicting intents on ‹"k1"›, ‹"k2"›, released latches
 
 sequence req=reqTwoKeyWaiter
 ----
@@ -220,12 +220,12 @@ num=2
 
 # Simulate that the replicated locks were discovered, so they are added to the
 # lock table. Keys "k1" and "k2" were previously discovered, but "k3" is new.
-handle-write-intent-error req=reqThreeKeyWaiter lease-seq=1
- intent txn=txnThreeKeyWriter key=k1
- intent txn=txnThreeKeyWriter key=k2
- intent txn=txnThreeKeyWriter key=k3
+handle-lock-conflict-error req=reqThreeKeyWaiter lease-seq=1
+  lock txn=txnThreeKeyWriter key=k1
+  lock txn=txnThreeKeyWriter key=k2
+  lock txn=txnThreeKeyWriter key=k3
 ----
-[11] handle write intent error reqThreeKeyWaiter: handled conflicting intents on ‹"k1"›, ‹"k2"›, ‹"k3"›, released latches
+[11] handle lock conflict error reqThreeKeyWaiter: handled conflicting intents on ‹"k1"›, ‹"k2"›, ‹"k3"›, released latches
 
 sequence req=reqThreeKeyWaiter
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_elsewhere
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_elsewhere
@@ -52,7 +52,7 @@ sequence req=reqWaiter
 handle-lock-conflict-error req=reqWaiter lease-seq=1
   lock txn=txnWriter key=k
 ----
-[3] handle lock conflict error reqWaiter: handled conflicting intents on ‹"k"›, released latches
+[3] handle lock conflict error reqWaiter: handled conflicting locks on ‹"k"›, released latches
 
 sequence req=reqWaiter
 ----
@@ -194,7 +194,7 @@ handle-lock-conflict-error req=reqTwoKeyWaiter lease-seq=1
   lock txn=txnThreeKeyWriter key=k1
   lock txn=txnThreeKeyWriter key=k2
 ----
-[9] handle lock conflict error reqTwoKeyWaiter: handled conflicting intents on ‹"k1"›, ‹"k2"›, released latches
+[9] handle lock conflict error reqTwoKeyWaiter: handled conflicting locks on ‹"k1"›, ‹"k2"›, released latches
 
 sequence req=reqTwoKeyWaiter
 ----
@@ -225,7 +225,7 @@ handle-lock-conflict-error req=reqThreeKeyWaiter lease-seq=1
   lock txn=txnThreeKeyWriter key=k2
   lock txn=txnThreeKeyWriter key=k3
 ----
-[11] handle lock conflict error reqThreeKeyWaiter: handled conflicting intents on ‹"k1"›, ‹"k2"›, ‹"k3"›, released latches
+[11] handle lock conflict error reqThreeKeyWaiter: handled conflicting locks on ‹"k1"›, ‹"k2"›, ‹"k3"›, released latches
 
 sequence req=reqThreeKeyWaiter
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_policy_error
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_policy_error
@@ -107,7 +107,7 @@ sequence req=reqNoWait1
 [4] sequence reqNoWait1: pushing txn 00000001 to check if abandoned
 [4] sequence reqNoWait1: pushee not abandoned
 [4] sequence reqNoWait1: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"k"› for 0.000s
-[4] sequence reqNoWait1: sequencing complete, returned error: conflicting intents on ‹"k"› [reason=wait_policy]
+[4] sequence reqNoWait1: sequencing complete, returned error: conflicting locks on ‹"k"› [reason=wait_policy]
 
 # -------------------------------------------------------------
 # Read-only request with WaitPolicy_Error hits abandoned lock.
@@ -168,7 +168,7 @@ sequence req=reqNoWait2
 [6] sequence reqNoWait2: waiting in lock wait-queues
 [6] sequence reqNoWait2: lock wait-queue event: wait for (distinguished) txn 00000003 running request @ key ‹"k2"› (queuedWriters: 2, queuedReaders: 0)
 [6] sequence reqNoWait2: conflicted with ‹00000003-0000-0000-0000-000000000000› on ‹"k2"› for 0.000s
-[6] sequence reqNoWait2: sequencing complete, returned error: conflicting intents on ‹"k2"› [reason=wait_policy]
+[6] sequence reqNoWait2: sequencing complete, returned error: conflicting locks on ‹"k2"› [reason=wait_policy]
 
 # -------------------------------------------------------------
 # Read-only request with WaitPolicy_Error discovers lock. The
@@ -189,7 +189,7 @@ sequence req=reqNoWait3
 handle-lock-conflict-error req=reqNoWait3 lease-seq=1
   lock txn=txn2 key=k4
 ----
-[8] handle lock conflict error reqNoWait3: handled conflicting intents on ‹"k4"›, released latches
+[8] handle lock conflict error reqNoWait3: handled conflicting locks on ‹"k4"›, released latches
 
 sequence req=reqNoWait3
 ----
@@ -201,7 +201,7 @@ sequence req=reqNoWait3
 [9] sequence reqNoWait3: pushing txn 00000002 to check if abandoned
 [9] sequence reqNoWait3: pushee not abandoned
 [9] sequence reqNoWait3: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"k4"› for 0.000s
-[9] sequence reqNoWait3: sequencing complete, returned error: conflicting intents on ‹"k4"› [reason=wait_policy]
+[9] sequence reqNoWait3: sequencing complete, returned error: conflicting locks on ‹"k4"› [reason=wait_policy]
 
 debug-lock-table
 ----
@@ -249,7 +249,7 @@ sequence req=reqNoWait4
 handle-lock-conflict-error req=reqNoWait4 lease-seq=1
   lock txn=txn2 key=k5
 ----
-[11] handle lock conflict error reqNoWait4: handled conflicting intents on ‹"k5"›, released latches
+[11] handle lock conflict error reqNoWait4: handled conflicting locks on ‹"k5"›, released latches
 
 sequence req=reqNoWait4
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_policy_error
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_policy_error
@@ -186,10 +186,10 @@ sequence req=reqNoWait3
 [7] sequence reqNoWait3: scanning lock table for conflicting locks
 [7] sequence reqNoWait3: sequencing complete, returned guard
 
-handle-write-intent-error req=reqNoWait3 lease-seq=1
-  intent txn=txn2 key=k4
+handle-lock-conflict-error req=reqNoWait3 lease-seq=1
+  lock txn=txn2 key=k4
 ----
-[8] handle write intent error reqNoWait3: handled conflicting intents on ‹"k4"›, released latches
+[8] handle lock conflict error reqNoWait3: handled conflicting intents on ‹"k4"›, released latches
 
 sequence req=reqNoWait3
 ----
@@ -246,10 +246,10 @@ sequence req=reqNoWait4
 [10] sequence reqNoWait4: scanning lock table for conflicting locks
 [10] sequence reqNoWait4: sequencing complete, returned guard
 
-handle-write-intent-error req=reqNoWait4 lease-seq=1
-  intent txn=txn2 key=k5
+handle-lock-conflict-error req=reqNoWait4 lease-seq=1
+  lock txn=txn2 key=k5
 ----
-[11] handle write intent error reqNoWait4: handled conflicting intents on ‹"k5"›, released latches
+[11] handle lock conflict error reqNoWait4: handled conflicting intents on ‹"k5"›, released latches
 
 sequence req=reqNoWait4
 ----

--- a/pkg/kv/kvserver/replica_closedts_internal_test.go
+++ b/pkg/kv/kvserver/replica_closedts_internal_test.go
@@ -847,7 +847,7 @@ func TestServerSideBoundedStalenessNegotiation(t *testing.T) {
 				minTSBound: ts20,
 				expErr: ifStrict(
 					"bounded staleness read .* could not be satisfied",
-					"conflicting intents on .*",
+					"conflicting locks on .*",
 				),
 			},
 			{
@@ -856,7 +856,7 @@ func TestServerSideBoundedStalenessNegotiation(t *testing.T) {
 				minTSBound: ts30,
 				expErr: ifStrict(
 					"bounded staleness read .* could not be satisfied",
-					"conflicting intents on .*",
+					"conflicting locks on .*",
 				),
 			},
 			{
@@ -865,7 +865,7 @@ func TestServerSideBoundedStalenessNegotiation(t *testing.T) {
 				minTSBound: ts40,
 				expErr: ifStrict(
 					"bounded staleness read .* could not be satisfied",
-					"conflicting intents on .*",
+					"conflicting locks on .*",
 				),
 			},
 			{
@@ -880,7 +880,7 @@ func TestServerSideBoundedStalenessNegotiation(t *testing.T) {
 				minTSBound: ts20,
 				expErr: ifStrict(
 					"bounded staleness read .* could not be satisfied",
-					"conflicting intents on .*",
+					"conflicting locks on .*",
 				),
 			},
 			{
@@ -889,7 +889,7 @@ func TestServerSideBoundedStalenessNegotiation(t *testing.T) {
 				minTSBound: ts30,
 				expErr: ifStrict(
 					"bounded staleness read .* could not be satisfied",
-					"conflicting intents on .*",
+					"conflicting locks on .*",
 				),
 			},
 			{
@@ -898,7 +898,7 @@ func TestServerSideBoundedStalenessNegotiation(t *testing.T) {
 				minTSBound: ts40,
 				expErr: ifStrict(
 					"bounded staleness read .* could not be satisfied",
-					"conflicting intents on .*",
+					"conflicting locks on .*",
 				),
 			},
 			{

--- a/pkg/kv/kvserver/replica_closedts_test.go
+++ b/pkg/kv/kvserver/replica_closedts_test.go
@@ -772,7 +772,7 @@ func TestNonBlockingReadsAtResolvedTimestamp(t *testing.T) {
 
 			// Issue a transactional scan over the keys at the resolved timestamp on
 			// the same store. Use an error wait policy so that we'll hear an error
-			// (WriteIntentError) under conditions that would otherwise cause us to
+			// (LockConflictError) under conditions that would otherwise cause us to
 			// block on an intent. Send to a specific store instead of through a
 			// DistSender so that we'll hear an error (NotLeaseholderError) if the
 			// request would otherwise be redirected to the leaseholder.
@@ -814,7 +814,7 @@ func TestNonBlockingReadsWithServerSideBoundedStalenessNegotiation(t *testing.T)
 		return func(ctx context.Context) error {
 			// Issue a bounded-staleness read (a read with a MinTimestampBound)
 			// over the keys. Use an error wait policy so that we'll hear an error
-			// (WriteIntentError) under conditions that would otherwise cause us
+			// (LockConflictError) under conditions that would otherwise cause us
 			// to block on an intent. Send to a specific store instead of through
 			// a DistSender so that we'll hear an error (NotLeaseholderError) if
 			// the request would otherwise be redirected to the leaseholder.

--- a/pkg/kv/kvserver/replica_init.go
+++ b/pkg/kv/kvserver/replica_init.go
@@ -116,7 +116,7 @@ func newUninitializedReplicaWithoutRaftGroup(
 			IntentResolver:    store.intentResolver,
 			TxnWaitMetrics:    store.txnWaitMetrics,
 			SlowLatchGauge:    store.metrics.SlowLatchRequests,
-			DisableTxnPushing: store.TestingKnobs().DontPushOnWriteIntentError,
+			DisableTxnPushing: store.TestingKnobs().DontPushOnLockConflictError,
 			TxnWaitKnobs:      store.TestingKnobs().TxnWaitKnobs,
 		}),
 	}

--- a/pkg/kv/kvserver/replica_read.go
+++ b/pkg/kv/kvserver/replica_read.go
@@ -298,7 +298,7 @@ func (r *Replica) canDropLatchesBeforeEval(
 		ctx, 3, "can drop latches early for batch (%v); scanning lock table first to detect conflicts", ba,
 	)
 
-	maxIntents := storage.MaxIntentsPerWriteIntentError.Get(&r.store.cfg.Settings.SV)
+	maxIntents := storage.MaxIntentsPerLockConflictError.Get(&r.store.cfg.Settings.SV)
 	var intents []roachpb.Intent
 	// Check if any of the requests within the batch need to resolve any intents
 	// or if any of them need to use an intent interleaving iterator.

--- a/pkg/kv/kvserver/replica_read.go
+++ b/pkg/kv/kvserver/replica_read.go
@@ -324,7 +324,7 @@ func (r *Replica) canDropLatchesBeforeEval(
 	}
 	if len(intents) > 0 {
 		return false /* ok */, false /* stillNeedsIntentInterleaving */, maybeAttachLease(
-			kvpb.NewError(&kvpb.LockConflictError{Intents: intents}), &st.Lease,
+			kvpb.NewError(&kvpb.LockConflictError{Locks: intents}), &st.Lease,
 		)
 	}
 	// If there were no conflicts, then the request can drop its latches and

--- a/pkg/kv/kvserver/replica_read.go
+++ b/pkg/kv/kvserver/replica_read.go
@@ -136,7 +136,7 @@ func (r *Replica) executeReadOnlyBatch(
 			// wait until resolution and evaluate pessimistically again.
 			//
 			// TODO(sumeer): scans and gets are correctly setting the resume span
-			// when returning a WriteIntentError. I am not sure about other
+			// when returning a LockConflictError. I am not sure about other
 			// concurrency errors. We could narrow the spans we check the latch
 			// conflicts for by using collectSpansRead as done below in the
 			// non-error path.
@@ -272,7 +272,7 @@ var allowDroppingLatchesBeforeEval = settings.RegisterBoolSetting(
 // `PinEngineStateForIterators` in `executeReadOnlyBatch`), so if there are no
 // lock conflicts, the rest of the execution is guaranteed to be isolated from
 // the effects of other requests.
-// If any conflicting intents are found, then it returns a WriteIntentError
+// If any conflicting intents are found, then it returns a LockConflictError
 // which needs to be handled by the caller before proceeding.
 //
 // [2] if the request can drop its latches early, whether it needs an intent
@@ -324,7 +324,7 @@ func (r *Replica) canDropLatchesBeforeEval(
 	}
 	if len(intents) > 0 {
 		return false /* ok */, false /* stillNeedsIntentInterleaving */, maybeAttachLease(
-			kvpb.NewError(&kvpb.WriteIntentError{Intents: intents}), &st.Lease,
+			kvpb.NewError(&kvpb.LockConflictError{Intents: intents}), &st.Lease,
 		)
 	}
 	// If there were no conflicts, then the request can drop its latches and

--- a/pkg/kv/kvserver/replica_send.go
+++ b/pkg/kv/kvserver/replica_send.go
@@ -756,7 +756,7 @@ func (r *Replica) handleLockConflictError(
 		return g, pErr
 	}
 	// g's latches will be dropped, but it retains its spot in lock wait-queues.
-	return r.concMgr.HandleWriterIntentError(ctx, g, t.LeaseSequence, t)
+	return r.concMgr.HandleLockConflictError(ctx, g, t.LeaseSequence, t)
 }
 
 func (r *Replica) handleTransactionPushError(

--- a/pkg/kv/kvserver/replica_send.go
+++ b/pkg/kv/kvserver/replica_send.go
@@ -752,7 +752,7 @@ func (r *Replica) handleLockConflictError(
 	pErr *kvpb.Error,
 	t *kvpb.LockConflictError,
 ) (*concurrency.Guard, *kvpb.Error) {
-	if r.store.cfg.TestingKnobs.DontPushOnWriteIntentError {
+	if r.store.cfg.TestingKnobs.DontPushOnLockConflictError {
 		return g, pErr
 	}
 	// g's latches will be dropped, but it retains its spot in lock wait-queues.

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -3149,7 +3149,7 @@ func TestConditionalPutUpdatesTSCacheOnError(t *testing.T) {
 	stopper := stop.NewStopper()
 	defer stopper.Stop(ctx)
 	cfg := TestStoreConfig(hlc.NewClockForTesting(tc.manualClock))
-	cfg.TestingKnobs.DontPushOnWriteIntentError = true
+	cfg.TestingKnobs.DontPushOnLockConflictError = true
 	tc.StartWithStoreConfig(ctx, t, stopper, cfg)
 
 	// Set clock to time 2s and do the conditional put.
@@ -3233,7 +3233,7 @@ func TestInitPutUpdatesTSCacheOnError(t *testing.T) {
 	stopper := stop.NewStopper()
 	defer stopper.Stop(ctx)
 	cfg := TestStoreConfig(hlc.NewClockForTesting(tc.manualClock))
-	cfg.TestingKnobs.DontPushOnWriteIntentError = true
+	cfg.TestingKnobs.DontPushOnLockConflictError = true
 	tc.StartWithStoreConfig(ctx, t, stopper, cfg)
 
 	// InitPut args to write "0". Should succeed.
@@ -3375,7 +3375,7 @@ func TestReplicaNoTSCacheUpdateOnFailure(t *testing.T) {
 	stopper := stop.NewStopper()
 	defer stopper.Stop(ctx)
 	cfg := TestStoreConfig(nil)
-	cfg.TestingKnobs.DontPushOnWriteIntentError = true
+	cfg.TestingKnobs.DontPushOnLockConflictError = true
 	tc.StartWithStoreConfig(ctx, t, stopper, cfg)
 
 	// Test for both read & write attempts.
@@ -4670,7 +4670,7 @@ func TestEndTxnRollbackAbortedTransaction(t *testing.T) {
 		stopper := stop.NewStopper()
 		defer stopper.Stop(ctx)
 		cfg := TestStoreConfig(nil)
-		cfg.TestingKnobs.DontPushOnWriteIntentError = true
+		cfg.TestingKnobs.DontPushOnLockConflictError = true
 		tc.StartWithStoreConfig(ctx, t, stopper, cfg)
 
 		key := []byte("a")
@@ -4854,7 +4854,7 @@ func TestBatchRetryCantCommitIntents(t *testing.T) {
 	stopper := stop.NewStopper()
 	defer stopper.Stop(ctx)
 	cfg := TestStoreConfig(nil)
-	cfg.TestingKnobs.DontPushOnWriteIntentError = true
+	cfg.TestingKnobs.DontPushOnLockConflictError = true
 	tc.StartWithStoreConfig(ctx, t, stopper, cfg)
 
 	key := roachpb.Key("a")
@@ -5065,7 +5065,7 @@ func TestEndTxnResolveOnlyLocalIntents(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	tc := testContext{}
 	tsc := TestStoreConfig(nil)
-	tsc.TestingKnobs.DontPushOnWriteIntentError = true
+	tsc.TestingKnobs.DontPushOnLockConflictError = true
 	key := roachpb.Key("a")
 	splitKey := roachpb.RKey(key).Next()
 	tsc.TestingKnobs.EvalKnobs.TestingEvalFilter =
@@ -6785,7 +6785,7 @@ func TestReplicaDanglingMetaIntent(t *testing.T) {
 		stopper := stop.NewStopper()
 		defer stopper.Stop(ctx)
 		cfg := TestStoreConfig(nil)
-		cfg.TestingKnobs.DontPushOnWriteIntentError = true
+		cfg.TestingKnobs.DontPushOnLockConflictError = true
 		cfg.TestingKnobs.DisableCanAckBeforeApplication = true
 		tc.StartWithStoreConfig(ctx, t, stopper, cfg)
 

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -3186,8 +3186,8 @@ func TestConditionalPutUpdatesTSCacheOnError(t *testing.T) {
 	t3 := makeTS(3*time.Second.Nanoseconds(), 0)
 	tc.manualClock.MustAdvanceTo(t3.GoTime())
 	_, pErr = tc.SendWrapped(&cpArgs1)
-	if _, ok := pErr.GetDetail().(*kvpb.WriteIntentError); !ok {
-		t.Errorf("expected WriteIntentError; got %v", pErr)
+	if _, ok := pErr.GetDetail().(*kvpb.LockConflictError); !ok {
+		t.Errorf("expected LockConflictError; got %v", pErr)
 	}
 
 	// Abort the intent and try a transactional conditional put at
@@ -3279,8 +3279,8 @@ func TestInitPutUpdatesTSCacheOnError(t *testing.T) {
 	t3 := makeTS(3*time.Second.Nanoseconds(), 0)
 	tc.manualClock.MustAdvanceTo(t3.GoTime())
 	_, pErr = tc.SendWrapped(&ipArgs2)
-	if _, ok := pErr.GetDetail().(*kvpb.WriteIntentError); !ok {
-		t.Errorf("expected WriteIntentError; got %v", pErr)
+	if _, ok := pErr.GetDetail().(*kvpb.LockConflictError); !ok {
+		t.Errorf("expected LockConflictError; got %v", pErr)
 	}
 
 	// Abort the intent and try a transactional init put at a later
@@ -3399,8 +3399,8 @@ func TestReplicaNoTSCacheUpdateOnFailure(t *testing.T) {
 		ts := tc.Clock().Now() // later timestamp
 
 		_, pErr = tc.SendWrappedWith(kvpb.Header{Timestamp: ts}, args)
-		if _, ok := pErr.GetDetail().(*kvpb.WriteIntentError); !ok {
-			t.Errorf("expected WriteIntentError; got %v", pErr)
+		if _, ok := pErr.GetDetail().(*kvpb.LockConflictError); !ok {
+			t.Errorf("expected LockConflictError; got %v", pErr)
 		}
 
 		// Write the intent again -- should not have its timestamp upgraded!
@@ -4701,8 +4701,8 @@ func TestEndTxnRollbackAbortedTransaction(t *testing.T) {
 			t.Fatal(err)
 		}
 		_, pErr := tc.Sender().Send(ctx, ba)
-		if _, ok := pErr.GetDetail().(*kvpb.WriteIntentError); !ok {
-			t.Errorf("expected write intent error, but got %s", pErr)
+		if _, ok := pErr.GetDetail().(*kvpb.LockConflictError); !ok {
+			t.Errorf("expected lock conflict error, but got %s", pErr)
 		}
 
 		if populateAbortSpan {
@@ -4923,8 +4923,8 @@ func TestBatchRetryCantCommitIntents(t *testing.T) {
 	// Intent should have been created.
 	gArgs := getArgs(key)
 	_, pErr = tc.SendWrapped(&gArgs)
-	if _, ok := pErr.GetDetail().(*kvpb.WriteIntentError); !ok {
-		t.Errorf("expected WriteIntentError, got: %v", pErr)
+	if _, ok := pErr.GetDetail().(*kvpb.LockConflictError); !ok {
+		t.Errorf("expected LockConflictError, got: %v", pErr)
 	}
 
 	// Heartbeat should fail with a TransactionAbortedError.
@@ -4943,8 +4943,8 @@ func TestBatchRetryCantCommitIntents(t *testing.T) {
 	// Expect that the txn left behind an intent on key A.
 	gArgs = getArgs(key)
 	_, pErr = tc.SendWrapped(&gArgs)
-	if _, ok := pErr.GetDetail().(*kvpb.WriteIntentError); !ok {
-		t.Errorf("expected WriteIntentError, got: %v", pErr)
+	if _, ok := pErr.GetDetail().(*kvpb.LockConflictError); !ok {
+		t.Errorf("expected LockConflictError, got: %v", pErr)
 	}
 }
 
@@ -5094,8 +5094,8 @@ func TestEndTxnResolveOnlyLocalIntents(t *testing.T) {
 			t.Fatal(err)
 		}
 		_, pErr := newRepl.Send(ctx, ba)
-		if _, ok := pErr.GetDetail().(*kvpb.WriteIntentError); !ok {
-			t.Errorf("expected write intent error, but got %s", pErr)
+		if _, ok := pErr.GetDetail().(*kvpb.LockConflictError); !ok {
+			t.Errorf("expected lock conflict error, but got %s", pErr)
 		}
 	}
 
@@ -6769,7 +6769,7 @@ func TestChangeReplicasDuplicateError(t *testing.T) {
 
 // TestReplicaDanglingMetaIntent creates a dangling intent on a meta2
 // record and verifies that RangeLookup scans behave
-// appropriately. Normally, the old value and a write intent error
+// appropriately. Normally, the old value and a lock conflict error
 // should be returned. If IgnoreIntents is specified, then a random
 // choice of old or new is returned with no error.
 // TODO(tschottdorf): add a test in which there is a dangling intent on a
@@ -6822,7 +6822,7 @@ func TestReplicaDanglingMetaIntent(t *testing.T) {
 		}
 
 		// Now lookup the range; should get the value. Since the lookup is
-		// not consistent, there's no WriteIntentError. It should return both
+		// not consistent, there's no LockConflictError. It should return both
 		// the committed descriptor and the intent descriptor.
 		//
 		// Note that 'A' < 'a'.
@@ -6843,8 +6843,8 @@ func TestReplicaDanglingMetaIntent(t *testing.T) {
 
 		// Switch to consistent lookups, which should run into the intent.
 		_, _, err = kv.RangeLookup(ctx, tc.Sender(), newKey, kvpb.CONSISTENT, 0, reverse)
-		if !errors.HasType(err, (*kvpb.WriteIntentError)(nil)) {
-			t.Fatalf("expected WriteIntentError, not %s", err)
+		if !errors.HasType(err, (*kvpb.LockConflictError)(nil)) {
+			t.Fatalf("expected LockConflictError, not %s", err)
 		}
 	})
 }

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -2306,9 +2306,9 @@ func TestStoreScanIntents(t *testing.T) {
 // limits.
 //
 // The test proceeds as follows: a writer lays down more than
-// `MaxIntentsPerWriteIntentErrorDefault` intents, and a reader is expected to
+// `MaxIntentsPerLockConflictError` intents, and a reader is expected to
 // encounter these intents and raise a `LockConflictError` with exactly
-// `MaxIntentsPerWriteIntentErrorDefault` intents in the error.
+// `MaxIntentsPerLockConflictError` intents in the error.
 func TestStoreScanIntentsRespectsLimit(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -2331,10 +2331,10 @@ func TestStoreScanIntentsRespectsLimit(t *testing.T) {
 						ctx context.Context, ba *kvpb.BatchRequest, pErr *kvpb.Error,
 					) {
 						if errors.HasType(pErr.GoError(), (*kvpb.LockConflictError)(nil)) {
-							// Assert that the LockConflictError has MaxIntentsPerWriteIntentErrorIntents.
+							// Assert that the LockConflictError has MaxIntentsPerLockConflictError intents.
 							if trap := interceptLockConflictErrors.Load(); trap != nil && trap.(bool) {
 								require.Equal(
-									t, storage.MaxIntentsPerWriteIntentErrorDefault,
+									t, storage.MaxIntentsPerLockConflictErrorDefault,
 									len(pErr.GetDetail().(*kvpb.LockConflictError).Intents),
 								)
 								interceptLockConflictErrors.Store(false)
@@ -2356,13 +2356,13 @@ func TestStoreScanIntentsRespectsLimit(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(2)
 
-	// Lay down more than `MaxIntentsPerWriteIntentErrorDefault` intents.
+	// Lay down more than `MaxIntentsPerLockConflictErrorDefault` intents.
 	go func() {
 		defer wg.Done()
 		txn := newTransaction(
 			"test", roachpb.Key("test-key"), roachpb.NormalUserPriority, tc.Server(0).Clock(),
 		)
-		for j := 0; j < storage.MaxIntentsPerWriteIntentErrorDefault+10; j++ {
+		for j := 0; j < storage.MaxIntentsPerLockConflictErrorDefault+10; j++ {
 			var key roachpb.Key
 			key = append(key, keys.ScratchRangeMin...)
 			key = append(key, []byte(fmt.Sprintf("%d", j))...)
@@ -2385,10 +2385,10 @@ func TestStoreScanIntentsRespectsLimit(t *testing.T) {
 	}
 
 	// Now, expect a conflicting reader to encounter the intents and raise a
-	// LockConflictError with exactly `MaxIntentsPerWriteIntentErrorDefault`
+	// LockConflictError with exactly `MaxIntentsPerLockConflictErrorDefault`
 	// intents. See the TestingConcurrencyRetryFilter above.
 	var ba kv.Batch
-	for i := 0; i < storage.MaxIntentsPerWriteIntentErrorDefault+10; i += 10 {
+	for i := 0; i < storage.MaxIntentsPerLockConflictErrorDefault+10; i += 10 {
 		for _, key := range intentKeys[i : i+10] {
 			args := getArgs(key)
 			ba.AddRawRequest(&args)

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -2335,7 +2335,7 @@ func TestStoreScanIntentsRespectsLimit(t *testing.T) {
 							if trap := interceptLockConflictErrors.Load(); trap != nil && trap.(bool) {
 								require.Equal(
 									t, storage.MaxIntentsPerLockConflictErrorDefault,
-									len(pErr.GetDetail().(*kvpb.LockConflictError).Intents),
+									len(pErr.GetDetail().(*kvpb.LockConflictError).Locks),
 								)
 								interceptLockConflictErrors.Store(false)
 								// Allow the writer to commit.

--- a/pkg/kv/kvserver/testing_knobs.go
+++ b/pkg/kv/kvserver/testing_knobs.go
@@ -271,12 +271,12 @@ type StoreTestingKnobs struct {
 	SystemLogsGCPeriod time.Duration
 	// SystemLogsGCGCDone is used to notify when system logs GC is done.
 	SystemLogsGCGCDone chan<- struct{}
-	// DontPushOnWriteIntentError will propagate a lock conflict error immediately
-	// instead of utilizing the intent resolver to try to push the corresponding
-	// transaction.
+	// DontPushOnLockConflictError will propagate a lock conflict error
+	// immediately instead of utilizing the intent resolver to try to push the
+	// corresponding transaction.
 	// TODO(nvanbenschoten): can we replace this knob with usage of the Error
 	// WaitPolicy on BatchRequests?
-	DontPushOnWriteIntentError bool
+	DontPushOnLockConflictError bool
 	// DontRetryPushTxnFailures will propagate a push txn failure immediately
 	// instead of utilizing the txn wait queue to wait for the transaction to
 	// finish or be pushed by a higher priority contender.

--- a/pkg/kv/kvserver/testing_knobs.go
+++ b/pkg/kv/kvserver/testing_knobs.go
@@ -271,7 +271,7 @@ type StoreTestingKnobs struct {
 	SystemLogsGCPeriod time.Duration
 	// SystemLogsGCGCDone is used to notify when system logs GC is done.
 	SystemLogsGCGCDone chan<- struct{}
-	// DontPushOnWriteIntentError will propagate a write intent error immediately
+	// DontPushOnWriteIntentError will propagate a lock conflict error immediately
 	// instead of utilizing the intent resolver to try to push the corresponding
 	// transaction.
 	// TODO(nvanbenschoten): can we replace this knob with usage of the Error

--- a/pkg/kv/kvserver/txnwait/queue.go
+++ b/pkg/kv/kvserver/txnwait/queue.go
@@ -978,7 +978,7 @@ func (q *Queue) queryTxnStatus(
 		//
 		// Scenario:
 		// - we're aborted and don't know if we have a read-write conflict
-		// - the push above fails and we get a WriteIntentError
+		// - the push above fails and we get a LockConflictError
 		// - we try to update our transaction (right here, and if we don't we might
 		// be stuck in a race, that's why we do this - the txn proto we're using
 		// might be outdated)

--- a/pkg/kv/txn_external_test.go
+++ b/pkg/kv/txn_external_test.go
@@ -428,7 +428,7 @@ func testTxnNegotiateAndSendDoesNotBlock(t *testing.T, multiRange, strict, route
 				if err := store.DB().Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
 					// Issue a bounded-staleness read over the keys. If using strict
 					// bounded staleness, use an error wait policy so that we'll hear an
-					// error (WriteIntentError) under conditions that would otherwise
+					// error (LockConflictError) under conditions that would otherwise
 					// cause us to block on an intent. Otherwise, allow the request to be
 					// redirected to the leaseholder and to block on intents.
 					ba := &kvpb.BatchRequest{}

--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -1968,7 +1968,7 @@ func (l *Lease) Equal(that interface{}) bool {
 }
 
 // MakeIntent makes an intent with the given txn and key.
-// This is suitable for use when constructing WriteIntentError.
+// This is suitable for use when constructing LockConflictError.
 func MakeIntent(txn *enginepb.TxnMeta, key Key) Intent {
 	var i Intent
 	i.Key = key

--- a/pkg/sql/row/errors.go
+++ b/pkg/sql/row/errors.go
@@ -56,7 +56,7 @@ func ConvertBatchError(ctx context.Context, tableDesc catalog.TableDescriptor, b
 		return NewUniquenessConstraintViolationError(ctx, tableDesc, kv.Key, v.ActualValue)
 
 	case *kvpb.LockConflictError:
-		key := v.Intents[0].Key
+		key := v.Locks[0].Key
 		decodeKeyFn := func() (tableName string, indexName string, colNames []string, values []string, err error) {
 			codec, index, err := decodeKeyCodecAndIndex(tableDesc, key)
 			if err != nil {
@@ -84,7 +84,7 @@ func ConvertFetchError(spec *fetchpb.IndexFetchSpec, err error) error {
 	}
 	switch {
 	case errors.As(err, &errs.lc):
-		key := errs.lc.Intents[0].Key
+		key := errs.lc.Locks[0].Key
 		decodeKeyFn := func() (tableName string, indexName string, colNames []string, values []string, err error) {
 			colNames, values, err = decodeKeyValsUsingSpec(spec, key)
 			return spec.TableName, spec.IndexName, colNames, values, err

--- a/pkg/sql/row/errors.go
+++ b/pkg/sql/row/errors.go
@@ -55,7 +55,7 @@ func ConvertBatchError(ctx context.Context, tableDesc catalog.TableDescriptor, b
 		}
 		return NewUniquenessConstraintViolationError(ctx, tableDesc, kv.Key, v.ActualValue)
 
-	case *kvpb.WriteIntentError:
+	case *kvpb.LockConflictError:
 		key := v.Intents[0].Key
 		decodeKeyFn := func() (tableName string, indexName string, colNames []string, values []string, err error) {
 			codec, index, err := decodeKeyCodecAndIndex(tableDesc, key)
@@ -79,17 +79,17 @@ func ConvertBatchError(ctx context.Context, tableDesc catalog.TableDescriptor, b
 // key-value fetch to a user friendly SQL error.
 func ConvertFetchError(spec *fetchpb.IndexFetchSpec, err error) error {
 	var errs struct {
-		wi *kvpb.WriteIntentError
+		lc *kvpb.LockConflictError
 		bs *kvpb.MinTimestampBoundUnsatisfiableError
 	}
 	switch {
-	case errors.As(err, &errs.wi):
-		key := errs.wi.Intents[0].Key
+	case errors.As(err, &errs.lc):
+		key := errs.lc.Intents[0].Key
 		decodeKeyFn := func() (tableName string, indexName string, colNames []string, values []string, err error) {
 			colNames, values, err = decodeKeyValsUsingSpec(spec, key)
 			return spec.TableName, spec.IndexName, colNames, values, err
 		}
-		return newLockNotAvailableError(errs.wi.Reason, decodeKeyFn)
+		return newLockNotAvailableError(errs.lc.Reason, decodeKeyFn)
 
 	case errors.As(err, &errs.bs):
 		return pgerror.WithCandidateCode(
@@ -160,11 +160,11 @@ func decodeKeyValsUsingSpec(
 // acquire a lock. It uses an IndexFetchSpec for the corresponding index (the
 // fetch columns in the spec are not used).
 func newLockNotAvailableError(
-	reason kvpb.WriteIntentError_Reason,
+	reason kvpb.LockConflictError_Reason,
 	decodeKeyFn func() (tableName string, indexName string, colNames []string, values []string, err error),
 ) error {
 	baseMsg := "could not obtain lock on row"
-	if reason == kvpb.WriteIntentError_REASON_LOCK_TIMEOUT {
+	if reason == kvpb.LockConflictError_REASON_LOCK_TIMEOUT {
 		baseMsg = "canceling statement due to lock timeout on row"
 	}
 	tableName, indexName, colNames, values, err := decodeKeyFn()

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -1231,7 +1231,7 @@ func mvccGetWithValueHeader(
 		return optionalValue{}, nil, enginepb.MVCCValueHeader{}, err
 	}
 	if opts.errOnIntents() && len(intents) > 0 {
-		return optionalValue{}, nil, enginepb.MVCCValueHeader{}, &kvpb.LockConflictError{Intents: intents}
+		return optionalValue{}, nil, enginepb.MVCCValueHeader{}, &kvpb.LockConflictError{Locks: intents}
 	}
 
 	if len(intents) > 1 {
@@ -1954,7 +1954,7 @@ func mvccPutInternal(
 			if opts.Txn == nil || meta.Txn.ID != opts.Txn.ID {
 				// The current Put operation does not come from the same
 				// transaction.
-				return false, &kvpb.LockConflictError{Intents: []roachpb.Intent{
+				return false, &kvpb.LockConflictError{Locks: []roachpb.Intent{
 					roachpb.MakeIntent(meta.Txn, key),
 				}}
 			} else if opts.Txn.Epoch < meta.Txn.Epoch {
@@ -3221,7 +3221,7 @@ func MVCCPredicateDeleteRange(
 	if intents, err := ScanIntents(ctx, rw, startKey, endKey, maxIntents, 0); err != nil {
 		return nil, err
 	} else if len(intents) > 0 {
-		return nil, &kvpb.LockConflictError{Intents: intents}
+		return nil, &kvpb.LockConflictError{Locks: intents}
 	}
 
 	// continueRun returns three bools: the first is true if the current run
@@ -3516,7 +3516,7 @@ func MVCCDeleteRangeUsingTombstone(
 	if intents, err := ScanIntents(ctx, rw, startKey, endKey, maxIntents, 0); err != nil {
 		return err
 	} else if len(intents) > 0 {
-		return &kvpb.LockConflictError{Intents: intents}
+		return &kvpb.LockConflictError{Locks: intents}
 	}
 
 	// If requested, check if there are any point keys/tombstones in the span that
@@ -3900,7 +3900,7 @@ func finalizeScanResult(
 	}
 
 	if opts.errOnIntents() && len(res.Intents) > 0 {
-		return &kvpb.LockConflictError{Intents: res.Intents}
+		return &kvpb.LockConflictError{Locks: res.Intents}
 	}
 	return nil
 }

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -63,7 +63,7 @@ const (
 	MinimumMaxOpenFiles = 1700
 	// MaxIntentsPerWriteIntentErrorDefault is the default value for maximum
 	// number of intents reported by ExportToSST and Scan operations in
-	// WriteIntentError is set to half of the maximum lock table size.
+	// LockConflictError is set to half of the maximum lock table size.
 	// This value is subject to tuning in real environment as we have more data
 	// available.
 	MaxIntentsPerWriteIntentErrorDefault = 5000
@@ -109,7 +109,7 @@ func CanUseMVCCRangeTombstones(ctx context.Context, st *cluster.Settings) bool {
 }
 
 // MaxIntentsPerWriteIntentError sets maximum number of intents returned in
-// WriteIntentError in operations that return multiple intents per error.
+// LockConflictError in operations that return multiple intents per error.
 // Currently it is used in Scan, ReverseScan, and ExportToSST.
 var MaxIntentsPerWriteIntentError = settings.RegisterIntSetting(
 	settings.TenantWritable,
@@ -819,7 +819,7 @@ func MVCCGetProto(
 	// If we found a result, parse it regardless of the error returned by MVCCGet.
 	if found && msg != nil {
 		// If the unmarshal failed, return its result. Otherwise, pass
-		// through the underlying error (which may be a WriteIntentError
+		// through the underlying error (which may be a LockConflictError
 		// to be handled specially alongside the returned value).
 		if err := valueRes.Value.GetProto(msg); err != nil {
 			return found, err
@@ -986,7 +986,7 @@ type MVCCGetResult struct {
 	// returned instead.
 	Value *roachpb.Value
 	// In inconsistent mode, the intent if an intent is encountered. In
-	// consistent mode, an intent will generate a WriteIntentError with the
+	// consistent mode, an intent will generate a LockConflictError with the
 	// intent embedded within and the intent parameter will be nil.
 	Intent *roachpb.Intent
 	// See the documentation for kvpb.ResponseHeader for information on
@@ -1083,7 +1083,7 @@ func newMVCCIterator(
 //
 // In inconsistent mode, if an intent is encountered, it will be placed in the
 // intent field. By contrast, in consistent mode, an intent will generate a
-// WriteIntentError with the intent embedded within, and the intent result
+// LockConflictError with the intent embedded within, and the intent result
 // parameter will be nil.
 //
 // Note that transactional gets must be consistent. Put another way, only
@@ -1094,14 +1094,14 @@ func newMVCCIterator(
 //
 // When reading in "skip locked" mode, a key that is locked by a transaction
 // other than the reader is not included in the result set and does not result
-// in a WriteIntentError. Instead, the key is included in the encountered intent
+// in a LockConflictError. Instead, the key is included in the encountered intent
 // result parameter so that it can be resolved asynchronously. In this mode, the
 // LockTableView provided in the options is consulted any observed key to
 // determine whether it is locked with an unreplicated lock.
 //
 // When reading in "fail on more recent" mode, a WriteTooOldError will be
 // returned if the read observes a version with a timestamp above the read
-// timestamp. Similarly, a WriteIntentError will be returned if the read
+// timestamp. Similarly, a LockConflictError will be returned if the read
 // observes another transaction's intent, even if it has a timestamp above
 // the read timestamp.
 func MVCCGet(
@@ -1231,7 +1231,7 @@ func mvccGetWithValueHeader(
 		return optionalValue{}, nil, enginepb.MVCCValueHeader{}, err
 	}
 	if opts.errOnIntents() && len(intents) > 0 {
-		return optionalValue{}, nil, enginepb.MVCCValueHeader{}, &kvpb.WriteIntentError{Intents: intents}
+		return optionalValue{}, nil, enginepb.MVCCValueHeader{}, &kvpb.LockConflictError{Intents: intents}
 	}
 
 	if len(intents) > 1 {
@@ -1643,7 +1643,7 @@ func mvccPutUsingIter(
 // result of calling valueFn on the data read at readTimestamp. The
 // function uses a non-transactional read, so uncertainty does not apply
 // and any intents (even the caller's own if the caller is operating on
-// behalf of a transaction), will result in a WriteIntentError. Because
+// behalf of a transaction), will result in a LockConflictError. Because
 // of this, the function is only called from places where intents have
 // already been considered.
 func maybeGetValue(
@@ -1954,7 +1954,7 @@ func mvccPutInternal(
 			if opts.Txn == nil || meta.Txn.ID != opts.Txn.ID {
 				// The current Put operation does not come from the same
 				// transaction.
-				return false, &kvpb.WriteIntentError{Intents: []roachpb.Intent{
+				return false, &kvpb.LockConflictError{Intents: []roachpb.Intent{
 					roachpb.MakeIntent(meta.Txn, key),
 				}}
 			} else if opts.Txn.Epoch < meta.Txn.Epoch {
@@ -3154,7 +3154,7 @@ func MVCCDeleteRange(
 // The keyspaces of each run do not overlap.
 //
 // This operation is non-transactional, but will check for existing intents in
-// the target key span, regardless of timestamp, and return a WriteIntentError
+// the target key span, regardless of timestamp, and return a LockConflictError
 // containing up to maxIntents intents.
 //
 // MVCCPredicateDeleteRange will return with a resumeSpan if the number of tombstones
@@ -3221,7 +3221,7 @@ func MVCCPredicateDeleteRange(
 	if intents, err := ScanIntents(ctx, rw, startKey, endKey, maxIntents, 0); err != nil {
 		return nil, err
 	} else if len(intents) > 0 {
-		return nil, &kvpb.WriteIntentError{Intents: intents}
+		return nil, &kvpb.LockConflictError{Intents: intents}
 	}
 
 	// continueRun returns three bools: the first is true if the current run
@@ -3447,7 +3447,7 @@ func MVCCPredicateDeleteRange(
 // MVCCDeleteRangeUsingTombstone deletes the given MVCC keyspan at the given
 // timestamp using an MVCC range tombstone (rather than MVCC point tombstones).
 // This operation is non-transactional, but will check for existing intents and
-// return a WriteIntentError containing up to maxIntents intents. Can't be used
+// return a LockConflictError containing up to maxIntents intents. Can't be used
 // across local keyspace.
 //
 // The leftPeekBound and rightPeekBound parameters are used when looking for
@@ -3516,7 +3516,7 @@ func MVCCDeleteRangeUsingTombstone(
 	if intents, err := ScanIntents(ctx, rw, startKey, endKey, maxIntents, 0); err != nil {
 		return err
 	} else if len(intents) > 0 {
-		return &kvpb.WriteIntentError{Intents: intents}
+		return &kvpb.LockConflictError{Intents: intents}
 	}
 
 	// If requested, check if there are any point keys/tombstones in the span that
@@ -3900,7 +3900,7 @@ func finalizeScanResult(
 	}
 
 	if opts.errOnIntents() && len(res.Intents) > 0 {
-		return &kvpb.WriteIntentError{Intents: res.Intents}
+		return &kvpb.LockConflictError{Intents: res.Intents}
 	}
 	return nil
 }
@@ -4015,7 +4015,7 @@ type MVCCScanOptions struct {
 	// will be fetched and returned too.
 	WholeRowsOfSize int32
 	// MaxIntents is a maximum number of intents collected by scanner in
-	// consistent mode before returning WriteIntentError.
+	// consistent mode before returning LockConflictError.
 	//
 	// Not used in inconsistent scans.
 	// The zero value indicates no limit.
@@ -4100,7 +4100,7 @@ type MVCCScanResult struct {
 //
 // When scanning inconsistently, any encountered intents will be placed in the
 // dedicated result parameter. By contrast, when scanning consistently, any
-// encountered intents will cause the scan to return a WriteIntentError with the
+// encountered intents will cause the scan to return a LockConflictError with the
 // intents embedded within.
 //
 // Note that transactional scans must be consistent. Put another way, only
@@ -4108,7 +4108,7 @@ type MVCCScanResult struct {
 //
 // When scanning in "skip locked" mode, keys that are locked by transactions
 // other than the reader are not included in the result set and do not result in
-// a WriteIntentError. Instead, these keys are included in the encountered
+// a LockConflictError. Instead, these keys are included in the encountered
 // intents result parameter so that they can be resolved asynchronously. In this
 // mode, the LockTableView provided in the options is consulted for each key to
 // determine whether it is locked with an unreplicated lock.
@@ -4117,7 +4117,7 @@ type MVCCScanResult struct {
 // returned if the scan observes a version with a timestamp at or above the read
 // timestamp. If the scan observes multiple versions with timestamp at or above
 // the read timestamp, the maximum will be returned in the WriteTooOldError.
-// Similarly, a WriteIntentError will be returned if the scan observes another
+// Similarly, a LockConflictError will be returned if the scan observes another
 // transaction's intent, even if it has a timestamp above the read timestamp.
 func MVCCScan(
 	ctx context.Context,
@@ -4191,7 +4191,7 @@ func MVCCScanAsTxn(
 // the reverse flag is set, the iterator will be moved in reverse order. If the
 // scan options specify an inconsistent scan, all "ignored" intents will be
 // returned. In consistent mode, intents are only ever returned as part of a
-// WriteIntentError. In Tombstones mode, MVCC range tombstones are emitted as
+// LockConflictError. In Tombstones mode, MVCC range tombstones are emitted as
 // synthetic point tombstones above existing point keys.
 func MVCCIterate(
 	ctx context.Context,
@@ -6666,7 +6666,7 @@ type ExportRequestResumeInfo struct {
 // and overlapping [StartKey, EndKey) are returned. If only the latest revision
 // is requested, only the most recent matching tombstone is returned.
 //
-// Intents within the time and span bounds will return a WriteIntentError, while
+// Intents within the time and span bounds will return a LockConflictError, while
 // intents outside are ignored.
 //
 // Returns an export summary and a resume key that allows resuming the export if
@@ -7043,7 +7043,7 @@ type MVCCExportOptions struct {
 	// exists to prevent creating SSTs which are too large to be used.
 	MaxSize uint64
 	// MaxIntents specifies the number of intents to collect and return in a
-	// WriteIntentError. The caller will likely resolve the returned intents and
+	// LockConflictError. The caller will likely resolve the returned intents and
 	// retry the call, which would be quadratic, so this significantly reduces the
 	// overall number of scans. 0 disables batching and returns the first intent,
 	// pass math.MaxUint64 to collect all.

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -61,12 +61,12 @@ const (
 	// minimum total for a single store node must be under 2048 for Windows
 	// compatibility.
 	MinimumMaxOpenFiles = 1700
-	// MaxIntentsPerWriteIntentErrorDefault is the default value for maximum
+	// MaxIntentsPerLockConflictErrorDefault is the default value for maximum
 	// number of intents reported by ExportToSST and Scan operations in
-	// LockConflictError is set to half of the maximum lock table size.
-	// This value is subject to tuning in real environment as we have more data
+	// LockConflictError is set to half of the maximum lock table size. This
+	// value is subject to tuning in real environment as we have more data
 	// available.
-	MaxIntentsPerWriteIntentErrorDefault = 5000
+	MaxIntentsPerLockConflictErrorDefault = 5000
 )
 
 var minWALSyncInterval = settings.RegisterDurationSetting(
@@ -108,14 +108,14 @@ func CanUseMVCCRangeTombstones(ctx context.Context, st *cluster.Settings) bool {
 		MVCCRangeTombstonesEnabledInMixedClusters.Get(&st.SV)
 }
 
-// MaxIntentsPerWriteIntentError sets maximum number of intents returned in
+// MaxIntentsPerLockConflictError sets maximum number of intents returned in
 // LockConflictError in operations that return multiple intents per error.
 // Currently it is used in Scan, ReverseScan, and ExportToSST.
-var MaxIntentsPerWriteIntentError = settings.RegisterIntSetting(
+var MaxIntentsPerLockConflictError = settings.RegisterIntSetting(
 	settings.TenantWritable,
 	"storage.mvcc.max_intents_per_error",
 	"maximum number of intents returned in error during export of scan requests",
-	MaxIntentsPerWriteIntentErrorDefault,
+	MaxIntentsPerLockConflictErrorDefault,
 )
 
 var rocksdbConcurrency = envutil.EnvOrDefaultInt(

--- a/pkg/storage/mvcc_incremental_iterator.go
+++ b/pkg/storage/mvcc_incremental_iterator.go
@@ -438,7 +438,7 @@ func (i *MVCCIncrementalIterator) updateMeta() error {
 		switch i.intentPolicy {
 		case MVCCIncrementalIterIntentPolicyError:
 			i.err = &kvpb.LockConflictError{
-				Intents: []roachpb.Intent{
+				Locks: []roachpb.Intent{
 					roachpb.MakeIntent(i.meta.Txn, i.iter.UnsafeKey().Key.Clone()),
 				},
 			}
@@ -766,12 +766,13 @@ func (i *MVCCIncrementalIterator) NumCollectedIntents() int {
 // TryGetIntentError returns kvpb.LockConflictError if intents were encountered
 // during iteration and intent aggregation is enabled. Otherwise function
 // returns nil. kvpb.LockConflictError will contain all encountered intents.
+// TODO(nvanbenschoten): rename to TryGetLockConflictError.
 func (i *MVCCIncrementalIterator) TryGetIntentError() error {
 	if len(i.intents) == 0 {
 		return nil
 	}
 	return &kvpb.LockConflictError{
-		Intents: i.intents,
+		Locks: i.intents,
 	}
 }
 

--- a/pkg/storage/mvcc_incremental_iterator.go
+++ b/pkg/storage/mvcc_incremental_iterator.go
@@ -140,7 +140,7 @@ const (
 	// MVCCIncrementalIterIntentPolicyAggregate will not fail on
 	// first encountered intent, but will proceed further. All
 	// found intents will be aggregated into a single
-	// WriteIntentError which would be updated during
+	// LockConflictError which would be updated during
 	// iteration. Consumer would be free to decide if it wants to
 	// keep collecting entries and intents or skip entries.
 	MVCCIncrementalIterIntentPolicyAggregate
@@ -437,7 +437,7 @@ func (i *MVCCIncrementalIterator) updateMeta() error {
 	if i.startTime.Less(metaTimestamp) && metaTimestamp.LessEq(i.endTime) {
 		switch i.intentPolicy {
 		case MVCCIncrementalIterIntentPolicyError:
-			i.err = &kvpb.WriteIntentError{
+			i.err = &kvpb.LockConflictError{
 				Intents: []roachpb.Intent{
 					roachpb.MakeIntent(i.meta.Txn, i.iter.UnsafeKey().Key.Clone()),
 				},
@@ -763,14 +763,14 @@ func (i *MVCCIncrementalIterator) NumCollectedIntents() int {
 	return len(i.intents)
 }
 
-// TryGetIntentError returns kvpb.WriteIntentError if intents were encountered
+// TryGetIntentError returns kvpb.LockConflictError if intents were encountered
 // during iteration and intent aggregation is enabled. Otherwise function
-// returns nil. kvpb.WriteIntentError will contain all encountered intents.
+// returns nil. kvpb.LockConflictError will contain all encountered intents.
 func (i *MVCCIncrementalIterator) TryGetIntentError() error {
 	if len(i.intents) == 0 {
 		return nil
 	}
-	return &kvpb.WriteIntentError{
+	return &kvpb.LockConflictError{
 		Intents: i.intents,
 	}
 }

--- a/pkg/storage/mvcc_incremental_iterator_test.go
+++ b/pkg/storage/mvcc_incremental_iterator_test.go
@@ -534,10 +534,10 @@ func TestMVCCIncrementalIteratorNextIgnoringTime(t *testing.T) {
 	// ensuring that the SeekGE() doesn't encounter an intent.
 	t.Run("intents", func(t *testing.T) {
 		ignoreTimeExpectErr(t, e, testKey1, testKey2.PrefixEnd(), tsMin, tsMax,
-			"conflicting intents", false)
+			"conflicting locks", false)
 	})
 	t.Run("intents", func(t *testing.T) {
-		ignoreTimeExpectErr(t, e, localMax, keyMax, tsMin, ts4, "conflicting intents", false)
+		ignoreTimeExpectErr(t, e, localMax, keyMax, tsMin, ts4, "conflicting locks", false)
 	})
 	// Intents above the upper time bound or beneath the lower time bound must
 	// be ignored. Note that the lower time bound is exclusive while the upper
@@ -667,10 +667,10 @@ func TestMVCCIncrementalIteratorNextKeyIgnoringTime(t *testing.T) {
 	// ensuring that the SeekGE() doesn't encounter an intent.
 	t.Run("intents", func(t *testing.T) {
 		ignoreTimeExpectErr(t, e, testKey1, testKey2.PrefixEnd(), tsMin, tsMax,
-			"conflicting intents", true)
+			"conflicting locks", true)
 	})
 	t.Run("intents", func(t *testing.T) {
-		ignoreTimeExpectErr(t, e, localMax, keyMax, tsMin, ts4, "conflicting intents", true)
+		ignoreTimeExpectErr(t, e, localMax, keyMax, tsMin, ts4, "conflicting locks", true)
 	})
 	// Intents above the upper time bound or beneath the lower time bound must
 	// be ignored. Note that the lower time bound is exclusive while the upper
@@ -1177,7 +1177,7 @@ func TestMVCCIncrementalIteratorIntentRewrittenConcurrently(t *testing.T) {
 		// observe and return nothing because there will be no committed or
 		// provisional keys in its time range.
 		if err != nil {
-			if !testutils.IsError(err, `conflicting intents on "kA"`) {
+			if !testutils.IsError(err, `conflicting locks on "kA"`) {
 				return err
 			}
 		} else {
@@ -1284,7 +1284,7 @@ func TestMVCCIncrementalIteratorIntentDeletion(t *testing.T) {
 	}, kvs)
 	// At ts3, we should see the new intent
 	_, err = slurpKVsInTimeRange(db, kA, ts0, ts3)
-	require.EqualError(t, err, `conflicting intents on "kA"`)
+	require.EqualError(t, err, `conflicting locks on "kA"`)
 
 	// Similar to the kA ts1 check, but there is no newer intent. We expect to
 	// pick up the intent deletion and it should cancel out the intent, leaving
@@ -1297,7 +1297,7 @@ func TestMVCCIncrementalIteratorIntentDeletion(t *testing.T) {
 
 	// Sanity check that we see the still unresolved intent for kC ts1.
 	_, err = slurpKVsInTimeRange(db, kC, ts0, ts1)
-	require.EqualError(t, err, `conflicting intents on "kC"`)
+	require.EqualError(t, err, `conflicting locks on "kC"`)
 }
 
 func TestMVCCIncrementalIteratorIntentStraddlesSStables(t *testing.T) {

--- a/pkg/storage/mvcc_incremental_iterator_test.go
+++ b/pkg/storage/mvcc_incremental_iterator_test.go
@@ -195,7 +195,7 @@ func assertExportedErrs(
 		ExportAllRevisions: revisions,
 		TargetSize:         big,
 		MaxSize:            big,
-		MaxIntents:         uint64(MaxIntentsPerWriteIntentError.Default()),
+		MaxIntents:         uint64(MaxIntentsPerLockConflictError.Default()),
 		StopMidKey:         false,
 	}, &bytes.Buffer{})
 	require.Error(t, err)

--- a/pkg/storage/mvcc_incremental_iterator_test.go
+++ b/pkg/storage/mvcc_incremental_iterator_test.go
@@ -123,8 +123,8 @@ func assertExpectErr(
 
 	_, err := iter.Valid()
 	if lcErr := (*kvpb.LockConflictError)(nil); errors.As(err, &lcErr) {
-		if !expectedIntent.Key.Equal(lcErr.Intents[0].Key) {
-			t.Fatalf("Expected intent key %v, but got %v", expectedIntent.Key, lcErr.Intents[0].Key)
+		if !expectedIntent.Key.Equal(lcErr.Locks[0].Key) {
+			t.Fatalf("Expected intent key %v, but got %v", expectedIntent.Key, lcErr.Locks[0].Key)
 		}
 	} else {
 		t.Fatalf("expected error with intent %v but got %v", expectedIntent, err)
@@ -165,11 +165,11 @@ func assertExpectErrs(
 	err := iter.TryGetIntentError()
 	if lcErr := (*kvpb.LockConflictError)(nil); errors.As(err, &lcErr) {
 		for i := range expectedIntents {
-			if !expectedIntents[i].Key.Equal(lcErr.Intents[i].Key) {
-				t.Fatalf("%d intent key: got %v, expected %v", i, lcErr.Intents[i].Key, expectedIntents[i].Key)
+			if !expectedIntents[i].Key.Equal(lcErr.Locks[i].Key) {
+				t.Fatalf("%d intent key: got %v, expected %v", i, lcErr.Locks[i].Key, expectedIntents[i].Key)
 			}
-			if !expectedIntents[i].Txn.ID.Equal(lcErr.Intents[i].Txn.ID) {
-				t.Fatalf("%d intent key: got %v, expected %v", i, lcErr.Intents[i].Txn.ID, expectedIntents[i].Txn.ID)
+			if !expectedIntents[i].Txn.ID.Equal(lcErr.Locks[i].Txn.ID) {
+				t.Fatalf("%d intent key: got %v, expected %v", i, lcErr.Locks[i].Txn.ID, expectedIntents[i].Txn.ID)
 			}
 		}
 	} else {
@@ -202,11 +202,11 @@ func assertExportedErrs(
 
 	if lcErr := (*kvpb.LockConflictError)(nil); errors.As(err, &lcErr) {
 		for i := range expectedIntents {
-			if !expectedIntents[i].Key.Equal(lcErr.Intents[i].Key) {
-				t.Fatalf("%d intent key: got %v, expected %v", i, lcErr.Intents[i].Key, expectedIntents[i].Key)
+			if !expectedIntents[i].Key.Equal(lcErr.Locks[i].Key) {
+				t.Fatalf("%d intent key: got %v, expected %v", i, lcErr.Locks[i].Key, expectedIntents[i].Key)
 			}
-			if !expectedIntents[i].Txn.ID.Equal(lcErr.Intents[i].Txn.ID) {
-				t.Fatalf("%d intent key: got %v, expected %v", i, lcErr.Intents[i].Txn.ID, expectedIntents[i].Txn.ID)
+			if !expectedIntents[i].Txn.ID.Equal(lcErr.Locks[i].Txn.ID) {
+				t.Fatalf("%d intent key: got %v, expected %v", i, lcErr.Locks[i].Txn.ID, expectedIntents[i].Txn.ID)
 			}
 		}
 	} else {
@@ -787,7 +787,7 @@ func TestMVCCIncrementalIteratorIntentPolicy(t *testing.T) {
 	kv2_2_2 := makeKVT(testKey2, testValue2, ts2)
 	txn, intent2_2_2 := makeKVTxn(testKey2, ts2)
 
-	lcErr := &kvpb.LockConflictError{Intents: []roachpb.Intent{intent2_2_2}}
+	lcErr := &kvpb.LockConflictError{Locks: []roachpb.Intent{intent2_2_2}}
 
 	e := NewDefaultInMemForTesting()
 	defer e.Close()

--- a/pkg/storage/mvcc_incremental_iterator_test.go
+++ b/pkg/storage/mvcc_incremental_iterator_test.go
@@ -122,9 +122,9 @@ func assertExpectErr(
 	}
 
 	_, err := iter.Valid()
-	if intentErr := (*kvpb.WriteIntentError)(nil); errors.As(err, &intentErr) {
-		if !expectedIntent.Key.Equal(intentErr.Intents[0].Key) {
-			t.Fatalf("Expected intent key %v, but got %v", expectedIntent.Key, intentErr.Intents[0].Key)
+	if lcErr := (*kvpb.LockConflictError)(nil); errors.As(err, &lcErr) {
+		if !expectedIntent.Key.Equal(lcErr.Intents[0].Key) {
+			t.Fatalf("Expected intent key %v, but got %v", expectedIntent.Key, lcErr.Intents[0].Key)
 		}
 	} else {
 		t.Fatalf("expected error with intent %v but got %v", expectedIntent, err)
@@ -163,17 +163,17 @@ func assertExpectErrs(
 		t.Fatalf("Expected %d intents but found %d", len(expectedIntents), iter.NumCollectedIntents())
 	}
 	err := iter.TryGetIntentError()
-	if intentErr := (*kvpb.WriteIntentError)(nil); errors.As(err, &intentErr) {
+	if lcErr := (*kvpb.LockConflictError)(nil); errors.As(err, &lcErr) {
 		for i := range expectedIntents {
-			if !expectedIntents[i].Key.Equal(intentErr.Intents[i].Key) {
-				t.Fatalf("%d intent key: got %v, expected %v", i, intentErr.Intents[i].Key, expectedIntents[i].Key)
+			if !expectedIntents[i].Key.Equal(lcErr.Intents[i].Key) {
+				t.Fatalf("%d intent key: got %v, expected %v", i, lcErr.Intents[i].Key, expectedIntents[i].Key)
 			}
-			if !expectedIntents[i].Txn.ID.Equal(intentErr.Intents[i].Txn.ID) {
-				t.Fatalf("%d intent key: got %v, expected %v", i, intentErr.Intents[i].Txn.ID, expectedIntents[i].Txn.ID)
+			if !expectedIntents[i].Txn.ID.Equal(lcErr.Intents[i].Txn.ID) {
+				t.Fatalf("%d intent key: got %v, expected %v", i, lcErr.Intents[i].Txn.ID, expectedIntents[i].Txn.ID)
 			}
 		}
 	} else {
-		t.Fatalf("Expected kvpb.WriteIntentError, found %T", err)
+		t.Fatalf("Expected kvpb.LockConflictError, found %T", err)
 	}
 }
 
@@ -200,17 +200,17 @@ func assertExportedErrs(
 	}, &bytes.Buffer{})
 	require.Error(t, err)
 
-	if intentErr := (*kvpb.WriteIntentError)(nil); errors.As(err, &intentErr) {
+	if lcErr := (*kvpb.LockConflictError)(nil); errors.As(err, &lcErr) {
 		for i := range expectedIntents {
-			if !expectedIntents[i].Key.Equal(intentErr.Intents[i].Key) {
-				t.Fatalf("%d intent key: got %v, expected %v", i, intentErr.Intents[i].Key, expectedIntents[i].Key)
+			if !expectedIntents[i].Key.Equal(lcErr.Intents[i].Key) {
+				t.Fatalf("%d intent key: got %v, expected %v", i, lcErr.Intents[i].Key, expectedIntents[i].Key)
 			}
-			if !expectedIntents[i].Txn.ID.Equal(intentErr.Intents[i].Txn.ID) {
-				t.Fatalf("%d intent key: got %v, expected %v", i, intentErr.Intents[i].Txn.ID, expectedIntents[i].Txn.ID)
+			if !expectedIntents[i].Txn.ID.Equal(lcErr.Intents[i].Txn.ID) {
+				t.Fatalf("%d intent key: got %v, expected %v", i, lcErr.Intents[i].Txn.ID, expectedIntents[i].Txn.ID)
 			}
 		}
 	} else {
-		t.Fatalf("Expected kvpb.WriteIntentError, found %T", err)
+		t.Fatalf("Expected kvpb.LockConflictError, found %T", err)
 	}
 }
 
@@ -787,7 +787,7 @@ func TestMVCCIncrementalIteratorIntentPolicy(t *testing.T) {
 	kv2_2_2 := makeKVT(testKey2, testValue2, ts2)
 	txn, intent2_2_2 := makeKVTxn(testKey2, ts2)
 
-	intentErr := &kvpb.WriteIntentError{Intents: []roachpb.Intent{intent2_2_2}}
+	lcErr := &kvpb.LockConflictError{Intents: []roachpb.Intent{intent2_2_2}}
 
 	e := NewDefaultInMemForTesting()
 	defer e.Close()
@@ -815,14 +815,14 @@ func TestMVCCIncrementalIteratorIntentPolicy(t *testing.T) {
 			}
 		}
 		_, err := iter.Valid()
-		assert.EqualError(t, err, intentErr.Error())
+		assert.EqualError(t, err, lcErr.Error())
 
 		iter.SeekGE(MakeMVCCMetadataKey(testKey1))
 		_, err = iter.Valid()
 		require.NoError(t, err)
 		for ; ; iter.NextIgnoringTime() {
 			if ok, err := iter.Valid(); !ok {
-				assert.EqualError(t, err, intentErr.Error())
+				assert.EqualError(t, err, lcErr.Error())
 				break
 			}
 		}
@@ -982,20 +982,20 @@ func TestMVCCIncrementalIterator(t *testing.T) {
 		t.Run("del", assertEqualKVs(e, localMax, keyMax, ts1, tsMax, latest, kvs(kv1Deleted3, kv2_2_2)))
 
 		// Exercise intent handling.
-		txn1, intentErr1 := makeKVTxn(testKey1, ts4)
+		txn1, lcErr1 := makeKVTxn(testKey1, ts4)
 		if err := MVCCPut(ctx, e, txn1.TxnMeta.Key, txn1.ReadTimestamp, testValue4, MVCCWriteOptions{Txn: &txn1}); err != nil {
 			t.Fatal(err)
 		}
-		txn2, intentErr2 := makeKVTxn(testKey2, ts4)
+		txn2, lcErr2 := makeKVTxn(testKey2, ts4)
 		if err := MVCCPut(ctx, e, txn2.TxnMeta.Key, txn2.ReadTimestamp, testValue4, MVCCWriteOptions{Txn: &txn2}); err != nil {
 			t.Fatal(err)
 		}
 		t.Run("intents-1",
-			iterateExpectErr(e, testKey1, testKey1.PrefixEnd(), tsMin, tsMax, latest, intents(intentErr1)))
+			iterateExpectErr(e, testKey1, testKey1.PrefixEnd(), tsMin, tsMax, latest, intents(lcErr1)))
 		t.Run("intents-2",
-			iterateExpectErr(e, testKey2, testKey2.PrefixEnd(), tsMin, tsMax, latest, intents(intentErr2)))
+			iterateExpectErr(e, testKey2, testKey2.PrefixEnd(), tsMin, tsMax, latest, intents(lcErr2)))
 		t.Run("intents-multi",
-			iterateExpectErr(e, localMax, keyMax, tsMin, ts4, latest, intents(intentErr1, intentErr2)))
+			iterateExpectErr(e, localMax, keyMax, tsMin, ts4, latest, intents(lcErr1, lcErr2)))
 		// Intents above the upper time bound or beneath the lower time bound must
 		// be ignored (#28358). Note that the lower time bound is exclusive while
 		// the upper time bound is inclusive.
@@ -1048,21 +1048,21 @@ func TestMVCCIncrementalIterator(t *testing.T) {
 		t.Run("del", assertEqualKVs(e, localMax, keyMax, ts1, tsMax, all, kvs(kv1Deleted3, kv1_2_2, kv2_2_2)))
 
 		// Exercise intent handling.
-		txn1, intentErr1 := makeKVTxn(testKey1, ts4)
+		txn1, lcErr1 := makeKVTxn(testKey1, ts4)
 		if err := MVCCPut(ctx, e, txn1.TxnMeta.Key, txn1.ReadTimestamp, testValue4, MVCCWriteOptions{Txn: &txn1}); err != nil {
 			t.Fatal(err)
 		}
-		txn2, intentErr2 := makeKVTxn(testKey2, ts4)
+		txn2, lcErr2 := makeKVTxn(testKey2, ts4)
 		if err := MVCCPut(ctx, e, txn2.TxnMeta.Key, txn2.ReadTimestamp, testValue4, MVCCWriteOptions{Txn: &txn2}); err != nil {
 			t.Fatal(err)
 		}
 		// Single intent tests are verifying behavior when intent collection is not enabled.
 		t.Run("intents-1",
-			iterateExpectErr(e, testKey1, testKey1.PrefixEnd(), tsMin, tsMax, all, intents(intentErr1)))
+			iterateExpectErr(e, testKey1, testKey1.PrefixEnd(), tsMin, tsMax, all, intents(lcErr1)))
 		t.Run("intents-2",
-			iterateExpectErr(e, testKey2, testKey2.PrefixEnd(), tsMin, tsMax, all, intents(intentErr2)))
+			iterateExpectErr(e, testKey2, testKey2.PrefixEnd(), tsMin, tsMax, all, intents(lcErr2)))
 		t.Run("intents-multi",
-			iterateExpectErr(e, localMax, keyMax, tsMin, ts4, all, intents(intentErr1, intentErr2)))
+			iterateExpectErr(e, localMax, keyMax, tsMin, ts4, all, intents(lcErr1, lcErr2)))
 		// Intents above the upper time bound or beneath the lower time bound must
 		// be ignored (#28358). Note that the lower time bound is exclusive while
 		// the upper time bound is inclusive.
@@ -1172,7 +1172,7 @@ func TestMVCCIncrementalIteratorIntentRewrittenConcurrently(t *testing.T) {
 
 		// There are two permissible outcomes from the scan. If the iteration
 		// wins the race with the put that moves the intent then it should
-		// observe the intent and return a write intent error. If the iteration
+		// observe the intent and return a lock conflict error. If the iteration
 		// loses the race with the put that moves the intent then it should
 		// observe and return nothing because there will be no committed or
 		// provisional keys in its time range.
@@ -1402,8 +1402,8 @@ func TestMVCCIncrementalIteratorIntentStraddlesSStables(t *testing.T) {
 		for it.SeekGE(MVCCKey{Key: keys.LocalMax}); ; it.Next() {
 			ok, err := it.Valid()
 			if err != nil {
-				if errors.HasType(err, (*kvpb.WriteIntentError)(nil)) {
-					// This is the write intent error we were expecting.
+				if errors.HasType(err, (*kvpb.LockConflictError)(nil)) {
+					// This is the lock conflict error we were expecting.
 					return
 				}
 				t.Fatalf("%T: %s", err, err)
@@ -1412,7 +1412,7 @@ func TestMVCCIncrementalIteratorIntentStraddlesSStables(t *testing.T) {
 				break
 			}
 		}
-		t.Fatalf("expected write intent error, but found success")
+		t.Fatalf("expected lock conflict error, but found success")
 	}
 }
 

--- a/pkg/storage/mvcc_test.go
+++ b/pkg/storage/mvcc_test.go
@@ -477,7 +477,7 @@ func TestMVCCGetAndDeleteInTxn(t *testing.T) {
 	}
 }
 
-func TestMVCCGetWriteIntentError(t *testing.T) {
+func TestMVCCGetLockConflictError(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
@@ -506,7 +506,7 @@ func mkVal(s string, ts hlc.Timestamp) roachpb.Value {
 	return v
 }
 
-func TestMVCCScanWriteIntentError(t *testing.T) {
+func TestMVCCScanLockConflictError(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
@@ -558,7 +558,7 @@ func TestMVCCScanWriteIntentError(t *testing.T) {
 				roachpb.MakeIntent(&txn1ts.TxnMeta, testKey1),
 				roachpb.MakeIntent(&txn2ts.TxnMeta, testKey4),
 			},
-			// would be []roachpb.KeyValue{fixtureKVs[3], fixtureKVs[4]} without WriteIntentError
+			// would be []roachpb.KeyValue{fixtureKVs[3], fixtureKVs[4]} without LockConflictError
 			expValues: nil,
 		},
 		{
@@ -598,14 +598,14 @@ func TestMVCCScanWriteIntentError(t *testing.T) {
 		t.Run(scan.name, func(t *testing.T) {
 			res, err := MVCCScan(ctx, engine, testKey1, testKey6.Next(),
 				hlc.Timestamp{WallTime: 1}, MVCCScanOptions{Inconsistent: !scan.consistent, Txn: scan.txn, MaxIntents: 2})
-			var wiErr *kvpb.WriteIntentError
-			_ = errors.As(err, &wiErr)
-			if (err == nil) != (wiErr == nil) {
+			var lcErr *kvpb.LockConflictError
+			_ = errors.As(err, &lcErr)
+			if (err == nil) != (lcErr == nil) {
 				t.Errorf("unexpected error: %+v", err)
 			}
 
-			if wiErr == nil != !scan.consistent {
-				t.Fatalf("expected write intent error; got %s", err)
+			if lcErr == nil != !scan.consistent {
+				t.Fatalf("expected lock conflict error; got %s", err)
 			}
 
 			intents := res.Intents
@@ -615,7 +615,7 @@ func TestMVCCScanWriteIntentError(t *testing.T) {
 			}
 
 			if scan.consistent {
-				intents = wiErr.Intents
+				intents = lcErr.Intents
 			}
 
 			if !reflect.DeepEqual(intents, scan.expIntents) {
@@ -725,8 +725,8 @@ func TestMVCCGetProtoInconsistent(t *testing.T) {
 		Txn:          txn1,
 	}); err == nil {
 		t.Error("expected an error getting inconsistently in txn")
-	} else if errors.HasType(err, (*kvpb.WriteIntentError)(nil)) {
-		t.Error("expected non-WriteIntentError with inconsistent read in txn")
+	} else if errors.HasType(err, (*kvpb.LockConflictError)(nil)) {
+		t.Error("expected non-LockConflictError with inconsistent read in txn")
 	}
 
 	// Inconsistent get will fetch value1 for any timestamp.
@@ -2807,8 +2807,8 @@ func TestMVCCResolveIntentTxnTimestampMismatch(t *testing.T) {
 		{hlc.MaxTimestamp, true},
 	} {
 		_, err := MVCCGet(ctx, engine, testKey1, test.Timestamp, MVCCGetOptions{})
-		if errors.HasType(err, (*kvpb.WriteIntentError)(nil)) != test.found {
-			t.Fatalf("%d: expected write intent error: %t, got %v", i, test.found, err)
+		if errors.HasType(err, (*kvpb.LockConflictError)(nil)) != test.found {
+			t.Fatalf("%d: expected lock conflict error: %t, got %v", i, test.found, err)
 		}
 	}
 }
@@ -3130,8 +3130,8 @@ func TestMVCCGetWithDiffEpochs(t *testing.T) {
 			if test.expErr {
 				if err == nil {
 					t.Errorf("test %d: unexpected success", i)
-				} else if !errors.HasType(err, (*kvpb.WriteIntentError)(nil)) {
-					t.Errorf("test %d: expected write intent error; got %v", i, err)
+				} else if !errors.HasType(err, (*kvpb.LockConflictError)(nil)) {
+					t.Errorf("test %d: expected lock conflict error; got %v", i, err)
 				}
 			} else if err != nil || valueRes.Value == nil || !bytes.Equal(test.expValue.RawBytes, valueRes.Value.RawBytes) {
 				t.Errorf("test %d: expected value %q, err nil; got %+v, %v", i, test.expValue.RawBytes, valueRes.Value, err)
@@ -3452,7 +3452,7 @@ func TestMVCCResolveWithPushedTimestamp(t *testing.T) {
 
 	valueRes, err = MVCCGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 1}, MVCCGetOptions{})
 	if valueRes.Value != nil || err == nil {
-		t.Fatalf("expected both value nil and err to be a writeIntentError: %+v", valueRes.Value)
+		t.Fatalf("expected both value nil and err to be a LockConflictError: %+v", valueRes.Value)
 	}
 
 	// Can still fetch the value using txn1.
@@ -6644,7 +6644,7 @@ func TestMVCCExportToSSTFailureIntentBatching(t *testing.T) {
 				require.NoError(t, err)
 			} else {
 				require.Error(t, err)
-				e := (*kvpb.WriteIntentError)(nil)
+				e := (*kvpb.LockConflictError)(nil)
 				if !errors.As(err, &e) {
 					require.Fail(t, "Expected WriteIntentFailure, got %T", err)
 				}

--- a/pkg/storage/mvcc_test.go
+++ b/pkg/storage/mvcc_test.go
@@ -2019,7 +2019,7 @@ func TestMVCCClearTimeRange(t *testing.T) {
 		defer b.Close()
 		addIntent(t, b)
 		_, err := MVCCClearTimeRange(ctx, b, nil, localMax, keyMax, ts0, ts5, nil, nil, 64, 10, 1<<10)
-		require.EqualError(t, err, "conflicting intents on \"/db3\"")
+		require.EqualError(t, err, "conflicting locks on \"/db3\"")
 	})
 
 	t.Run("clear exactly hitting intent fails", func(t *testing.T) {
@@ -2027,7 +2027,7 @@ func TestMVCCClearTimeRange(t *testing.T) {
 		defer b.Close()
 		addIntent(t, b)
 		_, err := MVCCClearTimeRange(ctx, b, nil, testKey3, testKey4, ts2, ts3, nil, nil, 64, 10, 1<<10)
-		require.EqualError(t, err, "conflicting intents on \"/db3\"")
+		require.EqualError(t, err, "conflicting locks on \"/db3\"")
 	})
 
 	t.Run("clear everything above intent", func(t *testing.T) {

--- a/pkg/storage/mvcc_test.go
+++ b/pkg/storage/mvcc_test.go
@@ -6637,7 +6637,7 @@ func TestMVCCExportToSSTFailureIntentBatching(t *testing.T) {
 				ExportAllRevisions: true,
 				TargetSize:         0,
 				MaxSize:            0,
-				MaxIntents:         uint64(MaxIntentsPerWriteIntentError.Default()),
+				MaxIntents:         uint64(MaxIntentsPerLockConflictError.Default()),
 				StopMidKey:         false,
 			}, &bytes.Buffer{})
 			if len(expectedIntentIndices) == 0 {
@@ -6657,7 +6657,7 @@ func TestMVCCExportToSSTFailureIntentBatching(t *testing.T) {
 	}
 
 	// Export range is fixed to k:["00010", "10000"), ts:(999, 2000] for all tests.
-	testDataCount := int(MaxIntentsPerWriteIntentError.Default() + 1)
+	testDataCount := int(MaxIntentsPerLockConflictError.Default() + 1)
 	testData := make([]testValue, testDataCount*2)
 	expectedErrors := make([]int, testDataCount)
 	for i := 0; i < testDataCount; i++ {
@@ -6665,7 +6665,7 @@ func TestMVCCExportToSSTFailureIntentBatching(t *testing.T) {
 		testData[i*2+1] = intent(key(i*2+12), "intent", ts(1001))
 		expectedErrors[i] = i*2 + 1
 	}
-	t.Run("Receive no more than limit intents", checkReportedErrors(testData, expectedErrors[:MaxIntentsPerWriteIntentError.Default()]))
+	t.Run("Receive no more than limit intents", checkReportedErrors(testData, expectedErrors[:MaxIntentsPerLockConflictError.Default()]))
 }
 
 // TestMVCCExportToSSTSplitMidKey verifies that split mid key in exports will

--- a/pkg/storage/mvcc_test.go
+++ b/pkg/storage/mvcc_test.go
@@ -615,7 +615,7 @@ func TestMVCCScanLockConflictError(t *testing.T) {
 			}
 
 			if scan.consistent {
-				intents = lcErr.Intents
+				intents = lcErr.Locks
 			}
 
 			if !reflect.DeepEqual(intents, scan.expIntents) {
@@ -6648,9 +6648,9 @@ func TestMVCCExportToSSTFailureIntentBatching(t *testing.T) {
 				if !errors.As(err, &e) {
 					require.Fail(t, "Expected WriteIntentFailure, got %T", err)
 				}
-				require.Equal(t, len(expectedIntentIndices), len(e.Intents))
+				require.Equal(t, len(expectedIntentIndices), len(e.Locks))
 				for i, dataIdx := range expectedIntentIndices {
-					requireTxnForValue(t, data[dataIdx], e.Intents[i])
+					requireTxnForValue(t, data[dataIdx], e.Locks[i])
 				}
 			}
 		}

--- a/pkg/storage/pebble_mvcc_scanner.go
+++ b/pkg/storage/pebble_mvcc_scanner.go
@@ -980,7 +980,7 @@ func (p *pebbleMVCCScanner) getOne(ctx context.Context) (ok, added bool) {
 			// intents written by other transactions and seek to the next key.
 			// However, we return the intent separately if we have room; the caller
 			// may want to resolve it. Unlike below, this intent will not result in
-			// a WriteIntentError because MVCC{Scan,Get}Options.errOnIntents returns
+			// a LockConflictError because MVCC{Scan,Get}Options.errOnIntents returns
 			// false when skipLocked in enabled.
 			if p.maxIntents == 0 || int64(p.intents.Count()) < p.maxIntents {
 				if !p.addCurIntent(ctx) {
@@ -1004,7 +1004,7 @@ func (p *pebbleMVCCScanner) getOne(ctx context.Context) (ok, added bool) {
 		if !p.addCurIntent(ctx) {
 			return false, false
 		}
-		// Limit number of intents returned in write intent error.
+		// Limit number of intents returned in lock conflict error.
 		if p.maxIntents > 0 && int64(p.intents.Count()) >= p.maxIntents {
 			p.resumeReason = kvpb.RESUME_INTENT_LIMIT
 			return false, false

--- a/pkg/storage/sst.go
+++ b/pkg/storage/sst.go
@@ -282,7 +282,7 @@ func CheckSSTConflicts(
 				// of scans.
 				intents = append(intents, roachpb.MakeIntent(mvccMeta.Txn, extIter.UnsafeKey().Key.Clone()))
 				if int64(len(intents)) >= maxIntents {
-					return &kvpb.LockConflictError{Intents: intents}
+					return &kvpb.LockConflictError{Locks: intents}
 				}
 				return nil
 			}
@@ -532,7 +532,7 @@ func CheckSSTConflicts(
 				}
 				intents = append(intents, roachpb.MakeIntent(mvccMeta.Txn, extIter.UnsafeKey().Key.Clone()))
 				if int64(len(intents)) >= maxIntents {
-					return statsDiff, &kvpb.LockConflictError{Intents: intents}
+					return statsDiff, &kvpb.LockConflictError{Locks: intents}
 				}
 				extIter.Next()
 				continue
@@ -1223,7 +1223,7 @@ func CheckSSTConflicts(
 		return enginepb.MVCCStats{}, sstErr
 	}
 	if len(intents) > 0 {
-		return enginepb.MVCCStats{}, &kvpb.LockConflictError{Intents: intents}
+		return enginepb.MVCCStats{}, &kvpb.LockConflictError{Locks: intents}
 	}
 
 	return statsDiff, nil

--- a/pkg/storage/sst.go
+++ b/pkg/storage/sst.go
@@ -282,7 +282,7 @@ func CheckSSTConflicts(
 				// of scans.
 				intents = append(intents, roachpb.MakeIntent(mvccMeta.Txn, extIter.UnsafeKey().Key.Clone()))
 				if int64(len(intents)) >= maxIntents {
-					return &kvpb.WriteIntentError{Intents: intents}
+					return &kvpb.LockConflictError{Intents: intents}
 				}
 				return nil
 			}
@@ -532,7 +532,7 @@ func CheckSSTConflicts(
 				}
 				intents = append(intents, roachpb.MakeIntent(mvccMeta.Txn, extIter.UnsafeKey().Key.Clone()))
 				if int64(len(intents)) >= maxIntents {
-					return statsDiff, &kvpb.WriteIntentError{Intents: intents}
+					return statsDiff, &kvpb.LockConflictError{Intents: intents}
 				}
 				extIter.Next()
 				continue
@@ -1223,7 +1223,7 @@ func CheckSSTConflicts(
 		return enginepb.MVCCStats{}, sstErr
 	}
 	if len(intents) > 0 {
-		return enginepb.MVCCStats{}, &kvpb.WriteIntentError{Intents: intents}
+		return enginepb.MVCCStats{}, &kvpb.LockConflictError{Intents: intents}
 	}
 
 	return statsDiff, nil

--- a/pkg/storage/sst_test.go
+++ b/pkg/storage/sst_test.go
@@ -98,7 +98,7 @@ func TestCheckSSTConflictsMaxIntents(t *testing.T) {
 					require.ErrorAs(t, err, &lcErr)
 
 					actual := []string{}
-					for _, i := range lcErr.Intents {
+					for _, i := range lcErr.Locks {
 						actual = append(actual, string(i.Key))
 					}
 					require.Equal(t, tc.expectIntents, actual)

--- a/pkg/storage/sst_test.go
+++ b/pkg/storage/sst_test.go
@@ -89,16 +89,16 @@ func TestCheckSSTConflictsMaxIntents(t *testing.T) {
 		t.Run(fmt.Sprintf("maxIntents=%d", tc.maxIntents), func(t *testing.T) {
 			for _, usePrefixSeek := range []bool{false, true} {
 				t.Run(fmt.Sprintf("usePrefixSeek=%v", usePrefixSeek), func(t *testing.T) {
-					// Provoke and check WriteIntentErrors.
+					// Provoke and check LockConflictError.
 					startKey, endKey := MVCCKey{Key: roachpb.Key(start)}, MVCCKey{Key: roachpb.Key(end)}
 					_, err := CheckSSTConflicts(ctx, sstFile.Bytes(), engine, startKey, endKey, startKey.Key, endKey.Key.Next(),
 						false /*disallowShadowing*/, hlc.Timestamp{} /*disallowShadowingBelow*/, hlc.Timestamp{} /* sstReqTS */, tc.maxIntents, usePrefixSeek)
 					require.Error(t, err)
-					writeIntentErr := &kvpb.WriteIntentError{}
-					require.ErrorAs(t, err, &writeIntentErr)
+					lcErr := &kvpb.LockConflictError{}
+					require.ErrorAs(t, err, &lcErr)
 
 					actual := []string{}
-					for _, i := range writeIntentErr.Intents {
+					for _, i := range lcErr.Intents {
 						actual = append(actual, string(i.Key))
 					}
 					require.Equal(t, tc.expectIntents, actual)

--- a/pkg/storage/testdata/mvcc_histories/delete_range_predicate
+++ b/pkg/storage/testdata/mvcc_histories/delete_range_predicate
@@ -94,7 +94,7 @@ data: "h"/4.000000000,0 -> /BYTES/h4
 meta: "i"/0,0 -> txn={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "i"/7.000000000,0 -> /BYTES/i7
 stats: key_count=8 key_bytes=160 val_count=12 val_bytes=111 range_key_count=2 range_key_bytes=27 range_val_count=2 live_count=3 live_bytes=111 gc_bytes_age=17863 intent_count=1 intent_bytes=19 separated_intent_count=1 intent_age=93
-error: (*kvpb.WriteIntentError:) conflicting intents on "i"
+error: (*kvpb.LockConflictError:) conflicting intents on "i"
 
 run stats error
 del_range_pred k=i end=+i ts=6 startTime=1
@@ -118,7 +118,7 @@ data: "h"/4.000000000,0 -> /BYTES/h4
 meta: "i"/0,0 -> txn={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "i"/7.000000000,0 -> /BYTES/i7
 stats: key_count=8 key_bytes=160 val_count=12 val_bytes=111 range_key_count=2 range_key_bytes=27 range_val_count=2 live_count=3 live_bytes=111 gc_bytes_age=17863 intent_count=1 intent_bytes=19 separated_intent_count=1 intent_age=93
-error: (*kvpb.WriteIntentError:) conflicting intents on "i"
+error: (*kvpb.LockConflictError:) conflicting intents on "i"
 
 # error encountering point key at d5.
 # a tombstone should not get written at c5 or e5, since

--- a/pkg/storage/testdata/mvcc_histories/delete_range_predicate
+++ b/pkg/storage/testdata/mvcc_histories/delete_range_predicate
@@ -94,7 +94,7 @@ data: "h"/4.000000000,0 -> /BYTES/h4
 meta: "i"/0,0 -> txn={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "i"/7.000000000,0 -> /BYTES/i7
 stats: key_count=8 key_bytes=160 val_count=12 val_bytes=111 range_key_count=2 range_key_bytes=27 range_val_count=2 live_count=3 live_bytes=111 gc_bytes_age=17863 intent_count=1 intent_bytes=19 separated_intent_count=1 intent_age=93
-error: (*kvpb.LockConflictError:) conflicting intents on "i"
+error: (*kvpb.LockConflictError:) conflicting locks on "i"
 
 run stats error
 del_range_pred k=i end=+i ts=6 startTime=1
@@ -118,7 +118,7 @@ data: "h"/4.000000000,0 -> /BYTES/h4
 meta: "i"/0,0 -> txn={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "i"/7.000000000,0 -> /BYTES/i7
 stats: key_count=8 key_bytes=160 val_count=12 val_bytes=111 range_key_count=2 range_key_bytes=27 range_val_count=2 live_count=3 live_bytes=111 gc_bytes_age=17863 intent_count=1 intent_bytes=19 separated_intent_count=1 intent_age=93
-error: (*kvpb.LockConflictError:) conflicting intents on "i"
+error: (*kvpb.LockConflictError:) conflicting locks on "i"
 
 # error encountering point key at d5.
 # a tombstone should not get written at c5 or e5, since

--- a/pkg/storage/testdata/mvcc_histories/export
+++ b/pkg/storage/testdata/mvcc_histories/export
@@ -81,17 +81,17 @@ data: "o"/7.000000000,0 -> /BYTES/n7
 run error
 export k=a end=z
 ----
-error: (*kvpb.WriteIntentError:) conflicting intents on "a"
+error: (*kvpb.LockConflictError:) conflicting intents on "a"
 
 run error
 export k=a end=z maxIntents=100
 ----
-error: (*kvpb.WriteIntentError:) conflicting intents on "a", "d", "j", "l", "o"
+error: (*kvpb.LockConflictError:) conflicting intents on "a", "d", "j", "l", "o"
 
 run error
 export k=a end=z maxIntents=3
 ----
-error: (*kvpb.WriteIntentError:) conflicting intents on "a", "d", "j"
+error: (*kvpb.LockConflictError:) conflicting intents on "a", "d", "j"
 
 # Export the entire dataset below the intents, with full revision history.
 run ok

--- a/pkg/storage/testdata/mvcc_histories/export
+++ b/pkg/storage/testdata/mvcc_histories/export
@@ -81,17 +81,17 @@ data: "o"/7.000000000,0 -> /BYTES/n7
 run error
 export k=a end=z
 ----
-error: (*kvpb.LockConflictError:) conflicting intents on "a"
+error: (*kvpb.LockConflictError:) conflicting locks on "a"
 
 run error
 export k=a end=z maxIntents=100
 ----
-error: (*kvpb.LockConflictError:) conflicting intents on "a", "d", "j", "l", "o"
+error: (*kvpb.LockConflictError:) conflicting locks on "a", "d", "j", "l", "o"
 
 run error
 export k=a end=z maxIntents=3
 ----
-error: (*kvpb.LockConflictError:) conflicting intents on "a", "d", "j"
+error: (*kvpb.LockConflictError:) conflicting locks on "a", "d", "j"
 
 # Export the entire dataset below the intents, with full revision history.
 run ok

--- a/pkg/storage/testdata/mvcc_histories/export_fingerprint
+++ b/pkg/storage/testdata/mvcc_histories/export_fingerprint
@@ -81,17 +81,17 @@ data: "o"/7.000000000,0 -> /BYTES/n7
 run error
 export fingerprint k=a end=z
 ----
-error: (*kvpb.LockConflictError:) conflicting intents on "a"
+error: (*kvpb.LockConflictError:) conflicting locks on "a"
 
 run error
 export fingerprint k=a end=z maxIntents=100
 ----
-error: (*kvpb.LockConflictError:) conflicting intents on "a", "d", "j", "l", "o"
+error: (*kvpb.LockConflictError:) conflicting locks on "a", "d", "j", "l", "o"
 
 run error
 export fingerprint k=a end=z maxIntents=3
 ----
-error: (*kvpb.LockConflictError:) conflicting intents on "a", "d", "j"
+error: (*kvpb.LockConflictError:) conflicting locks on "a", "d", "j"
 
 # Export the entire dataset below the intents, with full revision history.
 run ok

--- a/pkg/storage/testdata/mvcc_histories/export_fingerprint
+++ b/pkg/storage/testdata/mvcc_histories/export_fingerprint
@@ -81,17 +81,17 @@ data: "o"/7.000000000,0 -> /BYTES/n7
 run error
 export fingerprint k=a end=z
 ----
-error: (*kvpb.WriteIntentError:) conflicting intents on "a"
+error: (*kvpb.LockConflictError:) conflicting intents on "a"
 
 run error
 export fingerprint k=a end=z maxIntents=100
 ----
-error: (*kvpb.WriteIntentError:) conflicting intents on "a", "d", "j", "l", "o"
+error: (*kvpb.LockConflictError:) conflicting intents on "a", "d", "j", "l", "o"
 
 run error
 export fingerprint k=a end=z maxIntents=3
 ----
-error: (*kvpb.WriteIntentError:) conflicting intents on "a", "d", "j"
+error: (*kvpb.LockConflictError:) conflicting intents on "a", "d", "j"
 
 # Export the entire dataset below the intents, with full revision history.
 run ok

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_gets
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_gets
@@ -361,19 +361,19 @@ run error
 get k=e ts=3 failOnMoreRecent
 ----
 get: "e" -> <no data>
-error: (*kvpb.LockConflictError:) conflicting intents on "e"
+error: (*kvpb.LockConflictError:) conflicting locks on "e"
 
 run error
 get k=e ts=4 failOnMoreRecent
 ----
 get: "e" -> <no data>
-error: (*kvpb.LockConflictError:) conflicting intents on "e"
+error: (*kvpb.LockConflictError:) conflicting locks on "e"
 
 run error
 get k=e ts=5 failOnMoreRecent
 ----
 get: "e" -> <no data>
-error: (*kvpb.LockConflictError:) conflicting intents on "e"
+error: (*kvpb.LockConflictError:) conflicting locks on "e"
 
 # failOnMoreRecent: g
 run error

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_gets
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_gets
@@ -361,19 +361,19 @@ run error
 get k=e ts=3 failOnMoreRecent
 ----
 get: "e" -> <no data>
-error: (*kvpb.WriteIntentError:) conflicting intents on "e"
+error: (*kvpb.LockConflictError:) conflicting intents on "e"
 
 run error
 get k=e ts=4 failOnMoreRecent
 ----
 get: "e" -> <no data>
-error: (*kvpb.WriteIntentError:) conflicting intents on "e"
+error: (*kvpb.LockConflictError:) conflicting intents on "e"
 
 run error
 get k=e ts=5 failOnMoreRecent
 ----
 get: "e" -> <no data>
-error: (*kvpb.WriteIntentError:) conflicting intents on "e"
+error: (*kvpb.LockConflictError:) conflicting intents on "e"
 
 # failOnMoreRecent: g
 run error

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_iter_incremental
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_iter_incremental
@@ -923,7 +923,7 @@ iter_scan
 ----
 iter_seek_ge: err=conflicting intents on "a"
 iter_scan: err=conflicting intents on "a"
-error: (*kvpb.WriteIntentError:) conflicting intents on "a"
+error: (*kvpb.LockConflictError:) conflicting intents on "a"
 
 run error
 iter_new_incremental types=pointsAndRanges k=a end=z intents=aggregate
@@ -959,7 +959,7 @@ iter_scan: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>] !
 iter_scan: "m"/8.000000000,0=/BYTES/m8 {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
 iter_scan: "o"/7.000000000,0=/BYTES/o7 !
 iter_scan: .
-error: (*kvpb.WriteIntentError:) conflicting intents on "a", "d", "j", "l", "m", "o"
+error: (*kvpb.LockConflictError:) conflicting intents on "a", "d", "j", "l", "m", "o"
 
 run error
 iter_new_incremental types=pointsAndRanges k=a end=z endTs=7 intents=aggregate
@@ -993,7 +993,7 @@ iter_scan: "l"/7.000000000,0=/BYTES/l7
 iter_scan: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>] !
 iter_scan: "o"/7.000000000,0=/BYTES/o7 !
 iter_scan: .
-error: (*kvpb.WriteIntentError:) conflicting intents on "a", "j", "l", "o"
+error: (*kvpb.LockConflictError:) conflicting intents on "a", "j", "l", "o"
 
 run ok
 iter_new_incremental types=pointsAndRanges k=a end=z endTs=6 intents=aggregate
@@ -1061,7 +1061,7 @@ iter_next_ignoring_time
 ----
 iter_seek_ge: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>] !
 iter_next_ignoring_time: err=conflicting intents on "d"
-error: (*kvpb.WriteIntentError:) conflicting intents on "d"
+error: (*kvpb.LockConflictError:) conflicting intents on "d"
 
 run ok
 iter_new_incremental types=pointsAndRanges k=a end=z startTs=2 endTs=4 intents=error
@@ -1078,7 +1078,7 @@ iter_next_key_ignoring_time
 ----
 iter_seek_ge: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>] !
 iter_next_key_ignoring_time: err=conflicting intents on "d"
-error: (*kvpb.WriteIntentError:) conflicting intents on "d"
+error: (*kvpb.LockConflictError:) conflicting intents on "d"
 
 # rangesOnly doesn't care about intents.
 run ok

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_iter_incremental
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_iter_incremental
@@ -921,9 +921,9 @@ iter_new_incremental types=pointsAndRanges k=a end=z intents=error
 iter_seek_ge k=a
 iter_scan
 ----
-iter_seek_ge: err=conflicting intents on "a"
-iter_scan: err=conflicting intents on "a"
-error: (*kvpb.LockConflictError:) conflicting intents on "a"
+iter_seek_ge: err=conflicting locks on "a"
+iter_scan: err=conflicting locks on "a"
+error: (*kvpb.LockConflictError:) conflicting locks on "a"
 
 run error
 iter_new_incremental types=pointsAndRanges k=a end=z intents=aggregate
@@ -959,7 +959,7 @@ iter_scan: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>] !
 iter_scan: "m"/8.000000000,0=/BYTES/m8 {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
 iter_scan: "o"/7.000000000,0=/BYTES/o7 !
 iter_scan: .
-error: (*kvpb.LockConflictError:) conflicting intents on "a", "d", "j", "l", "m", "o"
+error: (*kvpb.LockConflictError:) conflicting locks on "a", "d", "j", "l", "m", "o"
 
 run error
 iter_new_incremental types=pointsAndRanges k=a end=z endTs=7 intents=aggregate
@@ -993,7 +993,7 @@ iter_scan: "l"/7.000000000,0=/BYTES/l7
 iter_scan: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>] !
 iter_scan: "o"/7.000000000,0=/BYTES/o7 !
 iter_scan: .
-error: (*kvpb.LockConflictError:) conflicting intents on "a", "j", "l", "o"
+error: (*kvpb.LockConflictError:) conflicting locks on "a", "j", "l", "o"
 
 run ok
 iter_new_incremental types=pointsAndRanges k=a end=z endTs=6 intents=aggregate
@@ -1060,8 +1060,8 @@ iter_seek_ge k=c
 iter_next_ignoring_time
 ----
 iter_seek_ge: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>] !
-iter_next_ignoring_time: err=conflicting intents on "d"
-error: (*kvpb.LockConflictError:) conflicting intents on "d"
+iter_next_ignoring_time: err=conflicting locks on "d"
+error: (*kvpb.LockConflictError:) conflicting locks on "d"
 
 run ok
 iter_new_incremental types=pointsAndRanges k=a end=z startTs=2 endTs=4 intents=error
@@ -1077,8 +1077,8 @@ iter_seek_ge k=c
 iter_next_key_ignoring_time
 ----
 iter_seek_ge: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>] !
-iter_next_key_ignoring_time: err=conflicting intents on "d"
-error: (*kvpb.LockConflictError:) conflicting intents on "d"
+iter_next_key_ignoring_time: err=conflicting locks on "d"
+error: (*kvpb.LockConflictError:) conflicting locks on "d"
 
 # rangesOnly doesn't care about intents.
 run ok

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_scans
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_scans
@@ -431,19 +431,19 @@ run error
 scan k=e end=f ts=3 failOnMoreRecent
 ----
 scan: "e"-"f" -> <no data>
-error: (*kvpb.LockConflictError:) conflicting intents on "e"
+error: (*kvpb.LockConflictError:) conflicting locks on "e"
 
 run error
 scan k=e end=f ts=4 failOnMoreRecent
 ----
 scan: "e"-"f" -> <no data>
-error: (*kvpb.LockConflictError:) conflicting intents on "e"
+error: (*kvpb.LockConflictError:) conflicting locks on "e"
 
 run error
 scan k=e end=f ts=5 failOnMoreRecent
 ----
 scan: "e"-"f" -> <no data>
-error: (*kvpb.LockConflictError:) conflicting intents on "e"
+error: (*kvpb.LockConflictError:) conflicting locks on "e"
 
 # failOnMoreRecent: g-h
 run error

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_scans
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_scans
@@ -431,19 +431,19 @@ run error
 scan k=e end=f ts=3 failOnMoreRecent
 ----
 scan: "e"-"f" -> <no data>
-error: (*kvpb.WriteIntentError:) conflicting intents on "e"
+error: (*kvpb.LockConflictError:) conflicting intents on "e"
 
 run error
 scan k=e end=f ts=4 failOnMoreRecent
 ----
 scan: "e"-"f" -> <no data>
-error: (*kvpb.WriteIntentError:) conflicting intents on "e"
+error: (*kvpb.LockConflictError:) conflicting intents on "e"
 
 run error
 scan k=e end=f ts=5 failOnMoreRecent
 ----
 scan: "e"-"f" -> <no data>
-error: (*kvpb.WriteIntentError:) conflicting intents on "e"
+error: (*kvpb.LockConflictError:) conflicting intents on "e"
 
 # failOnMoreRecent: g-h
 run error

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_writes
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_writes
@@ -278,7 +278,7 @@ meta: "i"/0,0 -> txn={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0
 data: "i"/7.000000000,0 -> /BYTES/i7
 error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k" at timestamp 3.000000000,0 too old; must write at or above 4.000000000,1
 
-# Writing below intents should return a WriteIntentError, both when above and
+# Writing below intents should return a LockConflictError, both when above and
 # below the intent timestamp and any existing values.
 run error
 del_range_ts k=d end=e ts=3
@@ -297,7 +297,7 @@ data: "g"/2.000000000,0 -> /BYTES/g2
 meta: "h"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/inline mergeTs=<nil> txnDidNotUpdateMeta=false
 meta: "i"/0,0 -> txn={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "i"/7.000000000,0 -> /BYTES/i7
-error: (*kvpb.WriteIntentError:) conflicting intents on "d"
+error: (*kvpb.LockConflictError:) conflicting intents on "d"
 
 run error
 del_range_ts k=d end=e ts=5
@@ -316,7 +316,7 @@ data: "g"/2.000000000,0 -> /BYTES/g2
 meta: "h"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/inline mergeTs=<nil> txnDidNotUpdateMeta=false
 meta: "i"/0,0 -> txn={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "i"/7.000000000,0 -> /BYTES/i7
-error: (*kvpb.WriteIntentError:) conflicting intents on "d"
+error: (*kvpb.LockConflictError:) conflicting intents on "d"
 
 run error
 del_range_ts k=i end=j ts=5
@@ -335,7 +335,7 @@ data: "g"/2.000000000,0 -> /BYTES/g2
 meta: "h"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/inline mergeTs=<nil> txnDidNotUpdateMeta=false
 meta: "i"/0,0 -> txn={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "i"/7.000000000,0 -> /BYTES/i7
-error: (*kvpb.WriteIntentError:) conflicting intents on "i"
+error: (*kvpb.LockConflictError:) conflicting intents on "i"
 
 run error
 del_range_ts k=i end=j ts=7
@@ -354,7 +354,7 @@ data: "g"/2.000000000,0 -> /BYTES/g2
 meta: "h"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/inline mergeTs=<nil> txnDidNotUpdateMeta=false
 meta: "i"/0,0 -> txn={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "i"/7.000000000,0 -> /BYTES/i7
-error: (*kvpb.WriteIntentError:) conflicting intents on "i"
+error: (*kvpb.LockConflictError:) conflicting intents on "i"
 
 run error
 del_range_ts k=i end=j ts=10
@@ -373,7 +373,7 @@ data: "g"/2.000000000,0 -> /BYTES/g2
 meta: "h"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/inline mergeTs=<nil> txnDidNotUpdateMeta=false
 meta: "i"/0,0 -> txn={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "i"/7.000000000,0 -> /BYTES/i7
-error: (*kvpb.WriteIntentError:) conflicting intents on "i"
+error: (*kvpb.LockConflictError:) conflicting intents on "i"
 
 # Writing above an inline value should error. We disable passing covered MVCC
 # stats in metamorphic tests because it changes the error message.

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_writes
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_writes
@@ -297,7 +297,7 @@ data: "g"/2.000000000,0 -> /BYTES/g2
 meta: "h"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/inline mergeTs=<nil> txnDidNotUpdateMeta=false
 meta: "i"/0,0 -> txn={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "i"/7.000000000,0 -> /BYTES/i7
-error: (*kvpb.LockConflictError:) conflicting intents on "d"
+error: (*kvpb.LockConflictError:) conflicting locks on "d"
 
 run error
 del_range_ts k=d end=e ts=5
@@ -316,7 +316,7 @@ data: "g"/2.000000000,0 -> /BYTES/g2
 meta: "h"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/inline mergeTs=<nil> txnDidNotUpdateMeta=false
 meta: "i"/0,0 -> txn={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "i"/7.000000000,0 -> /BYTES/i7
-error: (*kvpb.LockConflictError:) conflicting intents on "d"
+error: (*kvpb.LockConflictError:) conflicting locks on "d"
 
 run error
 del_range_ts k=i end=j ts=5
@@ -335,7 +335,7 @@ data: "g"/2.000000000,0 -> /BYTES/g2
 meta: "h"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/inline mergeTs=<nil> txnDidNotUpdateMeta=false
 meta: "i"/0,0 -> txn={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "i"/7.000000000,0 -> /BYTES/i7
-error: (*kvpb.LockConflictError:) conflicting intents on "i"
+error: (*kvpb.LockConflictError:) conflicting locks on "i"
 
 run error
 del_range_ts k=i end=j ts=7
@@ -354,7 +354,7 @@ data: "g"/2.000000000,0 -> /BYTES/g2
 meta: "h"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/inline mergeTs=<nil> txnDidNotUpdateMeta=false
 meta: "i"/0,0 -> txn={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "i"/7.000000000,0 -> /BYTES/i7
-error: (*kvpb.LockConflictError:) conflicting intents on "i"
+error: (*kvpb.LockConflictError:) conflicting locks on "i"
 
 run error
 del_range_ts k=i end=j ts=10
@@ -373,7 +373,7 @@ data: "g"/2.000000000,0 -> /BYTES/g2
 meta: "h"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/inline mergeTs=<nil> txnDidNotUpdateMeta=false
 meta: "i"/0,0 -> txn={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "i"/7.000000000,0 -> /BYTES/i7
-error: (*kvpb.LockConflictError:) conflicting intents on "i"
+error: (*kvpb.LockConflictError:) conflicting locks on "i"
 
 # Writing above an inline value should error. We disable passing covered MVCC
 # stats in metamorphic tests because it changes the error message.

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_writes_idempotent
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_writes_idempotent
@@ -177,7 +177,7 @@ data: "k"/3.000000000,0 -> /BYTES/k3
 data: "m"/1.000000000,0 -> /BYTES/m1
 data: "n"/3.000000000,0 -> /<empty>
 meta: "p"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/p0 mergeTs=<nil> txnDidNotUpdateMeta=false
-error: (*kvpb.LockConflictError:) conflicting intents on "i"
+error: (*kvpb.LockConflictError:) conflicting locks on "i"
 
 # Idempotent writes: exact, left, right, subset.
 run stats ok

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_writes_idempotent
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_writes_idempotent
@@ -177,7 +177,7 @@ data: "k"/3.000000000,0 -> /BYTES/k3
 data: "m"/1.000000000,0 -> /BYTES/m1
 data: "n"/3.000000000,0 -> /<empty>
 meta: "p"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/p0 mergeTs=<nil> txnDidNotUpdateMeta=false
-error: (*kvpb.WriteIntentError:) conflicting intents on "i"
+error: (*kvpb.LockConflictError:) conflicting intents on "i"
 
 # Idempotent writes: exact, left, right, subset.
 run stats ok

--- a/pkg/storage/testdata/mvcc_histories/read_fail_on_more_recent
+++ b/pkg/storage/testdata/mvcc_histories/read_fail_on_more_recent
@@ -101,31 +101,31 @@ run error
 get k=k2 ts=9,0 failOnMoreRecent
 ----
 get: "k2" -> <no data>
-error: (*kvpb.WriteIntentError:) conflicting intents on "k2"
+error: (*kvpb.LockConflictError:) conflicting intents on "k2"
 
 run error
 get k=k2 ts=10,0
 ----
 get: "k2" -> <no data>
-error: (*kvpb.WriteIntentError:) conflicting intents on "k2"
+error: (*kvpb.LockConflictError:) conflicting intents on "k2"
 
 run error
 get k=k2 ts=10,0 failOnMoreRecent
 ----
 get: "k2" -> <no data>
-error: (*kvpb.WriteIntentError:) conflicting intents on "k2"
+error: (*kvpb.LockConflictError:) conflicting intents on "k2"
 
 run error
 get k=k2 ts=11,0
 ----
 get: "k2" -> <no data>
-error: (*kvpb.WriteIntentError:) conflicting intents on "k2"
+error: (*kvpb.LockConflictError:) conflicting intents on "k2"
 
 run error
 get k=k2 ts=11,0 failOnMoreRecent
 ----
 get: "k2" -> <no data>
-error: (*kvpb.WriteIntentError:) conflicting intents on "k2"
+error: (*kvpb.LockConflictError:) conflicting intents on "k2"
 
 run ok
 scan k=k2 end=k3 ts=9,0
@@ -136,31 +136,31 @@ run error
 scan k=k2 end=k3 ts=9,0 failOnMoreRecent
 ----
 scan: "k2"-"k3" -> <no data>
-error: (*kvpb.WriteIntentError:) conflicting intents on "k2"
+error: (*kvpb.LockConflictError:) conflicting intents on "k2"
 
 run error
 scan k=k2 end=k3 ts=10,0
 ----
 scan: "k2"-"k3" -> <no data>
-error: (*kvpb.WriteIntentError:) conflicting intents on "k2"
+error: (*kvpb.LockConflictError:) conflicting intents on "k2"
 
 run error
 scan k=k2 end=k3 ts=10,0 failOnMoreRecent
 ----
 scan: "k2"-"k3" -> <no data>
-error: (*kvpb.WriteIntentError:) conflicting intents on "k2"
+error: (*kvpb.LockConflictError:) conflicting intents on "k2"
 
 run error
 scan k=k2 end=k3 ts=11,0
 ----
 scan: "k2"-"k3" -> <no data>
-error: (*kvpb.WriteIntentError:) conflicting intents on "k2"
+error: (*kvpb.LockConflictError:) conflicting intents on "k2"
 
 run error
 scan k=k2 end=k3 ts=11,0 failOnMoreRecent
 ----
 scan: "k2"-"k3" -> <no data>
-error: (*kvpb.WriteIntentError:) conflicting intents on "k2"
+error: (*kvpb.LockConflictError:) conflicting intents on "k2"
 
 # More test cases:
 # 
@@ -186,7 +186,7 @@ run error
 scan k=k1 end=k3 ts=10,0
 ----
 scan: "k1"-"k3" -> <no data>
-error: (*kvpb.WriteIntentError:) conflicting intents on "k2"
+error: (*kvpb.LockConflictError:) conflicting intents on "k2"
 
 run error
 scan k=k1 end=k3 ts=10,0 failOnMoreRecent
@@ -198,13 +198,13 @@ run error
 scan k=k1 end=k3 ts=11,0
 ----
 scan: "k1"-"k3" -> <no data>
-error: (*kvpb.WriteIntentError:) conflicting intents on "k2"
+error: (*kvpb.LockConflictError:) conflicting intents on "k2"
 
 run error
 scan k=k1 end=k3 ts=11,0 failOnMoreRecent
 ----
 scan: "k1"-"k3" -> <no data>
-error: (*kvpb.WriteIntentError:) conflicting intents on "k2"
+error: (*kvpb.LockConflictError:) conflicting intents on "k2"
 
 # The failOnMoreRecent and inconsistent options cannot be used together.
 

--- a/pkg/storage/testdata/mvcc_histories/read_fail_on_more_recent
+++ b/pkg/storage/testdata/mvcc_histories/read_fail_on_more_recent
@@ -101,31 +101,31 @@ run error
 get k=k2 ts=9,0 failOnMoreRecent
 ----
 get: "k2" -> <no data>
-error: (*kvpb.LockConflictError:) conflicting intents on "k2"
+error: (*kvpb.LockConflictError:) conflicting locks on "k2"
 
 run error
 get k=k2 ts=10,0
 ----
 get: "k2" -> <no data>
-error: (*kvpb.LockConflictError:) conflicting intents on "k2"
+error: (*kvpb.LockConflictError:) conflicting locks on "k2"
 
 run error
 get k=k2 ts=10,0 failOnMoreRecent
 ----
 get: "k2" -> <no data>
-error: (*kvpb.LockConflictError:) conflicting intents on "k2"
+error: (*kvpb.LockConflictError:) conflicting locks on "k2"
 
 run error
 get k=k2 ts=11,0
 ----
 get: "k2" -> <no data>
-error: (*kvpb.LockConflictError:) conflicting intents on "k2"
+error: (*kvpb.LockConflictError:) conflicting locks on "k2"
 
 run error
 get k=k2 ts=11,0 failOnMoreRecent
 ----
 get: "k2" -> <no data>
-error: (*kvpb.LockConflictError:) conflicting intents on "k2"
+error: (*kvpb.LockConflictError:) conflicting locks on "k2"
 
 run ok
 scan k=k2 end=k3 ts=9,0
@@ -136,31 +136,31 @@ run error
 scan k=k2 end=k3 ts=9,0 failOnMoreRecent
 ----
 scan: "k2"-"k3" -> <no data>
-error: (*kvpb.LockConflictError:) conflicting intents on "k2"
+error: (*kvpb.LockConflictError:) conflicting locks on "k2"
 
 run error
 scan k=k2 end=k3 ts=10,0
 ----
 scan: "k2"-"k3" -> <no data>
-error: (*kvpb.LockConflictError:) conflicting intents on "k2"
+error: (*kvpb.LockConflictError:) conflicting locks on "k2"
 
 run error
 scan k=k2 end=k3 ts=10,0 failOnMoreRecent
 ----
 scan: "k2"-"k3" -> <no data>
-error: (*kvpb.LockConflictError:) conflicting intents on "k2"
+error: (*kvpb.LockConflictError:) conflicting locks on "k2"
 
 run error
 scan k=k2 end=k3 ts=11,0
 ----
 scan: "k2"-"k3" -> <no data>
-error: (*kvpb.LockConflictError:) conflicting intents on "k2"
+error: (*kvpb.LockConflictError:) conflicting locks on "k2"
 
 run error
 scan k=k2 end=k3 ts=11,0 failOnMoreRecent
 ----
 scan: "k2"-"k3" -> <no data>
-error: (*kvpb.LockConflictError:) conflicting intents on "k2"
+error: (*kvpb.LockConflictError:) conflicting locks on "k2"
 
 # More test cases:
 # 
@@ -186,7 +186,7 @@ run error
 scan k=k1 end=k3 ts=10,0
 ----
 scan: "k1"-"k3" -> <no data>
-error: (*kvpb.LockConflictError:) conflicting intents on "k2"
+error: (*kvpb.LockConflictError:) conflicting locks on "k2"
 
 run error
 scan k=k1 end=k3 ts=10,0 failOnMoreRecent
@@ -198,13 +198,13 @@ run error
 scan k=k1 end=k3 ts=11,0
 ----
 scan: "k1"-"k3" -> <no data>
-error: (*kvpb.LockConflictError:) conflicting intents on "k2"
+error: (*kvpb.LockConflictError:) conflicting locks on "k2"
 
 run error
 scan k=k1 end=k3 ts=11,0 failOnMoreRecent
 ----
 scan: "k1"-"k3" -> <no data>
-error: (*kvpb.LockConflictError:) conflicting intents on "k2"
+error: (*kvpb.LockConflictError:) conflicting locks on "k2"
 
 # The failOnMoreRecent and inconsistent options cannot be used together.
 

--- a/pkg/storage/testdata/mvcc_histories/uncertainty_interval
+++ b/pkg/storage/testdata/mvcc_histories/uncertainty_interval
@@ -416,13 +416,13 @@ run error
 get t=txn13 k=k2
 ----
 get: "k2" -> <no data>
-error: (*kvpb.LockConflictError:) conflicting intents on "k2"
+error: (*kvpb.LockConflictError:) conflicting locks on "k2"
 
 run error
 scan t=txn13 k=k2
 ----
 scan: "k2"-"k2\x00" -> <no data>
-error: (*kvpb.LockConflictError:) conflicting intents on "k2"
+error: (*kvpb.LockConflictError:) conflicting locks on "k2"
 
 
 run ok
@@ -445,13 +445,13 @@ run error
 get t=txn14 k=k2
 ----
 get: "k2" -> <no data>
-error: (*kvpb.LockConflictError:) conflicting intents on "k2"
+error: (*kvpb.LockConflictError:) conflicting locks on "k2"
 
 run error
 scan t=txn14 k=k2
 ----
 scan: "k2"-"k2\x00" -> <no data>
-error: (*kvpb.LockConflictError:) conflicting intents on "k2"
+error: (*kvpb.LockConflictError:) conflicting locks on "k2"
 
 
 run ok
@@ -474,10 +474,10 @@ run error
 get t=txn15 k=k2
 ----
 get: "k2" -> <no data>
-error: (*kvpb.LockConflictError:) conflicting intents on "k2"
+error: (*kvpb.LockConflictError:) conflicting locks on "k2"
 
 run error
 scan t=txn15 k=k2
 ----
 scan: "k2"-"k2\x00" -> <no data>
-error: (*kvpb.LockConflictError:) conflicting intents on "k2"
+error: (*kvpb.LockConflictError:) conflicting locks on "k2"

--- a/pkg/storage/testdata/mvcc_histories/uncertainty_interval
+++ b/pkg/storage/testdata/mvcc_histories/uncertainty_interval
@@ -416,13 +416,13 @@ run error
 get t=txn13 k=k2
 ----
 get: "k2" -> <no data>
-error: (*kvpb.WriteIntentError:) conflicting intents on "k2"
+error: (*kvpb.LockConflictError:) conflicting intents on "k2"
 
 run error
 scan t=txn13 k=k2
 ----
 scan: "k2"-"k2\x00" -> <no data>
-error: (*kvpb.WriteIntentError:) conflicting intents on "k2"
+error: (*kvpb.LockConflictError:) conflicting intents on "k2"
 
 
 run ok
@@ -445,13 +445,13 @@ run error
 get t=txn14 k=k2
 ----
 get: "k2" -> <no data>
-error: (*kvpb.WriteIntentError:) conflicting intents on "k2"
+error: (*kvpb.LockConflictError:) conflicting intents on "k2"
 
 run error
 scan t=txn14 k=k2
 ----
 scan: "k2"-"k2\x00" -> <no data>
-error: (*kvpb.WriteIntentError:) conflicting intents on "k2"
+error: (*kvpb.LockConflictError:) conflicting intents on "k2"
 
 
 run ok
@@ -474,10 +474,10 @@ run error
 get t=txn15 k=k2
 ----
 get: "k2" -> <no data>
-error: (*kvpb.WriteIntentError:) conflicting intents on "k2"
+error: (*kvpb.LockConflictError:) conflicting intents on "k2"
 
 run error
 scan t=txn15 k=k2
 ----
 scan: "k2"-"k2\x00" -> <no data>
-error: (*kvpb.WriteIntentError:) conflicting intents on "k2"
+error: (*kvpb.LockConflictError:) conflicting intents on "k2"

--- a/pkg/storage/testdata/mvcc_histories/uncertainty_interval_with_local_uncertainty_limit
+++ b/pkg/storage/testdata/mvcc_histories/uncertainty_interval_with_local_uncertainty_limit
@@ -2095,49 +2095,49 @@ run error
 get t=txn20 k=k5 localUncertaintyLimit=20,0
 ----
 get: "k5" -> <no data>
-error: (*kvpb.WriteIntentError:) conflicting intents on "k5"
+error: (*kvpb.LockConflictError:) conflicting intents on "k5"
 
 run error
 scan t=txn20 k=k5 localUncertaintyLimit=20,0
 ----
 scan: "k5"-"k5\x00" -> <no data>
-error: (*kvpb.WriteIntentError:) conflicting intents on "k5"
+error: (*kvpb.LockConflictError:) conflicting intents on "k5"
 
 run error
 get t=txn20 k=k6 localUncertaintyLimit=20,0
 ----
 get: "k6" -> <no data>
-error: (*kvpb.WriteIntentError:) conflicting intents on "k6"
+error: (*kvpb.LockConflictError:) conflicting intents on "k6"
 
 run error
 scan t=txn20 k=k6 localUncertaintyLimit=20,0
 ----
 scan: "k6"-"k6\x00" -> <no data>
-error: (*kvpb.WriteIntentError:) conflicting intents on "k6"
+error: (*kvpb.LockConflictError:) conflicting intents on "k6"
 
 run error
 get t=txn20 k=k7 localUncertaintyLimit=20,0
 ----
 get: "k7" -> <no data>
-error: (*kvpb.WriteIntentError:) conflicting intents on "k7"
+error: (*kvpb.LockConflictError:) conflicting intents on "k7"
 
 run error
 scan t=txn20 k=k7 localUncertaintyLimit=20,0
 ----
 scan: "k7"-"k7\x00" -> <no data>
-error: (*kvpb.WriteIntentError:) conflicting intents on "k7"
+error: (*kvpb.LockConflictError:) conflicting intents on "k7"
 
 run error
 get t=txn20 k=k8 localUncertaintyLimit=20,0
 ----
 get: "k8" -> <no data>
-error: (*kvpb.WriteIntentError:) conflicting intents on "k8"
+error: (*kvpb.LockConflictError:) conflicting intents on "k8"
 
 run error
 scan t=txn20 k=k8 localUncertaintyLimit=20,0
 ----
 scan: "k8"-"k8\x00" -> <no data>
-error: (*kvpb.WriteIntentError:) conflicting intents on "k8"
+error: (*kvpb.LockConflictError:) conflicting intents on "k8"
 
 # A subset of the previous test cases, but with non-transactional reads:
 #
@@ -3004,46 +3004,46 @@ run error
 get k=k5 ts=25,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
 ----
 get: "k5" -> <no data>
-error: (*kvpb.WriteIntentError:) conflicting intents on "k5"
+error: (*kvpb.LockConflictError:) conflicting intents on "k5"
 
 run error
 scan k=k5 ts=25,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
 ----
 scan: "k5"-"k5\x00" -> <no data>
-error: (*kvpb.WriteIntentError:) conflicting intents on "k5"
+error: (*kvpb.LockConflictError:) conflicting intents on "k5"
 
 run error
 get k=k6 ts=25,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
 ----
 get: "k6" -> <no data>
-error: (*kvpb.WriteIntentError:) conflicting intents on "k6"
+error: (*kvpb.LockConflictError:) conflicting intents on "k6"
 
 run error
 scan k=k6 ts=25,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
 ----
 scan: "k6"-"k6\x00" -> <no data>
-error: (*kvpb.WriteIntentError:) conflicting intents on "k6"
+error: (*kvpb.LockConflictError:) conflicting intents on "k6"
 
 run error
 get k=k7 ts=25,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
 ----
 get: "k7" -> <no data>
-error: (*kvpb.WriteIntentError:) conflicting intents on "k7"
+error: (*kvpb.LockConflictError:) conflicting intents on "k7"
 
 run error
 scan k=k7 ts=25,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
 ----
 scan: "k7"-"k7\x00" -> <no data>
-error: (*kvpb.WriteIntentError:) conflicting intents on "k7"
+error: (*kvpb.LockConflictError:) conflicting intents on "k7"
 
 run error
 get k=k8 ts=25,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
 ----
 get: "k8" -> <no data>
-error: (*kvpb.WriteIntentError:) conflicting intents on "k8"
+error: (*kvpb.LockConflictError:) conflicting intents on "k8"
 
 run error
 scan k=k8 ts=25,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
 ----
 scan: "k8"-"k8\x00" -> <no data>
-error: (*kvpb.WriteIntentError:) conflicting intents on "k8"
+error: (*kvpb.LockConflictError:) conflicting intents on "k8"

--- a/pkg/storage/testdata/mvcc_histories/uncertainty_interval_with_local_uncertainty_limit
+++ b/pkg/storage/testdata/mvcc_histories/uncertainty_interval_with_local_uncertainty_limit
@@ -2095,49 +2095,49 @@ run error
 get t=txn20 k=k5 localUncertaintyLimit=20,0
 ----
 get: "k5" -> <no data>
-error: (*kvpb.LockConflictError:) conflicting intents on "k5"
+error: (*kvpb.LockConflictError:) conflicting locks on "k5"
 
 run error
 scan t=txn20 k=k5 localUncertaintyLimit=20,0
 ----
 scan: "k5"-"k5\x00" -> <no data>
-error: (*kvpb.LockConflictError:) conflicting intents on "k5"
+error: (*kvpb.LockConflictError:) conflicting locks on "k5"
 
 run error
 get t=txn20 k=k6 localUncertaintyLimit=20,0
 ----
 get: "k6" -> <no data>
-error: (*kvpb.LockConflictError:) conflicting intents on "k6"
+error: (*kvpb.LockConflictError:) conflicting locks on "k6"
 
 run error
 scan t=txn20 k=k6 localUncertaintyLimit=20,0
 ----
 scan: "k6"-"k6\x00" -> <no data>
-error: (*kvpb.LockConflictError:) conflicting intents on "k6"
+error: (*kvpb.LockConflictError:) conflicting locks on "k6"
 
 run error
 get t=txn20 k=k7 localUncertaintyLimit=20,0
 ----
 get: "k7" -> <no data>
-error: (*kvpb.LockConflictError:) conflicting intents on "k7"
+error: (*kvpb.LockConflictError:) conflicting locks on "k7"
 
 run error
 scan t=txn20 k=k7 localUncertaintyLimit=20,0
 ----
 scan: "k7"-"k7\x00" -> <no data>
-error: (*kvpb.LockConflictError:) conflicting intents on "k7"
+error: (*kvpb.LockConflictError:) conflicting locks on "k7"
 
 run error
 get t=txn20 k=k8 localUncertaintyLimit=20,0
 ----
 get: "k8" -> <no data>
-error: (*kvpb.LockConflictError:) conflicting intents on "k8"
+error: (*kvpb.LockConflictError:) conflicting locks on "k8"
 
 run error
 scan t=txn20 k=k8 localUncertaintyLimit=20,0
 ----
 scan: "k8"-"k8\x00" -> <no data>
-error: (*kvpb.LockConflictError:) conflicting intents on "k8"
+error: (*kvpb.LockConflictError:) conflicting locks on "k8"
 
 # A subset of the previous test cases, but with non-transactional reads:
 #
@@ -3004,46 +3004,46 @@ run error
 get k=k5 ts=25,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
 ----
 get: "k5" -> <no data>
-error: (*kvpb.LockConflictError:) conflicting intents on "k5"
+error: (*kvpb.LockConflictError:) conflicting locks on "k5"
 
 run error
 scan k=k5 ts=25,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
 ----
 scan: "k5"-"k5\x00" -> <no data>
-error: (*kvpb.LockConflictError:) conflicting intents on "k5"
+error: (*kvpb.LockConflictError:) conflicting locks on "k5"
 
 run error
 get k=k6 ts=25,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
 ----
 get: "k6" -> <no data>
-error: (*kvpb.LockConflictError:) conflicting intents on "k6"
+error: (*kvpb.LockConflictError:) conflicting locks on "k6"
 
 run error
 scan k=k6 ts=25,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
 ----
 scan: "k6"-"k6\x00" -> <no data>
-error: (*kvpb.LockConflictError:) conflicting intents on "k6"
+error: (*kvpb.LockConflictError:) conflicting locks on "k6"
 
 run error
 get k=k7 ts=25,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
 ----
 get: "k7" -> <no data>
-error: (*kvpb.LockConflictError:) conflicting intents on "k7"
+error: (*kvpb.LockConflictError:) conflicting locks on "k7"
 
 run error
 scan k=k7 ts=25,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
 ----
 scan: "k7"-"k7\x00" -> <no data>
-error: (*kvpb.LockConflictError:) conflicting intents on "k7"
+error: (*kvpb.LockConflictError:) conflicting locks on "k7"
 
 run error
 get k=k8 ts=25,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
 ----
 get: "k8" -> <no data>
-error: (*kvpb.LockConflictError:) conflicting intents on "k8"
+error: (*kvpb.LockConflictError:) conflicting locks on "k8"
 
 run error
 scan k=k8 ts=25,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
 ----
 scan: "k8"-"k8\x00" -> <no data>
-error: (*kvpb.LockConflictError:) conflicting intents on "k8"
+error: (*kvpb.LockConflictError:) conflicting locks on "k8"

--- a/pkg/storage/testdata/mvcc_histories/uncertainty_interval_with_local_uncertainty_limit_disable_local_timestamps
+++ b/pkg/storage/testdata/mvcc_histories/uncertainty_interval_with_local_uncertainty_limit_disable_local_timestamps
@@ -2015,49 +2015,49 @@ run error
 get t=txn20 k=k5 localUncertaintyLimit=20,0
 ----
 get: "k5" -> <no data>
-error: (*kvpb.LockConflictError:) conflicting intents on "k5"
+error: (*kvpb.LockConflictError:) conflicting locks on "k5"
 
 run error
 scan t=txn20 k=k5 localUncertaintyLimit=20,0
 ----
 scan: "k5"-"k5\x00" -> <no data>
-error: (*kvpb.LockConflictError:) conflicting intents on "k5"
+error: (*kvpb.LockConflictError:) conflicting locks on "k5"
 
 run error
 get t=txn20 k=k6 localUncertaintyLimit=20,0
 ----
 get: "k6" -> <no data>
-error: (*kvpb.LockConflictError:) conflicting intents on "k6"
+error: (*kvpb.LockConflictError:) conflicting locks on "k6"
 
 run error
 scan t=txn20 k=k6 localUncertaintyLimit=20,0
 ----
 scan: "k6"-"k6\x00" -> <no data>
-error: (*kvpb.LockConflictError:) conflicting intents on "k6"
+error: (*kvpb.LockConflictError:) conflicting locks on "k6"
 
 run error
 get t=txn20 k=k7 localUncertaintyLimit=20,0
 ----
 get: "k7" -> <no data>
-error: (*kvpb.LockConflictError:) conflicting intents on "k7"
+error: (*kvpb.LockConflictError:) conflicting locks on "k7"
 
 run error
 scan t=txn20 k=k7 localUncertaintyLimit=20,0
 ----
 scan: "k7"-"k7\x00" -> <no data>
-error: (*kvpb.LockConflictError:) conflicting intents on "k7"
+error: (*kvpb.LockConflictError:) conflicting locks on "k7"
 
 run error
 get t=txn20 k=k8 localUncertaintyLimit=20,0
 ----
 get: "k8" -> <no data>
-error: (*kvpb.LockConflictError:) conflicting intents on "k8"
+error: (*kvpb.LockConflictError:) conflicting locks on "k8"
 
 run error
 scan t=txn20 k=k8 localUncertaintyLimit=20,0
 ----
 scan: "k8"-"k8\x00" -> <no data>
-error: (*kvpb.LockConflictError:) conflicting intents on "k8"
+error: (*kvpb.LockConflictError:) conflicting locks on "k8"
 
 # A subset of the previous test cases, but with non-transactional reads:
 #
@@ -2900,46 +2900,46 @@ run error
 get k=k5 ts=25,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
 ----
 get: "k5" -> <no data>
-error: (*kvpb.LockConflictError:) conflicting intents on "k5"
+error: (*kvpb.LockConflictError:) conflicting locks on "k5"
 
 run error
 scan k=k5 ts=25,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
 ----
 scan: "k5"-"k5\x00" -> <no data>
-error: (*kvpb.LockConflictError:) conflicting intents on "k5"
+error: (*kvpb.LockConflictError:) conflicting locks on "k5"
 
 run error
 get k=k6 ts=25,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
 ----
 get: "k6" -> <no data>
-error: (*kvpb.LockConflictError:) conflicting intents on "k6"
+error: (*kvpb.LockConflictError:) conflicting locks on "k6"
 
 run error
 scan k=k6 ts=25,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
 ----
 scan: "k6"-"k6\x00" -> <no data>
-error: (*kvpb.LockConflictError:) conflicting intents on "k6"
+error: (*kvpb.LockConflictError:) conflicting locks on "k6"
 
 run error
 get k=k7 ts=25,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
 ----
 get: "k7" -> <no data>
-error: (*kvpb.LockConflictError:) conflicting intents on "k7"
+error: (*kvpb.LockConflictError:) conflicting locks on "k7"
 
 run error
 scan k=k7 ts=25,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
 ----
 scan: "k7"-"k7\x00" -> <no data>
-error: (*kvpb.LockConflictError:) conflicting intents on "k7"
+error: (*kvpb.LockConflictError:) conflicting locks on "k7"
 
 run error
 get k=k8 ts=25,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
 ----
 get: "k8" -> <no data>
-error: (*kvpb.LockConflictError:) conflicting intents on "k8"
+error: (*kvpb.LockConflictError:) conflicting locks on "k8"
 
 run error
 scan k=k8 ts=25,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
 ----
 scan: "k8"-"k8\x00" -> <no data>
-error: (*kvpb.LockConflictError:) conflicting intents on "k8"
+error: (*kvpb.LockConflictError:) conflicting locks on "k8"

--- a/pkg/storage/testdata/mvcc_histories/uncertainty_interval_with_local_uncertainty_limit_disable_local_timestamps
+++ b/pkg/storage/testdata/mvcc_histories/uncertainty_interval_with_local_uncertainty_limit_disable_local_timestamps
@@ -2015,49 +2015,49 @@ run error
 get t=txn20 k=k5 localUncertaintyLimit=20,0
 ----
 get: "k5" -> <no data>
-error: (*kvpb.WriteIntentError:) conflicting intents on "k5"
+error: (*kvpb.LockConflictError:) conflicting intents on "k5"
 
 run error
 scan t=txn20 k=k5 localUncertaintyLimit=20,0
 ----
 scan: "k5"-"k5\x00" -> <no data>
-error: (*kvpb.WriteIntentError:) conflicting intents on "k5"
+error: (*kvpb.LockConflictError:) conflicting intents on "k5"
 
 run error
 get t=txn20 k=k6 localUncertaintyLimit=20,0
 ----
 get: "k6" -> <no data>
-error: (*kvpb.WriteIntentError:) conflicting intents on "k6"
+error: (*kvpb.LockConflictError:) conflicting intents on "k6"
 
 run error
 scan t=txn20 k=k6 localUncertaintyLimit=20,0
 ----
 scan: "k6"-"k6\x00" -> <no data>
-error: (*kvpb.WriteIntentError:) conflicting intents on "k6"
+error: (*kvpb.LockConflictError:) conflicting intents on "k6"
 
 run error
 get t=txn20 k=k7 localUncertaintyLimit=20,0
 ----
 get: "k7" -> <no data>
-error: (*kvpb.WriteIntentError:) conflicting intents on "k7"
+error: (*kvpb.LockConflictError:) conflicting intents on "k7"
 
 run error
 scan t=txn20 k=k7 localUncertaintyLimit=20,0
 ----
 scan: "k7"-"k7\x00" -> <no data>
-error: (*kvpb.WriteIntentError:) conflicting intents on "k7"
+error: (*kvpb.LockConflictError:) conflicting intents on "k7"
 
 run error
 get t=txn20 k=k8 localUncertaintyLimit=20,0
 ----
 get: "k8" -> <no data>
-error: (*kvpb.WriteIntentError:) conflicting intents on "k8"
+error: (*kvpb.LockConflictError:) conflicting intents on "k8"
 
 run error
 scan t=txn20 k=k8 localUncertaintyLimit=20,0
 ----
 scan: "k8"-"k8\x00" -> <no data>
-error: (*kvpb.WriteIntentError:) conflicting intents on "k8"
+error: (*kvpb.LockConflictError:) conflicting intents on "k8"
 
 # A subset of the previous test cases, but with non-transactional reads:
 #
@@ -2900,46 +2900,46 @@ run error
 get k=k5 ts=25,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
 ----
 get: "k5" -> <no data>
-error: (*kvpb.WriteIntentError:) conflicting intents on "k5"
+error: (*kvpb.LockConflictError:) conflicting intents on "k5"
 
 run error
 scan k=k5 ts=25,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
 ----
 scan: "k5"-"k5\x00" -> <no data>
-error: (*kvpb.WriteIntentError:) conflicting intents on "k5"
+error: (*kvpb.LockConflictError:) conflicting intents on "k5"
 
 run error
 get k=k6 ts=25,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
 ----
 get: "k6" -> <no data>
-error: (*kvpb.WriteIntentError:) conflicting intents on "k6"
+error: (*kvpb.LockConflictError:) conflicting intents on "k6"
 
 run error
 scan k=k6 ts=25,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
 ----
 scan: "k6"-"k6\x00" -> <no data>
-error: (*kvpb.WriteIntentError:) conflicting intents on "k6"
+error: (*kvpb.LockConflictError:) conflicting intents on "k6"
 
 run error
 get k=k7 ts=25,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
 ----
 get: "k7" -> <no data>
-error: (*kvpb.WriteIntentError:) conflicting intents on "k7"
+error: (*kvpb.LockConflictError:) conflicting intents on "k7"
 
 run error
 scan k=k7 ts=25,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
 ----
 scan: "k7"-"k7\x00" -> <no data>
-error: (*kvpb.WriteIntentError:) conflicting intents on "k7"
+error: (*kvpb.LockConflictError:) conflicting intents on "k7"
 
 run error
 get k=k8 ts=25,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
 ----
 get: "k8" -> <no data>
-error: (*kvpb.WriteIntentError:) conflicting intents on "k8"
+error: (*kvpb.LockConflictError:) conflicting intents on "k8"
 
 run error
 scan k=k8 ts=25,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
 ----
 scan: "k8"-"k8\x00" -> <no data>
-error: (*kvpb.WriteIntentError:) conflicting intents on "k8"
+error: (*kvpb.LockConflictError:) conflicting intents on "k8"

--- a/pkg/storage/testdata/mvcc_histories/update_existing_key_diff_txn
+++ b/pkg/storage/testdata/mvcc_histories/update_existing_key_diff_txn
@@ -13,7 +13,7 @@ with t=B
 txn: "B" meta={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=44.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=44.000000000,0 wto=false gul=0,0
 meta: "a"/0,0 -> txn={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=33.000000000,0 min=0,0 seq=0} ts=33.000000000,0 del=false klen=12 vlen=8 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "a"/33.000000000,0 -> /BYTES/xyz
-error: (*kvpb.WriteIntentError:) conflicting intents on "a"
+error: (*kvpb.LockConflictError:) conflicting intents on "a"
 
 ## It's possible to observe the intent with an inconsistent read.
 

--- a/pkg/storage/testdata/mvcc_histories/update_existing_key_diff_txn
+++ b/pkg/storage/testdata/mvcc_histories/update_existing_key_diff_txn
@@ -1,5 +1,5 @@
 ## Two overlapping txns.
-## Two writes to the same key should be rejected with "write intent error", "conflicting intents".
+## Two writes to the same key should be rejected with a LockConflictError.
 
 run error
 with t=A
@@ -13,7 +13,7 @@ with t=B
 txn: "B" meta={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=44.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=44.000000000,0 wto=false gul=0,0
 meta: "a"/0,0 -> txn={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=33.000000000,0 min=0,0 seq=0} ts=33.000000000,0 del=false klen=12 vlen=8 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "a"/33.000000000,0 -> /BYTES/xyz
-error: (*kvpb.LockConflictError:) conflicting intents on "a"
+error: (*kvpb.LockConflictError:) conflicting locks on "a"
 
 ## It's possible to observe the intent with an inconsistent read.
 


### PR DESCRIPTION
Informs #100193.

This PR renames `WriteIntentError` to `LockConflictError`, and then performs a series of related renames. See individual commits. The commits intentionally avoid doing anything other than renaming types/fields/variables and updating comments. No logic is changed and there are a few TODOs introduced.

The intention is to follow this up with a rename of `roachpb.Intent` to `roachpb.Lock`, which will allow us to add a `Strength` field to the proto. We need this to propagate evaluation-time conflicts with replicated locks.

Release note: None