### PR TITLE
upgrades: avoid possible self-contention in tenant upgrade

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1460,7 +1460,7 @@ type ExecutorConfig struct {
 type UpdateVersionSystemSettingHook func(
 	ctx context.Context,
 	version clusterversion.ClusterVersion,
-	validate func(ctx context.Context) error,
+	validate func(ctx context.Context, txn *kv.Txn) error,
 ) error
 
 // VersionUpgradeHook is used to run upgrades starting in v21.1.

--- a/pkg/sql/set_cluster_setting.go
+++ b/pkg/sql/set_cluster_setting.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/docs"
+	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/multitenant"
 	"github.com/cockroachdb/cockroach/pkg/multitenant/mtinfopb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -547,7 +548,7 @@ func setVersionSetting(
 	// Updates the version inside the system.settings table.
 	// If we are already at or above the target version, then this
 	// function is idempotent.
-	updateVersionSystemSetting := func(ctx context.Context, version clusterversion.ClusterVersion, postSettingValidate func(ctx context.Context) error) error {
+	updateVersionSystemSetting := func(ctx context.Context, version clusterversion.ClusterVersion, postSettingValidate func(ctx context.Context, txn *kv.Txn) error) error {
 		rawValue, err := protoutil.Marshal(&version)
 		if err != nil {
 			return err
@@ -596,10 +597,9 @@ func setVersionSetting(
 			// servers present at the time of the settings update, matches the
 			// set that was present when the fence bump occurred (see comment in
 			// upgrademanager.Migrate() for more details).
-			if err = postSettingValidate(ctx); err != nil {
+			if err = postSettingValidate(ctx, txn.KV()); err != nil {
 				return err
 			}
-
 			return err
 		})
 	}

--- a/pkg/upgrade/system_upgrade.go
+++ b/pkg/upgrade/system_upgrade.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/keyvisualizer"
+	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -51,7 +52,7 @@ type Cluster interface {
 	// ValidateAfterUpdateSystemVersion performs any required validation after
 	// the system version is updated. This is used to perform additional
 	// validation during the tenant upgrade interlock.
-	ValidateAfterUpdateSystemVersion(ctx context.Context) error
+	ValidateAfterUpdateSystemVersion(ctx context.Context, txn *kv.Txn) error
 
 	// UntilClusterStable invokes the given closure until the cluster membership
 	// is stable, i.e once the set of nodes in the cluster before and after the

--- a/pkg/upgrade/upgradecluster/cluster.go
+++ b/pkg/upgrade/upgradecluster/cluster.go
@@ -143,6 +143,6 @@ func (c *Cluster) IterateRangeDescriptors(
 }
 
 // ValidateAfterUpdateSystemVersion is part of the upgrade.Cluster interface.
-func (c *Cluster) ValidateAfterUpdateSystemVersion(_ context.Context) error {
+func (c *Cluster) ValidateAfterUpdateSystemVersion(_ context.Context, _ *kv.Txn) error {
 	return nil
 }

--- a/pkg/upgrade/upgradecluster/tenant_cluster.go
+++ b/pkg/upgrade/upgradecluster/tenant_cluster.go
@@ -316,14 +316,14 @@ func (inconsistentSQLServersError) Error() string {
 
 var InconsistentSQLServersError = inconsistentSQLServersError{}
 
-func (t *TenantCluster) ValidateAfterUpdateSystemVersion(ctx context.Context) error {
+func (t *TenantCluster) ValidateAfterUpdateSystemVersion(ctx context.Context, txn *kv.Txn) error {
 	if len(t.instancesAtBump) == 0 {
 		// We should never get here with an empty slice, since bump must be
 		// called before validation.
 		return errors.AssertionFailedf("call to validate with empty instances slice")
 	}
 
-	instances, err := t.InstanceReader.GetAllInstancesNoCache(ctx)
+	instances, err := t.InstanceReader.GetAllInstancesUsingTxn(ctx, txn)
 	if err != nil {
 		return err
 	}

--- a/pkg/upgrade/upgrademanager/manager.go
+++ b/pkg/upgrade/upgrademanager/manager.go
@@ -381,10 +381,10 @@ func (m *Manager) Migrate(
 	// tenant upgrade case to ensure that no new SQL servers were started
 	// mid-upgrade, with versions that are incompatible with the attempted
 	// upgrade (because their binary version is too low).
-	validate := func(ctx context.Context) error {
-		return m.deps.Cluster.ValidateAfterUpdateSystemVersion(ctx)
+	validate := func(ctx context.Context, txn *kv.Txn) error {
+		return m.deps.Cluster.ValidateAfterUpdateSystemVersion(ctx, txn)
 	}
-	skipValidation := func(ctx context.Context) error {
+	skipValidation := func(ctx context.Context, txn *kv.Txn) error {
 		return nil
 	}
 


### PR DESCRIPTION
During an upgrade inside a tenant, we attempt to persist the version to the system.settings table and then run validations:

```golang
    return db.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
      // ... elided ..
      if _, err = txn.ExecEx(
      	ctx, "update-setting", txn.KV(),
      	sessiondata.RootUserSessionDataOverride,
      	`UPSERT INTO system.settings (name, value, "lastUpdated", "valueType") VALUES ($1, $2, now(), $3)`,
      	setting.InternalKey(), string(rawValue), setting.Typ(),
      ); err != nil {
      	return err
      }

      // Perform any necessary post-setting validation. This is used in
      // the tenant upgrade interlock to ensure that the set of sql
      // servers present at the time of the settings update, matches the
      // set that was present when the fence bump occurred (see comment in
      // upgrademanager.Migrate() for more details).
      if err = postSettingValidate(ctx); err != nil {
      	return err
      }
    })
```

The validation function in question is
`(t *TenantCluster).ValidateAfterUpdateSystemVersion` which uses the instance reader to get all of the instances. However, to account for system schema changes to the SQL instances table, the instance reader also wants to read the version. It does this via
`(*SettingsWatcher).VersionGuard` which reads the current version directly from disk.

Unfortunately, this read in the VersionGuard is in a different transaction than our update transaction above.

When writing an upgrade-related test that I wanted to run inside a tenant, this seemed to result in a 5-10s stall during the upgrade process.

Epic: CRDB-26691

Release note: None