### PR TITLE
upgrades: account for duplicate rows job_info rows

### DIFF
--- a/pkg/upgrade/upgrademanager/BUILD.bazel
+++ b/pkg/upgrade/upgrademanager/BUILD.bazel
@@ -47,6 +47,7 @@ go_test(
     ],
     args = ["-test.timeout=295s"],
     deps = [
+        ":upgrademanager",
         "//pkg/base",
         "//pkg/ccl",
         "//pkg/ccl/kvccl/kvtenantccl",
@@ -65,6 +66,7 @@ go_test(
         "//pkg/settings/cluster",
         "//pkg/sql/execinfra",
         "//pkg/sql/isql",
+        "//pkg/sql/protoreflect",
         "//pkg/sql/sem/eval",
         "//pkg/testutils",
         "//pkg/testutils/serverutils",


### PR DESCRIPTION
This addresses a theoretical problem with the new query to find active migration jobs. The job_info table can have multiple rows for the same (job_id, info_key) pair if the job in question happened to be running between the migration where we start writing to the job_info table and the migration.

Previously, if a migration job had two legacy_payload entries in the job_info table, the manager would fail as two rows would be produced by its lookup query.

It isn't clear to me that this is possible for the relevant migration jobs. That's because:

1. This query is only used _after_ the job_info backfill is complete; and,
2. After the job_info backfill is complete, it will only be looking for migrations that started after that version.

However, that is subtle enough to make us nervous. So, here we only return distinct job IDs from the lookup query.

The test here is very synthetic and is larger than it needs to be because I went down a rabbit hole trying to get it to work in both the system tenant and a guest tenant.

The test is slow but will get a little faster after #109111 is merged.

Epic: none

Release note: None