### PR TITLE
release-23.1: backupccl: skip backing up excluded spans

### DIFF
--- a/pkg/ccl/backupccl/backup_job.go
+++ b/pkg/ccl/backupccl/backup_job.go
@@ -175,6 +175,23 @@ func backup(
 		}
 	}
 
+	// Add the spans for any tables that are excluded from backup to the set of
+	// already-completed spans, as there is nothing to do for them.
+	descs := iterFactory.NewDescIter(ctx)
+	defer descs.Close()
+	for ; ; descs.Next() {
+		if ok, err := descs.Valid(); err != nil {
+			return roachpb.RowCount{}, 0, err
+		} else if !ok {
+			break
+		}
+
+		if tbl, _, _, _, _ := descpb.GetDescriptors(descs.Value()); tbl != nil && tbl.ExcludeDataFromBackup {
+			prefix := execCtx.ExecCfg().Codec.TablePrefix(uint32(tbl.ID))
+			completedSpans = append(completedSpans, roachpb.Span{Key: prefix, EndKey: prefix.PrefixEnd()})
+		}
+	}
+
 	// Subtract out any completed spans.
 	spans := filterSpans(backupManifest.Spans, completedSpans)
 	introducedSpans := filterSpans(backupManifest.IntroducedSpans, completedIntroducedSpans)

--- a/pkg/ccl/backupccl/backup_job.go
+++ b/pkg/ccl/backupccl/backup_job.go
@@ -181,7 +181,7 @@ func backup(
 	defer descs.Close()
 	for ; ; descs.Next() {
 		if ok, err := descs.Valid(); err != nil {
-			return roachpb.RowCount{}, 0, err
+			return roachpb.RowCount{}, err
 		} else if !ok {
 			break
 		}


### PR DESCRIPTION
Backport 1/1 commits from #108627.

/cc @cockroachdb/release

---

Previously we sent export requests to all spans being backed up. The ranges for spans of tables that had set the flag to exclude data from backup would reply with an empty response, excluding their data, but the backup process still sent these ranges these requests.

This changes the backup process to not send requests for spans from excluded tables, when performing database, table, or cluster backups. Backups of tenants will still send export requests to every range for the tenant span, and those ranges that host tables that are excluded will continue to reply with no data.

This is done both as an optimization, and so that backups can succeed even when a table is unavailable, if, and only if, that table is excluded.

Release note (ops change): BACKUP now skips contacting the ranges for tables on which exclude_data_from_backup is set, and can thus succeed even if an excluded table is unavailable.
Epic: none.


Release justification: small performance improvement as well as potential improvement of reliability in partially unavailable clusters.