### PR TITLE
sql: special-case a DB name to serve as hidden-by-default obs DB

### DIFF
--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -2087,6 +2087,7 @@ GO_TARGETS = [
     "//pkg/sql/sqlliveness/sqllivenesstestutils:sqllivenesstestutils",
     "//pkg/sql/sqlliveness:sqlliveness",
     "//pkg/sql/sqlnoccltest:sqlnoccltest_test",
+    "//pkg/sql/sqlstats/constants:constants",
     "//pkg/sql/sqlstats/insights/integration:integration_test",
     "//pkg/sql/sqlstats/insights:insights",
     "//pkg/sql/sqlstats/insights:insights_test",

--- a/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
@@ -1228,6 +1228,13 @@ func TestTenantLogic_numeric_references(
 	runLogicTest(t, "numeric_references")
 }
 
+func TestTenantLogic_obs_db_hidden(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "obs_db_hidden")
+}
+
 func TestTenantLogic_on_update(
 	t *testing.T,
 ) {

--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -502,6 +502,7 @@ go_library(
         "//pkg/sql/sqlinstance",
         "//pkg/sql/sqlliveness",
         "//pkg/sql/sqlstats",
+        "//pkg/sql/sqlstats/constants",
         "//pkg/sql/sqlstats/insights",
         "//pkg/sql/sqlstats/persistedsqlstats",
         "//pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil",

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -585,6 +585,10 @@ CREATE TABLE crdb_internal.tables (
 				// this virtual table before the dropped table descriptors are
 				// effectively deleted.
 				dbName = fmt.Sprintf("[%d]", table.GetParentID())
+			} else {
+				if p.isDBHidden(dbName, db) {
+					continue
+				}
 			}
 			schemaName := scNames[table.GetParentSchemaID()]
 			if schemaName == "" {

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -3138,6 +3138,10 @@ func (m *sessionDataMutator) SetDirectColumnarScansEnabled(b bool) {
 	m.data.DirectColumnarScansEnabled = b
 }
 
+func (m *sessionDataMutator) SetExposeObservabilitySchema(b bool) {
+	m.data.ExposeObservabilitySchema = b
+}
+
 func (m *sessionDataMutator) SetDisablePlanGists(val bool) {
 	m.data.DisablePlanGists = val
 }

--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -39,6 +39,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/semenumpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/constants"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/sql/vtable"
 	"github.com/cockroachdb/cockroach/pkg/util/collatedstring"
@@ -2423,6 +2424,9 @@ func forEachSchema(
 		if err != nil {
 			return err
 		}
+		if p.isDBHidden(db.GetName(), dbContext) {
+			return nil
+		}
 		return forEachDatabase(db)
 	})
 }
@@ -2464,6 +2468,9 @@ func forEachDatabaseDesc(
 			}
 			canSeeDescriptor = hasPriv || p.CurrentDatabase() == dbDesc.GetName()
 		}
+		if p.isDBHidden(dbDesc.GetName(), dbContext) {
+			canSeeDescriptor = false
+		}
 		if canSeeDescriptor {
 			if err := fn(dbDesc); err != nil {
 				return err
@@ -2472,6 +2479,23 @@ func forEachDatabaseDesc(
 	}
 
 	return nil
+}
+
+func (p *planner) isDBHidden(dbName string, dbContext catalog.DatabaseDescriptor) bool {
+	if dbContext != nil && dbContext.GetName() == dbName {
+		// If the user is targeting the obs db explicitly in an introspection query,
+		// include it.
+		return false
+	}
+	if p.CurrentDatabase() == dbName {
+		// It would be poor UX to hide the obs db if it is currently selected as current DB.
+		return false
+	}
+	// Hide the observability database unless the session vars says it should show up.
+	if dbName == constants.ObservabilityDatabaseName && !p.SessionData().ExposeObservabilitySchema {
+		return true
+	}
+	return false
 }
 
 // forEachTypeDesc calls a function for each TypeDescriptor. If dbContext is
@@ -2661,6 +2685,10 @@ func forEachTypeDescWithTableLookupInternalFromDescriptors(
 		if err != nil {
 			return err
 		}
+		if p.isDBHidden(dbDesc.GetName(), dbContext) {
+			continue
+		}
+
 		canSeeDescriptor, err := userCanSeeDescriptor(ctx, p, typDesc, dbDesc, allowAdding)
 		if err != nil {
 			return err
@@ -2716,6 +2744,10 @@ func forEachTableDescWithTableLookupInternalFromDescriptors(
 		case virtualMany:
 			for _, dbID := range lCtx.dbIDs {
 				dbDesc := lCtx.dbDescs[dbID]
+				// If the database is hidden and it is not current, skip it.
+				if p.isDBHidden(dbDesc.GetName(), dbContext) {
+					continue
+				}
 				if err := iterate(dbDesc); err != nil {
 					return err
 				}
@@ -2727,6 +2759,12 @@ func forEachTableDescWithTableLookupInternalFromDescriptors(
 	for _, tbID := range lCtx.tbIDs {
 		table := lCtx.tbDescs[tbID]
 		dbDesc, parentExists := lCtx.dbDescs[table.GetParentID()]
+
+		// If the database is hidden and it is not current, skip it.
+		if parentExists && p.isDBHidden(dbDesc.GetName(), dbContext) {
+			continue
+		}
+
 		canSeeDescriptor, err := userCanSeeDescriptor(ctx, p, table, dbDesc, allowAdding)
 		if err != nil {
 			return err

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -5317,6 +5317,7 @@ experimental_enable_implicit_column_partitioning           off
 experimental_enable_temp_tables                            off
 experimental_enable_unique_without_index_constraints       on
 experimental_hash_group_join_enabled                       off
+expose_observability_schema                                off
 extra_float_digits                                         1
 force_savepoint_restart                                    off
 foreign_key_cascades_limit                                 10000

--- a/pkg/sql/logictest/testdata/logic_test/obs_db_hidden
+++ b/pkg/sql/logictest/testdata/logic_test/obs_db_hidden
@@ -1,0 +1,143 @@
+# This file asserts that a DB with the special obs db name is
+# hidden by default.
+
+subtest default_config
+
+statement ok
+CREATE DATABASE "$OBS"; CREATE TABLE "$OBS".obs_unused(unused INT);
+
+query T rowsort
+SELECT database_name FROM [SHOW DATABASES]
+----
+defaultdb
+postgres
+system
+test
+
+query T rowsort
+SELECT name FROM crdb_internal.databases
+----
+defaultdb
+postgres
+system
+test
+
+query T rowsort
+SELECT datname FROM pg_catalog.pg_database WHERE datname = '$OBS'
+----
+
+query T rowsort
+SELECT name FROM "".crdb_internal.tables WHERE database_name='$OBS'
+----
+
+query TT rowsort
+SELECT catalog_name, schema_name FROM "".information_schema.schemata WHERE catalog_name='$OBS'
+----
+
+# It shows up if the db prefix was explicitely selected.
+query T rowsort
+SELECT name FROM "$OBS".crdb_internal.tables WHERE name = 'obs_unused'
+----
+obs_unused
+
+query TT rowsort
+SELECT catalog_name, schema_name FROM "$OBS".information_schema.schemata WHERE catalog_name='$OBS'
+----
+$OBS  crdb_internal
+$OBS  information_schema
+$OBS  pg_catalog
+$OBS  pg_extension
+$OBS  public
+
+subtest with_session_var
+
+statement ok
+SET expose_observability_schema = true
+
+query T rowsort
+SELECT database_name FROM [SHOW DATABASES]
+----
+$OBS
+defaultdb
+postgres
+system
+test
+
+query T rowsort
+SELECT name FROM "".crdb_internal.databases
+----
+$OBS
+defaultdb
+postgres
+system
+test
+
+query T rowsort
+SELECT datname FROM pg_catalog.pg_database WHERE datname = '$OBS'
+----
+$OBS
+
+query TT rowsort
+SELECT catalog_name, schema_name FROM "".information_schema.schemata WHERE catalog_name='$OBS'
+----
+$OBS  crdb_internal
+$OBS  information_schema
+$OBS  pg_catalog
+$OBS  pg_extension
+$OBS  public
+
+query T rowsort
+SELECT name FROM "".crdb_internal.tables WHERE name = 'obs_unused'
+----
+obs_unused
+
+statement ok
+RESET expose_observability_schema;
+
+
+subtest obs_currently_selected
+
+statement ok
+SET database = "$OBS"
+
+query T rowsort
+SELECT database_name FROM [SHOW DATABASES]
+----
+$OBS
+defaultdb
+postgres
+system
+test
+
+query T rowsort
+SELECT name FROM crdb_internal.databases
+----
+$OBS
+defaultdb
+postgres
+system
+test
+
+query T rowsort
+SELECT datname FROM pg_catalog.pg_database WHERE datname = '$OBS'
+----
+$OBS
+
+query TT rowsort
+SELECT catalog_name, schema_name FROM "".information_schema.schemata WHERE catalog_name='$OBS'
+----
+$OBS  crdb_internal
+$OBS  information_schema
+$OBS  pg_catalog
+$OBS  pg_extension
+$OBS  public
+
+query T rowsort
+SELECT name FROM "".crdb_internal.tables WHERE database_name='$OBS'
+----
+obs_unused
+
+query T rowsort
+SELECT table_name FROM [SHOW TABLES] WHERE table_name = 'obs_unused'
+----
+obs_unused

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -2752,6 +2752,7 @@ experimental_enable_implicit_column_partitioning           off                 N
 experimental_enable_temp_tables                            off                 NULL      NULL        NULL        string
 experimental_enable_unique_without_index_constraints       on                  NULL      NULL        NULL        string
 experimental_hash_group_join_enabled                       off                 NULL      NULL        NULL        string
+expose_observability_schema                                off                 NULL      NULL        NULL        string
 extra_float_digits                                         1                   NULL      NULL        NULL        string
 force_savepoint_restart                                    off                 NULL      NULL        NULL        string
 foreign_key_cascades_limit                                 10000               NULL      NULL        NULL        string
@@ -2915,6 +2916,7 @@ experimental_enable_implicit_column_partitioning           off                 N
 experimental_enable_temp_tables                            off                 NULL  user     NULL      off                 off
 experimental_enable_unique_without_index_constraints       on                  NULL  user     NULL      off                 off
 experimental_hash_group_join_enabled                       off                 NULL  user     NULL      off                 off
+expose_observability_schema                                off                 NULL  user     NULL      off                 off
 extra_float_digits                                         1                   NULL  user     NULL      1                   2
 force_savepoint_restart                                    off                 NULL  user     NULL      off                 off
 foreign_key_cascades_limit                                 10000               NULL  user     NULL      10000               10000
@@ -3075,6 +3077,7 @@ experimental_enable_implicit_column_partitioning           NULL    NULL     NULL
 experimental_enable_temp_tables                            NULL    NULL     NULL     NULL        NULL
 experimental_enable_unique_without_index_constraints       NULL    NULL     NULL     NULL        NULL
 experimental_hash_group_join_enabled                       NULL    NULL     NULL     NULL        NULL
+expose_observability_schema                                NULL    NULL     NULL     NULL        NULL
 extra_float_digits                                         NULL    NULL     NULL     NULL        NULL
 force_savepoint_restart                                    NULL    NULL     NULL     NULL        NULL
 foreign_key_cascades_limit                                 NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -82,6 +82,7 @@ experimental_enable_implicit_column_partitioning           off
 experimental_enable_temp_tables                            off
 experimental_enable_unique_without_index_constraints       off
 experimental_hash_group_join_enabled                       off
+expose_observability_schema                                off
 extra_float_digits                                         1
 force_savepoint_restart                                    off
 foreign_key_cascades_limit                                 10000

--- a/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
@@ -1206,6 +1206,13 @@ func TestLogic_numeric_references(
 	runLogicTest(t, "numeric_references")
 }
 
+func TestLogic_obs_db_hidden(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "obs_db_hidden")
+}
+
 func TestLogic_on_update(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
@@ -1206,6 +1206,13 @@ func TestLogic_numeric_references(
 	runLogicTest(t, "numeric_references")
 }
 
+func TestLogic_obs_db_hidden(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "obs_db_hidden")
+}
+
 func TestLogic_on_update(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist/generated_test.go
@@ -1213,6 +1213,13 @@ func TestLogic_numeric_references(
 	runLogicTest(t, "numeric_references")
 }
 
+func TestLogic_obs_db_hidden(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "obs_db_hidden")
+}
+
 func TestLogic_on_update(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
+++ b/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
@@ -1192,6 +1192,13 @@ func TestLogic_numeric_references(
 	runLogicTest(t, "numeric_references")
 }
 
+func TestLogic_obs_db_hidden(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "obs_db_hidden")
+}
+
 func TestLogic_on_update(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-mixed-22.2-23.1/generated_test.go
+++ b/pkg/sql/logictest/tests/local-mixed-22.2-23.1/generated_test.go
@@ -1185,6 +1185,13 @@ func TestLogic_numeric_references(
 	runLogicTest(t, "numeric_references")
 }
 
+func TestLogic_obs_db_hidden(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "obs_db_hidden")
+}
+
 func TestLogic_on_update(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/local-vec-off/generated_test.go
@@ -1220,6 +1220,13 @@ func TestLogic_numeric_references(
 	runLogicTest(t, "numeric_references")
 }
 
+func TestLogic_obs_db_hidden(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "obs_db_hidden")
+}
+
 func TestLogic_on_update(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local/generated_test.go
+++ b/pkg/sql/logictest/tests/local/generated_test.go
@@ -1332,6 +1332,13 @@ func TestLogic_numeric_references(
 	runLogicTest(t, "numeric_references")
 }
 
+func TestLogic_obs_db_hidden(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "obs_db_hidden")
+}
+
 func TestLogic_on_update(
 	t *testing.T,
 ) {

--- a/pkg/sql/sessiondatapb/session_data.proto
+++ b/pkg/sql/sessiondatapb/session_data.proto
@@ -112,6 +112,9 @@ message SessionData {
   // that is used for builtins like to_tsvector and to_tsquery if no
   // text search configuration is explicitly passed in.
   string default_text_search_config = 26;
+  // ExposeObservabilitySchema determines whether the obs schema shows up
+  // in schema introspection.
+  bool expose_observability_schema = 27;
 }
 
 // DataConversionConfig contains the parameters that influence the output

--- a/pkg/sql/sqlstats/constants/BUILD.bazel
+++ b/pkg/sql/sqlstats/constants/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "constants",
+    srcs = ["constants.go"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/sql/sqlstats/constants",
+    visibility = ["//visibility:public"],
+)

--- a/pkg/sql/sqlstats/constants/constants.go
+++ b/pkg/sql/sqlstats/constants/constants.go
@@ -1,0 +1,20 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package constants
+
+const (
+	// ObservabilityDatabaseName is the name of the obs database.
+	//
+	// We use the special character "$" and capitals because we want to
+	// minimize the risk that this database name will overlap with any
+	// database a customer may have created already.
+	ObservabilityDatabaseName = "$OBS"
+)

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -513,6 +513,23 @@ var varGen = map[string]sessionVar{
 	},
 
 	// CockroachDB extension.
+	`expose_observability_schema`: {
+		GetStringVal: makePostgresBoolGetStringValFn(`expose_obsevability_schema`),
+		Set: func(_ context.Context, m sessionDataMutator, s string) error {
+			b, err := paramparse.ParseBoolVar(`expose_observability_schema`, s)
+			if err != nil {
+				return err
+			}
+			m.SetExposeObservabilitySchema(b)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().ExposeObservabilitySchema), nil
+		},
+		GlobalDefault: globalFalse,
+	},
+
+	// CockroachDB extension.
 	`disable_plan_gists`: {
 		GetStringVal: makePostgresBoolGetStringValFn(`disable_plan_gists`),
 		Set: func(_ context.Context, m sessionDataMutator, s string) error {


### PR DESCRIPTION
Informs #109125.

In a later change we plan to introduce a new database whose purpose is to hold observability data.

One of the main goals of this change is to arrive at a project state where folk in the observability team can add new tables to that schema without having to update many unit tests throughout the code base.

To achieve the latter, it is thus important to special-case the (future) observability DB so that it does not show up in introspection by default. This is necessary because many unit tests assert what exists in the initial namespace when a cluster is created.

This commit achieves this by doing the following:

- it introduces special-casing in introspection to hide the observability DB name by default.

- it adds a new session variable `expose_observability_schema` which can be set to opt into obs DB visibility. This can help during development.

Release note: None