### PR TITLE
release-23.1.9-rc: roachtest: better handling of infrastructure flakes and update aws-cli

### DIFF
--- a/build/.bazelbuilderversion
+++ b/build/.bazelbuilderversion
@@ -1,1 +1,1 @@
-cockroachdb/bazel:20230303-060247
+cockroachdb/bazel:20230815-141035

--- a/build/.bazelbuilderversion-fips
+++ b/build/.bazelbuilderversion-fips
@@ -1,1 +1,1 @@
-cockroachdb/bazel-fips:20230303-060247
+cockroachdb/bazel-fips:20230815-141035

--- a/build/bazelbuilder/Dockerfile
+++ b/build/bazelbuilder/Dockerfile
@@ -87,10 +87,10 @@ RUN apt-get purge -y \
 # NB: we don't use apt-get because we need an up to date version of awscli
 # If you update the below, you should probably also update build/builder/Dockerfile.
 RUN case ${TARGETPLATFORM} in \
-    "linux/amd64") ARCH=x86_64; SHASUM=7ee475f22c1b35cc9e53affbf96a9ffce91706e154a9441d0d39cbf8366b718e ;; \
-    "linux/arm64") ARCH=aarch64; SHASUM=624ebb04705d4909eb0d56d467fe6b8b5c53a8c59375ed520e70236120125077 ;; \
+    "linux/amd64") ARCH=x86_64; SHASUM=e679933eec90b0e5a75d485be6c2fae0f89a3f9ccdcb1748be69f8f456e9a85f ;; \
+    "linux/arm64") ARCH=aarch64; SHASUM=7d6460f795712ebdac7e3c60d4800dde682d136d909810402aac164f2789b860 ;; \
   esac && \
- curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-$ARCH-2.0.30.zip" -o "awscliv2.zip" && \
+ curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-$ARCH-2.13.9.zip" -o "awscliv2.zip" && \
  echo "$SHASUM awscliv2.zip" | sha256sum -c - && \
  unzip awscliv2.zip && \
  ./aws/install && \

--- a/build/builder.sh
+++ b/build/builder.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 image=cockroachdb/builder
-version=20230614-164006
+version=20230815-142459
 
 function init() {
   docker build --tag="${image}" "$(dirname "${0}")/builder"

--- a/build/builder/Dockerfile
+++ b/build/builder/Dockerfile
@@ -152,10 +152,14 @@ RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key ad
  && curl -fsSL https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
  && echo "deb [arch=amd64] https://dl.google.com/linux/chrome/deb/ stable main" | tee /etc/apt/sources.list.d/google.list \
  && curl https://bazel.build/bazel-release.pub.gpg | apt-key add - \
+ && curl -fsLS https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | apt-key add - \
+ && echo "deb https://packages.microsoft.com/repos/azure-cli/ focal main" > /etc/apt/sources.list.d/azure-cli.list \
  && apt-get update \
  && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    azure-cli \
     ccache \
     google-cloud-sdk \
+    google-cloud-cli-gke-gcloud-auth-plugin \
     lsof \
     netcat \
     netbase \
@@ -164,19 +168,21 @@ RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key ad
     openssh-client \
     yarn \
     google-chrome-stable \
-    unzip
+    unzip \
+&& apt-get clean
 
 # awscli - roachtests
 # NB: we don't use apt-get because we need an up to date version of awscli
 # If you update the below, you should probably also update build/bazelbuilder/Dockerfile.
-RUN curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.0.30.zip" -o "awscliv2.zip" && \
- echo "7ee475f22c1b35cc9e53affbf96a9ffce91706e154a9441d0d39cbf8366b718e  awscliv2.zip" | sha256sum -c - && \
+RUN curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.13.9.zip" -o "awscliv2.zip" && \
+ echo "e679933eec90b0e5a75d485be6c2fae0f89a3f9ccdcb1748be69f8f456e9a85f  awscliv2.zip" | sha256sum -c - && \
  unzip awscliv2.zip && \
  ./aws/install && \
  rm -rf aws awscliv2.zip
 
 # git - Upgrade to a more modern version
 RUN DEBIAN_FRONTEND=noninteractive apt-get install dh-autoreconf libcurl4-gnutls-dev libexpat1-dev gettext libz-dev libssl-dev -y && \
+    apt-get clean && \
     curl -fsSL https://github.com/git/git/archive/v2.29.2.zip -o "git-2.29.2.zip" && \
     unzip "git-2.29.2.zip" && \
     cd git-2.29.2 && \

--- a/pkg/cmd/internal/issues/issues_test.go
+++ b/pkg/cmd/internal/issues/issues_test.go
@@ -57,6 +57,7 @@ func TestPost(t *testing.T) {
 		message              string
 		artifacts            string
 		reproCmd             string
+		skipTestFailure      bool
 		reproTitle, reproURL string
 	}
 
@@ -150,6 +151,13 @@ test logs left over in: /go/src/github.com/cockroachdb/cockroach/artifacts/logTe
 			message:     "boom",
 			reproURL:    "https://github.com/cockroachdb/cockroach",
 			reproTitle:  "FooBar README",
+		},
+		{
+			name:            "infrastructure-flake",
+			packageName:     "roachtest",
+			testName:        "TestCDC",
+			message:         "Something went wrong",
+			skipTestFailure: true,
 		},
 	}
 
@@ -353,14 +361,15 @@ test logs left over in: /go/src/github.com/cockroachdb/cockroach/artifacts/logTe
 				repro = HelpCommandAsLink(c.reproTitle, c.reproURL)
 			}
 			req := PostRequest{
-				PackageName:     c.packageName,
-				TestName:        c.testName,
-				Message:         c.message,
-				Artifacts:       c.artifacts,
-				MentionOnCreate: []string{"@cockroachdb/idonotexistbecausethisisatest"},
-				HelpCommand:     repro,
-				ExtraLabels:     []string{"release-blocker"},
-				ExtraParams:     map[string]string{"ROACHTEST_cloud": "gce"},
+				PackageName:          c.packageName,
+				TestName:             c.testName,
+				Message:              c.message,
+				SkipLabelTestFailure: c.skipTestFailure,
+				Artifacts:            c.artifacts,
+				MentionOnCreate:      []string{"@cockroachdb/idonotexistbecausethisisatest"},
+				HelpCommand:          repro,
+				ExtraLabels:          []string{"release-blocker"},
+				ExtraParams:          map[string]string{"ROACHTEST_cloud": "gce"},
 			}
 			require.NoError(t, p.post(context.Background(), UnitTestFormatter, req))
 

--- a/pkg/cmd/internal/issues/testdata/post/infrastructure-flake-matching-and-related-issue.txt
+++ b/pkg/cmd/internal/issues/testdata/post/infrastructure-flake-matching-and-related-issue.txt
@@ -1,0 +1,38 @@
+post
+----
+----
+searchIssue repo:"cockroach" user:"cockroachdb" is:issue is:open in:title label:"O-robot" sort:created-desc "roachtest: TestCDC failed" label:branch-release-0.1 -label:X-noreuse: [github.Issue{Number:31, Title:"roachtest: TestCDC-similar failed [failure reason]", Labels:[github.Label{URL:"fake", Name:"C-test-failure"} github.Label{URL:"fake", Name:"O-robot"} github.Label{URL:"fake", Name:"release-0.1"}]} github.Issue{Number:30, Title:"roachtest: TestCDC failed [failure reason]", Labels:[github.Label{URL:"fake", Name:"C-test-failure"} github.Label{URL:"fake", Name:"O-robot"} github.Label{URL:"fake", Name:"release-0.1"}]}]
+searchIssue repo:"cockroach" user:"cockroachdb" is:issue is:open in:title label:"O-robot" sort:created-desc "roachtest: TestCDC failed" -label:branch-release-0.1: [github.Issue{Number:40, Title:"roachtest: TestCDC failed [failure reason]", Labels:[github.Label{URL:"fake", Name:"C-test-failure"} github.Label{URL:"fake", Name:"O-robot"} github.Label{URL:"fake", Name:"release-0.2"}]}]
+createComment owner=cockroachdb repo=cockroach issue=30:
+
+roachtest.TestCDC [failed](https://teamcity.example.com/buildConfiguration/nightly123/8008135?buildTab=log) on release-0.1 @ [abcd123](https://github.com/cockroachdb/cockroach/commits/abcd123):
+
+
+```
+Something went wrong
+```
+<p>Parameters: <code>GOFLAGS=race</code>
+, <code>ROACHTEST_cloud=gce</code>
+, <code>TAGS=deadlock</code>
+</p>
+<details><summary>Help</summary>
+<p>
+
+See also: [How To Investigate a Go Test Failure \(internal\)](https://cockroachlabs.atlassian.net/l/c/HgfXfJgM)
+</p>
+</details>
+<details><summary>Same failure on other branches</summary>
+<p>
+
+- #40 roachtest: TestCDC failed [failure reason] [C-test-failure O-robot release-0.2]
+</p>
+</details>
+<sub>
+
+[This test on roachdash](https://roachdash.crdb.dev/?filter=status:open%20t:.*TestCDC.*&sort=title+created&display=lastcommented+project) | [Improve this report!](https://github.com/cockroachdb/cockroach/tree/master/pkg/cmd/internal/issues)
+</sub>
+
+
+Rendered: https://github.com/cockroachdb/cockroach/issues/new?body=roachtest.TestCDC+%5Bfailed%5D%28https%3A%2F%2Fteamcity.example.com%2FbuildConfiguration%2Fnightly123%2F8008135%3FbuildTab%3Dlog%29+on+release-0.1+%40+%5Babcd123%5D%28https%3A%2F%2Fgithub.com%2Fcockroachdb%2Fcockroach%2Fcommits%2Fabcd123%29%3A%0A%0A%0A%60%60%60%0ASomething+went+wrong%0A%60%60%60%0A%3Cp%3EParameters%3A+%3Ccode%3EGOFLAGS%3Drace%3C%2Fcode%3E%0A%2C+%3Ccode%3EROACHTEST_cloud%3Dgce%3C%2Fcode%3E%0A%2C+%3Ccode%3ETAGS%3Ddeadlock%3C%2Fcode%3E%0A%3C%2Fp%3E%0A%3Cdetails%3E%3Csummary%3EHelp%3C%2Fsummary%3E%0A%3Cp%3E%0A%0ASee+also%3A+%5BHow+To+Investigate+a+Go+Test+Failure+%5C%28internal%5C%29%5D%28https%3A%2F%2Fcockroachlabs.atlassian.net%2Fl%2Fc%2FHgfXfJgM%29%0A%3C%2Fp%3E%0A%3C%2Fdetails%3E%0A%3Cdetails%3E%3Csummary%3ESame+failure+on+other+branches%3C%2Fsummary%3E%0A%3Cp%3E%0A%0A-+%2340+roachtest%3A+TestCDC+failed+%5Bfailure+reason%5D+%5BC-test-failure+O-robot+release-0.2%5D%0A%3C%2Fp%3E%0A%3C%2Fdetails%3E%0A%3Csub%3E%0A%0A%5BThis+test+on+roachdash%5D%28https%3A%2F%2Froachdash.crdb.dev%2F%3Ffilter%3Dstatus%3Aopen%2520t%3A.%2ATestCDC.%2A%26sort%3Dtitle%2Bcreated%26display%3Dlastcommented%2Bproject%29+%7C+%5BImprove+this+report%21%5D%28https%3A%2F%2Fgithub.com%2Fcockroachdb%2Fcockroach%2Ftree%2Fmaster%2Fpkg%2Fcmd%2Finternal%2Fissues%29%0A%3C%2Fsub%3E%0A&title=%3Ccomment%3E
+----
+----

--- a/pkg/cmd/internal/issues/testdata/post/infrastructure-flake-matching-issue.txt
+++ b/pkg/cmd/internal/issues/testdata/post/infrastructure-flake-matching-issue.txt
@@ -1,0 +1,32 @@
+post
+----
+----
+searchIssue repo:"cockroach" user:"cockroachdb" is:issue is:open in:title label:"O-robot" sort:created-desc "roachtest: TestCDC failed" label:branch-release-0.1 -label:X-noreuse: [github.Issue{Number:30, Title:"roachtest: TestCDC failed [failure reason]", Labels:[github.Label{URL:"fake", Name:"C-test-failure"} github.Label{URL:"fake", Name:"O-robot"} github.Label{URL:"fake", Name:"release-0.1"}]} github.Issue{Number:32, Title:"roachtest: TestCDC-similar failed [failure reason]", Labels:[github.Label{URL:"fake", Name:"C-test-failure"} github.Label{URL:"fake", Name:"O-robot"} github.Label{URL:"fake", Name:"release-0.1"}]}]
+searchIssue repo:"cockroach" user:"cockroachdb" is:issue is:open in:title label:"O-robot" sort:created-desc "roachtest: TestCDC failed" -label:branch-release-0.1: []
+createComment owner=cockroachdb repo=cockroach issue=30:
+
+roachtest.TestCDC [failed](https://teamcity.example.com/buildConfiguration/nightly123/8008135?buildTab=log) on release-0.1 @ [abcd123](https://github.com/cockroachdb/cockroach/commits/abcd123):
+
+
+```
+Something went wrong
+```
+<p>Parameters: <code>GOFLAGS=race</code>
+, <code>ROACHTEST_cloud=gce</code>
+, <code>TAGS=deadlock</code>
+</p>
+<details><summary>Help</summary>
+<p>
+
+See also: [How To Investigate a Go Test Failure \(internal\)](https://cockroachlabs.atlassian.net/l/c/HgfXfJgM)
+</p>
+</details>
+<sub>
+
+[This test on roachdash](https://roachdash.crdb.dev/?filter=status:open%20t:.*TestCDC.*&sort=title+created&display=lastcommented+project) | [Improve this report!](https://github.com/cockroachdb/cockroach/tree/master/pkg/cmd/internal/issues)
+</sub>
+
+
+Rendered: https://github.com/cockroachdb/cockroach/issues/new?body=roachtest.TestCDC+%5Bfailed%5D%28https%3A%2F%2Fteamcity.example.com%2FbuildConfiguration%2Fnightly123%2F8008135%3FbuildTab%3Dlog%29+on+release-0.1+%40+%5Babcd123%5D%28https%3A%2F%2Fgithub.com%2Fcockroachdb%2Fcockroach%2Fcommits%2Fabcd123%29%3A%0A%0A%0A%60%60%60%0ASomething+went+wrong%0A%60%60%60%0A%3Cp%3EParameters%3A+%3Ccode%3EGOFLAGS%3Drace%3C%2Fcode%3E%0A%2C+%3Ccode%3EROACHTEST_cloud%3Dgce%3C%2Fcode%3E%0A%2C+%3Ccode%3ETAGS%3Ddeadlock%3C%2Fcode%3E%0A%3C%2Fp%3E%0A%3Cdetails%3E%3Csummary%3EHelp%3C%2Fsummary%3E%0A%3Cp%3E%0A%0ASee+also%3A+%5BHow+To+Investigate+a+Go+Test+Failure+%5C%28internal%5C%29%5D%28https%3A%2F%2Fcockroachlabs.atlassian.net%2Fl%2Fc%2FHgfXfJgM%29%0A%3C%2Fp%3E%0A%3C%2Fdetails%3E%0A%3Csub%3E%0A%0A%5BThis+test+on+roachdash%5D%28https%3A%2F%2Froachdash.crdb.dev%2F%3Ffilter%3Dstatus%3Aopen%2520t%3A.%2ATestCDC.%2A%26sort%3Dtitle%2Bcreated%26display%3Dlastcommented%2Bproject%29+%7C+%5BImprove+this+report%21%5D%28https%3A%2F%2Fgithub.com%2Fcockroachdb%2Fcockroach%2Ftree%2Fmaster%2Fpkg%2Fcmd%2Finternal%2Fissues%29%0A%3C%2Fsub%3E%0A&title=%3Ccomment%3E
+----
+----

--- a/pkg/cmd/internal/issues/testdata/post/infrastructure-flake-no-issue.txt
+++ b/pkg/cmd/internal/issues/testdata/post/infrastructure-flake-no-issue.txt
@@ -1,0 +1,38 @@
+post
+----
+----
+searchIssue repo:"cockroach" user:"cockroachdb" is:issue is:open in:title label:"O-robot" sort:created-desc "roachtest: TestCDC failed" label:branch-release-0.1 -label:X-noreuse: []
+searchIssue repo:"cockroach" user:"cockroachdb" is:issue is:open in:title label:"O-robot" sort:created-desc "roachtest: TestCDC failed" -label:branch-release-0.1: []
+getLatestTag: result v3.3.0
+listMilestones owner=cockroachdb repo=cockroach: result [github.Milestone{Number:2, Title:"3.3"} github.Milestone{Number:1, Title:"3.2"}]
+createIssue owner=cockroachdb repo=cockroach:
+github.IssueRequest{Labels:["O-robot" "branch-release-0.1" "release-blocker"], Milestone:2}
+
+roachtest: TestCDC failed
+
+roachtest.TestCDC [failed](https://teamcity.example.com/buildConfiguration/nightly123/8008135?buildTab=log) on release-0.1 @ [abcd123](https://github.com/cockroachdb/cockroach/commits/abcd123):
+
+
+```
+Something went wrong
+```
+<p>Parameters: <code>GOFLAGS=race</code>
+, <code>ROACHTEST_cloud=gce</code>
+, <code>TAGS=deadlock</code>
+</p>
+<details><summary>Help</summary>
+<p>
+
+See also: [How To Investigate a Go Test Failure \(internal\)](https://cockroachlabs.atlassian.net/l/c/HgfXfJgM)
+</p>
+</details>
+/cc @cockroachdb/idonotexistbecausethisisatest
+<sub>
+
+[This test on roachdash](https://roachdash.crdb.dev/?filter=status:open%20t:.*TestCDC.*&sort=title+created&display=lastcommented+project) | [Improve this report!](https://github.com/cockroachdb/cockroach/tree/master/pkg/cmd/internal/issues)
+</sub>
+
+
+Rendered: https://github.com/cockroachdb/cockroach/issues/new?body=roachtest.TestCDC+%5Bfailed%5D%28https%3A%2F%2Fteamcity.example.com%2FbuildConfiguration%2Fnightly123%2F8008135%3FbuildTab%3Dlog%29+on+release-0.1+%40+%5Babcd123%5D%28https%3A%2F%2Fgithub.com%2Fcockroachdb%2Fcockroach%2Fcommits%2Fabcd123%29%3A%0A%0A%0A%60%60%60%0ASomething+went+wrong%0A%60%60%60%0A%3Cp%3EParameters%3A+%3Ccode%3EGOFLAGS%3Drace%3C%2Fcode%3E%0A%2C+%3Ccode%3EROACHTEST_cloud%3Dgce%3C%2Fcode%3E%0A%2C+%3Ccode%3ETAGS%3Ddeadlock%3C%2Fcode%3E%0A%3C%2Fp%3E%0A%3Cdetails%3E%3Csummary%3EHelp%3C%2Fsummary%3E%0A%3Cp%3E%0A%0ASee+also%3A+%5BHow+To+Investigate+a+Go+Test+Failure+%5C%28internal%5C%29%5D%28https%3A%2F%2Fcockroachlabs.atlassian.net%2Fl%2Fc%2FHgfXfJgM%29%0A%3C%2Fp%3E%0A%3C%2Fdetails%3E%0A%2Fcc+%40cockroachdb%2Fidonotexistbecausethisisatest%0A%3Csub%3E%0A%0A%5BThis+test+on+roachdash%5D%28https%3A%2F%2Froachdash.crdb.dev%2F%3Ffilter%3Dstatus%3Aopen%2520t%3A.%2ATestCDC.%2A%26sort%3Dtitle%2Bcreated%26display%3Dlastcommented%2Bproject%29+%7C+%5BImprove+this+report%21%5D%28https%3A%2F%2Fgithub.com%2Fcockroachdb%2Fcockroach%2Ftree%2Fmaster%2Fpkg%2Fcmd%2Finternal%2Fissues%29%0A%3C%2Fsub%3E%0A&title=roachtest%3A+TestCDC+failed
+----
+----

--- a/pkg/cmd/internal/issues/testdata/post/infrastructure-flake-related-issue.txt
+++ b/pkg/cmd/internal/issues/testdata/post/infrastructure-flake-related-issue.txt
@@ -1,0 +1,44 @@
+post
+----
+----
+searchIssue repo:"cockroach" user:"cockroachdb" is:issue is:open in:title label:"O-robot" sort:created-desc "roachtest: TestCDC failed" label:branch-release-0.1 -label:X-noreuse: []
+searchIssue repo:"cockroach" user:"cockroachdb" is:issue is:open in:title label:"O-robot" sort:created-desc "roachtest: TestCDC failed" -label:branch-release-0.1: [github.Issue{Number:41, Title:"roachtest: TestCDC-similar failed [failure reason]", Labels:[github.Label{URL:"fake", Name:"C-test-failure"} github.Label{URL:"fake", Name:"O-robot"} github.Label{URL:"fake", Name:"release-0.2"}]} github.Issue{Number:40, Title:"roachtest: TestCDC failed [failure reason]", Labels:[github.Label{URL:"fake", Name:"C-test-failure"} github.Label{URL:"fake", Name:"O-robot"} github.Label{URL:"fake", Name:"release-0.2"}]}]
+getLatestTag: result v3.3.0
+listMilestones owner=cockroachdb repo=cockroach: result [github.Milestone{Number:2, Title:"3.3"} github.Milestone{Number:1, Title:"3.2"}]
+createIssue owner=cockroachdb repo=cockroach:
+github.IssueRequest{Labels:["O-robot" "branch-release-0.1" "release-blocker"], Milestone:2}
+
+roachtest: TestCDC failed
+
+roachtest.TestCDC [failed](https://teamcity.example.com/buildConfiguration/nightly123/8008135?buildTab=log) on release-0.1 @ [abcd123](https://github.com/cockroachdb/cockroach/commits/abcd123):
+
+
+```
+Something went wrong
+```
+<p>Parameters: <code>GOFLAGS=race</code>
+, <code>ROACHTEST_cloud=gce</code>
+, <code>TAGS=deadlock</code>
+</p>
+<details><summary>Help</summary>
+<p>
+
+See also: [How To Investigate a Go Test Failure \(internal\)](https://cockroachlabs.atlassian.net/l/c/HgfXfJgM)
+</p>
+</details>
+<details><summary>Same failure on other branches</summary>
+<p>
+
+- #40 roachtest: TestCDC failed [failure reason] [C-test-failure O-robot release-0.2]
+</p>
+</details>
+/cc @cockroachdb/idonotexistbecausethisisatest
+<sub>
+
+[This test on roachdash](https://roachdash.crdb.dev/?filter=status:open%20t:.*TestCDC.*&sort=title+created&display=lastcommented+project) | [Improve this report!](https://github.com/cockroachdb/cockroach/tree/master/pkg/cmd/internal/issues)
+</sub>
+
+
+Rendered: https://github.com/cockroachdb/cockroach/issues/new?body=roachtest.TestCDC+%5Bfailed%5D%28https%3A%2F%2Fteamcity.example.com%2FbuildConfiguration%2Fnightly123%2F8008135%3FbuildTab%3Dlog%29+on+release-0.1+%40+%5Babcd123%5D%28https%3A%2F%2Fgithub.com%2Fcockroachdb%2Fcockroach%2Fcommits%2Fabcd123%29%3A%0A%0A%0A%60%60%60%0ASomething+went+wrong%0A%60%60%60%0A%3Cp%3EParameters%3A+%3Ccode%3EGOFLAGS%3Drace%3C%2Fcode%3E%0A%2C+%3Ccode%3EROACHTEST_cloud%3Dgce%3C%2Fcode%3E%0A%2C+%3Ccode%3ETAGS%3Ddeadlock%3C%2Fcode%3E%0A%3C%2Fp%3E%0A%3Cdetails%3E%3Csummary%3EHelp%3C%2Fsummary%3E%0A%3Cp%3E%0A%0ASee+also%3A+%5BHow+To+Investigate+a+Go+Test+Failure+%5C%28internal%5C%29%5D%28https%3A%2F%2Fcockroachlabs.atlassian.net%2Fl%2Fc%2FHgfXfJgM%29%0A%3C%2Fp%3E%0A%3C%2Fdetails%3E%0A%3Cdetails%3E%3Csummary%3ESame+failure+on+other+branches%3C%2Fsummary%3E%0A%3Cp%3E%0A%0A-+%2340+roachtest%3A+TestCDC+failed+%5Bfailure+reason%5D+%5BC-test-failure+O-robot+release-0.2%5D%0A%3C%2Fp%3E%0A%3C%2Fdetails%3E%0A%2Fcc+%40cockroachdb%2Fidonotexistbecausethisisatest%0A%3Csub%3E%0A%0A%5BThis+test+on+roachdash%5D%28https%3A%2F%2Froachdash.crdb.dev%2F%3Ffilter%3Dstatus%3Aopen%2520t%3A.%2ATestCDC.%2A%26sort%3Dtitle%2Bcreated%26display%3Dlastcommented%2Bproject%29+%7C+%5BImprove+this+report%21%5D%28https%3A%2F%2Fgithub.com%2Fcockroachdb%2Fcockroach%2Ftree%2Fmaster%2Fpkg%2Fcmd%2Finternal%2Fissues%29%0A%3C%2Fsub%3E%0A&title=roachtest%3A+TestCDC+failed
+----
+----

--- a/pkg/cmd/roachtest/github.go
+++ b/pkg/cmd/roachtest/github.go
@@ -137,16 +137,19 @@ func (g *githubIssues) createPostRequest(
 	issueClusterName := ""
 
 	messagePrefix := ""
+	var infraFlake bool
 	// Overrides to shield eng teams from potential flakes
 	switch {
 	case failureContainsError(firstFailure, errClusterProvisioningFailed):
 		issueOwner = registry.OwnerDevInf
 		issueName = "cluster_creation"
 		messagePrefix = fmt.Sprintf("test %s was skipped due to ", testName)
+		infraFlake = true
 	case failureContainsError(firstFailure, rperrors.ErrSSH255):
 		issueOwner = registry.OwnerTestEng
 		issueName = "ssh_problem"
 		messagePrefix = fmt.Sprintf("test %s failed due to ", testName)
+		infraFlake = true
 	case failureContainsError(firstFailure, errDuringPostAssertions):
 		messagePrefix = fmt.Sprintf("test %s failed during post test assertions (see test-post-assertions.log) due to ", testName)
 	}
@@ -154,7 +157,7 @@ func (g *githubIssues) createPostRequest(
 	// Issues posted from roachtest are identifiable as such, and they are also release blockers
 	// (this label may be removed by a human upon closer investigation).
 	labels := []string{"O-roachtest"}
-	if !spec.NonReleaseBlocker {
+	if !spec.NonReleaseBlocker && !infraFlake {
 		labels = append(labels, "release-blocker")
 	}
 

--- a/pkg/cmd/roachtest/github.go
+++ b/pkg/cmd/roachtest/github.go
@@ -210,15 +210,16 @@ func (g *githubIssues) createPostRequest(
 	}
 
 	return issues.PostRequest{
-		MentionOnCreate: mention,
-		ProjectColumnID: projColID,
-		PackageName:     "roachtest",
-		TestName:        issueName,
-		Message:         messagePrefix + message,
-		Artifacts:       artifacts,
-		ExtraLabels:     labels,
-		ExtraParams:     clusterParams,
-		HelpCommand:     generateHelpCommand(issueClusterName, start, end),
+		MentionOnCreate:      mention,
+		ProjectColumnID:      projColID,
+		PackageName:          "roachtest",
+		TestName:             issueName,
+		Message:              messagePrefix + message,
+		SkipLabelTestFailure: infraFlake, // infra-flakes are not marked as C-test-failure
+		Artifacts:            artifacts,
+		ExtraLabels:          labels,
+		ExtraParams:          clusterParams,
+		HelpCommand:          generateHelpCommand(issueClusterName, start, end),
 	}, nil
 }
 

--- a/pkg/cmd/roachtest/github_test.go
+++ b/pkg/cmd/roachtest/github_test.go
@@ -122,17 +122,18 @@ func TestCreatePostRequest(t *testing.T) {
 	}
 
 	testCases := []struct {
-		nonReleaseBlocker      bool
-		clusterCreationFailed  bool
-		loadTeamsFailed        bool
-		localSSD               bool
-		arch                   vm.CPUArch
-		failure                failure
-		expectedPost           bool
-		expectedReleaseBlocker bool
-		expectedParams         map[string]string
+		nonReleaseBlocker       bool
+		clusterCreationFailed   bool
+		loadTeamsFailed         bool
+		localSSD                bool
+		arch                    vm.CPUArch
+		failure                 failure
+		expectedPost            bool
+		expectedReleaseBlocker  bool
+		expectedSkipTestFailure bool
+		expectedParams          map[string]string
 	}{
-		{true, false, false, false, "", createFailure(errors.New("other")), true, false,
+		{true, false, false, false, "", createFailure(errors.New("other")), true, false, false,
 			prefixAll(map[string]string{
 				"cloud":     "gce",
 				"encrypted": "false",
@@ -143,7 +144,7 @@ func TestCreatePostRequest(t *testing.T) {
 				"localSSD":  "false",
 			}),
 		},
-		{true, false, false, true, vm.ArchARM64, createFailure(errClusterProvisioningFailed), true, false,
+		{true, false, false, true, vm.ArchARM64, createFailure(errClusterProvisioningFailed), true, false, true,
 			prefixAll(map[string]string{
 				"cloud":     "gce",
 				"encrypted": "false",
@@ -158,7 +159,7 @@ func TestCreatePostRequest(t *testing.T) {
 		// !nonReleaseBlocker and issue is an SSH flake. Also ensure that
 		// in the event of a failed cluster creation, nil `vmOptions` and
 		// `clusterImpl` are not dereferenced
-		{false, true, false, false, "", createFailure(rperrors.ErrSSH255), true, false,
+		{false, true, false, false, "", createFailure(rperrors.ErrSSH255), true, false, true,
 			prefixAll(map[string]string{
 				"cloud": "gce",
 				"ssd":   "0",
@@ -166,9 +167,9 @@ func TestCreatePostRequest(t *testing.T) {
 			}),
 		},
 		//Simulate failure loading TEAMS.yaml
-		{true, false, true, false, "", createFailure(errors.New("other")), false, false, nil},
+		{true, false, true, false, "", createFailure(errors.New("other")), false, false, false, nil},
 		//Error during post test assertions
-		{true, false, false, false, "", createFailure(errDuringPostAssertions), false, false, nil},
+		{true, false, false, false, "", createFailure(errDuringPostAssertions), false, false, false, nil},
 	}
 
 	reg := makeTestRegistry(spec.GCE, "", "", false, false)
@@ -233,6 +234,7 @@ func TestCreatePostRequest(t *testing.T) {
 
 				require.True(t, contains(req.ExtraLabels, nil, "O-roachtest"))
 				require.Equal(t, c.expectedReleaseBlocker, contains(req.ExtraLabels, nil, "release-blocker"))
+				require.Equal(t, c.expectedSkipTestFailure, req.SkipLabelTestFailure)
 
 				expectedTeam := "@cockroachdb/unowned"
 				expectedName := "github_test"

--- a/pkg/cmd/roachtest/github_test.go
+++ b/pkg/cmd/roachtest/github_test.go
@@ -158,9 +158,7 @@ func TestCreatePostRequest(t *testing.T) {
 		// !nonReleaseBlocker and issue is an SSH flake. Also ensure that
 		// in the event of a failed cluster creation, nil `vmOptions` and
 		// `clusterImpl` are not dereferenced
-		// expectedReleaseBlocker is true on this branch due to a backport, which doesn't include
-		// a change to exclude infra flakes from being labeled as release blockers.
-		{false, true, false, false, "", createFailure(rperrors.ErrSSH255), true, true,
+		{false, true, false, false, "", createFailure(rperrors.ErrSSH255), true, false,
 			prefixAll(map[string]string{
 				"cloud": "gce",
 				"ssd":   "0",


### PR DESCRIPTION
Epic: none

Release note: None

Backport:
  * 1/1 commits from "roachtest: SSH errors and cluster creation failure not release blockers" (#101754)
  * 1/1 commits from "internal/issues: allow creation of issues not marked as C-test-failure" (#108644)
  * 1/1 commits from "build: update aws-cli" (#108744)

Please see individual PRs for details.

/cc @cockroachdb/release

Release justification: test-only changes.
