### PR TITLE
roachtest: Cast snapshot-recd bytes to int in disagg-rebalance

### DIFF
--- a/pkg/cmd/roachtest/tests/disagg_rebalance.go
+++ b/pkg/cmd/roachtest/tests/disagg_rebalance.go
@@ -114,7 +114,7 @@ func registerDisaggRebalance(r registry.Registry) {
 			}
 			var bytesSnapshotted int64
 			if err := db.QueryRow(
-				"SELECT metrics['range.snapshots.rcvd-bytes'] FROM crdb_internal.kv_store_status WHERE node_id = $1 LIMIT 1",
+				"SELECT metrics['range.snapshots.rcvd-bytes']::INT FROM crdb_internal.kv_store_status WHERE node_id = $1 LIMIT 1",
 				4,
 			).Scan(&bytesSnapshotted); err != nil {
 				t.Fatal(err)


### PR DESCRIPTION
Previously we were reading a float value as an int, which would trip up the Scan() method if the float value was large enough to be wired over in scientified notation eg. `2.3456E7`. This change ensures that Cockroach prints out the value as an integer to avoid the scan-time error in the roachtest.

Fixes #109114.

Epic: none

Release note: None