### PR TITLE
sql: make the SQL stats namespace customizable

### DIFF
--- a/pkg/ccl/serverccl/testdata/api_v2_sql
+++ b/pkg/ccl/serverccl/testdata/api_v2_sql
@@ -10,6 +10,7 @@ sql admin
  "num_statements": 1,
  "request": {
   "application_name": "$ api-v2-sql",
+  "auto_obs_db": false,
   "database": "system",
   "execute": false,
   "max_result_size": 10000,

--- a/pkg/clusterversion/cockroach_versions.go
+++ b/pkg/clusterversion/cockroach_versions.go
@@ -315,7 +315,7 @@ const (
 	V23_1BackfillTypeColumnInJobsTable
 
 	// V23_1_AlterSystemStatementStatisticsAddIndexesUsage creates indexes usage virtual column
-	// based on (statistics->>'indexes') with inverted index on table system.statement_statistics.
+	// based on (statistics->>'indexes') with inverted index on table statement_statistics.
 	V23_1_AlterSystemStatementStatisticsAddIndexesUsage
 
 	// V23_1EnsurePebbleFormatSSTableValueBlocks upgrades the Pebble format major

--- a/pkg/server/api_v2_sql.go
+++ b/pkg/server/api_v2_sql.go
@@ -207,6 +207,7 @@ func (a *apiV2Server) execSQL(w http.ResponseWriter, r *http.Request) {
 		Execute         bool   `json:"execute"`
 		SeparateTxns    bool   `json:"separate_txns"`
 		StopOnError     bool   `json:"stop_on_error"`
+		AutoObsDB       bool   `json:"auto_obs_db"`
 		Statements      []struct {
 			SQL       string                               `json:"sql"`
 			stmt      statements.Statement[tree.Statement] `json:"-"`
@@ -466,6 +467,8 @@ func (a *apiV2Server) execSQL(w http.ResponseWriter, r *http.Request) {
 							User:            username,
 							Database:        requestPayload.Database,
 							ApplicationName: requestPayload.ApplicationName,
+
+							AutoSelectObservabilityDatabase: requestPayload.AutoObsDB,
 						},
 						stmt.SQL, stmt.Arguments...)
 					if err != nil {

--- a/pkg/server/drain_test.go
+++ b/pkg/server/drain_test.go
@@ -144,6 +144,8 @@ INSERT INTO t.test VALUES (3);
 		"expected to find in-memory stats",
 	)
 
+	sqlDB.Exec(t, "SET database = crdb_internal.current_observability_database()")
+
 	// Sanity check: verify that the statement statistics system table is empty.
 	sqlDB.CheckQueryResults(t,
 		`SELECT count(*) FROM system.statement_statistics WHERE node_id = 1`,

--- a/pkg/server/testdata/api_v2_sql
+++ b/pkg/server/testdata/api_v2_sql
@@ -8,6 +8,7 @@ sql admin
  "num_statements": 1,
  "request": {
   "application_name": "$ api-v2-sql",
+  "auto_obs_db": false,
   "database": "system",
   "execute": false,
   "max_result_size": 10000,
@@ -904,4 +905,40 @@ sql admin
   ]
  },
  "num_statements": 4
+}
+
+# Test the automatic selection of an o11y database.
+sql admin
+{
+  "database": "defaultdb",
+  "auto_obs_db": true,
+  "execute": true,
+  "statements": [{"sql": "SELECT current_database()"}]
+}
+----
+{
+ "execution": {
+  "txn_results": [
+   {
+    "columns": [
+     {
+      "name": "current_database",
+      "oid": 25,
+      "type": "STRING"
+     }
+    ],
+    "end": "1970-01-01T00:00:00Z",
+    "rows": [
+     {
+      "current_database": "system"
+     }
+    ],
+    "rows_affected": 0,
+    "start": "1970-01-01T00:00:00Z",
+    "statement": 1,
+    "tag": "SELECT"
+   }
+  ]
+ },
+ "num_statements": 1
 }

--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -26,6 +26,7 @@ go_library(
         "apply_join.go",
         "audit_logging.go",
         "authorization.go",
+        "auto_obs_db.go",
         "backfill.go",
         "buffer.go",
         "buffer_util.go",

--- a/pkg/sql/auto_obs_db.go
+++ b/pkg/sql/auto_obs_db.go
@@ -1,0 +1,44 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sql
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/catconstants"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+)
+
+// CurrentObservabilityDatabase implements the eval.SessionAccessor interface.
+func (p *planner) CurrentObservabilityDatabase(ctx context.Context) (string, error) {
+	// TODO(knz): put more intelligent logic in here.
+	return catconstants.SystemDatabaseName, nil
+}
+
+// maybeSelectObservabilityDB, if the caller has requested so, auto-selects
+// the Database session field based on the current location of the session db.
+func (ie *InternalExecutor) maybeSelectObservabilityDB(
+	ctx context.Context,
+	opName string,
+	txn *kv.Txn,
+	sessionDataOverride sessiondata.InternalExecutorOverride,
+	sd *sessiondata.SessionData,
+) error {
+	if !sessionDataOverride.AutoSelectObservabilityDatabase {
+		return nil
+	}
+
+	// TODO(knz): put more intelligent logic in here.
+	sd.Database = catconstants.SystemDatabaseName
+
+	return nil
+}

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -1696,7 +1696,7 @@ var legacyAnonymizedStmt = tree.NewDString("")
 
 var crdbInternalNodeStmtStatsTable = virtualSchemaTable{
 	comment: `statement statistics. ` +
-		`The contents of this table are flushed to the system.statement_statistics table at the interval set by the ` +
+		`The contents of this table are flushed to the statement_statistics table at the interval set by the ` +
 		`cluster setting sql.stats.flush.interval (by default, 10m).`,
 	schema: `
 CREATE TABLE crdb_internal.node_statement_statistics (
@@ -1954,7 +1954,7 @@ CREATE TABLE crdb_internal.node_statement_statistics (
 // StmtFingerprintID and TxnKey. Issue #55284
 var crdbInternalTransactionStatisticsTable = virtualSchemaTable{
 	comment: `finer-grained transaction statistics. ` +
-		`The contents of this table are flushed to the system.transaction_statistics table at the interval set by the ` +
+		`The contents of this table are flushed to the transaction_statistics table at the interval set by the ` +
 		`cluster setting sql.stats.flush.interval (by default, 10m).`,
 	schema: `
 CREATE TABLE crdb_internal.node_transaction_statistics (
@@ -6959,7 +6959,7 @@ CREATE VIEW crdb_internal.statement_statistics_persisted AS
 }
 
 // crdb_internal.statement_activity view to give permission to non-admins
-// to access the system.statement_activity table
+// to access the statement_activity table
 var crdbInternalStmtActivityView = virtualSchemaView{
 	schema: `
 CREATE VIEW crdb_internal.statement_activity AS
@@ -7005,7 +7005,7 @@ CREATE VIEW crdb_internal.statement_activity AS
 }
 
 // crdb_internal.transaction_activity is a view to give permission to non-admins
-// to access the system.transaction_activity table
+// to access the transaction_activity table
 var crdbInternalTxnActivityView = virtualSchemaView{
 	schema: `
 CREATE VIEW crdb_internal.transaction_activity AS

--- a/pkg/sql/faketreeeval/evalctx.go
+++ b/pkg/sql/faketreeeval/evalctx.go
@@ -387,6 +387,13 @@ func (ep *DummyEvalPlanner) ResolveTableName(
 	return 0, errors.WithStack(errEvalPlanner)
 }
 
+// CurrentObservabilityDatabase is part of the eval.SessionAccessor interface.
+func (ep *DummyEvalPlanner) CurrentObservabilityDatabase(
+	ctx context.Context, tn *tree.TableName,
+) (string, error) {
+	return "", errors.WithStack(errEvalPlanner)
+}
+
 // GetTypeFromValidSQLSyntax is part of the eval.Planner interface.
 func (ep *DummyEvalPlanner) GetTypeFromValidSQLSyntax(sql string) (*types.T, error) {
 	return nil, errors.WithStack(errEvalPlanner)
@@ -586,6 +593,11 @@ func (ep *DummySessionAccessor) HasViewActivityOrViewActivityRedactedRole(
 	context.Context,
 ) (bool, error) {
 	return false, errors.WithStack(errEvalSessionVar)
+}
+
+// currentObservabilityDatabase is part of the eval.SessionAccessor interface.
+func (so *DummySessionAccessor) CurrentObservabilityDatabase(ctx context.Context) (string, error) {
+	return "", errors.WithStack(errEvalSessionVar)
 }
 
 // DummyClientNoticeSender implements the eval.ClientNoticeSender interface.

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -978,6 +978,9 @@ func (ie *InternalExecutor) execInternal(
 
 	applyInternalExecutorSessionExceptions(sd)
 	applyOverrides(sessionDataOverride, sd)
+	if err := ie.maybeSelectObservabilityDB(ctx, opName, txn, sessionDataOverride, sd); err != nil {
+		return nil, err
+	}
 	sd.Internal = true
 	if sd.User().Undefined() {
 		return nil, errors.AssertionFailedf("no user specified for internal query")

--- a/pkg/sql/logictest/testdata/logic_test/workload_indexrecs
+++ b/pkg/sql/logictest/testdata/logic_test/workload_indexrecs
@@ -5,12 +5,15 @@ INSERT INTO system.users VALUES  ('node', NULL, true, 3);
 GRANT NODE TO root;
 
 statement ok
-CREATE TABLE t1 (k INT, i INT, f FLOAT, s STRING)
+SET database = crdb_internal.current_observability_database()
+
+statement ok
+CREATE TABLE test.t1 (k INT, i INT, f FLOAT, s STRING)
 
 
 # Basic tests for creation
 statement ok
-INSERT INTO system.statement_statistics (
+INSERT INTO statement_statistics (
   index_recommendations,
   aggregated_ts,
   fingerprint_id,
@@ -53,10 +56,10 @@ CREATE INDEX ON t1 (k);
 
 # Basic tests for replacement
 statement ok
-CREATE INDEX t1_i ON t1(i);
+CREATE INDEX t1_i ON test.t1(i);
 
 statement ok
-INSERT INTO system.statement_statistics (
+INSERT INTO statement_statistics (
   index_recommendations,
   aggregated_ts,
   fingerprint_id,
@@ -102,7 +105,7 @@ CREATE INDEX ON t1 (k);
 
 # Basic tests for alteration to show it is skipped
 statement ok
-INSERT INTO system.statement_statistics (
+INSERT INTO statement_statistics (
   index_recommendations,
   aggregated_ts,
   fingerprint_id,
@@ -148,7 +151,7 @@ CREATE INDEX ON t1 (k);
 
 # Test for the new index "t1(k, i)" covering the previous one "t1(k)"
 statement ok
-INSERT INTO system.statement_statistics (
+INSERT INTO statement_statistics (
   index_recommendations,
   aggregated_ts,
   fingerprint_id,
@@ -194,7 +197,7 @@ CREATE INDEX ON t1 (k, i);
 
 # Test for the storing part "t1(i) storing (k)" covered by one index "t1(i, k)"
 statement ok
-INSERT INTO system.statement_statistics (
+INSERT INTO statement_statistics (
   index_recommendations,
   aggregated_ts,
   fingerprint_id,
@@ -241,7 +244,7 @@ CREATE INDEX ON t1 (k, i);
 
 # Test for duplicate DROP INDEX t1_i
 statement ok
-INSERT INTO system.statement_statistics (
+INSERT INTO statement_statistics (
   index_recommendations,
   aggregated_ts,
   fingerprint_id,
@@ -288,12 +291,12 @@ DROP INDEX t1_i;
 
 
 statement ok
-CREATE TABLE t2 (k INT, i INT, f FLOAT, s STRING)
+CREATE TABLE test.t2 (k INT, i INT, f FLOAT, s STRING)
 
 
 # Test for multi-table (t1, t2)
 statement ok
-INSERT INTO system.statement_statistics (
+INSERT INTO statement_statistics (
   index_recommendations,
   aggregated_ts,
   fingerprint_id,
@@ -344,12 +347,12 @@ DROP INDEX t1_i;
 
 
 statement ok
-CREATE TABLE t3 (k INT, i INT, f FLOAT, s STRING)
+CREATE TABLE test.t3 (k INT, i INT, f FLOAT, s STRING)
 
 
 # Test for multi-table (t1, t2, t3)
 statement ok
-INSERT INTO system.statement_statistics (
+INSERT INTO statement_statistics (
   index_recommendations,
   aggregated_ts,
   fingerprint_id,

--- a/pkg/sql/opt/exec/execbuilder/testdata/sql_activity_stats_compaction
+++ b/pkg/sql/opt/exec/execbuilder/testdata/sql_activity_stats_compaction
@@ -1,7 +1,7 @@
 # LogicTest: local
 
-# Ensure we can run DELETE statement on system.statement_statistics and
-# system.transaction_statistics table.
+# Ensure we can run DELETE statement on statement_statistics and
+# transaction_statistics table.
 statement ok
 INSERT INTO system.users VALUES ('node', NULL, true, 3);
 
@@ -16,11 +16,14 @@ let $current_agg_ts
 SELECT concat('''', date_trunc('hour', '2022-05-04 16:10'::TIMESTAMPTZ)::STRING, '''::TIMESTAMPTZ')
 
 statement ok
-DELETE FROM system.table_statistics WHERE true;
+SET database = crdb_internal.current_observability_database()
+
+statement ok
+DELETE FROM table_statistics WHERE true;
 
 
 statement ok
-ALTER TABLE system.statement_statistics INJECT STATISTICS '[
+ALTER TABLE statement_statistics INJECT STATISTICS '[
     {
         "columns": [
             "aggregated_ts"
@@ -218,7 +221,7 @@ ALTER TABLE system.statement_statistics INJECT STATISTICS '[
 
 query T
 EXPLAIN (VERBOSE)
-DELETE FROM system.statement_statistics
+DELETE FROM statement_statistics
 WHERE crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8 = 0
   AND aggregated_ts < $current_agg_ts
 ORDER BY aggregated_ts ASC
@@ -266,7 +269,7 @@ vectorized: true
                   limit: 1024
 
 statement ok
-ALTER TABLE system.transaction_statistics INJECT STATISTICS '[
+ALTER TABLE transaction_statistics INJECT STATISTICS '[
     {
         "columns": [
             "aggregated_ts"
@@ -405,7 +408,7 @@ ALTER TABLE system.transaction_statistics INJECT STATISTICS '[
 
 query T
 EXPLAIN (VERBOSE)
-DELETE FROM system.transaction_statistics
+DELETE FROM transaction_statistics
   WHERE crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8 = 0
     AND aggregated_ts < $current_agg_ts
   ORDER BY aggregated_ts ASC
@@ -451,7 +454,7 @@ vectorized: true
 
 query T
 EXPLAIN (VERBOSE)
-DELETE FROM system.statement_statistics
+DELETE FROM statement_statistics
 WHERE crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8 = 0
 AND (
   (
@@ -510,7 +513,7 @@ vectorized: true
 
 query T
 EXPLAIN (VERBOSE)
-DELETE FROM system.transaction_statistics
+DELETE FROM transaction_statistics
       WHERE crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8 = 0
       AND (
         (

--- a/pkg/sql/opt/exec/execbuilder/testdata/sql_statistics_persisted
+++ b/pkg/sql/opt/exec/execbuilder/testdata/sql_statistics_persisted
@@ -1,7 +1,7 @@
 # LogicTest: local
 
-# Ensure we can run ALTER statements on the system.statement_statistics and
-# system.transaction_statistics tables.
+# Ensure we can run ALTER statements on the statement_statistics and
+# transaction_statistics tables.
 statement ok
 INSERT INTO system.users VALUES ('node', NULL, true, 3);
 
@@ -9,7 +9,11 @@ statement ok
 GRANT node TO root;
 
 statement ok
-ALTER TABLE system.statement_statistics INJECT STATISTICS '[
+SET database = crdb_internal.current_observability_database()
+
+
+statement ok
+ALTER TABLE statement_statistics INJECT STATISTICS '[
     {
         "columns": [
             "aggregated_ts"
@@ -365,7 +369,7 @@ SELECT * FROM ((SELECT
   p99_latency,
   metadata,
   statistics
-FROM system.statement_statistics
+FROM statement_statistics
 WHERE app_name NOT LIKE '$ internal%' AND aggregated_ts > ('2023-03-21 15:05'::TIMESTAMPTZ - INTERVAL '1 hour')
 ORDER BY execution_count DESC LIMIT 500)
 UNION (SELECT
@@ -381,7 +385,7 @@ UNION (SELECT
   p99_latency,
   metadata,
   statistics
-FROM system.statement_statistics
+FROM statement_statistics
 WHERE app_name NOT LIKE '$ internal%' AND aggregated_ts > ('2023-03-21 15:05'::TIMESTAMPTZ - INTERVAL '1 hour')
 ORDER BY service_latency DESC LIMIT 500)
 UNION (SELECT
@@ -397,7 +401,7 @@ UNION (SELECT
   p99_latency,
   metadata,
   statistics
-FROM system.statement_statistics
+FROM statement_statistics
 WHERE app_name NOT LIKE '$ internal%' AND aggregated_ts > ('2023-03-21 15:05'::TIMESTAMPTZ - INTERVAL '1 hour')
 ORDER BY cpu_sql_nanos DESC LIMIT 500)
 UNION (SELECT
@@ -413,7 +417,7 @@ UNION (SELECT
   p99_latency,
   metadata,
   statistics
-FROM system.statement_statistics
+FROM statement_statistics
 WHERE app_name NOT LIKE '$ internal%' AND aggregated_ts > ('2023-03-21 15:05'::TIMESTAMPTZ - INTERVAL '1 hour')
 ORDER BY contention_time DESC LIMIT 500)
 UNION (SELECT
@@ -429,7 +433,7 @@ UNION (SELECT
   p99_latency,
   metadata,
   statistics
-FROM system.statement_statistics
+FROM statement_statistics
 WHERE app_name NOT LIKE '$ internal%' AND aggregated_ts > ('2023-03-21 15:05'::TIMESTAMPTZ - INTERVAL '1 hour')
 ORDER BY total_estimated_execution_time DESC LIMIT 500)
  UNION (SELECT
@@ -445,7 +449,7 @@ ORDER BY total_estimated_execution_time DESC LIMIT 500)
   p99_latency,
   metadata,
   statistics
-FROM system.statement_statistics
+FROM statement_statistics
 WHERE app_name NOT LIKE '$ internal%' AND aggregated_ts > ('2023-03-21 15:05'::TIMESTAMPTZ - INTERVAL '1 hour')
 ORDER BY p99_latency DESC LIMIT 500))
 ----
@@ -823,7 +827,7 @@ vectorized: true
               spans: /2023-03-21T14:05:00.000001Z-
 
 statement ok
-ALTER TABLE system.transaction_statistics INJECT STATISTICS '[
+ALTER TABLE transaction_statistics INJECT STATISTICS '[
     {
         "columns": [
             "aggregated_ts"
@@ -1100,7 +1104,7 @@ SELECT * FROM ((SELECT
   p99_latency,
   metadata,
   statistics
-FROM system.transaction_statistics
+FROM transaction_statistics
 WHERE app_name NOT LIKE '$ internal%' AND aggregated_ts > ('2023-03-21 15:05'::TIMESTAMPTZ - INTERVAL '1 hour')
 ORDER BY execution_count DESC LIMIT 500)
 UNION (SELECT
@@ -1115,7 +1119,7 @@ UNION (SELECT
   p99_latency,
   metadata,
   statistics
-FROM system.transaction_statistics
+FROM transaction_statistics
 WHERE app_name NOT LIKE '$ internal%' AND aggregated_ts > ('2023-03-21 15:05'::TIMESTAMPTZ - INTERVAL '1 hour')
 ORDER BY service_latency DESC LIMIT 500)
 UNION (SELECT
@@ -1130,7 +1134,7 @@ UNION (SELECT
   p99_latency,
   metadata,
   statistics
-FROM system.transaction_statistics
+FROM transaction_statistics
 WHERE app_name NOT LIKE '$ internal%' AND aggregated_ts > ('2023-03-21 15:05'::TIMESTAMPTZ - INTERVAL '1 hour')
 ORDER BY cpu_sql_nanos DESC LIMIT 500)
 UNION (SELECT
@@ -1145,7 +1149,7 @@ UNION (SELECT
   p99_latency,
   metadata,
   statistics
-FROM system.transaction_statistics
+FROM transaction_statistics
 WHERE app_name NOT LIKE '$ internal%' AND aggregated_ts > ('2023-03-21 15:05'::TIMESTAMPTZ - INTERVAL '1 hour')
 ORDER BY contention_time DESC LIMIT 500)
 UNION (SELECT
@@ -1160,7 +1164,7 @@ UNION (SELECT
   p99_latency,
   metadata,
   statistics
-FROM system.transaction_statistics
+FROM transaction_statistics
 WHERE app_name NOT LIKE '$ internal%' AND aggregated_ts > ('2023-03-21 15:05'::TIMESTAMPTZ- INTERVAL '1 hour')
 ORDER BY total_estimated_execution_time DESC LIMIT 500)
 UNION (SELECT
@@ -1175,7 +1179,7 @@ UNION (SELECT
   p99_latency,
   metadata,
   statistics
-FROM system.transaction_statistics
+FROM transaction_statistics
 WHERE app_name NOT LIKE '$ internal%' AND aggregated_ts > ('2023-03-21 15:05'::TIMESTAMPTZ- INTERVAL '1 hour')
 ORDER BY p99_latency DESC LIMIT 500))
 ----

--- a/pkg/sql/opt/workloadindexrec/workload_indexrecs.go
+++ b/pkg/sql/opt/workloadindexrec/workload_indexrecs.go
@@ -64,15 +64,15 @@ func FindWorkloadRecs(
 }
 
 // collectIndexRecs collects all the index recommendations stored in the
-// system.statement_statistics with the time later than ts.
+// statement_statistics with the time later than ts.
 func collectIndexRecs(
 	ctx context.Context, evalCtx *eval.Context, ts *tree.DTimestampTZ,
 ) ([]tree.CreateIndex, []tree.DropIndex, error) {
-	query := `SELECT index_recommendations FROM system.statement_statistics
+	query := `SELECT index_recommendations FROM statement_statistics
 						 WHERE (statistics -> 'statistics' ->> 'lastExecAt')::TIMESTAMPTZ > $1
 						 AND array_length(index_recommendations, 1) > 0;`
 	indexRecs, err := evalCtx.Planner.QueryIteratorEx(ctx, "get-candidates-for-workload-indexrecs",
-		sessiondata.NoSessionDataOverride, query, ts.Time)
+		sessiondata.ObservabilitySessionDataOverride, query, ts.Time)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -7183,6 +7183,27 @@ table's zone configuration this will return NULL.`,
 			Volatility: volatility.Volatile,
 		},
 	),
+
+	"crdb_internal.current_observability_database": makeBuiltin(
+		tree.FunctionProperties{
+			Category:         builtinconstants.CategorySystemInfo,
+			DistsqlBlocklist: true, // applicable only on the gateway
+		},
+		tree.Overload{
+			Types:      tree.ParamTypes{},
+			ReturnType: tree.FixedReturnType(types.String),
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				db, err := evalCtx.SessionAccessor.CurrentObservabilityDatabase(ctx)
+				if err != nil {
+					return nil, err
+				}
+				return tree.NewDString(db), nil
+			},
+			Info:       `This function returns the current database for observability tables.`,
+			Volatility: volatility.Volatile,
+		},
+	),
+
 	// Deletes the underlying spans backing a table, only
 	// if the user provides explicit acknowledgement of the
 	// form "I acknowledge this will irrevocably delete all revisions

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -2452,6 +2452,7 @@ var builtinOidsArray = []string{
 	2481: `bitmask_xor(a: string, b: string) -> varbit`,
 	2482: `bitmask_xor(a: varbit, b: string) -> varbit`,
 	2483: `bitmask_xor(a: string, b: varbit) -> varbit`,
+	2484: `crdb_internal.current_observability_database() -> string`,
 }
 
 var builtinOidsBySignature map[string]oid.Oid

--- a/pkg/sql/sem/eval/deps.go
+++ b/pkg/sql/sem/eval/deps.go
@@ -486,6 +486,9 @@ type SessionAccessor interface {
 	// HasViewActivityOrViewActivityRedactedRole returns true iff the current session user has the
 	// VIEWACTIVITY or VIEWACTIVITYREDACTED permission.
 	HasViewActivityOrViewActivityRedactedRole(ctx context.Context) (bool, error)
+
+	// CurrentObservabilityDatabase returns the name of the currently active obs database.
+	CurrentObservabilityDatabase(ctx context.Context) (string, error)
 }
 
 // PreparedStatementState is a limited interface that exposes metadata about

--- a/pkg/sql/sessiondata/internal.go
+++ b/pkg/sql/sessiondata/internal.go
@@ -47,6 +47,11 @@ type InternalExecutorOverride struct {
 	// does **not** propagate further to "nested" executors that are spawned up
 	// by the "top" executor.
 	InjectRetryErrorsEnabled bool
+	// AutoSelectObservabilityDatabase, if true, automatically sets
+	// the Database session field to the currently active observability database.
+	// This will select between 'system.' and a yet-to-be defined
+	// observability database automatically.
+	AutoSelectObservabilityDatabase bool
 }
 
 // NoSessionDataOverride is the empty InternalExecutorOverride which does not
@@ -63,4 +68,12 @@ var NodeUserSessionDataOverride = InternalExecutorOverride{
 // the user to the RootUser.
 var RootUserSessionDataOverride = InternalExecutorOverride{
 	User: username.MakeSQLUsernameFromPreNormalizedString(username.RootUser),
+}
+
+// ObservabilitySessionDataOverride is an InternalExecutorOverride which
+// overrides the database to the observability database and accesses
+// the data using the NodeUser.
+var ObservabilitySessionDataOverride = InternalExecutorOverride{
+	User:                            username.MakeSQLUsernameFromPreNormalizedString(username.NodeUser),
+	AutoSelectObservabilityDatabase: true,
 }

--- a/pkg/sql/sql_activity_update_job_test.go
+++ b/pkg/sql/sql_activity_update_job_test.go
@@ -63,36 +63,37 @@ func TestSqlActivityUpdateJob(t *testing.T) {
 	defer sqlDB.Close()
 
 	db := sqlutils.MakeSQLRunner(sqlDB)
+	db.Exec(t, "SET database = crdb_internal.current_observability_database()")
 
 	var count int
-	row := db.QueryRow(t, "SELECT count_rows() FROM system.public.transaction_activity")
+	row := db.QueryRow(t, "SELECT count_rows() FROM transaction_activity")
 	row.Scan(&count)
-	require.Equal(t, 0, count, "system.transaction_activity: expect:0, actual:%d", count)
+	require.Equal(t, 0, count, "transaction_activity: expect:0, actual:%d", count)
 
-	row = db.QueryRow(t, "SELECT count_rows() FROM system.public.statement_activity")
+	row = db.QueryRow(t, "SELECT count_rows() FROM statement_activity")
 	row.Scan(&count)
-	require.Equal(t, 0, count, "system.statement_activity: expect:0, actual:%d", count)
+	require.Equal(t, 0, count, "statement_activity: expect:0, actual:%d", count)
 
 	row = db.QueryRow(t,
 		"SELECT count_rows() FROM system.public.jobs WHERE job_type = 'AUTO UPDATE SQL ACTIVITY' and id = 103")
 	row.Scan(&count)
 	require.Equal(t, 0, count, "jobs: expect:0, actual:%d", count)
 
-	row = db.QueryRow(t, "SELECT count_rows() FROM system.public.transaction_statistics")
+	row = db.QueryRow(t, "SELECT count_rows() FROM transaction_statistics")
 	row.Scan(&count)
-	require.Equal(t, 0, count, "system.transaction_statistics: expect:0, actual:%d", count)
+	require.Equal(t, 0, count, "transaction_statistics: expect:0, actual:%d", count)
 
-	row = db.QueryRow(t, "SELECT count_rows() FROM system.public.statement_statistics")
+	row = db.QueryRow(t, "SELECT count_rows() FROM statement_statistics")
 	row.Scan(&count)
-	require.Equal(t, 0, count, "system.statement_statistics: expect:0, actual:%d", count)
+	require.Equal(t, 0, count, "statement_statistics: expect:0, actual:%d", count)
 
 	row = db.QueryRow(t, "SELECT count_rows() FROM crdb_internal.transaction_activity")
 	row.Scan(&count)
-	require.Equal(t, 0, count, "crdb_internal.transaction_activity: expect:0, actual:%d", count)
+	require.Equal(t, 0, count, "transaction_activity: expect:0, actual:%d", count)
 
 	row = db.QueryRow(t, "SELECT count_rows() FROM crdb_internal.statement_activity")
 	row.Scan(&count)
-	require.Equal(t, 0, count, "crdb_internal.statement_activity: expect:0, actual:%d", count)
+	require.Equal(t, 0, count, "statement_activity: expect:0, actual:%d", count)
 
 	execCfg := srv.ExecutorConfig().(ExecutorConfig)
 	st := cluster.MakeTestingClusterSettings()
@@ -100,13 +101,13 @@ func TestSqlActivityUpdateJob(t *testing.T) {
 
 	require.NoError(t, updater.TransferStatsToActivity(ctx))
 
-	row = db.QueryRow(t, "SELECT count_rows() FROM system.public.transaction_activity")
+	row = db.QueryRow(t, "SELECT count_rows() FROM transaction_activity")
 	row.Scan(&count)
-	require.Equal(t, 0, count, "system.transaction_activity: expect:0, actual:%d", count)
+	require.Equal(t, 0, count, "transaction_activity: expect:0, actual:%d", count)
 
-	row = db.QueryRow(t, "SELECT count_rows() FROM system.public.statement_activity")
+	row = db.QueryRow(t, "SELECT count_rows() FROM statement_activity")
 	row.Scan(&count)
-	require.Equal(t, 0, count, "system.statement_activity: expect:0, actual:%d", count)
+	require.Equal(t, 0, count, "statement_activity: expect:0, actual:%d", count)
 
 	appName := "TestSqlActivityUpdateJob"
 	db.Exec(t, "SET SESSION application_name=$1", appName)
@@ -121,13 +122,13 @@ func TestSqlActivityUpdateJob(t *testing.T) {
 	// being a few rows.
 	require.NoError(t, updater.TransferStatsToActivity(ctx))
 
-	row = db.QueryRow(t, "SELECT count_rows() FROM system.public.transaction_activity WHERE app_name = $1", appName)
+	row = db.QueryRow(t, "SELECT count_rows() FROM transaction_activity WHERE app_name = $1", appName)
 	row.Scan(&count)
-	require.Equal(t, count, 1, "system.transaction_activity after transfer: expect:1, actual:%d", count)
+	require.Equal(t, count, 1, "transaction_activity after transfer: expect:1, actual:%d", count)
 
-	row = db.QueryRow(t, "SELECT count_rows() FROM system.public.statement_activity WHERE app_name = $1", appName)
+	row = db.QueryRow(t, "SELECT count_rows() FROM statement_activity WHERE app_name = $1", appName)
 	row.Scan(&count)
-	require.Equal(t, count, 1, "system.statement_activity after transfer: expect:1, actual:%d", count)
+	require.Equal(t, count, 1, "statement_activity after transfer: expect:1, actual:%d", count)
 
 	row = db.QueryRow(t, "SELECT count_rows() FROM crdb_internal.transaction_activity WHERE app_name = $1", appName)
 	row.Scan(&count)
@@ -140,13 +141,13 @@ func TestSqlActivityUpdateJob(t *testing.T) {
 	// Reset the stats and verify all sql stats tables are empty.
 	db.Exec(t, "SELECT crdb_internal.reset_sql_stats()")
 
-	row = db.QueryRow(t, "SELECT count_rows() FROM system.public.transaction_activity")
+	row = db.QueryRow(t, "SELECT count_rows() FROM transaction_activity")
 	row.Scan(&count)
-	require.Zero(t, count, "system.transaction_activity after transfer: expect:0, actual:%d", count)
+	require.Zero(t, count, "transaction_activity after transfer: expect:0, actual:%d", count)
 
-	row = db.QueryRow(t, "SELECT count_rows() FROM system.public.statement_activity")
+	row = db.QueryRow(t, "SELECT count_rows() FROM statement_activity")
 	row.Scan(&count)
-	require.Zero(t, count, "system.statement_activity after transfer: expect:0, actual:%d", count)
+	require.Zero(t, count, "statement_activity after transfer: expect:0, actual:%d", count)
 
 	row = db.QueryRow(t, "SELECT count_rows() FROM crdb_internal.transaction_activity")
 	row.Scan(&count)
@@ -180,16 +181,17 @@ func TestSqlActivityUpdateTopLimitJob(t *testing.T) {
 	defer sqlDB.Close()
 
 	db := sqlutils.MakeSQLRunner(sqlDB)
+	db.Exec(t, "SET database = crdb_internal.current_observability_database()")
 
 	// Give permission to write to sys tables.
 	db.Exec(t, "INSERT INTO system.users VALUES ('node', NULL, true, 3)")
 	db.Exec(t, "GRANT node TO root")
 
 	// Make sure all the tables are empty initially.
-	db.Exec(t, "DELETE FROM system.public.transaction_activity")
-	db.Exec(t, "DELETE FROM system.public.statement_activity")
-	db.Exec(t, "DELETE FROM system.public.transaction_statistics")
-	db.Exec(t, "DELETE FROM system.public.statement_statistics")
+	db.Exec(t, "DELETE FROM transaction_activity")
+	db.Exec(t, "DELETE FROM statement_activity")
+	db.Exec(t, "DELETE FROM transaction_statistics")
+	db.Exec(t, "DELETE FROM statement_statistics")
 
 	execCfg := srv.ExecutorConfig().(ExecutorConfig)
 	st := cluster.MakeTestingClusterSettings()
@@ -239,7 +241,7 @@ func TestSqlActivityUpdateTopLimitJob(t *testing.T) {
 		// Execution count.
 		for j := 0; j < topLimit; j++ {
 			updateStatsCount++
-			db.Exec(t, `UPDATE system.public.statement_statistics
+			db.Exec(t, `UPDATE statement_statistics
 			SET statistics =  jsonb_set(jsonb_set(statistics, '{execution_statistics, cnt}', to_jsonb($1::INT)),
 			    '{statistics, svcLat, mean}', to_jsonb($2::FLOAT))
 			    WHERE app_name = $3;`, 10000+updateStatsCount, 0.0000001, getAppName(updateStatsCount))
@@ -248,7 +250,7 @@ func TestSqlActivityUpdateTopLimitJob(t *testing.T) {
 		// Service latency time.
 		for j := 0; j < topLimit; j++ {
 			updateStatsCount++
-			db.Exec(t, `UPDATE system.public.statement_statistics
+			db.Exec(t, `UPDATE statement_statistics
 			SET statistics =  jsonb_set(jsonb_set(statistics, '{execution_statistics, cnt}', to_jsonb($1::INT)),
 			    '{statistics, svcLat, mean}', to_jsonb($2::FLOAT))
 			    WHERE app_name = $3;`, 1, 1000+updateStatsCount, getAppName(updateStatsCount))
@@ -258,7 +260,7 @@ func TestSqlActivityUpdateTopLimitJob(t *testing.T) {
 		// and service latency, but greater when multiplied together.
 		for j := 0; j < topLimit; j++ {
 			updateStatsCount++
-			db.Exec(t, `UPDATE system.public.statement_statistics
+			db.Exec(t, `UPDATE statement_statistics
 			SET statistics =  jsonb_set(jsonb_set(statistics, '{execution_statistics, cnt}', to_jsonb($1::INT)),
 			    '{statistics, svcLat, mean}', to_jsonb($2::FLOAT))
 			    WHERE app_name = $3;`, 500+updateStatsCount, 500+updateStatsCount, getAppName(updateStatsCount))
@@ -269,7 +271,7 @@ func TestSqlActivityUpdateTopLimitJob(t *testing.T) {
 		for _, updateField := range columnsToChangeValues {
 			for j := 0; j < topLimit; j++ {
 				updateStatsCount++
-				db.Exec(t, `UPDATE system.public.statement_statistics
+				db.Exec(t, `UPDATE statement_statistics
 			SET statistics =  jsonb_set(statistics, $1, to_jsonb($2::INT)) 
 			WHERE app_name = $3;`, updateField, 10000+updateStatsCount, getAppName(updateStatsCount))
 			}
@@ -283,17 +285,17 @@ func TestSqlActivityUpdateTopLimitJob(t *testing.T) {
 
 		maxRows := topLimit * 6 // Number of top columns to select from.
 		row := db.QueryRow(t,
-			`SELECT count_rows() FROM system.public.transaction_activity WHERE app_name LIKE 'TestSqlActivityUpdateJobLoop%'`)
+			`SELECT count_rows() FROM transaction_activity WHERE app_name LIKE 'TestSqlActivityUpdateJobLoop%'`)
 		var count int
 		row.Scan(&count)
 		require.LessOrEqual(t, count, maxRows, "transaction_activity after transfer: actual:%d, max:%d", count, maxRows)
 
 		row = db.QueryRow(t,
-			`SELECT count_rows() FROM system.public.statement_activity WHERE app_name LIKE 'TestSqlActivityUpdateJobLoop%'`)
+			`SELECT count_rows() FROM statement_activity WHERE app_name LIKE 'TestSqlActivityUpdateJobLoop%'`)
 		row.Scan(&count)
 		require.LessOrEqual(t, count, maxRows, "statement_activity after transfer: actual:%d, max:%d", count, maxRows)
 
-		row = db.QueryRow(t, `SELECT count_rows() FROM system.public.transaction_activity`)
+		row = db.QueryRow(t, `SELECT count_rows() FROM transaction_activity`)
 		row.Scan(&count)
 		require.LessOrEqual(t, count, maxRows, "transaction_activity after transfer: actual:%d, max:%d", count, maxRows)
 	}
@@ -317,7 +319,10 @@ func TestSqlActivityJobRunsAfterStatsFlush(t *testing.T) {
 	defer srv.Stopper().Stop(context.Background())
 	defer db.Close()
 
-	_, err := db.ExecContext(ctx, "SET CLUSTER SETTING sql.stats.flush.interval = '100ms'")
+	_, err := db.ExecContext(ctx, "SET database = crdb_internal.current_observability_database()")
+	require.NoError(t, err)
+
+	_, err = db.ExecContext(ctx, "SET CLUSTER SETTING sql.stats.flush.interval = '100ms'")
 	require.NoError(t, err)
 	appName := "TestScheduledSQLStatsCompaction"
 	_, err = db.ExecContext(ctx, "SET SESSION application_name=$1", appName)
@@ -328,7 +333,7 @@ func TestSqlActivityJobRunsAfterStatsFlush(t *testing.T) {
 		require.NoError(t, err)
 
 		row := db.QueryRowContext(ctx, "SELECT count_rows() "+
-			"FROM system.public.transaction_activity WHERE app_name = $1", appName)
+			"FROM transaction_activity WHERE app_name = $1", appName)
 		var count int
 		err = row.Scan(&count)
 		if err != nil {
@@ -339,7 +344,7 @@ func TestSqlActivityJobRunsAfterStatsFlush(t *testing.T) {
 		}
 
 		row = db.QueryRowContext(ctx, "SELECT count_rows() "+
-			"FROM system.public.statement_activity WHERE app_name = $1", appName)
+			"FROM statement_activity WHERE app_name = $1", appName)
 		err = row.Scan(&count)
 		if err != nil {
 			return err
@@ -352,7 +357,7 @@ func TestSqlActivityJobRunsAfterStatsFlush(t *testing.T) {
 	}, 1*time.Minute)
 }
 
-// TestTransactionActivityMetadata verifies the metadata JSON column of system.transaction_activity are
+// TestTransactionActivityMetadata verifies the metadata JSON column of transaction_activity are
 // what we expect it to be. This test was added to address #103618.
 func TestTransactionActivityMetadata(t *testing.T) {
 	defer leaktest.AfterTest(t)()
@@ -395,7 +400,7 @@ func TestTransactionActivityMetadata(t *testing.T) {
 	}
 
 	require.NoError(t, updater.TransferStatsToActivity(ctx))
-	db.QueryRow(t, "SELECT metadata FROM system.public.transaction_activity LIMIT 1").Scan(&metadataJSON)
+	db.QueryRow(t, "SELECT metadata FROM transaction_activity LIMIT 1").Scan(&metadataJSON)
 	require.NoError(t, json.Unmarshal([]byte(metadataJSON), &metadata))
 	require.NotEmpty(t, metadata.StmtFingerprintIDs)
 
@@ -408,7 +413,7 @@ func TestTransactionActivityMetadata(t *testing.T) {
 	require.NoError(t, updater.transferTopStats(ctx, stubTime, 100, 100, 100))
 
 	// Ensure that the metadata column contains the populated 'stmtFingerprintIDs' field.
-	db.QueryRow(t, "SELECT metadata FROM system.public.transaction_activity LIMIT 1").Scan(&metadataJSON)
+	db.QueryRow(t, "SELECT metadata FROM transaction_activity LIMIT 1").Scan(&metadataJSON)
 	require.NoError(t, json.Unmarshal([]byte(metadataJSON), &metadata))
 	require.NotEmpty(t, metadata.StmtFingerprintIDs)
 }
@@ -446,6 +451,8 @@ func TestActivityStatusCombineAPI(t *testing.T) {
 	updater := newSqlActivityUpdater(st, execCfg.InternalDB, sqlStatsKnobs)
 
 	db := sqlutils.MakeSQLRunner(sqlDB)
+	db.Exec(t, "SET database = crdb_internal.current_observability_database()")
+
 	// Generate a random app name each time to avoid conflicts
 	appName := "test_status_api" + uuid.FastMakeV4().String()
 	db.Exec(t, "SET SESSION application_name = $1", appName)
@@ -466,7 +473,7 @@ func TestActivityStatusCombineAPI(t *testing.T) {
 	}
 
 	require.NoError(t, updater.TransferStatsToActivity(ctx))
-	db.QueryRow(t, "SELECT metadata FROM system.public.transaction_activity LIMIT 1").Scan(&metadataJSON)
+	db.QueryRow(t, "SELECT metadata FROM transaction_activity LIMIT 1").Scan(&metadataJSON)
 	require.NoError(t, json.Unmarshal([]byte(metadataJSON), &metadata))
 	require.NotEmpty(t, metadata.StmtFingerprintIDs)
 
@@ -489,8 +496,8 @@ func TestActivityStatusCombineAPI(t *testing.T) {
 	// Grant permission and change the activity table info
 	db.Exec(t, "INSERT INTO system.users VALUES ('node', NULL, true, 3)")
 	db.Exec(t, "GRANT node TO root")
-	db.Exec(t, "UPDATE system.public.statement_activity SET app_name = 'randomapp' where app_name = $1;", appName)
-	db.Exec(t, "UPDATE system.public.transaction_activity SET app_name = 'randomapp' where app_name = $1;", appName)
+	db.Exec(t, "UPDATE statement_activity SET app_name = 'randomapp' where app_name = $1;", appName)
+	db.Exec(t, "UPDATE transaction_activity SET app_name = 'randomapp' where app_name = $1;", appName)
 
 	if err := getStatusJSONProto(s, "combinedstmts", &resp, start, end); err != nil {
 		t.Fatal(err)

--- a/pkg/sql/sqlstats/persistedsqlstats/cluster_settings.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/cluster_settings.go
@@ -79,7 +79,7 @@ var SQLStatsFlushJitter = settings.RegisterFloatSetting(
 )
 
 // SQLStatsMaxPersistedRows specifies maximum number of rows that will be
-// retained in system.statement_statistics and system.transaction_statistics.
+// retained in statement_statistics and transaction_statistics.
 var SQLStatsMaxPersistedRows = settings.RegisterIntSetting(
 	settings.TenantWritable,
 	"sql.stats.persisted_rows.max",

--- a/pkg/sql/sqlstats/persistedsqlstats/compaction_scheduling.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/compaction_scheduling.go
@@ -106,7 +106,7 @@ func checkExistingCompactionSchedule(ctx context.Context, txn isql.Txn) (exists 
 	query := "SELECT count(*) FROM system.scheduled_jobs WHERE schedule_name = $1"
 
 	row, err := txn.QueryRowEx(ctx, "check-existing-sql-stats-schedule", txn.KV(),
-		sessiondata.NodeUserSessionDataOverride,
+		sessiondata.ObservabilitySessionDataOverride,
 		query, compactionScheduleName,
 	)
 

--- a/pkg/sql/sqlstats/persistedsqlstats/controller.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/controller.go
@@ -62,11 +62,11 @@ func (s *Controller) ResetClusterSQLStats(ctx context.Context) error {
 		return err
 	}
 
-	if err := s.resetSysTableStats(ctx, "system.statement_statistics"); err != nil {
+	if err := s.resetSysTableStats(ctx, "statement_statistics"); err != nil {
 		return err
 	}
 
-	if err := s.resetSysTableStats(ctx, "system.transaction_statistics"); err != nil {
+	if err := s.resetSysTableStats(ctx, "transaction_statistics"); err != nil {
 		return err
 	}
 
@@ -80,11 +80,11 @@ func (s *Controller) ResetActivityTables(ctx context.Context) error {
 		return nil
 	}
 
-	if err := s.resetSysTableStats(ctx, "system.statement_activity"); err != nil {
+	if err := s.resetSysTableStats(ctx, "statement_activity"); err != nil {
 		return err
 	}
 
-	return s.resetSysTableStats(ctx, "system.transaction_activity")
+	return s.resetSysTableStats(ctx, "transaction_activity")
 }
 
 func (s *Controller) resetSysTableStats(ctx context.Context, tableName string) (err error) {
@@ -93,7 +93,7 @@ func (s *Controller) resetSysTableStats(ctx context.Context, tableName string) (
 		ctx,
 		"reset-sql-stats",
 		nil, /* txn */
-		sessiondata.NodeUserSessionDataOverride,
+		sessiondata.ObservabilitySessionDataOverride,
 		"TRUNCATE "+tableName)
 	return err
 }

--- a/pkg/sql/sqlstats/persistedsqlstats/reader_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/reader_test.go
@@ -286,13 +286,15 @@ func verifyInMemoryStmtFingerprints(
 func verifyDiskStmtFingerprints(
 	t *testing.T, sqlRunner *sqlutils.SQLRunner, expectedStmtsNoConst map[string]int64,
 ) {
+	defer useObsDB(t, sqlRunner)()
+
 	require.NotEmpty(t, expectedStmtsNoConst)
 	expectedStmtsNoConstCopy := make(map[string]int64, len(expectedStmtsNoConst))
 	stmtQuery := `SELECT ss.metadata->>'query' as query,
        ss.statistics->'statistics'->>'cnt' as count,
        ts.execution_count
-FROM system.statement_statistics ss
-    LEFT JOIN system.transaction_statistics ts ON ss.transaction_fingerprint_id = ts.fingerprint_id
+FROM statement_statistics ss
+    LEFT JOIN transaction_statistics ts ON ss.transaction_fingerprint_id = ts.fingerprint_id
 WHERE ss.metadata->>'query' in ( `
 
 	for fingerprint, cnt := range expectedStmtsNoConst {

--- a/pkg/sql/sqlstats/persistedsqlstats/scheduled_job_monitor.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/scheduled_job_monitor.go
@@ -134,7 +134,7 @@ func (j *jobMonitor) getSchedule(
 		ctx,
 		"load-sql-stats-scheduled-job",
 		txn.KV(),
-		sessiondata.NodeUserSessionDataOverride,
+		sessiondata.ObservabilitySessionDataOverride,
 		"SELECT schedule_id FROM system.scheduled_jobs WHERE schedule_name = $1",
 		compactionScheduleName,
 	)

--- a/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_encoding.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_encoding.go
@@ -47,7 +47,7 @@ func ExplainTreePlanNodeToJSON(node *appstatspb.ExplainTreePlanNode) json.JSON {
 //
 //	{
 //	  "$schema": "https://json-schema.org/draft/2020-12/schema",
-//	  "title": "system.statement_statistics.metadata",
+//	  "title": "statement_statistics.metadata",
 //	  "type": "object",
 //	  "properties": {
 //	    "stmtType":             { "type": "string" },
@@ -71,7 +71,7 @@ func BuildStmtMetadataJSON(statistics *appstatspb.CollectedStatementStatistics) 
 //
 //		{
 //		  "$schema": "https://json-schema.org/draft/2020-12/schema",
-//		  "title": "system.statement_statistics.statistics",
+//		  "title": "statement_statistics.statistics",
 //		  "type": "object",
 //
 //		  "definitions": {
@@ -241,7 +241,7 @@ func BuildStmtStatisticsJSON(statistics *appstatspb.StatementStatistics) (json.J
 //
 //	{
 //	  "$schema": "https://json-schema.org/draft/2020-12/schema",
-//	  "title": "system.transaction_statistics.metadata",
+//	  "title": "transaction_statistics.metadata",
 //	  "type": "object",
 //	  "properties": {
 //	    "stmtFingerprintIDs": {
@@ -271,7 +271,7 @@ func BuildTxnMetadataJSON(
 //
 //	{
 //	  "$schema": "https://json-schema.org/draft/2020-12/schema",
-//	  "title": "system.statement_statistics.statistics",
+//	  "title": "statement_statistics.statistics",
 //	  "type": "object",
 //
 //	  "definitions": {
@@ -409,7 +409,7 @@ func BuildTxnStatisticsJSON(
 //
 //	{
 //	  "$schema": "https://json-schema.org/draft/2020-12/schema",
-//	  "title": "system.statement_statistics.aggregated_metadata",
+//	  "title": "statement_statistics.aggregated_metadata",
 //	  "type": "object",
 //
 //	  "properties": {

--- a/pkg/sql/sqlstats/persistedsqlstats/stmt_reader.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/stmt_reader.go
@@ -87,7 +87,7 @@ func (s *PersistedSQLStats) persistedStmtStatsIter(
 		ctx,
 		"read-stmt-stats",
 		nil, /* txn */
-		sessiondata.NodeUserSessionDataOverride,
+		sessiondata.ObservabilitySessionDataOverride,
 		query,
 	)
 
@@ -120,7 +120,7 @@ func (s *PersistedSQLStats) getFetchQueryForStmtStatsTable(
 SELECT 
   %[1]s
 FROM
-	system.statement_statistics
+	statement_statistics
 %[2]s`
 
 	followerReadClause := s.cfg.Knobs.GetAOSTClause()

--- a/pkg/sql/sqlstats/persistedsqlstats/txn_reader.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/txn_reader.go
@@ -86,7 +86,7 @@ func (s *PersistedSQLStats) persistedTxnStatsIter(
 		ctx,
 		"read-txn-stats",
 		nil, /* txn */
-		sessiondata.NodeUserSessionDataOverride,
+		sessiondata.ObservabilitySessionDataOverride,
 		query,
 	); err != nil {
 		return nil /* iter */, 0 /* expectedColCnt */, err
@@ -113,7 +113,7 @@ func (s *PersistedSQLStats) getFetchQueryForTxnStatsTable(
 SELECT 
   %[1]s
 FROM
-	system.transaction_statistics
+	transaction_statistics
 %[2]s`
 
 	followerReadClause := s.cfg.Knobs.GetAOSTClause()

--- a/pkg/sql/sqlstats/sslocal/cluster_settings.go
+++ b/pkg/sql/sqlstats/sslocal/cluster_settings.go
@@ -16,7 +16,7 @@ import "github.com/cockroachdb/cockroach/pkg/settings"
 // per-statment statistics by transaction fingerprint. While enabled by
 // default, it may be useful to disable for workloads that run the same
 // statements across many (ad-hoc) transaction fingerprints, producing
-// higher-cardinality data in the system.statement_statistics table than
+// higher-cardinality data in the statement_statistics table than
 // the cleanup job is able to keep up with. See #78338.
 var AssociateStmtWithTxnFingerprint = settings.RegisterBoolSetting(
 	settings.TenantWritable,


### PR DESCRIPTION
Informs #109125.

Prior to this patch, the prefix `system.` for all the persisted SQL stats was "baked" into the SQL queries used by the stats subsystem.

In a later stage, we will want to define a new obs DB and also an auto-migration to move the obs tables from `system` into the new DB.

In order for that later stage to be successful, it is important to remove the hardcoding of `system.` in the queries.

This patch achieves this as follows:

- It introduces a new internal executor override flag `AutoSelectObservabilityDatabase`, which automatically selects the "current database" session var in the executed query depending on context.

- It introduces a new built-in function `crdb_internal.current_observability_database()` for use in tests.

- It removes the `system.` prefix from the various SQL queries that access observability tables, replacing them with implicit access using one of the two facilities introduced above.

  There are two exceptions:

  - the view definitions in `crdb_internal`.
  - the scraping performed by `debug zip`.

  These will be convered at a later stage.

- It introduces a new query flag `auto_obs_db` for the SQL-over-HTTP
  endpoint, for use by the front-end apps (if/when relevant).

  (At the time of this writing, there is no access to system.XXX
  observability tables over HTTP, so this mechanism is nice-to-have.)

(This patch should also be backported.)

Release note: None