### PR TITLE
release-23.1: roachprod: roachtest: refactoring

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -94,7 +94,6 @@ require (
 	github.com/andy-kimball/arenaskl v0.0.0-20200617143215-f701008588b9
 	github.com/andygrunwald/go-jira v1.14.0
 	github.com/apache/arrow/go/arrow v0.0.0-20200923215132-ac86123a3f01
-	github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.18.2
 	github.com/axiomhq/hyperloglog v0.0.0-20181223111420-4b99d0c2c99e
 	github.com/bazelbuild/rules_go v0.26.0

--- a/go.sum
+++ b/go.sum
@@ -287,7 +287,6 @@ github.com/apache/thrift v0.15.0/go.mod h1:PHK3hniurgQaNMZYaCLEqXKsYK8upmhPbmdP2
 github.com/apache/thrift v0.16.0 h1:qEy6UW60iVOlUy+b9ZR0d5WzUWYGOo4HfopoyBaNmoY=
 github.com/apache/thrift v0.16.0/go.mod h1:PHK3hniurgQaNMZYaCLEqXKsYK8upmhPbmdP2FXSqgU=
 github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de/go.mod h1:DCaWoUhZrYW9p1lxo/cm8EmUOOzAPSEZNGF2DK1dJgw=
-github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e h1:QEF07wC0T1rKkctt1RINW/+RMTVmiwxETico2l3gxJA=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=

--- a/pkg/cmd/roachtest/BUILD.bazel
+++ b/pkg/cmd/roachtest/BUILD.bazel
@@ -46,7 +46,6 @@ go_library(
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "//pkg/util/version",
-        "@com_github_armon_circbuf//:circbuf",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_logtags//:logtags",
         "@com_github_lib_pq//:pq",

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -32,7 +32,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/armon/circbuf"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil"
@@ -432,161 +431,6 @@ func initBinariesAndLibraries() {
 		if len(paths) > 0 {
 			fmt.Printf("\tlibraries %q at: %s\n", arch, strings.Join(paths, ", "))
 		}
-	}
-}
-
-// execCmd is like execCmdEx, but doesn't return the command's output.
-func execCmd(
-	ctx context.Context, l *logger.Logger, clusterName string, secure bool, args ...string,
-) error {
-	return execCmdEx(ctx, l, clusterName, secure, args...).err
-}
-
-type cmdRes struct {
-	err error
-	// stdout and stderr are the commands output. Note that this is truncated and
-	// only a tail is returned.
-	stdout, stderr string
-}
-
-// execCmdEx runs a command and returns its error and output.
-//
-// Note that the output is truncated; only a tail is returned.
-// Also note that if the command exits with an error code, its output is also
-// included in cmdRes.err.
-func execCmdEx(
-	ctx context.Context, l *logger.Logger, clusterName string, secure bool, args ...string,
-) cmdRes {
-	var cancel func()
-	ctx, cancel = context.WithCancel(ctx)
-	defer cancel()
-
-	l.Printf("> %s\n", strings.Join(args, " "))
-	var roachprodRunStdout, roachprodRunStderr io.Writer
-
-	debugStdoutBuffer, _ := circbuf.NewBuffer(4096)
-	debugStderrBuffer, _ := circbuf.NewBuffer(4096)
-
-	// Do a dance around https://github.com/golang/go/issues/23019.
-	// When the command we run launches a subprocess, that subprocess receives
-	// a copy of our Command's Stdout/Stderr file descriptor, which effectively
-	// means that the file descriptors close only when that subcommand returns.
-	// However, proactively killing the subcommand is not really possible - we
-	// will only manage to kill the parent process that we launched directly.
-	// In practice this means that if we try to react to context cancellation,
-	// the pipes we read the output from will wait for the *subprocess* to
-	// terminate, leaving us hanging, potentially indefinitely.
-	// To work around it, use pipes and set a read deadline on our (read) end of
-	// the pipes when we detect a context cancellation.
-	var closePipes func(ctx context.Context)
-	var wg sync.WaitGroup
-	{
-
-		var wOut, wErr, rOut, rErr *os.File
-		var cwOnce sync.Once
-		closePipes = func(ctx context.Context) {
-			// Idempotently closes the writing end of the pipes. This is called either
-			// when the process returns or when it was killed due to context
-			// cancellation. In the former case, close the writing ends of the pipe
-			// so that the copy goroutines started below return (without missing any
-			// output). In the context cancellation case, we set a deadline to force
-			// the goroutines to quit eagerly. This is important since the command
-			// may have duplicated wOut and wErr to its possible subprocesses, which
-			// may continue to run for long periods of time, and would otherwise
-			// block this command. In theory this is possible also when the command
-			// returns on its own accord, so we set a (more lenient) deadline in the
-			// first case as well.
-			//
-			// NB: there's also the option (at least on *nix) to use a process group,
-			// but it doesn't look portable:
-			// https://medium.com/@felixge/killing-a-child-process-and-all-of-its-children-in-go-54079af94773
-			cwOnce.Do(func() {
-				if wOut != nil {
-					_ = wOut.Close()
-				}
-				if wErr != nil {
-					_ = wErr.Close()
-				}
-				dur := 10 * time.Second // wait up to 10s for subprocesses
-				if ctx.Err() != nil {
-					dur = 10 * time.Millisecond
-				}
-				deadline := timeutil.Now().Add(dur)
-				if rOut != nil {
-					_ = rOut.SetReadDeadline(deadline)
-				}
-				if rErr != nil {
-					_ = rErr.SetReadDeadline(deadline)
-				}
-			})
-		}
-		defer closePipes(ctx)
-
-		var err error
-		rOut, wOut, err = os.Pipe()
-		if err != nil {
-			return cmdRes{err: err}
-		}
-
-		rErr, wErr, err = os.Pipe()
-		if err != nil {
-			return cmdRes{err: err}
-		}
-		roachprodRunStdout = wOut
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			_, _ = io.Copy(l.Stdout, io.TeeReader(rOut, debugStdoutBuffer))
-		}()
-
-		if l.Stderr == l.Stdout {
-			// If l.Stderr == l.Stdout, we use only one pipe to avoid
-			// duplicating everything.
-			roachprodRunStderr = wOut
-		} else {
-			roachprodRunStderr = wErr
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-				_, _ = io.Copy(l.Stderr, io.TeeReader(rErr, debugStderrBuffer))
-			}()
-		}
-	}
-
-	err := roachprod.Run(ctx, l, clusterName, "" /* SSHOptions */, "" /* processTag */, secure, roachprodRunStdout, roachprodRunStderr, args)
-	closePipes(ctx)
-	wg.Wait()
-
-	stdoutString := debugStdoutBuffer.String()
-	if debugStdoutBuffer.TotalWritten() > debugStdoutBuffer.Size() {
-		stdoutString = "<... some data truncated by circular buffer; go to artifacts for details ...>\n" + stdoutString
-	}
-	stderrString := debugStderrBuffer.String()
-	if debugStderrBuffer.TotalWritten() > debugStderrBuffer.Size() {
-		stderrString = "<... some data truncated by circular buffer; go to artifacts for details ...>\n" + stderrString
-	}
-
-	if err != nil {
-		// Context errors opaquely appear as "signal killed" when manifested.
-		// We surface this error explicitly.
-		if ctx.Err() != nil {
-			err = errors.CombineErrors(ctx.Err(), err)
-		}
-
-		if err != nil {
-			err = &cluster.WithCommandDetails{
-				Wrapped: err,
-				Cmd:     strings.Join(args, " "),
-				Stderr:  stderrString,
-				Stdout:  stdoutString,
-			}
-		}
-	}
-
-	return cmdRes{
-		err:    err,
-		stdout: stdoutString,
-		stderr: stderrString,
 	}
 }
 
@@ -2251,41 +2095,31 @@ func (c *clusterImpl) Run(ctx context.Context, node option.NodeListOption, args 
 // will be redirected to a file which is logged via the cluster-wide logger in
 // case of an error. Logs will sort chronologically. Failing invocations will
 // have an additional marker file with a `.failed` extension instead of `.log`.
-func (c *clusterImpl) RunE(ctx context.Context, node option.NodeListOption, args ...string) error {
+func (c *clusterImpl) RunE(ctx context.Context, nodes option.NodeListOption, args ...string) error {
 	if len(args) == 0 {
 		return errors.New("No command passed")
 	}
-	l, logFile, err := c.loggerForCmd(node, args...)
+	l, logFile, err := c.loggerForCmd(nodes, args...)
 	if err != nil {
 		return err
 	}
+	defer l.Close()
 
-	if err := errors.Wrap(ctx.Err(), "cluster.RunE"); err != nil {
-		return err
-	}
-	err = execCmd(ctx, l, c.MakeNodes(node), c.IsSecure(), args...)
-
-	l.Printf("> result: %+v", err)
-	if err := ctx.Err(); err != nil {
-		l.Printf("(note: incoming context was canceled: %s", err)
-	}
-	// We need to protect ourselves from a race where cluster logger is
-	// concurrently closed before child logger is created. In that case child
-	// logger will have no log file but would write to stderr instead and we can't
-	// create a meaningful ".failed" file for it.
-	physicalFileName := ""
-	if l.File != nil {
-		physicalFileName = l.File.Name()
-	}
-	l.Close()
-	if err != nil && len(physicalFileName) > 0 {
-		failedPhysicalFileName := strings.TrimSuffix(physicalFileName, ".log") + ".failed"
-		if failedFile, err2 := os.Create(failedPhysicalFileName); err2 != nil {
-			failedFile.Close()
+	cmd := strings.Join(args, " ")
+	c.t.L().Printf("running cmd `%s` on nodes [%v]; details in %s.log", roachprod.TruncateString(cmd, 30), nodes, logFile)
+	l.Printf("> %s", cmd)
+	if err := roachprod.Run(ctx, l, c.MakeNodes(nodes), "", "", c.IsSecure(), l.Stdout, l.Stderr, args); err != nil {
+		if err := ctx.Err(); err != nil {
+			l.Printf("(note: incoming context was canceled: %s)", err)
+			return err
 		}
+
+		l.Printf("> result: %s", err)
+		createFailedFile(l.File.Name())
+		return errors.Wrapf(err, "full command output in %s.log", logFile)
 	}
-	err = errors.Wrapf(err, "output in %s", logFile)
-	return err
+	l.Printf("> result: <ok>")
+	return nil
 }
 
 // RunWithDetailsSingleNode is just like RunWithDetails but used when 1) operating
@@ -2299,10 +2133,7 @@ func (c *clusterImpl) RunWithDetailsSingleNode(
 		return install.RunResultDetails{}, errors.Newf("RunWithDetailsSingleNode received %d nodes. Use RunWithDetails if you need to run on multiple nodes.", len(nodes))
 	}
 	results, err := c.RunWithDetails(ctx, testLogger, nodes, args...)
-	if err != nil {
-		return install.RunResultDetails{}, err
-	}
-	return results[0], results[0].Err
+	return results[0], errors.CombineErrors(err, results[0].Err)
 }
 
 // RunWithDetails runs a command on the specified nodes, returning the results
@@ -2315,49 +2146,55 @@ func (c *clusterImpl) RunWithDetails(
 	if len(args) == 0 {
 		return nil, errors.New("No command passed")
 	}
-	l, _, err := c.loggerForCmd(nodes, args...)
+	l, logFile, err := c.loggerForCmd(nodes, args...)
 	if err != nil {
 		return nil, err
 	}
-	physicalFileName := ""
-	if l.File != nil {
-		physicalFileName = l.File.Name()
+	defer l.Close()
+
+	cmd := strings.Join(args, " ")
+
+	// This could probably be removed in favour of c.t.L() but it's used extensively in roachtests.
+	if testLogger != nil {
+		testLogger.Printf("running cmd `%s` on nodes [%v]; details in %s.log", roachprod.TruncateString(cmd, 30), nodes, logFile)
 	}
 
-	if err := ctx.Err(); err != nil {
-		l.Printf("(note: incoming context was canceled: %s", err)
+	l.Printf("> %s", cmd)
+	results, err := roachprod.RunWithDetails(ctx, l, c.MakeNodes(nodes), "" /* SSHOptions */, "" /* processTag */, c.IsSecure(), args)
+
+	logFileFull := l.File.Name()
+	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			l.Printf("(note: incoming context was canceled: %s)", err)
+			return nil, ctxErr
+		}
+
+		l.Printf("> result: %s", err)
+		createFailedFile(logFileFull)
 		return nil, err
 	}
 
-	l.Printf("running %s on nodes: %v", strings.Join(args, " "), nodes)
-	if testLogger != nil {
-		testLogger.Printf("> %s\n", strings.Join(args, " "))
-	}
-
-	results, err := roachprod.RunWithDetails(ctx, l, c.MakeNodes(nodes), "" /* SSHOptions */, "" /* processTag */, false /* secure */, args)
-	if err != nil && len(physicalFileName) > 0 {
-		l.Printf("> result: %+v", err)
-		createFailedFile(physicalFileName)
-		return results, err
-	}
-
+	hasError := false
 	for _, result := range results {
 		if result.Err != nil {
-			err = result.Err
-			l.Printf("> Error for Node %d: %+v", int(result.Node), result.Err)
+			hasError = true
+			l.Printf("> result: Error for Node %d: %+v", int(result.Node), result.Err)
 		}
 	}
-	if err != nil {
-		createFailedFile(physicalFileName)
+	if hasError {
+		createFailedFile(logFileFull)
+	} else {
+		l.Printf("> result: <ok>")
 	}
-	l.Close()
 	return results, nil
 }
 
-func createFailedFile(logFileName string) {
-	failedPhysicalFileName := strings.TrimSuffix(logFileName, ".log") + ".failed"
-	if failedFile, err2 := os.Create(failedPhysicalFileName); err2 != nil {
-		failedFile.Close()
+func createFailedFile(logFile string) {
+	if logFile == "" {
+		return
+	}
+	if file, err := os.Create(strings.TrimSuffix(logFile, ".log") + ".failed"); err == nil {
+		file.Close()
 	}
 }
 
@@ -2446,7 +2283,7 @@ func (c *clusterImpl) ExternalPGUrl(
 	return c.pgURLErr(ctx, l, node, true, tenant)
 }
 
-func addrToAdminUIAddr(c *clusterImpl, addr string) (string, error) {
+func addrToAdminUIAddr(addr string) (string, error) {
 	host, port, err := net.SplitHostPort(addr)
 	if err != nil {
 		return "", err
@@ -2498,7 +2335,7 @@ func (c *clusterImpl) InternalAdminUIAddr(
 		return nil, err
 	}
 	for _, u := range urls {
-		adminUIAddr, err := addrToAdminUIAddr(c, u)
+		adminUIAddr, err := addrToAdminUIAddr(u)
 		if err != nil {
 			return nil, err
 		}
@@ -2518,7 +2355,7 @@ func (c *clusterImpl) ExternalAdminUIAddr(
 		return nil, err
 	}
 	for _, u := range externalAddrs {
-		adminUIAddr, err := addrToAdminUIAddr(c, u)
+		adminUIAddr, err := addrToAdminUIAddr(u)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -1085,16 +1085,19 @@ func (r *testRunner) runTest(
 		t.ReplaceL(logger)
 	}
 
-	// Awkward file name to keep it close to test.log.
-	l.Printf("running post test assertions (test-post-assertions.log)")
-	replaceLogger("test-post-assertions")
+	if !t.Failed() {
+		// Awkward file name to keep it close to test.log.
+		l.Printf("running post test assertions (test-post-assertions.log)")
+		replaceLogger("test-post-assertions")
 
-	// We still want to run the post-test assertions even if the test timed out as it
-	// might provide useful information about the health of the nodes. Any assertion failures
-	// will will be recorded against, and eventually fail, the test.
-	// TODO (miral): consider not running these assertions if the test has already failed
-	if err := r.postTestAssertions(ctx, t, c, 10*time.Minute); err != nil {
-		l.Printf("error during post test assertions: %v; see test-post-assertions.log for details", err)
+		// We still want to run the post-test assertions even if the test timed out as it
+		// might provide useful information about the health of the nodes. Any assertion failures
+		// will will be recorded against, and eventually fail, the test.
+		if err := r.postTestAssertions(ctx, t, c, 10*time.Minute); err != nil {
+			l.Printf("error during post test assertions: %v; see test-post-assertions.log for details", err)
+		}
+	} else {
+		l.Printf("skipping post test assertions as test failed")
 	}
 
 	// From now on, all logging goes to test-teardown.log to give a clear separation between

--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -2483,8 +2483,8 @@ func WithDisplay(display string) ParallelOption {
 }
 
 // Parallel runs a user-defined function across the nodes in the
-// cluster. If any of the commands fail, Parallel will log an error
-// and exit the program.
+// cluster. If any of the commands fail, Parallel will log each failure
+// and return an error.
 //
 // See ParallelE for more information.
 func (c *SyncedCluster) Parallel(

--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -133,7 +133,7 @@ var DefaultSSHRetryOpts = newRunRetryOpts(defaultRetryOpt, func(res *RunResultDe
 var noScpRetrySubstrings = []string{"no such file or directory", "permission denied", "connection timed out"}
 var defaultSCPRetry = newRunRetryOpts(defaultRetryOpt,
 	func(res *RunResultDetails) bool {
-		out := strings.ToLower(res.Stderr)
+		out := strings.ToLower(res.Output(false))
 		for _, s := range noScpRetrySubstrings {
 			if strings.Contains(out, s) {
 				return false
@@ -146,10 +146,13 @@ var defaultSCPRetry = newRunRetryOpts(defaultRetryOpt,
 // runWithMaybeRetry will run the specified function `f` at least once, or only
 // once if `runRetryOpts` is nil
 //
-// Any RunResultDetails with a non nil err from `f` is passed to `runRetryOpts.shouldRetryFn` which,
+// Any RunResultDetails containing a non nil err from `f` is passed to `runRetryOpts.shouldRetryFn` which,
 // if it returns true, will result in `f` being retried using the `retryOpts`
 // If the `shouldRetryFn` is not specified (nil), then retries will be performed
-// regardless of the previous result / error
+// regardless of the previous result / error.
+//
+// If a non-nil error (as opposed to the result containing a non-nil error) is returned,
+// the function will *not* be retried.
 //
 // We operate on a pointer to RunResultDetails as it has already been
 // captured in a *RunResultDetails[] in Run, but here we may enrich with attempt
@@ -166,7 +169,7 @@ func runWithMaybeRetry(
 			return nil, err
 		}
 		res.Attempt = 1
-		return res, err
+		return res, nil
 	}
 
 	var res = &RunResultDetails{}
@@ -851,6 +854,48 @@ func newRunResultDetails(node Node, err error) *RunResultDetails {
 	return &res
 }
 
+// Output prints either the combined, or separated stdout and stderr command output
+func (r *RunResultDetails) Output(decorate bool) string {
+	var builder strings.Builder
+	outputExists := false
+	writeVal := func(label string, value string) {
+		s := strings.TrimSpace(value)
+		if builder.Len() > 0 {
+			builder.WriteByte('\n')
+		}
+
+		if s == "" {
+			if decorate {
+				builder.WriteString(label)
+				builder.WriteString(": <empty>")
+			}
+			return
+		}
+
+		if label != "" && decorate {
+			builder.WriteString(label)
+			builder.WriteString(":")
+		}
+		builder.WriteString(s)
+		builder.WriteString("\n")
+		outputExists = true
+	}
+
+	writeVal("stdout", r.Stdout)
+	writeVal("stderr", r.Stderr)
+
+	// Only if stderr and stdout are empty do we check the combined output.
+	if !outputExists {
+		builder.Reset()
+		writeVal("", r.CombinedOut)
+	}
+
+	if !outputExists {
+		return ""
+	}
+	return builder.String()
+}
+
 // RunCmdOptions is used to configure the behavior of `runCmdOnSingleNode`
 type RunCmdOptions struct {
 	combinedOut             bool
@@ -867,17 +912,18 @@ func defaultCmdOpts(debugName string) RunCmdOptions {
 	}
 }
 
-// runCmdOnSingleNode runs a command on a single node
-// `combined` controls whether the stdout and stderr are combined into `RunResultDetails.CombinedOut`.
-// `withEnvVars` controls whether the command is run with the ROACHPROD env variable, and
-// should be true for all user commands.
+// runCmdOnSingleNode is a common entry point for all commands that run on a single node,
+// including user commands from roachtests and roachprod commands.
+// The `opts` struct is used to configure the behavior of the command, including
+// - whether stdout and stderr or combined output is desired
+// - specifying the stdin, stdout, and stderr streams
+// - specifying the remote session options
+// - whether the command should be run with the ROACHPROD env variable (true for all user commands)
 func (c *SyncedCluster) runCmdOnSingleNode(
 	ctx context.Context, l *logger.Logger, node Node, cmd string, opts RunCmdOptions,
 ) (*RunResultDetails, error) {
 	// Argument template expansion is node specific (e.g. for {store-dir}).
-	e := expander{
-		node: node,
-	}
+	e := expander{node: node}
 	expandedCmd, err := e.expand(ctx, l, c, cmd)
 	if err != nil {
 		return nil, errors.WithDetailf(err, "error expanding command: %s", cmd)
@@ -938,7 +984,18 @@ func (c *SyncedCluster) runCmdOnSingleNode(
 	}
 
 	if res.Err != nil {
-		detailMsg := fmt.Sprintf("Node %d. Command with error:\n```\n%s\n```\n", node, cmd)
+		output := res.Output(true)
+		// Somewhat arbitrary limit to give us a chance to see some of the output
+		// in the failure_*.log, since the full output is in the run_*.log.
+		oLen := len(output)
+		if oLen > 1024 {
+			output = "<truncated> ... " + output[oLen-1024:oLen-1]
+		}
+
+		if output == "" {
+			output = "<no output>"
+		}
+		detailMsg := fmt.Sprintf("Node %d. Command with error:\n```\n%s\n```\n%s", node, cmd, output)
 		res.Err = errors.WithDetail(res.Err, detailMsg)
 	}
 	return res, nil
@@ -967,7 +1024,7 @@ func (c *SyncedCluster) Run(
 	stream := len(nodes) == 1
 	var display string
 	if !stream {
-		display = fmt.Sprintf("%s: %s", c.Name, title)
+		display = fmt.Sprintf("%s:%v: %s", c.Name, nodes, title)
 	}
 
 	results, _, err := c.ParallelE(ctx, l, nodes, func(ctx context.Context, node Node) (*RunResultDetails, error) {
@@ -990,6 +1047,21 @@ func (c *SyncedCluster) Run(
 
 // processResults returns the error from the RunResultDetails with the highest RemoteExitStatus
 func processResults(results []*RunResultDetails, stream bool, stdout io.Writer) error {
+
+	// Easier to read output when we indent each line of the output. If an error is
+	// present, we also include the error message at the top.
+	format := func(s string, e error) string {
+		s = strings.ReplaceAll(s, "\n", "\n\t")
+		if e != nil {
+			return fmt.Sprintf("\t<err> %v\n\t%s", e, s)
+		}
+
+		if s == "" {
+			return "\t<ok>"
+		}
+		return fmt.Sprintf("\t<ok>\n\t%s", s)
+	}
+
 	var resultWithError *RunResultDetails
 	for i, r := range results {
 		// We no longer wait for all nodes to complete before returning in the case of an error (#100403)
@@ -1001,7 +1073,7 @@ func processResults(results []*RunResultDetails, stream bool, stdout io.Writer) 
 		// Emit the cached output of each result. When stream == true, the output is emitted
 		// as it is generated in `runCmdOnSingleNode`.
 		if !stream {
-			fmt.Fprintf(stdout, "  %2d: %s\n%v\n", i+1, strings.TrimSpace(r.CombinedOut), r.Err)
+			fmt.Fprintf(stdout, "  %2d: %s\n", i+1, format(r.Output(true), r.Err))
 		}
 
 		if r.Err != nil {
@@ -1027,7 +1099,7 @@ func processResults(results []*RunResultDetails, stream bool, stdout io.Writer) 
 func (c *SyncedCluster) RunWithDetails(
 	ctx context.Context, l *logger.Logger, nodes Nodes, title, cmd string,
 ) ([]RunResultDetails, error) {
-	display := fmt.Sprintf("%s: %s", c.Name, title)
+	display := fmt.Sprintf("%s:%v: %s", c.Name, nodes, title)
 
 	// Failing slow here allows us to capture the output of all nodes even if one fails with a command error.
 	resultPtrs, _, err := c.ParallelE(ctx, l, nodes, func(ctx context.Context, node Node) (*RunResultDetails, error) {
@@ -1158,7 +1230,6 @@ tar cf - .ssh/id_rsa .ssh/id_rsa.pub .ssh/authorized_keys
 		runOpts := defaultCmdOpts("ssh-gen-key")
 		runOpts.combinedOut = false
 		return c.runCmdOnSingleNode(ctx, l, n, cmd, runOpts)
-		//sess := c.newSession(l, 1, cmd, withDebugName("ssh-gen-key"))
 	}, WithDisplay("generating ssh key"))
 
 	if err != nil {
@@ -1172,7 +1243,6 @@ tar cf - .ssh/id_rsa .ssh/id_rsa.pub .ssh/authorized_keys
 		runOpts := defaultCmdOpts("ssh-dist-key")
 		runOpts.stdin = bytes.NewReader(sshTar)
 		return c.runCmdOnSingleNode(ctx, l, node, `tar xf -`, runOpts)
-		//sess := c.newSession(l, node, cmd, withDebugName("ssh-dist-key"))
 	}, WithDisplay("distributing ssh key")); err != nil {
 		return err
 	}
@@ -1526,8 +1596,9 @@ func (c *SyncedCluster) fileExistsOnFirstNode(
 	l.Printf("%s: checking %s", c.Name, path)
 	runOpts := defaultCmdOpts("check-file-exists")
 	runOpts.includeRoachprodEnvVars = true
-	_, err := c.runCmdOnSingleNode(ctx, l, 1, `test -e `+path, runOpts)
-	return err == nil
+	res, _ := c.runCmdOnSingleNode(ctx, l, 1, `test -e `+path, runOpts)
+	// We only return true if the command succeeded.
+	return res != nil && res.RemoteExitStatus == 0
 }
 
 // createNodeCertArguments returns a list of strings appropriate for use as
@@ -2234,7 +2305,6 @@ func (c *SyncedCluster) Get(
 	}
 
 	if config.Quiet && l.File != nil {
-		l.Printf("\n")
 		linesMu.Lock()
 		for i := range lines {
 			l.Printf("  %2d: %s", nodes[i], lines[i])
@@ -2463,7 +2533,7 @@ type ParallelResult struct {
 // ParallelE only returns an error for roachprod itself, not any command errors run
 // on the cluster.
 //
-// ParallelE  runs at most `concurrency` (or  `config.MaxConcurrency` if it is lower) in parallel.
+// ParallelE runs at most `concurrency` (or  `config.MaxConcurrency` if it is lower) in parallel.
 // If `concurrency` is 0, then it defaults to `len(nodes)`.
 //
 // The function returns pointers to *RunResultDetails as we may enrich
@@ -2609,12 +2679,12 @@ func (c *SyncedCluster) ParallelE(
 // to maintain parity with auto-init behavior of `roachprod start` (when
 // --skip-init) is not specified.
 func (c *SyncedCluster) Init(ctx context.Context, l *logger.Logger, node Node) error {
-	if err := c.initializeCluster(ctx, l, node); err != nil {
-		return errors.WithDetail(err, "install.Init() failed: unable to initialize cluster.")
+	if res, err := c.initializeCluster(ctx, l, node); err != nil || (res != nil && res.Err != nil) {
+		return errors.WithDetail(errors.CombineErrors(err, res.Err), "install.Init() failed: unable to initialize cluster.")
 	}
 
-	if err := c.setClusterSettings(ctx, l, node); err != nil {
-		return errors.WithDetail(err, "install.Init() failed: unable to set cluster settings.")
+	if res, err := c.setClusterSettings(ctx, l, node); err != nil || (res != nil && res.Err != nil) {
+		return errors.WithDetail(errors.CombineErrors(err, res.Err), "install.Init() failed: unable to set cluster settings.")
 	}
 
 	return nil

--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -22,7 +22,6 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
-	"sort"
 	"strings"
 	"sync"
 	"syscall"
@@ -146,7 +145,8 @@ var defaultSCPRetry = newRunRetryOpts(defaultRetryOpt,
 
 // runWithMaybeRetry will run the specified function `f` at least once, or only
 // once if `runRetryOpts` is nil
-// Any returned error from `f` is passed to `runRetryOpts.shouldRetryFn` which,
+//
+// Any RunResultDetails with a non nil err from `f` is passed to `runRetryOpts.shouldRetryFn` which,
 // if it returns true, will result in `f` being retried using the `retryOpts`
 // If the `shouldRetryFn` is not specified (nil), then retries will be performed
 // regardless of the previous result / error
@@ -162,19 +162,24 @@ func runWithMaybeRetry(
 ) (*RunResultDetails, error) {
 	if retryOpts == nil {
 		res, err := f(ctx)
+		if err != nil {
+			return nil, err
+		}
 		res.Attempt = 1
 		return res, err
 	}
 
-	var res *RunResultDetails
-	var err error
-	var cmdErr error
+	var res = &RunResultDetails{}
+	var cmdErr, err error
 
 	for r := retry.StartWithCtx(ctx, retryOpts.Options); r.Next(); {
 		res, err = f(ctx)
+		if err != nil {
+			// non retryable roachprod error
+			return nil, err
+		}
 		res.Attempt = r.CurrentAttempt() + 1
-		// nil err (non-nil denotes a roachprod error) indicates a potentially retryable res.Err
-		if err == nil && res.Err != nil {
+		if res.Err != nil {
 			cmdErr = errors.CombineErrors(cmdErr, res.Err)
 			if retryOpts.shouldRetryFn == nil || retryOpts.shouldRetryFn(res) {
 				l.Printf("encountered [%v] on attempt %v of %v", res.Err, r.CurrentAttempt()+1, retryOpts.MaxRetries+1)
@@ -193,7 +198,7 @@ func runWithMaybeRetry(
 			l.Printf("command successful after %v attempts", res.Attempt)
 		}
 	}
-	return res, err
+	return res, nil
 }
 
 func scpWithRetry(
@@ -420,9 +425,7 @@ func (c *SyncedCluster) kill(
 		// `kill -9` without wait is never what a caller wants. See #77334.
 		wait = true
 	}
-	return c.Parallel(ctx, l, len(c.Nodes), func(ctx context.Context, i int) (*RunResultDetails, error) {
-		node := c.Nodes[i]
-
+	return c.Parallel(ctx, l, c.Nodes, func(ctx context.Context, node Node) (*RunResultDetails, error) {
 		var waitCmd string
 		if wait {
 			waitCmd = fmt.Sprintf(`
@@ -467,13 +470,7 @@ fi`,
 			waitCmd,                   // [5]
 		)
 
-		sess := c.newSession(l, node, cmd, withDebugName("node-"+cmdName))
-		defer sess.Close()
-
-		out, cmdErr := sess.CombinedOutput(ctx)
-		res := newRunResultDetails(node, cmdErr)
-		res.CombinedOut = out
-		return res, res.Err
+		return c.runCmdOnSingleNode(ctx, l, node, cmd, defaultCmdOpts("kill"))
 	}, WithDisplay(display), WithRetryOpts(nil)) // Disable SSH Retries
 }
 
@@ -483,8 +480,7 @@ func (c *SyncedCluster) Wipe(ctx context.Context, l *logger.Logger, preserveCert
 	if err := c.Stop(ctx, l, 9, true /* wait */, 0 /* maxWait */); err != nil {
 		return err
 	}
-	return c.Parallel(ctx, l, len(c.Nodes), func(ctx context.Context, i int) (*RunResultDetails, error) {
-		node := c.Nodes[i]
+	return c.Parallel(ctx, l, c.Nodes, func(ctx context.Context, node Node) (*RunResultDetails, error) {
 		var cmd string
 		if c.IsLocal() {
 			// Not all shells like brace expansion, so we'll do it here
@@ -494,7 +490,7 @@ func (c *SyncedCluster) Wipe(ctx context.Context, l *logger.Logger, preserveCert
 				dirs = append(dirs, "tenant-certs*")
 			}
 			for _, dir := range dirs {
-				cmd += fmt.Sprintf(`rm -fr %s/%s ;`, c.localVMDir(c.Nodes[i]), dir)
+				cmd += fmt.Sprintf(`rm -fr %s/%s ;`, c.localVMDir(node), dir)
 			}
 		} else {
 			rmCmds := []string{
@@ -508,13 +504,7 @@ func (c *SyncedCluster) Wipe(ctx context.Context, l *logger.Logger, preserveCert
 
 			cmd = strings.Join(rmCmds, " && ")
 		}
-		sess := c.newSession(l, node, cmd, withDebugName("node-wipe"))
-		defer sess.Close()
-
-		out, cmdErr := sess.CombinedOutput(ctx)
-		res := newRunResultDetails(node, cmdErr)
-		res.CombinedOut = out
-		return res, res.Err
+		return c.runCmdOnSingleNode(ctx, l, node, cmd, defaultCmdOpts("wipe"))
 	}, WithDisplay(display))
 }
 
@@ -530,10 +520,7 @@ type NodeStatus struct {
 // Status TODO(peter): document
 func (c *SyncedCluster) Status(ctx context.Context, l *logger.Logger) ([]NodeStatus, error) {
 	display := fmt.Sprintf("%s: status", c.Name)
-	results := make([]NodeStatus, len(c.Nodes))
-	if err := c.Parallel(ctx, l, len(c.Nodes), func(ctx context.Context, i int) (*RunResultDetails, error) {
-		node := c.Nodes[i]
-
+	res, _, err := c.ParallelE(ctx, l, c.Nodes, func(ctx context.Context, node Node) (*RunResultDetails, error) {
 		binary := cockroachNodeBinary(c, node)
 		cmd := fmt.Sprintf(`out=$(ps axeww -o pid -o ucomm -o command | \
   sed 's/export ROACHPROD=//g' | \
@@ -547,33 +534,24 @@ else
   echo ${out}
 fi
 `
-		sess := c.newSession(l, node, cmd, withDebugName("node-status"))
-		defer sess.Close()
+		return c.runCmdOnSingleNode(ctx, l, node, cmd, defaultCmdOpts("status"))
+	}, WithDisplay(display))
 
-		out, cmdErr := sess.CombinedOutput(ctx)
-		res := newRunResultDetails(node, cmdErr)
-		res.CombinedOut = out
-
-		if res.Err != nil {
-			return res, errors.Wrapf(res.Err, "~ %s\n%s", cmd, res.CombinedOut)
-		}
-
-		msg := strings.TrimSpace(string(res.CombinedOut))
-		if msg == "" {
-			results[i] = NodeStatus{Running: false}
-			return res, nil
-		}
-		info := strings.Split(msg, " ")
-		results[i] = NodeStatus{Running: true, Version: info[0], Pid: info[1]}
-
-		return res, nil
-	}, WithDisplay(display)); err != nil {
+	if err != nil {
 		return nil, err
 	}
-	for i := 0; i < len(results); i++ {
-		results[i].NodeID = int(c.Nodes[i])
+
+	statuses := make([]NodeStatus, len(c.Nodes))
+	for i, res := range res {
+		msg := strings.TrimSpace(res.CombinedOut)
+		if msg == "" {
+			statuses[i] = NodeStatus{NodeID: int(res.Node), Running: false}
+			continue
+		}
+		info := strings.Split(msg, " ")
+		statuses[i] = NodeStatus{NodeID: int(res.Node), Running: true, Version: info[0], Pid: info[1]}
 	}
-	return results, nil
+	return statuses, nil
 }
 
 // MonitorNodeSkipped represents a node whose status was not checked.
@@ -766,6 +744,7 @@ done
 				return
 			}
 
+			// This is the exception to funneling all SSH traffic through `c.runCmdOnSingleNode`
 			sess := c.newSession(l, node, buf.String(), withDebugDisabled())
 			defer sess.Close()
 
@@ -854,7 +833,7 @@ type RunResultDetails struct {
 	Node             Node
 	Stdout           string
 	Stderr           string
-	CombinedOut      []byte
+	CombinedOut      string
 	Err              error
 	RemoteExitStatus int
 	Attempt          int
@@ -872,13 +851,28 @@ func newRunResultDetails(node Node, err error) *RunResultDetails {
 	return &res
 }
 
+// RunCmdOptions is used to configure the behavior of `runCmdOnSingleNode`
+type RunCmdOptions struct {
+	combinedOut             bool
+	includeRoachprodEnvVars bool
+	stdin                   io.Reader
+	stdout, stderr          io.Writer
+	remoteOptions           []remoteSessionOption
+}
+
+func defaultCmdOpts(debugName string) RunCmdOptions {
+	return RunCmdOptions{
+		combinedOut:   true,
+		remoteOptions: []remoteSessionOption{withDebugName(debugName)},
+	}
+}
+
+// runCmdOnSingleNode runs a command on a single node
+// `combined` controls whether the stdout and stderr are combined into `RunResultDetails.CombinedOut`.
+// `withEnvVars` controls whether the command is run with the ROACHPROD env variable, and
+// should be true for all user commands.
 func (c *SyncedCluster) runCmdOnSingleNode(
-	ctx context.Context,
-	l *logger.Logger,
-	node Node,
-	cmd string,
-	combined bool,
-	stdout, stderr io.Writer,
+	ctx context.Context, l *logger.Logger, node Node, cmd string, opts RunCmdOptions,
 ) (*RunResultDetails, error) {
 	// Argument template expansion is node specific (e.g. for {store-dir}).
 	e := expander{
@@ -886,9 +880,10 @@ func (c *SyncedCluster) runCmdOnSingleNode(
 	}
 	expandedCmd, err := e.expand(ctx, l, c, cmd)
 	if err != nil {
-		return newRunResultDetails(node, err), err
+		return nil, errors.WithDetailf(err, "error expanding command: %s", cmd)
 	}
 
+	nodeCmd := expandedCmd
 	// Be careful about changing these command strings. In particular, we need
 	// to support running commands in the background on both local and remote
 	// nodes. For example:
@@ -897,28 +892,43 @@ func (c *SyncedCluster) runCmdOnSingleNode(
 	//
 	// That command should return immediately. And a "roachprod status" should
 	// reveal that the sleep command is running on the cluster.
-	envVars := append([]string{
-		fmt.Sprintf("ROACHPROD=%s", c.roachprodEnvValue(node)), "GOTRACEBACK=crash",
-	}, config.DefaultEnvVars()...)
-	nodeCmd := fmt.Sprintf(`export %s && bash -c %s`,
-		strings.Join(envVars, " "), ssh.Escape1(expandedCmd))
-	if c.IsLocal() {
-		nodeCmd = fmt.Sprintf("cd %s; %s", c.localVMDir(node), nodeCmd)
+	if opts.includeRoachprodEnvVars {
+		envVars := append([]string{
+			fmt.Sprintf("ROACHPROD=%s", c.roachprodEnvValue(node)), "GOTRACEBACK=crash",
+		}, config.DefaultEnvVars()...)
+		nodeCmd = fmt.Sprintf(`export %s && bash -c %s`,
+			strings.Join(envVars, " "), ssh.Escape1(expandedCmd))
+		if c.IsLocal() {
+			nodeCmd = fmt.Sprintf("cd %s; %s", c.localVMDir(node), nodeCmd)
+		}
 	}
 
-	sess := c.newSession(l, node, nodeCmd, withDebugName(GenFilenameFromArgs(20, expandedCmd)))
+	// This default can be overridden by the caller, and is hence specified first
+	sessionOpts := []remoteSessionOption{withDebugName(GenFilenameFromArgs(20, expandedCmd))}
+	sess := c.newSession(l, node, nodeCmd, append(sessionOpts, opts.remoteOptions...)...)
 	defer sess.Close()
 
+	if opts.stdin != nil {
+		sess.SetStdin(opts.stdin)
+	}
+	if opts.stdout == nil {
+		opts.stdout = io.Discard
+	}
+	if opts.stderr == nil {
+		opts.stderr = io.Discard
+	}
+
 	var res *RunResultDetails
-	if combined {
+	if opts.combinedOut {
 		out, cmdErr := sess.CombinedOutput(ctx)
 		res = newRunResultDetails(node, cmdErr)
-		res.CombinedOut = out
+		res.CombinedOut = string(out)
 	} else {
 		// We stream the output if running on a single node.
 		var stdoutBuffer, stderrBuffer bytes.Buffer
-		multStdout := io.MultiWriter(&stdoutBuffer, stdout)
-		multStderr := io.MultiWriter(&stderrBuffer, stderr)
+
+		multStdout := io.MultiWriter(&stdoutBuffer, opts.stdout)
+		multStderr := io.MultiWriter(&stderrBuffer, opts.stderr)
 		sess.SetStdout(multStdout)
 		sess.SetStderr(multStderr)
 
@@ -960,17 +970,18 @@ func (c *SyncedCluster) Run(
 		display = fmt.Sprintf("%s: %s", c.Name, title)
 	}
 
-	results := make([]*RunResultDetails, len(nodes))
-
-	// A result is the output of running a command (could be interpreted as an error)
-	if _, err := c.ParallelE(ctx, l, len(nodes), func(ctx context.Context, i int) (*RunResultDetails, error) {
-		// An err returned here is an unexpected state within roachprod (non-command error).
-		// For errors that occur as part of running a command over ssh, the `result` will contain
-		// the actual error on a specific node.
-		result, err := c.runCmdOnSingleNode(ctx, l, nodes[i], cmd, !stream, stdout, stderr)
-		results[i] = result
+	results, _, err := c.ParallelE(ctx, l, nodes, func(ctx context.Context, node Node) (*RunResultDetails, error) {
+		opts := RunCmdOptions{
+			combinedOut:             !stream,
+			includeRoachprodEnvVars: true,
+			stdout:                  stdout,
+			stderr:                  stderr,
+		}
+		result, err := c.runCmdOnSingleNode(ctx, l, node, cmd, opts)
 		return result, err
-	}, append(opts, WithDisplay(display))...); err != nil {
+	}, append(opts, WithDisplay(display))...)
+
+	if err != nil {
 		return err
 	}
 
@@ -987,8 +998,10 @@ func processResults(results []*RunResultDetails, stream bool, stdout io.Writer) 
 			continue
 		}
 
+		// Emit the cached output of each result. When stream == true, the output is emitted
+		// as it is generated in `runCmdOnSingleNode`.
 		if !stream {
-			fmt.Fprintf(stdout, "  %2d: %s\n%v\n", i+1, strings.TrimSpace(string(r.CombinedOut)), r.Err)
+			fmt.Fprintf(stdout, "  %2d: %s\n%v\n", i+1, strings.TrimSpace(r.CombinedOut), r.Err)
 		}
 
 		if r.Err != nil {
@@ -1016,16 +1029,18 @@ func (c *SyncedCluster) RunWithDetails(
 ) ([]RunResultDetails, error) {
 	display := fmt.Sprintf("%s: %s", c.Name, title)
 
-	// We use pointers here as we are capturing the state of a result even though it may
-	// be processed further by the caller.
-	resultPtrs := make([]*RunResultDetails, len(nodes))
-
 	// Failing slow here allows us to capture the output of all nodes even if one fails with a command error.
-	if _, err := c.ParallelE(ctx, l, len(nodes), func(ctx context.Context, i int) (*RunResultDetails, error) { //nolint:errcheck
-		result, err := c.runCmdOnSingleNode(ctx, l, nodes[i], cmd, false, l.Stdout, l.Stderr)
-		resultPtrs[i] = result
+	resultPtrs, _, err := c.ParallelE(ctx, l, nodes, func(ctx context.Context, node Node) (*RunResultDetails, error) {
+		opts := RunCmdOptions{
+			includeRoachprodEnvVars: true,
+			stdout:                  l.Stdout,
+			stderr:                  l.Stderr,
+		}
+		result, err := c.runCmdOnSingleNode(ctx, l, node, cmd, opts)
 		return result, err
-	}, WithDisplay(display), WithWaitOnFail()); err != nil {
+	}, WithDisplay(display), WithWaitOnFail())
+
+	if err != nil {
 		return nil, err
 	}
 
@@ -1071,37 +1086,33 @@ func (c *SyncedCluster) RepeatRun(
 // Wait TODO(peter): document
 func (c *SyncedCluster) Wait(ctx context.Context, l *logger.Logger) error {
 	display := fmt.Sprintf("%s: waiting for nodes to start", c.Name)
-	errs := make([]error, len(c.Nodes))
-	if err := c.Parallel(ctx, l, len(c.Nodes), func(ctx context.Context, i int) (*RunResultDetails, error) {
-		node := c.Nodes[i]
+	_, hasError, err := c.ParallelE(ctx, l, c.Nodes, func(ctx context.Context, node Node) (*RunResultDetails, error) {
 		res := &RunResultDetails{Node: node}
+		var err error
 		cmd := "test -e /mnt/data1/.roachprod-initialized"
+		opts := defaultCmdOpts("wait-init")
 		for j := 0; j < 600; j++ {
-			sess := c.newSession(l, node, cmd, withDebugDisabled())
-			defer sess.Close()
-
-			_, err := sess.CombinedOutput(ctx)
+			res, err = c.runCmdOnSingleNode(ctx, l, node, cmd, opts)
 			if err != nil {
+				return nil, err
+			}
+
+			if res.Err != nil {
 				time.Sleep(500 * time.Millisecond)
 				continue
 			}
 			return res, nil
 		}
-		errs[i] = errors.New("timed out after 5m")
-		res.Err = errs[i]
+		res.Err = errors.New("timed out after 5m")
+		l.Printf("  %2d: %v", node, res.Err)
 		return res, nil
-	}, WithDisplay(display), WithRetryOpts(nil)); err != nil {
+	}, WithDisplay(display), WithRetryOpts(nil))
+
+	if err != nil {
 		return err
 	}
 
-	var foundErr bool
-	for i, err := range errs {
-		if err != nil {
-			l.Printf("  %2d: %v", c.Nodes[i], err)
-			foundErr = true
-		}
-	}
-	if foundErr {
+	if hasError {
 		return errors.New("not all nodes booted successfully")
 	}
 	return nil
@@ -1132,10 +1143,9 @@ func (c *SyncedCluster) SetupSSH(ctx context.Context, l *logger.Logger) error {
 			c.Name, len(c.Nodes), len(c.VMs))
 	}
 
-	// Generate an ssh key that we'll distribute to all of the nodes in the
+	// Generate an ssh key that we'll distribute to all the nodes in the
 	// cluster in order to allow inter-node ssh.
-	var sshTar []byte
-	if err := c.Parallel(ctx, l, 1, func(ctx context.Context, i int) (*RunResultDetails, error) {
+	results, _, err := c.ParallelE(ctx, l, c.Nodes[0:1], func(ctx context.Context, n Node) (*RunResultDetails, error) {
 		// Create the ssh key and then tar up the public, private and
 		// authorized_keys files and output them to stdout. We'll take this output
 		// and pipe it back into tar on the other nodes in the cluster.
@@ -1145,47 +1155,24 @@ test -f .ssh/id_rsa || \
    cat .ssh/id_rsa.pub >> .ssh/authorized_keys);
 tar cf - .ssh/id_rsa .ssh/id_rsa.pub .ssh/authorized_keys
 `
+		runOpts := defaultCmdOpts("ssh-gen-key")
+		runOpts.combinedOut = false
+		return c.runCmdOnSingleNode(ctx, l, n, cmd, runOpts)
+		//sess := c.newSession(l, 1, cmd, withDebugName("ssh-gen-key"))
+	}, WithDisplay("generating ssh key"))
 
-		sess := c.newSession(l, 1, cmd, withDebugName("ssh-gen-key"))
-		defer sess.Close()
-
-		var stdout bytes.Buffer
-		var stderr bytes.Buffer
-		sess.SetStdout(&stdout)
-		sess.SetStderr(&stderr)
-
-		res := newRunResultDetails(1, sess.Run(ctx))
-
-		res.Stdout = stdout.String()
-		res.Stderr = stderr.String()
-		if res.Err != nil {
-			return res, errors.Wrapf(res.Err, "%s: stderr:\n%s", cmd, res.Stderr)
-		}
-		sshTar = []byte(res.Stdout)
-		return res, nil
-	}, WithDisplay("generating ssh key")); err != nil {
+	if err != nil {
 		return err
 	}
 
+	sshTar := []byte(results[0].Stdout)
 	// Skip the first node which is where we generated the key.
 	nodes := c.Nodes[1:]
-	if err := c.Parallel(ctx, l, len(nodes), func(ctx context.Context, i int) (*RunResultDetails, error) {
-		node := nodes[i]
-		cmd := `tar xf -`
-
-		sess := c.newSession(l, node, cmd, withDebugName("ssh-dist-key"))
-		defer sess.Close()
-
-		sess.SetStdin(bytes.NewReader(sshTar))
-
-		out, cmdErr := sess.CombinedOutput(ctx)
-		res := newRunResultDetails(node, cmdErr)
-		res.CombinedOut = out
-
-		if res.Err != nil {
-			return res, errors.Wrapf(res.Err, "%s: output:\n%s", cmd, res.CombinedOut)
-		}
-		return res, nil
+	if err := c.Parallel(ctx, l, nodes, func(ctx context.Context, node Node) (*RunResultDetails, error) {
+		runOpts := defaultCmdOpts("ssh-dist-key")
+		runOpts.stdin = bytes.NewReader(sshTar)
+		return c.runCmdOnSingleNode(ctx, l, node, `tar xf -`, runOpts)
+		//sess := c.newSession(l, node, cmd, withDebugName("ssh-dist-key"))
 	}, WithDisplay("distributing ssh key")); err != nil {
 		return err
 	}
@@ -1206,25 +1193,25 @@ tar cf - .ssh/id_rsa .ssh/id_rsa.pub .ssh/authorized_keys
 	providerPrivateIPs := make(map[string][]nodeInfo)
 	publicIPs := make([]string, 0, len(c.Nodes))
 	for _, node := range c.Nodes {
-		provider := c.VMs[node-1].Provider
-		ip, err := c.GetInternalIP(node)
-		if err != nil {
-			return err
-		}
-		providerPrivateIPs[provider] = append(providerPrivateIPs[provider], nodeInfo{node: node, ip: ip})
+		v := c.VMs[node-1]
+		providerPrivateIPs[v.Provider] = append(providerPrivateIPs[v.Provider], nodeInfo{node: node, ip: v.PrivateIP})
 		publicIPs = append(publicIPs, c.Host(node))
 	}
 
 	providerKnownHostData := make(map[string][]byte)
 	providers := maps.Keys(providerPrivateIPs)
+
 	// Only need to scan on the first node of each provider.
-	if err := c.Parallel(ctx, l, len(providers), func(ctx context.Context, i int) (*RunResultDetails, error) {
-		provider := providers[i]
-		node := providerPrivateIPs[provider][0].node
+	firstNodes := make([]Node, len(providers))
+	for i, provider := range providers {
+		firstNodes[i] = providerPrivateIPs[provider][0].node
+	}
+	if err := c.Parallel(ctx, l, firstNodes, func(ctx context.Context, node Node) (*RunResultDetails, error) {
 		// Scan a combination of all remote IPs and local IPs pertaining to this
 		// node's cloud provider.
 		scanIPs := append([]string{}, publicIPs...)
-		for _, nodeInfo := range providerPrivateIPs[provider] {
+		nodeProvider := c.VMs[node-1].Provider
+		for _, nodeInfo := range providerPrivateIPs[nodeProvider] {
 			scanIPs = append(scanIPs, nodeInfo.ip)
 		}
 
@@ -1250,32 +1237,25 @@ for i in {1..20}; do
 done
 exit 1
 `
+		runOpts := defaultCmdOpts("ssh-scan-hosts")
+		runOpts.combinedOut = false
+		res, err := c.runCmdOnSingleNode(ctx, l, node, cmd, runOpts)
+		if err != nil {
+			return nil, err
+		}
 
-		sess := c.newSession(l, node, cmd, withDebugName("ssh-scan-hosts"))
-		defer sess.Close()
-
-		var stdout bytes.Buffer
-		var stderr bytes.Buffer
-		sess.SetStdout(&stdout)
-		sess.SetStderr(&stderr)
-
-		res := newRunResultDetails(node, sess.Run(ctx))
-
-		res.Stdout = stdout.String()
-		res.Stderr = stderr.String()
 		if res.Err != nil {
-			return res, errors.Wrapf(res.Err, "%s: stderr:\n%s", cmd, res.Stderr)
+			return res, nil
 		}
 		mu.Lock()
-		providerKnownHostData[provider] = stdout.Bytes()
+		providerKnownHostData[nodeProvider] = []byte(res.Stdout)
 		mu.Unlock()
 		return res, nil
 	}, WithDisplay("scanning hosts")); err != nil {
 		return err
 	}
 
-	if err := c.Parallel(ctx, l, len(c.Nodes), func(ctx context.Context, i int) (*RunResultDetails, error) {
-		node := c.Nodes[i]
+	if err := c.Parallel(ctx, l, c.Nodes, func(ctx context.Context, node Node) (*RunResultDetails, error) {
 		provider := c.VMs[node-1].Provider
 		const cmd = `
 known_hosts_data="$(cat)"
@@ -1304,19 +1284,9 @@ if [[ "$(whoami)" != "` + config.SharedUser + `" ]]; then
         '"'"'{}'"'"' ~` + config.SharedUser + `/.ssh' \;
 fi
 `
-
-		sess := c.newSession(l, node, cmd, withDebugName("ssh-dist-known-hosts"))
-		defer sess.Close()
-
-		sess.SetStdin(bytes.NewReader(providerKnownHostData[provider]))
-		out, cmdErr := sess.CombinedOutput(ctx)
-		res := newRunResultDetails(node, cmdErr)
-		res.CombinedOut = out
-
-		if res.Err != nil {
-			return res, errors.Wrapf(res.Err, "%s: output:\n%s", cmd, res.CombinedOut)
-		}
-		return res, nil
+		runOpts := defaultCmdOpts("ssh-dist-known-hosts")
+		runOpts.stdin = bytes.NewReader(providerKnownHostData[provider])
+		return c.runCmdOnSingleNode(ctx, l, node, cmd, runOpts)
 	}, WithDisplay("distributing known_hosts")); err != nil {
 		return err
 	}
@@ -1327,8 +1297,7 @@ fi
 		// additional authorized_keys to both the current user (your username on
 		// gce and the shared user on aws) as well as to the shared user on both
 		// platforms.
-		if err := c.Parallel(ctx, l, len(c.Nodes), func(ctx context.Context, i int) (*RunResultDetails, error) {
-			node := c.Nodes[i]
+		if err := c.Parallel(ctx, l, c.Nodes, func(ctx context.Context, node Node) (*RunResultDetails, error) {
 			const cmd = `
 keys_data="$(cat)"
 set -e
@@ -1352,18 +1321,9 @@ if [[ "$(whoami)" != "` + config.SharedUser + `" ]]; then
 fi
 `
 
-			sess := c.newSession(l, node, cmd, withDebugName("ssh-add-extra-keys"))
-			defer sess.Close()
-
-			sess.SetStdin(bytes.NewReader(c.AuthorizedKeys))
-			out, cmdErr := sess.CombinedOutput(ctx)
-			res := newRunResultDetails(node, cmdErr)
-			res.CombinedOut = out
-
-			if res.Err != nil {
-				return res, errors.Wrapf(res.Err, "~ %s\n%s", cmd, res.CombinedOut)
-			}
-			return res, nil
+			runOpts := defaultCmdOpts("ssh-add-extra-keys")
+			runOpts.stdin = bytes.NewReader(c.AuthorizedKeys)
+			return c.runCmdOnSingleNode(ctx, l, node, cmd, runOpts)
 		}, WithDisplay("adding additional authorized keys")); err != nil {
 			return err
 		}
@@ -1377,12 +1337,9 @@ const (
 	tenantCertsTarName = "tenant-certs.tar"
 )
 
-// DistributeCerts will generate and distribute certificates to all of the
-// nodes.
+// DistributeCerts will generate and distribute certificates to all the nodes.
 func (c *SyncedCluster) DistributeCerts(ctx context.Context, l *logger.Logger) error {
-	if found, err := c.checkForCertificates(ctx, l); err != nil {
-		return err
-	} else if found {
+	if c.checkForCertificates(ctx, l) {
 		return nil
 	}
 
@@ -1392,9 +1349,8 @@ func (c *SyncedCluster) DistributeCerts(ctx context.Context, l *logger.Logger) e
 	}
 
 	// Generate the ca, client and node certificates on the first node.
-	var msg string
 	display := fmt.Sprintf("%s: initializing certs", c.Name)
-	if err := c.Parallel(ctx, l, 1, func(ctx context.Context, i int) (*RunResultDetails, error) {
+	if err := c.Parallel(ctx, l, c.Nodes[0:1], func(ctx context.Context, node Node) (*RunResultDetails, error) {
 		var cmd string
 		if c.IsLocal() {
 			cmd = fmt.Sprintf(`cd %s ; `, c.localVMDir(1))
@@ -1422,23 +1378,9 @@ fi
 tar cvf %[3]s certs
 `, cockroachNodeBinary(c, 1), strings.Join(nodeNames, " "), certsTarName)
 
-		sess := c.newSession(l, 1, cmd, withDebugName("init-certs"))
-		defer sess.Close()
-
-		out, cmdErr := sess.CombinedOutput(ctx)
-		res := newRunResultDetails(1, cmdErr)
-		res.CombinedOut = out
-
-		if res.Err != nil {
-			msg = fmt.Sprintf("%s: %v", res.CombinedOut, res.Err)
-		}
-		return res, nil
+		return c.runCmdOnSingleNode(ctx, l, node, cmd, defaultCmdOpts("init-certs"))
 	}, WithDisplay(display)); err != nil {
-		return err
-	}
-
-	if msg != "" {
-		fmt.Fprintln(os.Stderr, msg)
+		fmt.Fprintln(os.Stderr, err)
 		exit.WithCode(exit.UnspecifiedError())
 	}
 
@@ -1458,15 +1400,11 @@ tar cvf %[3]s certs
 func (c *SyncedCluster) DistributeTenantCerts(
 	ctx context.Context, l *logger.Logger, hostCluster *SyncedCluster, tenantID int,
 ) error {
-	if found, err := hostCluster.checkForTenantCertificates(ctx, l); err != nil {
-		return err
-	} else if found {
+	if hostCluster.checkForTenantCertificates(ctx, l) {
 		return nil
 	}
 
-	if found, err := hostCluster.checkForCertificates(ctx, l); err != nil {
-		return err
-	} else if !found {
+	if !hostCluster.checkForCertificates(ctx, l) {
 		return errors.New("host cluster missing certificate bundle")
 	}
 
@@ -1497,9 +1435,7 @@ func (c *SyncedCluster) createTenantCertBundle(
 	ctx context.Context, l *logger.Logger, bundleName string, tenantID int, nodeNames []string,
 ) error {
 	display := fmt.Sprintf("%s: initializing tenant certs", c.Name)
-	return c.Parallel(ctx, l, 1, func(ctx context.Context, i int) (*RunResultDetails, error) {
-		node := c.Nodes[i]
-
+	return c.Parallel(ctx, l, c.Nodes[0:1], func(ctx context.Context, node Node) (*RunResultDetails, error) {
 		cmd := "set -e;"
 		if c.IsLocal() {
 			cmd += fmt.Sprintf(`cd %s ; `, c.localVMDir(1))
@@ -1530,17 +1466,7 @@ fi
 			bundleName,
 		)
 
-		sess := c.newSession(l, node, cmd, withDebugName("create-tenant-cert-bundle"))
-		defer sess.Close()
-
-		out, cmdErr := sess.CombinedOutput(ctx)
-		res := newRunResultDetails(node, cmdErr)
-		res.CombinedOut = out
-
-		if res.Err != nil {
-			return res, errors.Wrapf(res.Err, "certificate creation error: %s", res.CombinedOut)
-		}
-		return res, nil
+		return c.runCmdOnSingleNode(ctx, l, node, cmd, defaultCmdOpts("create-tenant-cert-bundle"))
 	}, WithDisplay(display))
 }
 
@@ -1576,7 +1502,7 @@ func (c *SyncedCluster) getFileFromFirstNode(
 
 // checkForCertificates checks if the cluster already has a certs bundle created
 // on the first node.
-func (c *SyncedCluster) checkForCertificates(ctx context.Context, l *logger.Logger) (bool, error) {
+func (c *SyncedCluster) checkForCertificates(ctx context.Context, l *logger.Logger) bool {
 	dir := ""
 	if c.IsLocal() {
 		dir = c.localVMDir(1)
@@ -1586,9 +1512,7 @@ func (c *SyncedCluster) checkForCertificates(ctx context.Context, l *logger.Logg
 
 // checkForTenantCertificates checks if the cluster already has a tenant-certs bundle created
 // on the first node.
-func (c *SyncedCluster) checkForTenantCertificates(
-	ctx context.Context, l *logger.Logger,
-) (bool, error) {
+func (c *SyncedCluster) checkForTenantCertificates(ctx context.Context, l *logger.Logger) bool {
 	dir := ""
 	if c.IsLocal() {
 		dir = c.localVMDir(1)
@@ -1598,13 +1522,12 @@ func (c *SyncedCluster) checkForTenantCertificates(
 
 func (c *SyncedCluster) fileExistsOnFirstNode(
 	ctx context.Context, l *logger.Logger, path string,
-) (bool, error) {
+) bool {
 	l.Printf("%s: checking %s", c.Name, path)
-	// We use `echo -n` below stop echo from including a newline
-	// character in the output, allowing us to compare it directly with
-	// "0".
-	result, err := c.runCmdOnSingleNode(ctx, l, 1, `$(test -e `+path+`); echo -n $?`, false, l.Stdout, l.Stderr)
-	return result.Stdout == "0", err
+	runOpts := defaultCmdOpts("check-file-exists")
+	runOpts.includeRoachprodEnvVars = true
+	_, err := c.runCmdOnSingleNode(ctx, l, 1, `test -e `+path, runOpts)
+	return err == nil
 }
 
 // createNodeCertArguments returns a list of strings appropriate for use as
@@ -1647,8 +1570,7 @@ func (c *SyncedCluster) distributeLocalCertsTar(
 	}
 
 	display := c.Name + ": distributing certs"
-	return c.Parallel(ctx, l, len(nodes), func(ctx context.Context, i int) (*RunResultDetails, error) {
-		node := nodes[i]
+	return c.Parallel(ctx, l, nodes, func(ctx context.Context, node Node) (*RunResultDetails, error) {
 		var cmd string
 		if c.IsLocal() {
 			cmd = fmt.Sprintf("cd %s ; ", c.localVMDir(node))
@@ -1659,18 +1581,9 @@ func (c *SyncedCluster) distributeLocalCertsTar(
 			cmd += "tar xf -"
 		}
 
-		sess := c.newSession(l, node, cmd, withDebugName("dist-local-certs"))
-		defer sess.Close()
-
-		sess.SetStdin(bytes.NewReader(certsTar))
-		out, cmdErr := sess.CombinedOutput(ctx)
-		res := newRunResultDetails(node, cmdErr)
-		res.CombinedOut = out
-
-		if res.Err != nil {
-			return res, errors.Wrapf(res.Err, "~ %s\n%s", cmd, res.CombinedOut)
-		}
-		return res, nil
+		runOpts := defaultCmdOpts("dist-local-certs")
+		runOpts.stdin = bytes.NewReader(certsTar)
+		return c.runCmdOnSingleNode(ctx, l, node, cmd, runOpts)
 	}, WithDisplay(display))
 }
 
@@ -2354,21 +2267,15 @@ func (c *SyncedCluster) pgurls(
 func (c *SyncedCluster) pghosts(
 	ctx context.Context, l *logger.Logger, nodes Nodes,
 ) (map[Node]string, error) {
-	ips := make([]string, len(nodes))
-	if err := c.Parallel(ctx, l, len(nodes), func(ctx context.Context, i int) (*RunResultDetails, error) {
-		node := nodes[i]
-		res := &RunResultDetails{Node: node}
-		res.Stdout, res.Err = c.GetInternalIP(node)
-		ips[i] = res.Stdout
-		return res, nil
-	}); err != nil {
-		return nil, errors.Wrapf(err, "pghosts")
+	m := make(map[Node]string, len(nodes))
+
+	for i := 0; i < len(nodes); i++ {
+		ip, err := c.GetInternalIP(nodes[i])
+		if err == nil {
+			m[nodes[i]] = ip
+		}
 	}
 
-	m := make(map[Node]string, len(ips))
-	for i, ip := range ips {
-		m[nodes[i]] = ip
-	}
 	return m, nil
 }
 
@@ -2464,16 +2371,8 @@ func scp(l *logger.Logger, src, dest string) (*RunResultDetails, error) {
 	}
 
 	res := newRunResultDetails(-1, err)
-	res.CombinedOut = out
+	res.CombinedOut = string(out)
 	return res, nil
-}
-
-// ParallelResult captures the result of a user-defined function
-// passed to Parallel or ParallelE.
-type ParallelResult struct {
-	Index int
-	Out   []byte
-	Err   error
 }
 
 type ParallelOptions struct {
@@ -2521,68 +2420,73 @@ func WithDisplay(display string) ParallelOption {
 func (c *SyncedCluster) Parallel(
 	ctx context.Context,
 	l *logger.Logger,
-	count int,
-	fn func(ctx context.Context, i int) (*RunResultDetails, error),
+	nodes Nodes,
+	fn func(ctx context.Context, n Node) (*RunResultDetails, error),
 	opts ...ParallelOption,
 ) error {
-	// failed will contain command errors if any occur.
-	// err is an unexpected roachprod error, which we return immediately.
-	failed, err := c.ParallelE(ctx, l, count, fn, opts...)
+	results, hasError, err := c.ParallelE(ctx, l, nodes, fn, opts...)
+	// `err` is an unexpected roachprod error, which we return immediately.
 	if err != nil {
 		return err
 	}
 
-	if len(failed) > 0 {
-		sort.Slice(failed, func(i, j int) bool { return failed[i].Index < failed[j].Index })
-		for _, f := range failed {
+	// `hasError` is true if any of the commands returned an error.
+	if hasError {
+		for _, r := range results {
 			// Since this function is potentially returning a single error despite
 			// having run on multiple nodes, we combine all the errors into a single
 			// error.
-			err = errors.CombineErrors(err, f.Err)
-			l.Errorf("%d: %+v: %s", f.Index, f.Err, f.Out)
+			if r != nil && r.Err != nil {
+				err = errors.CombineErrors(err, r.Err)
+				l.Errorf("%d: %+v: %s", r.Node, r.Err, r.CombinedOut)
+			}
 		}
-		return errors.Wrap(err, "one or more parallel execution failure")
+		return errors.Wrap(err, "one or more parallel execution failure(s)")
 	}
 	return nil
 }
 
-// ParallelE runs the given function in parallel across the given
-// nodes.
+type ParallelResult struct {
+	// Index is the order position in which the node was passed to Parallel.
+	// This is useful in maintaining the order of results.
+	Index int
+	*RunResultDetails
+}
+
+// ParallelE runs the given function in parallel on the specified nodes.
 //
-// By default, this will fail fast if a command error occurs on any node, in which
-// case the function will return a slice containing the erroneous result.
-//
-// If `WithWaitOnFail()` is passed in, then the function will wait for all
-// invocations to complete before returning a slice with all failed results.
+// By default, this will fail fast if a command error occurs on any node, and return
+// a slice containing all results up to that point, along with a boolean indicating
+// that at least one error occurred. If `WithWaitOnFail()` is passed in, then the function
+// will wait for all invocations to complete before returning.
 //
 // ParallelE only returns an error for roachprod itself, not any command errors run
-// on the cluster. It is up to the caller to check the slice for command errors. Any
-// such roachprod error will always be returned immediately.
+// on the cluster.
 //
-// ParallelE runs the user-defined functions on the first `count`
-// nodes in the cluster. It runs at most `concurrency` (or
-// `config.MaxConcurrency` if it is lower) in parallel. If `concurrency` is
-// 0, then it defaults to `count`.
+// ParallelE  runs at most `concurrency` (or  `config.MaxConcurrency` if it is lower) in parallel.
+// If `concurrency` is 0, then it defaults to `len(nodes)`.
 //
-// The function returns a pointer to RunResultDetails as we may enrich
+// The function returns pointers to *RunResultDetails as we may enrich
 // the result with retry information (attempt number, wrapper error).
 //
 // RunRetryOpts controls the retry behavior in the case that
 // the function fails, but returns a nil error. A non-nil error returned by the
 // function denotes a roachprod error and will not be retried regardless of the
 // retry options.
+// NB: Result order is the same as input node order
 func (c *SyncedCluster) ParallelE(
 	ctx context.Context,
 	l *logger.Logger,
-	count int,
-	fn func(ctx context.Context, i int) (*RunResultDetails, error),
+	nodes Nodes,
+	fn func(ctx context.Context, n Node) (*RunResultDetails, error),
 	opts ...ParallelOption,
-) ([]ParallelResult, error) {
+) ([]*RunResultDetails, bool, error) {
 	options := ParallelOptions{retryOpts: DefaultSSHRetryOpts}
 	for _, opt := range opts {
 		opt(&options)
 	}
 
+	count := len(nodes)
 	if options.concurrency == 0 || options.concurrency > count {
 		options.concurrency = count
 	}
@@ -2590,8 +2494,9 @@ func (c *SyncedCluster) ParallelE(
 		options.concurrency = config.MaxConcurrency
 	}
 
-	results := make(chan ParallelResult, count)
+	completed := make(chan ParallelResult, count)
 	errorChannel := make(chan error)
+
 	var wg sync.WaitGroup
 	wg.Add(count)
 
@@ -2607,12 +2512,13 @@ func (c *SyncedCluster) ParallelE(
 			defer wg.Done()
 			// This is rarely expected to return an error, but we fail fast in case.
 			// Command errors, which are far more common, will be contained within the result.
-			res, err := runWithMaybeRetry(groupCtx, l, options.retryOpts, func(ctx context.Context) (*RunResultDetails, error) { return fn(ctx, i) })
+			res, err := runWithMaybeRetry(groupCtx, l, options.retryOpts, func(ctx context.Context) (*RunResultDetails, error) { return fn(ctx, nodes[i]) })
 			if err != nil {
 				errorChannel <- err
 				return
 			}
-			results <- ParallelResult{i, res.CombinedOut, res.Err}
+			// The index is captured here so that we can maintain the order of results.
+			completed <- ParallelResult{Index: i, RunResultDetails: res}
 		}(index)
 		index++
 	}
@@ -2622,9 +2528,9 @@ func (c *SyncedCluster) ParallelE(
 	}
 
 	go func() {
+		defer close(completed)
+		defer close(errorChannel)
 		wg.Wait()
-		close(results)
-		close(errorChannel)
 	}()
 
 	var writer ui.Writer
@@ -2644,47 +2550,45 @@ func (c *SyncedCluster) ParallelE(
 		}
 	}
 	defer ticker.Stop()
-	complete := make([]bool, count)
-	var failed []ParallelResult
 
 	var spinner = []string{"|", "/", "-", "\\"}
 	spinnerIdx := 0
 
+	var hasError bool
+	n := 0
+	results := make([]*RunResultDetails, count)
 	for done := false; !done; {
 		select {
 		case <-ticker.C:
 			if config.Quiet && l.File == nil {
 				fmt.Fprintf(out, ".")
 			}
-		case r, ok := <-results:
-			if r.Err != nil { // Command error
-				failed = append(failed, r)
-				if !options.waitOnFail {
-					groupCancel()
-					return failed, nil
+		case r, ok := <-completed:
+			if ok {
+				results[r.Index] = r.RunResultDetails
+				n++
+				if r.Err != nil { // Command error
+					hasError = true
+					if !options.waitOnFail {
+						groupCancel()
+						return results, true, nil
+					}
+				}
+				if index < count {
+					startNext()
 				}
 			}
 			done = !ok
+		case err, ok := <-errorChannel: // Roachprod error
 			if ok {
-				complete[r.Index] = true
+				groupCancel()
+				return nil, false, err
 			}
-			if index < count {
-				startNext()
-			}
-		case err := <-errorChannel: // Roachprod error
-			groupCancel()
-			return nil, err
 		}
 
 		if !config.Quiet && l.File == nil {
 			fmt.Fprint(&writer, options.display)
-			var n int
-			for i := range complete {
-				if complete[i] {
-					n++
-				}
-			}
-			fmt.Fprintf(&writer, " %d/%d", n, len(complete))
+			fmt.Fprintf(&writer, " %d/%d", n, count)
 			if !done {
 				fmt.Fprintf(&writer, " %s", spinner[spinnerIdx%len(spinner)])
 			}
@@ -2698,7 +2602,7 @@ func (c *SyncedCluster) ParallelE(
 		fmt.Fprintf(out, "\n")
 	}
 
-	return failed, nil
+	return results, hasError, nil
 }
 
 // Init initializes the cluster. It does it through node 1 (as per TargetNodes)

--- a/pkg/roachprod/install/cockroach.go
+++ b/pkg/roachprod/install/cockroach.go
@@ -18,7 +18,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"sort"
 	"strings"
 	"text/template"
 
@@ -183,8 +182,7 @@ func (c *SyncedCluster) Start(ctx context.Context, l *logger.Logger, startOpts S
 	l.Printf("%s: starting nodes", c.Name)
 
 	// SSH retries are disabled by passing nil RunRetryOpts
-	if err := c.Parallel(ctx, l, len(nodes), func(ctx context.Context, nodeIdx int) (*RunResultDetails, error) {
-		node := nodes[nodeIdx]
+	if err := c.Parallel(ctx, l, nodes, func(ctx context.Context, node Node) (*RunResultDetails, error) {
 		res := &RunResultDetails{Node: node}
 		// NB: if cockroach started successfully, we ignore the output as it is
 		// some harmless start messaging.
@@ -322,16 +320,8 @@ func (c *SyncedCluster) ExecOrInteractiveSQL(
 func (c *SyncedCluster) ExecSQL(
 	ctx context.Context, l *logger.Logger, tenantName string, args []string,
 ) error {
-	type result struct {
-		node   Node
-		output string
-	}
-	resultChan := make(chan result, len(c.Nodes))
-
 	display := fmt.Sprintf("%s: executing sql", c.Name)
-	if err := c.Parallel(ctx, l, len(c.Nodes), func(ctx context.Context, nodeIdx int) (*RunResultDetails, error) {
-		node := c.Nodes[nodeIdx]
-
+	results, _, err := c.ParallelE(ctx, l, c.Nodes, func(ctx context.Context, node Node) (*RunResultDetails, error) {
 		var cmd string
 		if c.IsLocal() {
 			cmd = fmt.Sprintf(`cd %s ; `, c.localVMDir(node))
@@ -340,31 +330,15 @@ func (c *SyncedCluster) ExecSQL(
 			c.NodeURL("localhost", c.NodePort(node), tenantName) + " " +
 			ssh.Escape(args)
 
-		sess := c.newSession(l, node, cmd, withDebugName("run-sql"))
-		defer sess.Close()
+		return c.runCmdOnSingleNode(ctx, l, node, cmd, defaultCmdOpts("run-sql"))
+	}, WithDisplay(display), WithWaitOnFail())
 
-		out, cmdErr := sess.CombinedOutput(ctx)
-		res := newRunResultDetails(node, cmdErr)
-		res.CombinedOut = out
-
-		if res.Err != nil {
-			res.Err = errors.Wrapf(res.Err, "~ %s\n%s", cmd, res.CombinedOut)
-		}
-		resultChan <- result{node: node, output: string(res.CombinedOut)}
-		return res, nil
-	}, WithDisplay(display), WithWaitOnFail()); err != nil {
+	if err != nil {
 		return err
 	}
 
-	results := make([]result, 0, len(c.Nodes))
-	for range c.Nodes {
-		results = append(results, <-resultChan)
-	}
-	sort.Slice(results, func(i, j int) bool {
-		return results[i].node < results[j].node
-	})
 	for _, r := range results {
-		l.Printf("node %d:\n%s", r.node, r.output)
+		l.Printf("node %d:\n%s", r.Node, r.CombinedOut)
 	}
 
 	return nil
@@ -377,41 +351,39 @@ func (c *SyncedCluster) startNode(
 	if err != nil {
 		return "", err
 	}
-
-	if err := func() error {
-		var cmd string
-		if c.IsLocal() {
-			cmd = fmt.Sprintf(`cd %s ; `, c.localVMDir(node))
-		}
-		cmd += `cat > cockroach.sh && chmod +x cockroach.sh`
-
-		sess := c.newSession(l, node, cmd)
-		defer sess.Close()
-
-		sess.SetStdin(strings.NewReader(startCmd))
-		if out, err := sess.CombinedOutput(ctx); err != nil {
-			return errors.Wrapf(err, "failed to upload start script: %s", out)
-		}
-
-		return nil
-	}(); err != nil {
-		return "", err
-	}
-
-	var cmd string
+	var uploadCmd string
 	if c.IsLocal() {
-		cmd = fmt.Sprintf(`cd %s ; `, c.localVMDir(node))
+		uploadCmd = fmt.Sprintf(`cd %s ; `, c.localVMDir(node))
 	}
-	cmd += "./cockroach.sh"
+	uploadCmd += `cat > cockroach.sh && chmod +x cockroach.sh`
 
-	sess := c.newSession(l, node, cmd)
-	defer sess.Close()
-
-	out, err := sess.CombinedOutput(ctx)
-	if err != nil {
-		return "", errors.Wrapf(err, "~ %s\n%s", cmd, out)
+	var res = &RunResultDetails{}
+	uploadOpts := defaultCmdOpts("upload-start-script")
+	uploadOpts.stdin = strings.NewReader(startCmd)
+	res, err = c.runCmdOnSingleNode(ctx, l, node, uploadCmd, uploadOpts)
+	if err != nil || res.Err != nil {
+		out := ""
+		if res != nil {
+			out = res.CombinedOut
+		}
+		return "", errors.Wrapf(err, "failed to upload start script: %s", out)
 	}
-	return strings.TrimSpace(string(out)), nil
+
+	var runScriptCmd string
+	if c.IsLocal() {
+		runScriptCmd = fmt.Sprintf(`cd %s ; `, c.localVMDir(node))
+	}
+	runScriptCmd += "./cockroach.sh"
+	res, err = c.runCmdOnSingleNode(ctx, l, node, runScriptCmd, defaultCmdOpts("run-start-script"))
+	if err != nil || res.Err != nil {
+		out := ""
+		if res != nil {
+			out = res.CombinedOut
+		}
+		return "", errors.Wrapf(err, "~ %s\n%s", runScriptCmd, out)
+	}
+
+	return strings.TrimSpace(res.CombinedOut), nil
 }
 
 func (c *SyncedCluster) generateStartCmd(
@@ -647,15 +619,16 @@ func (c *SyncedCluster) initializeCluster(ctx context.Context, l *logger.Logger,
 	l.Printf("%s: initializing cluster\n", c.Name)
 	cmd := c.generateInitCmd(node)
 
-	sess := c.newSession(l, node, cmd, withDebugName("init-cluster"))
-	defer sess.Close()
-
-	out, err := sess.CombinedOutput(ctx)
-	if err != nil {
+	res, err := c.runCmdOnSingleNode(ctx, l, node, cmd, defaultCmdOpts("init-cluster"))
+	if err != nil || res.Err != nil {
+		out := ""
+		if res != nil {
+			out = res.CombinedOut
+		}
 		return errors.Wrapf(err, "~ %s\n%s", cmd, out)
 	}
 
-	if out := strings.TrimSpace(string(out)); out != "" {
+	if out := strings.TrimSpace(res.CombinedOut); out != "" {
 		l.Printf(out)
 	}
 	return nil
@@ -665,14 +638,16 @@ func (c *SyncedCluster) setClusterSettings(ctx context.Context, l *logger.Logger
 	l.Printf("%s: setting cluster settings", c.Name)
 	cmd := c.generateClusterSettingCmd(l, node)
 
-	sess := c.newSession(l, node, cmd, withDebugName("set-cluster-settings"))
-	defer sess.Close()
-
-	out, err := sess.CombinedOutput(ctx)
-	if err != nil {
+	res, err := c.runCmdOnSingleNode(ctx, l, node, cmd, defaultCmdOpts("set-cluster-settings"))
+	if err != nil || res.Err != nil {
+		out := ""
+		if res != nil {
+			out = res.CombinedOut
+		}
 		return errors.Wrapf(err, "~ %s\n%s", cmd, out)
 	}
-	if out := strings.TrimSpace(string(out)); out != "" {
+
+	if out := strings.TrimSpace(res.CombinedOut); out != "" {
 		l.Printf(out)
 	}
 	return nil
@@ -847,15 +822,17 @@ func (c *SyncedCluster) createFixedBackupSchedule(
 	// Instead of using `c.ExecSQL()`, use the more flexible c.newSession(), which allows us to
 	// 1) prefix the schedule backup cmd with COCKROACH_CONNECT_TIMEOUT.
 	// 2) run the command against the first node in the cluster target.
-	sess := c.newSession(l, node, fullCmd, withDebugName("init-backup-schedule"))
-	defer sess.Close()
-
-	out, err := sess.CombinedOutput(ctx)
-	if err != nil {
+	//sess := c.newSession(l, node, fullCmd, withDebugName("init-backup-schedule"))
+	res, err := c.runCmdOnSingleNode(ctx, l, node, fullCmd, defaultCmdOpts("init-backup-schedule"))
+	if err != nil || res.Err != nil {
+		out := ""
+		if res != nil {
+			out = res.CombinedOut
+		}
 		return errors.Wrapf(err, "~ %s\n%s", fullCmd, out)
 	}
 
-	if out := strings.TrimSpace(string(out)); out != "" {
+	if out := strings.TrimSpace(res.CombinedOut); out != "" {
 		l.Printf(out)
 	}
 	return nil

--- a/pkg/roachprod/install/cockroach.go
+++ b/pkg/roachprod/install/cockroach.go
@@ -183,49 +183,34 @@ func (c *SyncedCluster) Start(ctx context.Context, l *logger.Logger, startOpts S
 
 	// SSH retries are disabled by passing nil RunRetryOpts
 	if err := c.Parallel(ctx, l, nodes, func(ctx context.Context, node Node) (*RunResultDetails, error) {
-		res := &RunResultDetails{Node: node}
 		// NB: if cockroach started successfully, we ignore the output as it is
 		// some harmless start messaging.
-		if _, err := c.startNode(ctx, l, node, startOpts); err != nil {
-			res.Err = err
+		res, err := c.startNode(ctx, l, node, startOpts)
+		if err != nil || res.Err != nil {
+			// If err is non-nil, then this will not be retried, but if res.Err is non-nil, it will be.
 			return res, err
 		}
 
 		// Code that follows applies only for regular nodes.
-		if startOpts.Target != StartDefault {
-			return res, nil
-		}
-
 		// We reserve a few special operations (bootstrapping, and setting
 		// cluster settings) to the InitTarget.
-		if startOpts.GetInitTarget() != node {
+		if startOpts.Target != StartDefault || startOpts.GetInitTarget() != node || startOpts.SkipInit {
 			return res, nil
 		}
 
 		// NB: The code blocks below are not parallelized, so it's safe for us
 		// to use fmt.Printf style logging.
 
-		// 1. We don't init invoked using `--skip-init`.
-		// 2. We don't init when invoking with `start-single-node`.
-
-		if startOpts.SkipInit {
-			return res, nil
-		}
-
 		// For single node clusters, this can be skipped because during the c.StartNode call above,
 		// the `--start-single-node` flag will handle all of this for us.
 		shouldInit := !c.useStartSingleNode()
 		if shouldInit {
-			if err := c.initializeCluster(ctx, l, node); err != nil {
-				res.Err = err
-				return res, errors.Wrap(err, "failed to initialize cluster")
+			if res, err := c.initializeCluster(ctx, l, node); err != nil || res.Err != nil {
+				// If err is non-nil, then this will not be retried, but if res.Err is non-nil, it will be.
+				return res, err
 			}
 		}
-		if err := c.setClusterSettings(ctx, l, node); err != nil {
-			res.Err = err
-			return res, errors.Wrap(err, "failed to set cluster settings")
-		}
-		return res, nil
+		return c.setClusterSettings(ctx, l, node)
 	}, WithConcurrency(parallelism)); err != nil {
 		return err
 	}
@@ -346,10 +331,10 @@ func (c *SyncedCluster) ExecSQL(
 
 func (c *SyncedCluster) startNode(
 	ctx context.Context, l *logger.Logger, node Node, startOpts StartOpts,
-) (string, error) {
+) (*RunResultDetails, error) {
 	startCmd, err := c.generateStartCmd(ctx, l, node, startOpts)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	var uploadCmd string
 	if c.IsLocal() {
@@ -362,11 +347,7 @@ func (c *SyncedCluster) startNode(
 	uploadOpts.stdin = strings.NewReader(startCmd)
 	res, err = c.runCmdOnSingleNode(ctx, l, node, uploadCmd, uploadOpts)
 	if err != nil || res.Err != nil {
-		out := ""
-		if res != nil {
-			out = res.CombinedOut
-		}
-		return "", errors.Wrapf(err, "failed to upload start script: %s", out)
+		return res, err
 	}
 
 	var runScriptCmd string
@@ -374,16 +355,7 @@ func (c *SyncedCluster) startNode(
 		runScriptCmd = fmt.Sprintf(`cd %s ; `, c.localVMDir(node))
 	}
 	runScriptCmd += "./cockroach.sh"
-	res, err = c.runCmdOnSingleNode(ctx, l, node, runScriptCmd, defaultCmdOpts("run-start-script"))
-	if err != nil || res.Err != nil {
-		out := ""
-		if res != nil {
-			out = res.CombinedOut
-		}
-		return "", errors.Wrapf(err, "~ %s\n%s", runScriptCmd, out)
-	}
-
-	return strings.TrimSpace(res.CombinedOut), nil
+	return c.runCmdOnSingleNode(ctx, l, node, runScriptCmd, defaultCmdOpts("run-start-script"))
 }
 
 func (c *SyncedCluster) generateStartCmd(
@@ -615,42 +587,36 @@ func (c *SyncedCluster) maybeScaleMem(val int) int {
 	return val
 }
 
-func (c *SyncedCluster) initializeCluster(ctx context.Context, l *logger.Logger, node Node) error {
+func (c *SyncedCluster) initializeCluster(
+	ctx context.Context, l *logger.Logger, node Node,
+) (*RunResultDetails, error) {
 	l.Printf("%s: initializing cluster\n", c.Name)
 	cmd := c.generateInitCmd(node)
 
 	res, err := c.runCmdOnSingleNode(ctx, l, node, cmd, defaultCmdOpts("init-cluster"))
-	if err != nil || res.Err != nil {
-		out := ""
-		if res != nil {
-			out = res.CombinedOut
+	if res != nil {
+		out := strings.TrimSpace(res.CombinedOut)
+		if out != "" {
+			l.Printf(out)
 		}
-		return errors.Wrapf(err, "~ %s\n%s", cmd, out)
 	}
-
-	if out := strings.TrimSpace(res.CombinedOut); out != "" {
-		l.Printf(out)
-	}
-	return nil
+	return res, err
 }
 
-func (c *SyncedCluster) setClusterSettings(ctx context.Context, l *logger.Logger, node Node) error {
+func (c *SyncedCluster) setClusterSettings(
+	ctx context.Context, l *logger.Logger, node Node,
+) (*RunResultDetails, error) {
 	l.Printf("%s: setting cluster settings", c.Name)
 	cmd := c.generateClusterSettingCmd(l, node)
 
 	res, err := c.runCmdOnSingleNode(ctx, l, node, cmd, defaultCmdOpts("set-cluster-settings"))
-	if err != nil || res.Err != nil {
-		out := ""
-		if res != nil {
-			out = res.CombinedOut
+	if res != nil {
+		out := strings.TrimSpace(res.CombinedOut)
+		if out != "" {
+			l.Printf(out)
 		}
-		return errors.Wrapf(err, "~ %s\n%s", cmd, out)
 	}
-
-	if out := strings.TrimSpace(res.CombinedOut); out != "" {
-		l.Printf(out)
-	}
-	return nil
+	return res, err
 }
 
 func (c *SyncedCluster) generateClusterSettingCmd(l *logger.Logger, node Node) string {
@@ -819,10 +785,9 @@ func (c *SyncedCluster) createFixedBackupSchedule(
 	url := c.NodeURL("localhost", c.NodePort(node), "" /* tenantName */)
 	fullCmd := fmt.Sprintf(`COCKROACH_CONNECT_TIMEOUT=%d %s sql --url %s -e %q`,
 		startSQLTimeout, binary, url, createScheduleCmd)
-	// Instead of using `c.ExecSQL()`, use the more flexible c.newSession(), which allows us to
+	// Instead of using `c.ExecSQL()`, use `c.runCmdOnSingleNode()`, which allows us to
 	// 1) prefix the schedule backup cmd with COCKROACH_CONNECT_TIMEOUT.
 	// 2) run the command against the first node in the cluster target.
-	//sess := c.newSession(l, node, fullCmd, withDebugName("init-backup-schedule"))
 	res, err := c.runCmdOnSingleNode(ctx, l, node, fullCmd, defaultCmdOpts("init-backup-schedule"))
 	if err != nil || res.Err != nil {
 		out := ""

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -359,6 +359,14 @@ func List(l *logger.Logger, listMine bool, clusterNamePattern string) (cloud.Clo
 	return filteredCloud, nil
 }
 
+// TruncateString truncates a string to maxLength and adds "..." to the end.
+func TruncateString(s string, maxLength int) string {
+	if len(s) > maxLength {
+		return s[:maxLength-3] + "..."
+	}
+	return s
+}
+
 // Run runs a command on the nodes in a cluster.
 func Run(
 	ctx context.Context,
@@ -384,11 +392,7 @@ func Run(
 	}
 
 	cmd := strings.TrimSpace(strings.Join(cmdArray, " "))
-	title := cmd
-	if len(title) > 30 {
-		title = title[:27] + "..."
-	}
-	return c.Run(ctx, l, stdout, stderr, c.Nodes, title, cmd, opts...)
+	return c.Run(ctx, l, stdout, stderr, c.Nodes, TruncateString(cmd, 30), cmd, opts...)
 }
 
 // RunWithDetails runs a command on the nodes in a cluster.
@@ -414,11 +418,7 @@ func RunWithDetails(
 	}
 
 	cmd := strings.TrimSpace(strings.Join(cmdArray, " "))
-	title := cmd
-	if len(title) > 30 {
-		title = title[:27] + "..."
-	}
-	return c.RunWithDetails(ctx, l, c.Nodes, title, cmd)
+	return c.RunWithDetails(ctx, l, c.Nodes, TruncateString(cmd, 30), cmd)
 }
 
 // SQL runs `cockroach sql` on a remote cluster. If a single node is passed,


### PR DESCRIPTION
Backport 3/3 commits from #104915.

/cc @cockroachdb/release

---

This commit addresses some usability issues within roachprod/roachtest, and does some minor clean up.

Summary:

`roachprod`

- `c.Parallel` now accepts  `nodes Nodes` and `func(ctx context.Context, node Node)`. Previously, these was an `int n` representing the first `n` nodes to operate on, and `func(ctx context.Context, int n)`, where second arg would confusingly represented the index of the node being operated on, which was wholly dependent on a captured-by-reference slice at the call site.  This change makes it explicit to the caller and the function, which exact node is targeted. 

- `c.Parallel` now returns `[]*RunResultDetails, boolean, error`. The slice will contain results, successful and failed, for each node (or thus far, depending on fail-fast behaviour). The boolean is a signal to the caller that at least one of the results in the slice suffered from a command error, which can be inspected in the result itself. The `error` now more idiomatically represents an unrecoverable error encountered during `Parallel`; i.e. an un retryable error in `roachprod`. In the latter case, results will be `nil`.

- All calls to execute a remote command on a node are all funnelled to `c.runCmdOnSingleNode`, ensuring consistency, and reducing duplicated code. This function accepts a `RunCmdOptions`  struct to configure it's behaviour, including `stdin/out`

- `runCmdOnSingleNode` : in error cases, include stdout/err output (truncated after n bytes - effectively `tail`). This output will show in the `failure_n.log` and give convenient insight. Full output is always retained in the run log.

- `RunResultDetails.{Stdout,Stderr,CombinedOut}` are now all `string` to represent the most common use case, and a convenience `r.Output()` added to print out the contents of `Stderr,Stdout,CombinedOut`

- Remove complex legacy pipe processing logic from `roachtest` (`execCmd,execCmdEx`), previously used when `roachprod` was not a library of `roachtest`

- When showing the result of a command on each node on the CLI, explicitly display `<ok>` or `<err>` followed by output/error


`roachtest`

- skip post-test assertions on a test failure

- removal of `execCmd/execCmdRes` which were doing some complex pipe processing before calling roachprod.Run (not required since roachprod is a lib of roachtest)

Minor

- Clean up various redundant/unused variables
- Typos
- Command formatting

Informs: #104312 
Informs: #104316 (TBD)

Epic: none
Release note: none
Release justification: test-only change
