### PR TITLE
release-23.1: roachprod: remove references to `andrei-jepsen`

### DIFF
--- a/pkg/roachprod/k8s/roachprod-gc.yaml
+++ b/pkg/roachprod/k8s/roachprod-gc.yaml
@@ -34,7 +34,7 @@ spec:
               image: gcr.io/cockroach-dev-inf/cockroachlabs/roachprod:master
               args:
                 - gc
-                - --gce-project=cockroach-ephemeral,andrei-jepsen,cockroach-roachstress
+                - --gce-project=cockroach-ephemeral,cockroach-roachstress
                 - --slack-token
                 - $(SLACK_TOKEN)
               env:

--- a/pkg/roachprod/vm/gce/gcloud.go
+++ b/pkg/roachprod/vm/gce/gcloud.go
@@ -53,7 +53,7 @@ func DefaultProject() string {
 }
 
 // projects for which a cron GC job exists.
-var projectsWithGC = []string{defaultProject, "andrei-jepsen"}
+var projectsWithGC = []string{defaultProject}
 
 // Denotes if this provider was successfully initialized.
 var initialized = false


### PR DESCRIPTION
Backport 1/1 commits from #109147.

/cc @cockroachdb/release

---

This GCP project was deleted.

Epic: none
Release note: None
Release justification: Test-only code change
