### PR TITLE
release-22.2: roachprod: remove references to `andrei-jepsen`

### DIFF
--- a/pkg/roachprod/k8s/roachprod-gc.yaml
+++ b/pkg/roachprod/k8s/roachprod-gc.yaml
@@ -34,7 +34,7 @@ spec:
               image: gcr.io/cockroach-dev-inf/cockroachlabs/roachprod:master
               args:
                 - gc
-                - --gce-project=cockroach-ephemeral,andrei-jepsen,cockroach-roachstress
+                - --gce-project=cockroach-ephemeral,cockroach-roachstress
                 - --slack-token
                 - $(SLACK_TOKEN)
               env:

--- a/pkg/roachprod/vm/gce/gcloud.go
+++ b/pkg/roachprod/vm/gce/gcloud.go
@@ -52,7 +52,7 @@ func DefaultProject() string {
 }
 
 // projects for which a cron GC job exists.
-var projectsWithGC = []string{defaultProject, "andrei-jepsen"}
+var projectsWithGC = []string{defaultProject}
 
 // Init registers the GCE provider into vm.Providers.
 //


### PR DESCRIPTION
Backport 1/1 commits from #109147.

/cc @cockroachdb/release

---

This GCP project was deleted.

Epic: none
Release note: None
Release justification: Test-only code change
