### PR TITLE
build: update some configurations for remote build execution

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -58,7 +58,7 @@ build:cibase --lintonbuild
 # Ref: https://github.com/bazelbuild/rules_go/pull/2456
 test:cibase --test_env=GO_TEST_WRAP_TESTV=1
 # Dump all output for failed tests to the build log.
-test:cibase --test_output=errors
+test:ci --test_output=errors
 # Put all tmp artifacts in /artifacts/tmp.
 test:ci --test_tmpdir=/artifacts/tmp
 build:ci --config=cibase

--- a/pkg/base/BUILD.bazel
+++ b/pkg/base/BUILD.bazel
@@ -59,6 +59,9 @@ go_test(
     ],
     args = ["-test.timeout=55s"],
     data = glob(["testdata/**"]),
+    exec_properties = {
+        "dockerNetwork": "standard",
+    },
     deps = [
         ":base",
         "//pkg/roachpb",

--- a/pkg/ccl/cloudccl/cloudprivilege/BUILD.bazel
+++ b/pkg/ccl/cloudccl/cloudprivilege/BUILD.bazel
@@ -7,6 +7,9 @@ go_test(
         "privileges_test.go",
     ],
     args = ["-test.timeout=295s"],
+    exec_properties = {
+        "dockerNetwork": "standard",
+    },
     tags = ["ccl_test"],
     deps = [
         "//pkg/base",

--- a/pkg/ccl/cloudccl/externalconn/BUILD.bazel
+++ b/pkg/ccl/cloudccl/externalconn/BUILD.bazel
@@ -8,6 +8,9 @@ go_test(
     ],
     args = ["-test.timeout=295s"],
     data = glob(["testdata/**"]),
+    exec_properties = {
+        "dockerNetwork": "standard",
+    },
     tags = ["ccl_test"],
     deps = [
         "//pkg/base",

--- a/pkg/ccl/logictestccl/tests/3node-tenant-multiregion/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/3node-tenant-multiregion/BUILD.bazel
@@ -14,7 +14,9 @@ go_test(
         "//pkg/sql/logictest:testdata",  # keep
         "//pkg/sql/opt/exec/execbuilder:testdata",  # keep
     ],
-    exec_properties = {"Pool": "large"},
+    exec_properties = {
+        "Pool": "large",
+    },
     shard_count = 5,
     tags = [
         "ccl_test",

--- a/pkg/ccl/logictestccl/tests/3node-tenant/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/3node-tenant/BUILD.bazel
@@ -14,7 +14,9 @@ go_test(
         "//pkg/sql/logictest:testdata",  # keep
         "//pkg/sql/opt/exec/execbuilder:testdata",  # keep
     ],
-    exec_properties = {"Pool": "large"},
+    exec_properties = {
+        "Pool": "large",
+    },
     shard_count = 48,
     tags = [
         "ccl_test",

--- a/pkg/ccl/logictestccl/tests/5node/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/5node/BUILD.bazel
@@ -12,7 +12,9 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
-    exec_properties = {"Pool": "large"},
+    exec_properties = {
+        "Pool": "large",
+    },
     shard_count = 5,
     tags = [
         "ccl_test",

--- a/pkg/ccl/logictestccl/tests/fakedist-disk/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/fakedist-disk/BUILD.bazel
@@ -12,7 +12,9 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
-    exec_properties = {"Pool": "large"},
+    exec_properties = {
+        "Pool": "large",
+    },
     shard_count = 5,
     tags = [
         "ccl_test",

--- a/pkg/ccl/logictestccl/tests/fakedist-vec-off/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/fakedist-vec-off/BUILD.bazel
@@ -12,7 +12,9 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
-    exec_properties = {"Pool": "large"},
+    exec_properties = {
+        "Pool": "large",
+    },
     shard_count = 5,
     tags = [
         "ccl_test",

--- a/pkg/ccl/logictestccl/tests/fakedist/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/fakedist/BUILD.bazel
@@ -12,7 +12,9 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
-    exec_properties = {"Pool": "large"},
+    exec_properties = {
+        "Pool": "large",
+    },
     shard_count = 6,
     tags = [
         "ccl_test",

--- a/pkg/ccl/logictestccl/tests/local-legacy-schema-changer/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/local-legacy-schema-changer/BUILD.bazel
@@ -12,7 +12,9 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
-    exec_properties = {"Pool": "large"},
+    exec_properties = {
+        "Pool": "large",
+    },
     shard_count = 5,
     tags = [
         "ccl_test",

--- a/pkg/ccl/logictestccl/tests/local-mixed-22.2-23.1/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/local-mixed-22.2-23.1/BUILD.bazel
@@ -12,7 +12,9 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
-    exec_properties = {"Pool": "large"},
+    exec_properties = {
+        "Pool": "large",
+    },
     shard_count = 6,
     tags = [
         "ccl_test",

--- a/pkg/ccl/logictestccl/tests/local-vec-off/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/local-vec-off/BUILD.bazel
@@ -12,7 +12,9 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
-    exec_properties = {"Pool": "large"},
+    exec_properties = {
+        "Pool": "large",
+    },
     shard_count = 5,
     tags = [
         "ccl_test",

--- a/pkg/ccl/logictestccl/tests/local/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/local/BUILD.bazel
@@ -12,7 +12,9 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
-    exec_properties = {"Pool": "large"},
+    exec_properties = {
+        "Pool": "large",
+    },
     shard_count = 19,
     tags = [
         "ccl_test",

--- a/pkg/ccl/logictestccl/tests/multiregion-15node-5region-3azs/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/multiregion-15node-5region-3azs/BUILD.bazel
@@ -12,7 +12,9 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
-    exec_properties = {"Pool": "large"},
+    exec_properties = {
+        "Pool": "large",
+    },
     shard_count = 4,
     tags = [
         "ccl_test",

--- a/pkg/ccl/logictestccl/tests/multiregion-3node-3superlongregions/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/multiregion-3node-3superlongregions/BUILD.bazel
@@ -12,7 +12,9 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
-    exec_properties = {"Pool": "large"},
+    exec_properties = {
+        "Pool": "large",
+    },
     shard_count = 1,
     tags = [
         "ccl_test",

--- a/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs-no-los/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs-no-los/BUILD.bazel
@@ -12,7 +12,9 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
-    exec_properties = {"Pool": "large"},
+    exec_properties = {
+        "Pool": "large",
+    },
     shard_count = 19,
     tags = [
         "ccl_test",

--- a/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs-tenant/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs-tenant/BUILD.bazel
@@ -12,7 +12,9 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
-    exec_properties = {"Pool": "large"},
+    exec_properties = {
+        "Pool": "large",
+    },
     shard_count = 15,
     tags = [
         "ccl_test",

--- a/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs-vec-off/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs-vec-off/BUILD.bazel
@@ -12,7 +12,9 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
-    exec_properties = {"Pool": "large"},
+    exec_properties = {
+        "Pool": "large",
+    },
     shard_count = 8,
     tags = [
         "ccl_test",

--- a/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs/BUILD.bazel
@@ -12,7 +12,9 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
-    exec_properties = {"Pool": "large"},
+    exec_properties = {
+        "Pool": "large",
+    },
     shard_count = 26,
     tags = [
         "ccl_test",

--- a/pkg/ccl/sqlitelogictestccl/tests/3node-tenant/BUILD.bazel
+++ b/pkg/ccl/sqlitelogictestccl/tests/3node-tenant/BUILD.bazel
@@ -9,7 +9,9 @@ go_test(
         "//c-deps:libgeos",  # keep
         "@com_github_cockroachdb_sqllogictest//:testfiles",  # keep
     ],
-    exec_properties = {"Pool": "large"},
+    exec_properties = {
+        "Pool": "large",
+    },
     shard_count = 48,
     tags = [
         "ccl_test",

--- a/pkg/cloud/amazon/BUILD.bazel
+++ b/pkg/cloud/amazon/BUILD.bazel
@@ -53,6 +53,9 @@ go_test(
     ],
     args = ["-test.timeout=55s"],
     embed = [":amazon"],
+    exec_properties = {
+        "dockerNetwork": "standard",
+    },
     deps = [
         "//pkg/base",
         "//pkg/blobs",

--- a/pkg/cmd/generate-logictest/templates.go
+++ b/pkg/cmd/generate-logictest/templates.go
@@ -268,7 +268,11 @@ go_test(
         "//pkg/sql/logictest:testdata",  # keep{{ end }}{{ if .ExecBuildLogicTest }}
         "//pkg/sql/opt/exec/execbuilder:testdata",  # keep{{ end }}
     ],
-    exec_properties = {"Pool": "large"},
+    exec_properties = {{ if eq .TestRuleName "cockroach-go-testserver-upgrade-to-master" }}{
+        "dockerNetwork": "standard",
+        {{ else }}{
+        {{ end }}"Pool": "large",
+    },
     shard_count = {{ if gt .TestCount 48 }}48{{ else }}{{ .TestCount }}{{end}},
     tags = [{{ if .Ccl }}
         "ccl_test",{{ end }}

--- a/pkg/sql/logictest/tests/5node-disk/BUILD.bazel
+++ b/pkg/sql/logictest/tests/5node-disk/BUILD.bazel
@@ -12,7 +12,9 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/sql/logictest:testdata",  # keep
     ],
-    exec_properties = {"Pool": "large"},
+    exec_properties = {
+        "Pool": "large",
+    },
     shard_count = 14,
     tags = [
         "cpu:3",

--- a/pkg/sql/logictest/tests/5node/BUILD.bazel
+++ b/pkg/sql/logictest/tests/5node/BUILD.bazel
@@ -12,7 +12,9 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/sql/logictest:testdata",  # keep
     ],
-    exec_properties = {"Pool": "large"},
+    exec_properties = {
+        "Pool": "large",
+    },
     shard_count = 20,
     tags = [
         "cpu:3",

--- a/pkg/sql/logictest/tests/cockroach-go-testserver-upgrade-to-master/BUILD.bazel
+++ b/pkg/sql/logictest/tests/cockroach-go-testserver-upgrade-to-master/BUILD.bazel
@@ -13,7 +13,10 @@ go_test(
         "//pkg/cmd/cockroach-short",  # keep
         "//pkg/sql/logictest:testdata",  # keep
     ],
-    exec_properties = {"Pool": "large"},
+    exec_properties = {
+        "dockerNetwork": "standard",
+        "Pool": "large",
+    },
     shard_count = 9,
     tags = [
         "cpu:2",

--- a/pkg/sql/logictest/tests/fakedist-disk/BUILD.bazel
+++ b/pkg/sql/logictest/tests/fakedist-disk/BUILD.bazel
@@ -12,7 +12,9 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/sql/logictest:testdata",  # keep
     ],
-    exec_properties = {"Pool": "large"},
+    exec_properties = {
+        "Pool": "large",
+    },
     shard_count = 48,
     tags = [
         "cpu:2",

--- a/pkg/sql/logictest/tests/fakedist-vec-off/BUILD.bazel
+++ b/pkg/sql/logictest/tests/fakedist-vec-off/BUILD.bazel
@@ -12,7 +12,9 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/sql/logictest:testdata",  # keep
     ],
-    exec_properties = {"Pool": "large"},
+    exec_properties = {
+        "Pool": "large",
+    },
     shard_count = 48,
     tags = [
         "cpu:2",

--- a/pkg/sql/logictest/tests/fakedist/BUILD.bazel
+++ b/pkg/sql/logictest/tests/fakedist/BUILD.bazel
@@ -12,7 +12,9 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/sql/logictest:testdata",  # keep
     ],
-    exec_properties = {"Pool": "large"},
+    exec_properties = {
+        "Pool": "large",
+    },
     shard_count = 48,
     tags = [
         "cpu:2",

--- a/pkg/sql/logictest/tests/local-legacy-schema-changer/BUILD.bazel
+++ b/pkg/sql/logictest/tests/local-legacy-schema-changer/BUILD.bazel
@@ -12,7 +12,9 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/sql/logictest:testdata",  # keep
     ],
-    exec_properties = {"Pool": "large"},
+    exec_properties = {
+        "Pool": "large",
+    },
     shard_count = 48,
     tags = [
         "cpu:1",

--- a/pkg/sql/logictest/tests/local-mixed-22.2-23.1/BUILD.bazel
+++ b/pkg/sql/logictest/tests/local-mixed-22.2-23.1/BUILD.bazel
@@ -12,7 +12,9 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/sql/logictest:testdata",  # keep
     ],
-    exec_properties = {"Pool": "large"},
+    exec_properties = {
+        "Pool": "large",
+    },
     shard_count = 48,
     tags = [
         "cpu:1",

--- a/pkg/sql/logictest/tests/local-vec-off/BUILD.bazel
+++ b/pkg/sql/logictest/tests/local-vec-off/BUILD.bazel
@@ -12,7 +12,9 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/sql/logictest:testdata",  # keep
     ],
-    exec_properties = {"Pool": "large"},
+    exec_properties = {
+        "Pool": "large",
+    },
     shard_count = 48,
     tags = [
         "cpu:1",

--- a/pkg/sql/logictest/tests/local/BUILD.bazel
+++ b/pkg/sql/logictest/tests/local/BUILD.bazel
@@ -12,7 +12,9 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/sql/logictest:testdata",  # keep
     ],
-    exec_properties = {"Pool": "large"},
+    exec_properties = {
+        "Pool": "large",
+    },
     shard_count = 48,
     tags = [
         "cpu:1",

--- a/pkg/sql/logictest/tests/multiregion-9node-3region-3azs/BUILD.bazel
+++ b/pkg/sql/logictest/tests/multiregion-9node-3region-3azs/BUILD.bazel
@@ -12,7 +12,9 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/sql/logictest:testdata",  # keep
     ],
-    exec_properties = {"Pool": "large"},
+    exec_properties = {
+        "Pool": "large",
+    },
     shard_count = 1,
     tags = [
         "cpu:4",

--- a/pkg/sql/logictest/tests/multiregion-invalid-locality/BUILD.bazel
+++ b/pkg/sql/logictest/tests/multiregion-invalid-locality/BUILD.bazel
@@ -12,7 +12,9 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/sql/logictest:testdata",  # keep
     ],
-    exec_properties = {"Pool": "large"},
+    exec_properties = {
+        "Pool": "large",
+    },
     shard_count = 1,
     tags = [
         "cpu:2",

--- a/pkg/sql/opt/exec/execbuilder/tests/5node/BUILD.bazel
+++ b/pkg/sql/opt/exec/execbuilder/tests/5node/BUILD.bazel
@@ -12,7 +12,9 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/sql/opt/exec/execbuilder:testdata",  # keep
     ],
-    exec_properties = {"Pool": "large"},
+    exec_properties = {
+        "Pool": "large",
+    },
     shard_count = 29,
     tags = [
         "cpu:3",

--- a/pkg/sql/opt/exec/execbuilder/tests/fakedist-disk/BUILD.bazel
+++ b/pkg/sql/opt/exec/execbuilder/tests/fakedist-disk/BUILD.bazel
@@ -12,7 +12,9 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/sql/opt/exec/execbuilder:testdata",  # keep
     ],
-    exec_properties = {"Pool": "large"},
+    exec_properties = {
+        "Pool": "large",
+    },
     shard_count = 1,
     tags = [
         "cpu:2",

--- a/pkg/sql/opt/exec/execbuilder/tests/fakedist-vec-off/BUILD.bazel
+++ b/pkg/sql/opt/exec/execbuilder/tests/fakedist-vec-off/BUILD.bazel
@@ -12,7 +12,9 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/sql/opt/exec/execbuilder:testdata",  # keep
     ],
-    exec_properties = {"Pool": "large"},
+    exec_properties = {
+        "Pool": "large",
+    },
     shard_count = 1,
     tags = [
         "cpu:2",

--- a/pkg/sql/opt/exec/execbuilder/tests/fakedist/BUILD.bazel
+++ b/pkg/sql/opt/exec/execbuilder/tests/fakedist/BUILD.bazel
@@ -12,7 +12,9 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/sql/opt/exec/execbuilder:testdata",  # keep
     ],
-    exec_properties = {"Pool": "large"},
+    exec_properties = {
+        "Pool": "large",
+    },
     shard_count = 1,
     tags = [
         "cpu:2",

--- a/pkg/sql/opt/exec/execbuilder/tests/local-legacy-schema-changer/BUILD.bazel
+++ b/pkg/sql/opt/exec/execbuilder/tests/local-legacy-schema-changer/BUILD.bazel
@@ -12,7 +12,9 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/sql/opt/exec/execbuilder:testdata",  # keep
     ],
-    exec_properties = {"Pool": "large"},
+    exec_properties = {
+        "Pool": "large",
+    },
     shard_count = 1,
     tags = [
         "cpu:1",

--- a/pkg/sql/opt/exec/execbuilder/tests/local-mixed-22.2-23.1/BUILD.bazel
+++ b/pkg/sql/opt/exec/execbuilder/tests/local-mixed-22.2-23.1/BUILD.bazel
@@ -12,7 +12,9 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/sql/opt/exec/execbuilder:testdata",  # keep
     ],
-    exec_properties = {"Pool": "large"},
+    exec_properties = {
+        "Pool": "large",
+    },
     shard_count = 1,
     tags = [
         "cpu:1",

--- a/pkg/sql/opt/exec/execbuilder/tests/local-vec-off/BUILD.bazel
+++ b/pkg/sql/opt/exec/execbuilder/tests/local-vec-off/BUILD.bazel
@@ -12,7 +12,9 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/sql/opt/exec/execbuilder:testdata",  # keep
     ],
-    exec_properties = {"Pool": "large"},
+    exec_properties = {
+        "Pool": "large",
+    },
     shard_count = 1,
     tags = [
         "cpu:1",

--- a/pkg/sql/opt/exec/execbuilder/tests/local/BUILD.bazel
+++ b/pkg/sql/opt/exec/execbuilder/tests/local/BUILD.bazel
@@ -12,7 +12,9 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/sql/opt/exec/execbuilder:testdata",  # keep
     ],
-    exec_properties = {"Pool": "large"},
+    exec_properties = {
+        "Pool": "large",
+    },
     shard_count = 48,
     tags = [
         "cpu:1",

--- a/pkg/sql/sqlitelogictest/tests/fakedist-disk/BUILD.bazel
+++ b/pkg/sql/sqlitelogictest/tests/fakedist-disk/BUILD.bazel
@@ -9,7 +9,9 @@ go_test(
         "//c-deps:libgeos",  # keep
         "@com_github_cockroachdb_sqllogictest//:testfiles",  # keep
     ],
-    exec_properties = {"Pool": "large"},
+    exec_properties = {
+        "Pool": "large",
+    },
     shard_count = 48,
     tags = [
         "cpu:2",

--- a/pkg/sql/sqlitelogictest/tests/fakedist-vec-off/BUILD.bazel
+++ b/pkg/sql/sqlitelogictest/tests/fakedist-vec-off/BUILD.bazel
@@ -9,7 +9,9 @@ go_test(
         "//c-deps:libgeos",  # keep
         "@com_github_cockroachdb_sqllogictest//:testfiles",  # keep
     ],
-    exec_properties = {"Pool": "large"},
+    exec_properties = {
+        "Pool": "large",
+    },
     shard_count = 48,
     tags = [
         "cpu:2",

--- a/pkg/sql/sqlitelogictest/tests/fakedist/BUILD.bazel
+++ b/pkg/sql/sqlitelogictest/tests/fakedist/BUILD.bazel
@@ -9,7 +9,9 @@ go_test(
         "//c-deps:libgeos",  # keep
         "@com_github_cockroachdb_sqllogictest//:testfiles",  # keep
     ],
-    exec_properties = {"Pool": "large"},
+    exec_properties = {
+        "Pool": "large",
+    },
     shard_count = 48,
     tags = [
         "cpu:2",

--- a/pkg/sql/sqlitelogictest/tests/local-legacy-schema-changer/BUILD.bazel
+++ b/pkg/sql/sqlitelogictest/tests/local-legacy-schema-changer/BUILD.bazel
@@ -9,7 +9,9 @@ go_test(
         "//c-deps:libgeos",  # keep
         "@com_github_cockroachdb_sqllogictest//:testfiles",  # keep
     ],
-    exec_properties = {"Pool": "large"},
+    exec_properties = {
+        "Pool": "large",
+    },
     shard_count = 48,
     tags = [
         "cpu:1",

--- a/pkg/sql/sqlitelogictest/tests/local-mixed-22.2-23.1/BUILD.bazel
+++ b/pkg/sql/sqlitelogictest/tests/local-mixed-22.2-23.1/BUILD.bazel
@@ -9,7 +9,9 @@ go_test(
         "//c-deps:libgeos",  # keep
         "@com_github_cockroachdb_sqllogictest//:testfiles",  # keep
     ],
-    exec_properties = {"Pool": "large"},
+    exec_properties = {
+        "Pool": "large",
+    },
     shard_count = 48,
     tags = [
         "cpu:1",

--- a/pkg/sql/sqlitelogictest/tests/local-vec-off/BUILD.bazel
+++ b/pkg/sql/sqlitelogictest/tests/local-vec-off/BUILD.bazel
@@ -9,7 +9,9 @@ go_test(
         "//c-deps:libgeos",  # keep
         "@com_github_cockroachdb_sqllogictest//:testfiles",  # keep
     ],
-    exec_properties = {"Pool": "large"},
+    exec_properties = {
+        "Pool": "large",
+    },
     shard_count = 48,
     tags = [
         "cpu:1",

--- a/pkg/sql/sqlitelogictest/tests/local/BUILD.bazel
+++ b/pkg/sql/sqlitelogictest/tests/local/BUILD.bazel
@@ -9,7 +9,9 @@ go_test(
         "//c-deps:libgeos",  # keep
         "@com_github_cockroachdb_sqllogictest//:testfiles",  # keep
     ],
-    exec_properties = {"Pool": "large"},
+    exec_properties = {
+        "Pool": "large",
+    },
     shard_count = 48,
     tags = [
         "cpu:1",


### PR DESCRIPTION
1. Use the `large` pool of executors for `enormous` test targets
2. Add (temporary) network access to the following tests: `amazon_test`,
   `base_test`, `cloudprivilege_test`, `externalconn_test`, and
   `cockroach-go-testserver-upgrade-to-master` logictests. These
   erroneously have a dependency on network assets; bugs have been
   filed for each of these.

Epic: CRDB-8308
Release note: None