### PR TITLE
sql: version gate UNIQUE constraint with json column

### DIFF
--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -1944,6 +1944,9 @@ func NewTableDesc(
 			); err != nil {
 				return nil, err
 			}
+			if err := checkIndexColumns(&desc, d.Columns, d.Storing, d.Inverted, version); err != nil {
+				return nil, err
+			}
 			if !version.IsActive(clusterversion.V23_2_PartiallyVisibleIndexes) &&
 				d.Invisibility > 0.0 && d.Invisibility < 1.0 {
 				return nil, unimplemented.New("partially visible indexes", "partially visible indexes are not yet supported")

--- a/pkg/sql/logictest/testdata/logic_test/json_index_local_mixed
+++ b/pkg/sql/logictest/testdata/logic_test/json_index_local_mixed
@@ -1,0 +1,31 @@
+# LogicTest: local-mixed-22.2-23.1
+
+statement ok
+SET use_declarative_schema_changer = 'off'
+
+statement error pgcode 42P16 not indexable in a non-inverted index
+CREATE TABLE t (x JSONB PRIMARY KEY)
+
+statement error pgcode 42P16 not indexable in a non-inverted index
+CREATE TABLE t (x INT PRIMARY KEY, y JSON, INDEX (y ASC))
+
+statement error pgcode 42P16 not indexable in a non-inverted index
+CREATE TABLE t (x INT PRIMARY KEY, y JSON, UNIQUE (x ASC, y ASC))
+
+statement ok
+CREATE TABLE t (x JSONB)
+
+statement error pgcode 42P16 not indexable in a non-inverted index
+CREATE INDEX t_idx ON t(x)
+
+statement ok
+SET use_declarative_schema_changer = 'unsafe_always'
+
+statement error pgcode 42P16 not indexable in a non-inverted index
+CREATE TABLE t2 (x JSONB PRIMARY KEY)
+
+statement error pgcode 42P16 not indexable in a non-inverted index
+CREATE TABLE t2 (x INT PRIMARY KEY, y JSON, INDEX (y ASC))
+
+statement error pgcode 42P16 not indexable in a non-inverted index
+CREATE TABLE t2 (x INT PRIMARY KEY, y JSON, UNIQUE (x ASC, y ASC))

--- a/pkg/sql/logictest/tests/local-mixed-22.2-23.1/generated_test.go
+++ b/pkg/sql/logictest/tests/local-mixed-22.2-23.1/generated_test.go
@@ -1073,6 +1073,13 @@ func TestLogic_json_builtins(
 	runLogicTest(t, "json_builtins")
 }
 
+func TestLogic_json_index_local_mixed(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "json_index_local_mixed")
+}
+
 func TestLogic_kv_builtin_functions(
 	t *testing.T,
 ) {


### PR DESCRIPTION
This prevents the usage of a json column in a unique constraint, until after the upgrade is finalized.

fixes https://github.com/cockroachdb/cockroach/issues/108978
Release note: None