### PR TITLE
 ci,ui: don't lint `e2e-tests`

### DIFF
--- a/pkg/ui/BUILD.bazel
+++ b/pkg/ui/BUILD.bazel
@@ -38,7 +38,6 @@ test_suite(
     tests = [
         "//pkg/ui/workspaces/cluster-ui:lint",
         "//pkg/ui/workspaces/db-console:lint",
-        "//pkg/ui/workspaces/e2e-tests:lint",
     ],
 )
 


### PR DESCRIPTION
This workspace has a huge download of `cypress` which was causing
CI to flake.

Epic: none
Release note: None