### PR TITLE
storage: Make noopCloseReader support ReaderWithMustIterators

### DIFF
--- a/pkg/storage/mvcc_history_test.go
+++ b/pkg/storage/mvcc_history_test.go
@@ -2683,7 +2683,7 @@ func (i *iterWithCloser) Close() {
 
 // noopCloseReader overrides Reader.Close() with a noop.
 type noopCloseReader struct {
-	storage.Reader
+	storage.ReaderWithMustIterators
 }
 
 func (noopCloseReader) Close() {}


### PR DESCRIPTION
Prevents a panic in a cast in the MVCCIncrementalIterator creation path, which is the only path that requires a cast to ReaderWithMustIterators.

Fixes #109158.

Epic: CRDB-30807

Release note: None