### PR TITLE
ui: show warning when data is not old enough

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
@@ -98,6 +98,7 @@ import { CockroachCloudContext } from "../contexts";
 import { filterByTimeScale } from "./diagnostics/diagnosticsUtils";
 import { FormattedTimescale } from "../timeScaleDropdown/formattedTimeScale";
 import { Timestamp } from "../timestamp";
+import { TimeScaleLabel } from "src/timeScaleDropdown/timeScaleLabel";
 
 type StatementDetailsResponse =
   cockroach.server.serverpb.StatementDetailsResponse;
@@ -712,13 +713,10 @@ export class StatementDetails extends React.Component<
           </PageConfigItem>
         </PageConfig>
         <p className={timeScaleStylesCx("time-label", "label-margin")}>
-          Showing aggregated stats from{" "}
-          <span className={timeScaleStylesCx("bold")}>
-            <FormattedTimescale
-              ts={this.props.timeScale}
-              requestTime={moment(this.props.requestTime)}
-            />
-          </span>
+          <TimeScaleLabel
+            timeScale={this.props.timeScale}
+            requestTime={moment(this.props.requestTime)}
+          />
         </p>
         <section className={cx("section")}>
           <Row gutter={24}>

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.fixture.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.fixture.ts
@@ -19,8 +19,12 @@ import { StatementDiagnosticsReport } from "../api";
 import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
 import { DEFAULT_STATS_REQ_OPTIONS } from "src/api/statementsApi";
 import { mockStmtStats } from "src/api/testUtils";
+import * as protos from "@cockroachlabs/crdb-protobuf-client";
 
 const history = createMemoryHistory({ initialEntries: ["/statements"] });
+const timestamp = new protos.google.protobuf.Timestamp({
+  seconds: new Long(Date.parse("Sep 15 2021 01:00:00 GMT") * 1e-3),
+});
 
 const diagnosticsReports: StatementDiagnosticsReport[] = [
   {
@@ -382,6 +386,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
   hasViewActivityRedactedRole: false,
   hasAdminRole: true,
   statementDiagnostics: [],
+  oldestDataAvailable: timestamp,
   dismissAlertMessage: noop,
   refreshDatabases: noop,
   refreshStatementDiagnosticsRequests: noop,

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
@@ -32,7 +32,7 @@ import {
   updateFiltersQueryParamsOnTab,
 } from "../queryFilter";
 
-import { syncHistory, unique } from "src/util";
+import { Timestamp, TimestampToMoment, syncHistory, unique } from "src/util";
 import {
   AggregateStatistics,
   makeStatementsColumns,
@@ -95,7 +95,7 @@ import {
 import { SearchCriteria } from "src/searchCriteria/searchCriteria";
 import timeScaleStyles from "../timeScaleDropdown/timeScale.module.scss";
 import { RequestState } from "src/api/types";
-import { FormattedTimescale } from "../timeScaleDropdown/formattedTimeScale";
+import { TimeScaleLabel } from "src/timeScaleDropdown/timeScaleLabel";
 
 const cx = classNames.bind(styles);
 const sortableTableCx = classNames.bind(sortableTableStyles);
@@ -154,6 +154,7 @@ export interface StatementsPageStateProps {
   stmtsTotalRuntimeSecs: number;
   statementDiagnostics: StatementDiagnosticsResponse | null;
   requestTime: moment.Moment;
+  oldestDataAvailable: Timestamp;
 }
 
 export interface StatementsPageState {
@@ -586,12 +587,6 @@ export class StatementsPage extends React.Component<
       isSelectedColumn(userSelectedColumnsToShow, c),
     );
 
-    const period = (
-      <FormattedTimescale
-        ts={this.props.timeScale}
-        requestTime={moment(this.props.requestTime)}
-      />
-    );
     const sortSettingLabel = getSortLabel(
       this.props.reqSortSetting,
       "Statement",
@@ -641,8 +636,14 @@ export class StatementsPage extends React.Component<
           <PageConfig className={cx("float-right")}>
             <PageConfigItem>
               <p className={timeScaleStylesCx("time-label")}>
-                Showing aggregated stats from{" "}
-                <span className={timeScaleStylesCx("bold")}>{period}</span>
+                <TimeScaleLabel
+                  timeScale={this.props.timeScale}
+                  requestTime={moment(this.props.requestTime)}
+                  oldestDataTime={
+                    this.props.oldestDataAvailable &&
+                    TimestampToMoment(this.props.oldestDataAvailable)
+                  }
+                />
                 {", "}
                 <ResultsPerPageLabel
                   pagination={{ ...pagination, total: data.length }}

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPageConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPageConnected.tsx
@@ -103,6 +103,8 @@ export const ConnectedStatementsPage = withRouter(
           state.adminUI?.statements?.data?.stmts_total_runtime_secs ?? 0,
         statementsResponse: state.adminUI.statements,
         statementDiagnostics: state.adminUI.statementDiagnostics?.data,
+        oldestDataAvailable:
+          state.adminUI?.statements?.data?.oldest_aggregated_ts_returned,
       },
       activePageProps: mapStateToActiveStatementsPageProps(state),
     }),

--- a/pkg/ui/workspaces/cluster-ui/src/tableStatistics/tableStatistics.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/tableStatistics/tableStatistics.tsx
@@ -15,6 +15,9 @@ import { Button } from "src/button";
 import { ResultsPerPageLabel } from "src/pagination";
 import classNames from "classnames/bind";
 import timeScaleStyles from "../timeScaleDropdown/timeScale.module.scss";
+import { TimeScaleLabel } from "src/timeScaleDropdown/timeScaleLabel";
+import { TimeScale } from "src/timeScaleDropdown";
+import moment from "moment-timezone";
 
 const { statistic, countTitle } = statisticsClasses;
 const timeScaleStylesCx = classNames.bind(timeScaleStyles);
@@ -26,7 +29,8 @@ interface TableStatistics {
   activeFilters: number;
   search?: string;
   onClearFilters?: () => void;
-  period?: string;
+  timeScale?: TimeScale;
+  requestTime?: moment.Moment;
 }
 
 // TableStatistics shows statistics about the results being
@@ -41,14 +45,14 @@ export const TableStatistics: React.FC<TableStatistics> = ({
   arrayItemName,
   onClearFilters,
   activeFilters,
-  period,
+  timeScale,
+  requestTime,
 }) => {
-  const periodLabel = (
+  const periodLabel = timeScale && requestTime && (
     <>
       &nbsp;&nbsp;&nbsp;| &nbsp;
       <p className={timeScaleStylesCx("time-label")}>
-        Showing aggregated stats from{" "}
-        <span className={timeScaleStylesCx("bold")}>{period}</span>
+        <TimeScaleLabel timeScale={timeScale} requestTime={requestTime} />
       </p>
     </>
   );
@@ -60,7 +64,7 @@ export const TableStatistics: React.FC<TableStatistics> = ({
         pageName={arrayItemName}
         search={search}
       />
-      {period && periodLabel}
+      {periodLabel}
     </>
   );
 
@@ -76,7 +80,7 @@ export const TableStatistics: React.FC<TableStatistics> = ({
   const resultsCountAndClear = (
     <>
       {totalCount} {totalCount === 1 ? "result" : "results"}
-      {period && periodLabel}
+      {periodLabel}
       &nbsp;&nbsp;&nbsp;{onClearFilters && clearBtn}
     </>
   );

--- a/pkg/ui/workspaces/cluster-ui/src/timeScaleDropdown/timeScale.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/timeScaleDropdown/timeScale.module.scss
@@ -37,6 +37,10 @@
     font-family: $font-family--bold;
     color: $colors--neutral-7;
   }
+  .warning-icon-area {
+    margin-bottom: -3px;
+    margin-right: 2px;
+  }
 }
 
 .label-margin {

--- a/pkg/ui/workspaces/cluster-ui/src/timeScaleDropdown/timeScaleLabel.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/timeScaleDropdown/timeScaleLabel.tsx
@@ -1,0 +1,77 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React, { useContext } from "react";
+import moment from "moment-timezone";
+import { TimeScale } from "./timeScaleTypes";
+import { FormattedTimescale } from "./formattedTimeScale";
+import classNames from "classnames/bind";
+import timeScaleStyles from "../timeScaleDropdown/timeScale.module.scss";
+import { Icon } from "@cockroachlabs/ui-components";
+import { Tooltip } from "antd";
+import "antd/lib/tooltip/style";
+import { Timezone } from "src/timestamp";
+import { dateFormat, timeFormat } from "./timeScaleDropdown";
+import { TimezoneContext } from "src/contexts/timezoneContext";
+import { toRoundedDateRange } from "./utils";
+
+const timeScaleStylesCx = classNames.bind(timeScaleStyles);
+
+interface TimeScaleLabelProps {
+  timeScale: TimeScale;
+  requestTime: moment.Moment;
+  oldestDataTime?: moment.Moment;
+}
+
+export const TimeScaleLabel: React.FC<TimeScaleLabelProps> = ({
+  timeScale,
+  requestTime,
+  oldestDataTime,
+}): React.ReactElement => {
+  const period = (
+    <FormattedTimescale ts={timeScale} requestTime={moment(requestTime)} />
+  );
+  const label = (
+    <>
+      Showing aggregated stats from{" "}
+      <span className={timeScaleStylesCx("bold")}>{period}</span>
+    </>
+  );
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const [start, _] = toRoundedDateRange(timeScale);
+  const showWarning = oldestDataTime && oldestDataTime.diff(start, "hours") > 1;
+  const timezone = useContext(TimezoneContext);
+  const oldestTz = moment(oldestDataTime)?.tz(timezone);
+  const oldestLabel = (
+    <>
+      {`SQL Stats are available since ${oldestTz?.format(
+        dateFormat,
+      )} ${oldestTz?.format(timeFormat)} `}
+      <Timezone />
+    </>
+  );
+
+  const warning = (
+    <Tooltip placement="bottom" title={oldestLabel}>
+      <Icon
+        iconName="Caution"
+        fill="warning"
+        className={timeScaleStylesCx("warning-icon-area")}
+      />
+    </Tooltip>
+  );
+
+  return (
+    <>
+      {showWarning && warning} {label}
+    </>
+  );
+};

--- a/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetails.tsx
@@ -88,12 +88,12 @@ import {
 } from "../insightsTable/insightsTable";
 import { CockroachCloudContext } from "../contexts";
 import { SqlStatsSortType } from "src/api/statementsApi";
-import { FormattedTimescale } from "../timeScaleDropdown/formattedTimeScale";
 import {
   getStatementsForTransaction,
   getTxnFromSqlStatsMemoized,
   getTxnQueryString,
 } from "./transactionDetailsUtils";
+import { TimeScaleLabel } from "src/timeScaleDropdown/timeScaleLabel";
 const { containerClass } = tableClasses;
 const cx = classNames.bind(statementsStyles);
 const timeScaleStylesCx = classNames.bind(timeScaleStyles);
@@ -289,12 +289,6 @@ export class TransactionDetails extends React.Component<
     const error = this.props.txnStatsResp?.error;
     const { latestTransactionText, statements } = this.state;
     const transactionStats = transaction?.stats_data?.stats;
-    const period = (
-      <FormattedTimescale
-        ts={this.props.timeScale}
-        requestTime={moment(this.props.requestTime)}
-      />
-    );
 
     return (
       <div>
@@ -324,8 +318,10 @@ export class TransactionDetails extends React.Component<
         <p
           className={timeScaleStylesCx("time-label", "label-no-margin-bottom")}
         >
-          Showing aggregated stats from{" "}
-          <span className={timeScaleStylesCx("bold")}>{period}</span>
+          <TimeScaleLabel
+            timeScale={this.props.timeScale}
+            requestTime={moment(this.props.requestTime)}
+          />
         </p>
         <Loading
           error={error}

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.stories.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.stories.tsx
@@ -22,6 +22,7 @@ import {
   routeProps,
   sortSetting,
   timeScale,
+  timestamp,
 } from "./transactions.fixture";
 
 import { TransactionsPage } from ".";
@@ -62,6 +63,7 @@ storiesOf("Transactions Page", module)
         filters={filters}
         nodeRegions={nodeRegions}
         hasAdminRole={true}
+        oldestDataAvailable={timestamp}
         onFilterChange={noop}
         onSortingChange={noop}
         refreshData={noop}
@@ -94,6 +96,7 @@ storiesOf("Transactions Page", module)
         filters={filters}
         nodeRegions={nodeRegions}
         hasAdminRole={true}
+        oldestDataAvailable={timestamp}
         onFilterChange={noop}
         onSortingChange={noop}
         refreshData={noop}
@@ -133,6 +136,7 @@ storiesOf("Transactions Page", module)
         history={history}
         nodeRegions={nodeRegions}
         hasAdminRole={true}
+        oldestDataAvailable={timestamp}
         onFilterChange={noop}
         onSortingChange={noop}
         refreshData={noop}
@@ -165,6 +169,7 @@ storiesOf("Transactions Page", module)
         filters={filters}
         nodeRegions={nodeRegions}
         hasAdminRole={true}
+        oldestDataAvailable={timestamp}
         onFilterChange={noop}
         onSortingChange={noop}
         refreshData={noop}
@@ -201,6 +206,7 @@ storiesOf("Transactions Page", module)
         filters={filters}
         nodeRegions={nodeRegions}
         hasAdminRole={true}
+        oldestDataAvailable={timestamp}
         onFilterChange={noop}
         onSortingChange={noop}
         refreshData={noop}

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
@@ -33,7 +33,7 @@ import {
   filterTransactions,
 } from "./utils";
 import { flatMap, merge } from "lodash";
-import { unique, syncHistory } from "src/util";
+import { Timestamp, TimestampToMoment, syncHistory, unique } from "src/util";
 import { EmptyTransactionsPlaceholder } from "./emptyTransactionsPlaceholder";
 import { Loading } from "../loading";
 import { Delayed } from "../delayed";
@@ -82,9 +82,9 @@ import {
 } from "src/util/sqlActivityConstants";
 import { SearchCriteria } from "src/searchCriteria/searchCriteria";
 import timeScaleStyles from "../timeScaleDropdown/timeScale.module.scss";
-import { FormattedTimescale } from "../timeScaleDropdown/formattedTimeScale";
 import { RequestState } from "../api";
 import moment from "moment-timezone";
+import { TimeScaleLabel } from "src/timeScaleDropdown/timeScaleLabel";
 
 const cx = classNames.bind(styles);
 const timeScaleStylesCx = classNames.bind(timeScaleStyles);
@@ -110,6 +110,7 @@ export interface TransactionsPageStateProps {
   sortSetting: SortSetting;
   hasAdminRole?: UIConfigState["hasAdminRole"];
   requestTime: moment.Moment;
+  oldestDataAvailable: Timestamp;
 }
 
 export interface TransactionsPageDispatchProps {
@@ -535,12 +536,6 @@ export class TransactionsPage extends React.Component<
       isSelectedColumn(userSelectedColumnsToShow, c),
     );
 
-    const period = (
-      <FormattedTimescale
-        ts={this.props.timeScale}
-        requestTime={moment(this.props.requestTime)}
-      />
-    );
     const sortSettingLabel = getSortLabel(
       this.props.reqSortSetting,
       "Transaction",
@@ -587,8 +582,14 @@ export class TransactionsPage extends React.Component<
           <PageConfig className={cx("float-right")}>
             <PageConfigItem>
               <p className={timeScaleStylesCx("time-label")}>
-                Showing aggregated stats from{" "}
-                <span className={timeScaleStylesCx("bold")}>{period}</span>
+                <TimeScaleLabel
+                  timeScale={this.props.timeScale}
+                  requestTime={moment(this.props.requestTime)}
+                  oldestDataTime={
+                    this.props.oldestDataAvailable &&
+                    TimestampToMoment(this.props.oldestDataAvailable)
+                  }
+                />
                 {", "}
                 <ResultsPerPageLabel
                   pagination={{

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPageConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPageConnected.tsx
@@ -88,6 +88,8 @@ export const TransactionsPageConnected = withRouter(
         limit: selectTxnsPageLimit(state),
         reqSortSetting: selectTxnsPageReqSort(state),
         requestTime: selectRequestTime(state),
+        oldestDataAvailable:
+          state.adminUI?.transactions?.data?.oldest_aggregated_ts_returned,
       },
       activePageProps: mapStateToActiveTransactionsPageProps(state),
     }),

--- a/pkg/ui/workspaces/cluster-ui/src/util/convert.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/convert.ts
@@ -12,7 +12,7 @@ import moment from "moment-timezone";
 import * as protos from "@cockroachlabs/crdb-protobuf-client";
 import { fromNumber } from "long";
 
-type Timestamp = protos.google.protobuf.ITimestamp;
+export type Timestamp = protos.google.protobuf.ITimestamp;
 
 export const minDate = moment.utc("0001-01-01"); // minimum value as per UTC.
 

--- a/pkg/ui/workspaces/db-console/src/views/statements/statementsPage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/statements/statementsPage.tsx
@@ -247,6 +247,8 @@ export default withRouter(
           state.cachedData?.statements?.data?.stmts_total_runtime_secs ?? 0,
         statementsResponse: selectStatements(state),
         statementDiagnostics: selectStatementDiagnostics(state)?.data,
+        oldestDataAvailable:
+          state.cachedData?.statements?.data?.oldest_aggregated_ts_returned,
       },
       activePageProps: mapStateToActiveStatementViewProps(state),
     }),

--- a/pkg/ui/workspaces/db-console/src/views/transactions/transactionsPage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/transactions/transactionsPage.tsx
@@ -61,6 +61,13 @@ export const selectLastReset = createSelector(
   },
 );
 
+const selectOldestDate = createSelector(
+  (state: AdminUIState) => state.cachedData.transactions,
+  (txns: CachedDataReducerState<StatementsResponseMessage>) => {
+    return txns?.data?.oldest_aggregated_ts_returned;
+  },
+);
+
 export const sortSettingLocalSetting = new LocalSetting(
   "sortSetting/TransactionsPage",
   (state: AdminUIState) => state.localSettings,
@@ -169,6 +176,7 @@ const TransactionsPageConnected = withRouter(
         limit: limitSetting.selector(state),
         reqSortSetting: reqSortSetting.selector(state),
         requestTime: requestTimeLocalSetting.selector(state),
+        oldestDataAvailable: selectOldestDate(state),
       },
       activePageProps: mapStateToActiveTransactionsPageProps(state),
     }),


### PR DESCRIPTION
If a user selects a time period that we don't have the data for it (because it was already cleaned),
we show a warning to indicate the data might not be complete.

Fix #108989

<img width="334" alt="Screenshot 2023-08-23 at 5 30 18 PM" src="https://github.com/cockroachdb/cockroach/assets/1017486/ed9d9768-c4b4-456f-b5ce-0156bbfd9d4f">



https://www.loom.com/share/a7e0b0738d834bb0b6f38a9da43fb6a4


Release note (ui change): Show warning when time period selected on SQL Activity is older than the oldest data available.