### PR TITLE
build: more resources for building AWS dependency

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -488,6 +488,10 @@ def go_deps():
         name = "com_github_aws_aws_sdk_go_v2_service_ec2",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/aws/aws-sdk-go-v2/service/ec2",
+        patch_args = ["-p1"],
+        patches = [
+            "@com_github_cockroachdb_cockroach//build/patches:com_github_aws_aws_sdk_go_v2_service_ec2.patch",
+        ],
         sha256 = "b24b82535334bd7716000ba1af24acc03fcbbcb8817b8e229e9368c1fbbe6c3e",
         strip_prefix = "github.com/aws/aws-sdk-go-v2/service/ec2@v1.34.0",
         urls = [

--- a/build/patches/com_github_aws_aws_sdk_go_v2_service_ec2.patch
+++ b/build/patches/com_github_aws_aws_sdk_go_v2_service_ec2.patch
@@ -1,0 +1,11 @@
+diff -urN a/BUILD.bazel b/BUILD.bazel
+--- a/BUILD.bazel
++++ b/BUILD.bazel
+@@ -533,6 +533,7 @@
+         "serializers.go",
+         "validators.go",
+     ],
++    exec_properties = { "Pool": "large" },
+     importpath = "github.com/aws/aws-sdk-go-v2/service/ec2",
+     visibility = ["//visibility:public"],
+     deps = [


### PR DESCRIPTION
This is a huge package with apparently a lot of auto-generated code that was causing OOM's on EngFlow RBE. This fixes it.

Epic: none
Release note: CRDB-8308