### PR TITLE
changefeedccl: restart when memory limit changes

### DIFF
--- a/pkg/ccl/changefeedccl/testing_knobs.go
+++ b/pkg/ccl/changefeedccl/testing_knobs.go
@@ -77,6 +77,9 @@ type TestingKnobs struct {
 
 	// OnDrain returns the channel to select on to detect node drain
 	OnDrain func() <-chan struct{}
+
+	// AggregatorStarted is called when `(*changeAggregator) Start` completes.
+	AggregatorStarted func(memLimit int64)
 }
 
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.


### PR DESCRIPTION
Previously, changing `changefeed.memory.per_changefeed_limit` would require restarting a changefeed for the setting to take effect.

This change makes it so that when the changefeed coordinator detects a change in memory limits, it restarts all the aggregators using a retryable error.

Release note: None
Informs: https://github.com/cockroachdb/cockroach/issues/96953
Epic: None