### PR TITLE
roachtest: remove healthchecker from DR tests

### DIFF
--- a/pkg/cmd/roachtest/tests/cluster_to_cluster.go
+++ b/pkg/cmd/roachtest/tests/cluster_to_cluster.go
@@ -832,7 +832,14 @@ func runAcceptanceClusterReplication(ctx context.Context, t test.Test, c cluster
 	}
 	rd := makeReplicationDriver(t, c, sp)
 	rd.setupC2C(ctx, t, c)
-	rd.main(ctx)
+
+	// Spin up a monitor to capture any node deaths.
+	m := rd.newMonitor(ctx)
+	m.Go(func(ctx context.Context) error {
+		rd.main(ctx)
+		return nil
+	})
+	m.Wait()
 }
 
 func registerClusterToCluster(r registry.Registry) {
@@ -929,18 +936,13 @@ func registerClusterToCluster(r registry.Registry) {
 			func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				rd := makeReplicationDriver(t, c, sp)
 				rd.setupC2C(ctx, t, c)
+				// Spin up a monitor to capture any node deaths.
 				m := rd.newMonitor(ctx)
-
-				hc := roachtestutil.NewHealthChecker(t, c, rd.crdbNodes())
 				m.Go(func(ctx context.Context) error {
-					require.NoError(t, hc.Runner(ctx))
+					rd.main(ctx)
 					return nil
 				})
-				defer func() {
-					hc.Done()
-					m.Wait()
-				}()
-				rd.main(ctx)
+				m.Wait()
 			})
 	}
 }

--- a/pkg/cmd/roachtest/tests/restore.go
+++ b/pkg/cmd/roachtest/tests/restore.go
@@ -135,8 +135,6 @@ func registerRestore(r registry.Registry) {
 			m := c.NewMonitor(ctx)
 			dul := roachtestutil.NewDiskUsageLogger(t, c)
 			m.Go(dul.Runner)
-			hc := roachtestutil.NewHealthChecker(t, c, c.All())
-			m.Go(hc.Runner)
 
 			jobIDCh := make(chan jobspb.JobID)
 			jobCompleteCh := make(chan struct{}, 1)
@@ -210,7 +208,6 @@ func registerRestore(r registry.Registry) {
 
 			m.Go(func(ctx context.Context) error {
 				defer dul.Done()
-				defer hc.Done()
 				defer close(jobCompleteCh)
 				defer close(jobIDCh)
 				t.Status(`running restore`)
@@ -414,12 +411,8 @@ func registerRestore(r registry.Registry) {
 				m := c.NewMonitor(ctx)
 				dul := roachtestutil.NewDiskUsageLogger(t, c)
 				m.Go(dul.Runner)
-				hc := roachtestutil.NewHealthChecker(t, c, c.All())
-				m.Go(hc.Runner)
-
 				m.Go(func(ctx context.Context) error {
 					defer dul.Done()
-					defer hc.Done()
 					t.Status(`running setup statements`)
 					db, err := rd.c.ConnE(ctx, rd.t.L(), rd.c.Node(1)[0])
 					if err != nil {


### PR DESCRIPTION
The healthchecker utility adds little coverage beyond a roachtest monitor and
has been a frequent cause of connection timeout errors (roachtest flakes), as
it opens a new sql connection every five seconds during the test.

Informs https://github.com/cockroachdb/cockroach/issues/109027
Informs https://github.com/cockroachdb/cockroach/issues/109023

Epic: none