### PR TITLE
bazci/githubpost: allow C-Test-Failure to be disabled by CI config

### DIFF
--- a/pkg/cmd/bazci/githubpost/githubpost.go
+++ b/pkg/cmd/bazci/githubpost/githubpost.go
@@ -78,14 +78,15 @@ func defaultFormatter(ctx context.Context, f failure) (issues.IssueFormatter, is
 		}
 	}
 	return issues.UnitTestFormatter, issues.PostRequest{
-		TestName:        f.testName,
-		PackageName:     f.packageName,
-		Message:         f.testMessage,
-		Artifacts:       "/", // best we can do for unit tests
-		HelpCommand:     issues.UnitTestHelpCommand(repro),
-		MentionOnCreate: mentions,
-		ProjectColumnID: projColID,
-		ExtraLabels:     extraLabels,
+		TestName:             f.testName,
+		PackageName:          f.packageName,
+		Message:              f.testMessage,
+		Artifacts:            "/", // best we can do for unit tests
+		HelpCommand:          issues.UnitTestHelpCommand(repro),
+		MentionOnCreate:      mentions,
+		ProjectColumnID:      projColID,
+		ExtraLabels:          extraLabels,
+		SkipLabelTestFailure: os.Getenv("SKIP_LABEL_TEST_FAILURE") != "",
 	}
 }
 


### PR DESCRIPTION
    This commit teaches the GitHub issue logger to respect the new
    `SKIP_LABEL_TEST_FAILURE` environment variable. Setting this envvar to
    any non-zero string value will set `SkipLabelTestFailure` to true, which
    causes the logger to not set the `C-Test-Failure` but continue to log
    failures on aggregate issues.

    Doing so allows us to continue logging the behavioral divergences
    discovered by `TestComposeCompare` without treating them as strict test
    failures.

    The environment variable is intentionally applied to all failures within
    a given CI configuration rather than on a test name basis. This should
    incentivize relegation of high failure tests to isolated CI builds and
    set an appropriate threshold for when a test may be excluded from being
    considered a failure.

Informs: #99181, #89361, #108652, #82867
Release note: None
