### PR TITLE
ui: fix metrics page when viewing a tenant with hyphenated name

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/index.tsx
@@ -328,7 +328,7 @@ export class NodeGraphs extends React.Component<
     const nodeSources = selectedNode !== "" ? [selectedNode] : null;
     const selectedTenant = isSystemTenant(currentTenant)
       ? getMatchParamByName(match, tenantNameAttr) || ""
-      : currentTenant;
+      : undefined;
     // When "all" is the selected source, some graphs display a line for every
     // node in the cluster using the nodeIDs collection. However, if a specific
     // node is already selected, these per-node graphs should only display data


### PR DESCRIPTION
This PR fixes an issue where no metrics would load in when a tenant had a hyphenated name. This was due to trying to use the `Long.fromString()` conversion on a string with a hyphen which it doesn't support. The logic was incorrect for this case anyway so instead a new function `determineTenantID` is introduced which will set the `tenant_id` to `undefined` in this case since we don't need to pass `tenant_id` when switching to a non-system tenant in global context.

Fixes: #109124

Release note (bug fix): fixed an issue on the metrics page where no metrics would load when viewing the non-system tenant in a global context when the tenant name was hyphenated.

<img width="1422" alt="Screenshot 2023-08-21 at 3 33 31 PM" src="https://github.com/cockroachdb/cockroach/assets/17861665/962ffacb-8763-4b5d-9257-c7e3982f7bd5">
