### PR TITLE
bazel: remove `no-remote-exec` tag from tests

### DIFF
--- a/pkg/col/coldata/BUILD.bazel
+++ b/pkg/col/coldata/BUILD.bazel
@@ -42,7 +42,6 @@ go_test(
     ],
     args = ["-test.timeout=55s"],
     embed = [":coldata"],
-    tags = ["no-remote-exec"],  # keep
     deps = [
         "//pkg/col/coldatatestutils",
         "//pkg/sql/colconv",

--- a/pkg/kv/kvclient/kvcoord/BUILD.bazel
+++ b/pkg/kv/kvclient/kvcoord/BUILD.bazel
@@ -153,7 +153,6 @@ go_test(
     data = glob(["testdata/**"]),
     embed = [":kvcoord"],
     shard_count = 16,
-    tags = ["no-remote-exec"],
     deps = [
         "//build/bazelutil:noop",
         "//pkg/base",

--- a/pkg/roachpb/BUILD.bazel
+++ b/pkg/roachpb/BUILD.bazel
@@ -70,7 +70,6 @@ go_test(
     ],
     args = ["-test.timeout=55s"],
     embed = [":roachpb"],
-    tags = ["no-remote-exec"],
     deps = [
         "//pkg/cli/exit",
         "//pkg/keys",

--- a/pkg/server/diagnostics/BUILD.bazel
+++ b/pkg/server/diagnostics/BUILD.bazel
@@ -59,7 +59,6 @@ go_test(
     ],
     args = ["-test.timeout=295s"],
     embed = [":diagnostics"],
-    tags = ["no-remote-exec"],
     deps = [
         "//pkg/base",
         "//pkg/build",

--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -737,7 +737,6 @@ go_test(
     embed = [":sql"],
     exec_properties = {"Pool": "large"},
     shard_count = 16,
-    tags = ["no-remote-exec"],
     deps = [
         "//pkg/base",
         "//pkg/build/bazel",

--- a/pkg/sql/catalog/BUILD.bazel
+++ b/pkg/sql/catalog/BUILD.bazel
@@ -60,7 +60,6 @@ go_test(
     ],
     args = ["-test.timeout=55s"],
     embed = [":catalog"],
-    tags = ["no-remote-exec"],
     deps = [
         "//pkg/sql/catalog/colinfo",
         "//pkg/sql/catalog/dbdesc",

--- a/pkg/sql/colexec/colexecbase/BUILD.bazel
+++ b/pkg/sql/colexec/colexecbase/BUILD.bazel
@@ -54,7 +54,6 @@ go_test(
         "simple_project_test.go",
     ],
     args = ["-test.timeout=295s"],
-    tags = ["no-remote-exec"],
     deps = [
         ":colexecbase",
         "//pkg/col/coldata",

--- a/pkg/sql/colexec/colexechash/BUILD.bazel
+++ b/pkg/sql/colexec/colexechash/BUILD.bazel
@@ -39,7 +39,6 @@ go_test(
     ],
     args = ["-test.timeout=295s"],
     embed = [":colexechash"],
-    tags = ["no-remote-exec"],
     deps = [
         "//pkg/col/coldata",
         "//pkg/col/coldataext",

--- a/pkg/sql/colexec/colexecjoin/BUILD.bazel
+++ b/pkg/sql/colexec/colexecjoin/BUILD.bazel
@@ -49,7 +49,6 @@ go_test(
     ],
     args = ["-test.timeout=295s"],
     embed = [":colexecjoin"],
-    tags = ["no-remote-exec"],
     deps = [
         "//pkg/col/coldata",
         "//pkg/col/coldataext",

--- a/pkg/sql/colexec/colexecproj/BUILD.bazel
+++ b/pkg/sql/colexec/colexecproj/BUILD.bazel
@@ -46,7 +46,6 @@ go_test(
     ],
     args = ["-test.timeout=295s"],
     embed = [":colexecproj"],  # keep
-    tags = ["no-remote-exec"],
     deps = [
         "//pkg/col/coldata",
         "//pkg/col/coldataext",

--- a/pkg/sql/colexec/colexecsel/BUILD.bazel
+++ b/pkg/sql/colexec/colexecsel/BUILD.bazel
@@ -40,7 +40,6 @@ go_test(
     ],
     args = ["-test.timeout=295s"],
     embed = [":colexecsel"],
-    tags = ["no-remote-exec"],
     deps = [
         "//pkg/col/coldata",
         "//pkg/col/coldataext",

--- a/pkg/sql/colexec/colexecspan/BUILD.bazel
+++ b/pkg/sql/colexec/colexecspan/BUILD.bazel
@@ -43,7 +43,6 @@ go_test(
     ],
     args = ["-test.timeout=295s"],
     embed = [":colexecspan"],  # keep
-    tags = ["no-remote-exec"],
     deps = [
         "//pkg/col/coldata",
         "//pkg/col/coldataext",

--- a/pkg/sql/colexec/colexecutils/BUILD.bazel
+++ b/pkg/sql/colexec/colexecutils/BUILD.bazel
@@ -51,7 +51,6 @@ go_test(
     ],
     args = ["-test.timeout=295s"],
     embed = [":colexecutils"],
-    tags = ["no-remote-exec"],
     deps = [
         "//pkg/col/coldata",
         "//pkg/col/coldataext",

--- a/pkg/sql/colexec/colexecwindow/BUILD.bazel
+++ b/pkg/sql/colexec/colexecwindow/BUILD.bazel
@@ -57,7 +57,6 @@ go_test(
     ],
     args = ["-test.timeout=295s"],
     embed = [":colexecwindow"],
-    tags = ["no-remote-exec"],
     deps = [
         "//pkg/col/coldata",
         "//pkg/col/coldataext",

--- a/pkg/sql/colflow/BUILD.bazel
+++ b/pkg/sql/colflow/BUILD.bazel
@@ -83,7 +83,6 @@ go_test(
     ],
     args = ["-test.timeout=295s"],
     embed = [":colflow"],
-    tags = ["no-remote-exec"],
     deps = [
         "//pkg/base",
         "//pkg/col/coldata",

--- a/pkg/sql/execinfra/BUILD.bazel
+++ b/pkg/sql/execinfra/BUILD.bazel
@@ -92,7 +92,6 @@ go_test(
     ],
     args = ["-test.timeout=55s"],
     embed = [":execinfra"],
-    tags = ["no-remote-exec"],
     deps = [
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",

--- a/pkg/sql/flowinfra/BUILD.bazel
+++ b/pkg/sql/flowinfra/BUILD.bazel
@@ -68,7 +68,6 @@ go_test(
     ],
     args = ["-test.timeout=295s"],
     embed = [":flowinfra"],
-    tags = ["no-remote-exec"],
     deps = [
         "//pkg/base",
         "//pkg/ccl/kvccl/kvtenantccl",

--- a/pkg/sql/rowexec/BUILD.bazel
+++ b/pkg/sql/rowexec/BUILD.bazel
@@ -147,7 +147,6 @@ go_test(
     ],
     args = ["-test.timeout=295s"],
     embed = [":rowexec"],
-    tags = ["no-remote-exec"],
     deps = [
         "//pkg/base",
         "//pkg/gossip",

--- a/pkg/sql/rowflow/BUILD.bazel
+++ b/pkg/sql/rowflow/BUILD.bazel
@@ -43,7 +43,6 @@ go_test(
     ],
     args = ["-test.timeout=55s"],
     embed = [":rowflow"],
-    tags = ["no-remote-exec"],
     deps = [
         "//pkg/base",
         "//pkg/keys",


### PR DESCRIPTION
I have seen all these tests succeed under remote execution. For
those that are still failing, I will file bugs.

Epic: CRDB-8308
Release note: None