### PR TITLE
sql: fix hang inside TestModificationTimeTxnOrdering

### DIFF
--- a/pkg/sql/catalog/lease/lease_test.go
+++ b/pkg/sql/catalog/lease/lease_test.go
@@ -1704,10 +1704,8 @@ INSERT INTO t.kv VALUES ('a', 'b');
 func TestModificationTimeTxnOrdering(testingT *testing.T) {
 	defer leaktest.AfterTest(testingT)()
 
-	skip.WithIssue(testingT, 22479)
-
 	// Decide how long we should run this.
-	maxTime := time.Duration(5) * time.Second
+	maxTime := time.Duration(20) * time.Second
 	if skip.NightlyStress() {
 		maxTime = time.Duration(2) * time.Minute
 	}


### PR DESCRIPTION
Previously, due to past refactors in the code this test regressed because se stopped populating the
modification timestamp (which could have been dated). To address this, this patch modifies the helpers to set the modification timestamp.

Fixes: #22479

Release note: None