### PR TITLE
release-22.2: sql: fix ambigious udf overload with null arguments

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/enums
+++ b/pkg/sql/logictest/testdata/logic_test/enums
@@ -1751,7 +1751,7 @@ $$;
 query TT
 SELECT "🙏"('😊'), "🙏"(NULL:::"Emoji 😉")
 ----
-NULL  NULL
+NULL  mixed
 
 statement ok
 CREATE DATABASE "DB➕➕";

--- a/pkg/sql/logictest/testdata/logic_test/udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf
@@ -2839,3 +2839,35 @@ statement error unknown function: public\.LOWERCASE_HINT_ERROR_EXPLICIT_SCHEMA_F
 SELECT public."LOWERCASE_HINT_ERROR_EXPLICIT_SCHEMA_FN"();
 
 subtest end
+
+subtest r88374
+
+statement ok
+CREATE FUNCTION f88374(i INT2) RETURNS INT STRICT LANGUAGE SQL AS 'SELECT 2';
+
+statement ok
+CREATE FUNCTION f88374(i TEXT) RETURNS INT STRICT LANGUAGE SQL AS 'SELECT 2';
+
+statement error pgcode 42725 ambiguous call
+SELECT f88374(NULL);
+
+statement ok
+CREATE TABLE t88374 (a INT, b INT);
+
+statement ok
+INSERT INTO t88374 VALUES (1, NULL);
+
+statement ok
+CREATE FUNCTION g88374 (i INT) RETURNS INT CALLED ON NULL INPUT LANGUAGE SQL AS $$ SELECT a FROM t88374 WHERE b IS NOT DISTINCT FROM i $$;
+
+query I
+SELECT g88374(NULL);
+----
+1
+
+query I
+SELECT g88374(NULL::INT);
+----
+1
+
+subtest end


### PR DESCRIPTION
This change backports a small change from a larger PR (#98162) that prevents short-circuiting type checking for UDF function overloads. This allows us to do more precise type checking even if inputs are NULL.

Epic: none
Fixes: #88374

Release note (bug fix): Fixes ambiguous calls to UDFs with NULL arguments.

Release justification: Fixes a bug referencing UDF overloads.