### PR TITLE
[test] sql stats: trigger maybe_stress for other combinedstmts API tests

### DIFF
--- a/pkg/server/application_api/sql_stats_test.go
+++ b/pkg/server/application_api/sql_stats_test.go
@@ -96,6 +96,7 @@ func TestStatusAPICombinedTransactions(t *testing.T) {
 			count:         1,
 			numRows:       2,
 		},
+		{query: `SELECT * FROM posts WHERE id = 1`, fingerprinted: `SELECT * FROM posts WHERE id = _`, count: 1, numRows: 1},
 	}
 
 	appNameToTestCase := make(map[string]testCase)
@@ -677,6 +678,7 @@ func TestStatusAPICombinedStatements(t *testing.T) {
 			fingerprinted: `INSERT INTO posts VALUES (_, '_')`,
 		},
 		{stmt: `SELECT * FROM posts`},
+		{stmt: `SELECT body FROM posts`},
 	}
 
 	for _, stmt := range statements {

--- a/pkg/server/combined_statement_stats.go
+++ b/pkg/server/combined_statement_stats.go
@@ -688,16 +688,28 @@ FROM (SELECT fingerprint_id,
 
 		aggregatedTs := tree.MustBeDTimestampTZ(row[3]).Time
 
-		var metadata appstatspb.CollectedStatementStatistics
-		metadataJSON := tree.MustBeDJSON(row[4]).JSON
-		if err = sqlstatsutil.DecodeStmtStatsMetadataJSON(metadataJSON, &metadata); err != nil {
+		// The metadata is aggregated across all the statements with the same fingerprint.
+		aggregateMetadataJSON := tree.MustBeDJSON(row[4]).JSON
+		var aggregateMetadata appstatspb.AggregatedStatementMetadata
+		if err = sqlstatsutil.DecodeAggregatedMetadataJSON(aggregateMetadataJSON, &aggregateMetadata); err != nil {
 			return nil, srverrors.ServerError(ctx, err)
 		}
 
-		metadata.Key.App = app
+		metadata := appstatspb.CollectedStatementStatistics{
+			Key: appstatspb.StatementStatisticsKey{
+				App:          app,
+				DistSQL:      aggregateMetadata.DistSQLCount > 0,
+				FullScan:     aggregateMetadata.FullScanCount > 0,
+				Failed:       aggregateMetadata.FailedCount > 0,
+				Query:        aggregateMetadata.Query,
+				QuerySummary: aggregateMetadata.QuerySummary,
+				Database:     strings.Join(aggregateMetadata.Databases, ","),
+			},
+		}
 
+		var stats appstatspb.StatementStatistics
 		statsJSON := tree.MustBeDJSON(row[5]).JSON
-		if err = sqlstatsutil.DecodeStmtStatsStatisticsJSON(statsJSON, &metadata.Stats); err != nil {
+		if err = sqlstatsutil.DecodeStmtStatsStatisticsJSON(statsJSON, &stats); err != nil {
 			return nil, srverrors.ServerError(ctx, err)
 		}
 
@@ -707,12 +719,11 @@ FROM (SELECT fingerprint_id,
 				AggregatedTs: aggregatedTs,
 			},
 			ID:                appstatspb.StmtFingerprintID(statementFingerprintID),
-			Stats:             metadata.Stats,
+			Stats:             stats,
 			TxnFingerprintIDs: txnFingerprintIDs,
 		}
 
 		statements = append(statements, stmt)
-
 	}
 
 	if err != nil {


### PR DESCRIPTION
This is a test to trigger `maybe_stress` for other tests hitting the
`combinedStmts` API endpoint.

Release note: None