### PR TITLE
release-22.2: roachtest: use X-infra-flake for GH issues created due to infra flakes

### DIFF
--- a/pkg/cmd/roachtest/github.go
+++ b/pkg/cmd/roachtest/github.go
@@ -82,7 +82,7 @@ func (g *githubIssues) createPostRequest(
 	var infraFlake bool
 	// Overrides to shield eng teams from potential flakes
 	if cat == clusterCreationErr {
-		issueOwner = registry.OwnerDevInf
+		issueOwner = registry.OwnerTestEng
 		issueName = "cluster_creation"
 		messagePrefix = fmt.Sprintf("test %s was skipped due to ", t.Name())
 		infraFlake = true
@@ -97,7 +97,9 @@ func (g *githubIssues) createPostRequest(
 	// they are also release blockers (this label may be removed
 	// by a human upon closer investigation).
 	labels := []string{"O-roachtest"}
-	if !spec.NonReleaseBlocker && !infraFlake {
+	if infraFlake {
+		labels = append(labels, "X-infra-flake")
+	} else if !spec.NonReleaseBlocker {
 		labels = append(labels, "release-blocker")
 	}
 

--- a/pkg/cmd/roachtest/github_test.go
+++ b/pkg/cmd/roachtest/github_test.go
@@ -226,7 +226,7 @@ func TestCreatePostRequest(t *testing.T) {
 			expectedMessagePrefix := ""
 
 			if c.category == clusterCreationErr {
-				expectedTeam = "@cockroachdb/dev-inf"
+				expectedTeam = "@cockroachdb/test-eng"
 				expectedName = "cluster_creation"
 				expectedMessagePrefix = "test github_test was skipped due to "
 			} else if c.category == sshErr {


### PR DESCRIPTION
Backport 1/1 commits from #109139.

/cc @cockroachdb/release

---

Previous changes in [1], [2], removed C-test-failure and release-blocker for issued that are auto-triaged to be infra-flakes. This change merely appends X-infra-flake and adds OwnerTestEng as the owner for "cluster creation" flakes. (The latter was previously owned by DevInf.)

[1] https://github.com/cockroachdb/cockroach/pull/101754
[2] https://github.com/cockroachdb/cockroach/pull/108644

Epic: none

Release note: None
Release justification: test only change