### PR TITLE
kvserver: enforce raftGroup invariant

### DIFF
--- a/pkg/kv/kvserver/replica_destroy.go
+++ b/pkg/kv/kvserver/replica_destroy.go
@@ -182,5 +182,9 @@ func (r *Replica) disconnectReplicationRaftMuLocked(ctx context.Context) {
 		// share the error across proposals).
 		p.finishApplication(ctx, makeProposalResultErr(kvpb.NewAmbiguousResultError(apply.ErrRemoved)))
 	}
+
+	if !r.mu.destroyStatus.Removed() {
+		log.Fatalf(ctx, "removing raft group before destroying replica %s", r)
+	}
 	r.mu.internalRaftGroup = nil
 }

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -9204,9 +9204,8 @@ func TestCancelPendingCommands(t *testing.T) {
 		t.Fatalf("command finished earlier than expected with error %v", pErr)
 	default:
 	}
-	tc.repl.raftMu.Lock()
-	tc.repl.disconnectReplicationRaftMuLocked(ctx)
-	tc.repl.raftMu.Unlock()
+	require.NoError(t, tc.store.RemoveReplica(ctx, tc.repl, tc.repl.Desc().NextReplicaID,
+		RemoveOptions{DestroyData: true}))
 	pErr := <-errChan
 	if _, ok := pErr.GetDetail().(*kvpb.AmbiguousResultError); !ok {
 		t.Errorf("expected AmbiguousResultError, got %v", pErr)


### PR DESCRIPTION
This commit adds assertion that `Replica` is marked destroyed before `raftGroup` is
set to nil. This is to ensure the invariant:

	!r.mu.destroyStatus.Removed() → internalRaftGroup != nil

This commit also fixes `TestCancelPendingCommands` which had been incorrectly destroying a replica (not setting the destroy status, but setting `raftGroup` to nil). The newly added assertion would fire on this test before the fix.

Fixes #109121
Epic: none
Release note: none