### PR TITLE
Revert "jobs: attempt to backfill missing info rows on the fly"

### DIFF
--- a/pkg/jobs/job_info_storage.go
+++ b/pkg/jobs/job_info_storage.go
@@ -13,7 +13,6 @@ package jobs
 import (
 	"bytes"
 	"context"
-	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -24,7 +23,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
-	"github.com/cockroachdb/redact"
 )
 
 // InfoStorage can be used to read and write rows to system.job_info table. All
@@ -319,39 +317,4 @@ func (i InfoStorage) GetLegacyProgress(ctx context.Context) ([]byte, bool, error
 // WriteLegacyProgress writes the job's Progress to the system.job_info table.
 func (i InfoStorage) WriteLegacyProgress(ctx context.Context, progress []byte) error {
 	return i.Write(ctx, LegacyProgressKey, progress)
-}
-
-// BackfillLegacyPayload copies a legacy payload from system.jobs. #104798.
-func (i InfoStorage) BackfillLegacyPayload(ctx context.Context) ([]byte, error) {
-	return i.backfillMissing(ctx, "payload")
-}
-
-// BackfillLegacyProgress copies a legacy progress from system.jobs. #104798.
-func (i InfoStorage) BackfillLegacyProgress(ctx context.Context) ([]byte, error) {
-	return i.backfillMissing(ctx, "progress")
-}
-
-func (i InfoStorage) backfillMissing(ctx context.Context, kind string) ([]byte, error) {
-	row, err := i.txn.QueryRowEx(
-		ctx, fmt.Sprintf("job-info-fix-%s", kind), i.txn.KV(),
-		sessiondata.NodeUserSessionDataOverride,
-		`INSERT INTO system.job_info (job_id, info_key, value) 
-			SELECT id, 'legacy_`+kind+`', `+kind+` FROM system.jobs WHERE id = $1 AND `+kind+` IS NOT NULL
-			RETURNING value`,
-		i.j.ID(),
-	)
-
-	if err != nil {
-		return nil, err
-	}
-
-	if row == nil {
-		return nil, errors.Wrapf(&JobNotFoundError{jobID: i.j.ID()}, "job %s not found in system.jobs", redact.SafeString(kind))
-	}
-
-	value, ok := row[0].(*tree.DBytes)
-	if !ok {
-		return nil, errors.AssertionFailedf("job info: expected value to be DBytes (was %T)", row[0])
-	}
-	return []byte(*value), nil
 }

--- a/pkg/jobs/jobs_test.go
+++ b/pkg/jobs/jobs_test.go
@@ -1618,7 +1618,7 @@ func TestJobLifecycle(t *testing.T) {
 			}, registry.MakeJobID(), txn)
 			return errors.New("boom")
 		}))
-		if err := job.Started(ctx); !testutils.IsError(err, "job payload not found in system.jobs") {
+		if err := job.Started(ctx); !testutils.IsError(err, "not found in system.jobs table") {
 			t.Fatalf("unexpected error %v", err)
 		}
 	})

--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -1861,13 +1861,6 @@ func (r *Registry) MarkIdle(job *Job, isIdle bool) {
 	}
 }
 
-// TestingForgetJob causes the registry to forget it has adopted a job.
-func (r *Registry) TestingForgetJob(id jobspb.JobID) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	delete(r.mu.adoptedJobs, id)
-}
-
 func (r *Registry) cancelAllAdoptedJobs() {
 	r.mu.Lock()
 	defer r.mu.Unlock()

--- a/pkg/jobs/update.go
+++ b/pkg/jobs/update.go
@@ -108,33 +108,7 @@ func (u Updater) update(ctx context.Context, useReadLock bool, updateFn UpdateFn
 		return err
 	}
 	if row == nil {
-		// Maybe try to fix a row missed by 23.1.3 backfill and re-read. #104798.
-		if u.j.registry.settings.Version.IsActive(ctx, clusterversion.V23_1JobInfoTableIsBackfilled) {
-			i := j.InfoStorage(u.txn)
-
-			_, err := i.BackfillLegacyPayload(ctx)
-			if err != nil {
-				return errors.Wrap(err, "failed to backfill job info payload during update")
-			}
-
-			_, err = i.BackfillLegacyProgress(ctx)
-			if err != nil {
-				return errors.Wrap(err, "failed to backfill job info progress during update")
-			}
-
-			row, err = u.txn.QueryRowEx(
-				ctx, "select-job", u.txn.KV(),
-				sessiondata.RootUserSessionDataOverride,
-				getSelectStmtForJobUpdate(ctx, j.session != nil, useReadLock, u.j.registry.settings.Version), j.ID(),
-			)
-
-			if err != nil {
-				return err
-			}
-		}
-		if row == nil {
-			return errors.Errorf("not found in system.jobs table")
-		}
+		return errors.Errorf("not found in system.jobs table")
 	}
 
 	if status, err = unmarshalStatus(row[0]); err != nil {

--- a/pkg/upgrade/upgrades/backfill_job_info_table_migration.go
+++ b/pkg/upgrade/upgrades/backfill_job_info_table_migration.go
@@ -45,15 +45,9 @@ const (
 	backfillJobInfoProgressStmt = backfillJobInfoSharedPrefix + jobs.LegacyProgressKey + `', progress` + backfillJobInfoSharedSuffix
 )
 
-// TestingSkipInfoBackfill is a testing hook.
-var TestingSkipInfoBackfill bool
-
 func backfillJobInfoTable(
 	ctx context.Context, cs clusterversion.ClusterVersion, d upgrade.TenantDeps,
 ) error {
-	if TestingSkipInfoBackfill {
-		return nil
-	}
 
 	for step, stmt := range []string{backfillJobInfoPayloadStmt, backfillJobInfoProgressStmt} {
 		var resumeAfter int


### PR DESCRIPTION
This reverts commit 9d59881056d7e77813543371d39563c1d7069d21.

We never backported this to 23.1, and have not seen any indication that we will need to, and it is not needed in 23.2.

Release note: none.
Epic: none.