### PR TITLE
server: properly connect the scheduler latency sampler to its listener

### DIFF
--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -622,6 +622,7 @@ func (s *SQLServerWrapper) PreStart(ctx context.Context) error {
 	// Start measuring the Go scheduler latency.
 	if err := schedulerlatency.StartSampler(
 		workersCtx, s.sqlServer.cfg.Settings, s.stopper, s.registry, base.DefaultMetricsSampleInterval,
+		nil, /* listener */
 	); err != nil {
 		return err
 	}

--- a/pkg/util/admission/BUILD.bazel
+++ b/pkg/util/admission/BUILD.bazel
@@ -35,6 +35,7 @@ go_library(
         "//pkg/util/humanizeutil",
         "//pkg/util/log",
         "//pkg/util/metric",
+        "//pkg/util/schedulerlatency",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/util/admission/admission.go
+++ b/pkg/util/admission/admission.go
@@ -132,6 +132,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb"
+	"github.com/cockroachdb/cockroach/pkg/util/schedulerlatency"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble"
 )
@@ -361,9 +362,7 @@ type elasticCPULimiter interface {
 
 // SchedulerLatencyListener listens to the latest scheduler latency data. We
 // expect this to be called every scheduler_latency.sample_period.
-type SchedulerLatencyListener interface {
-	SchedulerLatency(p99, period time.Duration)
-}
+type SchedulerLatencyListener = schedulerlatency.LatencyObserver
 
 // grantKind represents the two kind of ways we grant admission: using a slot
 // or a token. The slot terminology is akin to a scheduler, where a scheduling

--- a/pkg/util/schedulerlatency/BUILD.bazel
+++ b/pkg/util/schedulerlatency/BUILD.bazel
@@ -39,6 +39,7 @@ go_test(
         "//pkg/util/stop",
         "//pkg/util/syncutil",
         "@com_github_cockroachdb_datadriven//:datadriven",
+        "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",
     ],
 )


### PR DESCRIPTION
Prior to this patch, if we had N servers running (e.g. in tests) we would have N^2 callbacks called every sample round (one sampler per server, N calls per sampler) because it used a global callback registry.

Also it wasn't particularly elegant design, as we should eschew global registries altogether.

This patch enhances the situation by only having one listener per sampler.

Release note: None

Needed to solve #109225.
Epic: CRDB-26691