### PR TITLE
release-23.1: roachtest: remove healthchecker from DR tests

### DIFF
--- a/pkg/cmd/roachtest/tests/restore.go
+++ b/pkg/cmd/roachtest/tests/restore.go
@@ -135,8 +135,6 @@ func registerRestore(r registry.Registry) {
 			m := c.NewMonitor(ctx)
 			dul := roachtestutil.NewDiskUsageLogger(t, c)
 			m.Go(dul.Runner)
-			hc := roachtestutil.NewHealthChecker(t, c, c.All())
-			m.Go(hc.Runner)
 
 			jobIDCh := make(chan jobspb.JobID)
 			jobCompleteCh := make(chan struct{}, 1)
@@ -210,7 +208,6 @@ func registerRestore(r registry.Registry) {
 
 			m.Go(func(ctx context.Context) error {
 				defer dul.Done()
-				defer hc.Done()
 				defer close(jobCompleteCh)
 				defer close(jobIDCh)
 				t.Status(`running restore`)
@@ -372,12 +369,7 @@ func registerRestore(r registry.Registry) {
 				m := c.NewMonitor(ctx)
 				dul := roachtestutil.NewDiskUsageLogger(t, c)
 				m.Go(dul.Runner)
-				hc := roachtestutil.NewHealthChecker(t, c, c.All())
-				m.Go(hc.Runner)
-
 				m.Go(func(ctx context.Context) error {
-					defer dul.Done()
-					defer hc.Done()
 					t.Status(`running restore`)
 					metricCollector := rd.initRestorePerfMetrics(ctx, durationGauge)
 					if err := rd.run(ctx, ""); err != nil {


### PR DESCRIPTION
Backport 1/1 commits from #109171.

/cc @cockroachdb/release

Release justification: test infra flake fix

---

The healthchecker utility adds little coverage beyond a roachtest monitor and
has been a frequent cause of connection timeout errors (roachtest flakes), as
it opens a new sql connection every five seconds during the test.

Fixes https://github.com/cockroachdb/cockroach/issues/109027
Informs https://github.com/cockroachdb/cockroach/issues/109023

Epic: none
