### PR TITLE
enginepb,concurrency: clean up {,the usage of} TxnSeqIsIgnored

### DIFF
--- a/pkg/kv/kvserver/concurrency/lock_table.go
+++ b/pkg/kv/kvserver/concurrency/lock_table.go
@@ -1063,11 +1063,7 @@ func (ulh *unreplicatedLockHolderInfo) rollbackIgnoredSeqNumbers(
 		if minSeqNumber == -1 {
 			continue
 		}
-		i := sort.Search(len(ignoredSeqNums), func(i int) bool {
-			return ignoredSeqNums[i].End >= minSeqNumber
-		})
-		shouldIgnore := i != len(ignoredSeqNums) && minSeqNumber >= ignoredSeqNums[i].Start
-		if shouldIgnore {
+		if enginepb.TxnSeqIsIgnored(minSeqNumber, ignoredSeqNums) {
 			ulh.strengths[strIdx] = -1
 		}
 	}


### PR DESCRIPTION
Prior to this patch, we were rolling out bespoke logic to determine whether a sequence number was ignored or not when acquiring/updating locks in the lock table. This patch switches that usage to call into enginepb.TxnSeqIsIgnored instead.

While here, we also change the implementation of TxnSeqIsIgnored to use a binary search and update some commentary.

Epic: none

Release note: None