### PR TITLE
cmd: error if try to use --stream-output with --stress

### DIFF
--- a/pkg/cmd/dev/test.go
+++ b/pkg/cmd/dev/test.go
@@ -202,6 +202,10 @@ func (d *dev) test(cmd *cobra.Command, commandLine []string) error {
 		}
 	}
 
+	if stress && streamOutput {
+		return fmt.Errorf("cannot combine --%s and --%s", stressFlag, streamOutputFlag)
+	}
+
 	if rewrite {
 		ignoreCache = true
 		disableTestSharding = true

--- a/pkg/cmd/dev/testdata/datadriven/testlogic
+++ b/pkg/cmd/dev/testdata/datadriven/testlogic
@@ -57,28 +57,28 @@ getenv DEV_I_UNDERSTAND_ABOUT_STRESS
 bazel test //pkg/sql/logictest/tests/... --test_env=GOTRACEBACK=all --local_cpu_resources=8 --test_arg -show-sql --test_timeout=65 --test_arg -test.timeout=1m0s --test_env=COCKROACH_STRESS=true --notest_keep_going --runs_per_test=500 --test_filter auto_span_config_reconciliation/ --test_sharding_strategy=disabled --test_output errors
 
 exec
-dev testlogic base --files=auto_span_config_reconciliation --stress --stream-output
+dev testlogic base --files=auto_span_config_reconciliation --stress
 ----
 bazel info workspace --color=no
 bazel info workspace --color=no
 bazel run pkg/cmd/generate-logictest -- -out-dir=crdb-checkout
 getenv DEV_I_UNDERSTAND_ABOUT_STRESS
-bazel test //pkg/sql/logictest/tests/... --test_env=GOTRACEBACK=all --test_arg -show-sql --test_env=COCKROACH_STRESS=true --notest_keep_going --runs_per_test=500 --test_filter auto_span_config_reconciliation/ --test_sharding_strategy=disabled --test_output streamed
+bazel test //pkg/sql/logictest/tests/... --test_env=GOTRACEBACK=all --test_arg -show-sql --test_env=COCKROACH_STRESS=true --notest_keep_going --runs_per_test=500 --test_filter auto_span_config_reconciliation/ --test_sharding_strategy=disabled --test_output errors
 
 exec
-dev testlogic base --files=auto_span_config_reconciliation --stress --stream-output
+dev testlogic base --files=auto_span_config_reconciliation --stress
 ----
 bazel info workspace --color=no
 bazel info workspace --color=no
 bazel run pkg/cmd/generate-logictest -- -out-dir=crdb-checkout
 getenv DEV_I_UNDERSTAND_ABOUT_STRESS
-bazel test //pkg/sql/logictest/tests/... --test_env=GOTRACEBACK=all --test_arg -show-sql --test_env=COCKROACH_STRESS=true --notest_keep_going --runs_per_test=500 --test_filter auto_span_config_reconciliation/ --test_sharding_strategy=disabled --test_output streamed
+bazel test //pkg/sql/logictest/tests/... --test_env=GOTRACEBACK=all --test_arg -show-sql --test_env=COCKROACH_STRESS=true --notest_keep_going --runs_per_test=500 --test_filter auto_span_config_reconciliation/ --test_sharding_strategy=disabled --test_output errors
 
 exec
-dev testlogic base --files=auto_span_config_reconciliation --stress --stream-output
+dev testlogic base --files=auto_span_config_reconciliation --stress
 ----
 bazel info workspace --color=no
 bazel info workspace --color=no
 bazel run pkg/cmd/generate-logictest -- -out-dir=crdb-checkout
 getenv DEV_I_UNDERSTAND_ABOUT_STRESS
-bazel test //pkg/sql/logictest/tests/... --test_env=GOTRACEBACK=all --test_arg -show-sql --test_env=COCKROACH_STRESS=true --notest_keep_going --runs_per_test=500 --test_filter auto_span_config_reconciliation/ --test_sharding_strategy=disabled --test_output streamed
+bazel test //pkg/sql/logictest/tests/... --test_env=GOTRACEBACK=all --test_arg -show-sql --test_env=COCKROACH_STRESS=true --notest_keep_going --runs_per_test=500 --test_filter auto_span_config_reconciliation/ --test_sharding_strategy=disabled --test_output errors

--- a/pkg/cmd/dev/testlogic.go
+++ b/pkg/cmd/dev/testlogic.go
@@ -240,6 +240,9 @@ func (d *dev) testlogic(cmd *cobra.Command, commandLine []string) error {
 		args = append(args, fmt.Sprintf("--test_env=COCKROACH_WORKSPACE=%s", workspace))
 		args = append(args, "--test_arg", "-rewrite")
 	}
+	if stress && streamOutput {
+		return fmt.Errorf("cannot combine --%s and --%s", stressFlag, streamOutputFlag)
+	}
 	if showDiff {
 		args = append(args, "--test_arg", "-show-diff")
 	}


### PR DESCRIPTION
Previously running these two flags together would force serialization on `--stress`, which doesn't make any sense. This PR adds an error when the two flags are attempted to be used together.

Fixes: #108150
Release note: None