### PR TITLE
roachpb: rename Intent to Lock, add Strength field to Lock

### DIFF
--- a/pkg/kv/kvpb/errors.go
+++ b/pkg/kv/kvpb/errors.go
@@ -927,7 +927,7 @@ func (e *LockConflictError) printError(buf Printer) {
 	// If we have a lot of locks, we only want to show the first and the last.
 	const maxBegin = 5
 	const maxEnd = 5
-	var begin, end []roachpb.Intent
+	var begin, end []roachpb.Lock
 	if len(e.Locks) <= maxBegin+maxEnd {
 		begin = e.Locks
 	} else {
@@ -1344,7 +1344,7 @@ var _ ErrorDetailInterface = &MVCCHistoryMutationError{}
 func NewIntentMissingError(key roachpb.Key, wrongIntent *roachpb.Intent) *IntentMissingError {
 	return &IntentMissingError{
 		Key:         key,
-		WrongIntent: wrongIntent,
+		WrongIntent: wrongIntent.AsLockPtr(),
 	}
 }
 

--- a/pkg/kv/kvpb/errors.proto
+++ b/pkg/kv/kvpb/errors.proto
@@ -331,9 +331,7 @@ message TransactionStatusError {
 // there's no ambiguity; the error carries a WriteTimestamp that's the
 // upper bound of the timestamps intents were written at.
 message LockConflictError {
-  // TODO(nvanbenschoten): rename roachpb.Intent to roachpb.Lock and add a
-  // lock.Strength field.
-  repeated roachpb.Intent locks = 1 [(gogoproto.nullable) = false];
+  repeated roachpb.Lock locks = 1 [(gogoproto.nullable) = false];
   reserved 2;
   // The sequence of the lease that the operation which hit this error was
   // operating under. Used on the server to avoid adding discovered locks
@@ -577,7 +575,7 @@ message MVCCHistoryMutationError {
 // not there.
 message IntentMissingError {
   // The non-matching intent that was found at that key, if any.
-  optional roachpb.Intent wrong_intent = 1;
+  optional roachpb.Lock wrong_intent = 1;
   // The key where the intent was expected.
   optional bytes key = 2 [(gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/roachpb.Key"];
 }

--- a/pkg/kv/kvserver/batcheval/cmd_add_sstable.go
+++ b/pkg/kv/kvserver/batcheval/cmd_add_sstable.go
@@ -273,7 +273,7 @@ func EvalAddSSTable(
 		if err != nil {
 			return result.Result{}, errors.Wrap(err, "scanning intents")
 		} else if len(intents) > 0 {
-			return result.Result{}, &kvpb.LockConflictError{Locks: intents}
+			return result.Result{}, &kvpb.LockConflictError{Locks: roachpb.AsLocks(intents)}
 		}
 	}
 

--- a/pkg/kv/kvserver/batcheval/cmd_clear_range.go
+++ b/pkg/kv/kvserver/batcheval/cmd_clear_range.go
@@ -117,7 +117,7 @@ func ClearRange(
 	if err != nil {
 		return result.Result{}, err
 	} else if len(intents) > 0 {
-		return result.Result{}, &kvpb.LockConflictError{Locks: intents}
+		return result.Result{}, &kvpb.LockConflictError{Locks: roachpb.AsLocks(intents)}
 	}
 
 	// Before clearing, compute the delta in MVCCStats.

--- a/pkg/kv/kvserver/concurrency/concurrency_control.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_control.go
@@ -637,8 +637,9 @@ type lockTable interface {
 	// true) or whether it was ignored because the lockTable is currently
 	// disabled (false).
 	AddDiscoveredLock(
-		intent *roachpb.Intent, seq roachpb.LeaseSequence, consultTxnStatusCache bool,
-		guard lockTableGuard) (bool, error)
+		foundLock *roachpb.Lock, seq roachpb.LeaseSequence,
+		consultTxnStatusCache bool, guard lockTableGuard,
+	) (bool, error)
 
 	// AcquireLock informs the lockTable that a new lock was acquired or an
 	// existing lock was updated.

--- a/pkg/kv/kvserver/concurrency/concurrency_manager.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager.go
@@ -482,15 +482,15 @@ func (m *managerImpl) HandleLockConflictError(
 	consultTxnStatusCache :=
 		int64(len(t.Locks)) > DiscoveredLocksThresholdToConsultTxnStatusCache.Get(&m.st.SV)
 	for i := range t.Locks {
-		intent := &t.Locks[i]
-		added, err := m.lt.AddDiscoveredLock(intent, seq, consultTxnStatusCache, g.ltg)
+		foundLock := &t.Locks[i]
+		added, err := m.lt.AddDiscoveredLock(foundLock, seq, consultTxnStatusCache, g.ltg)
 		if err != nil {
 			log.Fatalf(ctx, "%v", err)
 		}
 		if !added {
 			log.VEventf(ctx, 2,
 				"intent on %s discovered but not added to disabled lock table",
-				intent.Key.String())
+				foundLock.Key.String())
 		}
 	}
 

--- a/pkg/kv/kvserver/concurrency/concurrency_manager_test.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager_test.go
@@ -306,8 +306,8 @@ func TestConcurrencyManagerBasic(t *testing.T) {
 				var leaseSeq int
 				d.ScanArgs(t, "lease-seq", &leaseSeq)
 
-				// Each roachpb.Intent is provided on an indented line.
-				var intents []roachpb.Intent
+				// Each roachpb.Lock is provided on an indented line.
+				var locks []roachpb.Lock
 				singleReqLines := strings.Split(d.Input, "\n")
 				for _, line := range singleReqLines {
 					var err error
@@ -329,13 +329,13 @@ func TestConcurrencyManagerBasic(t *testing.T) {
 					var key string
 					d.ScanArgs(t, "key", &key)
 
-					intents = append(intents, roachpb.MakeIntent(&txn.TxnMeta, roachpb.Key(key)))
+					locks = append(locks, roachpb.MakeLock(&txn.TxnMeta, roachpb.Key(key), lock.Intent))
 				}
 
 				opName := fmt.Sprintf("handle lock conflict error %s", reqName)
 				mon.runAsync(opName, func(ctx context.Context) {
 					seq := roachpb.LeaseSequence(leaseSeq)
-					lcErr := &kvpb.LockConflictError{Locks: intents}
+					lcErr := &kvpb.LockConflictError{Locks: locks}
 					guard, err := m.HandleLockConflictError(ctx, prev, seq, lcErr)
 					if err != nil {
 						log.Eventf(ctx, "handled %v, returned error: %v", lcErr, err)

--- a/pkg/kv/kvserver/concurrency/lock_table.go
+++ b/pkg/kv/kvserver/concurrency/lock_table.go
@@ -3525,6 +3525,8 @@ func (t *lockTableImpl) AddDiscoveredLock(
 		// higher lease sequence than the current value of enabledSeq.
 		return false, errors.AssertionFailedf("unexpected lease sequence: %d > %d", seq, t.enabledSeq)
 	}
+	// TODO(arul): lift this limitation.
+	assert(foundLock.Strength == lock.Intent, "unsupported lock strength")
 	g := guard.(*lockTableGuardImpl)
 	key := foundLock.Key
 	str, err := findHighestLockStrengthInSpans(key, g.spans)

--- a/pkg/kv/kvserver/concurrency/lock_table_test.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_test.go
@@ -457,7 +457,7 @@ func TestLockTableBasic(t *testing.T) {
 				if !ok {
 					d.Fatalf(t, "unknown txn %s", txnName)
 				}
-				intent := roachpb.MakeIntent(txnMeta, roachpb.Key(key))
+				foundLock := roachpb.MakeLock(txnMeta, roachpb.Key(key), lock.Intent)
 				seq := int(1)
 				if d.HasArg("lease-seq") {
 					d.ScanArgs(t, "lease-seq", &seq)
@@ -468,7 +468,7 @@ func TestLockTableBasic(t *testing.T) {
 				}
 				leaseSeq := roachpb.LeaseSequence(seq)
 				if _, err := lt.AddDiscoveredLock(
-					&intent, leaseSeq, consultTxnStatusCache, g); err != nil {
+					&foundLock, leaseSeq, consultTxnStatusCache, g); err != nil {
 					return err.Error()
 				}
 				return lt.String()
@@ -821,6 +821,11 @@ func intentsToResolveToStr(toResolve []roachpb.LockUpdate, startOnNewLine bool) 
 	return buf.String()
 }
 
+func newLock(txn *enginepb.TxnMeta, key roachpb.Key, str lock.Strength) *roachpb.Lock {
+	l := roachpb.MakeLock(txn, key, str)
+	return &l
+}
+
 func TestLockTableMaxLocks(t *testing.T) {
 	lt := newLockTable(
 		5, roachpb.RangeID(3), hlc.NewClockForTesting(nil), cluster.MakeTestingClusterSettings(),
@@ -860,9 +865,7 @@ func TestLockTableMaxLocks(t *testing.T) {
 		for j := 0; j < 10; j++ {
 			k := i*20 + j
 			added, err := lt.AddDiscoveredLock(
-				&roachpb.Intent{
-					Intent_SingleKeySpan: roachpb.Intent_SingleKeySpan{Key: keys[k]}, Txn: txnMeta,
-				},
+				newLock(&txnMeta, keys[k], lock.Intent),
 				0, false, guards[i])
 			require.True(t, added)
 			require.NoError(t, err)
@@ -882,9 +885,7 @@ func TestLockTableMaxLocks(t *testing.T) {
 	require.Equal(t, int64(10), lt.lockCountForTesting())
 	// Add another discovered lock, to trigger tryClearLocks.
 	added, err := lt.AddDiscoveredLock(
-		&roachpb.Intent{
-			Intent_SingleKeySpan: roachpb.Intent_SingleKeySpan{Key: keys[9*20+10]}, Txn: txnMeta,
-		},
+		newLock(&txnMeta, keys[9*20+10], lock.Intent),
 		0, false, guards[9])
 	require.True(t, added)
 	require.NoError(t, err)
@@ -893,9 +894,7 @@ func TestLockTableMaxLocks(t *testing.T) {
 	require.Equal(t, int64(101), int64(lt.locks.lockIDSeqNum))
 	// Add another discovered lock, to trigger tryClearLocks.
 	added, err = lt.AddDiscoveredLock(
-		&roachpb.Intent{
-			Intent_SingleKeySpan: roachpb.Intent_SingleKeySpan{Key: keys[9*20+11]}, Txn: txnMeta,
-		},
+		newLock(&txnMeta, keys[9*20+11], lock.Intent),
 		0, false, guards[9])
 	require.True(t, added)
 	require.NoError(t, err)
@@ -909,9 +908,7 @@ func TestLockTableMaxLocks(t *testing.T) {
 	lt.locks.lockAddMaxLocksCheckInterval = 2
 	// Add another discovered lock.
 	added, err = lt.AddDiscoveredLock(
-		&roachpb.Intent{
-			Intent_SingleKeySpan: roachpb.Intent_SingleKeySpan{Key: keys[9*20+12]}, Txn: txnMeta,
-		},
+		newLock(&txnMeta, keys[9*20+12], lock.Intent),
 		0, false, guards[9])
 	require.True(t, added)
 	require.NoError(t, err)
@@ -919,9 +916,7 @@ func TestLockTableMaxLocks(t *testing.T) {
 	require.Equal(t, int64(7), lt.lockCountForTesting())
 	// Add another discovered lock, to trigger tryClearLocks.
 	added, err = lt.AddDiscoveredLock(
-		&roachpb.Intent{
-			Intent_SingleKeySpan: roachpb.Intent_SingleKeySpan{Key: keys[9*20+13]}, Txn: txnMeta,
-		},
+		newLock(&txnMeta, keys[9*20+13], lock.Intent),
 		0, false, guards[9])
 	require.True(t, added)
 	require.NoError(t, err)
@@ -936,9 +931,7 @@ func TestLockTableMaxLocks(t *testing.T) {
 	lt.Dequeue(guards[8])
 	// Add another discovered lock.
 	added, err = lt.AddDiscoveredLock(
-		&roachpb.Intent{
-			Intent_SingleKeySpan: roachpb.Intent_SingleKeySpan{Key: keys[9*20+14]}, Txn: txnMeta,
-		},
+		newLock(&txnMeta, keys[9*20+14], lock.Intent),
 		0, false, guards[9])
 	require.True(t, added)
 	require.NoError(t, err)
@@ -946,9 +939,7 @@ func TestLockTableMaxLocks(t *testing.T) {
 	// Add another discovered lock, to trigger tryClearLocks, and push us over 5
 	// locks.
 	added, err = lt.AddDiscoveredLock(
-		&roachpb.Intent{
-			Intent_SingleKeySpan: roachpb.Intent_SingleKeySpan{Key: keys[9*20+15]}, Txn: txnMeta,
-		},
+		newLock(&txnMeta, keys[9*20+15], lock.Intent),
 		0, false, guards[9])
 	require.True(t, added)
 	require.NoError(t, err)
@@ -959,9 +950,7 @@ func TestLockTableMaxLocks(t *testing.T) {
 	// Add locks to push us over 5 locks.
 	for i := 16; i < 20; i++ {
 		added, err = lt.AddDiscoveredLock(
-			&roachpb.Intent{
-				Intent_SingleKeySpan: roachpb.Intent_SingleKeySpan{Key: keys[9*20+i]}, Txn: txnMeta,
-			},
+			newLock(&txnMeta, keys[9*20+i], lock.Intent),
 			0, false, guards[9])
 		require.True(t, added)
 		require.NoError(t, err)
@@ -1007,9 +996,7 @@ func TestLockTableMaxLocksWithMultipleNotRemovableRefs(t *testing.T) {
 	// The first 6 requests discover 3 locks total.
 	for i := 0; i < 6; i++ {
 		added, err := lt.AddDiscoveredLock(
-			&roachpb.Intent{
-				Intent_SingleKeySpan: roachpb.Intent_SingleKeySpan{Key: keys[i/2]}, Txn: txnMeta,
-			},
+			newLock(&txnMeta, keys[i/2], lock.Intent),
 			0, false, guards[i])
 		require.True(t, added)
 		require.NoError(t, err)
@@ -1024,9 +1011,7 @@ func TestLockTableMaxLocksWithMultipleNotRemovableRefs(t *testing.T) {
 	}
 	// Add another lock using request 6.
 	added, err := lt.AddDiscoveredLock(
-		&roachpb.Intent{
-			Intent_SingleKeySpan: roachpb.Intent_SingleKeySpan{Key: keys[6/2]}, Txn: txnMeta,
-		},
+		newLock(&txnMeta, keys[6/2], lock.Intent),
 		0, false, guards[6])
 	require.True(t, added)
 	require.NoError(t, err)
@@ -1044,9 +1029,7 @@ func TestLockTableMaxLocksWithMultipleNotRemovableRefs(t *testing.T) {
 	require.Equal(t, int64(4), lt.lockCountForTesting())
 	// Add another lock using request 8.
 	added, err = lt.AddDiscoveredLock(
-		&roachpb.Intent{
-			Intent_SingleKeySpan: roachpb.Intent_SingleKeySpan{Key: keys[8/2]}, Txn: txnMeta,
-		},
+		newLock(&txnMeta, keys[8/2], lock.Intent),
 		0, false, guards[8])
 	require.True(t, added)
 	require.NoError(t, err)

--- a/pkg/kv/kvserver/concurrency/lock_table_waiter.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_waiter.go
@@ -1258,8 +1258,10 @@ const (
 )
 
 func newLockConflictErr(req Request, ws waitingState, reason kvpb.LockConflictError_Reason) *Error {
+	// TODO(nvanbenschoten): we should use the correct Lock strength of the lock
+	// holder, once we have it.
 	err := kvpb.NewError(&kvpb.LockConflictError{
-		Locks:  []roachpb.Intent{roachpb.MakeIntent(ws.txn, ws.key)},
+		Locks:  []roachpb.Lock{roachpb.MakeIntent(ws.txn, ws.key).AsLock()},
 		Reason: reason,
 	})
 	// TODO(nvanbenschoten): setting an error index can assist the KV client in

--- a/pkg/kv/kvserver/replica_read.go
+++ b/pkg/kv/kvserver/replica_read.go
@@ -324,7 +324,7 @@ func (r *Replica) canDropLatchesBeforeEval(
 	}
 	if len(intents) > 0 {
 		return false /* ok */, false /* stillNeedsIntentInterleaving */, maybeAttachLease(
-			kvpb.NewError(&kvpb.LockConflictError{Locks: intents}), &st.Lease,
+			kvpb.NewError(&kvpb.LockConflictError{Locks: roachpb.AsLocks(intents)}), &st.Lease,
 		)
 	}
 	// If there were no conflicts, then the request can drop its latches and

--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -1973,8 +1973,7 @@ func MakeLock(txn *enginepb.TxnMeta, key Key, str lock.Strength) Lock {
 	var l Lock
 	l.Txn = *txn
 	l.Key = key
-	// TODO(nvanbenschoten): add this field.
-	// l.Strength = str
+	l.Strength = str
 	return l
 }
 

--- a/pkg/roachpb/data.proto
+++ b/pkg/roachpb/data.proto
@@ -532,16 +532,15 @@ message TransactionRecord {
   reserved 2, 3, 6, 7, 8, 9, 10, 12, 13, 14, 15, 16;
 }
 
-// A Intent is a Span together with a Transaction metadata. Intents messages
-// are used to reference persistent on-disk write intents. They are used on
-// the return path of e.g. scans, to report the existence of a write intent
-// on a key.
+// A Lock is a Key together with a Transaction metadata (the lock holder) and a
+// strength. They are used on the return path of e.g. scans, to report the
+// existence of a locks on a key.
 //
-// Note: avoid constructing Intent directly; consider using MakeIntent() instead.
-message Intent {
+// Note: avoid constructing Lock directly; use MakeLock or MakeIntent instead.
+message Lock {
   // SingleKeySpan preserves wire compatibility with an earlier version of this
-  // proto which used a Span. An Intent never spans keys, so there was no need
-  // for this to contain an EndKey.
+  // proto which used a Span. A Lock never spans keys, so there was no need for
+  // this to contain an EndKey.
   message SingleKeySpan {
     reserved 1, 2, 4;
     // The start key of the key range.

--- a/pkg/roachpb/data.proto
+++ b/pkg/roachpb/data.proto
@@ -548,6 +548,7 @@ message Lock {
   }
   SingleKeySpan single_key_span = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
   storage.enginepb.TxnMeta txn = 2 [(gogoproto.nullable) = false];
+  kv.kvserver.concurrency.lock.Strength strength = 3;
 }
 
 // A LockAcquisition represents the action of a Transaction acquiring a lock

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -1466,7 +1466,7 @@ func Scan(reader Reader, start, end roachpb.Key, max int64) ([]MVCCKeyValue, err
 func ScanIntents(
 	ctx context.Context, reader Reader, start, end roachpb.Key, maxIntents int64, targetBytes int64,
 ) ([]roachpb.Intent, error) {
-	intents := []roachpb.Intent{}
+	var intents []roachpb.Intent
 
 	if bytes.Compare(start, end) >= 0 {
 		return intents, nil

--- a/pkg/storage/mvcc_history_test.go
+++ b/pkg/storage/mvcc_history_test.go
@@ -1642,7 +1642,7 @@ func cmdScan(e *evalCtx) error {
 		// ascertain no result is populated in the intents when an error
 		// occurs.
 		for _, intent := range res.Intents {
-			e.results.buf.Printf("scan: intent %v {%s}\n", intent.Intent_SingleKeySpan.Key, intent.Txn)
+			e.results.buf.Printf("scan: intent %v {%s}\n", intent.Key, intent.Txn)
 		}
 		for _, val := range res.KVs {
 			e.results.buf.Printf("scan: %v -> %v @%v\n", val.Key, val.Value.PrettyPrint(), val.Value.Timestamp)

--- a/pkg/storage/mvcc_incremental_iterator.go
+++ b/pkg/storage/mvcc_incremental_iterator.go
@@ -438,8 +438,8 @@ func (i *MVCCIncrementalIterator) updateMeta() error {
 		switch i.intentPolicy {
 		case MVCCIncrementalIterIntentPolicyError:
 			i.err = &kvpb.LockConflictError{
-				Locks: []roachpb.Intent{
-					roachpb.MakeIntent(i.meta.Txn, i.iter.UnsafeKey().Key.Clone()),
+				Locks: []roachpb.Lock{
+					roachpb.MakeIntent(i.meta.Txn, i.iter.UnsafeKey().Key.Clone()).AsLock(),
 				},
 			}
 			i.valid = false
@@ -772,7 +772,7 @@ func (i *MVCCIncrementalIterator) TryGetIntentError() error {
 		return nil
 	}
 	return &kvpb.LockConflictError{
-		Locks: i.intents,
+		Locks: roachpb.AsLocks(i.intents),
 	}
 }
 

--- a/pkg/storage/mvcc_incremental_iterator_test.go
+++ b/pkg/storage/mvcc_incremental_iterator_test.go
@@ -787,7 +787,7 @@ func TestMVCCIncrementalIteratorIntentPolicy(t *testing.T) {
 	kv2_2_2 := makeKVT(testKey2, testValue2, ts2)
 	txn, intent2_2_2 := makeKVTxn(testKey2, ts2)
 
-	lcErr := &kvpb.LockConflictError{Locks: []roachpb.Intent{intent2_2_2}}
+	lcErr := &kvpb.LockConflictError{Locks: []roachpb.Lock{intent2_2_2.AsLock()}}
 
 	e := NewDefaultInMemForTesting()
 	defer e.Close()

--- a/pkg/storage/pebble_test.go
+++ b/pkg/storage/pebble_test.go
@@ -500,10 +500,6 @@ func key(k int) roachpb.Key {
 	return []byte(fmt.Sprintf("%05d", k))
 }
 
-func requireTxnForValue(t *testing.T, val testValue, intent roachpb.Intent) {
-	require.Equal(t, val.txn.Key, intent.Txn.Key)
-}
-
 // nonFatalLogger implements pebble.Logger by recording that a fatal log event
 // was encountered at least once. Fatal log events are downgraded to Info level.
 type nonFatalLogger struct {

--- a/pkg/storage/sst.go
+++ b/pkg/storage/sst.go
@@ -282,7 +282,7 @@ func CheckSSTConflicts(
 				// of scans.
 				intents = append(intents, roachpb.MakeIntent(mvccMeta.Txn, extIter.UnsafeKey().Key.Clone()))
 				if int64(len(intents)) >= maxIntents {
-					return &kvpb.LockConflictError{Locks: intents}
+					return &kvpb.LockConflictError{Locks: roachpb.AsLocks(intents)}
 				}
 				return nil
 			}
@@ -532,7 +532,7 @@ func CheckSSTConflicts(
 				}
 				intents = append(intents, roachpb.MakeIntent(mvccMeta.Txn, extIter.UnsafeKey().Key.Clone()))
 				if int64(len(intents)) >= maxIntents {
-					return statsDiff, &kvpb.LockConflictError{Locks: intents}
+					return statsDiff, &kvpb.LockConflictError{Locks: roachpb.AsLocks(intents)}
 				}
 				extIter.Next()
 				continue
@@ -1223,7 +1223,7 @@ func CheckSSTConflicts(
 		return enginepb.MVCCStats{}, sstErr
 	}
 	if len(intents) > 0 {
-		return enginepb.MVCCStats{}, &kvpb.LockConflictError{Locks: intents}
+		return enginepb.MVCCStats{}, &kvpb.LockConflictError{Locks: roachpb.AsLocks(intents)}
 	}
 
 	return statsDiff, nil


### PR DESCRIPTION
Informs https://github.com/cockroachdb/cockroach/issues/100193. Needed to allow discovery of replicated locks with different strengths.

The first commit renames `roachpb.Intent` to `roachpb.Lock` in preparation for us adding a strength field to the type and generalizing its use for any lock strength.

To retain some type-safety, the commit also re-introduces a `roachpb.Intent` type, which is a specialization of `Lock` and includes a set of upcasting methods.

The second commit then adds a strength field to the Lock proto.

Release note: None