### PR TITLE
release-22.2: backupccl: add WITH NOWAIT option to SHOW BACKUP

### DIFF
--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -67,6 +67,7 @@ const (
 	backupOptDebugMetadataSST    = "debug_dump_metadata_sst"
 	backupOptEncDir              = "encryption_info_dir"
 	backupOptCheckFiles          = "check_files"
+	backupOptNowait              = "nowait"
 	backupOptConnTestTransfer    = "transfer"
 	backupOptConnTestDuration    = "time"
 	backupOptConnTestConcurrency = "concurrently"

--- a/pkg/ccl/backupccl/testdata/backup-restore/show_backup
+++ b/pkg/ccl/backupccl/testdata/backup-restore/show_backup
@@ -16,6 +16,16 @@ true
 link-backup server=s1 src-path=show_backup_validate,valid-22.2 dest-path=valid-22.2
 ----
 
+query-sql
+SELECT sum(size_bytes) FROM [SHOW BACKUP 'valid-22.2' IN 'nodelocal://1/'];
+----
+1120
+
+query-sql
+SELECT sum(size_bytes) FROM [SHOW BACKUP 'valid-22.2' IN 'nodelocal://1/' WITH nowait];
+----
+0
+
 # This backup is completely valid, but has no jobs.
 query-sql regex=No\sproblems\sfound!
 SELECT * FROM [SHOW BACKUP VALIDATE FROM 'valid-22.2' IN 'nodelocal://0/'];


### PR DESCRIPTION
Backport 1/1 commits from #107501.

/cc @cockroachdb/release

---

Computing the sizes requires reading more metadata, which can be skipped if the sizes are not required.

Release note: none.
Epic: none.


Release justification: Hidden optional argument for use in CC to list backups faster.