### PR TITLE
release-23.1: ui: allow txn details link without app spec

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/transactionsTable/transactionsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsTable/transactionsTable.tsx
@@ -82,10 +82,12 @@ interface TransactionLinkTargetProps {
 export const TransactionLinkTarget = (
   props: TransactionLinkTargetProps,
 ): string => {
-  const searchParams = propsToQueryString({
-    [appNamesAttr]: [props.application],
-  });
-
+  let searchParams = "";
+  if (props.application != null) {
+    searchParams = propsToQueryString({
+      [appNamesAttr]: [props.application],
+    });
+  }
   return `/transaction/${props.transactionFingerprintId}?${searchParams}`;
 };
 


### PR DESCRIPTION
Backporting subset of changes from #107742 (only TransactionLinkTarget changes).
cc @cockroachdb/release 

------------------------------------------------
Previously, the `TransactionLinkTarget` would always specify an app name even if one was not provided in the props. This would effectively make the app name the empty string (unset), which was causing txns details routed from insights contention tables to not being able to be found, unless the appName query was manually removed from the URL.

Epic: none

Release note (bug fix): Going to txn details from insights contention is fixed (link would not show any results previously).

Release justification: bug fix

https://www.loom.com/share/18d1884c920d4d039cbcc4bbfce43e84