### PR TITLE
pkg/util/log: change default httpSink timeout to 2s

### DIFF
--- a/pkg/cli/log_flags_test.go
+++ b/pkg/cli/log_flags_test.go
@@ -51,7 +51,7 @@ func TestSetupLogging(t *testing.T) {
 	const defaultHTTPConfig = `http-defaults: {` +
 		`method: POST, ` +
 		`unsafe-tls: false, ` +
-		`timeout: 0s, ` +
+		`timeout: 2s, ` +
 		`disable-keep-alives: false, ` +
 		`compression: gzip, ` +
 		`filter: INFO, ` +

--- a/pkg/util/log/logconfig/config.go
+++ b/pkg/util/log/logconfig/config.go
@@ -69,6 +69,7 @@ http-defaults:
     format: ` + DefaultHTTPFormat + `
     redactable: true
     exit-on-error: false
+    timeout: 2s
     buffering:
       max-staleness: 5s	
       flush-trigger-size: 1mib

--- a/pkg/util/log/logconfig/testdata/validate
+++ b/pkg/util/log/logconfig/testdata/validate
@@ -634,7 +634,7 @@ sinks:
       address: a
       method: POST
       unsafe-tls: false
-      timeout: 0s
+      timeout: 2s
       disable-keep-alives: false
       headers: {X-CRDB-HEADER: header-value-a}
       compression: gzip
@@ -654,7 +654,7 @@ sinks:
       address: b
       method: POST
       unsafe-tls: false
-      timeout: 0s
+      timeout: 2s
       disable-keep-alives: false
       headers: {X-ANOTHER-HEADER: zz-yy-bb, X-CRDB-HEADER: header-value-b}
       compression: gzip
@@ -674,7 +674,7 @@ sinks:
       address: c
       method: POST
       unsafe-tls: false
-      timeout: 0s
+      timeout: 2s
       disable-keep-alives: false
       compression: gzip
       filter: INFO
@@ -693,7 +693,7 @@ sinks:
       address: d
       method: POST
       unsafe-tls: false
-      timeout: 0s
+      timeout: 2s
       disable-keep-alives: false
       compression: gzip
       filter: INFO

--- a/pkg/util/log/logconfig/validate.go
+++ b/pkg/util/log/logconfig/validate.go
@@ -111,8 +111,11 @@ func (c *Config) Validate(defaultLogDir *string) (resErr error) {
 		UnsafeTLS:         &bf,
 		DisableKeepAlives: &bf,
 		Method:            func() *HTTPSinkMethod { m := HTTPSinkMethod(http.MethodPost); return &m }(),
-		Timeout:           &zeroDuration,
-		Compression:       &GzipCompression,
+		Timeout: func() *time.Duration {
+			twoS := 2 * time.Second
+			return &twoS
+		}(),
+		Compression: &GzipCompression,
 	}
 
 	propagateCommonDefaults(&baseFileDefaults.CommonSinkConfig, baseCommonSinkConfig)

--- a/pkg/util/log/testdata/config
+++ b/pkg/util/log/testdata/config
@@ -117,7 +117,7 @@ sinks:
       address: localhost:5170
       method: POST
       unsafe-tls: false
-      timeout: 0s
+      timeout: 2s
       disable-keep-alives: false
       compression: gzip
       filter: INFO


### PR DESCRIPTION
Previously, the default timeout for the httpSink was
for there to be no timeout at all.

This means that the first call to `output()` on where
the http target was unavailable would hang forever.
This would deadlock the calling goroutine, whether
that's the bufferedSink flush goroutine, or (even worse)
a server goroutine in the event that the httpSink is not
buffered.

Our default timeout should not deadlock in the worst case
scenario. Admittedly, `2s` would also cause a noticeable
performance degradation in the event that the httpSink was
unbuffered, but it would at least be able to emit logs
indicating the timeout as the cause. Availability would also
be maintained to some degree. Previously, the deadlocks
due to no timeout being set by default meant that no
indication was ever given that the httpSink was unable
to reach the http target.

Release note (ops change): The default value of `timeout`
for `http-servers` logging sinks has been changed from
"no timeout" to `2s`. This will be reflected in the
`http-defaults` section of the log configuration. Users
still maintain the ability to override the timeout, or
disable it by explicitly setting it to `0` (e.g. `timeout: 0`).

Fixes: https://github.com/cockroachdb/cockroach/issues/109263