### PR TITLE
ccl/sqlproxyccl: TestInsecureProxy failure fix

### DIFF
--- a/pkg/ccl/sqlproxyccl/proxy_handler_test.go
+++ b/pkg/ccl/sqlproxyccl/proxy_handler_test.go
@@ -1004,8 +1004,16 @@ func TestInsecureProxy(t *testing.T) {
 	te.TestConnect(ctx, t, url, func(conn *pgx.Conn) {
 		require.NoError(t, runTestQuery(ctx, conn))
 	})
-	require.Equal(t, int64(1), s.metrics.AuthFailedCount.Count())
-	require.Equal(t, int64(1), s.metrics.SuccessfulConnCount.Count())
+	testutils.SucceedsSoon(t, func() error {
+		if s.metrics.AuthFailedCount.Count() != 1 ||
+			s.metrics.SuccessfulConnCount.Count() != 1 {
+			return errors.Newf("expected metrics to update, got: "+
+				"AuthFailedCount=%d, SuccessfulConnCount=%d",
+				s.metrics.AuthFailedCount.Count(), s.metrics.SuccessfulConnCount.Count(),
+			)
+		}
+		return nil
+	})
 	count, _ := s.metrics.ConnectionLatency.Total()
 	require.Equal(t, int64(1), count)
 }


### PR DESCRIPTION
TestInsecureProxy failed in
https://github.com/cockroachdb/cockroach/issues/109178 most likely due to race between the proxy setting the metric and the test thread running the check. This PR changes the test to wait a bit for the metrics to be updated.

Epic: none

Release note: None