### PR TITLE
release-23.1: sql: use seeded random for schemachange opsgen

### DIFF
--- a/pkg/workload/schemachange/BUILD.bazel
+++ b/pkg/workload/schemachange/BUILD.bazel
@@ -30,6 +30,7 @@ go_library(
         "//pkg/sql/sem/tree",
         "//pkg/sql/types",
         "//pkg/util/encoding",
+        "//pkg/util/randutil",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "//pkg/workload",


### PR DESCRIPTION
Backport 1/1 commits from #108922.

/cc @cockroachdb/release

---

A schemachange TestWorkload failure was difficult to reproduce; to address this, this patch uses randutil's `NewTestRand()` to allow for a global seed to be set when stressing this test.

Epic: none
Informs: https://github.com/cockroachdb/cockroach/issues/108695
Informs: https://github.com/cockroachdb/cockroach/issues/105517
Informs: https://github.com/cockroachdb/cockroach/issues/109218
Release note: none

Release justification: test only change