### PR TITLE
teamcity-trigger: reduce backupccl paralleism

### DIFF
--- a/pkg/cmd/teamcity-trigger/main.go
+++ b/pkg/cmd/teamcity-trigger/main.go
@@ -157,7 +157,9 @@ func runTC(queueBuild func(string, map[string]string)) {
 			opts["env.EXTRA_BAZEL_FLAGS"] = "--test_env COCKROACH_KVNEMESIS_STEPS=1000"
 		}
 
-		if testTarget == "//pkg/sql/logictest:logictest_test" || testTarget == "//pkg/kv/kvserver:kvserver_test" {
+		if testTarget == "//pkg/sql/logictest:logictest_test" ||
+			testTarget == "//pkg/kv/kvserver:kvserver_test" ||
+			testTarget == "//pkg/ccl/backupccl:backupccl_test" {
 			// Stress heavy with reduced parallelism (to avoid overloading the
 			// machine, see https://github.com/cockroachdb/cockroach/pull/10966).
 			parallelism /= 2


### PR DESCRIPTION
This patch halves the cpu parallelism used for backupccl tests in the nightly stress job as an attempt to prevent mysterious exit 8 errors which we suspect occur due to resource exhaustion.

Informs #109233

Release note: None