### PR TITLE
storage,kv: Remove Read{er,Writer}WithMustIterators

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_export_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_export_test.go
@@ -530,11 +530,14 @@ func exportUsingGoIterator(
 		return nil, nil
 	}
 
-	iter := storage.NewMVCCIncrementalIterator(reader.(storage.ReaderWithMustIterators), storage.MVCCIncrementalIterOptions{
+	iter, err := storage.NewMVCCIncrementalIterator(reader, storage.MVCCIncrementalIterOptions{
 		EndKey:    endKey,
 		StartTime: startTime,
 		EndTime:   endTime,
 	})
+	if err != nil {
+		return nil, err
+	}
 	defer iter.Close()
 	for iter.SeekGE(storage.MakeMVCCMetadataKey(startKey)); ; iterFn(iter) {
 		ok, err := iter.Valid()

--- a/pkg/kv/kvserver/batcheval/cmd_refresh_range.go
+++ b/pkg/kv/kvserver/batcheval/cmd_refresh_range.go
@@ -77,7 +77,7 @@ func refreshRange(
 	// Construct an incremental iterator with the desired time bounds. Incremental
 	// iterators will emit MVCC tombstones by default and will emit intents when
 	// configured to do so (see IntentPolicy).
-	iter := storage.NewMVCCIncrementalIterator(reader.(storage.ReaderWithMustIterators), storage.MVCCIncrementalIterOptions{
+	iter, err := storage.NewMVCCIncrementalIterator(reader, storage.MVCCIncrementalIterOptions{
 		KeyTypes:     storage.IterKeyTypePointsAndRanges,
 		StartKey:     span.Key,
 		EndKey:       span.EndKey,
@@ -85,6 +85,9 @@ func refreshRange(
 		EndTime:      refreshTo,   // inclusive
 		IntentPolicy: storage.MVCCIncrementalIterIntentPolicyEmit,
 	})
+	if err != nil {
+		return err
+	}
 	defer iter.Close()
 
 	var meta enginepb.MVCCMetadata

--- a/pkg/kv/kvserver/rangefeed/catchup_scan_bench_test.go
+++ b/pkg/kv/kvserver/rangefeed/catchup_scan_bench_test.go
@@ -50,10 +50,13 @@ func runCatchUpBenchmark(b *testing.B, emk engineMaker, opts benchOptions) (numE
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		func() {
-			iter := rangefeed.NewCatchUpIterator(eng, span, opts.ts, nil, nil)
+			iter, err := rangefeed.NewCatchUpIterator(eng, span, opts.ts, nil, nil)
+			if err != nil {
+				b.Fatal(err)
+			}
 			defer iter.Close()
 			counter := 0
-			err := iter.CatchUpScan(ctx, func(*kvpb.RangeFeedEvent) error {
+			err = iter.CatchUpScan(ctx, func(*kvpb.RangeFeedEvent) error {
 				counter++
 				return nil
 			}, opts.withDiff)

--- a/pkg/kv/kvserver/rangefeed/catchup_scan_test.go
+++ b/pkg/kv/kvserver/rangefeed/catchup_scan_test.go
@@ -113,7 +113,8 @@ func TestCatchupScan(t *testing.T) {
 	}
 	testutils.RunTrueAndFalse(t, "withDiff", func(t *testing.T, withDiff bool) {
 		span := roachpb.Span{Key: testKey1, EndKey: roachpb.KeyMax}
-		iter := NewCatchUpIterator(eng, span, ts1, nil, nil)
+		iter, err := NewCatchUpIterator(eng, span, ts1, nil, nil)
+		require.NoError(t, err)
 		defer iter.Close()
 		var events []kvpb.RangeFeedValue
 		// ts1 here is exclusive, so we do not want the versions at ts1.
@@ -156,10 +157,11 @@ func TestCatchupScanInlineError(t *testing.T) {
 
 	// Run a catchup scan across the span and watch it error.
 	span := roachpb.Span{Key: keys.LocalMax, EndKey: keys.MaxKey}
-	iter := NewCatchUpIterator(eng, span, hlc.Timestamp{}, nil, nil)
+	iter, err := NewCatchUpIterator(eng, span, hlc.Timestamp{}, nil, nil)
+	require.NoError(t, err)
 	defer iter.Close()
 
-	err := iter.CatchUpScan(ctx, nil, false)
+	err = iter.CatchUpScan(ctx, nil, false)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "unexpected inline value")
 }
@@ -196,7 +198,8 @@ func TestCatchupScanSeesOldIntent(t *testing.T) {
 
 	// Run a catchup scan across the span and watch it succeed.
 	span := roachpb.Span{Key: keys.LocalMax, EndKey: keys.MaxKey}
-	iter := NewCatchUpIterator(eng, span, tsCutoff, nil, nil)
+	iter, err := NewCatchUpIterator(eng, span, tsCutoff, nil, nil)
+	require.NoError(t, err)
 	defer iter.Close()
 
 	keys := map[string]struct{}{}

--- a/pkg/kv/kvserver/rangefeed/registry.go
+++ b/pkg/kv/kvserver/rangefeed/registry.go
@@ -590,17 +590,21 @@ func (r *registration) waitForCaughtUp() error {
 
 // maybeConstructCatchUpIter calls the catchUpIterConstructor and attaches
 // the catchUpIter to be detached in the catchUpScan or closed on disconnect.
-func (r *registration) maybeConstructCatchUpIter() {
+func (r *registration) maybeConstructCatchUpIter() error {
 	if r.catchUpIterConstructor == nil {
-		return
+		return nil
 	}
 
-	catchUpIter := r.catchUpIterConstructor(r.span, r.catchUpTimestamp)
+	catchUpIter, err := r.catchUpIterConstructor(r.span, r.catchUpTimestamp)
+	if err != nil {
+		return err
+	}
 	r.catchUpIterConstructor = nil
 
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.mu.catchUpIter = catchUpIter
+	return nil
 }
 
 // detachCatchUpIter detaches the catchUpIter that was previously attached.

--- a/pkg/kv/kvserver/rangefeed/registry_test.go
+++ b/pkg/kv/kvserver/rangefeed/registry_test.go
@@ -104,12 +104,12 @@ func makeCatchUpIteratorConstructor(iter storage.SimpleMVCCIterator) CatchUpIter
 	if iter == nil {
 		return nil
 	}
-	return func(span roachpb.Span, startTime hlc.Timestamp) *CatchUpIterator {
+	return func(span roachpb.Span, startTime hlc.Timestamp) (*CatchUpIterator, error) {
 		return &CatchUpIterator{
 			simpleCatchupIter: simpleCatchupIterAdapter{iter},
 			span:              span,
 			startTime:         startTime,
-		}
+		}, nil
 	}
 }
 
@@ -129,7 +129,9 @@ func newTestRegistration(
 		func() {},
 		&future.ErrorFuture{},
 	)
-	r.maybeConstructCatchUpIter()
+	if err := r.maybeConstructCatchUpIter(); err != nil {
+		panic(err)
+	}
 	return &testRegistration{
 		registration: r,
 		stream:       s,

--- a/pkg/kv/kvserver/spanset/batch.go
+++ b/pkg/kv/kvserver/spanset/batch.go
@@ -496,16 +496,6 @@ func (s spanSetReader) NewMVCCIterator(
 	return NewIteratorAt(mvccIter, s.spans, s.ts), nil
 }
 
-func (s spanSetReader) MustMVCCIterator(
-	iterKind storage.MVCCIterKind, opts storage.IterOptions,
-) storage.MVCCIterator {
-	iter, err := s.NewMVCCIterator(iterKind, opts)
-	if err != nil {
-		panic(err)
-	}
-	return iter
-}
-
 func (s spanSetReader) NewEngineIterator(opts storage.IterOptions) (storage.EngineIterator, error) {
 	engineIter, err := s.r.NewEngineIterator(opts)
 	if err != nil {
@@ -517,14 +507,6 @@ func (s spanSetReader) NewEngineIterator(opts storage.IterOptions) (storage.Engi
 		spansOnly: s.spansOnly,
 		ts:        s.ts,
 	}, nil
-}
-
-func (s spanSetReader) MustEngineIterator(opts storage.IterOptions) storage.EngineIterator {
-	iter, err := s.NewEngineIterator(opts)
-	if err != nil {
-		panic(err)
-	}
-	return iter
 }
 
 // ConsistentIterators implements the storage.Reader interface.

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -639,25 +639,6 @@ type Reader interface {
 	PinEngineStateForIterators() error
 }
 
-// ReaderWithMustIterators is a Reader that guarantees no errors during
-// iterator creation.
-//
-// TODO(bilal): The only user of this interface is NewMVCCIncrementalIterator.
-// Update that method to handle errors and remove this interface.
-type ReaderWithMustIterators interface {
-	Reader
-
-	// MustMVCCIterator is identical to NewMVCCIterator, except it is implemented
-	// only for those Reader implementations that do not return an error on
-	// iterator creation.
-	MustMVCCIterator(iterKind MVCCIterKind, opts IterOptions) MVCCIterator
-
-	// MustEngineIterator is identical to NewEngineIterator, except it is
-	// implemented only for those Reader implementations that do not return an
-	// error on iterator creation.
-	MustEngineIterator(opts IterOptions) EngineIterator
-}
-
 // Writer is the write interface to an engine's data.
 type Writer interface {
 	// ApplyBatchRepr atomically applies a set of batched updates. Created by
@@ -926,15 +907,6 @@ type ReadWriter interface {
 	Writer
 }
 
-// ReadWriterWithMustIterators is a version of ReadWriter that supports iterator
-// creation without errors.
-//
-// TODO(bilal): Move away from this interface and onto ReadWriter.
-type ReadWriterWithMustIterators interface {
-	ReaderWithMustIterators
-	Writer
-}
-
 // DurabilityRequirement is an advanced option. If in doubt, use
 // StandardDurability.
 //
@@ -953,7 +925,7 @@ const (
 
 // Engine is the interface that wraps the core operations of a key/value store.
 type Engine interface {
-	ReaderWithMustIterators
+	Reader
 	Writer
 	// Attrs returns the engine/store attributes.
 	Attrs() roachpb.Attributes
@@ -1104,7 +1076,7 @@ type Batch interface {
 	// iterator creation. To guarantee that they see all the mutations, the
 	// iterator has to be repositioned using a seek operation, after the
 	// mutations were done.
-	ReaderWithMustIterators
+	Reader
 	WriteBatch
 }
 

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -1500,33 +1500,9 @@ func (p *Pebble) NewMVCCIterator(iterKind MVCCIterKind, opts IterOptions) (MVCCI
 	return maybeWrapInUnsafeIter(iter), nil
 }
 
-// MustMVCCIterator implements the ReaderWithMustIterators interface.
-//
-// If the underlying DB struct in Pebble ever starts returning errors in
-// NewIter(), this method must be removed.
-func (p *Pebble) MustMVCCIterator(iterKind MVCCIterKind, opts IterOptions) MVCCIterator {
-	iter, err := p.NewMVCCIterator(iterKind, opts)
-	if err != nil {
-		panic(err)
-	}
-	return iter
-}
-
 // NewEngineIterator implements the Engine interface.
 func (p *Pebble) NewEngineIterator(opts IterOptions) (EngineIterator, error) {
 	return newPebbleIterator(p.db, opts, StandardDurability, p)
-}
-
-// MustEngineIterator implements the ReaderWithMustIterators interface.
-//
-// If the underlying DB struct in Pebble ever starts returning errors in
-// NewIter(), this method must be removed.
-func (p *Pebble) MustEngineIterator(opts IterOptions) EngineIterator {
-	iter, err := p.NewEngineIterator(opts)
-	if err != nil {
-		panic(err)
-	}
-	return iter
 }
 
 // ScanInternal implements the Engine interface.
@@ -2513,18 +2489,6 @@ func (p *pebbleReadOnly) NewMVCCIterator(
 	return maybeWrapInUnsafeIter(iter), nil
 }
 
-// MustMVCCIterator implements the ReaderWithMustIterators interface.
-//
-// If the underlying DB struct in Pebble ever starts returning errors in
-// NewIter(), this method must be removed.
-func (p *pebbleReadOnly) MustMVCCIterator(iterKind MVCCIterKind, opts IterOptions) MVCCIterator {
-	iter, err := p.NewMVCCIterator(iterKind, opts)
-	if err != nil {
-		panic(err)
-	}
-	return iter
-}
-
 // NewEngineIterator implements the Engine interface.
 func (p *pebbleReadOnly) NewEngineIterator(opts IterOptions) (EngineIterator, error) {
 	if p.closed {
@@ -2559,18 +2523,6 @@ func (p *pebbleReadOnly) NewEngineIterator(opts IterOptions) (EngineIterator, er
 
 	iter.inuse = true
 	return iter, nil
-}
-
-// MustEngineIterator implements the ReaderWithMustIterators interface.
-//
-// If the underlying DB struct in Pebble ever starts returning errors in
-// NewIter(), this method must be removed.
-func (p *pebbleReadOnly) MustEngineIterator(opts IterOptions) EngineIterator {
-	iter, err := p.NewEngineIterator(opts)
-	if err != nil {
-		panic(err)
-	}
-	return iter
 }
 
 // ConsistentIterators implements the Engine interface.
@@ -2766,33 +2718,9 @@ func (p *pebbleSnapshot) NewMVCCIterator(
 	return maybeWrapInUnsafeIter(MVCCIterator(iter)), nil
 }
 
-// MustMVCCIterator implements the ReaderWithMustIterators interface.
-//
-// If the underlying Snapshot struct in Pebble ever starts returning errors in
-// NewIter(), this method must be removed.
-func (p *pebbleSnapshot) MustMVCCIterator(iterKind MVCCIterKind, opts IterOptions) MVCCIterator {
-	iter, err := p.NewMVCCIterator(iterKind, opts)
-	if err != nil {
-		panic(err)
-	}
-	return iter
-}
-
 // NewEngineIterator implements the Reader interface.
 func (p pebbleSnapshot) NewEngineIterator(opts IterOptions) (EngineIterator, error) {
 	return newPebbleIterator(p.snapshot, opts, StandardDurability, p.parent)
-}
-
-// MustEngineIterator implements the ReaderWithMustIterators interface.
-//
-// If the underlying Snapshot struct in Pebble ever starts returning errors in
-// NewIter(), this method must be removed.
-func (p *pebbleSnapshot) MustEngineIterator(opts IterOptions) EngineIterator {
-	iter, err := p.NewEngineIterator(opts)
-	if err != nil {
-		panic(err)
-	}
-	return iter
 }
 
 // ConsistentIterators implements the Reader interface.

--- a/pkg/storage/pebble_batch.go
+++ b/pkg/storage/pebble_batch.go
@@ -223,18 +223,6 @@ func (p *pebbleBatch) NewMVCCIterator(
 	return maybeWrapInUnsafeIter(iter), nil
 }
 
-// MustMVCCIterator implements the ReaderWithMustIterators interface.
-//
-// If the underlying Batch struct in Pebble ever starts returning errors in
-// NewIter(), this method must be removed.
-func (p *pebbleBatch) MustMVCCIterator(iterKind MVCCIterKind, opts IterOptions) MVCCIterator {
-	iter, err := p.NewMVCCIterator(iterKind, opts)
-	if err != nil {
-		panic(err)
-	}
-	return iter
-}
-
 // NewEngineIterator implements the Batch interface.
 func (p *pebbleBatch) NewEngineIterator(opts IterOptions) (EngineIterator, error) {
 	if p.writeOnly {
@@ -271,18 +259,6 @@ func (p *pebbleBatch) NewEngineIterator(opts IterOptions) (EngineIterator, error
 
 	iter.inuse = true
 	return iter, nil
-}
-
-// MustEngineIterator implements the ReaderWithMustIterators interface.
-//
-// If the underlying Batch struct in Pebble ever starts returning errors in
-// NewIter(), this method must be removed.
-func (p *pebbleBatch) MustEngineIterator(opts IterOptions) EngineIterator {
-	iter, err := p.NewEngineIterator(opts)
-	if err != nil {
-		panic(err)
-	}
-	return iter
 }
 
 // ScanInternal implements the Reader interface.


### PR DESCRIPTION
Reader and ReadWriterWithMustIterators were added as a stop-gap in #108864 to avoid having to refactor uses of MVCCIncrementalIterator (and by extention, CatchUpIterator) all in one mega PR. This change addresses some TODOs around moving to `Reader` which has an error return value in the constructor for iterators, and adds the relevant non-repetitive/straightforward plumbing to thread this error through those non-mechanical code paths.

Epic: none

Release note: None