### PR TITLE
streamingccl: stream span config checkpoints

### DIFF
--- a/pkg/ccl/streamingccl/streamproducer/span_config_event_stream.go
+++ b/pkg/ccl/streamingccl/streamproducer/span_config_event_stream.go
@@ -11,6 +11,7 @@ package streamproducer
 import (
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/rangefeed/rangefeedcache"
@@ -22,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
@@ -207,6 +209,10 @@ func (s *spanConfigEventStream) streamLoop(ctx context.Context) error {
 	pacer := makeCheckpointPacer(s.spec.Config.MinCheckpointFrequency)
 	bufferedEvents := make([]streampb.StreamedSpanConfigEntry, 0)
 	batcher := makeStreamEventBatcher()
+	frontier, err := makeSpanConfigFrontier(s.spec.Spans)
+	if err != nil {
+		return err
+	}
 
 	for {
 		select {
@@ -217,7 +223,13 @@ func (s *spanConfigEventStream) streamLoop(ctx context.Context) error {
 		case update := <-s.updateCh:
 			for _, ev := range update.Events {
 				spcfgEvent := ev.(*spanconfigkvsubscriber.BufferEvent)
-				target := spcfgEvent.Update.GetTarget().ToProto()
+				target := spcfgEvent.Update.GetTarget()
+				if target.IsSystemTarget() {
+					// We skip replicating SystemTarget Span configs as they are created
+					// via the internal span config machinery, not via a public facing API
+					// (like the KVAccessor).
+					continue
+				}
 				_, tenantID, err := keys.DecodeTenantPrefix(target.GetSpan().Key)
 				if err != nil {
 					return err
@@ -228,23 +240,52 @@ func (s *spanConfigEventStream) streamLoop(ctx context.Context) error {
 
 				streamedSpanCfgEntry := streampb.StreamedSpanConfigEntry{
 					SpanConfig: roachpb.SpanConfigEntry{
-						Target: target,
+						Target: target.ToProto(),
 						Config: spcfgEvent.Update.GetConfig(),
 					},
 					Timestamp: spcfgEvent.Timestamp(),
 				}
 				bufferedEvents = append(bufferedEvents, streamedSpanCfgEntry)
 			}
-			batcher.addSpanConfigs(bufferedEvents)
+			batcher.addSpanConfigs(bufferedEvents, update.Timestamp)
 			bufferedEvents = bufferedEvents[:0]
 			if pacer.shouldCheckpoint(update.Timestamp, true) {
-				if err := s.flushEvent(ctx, &streampb.StreamEvent{Batch: &batcher.batch}); err != nil {
+				if batcher.getSize() > 0 {
+					if err := s.flushEvent(ctx, &streampb.StreamEvent{Batch: &batcher.batch}); err != nil {
+						return err
+					}
+				}
+				frontier.update(update.Timestamp)
+				if err := s.flushEvent(ctx, &streampb.StreamEvent{Checkpoint: &frontier.checkpoint}); err != nil {
 					return err
 				}
 				batcher.reset()
 			}
 		}
 	}
+}
+
+func makeSpanConfigFrontier(spans roachpb.Spans) (*spanConfigFrontier, error) {
+	if len(spans) != 1 {
+		return nil, errors.AssertionFailedf("unexpected input span length %d", len(spans))
+	}
+	checkpoint := streampb.StreamEvent_StreamCheckpoint{
+		ResolvedSpans: []jobspb.ResolvedSpan{{
+			Span: spans[0],
+		},
+		},
+	}
+	return &spanConfigFrontier{
+		checkpoint: checkpoint,
+	}, nil
+}
+
+type spanConfigFrontier struct {
+	checkpoint streampb.StreamEvent_StreamCheckpoint
+}
+
+func (spf *spanConfigFrontier) update(frontier hlc.Timestamp) {
+	spf.checkpoint.ResolvedSpans[0].Timestamp = frontier
 }
 
 func streamSpanConfigPartition(

--- a/pkg/ccl/streamingccl/streamproducer/stream_event_batcher.go
+++ b/pkg/ccl/streamingccl/streamproducer/stream_event_batcher.go
@@ -57,7 +57,9 @@ func (seb *streamEventBatcher) addDelRange(d *kvpb.RangeFeedDeleteRange) {
 // that an update is newer than the tracked frontier and by checking for
 // duplicates within the inputEvents. This function assumes that the input events are
 // timestamp ordered and that the largest timestamp in the batch is the rangefeed frontier.
-func (seb *streamEventBatcher) addSpanConfigs(inputEvents []streampb.StreamedSpanConfigEntry) {
+func (seb *streamEventBatcher) addSpanConfigs(
+	inputEvents []streampb.StreamedSpanConfigEntry, inputFrontier hlc.Timestamp,
+) {
 
 	// eventSeenAtCurrentTimestamp is used to track unique events within the
 	// inputEvents at the current timestamp.
@@ -82,9 +84,7 @@ func (seb *streamEventBatcher) addSpanConfigs(inputEvents []streampb.StreamedSpa
 			seb.size += event.Size()
 		}
 	}
-	if len(seb.batch.SpanConfigs) > 0 {
-		seb.spanConfigFrontier = seb.batch.SpanConfigs[len(seb.batch.SpanConfigs)-1].Timestamp
-	}
+	seb.spanConfigFrontier = inputFrontier
 }
 
 func (seb *streamEventBatcher) getSize() int {


### PR DESCRIPTION
This patch modifies the span config event stream to emit a checkpoint event
containing the rangefeed frontier after the event stream processes each
rangefeed cache flush.

The span config client can then use this information while processing updates.
Specifically, the subscription.Next() call may return a
checkpoint which indicates that all updates up to a given frontier have been
emitted by the rangefeed.

This patch also fixes two bugs:
- prevents sending an empty batch of updates
- prevents sending system target span config updates

Informs https://github.com/cockroachdb/cockroach/issues/106823

Release note: None