### PR TITLE
sql: fix expected batch count for edge case in copy test

### DIFF
--- a/pkg/sql/copy/copy_test.go
+++ b/pkg/sql/copy/copy_test.go
@@ -601,9 +601,10 @@ func TestLargeDynamicRows(t *testing.T) {
 	err = conn.Exec(ctx, "RESET CLUSTER SETTING kv.raft.command.max_size")
 	require.NoError(t, err)
 
-	// This won't work if the batch size gets set to less than 4.
-	if sql.CopyBatchRowSize < 4 {
-		sql.SetCopyFromBatchSize(4)
+	// This won't work if the batch size gets set to less than 5. When the batch
+	// size is 4, the test hook will count an extra empty batch.
+	if sql.CopyBatchRowSize < 5 {
+		sql.SetCopyFromBatchSize(5)
 	}
 
 	_, err = conn.GetDriverConn().CopyFrom(ctx, strings.NewReader(sb.String()), "COPY t FROM STDIN")


### PR DESCRIPTION
In TestLargeDynamicRows we test that 4 rows of data can fit in a batch size of at least 4 rows given default memory sizes. However, when we set the batch row size to the minimum value of 4, the test hook that counts batches counts an extra empty batch. This PR changes adjusts the minimum row size to 5 for the purposes of this test.

Epic: None
Fixes: #109134

Release note: None