### PR TITLE
[CC-24092] cluster-ui: lint for usages of console logging

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/.eslintrc.json
+++ b/pkg/ui/workspaces/cluster-ui/.eslintrc.json
@@ -11,6 +11,9 @@
     "@typescript-eslint/no-explicit-any": "warn",
     "@typescript-eslint/no-namespace": "off",
     "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_" }],
-    "@cockroachlabs/crdb/require-antd-style-import": "error"
+    "@cockroachlabs/crdb/require-antd-style-import": "error",
+    // Instead of using console log methods directly, cluster-ui code should
+    // call the getLogger() method to provide the appropriate logger.
+    "no-console": "error"
   }
 }


### PR DESCRIPTION
In order to provide more structured error data in management-console, setLogger and getLogger methods were previously added to cluster-ui. They allow the logger to be overridden when used from the cloud. The benefits rely on using the new methods in console-ui instead of console logging methods.  This change adds a lint rule to ensure console logging methods are not used.

Release note: none
Epic: none