### PR TITLE
Revert "concurrency: stop storing txn meta by reference in txnLock"

### DIFF
--- a/pkg/kv/kvserver/concurrency/lock_table_test.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_test.go
@@ -1881,7 +1881,7 @@ func TestLockStateSafeFormat(t *testing.T) {
 	}
 	holder := &txnLock{}
 	l.holders.PushFront(holder)
-	holder.txn = enginepb.TxnMeta{ID: uuid.NamespaceDNS}
+	holder.txn = &enginepb.TxnMeta{ID: uuid.NamespaceDNS}
 	// TODO(arul): add something about replicated locks here too.
 	holder.unreplicatedInfo.init()
 	holder.unreplicatedInfo.ts = hlc.Timestamp{WallTime: 123, Logical: 7}


### PR DESCRIPTION
This reverts commit 0da9146f7b039cc442cba02755c21882d5497c95.

Because we were still returning a pointer, calling code that read from this variable
are now reading from the same copy that we would be overwriting at line 1436. Previously 
the write there was just swapping in a new pointer so callers with a reference to the old pointer
could read without a technical data race.

This probably isn't the best fix but I'm not familiar enough with this code to know whether this
is just revealing an existing bug. That is, was it previously OK if callers were reading from a stale copy? 

Fixes #109313
Fixes #109314
Fixes #109311
Fixes #109310
Fixes #109307
Fixes #109305
Fixes #109303
Fixes #109321
Fixes #109322
Fixes #109323
Fixes #109325

Release note: None