### PR TITLE
release-22.2: roachtest: remove healthchecker from DR tests

### DIFF
--- a/pkg/cmd/roachtest/tests/restore.go
+++ b/pkg/cmd/roachtest/tests/restore.go
@@ -582,8 +582,6 @@ func registerRestore(r registry.Registry) {
 				// having terminated when the test ends.
 				dul := NewDiskUsageLogger(t, c)
 				m.Go(dul.Runner)
-				hc := NewHealthChecker(t, c, c.All())
-				m.Go(hc.Runner)
 
 				// TODO(peter): This currently causes the test to fail because we see a
 				// flurry of valid merges when the restore finishes.
@@ -599,7 +597,6 @@ func registerRestore(r registry.Registry) {
 				tick, perfBuf := initBulkJobPerfArtifacts(testName, item.timeout)
 				m.Go(func(ctx context.Context) error {
 					defer dul.Done()
-					defer hc.Done()
 					t.Status(`running restore`)
 					// Tick once before starting the restore, and once after to
 					// capture the total elapsed time. This is used by
@@ -661,8 +658,6 @@ func registerRestore(r registry.Registry) {
 			// having terminated when the test ends.
 			dul := NewDiskUsageLogger(t, c)
 			m.Go(dul.Runner)
-			hc := NewHealthChecker(t, c, c.All())
-			m.Go(hc.Runner)
 
 			jobIDCh := make(chan jobspb.JobID)
 			jobCompleteCh := make(chan struct{}, 1)
@@ -736,7 +731,6 @@ func registerRestore(r registry.Registry) {
 			tick, perfBuf := initBulkJobPerfArtifacts(withPauseTestName, withPauseTimeout)
 			m.Go(func(ctx context.Context) error {
 				defer dul.Done()
-				defer hc.Done()
 				defer close(jobCompleteCh)
 				defer close(jobIDCh)
 				t.Status(`running restore`)


### PR DESCRIPTION
Backport 1/1 commits from #109171.

/cc @cockroachdb/release

Release justification: test infra flake fix

---

The healthchecker utility adds little coverage beyond a roachtest monitor and has been a frequent cause of connection timeout errors (roachtest flakes), as it opens a new sql connection every five seconds during the test.

Fixes #109023

Epic: none