### PR TITLE
roachtest: simplify address functions

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -2378,26 +2378,6 @@ func (c *clusterImpl) adminUIAddr(
 	return addrs, nil
 }
 
-// InternalAddr returns the internal address in the form host:port for the
-// specified nodes.
-func (c *clusterImpl) InternalAddr(
-	ctx context.Context, l *logger.Logger, node option.NodeListOption,
-) ([]string, error) {
-	var addrs []string
-	urls, err := c.pgURLErr(ctx, l, node, false, "")
-	if err != nil {
-		return nil, err
-	}
-	for _, u := range urls {
-		addr, err := urlToAddr(u)
-		if err != nil {
-			return nil, err
-		}
-		addrs = append(addrs, addr)
-	}
-	return addrs, nil
-}
-
 // InternalIP returns the internal IP addresses for the specified nodes.
 func (c *clusterImpl) InternalIP(
 	ctx context.Context, l *logger.Logger, node option.NodeListOption,
@@ -2405,13 +2385,27 @@ func (c *clusterImpl) InternalIP(
 	return roachprod.IP(l, c.MakeNodes(node), false)
 }
 
+// InternalAddr returns the internal address in the form host:port for the
+// specified nodes.
+func (c *clusterImpl) InternalAddr(
+	ctx context.Context, l *logger.Logger, node option.NodeListOption,
+) ([]string, error) {
+	return c.addr(ctx, l, node, false)
+}
+
 // ExternalAddr returns the external address in the form host:port for the
 // specified node.
 func (c *clusterImpl) ExternalAddr(
 	ctx context.Context, l *logger.Logger, node option.NodeListOption,
 ) ([]string, error) {
+	return c.addr(ctx, l, node, true)
+}
+
+func (c *clusterImpl) addr(
+	ctx context.Context, l *logger.Logger, node option.NodeListOption, external bool,
+) ([]string, error) {
 	var addrs []string
-	urls, err := c.pgURLErr(ctx, l, node, true, "")
+	urls, err := c.pgURLErr(ctx, l, node, external, "")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -2342,26 +2342,9 @@ func addrToHostPort(addr string) (string, int, error) {
 // InternalAdminUIAddr returns the internal Admin UI address in the form host:port
 // for the specified node.
 func (c *clusterImpl) InternalAdminUIAddr(
-	ctx context.Context, l *logger.Logger, node option.NodeListOption,
+	_ context.Context, l *logger.Logger, node option.NodeListOption,
 ) ([]string, error) {
-	var addrs []string
-	internalAddrs, err := roachprod.AdminURL(l, c.MakeNodes(node), "", "",
-		false, false, false)
-	if err != nil {
-		return nil, err
-	}
-	for _, u := range internalAddrs {
-		addr, err := urlToAddr(u)
-		if err != nil {
-			return nil, err
-		}
-		adminUIAddr, err := addrToAdminUIAddr(addr)
-		if err != nil {
-			return nil, err
-		}
-		addrs = append(addrs, adminUIAddr)
-	}
-	return addrs, nil
+	return c.adminUIAddr(l, node, false)
 }
 
 // ExternalAdminUIAddr returns the external Admin UI address in the form host:port
@@ -2369,13 +2352,19 @@ func (c *clusterImpl) InternalAdminUIAddr(
 func (c *clusterImpl) ExternalAdminUIAddr(
 	_ context.Context, l *logger.Logger, node option.NodeListOption,
 ) ([]string, error) {
+	return c.adminUIAddr(l, node, true)
+}
+
+func (c *clusterImpl) adminUIAddr(
+	l *logger.Logger, node option.NodeListOption, external bool,
+) ([]string, error) {
 	var addrs []string
-	externalAddrs, err := roachprod.AdminURL(l, c.MakeNodes(node), "", "",
-		true, false, false)
+	adminURLs, err := roachprod.AdminURL(l, c.MakeNodes(node), "", "",
+		external, false, false)
 	if err != nil {
 		return nil, err
 	}
-	for _, u := range externalAddrs {
+	for _, u := range adminURLs {
 		addr, err := urlToAddr(u)
 		if err != nil {
 			return nil, err

--- a/pkg/cmd/roachtest/cluster/cluster_interface.go
+++ b/pkg/cmd/roachtest/cluster/cluster_interface.go
@@ -73,6 +73,7 @@ type Cluster interface {
 	ExternalPGUrl(ctx context.Context, l *logger.Logger, node option.NodeListOption, tenant string) ([]string, error)
 
 	// SQL clients to nodes.
+
 	Conn(ctx context.Context, l *logger.Logger, node int, opts ...func(*option.ConnOption)) *gosql.DB
 	ConnE(ctx context.Context, l *logger.Logger, node int, opts ...func(*option.ConnOption)) (*gosql.DB, error)
 
@@ -110,7 +111,7 @@ type Cluster interface {
 	IsLocal() bool
 	// IsSecure returns true iff the cluster uses TLS.
 	IsSecure() bool
-	// Returns CPU architecture of the nodes.
+	// Architecture returns CPU architecture of the nodes.
 	Architecture() vm.CPUArch
 
 	// Deleting CockroachDB data and logs on nodes.


### PR DESCRIPTION
Combine the duplicated logic for (Internal,External)AdminUIAddr into one
function.

Epic: None
Release note: NoneBackport 3/3 commits from #109160.

/cc @cockroachdb/release

---

Combine the duplicated logic for internal and external address functions in cluster into one function. This prevents changing one and forgetting to update the other.

Epic: None
Release note: None
Release justification: Test only change
