### PR TITLE
server: add size limit test for `_status/vars`

### DIFF
--- a/pkg/server/application_api/metrics_test.go
+++ b/pkg/server/application_api/metrics_test.go
@@ -13,6 +13,7 @@ package application_api_test
 import (
 	"bytes"
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -20,10 +21,15 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server/apiconstants"
 	"github.com/cockroachdb/cockroach/pkg/server/srvtestutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/httputil"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
 )
+
+// _status/vars outputted lines as of the creation of the TestStatusVarsSizeLimit test.
+var sizeLimit = 9650
 
 // TestMetricsMetadata ensures that the server's recorder return metrics and
 // that each metric has a Name, Help, Unit, and DisplayUnit defined.
@@ -111,6 +117,31 @@ func TestStatusVarsTxnMetrics(t *testing.T) {
 	if !bytes.Contains(body, []byte("sql_txn_rollback_count{node_id=\"1\"} 0")) {
 		t.Errorf("expected `sql_txn_rollback_count{node_id=\"1\"} 0`, got: %s", body)
 	}
+}
+
+// TestStatusVarsSizeLimit verifies the output of _status/vars has not increased
+// substantially from the time of writing this test.
+// Substantial increases to _status/vars have been linked to significantly increased
+// memory usage in Prometheus and OOMs so it is best to have this test act as a warning
+// signal to prevent this. If the limit has been exceeded and it is not due to a bug
+// please consult with the observability infrastructure team to determine a course of
+// action to allow the new metrics to be available.
+// TODO(santamaura): if more use cases for comparison logic between a development branch
+// and master become prevalent then we should replace this with a CI job to check the amount
+// of increase to _status/vars and retire this test.
+func TestStatusVarsSizeLimit(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	skip.UnderRace(t, "unrelated data race")
+	skip.UnderStress(t, "unnecessary to test this scenario")
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(context.Background())
+	body, err := srvtestutils.GetText(s, s.AdminURL().WithPath(apiconstants.StatusPrefix+"vars").String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(string(body), "\n")
+	require.LessOrEqual(t, len(lines), int(float64(sizeLimit)*1.5))
 }
 
 func TestSpanStatsResponse(t *testing.T) {


### PR DESCRIPTION
This commit adds a test `TestStatusVarsSizeLimit`
to verify that `_status/vars` is not returning
a substantially larger output than it is currently. In the future if there are more cases which require comparison between a development branch and master a CI job should be created and one of the tasks it should do is compares the output of `_status/vars` on the development branch and master, At that point this test should be retired.

Resolves #89756

Release note: None