### PR TITLE
streamingccl: attempt to deflake TestStreamDeleteRange

### DIFF
--- a/pkg/ccl/streamingccl/streamproducer/BUILD.bazel
+++ b/pkg/ccl/streamingccl/streamproducer/BUILD.bazel
@@ -115,6 +115,7 @@ go_test(
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",
         "//pkg/sql/sessiondatapb",
+        "//pkg/storage",
         "//pkg/testutils",
         "//pkg/testutils/jobutils",
         "//pkg/testutils/serverutils",

--- a/pkg/testutils/storageutils/BUILD.bazel
+++ b/pkg/testutils/storageutils/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
         "//pkg/util/protoutil",
         "//pkg/util/syncutil",
         "//pkg/util/syncutil/singleflight",
+        "@com_github_cockroachdb_pebble//:pebble",
         "@com_github_stretchr_testify//require",
     ],
 )


### PR DESCRIPTION
Previously, we re-enabled this test, understanding that this test could flake if we happened to hit something that caused us to see the range feeds during a catchup scan rather than as part of the caught up range feed.

Here, we add code to normalize the representation of the delete ranges. We also improve the consumer code to ensure that we are always looking at a complete set of range feed updates.

Possibly Fixes #109312

Epic: none

Release note: None