### PR TITLE
release-22.2: bazci/githubpost: allow C-Test-Failure to be disabled by CI config

### DIFF
--- a/pkg/cmd/github-post/main.go
+++ b/pkg/cmd/github-post/main.go
@@ -64,14 +64,15 @@ func defaultFormatter(ctx context.Context, f failure) (issues.IssueFormatter, is
 		}
 	}
 	return issues.UnitTestFormatter, issues.PostRequest{
-		TestName:        f.testName,
-		PackageName:     f.packageName,
-		Message:         f.testMessage,
-		Artifacts:       "/", // best we can do for unit tests
-		HelpCommand:     issues.UnitTestHelpCommand(repro),
-		MentionOnCreate: mentions,
-		ProjectColumnID: projColID,
-		ExtraLabels:     extraLabels,
+		TestName:             f.testName,
+		PackageName:          f.packageName,
+		Message:              f.testMessage,
+		Artifacts:            "/", // best we can do for unit tests
+		HelpCommand:          issues.UnitTestHelpCommand(repro),
+		MentionOnCreate:      mentions,
+		ProjectColumnID:      projColID,
+		ExtraLabels:          extraLabels,
+		SkipLabelTestFailure: os.Getenv("SKIP_LABEL_TEST_FAILURE") != "",
 	}
 }
 

--- a/pkg/cmd/github-post/main_test.go
+++ b/pkg/cmd/github-post/main_test.go
@@ -24,17 +24,20 @@ import (
 
 func TestListFailures(t *testing.T) {
 	type issue struct {
-		testName    string
-		title       string
-		message     string
-		expRepro    string
-		mention     []string
-		extraLabels []string
-		hasProject  bool
+		testName             string
+		title                string
+		message              string
+		expRepro             string
+		mention              []string
+		extraLabels          []string
+		hasProject           bool
+		skiplabelTestFailure bool
 	}
+
 	// Each test case expects a number of issues.
 	testCases := []struct {
 		pkgEnv    string
+		extraEnv  map[string]string
 		fileName  string
 		expPkg    string
 		expIssues []issue
@@ -51,6 +54,24 @@ func TestListFailures(t *testing.T) {
 				mention:     []string{"@cockroachdb/kv"},
 				extraLabels: []string{"T-kv"},
 				hasProject:  true,
+			}},
+			formatter: defaultFormatter,
+		},
+		{
+			// A clone of the above but configured to set SkipTestLabelTestFailure to
+			// true.
+			pkgEnv:   "",
+			extraEnv: map[string]string{"SKIP_LABEL_TEST_FAILURE": "1"},
+			fileName: "implicit-pkg.json",
+			expPkg:   "github.com/cockroachdb/cockroach/pkg/util/stop",
+			expIssues: []issue{{
+				testName:             "TestStopperWithCancelConcurrent",
+				title:                "util/stop: TestStopperWithCancelConcurrent failed",
+				message:              "this is just a testing issue",
+				mention:              []string{"@cockroachdb/kv"},
+				extraLabels:          []string{"T-kv"},
+				hasProject:           true,
+				skiplabelTestFailure: true,
 			}},
 			formatter: defaultFormatter,
 		},
@@ -262,8 +283,14 @@ TestXXA - 1.00s
 	}
 	for _, c := range testCases {
 		t.Run(c.fileName, func(t *testing.T) {
-			if err := os.Setenv("PKG", c.pkgEnv); err != nil {
-				t.Fatal(err)
+			if c.extraEnv == nil {
+				c.extraEnv = make(map[string]string)
+			}
+
+			c.extraEnv["PKG"] = c.pkgEnv
+
+			for k, v := range c.extraEnv {
+				t.Setenv(k, v)
 			}
 
 			file, err := os.Open(testutils.TestDataPath(t, c.fileName))
@@ -313,6 +340,7 @@ TestXXA - 1.00s
 				assert.Equal(t, c.expIssues[curIssue].mention, req.MentionOnCreate)
 				assert.Equal(t, c.expIssues[curIssue].hasProject, req.ProjectColumnID != 0)
 				assert.Equal(t, c.expIssues[curIssue].extraLabels, req.ExtraLabels)
+				assert.Equal(t, c.expIssues[curIssue].skiplabelTestFailure, req.SkipLabelTestFailure)
 				// On next invocation, we'll check the next expected issue.
 				curIssue++
 				return nil


### PR DESCRIPTION
Backport 1/1 commits from #109173.

/cc @cockroachdb/release

---

    This commit teaches the GitHub issue logger to respect the new
    `SKIP_LABEL_TEST_FAILURE` environment variable. Setting this envvar to
    any non-zero string value will set `SkipLabelTestFailure` to true, which
    causes the logger to not set the `C-Test-Failure` but continue to log
    failures on aggregate issues.

    Doing so allows us to continue logging the behavioral divergences
    discovered by `TestComposeCompare` without treating them as strict test
    failures.

    The environment variable is intentionally applied to all failures within
    a given CI configuration rather than on a test name basis. This should
    incentivize relegation of high failure tests to isolated CI builds and
    set an appropriate threshold for when a test may be excluded from being
    considered a failure.

Informs: #99181, #89361, #108652, #82867
Release note: None
Release justification: CI change only

