### PR TITLE
release-23.1.9-rc: base: add env vars for RPC settings

### DIFF
--- a/pkg/base/config.go
+++ b/pkg/base/config.go
@@ -146,7 +146,7 @@ var (
 	// both a network roundtrip and a TCP retransmit, but we don't need to
 	// tolerate more than 1 retransmit per connection attempt, so
 	// 2 * NetworkTimeout is sufficient.
-	DialTimeout = 2 * NetworkTimeout
+	DialTimeout = envutil.EnvOrDefaultDuration("COCKROACH_RPC_DIAL_TIMEOUT", 2*NetworkTimeout)
 
 	// PingInterval is the interval between network heartbeat pings. It is used
 	// both for RPC heartbeat intervals and gRPC server keepalive pings. It is
@@ -212,7 +212,8 @@ var (
 	// heartbeats and reduce this to NetworkTimeout (plus DialTimeout for the
 	// initial heartbeat), see:
 	// https://github.com/cockroachdb/cockroach/issues/93397.
-	defaultRPCHeartbeatTimeout = 3 * NetworkTimeout
+	defaultRPCHeartbeatTimeout = envutil.EnvOrDefaultDuration(
+		"COCKROACH_RPC_HEARTBEAT_TIMEOUT", 3*NetworkTimeout)
 
 	// defaultRaftTickInterval is the default resolution of the Raft timer.
 	defaultRaftTickInterval = envutil.EnvOrDefaultDuration(


### PR DESCRIPTION
Backport 1/1 commits from #109318.

/cc @cockroachdb/release

---

Epic: none
Release note (ops change): The RPC dial and heartbeat timeouts can now be configured via the environment variables COCKROACH_RPC_DIAL_TIMEOUT (default 2x COCKROACH_NETWORK_TIMEOUT or 2x2=4 seconds) and COCKROACH_RPC_HEARTBEAT_TIMEOUT (default 3x COCKROACH_NETWORK_TIMEOUT or 3x2=6 seconds). This allows configuring these values independently of COCKROACH_NETWORK_TIMEOUT.

Release justification: Unable to work around a customer issue without this parameter.
