### PR TITLE
generate-bazel-extra: make `dev gen bazel` work with custom symlink

### DIFF
--- a/pkg/cmd/generate-bazel-extra/main.go
+++ b/pkg/cmd/generate-bazel-extra/main.go
@@ -41,7 +41,7 @@ var (
 )
 
 func runBuildozer(args []string) {
-	const buildozer = "_bazel/bin/external/com_github_bazelbuild_buildtools/buildozer/buildozer_/buildozer"
+	var buildozer = os.Args[0] + ".runfiles/../../../../../external/com_github_bazelbuild_buildtools/buildozer/buildozer_/buildozer"
 	cmd := exec.Command(buildozer, args...)
 	output, err := cmd.CombinedOutput()
 	if err != nil {


### PR DESCRIPTION
Previously, running `dev gen bazel` with a custom symlink would fail because the path to buildozer was hardcoded. This PR replaces the hardcoded path with a search to the location of generate-bazel-extra and finds buildozer from the relative resulting path.

Fixes: #94162
Release note: None