### PR TITLE
release-23.1: roachtest: clean up node shutdown infra and deflake c2c/shutdown

### DIFF
--- a/pkg/cmd/roachtest/tests/backup.go
+++ b/pkg/cmd/roachtest/tests/backup.go
@@ -222,7 +222,7 @@ func registerBackupNodeShutdown(r registry.Registry) {
 			nodeToShutdown := 3
 			dest := loadBackupData(ctx, t, c)
 			backupQuery := `BACKUP bank.bank TO 'nodelocal://1/` + dest + `' WITH DETACHED`
-			startBackup := func(c cluster.Cluster, t test.Test) (jobID string, err error) {
+			startBackup := func(c cluster.Cluster, t test.Test) (jobID jobspb.JobID, err error) {
 				gatewayDB := c.Conn(ctx, t.L(), gatewayNode)
 				defer gatewayDB.Close()
 
@@ -244,7 +244,7 @@ func registerBackupNodeShutdown(r registry.Registry) {
 			nodeToShutdown := 2
 			dest := loadBackupData(ctx, t, c)
 			backupQuery := `BACKUP bank.bank TO 'nodelocal://1/` + dest + `' WITH DETACHED`
-			startBackup := func(c cluster.Cluster, t test.Test) (jobID string, err error) {
+			startBackup := func(c cluster.Cluster, t test.Test) (jobID jobspb.JobID, err error) {
 				gatewayDB := c.Conn(ctx, t.L(), gatewayNode)
 				defer gatewayDB.Close()
 

--- a/pkg/cmd/roachtest/tests/cluster_to_cluster.go
+++ b/pkg/cmd/roachtest/tests/cluster_to_cluster.go
@@ -337,6 +337,9 @@ type replicationDriver struct {
 	// beforeWorkloadHook is called before the main workload begins.
 	beforeWorkloadHook func()
 
+	// cutoverStarted closes once the driver issues a cutover commmand.
+	cutoverStarted chan struct{}
+
 	// replicationStartHook is called as soon as the replication job begins.
 	replicationStartHook func(ctx context.Context, sp *replicationDriver)
 
@@ -431,6 +434,7 @@ func (rd *replicationDriver) setupC2C(ctx context.Context, t test.Test, c cluste
 	rd.metrics = &c2cMetrics{}
 	rd.replicationStartHook = func(ctx context.Context, sp *replicationDriver) {}
 	rd.beforeWorkloadHook = func() {}
+	rd.cutoverStarted = make(chan struct{})
 
 	if !c.IsLocal() {
 		// TODO(msbutler): pass a proper cluster replication dashboard and figure out why we need to
@@ -549,6 +553,7 @@ func (rd *replicationDriver) stopReplicationStream(
 	ctx context.Context, ingestionJob int, cutoverTime time.Time,
 ) {
 	rd.setup.dst.sysSQL.Exec(rd.t, `ALTER TENANT $1 COMPLETE REPLICATION TO SYSTEM TIME $2::string`, rd.setup.dst.name, cutoverTime)
+	close(rd.cutoverStarted)
 	err := retry.ForDuration(time.Minute*5, func() error {
 		var status string
 		var payloadBytes []byte
@@ -1016,28 +1021,45 @@ func getPhase(rd *replicationDriver, dstJobID jobspb.JobID) c2cPhase {
 	return phaseCutover
 }
 
-func waitForTargetPhase(rd *replicationDriver, dstJobID jobspb.JobID, targetPhase c2cPhase) error {
+func waitForTargetPhase(
+	ctx context.Context, rd *replicationDriver, dstJobID jobspb.JobID, targetPhase c2cPhase,
+) error {
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
 	for {
 		currentPhase := getPhase(rd, dstJobID)
-		rd.t.L().Printf("Current Phase %s", currentPhase.String())
-		switch {
-		case currentPhase < targetPhase:
-			time.Sleep(5 * time.Second)
-		case currentPhase == targetPhase:
-			rd.t.L().Printf("In target phase %s", currentPhase.String())
+		rd.t.L().Printf("current Phase %s", currentPhase.String())
+		select {
+		case <-rd.cutoverStarted:
+			require.Equal(rd.t, phaseCutover, getPhase(rd, dstJobID), "the replication job is not yet in the cutover phase")
+			rd.t.L().Printf("cutover phase discovered via channel")
 			return nil
-		default:
-			return errors.New("c2c job past target phase")
+		case <-ticker.C:
+			switch {
+			case currentPhase < targetPhase:
+			case currentPhase == targetPhase:
+				rd.t.L().Printf("In target phase %s", currentPhase.String())
+				return nil
+			default:
+				return errors.New("c2c job past target phase")
+			}
+		case <-ctx.Done():
+			return ctx.Err()
 		}
 	}
 }
 
-func sleepBeforeResiliencyEvent(rd *replicationDriver) {
+func sleepBeforeResiliencyEvent(rd *replicationDriver, phase c2cPhase) {
 	// Assuming every C2C phase lasts at least 10 seconds, introduce some waiting
 	// before a resiliency event (e.g. a node shutdown) to ensure the event occurs
 	// once we're fully settled into the target phase (e.g. the stream ingestion
 	// processors have observed the cutover signal).
-	randomSleep := time.Duration(1+rd.rng.Intn(2)) * time.Second
+	baseSleep := 1
+	if phase == phaseCutover {
+		// Cutover can sometimes be fast, so sleep for less time.
+		baseSleep = 0
+	}
+	randomSleep := time.Duration(baseSleep+rd.rng.Intn(2)) * time.Second
 	rd.t.L().Printf("Take a %s power nap", randomSleep)
 	time.Sleep(randomSleep)
 }
@@ -1151,10 +1173,10 @@ func registerClusterReplicationResilience(r registry.Registry) {
 				// DR scenario the src cluster may have gone belly up during a
 				// successful c2c replication execution.
 				shutdownStarter := func() jobStarter {
-					return func(c cluster.Cluster, t test.Test) (string, error) {
-						require.NoError(t, waitForTargetPhase(rrd.replicationDriver, rrd.dstJobID, rrd.phase))
-						sleepBeforeResiliencyEvent(rrd.replicationDriver)
-						return fmt.Sprintf("%d", rrd.dstJobID), nil
+					return func(c cluster.Cluster, t test.Test) (jobspb.JobID, error) {
+						require.NoError(t, waitForTargetPhase(ctx, rrd.replicationDriver, rrd.dstJobID, rrd.phase))
+						sleepBeforeResiliencyEvent(rrd.replicationDriver, rrd.phase)
+						return rrd.dstJobID, nil
 					}
 				}
 				destinationWatcherNode := rrd.watcherNode
@@ -1215,8 +1237,8 @@ func registerClusterReplicationDisconnect(r registry.Registry) {
 		dstJobID := jobspb.JobID(getIngestionJobID(t, rd.setup.dst.sysSQL, rd.setup.dst.name))
 
 		// TODO(msbutler): disconnect nodes during a random phase
-		require.NoError(t, waitForTargetPhase(rd, dstJobID, phaseSteadyState))
-		sleepBeforeResiliencyEvent(rd)
+		require.NoError(t, waitForTargetPhase(ctx, rd, dstJobID, phaseSteadyState))
+		sleepBeforeResiliencyEvent(rd, phaseSteadyState)
 		ingestionProgress := getJobProgress(t, rd.setup.dst.sysSQL, dstJobID).GetStreamIngest()
 
 		srcDestConnections := getSrcDestNodePairs(rd, ingestionProgress)

--- a/pkg/cmd/roachtest/tests/restore.go
+++ b/pkg/cmd/roachtest/tests/restore.go
@@ -57,9 +57,8 @@ func registerRestoreNodeShutdown(r registry.Registry) {
 
 	makeRestoreStarter := func(ctx context.Context, t test.Test, c cluster.Cluster,
 		gatewayNode int, rd restoreDriver) jobStarter {
-		return func(c cluster.Cluster, t test.Test) (string, error) {
-			jobID, err := rd.runDetached(ctx, "DATABASE tpce", gatewayNode)
-			return fmt.Sprintf("%d", jobID), err
+		return func(c cluster.Cluster, t test.Test) (jobspb.JobID, error) {
+			return rd.runDetached(ctx, "DATABASE tpce", gatewayNode)
 		}
 	}
 


### PR DESCRIPTION
Backport 1/1 commits from #109227.

/cc @cockroachdb/release

Release justification: test infra change

---


The c2c/shutdown tests can flake if a node shuts down during cutover because
cutover may complete before the node shutdown infra has a chance to shut the
job down. This patch speeds the node infra shutdown logic in the following
ways:
- Previously, the c2c driver would poll every 5 seconds for the cutover phase.
  This patch adds a channel that will signal immediatly when cutover has begun.
- Previously the node shutdown infra would wait for all ranges to be fully
  replicated and wait an additional second before beginning shutdown. This
patch elides these checks for c2c node shutdown tests, as they can be shut down
immediatly after the `jobStarter` function returns.

This patch cleans up the roachtest node shutdown helper used by a variety of
tests. Notably, the patch removes one unecessary goroutine.

Informs #109119
Informs #108760

Release note: None
    
