### PR TITLE
sqlsmith: categorize CREATE FUNCTION as a mutating statement

### DIFF
--- a/pkg/internal/sqlsmith/relational.go
+++ b/pkg/internal/sqlsmith/relational.go
@@ -109,10 +109,10 @@ var (
 		{1, makeRestore},
 		{1, makeExport},
 		{1, makeImport},
+		{1, makeCreateFunc},
 	}
 	nonMutatingStatements = []statementWeight{
 		{10, makeSelect},
-		{1, makeCreateFunc},
 	}
 	allStatements = append(mutatingStatements, nonMutatingStatements...)
 


### PR DESCRIPTION
Since it alters state, it should not count as non-mutating.

fixes https://github.com/cockroachdb/cockroach/issues/108888
Release note: None