### PR TITLE
concurrency: allow multiple txns to acquire shared locks on a single key 

### DIFF
--- a/pkg/kv/kvserver/concurrency/lock_table.go
+++ b/pkg/kv/kvserver/concurrency/lock_table.go
@@ -2748,13 +2748,6 @@ func (kl *keyLocks) acquireLock(acq *roachpb.LockAcquisition, clock *hlc.Clock) 
 		return nil
 	}
 
-	if kl.isLocked() {
-		// TODO(arul): multilpe lock holders on a single key haven't been wired up
-		// fully. Return an error until that's the case. Note that the reacquisition
-		// case has already been handled above.
-		return errors.AssertionFailedf("existing lock cannot be acquired by different transaction")
-	}
-
 	// NB: The lock isn't held, so the request trying to acquire the lock must be
 	// an (inactive) queued writer in the lock's wait queues. Typically, we expect
 	// this to be the first queued writer; the list of queued writers is

--- a/pkg/kv/kvserver/concurrency/lock_table.go
+++ b/pkg/kv/kvserver/concurrency/lock_table.go
@@ -1680,7 +1680,9 @@ func (kl *keyLocks) safeFormat(sb *redact.StringBuilder, txnStatusCache *txnStat
 		for e := kl.queuedWriters.Front(); e != nil; e = e.Next() {
 			qg := e.Value.(*queuedGuard)
 			g := qg.guard
-			sb.Printf("    active: %t req: %d, txn: ", redact.Safe(qg.active), redact.Safe(qg.guard.seqNum))
+			sb.Printf("    active: %t req: %d, strength: %s, txn: ",
+				redact.Safe(qg.active), redact.Safe(qg.guard.seqNum), redact.Safe(qg.mode.Strength),
+			)
 			if g.txn == nil {
 				sb.SafeString("none\n")
 			} else {

--- a/pkg/kv/kvserver/concurrency/lock_table_test.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_test.go
@@ -1882,16 +1882,16 @@ func TestLockStateSafeFormat(t *testing.T) {
 	holder := &txnLock{}
 	l.holders.PushFront(holder)
 	holder.txn = &enginepb.TxnMeta{ID: uuid.NamespaceDNS}
-	// TODO(arul): add something about replicated locks here too.
 	holder.unreplicatedInfo.init()
 	holder.unreplicatedInfo.ts = hlc.Timestamp{WallTime: 123, Logical: 7}
 	require.NoError(t, holder.unreplicatedInfo.acquire(lock.Exclusive, 1))
 	require.NoError(t, holder.unreplicatedInfo.acquire(lock.Shared, 3))
+	holder.replicatedInfo.ts = hlc.Timestamp{WallTime: 125, Logical: 1}
 	require.EqualValues(t,
-		" lock: ‹\"KEY\"›\n  holder: txn: 6ba7b810-9dad-11d1-80b4-00c04fd430c8 epoch: 0, iso: Serializable, ts: 0.000000123,7, info: unrepl [(str: Exclusive seq: 1), (str: Shared seq: 3)]\n",
+		" lock: ‹\"KEY\"›\n  holder: txn: 6ba7b810-9dad-11d1-80b4-00c04fd430c8 epoch: 0, iso: Serializable, ts: 0.000000123,7, info: repl, unrepl [(str: Exclusive seq: 1), (str: Shared seq: 3)]\n",
 		redact.Sprint(l))
 	require.EqualValues(t,
-		" lock: ‹×›\n  holder: txn: 6ba7b810-9dad-11d1-80b4-00c04fd430c8 epoch: 0, iso: Serializable, ts: 0.000000123,7, info: unrepl [(str: Exclusive seq: 1), (str: Shared seq: 3)]\n",
+		" lock: ‹×›\n  holder: txn: 6ba7b810-9dad-11d1-80b4-00c04fd430c8 epoch: 0, iso: Serializable, ts: 0.000000123,7, info: repl, unrepl [(str: Exclusive seq: 1), (str: Shared seq: 3)]\n",
 		redact.Sprint(l).Redact())
 }
 

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/clear_abandoned_intents
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/clear_abandoned_intents
@@ -166,7 +166,7 @@ num=1
  lock: "a"
   holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
    queued writers:
-    active: false req: 2, txn: 00000001-0000-0000-0000-000000000000
+    active: false req: 2, strength: Intent, txn: 00000001-0000-0000-0000-000000000000
 
 sequence req=req1
 ----
@@ -202,11 +202,11 @@ debug-lock-table
 num=2
  lock: "a"
    queued writers:
-    active: false req: 2, txn: 00000001-0000-0000-0000-000000000000
+    active: false req: 2, strength: Intent, txn: 00000001-0000-0000-0000-000000000000
  lock: "b"
   holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [holder finalized: committed]
    queued writers:
-    active: false req: 2, txn: 00000001-0000-0000-0000-000000000000
+    active: false req: 2, strength: Intent, txn: 00000001-0000-0000-0000-000000000000
 
 sequence req=req1
 ----
@@ -231,14 +231,14 @@ debug-lock-table
 num=3
  lock: "a"
    queued writers:
-    active: false req: 2, txn: 00000001-0000-0000-0000-000000000000
+    active: false req: 2, strength: Intent, txn: 00000001-0000-0000-0000-000000000000
  lock: "b"
    queued writers:
-    active: false req: 2, txn: 00000001-0000-0000-0000-000000000000
+    active: false req: 2, strength: Intent, txn: 00000001-0000-0000-0000-000000000000
  lock: "c"
   holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [holder finalized: committed]
    queued writers:
-    active: false req: 2, txn: 00000001-0000-0000-0000-000000000000
+    active: false req: 2, strength: Intent, txn: 00000001-0000-0000-0000-000000000000
 
 sequence req=req1
 ----
@@ -258,13 +258,13 @@ debug-lock-table
 num=3
  lock: "a"
    queued writers:
-    active: false req: 2, txn: 00000001-0000-0000-0000-000000000000
+    active: false req: 2, strength: Intent, txn: 00000001-0000-0000-0000-000000000000
  lock: "b"
    queued writers:
-    active: false req: 2, txn: 00000001-0000-0000-0000-000000000000
+    active: false req: 2, strength: Intent, txn: 00000001-0000-0000-0000-000000000000
  lock: "c"
    queued writers:
-    active: false req: 2, txn: 00000001-0000-0000-0000-000000000000
+    active: false req: 2, strength: Intent, txn: 00000001-0000-0000-0000-000000000000
 
 finish req=req1
 ----
@@ -451,15 +451,15 @@ num=3
  lock: "c"
   holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
    queued writers:
-    active: false req: 5, txn: 00000001-0000-0000-0000-000000000000
+    active: false req: 5, strength: Intent, txn: 00000001-0000-0000-0000-000000000000
  lock: "d"
   holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
    queued writers:
-    active: false req: 5, txn: 00000001-0000-0000-0000-000000000000
+    active: false req: 5, strength: Intent, txn: 00000001-0000-0000-0000-000000000000
  lock: "e"
   holder: txn: 00000005-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
    queued writers:
-    active: false req: 5, txn: 00000001-0000-0000-0000-000000000000
+    active: false req: 5, strength: Intent, txn: 00000001-0000-0000-0000-000000000000
 
 sequence req=req1
 ----
@@ -478,16 +478,16 @@ num=3
  lock: "c"
   holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
    queued writers:
-    active: true req: 5, txn: 00000001-0000-0000-0000-000000000000
+    active: true req: 5, strength: Intent, txn: 00000001-0000-0000-0000-000000000000
    distinguished req: 5
  lock: "d"
   holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
    queued writers:
-    active: false req: 5, txn: 00000001-0000-0000-0000-000000000000
+    active: false req: 5, strength: Intent, txn: 00000001-0000-0000-0000-000000000000
  lock: "e"
   holder: txn: 00000005-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
    queued writers:
-    active: false req: 5, txn: 00000001-0000-0000-0000-000000000000
+    active: false req: 5, strength: Intent, txn: 00000001-0000-0000-0000-000000000000
 
 new-request name=req3 txn=txn3 ts=10,1
   put key=a value=v3
@@ -537,16 +537,16 @@ num=5
  lock: "c"
   holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
    queued writers:
-    active: true req: 5, txn: 00000001-0000-0000-0000-000000000000
+    active: true req: 5, strength: Intent, txn: 00000001-0000-0000-0000-000000000000
    distinguished req: 5
  lock: "d"
   holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
    queued writers:
-    active: false req: 5, txn: 00000001-0000-0000-0000-000000000000
+    active: false req: 5, strength: Intent, txn: 00000001-0000-0000-0000-000000000000
  lock: "e"
   holder: txn: 00000005-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
    queued writers:
-    active: false req: 5, txn: 00000001-0000-0000-0000-000000000000
+    active: false req: 5, strength: Intent, txn: 00000001-0000-0000-0000-000000000000
 
 new-request name=req2 txn=txn2 ts=11,1
   scan key=a endkey=c
@@ -577,16 +577,16 @@ num=5
  lock: "c"
   holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
    queued writers:
-    active: true req: 5, txn: 00000001-0000-0000-0000-000000000000
+    active: true req: 5, strength: Intent, txn: 00000001-0000-0000-0000-000000000000
    distinguished req: 5
  lock: "d"
   holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
    queued writers:
-    active: false req: 5, txn: 00000001-0000-0000-0000-000000000000
+    active: false req: 5, strength: Intent, txn: 00000001-0000-0000-0000-000000000000
  lock: "e"
   holder: txn: 00000005-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
    queued writers:
-    active: false req: 5, txn: 00000001-0000-0000-0000-000000000000
+    active: false req: 5, strength: Intent, txn: 00000001-0000-0000-0000-000000000000
 
 debug-advance-clock ts=123
 ----
@@ -619,15 +619,15 @@ num=4
    distinguished req: 8
  lock: "c"
    queued writers:
-    active: false req: 5, txn: 00000001-0000-0000-0000-000000000000
+    active: false req: 5, strength: Intent, txn: 00000001-0000-0000-0000-000000000000
  lock: "d"
   holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [holder finalized: aborted]
    queued writers:
-    active: false req: 5, txn: 00000001-0000-0000-0000-000000000000
+    active: false req: 5, strength: Intent, txn: 00000001-0000-0000-0000-000000000000
  lock: "e"
   holder: txn: 00000005-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
    queued writers:
-    active: true req: 5, txn: 00000001-0000-0000-0000-000000000000
+    active: true req: 5, strength: Intent, txn: 00000001-0000-0000-0000-000000000000
    distinguished req: 5
 
 debug-advance-clock ts=123
@@ -652,14 +652,14 @@ debug-lock-table
 num=3
  lock: "c"
    queued writers:
-    active: false req: 5, txn: 00000001-0000-0000-0000-000000000000
+    active: false req: 5, strength: Intent, txn: 00000001-0000-0000-0000-000000000000
  lock: "d"
    queued writers:
-    active: false req: 5, txn: 00000001-0000-0000-0000-000000000000
+    active: false req: 5, strength: Intent, txn: 00000001-0000-0000-0000-000000000000
  lock: "e"
   holder: txn: 00000005-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
    queued writers:
-    active: true req: 5, txn: 00000001-0000-0000-0000-000000000000
+    active: true req: 5, strength: Intent, txn: 00000001-0000-0000-0000-000000000000
    distinguished req: 5
 
 finish req=req2

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/deadlocks
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/deadlocks
@@ -372,18 +372,18 @@ num=3
  lock: "a"
   holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
    queued writers:
-    active: true req: 10, txn: 00000004-0000-0000-0000-000000000000
-    active: true req: 13, txn: 00000003-0000-0000-0000-000000000000
+    active: true req: 10, strength: Intent, txn: 00000004-0000-0000-0000-000000000000
+    active: true req: 13, strength: Intent, txn: 00000003-0000-0000-0000-000000000000
    distinguished req: 10
  lock: "b"
   holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
    queued writers:
-    active: true req: 11, txn: 00000001-0000-0000-0000-000000000000
+    active: true req: 11, strength: Intent, txn: 00000001-0000-0000-0000-000000000000
    distinguished req: 11
  lock: "c"
   holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
    queued writers:
-    active: true req: 12, txn: 00000002-0000-0000-0000-000000000000
+    active: true req: 12, strength: Intent, txn: 00000002-0000-0000-0000-000000000000
    distinguished req: 12
 
 # Break the deadlock by aborting txn1.
@@ -576,11 +576,11 @@ num=3
   holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
  lock: "b"
    queued writers:
-    active: false req: 17, txn: 00000004-0000-0000-0000-000000000000
+    active: false req: 17, strength: Intent, txn: 00000004-0000-0000-0000-000000000000
  lock: "c"
   holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
    queued writers:
-    active: true req: 17, txn: 00000004-0000-0000-0000-000000000000
+    active: true req: 17, strength: Intent, txn: 00000004-0000-0000-0000-000000000000
    distinguished req: 17
 
 # --------------------------------
@@ -626,17 +626,17 @@ num=3
  lock: "a"
   holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
    queued writers:
-    active: true req: 19, txn: 00000003-0000-0000-0000-000000000000
+    active: true req: 19, strength: Intent, txn: 00000003-0000-0000-0000-000000000000
    distinguished req: 19
  lock: "b"
    queued writers:
-    active: false req: 17, txn: 00000004-0000-0000-0000-000000000000
-    active: true req: 18, txn: 00000001-0000-0000-0000-000000000000
+    active: false req: 17, strength: Intent, txn: 00000004-0000-0000-0000-000000000000
+    active: true req: 18, strength: Intent, txn: 00000001-0000-0000-0000-000000000000
    distinguished req: 18
  lock: "c"
   holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
    queued writers:
-    active: true req: 17, txn: 00000004-0000-0000-0000-000000000000
+    active: true req: 17, strength: Intent, txn: 00000004-0000-0000-0000-000000000000
    distinguished req: 17
 
 # Break the deadlock by aborting txn4.
@@ -812,11 +812,11 @@ num=3
   holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
  lock: "b"
    queued writers:
-    active: false req: 23, txn: 00000004-0000-0000-0000-000000000000
+    active: false req: 23, strength: Intent, txn: 00000004-0000-0000-0000-000000000000
  lock: "c"
   holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
    queued writers:
-    active: true req: 23, txn: 00000004-0000-0000-0000-000000000000
+    active: true req: 23, strength: Intent, txn: 00000004-0000-0000-0000-000000000000
    distinguished req: 23
 
 # --------------------------------
@@ -862,17 +862,17 @@ num=3
  lock: "a"
   holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
    queued writers:
-    active: true req: 25, txn: 00000003-0000-0000-0000-000000000000
+    active: true req: 25, strength: Intent, txn: 00000003-0000-0000-0000-000000000000
    distinguished req: 25
  lock: "b"
    queued writers:
-    active: false req: 23, txn: 00000004-0000-0000-0000-000000000000
-    active: true req: 24, txn: 00000001-0000-0000-0000-000000000000
+    active: false req: 23, strength: Intent, txn: 00000004-0000-0000-0000-000000000000
+    active: true req: 24, strength: Intent, txn: 00000001-0000-0000-0000-000000000000
    distinguished req: 24
  lock: "c"
   holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
    queued writers:
-    active: true req: 23, txn: 00000004-0000-0000-0000-000000000000
+    active: true req: 23, strength: Intent, txn: 00000004-0000-0000-0000-000000000000
    distinguished req: 23
 
 # Break the deadlock by aborting txn1.
@@ -1085,16 +1085,16 @@ debug-lock-table
 num=3
  lock: "a"
    queued writers:
-    active: false req: 30, txn: 00000004-0000-0000-0000-000000000000
+    active: false req: 30, strength: Intent, txn: 00000004-0000-0000-0000-000000000000
  lock: "b"
    queued writers:
-    active: false req: 29, txn: 00000005-0000-0000-0000-000000000000
-    active: true req: 30, txn: 00000004-0000-0000-0000-000000000000
+    active: false req: 29, strength: Intent, txn: 00000005-0000-0000-0000-000000000000
+    active: true req: 30, strength: Intent, txn: 00000004-0000-0000-0000-000000000000
    distinguished req: 30
  lock: "c"
   holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
    queued writers:
-    active: true req: 29, txn: 00000005-0000-0000-0000-000000000000
+    active: true req: 29, strength: Intent, txn: 00000005-0000-0000-0000-000000000000
    distinguished req: 29
 
 # --------------------------------
@@ -1124,18 +1124,18 @@ debug-lock-table
 num=3
  lock: "a"
    queued writers:
-    active: false req: 30, txn: 00000004-0000-0000-0000-000000000000
-    active: true req: 31, txn: 00000003-0000-0000-0000-000000000000
+    active: false req: 30, strength: Intent, txn: 00000004-0000-0000-0000-000000000000
+    active: true req: 31, strength: Intent, txn: 00000003-0000-0000-0000-000000000000
    distinguished req: 31
  lock: "b"
    queued writers:
-    active: false req: 29, txn: 00000005-0000-0000-0000-000000000000
-    active: true req: 30, txn: 00000004-0000-0000-0000-000000000000
+    active: false req: 29, strength: Intent, txn: 00000005-0000-0000-0000-000000000000
+    active: true req: 30, strength: Intent, txn: 00000004-0000-0000-0000-000000000000
    distinguished req: 30
  lock: "c"
   holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
    queued writers:
-    active: true req: 29, txn: 00000005-0000-0000-0000-000000000000
+    active: true req: 29, strength: Intent, txn: 00000005-0000-0000-0000-000000000000
    distinguished req: 29
 
 # Break the deadlock by aborting txn4.

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/lock_timeout
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/lock_timeout
@@ -83,7 +83,7 @@ num=3
  lock: "k2"
   holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued writers:
-    active: true req: 3, txn: 00000003-0000-0000-0000-000000000000
+    active: true req: 3, strength: Intent, txn: 00000003-0000-0000-0000-000000000000
    distinguished req: 3
  lock: "k3"
   holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 11.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
@@ -141,11 +141,11 @@ debug-lock-table
 num=2
  lock: "k2"
    queued writers:
-    active: false req: 3, txn: 00000003-0000-0000-0000-000000000000
+    active: false req: 3, strength: Intent, txn: 00000003-0000-0000-0000-000000000000
  lock: "k3"
   holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 11.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued writers:
-    active: true req: 3, txn: 00000003-0000-0000-0000-000000000000
+    active: true req: 3, strength: Intent, txn: 00000003-0000-0000-0000-000000000000
    distinguished req: 3
 
 # -------------------------------------------------------------
@@ -208,11 +208,11 @@ debug-lock-table
 num=3
  lock: "k2"
    queued writers:
-    active: false req: 3, txn: 00000003-0000-0000-0000-000000000000
+    active: false req: 3, strength: Intent, txn: 00000003-0000-0000-0000-000000000000
  lock: "k3"
   holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 11.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued writers:
-    active: true req: 3, txn: 00000003-0000-0000-0000-000000000000
+    active: true req: 3, strength: Intent, txn: 00000003-0000-0000-0000-000000000000
    distinguished req: 3
  lock: "k4"
   holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/queue_length_exceeded
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/queue_length_exceeded
@@ -91,9 +91,9 @@ num=1
  lock: "k"
   holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued writers:
-    active: true req: 2, txn: 00000002-0000-0000-0000-000000000000
-    active: true req: 3, txn: 00000003-0000-0000-0000-000000000000
-    active: true req: 4, txn: 00000004-0000-0000-0000-000000000000
+    active: true req: 2, strength: Intent, txn: 00000002-0000-0000-0000-000000000000
+    active: true req: 3, strength: Intent, txn: 00000003-0000-0000-0000-000000000000
+    active: true req: 4, strength: Intent, txn: 00000004-0000-0000-0000-000000000000
    distinguished req: 2
 
 # -------------------------------------------------------------
@@ -171,8 +171,8 @@ num=1
  lock: "k"
   holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 11.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued writers:
-    active: true req: 3, txn: 00000003-0000-0000-0000-000000000000
-    active: true req: 4, txn: 00000004-0000-0000-0000-000000000000
+    active: true req: 3, strength: Intent, txn: 00000003-0000-0000-0000-000000000000
+    active: true req: 4, strength: Intent, txn: 00000004-0000-0000-0000-000000000000
    distinguished req: 3
 
 # -------------------------------------------------------------

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/range_state_listener
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/range_state_listener
@@ -103,7 +103,7 @@ num=2
  lock: "k"
   holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
    queued writers:
-    active: true req: 2, txn: 00000002-0000-0000-0000-000000000000
+    active: true req: 2, strength: Intent, txn: 00000002-0000-0000-0000-000000000000
    distinguished req: 2
  lock: "k2"
   holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
@@ -166,7 +166,7 @@ num=1
  lock: "k"
   holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
    queued writers:
-    active: false req: 3, txn: 00000002-0000-0000-0000-000000000000
+    active: false req: 3, strength: Intent, txn: 00000002-0000-0000-0000-000000000000
 
 sequence req=req2
 ----
@@ -213,7 +213,7 @@ debug-lock-table
 num=1
  lock: "k"
    queued writers:
-    active: false req: 3, txn: 00000002-0000-0000-0000-000000000000
+    active: false req: 3, strength: Intent, txn: 00000002-0000-0000-0000-000000000000
 
 on-lock-acquired req=req2 key=k
 ----
@@ -281,7 +281,7 @@ num=1
  lock: "k"
   holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
    queued writers:
-    active: false req: 4, txn: 00000003-0000-0000-0000-000000000000
+    active: false req: 4, strength: Intent, txn: 00000003-0000-0000-0000-000000000000
 
 sequence req=req3
 ----
@@ -323,7 +323,7 @@ debug-lock-table
 num=1
  lock: "k"
    queued writers:
-    active: false req: 4, txn: 00000003-0000-0000-0000-000000000000
+    active: false req: 4, strength: Intent, txn: 00000003-0000-0000-0000-000000000000
 
 on-lock-acquired req=req3 key=k
 ----
@@ -412,7 +412,7 @@ num=1
  lock: "k"
   holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
    queued writers:
-    active: true req: 6, txn: 00000002-0000-0000-0000-000000000000
+    active: true req: 6, strength: Intent, txn: 00000002-0000-0000-0000-000000000000
    distinguished req: 6
 
 on-split
@@ -439,7 +439,7 @@ num=1
  lock: "k"
   holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
    queued writers:
-    active: false req: 6, txn: 00000002-0000-0000-0000-000000000000
+    active: false req: 6, strength: Intent, txn: 00000002-0000-0000-0000-000000000000
 
 sequence req=req2
 ----
@@ -481,7 +481,7 @@ debug-lock-table
 num=1
  lock: "k"
    queued writers:
-    active: false req: 6, txn: 00000002-0000-0000-0000-000000000000
+    active: false req: 6, strength: Intent, txn: 00000002-0000-0000-0000-000000000000
 
 on-lock-acquired req=req2 key=k
 ----
@@ -591,7 +591,7 @@ num=1
  lock: "k"
   holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
    queued writers:
-    active: true req: 8, txn: 00000002-0000-0000-0000-000000000000
+    active: true req: 8, strength: Intent, txn: 00000002-0000-0000-0000-000000000000
    distinguished req: 8
 
 on-merge
@@ -659,7 +659,7 @@ num=1
  lock: "k"
   holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
    queued writers:
-    active: false req: 10, txn: 00000002-0000-0000-0000-000000000000
+    active: false req: 10, strength: Intent, txn: 00000002-0000-0000-0000-000000000000
 
 sequence req=req2
 ----
@@ -701,7 +701,7 @@ debug-lock-table
 num=1
  lock: "k"
    queued writers:
-    active: false req: 10, txn: 00000002-0000-0000-0000-000000000000
+    active: false req: 10, strength: Intent, txn: 00000002-0000-0000-0000-000000000000
 
 on-lock-acquired req=req2 key=k
 ----
@@ -790,7 +790,7 @@ num=1
  lock: "k"
   holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
    queued writers:
-    active: true req: 12, txn: 00000002-0000-0000-0000-000000000000
+    active: true req: 12, strength: Intent, txn: 00000002-0000-0000-0000-000000000000
    distinguished req: 12
 
 on-snapshot-applied
@@ -817,7 +817,7 @@ num=1
  lock: "k"
   holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
    queued writers:
-    active: false req: 12, txn: 00000002-0000-0000-0000-000000000000
+    active: false req: 12, strength: Intent, txn: 00000002-0000-0000-0000-000000000000
 
 sequence req=req2
 ----
@@ -859,7 +859,7 @@ debug-lock-table
 num=1
  lock: "k"
    queued writers:
-    active: false req: 12, txn: 00000002-0000-0000-0000-000000000000
+    active: false req: 12, strength: Intent, txn: 00000002-0000-0000-0000-000000000000
 
 on-lock-acquired req=req2 key=k
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/resolve_pushed_intents
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/resolve_pushed_intents
@@ -116,7 +116,7 @@ debug-lock-table
 num=1
  lock: "c"
    queued writers:
-    active: false req: 2, txn: 00000003-0000-0000-0000-000000000000
+    active: false req: 2, strength: Intent, txn: 00000003-0000-0000-0000-000000000000
 
 on-txn-updated txn=txn2 status=aborted
 ----
@@ -477,7 +477,7 @@ debug-lock-table
 num=1
  lock: "c"
    queued writers:
-    active: false req: 7, txn: 00000003-0000-0000-0000-000000000000
+    active: false req: 7, strength: Intent, txn: 00000003-0000-0000-0000-000000000000
 
 on-txn-updated txn=txn2 status=aborted
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/update
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/update
@@ -383,7 +383,7 @@ num=1
  lock: "k"
   holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl, unrepl [(str: Exclusive seq: 0)]
    queued writers:
-    active: true req: 9, txn: none
+    active: true req: 9, strength: Intent, txn: none
    distinguished req: 9
 
 # Finish off txn1. Not needed once we can get rid of req4.

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_elsewhere
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_elsewhere
@@ -71,7 +71,7 @@ num=1
  lock: "k"
   holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
    queued writers:
-    active: true req: 2, txn: 00000002-0000-0000-0000-000000000000
+    active: true req: 2, strength: Intent, txn: 00000002-0000-0000-0000-000000000000
    distinguished req: 2
 
 sequence req=reqSecondLock

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_policy_error
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_policy_error
@@ -83,7 +83,7 @@ num=3
  lock: "k2"
   holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued writers:
-    active: true req: 3, txn: 00000003-0000-0000-0000-000000000000
+    active: true req: 3, strength: Intent, txn: 00000003-0000-0000-0000-000000000000
    distinguished req: 3
  lock: "k3"
   holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 11.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
@@ -143,11 +143,11 @@ debug-lock-table
 num=2
  lock: "k2"
    queued writers:
-    active: false req: 3, txn: 00000003-0000-0000-0000-000000000000
+    active: false req: 3, strength: Intent, txn: 00000003-0000-0000-0000-000000000000
  lock: "k3"
   holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 11.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued writers:
-    active: true req: 3, txn: 00000003-0000-0000-0000-000000000000
+    active: true req: 3, strength: Intent, txn: 00000003-0000-0000-0000-000000000000
    distinguished req: 3
 
 # -------------------------------------------------------------
@@ -208,11 +208,11 @@ debug-lock-table
 num=3
  lock: "k2"
    queued writers:
-    active: false req: 3, txn: 00000003-0000-0000-0000-000000000000
+    active: false req: 3, strength: Intent, txn: 00000003-0000-0000-0000-000000000000
  lock: "k3"
   holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 11.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued writers:
-    active: true req: 3, txn: 00000003-0000-0000-0000-000000000000
+    active: true req: 3, strength: Intent, txn: 00000003-0000-0000-0000-000000000000
    distinguished req: 3
  lock: "k4"
   holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_policy_skip
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_policy_skip
@@ -114,7 +114,7 @@ num=4
   holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 11.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
  lock: "k4"
    queued writers:
-    active: false req: 4, txn: 00000004-0000-0000-0000-000000000000
+    active: false req: 4, strength: Intent, txn: 00000004-0000-0000-0000-000000000000
 
 # -------------------------------------------------------------
 # Read-only request with WaitPolicy_Skip hits lock sequences

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_self
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_self
@@ -102,9 +102,9 @@ debug-lock-table
 num=1
  lock: "k"
    queued writers:
-    active: false req: 2, txn: 00000001-0000-0000-0000-000000000000
-    active: true req: 3, txn: 00000003-0000-0000-0000-000000000000
-    active: true req: 4, txn: 00000001-0000-0000-0000-000000000000
+    active: false req: 2, strength: Intent, txn: 00000001-0000-0000-0000-000000000000
+    active: true req: 3, strength: Intent, txn: 00000003-0000-0000-0000-000000000000
+    active: true req: 4, strength: Intent, txn: 00000001-0000-0000-0000-000000000000
    distinguished req: 3
 
 

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/acquire_ignored_seqs
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/acquire_ignored_seqs
@@ -117,7 +117,7 @@ num=1
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl, unrepl [(str: Exclusive seq: 1)]
    queued writers:
-    active: true req: 3, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 3
 
 # However, unreplicated lock acquisition with the same ignored sequence number
@@ -131,7 +131,7 @@ num=1
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl, unrepl [(str: Exclusive seq: 1)]
    queued writers:
-    active: true req: 3, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 3
 
 # ------------------------------------------------------------------------------
@@ -150,7 +150,7 @@ num=1
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl, unrepl [(str: Exclusive seq: 11)]
    queued writers:
-    active: true req: 3, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 3
 
 # ------------------------------------------------------------------------------
@@ -172,5 +172,5 @@ num=1
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, iso: Serializable, ts: 11.000000000,1, info: repl
    queued writers:
-    active: true req: 3, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 3

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/add_discovered
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/add_discovered
@@ -69,8 +69,8 @@ release txn=txn1 span=a
 num=1
  lock: "a"
    queued writers:
-    active: false req: 2, txn: 00000000-0000-0000-0000-000000000002
-    active: true req: 3, txn: 00000000-0000-0000-0000-000000000003
+    active: false req: 2, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 3
 
 guard-state r=req2
@@ -91,7 +91,7 @@ num=1
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
    queued writers:
-    active: false req: 2, txn: 00000000-0000-0000-0000-000000000002
+    active: false req: 2, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
 
 scan r=req2
 ----
@@ -111,7 +111,7 @@ num=1
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
    queued writers:
-    active: true req: 2, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 2, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 2
 
 release txn=txn3 span=a
@@ -119,7 +119,7 @@ release txn=txn3 span=a
 num=1
  lock: "a"
    queued writers:
-    active: false req: 2, txn: 00000000-0000-0000-0000-000000000002
+    active: false req: 2, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
 
 guard-state r=req2
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/basic
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/basic
@@ -135,7 +135,7 @@ update txn=txn1 ts=11,1 epoch=1 span=b
 num=3
  lock: "b"
    queued writers:
-    active: false req: 4, txn: 00000000-0000-0000-0000-000000000002
+    active: false req: 4, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
  lock: "c"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
  lock: "e"
@@ -157,10 +157,10 @@ update txn=txn1 ts=11,1 epoch=1 span=c,e
 num=3
  lock: "b"
    queued writers:
-    active: false req: 4, txn: 00000000-0000-0000-0000-000000000002
+    active: false req: 4, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
  lock: "c"
    queued writers:
-    active: false req: 4, txn: 00000000-0000-0000-0000-000000000002
+    active: false req: 4, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
  lock: "e"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
 
@@ -188,13 +188,13 @@ num=4
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 6.000000000,0, info: repl
    queued writers:
-    active: false req: 4, txn: 00000000-0000-0000-0000-000000000002
+    active: false req: 4, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
  lock: "b"
    queued writers:
-    active: false req: 4, txn: 00000000-0000-0000-0000-000000000002
+    active: false req: 4, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
  lock: "c"
    queued writers:
-    active: false req: 4, txn: 00000000-0000-0000-0000-000000000002
+    active: false req: 4, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
  lock: "e"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
 
@@ -204,13 +204,13 @@ num=5
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 6.000000000,0, info: repl
    queued writers:
-    active: false req: 4, txn: 00000000-0000-0000-0000-000000000002
+    active: false req: 4, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
  lock: "b"
    queued writers:
-    active: false req: 4, txn: 00000000-0000-0000-0000-000000000002
+    active: false req: 4, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
  lock: "c"
    queued writers:
-    active: false req: 4, txn: 00000000-0000-0000-0000-000000000002
+    active: false req: 4, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
  lock: "e"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
  lock: "f"
@@ -255,14 +255,14 @@ num=5
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 6.000000000,0, info: repl
    queued writers:
-    active: true req: 4, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 4, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 4
  lock: "b"
    queued writers:
-    active: false req: 4, txn: 00000000-0000-0000-0000-000000000002
+    active: false req: 4, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
  lock: "c"
    queued writers:
-    active: false req: 4, txn: 00000000-0000-0000-0000-000000000002
+    active: false req: 4, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
  lock: "e"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
  lock: "f"
@@ -393,14 +393,14 @@ num=5
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 6.000000000,0, info: repl
    queued writers:
-    active: true req: 4, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 4, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 4
  lock: "b"
    queued writers:
-    active: false req: 4, txn: 00000000-0000-0000-0000-000000000002
+    active: false req: 4, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
  lock: "c"
    queued writers:
-    active: false req: 4, txn: 00000000-0000-0000-0000-000000000002
+    active: false req: 4, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
  lock: "e"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
  lock: "f"
@@ -441,16 +441,16 @@ num=5
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 6.000000000,0, info: repl
    queued writers:
-    active: true req: 4, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 4, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 4
  lock: "b"
    queued writers:
-    active: false req: 4, txn: 00000000-0000-0000-0000-000000000002
-    active: true req: 6, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 4, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 6, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 6
  lock: "c"
    queued writers:
-    active: false req: 4, txn: 00000000-0000-0000-0000-000000000002
+    active: false req: 4, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
  lock: "e"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
  lock: "f"
@@ -596,17 +596,17 @@ num=5
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 6.000000000,0, info: repl
    queued writers:
-    active: true req: 4, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 4, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 4
  lock: "b"
    queued writers:
-    active: false req: 4, txn: 00000000-0000-0000-0000-000000000002
-    active: true req: 6, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 4, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 6, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 6
  lock: "c"
    queued writers:
-    active: false req: 4, txn: 00000000-0000-0000-0000-000000000002
-    active: true req: 7, txn: 00000000-0000-0000-0000-000000000003
+    active: false req: 4, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 7, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 7
  lock: "e"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
@@ -737,16 +737,16 @@ release txn=txn3 span=a
 num=5
  lock: "a"
    queued writers:
-    active: false req: 4, txn: 00000000-0000-0000-0000-000000000002
+    active: false req: 4, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
  lock: "b"
    queued writers:
-    active: false req: 4, txn: 00000000-0000-0000-0000-000000000002
-    active: true req: 6, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 4, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 6, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 6
  lock: "c"
    queued writers:
-    active: false req: 4, txn: 00000000-0000-0000-0000-000000000002
-    active: true req: 7, txn: 00000000-0000-0000-0000-000000000003
+    active: false req: 4, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 7, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 7
  lock: "e"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
@@ -766,16 +766,16 @@ print
 num=5
  lock: "a"
    queued writers:
-    active: false req: 4, txn: 00000000-0000-0000-0000-000000000002
+    active: false req: 4, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
  lock: "b"
    queued writers:
-    active: false req: 4, txn: 00000000-0000-0000-0000-000000000002
-    active: true req: 6, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 4, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 6, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 6
  lock: "c"
    queued writers:
-    active: false req: 4, txn: 00000000-0000-0000-0000-000000000002
-    active: true req: 7, txn: 00000000-0000-0000-0000-000000000003
+    active: false req: 4, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 7, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 7
  lock: "e"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
@@ -909,16 +909,16 @@ release txn=txn3 span=f
 num=4
  lock: "a"
    queued writers:
-    active: false req: 4, txn: 00000000-0000-0000-0000-000000000002
+    active: false req: 4, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
  lock: "b"
    queued writers:
-    active: false req: 4, txn: 00000000-0000-0000-0000-000000000002
-    active: true req: 6, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 4, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 6, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 6
  lock: "c"
    queued writers:
-    active: false req: 4, txn: 00000000-0000-0000-0000-000000000002
-    active: true req: 7, txn: 00000000-0000-0000-0000-000000000003
+    active: false req: 4, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 7, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 7
  lock: "e"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
@@ -952,16 +952,16 @@ acquire r=req4 k=b durability=r strength=intent
 num=4
  lock: "a"
    queued writers:
-    active: false req: 4, txn: 00000000-0000-0000-0000-000000000002
+    active: false req: 4, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 8.000000000,12, info: repl
    queued writers:
-    active: true req: 6, txn: 00000000-0000-0000-0000-000000000001
+    active: true req: 6, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 6
  lock: "c"
    queued writers:
-    active: false req: 4, txn: 00000000-0000-0000-0000-000000000002
-    active: true req: 7, txn: 00000000-0000-0000-0000-000000000003
+    active: false req: 4, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 7, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 7
  lock: "e"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
@@ -971,16 +971,16 @@ acquire r=req4 k=c durability=r strength=intent
 num=4
  lock: "a"
    queued writers:
-    active: false req: 4, txn: 00000000-0000-0000-0000-000000000002
+    active: false req: 4, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 8.000000000,12, info: repl
    queued writers:
-    active: true req: 6, txn: 00000000-0000-0000-0000-000000000001
+    active: true req: 6, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 6
  lock: "c"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 8.000000000,12, info: repl
    queued writers:
-    active: true req: 7, txn: 00000000-0000-0000-0000-000000000003
+    active: true req: 7, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 7
  lock: "e"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
@@ -998,16 +998,16 @@ print
 num=4
  lock: "a"
    queued writers:
-    active: false req: 4, txn: 00000000-0000-0000-0000-000000000002
+    active: false req: 4, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 8.000000000,12, info: repl
    queued writers:
-    active: true req: 6, txn: 00000000-0000-0000-0000-000000000001
+    active: true req: 6, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 6
  lock: "c"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 8.000000000,12, info: repl
    queued writers:
-    active: true req: 7, txn: 00000000-0000-0000-0000-000000000003
+    active: true req: 7, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 7
  lock: "e"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
@@ -1114,12 +1114,12 @@ num=3
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 8.000000000,12, info: repl
    queued writers:
-    active: true req: 6, txn: 00000000-0000-0000-0000-000000000001
+    active: true req: 6, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 6
  lock: "c"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 8.000000000,12, info: repl
    queued writers:
-    active: true req: 7, txn: 00000000-0000-0000-0000-000000000003
+    active: true req: 7, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 7
  lock: "e"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
@@ -1150,11 +1150,11 @@ num=3
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 8.000000000,12, info: repl
    queued writers:
-    active: true req: 6, txn: 00000000-0000-0000-0000-000000000001
+    active: true req: 6, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 6
  lock: "c"
    queued writers:
-    active: false req: 7, txn: 00000000-0000-0000-0000-000000000003
+    active: false req: 7, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
  lock: "e"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
 
@@ -1172,11 +1172,11 @@ num=3
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 8.000000000,12, info: repl
    queued writers:
-    active: true req: 6, txn: 00000000-0000-0000-0000-000000000001
+    active: true req: 6, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 6
  lock: "c"
    queued writers:
-    active: false req: 7, txn: 00000000-0000-0000-0000-000000000003
+    active: false req: 7, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
  lock: "e"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
 
@@ -1286,10 +1286,10 @@ release txn=txn2 span=b
 num=3
  lock: "b"
    queued writers:
-    active: false req: 6, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 6, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
  lock: "c"
    queued writers:
-    active: false req: 7, txn: 00000000-0000-0000-0000-000000000003
+    active: false req: 7, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
  lock: "e"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
 
@@ -1322,11 +1322,11 @@ print
 num=3
  lock: "b"
    queued writers:
-    active: false req: 6, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 6, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
  lock: "c"
    queued writers:
-    active: false req: 6, txn: 00000000-0000-0000-0000-000000000001
-    active: false req: 7, txn: 00000000-0000-0000-0000-000000000003
+    active: false req: 6, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 7, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
  lock: "e"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
 
@@ -1440,7 +1440,7 @@ dequeue r=req6
 num=2
  lock: "c"
    queued writers:
-    active: false req: 7, txn: 00000000-0000-0000-0000-000000000003
+    active: false req: 7, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
  lock: "e"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
 
@@ -1737,9 +1737,9 @@ num=1
  lock: "c"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
    queued writers:
-    active: true req: 10, txn: 00000000-0000-0000-0000-000000000002
-    active: true req: 11, txn: 00000000-0000-0000-0000-000000000003
-    active: true req: 12, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 10, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 11, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
+    active: true req: 12, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 10
 
 metrics
@@ -1837,9 +1837,9 @@ release txn=txn1 span=c
 num=1
  lock: "c"
    queued writers:
-    active: false req: 10, txn: 00000000-0000-0000-0000-000000000002
-    active: true req: 11, txn: 00000000-0000-0000-0000-000000000003
-    active: true req: 12, txn: 00000000-0000-0000-0000-000000000002
+    active: false req: 10, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 11, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
+    active: true req: 12, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 11
 
 guard-state r=req10
@@ -1863,9 +1863,9 @@ print
 num=1
  lock: "c"
    queued writers:
-    active: false req: 10, txn: 00000000-0000-0000-0000-000000000002
-    active: true req: 11, txn: 00000000-0000-0000-0000-000000000003
-    active: true req: 12, txn: 00000000-0000-0000-0000-000000000002
+    active: false req: 10, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 11, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
+    active: true req: 12, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 11
 
 metrics
@@ -1963,7 +1963,7 @@ num=1
  lock: "c"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 8.000000000,12, info: unrepl [(str: Exclusive seq: 0)]
    queued writers:
-    active: true req: 11, txn: 00000000-0000-0000-0000-000000000003
+    active: true req: 11, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 11
 
 guard-state r=req11
@@ -1981,7 +1981,7 @@ num=1
  lock: "c"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 8.000000000,12, info: unrepl [(str: Exclusive seq: 0)]
    queued writers:
-    active: true req: 11, txn: 00000000-0000-0000-0000-000000000003
+    active: true req: 11, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 11
 
 metrics
@@ -2080,7 +2080,7 @@ num=1
  lock: "c"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 8.000000000,12, info: unrepl [(str: Exclusive seq: 0)]
    queued writers:
-    active: true req: 11, txn: 00000000-0000-0000-0000-000000000003
+    active: true req: 11, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 11
 
 acquire r=req12 k=c durability=r strength=intent
@@ -2089,7 +2089,7 @@ num=1
  lock: "c"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 8.000000000,12, info: repl, unrepl [(str: Exclusive seq: 0)]
    queued writers:
-    active: true req: 11, txn: 00000000-0000-0000-0000-000000000003
+    active: true req: 11, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 11
 
 dequeue r=req12
@@ -2098,7 +2098,7 @@ num=1
  lock: "c"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 8.000000000,12, info: repl, unrepl [(str: Exclusive seq: 0)]
    queued writers:
-    active: true req: 11, txn: 00000000-0000-0000-0000-000000000003
+    active: true req: 11, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 11
 
 guard-state r=req11
@@ -2110,7 +2110,7 @@ release txn=txn2 span=b,d
 num=1
  lock: "c"
    queued writers:
-    active: false req: 11, txn: 00000000-0000-0000-0000-000000000003
+    active: false req: 11, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
 
 guard-state r=req11
 ----
@@ -2121,7 +2121,7 @@ print
 num=1
  lock: "c"
    queued writers:
-    active: false req: 11, txn: 00000000-0000-0000-0000-000000000003
+    active: false req: 11, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
 
 metrics
 ----
@@ -2251,14 +2251,14 @@ release txn=txn2 span=b,d
 num=1
  lock: "c"
    queued writers:
-    active: false req: 14, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 14, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
 
 dequeue r=req15
 ----
 num=1
  lock: "c"
    queued writers:
-    active: false req: 14, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 14, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
 
 new-request r=req16 txn=none ts=10,12 spans=none@c
 ----
@@ -2419,12 +2419,12 @@ num=2
  lock: "c"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, iso: Serializable, ts: 9.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued writers:
-    active: true req: 18, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 18, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 18
  lock: "d"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, iso: Serializable, ts: 9.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued writers:
-    active: true req: 19, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 19, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 19
 
 metrics
@@ -2525,11 +2525,11 @@ release txn=txn1 span=c
 num=2
  lock: "c"
    queued writers:
-    active: false req: 18, txn: 00000000-0000-0000-0000-000000000002
+    active: false req: 18, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
  lock: "d"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, iso: Serializable, ts: 9.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued writers:
-    active: true req: 19, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 19, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 19
 
 guard-state r=req18
@@ -2541,12 +2541,12 @@ print
 num=2
  lock: "c"
    queued writers:
-    active: false req: 18, txn: 00000000-0000-0000-0000-000000000002
+    active: false req: 18, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
  lock: "d"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, iso: Serializable, ts: 9.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued writers:
-    active: true req: 18, txn: 00000000-0000-0000-0000-000000000002
-    active: true req: 19, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 18, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 19, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 19
 
 metrics
@@ -2646,11 +2646,11 @@ release txn=txn1 span=d
 num=2
  lock: "c"
    queued writers:
-    active: false req: 18, txn: 00000000-0000-0000-0000-000000000002
+    active: false req: 18, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
  lock: "d"
    queued writers:
-    active: false req: 18, txn: 00000000-0000-0000-0000-000000000002
-    active: true req: 19, txn: 00000000-0000-0000-0000-000000000002
+    active: false req: 18, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 19, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
 
 scan r=req18
 ----
@@ -2661,7 +2661,7 @@ acquire r=req18 k=d durability=u strength=exclusive
 num=2
  lock: "c"
    queued writers:
-    active: false req: 18, txn: 00000000-0000-0000-0000-000000000002
+    active: false req: 18, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
  lock: "d"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
 
@@ -2747,7 +2747,7 @@ num=2
  lock: "c"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued writers:
-    active: true req: 22, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 22, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 22
  lock: "d"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
@@ -2856,11 +2856,11 @@ num=2
  lock: "c"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued writers:
-    active: true req: 22, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 22, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 22
  lock: "d"
    queued writers:
-    active: false req: 23, txn: 00000000-0000-0000-0000-000000000003
+    active: false req: 23, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000003
 
 guard-state r=req23
 ----
@@ -2880,10 +2880,10 @@ release txn=txn1 span=c
 num=2
  lock: "c"
    queued writers:
-    active: false req: 22, txn: 00000000-0000-0000-0000-000000000002
+    active: false req: 22, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
  lock: "d"
    queued writers:
-    active: false req: 23, txn: 00000000-0000-0000-0000-000000000003
+    active: false req: 23, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000003
 
 guard-state r=req22
 ----
@@ -2894,11 +2894,11 @@ print
 num=2
  lock: "c"
    queued writers:
-    active: false req: 22, txn: 00000000-0000-0000-0000-000000000002
+    active: false req: 22, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
  lock: "d"
    queued writers:
-    active: false req: 22, txn: 00000000-0000-0000-0000-000000000002
-    active: false req: 23, txn: 00000000-0000-0000-0000-000000000003
+    active: false req: 22, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
+    active: false req: 23, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000003
 
 metrics
 ----
@@ -2996,11 +2996,11 @@ acquire r=req23 k=d durability=u strength=exclusive
 num=2
  lock: "c"
    queued writers:
-    active: false req: 22, txn: 00000000-0000-0000-0000-000000000002
+    active: false req: 22, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
  lock: "d"
   holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued writers:
-    active: false req: 22, txn: 00000000-0000-0000-0000-000000000002
+    active: false req: 22, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
 
 dequeue r=req22
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/clear
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/clear
@@ -117,12 +117,12 @@ num=3
    waiting readers:
     req: 3, txn: none
    queued writers:
-    active: true req: 4, txn: none
+    active: true req: 4, strength: Intent, txn: none
    distinguished req: 3
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
    queued writers:
-    active: true req: 5, txn: 00000000-0000-0000-0000-000000000003
+    active: true req: 5, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 5
  lock: "c"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 8.000000000,1, info: repl

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/clear_finalized_txn_locks
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/clear_finalized_txn_locks
@@ -49,7 +49,7 @@ num=1
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
    queued writers:
-    active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
 
 add-discovered r=req1 k=b txn=txn2
 ----
@@ -57,11 +57,11 @@ num=2
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
    queued writers:
-    active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
    queued writers:
-    active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
 
 add-discovered r=req1 k=d txn=txn3
 ----
@@ -69,15 +69,15 @@ num=3
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
    queued writers:
-    active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
    queued writers:
-    active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
  lock: "d"
   holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl
    queued writers:
-    active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
 
 add-discovered r=req1 k=e txn=txn3
 ----
@@ -85,19 +85,19 @@ num=4
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
    queued writers:
-    active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
    queued writers:
-    active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
  lock: "d"
   holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl
    queued writers:
-    active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
  lock: "e"
   holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl
    queued writers:
-    active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
 
 scan r=req2
 ----
@@ -109,21 +109,21 @@ num=5
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
    queued writers:
-    active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
    queued writers:
-    active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
  lock: "c"
   holder: txn: 00000000-0000-0000-0000-000000000004 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
  lock: "d"
   holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl
    queued writers:
-    active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
  lock: "e"
   holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl
    queued writers:
-    active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
 
 dequeue r=req2
 ----
@@ -131,21 +131,21 @@ num=5
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
    queued writers:
-    active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
    queued writers:
-    active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
  lock: "c"
   holder: txn: 00000000-0000-0000-0000-000000000004 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
  lock: "d"
   holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl
    queued writers:
-    active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
  lock: "e"
   holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl
    queued writers:
-    active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
 
 scan r=req1
 ----
@@ -157,22 +157,22 @@ num=5
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
    queued writers:
-    active: true req: 1, txn: 00000000-0000-0000-0000-000000000001
+    active: true req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 1
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
    queued writers:
-    active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
  lock: "c"
   holder: txn: 00000000-0000-0000-0000-000000000004 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
  lock: "d"
   holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl
    queued writers:
-    active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
  lock: "e"
   holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl
    queued writers:
-    active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
 
 pushed-txn-updated txn=txn2 status=aborted
 ----
@@ -191,24 +191,24 @@ num=5
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [holder finalized: aborted]
    queued writers:
-    active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [holder finalized: aborted]
    queued writers:
-    active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
  lock: "c"
   holder: txn: 00000000-0000-0000-0000-000000000004 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
    queued writers:
-    active: true req: 1, txn: 00000000-0000-0000-0000-000000000001
+    active: true req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 1
  lock: "d"
   holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl
    queued writers:
-    active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
  lock: "e"
   holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl
    queued writers:
-    active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
 
 pushed-txn-updated txn=txn3 status=committed
 ----
@@ -219,22 +219,22 @@ num=5
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [holder finalized: aborted]
    queued writers:
-    active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [holder finalized: aborted]
    queued writers:
-    active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
  lock: "c"
    queued writers:
-    active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
  lock: "d"
   holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [holder finalized: committed]
    queued writers:
-    active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
  lock: "e"
   holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [holder finalized: committed]
    queued writers:
-    active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
 
 
 guard-state r=req1
@@ -251,19 +251,19 @@ print
 num=5
  lock: "a"
    queued writers:
-    active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
  lock: "b"
    queued writers:
-    active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
  lock: "c"
    queued writers:
-    active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
  lock: "d"
    queued writers:
-    active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
  lock: "e"
    queued writers:
-    active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
 
 dequeue r=req1
 ----
@@ -297,7 +297,7 @@ num=1
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl
    queued writers:
-    active: false req: 3, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 3, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
 
 add-discovered r=req3 k=c txn=txn2
 ----
@@ -305,11 +305,11 @@ num=2
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl
    queued writers:
-    active: false req: 3, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 3, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
  lock: "c"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl
    queued writers:
-    active: false req: 3, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 3, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
 
 scan r=req4
 ----
@@ -321,13 +321,13 @@ num=3
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl
    queued writers:
-    active: false req: 3, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 3, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
  lock: "c"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl
    queued writers:
-    active: false req: 3, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 3, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
 
 dequeue r=req4
 ----
@@ -335,13 +335,13 @@ num=3
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl
    queued writers:
-    active: false req: 3, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 3, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
  lock: "c"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl
    queued writers:
-    active: false req: 3, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 3, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
 
 pushed-txn-updated txn=txn2 status=aborted
 ----
@@ -362,13 +362,13 @@ print
 num=3
  lock: "a"
    queued writers:
-    active: false req: 3, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 3, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
  lock: "b"
    queued writers:
-    active: false req: 3, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 3, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
  lock: "c"
    queued writers:
-    active: false req: 3, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 3, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
 
 dequeue r=req3
 ----
@@ -400,7 +400,7 @@ num=1
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl
    queued writers:
-    active: false req: 5, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 5, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
 
 add-discovered r=req5 k=b txn=txn2
 ----
@@ -408,11 +408,11 @@ num=2
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl
    queued writers:
-    active: false req: 5, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 5, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl
    queued writers:
-    active: false req: 5, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 5, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
 
 scan r=req5
 ----
@@ -424,12 +424,12 @@ num=2
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl
    queued writers:
-    active: true req: 5, txn: 00000000-0000-0000-0000-000000000001
+    active: true req: 5, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 5
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl
    queued writers:
-    active: false req: 5, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 5, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
 
 pushed-txn-updated txn=txn2 status=aborted
 ----
@@ -452,26 +452,26 @@ num=2
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [holder finalized: aborted]
    queued writers:
-    active: true req: 5, txn: 00000000-0000-0000-0000-000000000001
-    active: true req: 6, txn: 00000000-0000-0000-0000-000000000003
+    active: true req: 5, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
+    active: true req: 6, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 5
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [holder finalized: aborted]
    queued writers:
-    active: false req: 5, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 5, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
 
 release txn=txn2 span=a
 ----
 num=2
  lock: "a"
    queued writers:
-    active: false req: 5, txn: 00000000-0000-0000-0000-000000000001
-    active: true req: 6, txn: 00000000-0000-0000-0000-000000000003
+    active: false req: 5, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
+    active: true req: 6, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 6
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [holder finalized: aborted]
    queued writers:
-    active: false req: 5, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 5, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
 
 guard-state r=req6
 ----
@@ -488,19 +488,19 @@ print
 num=2
  lock: "a"
    queued writers:
-    active: false req: 5, txn: 00000000-0000-0000-0000-000000000001
-    active: true req: 6, txn: 00000000-0000-0000-0000-000000000003
+    active: false req: 5, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
+    active: true req: 6, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 6
  lock: "b"
    queued writers:
-    active: false req: 5, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 5, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
 
 dequeue r=req5
 ----
 num=1
  lock: "a"
    queued writers:
-    active: false req: 6, txn: 00000000-0000-0000-0000-000000000003
+    active: false req: 6, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000003
 
 dequeue r=req6
 ----
@@ -532,7 +532,7 @@ num=1
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl
    queued writers:
-    active: false req: 7, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 7, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
 
 add-discovered r=req7 k=b txn=txn2
 ----
@@ -540,11 +540,11 @@ num=2
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl
    queued writers:
-    active: false req: 7, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 7, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl
    queued writers:
-    active: false req: 7, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 7, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
 
 scan r=req7
 ----
@@ -560,12 +560,12 @@ num=2
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl
    queued writers:
-    active: true req: 7, txn: 00000000-0000-0000-0000-000000000001
+    active: true req: 7, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 7
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl
    queued writers:
-    active: false req: 7, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 7, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
 
 pushed-txn-updated txn=txn2 status=aborted
 ----
@@ -590,10 +590,10 @@ print
 num=2
  lock: "a"
    queued writers:
-    active: false req: 7, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 7, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
  lock: "b"
    queued writers:
-    active: false req: 7, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 7, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
 
 dequeue r=req7
 ----
@@ -735,7 +735,7 @@ num=1
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 12.000000000,1, info: repl
    queued writers:
-    active: false req: 11, txn: none
+    active: false req: 11, strength: Intent, txn: none
 
 pushed-txn-updated txn=txn2 status=aborted
 ----
@@ -919,10 +919,10 @@ print
 num=6
  lock: "a"
    queued writers:
-    active: false req: 13, txn: 00000000-0000-0000-0000-000000000005
+    active: false req: 13, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000005
  lock: "b"
    queued writers:
-    active: false req: 13, txn: 00000000-0000-0000-0000-000000000005
+    active: false req: 13, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000005
  lock: "c"
   holder: txn: 00000000-0000-0000-0000-000000000006 epoch: 0, iso: Serializable, ts: 11.000000000,0, info: unrepl [(str: Exclusive seq: 0)] [holder finalized: aborted]
  lock: "d"
@@ -945,10 +945,10 @@ print
 num=4
  lock: "a"
    queued writers:
-    active: false req: 13, txn: 00000000-0000-0000-0000-000000000005
+    active: false req: 13, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000005
  lock: "b"
    queued writers:
-    active: false req: 13, txn: 00000000-0000-0000-0000-000000000005
+    active: false req: 13, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000005
  lock: "e"
   holder: txn: 00000000-0000-0000-0000-000000000006 epoch: 0, iso: Serializable, ts: 11.000000000,0, info: unrepl [(str: Exclusive seq: 0)] [holder finalized: aborted]
  lock: "f"
@@ -959,10 +959,10 @@ print
 num=4
  lock: "a"
    queued writers:
-    active: false req: 13, txn: 00000000-0000-0000-0000-000000000005
+    active: false req: 13, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000005
  lock: "b"
    queued writers:
-    active: false req: 13, txn: 00000000-0000-0000-0000-000000000005
+    active: false req: 13, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000005
  lock: "e"
   holder: txn: 00000000-0000-0000-0000-000000000006 epoch: 0, iso: Serializable, ts: 11.000000000,0, info: unrepl [(str: Exclusive seq: 0)] [holder finalized: aborted]
  lock: "f"
@@ -981,10 +981,10 @@ print
 num=2
  lock: "a"
    queued writers:
-    active: false req: 13, txn: 00000000-0000-0000-0000-000000000005
+    active: false req: 13, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000005
  lock: "b"
    queued writers:
-    active: false req: 13, txn: 00000000-0000-0000-0000-000000000005
+    active: false req: 13, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000005
 
 # -----------------------------------------------------------------------------
 # Ensure a claimant can never simultaneously be a distinguished waiter as well.
@@ -1007,7 +1007,7 @@ num=1
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000007 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl
    queued writers:
-    active: false req: 16, txn: 00000000-0000-0000-0000-000000000005
+    active: false req: 16, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000005
 
 add-discovered r=req17 k=b txn=txn8
 ----
@@ -1015,11 +1015,11 @@ num=2
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000007 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl
    queued writers:
-    active: false req: 16, txn: 00000000-0000-0000-0000-000000000005
+    active: false req: 16, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000005
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000008 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl
    queued writers:
-    active: false req: 16, txn: 00000000-0000-0000-0000-000000000005
+    active: false req: 16, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000005
 
 scan r=req17
 ----
@@ -1031,12 +1031,12 @@ num=2
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000007 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl
    queued writers:
-    active: true req: 16, txn: 00000000-0000-0000-0000-000000000005
+    active: true req: 16, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000005
    distinguished req: 16
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000008 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl
    queued writers:
-    active: false req: 16, txn: 00000000-0000-0000-0000-000000000005
+    active: false req: 16, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000005
 
 pushed-txn-updated txn=txn7 status=aborted
 ----
@@ -1057,11 +1057,11 @@ num=2
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000007 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [holder finalized: aborted]
    queued writers:
-    active: false req: 16, txn: 00000000-0000-0000-0000-000000000005
+    active: false req: 16, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000005
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000008 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl
    queued writers:
-    active: true req: 16, txn: 00000000-0000-0000-0000-000000000005
+    active: true req: 16, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000005
    distinguished req: 16
 
 new-request r=req18 txn=txn8 ts=11,0 spans=exclusive@a
@@ -1078,11 +1078,11 @@ num=2
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000007 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [holder finalized: aborted]
    queued writers:
-    active: false req: 16, txn: 00000000-0000-0000-0000-000000000005
-    active: true req: 17, txn: 00000000-0000-0000-0000-000000000008
+    active: false req: 16, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000005
+    active: true req: 17, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000008
    distinguished req: 17
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000008 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl
    queued writers:
-    active: true req: 16, txn: 00000000-0000-0000-0000-000000000005
+    active: true req: 16, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000005
    distinguished req: 16

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/disable
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/disable
@@ -75,7 +75,7 @@ num=1
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
    queued writers:
-    active: false req: 2, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 2, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
 
 scan r=req2
 ----
@@ -90,7 +90,7 @@ release txn=txn2 span=a
 num=1
  lock: "a"
    queued writers:
-    active: false req: 2, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 2, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
 
 guard-state r=req2
 ----
@@ -101,7 +101,7 @@ acquire r=req2 k=c durability=u strength=exclusive
 num=2
  lock: "a"
    queued writers:
-    active: false req: 2, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 2, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
  lock: "c"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
 

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/discovered_locks_consults_txn_cache
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/discovered_locks_consults_txn_cache
@@ -42,7 +42,7 @@ num=1
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [holder finalized: aborted]
    queued writers:
-    active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 1, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
 
 # Nothing to resolve yet.
 resolve-before-scanning r=req1
@@ -64,7 +64,7 @@ print
 num=1
  lock: "a"
    queued writers:
-    active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 1, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
 
 scan r=req1
 ----
@@ -79,7 +79,7 @@ add-discovered r=req1 k=b txn=txn3 consult-txn-status-cache=true
 num=1
  lock: "a"
    queued writers:
-    active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 1, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
 
 # Txn is finalized and txnStatusCache is consulted.
 add-discovered r=req1 k=c txn=txn3 consult-txn-status-cache=true
@@ -87,7 +87,7 @@ add-discovered r=req1 k=c txn=txn3 consult-txn-status-cache=true
 num=1
  lock: "a"
    queued writers:
-    active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 1, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
 
 # Txn is not finalized and txnStatusCache is consulted.
 add-discovered r=req1 k=d txn=txn4 consult-txn-status-cache=true
@@ -95,11 +95,11 @@ add-discovered r=req1 k=d txn=txn4 consult-txn-status-cache=true
 num=2
  lock: "a"
    queued writers:
-    active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 1, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
  lock: "d"
   holder: txn: 00000000-0000-0000-0000-000000000004 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl
    queued writers:
-    active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 1, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
 
 # Locks for b and c were not added to lock table.
 resolve-before-scanning r=req1

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/dup_access
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/dup_access
@@ -53,7 +53,7 @@ num=1
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued writers:
-    active: true req: 2, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 2, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 2
 
 release txn=txn1 span=a
@@ -61,7 +61,7 @@ release txn=txn1 span=a
 num=1
  lock: "a"
    queued writers:
-    active: false req: 2, txn: 00000000-0000-0000-0000-000000000002
+    active: false req: 2, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
 
 guard-state r=req2
 ----
@@ -145,12 +145,12 @@ num=3
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued writers:
-    active: true req: 4, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 4, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 4
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued writers:
-    active: true req: 5, txn: 00000000-0000-0000-0000-000000000003
+    active: true req: 5, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 5
  lock: "c"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
@@ -163,11 +163,11 @@ num=3
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued writers:
-    active: true req: 4, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 4, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 4
  lock: "b"
    queued writers:
-    active: false req: 5, txn: 00000000-0000-0000-0000-000000000003
+    active: false req: 5, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
  lock: "c"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
 
@@ -181,15 +181,15 @@ num=3
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued writers:
-    active: true req: 4, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 4, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 4
  lock: "b"
    queued writers:
-    active: false req: 5, txn: 00000000-0000-0000-0000-000000000003
+    active: false req: 5, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
  lock: "c"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued writers:
-    active: true req: 5, txn: 00000000-0000-0000-0000-000000000003
+    active: true req: 5, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 5
 
 # req4 breaks the reservation of req4 at "b".
@@ -199,14 +199,14 @@ release txn=txn1 span=a
 num=3
  lock: "a"
    queued writers:
-    active: false req: 4, txn: 00000000-0000-0000-0000-000000000002
+    active: false req: 4, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
  lock: "b"
    queued writers:
-    active: false req: 5, txn: 00000000-0000-0000-0000-000000000003
+    active: false req: 5, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
  lock: "c"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued writers:
-    active: true req: 5, txn: 00000000-0000-0000-0000-000000000003
+    active: true req: 5, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 5
 
 guard-state r=req4
@@ -218,15 +218,15 @@ print
 num=3
  lock: "a"
    queued writers:
-    active: false req: 4, txn: 00000000-0000-0000-0000-000000000002
+    active: false req: 4, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
  lock: "b"
    queued writers:
-    active: false req: 4, txn: 00000000-0000-0000-0000-000000000002
-    active: false req: 5, txn: 00000000-0000-0000-0000-000000000003
+    active: false req: 4, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
+    active: false req: 5, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
  lock: "c"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued writers:
-    active: true req: 5, txn: 00000000-0000-0000-0000-000000000003
+    active: true req: 5, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 5
 
 # req5 encounters the reservation by req4 at "b" when looking at it for its read access, but ignores
@@ -236,14 +236,14 @@ release txn=txn1 span=c
 num=3
  lock: "a"
    queued writers:
-    active: false req: 4, txn: 00000000-0000-0000-0000-000000000002
+    active: false req: 4, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
  lock: "b"
    queued writers:
-    active: false req: 4, txn: 00000000-0000-0000-0000-000000000002
-    active: false req: 5, txn: 00000000-0000-0000-0000-000000000003
+    active: false req: 4, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
+    active: false req: 5, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
  lock: "c"
    queued writers:
-    active: false req: 5, txn: 00000000-0000-0000-0000-000000000003
+    active: false req: 5, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
 
 guard-state r=req5
 ----
@@ -258,25 +258,25 @@ print
 num=3
  lock: "a"
    queued writers:
-    active: false req: 4, txn: 00000000-0000-0000-0000-000000000002
+    active: false req: 4, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
  lock: "b"
    queued writers:
-    active: false req: 4, txn: 00000000-0000-0000-0000-000000000002
-    active: true req: 5, txn: 00000000-0000-0000-0000-000000000003
+    active: false req: 4, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 5, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 5
  lock: "c"
    queued writers:
-    active: false req: 5, txn: 00000000-0000-0000-0000-000000000003
+    active: false req: 5, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
 
 dequeue r=req4
 ----
 num=2
  lock: "b"
    queued writers:
-    active: false req: 5, txn: 00000000-0000-0000-0000-000000000003
+    active: false req: 5, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
  lock: "c"
    queued writers:
-    active: false req: 5, txn: 00000000-0000-0000-0000-000000000003
+    active: false req: 5, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
 
 dequeue r=req5
 ----
@@ -376,13 +376,13 @@ num=3
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued writers:
-    active: true req: 7, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 7, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 7
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued writers:
-    active: true req: 8, txn: none
-    active: true req: 9, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 8, strength: Intent, txn: none
+    active: true req: 9, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 8
  lock: "c"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
@@ -395,11 +395,11 @@ num=3
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued writers:
-    active: true req: 7, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 7, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 7
  lock: "b"
    queued writers:
-    active: false req: 9, txn: 00000000-0000-0000-0000-000000000002
+    active: false req: 9, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
  lock: "c"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
 
@@ -413,15 +413,15 @@ num=3
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued writers:
-    active: true req: 7, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 7, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 7
  lock: "b"
    queued writers:
-    active: false req: 9, txn: 00000000-0000-0000-0000-000000000002
+    active: false req: 9, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
  lock: "c"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued writers:
-    active: true req: 8, txn: none
+    active: true req: 8, strength: Intent, txn: none
    distinguished req: 8
 
 # req7 is doneWaiting and proceeds to acquire the lock at "b".
@@ -431,14 +431,14 @@ release txn=txn1 span=a
 num=3
  lock: "a"
    queued writers:
-    active: false req: 7, txn: 00000000-0000-0000-0000-000000000002
+    active: false req: 7, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
  lock: "b"
    queued writers:
-    active: false req: 9, txn: 00000000-0000-0000-0000-000000000002
+    active: false req: 9, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
  lock: "c"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued writers:
-    active: true req: 8, txn: none
+    active: true req: 8, strength: Intent, txn: none
    distinguished req: 8
 
 guard-state r=req7
@@ -450,15 +450,15 @@ print
 num=3
  lock: "a"
    queued writers:
-    active: false req: 7, txn: 00000000-0000-0000-0000-000000000002
+    active: false req: 7, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
  lock: "b"
    queued writers:
-    active: false req: 7, txn: 00000000-0000-0000-0000-000000000002
-    active: false req: 9, txn: 00000000-0000-0000-0000-000000000002
+    active: false req: 7, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
+    active: false req: 9, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
  lock: "c"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued writers:
-    active: true req: 8, txn: none
+    active: true req: 8, strength: Intent, txn: none
    distinguished req: 8
 
 scan r=req7
@@ -470,13 +470,13 @@ acquire r=req7 k=b durability=u strength=exclusive
 num=3
  lock: "a"
    queued writers:
-    active: false req: 7, txn: 00000000-0000-0000-0000-000000000002
+    active: false req: 7, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
  lock: "c"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued writers:
-    active: true req: 8, txn: none
+    active: true req: 8, strength: Intent, txn: none
    distinguished req: 8
 
 # req8 encounters the lock held by req7 at "b" when looking at it for its read access.
@@ -485,7 +485,7 @@ release txn=txn1 span=c
 num=2
  lock: "a"
    queued writers:
-    active: false req: 7, txn: 00000000-0000-0000-0000-000000000002
+    active: false req: 7, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
 
@@ -498,7 +498,7 @@ print
 num=2
  lock: "a"
    queued writers:
-    active: false req: 7, txn: 00000000-0000-0000-0000-000000000002
+    active: false req: 7, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    waiting readers:
@@ -587,12 +587,12 @@ num=2
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued writers:
-    active: true req: 11, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 11, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 11
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued writers:
-    active: true req: 12, txn: 00000000-0000-0000-0000-000000000003
+    active: true req: 12, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 12
 
 # req12 reserves "b".
@@ -603,11 +603,11 @@ num=2
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued writers:
-    active: true req: 11, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 11, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 11
  lock: "b"
    queued writers:
-    active: false req: 12, txn: 00000000-0000-0000-0000-000000000003
+    active: false req: 12, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
 
 # req11 reserves "a"
 release txn=txn1 span=a
@@ -615,10 +615,10 @@ release txn=txn1 span=a
 num=2
  lock: "a"
    queued writers:
-    active: false req: 11, txn: 00000000-0000-0000-0000-000000000002
+    active: false req: 11, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
  lock: "b"
    queued writers:
-    active: false req: 12, txn: 00000000-0000-0000-0000-000000000003
+    active: false req: 12, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
 
 # req11 breaks the reservation at "b"
 guard-state r=req11
@@ -630,11 +630,11 @@ print
 num=2
  lock: "a"
    queued writers:
-    active: false req: 11, txn: 00000000-0000-0000-0000-000000000002
+    active: false req: 11, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
  lock: "b"
    queued writers:
-    active: false req: 11, txn: 00000000-0000-0000-0000-000000000002
-    active: false req: 12, txn: 00000000-0000-0000-0000-000000000003
+    active: false req: 11, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
+    active: false req: 12, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
 
 scan r=req11
 ----
@@ -645,11 +645,11 @@ acquire r=req11 k=b durability=u strength=exclusive
 num=2
  lock: "a"
    queued writers:
-    active: false req: 11, txn: 00000000-0000-0000-0000-000000000002
+    active: false req: 11, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued writers:
-    active: false req: 12, txn: 00000000-0000-0000-0000-000000000003
+    active: false req: 12, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
 
 # req12 ignores the lock at "b" when it encounters it again as a reader. So it will
 # enter the doneWaiting state. It will wait again when it rescans.
@@ -672,7 +672,7 @@ num=1
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued writers:
-    active: true req: 12, txn: 00000000-0000-0000-0000-000000000003
+    active: true req: 12, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 12
 
 dequeue r=req12

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/lock_changes
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/lock_changes
@@ -68,7 +68,7 @@ num=1
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 8.000000000,0, info: repl, unrepl [(str: Exclusive seq: 2)]
    queued writers:
-    active: true req: 1, txn: none
+    active: true req: 1, strength: Intent, txn: none
    distinguished req: 1
 
 dequeue r=reqContend

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/lock_dropped
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/lock_dropped
@@ -97,7 +97,7 @@ num=1
    waiting readers:
     req: 1, txn: none
    queued writers:
-    active: true req: 2, txn: none
+    active: true req: 2, strength: Intent, txn: none
    distinguished req: 1
 
 acquire r=req1 k=a durability=r strength=intent
@@ -108,7 +108,7 @@ num=1
    waiting readers:
     req: 1, txn: none
    queued writers:
-    active: true req: 2, txn: none
+    active: true req: 2, strength: Intent, txn: none
    distinguished req: 1
 
 guard-state r=reqContendReader

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/non_active_waiter
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/non_active_waiter
@@ -22,7 +22,7 @@ num=1
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl
    queued writers:
-    active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 1, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
 
 add-discovered r=req1 k=b txn=txn2
 ----
@@ -30,7 +30,7 @@ num=2
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl
    queued writers:
-    active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 1, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl
 
@@ -40,13 +40,13 @@ num=3
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl
    queued writers:
-    active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 1, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl
  lock: "c"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl
    queued writers:
-    active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 1, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
 
 # req1 is not in the queue for "b" as readers are never inactive waiters.
 
@@ -56,13 +56,13 @@ num=3
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl
    queued writers:
-    active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 1, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl
  lock: "c"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl
    queued writers:
-    active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 1, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
 
 new-request r=req2 txn=txn1 ts=10 spans=intent@c
 ----
@@ -79,14 +79,14 @@ num=3
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl
    queued writers:
-    active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 1, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl
  lock: "c"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl
    queued writers:
-    active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
-    active: true req: 2, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 1, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
+    active: true req: 2, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 2
 
 scan r=req1
@@ -103,15 +103,15 @@ num=3
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl
    queued writers:
-    active: true req: 1, txn: 00000000-0000-0000-0000-000000000001
+    active: true req: 1, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 1
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl
  lock: "c"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl
    queued writers:
-    active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
-    active: true req: 2, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 1, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
+    active: true req: 2, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 2
 
 # req1 waits at "c" but not as distinguished waiter.
@@ -120,14 +120,14 @@ release txn=txn2 span=a
 num=3
  lock: "a"
    queued writers:
-    active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 1, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl
  lock: "c"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl
    queued writers:
-    active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
-    active: true req: 2, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 1, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
+    active: true req: 2, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 2
 
 guard-state r=req1
@@ -139,14 +139,14 @@ print
 num=3
  lock: "a"
    queued writers:
-    active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 1, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl
  lock: "c"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl
    queued writers:
-    active: true req: 1, txn: 00000000-0000-0000-0000-000000000001
-    active: true req: 2, txn: 00000000-0000-0000-0000-000000000001
+    active: true req: 1, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
+    active: true req: 2, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 2
 
 # req1 waits at "b" as reader.
@@ -156,13 +156,13 @@ release txn=txn2 span=c
 num=3
  lock: "a"
    queued writers:
-    active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 1, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl
  lock: "c"
    queued writers:
-    active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
-    active: true req: 2, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 1, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
+    active: true req: 2, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
 
 guard-state r=req1
 ----
@@ -177,7 +177,7 @@ print
 num=3
  lock: "a"
    queued writers:
-    active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 1, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl
    waiting readers:
@@ -185,8 +185,8 @@ num=3
    distinguished req: 1
  lock: "c"
    queued writers:
-    active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
-    active: true req: 2, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 1, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
+    active: true req: 2, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
 
 # req1 is done waiting.
 
@@ -195,11 +195,11 @@ release txn=txn2 span=b
 num=2
  lock: "a"
    queued writers:
-    active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 1, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
  lock: "c"
    queued writers:
-    active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
-    active: true req: 2, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 1, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
+    active: true req: 2, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
 
 guard-state r=req1
 ----
@@ -210,7 +210,7 @@ dequeue r=req1
 num=1
  lock: "c"
    queued writers:
-    active: false req: 2, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 2, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
 
 guard-state r=req2
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/non_txn_write
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/non_txn_write
@@ -91,18 +91,18 @@ num=3
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued writers:
-    active: true req: 2, txn: 00000000-0000-0000-0000-000000000002
-    active: true req: 4, txn: none
+    active: true req: 2, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 4, strength: Intent, txn: none
    distinguished req: 2
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued writers:
-    active: true req: 3, txn: 00000000-0000-0000-0000-000000000003
+    active: true req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 3
  lock: "c"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued writers:
-    active: true req: 5, txn: 00000000-0000-0000-0000-000000000003
+    active: true req: 5, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 5
 
 # The locks at a, b, c are released. The non-transactional request waits behind
@@ -113,15 +113,15 @@ release txn=txn1 span=a,d
 num=3
  lock: "a"
    queued writers:
-    active: false req: 2, txn: 00000000-0000-0000-0000-000000000002
-    active: true req: 4, txn: none
+    active: false req: 2, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 4, strength: Intent, txn: none
    distinguished req: 4
  lock: "b"
    queued writers:
-    active: false req: 3, txn: 00000000-0000-0000-0000-000000000003
+    active: false req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
  lock: "c"
    queued writers:
-    active: false req: 5, txn: 00000000-0000-0000-0000-000000000003
+    active: false req: 5, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
 
 guard-state r=req2
 ----
@@ -153,16 +153,16 @@ print
 num=3
  lock: "a"
    queued writers:
-    active: false req: 2, txn: 00000000-0000-0000-0000-000000000002
-    active: true req: 4, txn: none
-    active: true req: 6, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 2, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 4, strength: Intent, txn: none
+    active: true req: 6, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 4
  lock: "b"
    queued writers:
-    active: false req: 3, txn: 00000000-0000-0000-0000-000000000003
+    active: false req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
  lock: "c"
    queued writers:
-    active: false req: 5, txn: 00000000-0000-0000-0000-000000000003
+    active: false req: 5, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
 
 # Release the reservation at a. The first waiter is non-transactional so it will not acquire the
 # reservation. The second waiter will acquire the reservation. The non-transactional request will
@@ -173,13 +173,13 @@ dequeue r=req2
 num=3
  lock: "a"
    queued writers:
-    active: false req: 6, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 6, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
  lock: "b"
    queued writers:
-    active: false req: 3, txn: 00000000-0000-0000-0000-000000000003
+    active: false req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
  lock: "c"
    queued writers:
-    active: false req: 5, txn: 00000000-0000-0000-0000-000000000003
+    active: false req: 5, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
 
 guard-state r=req4
 ----
@@ -194,15 +194,15 @@ print
 num=3
  lock: "a"
    queued writers:
-    active: false req: 6, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 6, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
  lock: "b"
    queued writers:
-    active: false req: 3, txn: 00000000-0000-0000-0000-000000000003
-    active: true req: 4, txn: none
+    active: false req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
+    active: true req: 4, strength: Intent, txn: none
    distinguished req: 4
  lock: "c"
    queued writers:
-    active: false req: 5, txn: 00000000-0000-0000-0000-000000000003
+    active: false req: 5, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
 
 # Release the reservation at b. The non-transactional waiter will be done at b, and when it gets
 # to c it will see a reservation holder with a higher sequence num and ignore it.
@@ -212,10 +212,10 @@ dequeue r=req3
 num=2
  lock: "a"
    queued writers:
-    active: false req: 6, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 6, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
  lock: "c"
    queued writers:
-    active: false req: 5, txn: 00000000-0000-0000-0000-000000000003
+    active: false req: 5, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
 
 guard-state r=req4
 ----
@@ -230,10 +230,10 @@ print
 num=2
  lock: "a"
    queued writers:
-    active: false req: 6, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 6, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
  lock: "c"
    queued writers:
-    active: false req: 5, txn: 00000000-0000-0000-0000-000000000003
+    active: false req: 5, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
 
 # Non-transactional request scans again and proceeds to evaluation and discovers a lock at c
 
@@ -246,12 +246,12 @@ add-discovered r=req4 k=c txn=txn2
 num=2
  lock: "a"
    queued writers:
-    active: false req: 6, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 6, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
  lock: "c"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl
    queued writers:
-    active: false req: 4, txn: none
-    active: false req: 5, txn: 00000000-0000-0000-0000-000000000003
+    active: false req: 4, strength: Intent, txn: none
+    active: false req: 5, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
 
 scan r=req4
 ----
@@ -276,10 +276,10 @@ release txn=txn2 span=c
 num=2
  lock: "a"
    queued writers:
-    active: false req: 6, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 6, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
  lock: "c"
    queued writers:
-    active: false req: 5, txn: 00000000-0000-0000-0000-000000000003
+    active: false req: 5, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
 
 guard-state r=req4
 ----
@@ -296,17 +296,17 @@ dequeue r=req4
 num=2
  lock: "a"
    queued writers:
-    active: false req: 6, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 6, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
  lock: "c"
    queued writers:
-    active: false req: 5, txn: 00000000-0000-0000-0000-000000000003
+    active: false req: 5, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
 
 dequeue r=req5
 ----
 num=1
  lock: "a"
    queued writers:
-    active: false req: 6, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 6, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
 
 dequeue r=req6
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/query
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/query
@@ -137,14 +137,14 @@ num=3
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,2, info: unrepl [(str: Exclusive seq: 0)]
    queued writers:
-    active: true req: 3, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 3
  lock: "c"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
  lock: "e"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
    queued writers:
-    active: true req: 4, txn: 00000000-0000-0000-0000-000000000003
+    active: true req: 4, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 4
 
 query span=a,/Max max-bytes=100

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/queue_length_exceeded
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/queue_length_exceeded
@@ -43,8 +43,8 @@ num=1
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued writers:
-    active: true req: 2, txn: 00000000-0000-0000-0000-000000000002
-    active: true req: 3, txn: 00000000-0000-0000-0000-000000000003
+    active: true req: 2, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 2
 
 # ---------------------------------------------------------------------------------
@@ -72,8 +72,8 @@ num=1
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued writers:
-    active: true req: 2, txn: 00000000-0000-0000-0000-000000000002
-    active: true req: 3, txn: 00000000-0000-0000-0000-000000000003
+    active: true req: 2, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 2
 
 # ---------------------------------------------------------------------------------
@@ -100,8 +100,8 @@ num=1
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued writers:
-    active: true req: 2, txn: 00000000-0000-0000-0000-000000000002
-    active: true req: 3, txn: 00000000-0000-0000-0000-000000000003
+    active: true req: 2, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 2
 
 # ---------------------------------------------------------------------------------
@@ -128,8 +128,8 @@ num=1
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued writers:
-    active: true req: 2, txn: 00000000-0000-0000-0000-000000000002
-    active: true req: 3, txn: 00000000-0000-0000-0000-000000000003
+    active: true req: 2, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 2
 
 # ---------------------------------------------------------------------------------
@@ -153,8 +153,8 @@ num=1
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued writers:
-    active: true req: 2, txn: 00000000-0000-0000-0000-000000000002
-    active: true req: 3, txn: 00000000-0000-0000-0000-000000000003
+    active: true req: 2, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 2
 
 new-request r=req8 txn=none ts=10 spans=intent@a max-lock-wait-queue-length=2
@@ -174,8 +174,8 @@ num=1
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued writers:
-    active: true req: 2, txn: 00000000-0000-0000-0000-000000000002
-    active: true req: 3, txn: 00000000-0000-0000-0000-000000000003
+    active: true req: 2, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 2
 
 # ------------------------------------------------------------------------------
@@ -201,8 +201,8 @@ num=2
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued writers:
-    active: true req: 2, txn: 00000000-0000-0000-0000-000000000002
-    active: true req: 3, txn: 00000000-0000-0000-0000-000000000003
+    active: true req: 2, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 2
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000006 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
@@ -227,13 +227,13 @@ num=2
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued writers:
-    active: true req: 2, txn: 00000000-0000-0000-0000-000000000002
-    active: true req: 3, txn: 00000000-0000-0000-0000-000000000003
+    active: true req: 2, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 2
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000006 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued writers:
-    active: true req: 10, txn: 00000000-0000-0000-0000-000000000007
+    active: true req: 10, strength: Intent, txn: 00000000-0000-0000-0000-000000000007
    distinguished req: 10
 
 # Re-scan.

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/shared_locks
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/shared_locks
@@ -53,8 +53,8 @@ num=1
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Shared seq: 0)]
    queued writers:
-    active: false req: 2, txn: 00000000-0000-0000-0000-000000000002
-    active: false req: 3, txn: 00000000-0000-0000-0000-000000000002
+    active: false req: 2, strength: Shared, txn: 00000000-0000-0000-0000-000000000002
+    active: false req: 3, strength: Shared, txn: 00000000-0000-0000-0000-000000000002
 
 # TODO(arul): This is currently a limitation of the lock table, as it doesn't
 # allow multiple locks on a single key from different transactions.
@@ -82,10 +82,10 @@ num=1
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Shared seq: 0)]
    queued writers:
-    active: false req: 2, txn: 00000000-0000-0000-0000-000000000002
-    active: false req: 3, txn: 00000000-0000-0000-0000-000000000002
-    active: true req: 4, txn: 00000000-0000-0000-0000-000000000002
-    active: true req: 5, txn: 00000000-0000-0000-0000-000000000002
+    active: false req: 2, strength: Shared, txn: 00000000-0000-0000-0000-000000000002
+    active: false req: 3, strength: Shared, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 4, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 5, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 4
 
 # ------------------------------------------------------------------------------
@@ -107,9 +107,9 @@ num=1
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Shared seq: 0)]
    queued writers:
-    active: false req: 2, txn: 00000000-0000-0000-0000-000000000002
-    active: false req: 3, txn: 00000000-0000-0000-0000-000000000002
-    active: true req: 4, txn: 00000000-0000-0000-0000-000000000002
-    active: true req: 5, txn: 00000000-0000-0000-0000-000000000002
-    active: true req: 6, txn: 00000000-0000-0000-0000-000000000002
+    active: false req: 2, strength: Shared, txn: 00000000-0000-0000-0000-000000000002
+    active: false req: 3, strength: Shared, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 4, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 5, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 6, strength: Shared, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 4

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/shared_locks
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/shared_locks
@@ -10,6 +10,10 @@ new-txn txn=txn2 ts=10 epoch=0 seq=0
 new-request r=req1 txn=txn1 ts=10 spans=shared@a
 ----
 
+scan r=req1
+----
+start-waiting: false
+
 acquire r=req1 k=a durability=u strength=shared
 ----
 num=1
@@ -53,8 +57,8 @@ num=1
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Shared seq: 0)]
    queued writers:
-    active: false req: 2, strength: Shared, txn: 00000000-0000-0000-0000-000000000002
     active: false req: 3, strength: Shared, txn: 00000000-0000-0000-0000-000000000002
+    active: false req: 4, strength: Shared, txn: 00000000-0000-0000-0000-000000000002
 
 # TODO(arul): This is currently a limitation of the lock table, as it doesn't
 # allow multiple locks on a single key from different transactions.
@@ -82,11 +86,11 @@ num=1
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Shared seq: 0)]
    queued writers:
-    active: false req: 2, strength: Shared, txn: 00000000-0000-0000-0000-000000000002
     active: false req: 3, strength: Shared, txn: 00000000-0000-0000-0000-000000000002
-    active: true req: 4, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
-    active: true req: 5, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
-   distinguished req: 4
+    active: false req: 4, strength: Shared, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 5, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 6, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
+   distinguished req: 5
 
 # ------------------------------------------------------------------------------
 # Ensure requests with locking strength shared actively wait if there are active
@@ -107,9 +111,9 @@ num=1
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Shared seq: 0)]
    queued writers:
-    active: false req: 2, strength: Shared, txn: 00000000-0000-0000-0000-000000000002
     active: false req: 3, strength: Shared, txn: 00000000-0000-0000-0000-000000000002
-    active: true req: 4, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
-    active: true req: 5, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
-    active: true req: 6, strength: Shared, txn: 00000000-0000-0000-0000-000000000002
-   distinguished req: 4
+    active: false req: 4, strength: Shared, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 5, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 6, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 7, strength: Shared, txn: 00000000-0000-0000-0000-000000000002
+   distinguished req: 5

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/shared_locks
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/shared_locks
@@ -7,6 +7,12 @@ new-txn txn=txn1 ts=10 epoch=0 seq=0
 new-txn txn=txn2 ts=10 epoch=0 seq=0
 ----
 
+new-txn txn=txn3 ts=10 epoch=0 seq=0
+----
+
+new-txn txn=txn4 ts=10 epoch=0 seq=0
+----
+
 new-request r=req1 txn=txn1 ts=10 spans=shared@a
 ----
 
@@ -22,7 +28,7 @@ num=1
 
 # ------------------------------------------------------------------------------
 # Ensure conflict resolution semantics for shared locks are sane -- that is,
-# if a shared lock is held on a key, {shared, non} locking requests are allowed
+# if a shared lock is held on a key, {shared, none} locking requests are allowed
 # to proceed; {intent, exclusive} locking requests are not.
 # ------------------------------------------------------------------------------
 
@@ -60,11 +66,22 @@ num=1
     active: false req: 3, strength: Shared, txn: 00000000-0000-0000-0000-000000000002
     active: false req: 4, strength: Shared, txn: 00000000-0000-0000-0000-000000000002
 
-# TODO(arul): This is currently a limitation of the lock table, as it doesn't
-# allow multiple locks on a single key from different transactions.
 acquire r=req3 k=a durability=u strength=shared
 ----
-existing lock cannot be acquired by different transaction
+num=1
+ lock: "a"
+  holders: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Shared seq: 0)]
+           txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Shared seq: 0)]
+
+# Re-acquisition of the shared lock by req4 should work as well, as req4 is part
+# of the same transaction (txn 2) as req3; req3 just acquired a shared lock.
+acquire r=req4 k=a durability=u strength=shared
+----
+num=1
+ lock: "a"
+  holders: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Shared seq: 0)]
+           txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Shared seq: 0)]
+
 
 new-request r=req5 txn=txn2 ts=10 spans=exclusive@a
 ----
@@ -84,10 +101,9 @@ print
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Shared seq: 0)]
+  holders: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Shared seq: 0)]
+           txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Shared seq: 0)]
    queued writers:
-    active: false req: 3, strength: Shared, txn: 00000000-0000-0000-0000-000000000002
-    active: false req: 4, strength: Shared, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 5, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 6, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 5
@@ -98,7 +114,7 @@ num=1
 # compatible with the shared lock request).
 # ------------------------------------------------------------------------------
 
-new-request r=req7 txn=txn2 ts=10 spans=shared@a
+new-request r=req7 txn=txn3 ts=10 spans=shared@a
 ----
 
 scan r=req7
@@ -109,11 +125,172 @@ print
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Shared seq: 0)]
+  holders: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Shared seq: 0)]
+           txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Shared seq: 0)]
    queued writers:
-    active: false req: 3, strength: Shared, txn: 00000000-0000-0000-0000-000000000002
-    active: false req: 4, strength: Shared, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 5, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 6, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
-    active: true req: 7, strength: Shared, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 7, strength: Shared, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 5
+
+# However, if the shared lock is held by the transaction itself, it doesn't need
+# to actively wait.
+
+new-request r=req8 txn=txn2 ts=10 spans=shared@a
+----
+
+scan r=req8
+----
+start-waiting: false
+
+print
+----
+num=1
+ lock: "a"
+  holders: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Shared seq: 0)]
+           txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Shared seq: 0)]
+   queued writers:
+    active: true req: 5, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 6, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 7, strength: Shared, txn: 00000000-0000-0000-0000-000000000003
+   distinguished req: 5
+
+# ------------------------------------------------------------------------------
+# Ensure a key is locked with SHARED locking strength until the all
+# transactions that hold SHARED LOCKs have released it.
+# ------------------------------------------------------------------------------
+
+clear
+----
+num=0
+
+# Acquire SHARED locks using 3 transactions.
+new-request r=req9 txn=txn1 ts=10 spans=shared@a
+----
+
+scan r=req9
+----
+start-waiting: false
+
+acquire r=req9 k=a durability=u strength=shared
+----
+num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Shared seq: 0)]
+
+new-request r=req10 txn=txn2 ts=10 spans=shared@a
+----
+
+scan r=req10
+----
+start-waiting: false
+
+acquire r=req10 k=a durability=u strength=shared
+----
+num=1
+ lock: "a"
+  holders: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Shared seq: 0)]
+           txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Shared seq: 0)]
+
+acquire r=req10 k=a durability=u strength=shared
+----
+num=1
+ lock: "a"
+  holders: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Shared seq: 0)]
+           txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Shared seq: 0)]
+
+new-request r=req11 txn=txn3 ts=10 spans=shared@a
+----
+
+scan r=req11
+----
+start-waiting: false
+
+acquire r=req11 k=a durability=u strength=shared
+----
+num=1
+ lock: "a"
+  holders: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Shared seq: 0)]
+           txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Shared seq: 0)]
+           txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Shared seq: 0)]
+
+new-request r=req12 txn=txn4 ts=10 spans=exclusive@a
+----
+
+scan r=req12
+----
+start-waiting: true
+
+print
+----
+num=1
+ lock: "a"
+  holders: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Shared seq: 0)]
+           txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Shared seq: 0)]
+           txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Shared seq: 0)]
+   queued writers:
+    active: true req: 12, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000004
+   distinguished req: 12
+
+# Start releasing the shared locks, one by one.
+
+release txn=txn1 span=a
+----
+num=1
+ lock: "a"
+  holders: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Shared seq: 0)]
+           txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Shared seq: 0)]
+   queued writers:
+    active: true req: 12, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000004
+   distinguished req: 12
+
+release txn=txn2 span=a
+----
+num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Shared seq: 0)]
+   queued writers:
+    active: true req: 12, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000004
+   distinguished req: 12
+
+# Now that all shared locks have been released, the exclusive locking request is
+# free to proceed.
+release txn=txn3 span=a
+----
+num=1
+ lock: "a"
+   queued writers:
+    active: false req: 12, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000004
+
+
+# TODO(arul): (non-exhaustive list) of shared lock state transitions that aren't
+# currently supported (and we need to add support for):
+#
+# 1. - lock holder: exclusive, wait queue: (shared, shared, shared).
+# Once the exclusive lock is released, all the shared locking requests should
+# be able to acquire a joint claim.
+# 2. - lock holder: exclusive, wait queue: (shared, shared, shared, exclusive, shared).
+# Once the exclusive lock is released, only the head of the queue that is
+# compatible (the first three shared lock requests) should be able to acquire
+# a joint claim.
+# 3. - lock holder: none, wait queue: (shared, shared), some other shared locking
+# request acquires a joint claim by inserting itself at the start of the queue.
+# Same for a shared locking request that enters the middle of the queue.
+# 4. - lock holder: none, wait queue: (shared, shared), some other exclusive
+# locking request inserts itself at the front of the queue (breaking the
+# reservation). Ditto for a partial break, where the exclusive locking request
+# inserts itself in the middle of the queue.
+# 5. - lock holder: none, wait queue: (exclusive, shared, shared), exclusive
+# acquires lock and exits queue. Another for exclusive exiting the queue without
+# acquiring the lock.
+# 6. Lock promotion cases where the lock is held with strength shared, and
+# there's another request (from the same txn) with lock strength exclusive
+# that's trying to acquire the lock further back in the wait queue.
+# 7. Cases where a lock is held with strength exclusive, and there's another
+# request from the same transaction trying to acquire the lock with strength
+# shared. To make things interesting, the lock table's wait queue should be
+# non-empty.
+# 8. Cases where the waiter is a non-transactional writer. For example, a state
+# transition that uncorks a number of non-transactional writer from the head of
+# the queue.
+

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/size_limit_exceeded
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/size_limit_exceeded
@@ -70,7 +70,7 @@ num=3
  lock: "c"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl, unrepl [(str: Exclusive seq: 0)]
    queued writers:
-    active: true req: 2, txn: none
+    active: true req: 2, strength: Intent, txn: none
    distinguished req: 2
 
 dequeue r=reqContend
@@ -113,8 +113,8 @@ num=3
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued writers:
-    active: true req: 3, txn: 00000000-0000-0000-0000-000000000002
-    active: true req: 4, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 4, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 3
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
@@ -126,8 +126,8 @@ release txn=txn1 span=a
 num=3
  lock: "a"
    queued writers:
-    active: false req: 3, txn: 00000000-0000-0000-0000-000000000002
-    active: true req: 4, txn: 00000000-0000-0000-0000-000000000002
+    active: false req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 4, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
  lock: "c"
@@ -146,12 +146,12 @@ print
 num=3
  lock: "a"
    queued writers:
-    active: false req: 3, txn: 00000000-0000-0000-0000-000000000002
-    active: true req: 4, txn: 00000000-0000-0000-0000-000000000002
+    active: false req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 4, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued writers:
-    active: true req: 3, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 3
  lock: "c"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl, unrepl [(str: Exclusive seq: 0)]
@@ -193,25 +193,25 @@ add-discovered r=req7 k=d txn=txn1
 num=4
  lock: "a"
    queued writers:
-    active: false req: 3, txn: 00000000-0000-0000-0000-000000000002
-    active: true req: 4, txn: 00000000-0000-0000-0000-000000000002
+    active: false req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 4, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    waiting readers:
     req: 5, txn: 00000000-0000-0000-0000-000000000002
    queued writers:
-    active: true req: 3, txn: 00000000-0000-0000-0000-000000000002
-    active: true req: 6, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 6, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 3
  lock: "c"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl, unrepl [(str: Exclusive seq: 0)]
    queued writers:
-    active: true req: 7, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 7, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 7
  lock: "d"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl
    queued writers:
-    active: false req: 8, txn: 00000000-0000-0000-0000-000000000002
+    active: false req: 8, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
 
 new-request r=req8 txn=txn2 ts=10 spans=exclusive@e
 ----
@@ -228,7 +228,7 @@ num=1
  lock: "d"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl
    queued writers:
-    active: false req: 8, txn: 00000000-0000-0000-0000-000000000002
+    active: false req: 8, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
 
 guard-state r=req2
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/skip_locked
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/skip_locked
@@ -118,7 +118,7 @@ num=4
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
  lock: "f"
    queued writers:
-    active: false req: 3, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
 
 new-request r=req4 txn=txn1 ts=10,1 spans=shared@g
 ----
@@ -142,7 +142,7 @@ num=5
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
  lock: "f"
    queued writers:
-    active: false req: 3, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
  lock: "g"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Shared seq: 0)]
 
@@ -168,7 +168,7 @@ num=6
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
  lock: "f"
    queued writers:
-    active: false req: 3, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
  lock: "g"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Shared seq: 0)]
  lock: "h"
@@ -196,7 +196,7 @@ num=7
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
  lock: "f"
    queued writers:
-    active: false req: 3, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
  lock: "g"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Shared seq: 0)]
  lock: "h"
@@ -226,7 +226,7 @@ num=7
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
  lock: "f"
    queued writers:
-    active: false req: 3, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
  lock: "g"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Shared seq: 0)]
  lock: "h"
@@ -234,7 +234,7 @@ num=7
  lock: "i"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 9.000000000,1, info: unrepl [(str: Shared seq: 0)]
    queued writers:
-    active: true req: 7, txn: 00000000-0000-0000-0000-000000000001
+    active: true req: 7, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 7
 
 # ---------------------------------------------------------------------------------
@@ -373,7 +373,7 @@ num=7
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
  lock: "f"
    queued writers:
-    active: false req: 3, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
  lock: "g"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Shared seq: 0)]
  lock: "h"
@@ -381,7 +381,7 @@ num=7
  lock: "i"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 9.000000000,1, info: unrepl [(str: Shared seq: 0)]
    queued writers:
-    active: true req: 7, txn: 00000000-0000-0000-0000-000000000001
+    active: true req: 7, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 7
 
 # ---------------------------------------------------------------------------------
@@ -447,7 +447,7 @@ num=7
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
  lock: "f"
    queued writers:
-    active: false req: 3, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
  lock: "g"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Shared seq: 0)]
  lock: "h"
@@ -455,7 +455,7 @@ num=7
  lock: "i"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 9.000000000,1, info: unrepl [(str: Shared seq: 0)]
    queued writers:
-    active: true req: 7, txn: 00000000-0000-0000-0000-000000000001
+    active: true req: 7, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 7
 
 # ---------------------------------------------------------------------------------

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/update
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/update
@@ -98,8 +98,8 @@ num=1
     req: 4, txn: none
     req: 2, txn: 00000000-0000-0000-0000-000000000002
    queued writers:
-    active: true req: 3, txn: 00000000-0000-0000-0000-000000000003
-    active: true req: 5, txn: none
+    active: true req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
+    active: true req: 5, strength: Intent, txn: none
    distinguished req: 2
 
 metrics
@@ -205,8 +205,8 @@ num=1
     req: 4, txn: none
     req: 2, txn: 00000000-0000-0000-0000-000000000002
    queued writers:
-    active: true req: 3, txn: 00000000-0000-0000-0000-000000000003
-    active: true req: 5, txn: none
+    active: true req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
+    active: true req: 5, strength: Intent, txn: none
    distinguished req: 2
 
 # -------------------------------------------------------------
@@ -223,8 +223,8 @@ num=1
    waiting readers:
     req: 4, txn: none
    queued writers:
-    active: true req: 3, txn: 00000000-0000-0000-0000-000000000003
-    active: true req: 5, txn: none
+    active: true req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
+    active: true req: 5, strength: Intent, txn: none
    distinguished req: 4
 
 guard-state r=req2
@@ -243,8 +243,8 @@ num=1
    waiting readers:
     req: 4, txn: none
    queued writers:
-    active: true req: 3, txn: 00000000-0000-0000-0000-000000000003
-    active: true req: 5, txn: none
+    active: true req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
+    active: true req: 5, strength: Intent, txn: none
    distinguished req: 4
 
 # -------------------------------------------------------------
@@ -260,8 +260,8 @@ num=1
    waiting readers:
     req: 4, txn: none
    queued writers:
-    active: true req: 3, txn: 00000000-0000-0000-0000-000000000003
-    active: true req: 5, txn: none
+    active: true req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
+    active: true req: 5, strength: Intent, txn: none
    distinguished req: 4
 
 # -------------------------------------------------------------
@@ -276,8 +276,8 @@ num=1
    waiting readers:
     req: 4, txn: none
    queued writers:
-    active: true req: 3, txn: 00000000-0000-0000-0000-000000000003
-    active: true req: 5, txn: none
+    active: true req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
+    active: true req: 5, strength: Intent, txn: none
    distinguished req: 4
 
 # -------------------------------------------------------------
@@ -292,8 +292,8 @@ num=1
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 17.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
    queued writers:
-    active: true req: 3, txn: 00000000-0000-0000-0000-000000000003
-    active: true req: 5, txn: none
+    active: true req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
+    active: true req: 5, strength: Intent, txn: none
    distinguished req: 3
 
 guard-state r=req4
@@ -310,8 +310,8 @@ num=1
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 17.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
    queued writers:
-    active: true req: 3, txn: 00000000-0000-0000-0000-000000000003
-    active: true req: 5, txn: none
+    active: true req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
+    active: true req: 5, strength: Intent, txn: none
    distinguished req: 3
 
 # -------------------------------------------------------------
@@ -324,8 +324,8 @@ num=1
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 19.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
    queued writers:
-    active: true req: 3, txn: 00000000-0000-0000-0000-000000000003
-    active: true req: 5, txn: none
+    active: true req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
+    active: true req: 5, strength: Intent, txn: none
    distinguished req: 3
 
 # -------------------------------------------------------------
@@ -340,8 +340,8 @@ update txn=txn1 ts=19,1 epoch=1 span=a
 num=1
  lock: "a"
    queued writers:
-    active: false req: 3, txn: 00000000-0000-0000-0000-000000000003
-    active: true req: 5, txn: none
+    active: false req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
+    active: true req: 5, strength: Intent, txn: none
    distinguished req: 5
 
 guard-state r=req3

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/wait_self
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/wait_self
@@ -75,9 +75,9 @@ num=1
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued writers:
-    active: true req: 2, txn: 00000000-0000-0000-0000-000000000002
-    active: true req: 3, txn: 00000000-0000-0000-0000-000000000003
-    active: true req: 4, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 2, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
+    active: true req: 4, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 2
 
 release txn=txn1 span=a
@@ -85,9 +85,9 @@ release txn=txn1 span=a
 num=1
  lock: "a"
    queued writers:
-    active: false req: 2, txn: 00000000-0000-0000-0000-000000000002
-    active: true req: 3, txn: 00000000-0000-0000-0000-000000000003
-    active: true req: 4, txn: 00000000-0000-0000-0000-000000000002
+    active: false req: 2, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
+    active: true req: 4, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 3
 
 guard-state r=req2
@@ -107,9 +107,9 @@ print
 num=1
  lock: "a"
    queued writers:
-    active: false req: 2, txn: 00000000-0000-0000-0000-000000000002
-    active: true req: 3, txn: 00000000-0000-0000-0000-000000000003
-    active: true req: 4, txn: 00000000-0000-0000-0000-000000000002
+    active: false req: 2, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
+    active: true req: 4, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 3
 
 # Stays in waitSelf state if scans again.
@@ -132,7 +132,7 @@ num=1
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued writers:
-    active: true req: 3, txn: 00000000-0000-0000-0000-000000000003
+    active: true req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 3
 
 guard-state r=req3


### PR DESCRIPTION
See individual commits for details.