### PR TITLE
release-23.1: TEAMS: fix backport of 107498

### DIFF
--- a/.github/workflows/add-issues-to-project.yml
+++ b/.github/workflows/add-issues-to-project.yml
@@ -25,3 +25,8 @@ jobs:
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
           # A comma-separated list of labels to use as a filter for issue to be added
           labeled: T-cdc
+      - uses: actions/add-to-project@v0.4.0
+        with:
+          project-url: https://github.com/orgs/cockroachdb/projects/45
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          labeled: T-sql-queries


### PR DESCRIPTION
I think this part was missed in the original backport of #107498 in #108919.

Epic: None

Release note: None

Release justification: CI only change.