### PR TITLE
builtins: remove join hint in pg_table_is_visible

### DIFF
--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -1288,7 +1288,7 @@ var pgBuiltins = map[string]builtinDefinition{
 			ReturnType: tree.FixedReturnType(types.Bool),
 			Body: `SELECT n.nspname = any current_schemas(true)
              FROM pg_catalog.pg_type t
-             INNER LOOKUP JOIN pg_catalog.pg_namespace n
+             JOIN pg_catalog.pg_namespace n
              ON t.typnamespace = n.oid
              WHERE t.oid=$1 LIMIT 1`,
 			CalledOnNullInput: true,


### PR DESCRIPTION
This join hint was making queries slower for large data sets.

informs #108334

Release note: None