### PR TITLE
sql: skip TestRelocateNonVoters under race

### DIFF
--- a/pkg/sql/multitenant_admin_function_test.go
+++ b/pkg/sql/multitenant_admin_function_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltestutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -843,6 +844,11 @@ func TestRelocateNonVoters(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	defer ccl.TestingEnableEnterprise()()
+
+	// This test occasionally flakes under race. More context can be found in
+	// #108081, but there is really no benefit from running it under race, so
+	// we just skip that config.
+	skip.UnderRace(t)
 
 	testCases := []testCase{
 		{


### PR DESCRIPTION
This test occasionally flakes under race. More context can be found in #108081, but there is really no benefit from running it under race, so we just skip that config. I've stressed it for 10k runs with oversubscription of cpus and got no failures.

Fixes: #108081.

Release note: None