### PR TITLE
typedesc: avoid slice copy when hydrating enums

### DIFF
--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -682,6 +682,7 @@ go_test(
         "scatter_test.go",
         "schema_changer_helpers_test.go",
         "schema_changer_test.go",
+        "schema_resolver_test.go",
         "scrub_test.go",
         "sequence_test.go",
         "server_params_test.go",

--- a/pkg/sql/schema_resolver_test.go
+++ b/pkg/sql/schema_resolver_test.go
@@ -1,0 +1,69 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sql
+
+import (
+	"context"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/security/username"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/lib/pq/oid"
+	"github.com/stretchr/testify/require"
+)
+
+// This benchmark tests the performance of resolving an enum with many (10,000)
+// values. This is a regression test for #109228.
+func BenchmarkResolveTypeByOID(b *testing.B) {
+	defer leaktest.AfterTest(b)()
+	defer log.Scope(b).Close(b)
+
+	s, sqlDB, kvDB := serverutils.StartServer(b, base.TestServerArgs{})
+	defer s.Stopper().Stop(context.Background())
+
+	query := strings.Builder{}
+	query.WriteString("CREATE TYPE typ AS ENUM ('v0'")
+	for i := 1; i < 10_000; i++ {
+		query.WriteString(", 'v")
+		query.WriteString(strconv.Itoa(i))
+		query.WriteString("'")
+	}
+	query.WriteString(")")
+	_, err := sqlDB.Exec(query.String())
+	require.NoError(b, err)
+
+	var typOID uint32
+	err = sqlDB.QueryRow("SELECT 'typ'::regtype::oid").Scan(&typOID)
+	require.NoError(b, err)
+
+	ctx := context.Background()
+	execCfg := s.ExecutorConfig().(ExecutorConfig)
+	sd := NewInternalSessionData(ctx, execCfg.Settings, "test")
+	sd.Database = "defaultdb"
+	planner, cleanup := newInternalPlanner("test", kv.NewTxn(ctx, kvDB, s.NodeID()),
+		username.RootUserName(), &MemoryMetrics{}, &execCfg, sd,
+	)
+	defer cleanup()
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		typ, err := planner.schemaResolver.ResolveTypeByOID(ctx, oid.Oid(typOID))
+		require.NoError(b, err)
+		require.Equal(b, "typ", typ.Name())
+	}
+	b.StopTimer()
+}


### PR DESCRIPTION
A profile showed that when an enum has a lot of values, hydrating it can become expensive since it requires initializing a large slice.

Since these objects are immutable, we can just reference the slice directly.

```
goos: darwin
goarch: arm64
                    │   bench-old   │              bench-new              │
                    │    sec/op     │    sec/op     vs base               │
ResolveTypeByOID-10   106.266µ ± 4%   1.246µ ± 14%  -98.83% (p=0.002 n=6)

                    │   bench-old   │             bench-new             │
                    │     B/op      │    B/op     vs base               │
ResolveTypeByOID-10   422992.5 ± 0%   453.0 ± 0%  -99.89% (p=0.002 n=6)

                    │ bench-old  │             bench-new             │
                    │ allocs/op  │ allocs/op   vs base               │
ResolveTypeByOID-10   51.00 ± 4%   12.00 ± 0%  -76.47% (p=0.002 n=6)
```

informs https://github.com/cockroachdb/cockroach/issues/109228
Release note (performance improvement): Improved the cost of resolving a
user-defined enum type that has many values.