### PR TITLE
storage: encode and decode Shared and Exclusive lock-table keys

### DIFF
--- a/pkg/storage/engine_key_test.go
+++ b/pkg/storage/engine_key_test.go
@@ -36,11 +36,25 @@ func TestLockTableKeyEncodeDecode(t *testing.T) {
 	testCases := []struct {
 		key LockTableKey
 	}{
+		// Shared locks.
+		{key: LockTableKey{Key: roachpb.Key("foo"), Strength: lock.Shared, TxnUUID: uuid1}},
+		{key: LockTableKey{Key: roachpb.Key("a"), Strength: lock.Shared, TxnUUID: uuid2}},
+		{key: LockTableKey{
+			Key:      keys.RangeDescriptorKey(roachpb.RKey("baz")), // causes a doubly-local range local key
+			Strength: lock.Shared,
+			TxnUUID:  uuid1}},
+		// Exclusive locks.
+		{key: LockTableKey{Key: roachpb.Key("foo"), Strength: lock.Exclusive, TxnUUID: uuid1}},
+		{key: LockTableKey{Key: roachpb.Key("a"), Strength: lock.Exclusive, TxnUUID: uuid2}},
+		{key: LockTableKey{
+			Key:      keys.RangeDescriptorKey(roachpb.RKey("baz")), // causes a doubly-local range local key
+			Strength: lock.Exclusive,
+			TxnUUID:  uuid1}},
+		// Intent locks.
 		{key: LockTableKey{Key: roachpb.Key("foo"), Strength: lock.Intent, TxnUUID: uuid1}},
 		{key: LockTableKey{Key: roachpb.Key("a"), Strength: lock.Intent, TxnUUID: uuid2}},
-		// Causes a doubly-local range local key.
 		{key: LockTableKey{
-			Key:      keys.RangeDescriptorKey(roachpb.RKey("baz")),
+			Key:      keys.RangeDescriptorKey(roachpb.RKey("baz")), // causes a doubly-local range local key
 			Strength: lock.Intent,
 			TxnUUID:  uuid1}},
 	}


### PR DESCRIPTION
Part of #100193.

This commit adds support for encoding and decoding LockTableKeys with Shared and Exclusive lock strengths. Most of the work for this was already done in 666f67e1. This commit just hooks up the other strengths so we can start testing with them.

Release note: None