### PR TITLE
colrpc, flowinfra, kvcoord, server: wrap sends and recvs in tracing

### DIFF
--- a/pkg/kv/kvclient/kvcoord/transport.go
+++ b/pkg/kv/kvclient/kvcoord/transport.go
@@ -207,7 +207,9 @@ func (gt *grpcTransport) sendBatch(
 	if rpc.IsLocal(iface) {
 		gt.opts.metrics.LocalSentCount.Inc(1)
 	}
+	log.VEvent(ctx, 2, "sending batch request")
 	reply, err := iface.Batch(ctx, ba)
+	log.VEvent(ctx, 2, "received batch response")
 	// If we queried a remote node, perform extra validation.
 	if reply != nil && !rpc.IsLocal(iface) {
 		if err == nil {

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -1318,6 +1318,7 @@ func (n *Node) batchInternal(
 	}()
 	if log.HasSpanOrEvent(ctx) {
 		log.Eventf(ctx, "node received request: %s", args.Summary())
+		defer log.Event(ctx, "node sending response")
 	}
 
 	tStart := timeutil.Now()

--- a/pkg/sql/colflow/colrpc/outbox.go
+++ b/pkg/sql/colflow/colrpc/outbox.go
@@ -314,6 +314,7 @@ func (o *Outbox) sendBatches(
 			// o.scratch.msg can be reused as soon as Send returns since it returns as
 			// soon as the message is written to the control buffer. The message is
 			// marshaled (bytes are copied) before writing.
+			log.VEvent(ctx, 2, "Outbox sending batch")
 			if err := stream.Send(o.scratch.msg); err != nil {
 				flowinfra.HandleStreamErr(ctx, "Send (batches)", err, flowCtxCancel, outboxCtxCancel)
 				return
@@ -360,6 +361,7 @@ func (o *Outbox) sendMetadata(ctx context.Context, stream flowStreamClient, errT
 	if len(msg.Data.Metadata) == 0 {
 		return nil
 	}
+	log.VEvent(ctx, 2, "Outbox sending metadata")
 	return stream.Send(msg)
 }
 

--- a/pkg/sql/distsql/server.go
+++ b/pkg/sql/distsql/server.go
@@ -713,11 +713,13 @@ func (ds *ServerImpl) flowStreamInt(
 		if err == io.EOF {
 			return errors.AssertionFailedf("missing header message")
 		}
+		log.VEventf(ctx, 2, "FlowStream (server) error while receiving header: %v", err)
 		return err
 	}
 	if msg.Header == nil {
 		return errors.AssertionFailedf("no header in first message")
 	}
+	log.VEvent(ctx, 2, "FlowStream (server) received header")
 	flowID := msg.Header.FlowID
 	streamID := msg.Header.StreamID
 	if log.V(1) {

--- a/pkg/sql/flowinfra/inbound.go
+++ b/pkg/sql/flowinfra/inbound.go
@@ -141,6 +141,7 @@ func processInboundStreamHelper(
 			if err != nil {
 				if err != io.EOF {
 					// Communication error.
+					log.VEventf(ctx, 2, "Inbox communication error: %v", err)
 					err = pgerror.Wrap(err, pgcode.InternalConnectionFailure, "inbox communication error")
 					sendErrToConsumer(err)
 					errChan <- err
@@ -152,6 +153,7 @@ func processInboundStreamHelper(
 				return
 			}
 
+			log.VEvent(ctx, 2, "Inbox received message")
 			if res := processProducerMessage(
 				ctx, f, stream, dst, &sd, &draining, msg,
 			); res.err != nil || res.consumerClosed {

--- a/pkg/sql/flowinfra/outbox.go
+++ b/pkg/sql/flowinfra/outbox.go
@@ -174,9 +174,7 @@ func (m *Outbox) flush(ctx context.Context) error {
 	}
 	msg := m.encoder.FormMessage(ctx)
 
-	if log.V(3) {
-		log.Infof(ctx, "flushing outbox")
-	}
+	log.VEvent(ctx, 2, "Outbox flushing")
 	sendErr := m.stream.Send(msg)
 	if m.statsCollectionEnabled {
 		m.streamStats.NetTx.BytesSent.Add(int64(msg.Size()))
@@ -191,11 +189,9 @@ func (m *Outbox) flush(ctx context.Context) error {
 		HandleStreamErr(ctx, "flushing", sendErr, m.flowCtxCancel, m.outboxCtxCancel)
 		// Make sure the stream is not used any more.
 		m.stream = nil
-		if log.V(1) {
-			log.Errorf(ctx, "outbox flush error: %s", sendErr)
-		}
-	} else if log.V(3) {
-		log.Infof(ctx, "outbox flushed")
+		log.VErrEventf(ctx, 1, "Outbox flush error: %s", sendErr)
+	} else {
+		log.VEvent(ctx, 2, "Outbox flushed")
 	}
 	if sendErr != nil {
 		return sendErr


### PR DESCRIPTION
**colrpc, flowinfra: wrap send and recv in tracing**

This commit adds trace events immediately before DistSQL sends and immediately after DistSQL recvs so that we can better determine where the latency is during performance incidents.

Informs: #108790

Epic: None

Release note: None

---

**kvcoord, server: wrap BatchRequest send and recv in tracing**

Add trace events immediately before and after kvclient / kvserver BatchRequest send and receive so that we can better determine where latency is during performance incidents.

Informs: #108790

Epic: None

Release note: None