### PR TITLE
roachtest: close the disk usage logger in restore perf tests

### DIFF
--- a/pkg/cmd/roachtest/tests/restore.go
+++ b/pkg/cmd/roachtest/tests/restore.go
@@ -371,6 +371,7 @@ func registerRestore(r registry.Registry) {
 				dul := roachtestutil.NewDiskUsageLogger(t, c)
 				m.Go(dul.Runner)
 				m.Go(func(ctx context.Context) error {
+					defer dul.Done()
 					t.Status(`running restore`)
 					metricCollector := rd.initRestorePerfMetrics(ctx, durationGauge)
 					if err := rd.run(ctx, ""); err != nil {


### PR DESCRIPTION
To address a different flakey roachtest issue, #109235 inadvertently deleted a call to close the disk usage logger. This caused all perf based roachtests to hang after the restore completed.

Fixes #109405
Fixes #109408
Fixes #109406
Fixes #109407
Fixes #109409

Release note: None