### PR TITLE
roachtest/jepsen: bump jepsen test version

### DIFF
--- a/pkg/cmd/roachtest/tests/jepsen.go
+++ b/pkg/cmd/roachtest/tests/jepsen.go
@@ -81,7 +81,7 @@ const jepsenRepo = "https://github.com/cockroachdb/jepsen"
 const repoBranch = "tc-nightly"
 
 const gcpPath = "https://storage.googleapis.com/cockroach-jepsen"
-const binaryVersion = "0.1.0-21cbebe-standalone"
+const binaryVersion = "0.1.0-782e8c1-standalone"
 
 var jepsenNemeses = []struct {
 	name, config string


### PR DESCRIPTION
This commit bumps the jepsen test binary version to the newest commit https://github.com/cockroachdb/jepsen/commit/782e8c1 in the `tc-nightly-main` branch.

The new version includes https://github.com/cockroachdb/jepsen/pull/36 which is helpful for debugging test failures like #104602.

Touches #104602
Epic: none
Release note: none