### PR TITLE
errorutil: de-emphasize "multi-tenancy" in the main compat error message

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -3554,7 +3554,9 @@ func TestChangefeedWorksOnRBRChange(t *testing.T) {
 	//
 	// error executing 'ALTER DATABASE d PRIMARY REGION
 	// "us-east-1"': pq: get_live_cluster_regions: unimplemented:
-	// operation is unsupported in multi-tenancy mode
+	// operation is unsupported inside virtual clusters
+	//
+	// TODO(knz): This seems incorrect; see issue #109418.
 	opts := []feedTestOption{
 		feedTestNoTenants,
 		feedTestEnterpriseSinks,

--- a/pkg/ccl/changefeedccl/nemeses_test.go
+++ b/pkg/ccl/changefeedccl/nemeses_test.go
@@ -48,10 +48,11 @@ func TestChangefeedNemeses(t *testing.T) {
 	}
 
 	// Tenant tests disabled because ALTER TABLE .. SPLIT is not
-	// support in multi-tenancy mode:
+	// supported with cluster virtualization:
 	//
-	// nemeses_test.go:39: pq: unimplemented: operation is
-	// unsupported in multi-tenancy mode
+	// nemeses_test.go:39: pq: unimplemented: operation is unsupported inside virtual clusters
+	//
+	// TODO(knz): This seems incorrect, see issue #109417.
 	cdcTest(t, testFn, feedTestNoTenants)
 	log.Flush()
 	entries, err := log.FetchEntriesFromFiles(0, math.MaxInt64, 1,

--- a/pkg/ccl/changefeedccl/validations_test.go
+++ b/pkg/ccl/changefeedccl/validations_test.go
@@ -98,10 +98,12 @@ func TestCatchupScanOrdering(t *testing.T) {
 			}
 		})
 	}
-	// Tenant tests skipped because of:
-	// validations_test.go:40: executing ALTER TABLE bank SPLIT AT
-	// VALUES (5): pq: unimplemented: operation is unsupported in
-	// multi-tenancy mode
+	// Tenant tests disabled because ALTER TABLE .. SPLIT is not
+	// supported with cluster virtualization:
+	//
+	// nemeses_test.go:39: pq: unimplemented: operation is unsupported inside virtual clusters
+	//
+	// TODO(knz): This seems incorrect, see issue #109417.
 	cdcTest(t, testFn, feedTestNoTenants)
 }
 

--- a/pkg/ccl/logictestccl/testdata/logic_test/crdb_internal_tenant
+++ b/pkg/ccl/logictestccl/testdata/logic_test/crdb_internal_tenant
@@ -418,17 +418,17 @@ node_id  component  field   value
 0        UI         Port    <port>
 0        UI         URI     /
 
-statement error unsupported in multi-tenancy mode
+statement error unsupported within a virtual cluster
 SELECT node_id, network, regexp_replace(address, '\d+$', '<port>') as address, attrs, locality, regexp_replace(server_version, '^\d+\.\d+(-\d+)?$', '<server_version>') as server_version FROM crdb_internal.gossip_nodes WHERE node_id = 1
 
-statement error unsupported in multi-tenancy mode
+statement error unsupported within a virtual cluster
 SELECT node_id, epoch, regexp_replace(expiration, '^\d+\.\d+,\d+$', '<timestamp>') as expiration, draining, decommissioning, membership FROM crdb_internal.gossip_liveness WHERE node_id = 1
 
-statement error unsupported in multi-tenancy mode
+statement error unsupported within a virtual cluster
 SELECT node_id, network, regexp_replace(address, '\d+$', '<port>') as address, attrs, locality, regexp_replace(server_version, '^\d+\.\d+(-\d+)?$', '<server_version>') as server_version, regexp_replace(go_version, '^go.+$', '<go_version>') as go_version
 FROM crdb_internal.kv_node_status WHERE node_id = 1
 
-statement error unsupported in multi-tenancy mode
+statement error unsupported within a virtual cluster
 SELECT node_id, store_id, attrs, used
 FROM crdb_internal.kv_store_status WHERE node_id = 1
 

--- a/pkg/ccl/logictestccl/testdata/logic_test/tenant_unsupported
+++ b/pkg/ccl/logictestccl/testdata/logic_test/tenant_unsupported
@@ -37,8 +37,8 @@ CREATE TEMP TABLE users (id UUID, city STRING, CONSTRAINT "primary" PRIMARY KEY 
 
 # Cannot read store or node status
 
-statement error operation is unsupported in multi-tenancy mode
+statement error operation is unsupported within a virtual cluster
 SELECT * FROM crdb_internal.kv_store_status
 
-statement error operation is unsupported in multi-tenancy mode
+statement error operation is unsupported within a virtual cluster
 SELECT * FROM crdb_internal.kv_node_status

--- a/pkg/ccl/logictestccl/testdata/logic_test/zone_config_secondary_tenants_disallowed
+++ b/pkg/ccl/logictestccl/testdata/logic_test/zone_config_secondary_tenants_disallowed
@@ -3,7 +3,7 @@
 # Note that we haven't used the setting override directive in this file to
 # override the default.
 
-statement error pq: unimplemented: operation is unsupported in multi-tenancy mode
+statement error pq: unimplemented: operation is unsupported within a virtual cluster
 ALTER TABLE t CONFIGURE ZONE USING num_replicas = 5;
 
 statement error setting sql.virtual_cluster.feature_access.zone_configs.enabled is only settable by the operator

--- a/pkg/ccl/workloadccl/fixture.go
+++ b/pkg/ccl/workloadccl/fixture.go
@@ -336,7 +336,7 @@ func getNodeCount(ctx context.Context, sqlDB *gosql.DB) (int, error) {
 	if err := sqlDB.QueryRow(numNodesQuery).Scan(&numNodes); err != nil {
 		// If the query is unsupported because we're in
 		// multi-tenant mode, use the sql_instances table.
-		if !strings.Contains(err.Error(), errorutil.UnsupportedWithMultiTenancyMessage) {
+		if !strings.Contains(err.Error(), errorutil.UnsupportedUnderClusterVirtualizationMessage) {
 			return 0, err
 
 		}

--- a/pkg/cli/interactive_tests/test_demo_partitioning.tcl
+++ b/pkg/cli/interactive_tests/test_demo_partitioning.tcl
@@ -132,7 +132,7 @@ end_test
 start_test "Expect an error if geo-partitioning is requested with multitenant mode"
 send "$argv demo --no-line-editor --geo-partitioned-replicas --log-dir=logs \r"
 # expect a failure
-eexpect "operation is unsupported in multi-tenancy mode"
+eexpect "operation is unsupported within a virtual cluster"
 eexpect $prompt
 end_test
 

--- a/pkg/cli/testdata/zip/testzip_external_process_virtualization
+++ b/pkg/cli/testdata/zip/testzip_external_process_virtualization
@@ -30,14 +30,14 @@ debug zip --concurrency=1 --cpu-profile-duration=1s /dev/null
 [cluster] retrieving SQL data for crdb_internal.invalid_objects... writing output: debug/crdb_internal.invalid_objects.txt... done
 [cluster] retrieving SQL data for crdb_internal.jobs... writing output: debug/crdb_internal.jobs.txt... done
 [cluster] retrieving SQL data for crdb_internal.kv_node_liveness... writing output: debug/crdb_internal.kv_node_liveness.txt...
-[cluster] retrieving SQL data for crdb_internal.kv_node_liveness: last request failed: ERROR: unimplemented: operation is unsupported in multi-tenancy mode (SQLSTATE 0A000)
+[cluster] retrieving SQL data for crdb_internal.kv_node_liveness: last request failed: ERROR: unimplemented: operation is unsupported within a virtual cluster (SQLSTATE 0A000)
 [cluster] retrieving SQL data for crdb_internal.kv_node_liveness: creating error output: debug/crdb_internal.kv_node_liveness.txt.err.txt... done
 [cluster] retrieving SQL data for crdb_internal.kv_node_status... writing output: debug/crdb_internal.kv_node_status.txt...
-[cluster] retrieving SQL data for crdb_internal.kv_node_status: last request failed: ERROR: unimplemented: operation is unsupported in multi-tenancy mode (SQLSTATE 0A000)
+[cluster] retrieving SQL data for crdb_internal.kv_node_status: last request failed: ERROR: unimplemented: operation is unsupported within a virtual cluster (SQLSTATE 0A000)
 [cluster] retrieving SQL data for crdb_internal.kv_node_status: creating error output: debug/crdb_internal.kv_node_status.txt.err.txt... done
 [cluster] retrieving SQL data for crdb_internal.kv_protected_ts_records... writing output: debug/crdb_internal.kv_protected_ts_records.txt... done
 [cluster] retrieving SQL data for crdb_internal.kv_store_status... writing output: debug/crdb_internal.kv_store_status.txt...
-[cluster] retrieving SQL data for crdb_internal.kv_store_status: last request failed: ERROR: unimplemented: operation is unsupported in multi-tenancy mode (SQLSTATE 0A000)
+[cluster] retrieving SQL data for crdb_internal.kv_store_status: last request failed: ERROR: unimplemented: operation is unsupported within a virtual cluster (SQLSTATE 0A000)
 [cluster] retrieving SQL data for crdb_internal.kv_store_status: creating error output: debug/crdb_internal.kv_store_status.txt.err.txt... done
 [cluster] retrieving SQL data for crdb_internal.kv_system_privileges... writing output: debug/crdb_internal.kv_system_privileges.txt... done
 [cluster] retrieving SQL data for crdb_internal.partitions... writing output: debug/crdb_internal.partitions.txt... done
@@ -111,13 +111,13 @@ debug zip --concurrency=1 --cpu-profile-duration=1s /dev/null
 [node 1] retrieving SQL data for crdb_internal.active_range_feeds... writing output: debug/nodes/1/crdb_internal.active_range_feeds.txt... done
 [node 1] retrieving SQL data for crdb_internal.feature_usage... writing output: debug/nodes/1/crdb_internal.feature_usage.txt... done
 [node 1] retrieving SQL data for crdb_internal.gossip_alerts... writing output: debug/nodes/1/crdb_internal.gossip_alerts.txt...
-[node 1] retrieving SQL data for crdb_internal.gossip_alerts: last request failed: ERROR: unimplemented: operation is unsupported in multi-tenancy mode (SQLSTATE 0A000)
+[node 1] retrieving SQL data for crdb_internal.gossip_alerts: last request failed: ERROR: unimplemented: operation is unsupported within a virtual cluster (SQLSTATE 0A000)
 [node 1] retrieving SQL data for crdb_internal.gossip_alerts: creating error output: debug/nodes/1/crdb_internal.gossip_alerts.txt.err.txt... done
 [node 1] retrieving SQL data for crdb_internal.gossip_liveness... writing output: debug/nodes/1/crdb_internal.gossip_liveness.txt...
-[node 1] retrieving SQL data for crdb_internal.gossip_liveness: last request failed: ERROR: unimplemented: operation is unsupported in multi-tenancy mode (SQLSTATE 0A000)
+[node 1] retrieving SQL data for crdb_internal.gossip_liveness: last request failed: ERROR: unimplemented: operation is unsupported within a virtual cluster (SQLSTATE 0A000)
 [node 1] retrieving SQL data for crdb_internal.gossip_liveness: creating error output: debug/nodes/1/crdb_internal.gossip_liveness.txt.err.txt... done
 [node 1] retrieving SQL data for crdb_internal.gossip_nodes... writing output: debug/nodes/1/crdb_internal.gossip_nodes.txt...
-[node 1] retrieving SQL data for crdb_internal.gossip_nodes: last request failed: ERROR: unimplemented: operation is unsupported in multi-tenancy mode (SQLSTATE 0A000)
+[node 1] retrieving SQL data for crdb_internal.gossip_nodes: last request failed: ERROR: unimplemented: operation is unsupported within a virtual cluster (SQLSTATE 0A000)
 [node 1] retrieving SQL data for crdb_internal.gossip_nodes: creating error output: debug/nodes/1/crdb_internal.gossip_nodes.txt.err.txt... done
 [node 1] retrieving SQL data for crdb_internal.leases... writing output: debug/nodes/1/crdb_internal.leases.txt... done
 [node 1] retrieving SQL data for crdb_internal.node_build_info... writing output: debug/nodes/1/crdb_internal.node_build_info.txt... done

--- a/pkg/cli/testdata/zip/testzip_shared_process_virtualization
+++ b/pkg/cli/testdata/zip/testzip_shared_process_virtualization
@@ -152,14 +152,14 @@ debug zip --concurrency=1 --cpu-profile-duration=1s /dev/null
 [cluster] retrieving SQL data for crdb_internal.invalid_objects... writing output: debug/cluster/test-tenant/crdb_internal.invalid_objects.txt... done
 [cluster] retrieving SQL data for crdb_internal.jobs... writing output: debug/cluster/test-tenant/crdb_internal.jobs.txt... done
 [cluster] retrieving SQL data for crdb_internal.kv_node_liveness... writing output: debug/cluster/test-tenant/crdb_internal.kv_node_liveness.txt...
-[cluster] retrieving SQL data for crdb_internal.kv_node_liveness: last request failed: ERROR: unimplemented: operation is unsupported in multi-tenancy mode (SQLSTATE 0A000)
+[cluster] retrieving SQL data for crdb_internal.kv_node_liveness: last request failed: ERROR: unimplemented: operation is unsupported within a virtual cluster (SQLSTATE 0A000)
 [cluster] retrieving SQL data for crdb_internal.kv_node_liveness: creating error output: debug/cluster/test-tenant/crdb_internal.kv_node_liveness.txt.err.txt... done
 [cluster] retrieving SQL data for crdb_internal.kv_node_status... writing output: debug/cluster/test-tenant/crdb_internal.kv_node_status.txt...
-[cluster] retrieving SQL data for crdb_internal.kv_node_status: last request failed: ERROR: unimplemented: operation is unsupported in multi-tenancy mode (SQLSTATE 0A000)
+[cluster] retrieving SQL data for crdb_internal.kv_node_status: last request failed: ERROR: unimplemented: operation is unsupported within a virtual cluster (SQLSTATE 0A000)
 [cluster] retrieving SQL data for crdb_internal.kv_node_status: creating error output: debug/cluster/test-tenant/crdb_internal.kv_node_status.txt.err.txt... done
 [cluster] retrieving SQL data for crdb_internal.kv_protected_ts_records... writing output: debug/cluster/test-tenant/crdb_internal.kv_protected_ts_records.txt... done
 [cluster] retrieving SQL data for crdb_internal.kv_store_status... writing output: debug/cluster/test-tenant/crdb_internal.kv_store_status.txt...
-[cluster] retrieving SQL data for crdb_internal.kv_store_status: last request failed: ERROR: unimplemented: operation is unsupported in multi-tenancy mode (SQLSTATE 0A000)
+[cluster] retrieving SQL data for crdb_internal.kv_store_status: last request failed: ERROR: unimplemented: operation is unsupported within a virtual cluster (SQLSTATE 0A000)
 [cluster] retrieving SQL data for crdb_internal.kv_store_status: creating error output: debug/cluster/test-tenant/crdb_internal.kv_store_status.txt.err.txt... done
 [cluster] retrieving SQL data for crdb_internal.kv_system_privileges... writing output: debug/cluster/test-tenant/crdb_internal.kv_system_privileges.txt... done
 [cluster] retrieving SQL data for crdb_internal.partitions... writing output: debug/cluster/test-tenant/crdb_internal.partitions.txt... done
@@ -233,13 +233,13 @@ debug zip --concurrency=1 --cpu-profile-duration=1s /dev/null
 [node 1] retrieving SQL data for crdb_internal.active_range_feeds... writing output: debug/cluster/test-tenant/nodes/1/crdb_internal.active_range_feeds.txt... done
 [node 1] retrieving SQL data for crdb_internal.feature_usage... writing output: debug/cluster/test-tenant/nodes/1/crdb_internal.feature_usage.txt... done
 [node 1] retrieving SQL data for crdb_internal.gossip_alerts... writing output: debug/cluster/test-tenant/nodes/1/crdb_internal.gossip_alerts.txt...
-[node 1] retrieving SQL data for crdb_internal.gossip_alerts: last request failed: ERROR: unimplemented: operation is unsupported in multi-tenancy mode (SQLSTATE 0A000)
+[node 1] retrieving SQL data for crdb_internal.gossip_alerts: last request failed: ERROR: unimplemented: operation is unsupported within a virtual cluster (SQLSTATE 0A000)
 [node 1] retrieving SQL data for crdb_internal.gossip_alerts: creating error output: debug/cluster/test-tenant/nodes/1/crdb_internal.gossip_alerts.txt.err.txt... done
 [node 1] retrieving SQL data for crdb_internal.gossip_liveness... writing output: debug/cluster/test-tenant/nodes/1/crdb_internal.gossip_liveness.txt...
-[node 1] retrieving SQL data for crdb_internal.gossip_liveness: last request failed: ERROR: unimplemented: operation is unsupported in multi-tenancy mode (SQLSTATE 0A000)
+[node 1] retrieving SQL data for crdb_internal.gossip_liveness: last request failed: ERROR: unimplemented: operation is unsupported within a virtual cluster (SQLSTATE 0A000)
 [node 1] retrieving SQL data for crdb_internal.gossip_liveness: creating error output: debug/cluster/test-tenant/nodes/1/crdb_internal.gossip_liveness.txt.err.txt... done
 [node 1] retrieving SQL data for crdb_internal.gossip_nodes... writing output: debug/cluster/test-tenant/nodes/1/crdb_internal.gossip_nodes.txt...
-[node 1] retrieving SQL data for crdb_internal.gossip_nodes: last request failed: ERROR: unimplemented: operation is unsupported in multi-tenancy mode (SQLSTATE 0A000)
+[node 1] retrieving SQL data for crdb_internal.gossip_nodes: last request failed: ERROR: unimplemented: operation is unsupported within a virtual cluster (SQLSTATE 0A000)
 [node 1] retrieving SQL data for crdb_internal.gossip_nodes: creating error output: debug/cluster/test-tenant/nodes/1/crdb_internal.gossip_nodes.txt.err.txt... done
 [node 1] retrieving SQL data for crdb_internal.leases... writing output: debug/cluster/test-tenant/nodes/1/crdb_internal.leases.txt... done
 [node 1] retrieving SQL data for crdb_internal.node_build_info... writing output: debug/cluster/test-tenant/nodes/1/crdb_internal.node_build_info.txt... done

--- a/pkg/inspectz/unsupported.go
+++ b/pkg/inspectz/unsupported.go
@@ -28,12 +28,12 @@ var _ inspectzpb.InspectzServer = Unsupported{}
 func (u Unsupported) KVFlowController(
 	ctx context.Context, request *kvflowinspectpb.ControllerRequest,
 ) (*kvflowinspectpb.ControllerResponse, error) {
-	return nil, errorutil.UnsupportedWithMultiTenancy(errorutil.FeatureNotAvailableToNonSystemTenantsIssue)
+	return nil, errorutil.UnsupportedUnderClusterVirtualization(errorutil.FeatureNotAvailableToNonSystemTenantsIssue)
 }
 
 // KVFlowHandles is part of the inspectzpb.InspectzServer interface.
 func (u Unsupported) KVFlowHandles(
 	ctx context.Context, request *kvflowinspectpb.HandlesRequest,
 ) (*kvflowinspectpb.HandlesResponse, error) {
-	return nil, errorutil.UnsupportedWithMultiTenancy(errorutil.FeatureNotAvailableToNonSystemTenantsIssue)
+	return nil, errorutil.UnsupportedUnderClusterVirtualization(errorutil.FeatureNotAvailableToNonSystemTenantsIssue)
 }

--- a/pkg/kv/kvserver/kvserverbase/stores.go
+++ b/pkg/kv/kvserver/kvserverbase/stores.go
@@ -53,5 +53,5 @@ var _ StoresIterator = UnsupportedStoresIterator{}
 
 // ForEachStore is part of the StoresIterator interface.
 func (i UnsupportedStoresIterator) ForEachStore(f func(Store) error) error {
-	return errorutil.UnsupportedWithMultiTenancy(errorutil.FeatureNotAvailableToNonSystemTenantsIssue)
+	return errorutil.UnsupportedUnderClusterVirtualization(errorutil.FeatureNotAvailableToNonSystemTenantsIssue)
 }

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -222,7 +222,7 @@ type SQLServer struct {
 //
 // TODO(tbg): give all of these fields a wrapper that can signal whether the
 // respective object is available. When it is not, return
-// UnsupportedWithMultiTenancy.
+// UnsupportedUnderClusterVirtualization.
 type sqlServerOptionalKVArgs struct {
 	// nodesStatusServer gives access to the NodesStatus service.
 	nodesStatusServer serverpb.OptionalNodesStatusServer

--- a/pkg/sql/logictest/testdata/logic_test/kv_builtin_functions_tenant
+++ b/pkg/sql/logictest/testdata/logic_test/kv_builtin_functions_tenant
@@ -1,7 +1,7 @@
 # LogicTest: 3node-tenant
 
-query error pq: crdb_internal.kv_set_queue_active\(\): unimplemented: operation is unsupported in multi-tenancy mode
+query error pq: crdb_internal.kv_set_queue_active\(\): unimplemented: operation is unsupported within a virtual cluster
 select crdb_internal.kv_set_queue_active('split', true);
 
-query error pq: crdb_internal.kv_enqueue_replica\(\): unimplemented: operation is unsupported in multi-tenancy mode
+query error pq: crdb_internal.kv_enqueue_replica\(\): unimplemented: operation is unsupported within a virtual cluster
 select crdb_internal.kv_enqueue_replica(42, 'split', true);

--- a/pkg/sql/set_zone_config.go
+++ b/pkg/sql/set_zone_config.go
@@ -264,7 +264,7 @@ func (p *planner) SetZoneConfig(ctx context.Context, n *tree.SetZoneConfig) (pla
 		// Return an unimplemented error here instead of referencing the cluster
 		// setting here as zone configurations for secondary tenants are intended to
 		// be hidden.
-		return nil, errorutil.UnsupportedWithMultiTenancy(MultitenancyZoneCfgIssueNo)
+		return nil, errorutil.UnsupportedUnderClusterVirtualization(MultitenancyZoneCfgIssueNo)
 	}
 
 	if err := checkPrivilegeForSetZoneConfig(ctx, p, n.ZoneSpecifier); err != nil {

--- a/pkg/util/errorutil/tenant.go
+++ b/pkg/util/errorutil/tenant.go
@@ -12,15 +12,15 @@ package errorutil
 
 import "github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 
-// UnsupportedWithMultiTenancyMessage is the message used by UnsupportedWithMultiTenancy error.
-const UnsupportedWithMultiTenancyMessage = "operation is unsupported in multi-tenancy mode"
+// UnsupportedUnderClusterVirtualizationMessage is the message used by UnsupportedUnderClusterVirtualization error.
+const UnsupportedUnderClusterVirtualizationMessage = "operation is unsupported within a virtual cluster"
 
-// UnsupportedWithMultiTenancy returns an error suitable for returning when an
-// operation could not be carried out due to the SQL server running in
-// multi-tenancy mode. In that mode, Gossip and other components of the KV layer
-// are not available.
-func UnsupportedWithMultiTenancy(issue int) error {
-	return unimplemented.NewWithIssue(issue, UnsupportedWithMultiTenancyMessage)
+// UnsupportedUnderClusterVirtualization returns an error suitable for
+// returning when an operation could not be carried out due to the SQL
+// server running inside a virtual cluster. In that mode, Gossip and
+// other components of the KV layer are not available.
+func UnsupportedUnderClusterVirtualization(issue int) error {
+	return unimplemented.NewWithIssue(issue, UnsupportedUnderClusterVirtualizationMessage)
 }
 
 // FeatureNotAvailableToNonSystemTenantsIssue is to be used with the

--- a/pkg/util/errorutil/tenant_deprecated_wrapper.go
+++ b/pkg/util/errorutil/tenant_deprecated_wrapper.go
@@ -76,7 +76,7 @@ func (w TenantSQLDeprecatedWrapper) Optional() (interface{}, bool) {
 func (w TenantSQLDeprecatedWrapper) OptionalErr(issue int) (interface{}, error) {
 	v, ok := w.Optional()
 	if !ok {
-		return nil, UnsupportedWithMultiTenancy(issue)
+		return nil, UnsupportedUnderClusterVirtualization(issue)
 	}
 	return v, nil
 }

--- a/pkg/workload/workloadsql/workloadsql.go
+++ b/pkg/workload/workloadsql/workloadsql.go
@@ -108,7 +108,7 @@ func Split(ctx context.Context, db *gosql.DB, table workload.Table, concurrency 
 	_, err := db.Exec("SHOW RANGES FROM TABLE system.descriptor")
 	if err != nil {
 		if strings.Contains(err.Error(), "not fully contained in tenant") ||
-			strings.Contains(err.Error(), errorutil.UnsupportedWithMultiTenancyMessage) {
+			strings.Contains(err.Error(), errorutil.UnsupportedUnderClusterVirtualizationMessage) {
 			log.Infof(ctx, `skipping workload splits; can't split on tenants'`)
 			//nolint:returnerrcheck
 			return nil
@@ -171,9 +171,12 @@ func Split(ctx context.Context, db *gosql.DB, table workload.Table, concurrency 
 					// not) help you.
 					stmt := buf.String()
 					if _, err := db.Exec(stmt); err != nil {
-						if strings.Contains(err.Error(), errorutil.UnsupportedWithMultiTenancyMessage) {
+						if strings.Contains(err.Error(), errorutil.UnsupportedUnderClusterVirtualizationMessage) {
 							// We don't care about split errors if we're running a workload
-							// in multi-tenancy mode; we can't do them so we'll just continue
+							// with virtual clusters; we can't do them so we'll just continue.
+							//
+							// TODO(knz): This seems incorrect: this should be possible
+							// with the right capability. See: #109422.
 							break
 						}
 						return errors.Wrapf(err, "executing %s", stmt)


### PR DESCRIPTION
Prior to this patch:

```
pq: operation is unsupported in multi-tenancy mode
```

After this patch:

```
pq: operation is unsupported within virtual clusters
```

Release note: None
Epic: CRDB-29380
Relates to CRDB-26687.