### PR TITLE
backupccl: replace TestBackupRestoreSystemJobsProgress

### DIFF
--- a/pkg/ccl/backupccl/backup_job.go
+++ b/pkg/ccl/backupccl/backup_job.go
@@ -281,6 +281,9 @@ func backup(
 			// Signal that an ExportRequest finished to update job progress.
 			for i := int32(0); i < progDetails.CompletedSpans; i++ {
 				requestFinishedCh <- struct{}{}
+				if execCtx.ExecCfg().TestingKnobs.AfterBackupChunk != nil {
+					execCtx.ExecCfg().TestingKnobs.AfterBackupChunk()
+				}
 			}
 
 			// Update the per-component progress maintained by the job profiler.

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1620,6 +1620,9 @@ type ExecutorTestingKnobs struct {
 		txnFingerprintID appstatspb.TransactionFingerprintID,
 	)
 
+	// AfterBackupChunk is called after each chunk of a backup is completed.
+	AfterBackupChunk func()
+
 	// AfterBackupCheckpoint if set will be called after a BACKUP-CHECKPOINT
 	// is written.
 	AfterBackupCheckpoint func()


### PR DESCRIPTION
This replaces the complex TestBackupRestoreSystemJobsProgress test with a much simpler test that the number of chunk events sent to the progress logger is non-zero during the simple single backup test, TestBackupRestoreSingleNodeLocal.

Release note: none.
Epic: none.

Fixes #68571.