### PR TITLE
roachprod: azure gc cleans up empty clusters

### DIFF
--- a/pkg/roachprod/cloud/cluster_cloud.go
+++ b/pkg/roachprod/cloud/cluster_cloud.go
@@ -163,6 +163,11 @@ func (c *Cluster) IsLocal() bool {
 	return config.IsLocalClusterName(c.Name)
 }
 
+// IsEmptyCluster returns true if a cluster has no resources.
+func (c *Cluster) IsEmptyCluster() bool {
+	return c.VMs[0].EmptyCluster
+}
+
 // ListCloud returns information about all instances (across all available
 // providers).
 func ListCloud(l *logger.Logger, options vm.ListOptions) (*Cloud, error) {
@@ -201,8 +206,9 @@ func ListCloud(l *logger.Logger, options vm.ListOptions) (*Cloud, error) {
 			}
 
 			// Anything with an error gets tossed into the BadInstances slice, and we'll correct
-			// the problem later on.
-			if len(v.Errors) > 0 {
+			// the problem later on. Ignore empty clusters since BadInstances will be destroyed on
+			// the VM level. GC will destroy them instead.
+			if len(v.Errors) > 0 && !v.EmptyCluster {
 				cloud.BadInstances = append(cloud.BadInstances, v)
 				continue
 			}
@@ -231,7 +237,11 @@ func ListCloud(l *logger.Logger, options vm.ListOptions) (*Cloud, error) {
 	}
 
 	// Sort VMs for each cluster. We want to make sure we always have the same order.
+	// Also assert that no cluster can be empty.
 	for _, c := range cloud.Clusters {
+		if len(c.VMs) == 0 {
+			return nil, errors.Errorf("found no VMs in cluster %s", c.Name)
+		}
 		sort.Sort(c.VMs)
 	}
 

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -1193,7 +1193,7 @@ func Destroy(
 		if err != nil {
 			return err
 		}
-		cld, err = cloud.ListCloud(l, vm.ListOptions{})
+		cld, err = cloud.ListCloud(l, vm.ListOptions{IncludeEmptyClusters: true})
 		if err != nil {
 			return err
 		}
@@ -1223,7 +1223,7 @@ func Destroy(
 			}
 			if cld == nil {
 				var err error
-				cld, err = cloud.ListCloud(l, vm.ListOptions{})
+				cld, err = cloud.ListCloud(l, vm.ListOptions{IncludeEmptyClusters: true})
 				if err != nil {
 					return err
 				}
@@ -1241,7 +1241,12 @@ func destroyCluster(cld *cloud.Cloud, l *logger.Logger, clusterName string) erro
 	if !ok {
 		return fmt.Errorf("cluster %s does not exist", clusterName)
 	}
-	l.Printf("Destroying cluster %s with %d nodes", clusterName, len(c.VMs))
+	if c.IsEmptyCluster() {
+		l.Printf("Destroying empty cluster %s with 0 nodes", clusterName)
+	} else {
+		l.Printf("Destroying cluster %s with %d nodes", clusterName, len(c.VMs))
+	}
+
 	return cloud.DestroyCluster(l, c)
 }
 
@@ -1270,7 +1275,7 @@ func (e *ClusterAlreadyExistsError) Error() string {
 }
 
 func cleanupFailedCreate(l *logger.Logger, clusterName string) error {
-	cld, err := cloud.ListCloud(l, vm.ListOptions{})
+	cld, err := cloud.ListCloud(l, vm.ListOptions{IncludeEmptyClusters: true})
 	if err != nil {
 		return err
 	}
@@ -1400,7 +1405,7 @@ func GC(l *logger.Logger, dryrun bool) error {
 	if err := LoadClusters(); err != nil {
 		return err
 	}
-	cld, err := cloud.ListCloud(l, vm.ListOptions{})
+	cld, err := cloud.ListCloud(l, vm.ListOptions{IncludeEmptyClusters: true})
 	if err == nil {
 		// GCClusters depends on ListCloud so only call it if ListCloud runs without errors
 		err = cloud.GCClusters(l, cld, dryrun)

--- a/pkg/roachprod/vm/azure/azure.go
+++ b/pkg/roachprod/vm/azure/azure.go
@@ -468,6 +468,11 @@ func (p *Provider) List(l *logger.Logger, opts vm.ListOptions) (vm.List, error) 
 		return nil, err
 	}
 
+	// Keep track of which clusters we find through listing VMs.
+	// If later we need to list resource groups to find empty clusters,
+	// we want to make sure we don't add anything twice.
+	foundClusters := make(map[string]bool)
+
 	var ret vm.List
 	for it.NotDone() {
 		found := it.Value()
@@ -523,12 +528,87 @@ func (p *Provider) List(l *logger.Logger, opts vm.ListOptions) (vm.List, error) 
 			return nil, err
 		}
 
+		clusterName, _ := m.ClusterName()
+		foundClusters[clusterName] = true
 		ret = append(ret, m)
 
 		if err := it.NextWithContext(ctx); err != nil {
 			return nil, err
 		}
+	}
 
+	// Azure allows for clusters to exist even if the attached VM no longer exists.
+	// Such a cluster won't be found by listing all azure VMs like above.
+	// Normally we don't want to access these clusters except for deleting them.
+	if opts.IncludeEmptyClusters {
+		groupsClient := resources.NewGroupsClient(*sub.SubscriptionID)
+		if groupsClient.Authorizer, err = p.getAuthorizer(); err != nil {
+			return nil, err
+		}
+
+		// List all resource groups for clusters under the subscription.
+		filter := fmt.Sprintf("tagName eq '%s'", vm.TagCluster)
+		it, err := groupsClient.ListComplete(ctx, filter, nil /* limit */)
+		if err != nil {
+			return nil, err
+		}
+
+		for it.NotDone() {
+			resourceGroup := it.Value()
+			if _, ok := resourceGroup.Tags[vm.TagRoachprod]; !ok {
+				if err := it.NextWithContext(ctx); err != nil {
+					return nil, err
+				}
+				continue
+			}
+
+			// Resource Groups have the name format "user-<clusterid>-<region>",
+			// while clusters have the name format "user-<clusterid>".
+			parts := strings.Split(*resourceGroup.Name, "-")
+			clusterName := strings.Join(parts[:len(parts)-1], "-")
+			if foundClusters[clusterName] {
+				if err := it.NextWithContext(ctx); err != nil {
+					return nil, err
+				}
+				continue
+			}
+
+			// The cluster does not have a VM, but roachprod assumes that this is not
+			// possible and implements providers on the VM level. A VM-less cluster will
+			// not have access to provider info or methods. To still allow this cluster to
+			// be deleted, we must create a fake VM, indicated by EmptyCluster.
+			m := vm.VM{
+				Name:       *resourceGroup.Name,
+				Provider:   ProviderName,
+				RemoteUser: remoteUser,
+				VPC:        "global",
+				// We add a fake availability-zone suffix since other roachprod
+				// code assumes particular formats. For example, "eastus2z".
+				Zone:         *resourceGroup.Location + "z",
+				EmptyCluster: true,
+			}
+
+			// We ignore any parsing errors here as roachprod tries to destroy "bad VMs".
+			// We don't want that since this is a fake VM, we need to destroy the resource
+			// group instead. This will be done by GC when it sees that no m.CreatedAt exists.
+			createdPtr := resourceGroup.Tags[vm.TagCreated]
+			if createdPtr != nil {
+				parsed, _ := time.Parse(time.RFC3339, *createdPtr)
+				m.CreatedAt = parsed
+			}
+
+			lifetimePtr := resourceGroup.Tags[vm.TagLifetime]
+			if lifetimePtr != nil {
+				parsed, _ := time.ParseDuration(*lifetimePtr)
+				m.Lifetime = parsed
+			}
+
+			ret = append(ret, m)
+
+			if err := it.NextWithContext(ctx); err != nil {
+				return nil, err
+			}
+		}
 	}
 
 	return ret, nil

--- a/pkg/roachprod/vm/vm.go
+++ b/pkg/roachprod/vm/vm.go
@@ -117,6 +117,11 @@ type VM struct {
 	// CostPerHour is the estimated cost per hour of this VM, in US dollars. 0 if
 	//there is no estimate available.
 	CostPerHour float64
+
+	// EmptyCluster indicates that the VM does not exist. Azure allows for empty
+	// clusters, but roachprod does not allow VM-less clusters except when deleting them.
+	// A fake VM will be used in this scenario.
+	EmptyCluster bool
 }
 
 // Name generates the name for the i'th node in a cluster.
@@ -383,6 +388,7 @@ type VolumeCreateOpts struct {
 
 type ListOptions struct {
 	IncludeVolumes       bool
+	IncludeEmptyClusters bool
 	ComputeEstimatedCost bool
 }
 


### PR DESCRIPTION
Azure allows for clusters to exist with no attached VM, which roachprod assumes is not possible. This would occur if azure.create failed after creating a resource group but before creating a VM. Roachprod GC only searches for VMs when searching for clusters, so these VM-less clusters would never be found and cleaned up.

This change adds the ability to list empty clusters by querying resource groups instead of VMs. This is used by GC and destroy jobs to correctly identify and cleanup these dangling resources.

Epic: https://cockroachlabs.atlassian.net/browse/CRDB-3373
Release note: None