### PR TITLE
changefeedccl: Emit span resolved event when end time reached 

### DIFF
--- a/pkg/ccl/changefeedccl/cdcutils/throttle.go
+++ b/pkg/ccl/changefeedccl/cdcutils/throttle.go
@@ -12,7 +12,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"math"
 	"sync"
 	"time"
 
@@ -69,7 +68,7 @@ func (t *Throttler) AcquireFlushQuota(ctx context.Context) error {
 func (t *Throttler) updateConfig(config changefeedbase.SinkThrottleConfig) {
 	setLimits := func(rl *quotapool.RateLimiter, rate, burst float64) {
 		// set rateBudget to unlimited if rate is 0.
-		rateBudget := quotapool.Limit(math.MaxInt64)
+		rateBudget := quotapool.Inf()
 		if rate > 0 {
 			rateBudget = quotapool.Limit(rate)
 		}

--- a/pkg/ccl/changefeedccl/kvevent/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/kvevent/BUILD.bazel
@@ -52,6 +52,7 @@ go_test(
         "//pkg/sql/rowenc/keyside",
         "//pkg/sql/sem/tree",
         "//pkg/sql/types",
+        "//pkg/testutils",
         "//pkg/util",
         "//pkg/util/ctxgroup",
         "//pkg/util/encoding",

--- a/pkg/ccl/changefeedccl/kvevent/blocking_buffer.go
+++ b/pkg/ccl/changefeedccl/kvevent/blocking_buffer.go
@@ -105,6 +105,7 @@ func newMemBuffer(
 
 	b.qp = allocPool{
 		AbstractPool: quotapool.New("changefeed", quota, opts...),
+		sv:           sv,
 		metrics:      metrics,
 	}
 
@@ -218,6 +219,7 @@ func (b *blockingBuffer) enqueue(ctx context.Context, e Event) (err error) {
 	}
 
 	b.metrics.BufferEntriesIn.Inc(1)
+	b.metrics.BufferEntriesByType[e.et.Index()].Inc(1)
 	b.mu.queue.enqueue(e)
 
 	select {
@@ -246,6 +248,7 @@ func (b *blockingBuffer) AcquireMemory(ctx context.Context, n int64) (alloc Allo
 		return alloc, err
 	}
 	b.metrics.BufferEntriesMemAcquired.Inc(n)
+	b.metrics.AllocatedMem.Inc(n)
 	return alloc, nil
 }
 
@@ -324,6 +327,7 @@ func (b *blockingBuffer) CloseWithReason(ctx context.Context, reason error) erro
 		quota := r.(*memQuota)
 		quota.closed = true
 		quota.acc.Close(ctx)
+		b.metrics.AllocatedMem.Dec(quota.allocated)
 		return false
 	})
 
@@ -442,9 +446,14 @@ func (r *memRequest) ShouldWait() bool {
 type allocPool struct {
 	*quotapool.AbstractPool
 	metrics *Metrics
+	sv      *settings.Values
 }
 
 func (ap allocPool) Release(ctx context.Context, bytes, entries int64) {
+	if bytes < 0 {
+		logcrash.ReportOrPanic(ctx, ap.sv, "attempt to release negative bytes (%d) into pool", bytes)
+	}
+
 	ap.AbstractPool.Update(func(r quotapool.Resource) (shouldNotify bool) {
 		quota := r.(*memQuota)
 		if quota.closed {
@@ -452,6 +461,7 @@ func (ap allocPool) Release(ctx context.Context, bytes, entries int64) {
 		}
 		quota.acc.Shrink(ctx, bytes)
 		quota.allocated -= bytes
+		ap.metrics.AllocatedMem.Dec(bytes)
 		ap.metrics.BufferEntriesMemReleased.Inc(bytes)
 		ap.metrics.BufferEntriesReleased.Inc(entries)
 		return true

--- a/pkg/ccl/changefeedccl/kvevent/blocking_buffer_test.go
+++ b/pkg/ccl/changefeedccl/kvevent/blocking_buffer_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/kvevent"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -22,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/randgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc/keyside"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
@@ -32,6 +34,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/quotapool"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -94,9 +97,6 @@ func TestBlockingBuffer(t *testing.T) {
 	}
 	st := cluster.MakeTestingClusterSettings()
 	buf := kvevent.TestingNewMemBuffer(ba, &st.SV, &metrics, notifyWait)
-	defer func() {
-		require.NoError(t, buf.CloseWithReason(context.Background(), nil))
-	}()
 
 	producerCtx, stopProducers := context.WithCancel(context.Background())
 	wg := ctxgroup.WithContext(producerCtx)
@@ -105,26 +105,79 @@ func TestBlockingBuffer(t *testing.T) {
 	}()
 
 	// Start adding KVs to the buffer until we block.
+	var numResolvedEvents, numKVEvents int
 	wg.GoCtx(func(ctx context.Context) error {
 		rnd, _ := randutil.NewTestRand()
 		for {
-			err := buf.Add(ctx, kvevent.MakeKVEvent(makeRangeFeedEvent(rnd, 256, 0)))
-			if err != nil {
-				return err
+			if rnd.Int()%20 == 0 {
+				prefix := keys.SystemSQLCodec.TablePrefix(42)
+				sp := roachpb.Span{Key: prefix, EndKey: prefix.Next()}
+				if err := buf.Add(ctx, kvevent.NewBackfillResolvedEvent(sp, hlc.Timestamp{}, jobspb.ResolvedSpan_BACKFILL)); err != nil {
+					return err
+				}
+				numResolvedEvents++
+			} else {
+				if err := buf.Add(ctx, kvevent.MakeKVEvent(makeRangeFeedEvent(rnd, 256, 0))); err != nil {
+					return err
+				}
+				numKVEvents++
 			}
 		}
 	})
 
-	<-waitCh
+	require.NoError(t, timeutil.RunWithTimeout(
+		context.Background(), "wait", 10*time.Second, func(ctx context.Context) error {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-waitCh:
+				return nil
+			}
+		}))
 
 	// Keep consuming events until we get pushback metrics updated.
+	var numPopped, numFlush int
 	for metrics.BufferPushbackNanos.Count() == 0 {
 		e, err := buf.Get(context.Background())
 		require.NoError(t, err)
 		a := e.DetachAlloc()
 		a.Release(context.Background())
+		numPopped++
+		if e.Type() == kvevent.TypeFlush {
+			numFlush++
+		}
 	}
+
+	// Allocated memory gauge should be non-zero once we buffer some events.
+	testutils.SucceedsWithin(t, func() error {
+		if metrics.AllocatedMem.Value() > 0 {
+			return nil
+		}
+		return errors.New("waiting for allocated mem > 0")
+	}, 5*time.Second)
+
 	stopProducers()
+	require.ErrorIs(t, wg.Wait(), context.Canceled)
+
+	require.EqualValues(t, numKVEvents+numResolvedEvents, metrics.BufferEntriesIn.Count())
+	require.EqualValues(t, numPopped, metrics.BufferEntriesOut.Count())
+	require.Greater(t, metrics.BufferEntriesMemReleased.Count(), int64(0))
+
+	// Flush events are special in that they are ephemeral event that doesn't get
+	// counted when releasing (it's 0 entries and 0 byte event).
+	require.EqualValues(t, numPopped-numFlush, metrics.BufferEntriesReleased.Count())
+
+	require.EqualValues(t, numKVEvents, metrics.BufferEntriesByType[kvevent.TypeKV].Count())
+	require.EqualValues(t, numResolvedEvents, metrics.BufferEntriesByType[kvevent.TypeResolved].Count())
+
+	// We might have seen numFlush events, but they are synthetic, and only explicitly enqueued
+	// flush events are counted.
+	require.EqualValues(t, 0, metrics.BufferEntriesByType[kvevent.TypeFlush].Count())
+
+	// After buffer closed, resources are released, and metrics adjusted to reflect.
+	require.NoError(t, buf.CloseWithReason(context.Background(), context.Canceled))
+
+	require.EqualValues(t, 0, metrics.AllocatedMem.Value())
 }
 
 func TestBlockingBufferNotifiesConsumerWhenOutOfMemory(t *testing.T) {

--- a/pkg/ccl/changefeedccl/kvevent/event.go
+++ b/pkg/ccl/changefeedccl/kvevent/event.go
@@ -136,6 +136,11 @@ func (t Type) Index() int {
 	}
 }
 
+// Raw returns the underlying RangeFeedEvent.
+func (e *Event) Raw() *kvpb.RangeFeedEvent {
+	return e.ev
+}
+
 // ApproximateSize returns events approximate size in bytes.
 func (e *Event) ApproximateSize() int {
 	if e.et == TypeFlush {

--- a/pkg/ccl/changefeedccl/kvevent/event.go
+++ b/pkg/ccl/changefeedccl/kvevent/event.go
@@ -77,13 +77,10 @@ type MemAllocator interface {
 type Type uint8
 
 const (
-	// TypeUnknown indicates the event could not be parsed. Will fail the feed.
-	TypeUnknown Type = iota
-
 	// TypeFlush indicates a request to flush buffered data.
 	// This request type is emitted by blocking buffer when it's blocked, waiting
 	// for more memory.
-	TypeFlush
+	TypeFlush Type = iota
 
 	// TypeKV indicates that the KV, PrevKeyValue, and BackfillTimestamp methods
 	// on the Event meaningful.
@@ -98,6 +95,9 @@ const (
 	// TypeResolved indicates that the Resolved method on the Event will be
 	// meaningful.
 	TypeResolved = resolvedNone
+
+	// number of event types.
+	numEventTypes = TypeResolved + 1
 )
 
 // Event represents an event emitted by a kvfeed. It is either a KV or a
@@ -117,6 +117,22 @@ func (e *Event) Type() Type {
 		return TypeResolved
 	default:
 		return e.et
+	}
+}
+
+// Index returns numerical/ordinal type index suitable for indexing into arrays.
+func (t Type) Index() int {
+	switch t {
+	case TypeFlush:
+		return int(TypeFlush)
+	case TypeKV:
+		return int(TypeKV)
+	case TypeResolved, resolvedBackfill, resolvedRestart, resolvedExit:
+		return int(TypeResolved)
+	default:
+		log.Warningf(context.TODO(),
+			"returning TypeFlush boundary type for unknown event type %d", t)
+		return int(TypeFlush)
 	}
 }
 

--- a/pkg/cmd/roachtest/tests/cdc_bench.go
+++ b/pkg/cmd/roachtest/tests/cdc_bench.go
@@ -100,9 +100,6 @@ func registerCDCBench(r registry.Registry) {
 					RequiresLicense: true,
 					Timeout:         2 * time.Hour, // catchup scans with 100k ranges can take >1 hour
 					Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-						if ranges == 100000 && scanType == cdcBenchCatchupScan {
-							t.Skip("fails to complete, see https://github.com/cockroachdb/cockroach/issues/108157")
-						}
 						runCDCBenchScan(ctx, t, c, scanType, rows, ranges, protocol, format)
 					},
 				})
@@ -173,6 +170,37 @@ func makeCDCBenchOptions() (option.StartOpts, install.ClusterSettings) {
 	// ranges aren't able to keep up.
 	settings.ClusterSettings["kv.rangefeed.range_stuck_threshold"] = "0"
 
+	// Checkpoint frequently.  Some of the larger benchmarks might overload the
+	// cluster.  Producing frequent span-level checkpoints helps with recovery.
+	settings.ClusterSettings["changefeed.frontier_checkpoint_frequency"] = "60s"
+	settings.ClusterSettings["changefeed.frontier_highwater_lag_checkpoint_threshold"] = "30s"
+
+	// Bump up the number of allowed catchup scans.  Doing catchup for 100k ranges with default
+	// configuration (8 client side, 16 per store) takes a while (~1500-2000 ranges per min minutes).
+	settings.ClusterSettings["kv.rangefeed.catchup_scan_concurrency"] = "16"
+	settings.ClusterSettings["kv.rangefeed.concurrent_catchup_iterators"] = "16"
+
+	// Give changefeed more memory and slow down rangefeed checkpoints.
+	// When running large catchup scan benchmarks (100k ranges), as the benchmark
+	// nears completion, more and more ranges generate checkpoint events.  When
+	// the rate of checkpoints high (default used to be 200ms), the changefeed
+	// begins to block on memory acquisition since the fan in factor (~20k
+	// ranges/node) greatly exceeds processing loop speed (1 goroutine).
+	// The current pipeline looks like this:
+	//    rangefeed ->
+	//       1 goroutine physicalKVFeed (acquire Memory) ->
+	//       1 goroutine copyFromSourceToDestination (filter events) ->
+	//       1 goroutine changeAggregator.Next ->
+	//       N goroutines rest of the pipeline (encode and emit)
+	// The memory for the checkpoint events (even ones after end_time) must be allocated
+	// first; then these events are thrown away (many inefficiencies here -- but
+	// it's the only thing we can do w/out having to add "end time" support to the rangefeed library).
+	// The rate of incoming events greatly exceeds the rate with which we consume these events
+	// (and release allocations), resulting in significant drop in completed ranges throughput.
+	// Current default is 3s, but if needed increase this time out:
+	//    settings.ClusterSettings["kv.rangefeed.closed_timestamp_refresh_interval"] = "5s"
+	settings.ClusterSettings["changefeed.memory.per_changefeed_limit"] = "4G"
+
 	// Scheduled backups may interfere with performance, disable them.
 	opts.RoachprodOpts.ScheduleBackups = false
 
@@ -180,6 +208,13 @@ func makeCDCBenchOptions() (option.StartOpts, install.ClusterSettings) {
 	// reliable results, since we can otherwise randomly hit timeouts and incur
 	// catchup scans.
 	settings.Env = append(settings.Env, "COCKROACH_RANGEFEED_SEND_TIMEOUT=0")
+
+	// If this benchmark experiences periodic changefeed restarts due to rpc errors
+	// (grpc context canceled), consider increase network timeout.
+	// Under significant load (due to rangefeed), timeout could easily be triggered
+	// due to elevated goroutine scheduling latency.
+	// Current default is 4s which should be sufficient.
+	// settings.Env = append(settings.Env, "COCKROACH_NETWORK_TIMEOUT=6s")
 
 	return opts, settings
 }
@@ -286,6 +321,11 @@ func runCDCBenchScan(
 	default:
 		t.Fatalf("unknown scan type %q", scanType)
 	}
+
+	// Lock schema so that changefeed schema feed runs under fast path.
+	_, err := conn.ExecContext(ctx, "ALTER TABLE kv.kv  SET (schema_locked = true);")
+	require.NoError(t, err)
+
 	var jobID int
 	require.NoError(t, conn.QueryRowContext(ctx,
 		fmt.Sprintf(`CREATE CHANGEFEED FOR kv.kv INTO '%s' WITH %s`, sink, with)).
@@ -430,6 +470,11 @@ func runCDCBenchWorkload(
 	var done atomic.Value // time.Time
 	if cdcEnabled {
 		t.L().Printf("starting changefeed")
+
+		// Lock schema so that changefeed schema feed runs under fast path.
+		_, err := conn.ExecContext(ctx, "ALTER TABLE kv.kv  SET (schema_locked = true);")
+		require.NoError(t, err)
+
 		require.NoError(t, conn.QueryRowContext(ctx, fmt.Sprintf(
 			`CREATE CHANGEFEED FOR kv.kv INTO '%s' WITH format = '%s', initial_scan = 'no'`,
 			sink, format)).

--- a/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed.go
@@ -375,9 +375,7 @@ func (r *rangeFeedRegistry) ForEachPartialRangefeed(fn ActiveRangeFeedIterFn) (i
 	partialRangeFeed := func(active *activeRangeFeed) PartialRangeFeed {
 		active.Lock()
 		defer active.Unlock()
-		p := active.PartialRangeFeed
-		p.InCatchup = active.catchupRes != nil
-		return p
+		return active.PartialRangeFeed
 	}
 	r.ranges.Range(func(k, v interface{}) bool {
 		active := k.(*activeRangeFeed)
@@ -520,6 +518,7 @@ func newActiveRangeFeed(
 			Span:        span,
 			StartAfter:  startAfter,
 			CreatedTime: timeutil.Now(),
+			InCatchup:   true,
 		},
 	}
 
@@ -541,6 +540,9 @@ func (a *activeRangeFeed) releaseCatchupScan() {
 	if a.catchupRes != nil {
 		a.catchupRes.Release()
 		a.catchupRes = nil
+		a.Lock()
+		a.InCatchup = false
+		a.Unlock()
 	}
 }
 


### PR DESCRIPTION
Changefeed supports a mode where the user wants to emit
all events that occurred since some time in the past (`cursor`),
and end the changefeed (`end_time) at the time in the near future.

In this mode, the rangefeed catchup scan starting from `cursor`
position could take some time -- maybe even a lot of time --
and in this case, the very first checkpoint kvfeed will observe
will be after `end_time`.  All of the events, including
checkpoints after `end_time` are skipped, as they should.

However, this meant that no changefeed checkpoint
records could be produced until entire changefeed completes.
This PR ensures that once the `end_time` is reached, we will
emit 1 "resolved event" for that span, so that changefeed
can produce span based checkpoint if needed.

Fixes https://github.com/cockroachdb/cockroach/issues/108464

Release note: None