### PR TITLE
build: fix PR coverage when a package is added/removed

### DIFF
--- a/build/ghactions/pr-codecov-run-tests.sh
+++ b/build/ghactions/pr-codecov-run-tests.sh
@@ -20,11 +20,18 @@ fi
 paths=""
 sep=""
 for p in ${packages}; do
-  paths="${paths}${sep}//$p:*"
-  sep=" + "
+  # Check if the path is really a package in this tree. We do this by checking
+  # for a BUILD.bazel file.
+  if [ -f "${p}/BUILD.bazel" ]; then
+    paths="${paths}${sep}//${p}:*"
+    sep=" + "
+  fi
 done
 
-targets=$(bazel query "kind(\".*_test\", ${paths})")
+targets=""
+if [ -n "${paths}" ]; then
+  targets=$(bazel query "kind(\".*_test\", ${paths})")
+fi
 
 if [[ -z "${targets}" ]]; then
   echo "No test targets found"


### PR DESCRIPTION
The PR coverage script for running tests fails if a package does not exist (because it was added or removed in the PR). This change improves the script to ignore package paths for which a `BUILD.bazel` does not exist.

Epic: none
Release note: None