### PR TITLE
kvadmission: fix handling of non-elastic work with flow control

### DIFF
--- a/pkg/kv/kvserver/flow_control_replica_integration_test.go
+++ b/pkg/kv/kvserver/flow_control_replica_integration_test.go
@@ -413,9 +413,9 @@ func newMockFlowHandle(
 
 func (m *mockFlowHandle) Admit(
 	ctx context.Context, pri admissionpb.WorkPriority, ct time.Time,
-) error {
+) (bool, error) {
 	m.t.Fatal("unimplemented")
-	return nil
+	return false, nil
 }
 
 func (m *mockFlowHandle) DeductTokensFor(

--- a/pkg/kv/kvserver/kvflowcontrol/kvflowcontroller/kvflowcontroller_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/kvflowcontroller/kvflowcontroller_test.go
@@ -196,7 +196,9 @@ func TestInspectController(t *testing.T) {
 
 	// Set up a single connected stream, s1/t1, and ensure it shows up in the
 	// Inspect() state.
-	require.NoError(t, controller.Admit(ctx, admissionpb.NormalPri, time.Time{}, makeConnectedStream(1)))
+	admitted, err := controller.Admit(ctx, admissionpb.NormalPri, time.Time{}, makeConnectedStream(1))
+	require.NoError(t, err)
+	require.True(t, admitted)
 	require.Len(t, controller.Inspect(ctx), 1)
 	require.Equal(t, controller.Inspect(ctx)[0],
 		makeInspectStream(1, 8<<20 /* 8MiB */, 16<<20 /* 16 MiB */))
@@ -211,7 +213,9 @@ func TestInspectController(t *testing.T) {
 
 	// Connect another stream, s1/s2, and ensure it shows up in the Inspect()
 	// state.
-	require.NoError(t, controller.Admit(ctx, admissionpb.BulkNormalPri, time.Time{}, makeConnectedStream(2)))
+	admitted, err = controller.Admit(ctx, admissionpb.BulkNormalPri, time.Time{}, makeConnectedStream(2))
+	require.NoError(t, err)
+	require.True(t, admitted)
 	require.Len(t, controller.Inspect(ctx), 2)
 	require.Equal(t, controller.Inspect(ctx)[1],
 		makeInspectStream(2, 8<<20 /* 8MiB */, 16<<20 /* 16 MiB */))

--- a/pkg/kv/kvserver/kvflowcontrol/kvflowhandle/kvflowhandle.go
+++ b/pkg/kv/kvserver/kvflowcontrol/kvflowhandle/kvflowhandle.go
@@ -79,7 +79,9 @@ func New(
 var _ kvflowcontrol.Handle = &Handle{}
 
 // Admit is part of the kvflowcontrol.Handle interface.
-func (h *Handle) Admit(ctx context.Context, pri admissionpb.WorkPriority, ct time.Time) error {
+func (h *Handle) Admit(
+	ctx context.Context, pri admissionpb.WorkPriority, ct time.Time,
+) (bool, error) {
 	if h == nil {
 		// TODO(irfansharif): This can happen if we're proposing immediately on
 		// a newly split off RHS that doesn't know it's a leader yet (so we
@@ -92,14 +94,14 @@ func (h *Handle) Admit(ctx context.Context, pri admissionpb.WorkPriority, ct tim
 		// As for cluster settings that disable flow control entirely or only
 		// for regular traffic, that can be dealt with at the caller by not
 		// calling .Admit() and ensuring we use the right raft entry encodings.
-		return nil
+		return false, nil
 	}
 
 	h.mu.Lock()
 	if h.mu.closed {
 		h.mu.Unlock()
 		log.Errorf(ctx, "operating on a closed handle")
-		return nil
+		return false, nil
 	}
 
 	// NB: We're using a copy-on-write scheme elsewhere to maintain this slice
@@ -115,15 +117,20 @@ func (h *Handle) Admit(ctx context.Context, pri admissionpb.WorkPriority, ct tim
 	h.metrics.onWaiting(class)
 	tstart := h.clock.PhysicalTime()
 
+	// NB: We track whether the last stream was subject to flow control, this
+	// helps us decide later if we should be deducting tokens for this work.
+	var admitted bool
 	for _, c := range connections {
-		if err := h.controller.Admit(ctx, pri, ct, c); err != nil {
+		var err error
+		admitted, err = h.controller.Admit(ctx, pri, ct, c)
+		if err != nil {
 			h.metrics.onErrored(class, h.clock.PhysicalTime().Sub(tstart))
-			return err
+			return false, err
 		}
 	}
 
 	h.metrics.onAdmitted(class, h.clock.PhysicalTime().Sub(tstart))
-	return nil
+	return admitted, nil
 }
 
 // DeductTokensFor is part of the kvflowcontrol.Handle interface.

--- a/pkg/kv/kvserver/kvflowcontrol/kvflowhandle/noop.go
+++ b/pkg/kv/kvserver/kvflowcontrol/kvflowhandle/noop.go
@@ -26,8 +26,10 @@ type Noop struct{}
 var _ kvflowcontrol.Handle = Noop{}
 
 // Admit is part of the kvflowcontrol.Handle interface.
-func (n Noop) Admit(ctx context.Context, priority admissionpb.WorkPriority, time time.Time) error {
-	return nil
+func (n Noop) Admit(
+	ctx context.Context, priority admissionpb.WorkPriority, time time.Time,
+) (bool, error) {
+	return false, nil
 }
 
 // DeductTokensFor is part of the kvflowcontrol.Handle interface.

--- a/pkg/kv/kvserver/replica_proposal_buf_test.go
+++ b/pkg/kv/kvserver/replica_proposal_buf_test.go
@@ -1166,8 +1166,8 @@ var _ kvflowcontrol.Handle = &testFlowTokenHandle{}
 
 func (t *testFlowTokenHandle) Admit(
 	ctx context.Context, priority admissionpb.WorkPriority, t2 time.Time,
-) error {
-	return nil
+) (bool, error) {
+	return false, nil
 }
 
 func (t *testFlowTokenHandle) DeductTokensFor(


### PR DESCRIPTION
Previously, when we were skipping flow control for regular work, we were
still encoding raft messages with AC encoding. This would enqueue
essentially no-op AC work items below raft, increasing the possibility
of OOM. This is because we would not be pacing the rate of regular work
by below-raft admission rates but it would be consuming memory in
below-raft work queues.

This change skips encoding raft messages with AC encoding for cases
where we bypass flow control. Additionally, we still subject such work
to above-raft IO admission control, if enabled.

Informs https://github.com/cockroachdb/cockroach/issues/104154.

Release note: None