### PR TITLE
server: enable a few cluster settings by default in test tenants

### DIFF
--- a/pkg/ccl/backupccl/backup_tenant_test.go
+++ b/pkg/ccl/backupccl/backup_tenant_test.go
@@ -148,15 +148,6 @@ func TestTenantBackupMultiRegionDatabases(t *testing.T) {
 	defer tSQL.Close()
 	tenSQLDB := sqlutils.MakeSQLRunner(tSQL)
 
-	setAndWaitForTenantReadOnlyClusterSetting(
-		t,
-		sql.SecondaryTenantsMultiRegionAbstractionsEnabledSettingName,
-		sqlDB,
-		tenSQLDB,
-		tenID,
-		"true",
-	)
-
 	// Setup.
 	const tenDst = "userfile:///ten_backup"
 	const hostDst = "userfile:///host_backup"

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -5869,8 +5869,6 @@ func TestProtectedTimestampsDuringBackup(t *testing.T) {
 
 	conn := tc.ServerConn(0)
 	systemTenantRunner := sqlutils.MakeSQLRunner(conn)
-	setAndWaitForTenantReadOnlyClusterSetting(t, sql.SecondaryTenantZoneConfigsEnabled.Name(),
-		systemTenantRunner, ttSQLDB, tenantID, "true")
 
 	// Run the test as the system tenant, and as the secondary tenant.
 	testutils.RunTrueAndFalse(t, "secondary-tenant", func(t *testing.T,
@@ -8705,8 +8703,10 @@ func TestBackupOnlyPublicIndexes(t *testing.T) {
 	// export request for /Table/*/1-3 and while /Table/*/1-2 has
 	// no data in it, the start key is based on the start key of
 	// our request.
+	// TODO(ssd): figure out why enabling SCATTER setting in #109449 changed the
+	// span in the default test tenant case.
 	if tc.StartedDefaultTestTenant() {
-		require.Regexp(t, fmt.Sprintf(".*/Table/%d/{1-3}", dataBankTableID), inc3Spans[0].String())
+		require.Regexp(t, fmt.Sprintf(".*/Table/%d/{1/900-3}", dataBankTableID), inc3Spans[0].String())
 	} else {
 		require.Regexp(t, fmt.Sprintf(".*/Table/%d/{2-3}", dataBankTableID), inc3Spans[0].String())
 	}

--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -40,7 +40,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
-	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -529,13 +528,10 @@ func startTestTenant(
 	tenantRunner := sqlutils.MakeSQLRunner(tenantDB)
 	tenantRunner.ExecMultiple(t, strings.Split(tenantSetupStatements, ";")...)
 
-	ctx := context.Background()
-	sql.SecondaryTenantSplitAtEnabled.Override(ctx, &tenantServer.ClusterSettings().SV, true)
-	sql.SecondaryTenantScatterEnabled.Override(ctx, &tenantServer.ClusterSettings().SV, true)
 	waitForTenantPodsActive(t, tenantServer, 1)
 	resetRetry := testingUseFastRetry()
 	return tenantID, tenantServer, tenantDB, func() {
-		tenantServer.AppStopper().Stop(ctx)
+		tenantServer.AppStopper().Stop(context.Background())
 		resetRetry()
 	}
 }

--- a/pkg/ccl/logictestccl/testdata/logic_test/alter_table_locality
+++ b/pkg/ccl/logictestccl/testdata/logic_test/alter_table_locality
@@ -1,4 +1,3 @@
-# tenant-cluster-setting-override-opt: sql.virtual_cluster.feature_access.zone_configs.enabled=true sql.virtual_cluster.feature_access.multiregion.enabled=true
 # LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-no-los
 
 statement ok

--- a/pkg/ccl/logictestccl/testdata/logic_test/auto_rehoming
+++ b/pkg/ccl/logictestccl/testdata/logic_test/auto_rehoming
@@ -1,4 +1,3 @@
-# tenant-cluster-setting-override-opt: sql.virtual_cluster.feature_access.multiregion.enabled=true
 # LogicTest: local
 
 statement ok

--- a/pkg/ccl/logictestccl/testdata/logic_test/crdb_internal_tenant
+++ b/pkg/ccl/logictestccl/testdata/logic_test/crdb_internal_tenant
@@ -440,9 +440,6 @@ test  {}
 statement ok
 CREATE TABLE foo (a INT PRIMARY KEY, INDEX idx(a)); INSERT INTO foo VALUES(1)
 
-statement error tenant cluster setting sql.virtual_cluster.feature_access.manual_range_split.enabled disabled
-ALTER TABLE foo SPLIT AT VALUES(2)
-
 # Make sure that the cluster id isn't unset.
 query B
 select crdb_internal.cluster_id() != '00000000-0000-0000-0000-000000000000' FROM foo

--- a/pkg/ccl/logictestccl/testdata/logic_test/global_placement_restricted
+++ b/pkg/ccl/logictestccl/testdata/logic_test/global_placement_restricted
@@ -1,4 +1,3 @@
-# tenant-cluster-setting-override-opt: sql.virtual_cluster.feature_access.multiregion.enabled=true
 # LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-vec-off multiregion-9node-3region-3azs-no-los
 
 statement ok

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region
@@ -1,4 +1,3 @@
-# tenant-cluster-setting-override-opt: sql.virtual_cluster.feature_access.multiregion.enabled=true
 # knob-opt: sync-event-log
 # LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-tenant multiregion-9node-3region-3azs-no-los
 

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_alter_table_regional_by_row
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_alter_table_regional_by_row
@@ -1,4 +1,3 @@
-# tenant-cluster-setting-override-opt: sql.virtual_cluster.feature_access.multiregion.enabled=true
 # LogicTest: multiregion-9node-3region-3azs
 
 # This file contains a regression test for ALTER TABLE ... REGIONAL BY ROW

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_backup
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_backup
@@ -1,4 +1,3 @@
-# tenant-cluster-setting-override-opt: sql.virtual_cluster.feature_access.zone_configs.enabled=true sql.virtual_cluster.feature_access.multiregion.enabled=true
 # LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-no-los
 
 # Tests in this file assume no multi-region tenant setup as tenants have no

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_default_primary_region
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_default_primary_region
@@ -1,4 +1,3 @@
-# tenant-cluster-setting-override-opt: sql.virtual_cluster.feature_access.multiregion.enabled=true
 # LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-tenant multiregion-9node-3region-3azs-no-los
 
 statement ok

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_drop_region
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_drop_region
@@ -1,4 +1,3 @@
-# tenant-cluster-setting-override-opt: sql.virtual_cluster.feature_access.multiregion.enabled=true
 # LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-tenant multiregion-9node-3region-3azs-no-los
 
 query TTTTT rowsort

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_foreign_key_lookup_join
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_foreign_key_lookup_join
@@ -1,4 +1,3 @@
-# tenant-cluster-setting-override-opt: sql.virtual_cluster.feature_access.multiregion.enabled=true
 # LogicTest: multiregion-9node-3region-3azs !metamorphic-batch-sizes
 
 # Set the closed timestamp interval to be short to shorten the amount of time

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_import_export
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_import_export
@@ -1,4 +1,3 @@
-# tenant-cluster-setting-override-opt: sql.virtual_cluster.feature_access.multiregion.enabled=true
 # LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-vec-off multiregion-9node-3region-3azs-no-los
 
 # Tests in this file assume no multi-region tenant setup as tenants have no

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_locality_optimized_search_query_behavior
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_locality_optimized_search_query_behavior
@@ -1,4 +1,3 @@
-# tenant-cluster-setting-override-opt: sql.virtual_cluster.feature_access.multiregion.enabled=true
 # LogicTest: multiregion-9node-3region-3azs
 # TODO(#75864): enable multiregion-9node-3region-3azs-tenant.
 

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_privileges
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_privileges
@@ -1,4 +1,3 @@
-# tenant-cluster-setting-override-opt: sql.virtual_cluster.feature_access.multiregion.enabled=true
 # LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-tenant multiregion-9node-3region-3azs-no-los
 
 user root

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_query_behavior
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_query_behavior
@@ -1,4 +1,3 @@
-# tenant-cluster-setting-override-opt: sql.virtual_cluster.feature_access.multiregion.enabled=true
 # LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-no-los
 # TODO(#75864): enable multiregion-9node-3region-3azs-tenant.
 

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_remote_access_error
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_remote_access_error
@@ -1,4 +1,3 @@
-# tenant-cluster-setting-override-opt: sql.virtual_cluster.feature_access.multiregion.enabled=true
 # LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-vec-off !metamorphic-batch-sizes
 # Currently this test and other multiregion tests may flake often when run
 # under the multiregion-9node-3region-3azs-vec-off config, and less often

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_secondary_tenants_abstractions_disallowed
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_secondary_tenants_abstractions_disallowed
@@ -1,4 +1,5 @@
 # LogicTest: multiregion-9node-3region-3azs-tenant
+# tenant-cluster-setting-override-opt: sql.virtual_cluster.feature_access.multiregion.enabled=false
 
 statement error pq: setting sql.virtual_cluster.feature_access.multiregion.enabled disallows use of multi-region abstractions
 CREATE DATABASE db PRIMARY REGION "us-east1"

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_show
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_show
@@ -1,4 +1,3 @@
-# tenant-cluster-setting-override-opt: sql.virtual_cluster.feature_access.multiregion.enabled=true
 # LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-tenant multiregion-9node-3region-3azs-no-los
 
 statement ok

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_survival_goal
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_survival_goal
@@ -1,4 +1,3 @@
-# tenant-cluster-setting-override-opt: sql.virtual_cluster.feature_access.multiregion.enabled=true
 # knob-opt: sync-event-log
 # LogicTest: multiregion-9node-3region-3azs-tenant
 

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_system_database
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_system_database
@@ -1,5 +1,4 @@
 # LogicTest: 3node-tenant-multiregion
-# tenant-cluster-setting-override-opt: sql.virtual_cluster.feature_access.multiregion.enabled=true
 
 # Only the root user can modify the system database's regions.
 user root

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_zone_config_extensions
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_zone_config_extensions
@@ -1,4 +1,3 @@
-# tenant-cluster-setting-override-opt: sql.virtual_cluster.feature_access.multiregion.enabled=true
 # LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-tenant
 
 query TTTTT rowsort

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_zone_configs
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_zone_configs
@@ -1,4 +1,3 @@
-# tenant-cluster-setting-override-opt: sql.virtual_cluster.feature_access.zone_configs.enabled=true sql.virtual_cluster.feature_access.multiregion.enabled=true
 # LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-tenant multiregion-9node-3region-3azs-no-los
 
 query TTTTT rowsort

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_zone_configs_long_regions
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_zone_configs_long_regions
@@ -1,4 +1,3 @@
-# tenant-cluster-setting-override-opt: sql.virtual_cluster.feature_access.multiregion.enabled=true
 # LogicTest: multiregion-3node-3superlongregions
 
 query TTTTT rowsort

--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning
@@ -1,4 +1,3 @@
-# tenant-cluster-setting-override-opt: sql.virtual_cluster.feature_access.zone_configs.enabled=true
 # LogicTest: local
 
 statement error syntax

--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning_hash_sharded_index_mr
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning_hash_sharded_index_mr
@@ -1,4 +1,3 @@
-# tenant-cluster-setting-override-opt: sql.virtual_cluster.feature_access.multiregion.enabled=true
 # LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-tenant multiregion-9node-3region-3azs-no-los
 
 statement ok

--- a/pkg/ccl/logictestccl/testdata/logic_test/placement
+++ b/pkg/ccl/logictestccl/testdata/logic_test/placement
@@ -1,4 +1,3 @@
-# tenant-cluster-setting-override-opt: sql.virtual_cluster.feature_access.multiregion.enabled=true
 # LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-vec-off multiregion-9node-3region-3azs-no-los
 
 statement error PLACEMENT requires that the session setting enable_multiregion_placement_policy is enabled

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
@@ -1,4 +1,3 @@
-# tenant-cluster-setting-override-opt: sql.virtual_cluster.feature_access.zone_configs.enabled=true sql.virtual_cluster.feature_access.multiregion.enabled=true
 # LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-vec-off multiregion-9node-3region-3azs-tenant multiregion-9node-3region-3azs-no-los
 
 statement ok

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_auto_rehoming
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_auto_rehoming
@@ -1,4 +1,3 @@
-# tenant-cluster-setting-override-opt: sql.virtual_cluster.feature_access.multiregion.enabled=true
 # LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-tenant multiregion-9node-3region-3azs-no-los
 
 statement ok

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_hash_sharded_index
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_hash_sharded_index
@@ -1,4 +1,3 @@
-# tenant-cluster-setting-override-opt: sql.virtual_cluster.feature_access.multiregion.enabled=true
 # LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-no-los
 
 statement ok

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_hash_sharded_index_query_plan
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_hash_sharded_index_query_plan
@@ -1,4 +1,3 @@
-# tenant-cluster-setting-override-opt: sql.virtual_cluster.feature_access.multiregion.enabled=true
 # LogicTest: multiregion-9node-3region-3azs !metamorphic-batch-sizes
 # TODO(#75864): enable multiregion-9node-3region-3azs-tenant
 

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_placement_restricted
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_placement_restricted
@@ -1,4 +1,3 @@
-# tenant-cluster-setting-override-opt: sql.virtual_cluster.feature_access.multiregion.enabled=true
 # LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-vec-off multiregion-9node-3region-3azs-tenant multiregion-9node-3region-3azs-no-los
 
 statement ok

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_query_behavior
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_query_behavior
@@ -1,4 +1,3 @@
-# tenant-cluster-setting-override-opt: sql.virtual_cluster.feature_access.multiregion.enabled=true
 # LogicTest: multiregion-9node-3region-3azs !metamorphic-batch-sizes
 # TODO(#75864): enable multiregion-9node-3region-3azs-tenant and/or revert
 # the commit that split these changes out.

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_rename_column
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_rename_column
@@ -1,4 +1,3 @@
-# tenant-cluster-setting-override-opt: sql.virtual_cluster.feature_access.multiregion.enabled=true
 # LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-vec-off multiregion-9node-3region-3azs-tenant multiregion-9node-3region-3azs-no-los
 
 # This test seems to flake (#60717).

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_table_placement_restricted
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_table_placement_restricted
@@ -1,4 +1,3 @@
-# tenant-cluster-setting-override-opt: sql.virtual_cluster.feature_access.multiregion.enabled=true
 # LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-vec-off multiregion-9node-3region-3azs-tenant multiregion-9node-3region-3azs-no-los
 
 statement ok

--- a/pkg/ccl/logictestccl/testdata/logic_test/secondary_region
+++ b/pkg/ccl/logictestccl/testdata/logic_test/secondary_region
@@ -1,4 +1,3 @@
-# tenant-cluster-setting-override-opt: sql.virtual_cluster.feature_access.multiregion.enabled=true
 # LogicTest: multiregion-15node-5region-3azs
 
 query TTTTT colnames,rowsort

--- a/pkg/ccl/logictestccl/testdata/logic_test/super_regions
+++ b/pkg/ccl/logictestccl/testdata/logic_test/super_regions
@@ -1,4 +1,3 @@
-# tenant-cluster-setting-override-opt: sql.virtual_cluster.feature_access.multiregion.enabled=true
 # LogicTest: multiregion-15node-5region-3azs
 
 statement ok

--- a/pkg/ccl/logictestccl/testdata/logic_test/super_regions_backup
+++ b/pkg/ccl/logictestccl/testdata/logic_test/super_regions_backup
@@ -1,4 +1,3 @@
-# tenant-cluster-setting-override-opt: sql.virtual_cluster.feature_access.multiregion.enabled=true
 # LogicTest: multiregion-15node-5region-3azs
 
 statement ok

--- a/pkg/ccl/logictestccl/testdata/logic_test/super_regions_cluster_settings
+++ b/pkg/ccl/logictestccl/testdata/logic_test/super_regions_cluster_settings
@@ -1,4 +1,3 @@
-# tenant-cluster-setting-override-opt: sql.virtual_cluster.feature_access.multiregion.enabled=true
 # LogicTest: multiregion-15node-5region-3azs
 
 statement ok

--- a/pkg/ccl/logictestccl/testdata/logic_test/zone_config_secondary_tenants
+++ b/pkg/ccl/logictestccl/testdata/logic_test/zone_config_secondary_tenants
@@ -1,5 +1,4 @@
 # LogicTest: 3node-tenant
-# tenant-cluster-setting-override-opt: sql.virtual_cluster.feature_access.zone_configs.enabled=true
 # Zone config logic tests that are only meant to work for secondary tenants.
 
 statement ok

--- a/pkg/ccl/logictestccl/testdata/logic_test/zone_config_secondary_tenants_disallowed
+++ b/pkg/ccl/logictestccl/testdata/logic_test/zone_config_secondary_tenants_disallowed
@@ -1,7 +1,5 @@
 # LogicTest: 3node-tenant
-
-# Note that we haven't used the setting override directive in this file to
-# override the default.
+# tenant-cluster-setting-override-opt: sql.virtual_cluster.feature_access.zone_configs.enabled=false
 
 statement error pq: unimplemented: operation is unsupported within a virtual cluster
 ALTER TABLE t CONFIGURE ZONE USING num_replicas = 5;

--- a/pkg/ccl/multiregionccl/cold_start_latency_test.go
+++ b/pkg/ccl/multiregionccl/cold_start_latency_test.go
@@ -165,8 +165,6 @@ func TestColdStartLatency(t *testing.T) {
 		var stmts []string
 		if !isTenant {
 			stmts = []string{
-				"ALTER TENANT ALL SET CLUSTER SETTING sql.virtual_cluster.feature_access.zone_configs.enabled = true",
-				"ALTER TENANT ALL SET CLUSTER SETTING sql.virtual_cluster.feature_access.multiregion.enabled = true",
 				`alter range meta configure zone using constraints = '{"+region=us-east1": 1, "+region=us-west1": 1, "+region=europe-west1": 1}';`,
 			}
 		} else {

--- a/pkg/ccl/multiregionccl/regional_by_row_system_database_test.go
+++ b/pkg/ccl/multiregionccl/regional_by_row_system_database_test.go
@@ -28,15 +28,10 @@ func TestRegionalByRowTablesInTheSystemDatabase(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	tc, sqlDB, cleanup := multiregionccltestutils.TestingCreateMultiRegionCluster(t, 3, base.TestingKnobs{})
+	tc, _, cleanup := multiregionccltestutils.TestingCreateMultiRegionCluster(t, 3, base.TestingKnobs{})
 	defer cleanup()
 	defer tc.Stopper().Stop(ctx)
 
-	// Allow the tenant to make itself multi-region.
-	sqlutils.MakeSQLRunner(sqlDB).Exec(t, `
-ALTER TENANT ALL
-SET CLUSTER SETTING
-sql.virtual_cluster.feature_access.multiregion.enabled = true;`)
 	tenant, tenantDB := serverutils.StartTenant(t, tc.Server(0), base.TestTenantArgs{
 		TenantName:  "test",
 		TenantID:    serverutils.TestTenantID(),

--- a/pkg/ccl/multitenantccl/tenantcapabilitiesccl/BUILD.bazel
+++ b/pkg/ccl/multitenantccl/tenantcapabilitiesccl/BUILD.bazel
@@ -18,8 +18,6 @@ go_test(
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",
         "//pkg/server",
-        "//pkg/settings/cluster",
-        "//pkg/sql",
         "//pkg/testutils",
         "//pkg/testutils/datapathutils",
         "//pkg/testutils/serverutils",

--- a/pkg/ccl/multitenantccl/tenantcapabilitiesccl/capabilities_test.go
+++ b/pkg/ccl/multitenantccl/tenantcapabilitiesccl/capabilities_test.go
@@ -17,8 +17,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/rangefeed/rangefeedcache"
 	"github.com/cockroachdb/cockroach/pkg/multitenant/tenantcapabilities"
 	"github.com/cockroachdb/cockroach/pkg/multitenant/tenantcapabilities/tenantcapabilitieswatcher"
-	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
-	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/datapathutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -87,20 +85,8 @@ func TestDataDriven(t *testing.T) {
 		defer tc.Stopper().Stop(ctx)
 		systemSQLDB := sqlutils.MakeSQLRunner(tc.ServerConn(0))
 
-		// Create a tenant; we also want to allow test writers to issue
-		// ALTER TABLE ... SPLIT statements, so configure the settings as such.
-		// TODO(knz): Once https://github.com/cockroachdb/cockroach/issues/96512 is
-		// resolved, we could override this cluster setting for the secondary tenant
-		// using SQL instead of reaching in using this testing knob. One way to do
-		// so would be to perform the override for all tenants and only then
-		// initializing our test tenant; However, the linked issue above prevents
-		// us from being able to do so.
-		settings := cluster.MakeTestingClusterSettings()
-		sql.SecondaryTenantSplitAtEnabled.Override(ctx, &settings.SV, true)
-		sql.SecondaryTenantScatterEnabled.Override(ctx, &settings.SV, true)
 		tenantArgs := base.TestTenantArgs{
 			TenantID: serverutils.TestTenantID(),
-			Settings: settings,
 		}
 		testTenantInterface, err := tc.Server(0).StartTenant(ctx, tenantArgs)
 		require.NoError(t, err)

--- a/pkg/ccl/partitionccl/zone_test.go
+++ b/pkg/ccl/partitionccl/zone_test.go
@@ -981,8 +981,7 @@ func TestPrimaryKeyChangeZoneConfigs(t *testing.T) {
 	ctx := context.Background()
 	s, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
-	codec, sv := s.ApplicationLayer().Codec(), &s.ApplicationLayer().ClusterSettings().SV
-	sql.SecondaryTenantZoneConfigsEnabled.Override(ctx, sv, true)
+	codec := s.ApplicationLayer().Codec()
 
 	// Write a table with some partitions into the database,
 	// and change its primary key.
@@ -1163,8 +1162,6 @@ func TestZoneConfigAppliesToTemporaryIndex(t *testing.T) {
 
 	tdb := sqlutils.MakeSQLRunner(sqlDB)
 	codec := s.Codec()
-	sv := &s.ClusterSettings().SV
-	sql.SecondaryTenantZoneConfigsEnabled.Override(context.Background(), sv, true)
 
 	if _, err := sqlDB.Exec(`
 SET use_declarative_schema_changer='off';

--- a/pkg/ccl/serverccl/admin_test.go
+++ b/pkg/ccl/serverccl/admin_test.go
@@ -61,11 +61,6 @@ func TestAdminAPIDataDistributionPartitioning(t *testing.T) {
 
 	firstServer := testCluster.Server(0)
 
-	// Enable zone configs for secondary tenants.
-	systemSqlDb := firstServer.SystemLayer().SQLConn(t, "system")
-	_, err := systemSqlDb.Exec("ALTER TENANT ALL SET CLUSTER SETTING sql.virtual_cluster.feature_access.zone_configs.enabled = true")
-	require.NoError(t, err)
-
 	sqlDB := sqlutils.MakeSQLRunner(testCluster.ServerConn(0))
 
 	sqlDB.Exec(t, `CREATE DATABASE roachblog`)
@@ -95,7 +90,7 @@ func TestAdminAPIDataDistributionPartitioning(t *testing.T) {
 	}
 
 	var resp serverpb.DataDistributionResponse
-	err = serverutils.GetJSONProto(firstServer, adminPrefix+"data_distribution", &resp)
+	err := serverutils.GetJSONProto(firstServer, adminPrefix+"data_distribution", &resp)
 	require.NoError(t, err)
 
 	actualZoneConfigNames := map[string]struct{}{}

--- a/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/datadriven_test.go
+++ b/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/datadriven_test.go
@@ -142,7 +142,6 @@ func TestDataDriven(t *testing.T) {
 			switch d.Cmd {
 			case "initialize":
 				secondaryTenant := spanConfigTestCluster.InitializeTenant(ctx, tenantID)
-				spanConfigTestCluster.AllowSecondaryTenantToSetZoneConfigurations(t, tenantID)
 				spanConfigTestCluster.EnsureTenantCanSetZoneConfigurationsOrFatal(t, secondaryTenant)
 
 			case "exec-sql":

--- a/pkg/ccl/spanconfigccl/spanconfigsplitterccl/datadriven_test.go
+++ b/pkg/ccl/spanconfigccl/spanconfigsplitterccl/datadriven_test.go
@@ -81,7 +81,6 @@ func TestDataDriven(t *testing.T) {
 
 		tenantID := roachpb.MustMakeTenantID(10)
 		tenant := spanConfigTestCluster.InitializeTenant(ctx, tenantID)
-		spanConfigTestCluster.AllowSecondaryTenantToSetZoneConfigurations(t, tenantID)
 		spanConfigTestCluster.EnsureTenantCanSetZoneConfigurationsOrFatal(t, tenant)
 
 		// TODO(irfansharif): Expose this through the test harness once we integrate

--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/datadriven_test.go
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/datadriven_test.go
@@ -151,7 +151,6 @@ func TestDataDriven(t *testing.T) {
 		if strings.Contains(path, "tenant") {
 			tenantID := roachpb.MustMakeTenantID(10)
 			tenant = spanConfigTestCluster.InitializeTenant(ctx, tenantID)
-			spanConfigTestCluster.AllowSecondaryTenantToSetZoneConfigurations(t, tenantID)
 			spanConfigTestCluster.EnsureTenantCanSetZoneConfigurationsOrFatal(t, tenant)
 		} else {
 			tenant = spanConfigTestCluster.InitializeTenant(ctx, roachpb.SystemTenantID)

--- a/pkg/ccl/testccl/sqlstatsccl/BUILD.bazel
+++ b/pkg/ccl/testccl/sqlstatsccl/BUILD.bazel
@@ -17,8 +17,6 @@ go_test(
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",
         "//pkg/server",
-        "//pkg/settings/cluster",
-        "//pkg/sql",
         "//pkg/sql/appstatspb",
         "//pkg/testutils",
         "//pkg/testutils/serverutils",

--- a/pkg/ccl/testutilsccl/alter_primary_key.go
+++ b/pkg/ccl/testutilsccl/alter_primary_key.go
@@ -97,11 +97,6 @@ func AlterPrimaryKeyCorrectZoneConfigTest(
 			db = sqlDB
 			defer s.Stopper().Stop(ctx)
 
-			st := s.ApplicationLayer().ClusterSettings()
-			// Ensure multi-region abstractions and zone configs are enabled in secondary tenants.
-			sql.SecondaryTenantZoneConfigsEnabled.Override(ctx, &st.SV, true)
-			sql.SecondaryTenantsMultiRegionAbstractionsEnabled.Override(ctx, &st.SV, true)
-
 			if _, err := sqlDB.Exec(fmt.Sprintf(`
 %s;
 USE t;

--- a/pkg/internal/sqlsmith/BUILD.bazel
+++ b/pkg/internal/sqlsmith/BUILD.bazel
@@ -60,7 +60,6 @@ go_test(
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",
         "//pkg/server",
-        "//pkg/sql",
         "//pkg/sql/parser",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/sqlutils",

--- a/pkg/internal/sqlsmith/setup_test.go
+++ b/pkg/internal/sqlsmith/setup_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/ccl"
 	"github.com/cockroachdb/cockroach/pkg/internal/sqlsmith"
-	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
@@ -47,8 +46,6 @@ func TestSetups(t *testing.T) {
 			ctx := context.Background()
 			srv, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{})
 			defer srv.Stopper().Stop(ctx)
-			sql.SecondaryTenantSplitAtEnabled.Override(ctx, &srv.ApplicationLayer().ClusterSettings().SV, true)
-			sql.SecondaryTenantScatterEnabled.Override(ctx, &srv.ApplicationLayer().ClusterSettings().SV, true)
 
 			rnd, _ := randutil.NewTestRand()
 
@@ -74,8 +71,6 @@ func TestGenerateParse(t *testing.T) {
 	ctx := context.Background()
 	srv, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{})
 	defer srv.Stopper().Stop(ctx)
-	sql.SecondaryTenantSplitAtEnabled.Override(ctx, &srv.ApplicationLayer().ClusterSettings().SV, true)
-	sql.SecondaryTenantScatterEnabled.Override(ctx, &srv.ApplicationLayer().ClusterSettings().SV, true)
 
 	rnd, seed := randutil.NewTestRand()
 	t.Log("seed:", seed)

--- a/pkg/kv/kvclient/kvstreamer/large_keys_test.go
+++ b/pkg/kv/kvclient/kvstreamer/large_keys_test.go
@@ -78,9 +78,7 @@ func TestLargeKeys(t *testing.T) {
 			},
 		},
 	})
-	ctx := context.Background()
-	defer s.Stopper().Stop(ctx)
-	sql.SecondaryTenantSplitAtEnabled.Override(ctx, &s.ApplicationLayer().ClusterSettings().SV, true)
+	defer s.Stopper().Stop(context.Background())
 
 	// We will lower the distsql_workmem limit so that we can operate with
 	// smaller blobs.

--- a/pkg/kv/kvclient/kvstreamer/streamer_test.go
+++ b/pkg/kv/kvclient/kvstreamer/streamer_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/lock"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
-	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -246,9 +245,7 @@ func TestStreamerCorrectlyDiscardsResponses(t *testing.T) {
 	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{
 		SQLMemoryPoolSize: 1 << 30, /* 1GiB */
 	})
-	ctx := context.Background()
-	defer s.Stopper().Stop(ctx)
-	sql.SecondaryTenantSplitAtEnabled.Override(ctx, &s.ApplicationLayer().ClusterSettings().SV, true)
+	defer s.Stopper().Stop(context.Background())
 
 	// The initial estimate for TargetBytes argument for each asynchronous
 	// request by the Streamer will be numRowsPerRange x InitialAvgResponseSize,
@@ -311,9 +308,7 @@ func TestStreamerWideRows(t *testing.T) {
 	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{
 		SQLMemoryPoolSize: 1 << 30, /* 1GiB */
 	})
-	ctx := context.Background()
-	defer s.Stopper().Stop(ctx)
-	sql.SecondaryTenantSplitAtEnabled.Override(ctx, &s.ApplicationLayer().ClusterSettings().SV, true)
+	defer s.Stopper().Stop(context.Background())
 
 	const blobSize = 10 * kvstreamer.InitialAvgResponseSize
 	const numRows = 2
@@ -417,7 +412,6 @@ func TestStreamerEmptyScans(t *testing.T) {
 
 	ts := srv.ApplicationLayer()
 	codec := ts.Codec()
-	sql.SecondaryTenantSplitAtEnabled.Override(ctx, &ts.ClusterSettings().SV, true)
 
 	// Create a dummy table for which we know the encoding of valid keys.
 	// Although not strictly necessary, we set up two column families since with
@@ -487,9 +481,7 @@ func TestStreamerMultiRangeScan(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
-	ctx := context.Background()
-	defer s.Stopper().Stop(ctx)
-	sql.SecondaryTenantSplitAtEnabled.Override(ctx, &s.ApplicationLayer().ClusterSettings().SV, true)
+	defer s.Stopper().Stop(context.Background())
 
 	rng, _ := randutil.NewTestRand()
 	numRows := rng.Intn(100) + 2

--- a/pkg/kv/kvclient/rangefeed/BUILD.bazel
+++ b/pkg/kv/kvclient/rangefeed/BUILD.bazel
@@ -78,7 +78,6 @@ go_test(
         "//pkg/settings/cluster",
         "//pkg/spanconfig",
         "//pkg/spanconfig/spanconfigptsreader",
-        "//pkg/sql",
         "//pkg/sql/catalog/desctestutils",
         "//pkg/storage",
         "//pkg/testutils",

--- a/pkg/kv/kvclient/rangefeed/db_adapter_external_test.go
+++ b/pkg/kv/kvclient/rangefeed/db_adapter_external_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
-	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/desctestutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -57,8 +56,6 @@ func TestDBClientScan(t *testing.T) {
 	srv, sqlDB, db := serverutils.StartServer(t, base.TestServerArgs{})
 	defer srv.Stopper().Stop(ctx)
 	ts := srv.ApplicationLayer()
-
-	sql.SecondaryTenantSplitAtEnabled.Override(ctx, &ts.ClusterSettings().SV, true)
 
 	beforeAny := db.Clock().Now()
 

--- a/pkg/kv/kvserver/batcheval/cmd_export_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_export_test.go
@@ -61,8 +61,6 @@ func TestExportCmd(t *testing.T) {
 	defer srv.Stopper().Stop(ctx)
 	ts := srv.ApplicationLayer()
 
-	sql.SecondaryTenantSplitAtEnabled.Override(ctx, &ts.ClusterSettings().SV, true)
-
 	export := func(
 		t *testing.T, start hlc.Timestamp, mvccFilter kvpb.MVCCFilter, maxResponseSSTBytes int64,
 	) (kvpb.Response, *kvpb.Error) {
@@ -466,9 +464,6 @@ func TestExportRequestWithCPULimitResumeSpans(t *testing.T) {
 	s := srv.ApplicationLayer()
 	sqlDB := tc.Conns[0]
 	kvDB := s.DB()
-
-	sql.SecondaryTenantSplitAtEnabled.Override(context.Background(), &s.ClusterSettings().SV, true)
-	sql.SecondaryTenantScatterEnabled.Override(context.Background(), &s.ClusterSettings().SV, true)
 
 	db := sqlutils.MakeSQLRunner(sqlDB)
 	execCfg := s.ExecutorConfig().(sql.ExecutorConfig)

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -1528,6 +1528,17 @@ func (ts *testServer) StartTenant(
 	baseCfg.HeapProfileDirName = ts.Cfg.BaseConfig.HeapProfileDirName
 	baseCfg.GoroutineDumpDirName = ts.Cfg.BaseConfig.GoroutineDumpDirName
 
+	// TODO(knz): Once https://github.com/cockroachdb/cockroach/issues/96512 is
+	// resolved, we could override this cluster setting for the secondary tenant
+	// using SQL instead of reaching in using this testing knob. One way to do
+	// so would be to perform the override for all tenants and only then
+	// initializing our test tenant; However, the linked issue above prevents
+	// us from being able to do so.
+	sql.SecondaryTenantScatterEnabled.Override(ctx, &baseCfg.Settings.SV, true)
+	sql.SecondaryTenantSplitAtEnabled.Override(ctx, &baseCfg.Settings.SV, true)
+	sql.SecondaryTenantZoneConfigsEnabled.Override(ctx, &baseCfg.Settings.SV, true)
+	sql.SecondaryTenantsMultiRegionAbstractionsEnabled.Override(ctx, &baseCfg.Settings.SV, true)
+
 	// Waiting for capabilities can time To avoid paying this cost in all
 	// cases, we only set the nodelocal storage capability if the caller has
 	// configured an ExternalIODir since nodelocal storage only works with

--- a/pkg/spanconfig/spanconfigtestutils/spanconfigtestcluster/cluster.go
+++ b/pkg/spanconfig/spanconfigtestutils/spanconfigtestcluster/cluster.go
@@ -113,19 +113,6 @@ func (h *Handle) InitializeTenant(ctx context.Context, tenID roachpb.TenantID) *
 	return tenantState
 }
 
-// AllowSecondaryTenantToSetZoneConfigurations enables zone configuration
-// support for the given tenant. Given the cluster setting involved is tenant
-// read-only, the SQL statement is run as the system tenant.
-func (h *Handle) AllowSecondaryTenantToSetZoneConfigurations(t *testing.T, tenID roachpb.TenantID) {
-	_, found := h.LookupTenant(tenID)
-	require.True(t, found)
-	h.sysDB.Exec(
-		t,
-		"ALTER TENANT [$1] SET CLUSTER SETTING sql.virtual_cluster.feature_access.zone_configs.enabled = true",
-		tenID.ToUint64(),
-	)
-}
-
 // EnsureTenantCanSetZoneConfigurationsOrFatal ensures that the tenant observes
 // a 'true' value for sql.zone_configs.allow_for_secondary_tenants.enabled. It
 // fatals if this condition doesn't evaluate within SucceedsSoonDuration.

--- a/pkg/sql/backfill_protected_timestamp_test.go
+++ b/pkg/sql/backfill_protected_timestamp_test.go
@@ -105,11 +105,6 @@ func TestValidationWithProtectedTS(t *testing.T) {
 		require.NoError(t, ptp.Refresh(ctx, asOf))
 	}
 
-	// By default, secondary tenants aren't allowed to muck with the zone
-	// config, so give them this ability if we happened to start the default
-	// test tenant.
-	sql.SecondaryTenantZoneConfigsEnabled.Override(ctx, &tenantSettings.SV, true)
-
 	for _, sql := range []string{
 		"SET CLUSTER SETTING kv.closed_timestamp.target_duration = '10ms'",
 		"ALTER TENANT ALL SET CLUSTER SETTING kv.closed_timestamp.target_duration = '10ms'",

--- a/pkg/sql/catalog/internal/catkv/catalog_reader_test.go
+++ b/pkg/sql/catalog/internal/catkv/catalog_reader_test.go
@@ -71,8 +71,6 @@ func TestDataDriven(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			s := tc.layer
 
-			sql.SecondaryTenantZoneConfigsEnabled.Override(ctx, &s.ClusterSettings().SV, true)
-
 			sqlDB := s.SQLConn(t, "")
 			tdb := sqlutils.MakeSQLRunner(sqlDB)
 			execCfg := s.ExecutorConfig().(sql.ExecutorConfig)

--- a/pkg/sql/catalog/lease/lease_test.go
+++ b/pkg/sql/catalog/lease/lease_test.go
@@ -3189,7 +3189,6 @@ func TestLeaseBulkInsertWithImplicitTxn(t *testing.T) {
 	defer srv.Stopper().Stop(ctx)
 	s := srv.Server(0).ApplicationLayer()
 	conn := srv.ServerConn(0)
-	sql.SecondaryTenantSplitAtEnabled.Override(ctx, &s.ClusterSettings().SV, true)
 	// Setup tables for the test.
 	_, err := conn.Exec(`
 CREATE TABLE t1(val int);

--- a/pkg/sql/distsql_running_test.go
+++ b/pkg/sql/distsql_running_test.go
@@ -625,7 +625,6 @@ func TestDistSQLReceiverDrainsMeta(t *testing.T) {
 			Insecure: true,
 		}})
 	defer tc.Stopper().Stop(ctx)
-	SecondaryTenantSplitAtEnabled.Override(ctx, &tc.Server(0).ApplicationLayer().ClusterSettings().SV, true)
 
 	// Create a table with 30 rows, split them into 3 ranges with each node
 	// having one.

--- a/pkg/sql/execstats/traceanalyzer_test.go
+++ b/pkg/sql/execstats/traceanalyzer_test.go
@@ -82,7 +82,6 @@ func TestTraceAnalyzer(t *testing.T) {
 	const gatewayNode = 0
 	srv, s := tc.Server(gatewayNode), tc.ApplicationLayer(gatewayNode)
 	if srv.StartedDefaultTestTenant() {
-		sql.SecondaryTenantSplitAtEnabled.Override(ctx, &s.ClusterSettings().SV, true)
 		systemSqlDB := srv.SystemLayer().SQLConn(t, "system")
 		_, err := systemSqlDB.Exec(`ALTER TENANT [$1] GRANT CAPABILITY can_admin_relocate_range=true`, serverutils.TestTenantID().ToUint64())
 		require.NoError(t, err)

--- a/pkg/sql/explain_test.go
+++ b/pkg/sql/explain_test.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/internal/sqlsmith"
-	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/tests"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -44,10 +43,6 @@ func TestStatementReuses(t *testing.T) {
 	ctx := context.Background()
 	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
-	tenantSettings := s.ApplicationLayer().ClusterSettings()
-	sql.SecondaryTenantScatterEnabled.Override(ctx, &tenantSettings.SV, true)
-	sql.SecondaryTenantSplitAtEnabled.Override(ctx, &tenantSettings.SV, true)
-	sql.SecondaryTenantZoneConfigsEnabled.Override(ctx, &tenantSettings.SV, true)
 
 	initStmts := []string{
 		`CREATE DATABASE d`,
@@ -523,8 +518,6 @@ func TestExplainRedact(t *testing.T) {
 	params, _ := createTestServerParams()
 	srv, sqlDB, _ := serverutils.StartServer(t, params)
 	defer srv.Stopper().Stop(ctx)
-	sql.SecondaryTenantSplitAtEnabled.Override(ctx, &srv.ApplicationLayer().ClusterSettings().SV, true)
-	sql.SecondaryTenantScatterEnabled.Override(ctx, &srv.ApplicationLayer().ClusterSettings().SV, true)
 
 	query := func(sql string) (*gosql.Rows, error) {
 		return sqlDB.QueryContext(ctx, sql)

--- a/pkg/sql/importer/exportcsv_test.go
+++ b/pkg/sql/importer/exportcsv_test.go
@@ -70,8 +70,6 @@ func setupExportableBank(t *testing.T, nodes, rows int) (*sqlutils.SQLRunner, st
 	)
 	s := tc.ApplicationLayer(0)
 	tenantSettings := s.ClusterSettings()
-	sql.SecondaryTenantSplitAtEnabled.Override(ctx, &tenantSettings.SV, true)
-	sql.SecondaryTenantScatterEnabled.Override(ctx, &tenantSettings.SV, true)
 	conn := s.SQLConn(t, "defaultdb")
 	db := sqlutils.MakeSQLRunner(conn)
 
@@ -665,7 +663,6 @@ func TestProcessorEncountersUncertaintyError(t *testing.T) {
 	defer tc.Stopper().Stop(ctx)
 
 	if tc.StartedDefaultTestTenant() {
-		sql.SecondaryTenantSplitAtEnabled.Override(ctx, &tc.Server(0).ApplicationLayer().ClusterSettings().SV, true)
 		systemSqlDB := tc.Server(0).SystemLayer().SQLConn(t, "system")
 		_, err := systemSqlDB.Exec(`ALTER TENANT [$1] GRANT CAPABILITY can_admin_relocate_range=true`, serverutils.TestTenantID().ToUint64())
 		require.NoError(t, err)

--- a/pkg/sql/importer/import_into_test.go
+++ b/pkg/sql/importer/import_into_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/protectedts"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
@@ -69,7 +68,6 @@ func TestProtectedTimestampsDuringImportInto(t *testing.T) {
 	s := tc.Server(0).ApplicationLayer()
 	tenantSettings := s.ClusterSettings()
 	protectedts.PollInterval.Override(ctx, &tenantSettings.SV, 100*time.Millisecond)
-	sql.SecondaryTenantZoneConfigsEnabled.Override(ctx, &tenantSettings.SV, true)
 
 	tc.WaitForNodeLiveness(t)
 	require.NoError(t, tc.WaitForFullReplication())

--- a/pkg/sql/logictest/testdata/logic_test/distsql_tenant_locality
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_tenant_locality
@@ -1,5 +1,4 @@
 # LogicTest: 3node-tenant-multiregion
-# tenant-cluster-setting-override-opt: sql.virtual_cluster.feature_access.manual_range_split.enabled=true sql.virtual_cluster.feature_access.zone_configs.enabled=true sql.virtual_cluster.feature_access.multiregion.enabled=true
 
 # Create a table on the secondary tenant.
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/sql_keys
+++ b/pkg/sql/logictest/testdata/logic_test/sql_keys
@@ -1,5 +1,4 @@
 # LogicTest: local 3node-tenant
-# tenant-cluster-setting-override-opt: sql.virtual_cluster.feature_access.manual_range_split.enabled=true
 
 # This test depends on table ID's being stable, so add new tests at the bottom
 # of the file.

--- a/pkg/sql/logictest/testdata/logic_test/zone_config
+++ b/pkg/sql/logictest/testdata/logic_test/zone_config
@@ -1,7 +1,3 @@
-# As these tests are run for both the system tenant and secondary tenants, we
-# turn on the setting that gates setting zone configs for system tenants.
-# tenant-cluster-setting-override-opt: sql.virtual_cluster.feature_access.zone_configs.enabled=true
-
 # Check that we can alter the default zone config.
 statement ok
 ALTER RANGE default CONFIGURE ZONE USING num_replicas = 1

--- a/pkg/sql/mem_limit_test.go
+++ b/pkg/sql/mem_limit_test.go
@@ -157,7 +157,6 @@ func TestStreamerTightBudget(t *testing.T) {
 	})
 	ctx := context.Background()
 	defer s.Stopper().Stop(ctx)
-	SecondaryTenantSplitAtEnabled.Override(ctx, &s.ApplicationLayer().ClusterSettings().SV, true)
 
 	const blobSize = 1 << 20
 	const numRows = 5

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_tenant
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_tenant
@@ -1,5 +1,4 @@
 # LogicTest: 3node-tenant
-# tenant-cluster-setting-override-opt: sql.virtual_cluster.feature_access.zone_configs.enabled=true sql.virtual_cluster.feature_access.multiregion.enabled=true sql.virtual_cluster.feature_access.manual_range_split.enabled=true
 
 statement ok
 CREATE TABLE tbl1 (a INT PRIMARY KEY, b INT)

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_tenant_locality
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_tenant_locality
@@ -1,5 +1,4 @@
 # LogicTest: 3node-tenant-multiregion
-# tenant-cluster-setting-override-opt: sql.virtual_cluster.feature_access.manual_range_split.enabled=true sql.virtual_cluster.feature_access.zone_configs.enabled=true sql.virtual_cluster.feature_access.multiregion.enabled=true
 
 # Create a table on the secondary tenant.
 statement ok

--- a/pkg/sql/opt/exec/explain/BUILD.bazel
+++ b/pkg/sql/opt/exec/explain/BUILD.bazel
@@ -66,7 +66,6 @@ go_test(
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",
         "//pkg/server",
-        "//pkg/sql",
         "//pkg/sql/catalog/colinfo",
         "//pkg/sql/execinfra",
         "//pkg/sql/opt/cat",

--- a/pkg/sql/opt/exec/explain/output_test.go
+++ b/pkg/sql/opt/exec/explain/output_test.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/multitenant/tenantcapabilities"
-	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec/explain"
@@ -187,7 +186,6 @@ func TestCPUTimeEndToEnd(t *testing.T) {
 	defer tc.Stopper().Stop(ctx)
 
 	if srv := tc.Server(0); srv.StartedDefaultTestTenant() {
-		sql.SecondaryTenantSplitAtEnabled.Override(ctx, &srv.ApplicationLayer().ClusterSettings().SV, true)
 		systemSqlDB := srv.SystemLayer().SQLConn(t, "system")
 		_, err := systemSqlDB.Exec(`ALTER TENANT [$1] GRANT CAPABILITY can_admin_relocate_range=true`, serverutils.TestTenantID().ToUint64())
 		require.NoError(t, err)

--- a/pkg/sql/pgwire/pgwire_test.go
+++ b/pkg/sql/pgwire/pgwire_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
-	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -819,9 +818,6 @@ func TestPGPreparedQuery(t *testing.T) {
 	ctx := context.Background()
 	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
-
-	ts := s.ApplicationLayer()
-	sql.SecondaryTenantZoneConfigsEnabled.Override(ctx, &ts.ClusterSettings().SV, true)
 
 	// Update the default AS OF time for querying the system.table_statistics
 	// table to create the crdb_internal.table_row_statistics table.

--- a/pkg/sql/revert_test.go
+++ b/pkg/sql/revert_test.go
@@ -48,7 +48,6 @@ func TestTableRollback(t *testing.T) {
 	tt := s.ApplicationLayer()
 	codec, sv := tt.Codec(), &tt.ClusterSettings().SV
 	execCfg := tt.ExecutorConfig().(sql.ExecutorConfig)
-	sql.SecondaryTenantSplitAtEnabled.Override(ctx, sv, true)
 
 	db := sqlutils.MakeSQLRunner(sqlDB)
 	db.Exec(t, `CREATE DATABASE IF NOT EXISTS test`)

--- a/pkg/sql/scatter_test.go
+++ b/pkg/sql/scatter_test.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/desctestutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/randgen"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -119,9 +118,6 @@ func TestScatterResponse(t *testing.T) {
 	defer ts.Stopper().Stop(context.Background())
 
 	s := ts.ApplicationLayer()
-
-	sql.SecondaryTenantSplitAtEnabled.Override(ctx, &s.ClusterSettings().SV, true)
-	sql.SecondaryTenantScatterEnabled.Override(ctx, &s.ClusterSettings().SV, true)
 
 	sqlutils.CreateTable(
 		t, sqlDB, "t",

--- a/pkg/sql/schemachanger/scbuild/builder_test.go
+++ b/pkg/sql/schemachanger/scbuild/builder_test.go
@@ -116,7 +116,6 @@ func TestBuildDataDriven(t *testing.T) {
 				s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{})
 				defer s.Stopper().Stop(ctx)
 				tt := s.ApplicationLayer()
-				sql.SecondaryTenantZoneConfigsEnabled.Override(ctx, &tt.ClusterSettings().SV, true)
 				tdb := sqlutils.MakeSQLRunner(sqlDB)
 				datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {
 					return run(ctx, t, depsType.name, d, tt, s.NodeID(), tdb, depsType.dependenciesWrapper)

--- a/pkg/sql/schemachanger/sctest/test_server_factory.go
+++ b/pkg/sql/schemachanger/sctest/test_server_factory.go
@@ -97,8 +97,6 @@ func (f SingleNodeTestClusterFactory) Run(
 		args.Knobs.SQLDeclarativeSchemaChanger = f.scexec
 	}
 	s, db, _ := serverutils.StartServer(t, args)
-	sv := &s.ApplicationLayer().ClusterSettings().SV
-	sql.SecondaryTenantZoneConfigsEnabled.Override(ctx, sv, true)
 	defer func() {
 		s.Stopper().Stop(ctx)
 	}()

--- a/pkg/sql/sqlnoccltest/BUILD.bazel
+++ b/pkg/sql/sqlnoccltest/BUILD.bazel
@@ -13,7 +13,6 @@ go_test(
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",
         "//pkg/server",
-        "//pkg/sql",
         "//pkg/sql/catalog/catalogkeys",
         "//pkg/sql/catalog/catpb",
         "//pkg/sql/catalog/desctestutils",

--- a/pkg/sql/sqlnoccltest/partition_test.go
+++ b/pkg/sql/sqlnoccltest/partition_test.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
-	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkeys"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/desctestutils"
@@ -39,7 +38,6 @@ func TestRemovePartitioningOSS(t *testing.T) {
 	srv, sqlDBRaw, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
 	defer srv.Stopper().Stop(ctx)
 	s := srv.ApplicationLayer()
-	sql.SecondaryTenantZoneConfigsEnabled.Override(ctx, &s.ClusterSettings().SV, true)
 	sqlDB := sqlutils.MakeSQLRunner(sqlDBRaw)
 
 	const numRows = 100

--- a/pkg/sql/sqltestutils/show_create_table.go
+++ b/pkg/sql/sqltestutils/show_create_table.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/stretchr/testify/require"
 )
@@ -49,9 +48,6 @@ func ShowCreateTableTest(
 		},
 	})
 	defer s.Stopper().Stop(context.Background())
-	tenantSettings := s.ApplicationLayer().ClusterSettings()
-	// In case we're with multi region abstractions against the test tenant.
-	sql.SecondaryTenantsMultiRegionAbstractionsEnabled.Override(context.Background(), &tenantSettings.SV, true)
 
 	if _, err := sqlDB.Exec(`
     SET CLUSTER SETTING sql.cross_db_fks.enabled = TRUE;

--- a/pkg/sql/tests/rsg_test.go
+++ b/pkg/sql/tests/rsg_test.go
@@ -808,8 +808,6 @@ func testRandomSyntax(
 	}
 	srv, rawDB, _ := serverutils.StartServer(t, params)
 	defer srv.Stopper().Stop(ctx)
-	sql.SecondaryTenantSplitAtEnabled.Override(ctx, &srv.ApplicationLayer().ClusterSettings().SV, true)
-	sql.SecondaryTenantScatterEnabled.Override(ctx, &srv.ApplicationLayer().ClusterSettings().SV, true)
 	db := &verifyFormatDB{db: rawDB}
 	err := db.exec(t, ctx, "SET CLUSTER SETTING schemachanger.job.max_retry_backoff='1s'")
 	require.NoError(t, err)

--- a/pkg/sql/tests/truncate_test.go
+++ b/pkg/sql/tests/truncate_test.go
@@ -399,9 +399,6 @@ func TestTruncatePreservesSplitPoints(t *testing.T) {
 			s := tc.ApplicationLayer(0)
 			tenantSettings := s.ClusterSettings()
 			conn := s.SQLConn(t, "defaultdb")
-			// Ensure that if we're running with the test tenant, it can split
-			// the table below.
-			sql.SecondaryTenantSplitAtEnabled.Override(ctx, &tenantSettings.SV, true)
 
 			{
 				// This test asserts on KV-internal effects (i.e. range splits

--- a/pkg/workload/bank/BUILD.bazel
+++ b/pkg/workload/bank/BUILD.bazel
@@ -32,7 +32,6 @@ go_test(
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",
         "//pkg/server",
-        "//pkg/sql",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/sqlutils",
         "//pkg/testutils/testcluster",

--- a/pkg/workload/bank/bank_test.go
+++ b/pkg/workload/bank/bank_test.go
@@ -16,7 +16,6 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
-	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -50,12 +49,7 @@ func TestBank(t *testing.T) {
 	})
 	defer srv.Stopper().Stop(ctx)
 
-	s := srv.ApplicationLayer()
-
 	sqlutils.MakeSQLRunner(db).Exec(t, `CREATE DATABASE test`)
-
-	// To enable workloadsql.Split.
-	sql.SecondaryTenantSplitAtEnabled.Override(ctx, &s.ClusterSettings().SV, true)
 
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("rows=%d/ranges=%d", test.rows, test.ranges), func(t *testing.T) {

--- a/pkg/workload/insights/BUILD.bazel
+++ b/pkg/workload/insights/BUILD.bazel
@@ -33,7 +33,6 @@ go_test(
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",
         "//pkg/server",
-        "//pkg/sql",
         "//pkg/sql/sem/tree",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/sqlutils",

--- a/pkg/workload/insights/insights_test.go
+++ b/pkg/workload/insights/insights_test.go
@@ -16,7 +16,6 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
-	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
@@ -50,12 +49,8 @@ func TestInsightsWorkload(t *testing.T) {
 		DefaultTestTenant: base.TestIsForStuffThatShouldWorkWithSecondaryTenantsButDoesntYet(109458),
 	})
 	defer srv.Stopper().Stop(ctx)
-	s := srv.ApplicationLayer()
 
 	sqlutils.MakeSQLRunner(db).Exec(t, `CREATE DATABASE test`)
-
-	// To enable workloadsql.Split.
-	sql.SecondaryTenantSplitAtEnabled.Override(ctx, &s.ClusterSettings().SV, true)
 
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("rows=%d/ranges=%d", test.rows, test.ranges), func(t *testing.T) {

--- a/pkg/workload/workloadsql/BUILD.bazel
+++ b/pkg/workload/workloadsql/BUILD.bazel
@@ -38,7 +38,6 @@ go_test(
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",
         "//pkg/server",
-        "//pkg/sql",
         "//pkg/sql/sem/tree",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/sqlutils",

--- a/pkg/workload/workloadsql/workloadsql_test.go
+++ b/pkg/workload/workloadsql/workloadsql_test.go
@@ -17,7 +17,6 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
-	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
@@ -88,10 +87,6 @@ func TestSplits(t *testing.T) {
 		DefaultTestTenant: base.TestIsForStuffThatShouldWorkWithSecondaryTenantsButDoesntYet(109458),
 	})
 	defer srv.Stopper().Stop(ctx)
-
-	s := srv.ApplicationLayer()
-	// To enable workloadsql.Split.
-	sql.SecondaryTenantSplitAtEnabled.Override(ctx, &s.ClusterSettings().SV, true)
 
 	sqlDB := sqlutils.MakeSQLRunner(db)
 	sqlDB.Exec(t, `CREATE DATABASE test`)


### PR DESCRIPTION
This commit makes it so that `StartTenant` helper method overrides the default values for all cluster settings that gate some functionality in the secondary tenants to enable them. The rationale is that we do want this enabled in all places except when the test itself precisely controls what's enabled (and there are few of those).

Continuation of this work would be to consider granting all capabilities by default (unless the caller explicitly asks not to), but that should be done in a follow-up (tracked in #109477).

Epic: None

Release note: None