### PR TITLE
release: don't use `git describe` to generate tag versions

### DIFF
--- a/build/teamcity-support.sh
+++ b/build/teamcity-support.sh
@@ -311,3 +311,17 @@ check_workspace_clean() {
   fi
   echo "##teamcity[testFinished name='CheckGeneratedCode/$1']"
 }
+
+describe_version() {
+    # We emulate the behavior of `git describe` here without actually consulting
+    # any git tags. Instead, we assume that pkg/build/version.txt contains what
+    # would be the "git tag".
+    version_txt_changed_at=$(git log --pretty=%H -n1 -- pkg/build/version.txt)
+    num_commits=$(git log --oneline $version_txt_changed_at..HEAD | wc -l | xargs echo)
+    if [ $num_commits -eq 0 ]; then
+        build_name=$(cat pkg/build/version.txt)
+    else
+        build_name=$(cat pkg/build/version.txt)-$num_commits-g$(git rev-parse --short HEAD)$(git diff --quiet || echo '-dirty')
+    fi
+    echo $build_name
+}

--- a/build/teamcity/internal/release/process/make-and-publish-build-artifacts.sh
+++ b/build/teamcity/internal/release/process/make-and-publish-build-artifacts.sh
@@ -8,8 +8,7 @@ source "$dir/teamcity-bazel-support.sh"  # for run_bazel
 
 tc_start_block "Variable Setup"
 
-build_name=$(git describe --tags --dirty --match=v[0-9]* 2> /dev/null || git rev-parse --short HEAD;)
-
+build_name=$(describe_version)
 # On no match, `grep -Eo` returns 1. `|| echo""` makes the script not error.
 release_branch="$(echo "$build_name" | grep -Eo "^v[0-9]+\.[0-9]+" || echo"")"
 is_custom_build="$(echo "$TC_BUILD_BRANCH" | grep -Eo "^custombuild-" || echo "")"

--- a/build/teamcity/internal/release/process/make-and-publish-build-tagging.sh
+++ b/build/teamcity/internal/release/process/make-and-publish-build-tagging.sh
@@ -8,8 +8,7 @@ source "$dir/teamcity-bazel-support.sh"  # for run_bazel
 
 tc_start_block "Variable Setup"
 
-build_name=$(git describe --tags --dirty --match=v[0-9]* 2> /dev/null || git rev-parse --short HEAD;)
-
+build_name=$(describe_version)
 # On no match, `grep -Eo` returns 1. `|| echo""` makes the script not error.
 release_branch="$(echo "$build_name" | grep -Eo "^v[0-9]+\.[0-9]+" || echo"")"
 is_custom_build="$(echo "$TC_BUILD_BRANCH" | grep -Eo "^custombuild-" || echo "")"


### PR DESCRIPTION
This doesn't work unless you happen to have created a `git tag` for the commit associated with bumping `pkg/build/version.txt`. Instead, we replicate the logic that `git describe --tags --dirty` would do: compute the number of commits between the commit where the "tag" (actually `pkg/build/version.txt`) is and `HEAD`, then use that to compute a pseudo-version. There should be no difference between build tags before and after the change except that this will continue to work even if the step of pushing the `git tag` was skipped.

Epic: none
Release note: None