### PR TITLE
sql: add error and reporting when unable to fix malformed quantile

### DIFF
--- a/pkg/sql/stats/BUILD.bazel
+++ b/pkg/sql/stats/BUILD.bazel
@@ -52,6 +52,7 @@ go_library(
         "//pkg/util/hlc",
         "//pkg/util/intsets",
         "//pkg/util/log",
+        "//pkg/util/log/logcrash",
         "//pkg/util/mon",
         "//pkg/util/protoutil",
         "//pkg/util/stop",

--- a/pkg/sql/stats/quantile.go
+++ b/pkg/sql/stats/quantile.go
@@ -105,7 +105,7 @@ var zeroQuantile = quantile{{p: 0, v: 0}, {p: 1, v: 0}}
 // If you are introducing a new histogram version, please check whether
 // makeQuantile and quantile.toHistogram need to change, and then increase the
 // hard-coded number here.
-const _ uint = 2 - uint(histVersion)
+const _ = 2 - uint(histVersion)
 
 // canMakeQuantile returns true if a quantile function can be created for a
 // histogram of the given type. Note that by not supporting BYTES we rule out
@@ -656,10 +656,10 @@ func (q quantile) integrateSquared() float64 {
 // This function fixes the negative slope pieces by "moving" p from the
 // overlapping places to where it should be. No p is lost in the making of these
 // calculations.
-func (q quantile) fixMalformed() quantile {
+func (q quantile) fixMalformed() (quantile, error) {
 	// Check for the happy case where q is already well-formed.
 	if q.isWellFormed() {
-		return q
+		return q, nil
 	}
 
 	// To fix a malformed quantile function, we recalculate p for each distinct
@@ -803,6 +803,9 @@ func (q quantile) fixMalformed() quantile {
 		// "below" our horizontal line (<= v) and ends "above" our horizontal line
 		// (> v) and we always add two intersectionPs for "double roots" touching
 		// our line from above (one endpoint > v, one endpoint = v).
+		if len(intersectionPs) == 0 {
+			return q, errors.New("unable to fix malformed stats quantile")
+		}
 		lessEqP := intersectionPs[0]
 		for j := 1; j < len(intersectionPs); j += 2 {
 			lessEqP += intersectionPs[j+1] - intersectionPs[j]
@@ -818,7 +821,7 @@ func (q quantile) fixMalformed() quantile {
 			fixed = append(fixed, quantilePoint{p: lessEqP, v: val})
 		}
 	}
-	return fixed
+	return fixed, nil
 }
 
 // isWellFormed returns true if q is well-formed (i.e. is non-decreasing in v).

--- a/pkg/sql/stats/quantile_test.go
+++ b/pkg/sql/stats/quantile_test.go
@@ -1348,7 +1348,10 @@ func TestQuantileOps(t *testing.T) {
 			if intSqMult0 != 0 {
 				t.Errorf("test case %d incorrect intSqMult0 %v expected 0", i, intSqMult0)
 			}
-			fixed := tc.q.fixMalformed()
+			fixed, err := tc.q.fixMalformed()
+			if err != nil {
+				t.Errorf("test case %d has an unexpected error: %s", i, err)
+			}
 			if !reflect.DeepEqual(fixed, tc.fixed) {
 				t.Errorf("test case %d incorrect fixed %v expected %v", i, fixed, tc.fixed)
 			}
@@ -1407,7 +1410,10 @@ func TestQuantileOpsRandom(t *testing.T) {
 			if intSqMult0 != 0 {
 				t.Errorf("seed %v quantile %v incorrect intSqMult0 %v expected 0", seed, q, intSqMult0)
 			}
-			fixed := q.fixMalformed()
+			fixed, err := q.fixMalformed()
+			if err != nil {
+				t.Errorf("seed %v quantile %v had an unexpected error: %s", seed, q, err)
+			}
 			intSqFixed := fixed.integrateSquared()
 			// This seems like it should run into floating point errors, but it hasn't
 			// yet, so yay?

--- a/pkg/sql/stats/simple_linear_regression_test.go
+++ b/pkg/sql/stats/simple_linear_regression_test.go
@@ -286,7 +286,11 @@ func TestQuantileSimpleLinearRegression(t *testing.T) {
 	for i, tc := range testCases {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			yn, r2 := quantileSimpleLinearRegression(tc.x, tc.y, tc.xn)
-			yn = yn.fixMalformed()
+			var err error
+			yn, err = yn.fixMalformed()
+			if err != nil {
+				t.Errorf("test case %d had an unexpected error: %s", i, err)
+			}
 			if !reflect.DeepEqual(yn, tc.yn) {
 				t.Errorf("test case %d incorrect yn %v expected %v", i, yn, tc.yn)
 			}


### PR DESCRIPTION
This PR captures quantile information for future reproduction when we encounter a malformed quantile that we're unable to fix, instead of inducing an inactionable panic.

Epic: None
Fixes: #109060

Release note: None