### PR TITLE
server: batch large span stats requests

### DIFF
--- a/pkg/roachpb/span_stats.go
+++ b/pkg/roachpb/span_stats.go
@@ -18,7 +18,7 @@ import (
 
 // Put span statistics cluster settings here to avoid import cycle.
 
-const DefaultSpanStatsSpanLimit = 500
+const DefaultSpanStatsSpanLimit = 1000
 
 // SpanStatsBatchLimit registers the maximum number of spans allowed in a
 // span stats request payload.

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -455,6 +455,7 @@ go_test(
         "server_test.go",
         "settings_cache_test.go",
         "settings_test.go",
+        "span_stats_server_test.go",
         "span_stats_test.go",
         "statements_test.go",
         "status_ext_test.go",

--- a/pkg/server/span_stats_server_test.go
+++ b/pkg/server/span_stats_server_test.go
@@ -1,0 +1,109 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package server
+
+import (
+	"context"
+	"encoding/binary"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+func makeSpans(n int, offset int) roachpb.Spans {
+	spans := make([]roachpb.Span, 0, n)
+
+	for i := offset; i < n+offset; i++ {
+		startKey := make(roachpb.Key, 8)
+		endKey := make(roachpb.Key, 8)
+		binary.LittleEndian.PutUint64(startKey, uint64(i))
+		binary.LittleEndian.PutUint64(endKey, uint64(i+1))
+		spans = append(spans, roachpb.Span{Key: startKey, EndKey: endKey})
+	}
+
+	return spans
+}
+
+func TestSpanStatsBatching(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+
+	type testCase struct {
+		nSpans          int
+		limit           int
+		expectedBatches [][]roachpb.Span
+	}
+
+	testCases := []testCase{
+		{nSpans: 2, limit: 5, expectedBatches: [][]roachpb.Span{
+			makeSpans(2, 0), // Expect 1 batch of length 2.
+		}},
+		{nSpans: 5, limit: 5, expectedBatches: [][]roachpb.Span{
+			makeSpans(5, 0), // Expect 1 batch of length 5.
+		}},
+		{nSpans: 4, limit: 3, expectedBatches: [][]roachpb.Span{
+			makeSpans(3, 0), // Expect 1st batch of length 3.
+			makeSpans(1, 3), // Expect 2nd batch of length 1.
+		}},
+		{nSpans: 5, limit: 3, expectedBatches: [][]roachpb.Span{
+			makeSpans(3, 0), // Expect 1st batch of length 3.
+			makeSpans(2, 3), // Expect 2nd batch of length 2.
+		}},
+		{nSpans: 6, limit: 3, expectedBatches: [][]roachpb.Span{
+			makeSpans(3, 0), // Expect 1st batch of length 3.
+			makeSpans(3, 3), // Expect 2nd batch of length 3.
+		}},
+	}
+
+	for _, tcase := range testCases {
+		numBatches := 0
+		mockSpanStatsEndpoint := func(
+			ctx context.Context,
+			req *roachpb.SpanStatsRequest,
+		) (*roachpb.SpanStatsResponse, error) {
+
+			require.Equal(t, req.Spans, tcase.expectedBatches[numBatches])
+			numBatches++
+
+			res := &roachpb.SpanStatsResponse{}
+			res.SpanToStats = make(map[string]*roachpb.SpanStats)
+
+			// Provide a response for all spans, and an error per
+			// invocation. This lets us confirm that all batched
+			// responses make their way back to the caller.
+			for _, sp := range req.Spans {
+				res.SpanToStats[sp.String()] = &roachpb.SpanStats{}
+			}
+			res.Errors = append(res.Errors, "some error")
+			return res, nil
+		}
+
+		req := &roachpb.SpanStatsRequest{}
+		req.Spans = makeSpans(tcase.nSpans, 0 /* offset */)
+		res, err := batchedSpanStats(ctx, req, mockSpanStatsEndpoint, tcase.limit)
+		require.NoError(t, err)
+
+		// Assert that the mocked span stats function is invoked the correct
+		// number of times.
+		require.Equal(t, len(tcase.expectedBatches), numBatches)
+
+		// Assert that the responses from each batch are returned to the caller.
+		require.Equal(t, tcase.nSpans, len(res.SpanToStats))
+
+		// Assert that the errors from each batch are returned to the caller.
+		require.Equal(t, len(tcase.expectedBatches), len(res.Errors))
+	}
+
+}

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -32,7 +32,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/build"
-	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
@@ -3627,7 +3626,13 @@ func (s *statusServer) SpanStats(
 		// already returns a proper gRPC error status.
 		return nil, err
 	}
-	return s.sqlServer.tenantConnect.SpanStats(ctx, req)
+
+	if err := verifySpanStatsRequest(ctx, req, s.st.Version); err != nil {
+		return nil, err
+	}
+
+	batchSize := int(roachpb.SpanStatsBatchLimit.Get(&s.st.SV))
+	return batchedSpanStats(ctx, req, s.sqlServer.tenantConnect.SpanStats, batchSize)
 }
 
 func (s *systemStatusServer) SpanStats(
@@ -3641,26 +3646,12 @@ func (s *systemStatusServer) SpanStats(
 		return nil, err
 	}
 
-	// If the cluster's active version is less than 23.1 return a mixed version error.
-	if !s.st.Version.IsActive(ctx, clusterversion.V23_1) {
-		return nil, errors.New(MixedVersionErr)
+	if err := verifySpanStatsRequest(ctx, req, s.st.Version); err != nil {
+		return nil, err
 	}
 
-	// If we receive a request using the old format.
-	if isLegacyRequest(req) {
-		// We want to force 23.1 callers to use the new format (e.g. Spans field).
-		if req.NodeID == "0" {
-			return nil, errors.New(UnexpectedLegacyRequest)
-		}
-		// We want to error if we receive a legacy request from a 22.2
-		// node (e.g. during a mixed-version fanout).
-		return nil, errors.New(MixedVersionErr)
-	}
-	if len(req.Spans) > int(roachpb.SpanStatsBatchLimit.Get(&s.st.SV)) {
-		return nil, errors.Newf(exceedSpanLimitPlaceholder, len(req.Spans), int(roachpb.SpanStatsBatchLimit.Get(&s.st.SV)))
-	}
-
-	return s.getSpanStatsInternal(ctx, req)
+	batchSize := int(roachpb.SpanStatsBatchLimit.Get(&s.st.SV))
+	return batchedSpanStats(ctx, req, s.getSpanStatsInternal, batchSize)
 }
 
 // Diagnostics returns an anonymized diagnostics report.


### PR DESCRIPTION
Previously, span stats requests could only request a maximum of 500 spans at a time, otherwise the request would return an error.

This commit adds transparent batching at both the system tenant's handler and the secondary tenant's handler. The cluster setting `server.span_stats.span_batch_limit` is used to control the size of the batches. The default value has been raised to 1000.

Resolves #105638
Epic: CRDB-30635
Release note (ops change): Requests for database details or table details from the UI, or usages of `SHOW RANGES WITH DETAILS` are no longer subject to errors if the number of requested spans is too large.