### PR TITLE
dev: make `dev test --count 1` invalidate cached test results

### DIFF
--- a/dev
+++ b/dev
@@ -8,7 +8,7 @@ fi
 set -euo pipefail
 
 # Bump this counter to force rebuilding `dev` on all machines.
-DEV_VERSION=84
+DEV_VERSION=85
 
 THIS_DIR=$(cd "$(dirname "$0")" && pwd)
 BINARY_DIR=$THIS_DIR/bin/dev-versions

--- a/pkg/cmd/dev/testdata/datadriven/test
+++ b/pkg/cmd/dev/testdata/datadriven/test
@@ -21,7 +21,7 @@ bazel test pkg/util/tracing:all --test_env=GOTRACEBACK=all '--test_filter=TestSt
 exec
 dev test pkg/util/tracing -f TestStartChild* --ignore-cache
 ----
-bazel test pkg/util/tracing:all --nocache_test_results --test_env=GOTRACEBACK=all '--test_filter=TestStartChild*' --test_sharding_strategy=disabled --test_output errors --build_event_binary_file=/tmp/path
+bazel test pkg/util/tracing:all --test_env=GOTRACEBACK=all '--test_filter=TestStartChild*' --test_sharding_strategy=disabled --nocache_test_results --test_output errors --build_event_binary_file=/tmp/path
 
 exec
 dev test //pkg/testutils --timeout=10s
@@ -62,7 +62,7 @@ exec
 dev test pkg/cmd/dev -f TestDataDriven/test --rewrite -v
 ----
 bazel info workspace --color=no
-bazel test pkg/cmd/dev:all --nocache_test_results --test_env=GOTRACEBACK=all --test_env=COCKROACH_WORKSPACE=crdb-checkout --test_arg -rewrite --sandbox_writable_path=crdb-checkout/pkg/cmd/dev --test_filter=TestDataDriven/test --test_arg -test.v --test_sharding_strategy=disabled --test_output all --build_event_binary_file=/tmp/path
+bazel test pkg/cmd/dev:all --test_env=GOTRACEBACK=all --test_env=COCKROACH_WORKSPACE=crdb-checkout --test_arg -rewrite --sandbox_writable_path=crdb-checkout/pkg/cmd/dev --test_filter=TestDataDriven/test --test_arg -test.v --test_sharding_strategy=disabled --nocache_test_results --test_output all --build_event_binary_file=/tmp/path
 
 exec
 dev test pkg/server -f=TestSpanStatsResponse -v --count=5 --vmodule=raft=1
@@ -84,7 +84,7 @@ exec
 dev test pkg/ccl/logictestccl -f=TestTenantLogic/3node-tenant/system -v --rewrite
 ----
 bazel info workspace --color=no
-bazel test pkg/ccl/logictestccl:all --nocache_test_results --test_env=GOTRACEBACK=all --test_env=COCKROACH_WORKSPACE=crdb-checkout --test_arg -rewrite --sandbox_writable_path=crdb-checkout/pkg/ccl/logictestccl --sandbox_writable_path=crdb-checkout/pkg/sql/logictest --sandbox_writable_path=crdb-checkout/pkg/sql/opt/exec/execbuilder --test_filter=TestTenantLogic/3node-tenant/system --test_arg -test.v --test_sharding_strategy=disabled --test_output all --build_event_binary_file=/tmp/path
+bazel test pkg/ccl/logictestccl:all --test_env=GOTRACEBACK=all --test_env=COCKROACH_WORKSPACE=crdb-checkout --test_arg -rewrite --sandbox_writable_path=crdb-checkout/pkg/ccl/logictestccl --sandbox_writable_path=crdb-checkout/pkg/sql/logictest --sandbox_writable_path=crdb-checkout/pkg/sql/opt/exec/execbuilder --test_filter=TestTenantLogic/3node-tenant/system --test_arg -test.v --test_sharding_strategy=disabled --nocache_test_results --test_output all --build_event_binary_file=/tmp/path
 
 exec
 dev test pkg/spanconfig/spanconfigkvsubscriber -f=TestDecodeSpanTargets -v --stream-output
@@ -115,19 +115,19 @@ exec
 dev test pkg/sql/schemachanger --rewrite -v
 ----
 bazel info workspace --color=no
-bazel test pkg/sql/schemachanger:all --nocache_test_results --test_env=GOTRACEBACK=all --test_env=COCKROACH_WORKSPACE=crdb-checkout --test_arg -rewrite --sandbox_writable_path=crdb-checkout/pkg/sql/schemachanger --test_arg -test.v --test_sharding_strategy=disabled --test_output all --build_event_binary_file=/tmp/path
+bazel test pkg/sql/schemachanger:all --test_env=GOTRACEBACK=all --test_env=COCKROACH_WORKSPACE=crdb-checkout --test_arg -rewrite --sandbox_writable_path=crdb-checkout/pkg/sql/schemachanger --test_arg -test.v --test_sharding_strategy=disabled --nocache_test_results --test_output all --build_event_binary_file=/tmp/path
 
 exec
 dev test pkg/sql/opt/xform --rewrite
 ----
 bazel info workspace --color=no
-bazel test pkg/sql/opt/xform:all --nocache_test_results --test_env=GOTRACEBACK=all --test_env=COCKROACH_WORKSPACE=crdb-checkout --test_arg -rewrite --sandbox_writable_path=crdb-checkout/pkg/sql/opt/xform --sandbox_writable_path=crdb-checkout/pkg/sql/opt/testutils/opttester/testfixtures --test_sharding_strategy=disabled --test_output errors --build_event_binary_file=/tmp/path
+bazel test pkg/sql/opt/xform:all --test_env=GOTRACEBACK=all --test_env=COCKROACH_WORKSPACE=crdb-checkout --test_arg -rewrite --sandbox_writable_path=crdb-checkout/pkg/sql/opt/xform --sandbox_writable_path=crdb-checkout/pkg/sql/opt/testutils/opttester/testfixtures --test_sharding_strategy=disabled --nocache_test_results --test_output errors --build_event_binary_file=/tmp/path
 
 exec
 dev test pkg/sql/... --rewrite
 ----
 bazel info workspace --color=no
-bazel test pkg/sql/... --nocache_test_results --test_env=GOTRACEBACK=all --test_env=COCKROACH_WORKSPACE=crdb-checkout --test_arg -rewrite --sandbox_writable_path=crdb-checkout/pkg/sql --test_sharding_strategy=disabled --test_output errors --build_event_binary_file=/tmp/path
+bazel test pkg/sql/... --test_env=GOTRACEBACK=all --test_env=COCKROACH_WORKSPACE=crdb-checkout --test_arg -rewrite --sandbox_writable_path=crdb-checkout/pkg/sql --test_sharding_strategy=disabled --nocache_test_results --test_output errors --build_event_binary_file=/tmp/path
 
 exec
 dev test pkg/spanconfig/spanconfigstore --test-args '-test.timeout=0.5s'
@@ -162,3 +162,8 @@ dev test pkg/spanconfig/spanconfigstore --stress --count 250
 ----
 getenv DEV_I_UNDERSTAND_ABOUT_STRESS
 bazel test pkg/spanconfig/spanconfigstore:all --test_env=GOTRACEBACK=all --test_env=COCKROACH_STRESS=true --notest_keep_going --runs_per_test=250 --test_output errors --build_event_binary_file=/tmp/path
+
+exec
+dev test pkg/spanconfig/spanconfigstore --count 1
+----
+bazel test pkg/spanconfig/spanconfigstore:all --test_env=GOTRACEBACK=all --nocache_test_results --test_output errors --build_event_binary_file=/tmp/path


### PR DESCRIPTION
This matches the behavior of `go test`.

Epic: none
Release note: None