### PR TITLE
server: use params for temp storage and settings for default test tenant

### DIFF
--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -599,7 +599,14 @@ func (ts *testServer) maybeStartDefaultTestTenant(ctx context.Context) error {
 		return nil // nolint:returnerrcheck
 	}
 
-	tempStorageConfig := base.DefaultTestTempStorageConfig(cluster.MakeTestingClusterSettings())
+	tenantSettings := ts.params.Settings
+	if tenantSettings == nil {
+		tenantSettings = cluster.MakeTestingClusterSettings()
+	}
+	tempStorageConfig := ts.params.TempStorageConfig
+	if tempStorageConfig.Settings == nil {
+		tempStorageConfig = base.DefaultTestTempStorageConfig(tenantSettings)
+	}
 	params := base.TestTenantArgs{
 		// Currently, all the servers leverage the same tenant ID. We may
 		// want to change this down the road, for more elaborate testing.
@@ -614,7 +621,7 @@ func (ts *testServer) maybeStartDefaultTestTenant(ctx context.Context) error {
 		SSLCertsDir:               ts.params.SSLCertsDir,
 		TestingKnobs:              ts.params.Knobs,
 		StartDiagnosticsReporting: ts.params.StartDiagnosticsReporting,
-		Settings:                  ts.params.Settings,
+		Settings:                  tenantSettings,
 	}
 
 	// Since we're creating a tenant, it doesn't make sense to pass through the

--- a/pkg/sql/colflow/BUILD.bazel
+++ b/pkg/sql/colflow/BUILD.bazel
@@ -85,11 +85,13 @@ go_test(
     embed = [":colflow"],
     deps = [
         "//pkg/base",
+        "//pkg/ccl",
         "//pkg/col/coldata",
         "//pkg/col/coldataext",
         "//pkg/col/coldatatestutils",
         "//pkg/keys",
         "//pkg/kv",
+        "//pkg/multitenant/tenantcapabilities",
         "//pkg/roachpb",
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",


### PR DESCRIPTION
This commit makes it so that we use the settings and temp storage from the server params (if available) when starting up the default test tenant. The temp storage fix allows us to adjust one test to work with the test tenant.

Fixes: #109456.

Release note: None