### PR TITLE
release-23.1: sql/tests: fix test size of random syntax generation

### DIFF
--- a/pkg/sql/tests/BUILD.bazel
+++ b/pkg/sql/tests/BUILD.bazel
@@ -32,7 +32,7 @@ go_library(
 
 go_test(
     name = "tests_test",
-    size = "large",
+    size = "enormous",
     srcs = [
         "allow_role_memberships_to_change_during_transaction_test.go",
         "autocommit_extended_protocol_test.go",
@@ -60,7 +60,7 @@ go_test(
         "truncate_test.go",
         "virtual_table_test.go",
     ],
-    args = ["-test.timeout=895s"],
+    args = ["-test.timeout=3595s"],
     data = glob(["testdata/**"]),
     embed = [":tests"],
     shard_count = 16,


### PR DESCRIPTION
Previously, the test size of the RSG tests within the nightly environment was not configured correctly. While the nightly script sets a timeout, its overwritten by the value from the bazel files. As a result, the TestRandomSyntaxFunction fails in CI environments when run using the nightly scripts. To address this, this patch bumps the test size to enormous.

Fixes: #109068

Release note: None

Release justification: low risk fix linked to build environment only