### PR TITLE
release-23.1: sql: add in-flight trace to the stmt bundle

### DIFF
--- a/pkg/sql/explain_bundle_test.go
+++ b/pkg/sql/explain_bundle_test.go
@@ -364,6 +364,18 @@ CREATE TABLE users(id UUID DEFAULT gen_random_uuid() PRIMARY KEY, promo_id INT R
 			base, plans, "distsql.html errors.txt stats-defaultdb.public.permissions.sql vec.txt vec-v.txt",
 		)
 	})
+
+	t.Run("with in-flight trace", func(t *testing.T) {
+		r.Exec(t, "SET CLUSTER SETTING sql.stmt_diagnostics.in_flight_trace_collector.poll_interval = '0.25s'")
+		defer r.Exec(t, "SET CLUSTER SETTING sql.stmt_diagnostics.in_flight_trace_collector.poll_interval = '0s'")
+		// Sleep for 1s during the query execution to allow for the trace
+		// collector goroutine to start.
+		rows := r.QueryStr(t, "EXPLAIN ANALYZE (DEBUG) SELECT pg_sleep(1)")
+		checkBundle(
+			t, fmt.Sprint(rows), "" /* tableName */, nil /* contentCheck */, false, /* expectErrors */
+			base, plans, "distsql.html vec.txt vec-v.txt inflight-trace-n1.txt inflight-trace-jaeger-n1.json",
+		)
+	})
 }
 
 // checkBundle searches text strings for a bundle URL and then verifies that the

--- a/pkg/sql/instrumentation.go
+++ b/pkg/sql/instrumentation.go
@@ -126,6 +126,8 @@ type instrumentationHelper struct {
 	origCtx          context.Context
 	evalCtx          *eval.Context
 
+	inFlightTraceCollector
+
 	queryLevelStatsWithErr *execstats.QueryLevelStatsWithErr
 
 	// If savePlanForStats is true and the explainPlan was collected, the
@@ -241,6 +243,130 @@ func (ih *instrumentationHelper) SetOutputMode(outputMode outputMode, explainFla
 	ih.explainFlags = explainFlags
 }
 
+type inFlightTraceCollector struct {
+	// cancel is nil if the collector goroutine is not started.
+	cancel context.CancelFunc
+	// waitCh will be closed by the collector goroutine when it exits. It serves
+	// as a synchronization mechanism for accessing trace and errors fields.
+	waitCh chan struct{}
+	// trace contains the latest recording that the collector goroutine polled.
+	trace []traceFromSQLInstance
+	// errors accumulates all errors that the collector ran into throughout its
+	// lifecycle.
+	errors []error
+	// timeoutTrace, if set, contains the trace recording obtained by the main
+	// goroutine in case the query execution was canceled due to a statement
+	// timeout.
+	timeoutTrace []traceFromSQLInstance
+}
+
+type traceFromSQLInstance struct {
+	nodeID int64
+	trace  string
+	jaeger string
+}
+
+const inFlightTraceOpName = "bundle-in-flight-trace"
+
+// pollTrace queries the crdb_internal.cluster_inflight_traces virtual table to
+// retrieve the trace for the provided traceID.
+func pollInFlightTrace(
+	ctx context.Context, ie isql.Executor, traceID tracingpb.TraceID,
+) ([]traceFromSQLInstance, error) {
+	it, err := ie.QueryIterator(
+		ctx, inFlightTraceOpName, nil, /* txn */
+		"SELECT node_id, trace_str, jaeger_json FROM crdb_internal.cluster_inflight_traces WHERE trace_id = $1",
+		traceID,
+	)
+	var trace []traceFromSQLInstance
+	if err == nil {
+		var ok bool
+		for ok, err = it.Next(ctx); ok; ok, err = it.Next(ctx) {
+			row := it.Cur()
+			trace = append(trace, traceFromSQLInstance{
+				nodeID: int64(tree.MustBeDInt(row[0])),
+				trace:  string(tree.MustBeDString(row[1])),
+				jaeger: string(tree.MustBeDString(row[2])),
+			})
+		}
+	}
+	return trace, err
+}
+
+func (c inFlightTraceCollector) finish() {
+	if c.cancel == nil {
+		// The in-flight trace collector goroutine wasn't started.
+		return
+	}
+	// Cancel the collector goroutine and block until it exits.
+	c.cancel()
+	<-c.waitCh
+}
+
+var inFlightTraceCollectorPollInterval = settings.RegisterDurationSetting(
+	settings.TenantWritable,
+	"sql.stmt_diagnostics.in_flight_trace_collector.poll_interval",
+	"determines the interval between polling done by the in-flight trace "+
+		"collector for the statement bundle, set to zero to disable",
+	0,
+	settings.NonNegativeDuration,
+)
+
+var timeoutTraceCollectionEnabled = settings.RegisterBoolSetting(
+	settings.TenantWritable,
+	"sql.stmt_diagnostics.timeout_trace_collection.enabled",
+	"determines whether the in-flight trace collection is performed when building "+
+		"the statement bundle if the timeout is detected",
+	true,
+)
+
+// startInFlightTraceCollector starts another goroutine that will periodically
+// query the crdb_internal virtual table to obtain the in-flight trace for the
+// span of the instrumentationHelper. It should only be called when we're
+// collecting a bundle and inFlightTraceCollector.finish must be called when
+// building the bundle.
+func (ih *instrumentationHelper) startInFlightTraceCollector(
+	ctx context.Context, ie isql.Executor, pollInterval time.Duration,
+) {
+	traceID := ih.sp.TraceID()
+	c := &ih.inFlightTraceCollector
+	ctx, c.cancel = context.WithCancel(ctx)
+	c.waitCh = make(chan struct{})
+	go func(ctx context.Context) {
+		defer close(c.waitCh)
+		// Derive a detached tracing span that won't pollute the recording we're
+		// collecting for the bundle.
+		var sp *tracing.Span
+		ctx, sp = ih.sp.Tracer().StartSpanCtx(ctx, inFlightTraceOpName, tracing.WithDetachedRecording())
+		defer sp.Finish()
+
+		timer := time.NewTimer(pollInterval)
+		defer timer.Stop()
+
+		for {
+			// Now sleep for the duration of the poll interval (or until we're
+			// canceled).
+			select {
+			case <-ctx.Done():
+				return
+			case <-timer.C:
+				timer.Reset(pollInterval)
+			}
+
+			trace, err := pollInFlightTrace(ctx, ie, traceID)
+			if err == nil {
+				c.trace = trace
+			} else if ctx.Err() == nil {
+				// When the context is canceled, we expect to receive an error.
+				// Note that the context cancellation occurs in the "happy" case
+				// too when the execution of the traced query finished, and
+				// we're building the bundle, so we're ignoring such an error.
+				c.errors = append(c.errors, err)
+			}
+		}
+	}(ctx)
+}
+
 // Setup potentially enables verbose tracing for the statement, depending on
 // output mode or statement diagnostic activation requests. Finish() must be
 // called after the statement finishes execution (unless needFinish=false, in
@@ -294,6 +420,11 @@ func (ih *instrumentationHelper) Setup(
 		}
 		// Make sure that the builtins use the correct context.
 		ih.evalCtx.SetDeprecatedContext(newCtx)
+		if ih.collectBundle {
+			if pollInterval := inFlightTraceCollectorPollInterval.Get(cfg.SV()); pollInterval > 0 {
+				ih.startInFlightTraceCollector(ctx, cfg.InternalDB.Executor(), pollInterval)
+			}
+		}
 	}()
 
 	if sp := tracing.SpanFromContext(ctx); sp != nil {
@@ -372,15 +503,17 @@ func (ih *instrumentationHelper) Finish(
 		return retErr
 	}
 
+	if ih.shouldFinishSpan {
+		// Make sure that we always finish the tracing spans if we need to. Note
+		// that we defer this so that we can collect the timeout trace if
+		// necessary when building the bundle.
+		defer ih.sp.Finish()
+	}
+
 	// Record the statement information that we've collected.
 	// Note that in case of implicit transactions, the trace contains the auto-commit too.
-	var trace tracingpb.Recording
-
-	if ih.shouldFinishSpan {
-		trace = ih.sp.FinishAndGetConfiguredRecording()
-	} else {
-		trace = ih.sp.GetConfiguredRecording()
-	}
+	traceID := ih.sp.TraceID()
+	trace := ih.sp.GetConfiguredRecording()
 
 	if ih.withStatementTrace != nil {
 		ih.withStatementTrace(trace, stmtRawSQL)
@@ -398,6 +531,7 @@ func (ih *instrumentationHelper) Finish(
 	var bundle diagnosticsBundle
 	var warnings []string
 	if ih.collectBundle {
+		ih.inFlightTraceCollector.finish()
 		ie := p.extendedEvalCtx.ExecCfg.InternalDB.Executor(
 			isql.WithSessionData(p.SessionData()),
 		)
@@ -432,11 +566,18 @@ func (ih *instrumentationHelper) Finish(
 				var cancel context.CancelFunc
 				bundleCtx, cancel = context.WithTimeout(context.Background(), 10*time.Second) // nolint:context
 				defer cancel()
+				if timeoutTraceCollectionEnabled.Get(cfg.SV()) {
+					if tr, err := pollInFlightTrace(bundleCtx, ie, traceID); err == nil {
+						// Ignore any errors since this is done on the
+						// best-effort basis.
+						ih.inFlightTraceCollector.timeoutTrace = tr
+					}
+				}
 			}
 			bundle = buildStatementBundle(
 				bundleCtx, ih.explainFlags, cfg.DB, ie.(*InternalExecutor), stmtRawSQL, &p.curPlan,
 				ob.BuildString(), trace, placeholders, res.Err(), payloadErr, retErr,
-				&p.extendedEvalCtx.Settings.SV,
+				&p.extendedEvalCtx.Settings.SV, ih.inFlightTraceCollector,
 			)
 			// Include all non-critical errors as warnings. Note that these
 			// error strings might contain PII, but the warnings are only shown


### PR DESCRIPTION
Backport 1/1 commits from #108754.

/cc @cockroachdb/release

---

This commit introduces the collection of the in-flight trace to the stmt bundle. It is achieved by starting up a new goroutine on the gateway for the query which periodically polls the `crdb_internal` virtual table for the bundle's traceID, and then the latest result of that polling is included into the bundle. This feature will be helpful in investigating the timeouts in which case we're unable to propagate the full trace at the end of the query execution (because it's stopped abruptly). This feature is disabled by default (because in the common case the final trace is there, so it'd be an additional and redundant overhead for the bundle collection), and it's controlled by the undocumented cluster setting `sql.stmt_diagnostics.in_flight_trace_collector.poll_interval`.

It's worth noting that this new goroutine derives a separate tracing span with detached recording option in order to not pollute the query's trace. Also, the format of the virtual table doesn't seem to allow us to combine traces from multiple nodes, so each node involved in the query will result in an additional file.

This commit additionally attempts to obtain the "timeout" trace by polling the same virtual table from the main goroutine when building the bundle in case the context cancellation is detected (which is assumed to be the statement timeout having been triggered). This "timeout" trace is then included as a separate file in the bundle. This required deferring finishing the tracing span on the gateway in order to allow for the virtual table to find the trace on the gateway. Note that given that context cancellation results in an abrupt shutdown of the query plan, it's possible that remote flows have already exited (meaning that the traces from the remote nodes won't be found by the virtual table), still it seems to be better than nothing. Also note that there is no unit test case for this scenario because the query results in an error, so it's a bit annoying to access the bundle. I did verify manually that the timeout trace shows up in the bundle. This "timeout" trace collection is controlled via `sql.stmt_diagnostics.timeout_trace_collection.enabled` cluster setting and is enabled by default.

Fixes: #107744.

Release note: None

Release justification: low-risk debugging improvement.