### PR TITLE
release-22.2: sql: add in-flight trace to the stmt bundle

### DIFF
--- a/pkg/sql/explain_bundle.go
+++ b/pkg/sql/explain_bundle.go
@@ -138,6 +138,7 @@ func buildStatementBundle(
 	placeholders *tree.PlaceholderInfo,
 	queryErr, payloadErr, commErr error,
 	sv *settings.Values,
+	c inFlightTraceCollector,
 ) diagnosticsBundle {
 	if plan == nil {
 		return diagnosticsBundle{collectionErr: errors.AssertionFailedf("execution terminated early")}
@@ -150,6 +151,7 @@ func buildStatementBundle(
 	b.addDistSQLDiagrams()
 	b.addExplainVec()
 	b.addTrace()
+	b.addInFlightTrace(c)
 	b.addEnv(ctx)
 	b.addErrors(queryErr, payloadErr, commErr)
 
@@ -363,6 +365,30 @@ The UI can then be accessed at http://localhost:16686/search`, b.stmt)
 		b.z.AddFile("trace-jaeger.txt", err.Error())
 	} else {
 		b.z.AddFile("trace-jaeger.json", jaegerJSON)
+	}
+}
+
+func (b *stmtBundleBuilder) addInFlightTrace(c inFlightTraceCollector) {
+	for _, trace := range c.trace {
+		b.z.AddFile(fmt.Sprintf("inflight-trace-n%d.txt", trace.nodeID), trace.trace)
+		b.z.AddFile(fmt.Sprintf("inflight-trace-jaeger-n%d.json", trace.nodeID), trace.jaeger)
+	}
+	if len(c.trace) == 0 && len(c.errors) > 0 {
+		// Include all errors accumulated throughout the in-flight tracing if we
+		// weren't able to get even a single trace.
+		var sb strings.Builder
+		for j, err := range c.errors {
+			if j > 0 {
+				sb.WriteString("\n")
+			}
+			sb.WriteString(err.Error())
+		}
+		b.z.AddFile("inflight-trace-errors.txt", sb.String())
+	}
+	// Include the timeout trace if available.
+	for _, trace := range c.timeoutTrace {
+		b.z.AddFile(fmt.Sprintf("timeout-trace-n%d.txt", trace.nodeID), trace.trace)
+		b.z.AddFile(fmt.Sprintf("timeout-trace-jaeger-n%d.json", trace.nodeID), trace.jaeger)
 	}
 }
 

--- a/pkg/sql/explain_bundle_test.go
+++ b/pkg/sql/explain_bundle_test.go
@@ -305,6 +305,18 @@ CREATE TABLE users(id UUID DEFAULT gen_random_uuid() PRIMARY KEY, promo_id INT R
 			base, plans, "distsql.html errors.txt stats-defaultdb.public.permissions.sql vec.txt vec-v.txt",
 		)
 	})
+
+	t.Run("with in-flight trace", func(t *testing.T) {
+		r.Exec(t, "SET CLUSTER SETTING sql.stmt_diagnostics.in_flight_trace_collector.poll_interval = '0.25s'")
+		defer r.Exec(t, "SET CLUSTER SETTING sql.stmt_diagnostics.in_flight_trace_collector.poll_interval = '0s'")
+		// Sleep for 1s during the query execution to allow for the trace
+		// collector goroutine to start.
+		rows := r.QueryStr(t, "EXPLAIN ANALYZE (DEBUG) SELECT pg_sleep(1)")
+		checkBundle(
+			t, fmt.Sprint(rows), "" /* tableName */, nil /* contentCheck */, false, /* expectErrors */
+			base, plans, "distsql.html vec.txt vec-v.txt inflight-trace-n1.txt inflight-trace-jaeger-n1.json",
+		)
+	})
 }
 
 // checkBundle searches text strings for a bundle URL and then verifies that the

--- a/pkg/sql/instrumentation.go
+++ b/pkg/sql/instrumentation.go
@@ -37,6 +37,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sessionphase"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/sql/stmtdiagnostics"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
@@ -123,6 +124,8 @@ type instrumentationHelper struct {
 	shouldFinishSpan bool
 	origCtx          context.Context
 	evalCtx          *eval.Context
+
+	inFlightTraceCollector
 
 	queryLevelStatsWithErr *execstats.QueryLevelStatsWithErr
 
@@ -234,6 +237,130 @@ func (ih *instrumentationHelper) SetOutputMode(outputMode outputMode, explainFla
 	ih.explainFlags = explainFlags
 }
 
+type inFlightTraceCollector struct {
+	// cancel is nil if the collector goroutine is not started.
+	cancel context.CancelFunc
+	// waitCh will be closed by the collector goroutine when it exits. It serves
+	// as a synchronization mechanism for accessing trace and errors fields.
+	waitCh chan struct{}
+	// trace contains the latest recording that the collector goroutine polled.
+	trace []traceFromSQLInstance
+	// errors accumulates all errors that the collector ran into throughout its
+	// lifecycle.
+	errors []error
+	// timeoutTrace, if set, contains the trace recording obtained by the main
+	// goroutine in case the query execution was canceled due to a statement
+	// timeout.
+	timeoutTrace []traceFromSQLInstance
+}
+
+type traceFromSQLInstance struct {
+	nodeID int64
+	trace  string
+	jaeger string
+}
+
+const inFlightTraceOpName = "bundle-in-flight-trace"
+
+// pollTrace queries the crdb_internal.cluster_inflight_traces virtual table to
+// retrieve the trace for the provided traceID.
+func pollInFlightTrace(
+	ctx context.Context, ie sqlutil.InternalExecutor, traceID tracingpb.TraceID,
+) ([]traceFromSQLInstance, error) {
+	it, err := ie.QueryIterator(
+		ctx, inFlightTraceOpName, nil, /* txn */
+		"SELECT node_id, trace_str, jaeger_json FROM crdb_internal.cluster_inflight_traces WHERE trace_id = $1",
+		traceID,
+	)
+	var trace []traceFromSQLInstance
+	if err == nil {
+		var ok bool
+		for ok, err = it.Next(ctx); ok; ok, err = it.Next(ctx) {
+			row := it.Cur()
+			trace = append(trace, traceFromSQLInstance{
+				nodeID: int64(tree.MustBeDInt(row[0])),
+				trace:  string(tree.MustBeDString(row[1])),
+				jaeger: string(tree.MustBeDString(row[2])),
+			})
+		}
+	}
+	return trace, err
+}
+
+func (c inFlightTraceCollector) finish() {
+	if c.cancel == nil {
+		// The in-flight trace collector goroutine wasn't started.
+		return
+	}
+	// Cancel the collector goroutine and block until it exits.
+	c.cancel()
+	<-c.waitCh
+}
+
+var inFlightTraceCollectorPollInterval = settings.RegisterDurationSetting(
+	settings.TenantWritable,
+	"sql.stmt_diagnostics.in_flight_trace_collector.poll_interval",
+	"determines the interval between polling done by the in-flight trace "+
+		"collector for the statement bundle, set to zero to disable",
+	0,
+	settings.NonNegativeDuration,
+)
+
+var timeoutTraceCollectionEnabled = settings.RegisterBoolSetting(
+	settings.TenantWritable,
+	"sql.stmt_diagnostics.timeout_trace_collection.enabled",
+	"determines whether the in-flight trace collection is performed when building "+
+		"the statement bundle if the timeout is detected",
+	true,
+)
+
+// startInFlightTraceCollector starts another goroutine that will periodically
+// query the crdb_internal virtual table to obtain the in-flight trace for the
+// span of the instrumentationHelper. It should only be called when we're
+// collecting a bundle and inFlightTraceCollector.finish must be called when
+// building the bundle.
+func (ih *instrumentationHelper) startInFlightTraceCollector(
+	ctx context.Context, ie sqlutil.InternalExecutor, pollInterval time.Duration,
+) {
+	traceID := ih.sp.TraceID()
+	c := &ih.inFlightTraceCollector
+	ctx, c.cancel = context.WithCancel(ctx)
+	c.waitCh = make(chan struct{})
+	go func(ctx context.Context) {
+		defer close(c.waitCh)
+		// Derive a detached tracing span that won't pollute the recording we're
+		// collecting for the bundle.
+		var sp *tracing.Span
+		ctx, sp = ih.sp.Tracer().StartSpanCtx(ctx, inFlightTraceOpName, tracing.WithDetachedRecording())
+		defer sp.Finish()
+
+		timer := time.NewTimer(pollInterval)
+		defer timer.Stop()
+
+		for {
+			// Now sleep for the duration of the poll interval (or until we're
+			// canceled).
+			select {
+			case <-ctx.Done():
+				return
+			case <-timer.C:
+				timer.Reset(pollInterval)
+			}
+
+			trace, err := pollInFlightTrace(ctx, ie, traceID)
+			if err == nil {
+				c.trace = trace
+			} else if ctx.Err() == nil {
+				// When the context is canceled, we expect to receive an error.
+				// Note that the context cancellation occurs in the "happy" case
+				// too when the execution of the traced query finished, and
+				// we're building the bundle, so we're ignoring such an error.
+				c.errors = append(c.errors, err)
+			}
+		}
+	}(ctx)
+}
+
 // Setup potentially enables verbose tracing for the statement, depending on
 // output mode or statement diagnostic activation requests. Finish() must be
 // called after the statement finishes execution (unless needFinish=false, in
@@ -283,6 +410,14 @@ func (ih *instrumentationHelper) Setup(
 			// Populate traceMetadata at the end once we have all properties of
 			// the helper setup.
 			ih.traceMetadata = make(execNodeTraceMetadata)
+		}
+		if ih.collectBundle {
+			if pollInterval := inFlightTraceCollectorPollInterval.Get(cfg.SV()); pollInterval > 0 {
+				ie := p.extendedEvalCtx.ExecCfg.InternalExecutorFactory.NewInternalExecutor(
+					p.SessionData(),
+				)
+				ih.startInFlightTraceCollector(ctx, ie, pollInterval)
+			}
 		}
 	}()
 
@@ -353,15 +488,17 @@ func (ih *instrumentationHelper) Finish(
 		return retErr
 	}
 
+	if ih.shouldFinishSpan {
+		// Make sure that we always finish the tracing spans if we need to. Note
+		// that we defer this so that we can collect the timeout trace if
+		// necessary when building the bundle.
+		defer ih.sp.Finish()
+	}
+
 	// Record the statement information that we've collected.
 	// Note that in case of implicit transactions, the trace contains the auto-commit too.
-	var trace tracingpb.Recording
-
-	if ih.shouldFinishSpan {
-		trace = ih.sp.FinishAndGetConfiguredRecording()
-	} else {
-		trace = ih.sp.GetConfiguredRecording()
-	}
+	traceID := ih.sp.TraceID()
+	trace := ih.sp.GetConfiguredRecording()
 
 	if ih.withStatementTrace != nil {
 		ih.withStatementTrace(trace, stmtRawSQL)
@@ -379,6 +516,7 @@ func (ih *instrumentationHelper) Finish(
 	var bundle diagnosticsBundle
 	var warnings []string
 	if ih.collectBundle {
+		ih.inFlightTraceCollector.finish()
 		ie := p.extendedEvalCtx.ExecCfg.InternalExecutorFactory.NewInternalExecutor(
 			p.SessionData(),
 		)
@@ -414,10 +552,18 @@ func (ih *instrumentationHelper) Finish(
 				var cancel context.CancelFunc
 				bundleCtx, cancel = context.WithTimeout(context.Background(), 10*time.Second) // nolint:context
 				defer cancel()
+				if timeoutTraceCollectionEnabled.Get(cfg.SV()) {
+					if tr, err := pollInFlightTrace(bundleCtx, ie, traceID); err == nil {
+						// Ignore any errors since this is done on the
+						// best-effort basis.
+						ih.inFlightTraceCollector.timeoutTrace = tr
+					}
+				}
 			}
 			bundle = buildStatementBundle(
-				bundleCtx, cfg.DB, ie.(*InternalExecutor), stmtRawSQL, &p.curPlan, ob.BuildString(), trace,
-				placeholders, res.Err(), payloadErr, retErr, &p.extendedEvalCtx.Settings.SV,
+				bundleCtx, cfg.DB, ie.(*InternalExecutor), stmtRawSQL, &p.curPlan,
+				ob.BuildString(), trace, placeholders, res.Err(), payloadErr, retErr,
+				&p.extendedEvalCtx.Settings.SV, ih.inFlightTraceCollector,
 			)
 			// Include all non-critical errors as warnings. Note that these
 			// error strings might contain PII, but the warnings are only shown


### PR DESCRIPTION
Backport 1/1 commits from #108754.

/cc @cockroachdb/release

---

This commit introduces the collection of the in-flight trace to the stmt bundle. It is achieved by starting up a new goroutine on the gateway for the query which periodically polls the `crdb_internal` virtual table for the bundle's traceID, and then the latest result of that polling is included into the bundle. This feature will be helpful in investigating the timeouts in which case we're unable to propagate the full trace at the end of the query execution (because it's stopped abruptly). This feature is disabled by default (because in the common case the final trace is there, so it'd be an additional and redundant overhead for the bundle collection), and it's controlled by the undocumented cluster setting `sql.stmt_diagnostics.in_flight_trace_collector.poll_interval`.

It's worth noting that this new goroutine derives a separate tracing span with detached recording option in order to not pollute the query's trace. Also, the format of the virtual table doesn't seem to allow us to combine traces from multiple nodes, so each node involved in the query will result in an additional file.

This commit additionally attempts to obtain the "timeout" trace by polling the same virtual table from the main goroutine when building the bundle in case the context cancellation is detected (which is assumed to be the statement timeout having been triggered). This "timeout" trace is then included as a separate file in the bundle. This required deferring finishing the tracing span on the gateway in order to allow for the virtual table to find the trace on the gateway. Note that given that context cancellation results in an abrupt shutdown of the query plan, it's possible that remote flows have already exited (meaning that the traces from the remote nodes won't be found by the virtual table), still it seems to be better than nothing. Also note that there is no unit test case for this scenario because the query results in an error, so it's a bit annoying to access the bundle. I did verify manually that the timeout trace shows up in the bundle. This "timeout" trace collection is controlled via `sql.stmt_diagnostics.timeout_trace_collection.enabled` cluster setting and is enabled by default.

Fixes: #107744.

Release note: None

Release justification: low-risk debugging improvement.