### PR TITLE
kvserver: reproduce issue 109230

### DIFF
--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -2120,6 +2120,7 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 
 	// Gossip is only ever nil while bootstrapping a cluster and
 	// in unittests.
+	time.Sleep(100 * time.Millisecond)
 	if s.cfg.Gossip != nil {
 		s.storeGossip.stopper = stopper
 		s.storeGossip.Ident = *s.Ident


### PR DESCRIPTION
Informs #109230
Epic: none
Release note: none