### PR TITLE
cli: add longer timeout and more logging

### DIFF
--- a/pkg/cli/interactive_tests/common.tcl
+++ b/pkg/cli/interactive_tests/common.tcl
@@ -17,7 +17,7 @@ system "rm -f $histfile"
 
 # Everything in this test should be fast. Don't be tolerant for long
 # waits.
-set timeout 30
+set timeout 45
 
 # When run via Docker the enclosing terminal has 0 columns and 0 rows,
 # and this confuses readline. Ensure sane defaults here.
@@ -63,6 +63,7 @@ proc handle_timeout {text} {
     exit 1
 }
 proc eexpect {text} {
+    system "echo; echo \$(date '+.%y%m%d %H:%M:%S.%N') START EXPECT TEST | tee -a logs/expect-cmd.log"
     expect {
 	$text {}
 	timeout { handle_timeout $text }


### PR DESCRIPTION
This increases the timeout for `eexpect`, along
with adding additional logging that displays a
timestamp of when `eexpect` is called.

With the logging change, we hope to validate
our assumption that the `eexpect` calls are
all nearing a timeout issue and that the flake
was due to a couple seconds of misfortune.

Epic: none
fixes: #100319
fixes: https://github.com/cockroachdb/cockroach/issues/108616
fixes: https://github.com/cockroachdb/cockroach/issues/108822

Release note: none