### PR TITLE
insights/integration: deflake TestInsightsIntegrationForContention

### DIFF
--- a/pkg/sql/sqlstats/insights/integration/insights_test.go
+++ b/pkg/sql/sqlstats/insights/integration/insights_test.go
@@ -628,11 +628,22 @@ func TestInsightsIntegrationForContention(t *testing.T) {
 		}
 
 		if rowCount < 1 {
-			return fmt.Errorf("cluster_execution_insights did not return any rows")
+			var queryStatsMsg string
+			var contentionMean string
+			err = conn.DB.QueryRowContext(ctx, `
+			SELECT 
+				statistics->'execution_statistics'->'contentionTime'->> 'mean'
+			FROM crdb_internal.statement_statistics
+			WHERE metadata->>'query' like 'UPDATE t SET s =%'`).Scan(&contentionMean)
+			if err != nil {
+				queryStatsMsg = fmt.Sprintf("attempted to get contention statistics for 'UPDATE' query: %s", err.Error())
+			} else {
+				queryStatsMsg = fmt.Sprintf("contention mean for the 'UPDATE' query: %+v", contentionMean)
+			}
+			return fmt.Errorf("cluster_execution_insights did not return any rows - %s", queryStatsMsg)
 		}
-
 		return nil
-	}, 5*time.Second)
+	}, 10*time.Second)
 }
 
 // Testing that the index recommendation is included


### PR DESCRIPTION
Resolves: #109062

This PR bumps the timeout on TestInsightsIntegrationForContention.

Prior to this change, stressing after 10k runs and stressing with race for 1k runs all pass on GCE worker, the suspicion is that the CI slowness/load causes the the timeout to fail.

Some additional debug info was added to the error log - contention statistics for the query we expect to generate an insight. If this test continues to flake, we will know whether we are generating the contention we expect or if there is an issue with insights ingestion.

Release note: None