### PR TITLE
opt: fix ordinal column reference internal error

### DIFF
--- a/pkg/sql/opt/optbuilder/testdata/table_ref
+++ b/pkg/sql/opt/optbuilder/testdata/table_ref
@@ -1,0 +1,20 @@
+exec-ddl
+CREATE TABLE t (
+  k INT PRIMARY KEY,
+  j JSON,
+  INVERTED INDEX (j)
+)
+----
+
+build
+SELECT * FROM [53 AS foo]
+----
+project
+ ├── columns: k:1!null j:2
+ └── scan t [as=foo]
+      └── columns: k:1!null j:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+
+build
+SELECT * FROM [53(5) AS foo]
+----
+error (42703): column [5] does not exist

--- a/pkg/sql/opt/optbuilder/util.go
+++ b/pkg/sql/opt/optbuilder/util.go
@@ -694,7 +694,9 @@ func resolveNumericColumnRefs(tab cat.Table, columns []tree.ColumnID) (ordinals 
 		cnt := tab.ColumnCount()
 		for ord < cnt {
 			col := tab.Column(ord)
-			if col.ColID() == cat.StableID(c) && col.Visibility() != cat.Inaccessible {
+			// NOTE: Inverted columns cannot be referenced.
+			if col.Kind() != cat.Inverted && col.ColID() == cat.StableID(c) &&
+				col.Visibility() != cat.Inaccessible {
 				break
 			}
 			ord++


### PR DESCRIPTION
This commit fixes a bug that caused internal errors when referencing a
non-existent column by ordinal in a numeric table reference. The bug
only occurred for tables with at least one inverted index.

There is no release note because numeric table references are
undocumented.

Fixes #109399

Release note: None
