### PR TITLE
kv: prioritize errors in UpdateStateOnRemoteRetryableErr

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
@@ -2017,6 +2017,8 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 	// operates between keys "a" and "z" and expects a single split point at "b".
 	// See the call to setupMultipleRanges below.
 	storeKnobs.DisableLoadBasedSplitting = true
+	// Similarly, disable the merge queue to avoid unexpected merges.
+	storeKnobs.DisableMergeQueue = true
 
 	var refreshSpansCondenseFilter atomic.Value
 	s := serverutils.StartServerOnly(t,

--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
@@ -803,6 +803,16 @@ func (tc *TxnCoordSender) cleanupTxnLocked(ctx context.Context) {
 // expected to check the ID of the resulting transaction. If the TxnCoordSender
 // can still be used, it will have been prepared for a new epoch.
 func (tc *TxnCoordSender) handleRetryableErrLocked(ctx context.Context, pErr *kvpb.Error) error {
+	// If the transaction is already in a retryable state and the provided error
+	// does not have a higher priority than the existing error, return the
+	// existing error instead of attempting to handle the retryable error. This
+	// prevents the TxnCoordSender from losing information about a higher
+	// priority error.
+	if tc.mu.txnState == txnRetryableError &&
+		kvpb.ErrPriority(pErr.GoError()) <= kvpb.ErrPriority(tc.mu.storedRetryableErr) {
+		return tc.mu.storedRetryableErr
+	}
+
 	// If the error is a transaction retry error, update metrics to
 	// reflect the reason for the restart. More details about the
 	// different error types are documented above on the metaRestart
@@ -882,8 +892,8 @@ func (tc *TxnCoordSender) handleTransactionRetryWithProtoRefreshErrorErrLocked(
 	if retErr.PrevTxnAborted() {
 		// Remember that this txn is aborted to reject future requests.
 		tc.mu.txn.Status = roachpb.ABORTED
-		// Abort the old txn. The client is not supposed to use use this
-		// TxnCoordSender any more.
+		// Abort the old txn. The client is not supposed to use this
+		// TxnCoordSender anymore.
 		tc.interceptorAlloc.txnHeartbeater.abortTxnAsyncLocked(ctx)
 		tc.cleanupTxnLocked(ctx)
 		return
@@ -1303,7 +1313,7 @@ func (tc *TxnCoordSender) GetLeafTxnInputState(
 	}
 
 	// Also mark the TxnCoordSender as "active".  This prevents changing
-	// the priority after a leaf has been created. It als conservatively
+	// the priority after a leaf has been created. It also conservatively
 	// ensures that Active() returns true if there's maybe a command
 	// being executed concurrently by a leaf.
 	tc.mu.active = true

--- a/pkg/kv/txn_external_test.go
+++ b/pkg/kv/txn_external_test.go
@@ -958,6 +958,105 @@ func TestUpdateStateOnRemoteRetryableErr(t *testing.T) {
 	}
 }
 
+// TestUpdateStateOnRemoteRetryableErrErrorRanking tests that when multiple
+// errors are provided to UpdateStateOnRemoteRetryableError, the error with the
+// highest priority is used to update the transaction state and errors with
+// lower priority are unable to change the transaction state.
+func TestUpdateStateOnRemoteRetryableErrErrorRanking(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	s, _, db := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(ctx)
+
+	orderedErrs := []struct {
+		err         *kvpb.Error
+		expNewError bool // if we expect the txn's retryable error to change
+		expNewEpoch bool // if we expect the epoch to be bumped
+		expAborted  bool // if we expect the txn to be aborted
+	}{
+		// Step 1. The txn starts out with no retryable error and restarts when
+		// it hits an uncertainty error.
+		{
+			err:         kvpb.NewError(&kvpb.ReadWithinUncertaintyIntervalError{}),
+			expNewError: true,
+			expNewEpoch: true,
+			expAborted:  false,
+		},
+		// Step 2. The txn ignores any further retryable errors from the same
+		// epoch.
+		{
+			err:         kvpb.NewError(&kvpb.WriteTooOldError{}),
+			expNewError: false,
+			expNewEpoch: false,
+			expAborted:  false,
+		},
+		// Step 3. The txn moves to an aborted state when it hits a txn aborted
+		// error.
+		{
+			err:         kvpb.NewError(&kvpb.TransactionAbortedError{}),
+			expNewError: true,
+			expNewEpoch: false,
+			expAborted:  true,
+		},
+		// Step 4. The txn ignores any further retryable errors.
+		{
+			err:         kvpb.NewError(&kvpb.ReadWithinUncertaintyIntervalError{}),
+			expNewError: false,
+			expNewEpoch: false,
+			expAborted:  true,
+		},
+		// Step 5. The txn ignores any further txn aborted errors.
+		{
+			err:         kvpb.NewError(&kvpb.TransactionAbortedError{}),
+			expNewError: false,
+			expNewEpoch: false,
+			expAborted:  true,
+		},
+	}
+
+	// Unlike TestUpdateStateOnRemoteRetryableErr, use the same txn for all
+	// errors and observe how it changes as each error is consumed.
+	txn := db.NewTxn(ctx, "test")
+	tcs := txn.Sender()
+	txnProto := tcs.TestingCloneTxn()
+	for _, tc := range orderedErrs {
+		retryErrBefore := tcs.GetRetryableErr(ctx)
+		epochBefore := tcs.Epoch()
+
+		pErr := tc.err
+		pErr.SetTxn(txnProto)
+		err := txn.UpdateStateOnRemoteRetryableErr(ctx, pErr)
+		// Ensure what we got back is a TransactionRetryWithProtoRefreshError.
+		require.IsType(t, &kvpb.TransactionRetryWithProtoRefreshError{}, err)
+		// Ensure the same thing is stored on the TxnCoordSender as well.
+		retErr := tcs.GetRetryableErr(ctx)
+		require.Equal(t, retErr, err)
+		require.Equal(t, retErr.PrevTxnID, txnProto.ID)
+		require.True(t, retErr.TxnMustRestartFromBeginning())
+
+		// Assert that the transaction's state has changed as expected.
+		if tc.expNewError {
+			require.NotEqual(t, retErr, retryErrBefore)
+		} else {
+			require.Equal(t, retErr, retryErrBefore)
+		}
+		if tc.expNewEpoch {
+			require.Equal(t, epochBefore+1, tcs.Epoch())
+		} else {
+			require.Equal(t, epochBefore, tcs.Epoch())
+		}
+		if tc.expAborted {
+			require.Equal(t, roachpb.ABORTED, tcs.TxnStatus())
+			require.True(t, retErr.PrevTxnAborted())
+		} else {
+			require.Equal(t, roachpb.PENDING, tcs.TxnStatus())
+			require.False(t, retErr.PrevTxnAborted())
+		}
+	}
+}
+
 // TestUpdateRootWithLeafStateReadsBelowRefreshTimestamp ensures that if a leaf
 // transaction has performed reads below the root transaction's refreshed
 // timestamp an assertion error is returned. Note that the construction here


### PR DESCRIPTION
Fixes #108853.

This commit adds logic in TxnCoordSender.UpdateStateOnRemoteRetryableErr to prioritize retryable errors based on their ErrorPriority, such that lower priority errors cannot clobber state transitions performed by higher priority errors. This ensures that if a transaction is handed a transaction aborted error and then later a transaction retry error, the latter does not cause the transaction to exit an ABORTED state.

Release note (bug fix): Fixed a bug that could cause a transaction performing multiple parallel foreign key checks to return a `concurrent txn use detected` error.