### PR TITLE
concurrency: use generic lists in the lock table

### DIFF
--- a/pkg/kv/kvserver/concurrency/BUILD.bazel
+++ b/pkg/kv/kvserver/concurrency/BUILD.bazel
@@ -30,6 +30,7 @@ go_library(
         "//pkg/settings/cluster",
         "//pkg/storage/enginepb",
         "//pkg/util/buildutil",
+        "//pkg/util/container/list",
         "//pkg/util/hlc",
         "//pkg/util/humanizeutil",
         "//pkg/util/log",


### PR DESCRIPTION

Now that https://github.com/cockroachdb/cockroach/commit/cda4fa2f1e14678c82ee15deff9267ac5f49e4f4 has landed, we can make use of generic lists in a few places in the lock table.

Epic: none
Release note: None