### PR TITLE
asim: remove unnecessary details when printing time

### DIFF
--- a/pkg/kv/kvserver/asim/tests/output.go
+++ b/pkg/kv/kvserver/asim/tests/output.go
@@ -152,7 +152,7 @@ func (tr testResultsReport) String() string {
 			buf.WriteString(fmt.Sprintf("\t%v\n", output.eventGen))
 		}
 		if failed || tr.flags.Has(OutputInitialState) {
-			buf.WriteString(fmt.Sprintf("initial state at %s:\n", output.initialTime.String()))
+			buf.WriteString(fmt.Sprintf("initial state at %s:\n", output.initialTime.Format("2006-01-02 15:04:05")))
 			buf.WriteString(fmt.Sprintf("\t%v\n", output.initialState.PrettyPrint()))
 		}
 		if failed || tr.flags.Has(OutputTopology) {

--- a/pkg/kv/kvserver/asim/tests/testdata/rand/default_settings
+++ b/pkg/kv/kvserver/asim/tests/testdata/rand/default_settings
@@ -105,17 +105,17 @@ eval verbose=(initial_state)
 ----
 ----------------------------------
 sample1: start running
-initial state at 2022-03-21 11:00:00 +0000 UTC:
+initial state at 2022-03-21 11:00:00:
 	stores(3)=[s1n1=(replicas(10)),s2n2=(replicas(10)),s3n3=(replicas(10))]
 sample1: pass
 ----------------------------------
 sample2: start running
-initial state at 2022-03-21 11:00:00 +0000 UTC:
+initial state at 2022-03-21 11:00:00:
 	stores(3)=[s1n1=(replicas(10)),s2n2=(replicas(10)),s3n3=(replicas(10))]
 sample2: pass
 ----------------------------------
 sample3: start running
-initial state at 2022-03-21 11:00:00 +0000 UTC:
+initial state at 2022-03-21 11:00:00:
 	stores(3)=[s1n1=(replicas(10)),s2n2=(replicas(10)),s3n3=(replicas(10))]
 sample3: pass
 ----------------------------------
@@ -175,7 +175,7 @@ configurations generated using seed 3440579354231278675
 	basic ranges with placement_type=even, ranges=10, key_space=200000, replication_factor=3, bytes=0
 	basic load with rw_ratio=0.00, rate=0.00, skewed_access=false, min_block_size=1, max_block_size=1, min_key=1, max_key=200000
 	number of static events generated=0
-initial state at 2022-03-21 11:00:00 +0000 UTC:
+initial state at 2022-03-21 11:00:00:
 	stores(3)=[s1n1=(replicas(10)),s2n2=(replicas(10)),s3n3=(replicas(10))]
 sample1: pass
 ----------------------------------
@@ -185,7 +185,7 @@ configurations generated using seed 608747136543856411
 	basic ranges with placement_type=even, ranges=10, key_space=200000, replication_factor=3, bytes=0
 	basic load with rw_ratio=0.00, rate=0.00, skewed_access=false, min_block_size=1, max_block_size=1, min_key=1, max_key=200000
 	number of static events generated=0
-initial state at 2022-03-21 11:00:00 +0000 UTC:
+initial state at 2022-03-21 11:00:00:
 	stores(3)=[s1n1=(replicas(10)),s2n2=(replicas(10)),s3n3=(replicas(10))]
 sample2: pass
 ----------------------------------
@@ -195,7 +195,7 @@ configurations generated using seed 5571782338101878760
 	basic ranges with placement_type=even, ranges=10, key_space=200000, replication_factor=3, bytes=0
 	basic load with rw_ratio=0.00, rate=0.00, skewed_access=false, min_block_size=1, max_block_size=1, min_key=1, max_key=200000
 	number of static events generated=0
-initial state at 2022-03-21 11:00:00 +0000 UTC:
+initial state at 2022-03-21 11:00:00:
 	stores(3)=[s1n1=(replicas(10)),s2n2=(replicas(10)),s3n3=(replicas(10))]
 sample3: pass
 ----------------------------------
@@ -225,7 +225,7 @@ configurations generated using seed 3440579354231278675
 	basic ranges with placement_type=even, ranges=10, key_space=200000, replication_factor=3, bytes=0
 	basic load with rw_ratio=0.00, rate=0.00, skewed_access=false, min_block_size=1, max_block_size=1, min_key=1, max_key=200000
 	number of static events generated=0
-initial state at 2022-03-21 11:00:00 +0000 UTC:
+initial state at 2022-03-21 11:00:00:
 	stores(3)=[s1n1=(replicas(10)),s2n2=(replicas(10)),s3n3=(replicas(10))]
 topology:
 AU_EAST
@@ -239,7 +239,7 @@ configurations generated using seed 608747136543856411
 	basic ranges with placement_type=even, ranges=10, key_space=200000, replication_factor=3, bytes=0
 	basic load with rw_ratio=0.00, rate=0.00, skewed_access=false, min_block_size=1, max_block_size=1, min_key=1, max_key=200000
 	number of static events generated=0
-initial state at 2022-03-21 11:00:00 +0000 UTC:
+initial state at 2022-03-21 11:00:00:
 	stores(3)=[s1n1=(replicas(10)),s2n2=(replicas(10)),s3n3=(replicas(10))]
 topology:
 AU_EAST
@@ -253,7 +253,7 @@ configurations generated using seed 5571782338101878760
 	basic ranges with placement_type=even, ranges=10, key_space=200000, replication_factor=3, bytes=0
 	basic load with rw_ratio=0.00, rate=0.00, skewed_access=false, min_block_size=1, max_block_size=1, min_key=1, max_key=200000
 	number of static events generated=0
-initial state at 2022-03-21 11:00:00 +0000 UTC:
+initial state at 2022-03-21 11:00:00:
 	stores(3)=[s1n1=(replicas(10)),s2n2=(replicas(10)),s3n3=(replicas(10))]
 topology:
 AU_EAST

--- a/pkg/kv/kvserver/asim/tests/testdata/rand/rand_cluster
+++ b/pkg/kv/kvserver/asim/tests/testdata/rand/rand_cluster
@@ -66,7 +66,7 @@ configurations generated using seed 608747136543856411
 	basic ranges with placement_type=even, ranges=10, key_space=200000, replication_factor=3, bytes=0
 	basic load with rw_ratio=0.00, rate=0.00, skewed_access=false, min_block_size=1, max_block_size=1, min_key=1, max_key=200000
 	number of static events generated=0
-initial state at 2022-03-21 11:00:00 +0000 UTC:
+initial state at 2022-03-21 11:00:00:
 	stores(28)=[s1n1=(replicas(1)),s2n2=(replicas(1)),s3n3=(replicas(1)),s4n4=(replicas(1)),s5n5=(replicas(1)),s6n6=(replicas(1)),s7n7=(replicas(1)),s8n8=(replicas(1)),s9n9=(replicas(2)),s10n10=(replicas(1)),s11n11=(replicas(1)),s12n12=(replicas(1)),s13n13=(replicas(1)),s14n14=(replicas(1)),s15n15=(replicas(1)),s16n16=(replicas(1)),s17n17=(replicas(1)),s18n18=(replicas(1)),s19n19=(replicas(1)),s20n20=(replicas(1)),s21n21=(replicas(1)),s22n22=(replicas(2)),s23n23=(replicas(1)),s24n24=(replicas(1)),s25n25=(replicas(1)),s26n26=(replicas(1)),s27n27=(replicas(1)),s28n28=(replicas(1))]
 topology:
 EU
@@ -97,7 +97,7 @@ configurations generated using seed 1926012586526624009
 	basic ranges with placement_type=even, ranges=10, key_space=200000, replication_factor=3, bytes=0
 	basic load with rw_ratio=0.00, rate=0.00, skewed_access=false, min_block_size=1, max_block_size=1, min_key=1, max_key=200000
 	number of static events generated=0
-initial state at 2022-03-21 11:00:00 +0000 UTC:
+initial state at 2022-03-21 11:00:00:
 	stores(36)=[s1n1=(replicas(1)),s2n2=(replicas(1)),s3n3=(replicas(1)),s4n4=(replicas(1)),s5n5=(replicas(1)),s6n6=(replicas(1)),s7n7=(replicas(0)),s8n8=(replicas(1)),s9n9=(replicas(1)),s10n10=(replicas(1)),s11n11=(replicas(1)),s12n12=(replicas(1)),s13n13=(replicas(0)),s14n14=(replicas(1)),s15n15=(replicas(0)),s16n16=(replicas(0)),s17n17=(replicas(1)),s18n18=(replicas(1)),s19n19=(replicas(1)),s20n20=(replicas(1)),s21n21=(replicas(1)),s22n22=(replicas(1)),s23n23=(replicas(1)),s24n24=(replicas(1)),s25n25=(replicas(1)),s26n26=(replicas(1)),s27n27=(replicas(1)),s28n28=(replicas(0)),s29n29=(replicas(1)),s30n30=(replicas(1)),s31n31=(replicas(0)),s32n32=(replicas(1)),s33n33=(replicas(1)),s34n34=(replicas(1)),s35n35=(replicas(1)),s36n36=(replicas(1))]
 topology:
 EU
@@ -132,7 +132,7 @@ configurations generated using seed 3534334367214237261
 	basic ranges with placement_type=even, ranges=10, key_space=200000, replication_factor=3, bytes=0
 	basic load with rw_ratio=0.00, rate=0.00, skewed_access=false, min_block_size=1, max_block_size=1, min_key=1, max_key=200000
 	number of static events generated=0
-initial state at 2022-03-21 11:00:00 +0000 UTC:
+initial state at 2022-03-21 11:00:00:
 	stores(28)=[s1n1=(replicas(1)),s2n2=(replicas(1)),s3n3=(replicas(1)),s4n4=(replicas(1)),s5n5=(replicas(1)),s6n6=(replicas(1)),s7n7=(replicas(1)),s8n8=(replicas(1)),s9n9=(replicas(2)),s10n10=(replicas(1)),s11n11=(replicas(1)),s12n12=(replicas(1)),s13n13=(replicas(1)),s14n14=(replicas(1)),s15n15=(replicas(1)),s16n16=(replicas(1)),s17n17=(replicas(1)),s18n18=(replicas(1)),s19n19=(replicas(1)),s20n20=(replicas(1)),s21n21=(replicas(1)),s22n22=(replicas(2)),s23n23=(replicas(1)),s24n24=(replicas(1)),s25n25=(replicas(1)),s26n26=(replicas(1)),s27n27=(replicas(1)),s28n28=(replicas(1))]
 topology:
 EU

--- a/pkg/kv/kvserver/asim/tests/testdata/rand/rand_ranges
+++ b/pkg/kv/kvserver/asim/tests/testdata/rand/rand_ranges
@@ -176,7 +176,7 @@ configurations generated using seed 2643318057788968173
 	randomized ranges with placement_type=random, ranges=944, key_space=150098, replication_factor=1, bytes=0
 	basic load with rw_ratio=0.00, rate=0.00, skewed_access=false, min_block_size=1, max_block_size=1, min_key=1, max_key=200000
 	number of static events generated=0
-initial state at 2022-03-21 11:00:00 +0000 UTC:
+initial state at 2022-03-21 11:00:00:
 	stores(15)=[s1n1=(replicas(65)),s2n2=(replicas(64)),s3n3=(replicas(66)),s4n4=(replicas(63)),s5n5=(replicas(63)),s6n6=(replicas(63)),s7n7=(replicas(63)),s8n8=(replicas(62)),s9n9=(replicas(64)),s10n10=(replicas(64)),s11n11=(replicas(62)),s12n12=(replicas(63)),s13n13=(replicas(63)),s14n14=(replicas(64)),s15n15=(replicas(64))]
 topology:
 US

--- a/pkg/kv/kvserver/asim/tests/testdata/rand/weighted_rand
+++ b/pkg/kv/kvserver/asim/tests/testdata/rand/weighted_rand
@@ -25,17 +25,17 @@ generating events configurations using static option
 generating settings configurations using static option
 ----------------------------------
 sample1: start running
-initial state at 2022-03-21 11:00:00 +0000 UTC:
+initial state at 2022-03-21 11:00:00:
 	stores(3)=[s1n1=(replicas(563)),s2n1=(replicas(563)),s3n1=(replicas(563))]
 sample1: pass
 ----------------------------------
 sample2: start running
-initial state at 2022-03-21 11:00:00 +0000 UTC:
+initial state at 2022-03-21 11:00:00:
 	stores(3)=[s1n1=(replicas(299)),s2n1=(replicas(299)),s3n1=(replicas(299))]
 sample2: pass
 ----------------------------------
 sample3: start running
-initial state at 2022-03-21 11:00:00 +0000 UTC:
+initial state at 2022-03-21 11:00:00:
 	stores(3)=[s1n1=(replicas(521)),s2n1=(replicas(521)),s3n1=(replicas(521))]
 sample3: pass
 ----------------------------------
@@ -72,7 +72,7 @@ configurations generated using seed 5571782338101878760
 	weighted randomized ranges with placement_type=weighted_rand, weighted_rand=[0 0 0 0.3 0.3 0.4], ranges=563, key_space=160411, replication_factor=3, bytes=0
 	basic load with rw_ratio=0.00, rate=0.00, skewed_access=false, min_block_size=1, max_block_size=1, min_key=1, max_key=200000
 	number of static events generated=0
-initial state at 2022-03-21 11:00:00 +0000 UTC:
+initial state at 2022-03-21 11:00:00:
 	stores(6)=[s1n1=(replicas(132)),s2n1=(replicas(130)),s3n2=(replicas(131)),s4n2=(replicas(437)),s5n3=(replicas(428)),s6n3=(replicas(431))]
 sample1: pass
 ----------------------------------
@@ -82,7 +82,7 @@ configurations generated using seed 4299969443970870044
 	weighted randomized ranges with placement_type=weighted_rand, weighted_rand=[0 0 0 0.3 0.3 0.4], ranges=299, key_space=9542, replication_factor=3, bytes=0
 	basic load with rw_ratio=0.00, rate=0.00, skewed_access=false, min_block_size=1, max_block_size=1, min_key=1, max_key=200000
 	number of static events generated=0
-initial state at 2022-03-21 11:00:00 +0000 UTC:
+initial state at 2022-03-21 11:00:00:
 	stores(6)=[s1n1=(replicas(140)),s2n1=(replicas(136)),s3n2=(replicas(139)),s4n2=(replicas(169)),s5n3=(replicas(142)),s6n3=(replicas(171))]
 sample2: pass
 ----------------------------------
@@ -92,7 +92,7 @@ configurations generated using seed 4157513341729910236
 	weighted randomized ranges with placement_type=weighted_rand, weighted_rand=[0 0 0 0.3 0.3 0.4], ranges=521, key_space=82660, replication_factor=3, bytes=0
 	basic load with rw_ratio=0.00, rate=0.00, skewed_access=false, min_block_size=1, max_block_size=1, min_key=1, max_key=200000
 	number of static events generated=0
-initial state at 2022-03-21 11:00:00 +0000 UTC:
+initial state at 2022-03-21 11:00:00:
 	stores(6)=[s1n1=(replicas(180)),s2n1=(replicas(181)),s3n2=(replicas(183)),s4n2=(replicas(386)),s5n3=(replicas(247)),s6n3=(replicas(386))]
 sample3: pass
 ----------------------------------


### PR DESCRIPTION
Previously, the framework outputs the complete time.Time string including
unnecessary details related to UTC when printing initial state. This patch
formats the string to yyyy-mm-dd HH:mm:ss.

Epic: none
Release note: none