### PR TITLE
concurrency: correctly establish joint claims when a lock is released

### DIFF
--- a/pkg/kv/kvserver/concurrency/lock_table.go
+++ b/pkg/kv/kvserver/concurrency/lock_table.go
@@ -3208,9 +3208,9 @@ func (kl *keyLocks) requestDone(g *lockTableGuardImpl) (gc bool) {
 		// The first request in the queuedLockingRequests should always be an
 		// inactive, transactional locking request if the lock isn't held. That may
 		// no longer be true if the guy we removed above was serving this purpose;
-		// the call to maybeReleaseFirstLockingRequest should fix that. And if
-		// it wasn't, it'll be a no-op.
-		kl.maybeReleaseFirstLockingRequest()
+		// the call to maybeReleaseCompatibleLockingRequests should fix that. And if
+		// it wasn't serving that purpose, it'll be a no-op.
+		kl.maybeReleaseCompatibleLockingRequests()
 	}
 
 	if !doneRemoval {
@@ -3298,7 +3298,7 @@ func (kl *keyLocks) releaseWaitersOnKeyUnlocked() (gc bool) {
 		kl.removeReader(curr)
 	}
 
-	kl.maybeReleaseFirstLockingRequest()
+	kl.maybeReleaseCompatibleLockingRequests()
 
 	// We've already cleared waiting readers above. The lock can be released if
 	// there are no waiting locking requests, active or otherwise.
@@ -3309,28 +3309,35 @@ func (kl *keyLocks) releaseWaitersOnKeyUnlocked() (gc bool) {
 	return false
 }
 
-// maybeReleaseFirstLockingRequest goes through the list of locking requests waiting
-// in the receiver's wait queues and, if present and actively waiting,
-// releases the first locking request it finds. Releasing a locking request
-// entails marking it as inactive and nudging it with a call to notify().
+// maybeReleaseCompatibleLockingRequests goes through the list of locking
+// requests waiting in the receiver's wait queue and releases all requests from
+// the head of the queue that are compatible with each other. Releasing[1] a
+// locking request entails marking it as inactive and nudging it by calling
+// notify(). The released request(s) are said to have established a (possibly
+// joint) claim.
 //
-// Any non-transactional writers at the head of the queue are also released. The
-// function will no-op if the first locking request is already marked inactive
-// (i.e. there's no releasing to do).
+// Any non-transactional writers at the head of the queue are also released.
+//
+// [1] If the request is not actively waiting in the lock wait queue, it's a
+// noop for the request.
 //
 // REQUIRES: kl.mu is locked.
 // REQUIRES: the (receiver) lock must not be held.
 // REQUIRES: there should not be any waitingReaders in the lock's wait queues.
-func (kl *keyLocks) maybeReleaseFirstLockingRequest() {
+func (kl *keyLocks) maybeReleaseCompatibleLockingRequests() {
 	if kl.isLocked() {
-		panic("maybeReleaseFirstLockingRequest called when lock is held")
+		panic("maybeReleaseCompatibleLockingRequests called when lock is held")
 	}
 	if kl.waitingReaders.Len() != 0 {
 		panic("there cannot be waiting readers")
 	}
 
-	// The prefix of the queue that is non-transactional writers is done
-	// waiting.
+	// The prefix of the queue that is non-transactional writers is done waiting.
+	// As non-transactional writers have lock.Intent locking strength, they will
+	// be incompatible with any (possibly joint) claim that transactional
+	// request(s) will establish by the time we're done with this method. This
+	// means we only need special case handling for non-transactional requests
+	// just once -- for the ones that are at the head of the queue.
 	for e := kl.queuedLockingRequests.Front(); e != nil; {
 		qg := e.Value
 		g := qg.guard
@@ -3346,24 +3353,44 @@ func (kl *keyLocks) maybeReleaseFirstLockingRequest() {
 		return // no locking requests
 	}
 
-	// Check if the first locking request is active, and if it is, mark it as
-	// inactive. The call to doneActivelyWaitingAtLock should nudge it to pick up
-	// its scan from where it left off.
-	e := kl.queuedLockingRequests.Front()
-	qg := e.Value
-	g := qg.guard
-	if qg.active {
-		qg.active = false // mark as inactive
-		if g == kl.distinguishedWaiter {
-			// We're only clearing the distinguishedWaiter for now; a new one will be
-			// selected below in the call to informActiveWaiters.
-			kl.distinguishedWaiter = nil
+	// Mark all compatible locking requests as inactive. While doing so, we check
+	// if they were actively waiting at this key -- if they were, and we
+	// transitioned them to inactive, a call to doneActivelyWaitingAtLock should
+	// nudge the request to pick up its scan from where it left off.
+
+	var mode lock.Mode
+	for e := kl.queuedLockingRequests.Front(); e != nil; e = e.Next() {
+		qg := e.Value
+		g := qg.guard
+
+		if mode.Empty() {
+			mode = qg.mode
+		} else {
+			if lock.Conflicts(mode, qg.mode, &qg.guard.lt.settings.SV) {
+				break
+			}
+			// NB: Once we add support for UPDATE locking strength, this logic
+			// will need to accumulate the strongest lock mode seen so far. For
+			// example, consider the following:
+			// waitQueue: [Shared, Update, Shared, Update, Exclusive]
+			//
+			// We want to release the first 3 requests (as they're compatible with
+			// each other), not the first 4.
 		}
-		g.mu.Lock()
-		g.doneActivelyWaitingAtLock()
-		g.mu.Unlock()
+
+		if qg.active {
+			qg.active = false // mark as inactive
+			if g == kl.distinguishedWaiter {
+				// We're only clearing the distinguishedWaiter for now; a new one will be
+				// selected below in the call to informActiveWaiters.
+				kl.distinguishedWaiter = nil
+			}
+			g.mu.Lock()
+			g.doneActivelyWaitingAtLock()
+			g.mu.Unlock()
+		}
+		// Else the waiter is already inactive.
 	}
-	// Else the waiter is already inactive.
 
 	// Tell the active waiters who they are waiting for.
 	kl.informActiveWaiters()

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/shared_locks
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/shared_locks
@@ -13,6 +13,9 @@ new-txn txn=txn3 ts=10 epoch=0 seq=0
 new-txn txn=txn4 ts=10 epoch=0 seq=0
 ----
 
+new-txn txn=txn5 ts=10 epoch=0 seq=0
+----
+
 new-request r=req1 txn=txn1 ts=10 spans=shared@a
 ----
 
@@ -263,33 +266,638 @@ num=1
     active: false req: 12, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000004
 
 
+# ------------------------------------------------------------------------------
+# Basic test for joint claims -- ensure all shared lock requests waiting on an
+# exclusive lock to be released are able to acquire a joint claim when the
+# exclusive lock is released.
+# ------------------------------------------------------------------------------
+
+acquire r=req12 k=a durability=u strength=exclusive
+----
+num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000004 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
+
+
+new-request r=req13 txn=txn1 ts=10 spans=shared@a
+----
+
+scan r=req13
+----
+start-waiting: true
+
+new-request r=req14 txn=txn2 ts=10 spans=shared@a
+----
+
+scan r=req14
+----
+start-waiting: true
+
+new-request r=req15 txn=txn3 ts=10 spans=shared@a
+----
+
+scan r=req15
+----
+start-waiting: true
+
+print
+----
+num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000004 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
+   queued locking requests:
+    active: true req: 13, strength: Shared, txn: 00000000-0000-0000-0000-000000000001
+    active: true req: 14, strength: Shared, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 15, strength: Shared, txn: 00000000-0000-0000-0000-000000000003
+   distinguished req: 13
+
+release txn=txn4 span=a
+----
+num=1
+ lock: "a"
+   queued locking requests:
+    active: false req: 13, strength: Shared, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 14, strength: Shared, txn: 00000000-0000-0000-0000-000000000002
+    active: false req: 15, strength: Shared, txn: 00000000-0000-0000-0000-000000000003
+
+# ------------------------------------------------------------------------------
+# Ensure only the head of the queue that is compatible with each other is able
+# to acquire a joint claim when an exclusive lock is released. Setup:
+# lock holder: X, wait queue: (S, S, X, S).
+# ------------------------------------------------------------------------------
+
+clear
+----
+num=0
+
+new-request r=req16 txn=txn5 ts=10 spans=exclusive@a
+----
+
+scan r=req16
+----
+start-waiting: false
+
+acquire r=req16 k=a durability=u strength=exclusive
+----
+num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000005 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
+
+new-request r=req17 txn=txn1 ts=10 spans=shared@a
+----
+
+scan r=req17
+----
+start-waiting: true
+
+new-request r=req18 txn=txn2 ts=10 spans=shared@a
+----
+
+scan r=req18
+----
+start-waiting: true
+
+new-request r=req19 txn=txn3 ts=10 spans=exclusive@a
+----
+
+scan r=req19
+----
+start-waiting: true
+
+new-request r=req20 txn=txn1 ts=10 spans=shared@a
+----
+
+scan r=req20
+----
+start-waiting: true
+
+print
+----
+num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000005 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
+   queued locking requests:
+    active: true req: 17, strength: Shared, txn: 00000000-0000-0000-0000-000000000001
+    active: true req: 18, strength: Shared, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 19, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000003
+    active: true req: 20, strength: Shared, txn: 00000000-0000-0000-0000-000000000001
+   distinguished req: 17
+
+# Setup complete. Release the exclusive lock and ensure only req17 and req18
+# establish a joint claim. In particular, req20 should be sitting tight.
+release txn=txn5 span=a
+----
+num=1
+ lock: "a"
+   queued locking requests:
+    active: false req: 17, strength: Shared, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 18, strength: Shared, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 19, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000003
+    active: true req: 20, strength: Shared, txn: 00000000-0000-0000-0000-000000000001
+   distinguished req: 19
+
+# Ensure nothing changes with req20 once req18 acquires the lock. This is
+# because they belong to different transactions (txn1 and txn2, respectively).
+acquire r=req18 k=a durability=u strength=shared
+----
+num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Shared seq: 0)]
+   queued locking requests:
+    active: false req: 17, strength: Shared, txn: 00000000-0000-0000-0000-000000000001
+    active: true req: 19, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000003
+    active: true req: 20, strength: Shared, txn: 00000000-0000-0000-0000-000000000001
+   distinguished req: 19
+
+# However, once req17 acquires the shared lock, req20 should be allowed to
+# proceed -- this is because they both belong to the same transaction (txn1).
+acquire r=req17 k=a durability=u strength=shared
+----
+num=1
+ lock: "a"
+  holders: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Shared seq: 0)]
+           txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Shared seq: 0)]
+   queued locking requests:
+    active: true req: 19, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000003
+   distinguished req: 19
+
+# req20 should be able to come back around and acquire a shared lock for itself.
+# This doesn't change anything though, as the lock was already held by txn1.
+acquire r=req20 k=a durability=u strength=shared
+----
+num=1
+ lock: "a"
+  holders: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Shared seq: 0)]
+           txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Shared seq: 0)]
+   queued locking requests:
+    active: true req: 19, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000003
+   distinguished req: 19
+
+
+# ------------------------------------------------------------------------------
+# Similar to the test above, but this time with a non-transactional writer
+# instead of the exclusive lock. To make things a bit more interesting, we also
+# add a few non-transactional writers at the head of the queue.
+# lock holder: X, wait queue: (NTW, NTW, NTW, S, S, NTW, S).
+# ------------------------------------------------------------------------------
+
+clear
+----
+num=0
+
+new-request r=req21 txn=txn5 ts=10 spans=exclusive@a
+----
+
+scan r=req21
+----
+start-waiting: false
+
+acquire r=req21 k=a durability=u strength=exclusive
+----
+num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000005 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
+
+new-request r=req22 txn=none ts=10 spans=intent@a
+----
+
+scan r=req22
+----
+start-waiting: true
+
+new-request r=req23 txn=none ts=10 spans=intent@a
+----
+
+scan r=req23
+----
+start-waiting: true
+
+new-request r=req24 txn=none ts=10 spans=intent@a
+----
+
+scan r=req24
+----
+start-waiting: true
+
+new-request r=req25 txn=txn1 ts=10 spans=shared@a
+----
+
+scan r=req25
+----
+start-waiting: true
+
+new-request r=req26 txn=txn2 ts=10 spans=shared@a
+----
+
+scan r=req26
+----
+start-waiting: true
+
+new-request r=req27 txn=none ts=10 spans=intent@a
+----
+
+scan r=req27
+----
+start-waiting: true
+
+new-request r=req28 txn=txn3 ts=10 spans=shared@a
+----
+
+scan r=req28
+----
+start-waiting: true
+
+
+print
+----
+num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000005 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
+   queued locking requests:
+    active: true req: 22, strength: Intent, txn: none
+    active: true req: 23, strength: Intent, txn: none
+    active: true req: 24, strength: Intent, txn: none
+    active: true req: 25, strength: Shared, txn: 00000000-0000-0000-0000-000000000001
+    active: true req: 26, strength: Shared, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 27, strength: Intent, txn: none
+    active: true req: 28, strength: Shared, txn: 00000000-0000-0000-0000-000000000003
+   distinguished req: 22
+
+# We're done setting up. Let's release the lock.
+
+release txn=txn5 span=a
+----
+num=1
+ lock: "a"
+   queued locking requests:
+    active: false req: 25, strength: Shared, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 26, strength: Shared, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 27, strength: Intent, txn: none
+    active: true req: 28, strength: Shared, txn: 00000000-0000-0000-0000-000000000003
+   distinguished req: 27
+
+# ------------------------------------------------------------------------------
+# Ensure a shared lock request doesn't need to wait if its transaction already
+# holds the lock with strength exclusive. To make things interesting, we make
+# the lock's wait queue non-empty.
+# ------------------------------------------------------------------------------
+
+clear
+----
+num=0
+
+new-request r=req29 txn=txn5 ts=10 spans=exclusive@a
+----
+
+scan r=req29
+----
+start-waiting: false
+
+acquire r=req29 k=a durability=u strength=exclusive
+----
+num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000005 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
+
+new-request r=req30 txn=txn1 ts=10 spans=shared@a
+----
+
+scan r=req30
+----
+start-waiting: true
+
+new-request r=req31 txn=txn2 ts=10 spans=exclusive@a
+----
+
+scan r=req31
+----
+start-waiting: true
+
+print
+----
+num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000005 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
+   queued locking requests:
+    active: true req: 30, strength: Shared, txn: 00000000-0000-0000-0000-000000000001
+    active: true req: 31, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
+   distinguished req: 30
+
+# Shared lock request from txn5 (which already holds the lock on key "a")
+new-request r=req32 txn=txn5 ts=10 spans=shared@a
+----
+
+scan r=req32
+----
+start-waiting: false
+
+acquire r=req32 k=a durability=u strength=shared
+----
+num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000005 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0), (str: Shared seq: 0)]
+   queued locking requests:
+    active: true req: 30, strength: Shared, txn: 00000000-0000-0000-0000-000000000001
+    active: true req: 31, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
+   distinguished req: 30
+
+# ------------------------------------------------------------------------------
+# Add a test where one of the waiters to be released is already an inactive
+# waiter. We should no-op at that waiter and continue on with our scan, stopping
+# when an incompatibility is found (or the queue is exhausted). We test the
+# queue is exhausted case.
+# ------------------------------------------------------------------------------
+
+dequeue r=req31
+----
+num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000005 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0), (str: Shared seq: 0)]
+   queued locking requests:
+    active: true req: 30, strength: Shared, txn: 00000000-0000-0000-0000-000000000001
+   distinguished req: 30
+
+release txn=txn5 span=a
+----
+num=1
+ lock: "a"
+   queued locking requests:
+    active: false req: 30, strength: Shared, txn: 00000000-0000-0000-0000-000000000001
+
+new-request r=req33 txn=txn5 ts=10 spans=exclusive@a
+----
+
+scan r=req33
+----
+start-waiting: true
+
+# Req3 was supposed to wait, but we'll acquire the lock here to get where our
+# test setup wants to get.
+acquire r=req33 k=a durability=u strength=exclusive
+----
+num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000005 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
+   queued locking requests:
+    active: false req: 30, strength: Shared, txn: 00000000-0000-0000-0000-000000000001
+
+new-request r=req34 txn=txn2 ts=10 spans=shared@a
+----
+
+scan r=req34
+----
+start-waiting: true
+
+print
+----
+num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000005 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
+   queued locking requests:
+    active: false req: 30, strength: Shared, txn: 00000000-0000-0000-0000-000000000001
+    active: true req: 34, strength: Shared, txn: 00000000-0000-0000-0000-000000000002
+   distinguished req: 34
+
+release txn=txn5 span=a
+----
+num=1
+ lock: "a"
+   queued locking requests:
+    active: false req: 30, strength: Shared, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 34, strength: Shared, txn: 00000000-0000-0000-0000-000000000002
+
+# ------------------------------------------------------------------------------
+# Test that if shared locks are waiting behind an exclusive lock in the wait
+# queue, and the lock is released, only the exclusive lock request is allowed to
+# proceed. Setup:
+# lock holder: X, wait queue: (X, S, S)
+# ------------------------------------------------------------------------------
+
+clear
+----
+num=0
+
+new-request r=req35 txn=txn5 ts=10 spans=exclusive@a
+----
+
+scan r=req35
+----
+start-waiting: false
+
+acquire r=req35 k=a durability=u strength=exclusive
+----
+num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000005 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
+
+new-request r=req36 txn=txn1 ts=10 spans=exclusive@a
+----
+
+scan r=req36
+----
+start-waiting: true
+
+new-request r=req37 txn=txn2 ts=10 spans=shared@a
+----
+
+scan r=req37
+----
+start-waiting: true
+
+new-request r=req38 txn=txn3 ts=10 spans=shared@a
+----
+
+scan r=req38
+----
+start-waiting: true
+
+new-request r=req39 txn=txn4 ts=10 spans=exclusive@a
+----
+
+scan r=req39
+----
+start-waiting: true
+
+print
+----
+num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000005 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
+   queued locking requests:
+    active: true req: 36, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
+    active: true req: 37, strength: Shared, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 38, strength: Shared, txn: 00000000-0000-0000-0000-000000000003
+    active: true req: 39, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000004
+   distinguished req: 36
+
+# Release the lock. Only req36 should be allowed to proceed.
+release txn=txn5 span=a
+----
+num=1
+ lock: "a"
+   queued locking requests:
+    active: false req: 36, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
+    active: true req: 37, strength: Shared, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 38, strength: Shared, txn: 00000000-0000-0000-0000-000000000003
+    active: true req: 39, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000004
+   distinguished req: 37
+
+# ------------------------------------------------------------------------------
+# Ensure that if a exclusive locking request (req36) exits the lock table
+# without acquiring the lock, compatible requests in the wait queue (req37 and
+# req38) are nudged to establish a claim and proceed. Note that only the
+# requests that are compatible should be able to establish a claim -- this
+# excludes req39.
+# ------------------------------------------------------------------------------
+dequeue r=req36
+----
+num=1
+ lock: "a"
+   queued locking requests:
+    active: false req: 37, strength: Shared, txn: 00000000-0000-0000-0000-000000000002
+    active: false req: 38, strength: Shared, txn: 00000000-0000-0000-0000-000000000003
+    active: true req: 39, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000004
+   distinguished req: 39
+
+# ------------------------------------------------------------------------------
+# Same set up as above, but this time, have the exclusive locking request
+# acquire the lock (instead of exiting the lock table without acquiring it).
+# The shared lock requests waiting behind it should continue to sit tight.
+# ------------------------------------------------------------------------------
+
+clear
+----
+num=0
+
+new-request r=req40 txn=txn5 ts=10 spans=exclusive@a
+----
+
+scan r=req40
+----
+start-waiting: false
+
+acquire r=req40 k=a durability=u strength=exclusive
+----
+num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000005 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
+
+new-request r=req41 txn=txn1 ts=10 spans=exclusive@a
+----
+
+scan r=req41
+----
+start-waiting: true
+
+new-request r=req42 txn=txn2 ts=10 spans=shared@a
+----
+
+scan r=req42
+----
+start-waiting: true
+
+new-request r=req43 txn=txn3 ts=10 spans=shared@a
+----
+
+scan r=req43
+----
+start-waiting: true
+
+
+print
+----
+num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000005 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
+   queued locking requests:
+    active: true req: 41, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
+    active: true req: 42, strength: Shared, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 43, strength: Shared, txn: 00000000-0000-0000-0000-000000000003
+   distinguished req: 41
+
+# Release the lock. Only req41 should be allowed to proceed.
+release txn=txn5 span=a
+----
+num=1
+ lock: "a"
+   queued locking requests:
+    active: false req: 41, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
+    active: true req: 42, strength: Shared, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 43, strength: Shared, txn: 00000000-0000-0000-0000-000000000003
+   distinguished req: 42
+
+# This time, we'll actually let the exclusive locking request (req41) acquire
+# the lock. Nothing should change with req42 and req43 -- they should sit tight.
+acquire r=req41 k=a durability=u strength=exclusive
+----
+num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
+   queued locking requests:
+    active: true req: 42, strength: Shared, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 43, strength: Shared, txn: 00000000-0000-0000-0000-000000000003
+   distinguished req: 42
+
+# ------------------------------------------------------------------------------
+# A few more tests of requests exiting the lock table without acquiring locks.
+# Setup:
+# lock holder: _, wait queue(S, S, X)
+# If one of the shared locking requests exits the wait queue without acquiring
+# the lock, the exclusive locking request should continue to sit tight.
+# ------------------------------------------------------------------------------
+
+new-request r=req44 txn=txn4 ts=10 spans=exclusive@a
+----
+
+scan r=req44
+----
+start-waiting: true
+
+release txn=txn1 span=a
+----
+num=1
+ lock: "a"
+   queued locking requests:
+    active: false req: 42, strength: Shared, txn: 00000000-0000-0000-0000-000000000002
+    active: false req: 43, strength: Shared, txn: 00000000-0000-0000-0000-000000000003
+    active: true req: 44, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000004
+   distinguished req: 44
+
+# Have req42 exit the lock table without acquiring its shared lock. Nothing
+# should change with req44.
+dequeue r=req42
+----
+num=1
+ lock: "a"
+   queued locking requests:
+    active: false req: 43, strength: Shared, txn: 00000000-0000-0000-0000-000000000003
+    active: true req: 44, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000004
+   distinguished req: 44
+
+# However, once req43 exits without acquiring its shared lock, req44 should be
+# allowed to proceed.
+dequeue r=req43
+----
+num=1
+ lock: "a"
+   queued locking requests:
+    active: false req: 44, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000004
+
+
 # TODO(arul): (non-exhaustive list) of shared lock state transitions that aren't
 # currently supported (and we need to add support for):
 #
-# 1. - lock holder: exclusive, wait queue: (shared, shared, shared).
-# Once the exclusive lock is released, all the shared locking requests should
-# be able to acquire a joint claim.
-# 2. - lock holder: exclusive, wait queue: (shared, shared, shared, exclusive, shared).
-# Once the exclusive lock is released, only the head of the queue that is
-# compatible (the first three shared lock requests) should be able to acquire
-# a joint claim.
-# 3. - lock holder: none, wait queue: (shared, shared), some other shared locking
+# 1. - lock holder: none, wait queue: (shared, shared), some other shared locking
 # request acquires a joint claim by inserting itself at the start of the queue.
 # Same for a shared locking request that enters the middle of the queue.
-# 4. - lock holder: none, wait queue: (shared, shared), some other exclusive
+#
+# 2. - lock holder: none, wait queue: (shared, shared), some other exclusive
 # locking request inserts itself at the front of the queue (breaking the
 # reservation). Ditto for a partial break, where the exclusive locking request
 # inserts itself in the middle of the queue.
-# 5. - lock holder: none, wait queue: (exclusive, shared, shared), exclusive
-# acquires lock and exits queue. Another for exclusive exiting the queue without
-# acquiring the lock.
-# 6. Lock promotion cases where the lock is held with strength shared, and
+#
+# 3. Lock promotion cases where the lock is held with strength shared, and
 # there's another request (from the same txn) with lock strength exclusive
-# that's trying to acquire the lock further back in the wait queue.
-# 7. Cases where a lock is held with strength exclusive, and there's another
-# request from the same transaction trying to acquire the lock with strength
-# shared. To make things interesting, the lock table's wait queue should be
-# non-empty.
-# 8. Cases where the waiter is a non-transactional writer. For example, a state
-# transition that uncorks a number of non-transactional writer from the head of
-# the queue.
+# that's trying to acquire the lock further back in the wait queue. We'll be
+# disallowing these in the short term, so this case might not be tested for a
+# while.


### PR DESCRIPTION
This patch closes the loop on joint claims. In particular, it correctly
handles which locking requests are allowed to proceed when a lock is
released. We also handle the case where a request that holds a claim
(but not the lock) drops out without acquiring the lock. The handling
itself is simple -- the head of the locking requests wait queue that is
compatible with each other is allowed to proceed. The compatible
request(s) are said to have established a (possibly joint) claim.

Most of this patch is beefing up testing. Some of the testing additions
here weren't strictly related to the code change.

Closes https://github.com/cockroachdb/cockroach/issues/102272

Epic: none

Release note: None