### PR TITLE
builtins: avoid overflow in sum square difference calculation

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/distsql_agg
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_agg
@@ -738,3 +738,60 @@ SELECT 1 FROM t108901 WHERE
 statement ok
 RESET testing_optimizer_random_seed;
 RESET testing_optimizer_disable_rule_probability;
+
+subtest 109334_regr
+
+# Regression test for #109334
+
+statement ok
+CREATE TABLE IF NOT EXISTS t109334 AS
+        SELECT
+                1.7976931348623157e+308::FLOAT8 AS _float8,
+                1::FLOAT8 AS grouping_col
+        FROM
+                generate_series(1, 1) AS g;
+
+statement ok
+ALTER TABLE t109334 SPLIT AT VALUES (1), (10);
+
+statement ok
+ALTER TABLE t109334 SCATTER;
+
+# Check that var_pop applied to a single value never overflows.
+query FFI
+SELECT
+        _float8,
+        var_pop(_float8::FLOAT8)::FLOAT8,
+        count(*)
+FROM
+        t109334
+GROUP BY
+        _float8;
+----
+1.7976931348623157e+308  0  1
+
+statement ok
+INSERT INTO t109334 SELECT g*1.23456789, 2::FLOAT8 FROM generate_series(1, 50) AS g;
+
+statement ok
+ALTER TABLE t109334 SPLIT AT VALUES (1), (10), (100), (100000), (1000000), (10000000000), (100000000000);
+
+statement ok
+ALTER TABLE t109334 SCATTER;
+
+# Check that applying operations in the calculation of single pass squared
+# difference in a different order results in the same value as before,
+# though this may not be the case for all data sets. Slight precision
+# differences are expected in floating point calculations due to different
+# orders of evaluation.
+query FI rowsort
+SELECT
+        var_pop(_float8::FLOAT8)::FLOAT8,
+        count(*)
+FROM
+        t109334
+GROUP BY
+        grouping_col;
+----
+317.40587747271735  50
+0                   1

--- a/pkg/sql/sem/builtins/aggregate_builtins.go
+++ b/pkg/sql/sem/builtins/aggregate_builtins.go
@@ -3910,7 +3910,7 @@ func (a *floatSumSqrDiffsAggregate) Add(
 	// considering that we are losing 11 bits on a 52+-bit operation and
 	// that users dealing with floating points should be aware
 	// of floating-point imprecision.
-	a.sqrDiff += sqrDiff + delta*delta*float64(count)*float64(a.count)/float64(totalCount)
+	a.sqrDiff += sqrDiff + float64(count)*float64(a.count)*(delta/float64(totalCount))*delta
 	a.count = totalCount
 	a.mean += delta * float64(count) / float64(a.count)
 	return nil


### PR DESCRIPTION
For very large floating point values, the var_pop aggregate function may easily overflow when calculating the intermediate result of the sum square difference on the very first row processed in the final aggregation step of a distributed query.

The calculation is:
```
a.sqrDiff += sqrDiff + delta*delta*float64(count)*float64(a.count)/float64(totalCount)
```

As there have been no results computed yet, the current mean value is zero, and delta, the difference between the input and the mean, is the input value itself. When this is a large value, greater than 1.340781e+154, the calculation `delta*delta` yields `+Inf` and the result remains `+Inf` even though the value is later multiplied by a count of zero (the running count of number of values).

The solution is to change the order of operations to multiply the counts first, and divide delta directly by totalCount, to avoid overflow in as many cases as possible.

Note, this fixes the single-row case, but does not fix cases where the calculation of the sum, which is an input to `floatSumSqrDiffsAggregate.Add`, has overflowed due to summing many large values.

Epic: none
Fixes: #109334

Release note: None