### PR TITLE
schemafeed: Make fast path check more efficient

### DIFF
--- a/pkg/ccl/changefeedccl/kvfeed/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/kvfeed/BUILD.bazel
@@ -33,6 +33,7 @@ go_library(
         "//pkg/util/retry",
         "//pkg/util/span",
         "//pkg/util/timeutil",
+        "//pkg/util/tracing",
         "@com_github_cockroachdb_errors//:errors",
     ],
 )

--- a/pkg/ccl/changefeedccl/kvfeed/kv_feed.go
+++ b/pkg/ccl/changefeedccl/kvfeed/kv_feed.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/span"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
 )
 
@@ -575,6 +576,11 @@ func copyFromSourceToDestUntilTableEvent(
 	endTime hlc.Timestamp,
 	knobs TestingKnobs,
 ) error {
+	// Strip out tracing span from context (if any).
+	// This code runs on a hot path (event loop) -- even checks for
+	// log.ExpensiveLogEnabled are more expensive when we have real span.
+	ctx = tracing.ContextWithSpan(ctx, nil /* span */)
+
 	var (
 		scanBoundary errBoundaryReached
 		endTimeIsSet = !endTime.IsEmpty()

--- a/pkg/ccl/changefeedccl/schemafeed/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/schemafeed/BUILD.bazel
@@ -32,7 +32,6 @@ go_library(
         "//pkg/util/encoding",
         "//pkg/util/hlc",
         "//pkg/util/intsets",
-        "//pkg/util/iterutil",
         "//pkg/util/log",
         "//pkg/util/metric",
         "//pkg/util/syncutil",


### PR DESCRIPTION
`pauseOrResumePolling` is invoked on hot path.  This PR improves the efficiency of this method by removing some of the overhead observed during load testing benchmark (cdc/tpcc-1000).

First, avoid using `targets.EachTableID` iterator method. Iteration over map is more expensive (and shows up in profiles). Instead, simply memoize the list of table IDs and use regular for loop to iterate.

Second, `pauseOrResumePolling` utilized two maps
to store tableID to table descriptor version mapping for schema locked tables.  These tables were compared for equality on every call.  That's not necessary.  As soon as any discrepancy between "high water" versions and "current" versions are discovered, schema feed falls back to "slow" path.  Therefore, it is sufficient to simply store the state for 1 set of descriptors at highwater; Use a simple loop to verify if "current" descriptors still match versions and are locked.

Finally, it is not necessary to reload highwater descriptors on each call -- simly doing this when highwater advances is sufficient.

Epic: None

Release note: None