### PR TITLE
optbuilder: bypass inverted columns when resolving columns by StableID

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/inverted_index
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_index
@@ -2044,3 +2044,19 @@ SELECT primes FROM cb WHERE primes && numbers ORDER BY primes
 statement ok
 CREATE TABLE t84569 (name_col NAME NOT NULL, INVERTED INDEX (name_col gin_trgm_ops));
 INSERT INTO t84569 (name_col) VALUES ('X'::NAME)
+
+# Regression test for #109399
+
+statement ok
+CREATE TABLE t109399 (name_col NAME NOT NULL, INVERTED INDEX (name_col gin_trgm_ops));
+INSERT INTO t109399 (name_col) VALUES ('X'::NAME);
+
+query T
+SELECT * FROM [124(1) AS foo(bar)];
+----
+X
+
+# The presence of an inverted index in a table should not cause selection of
+# an undefined column to cause an internal error.
+statement error pq: column \[3\] does not exist
+SELECT * FROM [124(3) AS foo(bar)];

--- a/pkg/sql/opt/optbuilder/util.go
+++ b/pkg/sql/opt/optbuilder/util.go
@@ -694,6 +694,13 @@ func resolveNumericColumnRefs(tab cat.Table, columns []tree.ColumnID) (ordinals 
 		cnt := tab.ColumnCount()
 		for ord < cnt {
 			col := tab.Column(ord)
+			if col.Kind() == cat.Inverted {
+				// An implicit inverted column refers to another column in the table
+				// with a Kind of `cat.Ordinary`. The inverted column should never be
+				// matched directly.
+				ord++
+				continue
+			}
 			if col.ColID() == cat.StableID(c) && col.Visibility() != cat.Inaccessible {
 				break
 			}


### PR DESCRIPTION
When resolving columns for tableID(columnID) SQL syntax, where tableID
and columnID are integers, if columnID represents a nonexistent column
in the table, and the table has an inverted index, the result is an
internal error. This is because `resolveNumericColumnRefs` loops through
all column kinds in the `cat.Table` definition, calling `Column.ColID`  
on each one. That function panics if the column kind is `Inverted`.     
Inverted columns are special implicit columns that represent the keys of                        
inverted indexes and don't directly represent table columns, though they                
may refer to them.

The solution is to skip over implicit inverted columns in function
`resolveNumericColumnRefs`.

This is no release note because this SQL syntax is undocumented.

Epic: none 
Fixes: #109399

Release note: None 