### PR TITLE
storage: ignore non-intent locks in `intentInterleavingIter`

### DIFF
--- a/pkg/storage/intent_interleaving_iter_test.go
+++ b/pkg/storage/intent_interleaving_iter_test.go
@@ -358,6 +358,10 @@ func TestIntentInterleavingIter(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
+				// maxIntentItersBeforeSeek defaults to a metamorphic value in
+				// tests. We set it to a fixed value here to make iteration
+				// behavior deterministic.
+				iiter.(*intentInterleavingIter).maxIntentItersBeforeSeek = 6
 				iter := maybeWrapInUnsafeIter(iiter)
 				var b strings.Builder
 				defer iter.Close()

--- a/pkg/storage/testdata/intent_interleaving_iter/basic
+++ b/pkg/storage/testdata/intent_interleaving_iter/basic
@@ -1,8 +1,16 @@
-# Separated intents, and one inline meta.
+# Separated intents, and one inline meta. Also some locks to ignore.
 define
 locks
-meta k=a ts=20 txn=1
-meta k=b ts=30 txn=2
+meta k=a str=intent ts=20 txn=1
+meta k=a str=shared       txn=1
+meta k=b str=intent ts=30 txn=2
+meta k=b str=exclusive    txn=2
+meta k=d str=shared       txn=1
+meta k=d str=shared       txn=2
+meta k=d str=shared       txn=3
+meta k=d str=shared       txn=4
+meta k=d str=shared       txn=5
+meta k=d str=shared       txn=6
 mvcc
 value k=a ts=20 v=a20
 value k=a ts=10 v=a10
@@ -64,7 +72,7 @@ next: output: value k=b ts=30.000000000,0 v=b30
 next: output: meta k=c
 next: output: value k=d ts=25.000000000,0 v=d25
 next: output: .
-stats: (interface (dir, seek, step): (fwd, 2, 9), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 2, 7), (rev, 0, 0))
+stats: (interface (dir, seek, step): (fwd, 2, 19), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 2, 15), (rev, 0, 0))
 prev: output: value k=d ts=25.000000000,0 v=d25
 prev: output: meta k=c
 prev: output: value k=b ts=30.000000000,0 v=b30
@@ -73,16 +81,16 @@ prev: output: value k=a ts=10.000000000,0 v=a10
 prev: output: value k=a ts=20.000000000,0 v=a20
 prev: output: meta k=a ts=20.000000000,0 txn=1
 prev: output: .
-stats: (interface (dir, seek, step): (fwd, 2, 9), (rev, 0, 11)), (internal (dir, seek, step): (fwd, 2, 7), (rev, 2, 7))
+stats: (interface (dir, seek, step): (fwd, 2, 19), (rev, 0, 19)), (internal (dir, seek, step): (fwd, 2, 15), (rev, 2, 15))
 seek-ge "b"/0,0: output: meta k=b ts=30.000000000,0 txn=2
-stats: (interface (dir, seek, step): (fwd, 4, 9), (rev, 0, 11)), (internal (dir, seek, step): (fwd, 4, 7), (rev, 2, 7))
+stats: (interface (dir, seek, step): (fwd, 4, 19), (rev, 0, 19)), (internal (dir, seek, step): (fwd, 4, 15), (rev, 2, 15))
 next: output: value k=b ts=30.000000000,0 v=b30
 next: output: meta k=c
 prev: output: value k=b ts=30.000000000,0 v=b30
 prev: output: meta k=b ts=30.000000000,0 txn=2
 prev: output: value k=a ts=10.000000000,0 v=a10
 seek-lt "b"/0,0: output: value k=a ts=10.000000000,0 v=a10
-stats: (interface (dir, seek, step): (fwd, 4, 11), (rev, 2, 16)), (internal (dir, seek, step): (fwd, 4, 9), (rev, 5, 14))
+stats: (interface (dir, seek, step): (fwd, 4, 23), (rev, 2, 27)), (internal (dir, seek, step): (fwd, 4, 18), (rev, 4, 26))
 next: output: meta k=b ts=30.000000000,0 txn=2
 prev: output: value k=a ts=10.000000000,0 v=a10
 prev: output: value k=a ts=20.000000000,0 v=a20
@@ -293,11 +301,11 @@ next-key: output: .
 # Many separated intents.
 define
 locks
-meta k=a ts=10 txn=1
-meta k=b ts=20 txn=2
-meta k=c ts=30 txn=3
-meta k=d ts=40 txn=4
-meta k=e ts=50 txn=5
+meta k=a str=intent ts=10 txn=1
+meta k=b str=intent ts=20 txn=2
+meta k=c str=intent ts=30 txn=3
+meta k=d str=intent ts=40 txn=4
+meta k=e str=intent ts=50 txn=5
 mvcc
 value k=a ts=10 v=a10
 value k=b ts=20 v=b20
@@ -367,16 +375,20 @@ prev: output: .
 # Local keys. This exercises local keys having separated locks.
 define
 locks
-meta k=La ts=10 txn=1
-meta k=Lb ts=20 txn=2
-meta k=Lc ts=30 txn=4
+meta k=La str=intent ts=10 txn=1
+meta k=La str=shared       txn=1
+meta k=Lb str=intent ts=20 txn=2
+meta k=Lc str=intent ts=30 txn=4
+meta k=Lc str=exclusive    txn=4
+meta k=Ld str=exclusive    txn=4
 mvcc
 value k=La ts=10 v=a10
 value k=Lb ts=20 v=b20
 value k=Lc ts=30 v=c30
+value k=Ld ts=30 v=d40
 ----
 
-iter lower=La upper=Ld
+iter lower=La upper=Le
 seek-ge k=La
 next
 next
@@ -384,6 +396,8 @@ next
 next
 next
 next
+next
+prev
 prev
 prev
 prev
@@ -398,7 +412,9 @@ next: output: meta k=Lb ts=20.000000000,0 txn=2
 next: output: value k=Lb ts=20.000000000,0 v=b20
 next: output: meta k=Lc ts=30.000000000,0 txn=4
 next: output: value k=Lc ts=30.000000000,0 v=c30
+next: output: value k=Ld ts=30.000000000,0 v=d40
 next: output: .
+prev: output: value k=Ld ts=30.000000000,0 v=d40
 prev: output: value k=Lc ts=30.000000000,0 v=c30
 prev: output: meta k=Lc ts=30.000000000,0 txn=4
 prev: output: value k=Lb ts=20.000000000,0 v=b20
@@ -409,7 +425,7 @@ prev: output: .
 
 # Confirm that the lock table iterator does not step out of the lock table
 # keys space despite no lower bound.
-iter upper=Lc
+iter upper=Ld
 seek-ge k=La
 next
 prev
@@ -431,13 +447,15 @@ next: output: meta k=Lb ts=20.000000000,0 txn=2
 # Confirm that the underlying MVCCIterator does not iterate into the lock
 # table key space despite no upper bound.
 iter lower=La
-seek-lt k=Ld
+seek-lt k=Le
 prev
 prev
 prev
 prev
 prev
 prev
+prev
+next
 next
 next
 next
@@ -448,7 +466,8 @@ next
 next
 prev
 ----
-seek-lt "Ld"/0,0: output: value k=Lc ts=30.000000000,0 v=c30
+seek-lt "Le"/0,0: output: value k=Ld ts=30.000000000,0 v=d40
+prev: output: value k=Lc ts=30.000000000,0 v=c30
 prev: output: meta k=Lc ts=30.000000000,0 txn=4
 prev: output: value k=Lb ts=20.000000000,0 v=b20
 prev: output: meta k=Lb ts=20.000000000,0 txn=2
@@ -461,9 +480,10 @@ next: output: meta k=Lb ts=20.000000000,0 txn=2
 next: output: value k=Lb ts=20.000000000,0 v=b20
 next: output: meta k=Lc ts=30.000000000,0 txn=4
 next: output: value k=Lc ts=30.000000000,0 v=c30
+next: output: value k=Ld ts=30.000000000,0 v=d40
 next: output: .
 next: output: .
-prev: output: value k=Lc ts=30.000000000,0 v=c30
+prev: output: value k=Ld ts=30.000000000,0 v=d40
 
 iter prefix=true
 seek-ge k=Lb
@@ -498,10 +518,10 @@ seek-ge "Lc"/25.000000000,0: output: .
 # slice is smaller than cap and the first byte beyond len is 0.
 define
 locks
-meta k=abcdefg\0 ts=20 txn=1
-meta k=b\0c\0d ts=20 txn=1
-meta k=bcdefgh\0 ts=20 txn=1
-meta k=cdefghijklmnopq\0 ts=20 txn=1
+meta k=abcdefg\0         str=intent ts=20 txn=1
+meta k=b\0c\0d           str=intent ts=20 txn=1
+meta k=bcdefgh\0         str=intent ts=20 txn=1
+meta k=cdefghijklmnopq\0 str=intent ts=20 txn=1
 mvcc
 value k=abcdefg\0 ts=20 v=a
 value k=b\0c\0d ts=20 v=b1
@@ -560,11 +580,11 @@ prev: output: .
 
 define
 locks
-meta k=La ts=10 txn=1
-meta k=Lb ts=20 txn=2
-meta k=Lc ts=30 txn=4
-meta k=b ts=40 txn=5
-meta k=d ts=50 txn=6
+meta k=La str=intent ts=10 txn=1
+meta k=Lb str=intent ts=20 txn=2
+meta k=Lc str=intent ts=30 txn=4
+meta k=b  str=intent ts=40 txn=5
+meta k=d  str=intent ts=50 txn=6
 mvcc
 value k=La ts=10 v=a10
 value k=Lb ts=20 v=b20
@@ -644,9 +664,9 @@ seek-ge "c"/0,0: output: .
 # worthwhile for the intentInterleavingIter to work cleanly here.
 define
 locks
-meta k=Lb ts=20 txn=2
-meta k=Sc ts=30 txn=3
-meta k=d ts=40 txn=4
+meta k=Lb str=intent ts=20 txn=2
+meta k=Sc str=intent ts=30 txn=3
+meta k=d  str=intent ts=40 txn=4
 mvcc
 value k=Lb ts=20 v=b20
 value k=Sc ts=30 v=c30
@@ -734,8 +754,8 @@ prev: output: value k=Sc ts=30.000000000,0 v=c30
 # non-zero timestamps is bogus, but harmless.
 define
 locks
-meta k=Lb ts=20 txn=2
-meta k=e ts=50 txn=3
+meta k=Lb str=intent ts=20 txn=2
+meta k=e  str=intent ts=50 txn=3
 mvcc
 value k=Lb ts=20 v=b20
 value k=Sc ts=30 v=c30

--- a/pkg/storage/testdata/intent_interleaving_iter/basic
+++ b/pkg/storage/testdata/intent_interleaving_iter/basic
@@ -72,7 +72,7 @@ next: output: value k=b ts=30.000000000,0 v=b30
 next: output: meta k=c
 next: output: value k=d ts=25.000000000,0 v=d25
 next: output: .
-stats: (interface (dir, seek, step): (fwd, 2, 19), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 2, 15), (rev, 0, 0))
+stats: (interface (dir, seek, step): (fwd, 3, 17), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 3, 13), (rev, 0, 0))
 prev: output: value k=d ts=25.000000000,0 v=d25
 prev: output: meta k=c
 prev: output: value k=b ts=30.000000000,0 v=b30
@@ -81,16 +81,16 @@ prev: output: value k=a ts=10.000000000,0 v=a10
 prev: output: value k=a ts=20.000000000,0 v=a20
 prev: output: meta k=a ts=20.000000000,0 txn=1
 prev: output: .
-stats: (interface (dir, seek, step): (fwd, 2, 19), (rev, 0, 19)), (internal (dir, seek, step): (fwd, 2, 15), (rev, 2, 15))
+stats: (interface (dir, seek, step): (fwd, 3, 17), (rev, 1, 17)), (internal (dir, seek, step): (fwd, 3, 13), (rev, 3, 14))
 seek-ge "b"/0,0: output: meta k=b ts=30.000000000,0 txn=2
-stats: (interface (dir, seek, step): (fwd, 4, 19), (rev, 0, 19)), (internal (dir, seek, step): (fwd, 4, 15), (rev, 2, 15))
+stats: (interface (dir, seek, step): (fwd, 5, 17), (rev, 1, 17)), (internal (dir, seek, step): (fwd, 5, 13), (rev, 3, 14))
 next: output: value k=b ts=30.000000000,0 v=b30
 next: output: meta k=c
 prev: output: value k=b ts=30.000000000,0 v=b30
 prev: output: meta k=b ts=30.000000000,0 txn=2
 prev: output: value k=a ts=10.000000000,0 v=a10
 seek-lt "b"/0,0: output: value k=a ts=10.000000000,0 v=a10
-stats: (interface (dir, seek, step): (fwd, 4, 23), (rev, 2, 27)), (internal (dir, seek, step): (fwd, 4, 18), (rev, 4, 26))
+stats: (interface (dir, seek, step): (fwd, 5, 21), (rev, 3, 25)), (internal (dir, seek, step): (fwd, 5, 16), (rev, 5, 25))
 next: output: meta k=b ts=30.000000000,0 txn=2
 prev: output: value k=a ts=10.000000000,0 v=a10
 prev: output: value k=a ts=20.000000000,0 v=a20

--- a/pkg/storage/testdata/intent_interleaving_iter/error_race
+++ b/pkg/storage/testdata/intent_interleaving_iter/error_race
@@ -6,8 +6,8 @@
 # Error case: Multiple separated intents with no provisional values
 define
 locks
-meta k=b ts=20 txn=2
-meta k=d ts=40 txn=4
+meta k=b str=intent ts=20 txn=2
+meta k=d str=intent ts=40 txn=4
 ----
 
 iter lower=a upper=f
@@ -36,10 +36,10 @@ prev: output: err: reverse iteration discovered intent without provisional value
 # Error case: Multiple intents for a key
 define
 locks
-meta k=a ts=10 txn=1
-meta k=b ts=20 txn=2
-meta k=b ts=20 txn=4
-meta k=c ts=30 txn=4
+meta k=a str=intent ts=10 txn=1
+meta k=b str=intent ts=20 txn=2
+meta k=b str=intent ts=20 txn=4
+meta k=c str=intent ts=30 txn=4
 mvcc
 value k=a ts=10 v=a10
 value k=b ts=20 v=b20

--- a/pkg/storage/testdata/intent_interleaving_iter/error_race_off
+++ b/pkg/storage/testdata/intent_interleaving_iter/error_race_off
@@ -6,8 +6,8 @@
 # Error case: Multiple separated intents with no provisional values
 define
 locks
-meta k=b ts=20 txn=2
-meta k=d ts=40 txn=4
+meta k=b str=intent ts=20 txn=2
+meta k=d str=intent ts=40 txn=4
 ----
 
 iter lower=a upper=f
@@ -36,10 +36,10 @@ prev: output: err: reverse iteration discovered intent without provisional value
 # Error case: Multiple intents for a key
 define
 locks
-meta k=a ts=10 txn=1
-meta k=b ts=20 txn=2
-meta k=b ts=20 txn=4
-meta k=c ts=30 txn=4
+meta k=a str=intent ts=10 txn=1
+meta k=b str=intent ts=20 txn=2
+meta k=b str=intent ts=20 txn=4
+meta k=c str=intent ts=30 txn=4
 mvcc
 value k=a ts=10 v=a10
 value k=b ts=20 v=b20

--- a/pkg/storage/testdata/mvcc_histories/iter_prefix_next_key
+++ b/pkg/storage/testdata/mvcc_histories/iter_prefix_next_key
@@ -87,8 +87,8 @@ iter_prev
 ----
 iter_seek_ge: "a"/3.000000000,0=/BYTES/a3
 iter_next: "a"/2.000000000,0=/BYTES/a2
-iter_prev: err=intentIter should not be after iter
-error: (*withstack.withStack:) intentIter should not be after iter
+iter_prev: err=pebble: unsupported reverse prefix iteration
+error: (*withstack.withStack:) pebble: unsupported reverse prefix iteration
 
 # Complete iterator with intents and range keys.
 run ok


### PR DESCRIPTION
Informs #100193.
Closes #109644.

This commit updates the intentInterleavingIter to ignore locks in the lock table keyspace with strengths other than lock.Intent (i.e. shared and exclusive locks). Future versions of the iterator may expose information to users about whether any non-intent locks were observed and, if so, which keys they were found on. For now, no such information is exposed.

This change is needed for replicated locks. Non-locking reads will not interact with these locks at all, so we want the intentInterleavingIter to ignore them. Meanwhile, locking reads and writes will use a different abstraction to peek into the lock table and look for conflicts.

<details>
  <summary>Benchmark delta without Locks</summary>
  
  ```
name                                                                     old time/op    new time/op    delta
IntentInterleavingIterNext/version=1/intentStride=100/keyLen=100-10         112ns ± 7%     111ns ± 4%    ~     (p=0.332 n=25+22)
IntentInterleavingIterNext/version=1/intentStride=1000000/keyLen=10-10     61.6ns ± 4%    61.1ns ± 2%    ~     (p=0.340 n=24+20)
IntentInterleavingIterNext/version=1/intentStride=1000000/keyLen=100-10    66.2ns ± 5%    66.1ns ± 4%    ~     (p=0.788 n=25+25)
IntentInterleavingIterNext/version=5/intentStride=1/keyLen=100-10           115ns ±10%     114ns ± 4%    ~     (p=0.367 n=25+25)
IntentInterleavingIterNext/version=5/intentStride=1000000/keyLen=10-10     58.9ns ± 4%    59.7ns ± 4%    ~     (p=0.051 n=21+25)
IntentInterleavingIterNext/version=5/intentStride=1000000/keyLen=100-10    63.7ns ± 3%    64.2ns ± 4%    ~     (p=0.100 n=24+25)
IntentInterleavingIterPrev/version=1/intentStride=100/keyLen=100-10         123ns ± 8%     124ns ± 4%    ~     (p=0.081 n=25+24)
IntentInterleavingIterNext/version=5/intentStride=100/keyLen=100-10         109ns ± 4%     110ns ± 4%  +0.81%  (p=0.002 n=24+24)
IntentInterleavingIterNext/version=5/intentStride=100/keyLen=10-10          100ns ± 4%     102ns ± 1%  +1.49%  (p=0.003 n=24+20)
IntentInterleavingIterPrev/version=5/intentStride=1/keyLen=10-10           84.9ns ± 4%    86.3ns ± 4%  +1.60%  (p=0.000 n=24+24)
IntentInterleavingIterPrev/version=1/intentStride=1000000/keyLen=100-10     122ns ± 6%     124ns ± 4%  +1.90%  (p=0.001 n=25+24)
IntentInterleavingIterPrev/version=5/intentStride=1000000/keyLen=100-10     123ns ± 4%     126ns ± 7%  +2.44%  (p=0.000 n=24+24)
IntentInterleavingIterNext/version=1/intentStride=100/keyLen=10-10          101ns ± 4%     104ns ± 5%  +2.46%  (p=0.000 n=25+24)
IntentInterleavingIterNext/version=5/intentStride=1/keyLen=10-10            103ns ± 6%     105ns ± 5%  +2.64%  (p=0.000 n=23+24)
IntentInterleavingIterPrev/version=5/intentStride=100/keyLen=100-10         122ns ± 3%     126ns ± 5%  +2.75%  (p=0.000 n=22+25)
IntentInterleavingIterPrev/version=5/intentStride=1/keyLen=100-10          92.0ns ± 2%    94.8ns ± 6%  +3.13%  (p=0.000 n=23+24)
IntentInterleavingIterPrev/version=1/intentStride=1000000/keyLen=10-10      112ns ± 4%     116ns ± 6%  +3.24%  (p=0.000 n=25+25)
IntentInterleavingIterPrev/version=1/intentStride=100/keyLen=10-10          112ns ± 5%     116ns ± 4%  +3.36%  (p=0.000 n=25+25)
IntentInterleavingIterPrev/version=5/intentStride=100/keyLen=10-10          112ns ± 3%     116ns ± 4%  +3.65%  (p=0.000 n=25+25)
IntentInterleavingIterNext/version=1/intentStride=1/keyLen=100-10           112ns ± 8%     117ns ± 1%  +3.83%  (p=0.000 n=25+20)
IntentInterleavingIterPrev/version=5/intentStride=1000000/keyLen=10-10      111ns ± 2%     116ns ± 3%  +4.02%  (p=0.000 n=21+24)
IntentInterleavingIterNext/version=1/intentStride=1/keyLen=10-10            103ns ± 4%     107ns ± 3%  +4.07%  (p=0.000 n=25+21)
IntentInterleavingIterPrev/version=1/intentStride=1/keyLen=100-10           105ns ± 3%     111ns ± 6%  +6.23%  (p=0.000 n=24+25)
IntentInterleavingIterPrev/version=1/intentStride=1/keyLen=10-10           94.4ns ± 3%   100.5ns ± 5%  +6.48%  (p=0.000 n=23+25)

name                                                                     old alloc/op   new alloc/op   delta
IntentInterleavingIterNext/version=1/intentStride=1/keyLen=10-10            0.00B          0.00B         ~     (all equal)
IntentInterleavingIterNext/version=1/intentStride=1/keyLen=100-10           0.00B          0.00B         ~     (all equal)
IntentInterleavingIterNext/version=1/intentStride=100/keyLen=10-10          0.00B          0.00B         ~     (all equal)
IntentInterleavingIterNext/version=1/intentStride=100/keyLen=100-10         0.00B          0.00B         ~     (all equal)
IntentInterleavingIterNext/version=1/intentStride=1000000/keyLen=10-10      0.00B          0.00B         ~     (all equal)
IntentInterleavingIterNext/version=1/intentStride=1000000/keyLen=100-10     0.00B          0.00B         ~     (all equal)
IntentInterleavingIterNext/version=5/intentStride=1/keyLen=10-10            0.00B          0.00B         ~     (all equal)
IntentInterleavingIterNext/version=5/intentStride=1/keyLen=100-10           0.00B          0.00B         ~     (all equal)
IntentInterleavingIterNext/version=5/intentStride=100/keyLen=10-10          0.00B          0.00B         ~     (all equal)
IntentInterleavingIterNext/version=5/intentStride=100/keyLen=100-10         0.00B          0.00B         ~     (all equal)
IntentInterleavingIterNext/version=5/intentStride=1000000/keyLen=10-10      0.00B          0.00B         ~     (all equal)
IntentInterleavingIterNext/version=5/intentStride=1000000/keyLen=100-10     0.00B          0.00B         ~     (all equal)
IntentInterleavingIterPrev/version=1/intentStride=1/keyLen=10-10            0.00B          0.00B         ~     (all equal)
IntentInterleavingIterPrev/version=1/intentStride=1/keyLen=100-10           0.00B          0.00B         ~     (all equal)
IntentInterleavingIterPrev/version=1/intentStride=100/keyLen=10-10          0.00B          0.00B         ~     (all equal)
IntentInterleavingIterPrev/version=1/intentStride=100/keyLen=100-10         0.00B          0.00B         ~     (all equal)
IntentInterleavingIterPrev/version=1/intentStride=1000000/keyLen=10-10      0.00B          0.00B         ~     (all equal)
IntentInterleavingIterPrev/version=1/intentStride=1000000/keyLen=100-10     0.00B          0.00B         ~     (all equal)
IntentInterleavingIterPrev/version=5/intentStride=1/keyLen=10-10            0.00B          0.00B         ~     (all equal)
IntentInterleavingIterPrev/version=5/intentStride=1/keyLen=100-10           0.00B          0.00B         ~     (all equal)
IntentInterleavingIterPrev/version=5/intentStride=100/keyLen=10-10          0.00B          0.00B         ~     (all equal)
IntentInterleavingIterPrev/version=5/intentStride=100/keyLen=100-10         0.00B          0.00B         ~     (all equal)
IntentInterleavingIterPrev/version=5/intentStride=1000000/keyLen=10-10      0.00B          0.00B         ~     (all equal)
IntentInterleavingIterPrev/version=5/intentStride=1000000/keyLen=100-10     0.00B          0.00B         ~     (all equal)

name                                                                     old allocs/op  new allocs/op  delta
IntentInterleavingIterNext/version=1/intentStride=1/keyLen=10-10             0.00           0.00         ~     (all equal)
IntentInterleavingIterNext/version=1/intentStride=1/keyLen=100-10            0.00           0.00         ~     (all equal)
IntentInterleavingIterNext/version=1/intentStride=100/keyLen=10-10           0.00           0.00         ~     (all equal)
IntentInterleavingIterNext/version=1/intentStride=100/keyLen=100-10          0.00           0.00         ~     (all equal)
IntentInterleavingIterNext/version=1/intentStride=1000000/keyLen=10-10       0.00           0.00         ~     (all equal)
IntentInterleavingIterNext/version=1/intentStride=1000000/keyLen=100-10      0.00           0.00         ~     (all equal)
IntentInterleavingIterNext/version=5/intentStride=1/keyLen=10-10             0.00           0.00         ~     (all equal)
IntentInterleavingIterNext/version=5/intentStride=1/keyLen=100-10            0.00           0.00         ~     (all equal)
IntentInterleavingIterNext/version=5/intentStride=100/keyLen=10-10           0.00           0.00         ~     (all equal)
IntentInterleavingIterNext/version=5/intentStride=100/keyLen=100-10          0.00           0.00         ~     (all equal)
IntentInterleavingIterNext/version=5/intentStride=1000000/keyLen=10-10       0.00           0.00         ~     (all equal)
IntentInterleavingIterNext/version=5/intentStride=1000000/keyLen=100-10      0.00           0.00         ~     (all equal)
IntentInterleavingIterPrev/version=1/intentStride=1/keyLen=10-10             0.00           0.00         ~     (all equal)
IntentInterleavingIterPrev/version=1/intentStride=1/keyLen=100-10            0.00           0.00         ~     (all equal)
IntentInterleavingIterPrev/version=1/intentStride=100/keyLen=10-10           0.00           0.00         ~     (all equal)
IntentInterleavingIterPrev/version=1/intentStride=100/keyLen=100-10          0.00           0.00         ~     (all equal)
IntentInterleavingIterPrev/version=1/intentStride=1000000/keyLen=10-10       0.00           0.00         ~     (all equal)
IntentInterleavingIterPrev/version=1/intentStride=1000000/keyLen=100-10      0.00           0.00         ~     (all equal)
IntentInterleavingIterPrev/version=5/intentStride=1/keyLen=10-10             0.00           0.00         ~     (all equal)
IntentInterleavingIterPrev/version=5/intentStride=1/keyLen=100-10            0.00           0.00         ~     (all equal)
IntentInterleavingIterPrev/version=5/intentStride=100/keyLen=10-10           0.00           0.00         ~     (all equal)
IntentInterleavingIterPrev/version=5/intentStride=100/keyLen=100-10          0.00           0.00         ~     (all equal)
IntentInterleavingIterPrev/version=5/intentStride=1000000/keyLen=10-10       0.00           0.00         ~     (all equal)
IntentInterleavingIterPrev/version=5/intentStride=1000000/keyLen=100-10      0.00           0.00         ~     (all equal)
  ```
</details>

<details>
  <summary>Benchmarks with Locks</summary>
  
  ```
name                                                                                        time/op
IntentInterleavingIterNext/version=1/intentStride=1/lockStride=1/keyLen=10-10                149ns ± 1%
IntentInterleavingIterNext/version=1/intentStride=1/lockStride=1/keyLen=100-10               161ns ± 1%
IntentInterleavingIterNext/version=1/intentStride=1/lockStride=100/keyLen=10-10              105ns ± 0%
IntentInterleavingIterNext/version=1/intentStride=1/lockStride=100/keyLen=100-10             113ns ± 1%
IntentInterleavingIterNext/version=1/intentStride=1/lockStride=1000000/keyLen=10-10          104ns ± 1%
IntentInterleavingIterNext/version=1/intentStride=1/lockStride=1000000/keyLen=100-10         112ns ± 1%
IntentInterleavingIterNext/version=1/intentStride=100/lockStride=1/keyLen=10-10              173ns ± 2%
IntentInterleavingIterNext/version=1/intentStride=100/lockStride=1/keyLen=100-10             187ns ± 1%
IntentInterleavingIterNext/version=1/intentStride=100/lockStride=100/keyLen=10-10           94.3ns ± 1%
IntentInterleavingIterNext/version=1/intentStride=100/lockStride=100/keyLen=100-10           102ns ± 1%
IntentInterleavingIterNext/version=1/intentStride=100/lockStride=1000000/keyLen=10-10       93.0ns ± 1%
IntentInterleavingIterNext/version=1/intentStride=100/lockStride=1000000/keyLen=100-10       100ns ± 1%
IntentInterleavingIterNext/version=1/intentStride=1000000/lockStride=1/keyLen=10-10          172ns ± 1%
IntentInterleavingIterNext/version=1/intentStride=1000000/lockStride=1/keyLen=100-10         188ns ± 1%
IntentInterleavingIterNext/version=1/intentStride=1000000/lockStride=100/keyLen=10-10       93.6ns ± 1%
IntentInterleavingIterNext/version=1/intentStride=1000000/lockStride=100/keyLen=100-10       101ns ± 1%
IntentInterleavingIterNext/version=1/intentStride=1000000/lockStride=1000000/keyLen=10-10   54.1ns ± 1%
IntentInterleavingIterNext/version=1/intentStride=1000000/lockStride=1000000/keyLen=100-10  58.8ns ± 1%
IntentInterleavingIterNext/version=5/intentStride=1/lockStride=1/keyLen=10-10                112ns ± 0%
IntentInterleavingIterNext/version=5/intentStride=1/lockStride=1/keyLen=100-10               121ns ± 1%
IntentInterleavingIterNext/version=5/intentStride=1/lockStride=100/keyLen=10-10             96.6ns ± 1%
IntentInterleavingIterNext/version=5/intentStride=1/lockStride=100/keyLen=100-10             105ns ± 1%
IntentInterleavingIterNext/version=5/intentStride=1/lockStride=1000000/keyLen=10-10         96.6ns ± 1%
IntentInterleavingIterNext/version=5/intentStride=1/lockStride=1000000/keyLen=100-10         104ns ± 0%
IntentInterleavingIterNext/version=5/intentStride=100/lockStride=1/keyLen=10-10              108ns ± 1%
IntentInterleavingIterNext/version=5/intentStride=100/lockStride=1/keyLen=100-10             118ns ± 0%
IntentInterleavingIterNext/version=5/intentStride=100/lockStride=100/keyLen=10-10           91.5ns ± 1%
IntentInterleavingIterNext/version=5/intentStride=100/lockStride=100/keyLen=100-10          98.6ns ± 0%
IntentInterleavingIterNext/version=5/intentStride=100/lockStride=1000000/keyLen=10-10       91.2ns ± 1%
IntentInterleavingIterNext/version=5/intentStride=100/lockStride=1000000/keyLen=100-10      98.5ns ± 1%
IntentInterleavingIterNext/version=5/intentStride=1000000/lockStride=1/keyLen=10-10          108ns ± 1%
IntentInterleavingIterNext/version=5/intentStride=1000000/lockStride=1/keyLen=100-10         118ns ± 0%
IntentInterleavingIterNext/version=5/intentStride=1000000/lockStride=100/keyLen=10-10       91.6ns ± 1%
IntentInterleavingIterNext/version=5/intentStride=1000000/lockStride=100/keyLen=100-10      98.9ns ± 1%
IntentInterleavingIterNext/version=5/intentStride=1000000/lockStride=1000000/keyLen=10-10   51.6ns ± 0%
IntentInterleavingIterNext/version=5/intentStride=1000000/lockStride=1000000/keyLen=100-10  56.5ns ± 2%
IntentInterleavingIterPrev/version=1/intentStride=1/lockStride=1/keyLen=10-10                149ns ± 1%
IntentInterleavingIterPrev/version=1/intentStride=1/lockStride=1/keyLen=100-10               159ns ± 1%
IntentInterleavingIterPrev/version=1/intentStride=1/lockStride=100/keyLen=10-10             96.7ns ± 1%
IntentInterleavingIterPrev/version=1/intentStride=1/lockStride=100/keyLen=100-10             105ns ± 5%
IntentInterleavingIterPrev/version=1/intentStride=1/lockStride=1000000/keyLen=10-10         94.2ns ± 0%
IntentInterleavingIterPrev/version=1/intentStride=1/lockStride=1000000/keyLen=100-10         103ns ± 0%
IntentInterleavingIterPrev/version=1/intentStride=100/lockStride=1/keyLen=10-10              190ns ± 0%
IntentInterleavingIterPrev/version=1/intentStride=100/lockStride=1/keyLen=100-10             207ns ± 0%
IntentInterleavingIterPrev/version=1/intentStride=100/lockStride=100/keyLen=10-10            103ns ± 1%
IntentInterleavingIterPrev/version=1/intentStride=100/lockStride=100/keyLen=100-10           111ns ± 1%
IntentInterleavingIterPrev/version=1/intentStride=100/lockStride=1000000/keyLen=10-10        102ns ± 1%
IntentInterleavingIterPrev/version=1/intentStride=100/lockStride=1000000/keyLen=100-10       110ns ± 1%
IntentInterleavingIterPrev/version=1/intentStride=1000000/lockStride=1/keyLen=10-10          190ns ± 0%
IntentInterleavingIterPrev/version=1/intentStride=1000000/lockStride=1/keyLen=100-10         207ns ± 0%
IntentInterleavingIterPrev/version=1/intentStride=1000000/lockStride=100/keyLen=10-10        102ns ± 1%
IntentInterleavingIterPrev/version=1/intentStride=1000000/lockStride=100/keyLen=100-10       111ns ± 1%
IntentInterleavingIterPrev/version=1/intentStride=1000000/lockStride=1000000/keyLen=10-10    101ns ± 0%
IntentInterleavingIterPrev/version=1/intentStride=1000000/lockStride=1000000/keyLen=100-10   110ns ± 1%
IntentInterleavingIterPrev/version=5/intentStride=1/lockStride=1/keyLen=10-10               94.7ns ± 0%
IntentInterleavingIterPrev/version=5/intentStride=1/lockStride=1/keyLen=100-10               103ns ± 1%
IntentInterleavingIterPrev/version=5/intentStride=1/lockStride=100/keyLen=10-10             77.8ns ± 1%
IntentInterleavingIterPrev/version=5/intentStride=1/lockStride=100/keyLen=100-10            86.4ns ± 1%
IntentInterleavingIterPrev/version=5/intentStride=1/lockStride=1000000/keyLen=10-10         78.5ns ± 0%
IntentInterleavingIterPrev/version=5/intentStride=1/lockStride=1000000/keyLen=100-10        86.3ns ± 0%
IntentInterleavingIterPrev/version=5/intentStride=100/lockStride=1/keyLen=10-10              123ns ± 0%
IntentInterleavingIterPrev/version=5/intentStride=100/lockStride=1/keyLen=100-10             135ns ± 1%
IntentInterleavingIterPrev/version=5/intentStride=100/lockStride=100/keyLen=10-10            103ns ± 2%
IntentInterleavingIterPrev/version=5/intentStride=100/lockStride=100/keyLen=100-10           111ns ± 0%
IntentInterleavingIterPrev/version=5/intentStride=100/lockStride=1000000/keyLen=10-10        102ns ± 1%
IntentInterleavingIterPrev/version=5/intentStride=100/lockStride=1000000/keyLen=100-10       111ns ± 1%
IntentInterleavingIterPrev/version=5/intentStride=1000000/lockStride=1/keyLen=10-10          121ns ± 0%
IntentInterleavingIterPrev/version=5/intentStride=1000000/lockStride=1/keyLen=100-10         133ns ± 2%
IntentInterleavingIterPrev/version=5/intentStride=1000000/lockStride=100/keyLen=10-10        102ns ± 0%
IntentInterleavingIterPrev/version=5/intentStride=1000000/lockStride=100/keyLen=100-10       112ns ± 1%
IntentInterleavingIterPrev/version=5/intentStride=1000000/lockStride=1000000/keyLen=10-10    102ns ± 0%
IntentInterleavingIterPrev/version=5/intentStride=1000000/lockStride=1000000/keyLen=100-10   111ns ± 0%

name                                                                                        alloc/op
IntentInterleavingIterNext/version=1/intentStride=1/lockStride=1/keyLen=10-10                0.00B
IntentInterleavingIterNext/version=1/intentStride=1/lockStride=1/keyLen=100-10               0.00B
IntentInterleavingIterNext/version=1/intentStride=1/lockStride=100/keyLen=10-10              0.00B
IntentInterleavingIterNext/version=1/intentStride=1/lockStride=100/keyLen=100-10             0.00B
IntentInterleavingIterNext/version=1/intentStride=1/lockStride=1000000/keyLen=10-10          0.00B
IntentInterleavingIterNext/version=1/intentStride=1/lockStride=1000000/keyLen=100-10         0.00B
IntentInterleavingIterNext/version=1/intentStride=100/lockStride=1/keyLen=10-10              0.00B
IntentInterleavingIterNext/version=1/intentStride=100/lockStride=1/keyLen=100-10             0.00B
IntentInterleavingIterNext/version=1/intentStride=100/lockStride=100/keyLen=10-10            0.00B
IntentInterleavingIterNext/version=1/intentStride=100/lockStride=100/keyLen=100-10           0.00B
IntentInterleavingIterNext/version=1/intentStride=100/lockStride=1000000/keyLen=10-10        0.00B
IntentInterleavingIterNext/version=1/intentStride=100/lockStride=1000000/keyLen=100-10       0.00B
IntentInterleavingIterNext/version=1/intentStride=1000000/lockStride=1/keyLen=10-10          0.00B
IntentInterleavingIterNext/version=1/intentStride=1000000/lockStride=1/keyLen=100-10         0.00B
IntentInterleavingIterNext/version=1/intentStride=1000000/lockStride=100/keyLen=10-10        0.00B
IntentInterleavingIterNext/version=1/intentStride=1000000/lockStride=100/keyLen=100-10       0.00B
IntentInterleavingIterNext/version=1/intentStride=1000000/lockStride=1000000/keyLen=10-10    0.00B
IntentInterleavingIterNext/version=1/intentStride=1000000/lockStride=1000000/keyLen=100-10   0.00B
IntentInterleavingIterNext/version=5/intentStride=1/lockStride=1/keyLen=10-10                0.00B
IntentInterleavingIterNext/version=5/intentStride=1/lockStride=1/keyLen=100-10               0.00B
IntentInterleavingIterNext/version=5/intentStride=1/lockStride=100/keyLen=10-10              0.00B
IntentInterleavingIterNext/version=5/intentStride=1/lockStride=100/keyLen=100-10             0.00B
IntentInterleavingIterNext/version=5/intentStride=1/lockStride=1000000/keyLen=10-10          0.00B
IntentInterleavingIterNext/version=5/intentStride=1/lockStride=1000000/keyLen=100-10         0.00B
IntentInterleavingIterNext/version=5/intentStride=100/lockStride=1/keyLen=10-10              0.00B
IntentInterleavingIterNext/version=5/intentStride=100/lockStride=1/keyLen=100-10             0.00B
IntentInterleavingIterNext/version=5/intentStride=100/lockStride=100/keyLen=10-10            0.00B
IntentInterleavingIterNext/version=5/intentStride=100/lockStride=100/keyLen=100-10           0.00B
IntentInterleavingIterNext/version=5/intentStride=100/lockStride=1000000/keyLen=10-10        0.00B
IntentInterleavingIterNext/version=5/intentStride=100/lockStride=1000000/keyLen=100-10       0.00B
IntentInterleavingIterNext/version=5/intentStride=1000000/lockStride=1/keyLen=10-10          0.00B
IntentInterleavingIterNext/version=5/intentStride=1000000/lockStride=1/keyLen=100-10         0.00B
IntentInterleavingIterNext/version=5/intentStride=1000000/lockStride=100/keyLen=10-10        0.00B
IntentInterleavingIterNext/version=5/intentStride=1000000/lockStride=100/keyLen=100-10       0.00B
IntentInterleavingIterNext/version=5/intentStride=1000000/lockStride=1000000/keyLen=10-10    0.00B
IntentInterleavingIterNext/version=5/intentStride=1000000/lockStride=1000000/keyLen=100-10   0.00B
IntentInterleavingIterPrev/version=1/intentStride=1/lockStride=1/keyLen=10-10                0.00B
IntentInterleavingIterPrev/version=1/intentStride=1/lockStride=1/keyLen=100-10               0.00B
IntentInterleavingIterPrev/version=1/intentStride=1/lockStride=100/keyLen=10-10              0.00B
IntentInterleavingIterPrev/version=1/intentStride=1/lockStride=100/keyLen=100-10             0.00B
IntentInterleavingIterPrev/version=1/intentStride=1/lockStride=1000000/keyLen=10-10          0.00B
IntentInterleavingIterPrev/version=1/intentStride=1/lockStride=1000000/keyLen=100-10         0.00B
IntentInterleavingIterPrev/version=1/intentStride=100/lockStride=1/keyLen=10-10              0.00B
IntentInterleavingIterPrev/version=1/intentStride=100/lockStride=1/keyLen=100-10             0.00B
IntentInterleavingIterPrev/version=1/intentStride=100/lockStride=100/keyLen=10-10            0.00B
IntentInterleavingIterPrev/version=1/intentStride=100/lockStride=100/keyLen=100-10           0.00B
IntentInterleavingIterPrev/version=1/intentStride=100/lockStride=1000000/keyLen=10-10        0.00B
IntentInterleavingIterPrev/version=1/intentStride=100/lockStride=1000000/keyLen=100-10       0.00B
IntentInterleavingIterPrev/version=1/intentStride=1000000/lockStride=1/keyLen=10-10          0.00B
IntentInterleavingIterPrev/version=1/intentStride=1000000/lockStride=1/keyLen=100-10         0.00B
IntentInterleavingIterPrev/version=1/intentStride=1000000/lockStride=100/keyLen=10-10        0.00B
IntentInterleavingIterPrev/version=1/intentStride=1000000/lockStride=100/keyLen=100-10       0.00B
IntentInterleavingIterPrev/version=1/intentStride=1000000/lockStride=1000000/keyLen=10-10    0.00B
IntentInterleavingIterPrev/version=1/intentStride=1000000/lockStride=1000000/keyLen=100-10   0.00B
IntentInterleavingIterPrev/version=5/intentStride=1/lockStride=1/keyLen=10-10                0.00B
IntentInterleavingIterPrev/version=5/intentStride=1/lockStride=1/keyLen=100-10               0.00B
IntentInterleavingIterPrev/version=5/intentStride=1/lockStride=100/keyLen=10-10              0.00B
IntentInterleavingIterPrev/version=5/intentStride=1/lockStride=100/keyLen=100-10             0.00B
IntentInterleavingIterPrev/version=5/intentStride=1/lockStride=1000000/keyLen=10-10          0.00B
IntentInterleavingIterPrev/version=5/intentStride=1/lockStride=1000000/keyLen=100-10         0.00B
IntentInterleavingIterPrev/version=5/intentStride=100/lockStride=1/keyLen=10-10              0.00B
IntentInterleavingIterPrev/version=5/intentStride=100/lockStride=1/keyLen=100-10             0.00B
IntentInterleavingIterPrev/version=5/intentStride=100/lockStride=100/keyLen=10-10            0.00B
IntentInterleavingIterPrev/version=5/intentStride=100/lockStride=100/keyLen=100-10           0.00B
IntentInterleavingIterPrev/version=5/intentStride=100/lockStride=1000000/keyLen=10-10        0.00B
IntentInterleavingIterPrev/version=5/intentStride=100/lockStride=1000000/keyLen=100-10       0.00B
IntentInterleavingIterPrev/version=5/intentStride=1000000/lockStride=1/keyLen=10-10          0.00B
IntentInterleavingIterPrev/version=5/intentStride=1000000/lockStride=1/keyLen=100-10         0.00B
IntentInterleavingIterPrev/version=5/intentStride=1000000/lockStride=100/keyLen=10-10        0.00B
IntentInterleavingIterPrev/version=5/intentStride=1000000/lockStride=100/keyLen=100-10       0.00B
IntentInterleavingIterPrev/version=5/intentStride=1000000/lockStride=1000000/keyLen=10-10    0.00B
IntentInterleavingIterPrev/version=5/intentStride=1000000/lockStride=1000000/keyLen=100-10   0.00B

name                                                                                        allocs/op
IntentInterleavingIterNext/version=1/intentStride=1/lockStride=1/keyLen=10-10                 0.00
IntentInterleavingIterNext/version=1/intentStride=1/lockStride=1/keyLen=100-10                0.00
IntentInterleavingIterNext/version=1/intentStride=1/lockStride=100/keyLen=10-10               0.00
IntentInterleavingIterNext/version=1/intentStride=1/lockStride=100/keyLen=100-10              0.00
IntentInterleavingIterNext/version=1/intentStride=1/lockStride=1000000/keyLen=10-10           0.00
IntentInterleavingIterNext/version=1/intentStride=1/lockStride=1000000/keyLen=100-10          0.00
IntentInterleavingIterNext/version=1/intentStride=100/lockStride=1/keyLen=10-10               0.00
IntentInterleavingIterNext/version=1/intentStride=100/lockStride=1/keyLen=100-10              0.00
IntentInterleavingIterNext/version=1/intentStride=100/lockStride=100/keyLen=10-10             0.00
IntentInterleavingIterNext/version=1/intentStride=100/lockStride=100/keyLen=100-10            0.00
IntentInterleavingIterNext/version=1/intentStride=100/lockStride=1000000/keyLen=10-10         0.00
IntentInterleavingIterNext/version=1/intentStride=100/lockStride=1000000/keyLen=100-10        0.00
IntentInterleavingIterNext/version=1/intentStride=1000000/lockStride=1/keyLen=10-10           0.00
IntentInterleavingIterNext/version=1/intentStride=1000000/lockStride=1/keyLen=100-10          0.00
IntentInterleavingIterNext/version=1/intentStride=1000000/lockStride=100/keyLen=10-10         0.00
IntentInterleavingIterNext/version=1/intentStride=1000000/lockStride=100/keyLen=100-10        0.00
IntentInterleavingIterNext/version=1/intentStride=1000000/lockStride=1000000/keyLen=10-10     0.00
IntentInterleavingIterNext/version=1/intentStride=1000000/lockStride=1000000/keyLen=100-10    0.00
IntentInterleavingIterNext/version=5/intentStride=1/lockStride=1/keyLen=10-10                 0.00
IntentInterleavingIterNext/version=5/intentStride=1/lockStride=1/keyLen=100-10                0.00
IntentInterleavingIterNext/version=5/intentStride=1/lockStride=100/keyLen=10-10               0.00
IntentInterleavingIterNext/version=5/intentStride=1/lockStride=100/keyLen=100-10              0.00
IntentInterleavingIterNext/version=5/intentStride=1/lockStride=1000000/keyLen=10-10           0.00
IntentInterleavingIterNext/version=5/intentStride=1/lockStride=1000000/keyLen=100-10          0.00
IntentInterleavingIterNext/version=5/intentStride=100/lockStride=1/keyLen=10-10               0.00
IntentInterleavingIterNext/version=5/intentStride=100/lockStride=1/keyLen=100-10              0.00
IntentInterleavingIterNext/version=5/intentStride=100/lockStride=100/keyLen=10-10             0.00
IntentInterleavingIterNext/version=5/intentStride=100/lockStride=100/keyLen=100-10            0.00
IntentInterleavingIterNext/version=5/intentStride=100/lockStride=1000000/keyLen=10-10         0.00
IntentInterleavingIterNext/version=5/intentStride=100/lockStride=1000000/keyLen=100-10        0.00
IntentInterleavingIterNext/version=5/intentStride=1000000/lockStride=1/keyLen=10-10           0.00
IntentInterleavingIterNext/version=5/intentStride=1000000/lockStride=1/keyLen=100-10          0.00
IntentInterleavingIterNext/version=5/intentStride=1000000/lockStride=100/keyLen=10-10         0.00
IntentInterleavingIterNext/version=5/intentStride=1000000/lockStride=100/keyLen=100-10        0.00
IntentInterleavingIterNext/version=5/intentStride=1000000/lockStride=1000000/keyLen=10-10     0.00
IntentInterleavingIterNext/version=5/intentStride=1000000/lockStride=1000000/keyLen=100-10    0.00
IntentInterleavingIterPrev/version=1/intentStride=1/lockStride=1/keyLen=10-10                 0.00
IntentInterleavingIterPrev/version=1/intentStride=1/lockStride=1/keyLen=100-10                0.00
IntentInterleavingIterPrev/version=1/intentStride=1/lockStride=100/keyLen=10-10               0.00
IntentInterleavingIterPrev/version=1/intentStride=1/lockStride=100/keyLen=100-10              0.00
IntentInterleavingIterPrev/version=1/intentStride=1/lockStride=1000000/keyLen=10-10           0.00
IntentInterleavingIterPrev/version=1/intentStride=1/lockStride=1000000/keyLen=100-10          0.00
IntentInterleavingIterPrev/version=1/intentStride=100/lockStride=1/keyLen=10-10               0.00
IntentInterleavingIterPrev/version=1/intentStride=100/lockStride=1/keyLen=100-10              0.00
IntentInterleavingIterPrev/version=1/intentStride=100/lockStride=100/keyLen=10-10             0.00
IntentInterleavingIterPrev/version=1/intentStride=100/lockStride=100/keyLen=100-10            0.00
IntentInterleavingIterPrev/version=1/intentStride=100/lockStride=1000000/keyLen=10-10         0.00
IntentInterleavingIterPrev/version=1/intentStride=100/lockStride=1000000/keyLen=100-10        0.00
IntentInterleavingIterPrev/version=1/intentStride=1000000/lockStride=1/keyLen=10-10           0.00
IntentInterleavingIterPrev/version=1/intentStride=1000000/lockStride=1/keyLen=100-10          0.00
IntentInterleavingIterPrev/version=1/intentStride=1000000/lockStride=100/keyLen=10-10         0.00
IntentInterleavingIterPrev/version=1/intentStride=1000000/lockStride=100/keyLen=100-10        0.00
IntentInterleavingIterPrev/version=1/intentStride=1000000/lockStride=1000000/keyLen=10-10     0.00
IntentInterleavingIterPrev/version=1/intentStride=1000000/lockStride=1000000/keyLen=100-10    0.00
IntentInterleavingIterPrev/version=5/intentStride=1/lockStride=1/keyLen=10-10                 0.00
IntentInterleavingIterPrev/version=5/intentStride=1/lockStride=1/keyLen=100-10                0.00
IntentInterleavingIterPrev/version=5/intentStride=1/lockStride=100/keyLen=10-10               0.00
IntentInterleavingIterPrev/version=5/intentStride=1/lockStride=100/keyLen=100-10              0.00
IntentInterleavingIterPrev/version=5/intentStride=1/lockStride=1000000/keyLen=10-10           0.00
IntentInterleavingIterPrev/version=5/intentStride=1/lockStride=1000000/keyLen=100-10          0.00
IntentInterleavingIterPrev/version=5/intentStride=100/lockStride=1/keyLen=10-10               0.00
IntentInterleavingIterPrev/version=5/intentStride=100/lockStride=1/keyLen=100-10              0.00
IntentInterleavingIterPrev/version=5/intentStride=100/lockStride=100/keyLen=10-10             0.00
IntentInterleavingIterPrev/version=5/intentStride=100/lockStride=100/keyLen=100-10            0.00
IntentInterleavingIterPrev/version=5/intentStride=100/lockStride=1000000/keyLen=10-10         0.00
IntentInterleavingIterPrev/version=5/intentStride=100/lockStride=1000000/keyLen=100-10        0.00
IntentInterleavingIterPrev/version=5/intentStride=1000000/lockStride=1/keyLen=10-10           0.00
IntentInterleavingIterPrev/version=5/intentStride=1000000/lockStride=1/keyLen=100-10          0.00
IntentInterleavingIterPrev/version=5/intentStride=1000000/lockStride=100/keyLen=10-10         0.00
IntentInterleavingIterPrev/version=5/intentStride=1000000/lockStride=100/keyLen=100-10        0.00
IntentInterleavingIterPrev/version=5/intentStride=1000000/lockStride=1000000/keyLen=10-10     0.00
IntentInterleavingIterPrev/version=5/intentStride=1000000/lockStride=1000000/keyLen=100-10    0.00
  ```
</details>

Release note: None