### PR TITLE
rpc: increase gRPC server timeout from 1x to 2x NetworkTimeout

### DIFF
--- a/pkg/rpc/keepalive.go
+++ b/pkg/rpc/keepalive.go
@@ -14,8 +14,23 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"google.golang.org/grpc/keepalive"
 )
+
+// serverTimeout is how long the server will wait for a TCP send to receive a
+// TCP ack before automatically closing the connection. gRPC enforces this via
+// the OS TCP stack by setting TCP_USER_TIMEOUT on the network socket.
+//
+// While NetworkTimeout should be sufficient here, we have seen instances where
+// this is affected by node load or other factors, so we set it to 2x
+// NetworkTimeout to avoid spurious closed connections. An aggressive timeout is
+// not particularly beneficial here, because the client-side timeout (in our
+// case the CRDB RPC heartbeat) is what matters for recovery time following
+// network or node outages -- the server side doesn't really care if the
+// connection remains open for a bit longer.
+var serverTimeout = envutil.EnvOrDefaultDuration(
+	"COCKROACH_RPC_SERVER_TIMEOUT", 2*base.NetworkTimeout)
 
 // 10 seconds is the minimum keepalive interval permitted by gRPC.
 // Setting it to a value lower than this will lead to gRPC adjusting to this
@@ -39,11 +54,9 @@ var clientKeepalive = keepalive.ClientParameters{
 var serverKeepalive = keepalive.ServerParameters{
 	// Send periodic pings on the connection when there is no other traffic.
 	Time: base.PingInterval,
-	// If the pings don't get a response within the timeout, we might be
-	// experiencing a network partition. gRPC will close the transport-level
-	// connection and all the pending RPCs (which may not have timeouts) will
-	// fail eagerly.
-	Timeout: base.NetworkTimeout,
+	// Close the connection if a TCP send (including a ping) does not receive a
+	// TCP ack within the given timeout. Enforced by the OS via TCP_USER_TIMEOUT.
+	Timeout: serverTimeout,
 }
 
 // By default, gRPC disconnects clients that send "too many" pings,


### PR DESCRIPTION
This is intended as a conservative backport that changes as little as possible. For 23.2, we should restructure these settings a bit, possibly by removing NetworkTimeout and using independent timeouts for each component/parameter, since they have unique considerations (e.g. whether they are enforced above the Go runtime or by the OS, to what extent they are subject to RPC head-of-line blocking, etc).

---

This patch increases the gRPC server timeout from 1x to 2x NetworkTimeout. This timeout determines how long the server will wait for a TCP send to receive a TCP ack before automatically closing the connection. gRPC enforces this via the OS TCP stack by setting TCP_USER_TIMEOUT on the network socket.

While NetworkTimeout should be sufficient here, we have seen instances where this is affected by node load or other factors, so we set it to 2x NetworkTimeout to avoid spurious closed connections. An aggressive timeout is not particularly beneficial here, because the client-side timeout (in our case the CRDB RPC heartbeat) is what matters for recovery time following network or node outages -- the server side doesn't really care if the connection remains open for a bit longer.

Touches #109317.

Epic: none
Release note (ops change): The default gRPC server-side send timeout has been increased from 2 seconds to 4 seconds (1x to 2x of COCKROACH_NETWORK_TIMEOUT), to avoid spurious connection failures in certain scenarios. This can be controlled via the new environment variable COCKROACH_RPC_SERVER_TIMEOUT.