### PR TITLE
roachtest: add O-rsg to random syntax tests

### DIFF
--- a/pkg/cmd/roachtest/github.go
+++ b/pkg/cmd/roachtest/github.go
@@ -164,6 +164,9 @@ func (g *githubIssues) createPostRequest(
 	} else if !spec.NonReleaseBlocker {
 		labels = append(labels, "release-blocker")
 	}
+	if len(spec.ExtraLabels) > 0 {
+		labels = append(labels, spec.ExtraLabels...)
+	}
 
 	teams, err := g.teamLoader()
 	if err != nil {

--- a/pkg/cmd/roachtest/registry/test_spec.go
+++ b/pkg/cmd/roachtest/registry/test_spec.go
@@ -119,6 +119,10 @@ type TestSpec struct {
 	// fingerprint, i.e. the node count, the version, etc. that appear in the
 	// infix. This will get rid of this awkward prefix naming restriction.
 	SnapshotPrefix string
+
+	// ExtraLabels are test-specific labels that will be added to the Github
+	// issue created when a failure occurs, in addition to default labels.
+	ExtraLabels []string
 }
 
 // PostValidation is a type of post-validation that runs after a test completes.

--- a/pkg/cmd/roachtest/testdata/help_command_createpost_6.txt
+++ b/pkg/cmd/roachtest/testdata/help_command_createpost_6.txt
@@ -1,0 +1,17 @@
+echo
+----
+----
+
+
+See: [roachtest README](https://github.com/cockroachdb/cockroach/blob/master/pkg/cmd/roachtest/README.md)
+
+
+
+See: [How To Investigate \(internal\)](https://cockroachlabs.atlassian.net/l/c/SSSBr8c7)
+
+
+
+See: [Grafana](https://go.crdb.dev/p/roachfana/foo/1689957243000/1689957733000)
+
+----
+----

--- a/pkg/cmd/roachtest/tests/costfuzz.go
+++ b/pkg/cmd/roachtest/tests/costfuzz.go
@@ -65,6 +65,7 @@ func registerCostFuzz(r registry.Registry) {
 					name: "costfuzz", setupName: setupName, run: runCostFuzzQuery,
 				})
 			},
+			ExtraLabels: []string{"O-rsg"},
 		})
 	}
 }

--- a/pkg/cmd/roachtest/tests/sqlsmith.go
+++ b/pkg/cmd/roachtest/tests/sqlsmith.go
@@ -322,6 +322,7 @@ WITH into_db = 'defaultdb', unsafe_restore_incompatible_version;
 				}
 				runSQLSmith(ctx, t, c, setup, setting)
 			},
+			ExtraLabels: []string{"O-rsg"},
 		})
 	}
 

--- a/pkg/cmd/roachtest/tests/tlp.go
+++ b/pkg/cmd/roachtest/tests/tlp.go
@@ -43,6 +43,7 @@ func registerTLP(r registry.Registry) {
 		Leases:          registry.MetamorphicLeases,
 		NativeLibs:      registry.LibGEOS,
 		Run:             runTLP,
+		ExtraLabels:     []string{"O-rsg"},
 	})
 }
 

--- a/pkg/cmd/roachtest/tests/unoptimized_query_oracle.go
+++ b/pkg/cmd/roachtest/tests/unoptimized_query_oracle.go
@@ -69,6 +69,7 @@ func registerUnoptimizedQueryOracle(r registry.Registry) {
 						},
 					})
 				},
+				ExtraLabels: []string{"O-rsg"},
 			})
 		}
 	}


### PR DESCRIPTION
The `O-rsg` label is now applied to issues created when a test with
randomized SQL syntax fails: sqlsmith, TLP, costfuzz, and unoptimized
query oracle tests.

Epic: None

Release note: None
