### PR TITLE
server,serverutils: simplify interfaces

### DIFF
--- a/pkg/ccl/backupccl/backup_tenant_test.go
+++ b/pkg/ccl/backupccl/backup_tenant_test.go
@@ -78,7 +78,7 @@ func TestBackupTenantImportingTable(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Destroy the tenant, then restore it.
-	tSrv.Stopper().Stop(ctx)
+	tSrv.AppStopper().Stop(ctx)
 	if _, err := sqlDB.DB.ExecContext(ctx, "ALTER TENANT [10] STOP SERVICE; DROP TENANT [10] IMMEDIATE"); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -8964,10 +8964,7 @@ func TestRestorePauseOnError(t *testing.T) {
 
 	var forceFailure bool
 	for i := range tc.Servers {
-		jobRegistry := tc.Servers[i].JobRegistry()
-		if tc.StartedDefaultTestTenant() {
-			jobRegistry = tc.Servers[i].TestTenants()[0].JobRegistry()
-		}
+		jobRegistry := tc.Servers[i].ApplicationLayer().JobRegistry()
 
 		jobRegistry.(*jobs.Registry).TestingWrapResumerConstructor(
 			jobspb.TypeRestore,

--- a/pkg/ccl/backupccl/datadriven_test.go
+++ b/pkg/ccl/backupccl/datadriven_test.go
@@ -826,12 +826,9 @@ func runTestDataDriven(t *testing.T, testFilePathFromWorkspace string) {
 			return ""
 
 		case "create-dummy-system-table":
-			db := ds.firstNode[lastCreatedCluster].DB()
-			execCfg := ds.firstNode[lastCreatedCluster].ExecutorConfig().(sql.ExecutorConfig)
-			testTenants := ds.firstNode[lastCreatedCluster].TestTenants()
-			if len(testTenants) > 0 {
-				execCfg = testTenants[0].ExecutorConfig().(sql.ExecutorConfig)
-			}
+			al := ds.firstNode[lastCreatedCluster].ApplicationLayer()
+			db := al.DB()
+			execCfg := al.ExecutorConfig().(sql.ExecutorConfig)
 			codec := execCfg.Codec
 			dummyTable := systemschema.SettingsTable
 			err := db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {

--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -535,7 +535,7 @@ func startTestTenant(
 	waitForTenantPodsActive(t, tenantServer, 1)
 	resetRetry := testingUseFastRetry()
 	return tenantID, tenantServer, tenantDB, func() {
-		tenantServer.Stopper().Stop(ctx)
+		tenantServer.AppStopper().Stop(ctx)
 		resetRetry()
 	}
 }

--- a/pkg/ccl/changefeedccl/kvfeed/scanner_test.go
+++ b/pkg/ccl/changefeedccl/kvfeed/scanner_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/kvevent"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
-	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/desctestutils"
@@ -52,14 +51,6 @@ func (r *recordResolvedWriter) AcquireMemory(ctx context.Context, n int64) (kvev
 	return kvevent.Alloc{}, nil
 }
 
-func tenantOrSystemCodec(s serverutils.TestServerInterface) keys.SQLCodec {
-	var codec = s.Codec()
-	if len(s.TestTenants()) > 0 {
-		codec = s.TestTenants()[0].Codec()
-	}
-	return codec
-}
-
 var _ kvevent.Writer = (*recordResolvedWriter)(nil)
 
 func TestEmitsResolvedDuringScan(t *testing.T) {
@@ -67,8 +58,9 @@ func TestEmitsResolvedDuringScan(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	s, db, kvdb := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop(ctx)
+	srv, db, kvdb := serverutils.StartServer(t, base.TestServerArgs{})
+	defer srv.Stopper().Stop(ctx)
+	s := srv.ApplicationLayer()
 
 	sqlDB := sqlutils.MakeSQLRunner(db)
 	sqlDB.Exec(t, `
@@ -76,7 +68,7 @@ CREATE TABLE t (a INT PRIMARY KEY);
 INSERT INTO t VALUES (1), (2), (3);
 `)
 
-	codec := tenantOrSystemCodec(s)
+	codec := s.Codec()
 	descr := desctestutils.TestingGetPublicTableDescriptor(kvdb, codec, "defaultdb", "t")
 	span := tableSpan(codec, uint32(descr.GetID()))
 

--- a/pkg/ccl/changefeedccl/schemafeed/schematestutils/schema_test_utils.go
+++ b/pkg/ccl/changefeedccl/schemafeed/schematestutils/schema_test_utils.go
@@ -149,7 +149,7 @@ func FetchDescVersionModificationTime(
 	version int,
 ) hlc.Timestamp {
 	db := serverutils.OpenDBConn(
-		t, s.SQLAddr(), dbName, false, s.Stopper())
+		t, s.SQLAddr(), dbName, false, s.AppStopper())
 
 	tblKey := s.Codec().TablePrefix(keys.DescriptorTableID)
 	header := kvpb.RequestHeader{

--- a/pkg/ccl/changefeedccl/schemafeed/table_event_filter_datadriven_test.go
+++ b/pkg/ccl/changefeedccl/schemafeed/table_event_filter_datadriven_test.go
@@ -69,7 +69,7 @@ func TestDataDriven(t *testing.T) {
 		ts := srv.ApplicationLayer()
 
 		tdb := sqlutils.MakeSQLRunner(sqlDB)
-		ctx, cancel := ts.Stopper().WithCancelOnQuiesce(ctx)
+		ctx, cancel := ts.AppStopper().WithCancelOnQuiesce(ctx)
 		defer cancel()
 		schemaFeeds := map[int]schemafeed.SchemaFeed{}
 		parseTargets := func(t *testing.T, in string) (targets changefeedbase.Targets) {

--- a/pkg/ccl/kvccl/kvtenantccl/upgradeccl/tenant_upgrade_test.go
+++ b/pkg/ccl/kvccl/kvtenantccl/upgradeccl/tenant_upgrade_test.go
@@ -127,7 +127,7 @@ func TestTenantUpgrade(t *testing.T) {
 		db.CheckQueryResults(t, "SHOW CLUSTER SETTING version", [][]string{{v2.String()}})
 
 		t.Log("restart the tenant")
-		tenantServer.Stopper().Stop(ctx)
+		tenantServer.AppStopper().Stop(ctx)
 		tenantServer, err := ts.StartTenant(ctx, base.TestTenantArgs{
 			TenantID: roachpb.MustMakeTenantID(initialTenantID),
 		})
@@ -150,7 +150,7 @@ func TestTenantUpgrade(t *testing.T) {
 			"SHOW CLUSTER SETTING version", [][]string{{v2.String()}})
 
 		t.Log("restart the new tenant")
-		tenant.Stopper().Stop(ctx)
+		tenant.AppStopper().Stop(ctx)
 		var err error
 		tenant, err = ts.StartTenant(ctx, base.TestTenantArgs{
 			TenantID: roachpb.MustMakeTenantID(postUpgradeTenantID),
@@ -274,7 +274,7 @@ func TestTenantUpgradeFailure(t *testing.T) {
 										// Wait until we are sure the stopper is quiescing.
 										for {
 											select {
-											case <-tenant.Stopper().ShouldQuiesce():
+											case <-tenant.AppStopper().ShouldQuiesce():
 												return nil
 											default:
 												continue
@@ -314,7 +314,7 @@ func TestTenantUpgradeFailure(t *testing.T) {
 		go func() {
 			<-tenantStopperChannel
 			t.Log("received async notification to stop tenant")
-			tenant.Stopper().Stop(ctx)
+			tenant.AppStopper().Stop(ctx)
 			t.Log("tenant stopped")
 			waitForTenantClose <- struct{}{}
 		}()
@@ -344,9 +344,9 @@ func TestTenantUpgradeFailure(t *testing.T) {
 			[][]string{{v1.String()}})
 
 		t.Log("restart the tenant")
-		tenant.Stopper().Stop(ctx)
+		tenant.AppStopper().Stop(ctx)
 		tenant, conn = startAndConnectToTenant(t, initialTenantID)
-		defer tenant.Stopper().Stop(ctx)
+		defer tenant.AppStopper().Stop(ctx)
 		db = sqlutils.MakeSQLRunner(conn)
 
 		// Keep trying to resume the stopper channel until the channel is closed,
@@ -380,6 +380,6 @@ func TestTenantUpgradeFailure(t *testing.T) {
 			"SELECT * FROM t", [][]string{{"1"}, {"2"}})
 		db.CheckQueryResults(t,
 			"SHOW CLUSTER SETTING version", [][]string{{v2.String()}})
-		tenant.Stopper().Stop(ctx)
+		tenant.AppStopper().Stop(ctx)
 	})
 }

--- a/pkg/ccl/kvccl/kvtenantccl/upgradeinterlockccl/local_test_util_test.go
+++ b/pkg/ccl/kvccl/kvtenantccl/upgradeinterlockccl/local_test_util_test.go
@@ -161,7 +161,7 @@ func runTest(t *testing.T, variant sharedtestutil.TestVariant, test sharedtestut
 		}
 		tenant, err := tc.Server(0).StartTenant(ctx, tenantArgs)
 		require.NoError(t, err)
-		return tenant.SQLConn(t, ""), func() { tenant.Stopper().Stop(ctx) }
+		return tenant.SQLConn(t, ""), func() { tenant.AppStopper().Stop(ctx) }
 	}
 
 	logf("creating an initial tenant server")
@@ -292,7 +292,7 @@ func runTest(t *testing.T, variant sharedtestutil.TestVariant, test sharedtestut
 		logf("shutting down the other tenant server")
 		otherServerStopper.Stop(ctx)
 	} else if otherServerStartError == nil {
-		defer otherServer.Stopper().Stop(ctx)
+		defer otherServer.AppStopper().Stop(ctx)
 		otherTenant := otherServer.SQLConn(t, "")
 		otherTenantRunner = sqlutils.MakeSQLRunner(otherTenant)
 		numTenantsStr = "2"

--- a/pkg/ccl/multiregionccl/cold_start_latency_test.go
+++ b/pkg/ccl/multiregionccl/cold_start_latency_test.go
@@ -286,7 +286,7 @@ COMMIT;`}
 SELECT checkpoint > extract(epoch from after)
   FROM checkpoint, after`,
 			[][]string{{"true"}})
-		tenant.Stopper().Stop(ctx)
+		tenant.AppStopper().Stop(ctx)
 	}
 
 	// Wait for the configs to be applied.
@@ -328,7 +328,7 @@ SELECT checkpoint > extract(epoch from after)
 			Locality: localities[i],
 		})
 		require.NoError(t, err)
-		defer tenant.Stopper().Stop(ctx)
+		defer tenant.AppStopper().Stop(ctx)
 		pgURL, cleanup, err := sqlutils.PGUrlWithOptionalClientCertsE(
 			tenant.AdvSQLAddr(), "tenantdata", url.UserPassword("foo", password),
 			false, // withClientCerts

--- a/pkg/ccl/multiregionccl/multiregion_system_table_test.go
+++ b/pkg/ccl/multiregionccl/multiregion_system_table_test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cockroachdb/apd/v3"
+	apd "github.com/cockroachdb/apd/v3"
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/ccl/multiregionccl/multiregionccltestutils"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -274,7 +274,7 @@ func TestMultiRegionTenantRegions(t *testing.T) {
 			},
 		},
 	})
-	defer ten.Stopper().Stop(ctx)
+	defer ten.AppStopper().Stop(ctx)
 	defer tSQL.Close()
 	tenSQLDB := sqlutils.MakeSQLRunner(tSQL)
 

--- a/pkg/ccl/multiregionccl/regional_by_row_system_database_test.go
+++ b/pkg/ccl/multiregionccl/regional_by_row_system_database_test.go
@@ -42,7 +42,7 @@ sql.virtual_cluster.feature_access.multiregion.enabled = true;`)
 		TenantID:    serverutils.TestTenantID(),
 		UseDatabase: "defaultdb",
 	})
-	defer tenant.Stopper().Stop(ctx)
+	defer tenant.AppStopper().Stop(ctx)
 
 	tdb := sqlutils.MakeSQLRunner(tenantDB)
 	tdb.Exec(t, `ALTER DATABASE system SET PRIMARY REGION "us-east1";`)

--- a/pkg/ccl/multitenantccl/tenantcostclient/query_ru_estimate_test.go
+++ b/pkg/ccl/multitenantccl/tenantcostclient/query_ru_estimate_test.go
@@ -83,7 +83,7 @@ func TestEstimateQueryRUConsumption(t *testing.T) {
 			},
 		},
 	})
-	defer tenant1.Stopper().Stop(ctx)
+	defer tenant1.AppStopper().Stop(ctx)
 	defer tenantDB1.Close()
 	tdb := sqlutils.MakeSQLRunner(tenantDB1)
 	tdb.Exec(t, "SET CLUSTER SETTING sql.stats.automatic_collection.enabled=false")

--- a/pkg/ccl/multitenantccl/tenantcostclient/tenant_side_test.go
+++ b/pkg/ccl/multitenantccl/tenantcostclient/tenant_side_test.go
@@ -1438,7 +1438,7 @@ func TestRUSettingsChanged(t *testing.T) {
 	tenant1, tenantDB1 := serverutils.StartTenant(t, s, base.TestTenantArgs{
 		TenantID: tenantID,
 	})
-	defer tenant1.Stopper().Stop(ctx)
+	defer tenant1.AppStopper().Stop(ctx)
 	defer tenantDB1.Close()
 
 	costClient, err := tenantcostclient.NewTenantSideCostController(tenant1.ClusterSettings(), tenantID, nil)

--- a/pkg/ccl/multitenantccl/tenantcostserver/server_test.go
+++ b/pkg/ccl/multitenantccl/tenantcostserver/server_test.go
@@ -97,7 +97,7 @@ func (ts *testState) start(t *testing.T) {
 }
 
 func (ts *testState) stop() {
-	ts.s.Stopper().Stop(context.Background())
+	ts.srv.Stopper().Stop(context.Background())
 }
 
 func (ts *testState) formatTime(tm time.Time) string {

--- a/pkg/ccl/serverccl/diagnosticsccl/reporter_test.go
+++ b/pkg/ccl/serverccl/diagnosticsccl/reporter_test.go
@@ -84,7 +84,7 @@ func TestTenantReport(t *testing.T) {
 	require.NotZero(t, len(last.FeatureUsage))
 
 	// Call PeriodicallyReportDiagnostics and ensure it sends out a report.
-	reporter.PeriodicallyReportDiagnostics(ctx, tenant.Stopper())
+	reporter.PeriodicallyReportDiagnostics(ctx, tenant.AppStopper())
 	testutils.SucceedsSoon(t, func() error {
 		if rt.diagServer.NumRequests() != 2 {
 			return errors.Errorf("did not receive a diagnostics report")

--- a/pkg/ccl/serverccl/server_sql_test.go
+++ b/pkg/ccl/serverccl/server_sql_test.go
@@ -207,7 +207,7 @@ func TestTenantProcessDebugging(t *testing.T) {
 			TenantName: "processdebug",
 		})
 	require.NoError(t, err)
-	defer tenant.Stopper().Stop(ctx)
+	defer tenant.AppStopper().Stop(ctx)
 
 	t.Run("system tenant pprof", func(t *testing.T) {
 		httpClient, err := s.GetAdminHTTPClient()

--- a/pkg/ccl/serverccl/tenant_migration_test.go
+++ b/pkg/ccl/serverccl/tenant_migration_test.go
@@ -111,7 +111,7 @@ func TestValidateTargetTenantClusterVersion(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			defer upgradePod.Stopper().Stop(context.Background())
+			defer upgradePod.AppStopper().Stop(context.Background())
 
 			tmServer := upgradePod.MigrationServer().(*server.TenantMigrationServer)
 			req := &serverpb.ValidateTargetClusterVersionRequest{
@@ -223,7 +223,7 @@ func TestBumpTenantClusterVersion(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			defer tenant.Stopper().Stop(context.Background())
+			defer tenant.AppStopper().Stop(context.Background())
 
 			// Check to see our initial active cluster versions are what we
 			// expect.

--- a/pkg/ccl/sqlproxyccl/backend_dialer_test.go
+++ b/pkg/ccl/sqlproxyccl/backend_dialer_test.go
@@ -97,11 +97,11 @@ func TestBackendDialTLS(t *testing.T) {
 
 	tenant10 := roachpb.MustMakeTenantID(10)
 	sql10, _ := serverutils.StartTenant(t, storageServer, base.TestTenantArgs{TenantID: tenant10})
-	defer sql10.Stopper().Stop(ctx)
+	defer sql10.AppStopper().Stop(ctx)
 
 	tenant11 := roachpb.MustMakeTenantID(11)
 	sql11, _ := serverutils.StartTenant(t, storageServer, base.TestTenantArgs{TenantID: tenant11})
-	defer sql11.Stopper().Stop(ctx)
+	defer sql11.AppStopper().Stop(ctx)
 
 	tests := []struct {
 		name     string

--- a/pkg/ccl/sqlproxyccl/proxy_handler_test.go
+++ b/pkg/ccl/sqlproxyccl/proxy_handler_test.go
@@ -1930,7 +1930,7 @@ func TestConnectionMigration(t *testing.T) {
 	// Start first SQL pod.
 	tenant1, tenantDB1 := serverutils.StartTenant(t, s, base.TestTenantArgs{TenantID: tenantID})
 	tenant1.PGPreServer().(*pgwire.PreServeConnHandler).TestingSetTrustClientProvidedRemoteAddr(true)
-	defer tenant1.Stopper().Stop(ctx)
+	defer tenant1.AppStopper().Stop(ctx)
 	defer tenantDB1.Close()
 
 	// Start second SQL pod.
@@ -1939,7 +1939,7 @@ func TestConnectionMigration(t *testing.T) {
 		DisableCreateTenant: true,
 	})
 	tenant2.PGPreServer().(*pgwire.PreServeConnHandler).TestingSetTrustClientProvidedRemoteAddr(true)
-	defer tenant2.Stopper().Stop(ctx)
+	defer tenant2.AppStopper().Stop(ctx)
 	defer tenantDB2.Close()
 
 	_, err = tenantDB1.Exec("CREATE USER testuser WITH PASSWORD 'hunter2'")

--- a/pkg/ccl/streamingccl/streamingest/replication_stream_e2e_test.go
+++ b/pkg/ccl/streamingccl/streamingest/replication_stream_e2e_test.go
@@ -505,7 +505,7 @@ func TestTenantStreamingUnavailableStreamAddress(t *testing.T) {
 	// test flakes, see #107499 for more info.
 	destroyedAddress := c.SrcURL.String()
 	require.NoError(t, c.SrcTenantConn.Close())
-	c.SrcTenantServer.Stopper().Stop(ctx)
+	c.SrcTenantServer.AppStopper().Stop(ctx)
 	c.SrcCluster.StopServer(0)
 
 	c.DestSysSQL.Exec(t, `RESUME JOB $1`, ingestionJobID)

--- a/pkg/ccl/streamingccl/streamproducer/replication_manager_test.go
+++ b/pkg/ccl/streamingccl/streamproducer/replication_manager_test.go
@@ -34,17 +34,13 @@ func TestReplicationManagerRequiresReplicationPrivilege(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	s, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop(ctx)
+	srv, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
+	defer srv.Stopper().Stop(ctx)
+	s := srv.ApplicationLayer()
+
 	tDB := sqlutils.MakeSQLRunner(sqlDB)
 
 	execCfg := s.ExecutorConfig().(sql.ExecutorConfig)
-
-	testTenants := s.TestTenants()
-	if len(testTenants) > 0 {
-		kvDB = testTenants[0].DB()
-		execCfg = testTenants[0].ExecutorConfig().(sql.ExecutorConfig)
-	}
 
 	var m sessiondatapb.MigratableSession
 	var sessionSerialized []byte

--- a/pkg/ccl/testccl/sqlccl/gc_job_test.go
+++ b/pkg/ccl/testccl/sqlccl/gc_job_test.go
@@ -40,7 +40,7 @@ func TestGCJobGetsMarkedIdle(t *testing.T) {
 	tenant, tenantDB := serverutils.StartTenant(t, s, base.TestTenantArgs{
 		TenantID: serverutils.TestTenantID(),
 	})
-	defer tenant.Stopper().Stop(ctx)
+	defer tenant.AppStopper().Stop(ctx)
 	defer tenantDB.Close()
 
 	sqlutils.MakeSQLRunner(mainDB).Exec(t,

--- a/pkg/ccl/testccl/sqlccl/session_revival_test.go
+++ b/pkg/ccl/testccl/sqlccl/session_revival_test.go
@@ -44,7 +44,7 @@ func TestAuthenticateWithSessionRevivalToken(t *testing.T) {
 	tenant, tenantDB := serverutils.StartTenant(t, s, base.TestTenantArgs{
 		TenantID: serverutils.TestTenantID(),
 	})
-	defer tenant.Stopper().Stop(ctx)
+	defer tenant.AppStopper().Stop(ctx)
 	defer tenantDB.Close()
 
 	_, err := tenantDB.Exec("CREATE USER testuser WITH PASSWORD 'hunter2'")

--- a/pkg/ccl/testccl/sqlccl/show_transfer_state_test.go
+++ b/pkg/ccl/testccl/sqlccl/show_transfer_state_test.go
@@ -37,7 +37,7 @@ func TestShowTransferState(t *testing.T) {
 	tenant, tenantDB := serverutils.StartTenant(t, s, base.TestTenantArgs{
 		TenantID: serverutils.TestTenantID(),
 	})
-	defer tenant.Stopper().Stop(ctx)
+	defer tenant.AppStopper().Stop(ctx)
 
 	_, err := tenantDB.Exec("CREATE USER testuser WITH PASSWORD 'hunter2'")
 	require.NoError(t, err)

--- a/pkg/kv/kvclient/rangefeed/db_adapter_external_test.go
+++ b/pkg/kv/kvclient/rangefeed/db_adapter_external_test.go
@@ -201,7 +201,7 @@ func TestDBClientScan(t *testing.T) {
 		// We expect 11 splits.
 		// One span will fail.  Verify we retry only the spans that we have not attempted before.
 		var parallelism = 6
-		f := rangefeed.NewFactoryWithDB(ts.Stopper(), dba, nil /* knobs */)
+		f := rangefeed.NewFactoryWithDB(ts.AppStopper(), dba, nil /* knobs */)
 		scanComplete := make(chan struct{})
 		scanErr := make(chan error, 1)
 		retryScanErr := errors.New("retry scan")

--- a/pkg/kv/kvclient/rangefeed/rangefeedcache/cache_test.go
+++ b/pkg/kv/kvclient/rangefeed/rangefeedcache/cache_test.go
@@ -72,7 +72,7 @@ func TestCache(t *testing.T) {
 		s.RangeFeedFactory().(*rangefeed.Factory),
 		[]roachpb.Span{scratchSpan},
 	)
-	require.NoError(t, c.Start(ctx, s.Stopper()))
+	require.NoError(t, c.Start(ctx, s.AppStopper()))
 	readRowsAt := func(t *testing.T, ts hlc.Timestamp) []roachpb.KeyValue {
 		txn := kvDB.NewTxn(ctx, "test")
 		require.NoError(t, txn.SetFixedTimestamp(ctx, ts))

--- a/pkg/kv/kvserver/protectedts/ptcache/cache_test.go
+++ b/pkg/kv/kvserver/protectedts/ptcache/cache_test.go
@@ -105,7 +105,7 @@ func TestCacheBasic(t *testing.T) {
 		DB:       insqlDB,
 		Storage:  m,
 	})
-	require.NoError(t, c.Start(ctx, s.Stopper()))
+	require.NoError(t, c.Start(ctx, s.AppStopper()))
 
 	// Make sure that protected timestamp gets updated.
 	ts := waitForAsOfAfter(t, c, hlc.Timestamp{})
@@ -196,7 +196,7 @@ func TestRefresh(t *testing.T) {
 		DB:       db,
 		Storage:  m,
 	})
-	require.NoError(t, c.Start(ctx, s.Stopper()))
+	require.NoError(t, c.Start(ctx, s.AppStopper()))
 
 	t.Run("already up-to-date", func(t *testing.T) {
 		ts := waitForAsOfAfter(t, c, hlc.Timestamp{})
@@ -361,7 +361,7 @@ func TestQueryRecord(t *testing.T) {
 		DB:       db,
 		Storage:  storage,
 	})
-	require.NoError(t, c.Start(ctx, s.Stopper()))
+	require.NoError(t, c.Start(ctx, s.AppStopper()))
 
 	// Wait for the initial fetch.
 	waitForAsOfAfter(t, c, hlc.Timestamp{})
@@ -427,7 +427,7 @@ func TestIterate(t *testing.T) {
 		DB:       db,
 		Storage:  m,
 	})
-	require.NoError(t, c.Start(ctx, s.Stopper()))
+	require.NoError(t, c.Start(ctx, s.AppStopper()))
 
 	sp42 := tableSpan(s.Codec(), 42)
 	sp43 := tableSpan(s.Codec(), 43)
@@ -573,7 +573,7 @@ func TestGetProtectionTimestamps(t *testing.T) {
 				DB:       s.InternalDB().(isql.DB),
 				Storage:  storage,
 			})
-			require.NoError(t, c.Start(ctx, s.Stopper()))
+			require.NoError(t, c.Start(ctx, s.AppStopper()))
 
 			testCase.test(t, p, c, func(records ...*ptpb.Record) {
 				for _, r := range records {
@@ -606,7 +606,7 @@ func TestSettingChangedLeadsToFetch(t *testing.T) {
 		DB:       db,
 		Storage:  m,
 	})
-	require.NoError(t, c.Start(ctx, s.Stopper()))
+	require.NoError(t, c.Start(ctx, s.AppStopper()))
 
 	// Make sure that the initial state has been fetched.
 	ts := waitForAsOfAfter(t, c, hlc.Timestamp{})

--- a/pkg/server/drain_test.go
+++ b/pkg/server/drain_test.go
@@ -305,7 +305,7 @@ func TestServerShutdownReleasesSession(t *testing.T) {
 	}
 
 	tenant, tenantSQLRaw := serverutils.StartTenant(t, s, tenantArgs)
-	defer tenant.Stopper().Stop(ctx)
+	defer tenant.AppStopper().Stop(ctx)
 	tenantSQL := sqlutils.MakeSQLRunner(tenantSQLRaw)
 
 	queryOwner := func(id base.SQLInstanceID) (owner *string) {
@@ -327,7 +327,7 @@ func TestServerShutdownReleasesSession(t *testing.T) {
 	require.True(t, sessionExists(*session))
 
 	require.NoError(t, tmpTenant.DrainClients(context.Background()))
-	tmpTenant.Stopper().Stop(ctx)
+	tmpTenant.AppStopper().Stop(ctx)
 
 	require.False(t, sessionExists(*session), "expected session %s to be deleted from the sqlliveness table, but it still exists", *session)
 	require.Nil(t, queryOwner(tmpSQLInstance), "expected sql_instance %d to have no owning session_id", tmpSQLInstance)

--- a/pkg/server/settingswatcher/settings_watcher_external_test.go
+++ b/pkg/server/settingswatcher/settings_watcher_external_test.go
@@ -164,7 +164,7 @@ func TestSettingWatcherOnTenant(t *testing.T) {
 	storage := &fakeStorage{}
 	sw := settingswatcher.New(s0.Clock(), fakeCodec, tenantSettings,
 		s0.ExecutorConfig().(sql.ExecutorConfig).RangeFeedFactory,
-		s0.Stopper(), storage)
+		s0.AppStopper(), storage)
 	require.NoError(t, sw.Start(ctx))
 	require.NoError(t, checkSettingsValuesMatch(s0.ClusterSettings(), tenantSettings))
 	for k, v := range toSet {
@@ -246,7 +246,7 @@ func TestSettingsWatcherWithOverrides(t *testing.T) {
 	srv, db, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
 	defer srv.Stopper().Stop(ctx)
 	ts := srv.ApplicationLayer()
-	stopper := ts.Stopper()
+	stopper := ts.AppStopper()
 
 	r := sqlutils.MakeSQLRunner(db)
 	// Set some settings (to verify handling of existing rows).

--- a/pkg/server/tenantsettingswatcher/watcher_test.go
+++ b/pkg/server/tenantsettingswatcher/watcher_test.go
@@ -52,7 +52,7 @@ func TestWatcher(t *testing.T) {
 	w := tenantsettingswatcher.New(
 		ts.Clock(),
 		ts.ExecutorConfig().(sql.ExecutorConfig).RangeFeedFactory,
-		ts.Stopper(),
+		ts.AppStopper(),
 		ts.ClusterSettings(),
 	)
 	err := w.Start(ctx, ts.SystemTableIDResolver().(catalog.SystemTableIDResolver))

--- a/pkg/spanconfig/spanconfigmanager/manager_test.go
+++ b/pkg/spanconfig/spanconfigmanager/manager_test.go
@@ -73,7 +73,7 @@ func TestManagerConcurrentJobCreation(t *testing.T) {
 	manager := spanconfigmanager.New(
 		ts.InternalDB().(isql.DB),
 		ts.JobRegistry().(*jobs.Registry),
-		ts.Stopper(),
+		ts.AppStopper(),
 		ts.ClusterSettings(),
 		ts.SpanConfigReconciler().(spanconfig.Reconciler),
 		&spanconfig.TestingKnobs{
@@ -157,7 +157,7 @@ func TestManagerStartsJobIfFailed(t *testing.T) {
 	manager := spanconfigmanager.New(
 		ts.InternalDB().(isql.DB),
 		ts.JobRegistry().(*jobs.Registry),
-		ts.Stopper(),
+		ts.AppStopper(),
 		ts.ClusterSettings(),
 		ts.SpanConfigReconciler().(spanconfig.Reconciler),
 		&spanconfig.TestingKnobs{
@@ -226,7 +226,7 @@ func TestManagerCheckJobConditions(t *testing.T) {
 	manager := spanconfigmanager.New(
 		ts.InternalDB().(isql.DB),
 		ts.JobRegistry().(*jobs.Registry),
-		ts.Stopper(),
+		ts.AppStopper(),
 		ts.ClusterSettings(),
 		ts.SpanConfigReconciler().(spanconfig.Reconciler),
 		&spanconfig.TestingKnobs{
@@ -326,7 +326,7 @@ func TestReconciliationJobErrorAndRecovery(t *testing.T) {
 	manager := spanconfigmanager.New(
 		ts.InternalDB().(isql.DB),
 		ts.JobRegistry().(*jobs.Registry),
-		ts.Stopper(),
+		ts.AppStopper(),
 		ts.ClusterSettings(),
 		ts.SpanConfigReconciler().(spanconfig.Reconciler),
 		&spanconfig.TestingKnobs{
@@ -420,7 +420,7 @@ func TestReconciliationUsesRightCheckpoint(t *testing.T) {
 	manager := spanconfigmanager.New(
 		ts.InternalDB().(isql.DB),
 		ts.JobRegistry().(*jobs.Registry),
-		ts.Stopper(),
+		ts.AppStopper(),
 		ts.ClusterSettings(),
 		ts.SpanConfigReconciler().(spanconfig.Reconciler),
 		nil,

--- a/pkg/sql/catalog/lease/lease_test.go
+++ b/pkg/sql/catalog/lease/lease_test.go
@@ -254,7 +254,7 @@ func (t *leaseTest) node(nodeID uint32) *lease.Manager {
 			t.server.SettingsWatcher().(*settingswatcher.SettingsWatcher),
 			cfgCpy.Codec,
 			t.leaseManagerTestingKnobs,
-			t.server.Stopper(),
+			t.server.AppStopper(),
 			cfgCpy.RangeFeedFactory,
 		)
 		ctx := logtags.AddTag(context.Background(), "leasemgr", nodeID)

--- a/pkg/sql/copy/copy_out_test.go
+++ b/pkg/sql/copy/copy_out_test.go
@@ -58,7 +58,7 @@ func TestCopyOutTransaction(t *testing.T) {
 		url.User(username.RootUser),
 	)
 	require.NoError(t, err)
-	s.Stopper().AddCloser(stop.CloserFn(func() { cleanupGoDB() }))
+	s.AppStopper().AddCloser(stop.CloserFn(func() { cleanupGoDB() }))
 	config, err := pgx.ParseConfig(pgURL.String())
 	require.NoError(t, err)
 
@@ -126,7 +126,7 @@ func TestCopyOutRandom(t *testing.T) {
 		url.User(username.RootUser),
 	)
 	require.NoError(t, err)
-	s.Stopper().AddCloser(stop.CloserFn(func() { cleanupGoDB() }))
+	s.AppStopper().AddCloser(stop.CloserFn(func() { cleanupGoDB() }))
 	config, err := pgx.ParseConfig(pgURL.String())
 	require.NoError(t, err)
 	config.Database = sqlutils.TestDB

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -7418,9 +7418,9 @@ func TestOperationAtRandomStateTransition(t *testing.T) {
 				},
 			},
 		}
-		s, sqlDB, _ := serverutils.StartServer(t, params)
+		srv, sqlDB, _ := serverutils.StartServer(t, params)
+		defer srv.Stopper().Stop(ctx)
 		sqlRunner := sqlutils.MakeSQLRunner(sqlDB)
-		defer s.Stopper().Stop(ctx)
 
 		sqlRunner.Exec(t, tc.setupSQL)
 		atomic.StoreInt32(&shouldCount, 1)
@@ -7433,7 +7433,7 @@ func TestOperationAtRandomStateTransition(t *testing.T) {
 			count     int32 // accessed atomically
 			shouldRun int32 // accessed atomically
 
-			s     serverutils.ApplicationLayerInterface
+			srv   serverutils.TestServerInterface
 			sqlDB *gosql.DB
 			kvDB  *kv.DB
 		)
@@ -7455,8 +7455,8 @@ func TestOperationAtRandomStateTransition(t *testing.T) {
 				},
 			},
 		}
-		s, sqlDB, kvDB = serverutils.StartServer(t, params)
-		defer s.Stopper().Stop(ctx)
+		srv, sqlDB, kvDB = serverutils.StartServer(t, params)
+		defer srv.Stopper().Stop(ctx)
 		_, err := sqlDB.Exec(tc.setupSQL)
 		require.NoError(t, err)
 		atomic.StoreInt32(&shouldRun, 1)

--- a/pkg/sql/sqlinstance/instancestorage/instancecache_test.go
+++ b/pkg/sql/sqlinstance/instancestorage/instancecache_test.go
@@ -94,7 +94,7 @@ func TestRangeFeed(t *testing.T) {
 
 		require.NoError(t, storage.generateAvailableInstanceRows(ctx, [][]byte{enum.One}, tenant.Clock().Now().Add(int64(time.Minute), 0)))
 
-		feed, err := storage.newInstanceCache(ctx, tenant.Stopper())
+		feed, err := storage.newInstanceCache(ctx, tenant.AppStopper())
 		require.NoError(t, err)
 		require.NotNil(t, feed)
 		defer feed.Close()
@@ -107,7 +107,7 @@ func TestRangeFeed(t *testing.T) {
 
 	t.Run("auth_error", func(t *testing.T) {
 		storage := newStorage(t, keys.SystemSQLCodec)
-		_, err := storage.newInstanceCache(ctx, tenant.Stopper())
+		_, err := storage.newInstanceCache(ctx, tenant.AppStopper())
 		require.True(t, grpcutil.IsAuthError(err), "expected %+v to be an auth error", err)
 	})
 
@@ -117,7 +117,7 @@ func TestRangeFeed(t *testing.T) {
 		ctx, cancel := context.WithCancel(ctx)
 		cancel()
 
-		_, err := storage.newInstanceCache(ctx, tenant.Stopper())
+		_, err := storage.newInstanceCache(ctx, tenant.AppStopper())
 		require.Error(t, err)
 		require.ErrorIs(t, err, ctx.Err())
 	})

--- a/pkg/sql/sqlinstance/instancestorage/instancereader_test.go
+++ b/pkg/sql/sqlinstance/instancestorage/instancereader_test.go
@@ -57,7 +57,7 @@ func TestReader(t *testing.T) {
 		table := desctestutils.TestingGetPublicTableDescriptor(s.DB(), s.Codec(), dbName, "sql_instances")
 		slStorage := slstorage.NewFakeStorage()
 		storage := instancestorage.NewTestingStorage(s.DB(), s.Codec(), table, slStorage, s.ClusterSettings(), s.Clock(), s.RangeFeedFactory().(*rangefeed.Factory), s.SettingsWatcher().(*settingswatcher.SettingsWatcher))
-		reader := instancestorage.NewTestingReader(storage, slStorage, s.Stopper(), s.DB())
+		reader := instancestorage.NewTestingReader(storage, slStorage, s.AppStopper(), s.DB())
 		return storage, slStorage, s.Clock(), reader
 	}
 

--- a/pkg/sql/sqlinstance/instancestorage/instancestorage_test.go
+++ b/pkg/sql/sqlinstance/instancestorage/instancestorage_test.go
@@ -560,7 +560,7 @@ func TestReclaimLoop(t *testing.T) {
 	sessionExpiry := clock.Now().Add(expiration.Nanoseconds(), 0)
 
 	db := s.InternalDB().(descs.DB)
-	err := storage.RunInstanceIDReclaimLoop(ctx, s.Stopper(), ts, db, func() hlc.Timestamp {
+	err := storage.RunInstanceIDReclaimLoop(ctx, s.AppStopper(), ts, db, func() hlc.Timestamp {
 		return sessionExpiry
 	})
 	require.NoError(t, err)

--- a/pkg/sql/sqlliveness/slstorage/slstorage_test.go
+++ b/pkg/sql/sqlliveness/slstorage/slstorage_test.go
@@ -680,7 +680,7 @@ func TestDeleteMidUpdateFails(t *testing.T) {
 
 	storage := slstorage.NewTestingStorage(
 		s.DB().AmbientContext,
-		s.Stopper(), s.Clock(), kvDB, s.Codec(), s.ClusterSettings(),
+		s.AppStopper(), s.Clock(), kvDB, s.Codec(), s.ClusterSettings(),
 		s.SettingsWatcher().(*settingswatcher.SettingsWatcher), table, timeutil.DefaultTimeSource{}.NewTimer,
 	)
 

--- a/pkg/sql/stats/automatic_stats_test.go
+++ b/pkg/sql/stats/automatic_stats_test.go
@@ -84,7 +84,7 @@ func TestMaybeRefreshStats(t *testing.T) {
 	// There are no stats yet, so this must refresh the statistics on table t
 	// even though rowsAffected=0.
 	refresher.maybeRefreshStats(
-		ctx, s.Stopper(), descA.GetID(), nil /* explicitSettings */, 0 /* rowsAffected */, time.Microsecond, /* asOf */
+		ctx, s.AppStopper(), descA.GetID(), nil /* explicitSettings */, 0 /* rowsAffected */, time.Microsecond, /* asOf */
 	)
 	if err := checkStatsCount(ctx, cache, descA, 1 /* expected */); err != nil {
 		t.Fatal(err)
@@ -93,7 +93,7 @@ func TestMaybeRefreshStats(t *testing.T) {
 	// Try to refresh again. With rowsAffected=0, the probability of a refresh
 	// is 0, so refreshing will not succeed.
 	refresher.maybeRefreshStats(
-		ctx, s.Stopper(), descA.GetID(), nil /* explicitSettings */, 0 /* rowsAffected */, time.Microsecond, /* asOf */
+		ctx, s.AppStopper(), descA.GetID(), nil /* explicitSettings */, 0 /* rowsAffected */, time.Microsecond, /* asOf */
 	)
 	if err := checkStatsCount(ctx, cache, descA, 1 /* expected */); err != nil {
 		t.Fatal(err)
@@ -103,7 +103,7 @@ func TestMaybeRefreshStats(t *testing.T) {
 	minStaleRows := int64(100000000)
 	explicitSettings := catpb.AutoStatsSettings{MinStaleRows: &minStaleRows}
 	refresher.maybeRefreshStats(
-		ctx, s.Stopper(), descA.GetID(), &explicitSettings, 10 /* rowsAffected */, time.Microsecond, /* asOf */
+		ctx, s.AppStopper(), descA.GetID(), &explicitSettings, 10 /* rowsAffected */, time.Microsecond, /* asOf */
 	)
 	if err := checkStatsCount(ctx, cache, descA, 1 /* expected */); err != nil {
 		t.Fatal(err)
@@ -114,7 +114,7 @@ func TestMaybeRefreshStats(t *testing.T) {
 	fractionStaleRows := float64(100000000)
 	explicitSettings = catpb.AutoStatsSettings{FractionStaleRows: &fractionStaleRows}
 	refresher.maybeRefreshStats(
-		ctx, s.Stopper(), descA.GetID(), &explicitSettings, 10 /* rowsAffected */, time.Microsecond, /* asOf */
+		ctx, s.AppStopper(), descA.GetID(), &explicitSettings, 10 /* rowsAffected */, time.Microsecond, /* asOf */
 	)
 	if err := checkStatsCount(ctx, cache, descA, 1 /* expected */); err != nil {
 		t.Fatal(err)
@@ -123,7 +123,7 @@ func TestMaybeRefreshStats(t *testing.T) {
 	// With rowsAffected=10, refreshing should work. Since there are more rows
 	// updated than exist in the table, the probability of a refresh is 100%.
 	refresher.maybeRefreshStats(
-		ctx, s.Stopper(), descA.GetID(), nil /* explicitSettings */, 10 /* rowsAffected */, time.Microsecond, /* asOf */
+		ctx, s.AppStopper(), descA.GetID(), nil /* explicitSettings */, 10 /* rowsAffected */, time.Microsecond, /* asOf */
 	)
 	if err := checkStatsCount(ctx, cache, descA, 2 /* expected */); err != nil {
 		t.Fatal(err)
@@ -134,7 +134,7 @@ func TestMaybeRefreshStats(t *testing.T) {
 	descRoleOptions :=
 		desctestutils.TestingGetPublicTableDescriptor(s.DB(), codec, "system", "role_options")
 	refresher.maybeRefreshStats(
-		ctx, s.Stopper(), descRoleOptions.GetID(), nil /* explicitSettings */, 10000 /* rowsAffected */, time.Microsecond, /* asOf */
+		ctx, s.AppStopper(), descRoleOptions.GetID(), nil /* explicitSettings */, 10000 /* rowsAffected */, time.Microsecond, /* asOf */
 	)
 	if err := checkStatsCount(ctx, cache, descRoleOptions, 5 /* expected */); err != nil {
 		t.Fatal(err)
@@ -144,7 +144,7 @@ func TestMaybeRefreshStats(t *testing.T) {
 	descLease :=
 		desctestutils.TestingGetPublicTableDescriptor(s.DB(), codec, "system", "lease")
 	refresher.maybeRefreshStats(
-		ctx, s.Stopper(), descLease.GetID(), nil /* explicitSettings */, 10000 /* rowsAffected */, time.Microsecond, /* asOf */
+		ctx, s.AppStopper(), descLease.GetID(), nil /* explicitSettings */, 10000 /* rowsAffected */, time.Microsecond, /* asOf */
 	)
 	if err := checkStatsCount(ctx, cache, descLease, 0 /* expected */); err != nil {
 		t.Fatal(err)
@@ -154,7 +154,7 @@ func TestMaybeRefreshStats(t *testing.T) {
 	descTableStats :=
 		desctestutils.TestingGetPublicTableDescriptor(s.DB(), codec, "system", "table_statistics")
 	refresher.maybeRefreshStats(
-		ctx, s.Stopper(), descTableStats.GetID(), nil /* explicitSettings */, 10000 /* rowsAffected */, time.Microsecond, /* asOf */
+		ctx, s.AppStopper(), descTableStats.GetID(), nil /* explicitSettings */, 10000 /* rowsAffected */, time.Microsecond, /* asOf */
 	)
 	if err := checkStatsCount(ctx, cache, descTableStats, 0 /* expected */); err != nil {
 		t.Fatal(err)
@@ -165,7 +165,7 @@ func TestMaybeRefreshStats(t *testing.T) {
 	// TODO(rytaft): Should not enqueue views to begin with.
 	descVW := desctestutils.TestingGetPublicTableDescriptor(s.DB(), codec, "t", "vw")
 	refresher.maybeRefreshStats(
-		ctx, s.Stopper(), descVW.GetID(), nil /* explicitSettings */, 0 /* rowsAffected */, time.Microsecond, /* asOf */
+		ctx, s.AppStopper(), descVW.GetID(), nil /* explicitSettings */, 0 /* rowsAffected */, time.Microsecond, /* asOf */
 	)
 	select {
 	case <-refresher.mutations:
@@ -499,7 +499,7 @@ func TestAverageRefreshTime(t *testing.T) {
 	// the statistics on table t. With rowsAffected=0, the probability of refresh
 	// is 0.
 	refresher.maybeRefreshStats(
-		ctx, s.Stopper(), table.GetID(), nil /* explicitSettings */, 0 /* rowsAffected */, time.Microsecond, /* asOf */
+		ctx, s.AppStopper(), table.GetID(), nil /* explicitSettings */, 0 /* rowsAffected */, time.Microsecond, /* asOf */
 	)
 	if err := checkStatsCount(ctx, cache, table, 20 /* expected */); err != nil {
 		t.Fatal(err)
@@ -549,7 +549,7 @@ func TestAverageRefreshTime(t *testing.T) {
 	// remain (5 from column k and 5 from column v), since the old stats on k
 	// and v were deleted.
 	refresher.maybeRefreshStats(
-		ctx, s.Stopper(), table.GetID(), nil /* explicitSettings */, 0 /* rowsAffected */, time.Microsecond, /* asOf */
+		ctx, s.AppStopper(), table.GetID(), nil /* explicitSettings */, 0 /* rowsAffected */, time.Microsecond, /* asOf */
 	)
 	if err := checkStatsCount(ctx, cache, table, 10 /* expected */); err != nil {
 		t.Fatal(err)
@@ -593,7 +593,7 @@ func TestAutoStatsReadOnlyTables(t *testing.T) {
 	AutomaticStatisticsClusterMode.Override(ctx, &st.SV, true)
 
 	if err := refresher.Start(
-		ctx, s.Stopper(), time.Millisecond, /* refreshInterval */
+		ctx, s.AppStopper(), time.Millisecond, /* refreshInterval */
 	); err != nil {
 		t.Fatal(err)
 	}
@@ -647,7 +647,7 @@ func TestAutoStatsOnStartupClusterSettingOff(t *testing.T) {
 
 	// Refresher start should trigger stats collection on t.a.
 	if err := refresher.Start(
-		ctx, s.Stopper(), time.Millisecond, /* refreshInterval */
+		ctx, s.AppStopper(), time.Millisecond, /* refreshInterval */
 	); err != nil {
 		t.Fatal(err)
 	}
@@ -694,7 +694,7 @@ func TestNoRetryOnFailure(t *testing.T) {
 
 	// Try to refresh stats on a table that doesn't exist.
 	r.maybeRefreshStats(
-		ctx, s.Stopper(), 100 /* tableID */, nil /* explicitSettings */, math.MaxInt32,
+		ctx, s.AppStopper(), 100 /* tableID */, nil /* explicitSettings */, math.MaxInt32,
 		time.Microsecond, /* asOfTime */
 	)
 


### PR DESCRIPTION
This commit simplifies as follows:

- it removes use of .SystemLayer() and .ApplicationLayer() from within the testServer code. This is ahead of a smarter implementation of these accessors in a later commit.

- it renames "Stopper" to "AppStopper" in "ApplicationLayerInterface", to disambiguate it from the stopper at the top level testServer.

Release note: None
Fixes #109565.
Epic: CRDB-18499