### PR TITLE
sql: fix SQL Activity table execution_total_cluster_seconds

### DIFF
--- a/pkg/server/combined_statement_stats.go
+++ b/pkg/server/combined_statement_stats.go
@@ -305,19 +305,30 @@ func getSourceStatsInfo(
 	whereClauseOldestDate := buffer.String()
 
 	getRuntime := func(table string) (float32, error) {
-		it, err := ie.QueryIteratorEx(
-			ctx,
-			fmt.Sprintf(`console-combined-stmts-%s-total-runtime`, table),
-			nil,
-			sessiondata.NodeUserSessionDataOverride,
-			fmt.Sprintf(`
+		var queryToGetClusterTotalRunTime string
+		if activityTableHasAllData {
+			queryToGetClusterTotalRunTime = fmt.Sprintf(`
+SELECT COALESCE(
+         execution_total_cluster_seconds,
+       0)
+FROM %s %s LIMIT 1`, table, whereClause)
+		} else {
+			queryToGetClusterTotalRunTime = fmt.Sprintf(`
 SELECT COALESCE(
           sum(
              (statistics -> 'statistics' -> 'svcLat' ->> 'mean')::FLOAT *
              (statistics -> 'statistics' ->> 'cnt')::FLOAT
           ),
        0)
-FROM %s %s`, table, whereClause), args...)
+FROM %s %s`, table, whereClause)
+		}
+
+		it, err := ie.QueryIteratorEx(
+			ctx,
+			fmt.Sprintf(`console-combined-stmts-%s-total-runtime`, table),
+			nil,
+			sessiondata.NodeUserSessionDataOverride,
+			queryToGetClusterTotalRunTime, args...)
 
 		if err != nil {
 			return 0, err

--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -783,6 +783,7 @@ go_test(
         "//pkg/server",
         "//pkg/server/serverpb",
         "//pkg/server/settingswatcher",
+        "//pkg/server/srvtestutils",
         "//pkg/server/status/statuspb",
         "//pkg/server/telemetry",
         "//pkg/settings",

--- a/pkg/sql/sql_activity_update_job.go
+++ b/pkg/sql/sql_activity_update_job.go
@@ -185,7 +185,7 @@ func (u *sqlActivityUpdater) TransferStatsToActivity(ctx context.Context) error 
 
 	// The counts are using AS OF SYSTEM TIME so the values may be slightly
 	// off. This is acceptable to increase the performance.
-	stmtRowCount, txnRowCount, totalStmtClusterExecCount, totalTxnClusterExecCount, err := u.getAostExecutionCount(ctx, aggTs)
+	stmtRowCount, txnRowCount, totalEstimatedStmtClusterExecSeconds, totalEstimatedTxnClusterExecSeconds, err := u.getAostRowCountAndTotalClusterExecSeconds(ctx, aggTs)
 	if err != nil {
 		return err
 	}
@@ -208,12 +208,12 @@ func (u *sqlActivityUpdater) TransferStatsToActivity(ctx context.Context) error 
 	// Just transfer all the stats to avoid overhead of getting
 	// the tops.
 	if stmtRowCount < (topLimit*numberOfTopColumns) && txnRowCount < (topLimit*numberOfTopColumns) {
-		return u.transferAllStats(ctx, aggTs, totalStmtClusterExecCount, totalTxnClusterExecCount)
+		return u.transferAllStats(ctx, aggTs, totalEstimatedStmtClusterExecSeconds, totalEstimatedTxnClusterExecSeconds)
 	}
 
 	// Only transfer the top sql.stats.activity.top.max for each of
 	// the 6 most popular columns
-	err = u.transferTopStats(ctx, aggTs, topLimit, totalStmtClusterExecCount, totalTxnClusterExecCount)
+	err = u.transferTopStats(ctx, aggTs, topLimit, totalEstimatedStmtClusterExecSeconds, totalEstimatedTxnClusterExecSeconds)
 	return err
 }
 
@@ -223,8 +223,8 @@ func (u *sqlActivityUpdater) TransferStatsToActivity(ctx context.Context) error 
 func (u *sqlActivityUpdater) transferAllStats(
 	ctx context.Context,
 	aggTs time.Time,
-	totalStmtClusterExecCount int64,
-	totalTxnClusterExecCount int64,
+	totalEstimatedStmtClusterExecSeconds float64,
+	totalEstimatedTxnClusterExecSeconds float64,
 ) error {
 	// Any change should update cockroach/pkg/sql/opt/exec/execbuilder/testdata/observability
 	_, err := u.db.Executor().ExecEx(ctx,
@@ -265,7 +265,7 @@ func (u *sqlActivityUpdater) transferAllStats(
                     fingerprint_id,
                     agg_interval));
 `,
-		totalTxnClusterExecCount,
+		totalEstimatedTxnClusterExecSeconds,
 		aggTs,
 	)
 
@@ -325,7 +325,7 @@ INTO system.public.statement_activity (aggregated_ts, fingerprint_id, transactio
                     plan,
                     index_recommendations));
 `,
-		totalStmtClusterExecCount,
+		totalEstimatedStmtClusterExecSeconds,
 		aggTs,
 	)
 
@@ -339,8 +339,8 @@ func (u *sqlActivityUpdater) transferTopStats(
 	ctx context.Context,
 	aggTs time.Time,
 	topLimit int64,
-	totalStmtClusterExecCount int64,
-	totalTxnClusterExecCount int64,
+	totalEstimatedStmtClusterExecSeconds float64,
+	totalEstimatedTxnClusterExecSeconds float64,
 ) (retErr error) {
 
 	// Deleting and inserting the activity tables needs to be done in the same
@@ -441,7 +441,7 @@ INTO system.public.transaction_activity
                     ts.fingerprint_id,
                     ts.agg_interval));
 `,
-			totalStmtClusterExecCount,
+			totalEstimatedTxnClusterExecSeconds,
 			aggTs,
 			topLimit,
 		)
@@ -560,7 +560,7 @@ INTO system.public.statement_activity
                     ss.plan,
                     ss.index_recommendations));
 `,
-			totalTxnClusterExecCount,
+			totalEstimatedStmtClusterExecSeconds,
 			aggTs,
 			topLimit,
 		)
@@ -647,55 +647,43 @@ FROM (SELECT max(ss.aggregated_ts) AS aggregated_ts,
 		 ss.plan,
 		 ss.index_recommendations));
 `,
-		totalStmtClusterExecCount,
+		totalEstimatedStmtClusterExecSeconds,
 		aggTs)
 
 	return err
 }
 
-// getAostExecutionCount is used to get the row counts of both the
-// system.statement_statistics and system.transaction_statistics.
-// It also gets the total execution count for the specified aggregated
-// timestamp.
-func (u *sqlActivityUpdater) getAostExecutionCount(
+// getAostRowCountAndTotalClusterExecSeconds is used to get the row counts of
+// both the system.statement_statistics and system.transaction_statistics.
+// It also gets the total execution seconds for all the stmts/txn for the
+// specified aggregated timestamp.
+func (u *sqlActivityUpdater) getAostRowCountAndTotalClusterExecSeconds(
 	ctx context.Context, aggTs time.Time,
 ) (
 	stmtRowCount int64,
 	txnRowCount int64,
-	totalStmtClusterExecCount int64,
-	totalTxnClusterExecCount int64,
+	totalEstimatedStmtClusterExecSeconds float64,
+	totalEstimatedTxnClusterExecSeconds float64,
 	retErr error,
 ) {
-
-	query := `
-SELECT row_count,
-       ex_sum
-FROM (SELECT count_rows():::int                     AS row_count,
-             COALESCE(sum(execution_count)::int, 0) AS ex_sum
-      FROM system.statement_statistics AS OF SYSTEM TIME follower_read_timestamp()
-      WHERE app_name not like '$ internal%' and aggregated_ts = $1
-      union all
-      SELECT
-          count_rows():::int AS row_count, COALESCE (sum(execution_count)::int, 0) AS ex_sum
-      FROM system.transaction_statistics AS OF SYSTEM TIME follower_read_timestamp()
-      WHERE app_name not like '$ internal%' and aggregated_ts = $1) AS OF SYSTEM TIME follower_read_timestamp()`
-
+	aost := "AS OF SYSTEM TIME follower_read_timestamp()"
 	if u.testingKnobs != nil {
-		// We repeat the query in order to avoid formatting the query every time.
-		aost := u.testingKnobs.GetAOSTClause()
-		query = fmt.Sprintf(`
+		aost = u.testingKnobs.GetAOSTClause()
+	}
+
+	query := fmt.Sprintf(`
 SELECT row_count,
        ex_sum
 FROM (SELECT count_rows():::int                     AS row_count,
-             COALESCE(sum(execution_count)::int, 0) AS ex_sum
+             COALESCE(sum(total_estimated_execution_time), 0) AS ex_sum
       FROM system.statement_statistics %[1]s
-      WHERE app_name not like '$ internal%%' and aggregated_ts = $1
+      WHERE aggregated_ts = $1
       union all
       SELECT
-          count_rows():::int AS row_count, COALESCE (sum(execution_count)::int, 0) AS ex_sum
+          count_rows():::int AS row_count, 
+          COALESCE (sum(total_estimated_execution_time), 0) AS ex_sum
       FROM system.transaction_statistics %[1]s
-      WHERE app_name not like '$ internal%%' and aggregated_ts = $1) %[1]s`, aost)
-	}
+      WHERE aggregated_ts = $1) %[1]s`, aost)
 
 	it, err := u.db.Executor().QueryIteratorEx(ctx,
 		"activity-flush-count",
@@ -711,18 +699,18 @@ FROM (SELECT count_rows():::int                     AS row_count,
 
 	defer func() { retErr = errors.CombineErrors(retErr, it.Close()) }()
 
-	stmtRowCount, totalStmtClusterExecCount, err = u.getExecutionCountFromRow(ctx, it)
+	stmtRowCount, totalEstimatedStmtClusterExecSeconds, err = u.getExecutionCountFromRow(ctx, it)
 	if err != nil {
 		return -1, -1, -1, -1, err
 	}
 
-	txnRowCount, totalTxnClusterExecCount, err = u.getExecutionCountFromRow(ctx, it)
-	return stmtRowCount, txnRowCount, totalStmtClusterExecCount, totalTxnClusterExecCount, err
+	txnRowCount, totalEstimatedTxnClusterExecSeconds, err = u.getExecutionCountFromRow(ctx, it)
+	return stmtRowCount, txnRowCount, totalEstimatedStmtClusterExecSeconds, totalEstimatedTxnClusterExecSeconds, err
 }
 
 func (u *sqlActivityUpdater) getExecutionCountFromRow(
 	ctx context.Context, iter isql.Rows,
-) (rowCount int64, totalExecutionCount int64, err error) {
+) (rowCount int64, totalEstimatedClusterExecSeconds float64, err error) {
 	ok, err := iter.Next(ctx)
 	if err != nil {
 		return -1, -1, err
@@ -737,7 +725,7 @@ func (u *sqlActivityUpdater) getExecutionCountFromRow(
 		return 0, 0, nil
 	}
 
-	return int64(tree.MustBeDInt(row[0])), int64(tree.MustBeDInt(row[1])), nil
+	return int64(tree.MustBeDInt(row[0])), float64(tree.MustBeDFloat(row[1])), nil
 }
 
 func (u *sqlActivityUpdater) getTimeNow() time.Time {


### PR DESCRIPTION
Problem:
1. The value in both the `statement_activity` and `transaction_activity` for the column `execution_total_cluster_seconds` was actually the `execution_total_cluster_count` instead of the total execution seconds for the cluster.
2. The `combinedstmts` endpoint returned value wrong value for `StmtsTotalRuntimeSecs` and `TxnsTotalRuntimeSecs`. It was only the total using the activity tables. The activity tables only cache The top N (default 500) results.

Solution:
1. Renamed variables to align what they mean and calculate the correct total value for `execution_total_cluster_seconds`.
2. Changed the `combinedstmts` to used the cached value from the column `execution_total_cluster_seconds` instead of calcuating it from the activity tables.

Fixes: #109445

Release note (sql change): The `statement_activity` and `transaction_activity` table column `execution_total_cluster_seconds` is now accurate. The `combinedstmts` endpoint returns the correct value for the `StmtsTotalRuntimeSecs` and `TxnsTotalRuntimeSecs` properties.