### PR TITLE
cmd/issues: test failures are filed as release-blockers

### DIFF
--- a/pkg/cmd/internal/issues/issues.go
+++ b/pkg/cmd/internal/issues/issues.go
@@ -46,8 +46,9 @@ func enforceMaxLength(s string) string {
 }
 
 const (
-	robotLabel       = "O-robot"
-	testFailureLabel = "C-test-failure"
+	robotLabel          = "O-robot"
+	testFailureLabel    = "C-test-failure"
+	releaseBlockerLabel = "release-blocker"
 )
 
 // Label we expect when checking existing issues. Sometimes users open
@@ -74,7 +75,7 @@ func issueLabels(req PostRequest) []string {
 		return labels
 	}
 
-	return append(labels, testFailureLabel)
+	return append(labels, testFailureLabel, releaseBlockerLabel)
 }
 
 // context augments context.Context with a logger.

--- a/pkg/cmd/internal/issues/testdata/post/failure-no-issue.txt
+++ b/pkg/cmd/internal/issues/testdata/post/failure-no-issue.txt
@@ -6,7 +6,7 @@ searchIssue repo:"cockroach" user:"cockroachdb" is:issue is:open in:title label:
 getBinaryVersion: result v3.3.0
 listMilestones owner=cockroachdb repo=cockroach: result [github.Milestone{Number:2, Title:"3.3"} github.Milestone{Number:1, Title:"3.2"}]
 createIssue owner=cockroachdb repo=cockroach:
-github.IssueRequest{Labels:["O-robot" "C-test-failure" "branch-release-0.1" "release-blocker"], Milestone:2}
+github.IssueRequest{Labels:["O-robot" "C-test-failure" "release-blocker" "branch-release-0.1" "release-blocker"], Milestone:2}
 
 storage: TestReplicateQueueRebalance failed
 

--- a/pkg/cmd/internal/issues/testdata/post/failure-related-issue.txt
+++ b/pkg/cmd/internal/issues/testdata/post/failure-related-issue.txt
@@ -6,7 +6,7 @@ searchIssue repo:"cockroach" user:"cockroachdb" is:issue is:open in:title label:
 getBinaryVersion: result v3.3.0
 listMilestones owner=cockroachdb repo=cockroach: result [github.Milestone{Number:2, Title:"3.3"} github.Milestone{Number:1, Title:"3.2"}]
 createIssue owner=cockroachdb repo=cockroach:
-github.IssueRequest{Labels:["O-robot" "C-test-failure" "branch-release-0.1" "release-blocker"], Milestone:2}
+github.IssueRequest{Labels:["O-robot" "C-test-failure" "release-blocker" "branch-release-0.1" "release-blocker"], Milestone:2}
 
 storage: TestReplicateQueueRebalance failed
 

--- a/pkg/cmd/internal/issues/testdata/post/failure-with-url-no-issue.txt
+++ b/pkg/cmd/internal/issues/testdata/post/failure-with-url-no-issue.txt
@@ -6,7 +6,7 @@ searchIssue repo:"cockroach" user:"cockroachdb" is:issue is:open in:title label:
 getBinaryVersion: result v3.3.0
 listMilestones owner=cockroachdb repo=cockroach: result [github.Milestone{Number:2, Title:"3.3"} github.Milestone{Number:1, Title:"3.2"}]
 createIssue owner=cockroachdb repo=cockroach:
-github.IssueRequest{Labels:["O-robot" "C-test-failure" "branch-release-0.1" "release-blocker"], Milestone:2}
+github.IssueRequest{Labels:["O-robot" "C-test-failure" "release-blocker" "branch-release-0.1" "release-blocker"], Milestone:2}
 
 cmd/roachtest: some-roachtest failed
 

--- a/pkg/cmd/internal/issues/testdata/post/failure-with-url-related-issue.txt
+++ b/pkg/cmd/internal/issues/testdata/post/failure-with-url-related-issue.txt
@@ -6,7 +6,7 @@ searchIssue repo:"cockroach" user:"cockroachdb" is:issue is:open in:title label:
 getBinaryVersion: result v3.3.0
 listMilestones owner=cockroachdb repo=cockroach: result [github.Milestone{Number:2, Title:"3.3"} github.Milestone{Number:1, Title:"3.2"}]
 createIssue owner=cockroachdb repo=cockroach:
-github.IssueRequest{Labels:["O-robot" "C-test-failure" "branch-release-0.1" "release-blocker"], Milestone:2}
+github.IssueRequest{Labels:["O-robot" "C-test-failure" "release-blocker" "branch-release-0.1" "release-blocker"], Milestone:2}
 
 cmd/roachtest: some-roachtest failed
 

--- a/pkg/cmd/internal/issues/testdata/post/fatal-no-issue.txt
+++ b/pkg/cmd/internal/issues/testdata/post/fatal-no-issue.txt
@@ -6,7 +6,7 @@ searchIssue repo:"cockroach" user:"cockroachdb" is:issue is:open in:title label:
 getBinaryVersion: result v3.3.0
 listMilestones owner=cockroachdb repo=cockroach: result [github.Milestone{Number:2, Title:"3.3"} github.Milestone{Number:1, Title:"3.2"}]
 createIssue owner=cockroachdb repo=cockroach:
-github.IssueRequest{Labels:["O-robot" "C-test-failure" "branch-release-0.1" "release-blocker"], Milestone:2}
+github.IssueRequest{Labels:["O-robot" "C-test-failure" "release-blocker" "branch-release-0.1" "release-blocker"], Milestone:2}
 
 storage: TestGossipHandlesReplacedNode failed
 

--- a/pkg/cmd/internal/issues/testdata/post/fatal-related-issue.txt
+++ b/pkg/cmd/internal/issues/testdata/post/fatal-related-issue.txt
@@ -6,7 +6,7 @@ searchIssue repo:"cockroach" user:"cockroachdb" is:issue is:open in:title label:
 getBinaryVersion: result v3.3.0
 listMilestones owner=cockroachdb repo=cockroach: result [github.Milestone{Number:2, Title:"3.3"} github.Milestone{Number:1, Title:"3.2"}]
 createIssue owner=cockroachdb repo=cockroach:
-github.IssueRequest{Labels:["O-robot" "C-test-failure" "branch-release-0.1" "release-blocker"], Milestone:2}
+github.IssueRequest{Labels:["O-robot" "C-test-failure" "release-blocker" "branch-release-0.1" "release-blocker"], Milestone:2}
 
 storage: TestGossipHandlesReplacedNode failed
 

--- a/pkg/cmd/internal/issues/testdata/post/panic-no-issue.txt
+++ b/pkg/cmd/internal/issues/testdata/post/panic-no-issue.txt
@@ -6,7 +6,7 @@ searchIssue repo:"cockroach" user:"cockroachdb" is:issue is:open in:title label:
 getBinaryVersion: result v3.3.0
 listMilestones owner=cockroachdb repo=cockroach: result [github.Milestone{Number:2, Title:"3.3"} github.Milestone{Number:1, Title:"3.2"}]
 createIssue owner=cockroachdb repo=cockroach:
-github.IssueRequest{Labels:["O-robot" "C-test-failure" "branch-release-0.1" "release-blocker"], Milestone:2}
+github.IssueRequest{Labels:["O-robot" "C-test-failure" "release-blocker" "branch-release-0.1" "release-blocker"], Milestone:2}
 
 storage: TestGossipHandlesReplacedNode failed
 

--- a/pkg/cmd/internal/issues/testdata/post/panic-related-issue.txt
+++ b/pkg/cmd/internal/issues/testdata/post/panic-related-issue.txt
@@ -6,7 +6,7 @@ searchIssue repo:"cockroach" user:"cockroachdb" is:issue is:open in:title label:
 getBinaryVersion: result v3.3.0
 listMilestones owner=cockroachdb repo=cockroach: result [github.Milestone{Number:2, Title:"3.3"} github.Milestone{Number:1, Title:"3.2"}]
 createIssue owner=cockroachdb repo=cockroach:
-github.IssueRequest{Labels:["O-robot" "C-test-failure" "branch-release-0.1" "release-blocker"], Milestone:2}
+github.IssueRequest{Labels:["O-robot" "C-test-failure" "release-blocker" "branch-release-0.1" "release-blocker"], Milestone:2}
 
 storage: TestGossipHandlesReplacedNode failed
 

--- a/pkg/cmd/internal/issues/testdata/post/rsg-crash-no-issue.txt
+++ b/pkg/cmd/internal/issues/testdata/post/rsg-crash-no-issue.txt
@@ -6,7 +6,7 @@ searchIssue repo:"cockroach" user:"cockroachdb" is:issue is:open in:title label:
 getBinaryVersion: result v3.3.0
 listMilestones owner=cockroachdb repo=cockroach: result [github.Milestone{Number:2, Title:"3.3"} github.Milestone{Number:1, Title:"3.2"}]
 createIssue owner=cockroachdb repo=cockroach:
-github.IssueRequest{Labels:["O-robot" "C-test-failure" "branch-release-0.1" "release-blocker"], Milestone:2}
+github.IssueRequest{Labels:["O-robot" "C-test-failure" "release-blocker" "branch-release-0.1" "release-blocker"], Milestone:2}
 
 sql/tests: TestRandomSyntaxSQLSmith failed
 

--- a/pkg/cmd/internal/issues/testdata/post/rsg-crash-related-issue.txt
+++ b/pkg/cmd/internal/issues/testdata/post/rsg-crash-related-issue.txt
@@ -6,7 +6,7 @@ searchIssue repo:"cockroach" user:"cockroachdb" is:issue is:open in:title label:
 getBinaryVersion: result v3.3.0
 listMilestones owner=cockroachdb repo=cockroach: result [github.Milestone{Number:2, Title:"3.3"} github.Milestone{Number:1, Title:"3.2"}]
 createIssue owner=cockroachdb repo=cockroach:
-github.IssueRequest{Labels:["O-robot" "C-test-failure" "branch-release-0.1" "release-blocker"], Milestone:2}
+github.IssueRequest{Labels:["O-robot" "C-test-failure" "release-blocker" "branch-release-0.1" "release-blocker"], Milestone:2}
 
 sql/tests: TestRandomSyntaxSQLSmith failed
 

--- a/pkg/cmd/internal/issues/testdata/post/with-artifacts-no-issue.txt
+++ b/pkg/cmd/internal/issues/testdata/post/with-artifacts-no-issue.txt
@@ -6,7 +6,7 @@ searchIssue repo:"cockroach" user:"cockroachdb" is:issue is:open in:title label:
 getBinaryVersion: result v3.3.0
 listMilestones owner=cockroachdb repo=cockroach: result [github.Milestone{Number:2, Title:"3.3"} github.Milestone{Number:1, Title:"3.2"}]
 createIssue owner=cockroachdb repo=cockroach:
-github.IssueRequest{Labels:["O-robot" "C-test-failure" "branch-release-0.1" "release-blocker"], Milestone:2}
+github.IssueRequest{Labels:["O-robot" "C-test-failure" "release-blocker" "branch-release-0.1" "release-blocker"], Milestone:2}
 
 storage: kv/splits/nodes=3/quiesce=true failed
 

--- a/pkg/cmd/internal/issues/testdata/post/with-artifacts-related-issue.txt
+++ b/pkg/cmd/internal/issues/testdata/post/with-artifacts-related-issue.txt
@@ -6,7 +6,7 @@ searchIssue repo:"cockroach" user:"cockroachdb" is:issue is:open in:title label:
 getBinaryVersion: result v3.3.0
 listMilestones owner=cockroachdb repo=cockroach: result [github.Milestone{Number:2, Title:"3.3"} github.Milestone{Number:1, Title:"3.2"}]
 createIssue owner=cockroachdb repo=cockroach:
-github.IssueRequest{Labels:["O-robot" "C-test-failure" "branch-release-0.1" "release-blocker"], Milestone:2}
+github.IssueRequest{Labels:["O-robot" "C-test-failure" "release-blocker" "branch-release-0.1" "release-blocker"], Milestone:2}
 
 storage: kv/splits/nodes=3/quiesce=true failed
 


### PR DESCRIPTION
Roachtest failures already file their issues as release-blocker to ensure that releases are blocked until a human has a chance to investiage and triage the failure, however previously this was not done for unit test failures including from nightly runs and stress runs. This change adds the label in those cases too.

Release note: none.
Epic: none.