### PR TITLE
release-22.2: sql: fix formatting of import, backup and create tenant

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -703,7 +703,7 @@ func TestBackupAndRestoreJobDescription(t *testing.T) {
 	sqlDB.Exec(t, "BACKUP TO ($1,$2,$3) INCREMENTAL FROM $4", append(incrementals, backups[0])...)
 	sqlDB.Exec(t, "BACKUP INTO ($1, $2, $3)", collections...)
 	sqlDB.Exec(t, "BACKUP INTO LATEST IN ($1, $2, $3)", collections...)
-	sqlDB.Exec(t, "BACKUP INTO LATEST IN ($1, $2, $3) WITH incremental_location = ($4, $5, $6)",
+	sqlDB.Exec(t, "BACKUP INTO LATEST IN ($1, $2, $3) WITH OPTIONS (incremental_location = ($4, $5, $6))",
 		append(collections, incrementals...)...)
 
 	sqlDB.ExpectErr(t, "the incremental_location option must contain the same number of locality",

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -4348,15 +4348,15 @@ func TestChangefeedDescription(t *testing.T) {
 	}{
 		{
 			create: "CREATE CHANGEFEED FOR foo INTO $1 WITH updated, envelope = $2",
-			descr:  `CREATE CHANGEFEED FOR TABLE foo INTO '` + redactedSink + `' WITH envelope = 'wrapped', updated`,
+			descr:  `CREATE CHANGEFEED FOR TABLE foo INTO '` + redactedSink + `' WITH OPTIONS (envelope = 'wrapped', updated)`,
 		},
 		{
 			create: "CREATE CHANGEFEED FOR public.foo INTO $1 WITH updated, envelope = $2",
-			descr:  `CREATE CHANGEFEED FOR TABLE public.foo INTO '` + redactedSink + `' WITH envelope = 'wrapped', updated`,
+			descr:  `CREATE CHANGEFEED FOR TABLE public.foo INTO '` + redactedSink + `' WITH OPTIONS (envelope = 'wrapped', updated)`,
 		},
 		{
 			create: "CREATE CHANGEFEED FOR d.public.foo INTO $1 WITH updated, envelope = $2",
-			descr:  `CREATE CHANGEFEED FOR TABLE d.public.foo INTO '` + redactedSink + `' WITH envelope = 'wrapped', updated`,
+			descr:  `CREATE CHANGEFEED FOR TABLE d.public.foo INTO '` + redactedSink + `' WITH OPTIONS (envelope = 'wrapped', updated)`,
 		},
 		{
 			// TODO(#85143): remove schema_change_policy='stop' from this test.

--- a/pkg/ccl/changefeedccl/show_changefeed_jobs_test.go
+++ b/pkg/ccl/changefeedccl/show_changefeed_jobs_test.go
@@ -418,7 +418,7 @@ func TestShowChangefeedJobsAlterChangefeed(t *testing.T) {
 		out = obtainJobRowFn()
 
 		require.Equal(t, jobID, out.id, "Expected id:%d but found id:%d", jobID, out.id)
-		require.Equal(t, "CREATE CHANGEFEED FOR TABLE d.public.bar INTO 'kafka://does.not.matter/' WITH resolved = '5s'", out.description, "Expected description:%s but found description:%s", "CREATE CHANGEFEED FOR TABLE bar INTO 'kafka://does.not.matter/ WITH resolved = '5s''", out.description)
+		require.Equal(t, "CREATE CHANGEFEED FOR TABLE d.public.bar INTO 'kafka://does.not.matter/' WITH OPTIONS (resolved = '5s')", out.description, "Expected description:%s but found description:%s", "CREATE CHANGEFEED FOR TABLE bar INTO 'kafka://does.not.matter/ WITH resolved = '5s''", out.description)
 		require.Equal(t, sinkURI, out.SinkURI, "Expected sinkUri:%s but found sinkUri:%s", sinkURI, out.SinkURI)
 		require.Equal(t, "bar", out.topics, "Expected topics:%s but found topics:%s", "bar", sortedTopics)
 		require.Equal(t, "{d.public.bar}", string(out.FullTableNames), "Expected fullTableNames:%s but found fullTableNames:%s", "{d.public.bar}", string(out.FullTableNames))

--- a/pkg/sql/importer/import_csv_mark_redaction_test.go
+++ b/pkg/sql/importer/import_csv_mark_redaction_test.go
@@ -30,7 +30,7 @@ func TestMarkRedactionCCLStatement(t *testing.T) {
 		expected string
 	}{
 		{
-			"IMPORT CSV 'file' WITH delimiter = 'foo'",
+			"IMPORT CSV 'file' WITH OPTIONS (delimiter = 'foo')",
 			"IMPORT CSV ‹'file'› WITH OPTIONS (delimiter = ‹'foo'›)",
 		},
 	}

--- a/pkg/sql/importer/import_stmt_test.go
+++ b/pkg/sql/importer/import_stmt_test.go
@@ -2281,7 +2281,7 @@ func TestImportCSVStmt(t *testing.T) {
 			`CREATE TABLE t (a int8 primary key, b string, index (b), index (a, b))`,
 			`IMPORT INTO t CSV DATA (%s) WITH decompress = 'none'`,
 			testFiles.gzipFiles,
-			` WITH decompress = 'none'`,
+			` WITH OPTIONS (decompress = 'none')`,
 			// This returns different errors for `make test` and `make testrace` but
 			// field is in both error messages.
 			`field`,
@@ -2291,7 +2291,7 @@ func TestImportCSVStmt(t *testing.T) {
 			`CREATE TABLE t (a int8 primary key, b string, index (b), index (a, b))`,
 			`IMPORT INTO t CSV DATA (%s) WITH decompress = 'gzip'`,
 			testFiles.files,
-			` WITH decompress = 'gzip'`,
+			` WITH OPTIONS (decompress = 'gzip')`,
 			"gzip: invalid header",
 		},
 		{
@@ -3123,7 +3123,7 @@ func TestImportIntoCSV(t *testing.T) {
 			"import-into-no-decompress-gzip",
 			`IMPORT INTO t (a, b) CSV DATA (%s) WITH decompress = 'none'`,
 			testFiles.gzipFiles,
-			` WITH decompress = 'none'`,
+			` WITH OPTIONS (decompress = 'none')`,
 			// This returns different errors for `make test` and `make testrace` but
 			// field is in both error messages.
 			"field",
@@ -3132,21 +3132,21 @@ func TestImportIntoCSV(t *testing.T) {
 			"import-into-no-decompress-gzip",
 			`IMPORT INTO t (a, b) CSV DATA (%s) WITH decompress = 'gzip'`,
 			testFiles.files,
-			` WITH decompress = 'gzip'`,
+			` WITH OPTIONS (decompress = 'gzip')`,
 			"gzip: invalid header",
 		},
 		{
 			"import-no-files-match-wildcard",
 			`IMPORT INTO t (a, b) CSV DATA (%s) WITH decompress = 'auto'`,
 			[]string{`'nodelocal://0/data-[0-9][0-9]*'`},
-			` WITH decompress = 'auto'`,
+			` WITH OPTIONS (decompress = 'auto')`,
 			`pq: no files matched`,
 		},
 		{
 			"import-into-no-glob-wildcard",
 			`IMPORT INTO t (a, b) CSV DATA (%s) WITH disable_glob_matching`,
 			testFiles.filesUsingWildcard,
-			` WITH disable_glob_matching`,
+			` WITH OPTIONS (disable_glob_matching)`,
 			"pq: (.+)no such file or directory: nodelocal storage file does not exist:",
 		},
 	} {

--- a/pkg/sql/parser/testdata/changefeed
+++ b/pkg/sql/parser/testdata/changefeed
@@ -23,6 +23,14 @@ EXPLAIN CREATE CHANGEFEED FOR TABLE foo INTO '_' -- literals removed
 EXPLAIN CREATE CHANGEFEED FOR TABLE _ INTO 'sink' -- identifiers removed
 
 parse
+EXPERIMENTAL CHANGEFEED FOR TABLE foo WITH OPTIONS (BUCKET_COUNT = 'string', 'string')
+----
+EXPERIMENTAL CHANGEFEED FOR TABLE foo WITH OPTIONS (bucket_count = 'string', "string") -- normalized!
+EXPERIMENTAL CHANGEFEED FOR TABLE (foo) WITH OPTIONS (bucket_count = ('string'), "string") -- fully parenthesized
+EXPERIMENTAL CHANGEFEED FOR TABLE foo WITH OPTIONS (bucket_count = '_', "string") -- literals removed
+EXPERIMENTAL CHANGEFEED FOR TABLE _ WITH OPTIONS (_ = 'string', _) -- identifiers removed
+
+parse
 CREATE CHANGEFEED FOR foo INTO 'sink'
 ----
 CREATE CHANGEFEED FOR TABLE foo INTO 'sink' -- normalized!
@@ -62,10 +70,10 @@ CREATE CHANGEFEED FOR TABLE _ INTO 'sink' -- identifiers removed
 parse
 CREATE CHANGEFEED FOR TABLE foo INTO 'sink' WITH bar = 'baz'
 ----
-CREATE CHANGEFEED FOR TABLE foo INTO 'sink' WITH bar = 'baz'
-CREATE CHANGEFEED FOR TABLE (foo) INTO ('sink') WITH bar = ('baz') -- fully parenthesized
-CREATE CHANGEFEED FOR TABLE foo INTO '_' WITH bar = '_' -- literals removed
-CREATE CHANGEFEED FOR TABLE _ INTO 'sink' WITH _ = 'baz' -- identifiers removed
+CREATE CHANGEFEED FOR TABLE foo INTO 'sink' WITH OPTIONS (bar = 'baz') -- normalized!
+CREATE CHANGEFEED FOR TABLE (foo) INTO ('sink') WITH OPTIONS (bar = ('baz')) -- fully parenthesized
+CREATE CHANGEFEED FOR TABLE foo INTO '_' WITH OPTIONS (bar = '_') -- literals removed
+CREATE CHANGEFEED FOR TABLE _ INTO 'sink' WITH OPTIONS (_ = 'baz') -- identifiers removed
 
 parse
 CREATE CHANGEFEED AS SELECT * FROM foo

--- a/pkg/sql/parser/testdata/show
+++ b/pkg/sql/parser/testdata/show
@@ -263,6 +263,14 @@ SHOW PUBLIC CLUSTER SETTINGS FOR TENANT $1 -- literals removed
 SHOW PUBLIC CLUSTER SETTINGS FOR TENANT $1 -- identifiers removed
 
 parse
+SHOW PUBLIC CLUSTER SETTINGS FOR TENANT INTERVAL 'string' DAY TO HOUR
+----
+SHOW PUBLIC CLUSTER SETTINGS FOR TENANT ('string'::INTERVAL DAY TO HOUR) -- normalized!
+SHOW PUBLIC CLUSTER SETTINGS FOR TENANT ((('string')::INTERVAL DAY TO HOUR)) -- fully parenthesized
+SHOW PUBLIC CLUSTER SETTINGS FOR TENANT ('_'::INTERVAL DAY TO HOUR) -- literals removed
+SHOW PUBLIC CLUSTER SETTINGS FOR TENANT ('string'::INTERVAL DAY TO HOUR) -- identifiers removed
+
+parse
 SHOW CLUSTER SETTING a FOR TENANT INTERVAL 'string' MONTH
 ----
 SHOW CLUSTER SETTING a FOR TENANT ('string'::INTERVAL MONTH) -- normalized!
@@ -977,6 +985,14 @@ SHOW STATISTICS FOR TABLE d.t
 SHOW STATISTICS FOR TABLE d.t -- fully parenthesized
 SHOW STATISTICS FOR TABLE d.t -- literals removed
 SHOW STATISTICS FOR TABLE _._ -- identifiers removed
+
+parse
+SHOW STATISTICS FOR TABLE d.t WITH OPTIONS (BUCKET_COUNT, SETTING, 'string', 'string' = LOW)
+----
+SHOW STATISTICS FOR TABLE d.t WITH OPTIONS (bucket_count, setting, "string", "string" = 'low') -- normalized!
+SHOW STATISTICS FOR TABLE d.t WITH OPTIONS (bucket_count, setting, "string", "string" = ('low')) -- fully parenthesized
+SHOW STATISTICS FOR TABLE d.t WITH OPTIONS (bucket_count, setting, "string", "string" = '_') -- literals removed
+SHOW STATISTICS FOR TABLE _._ WITH OPTIONS (_, _, _, _ = 'low') -- identifiers removed
 
 parse
 SHOW HISTOGRAM 123

--- a/pkg/sql/sem/tree/changefeed.go
+++ b/pkg/sql/sem/tree/changefeed.go
@@ -47,8 +47,9 @@ func (node *CreateChangefeed) Format(ctx *FmtCtx) {
 		ctx.FormatNode(node.SinkURI)
 	}
 	if node.Options != nil {
-		ctx.WriteString(" WITH ")
+		ctx.WriteString(" WITH OPTIONS (")
 		ctx.FormatNode(&node.Options)
+		ctx.WriteString(")")
 	}
 }
 

--- a/pkg/sql/sem/tree/show.go
+++ b/pkg/sql/sem/tree/show.go
@@ -766,8 +766,9 @@ func (node *ShowTableStats) Format(ctx *FmtCtx) {
 	ctx.WriteString("FOR TABLE ")
 	ctx.FormatNode(node.Table)
 	if len(node.Options) > 0 {
-		ctx.WriteString(" WITH ")
+		ctx.WriteString(" WITH OPTIONS (")
 		ctx.FormatNode(&node.Options)
+		ctx.WriteString(")")
 	}
 }
 


### PR DESCRIPTION
Backport 1/1 commits from #107892. Some of the changes were already backported in #108324 and #107185.

Fixes #109212

/cc @cockroachdb/release

---

Informs: #99185

This commit cherry-picked changes from #107723 and add fixes for formatting `EXPORT` and `CHANGEFEED` options.

Release note: None

Release justification: Fixes random test failures.
