### PR TITLE
workflows: release-blocker issues are never stale

### DIFF
--- a/.github/workflows/kv-test-failure-stale.yml
+++ b/.github/workflows/kv-test-failure-stale.yml
@@ -31,4 +31,4 @@ jobs:
         days-before-issue-stale: 30
         days-before-close: 5
         only-labels: 'T-kv,C-test-failure'
-        exempt-issue-labels: 'skipped-test,X-nostale'
+        exempt-issue-labels: 'release-blocker,skipped-test,X-nostale'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -31,4 +31,4 @@ jobs:
         days-before-pr-stale: 99999
         days-before-issue-stale: 540
         days-before-close: 10
-        exempt-issue-labels: 'X-anchored-telemetry,X-nostale'
+        exempt-issue-labels: 'release-blocker,X-anchored-telemetry,X-nostale'


### PR DESCRIPTION
Release note: none.
Epic: none.