### PR TITLE
asim: enable event series generation

### DIFF
--- a/pkg/kv/kvserver/asim/asim.go
+++ b/pkg/kv/kvserver/asim/asim.go
@@ -72,6 +72,10 @@ func (s *Simulator) State() state.State {
 	return s.state
 }
 
+func (s *Simulator) EventExecutor() scheduled.EventExecutor {
+	return s.eventExecutor
+}
+
 // NewSimulator constructs a valid Simulator.
 func NewSimulator(
 	duration time.Duration,

--- a/pkg/kv/kvserver/asim/event/mutation_event.go
+++ b/pkg/kv/kvserver/asim/event/mutation_event.go
@@ -61,7 +61,7 @@ func (se SetSpanConfigEvent) Func() EventFunc {
 }
 
 func (se SetSpanConfigEvent) String() string {
-	return ""
+	return fmt.Sprintf("set span config event with span=%v, config=%v", se.Span, &se.Config)
 }
 
 func (ae AddNodeEvent) Func() EventFunc {
@@ -83,7 +83,7 @@ func (ae AddNodeEvent) Func() EventFunc {
 }
 
 func (ae AddNodeEvent) String() string {
-	return ""
+	return fmt.Sprintf("add node event with num_of_stores=%d, locality_string=%s", ae.NumStores, ae.LocalityString)
 }
 
 func (sne SetNodeLivenessEvent) Func() EventFunc {
@@ -96,7 +96,7 @@ func (sne SetNodeLivenessEvent) Func() EventFunc {
 }
 
 func (sne SetNodeLivenessEvent) String() string {
-	return "'"
+	return fmt.Sprintf("set node liveness event with nodeID=%d, liveness_status=%v", sne.NodeId, sne.LivenessStatus)
 }
 
 func (sce SetCapacityOverrideEvent) Func() EventFunc {
@@ -107,5 +107,5 @@ func (sce SetCapacityOverrideEvent) Func() EventFunc {
 }
 
 func (sce SetCapacityOverrideEvent) String() string {
-	return "'"
+	return fmt.Sprintf("set capacity override event with storeID=%d, capacity_override=%v", sce.StoreID, sce.CapacityOverride)
 }

--- a/pkg/kv/kvserver/asim/gen/generator.go
+++ b/pkg/kv/kvserver/asim/gen/generator.go
@@ -46,6 +46,7 @@ type ClusterGen interface {
 	// and simulation settings provided.
 	Generate(seed int64, settings *config.SimulationSettings) state.State
 	String() string
+	Regions() []state.Region
 }
 
 // RangeGen provides a method to generate the initial range splits, range
@@ -161,6 +162,10 @@ func (lc LoadedCluster) String() string {
 	return fmt.Sprintf("loaded cluster with\n %v", lc.Info)
 }
 
+func (lc LoadedCluster) Regions() []state.Region {
+	return lc.Info.Regions
+}
+
 // BasicCluster implements the ClusterGen interace.
 type BasicCluster struct {
 	Nodes         int
@@ -178,6 +183,11 @@ func (bc BasicCluster) String() string {
 func (bc BasicCluster) Generate(seed int64, settings *config.SimulationSettings) state.State {
 	info := state.ClusterInfoWithStoreCount(bc.Nodes, bc.StoresPerNode)
 	return state.LoadClusterInfo(info, settings)
+}
+
+func (bc BasicCluster) Regions() []state.Region {
+	info := state.ClusterInfoWithStoreCount(bc.Nodes, bc.StoresPerNode)
+	return info.Regions
 }
 
 // LoadedRanges implements the RangeGen interface.

--- a/pkg/kv/kvserver/asim/scheduled/scheduled_event.go
+++ b/pkg/kv/kvserver/asim/scheduled/scheduled_event.go
@@ -11,6 +11,8 @@
 package scheduled
 
 import (
+	"fmt"
+	"strings"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/asim/event"
@@ -39,6 +41,13 @@ func (sel ScheduledEventList) Swap(i, j int) {
 type ScheduledEvent struct {
 	At          time.Time
 	TargetEvent event.Event
+}
+
+func (se ScheduledEvent) String() string {
+	buf := strings.Builder{}
+	buf.WriteString(fmt.Sprintf("\texecuted at: %s\n", se.At.Format("2006-01-02 15:04:05")))
+	buf.WriteString(fmt.Sprintf("\t\tevent: %s", se.TargetEvent.String()))
+	return buf.String()
 }
 
 // IsMutationEvent returns whether the scheduled event is a mutation event or an

--- a/pkg/kv/kvserver/asim/state/BUILD.bazel
+++ b/pkg/kv/kvserver/asim/state/BUILD.bazel
@@ -42,6 +42,7 @@ go_library(
         "@com_github_google_btree//:btree",
         "@io_etcd_go_raft_v3//:raft",
         "@io_etcd_go_raft_v3//tracker",
+        "@org_golang_google_protobuf//proto",
     ],
 )
 

--- a/pkg/kv/kvserver/asim/state/load.go
+++ b/pkg/kv/kvserver/asim/state/load.go
@@ -11,6 +11,8 @@
 package state
 
 import (
+	"fmt"
+
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/asim/workload"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/load"
@@ -145,6 +147,24 @@ func NewCapacityOverride() CapacityOverride {
 			L0MinimumSizePerSubLevel: capacityOverrideSentinel,
 		},
 	}
+}
+
+func (co CapacityOverride) String() string {
+	return fmt.Sprintf(
+		"capacity=%d, available=%d, used=%d, logical_bytes=%d, range_count=%d, lease_count=%d, "+
+			"queries_per_sec=%.2f, writes_per_sec=%.2f, cpu_per_sec=%.2f, l0_sublevels=%d, io_threhold=%v",
+		co.Capacity,
+		co.Available,
+		co.Used,
+		co.LogicalBytes,
+		co.RangeCount,
+		co.LeaseCount,
+		co.QueriesPerSecond,
+		co.WritesPerSecond,
+		co.CPUPerSecond,
+		co.L0Sublevels,
+		co.IOThreshold,
+	)
 }
 
 func mergeOverride(

--- a/pkg/kv/kvserver/asim/tests/BUILD.bazel
+++ b/pkg/kv/kvserver/asim/tests/BUILD.bazel
@@ -1,5 +1,28 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
+go_library(
+    name = "tests",
+    srcs = [
+        "default_settings.go",
+        "output.go",
+        "rand_framework.go",
+        "rand_gen.go",
+    ],
+    importpath = "github.com/cockroachdb/cockroach/pkg/kv/kvserver/asim/tests",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/config/zonepb",
+        "//pkg/kv/kvserver/asim/assertion",
+        "//pkg/kv/kvserver/asim/config",
+        "//pkg/kv/kvserver/asim/event",
+        "//pkg/kv/kvserver/asim/gen",
+        "//pkg/kv/kvserver/asim/history",
+        "//pkg/kv/kvserver/asim/scheduled",
+        "//pkg/kv/kvserver/asim/state",
+        "//pkg/roachpb",
+    ],
+)
+
 go_test(
     name = "tests_test",
     srcs = [
@@ -25,27 +48,5 @@ go_test(
         "@com_github_cockroachdb_datadriven//:datadriven",
         "@com_github_guptarohit_asciigraph//:asciigraph",
         "@com_github_stretchr_testify//require",
-    ],
-)
-
-go_library(
-    name = "tests",
-    srcs = [
-        "default_settings.go",
-        "output.go",
-        "rand_framework.go",
-        "rand_gen.go",
-    ],
-    importpath = "github.com/cockroachdb/cockroach/pkg/kv/kvserver/asim/tests",
-    visibility = ["//visibility:public"],
-    deps = [
-        "//pkg/config/zonepb",
-        "//pkg/kv/kvserver/asim/assertion",
-        "//pkg/kv/kvserver/asim/config",
-        "//pkg/kv/kvserver/asim/event",
-        "//pkg/kv/kvserver/asim/gen",
-        "//pkg/kv/kvserver/asim/history",
-        "//pkg/kv/kvserver/asim/state",
-        "//pkg/roachpb",
     ],
 )

--- a/pkg/kv/kvserver/asim/tests/BUILD.bazel
+++ b/pkg/kv/kvserver/asim/tests/BUILD.bazel
@@ -39,10 +39,13 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/kv/kvserver/asim/tests",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/config/zonepb",
         "//pkg/kv/kvserver/asim/assertion",
         "//pkg/kv/kvserver/asim/config",
+        "//pkg/kv/kvserver/asim/event",
         "//pkg/kv/kvserver/asim/gen",
         "//pkg/kv/kvserver/asim/history",
         "//pkg/kv/kvserver/asim/state",
+        "//pkg/roachpb",
     ],
 )

--- a/pkg/kv/kvserver/asim/tests/helpers_test.go
+++ b/pkg/kv/kvserver/asim/tests/helpers_test.go
@@ -64,6 +64,9 @@ func scanArg(t *testing.T, d *datadriven.TestData, key string, dest interface{})
 	case *livenesspb.NodeLivenessStatus:
 		d.ScanArgs(t, key, &tmp)
 		*dest = getNodeLivenessStatus(tmp)
+	case *eventSeriesType:
+		d.ScanArgs(t, key, &tmp)
+		*dest = getEventSeriesType(tmp)
 	default:
 		require.Fail(t, "unsupported type %T", dest)
 	}

--- a/pkg/kv/kvserver/asim/tests/output.go
+++ b/pkg/kv/kvserver/asim/tests/output.go
@@ -117,6 +117,7 @@ func printTestSettings(t testSettings, staticSettings staticOptionSettings, buf 
 
 	if t.randOptions.staticEvents {
 		buf.WriteString(configStr("events", "randomized"))
+		buf.WriteString(fmt.Sprintf("\t%v\n", t.eventGen))
 	} else {
 		buf.WriteString(configStr("events", "static"))
 	}

--- a/pkg/kv/kvserver/asim/tests/output.go
+++ b/pkg/kv/kvserver/asim/tests/output.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/asim/gen"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/asim/scheduled"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/asim/state"
 )
 
@@ -36,14 +37,17 @@ const (
 	OutputConfigGen // 1 << 2: 0000 0100
 	// OutputTopology displays the topology of cluster configurations.
 	OutputTopology // 1 << 3: 0000 1000
+	// OutputEvents displays delayed events executed.
+	OutputEvents // 1 << 4: 0001 0000
 	// OutputAll shows everything above.
-	OutputAll = (1 << (iota - 1)) - 1 // (1 << 4) - 1: 0000 1111
+	OutputAll = (1 << (iota - 1)) - 1 // (1 << 5) - 1: 0001 1111
 )
 
 // ScanFlags converts an array of input strings into a single flag.
 func (o OutputFlags) ScanFlags(inputs []string) OutputFlags {
 	dict := map[string]OutputFlags{"result_only": OutputResultOnly, "test_settings": OutputTestSettings,
-		"initial_state": OutputInitialState, "config_gen": OutputConfigGen, "topology": OutputTopology, "all": OutputAll}
+		"initial_state": OutputInitialState, "config_gen": OutputConfigGen, "topology": OutputTopology,
+		"events": OutputEvents, "all": OutputAll}
 	flag := OutputResultOnly
 	for _, input := range inputs {
 		flag = flag.set(dict[input])
@@ -62,15 +66,16 @@ func (o OutputFlags) Has(f OutputFlags) bool {
 }
 
 type testResult struct {
-	seed         int64
-	failed       bool
-	reason       string
-	clusterGen   gen.ClusterGen
-	rangeGen     gen.RangeGen
-	loadGen      gen.LoadGen
-	eventGen     gen.EventGen
-	initialTime  time.Time
-	initialState state.State
+	seed          int64
+	failed        bool
+	reason        string
+	clusterGen    gen.ClusterGen
+	rangeGen      gen.RangeGen
+	loadGen       gen.LoadGen
+	eventGen      gen.EventGen
+	initialTime   time.Time
+	initialState  state.State
+	eventExecutor scheduled.EventExecutor
 }
 
 type testResultsReport struct {
@@ -159,6 +164,9 @@ func (tr testResultsReport) String() string {
 		if failed || tr.flags.Has(OutputTopology) {
 			topology := output.initialState.Topology()
 			buf.WriteString(fmt.Sprintf("topology:\n%s", topology.String()))
+		}
+		if failed || tr.flags.Has(OutputEvents) {
+			buf.WriteString(output.eventExecutor.PrintEventsExecuted())
 		}
 		if failed {
 			buf.WriteString(fmt.Sprintf("sample%d: failed assertion\n%s", nthSample, output.reason))

--- a/pkg/kv/kvserver/asim/tests/rand_framework.go
+++ b/pkg/kv/kvserver/asim/tests/rand_framework.go
@@ -129,15 +129,16 @@ func (f randTestingFramework) runRandTest() testResult {
 	history := simulator.History()
 	failed, reason := checkAssertions(ctx, history, f.s.assertions)
 	return testResult{
-		seed:         seed,
-		failed:       failed,
-		reason:       reason,
-		clusterGen:   cluster,
-		rangeGen:     ranges,
-		loadGen:      load,
-		eventGen:     staticEvents,
-		initialState: initialState,
-		initialTime:  initialTime,
+		seed:          seed,
+		failed:        failed,
+		reason:        reason,
+		clusterGen:    cluster,
+		rangeGen:      ranges,
+		loadGen:       load,
+		eventGen:      staticEvents,
+		initialState:  initialState,
+		initialTime:   initialTime,
+		eventExecutor: simulator.EventExecutor(),
 	}
 }
 

--- a/pkg/kv/kvserver/asim/tests/rand_framework.go
+++ b/pkg/kv/kvserver/asim/tests/rand_framework.go
@@ -41,6 +41,7 @@ type testSettings struct {
 	randOptions   testRandOptions
 	clusterGen    clusterGenSettings
 	rangeGen      rangeGenSettings
+	eventGen      eventGenSettings
 }
 
 type randTestingFramework struct {
@@ -103,11 +104,13 @@ func (f randTestingFramework) getStaticSettings() gen.StaticSettings {
 	return gen.StaticSettings{}
 }
 
-func (f randTestingFramework) getStaticEvents() gen.StaticEvents {
+func (f randTestingFramework) getStaticEvents(
+	cluster gen.ClusterGen, settings gen.StaticSettings,
+) gen.StaticEvents {
 	if !f.s.randOptions.staticEvents {
 		return f.defaultStaticEventsGen()
 	}
-	return gen.StaticEvents{}
+	return f.randomEventSeriesGen(cluster, settings)
 }
 
 // runRandTest creates randomized configurations based on the specified test
@@ -118,7 +121,7 @@ func (f randTestingFramework) runRandTest() testResult {
 	ranges := f.getRanges()
 	load := f.getLoad()
 	staticSettings := f.getStaticSettings()
-	staticEvents := f.getStaticEvents()
+	staticEvents := f.getStaticEvents(cluster, staticSettings)
 	seed := f.s.randSource.Int63()
 	simulator := gen.GenerateSimulation(f.s.duration, cluster, ranges, load, staticSettings, staticEvents, seed)
 	initialState, initialTime := simulator.State(), simulator.Curr()
@@ -257,5 +260,16 @@ func (f randTestingFramework) randomBasicRangesGen() gen.RangeGen {
 		}
 	default:
 		panic("unknown ranges placement type")
+	}
+}
+
+func (f randTestingFramework) randomEventSeriesGen(
+	cluster gen.ClusterGen, settings gen.StaticSettings,
+) gen.StaticEvents {
+	switch eventsType := f.s.eventGen.eventsType; eventsType {
+	case cycleViaHardcodedSurvivalGoals:
+		return generateSurvivalGoalsEvents(cluster.Regions(), settings.Settings.StartTime, f.s.eventGen.durationToAssertOnEvent)
+	default:
+		panic("unknown event series type")
 	}
 }

--- a/pkg/kv/kvserver/asim/tests/rand_test.go
+++ b/pkg/kv/kvserver/asim/tests/rand_test.go
@@ -83,7 +83,7 @@ const (
 //	  4. sum of weights in the array should be equal to 1
 
 // 3. "eval" [seed=<int64>] [num_iterations=<int>] [duration=<time.Duration>]
-//  [verbose=(<[]("result_only","test_settings","initial_state","config_gen","topology","all")>)]
+// [verbose=(<[]("result_only","test_settings","initial_state","config_gen","event","topology","all")>)]
 // e.g. eval seed=20 duration=30m2s verbose=(test_settings,initial_state)
 //  - eval: generates a simulation based on the configuration set with the given
 //    commands.
@@ -102,6 +102,7 @@ const (
 //    - config_gen: displays the input configurations generated for each test
 //    iteration
 //    - topology: displays the topology of cluster configurations
+//    - event: displays events executed for the simulation
 //    - all: display everything above
 
 // 4. “change_static_option”[nodes=<int>][stores_per_node=<int>]

--- a/pkg/kv/kvserver/asim/tests/rand_test.go
+++ b/pkg/kv/kvserver/asim/tests/rand_test.go
@@ -136,6 +136,15 @@ const (
 //	- height (default value is 15): height of the plot
 //	- width (default value is 80): width of the plot
 
+//  5. "rand_events" [type=<string>{cycle_via_hardcoded_survival_goals}]
+//  [duration_to_assert_on_event=<time.Duration>]
+//  e.g. rand_events type=cycle_via_hardcoded_survival_goals duration=5m
+//  - rand_events: generates interesting event series to be scheduled in the
+//  simulation.
+//  - type: type of event series to be scheduled.
+//  - duration_to_assert_on_event: delay to add the assertion events post
+//    mutation events for mutation-assertion event series.
+
 // RandTestingFramework is initialized with specified testSetting and maintains
 // its state across all iterations. It repeats the test with different random
 // configurations. Each iteration in RandTestingFramework executes the following
@@ -150,6 +159,7 @@ func TestRandomized(t *testing.T) {
 		randOptions := testRandOptions{}
 		var rGenSettings rangeGenSettings
 		var cGenSettings clusterGenSettings
+		var eGenSettings eventGenSettings
 		staticOptionSettings := getDefaultStaticOptionSettings()
 		datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {
 			switch d.Cmd {
@@ -157,6 +167,7 @@ func TestRandomized(t *testing.T) {
 				randOptions = testRandOptions{}
 				rGenSettings = rangeGenSettings{}
 				cGenSettings = clusterGenSettings{}
+				eGenSettings = eventGenSettings{}
 				staticOptionSettings = getDefaultStaticOptionSettings()
 				return ""
 			case "rand_cluster":
@@ -206,7 +217,15 @@ func TestRandomized(t *testing.T) {
 			case "rand_load":
 				return "unimplemented: randomized load"
 			case "rand_events":
-				return "unimplemented: randomized events"
+				randOptions.staticEvents = true
+				seriesType, durationToAssertOnEvent := defaultEventsType, defaultDurationToAssertOnEvent
+				scanIfExists(t, d, "type", &seriesType)
+				scanIfExists(t, d, "duration_to_assert_on_event", &durationToAssertOnEvent)
+				eGenSettings = eventGenSettings{
+					durationToAssertOnEvent: durationToAssertOnEvent,
+					eventsType:              seriesType,
+				}
+				return ""
 			case "rand_settings":
 				return "unimplemented: randomized settings"
 			case "eval":
@@ -227,6 +246,7 @@ func TestRandomized(t *testing.T) {
 					randOptions:   randOptions,
 					rangeGen:      rGenSettings,
 					clusterGen:    cGenSettings,
+					eventGen:      eGenSettings,
 				}
 				f := newRandTestingFramework(s, staticOptionSettings)
 				outputs := f.runRandTestRepeated()

--- a/pkg/kv/kvserver/asim/tests/testdata/rand/default_settings
+++ b/pkg/kv/kvserver/asim/tests/testdata/rand/default_settings
@@ -231,6 +231,7 @@ topology:
 AU_EAST
   AU_EAST_1
     └── [1 2 3]
+no events were scheduled
 sample1: pass
 ----------------------------------
 sample2: start running
@@ -245,6 +246,7 @@ topology:
 AU_EAST
   AU_EAST_1
     └── [1 2 3]
+no events were scheduled
 sample2: pass
 ----------------------------------
 sample3: start running
@@ -259,6 +261,7 @@ topology:
 AU_EAST
   AU_EAST_1
     └── [1 2 3]
+no events were scheduled
 sample3: pass
 ----------------------------------
 

--- a/pkg/kv/kvserver/asim/tests/testdata/rand/events
+++ b/pkg/kv/kvserver/asim/tests/testdata/rand/events
@@ -1,0 +1,60 @@
+rand_cluster cluster_gen_type=multi_region
+----
+
+change_static_option ranges=1
+----
+
+rand_events type=cycle_via_hardcoded_survival_goals duration_to_assert_on_event=10m
+----
+
+eval duration=20m num_iterations=3 verbose=(events)
+----
+----------------------------------
+sample1: start running
+4 events executed:
+	executed at: 2022-03-21 11:00:00
+		event: set span config event with span={0000000000-9999999999}, config=range_min_bytes:134217728 range_max_bytes:536870912 gc_policy:<ttl_seconds:14400 > num_replicas:5 num_voters:3 constraints:<num_replicas:1 constraints:<key:"region" value:"US_East" > > constraints:<num_replicas:1 constraints:<key:"region" value:"US_West" > > constraints:<num_replicas:1 constraints:<key:"region" value:"EU" > > voter_constraints:<constraints:<key:"region" value:"US_East" > > lease_preferences:<constraints:<key:"region" value:"US_East" > > 
+	executed at: 2022-03-21 11:10:00
+		event: assertion checking event
+			1. assertion=conformance unavailable=0 under=0 over=0 violating=0 
+			passed
+	executed at: 2022-03-21 11:10:00
+		event: set span config event with span={0000000000-9999999999}, config=range_min_bytes:134217728 range_max_bytes:536870912 gc_policy:<ttl_seconds:14400 > num_replicas:5 num_voters:5 constraints:<num_replicas:1 constraints:<key:"region" value:"US_East" > > constraints:<num_replicas:1 constraints:<key:"region" value:"US_West" > > constraints:<num_replicas:1 constraints:<key:"region" value:"EU" > > voter_constraints:<num_replicas:2 constraints:<key:"region" value:"US_East" > > lease_preferences:<constraints:<key:"region" value:"US_East" > > 
+	executed at: 2022-03-21 11:20:00
+		event: assertion checking event
+			1. assertion=conformance unavailable=0 under=0 over=0 violating=0 
+			passed
+sample1: pass
+----------------------------------
+sample2: start running
+4 events executed:
+	executed at: 2022-03-21 11:00:00
+		event: set span config event with span={0000000000-9999999999}, config=range_min_bytes:134217728 range_max_bytes:536870912 gc_policy:<ttl_seconds:14400 > num_replicas:5 num_voters:3 constraints:<num_replicas:1 constraints:<key:"region" value:"US_East" > > constraints:<num_replicas:1 constraints:<key:"region" value:"US_West" > > constraints:<num_replicas:1 constraints:<key:"region" value:"EU" > > voter_constraints:<constraints:<key:"region" value:"US_East" > > lease_preferences:<constraints:<key:"region" value:"US_East" > > 
+	executed at: 2022-03-21 11:10:00
+		event: assertion checking event
+			1. assertion=conformance unavailable=0 under=0 over=0 violating=0 
+			passed
+	executed at: 2022-03-21 11:10:00
+		event: set span config event with span={0000000000-9999999999}, config=range_min_bytes:134217728 range_max_bytes:536870912 gc_policy:<ttl_seconds:14400 > num_replicas:5 num_voters:5 constraints:<num_replicas:1 constraints:<key:"region" value:"US_East" > > constraints:<num_replicas:1 constraints:<key:"region" value:"US_West" > > constraints:<num_replicas:1 constraints:<key:"region" value:"EU" > > voter_constraints:<num_replicas:2 constraints:<key:"region" value:"US_East" > > lease_preferences:<constraints:<key:"region" value:"US_East" > > 
+	executed at: 2022-03-21 11:20:00
+		event: assertion checking event
+			1. assertion=conformance unavailable=0 under=0 over=0 violating=0 
+			passed
+sample2: pass
+----------------------------------
+sample3: start running
+4 events executed:
+	executed at: 2022-03-21 11:00:00
+		event: set span config event with span={0000000000-9999999999}, config=range_min_bytes:134217728 range_max_bytes:536870912 gc_policy:<ttl_seconds:14400 > num_replicas:5 num_voters:3 constraints:<num_replicas:1 constraints:<key:"region" value:"US_East" > > constraints:<num_replicas:1 constraints:<key:"region" value:"US_West" > > constraints:<num_replicas:1 constraints:<key:"region" value:"EU" > > voter_constraints:<constraints:<key:"region" value:"US_East" > > lease_preferences:<constraints:<key:"region" value:"US_East" > > 
+	executed at: 2022-03-21 11:10:00
+		event: assertion checking event
+			1. assertion=conformance unavailable=0 under=0 over=0 violating=0 
+			passed
+	executed at: 2022-03-21 11:10:00
+		event: set span config event with span={0000000000-9999999999}, config=range_min_bytes:134217728 range_max_bytes:536870912 gc_policy:<ttl_seconds:14400 > num_replicas:5 num_voters:5 constraints:<num_replicas:1 constraints:<key:"region" value:"US_East" > > constraints:<num_replicas:1 constraints:<key:"region" value:"US_West" > > constraints:<num_replicas:1 constraints:<key:"region" value:"EU" > > voter_constraints:<num_replicas:2 constraints:<key:"region" value:"US_East" > > lease_preferences:<constraints:<key:"region" value:"US_East" > > 
+	executed at: 2022-03-21 11:20:00
+		event: assertion checking event
+			1. assertion=conformance unavailable=0 under=0 over=0 violating=0 
+			passed
+sample3: pass
+----------------------------------

--- a/pkg/kv/kvserver/asim/tests/testdata/rand/rand_cluster
+++ b/pkg/kv/kvserver/asim/tests/testdata/rand/rand_cluster
@@ -86,6 +86,7 @@ US_East
 US_West
   US_West_1
     └── [17 18]
+no events were scheduled
 sample1: pass
 ----------------------------------
 sample2: start running
@@ -121,6 +122,7 @@ US_West
     └── [17 18 19 20]
   US_West_3
     └── [21 22 23 24]
+no events were scheduled
 sample2: pass
 ----------------------------------
 sample3: start running
@@ -152,6 +154,7 @@ US_East
 US_West
   US_West_1
     └── [17 18]
+no events were scheduled
 sample3: pass
 ----------------------------------
 

--- a/pkg/kv/kvserver/asim/tests/testdata/rand/rand_ranges
+++ b/pkg/kv/kvserver/asim/tests/testdata/rand/rand_ranges
@@ -187,6 +187,7 @@ US
     └── [6 7 8 9 10]
   US_3
     └── [11 12 13 14 15]
+no events were scheduled
 sample2: failed assertion
   conformance unavailable=0 under=0 over=0 violating=0 
   actual unavailable=0 under=0, over=9 violating=0


### PR DESCRIPTION
**asim: enable event series generation**

This patch enables interesting event series to be generated and scheduled as
part of the simulation.

The following command is now supported:
"rand_events" [type=<string>{cycle_via_hardcoded_survival_goals}]
 [duration_to_assert_on_event=<time.Duration>]
 e.g. rand_events type=cycle_via_hardcoded_survival_goals duration=5m
 - rand_events: generates interesting event series to be scheduled in the
 simulation.
 - type: type of event series to be scheduled.
 - duration_to_assert_on_event: delay to add the assertion events post
   mutation events for mutation-assertion event series.

----

**asim: better output for executed events**

Previously, the randomized testing framework only reports number of scheduled
mutation and assertion events, offering no insights on their execution or the
results of the assertion events. This patch adds more output info to include
executed mutation events, conducted assertion checks, assertion results, and
their execution timing.

New verbosity flags for eval is now supported to print these info.
```
"eval" [verbose=events]
```

Part of: https://github.com/cockroachdb/cockroach/issues/106192
Release Note: none