### PR TITLE
ui: show source table on error message

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/sqlActivity/errorComponent.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sqlActivity/errorComponent.tsx
@@ -18,6 +18,7 @@ const cx = classNames.bind(styles);
 interface SQLActivityErrorProps {
   statsType: string;
   error: Error;
+  sourceTables?: string[];
 }
 
 export function mergeErrors(errs: Error | Error[]): Error {
@@ -76,6 +77,13 @@ const LoadingError: React.FC<SQLActivityErrorProps> = props => {
     ? "a timeout"
     : "an unexpected error";
 
+  const tablesInfo =
+    props.sourceTables?.length == 1
+      ? `Source Table: ${props.sourceTables[0]}`
+      : props.sourceTables?.length > 1
+      ? `Source Tables: ${props.sourceTables.join(", ")}`
+      : "";
+
   return (
     <div>
       <div className={cx("row")}>
@@ -92,11 +100,17 @@ const LoadingError: React.FC<SQLActivityErrorProps> = props => {
       </div>
       <div className={cx("row-small")}>
         <br />
-        <span>{`Debug information: ${moment
-          .utc()
-          .format("YYYY.MM.DD HH:mm:ss")} utc; Error message: ${
-          props?.error?.message
-        }; URL: ${url};`}</span>
+        <span>
+          {`Debug information: ${moment
+            .utc()
+            .format("YYYY.MM.DD HH:mm:ss")} utc;`}
+          <br />
+          {`Error message: ${props?.error?.message};`}
+          <br />
+          {`URL: ${url};`}
+          <br />
+          {tablesInfo}
+        </span>
       </div>
     </div>
   );

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
@@ -762,6 +762,10 @@ export class StatementsPage extends React.Component<
               LoadingError({
                 statsType: "statements",
                 error: this.props.statementsResponse?.error,
+                sourceTables: this.props.statementsResponse?.data
+                  ?.stmts_source_table && [
+                  this.props.statementsResponse?.data?.stmts_source_table,
+                ],
               })
             }
           />

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
@@ -689,6 +689,10 @@ export class TransactionsPage extends React.Component<
               LoadingError({
                 statsType: "transactions",
                 error: this.props.txnsResp.error,
+                sourceTables: this.props.txnsResp?.data?.txns_source_table && [
+                  this.props.txnsResp?.data?.txns_source_table,
+                  this.props.txnsResp?.data?.stmts_source_table,
+                ],
               })
             }
           />


### PR DESCRIPTION
When there is information about the source table
on SQL Activity pages, show that as part of the error message.

Example with a single source table:
<img width="924" alt="Screenshot 2023-08-28 at 12 42 37 PM" src="https://github.com/cockroachdb/cockroach/assets/1017486/1fe7bc8b-1c71-4997-bb66-76d3754a0593">



Example with 2 source tables:
<img width="743" alt="Screenshot 2023-08-28 at 12 44 07 PM" src="https://github.com/cockroachdb/cockroach/assets/1017486/6cf9d65c-8de0-47b3-885f-1758c7f0eaa3">



Example with no source tables:
<img width="623" alt="Screenshot 2023-08-28 at 12 45 50 PM" src="https://github.com/cockroachdb/cockroach/assets/1017486/34782ea7-02b1-438a-8d3a-2c604765dc38">


Epic: none
Release note: None