### PR TITLE
build: use crosslinux config in PR coverage action

### DIFF
--- a/build/ghactions/pr-codecov-run-tests.sh
+++ b/build/ghactions/pr-codecov-run-tests.sh
@@ -42,6 +42,7 @@ echo "Running tests"
 
 # TODO(radu): do we need --strip=never?
 bazel coverage \
+  --config=crosslinux \
   --@io_bazel_rules_go//go/config:cover_format=lcov --combined_report=lcov \
   --instrumentation_filter="//pkg/..." \
   ${targets}


### PR DESCRIPTION
Fix for a krb5-related build error.

Epic: none
Release note: None