### PR TITLE
kv: remove assertions around non-txn'al locking reqs

### DIFF
--- a/pkg/kv/kvserver/concurrency/lock_table.go
+++ b/pkg/kv/kvserver/concurrency/lock_table.go
@@ -801,19 +801,17 @@ func (g *lockTableGuardImpl) curLockMode() lock.Mode {
 
 // makeLockMode constructs and returns a lock mode.
 func makeLockMode(str lock.Strength, txn *roachpb.Transaction, ts hlc.Timestamp) lock.Mode {
+	iso := isolation.Serializable
+	if txn != nil {
+		iso = txn.IsoLevel
+	}
 	switch str {
 	case lock.None:
-		iso := isolation.Serializable
-		if txn != nil {
-			iso = txn.IsoLevel
-		}
 		return lock.MakeModeNone(ts, iso)
 	case lock.Shared:
-		assert(txn != nil, "only transactional requests can acquire shared locks")
 		return lock.MakeModeShared()
 	case lock.Exclusive:
-		assert(txn != nil, "only transactional requests can acquire exclusive locks")
-		return lock.MakeModeExclusive(ts, txn.IsoLevel)
+		return lock.MakeModeExclusive(ts, iso)
 	case lock.Intent:
 		return lock.MakeModeIntent(ts)
 	default:


### PR DESCRIPTION
Closes #107860.
Closes #109222.
Closes #109581.
Closes #109582.

We might want to re-introduce these assertions in the future and reject these requests higher up the stack. For now, just remove them to deflake tests.

Release note: None