### PR TITLE
pkg/server: protect server controller testArgs with mutex

### DIFF
--- a/pkg/server/server_controller.go
+++ b/pkg/server/server_controller.go
@@ -72,9 +72,6 @@ type serverController struct {
 	// st refers to the applicable cluster settings.
 	st *cluster.Settings
 
-	// testArgs is used when creating new tenant servers.
-	testArgs map[roachpb.TenantName]base.TestSharedProcessTenantArgs
-
 	// sendSQLRoutingError is a callback to use to report
 	// a tenant routing error to the incoming client.
 	sendSQLRoutingError func(ctx context.Context, conn net.Conn, tenantName roachpb.TenantName)
@@ -94,6 +91,9 @@ type serverController struct {
 		// TODO(knz): Detect when the mapping of name to tenant ID has
 		// changed, and invalidate the entry.
 		servers map[roachpb.TenantName]serverState
+
+		// testArgs is used when creating new tenant servers.
+		testArgs map[roachpb.TenantName]base.TestSharedProcessTenantArgs
 
 		// nextServerIdx is the index to provide to the next call to
 		// newServerFn.
@@ -118,7 +118,6 @@ func newServerController(
 		nodeID:              parentNodeID,
 		logger:              logger,
 		st:                  st,
-		testArgs:            make(map[roachpb.TenantName]base.TestSharedProcessTenantArgs),
 		stopper:             parentStopper,
 		tenantServerCreator: tenantServerCreator,
 		sendSQLRoutingError: sendSQLRoutingError,
@@ -127,6 +126,7 @@ func newServerController(
 	c.mu.servers = map[roachpb.TenantName]serverState{
 		catconstants.SystemTenantName: c.orchestrator.makeServerStateForSystemTenant(systemTenantNameContainer, systemServer),
 	}
+	c.mu.testArgs = make(map[roachpb.TenantName]base.TestSharedProcessTenantArgs)
 	parentStopper.AddCloser(c)
 	return c
 }

--- a/pkg/server/server_controller_orchestration.go
+++ b/pkg/server/server_controller_orchestration.go
@@ -228,7 +228,12 @@ func (c *serverController) newServerForOrchestrator(
 	ctx context.Context, nameContainer *roachpb.TenantNameContainer, tenantStopper *stop.Stopper,
 ) (orchestratedServer, error) {
 	tenantName := nameContainer.Get()
-	testArgs := c.testArgs[tenantName]
+	var testArgs base.TestSharedProcessTenantArgs
+	func() {
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		testArgs = c.mu.testArgs[tenantName]
+	}()
 
 	// Server does not exist yet: instantiate and start it.
 	idx := func() int {

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -1079,7 +1079,11 @@ func (ts *testServer) StartSharedProcessTenant(
 	}
 
 	// Save the args for use if the server needs to be created.
-	ts.topLevelServer.serverController.testArgs[args.TenantName] = args
+	func() {
+		ts.topLevelServer.serverController.mu.Lock()
+		defer ts.topLevelServer.serverController.mu.Unlock()
+		ts.topLevelServer.serverController.mu.testArgs[args.TenantName] = args
+	}()
 
 	tenantRow, err := ts.InternalExecutor().(*sql.InternalExecutor).QueryRow(
 		ctx, "testserver-check-tenant-active", nil, /* txn */


### PR DESCRIPTION
A race condition is hit within the serverController when dealing with the testArgs, which aren't protected by a mutex.

The TestServer writes to this map when starting shared process tenants, and the server controller orchestrator reads from it when instantiating a new server. Because of this, some TestRace failures were reported.

To fix this, this patch moves the testArgs map used by the server controller to be protected by the existing mutex.

Fixes: https://github.com/cockroachdb/cockroach/issues/109469

Release note: none