### PR TITLE
sql: strict_ddl_atomicity should disallow multi-stmt implicit txn

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/strict_ddl_atomicity
+++ b/pkg/sql/logictest/testdata/logic_test/strict_ddl_atomicity
@@ -46,5 +46,11 @@ SET strict_ddl_atomicity = true
 statement ok
 BEGIN
 
-statement error unimplemented: cannot run this DDL statement inside BEGIN..COMMIT as its atomicity cannot be guaranteed.*\n.*\n.*issue-v/42061
+statement error unimplemented: cannot run this DDL statement inside a multi-statement transaction as its atomicity cannot be guaranteed.*\n.*\n.*issue-v/42061
 ALTER TABLE testing ADD CONSTRAINT "unique_values" UNIQUE(v)
+
+statement ok
+ROLLBACK
+
+statement error unimplemented: cannot run this DDL statement inside a multi-statement transaction as its atomicity cannot be guaranteed.*\n.*\n.*issue-v/42061
+SELECT 1; ALTER TABLE testing ADD CONSTRAINT "unique_values" UNIQUE(v)

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -38,10 +38,10 @@ func (p *planner) getVirtualTabler() VirtualTabler {
 }
 
 func (p *planner) checkDDLAtomicity() error {
-	if !p.ExtendedEvalContext().TxnImplicit &&
+	if (!p.ExtendedEvalContext().TxnImplicit || !p.ExtendedEvalContext().TxnIsSingleStmt) &&
 		p.SessionData().StrictDDLAtomicity {
 		return errors.WithHint(unimplemented.NewWithIssue(42061,
-			"cannot run this DDL statement inside BEGIN..COMMIT as its atomicity cannot be guaranteed"),
+			"cannot run this DDL statement inside a multi-statement transaction as its atomicity cannot be guaranteed"),
 			"You can set the session variable 'strict_ddl_atomicity' to false if you are willing to accept atomicity violations.")
 	}
 	return nil


### PR DESCRIPTION
The previous commit 3de280109f4e1151ce5b72418e3c911f00b15fdc missed the case where an implicit transaction has multiple statements. These also should not be allowed if the setting is enabled and there is non-atomic DDL.

Epic: None
Release note: None