### PR TITLE
release-23.1: changefeedccl: ensure rangefeed setting is enabled in tests

### DIFF
--- a/pkg/ccl/changefeedccl/cdceval/expr_eval_test.go
+++ b/pkg/ccl/changefeedccl/cdceval/expr_eval_test.go
@@ -47,6 +47,7 @@ func TestEvaluator(t *testing.T) {
 	defer s.Stopper().Stop(context.Background())
 
 	sqlDB := sqlutils.MakeSQLRunner(db)
+	sqlDB.Exec(t, "SET CLUSTER SETTING kv.rangefeed.enabled = true")
 	sqlDB.Exec(t, `CREATE TYPE status AS ENUM ('open', 'closed', 'inactive')`)
 	sqlDB.Exec(t, `
 CREATE TABLE foo (

--- a/pkg/ccl/changefeedccl/cdcevent/event_test.go
+++ b/pkg/ccl/changefeedccl/cdcevent/event_test.go
@@ -140,6 +140,7 @@ func TestEventDecoder(t *testing.T) {
 	defer s.Stopper().Stop(context.Background())
 
 	sqlDB := sqlutils.MakeSQLRunner(db)
+	sqlDB.Exec(t, "SET CLUSTER SETTING kv.rangefeed.enabled = true")
 	sqlDB.Exec(t, `CREATE TYPE status AS ENUM ('open', 'closed', 'inactive')`)
 	sqlDB.Exec(t, `
 CREATE TABLE foo (
@@ -420,6 +421,7 @@ func TestEventColumnOrderingWithSchemaChanges(t *testing.T) {
 	defer s.Stopper().Stop(context.Background())
 
 	sqlDB := sqlutils.MakeSQLRunner(db)
+	sqlDB.Exec(t, "SET CLUSTER SETTING kv.rangefeed.enabled = true")
 	// Use alter column type to force column reordering.
 	sqlDB.Exec(t, `SET enable_experimental_alter_column_type_general = true`)
 
@@ -751,5 +753,4 @@ func TestMakeRowFromTuple(t *testing.T) {
 		require.Equal(t, current.valAsString, tree.AsStringWithFlags(d, tree.FmtExport))
 		return nil
 	}))
-
 }

--- a/pkg/ccl/changefeedccl/cdctest/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/cdctest/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//pkg/keys",
         "//pkg/kv/kvclient/rangefeed",
         "//pkg/kv/kvpb",
+        "//pkg/kv/kvserver",
         "//pkg/roachpb",
         "//pkg/sql",
         "//pkg/sql/catalog",

--- a/pkg/ccl/changefeedccl/cdctest/row.go
+++ b/pkg/ccl/changefeedccl/cdctest/row.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/rangefeed"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
@@ -37,6 +38,13 @@ func MakeRangeFeedValueReader(
 ) (func(t *testing.T) *kvpb.RangeFeedValue, func()) {
 	t.Helper()
 	execCfg := execCfgI.(sql.ExecutorConfig)
+
+	// Rangefeeds might still work even when this setting is false because span
+	// configs may enable them, but relying on span configs can be prone to
+	// issues as seen in #109507. Therefore, we assert that the cluster setting
+	// is set.
+	require.True(t, kvserver.RangefeedEnabled.Get(&execCfg.Settings.SV))
+
 	rows := make(chan *kvpb.RangeFeedValue)
 	ctx, cleanup := context.WithCancel(context.Background())
 

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -1809,8 +1809,8 @@ func (r *Replica) checkExecutionCanProceedForRangeFeed(
 	} else if err := r.checkSpanInRangeRLocked(ctx, rSpan); err != nil {
 		return err
 	} else if !r.isRangefeedEnabledRLocked() && !RangefeedEnabled.Get(&r.store.cfg.Settings.SV) {
-		return errors.Errorf("rangefeeds require the kv.rangefeed.enabled setting. See %s",
-			docs.URL(`change-data-capture.html#enable-rangefeeds-to-reduce-latency`))
+		return errors.Errorf("[r%d] rangefeeds require the kv.rangefeed.enabled setting. See %s",
+			r.RangeID, docs.URL(`change-data-capture.html#enable-rangefeeds-to-reduce-latency`))
 	} else if err := r.checkTSAboveGCThresholdRLocked(ts, status, false /* isAdmin */); err != nil {
 		return err
 	}


### PR DESCRIPTION
Previously, many tests which create rangefeeds would not explicitly set the `kv.rangefeed.enabled` setting to be true. These tests would still work because, by default, rangefeeds are enabled via span configs. However, it was observed that span configs are not immediately applied when range splits occur. This would cause the testing rangefeed reader to encounter errors and/or timeout on very rare occasions. See https://github.com/cockroachdb/cockroach/issues/109306#issuecomment-1692428425 for more info.

This change updates these tests to set the `kv.rangefeed.enabled` cluster setting to be true, which removes the dependency on span configs.

Closes: https://github.com/cockroachdb/cockroach/issues/109306
Epic: None
Release note: None