### PR TITLE
release-23.1: roachtest: enforce single upgrade in tenant-span-stats/mixed-version

### DIFF
--- a/pkg/cmd/roachtest/tests/mixed_version_tenant_span_stats.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_tenant_span_stats.go
@@ -47,7 +47,13 @@ func registerTenantSpanStatsMixedVersion(r registry.Registry) {
 				t.Fatal("predecessor binary already includes RPC protobuf changes, this test is no longer needed -- remove me")
 			}
 
-			mvt := mixedversion.NewTest(ctx, t, t.L(), c, c.All())
+			mvt := mixedversion.NewTest(
+				ctx, t, t.L(), c, c.All(),
+				// This test only makes sense in 22.2 / 23.1 mixed-version
+				// state; therefore, we enforce a single upgrade on every test
+				// run.
+				mixedversion.NumUpgrades(1),
+			)
 
 			tableName := "test"
 			var startKey string


### PR DESCRIPTION
The test is checking behaviour specific to the 22.2/23.1 mixed-version state; that's the only upgrade we want to perform in this test.

Fixes: #109576.

Release note: None

Release justification: test-only changes.