### PR TITLE
opt: fix bugs in plan gist decoding

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/explain_gist
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain_gist
@@ -189,3 +189,10 @@ SELECT crdb_internal.decode_plan_gist('AgGwAgQAgQIAAgAEBQITsAICAxgGDA==')
             └── • scan
                   table: ?@?
                   spans: 1+ spans
+
+# Regression test for #109560. Incorrectly formed plan gist should not cause
+# internal error.
+query T nosort
+SELECT crdb_internal.decode_external_plan_gist('Ag8f')
+----
+• union all

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain_gist
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain_gist
@@ -171,3 +171,21 @@ SELECT crdb_internal.decode_plan_gist('AgGSARIAAwlAsJ8BE5IBAhcGFg==')
           table: ?@?
           spans: 1+ spans
           limit
+
+# Regression test for #108979. Correctly decode inverted filters.
+query T nosort
+SELECT crdb_internal.decode_plan_gist('AgGwAgQAgQIAAgAEBQITsAICAxgGDA==')
+----
+• top-k
+│ order
+│
+└── • filter
+    │
+    └── • index join
+        │ table: ?@?
+        │
+        └── • inverted filter
+            │
+            └── • scan
+                  table: ?@?
+                  spans: 1+ spans

--- a/pkg/sql/opt/exec/explain/emit.go
+++ b/pkg/sql/opt/exec/explain/emit.go
@@ -780,8 +780,12 @@ func (e *emitter) emitNodeAttributes(n *Node) error {
 
 	case invertedFilterOp:
 		a := n.args.(*invertedFilterArgs)
-		ob.Attr("inverted column", a.Input.Columns()[a.InvColumn].Name)
-		ob.Attr("num spans", len(a.InvFilter.SpansToRead))
+		if a.InvColumn != 0 {
+			ob.Attr("inverted column", a.Input.Columns()[a.InvColumn].Name)
+		}
+		if a.InvFilter != nil && len(a.InvFilter.SpansToRead) > 0 {
+			ob.Attr("num spans", len(a.InvFilter.SpansToRead))
+		}
 
 	case invertedJoinOp:
 		a := n.args.(*invertedJoinArgs)

--- a/pkg/sql/opt/exec/explain/explain_factory.go
+++ b/pkg/sql/opt/exec/explain/explain_factory.go
@@ -90,6 +90,13 @@ func (n *Node) Annotate(id exec.ExplainAnnotationID, value interface{}) {
 func newNode(
 	op execOperator, args interface{}, ordering exec.OutputOrdering, children ...*Node,
 ) (*Node, error) {
+	nonNilChildren := make([]*Node, 0, len(children))
+	for i := range children {
+		if children[i] != nil {
+			nonNilChildren = append(nonNilChildren, children[i])
+		}
+	}
+	children = nonNilChildren
 	inputNodeCols := make([]colinfo.ResultColumns, len(children))
 	for i := range children {
 		inputNodeCols[i] = children[i].Columns()

--- a/pkg/sql/opt/exec/explain/plan_gist_factory.go
+++ b/pkg/sql/opt/exec/explain/plan_gist_factory.go
@@ -248,6 +248,9 @@ func (f *PlanGistFactory) decodeOp() execOperator {
 
 func (f *PlanGistFactory) popChild() *Node {
 	l := len(f.nodeStack)
+	if l == 0 {
+		return nil
+	}
 	n := f.nodeStack[l-1]
 	f.nodeStack = f.nodeStack[:l-1]
 

--- a/pkg/sql/opt/exec/explain/result_columns.go
+++ b/pkg/sql/opt/exec/explain/result_columns.go
@@ -42,13 +42,22 @@ func getResultColumns(
 	case filterOp, invertedFilterOp, limitOp, max1RowOp, sortOp, topKOp, bufferOp, hashSetOpOp,
 		streamingSetOpOp, unionAllOp, distinctOp, saveTableOp, recursiveCTEOp:
 		// These ops inherit the columns from their first input.
+		if len(inputs) == 0 {
+			return nil, nil
+		}
 		return inputs[0], nil
 
 	case simpleProjectOp:
+		if len(inputs) == 0 {
+			return nil, nil
+		}
 		a := args.(*simpleProjectArgs)
 		return projectCols(inputs[0], a.Cols, nil /* colNames */), nil
 
 	case serializingProjectOp:
+		if len(inputs) == 0 {
+			return nil, nil
+		}
 		a := args.(*serializingProjectArgs)
 		return projectCols(inputs[0], a.Cols, a.ColNames), nil
 
@@ -67,19 +76,34 @@ func getResultColumns(
 		return args.(*renderArgs).Columns, nil
 
 	case projectSetOp:
+		if len(inputs) == 0 {
+			return nil, nil
+		}
 		return appendColumns(inputs[0], args.(*projectSetArgs).ZipCols...), nil
 
 	case applyJoinOp:
+		if len(inputs) == 0 {
+			return nil, nil
+		}
 		a := args.(*applyJoinArgs)
 		return joinColumns(a.JoinType, inputs[0], a.RightColumns), nil
 
 	case hashJoinOp:
+		if len(inputs) < 2 {
+			return nil, nil
+		}
 		return joinColumns(args.(*hashJoinArgs).JoinType, inputs[0], inputs[1]), nil
 
 	case mergeJoinOp:
+		if len(inputs) < 2 {
+			return nil, nil
+		}
 		return joinColumns(args.(*mergeJoinArgs).JoinType, inputs[0], inputs[1]), nil
 
 	case lookupJoinOp:
+		if len(inputs) == 0 {
+			return nil, nil
+		}
 		a := args.(*lookupJoinArgs)
 		cols := joinColumns(a.JoinType, inputs[0], tableColumns(a.Table, a.LookupCols))
 		// The following matches the behavior of execFactory.ConstructLookupJoin.
@@ -89,16 +113,25 @@ func getResultColumns(
 		return cols, nil
 
 	case ordinalityOp:
+		if len(inputs) == 0 {
+			return nil, nil
+		}
 		return appendColumns(inputs[0], colinfo.ResultColumn{
 			Name: args.(*ordinalityArgs).ColName,
 			Typ:  types.Int,
 		}), nil
 
 	case groupByOp:
+		if len(inputs) == 0 {
+			return nil, nil
+		}
 		a := args.(*groupByArgs)
 		return groupByColumns(inputs[0], a.GroupCols, a.Aggregations), nil
 
 	case scalarGroupByOp:
+		if len(inputs) == 0 {
+			return nil, nil
+		}
 		a := args.(*scalarGroupByArgs)
 		return groupByColumns(inputs[0], nil /* groupCols */, a.Aggregations), nil
 
@@ -106,6 +139,9 @@ func getResultColumns(
 		return args.(*windowArgs).Window.Cols, nil
 
 	case invertedJoinOp:
+		if len(inputs) == 0 {
+			return nil, nil
+		}
 		a := args.(*invertedJoinArgs)
 		cols := joinColumns(a.JoinType, inputs[0], tableColumns(a.Table, a.LookupCols))
 		// The following matches the behavior of execFactory.ConstructInvertedJoin.


### PR DESCRIPTION
#### opt: fix plan gist decoding of inverted filters

Details about inverted filter nodes are not encoded in plan gists. The
plan gist decoder incorrectly assumed there were some details encoded,
and would raise an internal error whenever decoding a plan gist with an
inverted filter. This commit fixes the incorrect assumption to prevent
the internal error.

Fixes #108979

There is no release not because plan gists are an undocumented feature.

Release note: None

#### opt: fix plan gist decoding internal error

This commit fixes some cases where `crdb_internal.decode_plan_gist`
could raise internal index-out-of-bound errors when given incorrectly
formed input.

Fixes #109560

Release note: None
