### PR TITLE
backupccl: Refactor allocateDescriptorRewrites in restore_planning.go

### DIFF
--- a/pkg/ccl/backupccl/BUILD.bazel
+++ b/pkg/ccl/backupccl/BUILD.bazel
@@ -157,6 +157,7 @@ go_library(
         "@com_github_gogo_protobuf//types",
         "@com_github_kr_pretty//:pretty",
         "@com_github_robfig_cron_v3//:cron",
+        "@org_golang_x_exp//maps",
     ],
 )
 
@@ -266,12 +267,16 @@ go_test(
         "//pkg/sql/catalog/bootstrap",
         "//pkg/sql/catalog/catalogkeys",
         "//pkg/sql/catalog/catenumpb",
+        "//pkg/sql/catalog/dbdesc",
         "//pkg/sql/catalog/descbuilder",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/descs",
         "//pkg/sql/catalog/desctestutils",
+        "//pkg/sql/catalog/funcdesc",
+        "//pkg/sql/catalog/schemadesc",
         "//pkg/sql/catalog/systemschema",
         "//pkg/sql/catalog/tabledesc",
+        "//pkg/sql/catalog/typedesc",
         "//pkg/sql/execinfra",
         "//pkg/sql/execinfrapb",
         "//pkg/sql/importer",
@@ -340,6 +345,7 @@ go_test(
         "@com_github_robfig_cron_v3//:cron",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
+        "@org_golang_x_exp//slices",
         "@org_golang_x_sync//errgroup",
     ],
 )

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -11024,7 +11024,7 @@ $$;
 	err = sql.TestingDescsTxn(ctx, tgtServer, func(ctx context.Context, txn isql.Txn, col *descs.Collection) error {
 		dbDesc, err := col.ByNameWithLeased(txn.KV()).Get().Database(ctx, "db1")
 		require.NoError(t, err)
-		require.Equal(t, 107, int(dbDesc.GetID()))
+		require.Equal(t, 123, int(dbDesc.GetID()))
 
 		scDesc, err := col.ByNameWithLeased(txn.KV()).Get().Schema(ctx, dbDesc, "sc1")
 		require.NoError(t, err)
@@ -11048,7 +11048,7 @@ $$;
 		fnDesc, err := col.ByIDWithLeased(txn.KV()).WithoutNonPublic().Get().Function(ctx, descpb.ID(udfID))
 		require.NoError(t, err)
 		require.Equal(t, 130, int(fnDesc.GetID()))
-		require.Equal(t, 107, int(fnDesc.GetParentID()))
+		require.Equal(t, 123, int(fnDesc.GetParentID()))
 		require.Equal(t, 125, int(fnDesc.GetParentSchemaID()))
 		// Make sure db name and IDs are rewritten in function body.
 		require.Equal(t, "SELECT a FROM db1.sc1.tbl1;\nSELECT nextval(129:::REGCLASS);", fnDesc.GetFunctionBody())

--- a/pkg/ccl/backupccl/restore_planning.go
+++ b/pkg/ccl/backupccl/restore_planning.go
@@ -58,6 +58,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/roleoption"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catconstants"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/catid"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
@@ -67,6 +68,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/redact"
+	"golang.org/x/exp/maps"
 )
 
 const (
@@ -144,6 +146,617 @@ func maybeFilterMissingViews(
 	return filteredTablesByID, nil
 }
 
+func validateTableDependenciesForOptions(
+	tablesByID map[descpb.ID]*tabledesc.Mutable,
+	typesByID map[descpb.ID]*typedesc.Mutable,
+	functionsByID map[descpb.ID]*funcdesc.Mutable,
+	opts *tree.RestoreOptions,
+) error {
+	for _, table := range tablesByID {
+		// Check that foreign key targets exist.
+		for i := range table.OutboundFKs {
+			fk := &table.OutboundFKs[i]
+			if _, ok := tablesByID[fk.ReferencedTableID]; !ok {
+				if !opts.SkipMissingFKs {
+					return errors.Errorf(
+						"cannot restore table %q without referenced table %d (or %q option)",
+						table.Name, fk.ReferencedTableID, restoreOptSkipMissingFKs,
+					)
+				}
+			}
+		}
+
+		// Check that functions referenced in check constraints exist.
+		fnIDs, err := table.GetAllReferencedFunctionIDs()
+		if err != nil {
+			return err
+		}
+		for _, fnID := range fnIDs.Ordered() {
+			if _, ok := functionsByID[fnID]; !ok {
+				if !opts.SkipMissingUDFs {
+					return errors.Errorf(
+						"cannot restore table %q without referenced function %d (or %q option)",
+						table.Name, fnID, restoreOptSkipMissingUDFs,
+					)
+				}
+			}
+		}
+
+		// Check that referenced sequences exist.
+		for i := range table.Columns {
+			col := &table.Columns[i]
+			// Ensure that all referenced types are present.
+			if col.Type.UserDefined() {
+				// TODO (rohany): This can be turned into an option later.
+				id := typedesc.GetUserDefinedTypeDescID(col.Type)
+				if _, ok := typesByID[id]; !ok {
+					return errors.Errorf(
+						"cannot restore table %q without referenced type %d",
+						table.Name,
+						id,
+					)
+				}
+			}
+			for _, seqID := range col.UsesSequenceIds {
+				if _, ok := tablesByID[seqID]; !ok {
+					if !opts.SkipMissingSequences {
+						return errors.Errorf(
+							"cannot restore table %q without referenced sequence %d (or %q option)",
+							table.Name, seqID, restoreOptSkipMissingSequences,
+						)
+					}
+				}
+			}
+			for _, seqID := range col.OwnsSequenceIds {
+				if _, ok := tablesByID[seqID]; !ok {
+					if !opts.SkipMissingSequenceOwners {
+						return errors.Errorf(
+							"cannot restore table %q without referenced sequence %d (or %q option)",
+							table.Name, seqID, restoreOptSkipMissingSequenceOwners)
+					}
+				}
+			}
+		}
+
+		// Handle sequence ownership dependencies.
+		if table.IsSequence() && table.SequenceOpts.HasOwner() {
+			if _, ok := tablesByID[table.SequenceOpts.SequenceOwner.OwnerTableID]; !ok {
+				if !opts.SkipMissingSequenceOwners {
+					return errors.Errorf(
+						"cannot restore sequence %q without referenced owner table %d (or %q option)",
+						table.Name,
+						table.SequenceOpts.SequenceOwner.OwnerTableID,
+						restoreOptSkipMissingSequenceOwners,
+					)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// remapSystemDBDescsToTempDB remaps all the descriptors belonging to system
+// tables to the temp system DB.
+func remapSystemDBDescsToTempDB(
+	schemasByID map[descpb.ID]*schemadesc.Mutable,
+	tablesByID map[descpb.ID]*tabledesc.Mutable,
+	typesByID map[descpb.ID]*typedesc.Mutable,
+	tempSysDBID catid.DescID,
+	descriptorRewrites jobspb.DescRewriteMap,
+) {
+	for _, table := range tablesByID {
+		if table.GetParentID() == systemschema.SystemDB.GetID() {
+			descriptorRewrites[table.GetID()] = &jobspb.DescriptorRewrite{
+				ParentID:       tempSysDBID,
+				ParentSchemaID: keys.PublicSchemaIDForBackup,
+			}
+		}
+	}
+	for _, sc := range schemasByID {
+		if sc.GetParentID() == systemschema.SystemDB.GetID() {
+			descriptorRewrites[sc.GetID()] = &jobspb.DescriptorRewrite{ParentID: tempSysDBID}
+		}
+	}
+	for _, typ := range typesByID {
+		if typ.GetParentID() == systemschema.SystemDB.GetID() {
+			descriptorRewrites[typ.GetID()] = &jobspb.DescriptorRewrite{
+				ParentID:       tempSysDBID,
+				ParentSchemaID: keys.PublicSchemaIDForBackup,
+			}
+		}
+	}
+}
+
+// Construct rewrites for any user defined schemas.
+func remapSchemas(
+	ctx context.Context,
+	p sql.PlanHookState,
+	databasesByID map[descpb.ID]*dbdesc.Mutable,
+	schemasByID map[descpb.ID]*schemadesc.Mutable,
+	descriptorCoverage tree.DescriptorCoverage,
+	intoDB string,
+	restoreDBNames map[string]catalog.DatabaseDescriptor,
+	// Outputs
+	databasesWithDeprecatedPrivileges map[string]struct{},
+	descriptorRewrites jobspb.DescRewriteMap,
+) (bool, error) {
+
+	txn := p.InternalSQLTxn()
+	col := txn.Descriptors()
+	shouldBufferDeprecatedPrivilegeNotice := false
+
+	for _, sc := range schemasByID {
+		if _, ok := descriptorRewrites[sc.ID]; ok {
+			continue
+		}
+
+		targetDB, err := resolveTargetDB(databasesByID, intoDB, descriptorCoverage, sc)
+		if err != nil {
+			return false, err
+		}
+
+		if _, ok := restoreDBNames[targetDB]; ok {
+			descriptorRewrites[sc.ID] = &jobspb.DescriptorRewrite{}
+			continue
+		}
+		// Look up the parent database's ID.
+		parentID, parentDB, err := getDatabaseIDAndDesc(ctx, txn.KV(), col, targetDB)
+		if err != nil {
+			return false, err
+		}
+		if usesDeprecatedPrivileges, err := checkRestorePrivilegesOnDatabase(ctx, p, parentDB); err != nil {
+			return false, err
+		} else if usesDeprecatedPrivileges {
+			shouldBufferDeprecatedPrivilegeNotice = true
+			databasesWithDeprecatedPrivileges[parentDB.GetName()] = struct{}{}
+		}
+
+		// See if there is an existing schema with the same name.
+		id, err := col.LookupSchemaID(ctx, txn.KV(), parentID, sc.Name)
+		if err != nil {
+			return false, err
+		}
+		if id == descpb.InvalidID {
+			// If we didn't find a matching schema, then we'll restore this schema.
+			descriptorRewrites[sc.ID] = &jobspb.DescriptorRewrite{ParentID: parentID}
+		} else {
+			// If we found an existing schema, then we need to remap all references
+			// to this schema to the existing one.
+			desc, err := col.ByID(txn.KV()).Get().Schema(ctx, id)
+			if err != nil {
+				return false, err
+			}
+			descriptorRewrites[sc.ID] = &jobspb.DescriptorRewrite{
+				ParentID:   desc.GetParentID(),
+				ID:         desc.GetID(),
+				ToExisting: true,
+			}
+		}
+	}
+
+	return shouldBufferDeprecatedPrivilegeNotice, nil
+}
+
+func remapTables(
+	ctx context.Context,
+	p sql.PlanHookState,
+	databasesByID map[descpb.ID]*dbdesc.Mutable,
+	tablesByID map[descpb.ID]*tabledesc.Mutable,
+	descriptorCoverage tree.DescriptorCoverage,
+	intoDB string,
+	restoreDBNames map[string]catalog.DatabaseDescriptor,
+	// Outputs
+	databasesWithDeprecatedPrivileges map[string]struct{},
+	descriptorRewrites jobspb.DescRewriteMap,
+) (bool, error) {
+
+	txn := p.InternalSQLTxn()
+	col := txn.Descriptors()
+	shouldBufferDeprecatedPrivilegeNotice := false
+
+	for _, table := range tablesByID {
+		// If a descriptor has already been assigned a rewrite, then move on.
+		if _, ok := descriptorRewrites[table.ID]; ok {
+			continue
+		}
+
+		targetDB, err := resolveTargetDB(databasesByID, intoDB, descriptorCoverage, table)
+		if err != nil {
+			return false, err
+		}
+
+		if _, ok := restoreDBNames[targetDB]; ok {
+			descriptorRewrites[table.ID] = &jobspb.DescriptorRewrite{}
+			continue
+		}
+		var parentID descpb.ID
+		{
+			newParentID, err := col.LookupDatabaseID(ctx, txn.KV(), targetDB)
+			if err != nil {
+				return false, err
+			}
+			if newParentID == descpb.InvalidID {
+				return false, errors.Errorf("a database named %q needs to exist to restore table %q",
+					targetDB, table.Name)
+			}
+			parentID = newParentID
+		}
+
+		// If we are restoring the table into an existing schema in the target
+		// database, we must ensure that the table name is _not_ in use.
+		// This would fail the CPut later anyway, but this yields a prettier error.
+		//
+		// If we are restoring the table into a schema that is also being
+		// restored then we do not need to check for collisions as the backing
+		// up cluster would enforce uniqueness of table names in a schema.
+		rw, ok := descriptorRewrites[table.GetParentSchemaID()]
+		// We may not find an entry for the parent schema in our
+		// descriptorRewrites if it is a table being restored into the public
+		// schema of the system database. This public schema is a pseudo-schema
+		// i.e. it is not backed by a descriptor, hence we check for that case
+		// separately below.
+		restoringIntoExistingSchema := ok && rw.ToExisting
+		isSystemTable := table.GetParentID() == keys.SystemDatabaseID &&
+			table.GetParentSchemaID() == keys.SystemPublicSchemaID
+		if restoringIntoExistingSchema || isSystemTable {
+			schemaID := table.GetParentSchemaID()
+			if ok {
+				schemaID = rw.ID
+			}
+			tableName := tree.NewUnqualifiedTableName(tree.Name(table.GetName()))
+			err := descs.CheckObjectNameCollision(ctx, col, txn.KV(), parentID, schemaID, tableName)
+			if err != nil {
+				return false, err
+			}
+		}
+
+		// Check privileges.
+		parentDB, err := col.ByID(txn.KV()).Get().Database(ctx, parentID)
+		if err != nil {
+			return false, errors.Wrapf(err,
+				"failed to lookup parent DB %d", errors.Safe(parentID))
+		}
+		if usesDeprecatedPrivileges, err := checkRestorePrivilegesOnDatabase(ctx, p, parentDB); err != nil {
+			return false, err
+		} else if usesDeprecatedPrivileges {
+			shouldBufferDeprecatedPrivilegeNotice = true
+			databasesWithDeprecatedPrivileges[parentDB.GetName()] = struct{}{}
+		}
+
+		// We're restoring a table and not its parent database. We may block
+		// restoring multi-region tables to multi-region databases since
+		// regions may mismatch.
+		if err := checkMultiRegionCompatible(ctx, txn.KV(), col, table, parentDB); err != nil {
+			return false, pgerror.WithCandidateCode(err, pgcode.FeatureNotSupported)
+		}
+
+		// Create the table rewrite with the new parent ID. We've done all the
+		// up-front validation that we can.
+		descriptorRewrites[table.ID] = &jobspb.DescriptorRewrite{ParentID: parentID}
+
+		// If we're restoring to a public schema of database that already exists
+		// we can populate the rewrite ParentSchemaID field here since we
+		// already have the database descriptor.
+		if table.GetParentSchemaID() == keys.PublicSchemaIDForBackup ||
+			table.GetParentSchemaID() == descpb.InvalidID {
+			publicSchemaID := parentDB.GetSchemaID(catconstants.PublicSchemaName)
+			descriptorRewrites[table.ID].ParentSchemaID = publicSchemaID
+		}
+	}
+	return shouldBufferDeprecatedPrivilegeNotice, nil
+}
+
+func remapTypes(
+	ctx context.Context,
+	p sql.PlanHookState,
+	databasesByID map[descpb.ID]*dbdesc.Mutable,
+	typesByID map[descpb.ID]*typedesc.Mutable,
+	descriptorCoverage tree.DescriptorCoverage,
+	intoDB string,
+	restoreDBNames map[string]catalog.DatabaseDescriptor,
+	// Outputs
+	databasesWithDeprecatedPrivileges map[string]struct{},
+	descriptorRewrites jobspb.DescRewriteMap,
+) (bool, error) {
+
+	txn := p.InternalSQLTxn()
+	col := txn.Descriptors()
+	shouldBufferDeprecatedPrivilegeNotice := false
+
+	// Iterate through typesByID to construct a remapping entry for each type.
+	for _, typ := range typesByID {
+		// If a descriptor has already been assigned a rewrite, then move on.
+		if _, ok := descriptorRewrites[typ.ID]; ok {
+			continue
+		}
+
+		targetDB, err := resolveTargetDB(databasesByID, intoDB, descriptorCoverage, typ)
+		if err != nil {
+			return false, err
+		}
+
+		if _, ok := restoreDBNames[targetDB]; ok {
+			descriptorRewrites[typ.ID] = &jobspb.DescriptorRewrite{}
+			continue
+		}
+		// The remapping logic for a type will perform the remapping for a type's
+		// array type, so don't perform this logic for the array type itself.
+		if typ.AsAliasTypeDescriptor() != nil {
+			continue
+		}
+
+		// Look up the parent database's ID.
+		parentID, err := col.LookupDatabaseID(ctx, txn.KV(), targetDB)
+		if err != nil {
+			return false, err
+		}
+		if parentID == descpb.InvalidID {
+			return false, errors.Errorf("a database named %q needs to exist to restore type %q",
+				targetDB, typ.Name)
+		}
+		// Check privileges on the parent DB.
+		parentDB, err := col.ByID(txn.KV()).Get().Database(ctx, parentID)
+		if err != nil {
+			return false, errors.Wrapf(err,
+				"failed to lookup parent DB %d", errors.Safe(parentID))
+		}
+
+		// If we are restoring the type into an existing schema in the target
+		// database, we can find the type with the same name and don't need to
+		// create it as part of the restore.
+		//
+		// If we are restoring the type into a schema that is also being
+		// restored then we need to create the type and the array type as part
+		// of the restore.
+		var desc catalog.Descriptor
+		if rewrite, ok := descriptorRewrites[typ.GetParentSchemaID()]; ok && rewrite.ToExisting {
+			var err error
+			desc, err = descs.GetDescriptorCollidingWithObjectName(
+				ctx,
+				col,
+				txn.KV(),
+				parentID,
+				rewrite.ID,
+				typ.Name,
+			)
+			if err != nil {
+				return false, err
+			}
+
+			if desc == nil {
+				// If we did not find a type descriptor, ensure that the
+				// corresponding array type descriptor does not exist. This is
+				// because we will create both the type and array type below.
+				arrTyp := typesByID[typ.ArrayTypeID]
+				typeName := tree.NewUnqualifiedTypeName(arrTyp.GetName())
+				err = descs.CheckObjectNameCollision(ctx, col, txn.KV(), parentID, rewrite.ID, typeName)
+				if err != nil {
+					return false, errors.Wrapf(err, "name collision for %q's array type", typ.Name)
+				}
+			}
+		}
+
+		if desc == nil {
+			// If we didn't find a type with the same name, then mark that we
+			// need to create the type.
+
+			// Ensure that the user has the correct privilege to create types.
+			if usesDeprecatedPrivileges, err := checkRestorePrivilegesOnDatabase(ctx, p, parentDB); err != nil {
+				return false, err
+			} else if usesDeprecatedPrivileges {
+				shouldBufferDeprecatedPrivilegeNotice = true
+				databasesWithDeprecatedPrivileges[parentDB.GetName()] = struct{}{}
+			}
+
+			// Create a rewrite entry for the type.
+			descriptorRewrites[typ.ID] = &jobspb.DescriptorRewrite{ParentID: parentID}
+
+			// Create the rewrite entry for the array type as well.
+			arrTyp := typesByID[typ.ArrayTypeID]
+			descriptorRewrites[arrTyp.ID] = &jobspb.DescriptorRewrite{ParentID: parentID}
+		} else {
+			// If there was a name collision, we'll try to see if we can remap
+			// this type to the type existing in the cluster.
+
+			// If the collided object isn't a type, then error out.
+			existingType, isType := desc.(catalog.TypeDescriptor)
+			if !isType {
+				return false, sqlerrors.MakeObjectAlreadyExistsError(desc.DescriptorProto(), typ.Name)
+			}
+
+			// Check if the collided type is compatible to be remapped to.
+			if err := typ.IsCompatibleWith(existingType); err != nil {
+				return false, errors.Wrapf(
+					err,
+					"%q is not compatible with type %q existing in cluster",
+					existingType.GetName(),
+					existingType.GetName(),
+				)
+			}
+
+			// Remap both the type and its array type since they are compatible
+			// with the type existing in the cluster.
+			descriptorRewrites[typ.ID] = &jobspb.DescriptorRewrite{
+				ParentID:   existingType.GetParentID(),
+				ID:         existingType.GetID(),
+				ToExisting: true,
+			}
+			descriptorRewrites[typ.ArrayTypeID] = &jobspb.DescriptorRewrite{
+				ParentID:   existingType.GetParentID(),
+				ID:         existingType.TypeDesc().ArrayTypeID,
+				ToExisting: true,
+			}
+		}
+		// If we're restoring to a public schema of database that already exists
+		// we can populate the rewrite ParentSchemaID field here since we
+		// already have the database descriptor.
+		if typ.GetParentSchemaID() == keys.PublicSchemaIDForBackup ||
+			typ.GetParentSchemaID() == descpb.InvalidID {
+			publicSchemaID := parentDB.GetSchemaID(catconstants.PublicSchemaName)
+			descriptorRewrites[typ.ID].ParentSchemaID = publicSchemaID
+			descriptorRewrites[typ.ArrayTypeID].ParentSchemaID = publicSchemaID
+		}
+	}
+	return shouldBufferDeprecatedPrivilegeNotice, nil
+}
+
+func remapFunctions(
+	databasesByID map[descpb.ID]*dbdesc.Mutable,
+	functionsByID map[descpb.ID]*funcdesc.Mutable,
+	descriptorCoverage tree.DescriptorCoverage,
+	intoDB string,
+	restoreDBNames map[string]catalog.DatabaseDescriptor,
+	// Outputs
+	descriptorRewrites jobspb.DescRewriteMap,
+) error {
+	// TODO(chengxiong): we need to handle the cases of restoring tables when we
+	// start supporting udf references from other objects. Namely, we need to do
+	// collision checks similar to tables and types. However, there would be a
+	// bit shift since there is not namespace entry for functions. That means we
+	// need some function resolution for it.
+	for _, function := range functionsByID {
+		// User-defined functions are not allowed in tables, so restoring specific
+		// tables shouldn't match any udf descriptors.
+		if _, ok := descriptorRewrites[function.ID]; ok {
+			return errors.AssertionFailedf("function descriptors seen when restoring tables")
+		}
+
+		targetDB, err := resolveTargetDB(databasesByID, intoDB, descriptorCoverage, function)
+		if err != nil {
+			return err
+		}
+
+		if _, ok := restoreDBNames[targetDB]; !ok {
+			return errors.AssertionFailedf("function descriptor seen when restoring tables")
+		}
+
+		descriptorRewrites[function.ID] = &jobspb.DescriptorRewrite{}
+	}
+	return nil
+}
+
+func remapDatabases(
+	restoreDBs []catalog.DatabaseDescriptor,
+	newDBName string,
+	// Outputs
+	descriptorRewrites jobspb.DescRewriteMap,
+) {
+	for _, db := range restoreDBs {
+		rewrite := &jobspb.DescriptorRewrite{}
+		if newDBName != "" {
+			rewrite.NewDBName = newDBName
+		}
+		descriptorRewrites[db.GetID()] = rewrite
+	}
+}
+
+func getDescriptorByID(
+	id descpb.ID,
+	databasesByID map[descpb.ID]*dbdesc.Mutable,
+	schemasByID map[descpb.ID]*schemadesc.Mutable,
+	tablesByID map[descpb.ID]*tabledesc.Mutable,
+	typesByID map[descpb.ID]*typedesc.Mutable,
+	functionsByID map[descpb.ID]*funcdesc.Mutable,
+) catalog.Descriptor {
+	if desc, ok := databasesByID[id]; ok {
+		return desc
+	}
+	if desc, ok := schemasByID[id]; ok {
+		return desc
+	}
+	if desc, ok := tablesByID[id]; ok {
+		return desc
+	}
+	if desc, ok := typesByID[id]; ok {
+		return desc
+	}
+	if desc, ok := functionsByID[id]; ok {
+		return desc
+	}
+	return nil
+}
+
+// Allocate new IDs for each database and table.
+//
+// NB: we do this in a standalone transaction, not one that covers the
+// entire restore since restarts would be terrible (and our bulk import
+// primitive are non-transactional), but this does mean if something fails
+// during restore we've "leaked" the IDs, in that the generator will have
+// been incremented.
+//
+// NB: The ordering of the new IDs must be the same as the old ones,
+// otherwise the keys may sort differently after they're rekeyed. We could
+// handle this by chunking the AddSSTable calls more finely in Import, but
+// it would be a big performance hit.
+func allocateIDs(
+	ctx context.Context,
+	p sql.PlanHookState,
+	databasesByID map[descpb.ID]*dbdesc.Mutable,
+	schemasByID map[descpb.ID]*schemadesc.Mutable,
+	tablesByID map[descpb.ID]*tabledesc.Mutable,
+	typesByID map[descpb.ID]*typedesc.Mutable,
+	functionsByID map[descpb.ID]*funcdesc.Mutable,
+	// Outputs
+	descriptorRewrites jobspb.DescRewriteMap,
+) error {
+	oldIDs := maps.Keys(descriptorRewrites)
+	sort.Sort(descpb.IDs(oldIDs))
+
+	// First, assign new IDs to objects.
+	// Do this in order to maintain sorting of keys on disk.
+	for _, oldID := range oldIDs {
+		rewrite := descriptorRewrites[oldID]
+		if rewrite.ToExisting {
+			continue
+		}
+		newID, err := p.ExecCfg().DescIDGenerator.GenerateUniqueDescID(ctx)
+		if err != nil {
+			return err
+		}
+		rewrite.ID = newID
+	}
+
+	// Second, iterate through all rewrite objects and update parent IDs
+	// to new IDs assigned above.
+	//
+	// In some cases, these IDs will already be populated in the rewrite objects
+	// by the mapping functions. (E.g. the remapping of system tables, or when
+	// restoring objects into an existing DB or schema.) In those cases, respect
+	// the choice of ID.
+	//
+	// When not already populated, determine the proper parent object from the
+	// existing descriptor, then point the rewrite object to the already-updated
+	// parent object ID.
+	for _, oldID := range oldIDs {
+		desc := getDescriptorByID(
+			oldID,
+			databasesByID,
+			schemasByID,
+			tablesByID,
+			typesByID,
+			functionsByID)
+		if desc == nil {
+			// Objects in the rewrite map are not guaranteed to exist in the
+			// supplied descriptors. E.g. the array-type of a supplied type might
+			// be implied rather than explicit. In those cases, assume the rewrite
+			// object was populated correctly by the relevant remap function.
+			continue
+		}
+		rewrite := descriptorRewrites[oldID]
+		if rewrite.ParentID == descpb.InvalidID {
+			if parentRewrite, ok := descriptorRewrites[desc.GetParentID()]; ok {
+				rewrite.ParentID = parentRewrite.ID
+			}
+		}
+		if rewrite.ParentSchemaID == descpb.InvalidID {
+			if parentSchemaRewrite, ok := descriptorRewrites[desc.GetParentSchemaID()]; ok {
+				rewrite.ParentSchemaID = parentSchemaRewrite.ID
+			}
+		}
+	}
+	return nil
+}
+
 // allocateDescriptorRewrites determines the new ID and parentID (a "DescriptorRewrite")
 // for each table in sqlDescs and returns a mapping from old ID to said
 // DescriptorRewrite. It first validates that the provided sqlDescs can be restored
@@ -179,445 +792,83 @@ func allocateDescriptorRewrites(
 
 	// Fail fast if the tables to restore are incompatible with the specified
 	// options.
-	for _, table := range tablesByID {
-		// Check that foreign key targets exist.
-		for i := range table.OutboundFKs {
-			fk := &table.OutboundFKs[i]
-			if _, ok := tablesByID[fk.ReferencedTableID]; !ok {
-				if !opts.SkipMissingFKs {
-					return nil, errors.Errorf(
-						"cannot restore table %q without referenced table %d (or %q option)",
-						table.Name, fk.ReferencedTableID, restoreOptSkipMissingFKs,
-					)
-				}
-			}
-		}
+	if err := validateTableDependenciesForOptions(tablesByID, typesByID, functionsByID, &opts); err != nil {
+		return nil, err
+	}
 
-		// Check that functions referenced in check constraints exist.
-		fnIDs, err := table.GetAllReferencedFunctionIDs()
+	txn := p.InternalSQLTxn()
+	col := txn.Descriptors()
+	// Check that any DBs being restored do _not_ exist.
+	// Fail fast if the necessary databases don't exist or are otherwise
+	// incompatible with this restore.
+	if newDBName != "" {
+		dbID, err := col.LookupDatabaseID(ctx, txn.KV(), newDBName)
 		if err != nil {
 			return nil, err
 		}
-		for _, fnID := range fnIDs.Ordered() {
-			if _, ok := functionsByID[fnID]; !ok {
-				if !opts.SkipMissingUDFs {
-					return nil, errors.Errorf(
-						"cannot restore table %q without referenced function %d (or %q option)",
-						table.Name, fnID, restoreOptSkipMissingUDFs,
-					)
-				}
-			}
+		if dbID != descpb.InvalidID {
+			return nil, errors.Errorf("database %q already exists", newDBName)
 		}
-
-		// Check that referenced sequences exist.
-		for i := range table.Columns {
-			col := &table.Columns[i]
-			// Ensure that all referenced types are present.
-			if col.Type.UserDefined() {
-				// TODO (rohany): This can be turned into an option later.
-				id := typedesc.GetUserDefinedTypeDescID(col.Type)
-				if _, ok := typesByID[id]; !ok {
-					return nil, errors.Errorf(
-						"cannot restore table %q without referenced type %d",
-						table.Name,
-						id,
-					)
-				}
+	} else {
+		for name := range restoreDBNames {
+			dbID, err := col.LookupDatabaseID(ctx, txn.KV(), name)
+			if err != nil {
+				return nil, err
 			}
-			for _, seqID := range col.UsesSequenceIds {
-				if _, ok := tablesByID[seqID]; !ok {
-					if !opts.SkipMissingSequences {
-						return nil, errors.Errorf(
-							"cannot restore table %q without referenced sequence %d (or %q option)",
-							table.Name, seqID, restoreOptSkipMissingSequences,
-						)
-					}
-				}
-			}
-			for _, seqID := range col.OwnsSequenceIds {
-				if _, ok := tablesByID[seqID]; !ok {
-					if !opts.SkipMissingSequenceOwners {
-						return nil, errors.Errorf(
-							"cannot restore table %q without referenced sequence %d (or %q option)",
-							table.Name, seqID, restoreOptSkipMissingSequenceOwners)
-					}
-				}
-			}
-		}
-
-		// Handle sequence ownership dependencies.
-		if table.IsSequence() && table.SequenceOpts.HasOwner() {
-			if _, ok := tablesByID[table.SequenceOpts.SequenceOwner.OwnerTableID]; !ok {
-				if !opts.SkipMissingSequenceOwners {
-					return nil, errors.Errorf(
-						"cannot restore sequence %q without referenced owner table %d (or %q option)",
-						table.Name,
-						table.SequenceOpts.SequenceOwner.OwnerTableID,
-						restoreOptSkipMissingSequenceOwners,
-					)
-				}
+			if dbID != descpb.InvalidID {
+				return nil, errors.Errorf("database %q already exists", name)
 			}
 		}
 	}
 
-	needsNewParentIDs := make(map[string][]descpb.ID)
-
-	// Increment the DescIDSequenceKey so that it is higher than both the max desc ID
-	// in the backup and current max desc ID in the restoring cluster. This generator
-	// keeps produced the next descriptor ID.
 	if descriptorCoverage == tree.AllDescriptors || descriptorCoverage == tree.SystemUsers {
+		// Increment the DescIDSequenceKey so that it is higher than both the max desc ID
+		// in the backup and current max desc ID in the restoring cluster. This generator
+		// keeps produced the next descriptor ID.
 		tempSysDBID, err := p.ExecCfg().DescIDGenerator.GenerateUniqueDescID(ctx)
 		if err != nil {
 			return nil, err
 		}
-
-		// Remap all of the descriptor belonging to system tables to the temp system
-		// DB.
-		for _, table := range tablesByID {
-			if table.GetParentID() == systemschema.SystemDB.GetID() {
-				descriptorRewrites[table.GetID()] = &jobspb.DescriptorRewrite{
-					ParentID:       tempSysDBID,
-					ParentSchemaID: keys.PublicSchemaIDForBackup,
-				}
-			}
-		}
-		for _, sc := range schemasByID {
-			if sc.GetParentID() == systemschema.SystemDB.GetID() {
-				descriptorRewrites[sc.GetID()] = &jobspb.DescriptorRewrite{ParentID: tempSysDBID}
-			}
-		}
-		for _, typ := range typesByID {
-			if typ.GetParentID() == systemschema.SystemDB.GetID() {
-				descriptorRewrites[typ.GetID()] = &jobspb.DescriptorRewrite{
-					ParentID:       tempSysDBID,
-					ParentSchemaID: keys.PublicSchemaIDForBackup,
-				}
-			}
-		}
+		remapSystemDBDescsToTempDB(schemasByID, tablesByID, typesByID, tempSysDBID, descriptorRewrites)
 	}
 
 	var shouldBufferDeprecatedPrivilegeNotice bool
 	databasesWithDeprecatedPrivileges := make(map[string]struct{})
 
-	// Fail fast if the necessary databases don't exist or are otherwise
-	// incompatible with this restore.
-	if err := func() error {
-		txn := p.InternalSQLTxn()
-		col := txn.Descriptors()
-		// Check that any DBs being restored do _not_ exist.
-		for name := range restoreDBNames {
-			dbID, err := col.LookupDatabaseID(ctx, txn.KV(), name)
-			if err != nil {
-				return err
-			}
-			if dbID != descpb.InvalidID {
-				return errors.Errorf("database %q already exists", name)
-			}
-		}
+	if b, err := remapSchemas(
+		ctx, p, databasesByID, schemasByID, descriptorCoverage, intoDB, restoreDBNames,
+		databasesWithDeprecatedPrivileges, descriptorRewrites,
+	); err != nil {
+		return nil, err
+	} else {
+		shouldBufferDeprecatedPrivilegeNotice = b || shouldBufferDeprecatedPrivilegeNotice
+	}
 
-		// TODO (rohany, pbardea): These checks really need to be refactored.
-		// Construct rewrites for any user defined schemas.
-		for _, sc := range schemasByID {
-			if _, ok := descriptorRewrites[sc.ID]; ok {
-				continue
-			}
+	if b, err := remapTables(
+		ctx, p, databasesByID, tablesByID, descriptorCoverage, intoDB, restoreDBNames,
+		databasesWithDeprecatedPrivileges, descriptorRewrites,
+	); err != nil {
+		return nil, err
+	} else {
+		shouldBufferDeprecatedPrivilegeNotice = b || shouldBufferDeprecatedPrivilegeNotice
+	}
 
-			targetDB, err := resolveTargetDB(ctx, databasesByID, intoDB, descriptorCoverage, sc)
-			if err != nil {
-				return err
-			}
+	if b, err := remapTypes(
+		ctx, p, databasesByID, typesByID, descriptorCoverage, intoDB, restoreDBNames,
+		databasesWithDeprecatedPrivileges, descriptorRewrites,
+	); err != nil {
+		return nil, err
+	} else {
+		shouldBufferDeprecatedPrivilegeNotice = b || shouldBufferDeprecatedPrivilegeNotice
+	}
 
-			if _, ok := restoreDBNames[targetDB]; ok {
-				needsNewParentIDs[targetDB] = append(needsNewParentIDs[targetDB], sc.ID)
-			} else {
-				// Look up the parent database's ID.
-				parentID, parentDB, err := getDatabaseIDAndDesc(ctx, txn.KV(), col, targetDB)
-				if err != nil {
-					return err
-				}
-				if usesDeprecatedPrivileges, err := checkRestorePrivilegesOnDatabase(ctx, p, parentDB); err != nil {
-					return err
-				} else if usesDeprecatedPrivileges {
-					shouldBufferDeprecatedPrivilegeNotice = true
-					databasesWithDeprecatedPrivileges[parentDB.GetName()] = struct{}{}
-				}
-
-				// See if there is an existing schema with the same name.
-				id, err := col.LookupSchemaID(ctx, txn.KV(), parentID, sc.Name)
-				if err != nil {
-					return err
-				}
-				if id == descpb.InvalidID {
-					// If we didn't find a matching schema, then we'll restore this schema.
-					descriptorRewrites[sc.ID] = &jobspb.DescriptorRewrite{ParentID: parentID}
-				} else {
-					// If we found an existing schema, then we need to remap all references
-					// to this schema to the existing one.
-					desc, err := col.ByID(txn.KV()).Get().Schema(ctx, id)
-					if err != nil {
-						return err
-					}
-					descriptorRewrites[sc.ID] = &jobspb.DescriptorRewrite{
-						ParentID:   desc.GetParentID(),
-						ID:         desc.GetID(),
-						ToExisting: true,
-					}
-				}
-			}
-		}
-
-		for _, table := range tablesByID {
-			// If a descriptor has already been assigned a rewrite, then move on.
-			if _, ok := descriptorRewrites[table.ID]; ok {
-				continue
-			}
-
-			targetDB, err := resolveTargetDB(ctx, databasesByID, intoDB, descriptorCoverage, table)
-			if err != nil {
-				return err
-			}
-
-			if _, ok := restoreDBNames[targetDB]; ok {
-				needsNewParentIDs[targetDB] = append(needsNewParentIDs[targetDB], table.ID)
-			} else {
-				var parentID descpb.ID
-				{
-					newParentID, err := col.LookupDatabaseID(ctx, txn.KV(), targetDB)
-					if err != nil {
-						return err
-					}
-					if newParentID == descpb.InvalidID {
-						return errors.Errorf("a database named %q needs to exist to restore table %q",
-							targetDB, table.Name)
-					}
-					parentID = newParentID
-				}
-
-				// If we are restoring the table into an existing schema in the target
-				// database, we must ensure that the table name is _not_ in use.
-				// This would fail the CPut later anyway, but this yields a prettier error.
-				//
-				// If we are restoring the table into a schema that is also being
-				// restored then we do not need to check for collisions as the backing
-				// up cluster would enforce uniqueness of table names in a schema.
-				rw, ok := descriptorRewrites[table.GetParentSchemaID()]
-				// We may not find an entry for the parent schema in our
-				// descriptorRewrites if it is a table being restored into the public
-				// schema of the system database. This public schema is a pseudo-schema
-				// i.e. it is not backed by a descriptor, hence we check for that case
-				// separately below.
-				restoringIntoExistingSchema := ok && rw.ToExisting
-				isSystemTable := table.GetParentID() == keys.SystemDatabaseID &&
-					table.GetParentSchemaID() == keys.SystemPublicSchemaID
-				if restoringIntoExistingSchema || isSystemTable {
-					schemaID := table.GetParentSchemaID()
-					if ok {
-						schemaID = rw.ID
-					}
-					tableName := tree.NewUnqualifiedTableName(tree.Name(table.GetName()))
-					err := descs.CheckObjectNameCollision(ctx, col, txn.KV(), parentID, schemaID, tableName)
-					if err != nil {
-						return err
-					}
-				}
-
-				// Check privileges.
-				parentDB, err := col.ByID(txn.KV()).Get().Database(ctx, parentID)
-				if err != nil {
-					return errors.Wrapf(err,
-						"failed to lookup parent DB %d", errors.Safe(parentID))
-				}
-				if usesDeprecatedPrivileges, err := checkRestorePrivilegesOnDatabase(ctx, p, parentDB); err != nil {
-					return err
-				} else if usesDeprecatedPrivileges {
-					shouldBufferDeprecatedPrivilegeNotice = true
-					databasesWithDeprecatedPrivileges[parentDB.GetName()] = struct{}{}
-				}
-
-				// We're restoring a table and not its parent database. We may block
-				// restoring multi-region tables to multi-region databases since
-				// regions may mismatch.
-				if err := checkMultiRegionCompatible(ctx, txn.KV(), col, table, parentDB); err != nil {
-					return pgerror.WithCandidateCode(err, pgcode.FeatureNotSupported)
-				}
-
-				// Create the table rewrite with the new parent ID. We've done all the
-				// up-front validation that we can.
-				descriptorRewrites[table.ID] = &jobspb.DescriptorRewrite{ParentID: parentID}
-
-				// If we're restoring to a public schema of database that already exists
-				// we can populate the rewrite ParentSchemaID field here since we
-				// already have the database descriptor.
-				if table.GetParentSchemaID() == keys.PublicSchemaIDForBackup ||
-					table.GetParentSchemaID() == descpb.InvalidID {
-					publicSchemaID := parentDB.GetSchemaID(catconstants.PublicSchemaName)
-					descriptorRewrites[table.ID].ParentSchemaID = publicSchemaID
-				}
-			}
-		}
-
-		// Iterate through typesByID to construct a remapping entry for each type.
-		for _, typ := range typesByID {
-			// If a descriptor has already been assigned a rewrite, then move on.
-			if _, ok := descriptorRewrites[typ.ID]; ok {
-				continue
-			}
-
-			targetDB, err := resolveTargetDB(ctx, databasesByID, intoDB, descriptorCoverage, typ)
-			if err != nil {
-				return err
-			}
-
-			if _, ok := restoreDBNames[targetDB]; ok {
-				needsNewParentIDs[targetDB] = append(needsNewParentIDs[targetDB], typ.ID)
-			} else {
-				// The remapping logic for a type will perform the remapping for a type's
-				// array type, so don't perform this logic for the array type itself.
-				if typ.AsAliasTypeDescriptor() != nil {
-					continue
-				}
-
-				// Look up the parent database's ID.
-				parentID, err := col.LookupDatabaseID(ctx, txn.KV(), targetDB)
-				if err != nil {
-					return err
-				}
-				if parentID == descpb.InvalidID {
-					return errors.Errorf("a database named %q needs to exist to restore type %q",
-						targetDB, typ.Name)
-				}
-				// Check privileges on the parent DB.
-				parentDB, err := col.ByID(txn.KV()).Get().Database(ctx, parentID)
-				if err != nil {
-					return errors.Wrapf(err,
-						"failed to lookup parent DB %d", errors.Safe(parentID))
-				}
-
-				// If we are restoring the type into an existing schema in the target
-				// database, we can find the type with the same name and don't need to
-				// create it as part of the restore.
-				//
-				// If we are restoring the type into a schema that is also being
-				// restored then we need to create the type and the array type as part
-				// of the restore.
-				var desc catalog.Descriptor
-				if rewrite, ok := descriptorRewrites[typ.GetParentSchemaID()]; ok && rewrite.ToExisting {
-					var err error
-					desc, err = descs.GetDescriptorCollidingWithObjectName(
-						ctx,
-						col,
-						txn.KV(),
-						parentID,
-						rewrite.ID,
-						typ.Name,
-					)
-					if err != nil {
-						return err
-					}
-
-					if desc == nil {
-						// If we did not find a type descriptor, ensure that the
-						// corresponding array type descriptor does not exist. This is
-						// because we will create both the type and array type below.
-						arrTyp := typesByID[typ.ArrayTypeID]
-						typeName := tree.NewUnqualifiedTypeName(arrTyp.GetName())
-						err = descs.CheckObjectNameCollision(ctx, col, txn.KV(), parentID, rewrite.ID, typeName)
-						if err != nil {
-							return errors.Wrapf(err, "name collision for %q's array type", typ.Name)
-						}
-					}
-				}
-
-				if desc == nil {
-					// If we didn't find a type with the same name, then mark that we
-					// need to create the type.
-
-					// Ensure that the user has the correct privilege to create types.
-					if usesDeprecatedPrivileges, err := checkRestorePrivilegesOnDatabase(ctx, p, parentDB); err != nil {
-						return err
-					} else if usesDeprecatedPrivileges {
-						shouldBufferDeprecatedPrivilegeNotice = true
-						databasesWithDeprecatedPrivileges[parentDB.GetName()] = struct{}{}
-					}
-
-					// Create a rewrite entry for the type.
-					descriptorRewrites[typ.ID] = &jobspb.DescriptorRewrite{ParentID: parentID}
-
-					// Create the rewrite entry for the array type as well.
-					arrTyp := typesByID[typ.ArrayTypeID]
-					descriptorRewrites[arrTyp.ID] = &jobspb.DescriptorRewrite{ParentID: parentID}
-				} else {
-					// If there was a name collision, we'll try to see if we can remap
-					// this type to the type existing in the cluster.
-
-					// If the collided object isn't a type, then error out.
-					existingType, isType := desc.(catalog.TypeDescriptor)
-					if !isType {
-						return sqlerrors.MakeObjectAlreadyExistsError(desc.DescriptorProto(), typ.Name)
-					}
-
-					// Check if the collided type is compatible to be remapped to.
-					if err := typ.IsCompatibleWith(existingType); err != nil {
-						return errors.Wrapf(
-							err,
-							"%q is not compatible with type %q existing in cluster",
-							existingType.GetName(),
-							existingType.GetName(),
-						)
-					}
-
-					// Remap both the type and its array type since they are compatible
-					// with the type existing in the cluster.
-					descriptorRewrites[typ.ID] = &jobspb.DescriptorRewrite{
-						ParentID:   existingType.GetParentID(),
-						ID:         existingType.GetID(),
-						ToExisting: true,
-					}
-					descriptorRewrites[typ.ArrayTypeID] = &jobspb.DescriptorRewrite{
-						ParentID:   existingType.GetParentID(),
-						ID:         existingType.TypeDesc().ArrayTypeID,
-						ToExisting: true,
-					}
-				}
-				// If we're restoring to a public schema of database that already exists
-				// we can populate the rewrite ParentSchemaID field here since we
-				// already have the database descriptor.
-				if typ.GetParentSchemaID() == keys.PublicSchemaIDForBackup ||
-					typ.GetParentSchemaID() == descpb.InvalidID {
-					publicSchemaID := parentDB.GetSchemaID(catconstants.PublicSchemaName)
-					descriptorRewrites[typ.ID].ParentSchemaID = publicSchemaID
-					descriptorRewrites[typ.ArrayTypeID].ParentSchemaID = publicSchemaID
-				}
-			}
-		}
-
-		// TODO(chengxiong): we need to handle the cases of restoring tables when we
-		// start supporting udf references from other objects. Namely, we need to do
-		// collision checks similar to tables and types. However, there would be a
-		// bit shift since there is not namespace entry for functions. That means we
-		// need some function resolution for it.
-		for _, function := range functionsByID {
-			// User-defined functions are not allowed in tables, so restoring specific
-			// tables shouldn't match any udf descriptors.
-			if _, ok := descriptorRewrites[function.ID]; ok {
-				return errors.AssertionFailedf("function descriptors seen when restoring tables")
-			}
-
-			targetDB, err := resolveTargetDB(ctx, databasesByID, intoDB, descriptorCoverage, function)
-			if err != nil {
-				return err
-			}
-
-			if _, ok := restoreDBNames[targetDB]; ok {
-				needsNewParentIDs[targetDB] = append(needsNewParentIDs[targetDB], function.ID)
-			} else {
-				return errors.AssertionFailedf("function descriptor seen when restoring tables")
-			}
-		}
-		return nil
-	}(); err != nil {
+	if err := remapFunctions(
+		databasesByID, functionsByID, descriptorCoverage, intoDB, restoreDBNames, descriptorRewrites,
+	); err != nil {
 		return nil, err
 	}
+
+	remapDatabases(restoreDBs, newDBName, descriptorRewrites)
 
 	if shouldBufferDeprecatedPrivilegeNotice {
 		dbNames := make([]string, 0, len(databasesWithDeprecatedPrivileges))
@@ -628,106 +879,16 @@ func allocateDescriptorRewrites(
 			deprecatedPrivilegesRestorePreamble, p.User(), strings.Join(dbNames, ", ")))
 	}
 
-	// Allocate new IDs for each database and table.
-	//
-	// NB: we do this in a standalone transaction, not one that covers the
-	// entire restore since restarts would be terrible (and our bulk import
-	// primitive are non-transactional), but this does mean if something fails
-	// during restore we've "leaked" the IDs, in that the generator will have
-	// been incremented.
-	//
-	// NB: The ordering of the new IDs must be the same as the old ones,
-	// otherwise the keys may sort differently after they're rekeyed. We could
-	// handle this by chunking the AddSSTable calls more finely in Import, but
-	// it would be a big performance hit.
-
-	for _, db := range restoreDBs {
-		var newID descpb.ID
-		var err error
-		newID, err = p.ExecCfg().DescIDGenerator.GenerateUniqueDescID(ctx)
-		if err != nil {
-			return nil, err
-		}
-
-		descriptorRewrites[db.GetID()] = &jobspb.DescriptorRewrite{ID: newID}
-
-		// If a database restore has specified a new name for the restored database,
-		// then populate the rewrite with the newDBName, else the restored database name is preserved.
-		if newDBName != "" {
-			descriptorRewrites[db.GetID()].NewDBName = newDBName
-		}
-
-		for _, objectID := range needsNewParentIDs[db.GetName()] {
-			descriptorRewrites[objectID] = &jobspb.DescriptorRewrite{ParentID: newID}
-		}
-	}
-
-	// descriptorsToRemap usually contains all tables that are being restored,
-	// plus additional other descriptors.
-	descriptorsToRemap := make([]catalog.Descriptor, 0, len(tablesByID))
-	for _, table := range tablesByID {
-		descriptorsToRemap = append(descriptorsToRemap, table)
-	}
-
-	// Update the remapping information for type descriptors.
-	for _, typ := range typesByID {
-		// If the type is marked to be remapped to an existing type in the
-		// cluster, then we don't want to generate an ID for it.
-		if !descriptorRewrites[typ.ID].ToExisting {
-			descriptorsToRemap = append(descriptorsToRemap, typ)
-		}
-	}
-
-	// Update remapping information for schema descriptors.
-	for _, sc := range schemasByID {
-		// If this schema isn't being remapped to an existing schema, then
-		// request to generate an ID for it.
-		if !descriptorRewrites[sc.ID].ToExisting {
-			descriptorsToRemap = append(descriptorsToRemap, sc)
-		}
-	}
-
-	// Remap function descriptor IDs.
-	for _, fn := range functionsByID {
-		descriptorsToRemap = append(descriptorsToRemap, fn)
-	}
-
-	sort.Sort(catalog.Descriptors(descriptorsToRemap))
-
-	// Generate new IDs for the schemas, tables, and types that need to be
-	// remapped.
-	for _, desc := range descriptorsToRemap {
-		id, err := p.ExecCfg().DescIDGenerator.GenerateUniqueDescID(ctx)
-		if err != nil {
-			return nil, err
-		}
-		descriptorRewrites[desc.GetID()].ID = id
-	}
-
-	// Now that the descriptorRewrites contains a complete rewrite entry for every
-	// schema that is being restored, we can correctly populate the ParentSchemaID
-	// of all tables and types.
-	rewriteObject := func(desc catalog.Descriptor) {
-		if descriptorRewrites[desc.GetID()].ParentSchemaID != descpb.InvalidID {
-			// The rewrite is already populated for the Schema ID,
-			// don't rewrite again.
-			return
-		}
-		curSchemaID := desc.GetParentSchemaID()
-		newSchemaID := curSchemaID
-		if rw, ok := descriptorRewrites[curSchemaID]; ok {
-			newSchemaID = rw.ID
-		}
-		descriptorRewrites[desc.GetID()].ParentSchemaID = newSchemaID
-	}
-	for _, table := range tablesByID {
-		rewriteObject(table)
-	}
-	for _, typ := range typesByID {
-		rewriteObject(typ)
-	}
-	for _, fn := range functionsByID {
-		rewriteObject(fn)
+	if err := allocateIDs(
+		ctx,
+		p,
+		databasesByID,
+		schemasByID,
+		tablesByID,
+		typesByID,
+		functionsByID,
+		descriptorRewrites); err != nil {
+		return nil, err
 	}
 
 	return descriptorRewrites, nil
@@ -772,7 +933,6 @@ func dropDefaultUserDBs(ctx context.Context, txn isql.Txn) error {
 }
 
 func resolveTargetDB(
-	ctx context.Context,
 	databasesByID map[descpb.ID]*dbdesc.Mutable,
 	intoDB string,
 	descriptorCoverage tree.DescriptorCoverage,
@@ -1803,12 +1963,6 @@ func doRestorePlan(
 		return err
 	}
 
-	if restoreStmt.Options.NewDBName != nil {
-		if err := renameTargetDatabaseDescriptor(sqlDescs, restoreDBs, newDBName); err != nil {
-			return err
-		}
-	}
-
 	var oldTenantID *roachpb.TenantID
 	if len(tenants) > 0 {
 		if !p.ExecCfg().Codec.ForSystemTenant() {
@@ -2216,36 +2370,6 @@ func filteredUserCreatedDescriptors(
 		userDescs = append(userDescs, desc)
 	}
 	return userDescs
-}
-
-// renameTargetDatabaseDescriptor updates the name in the target database
-// descriptor to the user specified new_db_name. We update the database
-// descriptor in both sqlDescs that contains all the descriptors being restored,
-// and restoreDBs that contains just the target database descriptor. Renaming
-// the target descriptor ensures accurate name resolution during restore.
-func renameTargetDatabaseDescriptor(
-	sqlDescs []catalog.Descriptor, restoreDBs []catalog.DatabaseDescriptor, newDBName string,
-) error {
-	if len(restoreDBs) != 1 {
-		return errors.AssertionFailedf(
-			"expected restoreDBs to have 1 entry but found %d entries when renaming the target database",
-			len(restoreDBs))
-	}
-
-	for _, desc := range sqlDescs {
-		// Only process database descriptors.
-		db, isDB := desc.(*dbdesc.Mutable)
-		if !isDB {
-			continue
-		}
-		db.SetName(newDBName)
-	}
-	db, ok := restoreDBs[0].(*dbdesc.Mutable)
-	if !ok {
-		return errors.AssertionFailedf("expected *dbdesc.mutable but found %T", db)
-	}
-	db.SetName(newDBName)
-	return nil
 }
 
 // ensureMultiRegionDatabaseRestoreIsAllowed returns an error if restoring a

--- a/pkg/ccl/backupccl/restore_planning_test.go
+++ b/pkg/ccl/backupccl/restore_planning_test.go
@@ -10,14 +10,31 @@ package backupccl
 
 import (
 	"context"
+	"strings"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/ccl/backupccl/backuppb"
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/dbdesc"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/funcdesc"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/schemadesc"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/typedesc"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/slices"
 )
 
 func TestBackupManifestVersionCompatibility(t *testing.T) {
@@ -93,4 +110,400 @@ func TestBackupManifestVersionCompatibility(t *testing.T) {
 			require.NoError(t, checkBackupManifestVersionCompatability(context.Background(), version, manifest /*unsafe=*/, true))
 		})
 	}
+}
+
+func TestAllocateDescriptorRewrites(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+	opName := "allocate-descriptor-rewrites"
+	s, db, kvDB := serverutils.StartServer(t, base.TestServerArgs{
+		DefaultTestTenant: base.TestIsSpecificToStorageLayerAndNeedsASystemTenant,
+	})
+	defer s.Stopper().Stop(ctx)
+	execCfg := s.ExecutorConfig().(sql.ExecutorConfig)
+
+	var defaultDB *dbdesc.Mutable
+	var db1 *dbdesc.Mutable
+	var db2 *dbdesc.Mutable
+	var schema1 *schemadesc.Mutable
+	var schema2 *schemadesc.Mutable
+	var table1 *tabledesc.Mutable
+	var table2 *tabledesc.Mutable
+	var type1 *typedesc.Mutable
+	var type2 *typedesc.Mutable
+	var type1array *typedesc.Mutable
+	var type2array *typedesc.Mutable
+	var func1 *funcdesc.Mutable
+	var func2 *funcdesc.Mutable
+
+	var planner sql.PlanHookState
+
+	setupPlanner := func() {
+		plannerAsInterface, cleanup := sql.NewInternalPlanner(
+			opName,
+			kv.NewTxn(ctx, kvDB, s.NodeID()),
+			username.RootUserName(),
+			&sql.MemoryMetrics{},
+			&execCfg,
+			sql.NewInternalSessionData(ctx, execCfg.Settings, opName))
+		defer cleanup()
+		planner = plannerAsInterface.(sql.PlanHookState)
+	}
+
+	// This is a fairly expensive call. Individual tests should only call it
+	// when they specifically need it for cleanup, e.g. after dropping a
+	// database.
+	setup := func() {
+		query := `
+        DROP DATABASE IF EXISTS db1 cascade;
+        DROP DATABASE IF EXISTS db2 cascade;
+        DROP DATABASE IF EXISTS defaultdb cascade;
+        CREATE DATABASE db1;
+        CREATE DATABASE db2;
+        CREATE DATABASE defaultdb;
+        CREATE SCHEMA schema1;
+        CREATE SCHEMA schema2;
+        CREATE TABLE schema1.table1(id int)
+        CREATE TABLE schema1.table2(id int)
+        CREATE FUNCTION schema1.func1(a INT, b INT) RETURNS INT IMMUTABLE LEAKPROOF LANGUAGE SQL AS 'SELECT a + b';
+        CREATE FUNCTION schema1.func2(a INT, b INT) RETURNS INT IMMUTABLE LEAKPROOF LANGUAGE SQL AS 'SELECT a - b';
+        CREATE TYPE schema1.type1 AS (x INT, y INT);
+        CREATE TYPE schema1.type2 AS ENUM ('a', 'b');
+    `
+		for _, cmd := range strings.Split(query, "\n") {
+			_, err := db.ExecContext(ctx, cmd)
+			require.NoError(t, err)
+		}
+
+		setupPlanner()
+
+		txn := planner.InternalSQLTxn()
+		col := txn.Descriptors()
+		cat, err := col.GetAll(ctx, kv.NewTxn(ctx, kvDB, s.NodeID()))
+		require.NoError(t, err)
+		sqlDescs := cat.OrderedDescriptors()
+
+		type nameAndType struct {
+			name    string
+			objType string
+		}
+
+		asMutable := func(sqlDesc catalog.Descriptor) catalog.MutableDescriptor {
+			return sqlDesc.NewBuilder().BuildExistingMutable()
+		}
+
+		for _, sqlDesc := range sqlDescs {
+			name := sqlDesc.GetName()
+			objType := sqlDesc.GetObjectType()
+			nt := nameAndType{name: name, objType: string(objType)}
+			switch nt {
+			case nameAndType{name: "defaultdb", objType: "database"}:
+				defaultDB = asMutable(sqlDesc).(*dbdesc.Mutable)
+			case nameAndType{name: "db1", objType: "database"}:
+				db1 = asMutable(sqlDesc).(*dbdesc.Mutable)
+			case nameAndType{name: "db2", objType: "database"}:
+				db2 = asMutable(sqlDesc).(*dbdesc.Mutable)
+			case nameAndType{name: "schema1", objType: "schema"}:
+				schema1 = asMutable(sqlDesc).(*schemadesc.Mutable)
+			case nameAndType{name: "schema2", objType: "schema"}:
+				schema2 = asMutable(sqlDesc).(*schemadesc.Mutable)
+			case nameAndType{name: "table1", objType: "table"}:
+				table1 = asMutable(sqlDesc).(*tabledesc.Mutable)
+			case nameAndType{name: "table2", objType: "table"}:
+				table2 = asMutable(sqlDesc).(*tabledesc.Mutable)
+			case nameAndType{name: "type1", objType: "type"}:
+				type1 = asMutable(sqlDesc).(*typedesc.Mutable)
+			case nameAndType{name: "type2", objType: "type"}:
+				type2 = asMutable(sqlDesc).(*typedesc.Mutable)
+			case nameAndType{name: "_type1", objType: "type"}:
+				type1array = asMutable(sqlDesc).(*typedesc.Mutable)
+			case nameAndType{name: "_type2", objType: "type"}:
+				type2array = asMutable(sqlDesc).(*typedesc.Mutable)
+			case nameAndType{name: "func1", objType: "function"}:
+				func1 = asMutable(sqlDesc).(*funcdesc.Mutable)
+			case nameAndType{name: "func2", objType: "function"}:
+				func2 = asMutable(sqlDesc).(*funcdesc.Mutable)
+			}
+		}
+	}
+	setup()
+
+	validateSelfIDs := func(
+		rewrites jobspb.DescRewriteMap,
+		expected []catalog.Descriptor,
+	) error {
+		if len(rewrites) != len(expected) {
+			return errors.Newf("expected %d rewrites, got %d", len(expected), len(rewrites))
+		}
+		for _, desc := range expected {
+			rewrite, ok := rewrites[desc.GetID()]
+			if !ok {
+				return errors.Newf("no rewrite found for %v", desc)
+			}
+			if rewrite.ID == desc.GetID() {
+				return errors.Newf("expected new ID for %v", desc)
+			}
+		}
+		return nil
+	}
+
+	t.Run("allocateDescriptorRewrite", func(t *testing.T) {
+		t.Run("succeeds on empty input", func(t *testing.T) {
+			rewrites, err := allocateDescriptorRewrites(
+				ctx,
+				planner,
+				nil,
+				nil,
+				nil,
+				nil,
+				nil,
+				nil,
+				0,
+				tree.RestoreOptions{},
+				"",
+				"")
+			require.NoError(t, err)
+			require.Equal(t, jobspb.DescRewriteMap{}, rewrites)
+		})
+		t.Run("allocates into existing db", func(t *testing.T) {
+			rewrites, err := allocateDescriptorRewrites(
+				ctx,
+				planner,
+				map[descpb.ID]*dbdesc.Mutable{
+					defaultDB.GetID(): defaultDB,
+				},
+				map[descpb.ID]*schemadesc.Mutable{
+					schema1.GetID(): schema1,
+					schema2.GetID(): schema2,
+				},
+				map[descpb.ID]*tabledesc.Mutable{
+					table1.GetID(): table1,
+					table2.GetID(): table2,
+				},
+				map[descpb.ID]*typedesc.Mutable{
+					type1.GetID():      type1,
+					type2.GetID():      type2,
+					type1array.GetID(): type1array,
+					type2array.GetID(): type2array,
+				},
+				nil,
+				nil,
+				0,
+				tree.RestoreOptions{},
+				db2.GetName(),
+				"")
+			require.NoError(t, err)
+
+			// DB objects are not reallocated
+			require.NoError(t, validateSelfIDs(rewrites, []catalog.Descriptor{
+				schema1, schema2, table2, table2, type1, type2, type1array, type2array,
+			}))
+			// New objects' parent ID points to the ID of the target db (db2).
+			for _, rewrite := range rewrites {
+				require.Equal(t, db2.GetID(), rewrite.ParentID,
+					"expected rewrite to have db2 ID as parentID: %v", rewrite)
+			}
+			// New schema objects have no parent schema
+			for _, obj := range []catalog.Descriptor{
+				schema1, schema2,
+			} {
+				rewrite := rewrites[obj.GetID()]
+				require.Equalf(t, descpb.InvalidID, rewrite.ParentSchemaID,
+					"expected rewrite to have no parent schema, obj: %v, rewrite: %v", obj, rewrite)
+			}
+			// New non-schema objects point to the new ID of the new schema
+			newSchema1ID := rewrites[schema1.GetID()].ID
+			for _, obj := range []catalog.Descriptor{
+				table2, table2, type1, type2, type1array, type2array,
+			} {
+				rewrite := rewrites[obj.GetID()]
+				require.Equalf(t, newSchema1ID, rewrite.ParentSchemaID,
+					"expected rewrite to have new parent schema, obj: %v, rewrite: %v", obj, rewrite,
+				)
+			}
+		})
+
+		t.Run("allocates into new db", func(t *testing.T) {
+			rewrites, err := allocateDescriptorRewrites(
+				ctx,
+				planner,
+				map[descpb.ID]*dbdesc.Mutable{
+					defaultDB.GetID(): defaultDB,
+				},
+				map[descpb.ID]*schemadesc.Mutable{
+					schema1.GetID(): schema1,
+					schema2.GetID(): schema2,
+				},
+				map[descpb.ID]*tabledesc.Mutable{
+					table1.GetID(): table1,
+					table2.GetID(): table2,
+				},
+				map[descpb.ID]*typedesc.Mutable{
+					type1.GetID():      type1,
+					type2.GetID():      type2,
+					type1array.GetID(): type1array,
+					type2array.GetID(): type2array,
+				},
+				nil,
+				[]catalog.DatabaseDescriptor{
+					defaultDB,
+				},
+				0,
+				tree.RestoreOptions{},
+				"",
+				"db3")
+			require.NoError(t, err)
+
+			require.NoError(t, validateSelfIDs(rewrites, []catalog.Descriptor{
+				defaultDB, schema1, schema2, table2, table2, type1, type2, type1array, type2array,
+			}))
+
+			defaultDBID := defaultDB.GetID()
+			require.Equal(t, descpb.InvalidID, rewrites[defaultDBID].ParentID)
+
+			db3ID := rewrites[defaultDBID].ID
+
+			// New objects' parent ID points to the ID of the target db (db3).
+			for id, rewrite := range rewrites {
+				if id == defaultDBID {
+					continue
+				}
+				require.Equal(t, db3ID, rewrite.ParentID,
+					"expected rewrite to have db3 ID as parentID: %v", rewrite)
+			}
+			// New schema objects have no parent schema
+			for _, obj := range []catalog.Descriptor{
+				schema1, schema2,
+			} {
+				rewrite := rewrites[obj.GetID()]
+				require.Equalf(t, descpb.InvalidID, rewrite.ParentSchemaID,
+					"expected rewrite to have no parent schema, obj: %v, rewrite: %v", obj, rewrite)
+			}
+			// New non-schema objects point to the new ID of the new schema
+			newSchema1ID := rewrites[schema1.GetID()].ID
+			for _, obj := range []catalog.Descriptor{
+				table2, table2, type1, type2, type1array, type2array,
+			} {
+				rewrite := rewrites[obj.GetID()]
+				require.Equalf(t, newSchema1ID, rewrite.ParentSchemaID,
+					"expected rewrite to have new parent schema, obj: %v, rewrite: %v", obj, rewrite,
+				)
+			}
+		})
+
+		t.Run("allocates functions into new db", func(t *testing.T) {
+			rewrites, err := allocateDescriptorRewrites(
+				ctx,
+				planner,
+				map[descpb.ID]*dbdesc.Mutable{
+					defaultDB.GetID(): defaultDB,
+				},
+				nil,
+				nil,
+				nil,
+				map[descpb.ID]*funcdesc.Mutable{
+					func1.GetID(): func1,
+					func2.GetID(): func2,
+				},
+				[]catalog.DatabaseDescriptor{defaultDB},
+				0,
+				tree.RestoreOptions{},
+				"",
+				"db3")
+
+			require.NoError(t, err)
+
+			require.NoError(t, validateSelfIDs(rewrites, []catalog.Descriptor{
+				defaultDB,
+				func1,
+				func2,
+			}))
+
+			newDBID := rewrites[defaultDB.GetID()].ID
+			require.Equal(t, newDBID, rewrites[func1.GetID()].ParentID)
+			require.Equal(t, newDBID, rewrites[func2.GetID()].ParentID)
+		})
+
+		t.Run("allocates multiple dbs", func(t *testing.T) {
+			_, err := db.ExecContext(ctx, "DROP DATABASE IF EXISTS defaultdb")
+			require.NoError(t, err)
+			_, err = db.ExecContext(ctx, "DROP DATABASE IF EXISTS db1")
+			require.NoError(t, err)
+			_, err = db.ExecContext(ctx, "DROP DATABASE IF EXISTS db2")
+			require.NoError(t, err)
+			defer setup()
+
+			// Get a new plan state after dropping the DB.
+			setupPlanner()
+
+			rewrites, err := allocateDescriptorRewrites(
+				ctx,
+				planner,
+				map[descpb.ID]*dbdesc.Mutable{
+					defaultDB.GetID(): defaultDB,
+					db1.GetID():       db1,
+					db2.GetID():       db2,
+				},
+				map[descpb.ID]*schemadesc.Mutable{
+					schema1.GetID(): schema1,
+					schema2.GetID(): schema2,
+				},
+				map[descpb.ID]*tabledesc.Mutable{
+					table1.GetID(): table1,
+					table2.GetID(): table2,
+				},
+				map[descpb.ID]*typedesc.Mutable{
+					type1.GetID():      type1,
+					type2.GetID():      type2,
+					type1array.GetID(): type1array,
+					type2array.GetID(): type2array,
+				},
+				map[descpb.ID]*funcdesc.Mutable{
+					func1.GetID(): func1,
+					func2.GetID(): func2,
+				},
+				[]catalog.DatabaseDescriptor{defaultDB, db1, db2},
+				0,
+				tree.RestoreOptions{},
+				"",
+				"")
+			require.NoError(t, err)
+
+			// DB objects are reallocated
+			require.NoError(t, validateSelfIDs(rewrites, []catalog.Descriptor{
+				defaultDB, db1, db2, schema1, schema2, table2, table2, type1, type2, type1array, type2array, func1, func2,
+			}))
+
+			oldDBIDs := []descpb.ID{defaultDB.GetID(), db1.GetID(), db2.GetID()}
+			newDefaultDBID := rewrites[defaultDB.GetID()].ID
+			for oldID, rewrite := range rewrites {
+				if slices.Contains(oldDBIDs, oldID) {
+					// This is a DB rewrite and has no parent.
+					require.Equal(t, descpb.InvalidID, rewrite.ParentID)
+					continue
+				}
+				// This is an object rewrite and its parent is defaultDB.
+				require.Equal(t, newDefaultDBID, rewrite.ParentID,
+					"expected rewrite to have new defaultDB ID as parentID: %v", rewrite)
+			}
+			// New schema objects have no parent schema
+			for _, obj := range []catalog.Descriptor{
+				schema1, schema2,
+			} {
+				rewrite := rewrites[obj.GetID()]
+				require.Equalf(t, descpb.InvalidID, rewrite.ParentSchemaID,
+					"expected rewrite to have no parent schema, descriptor: %v, rewrite: %v", obj, rewrite)
+			}
+			// New non-schema objects point to the new ID of the new schema
+			newSchema1ID := rewrites[schema1.GetID()].ID
+			for _, obj := range []catalog.Descriptor{
+				table2, table2, type1, type2, type1array, type2array, func1, func2,
+			} {
+				rewrite := rewrites[obj.GetID()]
+				require.Equalf(t, newSchema1ID, rewrite.ParentSchemaID,
+					"expected rewrite to have new parent schema, descriptor: %v, rewrite: %v", obj, rewrite,
+				)
+			}
+		})
+	})
 }


### PR DESCRIPTION
backupccl: Refactor allocateDescriptorRewrites in restore_planning.go, for easier reasoning and more comprehensive unit-testability.

Most of this code ought to be a no-op from the user perspective. There are, however, two changes:
1. Allocation of new DB IDs has been moved later, to make the algorithm clearer. Previously they were assigned earlier in the process, in a for-loop that was a bit surprising.
2. Descriptor objects for databases are no longer updated with SetName() prior to allocation. These updates were not persisted to the database, and so not passed to the processor. That meant we had one method for tracking such an update during planning, and another during processing. Now we use the same method - NewDBName on a rewrite object - for both.

Note that this PR does not necessarily complete the unit-testing work here. Some of the new `remap*()` functions are themselves quite long, and can likely be broken up cogently; and all of them could use their own independent unit testing. Nonetheless this PR marks a good checkpoint.

Release note: None
Part of: https://cockroachlabs.atlassian.net/browse/CRDB-31024