### PR TITLE
sql: serialize under stress and unskip TestQueryCache

### DIFF
--- a/pkg/sql/plan_opt_test.go
+++ b/pkg/sql/plan_opt_test.go
@@ -113,13 +113,17 @@ func TestQueryCache(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	skip.WithIssue(t, 105174, "flaky test")
+	parallel := func(t *testing.T) {
+		if !skip.Stress() {
+			t.Parallel() // SAFE FOR TESTING
+		}
+	}
 
 	// Grouping the parallel subtests into a non-parallel subtest allows the defer
 	// call above to work as expected.
 	t.Run("group", func(t *testing.T) {
 		t.Run("simple", func(t *testing.T) {
-			t.Parallel() // SAFE FOR TESTING
+			parallel(t)
 			const numConns = 4
 			h := makeQueryCacheTestHelper(t, numConns)
 			defer h.Stop()
@@ -135,7 +139,7 @@ func TestQueryCache(t *testing.T) {
 		})
 
 		t.Run("simple-prepare", func(t *testing.T) {
-			t.Parallel() // SAFE FOR TESTING
+			parallel(t)
 			const numConns = 4
 			h := makeQueryCacheTestHelper(t, numConns)
 			defer h.Stop()
@@ -161,7 +165,7 @@ func TestQueryCache(t *testing.T) {
 		})
 
 		t.Run("simple-prepare-with-args", func(t *testing.T) {
-			t.Parallel() // SAFE FOR TESTING
+			parallel(t)
 			const numConns = 4
 			h := makeQueryCacheTestHelper(t, numConns)
 			defer h.Stop()
@@ -194,7 +198,7 @@ func TestQueryCache(t *testing.T) {
 		// Verify that using a relative timestamp literal interacts correctly with
 		// the query cache (#48717).
 		t.Run("relative-timestamp", func(t *testing.T) {
-			t.Parallel() // SAFE FOR TESTING
+			parallel(t)
 			h := makeQueryCacheTestHelper(t, 1 /* numConns */)
 			defer h.Stop()
 
@@ -208,7 +212,7 @@ func TestQueryCache(t *testing.T) {
 		})
 
 		t.Run("parallel", func(t *testing.T) {
-			t.Parallel() // SAFE FOR TESTING
+			parallel(t)
 			const numConns = 4
 			h := makeQueryCacheTestHelper(t, numConns)
 			defer h.Stop()
@@ -239,7 +243,7 @@ func TestQueryCache(t *testing.T) {
 		})
 
 		t.Run("parallel-prepare", func(t *testing.T) {
-			t.Parallel() // SAFE FOR TESTING
+			parallel(t)
 			const numConns = 4
 			h := makeQueryCacheTestHelper(t, numConns)
 			defer h.Stop()
@@ -282,7 +286,7 @@ SELECT cte.x, cte.y FROM cte LEFT JOIN cte as cte2 on cte.y = cte2.x`, j)
 
 		// Test connections running the same statement but under different databases.
 		t.Run("multidb", func(t *testing.T) {
-			t.Parallel() // SAFE FOR TESTING
+			parallel(t)
 			const numConns = 4
 			h := makeQueryCacheTestHelper(t, numConns)
 			defer h.Stop()
@@ -311,7 +315,7 @@ SELECT cte.x, cte.y FROM cte LEFT JOIN cte as cte2 on cte.y = cte2.x`, j)
 		})
 
 		t.Run("multidb-prepare", func(t *testing.T) {
-			t.Parallel() // SAFE FOR TESTING
+			parallel(t)
 			const numConns = 4
 			h := makeQueryCacheTestHelper(t, numConns)
 			defer h.Stop()
@@ -342,7 +346,7 @@ SELECT cte.x, cte.y FROM cte LEFT JOIN cte as cte2 on cte.y = cte2.x`, j)
 
 		// Test that a schema change triggers cache invalidation.
 		t.Run("schemachange", func(t *testing.T) {
-			t.Parallel() // SAFE FOR TESTING
+			parallel(t)
 			h := makeQueryCacheTestHelper(t, 2 /* numConns */)
 			defer h.Stop()
 			r0, r1 := h.runners[0], h.runners[1]
@@ -358,7 +362,7 @@ SELECT cte.x, cte.y FROM cte LEFT JOIN cte as cte2 on cte.y = cte2.x`, j)
 
 		// Test that creating new statistics triggers cache invalidation.
 		t.Run("statschange", func(t *testing.T) {
-			t.Parallel() // SAFE FOR TESTING
+			parallel(t)
 			h := makeQueryCacheTestHelper(t, 2 /* numConns */)
 			defer h.Stop()
 			r0, r1 := h.runners[0], h.runners[1]
@@ -383,7 +387,7 @@ SELECT cte.x, cte.y FROM cte LEFT JOIN cte as cte2 on cte.y = cte2.x`, j)
 
 		// Test that a schema change triggers cache invalidation.
 		t.Run("schemachange-prepare", func(t *testing.T) {
-			t.Parallel() // SAFE FOR TESTING
+			parallel(t)
 			h := makeQueryCacheTestHelper(t, 2 /* numConns */)
 			defer h.Stop()
 			r0, r1 := h.runners[0], h.runners[1]
@@ -398,7 +402,7 @@ SELECT cte.x, cte.y FROM cte LEFT JOIN cte as cte2 on cte.y = cte2.x`, j)
 		// Test a schema change where the other connections are running the query in
 		// parallel.
 		t.Run("schemachange-parallel", func(t *testing.T) {
-			t.Parallel() // SAFE FOR TESTING
+			parallel(t)
 			const numConns = 4
 
 			h := makeQueryCacheTestHelper(t, numConns)
@@ -480,7 +484,7 @@ SELECT cte.x, cte.y FROM cte LEFT JOIN cte as cte2 on cte.y = cte2.x`, j)
 		// Verify the case where a PREPARE encounters a query cache entry that was
 		// created by a direct execution (and hence has no PrepareMetadata).
 		t.Run("exec-and-prepare", func(t *testing.T) {
-			t.Parallel() // SAFE FOR TESTING
+			parallel(t)
 			h := makeQueryCacheTestHelper(t, 1 /* numConns */)
 			defer h.Stop()
 
@@ -503,7 +507,7 @@ SELECT cte.x, cte.y FROM cte LEFT JOIN cte as cte2 on cte.y = cte2.x`, j)
 
 		// Verify the case where we PREPARE the same statement with different hints.
 		t.Run("prepare-hints", func(t *testing.T) {
-			t.Parallel() // SAFE FOR TESTING
+			parallel(t)
 			h := makeQueryCacheTestHelper(t, 1 /* numConns */)
 			defer h.Stop()
 


### PR DESCRIPTION
This test would timeout under stress+race, this is because it exploits
t.Parallel to run 15 tests concurrently that each fire up a TestServer.
Fix the timeout by running the tests serially under stress.

Fixes: #105174
Epic: none
Release note: none
