### PR TITLE
release-23.1: metrics: assign histogram metric type on histogram construction

### DIFF
--- a/pkg/ts/catalog/metrics.go
+++ b/pkg/ts/catalog/metrics.go
@@ -104,6 +104,11 @@ var histogramMetricsNames = map[string]struct{}{
 	"kv.replica_read_batch_evaluate.latency":    {},
 	"kv.replica_write_batch_evaluate.latency":   {},
 	"leases.requests.latency":                   {},
+	"changefeed.nprocs_flush_nanos":             {},
+	"changefeed.nprocs_consume_event_nanos":     {},
+	"rebalancing.replicas.queriespersecond":     {},
+	"rebalancing.replicas.cpunanospersecond":    {},
+	"sql.pre_serve.mem.max":                     {},
 }
 
 func allInternalTSMetricsNames() []string {

--- a/pkg/util/metric/metric.go
+++ b/pkg/util/metric/metric.go
@@ -252,6 +252,7 @@ type HistogramOptions struct {
 }
 
 func NewHistogram(opt HistogramOptions) IHistogram {
+	opt.Metadata.MetricType = prometheusgo.MetricType_HISTOGRAM
 	if hdrEnabled && opt.Mode != HistogramModePrometheus {
 		if opt.Mode == HistogramModePreferHdrLatency {
 			return NewHdrLatency(opt.Metadata, opt.Duration)
@@ -481,6 +482,7 @@ func NewManualWindowHistogram(
 		panic(err.Error())
 	}
 
+	meta.MetricType = prometheusgo.MetricType_HISTOGRAM
 	h := &ManualWindowHistogram{
 		Metadata: meta,
 	}

--- a/pkg/util/schedulerlatency/histogram.go
+++ b/pkg/util/schedulerlatency/histogram.go
@@ -51,6 +51,7 @@ func newRuntimeHistogram(metadata metric.Metadata, buckets []float64) *runtimeHi
 	if buckets[0] == math.Inf(-1) {
 		buckets = buckets[1:]
 	}
+	metadata.MetricType = prometheusgo.MetricType_HISTOGRAM
 	h := &runtimeHistogram{
 		Metadata: metadata,
 		// Go runtime histograms as of go1.19 are always in seconds whereas


### PR DESCRIPTION
Backport 1/1 commits from #108597.

/cc @cockroachdb/release

---

This commit assigns prometheusgo.MetricType_HISTOGRAM to the
Metadata.MetricType on histogram construction.

Before this change, GetMetadata() was returning the
Metadata.MetricType zero value (prometheusgo.MetricType_COUNTER)
for all histograms that did not explicitly specify the
prometheusgo.MetricType_HISTOGRAM for Metadata.MetricType in
their Metadata definitions. This prevented checks on histogram
Metadata.MetricType from properly evaluating the metrics as
histograms.

Fixes https://github.com/cockroachdb/cockroach/issues/106448.
Fixes https://github.com/cockroachdb/cockroach/issues/107701.

Release note: None

Release justification: bug fix