### PR TITLE
ccl/sqlproxyccl: deflake TestDenylistUpdate

### DIFF
--- a/pkg/ccl/sqlproxyccl/proxy_handler_test.go
+++ b/pkg/ccl/sqlproxyccl/proxy_handler_test.go
@@ -1256,7 +1256,7 @@ func TestDenylistUpdate(t *testing.T) {
 		"Expected the connection to eventually fail",
 	)
 	require.Error(t, err)
-	require.Regexp(t, "closed|bad connection", err.Error())
+	require.Regexp(t, "(connection reset by peer|closed|bad connection)", err.Error())
 	require.Equal(t, int64(1), s.metrics.ExpiredClientConnCount.Count())
 }
 
@@ -2279,7 +2279,7 @@ func TestConnectionMigration(t *testing.T) {
 			t.Fatalf("require that pg_sleep query terminates")
 		case err = <-errCh:
 			require.Error(t, err)
-			require.Regexp(t, "(closed|bad connection)", err.Error())
+			require.Regexp(t, "(connection reset by peer|closed|bad connection)", err.Error())
 		}
 
 		require.EqualError(t, f.ctx.Err(), context.Canceled.Error())


### PR DESCRIPTION
Fixes https://github.com/cockroachdb/cockroach/issues/109216.

When the proxy closes the connection, it is possible that the next query
attempt may encounter a TCP reset error before the SQL driver realizes that
there is a problem, and starts delivering ErrBadConn. This commit deflakes
TestDenylistUpdate by also checking for such reset errors.

Release note: None

Epic: none

Release justification: SQL Proxy test only fix.