### PR TITLE
sql: refactor global privilege and legacy role option checking

### DIFF
--- a/pkg/sql/alter_role.go
+++ b/pkg/sql/alter_role.go
@@ -295,6 +295,7 @@ func (p *planner) AlterRoleSet(ctx context.Context, n *tree.AlterRoleSet) (planN
 		hasModify := false
 		hasSqlModify := false
 		hasCreateRole := false
+		// TODO(109258): Refactor this to use HasGlobalPrivilegeOrRoleOption.
 		// Check system privileges.
 		if ok, err := p.HasPrivilege(ctx, syntheticprivilege.GlobalPrivilegeObject, privilege.MODIFYCLUSTERSETTING, p.User()); err != nil {
 			return nil, err

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -36,7 +36,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgnotice"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
-	"github.com/cockroachdb/cockroach/pkg/sql/roleoption"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catconstants"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/semenumpb"
@@ -47,7 +46,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/stats"
 	"github.com/cockroachdb/cockroach/pkg/sql/storageparam"
 	"github.com/cockroachdb/cockroach/pkg/sql/storageparam/tablestorageparam"
-	"github.com/cockroachdb/cockroach/pkg/sql/syntheticprivilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
@@ -895,19 +893,13 @@ func (p *planner) setAuditMode(
 	}
 	if !hasAdmin {
 		// Check for system privilege first, otherwise fall back to role options.
-		hasModify, err := p.HasPrivilege(ctx, syntheticprivilege.GlobalPrivilegeObject, privilege.MODIFYCLUSTERSETTING, p.User())
+		hasModify, err := p.HasGlobalPrivilegeOrRoleOption(ctx, privilege.MODIFYCLUSTERSETTING)
 		if err != nil {
 			return false, err
 		}
 		if !hasModify {
-			hasModify, err = p.HasRoleOption(ctx, roleoption.MODIFYCLUSTERSETTING)
-			if err != nil {
-				return false, err
-			}
-			if !hasModify {
-				return false, pgerror.Newf(pgcode.InsufficientPrivilege,
-					"only users with admin or %s system privilege are allowed to change audit settings on a table ", privilege.MODIFYCLUSTERSETTING.String())
-			}
+			return false, pgerror.Newf(pgcode.InsufficientPrivilege,
+				"only users with admin or %s system privilege are allowed to change audit settings on a table ", privilege.MODIFYCLUSTERSETTING.String())
 		}
 	}
 

--- a/pkg/sql/authorization.go
+++ b/pkg/sql/authorization.go
@@ -124,6 +124,14 @@ type AuthorizationAccessor interface {
 	// the role options table. Example: CREATEROLE instead of NOCREATEROLE.
 	// NOLOGIN instead of LOGIN.
 	HasRoleOption(ctx context.Context, roleOption roleoption.Option) (bool, error)
+
+	// HasGlobalPrivilegeOrRoleOption returns a bool representing whether the current user
+	// has a global privilege or the corresponding legacy role option.
+	HasGlobalPrivilegeOrRoleOption(ctx context.Context, privilege privilege.Kind) (bool, error)
+
+	// CheckGlobalPrivilegeOrRoleOption checks if the current user has a global privilege
+	// or the corresponding legacy role option, and returns an error if the user does not.
+	CheckGlobalPrivilegeOrRoleOption(ctx context.Context, privilege privilege.Kind) error
 }
 
 var _ AuthorizationAccessor = &planner{}
@@ -804,6 +812,38 @@ func (p *planner) CheckRoleOption(ctx context.Context, roleOption roleoption.Opt
 	return nil
 }
 
+// HasGlobalPrivilegeOrRoleOption implements the AuthorizationAccessor interface.
+func (p *planner) HasGlobalPrivilegeOrRoleOption(
+	ctx context.Context, privilege privilege.Kind,
+) (bool, error) {
+	ok, err := p.HasPrivilege(ctx, syntheticprivilege.GlobalPrivilegeObject, privilege, p.User())
+	if err != nil {
+		return false, err
+	}
+	if ok {
+		return true, nil
+	}
+	if roleOption, ok := roleoption.ByName[privilege.String()]; ok {
+		return p.HasRoleOption(ctx, roleOption)
+	}
+	return false, nil
+}
+
+// CheckGlobalPrivilegeOrRoleOption implements the AuthorizationAccessor interface.
+func (p *planner) CheckGlobalPrivilegeOrRoleOption(
+	ctx context.Context, privilege privilege.Kind,
+) error {
+	ok, err := p.HasGlobalPrivilegeOrRoleOption(ctx, privilege)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return pgerror.Newf(pgcode.InsufficientPrivilege,
+			"user %s does not have %s privilege", p.User(), privilege)
+	}
+	return nil
+}
+
 // ConnAuditingClusterSettingName is the name of the cluster setting
 // for the cluster setting that enables pgwire-level connection audit
 // logs.
@@ -997,31 +1037,11 @@ func (p *planner) HasViewActivityOrViewActivityRedactedRole(ctx context.Context)
 }
 
 func (p *planner) HasViewActivityRedacted(ctx context.Context) (bool, error) {
-	if hasViewRedacted, err := p.HasPrivilege(ctx, syntheticprivilege.GlobalPrivilegeObject, privilege.VIEWACTIVITYREDACTED, p.User()); err != nil {
-		return false, err
-	} else if hasViewRedacted {
-		return true, nil
-	}
-	if hasViewRedacted, err := p.HasRoleOption(ctx, roleoption.VIEWACTIVITYREDACTED); err != nil {
-		return false, err
-	} else if hasViewRedacted {
-		return true, nil
-	}
-	return false, nil
+	return p.HasGlobalPrivilegeOrRoleOption(ctx, privilege.VIEWACTIVITYREDACTED)
 }
 
 func (p *planner) HasViewActivity(ctx context.Context) (bool, error) {
-	if hasView, err := p.HasPrivilege(ctx, syntheticprivilege.GlobalPrivilegeObject, privilege.VIEWACTIVITY, p.User()); err != nil {
-		return false, err
-	} else if hasView {
-		return true, nil
-	}
-	if hasView, err := p.HasRoleOption(ctx, roleoption.VIEWACTIVITY); err != nil {
-		return false, err
-	} else if hasView {
-		return true, nil
-	}
-	return false, nil
+	return p.HasGlobalPrivilegeOrRoleOption(ctx, privilege.VIEWACTIVITY)
 }
 
 func insufficientPrivilegeError(

--- a/pkg/sql/set_cluster_setting.go
+++ b/pkg/sql/set_cluster_setting.go
@@ -37,14 +37,12 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgnotice"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
-	"github.com/cockroachdb/cockroach/pkg/sql/roleoption"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessioninit"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
-	"github.com/cockroachdb/cockroach/pkg/sql/syntheticprivilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -69,62 +67,30 @@ type setClusterSettingNode struct {
 func checkPrivilegesForSetting(
 	ctx context.Context, p *planner, name settings.SettingName, action string,
 ) error {
-	// First check system privileges.
-	hasModify := false
-	hasSqlModify := false
-	hasView := false
-	if ok, err := p.HasPrivilege(ctx, syntheticprivilege.GlobalPrivilegeObject, privilege.MODIFYCLUSTERSETTING, p.User()); err != nil {
+	// If the user has modify privileges, then they can set or show any setting.
+	hasModify, err := p.HasGlobalPrivilegeOrRoleOption(ctx, privilege.MODIFYCLUSTERSETTING)
+	if err != nil {
 		return err
-	} else if ok {
-		hasModify = true
-		hasSqlModify = true
-		hasView = true
 	}
-	if !hasSqlModify {
-		if ok, err := p.HasPrivilege(ctx, syntheticprivilege.GlobalPrivilegeObject, privilege.MODIFYSQLCLUSTERSETTING, p.User()); err != nil {
-			return err
-		} else if ok {
-			hasSqlModify = true
-		}
-	}
-	if !hasView {
-		if ok, err := p.HasPrivilege(ctx, syntheticprivilege.GlobalPrivilegeObject, privilege.VIEWCLUSTERSETTING, p.User()); err != nil {
-			return err
-		} else if ok {
-			hasView = true
-		}
-	}
-
-	// Fallback to role option if the user doesn't have the privilege.
-	if !hasModify {
-		ok, err := p.HasRoleOption(ctx, roleoption.MODIFYCLUSTERSETTING)
-		if err != nil {
-			return err
-		}
-		hasModify = hasModify || ok
-		hasView = hasView || ok
-	}
-	if !hasView {
-		ok, err := p.HasRoleOption(ctx, roleoption.VIEWCLUSTERSETTING)
-		if err != nil {
-			return err
-		}
-		hasView = hasView || ok
-	}
-
-	isSqlSetting := strings.HasPrefix(string(name), "sql.defaults")
-	// If the user has modify they can do either action to any setting regardless of
-	// whether they have the other 2 settings.
 	if hasModify {
 		return nil
 	}
-	// If the user has sql modify they can do either action as long as its a sql.defaults
-	// setting.
-	if hasSqlModify && isSqlSetting {
-		return nil
+
+	// If the user only has sql modify privileges, then they can only set or show
+	// any sql.defaults setting.
+	isSqlSetting := strings.HasPrefix(string(name), "sql.defaults")
+	if isSqlSetting {
+		hasSqlModify, err := p.HasGlobalPrivilegeOrRoleOption(ctx, privilege.MODIFYSQLCLUSTERSETTING)
+		if err != nil {
+			return err
+		}
+		if hasSqlModify {
+			return nil
+		}
 	}
-	// From this point, the user does not have modify or has sql modify but it is not a
-	// sql.defaults setting so we can expect an error if the user wants to edit.
+
+	// If the user does not have modify or sql modify privileges, then they
+	// cannot set any settings.
 	if action == "set" {
 		if !isSqlSetting {
 			return pgerror.Newf(pgcode.InsufficientPrivilege,
@@ -136,18 +102,25 @@ func checkPrivilegesForSetting(
 			privilege.MODIFYCLUSTERSETTING, privilege.MODIFYSQLCLUSTERSETTING, action, name)
 	}
 
-	// From this point, if the user does not have view then we can expect an error.
-	if action == "show" && !hasView {
-		if !isSqlSetting {
-			return pgerror.Newf(pgcode.InsufficientPrivilege,
-				"only users with %s or %s privileges are allowed to %s cluster setting '%s'",
-				privilege.MODIFYCLUSTERSETTING, privilege.VIEWCLUSTERSETTING, action, name)
-		}
-		return pgerror.Newf(pgcode.InsufficientPrivilege,
-			"only users with %s, %s or %s privileges are allowed to %s cluster setting '%s'",
-			privilege.MODIFYCLUSTERSETTING, privilege.MODIFYSQLCLUSTERSETTING, privilege.VIEWCLUSTERSETTING, action, name)
+	// If the user has view privileges, then they can show any setting.
+	hasView, err := p.HasGlobalPrivilegeOrRoleOption(ctx, privilege.VIEWCLUSTERSETTING)
+	if err != nil {
+		return err
 	}
-	return nil
+	if action == "show" && hasView {
+		return nil
+	}
+
+	// If the user does not have modify, sql modify, or view privileges,
+	// then they cannot show any setting.
+	if !isSqlSetting {
+		return pgerror.Newf(pgcode.InsufficientPrivilege,
+			"only users with %s or %s privileges are allowed to %s cluster setting '%s'",
+			privilege.MODIFYCLUSTERSETTING, privilege.VIEWCLUSTERSETTING, action, name)
+	}
+	return pgerror.Newf(pgcode.InsufficientPrivilege,
+		"only users with %s, %s or %s privileges are allowed to %s cluster setting '%s'",
+		privilege.MODIFYCLUSTERSETTING, privilege.MODIFYSQLCLUSTERSETTING, privilege.VIEWCLUSTERSETTING, action, name)
 }
 
 // SetClusterSetting sets cluster settings.


### PR DESCRIPTION
This patch abstracts the logic for checking whether a user has a
global (system) privilege or the corresponding legacy role option
into a new function (`HasGlobalPrivilegeOrRoleOption`).

It also adds a wrapper function that returns an insufficient
privileges error when the user has neither the privilege nor
the legacy role option (`CheckGlobalPrivilegeOrRoleOption`).

Informs #103237

Release note: None