### PR TITLE
server: enable NetworkConnectivity endpoint for secondary tenants

### DIFF
--- a/pkg/kv/kvclient/kvtenant/connector.go
+++ b/pkg/kv/kvclient/kvtenant/connector.go
@@ -1013,6 +1013,16 @@ func (c *connector) Query(
 	return
 }
 
+func (c *connector) NetworkConnectivity(
+	ctx context.Context, req *serverpb.NetworkConnectivityRequest,
+) (resp *serverpb.NetworkConnectivityResponse, retErr error) {
+	retErr = c.withClient(ctx, func(ctx context.Context, client *client) (err error) {
+		resp, err = client.NetworkConnectivity(ctx, req)
+		return
+	})
+	return
+}
+
 // AddressResolver wraps a NodeDescStore interface in an adapter that allows it
 // be used as a nodedialer.AddressResolver. Addresses are resolved to a node's
 // address.

--- a/pkg/server/serverpb/status.go
+++ b/pkg/server/serverpb/status.go
@@ -82,6 +82,7 @@ type TenantStatusServer interface {
 	TenantRanges(context.Context, *TenantRangesRequest) (*TenantRangesResponse, error)
 	Regions(context.Context, *RegionsRequest) (*RegionsResponse, error)
 	HotRangesV2(context.Context, *HotRangesRequest) (*HotRangesResponseV2, error)
+	NetworkConnectivity(ctx context.Context, req *NetworkConnectivityRequest) (*NetworkConnectivityResponse, error)
 
 	// SpanStats is used to access MVCC stats from KV
 	SpanStats(context.Context, *roachpb.SpanStatsRequest) (*roachpb.SpanStatsResponse, error)

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -1967,6 +1967,19 @@ func (s *statusServer) NodeUI(
 	return &resp, nil
 }
 
+func (s *statusServer) NetworkConnectivity(
+	ctx context.Context, req *serverpb.NetworkConnectivityRequest,
+) (*serverpb.NetworkConnectivityResponse, error) {
+	ctx = s.AnnotateCtx(ctx)
+
+	err := s.privilegeChecker.RequireViewClusterMetadataPermission(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.sqlServer.tenantConnect.NetworkConnectivity(ctx, req)
+}
+
 // NetworkConnectivity collects information about connections statuses across all nodes.
 func (s *systemStatusServer) NetworkConnectivity(
 	ctx context.Context, req *serverpb.NetworkConnectivityRequest,


### PR DESCRIPTION
Before, NetworkConnectivity endpoint was available for system tenants only with suggestion that information about network latencies shouldn't be exposed for
secondary tenants. That's not true and secondary tenants with appropriate permissions can request such info. This change extends `statusServer` to enable `NetworkConnectivity` endpoint for secondary tenants.

Release note: None

Informs:  #110024

Epic: [CRDB-26687](https://cockroachlabs.atlassian.net/browse/CRDB-26687)