### PR TITLE
kvserver: start raft after gossip

### DIFF
--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -2096,11 +2096,6 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 		}
 	}
 
-	// Start Raft processing goroutines.
-	s.cfg.Transport.ListenIncomingRaftMessages(s.StoreID(), s)
-	s.cfg.Transport.ListenOutgoingMessage(s.StoreID(), s)
-	s.processRaft(ctx)
-
 	// Register a callback to unquiesce any ranges with replicas on a
 	// node transitioning from non-live to live.
 	if s.cfg.NodeLiveness != nil {
@@ -2172,6 +2167,11 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 			s.applyAllFromSpanConfigStore(ctx)
 		})
 	}
+
+	// Start Raft processing goroutines.
+	s.cfg.Transport.ListenIncomingRaftMessages(s.StoreID(), s)
+	s.cfg.Transport.ListenOutgoingMessage(s.StoreID(), s)
+	s.processRaft(ctx)
 
 	// Connect rangefeeds to closed timestamp updates.
 	s.startRangefeedUpdater(ctx)


### PR DESCRIPTION
This commit moves raft scheduler start after gossip initialization. Previously gossip was initialized only partially before raft is started, so raft could see uninitialized fields if it gets to them too quickly. This would cause nil dereference panics.

Fixes #109230
Epic: none
Release note (bug fix): fixed a nil dereference panic during node startup that could be caused by an incorrect initialization order.