### PR TITLE
release-22.2: ccl/sqlproxyccl: deflake TestDenylistUpdate

### DIFF
--- a/pkg/ccl/sqlproxyccl/proxy_handler_test.go
+++ b/pkg/ccl/sqlproxyccl/proxy_handler_test.go
@@ -824,7 +824,8 @@ func TestDenylistUpdate(t *testing.T) {
 		time.Second, 5*time.Millisecond,
 		"Expected the connection to eventually fail",
 	)
-	require.Regexp(t, "closed|bad connection", err.Error())
+	require.Error(t, err)
+	require.Regexp(t, "(connection reset by peer|closed|bad connection)", err.Error())
 	require.Equal(t, int64(1), s.metrics.ExpiredClientConnCount.Count())
 }
 
@@ -1828,7 +1829,7 @@ func TestConnectionMigration(t *testing.T) {
 			t.Fatalf("require that pg_sleep query terminates")
 		case err = <-errCh:
 			require.Error(t, err)
-			require.Regexp(t, "(closed|bad connection)", err.Error())
+			require.Regexp(t, "(connection reset by peer|closed|bad connection)", err.Error())
 		}
 
 		require.EqualError(t, f.ctx.Err(), context.Canceled.Error())


### PR DESCRIPTION
Backport 1/1 commits from #109643.

/cc @cockroachdb/release

---

Fixes https://github.com/cockroachdb/cockroach/issues/109216.

When the proxy closes the connection, it is possible that the next query
attempt may encounter a TCP reset error before the SQL driver realizes that
there is a problem, and starts delivering ErrBadConn. This commit deflakes
TestDenylistUpdate by also checking for such reset errors.

Release note: None

Epic: none

Release justification: SQL Proxy test only fix.
