### PR TITLE
release-23.1: kvserver: start raft after gossip

### DIFF
--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -2014,10 +2014,6 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 		}
 	}
 
-	// Start Raft processing goroutines.
-	s.cfg.Transport.Listen(s.StoreID(), s)
-	s.processRaft(ctx)
-
 	// Register a callback to unquiesce any ranges with replicas on a
 	// node transitioning from non-live to live.
 	if s.cfg.NodeLiveness != nil {
@@ -2089,6 +2085,10 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 			s.applyAllFromSpanConfigStore(ctx)
 		})
 	}
+
+	// Start Raft processing goroutines.
+	s.cfg.Transport.Listen(s.StoreID(), s)
+	s.processRaft(ctx)
 
 	if !s.cfg.TestingKnobs.DisableAutomaticLeaseRenewal {
 		s.startLeaseRenewer(ctx)


### PR DESCRIPTION
Backport 1/1 commits from #109659.

/cc @cockroachdb/release

---

This commit moves raft scheduler start after gossip initialization. Previously gossip was initialized only partially before raft is started, so raft could see uninitialized fields if it gets to them too quickly. This would cause nil dereference panics.

Fixes #109230
Epic: none
Release note (bug fix): fixed a nil dereference panic during node startup that could be caused by an incorrect initialization order.
Release justification: bug fix
