### PR TITLE
concurrency: support multiple lock strengths for replicated locks 

### DIFF
--- a/pkg/kv/kvserver/concurrency/lock_table.go
+++ b/pkg/kv/kvserver/concurrency/lock_table.go
@@ -1129,7 +1129,12 @@ func (rlh *replicatedLockHolderInfo) safeFormat(sb *redact.StringBuilder) {
 	if rlh.isEmpty() {
 		return
 	}
-	sb.SafeString("repl")
+	sb.SafeString("repl [")
+	sb.Printf(
+		"%s",
+		redact.Safe(lock.Intent),
+	)
+	sb.SafeString("]")
 }
 
 // Per-key locks state in lockTableImpl.

--- a/pkg/kv/kvserver/concurrency/lock_table.go
+++ b/pkg/kv/kvserver/concurrency/lock_table.go
@@ -1107,10 +1107,39 @@ func (ulh *unreplicatedLockHolderInfo) safeFormat(sb *redact.StringBuilder) {
 	sb.SafeString("]")
 }
 
-// Information about a lock holder for replicated locks. Notably, unlike
-// unreplicated locks, this does not include any sequence numbers.
+// Fixed length slice for all supported lock strengths for replicated locks. May
+// be used to iterate supported lock strengths in strength order (strongest to
+// weakest).
+var replicatedHolderStrengths = [...]lock.Strength{lock.Intent, lock.Exclusive, lock.Shared}
+
+// replicatedLockHolderStrengthToIndexMap returns a mapping between (strength,
+// index) pairs that can be used to index into the
+// replicatedLockHolderInfo.strengths array.
+//
+// Trying to use a lock strength that isn't supported with replicated locks to
+// index into the replicatedLockHolderInfo.strengths array will cause a runtime
+// error.
+var replicatedLockHolderStrengthToIndexMap = func() [lock.MaxStrength + 1]int {
+	var m [lock.MaxStrength + 1]int
+	// Initialize all to -1.
+	for str := range m {
+		m[str] = -1
+	}
+	// Set the indices of the valid strengths.
+	for i, str := range replicatedHolderStrengths {
+		m[str] = i
+	}
+	return m
+}()
+
+// Information about a lock holder for replicated locks.
 type replicatedLockHolderInfo struct {
-	// Lock strength is always lock.Intent.
+	// strengths tracks whether the lock is held with a particular strength or not.
+	// Notably, unlike unreplicated locks, we do not track the sequence number at
+	// which a lock was acquired with a particular strength. This way, we don't
+	// need to worry about keeping what's in the replicated lock table keyspace in
+	// sync with the in-memory lock table.
+	strengths [len(replicatedHolderStrengths)]bool
 
 	// The timestamp at which the replicated lock is held. Must not regress.
 	ts hlc.Timestamp
@@ -1118,11 +1147,35 @@ type replicatedLockHolderInfo struct {
 
 // clear removes previously tracked replicated lock holder information.
 func (rlh *replicatedLockHolderInfo) clear() {
+	rlh.resetStrengths()
 	rlh.ts = hlc.Timestamp{}
 }
 
 func (rlh *replicatedLockHolderInfo) isEmpty() bool {
-	return rlh.ts.IsEmpty()
+	for _, str := range replicatedHolderStrengths {
+		if rlh.held(str) { // lock is held
+			return false
+		}
+	}
+	assert(rlh.ts.IsEmpty(), "lock not held, timestamp should be empty")
+	return true
+}
+
+func (rlh *replicatedLockHolderInfo) resetStrengths() {
+	for strIdx := range rlh.strengths {
+		rlh.strengths[strIdx] = false
+	}
+}
+
+// acquire updates the tracking on the receiver to indicate a lock is held with
+// the supplied lock strength.
+func (rlh *replicatedLockHolderInfo) acquire(str lock.Strength) {
+	rlh.strengths[replicatedLockHolderStrengthToIndexMap[str]] = true
+}
+
+// held returns true if the receiver is held with the supplied lock strength.
+func (rlh *replicatedLockHolderInfo) held(str lock.Strength) bool {
+	return rlh.strengths[replicatedLockHolderStrengthToIndexMap[str]]
 }
 
 func (rlh *replicatedLockHolderInfo) safeFormat(sb *redact.StringBuilder) {
@@ -1130,10 +1183,20 @@ func (rlh *replicatedLockHolderInfo) safeFormat(sb *redact.StringBuilder) {
 		return
 	}
 	sb.SafeString("repl [")
-	sb.Printf(
-		"%s",
-		redact.Safe(lock.Intent),
-	)
+	first := true
+	for _, str := range replicatedHolderStrengths {
+		if !rlh.held(str) {
+			continue
+		}
+		if !first {
+			sb.Printf(", ")
+		}
+		first = false
+		sb.Printf(
+			"%s",
+			redact.Safe(str),
+		)
+	}
 	sb.SafeString("]")
 }
 
@@ -1409,6 +1472,7 @@ func (tl *txnLock) reacquireLock(acq *roachpb.LockAcquisition) error {
 		}
 	case lock.Replicated:
 		tl.replicatedInfo.ts.Forward(acq.Txn.WriteTimestamp)
+		tl.replicatedInfo.acquire(acq.Strength)
 	default:
 		panic(fmt.Sprintf("unknown lock durability: %s", acq.Durability))
 	}
@@ -2799,6 +2863,7 @@ func (kl *keyLocks) acquireLock(acq *roachpb.LockAcquisition, clock *hlc.Clock) 
 		}
 	case lock.Replicated:
 		tl.replicatedInfo.ts = acq.Txn.WriteTimestamp
+		tl.replicatedInfo.acquire(acq.Strength)
 	default:
 		panic(fmt.Sprintf("unknown lock durability: %s", acq.Durability))
 	}
@@ -2809,12 +2874,12 @@ func (kl *keyLocks) acquireLock(acq *roachpb.LockAcquisition, clock *hlc.Clock) 
 	return nil
 }
 
-// A replicated lock held by txn with timestamp ts was discovered by guard g
-// where g is trying to access this key with strength accessStrength.
-// Acquires l.mu.
+// discoveredLock is called with a lock that is discovered by guard g when trying
+// to access this key with strength accessStrength.
+//
+// Acquires kl.mu.
 func (kl *keyLocks) discoveredLock(
-	txn *enginepb.TxnMeta,
-	ts hlc.Timestamp,
+	foundLock *roachpb.Lock,
 	g *lockTableGuardImpl,
 	accessStrength lock.Strength,
 	notRemovable bool,
@@ -2829,22 +2894,23 @@ func (kl *keyLocks) discoveredLock(
 
 	var tl *txnLock
 	if kl.isLocked() {
-		e, found := kl.heldBy[txn.ID]
+		e, found := kl.heldBy[foundLock.Txn.ID]
 		tl = e.Value
 		if !found {
 			return errors.AssertionFailedf(
 				"discovered lock by different transaction (%s) than existing lock (see issue #63592): %s",
-				txn, kl)
+				foundLock.Txn, kl)
 		}
 		// TODO(arul): If the discovered lock indicates a newer epoch than what's
 		// being tracked, should we clear out unreplicatedLockInfo here?
 	} else {
-		tl = newTxnLock(txn, clock)
+		tl = newTxnLock(&foundLock.Txn, clock)
 		kl.lockAcquiredOrDiscovered(tl)
 	}
 
 	if tl.replicatedInfo.isEmpty() {
-		tl.replicatedInfo.ts = ts
+		tl.replicatedInfo.acquire(foundLock.Strength)
+		tl.replicatedInfo.ts = foundLock.Txn.WriteTimestamp
 	}
 
 	switch accessStrength {
@@ -2856,7 +2922,7 @@ func (kl *keyLocks) discoveredLock(
 		// the lock table. If not then it shouldn't have discovered the lock in
 		// the first place. Bugs here would cause infinite loops where the same
 		// lock is repeatedly re-discovered.
-		if g.ts.Less(ts) {
+		if foundLock.Strength != lock.Intent || g.ts.Less(foundLock.Txn.WriteTimestamp) {
 			return errors.AssertionFailedf("discovered non-conflicting lock")
 		}
 
@@ -2897,7 +2963,7 @@ func (kl *keyLocks) discoveredLock(
 	}
 
 	// If there are waiting requests from the same txn, they no longer need to wait.
-	kl.releaseLockingRequestsFromTxn(txn)
+	kl.releaseLockingRequestsFromTxn(&foundLock.Txn)
 
 	// Active waiters need to be told about who they are waiting for.
 	kl.informActiveWaiters()
@@ -3630,7 +3696,7 @@ func (t *lockTableImpl) AddDiscoveredLock(
 		g.notRemovableLock = l
 		notRemovableLock = true
 	}
-	err = l.discoveredLock(&foundLock.Txn, foundLock.Txn.WriteTimestamp, g, str, notRemovableLock, g.lt.clock)
+	err = l.discoveredLock(foundLock, g, str, notRemovableLock, g.lt.clock)
 	// Can't release tree.mu until call l.discoveredLock() since someone may
 	// find an empty lock and remove it from the tree.
 	t.locks.mu.Unlock()

--- a/pkg/kv/kvserver/concurrency/lock_table_test.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_test.go
@@ -1888,10 +1888,10 @@ func TestLockStateSafeFormat(t *testing.T) {
 	require.NoError(t, holder.unreplicatedInfo.acquire(lock.Shared, 3))
 	holder.replicatedInfo.ts = hlc.Timestamp{WallTime: 125, Logical: 1}
 	require.EqualValues(t,
-		" lock: ‹\"KEY\"›\n  holder: txn: 6ba7b810-9dad-11d1-80b4-00c04fd430c8 epoch: 0, iso: Serializable, ts: 0.000000123,7, info: repl, unrepl [(str: Exclusive seq: 1), (str: Shared seq: 3)]\n",
+		" lock: ‹\"KEY\"›\n  holder: txn: 6ba7b810-9dad-11d1-80b4-00c04fd430c8 epoch: 0, iso: Serializable, ts: 0.000000123,7, info: repl [Intent], unrepl [(str: Exclusive seq: 1), (str: Shared seq: 3)]\n",
 		redact.Sprint(l))
 	require.EqualValues(t,
-		" lock: ‹×›\n  holder: txn: 6ba7b810-9dad-11d1-80b4-00c04fd430c8 epoch: 0, iso: Serializable, ts: 0.000000123,7, info: repl, unrepl [(str: Exclusive seq: 1), (str: Shared seq: 3)]\n",
+		" lock: ‹×›\n  holder: txn: 6ba7b810-9dad-11d1-80b4-00c04fd430c8 epoch: 0, iso: Serializable, ts: 0.000000123,7, info: repl [Intent], unrepl [(str: Exclusive seq: 1), (str: Shared seq: 3)]\n",
 		redact.Sprint(l).Redact())
 }
 

--- a/pkg/kv/kvserver/concurrency/lock_table_test.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_test.go
@@ -1887,11 +1887,13 @@ func TestLockStateSafeFormat(t *testing.T) {
 	require.NoError(t, holder.unreplicatedInfo.acquire(lock.Exclusive, 1))
 	require.NoError(t, holder.unreplicatedInfo.acquire(lock.Shared, 3))
 	holder.replicatedInfo.ts = hlc.Timestamp{WallTime: 125, Logical: 1}
+	holder.replicatedInfo.acquire(lock.Intent)
+	holder.replicatedInfo.acquire(lock.Shared)
 	require.EqualValues(t,
-		" lock: ‹\"KEY\"›\n  holder: txn: 6ba7b810-9dad-11d1-80b4-00c04fd430c8 epoch: 0, iso: Serializable, ts: 0.000000123,7, info: repl [Intent], unrepl [(str: Exclusive seq: 1), (str: Shared seq: 3)]\n",
+		" lock: ‹\"KEY\"›\n  holder: txn: 6ba7b810-9dad-11d1-80b4-00c04fd430c8 epoch: 0, iso: Serializable, ts: 0.000000123,7, info: repl [Intent, Shared], unrepl [(str: Exclusive seq: 1), (str: Shared seq: 3)]\n",
 		redact.Sprint(l))
 	require.EqualValues(t,
-		" lock: ‹×›\n  holder: txn: 6ba7b810-9dad-11d1-80b4-00c04fd430c8 epoch: 0, iso: Serializable, ts: 0.000000123,7, info: repl [Intent], unrepl [(str: Exclusive seq: 1), (str: Shared seq: 3)]\n",
+		" lock: ‹×›\n  holder: txn: 6ba7b810-9dad-11d1-80b4-00c04fd430c8 epoch: 0, iso: Serializable, ts: 0.000000123,7, info: repl [Intent, Shared], unrepl [(str: Exclusive seq: 1), (str: Shared seq: 3)]\n",
 		redact.Sprint(l).Redact())
 }
 

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/clear_abandoned_intents
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/clear_abandoned_intents
@@ -37,25 +37,25 @@ debug-lock-table
 ----
 num=10
  lock: "a"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
  lock: "b"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
  lock: "c"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
  lock: "d"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
  lock: "e"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
  lock: "f"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
  lock: "g"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
  lock: "h"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
  lock: "i"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
  lock: "j"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
 
 sequence req=req1
 ----
@@ -72,28 +72,28 @@ debug-lock-table
 ----
 num=10
  lock: "a"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
    waiting readers:
     req: 1, txn: 00000001-0000-0000-0000-000000000000
    distinguished req: 1
  lock: "b"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
  lock: "c"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
  lock: "d"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
  lock: "e"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
  lock: "f"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
  lock: "g"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
  lock: "h"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
  lock: "i"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
  lock: "j"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
 
 debug-advance-clock ts=123
 ----
@@ -164,7 +164,7 @@ debug-lock-table
 ----
 num=1
  lock: "a"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
    queued locking requests:
     active: false req: 2, strength: Intent, txn: 00000001-0000-0000-0000-000000000000
 
@@ -204,7 +204,7 @@ num=2
    queued locking requests:
     active: false req: 2, strength: Intent, txn: 00000001-0000-0000-0000-000000000000
  lock: "b"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [holder finalized: committed]
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent] [holder finalized: committed]
    queued locking requests:
     active: false req: 2, strength: Intent, txn: 00000001-0000-0000-0000-000000000000
 
@@ -236,7 +236,7 @@ num=3
    queued locking requests:
     active: false req: 2, strength: Intent, txn: 00000001-0000-0000-0000-000000000000
  lock: "c"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [holder finalized: committed]
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent] [holder finalized: committed]
    queued locking requests:
     active: false req: 2, strength: Intent, txn: 00000001-0000-0000-0000-000000000000
 
@@ -306,9 +306,9 @@ debug-lock-table
 ----
 num=2
  lock: "a"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
  lock: "b"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
 
 new-request name=req2 txn=txn2 ts=10,1
   put key=g value=v1
@@ -338,9 +338,9 @@ debug-lock-table
 ----
 num=4
  lock: "a"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
  lock: "b"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
  lock: "g"
   holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
  lock: "h"
@@ -361,12 +361,12 @@ debug-lock-table
 ----
 num=4
  lock: "a"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
    waiting readers:
     req: 3, txn: 00000001-0000-0000-0000-000000000000
    distinguished req: 3
  lock: "b"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
  lock: "g"
   holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
  lock: "h"
@@ -449,15 +449,15 @@ debug-lock-table
 ----
 num=3
  lock: "c"
-  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
    queued locking requests:
     active: false req: 5, strength: Intent, txn: 00000001-0000-0000-0000-000000000000
  lock: "d"
-  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
    queued locking requests:
     active: false req: 5, strength: Intent, txn: 00000001-0000-0000-0000-000000000000
  lock: "e"
-  holder: txn: 00000005-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000005-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
    queued locking requests:
     active: false req: 5, strength: Intent, txn: 00000001-0000-0000-0000-000000000000
 
@@ -476,16 +476,16 @@ debug-lock-table
 ----
 num=3
  lock: "c"
-  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
    queued locking requests:
     active: true req: 5, strength: Intent, txn: 00000001-0000-0000-0000-000000000000
    distinguished req: 5
  lock: "d"
-  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
    queued locking requests:
     active: false req: 5, strength: Intent, txn: 00000001-0000-0000-0000-000000000000
  lock: "e"
-  holder: txn: 00000005-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000005-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
    queued locking requests:
     active: false req: 5, strength: Intent, txn: 00000001-0000-0000-0000-000000000000
 
@@ -535,16 +535,16 @@ num=5
  lock: "b"
   holder: txn: 00000004-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
  lock: "c"
-  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
    queued locking requests:
     active: true req: 5, strength: Intent, txn: 00000001-0000-0000-0000-000000000000
    distinguished req: 5
  lock: "d"
-  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
    queued locking requests:
     active: false req: 5, strength: Intent, txn: 00000001-0000-0000-0000-000000000000
  lock: "e"
-  holder: txn: 00000005-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000005-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
    queued locking requests:
     active: false req: 5, strength: Intent, txn: 00000001-0000-0000-0000-000000000000
 
@@ -575,16 +575,16 @@ num=5
  lock: "b"
   holder: txn: 00000004-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
  lock: "c"
-  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
    queued locking requests:
     active: true req: 5, strength: Intent, txn: 00000001-0000-0000-0000-000000000000
    distinguished req: 5
  lock: "d"
-  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
    queued locking requests:
     active: false req: 5, strength: Intent, txn: 00000001-0000-0000-0000-000000000000
  lock: "e"
-  holder: txn: 00000005-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000005-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
    queued locking requests:
     active: false req: 5, strength: Intent, txn: 00000001-0000-0000-0000-000000000000
 
@@ -621,11 +621,11 @@ num=4
    queued locking requests:
     active: false req: 5, strength: Intent, txn: 00000001-0000-0000-0000-000000000000
  lock: "d"
-  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [holder finalized: aborted]
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent] [holder finalized: aborted]
    queued locking requests:
     active: false req: 5, strength: Intent, txn: 00000001-0000-0000-0000-000000000000
  lock: "e"
-  holder: txn: 00000005-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000005-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
    queued locking requests:
     active: true req: 5, strength: Intent, txn: 00000001-0000-0000-0000-000000000000
    distinguished req: 5
@@ -657,7 +657,7 @@ num=3
    queued locking requests:
     active: false req: 5, strength: Intent, txn: 00000001-0000-0000-0000-000000000000
  lock: "e"
-  holder: txn: 00000005-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000005-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
    queued locking requests:
     active: true req: 5, strength: Intent, txn: 00000001-0000-0000-0000-000000000000
    distinguished req: 5

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/clear_abandoned_intents_wait_policy_error
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/clear_abandoned_intents_wait_policy_error
@@ -41,25 +41,25 @@ debug-lock-table
 ----
 num=10
  lock: "a"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
  lock: "b"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
  lock: "c"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
  lock: "d"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
  lock: "e"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
  lock: "f"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
  lock: "g"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
  lock: "h"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
  lock: "i"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
  lock: "j"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
 
 # ------------------------------------------------------------------------------
 # txn1 is the distinguished waiter on key "a". It will push txn2, notice that it

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/clear_abandoned_intents_without_adding_to_lock_table
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/clear_abandoned_intents_without_adding_to_lock_table
@@ -34,7 +34,7 @@ debug-lock-table
 ----
 num=1
  lock: "a"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
 
 sequence req=req1
 ----
@@ -51,7 +51,7 @@ debug-lock-table
 ----
 num=1
  lock: "a"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
    waiting readers:
     req: 1, txn: 00000001-0000-0000-0000-000000000000
    distinguished req: 1

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/discover_lock_after_lease_race
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/discover_lock_after_lease_race
@@ -138,7 +138,7 @@ debug-lock-table
 ----
 num=1
  lock: "k"
-  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Intent]
 
 sequence req=req4
 ----
@@ -161,7 +161,7 @@ debug-lock-table
 ----
 num=1
  lock: "k"
-  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Intent]
    waiting readers:
     req: 3, txn: 00000004-0000-0000-0000-000000000000
    distinguished req: 3

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/discovered_lock
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/discovered_lock
@@ -29,7 +29,7 @@ debug-lock-table
 ----
 num=1
  lock: "k"
-  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
 
 sequence req=req1
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/isolation_level
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/isolation_level
@@ -219,37 +219,37 @@ debug-lock-table
 ----
 num=16
  lock: "kRCHigh1"
-  holder: txn: 00000004-0000-0000-0000-000000000000 epoch: 0, iso: ReadCommitted, ts: 10.000000000,1, info: repl
+  holder: txn: 00000004-0000-0000-0000-000000000000 epoch: 0, iso: ReadCommitted, ts: 10.000000000,1, info: repl [Intent]
  lock: "kRCHigh2"
-  holder: txn: 00000004-0000-0000-0000-000000000000 epoch: 0, iso: ReadCommitted, ts: 10.000000000,1, info: repl
+  holder: txn: 00000004-0000-0000-0000-000000000000 epoch: 0, iso: ReadCommitted, ts: 10.000000000,1, info: repl [Intent]
  lock: "kRCHigh3"
-  holder: txn: 00000004-0000-0000-0000-000000000000 epoch: 0, iso: ReadCommitted, ts: 10.000000000,1, info: repl
+  holder: txn: 00000004-0000-0000-0000-000000000000 epoch: 0, iso: ReadCommitted, ts: 10.000000000,1, info: repl [Intent]
  lock: "kRCHigh4"
-  holder: txn: 00000004-0000-0000-0000-000000000000 epoch: 0, iso: ReadCommitted, ts: 10.000000000,1, info: repl
+  holder: txn: 00000004-0000-0000-0000-000000000000 epoch: 0, iso: ReadCommitted, ts: 10.000000000,1, info: repl [Intent]
  lock: "kRCNormal1"
-  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, iso: ReadCommitted, ts: 10.000000000,1, info: repl
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, iso: ReadCommitted, ts: 10.000000000,1, info: repl [Intent]
  lock: "kRCNormal2"
-  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, iso: ReadCommitted, ts: 10.000000000,1, info: repl
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, iso: ReadCommitted, ts: 10.000000000,1, info: repl [Intent]
  lock: "kRCNormal3"
-  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, iso: ReadCommitted, ts: 10.000000000,1, info: repl
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, iso: ReadCommitted, ts: 10.000000000,1, info: repl [Intent]
  lock: "kRCNormal4"
-  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, iso: ReadCommitted, ts: 10.000000000,1, info: repl
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, iso: ReadCommitted, ts: 10.000000000,1, info: repl [Intent]
  lock: "kSSIHigh1"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
  lock: "kSSIHigh2"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
  lock: "kSSIHigh3"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
  lock: "kSSIHigh4"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
  lock: "kSSINormal1"
-  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
  lock: "kSSINormal2"
-  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
  lock: "kSSINormal3"
-  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
  lock: "kSSINormal4"
-  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
 
 # -------------------------------------------------------------
 # Pushee: isolation=serializable, priority=normal
@@ -390,29 +390,29 @@ debug-lock-table
 ----
 num=12
  lock: "kRCHigh1"
-  holder: txn: 00000004-0000-0000-0000-000000000000 epoch: 0, iso: ReadCommitted, ts: 10.000000000,1, info: repl
+  holder: txn: 00000004-0000-0000-0000-000000000000 epoch: 0, iso: ReadCommitted, ts: 10.000000000,1, info: repl [Intent]
  lock: "kRCHigh2"
-  holder: txn: 00000004-0000-0000-0000-000000000000 epoch: 0, iso: ReadCommitted, ts: 10.000000000,1, info: repl
+  holder: txn: 00000004-0000-0000-0000-000000000000 epoch: 0, iso: ReadCommitted, ts: 10.000000000,1, info: repl [Intent]
  lock: "kRCHigh3"
-  holder: txn: 00000004-0000-0000-0000-000000000000 epoch: 0, iso: ReadCommitted, ts: 10.000000000,1, info: repl
+  holder: txn: 00000004-0000-0000-0000-000000000000 epoch: 0, iso: ReadCommitted, ts: 10.000000000,1, info: repl [Intent]
  lock: "kRCHigh4"
-  holder: txn: 00000004-0000-0000-0000-000000000000 epoch: 0, iso: ReadCommitted, ts: 10.000000000,1, info: repl
+  holder: txn: 00000004-0000-0000-0000-000000000000 epoch: 0, iso: ReadCommitted, ts: 10.000000000,1, info: repl [Intent]
  lock: "kRCNormal1"
-  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, iso: ReadCommitted, ts: 10.000000000,1, info: repl
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, iso: ReadCommitted, ts: 10.000000000,1, info: repl [Intent]
  lock: "kRCNormal2"
-  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, iso: ReadCommitted, ts: 10.000000000,1, info: repl
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, iso: ReadCommitted, ts: 10.000000000,1, info: repl [Intent]
  lock: "kRCNormal3"
-  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, iso: ReadCommitted, ts: 10.000000000,1, info: repl
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, iso: ReadCommitted, ts: 10.000000000,1, info: repl [Intent]
  lock: "kRCNormal4"
-  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, iso: ReadCommitted, ts: 10.000000000,1, info: repl
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, iso: ReadCommitted, ts: 10.000000000,1, info: repl [Intent]
  lock: "kSSIHigh1"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
  lock: "kSSIHigh2"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
  lock: "kSSIHigh3"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
  lock: "kSSIHigh4"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
 
 # -------------------------------------------------------------
 # Pushee: isolation=serializable, priority=high
@@ -551,21 +551,21 @@ debug-lock-table
 ----
 num=8
  lock: "kRCHigh1"
-  holder: txn: 00000004-0000-0000-0000-000000000000 epoch: 0, iso: ReadCommitted, ts: 10.000000000,1, info: repl
+  holder: txn: 00000004-0000-0000-0000-000000000000 epoch: 0, iso: ReadCommitted, ts: 10.000000000,1, info: repl [Intent]
  lock: "kRCHigh2"
-  holder: txn: 00000004-0000-0000-0000-000000000000 epoch: 0, iso: ReadCommitted, ts: 10.000000000,1, info: repl
+  holder: txn: 00000004-0000-0000-0000-000000000000 epoch: 0, iso: ReadCommitted, ts: 10.000000000,1, info: repl [Intent]
  lock: "kRCHigh3"
-  holder: txn: 00000004-0000-0000-0000-000000000000 epoch: 0, iso: ReadCommitted, ts: 10.000000000,1, info: repl
+  holder: txn: 00000004-0000-0000-0000-000000000000 epoch: 0, iso: ReadCommitted, ts: 10.000000000,1, info: repl [Intent]
  lock: "kRCHigh4"
-  holder: txn: 00000004-0000-0000-0000-000000000000 epoch: 0, iso: ReadCommitted, ts: 10.000000000,1, info: repl
+  holder: txn: 00000004-0000-0000-0000-000000000000 epoch: 0, iso: ReadCommitted, ts: 10.000000000,1, info: repl [Intent]
  lock: "kRCNormal1"
-  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, iso: ReadCommitted, ts: 10.000000000,1, info: repl
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, iso: ReadCommitted, ts: 10.000000000,1, info: repl [Intent]
  lock: "kRCNormal2"
-  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, iso: ReadCommitted, ts: 10.000000000,1, info: repl
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, iso: ReadCommitted, ts: 10.000000000,1, info: repl [Intent]
  lock: "kRCNormal3"
-  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, iso: ReadCommitted, ts: 10.000000000,1, info: repl
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, iso: ReadCommitted, ts: 10.000000000,1, info: repl [Intent]
  lock: "kRCNormal4"
-  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, iso: ReadCommitted, ts: 10.000000000,1, info: repl
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, iso: ReadCommitted, ts: 10.000000000,1, info: repl [Intent]
 
 # -------------------------------------------------------------
 # Pushee: isolation=read-committed, priority=normal
@@ -699,13 +699,13 @@ debug-lock-table
 ----
 num=4
  lock: "kRCHigh1"
-  holder: txn: 00000004-0000-0000-0000-000000000000 epoch: 0, iso: ReadCommitted, ts: 10.000000000,1, info: repl
+  holder: txn: 00000004-0000-0000-0000-000000000000 epoch: 0, iso: ReadCommitted, ts: 10.000000000,1, info: repl [Intent]
  lock: "kRCHigh2"
-  holder: txn: 00000004-0000-0000-0000-000000000000 epoch: 0, iso: ReadCommitted, ts: 10.000000000,1, info: repl
+  holder: txn: 00000004-0000-0000-0000-000000000000 epoch: 0, iso: ReadCommitted, ts: 10.000000000,1, info: repl [Intent]
  lock: "kRCHigh3"
-  holder: txn: 00000004-0000-0000-0000-000000000000 epoch: 0, iso: ReadCommitted, ts: 10.000000000,1, info: repl
+  holder: txn: 00000004-0000-0000-0000-000000000000 epoch: 0, iso: ReadCommitted, ts: 10.000000000,1, info: repl [Intent]
  lock: "kRCHigh4"
-  holder: txn: 00000004-0000-0000-0000-000000000000 epoch: 0, iso: ReadCommitted, ts: 10.000000000,1, info: repl
+  holder: txn: 00000004-0000-0000-0000-000000000000 epoch: 0, iso: ReadCommitted, ts: 10.000000000,1, info: repl [Intent]
 
 # -------------------------------------------------------------
 # Pushee: isolation=read-committed, priority=high

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/lock_timeout
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/lock_timeout
@@ -217,7 +217,7 @@ num=3
     active: true req: 3, strength: Intent, txn: 00000003-0000-0000-0000-000000000000
    distinguished req: 3
  lock: "k4"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [Intent]
 
 # -------------------------------------------------------------
 # Read-only request with lock timeout discovers abandoned
@@ -275,7 +275,7 @@ debug-lock-table
 ----
 num=1
  lock: "k4"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [holder finalized: aborted]
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [Intent] [holder finalized: aborted]
 
 reset
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/lock_timeout_v23_1
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/lock_timeout_v23_1
@@ -217,7 +217,7 @@ num=3
     active: true req: 3, strength: Intent, txn: 00000003-0000-0000-0000-000000000000
    distinguished req: 3
  lock: "k4"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [Intent]
 
 # -------------------------------------------------------------
 # Read-only request with lock timeout discovers abandoned
@@ -275,7 +275,7 @@ debug-lock-table
 ----
 num=1
  lock: "k4"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [holder finalized: aborted]
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [Intent] [holder finalized: aborted]
 
 reset
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/range_state_listener
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/range_state_listener
@@ -164,7 +164,7 @@ debug-lock-table
 ----
 num=1
  lock: "k"
-  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
    queued locking requests:
     active: false req: 3, strength: Intent, txn: 00000002-0000-0000-0000-000000000000
 
@@ -279,7 +279,7 @@ debug-lock-table
 ----
 num=1
  lock: "k"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
    queued locking requests:
     active: false req: 4, strength: Intent, txn: 00000003-0000-0000-0000-000000000000
 
@@ -437,7 +437,7 @@ debug-lock-table
 ----
 num=1
  lock: "k"
-  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
    queued locking requests:
     active: false req: 6, strength: Intent, txn: 00000002-0000-0000-0000-000000000000
 
@@ -657,7 +657,7 @@ debug-lock-table
 ----
 num=1
  lock: "k"
-  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
    queued locking requests:
     active: false req: 10, strength: Intent, txn: 00000002-0000-0000-0000-000000000000
 
@@ -815,7 +815,7 @@ debug-lock-table
 ----
 num=1
  lock: "k"
-  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
    queued locking requests:
     active: false req: 12, strength: Intent, txn: 00000002-0000-0000-0000-000000000000
 

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/resolve_pushed_intents
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/resolve_pushed_intents
@@ -40,25 +40,25 @@ debug-lock-table
 ----
 num=10
  lock: "a"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
  lock: "b"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
  lock: "c"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
  lock: "d"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
  lock: "e"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
  lock: "f"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
  lock: "g"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
  lock: "h"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
  lock: "i"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
  lock: "j"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
 
 # Before re-scanning and pushing, add a waiter on a single key to demonstrate
 # that uncontended, replicated keys are released when pushed, while contended,
@@ -168,9 +168,9 @@ debug-lock-table
 ----
 num=2
  lock: "a"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
  lock: "b"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
 
 new-request name=req2 txn=txn2 ts=10,1
   put key=g value=v1
@@ -200,9 +200,9 @@ debug-lock-table
 ----
 num=4
  lock: "a"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
  lock: "b"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
  lock: "g"
   holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
  lock: "h"
@@ -276,11 +276,11 @@ debug-lock-table
 ----
 num=3
  lock: "a"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
  lock: "b"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
  lock: "c"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
 
 sequence req=req1
 ----
@@ -366,25 +366,25 @@ debug-lock-table
 ----
 num=10
  lock: "a"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
  lock: "b"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
  lock: "c"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
  lock: "d"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
  lock: "e"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
  lock: "f"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
  lock: "g"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
  lock: "h"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
  lock: "i"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
  lock: "j"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
 
 # Before re-scanning and pushing, add a waiter on a single key to demonstrate
 # that uncontended, replicated keys are released when pushed, while contended,

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/resolve_pushed_intents_without_adding_to_lock_table
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/resolve_pushed_intents_without_adding_to_lock_table
@@ -34,7 +34,7 @@ debug-lock-table
 ----
 num=1
  lock: "a"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
 
 sequence req=req1
 ----
@@ -146,7 +146,7 @@ debug-lock-table
 ----
 num=1
  lock: "a"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
 
 sequence req=req1
 ----
@@ -202,23 +202,23 @@ debug-lock-table
 ----
 num=9
  lock: "b"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
  lock: "c"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
  lock: "d"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
  lock: "e"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
  lock: "f"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
  lock: "g"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
  lock: "h"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
  lock: "i"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
  lock: "j"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
 
 sequence req=req2
 ----
@@ -317,7 +317,7 @@ debug-lock-table
 ----
 num=1
  lock: "a"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
 
 sequence req=req1
 ----
@@ -373,23 +373,23 @@ debug-lock-table
 ----
 num=9
  lock: "b"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
  lock: "c"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
  lock: "d"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
  lock: "e"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
  lock: "f"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
  lock: "g"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
  lock: "h"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
  lock: "i"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
  lock: "j"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
 
 sequence req=req2
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/uncertainty
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/uncertainty
@@ -31,7 +31,7 @@ debug-lock-table
 ----
 num=1
  lock: "k"
-  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
 
 sequence req=req1
 ----
@@ -97,7 +97,7 @@ debug-lock-table
 ----
 num=1
  lock: "k"
-  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 100.000000000,1, info: repl
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 100.000000000,1, info: repl [Intent]
 
 sequence req=req1
 ----
@@ -166,7 +166,7 @@ debug-lock-table
 ----
 num=1
  lock: "k"
-  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 100.000000000,1, info: repl
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 100.000000000,1, info: repl [Intent]
 
 sequence req=req1
 ----
@@ -241,7 +241,7 @@ debug-lock-table
 ----
 num=1
  lock: "k"
-  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 14.000000000,1, info: repl
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 14.000000000,1, info: repl [Intent]
 
 sequence req=req1
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/update
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/update
@@ -381,7 +381,7 @@ debug-lock-table
 ----
 num=1
  lock: "k"
-  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl, unrepl [(str: Exclusive seq: 0)]
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent], unrepl [(str: Exclusive seq: 0)]
    queued locking requests:
     active: true req: 9, strength: Intent, txn: none
    distinguished req: 9

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_elsewhere
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_elsewhere
@@ -69,7 +69,7 @@ debug-lock-table
 ----
 num=1
  lock: "k"
-  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
    queued locking requests:
     active: true req: 2, strength: Intent, txn: 00000002-0000-0000-0000-000000000000
    distinguished req: 2
@@ -211,12 +211,12 @@ debug-lock-table
 ----
 num=2
  lock: "k1"
-  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
    waiting readers:
     req: 5, txn: 00000002-0000-0000-0000-000000000000
    distinguished req: 5
  lock: "k2"
-  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
 
 # Simulate that the replicated locks were discovered, so they are added to the
 # lock table. Keys "k1" and "k2" were previously discovered, but "k3" is new.
@@ -242,7 +242,7 @@ debug-lock-table
 ----
 num=1
  lock: "k1"
-  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
    waiting readers:
     req: 6, txn: 00000002-0000-0000-0000-000000000000
     req: 5, txn: 00000002-0000-0000-0000-000000000000

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_policy_error
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_policy_error
@@ -220,7 +220,7 @@ num=3
     active: true req: 3, strength: Intent, txn: 00000003-0000-0000-0000-000000000000
    distinguished req: 3
  lock: "k4"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [Intent]
 
 # -------------------------------------------------------------
 # Read-only request with WaitPolicy_Error discovers abandoned
@@ -281,7 +281,7 @@ debug-lock-table
 ----
 num=1
  lock: "k4"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [holder finalized: aborted]
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [Intent] [holder finalized: aborted]
 
 reset
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_policy_error_v23_1
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_policy_error_v23_1
@@ -220,7 +220,7 @@ num=3
     active: true req: 3, strength: Intent, txn: 00000003-0000-0000-0000-000000000000
    distinguished req: 3
  lock: "k4"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [Intent]
 
 # -------------------------------------------------------------
 # Read-only request with WaitPolicy_Error discovers abandoned
@@ -281,7 +281,7 @@ debug-lock-table
 ----
 num=1
  lock: "k4"
-  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [holder finalized: aborted]
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [Intent] [holder finalized: aborted]
 
 reset
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/acquire_ignored_seqs
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/acquire_ignored_seqs
@@ -115,7 +115,7 @@ acquire r=req7 k=a durability=r ignored-seqs=8 strength=intent
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl, unrepl [(str: Exclusive seq: 1)]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent], unrepl [(str: Exclusive seq: 1)]
    queued locking requests:
     active: true req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 3
@@ -129,7 +129,7 @@ acquire r=req8 k=a durability=u ignored-seqs=8 strength=exclusive
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl, unrepl [(str: Exclusive seq: 1)]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent], unrepl [(str: Exclusive seq: 1)]
    queued locking requests:
     active: true req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 3
@@ -148,7 +148,7 @@ acquire r=req9 k=a durability=u ignored-seqs=1,5-9 strength=exclusive
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl, unrepl [(str: Exclusive seq: 11)]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent], unrepl [(str: Exclusive seq: 11)]
    queued locking requests:
     active: true req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 3
@@ -170,7 +170,7 @@ acquire r=req10 k=a durability=r strength=intent
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, iso: Serializable, ts: 11.000000000,1, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, iso: Serializable, ts: 11.000000000,1, info: repl [Intent]
    queued locking requests:
     active: true req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 3

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/add_discovered
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/add_discovered
@@ -89,7 +89,7 @@ add-discovered r=req2 k=a txn=txn3
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
    queued locking requests:
     active: false req: 2, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
 
@@ -109,7 +109,7 @@ dequeue r=req3
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
    queued locking requests:
     active: true req: 2, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 2

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/add_discovered_old_lease
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/add_discovered_old_lease
@@ -29,7 +29,7 @@ add-discovered r=req1 k=b txn=txn2 lease-seq=5
 ----
 num=1
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Intent]
 
 add-discovered r=req1 k=c txn=txn2 lease-seq=6
 ----
@@ -39,4 +39,4 @@ print
 ----
 num=1
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Intent]

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/basic
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/basic
@@ -186,7 +186,7 @@ add-discovered r=req4 k=a txn=txn3
 ----
 num=4
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 6.000000000,0, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 6.000000000,0, info: repl [Intent]
    queued locking requests:
     active: false req: 4, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
  lock: "b"
@@ -202,7 +202,7 @@ add-discovered r=req4 k=f txn=txn3
 ----
 num=5
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 6.000000000,0, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 6.000000000,0, info: repl [Intent]
    queued locking requests:
     active: false req: 4, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
  lock: "b"
@@ -214,7 +214,7 @@ num=5
  lock: "e"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
  lock: "f"
-  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 6.000000000,0, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 6.000000000,0, info: repl [Intent]
 
 # Note that guard state has not changed yet. Discovering these locks means the caller has to
 # scan again.
@@ -253,7 +253,7 @@ print
 ----
 num=5
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 6.000000000,0, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 6.000000000,0, info: repl [Intent]
    queued locking requests:
     active: true req: 4, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 4
@@ -266,7 +266,7 @@ num=5
  lock: "e"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
  lock: "f"
-  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 6.000000000,0, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 6.000000000,0, info: repl [Intent]
 
 query
 ----
@@ -391,7 +391,7 @@ dequeue r=req5
 ----
 num=5
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 6.000000000,0, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 6.000000000,0, info: repl [Intent]
    queued locking requests:
     active: true req: 4, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 4
@@ -404,7 +404,7 @@ num=5
  lock: "e"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
  lock: "f"
-  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 6.000000000,0, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 6.000000000,0, info: repl [Intent]
 
 # 100ms passes between req5 and req6
 time-tick ms=100
@@ -439,7 +439,7 @@ print
 ----
 num=5
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 6.000000000,0, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 6.000000000,0, info: repl [Intent]
    queued locking requests:
     active: true req: 4, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 4
@@ -454,7 +454,7 @@ num=5
  lock: "e"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
  lock: "f"
-  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 6.000000000,0, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 6.000000000,0, info: repl [Intent]
 
 metrics
 ----
@@ -594,7 +594,7 @@ print
 ----
 num=5
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 6.000000000,0, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 6.000000000,0, info: repl [Intent]
    queued locking requests:
     active: true req: 4, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 4
@@ -611,7 +611,7 @@ num=5
  lock: "e"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
  lock: "f"
-  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 6.000000000,0, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 6.000000000,0, info: repl [Intent]
 
 metrics
 ----
@@ -751,7 +751,7 @@ num=5
  lock: "e"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
  lock: "f"
-  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 6.000000000,0, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 6.000000000,0, info: repl [Intent]
 
 guard-state r=req4
 ----
@@ -780,7 +780,7 @@ num=5
  lock: "e"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
  lock: "f"
-  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 6.000000000,0, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 6.000000000,0, info: repl [Intent]
    waiting readers:
     req: 4, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 4
@@ -954,7 +954,7 @@ num=4
    queued locking requests:
     active: false req: 4, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 8.000000000,12, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 8.000000000,12, info: repl [Intent]
    queued locking requests:
     active: true req: 6, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 6
@@ -973,12 +973,12 @@ num=4
    queued locking requests:
     active: false req: 4, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 8.000000000,12, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 8.000000000,12, info: repl [Intent]
    queued locking requests:
     active: true req: 6, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 6
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 8.000000000,12, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 8.000000000,12, info: repl [Intent]
    queued locking requests:
     active: true req: 7, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 7
@@ -1000,12 +1000,12 @@ num=4
    queued locking requests:
     active: false req: 4, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 8.000000000,12, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 8.000000000,12, info: repl [Intent]
    queued locking requests:
     active: true req: 6, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 6
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 8.000000000,12, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 8.000000000,12, info: repl [Intent]
    queued locking requests:
     active: true req: 7, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 7
@@ -1112,12 +1112,12 @@ dequeue r=req4
 ----
 num=3
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 8.000000000,12, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 8.000000000,12, info: repl [Intent]
    queued locking requests:
     active: true req: 6, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 6
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 8.000000000,12, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 8.000000000,12, info: repl [Intent]
    queued locking requests:
     active: true req: 7, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 7
@@ -1148,7 +1148,7 @@ release txn=txn2 span=c,f
 ----
 num=3
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 8.000000000,12, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 8.000000000,12, info: repl [Intent]
    queued locking requests:
     active: true req: 6, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 6
@@ -1170,7 +1170,7 @@ print
 ----
 num=3
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 8.000000000,12, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 8.000000000,12, info: repl [Intent]
    queued locking requests:
     active: true req: 6, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 6
@@ -2087,7 +2087,7 @@ acquire r=req12 k=c durability=r strength=intent
 ----
 num=1
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 8.000000000,12, info: repl, unrepl [(str: Exclusive seq: 0)]
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 8.000000000,12, info: repl [Intent], unrepl [(str: Exclusive seq: 0)]
    queued locking requests:
     active: true req: 11, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 11
@@ -2096,7 +2096,7 @@ dequeue r=req12
 ----
 num=1
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 8.000000000,12, info: repl, unrepl [(str: Exclusive seq: 0)]
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 8.000000000,12, info: repl [Intent], unrepl [(str: Exclusive seq: 0)]
    queued locking requests:
     active: true req: 11, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 11

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/clear
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/clear
@@ -68,7 +68,7 @@ num=3
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 8.000000000,1, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 8.000000000,1, info: repl [Intent]
 
 # A non-transactional read comes in at a and blocks on the lock.
 
@@ -125,7 +125,7 @@ num=3
     active: true req: 5, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 5
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 8.000000000,1, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 8.000000000,1, info: repl [Intent]
 
 # Clearing removes all locks and allows all waiting requests to proceed.
 

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/clear_finalized_txn_locks
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/clear_finalized_txn_locks
@@ -47,7 +47,7 @@ add-discovered r=req1 k=a txn=txn2
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
    queued locking requests:
     active: false req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
 
@@ -55,11 +55,11 @@ add-discovered r=req1 k=b txn=txn2
 ----
 num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
    queued locking requests:
     active: false req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
    queued locking requests:
     active: false req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
 
@@ -67,15 +67,15 @@ add-discovered r=req1 k=d txn=txn3
 ----
 num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
    queued locking requests:
     active: false req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
    queued locking requests:
     active: false req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
  lock: "d"
-  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [Intent]
    queued locking requests:
     active: false req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
 
@@ -83,19 +83,19 @@ add-discovered r=req1 k=e txn=txn3
 ----
 num=4
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
    queued locking requests:
     active: false req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
    queued locking requests:
     active: false req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
  lock: "d"
-  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [Intent]
    queued locking requests:
     active: false req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [Intent]
    queued locking requests:
     active: false req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
 
@@ -107,21 +107,21 @@ acquire r=req2 k=c durability=u strength=exclusive
 ----
 num=5
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
    queued locking requests:
     active: false req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
    queued locking requests:
     active: false req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
  lock: "c"
   holder: txn: 00000000-0000-0000-0000-000000000004 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
  lock: "d"
-  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [Intent]
    queued locking requests:
     active: false req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [Intent]
    queued locking requests:
     active: false req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
 
@@ -129,21 +129,21 @@ dequeue r=req2
 ----
 num=5
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
    queued locking requests:
     active: false req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
    queued locking requests:
     active: false req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
  lock: "c"
   holder: txn: 00000000-0000-0000-0000-000000000004 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
  lock: "d"
-  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [Intent]
    queued locking requests:
     active: false req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [Intent]
    queued locking requests:
     active: false req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
 
@@ -155,22 +155,22 @@ print
 ----
 num=5
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
    queued locking requests:
     active: true req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 1
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
    queued locking requests:
     active: false req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
  lock: "c"
   holder: txn: 00000000-0000-0000-0000-000000000004 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
  lock: "d"
-  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [Intent]
    queued locking requests:
     active: false req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [Intent]
    queued locking requests:
     active: false req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
 
@@ -189,11 +189,11 @@ print
 ----
 num=5
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [holder finalized: aborted]
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent] [holder finalized: aborted]
    queued locking requests:
     active: false req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [holder finalized: aborted]
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent] [holder finalized: aborted]
    queued locking requests:
     active: false req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
  lock: "c"
@@ -202,11 +202,11 @@ num=5
     active: true req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 1
  lock: "d"
-  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [Intent]
    queued locking requests:
     active: false req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [Intent]
    queued locking requests:
     active: false req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
 
@@ -217,22 +217,22 @@ release txn=txn4 span=c
 ----
 num=5
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [holder finalized: aborted]
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent] [holder finalized: aborted]
    queued locking requests:
     active: false req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [holder finalized: aborted]
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent] [holder finalized: aborted]
    queued locking requests:
     active: false req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
  lock: "c"
    queued locking requests:
     active: false req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
  lock: "d"
-  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [holder finalized: committed]
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [Intent] [holder finalized: committed]
    queued locking requests:
     active: false req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [holder finalized: committed]
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [Intent] [holder finalized: committed]
    queued locking requests:
     active: false req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
 
@@ -295,7 +295,7 @@ add-discovered r=req3 k=a txn=txn2
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [Intent]
    queued locking requests:
     active: false req: 3, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
 
@@ -303,11 +303,11 @@ add-discovered r=req3 k=c txn=txn2
 ----
 num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [Intent]
    queued locking requests:
     active: false req: 3, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [Intent]
    queued locking requests:
     active: false req: 3, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
 
@@ -319,13 +319,13 @@ acquire r=req4 k=b durability=u strength=exclusive
 ----
 num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [Intent]
    queued locking requests:
     active: false req: 3, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [Intent]
    queued locking requests:
     active: false req: 3, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
 
@@ -333,13 +333,13 @@ dequeue r=req4
 ----
 num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [Intent]
    queued locking requests:
     active: false req: 3, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [Intent]
    queued locking requests:
     active: false req: 3, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
 
@@ -398,7 +398,7 @@ add-discovered r=req5 k=a txn=txn2
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [Intent]
    queued locking requests:
     active: false req: 5, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
 
@@ -406,11 +406,11 @@ add-discovered r=req5 k=b txn=txn2
 ----
 num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [Intent]
    queued locking requests:
     active: false req: 5, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [Intent]
    queued locking requests:
     active: false req: 5, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
 
@@ -422,12 +422,12 @@ print
 ----
 num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [Intent]
    queued locking requests:
     active: true req: 5, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 5
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [Intent]
    queued locking requests:
     active: false req: 5, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
 
@@ -450,13 +450,13 @@ print
 ----
 num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [holder finalized: aborted]
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [Intent] [holder finalized: aborted]
    queued locking requests:
     active: true req: 5, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
     active: true req: 6, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 5
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [holder finalized: aborted]
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [Intent] [holder finalized: aborted]
    queued locking requests:
     active: false req: 5, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
 
@@ -469,7 +469,7 @@ num=2
     active: true req: 6, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 6
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [holder finalized: aborted]
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [Intent] [holder finalized: aborted]
    queued locking requests:
     active: false req: 5, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
 
@@ -530,7 +530,7 @@ add-discovered r=req7 k=a txn=txn2
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [Intent]
    queued locking requests:
     active: false req: 7, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
 
@@ -538,11 +538,11 @@ add-discovered r=req7 k=b txn=txn2
 ----
 num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [Intent]
    queued locking requests:
     active: false req: 7, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [Intent]
    queued locking requests:
     active: false req: 7, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
 
@@ -558,12 +558,12 @@ print
 ----
 num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [Intent]
    queued locking requests:
     active: true req: 7, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 7
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [Intent]
    queued locking requests:
     active: false req: 7, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
 
@@ -627,37 +627,37 @@ add-discovered r=req9 k=a txn=txn3
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 12.000000000,1, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 12.000000000,1, info: repl [Intent]
 
 add-discovered r=req9 k=b txn=txn3
 ----
 num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 12.000000000,1, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 12.000000000,1, info: repl [Intent]
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 12.000000000,1, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 12.000000000,1, info: repl [Intent]
 
 add-discovered r=req9 k=c txn=txn4
 ----
 num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 12.000000000,1, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 12.000000000,1, info: repl [Intent]
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 12.000000000,1, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 12.000000000,1, info: repl [Intent]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000004 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000004 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [Intent]
 
 add-discovered r=req9 k=d txn=txn4
 ----
 num=4
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 12.000000000,1, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 12.000000000,1, info: repl [Intent]
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 12.000000000,1, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 12.000000000,1, info: repl [Intent]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000004 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000004 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [Intent]
  lock: "d"
-  holder: txn: 00000000-0000-0000-0000-000000000004 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000004 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [Intent]
 
 pushed-txn-updated txn=txn3 status=aborted
 ----
@@ -674,16 +674,16 @@ print
 ----
 num=4
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 12.000000000,1, info: repl [holder finalized: aborted]
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 12.000000000,1, info: repl [Intent] [holder finalized: aborted]
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 12.000000000,1, info: repl [holder finalized: aborted]
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 12.000000000,1, info: repl [Intent] [holder finalized: aborted]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000004 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000004 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [Intent]
    waiting readers:
     req: 9, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 9
  lock: "d"
-  holder: txn: 00000000-0000-0000-0000-000000000004 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000004 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [Intent]
 
 scan r=req10
 ----
@@ -703,7 +703,7 @@ release txn=txn4 span=c
 ----
 num=1
  lock: "d"
-  holder: txn: 00000000-0000-0000-0000-000000000004 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [holder finalized: aborted]
+  holder: txn: 00000000-0000-0000-0000-000000000004 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [Intent] [holder finalized: aborted]
 
 guard-state r=req9
 ----
@@ -733,7 +733,7 @@ add-discovered r=req11 k=a txn=txn2
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 12.000000000,1, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 12.000000000,1, info: repl [Intent]
    queued locking requests:
     active: false req: 11, strength: Intent, txn: none
 
@@ -778,7 +778,7 @@ add-discovered r=req12 k=a txn=txn2
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 12.000000000,1, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 12.000000000,1, info: repl [Intent]
 
 pushed-txn-updated txn=txn2 status=aborted
 ----
@@ -1005,7 +1005,7 @@ add-discovered r=req17 k=a txn=txn7
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000007 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000007 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [Intent]
    queued locking requests:
     active: false req: 16, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000005
 
@@ -1013,11 +1013,11 @@ add-discovered r=req17 k=b txn=txn8
 ----
 num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000007 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000007 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [Intent]
    queued locking requests:
     active: false req: 16, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000005
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000008 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000008 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [Intent]
    queued locking requests:
     active: false req: 16, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000005
 
@@ -1029,12 +1029,12 @@ print
 ----
 num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000007 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000007 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [Intent]
    queued locking requests:
     active: true req: 16, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000005
    distinguished req: 16
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000008 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000008 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [Intent]
    queued locking requests:
     active: false req: 16, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000005
 
@@ -1055,11 +1055,11 @@ print
 ----
 num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000007 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [holder finalized: aborted]
+  holder: txn: 00000000-0000-0000-0000-000000000007 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [Intent] [holder finalized: aborted]
    queued locking requests:
     active: false req: 16, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000005
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000008 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000008 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [Intent]
    queued locking requests:
     active: true req: 16, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000005
    distinguished req: 16
@@ -1076,13 +1076,13 @@ print
 ----
 num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000007 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [holder finalized: aborted]
+  holder: txn: 00000000-0000-0000-0000-000000000007 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [Intent] [holder finalized: aborted]
    queued locking requests:
     active: false req: 16, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000005
     active: true req: 17, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000008
    distinguished req: 17
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000008 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000008 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [Intent]
    queued locking requests:
     active: true req: 16, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000005
    distinguished req: 16

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/disable
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/disable
@@ -73,7 +73,7 @@ add-discovered r=req2 k=a txn=txn2
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
    queued locking requests:
     active: false req: 2, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
 

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/discovered_locks_consults_txn_cache
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/discovered_locks_consults_txn_cache
@@ -40,7 +40,7 @@ add-discovered r=req1 k=a txn=txn2 consult-txn-status-cache=false
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [holder finalized: aborted]
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Intent] [holder finalized: aborted]
    queued locking requests:
     active: false req: 1, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
 
@@ -97,7 +97,7 @@ num=2
    queued locking requests:
     active: false req: 1, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
  lock: "d"
-  holder: txn: 00000000-0000-0000-0000-000000000004 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000004 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Intent]
    queued locking requests:
     active: false req: 1, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
 
@@ -120,7 +120,7 @@ dequeue r=req1
 ----
 num=1
  lock: "d"
-  holder: txn: 00000000-0000-0000-0000-000000000004 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000004 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Intent]
 
 clear
 ----
@@ -144,7 +144,7 @@ add-discovered r=req2 k=e txn=txn5 consult-txn-status-cache=false
 ----
 num=1
  lock: "e"
-  holder: txn: 00000000-0000-0000-0000-000000000005 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000005 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Intent]
 
 # Nothing to resolve yet.
 resolve-before-scanning r=req2
@@ -187,7 +187,7 @@ add-discovered r=req2 k=g txn=txn7 consult-txn-status-cache=true
 ----
 num=1
  lock: "g"
-  holder: txn: 00000000-0000-0000-0000-000000000007 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000007 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Intent]
 
 # Locks for f and g were not added to lock table.
 resolve-before-scanning r=req2
@@ -208,7 +208,7 @@ dequeue r=req2
 ----
 num=1
  lock: "g"
-  holder: txn: 00000000-0000-0000-0000-000000000007 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000007 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Intent]
 
 clear
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/isolation_level
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/isolation_level
@@ -109,15 +109,15 @@ add-discovered r=req6 k=a txn=txn2
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: ReadCommitted, ts: 10.000000000,1, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: ReadCommitted, ts: 10.000000000,1, info: repl [Intent]
 
 add-discovered r=req7 k=b txn=txn2
 ----
 num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: ReadCommitted, ts: 10.000000000,1, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: ReadCommitted, ts: 10.000000000,1, info: repl [Intent]
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: ReadCommitted, ts: 10.000000000,1, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: ReadCommitted, ts: 10.000000000,1, info: repl [Intent]
 
 scan r=req6
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/lock_changes
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/lock_changes
@@ -66,7 +66,7 @@ acquire r=req2 k=a durability=r strength=intent
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 8.000000000,0, info: repl, unrepl [(str: Exclusive seq: 2)]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 8.000000000,0, info: repl [Intent], unrepl [(str: Exclusive seq: 2)]
    queued locking requests:
     active: true req: 1, strength: Intent, txn: none
    distinguished req: 1
@@ -75,7 +75,7 @@ dequeue r=reqContend
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 8.000000000,0, info: repl, unrepl [(str: Exclusive seq: 2)]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 8.000000000,0, info: repl [Intent], unrepl [(str: Exclusive seq: 2)]
 
 # ---------------------------------------------------------------------------------
 # Lock is reacquired at a different epoch. The old sequence numbers are discarded.
@@ -91,7 +91,7 @@ acquire r=req3 k=a durability=u strength=exclusive
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, iso: Serializable, ts: 8.000000000,0, info: repl, unrepl [(str: Exclusive seq: 1)]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, iso: Serializable, ts: 8.000000000,0, info: repl [Intent], unrepl [(str: Exclusive seq: 1)]
 
 # ---------------------------------------------------------------------------------
 # Lock is reacquired at a different epoch with lower timestamp. This is allowed,
@@ -109,7 +109,7 @@ acquire r=req4 k=a durability=u strength=exclusive
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 2, iso: Serializable, ts: 8.000000000,0, info: repl, unrepl [(str: Exclusive seq: 0)]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 2, iso: Serializable, ts: 8.000000000,0, info: repl [Intent], unrepl [(str: Exclusive seq: 0)]
 
 # ---------------------------------------------------------------------------------
 # Reader waits until the timestamp of the lock is updated.
@@ -130,7 +130,7 @@ print
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 2, iso: Serializable, ts: 8.000000000,0, info: repl, unrepl [(str: Exclusive seq: 0)]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 2, iso: Serializable, ts: 8.000000000,0, info: repl [Intent], unrepl [(str: Exclusive seq: 0)]
    waiting readers:
     req: 2, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 2
@@ -145,7 +145,7 @@ acquire r=req6 k=a durability=r strength=intent
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 2, iso: Serializable, ts: 10.000000000,0, info: repl, unrepl [(str: Exclusive seq: 0)]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 2, iso: Serializable, ts: 10.000000000,0, info: repl [Intent], unrepl [(str: Exclusive seq: 0)]
    waiting readers:
     req: 2, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 2
@@ -158,7 +158,7 @@ acquire r=req6 k=a durability=u strength=exclusive
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 2, iso: Serializable, ts: 14.000000000,0, info: repl, unrepl [(str: Exclusive seq: 0)]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 2, iso: Serializable, ts: 14.000000000,0, info: repl [Intent], unrepl [(str: Exclusive seq: 0)]
 
 guard-state r=req5
 ----
@@ -186,7 +186,7 @@ add-discovered r=req7 k=a txn=txn1
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 2, iso: Serializable, ts: 14.000000000,0, info: repl, unrepl [(str: Exclusive seq: 0)]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 2, iso: Serializable, ts: 14.000000000,0, info: repl [Intent], unrepl [(str: Exclusive seq: 0)]
    waiting readers:
     req: 3, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 3
@@ -206,7 +206,7 @@ print
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 2, iso: Serializable, ts: 14.000000000,0, info: repl, unrepl [(str: Exclusive seq: 0)]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 2, iso: Serializable, ts: 14.000000000,0, info: repl [Intent], unrepl [(str: Exclusive seq: 0)]
    waiting readers:
     req: 3, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 3

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/lock_dropped
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/lock_dropped
@@ -104,7 +104,7 @@ acquire r=req1 k=a durability=r strength=intent
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl, unrepl [(str: Exclusive seq: 2)]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Intent], unrepl [(str: Exclusive seq: 2)]
    waiting readers:
     req: 1, txn: none
    queued locking requests:

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/non_active_waiter
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/non_active_waiter
@@ -20,7 +20,7 @@ add-discovered r=req1 k=a txn=txn2
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Intent]
    queued locking requests:
     active: false req: 1, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
 
@@ -28,23 +28,23 @@ add-discovered r=req1 k=b txn=txn2
 ----
 num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Intent]
    queued locking requests:
     active: false req: 1, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Intent]
 
 add-discovered r=req1 k=c txn=txn2
 ----
 num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Intent]
    queued locking requests:
     active: false req: 1, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Intent]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Intent]
    queued locking requests:
     active: false req: 1, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
 
@@ -54,13 +54,13 @@ print
 ----
 num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Intent]
    queued locking requests:
     active: false req: 1, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Intent]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Intent]
    queued locking requests:
     active: false req: 1, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
 
@@ -77,13 +77,13 @@ print
 ----
 num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Intent]
    queued locking requests:
     active: false req: 1, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Intent]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Intent]
    queued locking requests:
     active: false req: 1, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
     active: true req: 2, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
@@ -101,14 +101,14 @@ print
 ----
 num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Intent]
    queued locking requests:
     active: true req: 1, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 1
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Intent]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Intent]
    queued locking requests:
     active: false req: 1, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
     active: true req: 2, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
@@ -122,9 +122,9 @@ num=3
    queued locking requests:
     active: false req: 1, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Intent]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Intent]
    queued locking requests:
     active: false req: 1, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
     active: true req: 2, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
@@ -141,9 +141,9 @@ num=3
    queued locking requests:
     active: false req: 1, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Intent]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Intent]
    queued locking requests:
     active: true req: 1, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
     active: true req: 2, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
@@ -158,7 +158,7 @@ num=3
    queued locking requests:
     active: false req: 1, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Intent]
  lock: "c"
    queued locking requests:
     active: false req: 1, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
@@ -179,7 +179,7 @@ num=3
    queued locking requests:
     active: false req: 1, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Intent]
    waiting readers:
     req: 1, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 1

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/non_txn_write
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/non_txn_write
@@ -248,7 +248,7 @@ num=2
    queued locking requests:
     active: false req: 6, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Intent]
    queued locking requests:
     active: false req: 4, strength: Intent, txn: none
     active: false req: 5, strength: Intent, txn: 00000000-0000-0000-0000-000000000003

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/resolve_pushed_txn_locks
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/resolve_pushed_txn_locks
@@ -36,15 +36,15 @@ add-discovered r=req4 k=b txn=txn2
 ----
 num=1
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
 
 add-discovered r=req4 k=c txn=txn2
 ----
 num=2
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
 
 new-request r=reqLock txn=txn2 ts=10,1 spans=exclusive@a+exclusive@b+exclusive@c+exclusive@d
 ----
@@ -59,9 +59,9 @@ num=3
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
 
 acquire r=reqLock k=b durability=u strength=exclusive
 ----
@@ -69,9 +69,9 @@ num=3
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl, unrepl [(str: Exclusive seq: 0)]
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent], unrepl [(str: Exclusive seq: 0)]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
 
 dequeue r=reqLock
 ----
@@ -79,9 +79,9 @@ num=3
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl, unrepl [(str: Exclusive seq: 0)]
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent], unrepl [(str: Exclusive seq: 0)]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
 
 scan r=req1
 ----
@@ -104,12 +104,12 @@ num=3
     req: 3, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 3
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl, unrepl [(str: Exclusive seq: 0)]
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent], unrepl [(str: Exclusive seq: 0)]
    waiting readers:
     req: 4, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 4
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
    waiting readers:
     req: 5, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 5
@@ -127,12 +127,12 @@ num=3
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl, unrepl [(str: Exclusive seq: 0)]
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent], unrepl [(str: Exclusive seq: 0)]
    waiting readers:
     req: 4, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 4
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
    waiting readers:
     req: 5, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 5
@@ -164,7 +164,7 @@ num=3
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
    waiting readers:
     req: 5, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 5

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/size_limit_exceeded
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/size_limit_exceeded
@@ -68,7 +68,7 @@ num=3
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl, unrepl [(str: Exclusive seq: 0)]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Intent], unrepl [(str: Exclusive seq: 0)]
    queued locking requests:
     active: true req: 2, strength: Intent, txn: none
    distinguished req: 2
@@ -81,7 +81,7 @@ num=3
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl, unrepl [(str: Exclusive seq: 0)]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Intent], unrepl [(str: Exclusive seq: 0)]
 
 dequeue r=req1
 ----
@@ -91,7 +91,7 @@ num=3
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl, unrepl [(str: Exclusive seq: 0)]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Intent], unrepl [(str: Exclusive seq: 0)]
 
 new-request r=req2 txn=txn2 ts=10 spans=intent@a,c
 ----
@@ -119,7 +119,7 @@ num=3
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl, unrepl [(str: Exclusive seq: 0)]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Intent], unrepl [(str: Exclusive seq: 0)]
 
 release txn=txn1 span=a
 ----
@@ -131,7 +131,7 @@ num=3
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl, unrepl [(str: Exclusive seq: 0)]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Intent], unrepl [(str: Exclusive seq: 0)]
 
 guard-state r=req2
 ----
@@ -154,7 +154,7 @@ num=3
     active: true req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 3
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl, unrepl [(str: Exclusive seq: 0)]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Intent], unrepl [(str: Exclusive seq: 0)]
 
 new-request r=req4 txn=txn2 ts=10 spans=none@b
 ----
@@ -204,12 +204,12 @@ num=4
     active: true req: 6, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 3
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl, unrepl [(str: Exclusive seq: 0)]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Intent], unrepl [(str: Exclusive seq: 0)]
    queued locking requests:
     active: true req: 7, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 7
  lock: "d"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Intent]
    queued locking requests:
     active: false req: 8, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
 
@@ -226,7 +226,7 @@ acquire r=req8 k=e durability=u strength=exclusive
 ----
 num=1
  lock: "d"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Intent]
    queued locking requests:
     active: false req: 8, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
 


### PR DESCRIPTION
This patch changes how replicated locks are tracked in the lock table
to be able to support lock strengths other than lock.Intent. For now,
the lock table doesn't expect replicated locks to have any other lock
strength -- there are assertions in `AcquireLock` and
`AddDiscoveredLock` that make sure of this. These assertions will be
lifted in a subsequent patch, at which point we'll add the necessary
testing.

Informs https://github.com/cockroachdb/cockroach/issues/109673

Release note: None