### PR TITLE
backupccl: Revive TestCleanupIntentsDuringBackupPerformanceRegression

### DIFF
--- a/pkg/ccl/backupccl/BUILD.bazel
+++ b/pkg/ccl/backupccl/BUILD.bazel
@@ -167,6 +167,7 @@ go_test(
         "alter_backup_schedule_test.go",
         "alter_backup_test.go",
         "backup_cloud_test.go",
+        "backup_intents_test.go",
         "backup_planning_test.go",
         "backup_tenant_test.go",
         "backup_test.go",

--- a/pkg/ccl/backupccl/backup_intents_test.go
+++ b/pkg/ccl/backupccl/backup_intents_test.go
@@ -1,0 +1,124 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package backupccl_test
+
+import (
+	"context"
+	gosql "database/sql"
+	"fmt"
+	"sync/atomic"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/ccl"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCleanupIntentsDuringBackupPerformanceRegression tests the backup process
+// in the presence of unresolved intents.
+func TestCleanupIntentsDuringBackupPerformanceRegression(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	defer ccl.TestingEnableEnterprise()()
+
+	skip.UnderRace(t, "measures backup times to ensure intent resolution does not regress, can't work under race")
+	skip.UnderDeadlock(t, "measures backup times to ensure intent resolution does not regress, can't work under deadlock")
+
+	const totalRowCount = 10000
+	const perTransactionRowCount = 10
+
+	// Test with unresolved intents that belong to an aborted transaction (abort =
+	// true) or a pending transaction (abort = false).
+	testutils.RunTrueAndFalse(t, "abort", func(t *testing.T, abort bool) {
+		var numIntentResolveBatches atomic.Int32
+		var numPushBatches atomic.Int32
+
+		// Interceptor catches requests that cleanup transactions of size 10, which are
+		// test data transactions. All other requests pass though.
+		interceptor := func(ctx context.Context, req *kvpb.BatchRequest) *kvpb.Error {
+			if req.Requests[0].GetResolveIntent() != nil {
+				numIntentResolveBatches.Add(1)
+			}
+			if req.Requests[0].GetPushTxn() != nil {
+				numPushBatches.Add(1)
+			}
+			endTxn := req.Requests[0].GetEndTxn()
+			if endTxn != nil && !endTxn.Commit && len(endTxn.LockSpans) == perTransactionRowCount {
+				// If this is a rollback of one the test's SQL transactions, allow the
+				// EndTxn to proceed and mark the transaction record as ABORTED, but strip
+				// the request of its lock spans so that no intents are recorded into the
+				// transaction record or eagerly resolved. This is a bit of a hack, but it
+				// mimics the behavior of an abandoned transaction which is aborted by a
+				// pusher after expiring due to an absence of heartbeats.
+				endTxn.LockSpans = nil
+			}
+			return nil
+		}
+
+		serverKnobs := kvserver.StoreTestingKnobs{TestingRequestFilter: interceptor}
+		s, sqlDb, _ := serverutils.StartServer(t,
+			base.TestServerArgs{Knobs: base.TestingKnobs{Store: &serverKnobs}})
+		defer s.Stopper().Stop(context.Background())
+
+		// These cluster settings ensure that ExportRequests issued by the backup
+		// processor are not delayed for too long, especially for abort=false, when
+		// only the final high-priority ExportRequest can push the slow pending txn.
+		_, err := sqlDb.Exec("SET CLUSTER SETTING bulkio.backup.read_with_priority_after = '500ms'")
+		require.NoError(t, err)
+		_, err = sqlDb.Exec("SET CLUSTER SETTING bulkio.backup.read_retry_delay = '100ms'")
+		require.NoError(t, err)
+
+		_, err = sqlDb.Exec("create table foo(v int not null)")
+		require.NoError(t, err)
+
+		transactions := make([]*gosql.Tx, totalRowCount/perTransactionRowCount)
+
+		for i := 0; i < totalRowCount; i += perTransactionRowCount {
+			tx, err := sqlDb.Begin()
+			require.NoError(t, err)
+			transactions[i/perTransactionRowCount] = tx
+			for j := 0; j < perTransactionRowCount; j += 1 {
+				statement := fmt.Sprintf("insert into foo (v) values (%d)", i+j)
+				_, err = tx.Exec(statement)
+				require.NoError(t, err)
+			}
+			if abort {
+				require.NoError(t, tx.Rollback())
+			}
+		}
+
+		_, err = sqlDb.Exec("backup table foo to 'userfile:///test.foo'")
+		require.NoError(t, err, "Failed to run backup")
+
+		if !abort {
+			for _, tx := range transactions {
+				require.NoError(t, tx.Commit())
+			}
+		}
+
+		// We expect each group of 10 intents to take 2 intent resolution batches:
+		// - One intent gets discovered and added to the lock table, which forces the
+		//   abandoned txn to be pushed and added to the txnStatusCache.
+		// - The remaining nine intents get resolved together because they all belong
+		//   to an abandoned txn.
+		// In reality, intents get batched into even larger batches, so the actual
+		// number of intent resolution batches is lower than 2,000.
+		require.GreaterOrEqual(t, 2000, int(numIntentResolveBatches.Load()))
+		// Each of the 1,000 transactions is expected to get pushed once, but in an
+		// actual run of the test we might see more pushes (e.g. of other transactions).
+		require.GreaterOrEqual(t, 1100, int(numPushBatches.Load()))
+	})
+}


### PR DESCRIPTION
The TestCleanupIntentsDuringBackupPerformanceRegression was recently removed mosrtly because it was a flaky time-based unit test. Right before being removed it caught a bug in #108190, so this patch revives the test in a non-timed version. Instead, it checks the number of intent resolution batches and push requests, and ensures they are of the right order of magnitude.

Informs: #108226

Release note: None