### PR TITLE
testing: rewrite TestInitialPartitioning as SQLTranslator tests

### DIFF
--- a/pkg/ccl/partitionccl/partition_test.go
+++ b/pkg/ccl/partitionccl/partition_test.go
@@ -1199,41 +1199,6 @@ func setupPartitioningTestCluster(
 	}
 }
 
-func TestInitialPartitioning(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
-
-	// Skipping as part of test-infra-team flaky test cleanup.
-	skip.WithIssue(t, 49909)
-
-	// This test configures many sub-tests and is too slow to run under nightly
-	// race stress.
-	skip.UnderStressRace(t)
-	skip.UnderShort(t)
-
-	rng, _ := randutil.NewTestRand()
-	testCases := allPartitioningTests(rng)
-
-	ctx := context.Background()
-	db, sqlDB, cleanup := setupPartitioningTestCluster(ctx, t)
-	defer cleanup()
-
-	for _, test := range testCases {
-		if len(test.scans) == 0 {
-			continue
-		}
-		t.Run(test.name, func(t *testing.T) {
-			if err := test.parse(); err != nil {
-				t.Fatalf("%+v", err)
-			}
-			sqlDB.Exec(t, test.parsed.createStmt)
-			sqlDB.Exec(t, test.parsed.zoneConfigStmts)
-
-			testutils.SucceedsSoon(t, test.verifyScansFn(ctx, t, db))
-		})
-	}
-}
-
 func TestRepartitioning(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)

--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/partition/all_indexes
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/partition/all_indexes
@@ -1,0 +1,13 @@
+exec-sql
+CREATE DATABASE db;
+CREATE TABLE db.tbl (a INT PRIMARY KEY, b INT, c INT, INDEX idx1 (b), INDEX idx2 (c));
+ALTER INDEX db.tbl@idx1 CONFIGURE ZONE USING constraints = '[+n2]';
+ALTER INDEX db.tbl@idx2 CONFIGURE ZONE USING constraints = '[+n3]';
+----
+
+translate database=db table=tbl
+----
+/Table/106{-/2}                            range default
+/Table/106/{2-3}                           constraints=[+n2]
+/Table/106/{3-4}                           constraints=[+n3]
+/Table/10{6/4-7}                           range default

--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/partition/all_indexes_shuffled
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/partition/all_indexes_shuffled
@@ -1,0 +1,13 @@
+exec-sql
+CREATE DATABASE db;
+CREATE TABLE db.tbl (a INT PRIMARY KEY, b INT, c INT, INDEX idx1 (b), INDEX idx2 (c));
+ALTER INDEX db.tbl@idx2 CONFIGURE ZONE USING constraints = '[+n2]';
+ALTER INDEX db.tbl@idx1 CONFIGURE ZONE USING constraints = '[+n3]';
+----
+
+translate database=db table=tbl
+----
+/Table/106{-/2}                            range default
+/Table/106/{2-3}                           constraints=[+n3]
+/Table/106/{3-4}                           constraints=[+n2]
+/Table/10{6/4-7}                           range default

--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/partition/list_list_partitioning
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/partition/list_list_partitioning
@@ -1,0 +1,34 @@
+exec-sql
+CREATE DATABASE db;
+CREATE TABLE db.tbl (a INT, b INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a) (
+  PARTITION p3 VALUES IN (3) PARTITION BY LIST (b) (
+    PARTITION p34 VALUES IN (4)
+  ),
+  PARTITION p5 VALUES IN (5) PARTITION BY LIST (b) (
+    PARTITION p56 VALUES IN (6),
+    PARTITION p5d VALUES IN (DEFAULT)
+  ),
+  PARTITION pd VALUES IN (DEFAULT)
+);
+ALTER INDEX db.tbl@tbl_pkey CONFIGURE ZONE USING constraints = '[+n1]';
+ALTER PARTITION p3 OF INDEX db.tbl@tbl_pkey CONFIGURE ZONE USING constraints = '[+n2]';
+ALTER PARTITION p34 OF INDEX db.tbl@tbl_pkey CONFIGURE ZONE USING constraints = '[+n3]';
+ALTER PARTITION p5 OF INDEX db.tbl@tbl_pkey CONFIGURE ZONE USING constraints = '[+n1]';
+ALTER PARTITION p56 OF INDEX db.tbl@tbl_pkey CONFIGURE ZONE USING constraints = '[+n2]';
+ALTER PARTITION p5d OF INDEX db.tbl@tbl_pkey CONFIGURE ZONE USING constraints = '[+n3]';
+ALTER PARTITION pd OF INDEX db.tbl@tbl_pkey CONFIGURE ZONE USING constraints = '[+n1]';
+----
+
+translate database=db table=tbl
+----
+/Table/106{-/1}                            range default
+/Table/106/1{-/3}                          constraints=[+n1]
+/Table/106/1/3{-/4}                        constraints=[+n2]
+/Table/106/1/3/{4-5}                       constraints=[+n3]
+/Table/106/1/{3/5-4}                       constraints=[+n2]
+/Table/106/1/{4-5}                         constraints=[+n1]
+/Table/106/1/5{-/6}                        constraints=[+n3]
+/Table/106/1/5/{6-7}                       constraints=[+n2]
+/Table/106/1/{5/7-6}                       constraints=[+n3]
+/Table/106/{1/6-2}                         constraints=[+n1]
+/Table/10{6/2-7}                           range default

--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/partition/list_range_partitioning
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/partition/list_range_partitioning
@@ -1,0 +1,32 @@
+exec-sql
+CREATE DATABASE db;
+CREATE TABLE db.tbl (a INT, b INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a) (
+  PARTITION p3 VALUES IN (3) PARTITION BY RANGE (b) (
+    PARTITION p34 VALUES FROM (MINVALUE) TO (4)
+  ),
+  PARTITION p5 VALUES IN (5) PARTITION BY RANGE (b) (
+    PARTITION p56 VALUES FROM (MINVALUE) TO (6),
+    PARTITION p5d VALUES FROM (6) TO (MAXVALUE)
+  ),
+  PARTITION pd VALUES IN (DEFAULT)
+);
+ALTER INDEX db.tbl@tbl_pkey CONFIGURE ZONE USING constraints = '[+n1]';
+ALTER PARTITION p3 OF INDEX db.tbl@tbl_pkey CONFIGURE ZONE USING constraints = '[+n2]';
+ALTER PARTITION p34 OF INDEX db.tbl@tbl_pkey CONFIGURE ZONE USING constraints = '[+n3]';
+ALTER PARTITION p5 OF INDEX db.tbl@tbl_pkey CONFIGURE ZONE USING constraints = '[+n1]';
+ALTER PARTITION p56 OF INDEX db.tbl@tbl_pkey CONFIGURE ZONE USING constraints = '[+n2]';
+ALTER PARTITION p5d OF INDEX db.tbl@tbl_pkey CONFIGURE ZONE USING constraints = '[+n3]';
+ALTER PARTITION pd OF INDEX db.tbl@tbl_pkey CONFIGURE ZONE USING constraints = '[+n1]';
+----
+
+translate database=db table=tbl
+----
+/Table/106{-/1}                            range default
+/Table/106/1{-/3}                          constraints=[+n1]
+/Table/106/1/3{-/4}                        constraints=[+n3]
+/Table/106/1/{3/4-4}                       constraints=[+n2]
+/Table/106/1/{4-5}                         constraints=[+n1]
+/Table/106/1/5{-/6}                        constraints=[+n2]
+/Table/106/1/{5/6-6}                       constraints=[+n3]
+/Table/106/{1/6-2}                         constraints=[+n1]
+/Table/10{6/2-7}                           range default

--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/partition/multi_col_list_partitioning
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/partition/multi_col_list_partitioning
@@ -1,0 +1,23 @@
+exec-sql
+CREATE DATABASE db;
+CREATE TABLE db.tbl (a INT, b INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a, b) (
+  PARTITION p34 VALUES IN ((3, 4)),
+  PARTITION p56 VALUES IN ((5, 6)),
+  PARTITION p57 VALUES IN ((5, 7))
+);
+ALTER INDEX db.tbl@tbl_pkey CONFIGURE ZONE USING constraints = '[+n1]';
+ALTER PARTITION p34 OF INDEX db.tbl@tbl_pkey CONFIGURE ZONE USING constraints = '[+n2]';
+ALTER PARTITION p56 OF INDEX db.tbl@tbl_pkey CONFIGURE ZONE USING constraints = '[+n3]';
+ALTER PARTITION p57 OF INDEX db.tbl@tbl_pkey CONFIGURE ZONE USING constraints = '[+n1]';
+----
+
+translate database=db table=tbl
+----
+/Table/106{-/1}                            range default
+/Table/106/1{-/3/4}                        constraints=[+n1]
+/Table/106/1/3/{4-5}                       constraints=[+n2]
+/Table/106/1/{3/5-5/6}                     constraints=[+n1]
+/Table/106/1/5/{6-7}                       constraints=[+n3]
+/Table/106/1/5/{7-8}                       constraints=[+n1]
+/Table/106/{1/5/8-2}                       constraints=[+n1]
+/Table/10{6/2-7}                           range default

--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/partition/multi_col_list_partitioning_default
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/partition/multi_col_list_partitioning_default
@@ -1,0 +1,27 @@
+exec-sql
+CREATE DATABASE db;
+CREATE TABLE db.tbl (a INT, b INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a, b) (
+  PARTITION p34 VALUES IN ((3, 4)),
+  PARTITION p57 VALUES IN ((5, 7)),
+  PARTITION p58 VALUES IN ((5, 8)),
+  PARTITION p5d VALUES IN ((5, DEFAULT))
+);
+ALTER INDEX db.tbl@tbl_pkey CONFIGURE ZONE USING constraints = '[+n1]';
+ALTER PARTITION p34 OF INDEX db.tbl@tbl_pkey CONFIGURE ZONE USING constraints = '[+n2]';
+ALTER PARTITION p57 OF INDEX db.tbl@tbl_pkey CONFIGURE ZONE USING constraints = '[+n3]';
+ALTER PARTITION p58 OF INDEX db.tbl@tbl_pkey CONFIGURE ZONE USING constraints = '[+n1]';
+ALTER PARTITION p5d OF INDEX db.tbl@tbl_pkey CONFIGURE ZONE USING constraints = '[+n2]';
+----
+
+translate database=db table=tbl
+----
+/Table/106{-/1}                            range default
+/Table/106/1{-/3/4}                        constraints=[+n1]
+/Table/106/1/3/{4-5}                       constraints=[+n2]
+/Table/106/1/{3/5-5}                       constraints=[+n1]
+/Table/106/1/5{-/7}                        constraints=[+n2]
+/Table/106/1/5/{7-8}                       constraints=[+n3]
+/Table/106/1/5/{8-9}                       constraints=[+n1]
+/Table/106/1/{5/9-6}                       constraints=[+n2]
+/Table/106/{1/6-2}                         constraints=[+n1]
+/Table/10{6/2-7}                           range default

--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/partition/multi_col_list_partitioning_default_default
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/partition/multi_col_list_partitioning_default_default
@@ -1,0 +1,28 @@
+exec-sql
+CREATE DATABASE db;
+CREATE TABLE db.tbl (a INT, b INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a, b) (
+  PARTITION p34 VALUES IN ((3, 4)),
+  PARTITION p57 VALUES IN ((5, 7)),
+  PARTITION p58 VALUES IN ((5, 8)),
+  PARTITION p5d VALUES IN ((5, DEFAULT)),
+  PARTITION pd VALUES IN ((DEFAULT, DEFAULT))
+);
+ALTER PARTITION p34 OF INDEX db.tbl@tbl_pkey CONFIGURE ZONE USING constraints = '[+n1]';
+ALTER PARTITION p57 OF INDEX db.tbl@tbl_pkey CONFIGURE ZONE USING constraints = '[+n2]';
+ALTER PARTITION p58 OF INDEX db.tbl@tbl_pkey CONFIGURE ZONE USING constraints = '[+n3]';
+ALTER PARTITION p5d OF INDEX db.tbl@tbl_pkey CONFIGURE ZONE USING constraints = '[+n1]';
+ALTER PARTITION pd OF INDEX db.tbl@tbl_pkey CONFIGURE ZONE USING constraints = '[+n2]';
+----
+
+translate database=db table=tbl
+----
+/Table/106{-/1}                            range default
+/Table/106/1{-/3/4}                        constraints=[+n2]
+/Table/106/1/3/{4-5}                       constraints=[+n1]
+/Table/106/1/{3/5-5}                       constraints=[+n2]
+/Table/106/1/5{-/7}                        constraints=[+n1]
+/Table/106/1/5/{7-8}                       constraints=[+n2]
+/Table/106/1/5/{8-9}                       constraints=[+n3]
+/Table/106/1/{5/9-6}                       constraints=[+n1]
+/Table/106/{1/6-2}                         constraints=[+n2]
+/Table/10{6/2-7}                           range default

--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/partition/multi_col_list_partitioning_default_default_subpartitioned
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/partition/multi_col_list_partitioning_default_default_subpartitioned
@@ -1,0 +1,32 @@
+exec-sql
+CREATE DATABASE db;
+CREATE TABLE db.tbl (a INT, b INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a) (
+  PARTITION p3 VALUES IN (3) PARTITION BY LIST (b) (
+    PARTITION p34 VALUES IN (4)
+  ),
+  PARTITION p5 VALUES IN (5) PARTITION BY LIST (b) (
+    PARTITION p57 VALUES IN (7),
+    PARTITION p58 VALUES IN (8),
+    PARTITION p5d VALUES IN (DEFAULT)
+  ),
+  PARTITION pd VALUES IN (DEFAULT)
+);
+ALTER PARTITION p34 OF INDEX db.tbl@tbl_pkey CONFIGURE ZONE USING constraints = '[+n1]';
+ALTER PARTITION p57 OF INDEX db.tbl@tbl_pkey CONFIGURE ZONE USING constraints = '[+n2]';
+ALTER PARTITION p58 OF INDEX db.tbl@tbl_pkey CONFIGURE ZONE USING constraints = '[+n3]';
+ALTER PARTITION p5d OF INDEX db.tbl@tbl_pkey CONFIGURE ZONE USING constraints = '[+n1]';
+ALTER PARTITION pd OF INDEX db.tbl@tbl_pkey CONFIGURE ZONE USING constraints = '[+n2]';
+----
+
+translate database=db table=tbl
+----
+/Table/106{-/1}                            range default
+/Table/106/1{-/3/4}                        constraints=[+n2]
+/Table/106/1/3/{4-5}                       constraints=[+n1]
+/Table/106/1/{3/5-5}                       constraints=[+n2]
+/Table/106/1/5{-/7}                        constraints=[+n1]
+/Table/106/1/5/{7-8}                       constraints=[+n2]
+/Table/106/1/5/{8-9}                       constraints=[+n3]
+/Table/106/1/{5/9-6}                       constraints=[+n1]
+/Table/106/{1/6-2}                         constraints=[+n2]
+/Table/10{6/2-7}                           range default

--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/partition/multi_col_range_partitioning
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/partition/multi_col_range_partitioning
@@ -1,0 +1,21 @@
+exec-sql
+CREATE DATABASE db;
+CREATE TABLE db.tbl (a INT, b INT, PRIMARY KEY (a, b)) PARTITION BY RANGE (a, b) (
+  PARTITION p34 VALUES FROM (MINVALUE, MINVALUE) TO (3, 4),
+  PARTITION p56 VALUES FROM (3, 4) TO (5, 6),
+  PARTITION p57 VALUES FROM (5, 6) TO (5, 7)
+);
+ALTER INDEX db.tbl@tbl_pkey CONFIGURE ZONE USING constraints = '[+n1]';
+ALTER PARTITION p34 OF INDEX db.tbl@tbl_pkey CONFIGURE ZONE USING constraints = '[+n2]';
+ALTER PARTITION p56 OF INDEX db.tbl@tbl_pkey CONFIGURE ZONE USING constraints = '[+n3]';
+ALTER PARTITION p57 OF INDEX db.tbl@tbl_pkey CONFIGURE ZONE USING constraints = '[+n1]';
+----
+
+translate database=db table=tbl
+----
+/Table/106{-/1}                            range default
+/Table/106/1{-/3/4}                        constraints=[+n2]
+/Table/106/1/{3/4-5/6}                     constraints=[+n3]
+/Table/106/1/5/{6-7}                       constraints=[+n1]
+/Table/106/{1/5/7-2}                       constraints=[+n1]
+/Table/10{6/2-7}                           range default

--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/partition/multi_col_range_partitioning_descending
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/partition/multi_col_range_partitioning_descending
@@ -1,0 +1,19 @@
+exec-sql
+CREATE DATABASE db;
+CREATE TABLE db.tbl (a INT, b INT, c INT, PRIMARY KEY (a, b DESC, c)) PARTITION BY RANGE (a, b, c) (
+  PARTITION p6xx VALUES FROM (MINVALUE, MINVALUE, MINVALUE) TO (6, MAXVALUE, MAXVALUE),
+  PARTITION p75n VALUES FROM (7, MINVALUE, MINVALUE) TO (7, 5, MINVALUE),
+  PARTITION pxxx VALUES FROM (7, 5, MINVALUE) TO (MAXVALUE, MAXVALUE, MAXVALUE)
+);
+ALTER PARTITION p6xx OF INDEX db.tbl@tbl_pkey CONFIGURE ZONE USING constraints = '[+n1]';
+ALTER PARTITION p75n OF INDEX db.tbl@tbl_pkey CONFIGURE ZONE USING constraints = '[+n2]';
+ALTER PARTITION pxxx OF INDEX db.tbl@tbl_pkey CONFIGURE ZONE USING constraints = '[+n3]';
+----
+
+translate database=db table=tbl
+----
+/Table/106{-/1}                            range default
+/Table/106/1{-/7}                          constraints=[+n1]
+/Table/106/1/7{-/-6}                       constraints=[+n2]
+/Table/106/{1/7/-6-2}                      constraints=[+n3]
+/Table/10{6/2-7}                           range default

--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/partition/multi_col_range_partitioning_maxvalue
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/partition/multi_col_range_partitioning_maxvalue
@@ -1,0 +1,24 @@
+exec-sql
+CREATE DATABASE db;
+CREATE TABLE db.tbl (a INT, b INT, PRIMARY KEY (a, b)) PARTITION BY RANGE (a, b) (
+  PARTITION p3n VALUES FROM (MINVALUE, MINVALUE) TO (3, MINVALUE),
+  PARTITION p3x VALUES FROM (3, MINVALUE) TO (3, MAXVALUE),
+  PARTITION p56 VALUES FROM (3, MAXVALUE) TO (5, 6),
+  PARTITION p57 VALUES FROM (5, 6) TO (5, 7)
+);
+ALTER INDEX db.tbl@tbl_pkey CONFIGURE ZONE USING constraints = '[+n1]';
+ALTER PARTITION p3n OF INDEX db.tbl@tbl_pkey CONFIGURE ZONE USING constraints = '[+n2]';
+ALTER PARTITION p3x OF INDEX db.tbl@tbl_pkey CONFIGURE ZONE USING constraints = '[+n3]';
+ALTER PARTITION p56 OF INDEX db.tbl@tbl_pkey CONFIGURE ZONE USING constraints = '[+n1]';
+ALTER PARTITION p57 OF INDEX db.tbl@tbl_pkey CONFIGURE ZONE USING constraints = '[+n2]';
+----
+
+translate database=db table=tbl
+----
+/Table/106{-/1}                            range default
+/Table/106/1{-/3}                          constraints=[+n2]
+/Table/106/1/{3-4}                         constraints=[+n3]
+/Table/106/1/{4-5/6}                       constraints=[+n1]
+/Table/106/1/5/{6-7}                       constraints=[+n2]
+/Table/106/{1/5/7-2}                       constraints=[+n1]
+/Table/10{6/2-7}                           range default

--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/partition/multi_col_range_partitioning_maxvalue_maxvalue
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/partition/multi_col_range_partitioning_maxvalue_maxvalue
@@ -1,0 +1,25 @@
+exec-sql
+CREATE DATABASE db;
+CREATE TABLE db.tbl (a INT, b INT, PRIMARY KEY (a, b)) PARTITION BY RANGE (a, b) (
+  PARTITION p34 VALUES FROM (MINVALUE, MINVALUE) TO (3, 4),
+  PARTITION p3x VALUES FROM (3, 4) TO (3, MAXVALUE),
+  PARTITION p56 VALUES FROM (3, MAXVALUE) TO (5, 6),
+  PARTITION p57 VALUES FROM (5, 6) TO (5, 7),
+  PARTITION pxx VALUES FROM (5, 7) TO (MAXVALUE, MAXVALUE)
+);
+ALTER PARTITION p34 OF INDEX db.tbl@tbl_pkey CONFIGURE ZONE USING constraints = '[+n1]';
+ALTER PARTITION p3x OF INDEX db.tbl@tbl_pkey CONFIGURE ZONE USING constraints = '[+n2]';
+ALTER PARTITION p56 OF INDEX db.tbl@tbl_pkey CONFIGURE ZONE USING constraints = '[+n3]';
+ALTER PARTITION p57 OF INDEX db.tbl@tbl_pkey CONFIGURE ZONE USING constraints = '[+n1]';
+ALTER PARTITION pxx OF INDEX db.tbl@tbl_pkey CONFIGURE ZONE USING constraints = '[+n2]';
+----
+
+translate database=db table=tbl
+----
+/Table/106{-/1}                            range default
+/Table/106/1{-/3/4}                        constraints=[+n1]
+/Table/106/1/{3/4-4}                       constraints=[+n2]
+/Table/106/1/{4-5/6}                       constraints=[+n3]
+/Table/106/1/5/{6-7}                       constraints=[+n1]
+/Table/106/{1/5/7-2}                       constraints=[+n2]
+/Table/10{6/2-7}                           range default

--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/partition/multi_col_range_partitioning_sparse
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/partition/multi_col_range_partitioning_sparse
@@ -1,0 +1,20 @@
+exec-sql
+CREATE DATABASE db;
+CREATE TABLE db.tbl (a INT, b INT, PRIMARY KEY (a, b)) PARTITION BY RANGE (a, b) (
+  PARTITION p34  VALUES FROM (1, 2) TO (3, 4),
+  PARTITION p78 VALUES FROM (5, 6) TO (7, 8)
+);
+ALTER INDEX db.tbl@tbl_pkey CONFIGURE ZONE USING constraints = '[+n1]';
+ALTER PARTITION p34 OF INDEX db.tbl@tbl_pkey CONFIGURE ZONE USING constraints = '[+n2]';
+ALTER PARTITION p78 OF INDEX db.tbl@tbl_pkey CONFIGURE ZONE USING constraints = '[+n3]';
+----
+
+translate database=db table=tbl
+----
+/Table/106{-/1}                            range default
+/Table/106/1{-/1/2}                        constraints=[+n1]
+/Table/106/1/{1/2-3/4}                     constraints=[+n2]
+/Table/106/1/{3/4-5/6}                     constraints=[+n1]
+/Table/106/1/{5/6-7/8}                     constraints=[+n3]
+/Table/106/{1/7/8-2}                       constraints=[+n1]
+/Table/10{6/2-7}                           range default

--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/partition/scans
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/partition/scans
@@ -1,0 +1,22 @@
+exec-sql
+CREATE DATABASE db;
+CREATE TABLE db.tbl (a INT PRIMARY KEY, b INT) PARTITION BY LIST (a) (
+  PARTITION p3p5 VALUES IN ((3), (5)),
+  PARTITION p4 VALUES IN (4),
+  PARTITION pd VALUES IN (DEFAULT)
+);
+ALTER INDEX db.tbl@tbl_pkey CONFIGURE ZONE USING constraints = '[+n1]';
+ALTER PARTITION p3p5 OF INDEX db.tbl@tbl_pkey CONFIGURE ZONE USING constraints = '[+n2]';
+ALTER PARTITION p4 OF INDEX db.tbl@tbl_pkey CONFIGURE ZONE USING constraints = '[+n3]';
+ALTER PARTITION pd OF INDEX db.tbl@tbl_pkey CONFIGURE ZONE USING constraints = '[+n1]';
+----
+
+translate database=db table=tbl
+----
+/Table/106{-/1}                            range default
+/Table/106/1{-/3}                          constraints=[+n1]
+/Table/106/1/{3-4}                         constraints=[+n2]
+/Table/106/1/{4-5}                         constraints=[+n3]
+/Table/106/1/{5-6}                         constraints=[+n2]
+/Table/106/{1/6-2}                         constraints=[+n1]
+/Table/10{6/2-7}                           range default

--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/partition/secondary_index_list_partitioning
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/partition/secondary_index_list_partitioning
@@ -1,0 +1,19 @@
+exec-sql
+CREATE DATABASE db;
+CREATE TABLE db.tbl (a INT PRIMARY KEY, b INT, INDEX b_idx (b) PARTITION BY LIST (b) (
+  PARTITION p3 VALUES IN (3),
+  PARTITION p4 VALUES IN (4)
+));
+ALTER INDEX db.tbl@b_idx CONFIGURE ZONE USING constraints = '[+n2]';
+ALTER PARTITION p3 OF INDEX db.tbl@b_idx CONFIGURE ZONE USING constraints = '[+n2]';
+ALTER PARTITION p4 OF INDEX db.tbl@b_idx CONFIGURE ZONE USING constraints = '[+n3]';
+----
+
+translate database=db table=tbl
+----
+/Table/106{-/2}                            range default
+/Table/106/2{-/3}                          constraints=[+n2]
+/Table/106/2/{3-4}                         constraints=[+n2]
+/Table/106/2/{4-5}                         constraints=[+n3]
+/Table/106/{2/5-3}                         constraints=[+n2]
+/Table/10{6/3-7}                           range default

--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/partition/secondary_index_list_partitioning_default
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/partition/secondary_index_list_partitioning_default
@@ -1,0 +1,20 @@
+exec-sql
+CREATE DATABASE db;
+CREATE TABLE db.tbl (a INT PRIMARY KEY, b INT, INDEX b_idx (b) PARTITION BY LIST (b) (
+  PARTITION p4 VALUES IN (4),
+  PARTITION p5 VALUES IN (5),
+  PARTITION pd VALUES IN (DEFAULT)
+));
+ALTER PARTITION p4 OF INDEX db.tbl@b_idx CONFIGURE ZONE USING constraints = '[+n2]';
+ALTER PARTITION p5 OF INDEX db.tbl@b_idx CONFIGURE ZONE USING constraints = '[+n3]';
+ALTER PARTITION pd OF INDEX db.tbl@b_idx CONFIGURE ZONE USING constraints = '[+n1]';
+----
+
+translate database=db table=tbl
+----
+/Table/106{-/2}                            range default
+/Table/106/2{-/4}                          constraints=[+n1]
+/Table/106/2/{4-5}                         constraints=[+n2]
+/Table/106/2/{5-6}                         constraints=[+n3]
+/Table/106/{2/6-3}                         constraints=[+n1]
+/Table/10{6/3-7}                           range default

--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/partition/secondary_index_null
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/partition/secondary_index_null
@@ -1,0 +1,22 @@
+exec-sql
+CREATE DATABASE db;
+CREATE TABLE db.tbl (a INT PRIMARY KEY, b INT, INDEX b_idx (b) PARTITION BY LIST (b) (
+  PARTITION pl1 VALUES IN (NULL, 1),
+  PARTITION p3  VALUES IN (3)
+));
+ALTER INDEX db.tbl@b_idx CONFIGURE ZONE USING constraints = '[+n1]';
+ALTER PARTITION pl1 OF INDEX db.tbl@b_idx CONFIGURE ZONE USING constraints = '[+n2]';
+ALTER PARTITION p3 OF INDEX db.tbl@b_idx CONFIGURE ZONE USING constraints = '[+n3]';
+----
+
+translate database=db table=tbl
+----
+/Table/106{-/2}                            range default
+/Table/106/2{-/NULL}                       constraints=[+n1]
+/Table/106/2/{NULL-!NULL}                  constraints=[+n2]
+/Table/106/2/{!NULL-1}                     constraints=[+n1]
+/Table/106/2/{1-2}                         constraints=[+n2]
+/Table/106/2/{2-3}                         constraints=[+n1]
+/Table/106/2/{3-4}                         constraints=[+n3]
+/Table/106/{2/4-3}                         constraints=[+n1]
+/Table/10{6/3-7}                           range default

--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/partition/secondary_index_unpartitioned
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/partition/secondary_index_unpartitioned
@@ -1,0 +1,8 @@
+exec-sql
+CREATE DATABASE db;
+CREATE TABLE db.tbl (a INT PRIMARY KEY, b INT, INDEX b_idx (b));
+----
+
+translate database=db table=tbl
+----
+/Table/10{6-7}                             range default

--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/partition/single_col_list_partitioning
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/partition/single_col_list_partitioning
@@ -1,0 +1,16 @@
+exec-sql
+CREATE DATABASE db;
+CREATE TABLE db.tbl (a INT PRIMARY KEY) PARTITION BY LIST (a) (
+  PARTITION p3 VALUES IN (3),
+  PARTITION p4 VALUES IN (4)
+);
+ALTER PARTITION p3 OF INDEX db.tbl@tbl_pkey CONFIGURE ZONE USING constraints = '[+n2]';
+ALTER PARTITION p4 OF INDEX db.tbl@tbl_pkey CONFIGURE ZONE USING constraints = '[+n3]';
+----
+
+translate database=db table=tbl
+----
+/Table/106{-/1/3}                          range default
+/Table/106/1/{3-4}                         constraints=[+n2]
+/Table/106/1/{4-5}                         constraints=[+n3]
+/Table/10{6/1/5-7}                         range default

--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/partition/single_col_list_partitioning_default
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/partition/single_col_list_partitioning_default
@@ -1,0 +1,20 @@
+exec-sql
+CREATE DATABASE db;
+CREATE TABLE db.tbl (a INT PRIMARY KEY) PARTITION BY LIST (a) (
+  PARTITION p4 VALUES IN (4),
+  PARTITION p5 VALUES IN (5),
+  PARTITION pd VALUES IN (DEFAULT)
+);
+ALTER PARTITION p4 OF INDEX db.tbl@tbl_pkey CONFIGURE ZONE USING constraints = '[+n2]';
+ALTER PARTITION p5 OF INDEX db.tbl@tbl_pkey CONFIGURE ZONE USING constraints = '[+n3]';
+ALTER PARTITION pd OF INDEX db.tbl@tbl_pkey CONFIGURE ZONE USING constraints = '[+n1]';
+----
+
+translate database=db table=tbl
+----
+/Table/106{-/1}                            range default
+/Table/106/1{-/4}                          constraints=[+n1]
+/Table/106/1/{4-5}                         constraints=[+n2]
+/Table/106/1/{5-6}                         constraints=[+n3]
+/Table/106/{1/6-2}                         constraints=[+n1]
+/Table/10{6/2-7}                           range default

--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/partition/single_col_range_partitioning
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/partition/single_col_range_partitioning
@@ -1,0 +1,18 @@
+exec-sql
+CREATE DATABASE db;
+CREATE TABLE db.tbl (a INT PRIMARY KEY) PARTITION BY RANGE (a) (
+  PARTITION p3 VALUES FROM (MINVALUE) TO (3),
+  PARTITION p4 VALUES FROM (3) TO (4)
+);
+ALTER INDEX db.tbl@tbl_pkey CONFIGURE ZONE USING constraints = '[+n1]';
+ALTER PARTITION p3 OF INDEX db.tbl@tbl_pkey CONFIGURE ZONE USING constraints = '[+n2]';
+ALTER PARTITION p4 OF INDEX db.tbl@tbl_pkey CONFIGURE ZONE USING constraints = '[+n3]';
+----
+
+translate database=db table=tbl
+----
+/Table/106{-/1}                            range default
+/Table/106/1{-/3}                          constraints=[+n2]
+/Table/106/1/{3-4}                         constraints=[+n3]
+/Table/106/{1/4-2}                         constraints=[+n1]
+/Table/10{6/2-7}                           range default

--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/partition/single_col_range_partitioning_maxvalue
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/partition/single_col_range_partitioning_maxvalue
@@ -1,0 +1,19 @@
+exec-sql
+CREATE DATABASE db;
+CREATE TABLE db.tbl (a INT PRIMARY KEY) PARTITION BY RANGE (a) (
+  PARTITION p4 VALUES FROM (MINVALUE) TO (4),
+  PARTITION p5 VALUES FROM (4) TO (5),
+  PARTITION px VALUES FROM (5) TO (MAXVALUE)
+);
+ALTER PARTITION p4 OF INDEX db.tbl@tbl_pkey CONFIGURE ZONE USING constraints = '[+n1]';
+ALTER PARTITION p5 OF INDEX db.tbl@tbl_pkey CONFIGURE ZONE USING constraints = '[+n2]';
+ALTER PARTITION px OF INDEX db.tbl@tbl_pkey CONFIGURE ZONE USING constraints = '[+n3]';
+----
+
+translate database=db table=tbl
+----
+/Table/106{-/1}                            range default
+/Table/106/1{-/4}                          constraints=[+n1]
+/Table/106/1/{4-5}                         constraints=[+n2]
+/Table/106/{1/5-2}                         constraints=[+n3]
+/Table/10{6/2-7}                           range default

--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/partition/single_col_range_partitioning_sparse
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/partition/single_col_range_partitioning_sparse
@@ -1,0 +1,20 @@
+exec-sql
+CREATE DATABASE db;
+CREATE TABLE db.tbl (a INT PRIMARY KEY) PARTITION BY RANGE (a) (
+  PARTITION p1 VALUES FROM (1) TO (2),
+  PARTITION p3 VALUES FROM (3) TO (4)
+);
+ALTER INDEX db.tbl@tbl_pkey CONFIGURE ZONE USING constraints = '[+n1]';
+ALTER PARTITION p1 OF INDEX db.tbl@tbl_pkey CONFIGURE ZONE USING constraints = '[+n2]';
+ALTER PARTITION p3 OF INDEX db.tbl@tbl_pkey CONFIGURE ZONE USING constraints = '[+n3]';
+----
+
+translate database=db table=tbl
+----
+/Table/106{-/1}                            range default
+/Table/106/1{-/1}                          constraints=[+n1]
+/Table/106/1/{1-2}                         constraints=[+n2]
+/Table/106/1/{2-3}                         constraints=[+n1]
+/Table/106/1/{3-4}                         constraints=[+n3]
+/Table/106/{1/4-2}                         constraints=[+n1]
+/Table/10{6/2-7}                           range default

--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/partition/some_indexes
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/partition/some_indexes
@@ -1,0 +1,11 @@
+exec-sql
+CREATE DATABASE db;
+CREATE TABLE db.tbl (a INT PRIMARY KEY, b INT, c INT, INDEX idx1 (b), INDEX idx2 (c));
+ALTER INDEX db.tbl@idx2 CONFIGURE ZONE USING constraints = '[+n2]';
+----
+
+translate database=db table=tbl
+----
+/Table/106{-/3}                            range default
+/Table/106/{3-4}                           constraints=[+n2]
+/Table/10{6/4-7}                           range default

--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/partition/unpartitioned
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/partition/unpartitioned
@@ -1,0 +1,8 @@
+exec-sql
+CREATE DATABASE db;
+CREATE TABLE db.tbl (a INT PRIMARY KEY);
+----
+
+translate database=db table=tbl
+----
+/Table/10{6-7}                             range default


### PR DESCRIPTION
Fixes #49909

This rewrites TestInitialPartitioning subtests as SQLTranslator tests
so that they can be unskipped.

Release note: None