### PR TITLE
sql: fix index visibility parsing for small values

### DIFF
--- a/pkg/internal/sqlsmith/alter.go
+++ b/pkg/internal/sqlsmith/alter.go
@@ -364,11 +364,12 @@ func makeCreateIndex(s *Smither) (tree.Statement, bool) {
 		storing = append(storing, col.Name)
 	}
 
-	visibility := 1.0
+	invisibility := tree.IndexInvisibility{Value: 0.0}
 	if notvisible := s.d6() == 1; notvisible {
-		visibility = 0.0
+		invisibility.Value = 1.0
 		if s.coin() {
-			visibility = s.rnd.Float64() // [0.0, 1.0)
+			invisibility.Value = s.rnd.Float64() // [0.0, 1.0)
+			invisibility.FloatProvided = true
 		}
 	}
 
@@ -380,7 +381,7 @@ func makeCreateIndex(s *Smither) (tree.Statement, bool) {
 		Storing:      storing,
 		Inverted:     inverted,
 		Concurrently: s.coin(),
-		Invisibility: 1 - visibility,
+		Invisibility: invisibility,
 	}, true
 }
 

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -299,14 +299,14 @@ func (n *alterTableNode) startExec(params runParams) error {
 
 				activeVersion := params.ExecCfg().Settings.Version.ActiveVersion(params.ctx)
 				if !activeVersion.IsActive(clusterversion.V23_2_PartiallyVisibleIndexes) &&
-					d.Invisibility > 0.0 && d.Invisibility < 1.0 {
+					d.Invisibility.Value > 0.0 && d.Invisibility.Value < 1.0 {
 					return unimplemented.New("partially visible indexes", "partially visible indexes are not yet supported")
 				}
 				idx := descpb.IndexDescriptor{
 					Name:             string(d.Name),
 					Unique:           true,
-					NotVisible:       d.Invisibility != 0.0,
-					Invisibility:     d.Invisibility,
+					NotVisible:       d.Invisibility.Value != 0.0,
+					Invisibility:     d.Invisibility.Value,
 					StoreColumnNames: d.Storing.ToStrings(),
 					CreatedAtNanos:   params.EvalContext().GetTxnTimestamp(time.Microsecond).UnixNano(),
 				}

--- a/pkg/sql/create_index.go
+++ b/pkg/sql/create_index.go
@@ -200,7 +200,7 @@ func makeIndexDescriptor(
 	}
 
 	if !activeVersion.IsActive(clusterversion.V23_2_PartiallyVisibleIndexes) &&
-		n.Invisibility > 0.0 && n.Invisibility < 1.0 {
+		n.Invisibility.Value > 0.0 && n.Invisibility.Value < 1.0 {
 		return nil, unimplemented.New("partially visible indexes", "partially visible indexes are not yet supported")
 	}
 	indexDesc := descpb.IndexDescriptor{
@@ -209,8 +209,8 @@ func makeIndexDescriptor(
 		StoreColumnNames:  n.Storing.ToStrings(),
 		CreatedExplicitly: true,
 		CreatedAtNanos:    params.EvalContext().GetTxnTimestamp(time.Microsecond).UnixNano(),
-		NotVisible:        n.Invisibility != 0.0,
-		Invisibility:      n.Invisibility,
+		NotVisible:        n.Invisibility.Value != 0.0,
+		Invisibility:      n.Invisibility.Value,
 	}
 
 	if n.Inverted {

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -708,7 +708,7 @@ func addUniqueWithoutIndexTableDef(
 			"partitioned unique constraints without an index are not supported",
 		)
 	}
-	if d.Invisibility != 0.0 {
+	if d.Invisibility.Value != 0.0 {
 		// Theoretically, this should never happen because this is not supported by
 		// the parser. This is just a safe check.
 		return pgerror.Newf(pgcode.FeatureNotSupported,
@@ -1829,15 +1829,15 @@ func NewTableDesc(
 				return nil, err
 			}
 			if !version.IsActive(clusterversion.V23_2_PartiallyVisibleIndexes) &&
-				d.Invisibility > 0.0 && d.Invisibility < 1.0 {
+				d.Invisibility.Value > 0.0 && d.Invisibility.Value < 1.0 {
 				return nil, unimplemented.New("partially visible indexes", "partially visible indexes are not yet supported")
 			}
 			idx := descpb.IndexDescriptor{
 				Name:             string(d.Name),
 				StoreColumnNames: d.Storing.ToStrings(),
 				Version:          indexEncodingVersion,
-				NotVisible:       d.Invisibility != 0.0,
-				Invisibility:     d.Invisibility,
+				NotVisible:       d.Invisibility.Value != 0.0,
+				Invisibility:     d.Invisibility.Value,
 			}
 			if d.Inverted {
 				idx.Type = descpb.IndexDescriptor_INVERTED
@@ -1948,7 +1948,7 @@ func NewTableDesc(
 				return nil, err
 			}
 			if !version.IsActive(clusterversion.V23_2_PartiallyVisibleIndexes) &&
-				d.Invisibility > 0.0 && d.Invisibility < 1.0 {
+				d.Invisibility.Value > 0.0 && d.Invisibility.Value < 1.0 {
 				return nil, unimplemented.New("partially visible indexes", "partially visible indexes are not yet supported")
 			}
 			idx := descpb.IndexDescriptor{
@@ -1956,8 +1956,8 @@ func NewTableDesc(
 				Unique:           true,
 				StoreColumnNames: d.Storing.ToStrings(),
 				Version:          indexEncodingVersion,
-				NotVisible:       d.Invisibility != 0.0,
-				Invisibility:     d.Invisibility,
+				NotVisible:       d.Invisibility.Value != 0.0,
+				Invisibility:     d.Invisibility.Value,
 			}
 			columns := d.Columns
 			if d.Sharded != nil {
@@ -2660,7 +2660,7 @@ func replaceLikeTableOpts(n *tree.CreateTable, params runParams) (tree.TableDefs
 					Inverted:     idx.GetType() == descpb.IndexDescriptor_INVERTED,
 					Storing:      make(tree.NameList, 0, idx.NumSecondaryStoredColumns()),
 					Columns:      make(tree.IndexElemList, 0, idx.NumKeyColumns()),
-					Invisibility: idx.GetInvisibility(),
+					Invisibility: tree.IndexInvisibility{Value: idx.GetInvisibility()},
 				}
 				numColumns := idx.NumKeyColumns()
 				if idx.IsSharded() {

--- a/pkg/sql/opt/testutils/testcat/create_table.go
+++ b/pkg/sql/opt/testutils/testcat/create_table.go
@@ -863,7 +863,7 @@ func (tt *Table) addIndexWithVersion(
 		IdxZone:      cat.EmptyZone(),
 		table:        tt,
 		version:      version,
-		Invisibility: def.Invisibility,
+		Invisibility: def.Invisibility.Value,
 	}
 
 	// Look for name suffixes indicating this is a mutation index.

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -639,6 +639,9 @@ func (u *sqlSymUnion) idxElem() tree.IndexElem {
 func (u *sqlSymUnion) idxElems() tree.IndexElemList {
     return u.val.(tree.IndexElemList)
 }
+func (u *sqlSymUnion) indexInvisibility() tree.IndexInvisibility {
+    return u.val.(tree.IndexInvisibility)
+}
 func (u *sqlSymUnion) dropBehavior() tree.DropBehavior {
     return u.val.(tree.DropBehavior)
 }
@@ -1446,6 +1449,7 @@ func (u *sqlSymUnion) showCreateFormatOption() tree.ShowCreateFormatOption {
 %type <tree.OrderBy> sort_clause single_sort_clause opt_sort_clause
 %type <[]*tree.Order> sortby_list
 %type <tree.IndexElemList> index_params create_as_params
+%type <tree.IndexInvisibility> opt_index_visible alter_index_visible
 %type <tree.NameList> name_list privilege_list
 %type <[]int32> opt_array_bounds
 %type <*tree.Batch> opt_batch_clause
@@ -1570,7 +1574,7 @@ func (u *sqlSymUnion) showCreateFormatOption() tree.ShowCreateFormatOption {
 %type <str> extract_arg
 %type <bool> opt_varying
 
-%type <*tree.NumVal> signed_iconst only_signed_iconst alter_index_visible opt_index_visible
+%type <*tree.NumVal> signed_iconst only_signed_iconst
 %type <*tree.NumVal> signed_fconst only_signed_fconst
 %type <int32> iconst32
 %type <int64> signed_iconst64
@@ -2390,27 +2394,33 @@ alter_relocate_index_stmt:
 alter_index_visible_stmt:
   ALTER INDEX table_index_name alter_index_visible
   {
-    invisibility, _ := constant.Float64Val($4.numVal().AsConstantValue())
-    $$.val = &tree.AlterIndexVisible{Index: $3.tableIndexName(), Invisibility: invisibility, IfExists: false}
+    $$.val = &tree.AlterIndexVisible{
+      Index: $3.tableIndexName(),
+      Invisibility: $4.indexInvisibility(),
+      IfExists: false,
+    }
   }
 | ALTER INDEX IF EXISTS table_index_name alter_index_visible
   {
-    invisibility, _ := constant.Float64Val($6.numVal().AsConstantValue())
-    $$.val = &tree.AlterIndexVisible{Index: $5.tableIndexName(), Invisibility: invisibility, IfExists: true}
+    $$.val = &tree.AlterIndexVisible{
+      Index: $5.tableIndexName(),
+      Invisibility: $6.indexInvisibility(),
+      IfExists: true,
+    }
   }
 
 alter_index_visible:
   NOT VISIBLE
   {
-   $$.val = tree.NewNumVal(constant.MakeFloat64(1.0), "1.0", false /*negative*/)
+    $$.val = tree.IndexInvisibility{Value: 1.0}
   }
 | INVISIBLE
   {
-    $$.val = tree.NewNumVal(constant.MakeFloat64(1.0), "1.0", false /*negative*/)
+    $$.val = tree.IndexInvisibility{Value: 1.0}
   }
 | VISIBLE
   {
-   $$.val = tree.NewNumVal(constant.MakeFloat64(0.0), "0.0", false /*negative*/)
+    $$.val = tree.IndexInvisibility{Value: 0.0}
   }
 | VISIBILITY FCONST
   {
@@ -2420,9 +2430,7 @@ alter_index_visible:
         return 1
       }
     invisibilityConst := 1.0 - visibilityConst
-    invisibilityStr := fmt.Sprintf("%.2f", invisibilityConst)
-    treeNumVal := tree.NewNumVal(constant.MakeFloat64(invisibilityConst), invisibilityStr, false /*negative*/)
-    $$.val = treeNumVal
+    $$.val = tree.IndexInvisibility{Value: invisibilityConst, FloatProvided: true}
   }
 
 // Note: even though the ALTER RANGE ... CONFIGURE ZONE syntax only
@@ -9911,7 +9919,6 @@ generated_by_default_as:
 index_def:
   INDEX_BEFORE_PAREN '(' index_params ')' opt_hash_sharded opt_storing opt_partition_by_index opt_with_storage_parameter_list opt_where_clause opt_index_visible
   {
-    invisibility, _ := constant.Float64Val($10.numVal().AsConstantValue())
     $$.val = &tree.IndexTableDef{
       Name:             "",
       Columns:          $3.idxElems(),
@@ -9920,12 +9927,11 @@ index_def:
       PartitionByIndex: $7.partitionByIndex(),
       StorageParams:    $8.storageParams(),
       Predicate:        $9.expr(),
-      Invisibility:     invisibility,
+      Invisibility:     $10.indexInvisibility(),
     }
   }
 | INDEX_BEFORE_NAME_THEN_PAREN name '(' index_params ')' opt_hash_sharded opt_storing opt_partition_by_index opt_with_storage_parameter_list opt_where_clause opt_index_visible
   {
-    invisibility, _ := constant.Float64Val($11.numVal().AsConstantValue())
     $$.val = &tree.IndexTableDef{
       Name:             tree.Name($2),
       Columns:          $4.idxElems(),
@@ -9934,12 +9940,11 @@ index_def:
       PartitionByIndex: $8.partitionByIndex(),
       StorageParams:    $9.storageParams(),
       Predicate:        $10.expr(),
-      Invisibility:     invisibility,
+      Invisibility:     $11.indexInvisibility(),
     }
   }
 | UNIQUE INDEX opt_index_name '(' index_params ')' opt_hash_sharded opt_storing opt_partition_by_index opt_with_storage_parameter_list opt_where_clause opt_index_visible
   {
-    invisibility, _ := constant.Float64Val($12.numVal().AsConstantValue())
     $$.val = &tree.UniqueConstraintTableDef{
       IndexTableDef: tree.IndexTableDef {
         Name:             tree.Name($3),
@@ -9949,13 +9954,12 @@ index_def:
         PartitionByIndex: $9.partitionByIndex(),
         StorageParams:    $10.storageParams(),
         Predicate:        $11.expr(),
-        Invisibility:     invisibility,
+        Invisibility:     $12.indexInvisibility(),
       },
     }
   }
 | INVERTED INDEX_BEFORE_PAREN '(' index_params ')' opt_partition_by_index opt_with_storage_parameter_list opt_where_clause opt_index_visible
   {
-    invisibility, _ := constant.Float64Val($9.numVal().AsConstantValue())
     $$.val = &tree.IndexTableDef{
       Name:             "",
       Columns:          $4.idxElems(),
@@ -9963,12 +9967,11 @@ index_def:
       PartitionByIndex: $6.partitionByIndex(),
       StorageParams:    $7.storageParams(),
       Predicate:        $8.expr(),
-      Invisibility:     invisibility,
+      Invisibility:     $9.indexInvisibility(),
     }
   }
 | INVERTED INDEX_BEFORE_NAME_THEN_PAREN name '(' index_params ')' opt_partition_by_index opt_with_storage_parameter_list opt_where_clause opt_index_visible
   {
-    invisibility, _ := constant.Float64Val($10.numVal().AsConstantValue())
     $$.val = &tree.IndexTableDef{
       Name:             tree.Name($3),
       Columns:          $5.idxElems(),
@@ -9976,7 +9979,7 @@ index_def:
       PartitionByIndex: $7.partitionByIndex(),
       StorageParams:    $8.storageParams(),
       Predicate:        $9.expr(),
-      Invisibility:     invisibility,
+      Invisibility:     $10.indexInvisibility(),
     }
   }
 
@@ -10876,7 +10879,6 @@ composite_type_list:
 create_index_stmt:
   CREATE opt_unique INDEX opt_concurrently opt_index_name ON table_name opt_index_access_method '(' index_params ')' opt_hash_sharded opt_storing opt_partition_by_index opt_with_storage_parameter_list opt_where_clause opt_index_visible
   {
-    invisibility, _ := constant.Float64Val($17.numVal().AsConstantValue())
     table := $7.unresolvedObjectName().ToTableName()
     $$.val = &tree.CreateIndex{
       Name:             tree.Name($5),
@@ -10890,12 +10892,11 @@ create_index_stmt:
       Predicate:        $16.expr(),
       Inverted:         $8.bool(),
       Concurrently:     $4.bool(),
-      Invisibility:     invisibility,
+      Invisibility:     $17.indexInvisibility(),
     }
   }
 | CREATE opt_unique INDEX opt_concurrently IF NOT EXISTS index_name ON table_name opt_index_access_method '(' index_params ')' opt_hash_sharded opt_storing opt_partition_by_index opt_with_storage_parameter_list opt_where_clause opt_index_visible
   {
-    invisibility, _ := constant.Float64Val($20.numVal().AsConstantValue())
     table := $10.unresolvedObjectName().ToTableName()
     $$.val = &tree.CreateIndex{
       Name:             tree.Name($8),
@@ -10910,12 +10911,11 @@ create_index_stmt:
       StorageParams:    $18.storageParams(),
       Predicate:        $19.expr(),
       Concurrently:     $4.bool(),
-      Invisibility:     invisibility,
+      Invisibility:     $20.indexInvisibility(),
     }
   }
 | CREATE opt_unique INVERTED INDEX opt_concurrently opt_index_name ON table_name '(' index_params ')' opt_storing opt_partition_by_index opt_with_storage_parameter_list opt_where_clause opt_index_visible
   {
-    invisibility, _ := constant.Float64Val($16.numVal().AsConstantValue())
     table := $8.unresolvedObjectName().ToTableName()
     $$.val = &tree.CreateIndex{
       Name:             tree.Name($6),
@@ -10928,12 +10928,11 @@ create_index_stmt:
       StorageParams:    $14.storageParams(),
       Predicate:        $15.expr(),
       Concurrently:     $5.bool(),
-      Invisibility:     invisibility,
+      Invisibility:     $16.indexInvisibility(),
     }
   }
 | CREATE opt_unique INVERTED INDEX opt_concurrently IF NOT EXISTS index_name ON table_name '(' index_params ')' opt_storing opt_partition_by_index opt_with_storage_parameter_list opt_where_clause opt_index_visible
   {
-    invisibility, _ := constant.Float64Val($19.numVal().AsConstantValue())
     table := $11.unresolvedObjectName().ToTableName()
     $$.val = &tree.CreateIndex{
       Name:             tree.Name($9),
@@ -10947,7 +10946,7 @@ create_index_stmt:
       StorageParams:    $17.storageParams(),
       Predicate:        $18.expr(),
       Concurrently:     $5.bool(),
-      Invisibility:     invisibility,
+      Invisibility:     $19.indexInvisibility(),
     }
   }
 | CREATE opt_unique INDEX error // SHOW HELP: CREATE INDEX
@@ -11070,15 +11069,15 @@ opt_asc_desc:
 opt_index_visible:
   NOT VISIBLE
   {
-    $$.val = tree.NewNumVal(constant.MakeFloat64(1.0), "1.0", false /*negative*/)
+    $$.val = tree.IndexInvisibility{Value: 1.0}
   }
 | INVISIBLE
   {
-    $$.val = tree.NewNumVal(constant.MakeFloat64(1.0), "1.0", false /*negative*/)
+    $$.val = tree.IndexInvisibility{Value: 1.0}
   }
 | VISIBLE
   {
-    $$.val = tree.NewNumVal(constant.MakeFloat64(0.0), "0.0", false /*negative*/)
+    $$.val = tree.IndexInvisibility{Value: 0.0}
   }
 | VISIBILITY FCONST
   {
@@ -11088,13 +11087,11 @@ opt_index_visible:
         return 1
       }
     invisibilityConst := 1.0 - visibilityConst
-    invisibilityStr := fmt.Sprintf("%.2f", invisibilityConst)
-    treeNumVal := tree.NewNumVal(constant.MakeFloat64(invisibilityConst), invisibilityStr, false /*negative*/)
-    $$.val = treeNumVal
+    $$.val = tree.IndexInvisibility{Value: invisibilityConst, FloatProvided: true}
   }
 | /* EMPTY */
   {
-    $$.val = tree.NewNumVal(constant.MakeFloat64(0.0), "0.0", false /*negative*/)
+    $$.val = tree.IndexInvisibility{Value: 0.0}
   }
 
 alter_database_to_schema_stmt:

--- a/pkg/sql/parser/testdata/alter_index
+++ b/pkg/sql/parser/testdata/alter_index
@@ -431,3 +431,11 @@ ALTER INDEX db.t@i VISIBILITY 0.20 -- normalized!
 ALTER INDEX db.t@i VISIBILITY 0.20 -- fully parenthesized
 ALTER INDEX db.t@i VISIBILITY 0.20 -- literals removed
 ALTER INDEX _._@_ VISIBILITY 0.20 -- identifiers removed
+
+parse
+ALTER INDEX i VISIBILITY 7.379652426127388e-12
+----
+ALTER INDEX i VISIBILITY 0.00 -- normalized!
+ALTER INDEX i VISIBILITY 0.00 -- fully parenthesized
+ALTER INDEX i VISIBILITY 0.00 -- literals removed
+ALTER INDEX _ VISIBILITY 0.00 -- identifiers removed

--- a/pkg/sql/parser/testdata/create_index
+++ b/pkg/sql/parser/testdata/create_index
@@ -460,3 +460,11 @@ CREATE INDEX a ON b (c) VISIBILITY 0.20 -- normalized!
 CREATE INDEX a ON b (c) VISIBILITY 0.20 -- fully parenthesized
 CREATE INDEX a ON b (c) VISIBILITY 0.20 -- literals removed
 CREATE INDEX _ ON _ (_) VISIBILITY 0.20 -- identifiers removed
+
+parse
+CREATE INDEX ON t(a) VISIBILITY 7.379652426127388e-12
+----
+CREATE INDEX ON t (a) VISIBILITY 0.00 -- normalized!
+CREATE INDEX ON t (a) VISIBILITY 0.00 -- fully parenthesized
+CREATE INDEX ON t (a) VISIBILITY 0.00 -- literals removed
+CREATE INDEX ON _ (_) VISIBILITY 0.00 -- identifiers removed

--- a/pkg/sql/parser/testdata/create_table
+++ b/pkg/sql/parser/testdata/create_table
@@ -2459,6 +2459,14 @@ CREATE TABLE a (b INT8, c STRING, INDEX (b ASC, c DESC) STORING (c) VISIBILITY 0
 CREATE TABLE a (b INT8, c STRING, INDEX (b ASC, c DESC) STORING (c) VISIBILITY 0.20) -- literals removed
 CREATE TABLE _ (_ INT8, _ STRING, INDEX (_ ASC, _ DESC) STORING (_) VISIBILITY 0.20) -- identifiers removed
 
+parse
+CREATE TABLE t (a INT, INDEX (a) VISIBILITY 7.379652426127388e-12)
+----
+CREATE TABLE t (a INT8, INDEX (a) VISIBILITY 0.00) -- normalized!
+CREATE TABLE t (a INT8, INDEX (a) VISIBILITY 0.00) -- fully parenthesized
+CREATE TABLE t (a INT8, INDEX (a) VISIBILITY 0.00) -- literals removed
+CREATE TABLE _ (_ INT8, INDEX (_) VISIBILITY 0.00) -- identifiers removed
+
 # Creating an invisible unique index inside a table definition is supported by
 # the grammar rule, but the parser will throw an error for the following
 # statement. This is because the parser is doing a round trip in

--- a/pkg/sql/randgen/schema.go
+++ b/pkg/sql/randgen/schema.go
@@ -234,12 +234,13 @@ func RandCreateTableWithColumnIndexNumberGeneratorAndName(
 			// definition, we are only supporting not visible non-unique indexes for
 			// rand. Since not visible indexes are pretty rare, we are assigning index
 			// visibility randomly with a float [0.0,1.0) 1/6 of the time.
-			indexDef.Invisibility = 0.0
+			indexDef.Invisibility.Value = 0.0
 			if notvisible := rng.Intn(6) == 0; notvisible {
-				indexDef.Invisibility = 1.0
+				indexDef.Invisibility.Value = 1.0
 				if allowPartiallyVisibleIndex {
 					if rng.Intn(2) == 0 {
-						indexDef.Invisibility = 1 - rng.Float64()
+						indexDef.Invisibility.Value = 1 - rng.Float64()
+						indexDef.Invisibility.FloatProvided = true
 					}
 				}
 			}

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_add_constraint.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_add_constraint.go
@@ -443,7 +443,7 @@ func alterTableAddUniqueWithoutIndex(
 			"partitioned unique constraints without an index are not supported",
 		))
 	}
-	if d.Invisibility != 0.0 {
+	if d.Invisibility.Value != 0.0 {
 		// Theoretically, this should never happen because this is not supported by
 		// the parser. This is just a safe check.
 		panic(pgerror.Newf(pgcode.FeatureNotSupported,

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_index.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_index.go
@@ -86,7 +86,7 @@ func CreateIndex(b BuildCtx, n *tree.CreateIndex) {
 	}
 	activeVersion := b.EvalCtx().Settings.Version.ActiveVersion(context.TODO())
 	if !activeVersion.IsActive(clusterversion.V23_2_PartiallyVisibleIndexes) &&
-		n.Invisibility > 0.0 && n.Invisibility < 1.0 {
+		n.Invisibility.Value > 0.0 && n.Invisibility.Value < 1.0 {
 		panic(unimplemented.New("partially visible indexes", "partially visible indexes are not yet supported"))
 	}
 	var idxSpec indexSpec
@@ -95,8 +95,8 @@ func CreateIndex(b BuildCtx, n *tree.CreateIndex) {
 			IsUnique:       n.Unique,
 			IsInverted:     n.Inverted,
 			IsConcurrently: n.Concurrently,
-			IsNotVisible:   n.Invisibility != 0.0,
-			Invisibility:   n.Invisibility,
+			IsNotVisible:   n.Invisibility.Value != 0.0,
+			Invisibility:   n.Invisibility.Value,
 		},
 	}
 	var relation scpb.Element

--- a/pkg/sql/sem/tree/alter_index.go
+++ b/pkg/sql/sem/tree/alter_index.go
@@ -70,7 +70,7 @@ func (node *AlterIndexPartitionBy) Format(ctx *FmtCtx) {
 // AlterIndexVisible represents a ALTER INDEX ... [VISIBLE | NOT VISIBLE] statement.
 type AlterIndexVisible struct {
 	Index        TableIndexName
-	Invisibility float64
+	Invisibility IndexInvisibility
 	IfExists     bool
 }
 
@@ -83,13 +83,12 @@ func (node *AlterIndexVisible) Format(ctx *FmtCtx) {
 		ctx.WriteString("IF EXISTS ")
 	}
 	ctx.FormatNode(&node.Index)
-	invisibility := node.Invisibility
-
-	if invisibility == 0.0 {
-		ctx.WriteString(" VISIBLE")
-	} else if invisibility == 1.0 {
+	switch {
+	case node.Invisibility.FloatProvided:
+		ctx.WriteString(" VISIBILITY " + fmt.Sprintf("%.2f", 1-node.Invisibility.Value))
+	case node.Invisibility.Value == 1.0:
 		ctx.WriteString(" NOT VISIBLE")
-	} else {
-		ctx.WriteString(" VISIBILITY " + fmt.Sprintf("%.2f", 1-invisibility))
+	default:
+		ctx.WriteString(" VISIBLE")
 	}
 }

--- a/pkg/sql/sem/tree/create.go
+++ b/pkg/sql/sem/tree/create.go
@@ -228,6 +228,11 @@ func (l *IndexElemList) doc(p *PrettyCfg) pretty.Doc {
 	return p.commaSeparated(d...)
 }
 
+type IndexInvisibility struct {
+	Value         float64
+	FloatProvided bool
+}
+
 // CreateIndex represents a CREATE INDEX statement.
 type CreateIndex struct {
 	Name        Name
@@ -244,7 +249,7 @@ type CreateIndex struct {
 	StorageParams    StorageParams
 	Predicate        Expr
 	Concurrently     bool
-	Invisibility     float64
+	Invisibility     IndexInvisibility
 }
 
 // Format implements the NodeFormatter interface.
@@ -296,12 +301,11 @@ func (node *CreateIndex) Format(ctx *FmtCtx) {
 		ctx.WriteString(" WHERE ")
 		ctx.FormatNode(node.Predicate)
 	}
-	if invisibility := node.Invisibility; invisibility != 0.0 {
-		if invisibility == 1.0 {
-			ctx.WriteString(" NOT VISIBLE")
-		} else {
-			ctx.WriteString(" VISIBILITY " + fmt.Sprintf("%.2f", 1-invisibility))
-		}
+	switch {
+	case node.Invisibility.FloatProvided:
+		ctx.WriteString(" VISIBILITY " + fmt.Sprintf("%.2f", 1-node.Invisibility.Value))
+	case node.Invisibility.Value == 1.0:
+		ctx.WriteString(" NOT VISIBLE")
 	}
 }
 
@@ -1035,7 +1039,7 @@ type IndexTableDef struct {
 	PartitionByIndex *PartitionByIndex
 	StorageParams    StorageParams
 	Predicate        Expr
-	Invisibility     float64
+	Invisibility     IndexInvisibility
 }
 
 // Format implements the NodeFormatter interface.
@@ -1071,13 +1075,11 @@ func (node *IndexTableDef) Format(ctx *FmtCtx) {
 		ctx.WriteString(" WHERE ")
 		ctx.FormatNode(node.Predicate)
 	}
-
-	if invisibility := node.Invisibility; invisibility != 0.0 {
-		if invisibility == 1.0 {
-			ctx.WriteString(" NOT VISIBLE")
-		} else {
-			ctx.WriteString(" VISIBILITY " + fmt.Sprintf("%.2f", 1-invisibility))
-		}
+	switch {
+	case node.Invisibility.FloatProvided:
+		ctx.WriteString(" VISIBILITY " + fmt.Sprintf("%.2f", 1-node.Invisibility.Value))
+	case node.Invisibility.Value == 1.0:
+		ctx.WriteString(" NOT VISIBLE")
 	}
 }
 
@@ -1156,13 +1158,11 @@ func (node *UniqueConstraintTableDef) Format(ctx *FmtCtx) {
 		ctx.WriteString(" WHERE ")
 		ctx.FormatNode(node.Predicate)
 	}
-
-	if invisibility := node.Invisibility; invisibility != 0.0 {
-		if invisibility == 1.0 {
-			ctx.WriteString(" NOT VISIBLE")
-		} else {
-			ctx.WriteString(" VISIBILITY " + fmt.Sprintf("%.2f", 1-invisibility))
-		}
+	switch {
+	case node.Invisibility.FloatProvided:
+		ctx.WriteString(" VISIBILITY " + fmt.Sprintf("%.2f", 1-node.Invisibility.Value))
+	case node.Invisibility.Value == 1.0:
+		ctx.WriteString(" NOT VISIBLE")
 	}
 	if node.StorageParams != nil {
 		ctx.WriteString(" WITH (")

--- a/pkg/sql/sem/tree/pretty.go
+++ b/pkg/sql/sem/tree/pretty.go
@@ -1684,12 +1684,12 @@ func (node *CreateIndex) doc(p *PrettyCfg) pretty.Doc {
 	if node.Predicate != nil {
 		clauses = append(clauses, p.nestUnder(pretty.Keyword("WHERE"), p.Doc(node.Predicate)))
 	}
-	if invisibility := node.Invisibility; invisibility != 0.0 {
-		if invisibility == 1.0 {
-			clauses = append(clauses, pretty.Keyword(" NOT VISIBLE"))
-		} else {
-			clauses = append(clauses, pretty.Keyword(" VISIBILITY "+fmt.Sprintf("%.2f", 1-invisibility)))
-		}
+	switch {
+	case node.Invisibility.FloatProvided:
+		clauses = append(clauses,
+			pretty.Keyword(" VISIBILITY "+fmt.Sprintf("%.2f", 1-node.Invisibility.Value)))
+	case node.Invisibility.Value == 1.0:
+		clauses = append(clauses, pretty.Keyword(" NOT VISIBLE"))
 	}
 	return p.nestUnder(
 		pretty.Fold(pretty.ConcatSpace, title...),
@@ -1761,14 +1761,13 @@ func (node *IndexTableDef) doc(p *PrettyCfg) pretty.Doc {
 	if node.Predicate != nil {
 		clauses = append(clauses, p.nestUnder(pretty.Keyword("WHERE"), p.Doc(node.Predicate)))
 	}
-	if invisibility := node.Invisibility; invisibility != 0.0 {
-		if invisibility == 1.0 {
-			clauses = append(clauses, pretty.Keyword(" NOT VISIBLE"))
-		} else {
-			clauses = append(clauses, pretty.Keyword(" VISIBILITY "+fmt.Sprintf("%.2f", 1-invisibility)))
-		}
+	switch {
+	case node.Invisibility.FloatProvided:
+		clauses = append(clauses,
+			pretty.Keyword(" VISIBILITY "+fmt.Sprintf("%.2f", 1-node.Invisibility.Value)))
+	case node.Invisibility.Value == 1.0:
+		clauses = append(clauses, pretty.Keyword(" NOT VISIBLE"))
 	}
-
 	if len(clauses) == 0 {
 		return title
 	}
@@ -1825,15 +1824,13 @@ func (node *UniqueConstraintTableDef) doc(p *PrettyCfg) pretty.Doc {
 	if node.Predicate != nil {
 		clauses = append(clauses, p.nestUnder(pretty.Keyword("WHERE"), p.Doc(node.Predicate)))
 	}
-
-	if invisibility := node.Invisibility; invisibility != 0.0 {
-		if invisibility == 1.0 {
-			clauses = append(clauses, pretty.Keyword(" NOT VISIBLE"))
-		} else {
-			clauses = append(clauses, pretty.Keyword(" VISIBILITY "+fmt.Sprintf("%.2f", 1-invisibility)))
-		}
+	switch {
+	case node.Invisibility.FloatProvided:
+		clauses = append(clauses,
+			pretty.Keyword(" VISIBILITY "+fmt.Sprintf("%.2f", 1-node.Invisibility.Value)))
+	case node.Invisibility.Value == 1.0:
+		clauses = append(clauses, pretty.Keyword(" NOT VISIBLE"))
 	}
-
 	if node.StorageParams != nil {
 		clauses = append(clauses, p.bracketKeyword(
 			"WITH", "(",


### PR DESCRIPTION
This commit updates the parser and AST to keep track of whether or not
an index `VISIBILITY` float was provided in a `CREATE TABLE`,
`CREATE INDEX`, or `ALTER INDEX` statement. This allows the statements
to be round-tripped correctly with very low float values that would be
rounded to zero and change the `VISIBILITY` clause into `NOT VISIBLE`.

Fixes #108083

Release note: None
