### PR TITLE
sql: fix pg_catalog to show correct collation

### DIFF
--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -1267,17 +1267,17 @@ https://www.postgresql.org/docs/9.5/catalog-pg-database.html`,
 					ownerOid,                    // datdba
 					// If there is a change in encoding value for the database we must update
 					// the definitions of getdatabaseencoding within pg_builtin.
-					builtins.DatEncodingUTFId,  // encoding
-					builtins.DatEncodingEnUTF8, // datcollate
-					builtins.DatEncodingEnUTF8, // datctype
-					tree.DBoolFalse,            // datistemplate
-					tree.DBoolTrue,             // datallowconn
-					negOneVal,                  // datconnlimit
-					oidZero,                    // datlastsysoid
-					tree.DNull,                 // datfrozenxid
-					tree.DNull,                 // datminmxid
-					oidZero,                    // dattablespace
-					tree.DNull,                 // datacl
+					builtins.DatEncodingUTFId,       // encoding
+					tree.NewDString(PgCompatLocale), // datcollate
+					tree.NewDString(PgCompatLocale), // datctype
+					tree.DBoolFalse,                 // datistemplate
+					tree.DBoolTrue,                  // datallowconn
+					negOneVal,                       // datconnlimit
+					oidZero,                         // datlastsysoid
+					tree.DNull,                      // datfrozenxid
+					tree.DNull,                      // datminmxid
+					oidZero,                         // dattablespace
+					tree.DNull,                      // datacl
 				)
 			})
 	},

--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -297,10 +297,7 @@ func makeTypeIOBuiltins(builtinPrefix string, typ *types.T) map[string]builtinDe
 var (
 	// DatEncodingUTFId is the encoding ID for our only supported database
 	// encoding, UTF8.
-	DatEncodingUTFId = tree.NewDInt(6)
-	// DatEncodingEnUTF8 is the encoding name for our only supported database
-	// encoding, UTF8.
-	DatEncodingEnUTF8        = tree.NewDString("en_US.utf8")
+	DatEncodingUTFId         = tree.NewDInt(6)
 	datEncodingUTF8ShortName = tree.NewDString("UTF8")
 )
 


### PR DESCRIPTION
This makes the collation reported in pg_catalog consistent with the one in LC_COLLATE.

Epic: None
Release note: None