### PR TITLE
backupccl: avoid creating spans that start or end on a .Next() key

### DIFF
--- a/pkg/ccl/backupccl/restore_span_covering.go
+++ b/pkg/ccl/backupccl/restore_span_covering.go
@@ -401,14 +401,15 @@ func (f spanCoveringFilter) getLayersCoveredLater(
 // The cover for those spans would look like:
 //
 //	[a, b): 1, 6
-//	[b, f): 1, 2, 4, 6
+//	[b, c): 1, 4, 6
+//	[c, f): 1, 2, 4, 6
 //	[f, g): 6
 //	[g, h): 5, 6
 //	[h, i): 3, 5, 6, 8
 //	[l, m): 9
 //
-// This cover is created by iterating through the start and end keys of all the
-// files in the backup in key order via fileSpanStartAndEndKeyIterator. The
+// This cover is created by iterating through the start keys of all the
+// files in the backup in key order via fileSpanStartKeyIterator. The
 // cover spans are initially just the spans between each pair of adjacent keys
 // yielded by the iterator. We then iterate through each cover span and find all
 // the overlapping files. If the files that overlap a cover span is a subset of
@@ -444,10 +445,12 @@ func generateAndSendImportSpans(
 		return nil
 	}
 
-	startEndKeyIt, err := newFileSpanStartAndEndKeyIterator(ctx, backups, layerToBackupManifestFileIterFactory)
+	startKeyIt, err := newFileSpanStartKeyIterator(ctx, backups, layerToBackupManifestFileIterFactory)
 	if err != nil {
 		return err
 	}
+
+	var key roachpb.Key
 
 	fileIterByLayer := make([]bulk.Iterator[*backuppb.BackupManifest_File], 0, len(backups))
 	for layer := range backups {
@@ -502,16 +505,26 @@ func generateAndSendImportSpans(
 			firstInSpan = true
 			layersCoveredLater := filter.getLayersCoveredLater(span, backups)
 			for {
-				if ok, err := startEndKeyIt.valid(); !ok {
+				// NB: we iterate through all of the keys yielded by the iterator in order to
+				// construct spans for the cover. If the iterator's last key is less than the
+				// EndKey of the last required span, we additionally need to yield the last
+				// span's EndKey in order to complete the cover.
+				if ok, err := startKeyIt.valid(); !ok {
 					if err != nil {
 						return err
 					}
-					break
+
+					if key.Compare(span.EndKey) < 0 {
+						key = span.EndKey
+					} else {
+						break
+					}
+				} else {
+					key = startKeyIt.value()
 				}
 
-				key := startEndKeyIt.value()
 				if span.Key.Compare(key) >= 0 {
-					startEndKeyIt.next()
+					startKeyIt.next()
 					continue
 				}
 
@@ -523,7 +536,7 @@ func generateAndSendImportSpans(
 				}
 
 				if span.ContainsKey(key) {
-					coverSpan.EndKey = startEndKeyIt.value()
+					coverSpan.EndKey = startKeyIt.value()
 				} else {
 					coverSpan.EndKey = span.EndKey
 				}
@@ -555,8 +568,7 @@ func generateAndSendImportSpans(
 							sz = 16 << 20
 						}
 
-						fspan := endKeyInclusiveSpan(file.Span)
-						if coverSpan.Overlaps(fspan) {
+						if inclusiveOverlap(coverSpan, file.Span) {
 							covSize += sz
 							filesByLayer[layer] = append(filesByLayer[layer], file)
 						}
@@ -592,20 +604,15 @@ func generateAndSendImportSpans(
 					break
 				}
 
-				startEndKeyIt.next()
+				startKeyIt.next()
 			}
 		}
 	}
 	return flush(ctx)
 }
 
-// fileSpanStartAndEndKeyIterator yields (almost) all of the start and end keys
-// of the spans from the files in a backup chain in key order. A start or end
-// key from a file span will be yielded by the iterator if the key is not
-// covered by another file span within the same layer before it in FileCmp
-// order. In particular, this means that if all layers in a backup chain have
-// files with non-overlapping spans, then this iterator would return all start
-// and end keys for all file spans in order. For example:
+// fileSpanStartKeyIterator yields all of the unique start keys of the spans
+// from the files in a backup chain in key order by using a min heap.
 //
 //	backup
 //	0|     a___1___c c__2__e          h__3__i
@@ -614,39 +621,20 @@ func generateAndSendImportSpans(
 //	3|                                  h_8_i              l_9_m
 //	 keys--a---b---c---d---e---f---g---h----i---j---k---l----m------p---->
 //
-// In this case, since no file span overlaps with another file span within the same layer,
-// the iterator will yield all start and end keys:
-// [a, b, c, d, e, g, h, i, j, k, l, m]
-//
-// Another example, but with file spans that do overlap within a layer:
-//
-//	backup
-//	0|     a___1___c
-//	1|         b_____2_____e
-//	 |                 d___3___f
-//	2|     a___________4___________g
-//	3|
-//	 keys--a---b---c---d---e---f---g--->
-//
-// In this case, there is overlap between files 2 and 3 within layer 1. Since
-// the start and end keys 'b' and 'e' of file 2 will be yielded by the iterator
-// since there are no files before it within the same layer. Start key 'd' of
-// file 3 will not be yielded since it's covered by 2's span. The end key 'f'
-// will still be yielded since it's not covered by 2's span. So the iterator
-// will yield:
-// [a, b, c, e, f, g]
-type fileSpanStartAndEndKeyIterator struct {
+// In this case the iterator will yield all start keys:
+// [a, b, c, g, h, j, l]
+type fileSpanStartKeyIterator struct {
 	heap     *fileHeap
 	allIters []bulk.Iterator[*backuppb.BackupManifest_File]
 	err      error
 }
 
-func newFileSpanStartAndEndKeyIterator(
+func newFileSpanStartKeyIterator(
 	ctx context.Context,
 	backups []backuppb.BackupManifest,
 	layerToBackupManifestFileIterFactory backupinfo.LayerToBackupManifestFileIterFactory,
-) (*fileSpanStartAndEndKeyIterator, error) {
-	it := &fileSpanStartAndEndKeyIterator{}
+) (*fileSpanStartKeyIterator, error) {
+	it := &fileSpanStartKeyIterator{}
 	for layer := range backups {
 		iter, err := layerToBackupManifestFileIterFactory[layer].NewFileIter(ctx)
 		if err != nil {
@@ -659,11 +647,17 @@ func newFileSpanStartAndEndKeyIterator(
 	return it, nil
 }
 
-func (i *fileSpanStartAndEndKeyIterator) next() {
+func (i *fileSpanStartKeyIterator) next() {
 	if ok, _ := i.valid(); !ok {
 		return
 	}
 
+	// To find the next key for the iterator, we peek at the key of the
+	// min fileHeapItem in the heap. As long as the key is less than or
+	// equal to the previous key yielded by the iterator, we advance
+	// the iterator of the min fileHeapItem and push it back onto the heap
+	// until the key of the min fileHeapItem is greater than the previously
+	// yielded key.
 	prevKey := i.value()
 	for i.heap.Len() > 0 {
 		minItem := heap.Pop(i.heap).(fileHeapItem)
@@ -674,18 +668,12 @@ func (i *fileSpanStartAndEndKeyIterator) next() {
 			break
 		}
 
-		if minItem.cmpEndKey {
-			minItem.fileIter.Next()
-			if ok, err := minItem.fileIter.Valid(); err != nil {
-				i.err = err
-				return
-			} else if ok {
-				minItem.cmpEndKey = false
-				minItem.file = minItem.fileIter.Value()
-				heap.Push(i.heap, minItem)
-			}
-		} else {
-			minItem.cmpEndKey = true
+		minItem.fileIter.Next()
+		if ok, err := minItem.fileIter.Valid(); err != nil {
+			i.err = err
+			return
+		} else if ok {
+			minItem.file = minItem.fileIter.Value()
 			heap.Push(i.heap, minItem)
 		}
 	}
@@ -698,21 +686,21 @@ func (i *fileSpanStartAndEndKeyIterator) next() {
 	}
 }
 
-func (i *fileSpanStartAndEndKeyIterator) valid() (bool, error) {
+func (i *fileSpanStartKeyIterator) valid() (bool, error) {
 	if i.err != nil {
 		return false, i.err
 	}
 	return i.heap.Len() > 0, nil
 }
 
-func (i *fileSpanStartAndEndKeyIterator) value() roachpb.Key {
+func (i *fileSpanStartKeyIterator) value() roachpb.Key {
 	if ok, _ := i.valid(); !ok {
 		return nil
 	}
 
 	return i.heap.fileHeapItems[0].key()
 }
-func (i *fileSpanStartAndEndKeyIterator) reset() {
+func (i *fileSpanStartKeyIterator) reset() {
 	i.heap = &fileHeap{}
 	i.err = nil
 
@@ -725,28 +713,27 @@ func (i *fileSpanStartAndEndKeyIterator) reset() {
 		}
 
 		i.heap.fileHeapItems = append(i.heap.fileHeapItems, fileHeapItem{
-			fileIter:  iter,
-			file:      iter.Value(),
-			cmpEndKey: false,
+			fileIter: iter,
+			file:     iter.Value(),
 		})
 	}
 	heap.Init(i.heap)
 }
 
+// fileHeapItem is a wrapper for an iterator of *backuppb.BackupManifest_File
+// so that it can be used in a heap. The key that's being compared in this
+// wrapper is the start key of the span of the iterator's current
+// BackupManifest_File value.
 type fileHeapItem struct {
-	fileIter  bulk.Iterator[*backuppb.BackupManifest_File]
-	file      *backuppb.BackupManifest_File
-	cmpEndKey bool
+	fileIter bulk.Iterator[*backuppb.BackupManifest_File]
+	file     *backuppb.BackupManifest_File
 }
 
 func (f fileHeapItem) key() roachpb.Key {
-	fspan := endKeyInclusiveSpan(f.file.Span)
-	if f.cmpEndKey {
-		return fspan.EndKey
-	}
-	return fspan.Key
+	return f.file.Span.Key
 }
 
+// fileHeap is a min heap of fileHeapItems.
 type fileHeap struct {
 	fileHeapItems []fileHeapItem
 }
@@ -805,12 +792,11 @@ func getNewIntersectingFilesByLayer(
 				// inclusive. Because roachpb.Span and its associated operations
 				// are end key exclusive, we work around this by replacing the
 				// end key with its next value in order to include the end key.
-				fspan := endKeyInclusiveSpan(f.Span)
-				if span.Overlaps(fspan) {
+				if inclusiveOverlap(span, f.Span) {
 					layerFiles = append(layerFiles, f)
 				}
 
-				if span.EndKey.Compare(fspan.Key) <= 0 {
+				if span.EndKey.Compare(f.Span.Key) <= 0 {
 					break
 				}
 			}
@@ -834,4 +820,10 @@ func endKeyInclusiveSpan(sp roachpb.Span) roachpb.Span {
 	isp := sp.Clone()
 	isp.EndKey = isp.EndKey.Next()
 	return isp
+}
+
+// inclusiveOverlap returns true if sp, which is end key exclusive, overlaps
+// isp, which is end key inclusive.
+func inclusiveOverlap(sp roachpb.Span, isp roachpb.Span) bool {
+	return sp.Overlaps(isp) || sp.ContainsKey(isp.EndKey)
 }

--- a/pkg/ccl/backupccl/restore_span_covering_test.go
+++ b/pkg/ccl/backupccl/restore_span_covering_test.go
@@ -381,7 +381,7 @@ func TestRestoreEntryCoverExample(t *testing.T) {
 	c := makeCoverUtils(ctx, t, &execCfg)
 
 	// Setup and test the example in the comment of makeSimpleImportSpans.
-	spans := []roachpb.Span{c.sp("a", "f"), c.sp("f", "i"), c.sp("l", "m")}
+	spans := []roachpb.Span{c.sp("a", "f"), c.sp("f", "i"), c.sp("l", "p")}
 
 	backups := c.makeManifests([]roachpb.Spans{
 		{c.sp("a", "c"), c.sp("c", "e"), c.sp("h", "i")},
@@ -427,11 +427,12 @@ func TestRestoreEntryCoverExample(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, reduce([]execinfrapb.RestoreSpanEntry{
 			{Span: c.sp("a", "b"), Files: c.paths("1", "6")},
-			{Span: c.sp("b", "f"), Files: c.paths("2", "1", "4", "6")},
+			{Span: c.sp("b", "c"), Files: c.paths("1", "4", "6")},
+			{Span: c.sp("c", "f"), Files: c.paths("2", "1", "4", "6")},
 			{Span: c.sp("f", "g"), Files: c.paths("6")},
 			{Span: c.sp("g", "h"), Files: c.paths("5", "6")},
 			{Span: c.sp("h", "i"), Files: c.paths("3", "5", "6", "8")},
-			{Span: c.sp("l", "m"), Files: c.paths("9")},
+			{Span: c.sp("l", "p"), Files: c.paths("9")},
 		}), reduce(cover))
 		coverSimple, err := makeImportSpans(
 			ctx,
@@ -449,7 +450,7 @@ func TestRestoreEntryCoverExample(t *testing.T) {
 			{Span: c.sp("c\x00", "e\x00"), Files: c.paths("2", "4", "6")},
 			{Span: c.sp("e\x00", "f"), Files: c.paths("6")},
 			{Span: c.sp("f", "i"), Files: c.paths("3", "5", "6", "8")},
-			{Span: c.sp("l", "m"), Files: c.paths("9")},
+			{Span: c.sp("l", "m\x00"), Files: c.paths("9")},
 		}), reduce(coverSimple))
 	})
 
@@ -467,10 +468,11 @@ func TestRestoreEntryCoverExample(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, reduce([]execinfrapb.RestoreSpanEntry{
 			{Span: c.sp("a", "b"), Files: c.paths("1", "6")},
-			{Span: c.sp("b", "f"), Files: c.paths("2", "1", "4", "6")},
+			{Span: c.sp("b", "c"), Files: c.paths("1", "4", "6")},
+			{Span: c.sp("c", "f"), Files: c.paths("2", "1", "4", "6")},
 			{Span: c.sp("f", "h"), Files: c.paths("5", "6")},
 			{Span: c.sp("h", "i"), Files: c.paths("3", "5", "6", "8")},
-			{Span: c.sp("l", "m"), Files: c.paths("9")},
+			{Span: c.sp("l", "p"), Files: c.paths("9")},
 		}), reduce(coverSized))
 
 		coverSizedSimple, err := makeImportSpans(
@@ -487,7 +489,7 @@ func TestRestoreEntryCoverExample(t *testing.T) {
 		require.Equal(t, reduce([]execinfrapb.RestoreSpanEntry{
 			{Span: c.sp("a", "f"), Files: c.paths("1", "2", "4", "6")},
 			{Span: c.sp("f", "i"), Files: c.paths("3", "5", "6", "8")},
-			{Span: c.sp("l", "m"), Files: c.paths("9")},
+			{Span: c.sp("l", "m\x00"), Files: c.paths("9")},
 		}), reduce(coverSizedSimple))
 	})
 
@@ -511,7 +513,7 @@ func TestRestoreEntryCoverExample(t *testing.T) {
 			{Span: c.sp("f", "g"), Files: c.paths("6")},
 			{Span: c.sp("g", "h"), Files: c.paths("5", "6")},
 			{Span: c.sp("h", "i"), Files: c.paths("3", "5", "6", "8")},
-			{Span: c.sp("l", "m"), Files: c.paths("9")},
+			{Span: c.sp("l", "p"), Files: c.paths("9")},
 		}), reduce(coverIntroduced))
 
 		coverIntroducedSimple, err := makeImportSpans(
@@ -528,7 +530,7 @@ func TestRestoreEntryCoverExample(t *testing.T) {
 		require.Equal(t, reduce([]execinfrapb.RestoreSpanEntry{
 			{Span: c.sp("a", "f"), Files: c.paths("6")},
 			{Span: c.sp("f", "i"), Files: c.paths("3", "5", "6", "8")},
-			{Span: c.sp("l", "m"), Files: c.paths("9")},
+			{Span: c.sp("l", "m\x00"), Files: c.paths("9")},
 		}), reduce(coverIntroducedSimple))
 	})
 	t.Run("completed-spans", func(t *testing.T) {
@@ -557,7 +559,7 @@ func TestRestoreEntryCoverExample(t *testing.T) {
 			{Span: c.sp("a", "b"), Files: c.paths("1", "6")},
 			{Span: c.sp("c", "f"), Files: c.paths("2", "1", "4", "6")},
 			{Span: c.sp("f", "g"), Files: c.paths("6")},
-			{Span: c.sp("l", "m"), Files: c.paths("9")},
+			{Span: c.sp("l", "p"), Files: c.paths("9")},
 		}), reduce(coverCompleted))
 
 		coverCompletedSimple, err := makeImportSpans(
@@ -577,7 +579,7 @@ func TestRestoreEntryCoverExample(t *testing.T) {
 			{Span: c.sp("c\x00", "e\x00"), Files: c.paths("2", "4", "6")},
 			{Span: c.sp("e\x00", "f"), Files: c.paths("6")},
 			{Span: c.sp("f", "g"), Files: c.paths("6")},
-			{Span: c.sp("l", "m"), Files: c.paths("9")},
+			{Span: c.sp("l", "m\x00"), Files: c.paths("9")},
 		}), reduce(coverCompletedSimple))
 	})
 }
@@ -603,21 +605,21 @@ func TestFileSpanStartKeyIterator(t *testing.T) {
 			manifestFiles: []roachpb.Spans{
 				{c.sp("a", "b"), c.sp("c", "d"), c.sp("d\x00", "e")},
 			},
-			keysSurfaced: []string{"a", "b\x00", "c", "d\x00", "e\x00"},
+			keysSurfaced: []string{"a", "c", "d\x00"},
 		},
 		{
-			// shadow start key (b) if another span covers it.
+			// overlapping file spans.
 			manifestFiles: []roachpb.Spans{
 				{c.sp("a", "c"), c.sp("b", "d")},
 			},
-			keysSurfaced: []string{"a", "c\x00", "d\x00"},
+			keysSurfaced: []string{"a", "b"},
 		},
 		{
 			// swap the file order and expect an error.
 			manifestFiles: []roachpb.Spans{
 				{c.sp("b", "d"), c.sp("a", "c")},
 			},
-			keysSurfaced:  []string{"b", "d\x00", "a", "c\x00"},
+			keysSurfaced:  []string{"b", "a"},
 			expectedError: "out of order backup keys",
 		},
 		{
@@ -625,7 +627,7 @@ func TestFileSpanStartKeyIterator(t *testing.T) {
 			manifestFiles: []roachpb.Spans{
 				{c.sp("b", "f"), c.sp("c", "d"), c.sp("e", "g")},
 			},
-			keysSurfaced: []string{"b", "f\x00", "g\x00"},
+			keysSurfaced: []string{"b", "c", "e"},
 		},
 		{
 			// overlapping files within and across levels.
@@ -633,7 +635,7 @@ func TestFileSpanStartKeyIterator(t *testing.T) {
 				{c.sp("a", "e"), c.sp("d", "f")},
 				{c.sp("b", "c")},
 			},
-			keysSurfaced: []string{"a", "b", "c\x00", "e\x00", "f\x00"},
+			keysSurfaced: []string{"a", "b", "d"},
 		},
 		{
 			// overlapping start key in one level, but non overlapping in another level.
@@ -641,7 +643,7 @@ func TestFileSpanStartKeyIterator(t *testing.T) {
 				{c.sp("a", "c"), c.sp("b", "d")},
 				{c.sp("b", "c")},
 			},
-			keysSurfaced: []string{"a", "b", "c\x00", "d\x00"},
+			keysSurfaced: []string{"a", "b"},
 		},
 		{
 			// overlapping files in both levels.
@@ -649,7 +651,7 @@ func TestFileSpanStartKeyIterator(t *testing.T) {
 				{c.sp("b", "e"), c.sp("d", "i")},
 				{c.sp("a", "c"), c.sp("b", "h")},
 			},
-			keysSurfaced: []string{"a", "b", "c\x00", "e\x00", "h\x00", "i\x00"},
+			keysSurfaced: []string{"a", "b", "d"},
 		},
 		{
 			// ensure everything works with 3 layers.
@@ -658,7 +660,7 @@ func TestFileSpanStartKeyIterator(t *testing.T) {
 				{c.sp("b", "e"), c.sp("e", "f")},
 				{c.sp("c", "e"), c.sp("d", "f")},
 			},
-			keysSurfaced: []string{"a", "b", "c", "e\x00", "f\x00"},
+			keysSurfaced: []string{"a", "b", "c", "d", "e"},
 		},
 	} {
 		backups := c.makeManifests(sp.manifestFiles)
@@ -676,7 +678,7 @@ func TestFileSpanStartKeyIterator(t *testing.T) {
 
 		sanityCheckFileIterator(ctx, t, layerToBackupManifestFileIterFactory[0], backups[0])
 
-		startEndKeyIt, err := newFileSpanStartAndEndKeyIterator(ctx, backups, layerToBackupManifestFileIterFactory)
+		startEndKeyIt, err := newFileSpanStartKeyIterator(ctx, backups, layerToBackupManifestFileIterFactory)
 		require.NoError(t, err)
 
 		for _, expectedKey := range sp.keysSurfaced {


### PR DESCRIPTION
Remove all calls to key.Next() from generateAndSendImportSpans so that all cover
spans have valid keys as start and end keys.

This fixes an issue where a split can be called on an invalid key that's in the
form of `someValidKey.Next()` during restore. These invalid keys will generally
have a `NULL` at the end of the key, which will result in an error when calling
`EnsureSafeSplits` on this split key. Currently errors from `EnsureSafeSplits`
are ignored, and thus a split will always be attempted on this type of invalid
split key. This split key can land in the middle of a row with column families,
and thus result in failing SQL queries when querying the restored table.

Fixes: #109483

Release note (bug fix): Fixes an issue where a split can be called on an
invalid key that's in the form of someValidKey.Next() during restore. This split
key can land in the middle of a row with column families, and thus result in
failing SQL queries when querying the restored table.