### PR TITLE
rpc: increase gRPC server keepalive interval to 2x PingInterval

### DIFF
--- a/pkg/base/config.go
+++ b/pkg/base/config.go
@@ -148,10 +148,10 @@ var (
 	// 2 * NetworkTimeout is sufficient.
 	DialTimeout = envutil.EnvOrDefaultDuration("COCKROACH_RPC_DIAL_TIMEOUT", 2*NetworkTimeout)
 
-	// PingInterval is the interval between network heartbeat pings. It is used
-	// both for RPC heartbeat intervals and gRPC server keepalive pings. It is
-	// set to 1 second in order to fail fast, but with large default timeouts
-	// to tolerate high-latency multiregion clusters.
+	// PingInterval is the interval between RPC heartbeat pings. It is set to 1
+	// second in order to fail fast, but with large default timeouts to tolerate
+	// high-latency multiregion clusters. The gRPC server keepalive interval is
+	// also affected by this.
 	PingInterval = envutil.EnvOrDefaultDuration("COCKROACH_PING_INTERVAL", time.Second)
 
 	// defaultRangeLeaseDuration specifies the default range lease duration.


### PR DESCRIPTION
This patch increases the gRPC server keepalive interval from 1x to 2x PingInterval. These keepalive pings are used both to keep the connection alive, and to detect and close failed connections from the server-side. Keepalive pings are only sent and checked if there is no other activity on the connection.

We set this to 2x PingInterval, since we expect RPC heartbeats to be sent regularly (obviating the need for the keepalive ping), and there's no point sending keepalive pings until we've waited long enough for the RPC heartbeat to show up.

An environment variable COCKROACH_RPC_SERVER_KEEPALIVE_INTERVAL is also added to tune this.

Touches #109317.
Epic: none
Release note: None