### PR TITLE
startup: disable tenant in circuit breaker startup tests

### DIFF
--- a/pkg/base/test_server_args.go
+++ b/pkg/base/test_server_args.go
@@ -246,7 +246,7 @@ var (
 	// is attempted. This is the default behavior.
 	TestTenantProbabilisticOnly = DefaultTestTenantOptions{testBehavior: ttProb, allowAdditionalTenants: false}
 
-	// TestTenantProbabilisticOnly starts the test under a virtual
+	// TestTenantProbabilistic starts the test under a virtual
 	// cluster on a probabilistic basis. It allows the starting of
 	// additional virtual clusters.
 	TestTenantProbabilistic = DefaultTestTenantOptions{testBehavior: ttProb, allowAdditionalTenants: true}

--- a/pkg/util/startup/startup_test.go
+++ b/pkg/util/startup/startup_test.go
@@ -179,7 +179,7 @@ func runCircuitBreakerTestForKey(
 	require.NoError(t, tc.WaitFor5NodeReplication(), "failed to succeed 5x replication")
 
 	tc.ToggleReplicateQueues(false)
-	c := tc.ServerConn(0)
+	c := tc.Server(0).SystemLayer().SQLConn(t, "")
 	_, err := c.ExecContext(ctx, "set cluster setting kv.allocator.load_based_rebalancing='off'")
 	require.NoError(t, err, "failed to disable load rebalancer")
 	_, err = c.ExecContext(ctx,


### PR DESCRIPTION
Previously test used default connection for cluster setup which could be set to tenant metamorphically. This is not good as it doesn't allow changing system settings.
This commit changes sql connection from application to system.

Epic: none
Fixes: #109572

Release note: None