### PR TITLE
cluster-ui: break circular import of `rootActions`

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/store/index.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/index.ts
@@ -12,6 +12,7 @@ export { sagas } from "./sagas";
 export { notificationAction } from "./notifications";
 export { actions as analyticsActions } from "./analytics";
 export { actions as uiConfigActions } from "./uiConfig";
-export { rootReducer, rootActions } from "./reducers";
+export { rootReducer } from "./reducers";
 export type { UIConfigState } from "./uiConfig";
 export type { AppState } from "./reducers";
+export { rootActions } from "./rootActions";

--- a/pkg/ui/workspaces/cluster-ui/src/store/liveness/liveness.sagas.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/liveness/liveness.sagas.ts
@@ -13,7 +13,8 @@ import { getLiveness } from "src/api/livenessApi";
 import { actions } from "./liveness.reducer";
 
 import { CACHE_INVALIDATION_PERIOD, throttleWithReset } from "src/store/utils";
-import { rootActions } from "../reducers";
+
+import { rootActions } from "../rootActions";
 
 export function* refreshLivenessSaga() {
   yield put(actions.request());

--- a/pkg/ui/workspaces/cluster-ui/src/store/nodes/nodes.sagas.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/nodes/nodes.sagas.ts
@@ -14,7 +14,8 @@ import { actions } from "./nodes.reducer";
 
 import { CACHE_INVALIDATION_PERIOD, throttleWithReset } from "src/store/utils";
 import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
-import { rootActions } from "../reducers";
+
+import { rootActions } from "../rootActions";
 
 export function* refreshNodesSaga() {
   yield put(actions.request());

--- a/pkg/ui/workspaces/cluster-ui/src/store/reducers.spec.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/reducers.spec.ts
@@ -10,8 +10,9 @@
 
 import { assert } from "chai";
 import { createStore } from "redux";
-import { rootActions, rootReducer } from "./reducers";
+import { rootReducer } from "./reducers";
 import { actions as sqlStatsActions } from "./sqlStats";
+import { rootActions } from "./rootActions";
 
 describe("rootReducer", () => {
   it("resets redux state on RESET_STATE action", () => {

--- a/pkg/ui/workspaces/cluster-ui/src/store/reducers.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/reducers.ts
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-import { createAction, createReducer } from "@reduxjs/toolkit";
+import { createReducer } from "@reduxjs/toolkit";
 import { combineReducers, createStore } from "redux";
 import {
   ClusterLocksReqState,
@@ -27,12 +27,12 @@ import {
   TxnInsightDetailsCachedState,
 } from "./insightDetails/transactionInsightDetails";
 import {
-  StmtInsightsState,
   reducer as stmtInsights,
+  StmtInsightsState,
 } from "./insights/statementInsights";
 import {
-  TxnInsightsState,
   reducer as txnInsights,
+  TxnInsightsState,
 } from "./insights/transactionInsights";
 import { JobDetailsReducerState, reducer as job } from "./jobDetails";
 import { JobsState, reducer as jobs } from "./jobs";
@@ -58,7 +58,6 @@ import {
   TerminateQueryState,
 } from "./terminateQuery";
 import { reducer as uiConfig, UIConfigState } from "./uiConfig";
-import { DOMAIN_NAME } from "./utils";
 import {
   reducer as statementFingerprintInsights,
   StatementFingerprintInsightsCachedState,
@@ -80,6 +79,7 @@ import {
   JobProfilerExecutionDetailFilesState,
   reducer as executionDetailFiles,
 } from "./jobs/jobProfiler.reducer";
+import { rootActions } from "./rootActions";
 
 export type AdminUiState = {
   statementDiagnostics: StatementDiagnosticsState;
@@ -138,10 +138,6 @@ export const reducers = combineReducers<AdminUiState>({
   statementFingerprintInsights,
   clusterSettings,
 });
-
-export const rootActions = {
-  resetState: createAction(`${DOMAIN_NAME}/RESET_STATE`),
-};
 
 /**
  * rootReducer consolidates reducers slices and cases for handling global actions related to entire state.

--- a/pkg/ui/workspaces/cluster-ui/src/store/rootActions.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/rootActions.ts
@@ -1,0 +1,16 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { DOMAIN_NAME } from "./utils";
+import { createAction } from "@reduxjs/toolkit";
+
+export const rootActions = {
+  resetState: createAction(`${DOMAIN_NAME}/RESET_STATE`),
+};

--- a/pkg/ui/workspaces/cluster-ui/src/store/statementDiagnostics/statementDiagnostics.sagas.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/statementDiagnostics/statementDiagnostics.sagas.ts
@@ -23,7 +23,8 @@ import {
 } from "src/api/statementDiagnosticsApi";
 import { actions } from "./statementDiagnostics.reducer";
 import { CACHE_INVALIDATION_PERIOD, throttleWithReset } from "../utils";
-import { rootActions } from "../reducers";
+
+import { rootActions } from "../rootActions";
 
 export function* createDiagnosticsReportSaga(
   action: ReturnType<typeof actions.createReport>,

--- a/pkg/ui/workspaces/cluster-ui/src/store/uiConfig/uiConfig.sagas.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/uiConfig/uiConfig.sagas.ts
@@ -12,9 +12,9 @@ import { all, call, delay, put, takeLatest } from "redux-saga/effects";
 import { actions } from "./uiConfig.reducer";
 import { getUserSQLRoles } from "../../api/userApi";
 import { CACHE_INVALIDATION_PERIOD, throttleWithReset } from "../utils";
-import { rootActions } from "../reducers";
 import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
 import { getLogger } from "../../util";
+import { rootActions } from "../rootActions";
 
 export function* refreshUserSQLRolesSaga(): any {
   yield put(actions.requestUserSQLRoles());


### PR DESCRIPTION
Importing  `rootActions` from `reducers.ts` in cluster-ui was causing a circular import, preventing one of the redux fields experiencing the cyclic dependency from having their reducer populated, which omitted that field from the store altogether. Currently, this field is `uiConfig` which is affecting features that rely on checking the sql role of a user, such as displaying the `Reset SQL Stats` button.

This commit extracts `rootActions` into its own file to remove the cyclic dependencies created.

Fixes: https://github.com/cockroachdb/cockroach/issues/97996

Release note (bug fix): On CC, `Reset Sql Stats` button is now visible if the user has admin role.

Using a production buiild 23.1 cluster-ui version:
<img width="1909" alt="image" src="https://github.com/cockroachdb/cockroach/assets/20136951/348a941a-3be5-42ad-8b16-47cbf48f3f19">