### PR TITLE
sql: difference built-in as wrong return value type

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -2739,7 +2739,7 @@ The swap_ordinate_string parameter is a 2-character string naming the ordinates 
 </span></td><td>Immutable</td></tr>
 <tr><td><a name="decompress"></a><code>decompress(data: <a href="bytes.html">bytes</a>, codec: <a href="string.html">string</a>) &rarr; <a href="bytes.html">bytes</a></code></td><td><span class="funcdesc"><p>Decompress <code>data</code> with the specified <code>codec</code> (<code>gzip</code>, ‘lz4’, ‘snappy’, 'zstd).</p>
 </span></td><td>Immutable</td></tr>
-<tr><td><a name="difference"></a><code>difference(source: <a href="string.html">string</a>, target: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Convert two strings to their Soundex codes and then reports the number of matching code positions.</p>
+<tr><td><a name="difference"></a><code>difference(source: <a href="string.html">string</a>, target: <a href="string.html">string</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Convert two strings to their Soundex codes and then reports the number of matching code positions.</p>
 </span></td><td>Immutable</td></tr>
 <tr><td><a name="encode"></a><code>encode(data: <a href="bytes.html">bytes</a>, format: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Encodes <code>data</code> using <code>format</code> (<code>hex</code> / <code>escape</code> / <code>base64</code>).</p>
 </span></td><td>Immutable</td></tr>

--- a/pkg/sql/logictest/testdata/logic_test/fuzzystrmatch
+++ b/pkg/sql/logictest/testdata/logic_test/fuzzystrmatch
@@ -35,22 +35,22 @@ SELECT soundex('hello world!')
 ----
 H464
 
-query TTT
+query TTI
 SELECT soundex('Anne'), soundex('Ann'), difference('Anne', 'Ann');
 ----
 A500 A500 4
 
-query TTT
+query TTI
 SELECT soundex('Anne'), soundex('Andrew'), difference('Anne', 'Andrew');
 ----
 A500 A536 2
 
-query TTT
+query TTI
 SELECT soundex('Anne'), soundex('Margaret'), difference('Anne', 'Margaret');
 ----
 A500 M626 0
 
-query TTTT
+query TTTI
 SELECT soundex('Anne'), soundex(NULL), difference('Anne', NULL), difference(NULL, 'Bob');
 ----
 A500  NULL  NULL  NULL

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -28,7 +28,6 @@ import (
 	"math/rand"
 	"net"
 	"regexp/syntax"
-	"strconv"
 	"strings"
 	"time"
 	"unicode"
@@ -3819,11 +3818,11 @@ value if you rely on the HLC for accuracy.`,
 		tree.FunctionProperties{Category: builtinconstants.CategoryString},
 		tree.Overload{
 			Types:      tree.ParamTypes{{Name: "source", Typ: types.String}, {Name: "target", Typ: types.String}},
-			ReturnType: tree.FixedReturnType(types.String),
+			ReturnType: tree.FixedReturnType(types.Int),
 			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				s, t := string(tree.MustBeDString(args[0])), string(tree.MustBeDString(args[1]))
 				diff := fuzzystrmatch.Difference(s, t)
-				return tree.NewDString(strconv.Itoa(diff)), nil
+				return tree.NewDInt(tree.DInt(diff)), nil
 			},
 			Info:       "Convert two strings to their Soundex codes and then reports the number of matching code positions.",
 			Volatility: volatility.Immutable,

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -1215,7 +1215,7 @@ var builtinOidsArray = []string{
 	1234: `array_positions(array: anyenum[], elem: anyenum) -> int[]`,
 	1235: `array_positions(array: tuple[], elem: tuple) -> int[]`,
 	1236: `soundex(source: string) -> string`,
-	1237: `difference(source: string, target: string) -> string`,
+	1237: `difference(source: string, target: string) -> int`,
 	1238: `levenshtein(source: string, target: string) -> int`,
 	1239: `levenshtein(source: string, target: string, ins_cost: int, del_cost: int, sub_cost: int) -> int`,
 	1240: `json_remove_path(val: jsonb, path: string[]) -> jsonb`,


### PR DESCRIPTION
Previously, when the difference built-in was added into CRDB, the return type was text instead of integer. To address this, this patch fixes the return type to match Postgres.

Fixes: #109666

Release note (bug fix): The difference builtin had its return type incorrectly set to a string instead of an integer.