### PR TITLE
bulk,ccl: refactor tracing aggregator integration

### DIFF
--- a/pkg/ccl/backupccl/backup_processor.go
+++ b/pkg/ccl/backupccl/backup_processor.go
@@ -38,7 +38,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
-	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
@@ -173,11 +172,12 @@ func newBackupDataProcessor(
 			InputsToDrain: nil,
 			TrailingMetaCallback: func() []execinfrapb.ProducerMetadata {
 				bp.close()
-				meta := bp.constructTracingAggregatorProducerMeta(ctx)
-				if meta == nil {
-					return nil
+				if bp.agg != nil {
+					meta := bulk.ConstructTracingAggregatorProducerMeta(ctx,
+						bp.flowCtx.NodeID.SQLInstanceID(), bp.flowCtx.ID, bp.agg)
+					return []execinfrapb.ProducerMetadata{*meta}
 				}
-				return []execinfrapb.ProducerMetadata{*meta}
+				return nil
 			},
 		}); err != nil {
 		return nil, err
@@ -188,15 +188,17 @@ func newBackupDataProcessor(
 // Start is part of the RowSource interface.
 func (bp *backupDataProcessor) Start(ctx context.Context) {
 	ctx = logtags.AddTag(ctx, "job", bp.spec.JobID)
-	ctx = bp.StartInternal(ctx, backupProcessorName)
-	ctx, cancel := context.WithCancel(ctx)
 
 	// Construct an Aggregator to aggregate and render AggregatorEvents emitted in
 	// bps' trace recording.
-	ctx, bp.agg = bulk.MakeTracingAggregatorWithSpan(ctx,
-		fmt.Sprintf("%s-aggregator", backupProcessorName), bp.EvalCtx.Tracer)
+	bp.agg = bulk.TracingAggregatorForContext(ctx)
 	bp.aggTimer = timeutil.NewTimer()
-	bp.aggTimer.Reset(15 * time.Second)
+	// If the aggregator is nil, we do not want the timer to fire.
+	if bp.agg != nil {
+		bp.aggTimer.Reset(15 * time.Second)
+	}
+	ctx = bp.StartInternal(ctx, backupProcessorName, bp.agg)
+	ctx, cancel := context.WithCancel(ctx)
 
 	bp.cancelAndWaitForWorker = func() {
 		cancel()
@@ -246,36 +248,6 @@ func (bp *backupDataProcessor) constructProgressProducerMeta(
 	return &execinfrapb.ProducerMetadata{BulkProcessorProgress: &p}
 }
 
-func (bp *backupDataProcessor) constructTracingAggregatorProducerMeta(
-	ctx context.Context,
-) *execinfrapb.ProducerMetadata {
-	if bp.agg == nil {
-		return nil
-	}
-	aggEvents := &execinfrapb.TracingAggregatorEvents{
-		SQLInstanceID: bp.flowCtx.NodeID.SQLInstanceID(),
-		FlowID:        bp.flowCtx.ID,
-		Events:        make(map[string][]byte),
-	}
-	bp.agg.ForEachAggregatedEvent(func(name string, event bulk.TracingAggregatorEvent) {
-		msg, ok := event.(protoutil.Message)
-		if !ok {
-			// This should never happen but if it does skip the aggregated event.
-			log.Warningf(ctx, "event is not a protoutil.Message: %T", event)
-			return
-		}
-		data := make([]byte, msg.Size())
-		if _, err := msg.MarshalTo(data); err != nil {
-			// This should never happen but if it does skip the aggregated event.
-			log.Warningf(ctx, "failed to unmarshal aggregated event: %v", err.Error())
-			return
-		}
-		aggEvents.Events[name] = data
-	})
-
-	return &execinfrapb.ProducerMetadata{AggregatorEvents: aggEvents}
-}
-
 // Next is part of the RowSource interface.
 func (bp *backupDataProcessor) Next() (rowenc.EncDatumRow, *execinfrapb.ProducerMetadata) {
 	if bp.State != execinfra.StateRunning {
@@ -292,16 +264,14 @@ func (bp *backupDataProcessor) Next() (rowenc.EncDatumRow, *execinfrapb.Producer
 	case <-bp.aggTimer.C:
 		bp.aggTimer.Read = true
 		bp.aggTimer.Reset(15 * time.Second)
-		return nil, bp.constructTracingAggregatorProducerMeta(bp.Ctx())
+		return nil, bulk.ConstructTracingAggregatorProducerMeta(bp.Ctx(),
+			bp.flowCtx.NodeID.SQLInstanceID(), bp.flowCtx.ID, bp.agg)
 	}
 }
 
 func (bp *backupDataProcessor) close() {
 	bp.cancelAndWaitForWorker()
 	if bp.InternalClose() {
-		if bp.agg != nil {
-			bp.agg.Close()
-		}
 		bp.aggTimer.Stop()
 		bp.memAcc.Close(bp.Ctx())
 	}

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor.go
@@ -10,7 +10,6 @@ package streamingest
 
 import (
 	"context"
-	"fmt"
 	"sort"
 	"sync"
 	"time"
@@ -330,11 +329,12 @@ func newStreamIngestionDataProcessor(
 			InputsToDrain: []execinfra.RowSource{},
 			TrailingMetaCallback: func() []execinfrapb.ProducerMetadata {
 				sip.close()
-				meta := sip.constructTracingAggregatorProducerMeta(ctx)
-				if meta == nil {
-					return nil
+				if sip.agg != nil {
+					meta := bulkutil.ConstructTracingAggregatorProducerMeta(ctx,
+						sip.flowCtx.NodeID.SQLInstanceID(), sip.flowCtx.ID, sip.agg)
+					return []execinfrapb.ProducerMetadata{*meta}
 				}
-				return []execinfrapb.ProducerMetadata{*meta}
+				return nil
 			},
 		},
 	); err != nil {
@@ -342,36 +342,6 @@ func newStreamIngestionDataProcessor(
 	}
 
 	return sip, nil
-}
-
-func (sip *streamIngestionProcessor) constructTracingAggregatorProducerMeta(
-	ctx context.Context,
-) *execinfrapb.ProducerMetadata {
-	if sip.agg == nil {
-		return nil
-	}
-	aggEvents := &execinfrapb.TracingAggregatorEvents{
-		SQLInstanceID: sip.flowCtx.NodeID.SQLInstanceID(),
-		FlowID:        sip.flowCtx.ID,
-		Events:        make(map[string][]byte),
-	}
-	sip.agg.ForEachAggregatedEvent(func(name string, event bulkutil.TracingAggregatorEvent) {
-		msg, ok := event.(protoutil.Message)
-		if !ok {
-			// This should never happen but if it does skip the aggregated event.
-			log.Warningf(ctx, "event is not a protoutil.Message: %T", event)
-			return
-		}
-		data := make([]byte, msg.Size())
-		if _, err := msg.MarshalTo(data); err != nil {
-			// This should never happen but if it does skip the aggregated event.
-			log.Warningf(ctx, "failed to unmarshal aggregated event: %v", err.Error())
-			return
-		}
-		aggEvents.Events[name] = data
-	})
-
-	return &execinfrapb.ProducerMetadata{AggregatorEvents: aggEvents}
 }
 
 // Start launches a set of goroutines that read from the spans
@@ -397,14 +367,15 @@ func (sip *streamIngestionProcessor) constructTracingAggregatorProducerMeta(
 func (sip *streamIngestionProcessor) Start(ctx context.Context) {
 	ctx = logtags.AddTag(ctx, "job", sip.spec.JobID)
 	log.Infof(ctx, "starting ingest proc")
-	ctx = sip.StartInternal(ctx, streamIngestionProcessorName)
-
-	// Construct an Aggregator to aggregate and render AggregatorEvents emitted in
-	// sips' trace recording.
-	ctx, sip.agg = bulkutil.MakeTracingAggregatorWithSpan(ctx,
-		fmt.Sprintf("%s-aggregator", streamIngestionProcessorName), sip.EvalCtx.Tracer)
+	sip.agg = bulkutil.TracingAggregatorForContext(ctx)
 	sip.aggTimer = timeutil.NewTimer()
-	sip.aggTimer.Reset(15 * time.Second)
+
+	// If the aggregator is nil, we do not want the timer to fire.
+	if sip.agg != nil {
+		sip.aggTimer.Reset(15 * time.Second)
+	}
+
+	ctx = sip.StartInternal(ctx, streamIngestionProcessorName, sip.agg)
 
 	sip.metrics = sip.flowCtx.Cfg.JobRegistry.MetricsStruct().StreamIngest.(*Metrics)
 
@@ -521,7 +492,8 @@ func (sip *streamIngestionProcessor) Next() (rowenc.EncDatumRow, *execinfrapb.Pr
 	case <-sip.aggTimer.C:
 		sip.aggTimer.Read = true
 		sip.aggTimer.Reset(15 * time.Second)
-		return nil, sip.constructTracingAggregatorProducerMeta(sip.Ctx())
+		return nil, bulkutil.ConstructTracingAggregatorProducerMeta(sip.Ctx(),
+			sip.flowCtx.NodeID.SQLInstanceID(), sip.flowCtx.ID, sip.agg)
 	case err := <-sip.errCh:
 		sip.MoveToDraining(err)
 		return nil, sip.DrainHelper()
@@ -584,9 +556,6 @@ func (sip *streamIngestionProcessor) close() {
 	}
 	if sip.maxFlushRateTimer != nil {
 		sip.maxFlushRateTimer.Stop()
-	}
-	if sip.agg != nil {
-		sip.agg.Close()
 	}
 	sip.aggTimer.Stop()
 

--- a/pkg/util/bulk/BUILD.bazel
+++ b/pkg/util/bulk/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/util/bulk",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/base",
         "//pkg/clusterversion",
         "//pkg/jobs",
         "//pkg/jobs/jobspb",


### PR DESCRIPTION
The motivation for this change was to fix the leaked goroutine in https://github.com/cockroachdb/cockroach/issues/109658 but it led to a larger cleanup as explained below.

In https://github.com/cockroachdb/cockroach/pull/108458 and other PRs we taught the processors of backup, restore and c2c to periodically send metas containing the TracingAggregatorEvents, for the coordinator to then process and persist for improved observability. In that logic we were defensive against a scenario in which the processor received a root context with no tracing span. In which case we never initialized the tracing aggregator on the processor. This should never be possible in production code, but we want to prevent failing the replication job if this were to happen. As part of this defense we also returned `nil` instead of the meta in `Next()`. What We didn't realize was that return a nil row and nil meta indicates that the consumer has been completely drained and causes the processor to pre-emptively drain and shutdown.

With this change, if the root context does not have a tracing span and we are unable to init a tracing aggregator, we simply do not allow the timer controlling the return of the TracingAggergatorEvents to fire. By doing this, we avoid a situation where a nil row and nil meta are returned too early.

As part of this cleanup this change also simplifies the tracing aggregator. The aggregator is no longer responsible for creating a child span and registering a listener. Instead it simply returns an object that can be registered as an event listener by the caller. The former was an approach that was necessary when we wanted to decorate the span with LazyTags, but nobody uses LazyTags and we have a much better workflow to consume aggregator events with the `Advanced Debugging` job details page.

This simplification was motivated by the fact that `processorbase.StartInternal` now takes event listeners that can be registered with the tracing span of the context that hangs of the processor, and is accessible via the `processor.Ctx()` method.

Fixes: #109658
Release note: None