### PR TITLE
roachtest: add option to always use latest predecessor in mixedversion

### DIFF
--- a/pkg/cmd/roachtest/tests/mixed_version_backup.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_backup.go
@@ -2135,6 +2135,7 @@ func registerBackupMixedVersion(r registry.Registry) {
 				// that might exist in the cluster by the time the upgrade is
 				// attempted.
 				mixedversion.UpgradeTimeout(30*time.Minute),
+				mixedversion.AlwaysUseLatestPredecessors(),
 			)
 			testRNG := mvt.RNG()
 


### PR DESCRIPTION
See documentation for new function for more details. This PR also updates the `backup-restore/mixed-version` roachtest to use the new option.

Epic: none

Release note: None