### PR TITLE
release-23.1: changefeedccl: add changefeed_progress and aggregator_progress sli metrics

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -89,6 +89,7 @@ type changeAggregator struct {
 
 	metrics                *Metrics
 	sliMetrics             *sliMetrics
+	sliMetricsID           int64
 	closeTelemetryRecorder func()
 	knobs                  TestingKnobs
 }
@@ -262,6 +263,7 @@ func (ca *changeAggregator) Start(ctx context.Context) {
 		ca.cancel()
 		return
 	}
+	ca.sliMetricsID = ca.sliMetrics.claimId()
 
 	// TODO(jayant): add support for sinkless changefeeds using UUID
 	recorder := metricsRecorder(ca.sliMetrics)
@@ -493,6 +495,9 @@ func (ca *changeAggregator) close() {
 		// Best effort: context is often cancel by now, so we expect to see an error
 		_ = ca.sink.Close()
 	}
+
+	ca.closeMetrics()
+
 	ca.memAcc.Close(ca.Ctx())
 	if ca.kvFeedMemMon != nil {
 		ca.kvFeedMemMon.Stop(ca.Ctx())
@@ -593,6 +598,11 @@ func (ca *changeAggregator) noteResolvedSpan(resolved jobspb.ResolvedSpan) error
 		return err
 	}
 
+	// The resolved sliMetric data backs the aggregator_progress metric
+	if advanced {
+		ca.sliMetrics.setResolved(ca.sliMetricsID, ca.frontier.Frontier())
+	}
+
 	forceFlush := resolved.BoundaryType != jobspb.ResolvedSpan_NONE
 
 	checkpointFrontier := advanced &&
@@ -674,6 +684,12 @@ func (ca *changeAggregator) emitResolved(batch jobspb.ResolvedSpans) error {
 	return nil
 }
 
+// closeMetrics de-registers the aggregator from the sliMetrics registry so that
+// it's no longer considered by the aggregator_progress gauge
+func (ca *changeAggregator) closeMetrics() {
+	ca.sliMetrics.closeId(ca.sliMetricsID)
+}
+
 // ConsumerClosed is part of the RowSource interface.
 func (ca *changeAggregator) ConsumerClosed() {
 	// The consumer is done, Next() will not be called again.
@@ -738,9 +754,12 @@ type changeFrontier struct {
 	// metrics are monitoring counters shared between all changefeeds.
 	metrics    *Metrics
 	sliMetrics *sliMetrics
-	// metricsID is used as the unique id of this changefeed in the
-	// metrics.MaxBehindNanos map.
-	metricsID int
+
+	// sliMetricsID and metricsID uniquely identify the changefeed in the metrics's
+	// map (a shared struct across all changefeeds on the node) and the sliMetrics's
+	// map (shared structure between all feeds within the same scope on the node).
+	metricsID    int
+	sliMetricsID int64
 
 	knobs TestingKnobs
 }
@@ -1045,6 +1064,9 @@ func (cf *changeFrontier) Start(ctx context.Context) {
 	cf.metrics.mu.id++
 	sli.RunningCount.Inc(1)
 	cf.metrics.mu.Unlock()
+
+	cf.sliMetricsID = cf.sliMetrics.claimId()
+
 	// TODO(dan): It's very important that we de-register from the metric because
 	// if we orphan an entry in there, our monitoring will lie (say the changefeed
 	// is behind when it may not be). We call this in `close` but that doesn't
@@ -1084,6 +1106,8 @@ func (cf *changeFrontier) closeMetrics() {
 	delete(cf.metrics.mu.resolved, cf.metricsID)
 	cf.metricsID = -1
 	cf.metrics.mu.Unlock()
+
+	cf.sliMetrics.closeId(cf.sliMetricsID)
 }
 
 // Next is part of the RowSource interface.
@@ -1215,6 +1239,13 @@ func (cf *changeFrontier) forwardFrontier(resolved jobspb.ResolvedSpan) error {
 		// Keeping this after the checkpointJobProgress call will avoid
 		// some duplicates if a restart happens.
 		newResolved := cf.frontier.Frontier()
+
+		// The feed's checkpoint is tracked in a map which is used to inform the
+		// checkpoint_progress metric which will return the lowest timestamp across
+		// all feeds in the scope.
+		cf.sliMetrics.setCheckpoint(cf.sliMetricsID, newResolved)
+
+		// This backs max_behind_nanos which is deprecated in favor of checkpoint_progress
 		cf.metrics.mu.Lock()
 		if cf.metricsID != -1 {
 			cf.metrics.mu.resolved[cf.metricsID] = newResolved

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -424,6 +424,162 @@ func TestToJSONAsChangefeed(t *testing.T) {
 	cdcTest(t, testFn)
 }
 
+// TestChangefeedProgressMetrics tests the changefeed.aggregator_progress and
+// changefeed.checkpoint_progress metrics.
+func TestChangefeedProgressMetrics(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	// Verify the aggmetric functional gauges work correctly
+	t.Run("aggregate functional gauge", func(t *testing.T) {
+		cdcTest(t, func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
+			registry := s.Server.JobRegistry().(*jobs.Registry)
+			metrics := registry.MetricsStruct().Changefeed.(*Metrics)
+			defaultSLI, err := metrics.getSLIMetrics(defaultSLIScope)
+			require.NoError(t, err)
+			sliA, err := metrics.getSLIMetrics("scope_a")
+			require.NoError(t, err)
+			sliB, err := metrics.getSLIMetrics("scope_b")
+			require.NoError(t, err)
+
+			defaultSLI.mu.checkpoint[5] = hlc.Timestamp{WallTime: 1}
+
+			sliA.mu.checkpoint[1] = hlc.Timestamp{WallTime: 2}
+			sliA.mu.checkpoint[2] = hlc.Timestamp{WallTime: 5}
+			sliA.mu.checkpoint[3] = hlc.Timestamp{WallTime: 0} // Zero timestamp should be ignored.
+
+			sliB.mu.checkpoint[1] = hlc.Timestamp{WallTime: 4}
+			sliB.mu.checkpoint[2] = hlc.Timestamp{WallTime: 9}
+
+			// Ensure each scope gets the correct value
+			require.Equal(t, int64(1), defaultSLI.CheckpointProgress.Value())
+			require.Equal(t, int64(2), sliA.CheckpointProgress.Value())
+			require.Equal(t, int64(4), sliB.CheckpointProgress.Value())
+
+			// Ensure the value progresses upon changefeed progress
+			defaultSLI.mu.checkpoint[5] = hlc.Timestamp{WallTime: 20}
+			require.Equal(t, int64(20), defaultSLI.CheckpointProgress.Value())
+
+			// Ensure the value updates correctly upon changefeeds completing
+			delete(sliB.mu.checkpoint, 1)
+			require.Equal(t, int64(9), sliB.CheckpointProgress.Value())
+			delete(sliB.mu.checkpoint, 2)
+			require.Equal(t, int64(0), sliB.CheckpointProgress.Value())
+
+			// Ensure the aggregate value is correct after progress / completion
+			require.Equal(t, int64(2), metrics.AggMetrics.CheckpointProgress.Value())
+			sliA.mu.checkpoint[1] = hlc.Timestamp{WallTime: 30}
+			require.Equal(t, int64(5), metrics.AggMetrics.CheckpointProgress.Value())
+			delete(sliA.mu.checkpoint, 2)
+			require.Equal(t, int64(20), metrics.AggMetrics.CheckpointProgress.Value())
+			delete(defaultSLI.mu.checkpoint, 5)
+			require.Equal(t, int64(30), metrics.AggMetrics.CheckpointProgress.Value())
+			delete(sliA.mu.checkpoint, 1)
+			require.Equal(t, int64(0), metrics.AggMetrics.CheckpointProgress.Value())
+		})
+	})
+
+	// Verify that ids must be registered to have an effect.
+	t.Run("id registration", func(t *testing.T) {
+		cdcTest(t, func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
+			registry := s.Server.JobRegistry().(*jobs.Registry)
+			metrics := registry.MetricsStruct().Changefeed.(*Metrics)
+			sliA, err := metrics.getSLIMetrics("scope_a")
+			require.NoError(t, err)
+
+			unregisteredID := int64(999)
+			id1 := sliA.claimId()
+			id2 := sliA.claimId()
+			id3 := sliA.claimId()
+			sliA.setResolved(unregisteredID, hlc.Timestamp{WallTime: 0})
+			sliA.setResolved(id1, hlc.Timestamp{WallTime: 1})
+			sliA.setResolved(id2, hlc.Timestamp{WallTime: 2})
+			sliA.setResolved(id3, hlc.Timestamp{WallTime: 3})
+
+			sliA.setCheckpoint(unregisteredID, hlc.Timestamp{WallTime: 0})
+			sliA.setCheckpoint(id1, hlc.Timestamp{WallTime: 1})
+			sliA.setCheckpoint(id2, hlc.Timestamp{WallTime: 2})
+			sliA.setCheckpoint(id3, hlc.Timestamp{WallTime: 3})
+
+			require.Equal(t, int64(1), metrics.AggMetrics.CheckpointProgress.Value())
+			require.Equal(t, int64(1), metrics.AggMetrics.AggregatorProgress.Value())
+
+			sliA.closeId(id1)
+
+			require.Equal(t, int64(2), metrics.AggMetrics.CheckpointProgress.Value())
+			require.Equal(t, int64(2), metrics.AggMetrics.AggregatorProgress.Value())
+
+		})
+	})
+
+	// Verify that a changefeed updates the timestamps as it progresses
+	t.Run("running changefeed", func(t *testing.T) {
+		cdcTest(t, func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
+			sqlDB := sqlutils.MakeSQLRunner(s.DB)
+
+			sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY)`)
+			fooA := feed(t, f, `CREATE CHANGEFEED FOR foo WITH metrics_label='label_a', resolved='100ms'`)
+
+			registry := s.Server.JobRegistry().(*jobs.Registry)
+			metrics := registry.MetricsStruct().Changefeed.(*Metrics)
+			sliA, err := metrics.getSLIMetrics("label_a")
+			require.NoError(t, err)
+
+			// Verify that aggregator_progress has recurring updates
+			var lastTimestamp int64 = 0
+			for i := 0; i < 3; i++ {
+				testutils.SucceedsSoon(t, func() error {
+					progress := sliA.AggregatorProgress.Value()
+					if progress > lastTimestamp {
+						lastTimestamp = progress
+						return nil
+					}
+					return errors.Newf("waiting for aggregator_progress to advance from %d (value=%d)",
+						lastTimestamp, progress)
+				})
+			}
+
+			// Verify that checkpoint_progress has recurring updates
+			for i := 0; i < 3; i++ {
+				testutils.SucceedsSoon(t, func() error {
+					progress := sliA.CheckpointProgress.Value()
+					if progress > lastTimestamp {
+						lastTimestamp = progress
+						return nil
+					}
+					return errors.Newf("waiting for checkpoint_progress to advance from %d (value=%d)",
+						lastTimestamp, progress)
+				})
+			}
+
+			sliB, err := registry.MetricsStruct().Changefeed.(*Metrics).getSLIMetrics("label_b")
+			require.Equal(t, int64(0), sliB.AggregatorProgress.Value())
+			fooB := feed(t, f, `CREATE CHANGEFEED FOR foo WITH metrics_label='label_b', resolved='100ms'`)
+			defer closeFeed(t, fooB)
+			require.NoError(t, err)
+			// Verify that aggregator_progress has recurring updates
+			testutils.SucceedsSoon(t, func() error {
+				progress := sliB.AggregatorProgress.Value()
+				if progress > 0 {
+					return nil
+				}
+				return errors.Newf("waiting for second aggregator_progress to advance (value=%d)", progress)
+			})
+
+			closeFeed(t, fooA)
+			testutils.SucceedsSoon(t, func() error {
+				aggregatorProgress := sliA.AggregatorProgress.Value()
+				checkpointProgress := sliA.CheckpointProgress.Value()
+				if aggregatorProgress == 0 && checkpointProgress == 0 {
+					return nil
+				}
+				return errors.Newf("waiting for progress metrics to be 0 (ap=%d, cp=%d)",
+					aggregatorProgress, checkpointProgress)
+			})
+		})
+	})
+}
+
 func TestChangefeedIdleness(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)

--- a/pkg/ccl/changefeedccl/metrics.go
+++ b/pkg/ccl/changefeedccl/metrics.go
@@ -68,6 +68,8 @@ type AggMetrics struct {
 	InternalRetryMessageCount *aggmetric.AggGauge
 	SchemaRegistrations       *aggmetric.AggCounter
 	SchemaRegistryRetries     *aggmetric.AggCounter
+	AggregatorProgress        *aggmetric.AggGauge
+	CheckpointProgress        *aggmetric.AggGauge
 
 	// There is always at least 1 sliMetrics created for defaultSLI scope.
 	mu struct {
@@ -128,6 +130,55 @@ type sliMetrics struct {
 	InternalRetryMessageCount *aggmetric.Gauge
 	SchemaRegistrations       *aggmetric.Counter
 	SchemaRegistryRetries     *aggmetric.Counter
+	AggregatorProgress        *aggmetric.Gauge
+	CheckpointProgress        *aggmetric.Gauge
+
+	mu struct {
+		syncutil.Mutex
+		id         int64
+		resolved   map[int64]hlc.Timestamp
+		checkpoint map[int64]hlc.Timestamp
+	}
+}
+
+// closeId unregisters an id. The id can still be used after its closed, but
+// such usages will be noops.
+func (m *sliMetrics) closeId(id int64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.mu.checkpoint, id)
+	delete(m.mu.resolved, id)
+}
+
+// setResolved writes a resolved timestamp entry for the given id.
+func (m *sliMetrics) setResolved(id int64, ts hlc.Timestamp) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, ok := m.mu.resolved[id]; ok {
+		m.mu.resolved[id] = ts
+	}
+}
+
+// setCheckpoint writes a checkpoint timestamp entry for the given id.
+func (m *sliMetrics) setCheckpoint(id int64, ts hlc.Timestamp) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, ok := m.mu.checkpoint[id]; ok {
+		m.mu.checkpoint[id] = ts
+	}
+}
+
+// claimId claims a unique ID.
+func (m *sliMetrics) claimId() int64 {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	id := m.mu.id
+	// Seed entries with the zero timestamp and expect these to be
+	// ignored until a nonzero timestamp is written.
+	m.mu.checkpoint[id] = hlc.Timestamp{}
+	m.mu.resolved[id] = hlc.Timestamp{}
+	m.mu.id++
+	return id
 }
 
 // sinkDoesNotCompress is a sentinel value indicating the sink
@@ -551,6 +602,28 @@ func newAggregateMetrics(histogramWindow time.Duration) *AggMetrics {
 		Measurement: "Messages",
 		Unit:        metric.Unit_COUNT,
 	}
+	metaAggregatorProgress := metric.Metadata{
+		Name:        "changefeed.aggregator_progress",
+		Help:        "The earliest timestamp up to which any aggregator is guaranteed to have emitted all values for",
+		Measurement: "Unix Timestamp Nanoseconds",
+		Unit:        metric.Unit_TIMESTAMP_NS,
+	}
+	metaCheckpointProgress := metric.Metadata{
+		Name:        "changefeed.checkpoint_progress",
+		Help:        "The earliest timestamp of any changefeed's persisted checkpoint (values prior to this timestamp will never need to be re-emitted)",
+		Measurement: "Unix Timestamp Nanoseconds",
+		Unit:        metric.Unit_TIMESTAMP_NS,
+	}
+
+	functionalGaugeMinFn := func(childValues []int64) int64 {
+		var min int64
+		for _, val := range childValues {
+			if min == 0 || (val != 0 && val < min) {
+				min = val
+			}
+		}
+		return min
+	}
 	// NB: When adding new histograms, use sigFigs = 1.  Older histograms
 	// retain significant figures of 2.
 	b := aggmetric.MakeBuilder("scope")
@@ -613,6 +686,8 @@ func newAggregateMetrics(histogramWindow time.Duration) *AggMetrics {
 		InternalRetryMessageCount: b.Gauge(metaInternalRetryMessageCount),
 		SchemaRegistryRetries:     b.Counter(metaSchemaRegistryRetriesCount),
 		SchemaRegistrations:       b.Counter(metaSchemaRegistryRegistrations),
+		AggregatorProgress:        b.FunctionalGauge(metaAggregatorProgress, functionalGaugeMinFn),
+		CheckpointProgress:        b.FunctionalGauge(metaCheckpointProgress, functionalGaugeMinFn),
 	}
 	a.mu.sliMetrics = make(map[string]*sliMetrics)
 	_, err := a.getOrCreateScope(defaultSLIScope)
@@ -673,6 +748,29 @@ func (a *AggMetrics) getOrCreateScope(scope string) (*sliMetrics, error) {
 		SchemaRegistryRetries:     a.SchemaRegistryRetries.AddChild(scope),
 		SchemaRegistrations:       a.SchemaRegistrations.AddChild(scope),
 	}
+	sm.mu.resolved = make(map[int64]hlc.Timestamp)
+	sm.mu.checkpoint = make(map[int64]hlc.Timestamp)
+	sm.mu.id = 1 // start the first id at 1 so we can detect intiialization
+
+	minTimestampGetter := func(m map[int64]hlc.Timestamp) func() int64 {
+		return func() int64 {
+			sm.mu.Lock()
+			defer sm.mu.Unlock()
+			var minTs int64
+			for _, hlcTs := range m {
+				// Ignore empty timestamps which new entries are seeded with.
+				if hlcTs.WallTime != 0 {
+					// Track the min timestamp.
+					if minTs == 0 || hlcTs.WallTime < minTs {
+						minTs = hlcTs.WallTime
+					}
+				}
+			}
+			return minTs
+		}
+	}
+	sm.AggregatorProgress = a.AggregatorProgress.AddFunctionalChild(minTimestampGetter(sm.mu.resolved), scope)
+	sm.CheckpointProgress = a.CheckpointProgress.AddFunctionalChild(minTimestampGetter(sm.mu.checkpoint), scope)
 
 	a.mu.sliMetrics[scope] = sm
 	return sm, nil
@@ -694,6 +792,8 @@ type Metrics struct {
 	ParallelConsumerConsumeNanos   metric.IHistogram
 	ParallelConsumerInFlightEvents *metric.Gauge
 
+	// This map and the MaxBehindNanos metric are deprecated in favor of
+	// CheckpointProgress which is stored in the sliMetrics.
 	mu struct {
 		syncutil.Mutex
 		id       int

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -1647,6 +1647,18 @@ var charts = []sectionDescription{
 					"changefeed.schema_registry.registrations",
 				},
 			},
+			{
+				Title: "Changefeed Aggregator Progress",
+				Metrics: []string{
+					"changefeed.aggregator_progress",
+				},
+			},
+			{
+				Title: "Changefeed Checkpoint Progress",
+				Metrics: []string{
+					"changefeed.checkpoint_progress",
+				},
+			},
 		},
 	},
 	{

--- a/pkg/util/metric/aggmetric/agg_metric.go
+++ b/pkg/util/metric/aggmetric/agg_metric.go
@@ -38,6 +38,12 @@ func (b Builder) Gauge(metadata metric.Metadata) *AggGauge {
 	return NewGauge(metadata, b.labels...)
 }
 
+// FunctionalGauge constructs a new AggGauge with the Builder's labels who's
+// value is determined when asked for.
+func (b Builder) FunctionalGauge(metadata metric.Metadata, f func(cvs []int64) int64) *AggGauge {
+	return NewFunctionalGauge(metadata, f, b.labels...)
+}
+
 // GaugeFloat64 constructs a new AggGaugeFloat64 with the Builder's labels.
 func (b Builder) GaugeFloat64(metadata metric.Metadata) *AggGaugeFloat64 {
 	return NewGaugeFloat64(metadata, b.labels...)


### PR DESCRIPTION
Backport 1/1 commits from https://github.com/cockroachdb/cockroach/pull/108757

---

Resolves #97009

An aggregator_progress sli metric has been added to track the timestamp progress of each individual aggregator node, which can help identify single aggregators that lag behind the rest.  A checkpoint_progress sli metric has also been added to act in a similar capacity to max_behind_nanos.

max_behind_nanos can be removed but since this PR needs to be backported I left the max_behind_nanos code untouched to be removed in a followup PR.

I elected to keep everything as just the timestamp rather than a max_behind setup since it's still possible in graphing tools to determine the lag (ex: grafana query would be `time()*1000 -
(changefeed_aggregator_progress{scope!=""}/1000/1000))`.

Release note (ops change): changefeed metrics now include a changefeed.checkpoint_progress metric which is similar to changefeed.max_behind_nanos but supports metrics labels, as well as an changefeed.aggregator_progress metric which can track the progress of individual aggregators (the lowest timestamp for which all aggregators with the label have emitted all values they're responsible for).

Informs: https://github.com/cockroachdb/cockroach/issues/107266
Release justification: Observability improvement. Customer ask.