### PR TITLE
release-22.2: changefeedccl: add changefeed_progress and aggregator_progress sli metrics

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -90,6 +90,7 @@ type changeAggregator struct {
 
 	metrics                *Metrics
 	sliMetrics             *sliMetrics
+	sliMetricsID           int64
 	closeTelemetryRecorder func()
 	knobs                  TestingKnobs
 }
@@ -264,6 +265,7 @@ func (ca *changeAggregator) Start(ctx context.Context) {
 		ca.cancel()
 		return
 	}
+	ca.sliMetricsID = ca.sliMetrics.claimId()
 
 	// TODO(jayant): add support for sinkless changefeeds using UUID
 	recorder := metricsRecorder(ca.sliMetrics)
@@ -496,6 +498,9 @@ func (ca *changeAggregator) close() {
 			log.Warningf(ca.Ctx(), `error closing sink. goroutines may have leaked: %v`, err)
 		}
 	}
+
+	ca.closeMetrics()
+
 	ca.memAcc.Close(ca.Ctx())
 	if ca.kvFeedMemMon != nil {
 		ca.kvFeedMemMon.Stop(ca.Ctx())
@@ -589,6 +594,11 @@ func (ca *changeAggregator) noteResolvedSpan(resolved jobspb.ResolvedSpan) error
 		return err
 	}
 
+	// The resolved sliMetric data backs the aggregator_progress metric
+	if advanced {
+		ca.sliMetrics.setResolved(ca.sliMetricsID, ca.frontier.Frontier())
+	}
+
 	forceFlush := resolved.BoundaryType != jobspb.ResolvedSpan_NONE
 
 	checkpointFrontier := advanced &&
@@ -669,6 +679,12 @@ func (ca *changeAggregator) emitResolved(batch jobspb.ResolvedSpans) error {
 	return nil
 }
 
+// closeMetrics de-registers the aggregator from the sliMetrics registry so that
+// it's no longer considered by the aggregator_progress gauge
+func (ca *changeAggregator) closeMetrics() {
+	ca.sliMetrics.closeId(ca.sliMetricsID)
+}
+
 // ConsumerClosed is part of the RowSource interface.
 func (ca *changeAggregator) ConsumerClosed() {
 	// The consumer is done, Next() will not be called again.
@@ -733,9 +749,12 @@ type changeFrontier struct {
 	// metrics are monitoring counters shared between all changefeeds.
 	metrics    *Metrics
 	sliMetrics *sliMetrics
-	// metricsID is used as the unique id of this changefeed in the
-	// metrics.MaxBehindNanos map.
-	metricsID int
+
+	// sliMetricsID and metricsID uniquely identify the changefeed in the metrics's
+	// map (a shared struct across all changefeeds on the node) and the sliMetrics's
+	// map (shared structure between all feeds within the same scope on the node).
+	metricsID    int
+	sliMetricsID int64
 
 	knobs TestingKnobs
 }
@@ -1038,6 +1057,9 @@ func (cf *changeFrontier) Start(ctx context.Context) {
 	cf.metrics.mu.id++
 	sli.RunningCount.Inc(1)
 	cf.metrics.mu.Unlock()
+
+	cf.sliMetricsID = cf.sliMetrics.claimId()
+
 	// TODO(dan): It's very important that we de-register from the metric because
 	// if we orphan an entry in there, our monitoring will lie (say the changefeed
 	// is behind when it may not be). We call this in `close` but that doesn't
@@ -1077,6 +1099,8 @@ func (cf *changeFrontier) closeMetrics() {
 	delete(cf.metrics.mu.resolved, cf.metricsID)
 	cf.metricsID = -1
 	cf.metrics.mu.Unlock()
+
+	cf.sliMetrics.closeId(cf.sliMetricsID)
 }
 
 // Next is part of the RowSource interface.
@@ -1208,6 +1232,13 @@ func (cf *changeFrontier) forwardFrontier(resolved jobspb.ResolvedSpan) error {
 		// Keeping this after the checkpointJobProgress call will avoid
 		// some duplicates if a restart happens.
 		newResolved := cf.frontier.Frontier()
+
+		// The feed's checkpoint is tracked in a map which is used to inform the
+		// checkpoint_progress metric which will return the lowest timestamp across
+		// all feeds in the scope.
+		cf.sliMetrics.setCheckpoint(cf.sliMetricsID, newResolved)
+
+		// This backs max_behind_nanos which is deprecated in favor of checkpoint_progress
 		cf.metrics.mu.Lock()
 		if cf.metricsID != -1 {
 			cf.metrics.mu.resolved[cf.metricsID] = newResolved

--- a/pkg/ccl/changefeedccl/metrics.go
+++ b/pkg/ccl/changefeedccl/metrics.go
@@ -64,6 +64,8 @@ type AggMetrics struct {
 	InternalRetryMessageCount *aggmetric.AggGauge
 	SchemaRegistrations       *aggmetric.AggCounter
 	SchemaRegistryRetries     *aggmetric.AggCounter
+	AggregatorProgress        *aggmetric.AggGauge
+	CheckpointProgress        *aggmetric.AggGauge
 
 	// There is always at least 1 sliMetrics created for defaultSLI scope.
 	mu struct {
@@ -119,6 +121,55 @@ type sliMetrics struct {
 	InternalRetryMessageCount *aggmetric.Gauge
 	SchemaRegistrations       *aggmetric.Counter
 	SchemaRegistryRetries     *aggmetric.Counter
+	AggregatorProgress        *aggmetric.Gauge
+	CheckpointProgress        *aggmetric.Gauge
+
+	mu struct {
+		syncutil.Mutex
+		id         int64
+		resolved   map[int64]hlc.Timestamp
+		checkpoint map[int64]hlc.Timestamp
+	}
+}
+
+// closeId unregisters an id. The id can still be used after its closed, but
+// such usages will be noops.
+func (m *sliMetrics) closeId(id int64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.mu.checkpoint, id)
+	delete(m.mu.resolved, id)
+}
+
+// setResolved writes a resolved timestamp entry for the given id.
+func (m *sliMetrics) setResolved(id int64, ts hlc.Timestamp) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, ok := m.mu.resolved[id]; ok {
+		m.mu.resolved[id] = ts
+	}
+}
+
+// setCheckpoint writes a checkpoint timestamp entry for the given id.
+func (m *sliMetrics) setCheckpoint(id int64, ts hlc.Timestamp) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, ok := m.mu.checkpoint[id]; ok {
+		m.mu.checkpoint[id] = ts
+	}
+}
+
+// claimId claims a unique ID.
+func (m *sliMetrics) claimId() int64 {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	id := m.mu.id
+	// Seed entries with the zero timestamp and expect these to be
+	// ignored until a nonzero timestamp is written.
+	m.mu.checkpoint[id] = hlc.Timestamp{}
+	m.mu.resolved[id] = hlc.Timestamp{}
+	m.mu.id++
+	return id
 }
 
 // sinkDoesNotCompress is a sentinel value indicating the sink
@@ -500,6 +551,28 @@ func newAggregateMetrics(histogramWindow time.Duration) *AggMetrics {
 		Measurement: "Registrations",
 		Unit:        metric.Unit_COUNT,
 	}
+	metaAggregatorProgress := metric.Metadata{
+		Name:        "changefeed.aggregator_progress",
+		Help:        "The earliest timestamp up to which any aggregator is guaranteed to have emitted all values for",
+		Measurement: "Unix Timestamp Nanoseconds",
+		Unit:        metric.Unit_TIMESTAMP_NS,
+	}
+	metaCheckpointProgress := metric.Metadata{
+		Name:        "changefeed.checkpoint_progress",
+		Help:        "The earliest timestamp of any changefeed's persisted checkpoint (values prior to this timestamp will never need to be re-emitted)",
+		Measurement: "Unix Timestamp Nanoseconds",
+		Unit:        metric.Unit_TIMESTAMP_NS,
+	}
+
+	functionalGaugeMinFn := func(childValues []int64) int64 {
+		var min int64
+		for _, val := range childValues {
+			if min == 0 || (val != 0 && val < min) {
+				min = val
+			}
+		}
+		return min
+	}
 	// NB: When adding new histograms, use sigFigs = 1.  Older histograms
 	// retain significant figures of 2.
 	b := aggmetric.MakeBuilder("scope")
@@ -553,6 +626,8 @@ func newAggregateMetrics(histogramWindow time.Duration) *AggMetrics {
 		InternalRetryMessageCount: b.Gauge(metaInternalRetryMessageCount),
 		SchemaRegistryRetries:     b.Counter(metaSchemaRegistryRetriesCount),
 		SchemaRegistrations:       b.Counter(metaSchemaRegistryRegistrations),
+		AggregatorProgress:        b.FunctionalGauge(metaAggregatorProgress, functionalGaugeMinFn),
+		CheckpointProgress:        b.FunctionalGauge(metaCheckpointProgress, functionalGaugeMinFn),
 	}
 	a.mu.sliMetrics = make(map[string]*sliMetrics)
 	_, err := a.getOrCreateScope(defaultSLIScope)
@@ -610,6 +685,29 @@ func (a *AggMetrics) getOrCreateScope(scope string) (*sliMetrics, error) {
 		SchemaRegistryRetries:     a.SchemaRegistryRetries.AddChild(scope),
 		SchemaRegistrations:       a.SchemaRegistrations.AddChild(scope),
 	}
+	sm.mu.resolved = make(map[int64]hlc.Timestamp)
+	sm.mu.checkpoint = make(map[int64]hlc.Timestamp)
+	sm.mu.id = 1 // start the first id at 1 so we can detect intiialization
+
+	minTimestampGetter := func(m map[int64]hlc.Timestamp) func() int64 {
+		return func() int64 {
+			sm.mu.Lock()
+			defer sm.mu.Unlock()
+			var minTs int64
+			for _, hlcTs := range m {
+				// Ignore empty timestamps which new entries are seeded with.
+				if hlcTs.WallTime != 0 {
+					// Track the min timestamp.
+					if minTs == 0 || hlcTs.WallTime < minTs {
+						minTs = hlcTs.WallTime
+					}
+				}
+			}
+			return minTs
+		}
+	}
+	sm.AggregatorProgress = a.AggregatorProgress.AddFunctionalChild(minTimestampGetter(sm.mu.resolved), scope)
+	sm.CheckpointProgress = a.CheckpointProgress.AddFunctionalChild(minTimestampGetter(sm.mu.checkpoint), scope)
 
 	a.mu.sliMetrics[scope] = sm
 	return sm, nil
@@ -631,6 +729,8 @@ type Metrics struct {
 	ParallelConsumerConsumeNanos   *metric.Counter
 	ParallelConsumerInFlightEvents *metric.Gauge
 
+	// This map and the MaxBehindNanos metric are deprecated in favor of
+	// CheckpointProgress which is stored in the sliMetrics.
 	mu struct {
 		syncutil.Mutex
 		id       int

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -1570,6 +1570,18 @@ var charts = []sectionDescription{
 					"changefeed.schema_registry.registrations",
 				},
 			},
+			{
+				Title: "Changefeed Aggregator Progress",
+				Metrics: []string{
+					"changefeed.aggregator_progress",
+				},
+			},
+			{
+				Title: "Changefeed Checkpoint Progress",
+				Metrics: []string{
+					"changefeed.checkpoint_progress",
+				},
+			},
 		},
 	},
 	{

--- a/pkg/util/metric/aggmetric/agg_metric.go
+++ b/pkg/util/metric/aggmetric/agg_metric.go
@@ -38,6 +38,12 @@ func (b Builder) Gauge(metadata metric.Metadata) *AggGauge {
 	return NewGauge(metadata, b.labels...)
 }
 
+// FunctionalGauge constructs a new AggGauge with the Builder's labels who's
+// value is determined when asked for.
+func (b Builder) FunctionalGauge(metadata metric.Metadata, f func(cvs []int64) int64) *AggGauge {
+	return NewFunctionalGauge(metadata, f, b.labels...)
+}
+
 // GaugeFloat64 constructs a new AggGaugeFloat64 with the Builder's labels.
 func (b Builder) GaugeFloat64(metadata metric.Metadata) *AggGaugeFloat64 {
 	return NewGaugeFloat64(metadata, b.labels...)

--- a/pkg/util/metric/aggmetric/gauge.go
+++ b/pkg/util/metric/aggmetric/gauge.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/gogo/protobuf/proto"
+	"github.com/google/btree"
 	io_prometheus_client "github.com/prometheus/client_model/go"
 )
 
@@ -35,6 +36,29 @@ var _ metric.PrometheusExportable = (*AggGauge)(nil)
 // NewGauge constructs a new AggGauge.
 func NewGauge(metadata metric.Metadata, childLabels ...string) *AggGauge {
 	g := &AggGauge{g: *metric.NewGauge(metadata)}
+	g.init(childLabels)
+	return g
+}
+
+// NewFunctionalGauge constructs a new AggGauge whose value is determined when
+// asked for by calling the provided function with the current values of every
+// child of the AggGauge.
+func NewFunctionalGauge(
+	metadata metric.Metadata, f func(childValues []int64) int64, childLabels ...string,
+) *AggGauge {
+	g := &AggGauge{}
+	gaugeFn := func() int64 {
+		values := make([]int64, 0)
+		g.childSet.mu.Lock()
+		defer g.childSet.mu.Unlock()
+		g.childSet.mu.tree.Ascend(func(item btree.Item) (wantMore bool) {
+			cg := item.(*Gauge)
+			values = append(values, cg.Value())
+			return true
+		})
+		return f(values)
+	}
+	g.g = *metric.NewFunctionalGauge(metadata, gaugeFn)
 	g.init(childLabels)
 	return g
 }
@@ -88,6 +112,19 @@ func (g *AggGauge) AddChild(labelVals ...string) *Gauge {
 	return child
 }
 
+// AddFunctionalChild adds a Gauge to this AggGauge where the value is
+// determined when asked for. This method panics if a Gauge already exists for
+// this set of labelVals.
+func (g *AggGauge) AddFunctionalChild(fn func() int64, labelVals ...string) *Gauge {
+	child := &Gauge{
+		parent:           g,
+		labelValuesSlice: labelValuesSlice(labelVals),
+		fn:               fn,
+	}
+	g.add(child)
+	return child
+}
+
 // Gauge is a child of a AggGauge. When it is incremented or decremented, so
 // too is the parent. When metrics are collected by prometheus, each of the
 // children will appear with a distinct label, however, when cockroach
@@ -96,6 +133,7 @@ type Gauge struct {
 	labelValuesSlice
 	parent *AggGauge
 	value  int64
+	fn     func() int64
 }
 
 // ToPrometheusMetric constructs a prometheus metric for this Gauge.
@@ -116,6 +154,9 @@ func (g *Gauge) Destroy() {
 
 // Value returns the gauge's current value.
 func (g *Gauge) Value() int64 {
+	if g.fn != nil {
+		return g.fn()
+	}
 	return atomic.LoadInt64(&g.value)
 }
 


### PR DESCRIPTION
Backport 1/1 commits from https://github.com/cockroachdb/cockroach/pull/108757

---

Resolves #97009

An aggregator_progress sli metric has been added to track the timestamp progress of each individual aggregator node, which can help identify single aggregators that lag behind the rest.  A checkpoint_progress sli metric has also been added to act in a similar capacity to max_behind_nanos.

max_behind_nanos can be removed but since this PR needs to be backported I left the max_behind_nanos code untouched to be removed in a followup PR.

I elected to keep everything as just the timestamp rather than a max_behind setup since it's still possible in graphing tools to determine the lag (ex: grafana query would be `time()*1000 -
(changefeed_aggregator_progress{scope!=""}/1000/1000))`.

Release note (ops change): changefeed metrics now include a changefeed.checkpoint_progress metric which is similar to changefeed.max_behind_nanos but supports metrics labels, as well as an changefeed.aggregator_progress metric which can track the progress of individual aggregators (the lowest timestamp for which all aggregators with the label have emitted all values they're responsible for).

Informs: https://github.com/cockroachdb/cockroach/issues/107266
Release justification: Observability improvement. Customer ask.