### PR TITLE
roachpb: don't un-abort txn proto after restart

### DIFF
--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -1216,15 +1216,16 @@ func (t *Transaction) BumpReadTimestamp(timestamp hlc.Timestamp) {
 // others) for the transaction. If t.ID is empty, then the transaction is
 // copied from o.
 func (t *Transaction) Update(o *Transaction) {
+	ctx := context.TODO()
 	if o == nil {
 		return
 	}
-	o.AssertInitialized(context.TODO())
+	o.AssertInitialized(ctx)
 	if t.ID == (uuid.UUID{}) {
 		*t = *o
 		return
 	} else if t.ID != o.ID {
-		log.Fatalf(context.Background(), "updating txn %s with different txn %s", t.String(), o.String())
+		log.Fatalf(ctx, "updating txn %s with different txn %s", t.String(), o.String())
 		return
 	}
 	if len(t.Key) == 0 {
@@ -1234,9 +1235,15 @@ func (t *Transaction) Update(o *Transaction) {
 
 	// Update epoch-scoped state, depending on the two transactions' epochs.
 	if t.Epoch < o.Epoch {
+		// Ensure that the transaction status makes sense. If the transaction
+		// has already been finalized, then it should remain finalized.
+		if !t.Status.IsFinalized() {
+			t.Status = o.Status
+		} else if t.Status == COMMITTED {
+			log.Warningf(ctx, "updating COMMITTED txn %s with txn at later epoch %s", t.String(), o.String())
+		}
 		// Replace all epoch-scoped state.
 		t.Epoch = o.Epoch
-		t.Status = o.Status
 		t.WriteTooOld = o.WriteTooOld
 		t.ReadTimestampFixed = o.ReadTimestampFixed
 		t.Sequence = o.Sequence
@@ -1254,7 +1261,7 @@ func (t *Transaction) Update(o *Transaction) {
 			}
 		case ABORTED:
 			if o.Status == COMMITTED {
-				log.Warningf(context.Background(), "updating ABORTED txn %s with COMMITTED txn %s", t.String(), o.String())
+				log.Warningf(ctx, "updating ABORTED txn %s with COMMITTED txn %s", t.String(), o.String())
 			}
 		case COMMITTED:
 			// Nothing to do.
@@ -1299,7 +1306,7 @@ func (t *Transaction) Update(o *Transaction) {
 			// aborted.
 			t.Status = ABORTED
 		case COMMITTED:
-			log.Warningf(context.Background(), "updating txn %s with COMMITTED txn at earlier epoch %s", t.String(), o.String())
+			log.Warningf(ctx, "updating txn %s with COMMITTED txn at earlier epoch %s", t.String(), o.String())
 		}
 	}
 

--- a/pkg/roachpb/data_test.go
+++ b/pkg/roachpb/data_test.go
@@ -733,21 +733,35 @@ func TestTransactionUpdateStaging(t *testing.T) {
 
 // TestTransactionUpdateAbortedOldEpoch tests that Transaction.Update propagates
 // an ABORTED status even when that status comes from a proto with an old epoch.
-// Once a transaction is ABORTED, it will stay aborted, even if its coordinator
-// doesn't know this at the time that it increments its epoch and retries.
+// It also tests that Transaction.Update retains an ABORTED status even when it
+// is updated with a new epoch with a PENDING status. Either way, once a
+// transaction is ABORTED, it will stay aborted, even if its coordinator doesn't
+// know this at the time that it increments its epoch and retries.
 func TestTransactionUpdateAbortedOldEpoch(t *testing.T) {
-	txn := nonZeroTxn
-	txn.Status = ABORTED
+	txnAbort := nonZeroTxn
+	txnAbort.Status = ABORTED
 
-	txnRestart := txn
+	txnRestart := nonZeroTxn
 	txnRestart.Epoch++
 	txnRestart.Status = PENDING
-	txnRestart.Update(&txn)
 
-	expTxn := txn
-	expTxn.Epoch++
-	expTxn.Status = ABORTED
-	require.Equal(t, expTxn, txnRestart)
+	testCases := []struct {
+		name      string
+		recv, arg Transaction
+	}{
+		{name: "aborted receiver", recv: txnAbort, arg: txnRestart},
+		{name: "aborted argument", recv: txnRestart, arg: txnAbort},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.recv.Update(&tc.arg)
+
+			expTxn := nonZeroTxn
+			expTxn.Epoch++
+			expTxn.Status = ABORTED
+			require.Equal(t, expTxn, tc.recv)
+		})
+	}
 }
 
 func TestTransactionClone(t *testing.T) {


### PR DESCRIPTION
Informs #108853.

This commit updates `Transaction.Update` to prevent ABORTED transactions from being moved back to PENDING if updated with a PENDING transaction with a newer epoch. This is how the mistaken error handling in #108853 allowed a transaction restart error to clobber a transaction aborted error and then move the TxnCoordSender's status back to PENDING such that future requests were not rejected by `maybeRejectClientLocked`.

Release note: None