### PR TITLE
backupccl: during restore, do not .Next() any keys in makeSimpleImportSpans

### DIFF
--- a/pkg/ccl/backupccl/restore_span_covering.go
+++ b/pkg/ccl/backupccl/restore_span_covering.go
@@ -122,11 +122,11 @@ var _ backupManifestFileIterator = &sstFileIterator{}
 //
 // The cover for those spans would look like:
 //
-//	[a, c\x00): 1, 4, 6
-//	[c\x00, e\x00): 1, 2, 4, 6
-//	[e\x00, f): 2, 6
+//	[a, c): 1, 4, 6
+//	[c, e): 1, 2, 4, 6
+//	[e, f): 2, 6
 //	[f, i): 3, 5, 6, 8
-//	[l, m): 9
+//	[l, p): 9
 //
 // This example is tested in TestRestoreEntryCoverExample.
 //
@@ -154,6 +154,35 @@ func makeSimpleImportSpans(
 	for _, requiredSpan := range requiredSpans {
 		filteredSpans := filter.filterCompleted(requiredSpan)
 		for _, span := range filteredSpans {
+			// endKeyNotCoveredFiles is a collection of files that, due to the end key
+			// inclusive nature of their spans, do not have their end key covered by
+			// the current cover. These are kept around so that they can be included
+			// in the next entry's file list whenever the cover is extended. This
+			// collection is populated from files in two cases:
+			//
+			//  1. A file has an end key equal to the end key of the last cover
+			//     entry's span. This means that we are still creating the cover and next
+			//     cover entry or an extension of the current cover should cover the end
+			//     key of this file. If we are done with creating the cover of a required
+			//     span, then a last step of extending the last cover span to the end key
+			//     of the required span should also cover this file. The most common
+			//     example of this case is when a file span causes a new cover entry
+			//     to be added. For example, if the current cover is {[a, b), [b, d)},
+			//     and we encounter a file with span [c, e], this will create a new
+			//     cover with span [d, e). However, the file that created the cover
+			//     span will not have its end key "e" covered yet, and thus must be added
+			//     to endKeyNotCoveredFiles. If we next encounter a file with span [d, e],
+			//     this file will not create a new cover entry as its end key does
+			//     not extend beyond the cover, but the file will also be added to
+			//     endKeyNotCoveredFiles as its end key "e" is equal to the end key of
+			//     the final cover span and thus not covered.
+			//
+			//  2. A file has an end key equal to the start key of the current
+			//     (filtered) required span. This means that we've just begun processing
+			//     this span and this file should be covered as soon as we start creating
+			//     the cover for this span.
+			var endKeyNotCoveredFiles restoreFileSpecs
+
 			layersCoveredLater := filter.getLayersCoveredLater(span, backups)
 			spanCoverStart := len(cover)
 			for layer := range backups {
@@ -182,45 +211,68 @@ func makeSimpleImportSpans(
 						break
 					}
 					f := it.Value()
-					fspan := endKeyInclusiveSpan(f.Span)
-					if sp := span.Intersect(fspan); sp.Valid() {
-						fileSpec := execinfrapb.RestoreFileSpec{Path: f.Path, Dir: backups[layer].Dir}
-						if dir, ok := backupLocalityMap[layer][f.LocalityKV]; ok {
-							fileSpec = execinfrapb.RestoreFileSpec{Path: f.Path, Dir: dir}
-						}
+					fileSpec := execinfrapb.RestoreFileSpec{Path: f.Path, Dir: backups[layer].Dir}
+					if dir, ok := backupLocalityMap[layer][f.LocalityKV]; ok {
+						fileSpec = execinfrapb.RestoreFileSpec{Path: f.Path, Dir: dir}
+					}
 
-						// Lookup the size of the file being added; if the backup didn't
-						// record a file size, just assume it is 16mb for estimating.
-						sz := f.EntryCounts.DataSize
-						if sz == 0 {
-							sz = 16 << 20
-						}
+					// Lookup the size of the file being added; if the backup didn't
+					// record a file size, just assume it is 16mb for estimating.
+					sz := f.EntryCounts.DataSize
+					if sz == 0 {
+						sz = 16 << 20
+					}
 
+					if intersectingFileSpan, valid := getIntersectingFileSpan(span, f.Span); valid {
 						if len(cover) == spanCoverStart {
-							cover = append(cover, makeEntry(span.Key, sp.EndKey, fileSpec))
-							lastCovSpanSize = sz
+							if intersectingFileSpan.EndKey.Compare(span.Key) > 0 {
+								// If we can make a first cover span with the end key, do so.
+								entry := makeEntry(span.Key, intersectingFileSpan.EndKey)
+								lastCovSpanSize = 0
+								lastCovSpanSize += endKeyNotCoveredFiles.drain(&entry)
+
+								entry.Files = append(entry.Files, fileSpec)
+								lastCovSpanSize += sz
+
+								cover = append(cover, entry)
+							} else {
+								// Otherwise this is case 2 above where the file intersects only
+								// the start key of the span, so we add the file to
+								// endKeyNotCoveredFiles without creating a cover entry.
+								endKeyNotCoveredFiles.add(fileSpec, sz)
+							}
 						} else {
 							// If this file extends beyond the end of the last partition of the
 							// cover, either append a new partition for the uncovered span or
 							// grow the last one if size allows.
-							if covEnd := cover[len(cover)-1].Span.EndKey; sp.EndKey.Compare(covEnd) > 0 {
+							if covEnd := cover[len(cover)-1].Span.EndKey; intersectingFileSpan.EndKey.Compare(covEnd) > 0 {
 								// If adding the item size to the current rightmost span size will
 								// exceed the target size, make a new span, otherwise extend the
 								// rightmost span to include the item.
 								if lastCovSpanSize+sz > filter.targetSize {
-									cover = append(cover, makeEntry(covEnd, sp.EndKey, fileSpec))
-									lastCovSpanSize = sz
+									entry := makeEntry(covEnd, intersectingFileSpan.EndKey)
+									lastCovSpanSize = 0
+									lastCovSpanSize += endKeyNotCoveredFiles.drain(&entry)
+
+									entry.Files = append(entry.Files, fileSpec)
+									lastCovSpanSize += sz
+
+									cover = append(cover, entry)
 								} else {
-									cover[len(cover)-1].Span.EndKey = sp.EndKey
+									cover[len(cover)-1].Span.EndKey = intersectingFileSpan.EndKey
 									cover[len(cover)-1].Files = append(cover[len(cover)-1].Files, fileSpec)
 									lastCovSpanSize += sz
+
+									// Drain endKeyNotCoveredFiles if we extended the last cover span, as
+									// their end keys should be covered by any extension.
+									lastCovSpanSize += endKeyNotCoveredFiles.drain(&cover[len(cover)-1])
 								}
 							}
 							// Now ensure the file is included in any partition in the existing
 							// cover which overlaps.
-							for i := covPos; i < len(cover) && cover[i].Span.Key.Compare(sp.EndKey) < 0; i++ {
+							for i := covPos; i < len(cover) && cover[i].Span.Key.Compare(intersectingFileSpan.EndKey) <= 0; i++ {
 								// If file overlaps, it needs to be in this partition.
-								if cover[i].Span.Overlaps(sp) {
+								if inclusiveOverlap(cover[i].Span, f.Span) {
 									// If this is the last partition, we might have added it above.
 									if i == len(cover)-1 {
 										if last := len(cover[i].Files) - 1; last < 0 || cover[i].Files[last].Path != fileSpec.Path {
@@ -232,20 +284,48 @@ func makeSimpleImportSpans(
 										cover[i].Files = append(cover[i].Files, fileSpec)
 									}
 								}
-								// If partition i of the cover ends before this file starts, we
-								// know it also ends before any remaining files start too, as the
-								// files are sorted above by start key, so remaining files can
-								// start their search after this partition.
-								if cover[i].Span.EndKey.Compare(sp.Key) <= 0 {
+
+								// If partition i is not the final partition of the cover and if
+								// it ends before this file starts, we know it also ends before
+								// any remaining files start too, as the files are sorted above
+								// by start key, so remaining files can start their search after
+								// this partition. If partition i is the final partition of the
+								// cover, then it can still be extended by the next file, so we
+								// can't skip it.
+								if i < len(cover)-1 && cover[i].Span.EndKey.Compare(intersectingFileSpan.Key) <= 0 {
 									covPos = i + 1
 								}
 							}
 						}
-					} else if span.EndKey.Compare(fspan.Key) <= 0 {
+
+						// Add file to endKeyNotCoveredFiles if the file span's end key is
+						// the same as the last cover entry's span end key, as the end key
+						// is currently not covered by any entry, but will be covered by the
+						// next.
+						if len(cover) == 0 || intersectingFileSpan.EndKey.Compare(cover[len(cover)-1].Span.EndKey) == 0 {
+							endKeyNotCoveredFiles.add(fileSpec, sz)
+						}
+					} else if span.EndKey.Compare(f.Span.Key) <= 0 {
 						// If this file starts after the needed span ends, then all the files
 						// remaining do too so we're done checking files for this span.
 						break
 					}
+				}
+			}
+
+			// If we have some files in endKeyNotCoveredFiles and there are some cover
+			// entries for this required span, we can simply extend the end key of the
+			// last cover span so it covers the end keys of these files as well. If
+			// there is no cover entry for this span, then we create a new cover entry
+			// for the entire span and add these files.
+			if !endKeyNotCoveredFiles.empty() {
+				if len(cover) != spanCoverStart {
+					cover[len(cover)-1].Span.EndKey = span.EndKey
+					endKeyNotCoveredFiles.drain(&cover[len(cover)-1])
+				} else {
+					entry := makeEntry(span.Key, span.EndKey)
+					endKeyNotCoveredFiles.drain(&entry)
+					cover = append(cover, entry)
 				}
 			}
 		}
@@ -279,10 +359,9 @@ func createIntroducedSpanFrontier(
 	return introducedSpanFrontier, nil
 }
 
-func makeEntry(start, end roachpb.Key, f execinfrapb.RestoreFileSpec) execinfrapb.RestoreSpanEntry {
+func makeEntry(start, end roachpb.Key) execinfrapb.RestoreSpanEntry {
 	return execinfrapb.RestoreSpanEntry{
-		Span:  roachpb.Span{Key: start, EndKey: end},
-		Files: []execinfrapb.RestoreFileSpec{f},
+		Span: roachpb.Span{Key: start, EndKey: end},
 	}
 }
 
@@ -807,23 +886,72 @@ func getNewIntersectingFilesByLayer(
 	return files, nil
 }
 
-// endKeyInclusiveSpan returns a span with the same start key as the input span
-// but with its end key as the next key of the input's end key.
-//
-// NB: a backup file can currently have keys equal to its span's EndKey due to
-// the bug: https://github.com/cockroachdb/cockroach/issues/101963, effectively
-// meaning that we have to treat the span as end key inclusive. Because
-// roachpb.Span and its associated operations are end key exclusive, we work
-// around this by replacing the end key with its next value in order to include
-// the end key.
-func endKeyInclusiveSpan(sp roachpb.Span) roachpb.Span {
-	isp := sp.Clone()
-	isp.EndKey = isp.EndKey.Next()
-	return isp
-}
-
 // inclusiveOverlap returns true if sp, which is end key exclusive, overlaps
 // isp, which is end key inclusive.
 func inclusiveOverlap(sp roachpb.Span, isp roachpb.Span) bool {
 	return sp.Overlaps(isp) || sp.ContainsKey(isp.EndKey)
+}
+
+// getIntersectingFileSpan returns the intersection of sp, an end key exclusive
+// span, and ifsp, and end key inclusive file span. If a valid intersection
+// exists, then the function will return the intersection and true, otherwise it
+// will return an empty span and false. Note that the intersection span should
+// be used as an end key inclusive file span. It could have its start key equal
+// to its end key if the intersection is a point.
+func getIntersectingFileSpan(sp roachpb.Span, ifsp roachpb.Span) (roachpb.Span, bool) {
+	if !inclusiveOverlap(sp, ifsp) {
+		return roachpb.Span{}, false
+	}
+
+	if intersect := sp.Intersect(ifsp); intersect.Valid() {
+		// If there's a non-zero sized intersection, use that.
+		return intersect, true
+	}
+
+	// Otherwise, the inclusive overlap must be due to a point intersection
+	// between the end key of ifsp and the start key of sp. Just return a zero
+	// sized span with the same start and end key in this case.
+	return roachpb.Span{Key: ifsp.EndKey, EndKey: ifsp.EndKey}, true
+}
+
+// restoreFileSpecs wraps a slice of execinfrapb.RestoreFileSpec and keeps track
+// of the sizes of all of the files.
+type restoreFileSpecs struct {
+	files []execinfrapb.RestoreFileSpec
+	sizes []int64
+}
+
+// empty returns true if there are no files.
+func (rf *restoreFileSpecs) empty() bool {
+	return len(rf.files) == 0
+}
+
+// add adds an entry to files, and adds its size to the total file size.
+func (rf *restoreFileSpecs) add(f execinfrapb.RestoreFileSpec, sz int64) {
+	rf.files = append(rf.files, f)
+	rf.sizes = append(rf.sizes, sz)
+}
+
+// drain drains all files into the Files slice in entry and returns the total
+// size of the new files that were added.
+func (rf *restoreFileSpecs) drain(entry *execinfrapb.RestoreSpanEntry) (sz int64) {
+	for i, f := range rf.files {
+		found := false
+		for i := range entry.Files {
+			if entry.Files[i].Path == f.Path {
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			entry.Files = append(entry.Files, f)
+			sz += rf.sizes[i]
+		}
+	}
+
+	rf.files = rf.files[:0]
+	rf.sizes = rf.sizes[:0]
+
+	return sz
 }

--- a/pkg/ccl/backupccl/restore_span_covering_test.go
+++ b/pkg/ccl/backupccl/restore_span_covering_test.go
@@ -103,7 +103,7 @@ func MockBackupChain(
 
 		for f := range backups[i].Files {
 			start := f*5 + r.Intn(4)
-			end := start + 1 + r.Intn(25)
+			end := start + r.Intn(25) // Intentionally testing files with zero size spans.
 			k := encoding.EncodeVarintAscending(backups[i].Spans[f*spans/files].Key, 1)
 			k = k[:len(k):len(k)]
 			backups[i].Files[f].Span.Key = encoding.EncodeVarintAscending(k, int64(start))
@@ -446,11 +446,11 @@ func TestRestoreEntryCoverExample(t *testing.T) {
 			true)
 		require.NoError(t, err)
 		require.Equal(t, reduce([]execinfrapb.RestoreSpanEntry{
-			{Span: c.sp("a", "c\x00"), Files: c.paths("1", "2", "4", "6")},
-			{Span: c.sp("c\x00", "e\x00"), Files: c.paths("2", "4", "6")},
-			{Span: c.sp("e\x00", "f"), Files: c.paths("6")},
+			{Span: c.sp("a", "c"), Files: c.paths("1", "4", "6")},
+			{Span: c.sp("c", "e"), Files: c.paths("1", "2", "4", "6")},
+			{Span: c.sp("e", "f"), Files: c.paths("2", "6")},
 			{Span: c.sp("f", "i"), Files: c.paths("3", "5", "6", "8")},
-			{Span: c.sp("l", "m\x00"), Files: c.paths("9")},
+			{Span: c.sp("l", "p"), Files: c.paths("9")},
 		}), reduce(coverSimple))
 	})
 
@@ -489,7 +489,7 @@ func TestRestoreEntryCoverExample(t *testing.T) {
 		require.Equal(t, reduce([]execinfrapb.RestoreSpanEntry{
 			{Span: c.sp("a", "f"), Files: c.paths("1", "2", "4", "6")},
 			{Span: c.sp("f", "i"), Files: c.paths("3", "5", "6", "8")},
-			{Span: c.sp("l", "m\x00"), Files: c.paths("9")},
+			{Span: c.sp("l", "p"), Files: c.paths("9")},
 		}), reduce(coverSizedSimple))
 	})
 
@@ -530,7 +530,7 @@ func TestRestoreEntryCoverExample(t *testing.T) {
 		require.Equal(t, reduce([]execinfrapb.RestoreSpanEntry{
 			{Span: c.sp("a", "f"), Files: c.paths("6")},
 			{Span: c.sp("f", "i"), Files: c.paths("3", "5", "6", "8")},
-			{Span: c.sp("l", "m\x00"), Files: c.paths("9")},
+			{Span: c.sp("l", "p"), Files: c.paths("9")},
 		}), reduce(coverIntroducedSimple))
 	})
 	t.Run("completed-spans", func(t *testing.T) {
@@ -575,12 +575,51 @@ func TestRestoreEntryCoverExample(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, reduce([]execinfrapb.RestoreSpanEntry{
 			{Span: c.sp("a", "b"), Files: c.paths("1", "6")},
-			{Span: c.sp("c", "c\x00"), Files: c.paths("1", "2", "4", "6")},
-			{Span: c.sp("c\x00", "e\x00"), Files: c.paths("2", "4", "6")},
-			{Span: c.sp("e\x00", "f"), Files: c.paths("6")},
+			{Span: c.sp("c", "e"), Files: c.paths("1", "2", "4", "6")},
+			{Span: c.sp("e", "f"), Files: c.paths("2", "6")},
 			{Span: c.sp("f", "g"), Files: c.paths("6")},
-			{Span: c.sp("l", "m\x00"), Files: c.paths("9")},
+			{Span: c.sp("l", "p"), Files: c.paths("9")},
 		}), reduce(coverCompletedSimple))
+	})
+	t.Run("zero-size-file-spans", func(t *testing.T) {
+		spans := []roachpb.Span{c.sp("a", "f")}
+
+		backups := c.makeManifests([]roachpb.Spans{
+			{c.sp("a", "a")},
+		})
+
+		layerToIterFactory, err := backupinfo.GetBackupManifestIterFactories(ctx, execCfg.DistSQLSrv.ExternalStorage,
+			backups, nil, nil)
+		require.NoError(t, err)
+
+		cover, err := makeImportSpans(
+			ctx,
+			spans,
+			backups,
+			layerToIterFactory,
+			nil,
+			noSpanTargetSize,
+			emptySpanFrontier,
+			emptyCompletedSpans,
+			false)
+		require.NoError(t, err)
+		require.Equal(t, reduce([]execinfrapb.RestoreSpanEntry{
+			{Span: c.sp("a", "f"), Files: c.paths("1")},
+		}), reduce(cover))
+		coverSimple, err := makeImportSpans(
+			ctx,
+			spans,
+			backups,
+			layerToIterFactory,
+			nil,
+			noSpanTargetSize,
+			emptySpanFrontier,
+			emptyCompletedSpans,
+			true)
+		require.NoError(t, err)
+		require.Equal(t, reduce([]execinfrapb.RestoreSpanEntry{
+			{Span: c.sp("a", "f"), Files: c.paths("1")},
+		}), reduce(coverSimple))
 	})
 }
 
@@ -1136,5 +1175,153 @@ func runTestRestoreEntryCover(t *testing.T, numBackups int, simpleImportSpans bo
 				}
 			}
 		}
+	}
+}
+
+// TestRestoreEntryCover tests that the restore spans are correctly created
+// in the presence of files that have zero sized spans.
+func TestRestoreEntryCoverZeroSizeFiles(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	tc, _, _, cleanupFn := backupRestoreTestSetup(t, singleNode, 1, InitManualReplication)
+	defer cleanupFn()
+	execCfg := tc.Server(0).ExecutorConfig().(sql.ExecutorConfig)
+	c := makeCoverUtils(ctx, t, &execCfg)
+
+	emptySpanFrontier, err := spanUtils.MakeFrontierAt(completedSpanTime)
+	require.NoError(t, err)
+
+	emptyCompletedSpans := []jobspb.RestoreProgress_FrontierEntry{}
+
+	type simpleRestoreSpanEntry struct {
+		span  roachpb.Span
+		paths []string
+	}
+
+	type testCase struct {
+		name                   string
+		requiredSpans          []roachpb.Span
+		backupSpans            []roachpb.Spans
+		expectedCover          []simpleRestoreSpanEntry
+		expectedCoverSimple    []simpleRestoreSpanEntry
+		expectedCoverGenerated []simpleRestoreSpanEntry
+	}
+
+	for _, tt := range []testCase{
+		{
+			name:          "file at start of span",
+			requiredSpans: []roachpb.Span{c.sp("a", "b")},
+			backupSpans: []roachpb.Spans{
+				{c.sp("a", "a")},
+			},
+			expectedCover: []simpleRestoreSpanEntry{
+				{span: c.sp("a", "b"), paths: []string{"1"}},
+			},
+		},
+		{
+			name:          "file at end of span",
+			requiredSpans: []roachpb.Span{c.sp("a", "b")},
+			backupSpans: []roachpb.Spans{
+				{c.sp("b", "b")},
+			},
+			expectedCover: []simpleRestoreSpanEntry{},
+		},
+		{
+			name:          "file at middle of span",
+			requiredSpans: []roachpb.Span{c.sp("a", "c")},
+			backupSpans: []roachpb.Spans{
+				{c.sp("b", "b")},
+			},
+			expectedCoverSimple: []simpleRestoreSpanEntry{
+				{span: c.sp("a", "c"), paths: []string{"1"}},
+			},
+			expectedCoverGenerated: []simpleRestoreSpanEntry{
+				{span: c.sp("b", "c"), paths: []string{"1"}},
+			},
+		},
+		{
+			name:          "sz0 file at end of prev file",
+			requiredSpans: []roachpb.Span{c.sp("a", "f")},
+			backupSpans: []roachpb.Spans{
+				{c.sp("a", "b"), c.sp("b", "b"), c.sp("b", "c")},
+			},
+			expectedCoverSimple: []simpleRestoreSpanEntry{
+				{span: c.sp("a", "b"), paths: []string{"1"}},
+				{span: c.sp("b", "f"), paths: []string{"1", "2", "3"}},
+			},
+			expectedCoverGenerated: []simpleRestoreSpanEntry{
+				{span: c.sp("a", "b"), paths: []string{"1"}},
+				{span: c.sp("b", "f"), paths: []string{"2", "3", "1"}},
+			},
+		},
+		{
+			name: "sz0 file contained by prev file",
+			requiredSpans: []roachpb.Span{
+				c.sp("a", "f"),
+			},
+			backupSpans: []roachpb.Spans{
+				{c.sp("a", "c"), c.sp("b", "b"), c.sp("b", "d")},
+			},
+			expectedCoverSimple: []simpleRestoreSpanEntry{
+				{span: c.sp("a", "c"), paths: []string{"1", "2", "3"}},
+				{span: c.sp("c", "f"), paths: []string{"1", "3"}},
+			},
+			expectedCoverGenerated: []simpleRestoreSpanEntry{
+				{span: c.sp("a", "b"), paths: []string{"1"}},
+				{span: c.sp("b", "f"), paths: []string{"2", "3", "1"}},
+			},
+		},
+		{
+			name: "sz0 file contained by following file",
+			requiredSpans: []roachpb.Span{
+				c.sp("a", "f"),
+			},
+			backupSpans: []roachpb.Spans{
+				{c.sp("b", "b"), c.sp("b", "c"), c.sp("b", "d")},
+			},
+			expectedCoverSimple: []simpleRestoreSpanEntry{
+				{span: c.sp("a", "b"), paths: []string{"1"}},
+				{span: c.sp("b", "c"), paths: []string{"1", "2", "3"}},
+				{span: c.sp("c", "f"), paths: []string{"2", "3"}},
+			},
+			expectedCoverGenerated: []simpleRestoreSpanEntry{
+				{span: c.sp("b", "f"), paths: []string{"1", "2", "3"}},
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			c := makeCoverUtils(ctx, t, &execCfg)
+			backups := c.makeManifests(tt.backupSpans)
+
+			layerToIterFactory, err := backupinfo.GetBackupManifestIterFactories(ctx, execCfg.DistSQLSrv.ExternalStorage, backups, nil, nil)
+			require.NoError(t, err)
+
+			for _, simple := range []bool{true, false} {
+				expectedCover := tt.expectedCover
+				if len(expectedCover) == 0 && (len(tt.expectedCoverSimple) > 0 || len(tt.expectedCoverGenerated) > 0) {
+					if simple {
+						expectedCover = tt.expectedCoverSimple
+					} else {
+						expectedCover = tt.expectedCoverGenerated
+					}
+				}
+
+				cover, err := makeImportSpans(ctx, tt.requiredSpans, backups, layerToIterFactory, nil, noSpanTargetSize, emptySpanFrontier, emptyCompletedSpans, simple)
+				require.NoError(t, err)
+
+				simpleCover := make([]simpleRestoreSpanEntry, len(cover))
+				for i, entry := range cover {
+					simpleCover[i] = simpleRestoreSpanEntry{
+						span: entry.Span,
+					}
+					for _, file := range entry.Files {
+						simpleCover[i].paths = append(simpleCover[i].paths, file.Path)
+					}
+				}
+
+				require.Equal(t, expectedCover, simpleCover, "simple=%t", simple)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Previously, if `bulkio.restore.use_simple_import_spans` was true during
restore, makeSimpleImportSpans called .Next() on all end keys of its input
file spans in order to handle the fact that these spans are end keys are end
key inclusive. This resulted in some spans having start or end keys that are
not valid for splitting. This patch removes all .Next() calls in
makeSimpleImportSpans, and instead addresses the end key inclusive file spans
by constantly keeping track of all files that do not have their end points
covered as the covering is created, and immediately populating the next cover
entry with these files.

This fixes an issue where a split can be called on an invalid key that's in the
form of someValidKey.Next() during restore. These invalid keys will generally
have a NULL at the end of the key, which will result in an error when calling
EnsureSafeSplits on this split key. Currently errors from EnsureSafeSplits
are ignored, and thus a split will always be attempted on this type of invalid
split key. This split key can land in the middle of a row with column families,
and thus result in failing SQL queries when querying the restored table.

This patch adds some additional testing for backup manifest file entries with
zero sized spans. The previous .Next() called on all file spans meant that
there were no zero sized spans, so backups with these types of files were
under tested.

Informs: #109483

Release note (bug fix): Fixes an issue where a split can be called on an
invalid key that's in the form of someValidKey.Next() during restore
with `bulkio.restore.use_simple_import_spans=true`. This
split key can land in the middle of a row with column families, and thus result
in failing SQL queries when querying the restored table.