### PR TITLE
ui: use changefeed.checkpoint_latency in admin ui

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/changefeeds.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/changefeeds.tsx
@@ -108,17 +108,19 @@ export default function (props: GraphDashboardProps) {
     </LineGraph>,
 
     <LineGraph
-      title="Max Checkpoint Latency"
+      title="Progress Timestamp"
       isKvGraph={false}
-      tooltip={`The most any changefeed's persisted checkpoint is behind the present.  Larger values indicate issues with successfully ingesting or emitting changes.  If errors cause a changefeed to restart, or the changefeed is paused and unpaused, emitted data up to the last checkpoint may be re-emitted.`}
+      tooltip={`The latest timestamp up to which events have been successfully emitted for all changefeeds. Changefeeds will not emit data written before this timestamp. If this metric is stuck or far in the past, this indicates that one or more changefeeds are not making sufficient progress. If errors cause a changefeed to restart or if the changefeed is paused and unpaused, data emitted ahead of this timestamp may be re-emitted.`}
       tenantSource={tenantSource}
     >
-      <Axis units={AxisUnits.Duration} label="time">
+      <Axis units={AxisUnits.Duration} label="timestamp">
         <Metric
-          name="cr.node.changefeed.max_behind_nanos"
-          title="Max Checkpoint Latency"
+          name="cr.node.changefeed.checkpoint_progress"
+          title="Progress Timestamp"
+          // The value of this metric only increases with time (guaranteed by changefeeds). If we have two readings within some time window, the maximal value is the most up-to-date.
           downsampleMax
-          aggregateMax
+          // Take the oldest checkpoint from all running changefeeds. This is the latest timestamp for which all events have been emitted.
+          aggregateMin
         />
       </Axis>
     </LineGraph>,


### PR DESCRIPTION
This is a follow up PR to https://github.com/cockroachdb/cockroach/pull/108757. This updates the admin UI to use the new metric and includes a release note to update docs.

Previously, the admin UI would show `changefeed.max_behind_nanos` in the `Max Checkpoint Latency` chart. The better metric to use here is `changefeed.checkpoint_progress` because it is persistent and tracks checkpoints, unlike `changefeed.max_behind_nanos`. The name and description of the chart are updated to reflect what it measures.

Release note (ui change): The `Max Checkpoint Latency` graph in the admin UI is now called `Progress Timestamp`. It tracks the latest timestamp T such that all running changefeeds have successfully emitted events up to T. No changefeed will emit values below this timestamp. The underlying metric for this chart is `changefeed.checkpoint_progress`. If this metric stops advancing or is too far in the past, it may indicate that one or more changefeeds is stuck or slow.

We want to move away from `changefeed.max_behind_nanos` without deleting it because some customers may be using it. See #97931. Thus, this change was made to remove it from being used in the admin UI. We should remove this metric from the docs (https://www.cockroachlabs.com/docs/stable/monitor-and-debug-changefeeds) and instead mention `changefeed.checkpoint_progress`.

Informs:#97931