### PR TITLE
privilege: automate generation of AllPrivileges list

### DIFF
--- a/pkg/sql/privilege/kind_string.go
+++ b/pkg/sql/privilege/kind_string.go
@@ -39,6 +39,7 @@ func _() {
 	_ = x[REPLICATION-29]
 	_ = x[MANAGETENANT-30]
 	_ = x[VIEWSYSTEMTABLE-31]
+	_ = x[largestKind-31]
 }
 
 func (i Kind) String() string {

--- a/pkg/sql/privilege/privilege.go
+++ b/pkg/sql/privilege/privilege.go
@@ -72,7 +72,12 @@ const (
 	REPLICATION              Kind = 29
 	MANAGETENANT             Kind = 30
 	VIEWSYSTEMTABLE          Kind = 31
+	largestKind                   = VIEWSYSTEMTABLE
 )
+
+var isDeprecatedKind = map[Kind]bool{
+	DEPRECATEDGRANT: true,
+}
 
 // Privilege represents a privilege parsed from an Access Privilege Inquiry
 // Function's privilege string argument.
@@ -137,7 +142,8 @@ var isDescriptorBacked = map[ObjectType]bool{
 
 // Predefined sets of privileges.
 var (
-	AllPrivileges         = List{ALL, CHANGEFEED, CONNECT, CREATE, DROP, SELECT, INSERT, DELETE, UPDATE, USAGE, ZONECONFIG, EXECUTE, BACKUP, RESTORE, EXTERNALIOIMPLICITACCESS, VIEWJOB}
+	// AllPrivileges is populated during init.
+	AllPrivileges         List
 	ReadData              = List{SELECT}
 	ReadWriteData         = List{SELECT, INSERT, DELETE, UPDATE}
 	ReadWriteSequenceData = List{SELECT, UPDATE, USAGE}
@@ -489,4 +495,13 @@ type Object interface {
 	// GetName returns the name of the object. For example, the name of a
 	// table, schema or database.
 	GetName() string
+}
+
+func init() {
+	for kind := ALL; kind <= largestKind; kind++ {
+		if isDeprecatedKind[kind] {
+			continue
+		}
+		AllPrivileges = append(AllPrivileges, kind)
+	}
 }


### PR DESCRIPTION
This patch automates the process of generating the `AllPrivileges` list so that any newly added privileges will automatically be included.

Epic: None

Release note: None