### PR TITLE
storage: set L0CompactionConcurrency to 2

### DIFF
--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -571,8 +571,9 @@ func DefaultPebbleOptions() *pebble.Options {
 	}
 
 	opts := &pebble.Options{
-		Comparer:                    EngineComparer,
-		FS:                          vfs.Default,
+		Comparer: EngineComparer,
+		FS:       vfs.Default,
+		// A value of 2 triggers a compaction when there is 1 sub-level.
 		L0CompactionThreshold:       2,
 		L0StopWritesThreshold:       1000,
 		LBaseMaxBytes:               64 << 20, // 64 MB
@@ -584,6 +585,7 @@ func DefaultPebbleOptions() *pebble.Options {
 		BlockPropertyCollectors:     PebbleBlockPropertyCollectors,
 		FormatMajorVersion:          MinimumSupportedFormatVersion,
 	}
+	opts.Experimental.L0CompactionConcurrency = l0SubLevelCompactionConcurrency
 	// Automatically flush 10s after the first range tombstone is added to a
 	// memtable. This ensures that we can reclaim space even when there's no
 	// activity on the database generating flushes.


### PR DESCRIPTION
The default in Pebble, 10, delays increasing the compaction concurrency which leads to the bad behavior discussed in https://github.com/cockroachdb/pebble/issues/2832#issuecomment-1699743392. The value of 10 was chosen when admission control was not shaping incoming traffic until there were 20 sub-levels. Admission control now shapes regular traffic starting at 5 sub-levels and elastic traffic starting at 1 sub-level.

Informs https://github.com/cockroachdb/cockroach/issues/104862

Informs https://github.com/cockroachdb/pebble/issues/2832

Epic: none

Release note: None