### PR TITLE
spanconfig: pass SpanConfig by pointer

### DIFF
--- a/pkg/kv/kvserver/allocator/allocatorimpl/allocator.go
+++ b/pkg/kv/kvserver/allocator/allocatorimpl/allocator.go
@@ -863,7 +863,7 @@ func FilterReplicasForAction(
 func (a *Allocator) ComputeAction(
 	ctx context.Context,
 	storePool storepool.AllocatorStorePool,
-	conf roachpb.SpanConfig,
+	conf *roachpb.SpanConfig,
 	desc *roachpb.RangeDescriptor,
 ) (action AllocatorAction, priority float64) {
 	if storePool == nil {
@@ -931,7 +931,7 @@ func (a *Allocator) ComputeAction(
 func (a *Allocator) computeAction(
 	ctx context.Context,
 	storePool storepool.AllocatorStorePool,
-	conf roachpb.SpanConfig,
+	conf *roachpb.SpanConfig,
 	voterReplicas []roachpb.ReplicaDescriptor,
 	nonVoterReplicas []roachpb.ReplicaDescriptor,
 ) (action AllocatorAction, adjustedPriority float64) {
@@ -1197,7 +1197,7 @@ func (s *GoodCandidateSelector) selectOne(cl candidateList) *candidate {
 func (a *Allocator) AllocateTarget(
 	ctx context.Context,
 	storePool storepool.AllocatorStorePool,
-	conf roachpb.SpanConfig,
+	conf *roachpb.SpanConfig,
 	existingVoters, existingNonVoters []roachpb.ReplicaDescriptor,
 	replacing *roachpb.ReplicaDescriptor,
 	replicaStatus ReplicaStatus,
@@ -1277,7 +1277,7 @@ func (a *Allocator) AllocateTarget(
 func (a *Allocator) CheckAvoidsFragileQuorum(
 	ctx context.Context,
 	storePool storepool.AllocatorStorePool,
-	conf roachpb.SpanConfig,
+	conf *roachpb.SpanConfig,
 	existingVoters, remainingLiveNonVoters []roachpb.ReplicaDescriptor,
 	replicaStatus ReplicaStatus,
 	replicaType TargetReplicaType,
@@ -1317,7 +1317,7 @@ func (a *Allocator) CheckAvoidsFragileQuorum(
 func (a *Allocator) AllocateVoter(
 	ctx context.Context,
 	storePool storepool.AllocatorStorePool,
-	conf roachpb.SpanConfig,
+	conf *roachpb.SpanConfig,
 	existingVoters, existingNonVoters []roachpb.ReplicaDescriptor,
 	replacing *roachpb.ReplicaDescriptor,
 	replicaStatus ReplicaStatus,
@@ -1331,7 +1331,7 @@ func (a *Allocator) AllocateVoter(
 func (a *Allocator) AllocateNonVoter(
 	ctx context.Context,
 	storePool storepool.AllocatorStorePool,
-	conf roachpb.SpanConfig,
+	conf *roachpb.SpanConfig,
 	existingVoters, existingNonVoters []roachpb.ReplicaDescriptor,
 	replacing *roachpb.ReplicaDescriptor,
 	replicaStatus ReplicaStatus,
@@ -1346,7 +1346,7 @@ func (a *Allocator) AllocateTargetFromList(
 	ctx context.Context,
 	storePool storepool.AllocatorStorePool,
 	candidateStores storepool.StoreList,
-	conf roachpb.SpanConfig,
+	conf *roachpb.SpanConfig,
 	existingVoters, existingNonVoters []roachpb.ReplicaDescriptor,
 	options ScorerOptions,
 	selector CandidateSelector,
@@ -1361,7 +1361,7 @@ func (a *Allocator) allocateTargetFromList(
 	ctx context.Context,
 	storePool storepool.AllocatorStorePool,
 	candidateStores storepool.StoreList,
-	conf roachpb.SpanConfig,
+	conf *roachpb.SpanConfig,
 	existingVoters, existingNonVoters []roachpb.ReplicaDescriptor,
 	replacing *roachpb.ReplicaDescriptor,
 	options ScorerOptions,
@@ -1464,7 +1464,7 @@ func (a Allocator) simulateRemoveTarget(
 	ctx context.Context,
 	storePool storepool.AllocatorStorePool,
 	targetStore roachpb.StoreID,
-	conf roachpb.SpanConfig,
+	conf *roachpb.SpanConfig,
 	candidates []roachpb.ReplicaDescriptor,
 	existingVoters []roachpb.ReplicaDescriptor,
 	existingNonVoters []roachpb.ReplicaDescriptor,
@@ -1521,7 +1521,7 @@ func (a Allocator) simulateRemoveTarget(
 func (a Allocator) RemoveTarget(
 	ctx context.Context,
 	storePool storepool.AllocatorStorePool,
-	conf roachpb.SpanConfig,
+	conf *roachpb.SpanConfig,
 	candidateStoreList storepool.StoreList,
 	existingVoters []roachpb.ReplicaDescriptor,
 	existingNonVoters []roachpb.ReplicaDescriptor,
@@ -1601,7 +1601,7 @@ func (a Allocator) RemoveTarget(
 func (a Allocator) RemoveVoter(
 	ctx context.Context,
 	storePool storepool.AllocatorStorePool,
-	conf roachpb.SpanConfig,
+	conf *roachpb.SpanConfig,
 	voterCandidates []roachpb.ReplicaDescriptor,
 	existingVoters []roachpb.ReplicaDescriptor,
 	existingNonVoters []roachpb.ReplicaDescriptor,
@@ -1634,7 +1634,7 @@ func (a Allocator) RemoveVoter(
 func (a Allocator) RemoveNonVoter(
 	ctx context.Context,
 	storePool storepool.AllocatorStorePool,
-	conf roachpb.SpanConfig,
+	conf *roachpb.SpanConfig,
 	nonVoterCandidates []roachpb.ReplicaDescriptor,
 	existingVoters []roachpb.ReplicaDescriptor,
 	existingNonVoters []roachpb.ReplicaDescriptor,
@@ -1664,7 +1664,7 @@ func (a Allocator) RemoveNonVoter(
 func (a Allocator) RebalanceTarget(
 	ctx context.Context,
 	storePool storepool.AllocatorStorePool,
-	conf roachpb.SpanConfig,
+	conf *roachpb.SpanConfig,
 	raftStatus *raft.Status,
 	existingVoters, existingNonVoters []roachpb.ReplicaDescriptor,
 	rangeUsageInfo allocator.RangeUsageInfo,
@@ -1860,7 +1860,7 @@ func (a Allocator) RebalanceTarget(
 func (a Allocator) RebalanceVoter(
 	ctx context.Context,
 	storePool storepool.AllocatorStorePool,
-	conf roachpb.SpanConfig,
+	conf *roachpb.SpanConfig,
 	raftStatus *raft.Status,
 	existingVoters, existingNonVoters []roachpb.ReplicaDescriptor,
 	rangeUsageInfo allocator.RangeUsageInfo,
@@ -1896,7 +1896,7 @@ func (a Allocator) RebalanceVoter(
 func (a Allocator) RebalanceNonVoter(
 	ctx context.Context,
 	storePool storepool.AllocatorStorePool,
-	conf roachpb.SpanConfig,
+	conf *roachpb.SpanConfig,
 	raftStatus *raft.Status,
 	existingVoters, existingNonVoters []roachpb.ReplicaDescriptor,
 	rangeUsageInfo allocator.RangeUsageInfo,
@@ -1962,7 +1962,7 @@ func (a *Allocator) ValidLeaseTargets(
 	ctx context.Context,
 	storePool storepool.AllocatorStorePool,
 	desc *roachpb.RangeDescriptor,
-	conf roachpb.SpanConfig,
+	conf *roachpb.SpanConfig,
 	existing []roachpb.ReplicaDescriptor,
 	leaseRepl interface {
 		StoreID() roachpb.StoreID
@@ -2136,7 +2136,7 @@ func (a *Allocator) leaseholderShouldMoveDueToIOOverload(
 func (a *Allocator) leaseholderShouldMoveDueToPreferences(
 	ctx context.Context,
 	storePool storepool.AllocatorStorePool,
-	conf roachpb.SpanConfig,
+	conf *roachpb.SpanConfig,
 	leaseRepl interface {
 		StoreID() roachpb.StoreID
 		RaftStatus() *raft.Status
@@ -2220,7 +2220,7 @@ func (a *Allocator) TransferLeaseTarget(
 	ctx context.Context,
 	storePool storepool.AllocatorStorePool,
 	desc *roachpb.RangeDescriptor,
-	conf roachpb.SpanConfig,
+	conf *roachpb.SpanConfig,
 	existing []roachpb.ReplicaDescriptor,
 	leaseRepl interface {
 		StoreID() roachpb.StoreID
@@ -2494,7 +2494,7 @@ func (a *Allocator) ShouldTransferLease(
 	ctx context.Context,
 	storePool storepool.AllocatorStorePool,
 	desc *roachpb.RangeDescriptor,
-	conf roachpb.SpanConfig,
+	conf *roachpb.SpanConfig,
 	existing []roachpb.ReplicaDescriptor,
 	leaseRepl interface {
 		StoreID() roachpb.StoreID
@@ -2816,7 +2816,7 @@ func (a Allocator) shouldTransferLeaseForLeaseCountConvergence(
 // replicas that meet lease preferences (among the `existing` replicas).
 func (a Allocator) PreferredLeaseholders(
 	storePool storepool.AllocatorStorePool,
-	conf roachpb.SpanConfig,
+	conf *roachpb.SpanConfig,
 	existing []roachpb.ReplicaDescriptor,
 ) []roachpb.ReplicaDescriptor {
 	// Go one preference at a time. As soon as we've found replicas that match a

--- a/pkg/kv/kvserver/allocator/plan/replicate.go
+++ b/pkg/kv/kvserver/allocator/plan/replicate.go
@@ -61,7 +61,7 @@ type ReplicationPlanner interface {
 		now hlc.ClockTimestamp,
 		repl AllocatorReplica,
 		desc *roachpb.RangeDescriptor,
-		conf roachpb.SpanConfig,
+		conf *roachpb.SpanConfig,
 		canTransferLeaseFrom CanTransferLeaseFrom,
 	) (bool, float64)
 	// PlanOneChange calls the allocator to determine an action to be taken upon a
@@ -71,7 +71,7 @@ type ReplicationPlanner interface {
 		ctx context.Context,
 		repl AllocatorReplica,
 		desc *roachpb.RangeDescriptor,
-		conf roachpb.SpanConfig,
+		conf *roachpb.SpanConfig,
 		canTransferLeaseFrom CanTransferLeaseFrom,
 		scatter bool,
 	) (ReplicateChange, error)
@@ -82,7 +82,7 @@ type ReplicationPlanner interface {
 type CanTransferLeaseFrom func(
 	ctx context.Context,
 	repl LeaseCheckReplica,
-	conf roachpb.SpanConfig,
+	conf *roachpb.SpanConfig,
 ) bool
 
 // LeaseCheckReplica contains methods that may be used to check a replica's
@@ -90,7 +90,7 @@ type CanTransferLeaseFrom func(
 type LeaseCheckReplica interface {
 	HasCorrectLeaseType(lease roachpb.Lease) bool
 	LeaseStatusAt(ctx context.Context, now hlc.ClockTimestamp) kvserverpb.LeaseStatus
-	LeaseViolatesPreferences(context.Context, roachpb.SpanConfig) bool
+	LeaseViolatesPreferences(context.Context, *roachpb.SpanConfig) bool
 	OwnsValidLease(context.Context, hlc.ClockTimestamp) bool
 }
 
@@ -145,7 +145,7 @@ func (rp ReplicaPlanner) ShouldPlanChange(
 	now hlc.ClockTimestamp,
 	repl AllocatorReplica,
 	desc *roachpb.RangeDescriptor,
-	conf roachpb.SpanConfig,
+	conf *roachpb.SpanConfig,
 	canTransferLeaseFrom CanTransferLeaseFrom,
 ) (shouldPlanChange bool, priority float64) {
 
@@ -241,7 +241,7 @@ func (rp ReplicaPlanner) PlanOneChange(
 	ctx context.Context,
 	repl AllocatorReplica,
 	desc *roachpb.RangeDescriptor,
-	conf roachpb.SpanConfig,
+	conf *roachpb.SpanConfig,
 	canTransferLeaseFrom CanTransferLeaseFrom,
 	scatter bool,
 ) (change ReplicateChange, _ error) {
@@ -387,7 +387,7 @@ func (rp ReplicaPlanner) addOrReplaceVoters(
 	ctx context.Context,
 	repl AllocatorReplica,
 	desc *roachpb.RangeDescriptor,
-	conf roachpb.SpanConfig,
+	conf *roachpb.SpanConfig,
 	existingVoters []roachpb.ReplicaDescriptor,
 	remainingLiveVoters, remainingLiveNonVoters []roachpb.ReplicaDescriptor,
 	removeIdx int,
@@ -484,7 +484,7 @@ func (rp ReplicaPlanner) addOrReplaceNonVoters(
 	ctx context.Context,
 	repl AllocatorReplica,
 	_ *roachpb.RangeDescriptor,
-	conf roachpb.SpanConfig,
+	conf *roachpb.SpanConfig,
 	existingNonVoters []roachpb.ReplicaDescriptor,
 	liveVoterReplicas, liveNonVoterReplicas []roachpb.ReplicaDescriptor,
 	removeIdx int,
@@ -544,7 +544,7 @@ func (rp ReplicaPlanner) findRemoveVoter(
 		LastReplicaAdded() (roachpb.ReplicaID, time.Time)
 		RaftStatus() *raft.Status
 	},
-	conf roachpb.SpanConfig,
+	conf *roachpb.SpanConfig,
 	existingVoters, existingNonVoters []roachpb.ReplicaDescriptor,
 ) (roachpb.ReplicationTarget, string, error) {
 	// This retry loop involves quick operations on local state, so a
@@ -626,7 +626,7 @@ func (rp ReplicaPlanner) removeVoter(
 	ctx context.Context,
 	repl AllocatorReplica,
 	desc *roachpb.RangeDescriptor,
-	conf roachpb.SpanConfig,
+	conf *roachpb.SpanConfig,
 	existingVoters, existingNonVoters []roachpb.ReplicaDescriptor,
 ) (op AllocationOp, stats ReplicateStats, _ error) {
 	removeVoter, details, err := rp.findRemoveVoter(ctx, repl, conf, existingVoters, existingNonVoters)
@@ -669,7 +669,7 @@ func (rp ReplicaPlanner) removeNonVoter(
 	ctx context.Context,
 	repl AllocatorReplica,
 	_ *roachpb.RangeDescriptor,
-	conf roachpb.SpanConfig,
+	conf *roachpb.SpanConfig,
 	existingVoters, existingNonVoters []roachpb.ReplicaDescriptor,
 ) (op AllocationOp, stats ReplicateStats, _ error) {
 	removeNonVoter, details, err := rp.allocator.RemoveNonVoter(
@@ -709,7 +709,7 @@ func (rp ReplicaPlanner) removeDecommissioning(
 	ctx context.Context,
 	repl AllocatorReplica,
 	desc *roachpb.RangeDescriptor,
-	conf roachpb.SpanConfig,
+	conf *roachpb.SpanConfig,
 	targetType allocatorimpl.TargetReplicaType,
 ) (op AllocationOp, stats ReplicateStats, _ error) {
 	var decommissioningReplicas []roachpb.ReplicaDescriptor
@@ -805,7 +805,7 @@ func (rp ReplicaPlanner) considerRebalance(
 	ctx context.Context,
 	repl AllocatorReplica,
 	desc *roachpb.RangeDescriptor,
-	conf roachpb.SpanConfig,
+	conf *roachpb.SpanConfig,
 	existingVoters, existingNonVoters []roachpb.ReplicaDescriptor,
 	allocatorPrio float64,
 	canTransferLeaseFrom CanTransferLeaseFrom,
@@ -944,7 +944,7 @@ func (rp ReplicaPlanner) shedLeaseTarget(
 	ctx context.Context,
 	repl AllocatorReplica,
 	desc *roachpb.RangeDescriptor,
-	conf roachpb.SpanConfig,
+	conf *roachpb.SpanConfig,
 	opts allocator.TransferLeaseOptions,
 ) (op AllocationOp, _ error) {
 	usage := repl.RangeUsageInfo()
@@ -1002,7 +1002,7 @@ func (rp ReplicaPlanner) maybeTransferLeaseAwayTarget(
 	ctx context.Context,
 	repl AllocatorReplica,
 	desc *roachpb.RangeDescriptor,
-	conf roachpb.SpanConfig,
+	conf *roachpb.SpanConfig,
 	removeStoreID roachpb.StoreID,
 	canTransferLeaseFrom CanTransferLeaseFrom,
 ) (op AllocationOp, _ error) {

--- a/pkg/kv/kvserver/allocator_impl_test.go
+++ b/pkg/kv/kvserver/allocator_impl_test.go
@@ -32,7 +32,7 @@ import (
 
 const firstRangeID = roachpb.RangeID(1)
 
-var simpleSpanConfig = roachpb.SpanConfig{
+var simpleSpanConfig = &roachpb.SpanConfig{
 	NumReplicas: 1,
 	Constraints: []roachpb.ConstraintsConjunction{
 		{
@@ -323,7 +323,7 @@ func TestAllocatorRebalanceTarget(t *testing.T) {
 		result, _, details, ok := a.RebalanceVoter(
 			ctx,
 			sp,
-			roachpb.SpanConfig{},
+			&roachpb.SpanConfig{},
 			status,
 			replicas,
 			nil,
@@ -349,7 +349,7 @@ func TestAllocatorRebalanceTarget(t *testing.T) {
 		target, _, details, ok := a.RebalanceVoter(
 			ctx,
 			sp,
-			roachpb.SpanConfig{},
+			&roachpb.SpanConfig{},
 			status,
 			replicas,
 			nil,
@@ -369,7 +369,7 @@ func TestAllocatorRebalanceTarget(t *testing.T) {
 		target, origin, details, ok := a.RebalanceVoter(
 			ctx,
 			sp,
-			roachpb.SpanConfig{},
+			&roachpb.SpanConfig{},
 			status,
 			replicas,
 			nil,

--- a/pkg/kv/kvserver/asim/event/mutation_event.go
+++ b/pkg/kv/kvserver/asim/event/mutation_event.go
@@ -56,7 +56,7 @@ var _ Event = &SetCapacityOverrideEvent{}
 
 func (se SetSpanConfigEvent) Func() EventFunc {
 	return MutationFunc(func(ctx context.Context, s state.State) {
-		s.SetSpanConfig(se.Span, se.Config)
+		s.SetSpanConfig(se.Span, &se.Config)
 	})
 }
 

--- a/pkg/kv/kvserver/asim/op/relocate_range.go
+++ b/pkg/kv/kvserver/asim/op/relocate_range.go
@@ -72,7 +72,7 @@ func (s *SimRelocateOneOptions) StorePool() storepool.AllocatorStorePool {
 // SpanConfig returns the span configuration for the range with start key.
 func (s *SimRelocateOneOptions) SpanConfig(
 	ctx context.Context, startKey roachpb.RKey,
-) (roachpb.SpanConfig, error) {
+) (*roachpb.SpanConfig, error) {
 	return s.state.RangeFor(state.ToKey(startKey.AsRawKey())).SpanConfig(), nil
 }
 

--- a/pkg/kv/kvserver/asim/queue/allocator_replica.go
+++ b/pkg/kv/kvserver/asim/queue/allocator_replica.go
@@ -59,7 +59,7 @@ func (sr *SimulatorReplica) HasCorrectLeaseType(lease roachpb.Lease) bool {
 	return true
 }
 
-// CurrentLeaseStatus returns the status of the current lease for the
+// LeaseStatusAt returns the status of the current lease for the
 // timestamp given.
 //
 // Common operations to perform on the resulting status are to check if
@@ -85,7 +85,7 @@ func (sr *SimulatorReplica) LeaseStatusAt(
 // error or no preferences defined then it will return false and consider that
 // to be in-conformance.
 func (sr *SimulatorReplica) LeaseViolatesPreferences(
-	_ context.Context, conf roachpb.SpanConfig,
+	_ context.Context, conf *roachpb.SpanConfig,
 ) bool {
 	descs := sr.state.StoreDescriptors(true /* useCached */, sr.repl.StoreID())
 	if len(descs) != 1 {
@@ -147,7 +147,7 @@ func (sr *SimulatorReplica) GetFirstIndex() kvpb.RaftIndex {
 	return 2
 }
 
-func (sr *SimulatorReplica) SpanConfig() (roachpb.SpanConfig, error) {
+func (sr *SimulatorReplica) SpanConfig() (*roachpb.SpanConfig, error) {
 	return sr.rng.SpanConfig(), nil
 }
 

--- a/pkg/kv/kvserver/asim/queue/replicate_queue.go
+++ b/pkg/kv/kvserver/asim/queue/replicate_queue.go
@@ -60,7 +60,7 @@ func NewReplicateQueue(
 }
 
 func simCanTransferleaseFrom(
-	ctx context.Context, repl plan.LeaseCheckReplica, conf roachpb.SpanConfig,
+	ctx context.Context, repl plan.LeaseCheckReplica, conf *roachpb.SpanConfig,
 ) bool {
 	return true
 }
@@ -78,7 +78,7 @@ func (rq *replicateQueue) MaybeAdd(ctx context.Context, replica state.Replica, s
 	if err != nil {
 		log.Fatalf(ctx, "conf not found err=%v", err)
 	}
-	log.VEventf(ctx, 1, "maybe add replica=%s, config=%s", desc, &conf)
+	log.VEventf(ctx, 1, "maybe add replica=%s, config=%s", desc, conf)
 
 	shouldPlanChange, priority := rq.planner.ShouldPlanChange(
 		ctx,

--- a/pkg/kv/kvserver/asim/queue/replicate_queue_test.go
+++ b/pkg/kv/kvserver/asim/queue/replicate_queue_test.go
@@ -110,7 +110,7 @@ func TestReplicateQueue(t *testing.T) {
 		}
 	}
 
-	testingState := func(replicaCounts map[state.StoreID]int, spanConfig roachpb.SpanConfig, initialRF int) state.State {
+	testingState := func(replicaCounts map[state.StoreID]int, spanConfig *roachpb.SpanConfig, initialRF int) state.State {
 		s := state.NewStateWithReplCounts(replicaCounts, initialRF, 1000 /* keyspace */, testSettings)
 		for _, r := range s.Ranges() {
 			s.SetSpanConfigForRange(r.RangeID(), spanConfig)
@@ -362,7 +362,7 @@ func TestReplicateQueue(t *testing.T) {
 				initialRF = 2
 			}
 
-			s := testingState(tc.replicaCounts, spanConfig, initialRF)
+			s := testingState(tc.replicaCounts, &spanConfig, initialRF)
 			changer := state.NewReplicaChanger()
 			store, _ := s.Store(testingStore)
 			rq := NewReplicateQueue(

--- a/pkg/kv/kvserver/asim/queue/split_queue_test.go
+++ b/pkg/kv/kvserver/asim/queue/split_queue_test.go
@@ -48,7 +48,7 @@ func TestSplitQueue(t *testing.T) {
 			NumReplicas: replicationFactor,
 		}
 		for _, r := range s.Ranges() {
-			s.SetSpanConfigForRange(r.RangeID(), spanConfig)
+			s.SetSpanConfigForRange(r.RangeID(), &spanConfig)
 		}
 		s.TransferLease(state.RangeID(2 /* The interesting range */), leaseholder)
 		return s

--- a/pkg/kv/kvserver/asim/state/config_loader.go
+++ b/pkg/kv/kvserver/asim/state/config_loader.go
@@ -396,7 +396,7 @@ func LoadRangeInfo(s State, rangeInfos ...RangeInfo) {
 			))
 		}
 
-		if !s.SetSpanConfigForRange(rng.RangeID(), *r.Config) {
+		if !s.SetSpanConfigForRange(rng.RangeID(), r.Config) {
 			panic(fmt.Sprintf(
 				"Unable to load config: cannot set span config for range %s",
 				rng,

--- a/pkg/kv/kvserver/asim/state/impl.go
+++ b/pkg/kv/kvserver/asim/state/impl.go
@@ -127,7 +127,7 @@ func (rm *rmap) initFirstRange() {
 		startKey:    MinKey,
 		endKey:      MaxKey,
 		desc:        desc,
-		config:      defaultSpanConfig,
+		config:      &defaultSpanConfig,
 		replicas:    make(map[StoreID]*replica),
 		leaseholder: -1,
 	}
@@ -658,7 +658,7 @@ func (s *state) removeReplica(rangeID RangeID, storeID StoreID) bool {
 }
 
 // SetSpanConfigForRange set the span config for the Range with ID RangeID.
-func (s *state) SetSpanConfigForRange(rangeID RangeID, spanConfig roachpb.SpanConfig) bool {
+func (s *state) SetSpanConfigForRange(rangeID RangeID, spanConfig *roachpb.SpanConfig) bool {
 	if rng, ok := s.ranges.rangeMap[rangeID]; ok {
 		rng.config = spanConfig
 		return true
@@ -668,7 +668,7 @@ func (s *state) SetSpanConfigForRange(rangeID RangeID, spanConfig roachpb.SpanCo
 
 // SetSpanConfig sets the span config for all ranges represented by the span,
 // splitting if necessary.
-func (s *state) SetSpanConfig(span roachpb.Span, config roachpb.SpanConfig) {
+func (s *state) SetSpanConfig(span roachpb.Span, config *roachpb.SpanConfig) {
 	startKey := ToKey(span.Key)
 	endKey := ToKey(span.EndKey)
 
@@ -787,7 +787,7 @@ func (s *state) SplitRange(splitKey Key) (Range, Range, bool) {
 		rangeID:     rangeID,
 		startKey:    splitKey,
 		desc:        roachpb.RangeDescriptor{RangeID: roachpb.RangeID(rangeID), NextReplicaID: 1},
-		config:      defaultSpanConfig,
+		config:      &defaultSpanConfig,
 		replicas:    make(map[StoreID]*replica),
 		leaseholder: -1,
 	}
@@ -1242,7 +1242,7 @@ func (s *state) GetSpanConfigForKey(
 	if rng == nil {
 		panic(fmt.Sprintf("programming error: range for key %s doesn't exist", key))
 	}
-	return rng.config, nil
+	return *rng.config, nil
 }
 
 // Scan is added for the rangedesc.Scanner interface, required for
@@ -1404,7 +1404,7 @@ type rng struct {
 	rangeID          RangeID
 	startKey, endKey Key
 	desc             roachpb.RangeDescriptor
-	config           roachpb.SpanConfig
+	config           *roachpb.SpanConfig
 	replicas         map[StoreID]*replica
 	leaseholder      ReplicaID
 	size             int64
@@ -1450,7 +1450,7 @@ func (r *rng) String() string {
 }
 
 // SpanConfig returns the span config for this range.
-func (r *rng) SpanConfig() roachpb.SpanConfig {
+func (r *rng) SpanConfig() *roachpb.SpanConfig {
 	return r.config
 }
 

--- a/pkg/kv/kvserver/asim/state/state.go
+++ b/pkg/kv/kvserver/asim/state/state.go
@@ -135,10 +135,10 @@ type State interface {
 	// if it exists, otherwise it returns false.
 	RangeSpan(RangeID) (Key, Key, bool)
 	// SetSpanConfigForRange set the span config for the Range with ID RangeID.
-	SetSpanConfigForRange(RangeID, roachpb.SpanConfig) bool
+	SetSpanConfigForRange(RangeID, *roachpb.SpanConfig) bool
 	// SetSpanConfig sets the span config for all ranges represented by the span,
 	// splitting if necessary.
-	SetSpanConfig(roachpb.Span, roachpb.SpanConfig)
+	SetSpanConfig(roachpb.Span, *roachpb.SpanConfig)
 	// SetRangeBytes sets the size of the range with ID RangeID to be equal to
 	// the bytes given.
 	SetRangeBytes(RangeID, int64)
@@ -249,7 +249,7 @@ type Range interface {
 	// String returns a string representing the state of the range.
 	String() string
 	// SpanConfig returns the span config for this range.
-	SpanConfig() roachpb.SpanConfig
+	SpanConfig() *roachpb.SpanConfig
 	// Replicas returns all replicas which exist for this range.
 	Replicas() []Replica
 	// Replica returns the replica that is on the store with ID StoreID if it

--- a/pkg/kv/kvserver/asim/state/state_test.go
+++ b/pkg/kv/kvserver/asim/state/state_test.go
@@ -95,7 +95,7 @@ func TestRangeMap(t *testing.T) {
 	require.Equal(t, firstRange.startKey, MinKey)
 	require.Equal(t, firstRange.desc.StartKey, MinKey.ToRKey())
 	require.Equal(t, firstRange.desc.EndKey, MaxKey.ToRKey())
-	require.Equal(t, defaultSpanConfig, firstRange.SpanConfig())
+	require.Equal(t, defaultSpanConfig, *firstRange.SpanConfig())
 
 	k2 := Key(1)
 	k3 := Key(2)
@@ -611,7 +611,7 @@ func TestSetSpanConfig(t *testing.T) {
 				Key:    tc.start.ToRKey().AsRawKey(),
 				EndKey: tc.end.ToRKey().AsRawKey(),
 			}
-			s.SetSpanConfig(span, config)
+			s.SetSpanConfig(span, &config)
 			for _, rng := range s.Ranges() {
 				start, _, ok := s.RangeSpan(rng.RangeID())
 				require.True(t, ok)

--- a/pkg/kv/kvserver/asim/storerebalancer/candidate_replica.go
+++ b/pkg/kv/kvserver/asim/storerebalancer/candidate_replica.go
@@ -79,7 +79,7 @@ func (sr *simulatorReplica) GetFirstIndex() kvpb.RaftIndex {
 
 // DescAndSpanConfig returns the authoritative range descriptor as well
 // as the span config for the replica.
-func (sr *simulatorReplica) DescAndSpanConfig() (*roachpb.RangeDescriptor, roachpb.SpanConfig) {
+func (sr *simulatorReplica) DescAndSpanConfig() (*roachpb.RangeDescriptor, *roachpb.SpanConfig) {
 	return sr.rng.Descriptor(), sr.rng.SpanConfig()
 }
 

--- a/pkg/kv/kvserver/helpers_test.go
+++ b/pkg/kv/kvserver/helpers_test.go
@@ -56,7 +56,7 @@ func (s *Store) Transport() *RaftTransport {
 }
 
 func (s *Store) FindTargetAndTransferLease(
-	ctx context.Context, repl *Replica, desc *roachpb.RangeDescriptor, conf roachpb.SpanConfig,
+	ctx context.Context, repl *Replica, desc *roachpb.RangeDescriptor, conf *roachpb.SpanConfig,
 ) (bool, error) {
 	transferStatus, err := s.replicateQueue.shedLease(
 		ctx, repl, desc, conf, allocator.TransferLeaseOptions{ExcludeLeaseRepl: true},

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -1061,17 +1061,23 @@ func (r *Replica) IsQuiescent() bool {
 
 // DescAndSpanConfig returns the authoritative range descriptor as well
 // as the span config for the replica.
-func (r *Replica) DescAndSpanConfig() (*roachpb.RangeDescriptor, roachpb.SpanConfig) {
+func (r *Replica) DescAndSpanConfig() (*roachpb.RangeDescriptor, *roachpb.SpanConfig) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	return r.mu.state.Desc, r.mu.conf
+	// This method is being removed shortly. We can't pass out a pointer to the
+	// underlying replica's SpanConfig.
+	conf := r.mu.conf
+	return r.mu.state.Desc, &conf
 }
 
 // SpanConfig returns the authoritative span config for the replica.
-func (r *Replica) SpanConfig() roachpb.SpanConfig {
+func (r *Replica) SpanConfig() *roachpb.SpanConfig {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	return r.mu.conf
+	// This method is being removed shortly. We can't pass out a pointer to the
+	// underlying replica's SpanConfig.
+	conf := r.mu.conf
+	return &conf
 }
 
 // Desc returns the authoritative range descriptor, acquiring a replica lock in

--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -3561,7 +3561,7 @@ type RelocateOneOptions interface {
 	// StorePool returns the store's configured store pool.
 	StorePool() storepool.AllocatorStorePool
 	// SpanConfig returns the span configuration for the range with start key.
-	SpanConfig(ctx context.Context, startKey roachpb.RKey) (roachpb.SpanConfig, error)
+	SpanConfig(ctx context.Context, startKey roachpb.RKey) (*roachpb.SpanConfig, error)
 	// LeaseHolder returns the descriptor of the replica which holds the lease
 	// on the range with start key.
 	Leaseholder(ctx context.Context, startKey roachpb.RKey) (roachpb.ReplicaDescriptor, error)
@@ -3584,16 +3584,16 @@ func (roo *replicaRelocateOneOptions) StorePool() storepool.AllocatorStorePool {
 // SpanConfig returns the span configuration for the range with start key.
 func (roo *replicaRelocateOneOptions) SpanConfig(
 	ctx context.Context, startKey roachpb.RKey,
-) (roachpb.SpanConfig, error) {
+) (*roachpb.SpanConfig, error) {
 	confReader, err := roo.store.GetConfReader(ctx)
 	if err != nil {
-		return roachpb.SpanConfig{}, errors.Wrap(err, "can't relocate range")
+		return nil, errors.Wrap(err, "can't relocate range")
 	}
 	conf, err := confReader.GetSpanConfigForKey(ctx, startKey)
 	if err != nil {
-		return roachpb.SpanConfig{}, err
+		return nil, err
 	}
-	return conf, nil
+	return &conf, nil
 }
 
 // Leaseholder returns the descriptor of the replica which holds the lease on
@@ -3996,7 +3996,7 @@ func (r *Replica) adminScatter(
 	var allowLeaseTransfer bool
 	var err error
 	requeue := true
-	canTransferLease := func(ctx context.Context, repl plan.LeaseCheckReplica, conf roachpb.SpanConfig) bool {
+	canTransferLease := func(ctx context.Context, repl plan.LeaseCheckReplica, conf *roachpb.SpanConfig) bool {
 		return allowLeaseTransfer
 	}
 	for re := retry.StartWithCtx(ctx, retryOpts); re.Next(); {

--- a/pkg/kv/kvserver/replica_range_lease.go
+++ b/pkg/kv/kvserver/replica_range_lease.go
@@ -1571,7 +1571,7 @@ const (
 // LeaseViolatesPreferences checks if this replica owns the lease and if it
 // violates the lease preferences defined in the span config. If no preferences
 // are defined then it will return false and consider it to be in conformance.
-func (r *Replica) LeaseViolatesPreferences(ctx context.Context, conf roachpb.SpanConfig) bool {
+func (r *Replica) LeaseViolatesPreferences(ctx context.Context, conf *roachpb.SpanConfig) bool {
 	storeID := r.store.StoreID()
 	preferences := conf.LeasePreferences
 	leaseStatus := r.CurrentLeaseStatus(ctx)

--- a/pkg/kv/kvserver/replica_rankings.go
+++ b/pkg/kv/kvserver/replica_rankings.go
@@ -47,7 +47,7 @@ type CandidateReplica interface {
 	GetFirstIndex() kvpb.RaftIndex
 	// DescAndSpanConfig returns the authoritative range descriptor as well
 	// as the span config for the replica.
-	DescAndSpanConfig() (*roachpb.RangeDescriptor, roachpb.SpanConfig)
+	DescAndSpanConfig() (*roachpb.RangeDescriptor, *roachpb.SpanConfig)
 	// Desc returns the authoritative range descriptor.
 	Desc() *roachpb.RangeDescriptor
 	// RangeUsageInfo returns usage information (sizes and traffic) needed by

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -13465,7 +13465,7 @@ func TestReplicateQueueProcessOne(t *testing.T) {
 		tc.repl,
 		tc.repl.Desc(),
 		tc.repl.SpanConfig(),
-		func(ctx context.Context, repl plan.LeaseCheckReplica, conf roachpb.SpanConfig) bool { return false },
+		func(ctx context.Context, repl plan.LeaseCheckReplica, conf *roachpb.SpanConfig) bool { return false },
 		false, /* scatter */
 		true,  /* dryRun */
 	)

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -3497,7 +3497,7 @@ func (s *Store) ReplicateQueueDryRun(
 		s.cfg.AmbientCtx.Tracer, "replicate queue dry run",
 	)
 	defer collectAndFinish()
-	canTransferLease := func(ctx context.Context, repl plan.LeaseCheckReplica, conf roachpb.SpanConfig) bool {
+	canTransferLease := func(ctx context.Context, repl plan.LeaseCheckReplica, conf *roachpb.SpanConfig) bool {
 		return true
 	}
 	desc := repl.Desc()
@@ -3561,7 +3561,7 @@ func (s *Store) AllocatorCheckRange(
 		storePool = s.cfg.StorePool
 	}
 
-	action, _ := s.allocator.ComputeAction(ctx, storePool, conf, desc)
+	action, _ := s.allocator.ComputeAction(ctx, storePool, &conf, desc)
 
 	// In the case that the action does not require a target, return immediately.
 	if !(action.Add() || action.Replace()) {
@@ -3575,7 +3575,7 @@ func (s *Store) AllocatorCheckRange(
 		return action, roachpb.ReplicationTarget{}, sp.FinishAndGetConfiguredRecording(), err
 	}
 
-	target, _, err := s.allocator.AllocateTarget(ctx, storePool, conf,
+	target, _, err := s.allocator.AllocateTarget(ctx, storePool, &conf,
 		filteredVoters, filteredNonVoters, replacing, action.ReplicaStatus(), action.TargetReplicaType(),
 	)
 	if err == nil {
@@ -3586,7 +3586,7 @@ func (s *Store) AllocatorCheckRange(
 		fragileQuorumErr := s.allocator.CheckAvoidsFragileQuorum(
 			ctx,
 			storePool,
-			conf,
+			&conf,
 			desc.Replicas().VoterDescriptors(),
 			filteredVoters,
 			action.ReplicaStatus(),

--- a/pkg/kv/kvserver/store_rebalancer.go
+++ b/pkg/kv/kvserver/store_rebalancer.go
@@ -821,7 +821,7 @@ func (sr *StoreRebalancer) chooseLeaseToTransfer(
 type rangeRebalanceContext struct {
 	candidateReplica CandidateReplica
 	rangeDesc        *roachpb.RangeDescriptor
-	conf             roachpb.SpanConfig
+	conf             *roachpb.SpanConfig
 }
 
 func (sr *StoreRebalancer) chooseRangeToRebalance(

--- a/pkg/upgrade/BUILD.bazel
+++ b/pkg/upgrade/BUILD.bazel
@@ -20,7 +20,6 @@ go_library(
         "//pkg/roachpb",
         "//pkg/server/serverpb",
         "//pkg/settings/cluster",
-        "//pkg/spanconfig",
         "//pkg/sql/catalog/descs",
         "//pkg/sql/catalog/lease",
         "//pkg/sql/catalog/resolver",

--- a/pkg/upgrade/tenant_upgrade.go
+++ b/pkg/upgrade/tenant_upgrade.go
@@ -20,7 +20,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
-	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/lease"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/resolver"
@@ -43,12 +42,6 @@ type TenantDeps struct {
 
 	// TODO(ajwerner): Remove this in favor of the descs.DB above.
 	InternalExecutor isql.Executor
-
-	SpanConfig struct { // deps for span config upgrades; can be removed accordingly
-		spanconfig.KVAccessor
-		spanconfig.Splitter
-		Default roachpb.SpanConfig
-	}
 
 	TestingKnobs              *upgradebase.TestingKnobs
 	SchemaResolverConstructor func( // A constructor that returns a schema resolver for `descriptors` in `currDb`.

--- a/pkg/upgrade/upgradejob/upgrade_job.go
+++ b/pkg/upgrade/upgradejob/upgrade_job.go
@@ -97,9 +97,6 @@ func (r resumer) Resume(ctx context.Context, execCtxI interface{}) error {
 			TestingKnobs:     execCtx.ExecCfg().UpgradeTestingKnobs,
 			SessionData:      execCtx.SessionData(),
 		}
-		tenantDeps.SpanConfig.KVAccessor = execCtx.ExecCfg().SpanConfigKVAccessor
-		tenantDeps.SpanConfig.Splitter = execCtx.ExecCfg().SpanConfigSplitter
-		tenantDeps.SpanConfig.Default = execCtx.ExecCfg().DefaultZoneConfig.AsSpanConfig()
 
 		tenantDeps.SchemaResolverConstructor = func(
 			txn *kv.Txn, descriptors *descs.Collection, currDb string,


### PR DESCRIPTION
Note: Only the last 2 commits are only in this PR.

SpanConfig can be a large object and it is more efficient to pass by
pointer now that it goes through multiple layers of code.

Epic: none

Release note: None
