### PR TITLE
scheduledlogging: fix TestCaptureIndexUsageStats for secondary tenants

### DIFF
--- a/pkg/sql/scheduledlogging/BUILD.bazel
+++ b/pkg/sql/scheduledlogging/BUILD.bazel
@@ -37,6 +37,7 @@ go_test(
         "//pkg/security/securitytest",
         "//pkg/server",
         "//pkg/settings/cluster",
+        "//pkg/testutils",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/sqlutils",
         "//pkg/testutils/testcluster",

--- a/pkg/sql/scheduledlogging/captured_index_usage_stats.go
+++ b/pkg/sql/scheduledlogging/captured_index_usage_stats.go
@@ -71,9 +71,6 @@ type CaptureIndexUsageStatsTestingKnobs struct {
 	// scheduled interval in the case that the logging duration exceeds the
 	// default scheduled interval duration.
 	getOverlapDuration func() time.Duration
-	// onScheduleComplete allows tests to hook into when the current schedule
-	// is completed to check for the expected logs.
-	onScheduleComplete func()
 }
 
 // ModuleTestingKnobs implements base.ModuleTestingKnobs interface.
@@ -158,9 +155,6 @@ func (s *CaptureIndexUsageStatsLoggingScheduler) start(ctx context.Context, stop
 					dur = time.Second
 				}
 				timer.Reset(dur)
-				if s.knobs != nil && s.knobs.onScheduleComplete != nil {
-					s.knobs.onScheduleComplete()
-				}
 			}
 		}
 	})


### PR DESCRIPTION
This commit fixes flaky behavior when TestCaptureIndexUsageStats is run for secondary tenants. The previous synchronization mechanism between logging and the test was not consistent between system and secondary tenants.

Instead, there's no attempt to synchronize, and we rely on testutils.SucceedsSoon instead.

Resolves #109465
Epic: none
Release note: None