### PR TITLE
loqrecovery: fix TestRetrieveRangeStatus to wait 5x replication

### DIFF
--- a/pkg/kv/kvserver/loqrecovery/server_integration_test.go
+++ b/pkg/kv/kvserver/loqrecovery/server_integration_test.go
@@ -485,7 +485,8 @@ func TestRetrieveRangeStatus(t *testing.T) {
 
 	// Use scratch range to ensure we have a range that loses quorum.
 	sk := tc.ScratchRange(t)
-	require.NoError(t, tc.WaitForFullReplication(), "failed to wait for full replication")
+	require.NoError(t, tc.WaitFor5NodeReplication(),
+		"failed to wait for full replication of 5 node cluster")
 	tc.ToggleReplicateQueues(false)
 	tc.SplitRangeOrFatal(t, testutils.MakeKey(sk, []byte{255}))
 


### PR DESCRIPTION
Test requires full 5 node cluster to be able to survive the loss of 2 nodes. This commit adds checks to ensure RF is met prior to doing test.

Epic: none
Fixes: #109571

Release note: None