### PR TITLE
storage: don't reread value during inline conditional writes

### DIFF
--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -1640,37 +1640,6 @@ func mvccPutUsingIter(
 	return err
 }
 
-// maybeGetValue returns either value (if valueFn is nil) or else the
-// result of calling valueFn on the data read at readTimestamp. The
-// function uses a non-transactional read, so uncertainty does not apply
-// and any intents (even the caller's own if the caller is operating on
-// behalf of a transaction), will result in a LockConflictError. Because
-// of this, the function is only called from places where intents have
-// already been considered.
-func maybeGetValue(
-	ctx context.Context,
-	iter MVCCIterator,
-	key roachpb.Key,
-	value roachpb.Value,
-	exists bool,
-	readTimestamp hlc.Timestamp,
-	valueFn func(optionalValue) (roachpb.Value, error),
-) (roachpb.Value, error) {
-	// If a valueFn is specified, read existing value using the iter.
-	if valueFn == nil {
-		return value, nil
-	}
-	var exVal optionalValue
-	if exists {
-		var err error
-		exVal, _, err = mvccGet(ctx, iter, key, readTimestamp, MVCCGetOptions{Tombstones: true})
-		if err != nil {
-			return roachpb.Value{}, err
-		}
-	}
-	return valueFn(exVal)
-}
-
 // MVCCScanDecodeKeyValue decodes a key/value pair returned in an MVCCScan
 // "batch" (this is not the RocksDB batch repr format), returning both the
 // key/value and the suffix of data remaining in the batch.
@@ -2180,9 +2149,21 @@ func mvccPutInternal(
 			writeTimestamp.Forward(metaTimestamp.Next())
 			writeTooOldErr := kvpb.NewWriteTooOldError(readTimestamp, writeTimestamp, key)
 			return false, writeTooOldErr
-		} else {
-			if value, err = maybeGetValue(ctx, iter, key, value, ok, readTimestamp, valueFn); err != nil {
-				return false, err
+		} else /* meta.Txn == nil && metaTimestamp.Less(readTimestamp) */ {
+			// If a valueFn is specified, read the existing value using iter.
+			if valueFn != nil {
+				exVal, _, err := mvccGet(ctx, iter, key, readTimestamp, MVCCGetOptions{
+					Tombstones: true,
+					// Unlike above, we know that there are no intents on this
+					// key, so we don't need to perform an inconsistent read.
+				})
+				if err != nil {
+					return false, err
+				}
+				value, err = valueFn(exVal)
+				if err != nil {
+					return false, err
+				}
 			}
 		}
 	} else {

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -1874,8 +1874,8 @@ func mvccPutInternal(
 				ValueSize:      uint32(origMetaValSize),
 			})
 		} else {
-			buf.meta = enginepb.MVCCMetadata{RawBytes: value.RawBytes}
-			metaKeySize, metaValSize, err = buf.putInlineMeta(writer, metaKey, &buf.meta)
+			buf.newMeta = enginepb.MVCCMetadata{RawBytes: value.RawBytes}
+			metaKeySize, metaValSize, err = buf.putInlineMeta(writer, metaKey, &buf.newMeta)
 		}
 		if opts.Stats != nil {
 			updateStatsForInline(opts.Stats, key, origMetaKeySize, origMetaValSize, metaKeySize, metaValSize)

--- a/pkg/storage/testdata/mvcc_histories/inline
+++ b/pkg/storage/testdata/mvcc_histories/inline
@@ -1,0 +1,80 @@
+## A simple test of inline operations.
+
+run ok
+put k=i1 v=inline1
+put k=i2 v=inline2
+put k=i3 v=inline3
+----
+>> at end:
+meta: "i1"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/inline1 mergeTs=<nil> txnDidNotUpdateMeta=false
+meta: "i2"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/inline2 mergeTs=<nil> txnDidNotUpdateMeta=false
+meta: "i3"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/inline3 mergeTs=<nil> txnDidNotUpdateMeta=false
+
+run ok
+get k=i1
+get k=i2
+get k=i3
+----
+get: "i1" -> /BYTES/inline1 @0,0
+get: "i2" -> /BYTES/inline2 @0,0
+get: "i3" -> /BYTES/inline3 @0,0
+
+run ok
+scan k=i1 end=i4
+----
+scan: "i1" -> /BYTES/inline1 @0,0
+scan: "i2" -> /BYTES/inline2 @0,0
+scan: "i3" -> /BYTES/inline3 @0,0
+
+run ok
+del k=i1
+----
+del: "i1": found key true
+>> at end:
+meta: "i2"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/inline2 mergeTs=<nil> txnDidNotUpdateMeta=false
+meta: "i3"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/inline3 mergeTs=<nil> txnDidNotUpdateMeta=false
+
+run error
+cput k=i2 v=inline2b cond=incorrect
+----
+>> at end:
+meta: "i2"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/inline2 mergeTs=<nil> txnDidNotUpdateMeta=false
+meta: "i3"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/inline3 mergeTs=<nil> txnDidNotUpdateMeta=false
+error: (*kvpb.ConditionFailedError:) unexpected value: raw_bytes:"\000\000\000\000\003inline2" timestamp:<> 
+
+run ok
+cput k=i2 v=inline2b cond=inline2
+----
+>> at end:
+meta: "i2"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/inline2b mergeTs=<nil> txnDidNotUpdateMeta=false
+meta: "i3"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/inline3 mergeTs=<nil> txnDidNotUpdateMeta=false
+
+run error
+initput k=i3 v=inline3b
+----
+>> at end:
+meta: "i2"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/inline2b mergeTs=<nil> txnDidNotUpdateMeta=false
+meta: "i3"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/inline3 mergeTs=<nil> txnDidNotUpdateMeta=false
+error: (*kvpb.ConditionFailedError:) unexpected value: raw_bytes:"\000\000\000\000\003inline3" timestamp:<> 
+
+run ok
+initput k=i3 v=inline3
+----
+>> at end:
+meta: "i2"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/inline2b mergeTs=<nil> txnDidNotUpdateMeta=false
+meta: "i3"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/inline3 mergeTs=<nil> txnDidNotUpdateMeta=false
+
+run error
+increment k=i3
+----
+>> at end:
+meta: "i2"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/inline2b mergeTs=<nil> txnDidNotUpdateMeta=false
+meta: "i3"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/inline3 mergeTs=<nil> txnDidNotUpdateMeta=false
+error: (*withstack.withStack:) key "i3" does not contain an integer value
+
+run ok
+del_range k=i1 end=i4
+----
+del_range: "i1"-"i4" -> deleted 2 key(s)
+>> at end:
+<no data>


### PR DESCRIPTION
This commit removes the call to maybeGetValue when performing an inline conditional write. In such cases, we will have already read the value in the call to mvccGetMetadata, so we don't need to do so again.

I'm not aware of any workloads that are sensitive to the performance of conditional inline writes and I also suspect that the positioning of the Pebble iterator was avoiding some work during the second seek, so this is mainly just intended to be a code simplification.

Epic: None
Release note: None