### PR TITLE
allocator: change some log.VEventf to log.VInfof

### DIFF
--- a/pkg/kv/kvserver/allocator/allocatorimpl/allocator.go
+++ b/pkg/kv/kvserver/allocator/allocatorimpl/allocator.go
@@ -1444,7 +1444,7 @@ func (a *Allocator) allocateTargetFromList(
 		targetType,
 	)
 
-	log.KvDistribution.VEventf(ctx, 3, "allocate %s: %s", targetType, candidates)
+	log.KvDistribution.VInfof(ctx, 3, "allocate %s: %s", targetType, candidates)
 	if target := selector.selectOne(candidates); target != nil {
 		log.KvDistribution.VEventf(ctx, 3, "add target: %s", target)
 		details := decisionDetails{Target: target.compactString()}
@@ -1578,7 +1578,7 @@ func (a Allocator) RemoveTarget(
 	if bad := rankedCandidates.selectWorst(a.randGen); bad != nil {
 		for _, exist := range existingReplicas {
 			if exist.StoreID == bad.store.StoreID {
-				log.KvDistribution.VEventf(ctx, 3, "remove target: %s", bad)
+				log.KvDistribution.VInfof(ctx, 3, "remove target: %s", bad)
 				details := decisionDetails{Target: bad.compactString()}
 				detailsBytes, err := json.Marshal(details)
 				if err != nil {
@@ -2528,7 +2528,7 @@ func (a *Allocator) ShouldTransferLease(
 	sl, _, _ := storePool.GetStoreList(storepool.StoreFilterSuspect)
 	sl = sl.ExcludeInvalid(conf.Constraints)
 	sl = sl.ExcludeInvalid(conf.VoterConstraints)
-	log.KvDistribution.VEventf(ctx, 3, "ShouldTransferLease (lease-holder=s%d):\n%s", leaseRepl.StoreID(), sl)
+	log.KvDistribution.VInfof(ctx, 3, "ShouldTransferLease (lease-holder=s%d):\n%s", leaseRepl.StoreID(), sl)
 
 	transferDec, _ := a.shouldTransferLeaseForAccessLocality(
 		ctx,
@@ -2551,7 +2551,7 @@ func (a *Allocator) ShouldTransferLease(
 		log.KvDistribution.Fatalf(ctx, "unexpected transfer decision %d", transferDec)
 	}
 
-	log.KvDistribution.VEventf(
+	log.KvDistribution.VInfof(
 		ctx, 3, "ShouldTransferLease decision (lease-holder=s%d): %t", leaseRepl.StoreID(), result,
 	)
 	return result

--- a/pkg/kv/kvserver/allocator/plan/replicate.go
+++ b/pkg/kv/kvserver/allocator/plan/replicate.go
@@ -149,7 +149,7 @@ func (rp ReplicaPlanner) ShouldPlanChange(
 	canTransferLeaseFrom CanTransferLeaseFrom,
 ) (shouldPlanChange bool, priority float64) {
 
-	log.KvDistribution.VEventf(ctx, 6,
+	log.KvDistribution.VInfof(ctx, 6,
 		"computing range action desc=%s config=%s",
 		desc, conf.String())
 	action, priority := rp.allocator.ComputeAction(ctx, rp.storePool, conf, desc)
@@ -252,7 +252,7 @@ func (rp ReplicaPlanner) PlanOneChange(
 		Op:      AllocationNoop{},
 		Replica: repl,
 	}
-	log.KvDistribution.VEventf(ctx, 6,
+	log.KvDistribution.VInfof(ctx, 6,
 		"planning range change desc=%s config=%s",
 		desc, conf.String())
 
@@ -263,7 +263,7 @@ func (rp ReplicaPlanner) PlanOneChange(
 	// NB: the replication layer ensures that the below operations don't cause
 	// unavailability; see kvserver.execChangeReplicasTxn.
 	action, allocatorPrio := rp.allocator.ComputeAction(ctx, rp.storePool, conf, desc)
-	log.KvDistribution.VEventf(ctx, 1, "next replica action: %s", action)
+	log.KvDistribution.VInfof(ctx, 1, "next replica action: %s", action)
 
 	var err error
 	var op AllocationOp


### PR DESCRIPTION
When investigating delays in the allocator simulator test, we found that a
significant amount of time were spent on log.VEvent. Upon investigating, the log
events removed in this patch are those that occurred most frequently during
testing. I'm considering removing some of the log events here and would
appreciate a second pair of eye to better decide whether these log events are
useful for tracing.

See also: #107420
Part of: #107421
Release note: none

----

| Before| After |
| -| - |
| <img width="500" alt="Screenshot 2023-08-31 at 9 14 30 AM" src="https://github.com/cockroachdb/cockroach/assets/56973754/96767ce7-e434-418a-9d40-2637e487b31c">|<img width="500" alt="Screenshot 2023-08-31 at 9 14 43 AM" src="https://github.com/cockroachdb/cockroach/assets/56973754/608592f0-c0ac-4b07-9516-d4a6f3e89936">