### PR TITLE
rangefeed: deflake TestBudgetReleaseOnProcessorStop

### DIFF
--- a/pkg/kv/kvserver/rangefeed/processor_test.go
+++ b/pkg/kv/kvserver/rangefeed/processor_test.go
@@ -1105,7 +1105,7 @@ func TestBudgetReleaseOnProcessorStop(t *testing.T) {
 		PushTxnsInterval: pushTxnInterval,
 		PushTxnsAge:      pushTxnAge,
 		EventChanCap:     channelCapacity,
-		EventChanTimeout: time.Millisecond,
+		EventChanTimeout: 100 * time.Millisecond, // enough time for registration to process events
 		MemBudget:        fb,
 		Metrics:          NewMetrics(),
 	})


### PR DESCRIPTION
Fixes #109802
Epic: none
Release note: none