### PR TITLE
release-23.1: kv: deflake TestTxnCoordSenderRetries

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
@@ -2007,6 +2007,11 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 			return nil
 		}
 
+	// Disable load-based splitting to avoid unexpected range splits. The test
+	// operates between keys "a" and "z" and expects a single split point at "b".
+	// See the call to setupMultipleRanges below.
+	storeKnobs.DisableLoadBasedSplitting = true
+
 	var refreshSpansCondenseFilter atomic.Value
 	s, _, _ := serverutils.StartServer(t,
 		base.TestServerArgs{Knobs: base.TestingKnobs{
@@ -2767,10 +2772,10 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 			// This test is like the previous one in that the commit batch succeeds at
 			// an updated timestamp, but this time the EndTxn puts the
 			// transaction in the STAGING state instead of COMMITTED because there had
-			// been previous write in a different batch. Like above, the commit is
+			// been a previous write in a different batch. Like above, the commit is
 			// successful since there are no refresh spans (the request will succeed
 			// after a server-side refresh).
-			name: "write too old in staging commit",
+			name: "write too old with put in staging commit",
 			beforeTxnStart: func(ctx context.Context, db *kv.DB) error {
 				return db.Put(ctx, "a", "orig")
 			},


### PR DESCRIPTION
Backport 1/1 commits from #108151.

Release justification: testing.

/cc @cockroachdb/release

---

Fixes #107847.

This commit deflakes `TestTxnCoordSenderRetries`, which was observed to fail if a load-based split was performed at key "ab". A split at this key had the effect of turning the "write too old in staging commit" subtest into something closer to "multi-range batch commit with write too old (err on first range)", where the transaction record and write-write conflict were on different ranges.

This commit deflakes the test by disabling load-based splits.

While diagnosing the issue, I found two easy ways to reproduce the failure which demonstrate that load-based splitting was the source of the flakiness:
- manually split at key "ab"
- sleep for 10ms between each subtest, giving load-based splitting more time

With load-based splitting disabled, the test passes under race+stress even with the 10ms pauses.

Release note: None
