### PR TITLE
ccl/multiregionccl: deflake multi-region datadriven test

### DIFF
--- a/pkg/ccl/multiregionccl/datadriven_test.go
+++ b/pkg/ccl/multiregionccl/datadriven_test.go
@@ -113,7 +113,13 @@ func TestMultiRegionDataDriven(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	// This test speeds up replication changes by proactively enqueuing replicas
+	// into various queues. This has the benefit of reducing the time taken after
+	// zone config changes, however the downside of added overhead. Disable the
+	// test under deadlock builds, as the test is slow and susceptible to
+	// (legitimate) timing issues on a deadlock build.
 	skip.UnderRace(t, "flaky test")
+	skip.UnderDeadlock(t, "flaky test")
 	skip.WithIssue(t, 98020)
 	ctx := context.Background()
 	datadriven.Walk(t, datapathutils.TestDataPath(t), func(t *testing.T, path string) {

--- a/pkg/ccl/multiregionccl/datadriven_test.go
+++ b/pkg/ccl/multiregionccl/datadriven_test.go
@@ -186,13 +186,17 @@ func TestMultiRegionDataDriven(t *testing.T) {
 				}
 				// Speed up closing of timestamps, in order to sleep less below before
 				// we can use follower_read_timestamp(). follower_read_timestamp() uses
-				// sum of the following settings.
+				// sum of the following settings. Also, disable all kvserver lease
+				// transfers other than those required to satisfy a lease preference.
+				// This prevents the lease shifting around too quickly, which leads to
+				// concurrent replication changes being proposed by prior leaseholders.
 				for _, stmt := range strings.Split(`
 SET CLUSTER SETTING kv.closed_timestamp.target_duration = '0.4s';
 SET CLUSTER SETTING kv.closed_timestamp.side_transport_interval = '0.1s';
 SET CLUSTER SETTING kv.closed_timestamp.propagation_slack = '0.5s';
 SET CLUSTER SETTING kv.allocator.load_based_rebalancing = 'off';
-SET CLUSTER SETTING kv.allocator.load_based_lease_rebalancing.enabled = false
+SET CLUSTER SETTING kv.allocator.load_based_lease_rebalancing.enabled = false;
+SET CLUSTER SETTING kv.allocator.min_lease_transfer_interval = 5m
 `,
 					";") {
 					_, err = sqlConn.Exec(stmt)


### PR DESCRIPTION
Previously, `TestMultiRegionDataDriven` allowed kvserver (replicate queue) lease transfers to occur for lease count rebalancing. Load based rebalancing was disabled in an earlier patch #109050, however we saw in interleaving replication changes -- leading to flaky behavior.

Bump the `kv.allocator.min_lease_transfer_interval` to 5 minutes, effectively disabling internal lease transfers. Lease transfers which are required for lease preference satisfaction, and manual transfers are still permitted.

Fixes: #109215
Release note: None

---

`TestMultiRegionDataDriven` speeds up replication changes by proactively
enqueuing replicas into various queues. This has the benefit of reducing
the time taken after zone config changes, however the downside of added
overhead.

Disable the test under deadlock builds, as the test is slow and
susceptible to (legitimate) timing issues on a deadlock build.

Informs: https://github.com/cockroachdb/cockroach/issues/109215
Release note: None