### PR TITLE
server: add goroutinedumper file to TestStatusGetFiles

### DIFF
--- a/pkg/server/storage_api/files_test.go
+++ b/pkg/server/storage_api/files_test.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -84,6 +85,14 @@ func TestStatusGetFiles(t *testing.T) {
 
 	// Test fetching goroutine files.
 	t.Run("goroutines", func(t *testing.T) {
+
+		// regex for goroutine file names manually added
+		reDump := regexp.MustCompile(`goroutine_dump\d+.txt.gz`)
+		// regex for goroutine file names dumped by goroutinedumper
+		reOOMDump := regexp.MustCompile("goroutine_dump.*.double_since_last_dump.*.txt.gz")
+		// regex for content of goroutine files manually added
+		reDumpContent := regexp.MustCompile(`Goroutine dump \d+`)
+
 		const testFilesNo = 3
 		for i := 0; i < testFilesNo; i++ {
 			testGoroutineDir := filepath.Join(storeSpec.Path, "logs", base.GoroutineDumpDir)
@@ -103,18 +112,22 @@ func TestStatusGetFiles(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if a, e := len(response.Files), testFilesNo; a != e {
-			t.Errorf("expected %d files(s), found %d", e, a)
+		if a, e := len(response.Files), testFilesNo; a < e {
+			t.Errorf("expected at least %d files(s), found %d", e, a)
 		}
 
-		for i, file := range response.Files {
-			expectedFileName := fmt.Sprintf("goroutine_dump%d.txt.gz", i)
-			if file.Name != expectedFileName {
-				t.Fatalf("expected file name %s, found %s", expectedFileName, file.Name)
+		for _, file := range response.Files {
+			if reOOMDump.MatchString(file.Name) {
+				continue
 			}
-			expectedFileContents := []byte(fmt.Sprintf("Goroutine dump %d", i))
-			if !bytes.Equal(file.Contents, expectedFileContents) {
-				t.Fatalf("expected file contents %s, found %s", expectedFileContents, file.Contents)
+			if reDump.MatchString(file.Name) {
+				if !reDumpContent.Match(file.Contents) {
+					t.Fatalf("expected file content of form %s, found %s", reDumpContent,
+						file.Contents)
+				}
+			} else {
+				t.Fatalf("expected file name of form %s, found %s", reDump,
+					file.Name)
 			}
 		}
 	})


### PR DESCRIPTION
This commit refactors the goroutines subtest of TestStatusGetFiles to check for goroutinedumper files.

Fixes #109698.

Release note: None