### PR TITLE
release-22.2: spanconfig: skip protected timestamps on non-table data 

### DIFF
--- a/pkg/keys/spans.go
+++ b/pkg/keys/spans.go
@@ -16,6 +16,10 @@ var (
 	// EverythingSpan is a span that covers everything.
 	EverythingSpan = roachpb.Span{Key: roachpb.KeyMin, EndKey: roachpb.KeyMax}
 
+	// ExcludeFromBackupSpan is a span that covers the keyspace that we exclude
+	// from full cluster backup and do not place protected timestamps on.
+	ExcludeFromBackupSpan = roachpb.Span{Key: roachpb.KeyMin, EndKey: TableDataMin}
+
 	// Meta1Span holds all first level addressing records.
 	Meta1Span = roachpb.Span{Key: roachpb.KeyMin, EndKey: Meta2Prefix}
 

--- a/pkg/spanconfig/spanconfigkvsubscriber/kvsubscriber.go
+++ b/pkg/spanconfig/spanconfigkvsubscriber/kvsubscriber.go
@@ -366,6 +366,15 @@ func (s *KVSubscriber) GetProtectionTimestamps(
 	if err := s.mu.internal.ForEachOverlappingSpanConfig(ctx, sp,
 		func(sp roachpb.Span, config roachpb.SpanConfig) error {
 			for _, protection := range config.GCPolicy.ProtectionPolicies {
+				// If the current span is a subset of the key space we exclude from full
+				// cluster backups, then we ignore it. This avoids placing a protected
+				// timestamp and hold up GC on spans not needed for backup (i.e.
+				// NodeLiveness, Timeseries). These spans tend to be high churn,
+				// accumulating high amounts of MVCC garbage. Placing a PTS on these
+				// spans can thus be detrimental.
+				if keys.ExcludeFromBackupSpan.Contains(sp) {
+					continue
+				}
 				// If the SpanConfig that applies to this span indicates that the span
 				// is going to be excluded from backup, and the protection policy was
 				// written by a backup, then ignore it. This prevents the

--- a/pkg/spanconfig/spanconfigkvsubscriber/kvsubscriber_test.go
+++ b/pkg/spanconfig/spanconfigkvsubscriber/kvsubscriber_test.go
@@ -81,6 +81,14 @@ func TestGetProtectionTimestamps(t *testing.T) {
 	// Mark sp43 as excluded from backup.
 	sp43Cfg.cfg.ExcludeDataFromBackup = true
 
+	excludedKeyspaceConfig := makeSpanAndSpanConfigWithProtectionPolicies(keys.ExcludeFromBackupSpan, []roachpb.ProtectionPolicy{
+		{ProtectedTimestamp: ts4},
+	})
+
+	nodelivenessKeyspaceConfig := makeSpanAndSpanConfigWithProtectionPolicies(keys.NodeLivenessSpan, []roachpb.ProtectionPolicy{
+		{ProtectedTimestamp: ts4},
+	})
+
 	const timeDeltaFromTS1 = 10
 	mt := timeutil.NewManualTime(ts1.GoTime())
 	mt.AdvanceTo(ts1.Add(timeDeltaFromTS1, 0).GoTime())
@@ -96,7 +104,7 @@ func TestGetProtectionTimestamps(t *testing.T) {
 		nil,
 	)
 	m := &manualStore{
-		spanAndConfigs: []spanAndSpanConfig{sp42Cfg, sp43Cfg},
+		spanAndConfigs: []spanAndSpanConfig{sp42Cfg, sp43Cfg, excludedKeyspaceConfig, nodelivenessKeyspaceConfig},
 	}
 	subscriber.mu.internal = m
 
@@ -130,6 +138,42 @@ func TestGetProtectionTimestamps(t *testing.T) {
 			"span across two table spans",
 			func(t *testing.T, m *manualStore, subscriber *KVSubscriber) {
 				protections, _, err := subscriber.GetProtectionTimestamps(ctx, sp4243)
+				require.NoError(t, err)
+				sort.SliceIsSorted(protections, func(i, j int) bool {
+					return protections[i].Less(protections[j])
+				})
+				require.Equal(t, []hlc.Timestamp{ts1, ts2, ts4}, protections)
+			},
+		},
+		{
+			"ExcludeFromBackupSpan does not include PTS records",
+			func(t *testing.T, m *manualStore, subscriber *KVSubscriber) {
+				protections, _, err := subscriber.GetProtectionTimestamps(ctx, keys.ExcludeFromBackupSpan)
+				require.NoError(t, err)
+				sort.SliceIsSorted(protections, func(i, j int) bool {
+					return protections[i].Less(protections[j])
+				})
+				require.Empty(t, protections)
+			},
+		},
+		{
+			"NodeLivenessSpan does not include PTS records",
+			func(t *testing.T, m *manualStore, subscriber *KVSubscriber) {
+				protections, _, err := subscriber.GetProtectionTimestamps(ctx, keys.NodeLivenessSpan)
+				require.NoError(t, err)
+				sort.SliceIsSorted(protections, func(i, j int) bool {
+					return protections[i].Less(protections[j])
+				})
+				require.Empty(t, protections)
+			},
+		},
+		{
+			"span across back up boundary includes PTS records",
+			func(t *testing.T, m *manualStore, subscriber *KVSubscriber) {
+				protections, _, err := subscriber.GetProtectionTimestamps(
+					ctx,
+					roachpb.Span{Key: keys.MinKey, EndKey: sp43.EndKey},
+				)
 				require.NoError(t, err)
 				sort.SliceIsSorted(protections, func(i, j int) bool {
 					return protections[i].Less(protections[j])


### PR DESCRIPTION
Backport 1/1 commits from #109683.

/cc @cockroachdb/release

---

Previously, we were placing a protected timestamp using the
`EverythingSpan` which covered the entire keyspace when targeting a
cluster backup. This was non-ideal because not all are used for backup.
This is especially problematic for high churn ranges, such as node
liveness and timeseries, that can accumulate lots of MVCC garbage very
quickly. Placing a protected timestamp on these ranges, thus preventing
the MVCC GC to run, can cause badness.

This patch introduces a new span that covers the keyspace excluded from
backup. When we encounter a span that is within those bounds, we skip
placing a protected timestamp on it.

Fixes: https://github.com/cockroachdb/cockroach/issues/102338

Release note: None

Release justification: bug fix

