### PR TITLE
release-23.1: spanconfig: skip protected timestamps on non-table data 

### DIFF
--- a/pkg/keys/spans.go
+++ b/pkg/keys/spans.go
@@ -16,6 +16,10 @@ var (
 	// EverythingSpan is a span that covers everything.
 	EverythingSpan = roachpb.Span{Key: roachpb.KeyMin, EndKey: roachpb.KeyMax}
 
+	// ExcludeFromBackupSpan is a span that covers the keyspace that we exclude
+	// from full cluster backup and do not place protected timestamps on.
+	ExcludeFromBackupSpan = roachpb.Span{Key: roachpb.KeyMin, EndKey: TableDataMin}
+
 	// Meta1Span holds all first level addressing records.
 	Meta1Span = roachpb.Span{Key: roachpb.KeyMin, EndKey: Meta2Prefix}
 


### PR DESCRIPTION
Backport 1/1 commits from #109683.

/cc @cockroachdb/release

---

Previously, we were placing a protected timestamp using the
`EverythingSpan` which covered the entire keyspace when targeting a
cluster backup. This was non-ideal because not all are used for backup.
This is especially problematic for high churn ranges, such as node
liveness and timeseries, that can accumulate lots of MVCC garbage very
quickly. Placing a protected timestamp on these ranges, thus preventing
the MVCC GC to run, can cause badness.

This patch introduces a new span that covers the keyspace excluded from
backup. When we encounter a span that is within those bounds, we skip
placing a protected timestamp on it.

Fixes: https://github.com/cockroachdb/cockroach/issues/102338

Release note: None

Release justification: bug fix

