### PR TITLE
changefeedccl: add changefeed.lagging_ranges metric

### DIFF
--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -237,6 +237,7 @@ go_test(
         "//pkg/kv/kvclient/kvcoord",
         "//pkg/kv/kvpb",
         "//pkg/kv/kvserver",
+        "//pkg/kv/kvserver/closedts",
         "//pkg/kv/kvserver/kvserverbase",
         "//pkg/kv/kvserver/protectedts",
         "//pkg/roachpb",

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -50,6 +50,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/closedts"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/server"
@@ -1224,6 +1226,122 @@ func TestChangefeedInitialScan(t *testing.T) {
 	}
 
 	cdcTest(t, testFn)
+}
+
+// TestChangefeedLaggingRangesMetrics tests the behavior of the
+// changefeed.lagging_ranges metric.
+func TestChangefeedLaggingRangesMetrics(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
+		sqlDB := sqlutils.MakeSQLRunner(s.DB)
+
+		// Ensure a fast closed timestamp interval so ranges can catch up fast.
+		kvserver.RangeFeedRefreshInterval.Override(
+			context.Background(), &s.Server.ClusterSettings().SV, 20*time.Millisecond)
+		closedts.SideTransportCloseInterval.Override(
+			context.Background(), &s.Server.ClusterSettings().SV, 20*time.Millisecond)
+		closedts.TargetDuration.Override(
+			context.Background(), &s.Server.ClusterSettings().SV, 20*time.Millisecond)
+
+		skipMu := syncutil.Mutex{}
+		skippedRanges := map[string]struct{}{}
+		numRanges := 10
+		numRangesToSkip := int64(4)
+		var stopSkip atomic.Bool
+		// `shouldSkip` continuously skips checkpoints for the first `numRangesToSkip` ranges it sees.
+		// skipping is disabled by setting `stopSkip` to true.
+		shouldSkip := func(event *kvpb.RangeFeedEvent) bool {
+			if stopSkip.Load() {
+				return false
+			}
+			switch event.GetValue().(type) {
+			case *kvpb.RangeFeedCheckpoint:
+				sp := event.Checkpoint.Span
+				skipMu.Lock()
+				defer skipMu.Unlock()
+				if _, ok := skippedRanges[sp.String()]; ok || int64(len(skippedRanges)) < numRangesToSkip {
+					skippedRanges[sp.String()] = struct{}{}
+					return true
+				}
+			}
+			return false
+		}
+
+		knobs := s.TestingKnobs.DistSQL.(*execinfra.TestingKnobs).Changefeed.(*TestingKnobs)
+
+		knobs.FeedKnobs.RangefeedOptions = append(knobs.FeedKnobs.RangefeedOptions, kvcoord.TestingWithOnRangefeedEvent(
+			func(ctx context.Context, s roachpb.Span, _ int64, event *kvpb.RangeFeedEvent) (skip bool, _ error) {
+				return shouldSkip(event), nil
+			}),
+		)
+
+		registry := s.Server.JobRegistry().(*jobs.Registry)
+		sli1, err := registry.MetricsStruct().Changefeed.(*Metrics).getSLIMetrics("t1")
+		require.NoError(t, err)
+		laggingRangesTier1 := sli1.LaggingRanges
+		sli2, err := registry.MetricsStruct().Changefeed.(*Metrics).getSLIMetrics("t2")
+		require.NoError(t, err)
+		laggingRangesTier2 := sli2.LaggingRanges
+
+		assertLaggingRanges := func(tier string, expected int64) {
+			testutils.SucceedsWithin(t, func() error {
+				var laggingRangesObserved int64
+				if tier == "t1" {
+					laggingRangesObserved = laggingRangesTier1.Value()
+				} else {
+					laggingRangesObserved = laggingRangesTier2.Value()
+				}
+				if laggingRangesObserved != expected {
+					return fmt.Errorf("expected %d lagging ranges, but found %d", expected, laggingRangesObserved)
+				}
+				return nil
+			}, 10*time.Second)
+		}
+
+		sqlDB.Exec(t, fmt.Sprintf(`
+		  CREATE TABLE foo (key INT PRIMARY KEY);
+		  INSERT INTO foo (key) SELECT * FROM generate_series(1, %d);
+		  ALTER TABLE foo SPLIT AT (SELECT * FROM generate_series(1, %d, 1));
+  		`, numRanges, numRanges-1))
+		sqlDB.CheckQueryResults(t, `SELECT count(*) FROM [SHOW RANGES FROM TABLE foo]`,
+			[][]string{{fmt.Sprint(numRanges)}},
+		)
+
+		const laggingRangesOpts = `lagging_ranges_threshold="250ms", lagging_ranges_polling_interval="25ms"`
+		feed1Tier1 := feed(t, f,
+			fmt.Sprintf(`CREATE CHANGEFEED FOR foo WITH initial_scan='no', metrics_label="t1", %s`, laggingRangesOpts))
+		feed2Tier1 := feed(t, f,
+			fmt.Sprintf(`CREATE CHANGEFEED FOR foo WITH initial_scan='no', metrics_label="t1", %s`, laggingRangesOpts))
+		feed3Tier2 := feed(t, f,
+			fmt.Sprintf(`CREATE CHANGEFEED FOR foo WITH initial_scan='no', metrics_label="t2", %s`, laggingRangesOpts))
+
+		assertLaggingRanges("t1", numRangesToSkip*2)
+		assertLaggingRanges("t2", numRangesToSkip)
+
+		stopSkip.Store(true)
+		assertLaggingRanges("t1", 0)
+		assertLaggingRanges("t2", 0)
+
+		stopSkip.Store(false)
+		assertLaggingRanges("t1", numRangesToSkip*2)
+		assertLaggingRanges("t2", numRangesToSkip)
+
+		require.NoError(t, feed1Tier1.Close())
+		assertLaggingRanges("t1", numRangesToSkip)
+		assertLaggingRanges("t2", numRangesToSkip)
+
+		require.NoError(t, feed2Tier1.Close())
+		assertLaggingRanges("t1", 0)
+		assertLaggingRanges("t2", numRangesToSkip)
+
+		require.NoError(t, feed3Tier2.Close())
+		assertLaggingRanges("t1", 0)
+		assertLaggingRanges("t2", 0)
+	}
+	// Can't run on tenants due to lack of SPLIT AT support (#54254)
+	cdcTest(t, testFn, feedTestNoTenants, feedTestEnterpriseSinks)
 }
 
 func TestChangefeedBackfillObservability(t *testing.T) {

--- a/pkg/ccl/changefeedccl/changefeedbase/settings.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/settings.go
@@ -308,3 +308,11 @@ var SinkPacerRequestSize = settings.RegisterDurationSetting(
 	50*time.Millisecond,
 	settings.PositiveDuration,
 )
+
+// DefaultLaggingRangesThreshold is the default duration by which a range must be
+// lagging behind the present to be considered as 'lagging' behind in metrics.
+var DefaultLaggingRangesThreshold = 3 * time.Minute
+
+// DefaultLaggingRangesPollingInterval is the default polling rate at which
+// lagging ranges are checked and metrics are updated.
+var DefaultLaggingRangesPollingInterval = 1 * time.Minute

--- a/pkg/ccl/changefeedccl/kvfeed/testing_knobs.go
+++ b/pkg/ccl/changefeedccl/kvfeed/testing_knobs.go
@@ -33,6 +33,8 @@ type TestingKnobs struct {
 	// ModifyTimestamps is called on the timestamp for each RangefeedMessage
 	// before converting it into a kv event.
 	ModifyTimestamps func(*hlc.Timestamp)
+	// RangefeedOptions lets the kvfeed override rangefeed settings.
+	RangefeedOptions []kvcoord.RangeFeedOption
 }
 
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.

--- a/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed.go
@@ -89,10 +89,14 @@ func maxConcurrentCatchupScans(sv *settings.Values) int {
 	return int(l)
 }
 
+// ForEachRangeFn is used to execute `fn` over each range in a rangefeed.
+type ForEachRangeFn func(fn ActiveRangeFeedIterFn) error
+
 type rangeFeedConfig struct {
 	useMuxRangeFeed bool
 	overSystemTable bool
 	withDiff        bool
+	rangeObserver   func(ForEachRangeFn)
 
 	knobs struct {
 		// onRangefeedEvent invoked on each rangefeed event.
@@ -136,6 +140,14 @@ func WithSystemTablePriority() RangeFeedOption {
 func WithDiff() RangeFeedOption {
 	return optionFunc(func(c *rangeFeedConfig) {
 		c.withDiff = true
+	})
+}
+
+// WithRangeObserver is called when the rangefeed starts with a function that
+// can be used to iterate over all the ranges.
+func WithRangeObserver(observer func(ForEachRangeFn)) RangeFeedOption {
+	return optionFunc(func(c *rangeFeedConfig) {
+		c.rangeObserver = observer
 	})
 }
 
@@ -211,6 +223,9 @@ func (ds *DistSender) RangeFeedSpans(
 	rr := newRangeFeedRegistry(ctx, cfg.withDiff)
 	ds.activeRangeFeeds.Store(rr, nil)
 	defer ds.activeRangeFeeds.Delete(rr)
+	if cfg.rangeObserver != nil {
+		cfg.rangeObserver(rr.ForEachPartialRangefeed)
+	}
 
 	catchupSem := limit.MakeConcurrentRequestLimiter(
 		"distSenderCatchupLimit", maxConcurrentCatchupScans(&ds.st.SV))
@@ -303,34 +318,42 @@ type PartialRangeFeed struct {
 
 // ActiveRangeFeedIterFn is an iterator function which is passed PartialRangeFeed structure.
 // Iterator function may return an iterutil.StopIteration sentinel error to stop iteration
-// early; any other error is propagated.
+// early.
 type ActiveRangeFeedIterFn func(rfCtx RangeFeedContext, feed PartialRangeFeed) error
 
-// ForEachActiveRangeFeed invokes provided function for each active range feed.
-func (ds *DistSender) ForEachActiveRangeFeed(fn ActiveRangeFeedIterFn) (iterErr error) {
-	const continueIter = true
-	const stopIter = false
+const continueIter = true
+const stopIter = false
 
+// ForEachActiveRangeFeed invokes provided function for each active rangefeed.
+// iterutil.StopIteration can be returned by `fn` to stop iteration, and doing
+// so will not return this error.
+func (ds *DistSender) ForEachActiveRangeFeed(fn ActiveRangeFeedIterFn) (iterErr error) {
+	ds.activeRangeFeeds.Range(func(k, v interface{}) bool {
+		r := k.(*rangeFeedRegistry)
+		iterErr = r.ForEachPartialRangefeed(fn)
+		return iterErr == nil
+	})
+
+	return iterutil.Map(iterErr)
+}
+
+// ForEachPartialRangefeed invokes provided function for each partial rangefeed. Use manageIterationErrs
+// if the fn uses iterutil.StopIteration to stop iteration.
+func (r *rangeFeedRegistry) ForEachPartialRangefeed(fn ActiveRangeFeedIterFn) (iterErr error) {
 	partialRangeFeed := func(active *activeRangeFeed) PartialRangeFeed {
 		active.Lock()
 		defer active.Unlock()
 		return active.PartialRangeFeed
 	}
-
-	ds.activeRangeFeeds.Range(func(k, v interface{}) bool {
-		r := k.(*rangeFeedRegistry)
-		r.ranges.Range(func(k, v interface{}) bool {
-			active := k.(*activeRangeFeed)
-			if err := fn(r.RangeFeedContext, partialRangeFeed(active)); err != nil {
-				iterErr = err
-				return stopIter
-			}
-			return continueIter
-		})
-		return iterErr == nil
+	r.ranges.Range(func(k, v interface{}) bool {
+		active := k.(*activeRangeFeed)
+		if err := fn(r.RangeFeedContext, partialRangeFeed(active)); err != nil {
+			iterErr = err
+			return stopIter
+		}
+		return continueIter
 	})
-
-	return iterutil.Map(iterErr)
+	return iterErr
 }
 
 // activeRangeFeed is a thread safe PartialRangeFeed.
@@ -445,10 +468,10 @@ func newActiveRangeFeed(
 			StartAfter:  startAfter,
 			CreatedTime: timeutil.Now(),
 		},
-		release: func() {
-			rr.ranges.Delete(active)
-			c.Dec(1)
-		},
+	}
+	active.release = func() {
+		rr.ranges.Delete(active)
+		c.Dec(1)
 	}
 	rr.ranges.Store(active, nil)
 	c.Inc(1)

--- a/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed_test.go
@@ -12,7 +12,9 @@ package kvcoord_test
 
 import (
 	"context"
+	"fmt"
 	"math/rand"
+	"reflect"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -802,6 +804,117 @@ func TestRangeFeedMetricsManagement(t *testing.T) {
 
 		// We also know that we have blocked numCatchupToBlock ranges in their catchup scan.
 		require.EqualValues(t, numCatchupToBlock, metrics.RangefeedCatchupRanges.Value())
+	})
+}
+
+// TestRangefeedRangeObserver ensures the kvcoord.WithRangeObserver option
+// works correctly.
+func TestRangefeedRangeObserver(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{})
+	defer tc.Stopper().Stop(ctx)
+
+	ts := tc.Server(0)
+	sqlDB := sqlutils.MakeSQLRunner(tc.ServerConn(0))
+
+	kvserver.RangefeedEnabled.Override(
+		context.Background(), &ts.ClusterSettings().SV, true)
+
+	testutils.RunTrueAndFalse(t, "mux", func(t *testing.T, useMux bool) {
+		sqlDB.ExecMultiple(t,
+			`CREATE TABLE foo (key INT PRIMARY KEY)`,
+			`INSERT INTO foo (key) SELECT * FROM generate_series(1, 4)`,
+			`ALTER TABLE foo SPLIT AT (SELECT * FROM generate_series(1, 4, 1))`,
+		)
+		defer func() {
+			sqlDB.Exec(t, `DROP TABLE foo`)
+		}()
+
+		fooDesc := desctestutils.TestingGetPublicTableDescriptor(
+			ts.DB(), keys.SystemSQLCodec, "defaultdb", "foo")
+		fooSpan := fooDesc.PrimaryIndexSpan(keys.SystemSQLCodec)
+
+		ignoreValues := func(event kvcoord.RangeFeedMessage) {}
+
+		// Set up an observer to continuously poll for the list of ranges
+		// being watched.
+		var observedRangesMu syncutil.Mutex
+		observedRanges := make(map[string]struct{})
+		ctx2, cancel := context.WithCancel(context.Background())
+		g := ctxgroup.WithContext(ctx2)
+		defer func() {
+			cancel()
+			err := g.Wait()
+			// Ensure the observer goroutine terminates gracefully via context cancellation.
+			require.True(t, testutils.IsError(err, "context canceled"))
+		}()
+		observer := func(fn kvcoord.ForEachRangeFn) {
+			g.GoCtx(func(ctx context.Context) error {
+				for {
+					select {
+					case <-ctx.Done():
+						return ctx.Err()
+					case <-time.After(200 * time.Millisecond):
+					}
+					observedRangesMu.Lock()
+					observedRanges = make(map[string]struct{})
+					err := fn(func(rfCtx kvcoord.RangeFeedContext, feed kvcoord.PartialRangeFeed) error {
+						observedRanges[feed.Span.String()] = struct{}{}
+						return nil
+					})
+					observedRangesMu.Unlock()
+					if err != nil {
+						return err
+					}
+				}
+			})
+		}
+
+		closeFeed := rangeFeed(ts.DistSenderI(), fooSpan, ts.Clock().Now(), ignoreValues, useMux,
+			kvcoord.WithRangeObserver(observer))
+		defer closeFeed()
+
+		makeSpan := func(suffix string) string {
+			return fmt.Sprintf("/Table/%d/%s", fooDesc.GetID(), suffix)
+		}
+
+		// The initial set of ranges we expect to observe.
+		expectedRanges := map[string]struct{}{
+			makeSpan("1{-/1}"):  {},
+			makeSpan("1/{1-2}"): {},
+			makeSpan("1/{2-3}"): {},
+			makeSpan("1/{3-4}"): {},
+			makeSpan("{1/4-2}"): {},
+		}
+		checkExpectedRanges := func() {
+			testutils.SucceedsWithin(t, func() error {
+				observedRangesMu.Lock()
+				defer observedRangesMu.Unlock()
+				if !reflect.DeepEqual(observedRanges, expectedRanges) {
+					return errors.Newf("expected ranges %v, but got %v", expectedRanges, observedRanges)
+				}
+				return nil
+			}, 10*time.Second)
+		}
+		checkExpectedRanges()
+
+		// Add another range and ensure we can observe it.
+		sqlDB.ExecMultiple(t,
+			`INSERT INTO FOO VALUES(5)`,
+			`ALTER TABLE foo SPLIT AT VALUES(5)`,
+		)
+		expectedRanges = map[string]struct{}{
+			makeSpan("1{-/1}"):  {},
+			makeSpan("1/{1-2}"): {},
+			makeSpan("1/{2-3}"): {},
+			makeSpan("1/{3-4}"): {},
+			makeSpan("1/{4-5}"): {},
+			makeSpan("{1/5-2}"): {},
+		}
+		checkExpectedRanges()
 	})
 }
 


### PR DESCRIPTION
This change adds the `changefeed.lagging_ranges` metric which can be used to track
ranges which are behind. This metric is calculated based on a new changefeed option
`lagging_ranges_threshold` which is the amount of time that a range
checkpoint needs to be in the past to be considered lagging. This defaults to 3 minutes.
This change also adds the changefeed option `lagging_ranges_polling_interval` which is
the polling rate at which a rangefeed will poll for lagging ranges and update the metric.
This defaults to 1 minute.

Sometimes a range may not have any checkpoints for a while because the start time
may be far in the past (this causes a catchup scan during which no checkpoints are emitted).
In this case, the range is considered to the lagging if the created timestamp of the
rangefeed is older than `changefeed.lagging_ranges_threshold`. Note that this means that
any changefeed which starts with an initial scan containing a significant amount of data will
likely indicate nonzero `changefeed.lagging_ranges` until the initial scan is complete. This
is intentional.

Release note (ops change): A new metric `changefeed.lagging_ranges` is added to show the number of
ranges which are behind in changefeeds. This metric can be used with the `metrics_label` changefeed
option. A changefeed option `lagging_ranges_threshold` is added which is the amount of
time a range needs to be behind to be considered lagging. By default this is 3 minutes. There is also
a new option `lagging_ranges_polling_interval` which controls how often the lagging ranges
calculation is done. This setting defaults to polling every 1 minute. 

Note that polling adds latency to the metric being updated. For example, if a range falls behind
by 3 minutes, the metric may not update until an additional minute afterwards.

Also note that ranges undergoing an initial scan for longer than the threshold are considered to be
lagging. Starting a changefeed with an initial scan on a large table will likely increment the metric
for each range in the table. However, as ranges complete the initial scan, the number of ranges will
decrease.

Epic: None