### PR TITLE
release-23.1: sql: avoid reusing txn ID when logging BEGIN

### DIFF
--- a/pkg/sql/audit_logging.go
+++ b/pkg/sql/audit_logging.go
@@ -13,10 +13,12 @@ package sql
 import (
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/sql/auditlogging"
 	"github.com/cockroachdb/cockroach/pkg/sql/auditlogging/auditevents"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
@@ -52,7 +54,22 @@ func (p *planner) maybeAuditRoleBasedAuditEvent(ctx context.Context, execType ex
 	}
 
 	user := p.User()
-	userRoles, err := p.MemberOfWithAdminOption(ctx, user)
+	userRoles, err := func() (map[username.SQLUsername]bool, error) {
+		if p.Txn() != nil {
+			return p.MemberOfWithAdminOption(ctx, user)
+		} else {
+			// If there is no open transaction, then we need to create an internal
+			// one. This is the case for logging BEGIN statements, since the
+			// transaction is not opened until after BEGIN is logged.
+			var userRoles map[username.SQLUsername]bool
+			innerErr := p.ExecCfg().InternalDB.DescsTxn(ctx, func(ctx context.Context, txn descs.Txn) error {
+				var err error
+				userRoles, err = MemberOfWithAdminOption(ctx, p.ExecCfg(), txn, user)
+				return err
+			})
+			return userRoles, innerErr
+		}
+	}()
 	if err != nil {
 		log.Errorf(ctx, "RoleBasedAuditEvent: error getting user role memberships: %v", err)
 		return

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -3760,6 +3760,7 @@ func (ex *connExecutor) txnStateTransitionsApplyWrapper(
 		ex.extraTxnState.prepStmtsNamespaceAtTxnRewindPos.closeAllPortals(
 			ex.Ctx(), &ex.extraTxnState.prepStmtsNamespaceMemAcc,
 		)
+		ex.resetPlanner(ex.Ctx(), &ex.planner, nil, ex.server.cfg.Clock.PhysicalTime())
 	case txnRestart:
 		// In addition to resetting the extraTxnState, the restart event may
 		// also need to reset the sqlliveness.Session.

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -2177,6 +2177,8 @@ func (ex *connExecutor) beginTransactionTimestampsAndReadMode(
 	err error,
 ) {
 	now := ex.server.cfg.Clock.PhysicalTime()
+	p := &ex.planner
+	ex.resetPlanner(ctx, p, nil, now)
 	var modes tree.TransactionModes
 	if s != nil {
 		modes = s.Modes
@@ -2187,9 +2189,6 @@ func (ex *connExecutor) beginTransactionTimestampsAndReadMode(
 		return rwMode, now, nil, nil
 	}
 	ex.statsCollector.Reset(ex.applicationStats, ex.phaseTimes)
-	p := &ex.planner
-
-	ex.resetPlanner(ctx, p, nil, now)
 	asOf, err := p.EvalAsOfTimestamp(ctx, asOfClause)
 	if err != nil {
 		return 0, time.Time{}, nil, err


### PR DESCRIPTION
Backport 1/1 commits from #109655.

/cc @cockroachdb/release

---

Previously, when logging a BEGIN statement in telemetry logging, it would include the transaction ID of the previous transaction that was executed. Now, we reset the planner whenever a transaction is finished, so BEGIN will be logged with no transaction ID at all. (The transaction is not started until after BEGIN is logged, so we don't have any other ID to log.)

fixes https://github.com/cockroachdb/cockroach/issues/109599
Release justification: bug fix

Release note (bug fix): Fixed a bug where the BEGIN statement would
appear in telemetry logs with the wrong transaction ID. Now, it
will show no transaction ID, since there is no transaction open at the
time that BEGIN is executed.
