### PR TITLE
roachprod: update start-tenant command

### DIFF
--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -421,6 +421,7 @@ func (c *SyncedCluster) Signal(ctx context.Context, l *logger.Logger, sig int) e
 // cmdName and display specify the roachprod subcommand and a status message,
 // for output/logging. If wait is true, the command will wait for the processes
 // to exit, up to maxWait seconds.
+// TODO(herko): This command does not support tenants yet.
 func (c *SyncedCluster) kill(
 	ctx context.Context, l *logger.Logger, cmdName, display string, sig int, wait bool, maxWait int,
 ) error {
@@ -448,8 +449,8 @@ func (c *SyncedCluster) kill(
     done
     echo "${pid}: dead" >> %[1]s/roachprod.log
   done`,
-				c.LogDir(node), // [1]
-				maxWait,        // [2]
+				c.LogDir(node, "", 0), // [1]
+				maxWait,               // [2]
 			)
 		}
 
@@ -467,7 +468,7 @@ if [ -n "${pids}" ]; then
 %[5]s
 fi`,
 			cmdName,                   // [1]
-			c.LogDir(node),            // [2]
+			c.LogDir(node, "", 0),     // [2]
 			c.roachprodEnvRegex(node), // [3]
 			sig,                       // [4]
 			waitCmd,                   // [5]
@@ -1991,6 +1992,7 @@ func (c *SyncedCluster) Put(
 // <user> allows retrieval of logs from a roachprod cluster being run by another
 // user and assumes that the current user used to create c has the ability to
 // sudo into <user>.
+// TODO(herko): This command does not support tenants yet.
 func (c *SyncedCluster) Logs(
 	l *logger.Logger,
 	src, dest, user, filter, programFilter string,
@@ -2011,7 +2013,7 @@ func (c *SyncedCluster) Logs(
 		if c.IsLocal() {
 			// This here is a bit of a hack to guess that the parent of the log dir is
 			// the "home" for the local node and that the srcBase is relative to that.
-			localHome := filepath.Dir(c.LogDir(node))
+			localHome := filepath.Dir(c.LogDir(node, "", 0))
 			remote = filepath.Join(localHome, src) + "/"
 		} else {
 			logDir := src

--- a/pkg/roachprod/multitenant.go
+++ b/pkg/roachprod/multitenant.go
@@ -45,17 +45,6 @@ func StartTenant(
 		return err
 	}
 
-	if tc.Name == hc.Name {
-		// We allow using the same cluster, but the node sets must be disjoint.
-		for _, n1 := range tc.Nodes {
-			for _, n2 := range hc.Nodes {
-				if n1 == n2 {
-					return errors.Errorf("host and tenant nodes must be disjoint")
-				}
-			}
-		}
-	}
-
 	startOpts.Target = install.StartTenantSQL
 	if startOpts.TenantID < 2 {
 		return errors.Errorf("invalid tenant ID %d (must be 2 or higher)", startOpts.TenantID)


### PR DESCRIPTION
The roachprod `start-tenant` command previously only allowed the tenant and host cluster nodes to be disjoint. This is due to the fact that ports and log directories would collide, should a tenant be started on the same node as the host cluster. Changes on this PR and #106497 allow us to remove that requirement now.

Epic: CRDB-18499
Release note: None