### PR TITLE
sql: coherent handling of hidden session vars in info_schema

### DIFF
--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -1716,6 +1716,9 @@ var informationSchemaSessionVariables = virtualSchemaTable{
 	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		for _, vName := range varNames {
 			gen := varGen[vName]
+			if gen.Hidden {
+				continue
+			}
 			value, err := gen.Get(&p.extendedEvalCtx, p.Txn())
 			if err != nil {
 				return err

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -5419,9 +5419,9 @@ serial_normalization                                       rowid
 server_encoding                                            UTF8
 server_version                                             13.0.0
 server_version_num                                         130000
-session_user                                               root
 show_primary_key_constraint_on_not_visible_columns         on
 sql_safe_updates                                           off
+ssl                                                        on
 standard_conforming_strings                                on
 statement_timeout                                          0
 streamer_enabled                                           on

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -5305,7 +5305,6 @@ ORDER BY variable
 ----
 variable                                                   value
 allow_ordinal_column_references                            off
-allow_prepare_as_opt_plan                                  off
 allow_role_memberships_to_change_during_transaction        off
 alter_primary_region_super_region_override                 off
 application_name                                           ·
@@ -5320,7 +5319,6 @@ copy_from_retries_enabled                                  on
 cost_scans_with_default_col_size                           off
 database                                                   test
 datestyle                                                  ISO, MDY
-datestyle_enabled                                          on
 declare_cursor_statement_timeout_enabled                   on
 default_int_size                                           8
 default_table_access_method                                heap
@@ -5333,14 +5331,12 @@ default_transaction_read_only                              off
 default_transaction_use_follower_reads                     off
 default_with_oids                                          off
 descriptor_validation                                      on
-disable_drop_virtual_cluster                               off
 disable_hoist_projection_in_join_limitation                off
 disable_partially_distributed_plans                        off
 disable_plan_gists                                         off
 disallow_full_table_scans                                  off
 enable_auto_rehoming                                       off
 enable_create_stats_using_extremes                         off
-enable_drop_enum_value                                     on
 enable_durable_locking_for_serializable                    off
 enable_experimental_alter_column_type_general              off
 enable_implicit_fk_locking_for_serializable                off
@@ -5356,9 +5352,7 @@ enforce_home_region                                        off
 enforce_home_region_follower_reads_enabled                 off
 escape_string_warning                                      on
 expect_and_ignore_not_visible_columns_in_copy              off
-experimental_computed_column_rewrites                      ·
 experimental_enable_auto_rehoming                          off
-experimental_enable_hash_sharded_indexes                   on
 experimental_enable_implicit_column_partitioning           off
 experimental_enable_temp_tables                            off
 experimental_enable_unique_without_index_constraints       on
@@ -5375,7 +5369,6 @@ inject_retry_errors_enabled                                off
 inject_retry_errors_on_commit_enabled                      off
 integer_datetimes                                          on
 intervalstyle                                              postgres
-intervalstyle_enabled                                      on
 is_superuser                                               on
 join_reader_index_join_strategy_batch_size                 4.0 MiB
 join_reader_no_ordering_strategy_batch_size                2.0 MiB
@@ -5419,23 +5412,18 @@ prefer_lookup_joins_for_fks                                off
 prepared_statements_cache_size                             0 B
 propagate_input_ordering                                   off
 reorder_joins_limit                                        8
-replication                                                off
 require_explicit_primary_keys                              off
 results_buffer_size                                        16384
 role                                                       none
 row_security                                               off
-save_tables_prefix                                         ·
 search_path                                                "$user", public
 serial_normalization                                       rowid
 server_encoding                                            UTF8
 server_version                                             13.0.0
 server_version_num                                         130000
-session_authorization                                      root
 session_user                                               root
 show_primary_key_constraint_on_not_visible_columns         on
 sql_safe_updates                                           off
-ssl                                                        on
-ssl_renegotiation_limit                                    0
 standard_conforming_strings                                on
 statement_timeout                                          0
 streamer_enabled                                           on

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -5352,7 +5352,6 @@ enforce_home_region                                        off
 enforce_home_region_follower_reads_enabled                 off
 escape_string_warning                                      on
 expect_and_ignore_not_visible_columns_in_copy              off
-experimental_enable_auto_rehoming                          off
 experimental_enable_implicit_column_partitioning           off
 experimental_enable_temp_tables                            off
 experimental_enable_unique_without_index_constraints       on
@@ -5360,7 +5359,6 @@ experimental_hash_group_join_enabled                       off
 extra_float_digits                                         1
 force_savepoint_restart                                    off
 foreign_key_cascades_limit                                 10000
-idle_in_session_timeout                                    0
 idle_in_transaction_session_timeout                        0
 idle_session_timeout                                       0
 index_join_streamer_batch_size                             8.0 MiB

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -2748,8 +2748,6 @@ enforce_home_region                                        off                 N
 enforce_home_region_follower_reads_enabled                 off                 NULL      NULL        NULL        string
 escape_string_warning                                      on                  NULL      NULL        NULL        string
 expect_and_ignore_not_visible_columns_in_copy              off                 NULL      NULL        NULL        string
-experimental_distsql_planning                              off                 NULL      NULL        NULL        string
-experimental_enable_auto_rehoming                          off                 NULL      NULL        NULL        string
 experimental_enable_implicit_column_partitioning           off                 NULL      NULL        NULL        string
 experimental_enable_temp_tables                            off                 NULL      NULL        NULL        string
 experimental_enable_unique_without_index_constraints       on                  NULL      NULL        NULL        string
@@ -2757,7 +2755,6 @@ experimental_hash_group_join_enabled                       off                 N
 extra_float_digits                                         1                   NULL      NULL        NULL        string
 force_savepoint_restart                                    off                 NULL      NULL        NULL        string
 foreign_key_cascades_limit                                 10000               NULL      NULL        NULL        string
-idle_in_session_timeout                                    0                   NULL      NULL        NULL        string
 idle_in_transaction_session_timeout                        0                   NULL      NULL        NULL        string
 idle_session_timeout                                       0                   NULL      NULL        NULL        string
 index_join_streamer_batch_size                             8.0 MiB             NULL      NULL        NULL        string
@@ -2912,8 +2909,6 @@ enforce_home_region                                        off                 N
 enforce_home_region_follower_reads_enabled                 off                 NULL  user     NULL      off                 off
 escape_string_warning                                      on                  NULL  user     NULL      on                  on
 expect_and_ignore_not_visible_columns_in_copy              off                 NULL  user     NULL      off                 off
-experimental_distsql_planning                              off                 NULL  user     NULL      off                 off
-experimental_enable_auto_rehoming                          off                 NULL  user     NULL      off                 off
 experimental_enable_implicit_column_partitioning           off                 NULL  user     NULL      off                 off
 experimental_enable_temp_tables                            off                 NULL  user     NULL      off                 off
 experimental_enable_unique_without_index_constraints       on                  NULL  user     NULL      off                 off
@@ -2921,7 +2916,6 @@ experimental_hash_group_join_enabled                       off                 N
 extra_float_digits                                         1                   NULL  user     NULL      1                   2
 force_savepoint_restart                                    off                 NULL  user     NULL      off                 off
 foreign_key_cascades_limit                                 10000               NULL  user     NULL      10000               10000
-idle_in_session_timeout                                    0                   NULL  user     NULL      0s                  0s
 idle_in_transaction_session_timeout                        0                   NULL  user     NULL      0s                  0s
 idle_session_timeout                                       0                   NULL  user     NULL      0s                  0s
 index_join_streamer_batch_size                             8.0 MiB             NULL  user     NULL      8.0 MiB             8.0 MiB
@@ -3073,8 +3067,6 @@ enforce_home_region                                        NULL    NULL     NULL
 enforce_home_region_follower_reads_enabled                 NULL    NULL     NULL     NULL        NULL
 escape_string_warning                                      NULL    NULL     NULL     NULL        NULL
 expect_and_ignore_not_visible_columns_in_copy              NULL    NULL     NULL     NULL        NULL
-experimental_distsql_planning                              NULL    NULL     NULL     NULL        NULL
-experimental_enable_auto_rehoming                          NULL    NULL     NULL     NULL        NULL
 experimental_enable_implicit_column_partitioning           NULL    NULL     NULL     NULL        NULL
 experimental_enable_temp_tables                            NULL    NULL     NULL     NULL        NULL
 experimental_enable_unique_without_index_constraints       NULL    NULL     NULL     NULL        NULL
@@ -3082,7 +3074,6 @@ experimental_hash_group_join_enabled                       NULL    NULL     NULL
 extra_float_digits                                         NULL    NULL     NULL     NULL        NULL
 force_savepoint_restart                                    NULL    NULL     NULL     NULL        NULL
 foreign_key_cascades_limit                                 NULL    NULL     NULL     NULL        NULL
-idle_in_session_timeout                                    NULL    NULL     NULL     NULL        NULL
 idle_in_transaction_session_timeout                        NULL    NULL     NULL     NULL        NULL
 idle_session_timeout                                       NULL    NULL     NULL     NULL        NULL
 index_join_streamer_batch_size                             NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -2814,9 +2814,9 @@ serial_normalization                                       rowid               N
 server_encoding                                            UTF8                NULL      NULL        NULL        string
 server_version                                             13.0.0              NULL      NULL        NULL        string
 server_version_num                                         130000              NULL      NULL        NULL        string
-session_user                                               root                NULL      NULL        NULL        string
 show_primary_key_constraint_on_not_visible_columns         on                  NULL      NULL        NULL        string
 sql_safe_updates                                           off                 NULL      NULL        NULL        string
+ssl                                                        on                  NULL      NULL        NULL        string
 standard_conforming_strings                                on                  NULL      NULL        NULL        string
 statement_timeout                                          0                   NULL      NULL        NULL        string
 streamer_enabled                                           on                  NULL      NULL        NULL        string
@@ -2975,9 +2975,9 @@ serial_normalization                                       rowid               N
 server_encoding                                            UTF8                NULL  user     NULL      UTF8                UTF8
 server_version                                             13.0.0              NULL  user     NULL      13.0.0              13.0.0
 server_version_num                                         130000              NULL  user     NULL      130000              130000
-session_user                                               root                NULL  user     NULL      root                root
 show_primary_key_constraint_on_not_visible_columns         on                  NULL  user     NULL      on                  on
 sql_safe_updates                                           off                 NULL  user     NULL      off                 off
+ssl                                                        on                  NULL  user     NULL      on                  on
 standard_conforming_strings                                on                  NULL  user     NULL      on                  on
 statement_timeout                                          0                   NULL  user     NULL      0s                  0s
 streamer_enabled                                           on                  NULL  user     NULL      on                  on
@@ -3136,9 +3136,9 @@ server_encoding                                            NULL    NULL     NULL
 server_version                                             NULL    NULL     NULL     NULL        NULL
 server_version_num                                         NULL    NULL     NULL     NULL        NULL
 session_id                                                 NULL    NULL     NULL     NULL        NULL
-session_user                                               NULL    NULL     NULL     NULL        NULL
 show_primary_key_constraint_on_not_visible_columns         NULL    NULL     NULL     NULL        NULL
 sql_safe_updates                                           NULL    NULL     NULL     NULL        NULL
+ssl                                                        NULL    NULL     NULL     NULL        NULL
 standard_conforming_strings                                NULL    NULL     NULL     NULL        NULL
 statement_timeout                                          NULL    NULL     NULL     NULL        NULL
 streamer_enabled                                           NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -142,9 +142,9 @@ serial_normalization                                       rowid
 server_encoding                                            UTF8
 server_version                                             13.0.0
 server_version_num                                         130000
-session_user                                               root
 show_primary_key_constraint_on_not_visible_columns         on
 sql_safe_updates                                           off
+ssl                                                        on
 standard_conforming_strings                                on
 statement_timeout                                          0
 streamer_enabled                                           on

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -76,8 +76,6 @@ enforce_home_region                                        off
 enforce_home_region_follower_reads_enabled                 off
 escape_string_warning                                      on
 expect_and_ignore_not_visible_columns_in_copy              off
-experimental_distsql_planning                              off
-experimental_enable_auto_rehoming                          off
 experimental_enable_implicit_column_partitioning           off
 experimental_enable_temp_tables                            off
 experimental_enable_unique_without_index_constraints       off
@@ -85,7 +83,6 @@ experimental_hash_group_join_enabled                       off
 extra_float_digits                                         1
 force_savepoint_restart                                    off
 foreign_key_cascades_limit                                 10000
-idle_in_session_timeout                                    0
 idle_in_transaction_session_timeout                        0
 idle_session_timeout                                       0
 index_join_streamer_batch_size                             8.0 MiB

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -1379,7 +1379,6 @@ var varGen = map[string]sessionVar{
 
 	// See https://www.postgresql.org/docs/9.4/runtime-config-connection.html
 	`ssl`: {
-		Hidden: true,
 		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
 			return formatBoolAsPostgresSetting(evalCtx.SessionData().IsSSL), nil
 		},
@@ -1399,6 +1398,7 @@ var varGen = map[string]sessionVar{
 	// In PG this is a pseudo-function used with SELECT, not SHOW.
 	// See https://www.postgresql.org/docs/10/static/functions-info.html
 	`session_user`: {
+		Hidden: true,
 		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
 			return evalCtx.SessionData().User().Normalized(), nil
 		},

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -587,6 +587,7 @@ var varGen = map[string]sessionVar{
 
 	// CockroachDB extension.
 	`experimental_distsql_planning`: {
+		Hidden:       true,
 		GetStringVal: makePostgresBoolGetStringValFn(`experimental_distsql_planning`),
 		Set: func(_ context.Context, m sessionDataMutator, s string) error {
 			mode, ok := sessiondatapb.ExperimentalDistSQLPlanningModeFromString(s)
@@ -1466,6 +1467,7 @@ var varGen = map[string]sessionVar{
 	},
 
 	`idle_in_session_timeout`: {
+		Hidden:       true, // Superseded by `idle_session_timeout`.
 		GetStringVal: makeTimeoutVarGetter(`idle_in_session_timeout`),
 		Set:          idleInSessionTimeoutVarSet,
 		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
@@ -1767,9 +1769,7 @@ var varGen = map[string]sessionVar{
 
 	// CockroachDB extension.
 	// This is only kept for backwards compatibility and no longer has any effect.
-	`experimental_enable_hash_sharded_indexes`: makeBackwardsCompatBoolVar(
-		"experimental_enable_hash_sharded_indexes", true,
-	),
+	`experimental_enable_hash_sharded_indexes`: makeBackwardsCompatBoolVar("experimental_enable_hash_sharded_indexes", true),
 
 	// CockroachDB extension.
 	`disallow_full_table_scans`: {
@@ -2955,8 +2955,15 @@ func init() {
 
 	// Alias `idle_session_timeout` to match the PG 14 name.
 	// We create `idle_in_session_timeout` before its existence.
-	varGen[`idle_session_timeout`] = varGen[`idle_in_session_timeout`]
-	varGen[`experimental_enable_auto_rehoming`] = varGen[`enable_auto_rehoming`]
+	it := varGen[`idle_in_session_timeout`]
+	it.Hidden = false
+	varGen[`idle_session_timeout`] = it
+
+	// Compatibility with a previous version of CockroachDB.
+	ah := varGen[`enable_auto_rehoming`]
+	ah.Hidden = true
+	varGen[`experimental_enable_auto_rehoming`] = ah
+
 	// Initialize delegate.ValidVars.
 	for v := range varGen {
 		delegate.ValidVars[v] = struct{}{}


### PR DESCRIPTION
Fixes #109870.
Epic: CRDB-28893

Release note (bug fix): Certain SQL session variables are meant
to be hidden from introspection but were showing up in
`information_schema.session_variables`, which was incoherent with the
handling in `pg_catalog.pg_settings`. This bug has now been fixed.