### PR TITLE
roachtest/jepsen: bump jepsen test version

### DIFF
--- a/pkg/cmd/roachtest/tests/jepsen.go
+++ b/pkg/cmd/roachtest/tests/jepsen.go
@@ -81,7 +81,7 @@ const jepsenRepo = "https://github.com/cockroachdb/jepsen"
 const repoBranch = "tc-nightly"
 
 const gcpPath = "https://storage.googleapis.com/cockroach-jepsen"
-const binaryVersion = "0.1.0-782e8c1-standalone"
+const binaryVersion = "0.1.0-cdeef40-standalone"
 
 var jepsenNemeses = []struct {
 	name, config string


### PR DESCRIPTION
This commit bumps the jepsen test binary version to the newest commit cockroachdb/jepsen@cdeef40 in the `tc-nightly-main` branch.

The new version includes cockroachdb/jepsen#37 and cockroachdb/jepsen#38 which make Jepsen honour the "result is ambiguous" errors properly.

Fixes #104602
Fixes #104603
Fixes #104608
Fixes #105436

Epic: none
Release note: none