### PR TITLE
release-23.1: roachprod: azure gc cleans up empty clusters

### DIFF
--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -1175,7 +1175,7 @@ func Destroy(
 		if err != nil {
 			return err
 		}
-		cld, err = cloud.ListCloud(l, vm.ListOptions{})
+		cld, err = cloud.ListCloud(l, vm.ListOptions{IncludeEmptyClusters: true})
 		if err != nil {
 			return err
 		}
@@ -1205,7 +1205,7 @@ func Destroy(
 			}
 			if cld == nil {
 				var err error
-				cld, err = cloud.ListCloud(l, vm.ListOptions{})
+				cld, err = cloud.ListCloud(l, vm.ListOptions{IncludeEmptyClusters: true})
 				if err != nil {
 					return err
 				}
@@ -1223,7 +1223,12 @@ func destroyCluster(cld *cloud.Cloud, l *logger.Logger, clusterName string) erro
 	if !ok {
 		return fmt.Errorf("cluster %s does not exist", clusterName)
 	}
-	l.Printf("Destroying cluster %s with %d nodes", clusterName, len(c.VMs))
+	if c.IsEmptyCluster() {
+		l.Printf("Destroying empty cluster %s with 0 nodes", clusterName)
+	} else {
+		l.Printf("Destroying cluster %s with %d nodes", clusterName, len(c.VMs))
+	}
+
 	return cloud.DestroyCluster(l, c)
 }
 
@@ -1252,7 +1257,7 @@ func (e *ClusterAlreadyExistsError) Error() string {
 }
 
 func cleanupFailedCreate(l *logger.Logger, clusterName string) error {
-	cld, err := cloud.ListCloud(l, vm.ListOptions{})
+	cld, err := cloud.ListCloud(l, vm.ListOptions{IncludeEmptyClusters: true})
 	if err != nil {
 		return err
 	}
@@ -1382,7 +1387,7 @@ func GC(l *logger.Logger, dryrun bool) error {
 	if err := LoadClusters(); err != nil {
 		return err
 	}
-	cld, err := cloud.ListCloud(l, vm.ListOptions{})
+	cld, err := cloud.ListCloud(l, vm.ListOptions{IncludeEmptyClusters: true})
 	if err == nil {
 		// GCClusters depends on ListCloud so only call it if ListCloud runs without errors
 		err = cloud.GCClusters(l, cld, dryrun)

--- a/pkg/roachprod/vm/azure/azure.go
+++ b/pkg/roachprod/vm/azure/azure.go
@@ -452,6 +452,11 @@ func (p *Provider) List(l *logger.Logger, opts vm.ListOptions) (vm.List, error) 
 		return nil, err
 	}
 
+	// Keep track of which clusters we find through listing VMs.
+	// If later we need to list resource groups to find empty clusters,
+	// we want to make sure we don't add anything twice.
+	foundClusters := make(map[string]bool)
+
 	var ret vm.List
 	for it.NotDone() {
 		found := it.Value()
@@ -507,12 +512,87 @@ func (p *Provider) List(l *logger.Logger, opts vm.ListOptions) (vm.List, error) 
 			return nil, err
 		}
 
+		clusterName, _ := m.ClusterName()
+		foundClusters[clusterName] = true
 		ret = append(ret, m)
 
 		if err := it.NextWithContext(ctx); err != nil {
 			return nil, err
 		}
+	}
 
+	// Azure allows for clusters to exist even if the attached VM no longer exists.
+	// Such a cluster won't be found by listing all azure VMs like above.
+	// Normally we don't want to access these clusters except for deleting them.
+	if opts.IncludeEmptyClusters {
+		groupsClient := resources.NewGroupsClient(*sub.SubscriptionID)
+		if groupsClient.Authorizer, err = p.getAuthorizer(); err != nil {
+			return nil, err
+		}
+
+		// List all resource groups for clusters under the subscription.
+		filter := fmt.Sprintf("tagName eq '%s'", vm.TagCluster)
+		it, err := groupsClient.ListComplete(ctx, filter, nil /* limit */)
+		if err != nil {
+			return nil, err
+		}
+
+		for it.NotDone() {
+			resourceGroup := it.Value()
+			if _, ok := resourceGroup.Tags[vm.TagRoachprod]; !ok {
+				if err := it.NextWithContext(ctx); err != nil {
+					return nil, err
+				}
+				continue
+			}
+
+			// Resource Groups have the name format "user-<clusterid>-<region>",
+			// while clusters have the name format "user-<clusterid>".
+			parts := strings.Split(*resourceGroup.Name, "-")
+			clusterName := strings.Join(parts[:len(parts)-1], "-")
+			if foundClusters[clusterName] {
+				if err := it.NextWithContext(ctx); err != nil {
+					return nil, err
+				}
+				continue
+			}
+
+			// The cluster does not have a VM, but roachprod assumes that this is not
+			// possible and implements providers on the VM level. A VM-less cluster will
+			// not have access to provider info or methods. To still allow this cluster to
+			// be deleted, we must create a fake VM, indicated by EmptyCluster.
+			m := vm.VM{
+				Name:       *resourceGroup.Name,
+				Provider:   ProviderName,
+				RemoteUser: remoteUser,
+				VPC:        "global",
+				// We add a fake availability-zone suffix since other roachprod
+				// code assumes particular formats. For example, "eastus2z".
+				Zone:         *resourceGroup.Location + "z",
+				EmptyCluster: true,
+			}
+
+			// We ignore any parsing errors here as roachprod tries to destroy "bad VMs".
+			// We don't want that since this is a fake VM, we need to destroy the resource
+			// group instead. This will be done by GC when it sees that no m.CreatedAt exists.
+			createdPtr := resourceGroup.Tags[vm.TagCreated]
+			if createdPtr != nil {
+				parsed, _ := time.Parse(time.RFC3339, *createdPtr)
+				m.CreatedAt = parsed
+			}
+
+			lifetimePtr := resourceGroup.Tags[vm.TagLifetime]
+			if lifetimePtr != nil {
+				parsed, _ := time.ParseDuration(*lifetimePtr)
+				m.Lifetime = parsed
+			}
+
+			ret = append(ret, m)
+
+			if err := it.NextWithContext(ctx); err != nil {
+				return nil, err
+			}
+		}
 	}
 
 	return ret, nil

--- a/pkg/roachprod/vm/vm.go
+++ b/pkg/roachprod/vm/vm.go
@@ -109,6 +109,11 @@ type VM struct {
 
 	// NonBootAttachedVolumes are the non-bootable volumes attached to the VM.
 	NonBootAttachedVolumes []Volume `json:"non_bootable_volumes"`
+
+	// EmptyCluster indicates that the VM does not exist. Azure allows for empty
+	// clusters, but roachprod does not allow VM-less clusters except when deleting them.
+	// A fake VM will be used in this scenario.
+	EmptyCluster bool
 }
 
 // Name generates the name for the i'th node in a cluster.
@@ -290,7 +295,8 @@ type VolumeCreateOpts struct {
 }
 
 type ListOptions struct {
-	IncludeVolumes bool
+	IncludeVolumes       bool
+	IncludeEmptyClusters bool
 }
 
 // A Provider is a source of virtual machines running on some hosting platform.


### PR DESCRIPTION
Backport 1/1 commits from #109438.

/cc @cockroachdb/release

---

Azure allows for clusters to exist with no attached VM, which roachprod assumes is not possible. This would occur if azure.create failed after creating a resource group but before creating a VM. Roachprod GC only searches for VMs when searching for clusters, so these VM-less clusters would never be found and cleaned up.

This change adds the ability to list empty clusters by querying resource groups instead of VMs. This is used by GC and destroy jobs to correctly identify and cleanup these dangling resources.

Epic: https://cockroachlabs.atlassian.net/browse/CRDB-3373
Release note: None

---

Release justification:  infra change