### PR TITLE
release-23.1: roachprod: add multiple instance support

### DIFF
--- a/pkg/cmd/roachprod/flags.go
+++ b/pkg/cmd/roachprod/flags.go
@@ -48,6 +48,7 @@ var (
 	listPattern           string
 	secure                = false
 	tenantName            string
+	tenantInstance        int
 	extraSSHOptions       = ""
 	nodeEnv               []string
 	tag                   string
@@ -210,6 +211,8 @@ Default is "RECURRING '*/15 * * * *' FULL BACKUP '@hourly' WITH SCHEDULE OPTIONS
 	_ = startTenantCmd.MarkFlagRequired("host-cluster")
 	startTenantCmd.Flags().IntVarP(&startOpts.TenantID,
 		"tenant-id", "t", startOpts.TenantID, "tenant ID")
+	startTenantCmd.Flags().IntVar(&startOpts.TenantInstance,
+		"tenant-instance", 0, "specific tenant instance to connect to")
 
 	stopCmd.Flags().IntVar(&sig, "sig", sig, "signal to pass to kill")
 	stopCmd.Flags().BoolVar(&waitFlag, "wait", waitFlag, "wait for processes to exit")
@@ -345,6 +348,8 @@ Default is "RECURRING '*/15 * * * *' FULL BACKUP '@hourly' WITH SCHEDULE OPTIONS
 	for _, cmd := range []*cobra.Command{pgurlCmd, sqlCmd, adminurlCmd} {
 		cmd.Flags().StringVar(&tenantName,
 			"tenant-name", "", "specific tenant to connect to")
+		cmd.Flags().IntVar(&tenantInstance,
+			"tenant-instance", 0, "specific tenant instance to connect to")
 	}
 
 }

--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -807,7 +807,7 @@ var sqlCmd = &cobra.Command{
 	Long:  "Run `cockroach sql` on a remote cluster.\n",
 	Args:  cobra.MinimumNArgs(1),
 	Run: wrap(func(cmd *cobra.Command, args []string) error {
-		return roachprod.SQL(context.Background(), config.Logger, args[0], secure, tenantName, args[1:])
+		return roachprod.SQL(context.Background(), config.Logger, args[0], secure, tenantName, tenantInstance, args[1:])
 	}),
 }
 
@@ -819,9 +819,10 @@ var pgurlCmd = &cobra.Command{
 	Args: cobra.ExactArgs(1),
 	Run: wrap(func(cmd *cobra.Command, args []string) error {
 		urls, err := roachprod.PgURL(context.Background(), config.Logger, args[0], pgurlCertsDir, roachprod.PGURLOptions{
-			External:   external,
-			Secure:     secure,
-			TenantName: tenantName,
+			External:       external,
+			Secure:         secure,
+			TenantName:     tenantName,
+			TenantInstance: tenantInstance,
 		})
 		if err != nil {
 			return err
@@ -865,7 +866,9 @@ var adminurlCmd = &cobra.Command{
 `,
 	Args: cobra.ExactArgs(1),
 	Run: wrap(func(cmd *cobra.Command, args []string) error {
-		urls, err := roachprod.AdminURL(config.Logger, args[0], tenantName, adminurlPath, adminurlIPs, adminurlOpen, secure)
+		urls, err := roachprod.AdminURL(
+			config.Logger, args[0], tenantName, tenantInstance, adminurlPath, adminurlIPs, adminurlOpen, secure,
+		)
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -2359,7 +2359,7 @@ func (c *clusterImpl) adminUIAddr(
 	l *logger.Logger, node option.NodeListOption, external bool,
 ) ([]string, error) {
 	var addrs []string
-	adminURLs, err := roachprod.AdminURL(l, c.MakeNodes(node), "", "",
+	adminURLs, err := roachprod.AdminURL(l, c.MakeNodes(node), "", 0, "",
 		external, false, false)
 	if err != nil {
 		return nil, err

--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -2335,7 +2335,7 @@ func (c *SyncedCluster) Get(
 
 // pgurls returns a map of PG URLs for the given nodes.
 func (c *SyncedCluster) pgurls(
-	ctx context.Context, l *logger.Logger, nodes Nodes, tenantName string,
+	ctx context.Context, l *logger.Logger, nodes Nodes, tenantName string, tenantInstance int,
 ) (map[Node]string, error) {
 	hosts, err := c.pghosts(ctx, l, nodes)
 	if err != nil {
@@ -2343,7 +2343,7 @@ func (c *SyncedCluster) pgurls(
 	}
 	m := make(map[Node]string, len(hosts))
 	for node, host := range hosts {
-		desc, err := c.DiscoverService(node, tenantName, ServiceTypeSQL)
+		desc, err := c.DiscoverService(node, tenantName, ServiceTypeSQL, tenantInstance)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/roachprod/install/expander.go
+++ b/pkg/roachprod/install/expander.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
@@ -21,9 +22,9 @@ import (
 )
 
 var parameterRe = regexp.MustCompile(`{[^{}]*}`)
-var pgURLRe = regexp.MustCompile(`{pgurl(:[-,0-9]+)?(:[a-z0-9\-]+)?}`)
+var pgURLRe = regexp.MustCompile(`{pgurl(:[-,0-9]+)?(:[a-z0-9\-]+)?(:[0-9]+)?}`)
 var pgHostRe = regexp.MustCompile(`{pghost(:[-,0-9]+)?}`)
-var pgPortRe = regexp.MustCompile(`{pgport(:[-,0-9]+)?(:[a-z0-9\-]+)?}`)
+var pgPortRe = regexp.MustCompile(`{pgport(:[-,0-9]+)?(:[a-z0-9\-]+)?(:[0-9]+)?}`)
 var uiPortRe = regexp.MustCompile(`{uiport(:[-,0-9]+)}`)
 var storeDirRe = regexp.MustCompile(`{store-dir}`)
 var logDirRe = regexp.MustCompile(`{log-dir}`)
@@ -109,10 +110,41 @@ func (e *expander) maybeExpandMap(
 	return strings.Join(result, " "), nil
 }
 
+// extractTenantInfo extracts the tenant name and tenant instance from the given
+// tenant group match, if available. If no tenant information is provided, the
+// system tenant is assumed and if no tenant instance is provided, the first
+// instance is assumed.
+func extractTenantInfo(matches []string) (string, int, error) {
+	// Defaults if the passed in tenant group match is empty.
+	tenantName := SystemTenantName
+	tenantInstance := 0
+
+	// Extract the tenant name and instance matches.
+	trim := func(s string) string {
+		// Trim off the leading ':' in the capture group.
+		return s[1:]
+	}
+	tenantNameMatch := matches[0]
+	tenantInstanceMatch := matches[1]
+
+	if tenantNameMatch != "" {
+		tenantName = trim(tenantNameMatch)
+	}
+	if tenantInstanceMatch != "" {
+		var err error
+		tenantInstance, err = strconv.Atoi(trim(tenantInstanceMatch))
+		if err != nil {
+			return "", 0, err
+		}
+	}
+	return tenantName, tenantInstance, nil
+}
+
 // maybeExpandPgURL is an expanderFunc for {pgurl:<nodeSpec>}
 func (e *expander) maybeExpandPgURL(
 	ctx context.Context, l *logger.Logger, c *SyncedCluster, s string,
 ) (string, bool, error) {
+	var err error
 	m := pgURLRe.FindStringSubmatch(s)
 	if m == nil {
 		return s, false, nil
@@ -121,20 +153,17 @@ func (e *expander) maybeExpandPgURL(
 	if e.pgURLs == nil {
 		e.pgURLs = make(map[string]map[Node]string)
 	}
-	tenant := SystemTenantName
-	if m[2] != "" {
-		// Trim off the leading ':' in the capture group.
-		tenant = m[2][1:]
+	tenantName, tenantInstance, err := extractTenantInfo(m[2:])
+	if err != nil {
+		return "", false, err
 	}
-	if e.pgURLs[tenant] == nil {
-		var err error
-		e.pgURLs[tenant], err = c.pgurls(ctx, l, allNodes(len(c.VMs)), tenant)
+	if e.pgURLs[tenantName] == nil {
+		e.pgURLs[tenantName], err = c.pgurls(ctx, l, allNodes(len(c.VMs)), tenantName, tenantInstance)
 		if err != nil {
 			return "", false, err
 		}
 	}
-
-	s, err := e.maybeExpandMap(c, e.pgURLs[tenant], m[1])
+	s, err = e.maybeExpandMap(c, e.pgURLs[tenantName], m[1])
 	return s, err == nil, err
 }
 
@@ -167,16 +196,15 @@ func (e *expander) maybeExpandPgPort(
 	if m == nil {
 		return s, false, nil
 	}
-	tenant := SystemTenantName
-	if m[2] != "" {
-		// Trim off the leading ':' in the capture group.
-		tenant = m[2][1:]
+	tenantName, tenantInstance, err := extractTenantInfo(m[2:])
+	if err != nil {
+		return "", false, err
 	}
 
 	if e.pgPorts == nil {
 		e.pgPorts = make(map[Node]string, len(c.VMs))
 		for _, node := range allNodes(len(c.VMs)) {
-			desc, err := c.DiscoverService(node, tenant, ServiceTypeSQL)
+			desc, err := c.DiscoverService(node, tenantName, ServiceTypeSQL, tenantInstance)
 			if err != nil {
 				return s, false, err
 			}
@@ -184,7 +212,7 @@ func (e *expander) maybeExpandPgPort(
 		}
 	}
 
-	s, err := e.maybeExpandMap(c, e.pgPorts, m[1])
+	s, err = e.maybeExpandMap(c, e.pgPorts, m[1])
 	return s, err == nil, err
 }
 

--- a/pkg/roachprod/install/services_test.go
+++ b/pkg/roachprod/install/services_test.go
@@ -68,7 +68,7 @@ func TestServicePorts(t *testing.T) {
 		Nodes: allNodes(2),
 	}
 
-	descriptors, err := c.DiscoverServices(c.Nodes, "t1", ServiceTypeSQL)
+	descriptors, err := c.DiscoverServices("t1", ServiceTypeSQL, ServiceNodePredicate(c.Nodes...))
 	sort.Slice(descriptors, func(i, j int) bool {
 		return descriptors[i].Port < descriptors[j].Port
 	})

--- a/pkg/roachprod/multitenant.go
+++ b/pkg/roachprod/multitenant.go
@@ -65,7 +65,7 @@ func StartTenant(
 
 	// Create tenant, if necessary. We need to run this SQL against a single host.
 	l.Printf("Creating tenant metadata")
-	if err := hc.ExecSQL(ctx, l, hc.Nodes[:1], "", []string{
+	if err := hc.ExecSQL(ctx, l, hc.Nodes[:1], "", 0, []string{
 		`-e`,
 		fmt.Sprintf(createTenantIfNotExistsQuery, startOpts.TenantID),
 	}); err != nil {

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -417,6 +417,7 @@ func SQL(
 	clusterName string,
 	secure bool,
 	tenantName string,
+	tenantInstance int,
 	cmdArray []string,
 ) error {
 	if err := LoadClusters(); err != nil {
@@ -427,9 +428,9 @@ func SQL(
 		return err
 	}
 	if len(c.Nodes) == 1 {
-		return c.ExecOrInteractiveSQL(ctx, l, tenantName, cmdArray)
+		return c.ExecOrInteractiveSQL(ctx, l, tenantName, tenantInstance, cmdArray)
 	}
-	return c.ExecSQL(ctx, l, c.Nodes, tenantName, cmdArray)
+	return c.ExecSQL(ctx, l, c.Nodes, tenantName, tenantInstance, cmdArray)
 }
 
 // IP gets the ip addresses of the nodes in a cluster.
@@ -889,9 +890,10 @@ func Get(ctx context.Context, l *logger.Logger, clusterName, src, dest string) e
 }
 
 type PGURLOptions struct {
-	Secure     bool
-	External   bool
-	TenantName string
+	Secure         bool
+	External       bool
+	TenantName     string
+	TenantInstance int
 }
 
 // PgURL generates pgurls for the nodes in a cluster.
@@ -923,7 +925,7 @@ func PgURL(
 
 	var urls []string
 	for i, ip := range ips {
-		desc, err := c.DiscoverService(nodes[i], opts.TenantName, install.ServiceTypeSQL)
+		desc, err := c.DiscoverService(nodes[i], opts.TenantName, install.ServiceTypeSQL, opts.TenantInstance)
 		if err != nil {
 			return nil, err
 		}
@@ -939,12 +941,13 @@ func PgURL(
 }
 
 type urlConfig struct {
-	path          string
-	usePublicIP   bool
-	openInBrowser bool
-	secure        bool
-	port          int
-	tenantName    string
+	path           string
+	usePublicIP    bool
+	openInBrowser  bool
+	secure         bool
+	port           int
+	tenantName     string
+	tenantInstance int
 }
 
 func urlGenerator(
@@ -967,7 +970,7 @@ func urlGenerator(
 		}
 		port := uConfig.port
 		if port == 0 {
-			desc, err := c.DiscoverService(node, uConfig.tenantName, install.ServiceTypeUI)
+			desc, err := c.DiscoverService(node, uConfig.tenantName, install.ServiceTypeUI, uConfig.tenantInstance)
 			if err != nil {
 				return nil, err
 			}
@@ -995,7 +998,11 @@ func urlGenerator(
 
 // AdminURL generates admin UI URLs for the nodes in a cluster.
 func AdminURL(
-	l *logger.Logger, clusterName, tenantName, path string, usePublicIP, openInBrowser, secure bool,
+	l *logger.Logger,
+	clusterName, tenantName string,
+	tenantInstance int,
+	path string,
+	usePublicIP, openInBrowser, secure bool,
 ) ([]string, error) {
 	if err := LoadClusters(); err != nil {
 		return nil, err
@@ -1005,11 +1012,12 @@ func AdminURL(
 		return nil, err
 	}
 	uConfig := urlConfig{
-		path:          path,
-		usePublicIP:   usePublicIP,
-		openInBrowser: openInBrowser,
-		secure:        secure,
-		tenantName:    tenantName,
+		path:           path,
+		usePublicIP:    usePublicIP,
+		openInBrowser:  openInBrowser,
+		secure:         secure,
+		tenantName:     tenantName,
+		tenantInstance: tenantInstance,
 	}
 	return urlGenerator(c, l, c.TargetNodes(), uConfig)
 }


### PR DESCRIPTION
Backport 1/1 commits from #109437.

/cc @cockroachdb/release

---

This change adds instance support to services to enable starting more than one instance for the same tenant on the same VM. The instance is stored in the `weight` field of the service records. This allows for an easy way to uniquely identify multiple instances.

Epic: CRDB-18499
Release note: None
Release justification: Test only change
