### PR TITLE
roachtest: update version of nodejs used by ORM tests

### DIFF
--- a/pkg/cmd/roachtest/tests/knex.go
+++ b/pkg/cmd/roachtest/tests/knex.go
@@ -63,7 +63,7 @@ func registerKnex(r registry.Registry) {
 			c,
 			node,
 			"add nodesource repository",
-			`sudo apt install ca-certificates && curl -fsSL https://deb.nodesource.com/setup_16.x | sudo -E bash -`,
+			`sudo apt install ca-certificates && curl -fsSL https://deb.nodesource.com/setup_18.x | sudo -E bash -`,
 		)
 		require.NoError(t, err)
 

--- a/pkg/cmd/roachtest/tests/nodejs_postgres.go
+++ b/pkg/cmd/roachtest/tests/nodejs_postgres.go
@@ -73,7 +73,7 @@ func registerNodeJSPostgres(r registry.Registry) {
 			c,
 			node,
 			"add nodesource repository",
-			`sudo apt install ca-certificates && curl -sL https://deb.nodesource.com/setup_16.x | sudo -E bash -`,
+			`sudo apt install ca-certificates && curl -sL https://deb.nodesource.com/setup_18.x | sudo -E bash -`,
 		)
 		require.NoError(t, err)
 

--- a/pkg/cmd/roachtest/tests/sequelize.go
+++ b/pkg/cmd/roachtest/tests/sequelize.go
@@ -96,7 +96,7 @@ func registerSequelize(r registry.Registry) {
 			c,
 			node,
 			"add nodesource repository",
-			`sudo apt install ca-certificates && curl -sL https://deb.nodesource.com/setup_16.x | sudo -E bash -`,
+			`sudo apt install ca-certificates && curl -sL https://deb.nodesource.com/setup_18.x | sudo -E bash -`,
 		); err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/cmd/roachtest/tests/sqlalchemy.go
+++ b/pkg/cmd/roachtest/tests/sqlalchemy.go
@@ -30,7 +30,7 @@ import (
 var sqlAlchemyResultRegex = regexp.MustCompile(`^(?P<test>test.*::.*::[^ \[\]]*(?:\[.*])?) (?P<result>\w+)\s+\[.+]$`)
 var sqlAlchemyReleaseTagRegex = regexp.MustCompile(`^rel_(?P<major>\d+)_(?P<minor>\d+)_(?P<point>\d+)$`)
 
-var supportedSQLAlchemyTag = "2.0.2"
+var supportedSQLAlchemyTag = "2.0.20"
 
 // This test runs the SQLAlchemy dialect test suite against a single Cockroach
 // node.

--- a/pkg/cmd/roachtest/tests/typeorm.go
+++ b/pkg/cmd/roachtest/tests/typeorm.go
@@ -90,7 +90,7 @@ func registerTypeORM(r registry.Registry) {
 			c,
 			node,
 			"add nodesource repository",
-			`sudo apt install ca-certificates && curl -fsSL https://deb.nodesource.com/setup_16.x | sudo -E bash -`,
+			`sudo apt install ca-certificates && curl -fsSL https://deb.nodesource.com/setup_18.x | sudo -E bash -`,
 		); err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
Node 16 no longer is supported, so installation of it fails. Now we update to a supported version.

fixes https://github.com/cockroachdb/cockroach/issues/109890
fixes https://github.com/cockroachdb/cockroach/issues/109884
fixes https://github.com/cockroachdb/cockroach/issues/109882
fixes https://github.com/cockroachdb/cockroach/issues/109880
fixes https://github.com/cockroachdb/cockroach/issues/109878
fixes https://github.com/cockroachdb/cockroach/issues/109877
fixes https://github.com/cockroachdb/cockroach/issues/109874
fixes https://github.com/cockroachdb/cockroach/issues/109895
fixes https://github.com/cockroachdb/cockroach/issues/109888
fixes https://github.com/cockroachdb/cockroach/issues/109831
fixes https://github.com/cockroachdb/cockroach/issues/109916
fixes https://github.com/cockroachdb/cockroach/issues/109914
fixes https://github.com/cockroachdb/cockroach/issues/109913
fixes https://github.com/cockroachdb/cockroach/issues/109912
fixes https://github.com/cockroachdb/cockroach/issues/109909

Release note: None