### PR TITLE
requestbatcher,intentresolver: default to no inflight backpressure

### DIFF
--- a/pkg/kv/kvserver/intentresolver/BUILD.bazel
+++ b/pkg/kv/kvserver/intentresolver/BUILD.bazel
@@ -18,6 +18,8 @@ go_library(
         "//pkg/kv/kvserver/kvserverbase",
         "//pkg/kv/kvserver/txnwait",
         "//pkg/roachpb",
+        "//pkg/settings",
+        "//pkg/settings/cluster",
         "//pkg/storage/enginepb",
         "//pkg/util/hlc",
         "//pkg/util/log",

--- a/pkg/kv/kvserver/intentresolver/intent_resolver_integration_test.go
+++ b/pkg/kv/kvserver/intentresolver/intent_resolver_integration_test.go
@@ -363,6 +363,14 @@ func forceScanOnAllReplicationQueues(tc *testcluster.TestCluster) (err error) {
 // the intent for t1 and intent resolution is clogged up on the store
 // containing t1, unless the intent resolution for the "unavailable" t2 times
 // out.
+//
+// TODO(sumeer): this test clogs up batched intent resolution via an inflight
+// backpressure limit, which by default in no longer limited. But an inflight
+// backpressure limit does exist for GC of txn records. This test should
+// continue to exist until we have production experience with no inflight
+// backpressure for intent resolution. And after that we should create an
+// equivalent test for inflight backpressure for GC of txn records and remove
+// this test.
 func TestIntentResolutionUnavailableRange(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)

--- a/pkg/kv/kvserver/intentresolver/intent_resolver_test.go
+++ b/pkg/kv/kvserver/intentresolver/intent_resolver_test.go
@@ -762,6 +762,14 @@ func TestCleanupIntents(t *testing.T) {
 // TestIntentResolutionTimeout tests that running intent resolution with an
 // unavailable range eventually times out and finishes, and does not block
 // intent resolution on another available range.
+//
+// TODO(sumeer): this test clogs up batched intent resolution via an inflight
+// backpressure limit, which by default in no longer limited. But an inflight
+// backpressure limit does exist for GC of txn records. This test should
+// continue to exist until we have production experience with no inflight
+// backpressure for intent resolution. And after that we should create an
+// equivalent test for inflight backpressure for GC of txn records and remove
+// this test.
 func TestIntentResolutionTimeout(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 

--- a/pkg/kv/kvserver/replica_read.go
+++ b/pkg/kv/kvserver/replica_read.go
@@ -186,11 +186,15 @@ func (r *Replica) executeReadOnlyBatch(
 		g = nil
 	}
 
-	// Semi-synchronously process any intents that need resolving here in
-	// order to apply back pressure on the client which generated them. The
-	// resolution is semi-synchronous in that there is a limited number of
-	// outstanding asynchronous resolution tasks allowed after which
-	// further calls will block.
+	// Semi-synchronously process any intents that need resolving here in order
+	// to apply back pressure on the client which generated them. The resolution
+	// is semi-synchronous in that there is a limited number of outstanding
+	// asynchronous resolution tasks allowed after which further calls will
+	// block. The limited number of asynchronous resolution tasks ensures that
+	// the number of goroutines doing intent resolution does not diverge from
+	// the number of workload goroutines (see
+	// https://github.com/cockroachdb/cockroach/issues/4925#issuecomment-193015586
+	// for an old problem predating such a limit).
 	if len(intents) > 0 {
 		log.Eventf(ctx, "submitting %d intents to asynchronous processing", len(intents))
 		// We only allow synchronous intent resolution for consistent requests.

--- a/pkg/kv/kvserver/replica_write.go
+++ b/pkg/kv/kvserver/replica_write.go
@@ -207,8 +207,12 @@ func (r *Replica) executeWriteBatch(
 			// Semi-synchronously process any intents that need resolving here in
 			// order to apply back pressure on the client which generated them. The
 			// resolution is semi-synchronous in that there is a limited number of
-			// outstanding asynchronous resolution tasks allowed after which
-			// further calls will block.
+			// outstanding asynchronous resolution tasks allowed after which further
+			// calls will block. The limited number of asynchronous resolution tasks
+			// ensures that the number of goroutines doing intent resolution does
+			// not diverge from the number of workload goroutines (see
+			// https://github.com/cockroachdb/cockroach/issues/4925#issuecomment-193015586
+			// for an old problem predating such a limit).
 			if len(propResult.EndTxns) > 0 {
 				if err := r.store.intentResolver.CleanupTxnIntentsAsync(
 					ctx, r.RangeID, propResult.EndTxns, true, /* allowSync */

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -2000,6 +2000,7 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 		Clock:                s.cfg.Clock,
 		DB:                   s.db,
 		Stopper:              stopper,
+		Settings:             s.cfg.Settings,
 		TaskLimit:            s.cfg.IntentResolverTaskLimit,
 		AmbientCtx:           s.cfg.AmbientCtx,
 		TestingKnobs:         s.cfg.TestingKnobs.IntentResolverKnobs,


### PR DESCRIPTION
For point and ranged intent resolution, the concurrency is already controlled by the number of goroutines that are waiting to resolve intents. The one exception is when there are a huge number of point intents being resolved by a single waiter (which should be very rare since if those intents are from a single txn, they should be ranged intents), but in that case we have already paid the memory cost of buffering these intents, so we may as well send the intent resolution RPCs.

In case we have overlooked something, inflight backpressure can be restored via a cluster setting.

This change is a prerequisite simplification for doing admission control on intent resolution. We don't want an inflight RPC limit to be reached due to admission control being active on a node/store, starving out intent resolution requests for other stores. There is also the async task limit of IntentResolver.sem, but many cases that hit that limit fallback to synchronous waiting (allowSyncProcessing=true), so that limit is not considered harmful.

Informs #97108

Epic: CRDB-25458

Release note (ops change): A cluster setting is introduced (kv.intent_resolver.batcher.in_flight_backpressure_limit.enabled), that defaults to false, and decides whether an in-flight RPC limit is enforced on intent resolution RPCs.