### PR TITLE
rpc: properly delay config initialization until server instantiation

### DIFF
--- a/pkg/blobs/client_test.go
+++ b/pkg/blobs/client_test.go
@@ -55,7 +55,8 @@ func setUpService(
 	localExternalDir string,
 	remoteExternalDir string,
 ) BlobClientFactory {
-	s, err := rpc.NewServer(rpcContext)
+	ctx := context.Background()
+	s, err := rpc.NewServer(ctx, rpcContext)
 	require.NoError(t, err)
 
 	remoteBlobServer, err := NewBlobService(remoteExternalDir)
@@ -65,7 +66,7 @@ func setUpService(
 	ln, err := netutil.ListenAndServeGRPC(rpcContext.Stopper, s, util.TestAddr)
 	require.NoError(t, err)
 
-	s2, err := rpc.NewServer(rpcContext)
+	s2, err := rpc.NewServer(ctx, rpcContext)
 	require.NoError(t, err)
 	localBlobServer, err := NewBlobService(localExternalDir)
 	require.NoError(t, err)

--- a/pkg/cli/connect_join.go
+++ b/pkg/cli/connect_join.go
@@ -44,7 +44,7 @@ var connectJoinCmd = &cobra.Command{
 func requestPeerCA(
 	ctx context.Context, stopper *stop.Stopper, peer string, jt security.JoinToken,
 ) (*x509.CertPool, error) {
-	dialOpts := rpc.GetAddJoinDialOptions(nil)
+	dialOpts := rpc.GetAddJoinDialOptions(ctx, nil)
 
 	conn, err := grpc.DialContext(ctx, peer, dialOpts...)
 	if err != nil {
@@ -89,7 +89,7 @@ func requestCertBundle(
 	certPool *x509.CertPool,
 	jt security.JoinToken,
 ) (*server.CertificateBundle, error) {
-	dialOpts := rpc.GetAddJoinDialOptions(certPool)
+	dialOpts := rpc.GetAddJoinDialOptions(ctx, certPool)
 
 	conn, err := grpc.DialContext(ctx, peerAddr, dialOpts...)
 	if err != nil {

--- a/pkg/gossip/client_test.go
+++ b/pkg/gossip/client_test.go
@@ -59,7 +59,7 @@ func startGossipAtAddr(
 	rpcContext := rpc.NewInsecureTestingContextWithClusterID(ctx, clock, stopper, clusterID)
 	rpcContext.NodeID.Set(ctx, nodeID)
 
-	server, err := rpc.NewServer(rpcContext)
+	server, err := rpc.NewServer(ctx, rpcContext)
 	require.NoError(t, err)
 	g := NewTest(nodeID, stopper, registry, zonepb.DefaultZoneConfigRef())
 	RegisterGossipServer(server, g)
@@ -119,7 +119,7 @@ func startFakeServerGossips(
 	clock := hlc.NewClockForTesting(nil)
 	lRPCContext := rpc.NewInsecureTestingContextWithClusterID(ctx, clock, stopper, clusterID)
 
-	lserver, err := rpc.NewServer(lRPCContext)
+	lserver, err := rpc.NewServer(ctx, lRPCContext)
 	require.NoError(t, err)
 	local := NewTest(localNodeID, stopper, metric.NewRegistry(), zonepb.DefaultZoneConfigRef())
 	RegisterGossipServer(lserver, local)
@@ -128,7 +128,7 @@ func startFakeServerGossips(
 	local.start(lln.Addr())
 
 	rRPCContext := rpc.NewInsecureTestingContextWithClusterID(ctx, clock, stopper, clusterID)
-	rserver, err := rpc.NewServer(rRPCContext)
+	rserver, err := rpc.NewServer(ctx, rRPCContext)
 	require.NoError(t, err)
 	remote := newFakeGossipServer(rserver, stopper)
 	rln, err := netutil.ListenAndServeGRPC(stopper, rserver, util.IsolatedTestAddr)
@@ -476,7 +476,7 @@ func TestClientRegisterWithInitNodeID(t *testing.T) {
 		nodeID := roachpb.NodeID(i + 1)
 
 		rpcContext := rpc.NewInsecureTestingContextWithClusterID(ctx, clock, stopper, clusterID)
-		server, err := rpc.NewServer(rpcContext)
+		server, err := rpc.NewServer(ctx, rpcContext)
 		require.NoError(t, err)
 		// node ID must be non-zero
 		gnode := NewTest(nodeID, stopper, metric.NewRegistry(), zonepb.DefaultZoneConfigRef())

--- a/pkg/gossip/gossip_test.go
+++ b/pkg/gossip/gossip_test.go
@@ -707,7 +707,7 @@ func TestGossipJoinTwoClusters(t *testing.T) {
 		clock := hlc.NewClockForTesting(nil)
 		rpcContext := rpc.NewInsecureTestingContextWithClusterID(ctx, clock, stopper, clusterID)
 
-		server, err := rpc.NewServer(rpcContext)
+		server, err := rpc.NewServer(ctx, rpcContext)
 		require.NoError(t, err)
 
 		// node ID must be non-zero

--- a/pkg/gossip/simulation/network.go
+++ b/pkg/gossip/simulation/network.go
@@ -104,7 +104,8 @@ func NewNetwork(
 
 // CreateNode creates a simulation node and starts an RPC server for it.
 func (n *Network) CreateNode(defaultZoneConfig *zonepb.ZoneConfig) (*Node, error) {
-	server, err := rpc.NewServer(n.RPCContext)
+	ctx := context.TODO()
+	server, err := rpc.NewServer(ctx, n.RPCContext)
 	if err != nil {
 		return nil, err
 	}
@@ -116,7 +117,7 @@ func (n *Network) CreateNode(defaultZoneConfig *zonepb.ZoneConfig) (*Node, error
 	node.Gossip = gossip.NewTest(0, n.Stopper, node.Registry, defaultZoneConfig)
 	gossip.RegisterGossipServer(server, node.Gossip)
 	n.Stopper.AddCloser(stop.CloserFn(server.Stop))
-	_ = n.Stopper.RunAsyncTask(context.TODO(), "node-wait-quiesce", func(context.Context) {
+	_ = n.Stopper.RunAsyncTask(ctx, "node-wait-quiesce", func(context.Context) {
 		<-n.Stopper.ShouldQuiesce()
 		netutil.FatalIfUnexpected(ln.Close())
 		node.Gossip.EnableSimulationCycler(false)

--- a/pkg/kv/kvclient/kvcoord/send_test.go
+++ b/pkg/kv/kvclient/kvcoord/send_test.go
@@ -135,7 +135,7 @@ func TestSendToOneClient(t *testing.T) {
 	// checks to avoid log.Fatal.
 	rpcContext.TestingAllowNamedRPCToAnonymousServer = true
 
-	s, err := rpc.NewServer(rpcContext)
+	s, err := rpc.NewServer(ctx, rpcContext)
 	require.NoError(t, err)
 	kvpb.RegisterInternalServer(s, Node(0))
 	ln, err := netutil.ListenAndServeGRPC(rpcContext.Stopper, s, util.TestAddr)

--- a/pkg/kv/kvclient/kvtenant/connector_test.go
+++ b/pkg/kv/kvclient/kvtenant/connector_test.go
@@ -249,7 +249,7 @@ func TestConnectorGossipSubscription(t *testing.T) {
 	defer stopper.Stop(ctx)
 	clock := hlc.NewClockForTesting(nil)
 	rpcContext := rpc.NewInsecureTestingContext(ctx, clock, stopper)
-	s, err := rpc.NewServer(rpcContext)
+	s, err := rpc.NewServer(ctx, rpcContext)
 	require.NoError(t, err)
 
 	// Test setting the cluster ID by setting it to nil then ensuring it's later
@@ -408,7 +408,7 @@ func TestConnectorRangeLookup(t *testing.T) {
 	defer stopper.Stop(ctx)
 	clock := hlc.NewClockForTesting(nil)
 	rpcContext := rpc.NewInsecureTestingContext(ctx, clock, stopper)
-	s, err := rpc.NewServer(rpcContext)
+	s, err := rpc.NewServer(ctx, rpcContext)
 	require.NoError(t, err)
 
 	rangeLookupRespC := make(chan *kvpb.RangeLookupResponse, 1)
@@ -495,7 +495,7 @@ func TestConnectorRetriesUnreachable(t *testing.T) {
 
 	clock := hlc.NewClockForTesting(nil)
 	rpcContext := rpc.NewInsecureTestingContext(ctx, clock, stopper)
-	s, err := rpc.NewServer(rpcContext)
+	s, err := rpc.NewServer(ctx, rpcContext)
 	require.NoError(t, err)
 
 	node1 := &roachpb.NodeDescriptor{NodeID: 1, Address: util.MakeUnresolvedAddr("tcp", "1.1.1.1")}
@@ -592,7 +592,7 @@ func TestConnectorRetriesError(t *testing.T) {
 		gossipSubFn func(req *kvpb.GossipSubscriptionRequest, stream kvpb.Internal_GossipSubscriptionServer) error,
 		rangeLookupFn func(_ context.Context, req *kvpb.RangeLookupRequest) (*kvpb.RangeLookupResponse, error),
 	) string {
-		internalServer, err := rpc.NewServer(rpcContext)
+		internalServer, err := rpc.NewServer(ctx, rpcContext)
 		require.NoError(t, err)
 		kvpb.RegisterInternalServer(internalServer, &mockServer{rangeLookupFn: rangeLookupFn, gossipSubFn: gossipSubFn})
 		ln, err := net.Listen(util.TestAddr.Network(), util.TestAddr.String())

--- a/pkg/kv/kvclient/kvtenant/setting_overrides_test.go
+++ b/pkg/kv/kvclient/kvtenant/setting_overrides_test.go
@@ -39,7 +39,7 @@ func newTestConnector(
 	cleanup := func() { stopper.Stop(ctx) }
 	clock := hlc.NewClockForTesting(nil)
 	rpcContext := rpc.NewInsecureTestingContext(ctx, clock, stopper)
-	s, err := rpc.NewServer(rpcContext)
+	s, err := rpc.NewServer(ctx, rpcContext)
 	require.NoError(t, err)
 
 	tenantID := roachpb.MustMakeTenantID(5)
@@ -327,7 +327,7 @@ func TestCrossVersionMetadataSupport(t *testing.T) {
 
 			clock := hlc.NewClockForTesting(nil)
 			rpcContext := rpc.NewInsecureTestingContext(ctx, clock, stopper)
-			s, err := rpc.NewServer(rpcContext)
+			s, err := rpc.NewServer(ctx, rpcContext)
 			require.NoError(t, err)
 
 			gossipSubFn := func(req *kvpb.GossipSubscriptionRequest, stream kvpb.Internal_GossipSubscriptionServer) error {

--- a/pkg/kv/kvserver/closedts/sidetransport/sender_test.go
+++ b/pkg/kv/kvserver/closedts/sidetransport/sender_test.go
@@ -396,7 +396,7 @@ func newMockSideTransportGRPCServerWithOpts(
 	}
 
 	clock := hlc.NewClockForTesting(nil)
-	grpcServer, err := rpc.NewServer(rpc.NewInsecureTestingContext(ctx, clock, stopper))
+	grpcServer, err := rpc.NewServer(ctx, rpc.NewInsecureTestingContext(ctx, clock, stopper))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kv/kvserver/raft_transport_test.go
+++ b/pkg/kv/kvserver/raft_transport_test.go
@@ -174,7 +174,7 @@ func (rttc *raftTransportTestContext) AddNodeWithoutGossip(
 	disconnectListener kvserver.RaftTransportDisconnectListener,
 	knobs *kvserver.RaftTransportTestingKnobs,
 ) (*kvserver.RaftTransport, net.Addr) {
-	grpcServer, err := rpc.NewServer(rttc.nodeRPCContext)
+	grpcServer, err := rpc.NewServer(context.Background(), rttc.nodeRPCContext)
 	require.NoError(rttc.t, err)
 	ctwWithTracer := log.MakeTestingAmbientCtxWithNewTracer()
 	transport := kvserver.NewRaftTransport(

--- a/pkg/kv/kvserver/raft_transport_unit_test.go
+++ b/pkg/kv/kvserver/raft_transport_unit_test.go
@@ -54,7 +54,7 @@ func TestRaftTransportStartNewQueue(t *testing.T) {
 
 	// mrs := &dummyMultiRaftServer{}
 
-	grpcServer, err := rpc.NewServer(rpcC)
+	grpcServer, err := rpc.NewServer(ctx, rpcC)
 	require.NoError(t, err)
 	// RegisterMultiRaftServer(grpcServer, mrs)
 

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -188,7 +188,7 @@ func createTestStoreWithoutStart(
 	rpcOpts.TenantRPCAuthorizer = tenantcapabilitiesauthorizer.NewAllowEverythingAuthorizer()
 	rpcContext := rpc.NewContext(ctx, rpcOpts)
 	stopper.SetTracer(cfg.AmbientCtx.Tracer)
-	server, err := rpc.NewServer(rpcContext) // never started
+	server, err := rpc.NewServer(ctx, rpcContext) // never started
 	require.NoError(t, err)
 
 	// Some tests inject their own Gossip and StorePool, via

--- a/pkg/obsservice/obslib/ingest/ingest_integration_test.go
+++ b/pkg/obsservice/obslib/ingest/ingest_integration_test.go
@@ -79,7 +79,7 @@ func TestEventIngestionIntegration(t *testing.T) {
 			opts.Stopper = obsStop
 			opts.Settings = cluster.MakeTestingClusterSettings()
 			rpcContext := rpc.NewContext(ctx, opts)
-			grpcServer, err := rpc.NewServer(rpcContext)
+			grpcServer, err := rpc.NewServer(ctx, rpcContext)
 			require.NoError(t, err)
 			defer grpcServer.Stop()
 			logspb.RegisterLogsServiceServer(grpcServer, e)

--- a/pkg/rpc/addjoin.go
+++ b/pkg/rpc/addjoin.go
@@ -11,6 +11,7 @@
 package rpc
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"math"
@@ -25,7 +26,7 @@ import (
 // GetAddJoinDialOptions returns a standard list of DialOptions for use during
 // Add/Join operations.
 // TODO(aaron-crl): Possibly fold this into context.go.
-func GetAddJoinDialOptions(certPool *x509.CertPool) []grpc.DialOption {
+func GetAddJoinDialOptions(ctx context.Context, certPool *x509.CertPool) []grpc.DialOption {
 	// Populate the dialOpts.
 	var dialOpts []grpc.DialOption
 
@@ -41,9 +42,10 @@ func GetAddJoinDialOptions(certPool *x509.CertPool) []grpc.DialOption {
 		Backoff:           backoffConfig,
 		MinConnectTimeout: base.DialTimeout}))
 	dialOpts = append(dialOpts, grpc.WithKeepaliveParams(clientKeepalive))
+	var ws windowSizeSettings
 	dialOpts = append(dialOpts,
-		grpc.WithInitialWindowSize(initialWindowSize),
-		grpc.WithInitialConnWindowSize(initialConnWindowSize))
+		grpc.WithInitialWindowSize(ws.initialWindowSize(ctx)),
+		grpc.WithInitialConnWindowSize(ws.initialConnWindowSize(ctx)))
 
 	// Create a tls.Config that allows insecure mode if certPool is not set but
 	// requires it if certPool is set.

--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -58,8 +58,8 @@ import (
 // NewServer sets up an RPC server. Depending on the ServerOptions, the Server
 // either expects incoming connections from KV nodes, or from tenant SQL
 // servers.
-func NewServer(rpcCtx *Context, opts ...ServerOption) (*grpc.Server, error) {
-	srv, _ /* interceptors */, err := NewServerEx(rpcCtx, opts...)
+func NewServer(ctx context.Context, rpcCtx *Context, opts ...ServerOption) (*grpc.Server, error) {
+	srv, _ /* interceptors */, err := NewServerEx(ctx, rpcCtx, opts...)
 	return srv, err
 }
 
@@ -86,7 +86,7 @@ type ClientInterceptorInfo struct {
 // manually when bypassing gRPC to call into the server (like the
 // internalClientAdapter does).
 func NewServerEx(
-	rpcCtx *Context, opts ...ServerOption,
+	ctx context.Context, rpcCtx *Context, opts ...ServerOption,
 ) (s *grpc.Server, sii ServerInterceptorInfo, err error) {
 	var o serverOpts
 	for _, f := range opts {
@@ -102,8 +102,8 @@ func NewServerEx(
 		grpc.MaxSendMsgSize(math.MaxInt32),
 		// Adjust the stream and connection window sizes. The gRPC defaults are too
 		// low for high latency connections.
-		grpc.InitialWindowSize(initialWindowSize),
-		grpc.InitialConnWindowSize(initialConnWindowSize),
+		grpc.InitialWindowSize(rpcCtx.initialWindowSize(ctx)),
+		grpc.InitialConnWindowSize(rpcCtx.initialConnWindowSize(ctx)),
 		// The default number of concurrent streams/requests on a client connection
 		// is 100, while the server is unlimited. The client setting can only be
 		// controlled by adjusting the server value. Set a very large value for the
@@ -271,6 +271,10 @@ type Context struct {
 
 	// clientCreds is used to pass additional headers to called RPCs.
 	clientCreds credentials.PerRPCCredentials
+
+	// windowSizeSettings contains the memoized window size
+	// settings for this context.
+	windowSizeSettings
 }
 
 // SetLoopbackDialer configures the loopback dialer function.
@@ -1519,7 +1523,7 @@ func (rpcCtx *Context) GRPCDialOptions(
 func (rpcCtx *Context) grpcDialOptionsInternal(
 	ctx context.Context, target string, class ConnectionClass, transport transportType,
 ) ([]grpc.DialOption, error) {
-	dialOpts, err := rpcCtx.dialOptsCommon(target, class)
+	dialOpts, err := rpcCtx.dialOptsCommon(ctx, target, class)
 	if err != nil {
 		return nil, err
 	}
@@ -1747,7 +1751,7 @@ func (rpcCtx *Context) dialOptsNetwork(
 // dialOptsCommon computes options used for both in-memory and
 // over-the-network RPC connections.
 func (rpcCtx *Context) dialOptsCommon(
-	target string, class ConnectionClass,
+	ctx context.Context, target string, class ConnectionClass,
 ) ([]grpc.DialOption, error) {
 	// The limiting factor for lowering the max message size is the fact
 	// that a single large kv can be sent over the network in one message.
@@ -1771,11 +1775,11 @@ func (rpcCtx *Context) dialOptsCommon(
 	dialOpts = append(dialOpts, grpc.WithDisableRetry())
 
 	// Configure the window sizes with optional env var overrides.
-	dialOpts = append(dialOpts, grpc.WithInitialConnWindowSize(initialConnWindowSize))
+	dialOpts = append(dialOpts, grpc.WithInitialConnWindowSize(rpcCtx.initialConnWindowSize(ctx)))
 	if class == RangefeedClass {
-		dialOpts = append(dialOpts, grpc.WithInitialWindowSize(rangefeedInitialWindowSize))
+		dialOpts = append(dialOpts, grpc.WithInitialWindowSize(rpcCtx.rangefeedInitialWindowSize(ctx)))
 	} else {
-		dialOpts = append(dialOpts, grpc.WithInitialWindowSize(initialWindowSize))
+		dialOpts = append(dialOpts, grpc.WithInitialWindowSize(rpcCtx.initialWindowSize(ctx)))
 	}
 	unaryInterceptors := rpcCtx.clientUnaryInterceptors
 	unaryInterceptors = unaryInterceptors[:len(unaryInterceptors):len(unaryInterceptors)]

--- a/pkg/rpc/context_test.go
+++ b/pkg/rpc/context_test.go
@@ -443,7 +443,7 @@ func TestInternalClientAdapterRunsInterceptors(t *testing.T) {
 	serverCtx.AdvertiseAddr = "127.0.0.1:8888"
 	serverCtx.NodeID.Set(context.Background(), 1)
 
-	_ /* server */, serverInterceptors, err := NewServerEx(serverCtx)
+	_ /* server */, serverInterceptors, err := NewServerEx(ctx, serverCtx)
 	require.NoError(t, err)
 
 	// Pile on one more interceptor to make sure it's called.
@@ -543,7 +543,7 @@ func TestInternalClientAdapterWithClientStreamInterceptors(t *testing.T) {
 	serverCtx.AdvertiseAddr = "127.0.0.1:8888"
 	serverCtx.NodeID.Set(context.Background(), 1)
 
-	_ /* server */, serverInterceptors, err := NewServerEx(serverCtx)
+	_ /* server */, serverInterceptors, err := NewServerEx(ctx, serverCtx)
 	require.NoError(t, err)
 
 	testutils.RunTrueAndFalse(t, "use_mux_rangefeed", func(t *testing.T, useMux bool) {
@@ -618,7 +618,7 @@ func TestInternalClientAdapterWithServerStreamInterceptors(t *testing.T) {
 	serverCtx.AdvertiseAddr = "127.0.0.1:8888"
 	serverCtx.NodeID.Set(context.Background(), 1)
 
-	_ /* server */, serverInterceptors, err := NewServerEx(serverCtx)
+	_ /* server */, serverInterceptors, err := NewServerEx(ctx, serverCtx)
 	require.NoError(t, err)
 
 	testutils.RunTrueAndFalse(t, "use_mux_rangefeed", func(t *testing.T, useMux bool) {
@@ -772,7 +772,7 @@ func BenchmarkInternalClientAdapter(b *testing.B) {
 	serverCtx.AdvertiseAddr = "127.0.0.1:8888"
 	serverCtx.NodeID.Set(context.Background(), 1)
 
-	_, interceptors, err := NewServerEx(serverCtx)
+	_, interceptors, err := NewServerEx(ctx, serverCtx)
 	require.NoError(b, err)
 
 	internal := &internalServer{}
@@ -2059,7 +2059,7 @@ func TestRejectDialOnQuiesce(t *testing.T) {
 		defer srvStopper.Stop(ctx)
 		serverCtx := newTestContext(clusID, clock, maxOffset, srvStopper)
 		serverCtx.NodeID.Set(ctx, serverNodeID)
-		s, err := NewServer(serverCtx)
+		s, err := NewServer(ctx, serverCtx)
 		require.NoError(t, err)
 		ln, err := netutil.ListenAndServeGRPC(srvStopper, s, util.TestAddr)
 		require.NoError(t, err)

--- a/pkg/server/addjoin_test.go
+++ b/pkg/server/addjoin_test.go
@@ -50,7 +50,7 @@ func TestConsumeJoinToken(t *testing.T) {
 	var jt security.JoinToken
 	require.NoError(t, jt.UnmarshalText([]byte(token)))
 
-	dialOpts := rpc.GetAddJoinDialOptions(nil)
+	dialOpts := rpc.GetAddJoinDialOptions(ctx, nil)
 	conn, err := grpc.DialContext(ctx, s.RPCAddr(), dialOpts...)
 	require.NoError(t, err)
 	defer func() {
@@ -72,7 +72,7 @@ func TestConsumeJoinToken(t *testing.T) {
 	certPool := x509.NewCertPool()
 	certPool.AddCert(cert)
 
-	dialOpts = rpc.GetAddJoinDialOptions(certPool)
+	dialOpts = rpc.GetAddJoinDialOptions(ctx, certPool)
 	conn2, err := grpc.DialContext(ctx, s.RPCAddr(), dialOpts...)
 	require.NoError(t, err)
 	defer func() {

--- a/pkg/server/grpc_server.go
+++ b/pkg/server/grpc_server.go
@@ -31,11 +31,11 @@ type grpcServer struct {
 	mode                   serveMode
 }
 
-func newGRPCServer(rpcCtx *rpc.Context) (*grpcServer, error) {
+func newGRPCServer(ctx context.Context, rpcCtx *rpc.Context) (*grpcServer, error) {
 	s := &grpcServer{}
 	s.mode.set(modeInitializing)
 	srv, interceptorInfo, err := rpc.NewServerEx(
-		rpcCtx, rpc.WithInterceptor(func(path string) error {
+		ctx, rpcCtx, rpc.WithInterceptor(func(path string) error {
 			return s.intercept(path)
 		}))
 	if err != nil {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -372,7 +372,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterf
 	// and after ValidateAddrs().
 	rpcContext.CheckCertificateAddrs(ctx)
 
-	grpcServer, err := newGRPCServer(rpcContext)
+	grpcServer, err := newGRPCServer(ctx, rpcContext)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -1185,7 +1185,7 @@ func makeTenantSQLServerArgs(
 	externalStorage := esb.makeExternalStorage
 	externalStorageFromURI := esb.makeExternalStorageFromURI
 
-	grpcServer, err := newGRPCServer(rpcContext)
+	grpcServer, err := newGRPCServer(startupCtx, rpcContext)
 	if err != nil {
 		return sqlServerArgs{}, err
 	}

--- a/pkg/sql/distsql/inbound_test.go
+++ b/pkg/sql/distsql/inbound_test.go
@@ -76,7 +76,7 @@ func TestOutboxInboundStreamIntegration(t *testing.T) {
 	// We're going to serve multiple node IDs with that one context. Disable node ID checks.
 	rpcContext.TestingAllowNamedRPCToAnonymousServer = true
 
-	rpcSrv, err := rpc.NewServer(rpcContext)
+	rpcSrv, err := rpc.NewServer(ctx, rpcContext)
 	require.NoError(t, err)
 	defer rpcSrv.Stop()
 

--- a/pkg/sql/execinfrapb/testutils.go
+++ b/pkg/sql/execinfrapb/testutils.go
@@ -47,7 +47,7 @@ func StartMockDistSQLServer(
 ) (uuid.UUID, *MockDistSQLServer, net.Addr, error) {
 	rpcContext := newInsecureRPCContext(ctx, stopper)
 	rpcContext.NodeID.Set(context.TODO(), roachpb.NodeID(sqlInstanceID))
-	server, err := rpc.NewServer(rpcContext)
+	server, err := rpc.NewServer(ctx, rpcContext)
 	if err != nil {
 		return uuid.Nil, nil, nil, err
 	}


### PR DESCRIPTION
Fixes #109900.
Epic: CRDB-28893

A recent refactor surfaced a misdesign that had existed in the RPC package for a while: the RPC window size parameters was based off global variables only computed once. The misdesign was surfaced by the introduction of a bug in this recent refactor: the code was made to log some messages in case of misconfiguration. The logging was happening at init-time, and thus too early.

There are a couple of problems with this misdesign:

- it prevents computing new window parameters off new values of env vars set after the process has started up. (This is important as we evolve towards a server architecture with delayed initialization.)

- the associated logging did not properly output the log events to the right place, because it was not subject to the log config.

- the associated logging did not use the right logging tags.

This patch fixes this by delaying the computation to the point the RPC server is instantiated.

(No release note because the logging-related bug was not included in a user-facing release yet.)

Release note: None