### PR TITLE
norm: push Select into UniqueKeyExpr

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/select
+++ b/pkg/sql/logictest/testdata/logic_test/select
@@ -862,3 +862,81 @@ SELECT -488 OF FROM t;
 ----
 of
 -488
+
+subtest 109751_regr
+
+# Regression test for #109751
+
+statement ok
+CREATE TABLE trm (
+        id UUID NOT NULL,
+        trid UUID NOT NULL,
+        ts12 TIMESTAMP NOT NULL
+);
+INSERT INTO trm VALUES('5ebfedee-0dcf-41e6-a315-5fa0b51b9882',
+                       '5ebfedee-0dcf-41e6-a315-5fa0b51b9882',
+                       '1999-12-31 23:59:59');
+INSERT INTO trm VALUES('5ebfedee-0dcf-41e6-a315-5fa0b51b9883',
+                       '5ebfedee-0dcf-41e6-a315-5fa0b51b9883',
+                       '1999-12-31 23:59:58');
+INSERT INTO trm VALUES('5ebfedee-0dcf-41e6-a315-5fa0b51b9882',
+                       '5ebfedee-0dcf-41e6-a315-5fa0b51b9882',
+                       '1999-11-30 23:59:59');
+INSERT INTO trm VALUES('5ebfedee-0dcf-41e6-a315-5fa0b51b9883',
+                       '5ebfedee-0dcf-41e6-a315-5fa0b51b9883',
+                       '1999-11-30 23:59:58');
+INSERT INTO trm VALUES('5ebfedee-0dcf-41e6-a315-5fa0b51b9884',
+                       '5ebfedee-0dcf-41e6-a315-5fa0b51b9884',
+                       '1999-11-30 23:59:57');
+
+statement ok
+CREATE TABLE trrec (
+        id UUID NOT NULL,
+        trid STRING NOT NULL,
+        ts12 TIMESTAMP NOT NULL,
+        str16 STRING NULL,
+        INDEX trrec_idx5 (str16 ASC)
+);
+INSERT INTO trrec VALUES('5ebfedee-0dcf-41e6-a315-5fa0b51b9882', '1', '1999-12-31 23:59:59', '12345');
+INSERT INTO trrec VALUES('5ebfedee-0dcf-41e6-a315-5fa0b51b9883', '2', '1999-12-31 23:59:58', '12345');
+INSERT INTO trrec VALUES('5ebfedee-0dcf-41e6-a315-5fa0b51b9884', '3', '1999-12-31 23:59:57', '123456');
+
+statement ok
+CREATE TABLE trtab4 (
+        id UUID NOT NULL,
+        trid UUID NOT NULL,
+        dec1 DECIMAL(19,2) NOT NULL
+);
+INSERT INTO trtab4 VALUES('5ebfedee-0dcf-41e6-a315-5fa0b51b9882', '5ebfedee-0dcf-41e6-a315-5fa0b51b9882', 1.0);
+INSERT INTO trtab4 VALUES('5ebfedee-0dcf-41e6-a315-5fa0b51b9883', '5ebfedee-0dcf-41e6-a315-5fa0b51b9883', 2.0);
+INSERT INTO trtab4 VALUES('5ebfedee-0dcf-41e6-a315-5fa0b51b9884', '5ebfedee-0dcf-41e6-a315-5fa0b51b9884', 3.0);
+
+query TTT
+WITH
+  with2
+    AS (
+      SELECT
+        tq.trid, tq.dec1
+      FROM
+        trrec AS r INNER JOIN trtab4 AS tq ON r.id = tq.trid AND r.str16 = '12345'
+    )
+SELECT tr.id, tr.trid, val3.ts12
+FROM
+  trrec AS tr
+  INNER JOIN LATERAL (
+      SELECT  q.dec1 FROM with2 AS q WHERE tr.id = q.trid
+    ) AS q ON true
+  INNER JOIN LATERAL (
+      SELECT
+        m.ts12
+      FROM trm AS m WHERE tr.id = m.trid
+      ORDER BY m.ts12 ASC
+      LIMIT 1
+    ) AS val3 ON true
+WHERE
+  tr.str16 = '12345'
+ORDER BY 1 DESC
+;
+----
+5ebfedee-0dcf-41e6-a315-5fa0b51b9883  2  1999-11-30 23:59:58 +0000 +0000
+5ebfedee-0dcf-41e6-a315-5fa0b51b9882  1  1999-11-30 23:59:59 +0000 +0000

--- a/pkg/sql/opt/memo/testdata/typing
+++ b/pkg/sql/opt/memo/testdata/typing
@@ -423,7 +423,7 @@ project
  │    ├── grouping columns: rownum:14(int!null)
  │    ├── left-join (cross)
  │    │    ├── columns: expr:5(int!null) true:11(bool) rownum:14(int!null)
- │    │    ├── ordinality
+ │    │    ├── unique-key
  │    │    │    ├── columns: expr:5(int!null) rownum:14(int!null)
  │    │    │    └── project
  │    │    │         ├── columns: expr:5(int!null)

--- a/pkg/sql/opt/norm/decorrelate_funcs.go
+++ b/pkg/sql/opt/norm/decorrelate_funcs.go
@@ -376,10 +376,10 @@ func (c *CustomFuncs) ConstructApplyJoin(
 // strong key exists and the input expression is a Scan or a Scan wrapped in a
 // Select, EnsureKey returns a new Scan (possibly wrapped in a Select) with the
 // preexisting primary key for the table. If the input is not a Scan or
-// Select(Scan), EnsureKey wraps the input in an Ordinality operator, which
+// Select(Scan), EnsureKey wraps the input in a UniqueKey operator, which
 // provides a key column by uniquely numbering the rows. EnsureKey returns the
 // input expression (perhaps augmented with a key column(s) or wrapped by
-// Ordinality).
+// UniqueKey).
 func (c *CustomFuncs) EnsureKey(in memo.RelExpr) memo.RelExpr {
 	_, ok := c.CandidateKey(in)
 	if ok {
@@ -392,10 +392,10 @@ func (c *CustomFuncs) EnsureKey(in memo.RelExpr) memo.RelExpr {
 		return res
 	}
 
-	// Otherwise, wrap the input in an Ordinality operator.
+	// Otherwise, wrap the input in an UniqueKey operator.
 	colID := c.f.Metadata().AddColumn("rownum", types.Int)
-	private := memo.OrdinalityPrivate{ColID: colID}
-	return c.f.ConstructOrdinality(in, &private)
+	private := memo.UniqueKeyPrivate{ColID: colID}
+	return c.f.ConstructUniqueKey(in, &private)
 }
 
 // TryAddKeyToScan checks whether the input expression is a non-virtual table

--- a/pkg/sql/opt/norm/prune_cols_funcs.go
+++ b/pkg/sql/opt/norm/prune_cols_funcs.go
@@ -637,6 +637,14 @@ func (c *CustomFuncs) DerivePruneCols(e memo.RelExpr, disabledRules intsets.Fast
 		inputPruneCols := c.DerivePruneCols(ord.Input, disabledRules)
 		relProps.Rule.PruneCols = inputPruneCols.Difference(ord.Ordering.ColSet())
 
+	case opt.UniqueKeyOp:
+		if disabledRules.Contains(int(opt.PruneUniqueKeyCols)) {
+			// Avoid rule cycles.
+			break
+		}
+		uniqueKeyExpr := e.(*memo.UniqueKeyExpr)
+		relProps.Rule.PruneCols = c.DerivePruneCols(uniqueKeyExpr.Input, disabledRules)
+
 	case opt.IndexJoinOp, opt.LookupJoinOp, opt.MergeJoinOp:
 		// There is no need to prune columns projected by Index, Lookup or Merge
 		// joins, since its parent will always be an "alternate" expression in the

--- a/pkg/sql/opt/norm/rules/decorrelate.opt
+++ b/pkg/sql/opt/norm/rules/decorrelate.opt
@@ -356,7 +356,7 @@
 # column would not be constant necessarily, hence the use of ANY_NOT_NULL
 # instead of CONST_AGG.
 #
-# An ordinality column only needs to be synthesized if "left" does not already
+# A unique key column only needs to be synthesized if "left" does not already
 # have a strict key. We wrap the output in a Project operator to ensure that
 # the original output columns are preserved and the ordinality column is not
 # inadvertently added as a new output column.
@@ -485,7 +485,7 @@
 # In this example, the "notnull" canary is needed to determine if the value of
 # the ARRAY_AGG aggregation should be NULL or {NULL}.
 #
-# An ordinality column only needs to be synthesized if "left" does not already
+# A unique key column only needs to be synthesized if "left" does not already
 # have a key. The "true" column only needs to be added if "input" does not
 # already have a not-null column (and COUNT(*) is used).
 #

--- a/pkg/sql/opt/norm/rules/prune_cols.opt
+++ b/pkg/sql/opt/norm/rules/prune_cols.opt
@@ -342,6 +342,27 @@
     $passthrough
 )
 
+# PruneUniqueKeyCols discards UniqueKey input columns that are never used.
+[PruneUniqueKeyCols, Normalize]
+(Project
+    (UniqueKey $input:* $uniqueKeyPrivate:*)
+    $projections:*
+    $passthrough:* &
+        (CanPruneCols
+            $input
+            $needed:(UnionCols
+                (ProjectionOuterCols $projections)
+                $passthrough
+            )
+        )
+)
+=>
+(Project
+    (UniqueKey (PruneCols $input $needed) $uniqueKeyPrivate)
+    $projections
+    $passthrough
+)
+
 # PruneExplainCols discards Explain input columns that are never used by its
 # required physical properties.
 [PruneExplainCols, Normalize]

--- a/pkg/sql/opt/norm/rules/select.opt
+++ b/pkg/sql/opt/norm/rules/select.opt
@@ -105,6 +105,34 @@ $input
     (ExtractUnboundConditions $filters $inputCols)
 )
 
+# PushSelectIntoUniqueKey pushes the Select operator into its UniqueKey input.
+# This is typically preferable because it allows the Select to be pushed into
+# operations beneath the UniqueKey, minimizing the number of rows subsequent
+# operations need to process and potentially pushing the Select down far enough
+# to enable constrained scans. This may also enable other normalization rules,
+# which match on Select expressions, to fire.
+[PushSelectIntoUniqueKey, Normalize]
+(Select
+    (UniqueKey $input:* $private:*)
+    $filters:[
+        ...
+        $item:* &
+            (IsBoundBy $item $inputCols:(OutputCols $input))
+        ...
+    ]
+)
+=>
+(Select
+    (UniqueKey
+        (Select
+            $input
+            (ExtractBoundConditions $filters $inputCols)
+        )
+        $private
+    )
+    (ExtractUnboundConditions $filters $inputCols)
+)
+
 # MergeSelectInnerJoin merges a Select operator with an InnerJoin input by
 # AND'ing the filter conditions of each and creating a new InnerJoin with that
 # On condition. This is only safe to do with InnerJoin in the general case

--- a/pkg/sql/opt/norm/testdata/rules/decorrelate
+++ b/pkg/sql/opt/norm/testdata/rules/decorrelate
@@ -419,24 +419,22 @@ project
       ├── inner-join (cross)
       │    ├── columns: column1:1!null i:3 rownum:10!null
       │    ├── fd: (10)-->(1)
-      │    ├── select
+      │    ├── unique-key
       │    │    ├── columns: column1:1!null rownum:10!null
       │    │    ├── cardinality: [0 - 3]
       │    │    ├── key: (10)
       │    │    ├── fd: (10)-->(1)
-      │    │    ├── unique-key
-      │    │    │    ├── columns: column1:1!null rownum:10!null
-      │    │    │    ├── cardinality: [3 - 3]
-      │    │    │    ├── key: (10)
-      │    │    │    ├── fd: (10)-->(1)
-      │    │    │    └── values
-      │    │    │         ├── columns: column1:1!null
-      │    │    │         ├── cardinality: [3 - 3]
-      │    │    │         ├── (1,)
-      │    │    │         ├── (1,)
-      │    │    │         └── (1,)
-      │    │    └── filters
-      │    │         └── column1:1 > 3 [outer=(1), constraints=(/1: [/4 - ]; tight)]
+      │    │    └── select
+      │    │         ├── columns: column1:1!null
+      │    │         ├── cardinality: [0 - 3]
+      │    │         ├── values
+      │    │         │    ├── columns: column1:1!null
+      │    │         │    ├── cardinality: [3 - 3]
+      │    │         │    ├── (1,)
+      │    │         │    ├── (1,)
+      │    │         │    └── (1,)
+      │    │         └── filters
+      │    │              └── column1:1 > 3 [outer=(1), constraints=(/1: [/4 - ]; tight)]
       │    ├── scan a
       │    │    └── columns: i:3
       │    └── filters (true)

--- a/pkg/sql/opt/norm/testdata/rules/decorrelate
+++ b/pkg/sql/opt/norm/testdata/rules/decorrelate
@@ -384,7 +384,7 @@ project
       │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
       │    ├── key: (10)
       │    ├── fd: (10)-->(1), (2)-->(3), (1)==(2), (2)==(1)
-      │    ├── ordinality
+      │    ├── unique-key
       │    │    ├── columns: column1:1!null rownum:10!null
       │    │    ├── cardinality: [3 - 3]
       │    │    ├── key: (10)
@@ -424,7 +424,7 @@ project
       │    │    ├── cardinality: [0 - 3]
       │    │    ├── key: (10)
       │    │    ├── fd: (10)-->(1)
-      │    │    ├── ordinality
+      │    │    ├── unique-key
       │    │    │    ├── columns: column1:1!null rownum:10!null
       │    │    │    ├── cardinality: [3 - 3]
       │    │    │    ├── key: (10)
@@ -474,7 +474,7 @@ project
       │         ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
       │         ├── key: (11)
       │         ├── fd: (11)-->(1), (2)-->(3), (1)==(2), (2)==(1)
-      │         ├── ordinality
+      │         ├── unique-key
       │         │    ├── columns: column1:1!null rownum:11!null
       │         │    ├── cardinality: [3 - 3]
       │         │    ├── key: (11)
@@ -521,7 +521,7 @@ project
       │         ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
       │         ├── key: (13)
       │         ├── fd: (13)-->(1,2), (3)-->(4), (1)==(3), (3)==(1)
-      │         ├── ordinality
+      │         ├── unique-key
       │         │    ├── columns: column1:1!null column2:2!null rownum:13!null
       │         │    ├── cardinality: [3 - 3]
       │         │    ├── key: (13)
@@ -3742,7 +3742,7 @@ project
       │    │    ├── cardinality: [2 - ]
       │    │    ├── key: (2,6)
       │    │    ├── fd: (6)-->(1), (2)-->(3)
-      │    │    ├── ordinality
+      │    │    ├── unique-key
       │    │    │    ├── columns: column1:1!null rownum:6!null
       │    │    │    ├── cardinality: [2 - 2]
       │    │    │    ├── key: (6)
@@ -5166,7 +5166,7 @@ project
  │    │    ├── columns: i:2 column12:12 scalar:14!null notnull:15 rownum:18!null
  │    │    ├── immutable
  │    │    ├── fd: ()-->(14), (18)-->(2)
- │    │    ├── ordinality
+ │    │    ├── unique-key
  │    │    │    ├── columns: i:2 scalar:14!null rownum:18!null
  │    │    │    ├── key: (18)
  │    │    │    ├── fd: ()-->(14), (18)-->(2,14)
@@ -6356,7 +6356,7 @@ semi-join (hash)
 
 # Check that when the EnsureKey function is called on a Scan that has pruned its
 # key away, it creates a new Scan with the primary key added back rather than
-# introducing an ordinality operator.
+# introducing a unique-key operator.
 #
 # In this test case, the key column of a is pruned away from the Scan, but when
 # TryDecorrelateLimitOne calls EnsureKey on the Scan, the key is added back.
@@ -6421,7 +6421,7 @@ project
  └── projections
       └── xy.x:6 [as=x:10, outer=(6)]
 
-# EnsureKey should construct an Ordinality operator when it is called on a Scan
+# EnsureKey should construct a UniqueKey operator when it is called on a Scan
 # over a virtual table.
 norm
 SELECT (SELECT x FROM xy WHERE y=version LIMIT 1) FROM information_schema.tables
@@ -6437,7 +6437,7 @@ project
  │    │    ├── columns: version:7 xy.x:8 y:9 rownum:13!null
  │    │    ├── key: (8,13)
  │    │    ├── fd: (13)-->(7), (8)-->(9)
- │    │    ├── ordinality
+ │    │    ├── unique-key
  │    │    │    ├── columns: version:7 rownum:13!null
  │    │    │    ├── key: (13)
  │    │    │    ├── fd: (13)-->(7)

--- a/pkg/sql/opt/norm/testdata/rules/inline
+++ b/pkg/sql/opt/norm/testdata/rules/inline
@@ -1051,7 +1051,7 @@ project
  │    │    ├── columns: expr:8!null true:14 rownum:17!null
  │    │    ├── immutable
  │    │    ├── fd: (17)-->(8)
- │    │    ├── ordinality
+ │    │    ├── unique-key
  │    │    │    ├── columns: expr:8!null rownum:17!null
  │    │    │    ├── immutable
  │    │    │    ├── key: (17)

--- a/pkg/sql/opt/norm/testdata/rules/project
+++ b/pkg/sql/opt/norm/testdata/rules/project
@@ -779,7 +779,7 @@ project
  │    │    ├── cardinality: [2 - ]
  │    │    ├── immutable
  │    │    ├── fd: (11)-->(9)
- │    │    ├── ordinality
+ │    │    ├── unique-key
  │    │    │    ├── columns: column1_1:9!null rownum:11!null
  │    │    │    ├── cardinality: [2 - 2]
  │    │    │    ├── key: (11)
@@ -829,7 +829,7 @@ project
  │    │    │    ├── cardinality: [4 - 4]
  │    │    │    ├── multiplicity: left-rows(one-or-more), right-rows(one-or-more)
  │    │    │    ├── fd: (9)-->(7)
- │    │    │    ├── ordinality
+ │    │    │    ├── unique-key
  │    │    │    │    ├── columns: column1_1:7!null rownum:9!null
  │    │    │    │    ├── cardinality: [2 - 2]
  │    │    │    │    ├── key: (9)
@@ -1114,7 +1114,7 @@ project
  │    │    ├── columns: column1:2 "?column?":3!null rownum:5!null
  │    │    ├── cardinality: [2 - 8]
  │    │    ├── fd: (5)-->(3)
- │    │    ├── ordinality
+ │    │    ├── unique-key
  │    │    │    ├── columns: "?column?":3!null rownum:5!null
  │    │    │    ├── cardinality: [2 - 2]
  │    │    │    ├── key: (5)

--- a/pkg/sql/opt/norm/testdata/rules/select
+++ b/pkg/sql/opt/norm/testdata/rules/select
@@ -2108,3 +2108,329 @@ except-all
       ├── key: ()
       ├── fd: ()-->(2)
       └── (1.00,)
+
+# Regression test for #109751
+
+exec-ddl
+CREATE TABLE trm (
+        id UUID NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+        trid UUID NOT NULL,
+        ts12 TIMESTAMP NOT NULL
+);
+----
+
+exec-ddl
+CREATE TABLE trrec (
+        id UUID NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+        trid STRING NOT NULL,
+        ts12 TIMESTAMP NOT NULL,
+        str16 STRING NULL,
+        INDEX trrec_idx5 (str16 ASC)
+);
+----
+
+exec-ddl
+CREATE TABLE trtab4 (
+        id UUID NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+        trid UUID NOT NULL,
+        dec1 DECIMAL(19,2) NOT NULL
+);
+----
+
+# The filter on tr.str16 should be pushed into the val3 left lateral join.
+norm expect=PushSelectIntoUniqueKey
+WITH
+  with2
+    AS (
+      SELECT
+        tq.trid, tq.dec1
+      FROM
+        trrec AS r INNER JOIN trtab4 AS tq ON r.id = tq.trid AND r.str16 = '12345'
+    )
+SELECT tr.id, tr.trid
+FROM
+  trrec AS tr
+  LEFT JOIN LATERAL (
+      SELECT  q.dec1 FROM with2 AS q WHERE tr.id = q.trid
+    ) AS q ON true
+  LEFT JOIN LATERAL (
+      SELECT
+        --tr.id, -- Previously, including this column allowed the filter on
+                 -- str16 to be pushed into the join, but this is no longer
+                 -- required.
+        m.ts12
+      FROM trm AS m WHERE tr.id = m.trid
+      ORDER BY m.ts12 DESC
+      LIMIT 1
+    ) AS val3 ON true
+WHERE
+  tr.str16 = '12345'
+;
+----
+project
+ ├── columns: id:12!null trid:13!null
+ ├── fd: (12)-->(13)
+ └── distinct-on
+      ├── columns: tr.id:12!null tr.trid:13!null rownum:25!null
+      ├── grouping columns: rownum:25!null
+      ├── internal-ordering: -22
+      ├── key: (25)
+      ├── fd: (12)-->(13), (25)-->(12,13)
+      ├── sort
+      │    ├── columns: tr.id:12!null tr.trid:13!null m.trid:21 m.ts12:22 rownum:25!null
+      │    ├── fd: (12)-->(13), (25)-->(12,13)
+      │    ├── ordering: -22
+      │    └── left-join (hash)
+      │         ├── columns: tr.id:12!null tr.trid:13!null m.trid:21 m.ts12:22 rownum:25!null
+      │         ├── fd: (12)-->(13), (25)-->(12,13)
+      │         ├── unique-key
+      │         │    ├── columns: tr.id:12!null tr.trid:13!null rownum:25!null
+      │         │    ├── key: (25)
+      │         │    ├── fd: (12)-->(13), (25)-->(12,13)
+      │         │    └── project
+      │         │         ├── columns: tr.id:12!null tr.trid:13!null
+      │         │         ├── fd: (12)-->(13)
+      │         │         └── left-join (hash)
+      │         │              ├── columns: tr.id:12!null tr.trid:13!null tr.str16:15!null trid:18
+      │         │              ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-one)
+      │         │              ├── fd: ()-->(15), (12)-->(13)
+      │         │              ├── select
+      │         │              │    ├── columns: tr.id:12!null tr.trid:13!null tr.str16:15!null
+      │         │              │    ├── key: (12)
+      │         │              │    ├── fd: ()-->(15), (12)-->(13)
+      │         │              │    ├── scan trrec [as=tr]
+      │         │              │    │    ├── columns: tr.id:12!null tr.trid:13!null tr.str16:15
+      │         │              │    │    ├── key: (12)
+      │         │              │    │    └── fd: (12)-->(13,15)
+      │         │              │    └── filters
+      │         │              │         └── tr.str16:15 = '12345' [outer=(15), constraints=(/15: [/'12345' - /'12345']; tight), fd=()-->(15)]
+      │         │              ├── project
+      │         │              │    ├── columns: trid:18!null
+      │         │              │    ├── inner-join (hash)
+      │         │              │    │    ├── columns: r.id:1!null r.str16:4!null tq.trid:8!null
+      │         │              │    │    ├── multiplicity: left-rows(zero-or-more), right-rows(zero-or-one)
+      │         │              │    │    ├── fd: ()-->(4), (1)==(8), (8)==(1)
+      │         │              │    │    ├── select
+      │         │              │    │    │    ├── columns: r.id:1!null r.str16:4!null
+      │         │              │    │    │    ├── key: (1)
+      │         │              │    │    │    ├── fd: ()-->(4)
+      │         │              │    │    │    ├── scan trrec [as=r]
+      │         │              │    │    │    │    ├── columns: r.id:1!null r.str16:4
+      │         │              │    │    │    │    ├── key: (1)
+      │         │              │    │    │    │    └── fd: (1)-->(4)
+      │         │              │    │    │    └── filters
+      │         │              │    │    │         └── r.str16:4 = '12345' [outer=(4), constraints=(/4: [/'12345' - /'12345']; tight), fd=()-->(4)]
+      │         │              │    │    ├── scan trtab4 [as=tq]
+      │         │              │    │    │    └── columns: tq.trid:8!null
+      │         │              │    │    └── filters
+      │         │              │    │         └── r.id:1 = tq.trid:8 [outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(8), (8)==(1)]
+      │         │              │    └── projections
+      │         │              │         └── tq.trid:8 [as=trid:18, outer=(8)]
+      │         │              └── filters
+      │         │                   └── tr.id:12 = trid:18 [outer=(12,18), constraints=(/12: (/NULL - ]; /18: (/NULL - ]), fd=(12)==(18), (18)==(12)]
+      │         ├── scan trm [as=m]
+      │         │    └── columns: m.trid:21!null m.ts12:22!null
+      │         └── filters
+      │              └── tr.id:12 = m.trid:21 [outer=(12,21), constraints=(/12: (/NULL - ]; /21: (/NULL - ]), fd=(12)==(21), (21)==(12)]
+      └── aggregations
+           ├── const-agg [as=tr.id:12, outer=(12)]
+           │    └── tr.id:12
+           └── const-agg [as=tr.trid:13, outer=(13)]
+                └── tr.trid:13
+
+# The filter on tr.str16 should be pushed into the val3 inner lateral join.
+norm expect=PushSelectIntoUniqueKey
+WITH
+  with2
+    AS (
+      SELECT
+        tq.trid, tq.dec1
+      FROM
+        trrec AS r INNER JOIN trtab4 AS tq ON r.id = tq.trid AND r.str16 = '12345'
+    )
+SELECT tr.id, tr.trid
+FROM
+  trrec AS tr
+  INNER JOIN LATERAL (
+      SELECT  q.dec1 FROM with2 AS q WHERE tr.id = q.trid
+    ) AS q ON true
+  INNER JOIN LATERAL (
+      SELECT
+        --tr.id, -- Previously, including this column allowed the filter on
+                 -- str16 to be pushed into the join, but this is no longer
+                 -- required.
+        m.ts12
+      FROM trm AS m WHERE tr.id = m.trid
+      ORDER BY m.ts12 DESC
+      LIMIT 1
+    ) AS val3 ON true
+WHERE
+  tr.str16 = '12345'
+;
+----
+project
+ ├── columns: id:12!null trid:13!null
+ ├── fd: (12)-->(13)
+ └── distinct-on
+      ├── columns: tr.id:12!null tr.trid:13!null rownum:25!null
+      ├── grouping columns: rownum:25!null
+      ├── internal-ordering: -22 opt(12,13,21)
+      ├── key: (25)
+      ├── fd: (12)-->(13), (25)-->(12,13)
+      ├── sort
+      │    ├── columns: tr.id:12!null tr.trid:13!null m.trid:21!null m.ts12:22!null rownum:25!null
+      │    ├── fd: (12)-->(13), (25)-->(12,13), (12)==(21), (21)==(12)
+      │    ├── ordering: -22 opt(12,13,21) [actual: -22]
+      │    └── inner-join (hash)
+      │         ├── columns: tr.id:12!null tr.trid:13!null m.trid:21!null m.ts12:22!null rownum:25!null
+      │         ├── fd: (12)-->(13), (25)-->(12,13), (12)==(21), (21)==(12)
+      │         ├── unique-key
+      │         │    ├── columns: tr.id:12!null tr.trid:13!null rownum:25!null
+      │         │    ├── key: (25)
+      │         │    ├── fd: (12)-->(13), (25)-->(12,13)
+      │         │    └── project
+      │         │         ├── columns: tr.id:12!null tr.trid:13!null
+      │         │         ├── fd: (12)-->(13)
+      │         │         └── inner-join (hash)
+      │         │              ├── columns: tr.id:12!null tr.trid:13!null tr.str16:15!null trid:18!null
+      │         │              ├── multiplicity: left-rows(zero-or-more), right-rows(zero-or-one)
+      │         │              ├── fd: ()-->(15), (12)-->(13), (12)==(18), (18)==(12)
+      │         │              ├── select
+      │         │              │    ├── columns: tr.id:12!null tr.trid:13!null tr.str16:15!null
+      │         │              │    ├── key: (12)
+      │         │              │    ├── fd: ()-->(15), (12)-->(13)
+      │         │              │    ├── scan trrec [as=tr]
+      │         │              │    │    ├── columns: tr.id:12!null tr.trid:13!null tr.str16:15
+      │         │              │    │    ├── key: (12)
+      │         │              │    │    └── fd: (12)-->(13,15)
+      │         │              │    └── filters
+      │         │              │         └── tr.str16:15 = '12345' [outer=(15), constraints=(/15: [/'12345' - /'12345']; tight), fd=()-->(15)]
+      │         │              ├── project
+      │         │              │    ├── columns: trid:18!null
+      │         │              │    ├── inner-join (hash)
+      │         │              │    │    ├── columns: r.id:1!null r.str16:4!null tq.trid:8!null
+      │         │              │    │    ├── multiplicity: left-rows(zero-or-more), right-rows(zero-or-one)
+      │         │              │    │    ├── fd: ()-->(4), (1)==(8), (8)==(1)
+      │         │              │    │    ├── select
+      │         │              │    │    │    ├── columns: r.id:1!null r.str16:4!null
+      │         │              │    │    │    ├── key: (1)
+      │         │              │    │    │    ├── fd: ()-->(4)
+      │         │              │    │    │    ├── scan trrec [as=r]
+      │         │              │    │    │    │    ├── columns: r.id:1!null r.str16:4
+      │         │              │    │    │    │    ├── key: (1)
+      │         │              │    │    │    │    └── fd: (1)-->(4)
+      │         │              │    │    │    └── filters
+      │         │              │    │    │         └── r.str16:4 = '12345' [outer=(4), constraints=(/4: [/'12345' - /'12345']; tight), fd=()-->(4)]
+      │         │              │    │    ├── scan trtab4 [as=tq]
+      │         │              │    │    │    └── columns: tq.trid:8!null
+      │         │              │    │    └── filters
+      │         │              │    │         └── r.id:1 = tq.trid:8 [outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(8), (8)==(1)]
+      │         │              │    └── projections
+      │         │              │         └── tq.trid:8 [as=trid:18, outer=(8)]
+      │         │              └── filters
+      │         │                   └── tr.id:12 = trid:18 [outer=(12,18), constraints=(/12: (/NULL - ]; /18: (/NULL - ]), fd=(12)==(18), (18)==(12)]
+      │         ├── scan trm [as=m]
+      │         │    └── columns: m.trid:21!null m.ts12:22!null
+      │         └── filters
+      │              └── tr.id:12 = m.trid:21 [outer=(12,21), constraints=(/12: (/NULL - ]; /21: (/NULL - ]), fd=(12)==(21), (21)==(12)]
+      └── aggregations
+           ├── const-agg [as=tr.id:12, outer=(12)]
+           │    └── tr.id:12
+           └── const-agg [as=tr.trid:13, outer=(13)]
+                └── tr.trid:13
+
+# The filter on tr.str16 should be pushed into the val3 inner lateral join.
+norm expect=PushSelectIntoUniqueKey
+WITH
+  with2
+    AS (
+      SELECT
+        tq.trid, tq.dec1
+      FROM
+        trrec AS r INNER JOIN trtab4 AS tq ON r.id = tq.trid AND r.str16 = '12345'
+    )
+SELECT tr.id, tr.trid
+FROM
+  trrec AS tr
+  INNER JOIN LATERAL (
+      SELECT  q.dec1 FROM with2 AS q WHERE tr.id = q.trid
+    ) AS q ON true
+  INNER JOIN LATERAL (
+      SELECT
+        --tr.id, -- Previously, including this column allowed the filter on
+                 -- str16 to be pushed into the join, but this is no longer
+                 -- required.
+        m.ts12
+      FROM trm AS m WHERE tr.id = m.trid
+      ORDER BY m.ts12 DESC
+      LIMIT 100
+    ) AS val3 ON true
+WHERE
+  tr.str16 = '12345'
+;
+----
+project
+ ├── columns: id:12!null trid:13!null
+ ├── fd: (12)-->(13)
+ └── select
+      ├── columns: tr.id:12!null tr.trid:13!null m.trid:21!null m.ts12:22!null row_num:25!null rownum:26!null
+      ├── fd: (12)-->(13), (26)-->(12,13), (12)==(21), (21)==(12)
+      ├── window partition=(26) ordering=-22 opt(12-17,19,21,26)
+      │    ├── columns: tr.id:12!null tr.trid:13!null m.trid:21!null m.ts12:22!null row_num:25 rownum:26!null
+      │    ├── fd: (12)-->(13), (26)-->(12,13), (12)==(21), (21)==(12)
+      │    ├── inner-join (hash)
+      │    │    ├── columns: tr.id:12!null tr.trid:13!null m.trid:21!null m.ts12:22!null rownum:26!null
+      │    │    ├── fd: (12)-->(13), (26)-->(12,13), (12)==(21), (21)==(12)
+      │    │    ├── unique-key
+      │    │    │    ├── columns: tr.id:12!null tr.trid:13!null rownum:26!null
+      │    │    │    ├── key: (26)
+      │    │    │    ├── fd: (12)-->(13), (26)-->(12,13)
+      │    │    │    └── project
+      │    │    │         ├── columns: tr.id:12!null tr.trid:13!null
+      │    │    │         ├── fd: (12)-->(13)
+      │    │    │         └── inner-join (hash)
+      │    │    │              ├── columns: tr.id:12!null tr.trid:13!null tr.str16:15!null trid:18!null
+      │    │    │              ├── multiplicity: left-rows(zero-or-more), right-rows(zero-or-one)
+      │    │    │              ├── fd: ()-->(15), (12)-->(13), (12)==(18), (18)==(12)
+      │    │    │              ├── select
+      │    │    │              │    ├── columns: tr.id:12!null tr.trid:13!null tr.str16:15!null
+      │    │    │              │    ├── key: (12)
+      │    │    │              │    ├── fd: ()-->(15), (12)-->(13)
+      │    │    │              │    ├── scan trrec [as=tr]
+      │    │    │              │    │    ├── columns: tr.id:12!null tr.trid:13!null tr.str16:15
+      │    │    │              │    │    ├── key: (12)
+      │    │    │              │    │    └── fd: (12)-->(13,15)
+      │    │    │              │    └── filters
+      │    │    │              │         └── tr.str16:15 = '12345' [outer=(15), constraints=(/15: [/'12345' - /'12345']; tight), fd=()-->(15)]
+      │    │    │              ├── project
+      │    │    │              │    ├── columns: trid:18!null
+      │    │    │              │    ├── inner-join (hash)
+      │    │    │              │    │    ├── columns: r.id:1!null r.str16:4!null tq.trid:8!null
+      │    │    │              │    │    ├── multiplicity: left-rows(zero-or-more), right-rows(zero-or-one)
+      │    │    │              │    │    ├── fd: ()-->(4), (1)==(8), (8)==(1)
+      │    │    │              │    │    ├── select
+      │    │    │              │    │    │    ├── columns: r.id:1!null r.str16:4!null
+      │    │    │              │    │    │    ├── key: (1)
+      │    │    │              │    │    │    ├── fd: ()-->(4)
+      │    │    │              │    │    │    ├── scan trrec [as=r]
+      │    │    │              │    │    │    │    ├── columns: r.id:1!null r.str16:4
+      │    │    │              │    │    │    │    ├── key: (1)
+      │    │    │              │    │    │    │    └── fd: (1)-->(4)
+      │    │    │              │    │    │    └── filters
+      │    │    │              │    │    │         └── r.str16:4 = '12345' [outer=(4), constraints=(/4: [/'12345' - /'12345']; tight), fd=()-->(4)]
+      │    │    │              │    │    ├── scan trtab4 [as=tq]
+      │    │    │              │    │    │    └── columns: tq.trid:8!null
+      │    │    │              │    │    └── filters
+      │    │    │              │    │         └── r.id:1 = tq.trid:8 [outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(8), (8)==(1)]
+      │    │    │              │    └── projections
+      │    │    │              │         └── tq.trid:8 [as=trid:18, outer=(8)]
+      │    │    │              └── filters
+      │    │    │                   └── tr.id:12 = trid:18 [outer=(12,18), constraints=(/12: (/NULL - ]; /18: (/NULL - ]), fd=(12)==(18), (18)==(12)]
+      │    │    ├── scan trm [as=m]
+      │    │    │    └── columns: m.trid:21!null m.ts12:22!null
+      │    │    └── filters
+      │    │         └── tr.id:12 = m.trid:21 [outer=(12,21), constraints=(/12: (/NULL - ]; /21: (/NULL - ]), fd=(12)==(21), (21)==(12)]
+      │    └── windows
+      │         └── row-number [as=row_num:25]
+      └── filters
+           └── row_num:25 <= 100 [outer=(25), constraints=(/25: (/NULL - /100]; tight)]

--- a/pkg/sql/opt/norm/testdata/rules/with
+++ b/pkg/sql/opt/norm/testdata/rules/with
@@ -1334,7 +1334,7 @@ scalar-group-by
  │              │         ├── columns: i:6!null n:7!null rownum:11!null
  │              │         ├── multiplicity: left-rows(zero-or-more), right-rows(zero-or-one)
  │              │         ├── fd: ()-->(6,11)
- │              │         ├── ordinality
+ │              │         ├── unique-key
  │              │         │    ├── columns: i:6 rownum:11!null
  │              │         │    ├── cardinality: [1 - 1]
  │              │         │    ├── key: ()
@@ -1460,7 +1460,7 @@ scalar-group-by
  │              │    └── inner-join (cross)
  │              │         ├── columns: i:6!null n:7!null rownum:11!null
  │              │         ├── fd: (11)-->(6)
- │              │         ├── ordinality
+ │              │         ├── unique-key
  │              │         │    ├── columns: i:6 rownum:11!null
  │              │         │    ├── cardinality: [1 - ]
  │              │         │    ├── key: (11)
@@ -1677,7 +1677,7 @@ scalar-group-by
  │              │         ├── columns: i:6!null n:7!null rownum:11!null
  │              │         ├── multiplicity: left-rows(zero-or-more), right-rows(zero-or-one)
  │              │         ├── fd: ()-->(6,11)
- │              │         ├── ordinality
+ │              │         ├── unique-key
  │              │         │    ├── columns: i:6 rownum:11!null
  │              │         │    ├── cardinality: [1 - 1]
  │              │         │    ├── key: ()

--- a/pkg/sql/opt/norm/with_funcs.go
+++ b/pkg/sql/opt/norm/with_funcs.go
@@ -232,7 +232,7 @@ func (c *CustomFuncs) CanAddRecursiveLimit(
 	case *memo.WithScanExpr:
 		return t.With == withID
 	case *memo.ProjectExpr, *memo.SelectExpr, *memo.LimitExpr,
-		*memo.OrdinalityExpr, *memo.WindowExpr:
+		*memo.OrdinalityExpr, *memo.WindowExpr, *memo.UniqueKeyExpr:
 		// The operators never add rows to the input, although they can remove them.
 		// Therefore, a limit that applies to the input also applies to the output
 		// of these operators. In the case of a LimitExpr, we assume the limit is

--- a/pkg/sql/opt/ops/relational.opt
+++ b/pkg/sql/opt/ops/relational.opt
@@ -1244,6 +1244,19 @@ define ProjectSet {
     Zip ZipExpr
 }
 
+# UniqueKey adds a column to each row in its input containing a unique number.
+[Relational]
+define UniqueKey {
+    Input RelExpr
+    _ UniqueKeyPrivate
+}
+
+[Private]
+define UniqueKeyPrivate {
+    # ColID holds the id of the column introduced by this operator.
+    ColID ColumnID
+}
+
 # Window represents a window function. Window functions are operators which
 # allow computations that take into consideration other rows in the same result
 # set.

--- a/pkg/sql/opt/ordering/BUILD.bazel
+++ b/pkg/sql/opt/ordering/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "sort.go",
         "statement.go",
         "topk.go",
+        "uniquekey.go",
         "with.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/opt/ordering",

--- a/pkg/sql/opt/ordering/ordering.go
+++ b/pkg/sql/opt/ordering/ordering.go
@@ -311,6 +311,11 @@ func init() {
 		buildChildReqOrdering: exportBuildChildReqOrdering,
 		buildProvidedOrdering: noProvidedOrdering,
 	}
+	funcMap[opt.UniqueKeyOp] = funcs{
+		canProvideOrdering:    uniqueKeyCanProvideOrdering,
+		buildChildReqOrdering: uniqueKeyBuildChildReqOrdering,
+		buildProvidedOrdering: uniqueKeyBuildProvided,
+	}
 	funcMap[opt.WithOp] = funcs{
 		canProvideOrdering:    withCanProvideOrdering,
 		buildChildReqOrdering: withBuildChildReqOrdering,

--- a/pkg/sql/opt/ordering/uniquekey.go
+++ b/pkg/sql/opt/ordering/uniquekey.go
@@ -1,0 +1,34 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package ordering
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
+)
+
+func uniqueKeyCanProvideOrdering(expr memo.RelExpr, required *props.OrderingChoice) bool {
+	// UniqueKey operator can always pass through ordering to its input.
+	return true
+}
+
+func uniqueKeyBuildChildReqOrdering(
+	parent memo.RelExpr, required *props.OrderingChoice, childIdx int,
+) props.OrderingChoice {
+	// We can pass through any required ordering to the input.
+	return *required
+}
+
+func uniqueKeyBuildProvided(expr memo.RelExpr, required *props.OrderingChoice) opt.Ordering {
+	d := expr.(*memo.UniqueKeyExpr)
+	return d.Input.ProvidedPhysical().Ordering
+}

--- a/pkg/sql/opt/xform/coster.go
+++ b/pkg/sql/opt/xform/coster.go
@@ -593,6 +593,9 @@ func (c *coster) ComputeCost(candidate memo.RelExpr, required *physical.Required
 	case opt.ProjectSetOp:
 		cost = c.computeProjectSetCost(candidate.(*memo.ProjectSetExpr))
 
+	case opt.UniqueKeyOp:
+		cost = c.computeUniqueKeyCost(candidate.(*memo.UniqueKeyExpr))
+
 	case opt.ExplainOp:
 		// Technically, the cost of an Explain operation is independent of the cost
 		// of the underlying plan. However, we want to explain the plan we would get
@@ -1434,6 +1437,12 @@ func (c *coster) computeOrdinalityCost(ord *memo.OrdinalityExpr) memo.Cost {
 func (c *coster) computeProjectSetCost(projectSet *memo.ProjectSetExpr) memo.Cost {
 	// Add the CPU cost of emitting the rows.
 	cost := memo.Cost(projectSet.Relational().Statistics().RowCount) * cpuCostFactor
+	return cost
+}
+
+func (c *coster) computeUniqueKeyCost(uniqueKeyExpr *memo.UniqueKeyExpr) memo.Cost {
+	// Add the CPU cost of emitting the rows.
+	cost := memo.Cost(uniqueKeyExpr.Relational().Statistics().RowCount) * cpuCostFactor
 	return cost
 }
 

--- a/pkg/sql/opt/xform/physical_props.go
+++ b/pkg/sql/opt/xform/physical_props.go
@@ -172,7 +172,7 @@ func BuildChildPhysicalProps(
 			}
 		}
 
-	case opt.OrdinalityOp, opt.ProjectOp, opt.ProjectSetOp:
+	case opt.OrdinalityOp, opt.ProjectOp, opt.ProjectSetOp, opt.UniqueKeyOp:
 		childProps.LimitHint = parentProps.LimitHint
 
 	case opt.TopKOp:

--- a/pkg/sql/opt/xform/testdata/external/liquibase
+++ b/pkg/sql/opt/xform/testdata/external/liquibase
@@ -213,7 +213,7 @@ project
  │    │    │    │    │    │              └── objsubid:185 = 0 [outer=(185), constraints=(/185: [/0 - /0]; tight), fd=()-->(185)]
  │    │    │    │    │    └── scan kv_builtin_function_comments
  │    │    │    │    │         └── columns: crdb_internal.kv_builtin_function_comments.oid:181!null crdb_internal.kv_builtin_function_comments.description:182!null
- │    │    │    │    ├── ordinality
+ │    │    │    │    ├── unique-key
  │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.nspname:31!null spcname:37 c2.relname:50 n2.nspname:79 ci.relname:106 ftoptions:136 srvname:140 column172:172 rownum:192!null
  │    │    │    │    │    ├── immutable
  │    │    │    │    │    ├── key: (192)

--- a/pkg/sql/opt/xform/testdata/external/navicat
+++ b/pkg/sql/opt/xform/testdata/external/navicat
@@ -217,7 +217,7 @@ sort
       │    │    │    │    │    │              └── objsubid:185 = 0 [outer=(185), constraints=(/185: [/0 - /0]; tight), fd=()-->(185)]
       │    │    │    │    │    └── scan kv_builtin_function_comments
       │    │    │    │    │         └── columns: crdb_internal.kv_builtin_function_comments.oid:181!null crdb_internal.kv_builtin_function_comments.description:182!null
-      │    │    │    │    ├── ordinality
+      │    │    │    │    ├── unique-key
       │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.nspname:31!null spcname:37 c2.relname:50 n2.nspname:79 ci.relname:106 ftoptions:136 srvname:140 column172:172 rownum:192!null
       │    │    │    │    │    ├── immutable
       │    │    │    │    │    ├── key: (192)

--- a/pkg/sql/opt/xform/testdata/external/pgjdbc
+++ b/pkg/sql/opt/xform/testdata/external/pgjdbc
@@ -58,7 +58,7 @@ project
  │    │    │    │    ├── columns: t.oid:2!null t.typname:3!null t.typnamespace:4!null t.typtype:8 t.typbasetype:26 n.oid:34!null nspname:35!null objoid:86 classoid:87 description:89 c.oid:91 relname:92 relnamespace:93 n.oid:128 nspname:129 rownum:134!null
  │    │    │    │    ├── immutable
  │    │    │    │    ├── fd: (4)==(34), (34)==(4), (134)-->(2-4,8,26,34,35), (87)==(91), (91)==(87), (93)==(128), (128)==(93)
- │    │    │    │    ├── ordinality
+ │    │    │    │    ├── unique-key
  │    │    │    │    │    ├── columns: t.oid:2!null t.typname:3!null t.typnamespace:4!null t.typtype:8 t.typbasetype:26 n.oid:34!null nspname:35!null rownum:134!null
  │    │    │    │    │    ├── key: (134)
  │    │    │    │    │    ├── fd: (4)==(34), (34)==(4), (134)-->(2-4,8,26,34,35)


### PR DESCRIPTION
ops: add UniqueKeyExpr

This adds a `UniqueKeyExpr` which adds a column containing unique numbers
to any input. This is done to differentiate the operation added by
`EnsureKey`, which currently uses `OrdinalityExpr`, from a true
ordinality expression constructed for the WITH ORDINALITY SQL clause.
WITH ORDINALITY requires that rows receive a sequential numbering, and
the actual values returned matters, and if gotten wrong, means the query
returns incorrect results. This disallows certain operations from being
pushed into `OrdinalityExpr`, whereas `UniqueKeyExpr` should impose no
such restriction.

Informs: #109751

Release note: None

----
norm: push Select into UniqueKeyExpr

A join query with LIMIT 1 and a WHERE clause filter which could enable
constrained scan on a table index may perform a full scan the table,
and the optimizer may never consider query plans where the table is
read via a constrained index scan. Similar queries which project more
columns or expressions do consider constrained scans, because
normalization of the LIMIT portion of the query is delayed in that case
until the input to the LIMIT is a join expression.

The issue is that normalization rules such as TryDecorrelateLimitOne
inject a UniqueKey operation above a join, which prevents rules which
push a Select into a join from firing, such as PushSelectIntoJoinLeft,
which matches on a Select as the immediate parent of a join. The
expression tree may look like this:
```
├── select
│    ├── columns: tr.id:12!null tr.trid:13!null tr.str16:15!null rownum:25!null
│    ├── key: (25)
│    ├── fd: ()-->(15), (12)-->(13), (25)-->(12,13)
│    ├── unique-key
│    │    ├── columns: tr.id:12!null tr.trid:13!null tr.str16:15 rownum:25!null
│    │    ├── key: (25)
│    │    ├── fd: (12)-->(13,15), (25)-->(12,13,15)
│    │    └── project
│    │         ├── columns: tr.id:12!null tr.trid:13!null tr.str16:15
│    │         ├── fd: (12)-->(13,15)
│    │         └── left-join (hash)
│    │              ├── columns: tr.id:12!null tr.trid:13!null tr.str16:15 trid:18
│    │              ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-one)
│    │              ├── fd: (12)-->(13,15)
│    │              ├── scan trrec [as=tr]
│    │              │    ├── columns: tr.id:12!null tr.trid:13!null tr.str16:15
│    │              │    ├── key: (12)
│    │              │    └── fd: (12)-->(13,15)
│    │              ├── project
│    │              │    ├── columns: trid:18!null
...
│    │              │    └── projections
│    │└── tq.trid:8 [as=trid:18, outer=(8)]
│    │              └── filters
│    │                   └── tr.id:12 = trid:18 [outer=(12,18), constraints=(/12: (/NULL - ]; /18: (/NULL - ]), fd=(12)==(18), (18)==(12)]
│    └── filters
│         └── tr.str16:15 = '12345' [outer=(15), constraints=(/15: [/'12345' - /'12345']; tight), fd=()-->(15)]
```

The `unique-key` expression, in this case, was created by normalization
rule TryDecorrelateLimitOne to tag rows with a unique identifier so
duplicates can be removed later. We should be able to push the `select`
below this `unique-key`, because besides adding the unique identifier, it
is just passing rows through to the next operation.

The solution is to do just that, introduce a new normalization rule
which pushes a Select operation below a UniqueKey operation which was
created for duplicate row removal if the selection filter applies to
columns in the UniqueKey expression's input.

Epic: none
Fixes: #109751

Release note (bug fix): This patch fixes a performance issue in join
queries with a LIMIT clause, where the optimizer may fail to push a
WHERE clause filter into a join due to how the Limit operation is
internally rewritten, causing a full scan of the table referenced in the
filter.
