### PR TITLE
release-22.2: roachprod: azure gc cleans up empty clusters

### DIFF
--- a/pkg/roachprod/cloud/cluster_cloud.go
+++ b/pkg/roachprod/cloud/cluster_cloud.go
@@ -176,9 +176,14 @@ func namesFromVM(v vm.VM) (userName string, clusterName string, _ error) {
 	return parts[0], strings.Join(parts[:len(parts)-1], "-"), nil
 }
 
+// IsEmptyCluster returns true if a cluster has no resources.
+func (c *Cluster) IsEmptyCluster() bool {
+	return c.VMs[0].EmptyCluster
+}
+
 // ListCloud returns information about all instances (across all available
 // providers).
-func ListCloud(l *logger.Logger) (*Cloud, error) {
+func ListCloud(l *logger.Logger, options vm.ListOptions) (*Cloud, error) {
 	cloud := &Cloud{
 		Clusters: make(Clusters),
 	}
@@ -192,7 +197,7 @@ func ListCloud(l *logger.Logger) (*Cloud, error) {
 		provider := vm.Providers[providerName]
 		g.Go(func() error {
 			var err error
-			providerVMs[index], err = provider.List(l)
+			providerVMs[index], err = provider.List(l, options)
 			return err
 		})
 	}
@@ -210,8 +215,9 @@ func ListCloud(l *logger.Logger) (*Cloud, error) {
 			}
 
 			// Anything with an error gets tossed into the BadInstances slice, and we'll correct
-			// the problem later on.
-			if len(v.Errors) > 0 {
+			// the problem later on. Ignore empty clusters since BadInstances will be destroyed on
+			// the VM level. GC will destroy them instead.
+			if len(v.Errors) > 0 && !v.EmptyCluster {
 				cloud.BadInstances = append(cloud.BadInstances, v)
 				continue
 			}
@@ -239,7 +245,11 @@ func ListCloud(l *logger.Logger) (*Cloud, error) {
 	}
 
 	// Sort VMs for each cluster. We want to make sure we always have the same order.
+	// Also assert that no cluster can be empty.
 	for _, c := range cloud.Clusters {
+		if len(c.VMs) == 0 {
+			return nil, errors.Errorf("found no VMs in cluster %s", c.Name)
+		}
 		sort.Sort(c.VMs)
 	}
 

--- a/pkg/roachprod/cloud/gc.go
+++ b/pkg/roachprod/cloud/gc.go
@@ -42,7 +42,16 @@ type status struct {
 
 func (s *status) add(c *Cluster, now time.Time) {
 	exp := c.ExpiresAt()
-	if exp.After(now) {
+	// Clusters without VMs shouldn't exist and are likely dangling resources.
+	if c.IsEmptyCluster() {
+		// Give a one-hour grace period to avoid any race conditions where a cluster
+		// was created but the VMs are still initializing.
+		if now.After(c.CreatedAt.Add(time.Hour)) {
+			s.destroy = append(s.destroy, c)
+		} else {
+			s.good = append(s.good, c)
+		}
+	} else if exp.After(now) {
 		if exp.Before(now.Add(2 * time.Hour)) {
 			s.warn = append(s.warn, c)
 		} else {
@@ -305,8 +314,8 @@ func GCClusters(l *logger.Logger, cloud *Cloud, dryrun bool) error {
 	// Compile list of "bad vms" and destroy them.
 	var badVMs vm.List
 	for _, vm := range cloud.BadInstances {
-		// We only delete "bad vms" if they were created more than 1h ago.
-		if now.Sub(vm.CreatedAt) >= time.Hour {
+		// We skip fake VMs and only delete "bad vms" if they were created more than 1h ago.
+		if now.Sub(vm.CreatedAt) >= time.Hour && !vm.EmptyCluster {
 			badVMs = append(badVMs, vm)
 		}
 	}

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -252,7 +252,7 @@ func Sync(l *logger.Logger) (*cloud.Cloud, error) {
 	}
 	defer unlock()
 
-	cld, err := cloud.ListCloud(l)
+	cld, err := cloud.ListCloud(l, vm.ListOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -530,7 +530,7 @@ func Reset(l *logger.Logger, clusterName string) error {
 		return nil
 	}
 
-	cld, err := cloud.ListCloud(l)
+	cld, err := cloud.ListCloud(l, vm.ListOptions{})
 	if err != nil {
 		return err
 	}
@@ -624,7 +624,7 @@ func Extend(l *logger.Logger, clusterName string, lifetime time.Duration) error 
 	if err := LoadClusters(); err != nil {
 		return err
 	}
-	cld, err := cloud.ListCloud(l)
+	cld, err := cloud.ListCloud(l, vm.ListOptions{})
 	if err != nil {
 		return err
 	}
@@ -639,7 +639,7 @@ func Extend(l *logger.Logger, clusterName string, lifetime time.Duration) error 
 	}
 
 	// Reload the clusters and print details.
-	cld, err = cloud.ListCloud(l)
+	cld, err = cloud.ListCloud(l, vm.ListOptions{})
 	if err != nil {
 		return err
 	}
@@ -1134,7 +1134,7 @@ func Destroy(
 		if err != nil {
 			return err
 		}
-		cld, err = cloud.ListCloud(l)
+		cld, err = cloud.ListCloud(l, vm.ListOptions{IncludeEmptyClusters: true})
 		if err != nil {
 			return err
 		}
@@ -1164,7 +1164,7 @@ func Destroy(
 			}
 			if cld == nil {
 				var err error
-				cld, err = cloud.ListCloud(l)
+				cld, err = cloud.ListCloud(l, vm.ListOptions{IncludeEmptyClusters: true})
 				if err != nil {
 					return err
 				}
@@ -1182,7 +1182,12 @@ func destroyCluster(cld *cloud.Cloud, l *logger.Logger, clusterName string) erro
 	if !ok {
 		return fmt.Errorf("cluster %s does not exist", clusterName)
 	}
-	l.Printf("Destroying cluster %s with %d nodes", clusterName, len(c.VMs))
+	if c.IsEmptyCluster() {
+		l.Printf("Destroying empty cluster %s with 0 nodes", clusterName)
+	} else {
+		l.Printf("Destroying cluster %s with %d nodes", clusterName, len(c.VMs))
+	}
+
 	return cloud.DestroyCluster(c)
 }
 
@@ -1211,7 +1216,7 @@ func (e *ClusterAlreadyExistsError) Error() string {
 }
 
 func cleanupFailedCreate(l *logger.Logger, clusterName string) error {
-	cld, err := cloud.ListCloud(l)
+	cld, err := cloud.ListCloud(l, vm.ListOptions{IncludeEmptyClusters: true})
 	if err != nil {
 		return err
 	}
@@ -1258,7 +1263,7 @@ func Create(
 	}
 
 	if !isLocal {
-		cld, err := cloud.ListCloud(l)
+		cld, err := cloud.ListCloud(l, vm.ListOptions{})
 		if err != nil {
 			return err
 		}
@@ -1313,7 +1318,7 @@ func GC(l *logger.Logger, dryrun bool) error {
 	if err := LoadClusters(); err != nil {
 		return err
 	}
-	cld, err := cloud.ListCloud(l)
+	cld, err := cloud.ListCloud(l, vm.ListOptions{IncludeEmptyClusters: true})
 	if err == nil {
 		// GCClusters depends on ListCloud so only call it if ListCloud runs without errors
 		err = cloud.GCClusters(l, cld, dryrun)

--- a/pkg/roachprod/vm/aws/aws.go
+++ b/pkg/roachprod/vm/aws/aws.go
@@ -657,7 +657,7 @@ func (p *Provider) stsGetCallerIdentity() (string, error) {
 }
 
 // List is part of the vm.Provider interface.
-func (p *Provider) List(l *logger.Logger) (vm.List, error) {
+func (p *Provider) List(l *logger.Logger, opts vm.ListOptions) (vm.List, error) {
 	regions, err := p.allRegions(p.Config.availabilityZoneNames())
 	if err != nil {
 		return nil, err

--- a/pkg/roachprod/vm/azure/azure.go
+++ b/pkg/roachprod/vm/azure/azure.go
@@ -400,7 +400,7 @@ func (p *Provider) FindActiveAccount() (string, error) {
 
 // List implements the vm.Provider interface. This will query all
 // Azure VMs in the subscription and select those with a roachprod tag.
-func (p *Provider) List(l *logger.Logger) (vm.List, error) {
+func (p *Provider) List(l *logger.Logger, opts vm.ListOptions) (vm.List, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), p.OperationTimeout)
 	defer cancel()
 
@@ -419,6 +419,11 @@ func (p *Provider) List(l *logger.Logger) (vm.List, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// Keep track of which clusters we find through listing VMs.
+	// If later we need to list resource groups to find empty clusters,
+	// we want to make sure we don't add anything twice.
+	foundClusters := make(map[string]bool)
 
 	var ret vm.List
 	for it.NotDone() {
@@ -477,12 +482,88 @@ func (p *Provider) List(l *logger.Logger) (vm.List, error) {
 			return nil, err
 		}
 
+		parts := strings.Split(m.Name, "-")
+		clusterName := strings.Join(parts[:len(parts)-1], "-")
+		foundClusters[clusterName] = true
 		ret = append(ret, m)
 
 		if err := it.NextWithContext(ctx); err != nil {
 			return nil, err
 		}
+	}
 
+	// Azure allows for clusters to exist even if the attached VM no longer exists.
+	// Such a cluster won't be found by listing all azure VMs like above.
+	// Normally we don't want to access these clusters except for deleting them.
+	if opts.IncludeEmptyClusters {
+		groupsClient := resources.NewGroupsClient(*sub.SubscriptionID)
+		if groupsClient.Authorizer, err = p.getAuthorizer(); err != nil {
+			return nil, err
+		}
+
+		// List all resource groups for clusters under the subscription.
+		filter := fmt.Sprintf("tagName eq '%s'", vm.TagCluster)
+		it, err := groupsClient.ListComplete(ctx, filter, nil /* limit */)
+		if err != nil {
+			return nil, err
+		}
+
+		for it.NotDone() {
+			resourceGroup := it.Value()
+			if _, ok := resourceGroup.Tags[vm.TagRoachprod]; !ok {
+				if err := it.NextWithContext(ctx); err != nil {
+					return nil, err
+				}
+				continue
+			}
+
+			// Resource Groups have the name format "user-<clusterid>-<region>",
+			// while clusters have the name format "user-<clusterid>".
+			parts := strings.Split(*resourceGroup.Name, "-")
+			clusterName := strings.Join(parts[:len(parts)-1], "-")
+			if foundClusters[clusterName] {
+				if err := it.NextWithContext(ctx); err != nil {
+					return nil, err
+				}
+				continue
+			}
+
+			// The cluster does not have a VM, but roachprod assumes that this is not
+			// possible and implements providers on the VM level. A VM-less cluster will
+			// not have access to provider info or methods. To still allow this cluster to
+			// be deleted, we must create a fake VM, indicated by EmptyCluster.
+			m := vm.VM{
+				Name:       *resourceGroup.Name,
+				Provider:   ProviderName,
+				RemoteUser: remoteUser,
+				VPC:        "global",
+				// We add a fake availability-zone suffix since other roachprod
+				// code assumes particular formats. For example, "eastus2z".
+				Zone:         *resourceGroup.Location + "z",
+				EmptyCluster: true,
+			}
+
+			// We ignore any parsing errors here as roachprod tries to destroy "bad VMs".
+			// We don't want that since this is a fake VM, we need to destroy the resource
+			// group instead. This will be done by GC when it sees that no m.CreatedAt exists.
+			createdPtr := resourceGroup.Tags[vm.TagCreated]
+			if createdPtr != nil {
+				parsed, _ := time.Parse(time.RFC3339, *createdPtr)
+				m.CreatedAt = parsed
+			}
+
+			lifetimePtr := resourceGroup.Tags[vm.TagLifetime]
+			if lifetimePtr != nil {
+				parsed, _ := time.ParseDuration(*lifetimePtr)
+				m.Lifetime = parsed
+			}
+
+			ret = append(ret, m)
+
+			if err := it.NextWithContext(ctx); err != nil {
+				return nil, err
+			}
+		}
 	}
 
 	return ret, nil

--- a/pkg/roachprod/vm/flagstub/flagstub.go
+++ b/pkg/roachprod/vm/flagstub/flagstub.go
@@ -70,7 +70,7 @@ func (p *provider) FindActiveAccount() (string, error) {
 }
 
 // List implements vm.Provider and returns an empty list.
-func (p *provider) List(l *logger.Logger) (vm.List, error) {
+func (p *provider) List(l *logger.Logger, opts vm.ListOptions) (vm.List, error) {
 	return nil, nil
 }
 

--- a/pkg/roachprod/vm/gce/gcloud.go
+++ b/pkg/roachprod/vm/gce/gcloud.go
@@ -861,7 +861,7 @@ func (p *Provider) FindActiveAccount() (string, error) {
 }
 
 // List queries gcloud to produce a list of VM info objects.
-func (p *Provider) List(l *logger.Logger) (vm.List, error) {
+func (p *Provider) List(l *logger.Logger, opts vm.ListOptions) (vm.List, error) {
 	var vms vm.List
 	for _, prj := range p.GetProjects() {
 		args := []string{"compute", "instances", "list", "--project", prj, "--format", "json"}

--- a/pkg/roachprod/vm/local/local.go
+++ b/pkg/roachprod/vm/local/local.go
@@ -236,7 +236,7 @@ func (p *Provider) CreateProviderOpts() vm.ProviderOpts {
 }
 
 // List reports all the local cluster "VM" instances.
-func (p *Provider) List(l *logger.Logger) (vm.List, error) {
+func (p *Provider) List(l *logger.Logger, opts vm.ListOptions) (vm.List, error) {
 	var result vm.List
 	for _, clusterName := range p.clusters.Names() {
 		c := p.clusters[clusterName]

--- a/pkg/roachprod/vm/vm.go
+++ b/pkg/roachprod/vm/vm.go
@@ -110,6 +110,11 @@ type VM struct {
 
 	// LocalClusterName is only set for VMs in a local cluster.
 	LocalClusterName string `json:"local_cluster_name,omitempty"`
+
+	// EmptyCluster indicates that the VM does not exist. Azure allows for empty
+	// clusters, but roachprod does not allow VM-less clusters except when deleting them.
+	// A fake VM will be used in this scenario.
+	EmptyCluster bool
 }
 
 // Name generates the name for the i'th node in a cluster.
@@ -256,6 +261,10 @@ type ProviderOpts interface {
 	ConfigureClusterFlags(*pflag.FlagSet, MultipleProjectsOption)
 }
 
+type ListOptions struct {
+	IncludeEmptyClusters bool
+}
+
 // A Provider is a source of virtual machines running on some hosting platform.
 type Provider interface {
 	CreateProviderOpts() ProviderOpts
@@ -270,7 +279,7 @@ type Provider interface {
 	Extend(vms List, lifetime time.Duration) error
 	// Return the account name associated with the provider
 	FindActiveAccount() (string, error)
-	List(l *logger.Logger) (List, error)
+	List(l *logger.Logger, opts ListOptions) (List, error)
 	// The name of the Provider, which will also surface in the top-level Providers map.
 	Name() string
 


### PR DESCRIPTION
Backport 1/1 commits from #109438.

/cc @cockroachdb/release

---

Azure allows for clusters to exist with no attached VM, which roachprod assumes is not possible. This would occur if azure.create failed after creating a resource group but before creating a VM. Roachprod GC only searches for VMs when searching for clusters, so these VM-less clusters would never be found and cleaned up.

This change adds the ability to list empty clusters by querying resource groups instead of VMs. This is used by GC and destroy jobs to correctly identify and cleanup these dangling resources.

Epic: https://cockroachlabs.atlassian.net/browse/CRDB-3373
Release note: None

---

Release justification: infra changes
