### PR TITLE
release-22.2: ui: load table stats on database tables page

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/databaseDetailsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/databaseDetailsPage.tsx
@@ -321,6 +321,7 @@ export class DatabaseDetailsPage extends React.Component<
 
   private refresh(): void {
     let lastDetailsError: Error;
+    let lastStatsError: Error;
     // Load everything by default
     let filteredTables = this.props.tables;
 
@@ -363,6 +364,23 @@ export class DatabaseDetailsPage extends React.Component<
           table.details.lastError?.name === "GetDatabaseInfoError")
       ) {
         this.props.refreshTableDetails(this.props.name, table.name);
+      }
+
+      if (table.stats.lastError !== undefined) {
+        lastStatsError = table.stats.lastError;
+      }
+      if (
+        lastStatsError &&
+        this.state.lastStatsError?.name != lastStatsError?.name
+      ) {
+        this.setState({ lastStatsError: lastStatsError });
+      }
+      if (
+        !table.stats.loaded &&
+        !table.stats.loading &&
+        table.stats.lastError === undefined
+      ) {
+        return this.props.refreshTableStats(this.props.name, table.name);
       }
     });
   }


### PR DESCRIPTION
This functionality was mistakenly removed in #103860.

Epic: none
Release note (bug fix): Fixes a bug that prevented table stats from loading on the database table page.

Release justification: bug fix