### PR TITLE
release-23.1: storage: improve logging during range descriptor iteration

### DIFF
--- a/pkg/kv/kvpb/api.go
+++ b/pkg/kv/kvpb/api.go
@@ -1902,31 +1902,38 @@ func (c *TenantConsumption) Sub(other *TenantConsumption) {
 	}
 }
 
-func humanizePointCount(n uint64) redact.SafeString {
-	return redact.SafeString(humanize.SI(float64(n), ""))
+func humanizeCount(n uint64) redact.SafeString {
+	value, prefix := humanize.ComputeSI(float64(n))
+	return redact.SafeString(humanize.Ftoa(value) + prefix)
 }
 
 // SafeFormat implements redact.SafeFormatter.
 func (s *ScanStats) SafeFormat(w redact.SafePrinter, _ rune) {
-	w.Printf("scan stats: stepped %d times (%d internal); seeked %d times (%d internal); "+
+	w.Printf("scan stats: stepped %s times (%s internal); seeked %s times (%s internal); "+
 		"block-bytes: (total %s, cached %s); "+
 		"points: (count %s, key-bytes %s, value-bytes %s, tombstoned: %s) "+
 		"ranges: (count %s), (contained-points %s, skipped-points %s) "+
-		"evaluated requests: %d gets, %d scans, %d reverse scans",
-		s.NumInterfaceSteps, s.NumInternalSteps, s.NumInterfaceSeeks, s.NumInternalSeeks,
+		"evaluated requests: %s gets, %s scans, %s reverse scans",
+		humanizeCount(s.NumInterfaceSteps),
+		humanizeCount(s.NumInternalSteps),
+		humanizeCount(s.NumInterfaceSeeks),
+		humanizeCount(s.NumInternalSeeks),
 		humanizeutil.IBytes(int64(s.BlockBytes)),
 		humanizeutil.IBytes(int64(s.BlockBytesInCache)),
-		humanizePointCount(s.PointCount),
+		humanizeCount(s.PointCount),
 		humanizeutil.IBytes(int64(s.KeyBytes)),
 		humanizeutil.IBytes(int64(s.ValueBytes)),
-		humanizePointCount(s.PointsCoveredByRangeTombstones),
-		humanizePointCount(s.RangeKeyCount),
-		humanizePointCount(s.RangeKeyContainedPoints),
-		humanizePointCount(s.RangeKeySkippedPoints),
-		s.NumGets, s.NumScans, s.NumReverseScans)
+		humanizeCount(s.PointsCoveredByRangeTombstones),
+		humanizeCount(s.RangeKeyCount),
+		humanizeCount(s.RangeKeyContainedPoints),
+		humanizeCount(s.RangeKeySkippedPoints),
+		humanizeCount(s.NumGets),
+		humanizeCount(s.NumScans),
+		humanizeCount(s.NumReverseScans),
+	)
 	if s.SeparatedPointCount != 0 {
 		w.Printf(" separated: (count: %s, bytes: %s, bytes-fetched: %s)",
-			humanizePointCount(s.SeparatedPointCount),
+			humanizeCount(s.SeparatedPointCount),
 			humanizeutil.IBytes(int64(s.SeparatedPointValueBytes)),
 			humanizeutil.IBytes(int64(s.SeparatedPointValueBytesFetched)))
 	}

--- a/pkg/kv/kvserver/kvstorage/BUILD.bazel
+++ b/pkg/kv/kvserver/kvstorage/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
         "//pkg/util/iterutil",
         "//pkg/util/log",
         "//pkg/util/protoutil",
+        "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_redact//:redact",
         "@io_etcd_go_raft_v3//raftpb",

--- a/pkg/kv/kvserver/kvstorage/init.go
+++ b/pkg/kv/kvserver/kvstorage/init.go
@@ -14,8 +14,10 @@ import (
 	"bytes"
 	"context"
 	"sort"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/logstore"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/stateloader"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -24,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/iterutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/redact"
 	"go.etcd.io/raft/v3/raftpb"
@@ -244,7 +247,7 @@ func ReadStoreIdent(ctx context.Context, eng storage.Engine) (roachpb.StoreIdent
 func IterateRangeDescriptorsFromDisk(
 	ctx context.Context, reader storage.Reader, fn func(desc roachpb.RangeDescriptor) error,
 ) error {
-	log.Event(ctx, "beginning range descriptor iteration")
+	log.Info(ctx, "beginning range descriptor iteration")
 	// MVCCIterator over all range-local key-based data.
 	start := keys.RangeDescriptorKey(roachpb.RKeyMin)
 	end := keys.RangeDescriptorKey(roachpb.RKeyMax)
@@ -252,7 +255,25 @@ func IterateRangeDescriptorsFromDisk(
 	allCount := 0
 	matchCount := 0
 	bySuffix := make(map[redact.RedactableString]int)
+
+	var scanStats kvpb.ScanStats
+	opts := storage.MVCCScanOptions{
+		Inconsistent: true,
+		ScanStats:    &scanStats,
+	}
+	lastReportTime := timeutil.Now()
 	kvToDesc := func(kv roachpb.KeyValue) error {
+		const reportPeriod = 15 * time.Second
+		if timeutil.Since(lastReportTime) >= reportPeriod {
+			// Note: MVCCIterate scans and buffers 1000 keys at a time which could
+			// make the scan stats confusing. However, because this callback can't
+			// take a long time, it's very unlikely that we will log twice for the
+			// same batch of keys.
+			log.Infof(ctx, "range descriptor iteration in progress: %d keys, %d range descriptors (by suffix: %v); %v",
+				allCount, matchCount, bySuffix, &scanStats)
+			lastReportTime = timeutil.Now()
+		}
+
 		allCount++
 		// Only consider range metadata entries; ignore others.
 		startKey, suffix, _, err := keys.DecodeRangeKey(kv.Key)
@@ -267,7 +288,7 @@ func IterateRangeDescriptorsFromDisk(
 		if err := kv.Value.GetProto(&desc); err != nil {
 			return err
 		}
-		// Descriptor for range `[a,z)` must be found at `/rdsc/a`.
+		// Descriptor for range `[a,z)` must be found at `/Local/Range/a/RangeDescriptor`.
 		if !startKey.Equal(desc.StartKey.AsRawKey()) {
 			return errors.AssertionFailedf("descriptor stored at %s but has StartKey %s",
 				kv.Key, desc.StartKey)
@@ -286,10 +307,9 @@ func IterateRangeDescriptorsFromDisk(
 		return err
 	}
 
-	_, err := storage.MVCCIterate(ctx, reader, start, end, hlc.MaxTimestamp,
-		storage.MVCCScanOptions{Inconsistent: true}, kvToDesc)
-	log.Eventf(ctx, "iterated over %d keys to find %d range descriptors (by suffix: %v)",
-		allCount, matchCount, bySuffix)
+	_, err := storage.MVCCIterate(ctx, reader, start, end, hlc.MaxTimestamp, opts, kvToDesc)
+	log.Infof(ctx, "range descriptor iteration done: %d keys, %d range descriptors (by suffix: %v); %s",
+		allCount, matchCount, bySuffix, &scanStats)
 	return err
 }
 

--- a/pkg/kv/kvserver/kvstorage/testdata/init
+++ b/pkg/kv/kvserver/kvstorage/testdata/init
@@ -27,7 +27,7 @@ r6/60: uninitialized
 r7/70: r7:{a-c} [(n1,s1):70, next=71, gen=0]
 r8/80: r8:{c-f} [(n1,s1):80, next=81, gen=0]
 beginning range descriptor iteration
-iterated over 2 keys to find 2 range descriptors (by suffix: map[rdsc:2])
+range descriptor iteration done: 2 keys, 2 range descriptors (by suffix: map[rdsc:2]); scan stats: <redacted>
 removed legacy uninitialized replica for r5
 backfilled replicaID for initialized replica r7/70
 
@@ -38,4 +38,4 @@ r6/60: uninitialized
 r7/70: r7:{a-c} [(n1,s1):70, next=71, gen=0]
 r8/80: r8:{c-f} [(n1,s1):80, next=81, gen=0]
 beginning range descriptor iteration
-iterated over 2 keys to find 2 range descriptors (by suffix: map[rdsc:2])
+range descriptor iteration done: 2 keys, 2 range descriptors (by suffix: map[rdsc:2]); scan stats: <redacted>


### PR DESCRIPTION
#### kvpb: improve ScanStats string

The ScanStats string has an extraneous space for counts. This commit
fixes this and uses the humanize function for all counts.

Release note: None
Epic: none

#### storage: improve logging during range descriptor iteration

We use `log.Event` during range descriptor iteration which happens
while the node starts; traces are borderline useless here because the
server is not initialized yet.

We switch to regular logs and improve the output to show scan stats
and log updates periodically when the iteration takes a long time.

Epic: none
Release note: None

Release justification: we have seen cases of slow range descriptor iteration on startup; no logs are printed during this process (with #109518 making things more confusing), and we don't have much info as to why the process was slow. This PR improves the logging in this case.
