### PR TITLE
kv,enginepb: subject intent resolution to admission control

### DIFF
--- a/pkg/ccl/kvccl/kvfollowerreadsccl/followerreads_test.go
+++ b/pkg/ccl/kvccl/kvfollowerreadsccl/followerreads_test.go
@@ -98,7 +98,7 @@ func TestCanSendToFollower(t *testing.T) {
 	future := clock.Now().Add(2*clock.MaxOffset().Nanoseconds(), 0)
 
 	txn := func(ts hlc.Timestamp) *roachpb.Transaction {
-		txn := roachpb.MakeTransaction("txn", nil, 0, 0, ts, 0, 1)
+		txn := roachpb.MakeTransaction("txn", nil, 0, 0, ts, 0, 1, 0)
 		return &txn
 	}
 	withWriteTimestamp := func(txn *roachpb.Transaction, ts hlc.Timestamp) *roachpb.Transaction {

--- a/pkg/kv/BUILD.bazel
+++ b/pkg/kv/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "kv",
     srcs = [
+        "admission.go",
         "batch.go",
         "db.go",
         "doc.go",
@@ -51,6 +52,7 @@ go_test(
     name = "kv_test",
     size = "medium",
     srcs = [
+        "admission_test.go",
         "client_test.go",
         "db_test.go",
         "main_test.go",
@@ -85,6 +87,7 @@ go_test(
         "//pkg/testutils/skip",
         "//pkg/testutils/sqlutils",
         "//pkg/testutils/testcluster",
+        "//pkg/util/admission/admissionpb",
         "//pkg/util/encoding",
         "//pkg/util/hlc",
         "//pkg/util/leaktest",

--- a/pkg/kv/admission.go
+++ b/pkg/kv/admission.go
@@ -1,0 +1,69 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package kv
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb"
+)
+
+// AdmissionHeaderForLockUpdateForTxn constructs the admission header for the
+// given LockUpdate being done by txn.
+//
+// TODO(sumeer): We don't have a way of injecting TenantID, since the TenantID
+// is decided in rpc.kvAuth. The RPC will be sent from one storage server to
+// another, so it will run with the SystemTenantID, which is not desirable for
+// multi-tenant CockroachDB. We should be deciding the TenantID based on which
+// tenant the range belongs to.
+func AdmissionHeaderForLockUpdateForTxn(txn *roachpb.Transaction) kvpb.AdmissionHeader {
+	return kvpb.AdmissionHeader{
+		Priority: int32(admissionpb.AdjustedPriorityWhenHoldingLocks(admissionpb.WorkPriority(
+			txn.AdmissionPriority))),
+		CreateTime: txn.MinTimestamp.WallTime,
+		Source:     kvpb.AdmissionHeader_ROOT_KV,
+	}
+}
+
+// AdmissionHeaderForBypass alters the admission header so that admission
+// control can be bypassed.
+func AdmissionHeaderForBypass(h kvpb.AdmissionHeader) kvpb.AdmissionHeader {
+	h.Source = kvpb.AdmissionHeader_OTHER
+	return h
+}
+
+// MergeAdmissionHeaderForBatch merges admission headers to pick the highest
+// priority and oldest CreateTime.
+//
+// TODO(sumeer): the oldest CreateTime is based on the assumption of FIFO
+// ordering for the same priority, and does not play well with epoch-LIFO. But
+// no one is using epoch-LIFO in production, so this is ok for now.
+func MergeAdmissionHeaderForBatch(
+	bh kvpb.AdmissionHeader, h kvpb.AdmissionHeader,
+) kvpb.AdmissionHeader {
+	// kvpb.AdmissionHeader_OTHER bypasses admission, so prefer that.
+	if bh.Source == kvpb.AdmissionHeader_OTHER {
+		return bh
+	}
+	if h.Source == kvpb.AdmissionHeader_OTHER {
+		return h
+	}
+	if h.Priority > bh.Priority {
+		return h
+	} else if h.Priority < bh.Priority {
+		return bh
+	}
+	// h.Priority == bh.Priority
+	if bh.CreateTime > h.CreateTime {
+		return h
+	}
+	return bh
+}

--- a/pkg/kv/admission_test.go
+++ b/pkg/kv/admission_test.go
@@ -1,0 +1,67 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package kv
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAdmissionHeader(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	txn := roachpb.MakeTransaction("test", []byte("key"), 0, 0, hlc.Timestamp{WallTime: 10},
+		0, 0, admissionpb.UserHighPri)
+	ahHighPri := AdmissionHeaderForLockUpdateForTxn(&txn)
+	require.Equal(t, kvpb.AdmissionHeader{
+		// Priority bumped from UserHighPri to LockingUserHighPri to give priority to
+		// intent resolution.
+		Priority:   int32(admissionpb.LockingUserHighPri),
+		CreateTime: 10,
+		Source:     kvpb.AdmissionHeader_ROOT_KV,
+	}, ahHighPri)
+
+	ahBypass := AdmissionHeaderForBypass(ahHighPri)
+	require.Equal(t, kvpb.AdmissionHeader_OTHER, ahBypass.Source)
+
+	require.Equal(t, ahBypass, MergeAdmissionHeaderForBatch(ahHighPri, ahBypass))
+
+	txnAt20 := txn
+	txnAt20.MinTimestamp = hlc.Timestamp{WallTime: 20}
+	ahHighPriAt20 := AdmissionHeaderForLockUpdateForTxn(&txnAt20)
+	require.Equal(t, kvpb.AdmissionHeader{
+		Priority:   int32(admissionpb.LockingUserHighPri),
+		CreateTime: 20,
+		Source:     kvpb.AdmissionHeader_ROOT_KV,
+	}, ahHighPriAt20)
+	require.Equal(t, ahHighPri, MergeAdmissionHeaderForBatch(ahHighPriAt20, ahHighPri))
+
+	txnAt5 := txn
+	txnAt5.MinTimestamp = hlc.Timestamp{WallTime: 5}
+	txnAt5.AdmissionPriority = int32(admissionpb.LowPri)
+	ahLowPriAt5 := AdmissionHeaderForLockUpdateForTxn(&txnAt5)
+	require.Equal(t, kvpb.AdmissionHeader{
+		// Priority bumped from LowPri to LockingNormalPri to give priority to
+		// intent resolution.
+		Priority:   int32(admissionpb.LockingNormalPri),
+		CreateTime: 5,
+		Source:     kvpb.AdmissionHeader_ROOT_KV,
+	}, ahLowPriAt5)
+	require.Equal(t, ahHighPri, MergeAdmissionHeaderForBatch(ahHighPri, ahLowPriAt5))
+}

--- a/pkg/kv/client_test.go
+++ b/pkg/kv/client_test.go
@@ -944,7 +944,7 @@ func TestNodeIDAndObservedTimestamps(t *testing.T) {
 			now := db.Clock().NowAsClockTimestamp()
 			kvTxn := roachpb.MakeTransaction(
 				"unnamed", nil /* baseKey */, isolation.Serializable, roachpb.NormalUserPriority,
-				now.ToTimestamp(), db.Clock().MaxOffset().Nanoseconds(), int32(test.nodeID))
+				now.ToTimestamp(), db.Clock().MaxOffset().Nanoseconds(), int32(test.nodeID), 0)
 			txn := kv.NewTxnFromProto(ctx, db, test.nodeID, now, test.typ, &kvTxn)
 			ots := txn.TestingCloneTxn().ObservedTimestamps
 			if (len(ots) == 1 && ots[0].NodeID == test.nodeID) != test.expObserved {

--- a/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
@@ -78,7 +78,7 @@ func TestRangeLookupWithOpenTransaction(t *testing.T) {
 	// engine.
 	key := testutils.MakeKey(keys.Meta1Prefix, roachpb.KeyMax)
 	now := s.Clock().Now()
-	txn := roachpb.MakeTransaction("txn", roachpb.Key("foobar"), isolation.Serializable, 0, now, 0, int32(s.SQLInstanceID()))
+	txn := roachpb.MakeTransaction("txn", roachpb.Key("foobar"), isolation.Serializable, 0, now, 0, int32(s.SQLInstanceID()), 0)
 	if err := storage.MVCCPutProto(context.Background(), s.Engines()[0], key, now, &roachpb.RangeDescriptor{}, storage.MVCCWriteOptions{Txn: &txn}); err != nil {
 		t.Fatal(err)
 	}
@@ -1230,7 +1230,7 @@ func TestMultiRangeScanDeleteRange(t *testing.T) {
 	}
 
 	now := s.Clock().NowAsClockTimestamp()
-	txnProto := roachpb.MakeTransaction("MyTxn", nil, isolation.Serializable, 0, now.ToTimestamp(), 0, int32(s.SQLInstanceID()))
+	txnProto := roachpb.MakeTransaction("MyTxn", nil, isolation.Serializable, 0, now.ToTimestamp(), 0, int32(s.SQLInstanceID()), 0)
 	txn := kv.NewTxnFromProto(ctx, db, s.NodeID(), now, kv.RootTxn, &txnProto)
 
 	scan := kvpb.NewScan(writes[0], writes[len(writes)-1].Next(), false)

--- a/pkg/kv/kvclient/kvcoord/dist_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_test.go
@@ -618,7 +618,7 @@ func TestImmutableBatchArgs(t *testing.T) {
 
 	txn := roachpb.MakeTransaction(
 		"test", nil /* baseKey */, isolation.Serializable, roachpb.NormalUserPriority,
-		clock.Now(), clock.MaxOffset().Nanoseconds(), int32(ds.getNodeID()),
+		clock.Now(), clock.MaxOffset().Nanoseconds(), int32(ds.getNodeID()), 0,
 	)
 	origTxnTs := txn.WriteTimestamp
 
@@ -2458,6 +2458,7 @@ func TestMultiRangeGapReverse(t *testing.T) {
 		clock.Now(),
 		0, // maxOffsetNs
 		1, // coordinatorNodeID
+		0,
 	)
 
 	ba := &kvpb.BatchRequest{}
@@ -3264,7 +3265,7 @@ func TestParallelCommitsDetectIntentMissingCause(t *testing.T) {
 	key := roachpb.Key("a")
 	txn := roachpb.MakeTransaction(
 		"test", key, isolation.Serializable, roachpb.NormalUserPriority,
-		clock.Now(), clock.MaxOffset().Nanoseconds(), 1, /* coordinatorNodeID */
+		clock.Now(), clock.MaxOffset().Nanoseconds(), 1 /* coordinatorNodeID */, 0,
 	)
 
 	txnRecordPresent := true
@@ -3651,7 +3652,7 @@ func TestMultipleErrorsMerged(t *testing.T) {
 
 	txn := roachpb.MakeTransaction(
 		"test", nil /* baseKey */, isolation.Serializable, roachpb.NormalUserPriority,
-		clock.Now(), clock.MaxOffset().Nanoseconds(), 1, /* coordinatorNodeID */
+		clock.Now(), clock.MaxOffset().Nanoseconds(), 1 /* coordinatorNodeID */, 0,
 	)
 	// We're also going to check that the highest bumped WriteTimestamp makes it
 	// to the merged error.

--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender_test.go
@@ -937,15 +937,7 @@ func testTxnCoordSenderTxnUpdatedOnError(t *testing.T, isoLevel isolation.Level)
 			db := kv.NewDB(ambient, tsf, clock, stopper)
 			key := roachpb.Key("test-key")
 			now := clock.NowAsClockTimestamp()
-			origTxnProto := roachpb.MakeTransaction(
-				"test txn",
-				key,
-				isoLevel,
-				roachpb.UserPriority(0),
-				now.ToTimestamp(),
-				clock.MaxOffset().Nanoseconds(),
-				0, /* coordinatorNodeID */
-			)
+			origTxnProto := roachpb.MakeTransaction("test txn", key, isoLevel, roachpb.UserPriority(0), now.ToTimestamp(), clock.MaxOffset().Nanoseconds(), 0, 0)
 			// TODO(andrei): I've monkeyed with the priorities on this initial
 			// Transaction to keep the test happy from a previous version in which the
 			// Transaction was not initialized before use (which became insufficient

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_pipeliner_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_pipeliner_test.go
@@ -101,7 +101,7 @@ func makeMockTxnPipeliner(iter condensableSpanSetRangeIterator) (txnPipeliner, *
 
 func makeTxnProto() roachpb.Transaction {
 	return roachpb.MakeTransaction("test", []byte("key"), isolation.Serializable, 0,
-		hlc.Timestamp{WallTime: 10}, 0 /* maxOffsetNs */, 0 /* coordinatorNodeID */)
+		hlc.Timestamp{WallTime: 10}, 0 /* maxOffsetNs */, 0 /* coordinatorNodeID */, 0)
 }
 
 // TestTxnPipeliner1PCTransaction tests that the writes performed by 1PC

--- a/pkg/kv/kvpb/BUILD.bazel
+++ b/pkg/kv/kvpb/BUILD.bazel
@@ -30,6 +30,7 @@ go_library(
         "//pkg/kv/kvserver/concurrency/lock",
         "//pkg/roachpb",
         "//pkg/storage/enginepb",
+        "//pkg/util/admission/admissionpb",
         "//pkg/util/buildutil",
         "//pkg/util/caller",
         "//pkg/util/hlc",

--- a/pkg/kv/kvpb/api.proto
+++ b/pkg/kv/kvpb/api.proto
@@ -2825,6 +2825,9 @@ message BoundedStalenessHeader {
 // request.
 message AdmissionHeader {
   // Priority is utilized within a tenant. See admission.WorkPriority.
+  //
+  // TODO(sumeer): Use gogoproto.customtype to make this
+  // admissionpb.WorkPriority.
   int32 priority = 1;
   // CreateTime is equivalent to Time.UnixNano() at the creation time of this
   // request or a parent request. See admission.WorkInfo.Priority for details.

--- a/pkg/kv/kvpb/batch_test.go
+++ b/pkg/kv/kvpb/batch_test.go
@@ -389,7 +389,7 @@ func TestBatchResponseCombine(t *testing.T) {
 	{
 		txn := roachpb.MakeTransaction(
 			"test", nil /* baseKey */, isolation.Serializable, roachpb.NormalUserPriority,
-			hlc.Timestamp{WallTime: 123}, 0 /* baseKey */, 99, /* coordinatorNodeID */
+			hlc.Timestamp{WallTime: 123}, 0 /* baseKey */, 99 /* coordinatorNodeID */, 0,
 		)
 		brTxn := &BatchResponse{
 			BatchResponse_Header: BatchResponse_Header{

--- a/pkg/kv/kvpb/data.go
+++ b/pkg/kv/kvpb/data.go
@@ -13,6 +13,7 @@ package kvpb
 
 import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/errors"
 )
@@ -69,6 +70,7 @@ func PrepareTransactionForRetry(
 			now.ToTimestamp(),
 			clock.MaxOffset().Nanoseconds(),
 			txn.CoordinatorNodeID,
+			admissionpb.WorkPriority(txn.AdmissionPriority),
 		)
 		// Use the priority communicated back by the server.
 		txn.Priority = errTxnPri

--- a/pkg/kv/kvpb/data_test.go
+++ b/pkg/kv/kvpb/data_test.go
@@ -31,7 +31,7 @@ func testPrepareTransactionForRetry(t *testing.T, isoLevel isolation.Level) {
 	ts1 := hlc.Timestamp{WallTime: 1}
 	ts2 := hlc.Timestamp{WallTime: 2}
 	tsClock := hlc.Timestamp{WallTime: 3}
-	txn := roachpb.MakeTransaction("test", nil, isoLevel, -1, ts1, 0, 99)
+	txn := roachpb.MakeTransaction("test", nil, isoLevel, -1, ts1, 0, 99, 0)
 	txn2ID := uuid.MakeV4() // used if txn is aborted
 	tests := []struct {
 		name   string
@@ -167,7 +167,7 @@ func TestTransactionRefreshTimestamp(t *testing.T) {
 func testTransactionRefreshTimestamp(t *testing.T, isoLevel isolation.Level) {
 	ts1 := hlc.Timestamp{WallTime: 1}
 	ts2 := hlc.Timestamp{WallTime: 2}
-	txn := roachpb.MakeTransaction("test", nil, isoLevel, 1, ts1, 0, 99)
+	txn := roachpb.MakeTransaction("test", nil, isoLevel, 1, ts1, 0, 99, 0)
 	tests := []struct {
 		name  string
 		err   *Error

--- a/pkg/kv/kvpb/errors_test.go
+++ b/pkg/kv/kvpb/errors_test.go
@@ -55,7 +55,7 @@ func TestNewErrorNil(t *testing.T) {
 // TestSetTxn verifies that SetTxn updates the error message.
 func TestSetTxn(t *testing.T) {
 	e := NewError(NewTransactionAbortedError(ABORT_REASON_ABORTED_RECORD_FOUND))
-	txn := roachpb.MakeTransaction("test", roachpb.Key("a"), isolation.Serializable, 1, hlc.Timestamp{}, 0, 99)
+	txn := roachpb.MakeTransaction("test", roachpb.Key("a"), isolation.Serializable, 1, hlc.Timestamp{}, 0, 99, 0)
 	e.SetTxn(&txn)
 	if !strings.HasPrefix(
 		e.String(), "TransactionAbortedError(ABORT_REASON_ABORTED_RECORD_FOUND): \"test\"") {
@@ -174,7 +174,7 @@ func TestErrorRedaction(t *testing.T) {
 			hlc.Timestamp{WallTime: 2},
 			hlc.ClockTimestamp{WallTime: 1, Logical: 2},
 		))
-		txn := roachpb.MakeTransaction("foo", roachpb.Key("bar"), isolation.Serializable, 1, hlc.Timestamp{WallTime: 1}, 1, 99)
+		txn := roachpb.MakeTransaction("foo", roachpb.Key("bar"), isolation.Serializable, 1, hlc.Timestamp{WallTime: 1}, 1, 99, 0)
 		txn.ID = uuid.Nil
 		txn.Priority = 1234
 		wrappedPErr.UnexposedTxn = &txn

--- a/pkg/kv/kvpb/string_test.go
+++ b/pkg/kv/kvpb/string_test.go
@@ -40,6 +40,7 @@ func TestBatchRequestString(t *testing.T) {
 		hlc.Timestamp{}, // now
 		0,               // maxOffsetNs
 		99,              // coordinatorNodeID
+		0,
 	)
 	txn.ID = uuid.NamespaceDNS
 	ba.Txn = &txn

--- a/pkg/kv/kvserver/batcheval/cmd_add_sstable_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_add_sstable_test.go
@@ -1129,7 +1129,7 @@ func TestEvalAddSSTable(t *testing.T) {
 						defer engine.Close()
 
 						// Write initial data.
-						intentTxn := roachpb.MakeTransaction("intentTxn", nil, 0, 0, hlc.Timestamp{WallTime: intentTS * 1e9}, 0, 1)
+						intentTxn := roachpb.MakeTransaction("intentTxn", nil, 0, 0, hlc.Timestamp{WallTime: intentTS * 1e9}, 0, 1, 0)
 						b := engine.NewBatch()
 						defer b.Close()
 						for i := len(tc.data) - 1; i >= 0; i-- { // reverse, older timestamps first

--- a/pkg/kv/kvserver/batcheval/cmd_delete_range_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_delete_range_test.go
@@ -59,7 +59,7 @@ func TestDeleteRangeTombstone(t *testing.T) {
 		t.Helper()
 		var localTS hlc.ClockTimestamp
 
-		txn := roachpb.MakeTransaction("test", nil /* baseKey */, isolation.Serializable, roachpb.NormalUserPriority, hlc.Timestamp{WallTime: 5e9}, 0, 0)
+		txn := roachpb.MakeTransaction("test", nil /* baseKey */, isolation.Serializable, roachpb.NormalUserPriority, hlc.Timestamp{WallTime: 5e9}, 0, 0, 0)
 		require.NoError(t, storage.MVCCPut(ctx, rw, roachpb.Key("b"), hlc.Timestamp{WallTime: 2e9}, roachpb.MakeValueFromString("b2"), storage.MVCCWriteOptions{}))
 		require.NoError(t, storage.MVCCPut(ctx, rw, roachpb.Key("c"), hlc.Timestamp{WallTime: 4e9}, roachpb.MakeValueFromString("c4"), storage.MVCCWriteOptions{}))
 		require.NoError(t, storage.MVCCPut(ctx, rw, roachpb.Key("d"), hlc.Timestamp{WallTime: 2e9}, roachpb.MakeValueFromString("d2"), storage.MVCCWriteOptions{}))
@@ -217,8 +217,7 @@ func TestDeleteRangeTombstone(t *testing.T) {
 						Timestamp: rangeKey.Timestamp,
 					}
 					if tc.txn {
-						txn := roachpb.MakeTransaction(
-							"txn", nil, isolation.Serializable, roachpb.NormalUserPriority, rangeKey.Timestamp, 0, 0)
+						txn := roachpb.MakeTransaction("txn", nil, isolation.Serializable, roachpb.NormalUserPriority, rangeKey.Timestamp, 0, 0, 0)
 						h.Txn = &txn
 					}
 					var predicates kvpb.DeleteRangePredicates

--- a/pkg/kv/kvserver/batcheval/cmd_end_transaction_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_end_transaction_test.go
@@ -98,7 +98,7 @@ func TestIsEndTxnTriggeringRetryError(t *testing.T) {
 		name := fmt.Sprintf("iso=%s/wto=%t/pushed=%t/deadline=%t",
 			tt.txnIsoLevel, tt.txnWriteTooOld, tt.txnWriteTimestampPushed, tt.txnExceedingDeadline)
 		t.Run(name, func(t *testing.T) {
-			txn := roachpb.MakeTransaction("test", nil, tt.txnIsoLevel, 0, hlc.Timestamp{WallTime: 10}, 0, 1)
+			txn := roachpb.MakeTransaction("test", nil, tt.txnIsoLevel, 0, hlc.Timestamp{WallTime: 10}, 0, 1, 0)
 			if tt.txnWriteTooOld {
 				txn.WriteTooOld = true
 			}
@@ -135,7 +135,7 @@ func TestEndTxnUpdatesTransactionRecord(t *testing.T) {
 
 	k, k2 := roachpb.Key("a"), roachpb.Key("b")
 	ts, ts2, ts3 := hlc.Timestamp{WallTime: 1}, hlc.Timestamp{WallTime: 2}, hlc.Timestamp{WallTime: 3}
-	txn := roachpb.MakeTransaction("test", k, 0, 0, ts, 0, 1)
+	txn := roachpb.MakeTransaction("test", k, 0, 0, ts, 0, 1, 0)
 	writes := []roachpb.SequencedWrite{{Key: k, Sequence: 0}}
 	intents := []roachpb.Span{{Key: k2}}
 
@@ -1180,7 +1180,7 @@ func TestPartialRollbackOnEndTransaction(t *testing.T) {
 	k := roachpb.Key("a")
 	ts := hlc.Timestamp{WallTime: 1}
 	ts2 := hlc.Timestamp{WallTime: 2}
-	txn := roachpb.MakeTransaction("test", k, 0, 0, ts, 0, 1)
+	txn := roachpb.MakeTransaction("test", k, 0, 0, ts, 0, 1, 0)
 	endKey := roachpb.Key("z")
 	desc := roachpb.RangeDescriptor{
 		RangeID:  99,
@@ -1330,7 +1330,7 @@ func TestCommitWaitBeforeIntentResolutionIfCommitTrigger(t *testing.T) {
 
 				now := clock.Now()
 				commitTS := cfg.commitTS(now)
-				txn := roachpb.MakeTransaction("test", desc.StartKey.AsRawKey(), 0, 0, now, 0, 1)
+				txn := roachpb.MakeTransaction("test", desc.StartKey.AsRawKey(), 0, 0, now, 0, 1, 0)
 				txn.ReadTimestamp = commitTS
 				txn.WriteTimestamp = commitTS
 
@@ -1644,7 +1644,7 @@ func TestResolveLocalLocks(t *testing.T) {
 			defer batch.Close()
 
 			ts := hlc.Timestamp{WallTime: 1}
-			txn := roachpb.MakeTransaction("test", roachpb.Key("a"), 0, 0, ts, 0, 1)
+			txn := roachpb.MakeTransaction("test", roachpb.Key("a"), 0, 0, ts, 0, 1, 0)
 			txn.Status = roachpb.COMMITTED
 
 			for i := 0; i < numKeys; i++ {

--- a/pkg/kv/kvserver/batcheval/cmd_query_intent_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_query_intent_test.go
@@ -39,7 +39,7 @@ func TestQueryIntent(t *testing.T) {
 	}
 
 	writeIntent := func(k roachpb.Key, ts int64) roachpb.Transaction {
-		txn := roachpb.MakeTransaction("test", k, 0, 0, makeTS(ts), 0, 1)
+		txn := roachpb.MakeTransaction("test", k, 0, 0, makeTS(ts), 0, 1, 0)
 		_, err := storage.MVCCDelete(ctx, db, k, makeTS(ts), storage.MVCCWriteOptions{Txn: &txn})
 		require.NoError(t, err)
 		return txn

--- a/pkg/kv/kvserver/batcheval/cmd_query_resolved_timestamp_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_query_resolved_timestamp_test.go
@@ -48,7 +48,7 @@ func TestQueryResolvedTimestamp(t *testing.T) {
 		require.NoError(t, err)
 	}
 	writeIntent := func(k string, ts int64) {
-		txn := roachpb.MakeTransaction("test", roachpb.Key(k), 0, 0, makeTS(ts), 0, 1)
+		txn := roachpb.MakeTransaction("test", roachpb.Key(k), 0, 0, makeTS(ts), 0, 1, 0)
 		_, err := storage.MVCCDelete(ctx, db, roachpb.Key(k), makeTS(ts), storage.MVCCWriteOptions{Txn: &txn})
 		require.NoError(t, err)
 	}

--- a/pkg/kv/kvserver/batcheval/cmd_recover_txn_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_recover_txn_test.go
@@ -37,7 +37,7 @@ func TestRecoverTxn(t *testing.T) {
 	ctx := context.Background()
 	k, k2 := roachpb.Key("a"), roachpb.Key("b")
 	ts := hlc.Timestamp{WallTime: 1}
-	txn := roachpb.MakeTransaction("test", k, 0, 0, ts, 0, 1)
+	txn := roachpb.MakeTransaction("test", k, 0, 0, ts, 0, 1, 0)
 	txn.Status = roachpb.STAGING
 	txn.LockSpans = []roachpb.Span{{Key: k}}
 	txn.InFlightWrites = []roachpb.SequencedWrite{{Key: k2, Sequence: 0}}
@@ -104,7 +104,7 @@ func TestRecoverTxnRecordChanged(t *testing.T) {
 	ctx := context.Background()
 	k := roachpb.Key("a")
 	ts := hlc.Timestamp{WallTime: 1}
-	txn := roachpb.MakeTransaction("test", k, 0, 0, ts, 0, 1)
+	txn := roachpb.MakeTransaction("test", k, 0, 0, ts, 0, 1, 0)
 	txn.Status = roachpb.STAGING
 
 	testCases := []struct {

--- a/pkg/kv/kvserver/batcheval/cmd_resolve_intent_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_resolve_intent_test.go
@@ -151,7 +151,7 @@ func TestResolveIntentAfterPartialRollback(t *testing.T) {
 	ts := hlc.Timestamp{WallTime: 1}
 	ts2 := hlc.Timestamp{WallTime: 2}
 	endKey := roachpb.Key("z")
-	txn := roachpb.MakeTransaction("test", k, 0, 0, ts, 0, 1)
+	txn := roachpb.MakeTransaction("test", k, 0, 0, ts, 0, 1, 0)
 	desc := roachpb.RangeDescriptor{
 		RangeID:  99,
 		StartKey: roachpb.RKey(k),
@@ -295,7 +295,7 @@ func TestResolveIntentWithTargetBytes(t *testing.T) {
 		}
 		values[i] = roachpb.MakeValueFromBytes([]byte{b})
 	}
-	txn := roachpb.MakeTransaction("test", roachpb.Key("a"), 0, 0, ts, 0, 1)
+	txn := roachpb.MakeTransaction("test", roachpb.Key("a"), 0, 0, ts, 0, 1, 0)
 
 	testutils.RunTrueAndFalse(t, "ranged", func(t *testing.T, ranged bool) {
 		db := storage.NewDefaultInMemForTesting()

--- a/pkg/kv/kvserver/batcheval/cmd_revert_range_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_revert_range_test.go
@@ -167,7 +167,7 @@ func TestCmdRevertRange(t *testing.T) {
 		})
 	}
 
-	txn := roachpb.MakeTransaction("test", nil, isolation.Serializable, roachpb.NormalUserPriority, tsC, 1, 1)
+	txn := roachpb.MakeTransaction("test", nil, isolation.Serializable, roachpb.NormalUserPriority, tsC, 1, 1, 0)
 	if err := storage.MVCCPut(
 		ctx, eng, []byte("0012"), tsC, roachpb.MakeValueFromBytes([]byte("i")), storage.MVCCWriteOptions{Txn: &txn, Stats: &stats},
 	); err != nil {

--- a/pkg/kv/kvserver/batcheval/intent_test.go
+++ b/pkg/kv/kvserver/batcheval/intent_test.go
@@ -128,7 +128,7 @@ func TestCollectIntentsUsesSameIterator(t *testing.T) {
 
 				// Write an intent.
 				val := roachpb.MakeValueFromBytes([]byte("val"))
-				txn := roachpb.MakeTransaction("test", key, isolation.Serializable, roachpb.NormalUserPriority, ts, 0, 1)
+				txn := roachpb.MakeTransaction("test", key, isolation.Serializable, roachpb.NormalUserPriority, ts, 0, 1, 0)
 				var err error
 				if delete {
 					_, err = storage.MVCCDelete(ctx, db, key, ts, storage.MVCCWriteOptions{Txn: &txn})

--- a/pkg/kv/kvserver/batcheval/transaction_test.go
+++ b/pkg/kv/kvserver/batcheval/transaction_test.go
@@ -63,7 +63,7 @@ func TestUpdateAbortSpan(t *testing.T) {
 	}
 	as := abortspan.New(desc.RangeID)
 
-	txn := roachpb.MakeTransaction("test", txnKey, 0, 0, hlc.Timestamp{WallTime: 1}, 0, 1)
+	txn := roachpb.MakeTransaction("test", txnKey, 0, 0, hlc.Timestamp{WallTime: 1}, 0, 1, 0)
 	newTxnAbortSpanEntry := roachpb.AbortSpanEntry{
 		Key:       txn.Key,
 		Timestamp: txn.WriteTimestamp,

--- a/pkg/kv/kvserver/client_merge_test.go
+++ b/pkg/kv/kvserver/client_merge_test.go
@@ -587,8 +587,8 @@ func mergeCheckingTimestampCaches(
 	// Simulate a txn abort on the RHS from a node with a newer clock. Because
 	// the transaction record for the pushee was not yet written, this will bump
 	// the timestamp cache to record the abort.
-	pushee := roachpb.MakeTransaction("pushee", rhsKey, isolation.Serializable, roachpb.MinUserPriority, readTS, 0, 0)
-	pusher := roachpb.MakeTransaction("pusher", rhsKey, isolation.Serializable, roachpb.MaxUserPriority, readTS, 0, 0)
+	pushee := roachpb.MakeTransaction("pushee", rhsKey, isolation.Serializable, roachpb.MinUserPriority, readTS, 0, 0, 0)
+	pusher := roachpb.MakeTransaction("pusher", rhsKey, isolation.Serializable, roachpb.MaxUserPriority, readTS, 0, 0, 0)
 	ba = &kvpb.BatchRequest{}
 	ba.Timestamp = readTS.Next()
 	ba.RangeID = rhsDesc.RangeID
@@ -4958,7 +4958,7 @@ func sendWithTxn(
 	maxOffset time.Duration,
 	args kvpb.Request,
 ) error {
-	txn := roachpb.MakeTransaction("test txn", desc.StartKey.AsRawKey(), 0, 0, ts, maxOffset.Nanoseconds(), 0)
+	txn := roachpb.MakeTransaction("test txn", desc.StartKey.AsRawKey(), 0, 0, ts, maxOffset.Nanoseconds(), 0, 0)
 	_, pErr := kv.SendWrappedWith(context.Background(), store.TestSender(), kvpb.Header{Txn: &txn}, args)
 	return pErr.GoError()
 }

--- a/pkg/kv/kvserver/client_metrics_test.go
+++ b/pkg/kv/kvserver/client_metrics_test.go
@@ -196,7 +196,7 @@ func TestStoreResolveMetrics(t *testing.T) {
 	store.Metrics().ResolveAbortCount.Clear()
 	store.Metrics().ResolvePoisonCount.Clear()
 
-	txn := roachpb.MakeTransaction("foo", span.Key, isolation.Serializable, roachpb.MinUserPriority, hlc.Timestamp{WallTime: 123}, 999, int32(s.NodeID()))
+	txn := roachpb.MakeTransaction("foo", span.Key, isolation.Serializable, roachpb.MinUserPriority, hlc.Timestamp{WallTime: 123}, 999, int32(s.NodeID()), 0)
 
 	const resolveCommitCount = int64(200)
 	const resolveAbortCount = int64(800)

--- a/pkg/kv/kvserver/client_raft_test.go
+++ b/pkg/kv/kvserver/client_raft_test.go
@@ -6967,7 +6967,7 @@ func TestInvalidConfChangeRejection(t *testing.T) {
 	// See: https://github.com/cockroachdb/cockroach/issues/105797
 	var ba kvpb.BatchRequest
 	now := tc.Server(0).Clock().Now()
-	txn := roachpb.MakeTransaction("fake", k, isolation.Serializable, roachpb.NormalUserPriority, now, 500*time.Millisecond.Nanoseconds(), 1)
+	txn := roachpb.MakeTransaction("fake", k, isolation.Serializable, roachpb.NormalUserPriority, now, 500*time.Millisecond.Nanoseconds(), 1, 0)
 	ba.Txn = &txn
 	ba.Timestamp = now
 	ba.Add(&kvpb.EndTxnRequest{

--- a/pkg/kv/kvserver/client_replica_test.go
+++ b/pkg/kv/kvserver/client_replica_test.go
@@ -473,7 +473,7 @@ func testTxnReadWithinUncertaintyInterval(t *testing.T, observedTS bool, readOp 
 	now := s.Clock().Now()
 	maxOffset := s.Clock().MaxOffset().Nanoseconds()
 	require.NotZero(t, maxOffset)
-	txn := roachpb.MakeTransaction("test", key, isolation.Serializable, 1, now, maxOffset, int32(s.SQLInstanceID()))
+	txn := roachpb.MakeTransaction("test", key, isolation.Serializable, 1, now, maxOffset, int32(s.SQLInstanceID()), 0)
 	require.True(t, txn.ReadTimestamp.Less(txn.GlobalUncertaintyLimit))
 	require.Len(t, txn.ObservedTimestamps, 0)
 
@@ -625,7 +625,7 @@ func testTxnReadWithinUncertaintyIntervalAfterIntentResolution(
 	// Create a new writer transaction.
 	maxOffset := clocks[0].MaxOffset().Nanoseconds()
 	require.NotZero(t, maxOffset)
-	writerTxn := roachpb.MakeTransaction("test_writer", keyA, isolation.Serializable, 1, clocks[0].Now(), maxOffset, int32(tc.Servers[0].NodeID()))
+	writerTxn := roachpb.MakeTransaction("test_writer", keyA, isolation.Serializable, 1, clocks[0].Now(), maxOffset, int32(tc.Servers[0].NodeID()), 0)
 
 	// Write to key A and key B in the writer transaction.
 	for _, key := range []roachpb.Key{keyA, keyB} {
@@ -670,7 +670,7 @@ func testTxnReadWithinUncertaintyIntervalAfterIntentResolution(
 	//
 	// NB: we use writerTxn.MinTimestamp instead of clocks[1].Now() so that a
 	// stray clock update doesn't influence the reader's read timestamp.
-	readerTxn := roachpb.MakeTransaction("test_reader", keyA, isolation.Serializable, 1, writerTxn.MinTimestamp, maxOffset, int32(tc.Servers[1].NodeID()))
+	readerTxn := roachpb.MakeTransaction("test_reader", keyA, isolation.Serializable, 1, writerTxn.MinTimestamp, maxOffset, int32(tc.Servers[1].NodeID()), 0)
 	require.True(t, readerTxn.ReadTimestamp.Less(writerTxn.WriteTimestamp))
 	require.False(t, readerTxn.GlobalUncertaintyLimit.Less(writerTxn.WriteTimestamp))
 
@@ -826,7 +826,7 @@ func TestTxnReadWithinUncertaintyIntervalAfterLeaseTransfer(t *testing.T) {
 	now := clocks[1].Now()
 	maxOffset := clocks[1].MaxOffset().Nanoseconds()
 	require.NotZero(t, maxOffset)
-	txn := roachpb.MakeTransaction("test", keyB, isolation.Serializable, 1, now, maxOffset, int32(tc.Servers[1].SQLInstanceID()))
+	txn := roachpb.MakeTransaction("test", keyB, isolation.Serializable, 1, now, maxOffset, int32(tc.Servers[1].SQLInstanceID()), 0)
 	require.True(t, txn.ReadTimestamp.Less(txn.GlobalUncertaintyLimit))
 	require.Len(t, txn.ObservedTimestamps, 0)
 
@@ -1013,8 +1013,8 @@ func TestTxnReadWithinUncertaintyIntervalAfterRangeMerge(t *testing.T) {
 
 		// Create two identical transactions. The first one will perform a read to a
 		// store before the merge, the second will only read after the merge.
-		txn := roachpb.MakeTransaction("txn1", keyA, isolation.Serializable, 1, now, maxOffset, instanceId)
-		txn2 := roachpb.MakeTransaction("txn2", keyA, isolation.Serializable, 1, now, maxOffset, instanceId)
+		txn := roachpb.MakeTransaction("txn1", keyA, isolation.Serializable, 1, now, maxOffset, instanceId, 0)
+		txn2 := roachpb.MakeTransaction("txn2", keyA, isolation.Serializable, 1, now, maxOffset, instanceId, 0)
 
 		// Simulate a read which will cause the observed time to be set to now
 		resp, pErr := kv.SendWrappedWith(ctx, tc.Servers[1].DistSenderI().(kv.Sender), kvpb.Header{Txn: &txn}, getArgs(keyA))
@@ -1993,7 +1993,7 @@ func TestRangeLocalUncertaintyLimitAfterNewLease(t *testing.T) {
 	}
 
 	// Start a transaction using node2 as a gateway.
-	txn := roachpb.MakeTransaction("test", keyA, isolation.Serializable, 1, tc.Servers[1].Clock().Now(), tc.Servers[1].Clock().MaxOffset().Nanoseconds(), int32(tc.Servers[1].SQLInstanceID()))
+	txn := roachpb.MakeTransaction("test", keyA, isolation.Serializable, 1, tc.Servers[1].Clock().Now(), tc.Servers[1].Clock().MaxOffset().Nanoseconds(), int32(tc.Servers[1].SQLInstanceID()), 0)
 	// Simulate a read to another range on node2 by setting the observed timestamp.
 	txn.UpdateObservedTimestamp(2, tc.Servers[1].Clock().NowAsClockTimestamp())
 

--- a/pkg/kv/kvserver/client_split_test.go
+++ b/pkg/kv/kvserver/client_split_test.go
@@ -138,7 +138,7 @@ func TestStoreSplitAbortSpan(t *testing.T) {
 	left, middle, right := roachpb.Key("a"), roachpb.Key("b"), roachpb.Key("c")
 
 	txn := func(key roachpb.Key, ts hlc.Timestamp) *roachpb.Transaction {
-		txn := roachpb.MakeTransaction("test", key, 0, 0, ts, 0, int32(s.SQLInstanceID()))
+		txn := roachpb.MakeTransaction("test", key, 0, 0, ts, 0, int32(s.SQLInstanceID()), 0)
 		return &txn
 	}
 
@@ -465,6 +465,7 @@ func TestQueryLocksAcrossRanges(t *testing.T) {
 		s.Clock().NowAsClockTimestamp().ToTimestamp(),
 		s.Clock().MaxOffset().Nanoseconds(),
 		int32(s.SQLInstanceID()),
+		0,
 	)
 	txn3ID := txn3Proto.ID
 
@@ -635,7 +636,7 @@ func TestStoreRangeSplitIdempotency(t *testing.T) {
 	// Increments are a good way of testing idempotency. Up here, we
 	// address them to the original range, then later to the one that
 	// contains the key.
-	txn := roachpb.MakeTransaction("test", []byte("c"), isolation.Serializable, 10, store.Clock().Now(), 0, int32(s.SQLInstanceID()))
+	txn := roachpb.MakeTransaction("test", []byte("c"), isolation.Serializable, 10, store.Clock().Now(), 0, int32(s.SQLInstanceID()), 0)
 	lIncArgs := incrementArgs([]byte("apoptosis"), 100)
 	lTxn := txn
 	lTxn.Sequence++
@@ -3225,9 +3226,7 @@ func TestRangeLookupAsyncResolveIntent(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	txn := roachpb.MakeTransaction("test", key2, isolation.Serializable, 1,
-		store.Clock().Now(), store.Clock().MaxOffset().Nanoseconds(),
-		int32(s.SQLInstanceID()))
+	txn := roachpb.MakeTransaction("test", key2, isolation.Serializable, 1, store.Clock().Now(), store.Clock().MaxOffset().Nanoseconds(), int32(s.SQLInstanceID()), 0)
 	// Officially begin the transaction. If not for this, the intent resolution
 	// machinery would simply remove the intent we write below, see #3020.
 	// We send directly to Replica throughout this test, so there's no danger

--- a/pkg/kv/kvserver/closed_timestamp_test.go
+++ b/pkg/kv/kvserver/closed_timestamp_test.go
@@ -115,7 +115,7 @@ func TestClosedTimestampCanServe(t *testing.T) {
 			baWrite := &kvpb.BatchRequest{}
 			r := &kvpb.DeleteRequest{}
 			r.Key = desc.StartKey.AsRawKey()
-			txn := roachpb.MakeTransaction("testwrite", r.Key, isolation.Serializable, roachpb.NormalUserPriority, ts, 100, int32(tc.Server(0).SQLInstanceID()))
+			txn := roachpb.MakeTransaction("testwrite", r.Key, isolation.Serializable, roachpb.NormalUserPriority, ts, 100, int32(tc.Server(0).SQLInstanceID()), 0)
 			baWrite.Txn = &txn
 			baWrite.Add(r)
 			baWrite.RangeID = repls[0].RangeID
@@ -286,7 +286,7 @@ func TestClosedTimestampCantServeWithConflictingIntent(t *testing.T) {
 	// replica.
 	txnKey := desc.StartKey.AsRawKey()
 	txnKey = txnKey[:len(txnKey):len(txnKey)] // avoid aliasing
-	txn := roachpb.MakeTransaction("txn", txnKey, 0, 0, tc.Server(0).Clock().Now(), 0, int32(tc.Server(0).SQLInstanceID()))
+	txn := roachpb.MakeTransaction("txn", txnKey, 0, 0, tc.Server(0).Clock().Now(), 0, int32(tc.Server(0).SQLInstanceID()), 0)
 	var keys []roachpb.Key
 	for i := range repls {
 		key := append(txnKey, []byte(strconv.Itoa(i))...)
@@ -1369,7 +1369,7 @@ func verifyCanReadFromAllRepls(
 }
 
 func makeTxnReadBatchForDesc(desc roachpb.RangeDescriptor, ts hlc.Timestamp) *kvpb.BatchRequest {
-	txn := roachpb.MakeTransaction("txn", nil, 0, 0, ts, 0, 0)
+	txn := roachpb.MakeTransaction("txn", nil, 0, 0, ts, 0, 0, 0)
 
 	baRead := &kvpb.BatchRequest{}
 	baRead.Header.RangeID = desc.RangeID

--- a/pkg/kv/kvserver/concurrency/concurrency_control.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_control.go
@@ -405,6 +405,10 @@ type Request struct {
 	// with a LockConflictError instead of entering the queue and waiting.
 	MaxLockWaitQueueLength int
 
+	// AdmissionHeader is the header in the request's BatchRequest. It is plumbed
+	// through for intent resolution admission control.
+	AdmissionHeader kvpb.AdmissionHeader
+
 	// The poison.Policy to use for this Request.
 	PoisonPolicy poison.Policy
 
@@ -835,7 +839,7 @@ type lockTableWaiter interface {
 	// ResolveDeferredIntents resolves the batch of intents if the provided
 	// error is nil. The batch of intents may be resolved more efficiently than
 	// if they were resolved individually.
-	ResolveDeferredIntents(context.Context, []roachpb.LockUpdate) *Error
+	ResolveDeferredIntents(context.Context, kvpb.AdmissionHeader, []roachpb.LockUpdate) *Error
 }
 
 // txnWaitQueue holds a collection of wait-queues for transaction records.

--- a/pkg/kv/kvserver/concurrency/concurrency_manager.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager.go
@@ -503,7 +503,7 @@ func (m *managerImpl) HandleLockConflictError(
 	// If the discovery process collected a set of intents to resolve before the
 	// next evaluation attempt, do so.
 	if toResolve := g.ltg.ResolveBeforeScanning(); len(toResolve) > 0 {
-		if err := m.ltw.ResolveDeferredIntents(ctx, toResolve); err != nil {
+		if err := m.ltw.ResolveDeferredIntents(ctx, g.Req.AdmissionHeader, toResolve); err != nil {
 			m.FinishReq(g)
 			return nil, err
 		}

--- a/pkg/kv/kvserver/concurrency/lock_table_waiter_test.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_waiter_test.go
@@ -133,7 +133,7 @@ func setupLockTableWaiterTest() (
 }
 
 func makeTxnProto(name string) roachpb.Transaction {
-	return roachpb.MakeTransaction(name, []byte("key"), 0, 0, hlc.Timestamp{WallTime: 10}, 0, 6)
+	return roachpb.MakeTransaction(name, []byte("key"), 0, 0, hlc.Timestamp{WallTime: 10}, 0, 6, 0)
 }
 
 // TestLockTableWaiterWithTxn tests the lockTableWaiter's behavior under

--- a/pkg/kv/kvserver/gc/gc_test.go
+++ b/pkg/kv/kvserver/gc/gc_test.go
@@ -135,7 +135,7 @@ func TestIntentAgeThresholdSetting(t *testing.T) {
 	intentHlc := hlc.Timestamp{
 		WallTime: intentTs.Nanoseconds(),
 	}
-	txn := roachpb.MakeTransaction("txn", key, isolation.Serializable, roachpb.NormalUserPriority, intentHlc, 1000, 0)
+	txn := roachpb.MakeTransaction("txn", key, isolation.Serializable, roachpb.NormalUserPriority, intentHlc, 1000, 0, 0)
 	require.NoError(t, storage.MVCCPut(ctx, eng, key, intentHlc, value, storage.MVCCWriteOptions{Txn: &txn}))
 	require.NoError(t, eng.Flush())
 
@@ -194,7 +194,7 @@ func TestIntentCleanupBatching(t *testing.T) {
 	}
 	for _, prefix := range txnPrefixes {
 		key := []byte{prefix, objectKeys[0]}
-		txn := roachpb.MakeTransaction("txn", key, isolation.Serializable, roachpb.NormalUserPriority, intentHlc, 1000, 0)
+		txn := roachpb.MakeTransaction("txn", key, isolation.Serializable, roachpb.NormalUserPriority, intentHlc, 1000, 0, 0)
 		for _, suffix := range objectKeys {
 			key := []byte{prefix, suffix}
 			require.NoError(t, storage.MVCCPut(ctx, eng, key, intentHlc, value, storage.MVCCWriteOptions{Txn: &txn}))

--- a/pkg/kv/kvserver/intent_resolver_integration_test.go
+++ b/pkg/kv/kvserver/intent_resolver_integration_test.go
@@ -474,6 +474,7 @@ func TestReliableIntentCleanup(t *testing.T) {
 						now.ToTimestamp(),
 						srv.Clock().MaxOffset().Nanoseconds(),
 						int32(srv.SQLInstanceID()),
+						0,
 					)
 					pusher := kv.NewTxnFromProto(ctx, db, srv.NodeID(), now, kv.RootTxn, &pusherProto)
 					if err := pusher.Put(ctx, txnKey, []byte("pushit")); err != nil {

--- a/pkg/kv/kvserver/intentresolver/BUILD.bazel
+++ b/pkg/kv/kvserver/intentresolver/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "intentresolver",
     srcs = [
+        "admission.go",
         "intent_resolver.go",
         "metrics.go",
     ],
@@ -56,6 +57,7 @@ go_test(
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",
         "//pkg/server",
+        "//pkg/settings/cluster",
         "//pkg/storage/enginepb",
         "//pkg/testutils",
         "//pkg/testutils/serverutils",

--- a/pkg/kv/kvserver/intentresolver/admission.go
+++ b/pkg/kv/kvserver/intentresolver/admission.go
@@ -1,0 +1,169 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package intentresolver
+
+import "github.com/cockroachdb/cockroach/pkg/settings"
+
+// Admission control and locking (including intents):
+//
+// Admission control (AC) has a work scheduling mechanism based on (tenantID,
+// priority, createTime), where the priority values are defined in
+// admissionpb.WorkPriority, and can be one of three values for user txns
+// {UserLowPri, NormalPri, UserHighPri} (NB: these priorities are different
+// from enginepb.TxnPriority used inside concurrency control). All internal
+// background work in CockroachDB uses a priority < NormalPri. The high level
+// goal is to provide performance isolation of different queries by one of two
+// methods:
+// - Using AC's tenantID, for fair sharing. AC's tenantID can be decoupled
+//   from the serverless concept of tenantID (though this is not done yet), so
+//   we consider this more general setup below.
+// - Using different priorities.
+//
+// A challenge here is that AC queueing is barely aware of concurrency
+// control, so we have a lock priority inversion problem. Our initial solution
+// addressed this in a crude manner: (a) using LockingPri (which is greater
+// than UserHighPri) for work from txns that have already acquired locks,
+// regardless of the txn's original priority, (b) not subjecting intent
+// resolution to AC. But (b) caused overload (see
+// https://github.com/cockroachdb/cockroach/issues/97108). And (a) violates
+// our isolation goals: e.g. a user A could be running write txns at
+// UserLowPri on some set of tables T_A, while another user B could be running
+// txns at NormalPri on an unrelated set of tables T_B, and user A will
+// interfere with user B since A's txns will get elevated to LockingPri.
+//
+// The priority inversion problem is complicated from a software structure
+// perspective, since it requires taking information from the lock table and
+// feeding it into AC queues. And there are more fundamental difficulties:
+//
+// - Distributed priority inversion: The AC queue on node n1 could have low
+//   priority work from txn T1 waiting behind high priority work from txn T2,
+//   and low priority work from txn T3 waiting on a lock already held by T1 in
+//   the lock table. There is no need for T1 to skip past T2 in the AC queue
+//   since T3 is similarly low priority, so the lock release will be delayed.
+//   But on node n2, a lock held by T3 could have T2 waiting for it to be
+//   released (and no AC queueing). Without distributed knowledge, we cannot
+//   notice this transitive dependency of T2 on T1, and therefore the need to
+//   elevate the priority of T1.
+//
+// - Importance inversion: Using tenantID to isolate different workloads could
+//   have tenant U1 with lower shares holding a lock and tenant U2 with higher
+//   shares waiting on that lock. That is, the general problem cannot be
+//   captured solely using priorities.
+//
+// We define the performance isolation goals of AC in a more limited manner,
+// to sidestep this problem.
+//
+// Performance isolation between user txns can be achieved using different
+// tenantID or different priority only for txns that touch different parts (in
+// some partitioning) of the key space, with a few exceptions:
+//
+// - Lower importance (smaller tenant share or lower priority) non-locking
+//   read txns can share the key space with higher importance read or write
+//   txns.
+//
+// - One can switch between lower importance and higher importance (and vice
+//   versa) txns on a part of the key space. If there is time overlap during
+//   this switch where both lower and higher importance txns are running,
+//   priority inversion can happen.
+//
+// These goals are achieved by the following set of mechanisms:
+//
+// - Txns that already hold locks/intents use an AC priority that is logically
+//   +1 of the original txn priority. Since there are gaps between the
+//   different user priorities (UserLowPri=-50, NormalPri=0, UserHighPri=50),
+//   work in one part of the key space that executes with NormalPri+1 will not
+//   get prioritized over another part of the key space executing at
+//   UserHighPri. And when different tenantIDs are being used for performance
+//   isolation, the priority is irrelevant. The actual implementation uses a
+//   step that is bigger than +1. See
+//   admissionpb.AdjustedPriorityWhenHoldingLocks.
+//
+// - Intent resolution is subject to AC. The baseline (tenantID, priority,
+//   createTime) of intent resolution is that of the requester that is trying
+//   to resolve the intent. Adopting the same idea of +1, the intent
+//   resolution executes at priority+1.
+//
+// We consider some examples.
+//
+// Example 1: Consider the case of txns T1, T2, T3, where T2 is a lower
+// priority (say -50) read-only transaction, while T1, T3, have the same
+// priority, which is higher than T2, say 0. T1 has an intent at key k1, on
+// which T2 is waiting. T1 commits, and T2 attempts to resolve this intent
+// with an admission priority of -30, and is waiting for admission. Then T3
+// also starts waiting on the intent for key k1. It tries to resolve with a
+// priority of +10, so can get through the admission queues faster.
+//
+// Example 2: Similar to the previous case but T1 has not committed by the
+// time T3 starts waiting on the intent at k1. Say T1 wants to create another
+// intent at k2. T1 will use a priority of +10, which allows it to finish
+// acquiring intents and commit faster.
+//
+// In the above examples, no one is waiting on an intent from the lower
+// priority txn T3, since our performance isolation goals do not permit T3 to
+// be a writing transaction. However, there are some internal transactional
+// writes, like index backfills and TTL writes, that use a lower priority. We
+// consider this in the remaining examples.
+//
+// Example 3: T1 and T3 are writers with priority 0, and T2 is a writer with
+// priority -50. T2 has an intent on key k1 that is being waited on by T1. T2
+// commits. The intent resolution done by T1 will use priority +10, which is
+// desirable (it can get ahead of the intent resolution done by T2 itself,
+// which will run at priority -30).
+//
+// Example 4: T1 and T3 have priority -50, and T2 has priority 0. On an
+// overloaded node (so admission control queueing), T1 has an intent on key k1
+// that is being waited on by T3. T1 has another request on this node that is
+// waiting in the admission queue (priority -30) behind a request from T2
+// (priority 0; T2's request is for an unrelated key). There is no priority
+// inversion yet. On a different node with no overload, T3 has an intent on
+// key k2 that is being waited on by T2. This shows a distributed priority
+// inversion since T2 is waiting on T3 which is waiting on T1, and T1's
+// request is behind T2's request in the admission queue of the first node.
+// This could be addressed if the internal work (txns T1 and T3) knew the
+// priority of the user-facing work (txn T2), say specified in a SpanConfig,
+// and used that same priority after acquiring locks or when doing intent
+// resolution. Since we don't yet have this capability, we have a hack in
+// admissionpb.AdjustedPriorityWhenHoldingLocks that bumps the priority of
+// lock holding or lock resolving work up to 0 and then applies the logical +1
+// to the priority. In this example, it will cause T1 and T3 to have priority
+// +10 once they acquire locks or when they are resolving locks, eliminating
+// the priority inversion.
+//
+// Example 5: T1 and T3 have priority 0, and T2 has priority -50. T2 starts
+// waiting on an intent of txn T1 at key k1. T3 starts waiting after T2 in the
+// lock table queue for the same intent. T1 commits. The lock table logic (at
+// the time of writing this comment) will pick the first waiter as the
+// designated resolver, so intent resolution will use the priority of T2. Even
+// if this designated waiter logic were not there, and intent resolution was
+// done by both T2 and T3, we know that T2 is ahead in the lock table queue so
+// will acquire the lock first. And if T2 wants to acquire more locks after
+// the one on k1 we could have a priority inversion in that T3 is waiting on a
+// lock held by T2, while T2 is starved by other priority 0 work. The same
+// proper fix as example 4 applies here, and so does the same hack -- T2 will
+// resolve using priority +10 and will acquire subsequent intents with
+// priority +10.
+
+// sendImmediatelyBypassAdmissionControl sets the admission control behavior
+// for the less commonly used sendImmediately option. Since that option is
+// used when a waiter on the lock table is trying to resolve one intent, and
+// the waiter has already been admitted, the default is to bypass admission
+// control.
+var sendImmediatelyBypassAdmissionControl = settings.RegisterBoolSetting(
+	settings.SystemOnly, "kv.intent_resolver.send_immediately.bypass_admission_control.enabled",
+	"determines whether the sendImmediately option on intent resolution bypasses admission control",
+	true)
+
+// batchBypassAdmissionControl sets the admission control behavior for the
+// more common case of batched intent resolution. By default, this does not
+// bypass admission control.
+var batchBypassAdmissionControl = settings.RegisterBoolSetting(
+	settings.SystemOnly, "kv.intent_resolver.batch.bypass_admission_control.enabled",
+	"determined whether batched intent resolution bypasses admission control", false)

--- a/pkg/kv/kvserver/intentresolver/intent_resolver_test.go
+++ b/pkg/kv/kvserver/intentresolver/intent_resolver_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/isolation"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -52,8 +53,9 @@ func TestCleanupTxnIntentsOnGCAsync(t *testing.T) {
 	defer stopper.Stop(ctx)
 	clock := hlc.NewClockForTesting(nil)
 	cfg := Config{
-		Stopper: stopper,
-		Clock:   clock,
+		Stopper:  stopper,
+		Clock:    clock,
+		Settings: cluster.MakeTestingClusterSettings(),
 	}
 	type testCase struct {
 		txn *roachpb.Transaction
@@ -229,7 +231,8 @@ func TestCleanupTxnIntentsOnGCAsync(t *testing.T) {
 			}
 			txn := c.txn.Clone()
 			txn.LockSpans = append([]roachpb.Span{}, c.intentSpans...)
-			err := ir.CleanupTxnIntentsOnGCAsync(ctx, 1, txn, clock.Now(), onComplete)
+			err := ir.CleanupTxnIntentsOnGCAsync(
+				ctx, kvpb.AdmissionHeader{}, 1, txn, clock.Now(), onComplete)
 			if err != nil {
 				t.Fatalf("unexpected error sending async transaction")
 			}
@@ -255,8 +258,9 @@ func TestCleanupIntentsAsyncThrottled(t *testing.T) {
 	stopper := stop.NewStopper()
 	defer stopper.Stop(context.Background())
 	cfg := Config{
-		Stopper: stopper,
-		Clock:   clock,
+		Stopper:  stopper,
+		Clock:    clock,
+		Settings: cluster.MakeTestingClusterSettings(),
 	}
 	txn := newTransaction("txn", roachpb.Key("a"), 1, clock)
 	sf := newSendFuncs(t,
@@ -283,12 +287,14 @@ func TestCleanupIntentsAsyncThrottled(t *testing.T) {
 	}
 	// Running with allowSyncProcessing = false should result in an error and no
 	// requests being sent.
-	err := ir.CleanupIntentsAsync(context.Background(), testIntents, false)
+	err := ir.CleanupIntentsAsync(
+		context.Background(), kvpb.AdmissionHeader{}, testIntents, false)
 	assert.True(t, errors.Is(err, stop.ErrThrottled))
 	// Running with allowSyncProcessing = true should result in the synchronous
 	// processing of the intents resulting in no error and the consumption of the
 	// sendFuncs.
-	err = ir.CleanupIntentsAsync(context.Background(), testIntents, true)
+	err = ir.CleanupIntentsAsync(
+		context.Background(), kvpb.AdmissionHeader{}, testIntents, true)
 	assert.Nil(t, err)
 	assert.Equal(t, sf.len(), 0)
 }
@@ -303,6 +309,7 @@ func TestCleanupIntentsAsync(t *testing.T) {
 	}
 	clock := hlc.NewClockForTesting(nil)
 	txn := newTransaction("txn", roachpb.Key("a"), 1, clock)
+	st := cluster.MakeTestingClusterSettings()
 	testIntents := []roachpb.Intent{
 		roachpb.MakeIntent(&txn.TxnMeta, roachpb.Key("a")),
 	}
@@ -333,11 +340,13 @@ func TestCleanupIntentsAsync(t *testing.T) {
 			stopper := stop.NewStopper()
 			sf := newSendFuncs(t, c.sendFuncs...)
 			cfg := Config{
-				Stopper: stopper,
-				Clock:   clock,
+				Stopper:  stopper,
+				Clock:    clock,
+				Settings: st,
 			}
 			ir := newIntentResolverWithSendFuncs(cfg, sf, stopper)
-			err := ir.CleanupIntentsAsync(context.Background(), c.intents, true)
+			err := ir.CleanupIntentsAsync(
+				context.Background(), kvpb.AdmissionHeader{}, c.intents, true)
 			sf.drain(t)
 			stopper.Stop(context.Background())
 			assert.Nil(t, err, "error from CleanupIntentsAsync")
@@ -400,9 +409,10 @@ func TestCleanupMultipleIntentsAsync(t *testing.T) {
 		TestingKnobs: kvserverbase.IntentResolverTestingKnobs{
 			MaxIntentResolutionBatchSize: 1,
 		},
+		Settings: cluster.MakeTestingClusterSettings(),
 	}
 	ir := newIntentResolverWithSendFuncs(cfg, sf, stopper)
-	err := ir.CleanupIntentsAsync(ctx, testIntents, false)
+	err := ir.CleanupIntentsAsync(ctx, kvpb.AdmissionHeader{}, testIntents, false)
 	sf.drain(t)
 	stopper.Stop(ctx)
 	assert.Nil(t, err)
@@ -497,8 +507,9 @@ func TestCleanupTxnIntentsAsyncWithPartialRollback(t *testing.T) {
 	stopper := stop.NewStopper()
 	defer stopper.Stop(context.Background())
 	cfg := Config{
-		Stopper: stopper,
-		Clock:   clock,
+		Stopper:  stopper,
+		Clock:    clock,
+		Settings: cluster.MakeTestingClusterSettings(),
 	}
 	ir := newIntentResolverWithSendFuncs(cfg, sf, stopper)
 
@@ -571,8 +582,9 @@ func TestCleanupTxnIntentsAsync(t *testing.T) {
 			stopper := stop.NewStopper()
 			clock := hlc.NewClockForTesting(nil)
 			cfg := Config{
-				Stopper: stopper,
-				Clock:   clock,
+				Stopper:  stopper,
+				Clock:    clock,
+				Settings: cluster.MakeTestingClusterSettings(),
 			}
 			ir := newIntentResolverWithSendFuncs(cfg, c.sendFuncs, stopper)
 			if c.before != nil {
@@ -671,6 +683,7 @@ func TestCleanupMultipleTxnIntentsAsync(t *testing.T) {
 			MaxGCBatchSize:               1,
 			MaxIntentResolutionBatchSize: 1,
 		},
+		Settings: cluster.MakeTestingClusterSettings(),
 	}
 	ir := newIntentResolverWithSendFuncs(cfg, sf, stopper)
 	err := ir.CleanupTxnIntentsAsync(ctx, 1, testEndTxnIntents, false)
@@ -696,6 +709,7 @@ func TestCleanupIntents(t *testing.T) {
 	testIntents := []roachpb.Intent{
 		roachpb.MakeIntent(&txn.TxnMeta, roachpb.Key("a")),
 	}
+	st := cluster.MakeTestingClusterSettings()
 	type testCase struct {
 		intents     []roachpb.Intent
 		sendFuncs   *sendFuncs
@@ -751,8 +765,10 @@ func TestCleanupIntents(t *testing.T) {
 		t.Run("", func(t *testing.T) {
 			c.cfg.Stopper = stopper
 			c.cfg.Clock = clock
+			c.cfg.Settings = st
 			ir := newIntentResolverWithSendFuncs(c.cfg, c.sendFuncs, stopper)
-			num, err := ir.CleanupIntents(context.Background(), c.intents, clock.Now(), kvpb.PUSH_ABORT)
+			num, err := ir.CleanupIntents(
+				context.Background(), kvpb.AdmissionHeader{}, c.intents, clock.Now(), kvpb.PUSH_ABORT)
 			assert.Equal(t, num, c.expectedNum, "number of resolved intents")
 			assert.Equal(t, err != nil, c.expectedErr, "error during CleanupIntents: %v", err)
 		})
@@ -801,13 +817,15 @@ func TestIntentResolutionTimeout(t *testing.T) {
 			InFlightBackpressureLimit:           1,
 			MaxIntentResolutionSendBatchTimeout: 1 * time.Second,
 		},
+		Settings: cluster.MakeTestingClusterSettings(),
 	}
 	ir := newIntentResolverWithSendFuncsConcurrentSend(cfg, sf, stopper, true)
 
 	// Intent resolution on unavailable range.
 	var cleanupIntentsErrFinished int32
 	go func() {
-		num, err := ir.CleanupIntents(context.Background(), makeTxnIntents(t, clock, 1), clock.Now(), kvpb.PUSH_ABORT)
+		num, err := ir.CleanupIntents(context.Background(), kvpb.AdmissionHeader{},
+			makeTxnIntents(t, clock, 1), clock.Now(), kvpb.PUSH_ABORT)
 		require.Error(t, err)
 		require.Equal(t, num, 0)
 		atomic.StoreInt32(&cleanupIntentsErrFinished, 1)
@@ -818,7 +836,8 @@ func TestIntentResolutionTimeout(t *testing.T) {
 	go func() {
 		// Ensure intent resolution occurs after that of the unavailable range.
 		<-c
-		num, err := ir.CleanupIntents(context.Background(), makeTxnIntents(t, clock, 1), clock.Now(), kvpb.PUSH_ABORT)
+		num, err := ir.CleanupIntents(context.Background(), kvpb.AdmissionHeader{},
+			makeTxnIntents(t, clock, 1), clock.Now(), kvpb.PUSH_ABORT)
 		require.NoError(t, err)
 		require.Equal(t, num, 1)
 		atomic.StoreInt32(&cleanupIntentsSuccessFinished, 1)
@@ -846,7 +865,8 @@ func newTransaction(
 		now = clock.Now()
 	}
 	txn := roachpb.MakeTransaction(
-		name, baseKey, isolation.Serializable, userPriority, now, offset, 1 /* coordinatorNodeID */)
+		name, baseKey, isolation.Serializable, userPriority, now, offset,
+		1 /* coordinatorNodeID */, 0)
 	return &txn
 }
 

--- a/pkg/kv/kvserver/mvcc_gc_queue.go
+++ b/pkg/kv/kvserver/mvcc_gc_queue.go
@@ -570,36 +570,7 @@ func (r *replicaGCer) send(ctx context.Context, req kvpb.GCRequest) error {
 	// admission control here, as we are bypassing server.Node.
 	var admissionHandle kvadmission.Handle
 	if r.admissionController != nil {
-		pri := admissionpb.WorkPriority(gc.AdmissionPriority.Get(&r.repl.ClusterSettings().SV))
-		ba.AdmissionHeader = kvpb.AdmissionHeader{
-			// TODO(irfansharif): GC could be expected to be BulkNormalPri, so
-			// that it does not impact user-facing traffic when resources (e.g.
-			// CPU, write capacity of the store) are scarce. However long delays
-			// in GC can slow down user-facing traffic due to more versions in
-			// the store, and can increase write amplification of the store
-			// since there is more live data. Ideally, we should adjust this
-			// priority based on how far behind we are with respect to GC-ing
-			// data in this range. Keeping it static at NormalPri proved
-			// disruptive when a large volume of MVCC GC work is suddenly
-			// accrued (if an old protected timestamp record was just released
-			// for ex. following a long paused backup job being
-			// completed/canceled, or just an old, long running backup job
-			// finishing). For now, use a cluster setting that defaults to
-			// BulkNormalPri.
-			//
-			// After we implement dynamic priority adjustment, it's not clear
-			// whether we need additional pacing mechanisms to provide better
-			// latency isolation similar to ongoing work for backups (since MVCC
-			// GC work is CPU intensive): #82955. It's also worth noting that we
-			// might be able to do most MVCC GC work as part of regular
-			// compactions (#42514) -- the CPU use by the MVCC GC queue during
-			// keyspace might still be worth explicitly accounting/limiting, but
-			// it'll be lessened overall.
-			Priority:                 int32(pri),
-			CreateTime:               timeutil.Now().UnixNano(),
-			Source:                   kvpb.AdmissionHeader_ROOT_KV,
-			NoMemoryReservedAtSource: true,
-		}
+		ba.AdmissionHeader = gcAdmissionHeader(r.repl.ClusterSettings())
 		ba.Replica.StoreID = r.storeID
 		var err error
 		admissionHandle, err = r.admissionController.AdmitKVWork(ctx, roachpb.SystemTenantID, ba)
@@ -740,8 +711,8 @@ func (mgcq *mvccGCQueue) process(
 			storeID:             mgcq.store.StoreID(),
 		},
 		func(ctx context.Context, intents []roachpb.Intent) error {
-			intentCount, err := repl.store.intentResolver.
-				CleanupIntents(ctx, intents, gcTimestamp, kvpb.PUSH_TOUCH)
+			intentCount, err := repl.store.intentResolver.CleanupIntents(
+				ctx, gcAdmissionHeader(repl.store.ClusterSettings()), intents, gcTimestamp, kvpb.PUSH_TOUCH)
 			if err == nil {
 				mgcq.store.metrics.GCResolveSuccess.Inc(int64(intentCount))
 			} else {
@@ -751,7 +722,8 @@ func (mgcq *mvccGCQueue) process(
 		},
 		func(ctx context.Context, txn *roachpb.Transaction) error {
 			err := repl.store.intentResolver.
-				CleanupTxnIntentsOnGCAsync(ctx, repl.RangeID, txn, gcTimestamp,
+				CleanupTxnIntentsOnGCAsync(
+					ctx, gcAdmissionHeader(repl.store.ClusterSettings()), repl.RangeID, txn, gcTimestamp,
 					func(pushed, succeeded bool) {
 						if pushed {
 							mgcq.store.metrics.GCPushTxn.Inc(1)
@@ -913,4 +885,37 @@ func (*mvccGCQueue) purgatoryChan() <-chan time.Time {
 
 func (*mvccGCQueue) updateChan() <-chan time.Time {
 	return nil
+}
+
+func gcAdmissionHeader(st *cluster.Settings) kvpb.AdmissionHeader {
+	pri := admissionpb.WorkPriority(gc.AdmissionPriority.Get(&st.SV))
+	return kvpb.AdmissionHeader{
+		// TODO(irfansharif): GC could be expected to be BulkNormalPri, so
+		// that it does not impact user-facing traffic when resources (e.g.
+		// CPU, write capacity of the store) are scarce. However long delays
+		// in GC can slow down user-facing traffic due to more versions in
+		// the store, and can increase write amplification of the store
+		// since there is more live data. Ideally, we should adjust this
+		// priority based on how far behind we are with respect to GC-ing
+		// data in this range. Keeping it static at NormalPri proved
+		// disruptive when a large volume of MVCC GC work is suddenly
+		// accrued (if an old protected timestamp record was just released
+		// for ex. following a long paused backup job being
+		// completed/canceled, or just an old, long running backup job
+		// finishing). For now, use a cluster setting that defaults to
+		// BulkNormalPri.
+		//
+		// After we implement dynamic priority adjustment, it's not clear
+		// whether we need additional pacing mechanisms to provide better
+		// latency isolation similar to ongoing work for backups (since MVCC
+		// GC work is CPU intensive): #82955. It's also worth noting that we
+		// might be able to do most MVCC GC work as part of regular
+		// compactions (#42514) -- the CPU use by the MVCC GC queue during
+		// keyspace might still be worth explicitly accounting/limiting, but
+		// it'll be lessened overall.
+		Priority:                 int32(pri),
+		CreateTime:               timeutil.Now().UnixNano(),
+		Source:                   kvpb.AdmissionHeader_ROOT_KV,
+		NoMemoryReservedAtSource: true,
+	}
 }

--- a/pkg/kv/kvserver/rangefeed/catchup_scan_test.go
+++ b/pkg/kv/kvserver/rangefeed/catchup_scan_test.go
@@ -189,7 +189,7 @@ func TestCatchupScanSeesOldIntent(t *testing.T) {
 	require.NoError(t, storage.MVCCPut(ctx, eng, roachpb.Key("b"),
 		tsVersionInWindow, roachpb.MakeValueFromString("foo"), storage.MVCCWriteOptions{}))
 
-	txn := roachpb.MakeTransaction("foo", roachpb.Key("d"), isolation.Serializable, roachpb.NormalUserPriority, tsIntent, 100, 0)
+	txn := roachpb.MakeTransaction("foo", roachpb.Key("d"), isolation.Serializable, roachpb.NormalUserPriority, tsIntent, 100, 0, 0)
 	require.NoError(t, storage.MVCCPut(ctx, eng, roachpb.Key("d"),
 		tsIntent, roachpb.MakeValueFromString("intent"), storage.MVCCWriteOptions{Txn: &txn}))
 

--- a/pkg/kv/kvserver/replica_closedts_internal_test.go
+++ b/pkg/kv/kvserver/replica_closedts_internal_test.go
@@ -668,7 +668,7 @@ func TestQueryResolvedTimestamp(t *testing.T) {
 			tc.StartWithStoreConfig(ctx, t, stopper, cfg)
 
 			// Write an intent.
-			txn := roachpb.MakeTransaction("test", intentKey, 0, 0, intentTS, 0, 0)
+			txn := roachpb.MakeTransaction("test", intentKey, 0, 0, intentTS, 0, 0, 0)
 			{
 				pArgs := putArgs(intentKey, []byte("val"))
 				assignSeqNumsForReqs(&txn, &pArgs)
@@ -713,7 +713,7 @@ func TestQueryResolvedTimestampResolvesAbandonedIntents(t *testing.T) {
 
 	// Write an intent.
 	key := roachpb.Key("a")
-	txn := roachpb.MakeTransaction("test", key, 0, 0, ts10, 0, 0)
+	txn := roachpb.MakeTransaction("test", key, 0, 0, ts10, 0, 0, 0)
 	pArgs := putArgs(key, []byte("val"))
 	assignSeqNumsForReqs(&txn, &pArgs)
 	_, pErr := kv.SendWrappedWith(ctx, tc.Sender(), kvpb.Header{Txn: &txn}, &pArgs)
@@ -976,7 +976,7 @@ func TestServerSideBoundedStalenessNegotiation(t *testing.T) {
 				tc.StartWithStoreConfig(ctx, t, stopper, cfg)
 
 				// Write an intent.
-				txn := roachpb.MakeTransaction("test", intentKey, 0, 0, intentTS, 0, 0)
+				txn := roachpb.MakeTransaction("test", intentKey, 0, 0, intentTS, 0, 0, 0)
 				pArgs := putArgs(intentKey, []byte("val"))
 				assignSeqNumsForReqs(&txn, &pArgs)
 				_, pErr := kv.SendWrappedWith(ctx, tc.Sender(), kvpb.Header{Txn: &txn}, &pArgs)
@@ -1062,7 +1062,7 @@ func TestServerSideBoundedStalenessNegotiationWithResumeSpan(t *testing.T) {
 			send(kvpb.Header{Timestamp: makeTS(ts)}, &pArgs)
 		}
 		writeIntent := func(k string, ts int64) {
-			txn := roachpb.MakeTransaction("test", roachpb.Key(k), 0, 0, makeTS(ts), 0, 0)
+			txn := roachpb.MakeTransaction("test", roachpb.Key(k), 0, 0, makeTS(ts), 0, 0, 0)
 			pArgs := putArgs(roachpb.Key(k), val)
 			assignSeqNumsForReqs(&txn, &pArgs)
 			send(kvpb.Header{Txn: &txn}, &pArgs)

--- a/pkg/kv/kvserver/replica_closedts_test.go
+++ b/pkg/kv/kvserver/replica_closedts_test.go
@@ -779,7 +779,7 @@ func TestNonBlockingReadsAtResolvedTimestamp(t *testing.T) {
 			scan := kvpb.ScanRequest{
 				RequestHeader: kvpb.RequestHeaderFromSpan(keySpan),
 			}
-			txn := roachpb.MakeTransaction("test", keySpan.Key, 0, 0, resTS, 0, 0)
+			txn := roachpb.MakeTransaction("test", keySpan.Key, 0, 0, resTS, 0, 0, 0)
 			scanHeader := kvpb.Header{
 				RangeID:         rangeID,
 				ReadConsistency: kvpb.CONSISTENT,

--- a/pkg/kv/kvserver/replica_evaluate_test.go
+++ b/pkg/kv/kvserver/replica_evaluate_test.go
@@ -37,7 +37,7 @@ func TestEvaluateBatch(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ts := hlc.Timestamp{WallTime: 1}
-	txn := roachpb.MakeTransaction("test", roachpb.Key("a"), 0, 0, ts, 0, 0)
+	txn := roachpb.MakeTransaction("test", roachpb.Key("a"), 0, 0, ts, 0, 0, 0)
 
 	tcs := []testCase{
 		//

--- a/pkg/kv/kvserver/replica_follower_read_test.go
+++ b/pkg/kv/kvserver/replica_follower_read_test.go
@@ -89,6 +89,7 @@ func TestCanServeFollowerRead(t *testing.T) {
 				test.readTimestamp,
 				clock.MaxOffset().Nanoseconds(),
 				0, // coordinatorNodeID
+				0,
 			)
 
 			ba := &kvpb.BatchRequest{}
@@ -170,6 +171,7 @@ func TestCheckExecutionCanProceedAllowsFollowerReadWithInvalidLease(t *testing.T
 		tsBelowClosedTimestamp,
 		clock.MaxOffset().Nanoseconds(),
 		0, // coordinatorNodeID
+		0,
 	)
 
 	ba := &kvpb.BatchRequest{}

--- a/pkg/kv/kvserver/replica_learner_test.go
+++ b/pkg/kv/kvserver/replica_learner_test.go
@@ -1662,7 +1662,7 @@ func TestLearnerAndVoterOutgoingFollowerRead(t *testing.T) {
 
 	check := func() {
 		ts := tc.Server(0).Clock().Now()
-		txn := roachpb.MakeTransaction("txn", nil, 0, 0, ts, 0, int32(tc.Server(0).SQLInstanceID()))
+		txn := roachpb.MakeTransaction("txn", nil, 0, 0, ts, 0, int32(tc.Server(0).SQLInstanceID()), 0)
 		req := &kvpb.BatchRequest{Header: kvpb.Header{
 			RangeID:   scratchDesc.RangeID,
 			Timestamp: ts,

--- a/pkg/kv/kvserver/replica_rangefeed.go
+++ b/pkg/kv/kvserver/replica_rangefeed.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/admission"
+	"github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/future"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -168,7 +169,16 @@ func (tp *rangefeedTxnPusher) ResolveIntents(
 ) error {
 	return tp.ir.ResolveIntents(ctx, intents,
 		// NB: Poison is ignored for non-ABORTED intents.
-		intentresolver.ResolveOptions{Poison: true},
+		intentresolver.ResolveOptions{Poison: true, AdmissionHeader: kvpb.AdmissionHeader{
+			// Use NormalPri for rangefeed intent resolution, since it needs to be
+			// timely. NB: makeRangeFeedRequest decides the priority based on
+			// isSystemRange, but that is only for the initial scan, which can be
+			// expensive.
+			Priority:                 int32(admissionpb.NormalPri),
+			CreateTime:               timeutil.Now().UnixNano(),
+			Source:                   kvpb.AdmissionHeader_FROM_SQL,
+			NoMemoryReservedAtSource: true,
+		}},
 	).GoError()
 }
 

--- a/pkg/kv/kvserver/replica_read.go
+++ b/pkg/kv/kvserver/replica_read.go
@@ -210,6 +210,7 @@ func (r *Replica) executeReadOnlyBatch(
 			ba.WaitPolicy != lock.WaitPolicy_SkipLocked
 		if err := r.store.intentResolver.CleanupIntentsAsync(
 			ctx,
+			ba.AdmissionHeader,
 			intents,
 			allowSyncProcessing,
 		); err != nil {

--- a/pkg/kv/kvserver/replica_send.go
+++ b/pkg/kv/kvserver/replica_send.go
@@ -472,6 +472,7 @@ func (r *Replica) executeBatchWithConcurrencyRetries(
 			ReadConsistency: ba.ReadConsistency,
 			WaitPolicy:      ba.WaitPolicy,
 			LockTimeout:     ba.LockTimeout,
+			AdmissionHeader: ba.AdmissionHeader,
 			PoisonPolicy:    pp,
 			Requests:        ba.Requests,
 			LatchSpans:      latchSpans, // nil if g != nil

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -319,7 +319,7 @@ func newTransaction(
 		offset = clock.MaxOffset().Nanoseconds()
 		now = clock.Now()
 	}
-	txn := roachpb.MakeTransaction(name, baseKey, isoLevel, userPriority, now, offset, 0)
+	txn := roachpb.MakeTransaction(name, baseKey, isoLevel, userPriority, now, offset, 0, 0)
 	return &txn
 }
 
@@ -4810,7 +4810,7 @@ func TestErrorsDontCarryWriteTooOldFlag(t *testing.T) {
 	keyB := roachpb.Key("b")
 	// Start a transaction early to get a low timestamp.
 	txn := roachpb.MakeTransaction("test", keyA, isolation.Serializable, roachpb.NormalUserPriority,
-		tc.Clock().Now(), 0 /* maxOffsetNs */, 0 /* coordinatorNodeID */)
+		tc.Clock().Now(), 0 /* maxOffsetNs */, 0 /* coordinatorNodeID */, 0)
 
 	// Write a value outside of the txn to cause a WriteTooOldError later.
 	put := putArgs(keyA, []byte("val1"))
@@ -8416,7 +8416,7 @@ func TestRefreshFromBelowGCThreshold(t *testing.T) {
 				RefreshFrom:   ts2,
 			}
 		}
-		txn := roachpb.MakeTransaction("test", keyA, 0, 0, ts2, 0, 0)
+		txn := roachpb.MakeTransaction("test", keyA, 0, 0, ts2, 0, 0, 0)
 		txn.BumpReadTimestamp(ts4)
 
 		for _, testCase := range []struct {
@@ -10373,8 +10373,7 @@ func TestReplicaServersideRefreshes(t *testing.T) {
 	tc.manualClock.Advance(1)
 
 	newTxn := func(key string, ts hlc.Timestamp) *roachpb.Transaction {
-		txn := roachpb.MakeTransaction(
-			"test", roachpb.Key(key), isolation.Serializable, roachpb.NormalUserPriority, ts, 0, 0)
+		txn := roachpb.MakeTransaction("test", roachpb.Key(key), isolation.Serializable, roachpb.NormalUserPriority, ts, 0, 0, 0)
 		return &txn
 	}
 	send := func(ba *kvpb.BatchRequest) (hlc.Timestamp, error) {
@@ -11008,7 +11007,7 @@ func TestReplicaPushed1PC(t *testing.T) {
 
 	// Start a transaction and assign its ReadTimestamp.
 	ts1 := tc.Clock().Now()
-	txn := roachpb.MakeTransaction("test", k, isolation.Serializable, roachpb.NormalUserPriority, ts1, 0, 0)
+	txn := roachpb.MakeTransaction("test", k, isolation.Serializable, roachpb.NormalUserPriority, ts1, 0, 0, 0)
 
 	// Write a value outside the transaction.
 	tc.manualClock.Advance(10)

--- a/pkg/kv/kvserver/replica_write.go
+++ b/pkg/kv/kvserver/replica_write.go
@@ -222,7 +222,7 @@ func (r *Replica) executeWriteBatch(
 			}
 			if len(propResult.EncounteredIntents) > 0 {
 				if err := r.store.intentResolver.CleanupIntentsAsync(
-					ctx, propResult.EncounteredIntents, true, /* allowSync */
+					ctx, ba.AdmissionHeader, propResult.EncounteredIntents, true, /* allowSync */
 				); err != nil {
 					log.Warningf(ctx, "intent cleanup failed: %v", err)
 				}

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -2140,7 +2140,7 @@ func TestStoreSkipLockedTSCache(t *testing.T) {
 			t1 := timeutil.Unix(2, 0)
 			manualClock.MustAdvanceTo(t1)
 			lockedKey := roachpb.Key("b")
-			txn := roachpb.MakeTransaction("locker", lockedKey, 0, 0, makeTS(t1.UnixNano(), 0), 0, 0)
+			txn := roachpb.MakeTransaction("locker", lockedKey, 0, 0, makeTS(t1.UnixNano(), 0), 0, 0, 0)
 			txnH := kvpb.Header{Txn: &txn}
 			putArgs := putArgs(lockedKey, []byte("newval"))
 			_, pErr := kv.SendWrappedWith(ctx, store.TestSender(), txnH, &putArgs)

--- a/pkg/kv/kvserver/txnrecovery/manager_test.go
+++ b/pkg/kv/kvserver/txnrecovery/manager_test.go
@@ -40,7 +40,7 @@ func makeManager(s *kv.Sender) (Manager, *hlc.Clock, *stop.Stopper) {
 func makeStagingTransaction(clock *hlc.Clock) roachpb.Transaction {
 	now := clock.Now()
 	offset := clock.MaxOffset().Nanoseconds()
-	txn := roachpb.MakeTransaction("test", roachpb.Key("a"), 0, 0, now, offset, 0)
+	txn := roachpb.MakeTransaction("test", roachpb.Key("a"), 0, 0, now, offset, 0, 0)
 	txn.Status = roachpb.STAGING
 	return txn
 }

--- a/pkg/kv/kvserver/txnwait/queue_test.go
+++ b/pkg/kv/kvserver/txnwait/queue_test.go
@@ -523,7 +523,7 @@ func TestMaybeWaitForPushWithContextCancellation(t *testing.T) {
 	q.Enable(1 /* leaseSeq */)
 
 	// Enqueue pushee transaction in the queue.
-	txn := roachpb.MakeTransaction("test", nil, 0, 0, cfg.Clock.Now(), 0, 0)
+	txn := roachpb.MakeTransaction("test", nil, 0, 0, cfg.Clock.Now(), 0, 0, 0)
 	q.EnqueueTxn(&txn)
 
 	// Mock out responses to any QueryTxn requests.
@@ -614,7 +614,7 @@ func TestPushersReleasedAfterAnyQueryTxnFindsAbortedTxn(t *testing.T) {
 	defer TestingOverrideTxnLivenessThreshold(time.Hour)()
 
 	// Enqueue pushee transaction in the queue.
-	txn := roachpb.MakeTransaction("test", nil, 0, 0, cfg.Clock.Now(), 0, 0)
+	txn := roachpb.MakeTransaction("test", nil, 0, 0, cfg.Clock.Now(), 0, 0, 0)
 	q.EnqueueTxn(&txn)
 
 	const numPushees = 3

--- a/pkg/kv/txn.go
+++ b/pkg/kv/txn.go
@@ -139,6 +139,7 @@ func NewTxnWithAdmissionControl(
 		now.ToTimestamp(),
 		db.clock.MaxOffset().Nanoseconds(),
 		int32(db.ctx.NodeID.SQLInstanceID()),
+		priority,
 	)
 	txn := NewTxnFromProto(ctx, db, gatewayNodeID, now, RootTxn, &kvTxn)
 	txn.admissionHeader = kvpb.AdmissionHeader{
@@ -1639,20 +1640,8 @@ func (txn *Txn) DeferCommitWait(ctx context.Context) func(context.Context) error
 func (txn *Txn) AdmissionHeader() kvpb.AdmissionHeader {
 	h := txn.admissionHeader
 	if txn.mu.sender.IsLocking() {
-		// Assign higher priority to requests by txns that are locking, so that
-		// they release locks earlier. Note that this is a crude approach, and is
-		// worse than priority inheritance used for locks in realtime systems. We
-		// do this because admission control does not have visibility into the
-		// exact locks held by waiters in the admission queue, and cannot compare
-		// that with priorities of waiting requests in the various lock table
-		// queues. This crude approach has shown some benefit in tpcc with 3000
-		// warehouses, where it halved the number of lock waiters, and increased
-		// the transaction throughput by 10+%. In that experiment 40% of the
-		// BatchRequests evaluated by KV had been assigned high priority due to
-		// locking.
-		if h.Priority < int32(admissionpb.LockingPri) {
-			h.Priority = int32(admissionpb.LockingPri)
-		}
+		h.Priority = int32(admissionpb.AdjustedPriorityWhenHoldingLocks(
+			admissionpb.WorkPriority(h.Priority)))
 	}
 	return h
 }

--- a/pkg/roachpb/BUILD.bazel
+++ b/pkg/roachpb/BUILD.bazel
@@ -32,6 +32,7 @@ go_library(
         "//pkg/settings",
         "//pkg/storage/enginepb",
         "//pkg/util",
+        "//pkg/util/admission/admissionpb",
         "//pkg/util/bitarray",
         "//pkg/util/duration",
         "//pkg/util/encoding",

--- a/pkg/roachpb/data.proto
+++ b/pkg/roachpb/data.proto
@@ -501,6 +501,20 @@ message Transaction {
   repeated storage.enginepb.IgnoredSeqNumRange ignored_seqnums = 18
     [(gogoproto.nullable) = false, (gogoproto.customname) = "IgnoredSeqNums"];
 
+  // Admission control (AC) fields. AC needs the tuple (TenantID, Priority,
+  // CreateTime). TenantID can be inferred from the key space that is being
+  // operated on (in the future we will generalize the AC concept of TenantID,
+  // but for now this is tied to the serverless concept), so does not need to
+  // be stored. CreateTime is the same as TxnMeta.MinTimestamp. So we only
+  // store the AdmissionPriority.
+
+  // AdmissionPriority is the priority assigned for admission control, at
+  // transaction creation time. It is immutable.
+  //
+  // TODO(sumeer): Use gogoproto.customtype to make this
+  // admissionpb.WorkPriority.
+  sint32 admission_priority = 19;
+
   reserved 3, 6, 9, 13, 14;
 }
 

--- a/pkg/roachpb/data_test.go
+++ b/pkg/roachpb/data_test.go
@@ -438,7 +438,7 @@ func TestSetGetChecked(t *testing.T) {
 
 func TestTransactionBumpEpoch(t *testing.T) {
 	origNow := makeTS(10, 1)
-	txn := MakeTransaction("test", Key("a"), isolation.Serializable, 1, origNow, 0, 99)
+	txn := MakeTransaction("test", Key("a"), isolation.Serializable, 1, origNow, 0, 99, 0)
 	// Advance the txn timestamp.
 	txn.WriteTimestamp = txn.WriteTimestamp.Add(10, 2)
 	txn.BumpEpoch()
@@ -568,6 +568,7 @@ var nonZeroTxn = Transaction{
 	InFlightWrites:     []SequencedWrite{{Key: []byte("c"), Sequence: 1}},
 	ReadTimestampFixed: true,
 	IgnoredSeqNums:     []enginepb.IgnoredSeqNumRange{{Start: 888, End: 999}},
+	AdmissionPriority:  1,
 }
 
 func TestTransactionUpdate(t *testing.T) {
@@ -2128,7 +2129,7 @@ func TestTxnLocksAsLockUpdates(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ts := hlc.Timestamp{WallTime: 1}
-	txn := MakeTransaction("hello", Key("k"), isolation.Serializable, 0, ts, 0, 99)
+	txn := MakeTransaction("hello", Key("k"), isolation.Serializable, 0, ts, 0, 99, 0)
 
 	txn.Status = COMMITTED
 	txn.IgnoredSeqNums = []enginepb.IgnoredSeqNumRange{{Start: 0, End: 0}}

--- a/pkg/sql/flowinfra/cluster_test.go
+++ b/pkg/sql/flowinfra/cluster_test.go
@@ -99,6 +99,7 @@ func runTestClusterFlow(
 		now.ToTimestamp(),
 		0, // maxOffsetNs
 		int32(servers[0].SQLInstanceID()),
+		0,
 	)
 	txn := kv.NewTxnFromProto(ctx, kvDB, roachpb.NodeID(servers[0].SQLInstanceID()), now, kv.RootTxn, &txnProto)
 	leafInputState, err := txn.GetLeafTxnInputState(ctx)
@@ -411,6 +412,7 @@ func TestLimitedBufferingDeadlock(t *testing.T) {
 		now.ToTimestamp(),
 		0, // maxOffsetNs
 		int32(tc.Server(0).SQLInstanceID()),
+		0,
 	)
 	txn := kv.NewTxnFromProto(
 		context.Background(), tc.Server(0).DB(), tc.Server(0).NodeID(),
@@ -716,6 +718,7 @@ func BenchmarkInfrastructure(b *testing.B) {
 						now.ToTimestamp(),
 						0, // maxOffsetNs
 						int32(tc.Server(0).SQLInstanceID()),
+						0,
 					)
 					txn := kv.NewTxnFromProto(
 						context.Background(), tc.Server(0).DB(), tc.Server(0).NodeID(),

--- a/pkg/sql/sem/eval/timeconv_test.go
+++ b/pkg/sql/sem/eval/timeconv_test.go
@@ -66,6 +66,7 @@ func TestClusterTimestampConversion(t *testing.T) {
 			ts.ToTimestamp(),
 			0, // maxOffsetNs
 			1, // coordinatorNodeID
+			0,
 		)
 
 		ctx := eval.Context{

--- a/pkg/sql/sessiondatapb/local_only_session_data.go
+++ b/pkg/sql/sessiondatapb/local_only_session_data.go
@@ -293,12 +293,16 @@ const (
 	// Normal denotes an end user QoS level unchanged from the default.
 	Normal = QoSLevel(admissionpb.NormalPri)
 
+	// LockingNormal denotes an internal increased priority for normal
+	// transactions that are acquiring locks.
+	LockingNormal = QoSLevel(admissionpb.LockingNormalPri)
+
 	// UserHigh denotes an end user QoS level higher than the default.
 	UserHigh = QoSLevel(admissionpb.UserHighPri)
 
-	// Locking denotes an internal increased priority for transactions that are
-	// acquiring locks.
-	Locking = QoSLevel(admissionpb.LockingPri)
+	// LockingHigh denotes an internal increased priority for UserHigh
+	// transactions that are acquiring locks.
+	LockingHigh = QoSLevel(admissionpb.LockingUserHighPri)
 
 	// SystemHigh denotes the maximum system QoS level, which is not settable as a
 	// session default_transaction_quality_of_service value.
@@ -329,18 +333,24 @@ const (
 	// TTLLowName is the string value to display indicating a TTLLow QoS level.
 	TTLLowName = "ttl_low"
 
-	// LockingName is the string value to display indicating a Locking QoS level.
-	LockingName = "locking"
+	// LockingNormalName is the string value to display indicating a
+	// LockingNormal QoS level.
+	LockingNormalName = "locking-normal"
+
+	// LockingHighName is the string value to display indicating a LockingHigh
+	// QoS level.
+	LockingHighName = "locking-high"
 )
 
 var qosLevelsDict = map[QoSLevel]string{
-	SystemLow:  SystemLowName,
-	TTLLow:     TTLLowName,
-	UserLow:    UserLowName,
-	Normal:     NormalName,
-	UserHigh:   UserHighName,
-	Locking:    LockingName,
-	SystemHigh: SystemHighName,
+	SystemLow:     SystemLowName,
+	TTLLow:        TTLLowName,
+	UserLow:       UserLowName,
+	Normal:        NormalName,
+	LockingNormal: LockingNormalName,
+	UserHigh:      UserHighName,
+	LockingHigh:   LockingHighName,
+	SystemHigh:    SystemHighName,
 }
 
 // ParseQoSLevelFromString converts a string into a QoSLevel

--- a/pkg/storage/engine_test.go
+++ b/pkg/storage/engine_test.go
@@ -1634,7 +1634,7 @@ func TestEngineClearRange(t *testing.T) {
 	//
 	// However, certain clearers cannot clear intents, range keys, or point keys.
 	writeInitialData := func(t *testing.T, rw ReadWriter) {
-		txn := roachpb.MakeTransaction("test", nil, isolation.Serializable, roachpb.NormalUserPriority, wallTS(6), 1, 1)
+		txn := roachpb.MakeTransaction("test", nil, isolation.Serializable, roachpb.NormalUserPriority, wallTS(6), 1, 1, 0)
 		require.NoError(t, MVCCPut(ctx, rw, roachpb.Key("c"), wallTS(1), stringValue("c1").Value, MVCCWriteOptions{}))
 		require.NoError(t, rw.PutMVCCRangeKey(rangeKey("d", "h", 1), MVCCValue{}))
 		require.NoError(t, rw.PutMVCCRangeKey(rangeKey("a", "f", 2), MVCCValue{}))

--- a/pkg/storage/mvcc_stats_test.go
+++ b/pkg/storage/mvcc_stats_test.go
@@ -1770,7 +1770,7 @@ func TestMVCCStatsRandomized(t *testing.T) {
 	}
 	actions["EnsureTxn"] = func(s *state) (bool, string) {
 		if s.Txn == nil {
-			txn := roachpb.MakeTransaction("test", nil, 0, 0, s.TS, 0, 1)
+			txn := roachpb.MakeTransaction("test", nil, 0, 0, s.TS, 0, 1, 0)
 			s.Txn = &txn
 		}
 		return true, ""

--- a/pkg/storage/mvcc_test.go
+++ b/pkg/storage/mvcc_test.go
@@ -2011,7 +2011,7 @@ func TestMVCCClearTimeRange(t *testing.T) {
 	})
 
 	// Add an intent at k3@ts3.
-	txn := roachpb.MakeTransaction("test", nil, isolation.Serializable, roachpb.NormalUserPriority, ts3, 1, 1)
+	txn := roachpb.MakeTransaction("test", nil, isolation.Serializable, roachpb.NormalUserPriority, ts3, 1, 1, 0)
 	addIntent := func(t *testing.T, rw ReadWriter) {
 		require.NoError(t, MVCCPut(ctx, rw, testKey3, ts3, value3, MVCCWriteOptions{Txn: &txn}))
 	}

--- a/pkg/storage/pebble_test.go
+++ b/pkg/storage/pebble_test.go
@@ -470,7 +470,7 @@ type testValue struct {
 func intent(key roachpb.Key, val string, ts hlc.Timestamp) testValue {
 	var value = roachpb.MakeValueFromString(val)
 	value.InitChecksum(key)
-	tx := roachpb.MakeTransaction(fmt.Sprintf("txn-%v", key), key, isolation.Serializable, roachpb.NormalUserPriority, ts, 1000, 99)
+	tx := roachpb.MakeTransaction(fmt.Sprintf("txn-%v", key), key, isolation.Serializable, roachpb.NormalUserPriority, ts, 1000, 99, 0)
 	var txn = &tx
 	return testValue{key, value, ts, txn}
 }

--- a/pkg/util/admission/admissionpb/BUILD.bazel
+++ b/pkg/util/admission/admissionpb/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb",
     visibility = ["//visibility:public"],
     deps = [
+        "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_redact//:redact",
         "@com_github_cockroachdb_redact//interfaces",
     ],

--- a/pkg/util/admission/admissionpb/admissionpb.go
+++ b/pkg/util/admission/admissionpb/admissionpb.go
@@ -13,6 +13,7 @@ package admissionpb
 import (
 	"math"
 
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/redact"
 )
 
@@ -21,6 +22,8 @@ import (
 // priority work.
 type WorkPriority int8
 
+// When adding to this list, remember to update the initialization logic of
+// workPriorityToLockPriMap.
 const (
 	// LowPri is low priority work.
 	LowPri WorkPriority = math.MinInt8
@@ -33,10 +36,14 @@ const (
 	BulkNormalPri WorkPriority = -30
 	// NormalPri is normal priority work.
 	NormalPri WorkPriority = 0
+	// LockingNormalPri is used for user normal priority transactions that are
+	// acquiring locks.
+	LockingNormalPri WorkPriority = 10
 	// UserHighPri is high priority work from user submissions (SQL).
 	UserHighPri WorkPriority = 50
-	// LockingPri is for transactions that are acquiring locks.
-	LockingPri WorkPriority = 100
+	// LockingUserHighPri is for user high priority transactions that are
+	// acquiring locks.
+	LockingUserHighPri WorkPriority = 100
 	// HighPri is high priority work.
 	HighPri WorkPriority = math.MaxInt8
 	// OneAboveHighPri is one priority level above the highest priority.
@@ -59,14 +66,30 @@ func (w WorkPriority) SafeFormat(p redact.SafePrinter, verb rune) {
 // WorkPriorityDict is a mapping of the priorities to a short string name. The
 // name is used as the suffix on exported work queue metrics.
 var WorkPriorityDict = map[WorkPriority]string{
-	LowPri:        "low-pri",
-	TTLLowPri:     "ttl-low-pri",
-	UserLowPri:    "user-low-pri",
-	BulkNormalPri: "bulk-normal-pri",
-	NormalPri:     "normal-pri",
-	UserHighPri:   "user-high-pri",
-	LockingPri:    "locking-pri",
-	HighPri:       "high-pri",
+	LowPri:           "low-pri",
+	TTLLowPri:        "ttl-low-pri",
+	UserLowPri:       "user-low-pri",
+	BulkNormalPri:    "bulk-normal-pri",
+	NormalPri:        "normal-pri",
+	LockingNormalPri: "locking-normal-pri",
+	UserHighPri:      "user-high-pri",
+	// This ought to be called "locking-user-high-pri", but we retain the old
+	// name for continuity with metrics in older versions.
+	LockingUserHighPri: "locking-pri",
+	HighPri:            "high-pri",
+}
+
+// workPriorityToLockPriMap maps WorkPriority to another WorkPriority for when
+// the txn has already acquired a lock. Since WorkPriority can be negative,
+// and this map is an array, the index into the array is priToArrayIndex(p)
+// where p is a WorkPriority.
+//
+// The priority mapping is not simply p+1 since the enum values are used in
+// exported metrics, and we don't want to increase the number of such metrics.
+var workPriorityToLockPriMap [math.MaxInt8 - math.MinInt8 + 1]WorkPriority
+
+func priToArrayIndex(pri WorkPriority) int {
+	return int(pri) - math.MinInt8
 }
 
 // TestingReverseWorkPriorityDict is the reverse-lookup dictionary for
@@ -78,6 +101,74 @@ func init() {
 	for k, v := range WorkPriorityDict {
 		TestingReverseWorkPriorityDict[v] = k
 	}
+
+	orderedPris := []WorkPriority{
+		LowPri,
+		TTLLowPri,
+		UserLowPri,
+		BulkNormalPri,
+		NormalPri,
+		LockingNormalPri,
+		UserHighPri,
+		LockingUserHighPri,
+		HighPri,
+	}
+	j := 0
+	for i := range workPriorityToLockPriMap {
+		pri := WorkPriority(i) + math.MinInt8
+		if pri == orderedPris[j] && i != len(workPriorityToLockPriMap)-1 {
+			// Move to the next higher priority.
+			j++
+		}
+		workPriorityToLockPriMap[i] = orderedPris[j]
+	}
+	for i := range workPriorityToLockPriMap {
+		if priToArrayIndex(workPriorityToLockPriMap[i]) < i {
+			panic(errors.AssertionFailedf("workPriorityToLockPriMap at index %d has value %d",
+				i, workPriorityToLockPriMap[i]))
+		}
+		if priToArrayIndex(workPriorityToLockPriMap[i]) == i && i != priToArrayIndex(math.MaxInt8) {
+			panic(errors.AssertionFailedf(
+				"workPriorityToLockPriMap at index %d has no change for locking", i))
+		}
+	}
+}
+
+// AdjustedPriorityWhenHoldingLocks takes the original priority of a
+// transaction and updates it under the knowledge that the transaction is
+// holding locks.
+//
+// This broader context of locking is technically not in scope of the
+// admission package, but we define this function here as the WorkPriority
+// enum values are defined here.
+//
+// For example, UserLowPri should map to BulkNormalPri (see the hack below),
+// NormalPri maps to LockingNormalPri, and UserHighPri maps to
+// LockingUserHighPri. Say users are running at these different priorities in
+// different parts of the key space, say key-low, key-normal, key-high, then
+// even after the mapping, a txn holding locks (or resolving intents) in
+// key-low will have lower priority (BulkNormalPri) than the non-adjusted
+// priority in key-normal (NormalPri). The same holds true for txn holding
+// locks in key-normal, since LockingNormalPri is lower priority than
+// UserHighPri.
+//
+// Adjusting the priority can also be beneficial when all txns have the same
+// QoS requirements, but there is lock contention. In tpcc with 3000
+// warehouses, it halved the number of lock waiters, and increased the
+// transaction throughput by 10+%. In that experiment 40% of the BatchRequests
+// evaluated by KV had been assigned a higher priority due to locking.
+func AdjustedPriorityWhenHoldingLocks(pri WorkPriority) WorkPriority {
+	// TODO(sumeer): this is a temporary hack since index backfill and TTL can
+	// be running on tables that have user-facing work. We want these background
+	// transactions (when holding locks) to run at the priority of user-facing
+	// work + 1, but we don't know what that value is. This could be solved by
+	// providing the user-facing work priority in a SpanConfig, but for now we
+	// just assume that all user-facing work is running at NormalPri. See the
+	// examples in intentresolver/admission.go.
+	if pri < NormalPri {
+		pri = NormalPri
+	}
+	return workPriorityToLockPriMap[priToArrayIndex(pri)]
 }
 
 // WorkClass represents the class of work, which is defined entirely by its
@@ -129,5 +220,5 @@ var _ = TTLLowPri
 var _ = UserLowPri
 var _ = NormalPri
 var _ = UserHighPri
-var _ = LockingPri
+var _ = LockingUserHighPri
 var _ = HighPri

--- a/pkg/util/admission/grant_coordinator.go
+++ b/pkg/util/admission/grant_coordinator.go
@@ -462,7 +462,7 @@ func makeStoresGrantCoordinators(
 	storeWorkQueueMetrics :=
 		makeWorkQueueMetrics(workKindString(KVWork)+"-stores", registry,
 			admissionpb.TTLLowPri, admissionpb.BulkNormalPri,
-			admissionpb.NormalPri, admissionpb.LockingPri)
+			admissionpb.NormalPri, admissionpb.LockingNormalPri)
 	makeStoreRequester := makeStoreWorkQueue
 	if opts.makeStoreRequesterFunc != nil {
 		makeStoreRequester = opts.makeStoreRequesterFunc
@@ -530,7 +530,7 @@ func makeRegularGrantCoordinator(
 	}
 
 	kvSlotAdjuster.granter = kvg
-	wqMetrics := makeWorkQueueMetrics(workKindString(KVWork), registry, admissionpb.NormalPri, admissionpb.LockingPri)
+	wqMetrics := makeWorkQueueMetrics(workKindString(KVWork), registry, admissionpb.NormalPri, admissionpb.LockingNormalPri)
 	req := makeRequester(ambientCtx, KVWork, kvg, st, wqMetrics, makeWorkQueueOptions(KVWork))
 	coord.queues[KVWork] = req
 	kvg.requester = req
@@ -543,7 +543,7 @@ func makeRegularGrantCoordinator(
 		maxBurstTokens:       opts.SQLKVResponseBurstTokens,
 		cpuOverload:          kvSlotAdjuster,
 	}
-	wqMetrics = makeWorkQueueMetrics(workKindString(SQLKVResponseWork), registry, admissionpb.NormalPri, admissionpb.LockingPri)
+	wqMetrics = makeWorkQueueMetrics(workKindString(SQLKVResponseWork), registry, admissionpb.NormalPri, admissionpb.LockingNormalPri)
 	req = makeRequester(
 		ambientCtx, SQLKVResponseWork, tg, st, wqMetrics, makeWorkQueueOptions(SQLKVResponseWork))
 	coord.queues[SQLKVResponseWork] = req
@@ -557,7 +557,7 @@ func makeRegularGrantCoordinator(
 		maxBurstTokens:       opts.SQLSQLResponseBurstTokens,
 		cpuOverload:          kvSlotAdjuster,
 	}
-	wqMetrics = makeWorkQueueMetrics(workKindString(SQLSQLResponseWork), registry, admissionpb.NormalPri, admissionpb.LockingPri)
+	wqMetrics = makeWorkQueueMetrics(workKindString(SQLSQLResponseWork), registry, admissionpb.NormalPri, admissionpb.LockingNormalPri)
 	req = makeRequester(ambientCtx,
 		SQLSQLResponseWork, tg, st, wqMetrics, makeWorkQueueOptions(SQLSQLResponseWork))
 	coord.queues[SQLSQLResponseWork] = req
@@ -571,7 +571,7 @@ func makeRegularGrantCoordinator(
 		cpuOverload:     kvSlotAdjuster,
 		usedSlotsMetric: metrics.SQLLeafStartUsedSlots,
 	}
-	wqMetrics = makeWorkQueueMetrics(workKindString(SQLStatementLeafStartWork), registry, admissionpb.NormalPri, admissionpb.LockingPri)
+	wqMetrics = makeWorkQueueMetrics(workKindString(SQLStatementLeafStartWork), registry, admissionpb.NormalPri, admissionpb.LockingNormalPri)
 	req = makeRequester(ambientCtx,
 		SQLStatementLeafStartWork, sg, st, wqMetrics, makeWorkQueueOptions(SQLStatementLeafStartWork))
 	coord.queues[SQLStatementLeafStartWork] = req
@@ -585,7 +585,7 @@ func makeRegularGrantCoordinator(
 		cpuOverload:     kvSlotAdjuster,
 		usedSlotsMetric: metrics.SQLRootStartUsedSlots,
 	}
-	wqMetrics = makeWorkQueueMetrics(workKindString(SQLStatementRootStartWork), registry, admissionpb.NormalPri, admissionpb.LockingPri)
+	wqMetrics = makeWorkQueueMetrics(workKindString(SQLStatementRootStartWork), registry, admissionpb.NormalPri, admissionpb.LockingNormalPri)
 	req = makeRequester(ambientCtx,
 		SQLStatementRootStartWork, sg, st, wqMetrics, makeWorkQueueOptions(SQLStatementRootStartWork))
 	coord.queues[SQLStatementRootStartWork] = req


### PR DESCRIPTION

Intents are locks, and this change would worsen the lock
"priority inversion" problem introduced due to a combination of AC
queueing and lock table queueing. So we first redefine the AC
performance isolation goals when using different priorities or tenants.
This is outlined in a long comment in intentresolver.go, which follows
the argument in the internal doc
https://docs.google.com/document/d/1N2v_LdkJFzEVxft6qDQFvaGs1q_HiCnW9BSLji1rd98.

The summary is:
- Intent resolution uses the the (tenantID, priority, createTime) of
  the transaction (or internal work) that is trying to resolve the intent.
- Any transaction that has already acquired locks (or anything doing
  intent resolution) increments the priority by the minimum possible
  amount to proceed faster.

Subjecting intent resolution to admission control means that requests
that are waiting on locks, and therefore have already been admitted,
have their intent resolution requests also wait for admission. We ignore
the possibility of (distributed) deadlock in the KV CPU slots mechanism
due to this repeated waiting. CPU slots grow when slots are fully used
and CPU is under-utilized, so there is a possibility of a small delay
(to allow for the slots to grow), but no possibility of deadlock.

There are two cluster settings:
- kv.intent_resolver.send_immediately.bypass_admission_control.enabled
  defaults to true, and does not subject the single intent resolution
  corresponding to the sendImmediately case to admission control.
- kv.intent_resolver.batch.bypass_admission_control.enabled defaults
  to false, and subjects batched intent resolution to admission
  control.

Informs https://github.com/cockroachdb/cockroach/issues/97108

Epic: CRDB-25458

Release note (ops change): Two cluster settings are introduced to
control whether intent resolution is subject to admission control:
kv.intent_resolver.send_immediately.bypass_admission_control.enabled
and kv.intent_resolver.batch.bypass_admission_control.enabled.