### PR TITLE
roachtest: metamorphically run restore roachtests with simpleImportSpans

### DIFF
--- a/pkg/cmd/roachtest/tests/restore.go
+++ b/pkg/cmd/roachtest/tests/restore.go
@@ -824,6 +824,13 @@ func (rd *restoreDriver) prepareCluster(ctx context.Context) {
 	rd.c.Put(ctx, rd.t.Cockroach(), "./cockroach")
 	rd.c.Start(ctx, rd.t.L(), option.DefaultStartOptsNoBackups(), install.MakeClusterSettings())
 	rd.getAOST(ctx)
+
+	if rand.Intn(2) == 0 {
+		rd.t.L().Printf("Running non-default makeSimpleImportSpans")
+		conn := rd.c.Conn(ctx, rd.t.L(), 1)
+		_, err := conn.ExecContext(ctx, "SET CLUSTER SETTING bulkio.restore.simple_import_spans.enabled = true")
+		require.NoError(rd.t, err)
+	}
 }
 
 // getAOST gets the AOST to use in the restore cmd.


### PR DESCRIPTION
The patch will help bake #109750.

Release note: none
Epic: none