### PR TITLE
roachtest: add admission-control/disk-bandwidth

### DIFF
--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -998,18 +998,22 @@ memory that the store may consume, for example:
 </PRE>
 Optionally, to configure admission control enforcement to prevent disk
 bandwidth saturation, the "provisioned-rate" field can be specified with
-the "disk-name" and an optional "bandwidth". The bandwidth is used to override
-the value of the cluster setting, kvadmission.store.provisioned_bandwidth.
-For example:
+the optional "disk-name" and "bandwidth" parameters. If the "bandwidth"
+parameter is specified for a given store, admission control enforcement is
+enabled. Using the kvadmission.store.provisioned_bandwidth cluster setting also
+enables admission control enforcement. The "bandwidth" parameter takes
+precedence over the cluster setting. Example usage:
 <PRE>
 
-  --store=provisioned-rate=disk-name=nvme1n1
   --store=provisioned-rate=disk-name=sdb:bandwidth=250MiB/s
+  --store=provisioned-rate=disk-name=nvme1n1
+  --store=provisioned-rate=bandwidth=250MiB/s
 
 </PRE>
 Commas are forbidden in all values, since they are used to separate fields.
-Also, if you use equal signs in the file path to a store, you must use the
-"path" field label.
+If you use equal signs in the file path to a store, you must use the "path"
+field label. If the "disk-name" field is omitted, CockroachDB will attempt to
+automatically infer the disk name from the given store path.
 
 (default is 'cockroach-data' in current directory except for mt commands
 which use 'cockroach-data-tenant-X' for tenant 'X')

--- a/pkg/cmd/roachtest/tests/BUILD.bazel
+++ b/pkg/cmd/roachtest/tests/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "activerecord_blocklist.go",
         "admission_control.go",
         "admission_control_database_drop.go",
+        "admission_control_disk_bandwidth.go",
         "admission_control_elastic_backup.go",
         "admission_control_elastic_cdc.go",
         "admission_control_elastic_io.go",

--- a/pkg/cmd/roachtest/tests/admission_control.go
+++ b/pkg/cmd/roachtest/tests/admission_control.go
@@ -28,6 +28,7 @@ func registerAdmission(r registry.Registry) {
 	// roachperf. Need to munge with histogram data to compute % test run spent
 	// over some latency threshold. Will be Useful to track over time.
 
+	registerDiskBandwidth(r)
 	registerElasticControlForBackups(r)
 	registerElasticControlForCDC(r)
 	registerElasticControlForRowLevelTTL(r)

--- a/pkg/cmd/roachtest/tests/admission_control_disk_bandwidth.go
+++ b/pkg/cmd/roachtest/tests/admission_control_disk_bandwidth.go
@@ -1,0 +1,120 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package tests
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/prometheus"
+	"github.com/stretchr/testify/require"
+)
+
+// This test sets up a 1 node CRDB cluster on an 32vCPU machine, runs low
+// priority kv0 that will overload the compaction throughput (out of L0) of
+// the store. With admission control subjecting this low priority load to
+// elastic IO tokens, the overload is limited.
+func registerDiskBandwidth(r registry.Registry) {
+	r.Add(registry.TestSpec{
+		Name:      "admission-control/disk-bandwidth",
+		Owner:     registry.OwnerAdmissionControl,
+		Timeout:   time.Hour,
+		Benchmark: true,
+		// TODO(sumeer): Reduce to weekly after working well.
+		// Tags:      registry.Tags(`weekly`),
+		Cluster:         r.MakeClusterSpec(3, spec.CPU(32)),
+		RequiresLicense: true,
+		Leases:          registry.MetamorphicLeases,
+		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			if c.IsLocal() {
+				t.Skip("not meant to run locally")
+			}
+			if c.Spec().NodeCount != 3 {
+				t.Fatalf("expected 3 nodes, found %d", c.Spec().NodeCount)
+			}
+			crdbNodes := 1
+			promNode := c.Spec().NodeCount
+			regularNode, elasticNode := c.Spec().NodeCount, c.Spec().NodeCount-1
+
+			promCfg := &prometheus.Config{}
+			promCfg.WithPrometheusNode(c.Node(promNode).InstallNodes()[0]).
+				WithNodeExporter(c.Range(1, c.Spec().NodeCount-1).InstallNodes()).
+				WithCluster(c.Range(1, c.Spec().NodeCount-1).InstallNodes()).
+				WithGrafanaDashboard("https://go.crdb.dev/p/index-admission-control-grafana")
+			require.NoError(t, c.StartGrafana(ctx, t.L(), promCfg))
+
+			c.Put(ctx, t.Cockroach(), "./cockroach", c.Range(1, crdbNodes))
+			c.Put(ctx, t.DeprecatedWorkload(), "./workload", c.Node(regularNode))
+			c.Put(ctx, t.DeprecatedWorkload(), "./workload", c.Node(elasticNode))
+
+			startOpts := option.DefaultStartOptsNoBackups()
+			startOpts.RoachprodOpts.ExtraArgs = append(startOpts.RoachprodOpts.ExtraArgs,
+				"--vmodule=io_load_listener=2")
+			settings := install.MakeClusterSettings()
+			c.Start(ctx, t.L(), startOpts, settings, c.Range(1, crdbNodes))
+
+			setAdmissionControl(ctx, t, c, true)
+
+			{ // Activate disk bandwidth controls.
+				db := c.Conn(ctx, t.L(), crdbNodes)
+				defer db.Close()
+
+				if _, err := db.ExecContext(
+					ctx, "SET CLUSTER SETTING kvadmission.store.provisioned_bandwidth = '250MiB'"); err != nil {
+					t.Fatalf("failed to set kvadmission.store.provisioned_bandwidth: %v", err)
+				}
+			}
+
+			duration := 30 * time.Minute
+			t.Status("running workloads")
+			m := c.NewMonitor(ctx, c.Range(1, crdbNodes))
+
+			m.Go(func(ctx context.Context) error {
+				// Regular traffic: consumes 40-50% of the disk bandwidth (note
+				// the low concurrency=2, since regular traffic does not cause
+				// any disk bandwidth controls to be activated -- so we've
+				// explicitly set it up to leave significant unused bandwidth).
+				dur := " --duration=" + duration.String()
+				url := fmt.Sprintf(" {pgurl:1-%d}", crdbNodes)
+				cmd := "./workload run kv --init --histograms=perf/stats.json --concurrency=2 " +
+					"--splits=1000 --read-percent=0 --min-block-bytes=4096 --max-block-bytes=4096 " +
+					"--background-qos=false --tolerate-errors" + dur + url
+				c.Run(ctx, c.Node(regularNode), cmd)
+				return nil
+			})
+
+			m.Go(func(ctx context.Context) error {
+				// Then add elastic traffic with a high concurrency=1024 (this
+				// is more than enough to blow past the provisioned limit if
+				// there was no disk bandwidth control). The throughput of
+				// regular traffic stays stable.
+				time.Sleep(5 * time.Minute)
+
+				dur := " --duration=" + duration.String()
+				url := fmt.Sprintf(" {pgurl:1-%d}", crdbNodes)
+				cmd := "./workload run kv --init --histograms=perf/stats.json --concurrency=1024 " +
+					"--splits=1000 --read-percent=0 --min-block-bytes=4096 --max-block-bytes=4096 " +
+					"--background-qos=true --tolerate-errors" + dur + url
+				c.Run(ctx, c.Node(elasticNode), cmd)
+				return nil
+			})
+
+			m.Wait()
+		},
+	})
+}

--- a/pkg/kv/kvserver/kvadmission/kvadmission.go
+++ b/pkg/kv/kvserver/kvadmission/kvadmission.go
@@ -98,6 +98,12 @@ var rangefeedCatchupScanElasticControlEnabled = settings.RegisterBoolSetting(
 
 // ProvisionedBandwidth set a value of the provisioned
 // bandwidth for each store in the cluster.
+//
+// TODO(irfansharif): Now that we automatically infer disk names, if we're
+// unable to for whatever reason and this bandwidth setting is non-zero, we
+// don't have an easy way to communicate to the user that admission control
+// enforcement for disk bandwidth is not happening, despite expectations. Maybe
+// we surface this through SQL hints somehow?
 var ProvisionedBandwidth = settings.RegisterByteSizeSetting(
 	settings.SystemOnly, "kvadmission.store.provisioned_bandwidth",
 	"if set to a non-zero value, this is used as the provisioned bandwidth (in bytes/s), "+

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -327,6 +327,7 @@ go_library(
         "//pkg/util/stop",
         "//pkg/util/strutil",
         "//pkg/util/syncutil",
+        "//pkg/util/sysutil",
         "//pkg/util/timeutil",
         "//pkg/util/timeutil/ptp",
         "//pkg/util/tracing",

--- a/pkg/server/node_test.go
+++ b/pkg/server/node_test.go
@@ -953,7 +953,7 @@ func TestDiskStatsMap(t *testing.T) {
 	require.Equal(t, 0, len(stats))
 
 	// diskStatsMap initialized with these two stores.
-	require.NoError(t, dsm.initDiskStatsMap(specs, engines))
+	require.NoError(t, dsm.maybeInitDiskStatsMap(ctx, specs, engines))
 
 	// diskStatsFunc returns stats for these two stores, and an unknown store.
 	diskStatsFunc := func(context.Context) ([]status.DiskStats, error) {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1946,7 +1946,7 @@ func (s *topLevelServer) PreStart(ctx context.Context) error {
 	// wholly initialized stores (it reads the StoreIdentKeys). It also needs
 	// to come before the call into SetPebbleMetricsProvider, which internally
 	// uses the disk stats map we're initializing.
-	if err := s.node.registerEnginesForDiskStatsMap(s.cfg.Stores.Specs, s.engines); err != nil {
+	if err := s.node.registerEnginesForDiskStatsMap(ctx, s.cfg.Stores.Specs, s.engines); err != nil {
 		return errors.Wrapf(err, "failed to register engines for the disk stats map")
 	}
 

--- a/pkg/util/admission/disk_bandwidth.go
+++ b/pkg/util/admission/disk_bandwidth.go
@@ -208,7 +208,7 @@ func (d *diskLoadWatcher) getLoadLevel() diskLoadLevel {
 }
 
 func (d diskLoadWatcher) SafeFormat(p redact.SafePrinter, _ rune) {
-	p.Printf("disk bandwidth: read: %s/s, write: %s/s, provisioned: %s/s, util: %.2f",
+	p.Printf("read-bw %s/s write-bw %s/s provisioned-bw %s/s, util: %.2f",
 		humanizeutil.IBytes(d.lastInterval.readBandwidth),
 		humanizeutil.IBytes(d.lastInterval.writeBandwidth),
 		humanizeutil.IBytes(d.lastInterval.provisionedBandwidth), d.lastUtil)
@@ -359,9 +359,9 @@ func (d *diskBandwidthLimiter) computeElasticTokens(
 func (d *diskBandwidthLimiter) SafeFormat(p redact.SafePrinter, _ rune) {
 	ib := humanizeutil.IBytes
 	level := d.diskLoadWatcher.getLoadLevel()
-	p.Printf("diskBandwidthLimiter %s (%v): elastic-frac: %.2f, incoming: %s, "+
-		"elastic-tokens (used %s): %s",
+	p.Printf("disk bandwidth load level: %s (%v); elastic-frac ≈%.2f, incoming ≈%s, "+
+		"elastic-disk-bw-tokens %s (used %s)",
 		diskLoadLevelString(level), d.diskLoadWatcher, d.state.smoothedElasticFraction,
-		ib(int64(d.state.smoothedIncomingBytes)), ib(d.state.prevElasticTokensUsed),
-		ib(d.state.elasticTokens))
+		ib(int64(d.state.smoothedIncomingBytes)), ib(d.state.elasticTokens),
+		ib(d.state.prevElasticTokensUsed))
 }

--- a/pkg/util/admission/io_load_listener.go
+++ b/pkg/util/admission/io_load_listener.go
@@ -1059,13 +1059,14 @@ func (res adjustTokensResult) SafeFormat(p redact.SafePrinter, _ rune) {
 		p.SafeString("all")
 	}
 	if res.elasticDiskBWTokens != unlimitedTokens {
-		p.Printf("; elastic-disk-bw tokens %s (used %s, regular used %s): "+
-			"write model %.2fx+%s ingest model %.2fx+%s, ",
-			ib(res.elasticDiskBWTokens), ib(res.aux.diskBW.intervalLSMInfo.elasticTokensUsed),
+		p.Printf("; elastic-disk-bw-tokens %s (used %s regular-used %s): "+
+			"write-model %.2fx+%s ingest-model %.2fx+%s, ",
+			ib(res.elasticDiskBWTokens),
+			ib(res.aux.diskBW.intervalLSMInfo.elasticTokensUsed),
 			ib(res.aux.diskBW.intervalLSMInfo.regularTokensUsed),
 			res.l0WriteLM.multiplier, ib(res.l0WriteLM.constant),
 			res.ingestLM.multiplier, ib(res.ingestLM.constant))
-		p.Printf("disk bw read %s write %s provisioned %s",
+		p.Printf("read-bw %s/s write-bw %s/s provisioned-bw %s/s",
 			ib(res.aux.diskBW.intervalDiskLoadInfo.readBandwidth),
 			ib(res.aux.diskBW.intervalDiskLoadInfo.writeBandwidth),
 			ib(res.aux.diskBW.intervalDiskLoadInfo.provisionedBandwidth))

--- a/pkg/util/sysutil/BUILD.bazel
+++ b/pkg/util/sysutil/BUILD.bazel
@@ -6,6 +6,8 @@ go_library(
         "acl_unix.go",
         "acl_windows.go",
         "aclinfo.go",
+        "device_unix.go",
+        "device_windows.go",
         "large_file.go",
         "large_file_linux.go",
         "large_file_nonlinux.go",

--- a/pkg/util/sysutil/device_unix.go
+++ b/pkg/util/sysutil/device_unix.go
@@ -1,0 +1,76 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+//go:build !windows
+// +build !windows
+
+//lint:file-ignore unconvert (redundant conversions are necessary for cross-platform compatibility)
+
+package sysutil
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+)
+
+// GetDeviceMap returns a map of device IDs to device names, for all physical
+// devices.
+func GetDeviceMap() (map[uint64]string, error) {
+	entries, err := os.ReadDir("/dev")
+	if err != nil {
+		return nil, err
+	}
+	devices := make([]string, 0)
+	for _, entry := range entries {
+		info, err := entry.Info()
+		if err != nil {
+			return nil, err
+		}
+		name := info.Name()
+		if strings.HasPrefix(name, "loop") ||
+			strings.HasPrefix(name, "tty") ||
+			strings.HasPrefix(name, "pty") ||
+			strings.HasPrefix(name, "vcs") {
+			// Skip over pseudo devices (loop devices, {pseudo,}terminals,
+			// scrollback buffers).
+			continue
+		}
+		devices = append(devices, filepath.Join("/dev", name))
+	}
+
+	deviceIDToName := make(map[uint64]string)
+	for _, device := range devices {
+		di, err := os.Stat(device)
+		if err != nil {
+			return nil, err
+		}
+		if di.Sys() != nil {
+			if stat, ok := di.Sys().(*syscall.Stat_t); ok {
+				// st_rdev is the device ID (https://linux.die.net/man/2/stat).
+				// The names are specifically what comes after /dev/.
+				deviceIDToName[uint64(stat.Rdev)] = di.Name()
+			}
+		}
+	}
+
+	return deviceIDToName, nil
+}
+
+// GetDeviceID returns the underlying device ID for the given file.
+func GetDeviceID(info os.FileInfo) (uint64, bool) {
+	if info.Sys() != nil {
+		if stat, ok := info.Sys().(*syscall.Stat_t); ok {
+			return uint64(stat.Dev), true
+		}
+	}
+	return 0, false
+}

--- a/pkg/util/sysutil/device_windows.go
+++ b/pkg/util/sysutil/device_windows.go
@@ -1,0 +1,30 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+//go:build windows
+// +build windows
+
+package sysutil
+
+import (
+	"fmt"
+	"os"
+)
+
+// GetDeviceMap returns a map of device IDs to device names, for all physical
+// devices.
+func GetDeviceMap() (map[uint64]string, error) {
+	return nil, fmt.Errorf("unsupported on windows")
+}
+
+// GetDeviceID returns the underlying device ID for the given file.
+func GetDeviceID(info os.FileInfo) (uint64, bool) {
+	return 0, false
+}


### PR DESCRIPTION
Integration test for disk bandwidth tokens. First commit is from #109350.

Release note: None