### PR TITLE
serverutils: better doc the TestServerInterface

### DIFF
--- a/pkg/testutils/serverutils/conditional_wrap.go
+++ b/pkg/testutils/serverutils/conditional_wrap.go
@@ -21,21 +21,12 @@ import (
 )
 
 const tipText = `consider replacing the test server initialization from:
-
-    ts, db, kvDB := serverutils.StartServer(t, ...)
-    // or:
-    tc := serverutils.StartCluster(t, ...)
-    ts := tc.Server(0)
-
-To:
-
-    srv, db, kvDB := serverutils.StartServer(t, ...)
-    defer srv.Stop(...)
+    ts, ... := serverutils.StartServer(t, ...)
+    defer ts.Stopper().Stop(...)
+to:
+    srv, ... := serverutils.StartServer(t, ...)
+    defer srv.Stopper().Stop(...)
     ts := srv.ApplicationLayer()
-    // or:
-    tc := serverutils.StartCluster(t, ...)
-    ts := tc.Server(0).ApplicationLayer()
-
 `
 
 // When this env var is set, all the suspicious API calls are reported in test logs.
@@ -224,7 +215,9 @@ func makeSeriousNotifyFn(
 	}
 	return func(methodName string) {
 		reportFn(func() {
-			(*logFn)("\n%s\n\tWARNING: risky use of implicit %s via .%s()\nHINT: clarify intent using .%s().%s() or .%s().%s() instead.\n",
+			(*logFn)("\n%s\n\tWARNING: risky use of implicit %s via .%s()\n"+
+				"See: https://go.crdb.dev/p/testserver-api-problem\n"+
+				"HINT: clarify intent using .%s().%s() or .%s().%s() instead.\n",
 				GetExternalCaller(),
 				ifname, methodName, accessor1, methodName, accessor2, methodName)
 			(*logFn)("TIP: %s", tipText)

--- a/pkg/testutils/serverutils/conditional_wrap_internal_test.go
+++ b/pkg/testutils/serverutils/conditional_wrap_internal_test.go
@@ -38,7 +38,8 @@ func TestBenignNotifyFn(t *testing.T) {
 			fn("foo")
 			fn("foo")
 			result := buf.String()
-			require.Contains(t, result, "NOTICE: .foo() called via implicit interface IN;\nHINT: consider using .ACC().foo() instead")
+			require.Contains(t, result, "NOTICE: .foo() called via implicit interface IN")
+			require.Contains(t, result, "HINT: consider using .ACC().foo() instead")
 			if showTip {
 				require.Contains(t, result, "TIP:")
 			} else {
@@ -71,7 +72,8 @@ func TestSeriousNotifyFn(t *testing.T) {
 		fn("foo")
 		fn("foo")
 		result := buf.String()
-		require.Contains(t, result, "WARNING: risky use of implicit IN via .foo()\nHINT: clarify intent using .ACC1().foo() or .ACC2().foo() instead")
+		require.Contains(t, result, "WARNING: risky use of implicit IN via .foo()")
+		require.Contains(t, result, "HINT: clarify intent using .ACC1().foo() or .ACC2().foo() instead")
 		require.Contains(t, result, "TIP:")
 
 		if reportAllCalls {


### PR DESCRIPTION
This PR goes hand-in-hand with the following new doc page, which should be reviewed as well: https://cockroachlabs.atlassian.net/wiki/spaces/CRDB/pages/3155427384/TestServer+and+TestCluster

Epic: CRDB-18499

Release note: None