### PR TITLE
serverutils: redirect the implicit `ApplicationLayerInterface` properly

### DIFF
--- a/pkg/testutils/serverutils/api.go
+++ b/pkg/testutils/serverutils/api.go
@@ -65,11 +65,7 @@ type TestServerInterface interface {
 
 	// ApplicationLayerInterface is implemented by TestServerInterface
 	// for backward-compatibility with existing test code.
-	//
-	// It is CURRENTLY equivalent to .SystemLayer() however this is
-	// a misdesign and results in poor test semantics.
-	//
-	// See: https://go.crdb.dev/p/testserver-api-problem
+	// It is equivalent to the result of calling .ApplicationLayer().
 	//
 	// New tests should spell out their intent clearly by calling the
 	// .ApplicationLayer() (preferred) or .SystemLayer() methods

--- a/pkg/testutils/serverutils/conditional_wrap_test.go
+++ b/pkg/testutils/serverutils/conditional_wrap_test.go
@@ -84,7 +84,7 @@ func TestInterfaceNotices(t *testing.T) {
 			opts: (base.DefaultTestTenantOptions{}),
 			scenario: func(t *testing.T, exec func(func(serverutils.TestServerInterface)) string) {
 				result := exec(runCalls)
-				require.Contains(t, result, "WARNING: risky use of implicit ApplicationLayerInterface via .AppStopper()")
+				require.Contains(t, result, "NOTICE: .AppStopper() called via implicit interface ApplicationLayerInterface")
 				require.Contains(t, result, "NOTICE: .NodeID() called via implicit interface StorageLayerInterface")
 				require.Contains(t, result, "NOTICE: .StartedDefaultTestTenant() called via implicit interface TenantControlInterface")
 			},


### PR DESCRIPTION
All commits but the last 3 are from #110008.
Epic: CRDB-18499

Prior to this patch, the *implicit* `ApplicationLayerInterface`
implementation inside `TestServerInterface` was redirecting to
`SystemLayer()`. This was confusing, likely the source of bugs, and
resulted in insufficient test coverage.

This commit fixes it.

followup issues identified thanks to this work:
- actual bug: https://github.com/cockroachdb/cockroach/issues/110003
- possible bug: https://github.com/cockroachdb/cockroach/issues/110002
- possible bug: https://github.com/cockroachdb/cockroach/issues/110007
- possible bug: https://github.com/cockroachdb/cockroach/issues/110012
- feature gap: https://github.com/cockroachdb/cockroach/issues/110009
- feature gap: https://github.com/cockroachdb/cockroach/issues/110018
- feature gap: https://github.com/cockroachdb/cockroach/issues/110019
- feature gap: https://github.com/cockroachdb/cockroach/issues/110020
- feature gap: https://github.com/cockroachdb/cockroach/issues/110022
- feature gap: https://github.com/cockroachdb/cockroach/issues/110023
- feature gap: https://github.com/cockroachdb/cockroach/issues/110024