### PR TITLE
externalconn/testutils: fix a mistake in SetSQLDBForUser

### DIFF
--- a/pkg/ccl/partitionccl/zone_test.go
+++ b/pkg/ccl/partitionccl/zone_test.go
@@ -386,11 +386,14 @@ func TestZoneConfigAppliesToTemporaryIndex(t *testing.T) {
 		},
 	}
 
-	s, sqlDB, kvDB := serverutils.StartServer(t, params)
-	defer s.Stopper().Stop(context.Background())
+	srv, sqlDB, kvDB := serverutils.StartServer(t, params)
+	defer srv.Stopper().Stop(context.Background())
+
+	s := srv.ApplicationLayer()
+
 	tdb := sqlutils.MakeSQLRunner(sqlDB)
-	codec := s.ApplicationLayer().Codec()
-	sv := &s.ApplicationLayer().ClusterSettings().SV
+	codec := s.Codec()
+	sv := &s.ClusterSettings().SV
 	sql.SecondaryTenantZoneConfigsEnabled.Override(context.Background(), sv, true)
 
 	if _, err := sqlDB.Exec(`

--- a/pkg/cloud/externalconn/testutils/cluster.go
+++ b/pkg/cloud/externalconn/testutils/cluster.go
@@ -58,7 +58,7 @@ func (h *Handle) SetSQLDBForUser(tenantID roachpb.TenantID, user string) func() 
 		return resetToRootUser
 	}
 
-	userSQLDB := h.tc.Server(0).SQLConnForUser(h.t, user, "")
+	userSQLDB := tenantState.ApplicationLayerInterface.SQLConnForUser(h.t, user, "")
 	tenantState.curDB = sqlutils.MakeSQLRunner(userSQLDB)
 	tenantState.userToDB[user] = tenantState.curDB
 

--- a/pkg/server/server_controller_new_server.go
+++ b/pkg/server/server_controller_new_server.go
@@ -245,6 +245,7 @@ func makeSharedProcessTenantServerConfig(
 	baseCfg.Locality = kvServerCfg.BaseConfig.Locality
 	baseCfg.SpanConfigsDisabled = kvServerCfg.BaseConfig.SpanConfigsDisabled
 	baseCfg.EnableDemoLoginEndpoint = kvServerCfg.BaseConfig.EnableDemoLoginEndpoint
+	baseCfg.DefaultZoneConfig = kvServerCfg.BaseConfig.DefaultZoneConfig
 
 	// TODO(knz): use a single network interface for all tenant servers.
 	// See: https://github.com/cockroachdb/cockroach/issues/92524

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -1476,6 +1476,7 @@ func (ts *testServer) StartTenant(
 	baseCfg.StartDiagnosticsReporting = params.StartDiagnosticsReporting
 	baseCfg.DisableTLSForHTTP = params.DisableTLSForHTTP
 	baseCfg.EnableDemoLoginEndpoint = params.EnableDemoLoginEndpoint
+	baseCfg.DefaultZoneConfig = ts.Cfg.DefaultZoneConfig
 
 	// Waiting for capabilities can time To avoid paying this cost in all
 	// cases, we only set the nodelocal storage capability if the caller has

--- a/pkg/testutils/sqlutils/BUILD.bazel
+++ b/pkg/testutils/sqlutils/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
         "//pkg/sql/lexbase",
         "//pkg/sql/parser",
         "//pkg/sql/pgwire/pgerror",
+        "//pkg/sql/protoreflect",
         "//pkg/sql/sem/catconstants",
         "//pkg/sql/sem/tree",
         "//pkg/testutils",


### PR DESCRIPTION
All commits but the last are from #110004 (review only the last commit here)

Prior to this patch, this method was incorrectly swapping a SQL
connection to the secondary tenant for one to the system tenant.

This patch fixes it.

Epic: CRDB-18499