### PR TITLE
sql: implement CALL for simple procedures

### DIFF
--- a/docs/generated/sql/bnf/BUILD.bazel
+++ b/docs/generated/sql/bnf/BUILD.bazel
@@ -70,6 +70,7 @@ FILES = [
     "backup_options",
     "begin_stmt",
     "begin_transaction",
+    "call_stmt",
     "cancel_all_jobs_stmt",
     "cancel_job",
     "cancel_query",

--- a/docs/generated/sql/bnf/call_stmt.bnf
+++ b/docs/generated/sql/bnf/call_stmt.bnf
@@ -1,0 +1,2 @@
+call_stmt ::=
+	'CALL' proc_name '(' opt_expr_list ')'

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -10,6 +10,7 @@ stmt ::=
 stmt_without_legacy_transaction ::=
 	preparable_stmt
 	| analyze_stmt
+	| call_stmt
 	| copy_stmt
 	| comment_stmt
 	| execute_stmt
@@ -62,6 +63,9 @@ preparable_stmt ::=
 analyze_stmt ::=
 	'ANALYZE' analyze_target
 	| 'ANALYSE' analyze_target
+
+call_stmt ::=
+	'CALL' proc_name '(' opt_expr_list ')'
 
 copy_stmt ::=
 	'COPY' table_name opt_column_list 'FROM' 'STDIN' opt_with_copy_options opt_where_clause
@@ -312,6 +316,13 @@ upsert_stmt ::=
 
 analyze_target ::=
 	table_name
+
+proc_name ::=
+	db_object_name
+
+opt_expr_list ::=
+	expr_list
+	| 
 
 table_name ::=
 	db_object_name
@@ -975,6 +986,9 @@ db_object_name ::=
 	simple_db_object_name
 	| complex_db_object_name
 
+expr_list ::=
+	( a_expr ) ( ( ',' a_expr ) )*
+
 name_list ::=
 	( name ) ( ( ',' name ) )*
 
@@ -1001,9 +1015,6 @@ index_name ::=
 
 standalone_index_name ::=
 	db_object_name
-
-expr_list ::=
-	( a_expr ) ( ( ',' a_expr ) )*
 
 unreserved_keyword ::=
 	'ABORT'
@@ -3000,10 +3011,6 @@ case_expr ::=
 
 operator_op ::=
 	all_op
-
-opt_expr_list ::=
-	expr_list
-	| 
 
 expr_tuple_unambiguous ::=
 	'(' ')'

--- a/docs/generated/sql/bnf/stmt_without_legacy_transaction.bnf
+++ b/docs/generated/sql/bnf/stmt_without_legacy_transaction.bnf
@@ -1,6 +1,7 @@
 stmt_without_legacy_transaction ::=
 	preparable_stmt
 	| analyze_stmt
+	| call_stmt
 	| copy_stmt
 	| comment_stmt
 	| execute_stmt

--- a/pkg/ccl/changefeedccl/cdceval/func_resolver.go
+++ b/pkg/ccl/changefeedccl/cdceval/func_resolver.go
@@ -36,7 +36,7 @@ func newCDCFunctionResolver(wrapped tree.FunctionReferenceResolver) tree.Functio
 func (rs *cdcFunctionResolver) ResolveFunction(
 	ctx context.Context, name *tree.UnresolvedName, path tree.SearchPath,
 ) (*tree.ResolvedFunctionDefinition, error) {
-	fn, err := name.ToFunctionName()
+	fn, err := name.ToRoutineName()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/gen/bnf.bzl
+++ b/pkg/gen/bnf.bzl
@@ -70,6 +70,7 @@ BNF_SRCS = [
     "//docs/generated/sql/bnf:backup_options.bnf",
     "//docs/generated/sql/bnf:begin_stmt.bnf",
     "//docs/generated/sql/bnf:begin_transaction.bnf",
+    "//docs/generated/sql/bnf:call_stmt.bnf",
     "//docs/generated/sql/bnf:cancel_all_jobs_stmt.bnf",
     "//docs/generated/sql/bnf:cancel_job.bnf",
     "//docs/generated/sql/bnf:cancel_query.bnf",

--- a/pkg/gen/diagrams.bzl
+++ b/pkg/gen/diagrams.bzl
@@ -70,6 +70,7 @@ DIAGRAMS_SRCS = [
     "//docs/generated/sql/bnf:backup_options.html",
     "//docs/generated/sql/bnf:begin.html",
     "//docs/generated/sql/bnf:begin_transaction.html",
+    "//docs/generated/sql/bnf:call.html",
     "//docs/generated/sql/bnf:cancel.html",
     "//docs/generated/sql/bnf:cancel_all_jobs.html",
     "//docs/generated/sql/bnf:cancel_job.html",

--- a/pkg/gen/docs.bzl
+++ b/pkg/gen/docs.bzl
@@ -82,6 +82,7 @@ DOCS_SRCS = [
     "//docs/generated/sql/bnf:backup_options.bnf",
     "//docs/generated/sql/bnf:begin_stmt.bnf",
     "//docs/generated/sql/bnf:begin_transaction.bnf",
+    "//docs/generated/sql/bnf:call_stmt.bnf",
     "//docs/generated/sql/bnf:cancel_all_jobs_stmt.bnf",
     "//docs/generated/sql/bnf:cancel_job.bnf",
     "//docs/generated/sql/bnf:cancel_query.bnf",

--- a/pkg/sql/alter_function.go
+++ b/pkg/sql/alter_function.go
@@ -416,10 +416,11 @@ func (p *planner) mustGetMutableFunctionForAlter(
 
 func toSchemaOverloadSignature(fnDesc *funcdesc.Mutable) descpb.SchemaDescriptor_FunctionSignature {
 	ret := descpb.SchemaDescriptor_FunctionSignature{
-		ID:         fnDesc.GetID(),
-		ArgTypes:   make([]*types.T, len(fnDesc.GetParams())),
-		ReturnType: fnDesc.ReturnType.Type,
-		ReturnSet:  fnDesc.ReturnType.ReturnSet,
+		ID:          fnDesc.GetID(),
+		ArgTypes:    make([]*types.T, len(fnDesc.GetParams())),
+		ReturnType:  fnDesc.ReturnType.Type,
+		ReturnSet:   fnDesc.ReturnType.ReturnSet,
+		IsProcedure: fnDesc.IsProcedure,
 	}
 	for i := range fnDesc.Params {
 		ret.ArgTypes[i] = fnDesc.Params[i].Type

--- a/pkg/sql/catalog/descpb/structured.proto
+++ b/pkg/sql/catalog/descpb/structured.proto
@@ -1550,6 +1550,8 @@ message SchemaDescriptor {
     optional sql.sem.types.T return_type = 3;
 
     optional bool return_set = 4 [(gogoproto.nullable) = false];
+
+    optional bool is_procedure = 5 [(gogoproto.nullable) = false];
   }
 
   // Function contains a group of UDFs with the same name.
@@ -1655,7 +1657,10 @@ message FunctionDescriptor {
   // descriptor being changed as part of a declarative schema change.
   optional cockroach.sql.schemachanger.scpb.DescriptorState declarative_schema_changer_state = 20;
 
-  // Next field id is 21
+  // IsProcedure is true if the descriptor represents a procedure.
+  optional bool is_procedure = 21 [(gogoproto.nullable) = false];
+
+  // Next field id is 22
 }
 
 // Descriptor is a union type for descriptors for tables, schemas, databases,

--- a/pkg/sql/catalog/descs/dist_sql_function_resolver.go
+++ b/pkg/sql/catalog/descs/dist_sql_function_resolver.go
@@ -44,7 +44,7 @@ func NewDistSQLFunctionResolver(descs *Collection, txn *kv.Txn) *DistSQLFunction
 func (d *DistSQLFunctionResolver) ResolveFunction(
 	ctx context.Context, name *tree.UnresolvedName, path tree.SearchPath,
 ) (*tree.ResolvedFunctionDefinition, error) {
-	fn, err := name.ToFunctionName()
+	fn, err := name.ToRoutineName()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/catalog/funcdesc/func_desc.go
+++ b/pkg/sql/catalog/funcdesc/func_desc.go
@@ -66,6 +66,7 @@ func NewMutableFunctionDescriptor(
 	params []descpb.FunctionDescriptor_Parameter,
 	returnType *types.T,
 	returnSet bool,
+	isProcedure bool,
 	privs *catpb.PrivilegeDescriptor,
 ) Mutable {
 	return Mutable{
@@ -84,6 +85,7 @@ func NewMutableFunctionDescriptor(
 				Volatility:        catpb.DefaultFunctionVolatility,
 				LeakProof:         catpb.DefaultFunctionLeakProof,
 				NullInputBehavior: catpb.Function_CALLED_ON_NULL_INPUT,
+				IsProcedure:       isProcedure,
 				Privileges:        privs,
 				Version:           1,
 				ModificationTime:  hlc.Timestamp{},
@@ -689,13 +691,14 @@ func (desc *immutable) GetLanguage() catpb.Function_Language {
 
 func (desc *immutable) ToOverload() (ret *tree.Overload, err error) {
 	ret = &tree.Overload{
-		Oid:        catid.FuncIDToOID(desc.ID),
-		ReturnType: tree.FixedReturnType(desc.ReturnType.Type),
-		ReturnSet:  desc.ReturnType.ReturnSet,
-		Body:       desc.FunctionBody,
-		IsUDF:      true,
-		Version:    uint64(desc.Version),
-		Language:   desc.getCreateExprLang(),
+		Oid:         catid.FuncIDToOID(desc.ID),
+		ReturnType:  tree.FixedReturnType(desc.ReturnType.Type),
+		ReturnSet:   desc.ReturnType.ReturnSet,
+		Body:        desc.FunctionBody,
+		IsUDF:       true,
+		IsProcedure: desc.IsProcedure,
+		Version:     uint64(desc.Version),
+		Language:    desc.getCreateExprLang(),
 	}
 
 	argTypes := make(tree.ParamTypes, 0, len(desc.Params))

--- a/pkg/sql/catalog/schemadesc/schema_desc.go
+++ b/pkg/sql/catalog/schemadesc/schema_desc.go
@@ -513,6 +513,7 @@ func (desc *immutable) GetResolvedFuncDefinition(
 			},
 			IsUDF:                    true,
 			UDFContainsOnlySignature: true,
+			IsProcedure:              sig.IsProcedure,
 		}
 		if funcDescPb.Signatures[i].ReturnSet {
 			overload.Class = tree.GeneratorClass

--- a/pkg/sql/catalog/tabledesc/validate_test.go
+++ b/pkg/sql/catalog/tabledesc/validate_test.go
@@ -327,6 +327,7 @@ var validationMap = []struct {
 			"ModificationTime":              {status: thisFieldReferencesNoObjects},
 			"Version":                       {status: thisFieldReferencesNoObjects},
 			"DeclarativeSchemaChangerState": {status: thisFieldReferencesNoObjects},
+			"IsProcedure":                   {status: thisFieldReferencesNoObjects},
 		},
 	},
 }

--- a/pkg/sql/create_function.go
+++ b/pkg/sql/create_function.go
@@ -145,10 +145,11 @@ func (n *createFunctionNode) createNewFunction(
 	scDesc.AddFunction(
 		udfDesc.GetName(),
 		descpb.SchemaDescriptor_FunctionSignature{
-			ID:         udfDesc.GetID(),
-			ArgTypes:   paramTypes,
-			ReturnType: returnType,
-			ReturnSet:  udfDesc.ReturnType.ReturnSet,
+			ID:          udfDesc.GetID(),
+			ArgTypes:    paramTypes,
+			ReturnType:  returnType,
+			ReturnSet:   udfDesc.ReturnType.ReturnSet,
+			IsProcedure: udfDesc.IsProcedure,
 		},
 	)
 	if err := params.p.writeSchemaDescChange(params.ctx, scDesc, "Create Function"); err != nil {
@@ -303,6 +304,7 @@ func (n *createFunctionNode) getMutableFuncDesc(
 		pbParams,
 		returnType,
 		n.cf.ReturnType.IsSet,
+		n.cf.IsProcedure,
 		privileges,
 	)
 

--- a/pkg/sql/distsql_spec_exec_factory.go
+++ b/pkg/sql/distsql_spec_exec_factory.go
@@ -1245,3 +1245,7 @@ func (e *distSQLSpecExecFactory) ConstructLiteralValues(
 ) (exec.Node, error) {
 	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning: literal values")
 }
+
+func (e *distSQLSpecExecFactory) ConstructCall(proc *tree.RoutineExpr) (exec.Node, error) {
+	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning: call")
+}

--- a/pkg/sql/logictest/testdata/logic_test/procedure
+++ b/pkg/sql/logictest/testdata/logic_test/procedure
@@ -1,7 +1,14 @@
-statement error pgcode 0A000 procedures not supported
-CREATE PROCEDURE p() LANGUAGE SQL AS $$
-  SELECT nextval('s');
-$$
+statement ok
+CREATE PROCEDURE p() LANGUAGE SQL AS 'SELECT 1'
+
+# The isProcedure field of the descriptor should be set to true for a procedure.
+query T
+SELECT d->'function'->'isProcedure' FROM (
+  SELECT crdb_internal.pb_to_json('cockroach.sql.sqlbase.Descriptor', descriptor, false) d
+  FROM system.descriptor
+) WHERE d->'function'->'name' = '"p"'
+----
+true
 
 statement error pgcode 0A000 unimplemented: this syntax\nHINT.*\n.*17511
 CALL err()

--- a/pkg/sql/logictest/testdata/logic_test/procedure
+++ b/pkg/sql/logictest/testdata/logic_test/procedure
@@ -10,5 +10,5 @@ SELECT d->'function'->'isProcedure' FROM (
 ----
 true
 
-statement error pgcode 0A000 unimplemented: this syntax\nHINT.*\n.*17511
+statement error pgcode 0A000 unimplemented: procedures not supported
 CALL err()

--- a/pkg/sql/logictest/testdata/logic_test/procedure
+++ b/pkg/sql/logictest/testdata/logic_test/procedure
@@ -18,5 +18,38 @@ CREATE OR REPLACE PROCEDURE p() LANGUAGE SQL AS $$
   SELECT nextval('s');
 $$
 
-statement error pgcode 0A000 unimplemented: procedures not supported
+statement ok
 CALL p()
+
+query I
+SELECT currval('s')
+----
+1
+
+statement ok
+CREATE OR REPLACE PROCEDURE p() LANGUAGE SQL AS $$
+  SELECT 1;
+$$
+
+statement ok
+CALL p()
+
+# Ensure that the memo for the first execution of p was not re-used.
+query I
+SELECT currval('s')
+----
+1
+
+statement ok
+CREATE OR REPLACE PROCEDURE p_arg(i INT) LANGUAGE SQL AS $$
+  SELECT i;
+$$
+
+statement error pgcode 0A000 unimplemented: procedures with arguments not supported
+CALL p_arg(1)
+
+# TODO(mgartner): The error should state "procedure definition" too.
+statement error pgcode 0A000 unimplemented: CALL usage inside a function definition
+CREATE OR REPLACE PROCEDURE p2() LANGUAGE SQL AS $$
+  CALL p();
+$$

--- a/pkg/sql/logictest/testdata/logic_test/procedure
+++ b/pkg/sql/logictest/testdata/logic_test/procedure
@@ -10,5 +10,13 @@ SELECT d->'function'->'isProcedure' FROM (
 ----
 true
 
+statement ok
+CREATE SEQUENCE s
+
+statement ok
+CREATE OR REPLACE PROCEDURE p() LANGUAGE SQL AS $$
+  SELECT nextval('s');
+$$
+
 statement error pgcode 0A000 unimplemented: procedures not supported
-CALL err()
+CALL p()

--- a/pkg/sql/opt/cat/catalog.go
+++ b/pkg/sql/opt/cat/catalog.go
@@ -165,6 +165,11 @@ type Catalog interface {
 	// ResolveFunctionByOID resolves a function overload by OID.
 	ResolveFunctionByOID(ctx context.Context, oid oid.Oid) (*tree.RoutineName, *tree.Overload, error)
 
+	// ResolveProcedure resolves a procedure by name.
+	ResolveProcedure(
+		ctx context.Context, name *tree.UnresolvedObjectName, path tree.SearchPath,
+	) (*tree.Overload, error)
+
 	// CheckPrivilege verifies that the current user has the given privilege on
 	// the given catalog object. If not, then CheckPrivilege returns an error.
 	CheckPrivilege(ctx context.Context, o Object, priv privilege.Kind) error

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -309,7 +309,7 @@ func (b *Builder) buildRelational(e memo.RelExpr) (execPlan, error) {
 		ep, err = b.buildRecursiveCTE(t)
 
 	case *memo.CallExpr:
-		panic(unimplemented.Newf("procedures", "procedures not supported"))
+		ep, err = b.buildCall(t)
 
 	case *memo.ExplainExpr:
 		ep, err = b.buildExplain(t)
@@ -3112,6 +3112,52 @@ func (b *Builder) buildProjectSet(projectSet *memo.ProjectSetExpr) (execPlan, er
 		return execPlan{}, err
 	}
 
+	return ep, nil
+}
+
+func (b *Builder) buildCall(c *memo.CallExpr) (execPlan, error) {
+	udf := c.Proc.(*memo.UDFCallExpr)
+	if udf.Def == nil {
+		return execPlan{}, errors.AssertionFailedf("expected non-nil UDF definition")
+	}
+
+	for _, s := range udf.Def.Body {
+		if s.Relational().CanMutate {
+			b.ContainsMutation = true
+			break
+		}
+	}
+
+	// Create a tree.RoutinePlanFn that can plan the statements in the UDF body.
+	planGen := b.buildRoutinePlanGenerator(
+		udf.Def.Params,
+		udf.Def.Body,
+		udf.Def.BodyProps,
+		false, /* allowOuterWithRefs */
+		nil,   /* wrapRootExpr */
+	)
+
+	var args tree.TypedExprs
+	r := tree.NewTypedRoutineExpr(
+		udf.Def.Name,
+		args,
+		planGen,
+		udf.Typ,
+		true, /* enableStepping */
+		udf.Def.CalledOnNullInput,
+		udf.Def.MultiColDataSource,
+		udf.Def.SetReturning,
+		udf.TailCall,
+		true, /* procedure */
+		nil,  /* exceptionHandler */
+	)
+
+	var ep execPlan
+	var err error
+	ep.root, err = b.factory.ConstructCall(r)
+	if err != nil {
+		return execPlan{}, err
+	}
 	return ep, nil
 }
 

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -308,6 +308,9 @@ func (b *Builder) buildRelational(e memo.RelExpr) (execPlan, error) {
 	case *memo.RecursiveCTEExpr:
 		ep, err = b.buildRecursiveCTE(t)
 
+	case *memo.CallExpr:
+		panic(unimplemented.Newf("procedures", "procedures not supported"))
+
 	case *memo.ExplainExpr:
 		ep, err = b.buildExplain(t)
 

--- a/pkg/sql/opt/exec/execbuilder/scalar.go
+++ b/pkg/sql/opt/exec/execbuilder/scalar.go
@@ -701,6 +701,7 @@ func (b *Builder) buildExistsSubquery(
 				false, /* multiColOutput */
 				false, /* generator */
 				false, /* tailCall */
+				false, /* procedure */
 				nil,   /* exceptionHandler */
 			),
 			tree.DBoolFalse,
@@ -818,6 +819,7 @@ func (b *Builder) buildSubquery(
 			false, /* multiColOutput */
 			false, /* generator */
 			false, /* tailCall */
+			false, /* procedure */
 			nil,   /* exceptionHandler */
 		), nil
 	}
@@ -874,6 +876,7 @@ func (b *Builder) buildSubquery(
 			false, /* multiColOutput */
 			false, /* generator */
 			false, /* tailCall */
+			false, /* procedure */
 			nil,   /* exceptionHandler */
 		), nil
 	}
@@ -957,7 +960,7 @@ func (b *Builder) buildUDF(ctx *buildScalarCtx, scalar opt.ScalarExpr) (tree.Typ
 	)
 
 	// Enable stepping for volatile functions so that statements within the UDF
-	// see mutations made by the invoking statement and by previous executed
+	// see mutations made by the invoking statement and by previously executed
 	// statements.
 	enableStepping := udf.Def.Volatility == volatility.Volatile
 
@@ -989,6 +992,7 @@ func (b *Builder) buildUDF(ctx *buildScalarCtx, scalar opt.ScalarExpr) (tree.Typ
 				action.MultiColDataSource,
 				action.SetReturning,
 				false, /* tailCall */
+				false, /* procedure */
 				nil,   /* exceptionHandler */
 			)
 		}
@@ -1004,6 +1008,7 @@ func (b *Builder) buildUDF(ctx *buildScalarCtx, scalar opt.ScalarExpr) (tree.Typ
 		udf.Def.MultiColDataSource,
 		udf.Def.SetReturning,
 		udf.TailCall,
+		false, /* procedure */
 		exceptionHandler,
 	), nil
 }

--- a/pkg/sql/opt/exec/explain/plan_gist_factory.go
+++ b/pkg/sql/opt/exec/explain/plan_gist_factory.go
@@ -36,7 +36,7 @@ import (
 )
 
 func init() {
-	if numOperators != 61 {
+	if numOperators != 62 {
 		// This error occurs when an operator has been added or removed in
 		// pkg/sql/opt/exec/explain/factory.opt. If an operator is added at the
 		// end of factory.opt, simply adjust the hardcoded value above. If an

--- a/pkg/sql/opt/exec/explain/result_columns.go
+++ b/pkg/sql/opt/exec/explain/result_columns.go
@@ -232,7 +232,7 @@ func getResultColumns(
 
 	case createTableOp, createTableAsOp, createViewOp, controlJobsOp, controlSchedulesOp,
 		cancelQueriesOp, cancelSessionsOp, createStatisticsOp, errorIfRowsOp, deleteRangeOp,
-		createFunctionOp:
+		createFunctionOp, callOp:
 		// These operations produce no columns.
 		return nil, nil
 

--- a/pkg/sql/opt/exec/factory.opt
+++ b/pkg/sql/opt/exec/factory.opt
@@ -780,3 +780,8 @@ define LiteralValues {
 define ShowCompletions {
     Command *tree.ShowCompletions
 }
+
+# Call implements CALL for invoking a procedure.
+define Call {
+    Proc *tree.RoutineExpr
+}

--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -1109,6 +1109,10 @@ func (b *logicalPropsBuilder) buildExportProps(export *ExportExpr, rel *props.Re
 	b.buildBasicProps(export, export.Columns, rel)
 }
 
+func (b *logicalPropsBuilder) buildCallProps(c *CallExpr, rel *props.Relational) {
+	b.buildBasicProps(c, opt.ColList{}, rel)
+}
+
 func (b *logicalPropsBuilder) buildTopKProps(topK *TopKExpr, rel *props.Relational) {
 	// TopK has the same logical properties as limit.
 	b.buildLimitOrTopKProps(topK, rel, topK.K, true /* haveConstLimit */)

--- a/pkg/sql/opt/ops/statement.opt
+++ b/pkg/sql/opt/ops/statement.opt
@@ -355,3 +355,9 @@ define AlterRangeRelocatePrivate {
     # Props stores the required physical properties for the input expression.
     Props PhysProps
 }
+
+[Relational]
+define Call {
+    # Proc is the procedure being invoked. It is a UDFCallExpr.
+    Proc ScalarExpr
+}

--- a/pkg/sql/opt/optbuilder/BUILD.bazel
+++ b/pkg/sql/opt/optbuilder/BUILD.bazel
@@ -29,6 +29,7 @@ go_library(
         "orderby.go",
         "partial_index.go",
         "plpgsql.go",
+        "procedure.go",
         "project.go",
         "scalar.go",
         "scope.go",

--- a/pkg/sql/opt/optbuilder/builder.go
+++ b/pkg/sql/opt/optbuilder/builder.go
@@ -298,15 +298,13 @@ func (b *Builder) buildStmtAtRootWithScope(
 //	rather than a return value so its scopeColumns can be built up
 //	incrementally across several function calls.
 //
-// inScope   This parameter contains the name bindings that are visible for this
+// inScope - This parameter contains the name bindings that are visible for this
+// statement/expression (e.g., passed in from an enclosing statement).
 //
-//	statement/expression (e.g., passed in from an enclosing statement).
-//
-// outScope  This return value contains the newly bound variables that will be
-//
-//	visible to enclosing statements, as well as a pointer to any
-//	"parent" scope that is still visible. The top-level memo expression
-//	for the built statement/expression is returned in outScope.expr.
+// outScope - This return value contains the newly bound variables that will be
+// visible to enclosing statements, as well as a pointer to any
+// "parent" scope that is still visible. The top-level memo expression
+// for the built statement/expression is returned in outScope.expr.
 func (b *Builder) buildStmt(
 	stmt tree.Statement, desiredTypes []*types.T, inScope *scope,
 ) (outScope *scope) {
@@ -364,7 +362,7 @@ func (b *Builder) buildStmt(
 		return b.buildCreateFunction(stmt, inScope)
 
 	case *tree.Call:
-		panic(unimplemented.Newf("procedures", "procedures not supported"))
+		return b.buildProcedure(stmt, inScope)
 
 	case *tree.Explain:
 		return b.buildExplain(stmt, inScope)

--- a/pkg/sql/opt/optbuilder/builder.go
+++ b/pkg/sql/opt/optbuilder/builder.go
@@ -363,6 +363,9 @@ func (b *Builder) buildStmt(
 	case *tree.CreateRoutine:
 		return b.buildCreateFunction(stmt, inScope)
 
+	case *tree.Call:
+		panic(unimplemented.Newf("procedures", "procedures not supported"))
+
 	case *tree.Explain:
 		return b.buildExplain(stmt, inScope)
 

--- a/pkg/sql/opt/optbuilder/create_function.go
+++ b/pkg/sql/opt/optbuilder/create_function.go
@@ -38,10 +38,6 @@ func (b *Builder) buildCreateFunction(cf *tree.CreateRoutine, inScope *scope) (o
 		}
 	}
 
-	if cf.IsProcedure {
-		panic(unimplemented.New("CREATE PROCEDURE", "procedures not supported"))
-	}
-
 	sch, resName := b.resolveSchemaForCreateFunction(&cf.Name)
 	schID := b.factory.Metadata().AddSchema(sch)
 	cf.Name.ObjectNamePrefix = resName

--- a/pkg/sql/opt/optbuilder/procedure.go
+++ b/pkg/sql/opt/optbuilder/procedure.go
@@ -1,0 +1,126 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package optbuilder
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
+	"github.com/cockroachdb/errors"
+)
+
+// buildUDF builds a set of memo groups that represents a procedure invocation.
+func (b *Builder) buildProcedure(c *tree.Call, inScope *scope) *scope {
+	// Disable memo reuse. Note that this is not strictly necessary because
+	// optPlanningCtx does not attempt to reuse tree.Call statements, but exists
+	// for explicitness.
+	//
+	// TODO(mgartner): Enable memo reuse with CALL statements. This will require
+	// adding the resolved routine overload to the metadata so that we can track
+	// when a statement is stale.
+	b.DisableMemoReuse = true
+	outScope := inScope.push()
+
+	// Resolve the procedure.
+	o, err := b.catalog.ResolveProcedure(b.ctx, c.Name, &b.evalCtx.SessionData().SearchPath)
+	if err != nil {
+		panic(err)
+	}
+
+	// Build the routine.
+	routine := b.buildProcUDF(c, o, inScope)
+
+	// Build a call expression.
+	outScope.expr = b.factory.ConstructCall(routine)
+	return outScope
+}
+
+func (b *Builder) buildProcUDF(
+	c *tree.Call, o *tree.Overload, inScope *scope,
+) (out opt.ScalarExpr) {
+	// TODO(mgartner): Build argument expressions.
+	var args memo.ScalarListExpr
+	if len(c.Exprs) > 0 {
+		panic(unimplemented.New("CALL", "procedures with arguments not supported"))
+	}
+
+	// Create a new scope for building the statements in the function body. We
+	// start with an empty scope because a statement in the function body cannot
+	// refer to anything from the outer expression.
+	//
+	// TODO(mgartner): We may need to set bodyScope.atRoot=true to prevent
+	// CTEs that mutate and are not at the top-level.
+	bodyScope := b.allocScope()
+
+	// TODO(mgartner): Once other UDFs can be referenced from within a UDF, a
+	// boolean will not be sufficient to track whether or not we are in a UDF.
+	// We'll need to track the depth of the UDFs we are building expressions
+	// within.
+	// TODO(mgartner): Rename insideUDF.
+	b.insideUDF = true
+	isSetReturning := o.Class == tree.GeneratorClass
+	isMultiColDataSource := false
+
+	// Build an expression for each statement in the function body.
+	var body []memo.RelExpr
+	var bodyProps []*physical.Required
+	switch o.Language {
+	case tree.RoutineLangSQL:
+		// Parse the function body.
+		stmts, err := parser.Parse(o.Body)
+		if err != nil {
+			panic(err)
+		}
+		body = make([]memo.RelExpr, len(stmts))
+		bodyProps = make([]*physical.Required, len(stmts))
+
+		for i := range stmts {
+			stmtScope := b.buildStmtAtRootWithScope(stmts[i].AST, nil /* desiredTypes */, bodyScope)
+			expr, physProps := stmtScope.expr, stmtScope.makePhysicalProps()
+			body[i] = expr
+			bodyProps[i] = physProps
+		}
+	case tree.RoutineLangPLpgSQL:
+		// TODO(mgartner): Add support for PLpgSQL procedures.
+		if o.IsProcedure {
+			panic(unimplemented.New("CALL", "PLpgSQL procedures not supported"))
+		}
+	default:
+		panic(errors.AssertionFailedf("unexpected language: %v", o.Language))
+	}
+
+	b.insideUDF = false
+
+	// TODO(mgartner): Build argument expressions.
+	var params opt.ColList
+	out = b.factory.ConstructUDFCall(
+		args,
+		&memo.UDFCallPrivate{
+			Def: &memo.UDFDefinition{
+				Name:               c.Name.String(),
+				Typ:                types.Void,
+				Volatility:         o.Volatility,
+				SetReturning:       isSetReturning,
+				CalledOnNullInput:  o.CalledOnNullInput,
+				MultiColDataSource: isMultiColDataSource,
+				Body:               body,
+				BodyProps:          bodyProps,
+				Params:             params,
+			},
+		},
+	)
+
+	return b.finishBuildScalar(nil /* texpr */, out, inScope, nil /* outScope */, nil /* outCol */)
+}

--- a/pkg/sql/opt/optbuilder/testdata/procedure
+++ b/pkg/sql/opt/optbuilder/testdata/procedure
@@ -1,0 +1,81 @@
+exec-ddl
+CREATE TABLE abc (
+  a INT PRIMARY KEY,
+  b INT,
+  c INT
+)
+----
+
+# --------------------------------------------------
+# Procedure without arguments.
+# --------------------------------------------------
+
+build
+CALL p()
+----
+error (42883): procedure p does not exist
+
+exec-ddl
+CREATE OR REPLACE PROCEDURE p() LANGUAGE SQL AS 'INSERT INTO abc VALUES (1, 2, 3)'
+----
+
+build format=show-scalars
+CALL p()
+----
+call
+ └── udf: p
+      └── body
+           └── insert abc
+                ├── columns: <none>
+                ├── insert-mapping:
+                │    ├── column1:6 => a:1
+                │    ├── column2:7 => b:2
+                │    └── column3:8 => c:3
+                └── values
+                     ├── columns: column1:6!null column2:7!null column3:8!null
+                     └── tuple
+                          ├── const: 1
+                          ├── const: 2
+                          └── const: 3
+
+exec-ddl
+CREATE OR REPLACE PROCEDURE p() LANGUAGE SQL AS $$
+  INSERT INTO abc VALUES (1, 2, 3);
+  UPSERT INTO abc VALUES (4, 5, 6), (7, 8, 9);
+$$
+----
+
+build format=show-scalars
+CALL p()
+----
+call
+ └── udf: p
+      └── body
+           ├── insert abc
+           │    ├── columns: <none>
+           │    ├── insert-mapping:
+           │    │    ├── column1:6 => a:1
+           │    │    ├── column2:7 => b:2
+           │    │    └── column3:8 => c:3
+           │    └── values
+           │         ├── columns: column1:6!null column2:7!null column3:8!null
+           │         └── tuple
+           │              ├── const: 1
+           │              ├── const: 2
+           │              └── const: 3
+           └── upsert abc
+                ├── columns: <none>
+                ├── upsert-mapping:
+                │    ├── column1:14 => a:9
+                │    ├── column2:15 => b:10
+                │    └── column3:16 => c:11
+                └── values
+                     ├── columns: column1:14!null column2:15!null column3:16!null
+                     ├── tuple
+                     │    ├── const: 4
+                     │    ├── const: 5
+                     │    └── const: 6
+                     └── tuple
+                          ├── const: 7
+                          ├── const: 8
+                          └── const: 9

--- a/pkg/sql/opt/testutils/testcat/function.go
+++ b/pkg/sql/opt/testutils/testcat/function.go
@@ -29,7 +29,7 @@ var _ tree.FunctionReferenceResolver = (*Catalog)(nil)
 func (tc *Catalog) ResolveFunction(
 	ctx context.Context, name *tree.UnresolvedName, path tree.SearchPath,
 ) (*tree.ResolvedFunctionDefinition, error) {
-	fn, err := name.ToFunctionName()
+	fn, err := name.ToRoutineName()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/opt/testutils/testcat/function.go
+++ b/pkg/sql/opt/testutils/testcat/function.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/volatility"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
 	"github.com/cockroachdb/cockroach/pkg/util/treeprinter"
 	"github.com/cockroachdb/errors"
 	"github.com/lib/pq/oid"
@@ -55,8 +56,21 @@ func (tc *Catalog) ResolveFunctionByOID(
 	return nil, nil, errors.AssertionFailedf("ResolveFunctionByOID not supported in test catalog")
 }
 
-// CreateFunction handles the CREATE FUNCTION statement.
-func (tc *Catalog) CreateFunction(c *tree.CreateRoutine) {
+// ResolveProcedure is part of the tree.FunctionReferenceResolver interface.
+func (tc *Catalog) ResolveProcedure(
+	ctx context.Context, name *tree.UnresolvedObjectName, path tree.SearchPath,
+) (*tree.Overload, error) {
+	if def, ok := tc.udfs[name.String()]; ok {
+		o := def.Overloads[0]
+		if o.IsProcedure {
+			return o.Overload, nil
+		}
+	}
+	return nil, sqlerrors.NewProcedureUndefinedError(name)
+}
+
+// CreateRoutine handles the CREATE FUNCTION statement.
+func (tc *Catalog) CreateRoutine(c *tree.CreateRoutine) {
 	name := c.Name.String()
 	if _, ok := tree.FunDefs[name]; ok {
 		panic(fmt.Errorf("built-in function with name %q already exists", name))
@@ -106,6 +120,7 @@ func (tc *Catalog) CreateFunction(c *tree.CreateRoutine) {
 		Volatility:        v,
 		CalledOnNullInput: calledOnNullInput,
 		Language:          language,
+		IsProcedure:       c.IsProcedure,
 	}
 	if c.ReturnType.IsSet {
 		overload.Class = tree.GeneratorClass

--- a/pkg/sql/opt/testutils/testcat/test_catalog.go
+++ b/pkg/sql/opt/testutils/testcat/test_catalog.go
@@ -505,7 +505,7 @@ func (tc *Catalog) ExecuteDDLWithIndexVersion(
 		return "", nil
 
 	case *tree.CreateRoutine:
-		tc.CreateFunction(stmt)
+		tc.CreateRoutine(stmt)
 		return "", nil
 
 	case *tree.SetZoneConfig:

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -369,6 +369,12 @@ func (oc *optCatalog) ResolveFunctionByOID(
 	return oc.planner.ResolveFunctionByOID(ctx, oid)
 }
 
+func (oc *optCatalog) ResolveProcedure(
+	ctx context.Context, name *tree.UnresolvedObjectName, path tree.SearchPath,
+) (*tree.Overload, error) {
+	return oc.planner.ResolveProcedure(ctx, name, path)
+}
+
 func getDescFromCatalogObjectForPermissions(o cat.Object) (catalog.Descriptor, error) {
 	switch t := o.(type) {
 	case *optSchema:

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -2174,6 +2174,11 @@ func (ef *execFactory) ConstructExplain(
 	return n, nil
 }
 
+// ConstructCall is part of the exec.Factory interface.
+func (e *execFactory) ConstructCall(proc *tree.RoutineExpr) (exec.Node, error) {
+	return &callNode{proc: proc}, nil
+}
+
 // renderBuilder encapsulates the code to build a renderNode.
 type renderBuilder struct {
 	r   *renderNode

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -424,8 +424,6 @@ func TestUnimplementedSyntax(t *testing.T) {
 
 		{`ALTER AGGREGATE a`, 74775, `alter aggregate`, ``},
 
-		{`CALL foo`, 17511, `call procedure`, ``},
-
 		{`CREATE AGGREGATE a`, 74775, `create aggregate`, ``},
 		{`CREATE CAST a`, 0, `create cast`, ``},
 		{`CREATE CONSTRAINT TRIGGER a`, 28296, `create constraint`, ``},

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -1413,7 +1413,8 @@ func (u *sqlSymUnion) beginTransaction() *tree.BeginTransaction {
 %type <str> cursor_name database_name index_name opt_index_name column_name insert_column_item statistics_name window_name opt_in_database
 %type <str> family_name opt_family_name table_alias_name constraint_name target_name zone_name partition_name collation_name
 %type <str> db_object_name_component
-%type <*tree.UnresolvedObjectName> table_name db_name standalone_index_name sequence_name type_name view_name db_object_name simple_db_object_name complex_db_object_name
+%type <*tree.UnresolvedObjectName> table_name db_name standalone_index_name sequence_name type_name
+ %type <*tree.UnresolvedObjectName> view_name db_object_name simple_db_object_name complex_db_object_name proc_name
 %type <[]*tree.UnresolvedObjectName> type_name_list
 %type <str> schema_name opt_in_schema
 %type <tree.ObjectNamePrefix>  qualifiable_schema_name opt_schema_name wildcard_pattern
@@ -4009,9 +4010,18 @@ opt_with_options:
     $$.val = nil
   }
 
-// CALL invokes a stored procedure. It is not currently supported in CRDB.
+// %Help: CALL - invoke a procedure
+// %Category: Misc
+// %Text: CALL <name> ( [ <expr> [, ...] ] )
+// %SeeAlso: CREATE PROCEDURE
 call_stmt:
-  CALL error { return unimplementedWithIssueDetail(sqllex, 17511, "call procedure") }
+  CALL proc_name '(' opt_expr_list ')'
+  {
+    $$.val = &tree.Call{
+      Name: $2.unresolvedObjectName(),
+      Exprs: $4.exprs(),
+    }
+  }
 
 // The COPY grammar in postgres has 3 different versions, all of which are supported by postgres:
 // 1) The "really old" syntax from v7.2 and prior
@@ -16344,6 +16354,8 @@ table_name:            db_object_name
 db_name:               db_object_name
 
 standalone_index_name: db_object_name
+
+proc_name:             db_object_name
 
 explain_option_name:   non_reserved_word
 

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -4621,6 +4621,10 @@ create_proc_stmt:
       Params: $6.routineParams(),
       Options: $8.routineOptions(),
       RoutineBody: $9.routineBody(),
+      ReturnType: tree.RoutineReturnType{
+        Type: types.Void,
+        IsSet: true,
+      },
     }
   }
 | CREATE opt_or_replace PROCEDURE error // SHOW HELP: CREATE PROCEDURE

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -4594,7 +4594,7 @@ create_func_stmt:
   RETURNS opt_return_table opt_return_set routine_return_type
   opt_create_routine_opt_list opt_routine_body
   {
-    name := $4.unresolvedObjectName().ToFunctionName()
+    name := $4.unresolvedObjectName().ToRoutineName()
     $$.val = &tree.CreateRoutine{
       IsProcedure: false,
       Replace: $2.bool(),
@@ -4623,7 +4623,7 @@ create_proc_stmt:
   CREATE opt_or_replace PROCEDURE routine_create_name '(' opt_routine_param_with_default_list ')'
   opt_create_routine_opt_list opt_routine_body
   {
-    name := $4.unresolvedObjectName().ToFunctionName()
+    name := $4.unresolvedObjectName().ToRoutineName()
     $$.val = &tree.CreateRoutine{
       IsProcedure: true,
       Replace: $2.bool(),
@@ -4921,14 +4921,14 @@ function_with_paramtypes:
   db_object_name func_params
   {
     $$.val = tree.FuncObj{
-      FuncName: $1.unresolvedObjectName().ToFunctionName(),
+      FuncName: $1.unresolvedObjectName().ToRoutineName(),
       Params: $2.routineParams(),
     }
   }
   | db_object_name
   {
     $$.val = tree.FuncObj{
-      FuncName: $1.unresolvedObjectName().ToFunctionName(),
+      FuncName: $1.unresolvedObjectName().ToRoutineName(),
     }
   }
 

--- a/pkg/sql/parser/testdata/call
+++ b/pkg/sql/parser/testdata/call
@@ -1,0 +1,31 @@
+parse
+CALL p()
+----
+CALL p()
+CALL p() -- fully parenthesized
+CALL p() -- literals removed
+CALL _() -- identifiers removed
+
+parse
+CALL p(1, 'foo', 1.234, true, NULL)
+----
+CALL p(1, 'foo', 1.234, true, NULL)
+CALL p((1), ('foo'), (1.234), (true), (NULL)) -- fully parenthesized
+CALL p(_, '_', _, _, _) -- literals removed
+CALL _(1, 'foo', 1.234, true, NULL) -- identifiers removed
+
+error
+CALL p
+----
+at or near "EOF": syntax error
+DETAIL: source SQL:
+CALL p
+      ^
+
+error
+CALL
+----
+at or near "EOF": syntax error
+DETAIL: source SQL:
+CALL
+    ^

--- a/pkg/sql/plan_opt.go
+++ b/pkg/sql/plan_opt.go
@@ -358,6 +358,7 @@ func (opc *optPlanningCtx) reset(ctx context.Context) {
 	// support it for all statements in principle, but it would increase the
 	// surface of potential issues (conditions we need to detect to invalidate a
 	// cached memo).
+	// TODO(mgartner): Enable memo caching for CALL statements.
 	switch p.stmt.AST.(type) {
 	case *tree.ParenSelect, *tree.Select, *tree.SelectClause, *tree.UnionClause, *tree.ValuesClause,
 		*tree.Insert, *tree.Update, *tree.Delete, *tree.CannedOptPlan:

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_function.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_function.go
@@ -61,9 +61,10 @@ func CreateFunction(b BuildCtx, n *tree.CreateRoutine) {
 
 	fnID := b.GenerateUniqueDescID()
 	fn := scpb.Function{
-		FunctionID: fnID,
-		ReturnSet:  n.ReturnType.IsSet,
-		ReturnType: b.ResolveTypeRef(n.ReturnType.Type),
+		FunctionID:  fnID,
+		ReturnSet:   n.ReturnType.IsSet,
+		ReturnType:  b.ResolveTypeRef(n.ReturnType.Type),
+		IsProcedure: n.IsProcedure,
 	}
 	fn.Params = make([]scpb.Function_Parameter, len(n.Params))
 	for i, param := range n.Params {

--- a/pkg/sql/schemachanger/scdecomp/testdata/function
+++ b/pkg/sql/schemachanger/scdecomp/testdata/function
@@ -26,6 +26,7 @@ BackReferencedIDs:
 ElementState:
 - Function:
     functionId: 110
+    isProcedure: false
     params:
     - class:
         class: IN

--- a/pkg/sql/schemachanger/scdeps/sctestdeps/test_deps.go
+++ b/pkg/sql/schemachanger/scdeps/sctestdeps/test_deps.go
@@ -1239,7 +1239,7 @@ func (s *TestState) AddTableForStatsRefresh(id descpb.ID) {
 func (s *TestState) ResolveFunction(
 	ctx context.Context, name *tree.UnresolvedName, path tree.SearchPath,
 ) (*tree.ResolvedFunctionDefinition, error) {
-	fnName, err := name.ToFunctionName()
+	fnName, err := name.ToRoutineName()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/schemachanger/scexec/scmutationexec/function.go
+++ b/pkg/sql/schemachanger/scexec/scmutationexec/function.go
@@ -40,6 +40,7 @@ func (i *immediateVisitor) CreateFunctionDescriptor(
 		params,
 		op.Function.ReturnType.Type,
 		op.Function.ReturnSet,
+		op.Function.IsProcedure,
 		&catpb.PrivilegeDescriptor{Version: catpb.Version21_2},
 	)
 	mut.State = descpb.DescriptorState_ADD

--- a/pkg/sql/schemachanger/scexec/scmutationexec/references.go
+++ b/pkg/sql/schemachanger/scexec/scmutationexec/references.go
@@ -561,10 +561,11 @@ func (i *immediateVisitor) SetObjectParentID(ctx context.Context, op scop.SetObj
 		t.ParentSchemaID = sc.GetID()
 
 		ol := descpb.SchemaDescriptor_FunctionSignature{
-			ID:         obj.GetID(),
-			ArgTypes:   make([]*types.T, len(t.GetParams())),
-			ReturnType: t.GetReturnType().Type,
-			ReturnSet:  t.GetReturnType().ReturnSet,
+			ID:          obj.GetID(),
+			ArgTypes:    make([]*types.T, len(t.GetParams())),
+			ReturnType:  t.GetReturnType().Type,
+			ReturnSet:   t.GetReturnType().ReturnSet,
+			IsProcedure: t.IsProcedure,
 		}
 		for i := range t.Params {
 			ol.ArgTypes[i] = t.Params[i].Type

--- a/pkg/sql/schemachanger/scpb/elements.proto
+++ b/pkg/sql/schemachanger/scpb/elements.proto
@@ -673,6 +673,7 @@ message Function {
 
   bool return_set = 3;
   TypeT return_type = 4 [(gogoproto.nullable) = false];
+  bool is_procedure = 5;
 }
 
 message FunctionName {

--- a/pkg/sql/schemachanger/scpb/uml/table.puml
+++ b/pkg/sql/schemachanger/scpb/uml/table.puml
@@ -170,6 +170,7 @@ Function :  FunctionID
 Function : []Params
 Function :  ReturnSet
 Function :  ReturnType
+Function :  IsProcedure
 
 object FunctionBody
 

--- a/pkg/sql/schemachanger/sctest/backup.go
+++ b/pkg/sql/schemachanger/sctest/backup.go
@@ -509,7 +509,7 @@ func containsUDF(expr tree.Expr) (bool, error) {
 	_, err := tree.SimpleVisit(expr, func(expr tree.Expr) (recurse bool, newExpr tree.Expr, _ error) {
 		if fe, ok := expr.(*tree.FuncExpr); ok {
 			ref := fe.Func.FunctionReference.(*tree.UnresolvedName)
-			fn, err := ref.ToFunctionName()
+			fn, err := ref.ToRoutineName()
 			if err != nil {
 				return false, nil, err
 			}

--- a/pkg/sql/sem/tree/BUILD.bazel
+++ b/pkg/sql/sem/tree/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "annotation.go",
         "backup.go",
         "batch.go",
+        "call.go",
         "changefeed.go",
         "col_name.go",
         "comment_on_column.go",

--- a/pkg/sql/sem/tree/call.go
+++ b/pkg/sql/sem/tree/call.go
@@ -1,0 +1,30 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package tree
+
+// Call represents a CALL statement to invoke a procedure.
+type Call struct {
+	// Name is the name of the procedure.
+	Name *UnresolvedObjectName
+	// Exprs contains the arguments to pass to the procedure.
+	Exprs Exprs
+}
+
+// Format implements the NodeFormatter interface.
+func (node *Call) Format(ctx *FmtCtx) {
+	ctx.WriteString("CALL ")
+	ctx.FormatNode(node.Name)
+	ctx.WriteByte('(')
+	ctx.FormatNode(&node.Exprs)
+	ctx.WriteByte(')')
+}
+
+var _ Statement = &Call{}

--- a/pkg/sql/sem/tree/create_routine.go
+++ b/pkg/sql/sem/tree/create_routine.go
@@ -111,7 +111,7 @@ func (node *CreateRoutine) Format(ctx *FmtCtx) {
 		ctx.WriteString("FUNCTION ")
 	}
 	ctx.FormatNode(&node.Name)
-	ctx.WriteString("(")
+	ctx.WriteByte('(')
 	ctx.FormatNode(node.Params)
 	ctx.WriteString(")\n\t")
 	if !node.IsProcedure {
@@ -138,12 +138,12 @@ func (node *CreateRoutine) Format(ctx *FmtCtx) {
 		ctx.WriteString("$$")
 		for i, stmt := range node.BodyStatements {
 			if i > 0 {
-				ctx.WriteString(" ")
+				ctx.WriteByte(' ')
 			}
 			oldAnn := ctx.ann
 			ctx.ann = node.BodyAnnotations[i]
 			ctx.FormatNode(stmt)
-			ctx.WriteString(";")
+			ctx.WriteByte(';')
 			ctx.ann = oldAnn
 		}
 		ctx.WriteString("$$")

--- a/pkg/sql/sem/tree/function_definition_test.go
+++ b/pkg/sql/sem/tree/function_definition_test.go
@@ -73,7 +73,7 @@ func TestBuiltinFunctionResolver(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.testName, func(t *testing.T) {
-			fnName, err := tc.fnName.ToFunctionName()
+			fnName, err := tc.fnName.ToRoutineName()
 			require.NoError(t, err)
 			funcDef, err := tree.GetBuiltinFuncDefinition(fnName, &path)
 			require.NoError(t, err)

--- a/pkg/sql/sem/tree/function_name.go
+++ b/pkg/sql/sem/tree/function_name.go
@@ -98,7 +98,7 @@ func (ref *ResolvableFunctionReference) Resolve(
 	case *UnresolvedName:
 		if resolver == nil {
 			// If a resolver is not provided, just try to fetch a builtin function.
-			fn, err := t.ToFunctionName()
+			fn, err := t.ToRoutineName()
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/sql/sem/tree/name_part.go
+++ b/pkg/sql/sem/tree/name_part.go
@@ -229,11 +229,11 @@ func (u *UnresolvedName) ToUnresolvedObjectName(idx AnnotationIdx) (UnresolvedOb
 	)
 }
 
-// ToFunctionName converts an UnresolvedName to a RoutineName.
-func (u *UnresolvedName) ToFunctionName() (RoutineName, error) {
+// ToRoutineName converts an UnresolvedName to a RoutineName.
+func (u *UnresolvedName) ToRoutineName() (RoutineName, error) {
 	un, err := u.ToUnresolvedObjectName(NoAnnotation)
 	if err != nil {
 		return RoutineName{}, errors.Newf("invalid function name: %s", u.String())
 	}
-	return un.ToFunctionName(), nil
+	return un.ToRoutineName(), nil
 }

--- a/pkg/sql/sem/tree/object_name.go
+++ b/pkg/sql/sem/tree/object_name.go
@@ -240,8 +240,8 @@ func (u *UnresolvedObjectName) ToTableName() TableName {
 	return TableName{u.toObjName()}
 }
 
-// ToFunctionName converts the unresolved name to a function name.
-func (u *UnresolvedObjectName) ToFunctionName() RoutineName {
+// ToRoutineName converts the unresolved name to a function name.
+func (u *UnresolvedObjectName) ToRoutineName() RoutineName {
 	return RoutineName{u.toObjName()}
 }
 

--- a/pkg/sql/sem/tree/overload.go
+++ b/pkg/sql/sem/tree/overload.go
@@ -229,6 +229,9 @@ type Overload struct {
 	// IsUDF is set to true when this is a user-defined function overload built
 	// using CREATE FUNCTION. Note: Body can be empty even if IsUDF is true.
 	IsUDF bool
+	// IsProcedure is set to true when this is a user-defined procedure built
+	// using CREATE PROCEDURE.
+	IsProcedure bool
 	// Body is the SQL string body of a function. It can be set even if IsUDF is
 	// false if a builtin function is defined using a SQL string.
 	Body string

--- a/pkg/sql/sem/tree/routine.go
+++ b/pkg/sql/sem/tree/routine.go
@@ -120,6 +120,9 @@ type RoutineExpr struct {
 	// to avoid nesting execution. This is necessary for performant PLpgSQL loops.
 	TailCall bool
 
+	// Procedure is true if the routine is a procedure being invoked by CALL.
+	Procedure bool
+
 	// ExceptionHandler holds the information needed to handle errors if an
 	// exception block was defined.
 	ExceptionHandler *RoutineExceptionHandler
@@ -136,6 +139,7 @@ func NewTypedRoutineExpr(
 	multiColOutput bool,
 	generator bool,
 	tailCall bool,
+	procedure bool,
 	exceptionHandler *RoutineExceptionHandler,
 ) *RoutineExpr {
 	return &RoutineExpr{
@@ -148,6 +152,7 @@ func NewTypedRoutineExpr(
 		MultiColOutput:    multiColOutput,
 		Generator:         generator,
 		TailCall:          tailCall,
+		Procedure:         procedure,
 		ExceptionHandler:  exceptionHandler,
 	}
 }

--- a/pkg/sql/sem/tree/stmt.go
+++ b/pkg/sql/sem/tree/stmt.go
@@ -651,6 +651,15 @@ func (*BeginTransaction) StatementType() StatementType { return TypeTCL }
 func (*BeginTransaction) StatementTag() string { return "BEGIN" }
 
 // StatementReturnType implements the Statement interface.
+func (*Call) StatementReturnType() StatementReturnType { return Ack }
+
+// StatementType implements the Statement interface.
+func (*Call) StatementType() StatementType { return TypeTCL }
+
+// StatementTag returns a short string identifying the type of statement.
+func (*Call) StatementTag() string { return "CALL" }
+
+// StatementReturnType implements the Statement interface.
 func (*ControlJobs) StatementReturnType() StatementReturnType { return RowsAffected }
 
 // StatementType implements the Statement interface.
@@ -2219,6 +2228,7 @@ func (n *AlterSequence) String() string                       { return AsString(
 func (n *Analyze) String() string                             { return AsString(n) }
 func (n *Backup) String() string                              { return AsString(n) }
 func (n *BeginTransaction) String() string                    { return AsString(n) }
+func (n *Call) String() string                                { return AsString(n) }
 func (n *ControlJobs) String() string                         { return AsString(n) }
 func (n *ControlSchedules) String() string                    { return AsString(n) }
 func (n *ControlJobsForSchedules) String() string             { return AsString(n) }

--- a/pkg/sql/sqlerrors/errors.go
+++ b/pkg/sql/sqlerrors/errors.go
@@ -365,6 +365,10 @@ func NewCannotModifyVirtualSchemaError(schema string) error {
 		"%s is a virtual schema and cannot be modified", tree.ErrNameString(schema))
 }
 
+func NewProcedureUndefinedError(proc *tree.UnresolvedObjectName) error {
+	return pgerror.Newf(pgcode.UndefinedFunction, "procedure %s does not exist", proc)
+}
+
 // QueryTimeoutError is an error representing a query timeout.
 var QueryTimeoutError = pgerror.New(
 	pgcode.QueryCanceled, "query execution canceled due to statement timeout")

--- a/pkg/sql/walk.go
+++ b/pkg/sql/walk.go
@@ -370,6 +370,7 @@ var planNodeNames = map[reflect.Type]string{
 	reflect.TypeOf(&alterRoleSetNode{}):                        "alter role set var",
 	reflect.TypeOf(&applyJoinNode{}):                           "apply join",
 	reflect.TypeOf(&bufferNode{}):                              "buffer",
+	reflect.TypeOf(&callNode{}):                                "call",
 	reflect.TypeOf(&cancelQueriesNode{}):                       "cancel queries",
 	reflect.TypeOf(&cancelSessionsNode{}):                      "cancel sessions",
 	reflect.TypeOf(&cdcValuesNode{}):                           "wrapped streaming node",


### PR DESCRIPTION
#### sql: create descriptors for procedures

With this commit `CREATE PROCEDURE` now creates a function descriptor
designated as representing a procedure, specifically. The procedure
designation has been plumbed throughout the schema changer and into
`tree.Overload` so that it can be consumed in future commits.

Release note: None

#### sql: parse CALL

The `CALL` statement can now be parsed into an AST. Planning and
executing `CALL` is not yet supported.

Release note: None

#### opt: build CALL expressions

The optimizer can now construct simple CALL statements into optimizer
expressions. These expressions cannot yet be executed and only a limited
set of features is supported. For example, the optimizer can neither
construct CALL expressions for procedures with arguments nor for
procedures written in PL/pgSQL. Support for more complex procedures will
be added in follow-up commits.

Epic: CRDB-25388

Release note: None

#### sql: add execution support for CALL statements

It is now possible to execute simple procedures with the `CALL`
statement. Support for more complex procedures will be added in future
commits.

Epic: CRDB-25388

Release note: None

#### sql: rename "function" to "routine" in some cases

User-defined functions and procedures have many shared code-paths. To
avoid confusion, these code paths should use the more general term
"routine", rather than "function" or "procedure". This commit performs
some of this renaming.

Release note: None
