### PR TITLE
roachtest: backup source and destination tenants on c2c fingerprint mismatch

### DIFF
--- a/pkg/cmd/roachtest/tests/multitenant_utils.go
+++ b/pkg/cmd/roachtest/tests/multitenant_utils.go
@@ -340,12 +340,34 @@ func createInMemoryTenant(
 ) *gosql.DB {
 	sysSQL := sqlutils.MakeSQLRunner(c.Conn(ctx, t.L(), nodes.RandNode()[0]))
 	sysSQL.Exec(t, "CREATE TENANT $1", tenantName)
+
+	tenantConn := startInMemoryTenant(ctx, t, c, tenantName, nodes)
+	tenantSQL := sqlutils.MakeSQLRunner(tenantConn)
+	if secure {
+		createTenantAdminRole(t, tenantName, tenantSQL)
+	}
+	return tenantConn
+}
+
+// startInMemoryTenant starts an in memory tenant that has already been created.
+// This function also removes tenant rate limiters and sets a few cluster
+// settings on the tenant.  As a convenience, it also returns a connection to
+// the tenant (on a random node in the cluster).
+func startInMemoryTenant(
+	ctx context.Context,
+	t test.Test,
+	c cluster.Cluster,
+	tenantName string,
+	nodes option.NodeListOption,
+) *gosql.DB {
+	sysSQL := sqlutils.MakeSQLRunner(c.Conn(ctx, t.L(), nodes.RandNode()[0]))
 	sysSQL.Exec(t, "ALTER TENANT $1 START SERVICE SHARED", tenantName)
 	sysSQL.Exec(t, `ALTER TENANT $1 GRANT CAPABILITY can_view_node_info=true, can_admin_split=true,can_view_tsdb_metrics=true`, tenantName)
 	sysSQL.Exec(t, `ALTER TENANT $1 SET CLUSTER SETTING sql.split_at.allow_for_secondary_tenant.enabled=true`, tenantName)
 	sysSQL.Exec(t, `ALTER TENANT $1 SET CLUSTER SETTING sql.scatter.allow_for_secondary_tenant.enabled=true`, tenantName)
 	sysSQL.Exec(t, `ALTER TENANT $1 SET CLUSTER SETTING sql.zone_configs.allow_for_secondary_tenant.enabled=true`, tenantName)
-
+	sysSQL.Exec(t, `ALTER TENANT $1 SET CLUSTER SETTING enterprise.license = $2`, tenantName, config.CockroachDevLicense)
+	sysSQL.Exec(t, `ALTER TENANT $1 SET CLUSTER SETTING cluster.organization = 'Cockroach Labs - Production Testing'`, tenantName)
 	removeTenantRateLimiters(t, sysSQL, tenantName)
 
 	// Opening a SQL session to a newly created in-process tenant may require a
@@ -354,7 +376,6 @@ func createInMemoryTenant(
 	// first query. Therefore, wrap connection opening and a ping to the tenant
 	// server in a retry loop.
 	var tenantConn *gosql.DB
-	var tenantSQL *sqlutils.SQLRunner
 	testutils.SucceedsSoon(t, func() error {
 		var err error
 		tenantConn, err = c.ConnE(ctx, t.L(), nodes.RandNode()[0], option.TenantName(tenantName))
@@ -364,13 +385,9 @@ func createInMemoryTenant(
 		if err = tenantConn.Ping(); err != nil {
 			return err
 		}
-		tenantSQL = sqlutils.MakeSQLRunner(tenantConn)
 		return nil
 	})
 
-	if secure {
-		createTenantAdminRole(t, tenantName, tenantSQL)
-	}
 	return tenantConn
 }
 


### PR DESCRIPTION
In https://github.com/cockroachdb/cockroach/issues/109957, a c2c roachtest detected a fingerprint mismatch, but the code path
the roachtest takes on a mismatch failed to provide additional information
about the mismatch. This patch attempts to ensure that after a fingerprint
mismatch, the roachtest will gather a bunch of information we can use to
understand the nature of the mismatch.

Specifically, this patch modifies the fingerprint mismatch code path to take
cluster backups from the source and destination tenants. This patch adds a few
other related improvements to the c2c roachtest driver:
- the c2c/shutdown and c2c/kv0 roachtests will now occasionally test the
  fingerprint mismatch code path, to ensure it works properly when an actual
mismatch occurs.
- starts the destination tenant after cutover, which is required for the
  fingerprint mismatch code path.
- allows the roachtest user to pass the COCKROACH_RANDOM_SEED envar while
  running the roachtest.

Informs https://github.com/cockroachdb/cockroach/issues/109957

Release note: none