### PR TITLE
roachprod: report runs to DMS

### DIFF
--- a/pkg/cmd/roachprod/docker/entrypoint.sh
+++ b/pkg/cmd/roachprod/docker/entrypoint.sh
@@ -9,4 +9,6 @@ aws configure set aws_secret_access_key $(cat /secrets/aws_secret_access_key)
 # library to work
 aws configure set region us-east-1
 az login --service-principal -u $(cat /secrets/azure_user_id) -p $(cat /secrets/azure_password) -t $(cat /secrets/azure_tenant_id)
-exec /usr/local/bin/roachprod $@
+/usr/local/bin/roachprod "$@"
+# Report only successful runs to Dead Man's Snitch
+curl https://nosnch.in/060eb36e55


### PR DESCRIPTION
Previously, the roachprod gc runs was not reporting to Dead Man's Snitch, because the local changes made to the cronjob were removed by a deployment.

This PR adds a call to DMS to report successful runs.

Epic: none
Release note: None