### PR TITLE
release-23.1.10-rc: roachtest: fix calls to schemachange workload in acceptance/version-upgrade

### DIFF
--- a/pkg/cmd/roachtest/tests/versionupgrade.go
+++ b/pkg/cmd/roachtest/tests/versionupgrade.go
@@ -137,10 +137,19 @@ func runVersionUpgrade(ctx context.Context, t test.Test, c cluster.Cluster) {
 	mvt.InMixedVersion(
 		"test schema change step",
 		func(ctx context.Context, l *logger.Logger, rng *rand.Rand, h *mixedversion.Helper) error {
-			if c.IsLocal() {
-				l.Printf("skipping step in bors builds while failures are handled -- #99115")
+			tc := h.Context()
+			// We currently only stage the `workload` binary built off the
+			// SHA being tested; therefore, we skip testing the schemachange
+			// workload if this is not an upgrade or downgrade involving the
+			// current cockroach binary.
+			// TODO(renato): stage different workload binaries for the
+			// releases being used in the test and use the appropriate
+			// binary in this step.
+			if tc.FromVersion != clusterupgrade.MainVersion && tc.ToVersion != clusterupgrade.MainVersion {
+				l.Printf("skipping this step -- only supported when current version is involved")
 				return nil
 			}
+
 			l.Printf("running schema workload step")
 			runCmd := roachtestutil.NewCommand("./workload run schemachange").Flag("verbose", 1).Flag("max-ops", 10).Flag("concurrency", 2).Arg("{pgurl:1-%d}", len(c.All()))
 			randomNode := h.RandomNode(rng, c.All())


### PR DESCRIPTION
Backport 1/1 commits from #110029.

/cc @cockroachdb/release

---

The `schemachange` workload would always be called in that test; however, we are currently only staging the `workload` binary build on the SHA being tested; this is insufficient now that we test multiple upgrades in `mixedversion` tests.

We fix the immediate issue by not invoking the workload when we are not performing an upgrade or downgrade involving the current cockroach binary. In the future, it would be nice to stage multiple workload binaries and use the appropriate one in the mixed-version hook.

Epic: none

Release note: None

Release justification: test-only change.
