### PR TITLE
release-23.1: ccl/multiregionccl: disable transfers in multiregion test

### DIFF
--- a/pkg/ccl/multiregionccl/datadriven_test.go
+++ b/pkg/ccl/multiregionccl/datadriven_test.go
@@ -113,7 +113,13 @@ func TestMultiRegionDataDriven(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	// This test speeds up replication changes by proactively enqueuing replicas
+	// into various queues. This has the benefit of reducing the time taken after
+	// zone config changes, however the downside of added overhead. Disable the
+	// test under deadlock builds, as the test is slow and susceptible to
+	// (legitimate) timing issues on a deadlock build.
 	skip.UnderRace(t, "flaky test")
+	skip.UnderDeadlock(t, "flaky test")
 	ctx := context.Background()
 	datadriven.Walk(t, datapathutils.TestDataPath(t), func(t *testing.T, path string) {
 


### PR DESCRIPTION
Backport 2/2 commits from #109819.

/cc @cockroachdb/release

---

Previously, `TestMultiRegionDataDriven` allowed kvserver (replicate queue) lease transfers to occur for lease count rebalancing. Load based rebalancing was disabled in an earlier patch #109050, however we saw in interleaving replication changes -- leading to flaky behavior.

Bump the `kv.allocator.min_lease_transfer_interval` to 5 minutes, effectively disabling internal lease transfers. Lease transfers which are required for lease preference satisfaction, and manual transfers are still permitted.

Fixes: #109215
Release note: None

---

`TestMultiRegionDataDriven` speeds up replication changes by proactively
enqueuing replicas into various queues. This has the benefit of reducing
the time taken after zone config changes, however the downside of added
overhead.

Disable the test under deadlock builds, as the test is slow and
susceptible to (legitimate) timing issues on a deadlock build.

Informs: https://github.com/cockroachdb/cockroach/issues/109215
Release note: None

---

Release justification: Test only change.
