### PR TITLE
kv: disable merge queue in TestTxnCoordSenderRetries

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
@@ -2011,6 +2011,8 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 	// operates between keys "a" and "z" and expects a single split point at "b".
 	// See the call to setupMultipleRanges below.
 	storeKnobs.DisableLoadBasedSplitting = true
+	// Similarly, disable the merge queue to avoid unexpected merges.
+	storeKnobs.DisableMergeQueue = true
 
 	var refreshSpansCondenseFilter atomic.Value
 	s, _, _ := serverutils.StartServer(t,


### PR DESCRIPTION
Closes #109871.

Avoids test flakiness.

Release note: None