### PR TITLE
ccl/multiregionccl: unskip test multi region dd parent test

### DIFF
--- a/pkg/ccl/multiregionccl/datadriven_test.go
+++ b/pkg/ccl/multiregionccl/datadriven_test.go
@@ -202,7 +202,7 @@ SET CLUSTER SETTING kv.closed_timestamp.side_transport_interval = '0.1s';
 SET CLUSTER SETTING kv.closed_timestamp.propagation_slack = '0.5s';
 SET CLUSTER SETTING kv.allocator.load_based_rebalancing = 'off';
 SET CLUSTER SETTING kv.allocator.load_based_lease_rebalancing.enabled = false;
-SET CLUSTER SETTING kv.allocator.min_lease_transfer_interval = 5m
+SET CLUSTER SETTING kv.allocator.min_lease_transfer_interval = '5m'
 `,
 					";") {
 					_, err = sqlConn.Exec(stmt)

--- a/pkg/ccl/multiregionccl/datadriven_test.go
+++ b/pkg/ccl/multiregionccl/datadriven_test.go
@@ -120,7 +120,6 @@ func TestMultiRegionDataDriven(t *testing.T) {
 	// (legitimate) timing issues on a deadlock build.
 	skip.UnderRace(t, "flaky test")
 	skip.UnderDeadlock(t, "flaky test")
-	skip.WithIssue(t, 98020)
 	ctx := context.Background()
 	datadriven.Walk(t, datapathutils.TestDataPath(t), func(t *testing.T, path string) {
 		ds := datadrivenTestState{}


### PR DESCRIPTION
`TestMultiRegionDataDriven` was skipped in https://github.com/cockroachdb/cockroach/pull/108107 due to finish
(tracing span) being called twice in raft reproposals https://github.com/cockroachdb/cockroach/issues/107521, which
 https://github.com/cockroachdb/cockroach/pull/108775 fixed.

Unskip the top level `TestMultiRegionDataDriven` test. Note
`/secondary_region` is still skipped due to a known allocator bug.

Informs: https://github.com/cockroachdb/cockroach/issues/98020
Epic: none
Release note: None