### PR TITLE
roachtest: fix dependencies in typeorm tests

### DIFF
--- a/pkg/cmd/roachtest/tests/typeorm.go
+++ b/pkg/cmd/roachtest/tests/typeorm.go
@@ -25,7 +25,7 @@ import (
 )
 
 var typeORMReleaseTagRegex = regexp.MustCompile(`^(?P<major>\d+)\.(?P<minor>\d+)\.(?P<point>\d+)$`)
-var supportedTypeORMRelease = "0.3.5"
+var supportedTypeORMRelease = "0.3.17"
 
 // This test runs TypeORM's full test suite against a single cockroach node.
 func registerTypeORM(r registry.Registry) {


### PR DESCRIPTION
The new version avoids this error:
```
npm ERR!   File "/home/ubuntu/.node-gyp/18.17.1/include/node/common.gypi", line 1
npm ERR!     'uv_library%': 'static_library',
npm ERR!                  ^
npm ERR! SyntaxError: invalid syntax
npm ERR! gyp ERR! configure error
npm ERR! gyp ERR! stack Error: `gyp` failed with exit code: 1
npm ERR! gyp ERR! stack     at ChildProcess.onCpExit (/mnt/data1/typeorm/node_modules/node-gyp/lib/configure.js:345:16)
npm ERR! gyp ERR! stack     at ChildProcess.emit (node:events:514:28)
npm ERR! gyp ERR! stack     at ChildProcess._handle.onexit (node:internal/child_process:291:12)
npm ERR! gyp ERR! System Linux 5.15.0-1039-gcp
npm ERR! gyp ERR! command "/usr/bin/node" "/mnt/data1/typeorm/node_modules/.bin/node-gyp" "rebuild" "--release"
npm ERR! gyp ERR! cwd /mnt/data1/typeorm/node_modules/better-sqlite3
npm ERR! gyp ERR! node -v v18.17.1
npm ERR! gyp ERR! node-gyp -v v3.8.0
npm ERR! gyp ERR! not ok
```

fixes https://github.com/cockroachdb/cockroach/issues/109962
fixes https://github.com/cockroachdb/cockroach/issues/109961
fixes https://github.com/cockroachdb/cockroach/issues/109981
fixes https://github.com/cockroachdb/cockroach/issues/109980
fixes https://github.com/cockroachdb/cockroach/issues/109958
fixes https://github.com/cockroachdb/cockroach/issues/109963

Release note: None