### PR TITLE
sql/sem/tree: eliminate types.T allocations in collated string comparison

### DIFF
--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -1481,7 +1481,7 @@ func (d *DCollatedString) CompareError(ctx CompareContext, other Datum) (int, er
 		return 1, nil
 	}
 	v, ok := ctx.UnwrapDatum(other).(*DCollatedString)
-	if !ok || !d.ResolvedType().Equivalent(other.ResolvedType()) {
+	if !ok || !lex.LocaleNamesAreEqual(d.Locale, v.Locale) {
 		return 0, makeUnsupportedComparisonMessage(d, other)
 	}
 	res := bytes.Compare(d.Key, v.Key)

--- a/pkg/sql/types/types.go
+++ b/pkg/sql/types/types.go
@@ -192,12 +192,12 @@ type UserDefinedTypeMetadata struct {
 	// Name is the resolved name of this type.
 	Name *UserDefinedTypeName
 
+	// EnumData is non-nil iff the metadata is for an ENUM type.
+	EnumData *EnumMetadata
+
 	// Version is the descriptor version of the descriptor used to construct
 	// this version of the type metadata.
 	Version uint32
-
-	// EnumData is non-nil iff the metadata is for an ENUM type.
-	EnumData *EnumMetadata
 
 	// ImplicitRecordType is true if the metadata is for an implicit record type
 	// for a table. Note: this can be deleted if we migrate implicit record types


### PR DESCRIPTION
#### sql/sem/tree: eliminate types.T allocations in collated string comparison

This commit eliminates allocations of `types.T` in the `CompareError`
method of `DCollatedString`. Instead of allocating a new collated string
type and calling the `Equivalent` method on the type, `CompareError`
simply checks that the locales of the collated string datums match. This
matches the behavior of `Equivalent`.

Epic: None

Release note (performance improvement): Queries that compare collated
strings now use less memory and may execute faster.

#### sql/sem/types: more efficiently order UserDefinedTypeMetadata fields

The order of fields of the `types.UserDefinedTypedMetadata` struct,
which is embedded in `types.T`, has been changed to reduce padding
required for word-alignment. The struct size has been reduced from 32
bytes to 24 bytes.

Release note: None
