### PR TITLE
release-23.1: sqlsmith: don't test non-deterministic st_simplifypreservetopology

### DIFF
--- a/pkg/internal/sqlsmith/schema.go
+++ b/pkg/internal/sqlsmith/schema.go
@@ -494,6 +494,11 @@ var functions = func() map[tree.FunctionClass]map[oid.Oid][]function {
 			// run for a long time or never finish, so we avoid generating them.
 			// See #69213.
 			continue
+		case "st_simplifypreservetopology":
+			// The st_simplifypreservetopology function is non-deterministic in older
+			// versions of libgeos (See #108982). Skip testing this function on older
+			// CRDB release which are running a version of libgeos without the fix.
+			continue
 		}
 
 		if n := tree.Name(def.Name); n.String() != def.Name {


### PR DESCRIPTION
Function st_simplifypreservetopology is non-deterministic on older versions of libgeos, which can cause mismatches in SQLSmith tests. The upgrade of libgeos to fix this issue won't be backported to CRDB v23.1 and below, so this change avoids testing this function on older releases.

Fixes: #108982

Release note: None

Release justification: Test only change to avoid reporting known issue whose fix won't be backported.