### PR TITLE
kvserver: deflake TestProtectedTimestamps

### DIFF
--- a/pkg/kv/kvserver/client_protectedts_test.go
+++ b/pkg/kv/kvserver/client_protectedts_test.go
@@ -183,11 +183,8 @@ ORDER BY raw_start_key ASC LIMIT 1`)
 	// Verify that the record did indeed make its way down into KV where the
 	// replica can read it from.
 	ptsReader := tc.GetFirstStoreFromServer(t, 0).GetStoreConfig().ProtectedTimestampReader
-	require.NoError(
-		t,
-		ptutil.TestingVerifyProtectionTimestampExistsOnSpans(
-			ctx, t, s0, ptsReader, ptsRec.Timestamp, ptsRec.DeprecatedSpans,
-		),
+	ptutil.TestingWaitForProtectedTimestampToExistOnSpans(
+		ctx, t, s0, ptsReader, ptsRec.Timestamp, ptsRec.DeprecatedSpans,
 	)
 	upsertUntilBackpressure()
 	// We need to be careful choosing a time. We're a little limited because the
@@ -223,11 +220,8 @@ ORDER BY raw_start_key ASC LIMIT 1`)
 	// Verify that the record did indeed make its way down into KV where the
 	// replica can read it from. We then verify (below) that the failed record
 	// does not affect the ability to GC.
-	require.NoError(
-		t,
-		ptutil.TestingVerifyProtectionTimestampExistsOnSpans(
-			ctx, t, s0, ptsReader, failedRec.Timestamp, failedRec.DeprecatedSpans,
-		),
+	ptutil.TestingWaitForProtectedTimestampToExistOnSpans(
+		ctx, t, s0, ptsReader, failedRec.Timestamp, failedRec.DeprecatedSpans,
 	)
 
 	// Add a new record that is after the old record.
@@ -236,11 +230,8 @@ ORDER BY raw_start_key ASC LIMIT 1`)
 	laterRec.Timestamp = afterWrites
 	laterRec.Timestamp.Logical = 0
 	require.NoError(t, ptsWithDB.Protect(ctx, &laterRec))
-	require.NoError(
-		t,
-		ptutil.TestingVerifyProtectionTimestampExistsOnSpans(
-			ctx, t, s0, ptsReader, laterRec.Timestamp, laterRec.DeprecatedSpans,
-		),
+	ptutil.TestingWaitForProtectedTimestampToExistOnSpans(
+		ctx, t, s0, ptsReader, laterRec.Timestamp, laterRec.DeprecatedSpans,
 	)
 
 	// Release the record that had succeeded and ensure that GC eventually

--- a/pkg/kv/kvserver/client_replica_test.go
+++ b/pkg/kv/kvserver/client_replica_test.go
@@ -4228,15 +4228,9 @@ func TestStrictGCEnforcement(t *testing.T) {
 				}
 				ptsReader := tc.GetFirstStoreFromServer(t, i).GetStoreConfig().ProtectedTimestampReader
 				_, r := getFirstStoreReplica(t, tc.Server(i), tableKey)
-				testutils.SucceedsSoon(t, func() error {
-					if err := ptutil.TestingVerifyProtectionTimestampExistsOnSpans(ctx, t, tc.Server(i),
-						ptsReader, protectionTimestamp,
-						[]roachpb.Span{span}); err != nil {
-						return errors.Newf("protection timestamp %s does not exist on span %s",
-							protectionTimestamp, span)
-					}
-					return nil
-				})
+				ptutil.TestingWaitForProtectedTimestampToExistOnSpans(ctx, t, tc.Server(i),
+					ptsReader, protectionTimestamp,
+					[]roachpb.Span{span})
 				require.NoError(t, r.ReadProtectedTimestampsForTesting(ctx))
 			}
 		}


### PR DESCRIPTION
Previously, we weren't waiting for the PTS record to make its way to KV in this test. This meant expecting it to provide protection (which the test asserted) was racy with spanconfig reconciliation. Span config reconciliation is built over rangefeeds, so when we bumped the default value of `kv.rangefeed.closed_timestamp_refresh_interval` in #108667, it meant span config reconciliation would take longer. This caused the GC queue to run before the replica was aware of the PTS record, which violated a test assertion.

This patch fixes the issue by only enqueueing the range in the GC queue once the PTS record is known to have made it to KV.

Closes #109244

Release note: None