### PR TITLE
kvserver: speed up TestProtectedTimestamps

### DIFF
--- a/pkg/kv/kvserver/client_protectedts_test.go
+++ b/pkg/kv/kvserver/client_protectedts_test.go
@@ -72,6 +72,9 @@ func TestProtectedTimestamps(t *testing.T) {
 	_, err = conn.Exec("SET CLUSTER SETTING kv.closed_timestamp.target_duration = '100ms'") // speeds up the test
 	require.NoError(t, err)
 
+	_, err = conn.Exec("SET CLUSTER SETTING kv.rangefeed.closed_timestamp_refresh_interval = '200ms'") // speeds up the test
+	require.NoError(t, err)
+
 	_, err = conn.Exec("SET CLUSTER SETTING kv.enqueue_in_replicate_queue_on_span_config_update.enabled = true") // speeds up the test
 	require.NoError(t, err)
 


### PR DESCRIPTION
Reduce closed timestamp refresh interval from the default 3s to 200ms. This makes protected timestamp delivery (which the test waits for) faster.

Touches #109244
Release note: none
Epic: none