### PR TITLE
sql: return pgerror for duplicate regions in super region

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/secondary_region
+++ b/pkg/ccl/logictestccl/testdata/logic_test/secondary_region
@@ -469,6 +469,9 @@ ALTER DATABASE mr3 ADD SUPER REGION "test1" VALUES "us-east-1", "us-west-1"
 statement ok
 ALTER DATABASE mr3 ADD SUPER REGION "test2" VALUES "us-central-1", "ca-central-1"
 
+statement error pgcode 42710 pq: duplicate region us-central-1 found in super region test3
+ALTER DATABASE mr3 ADD SUPER REGION "test3" VALUES "us-central-1", "ca-central-1", "us-central-1"
+
 statement error pq: the secondary region must be in the same super region as the current primary region
 ALTER DATABASE mr3 SET SECONDARY REGION "us-east-1"
 

--- a/pkg/sql/alter_database.go
+++ b/pkg/sql/alter_database.go
@@ -1548,6 +1548,16 @@ func (p *planner) AlterDatabaseAddSuperRegion(
 		return nil, err
 	}
 
+	// Validate no duplicate regions exist.
+	existingRegionNames := make(map[tree.Name]struct{})
+	for _, region := range n.Regions {
+		if _, found := existingRegionNames[region]; found {
+			return nil, pgerror.Newf(pgcode.DuplicateObject,
+				"duplicate region %s found in super region %s", region, n.SuperRegionName)
+		}
+		existingRegionNames[region] = struct{}{}
+	}
+
 	dbDesc, err := p.Descriptors().MutableByName(p.txn).Database(ctx, string(n.DatabaseName))
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Previously, when duplicate regions would exist within a super region an internal assertion would be generated. This was inadequate since an assertion failure would lead to a stack dump. To address this, this patch
will generate a proper pgerror.

Fixes: #108556

Release note: None