### PR TITLE
privilege: automate generation of ByName map

### DIFF
--- a/pkg/sql/privilege/BUILD.bazel
+++ b/pkg/sql/privilege/BUILD.bazel
@@ -31,6 +31,7 @@ go_test(
         ":privilege",
         "//pkg/util/leaktest",
         "//pkg/util/log",
+        "@com_github_stretchr_testify//require",
     ],
 )
 

--- a/pkg/sql/privilege/privilege.go
+++ b/pkg/sql/privilege/privilege.go
@@ -177,40 +177,8 @@ func (k Kind) IsSetIn(bits uint64) bool {
 	return bits&k.Mask() != 0
 }
 
-// ByName is a map of string -> kind value.
-var ByName = map[string]Kind{
-	"ALL":                      ALL,
-	"CHANGEFEED":               CHANGEFEED,
-	"CONNECT":                  CONNECT,
-	"CREATE":                   CREATE,
-	"DROP":                     DROP,
-	"SELECT":                   SELECT,
-	"INSERT":                   INSERT,
-	"DELETE":                   DELETE,
-	"UPDATE":                   UPDATE,
-	"ZONECONFIG":               ZONECONFIG,
-	"USAGE":                    USAGE,
-	"RULE":                     RULE,
-	"MODIFYCLUSTERSETTING":     MODIFYCLUSTERSETTING,
-	"EXTERNALCONNECTION":       EXTERNALCONNECTION,
-	"VIEWACTIVITY":             VIEWACTIVITY,
-	"VIEWACTIVITYREDACTED":     VIEWACTIVITYREDACTED,
-	"VIEWCLUSTERSETTING":       VIEWCLUSTERSETTING,
-	"CANCELQUERY":              CANCELQUERY,
-	"NOSQLLOGIN":               NOSQLLOGIN,
-	"EXECUTE":                  EXECUTE,
-	"VIEWCLUSTERMETADATA":      VIEWCLUSTERMETADATA,
-	"VIEWDEBUG":                VIEWDEBUG,
-	"BACKUP":                   BACKUP,
-	"RESTORE":                  RESTORE,
-	"EXTERNALIOIMPLICITACCESS": EXTERNALIOIMPLICITACCESS,
-	"VIEWJOB":                  VIEWJOB,
-	"MODIFYSQLCLUSTERSETTING":  MODIFYSQLCLUSTERSETTING,
-	"REPLICATION":              REPLICATION,
-	"MANAGETENANT":             MANAGETENANT,
-	"VIEWSYSTEMTABLE":          VIEWSYSTEMTABLE,
-	"CREATEROLE":               CREATEROLE,
-}
+// ByName is a map of string -> kind value. It is populated by init.
+var ByName map[string]Kind
 
 // List is a list of privileges.
 type List []Kind
@@ -500,10 +468,14 @@ type Object interface {
 }
 
 func init() {
+	AllPrivileges = make([]Kind, 0, largestKind)
+	ByName = make(map[string]Kind)
+
 	for kind := ALL; kind <= largestKind; kind++ {
 		if isDeprecatedKind[kind] {
 			continue
 		}
 		AllPrivileges = append(AllPrivileges, kind)
+		ByName[kind.String()] = kind
 	}
 }

--- a/pkg/sql/privilege/privilege_test.go
+++ b/pkg/sql/privilege/privilege_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPrivilegeDecode(t *testing.T) {
@@ -57,5 +58,16 @@ func TestPrivilegeDecode(t *testing.T) {
 		if pl.SortedString() != tc.sorted {
 			t.Fatalf("%+v: wrong SortedString() output: %q", tc, pl.SortedString())
 		}
+	}
+}
+
+// TestByNameHasAllPrivileges verifies that every privilege is present in ByName.
+func TestByNameHasAllPrivileges(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	for _, kind := range privilege.AllPrivileges {
+		resolvedKind, ok := privilege.ByName[kind.String()]
+		require.True(t, ok)
+		require.Equal(t, kind, resolvedKind)
 	}
 }


### PR DESCRIPTION
This patch automates the process of generating the `ByName` map so that
any newly added privileges will automatically be included.

Epic: None

Release note: None