### PR TITLE
release-23.1: TEAMS: add T-sql-queries label

### DIFF
--- a/TEAMS.yaml
+++ b/TEAMS.yaml
@@ -36,6 +36,7 @@ cockroachdb/sql-queries:
     cockroachdb/sql-queries-prs: other
     cockroachdb/sql-optimizer: other
     cockroachdb/sql-opt-prs: other
+  label: T-sql-queries
 cockroachdb/cluster-observability:
   triage_column_id: 12618343
 cockroachdb/kv:


### PR DESCRIPTION
release-23.1: TEAMS: add T-sql-queries label

This commit will ensure that roachtest failures are correctly labelled
with the `T-sql-queries` label.

Epic: None

Release note: None

Release justification: Non-code change