### PR TITLE
builtins: add gen_random_bytes builtin function

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -428,6 +428,8 @@
 </ul>
 <p>This function requires an enterprise license on a CCL distribution.</p>
 </span></td><td>Immutable</td></tr>
+<tr><td><a name="gen_random_bytes"></a><code>gen_random_bytes(count: <a href="int.html">int</a>) &rarr; <a href="bytes.html">bytes</a></code></td><td><span class="funcdesc"><p>Returns <code>count</code> cryptographically strong random bytes. At most 1024 bytes can be extracted at a time.</p>
+</span></td><td>Volatile</td></tr>
 <tr><td><a name="gen_salt"></a><code>gen_salt(type: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Generates a salt for input into the <code>crypt</code> function using the default number of rounds.</p>
 </span></td><td>Volatile</td></tr>
 <tr><td><a name="gen_salt"></a><code>gen_salt(type: <a href="string.html">string</a>, iter_count: <a href="int.html">int</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Generates a salt for input into the <code>crypt</code> function using <code>iter_count</code> number of rounds.</p>

--- a/pkg/sql/logictest/testdata/logic_test/pgcrypto_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/pgcrypto_builtins
@@ -308,3 +308,24 @@ query error pgcode XXC01 decrypt_iv can only be used with a CCL distribution
 SELECT decrypt_iv('\x91b4ef63852013c8da53829da662b871', 'key', '123', 'aes')
 
 subtest end
+
+subtest gen_random_bytes
+
+statement error pgcode 22023 length 0 is outside the range
+SELECT gen_random_bytes(0)
+
+statement error pgcode 22023 length 1025 is outside the range
+SELECT gen_random_bytes(1025)
+
+query I
+SELECT length(gen_random_bytes(10))
+----
+10
+
+# Basic to make sure the same result isn't returned.
+query B
+SELECT gen_random_bytes(5) = gen_random_bytes(5)
+----
+false
+
+subtest end

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -2457,6 +2457,7 @@ var builtinOidsArray = []string{
 	2486: `encrypt_iv(data: bytes, key: bytes, iv: bytes, type: string) -> bytes`,
 	2487: `decrypt(data: bytes, key: bytes, type: string) -> bytes`,
 	2488: `decrypt_iv(data: bytes, key: bytes, iv: bytes, type: string) -> bytes`,
+	2489: `gen_random_bytes(count: int) -> bytes`,
 }
 
 var builtinOidsBySignature map[string]oid.Oid


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/21001

Release note (sql change): Added the gen_random_bytes builtin function, which generates cryptographically secure random bytes.