### PR TITLE
release-22.2: TEAMS: use workflow for SQL Queries issue triage

### DIFF
--- a/TEAMS.yaml
+++ b/TEAMS.yaml
@@ -30,7 +30,10 @@ cockroachdb/sql-queries:
   aliases:
     cockroachdb/sql-optimizer: other
     cockroachdb/sql-opt-prs: other
-  triage_column_id: 13549252
+  # SQL Queries team uses GH projects v2, which doesn't have a REST API, so
+  # there is no triage column ID.
+  # See .github/workflows/add-issues-to-project.yml.
+  label: T-sql-queries
 cockroachdb/sql-observability:
   triage_column_id: 12618343
 cockroachdb/kv:


### PR DESCRIPTION
Backport 1/1 commits from #107498.

/cc @cockroachdb/release

---

The SQL Queries team now uses Github Projects v2. This commit updates
`TEAMS.yaml` and `.github/workflows/add-issues-to-project.yml` so that
issues are assigned to the correct project for triage.

Epic: None

Release note: None

Release justification: Non-code change

