### PR TITLE
storage: deflake TestEngineKeyValidate

### DIFF
--- a/pkg/storage/engine_key_test.go
+++ b/pkg/storage/engine_key_test.go
@@ -288,7 +288,7 @@ func TestEngineKeyValidate(t *testing.T) {
 				if err := ek.Validate(); err != nil {
 					t.Errorf("%q.Validate() = %q, want nil", ek, err)
 				}
-				require.Equal(t, 0.0, testing.AllocsPerRun(1, func() {
+				require.Equal(t, 0.0, testing.AllocsPerRun(1000, func() {
 					_ = ek.Validate()
 				}))
 			}
@@ -301,7 +301,7 @@ func TestEngineKeyValidate(t *testing.T) {
 				if err := ek.Validate(); err != nil {
 					t.Errorf("%q.Validate() = %q, want nil", ek, err)
 				}
-				require.Equal(t, 0.0, testing.AllocsPerRun(1, func() {
+				require.Equal(t, 0.0, testing.AllocsPerRun(1000, func() {
 					_ = ek.Validate()
 				}))
 				buf = ek.Key[:0]


### PR DESCRIPTION
Average the allocs across many runs to avoid flakes from a single alloc (perhaps from the runtime or testing package?).

Epic: None
Fixes #109919.
Release note: none