### PR TITLE
sql: make random syntax generator test deterministic with a seed

### DIFF
--- a/pkg/sql/tests/rsg_test.go
+++ b/pkg/sql/tests/rsg_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
@@ -823,7 +824,8 @@ func testRandomSyntax(
 	if err != nil {
 		t.Fatal(err)
 	}
-	r, err := rsg.NewRSG(timeutil.Now().UnixNano(), string(yBytes), allowDuplicates)
+	_, seed := randutil.NewTestRand()
+	r, err := rsg.NewRSG(seed, string(yBytes), allowDuplicates)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
The RSG takes in a seed to establish its random number generator, since for some testing (e.g., benchmarking), we want to have a deterministic random generator. Previously, the RSG test used the current time as the seed to the RSG, which prevented us from reproducing any RSG tests.

This change gets a seed from the randutil random number generator, which now means that you can reproduce RSG test failures with commands like:

```
./dev test pkg/sql/tests -f=TestRandomSyntaxSQLSmith -- --test_arg
-rsg=1m --test_env=COCKROACH_RANDOM_SEED=42
```

Epic: None

Release note: None