### PR TITLE
release-22.2: indexrec: fix internal error with inverted indexes

### DIFF
--- a/pkg/sql/opt/indexrec/hypothetical_index.go
+++ b/pkg/sql/opt/indexrec/hypothetical_index.go
@@ -270,8 +270,8 @@ func (hi *hypotheticalIndex) hasPrefixOfExplicitCols(
 		existingIndexCol := existingIndex.Column(j)
 		indexCol := indexCols[j]
 
-		if isInverted && existingIndex.IsInverted() && j == m-1 {
-			// If the column is inverted, compare the source columns.
+		if indexCol.Kind() == cat.Inverted && existingIndexCol.Kind() == cat.Inverted {
+			// If the columns are inverted, compare their source columns.
 			if existingIndexCol.InvertedSourceColumnOrdinal() != indexCol.InvertedSourceColumnOrdinal() {
 				return false
 			}

--- a/pkg/sql/opt/indexrec/testdata/index
+++ b/pkg/sql/opt/indexrec/testdata/index
@@ -1953,3 +1953,48 @@ project
       ├── columns: v:2!null j:4
       ├── constraint: /2/1: [/2 - ]
       └── cost: 367.353333
+
+# Regression test for #109974. Do not panic by trying to find the inverted
+# source column for a non-inverted index column.
+exec-ddl
+CREATE TABLE t109974a (
+  g1 GEOGRAPHY
+)
+----
+
+exec-ddl
+CREATE TABLE t109974b (
+  k2 INT PRIMARY KEY,
+  g2 GEOGRAPHY,
+  INVERTED INDEX (k2, g2) NOT VISIBLE
+)
+----
+
+index-recommendations
+SELECT * FROM t109974b JOIN t109974a ON st_intersects(g2, g1);
+----
+creation: CREATE INVERTED INDEX ON t109974a (g1);
+--
+optimal plan:
+inner-join (lookup t109974a)
+ ├── columns: k2:1!null g2:2!null g1:6!null
+ ├── key columns: [13] = [7]
+ ├── lookup columns are key
+ ├── immutable
+ ├── cost: 111864.47
+ ├── fd: (1)-->(2)
+ ├── inner-join (inverted t109974a@_hyp_1)
+ │    ├── columns: k2:1!null g2:2 rowid:13!null
+ │    ├── inverted-expr
+ │    │    └── st_intersects(g2:2, g1:12)
+ │    ├── cost: 41464.44
+ │    ├── key: (1,13)
+ │    ├── fd: (1)-->(2)
+ │    ├── scan t109974b
+ │    │    ├── columns: k2:1!null g2:2
+ │    │    ├── cost: 1064.42
+ │    │    ├── key: (1)
+ │    │    └── fd: (1)-->(2)
+ │    └── filters (true)
+ └── filters
+      └── st_intersects(g2:2, g1:6) [outer=(2,6), immutable, constraints=(/2: (/NULL - ]; /6: (/NULL - ])]


### PR DESCRIPTION
Backport 1/1 commits from #110116.

/cc @cockroachdb/release

---

A bug was introduced in #108576 in code that compares index columns of
an existing index and a hypothetical index. Prior to this commit, this
logic only checked that the hypothetical index column was an inverted
column (the last explicitly indexed column in an inverted index) before
fetching the inverted source column ordinal for both the hypothetical
and existing index column. When the existing index column was not an
inverted column, and internal error would occur.

This commit fixes the bug by checking that both the hypothetical and
existing index columns are inverted columns before fetching the source
column ordinals.

There is no release note because this bug does not exist in any
releases.

Fixes #109974

Release note: None

---

Release justification: Fixes internal error in index recommendations.

