### PR TITLE
build: add cdeps to random syntax tests

### DIFF
--- a/build/teamcity/cockroach/nightlies/random_syntax_tests_impl.sh
+++ b/build/teamcity/cockroach/nightlies/random_syntax_tests_impl.sh
@@ -4,6 +4,7 @@ set -xeuo pipefail
 
 dir="$(dirname $(dirname $(dirname $(dirname "${0}"))))"
 
+bazel build --config ci --config force_build_cdeps //c-deps:libgeos
 bazel build //pkg/cmd/bazci --config=ci
 BAZEL_BIN=$(bazel info bazel-bin --config=ci)
 exit_status=0


### PR DESCRIPTION
Previously a failure occurred on these tests where it required libgeos. This change adds a build step to ensure that libgeos is in the bazel-bin dirs. This should fix the dependency issue.

Refs: #109986

Epic: None
Release note: None