### PR TITLE
kvserver: fix replica State update

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_gc.go
+++ b/pkg/kv/kvserver/batcheval/cmd_gc.go
@@ -280,9 +280,12 @@ func GC(
 		if !hint.IsEmpty() {
 			if hint.LatestRangeDeleteTimestamp.LessEq(gcThreshold) {
 				hint.ResetLatestRangeDeleteTimestamp()
-				res.Replicated.State = &kvserverpb.ReplicaState{
-					GCHint: hint,
+				// NB: Replicated.State can already contain GCThreshold from above. Make
+				// sure we don't accidentally remove it.
+				if res.Replicated.State == nil {
+					res.Replicated.State = &kvserverpb.ReplicaState{}
 				}
+				res.Replicated.State.GCHint = hint
 				if _, err := sl.SetGCHint(ctx, readWriter, cArgs.Stats, hint); err != nil {
 					return result.Result{}, err
 				}


### PR DESCRIPTION
The GC function in `cmd_gc.go` may update `res.Replicated.State` to non-nil in two places, setting `GCThreshold` and `GCHint` correspondingly.

Both updates reset `res.Replicated.State` with a newly created `&ReplicaState{}` containing the corresponding field. If only one of the fields is updated, this is fine. However, if both fields need to be updated, only the last one (`GCHint`) will take effect. This leads to on-disk and in-memory state inconsistency in a `Replica`, and panics.

This commit fixes the situation when both fields must be updated. Instead of creating the empty struct unconditionally, it checks whether the struct has already been initialized.

Such a situation never happens because updating `GCThreshold` and `GCHint` are gated by mutually excluding conditions. However, the panic manifests when these conditions are changed. This commit is a defence in depth.

Epic: none
Release note: none