### PR TITLE
roachprod: update roachprod-gc.yaml container tag

### DIFF
--- a/pkg/roachprod/k8s/roachprod-gc.yaml
+++ b/pkg/roachprod/k8s/roachprod-gc.yaml
@@ -31,7 +31,7 @@ spec:
         spec:
           containers:
             - name: roachprod-gc-cronjob
-              image: gcr.io/cockroach-dev-inf/cockroachlabs/roachprod:master
+              image: gcr.io/cockroach-dev-inf/cockroachlabs/roachprod:2b6e80e938e
               args:
                 - gc
                 - --gce-project=cockroach-ephemeral,cockroach-roachstress


### PR DESCRIPTION
The old roachprod-gc.yaml was not updated and the container tag pointed to master, an image that was no longer used. For future reference, we now keep the container tag updated with the current image roachprod-gc-cronjob is using.

Epic: none
Release note: None