### PR TITLE
release-23.1: sql/sem/tree: eliminate types.T allocations in collated string comparison

### DIFF
--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -1442,7 +1442,7 @@ func (d *DCollatedString) CompareError(ctx CompareContext, other Datum) (int, er
 		return 1, nil
 	}
 	v, ok := ctx.UnwrapDatum(other).(*DCollatedString)
-	if !ok || !d.ResolvedType().Equivalent(other.ResolvedType()) {
+	if !ok || !lex.LocaleNamesAreEqual(d.Locale, v.Locale) {
 		return 0, makeUnsupportedComparisonMessage(d, other)
 	}
 	res := bytes.Compare(d.Key, v.Key)


### PR DESCRIPTION
Backport 1/2 commits from #110066.

/cc @cockroachdb/release

---

#### sql/sem/tree: eliminate types.T allocations in collated string comparison

This commit eliminates allocations of `types.T` in the `CompareError`
method of `DCollatedString`. Instead of allocating a new collated string
type and calling the `Equivalent` method on the type, `CompareError`
simply checks that the locales of the collated string datums match. This
matches the behavior of `Equivalent`.

Epic: None

Release note (performance improvement): Queries that compare collated
strings now use less memory and may execute faster.

---

Release justification: Minor change that reduces allocations in
queries involving collated strings.

