### PR TITLE
concurrency: do not track timestamps for repl {exclusive,shared} locks 

### DIFF
--- a/pkg/kv/kvserver/concurrency/lock_table.go
+++ b/pkg/kv/kvserver/concurrency/lock_table.go
@@ -1140,10 +1140,15 @@ type replicatedLockHolderInfo struct {
 	// sync with the in-memory lock table.
 	strengths [len(replicatedHolderStrengths)]bool
 
-	// The timestamp at which the replicated lock is held. Must not regress.
-
-	// TODO(arul): This should correspond to an intent's timestamp. It should only
-	// be updated when an intent is discovered or acquired.
+	// ts is set iff the replicated lock is held with lock strength lock.Intent.
+	// The timestamp here corresponds to the timestamp at which the intent is
+	// written[*]. It must not regress.
+	//
+	// [*] As opposed to the timestamp of the transaction that wrote the intent,
+	// as known to the lock table. This is important because intents aren't
+	// rewritten when their transaction is pushed; they need to be resolved. As
+	// such, for the purposes of sequencing, non-locking readers must use the
+	// timestamp at which the intent is written when sequencing.
 	ts hlc.Timestamp
 }
 
@@ -1172,7 +1177,9 @@ func (rlh *replicatedLockHolderInfo) resetStrengths() {
 // acquire updates the tracking on the receiver to indicate a lock is held with
 // the supplied lock strength.
 func (rlh *replicatedLockHolderInfo) acquire(str lock.Strength, ts hlc.Timestamp) {
-	rlh.ts.Forward(ts)
+	if str == lock.Intent { // only set (or update) ts tracking for intents
+		rlh.ts.Forward(ts)
+	}
 	if rlh.held(str) {
 		return
 	}
@@ -1731,7 +1738,9 @@ func (kl *keyLocks) safeFormat(sb *redact.StringBuilder, txnStatusCache *txnStat
 			// formatting. The lowest timestamp contends with more transactions
 			// (assuming the strength dictates as such).
 			var ts hlc.Timestamp
-			if tl.isHeldReplicated() && tl.isHeldUnreplicated() {
+			if tl.isHeldUnreplicated() && tl.isHeldReplicated() &&
+				// timestamps for replicated locks are only tracked/relevant for intents
+				tl.replicatedInfo.held(lock.Intent) {
 				ts = tl.unreplicatedInfo.ts
 				ts.Backward(tl.replicatedInfo.ts)
 			} else if tl.isHeldUnreplicated() {

--- a/pkg/kv/kvserver/concurrency/lock_table_test.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_test.go
@@ -1925,13 +1925,13 @@ func TestLockStateSafeFormatMultipleLockHolders(t *testing.T) {
 	require.NoError(t, holder2.unreplicatedInfo.acquire(lock.Shared, 6))
 	require.EqualValues(t,
 		" lock: ‹\"KEY\"›\n"+
-			"  holders: txn: 6ba7b810-9dad-11d1-80b4-00c04fd430c8 epoch: 0, iso: Serializable, ts: 0.000000123,7, info: unrepl [(str: Shared seq: 3)]\n"+
-			"           txn: 6ba7b811-9dad-11d1-80b4-00c04fd430c8 epoch: 0, iso: Serializable, ts: 0.000000125,1, info: unrepl [(str: Shared seq: 6)]\n",
+			"  holders: txn: 6ba7b810-9dad-11d1-80b4-00c04fd430c8 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 3)]\n"+
+			"           txn: 6ba7b811-9dad-11d1-80b4-00c04fd430c8 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 6)]\n",
 		redact.Sprint(kl))
 	require.EqualValues(t,
 		" lock: ‹×›\n"+
-			"  holders: txn: 6ba7b810-9dad-11d1-80b4-00c04fd430c8 epoch: 0, iso: Serializable, ts: 0.000000123,7, info: unrepl [(str: Shared seq: 3)]\n"+
-			"           txn: 6ba7b811-9dad-11d1-80b4-00c04fd430c8 epoch: 0, iso: Serializable, ts: 0.000000125,1, info: unrepl [(str: Shared seq: 6)]\n",
+			"  holders: txn: 6ba7b810-9dad-11d1-80b4-00c04fd430c8 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 3)]\n"+
+			"           txn: 6ba7b811-9dad-11d1-80b4-00c04fd430c8 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 6)]\n",
 		redact.Sprint(kl).Redact())
 }
 

--- a/pkg/kv/kvserver/concurrency/lock_table_test.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_test.go
@@ -1896,10 +1896,10 @@ func TestLockStateSafeFormat(t *testing.T) {
 	holder.replicatedInfo.acquire(lock.Intent, replTS)
 	holder.replicatedInfo.acquire(lock.Shared, replTS)
 	require.EqualValues(t,
-		" lock: ‹\"KEY\"›\n  holder: txn: 6ba7b810-9dad-11d1-80b4-00c04fd430c8 epoch: 0, iso: Serializable, ts: 0.000000123,7, info: repl [Intent, Shared], unrepl [(str: Exclusive seq: 1), (str: Shared seq: 3)]\n",
+		" lock: ‹\"KEY\"›\n  holder: txn: 6ba7b810-9dad-11d1-80b4-00c04fd430c8 epoch: 0, iso: Serializable, ts: 0.000000125,1, info: repl [Intent, Shared], unrepl [(str: Exclusive seq: 1), (str: Shared seq: 3)]\n",
 		redact.Sprint(l))
 	require.EqualValues(t,
-		" lock: ‹×›\n  holder: txn: 6ba7b810-9dad-11d1-80b4-00c04fd430c8 epoch: 0, iso: Serializable, ts: 0.000000123,7, info: repl [Intent, Shared], unrepl [(str: Exclusive seq: 1), (str: Shared seq: 3)]\n",
+		" lock: ‹×›\n  holder: txn: 6ba7b810-9dad-11d1-80b4-00c04fd430c8 epoch: 0, iso: Serializable, ts: 0.000000125,1, info: repl [Intent, Shared], unrepl [(str: Exclusive seq: 1), (str: Shared seq: 3)]\n",
 		redact.Sprint(l).Redact())
 }
 

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/lock_changes
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/lock_changes
@@ -141,11 +141,11 @@ new-txn txn=txn1 ts=14 epoch=2 seq=1
 new-request r=req6 txn=txn1 ts=14 spans=intent@a+exclusive@a
 ----
 
-acquire r=req6 k=a durability=r strength=intent
+acquire r=req6 k=a durability=u strength=exclusive
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 2, iso: Serializable, ts: 10.000000000,0, info: repl [Intent], unrepl [(str: Exclusive seq: 0)]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 2, iso: Serializable, ts: 8.000000000,0, info: repl [Intent], unrepl [(str: Exclusive seq: 0)]
    waiting readers:
     req: 2, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 2
@@ -154,7 +154,7 @@ guard-state r=req5
 ----
 old: state=waitForDistinguished txn=txn1 key="a" held=true guard-strength=None
 
-acquire r=req6 k=a durability=u strength=exclusive
+acquire r=req6 k=a durability=r strength=intent
 ----
 num=1
  lock: "a"

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/optimistic
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/optimistic
@@ -158,7 +158,7 @@ acquire r=req5 k=a durability=u strength=shared
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Shared seq: 0)]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
 
 # Ensure a optimistic evaluation attempt from the same transaction that covers
 # key "a" succeeds -- both with lower and higher lock strengths than the
@@ -183,7 +183,7 @@ dequeue r=req6
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Shared seq: 0)]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
 
 new-request r=req7 txn=txn1 ts=10,1 spans=none@a,c
 ----
@@ -204,7 +204,7 @@ dequeue r=req7
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Shared seq: 0)]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
 
 # ------------------------------------------------------------------------------
 # Test that optimistic evaluation works with SHARED locking strength -- if a
@@ -232,7 +232,7 @@ dequeue r=req8
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Shared seq: 0)]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
 
 new-request r=req9 txn=txn2 ts=10,1 spans=exclusive@a,c
 ----
@@ -253,4 +253,4 @@ dequeue r=req9
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Shared seq: 0)]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/replicated_locks
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/replicated_locks
@@ -29,7 +29,7 @@ add-discovered r=req1 k=a txn=txn2 strength=shared
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Shared]
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Shared]
    queued locking requests:
     active: false req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
 
@@ -37,11 +37,11 @@ add-discovered r=req1 k=b txn=txn3 strength=exclusive
 ----
 num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Shared]
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Shared]
    queued locking requests:
     active: false req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Exclusive]
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Exclusive]
    queued locking requests:
     active: false req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
 
@@ -63,11 +63,11 @@ acquire r=req2 k=c durability=u strength=shared
 ----
 num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Shared]
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Shared]
    queued locking requests:
     active: false req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Exclusive]
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Exclusive]
    queued locking requests:
     active: false req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
  lock: "c"
@@ -84,14 +84,14 @@ add-discovered r=req3 k=a txn=txn3 strength=shared
 ----
 num=3
  lock: "a"
-  holders: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Shared]
-           txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Shared]
+  holders: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Shared]
+           txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Shared]
    queued locking requests:
     active: false req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
     active: true req: 3, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 3
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Exclusive]
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Exclusive]
    queued locking requests:
     active: false req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
  lock: "c"
@@ -101,19 +101,19 @@ add-discovered r=req3 k=c txn=txn3 strength=shared
 ----
 num=3
  lock: "a"
-  holders: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Shared]
-           txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Shared]
+  holders: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Shared]
+           txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Shared]
    queued locking requests:
     active: false req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
     active: true req: 3, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 3
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Exclusive]
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Exclusive]
    queued locking requests:
     active: false req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
  lock: "c"
   holders: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Shared seq: 0)]
-           txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Shared]
+           txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Shared]
    queued locking requests:
     active: false req: 3, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
 
@@ -149,8 +149,8 @@ add-discovered r=req4 k=b txn=txn3 strength=intent
 ----
 num=3
  lock: "a"
-  holders: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Shared]
-           txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Shared]
+  holders: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Shared]
+           txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Shared]
    queued locking requests:
     active: false req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
     active: true req: 3, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
@@ -163,7 +163,7 @@ num=3
     active: false req: 4, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
  lock: "c"
   holders: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Shared seq: 0)]
-           txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Shared]
+           txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Shared]
    queued locking requests:
     active: false req: 3, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
 
@@ -268,7 +268,7 @@ add-discovered r=req9 k=a txn=txn1 strength=exclusive
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Exclusive]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Exclusive]
    queued locking requests:
     active: false req: 9, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
 
@@ -283,11 +283,11 @@ add-discovered r=req10 k=b txn=txn1 strength=shared
 ----
 num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Exclusive]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Exclusive]
    queued locking requests:
     active: false req: 9, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Shared]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Shared]
    queued locking requests:
     active: false req: 10, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
 
@@ -306,7 +306,7 @@ num=2
    queued locking requests:
     active: false req: 9, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Shared]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Shared]
    queued locking requests:
     active: false req: 10, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
 
@@ -346,7 +346,7 @@ add-discovered r=req12 k=a txn=txn1 strength=exclusive
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Exclusive]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Exclusive]
    queued locking requests:
     active: false req: 12, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
 
@@ -355,11 +355,11 @@ add-discovered r=req12 k=b txn=txn1 strength=shared
 ----
 num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Exclusive]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Exclusive]
    queued locking requests:
     active: false req: 12, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Shared]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Shared]
    queued locking requests:
     active: false req: 12, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
 
@@ -374,11 +374,11 @@ acquire r=req13 k=a durability=r strength=exclusive
 ----
 num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Exclusive]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Exclusive]
    queued locking requests:
     active: false req: 12, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Shared]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Shared]
    queued locking requests:
     active: false req: 12, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
 
@@ -393,11 +393,11 @@ acquire r=req14 k=b durability=r strength=shared
 ----
 num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Exclusive]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Exclusive]
    queued locking requests:
     active: false req: 12, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Shared]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Shared]
    queued locking requests:
     active: false req: 12, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
 
@@ -418,11 +418,11 @@ acquire r=req15 k=a durability=r strength=exclusive
 ----
 num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Exclusive]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Exclusive]
    queued locking requests:
     active: false req: 12, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Shared]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Shared]
    queued locking requests:
     active: false req: 12, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
 
@@ -437,11 +437,11 @@ acquire r=req16 k=b durability=r strength=shared
 ----
 num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Exclusive]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Exclusive]
    queued locking requests:
     active: false req: 12, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Shared]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Shared]
    queued locking requests:
     active: false req: 12, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
 
@@ -458,11 +458,11 @@ acquire r=req17 k=a durability=r strength=exclusive
 ----
 num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 15.000000000,0, info: repl [Exclusive]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Exclusive]
    queued locking requests:
     active: false req: 12, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Shared]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Shared]
    queued locking requests:
     active: false req: 12, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
 
@@ -477,11 +477,11 @@ acquire r=req18 k=b durability=r strength=shared
 ----
 num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 15.000000000,0, info: repl [Exclusive]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Exclusive]
    queued locking requests:
     active: false req: 12, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 20.000000000,0, info: repl [Shared]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Shared]
    queued locking requests:
     active: false req: 12, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
 
@@ -510,7 +510,7 @@ add-discovered r=req19 k=a txn=txn1 strength=exclusive
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Exclusive]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Exclusive]
    queued locking requests:
     active: false req: 19, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
 
@@ -518,11 +518,11 @@ add-discovered r=req19 k=b txn=txn1 strength=shared
 ----
 num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Exclusive]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Exclusive]
    queued locking requests:
     active: false req: 19, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Shared]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Shared]
    queued locking requests:
     active: false req: 19, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
 
@@ -580,10 +580,10 @@ acquire r=req23 k=b durability=r strength=shared
 ----
 num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Exclusive]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Exclusive]
  lock: "b"
-  holders: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Shared]
-           txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Shared]
+  holders: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Shared]
+           txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Shared]
 
 # ------------------------------------------------------------------------------
 # Ensure non-locking reads do not conflict with replicated exclusive locks. We
@@ -607,7 +607,7 @@ add-discovered r=req24 k=a txn=txn1 strength=exclusive
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Exclusive]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Exclusive]
    queued locking requests:
     active: false req: 24, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
 
@@ -615,11 +615,11 @@ add-discovered r=req24 k=b txn=txn1 strength=exclusive
 ----
 num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Exclusive]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Exclusive]
    queued locking requests:
     active: false req: 24, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Exclusive]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Exclusive]
    queued locking requests:
     active: false req: 24, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
 
@@ -635,7 +635,7 @@ acquire r=req25 k=b durability=u strength=exclusive
 ----
 num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Exclusive]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Exclusive]
    queued locking requests:
     active: false req: 24, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
  lock: "b"
@@ -692,7 +692,7 @@ print
 ----
 num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Exclusive]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Exclusive]
    queued locking requests:
     active: false req: 24, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
  lock: "b"
@@ -703,3 +703,144 @@ num=2
    queued locking requests:
     active: false req: 24, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 29
+
+
+# ------------------------------------------------------------------------------
+# Ensure timestamp tracking works correctly for replicated locks. We test that:
+# 1. It corresponds to intents.
+# 2. It never regresses.
+# 3. It isn't updated when {shared, exclusive} locks are acquired/discovered.
+# ------------------------------------------------------------------------------
+
+clear
+----
+num=0
+
+new-request r=req32 txn=txn2 ts=10 spans=intent@a
+----
+
+scan r=req32
+----
+start-waiting: false
+
+# 1. Ensure the timestamp corresponds to the intent.
+add-discovered r=req32 k=a txn=txn1 strength=intent
+----
+num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Intent]
+   queued locking requests:
+    active: false req: 32, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
+
+# 2a. Try re-acquiring the lock with strength lock.Intent at a lower timestamp.
+new-request r=req33 txn=txn1 ts=7 spans=intent@a
+----
+
+scan r=req33
+----
+start-waiting: false
+
+acquire r=req33 k=a durability=r strength=intent
+----
+num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Intent]
+   queued locking requests:
+    active: false req: 32, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
+
+# 2b. Try re-acquiring the lock with strength lock.Intent at a higher timestamp.
+# The timestamp should be forwarded.
+new-request r=req34 txn=txn1 ts=25 spans=intent@a
+----
+
+scan r=req34
+----
+start-waiting: false
+
+acquire r=req34 k=a durability=r strength=intent
+----
+num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 25.000000000,0, info: repl [Intent]
+   queued locking requests:
+    active: false req: 32, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
+
+# 3. Ensure shared/exclusive lock discovery/acquisition does not forward the
+# timestamp.
+
+# 3a. Exclusive lock acquisition.
+new-request r=req35 txn=txn1 ts=30 spans=exclusive@a
+----
+
+scan r=req35
+----
+start-waiting: false
+
+acquire r=req35 k=a durability=r strength=exclusive
+----
+num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 25.000000000,0, info: repl [Intent, Exclusive]
+   queued locking requests:
+    active: false req: 32, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
+
+# 3b. Shared lock acquisition.
+new-request r=req36 txn=txn1 ts=35 spans=shared@a
+----
+
+scan r=req36
+----
+start-waiting: false
+
+acquire r=req36 k=a durability=r strength=shared
+----
+num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 25.000000000,0, info: repl [Intent, Exclusive, Shared]
+   queued locking requests:
+    active: false req: 32, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
+
+# 3c. Lock discovery; strength = Exclusive.
+new-request r=req37 txn=txn2 ts=10 spans=intent@a
+----
+
+scan r=req37
+----
+start-waiting: true
+
+# Bump txn1s timestamp to a value higher than the what the intent was written at.
+new-txn txn=txn1 ts=50 epoch=0 seq=0
+----
+
+add-discovered r=req37 k=a txn=txn1 strength=exclusive
+----
+num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 25.000000000,0, info: repl [Intent, Exclusive, Shared]
+   queued locking requests:
+    active: false req: 32, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 37, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
+   distinguished req: 37
+
+# 3d. Lock discovery; strength = Shared.
+new-request r=req38 txn=txn2 ts=10 spans=intent@a
+----
+
+scan r=req38
+----
+start-waiting: true
+
+# Bump txn1s timestamp to a value higher than the what the intent was written at.
+new-txn txn=txn1 ts=80 epoch=0 seq=0
+----
+
+add-discovered r=req38 k=a txn=txn1 strength=shared
+----
+num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 25.000000000,0, info: repl [Intent, Exclusive, Shared]
+   queued locking requests:
+    active: false req: 32, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 37, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 38, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
+   distinguished req: 37

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/replicated_locks
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/replicated_locks
@@ -844,3 +844,103 @@ num=1
     active: true req: 37, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 38, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 37
+
+# ------------------------------------------------------------------------------
+# Test the case where both an unreplicated exclusive lock and an intent exists
+# on a key. We test interactions with non-locking readers. Non-locking readers
+# should use the intent's timestamp when deciding whether to wait on the lock or
+# not.
+# ------------------------------------------------------------------------------
+
+clear
+----
+num=0
+
+new-request r=req39 txn=txn2 ts=10 spans=exclusive@a
+----
+
+scan r=req39
+----
+start-waiting: false
+
+acquire k=a r=req39 durability=u strength=exclusive
+----
+num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
+
+# add a waiter so the replicated lock acquisition doesn't drop the lock.
+new-request r=req40 txn=txn1 ts=10 spans=intent@a
+----
+
+scan  r=req40
+----
+start-waiting: true
+
+new-request r=req41 txn=txn2 ts=20 spans=intent@a
+----
+
+scan r=req41
+----
+start-waiting: false
+
+acquire k=a r=req41 durability=r strength=intent
+----
+num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 20.000000000,0, info: repl [Intent], unrepl [(str: Exclusive seq: 0)]
+   queued locking requests:
+    active: true req: 40, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
+   distinguished req: 40
+
+# Ensure non-locking readers at various timestamps -- below the exclusive lock
+# (10), at the exclusive lock (10), between exclusive and intent (20),
+# at the intent (20), and above the intent (20). Only non-locking reads at or
+# above the intent's timestamp should block.
+
+new-request r=req42 txn=txn1 ts=5 spans=none@a
+----
+
+scan r=req42
+----
+start-waiting: false
+
+new-request r=req43 txn=txn1 ts=10 spans=none@a
+----
+
+scan r=req43
+----
+start-waiting: false
+
+new-request r=req44 txn=txn1 ts=15 spans=none@a
+----
+
+scan r=req44
+----
+start-waiting: false
+
+new-request r=req45 txn=txn1 ts=20 spans=none@a
+----
+
+scan r=req45
+----
+start-waiting: true
+
+new-request r=req46 txn=txn1 ts=25 spans=none@a
+----
+
+scan r=req46
+----
+start-waiting: true
+
+print
+----
+num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 20.000000000,0, info: repl [Intent], unrepl [(str: Exclusive seq: 0)]
+   waiting readers:
+    req: 46, txn: 00000000-0000-0000-0000-000000000001
+    req: 45, txn: 00000000-0000-0000-0000-000000000001
+   queued locking requests:
+    active: true req: 40, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
+   distinguished req: 40

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/replicated_locks
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/replicated_locks
@@ -29,7 +29,7 @@ add-discovered r=req1 k=a txn=txn2 strength=shared
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Shared]
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, info: repl [Shared]
    queued locking requests:
     active: false req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
 
@@ -37,11 +37,11 @@ add-discovered r=req1 k=b txn=txn3 strength=exclusive
 ----
 num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Shared]
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, info: repl [Shared]
    queued locking requests:
     active: false req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Exclusive]
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, info: repl [Exclusive]
    queued locking requests:
     active: false req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
 
@@ -63,15 +63,15 @@ acquire r=req2 k=c durability=u strength=shared
 ----
 num=3
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Shared]
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, info: repl [Shared]
    queued locking requests:
     active: false req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Exclusive]
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, info: repl [Exclusive]
    queued locking requests:
     active: false req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Shared seq: 0)]
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
 
 new-request r=req3 txn=txn1 ts=10 spans=exclusive@a+exclusive@c
 ----
@@ -84,36 +84,36 @@ add-discovered r=req3 k=a txn=txn3 strength=shared
 ----
 num=3
  lock: "a"
-  holders: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Shared]
-           txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Shared]
+  holders: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, info: repl [Shared]
+           txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, info: repl [Shared]
    queued locking requests:
     active: false req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
     active: true req: 3, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 3
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Exclusive]
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, info: repl [Exclusive]
    queued locking requests:
     active: false req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
  lock: "c"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Shared seq: 0)]
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
 
 add-discovered r=req3 k=c txn=txn3 strength=shared
 ----
 num=3
  lock: "a"
-  holders: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Shared]
-           txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Shared]
+  holders: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, info: repl [Shared]
+           txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, info: repl [Shared]
    queued locking requests:
     active: false req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
     active: true req: 3, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 3
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Exclusive]
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, info: repl [Exclusive]
    queued locking requests:
     active: false req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
  lock: "c"
-  holders: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Shared seq: 0)]
-           txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Shared]
+  holders: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
+           txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, info: repl [Shared]
    queued locking requests:
     active: false req: 3, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
 
@@ -149,8 +149,8 @@ add-discovered r=req4 k=b txn=txn3 strength=intent
 ----
 num=3
  lock: "a"
-  holders: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Shared]
-           txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Shared]
+  holders: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, info: repl [Shared]
+           txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, info: repl [Shared]
    queued locking requests:
     active: false req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
     active: true req: 3, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
@@ -162,8 +162,8 @@ num=3
     active: false req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
     active: false req: 4, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
  lock: "c"
-  holders: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Shared seq: 0)]
-           txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Shared]
+  holders: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
+           txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, info: repl [Shared]
    queued locking requests:
     active: false req: 3, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
 
@@ -195,7 +195,7 @@ num=2
  lock: "a"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Shared seq: 0)]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
 
 # Add a waiter on both these keys so that the replicated lock acquisition
 # doesn't drop the lock.
@@ -230,7 +230,7 @@ num=2
     active: true req: 6, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 6
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Shared seq: 0)]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
    queued locking requests:
     active: true req: 7, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 7
@@ -244,7 +244,7 @@ num=2
     active: true req: 6, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 6
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Shared], unrepl [(str: Shared seq: 0)]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, info: repl [Shared], unrepl [(str: Shared seq: 0)]
    queued locking requests:
     active: true req: 7, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
    distinguished req: 7
@@ -268,7 +268,7 @@ add-discovered r=req9 k=a txn=txn1 strength=exclusive
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Exclusive]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, info: repl [Exclusive]
    queued locking requests:
     active: false req: 9, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
 
@@ -283,11 +283,11 @@ add-discovered r=req10 k=b txn=txn1 strength=shared
 ----
 num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Exclusive]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, info: repl [Exclusive]
    queued locking requests:
     active: false req: 9, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Shared]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, info: repl [Shared]
    queued locking requests:
     active: false req: 10, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
 
@@ -306,7 +306,7 @@ num=2
    queued locking requests:
     active: false req: 9, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Shared]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, info: repl [Shared]
    queued locking requests:
     active: false req: 10, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
 
@@ -318,7 +318,7 @@ num=2
    queued locking requests:
     active: false req: 9, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Shared], unrepl [(str: Shared seq: 0)]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, info: repl [Shared], unrepl [(str: Shared seq: 0)]
    queued locking requests:
     active: false req: 10, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
 
@@ -346,7 +346,7 @@ add-discovered r=req12 k=a txn=txn1 strength=exclusive
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Exclusive]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, info: repl [Exclusive]
    queued locking requests:
     active: false req: 12, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
 
@@ -355,11 +355,11 @@ add-discovered r=req12 k=b txn=txn1 strength=shared
 ----
 num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Exclusive]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, info: repl [Exclusive]
    queued locking requests:
     active: false req: 12, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Shared]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, info: repl [Shared]
    queued locking requests:
     active: false req: 12, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
 
@@ -374,11 +374,11 @@ acquire r=req13 k=a durability=r strength=exclusive
 ----
 num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Exclusive]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, info: repl [Exclusive]
    queued locking requests:
     active: false req: 12, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Shared]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, info: repl [Shared]
    queued locking requests:
     active: false req: 12, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
 
@@ -393,11 +393,11 @@ acquire r=req14 k=b durability=r strength=shared
 ----
 num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Exclusive]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, info: repl [Exclusive]
    queued locking requests:
     active: false req: 12, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Shared]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, info: repl [Shared]
    queued locking requests:
     active: false req: 12, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
 
@@ -418,11 +418,11 @@ acquire r=req15 k=a durability=r strength=exclusive
 ----
 num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Exclusive]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, info: repl [Exclusive]
    queued locking requests:
     active: false req: 12, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Shared]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, info: repl [Shared]
    queued locking requests:
     active: false req: 12, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
 
@@ -437,11 +437,11 @@ acquire r=req16 k=b durability=r strength=shared
 ----
 num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Exclusive]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, info: repl [Exclusive]
    queued locking requests:
     active: false req: 12, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Shared]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, info: repl [Shared]
    queued locking requests:
     active: false req: 12, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
 
@@ -458,11 +458,11 @@ acquire r=req17 k=a durability=r strength=exclusive
 ----
 num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Exclusive]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, info: repl [Exclusive]
    queued locking requests:
     active: false req: 12, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Shared]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, info: repl [Shared]
    queued locking requests:
     active: false req: 12, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
 
@@ -477,11 +477,11 @@ acquire r=req18 k=b durability=r strength=shared
 ----
 num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Exclusive]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, info: repl [Exclusive]
    queued locking requests:
     active: false req: 12, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Shared]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, info: repl [Shared]
    queued locking requests:
     active: false req: 12, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
 
@@ -510,7 +510,7 @@ add-discovered r=req19 k=a txn=txn1 strength=exclusive
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Exclusive]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, info: repl [Exclusive]
    queued locking requests:
     active: false req: 19, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
 
@@ -518,11 +518,11 @@ add-discovered r=req19 k=b txn=txn1 strength=shared
 ----
 num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Exclusive]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, info: repl [Exclusive]
    queued locking requests:
     active: false req: 19, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Shared]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, info: repl [Shared]
    queued locking requests:
     active: false req: 19, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
 
@@ -580,10 +580,10 @@ acquire r=req23 k=b durability=r strength=shared
 ----
 num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Exclusive]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, info: repl [Exclusive]
  lock: "b"
-  holders: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Shared]
-           txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Shared]
+  holders: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, info: repl [Shared]
+           txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, info: repl [Shared]
 
 # ------------------------------------------------------------------------------
 # Ensure non-locking reads do not conflict with replicated exclusive locks. We
@@ -607,7 +607,7 @@ add-discovered r=req24 k=a txn=txn1 strength=exclusive
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Exclusive]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, info: repl [Exclusive]
    queued locking requests:
     active: false req: 24, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
 
@@ -615,11 +615,11 @@ add-discovered r=req24 k=b txn=txn1 strength=exclusive
 ----
 num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Exclusive]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, info: repl [Exclusive]
    queued locking requests:
     active: false req: 24, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
  lock: "b"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Exclusive]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, info: repl [Exclusive]
    queued locking requests:
     active: false req: 24, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
 
@@ -635,7 +635,7 @@ acquire r=req25 k=b durability=u strength=exclusive
 ----
 num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Exclusive]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, info: repl [Exclusive]
    queued locking requests:
     active: false req: 24, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
  lock: "b"
@@ -692,7 +692,7 @@ print
 ----
 num=2
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 0,0, info: repl [Exclusive]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, info: repl [Exclusive]
    queued locking requests:
     active: false req: 24, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
  lock: "b"

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/shared_locks
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/shared_locks
@@ -27,7 +27,7 @@ acquire r=req1 k=a durability=u strength=shared
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Shared seq: 0)]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
 
 # ------------------------------------------------------------------------------
 # Ensure conflict resolution semantics for shared locks are sane -- that is,
@@ -64,7 +64,7 @@ print
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Shared seq: 0)]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
    queued locking requests:
     active: false req: 3, strength: Shared, txn: 00000000-0000-0000-0000-000000000002
     active: false req: 4, strength: Shared, txn: 00000000-0000-0000-0000-000000000002
@@ -73,8 +73,8 @@ acquire r=req3 k=a durability=u strength=shared
 ----
 num=1
  lock: "a"
-  holders: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Shared seq: 0)]
-           txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Shared seq: 0)]
+  holders: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
+           txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
 
 # Re-acquisition of the shared lock by req4 should work as well, as req4 is part
 # of the same transaction (txn 2) as req3; req3 just acquired a shared lock.
@@ -82,8 +82,8 @@ acquire r=req4 k=a durability=u strength=shared
 ----
 num=1
  lock: "a"
-  holders: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Shared seq: 0)]
-           txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Shared seq: 0)]
+  holders: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
+           txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
 
 
 new-request r=req5 txn=txn2 ts=10 spans=exclusive@a
@@ -104,8 +104,8 @@ print
 ----
 num=1
  lock: "a"
-  holders: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Shared seq: 0)]
-           txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Shared seq: 0)]
+  holders: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
+           txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
    queued locking requests:
     active: true req: 5, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 6, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
@@ -128,8 +128,8 @@ print
 ----
 num=1
  lock: "a"
-  holders: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Shared seq: 0)]
-           txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Shared seq: 0)]
+  holders: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
+           txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
    queued locking requests:
     active: true req: 5, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 6, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
@@ -150,8 +150,8 @@ print
 ----
 num=1
  lock: "a"
-  holders: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Shared seq: 0)]
-           txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Shared seq: 0)]
+  holders: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
+           txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
    queued locking requests:
     active: true req: 5, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 6, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
@@ -179,7 +179,7 @@ acquire r=req9 k=a durability=u strength=shared
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Shared seq: 0)]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
 
 new-request r=req10 txn=txn2 ts=10 spans=shared@a
 ----
@@ -192,15 +192,15 @@ acquire r=req10 k=a durability=u strength=shared
 ----
 num=1
  lock: "a"
-  holders: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Shared seq: 0)]
-           txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Shared seq: 0)]
+  holders: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
+           txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
 
 acquire r=req10 k=a durability=u strength=shared
 ----
 num=1
  lock: "a"
-  holders: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Shared seq: 0)]
-           txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Shared seq: 0)]
+  holders: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
+           txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
 
 new-request r=req11 txn=txn3 ts=10 spans=shared@a
 ----
@@ -213,9 +213,9 @@ acquire r=req11 k=a durability=u strength=shared
 ----
 num=1
  lock: "a"
-  holders: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Shared seq: 0)]
-           txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Shared seq: 0)]
-           txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Shared seq: 0)]
+  holders: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
+           txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
+           txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
 
 new-request r=req12 txn=txn4 ts=10 spans=exclusive@a
 ----
@@ -228,9 +228,9 @@ print
 ----
 num=1
  lock: "a"
-  holders: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Shared seq: 0)]
-           txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Shared seq: 0)]
-           txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Shared seq: 0)]
+  holders: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
+           txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
+           txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
    queued locking requests:
     active: true req: 12, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000004
    distinguished req: 12
@@ -241,8 +241,8 @@ release txn=txn1 span=a
 ----
 num=1
  lock: "a"
-  holders: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Shared seq: 0)]
-           txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Shared seq: 0)]
+  holders: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
+           txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
    queued locking requests:
     active: true req: 12, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000004
    distinguished req: 12
@@ -251,7 +251,7 @@ release txn=txn2 span=a
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Shared seq: 0)]
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
    queued locking requests:
     active: true req: 12, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000004
    distinguished req: 12
@@ -402,7 +402,7 @@ acquire r=req18 k=a durability=u strength=shared
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Shared seq: 0)]
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
    queued locking requests:
     active: false req: 17, strength: Shared, txn: 00000000-0000-0000-0000-000000000001
     active: true req: 19, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000003
@@ -415,8 +415,8 @@ acquire r=req17 k=a durability=u strength=shared
 ----
 num=1
  lock: "a"
-  holders: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Shared seq: 0)]
-           txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Shared seq: 0)]
+  holders: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
+           txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
    queued locking requests:
     active: true req: 19, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 19
@@ -427,8 +427,8 @@ acquire r=req20 k=a durability=u strength=shared
 ----
 num=1
  lock: "a"
-  holders: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Shared seq: 0)]
-           txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Shared seq: 0)]
+  holders: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
+           txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
    queued locking requests:
     active: true req: 19, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 19

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/skip_locked
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/skip_locked
@@ -144,7 +144,7 @@ num=5
    queued locking requests:
     active: false req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
  lock: "g"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Shared seq: 0)]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
 
 new-request r=req5 txn=txn2 ts=9,1 spans=shared@h
 ----
@@ -170,9 +170,9 @@ num=6
    queued locking requests:
     active: false req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
  lock: "g"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Shared seq: 0)]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
  lock: "h"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 9.000000000,1, info: unrepl [(str: Shared seq: 0)]
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
 
 new-request r=req6 txn=txn2 ts=9,1 spans=shared@i
 ----
@@ -198,11 +198,11 @@ num=7
    queued locking requests:
     active: false req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
  lock: "g"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Shared seq: 0)]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
  lock: "h"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 9.000000000,1, info: unrepl [(str: Shared seq: 0)]
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
  lock: "i"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 9.000000000,1, info: unrepl [(str: Shared seq: 0)]
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
 
 new-request r=req7 txn=txn1 ts=10,1 spans=exclusive@i
 ----
@@ -228,11 +228,11 @@ num=7
    queued locking requests:
     active: false req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
  lock: "g"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Shared seq: 0)]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
  lock: "h"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 9.000000000,1, info: unrepl [(str: Shared seq: 0)]
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
  lock: "i"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 9.000000000,1, info: unrepl [(str: Shared seq: 0)]
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
    queued locking requests:
     active: true req: 7, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 7
@@ -375,11 +375,11 @@ num=7
    queued locking requests:
     active: false req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
  lock: "g"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Shared seq: 0)]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
  lock: "h"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 9.000000000,1, info: unrepl [(str: Shared seq: 0)]
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
  lock: "i"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 9.000000000,1, info: unrepl [(str: Shared seq: 0)]
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
    queued locking requests:
     active: true req: 7, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 7
@@ -449,11 +449,11 @@ num=7
    queued locking requests:
     active: false req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
  lock: "g"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Shared seq: 0)]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
  lock: "h"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 9.000000000,1, info: unrepl [(str: Shared seq: 0)]
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
  lock: "i"
-  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 9.000000000,1, info: unrepl [(str: Shared seq: 0)]
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
    queued locking requests:
     active: true req: 7, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
    distinguished req: 7


### PR DESCRIPTION
Previously, the timestamp tracking for replicated locks would be updated
whenever a lock was acquired/rediscovered, regardless of the strength.
This wasn't great -- the timestamp of a replicated lock is only relavent
if it's strength is lock.Intent. Worse yet, because we were blindly
forwarding the timestamp tracking, non-locking readers could end up in
infinite lock discovery loops.

This patch fixes such issues by only tracking/forwarding timestamps
for intents when it comes to replicated locks.

Closes https://github.com/cockroachdb/cockroach/issues/109673

Release note: None