### PR TITLE
release-22.2: build: add cdeps to random syntax tests

### DIFF
--- a/build/teamcity/cockroach/nightlies/random_syntax_tests_impl.sh
+++ b/build/teamcity/cockroach/nightlies/random_syntax_tests_impl.sh
@@ -5,6 +5,7 @@ set -xeuo pipefail
 dir="$(dirname $(dirname $(dirname $(dirname "${0}"))))"
 source "$dir/teamcity-bazel-support.sh"
 
+bazel build --config ci --config force_build_cdeps //c-deps:libgeos
 bazel build //pkg/cmd/bazci //pkg/cmd/github-post //pkg/cmd/testfilter --config=ci
 BAZEL_BIN=$(bazel info bazel-bin --config=ci)
 GO_TEST_JSON_OUTPUT_FILE=/artifacts/test.json.txt


### PR DESCRIPTION
Backport 1/1 commits from #110129.

/cc @cockroachdb/release

---

Previously a failure occurred on these tests where it required libgeos. This change adds a build step to ensure that libgeos is in the bazel-bin dirs. This should fix the dependency issue.

Refs: #109986

Epic: None
Release note: None
Release justification: Test only change
