### PR TITLE
release-23.1: roachprod: update start-tenant command

### DIFF
--- a/pkg/roachprod/install/cockroach.go
+++ b/pkg/roachprod/install/cockroach.go
@@ -359,11 +359,31 @@ func (c *SyncedCluster) NodeDir(node Node, storeIndex int) string {
 }
 
 // LogDir returns the logs directory for the given node.
-func (c *SyncedCluster) LogDir(node Node) string {
+func (c *SyncedCluster) LogDir(node Node, tenantName string, instance int) string {
+	dirName := "logs" + tenantDirSuffix(tenantName, instance)
 	if c.IsLocal() {
-		return filepath.Join(c.localVMDir(node), "logs")
+		return filepath.Join(c.localVMDir(node), dirName)
 	}
-	return "logs"
+	return dirName
+}
+
+// TenantStoreDir returns the data directory for a given tenant.
+func (c *SyncedCluster) TenantStoreDir(node Node, tenantName string, instance int) string {
+	dataDir := fmt.Sprintf("data%s", tenantDirSuffix(tenantName, instance))
+	if c.IsLocal() {
+		return filepath.Join(c.localVMDir(node), dataDir)
+	}
+
+	return dataDir
+}
+
+// tenantDirSuffix returns the suffix to use for tenant-specific directories.
+// This suffix consists of the tenant name and instance number (if applicable).
+func tenantDirSuffix(tenantName string, instance int) string {
+	if tenantName != "" && tenantName != SystemTenantName {
+		return fmt.Sprintf("-%s-%d", tenantName, instance)
+	}
+	return ""
 }
 
 // CertsDir returns the certificate directory for the given node.
@@ -530,7 +550,7 @@ func (c *SyncedCluster) generateStartCmd(
 	}
 
 	return execStartTemplate(startTemplateData{
-		LogDir: c.LogDir(node),
+		LogDir: c.LogDir(node, startOpts.TenantName, startOpts.TenantInstance),
 		KeyCmd: keyCmd,
 		EnvVars: append(append([]string{
 			fmt.Sprintf("ROACHPROD=%s", c.roachprodEnvValue(node)),
@@ -607,7 +627,7 @@ func (c *SyncedCluster) generateStartArgs(
 		args = append(args, "--insecure")
 	}
 
-	logDir := c.LogDir(node)
+	logDir := c.LogDir(node, startOpts.TenantName, startOpts.TenantInstance)
 	idx1 := argExists(startOpts.ExtraArgs, "--log")
 	idx2 := argExists(startOpts.ExtraArgs, "--log-config-file")
 
@@ -685,7 +705,7 @@ func (c *SyncedCluster) generateStartArgs(
 	}
 
 	if startOpts.Target == StartDefault || startOpts.Target == StartTenantSQL {
-		args = append(args, c.generateStartFlagsSQL()...)
+		args = append(args, c.generateStartFlagsSQL(node, startOpts)...)
 	}
 
 	args = append(args, startOpts.ExtraArgs...)
@@ -755,10 +775,13 @@ func (c *SyncedCluster) generateStartFlagsKV(node Node, startOpts StartOpts) []s
 
 // generateStartFlagsSQL generates `cockroach start` and `cockroach mt
 // start-sql` arguments that are relevant for the SQL layers, used by both KV
-// and storage layers (and in particular, are never used by `
-func (c *SyncedCluster) generateStartFlagsSQL() []string {
+// and storage layers.
+func (c *SyncedCluster) generateStartFlagsSQL(node Node, startOpts StartOpts) []string {
 	var args []string
 	args = append(args, fmt.Sprintf("--max-sql-memory=%d%%", c.maybeScaleMem(25)))
+	if startOpts.Target == StartTenantSQL {
+		args = append(args, "--store", c.TenantStoreDir(node, startOpts.TenantName, startOpts.TenantInstance))
+	}
 	return args
 }
 

--- a/pkg/roachprod/multitenant.go
+++ b/pkg/roachprod/multitenant.go
@@ -45,17 +45,6 @@ func StartTenant(
 		return err
 	}
 
-	if tc.Name == hc.Name {
-		// We allow using the same cluster, but the node sets must be disjoint.
-		for _, n1 := range tc.Nodes {
-			for _, n2 := range hc.Nodes {
-				if n1 == n2 {
-					return errors.Errorf("host and tenant nodes must be disjoint")
-				}
-			}
-		}
-	}
-
 	startOpts.Target = install.StartTenantSQL
 	if startOpts.TenantID < 2 {
 		return errors.Errorf("invalid tenant ID %d (must be 2 or higher)", startOpts.TenantID)


### PR DESCRIPTION
Previously tenants were only able to start on disjoint clusters using roachprod,
thus allowing it to use the existing node and log directory methods without any
conflicts. Recently changes were made to start accommodating tenants on the same
VM via port management #106497.

This change updates the log logic to include discriminators for the tenant and
instance in the log directory. There is still logic, regarding log retrieval and
process management, that will need to be updated to make full use of the change.

Epic: CRDB-18499
Release note: None
Backport 2/2 commits from #109841.

/cc @cockroachdb/release

---

The roachprod `start-tenant` command previously only allowed the tenant and host cluster nodes to be disjoint. This is due to the fact that ports and log directories would collide, should a tenant be started on the same node as the host cluster. Changes on this PR and #106497 allow us to remove that requirement now.

Epic: CRDB-18499
Release note: None
Release justification: Test only change
