### PR TITLE
sql,syntheticprivilegecache: make node the owner of all synthetic privileges and virtual schemas

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -7836,10 +7836,10 @@ CREATE TYPE sc.typ AS ENUM ('hello');
 		sqlDB.CheckQueryResults(t, `SHOW TABLES`, [][]string{})
 		sqlDB.CheckQueryResults(t, `SHOW TYPES`, [][]string{})
 		sqlDB.CheckQueryResults(t, `SHOW SCHEMAS`, [][]string{
-			{"crdb_internal", "NULL"},
-			{"information_schema", "NULL"},
-			{"pg_catalog", "NULL"},
-			{"pg_extension", "NULL"},
+			{"crdb_internal", "node"},
+			{"information_schema", "node"},
+			{"pg_catalog", "node"},
+			{"pg_extension", "node"},
 			{"public", username.AdminRole},
 		})
 

--- a/pkg/ccl/backupccl/restore_old_versions_test.go
+++ b/pkg/ccl/backupccl/restore_old_versions_test.go
@@ -177,10 +177,10 @@ func restoreOldVersionClusterTest(exportDir string) func(t *testing.T) {
 		})
 
 		sqlDB.CheckQueryResults(t, "SHOW SCHEMAS", [][]string{
-			{"crdb_internal", "NULL"},
-			{"information_schema", "NULL"},
-			{"pg_catalog", "NULL"},
-			{"pg_extension", "NULL"},
+			{"crdb_internal", "node"},
+			{"information_schema", "node"},
+			{"pg_catalog", "node"},
+			{"pg_extension", "node"},
 			{"public", "admin"},
 		})
 

--- a/pkg/ccl/backupccl/testdata/backup-restore/backup-dropped-descriptors-declarative
+++ b/pkg/ccl/backupccl/testdata/backup-restore/backup-dropped-descriptors-declarative
@@ -147,13 +147,13 @@ USE d3;
 
 # We expect to not see the dropped schema 's'.
 query-sql
-SELECT schema_name FROM [SHOW SCHEMAS];
+SELECT schema_name FROM [SHOW SCHEMAS] ORDER BY 1;
 ----
-public
 crdb_internal
 information_schema
 pg_catalog
 pg_extension
+public
 
 
 query-sql
@@ -170,13 +170,13 @@ USE d4;
 ----
 
 query-sql
-SELECT schema_name FROM [SHOW SCHEMAS];
+SELECT schema_name FROM [SHOW SCHEMAS] ORDER BY 1;
 ----
-public
 crdb_internal
 information_schema
 pg_catalog
 pg_extension
+public
 
 query-sql
 SELECT schema_name, table_name FROM [SHOW TABLES];

--- a/pkg/ccl/backupccl/testdata/backup-restore/restore-on-fail-or-cancel-schema-objects
+++ b/pkg/ccl/backupccl/testdata/backup-restore/restore-on-fail-or-cancel-schema-objects
@@ -64,10 +64,10 @@ query-sql
 USE restore;
 SHOW SCHEMAS;
 ----
-crdb_internal <nil>
-information_schema <nil>
-pg_catalog <nil>
-pg_extension <nil>
+crdb_internal node
+information_schema node
+pg_catalog node
+pg_extension node
 public admin
 
 # Ensure that a database level restore also cleans up after itself. We do this

--- a/pkg/cli/clisqlshell/testdata/describe
+++ b/pkg/cli/clisqlshell/testdata/describe
@@ -122,8 +122,8 @@ List of schemas:
  WHERE TRUE AND n.nspname LIKE 'p%'
 ORDER BY 1
 Name,Owner
-pg_catalog,NULL
-pg_extension,NULL
+pg_catalog,node
+pg_extension,node
 public,admin
 
 cli
@@ -157,8 +157,8 @@ List of schemas:
  WHERE TRUE AND n.nspname LIKE 'p%'
 ORDER BY 1
 Name,Owner,Access privileges,Description
-pg_catalog,NULL,,
-pg_extension,NULL,,
+pg_catalog,node,,
+pg_extension,node,,
 public,admin,,
 
 cli
@@ -172,10 +172,10 @@ List of schemas:
  WHERE TRUE
 ORDER BY 1
 Name,Owner
-crdb_internal,NULL
-information_schema,NULL
-pg_catalog,NULL
-pg_extension,NULL
+crdb_internal,node
+information_schema,node
+pg_catalog,node
+pg_extension,node
 public,admin
 
 cli
@@ -191,10 +191,10 @@ List of schemas:
  WHERE TRUE
 ORDER BY 1
 Name,Owner,Access privileges,Description
-crdb_internal,NULL,,
-information_schema,NULL,,
-pg_catalog,NULL,,
-pg_extension,NULL,,
+crdb_internal,node,,
+information_schema,node,,
+pg_catalog,node,,
+pg_extension,node,,
 public,admin,,
 
 subtest end

--- a/pkg/sql/importer/import_stmt_test.go
+++ b/pkg/sql/importer/import_stmt_test.go
@@ -6410,7 +6410,7 @@ func TestImportPgDumpSchemas(t *testing.T) {
 		// Check that we have imported 4 schemas.
 		expectedSchemaNames := [][]string{{"bar"}, {"baz"}, {"foo"}, {"public"}}
 		sqlDB.CheckQueryResults(t,
-			`SELECT schema_name FROM [SHOW SCHEMAS] WHERE owner IS NOT NULL ORDER BY schema_name`,
+			`SELECT schema_name FROM [SHOW SCHEMAS] WHERE owner != 'node' ORDER BY schema_name`,
 			expectedSchemaNames)
 
 		// Check that we have a test table in each schema with the expected content.
@@ -6489,7 +6489,7 @@ func TestImportPgDumpSchemas(t *testing.T) {
 			sqlDB.Exec(t, `DROP TABLE schemadb.public.test`)
 		}
 		sqlDB.CheckQueryResults(t,
-			`SELECT schema_name FROM [SHOW SCHEMAS] WHERE owner <> 'NULL' ORDER BY schema_name`,
+			`SELECT schema_name FROM [SHOW SCHEMAS] WHERE owner <> 'node' ORDER BY schema_name`,
 			[][]string{{"bar"}, {"public"}})
 	})
 
@@ -6597,7 +6597,7 @@ func TestImportPgDumpSchemas(t *testing.T) {
 		}
 
 		// As a final sanity check that the schemas have been removed.
-		sqlDB.CheckQueryResults(t, `SELECT schema_name FROM [SHOW SCHEMAS] WHERE owner IS NOT NULL`,
+		sqlDB.CheckQueryResults(t, `SELECT schema_name FROM [SHOW SCHEMAS] WHERE owner != 'node'`,
 			[][]string{{"public"}})
 
 		// Check that the database descriptor has been updated with the removed schemas.

--- a/pkg/sql/logictest/testdata/logic_test/database
+++ b/pkg/sql/logictest/testdata/logic_test/database
@@ -62,10 +62,10 @@ query TT colnames,rowsort
 SHOW SCHEMAS FROM a
 ----
 schema_name         owner
-crdb_internal       NULL
-information_schema  NULL
-pg_catalog          NULL
-pg_extension        NULL
+crdb_internal       node
+information_schema  node
+pg_catalog          node
+pg_extension        node
 public              admin
 s                   root
 
@@ -379,10 +379,10 @@ query TT colnames,rowsort
 SHOW SCHEMAS
 ----
 schema_name         owner
-crdb_internal       NULL
-information_schema  NULL
-pg_catalog          NULL
-pg_extension        NULL
+crdb_internal       node
+information_schema  node
+pg_catalog          node
+pg_extension        node
 public              admin
 regression_105906   root
 
@@ -391,10 +391,10 @@ query TT colnames,rowsort
 SHOW SCHEMAS FROM regression_105906
 ----
 schema_name         owner
-crdb_internal       NULL
-information_schema  NULL
-pg_catalog          NULL
-pg_extension        NULL
+crdb_internal       node
+information_schema  node
+pg_catalog          node
+pg_extension        node
 public              admin
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/drop_owned_by
+++ b/pkg/sql/logictest/testdata/logic_test/drop_owned_by
@@ -484,10 +484,10 @@ SET DATABASE = d1
 query TT rowsort
 SHOW SCHEMAS FROM d1
 ----
-crdb_internal       NULL
-information_schema  NULL
-pg_catalog          NULL
-pg_extension        NULL
+crdb_internal       node
+information_schema  node
+pg_catalog          node
+pg_extension        node
 public              admin
 s1                  root
 s2                  root
@@ -526,10 +526,10 @@ DROP OWNED BY testuser
 query TT rowsort
 SHOW SCHEMAS FROM d1
 ----
-crdb_internal       NULL
-information_schema  NULL
-pg_catalog          NULL
-pg_extension        NULL
+crdb_internal       node
+information_schema  node
+pg_catalog          node
+pg_extension        node
 public              admin
 s1                  root
 s2                  root
@@ -560,10 +560,10 @@ SET DATABASE = d2
 query TT rowsort
 SHOW SCHEMAS FROM d2
 ----
-crdb_internal       NULL
-information_schema  NULL
-pg_catalog          NULL
-pg_extension        NULL
+crdb_internal       node
+information_schema  node
+pg_catalog          node
+pg_extension        node
 public              admin
 s1                  root
 s2                  testuser
@@ -587,10 +587,10 @@ DROP OWNED BY testuser
 query TT rowsort
 SHOW SCHEMAS FROM d2
 ----
-crdb_internal       NULL
-information_schema  NULL
-pg_catalog          NULL
-pg_extension        NULL
+crdb_internal       node
+information_schema  node
+pg_catalog          node
+pg_extension        node
 public              admin
 s1                  root
 

--- a/pkg/sql/logictest/testdata/logic_test/new_schema_changer
+++ b/pkg/sql/logictest/testdata/logic_test/new_schema_changer
@@ -1478,10 +1478,10 @@ skipif config local-mixed-22.2-23.1
 query TT rowsort
 SHOW SCHEMAS
 ----
-crdb_internal       NULL
-information_schema  NULL
-pg_catalog          NULL
-pg_extension        NULL
+crdb_internal       node
+information_schema  node
+pg_catalog          node
+pg_extension        node
 public              admin
 sc                  root
 
@@ -1493,10 +1493,10 @@ skipif config local-mixed-22.2-23.1
 query TT rowsort
 SHOW SCHEMAS
 ----
-crdb_internal       NULL
-information_schema  NULL
-pg_catalog          NULL
-pg_extension        NULL
+crdb_internal       node
+information_schema  node
+pg_catalog          node
+pg_extension        node
 public              admin
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -427,10 +427,10 @@ query OTOT colnames,rowsort
 SELECT * FROM pg_catalog.pg_namespace
 ----
 oid         nspname             nspowner    nspacl
-4294967295  crdb_internal       NULL        NULL
-4294967197  information_schema  NULL        NULL
-4294967110  pg_catalog          NULL        NULL
-4294966980  pg_extension        NULL        NULL
+4294967295  crdb_internal       3233629770  NULL
+4294967197  information_schema  3233629770  NULL
+4294967110  pg_catalog          3233629770  NULL
+4294966980  pg_extension        3233629770  NULL
 105         public              2310524507  NULL
 
 # Verify that we can still see the schemas even if we don't have any privilege
@@ -446,10 +446,10 @@ query OTOT colnames,rowsort
 SELECT * FROM pg_catalog.pg_namespace
 ----
 oid         nspname             nspowner    nspacl
-4294967295  crdb_internal       NULL        NULL
-4294967197  information_schema  NULL        NULL
-4294967110  pg_catalog          NULL        NULL
-4294966980  pg_extension        NULL        NULL
+4294967295  crdb_internal       3233629770  NULL
+4294967197  information_schema  3233629770  NULL
+4294967110  pg_catalog          3233629770  NULL
+4294966980  pg_extension        3233629770  NULL
 105         public              2310524507  NULL
 
 user root

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -264,10 +264,10 @@ SELECT * FROM [SHOW SCHEMAS FROM system]
 ----
 schema_name         owner
 public              admin
-crdb_internal       NULL
-information_schema  NULL
-pg_catalog          NULL
-pg_extension        NULL
+crdb_internal       node
+pg_extension        node
+pg_catalog          node
+information_schema  node
 
 query TT colnames,rowsort
 SELECT * FROM [SHOW SEQUENCES FROM system]
@@ -418,10 +418,10 @@ SELECT * FROM [SHOW SCHEMAS]
 ----
 schema_name         owner
 public              admin
-crdb_internal       NULL
-information_schema  NULL
-pg_catalog          NULL
-pg_extension        NULL
+crdb_internal       node
+pg_extension        node
+pg_catalog          node
+information_schema  node
 
 query TTTTIT colnames
 CREATE TABLE foo(x INT); SELECT * FROM [SHOW TABLES]

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -2083,7 +2083,8 @@ https://www.postgresql.org/docs/9.6/view-pg-matviews.html`,
 	},
 }
 
-var adminOID = makeOidHasher().UserOid(username.MakeSQLUsernameFromPreNormalizedString("admin"))
+var adminOID = makeOidHasher().UserOid(username.AdminRoleName())
+var nodeOID = makeOidHasher().UserOid(username.NodeUserName())
 
 var pgCatalogNamespaceTable = virtualSchemaTable{
 	comment: `available namespaces
@@ -2103,6 +2104,8 @@ https://www.postgresql.org/docs/9.5/catalog-pg-namespace.html`,
 					} else if sc.SchemaKind() == catalog.SchemaPublic {
 						// admin is the owner of the public schema.
 						ownerOID = adminOID
+					} else if sc.SchemaKind() == catalog.SchemaVirtual {
+						ownerOID = nodeOID
 					}
 					return addRow(
 						schemaOid(sc.GetID()),         // oid
@@ -2162,6 +2165,8 @@ https://www.postgresql.org/docs/9.5/catalog-pg-namespace.html`,
 				} else if sc.SchemaKind() == catalog.SchemaPublic {
 					// admin is the owner of the public schema.
 					ownerOID = adminOID
+				} else if sc.SchemaKind() == catalog.SchemaVirtual {
+					ownerOID = nodeOID
 				}
 				if err := addRow(
 					schemaOid(sc.GetID()),         // oid

--- a/pkg/sql/pgwire/pgwire_test.go
+++ b/pkg/sql/pgwire/pgwire_test.go
@@ -540,7 +540,7 @@ func TestPGPreparedQuery(t *testing.T) {
 				Results("users", "users_user_id_idx", false, 2, "username", "username", "ASC", true, true, true, 1),
 		}},
 		{"SHOW SCHEMAS FROM system", []preparedQueryTest{
-			baseTest.Results("crdb_internal", gosql.NullString{}).Others(4),
+			baseTest.Results("crdb_internal", "node").Others(4),
 		}},
 		{"SHOW CONSTRAINTS FROM system.users", []preparedQueryTest{
 			baseTest.Results("users", "primary", "PRIMARY KEY", "PRIMARY KEY (username ASC)", true).

--- a/pkg/sql/syntheticprivilegecache/accumulator.go
+++ b/pkg/sql/syntheticprivilegecache/accumulator.go
@@ -29,7 +29,9 @@ type accumulator struct {
 // newAccumulator initializes a Accumulator.
 func newAccumulator(objectType privilege.ObjectType, path string) *accumulator {
 	return &accumulator{
-		desc:       &catpb.PrivilegeDescriptor{},
+		desc: &catpb.PrivilegeDescriptor{
+			OwnerProto: username.NodeUserName().EncodeProto(),
+		},
 		objectType: objectType,
 		path:       path,
 	}


### PR DESCRIPTION
### syntheticprivilegecache: make node the owner of all synthetic privileges 

Synthetic privileges are never exposed directly to SQL users. As such,
they are internal objects that are owned by the cluster.

### sql: make node the owner of virtual schemas

Previously this would be NULL, but node is more correct since virtual
schemas are hardcoded.

Epic: None
Release note: None