### PR TITLE
kvprober: make the planner thread-safe to fix test-only race

### DIFF
--- a/pkg/kv/kvprober/kvprober_integration_test.go
+++ b/pkg/kv/kvprober/kvprober_integration_test.go
@@ -42,7 +42,6 @@ func TestProberDoesReadsAndWrites(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	skip.UnderShort(t)
-	skip.WithIssue(t, 109564)
 
 	ctx := context.Background()
 


### PR DESCRIPTION
https://github.com/cockroachdb/cockroach/issues/109564

**kvprober: make the planner thread-safe to fix test-only race**

This commit makes the planner thread-safe, in order to fix a test-only data race. This commit also un-skips the test that was skipped, when this bug was discovered.

Fixes: #109564
Release note: None.