### PR TITLE
kvserver: fix delegated snap gen change error

### DIFF
--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -2935,14 +2935,12 @@ func (r *Replica) validateSnapshotDelegationRequest(
 	// snapshot will still be valid since the leaseholder is also on this
 	// generation by now.
 	if desc.Generation < req.DescriptorGeneration {
-		log.VEventf(ctx, 2,
+		err := errors.Errorf(
 			"%s: generation has changed since snapshot was generated %s < %s",
-			r, req.DescriptorGeneration, desc.Generation,
+			r, desc.Generation, req.DescriptorGeneration,
 		)
-		return errors.Errorf(
-			"%s: generation has changed since snapshot was generated %s < %s",
-			r, req.DescriptorGeneration, desc.Generation,
-		)
+		log.VEventf(ctx, 2, "%v", err)
+		return err
 	}
 
 	// Check that the snapshot we generated has a descriptor that includes the


### PR DESCRIPTION
When the range descriptor of the delegate is lower than the descriptor generation of the delegating replica (leaseholder), the store returns an error, which is also logged (v=2).

The error message mixed up the delegating and delegated replica's generation. Swap them around.

Epic: none
Release note: None