### PR TITLE
roachpb: add lock durability info to Get/Scan/ReverseScan requests

### DIFF
--- a/pkg/ccl/kvccl/kvfollowerreadsccl/followerreads_test.go
+++ b/pkg/ccl/kvccl/kvfollowerreadsccl/followerreads_test.go
@@ -208,7 +208,7 @@ func TestCanSendToFollower(t *testing.T) {
 		},
 		{
 			name: "stale locking read",
-			ba:   batch(txn(stale), &kvpb.GetRequest{KeyLocking: lock.Exclusive}),
+			ba:   batch(txn(stale), &kvpb.GetRequest{KeyLockingStrength: lock.Exclusive}),
 			exp:  false,
 		},
 		{
@@ -345,7 +345,7 @@ func TestCanSendToFollower(t *testing.T) {
 		},
 		{
 			name:     "stale locking read, global reads policy",
-			ba:       batch(txn(stale), &kvpb.GetRequest{KeyLocking: lock.Exclusive}),
+			ba:       batch(txn(stale), &kvpb.GetRequest{KeyLockingStrength: lock.Exclusive}),
 			ctPolicy: roachpb.LEAD_FOR_GLOBAL_READS,
 			exp:      false,
 		},

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_heartbeater_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_heartbeater_test.go
@@ -176,7 +176,7 @@ func TestTxnHeartbeaterLoopStartedOnFirstLock(t *testing.T) {
 		if write {
 			ba.Add(&kvpb.PutRequest{RequestHeader: keyAHeader})
 		} else {
-			ba.Add(&kvpb.ScanRequest{RequestHeader: keyAHeader, KeyLocking: lock.Exclusive})
+			ba.Add(&kvpb.ScanRequest{RequestHeader: keyAHeader, KeyLockingStrength: lock.Exclusive})
 		}
 
 		br, pErr = th.SendLocked(ctx, ba)
@@ -344,7 +344,7 @@ func TestTxnHeartbeaterLoopStartsBeforeExpiry(t *testing.T) {
 			ba.Header = kvpb.Header{Txn: txn.Clone()}
 			keyA := roachpb.Key("a")
 			keyAHeader := kvpb.RequestHeader{Key: keyA}
-			ba.Add(&kvpb.GetRequest{RequestHeader: keyAHeader, KeyLocking: lock.Exclusive})
+			ba.Add(&kvpb.GetRequest{RequestHeader: keyAHeader, KeyLockingStrength: lock.Exclusive})
 
 			br, pErr := th.SendLocked(ctx, ba)
 			require.Nil(t, pErr)

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_pipeliner_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_pipeliner_test.go
@@ -122,8 +122,8 @@ func TestTxnPipeliner1PCTransaction(t *testing.T) {
 	ba := &kvpb.BatchRequest{}
 	ba.Header = kvpb.Header{Txn: &txn}
 	scanArgs := kvpb.ScanRequest{
-		RequestHeader: kvpb.RequestHeader{Key: keyA, EndKey: keyB},
-		KeyLocking:    lock.Exclusive,
+		RequestHeader:      kvpb.RequestHeader{Key: keyA, EndKey: keyB},
+		KeyLockingStrength: lock.Exclusive,
 	}
 	ba.Add(&scanArgs)
 	putArgs := kvpb.PutRequest{RequestHeader: kvpb.RequestHeader{Key: keyA}}
@@ -1353,7 +1353,7 @@ func TestTxnPipelinerRecordsLocksOnFailure(t *testing.T) {
 	ba.Header = kvpb.Header{Txn: &txn}
 	ba.Add(&kvpb.PutRequest{RequestHeader: kvpb.RequestHeader{Key: keyA}})
 	ba.Add(&kvpb.DeleteRangeRequest{RequestHeader: kvpb.RequestHeader{Key: keyB, EndKey: keyB.Next()}})
-	ba.Add(&kvpb.ScanRequest{RequestHeader: kvpb.RequestHeader{Key: keyC, EndKey: keyC.Next()}, KeyLocking: lock.Exclusive})
+	ba.Add(&kvpb.ScanRequest{RequestHeader: kvpb.RequestHeader{Key: keyC, EndKey: keyC.Next()}, KeyLockingStrength: lock.Exclusive})
 
 	mockPErr := kvpb.NewErrorf("boom")
 	mockSender.MockSend(func(ba *kvpb.BatchRequest) (*kvpb.BatchResponse, *kvpb.Error) {
@@ -1382,7 +1382,7 @@ func TestTxnPipelinerRecordsLocksOnFailure(t *testing.T) {
 	ba.Requests = nil
 	ba.Add(&kvpb.PutRequest{RequestHeader: kvpb.RequestHeader{Key: keyD}})
 	ba.Add(&kvpb.DeleteRangeRequest{RequestHeader: kvpb.RequestHeader{Key: keyE, EndKey: keyE.Next()}})
-	ba.Add(&kvpb.ScanRequest{RequestHeader: kvpb.RequestHeader{Key: keyF, EndKey: keyF.Next()}, KeyLocking: lock.Exclusive})
+	ba.Add(&kvpb.ScanRequest{RequestHeader: kvpb.RequestHeader{Key: keyF, EndKey: keyF.Next()}, KeyLockingStrength: lock.Exclusive})
 
 	mockSender.MockSend(func(ba *kvpb.BatchRequest) (*kvpb.BatchResponse, *kvpb.Error) {
 		require.Len(t, ba.Requests, 3)
@@ -1450,7 +1450,7 @@ func TestTxnPipelinerIgnoresLocksOnUnambiguousFailure(t *testing.T) {
 	ba.Header = kvpb.Header{Txn: &txn}
 	ba.Add(&kvpb.ConditionalPutRequest{RequestHeader: kvpb.RequestHeader{Key: keyA}})
 	ba.Add(&kvpb.DeleteRangeRequest{RequestHeader: kvpb.RequestHeader{Key: keyB, EndKey: keyB.Next()}})
-	ba.Add(&kvpb.ScanRequest{RequestHeader: kvpb.RequestHeader{Key: keyC, EndKey: keyC.Next()}, KeyLocking: lock.Exclusive})
+	ba.Add(&kvpb.ScanRequest{RequestHeader: kvpb.RequestHeader{Key: keyC, EndKey: keyC.Next()}, KeyLockingStrength: lock.Exclusive})
 
 	condFailedErr := kvpb.NewError(&kvpb.ConditionFailedError{})
 	condFailedErr.SetErrorIndex(0)
@@ -1480,7 +1480,7 @@ func TestTxnPipelinerIgnoresLocksOnUnambiguousFailure(t *testing.T) {
 	ba.Requests = nil
 	ba.Add(&kvpb.ConditionalPutRequest{RequestHeader: kvpb.RequestHeader{Key: keyD}})
 	ba.Add(&kvpb.DeleteRangeRequest{RequestHeader: kvpb.RequestHeader{Key: keyE, EndKey: keyE.Next()}})
-	ba.Add(&kvpb.ScanRequest{RequestHeader: kvpb.RequestHeader{Key: keyF, EndKey: keyF.Next()}, KeyLocking: lock.Exclusive})
+	ba.Add(&kvpb.ScanRequest{RequestHeader: kvpb.RequestHeader{Key: keyF, EndKey: keyF.Next()}, KeyLockingStrength: lock.Exclusive})
 
 	lockConflictErr := kvpb.NewError(&kvpb.LockConflictError{})
 	lockConflictErr.SetErrorIndex(2)

--- a/pkg/kv/kvclient/kvstreamer/streamer.go
+++ b/pkg/kv/kvclient/kvstreamer/streamer.go
@@ -1466,7 +1466,7 @@ func calculateFootprint(
 			}
 			if get.ResumeSpan != nil {
 				// This Get wasn't completed.
-				fp.resumeReqsMemUsage += requestSize(get.ResumeSpan.Key, get.ResumeSpan.EndKey)
+				fp.resumeReqsMemUsage += getRequestSize(get.ResumeSpan.Key)
 				fp.numIncompleteGets++
 			} else {
 				// This Get was completed.
@@ -1501,7 +1501,7 @@ func calculateFootprint(
 			}
 			if scan.ResumeSpan != nil {
 				// This Scan wasn't completed.
-				fp.resumeReqsMemUsage += requestSize(scan.ResumeSpan.Key, scan.ResumeSpan.EndKey)
+				fp.resumeReqsMemUsage += scanRequestSize(scan.ResumeSpan.Key, scan.ResumeSpan.EndKey)
 				fp.numIncompleteScans++
 			}
 		}

--- a/pkg/kv/kvclient/kvstreamer/streamer.go
+++ b/pkg/kv/kvclient/kvstreamer/streamer.go
@@ -1744,7 +1744,7 @@ func buildResumeSingleRangeBatch(
 			newGet := gets[0]
 			gets = gets[1:]
 			newGet.req.SetSpan(*get.ResumeSpan)
-			newGet.req.KeyLocking = s.keyLocking
+			newGet.req.KeyLockingStrength = s.keyLocking
 			newGet.union.Get = &newGet.req
 			resumeReq.reqs[resumeReqIdx].Value = &newGet.union
 			resumeReq.positions = append(resumeReq.positions, position)
@@ -1772,7 +1772,7 @@ func buildResumeSingleRangeBatch(
 			scans = scans[1:]
 			newScan.req.SetSpan(*scan.ResumeSpan)
 			newScan.req.ScanFormat = kvpb.BATCH_RESPONSE
-			newScan.req.KeyLocking = s.keyLocking
+			newScan.req.KeyLockingStrength = s.keyLocking
 			newScan.union.Scan = &newScan.req
 			resumeReq.reqs[resumeReqIdx].Value = &newScan.union
 			resumeReq.positions = append(resumeReq.positions, position)

--- a/pkg/kv/kvpb/api.proto
+++ b/pkg/kv/kvpb/api.proto
@@ -236,9 +236,32 @@ message GetRequest {
   // The desired key-level locking mode used during this get. When set to None
   // (the default), no key-level locking mode is used - meaning that the get
   // does not acquire a lock. When set to any other strength, a lock of that
-  // strength is acquired with the Unreplicated durability (i.e. best-effort)
-  // the key, if it exists.
-  kv.kvserver.concurrency.lock.Strength key_locking = 2;
+  // strength is acquired with the associated durability guarantees on the key,
+  // if it exists.
+  kv.kvserver.concurrency.lock.Strength key_locking_strength = 2;
+
+  // KeyLockingDurability denotes the durability with which locks, if any are
+  // acquired, should be acquired with. It should only be set in conjunction
+  // with a non-None KeyLockingStrength.
+  //
+  // Unreplicated locks are kept in-memory on the leaseholder of the locked key.
+  // As such, their existence until a transaction commits is best-effort. They
+  // are susceptible to things like lease transfers and node crashes. However,
+  // they are faster to acquire and resolve when compared to replicated locks.
+  // This makes them an appealing choice when locks are not required for
+  // correctness. This includes things like (non-exhaustive list):
+  // 1. Transactions that run under serializable isolation level.
+  // 2. Implicit SFU for weaker isolation levels, where we know we will
+  // subsequently perform a (replicated) intent write on the key being locked.
+  //
+  // Replicated locks on the other hand, once acquired, are guaranteed to exist
+  // until the transaction finalizes (commits or aborts). They are not
+  // susceptible to things like lease transfers, range {splits,merges}, memory
+  // limits, node crashes etc. Replication adds a performance penalty for lock
+  // acquisition and resolution; as such, they should only be used by
+  // transactions that need guaranteed locks for correctness (read:
+  // read-committed or snapshot isolation transactions).
+  kv.kvserver.concurrency.lock.Durability key_locking_durability = 3;
 }
 
 // A GetResponse is the return value from the Get() method.
@@ -609,14 +632,37 @@ message ScanRequest {
   // The desired key-level locking mode used during this scan. When set to None
   // (the default), no key-level locking mode is used - meaning that the scan
   // does not acquire any locks. When set to any other strength, a lock of that
-  // strength is acquired with the Unreplicated durability (i.e. best-effort) on
-  // each of the keys scanned by the request, subject to any key limit applied
-  // to the batch which limits the number of keys returned.
+  // strength is acquired with the associated durability guarantees on each of
+  // the keys scanned by the request, subject to any key limit applied to the
+  // batch which limits the number of keys returned.
   //
   // NOTE: the locks acquire with this strength are point locks on each of the
   // keys returned by the request, not a single range lock over the entire span
   // scanned by the request.
-  kv.kvserver.concurrency.lock.Strength key_locking = 5;
+  kv.kvserver.concurrency.lock.Strength key_locking_strength = 5;
+
+  // KeyLockingDurability denotes the durability with which locks, if any are
+  // acquired, should be acquired with. It should only be set in conjunction
+  // with a non-None KeyLockingStrength.
+  //
+  // Unreplicated locks are kept in-memory on the leaseholder of the locked key.
+  // As such, their existence until a transaction commits is best-effort. They
+  // are susceptible to things like lease transfers and node crashes. However,
+  // they are faster to acquire and resolve when compared to replicated locks.
+  // This makes them an appealing choice when locks are not required for
+  // correctness. This includes things like (non-exhaustive list):
+  // 1. Transactions that run under serializable isolation level.
+  // 2. Implicit SFU for weaker isolation levels, where we know we will
+  // subsequently perform a (replicated) intent write on the key being locked.
+  //
+  // Replicated locks on the other hand, once acquired, are guaranteed to exist
+  // until the transaction finalizes (commits or aborts). They are not
+  // susceptible to things like lease transfers, range {splits,merges}, memory
+  // limits, node crashes etc. Replication adds a performance penalty for lock
+  // acquisition and resolution; as such, they should only be used by
+  // transactions that need guaranteed locks for correctness (read:
+  // read-committed or snapshot isolation transactions).
+  kv.kvserver.concurrency.lock.Durability key_locking_durability = 6;
 }
 
 // A ScanResponse is the return value from the Scan() method.
@@ -674,14 +720,37 @@ message ReverseScanRequest {
   // The desired key-level locking mode used during this scan. When set to None
   // (the default), no key-level locking mode is used - meaning that the scan
   // does not acquire any locks. When set to any other strength, a lock of that
-  // strength is acquired with the Unreplicated durability (i.e. best-effort) on
-  // each of the keys scanned by the request, subject to any key limit applied
-  // to the batch which limits the number of keys returned.
+  // strength is acquired with the associated durability guarantees on each of
+  // the keys scanned by the request, subject to any key limit applied to the
+  // batch which limits the number of keys returned.
   //
   // NOTE: the locks acquire with this strength are point locks on each of the
   // keys returned by the request, not a single range lock over the entire span
   // scanned by the request.
-  kv.kvserver.concurrency.lock.Strength key_locking = 5;
+  kv.kvserver.concurrency.lock.Strength key_locking_strength = 5;
+
+  // KeyLockingDurability denotes the durability with which locks, if any are
+  // acquired, should be acquired with. It should only be set in conjunction
+  // with a non-None KeyLockingStrength.
+  //
+  // Unreplicated locks are kept in-memory on the leaseholder of the locked key.
+  // As such, their existence until a transaction commits is best-effort. They
+  // are susceptible to things like lease transfers and node crashes. However,
+  // they are faster to acquire and resolve when compared to replicated locks.
+  // This makes them an appealing choice when locks are not required for
+  // correctness. This includes things like (non-exhaustive list):
+  // 1. Transactions that run under serializable isolation level.
+  // 2. Implicit SFU for weaker isolation levels, where we know we will
+  // subsequently perform a (replicated) intent write on the key being locked.
+  //
+  // Replicated locks on the other hand, once acquired, are guaranteed to exist
+  // until the transaction finalizes (commits or aborts). They are not
+  // susceptible to things like lease transfers, range {splits,merges}, memory
+  // limits, node crashes etc. Replication adds a performance penalty for lock
+  // acquisition and resolution; as such, they should only be used by
+  // transactions that need guaranteed locks for correctness (read:
+  // read-committed or snapshot isolation transactions).
+  kv.kvserver.concurrency.lock.Durability key_locking_durability = 6;
 }
 
 // A ReverseScanResponse is the return value from the ReverseScan() method.

--- a/pkg/kv/kvpb/api_test.go
+++ b/pkg/kv/kvpb/api_test.go
@@ -381,9 +381,9 @@ func TestFlagCombinations(t *testing.T) {
 		&AddSSTableRequest{SSTTimestampToRequestTimestamp: hlc.Timestamp{Logical: 1}},
 		&DeleteRangeRequest{Inline: true},
 		&DeleteRangeRequest{UseRangeTombstone: true},
-		&GetRequest{KeyLocking: lock.Exclusive},
-		&ReverseScanRequest{KeyLocking: lock.Exclusive},
-		&ScanRequest{KeyLocking: lock.Exclusive},
+		&GetRequest{KeyLockingStrength: lock.Exclusive},
+		&ReverseScanRequest{KeyLockingStrength: lock.Exclusive},
+		&ScanRequest{KeyLockingStrength: lock.Exclusive},
 	}
 
 	reqTypes := []Request{}

--- a/pkg/kv/kvpb/batch_test.go
+++ b/pkg/kv/kvpb/batch_test.go
@@ -236,9 +236,9 @@ func TestLockSpanIterate(t *testing.T) {
 		{&ReverseScanRequest{}, &ReverseScanResponse{}, sp("e", "g"), sp("f", "g")},
 		{&PutRequest{}, &PutResponse{}, sp("h", ""), sp("", "")},
 		{&DeleteRangeRequest{}, &DeleteRangeResponse{}, sp("i", "k"), sp("j", "k")},
-		{&GetRequest{KeyLocking: lock.Exclusive}, &GetResponse{}, sp("l", ""), sp("", "")},
-		{&ScanRequest{KeyLocking: lock.Exclusive}, &ScanResponse{}, sp("m", "o"), sp("n", "o")},
-		{&ReverseScanRequest{KeyLocking: lock.Exclusive}, &ReverseScanResponse{}, sp("p", "r"), sp("q", "r")},
+		{&GetRequest{KeyLockingStrength: lock.Exclusive}, &GetResponse{}, sp("l", ""), sp("", "")},
+		{&ScanRequest{KeyLockingStrength: lock.Exclusive}, &ScanResponse{}, sp("m", "o"), sp("n", "o")},
+		{&ReverseScanRequest{KeyLockingStrength: lock.Exclusive}, &ReverseScanResponse{}, sp("p", "r"), sp("q", "r")},
 	}
 
 	// NB: can't import testutils for RunTrueAndFalse.
@@ -277,7 +277,7 @@ func TestLockSpanIterate(t *testing.T) {
 			// The intent writes are replicated locking request.
 			require.Equal(t, toExpSpans(testReqs[3], testReqs[4]), spans[lock.Replicated])
 
-			// The scans with KeyLocking are unreplicated locking requests.
+			// The scans with KeyLockingStrength are unreplicated locking requests.
 			require.Equal(t, toExpSpans(testReqs[5], testReqs[6], testReqs[7]), spans[lock.Unreplicated])
 		})
 	}

--- a/pkg/kv/kvserver/batcheval/cmd_get.go
+++ b/pkg/kv/kvserver/batcheval/cmd_get.go
@@ -37,7 +37,7 @@ func Get(
 		Inconsistent:          h.ReadConsistency != kvpb.CONSISTENT,
 		SkipLocked:            h.WaitPolicy == lock.WaitPolicy_SkipLocked,
 		Txn:                   h.Txn,
-		FailOnMoreRecent:      args.KeyLocking != lock.None,
+		FailOnMoreRecent:      args.KeyLockingStrength != lock.None,
 		ScanStats:             cArgs.ScanStats,
 		Uncertainty:           cArgs.Uncertainty,
 		MemoryAccount:         cArgs.EvalCtx.GetResponseMemoryAccount(),
@@ -83,8 +83,8 @@ func Get(
 	}
 
 	var res result.Result
-	if args.KeyLocking != lock.None && h.Txn != nil && getRes.Value != nil {
-		acq := roachpb.MakeLockAcquisition(h.Txn, args.Key, lock.Unreplicated, args.KeyLocking)
+	if args.KeyLockingStrength != lock.None && h.Txn != nil && getRes.Value != nil {
+		acq := roachpb.MakeLockAcquisition(h.Txn, args.Key, lock.Unreplicated, args.KeyLockingStrength)
 		res.Local.AcquiredLocks = []roachpb.LockAcquisition{acq}
 	}
 	res.Local.EncounteredIntents = intents

--- a/pkg/kv/kvserver/batcheval/cmd_reverse_scan.go
+++ b/pkg/kv/kvserver/batcheval/cmd_reverse_scan.go
@@ -50,7 +50,7 @@ func ReverseScan(
 		TargetBytes:           h.TargetBytes,
 		AllowEmpty:            h.AllowEmpty,
 		WholeRowsOfSize:       h.WholeRowsOfSize,
-		FailOnMoreRecent:      args.KeyLocking != lock.None,
+		FailOnMoreRecent:      args.KeyLockingStrength != lock.None,
 		Reverse:               true,
 		MemoryAccount:         cArgs.EvalCtx.GetResponseMemoryAccount(),
 		LockTable:             cArgs.Concurrency,
@@ -109,8 +109,8 @@ func ReverseScan(
 		}
 	}
 
-	if args.KeyLocking != lock.None && h.Txn != nil {
-		err = acquireUnreplicatedLocksOnKeys(&res, h.Txn, args.KeyLocking, args.ScanFormat, &scanRes)
+	if args.KeyLockingStrength != lock.None && h.Txn != nil {
+		err = acquireUnreplicatedLocksOnKeys(&res, h.Txn, args.KeyLockingStrength, args.ScanFormat, &scanRes)
 		if err != nil {
 			return result.Result{}, err
 		}

--- a/pkg/kv/kvserver/batcheval/cmd_scan.go
+++ b/pkg/kv/kvserver/batcheval/cmd_scan.go
@@ -50,7 +50,7 @@ func Scan(
 		TargetBytes:           h.TargetBytes,
 		AllowEmpty:            h.AllowEmpty,
 		WholeRowsOfSize:       h.WholeRowsOfSize,
-		FailOnMoreRecent:      args.KeyLocking != lock.None,
+		FailOnMoreRecent:      args.KeyLockingStrength != lock.None,
 		Reverse:               false,
 		MemoryAccount:         cArgs.EvalCtx.GetResponseMemoryAccount(),
 		LockTable:             cArgs.Concurrency,
@@ -109,8 +109,8 @@ func Scan(
 		}
 	}
 
-	if args.KeyLocking != lock.None && h.Txn != nil {
-		err = acquireUnreplicatedLocksOnKeys(&res, h.Txn, args.KeyLocking, args.ScanFormat, &scanRes)
+	if args.KeyLockingStrength != lock.None && h.Txn != nil {
+		err = acquireUnreplicatedLocksOnKeys(&res, h.Txn, args.KeyLockingStrength, args.ScanFormat, &scanRes)
 		if err != nil {
 			return result.Result{}, err
 		}

--- a/pkg/kv/kvserver/batcheval/declare.go
+++ b/pkg/kv/kvserver/batcheval/declare.go
@@ -87,7 +87,7 @@ func DefaultDeclareIsolatedKeys(
 			in := uncertainty.ComputeInterval(header, kvserverpb.LeaseStatus{}, maxOffset)
 			timestamp.Forward(in.GlobalLimit)
 		} else {
-			str = req.(kvpb.LockingReadRequest).KeyLockingStrength()
+			str, _ = req.(kvpb.LockingReadRequest).KeyLocking()
 			switch str {
 			// The lock.None case has already been handled above.
 			case lock.Shared:

--- a/pkg/kv/kvserver/client_merge_test.go
+++ b/pkg/kv/kvserver/client_merge_test.go
@@ -1681,7 +1681,7 @@ func TestStoreRangeMergeSplitRace_SplitWins(t *testing.T) {
 	var mergeEndTxnTimestamp atomic.Value
 	testingRequestFilter := func(_ context.Context, ba *kvpb.BatchRequest) *kvpb.Error {
 		for _, req := range ba.Requests {
-			if get := req.GetGet(); get != nil && get.KeyLocking != lock.None {
+			if get := req.GetGet(); get != nil && get.KeyLockingStrength != lock.None {
 				if v := lhsDescKey.Load(); v != nil && v.(roachpb.Key).Equal(get.Key) {
 					// If this is the first merge attempt, launch the split
 					// before the merge's first locking read succeeds.

--- a/pkg/kv/kvserver/concurrency/datadriven_util_test.go
+++ b/pkg/kv/kvserver/concurrency/datadriven_util_test.go
@@ -183,7 +183,7 @@ func scanSingleRequest(
 		var r kvpb.GetRequest
 		r.Sequence = maybeGetSeq()
 		r.Key = roachpb.Key(mustGetField("key"))
-		r.KeyLocking = maybeGetStr()
+		r.KeyLockingStrength = maybeGetStr()
 		return &r
 
 	case "scan":
@@ -193,7 +193,7 @@ func scanSingleRequest(
 		if v, ok := fields["endkey"]; ok {
 			r.EndKey = roachpb.Key(v)
 		}
-		r.KeyLocking = maybeGetStr()
+		r.KeyLockingStrength = maybeGetStr()
 		return &r
 
 	case "put":

--- a/pkg/kv/kvserver/concurrency/lock/locking.go
+++ b/pkg/kv/kvserver/concurrency/lock/locking.go
@@ -57,7 +57,7 @@ const MaxStrength = Intent
 const NumLockStrength = MaxStrength + 1
 
 // MaxDurability is the maximum value in the Durability enum.
-const MaxDurability = Unreplicated
+const MaxDurability = Replicated
 
 func init() {
 	for v := range Strength_name {

--- a/pkg/kv/kvserver/concurrency/lock/locking.proto
+++ b/pkg/kv/kvserver/concurrency/lock/locking.proto
@@ -200,15 +200,6 @@ message Mode {
 enum Durability {
   option (gogoproto.goproto_enum_prefix) = false;
 
-  // Replicated locks are held on at least a quorum of Replicas in a Range.
-  // They are slower to acquire and release than Unreplicated locks because
-  // updating them requires both cross-node coordination and interaction with
-  // durable storage. In exchange, Replicated locks provide a guarantee of
-  // survivability across lease transfers, leaseholder crashes, and other
-  // forms of failure events. They will remain available as long as their
-  // Range remains available and they will never be lost.
-  Replicated = 0;
-
   // Unreplicated locks are held only on a single Replica in a Range, which is
   // typically the leaseholder. Unreplicated locks are very fast to acquire
   // and release because they are held in memory or on fast local storage and
@@ -216,7 +207,16 @@ enum Durability {
   // locks provide no guarantee of survivability across lease transfers or
   // leaseholder crashes. They should therefore be thought of as best-effort
   // and should not be relied upon for correctness.
-  Unreplicated = 1;
+  Unreplicated = 0;
+
+  // Replicated locks are held on at least a quorum of Replicas in a Range.
+  // They are slower to acquire and release than Unreplicated locks because
+  // updating them requires both cross-node coordination and interaction with
+  // durable storage. In exchange, Replicated locks provide a guarantee of
+  // survivability across lease transfers, leaseholder crashes, and other
+  // forms of failure events. They will remain available as long as their
+  // Range remains available and they will never be lost.
+  Replicated = 1;
 }
 
 // WaitPolicy specifies the behavior of a request when it encounters conflicting

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/basic
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/basic
@@ -270,7 +270,7 @@ num=5
 
 query
 ----
-num locks: 1, bytes returned: 81, resume reason: RESUME_UNKNOWN, resume span: <nil>
+num locks: 1, bytes returned: 83, resume reason: RESUME_UNKNOWN, resume span: <nil>
  locks:
   range_id=3 key="a" holder=00000000-0000-0000-0000-000000000003 durability=Replicated duration=2s
    waiters:
@@ -712,7 +712,7 @@ topklocksbywaitduration:
 
 query
 ----
-num locks: 3, bytes returned: 288, resume reason: RESUME_UNKNOWN, resume span: <nil>
+num locks: 3, bytes returned: 286, resume reason: RESUME_UNKNOWN, resume span: <nil>
  locks:
   range_id=3 key="a" holder=00000000-0000-0000-0000-000000000003 durability=Replicated duration=2.65s
    waiters:
@@ -883,7 +883,7 @@ topklocksbywaitduration:
 
 query
 ----
-num locks: 3, bytes returned: 268, resume reason: RESUME_UNKNOWN, resume span: <nil>
+num locks: 3, bytes returned: 266, resume reason: RESUME_UNKNOWN, resume span: <nil>
  locks:
   range_id=3 key="b" holder=<nil> durability=Unreplicated duration=0s
    waiters:

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/query
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/query
@@ -45,7 +45,7 @@ num locks: 0, bytes returned: 0, resume reason: RESUME_UNKNOWN, resume span: <ni
 
 query span=a,d uncontended
 ----
-num locks: 1, bytes returned: 41, resume reason: RESUME_UNKNOWN, resume span: <nil>
+num locks: 1, bytes returned: 39, resume reason: RESUME_UNKNOWN, resume span: <nil>
  locks:
   range_id=3 key="c" holder=00000000-0000-0000-0000-000000000001 durability=Unreplicated duration=0s
 
@@ -82,14 +82,14 @@ num=3
 
 query span=a,f max-locks=2 uncontended
 ----
-num locks: 2, bytes returned: 82, resume reason: RESUME_KEY_LIMIT, resume span: {e-f}
+num locks: 2, bytes returned: 78, resume reason: RESUME_KEY_LIMIT, resume span: {e-f}
  locks:
   range_id=3 key="b" holder=00000000-0000-0000-0000-000000000001 durability=Unreplicated duration=0s
   range_id=3 key="c" holder=00000000-0000-0000-0000-000000000001 durability=Unreplicated duration=0s
 
 query span=a,f max-bytes=50 uncontended
 ----
-num locks: 1, bytes returned: 41, resume reason: RESUME_BYTE_LIMIT, resume span: {c-f}
+num locks: 1, bytes returned: 39, resume reason: RESUME_BYTE_LIMIT, resume span: {c-f}
  locks:
   range_id=3 key="b" holder=00000000-0000-0000-0000-000000000001 durability=Unreplicated duration=0s
 
@@ -97,7 +97,7 @@ num locks: 1, bytes returned: 41, resume reason: RESUME_BYTE_LIMIT, resume span:
 
 query span=a,f max-bytes=10 uncontended
 ----
-num locks: 1, bytes returned: 41, resume reason: RESUME_BYTE_LIMIT, resume span: {c-f}
+num locks: 1, bytes returned: 39, resume reason: RESUME_BYTE_LIMIT, resume span: {c-f}
  locks:
   range_id=3 key="b" holder=00000000-0000-0000-0000-000000000001 durability=Unreplicated duration=0s
 
@@ -149,7 +149,7 @@ num=3
 
 query span=a,/Max max-bytes=100
 ----
-num locks: 1, bytes returned: 91, resume reason: RESUME_BYTE_LIMIT, resume span: {e-/Max}
+num locks: 1, bytes returned: 89, resume reason: RESUME_BYTE_LIMIT, resume span: {e-/Max}
  locks:
   range_id=3 key="b" holder=00000000-0000-0000-0000-000000000001 durability=Unreplicated duration=200ms
    waiters:
@@ -157,7 +157,7 @@ num locks: 1, bytes returned: 91, resume reason: RESUME_BYTE_LIMIT, resume span:
 
 query span=b max-bytes=100
 ----
-num locks: 1, bytes returned: 91, resume reason: RESUME_UNKNOWN, resume span: <nil>
+num locks: 1, bytes returned: 89, resume reason: RESUME_UNKNOWN, resume span: <nil>
  locks:
   range_id=3 key="b" holder=00000000-0000-0000-0000-000000000001 durability=Unreplicated duration=200ms
    waiters:
@@ -165,7 +165,7 @@ num locks: 1, bytes returned: 91, resume reason: RESUME_UNKNOWN, resume span: <n
 
 query span=e,/Max max-bytes=100
 ----
-num locks: 1, bytes returned: 91, resume reason: RESUME_UNKNOWN, resume span: <nil>
+num locks: 1, bytes returned: 89, resume reason: RESUME_UNKNOWN, resume span: <nil>
  locks:
   range_id=3 key="e" holder=00000000-0000-0000-0000-000000000001 durability=Unreplicated duration=200ms
    waiters:

--- a/pkg/kv/kvserver/replica_evaluate_test.go
+++ b/pkg/kv/kvserver/replica_evaluate_test.go
@@ -293,7 +293,7 @@ func TestEvaluateBatch(t *testing.T) {
 			},
 		},
 		//
-		// Test suite for KeyLocking.
+		// Test suite for KeyLockingStrength.
 		//
 		{
 			// Two gets, one of which finds a key, one of which does not. An
@@ -302,10 +302,10 @@ func TestEvaluateBatch(t *testing.T) {
 			setup: func(t *testing.T, d *data) {
 				writeABCDEFAt(t, d, ts.Prev())
 				scanA := getArgsString("a")
-				scanA.KeyLocking = lock.Exclusive
+				scanA.KeyLockingStrength = lock.Exclusive
 				d.ba.Add(scanA)
 				scanG := getArgsString("g")
-				scanG.KeyLocking = lock.Exclusive
+				scanG.KeyLockingStrength = lock.Exclusive
 				d.ba.Add(scanG)
 				d.ba.Txn = &txn
 			},
@@ -322,10 +322,10 @@ func TestEvaluateBatch(t *testing.T) {
 			setup: func(t *testing.T, d *data) {
 				writeABCDEFAt(t, d, ts.Prev())
 				scanA := getArgsString("a")
-				scanA.KeyLocking = lock.Exclusive
+				scanA.KeyLockingStrength = lock.Exclusive
 				d.ba.Add(scanA)
 				scanG := getArgsString("g")
-				scanG.KeyLocking = lock.Exclusive
+				scanG.KeyLockingStrength = lock.Exclusive
 				d.ba.Add(scanG)
 			},
 			check: func(t *testing.T, r resp) {
@@ -341,13 +341,13 @@ func TestEvaluateBatch(t *testing.T) {
 			setup: func(t *testing.T, d *data) {
 				writeABCDEFAt(t, d, ts.Prev())
 				scanAD := scanArgsString("a", "d")
-				scanAD.KeyLocking = lock.Exclusive
+				scanAD.KeyLockingStrength = lock.Exclusive
 				d.ba.Add(scanAD)
 				scanEF := scanArgsString("e", "f")
-				scanEF.KeyLocking = lock.Exclusive
+				scanEF.KeyLockingStrength = lock.Exclusive
 				d.ba.Add(scanEF)
 				scanHJ := scanArgsString("h", "j")
-				scanHJ.KeyLocking = lock.Exclusive
+				scanHJ.KeyLockingStrength = lock.Exclusive
 				d.ba.Add(scanHJ)
 				d.ba.Txn = &txn
 			},
@@ -363,13 +363,13 @@ func TestEvaluateBatch(t *testing.T) {
 			setup: func(t *testing.T, d *data) {
 				writeABCDEFAt(t, d, ts.Prev())
 				scanAD := revScanArgsString("a", "d")
-				scanAD.KeyLocking = lock.Exclusive
+				scanAD.KeyLockingStrength = lock.Exclusive
 				d.ba.Add(scanAD)
 				scanEF := revScanArgsString("e", "f")
-				scanEF.KeyLocking = lock.Exclusive
+				scanEF.KeyLockingStrength = lock.Exclusive
 				d.ba.Add(scanEF)
 				scanHJ := revScanArgsString("h", "j")
-				scanHJ.KeyLocking = lock.Exclusive
+				scanHJ.KeyLockingStrength = lock.Exclusive
 				d.ba.Add(scanHJ)
 				d.ba.Txn = &txn
 			},
@@ -386,13 +386,13 @@ func TestEvaluateBatch(t *testing.T) {
 			setup: func(t *testing.T, d *data) {
 				writeABCDEFAt(t, d, ts.Prev())
 				scanAD := scanArgsString("a", "d")
-				scanAD.KeyLocking = lock.Exclusive
+				scanAD.KeyLockingStrength = lock.Exclusive
 				d.ba.Add(scanAD)
 				scanEF := scanArgsString("e", "f")
-				scanEF.KeyLocking = lock.Exclusive
+				scanEF.KeyLockingStrength = lock.Exclusive
 				d.ba.Add(scanEF)
 				scanHJ := scanArgsString("h", "j")
-				scanHJ.KeyLocking = lock.Exclusive
+				scanHJ.KeyLockingStrength = lock.Exclusive
 				d.ba.Add(scanHJ)
 			},
 			check: func(t *testing.T, r resp) {
@@ -407,13 +407,13 @@ func TestEvaluateBatch(t *testing.T) {
 			setup: func(t *testing.T, d *data) {
 				writeABCDEFAt(t, d, ts.Prev())
 				scanAD := revScanArgsString("a", "d")
-				scanAD.KeyLocking = lock.Exclusive
+				scanAD.KeyLockingStrength = lock.Exclusive
 				d.ba.Add(scanAD)
 				scanEF := revScanArgsString("e", "f")
-				scanEF.KeyLocking = lock.Exclusive
+				scanEF.KeyLockingStrength = lock.Exclusive
 				d.ba.Add(scanEF)
 				scanHJ := revScanArgsString("h", "j")
-				scanHJ.KeyLocking = lock.Exclusive
+				scanHJ.KeyLockingStrength = lock.Exclusive
 				d.ba.Add(scanHJ)
 			},
 			check: func(t *testing.T, r resp) {
@@ -431,7 +431,7 @@ func TestEvaluateBatch(t *testing.T) {
 			setup: func(t *testing.T, d *data) {
 				writeABCDEFAt(t, d, ts.Prev())
 				scanAE := scanArgsString("a", "e")
-				scanAE.KeyLocking = lock.Exclusive
+				scanAE.KeyLockingStrength = lock.Exclusive
 				d.ba.Add(scanAE)
 				d.ba.Txn = &txn
 				d.ba.MaxSpanRequestKeys = 3
@@ -449,7 +449,7 @@ func TestEvaluateBatch(t *testing.T) {
 			setup: func(t *testing.T, d *data) {
 				writeABCDEFAt(t, d, ts.Prev())
 				scanAE := revScanArgsString("a", "e")
-				scanAE.KeyLocking = lock.Exclusive
+				scanAE.KeyLockingStrength = lock.Exclusive
 				d.ba.Add(scanAE)
 				d.ba.Txn = &txn
 				d.ba.MaxSpanRequestKeys = 3
@@ -471,10 +471,10 @@ func TestEvaluateBatch(t *testing.T) {
 			setup: func(t *testing.T, d *data) {
 				writeABCDEFAt(t, d, ts.Prev())
 				scanAE := scanArgsString("a", "e")
-				scanAE.KeyLocking = lock.Exclusive
+				scanAE.KeyLockingStrength = lock.Exclusive
 				d.ba.Add(scanAE)
 				scanHJ := scanArgsString("h", "j")
-				scanHJ.KeyLocking = lock.Exclusive
+				scanHJ.KeyLockingStrength = lock.Exclusive
 				d.ba.Add(scanHJ)
 				d.ba.Txn = &txn
 				d.ba.MaxSpanRequestKeys = 3
@@ -492,10 +492,10 @@ func TestEvaluateBatch(t *testing.T) {
 			setup: func(t *testing.T, d *data) {
 				writeABCDEFAt(t, d, ts.Prev())
 				scanAE := revScanArgsString("a", "e")
-				scanAE.KeyLocking = lock.Exclusive
+				scanAE.KeyLockingStrength = lock.Exclusive
 				d.ba.Add(scanAE)
 				scanHJ := scanArgsString("h", "j")
-				scanHJ.KeyLocking = lock.Exclusive
+				scanHJ.KeyLockingStrength = lock.Exclusive
 				d.ba.Add(scanHJ)
 				d.ba.Txn = &txn
 				d.ba.MaxSpanRequestKeys = 3
@@ -515,7 +515,7 @@ func TestEvaluateBatch(t *testing.T) {
 			setup: func(t *testing.T, d *data) {
 				writeABCDEFAt(t, d, ts.Prev())
 				scanAE := scanArgsString("a", "e")
-				scanAE.KeyLocking = lock.Exclusive
+				scanAE.KeyLockingStrength = lock.Exclusive
 				d.ba.Add(scanAE)
 				d.ba.Txn = &txn
 				d.ba.TargetBytes = 1
@@ -533,7 +533,7 @@ func TestEvaluateBatch(t *testing.T) {
 			setup: func(t *testing.T, d *data) {
 				writeABCDEFAt(t, d, ts.Prev())
 				scanAE := revScanArgsString("a", "e")
-				scanAE.KeyLocking = lock.Exclusive
+				scanAE.KeyLockingStrength = lock.Exclusive
 				d.ba.Add(scanAE)
 				d.ba.Txn = &txn
 				d.ba.TargetBytes = 1
@@ -554,10 +554,10 @@ func TestEvaluateBatch(t *testing.T) {
 			setup: func(t *testing.T, d *data) {
 				writeABCDEFAt(t, d, ts.Prev())
 				scanAE := scanArgsString("a", "e")
-				scanAE.KeyLocking = lock.Exclusive
+				scanAE.KeyLockingStrength = lock.Exclusive
 				d.ba.Add(scanAE)
 				scanHJ := scanArgsString("h", "j")
-				scanHJ.KeyLocking = lock.Exclusive
+				scanHJ.KeyLockingStrength = lock.Exclusive
 				d.ba.Add(scanHJ)
 				d.ba.Txn = &txn
 				d.ba.TargetBytes = 1
@@ -575,10 +575,10 @@ func TestEvaluateBatch(t *testing.T) {
 			setup: func(t *testing.T, d *data) {
 				writeABCDEFAt(t, d, ts.Prev())
 				scanAE := revScanArgsString("a", "e")
-				scanAE.KeyLocking = lock.Exclusive
+				scanAE.KeyLockingStrength = lock.Exclusive
 				d.ba.Add(scanAE)
 				scanHJ := scanArgsString("h", "j")
-				scanHJ.KeyLocking = lock.Exclusive
+				scanHJ.KeyLockingStrength = lock.Exclusive
 				d.ba.Add(scanHJ)
 				d.ba.Txn = &txn
 				d.ba.TargetBytes = 1

--- a/pkg/kv/kvserver/replica_read.go
+++ b/pkg/kv/kvserver/replica_read.go
@@ -565,7 +565,8 @@ func (r *Replica) collectSpansRead(
 					union kvpb.RequestUnion_Get
 				})
 				getAlloc.get.Key = key
-				getAlloc.get.KeyLocking = req.(kvpb.LockingReadRequest).KeyLockingStrength()
+				getAlloc.get.KeyLockingStrength,
+					getAlloc.get.KeyLockingDurability = req.(kvpb.LockingReadRequest).KeyLocking()
 				getAlloc.union.Get = &getAlloc.get
 				ru := kvpb.RequestUnion{Value: &getAlloc.union}
 				baCopy.Requests = append(baCopy.Requests, ru)

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -2916,10 +2916,10 @@ func TestReplicaLatchingOptimisticEvaluationSkipLocked(t *testing.T) {
 				gArgs1, gArgs2 := getArgsString("a"), getArgsString("b")
 				gArgs3, gArgs4 := getArgsString("c"), getArgsString("d")
 				if lockingReads {
-					gArgs1.KeyLocking = lock.Exclusive
-					gArgs2.KeyLocking = lock.Exclusive
-					gArgs3.KeyLocking = lock.Exclusive
-					gArgs4.KeyLocking = lock.Exclusive
+					gArgs1.KeyLockingStrength = lock.Exclusive
+					gArgs2.KeyLockingStrength = lock.Exclusive
+					gArgs3.KeyLockingStrength = lock.Exclusive
+					gArgs4.KeyLockingStrength = lock.Exclusive
 				}
 				baRead.Add(gArgs1, gArgs2, gArgs3, gArgs4)
 			} else {
@@ -2927,8 +2927,8 @@ func TestReplicaLatchingOptimisticEvaluationSkipLocked(t *testing.T) {
 				sArgs1 := scanArgsString("a", "c")
 				sArgs2 := scanArgsString("c", "e")
 				if lockingReads {
-					sArgs1.KeyLocking = lock.Exclusive
-					sArgs2.KeyLocking = lock.Exclusive
+					sArgs1.KeyLockingStrength = lock.Exclusive
+					sArgs2.KeyLockingStrength = lock.Exclusive
 				}
 				baRead.Add(sArgs1, sArgs2)
 			}
@@ -10544,7 +10544,7 @@ func TestReplicaServersideRefreshes(t *testing.T) {
 				ba = &kvpb.BatchRequest{}
 				ba.Txn = newTxn("c-scan", ts.Prev())
 				scan := scanArgs(roachpb.Key("c-scan"), roachpb.Key("c-scan\x00"))
-				scan.KeyLocking = lock.Exclusive
+				scan.KeyLockingStrength = lock.Exclusive
 				ba.Add(scan)
 				return
 			},
@@ -10605,7 +10605,7 @@ func TestReplicaServersideRefreshes(t *testing.T) {
 				ba.Txn = newTxn("c-scan", ts.Prev())
 				ba.CanForwardReadTimestamp = true
 				scan := scanArgs(roachpb.Key("c-scan"), roachpb.Key("c-scan\x00"))
-				scan.KeyLocking = lock.Exclusive
+				scan.KeyLockingStrength = lock.Exclusive
 				ba.Add(scan)
 				return
 			},
@@ -10838,7 +10838,7 @@ func TestReplicaServersideRefreshes(t *testing.T) {
 				expTS = ba.Txn.WriteTimestamp
 
 				scan := scanArgs(roachpb.Key("lscan"), roachpb.Key("lscan\x00"))
-				scan.KeyLocking = lock.Exclusive
+				scan.KeyLockingStrength = lock.Exclusive
 				ba.Add(scan)
 				return
 			},

--- a/pkg/sql/insert_fast_path.go
+++ b/pkg/sql/insert_fast_path.go
@@ -200,8 +200,8 @@ func (r *insertFastPathRun) addFKChecks(
 		reqIdx := len(r.fkBatch.Requests)
 		r.fkBatch.Requests = append(r.fkBatch.Requests, kvpb.RequestUnion{})
 		r.fkBatch.Requests[reqIdx].MustSetInner(&kvpb.ScanRequest{
-			RequestHeader: kvpb.RequestHeaderFromSpan(span),
-			KeyLocking:    lockStrength,
+			RequestHeader:      kvpb.RequestHeaderFromSpan(span),
+			KeyLockingStrength: lockStrength,
 			// TODO(michae2): Once #100193 is finished, also include c.Locking.Durability.
 		})
 		r.fkSpanInfo = append(r.fkSpanInfo, insertFastPathFKSpanInfo{

--- a/pkg/sql/row/kv_batch_fetcher.go
+++ b/pkg/sql/row/kv_batch_fetcher.go
@@ -923,7 +923,7 @@ func spansToRequests(
 				// A span without an EndKey indicates that the caller is requesting a
 				// single key fetch, which can be served using a GetRequest.
 				gets[curGet].req.Key = spans[i].Key
-				gets[curGet].req.KeyLocking = keyLocking
+				gets[curGet].req.KeyLockingStrength = keyLocking
 				// TODO(michae2): Once #100193 is finished, also include locking durability.
 				gets[curGet].union.Get = &gets[curGet].req
 				reqs[i].Value = &gets[curGet].union
@@ -933,7 +933,7 @@ func spansToRequests(
 			curScan := i - curGet
 			scans[curScan].req.SetSpan(spans[i])
 			scans[curScan].req.ScanFormat = scanFormat
-			scans[curScan].req.KeyLocking = keyLocking
+			scans[curScan].req.KeyLockingStrength = keyLocking
 			// TODO(michae2): Once #100193 is finished, also include locking durability.
 			scans[curScan].union.ReverseScan = &scans[curScan].req
 			reqs[i].Value = &scans[curScan].union
@@ -948,7 +948,7 @@ func spansToRequests(
 				// A span without an EndKey indicates that the caller is requesting a
 				// single key fetch, which can be served using a GetRequest.
 				gets[curGet].req.Key = spans[i].Key
-				gets[curGet].req.KeyLocking = keyLocking
+				gets[curGet].req.KeyLockingStrength = keyLocking
 				// TODO(michae2): Once #100193 is finished, also include locking durability.
 				gets[curGet].union.Get = &gets[curGet].req
 				reqs[i].Value = &gets[curGet].union
@@ -958,7 +958,7 @@ func spansToRequests(
 			curScan := i - curGet
 			scans[curScan].req.SetSpan(spans[i])
 			scans[curScan].req.ScanFormat = scanFormat
-			scans[curScan].req.KeyLocking = keyLocking
+			scans[curScan].req.KeyLockingStrength = keyLocking
 			// TODO(michae2): Once #100193 is finished, also include locking durability.
 			scans[curScan].union.Scan = &scans[curScan].req
 			reqs[i].Value = &scans[curScan].union


### PR DESCRIPTION
This patch adds lock durability information to Get, Scan, and ReverseScan requests. This field is only ever meaningful in conjunction with a locking strength that's not lock.None.

By default, all locking requests ask for best-effort locks. This preserves the mixed version story between 23.1 <-> 23.2 nodes. However, transactions that need them for correctness (read: read committed), will now have the option to ask for guranteed durability locks. These will then correspond to replicated locks. Note that the field here is named in terms of durability guarantees, and not the specific implementation detail we'll use to provide this -- this is intentional. It allows us to offer a different kind of durable locks in the future, for example schemes that selectively replicate locks because they have buy-in from the both the kvserver and kvclient, in conjunction with some scheme to verify locks at commit time.

Informs #109672

Release note: None