### PR TITLE
sql: improve the c2c flow diagram

### DIFF
--- a/pkg/sql/execinfrapb/flow_diagram.go
+++ b/pkg/sql/execinfrapb/flow_diagram.go
@@ -531,7 +531,7 @@ func (s *StreamIngestionDataSpec) summary() (string, []string) {
 	)
 
 	annotations := []string{
-		"Partitions",
+		"Partitions:",
 	}
 
 	// Sort partitions by ID for stable output.
@@ -549,14 +549,15 @@ func (s *StreamIngestionDataSpec) summary() (string, []string) {
 			break
 		}
 		p := s.PartitionSpecs[srcID]
-		var spanDesc string
-		if len(p.Spans) <= spanLimit {
-			spanDesc = fmt.Sprintf("n%s: %v", srcID, p.Spans)
-		} else {
-			spanDesc = fmt.Sprintf("n%s: %v and %d more spans",
-				srcID, p.Spans[:spanLimit], len(p.Spans)-spanLimit)
+
+		annotations = append(annotations, fmt.Sprintf("Source node %s, spans:", srcID))
+		for i, span := range p.Spans {
+			if i == spanLimit {
+				annotations = append(annotations, fmt.Sprintf("and %d more spans", len(p.Spans)-spanLimit))
+				break
+			}
+			annotations = append(annotations, fmt.Sprintf("%v", span))
 		}
-		annotations = append(annotations, spanDesc)
 	}
 
 	return "StreamIngestionData", annotations

--- a/pkg/sql/execinfrapb/flow_diagram_test.go
+++ b/pkg/sql/execinfrapb/flow_diagram_test.go
@@ -884,10 +884,16 @@ func TestPlanDiagramReplicationStream(t *testing.T) {
       "core": {
         "title": "StreamIngestionData/1",
         "details": [
-          "Partitions",
-          "n1: [{a-b}]",
-          "n2: [{d-e}]",
-          "n3: [{f1-g1} {f2-g2} {f3-g3}] and 1 more spans",
+          "Partitions:",
+          "Source node 1, spans:",
+          "{a-b}",
+          "Source node 2, spans:",
+          "{d-e}",
+          "Source node 3, spans:",
+          "{f1-g1}",
+          "{f2-g2}",
+          "{f3-g3}",
+          "and 1 more spans",
           "and 1 more partitions"
         ]
       },


### PR DESCRIPTION
Clarify that the node mentioned is a source node.
Add some newlines so that we don't get super wide boxes.

Before:
<img width="1529" alt="Screenshot 2023-09-07 at 3 03 40 PM" src="https://github.com/cockroachdb/cockroach/assets/51982110/25b63908-dbc9-45d2-814e-9b83cfa25abf">

After:
<img width="534" alt="Screenshot 2023-09-07 at 3 30 43 PM" src="https://github.com/cockroachdb/cockroach/assets/51982110/10de624d-887a-438b-873b-65ee7e6c5682">


Epic: none

Release note: None