### PR TITLE
kvadmission: introduce byte-limit for flow control dispatch

### DIFF
--- a/pkg/kv/kvserver/flow_control_raft_transport_test.go
+++ b/pkg/kv/kvserver/flow_control_raft_transport_test.go
@@ -13,6 +13,7 @@ package kvserver_test
 import (
 	"context"
 	"fmt"
+	"math"
 	"sort"
 	"strconv"
 	"strings"
@@ -346,7 +347,7 @@ func TestFlowControlRaftTransport(t *testing.T) {
 						require.True(t, found, "uninitialized node, did you use 'add node=n%s'?", fromNodeID)
 
 						var buf strings.Builder
-						es := control.dispatch.PendingDispatchFor(toNodeID)
+						es, _ := control.dispatch.PendingDispatchFor(toNodeID, math.MaxInt64)
 						sort.Slice(es, func(i, j int) bool { // for determinism
 							if es[i].RangeID != es[j].RangeID {
 								return es[i].RangeID < es[j].RangeID

--- a/pkg/kv/kvserver/kvadmission/kvadmission.go
+++ b/pkg/kv/kvserver/kvadmission/kvadmission.go
@@ -129,6 +129,16 @@ var FlowTokenDispatchInterval = settings.RegisterDurationSetting(
 	settings.PositiveDuration, settings.NonNegativeDurationWithMaximum(time.Minute),
 )
 
+// FlowTokenDispatchMaxBytes determines the maximum number of bytes of dispatch
+// messages that are annotated onto a single RaftTransport message.
+var FlowTokenDispatchMaxBytes = settings.RegisterByteSizeSetting(
+	settings.SystemOnly,
+	"kvadmission.flow_control.dispatch.max_bytes",
+	"limits the size of flow control dispatch messages being attached to a single raft message",
+	64<<20,                         // 64 MB
+	settings.IntWithMinimum(1<<20), // 1 MB
+)
+
 // ConnectedStoreExpiration controls how long the RaftTransport layers considers
 // a stream connected without it having observed any messages from it.
 var ConnectedStoreExpiration = settings.RegisterDurationSetting(

--- a/pkg/kv/kvserver/kvflowcontrol/kvflowcontrol.go
+++ b/pkg/kv/kvserver/kvflowcontrol/kvflowcontrol.go
@@ -272,7 +272,7 @@ type DispatchWriter interface {
 // the stream breaking by freeing up all held tokens.
 type DispatchReader interface {
 	PendingDispatch() []roachpb.NodeID
-	PendingDispatchFor(roachpb.NodeID) []kvflowcontrolpb.AdmittedRaftLogEntries
+	PendingDispatchFor(nodeID roachpb.NodeID, maxBytes int64) (admittedRaftLogEntries []kvflowcontrolpb.AdmittedRaftLogEntries, remainingDispatches int)
 }
 
 func (t Tokens) String() string {

--- a/pkg/kv/kvserver/kvflowcontrol/kvflowdispatch/BUILD.bazel
+++ b/pkg/kv/kvserver/kvflowcontrol/kvflowdispatch/BUILD.bazel
@@ -37,6 +37,7 @@ go_test(
         "//pkg/util/leaktest",
         "//pkg/util/log",
         "//pkg/util/metric",
+        "//pkg/util/protoutil",
         "@com_github_cockroachdb_datadriven//:datadriven",
         "@com_github_stretchr_testify//require",
     ],

--- a/pkg/kv/kvserver/kvflowcontrol/kvflowdispatch/dummy.go
+++ b/pkg/kv/kvserver/kvflowcontrol/kvflowdispatch/dummy.go
@@ -35,6 +35,8 @@ func (d *dummy) PendingDispatch() []roachpb.NodeID {
 	return nil
 }
 
-func (d *dummy) PendingDispatchFor(id roachpb.NodeID) []kvflowcontrolpb.AdmittedRaftLogEntries {
-	return nil
+func (d *dummy) PendingDispatchFor(
+	nodeID roachpb.NodeID, maxBytes int64,
+) ([]kvflowcontrolpb.AdmittedRaftLogEntries, int) {
+	return nil, 0
 }

--- a/pkg/kv/kvserver/kvflowcontrol/kvflowdispatch/kvflowdispatch.go
+++ b/pkg/kv/kvserver/kvflowcontrol/kvflowdispatch/kvflowdispatch.go
@@ -23,6 +23,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 )
 
+// AdmittedRaftLogEntriesBytes is an estimate that comes from
+// kvflowdispatch.TestDispatchSize().
+const AdmittedRaftLogEntriesBytes = 50
+
 // Dispatch is a concrete implementation of the kvflowcontrol.Dispatch
 // interface. It's used to (i) dispatch information about admitted raft log
 // entries to specific nodes, and (ii) to read pending dispatches.
@@ -146,17 +150,21 @@ func (d *Dispatch) PendingDispatch() []roachpb.NodeID {
 
 // PendingDispatchFor is part of the kvflowcontrol.Dispatch interface.
 func (d *Dispatch) PendingDispatchFor(
-	nodeID roachpb.NodeID,
-) []kvflowcontrolpb.AdmittedRaftLogEntries {
+	nodeID roachpb.NodeID, maxBytes int64,
+) ([]kvflowcontrolpb.AdmittedRaftLogEntries, int) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
 	if _, ok := d.mu.outbox[nodeID]; !ok {
-		return nil
+		return nil, 0
 	}
 
 	var entries []kvflowcontrolpb.AdmittedRaftLogEntries
+	maxEntries := maxBytes / AdmittedRaftLogEntriesBytes
 	for key, dispatch := range d.mu.outbox[nodeID] {
+		if maxEntries == 0 {
+			break
+		}
 		// TODO(irfansharif,aaditya): This contributes to 0.5% of alloc_objects
 		// under kv0/enc=false/nodes=3/cpu=96. Maybe address it as part of
 		// #104154; we're simply copying things over. Maybe use a sync.Pool here
@@ -169,11 +177,17 @@ func (d *Dispatch) PendingDispatchFor(
 		})
 		wc := admissionpb.WorkClassFromPri(key.WorkPriority)
 		d.metrics.PendingDispatches[wc].Dec(1)
+		maxEntries -= 1
+		delete(d.mu.outbox[nodeID], key)
 	}
 
-	delete(d.mu.outbox, nodeID)
-	d.metrics.PendingNodes.Dec(1)
-	return entries
+	remainingDispatches := len(d.mu.outbox[nodeID])
+	if remainingDispatches == 0 {
+		delete(d.mu.outbox, nodeID)
+		d.metrics.PendingNodes.Dec(1)
+	}
+
+	return entries, remainingDispatches
 }
 
 // testingMetrics returns the underlying metrics struct for testing purposes.


### PR DESCRIPTION
This change introduces a byte-limit for dispatch messages that piggyback onto RaftTransport messages to avoid sending a message that is too large.

We do this by introducing a new cluster setting that can set the maximum number of bytes of dispatch messages we annotate onto a single RaftTransport message.

Informs #104154.

Release note: None