### PR TITLE
kv/bulk: ensure in-flight requests end on batcher reset

### DIFF
--- a/pkg/ccl/backupccl/restore_data_processor.go
+++ b/pkg/ccl/backupccl/restore_data_processor.go
@@ -767,7 +767,7 @@ func reserveRestoreWorkerMemory(
 // implement a mock SSTBatcher used purely for job progress tracking.
 type SSTBatcherExecutor interface {
 	AddMVCCKey(ctx context.Context, key storage.MVCCKey, value []byte) error
-	Reset(ctx context.Context) error
+	Reset(ctx context.Context)
 	Flush(ctx context.Context) error
 	Close(ctx context.Context)
 	GetSummary() kvpb.BulkOpSummary
@@ -786,9 +786,7 @@ func (b *sstBatcherNoop) AddMVCCKey(ctx context.Context, key storage.MVCCKey, va
 }
 
 // Reset resets the counter
-func (b *sstBatcherNoop) Reset(ctx context.Context) error {
-	return nil
-}
+func (b *sstBatcherNoop) Reset(ctx context.Context) {}
 
 // Flush noops.
 func (b *sstBatcherNoop) Flush(ctx context.Context) error {

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor.go
@@ -1188,9 +1188,7 @@ func (sip *streamIngestionProcessor) flushBuffer(b flushableBuffer) (*jobspb.Res
 	sip.metrics.IngestedEvents.Inc(int64(len(b.buffer.curKVBatch)))
 	sip.metrics.IngestedEvents.Inc(int64(len(b.buffer.curRangeKVBatch)))
 
-	if err := sip.batcher.Reset(ctx); err != nil {
-		return b.checkpoint, err
-	}
+	sip.batcher.Reset(ctx)
 
 	releaseBuffer(b.buffer)
 

--- a/pkg/kv/bulk/buffering_adder.go
+++ b/pkg/kv/bulk/buffering_adder.go
@@ -256,9 +256,7 @@ func (b *BufferingAdder) doFlush(ctx context.Context, forSize bool) error {
 		b.curBufSummary.Reset()
 		return nil
 	}
-	if err := b.sink.Reset(ctx); err != nil {
-		return err
-	}
+	b.sink.Reset(ctx)
 	b.sink.currentStats.BufferFlushes++
 
 	var before *bulkpb.IngestionPerformanceStats


### PR DESCRIPTION
streamingest: ensure batcher is always reset
kv/bulk: ensure in-flight requests end on batcher reset


Previously if `streamIngestionProcessor.flushBuffer()` had started adding keys to a batcher, it was possible that that batcher had filled and triggered an async flush. Typically this async flush would be awaited when `flushBuffer` explicitly calls `sip.batcher.Flush()` immediately after the loop in which it adds keys. However, if one of the key additions returned an error,  one of these async flushes could still be in-flight when that error causes `flushBuffer` to return early, without calling `Flush()` and waiting for it. Thus, `flushBuffer` could return and in doing so finish its local tracing span, that it handed to the batcher and is being used to send its still ongoing async flush, resulting in that request then finding itself using a finished span, which is illegal.

The changes here add waiting to inflight requests to `batcher.Reset()`, and then defer the reset of the batcher in `flushBuffer` so that it is always run, including before early returns, ensuring that `flushBuffer` never returns while its batcher has in-flight requests pending.

While I'm here: removed the unused error return from `Reset()`.