### PR TITLE
build: add teamcity scripts for test coverage

### DIFF
--- a/build/teamcity/cockroach/coverage/unit_tests_ccl.sh
+++ b/build/teamcity/cockroach/coverage/unit_tests_ccl.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+dir="$(dirname $(dirname $(dirname $(dirname "${0}"))))"
+
+source "$dir/teamcity-support.sh"  # For $root
+source "$dir/teamcity-bazel-support.sh"  # For run_bazel
+
+tc_start_block "Run CCL unit tests with coverage"
+BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="-e TC_BUILD_BRANCH -e GITHUB_API_TOKEN -e BUILD_VCS_NUMBER -e TC_BUILD_ID -e TC_SERVER_URL -e TC_BUILDTYPE_ID -e GITHUB_REPO" run_bazel build/teamcity/cockroach/coverage/unit_tests_ccl_impl.sh
+tc_end_block "Run CCL unit tests with coverage"

--- a/build/teamcity/cockroach/coverage/unit_tests_ccl_impl.sh
+++ b/build/teamcity/cockroach/coverage/unit_tests_ccl_impl.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -xeuo pipefail
+
+bazel build //pkg/cmd/bazci --config=ci
+
+$(bazel info bazel-bin --config=ci)/pkg/cmd/bazci/bazci_/bazci -- \
+  coverage \
+  --config=ci --config=use_ci_timeouts -c fastbuild \
+  --@io_bazel_rules_go//go/config:cover_format=lcov --combined_report=lcov \
+  --instrumentation_filter="//pkg/..." \
+  --profile=/artifacts/profile.gz \
+  //pkg:ccl_tests
+
+lcov_file="$(bazel info output_path)/_coverage/_coverage_report.dat"
+if [ ! -f "${lcov_file}" ]; then
+  echo "Coverage file ${lcov_file} does not exist"
+  exit 1
+fi
+
+cp "${lcov_file}" /artifacts/unit_tests_ccl.lcov

--- a/build/teamcity/cockroach/coverage/unit_tests_nonccl.sh
+++ b/build/teamcity/cockroach/coverage/unit_tests_nonccl.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+dir="$(dirname $(dirname $(dirname $(dirname "${0}"))))"
+
+source "$dir/teamcity-support.sh"  # For $root
+source "$dir/teamcity-bazel-support.sh"  # For run_bazel
+
+tc_start_block "Run non-CCL unit tests with coverage"
+BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="-e TC_BUILD_BRANCH -e GITHUB_API_TOKEN -e BUILD_VCS_NUMBER -e TC_BUILD_ID -e TC_SERVER_URL -e TC_BUILDTYPE_ID -e GITHUB_REPO" run_bazel build/teamcity/cockroach/coverage/unit_tests_nonccl_impl.sh
+tc_end_block "Run non-CCL unit tests with coverage"

--- a/build/teamcity/cockroach/coverage/unit_tests_nonccl_impl.sh
+++ b/build/teamcity/cockroach/coverage/unit_tests_nonccl_impl.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -xeuo pipefail
+
+bazel build //pkg/cmd/bazci --config=ci
+
+$(bazel info bazel-bin --config=ci)/pkg/cmd/bazci/bazci_/bazci -- \
+  coverage \
+  --config=ci --config=use_ci_timeouts -c fastbuild \
+  --@io_bazel_rules_go//go/config:cover_format=lcov --combined_report=lcov \
+  --instrumentation_filter="//pkg/..." \
+  --profile=/artifacts/profile.gz \
+  //pkg:small_non_ccl_tests //pkg:medium_non_ccl_tests //pkg:large_non_ccl_tests
+
+lcov_file="$(bazel info output_path)/_coverage/_coverage_report.dat"
+if [ ! -f "${lcov_file}" ]; then
+  echo "Coverage file ${lcov_file} does not exist"
+  exit 1
+fi
+
+cp "${lcov_file}" /artifacts/unit_tests_nonccl.lcov

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -8,6 +8,8 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+// Package cli is the command-line library used by the cockroach binary and
+// other utilities. See README.md.
 package cli
 
 import (

--- a/pkg/cli/userfiletable_test.go
+++ b/pkg/cli/userfiletable_test.go
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
+
 package cli
 
 import (

--- a/pkg/cmd/bazci/bazci.go
+++ b/pkg/cmd/bazci/bazci.go
@@ -206,7 +206,6 @@ func (s *monitorBuildServer) handleBuildEvent(
 			outputDir = strings.ReplaceAll(outputDir, ":", "/")
 			outputDir = filepath.Join("bazel-testlogs", outputDir)
 			summary := bazelBuildEvent.GetTestSummary()
-			lastAttempt := summary.AttemptCount
 			for _, testResult := range s.testResults[label] {
 				outputDir := outputDir
 				if testResult.run > 1 {
@@ -215,10 +214,11 @@ func (s *monitorBuildServer) handleBuildEvent(
 				if summary != nil && summary.ShardCount > 1 {
 					outputDir = filepath.Join(outputDir, fmt.Sprintf("shard_%d_of_%d", testResult.shard, summary.ShardCount))
 				}
-				// Add `.tc_ignore_attempt#` to the filename of all attempts but the last one. This ensures that
-				// those results are uploaded to TC in case we need them but the results are ignored
-				// by TC because the filename doesn't end with `.xml`.
-				append_tc_ignore := testResult.attempt != lastAttempt
+				// Add `.tc_ignore_attempt#` to the filename of all attempts but the
+				// last one. This ensures that those results are uploaded to TC in case
+				// we need them but the results are ignored by TC because the filename
+				// doesn't end with `.xml`.
+				append_tc_ignore := summary != nil && testResult.attempt != summary.AttemptCount
 				if testResult.testResult == nil {
 					continue
 				}

--- a/pkg/cmd/bazci/bazci.go
+++ b/pkg/cmd/bazci/bazci.go
@@ -48,6 +48,7 @@ const (
 	buildSubcmd             = "build"
 	runSubcmd               = "run"
 	testSubcmd              = "test"
+	coverageSubcmd          = "coverage"
 	mergeTestXMLsSubcmd     = "merge-test-xmls"
 	mungeTestXMLSubcmd      = "munge-test-xml"
 	beaverHubServerEndpoint = "https://beaver-hub-server-jjd2v2r2dq-uk.a.run.app/process"
@@ -223,7 +224,7 @@ func (s *monitorBuildServer) handleBuildEvent(
 					continue
 				}
 				for _, output := range testResult.testResult.TestActionOutput {
-					if output.Name == "test.log" || output.Name == "test.xml" {
+					if output.Name == "test.log" || output.Name == "test.xml" || output.Name == "test.lcov" {
 						src := strings.TrimPrefix(output.GetUri(), "file://")
 						dst := filepath.Join(artifactsDir, outputDir, filepath.Base(src))
 						if append_tc_ignore {
@@ -236,7 +237,7 @@ func (s *monitorBuildServer) handleBuildEvent(
 							s.testXmls = append(s.testXmls, src)
 						}
 					} else {
-						panic(output)
+						panic(fmt.Sprintf("Unknown TestActionOutput: %v", output))
 					}
 				}
 			}
@@ -318,8 +319,9 @@ func sendBepDataToBeaverHub(bepFilepath string) error {
 }
 
 func bazciImpl(cmd *cobra.Command, args []string) error {
-	if args[0] != buildSubcmd && args[0] != runSubcmd && args[0] != testSubcmd && args[0] != mungeTestXMLSubcmd && args[0] != mergeTestXMLsSubcmd {
-		return errors.Newf("First argument must be `build`, `run`, `test`, `merge-test-xmls`, or `munge-test-xml`; got %v", args[0])
+	if args[0] != buildSubcmd && args[0] != runSubcmd && args[0] != coverageSubcmd &&
+		args[0] != testSubcmd && args[0] != mungeTestXMLSubcmd && args[0] != mergeTestXMLsSubcmd {
+		return errors.Newf("First argument must be `build`, `run`, `test`, `coverage`, `merge-test-xmls`, or `munge-test-xml`; got %v", args[0])
 	}
 
 	// Special case: munge-test-xml/merge-test-xmls don't require running Bazel at all.


### PR DESCRIPTION
#### cli: add package comment

Fix for this error saw in a bazel coverage run:
```
pkg/cli/keytype_string.go:3:1: at least one file in a package should have a package comment (ST1000)
```

Epic: none
Release note: None

#### bazci: fix null pointer access

I ran into a null pointer access on `summary`. Some of the existing
code does check for `summary != nil` so it is an expected possible
condition. This fix moves the use of the field behind a check.

Epic: none
Release note: None

#### build: add teamcity scripts for test coverage

This commit adds teamcity scripts for generating unit test coverage.

We include some small modifications to `bazci` that allow using
`coverage` and saving the `coverage.dat` files to the artifacts.

Epic: none
Release note: None