### PR TITLE
release-23.1.10-rc: clusterversion: test, do no merge

### DIFF
--- a/pkg/clusterversion/cockroach_versions.go
+++ b/pkg/clusterversion/cockroach_versions.go
@@ -18,6 +18,7 @@ import (
 // Key is a unique identifier for a version of CockroachDB.
 type Key int
 
+// hello, world!
 // Version constants. These drive compatibility between versions as well as
 // migrations. Before you add a version or consider removing one, please
 // familiarize yourself with the rules below.


### PR DESCRIPTION
Backport 1/1 commits from #110227.

/cc @cockroachdb/release

---

Release note: None
Epic: none
