### PR TITLE
skip: add Unimplemented skip reason

### DIFF
--- a/pkg/server/authserver/authentication_test.go
+++ b/pkg/server/authserver/authentication_test.go
@@ -775,9 +775,9 @@ func TestAuthenticationMux(t *testing.T) {
 		t.Run("path="+tc.path, func(t *testing.T) {
 			if s.StartedDefaultTestTenant() && strings.HasPrefix(tc.path, ts.URLPrefix) {
 				// As of this writing, timeseries requests to secondary
-				// tenants are overly restricted. This is a bug. See
+				// tenants are overly restricted. This is a feature gap. See
 				// issue #102378.
-				skip.WithIssue(t, 102378)
+				skip.Unimplemented(t, 102378)
 			}
 
 			// Verify normal client returns 401 Unauthorized.

--- a/pkg/testutils/skip/skip.go
+++ b/pkg/testutils/skip/skip.go
@@ -37,6 +37,17 @@ func WithIssue(t SkippableTest, githubIssueID int, args ...interface{}) {
 		args...))
 }
 
+// Unimplemented skips this test case, loggint the given issue ID. It
+// is included in addition to WithIssue to allow the caller to signal
+// that this test is not being skipped because of a bug, but rather
+// because of an unimplemented feature.
+func Unimplemented(t SkippableTest, githubIssueID int, args ...interface{}) {
+	t.Helper()
+	maybeSkip(t, append([]interface{}{
+		fmt.Sprintf("https://github.com/cockroachdb/cockroach/issues/%d", githubIssueID)},
+		args...))
+}
+
 // IgnoreLint skips this test, explicitly marking it as not a test that
 // should be tracked as a "skipped test" by external tools. You should use this
 // if, for example, your test should only be run in Race mode.


### PR DESCRIPTION
Some test cases are skipped because we intend to work on a feature in the future and have written the test to show the desired end-state once written.

Having a special method for this case allows us to semantically distinguish these kinds of skips from skips that are the results of bugs or unknown issues.

Epic: none

Release note: None