### PR TITLE
*: fix bugs related to invalid use of PrefixEnd to compute tenant end key

### DIFF
--- a/pkg/ccl/cmdccl/clusterrepl/main.go
+++ b/pkg/ccl/cmdccl/clusterrepl/main.go
@@ -119,8 +119,7 @@ func streamPartition(ctx context.Context, streamAddr *url.URL) error {
 		return err
 	}
 
-	prefix := keys.MakeTenantPrefix(plan.SourceTenantID)
-	tenantSpan := roachpb.Span{Key: prefix, EndKey: prefix.PrefixEnd()}
+	tenantSpan := keys.MakeTenantSpan(plan.SourceTenantID)
 
 	var sps streampb.StreamPartitionSpec
 	sps.Config.MinCheckpointFrequency = *checkpointInterval

--- a/pkg/ccl/streamingccl/streamingest/replication_random_client_test.go
+++ b/pkg/ccl/streamingccl/streamingest/replication_random_client_test.go
@@ -279,9 +279,9 @@ func TestStreamIngestionJobWithRandomClient(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tenantPrefix := keys.MakeTenantPrefix(roachpb.MustMakeTenantID(uint64(newTenantID)))
-	t.Logf("counting kvs in span %v", tenantPrefix)
-	maxIngestedTS := assertExactlyEqualKVs(t, tc, streamValidator, revertRangeTargetTime, tenantPrefix)
+	tenantSpan := keys.MakeTenantSpan(roachpb.MustMakeTenantID(uint64(newTenantID)))
+	t.Logf("counting kvs in span %v", tenantSpan)
+	maxIngestedTS := assertExactlyEqualKVs(t, tc, streamValidator, revertRangeTargetTime, tenantSpan)
 	// Sanity check that the max ts in the store is less than the revert range
 	// target timestamp.
 	require.True(t, maxIngestedTS.LessEq(revertRangeTargetTime))
@@ -296,13 +296,13 @@ func assertExactlyEqualKVs(
 	tc *testcluster.TestCluster,
 	streamValidator *streamClientValidator,
 	frontierTimestamp hlc.Timestamp,
-	tenantPrefix roachpb.Key,
+	tenantSpan roachpb.Span,
 ) hlc.Timestamp {
 	// Iterate over the store.
 	store := tc.GetFirstStoreFromServer(t, 0)
 	it, err := store.TODOEngine().NewMVCCIterator(storage.MVCCKeyIterKind, storage.IterOptions{
-		LowerBound: tenantPrefix,
-		UpperBound: tenantPrefix.PrefixEnd(),
+		LowerBound: tenantSpan.Key,
+		UpperBound: tenantSpan.EndKey,
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/ccl/streamingccl/streamingest/replication_stream_e2e_test.go
+++ b/pkg/ccl/streamingccl/streamingest/replication_stream_e2e_test.go
@@ -366,10 +366,10 @@ func TestTenantStreamingCancelIngestion(t *testing.T) {
 		require.Nil(t, stats.ProducerStatus.ProtectedTimestamp)
 
 		// Check if dest tenant key ranges are not cleaned up.
-		destTenantPrefix := keys.MakeTenantPrefix(args.DestTenantID)
+		destTenantSpan := keys.MakeTenantSpan(args.DestTenantID)
 
 		rows, err := c.DestCluster.Server(0).DB().
-			Scan(ctx, destTenantPrefix, destTenantPrefix.PrefixEnd(), 10)
+			Scan(ctx, destTenantSpan.Key, destTenantSpan.EndKey, 10)
 		require.NoError(t, err)
 		require.NotEmpty(t, rows)
 
@@ -382,7 +382,7 @@ func TestTenantStreamingCancelIngestion(t *testing.T) {
 		c.DestSysSQL.Exec(t, "DROP TENANT [$1] IMMEDIATE",
 			args.DestTenantID.ToUint64())
 		rows, err = c.DestCluster.Server(0).DB().
-			Scan(ctx, destTenantPrefix, destTenantPrefix.PrefixEnd(), 10)
+			Scan(ctx, destTenantSpan.Key, destTenantSpan.EndKey, 10)
 		require.NoError(t, err)
 		require.Empty(t, rows)
 
@@ -439,9 +439,9 @@ func TestTenantStreamingDropTenantCancelsStream(t *testing.T) {
 		c.DestSysSQL.Exec(t, "SHOW JOBS WHEN COMPLETE SELECT job_id FROM [SHOW JOBS] WHERE job_type = 'SCHEMA CHANGE GC'")
 
 		// Check if dest tenant key range is cleaned up.
-		destTenantPrefix := keys.MakeTenantPrefix(args.DestTenantID)
+		destTenantSpan := keys.MakeTenantSpan(args.DestTenantID)
 		rows, err := c.DestCluster.Server(0).DB().
-			Scan(ctx, destTenantPrefix, destTenantPrefix.PrefixEnd(), 10)
+			Scan(ctx, destTenantSpan.Key, destTenantSpan.EndKey, 10)
 		require.NoError(t, err)
 		require.Empty(t, rows)
 
@@ -913,9 +913,9 @@ func TestProtectedTimestampManagement(t *testing.T) {
 			c.DestSysSQL.Exec(t, "SHOW JOBS WHEN COMPLETE SELECT job_id FROM [SHOW JOBS] WHERE job_type = 'SCHEMA CHANGE GC'")
 
 			// Check if dest tenant key range is cleaned up.
-			destTenantPrefix := keys.MakeTenantPrefix(args.DestTenantID)
+			destTenantSpan := keys.MakeTenantSpan(args.DestTenantID)
 			rows, err := c.DestCluster.Server(0).DB().
-				Scan(ctx, destTenantPrefix, destTenantPrefix.PrefixEnd(), 10)
+				Scan(ctx, destTenantSpan.Key, destTenantSpan.EndKey, 10)
 			require.NoError(t, err)
 			require.Empty(t, rows)
 

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_planning.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_planning.go
@@ -226,11 +226,10 @@ func ingestionPlanHook(
 			return err
 		}
 
-		prefix := keys.MakeTenantPrefix(destinationTenantID)
 		streamIngestionDetails := jobspb.StreamIngestionDetails{
 			StreamAddress:         string(streamAddress),
 			StreamID:              uint64(replicationProducerSpec.StreamID),
-			Span:                  roachpb.Span{Key: prefix, EndKey: prefix.PrefixEnd()},
+			Span:                  keys.MakeTenantSpan(destinationTenantID),
 			DestinationTenantID:   destinationTenantID,
 			SourceTenantName:      roachpb.TenantName(sourceTenant),
 			DestinationTenantName: roachpb.TenantName(dstTenantName),

--- a/pkg/ccl/streamingccl/streamproducer/producer_job.go
+++ b/pkg/ccl/streamingccl/streamproducer/producer_job.go
@@ -32,8 +32,8 @@ import (
 )
 
 func makeTenantSpan(tenantID uint64) roachpb.Span {
-	prefix := keys.MakeTenantPrefix(roachpb.MustMakeTenantID(tenantID))
-	return roachpb.Span{Key: prefix, EndKey: prefix.PrefixEnd()}
+	tenID := roachpb.MustMakeTenantID(tenantID)
+	return keys.MakeTenantSpan(tenID)
 }
 
 func makeProducerJobRecord(

--- a/pkg/config/system.go
+++ b/pkg/config/system.go
@@ -638,7 +638,7 @@ func (s *SystemConfig) tenantBoundarySplitKey(
 			log.Errorf(ctx, "unable to decode tenant ID from start key: %s", err)
 			return nil
 		}
-		if lowTenIDExcl == roachpb.MaxTenantID {
+		if lowTenIDExcl.ToUint64() >= roachpb.MaxTenantID.ToUint64() {
 			// MaxTenantID already split or outside range.
 			return nil
 		}

--- a/pkg/keys/sql.go
+++ b/pkg/keys/sql.go
@@ -27,6 +27,18 @@ func MakeTenantPrefix(tenID roachpb.TenantID) roachpb.Key {
 	return encoding.EncodeUvarintAscending(TenantPrefix, tenID.ToUint64())
 }
 
+// MakeTenantSpan creates the start/end key pair associated with the specified tenant.
+func MakeTenantSpan(tenID roachpb.TenantID) roachpb.Span {
+	if tenID == roachpb.SystemTenantID {
+		return roachpb.Span{Key: MinKey, EndKey: MaxKey}
+	}
+	tenIDint := tenID.ToUint64()
+	return roachpb.Span{
+		Key:    encoding.EncodeUvarintAscending(TenantPrefix, tenIDint),
+		EndKey: encoding.EncodeUvarintAscending(TenantPrefix, tenIDint+1),
+	}
+}
+
 // DecodeTenantPrefix determines the tenant ID from the key prefix, returning
 // the remainder of the key (with the prefix removed) and the decoded tenant ID.
 func DecodeTenantPrefix(key roachpb.Key) ([]byte, roachpb.TenantID, error) {
@@ -148,16 +160,12 @@ type sqlDecoder struct {
 
 // MakeSQLCodec creates a new  SQLCodec suitable for manipulating SQL keys.
 func MakeSQLCodec(tenID roachpb.TenantID) SQLCodec {
-	k := MakeTenantPrefix(tenID)
-	ek := MaxKey
-	if !tenID.IsSystem() {
-		// NB: We use the next tenant's (inclusive) start key as the end key.
-		ek = MakeTenantPrefix(roachpb.MustMakeTenantID(tenID.ToUint64() + 1))
-	}
-	k = k[:len(k):len(k)] // bound capacity, avoid aliasing
+	sp := MakeTenantSpan(tenID)
+	sp.Key = sp.Key[:len(sp.Key):len(sp.Key)]             // bound capacity, avoid aliasing
+	sp.EndKey = sp.EndKey[:len(sp.EndKey):len(sp.EndKey)] // bound capacity, avoid aliasing
 	return SQLCodec{
-		sqlEncoder: sqlEncoder{&k, &ek},
-		sqlDecoder: sqlDecoder{&k},
+		sqlEncoder: sqlEncoder{&sp.Key, &sp.EndKey},
+		sqlDecoder: sqlDecoder{&sp.Key},
 	}
 }
 

--- a/pkg/keys/sql.go
+++ b/pkg/keys/sql.go
@@ -182,6 +182,11 @@ func (e sqlEncoder) TenantPrefix() roachpb.Key {
 	return *e.buf
 }
 
+// TenantEndKey returns the end key of the tenant's keyspace.
+func (e sqlEncoder) TenantEndKey() roachpb.Key {
+	return *e.endKey
+}
+
 // TenantSpan returns a span representing the tenant's keyspace.
 func (e sqlEncoder) TenantSpan() roachpb.Span {
 	key := *e.buf

--- a/pkg/kv/kvclient/kvtenant/tenant_scan_range_descriptors_test.go
+++ b/pkg/kv/kvclient/kvtenant/tenant_scan_range_descriptors_test.go
@@ -65,7 +65,7 @@ func TestScanRangeDescriptors(t *testing.T) {
 	{
 		tc.SplitRangeOrFatal(t, ten2Split1)
 		tc.SplitRangeOrFatal(t, ten2Split2)
-		tc.SplitRangeOrFatal(t, ten2Codec.TenantPrefix().PrefixEnd()) // Last range
+		tc.SplitRangeOrFatal(t, ten2Codec.TenantEndKey()) // Last range
 	}
 
 	iter, err := iteratorFactory.NewIterator(ctx, ten2Codec.TenantSpan())
@@ -119,7 +119,7 @@ func TestScanRangeDescriptors(t *testing.T) {
 	// Last range we created above.
 	require.Equal(
 		t,
-		keys.MustAddr(ten2Codec.TenantPrefix().PrefixEnd()),
+		keys.MustAddr(ten2Codec.TenantEndKey()),
 		rangeDescs[numRanges-1].StartKey,
 	)
 }

--- a/pkg/roachpb/tenant.go
+++ b/pkg/roachpb/tenant.go
@@ -37,7 +37,9 @@ var MinTenantID = MustMakeTenantID(2)
 
 // MaxTenantID is the maximum ID of a (non-system) tenant in a multi-tenant
 // cluster.
-var MaxTenantID = MustMakeTenantID(math.MaxUint64)
+// We use MaxUint64-1 to ensure that we can always compute an end key
+// for the keyspace by adding 1 to the tenant ID.
+var MaxTenantID = MustMakeTenantID(math.MaxUint64 - 1)
 
 func init() {
 	// Inject the string representation of SystemTenantID into the log package

--- a/pkg/rpc/auth_tenant.go
+++ b/pkg/rpc/auth_tenant.go
@@ -482,12 +482,10 @@ func contextWithoutClientTenant(ctx context.Context) context.Context {
 
 func tenantPrefix(tenID roachpb.TenantID) roachpb.RSpan {
 	// TODO(nvanbenschoten): consider caching this span.
-	// TODO(multitenant): Requests which use codec.TenantSpan() might run into
-	// this check. See https://github.com/cockroachdb/cockroach/issues/104928.
-	prefix := roachpb.RKey(keys.MakeTenantPrefix(tenID))
+	sp := keys.MakeTenantSpan(tenID)
 	return roachpb.RSpan{
-		Key:    prefix,
-		EndKey: prefix.PrefixEnd(),
+		Key:    roachpb.RKey(sp.Key),
+		EndKey: roachpb.RKey(sp.EndKey),
 	}
 }
 

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -2466,11 +2466,7 @@ func (s *systemStatusServer) TenantRanges(
 		return nil, status.Error(codes.Internal, "no tenant ID found in context")
 	}
 
-	tenantPrefix := keys.MakeTenantPrefix(tID)
-	tenantKeySpan := roachpb.Span{
-		Key:    tenantPrefix,
-		EndKey: tenantPrefix.PrefixEnd(),
-	}
+	tenantKeySpan := keys.MakeTenantSpan(tID)
 
 	// rangeIDs contains all the `roachpb.RangeID`s found to exist within the
 	// tenant's keyspace.

--- a/pkg/spanconfig/target_test.go
+++ b/pkg/spanconfig/target_test.go
@@ -97,11 +97,8 @@ func TestKeyspaceTargeted(t *testing.T) {
 			expSpan: keys.EverythingSpan,
 		},
 		{
-			target: MakeTargetFromSystemTarget(TestingMakeTenantKeyspaceTargetOrFatal(t, ten10, ten10)),
-			expSpan: roachpb.Span{
-				Key:    keys.MakeTenantPrefix(ten10),
-				EndKey: keys.MakeTenantPrefix(ten10).PrefixEnd(),
-			},
+			target:  MakeTargetFromSystemTarget(TestingMakeTenantKeyspaceTargetOrFatal(t, ten10, ten10)),
+			expSpan: keys.MakeTenantSpan(ten10),
 		},
 		{
 			target: MakeTargetFromSystemTarget(
@@ -116,10 +113,7 @@ func TestKeyspaceTargeted(t *testing.T) {
 			target: MakeTargetFromSystemTarget(
 				TestingMakeTenantKeyspaceTargetOrFatal(t, roachpb.SystemTenantID, ten10),
 			),
-			expSpan: roachpb.Span{
-				Key:    keys.MakeTenantPrefix(ten10),
-				EndKey: keys.MakeTenantPrefix(ten10).PrefixEnd(),
-			},
+			expSpan: keys.MakeTenantSpan(ten10),
 		},
 		{
 			target:  MakeTargetFromSpan(roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("b")}),

--- a/pkg/sql/logictest/testdata/logic_test/tenant_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/tenant_builtins
@@ -31,6 +31,10 @@ SELECT crdb_internal.create_tenant(10, 'invalid_name')
 query error invalid tenant name
 SELECT crdb_internal.create_tenant(10, 'invalid.name')
 
+# The max tenant ID is less or equal to 18446744073709551614.
+query error out of range
+SELECT crdb_internal.create_tenant('{"id":18446744073709551615}'::jsonb)
+
 query I
 SELECT crdb_internal.create_tenant(10, 'tenant-number-ten')
 ----

--- a/pkg/sql/tenant_creation.go
+++ b/pkg/sql/tenant_creation.go
@@ -293,6 +293,9 @@ func CreateTenantRecord(
 		tenID = tenantID.ToUint64()
 		info.ID = tenID
 	}
+	if info.ID > roachpb.MaxTenantID.ToUint64() {
+		return roachpb.TenantID{}, pgerror.Newf(pgcode.ProgramLimitExceeded, "tenant ID %d out of range", info.ID)
+	}
 
 	// Update the ID sequence if available.
 	// We only keep the latest ID.

--- a/pkg/sql/tenant_gc.go
+++ b/pkg/sql/tenant_gc.go
@@ -72,11 +72,7 @@ func GCTenantSync(ctx context.Context, execCfg *ExecutorConfig, info *mtinfopb.T
 
 		// Clear out all span config records left over by the tenant.
 		tenID := roachpb.MustMakeTenantID(info.ID)
-		tenantPrefix := keys.MakeTenantPrefix(tenID)
-		tenantSpan := roachpb.Span{
-			Key:    tenantPrefix,
-			EndKey: tenantPrefix.PrefixEnd(),
-		}
+		tenantSpan := keys.MakeTenantSpan(tenID)
 
 		systemTarget, err := spanconfig.MakeTenantKeyspaceTarget(tenID, tenID)
 		if err != nil {

--- a/pkg/sql/tenant_test.go
+++ b/pkg/sql/tenant_test.go
@@ -72,11 +72,9 @@ func testDestroyTenantSynchronous(ctx context.Context, t *testing.T, sqlDB *gosq
 	const tenantStateQuery = `
 SELECT id, active FROM system.tenants WHERE id = 10
 `
+	tenantSpan := codec.TenantSpan()
 	checkKVsExistForTenant := func(t *testing.T, shouldExist bool) {
-		rows, err := kvDB.Scan(
-			ctx, codec.TenantPrefix(), codec.TenantPrefix().PrefixEnd(),
-			1, /* maxRows */
-		)
+		rows, err := kvDB.Scan(ctx, tenantSpan.Key, tenantSpan.EndKey, 1 /* maxRows */)
 		require.NoError(t, err)
 		require.Equal(t, shouldExist, len(rows) > 0)
 	}


### PR DESCRIPTION
Ever since #104974 we have decided that the exclusive end key of a virtual keyspace is at "current tenant ID + 1", not "start key / PrefixEnd".

This PR completes the investigation requested in #104928 and fixes some bugs in the process.

**See individual commits for details.**

Fixes #104928.
Fixes #110051.
Epic: CRDB-26091