### PR TITLE
ttl: do not remove all table TTL settings on RESET (ttl_expire_after)

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -1895,14 +1895,8 @@ func handleTTLStorageParamChange(
 		}
 	}
 
-	// Add TTL mutation if TTL is newly SET.
-	addTTLMutation := before == nil && after != nil
-
 	// Create new column.
 	if (before == nil || !before.HasDurationExpr()) && (after != nil && after.HasDurationExpr()) {
-		// Adding a TTL requires adding the automatic column and deferring the TTL
-		// addition to after the column is successfully added.
-		addTTLMutation = true
 		if catalog.FindColumnByName(tableDesc, catpb.TTLDefaultExpirationColumnName) != nil {
 			return false, pgerror.Newf(
 				pgcode.InvalidTableDefinition,
@@ -1937,21 +1931,9 @@ func handleTTLStorageParamChange(
 		}
 	}
 
-	// Add TTL mutation so that job is scheduled in SchemaChanger.
-	if addTTLMutation {
-		tableDesc.AddModifyRowLevelTTLMutation(
-			&descpb.ModifyRowLevelTTL{RowLevelTTL: after},
-			descpb.DescriptorMutation_ADD,
-		)
-	}
-
-	dropTTLMutation := before != nil && after == nil
-
 	// Remove existing column.
 	if (before != nil && before.HasDurationExpr()) && (after == nil || !after.HasDurationExpr()) {
 		telemetry.Inc(sqltelemetry.RowLevelTTLDropped)
-		// Create the DROP COLUMN job and the associated mutation.
-		dropTTLMutation = true
 		droppedViews, err := dropColumnImpl(params, tn, tableDesc, after, &tree.AlterTableDropColumn{
 			Column: catpb.TTLDefaultExpirationColumnName,
 		})
@@ -1964,10 +1946,22 @@ func handleTTLStorageParamChange(
 		}
 	}
 
-	if dropTTLMutation {
+	// Adding TTL requires adding the TTL job before adding the TTL fields.
+	// Removing TTL requires removing the TTL job before removing the TTL fields.
+	var direction descpb.DescriptorMutation_Direction
+	switch {
+	case before == nil && after != nil:
+		direction = descpb.DescriptorMutation_ADD
+	case before != nil && after == nil:
+		direction = descpb.DescriptorMutation_DROP
+	default:
+		descriptorChanged = true
+	}
+	if !descriptorChanged {
+		// Add TTL mutation so that job is scheduled in SchemaChanger.
 		tableDesc.AddModifyRowLevelTTLMutation(
 			&descpb.ModifyRowLevelTTL{RowLevelTTL: after},
-			descpb.DescriptorMutation_DROP,
+			direction,
 		)
 	}
 
@@ -1981,7 +1975,7 @@ func handleTTLStorageParamChange(
 		}
 	}
 
-	descriptorChanged = !addTTLMutation && !dropTTLMutation
+	// Modify the TTL fields here because it will not be done in a mutation.
 	if descriptorChanged {
 		tableDesc.RowLevelTTL = after
 	}

--- a/pkg/sql/logictest/testdata/logic_test/row_level_ttl
+++ b/pkg/sql/logictest/testdata/logic_test/row_level_ttl
@@ -1242,7 +1242,7 @@ CREATE TABLE public.tbl_set_both_reset_ttl_expire_after (
   expire_at TIMESTAMPTZ NULL,
   CONSTRAINT tbl_set_both_reset_ttl_expire_after_pkey PRIMARY KEY (id ASC),
   FAMILY fam_0_id_expire_at_crdb_internal_expiration (id, expire_at)
-)
+) WITH (ttl = 'on', ttl_expiration_expression = 'expire_at')
 
 let $label_suffix
 SELECT relname || ' [' || oid || ']' FROM pg_class WHERE relname = 'tbl_set_both_reset_ttl_expire_after'
@@ -1251,6 +1251,7 @@ query TTT
 SELECT schedule_status, recurrence, owner FROM [SHOW SCHEDULES]
 WHERE label = 'row-level-ttl: $label_suffix'
 ----
+ACTIVE  @daily  root
 
 subtest end
 

--- a/pkg/sql/logictest/testdata/logic_test/row_level_ttl
+++ b/pkg/sql/logictest/testdata/logic_test/row_level_ttl
@@ -595,27 +595,31 @@ ALTER TABLE test.public.tbl_ttl_on_noop WITH (ttl = 'on', ...)
 
 subtest end
 
-subtest ttl_job_cron
+subtest ttl_job_cron_invalid
 
 statement error invalid cron expression for "ttl_job_cron"
 CREATE TABLE tbl () WITH (ttl_expire_after = '10 seconds', ttl_job_cron = 'bad expr')
 
+subtest end
+
+subtest create_ttl_job_cron
+
 statement ok
-CREATE TABLE tbl_ttl_job_cron (
+CREATE TABLE tbl_create_ttl_job_cron (
   id INT PRIMARY KEY
 ) WITH (ttl_expire_after = '10 minutes', ttl_job_cron = '@daily')
 
 query T
-SELECT create_statement FROM [SHOW CREATE TABLE tbl_ttl_job_cron]
+SELECT create_statement FROM [SHOW CREATE TABLE tbl_create_ttl_job_cron]
 ----
-CREATE TABLE public.tbl_ttl_job_cron (
+CREATE TABLE public.tbl_create_ttl_job_cron (
   id INT8 NOT NULL,
   crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
-  CONSTRAINT tbl_ttl_job_cron_pkey PRIMARY KEY (id ASC)
+  CONSTRAINT tbl_create_ttl_job_cron_pkey PRIMARY KEY (id ASC)
 ) WITH (ttl = 'on', ttl_expire_after = '00:10:00':::INTERVAL, ttl_job_cron = '@daily')
 
 let $label_suffix
-SELECT relname || ' [' || oid || ']' FROM pg_class WHERE relname = 'tbl_ttl_job_cron'
+SELECT relname || ' [' || oid || ']' FROM pg_class WHERE relname = 'tbl_create_ttl_job_cron'
 
 query TTT
 SELECT schedule_status, recurrence, owner FROM [SHOW SCHEDULES]
@@ -623,18 +627,29 @@ WHERE label = 'row-level-ttl: $label_suffix'
 ----
 ACTIVE  @daily  root
 
+subtest end
+
+subtest set_ttl_job_cron
+
 statement ok
-ALTER TABLE tbl_ttl_job_cron SET (ttl_job_cron = '@weekly')
+CREATE TABLE tbl_set_ttl_job_cron (
+  id INT PRIMARY KEY
+) WITH (ttl_expire_after = '10 minutes', ttl_job_cron = '@daily')
+
+statement ok
+ALTER TABLE tbl_set_ttl_job_cron SET (ttl_job_cron = '@weekly')
 
 query T
-SELECT create_statement FROM [SHOW CREATE TABLE tbl_ttl_job_cron]
+SELECT create_statement FROM [SHOW CREATE TABLE tbl_set_ttl_job_cron]
 ----
-CREATE TABLE public.tbl_ttl_job_cron (
+CREATE TABLE public.tbl_set_ttl_job_cron (
   id INT8 NOT NULL,
   crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
-  CONSTRAINT tbl_ttl_job_cron_pkey PRIMARY KEY (id ASC)
+  CONSTRAINT tbl_set_ttl_job_cron_pkey PRIMARY KEY (id ASC)
 ) WITH (ttl = 'on', ttl_expire_after = '00:10:00':::INTERVAL, ttl_job_cron = '@weekly')
 
+let $label_suffix
+SELECT relname || ' [' || oid || ']' FROM pg_class WHERE relname = 'tbl_set_ttl_job_cron'
 
 query TTT
 SELECT schedule_status, recurrence, owner FROM [SHOW SCHEDULES]
@@ -642,17 +657,29 @@ WHERE label = 'row-level-ttl: $label_suffix'
 ----
 ACTIVE  @weekly  root
 
+subtest end
+
+subtest reset_ttl_job_cron
+
 statement ok
-ALTER TABLE tbl_ttl_job_cron RESET (ttl_job_cron)
+CREATE TABLE tbl_reset_ttl_job_cron (
+  id INT PRIMARY KEY
+) WITH (ttl_expire_after = '10 minutes', ttl_job_cron = '@daily')
+
+statement ok
+ALTER TABLE tbl_reset_ttl_job_cron RESET (ttl_job_cron)
 
 query T
-SELECT create_statement FROM [SHOW CREATE TABLE tbl_ttl_job_cron]
+SELECT create_statement FROM [SHOW CREATE TABLE tbl_reset_ttl_job_cron]
 ----
-CREATE TABLE public.tbl_ttl_job_cron (
+CREATE TABLE public.tbl_reset_ttl_job_cron (
   id INT8 NOT NULL,
   crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
-  CONSTRAINT tbl_ttl_job_cron_pkey PRIMARY KEY (id ASC)
+  CONSTRAINT tbl_reset_ttl_job_cron_pkey PRIMARY KEY (id ASC)
 ) WITH (ttl = 'on', ttl_expire_after = '00:10:00':::INTERVAL)
+
+let $label_suffix
+SELECT relname || ' [' || oid || ']' FROM pg_class WHERE relname = 'tbl_reset_ttl_job_cron'
 
 query TTT
 SELECT schedule_status, recurrence, owner FROM [SHOW SCHEDULES]
@@ -902,19 +929,14 @@ CREATE TABLE public.tbl_add_ttl_expiration_expression_to_ttl_expire_after (
   FAMILY fam_0_id_expire_at_crdb_internal_expiration (id, expire_at, crdb_internal_expiration)
 ) WITH (ttl = 'on', ttl_expire_after = '00:10:00':::INTERVAL, ttl_expiration_expression = 'crdb_internal_expiration')
 
-statement ok
-ALTER TABLE tbl_add_ttl_expiration_expression_to_ttl_expire_after RESET (ttl_expiration_expression)
+let $label_suffix
+SELECT relname || ' [' || oid || ']' FROM pg_class WHERE relname = 'tbl_add_ttl_expiration_expression_to_ttl_expire_after'
 
-query T
-SELECT create_statement FROM [SHOW CREATE TABLE tbl_add_ttl_expiration_expression_to_ttl_expire_after]
+query TTT
+SELECT schedule_status, recurrence, owner FROM [SHOW SCHEDULES]
+WHERE label = 'row-level-ttl: $label_suffix'
 ----
-CREATE TABLE public.tbl_add_ttl_expiration_expression_to_ttl_expire_after (
-  id INT8 NOT NULL,
-  expire_at TIMESTAMPTZ NULL,
-  crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
-  CONSTRAINT tbl_add_ttl_expiration_expression_to_ttl_expire_after_pkey PRIMARY KEY (id ASC),
-  FAMILY fam_0_id_expire_at_crdb_internal_expiration (id, expire_at, crdb_internal_expiration)
-) WITH (ttl = 'on', ttl_expire_after = '00:10:00':::INTERVAL)
+ACTIVE  @daily  root
 
 subtest end
 
@@ -941,18 +963,14 @@ CREATE TABLE public.tbl_add_ttl_expire_after_to_ttl_expiration_expression (
   FAMILY fam_0_id_expire_at (id, expire_at, crdb_internal_expiration)
 ) WITH (ttl = 'on', ttl_expire_after = '00:10:00':::INTERVAL, ttl_expiration_expression = 'expire_at')
 
-statement ok
-ALTER TABLE tbl_add_ttl_expire_after_to_ttl_expiration_expression RESET (ttl_expire_after)
+let $label_suffix
+SELECT relname || ' [' || oid || ']' FROM pg_class WHERE relname = 'tbl_add_ttl_expire_after_to_ttl_expiration_expression'
 
-query T
-SELECT create_statement FROM [SHOW CREATE TABLE tbl_add_ttl_expire_after_to_ttl_expiration_expression]
+query TTT
+SELECT schedule_status, recurrence, owner FROM [SHOW SCHEDULES]
+WHERE label = 'row-level-ttl: $label_suffix'
 ----
-CREATE TABLE public.tbl_add_ttl_expire_after_to_ttl_expiration_expression (
-  id INT8 NOT NULL,
-  expire_at TIMESTAMPTZ NULL,
-  CONSTRAINT tbl_add_ttl_expire_after_to_ttl_expiration_expression_pkey PRIMARY KEY (id ASC),
-  FAMILY fam_0_id_expire_at (id, expire_at)
-)
+ACTIVE  @daily  root
 
 subtest end
 
@@ -1197,5 +1215,79 @@ ALTER TABLE test.public."Table-Name" WITH (ttl = 'on', ...)
 
 statement ok
 DROP TABLE "Table-Name"
+
+subtest end
+
+# sets both ttl_exipire_after and ttl_expiration_expression
+subtest set_both_reset_ttl_expire_after
+
+statement ok
+CREATE TABLE tbl_set_both_reset_ttl_expire_after (
+  id INT PRIMARY KEY,
+  expire_at TIMESTAMPTZ,
+  FAMILY (id, expire_at)
+) WITH (
+  ttl_expire_after = '10m',
+  ttl_expiration_expression = 'expire_at'
+)
+
+statement ok
+ALTER TABLE tbl_set_both_reset_ttl_expire_after RESET (ttl_expire_after)
+
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE tbl_set_both_reset_ttl_expire_after]
+----
+CREATE TABLE public.tbl_set_both_reset_ttl_expire_after (
+  id INT8 NOT NULL,
+  expire_at TIMESTAMPTZ NULL,
+  CONSTRAINT tbl_set_both_reset_ttl_expire_after_pkey PRIMARY KEY (id ASC),
+  FAMILY fam_0_id_expire_at_crdb_internal_expiration (id, expire_at)
+)
+
+let $label_suffix
+SELECT relname || ' [' || oid || ']' FROM pg_class WHERE relname = 'tbl_set_both_reset_ttl_expire_after'
+
+query TTT
+SELECT schedule_status, recurrence, owner FROM [SHOW SCHEDULES]
+WHERE label = 'row-level-ttl: $label_suffix'
+----
+
+subtest end
+
+# sets both ttl_exipire_after and ttl_expiration_expression
+subtest set_both_reset_ttl_expiration_expression
+
+statement ok
+CREATE TABLE tbl_set_both_reset_ttl_expiration_expression (
+  id INT PRIMARY KEY,
+  expire_at TIMESTAMPTZ,
+  FAMILY (id, expire_at)
+) WITH (
+  ttl_expire_after = '10m',
+  ttl_expiration_expression = 'expire_at'
+)
+
+statement ok
+ALTER TABLE tbl_set_both_reset_ttl_expiration_expression RESET (ttl_expiration_expression)
+
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE tbl_set_both_reset_ttl_expiration_expression]
+----
+CREATE TABLE public.tbl_set_both_reset_ttl_expiration_expression (
+  id INT8 NOT NULL,
+  expire_at TIMESTAMPTZ NULL,
+  crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
+  CONSTRAINT tbl_set_both_reset_ttl_expiration_expression_pkey PRIMARY KEY (id ASC),
+  FAMILY fam_0_id_expire_at_crdb_internal_expiration (id, expire_at, crdb_internal_expiration)
+) WITH (ttl = 'on', ttl_expire_after = '00:10:00':::INTERVAL)
+
+let $label_suffix
+SELECT relname || ' [' || oid || ']' FROM pg_class WHERE relname = 'tbl_set_both_reset_ttl_expiration_expression'
+
+query TTT
+SELECT schedule_status, recurrence, owner FROM [SHOW SCHEDULES]
+WHERE label = 'row-level-ttl: $label_suffix'
+----
+ACTIVE  @daily  root
 
 subtest end

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -1595,13 +1595,13 @@ func (sc *SchemaChanger) done(ctx context.Context) error {
 
 			// If we are modifying TTL, then make sure the schedules are created
 			// or dropped as appropriate.
-			scheduledJobs := jobs.ScheduledJobTxn(txn)
 			if modify := m.AsModifyRowLevelTTL(); modify != nil && !modify.IsRollback() {
 				if fn := sc.testingKnobs.RunBeforeModifyRowLevelTTL; fn != nil {
 					if err := fn(); err != nil {
 						return err
 					}
 				}
+				scheduledJobs := jobs.ScheduledJobTxn(txn)
 				if m.Adding() {
 					scTable.RowLevelTTL = modify.RowLevelTTL()
 					shouldCreateScheduledJob := scTable.RowLevelTTL.ScheduleID == 0
@@ -1642,7 +1642,7 @@ func (sc *SchemaChanger) done(ctx context.Context) error {
 							return err
 						}
 					}
-					scTable.RowLevelTTL = nil
+					scTable.RowLevelTTL = modify.RowLevelTTL()
 				}
 			}
 

--- a/pkg/sql/show_create_external_connection.go
+++ b/pkg/sql/show_create_external_connection.go
@@ -120,8 +120,8 @@ func (p *planner) ShowCreateExternalConnection(
 			var rows []tree.Datums
 			for _, conn := range connections {
 				row := tree.Datums{
-					scheduleID: tree.NewDString(conn.ConnectionName()),
-					createStmt: tree.NewDString(conn.UnredactedConnectionStatement()),
+					scheduleIDIdx: tree.NewDString(conn.ConnectionName()),
+					createStmtIdx: tree.NewDString(conn.UnredactedConnectionStatement()),
 				}
 				rows = append(rows, row)
 			}

--- a/pkg/sql/show_create_schedule.go
+++ b/pkg/sql/show_create_schedule.go
@@ -32,8 +32,8 @@ var showCreateTableColumns = colinfo.ResultColumns{
 }
 
 const (
-	scheduleID = iota
-	createStmt
+	scheduleIDIdx = iota
+	createStmtIdx
 )
 
 func loadSchedules(params runParams, n *tree.ShowCreateSchedules) ([]*jobs.ScheduledJob, error) {
@@ -118,8 +118,8 @@ func (p *planner) ShowCreateSchedule(
 				}
 
 				row := tree.Datums{
-					scheduleID: tree.NewDInt(tree.DInt(sj.ScheduleID())),
-					createStmt: tree.NewDString(createStmtStr),
+					scheduleIDIdx: tree.NewDInt(tree.DInt(sj.ScheduleID())),
+					createStmtIdx: tree.NewDString(createStmtStr),
 				}
 				rows = append(rows, row)
 			}


### PR DESCRIPTION
Fixes #109138

Previously running `RESET (ttl_expire_after)` would remove all table TTL
settings if `ttl_expiration_expression` was set.

This PR fixes the schema changer to only remove all TTL settings on
`RESET (ttl)`.

Release note (bug fix): `RESET (ttl_expire_after)` no longer incorrectly
removes `ttl_expiration_expression`.