### PR TITLE
sql: switch discarded stats logging to a time interval

### DIFF
--- a/pkg/sql/sqlstats/cluster_settings.go
+++ b/pkg/sql/sqlstats/cluster_settings.go
@@ -115,6 +115,16 @@ var MaxMemReportedSQLStatsTxnFingerprints = settings.RegisterIntSetting(
 	100000,
 	settings.WithPublic)
 
+// DiscardedStatsLogInterval specifies the interval between log emissions for discarded
+// statement and transaction statistics due to reaching the SQL statistics memory limit.
+var DiscardedStatsLogInterval = settings.RegisterDurationSetting(
+	settings.TenantWritable,
+	"sql.metrics.discarded_stats.log_interval",
+	"interval between log emissions for discarded statistics due to SQL statistics memory limit",
+	1*time.Minute,
+	settings.NonNegativeDuration,
+	settings.WithVisibility(settings.Reserved))
+
 // MaxSQLStatsStmtFingerprintsPerExplicitTxn specifies the maximum of unique statement
 // fingerprints we store for each explicit transaction.
 //


### PR DESCRIPTION
To mitigate the OOM issues induced by frequent logging upon the end of
every transaction in the case of discarded stmt/txn stats, this commit
introduces a switch from per-transaction logging to time-interval-based
logging. An internal cluster setting,
`sql.metrcs.discarded_stats.log_interval`, is added to adjust this
interval.

Informs: https://cockroachlabs.atlassian.net/browse/SREOPS-7255

Release note (sql change): discarded stats warning log frequency is now
controlled by a cluster setting, defaulting to a 1-minute interval.