### PR TITLE
tenantcostclient: relax expectation in RU estimate test

### DIFF
--- a/pkg/ccl/multitenantccl/tenantcostclient/query_ru_estimate_test.go
+++ b/pkg/ccl/multitenantccl/tenantcostclient/query_ru_estimate_test.go
@@ -195,7 +195,7 @@ func TestEstimateQueryRUConsumption(t *testing.T) {
 	// Check the estimated RU aggregate for all the queries against the actual
 	// measured RU consumption for the tenant.
 	tenantMeasuredRUs = getTenantRUs() - tenantStartRUs
-	const deltaFraction = 0.05
+	const deltaFraction = 0.25
 	allowedDelta := tenantMeasuredRUs * deltaFraction
 	require.InDeltaf(t, tenantMeasuredRUs, tenantEstimatedRUs, allowedDelta,
 		"estimated RUs (%d) were not within %f RUs of the expected value (%f)",


### PR DESCRIPTION
In #106769 we tightened the RU estimate test to use 0.05 allowance, but we just saw a case where the difference was on the order of 0.2, so this commit bumps the allowed delta to 0.25 (which is still much better than 0.75 before #106769).

Fixes: #109732.

Release note: None