### PR TITLE
kvserver: requests that acquire repl locks should use read-write path

### DIFF
--- a/pkg/ccl/changefeedccl/kvfeed/scanner.go
+++ b/pkg/ccl/changefeedccl/kvfeed/scanner.go
@@ -188,7 +188,7 @@ func (p *scanRequestScanner) exportSpan(
 	for remaining := &span; remaining != nil; {
 		start := timeutil.Now()
 		b := txn.NewBatch()
-		r := kvpb.NewScan(remaining.Key, remaining.EndKey, kvpb.NonLocking).(*kvpb.ScanRequest)
+		r := kvpb.NewScan(remaining.Key, remaining.EndKey).(*kvpb.ScanRequest)
 		r.ScanFormat = kvpb.BATCH_RESPONSE
 		b.Header.TargetBytes = targetBytesPerScan
 		b.AdmissionHeader = kvpb.AdmissionHeader{

--- a/pkg/cli/debug_send_kv_batch_test.go
+++ b/pkg/cli/debug_send_kv_batch_test.go
@@ -37,7 +37,7 @@ func TestSendKVBatchExample(t *testing.T) {
 
 	var ba kvpb.BatchRequest
 	ba.Add(kvpb.NewPut(roachpb.Key("foo"), roachpb.MakeValueFromString("bar")))
-	ba.Add(kvpb.NewGet(roachpb.Key("foo"), kvpb.NonLocking))
+	ba.Add(kvpb.NewGet(roachpb.Key("foo")))
 
 	// NOTE: This cannot be marshaled using the standard Go JSON marshaler,
 	// since it does not correctly (un)marshal the JSON as mandated by the
@@ -72,7 +72,7 @@ func TestSendKVBatch(t *testing.T) {
 	// Protobuf spec. Instead, use the JSON marshaler shipped with Protobuf.
 	var ba kvpb.BatchRequest
 	ba.Add(kvpb.NewPut(roachpb.Key("foo"), roachpb.MakeValueFromString("bar")))
-	ba.Add(kvpb.NewGet(roachpb.Key("foo"), kvpb.NonLocking))
+	ba.Add(kvpb.NewGet(roachpb.Key("foo")))
 
 	jsonpb := protoutil.JSONPb{}
 	jsonProto, err := jsonpb.Marshal(&ba)

--- a/pkg/kv/kvclient/kvcoord/dist_sender_ambiguous_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_ambiguous_test.go
@@ -402,7 +402,7 @@ func TestTransactionUnexpectedlyCommitted(t *testing.T) {
 	getInBatch := func(t *testing.T, ctx context.Context, txn *kv.Txn, keys ...roachpb.Key) []int64 {
 		batch := txn.NewBatch()
 		for _, key := range keys {
-			batch.GetForUpdate(key)
+			batch.GetForUpdate(key, kvpb.BestEffort)
 		}
 		assert.NoError(t, txn.Run(ctx, batch))
 		assert.Len(t, batch.Results, len(keys))

--- a/pkg/kv/kvclient/kvcoord/dist_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_test.go
@@ -489,7 +489,7 @@ func TestSendRPCOrder(t *testing.T) {
 				RangeID:       rangeID, // Not used in this test, but why not.
 				RoutingPolicy: tc.routingPolicy,
 			}
-			req := kvpb.NewScan(roachpb.Key("a"), roachpb.Key("b"), kvpb.NonLocking)
+			req := kvpb.NewScan(roachpb.Key("a"), roachpb.Key("b"))
 			_, pErr := kv.SendWrappedWith(ctx, ds, header, req)
 			require.Nil(t, pErr)
 		})
@@ -950,7 +950,7 @@ func TestNoBackoffOnNotLeaseHolderErrorFromFollowerRead(t *testing.T) {
 		Lease: lease,
 	})
 
-	get := kvpb.NewGet(roachpb.Key("a"), kvpb.NonLocking)
+	get := kvpb.NewGet(roachpb.Key("a"))
 	_, pErr := kv.SendWrapped(ctx, ds, get)
 	require.Nil(t, pErr)
 	require.Equal(t, []roachpb.NodeID{1, 2}, sentTo)
@@ -1022,7 +1022,7 @@ func TestNoBackoffOnNotLeaseHolderErrorWithoutLease(t *testing.T) {
 
 	// Send a request. It should try all three replicas once: the first two fail
 	// with NLHE, the third one succeeds. None of them should trigger backoffs.
-	_, pErr := kv.SendWrapped(ctx, ds, kvpb.NewGet(roachpb.Key("a"), kvpb.NonLocking))
+	_, pErr := kv.SendWrapped(ctx, ds, kvpb.NewGet(roachpb.Key("a")))
 	require.NoError(t, pErr.GoError())
 	require.Equal(t, []roachpb.NodeID{1, 2, 3}, sentTo)
 	require.Equal(t, int64(0), ds.Metrics().InLeaseTransferBackoffs.Count())
@@ -1118,7 +1118,7 @@ func TestDistSenderMovesOnFromReplicaWithStaleLease(t *testing.T) {
 		Lease: cachedLease,
 	})
 
-	get := kvpb.NewGet(roachpb.Key("a"), kvpb.NonLocking)
+	get := kvpb.NewGet(roachpb.Key("a"))
 	_, pErr := kv.SendWrapped(ctx, ds, get)
 	require.Nil(t, pErr)
 
@@ -1240,7 +1240,7 @@ func TestDistSenderIgnoresNLHEBasedOnOldRangeGeneration(t *testing.T) {
 				Lease: cachedLease,
 			})
 
-			get := kvpb.NewGet(roachpb.Key("a"), kvpb.NonLocking)
+			get := kvpb.NewGet(roachpb.Key("a"))
 			_, pErr := kv.SendWrapped(ctx, ds, get)
 			require.Nil(t, pErr)
 
@@ -1349,7 +1349,7 @@ func TestDistSenderRetryOnTransportErrors(t *testing.T) {
 				Lease: cachedLease,
 			})
 
-			get := kvpb.NewGet(roachpb.Key("a"), kvpb.NonLocking)
+			get := kvpb.NewGet(roachpb.Key("a"))
 			_, pErr := kv.SendWrapped(ctx, ds, get)
 			if spec.shouldRetry {
 				require.True(t, secondReplicaTried, "Second replica was not retried")
@@ -1903,7 +1903,7 @@ func TestRetryOnWrongReplicaError(t *testing.T) {
 		Settings:           cluster.MakeTestingClusterSettings(),
 	}
 	ds := NewDistSender(cfg)
-	scan := kvpb.NewScan(roachpb.Key("a"), roachpb.Key("d"), kvpb.NonLocking)
+	scan := kvpb.NewScan(roachpb.Key("a"), roachpb.Key("d"))
 	if _, err := kv.SendWrapped(context.Background(), ds, scan); err != nil {
 		t.Errorf("scan encountered error: %s", err)
 	}
@@ -2007,7 +2007,7 @@ func TestRetryOnWrongReplicaErrorWithSuggestion(t *testing.T) {
 		RPCRetryOptions: &retry.Options{MaxRetries: 1},
 	}
 	ds := NewDistSender(cfg)
-	scan := kvpb.NewScan(roachpb.Key("a"), roachpb.Key("d"), kvpb.NonLocking)
+	scan := kvpb.NewScan(roachpb.Key("a"), roachpb.Key("d"))
 	if _, err := kv.SendWrapped(context.Background(), ds, scan); err != nil {
 		t.Errorf("scan encountered error: %s", err)
 	}
@@ -2127,7 +2127,7 @@ func TestSendRPCRetry(t *testing.T) {
 		Settings:          cluster.MakeTestingClusterSettings(),
 	}
 	ds := NewDistSender(cfg)
-	scan := kvpb.NewScan(roachpb.Key("a"), roachpb.Key("d"), kvpb.NonLocking)
+	scan := kvpb.NewScan(roachpb.Key("a"), roachpb.Key("d"))
 	sr, err := kv.SendWrappedWith(ctx, ds, kvpb.Header{MaxSpanRequestKeys: 1}, scan)
 	if err != nil {
 		t.Fatal(err)
@@ -2253,7 +2253,7 @@ func TestDistSenderDescriptorUpdatesOnSuccessfulRPCs(t *testing.T) {
 
 			// Send a request that's going to receive a response with a RangeInfo.
 			k := roachpb.Key("a")
-			get := kvpb.NewGet(k, kvpb.NonLocking)
+			get := kvpb.NewGet(k)
 			ba := &kvpb.BatchRequest{}
 			ba.Add(get)
 			_, pErr := ds.Send(ctx, ba)
@@ -2366,7 +2366,7 @@ func TestSendRPCRangeNotFoundError(t *testing.T) {
 		Settings:          cluster.MakeTestingClusterSettings(),
 	}
 	ds = NewDistSender(cfg)
-	get := kvpb.NewGet(roachpb.Key("b"), kvpb.NonLocking)
+	get := kvpb.NewGet(roachpb.Key("b"))
 	_, err := kv.SendWrapped(ctx, ds, get)
 	if err != nil {
 		t.Fatal(err)
@@ -2462,8 +2462,8 @@ func TestMultiRangeGapReverse(t *testing.T) {
 
 	ba := &kvpb.BatchRequest{}
 	ba.Txn = &txn
-	ba.Add(kvpb.NewReverseScan(splits[0], splits[1], kvpb.NonLocking))
-	ba.Add(kvpb.NewReverseScan(splits[2], splits[3], kvpb.NonLocking))
+	ba.Add(kvpb.NewReverseScan(splits[0], splits[1]))
+	ba.Add(kvpb.NewReverseScan(splits[2], splits[3]))
 
 	// Before fixing https://github.com/cockroachdb/cockroach/issues/18174, this
 	// would error with:
@@ -2564,7 +2564,7 @@ func TestMultiRangeMergeStaleDescriptor(t *testing.T) {
 		Settings: cluster.MakeTestingClusterSettings(),
 	}
 	ds := NewDistSender(cfg)
-	scan := kvpb.NewScan(roachpb.Key("a"), roachpb.Key("d"), kvpb.NonLocking)
+	scan := kvpb.NewScan(roachpb.Key("a"), roachpb.Key("d"))
 	// Set the Txn info to avoid an OpRequiresTxnError.
 	reply, err := kv.SendWrappedWith(ctx, ds, kvpb.Header{
 		MaxSpanRequestKeys: 10,
@@ -2918,7 +2918,6 @@ func TestTruncateWithLocalSpanAndDescriptor(t *testing.T) {
 	ba.Add(kvpb.NewScan(
 		keys.RangeDescriptorKey(roachpb.RKey("a")),
 		keys.RangeDescriptorKey(roachpb.RKey("c")),
-		kvpb.NonLocking,
 	))
 
 	if _, pErr := ds.Send(ctx, ba); pErr != nil {
@@ -4038,19 +4037,19 @@ func TestCanSendToFollower(t *testing.T) {
 			kvpb.Header{
 				Txn: &roachpb.Transaction{},
 			},
-			kvpb.NewGet(roachpb.Key("a"), kvpb.NonLocking),
+			kvpb.NewGet(roachpb.Key("a")),
 			1,
 		},
 		{
 			true,
 			kvpb.Header{},
-			kvpb.NewGet(roachpb.Key("a"), kvpb.NonLocking),
+			kvpb.NewGet(roachpb.Key("a")),
 			1,
 		},
 		{
 			false,
 			kvpb.Header{},
-			kvpb.NewGet(roachpb.Key("a"), kvpb.NonLocking),
+			kvpb.NewGet(roachpb.Key("a")),
 			2,
 		},
 	} {
@@ -4241,7 +4240,7 @@ func TestEvictMetaRange(t *testing.T) {
 		}
 		ds := NewDistSender(cfg)
 
-		scan := kvpb.NewScan(roachpb.Key("a"), roachpb.Key("b"), kvpb.NonLocking)
+		scan := kvpb.NewScan(roachpb.Key("a"), roachpb.Key("b"))
 		if _, pErr := kv.SendWrapped(ctx, ds, scan); pErr != nil {
 			t.Fatalf("scan encountered error: %s", pErr)
 		}
@@ -4256,7 +4255,7 @@ func TestEvictMetaRange(t *testing.T) {
 		// Simulate a split on the meta2 range and mark it as stale.
 		isStale = true
 
-		scan = kvpb.NewScan(roachpb.Key("b"), roachpb.Key("c"), kvpb.NonLocking)
+		scan = kvpb.NewScan(roachpb.Key("b"), roachpb.Key("c"))
 		if _, pErr := kv.SendWrapped(ctx, ds, scan); pErr != nil {
 			t.Fatalf("scan encountered error: %s", pErr)
 		}
@@ -4570,13 +4569,13 @@ func TestRequestSubdivisionAfterDescriptorChange(t *testing.T) {
 	splitKey := keys.MustAddr(keyB)
 
 	get := func(k roachpb.Key) kvpb.Request {
-		return kvpb.NewGet(k, kvpb.NonLocking)
+		return kvpb.NewGet(k)
 	}
 	scan := func(k roachpb.Key) kvpb.Request {
-		return kvpb.NewScan(k, k.Next(), kvpb.NonLocking)
+		return kvpb.NewScan(k, k.Next())
 	}
 	revScan := func(k roachpb.Key) kvpb.Request {
-		return kvpb.NewReverseScan(k, k.Next(), kvpb.NonLocking)
+		return kvpb.NewReverseScan(k, k.Next())
 	}
 
 	for _, tc := range []struct {
@@ -4709,7 +4708,7 @@ func TestRequestSubdivisionAfterDescriptorChangeWithUnavailableReplicasTerminate
 	splitKey := keys.MustAddr(keyB)
 
 	get := func(k roachpb.Key) kvpb.Request {
-		return kvpb.NewGet(k, kvpb.NonLocking)
+		return kvpb.NewGet(k)
 	}
 
 	ctx := context.Background()
@@ -4802,13 +4801,13 @@ func TestDescriptorChangeAfterRequestSubdivision(t *testing.T) {
 	laterSplitKey2 := keys.MustAddr(keyD)
 
 	get := func(k roachpb.Key) kvpb.Request {
-		return kvpb.NewGet(k, kvpb.NonLocking)
+		return kvpb.NewGet(k)
 	}
 	scan := func(k roachpb.Key) kvpb.Request {
-		return kvpb.NewScan(k, k.Next(), kvpb.NonLocking)
+		return kvpb.NewScan(k, k.Next())
 	}
 	revScan := func(k roachpb.Key) kvpb.Request {
-		return kvpb.NewReverseScan(k, k.Next(), kvpb.NonLocking)
+		return kvpb.NewReverseScan(k, k.Next())
 	}
 
 	for _, tc := range []struct {

--- a/pkg/kv/kvclient/kvcoord/transport_test.go
+++ b/pkg/kv/kvclient/kvcoord/transport_test.go
@@ -154,7 +154,7 @@ func TestResponseVerifyFailure(t *testing.T) {
 	}
 
 	ba := &kvpb.BatchRequest{}
-	req := kvpb.NewScan(roachpb.KeyMin, roachpb.KeyMax, kvpb.NonLocking)
+	req := kvpb.NewScan(roachpb.KeyMin, roachpb.KeyMax)
 	ba.Add(req)
 	br := ba.CreateReply()
 	resp := br.Responses[0].GetInner().(*kvpb.ScanResponse)

--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender_savepoints_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender_savepoints_test.go
@@ -174,7 +174,7 @@ func TestSavepoints(t *testing.T) {
 			case "get":
 				b := txn.NewBatch()
 				if td.HasArg("locking") {
-					b.GetForUpdate(td.CmdArgs[0].Key)
+					b.GetForUpdate(td.CmdArgs[0].Key, kvpb.BestEffort)
 				} else {
 					b.Get(td.CmdArgs[0].Key)
 				}

--- a/pkg/kv/kvclient/kvstreamer/streamer_test.go
+++ b/pkg/kv/kvclient/kvstreamer/streamer_test.go
@@ -90,7 +90,7 @@ func TestStreamerLimitations(t *testing.T) {
 		defer streamer.Close(ctx)
 		streamer.Init(kvstreamer.OutOfOrder, kvstreamer.Hints{UniqueRequests: true}, 1 /* maxKeysPerRow */, nil /* diskBuffer */)
 		k := append(s.Codec().TenantPrefix(), roachpb.Key("key")...)
-		get := kvpb.NewGet(k, kvpb.NonLocking)
+		get := kvpb.NewGet(k)
 		reqs := []kvpb.RequestUnion{{
 			Value: &kvpb.RequestUnion_Get{
 				Get: get.(*kvpb.GetRequest),

--- a/pkg/kv/kvnemesis/applier.go
+++ b/pkg/kv/kvnemesis/applier.go
@@ -237,15 +237,15 @@ type dbRunI interface {
 type clientI interface {
 	dbRunI
 	Get(context.Context, interface{}) (kv.KeyValue, error)
-	GetForUpdate(context.Context, interface{}) (kv.KeyValue, error)
-	GetForShare(context.Context, interface{}) (kv.KeyValue, error)
+	GetForUpdate(context.Context, interface{}, kvpb.KeyLockingDurabilityType) (kv.KeyValue, error)
+	GetForShare(context.Context, interface{}, kvpb.KeyLockingDurabilityType) (kv.KeyValue, error)
 	Put(context.Context, interface{}, interface{}) error
 	Scan(context.Context, interface{}, interface{}, int64) ([]kv.KeyValue, error)
-	ScanForUpdate(context.Context, interface{}, interface{}, int64) ([]kv.KeyValue, error)
-	ScanForShare(context.Context, interface{}, interface{}, int64) ([]kv.KeyValue, error)
+	ScanForUpdate(context.Context, interface{}, interface{}, int64, kvpb.KeyLockingDurabilityType) ([]kv.KeyValue, error)
+	ScanForShare(context.Context, interface{}, interface{}, int64, kvpb.KeyLockingDurabilityType) ([]kv.KeyValue, error)
 	ReverseScan(context.Context, interface{}, interface{}, int64) ([]kv.KeyValue, error)
-	ReverseScanForUpdate(context.Context, interface{}, interface{}, int64) ([]kv.KeyValue, error)
-	ReverseScanForShare(context.Context, interface{}, interface{}, int64) ([]kv.KeyValue, error)
+	ReverseScanForUpdate(context.Context, interface{}, interface{}, int64, kvpb.KeyLockingDurabilityType) ([]kv.KeyValue, error)
+	ReverseScanForShare(context.Context, interface{}, interface{}, int64, kvpb.KeyLockingDurabilityType) ([]kv.KeyValue, error)
 	Del(context.Context, ...interface{}) ([]roachpb.Key, error)
 	DelRange(context.Context, interface{}, interface{}, bool) ([]roachpb.Key, error)
 }
@@ -280,18 +280,18 @@ func batchRun(
 func applyClientOp(ctx context.Context, db clientI, op *Operation, inTxn bool) {
 	switch o := op.GetValue().(type) {
 	case *GetOperation:
-		fn := (*kv.Batch).Get
-		if o.ForUpdate {
-			fn = (*kv.Batch).GetForUpdate
-		}
-		if o.ForShare {
-			fn = (*kv.Batch).GetForShare
-		}
 		res, ts, err := dbRunWithResultAndTimestamp(ctx, db, func(b *kv.Batch) {
 			if o.SkipLocked {
 				b.Header.WaitPolicy = lock.WaitPolicy_SkipLocked
 			}
-			fn(b, o.Key)
+			dur := kvpb.BestEffort
+			if o.ForUpdate {
+				b.GetForUpdate(o.Key, dur)
+			} else if o.ForShare {
+				b.GetForShare(o.Key, dur)
+			} else {
+				b.Get(o.Key)
+			}
 		})
 		o.Result = resultInit(ctx, err)
 		if err != nil {
@@ -316,29 +316,28 @@ func applyClientOp(ctx context.Context, db clientI, op *Operation, inTxn bool) {
 		}
 		o.Result.OptionalTimestamp = ts
 	case *ScanOperation:
-		fn := (*kv.Batch).Scan
-		if o.Reverse {
-			if o.ForUpdate {
-				fn = (*kv.Batch).ReverseScanForUpdate
-			} else if o.ForShare {
-				fn = (*kv.Batch).ReverseScanForShare
-			} else {
-				fn = (*kv.Batch).ReverseScan
-			}
-		} else {
-			if o.ForUpdate {
-				fn = (*kv.Batch).ScanForUpdate
-			} else if o.ForShare {
-				fn = (*kv.Batch).ScanForShare
-			} else {
-				fn = (*kv.Batch).Scan
-			}
-		}
 		res, ts, err := dbRunWithResultAndTimestamp(ctx, db, func(b *kv.Batch) {
 			if o.SkipLocked {
 				b.Header.WaitPolicy = lock.WaitPolicy_SkipLocked
 			}
-			fn(b, o.Key, o.EndKey)
+			dur := kvpb.BestEffort
+			if o.Reverse {
+				if o.ForUpdate {
+					b.ReverseScanForUpdate(o.Key, o.EndKey, dur)
+				} else if o.ForShare {
+					b.ReverseScanForShare(o.Key, o.EndKey, dur)
+				} else {
+					b.ReverseScan(o.Key, o.EndKey)
+				}
+			} else {
+				if o.ForUpdate {
+					b.ScanForUpdate(o.Key, o.EndKey, dur)
+				} else if o.ForShare {
+					b.ScanForShare(o.Key, o.EndKey, dur)
+				} else {
+					b.Scan(o.Key, o.EndKey)
+				}
+			}
 		})
 		o.Result = resultInit(ctx, err)
 		if err != nil {
@@ -443,8 +442,10 @@ func applyBatchOp(
 	for i := range o.Ops {
 		switch subO := o.Ops[i].GetValue().(type) {
 		case *GetOperation:
+			// TODO(arul): Looks like I forgot to add shared locks here.
+			dur := kvpb.BestEffort
 			if subO.ForUpdate {
-				b.GetForUpdate(subO.Key)
+				b.GetForUpdate(subO.Key, dur)
 			} else {
 				b.Get(subO.Key)
 			}
@@ -452,12 +453,13 @@ func applyBatchOp(
 			b.Put(subO.Key, subO.Value())
 			setLastReqSeq(b, subO.Seq)
 		case *ScanOperation:
+			dur := kvpb.BestEffort
 			if subO.Reverse && subO.ForUpdate {
-				b.ReverseScanForUpdate(subO.Key, subO.EndKey)
+				b.ReverseScanForUpdate(subO.Key, subO.EndKey, dur)
 			} else if subO.Reverse {
 				b.ReverseScan(subO.Key, subO.EndKey)
 			} else if subO.ForUpdate {
-				b.ScanForUpdate(subO.Key, subO.EndKey)
+				b.ScanForUpdate(subO.Key, subO.EndKey, dur)
 			} else {
 				b.Scan(subO.Key, subO.EndKey)
 			}

--- a/pkg/kv/kvpb/api.go
+++ b/pkg/kv/kvpb/api.go
@@ -1189,15 +1189,29 @@ func (r *IsSpanEmptyRequest) ShallowCopy() Request {
 	return &shallowCopy
 }
 
-// NewGet returns a Request initialized to get the value at key. If
-// forUpdate is true, an unreplicated, exclusive lock is acquired on on
-// the key, if it exists.
-func NewGet(key roachpb.Key, str KeyLockingStrengthType) Request {
+// NewLockingGet returns a Request initialized to get the value at key. A lock
+// corresponding to the supplied lock strength and durability is acquired on the
+// key, if it exists.
+func NewLockingGet(
+	key roachpb.Key, str KeyLockingStrengthType, dur KeyLockingDurabilityType,
+) Request {
 	return &GetRequest{
 		RequestHeader: RequestHeader{
 			Key: key,
 		},
-		KeyLockingStrength: scanLockStrength(str),
+		KeyLockingStrength:   scanLockStrength(str),
+		KeyLockingDurability: scanLockDurability(dur),
+	}
+}
+
+// NewGet returns a Request initialized to get the value at key. No lock is
+// acquired on the key, even if it exists.
+func NewGet(key roachpb.Key) Request {
+	return &GetRequest{
+		RequestHeader: RequestHeader{
+			Key: key,
+		},
+		KeyLockingStrength: lock.None,
 	}
 }
 
@@ -1314,29 +1328,59 @@ func NewDeleteRange(startKey, endKey roachpb.Key, returnKeys bool) Request {
 	}
 }
 
-// NewScan returns a Request initialized to scan from start to end keys.
-// If forUpdate is true, unreplicated, exclusive locks are acquired on
-// each of the resulting keys.
-func NewScan(key, endKey roachpb.Key, str KeyLockingStrengthType) Request {
+// NewLockingScan returns a Request initialized to scan from start to end keys.
+// A lock corresponding to the supplied lock strength and durability will be
+// acquired on each of the resulting keys.
+func NewLockingScan(
+	key, endKey roachpb.Key, str KeyLockingStrengthType, dur KeyLockingDurabilityType,
+) Request {
 	return &ScanRequest{
 		RequestHeader: RequestHeader{
 			Key:    key,
 			EndKey: endKey,
 		},
-		KeyLockingStrength: scanLockStrength(str),
+		KeyLockingStrength:   scanLockStrength(str),
+		KeyLockingDurability: scanLockDurability(dur),
 	}
 }
 
-// NewReverseScan returns a Request initialized to reverse scan from end.
-// If forUpdate is true, unreplicated, exclusive locks are acquired on
-// each of the resulting keys.
-func NewReverseScan(key, endKey roachpb.Key, str KeyLockingStrengthType) Request {
+// NewScan returns a Request initialized to scan from start to end keys. No
+// locks will be acquired on the resulting keys.
+func NewScan(key, endKey roachpb.Key) Request {
+	return &ScanRequest{
+		RequestHeader: RequestHeader{
+			Key:    key,
+			EndKey: endKey,
+		},
+		KeyLockingStrength: lock.None,
+	}
+}
+
+// NewLockingReverseScan returns a Request initialized to reverse scan from end.
+// A lock corresponding to the supplied lock strength and durability will be
+// acquired on each of the resulting keys.
+func NewLockingReverseScan(
+	key, endKey roachpb.Key, str KeyLockingStrengthType, dur KeyLockingDurabilityType,
+) Request {
 	return &ReverseScanRequest{
 		RequestHeader: RequestHeader{
 			Key:    key,
 			EndKey: endKey,
 		},
-		KeyLockingStrength: scanLockStrength(str),
+		KeyLockingStrength:   scanLockStrength(str),
+		KeyLockingDurability: scanLockDurability(dur),
+	}
+}
+
+// NewReverseScan returns a Request initialized to reverse scan from end. No
+// locks will be acquired on each of the resulting keys.
+func NewReverseScan(key, endKey roachpb.Key) Request {
+	return &ReverseScanRequest{
+		RequestHeader: RequestHeader{
+			Key:    key,
+			EndKey: endKey,
+		},
+		KeyLockingStrength: lock.None,
 	}
 }
 
@@ -1362,16 +1406,59 @@ const (
 	ForUpdate
 )
 
+// KeyLockingDurabilityType is used to describe the durability goals of per-key
+// locks acquired by locking Get, Scan, and ReverseScan requests.
+type KeyLockingDurabilityType int8
+
+const (
+	// Invalid is meant to be used in places where supplying lock durability does
+	// not make sense. Notably, it's used by non-locking requests.
+	Invalid KeyLockingDurabilityType = iota
+	// BestEffort makes a best-effort attempt to hold any locks acquired until
+	// commit time. Locks are held in-memory on the leaseholder of the locked key;
+	// locks may be lost because of things like lease transfers, node restarts,
+	// range splits, and range merges. However, the unreplicated nature of these
+	// locks makes lock acquisition fast, making this a great choice for
+	// transactions that do not require locks for correctness -- serializable
+	// transactions.
+	BestEffort
+	// GuaranteedDurability guarantees that if the transaction commits then any
+	// locks acquired by it will be held until commit time. On commit, once the
+	// locks are released, no subsequent writers will be able to write at or below
+	// the transaction's commit timestamp -- regardless of the timestamp at which
+	// the lock was acquired. Simply put, once acquired, locks are guaranteed to
+	// provide protection until commit time.
+	//
+	// To provide this guarantee, locks are replicated -- which means they come
+	// with the performance penalties of doing so. They're attractive choices for
+	// transactions that require locks for correctness (read: read-committed,
+	// snapshot isolation).
+	GuaranteedDurability
+)
+
 func scanLockStrength(str KeyLockingStrengthType) lock.Strength {
 	switch str {
 	case NonLocking:
-		return lock.None
+		panic(fmt.Sprintf("unexpected strength %d", str))
 	case ForShare:
 		return lock.Shared
 	case ForUpdate:
 		return lock.Exclusive
 	default:
 		panic(fmt.Sprintf("unknown strength type: %d", str))
+	}
+}
+
+func scanLockDurability(dur KeyLockingDurabilityType) lock.Durability {
+	switch dur {
+	case Invalid:
+		panic("invalid lock durability")
+	case BestEffort:
+		return lock.Unreplicated
+	case GuaranteedDurability:
+		return lock.Replicated
+	default:
+		panic(fmt.Sprintf("unknown durability type: %d", dur))
 	}
 }
 

--- a/pkg/kv/kvpb/api.go
+++ b/pkg/kv/kvpb/api.go
@@ -93,8 +93,8 @@ var flagExclusions = map[flag][]flag{
 
 // IsReadOnly returns true iff the request is read-only. A request is
 // read-only if it does not go through raft, meaning that it cannot
-// change any replicated state. However, read-only requests may still
-// acquire locks with an unreplicated durability level; see IsLocking.
+// change any replicated state. However, read-only requests may still acquire
+// locks, but only with unreplicated durability.
 func IsReadOnly(args Request) bool {
 	flags := args.flags()
 	return (flags&isRead) != 0 && (flags&isWrite) == 0
@@ -1382,9 +1382,17 @@ func flagForLockStrength(l lock.Strength) flag {
 	return 0
 }
 
+func flagForLockDurability(d lock.Durability) flag {
+	if d == lock.Replicated {
+		return isWrite
+	}
+	return 0
+}
+
 func (gr *GetRequest) flags() flag {
 	maybeLocking := flagForLockStrength(gr.KeyLockingStrength)
-	return isRead | isTxn | maybeLocking | updatesTSCache | needsRefresh | canSkipLocked
+	maybeWrite := flagForLockDurability(gr.KeyLockingDurability)
+	return isRead | maybeWrite | isTxn | maybeLocking | updatesTSCache | needsRefresh | canSkipLocked
 }
 
 func (*PutRequest) flags() flag {
@@ -1474,12 +1482,14 @@ func (*RevertRangeRequest) flags() flag {
 
 func (sr *ScanRequest) flags() flag {
 	maybeLocking := flagForLockStrength(sr.KeyLockingStrength)
-	return isRead | isRange | isTxn | maybeLocking | updatesTSCache | needsRefresh | canSkipLocked
+	maybeWrite := flagForLockDurability(sr.KeyLockingDurability)
+	return isRead | maybeWrite | isRange | isTxn | maybeLocking | updatesTSCache | needsRefresh | canSkipLocked
 }
 
 func (rsr *ReverseScanRequest) flags() flag {
 	maybeLocking := flagForLockStrength(rsr.KeyLockingStrength)
-	return isRead | isRange | isReverse | isTxn | maybeLocking | updatesTSCache | needsRefresh | canSkipLocked
+	maybeWrite := flagForLockDurability(rsr.KeyLockingDurability)
+	return isRead | maybeWrite | isRange | isReverse | isTxn | maybeLocking | updatesTSCache | needsRefresh | canSkipLocked
 }
 
 // EndTxn updates the timestamp cache to prevent replays.

--- a/pkg/kv/kvpb/batch_test.go
+++ b/pkg/kv/kvpb/batch_test.go
@@ -344,9 +344,9 @@ func TestRefreshSpanIterate(t *testing.T) {
 
 func TestRefreshSpanIterateSkipLocked(t *testing.T) {
 	ba := BatchRequest{}
-	ba.Add(NewGet(roachpb.Key("a"), NonLocking))
-	ba.Add(NewScan(roachpb.Key("b"), roachpb.Key("d"), NonLocking))
-	ba.Add(NewReverseScan(roachpb.Key("e"), roachpb.Key("g"), NonLocking))
+	ba.Add(NewGet(roachpb.Key("a")))
+	ba.Add(NewScan(roachpb.Key("b"), roachpb.Key("d")))
+	ba.Add(NewReverseScan(roachpb.Key("e"), roachpb.Key("g")))
 	br := ba.CreateReply()
 
 	// Without a SkipLocked wait policy.

--- a/pkg/kv/kvserver/batcheval/cmd_get.go
+++ b/pkg/kv/kvserver/batcheval/cmd_get.go
@@ -84,7 +84,11 @@ func Get(
 
 	var res result.Result
 	if args.KeyLockingStrength != lock.None && h.Txn != nil && getRes.Value != nil {
-		acq := roachpb.MakeLockAcquisition(h.Txn, args.Key, lock.Unreplicated, args.KeyLockingStrength)
+		acq, err := acquireLockOnKey(ctx, readWriter, h.Txn, args.KeyLockingStrength,
+			args.KeyLockingDurability, args.Key)
+		if err != nil {
+			return result.Result{}, err
+		}
 		res.Local.AcquiredLocks = []roachpb.LockAcquisition{acq}
 	}
 	res.Local.EncounteredIntents = intents

--- a/pkg/kv/kvserver/batcheval/cmd_reverse_scan.go
+++ b/pkg/kv/kvserver/batcheval/cmd_reverse_scan.go
@@ -110,11 +110,14 @@ func ReverseScan(
 	}
 
 	if args.KeyLockingStrength != lock.None && h.Txn != nil {
-		err = acquireUnreplicatedLocksOnKeys(&res, h.Txn, args.KeyLockingStrength, args.ScanFormat, &scanRes)
+		acquiredLocks, err := acquireLocksOnKeys(ctx, readWriter, h.Txn, args.KeyLockingStrength,
+			args.KeyLockingDurability, args.ScanFormat, &scanRes)
 		if err != nil {
 			return result.Result{}, err
 		}
+		res.Local.AcquiredLocks = acquiredLocks
 	}
+
 	res.Local.EncounteredIntents = scanRes.Intents
 	return res, nil
 }

--- a/pkg/kv/kvserver/batcheval/cmd_scan.go
+++ b/pkg/kv/kvserver/batcheval/cmd_scan.go
@@ -110,11 +110,14 @@ func Scan(
 	}
 
 	if args.KeyLockingStrength != lock.None && h.Txn != nil {
-		err = acquireUnreplicatedLocksOnKeys(&res, h.Txn, args.KeyLockingStrength, args.ScanFormat, &scanRes)
+		acquiredLocks, err := acquireLocksOnKeys(ctx, readWriter, h.Txn, args.KeyLockingStrength,
+			args.KeyLockingDurability, args.ScanFormat, &scanRes)
 		if err != nil {
 			return result.Result{}, err
 		}
+		res.Local.AcquiredLocks = acquiredLocks
 	}
+
 	res.Local.EncounteredIntents = scanRes.Intents
 	return res, nil
 }

--- a/pkg/kv/kvserver/batcheval/intent.go
+++ b/pkg/kv/kvserver/batcheval/intent.go
@@ -14,7 +14,6 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/batcheval/result"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/lock"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
@@ -104,44 +103,108 @@ func readProvisionalVal(
 
 }
 
-// acquireUnreplicatedLocksOnKeys adds an unreplicated lock acquisition by the
-// transaction to the provided result.Result for each key in the scan result.
-func acquireUnreplicatedLocksOnKeys(
-	res *result.Result,
+// acquireLocksOnKeys acquires locks on each of the keys in the result of a
+// {,Reverse}ScanRequest. The locks are held by the specified transaction with
+// the supplied locks strength and durability. The list of LockAcquisitions is
+// returned to the caller, which the caller must accumulate in its result set.
+//
+// It is possible to run into a lock conflict error when trying to acquire a
+// lock on one of the keys. In such cases, a LockConflictError is returned to
+// the caller.
+func acquireLocksOnKeys(
+	ctx context.Context,
+	readWriter storage.ReadWriter,
 	txn *roachpb.Transaction,
 	str lock.Strength,
+	dur lock.Durability,
 	scanFmt kvpb.ScanFormat,
 	scanRes *storage.MVCCScanResult,
-) error {
-	res.Local.AcquiredLocks = make([]roachpb.LockAcquisition, scanRes.NumKeys)
+) ([]roachpb.LockAcquisition, error) {
+	acquiredLocks := make([]roachpb.LockAcquisition, scanRes.NumKeys)
 	switch scanFmt {
 	case kvpb.BATCH_RESPONSE:
 		var i int
-		return storage.MVCCScanDecodeKeyValues(scanRes.KVData, func(key storage.MVCCKey, _ []byte) error {
-			res.Local.AcquiredLocks[i] = roachpb.MakeLockAcquisition(txn, copyKey(key.Key), lock.Unreplicated, str)
+		err := storage.MVCCScanDecodeKeyValues(scanRes.KVData, func(key storage.MVCCKey, _ []byte) error {
+			k := copyKey(key.Key)
+			acq, err := acquireLockOnKey(ctx, readWriter, txn, str, dur, k)
+			if err != nil {
+				return err
+			}
+			acquiredLocks[i] = acq
 			i++
 			return nil
 		})
+		if err != nil {
+			return nil, err
+		}
+		return acquiredLocks, nil
 	case kvpb.KEY_VALUES:
 		for i, row := range scanRes.KVs {
-			res.Local.AcquiredLocks[i] = roachpb.MakeLockAcquisition(txn, copyKey(row.Key), lock.Unreplicated, str)
+			k := copyKey(row.Key)
+			acq, err := acquireLockOnKey(ctx, readWriter, txn, str, dur, k)
+			if err != nil {
+				return nil, err
+			}
+			acquiredLocks[i] = acq
 		}
-		return nil
+		return acquiredLocks, nil
 	case kvpb.COL_BATCH_RESPONSE:
-		return errors.AssertionFailedf("unexpectedly acquiring unreplicated locks with COL_BATCH_RESPONSE scan format")
+		return nil, errors.AssertionFailedf("unexpectedly acquiring unreplicated locks with COL_BATCH_RESPONSE scan format")
 	default:
 		panic("unexpected scanFormat")
 	}
 }
 
+// acquireLockOnKey acquires a lock on the specified key. The lock is acquired
+// by the specified transaction with the supplied lock strength and durability.
+// The resultant lock acquisition struct is returned, which the caller must
+// accumulate in its result set.
+//
+// It is possible for lock acquisition to run into a lock conflict error, in
+// which case a LockConflictError is returned to the caller.
+func acquireLockOnKey(
+	ctx context.Context,
+	readWriter storage.ReadWriter,
+	txn *roachpb.Transaction,
+	str lock.Strength,
+	dur lock.Durability,
+	key roachpb.Key,
+) (roachpb.LockAcquisition, error) {
+	// TODO(arul,nvanbenschoten): For now, we're only checking whether we have
+	// access to a legit pebble.Writer for replicated lock acquisition. We're not
+	// actually acquiring a replicated lock -- we can only do so once they're
+	// fully supported in the storage package. Until then, we grab an unreplicated
+	// lock regardless of what the caller asked us to do.
+	if dur == lock.Replicated {
+		// ShouldWriteLocalTimestamp is only implemented by a pebble.Writer; it'll
+		// panic if we were on the read-only evaluation path, and only had access to
+		// a pebble.ReadOnly.
+		readWriter.ShouldWriteLocalTimestamps(ctx)
+		// Regardless of what the caller asked for, we'll give it an unreplicated
+		// lock.
+		dur = lock.Unreplicated
+	}
+	switch dur {
+	case lock.Unreplicated:
+		// TODO(arul,nvanbenschoten): Call into MVCCCheckForAcquireLockHere.
+	case lock.Replicated:
+		// TODO(arul,nvanbenschoten): Call into MVCCAcquireLock here.
+	default:
+		panic("unexpected lock durability")
+	}
+	acq := roachpb.MakeLockAcquisition(txn, key, dur, str)
+	return acq, nil
+}
+
 // copyKey copies the provided roachpb.Key into a new byte slice, returning the
-// copy. It is used in acquireUnreplicatedLocksOnKeys for two reasons:
+// copy. It is used in acquireLocksOnKeys for two reasons:
 //  1. the keys in an MVCCScanResult, regardless of the scan format used, point
 //     to a small number of large, contiguous byte slices. These "MVCCScan
 //     batches" contain keys and their associated values in the same backing
 //     array. To avoid holding these entire backing arrays in memory and
-//     preventing them from being garbage collected indefinitely, we copy the key
-//     slices before coupling their lifetimes to those of unreplicated locks.
+//     preventing them from being garbage collected indefinitely, we copy the
+//     key slices before coupling their lifetimes to those of the constructed
+//     lock acquisitions.
 //  2. the KV API has a contract that byte slices returned from KV will not be
 //     mutated by higher levels. However, we have seen cases (e.g.#64228) where
 //     this contract is broken due to bugs. To defensively guard against this

--- a/pkg/kv/kvserver/client_replica_circuit_breaker_test.go
+++ b/pkg/kv/kvserver/client_replica_circuit_breaker_test.go
@@ -1069,14 +1069,14 @@ func (cbt *circuitBreakerTest) Write(idx int) error {
 func (cbt *circuitBreakerTest) Read(idx int) error {
 	cbt.t.Helper()
 	repl := cbt.repls[idx]
-	get := kvpb.NewGet(repl.Desc().StartKey.AsRawKey(), kvpb.NonLocking)
+	get := kvpb.NewGet(repl.Desc().StartKey.AsRawKey())
 	return cbt.Send(idx, get)
 }
 
 func (cbt *circuitBreakerTest) FollowerRead(idx int) error {
 	cbt.t.Helper()
 	repl := cbt.repls[idx]
-	get := kvpb.NewGet(repl.Desc().StartKey.AsRawKey(), kvpb.NonLocking)
+	get := kvpb.NewGet(repl.Desc().StartKey.AsRawKey())
 	ctx := context.Background()
 	ts := repl.GetCurrentClosedTimestamp(ctx)
 	return cbt.SendCtxTS(ctx, idx, get, ts)

--- a/pkg/kv/kvserver/client_replica_test.go
+++ b/pkg/kv/kvserver/client_replica_test.go
@@ -4970,6 +4970,67 @@ func setupDBAndWriteAAndB(t *testing.T) (serverutils.TestServerInterface, *kv.DB
 	return s, db
 }
 
+// TestSharedLocksBasic tests basic shared lock semantics. In particular, it
+// tests multiple shared locks are compatible with each other, but exclusive
+// locks aren't.
+func TestSharedLocksBasic(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	s, db := setupDBAndWriteAAndB(t)
+	defer s.Stopper().Stop(ctx)
+
+	testutils.RunTrueAndFalse(t, "guaranteed-durability", func(t *testing.T, guaranteedDurability bool) {
+		txn1 := db.NewTxn(ctx, "txn1")
+		txn2 := db.NewTxn(ctx, "txn2")
+
+		dur := kvpb.BestEffort
+		if guaranteedDurability {
+			dur = kvpb.GuaranteedDurability
+		}
+
+		res, err := txn1.ScanForShare(ctx, "a", "c", 0, dur)
+		require.NoError(t, err)
+		require.Equal(t, 2, len(res))
+
+		_, err = txn2.ReverseScanForShare(ctx, "a", "c", 0, dur)
+		require.NoError(t, err)
+		require.Equal(t, 2, len(res))
+
+		ch := make(chan struct{}, 1) // we won't pull off the channel
+		var wg sync.WaitGroup
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+			txn3 := db.NewTxn(ctx, "txn3")
+			res, err := txn3.GetForUpdate(ctx, "a", dur)
+			require.NoError(t, err)
+			ch <- struct{}{}
+			require.NotNil(t, res.Value)
+			require.NoError(t, txn3.Commit(ctx))
+		}()
+
+		ensureGetForUpdateIsBlocked := func() {
+			select {
+			case <-ch:
+				t.Fatal("expected GetForUpdate request to block")
+			case <-time.After(10 * time.Millisecond):
+				// sleep for a bit to allow the GetForUpdate to block.
+			}
+		}
+		ensureGetForUpdateIsBlocked()
+		require.NoError(t, txn1.Commit(ctx))
+		// Finalizing just one of the shared locking transactions shouldn't unblock
+		// the GetForUpdate.
+		ensureGetForUpdateIsBlocked()
+		require.NoError(t, txn2.Rollback(ctx))
+
+		wg.Wait()
+	})
+}
+
 // TestOptimisticEvalRetry tests the case where an optimistically evaluated
 // scan encounters contention from a concurrent txn holding unreplicated
 // exclusive locks, and therefore re-evaluates pessimistically, and eventually

--- a/pkg/kv/kvserver/client_replica_test.go
+++ b/pkg/kv/kvserver/client_replica_test.go
@@ -4983,7 +4983,7 @@ func TestOptimisticEvalRetry(t *testing.T) {
 	defer s.Stopper().Stop(ctx)
 
 	txn1 := db.NewTxn(ctx, "locking txn")
-	_, err := txn1.ScanForUpdate(ctx, "a", "c", 0)
+	_, err := txn1.ScanForUpdate(ctx, "a", "c", 0, kvpb.BestEffort)
 	require.NoError(t, err)
 
 	readDone := make(chan error)
@@ -5038,7 +5038,7 @@ func TestOptimisticEvalNoContention(t *testing.T) {
 	defer s.Stopper().Stop(ctx)
 
 	txn1 := db.NewTxn(ctx, "locking txn")
-	_, err := txn1.ScanForUpdate(ctx, "b", "c", 0)
+	_, err := txn1.ScanForUpdate(ctx, "b", "c", 0, kvpb.BestEffort)
 	require.NoError(t, err)
 
 	readDone := make(chan error)
@@ -5165,7 +5165,7 @@ func BenchmarkOptimisticEvalForLocks(b *testing.B) {
 					go func() {
 						for {
 							txn := db.NewTxn(ctx, "locking txn")
-							_, err = txn.ScanForUpdate(ctx, lockStart, "c", 0)
+							_, err = txn.ScanForUpdate(ctx, lockStart, "c", 0, kvpb.BestEffort)
 							require.NoError(b, err)
 							time.Sleep(5 * time.Millisecond)
 							// Normally, it would do a write here, but we don't bother.

--- a/pkg/kv/kvserver/client_split_test.go
+++ b/pkg/kv/kvserver/client_split_test.go
@@ -448,12 +448,12 @@ func TestQueryLocksAcrossRanges(t *testing.T) {
 	txn1 := kv.NewTxn(ctx, db, s.NodeID())
 	err = txn1.Put(ctx, roachpb.Key("c"), []byte("baz"))
 	require.NoError(t, err)
-	_, err = txn1.GetForUpdate(ctx, roachpb.Key("x"))
+	_, err = txn1.GetForUpdate(ctx, roachpb.Key("x"), kvpb.BestEffort)
 	require.NoError(t, err)
 
 	// Use txn2 to get an unreplicated lock on "p".
 	txn2 := kv.NewTxn(ctx, db, s.NodeID())
-	_, err = txn2.GetForUpdate(ctx, roachpb.Key("p"))
+	_, err = txn2.GetForUpdate(ctx, roachpb.Key("p"), kvpb.BestEffort)
 	require.NoError(t, err)
 
 	now := s.Clock().NowAsClockTimestamp()

--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -640,7 +640,7 @@ func (r *Replica) AdminMerge(
 		// shortly.
 		var rightDesc roachpb.RangeDescriptor
 		rightDescKey := keys.RangeDescriptorKey(origLeftDesc.EndKey)
-		dbRightDescKV, err := txn.GetForUpdate(ctx, rightDescKey)
+		dbRightDescKV, err := txn.GetForUpdate(ctx, rightDescKey, kvpb.BestEffort)
 		if err != nil {
 			return err
 		}
@@ -3290,12 +3290,13 @@ func conditionalGetDescValueFromDB(
 	forUpdate bool,
 	check func(*roachpb.RangeDescriptor) (matched, skip bool),
 ) (kvDesc *roachpb.RangeDescriptor, kvDescBytes []byte, skip bool, err error) {
-	get := txn.Get
-	if forUpdate {
-		get = txn.GetForUpdate
-	}
 	descKey := keys.RangeDescriptorKey(startKey)
-	existingDescKV, err := get(ctx, descKey)
+	var existingDescKV kv.KeyValue
+	if forUpdate {
+		existingDescKV, err = txn.GetForUpdate(ctx, descKey, kvpb.BestEffort)
+	} else {
+		existingDescKV, err = txn.Get(ctx, descKey)
+	}
 	if err != nil {
 		return nil, nil, false /* skip */, errors.Wrap(err, "fetching current range descriptor value")
 	}

--- a/pkg/kv/kvserver/replica_rankings_test.go
+++ b/pkg/kv/kvserver/replica_rankings_test.go
@@ -199,7 +199,7 @@ func TestAddSSTQPSStat(t *testing.T) {
 
 // genVariableRead returns a batch request containing, start-end sequential key reads.
 func genVariableRead(ctx context.Context, start, end roachpb.Key) *kvpb.BatchRequest {
-	scan := kvpb.NewScan(start, end, kvpb.NonLocking)
+	scan := kvpb.NewScan(start, end)
 	readBa := &kvpb.BatchRequest{}
 	readBa.Add(scan)
 	return readBa

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -11085,7 +11085,7 @@ func TestReplicaNotifyLockTableOn1PC(t *testing.T) {
 	txn := newTransaction("test", key, 1, tc.Clock())
 	ba := &kvpb.BatchRequest{}
 	ba.Header = kvpb.Header{Txn: txn}
-	ba.Add(kvpb.NewScan(key, key.Next(), kvpb.ForUpdate))
+	ba.Add(kvpb.NewLockingScan(key, key.Next(), kvpb.ForUpdate, kvpb.BestEffort))
 	if _, pErr := tc.Sender().Send(ctx, ba); pErr != nil {
 		t.Fatalf("unexpected error: %s", pErr)
 	}
@@ -11182,9 +11182,9 @@ func TestReplicaAsyncIntentResolutionOn1PC(t *testing.T) {
 		// Perform one or more "for update" gets. This should acquire unreplicated,
 		// exclusive locks on the keys.
 		b := txn.NewBatch()
-		b.GetForUpdate(keyA)
+		b.GetForUpdate(keyA, kvpb.BestEffort)
 		if external {
-			b.GetForUpdate(keyB)
+			b.GetForUpdate(keyB, kvpb.BestEffort)
 		}
 		err = txn.Run(ctx, b)
 		require.NoError(t, err)
@@ -11244,7 +11244,7 @@ func TestReplicaQueryLocks(t *testing.T) {
 			txn := newTransaction("test", keyA, 1, tc.Clock())
 			ba := &kvpb.BatchRequest{}
 			ba.Header = kvpb.Header{Txn: txn}
-			ba.Add(kvpb.NewScan(keyA, keyB.Next(), kvpb.ForUpdate))
+			ba.Add(kvpb.NewLockingScan(keyA, keyB.Next(), kvpb.ForUpdate, kvpb.BestEffort))
 			if _, pErr := tc.Sender().Send(ctx, ba); pErr != nil {
 				t.Fatalf("unexpected error: %s", pErr)
 			}

--- a/pkg/kv/txn_test.go
+++ b/pkg/kv/txn_test.go
@@ -574,7 +574,7 @@ func TestTxnNegotiateAndSend(t *testing.T) {
 			MinTimestampBound: ts10,
 		}
 		ba.RoutingPolicy = kvpb.RoutingPolicy_NEAREST
-		ba.Add(kvpb.NewGet(roachpb.Key("a"), kvpb.NonLocking))
+		ba.Add(kvpb.NewGet(roachpb.Key("a")))
 		br, pErr := txn.NegotiateAndSend(ctx, ba)
 
 		if fastPath {
@@ -685,7 +685,7 @@ func TestTxnNegotiateAndSendWithDeadline(t *testing.T) {
 				MaxTimestampBound: test.maxTSBound,
 			}
 			ba.RoutingPolicy = kvpb.RoutingPolicy_NEAREST
-			ba.Add(kvpb.NewGet(roachpb.Key("a"), kvpb.NonLocking))
+			ba.Add(kvpb.NewGet(roachpb.Key("a")))
 			br, pErr := txn.NegotiateAndSend(ctx, ba)
 
 			if test.expErr == "" {
@@ -755,7 +755,7 @@ func TestTxnNegotiateAndSendWithResumeSpan(t *testing.T) {
 		}
 		ba.RoutingPolicy = kvpb.RoutingPolicy_NEAREST
 		ba.MaxSpanRequestKeys = 2
-		ba.Add(kvpb.NewScan(roachpb.Key("a"), roachpb.Key("d"), kvpb.NonLocking))
+		ba.Add(kvpb.NewScan(roachpb.Key("a"), roachpb.Key("d")))
 		br, pErr := txn.NegotiateAndSend(ctx, ba)
 
 		if fastPath {

--- a/pkg/server/node_test.go
+++ b/pkg/server/node_test.go
@@ -713,7 +713,7 @@ func TestNodeBatchRequestPProfLabels(t *testing.T) {
 		return labels
 	}()
 
-	gr := kvpb.NewGet(roachpb.Key("a"), kvpb.NonLocking)
+	gr := kvpb.NewGet(roachpb.Key("a"))
 	pr := kvpb.NewPut(gr.Header().Key, roachpb.Value{})
 	ba.Add(gr, pr)
 
@@ -748,7 +748,7 @@ func TestNodeBatchRequestMetricsInc(t *testing.T) {
 	ba.RangeID = 1
 	ba.Replica.StoreID = 1
 
-	gr := kvpb.NewGet(roachpb.Key("a"), kvpb.NonLocking)
+	gr := kvpb.NewGet(roachpb.Key("a"))
 	pr := kvpb.NewPut(gr.Header().Key, roachpb.Value{})
 	ba.Add(gr, pr)
 

--- a/pkg/server/systemconfigwatcher/system_config_watcher_test.go
+++ b/pkg/server/systemconfigwatcher/system_config_watcher_test.go
@@ -131,7 +131,6 @@ func getSystemDescriptorAndZonesSpans(
 			kvpb.NewScan(
 				append(codec.TenantPrefix(), startKey...),
 				append(codec.TenantPrefix(), endKey...),
-				kvpb.NonLocking,
 			),
 		)
 		br, pErr := kvDB.NonTransactionalSender().Send(ctx, ba)

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -6394,7 +6394,7 @@ CREATE TABLE crdb_internal.lost_descriptors_with_data (
 			endPrefix := p.extendedEvalCtx.Codec.TablePrefix(uint32(endID - 1)).PrefixEnd()
 			b := p.Txn().NewBatch()
 			b.Header.MaxSpanRequestKeys = 1
-			scanRequest := kvpb.NewScan(startPrefix, endPrefix, kvpb.NonLocking).(*kvpb.ScanRequest)
+			scanRequest := kvpb.NewScan(startPrefix, endPrefix).(*kvpb.ScanRequest)
 			scanRequest.ScanFormat = kvpb.BATCH_RESPONSE
 			b.AddRawRequest(scanRequest)
 			err = p.execCfg.DB.Run(ctx, b)

--- a/pkg/sql/tests/kv_test.go
+++ b/pkg/sql/tests/kv_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	kv2 "github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -105,7 +106,7 @@ func (kv *kvNative) Update(rows, run int) error {
 		// Don't permute the rows, to be similar to SQL which sorts the spans in a
 		// batch.
 		for i := 0; i < rows; i++ {
-			b.GetForUpdate(fmt.Sprintf("%s%08d", kv.prefix, i))
+			b.GetForUpdate(fmt.Sprintf("%s%08d", kv.prefix, i), kvpb.BestEffort)
 		}
 		if err := txn.Run(ctx, b); err != nil {
 			return err

--- a/pkg/ts/server.go
+++ b/pkg/ts/server.go
@@ -489,7 +489,7 @@ func dumpTimeseriesAllSources(
 
 	for span != nil {
 		b := &kv.Batch{}
-		scan := kvpb.NewScan(span.Key, span.EndKey, kvpb.NonLocking)
+		scan := kvpb.NewScan(span.Key, span.EndKey)
 		b.AddRawRequest(scan)
 		b.Header.MaxSpanRequestKeys = dumpBatchSize
 		err := db.Run(ctx, b)

--- a/pkg/upgrade/upgrades/BUILD.bazel
+++ b/pkg/upgrade/upgrades/BUILD.bazel
@@ -51,6 +51,7 @@ go_library(
         "//pkg/keys",
         "//pkg/keyvisualizer/keyvisjob",
         "//pkg/kv",
+        "//pkg/kv/kvpb",
         "//pkg/multitenant/mtinfopb",
         "//pkg/roachpb",
         "//pkg/security/username",

--- a/pkg/upgrade/upgrades/desc_id_sequence_for_system_tenant.go
+++ b/pkg/upgrade/upgrades/desc_id_sequence_for_system_tenant.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
 	"github.com/cockroachdb/cockroach/pkg/upgrade"
 )
@@ -27,7 +28,7 @@ func descIDSequenceForSystemTenant(
 		return nil
 	}
 	return d.DB.KV().Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
-		oldEntry, err := txn.GetForUpdate(ctx, keys.LegacyDescIDGenerator)
+		oldEntry, err := txn.GetForUpdate(ctx, keys.LegacyDescIDGenerator, kvpb.BestEffort)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
First commit from https://github.com/cockroachdb/cockroach/pull/110201

Previously, {Get,Scan,ReverseScan}Requests all used the read-only
execution path. Things aren't so simple anymore, now that we want these
requests to be able to acquire replicated locks, which means they need
to go through raft (and therefore the read-write execution path). This
patch achieves exactly that.

Informs https://github.com/cockroachdb/cockroach/issues/100193

Release note: None