### PR TITLE
bazel: code coverage instrumentation for cockroach binary

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -17,6 +17,7 @@ build --flag_alias=crdb_test=//build/toolchains:crdb_test_flag
 build --flag_alias=crdb_test_off=//build/toolchains:crdb_test_off_flag
 build --flag_alias=cross=//build/toolchains:cross_flag
 build --flag_alias=dev=//build/toolchains:dev_flag
+build --flag_alias=bazel_code_coverage=//build/toolchains:bazel_code_coverage_flag
 build --flag_alias=force_build_cdeps=//build/toolchains:force_build_cdeps_flag
 build --flag_alias=lintonbuild=//build/toolchains:nogo_flag
 build --flag_alias=nolintonbuild=//build/toolchains:nonogo_explicit_flag

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -133,6 +133,8 @@ exports_files([
 # gazelle:exclude pkg/ui/distoss/distoss_no_bazel.go
 # gazelle:exclude pkg/util/buildutil/crdb_test_off.go
 # gazelle:exclude pkg/util/buildutil/crdb_test_on.go
+# gazelle:exclude pkg/testutils/bazelcodecover/crdb_test_off.go
+# gazelle:exclude pkg/testutils/bazelcodecover/crdb_test_on.go
 # gazelle:exclude pkg/acceptance/compose/gss/psql/*
 # gazelle:exclude pkg/acceptance/test_main.go
 #

--- a/build/toolchains/BUILD.bazel
+++ b/build/toolchains/BUILD.bazel
@@ -327,6 +327,19 @@ config_setting(
 )
 
 bool_flag(
+    name = "bazel_code_coverage_flag",
+    build_setting_default = False,
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "bazel_code_coverage",
+    flag_values = {
+        ":bazel_code_coverage_flag": "true",
+    },
+)
+
+bool_flag(
     name = "cross_flag",
     build_setting_default = False,
     visibility = ["//visibility:public"],

--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -2153,6 +2153,7 @@ GO_TARGETS = [
     "//pkg/storage/pebbleiter:pebbleiter_test",
     "//pkg/storage:storage",
     "//pkg/storage:storage_test",
+    "//pkg/testutils/bazelcodecover:bazelcodecover",
     "//pkg/testutils/colcontainerutils:colcontainerutils",
     "//pkg/testutils/datapathutils:datapathutils",
     "//pkg/testutils/diagutils:diagutils",

--- a/pkg/cli/BUILD.bazel
+++ b/pkg/cli/BUILD.bazel
@@ -181,6 +181,7 @@ go_library(
         "//pkg/storage",
         "//pkg/storage/enginepb",
         "//pkg/storage/fs",
+        "//pkg/testutils/bazelcodecover",
         "//pkg/testutils/serverutils",
         "//pkg/ts",
         "//pkg/ts/tspb",

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cli/cliflagcfg"
 	"github.com/cockroachdb/cockroach/pkg/cli/exit"
 	_ "github.com/cockroachdb/cockroach/pkg/cloud/impl" // register cloud storage providers
+	"github.com/cockroachdb/cockroach/pkg/testutils/bazelcodecover"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/log/logcrash"
 	"github.com/cockroachdb/cockroach/pkg/util/log/severity"
@@ -49,6 +50,7 @@ import (
 // to be the body of an action package main `main` func elsewhere. It is
 // abstracted for reuse by duplicated `main` funcs in different distributions.
 func Main() {
+	bazelcodecover.MaybeInitCodeCoverage()
 	if len(os.Args) == 1 {
 		os.Args = append(os.Args, "help")
 	}

--- a/pkg/testutils/bazelcodecover/BUILD.bazel
+++ b/pkg/testutils/bazelcodecover/BUILD.bazel
@@ -1,0 +1,34 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+# keep
+go_library(
+    name = "bazelcodecover",
+    srcs = select({
+        "//build/toolchains:bazel_code_coverage": [":gen-bazel-code-cover-on"],
+        "//conditions:default": [":gen-bazel-code-cover-off"],
+    }),
+    importpath = "github.com/cockroachdb/cockroach/pkg/testutils/bazelcodecover",
+    visibility = ["//visibility:public"],
+    deps = select({
+        "//build/toolchains:bazel_code_coverage": [
+            "@io_bazel_rules_go//go/tools/bzltestutil:go_default_library",
+        ],
+        "//conditions:default": [],
+    }),
+)
+
+REMOVE_GO_BUILD_CONSTRAINTS = "cat $< | grep -v '//go:build' | grep -v '// +build' > $@"
+
+genrule(
+    name = "gen-bazel-code-cover-on",
+    srcs = ["code_cover_on.go"],
+    outs = ["gen-code_cover_on.go"],
+    cmd = REMOVE_GO_BUILD_CONSTRAINTS,
+)
+
+genrule(
+    name = "gen-bazel-code-cover-off",
+    srcs = ["code_cover_off.go"],
+    outs = ["gen-code_cover_off.go"],
+    cmd = REMOVE_GO_BUILD_CONSTRAINTS,
+)

--- a/pkg/testutils/bazelcodecover/code_cover_off.go
+++ b/pkg/testutils/bazelcodecover/code_cover_off.go
@@ -1,0 +1,21 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+//go:build !bazel_code_cover
+// +build !bazel_code_cover
+
+// Package bazelcodecover allows instrumented binaries to output code coverage
+// data.
+package bazelcodecover
+
+// MaybeInitCodeCoverage does nothing unless we are building in a special
+// coverage collection mode. See the same function in the corresponding
+// code_cover_on.go file
+func MaybeInitCodeCoverage() {}

--- a/pkg/testutils/bazelcodecover/code_cover_on.go
+++ b/pkg/testutils/bazelcodecover/code_cover_on.go
@@ -1,0 +1,100 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+//go:build bazel_code_cover
+// +build bazel_code_cover
+
+// Package bazelcodecover allows instrumented binaries to output code coverage
+// data.
+package bazelcodecover
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	_ "unsafe"
+
+	"github.com/bazelbuild/rules_go/go/tools/coverdata"
+)
+
+// MaybeInitCodeCoverage sets up dumping of coverage counters on exit.
+//
+// BAZEL_COVER_DIR must be set; this is where a new .gocov coverage file will be
+// created. To build Cockroach in this mode, use:
+//
+//	bazel build --collect_code_coverage --bazel_code_coverage //pkg/cmd/cockroach:cockroach
+//
+// The `--collect_code_coverage` flag enables Bazel-driven coverage
+// instrumentation. The `--bazel_code_coverage` flag is an alias for
+// `//build/toolchains:bazel_code_coverage_flag` which is conceptually similar
+// to setting the `bazel_code_cover` build tag (it causes the build to use
+// `code_cover_on.go`).
+func MaybeInitCodeCoverage() {
+	// Go 1.20 adds binary instrumentation for integration tests [1]. However, we
+	// can't yet build in this mode through bazel (tracked in [2]).
+	//
+	// Instead, we hack into Bazel's coverage infrastructure and set up an exit
+	// hook to dump the counters. The approach follows Go's implementation (see
+	// [3]).
+	//
+	// [1] https://go.dev/testing/coverage/
+	// [2] https://github.com/bazelbuild/rules_go/issues/3513
+	// [3] https://github.com/golang/go/blob/dfbf809f2af753db69537a9431d6419142dfe80b/src/runtime/coverage/hooks.go
+
+	dir := os.Getenv("BAZEL_COVER_DIR")
+	if dir == "" {
+		fmt.Fprintln(os.Stderr, "warning: BAZEL_COVER_DIR not set, no coverage data emitted")
+		return
+	}
+	runtime_addExitHook(func() { emitCoverageCounters(dir) }, true /* runOnNonZeroExit */)
+}
+
+//go:linkname runtime_addExitHook runtime.addExitHook
+func runtime_addExitHook(f func(), runOnNonZeroExit bool)
+
+// emitCoverageCounters emits the counters to a new .gocov file in the given
+// directory; any error is reported to stderr.
+func emitCoverageCounters(dir string) {
+	if err := emitCoverageCountersImpl(dir); err != nil {
+		fmt.Fprintf(os.Stderr, "error emitting coverage data: %s\n", err)
+	}
+}
+
+func emitCoverageCountersImpl(dir string) (err error) {
+	filepath := filepath.Join(dir, fmt.Sprintf("cockroach-%012X.gocov", rand.Int63n(1<<48)))
+	file, err := os.Create(filepath)
+	if err != nil {
+		return err
+	}
+
+	for name, counts := range coverdata.Counters {
+		if strings.HasPrefix(name, "external/") ||
+			strings.HasPrefix(name, "bazel-out/") {
+			continue
+		}
+		blocks := coverdata.Blocks[name]
+		for i := range counts {
+			count := atomic.LoadUint32(&counts[i]) // For -mode=atomic.
+			_, err := fmt.Fprintf(file, "%s:%d.%d,%d.%d %d %d\n", name,
+				blocks[i].Line0, blocks[i].Col0,
+				blocks[i].Line1, blocks[i].Col1,
+				blocks[i].Stmts,
+				count)
+			if err != nil {
+				file.Close()
+				return err
+			}
+		}
+	}
+	return file.Close()
+}

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -502,6 +502,7 @@ func TestLint(t *testing.T) {
 					":!testutils/lint",
 					":!util/envutil/env.go",
 					":!testutils/data_path.go",
+					":!testutils/bazelcodecover/code_cover_on.go", // For BAZEL_COVER_DIR.
 					":!util/log/tracebacks.go",
 					":!util/sdnotify/sdnotify_unix.go",
 					":!util/grpcutil",                        // GRPC_GO_* variables


### PR DESCRIPTION
This change implements a special hook to dump coverage data (collected
through Bazel's infrastructure) from the Cockroach binary.

Sample cmdline to build in this mode:
```
bazel build --collect_code_coverage --bazel_code_coverage //pkg/cmd/cockroach:cockroach
```

The `--collect_code_coverage` flag enables Bazel-driven coverage
instrumentation. The `--bazel_code_coverage` flag is an alias for
`//build/toolchains:bazel_code_coverage_flag` which is conceptually
similar to setting the `bazel_code_cover` build tag (it causes the
build to use `code_cover_on.go`).

This build mode will allow us to collect coverage data from
roachtests: the nodes will run an instrumented binary and the
roachtest runner will pull the coverage data from the nodes.

Epic: none
Release mode: None