### PR TITLE
storage: add UnsafeLazyValue to EngineIterator interface

### DIFF
--- a/pkg/kv/kvserver/spanset/batch.go
+++ b/pkg/kv/kvserver/spanset/batch.go
@@ -401,14 +401,24 @@ func (i *EngineIterator) UnsafeEngineKey() (storage.EngineKey, error) {
 	return i.i.UnsafeEngineKey()
 }
 
+// EngineKey is part of the storage.EngineIterator interface.
+func (i *EngineIterator) EngineKey() (storage.EngineKey, error) {
+	return i.i.EngineKey()
+}
+
+// UnsafeRawEngineKey is part of the storage.EngineIterator interface.
+func (i *EngineIterator) UnsafeRawEngineKey() []byte {
+	return i.i.UnsafeRawEngineKey()
+}
+
 // UnsafeValue is part of the storage.EngineIterator interface.
 func (i *EngineIterator) UnsafeValue() ([]byte, error) {
 	return i.i.UnsafeValue()
 }
 
-// EngineKey is part of the storage.EngineIterator interface.
-func (i *EngineIterator) EngineKey() (storage.EngineKey, error) {
-	return i.i.EngineKey()
+// UnsafeLazyValue is part of the storage.EngineIterator interface.
+func (i *EngineIterator) UnsafeLazyValue() pebble.LazyValue {
+	return i.i.UnsafeLazyValue()
 }
 
 // Value is part of the storage.EngineIterator interface.
@@ -419,11 +429,6 @@ func (i *EngineIterator) Value() ([]byte, error) {
 // ValueLen is part of the storage.EngineIterator interface.
 func (i *EngineIterator) ValueLen() int {
 	return i.i.ValueLen()
-}
-
-// UnsafeRawEngineKey is part of the storage.EngineIterator interface.
-func (i *EngineIterator) UnsafeRawEngineKey() []byte {
-	return i.i.UnsafeRawEngineKey()
 }
 
 // CloneContext is part of the storage.EngineIterator interface.

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -360,6 +360,11 @@ type EngineIterator interface {
 	// invalidated on the next call to {Next,NextKey,Prev,SeekGE,SeekLT,Close}.
 	// REQUIRES: latest positioning function returned valid=true.
 	UnsafeValue() ([]byte, error)
+	// UnsafeLazyValue is only for use inside the storage package. It exposes
+	// the LazyValue at the current iterator position, and hence delays fetching
+	// the actual value.
+	// REQUIRES: latest positioning function returned valid=true.
+	UnsafeLazyValue() pebble.LazyValue
 	// Value returns the current value as a byte slice.
 	// REQUIRES: latest positioning function returned valid=true.
 	Value() ([]byte, error)

--- a/pkg/storage/pebble_iterator.go
+++ b/pkg/storage/pebble_iterator.go
@@ -522,7 +522,7 @@ func (p *pebbleIterator) UnsafeValue() ([]byte, error) {
 	return p.iter.ValueAndErr()
 }
 
-// UnsafeLazyValue implements the MVCCIterator interface.
+// UnsafeLazyValue implements the MVCCIterator and EngineIterator interfaces.
 func (p *pebbleIterator) UnsafeLazyValue() pebble.LazyValue {
 	if ok := p.iter.Valid(); !ok {
 		panic(errors.AssertionFailedf("UnsafeLazyValue called on !Valid iterator"))


### PR DESCRIPTION
All implementations of the interface except `spanset.EngineIterator` already implement the method.

Epic: None
Release note: None