### PR TITLE
c2c: use seperate spanConfigEventStreamSpec in the span config event stream

### DIFF
--- a/pkg/ccl/streamingccl/streamproducer/stream_lifetime.go
+++ b/pkg/ccl/streamingccl/streamproducer/stream_lifetime.go
@@ -354,7 +354,6 @@ func setupSpanConfigsStream(
 	}); err != nil {
 		return nil, err
 	}
-
 	spanConfigKey := evalCtx.Codec.TablePrefix(uint32(spanConfigID))
 
 	// TODO(msbutler): crop this span to the keyspan within the span config
@@ -362,11 +361,10 @@ func setupSpanConfigsStream(
 	// to stream span configs, which will make testing easier.
 	span := roachpb.Span{Key: spanConfigKey, EndKey: spanConfigKey.PrefixEnd()}
 
-	spec := streampb.StreamPartitionSpec{
-		Spans: roachpb.Spans{span},
-		Config: streampb.StreamPartitionSpec_ExecutionConfig{
-			MinCheckpointFrequency: streamingccl.StreamReplicationMinCheckpointFrequency.Get(&evalCtx.Settings.SV),
-			SpanConfigForTenant:    tenantID,
-		}}
-	return streamSpanConfigPartition(evalCtx, spec)
+	spec := streampb.SpanConfigEventStreamSpec{
+		Span:                   span,
+		TenantID:               tenantID,
+		MinCheckpointFrequency: streamingccl.StreamReplicationMinCheckpointFrequency.Get(&evalCtx.Settings.SV),
+	}
+	return streamSpanConfigs(evalCtx, spec)
 }

--- a/pkg/repstream/streampb/stream.proto
+++ b/pkg/repstream/streampb/stream.proto
@@ -66,13 +66,23 @@ message StreamPartitionSpec {
     google.protobuf.Duration min_checkpoint_frequency = 2
        [(gogoproto.nullable) = false, (gogoproto.stdduration) = true];
 
-    // Controls batch size in bytes.
+    // Controls the batch size, in bytes, sent over pgwire to the consumer.
     int64 batch_byte_size = 3;
-
-    roachpb.TenantID span_config_for_tenant = 4 [(gogoproto.nullable) = false];
   }
 
   ExecutionConfig config = 3 [(gogoproto.nullable) = false];
+}
+
+// SpanConfigEventStreamSpec is the span config event stream specification.
+message SpanConfigEventStreamSpec {
+  roachpb.Span span = 1 [(gogoproto.nullable) = false];
+
+  roachpb.TenantID tenant_id = 2 [(gogoproto.nullable) = false, (gogoproto.customname) = "TenantID"];
+
+  // Controls how often checkpoint records are published.
+  google.protobuf.Duration min_checkpoint_frequency = 3
+  [(gogoproto.nullable) = false, (gogoproto.stdduration) = true];
+
 }
 
 message ReplicationStreamSpec {


### PR DESCRIPTION
Previously, the spanConfigEventStream used a streamPartitionSpec, which contained a bunch of fields unecessary for span config streaming. This patch creates a new spanConfigEventStreamSpec which contains the fields only necessary for span config event streaming.

Informs #109059

Release note: None