### PR TITLE
teamcity-trigger: ensure that `race` tag is only passed once

### DIFF
--- a/pkg/cmd/teamcity-trigger/main.go
+++ b/pkg/cmd/teamcity-trigger/main.go
@@ -194,7 +194,6 @@ func runTC(queueBuild func(string, map[string]string)) {
 		opts["env.EXTRA_BAZEL_FLAGS"] = fmt.Sprintf("%s --@io_bazel_rules_go//go/config:race --test_env=GORACE=halt_on_error=1", extraBazelFlags)
 		opts["env.STRESSFLAGS"] = fmt.Sprintf("-maxruns %d -maxtime %s -maxfails %d -p %d",
 			maxRuns, maxTime, maxFails, noParallelism)
-		opts["env.TAGS"] = "race"
 		queueBuildThenWait(buildID, opts)
 		delete(opts, "env.TAGS")
 	}


### PR DESCRIPTION
By running under `-race`, the go command defines the `race` build tag for us [1].

Previously, we defined it under `TAGS` to let the issue poster know that this is a failure under `race` and indicate that in the issue.

At the time, defining the tag twice didn't cause issues but after #109773, it led to build failures [2].

To reproduce locally:
```
bazel test -s --config=race pkg/util/ctxgroup:all --test_env=GOTRACEBACK=all --define gotags=bazel,gss,race
```

As a follow-up, we should find another way to let the issue poster know that a failure was running under `race`.

[1] https://go.dev/doc/articles/race_detector#Excluding_Tests
[2] https://github.com/cockroachdb/cockroach/issues/109994#issuecomment-1712534225

Epic: none
Release note: None