### PR TITLE
tree: make typeCheckSameTypedExprs order invariant for tuples

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/tuple
+++ b/pkg/sql/logictest/testdata/logic_test/tuple
@@ -1201,11 +1201,10 @@ SELECT (CASE WHEN b THEN NULL ELSE ((ROW(1) AS a)) END).a from t78159
 ----
 1
 
-# TODO(rytaft): Uncomment this case once #109105 is fixed.
-# query B
-# SELECT (CASE WHEN b THEN ((ROW(1) AS a)) ELSE NULL END).a from t78159
-# ----
-# NULL
+query B
+SELECT (CASE WHEN b THEN ((ROW(1) AS a)) ELSE NULL END).a from t78159
+----
+NULL
 
 # Regression test for #78515. Propagate tuple labels when type-checking
 # expressions with multiple matching tuple types.
@@ -1259,3 +1258,28 @@ SELECT (ROW() AS a) IS NOT UNKNOWN
 
 statement error pgcode 42601 mismatch in tuple definition: 0 expressions, 1 labels
 SELECT CASE WHEN False THEN ROW() ELSE (ROW() AS a) END
+
+subtest 109105
+
+statement ok
+CREATE TABLE t109105 (a int);
+
+statement ok
+INSERT INTO t109105 VALUES (1),(2),(3),(4),(5),(6);
+
+# This should CAST the nulls in the rows to the types of the constant values
+# instead of erroring out.
+query T
+SELECT (CASE WHEN a = 1 THEN NULL
+             WHEN a = 2 THEN ROW(NULL, NULL, 1.1e3::FLOAT)
+             WHEN a = 3 THEN ROW(NULL, 1.1::DECIMAL, NULL)
+             WHEN a = 4 THEN ROW(1::INT, null, NULL)
+             WHEN a = 5 THEN NULL
+             ELSE NULL END) FROM t109105 ORDER BY 1;
+----
+NULL
+NULL
+NULL
+(,,1100)
+(,1.1,)
+(1,,)

--- a/pkg/sql/logictest/testdata/logic_test/typing
+++ b/pkg/sql/logictest/testdata/logic_test/typing
@@ -313,3 +313,39 @@ SELECT (CASE WHEN t108360_1.t > t108360_2.c THEN t108360_1.t ELSE t108360_2.c EN
 FROM t108360_1, t108360_2
 WHERE t108360_1.t = (CASE WHEN t108360_1.t > t108360_2.c THEN t108360_1.t ELSE t108360_2.c END);
 ----
+
+subtest implicit_cast_both_directions
+
+# The following results match Postgres.
+
+# The DATE should be implicitly CAST to a timestamp.
+query T
+SELECT ARRAY['1989-01-15':::DATE,'2005-11-14 21:51:05.000581':::TIMESTAMP];
+----
+{"1989-01-15 00:00:00","2005-11-14 21:51:05.000581"}
+
+# The DATE should be implicitly CAST to a timestamp.
+query T
+SELECT ARRAY['2005-11-14 21:51:05.000581':::TIMESTAMP, '1989-01-15':::DATE];
+----
+{"2005-11-14 21:51:05.000581","1989-01-15 00:00:00"}
+
+# The DATE should be implicitly CAST to a timestamp.
+query T
+SELECT COALESCE('2005-11-14 21:51:05.000581'::TIMESTAMP, '1989-01-15'::DATE);
+----
+2005-11-14 21:51:05.000581 +0000 +0000
+
+# The DATE should be implicitly CAST to a timestamp.
+query T
+SELECT COALESCE('1989-01-15'::DATE, '2005-11-14 21:51:05.000581'::TIMESTAMP);
+----
+1989-01-15 00:00:00 +0000 +0000
+
+# We should be able to implicitly cast to float.
+query O
+SELECT array_cat_agg(
+  ARRAY[(41664367676:::INT8,),(NULL,),((-0.12116245180368423):::FLOAT8,),((-0.42116245180368423):::DECIMAL,)]
+);
+----
+{(4.1664367676e+10),(),(-0.12116245180368423),(-0.4211624518036842)}

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -2685,11 +2685,6 @@ func typeCheckSameTypedExprs(
 					candidateType = typ
 				}
 			}
-			// TODO(mgartner): Remove this check now that we check the types
-			// below.
-			if typ := typedExpr.ResolvedType(); !(typ.Equivalent(candidateType) || typ.Family() == types.UnknownFamily) {
-				return nil, nil, unexpectedTypeError(exprs[i], candidateType, typ)
-			}
 			typedExprs[i] = typedExpr
 		}
 		if !constIdxs.Empty() {
@@ -2710,9 +2705,7 @@ func typeCheckSameTypedExprs(
 		// https://www.postgresql.org/docs/15/typeconv-union-case.html
 		for i, e := range typedExprs {
 			typ := e.ResolvedType()
-			// TODO(mgartner): There should probably be a cast if the types are
-			// not identical, not just if the types are not equivalent.
-			if typ.Equivalent(candidateType) || typ.Family() == types.UnknownFamily {
+			if typ.Identical(candidateType) || typ.Family() == types.UnknownFamily {
 				continue
 			}
 			if !cast.ValidCast(typ, candidateType, cast.ContextImplicit) {

--- a/pkg/sql/sem/tree/type_check_test.go
+++ b/pkg/sql/sem/tree/type_check_test.go
@@ -171,7 +171,10 @@ func TestTypeCheck(t *testing.T) {
 			`CASE WHEN true THEN ('a', 2) ELSE NULL:::RECORD END`,
 			`CASE WHEN true THEN ('a':::STRING, 2:::INT8) ELSE NULL END`,
 		},
-
+		{
+			`CASE WHEN true THEN NULL:::RECORD ELSE ('a', 2) END`,
+			`CASE WHEN true THEN NULL ELSE ('a':::STRING, 2:::INT8) END`,
+		},
 		{`((ROW (1) AS a)).a`, `1:::INT8`},
 		{`((('1', 2) AS a, b)).a`, `'1':::STRING`},
 		{`((('1', 2) AS a, b)).b`, `2:::INT8`},


### PR DESCRIPTION
Type checking of CASE expressions (and other expressions handled by
typeCheckSameTypedExprs) does not type check tuples properly because
typeCheckSameTypedTupleExprs checking is only done when the tuple is the
first expression in `exprs`.

This is fixed by finding the first tuple in `exprs`, searching the slice
starting at index 0, and using that to drive typeCheckSameTypedExprs.

Fixes: #109105

Release note: None

----
tree: apply casts in typeCheckSameTypedExprs for non-equivalent types

Function typeCheckSameTypedExprs is updated by #108387 and #109635 to
apply implicit CASTs to the different expressions input to an array,
tuple, case expression or other similar expression, to coerce them all
to a common data type, instead of erroring out. This is not done,
however, if the data types of these expressions are not equivalent with
each other, causing some cases to error out.

The fix is to match Postgres behavior and apply the casts even for
non-equivalent types.

Informs: #109105

Release note (sql change): This patch modifies type checking of arrays,
tuples, and case statements to allow implicit casting of scalar
expressions referenced in these constructs to a common data type, even
for types in different type families, as long at the implicit cast is
legal.