### PR TITLE
storage: add MVCCCheckForAcquireLock and MVCCAcquireLock functions

### DIFF
--- a/pkg/kv/kvserver/concurrency/lock_table.go
+++ b/pkg/kv/kvserver/concurrency/lock_table.go
@@ -1093,6 +1093,9 @@ func (ulh *unreplicatedLockHolderInfo) rollbackIgnoredSeqNumbers(
 	if len(ignoredSeqNums) == 0 {
 		return
 	}
+	// NOTE: this logic differs slightly from replicated lock acquisition, where
+	// we don't rollback locks at ignored sequence numbers unless they are the
+	// same strength as the lock acquisition. See the comment in MVCCAcquireLock.
 	for strIdx, minSeqNumber := range ulh.strengths {
 		if minSeqNumber == -1 {
 			continue

--- a/pkg/storage/BUILD.bazel
+++ b/pkg/storage/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "in_mem.go",
         "intent_interleaving_iter.go",
         "lock_table_iterator.go",
+        "lock_table_key_scanner.go",
         "min_version.go",
         "mvcc.go",
         "mvcc_incremental_iterator.go",

--- a/pkg/storage/lock_table_key_scanner.go
+++ b/pkg/storage/lock_table_key_scanner.go
@@ -1,0 +1,307 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package storage
+
+import (
+	"sync"
+
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/lock"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+	"github.com/cockroachdb/errors"
+)
+
+// Fixed length slice for all supported lock strengths for replicated locks. May
+// be used to iterate supported lock strengths in strength order (strongest to
+// weakest).
+var replicatedLockStrengths = [...]lock.Strength{lock.Intent, lock.Exclusive, lock.Shared}
+
+func init() {
+	if replicatedLockStrengths[0] != lock.MaxStrength {
+		panic("replicatedLockStrengths[0] != lock.MaxStrength; update replicatedLockStrengths?")
+	}
+}
+
+// replicatedLockStrengthToIndexMap returns a mapping between (strength, index)
+// pairs that can be used to index into the lockTableScanner.ownLocks array.
+//
+// Trying to use a lock strength that isn't supported with replicated locks to
+// index into the lockTableScanner.ownLocks array will cause a runtime error.
+var replicatedLockStrengthToIndexMap = func() (m [lock.MaxStrength + 1]int) {
+	// Initialize all to -1.
+	for str := range m {
+		m[str] = -1
+	}
+	// Set the indices of the valid strengths.
+	for i, str := range replicatedLockStrengths {
+		m[str] = i
+	}
+	return m
+}()
+
+// strongerOrEqualStrengths returns all supported lock strengths for replicated
+// locks that are as strong or stronger than the provided strength. The returned
+// slice is ordered from strongest to weakest.
+func strongerOrEqualStrengths(str lock.Strength) []lock.Strength {
+	return replicatedLockStrengths[:replicatedLockStrengthToIndexMap[str]+1]
+}
+
+// minConflictLockStrength returns the minimum lock strength that conflicts with
+// the provided lock strength.
+func minConflictLockStrength(str lock.Strength) (lock.Strength, error) {
+	switch str {
+	case lock.Shared:
+		return lock.Exclusive, nil
+	case lock.Exclusive, lock.Intent:
+		return lock.Shared, nil
+	default:
+		return 0, errors.AssertionFailedf(
+			"lockTableKeyScanner: unexpected lock strength %s", str.String())
+	}
+}
+
+// lockTableKeyScanner is used to scan a single key in the replicated lock
+// table. It searches for locks on the key that conflict with a (transaction,
+// lock strength) pair and for locks that the transaction has already acquired
+// on the key.
+//
+// The purpose of a lockTableKeyScanner is to determine whether a transaction
+// can acquire a lock on a key or perform an MVCC mutation on a key, and if so,
+// what lock table keys the transaction should write to perform the operation.
+type lockTableKeyScanner struct {
+	iter *LockTableIterator
+	// The transaction attempting to acquire a lock. The ID will be zero if a
+	// non-transactional request is attempting to perform an MVCC mutation.
+	txnID uuid.UUID
+	// Stop adding conflicting locks and abort scan once the maxConflicts limit
+	// is reached. Ignored if zero.
+	maxConflicts int64
+
+	// Stores any error returned. If non-nil, iteration short circuits.
+	err error
+	// Stores any locks that conflict with the transaction and locking strength.
+	conflicts []roachpb.Lock
+	// Stores any locks that the transaction has already acquired.
+	ownLocks [len(replicatedLockStrengths)]*enginepb.MVCCMetadata
+
+	// Avoids heap allocations.
+	ltKeyBuf     []byte
+	ltValue      enginepb.MVCCMetadata
+	firstOwnLock enginepb.MVCCMetadata
+}
+
+var lockTableKeyScannerPool = sync.Pool{
+	New: func() interface{} { return new(lockTableKeyScanner) },
+}
+
+// newLockTableKeyScanner creates a new lockTableKeyScanner.
+//
+// txn is the transaction attempting to acquire locks. If txn is not nil, locks
+// held by the transaction with any strength will be accumulated into the
+// ownLocks array. Otherwise, if txn is nil, the request is non-transactional
+// and no locks will be accumulated into the ownLocks array.
+//
+// str is the strength of the lock that the transaction (or non-transactional
+// request) is attempting to acquire. The scanner will search for locks held by
+// other transactions that conflict with this strength.
+//
+// maxConflicts is the maximum number of conflicting locks that the scanner
+// should accumulate before returning an error. If maxConflicts is zero, the
+// scanner will accumulate all conflicting locks.
+func newLockTableKeyScanner(
+	reader Reader, txn *roachpb.Transaction, str lock.Strength, maxConflicts int64,
+) (*lockTableKeyScanner, error) {
+	var txnID uuid.UUID
+	if txn != nil {
+		txnID = txn.ID
+	}
+	minConflictStr, err := minConflictLockStrength(str)
+	if err != nil {
+		return nil, err
+	}
+	iter, err := NewLockTableIterator(reader, LockTableIteratorOptions{
+		Prefix:      true,
+		MatchTxnID:  txnID,
+		MatchMinStr: minConflictStr,
+	})
+	if err != nil {
+		return nil, err
+	}
+	s := lockTableKeyScannerPool.Get().(*lockTableKeyScanner)
+	s.iter = iter
+	s.txnID = txnID
+	s.maxConflicts = maxConflicts
+	return s, nil
+}
+
+func (s *lockTableKeyScanner) close() {
+	s.iter.Close()
+	*s = lockTableKeyScanner{ltKeyBuf: s.ltKeyBuf}
+	lockTableKeyScannerPool.Put(s)
+}
+
+// scan scans the lock table at the provided key for locks held by other
+// transactions that conflict with the configured locking strength and for locks
+// of any strength that the configured transaction has already acquired.
+func (s *lockTableKeyScanner) scan(key roachpb.Key) error {
+	s.resetScanState()
+	for ok := s.seek(key); ok; ok = s.getOneAndAdvance() {
+	}
+	return s.afterScan()
+}
+
+// resetScanState resets the scanner's state before a scan.
+func (s *lockTableKeyScanner) resetScanState() {
+	s.err = nil
+	s.conflicts = nil
+	for i := range s.ownLocks {
+		s.ownLocks[i] = nil
+	}
+	s.ltValue.Reset()
+	s.firstOwnLock.Reset()
+}
+
+// afterScan returns any error encountered during the scan.
+func (s *lockTableKeyScanner) afterScan() error {
+	if s.err != nil {
+		return s.err
+	}
+	if len(s.conflicts) != 0 {
+		return &kvpb.LockConflictError{Locks: s.conflicts}
+	}
+	return nil
+}
+
+// seek seeks the iterator to the first lock table key associated with the
+// provided key. Returns true if the scanner should continue scanning, false
+// if not.
+func (s *lockTableKeyScanner) seek(key roachpb.Key) bool {
+	var ltKey roachpb.Key
+	ltKey, s.ltKeyBuf = keys.LockTableSingleKey(key, s.ltKeyBuf)
+	valid, err := s.iter.SeekEngineKeyGE(EngineKey{Key: ltKey})
+	if err != nil {
+		s.err = err
+	}
+	return valid
+}
+
+// getOneAndAdvance consumes the current lock table key and value and advances
+// the iterator. Returns true if the scanner should continue scanning, false if
+// not.
+func (s *lockTableKeyScanner) getOneAndAdvance() bool {
+	ltKey, ok := s.getLockTableKey()
+	if !ok {
+		return false
+	}
+	ltValue, ok := s.getLockTableValue()
+	if !ok {
+		return false
+	}
+	if !s.consumeLockTableKeyValue(ltKey, ltValue) {
+		return false
+	}
+	return s.advance()
+}
+
+// advance advances the iterator to the next lock table key.
+func (s *lockTableKeyScanner) advance() bool {
+	valid, err := s.iter.NextEngineKey()
+	if err != nil {
+		s.err = err
+	}
+	return valid
+}
+
+// getLockTableKey decodes the current lock table key.
+func (s *lockTableKeyScanner) getLockTableKey() (LockTableKey, bool) {
+	ltEngKey, err := s.iter.UnsafeEngineKey()
+	if err != nil {
+		s.err = err
+		return LockTableKey{}, false
+	}
+	ltKey, err := ltEngKey.ToLockTableKey()
+	if err != nil {
+		s.err = err
+		return LockTableKey{}, false
+	}
+	return ltKey, true
+}
+
+// getLockTableValue decodes the current lock table values.
+func (s *lockTableKeyScanner) getLockTableValue() (*enginepb.MVCCMetadata, bool) {
+	err := s.iter.ValueProto(&s.ltValue)
+	if err != nil {
+		s.err = err
+		return nil, false
+	}
+	return &s.ltValue, true
+}
+
+// consumeLockTableKeyValue consumes the current lock table key and value, which
+// is either a conflicting lock or a lock held by the scanning transaction.
+func (s *lockTableKeyScanner) consumeLockTableKeyValue(
+	ltKey LockTableKey, ltValue *enginepb.MVCCMetadata,
+) bool {
+	if ltValue.Txn == nil {
+		s.err = errors.AssertionFailedf("unexpectedly found non-transactional lock: %v", ltValue)
+		return false
+	}
+	if ltKey.TxnUUID != ltValue.Txn.ID {
+		s.err = errors.AssertionFailedf("lock table key (%+v) and value (%+v) txn ID mismatch", ltKey, ltValue)
+		return false
+	}
+	if ltKey.TxnUUID == s.txnID {
+		return s.consumeOwnLock(ltKey, ltValue)
+	}
+	return s.consumeConflictingLock(ltKey, ltValue)
+}
+
+// consumeOwnLock consumes a lock held by the scanning transaction.
+func (s *lockTableKeyScanner) consumeOwnLock(
+	ltKey LockTableKey, ltValue *enginepb.MVCCMetadata,
+) bool {
+	var ltValueCopy *enginepb.MVCCMetadata
+	if s.firstOwnLock.Txn == nil {
+		// This is the first lock held by the transaction that we've seen, so
+		// we can avoid the heap allocation.
+		ltValueCopy = &s.firstOwnLock
+	} else {
+		ltValueCopy = new(enginepb.MVCCMetadata)
+	}
+	// NOTE: this will alias internal pointer fields of ltValueCopy with those
+	// in ltValue, but this will not lead to issues when ltValue is updated by
+	// the next call to getLockTableValue, because its internal fields will be
+	// reset by protoutil.Unmarshal before unmarshalling.
+	*ltValueCopy = *ltValue
+	s.ownLocks[replicatedLockStrengthToIndexMap[ltKey.Strength]] = ltValueCopy
+	return true
+}
+
+// consumeConflictingLock consumes a conflicting lock.
+func (s *lockTableKeyScanner) consumeConflictingLock(
+	ltKey LockTableKey, ltValue *enginepb.MVCCMetadata,
+) bool {
+	conflict := roachpb.MakeLock(ltValue.Txn, ltKey.Key.Clone(), ltKey.Strength)
+	s.conflicts = append(s.conflicts, conflict)
+	if s.maxConflicts != 0 && s.maxConflicts == int64(len(s.conflicts)) {
+		return false
+	}
+	return true
+}
+
+// foundOwn returns the lock table value for the provided strength if the
+// transaction has already acquired a lock of that strength. Returns nil if not.
+func (s *lockTableKeyScanner) foundOwn(str lock.Strength) *enginepb.MVCCMetadata {
+	return s.ownLocks[replicatedLockStrengthToIndexMap[str]]
+}

--- a/pkg/storage/mvcc_history_test.go
+++ b/pkg/storage/mvcc_history_test.go
@@ -75,17 +75,19 @@ var (
 //
 // txn_begin      t=<name> [ts=<int>[,<int>]] [globalUncertaintyLimit=<int>[,<int>]]
 // txn_remove     t=<name>
-// txn_restart    t=<name>
+// txn_restart    t=<name> [epoch=<int>]
 // txn_update     t=<name> t2=<name>
-// txn_step       t=<name> [n=<int>]
+// txn_step       t=<name> [n=<int>] [seq=<int>]
 // txn_advance    t=<name> ts=<int>[,<int>]
 // txn_status     t=<name> status=<txnstatus>
 // txn_ignore_seqs t=<name> seqs=[<int>-<int>[,<int>-<int>...]]
 //
-// resolve_intent        t=<name> k=<key> [status=<txnstatus>] [clockWhilePending=<int>[,<int>]] [targetBytes=<int>]
-// resolve_intent_range  t=<name> k=<key> end=<key> [status=<txnstatus>] [maxKeys=<int>] [targetBytes=<int>]
-// check_intent          k=<key> [none]
-// add_unreplicated_lock t=<name> k=<key>
+// resolve_intent         t=<name> k=<key> [status=<txnstatus>] [clockWhilePending=<int>[,<int>]] [targetBytes=<int>]
+// resolve_intent_range   t=<name> k=<key> end=<key> [status=<txnstatus>] [maxKeys=<int>] [targetBytes=<int>]
+// check_intent           k=<key> [none]
+// add_unreplicated_lock  t=<name> k=<key>
+// check_for_acquire_lock t=<name> k=<key> str=<strength>
+// acquire_lock           t=<name> k=<key> str=<strength>
 //
 // cput           [t=<name>] [ts=<int>[,<int>]] [localTs=<int>[,<int>]] [resolve [status=<txnstatus>]] [ambiguousReplay] k=<key> v=<string> [raw] [cond=<string>]
 // del            [t=<name>] [ts=<int>[,<int>]] [localTs=<int>[,<int>]] [resolve [status=<txnstatus>]] [ambiguousReplay] k=<key>
@@ -354,6 +356,43 @@ func TestMVCCHistories(t *testing.T) {
 
 		// reportLockTable outputs the contents of the lock table.
 		reportLockTable := func(e *evalCtx, buf *redact.StringBuilder) error {
+			// Replicated locks.
+			ltStart := keys.LocalRangeLockTablePrefix
+			ltEnd := keys.LocalRangeLockTablePrefix.PrefixEnd()
+			iter, err := engine.NewEngineIterator(storage.IterOptions{UpperBound: ltEnd})
+			if err != nil {
+				return err
+			}
+			defer iter.Close()
+
+			var meta enginepb.MVCCMetadata
+			for valid, err := iter.SeekEngineKeyGE(storage.EngineKey{Key: ltStart}); ; valid, err = iter.NextEngineKey() {
+				if err != nil {
+					return err
+				} else if !valid {
+					break
+				}
+				eKey, err := iter.EngineKey()
+				if err != nil {
+					return err
+				}
+				ltKey, err := eKey.ToLockTableKey()
+				if err != nil {
+					return errors.Wrapf(err, "decoding LockTable key: %v", eKey)
+				}
+				// Unmarshal.
+				v, err := iter.UnsafeValue()
+				if err != nil {
+					return err
+				}
+				if err := protoutil.Unmarshal(v, &meta); err != nil {
+					return errors.Wrapf(err, "unmarshaling mvcc meta: %v", ltKey)
+				}
+				buf.Printf("lock (%s): %v/%s -> %+v\n",
+					lock.Replicated, ltKey.Key, ltKey.Strength, &meta)
+			}
+
+			// Unreplicated locks.
 			if len(e.unreplLocks) > 0 {
 				var ks []string
 				for k := range e.unreplLocks {
@@ -732,10 +771,12 @@ var commands = map[string]cmd{
 	"txn_step":        {typTxnUpdate, cmdTxnStep},
 	"txn_update":      {typTxnUpdate, cmdTxnUpdate},
 
-	"resolve_intent":        {typDataUpdate, cmdResolveIntent},
-	"resolve_intent_range":  {typDataUpdate, cmdResolveIntentRange},
-	"check_intent":          {typReadOnly, cmdCheckIntent},
-	"add_unreplicated_lock": {typLocksUpdate, cmdAddUnreplicatedLock},
+	"resolve_intent":         {typDataUpdate, cmdResolveIntent},
+	"resolve_intent_range":   {typDataUpdate, cmdResolveIntentRange},
+	"check_intent":           {typReadOnly, cmdCheckIntent},
+	"add_unreplicated_lock":  {typLocksUpdate, cmdAddUnreplicatedLock},
+	"check_for_acquire_lock": {typReadOnly, cmdCheckForAcquireLock},
+	"acquire_lock":           {typLocksUpdate, cmdAcquireLock},
 
 	"clear":                 {typDataUpdate, cmdClear},
 	"clear_range":           {typDataUpdate, cmdClearRange},
@@ -846,6 +887,11 @@ func cmdTxnRestart(e *evalCtx) error {
 	up := roachpb.NormalUserPriority
 	tp := enginepb.MinTxnPriority
 	txn.Restart(up, tp, ts)
+	if e.hasArg("epoch") {
+		var epoch int
+		e.scanArg("epoch", &epoch)
+		txn.Epoch = enginepb.TxnEpoch(epoch)
+	}
 	e.results.txn = txn
 	return nil
 }
@@ -1011,6 +1057,24 @@ func cmdAddUnreplicatedLock(e *evalCtx) error {
 	key := e.getKey()
 	e.unreplLocks[string(key)] = &txn.TxnMeta
 	return nil
+}
+
+func cmdCheckForAcquireLock(e *evalCtx) error {
+	return e.withReader(func(r storage.Reader) error {
+		txn := e.getTxn(optional)
+		key := e.getKey()
+		str := e.getStrength()
+		return storage.MVCCCheckForAcquireLock(e.ctx, r, txn, str, key, 0)
+	})
+}
+
+func cmdAcquireLock(e *evalCtx) error {
+	return e.withWriter("acquire_lock", func(rw storage.ReadWriter) error {
+		txn := e.getTxn(optional)
+		key := e.getKey()
+		str := e.getStrength()
+		return storage.MVCCAcquireLock(e.ctx, rw, txn, str, key, e.ms, 0)
+	})
 }
 
 func cmdClear(e *evalCtx) error {
@@ -2455,6 +2519,25 @@ func (e *evalCtx) getKeyRange() (sk, ek roachpb.Key) {
 		ek = toKey(endKeyS, codec)
 	}
 	return sk, ek
+}
+
+func (e *evalCtx) getStrength() lock.Strength {
+	e.t.Helper()
+	var strS string
+	e.scanArg("str", &strS)
+	switch strS {
+	case "none":
+		return lock.None
+	case "shared":
+		return lock.Shared
+	case "exclusive":
+		return lock.Exclusive
+	case "intent":
+		return lock.Intent
+	default:
+		e.Fatalf("unknown lock strength: %s", strS)
+		return 0
+	}
 }
 
 func (e *evalCtx) getTenantCodec() keys.SQLCodec {

--- a/pkg/storage/testdata/mvcc_histories/replicated_locks
+++ b/pkg/storage/testdata/mvcc_histories/replicated_locks
@@ -1,0 +1,318 @@
+run ok
+txn_begin t=A ts=10,0
+txn_begin t=B ts=11,0
+----
+>> at end:
+txn: "B" meta={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=11.000000000,0 wto=false gul=0,0
+
+run ok
+with t=A
+  check_for_acquire_lock k=k1 str=shared
+  check_for_acquire_lock k=k2 str=shared
+  check_for_acquire_lock k=k3 str=exclusive
+  acquire_lock k=k1 str=shared
+  acquire_lock k=k2 str=shared
+  acquire_lock k=k3 str=exclusive
+----
+>> at end:
+lock (Replicated): "k1"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=0} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+lock (Replicated): "k2"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=0} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+lock (Replicated): "k3"/Exclusive -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=0} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+
+# Reacquire with weaker, equal, and stronger strengths. All should succeed, but
+# only the stronger strength should actually write a new lock key.
+
+run ok
+with t=A
+  acquire_lock k=k2 str=shared
+  acquire_lock k=k2 str=exclusive
+  acquire_lock k=k3 str=shared
+  acquire_lock k=k3 str=exclusive
+----
+>> at end:
+lock (Replicated): "k1"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=0} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+lock (Replicated): "k2"/Exclusive -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=0} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+lock (Replicated): "k2"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=0} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+lock (Replicated): "k3"/Exclusive -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=0} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+
+# Reacquire with weaker, equal, and stronger strengths in new epoch. All should
+# succeed, but only the stronger strength acquisitions (in the new epoch) should
+# actually (re)write lock keys.
+
+run ok
+with t=A
+  txn_restart
+  acquire_lock k=k1 str=shared
+  acquire_lock k=k2 str=shared
+  acquire_lock k=k2 str=exclusive
+  acquire_lock k=k3 str=exclusive
+  acquire_lock k=k3 str=shared
+----
+>> at end:
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=10.000000000,0 wto=false gul=0,0
+lock (Replicated): "k1"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=0} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+lock (Replicated): "k2"/Exclusive -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=0} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+lock (Replicated): "k2"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=0} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+lock (Replicated): "k3"/Exclusive -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=0} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+
+# Reacquisition of the same locks in the same epoch with later sequences should
+# be no-ops.
+
+run ok
+with t=A
+  txn_step
+  acquire_lock k=k1 str=shared
+  acquire_lock k=k2 str=shared
+  acquire_lock k=k2 str=exclusive
+  acquire_lock k=k3 str=exclusive
+  acquire_lock k=k3 str=shared
+----
+>> at end:
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=10.000000000,0 wto=false gul=0,0
+lock (Replicated): "k1"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=0} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+lock (Replicated): "k2"/Exclusive -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=0} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+lock (Replicated): "k2"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=0} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+lock (Replicated): "k3"/Exclusive -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=0} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+
+# Reacquisition of the same locks in the same epoch with later sequences after
+# the earlier sequence has been rolled back should rewrite the locks with the
+# newer sequence.
+
+run ok
+with t=A
+  txn_ignore_seqs seqs=0-0
+  acquire_lock k=k1 str=shared
+  acquire_lock k=k2 str=shared
+  acquire_lock k=k2 str=exclusive
+  acquire_lock k=k3 str=exclusive
+  acquire_lock k=k3 str=shared
+----
+>> at end:
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=10.000000000,0 wto=false gul=0,0 isn=1
+lock (Replicated): "k1"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+lock (Replicated): "k2"/Exclusive -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+lock (Replicated): "k2"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+lock (Replicated): "k3"/Exclusive -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+
+# Txn B can only acquire a shared lock on k1.
+
+run ok
+with t=B
+  check_for_acquire_lock k=k1 str=shared
+  acquire_lock k=k1 str=shared
+----
+>> at end:
+lock (Replicated): "k1"/Shared -> txn={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+lock (Replicated): "k1"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+lock (Replicated): "k2"/Exclusive -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+lock (Replicated): "k2"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+lock (Replicated): "k3"/Exclusive -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+
+run error
+check_for_acquire_lock t=B k=k1 str=exclusive
+----
+error: (*kvpb.LockConflictError:) conflicting locks on "k1"
+
+run error
+acquire_lock t=B k=k1 str=exclusive
+----
+>> at end:
+lock (Replicated): "k1"/Shared -> txn={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+lock (Replicated): "k1"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+lock (Replicated): "k2"/Exclusive -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+lock (Replicated): "k2"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+lock (Replicated): "k3"/Exclusive -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+error: (*kvpb.LockConflictError:) conflicting locks on "k1"
+
+run error
+check_for_acquire_lock t=B k=k2 str=shared
+----
+error: (*kvpb.LockConflictError:) conflicting locks on "k2"
+
+run error
+acquire_lock t=B k=k2 str=shared
+----
+>> at end:
+lock (Replicated): "k1"/Shared -> txn={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+lock (Replicated): "k1"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+lock (Replicated): "k2"/Exclusive -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+lock (Replicated): "k2"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+lock (Replicated): "k3"/Exclusive -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+error: (*kvpb.LockConflictError:) conflicting locks on "k2"
+
+run error
+check_for_acquire_lock t=B k=k2 str=exclusive
+----
+error: (*kvpb.LockConflictError:) conflicting locks on "k2", "k2"
+
+run error
+acquire_lock t=B k=k2 str=exclusive
+----
+>> at end:
+lock (Replicated): "k1"/Shared -> txn={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+lock (Replicated): "k1"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+lock (Replicated): "k2"/Exclusive -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+lock (Replicated): "k2"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+lock (Replicated): "k3"/Exclusive -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+error: (*kvpb.LockConflictError:) conflicting locks on "k2", "k2"
+
+run error
+check_for_acquire_lock t=B k=k3 str=shared
+----
+error: (*kvpb.LockConflictError:) conflicting locks on "k3"
+
+run error
+acquire_lock t=B k=k3 str=shared
+----
+>> at end:
+lock (Replicated): "k1"/Shared -> txn={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+lock (Replicated): "k1"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+lock (Replicated): "k2"/Exclusive -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+lock (Replicated): "k2"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+lock (Replicated): "k3"/Exclusive -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+error: (*kvpb.LockConflictError:) conflicting locks on "k3"
+
+run error
+check_for_acquire_lock t=B k=k3 str=exclusive
+----
+error: (*kvpb.LockConflictError:) conflicting locks on "k3"
+
+run error
+acquire_lock t=B k=k3 str=exclusive
+----
+>> at end:
+lock (Replicated): "k1"/Shared -> txn={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+lock (Replicated): "k1"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+lock (Replicated): "k2"/Exclusive -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+lock (Replicated): "k2"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+lock (Replicated): "k3"/Exclusive -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+error: (*kvpb.LockConflictError:) conflicting locks on "k3"
+
+# Now that there are two shared locks on key k1, txn A can no longer upgrade its lock.
+
+run error
+check_for_acquire_lock t=A k=k1 str=exclusive
+----
+error: (*kvpb.LockConflictError:) conflicting locks on "k1"
+
+run error
+acquire_lock t=A k=k1 str=exclusive
+----
+>> at end:
+lock (Replicated): "k1"/Shared -> txn={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+lock (Replicated): "k1"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+lock (Replicated): "k2"/Exclusive -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+lock (Replicated): "k2"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+lock (Replicated): "k3"/Exclusive -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+error: (*kvpb.LockConflictError:) conflicting locks on "k1"
+
+# Intents are treated similarly to Exclusive locks.
+
+run ok
+put t=A k=k4 v=v4
+----
+>> at end:
+meta: "k4"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=10.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "k4"/10.000000000,0 -> /BYTES/v4
+
+run ok
+with t=A
+  check_for_acquire_lock k=k4 str=shared
+  check_for_acquire_lock k=k4 str=exclusive
+  acquire_lock k=k4 str=shared
+  acquire_lock k=k4 str=exclusive
+----
+>> at end:
+lock (Replicated): "k1"/Shared -> txn={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+lock (Replicated): "k1"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+lock (Replicated): "k2"/Exclusive -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+lock (Replicated): "k2"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+lock (Replicated): "k3"/Exclusive -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+lock (Replicated): "k4"/Intent -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=10.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+
+run error
+check_for_acquire_lock t=B k=k4 str=shared
+----
+error: (*kvpb.LockConflictError:) conflicting locks on "k4"
+
+run error
+acquire_lock t=B k=k4 str=shared
+----
+>> at end:
+lock (Replicated): "k1"/Shared -> txn={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+lock (Replicated): "k1"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+lock (Replicated): "k2"/Exclusive -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+lock (Replicated): "k2"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+lock (Replicated): "k3"/Exclusive -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+lock (Replicated): "k4"/Intent -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=10.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+error: (*kvpb.LockConflictError:) conflicting locks on "k4"
+
+# The intent history is considered when determining whether a reacquisition is
+# needed on the same key as a previous intent write.
+
+run ok
+with t=A
+  txn_step
+  put k=k4 v=v4_prime
+----
+>> at end:
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=2} lock=true stat=PENDING rts=10.000000000,0 wto=false gul=0,0 isn=1
+meta: "k4"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=2} ts=10.000000000,0 del=false klen=12 vlen=13 ih={{1 /BYTES/v4}} mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "k4"/10.000000000,0 -> /BYTES/v4_prime
+
+run ok
+with t=A
+  txn_step
+  acquire_lock k=k4 str=shared
+----
+>> at end:
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=3} lock=true stat=PENDING rts=10.000000000,0 wto=false gul=0,0 isn=1
+lock (Replicated): "k1"/Shared -> txn={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+lock (Replicated): "k1"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+lock (Replicated): "k2"/Exclusive -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+lock (Replicated): "k2"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+lock (Replicated): "k3"/Exclusive -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+lock (Replicated): "k4"/Intent -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=2} ts=10.000000000,0 del=false klen=12 vlen=13 ih={{1 /BYTES/v4}} mergeTs=<nil> txnDidNotUpdateMeta=false
+
+run
+with t=A
+  txn_ignore_seqs seqs=2-2
+  acquire_lock k=k4 str=shared
+----
+>> at end:
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=3} lock=true stat=PENDING rts=10.000000000,0 wto=false gul=0,0 isn=1
+lock (Replicated): "k1"/Shared -> txn={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+lock (Replicated): "k1"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+lock (Replicated): "k2"/Exclusive -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+lock (Replicated): "k2"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+lock (Replicated): "k3"/Exclusive -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+lock (Replicated): "k4"/Intent -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=2} ts=10.000000000,0 del=false klen=12 vlen=13 ih={{1 /BYTES/v4}} mergeTs=<nil> txnDidNotUpdateMeta=false
+
+run
+with t=A
+  txn_ignore_seqs seqs=1-2
+  acquire_lock k=k4 str=shared
+----
+>> at end:
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=3} lock=true stat=PENDING rts=10.000000000,0 wto=false gul=0,0 isn=1
+lock (Replicated): "k1"/Shared -> txn={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+lock (Replicated): "k1"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+lock (Replicated): "k2"/Exclusive -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+lock (Replicated): "k2"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+lock (Replicated): "k3"/Exclusive -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+lock (Replicated): "k4"/Intent -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=2} ts=10.000000000,0 del=false klen=12 vlen=13 ih={{1 /BYTES/v4}} mergeTs=<nil> txnDidNotUpdateMeta=false
+lock (Replicated): "k4"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=3} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+
+# Replicated locks are ignored by non-locking scans by any transaction. Note
+# that we terminate scans at key "k4" to ignore the intent that we just wrote,
+# which is not ignored by non-locking scans.
+
+run ok
+with k=k1 end=k4
+  scan t=A
+  scan t=B
+  scan notxn
+----
+scan: "k1"-"k4" -> <no data>
+scan: "k1"-"k4" -> <no data>
+scan: "k1"-"k4" -> <no data>

--- a/pkg/storage/testdata/mvcc_histories/replicated_locks_errors
+++ b/pkg/storage/testdata/mvcc_histories/replicated_locks_errors
@@ -1,0 +1,81 @@
+# Test invalid lock acquisition inputs.
+
+run error
+check_for_acquire_lock notxn k=k1 str=shared
+----
+error: (*withstack.withStack:) txn must be non-nil to acquire lock
+
+run error
+acquire_lock notxn k=k1 str=shared
+----
+>> at end:
+error: (*withstack.withStack:) txn must be non-nil to acquire lock
+
+run ok
+txn_begin t=A ts=10,0
+----
+>> at end:
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=10.000000000,0 wto=false gul=0,0
+
+run error
+check_for_acquire_lock t=A k=k1 str=none
+----
+error: (*withstack.withStack:) invalid lock strength to acquire lock: None
+
+run error
+check_for_acquire_lock t=A k=k1 str=intent
+----
+error: (*withstack.withStack:) invalid lock strength to acquire lock: Intent
+
+run error
+acquire_lock t=A k=k1 str=none
+----
+>> at end:
+error: (*withstack.withStack:) invalid lock strength to acquire lock: None
+
+run error
+acquire_lock t=A k=k1 str=intent
+----
+>> at end:
+error: (*withstack.withStack:) invalid lock strength to acquire lock: Intent
+
+
+# Test stale lock acquisition.
+
+run ok
+with t=A
+  txn_step seq=10
+  acquire_lock t=A k=k1 str=shared
+----
+>> at end:
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=10} lock=true stat=PENDING rts=10.000000000,0 wto=false gul=0,0
+lock (Replicated): "k1"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=10} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+
+run error
+with t=A
+  txn_step seq=5
+  acquire_lock t=A k=k1 str=shared
+----
+>> at end:
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=5} lock=true stat=PENDING rts=10.000000000,0 wto=false gul=0,0
+lock (Replicated): "k1"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=10} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+error: (*withstack.withStack:) cannot acquire lock with strength Shared at seq number 5, already held at higher seq number 10
+
+run ok
+with t=A
+  txn_restart epoch=2
+  acquire_lock t=A k=k1 str=shared
+----
+>> at end:
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=2 ts=10.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=10.000000000,0 wto=false gul=0,0
+lock (Replicated): "k1"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=2 ts=10.000000000,0 min=0,0 seq=0} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+
+run error
+with t=A
+  txn_restart epoch=1
+  acquire_lock t=A k=k1 str=shared
+----
+>> at end:
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=10.000000000,0 wto=false gul=0,0
+lock (Replicated): "k1"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=2 ts=10.000000000,0 min=0,0 seq=0} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+error: (*withstack.withStack:) locking request with epoch 1 came after lock had already been acquired at epoch 2 in txn 00000001-0000-0000-0000-000000000000

--- a/pkg/storage/testdata/mvcc_histories/skip_locked
+++ b/pkg/storage/testdata/mvcc_histories/skip_locked
@@ -28,7 +28,7 @@ put k=k2 v=v3 ts=13,0 t=B
 put k=k3 v=v4 ts=14,0 t=C
 put k=k4 v=v5 ts=15,0
 put k=k5 v=v6 ts=17,0
-add_lock k=k4 t=E
+add_unreplicated_lock k=k4 t=E
 ----
 >> at end:
 data: "k1"/11.000000000,0 -> /BYTES/v1
@@ -39,7 +39,7 @@ meta: "k3"/0,0 -> txn={id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=
 data: "k3"/14.000000000,0 -> /BYTES/v4
 data: "k4"/15.000000000,0 -> /BYTES/v5
 data: "k5"/17.000000000,0 -> /BYTES/v6
-lock-table: {k4:00000005-0000-0000-0000-000000000000}
+lock (Unreplicated): k4/Exclusive -> id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=16.000000000,0 min=0,0 seq=0
 
 # Test cases:
 #

--- a/pkg/storage/testdata/mvcc_histories/skip_locked
+++ b/pkg/storage/testdata/mvcc_histories/skip_locked
@@ -39,6 +39,8 @@ meta: "k3"/0,0 -> txn={id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=
 data: "k3"/14.000000000,0 -> /BYTES/v4
 data: "k4"/15.000000000,0 -> /BYTES/v5
 data: "k5"/17.000000000,0 -> /BYTES/v6
+lock (Replicated): "k2"/Intent -> txn={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0} ts=13.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+lock (Replicated): "k3"/Intent -> txn={id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0} ts=14.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 lock (Unreplicated): k4/Exclusive -> id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=16.000000000,0 min=0,0 seq=0
 
 # Test cases:


### PR DESCRIPTION
Fixes #109646.
Informs #100193.

This PR adds and implements two new MVCC functions: `MVCCCheckForAcquireLock` and `MVCCAcquireLock`. The former scans the replicated lock table to determine whether a lock acquisition is permitted. It will be used by unreplicated lock acquisition. The latter does the same, but then also writes the lock to the replicated lock table if permitted. It will be used by replicated lock acquisition.

MVCCStats handling is left as a TODO for after #109645 is addressed.

----

The two functions are built using a new abstraction, the `lockTableKeyScanner`.

The `lockTableKeyScanner` uses a `LockTableIterator` to scan a single key in the replicated lock table. It searches for locks on the key that conflict with a (transaction, strength) pair and for locks that the transaction has already acquired on the key.

The purpose of a `lockTableKeyScanner` is to determine whether a transaction can acquire a lock on a key or perform an MVCC mutation on a key, and if so, what lock table keys the transaction should write to perform the operation. It is used by this commit to implement the two new MVCC functions. In a future commit, it will also start to be used by `mvccPutInternal`, the kernel of all MVCC mutations.

Release note: None