### PR TITLE
storage: implement intent resolution using LockTableIterator

### DIFF
--- a/pkg/kv/kvserver/batch_spanset_test.go
+++ b/pkg/kv/kvserver/batch_spanset_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
@@ -581,7 +582,7 @@ func TestSpanSetMVCCResolveWriteIntentRange(t *testing.T) {
 	defer batch.Close()
 	intent := roachpb.LockUpdate{
 		Span:   roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("b\x00")},
-		Txn:    enginepb.TxnMeta{}, // unused
+		Txn:    enginepb.TxnMeta{ID: uuid.MakeV4()}, // unused
 		Status: roachpb.PENDING,
 	}
 	if _, _, _, _, err := storage.MVCCResolveWriteIntentRange(

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -4722,7 +4722,7 @@ func TestEndTxnRollbackAbortedTransaction(t *testing.T) {
 
 			if pErr := tc.store.intentResolver.ResolveIntents(ctx,
 				[]roachpb.LockUpdate{
-					roachpb.MakeLockUpdate(&txnRecord, roachpb.Span{Key: key}),
+					roachpb.MakeLockUpdate(txn, roachpb.Span{Key: key}),
 				}, intentresolver.ResolveOptions{Poison: true}); pErr != nil {
 				t.Fatal(pErr)
 			}

--- a/pkg/kv/kvserver/spanset/BUILD.bazel
+++ b/pkg/kv/kvserver/spanset/BUILD.bazel
@@ -16,7 +16,6 @@ go_library(
         "//pkg/util/hlc",
         "//pkg/util/log",
         "//pkg/util/protoutil",
-        "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_pebble//:pebble",
         "@com_github_cockroachdb_pebble//rangekey",

--- a/pkg/kv/kvserver/spanset/batch.go
+++ b/pkg/kv/kvserver/spanset/batch.go
@@ -20,7 +20,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
-	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/pebble"
 	"github.com/cockroachdb/pebble/rangekey"
 )
@@ -83,12 +82,6 @@ func (i *MVCCIterator) Valid() (bool, error) {
 func (i *MVCCIterator) SeekGE(key storage.MVCCKey) {
 	i.i.SeekGE(key)
 	i.checkAllowed(roachpb.Span{Key: key.Key}, true)
-}
-
-// SeekIntentGE is part of the storage.MVCCIterator interface.
-func (i *MVCCIterator) SeekIntentGE(key roachpb.Key, txnUUID uuid.UUID) {
-	i.i.SeekIntentGE(key, txnUUID)
-	i.checkAllowed(roachpb.Span{Key: key}, true)
 }
 
 // SeekLT is part of the storage.MVCCIterator interface.

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -257,13 +257,6 @@ type MVCCIterator interface {
 	// the first key.
 	Prev()
 
-	// SeekIntentGE is a specialized version of SeekGE(MVCCKey{Key: key}), when
-	// the caller expects to find an intent, and additionally has the txnUUID
-	// for the intent it is looking for. When running with separated intents,
-	// this can optimize the behavior of the underlying Engine for write heavy
-	// keys by avoiding the need to iterate over many deleted intents.
-	SeekIntentGE(key roachpb.Key, txnUUID uuid.UUID)
-
 	// UnsafeRawKey returns the current raw key which could be an encoded
 	// MVCCKey, or the more general EngineKey (for a lock table key).
 	// This is a low-level and dangerous method since it will expose the

--- a/pkg/storage/mvcc_history_metamorphic_iterator_test.go
+++ b/pkg/storage/mvcc_history_metamorphic_iterator_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
-	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/pebble"
 	"github.com/stretchr/testify/require"
 )
@@ -146,11 +145,6 @@ func (m *metamorphicIterator) moveAround() {
 		actions = append(actions, action{
 			"SeekLT(cur)",
 			func() { mvccIt.SeekLT(cur) },
-		}, action{
-			"SeekIntentGE(cur, 00000)",
-			func() {
-				mvccIt.SeekIntentGE(cur.Key, uuid.Nil)
-			},
 		}, action{
 			"SeekLT(Max)",
 			func() { mvccIt.SeekLT(storage.MVCCKeyMax) },
@@ -367,11 +361,6 @@ func (m *metamorphicMVCCIterator) Prev() {
 
 func (m *metamorphicMVCCIterator) UnsafeLazyValue() pebble.LazyValue {
 	return m.it.(storage.MVCCIterator).UnsafeLazyValue()
-}
-
-func (m *metamorphicMVCCIterator) SeekIntentGE(key roachpb.Key, txnUUID uuid.UUID) {
-	m.it.(storage.MVCCIterator).SeekIntentGE(key, txnUUID)
-	m.moveAround()
 }
 
 func (m *metamorphicMVCCIterator) UnsafeRawKey() []byte {

--- a/pkg/storage/mvcc_history_test.go
+++ b/pkg/storage/mvcc_history_test.go
@@ -107,7 +107,6 @@ var (
 // iter_new_incremental [k=<key>] [end=<key>] [startTs=<int>[,<int>]] [endTs=<int>[,<int>]] [types=pointsOnly|pointsWithRanges|pointsAndRanges|rangesOnly] [maskBelow=<int>[,<int>]] [intents=error|aggregate|emit]
 // iter_seek_ge   k=<key> [ts=<int>[,<int>]]
 // iter_seek_lt   k=<key> [ts=<int>[,<int>]]
-// iter_seek_intent_ge k=<key> txn=<name>
 // iter_next
 // iter_next_ignoring_time
 // iter_next_key_ignoring_time
@@ -805,7 +804,6 @@ var commands = map[string]cmd{
 	"iter_new_read_as_of":         {typReadOnly, cmdIterNewReadAsOf},    // readAsOfIterator
 	"iter_seek_ge":                {typReadOnly, cmdIterSeekGE},
 	"iter_seek_lt":                {typReadOnly, cmdIterSeekLT},
-	"iter_seek_intent_ge":         {typReadOnly, cmdIterSeekIntentGE},
 	"iter_next":                   {typReadOnly, cmdIterNext},
 	"iter_next_ignoring_time":     {typReadOnly, cmdIterNextIgnoringTime},    // MVCCIncrementalIterator
 	"iter_next_key_ignoring_time": {typReadOnly, cmdIterNextKeyIgnoringTime}, // MVCCIncrementalIterator
@@ -1921,16 +1919,6 @@ func cmdIterSeekGE(e *evalCtx) error {
 	key := e.getKey()
 	ts := e.getTs(nil)
 	e.iter.SeekGE(storage.MVCCKey{Key: key, Timestamp: ts})
-	printIter(e)
-	return nil
-}
-
-func cmdIterSeekIntentGE(e *evalCtx) error {
-	key := e.getKey()
-	var txnName string
-	e.scanArg("txn", &txnName)
-	txn := e.txns[txnName]
-	e.mvccIter().SeekIntentGE(key, txn.ID)
 	printIter(e)
 	return nil
 }

--- a/pkg/storage/mvcc_test.go
+++ b/pkg/storage/mvcc_test.go
@@ -3669,13 +3669,11 @@ func TestMVCCResolveTxnRangeResumeWithManyVersions(t *testing.T) {
 		numKeys, _, resumeSpan, _, err := MVCCResolveWriteIntentRange(ctx, engine, nil, lockUpdate,
 			MVCCResolveWriteIntentRangeOptions{MaxKeys: 20})
 		require.NoError(t, err)
-		if resumeSpan == nil {
-			// Last call resolves 0 intents.
-			require.Equal(t, int64(0), numKeys)
-			break
-		}
 		require.Equal(t, int64(20), numKeys)
 		i++
+		if resumeSpan == nil {
+			break
+		}
 		expResumeSpan := roachpb.Span{
 			Key:    makeKey(nil, (i*20-1)*10).Next(),
 			EndKey: lockUpdate.EndKey,

--- a/pkg/storage/pebble_iterator.go
+++ b/pkg/storage/pebble_iterator.go
@@ -21,7 +21,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/pebbleiter"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
-	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble"
 	"github.com/cockroachdb/pebble/sstable"
@@ -335,11 +334,6 @@ func (p *pebbleIterator) SeekGE(key MVCCKey) {
 	} else {
 		p.iter.SeekGE(p.keyBuf)
 	}
-}
-
-// SeekIntentGE implements the MVCCIterator interface.
-func (p *pebbleIterator) SeekIntentGE(key roachpb.Key, _ uuid.UUID) {
-	p.SeekGE(MVCCKey{Key: key})
 }
 
 // SeekEngineKeyGE implements the EngineIterator interface.

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_iter
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_iter
@@ -998,63 +998,6 @@ iter_next_key: {h-k}/[1.000000000,0=/<empty>] !
 iter_seek_ge: "d"/0,0=txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>] !
 iter_next_key: "e"/3.000000000,0=/BYTES/e3 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
 
-# Test SeekIntentGE both with and without intents and range keys.
-run ok
-iter_new types=pointsAndRanges
-iter_seek_intent_ge k=b txn=A
-iter_seek_intent_ge k=d txn=A
-iter_seek_intent_ge k=i txn=A
-iter_seek_intent_ge k=j txn=A
-iter_seek_intent_ge k=k txn=A
-----
-iter_seek_intent_ge: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
-iter_seek_intent_ge: "d"/0,0=txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>] !
-iter_seek_intent_ge: {h-k}/[1.000000000,0=/<empty>] !
-iter_seek_intent_ge: "j"/0,0=txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {h-k}/[1.000000000,0=/<empty>]
-iter_seek_intent_ge: "k"/5.000000000,0=/BYTES/k5 !
-
-run ok
-iter_new kind=keys types=pointsAndRanges
-iter_seek_intent_ge k=b txn=A
-iter_seek_intent_ge k=d txn=A
-iter_seek_intent_ge k=i txn=A
-iter_seek_intent_ge k=j txn=A
-iter_seek_intent_ge k=k txn=A
-----
-iter_seek_intent_ge: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
-iter_seek_intent_ge: {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>] !
-iter_seek_intent_ge: {h-k}/[1.000000000,0=/<empty>] !
-iter_seek_intent_ge: {h-k}/[1.000000000,0=/<empty>]
-iter_seek_intent_ge: "k"/5.000000000,0=/BYTES/k5 !
-
-run ok
-iter_new types=pointsOnly
-iter_seek_intent_ge k=b txn=A
-iter_seek_intent_ge k=d txn=A
-iter_seek_intent_ge k=i txn=A
-iter_seek_intent_ge k=j txn=A
-iter_seek_intent_ge k=k txn=A
-----
-iter_seek_intent_ge: "b"/4.000000000,0=/<empty>
-iter_seek_intent_ge: "d"/0,0=txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
-iter_seek_intent_ge: "j"/0,0=txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
-iter_seek_intent_ge: "j"/0,0=txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
-iter_seek_intent_ge: "k"/5.000000000,0=/BYTES/k5
-
-run ok
-iter_new types=rangesOnly
-iter_seek_intent_ge k=b txn=A
-iter_seek_intent_ge k=d txn=A
-iter_seek_intent_ge k=i txn=A
-iter_seek_intent_ge k=j txn=A
-iter_seek_intent_ge k=k txn=A
-----
-iter_seek_intent_ge: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
-iter_seek_intent_ge: {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>] !
-iter_seek_intent_ge: {h-k}/[1.000000000,0=/<empty>] !
-iter_seek_intent_ge: {h-k}/[1.000000000,0=/<empty>]
-iter_seek_intent_ge: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>] !
-
 # Try some masked scans at increasing timestamps.
 run ok
 iter_new types=pointsAndRanges maskBelow=1

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_iter_reverse_intent_seek_rangekeychanged_regression
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_iter_reverse_intent_seek_rangekeychanged_regression
@@ -58,27 +58,6 @@ iter_seek_lt: "b"/3.000000000,0=/BYTES/b3
 iter_prev: "b"/0,0=txn={id=00000001 key="b" iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} ts=3.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 iter_seek_ge: {a-b}/[1.000000000,0=/<empty>] !
 
-# Test the same for SeekIntentGE.
-run ok
-iter_new types=pointsAndRanges
-iter_seek_lt k=b+
-iter_prev
-iter_seek_ge txn=A k=b
-----
-iter_seek_lt: "b"/3.000000000,0=/BYTES/b3
-iter_prev: "b"/0,0=txn={id=00000001 key="b" iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} ts=3.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
-iter_seek_ge: "b"/0,0=txn={id=00000001 key="b" iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} ts=3.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
-
-run ok
-iter_new types=pointsAndRanges
-iter_seek_lt k=b+
-iter_prev
-iter_seek_intent_ge txn=A k=a
-----
-iter_seek_lt: "b"/3.000000000,0=/BYTES/b3
-iter_prev: "b"/0,0=txn={id=00000001 key="b" iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} ts=3.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
-iter_seek_intent_ge: {a-b}/[1.000000000,0=/<empty>] !
-
 # Test the same for SeekLT.
 run ok
 iter_new types=pointsAndRanges
@@ -118,18 +97,6 @@ iter_new types=pointsAndRanges
 iter_seek_lt k=b+
 iter_prev
 iter_prev
-iter_seek_intent_ge txn=A k=b
-----
-iter_seek_lt: "b"/3.000000000,0=/BYTES/b3
-iter_prev: "b"/0,0=txn={id=00000001 key="b" iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} ts=3.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
-iter_prev: "a"/2.000000000,0=/BYTES/a2 {a-b}/[1.000000000,0=/<empty>] !
-iter_seek_intent_ge: "b"/0,0=txn={id=00000001 key="b" iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} ts=3.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true !
-
-run ok
-iter_new types=pointsAndRanges
-iter_seek_lt k=b+
-iter_prev
-iter_prev
 iter_seek_lt k=b+
 ----
 iter_seek_lt: "b"/3.000000000,0=/BYTES/b3
@@ -158,16 +125,6 @@ iter_seek_ge k=c
 iter_seek_lt: "b"/3.000000000,0=/BYTES/b3
 iter_prev: "b"/0,0=txn={id=00000001 key="b" iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} ts=3.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 iter_seek_ge: {c-d}/[1.000000000,0=/<empty>] !
-
-run ok
-iter_new types=pointsAndRanges
-iter_seek_lt k=b+
-iter_prev
-iter_seek_intent_ge txn=A k=c
-----
-iter_seek_lt: "b"/3.000000000,0=/BYTES/b3
-iter_prev: "b"/0,0=txn={id=00000001 key="b" iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} ts=3.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
-iter_seek_intent_ge: {c-d}/[1.000000000,0=/<empty>] !
 
 run ok
 iter_new types=pointsAndRanges
@@ -224,27 +181,6 @@ iter_seek_ge k=a
 iter_seek_lt: "b"/3.000000000,0=/BYTES/b3
 iter_prev: "b"/0,0=txn={id=00000002 key="b" iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} ts=3.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 iter_seek_ge: {a-b}/[2.000000000,0=/<empty> 1.000000000,0=/<empty>] !
-
-# Test the same for SeekIntentGE.
-run ok
-iter_new types=pointsAndRanges
-iter_seek_lt k=b+
-iter_prev
-iter_seek_ge txn=A k=b
-----
-iter_seek_lt: "b"/3.000000000,0=/BYTES/b3
-iter_prev: "b"/0,0=txn={id=00000002 key="b" iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} ts=3.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
-iter_seek_ge: "b"/0,0=txn={id=00000002 key="b" iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} ts=3.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
-
-run ok
-iter_new types=pointsAndRanges
-iter_seek_lt k=b+
-iter_prev
-iter_seek_intent_ge txn=A k=a
-----
-iter_seek_lt: "b"/3.000000000,0=/BYTES/b3
-iter_prev: "b"/0,0=txn={id=00000002 key="b" iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} ts=3.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
-iter_seek_intent_ge: {a-b}/[2.000000000,0=/<empty> 1.000000000,0=/<empty>] !
 
 # Test the same for SeekLT.
 run ok

--- a/pkg/storage/verifying_iterator.go
+++ b/pkg/storage/verifying_iterator.go
@@ -10,11 +10,7 @@
 
 package storage
 
-import (
-	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/util/uuid"
-	"github.com/cockroachdb/pebble"
-)
+import "github.com/cockroachdb/pebble"
 
 // verifyingMVCCIterator is an MVCC iterator that wraps a pebbleIterator and
 // verifies roachpb.Value checksums for encountered values.
@@ -82,12 +78,6 @@ func (i *verifyingMVCCIterator) Prev() {
 // SeekGE implements MVCCIterator.
 func (i *verifyingMVCCIterator) SeekGE(key MVCCKey) {
 	i.pebbleIterator.SeekGE(key)
-	i.saveAndVerify()
-}
-
-// SeekIntentGE implements MVCCIterator.
-func (i *verifyingMVCCIterator) SeekIntentGE(key roachpb.Key, txnUUID uuid.UUID) {
-	i.pebbleIterator.SeekIntentGE(key, txnUUID)
 	i.saveAndVerify()
 }
 


### PR DESCRIPTION
Informs #109648.

This commit implements intent resolution (point and ranged) using a `LockTableIterator`, configured to return all locks for the transaction being resolved and no locks from other transactions. This is the first step towards releasing replicated locks during intent resolution.

While switching to a LockTableIterator, the commit is also able to remove separatedIntentAndVersionIter, iterForKeyVersions and mvccGetIntent, which were all used to avoid handing an MVCCMetadata directly to mvccResolveWriteIntent. Instead of continuing to treat intents as interleaved, we switch to handling intents entirely separately from their provisional value during intent resolution, which avoids jumping through these hoops and makes the code simpler.

The change to `TestMVCCResolveTxnRangeResumeWithManyVersions` is immaterial and has to do with the transaction ID filter being applied before the key limit (inside LockTableIterator), instead of after. The new behavior is actually better.

----

One concern I have about this change is that it removes the call to `SeekIntentGE` in `MVCCResolveWriteIntent`, which was added in d1c91e0e to guard against the case where many pebble tombstones from prior intents from different txns on a key surround the intent being resolved. Conceptually, we'd like to push optimizations that avoid scanning over these tombstones into the `LockTableIterator` like we plan to do for skipping over non-conflicting locks. Doing so would benefit all lock strengths. It would also benefit the case where an intent is not found and the seek hits tombstones from prior intents on later versions.

However, it's not clear how to do this with the current Pebble API. Pebble exposes a `SeekGEWithLimit` method, but this "limit" value is expressed as a key and not as a number of steps. How would we construct a limit key to bound the number of tombstones a seek observes before seeking directly to a specific (txn_id, lock_strength) version?

One option would be to seek to specific versions in the `LockTableIterator` when advancing the iterator in cases where the iterator is configured to match a specific txn ID. For example, performing the following translations:
```
SeekGE({Key: k}) -> SeekGE({Key: k, Strength: Intent, TxnID: <txn_id>})
Next()           -> SeekGE({Key: k, Strength: Exclusive, TxnID: <txn_id>})
Next()           -> SeekGE({Key: k, Strength: Shared, TxnID: <txn_id>})
```
Of course, this gets more complicated when some of these locks are not found and the iterator advances past them while seeking. In such cases, we're back to paying the cost of scanning over the tombstones.

If we knew which lock strengths we had acquired on a key, we could avoid some of this cost, but that would require API changes and client buy-in to track lock spans on a per-strength basis.

I'll capture the impact of this change on the following benchmarks and evaluate:
* BenchmarkIntentResolution
* BenchmarkIntentRangeResolution
* BenchmarkIntentScan

Release note: None