### PR TITLE
rangefeed: omit txn push attempt when intent queue is empty

### DIFF
--- a/pkg/kv/kvserver/rangefeed/processor.go
+++ b/pkg/kv/kvserver/rangefeed/processor.go
@@ -462,9 +462,9 @@ func (p *LegacyProcessor) run(
 
 		// Check whether any unresolved intents need a push.
 		case <-txnPushTickerC:
-			// Don't perform transaction push attempts until the resolved
-			// timestamp has been initialized.
-			if !p.rts.IsInit() {
+			// Don't perform transaction push attempts until the resolved timestamp
+			// has been initialized, or if we're not tracking any intents.
+			if !p.rts.IsInit() || p.rts.intentQ.Len() == 0 {
 				continue
 			}
 


### PR DESCRIPTION
`hlc.Clock.Now()` mutex acquisition during rangefeed txn push attempts has been seen to be a significant source of contention when running with many rangefeeds.

This patch short-circuits the txn push attempt if we're not tracking any intents, which is the common case.

Epic: none
Release note: None