### PR TITLE
release-23.1: sql,keys: disregard checks in *ZoneConfig*Batch

### DIFF
--- a/pkg/keys/constants.go
+++ b/pkg/keys/constants.go
@@ -506,7 +506,7 @@ var PseudoTableIDs = []uint32{
 	SystemRangesID,
 	TimeseriesRangesID,
 	LivenessRangesID,
-	PublicSchemaID,
+	SystemPublicSchemaID,
 	TenantsRangesID,
 }
 

--- a/pkg/sql/catalog/descs/collection.go
+++ b/pkg/sql/catalog/descs/collection.go
@@ -535,10 +535,7 @@ func (tc *Collection) WriteZoneConfigToBatch(
 		return err
 	}
 
-	if descID != keys.RootNamespaceID && !keys.IsPseudoTableID(uint32(descID)) {
-		return tc.AddUncommittedZoneConfig(descID, zc.ZoneConfigProto())
-	}
-	return nil
+	return tc.AddUncommittedZoneConfig(descID, zc.ZoneConfigProto())
 }
 
 // DeleteZoneConfigInBatch deletes zone config of the table.
@@ -555,9 +552,7 @@ func (tc *Collection) DeleteZoneConfigInBatch(
 		return err
 	}
 
-	if descID != keys.RootNamespaceID && !keys.IsPseudoTableID(uint32(descID)) {
-		tc.MarkUncommittedZoneConfigDeleted(descID)
-	}
+	tc.MarkUncommittedZoneConfigDeleted(descID)
 	return nil
 }
 

--- a/pkg/sql/logictest/testdata/logic_test/zone_config
+++ b/pkg/sql/logictest/testdata/logic_test/zone_config
@@ -363,3 +363,23 @@ bar  03:25:45
 baz  04:00:00
 vm   27:46:40
 zc   27:46:40
+
+statement error pgcode 23514 pq: cannot remove default zone
+ALTER RANGE default CONFIGURE ZONE DISCARD;
+
+# https://github.com/cockroachdb/cockroach/issues/108253
+subtest transactional_schemachanges
+
+statement ok
+CREATE DATABASE foo
+
+statement ok
+ALTER RANGE default CONFIGURE ZONE USING gc.ttlseconds = 3; ALTER RANGE default CONFIGURE ZONE USING gc.ttlseconds = 4;
+
+statement ok
+ALTER DATABASE foo CONFIGURE ZONE USING gc.ttlseconds = 3; ALTER DATABASE foo CONFIGURE ZONE USING gc.ttlseconds = 4;
+
+statement ok
+ALTER DATABASE foo CONFIGURE ZONE DISCARD; ALTER DATABASE foo CONFIGURE ZONE DISCARD;
+
+subtest end

--- a/pkg/sql/logictest/testdata/logic_test/zone_config_system_tenant
+++ b/pkg/sql/logictest/testdata/logic_test/zone_config_system_tenant
@@ -188,3 +188,10 @@ ORDER BY start_key
 90001
 1
 1
+
+subtest transactional_schemachanges
+
+statement ok
+ALTER RANGE meta CONFIGURE ZONE DISCARD; ALTER RANGE meta CONFIGURE ZONE DISCARD;
+
+subtest end


### PR DESCRIPTION
Backport 2/2 commits from #109774.

/cc @cockroachdb/release

---

Previously, a bug occured where a transactional schema change,
 `ALTER RANGE default CONFIGURE ZONE...`, statement would
produce a CPut failure, even though both statements do take effect.
This was due to a guard in the code that blocked us from adding the
first zone config to the uncommitted cache, causing the expValues
being updated to the KV batch to be the same for both statements.
This patch addresses the issue by removing the check and allowing
for `default` and psuedotables (like system ranges) to be added to
the uncommitted cache.

Epic: none
Release note (bug fix): two `ALTER RANGE default CONFIGURE ZONE` 
statements on the same line no longer displays an error. 
Fixes: #108253
Release justification: small bugfix & update to code