### PR TITLE
release: post-publishing fixes

### DIFF
--- a/pkg/cmd/release/update_orchestration.go
+++ b/pkg/cmd/release/update_orchestration.go
@@ -23,8 +23,20 @@ import (
 func updateOrchestration(gitDir string, version string) error {
 	// make sure we have the leading "v" in the version
 	version = "v" + strings.TrimPrefix(version, "v")
-	templatesDir := path.Join(gitDir, "cloud/kubernetes/templates")
-	outputDir := path.Join(gitDir, "cloud/kubernetes")
+	// Switch to the git directory to prevent file prefixes in the generated templates.
+	currDir, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("getting current directory: %w", err)
+	}
+	if err := os.Chdir(gitDir); err != nil {
+		return fmt.Errorf("switching to git directory: %w", err)
+	}
+	defer func() {
+		_ = os.Chdir(currDir)
+	}()
+
+	const templatesDir = "cloud/kubernetes/templates"
+	const outputDir = "cloud/kubernetes"
 	dirInfo, err := os.Stat(templatesDir)
 	if err != nil {
 		return fmt.Errorf("cannot stat templates directory: %w", err)

--- a/pkg/cmd/release/update_versions.go
+++ b/pkg/cmd/release/update_versions.go
@@ -32,6 +32,8 @@ import (
 const commitTemplate = `release: released CockroachDB version %s%s
 
 Release note: None
+Epic: None
+Release justification: non-production (release infra) change.
 `
 
 const releasedVersionFlag = "released-version"
@@ -208,7 +210,7 @@ func (r prRepo) createPullRequest() (string, error) {
 	cmd := exec.Command(parts[0], parts[1:]...)
 	log.Printf("creating PR by running `%s`", strings.Join(parts, " "))
 	cmd.Dir = r.checkoutDir()
-	out, err := cmd.CombinedOutput()
+	out, err := cmd.Output()
 	if err != nil {
 		return "", fmt.Errorf("failed creating pull request via `%s` with message '%s': %w", cmd.String(), string(out), err)
 	}


### PR DESCRIPTION
Previously, the generated orchestration files included the git directory checkout directory name, which doesn't carry any meaning.

This PR changes the working directory to the git checkout directory in order to use relative paths.

Fixes: RE-476

Commit messages now contain `Epic` and `Release justification` entries. 
Fixes: RE-469
Fixes: RE-468

`gh pr create` combined output may contain some warnings, while we expect only the PR URL. Use standard out only to catch the PR URL.

Release note: None