### PR TITLE
kvserver: deflake TestStoreMetrics

### DIFF
--- a/pkg/kv/kvserver/client_metrics_test.go
+++ b/pkg/kv/kvserver/client_metrics_test.go
@@ -51,17 +51,17 @@ func checkGauge(t *testing.T, id string, g gaugeValuer, e int64) {
 
 // verifyStatsOnServers checks a sets of stats on the specified
 // list of servers.
-func verifyStatsOnServers(t *testing.T, tc *testcluster.TestCluster, storeIdxSlice ...int) {
+func verifyStatsOnServers(
+	t *testing.T, tc *testcluster.TestCluster, locs map[int]storage.Location, storeIdxSlice ...int,
+) {
 	t.Helper()
-	var stores []*kvserver.Store
-	for _, storeIdx := range storeIdxSlice {
-		stores = append(stores, tc.GetFirstStoreFromServer(t, storeIdx))
-	}
+	ctx := context.Background()
 
 	// Sanity regression check for bug #4624: ensure intent count is zero.
 	// This may not be true immediately due to the asynchronous nature of
 	// non-local intent resolution.
-	for _, s := range stores {
+	for i := 0; i < tc.NumServers(); i++ {
+		s := tc.GetFirstStoreFromServer(t, i)
 		m := s.Metrics()
 		testutils.SucceedsSoon(t, func() error {
 			if a := m.IntentCount.Value(); a != 0 {
@@ -71,25 +71,20 @@ func verifyStatsOnServers(t *testing.T, tc *testcluster.TestCluster, storeIdxSli
 		})
 	}
 
-	// Acquire readers into all three stores.
-	// TODO(jackson): This still leaves an opening for a flake; I
-	// believe the previous code that stopped all servers also was
-	// susceptible to flakes.
-	consistentIters := make([]storage.Reader, len(stores))
-	defer func() {
-		for i := range consistentIters {
-			if consistentIters[i] != nil {
-				consistentIters[i].Close()
-			}
-		}
-	}()
-	for i, s := range stores {
-		ro := s.TODOEngine().NewReadOnly(storage.StandardDurability)
-		require.NoError(t, ro.PinEngineStateForIterators())
-		consistentIters[i] = ro
+	// Stop all servers.
+	//
+	// Stopping the servers stabilizes the metrics, ensuring
+	// background operations don't mutate metrics between reading and
+	// recomputing them.
+	for _, i := range storeIdxSlice {
+		tc.StopServer(i)
 	}
 
-	for i, s := range stores {
+	for _, storeIdx := range storeIdxSlice {
+		// The server is currently stopped and the engine is closed,
+		// but we can still retrieve the existing metrics off the
+		// Store.
+		s := tc.GetFirstStoreFromServer(t, storeIdx)
 		idString := s.Ident.String()
 		m := s.Metrics()
 
@@ -100,7 +95,16 @@ func verifyStatsOnServers(t *testing.T, tc *testcluster.TestCluster, storeIdxSli
 		}
 
 		// Compute real total MVCC statistics from store.
-		realStats, err := s.ComputeMVCCStats(consistentIters[i])
+		// To recompute the metrics, we need an open engine. Open the
+		// Engine again in read-only mode (leaving the rest of the
+		// Server stopped) to compute MVCC stats.
+		e, err := storage.Open(ctx, locs[storeIdx], s.GetStoreConfig().Settings,
+			storage.MustExist, storage.ReadOnly)
+		if err != nil {
+			t.Fatal(err)
+		}
+		realStats, err := s.ComputeMVCCStats(e)
+		e.Close()
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -129,38 +133,9 @@ func verifyStatsOnServers(t *testing.T, tc *testcluster.TestCluster, storeIdxSli
 	if t.Failed() {
 		t.Fatalf("verifyStatsOnServers failed, aborting test.")
 	}
-}
-
-func verifyStorageStats(t *testing.T, s *kvserver.Store) {
-	if err := s.ComputeMetrics(context.Background()); err != nil {
-		t.Fatal(err)
-	}
-
-	// TODO(jackson): Adjust TestStoreMetrics to reliably construct multiple
-	// levels within the LSM so that we can assert non-zero bloom filter
-	// statistics. At the time of writing, the engines in TestStoreMetrics
-	// sometimes contain files only in L6, which do not use bloom filters except
-	// when explicitly opted into.
-
-	m := s.Metrics()
-	testcases := []struct {
-		gauge *metric.Gauge
-		min   int64
-	}{
-		{m.RdbBlockCacheHits, 10},
-		{m.RdbBlockCacheMisses, 0},
-		{m.RdbBlockCacheUsage, 0},
-		{m.RdbBloomFilterPrefixChecked, 0},
-		{m.RdbBloomFilterPrefixUseful, 0},
-		{m.RdbMemtableTotalSize, 5000},
-		{m.RdbFlushes, 1},
-		{m.RdbCompactions, 0},
-		{m.RdbTableReadersMemEstimate, 50},
-	}
-	for _, tc := range testcases {
-		if a := tc.gauge.Value(); a < tc.min {
-			t.Errorf("gauge %s = %d < min %d", tc.gauge.GetName(), a, tc.min)
-		}
+	// Restart all servers.
+	for _, i := range storeIdxSlice {
+		require.NoError(t, tc.RestartServer(i))
 	}
 }
 
@@ -261,14 +236,17 @@ func TestStoreMetrics(t *testing.T) {
 
 	ctx := context.Background()
 	const numServers int = 3
+	stickyVFSRegistry := server.NewStickyVFSRegistry()
 	stickyServerArgs := make(map[int]base.TestServerArgs)
+	locs := make(map[int]storage.Location)
 	for i := 0; i < numServers; i++ {
+		stickyVFSID := strconv.FormatInt(int64(i), 10)
 		stickyServerArgs[i] = base.TestServerArgs{
 			CacheSize: 1 << 20, /* 1 MiB */
 			StoreSpecs: []base.StoreSpec{
 				{
 					InMemory:    true,
-					StickyVFSID: strconv.FormatInt(int64(i), 10),
+					StickyVFSID: stickyVFSID,
 					// Specify a size to trigger the BlockCache in Pebble.
 					Size: base.SizeSpec{
 						InBytes: 512 << 20, /* 512 MiB */
@@ -277,7 +255,7 @@ func TestStoreMetrics(t *testing.T) {
 			},
 			Knobs: base.TestingKnobs{
 				Server: &server.TestingKnobs{
-					StickyVFSRegistry: server.NewStickyVFSRegistry(),
+					StickyVFSRegistry: stickyVFSRegistry,
 				},
 				Store: &kvserver.StoreTestingKnobs{
 					DisableRaftLogQueue: true,
@@ -285,6 +263,7 @@ func TestStoreMetrics(t *testing.T) {
 				},
 			},
 		}
+		locs[i] = storage.MakeLocation("", stickyVFSRegistry.Get(stickyVFSID))
 	}
 	tc := testcluster.StartTestCluster(t, numServers,
 		base.TestClusterArgs{
@@ -292,15 +271,6 @@ func TestStoreMetrics(t *testing.T) {
 			ServerArgsPerNode: stickyServerArgs,
 		})
 	defer tc.Stopper().Stop(ctx)
-
-	// Flush Pebble memtables, so that Pebble begins using block-based tables.
-	// This is useful, because most of the stats we track don't apply to
-	// memtables.
-	for i := range tc.Servers {
-		if err := tc.GetFirstStoreFromServer(t, i).TODOEngine().Flush(); err != nil {
-			t.Fatal(err)
-		}
-	}
 
 	initialCount := tc.GetFirstStoreFromServer(t, 0).Metrics().ReplicaCount.Value()
 	key := tc.ScratchRange(t)
@@ -315,7 +285,7 @@ func TestStoreMetrics(t *testing.T) {
 	require.NoError(t, tc.WaitForVoters(key, tc.Targets(1, 2)...))
 
 	// Verify stats on store1 after replication.
-	verifyStatsOnServers(t, tc, 1)
+	verifyStatsOnServers(t, tc, locs, 1)
 
 	// Add some data to the "right" range.
 	rangeKeyStart, rangeKeyEnd := key, key.Next()
@@ -333,7 +303,7 @@ func TestStoreMetrics(t *testing.T) {
 	// do that given all if the system table activity generated by the TestCluster.
 	// We use Servers[1] and Servers[2] instead, since we can control the traffic
 	// on those servers.
-	verifyStatsOnServers(t, tc, 1, 2)
+	verifyStatsOnServers(t, tc, locs, 1, 2)
 
 	// Create a transaction statement that fails. Regression test for #4969.
 	if err := tc.GetFirstStoreFromServer(t, 0).DB().Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
@@ -347,7 +317,7 @@ func TestStoreMetrics(t *testing.T) {
 	}
 
 	// Verify stats after addition.
-	verifyStatsOnServers(t, tc, 1, 2)
+	verifyStatsOnServers(t, tc, locs, 1, 2)
 	checkGauge(t, "store 0", tc.GetFirstStoreFromServer(t, 0).Metrics().ReplicaCount, initialCount+1)
 	tc.RemoveLeaseHolderOrFatal(t, desc, tc.Target(0), tc.Target(1))
 	testutils.SucceedsSoon(t, func() error {
@@ -366,8 +336,38 @@ func TestStoreMetrics(t *testing.T) {
 	checkGauge(t, "store 1", tc.GetFirstStoreFromServer(t, 1).Metrics().ReplicaCount, 1)
 
 	// Verify all stats on all stores after range is removed.
-	verifyStatsOnServers(t, tc, 1, 2)
+	verifyStatsOnServers(t, tc, locs, 1, 2)
 
-	verifyStorageStats(t, tc.GetFirstStoreFromServer(t, 1))
-	verifyStorageStats(t, tc.GetFirstStoreFromServer(t, 2))
+	for _, serverIdx := range []int{1, 2} {
+		s := tc.GetFirstStoreFromServer(t, serverIdx)
+		if err := s.ComputeMetrics(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+
+		// TODO(jackson): Adjust this test to reliably construct multiple levels
+		// within the LSM so that we can assert non-zero bloom filter
+		// statistics. At the time of writing, the engines in TestStoreMetrics
+		// sometimes only contain files only in L6, which do not use bloom
+		// filters except when explicitly opted into.
+
+		m := s.Metrics()
+		testcases := []struct {
+			gauge *metric.Gauge
+			min   int64
+		}{
+			{m.RdbBlockCacheHits, 10},
+			{m.RdbBlockCacheMisses, 0},
+			{m.RdbBlockCacheUsage, 0},
+			{m.RdbBloomFilterPrefixChecked, 0},
+			{m.RdbBloomFilterPrefixUseful, 0},
+			{m.RdbMemtableTotalSize, 5000},
+			{m.RdbCompactions, 0},
+			{m.RdbTableReadersMemEstimate, 50},
+		}
+		for _, tc := range testcases {
+			if a := tc.gauge.Value(); a < tc.min {
+				t.Errorf("gauge %s = %d < min %d", tc.gauge.GetName(), a, tc.min)
+			}
+		}
+	}
 }


### PR DESCRIPTION
Resolve a test flake in TestStoreMetrics by reverting to stopping the TestServers in order to stabilize metrics. To recompute the metrics, the store's engine is reopened in read-only mode directly and closed again before restarting servers.

Epic: none
Fixes #109240.
Release note: None