### PR TITLE
sql: readd cancellation check between each dep rule

### DIFF
--- a/pkg/sql/schemachanger/scplan/internal/rules/registry.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/registry.go
@@ -36,9 +36,6 @@ func (r *Registry) ApplyDepRules(ctx context.Context, g *scgraph.Graph) error {
 		start := timeutil.Now()
 		var added int
 		if err := dr.q.Iterate(g.Database(), func(r rel.Result) error {
-			// Applying the dep rules can be slow in some cases. Check for
-			// cancellation when applying the rules to ensure we don't spin for
-			// too long while the user is waiting for the task to exit cleanly.
 			if ctx.Err() != nil {
 				return ctx.Err()
 			}
@@ -50,6 +47,12 @@ func (r *Registry) ApplyDepRules(ctx context.Context, g *scgraph.Graph) error {
 			)
 		}); err != nil {
 			return errors.Wrapf(err, "applying dep rule %s", dr.name)
+		}
+		// Applying the dep rules can be slow in some cases. Check for
+		// cancellation when applying the rules to ensure we don't spin for
+		// too long while the user is waiting for the task to exit cleanly.
+		if ctx.Err() != nil {
+			return ctx.Err()
 		}
 		if log.ExpensiveLogEnabled(ctx, 2) {
 			log.Infof(


### PR DESCRIPTION
In #110143, a cancellation check that was applied
between dep rules was thought to be redundant, but actually affects the behavior of rsg testing.

informs: #109304
informs: #109988

Release note: None