### PR TITLE
upgrade: remove buggy TTL repair

### DIFF
--- a/pkg/sql/catalog/tabledesc/table_desc_builder.go
+++ b/pkg/sql/catalog/tabledesc/table_desc_builder.go
@@ -244,13 +244,6 @@ func (tdb *tableDescriptorBuilder) StripDanglingBackReferences(
 			tdb.changes.Add(catalog.StrippedDanglingBackReferences)
 		}
 	}
-	// ... in the row_level_ttl field,
-	if ttl := tbl.RowLevelTTL; ttl != nil {
-		if id := jobspb.JobID(ttl.ScheduleID); id != jobspb.InvalidJobID && !nonTerminalJobIDMightExist(id) {
-			tbl.RowLevelTTL = nil
-			tdb.changes.Add(catalog.StrippedDanglingBackReferences)
-		}
-	}
 	// ... in the sequence ownership field.
 	if seq := tbl.SequenceOpts; seq != nil {
 		if id := seq.SequenceOwner.OwnerTableID; id != descpb.InvalidID && !descIDMightExist(id) {

--- a/pkg/sql/catalog/tabledesc/table_desc_test.go
+++ b/pkg/sql/catalog/tabledesc/table_desc_test.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/stretchr/testify/require"
 )
@@ -116,9 +115,6 @@ func TestStripDanglingBackReferences(t *testing.T) {
 					{MutationID: 2},
 				},
 				DropJobID: 1,
-				RowLevelTTL: &catpb.RowLevelTTL{
-					ScheduleID: 123,
-				},
 			},
 			expectedOutput: descpb.TableDescriptor{
 				Name: "foo",

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -3109,34 +3109,45 @@ func (t *logicTest) processSubtest(
 			if t.testserverCluster == nil {
 				return errors.Errorf(`could not perform "upgrade", not a cockroach-go/testserver cluster`)
 			}
-			nodeIdx, err := strconv.Atoi(fields[1])
-			if err != nil {
-				t.Fatal(err)
-			}
-			if err := t.testserverCluster.UpgradeNode(nodeIdx); err != nil {
-				t.Fatal(err)
-			}
-			for i := 0; i < t.cfg.NumNodes; i++ {
-				// Wait for each node to be reachable, since UpgradeNode uses `kill`
-				// to terminate nodes, and may introduce temporary unavailability in
-				// the system range.
-				if err := t.testserverCluster.WaitForInitFinishForNode(i); err != nil {
+			upgradeNode := func(nodeIdx int) {
+				if err := t.testserverCluster.UpgradeNode(nodeIdx); err != nil {
 					t.Fatal(err)
 				}
-			}
-			// The port may have changed, so we must remove all the cached connections
-			// to this node.
-			for _, m := range t.clients {
-				if c, ok := m[nodeIdx]; ok {
-					_ = c.Close()
+				for i := 0; i < t.cfg.NumNodes; i++ {
+					// Wait for each node to be reachable, since UpgradeNode uses `kill`
+					// to terminate nodes, and may introduce temporary unavailability in
+					// the system range.
+					if err := t.testserverCluster.WaitForInitFinishForNode(i); err != nil {
+						t.Fatal(err)
+					}
 				}
-				delete(m, nodeIdx)
+				// The port may have changed, so we must remove all the cached connections
+				// to this node.
+				for _, m := range t.clients {
+					if c, ok := m[nodeIdx]; ok {
+						_ = c.Close()
+					}
+					delete(m, nodeIdx)
+				}
+				// If we upgraded the node we are currently on, we need to open a new
+				// connection since the previous one might now be invalid.
+				if t.nodeIdx == nodeIdx {
+					t.setSessionUser(t.user, nodeIdx, false /* newSession */)
+				}
 			}
-			// If we upgraded the node we are currently on, we need to open a new
-			// connection since the previous one might now be invalid.
-			if t.nodeIdx == nodeIdx {
-				t.setSessionUser(t.user, nodeIdx, false /* newSession */)
+			nodeStr := fields[1]
+			if nodeStr == "all" {
+				for i := 0; i < t.cfg.NumNodes; i++ {
+					upgradeNode(i)
+				}
+			} else {
+				nodeIdx, err := strconv.Atoi(nodeStr)
+				if err != nil {
+					t.Fatal(err)
+				}
+				upgradeNode(nodeIdx)
 			}
+
 		default:
 			return errors.Errorf("%s:%d: unknown command: %s",
 				path, s.Line+subtest.lineLineIndexIntoFile, cmd,

--- a/pkg/sql/logictest/testdata/logic_test/mixed_version_upgrade_repair_descriptors
+++ b/pkg/sql/logictest/testdata/logic_test/mixed_version_upgrade_repair_descriptors
@@ -1,0 +1,22 @@
+# LogicTest: cockroach-go-testserver-upgrade-to-master
+
+statement ok
+CREATE TABLE tbl (
+  id INT PRIMARY KEY
+) WITH (ttl_expire_after = '10 minutes')
+
+upgrade all
+
+query B retry
+SELECT version LIKE '%23.1-%' FROM [SHOW CLUSTER SETTING version]
+----
+true
+
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE tbl]
+----
+CREATE TABLE public.tbl (
+  id INT8 NOT NULL,
+  crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
+  CONSTRAINT tbl_pkey PRIMARY KEY (id ASC)
+) WITH (ttl = 'on', ttl_expire_after = '00:10:00':::INTERVAL, ttl_job_cron = '@hourly')

--- a/pkg/sql/logictest/tests/cockroach-go-testserver-upgrade-to-master/BUILD.bazel
+++ b/pkg/sql/logictest/tests/cockroach-go-testserver-upgrade-to-master/BUILD.bazel
@@ -17,7 +17,7 @@ go_test(
         "dockerNetwork": "standard",
         "Pool": "large",
     },
-    shard_count = 9,
+    shard_count = 10,
     tags = [
         "cpu:2",
     ],

--- a/pkg/sql/logictest/tests/cockroach-go-testserver-upgrade-to-master/generated_test.go
+++ b/pkg/sql/logictest/tests/cockroach-go-testserver-upgrade-to-master/generated_test.go
@@ -140,3 +140,10 @@ func TestLogic_mixed_version_system_privileges_user_id(
 	defer leaktest.AfterTest(t)()
 	runLogicTest(t, "mixed_version_system_privileges_user_id")
 }
+
+func TestLogic_mixed_version_upgrade_repair_descriptors(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "mixed_version_upgrade_repair_descriptors")
+}


### PR DESCRIPTION
Fixes #110363

The TTL descriptor repair in FirstUpgradeFromReleasePrecondition incorrectly
removes TTL fields from table descriptors after incorrectly comparing the
table descriptor's TTL job schedule ID to a set of job IDs.

This change removes the repair until tests are properly added.

Release note (bug fix): Remove buggy TTL descriptor repair. Previously,
upgrading from 22.2.X to 23.1.9 incorrectly removed TTL storage params from
tables (visible via `SHOW CREATE TABLE <ttl-table>;`) while attempting to
repair table descriptors. This resulted in the node that attempts to run the
TTL job crashing due to a panic caused by the missing TTL storage params.
Clusters currently on 22.2.X should NOT be upgraded to 23.1.9 and should
be upgraded to 23.1.10 or later directly.