### PR TITLE
base_test: disable network access

### DIFF
--- a/pkg/base/BUILD.bazel
+++ b/pkg/base/BUILD.bazel
@@ -59,9 +59,6 @@ go_test(
     ],
     args = ["-test.timeout=55s"],
     data = glob(["testdata/**"]),
-    exec_properties = {
-        "dockerNetwork": "standard",
-    },
     deps = [
         ":base",
         "//pkg/roachpb",


### PR DESCRIPTION
Network access for this test is no longer necessary since #110069.

Epic: CRDB-8308
Release note: None