### PR TITLE
compose/gss: unskip TestGSSFileDescriptorCount

### DIFF
--- a/pkg/acceptance/compose/gss/docker-compose.yml
+++ b/pkg/acceptance/compose/gss/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       - keytab:/keytab
       - ${COCKROACH_BINARY:-../../../../cockroach-linux-2.6.32-gnu-amd64}:/cockroach/cockroach
   psql:
-    image: cockroachdb/acceptance-gss-psql:20230907-113902
+    image: cockroachdb/acceptance-gss-psql:20230920-104814
     user: "${UID}:${GID}"
     depends_on:
       - cockroach


### PR DESCRIPTION
The test did not work since it did not pass in the root password correctly.
The check for file descriptors was also too aggressive.

fixes https://github.com/cockroachdb/cockroach/issues/110194

Release note: None