### PR TITLE
build: add new `engflowpublic` config

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -112,22 +112,28 @@ build:macos --host_action_env=PATH=/opt/homebrew/bin:/opt/local/bin:/usr/local/b
 # more precise --workspace_status_command option.
 build:simplestamp --stamp --workspace_status_command=./build/bazelutil/stamp.sh
 
-build:engflow --define=EXECUTOR=remote
-build:engflow --disk_cache=
-build:engflow --experimental_inmemory_dotd_files
-build:engflow --experimental_inmemory_jdeps_files
-build:engflow --incompatible_strict_action_env=true
-build:engflow --remote_timeout=600
-build:engflow --nolegacy_important_outputs
-build:engflow --grpc_keepalive_time=30s
-build:engflow --experimental_remote_cache_compression=true
-build:engflow --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
+build:engflowbase --define=EXECUTOR=remote
+build:engflowbase --disk_cache=
+build:engflowbase --experimental_inmemory_dotd_files
+build:engflowbase --experimental_inmemory_jdeps_files
+build:engflowbase --incompatible_strict_action_env=true
+build:engflowbase --remote_timeout=600
+build:engflowbase --nolegacy_important_outputs
+build:engflowbase --grpc_keepalive_time=30s
+build:engflowbase --experimental_remote_cache_compression=true
+build:engflowbase --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
+build:engflowbase --extra_execution_platforms=//build/toolchains:cross_linux
+test:engflowbase --test_env=REMOTE_EXEC=1
+build:engflow --config=engflowbase
 build:engflow --remote_cache=grpcs://tanzanite.cluster.engflow.com
 build:engflow --remote_executor=grpcs://tanzanite.cluster.engflow.com
 build:engflow --bes_backend=grpcs://tanzanite.cluster.engflow.com
 build:engflow --bes_results_url=https://tanzanite.cluster.engflow.com/invocation/
-build:engflow --extra_execution_platforms=//build/toolchains:cross_linux
-test:engflow --test_env=REMOTE_EXEC=1
+build:engflowpublic --config=engflowbase
+build:engflowpublic --remote_cache=grpcs://mesolite.cluster.engflow.com
+build:engflowpublic --remote_executor=grpcs://mesolite.cluster.engflow.com
+build:engflowpublic --bes_backend=grpcs://mesolite.cluster.engflow.com
+build:engflowpublic --bes_results_url=https://mesolite.cluster.engflow.com/invocation/
 
 try-import %workspace%/.bazelrc.user
 


### PR DESCRIPTION
This uses all the same settings, except a different front-end for the RBE scheduler.

Epic: CRDB-8308
Release note: None