### PR TITLE
roachpb: deflake and unskip test make priority

### DIFF
--- a/pkg/roachpb/BUILD.bazel
+++ b/pkg/roachpb/BUILD.bazel
@@ -77,7 +77,6 @@ go_test(
         "//pkg/kv/kvserver/concurrency/isolation",
         "//pkg/kv/kvserver/concurrency/lock",
         "//pkg/storage/enginepb",
-        "//pkg/testutils/skip",
         "//pkg/testutils/zerofields",
         "//pkg/util",
         "//pkg/util/bitarray",

--- a/pkg/roachpb/data_test.go
+++ b/pkg/roachpb/data_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/isolation"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/lock"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
-	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/zerofields"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/bitarray"
@@ -909,7 +908,6 @@ func checkVal(val, expected, errFraction float64) bool {
 // in MakePriority returning priorities that are P times more likely
 // to be higher than a priority with user priority = 1.
 func TestMakePriority(t *testing.T) {
-	skip.WithIssue(t, 110303, "flaky test")
 	// Verify min & max.
 	if a, e := MakePriority(MinUserPriority), enginepb.MinTxnPriority; a != e {
 		t.Errorf("expected min txn priority %d; got %d", e, a)
@@ -932,7 +930,7 @@ func TestMakePriority(t *testing.T) {
 	}
 
 	// Generate values for all priorities.
-	const trials = 100000
+	const trials = 750000
 	values := make([][trials]enginepb.TxnPriority, len(userPs))
 	for i, userPri := range userPs {
 		for tr := 0; tr < trials; tr++ {


### PR DESCRIPTION
`TestMakePriority` was skipped in https://github.com/cockroachdb/cockroach/pull/110354 due to flakes. The test began
to flake after upgrading to `go1.20` in https://github.com/cockroachdb/cockroach/pull/109773, as the global rand was
seeded differently.

Bump the number of trials from 100k to 750k in order to collect more
samples of the underlying distribution, which deflakes the test. This
doubles the average test time, from 200ms to 400ms on a GCP C2 instance.

Passes 50k runs:

```
dev test pkg/roachpb -f TestMakePriority -v --stress --count=50000
...
//pkg/roachpb:roachpb_test                             PASSED in 0.9s
Stats over 50000 runs: max = 0.9s, min = 0.3s, avg = 0.4s, dev = 0.0s
```

Fixes: https://github.com/cockroachdb/cockroach/issues/110303
Release note: None