### PR TITLE
release-23.1: server: sql listen before tenant id set

### DIFF
--- a/pkg/base/config.go
+++ b/pkg/base/config.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"math"
 	"math/big"
+	"net"
 	"net/url"
 	"os"
 	"time"
@@ -340,6 +341,14 @@ type Config struct {
 	// SQLAddr is the configured SQL listen address.
 	// This is used if SplitListenSQL is set to true.
 	SQLAddr string
+
+	// SQLAddrListener will only be considered if SplitListenSQL is set and
+	// DisableSQLListener is not. Under these conditions, if not nil, it will be
+	// used as a listener for incoming SQL connection requests. This allows
+	// creating a listener early in the server initialization process and not
+	// rejecting incoming connection requests that may come before the server is
+	// fully ready.
+	SQLAddrListener net.Listener
 
 	// SQLAdvertiseAddr is the advertised SQL address.
 	// This is computed from SQLAddr if specified otherwise Addr.

--- a/pkg/cli/BUILD.bazel
+++ b/pkg/cli/BUILD.bazel
@@ -240,6 +240,7 @@ go_library(
         "@com_github_cockroachdb_redact//:redact",
         "@com_github_cockroachdb_ttycolor//:ttycolor",
         "@com_github_dustin_go_humanize//:go-humanize",
+        "@com_github_fsnotify_fsnotify//:fsnotify",
         "@com_github_gogo_protobuf//jsonpb",
         "@com_github_jackc_pgconn//:pgconn",
         "@com_github_jackc_pgtype//:pgtype",

--- a/pkg/cli/cliflags/flags_mt.go
+++ b/pkg/cli/cliflags/flags_mt.go
@@ -18,6 +18,15 @@ var (
 		Description: `The tenant ID under which to start the SQL server.`,
 	}
 
+	TenantIDFile = FlagInfo{
+		Name: "tenant-id-file",
+		Description: `Allows sourcing the tenant id from a file. The tenant id will
+be expected to be by itself on the first line of the file. The file has to exist
+on startup but may be empty or have partial id without ending newline. In this 
+case the tenant server will block and wait for the tenant id to be fully written 
+to the file.`,
+	}
+
 	KVAddrs = FlagInfo{
 		Name:        "kv-addrs",
 		EnvVar:      "COCKROACH_KV_ADDRS",

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -14,10 +14,12 @@ import (
 	"flag"
 	"fmt"
 	"net"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
+	"sync/atomic"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/cli/clientflags"
@@ -34,6 +36,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log/logflags"
 	"github.com/cockroachdb/cockroach/pkg/util/netutil/addr"
 	"github.com/cockroachdb/errors"
+	"github.com/fsnotify/fsnotify"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -61,6 +64,7 @@ var localityAdvertiseHosts localityList
 var startBackground bool
 var storeSpecs base.StoreSpecList
 var goMemLimit int64
+var tenantIDFile string
 
 // initPreFlagsDefaults initializes the values of the global variables
 // defined above.
@@ -91,6 +95,8 @@ func initPreFlagsDefaults() {
 	storeSpecs = base.StoreSpecList{}
 
 	goMemLimit = 0
+
+	tenantIDFile = ""
 }
 
 // AddPersistentPreRunE add 'fn' as a persistent pre-run function to 'cmd'.
@@ -545,6 +551,7 @@ func init() {
 	{
 		f := mtStartSQLCmd.Flags()
 		cliflagcfg.VarFlag(f, &tenantIDWrapper{&serverCfg.SQLConfig.TenantID}, cliflags.TenantID)
+		cliflagcfg.StringFlag(f, &tenantIDFile, cliflags.TenantIDFile)
 		cliflagcfg.StringSliceFlag(f, &serverCfg.SQLConfig.TenantKVAddrs, cliflags.KVAddrs)
 	}
 
@@ -948,6 +955,14 @@ func init() {
 	}
 }
 
+func tenantID(s string) (roachpb.TenantID, error) {
+	tenID, err := strconv.ParseUint(s, 10, 64)
+	if err != nil {
+		return roachpb.TenantID{}, errors.Wrap(err, "invalid tenant ID")
+	}
+	return roachpb.MakeTenantID(tenID)
+}
+
 type tenantIDWrapper struct {
 	tenID *roachpb.TenantID
 }
@@ -956,19 +971,68 @@ func (w *tenantIDWrapper) String() string {
 	return w.tenID.String()
 }
 func (w *tenantIDWrapper) Set(s string) error {
-	tenID, err := strconv.ParseUint(s, 10, 64)
+	cfgTenantID, err := tenantID(s)
 	if err != nil {
-		return errors.Wrap(err, "invalid tenant ID")
+		return err
 	}
-	if tenID == 0 {
-		return errors.New("invalid tenant ID")
-	}
-	*w.tenID = roachpb.MustMakeTenantID(tenID)
+	*w.tenID = cfgTenantID
 	return nil
 }
 
 func (w *tenantIDWrapper) Type() string {
 	return "number"
+}
+
+// tenantIDFromFile will look for the given file and read the full first
+// line of the file that should contain the `<TenantID>`.
+func tenantIDFromFile(
+	fileName string, watcherWaitCount *atomic.Uint32, watcherEventCount *atomic.Uint32,
+) (roachpb.TenantID, error) {
+	// Start watching the file for changes as the typical case is that the file
+	// will not have yet the tenant id at startup.
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return roachpb.TenantID{}, errors.Wrapf(err, "creating new watcher")
+	}
+	defer func() { _ = watcher.Close() }()
+	if err = watcher.Add(fileName); err != nil {
+		return roachpb.TenantID{}, errors.Wrapf(err, "adding %q to watcher", fileName)
+	}
+
+	for {
+		headBuf, err := os.ReadFile(fileName)
+		if err != nil {
+			return roachpb.TenantID{}, errors.Wrapf(err, "reading %q file", fileName)
+		}
+		if line, _, foundNewLine := strings.Cut(string(headBuf), "\n"); foundNewLine {
+			cfgTenantID, err := tenantID(line)
+			if err != nil {
+				return roachpb.TenantID{}, errors.Wrapf(err, "setting tenant id from line %q", line)
+			}
+			return cfgTenantID, nil
+		}
+
+		// Wait for file notification.
+		if watcherWaitCount != nil {
+			watcherWaitCount.Add(1)
+		}
+		select {
+		case _, ok := <-watcher.Events:
+			if watcherEventCount != nil {
+				watcherEventCount.Add(1)
+			}
+			if !ok {
+				return roachpb.TenantID{},
+					errors.Newf("fsnotify.Watcher got Events channel closed while waiting on %q", fileName)
+			}
+		case err, ok := <-watcher.Errors:
+			if !ok {
+				return roachpb.TenantID{},
+					errors.Newf("fsnotify.Watcher got Errors channel closed while waiting on %q", fileName)
+			}
+			return roachpb.TenantID{}, errors.Wrapf(err, "watcher error while waiting on %q", fileName)
+		}
+	}
 }
 
 // extraServerFlagInit configures the server.Config based on the command-line flags.
@@ -1221,8 +1285,7 @@ func mtStartSQLFlagsInit(cmd *cobra.Command) error {
 	if !fs.Changed(cliflags.Store.Name) {
 		// We assume that we only need to change top level store as temp dir configs are
 		// initialized when start is executed and temp dirs inherit path from first store.
-		tenantID := fs.Lookup(cliflags.TenantID.Name).Value.String()
-		serverCfg.Stores.Specs[0].Path += "-tenant-" + tenantID
+		serverCfg.Stores.Specs[0].Path += fmt.Sprintf("-tenant-%d", os.Getpid())
 	}
 
 	// In standalone SQL servers, we do not generate a ballast file,

--- a/pkg/cli/flags_test.go
+++ b/pkg/cli/flags_test.go
@@ -23,11 +23,13 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/cli/cliflags"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
 	"github.com/cockroachdb/cockroach/pkg/server/status"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -1414,7 +1416,8 @@ func TestSQLPodStorageDefaults(t *testing.T) {
 
 	defer initCLIDefaults()
 
-	expectedDefaultDir, err := base.GetAbsoluteStorePath("", "cockroach-data-tenant-9")
+	expectedDefaultDir, err := base.GetAbsoluteStorePath("",
+		fmt.Sprintf("cockroach-data-tenant-%d", os.Getpid()))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1437,4 +1440,109 @@ func TestSQLPodStorageDefaults(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_tenantID(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	tests := []struct {
+		name        string
+		arg         string
+		errContains string
+	}{
+		{"empty tenant id text", "", "invalid tenant ID: strconv.ParseUint"},
+		{"tenant id text not integer", "abc", "invalid tenant ID: strconv.ParseUint"},
+		{"tenant id is 0", "0", "invalid tenant ID"},
+		{"tenant id is valid", "2", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfgTenantID, err := tenantID(tt.arg)
+			if tt.errContains == "" {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.arg, cfgTenantID.String())
+			} else {
+				assert.ErrorContains(t, err, tt.errContains)
+				assert.Equal(t, roachpb.TenantID{}, cfgTenantID)
+			}
+		})
+	}
+}
+
+func Test_tenantIDFromFile(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	createTempFileWithData := func(data string) *os.File {
+		file, err := os.CreateTemp("", "")
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(file.Name(), []byte(data), 0777))
+		return file
+	}
+	t.Run("non-existent file", func(t *testing.T) {
+		cfgTenantID, err := tenantIDFromFile("non-existent-file", nil, nil)
+		require.ErrorContains(t, err, "no such file or directory")
+		require.Equal(t, roachpb.TenantID{}, cfgTenantID)
+	})
+
+	t.Run("file exists, has complete first row, but the value is an invalid tenant id",
+		func(t *testing.T) {
+			file := createTempFileWithData("abc\n")
+			defer file.Close()
+			cfgTenantID, err := tenantIDFromFile(file.Name(), nil, nil)
+			require.ErrorContains(t, err, "invalid tenant ID: strconv.ParseUint")
+			require.Equal(t, roachpb.TenantID{}, cfgTenantID)
+		})
+
+	t.Run("file exists, has incomplete first row, waits for it to complete and after completion with invalid tenant id fails",
+		func(t *testing.T) {
+			file := createTempFileWithData("abc")
+			defer file.Close()
+			watcherWaitCount := atomic.Uint32{}
+			watcherEventCount := atomic.Uint32{}
+			generatedError := atomic.Bool{}
+			go func() {
+				cfgTenantID, err := tenantIDFromFile(file.Name(), &watcherWaitCount, &watcherEventCount)
+				require.ErrorContains(t, err, "invalid tenant ID: strconv.ParseUint")
+				require.Equal(t, roachpb.TenantID{}, cfgTenantID)
+				generatedError.Store(true)
+			}()
+			require.Eventually(t, func() bool { return watcherWaitCount.Load() == 1 }, 10*time.Second, 10*time.Millisecond)
+			require.EqualValues(t, 0, watcherEventCount.Load())
+			require.Equal(t, false, generatedError.Load())
+			require.NoError(t, os.WriteFile(file.Name(), []byte("abc\n"), 0777))
+			require.Eventually(t, func() bool { return watcherEventCount.Load() > 0 }, 10*time.Second, 10*time.Millisecond)
+			require.Eventually(t, func() bool { return generatedError.Load() }, 10*time.Second, 10*time.Millisecond)
+		})
+
+	t.Run("file exists, has complete first row, it has tenant id and it is set to valid value",
+		func(t *testing.T) {
+			file := createTempFileWithData("123\n")
+			defer file.Close()
+			cfgTenantID, err := tenantIDFromFile(file.Name(), nil, nil)
+			require.NoError(t, err)
+			require.EqualValues(t, 123, cfgTenantID.ToUint64())
+		})
+
+	t.Run("file exists, has incomplete first row, waits for it to complete and after completion reads valid tenant id",
+		func(t *testing.T) {
+			file := createTempFileWithData("abc")
+			defer file.Close()
+			watcherWaitCount := atomic.Uint32{}
+			watcherEventCount := atomic.Uint32{}
+			runSuccessfuly := atomic.Bool{}
+			go func() {
+				cfgTenantID, err := tenantIDFromFile(file.Name(), &watcherWaitCount, &watcherEventCount)
+				require.NoError(t, err)
+				require.EqualValues(t, 123, cfgTenantID.ToUint64())
+				runSuccessfuly.Store(true)
+			}()
+			require.Eventually(t, func() bool { return watcherWaitCount.Load() == 1 }, 10*time.Second, 10*time.Millisecond)
+			require.EqualValues(t, 0, watcherEventCount.Load())
+			require.Equal(t, false, runSuccessfuly.Load())
+			require.NoError(t, os.WriteFile(file.Name(), []byte("123\n"), 0777))
+			require.Eventually(t, func() bool { return watcherEventCount.Load() > 0 }, 10*time.Second, 10*time.Millisecond)
+			require.Eventually(t, func() bool { return runSuccessfuly.Load() }, 10*time.Second, 10*time.Millisecond)
+		})
 }

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/docs"
 	"github.com/cockroachdb/cockroach/pkg/geo/geos"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvstorage"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security/clientsecopts"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/server"
@@ -533,6 +534,14 @@ func runStartInternal(
 			errors.New("no --join flags provided to 'cockroach start'"),
 			"Consider using 'cockroach init' or 'cockroach start-single-node' instead")
 		return err
+	}
+
+	// Check the --tenant-id-file flag.
+	if fl := cliflagcfg.FlagSetForCmd(cmd).Lookup(cliflags.TenantIDFile.Name); fl != nil && fl.Changed {
+		fileName := fl.Value.String()
+		serverCfg.DelayedSetTenantID = func() (roachpb.TenantID, error) {
+			return tenantIDFromFile(fileName, nil, nil)
+		}
 	}
 
 	// Now perform additional configuration tweaks specific to the start

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -441,6 +441,7 @@ go_test(
         "status_ext_test.go",
         "status_test.go",
         "sticky_engine_test.go",
+        "tenant_delayed_id_set_test.go",
         "tenant_range_lookup_test.go",
         "testserver_test.go",
         "user_test.go",

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -483,6 +483,9 @@ type SQLConfig struct {
 	// The tenant that the SQL server runs on the behalf of.
 	TenantID roachpb.TenantID
 
+	// If set, will to be called at server startup to obtain the tenant id.
+	DelayedSetTenantID func() (roachpb.TenantID, error)
+
 	// TempStorageConfig is used to configure temp storage, which stores
 	// ephemeral data when processing large queries.
 	TempStorageConfig base.TempStorageConfig

--- a/pkg/server/start_listen.go
+++ b/pkg/server/start_listen.go
@@ -67,7 +67,11 @@ func startListenRPCAndSQL(
 
 	var pgL net.Listener
 	if cfg.SplitListenSQL && enableSQLListener {
-		pgL, err = ListenAndUpdateAddrs(ctx, &cfg.SQLAddr, &cfg.SQLAdvertiseAddr, "sql")
+		if cfg.SQLAddrListener == nil {
+			pgL, err = ListenAndUpdateAddrs(ctx, &cfg.SQLAddr, &cfg.SQLAdvertiseAddr, "sql")
+		} else {
+			pgL = cfg.SQLAddrListener
+		}
 		if err != nil {
 			return nil, nil, nil, nil, err
 		}

--- a/pkg/server/tenant_delayed_id_set_test.go
+++ b/pkg/server/tenant_delayed_id_set_test.go
@@ -1,0 +1,109 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package server
+
+import (
+	"context"
+	"net/url"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/security/username"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/jackc/pgx/v4"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStartTenantWithDelayedID(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+
+	clusterSettings := cluster.MakeTestingClusterSettings()
+	args := base.TestServerArgs{
+		Settings: clusterSettings,
+	}
+	s, _, _ := serverutils.StartServer(t, args)
+	defer s.Stopper().Stop(ctx)
+
+	func() {
+		// Create the tenant.
+		tenantStopper := stop.NewStopper()
+		defer tenantStopper.Stop(ctx)
+		_, db := serverutils.StartTenant(t, s, base.TestTenantArgs{
+			Stopper:  tenantStopper,
+			TenantID: serverutils.TestTenantID()})
+		defer db.Close()
+	}()
+
+	st := cluster.MakeTestingClusterSettings()
+	baseCfg := makeTestBaseConfig(st, s.Stopper().Tracer())
+	sqlCfg := makeTestSQLConfig(st, roachpb.TenantID{})
+	sqlCfg.TenantLoopbackAddr = s.RPCAddr()
+
+	var tenantIDSet, listenerReady sync.WaitGroup
+	tenantIDSet.Add(1)
+	listenerReady.Add(1)
+
+	var timeTenantIDSet time.Time
+	sqlCfg.DelayedSetTenantID = func() (roachpb.TenantID, error) {
+		// Unblock the connect code bellow, so it can try to connect.
+		listenerReady.Done()
+		// Wait until getting a go ahead with setting the tenant id.
+		tenantIDSet.Wait()
+		return serverutils.TestTenantID(), nil
+	}
+
+	go func() {
+		sw, err := NewSeparateProcessTenantServer(
+			ctx,
+			s.Stopper(),
+			baseCfg,
+			sqlCfg,
+			roachpb.NewTenantNameContainer("delayed-tenant-set"),
+		)
+		require.NoError(t, err)
+		require.NoError(t, sw.Start(ctx))
+	}()
+
+	listenerReady.Wait()
+	// Try a connection.
+	pgURL, cleanupFn, err := sqlutils.PGUrlE(
+		baseCfg.SQLAdvertiseAddr, "testConn", url.User(username.RootUser))
+	require.NoError(t, err)
+	defer cleanupFn()
+	go func() {
+		time.Sleep(200 * time.Millisecond)
+		timeTenantIDSet = timeutil.Now()
+		tenantIDSet.Done()
+	}()
+	c, err := pgx.Connect(ctx, pgURL.String())
+	durationFromTenantIDSetToConnect := timeutil.Since(timeTenantIDSet)
+	require.NoError(t, err)
+	defer func() { _ = c.Close(ctx) }()
+	t.Logf("cold connect duration (from tenant id set to connect) %s", durationFromTenantIDSetToConnect)
+
+	connectStart := timeutil.Now()
+	c, err = pgx.Connect(ctx, pgURL.String())
+	warmConnectDuration := timeutil.Since(connectStart)
+	require.NoError(t, err)
+	defer func() { _ = c.Close(ctx) }()
+	t.Logf("warm connect duration %s", warmConnectDuration)
+}


### PR DESCRIPTION
Backport 1/1 commits from #110082.

/cc @cockroachdb/release

---

Previously, running SQL tenant processes required to specify the tenant
id as command flag. That prevented starting an SQL tenant process before
the tenant id associated is known and made it impossible to have a pool
of generic warm pods waiting to be associated with a tenant. Not being
able to have such pool makes also the cold start latency include the
cost of starting a new SQL tenant process. It was also possible that a
tenant connection is forwarded to a newly started tenant SQL process
before its SQL listener is on so clients may get refused connections. To
solve the problem, this PR adds a new flag that allows the tenant id to
be set by reading a file after the process starts. Such file, will be
empty when the SQL process starts and will be populated when the SQL
process is to be associated with a specific tenant. When the tenant id
is set through a file, and the file is empty at startup, the SQL process
will block and wait for the tenant id to be written in the file. This is
combined with a change where the SQL listener is created before the
tenant id is read from the file. This eliminates the posibility that a
client connection may be refused if it is forwarded quickly to the SQL
process.

Epic: [CC-8504](https://cockroachlabs.atlassian.net/browse/CC-8504)

Release note: None

Release Justification: Functionality specific to CC serverless that addresses cold start latency issues.