### PR TITLE
dev: don't "stress" `disallowed_imports_test`

### DIFF
--- a/dev
+++ b/dev
@@ -8,7 +8,7 @@ fi
 set -euo pipefail
 
 # Bump this counter to force rebuilding `dev` on all machines.
-DEV_VERSION=85
+DEV_VERSION=86
 
 THIS_DIR=$(cd "$(dirname "$0")" && pwd)
 BINARY_DIR=$THIS_DIR/bin/dev-versions

--- a/pkg/cmd/dev/test.go
+++ b/pkg/cmd/dev/test.go
@@ -362,7 +362,7 @@ func (d *dev) test(cmd *cobra.Command, commandLine []string) error {
 	if count == 1 {
 		ignoreCache = true
 	} else if count != 0 {
-		args = append(args, fmt.Sprintf("--runs_per_test=%d", count))
+		args = append(args, fmt.Sprintf("--runs_per_test=%d", count), "--runs_per_test=.*disallowed_imports_test@1")
 	}
 	if vModule != "" {
 		args = append(args, "--test_arg", fmt.Sprintf("-vmodule=%s", vModule))

--- a/pkg/cmd/dev/testdata/datadriven/test
+++ b/pkg/cmd/dev/testdata/datadriven/test
@@ -56,7 +56,7 @@ bazel test pkg/testutils:all pkg/util/limit:all --test_env=GOTRACEBACK=all --tes
 exec
 dev test pkg/spanconfig --count 5 --race
 ----
-bazel test --config=race pkg/spanconfig:all --test_env=GOTRACEBACK=all --runs_per_test=5 --test_output errors --build_event_binary_file=/tmp/path
+bazel test --config=race pkg/spanconfig:all --test_env=GOTRACEBACK=all --runs_per_test=5 '--runs_per_test=.*disallowed_imports_test@1' --test_output errors --build_event_binary_file=/tmp/path
 
 exec
 dev test pkg/cmd/dev -f TestDataDriven/test --rewrite -v
@@ -67,7 +67,7 @@ bazel test pkg/cmd/dev:all --test_env=GOTRACEBACK=all --test_env=COCKROACH_WORKS
 exec
 dev test pkg/server -f=TestSpanStatsResponse -v --count=5 --vmodule=raft=1
 ----
-bazel test pkg/server:all --test_env=GOTRACEBACK=all --test_filter=TestSpanStatsResponse --test_arg -test.v --runs_per_test=5 --test_arg -vmodule=raft=1 --test_sharding_strategy=disabled --test_output all --build_event_binary_file=/tmp/path
+bazel test pkg/server:all --test_env=GOTRACEBACK=all --test_filter=TestSpanStatsResponse --test_arg -test.v --runs_per_test=5 '--runs_per_test=.*disallowed_imports_test@1' --test_arg -vmodule=raft=1 --test_sharding_strategy=disabled --test_output all --build_event_binary_file=/tmp/path
 
 exec
 dev test --short
@@ -155,13 +155,13 @@ exec
 dev test pkg/spanconfig/spanconfigstore --stress
 ----
 getenv DEV_I_UNDERSTAND_ABOUT_STRESS
-bazel test pkg/spanconfig/spanconfigstore:all --test_env=GOTRACEBACK=all --test_env=COCKROACH_STRESS=true --notest_keep_going --runs_per_test=1000 --test_output errors --build_event_binary_file=/tmp/path
+bazel test pkg/spanconfig/spanconfigstore:all --test_env=GOTRACEBACK=all --test_env=COCKROACH_STRESS=true --notest_keep_going --runs_per_test=1000 '--runs_per_test=.*disallowed_imports_test@1' --test_output errors --build_event_binary_file=/tmp/path
 
 exec
 dev test pkg/spanconfig/spanconfigstore --stress --count 250
 ----
 getenv DEV_I_UNDERSTAND_ABOUT_STRESS
-bazel test pkg/spanconfig/spanconfigstore:all --test_env=GOTRACEBACK=all --test_env=COCKROACH_STRESS=true --notest_keep_going --runs_per_test=250 --test_output errors --build_event_binary_file=/tmp/path
+bazel test pkg/spanconfig/spanconfigstore:all --test_env=GOTRACEBACK=all --test_env=COCKROACH_STRESS=true --notest_keep_going --runs_per_test=250 '--runs_per_test=.*disallowed_imports_test@1' --test_output errors --build_event_binary_file=/tmp/path
 
 exec
 dev test pkg/spanconfig/spanconfigstore --count 1


### PR DESCRIPTION
These tests cannot be flaky and don't benefit from stressing.

Closes #110351.

Epic: CRDB-17171
Release note: None