### PR TITLE
storage: skip TestMVCCScanWithLargeKeyValue under race

### DIFF
--- a/pkg/storage/pebble_mvcc_scanner_test.go
+++ b/pkg/storage/pebble_mvcc_scanner_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
@@ -131,6 +132,8 @@ func TestMVCCScanWithManyVersionsAndSeparatedIntents(t *testing.T) {
 
 func TestMVCCScanWithLargeKeyValue(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	// This test has been observed to trip the disk-stall detector under -race.
+	skip.UnderRace(t, "large copies and memfs mutexes can cause excessive delays within VFS stack")
 
 	eng := createTestPebbleEngine()
 	defer eng.Close()


### PR DESCRIPTION
This test results in the creation of a large (~7MB) sstable block. The resulting memory copy to an in-memory file's buffer may be excessively slow in race builds, triggering the disk-stall detector. Skip this test under race builds.

Epic: none
Informs #110308.
Release note: none