### PR TITLE
ui: use MAX downsampler for sql connection rate

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/sql.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/sql.tsx
@@ -66,7 +66,7 @@ export default function (props: GraphDashboardProps) {
             name="cr.node.sql.new_conns"
             title={nodeDisplayName(nodeDisplayNameByID, node)}
             sources={[node]}
-            downsampler={TimeSeriesQueryAggregator.SUM}
+            downsampler={TimeSeriesQueryAggregator.MAX}
             nonNegativeRate
           />
         ))}


### PR DESCRIPTION
Epic: None

Release note (ui change): The "SQL Connection Rate" metric on the SQL Dashboard is downsampled using the MAX function instead of SUM. This improves situations where zooming out would cause the connection rate to increase for downsampled data.