### PR TITLE
release-23.1: roachtest: update github issue grafana link

### DIFF
--- a/pkg/cmd/roachtest/github.go
+++ b/pkg/cmd/roachtest/github.go
@@ -50,7 +50,7 @@ func roachtestPrefix(p string) string {
 
 // generateHelpCommand creates a HelpCommand for createPostRequest
 func generateHelpCommand(
-	clusterName string, cloud string, start time.Time, end time.Time,
+	testName string, clusterName string, cloud string, start time.Time, end time.Time,
 ) func(renderer *issues.Renderer) {
 	return func(renderer *issues.Renderer) {
 		issues.HelpCommandAsLink(
@@ -64,9 +64,13 @@ func generateHelpCommand(
 		// An empty clusterName corresponds to a cluster creation failure.
 		// We only scrape metrics from GCE clusters for now.
 		if spec.GCE == cloud && clusterName != "" {
+			// N.B. This assumes we are posting from a source that does not run a test more than once.
+			// Otherwise, we'd need to use `testRunId`, which encodes the run number and allows us
+			// to distinguish between multiple runs of the same test, instead of `testName`.
 			issues.HelpCommandAsLink(
 				"Grafana",
-				fmt.Sprintf("https://go.crdb.dev/p/roachfana/%s/%d/%d", clusterName, start.UnixMilli(), end.UnixMilli()),
+				fmt.Sprintf("https://go.crdb.dev/roachtest-grafana/%s/%s/%d/%d", vm.SanitizeLabel(runID),
+					vm.SanitizeLabel(testName), start.UnixMilli(), end.Add(2*time.Minute).UnixMilli()),
 			)(renderer)
 		}
 	}
@@ -223,7 +227,7 @@ func (g *githubIssues) createPostRequest(
 		Artifacts:            artifacts,
 		ExtraLabels:          labels,
 		ExtraParams:          clusterParams,
-		HelpCommand:          generateHelpCommand(issueClusterName, spec.Cluster.Cloud, start, end),
+		HelpCommand:          generateHelpCommand(testName, issueClusterName, spec.Cluster.Cloud, start, end),
 	}, nil
 }
 

--- a/pkg/cmd/roachtest/github_test.go
+++ b/pkg/cmd/roachtest/github_test.go
@@ -111,12 +111,12 @@ func TestGenerateHelpCommand(t *testing.T) {
 	end := time.Date(2023, time.July, 21, 16, 42, 13, 137, time.UTC)
 
 	r := &issues.Renderer{}
-	generateHelpCommand("foo-cluster", spec.GCE, start, end)(r)
+	generateHelpCommand("acceptance/gossip/locality-address", "foo-cluster", spec.GCE, start, end)(r)
 
 	echotest.Require(t, r.String(), filepath.Join("testdata", "help_command.txt"))
 
 	r = &issues.Renderer{}
-	generateHelpCommand("foo-cluster", spec.AWS, start, end)(r)
+	generateHelpCommand("acceptance/gossip/locality-address", "foo-cluster", spec.AWS, start, end)(r)
 
 	echotest.Require(t, r.String(), filepath.Join("testdata", "help_command_non_gce.txt"))
 }

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -938,9 +938,6 @@ func (r *testRunner) runTest(
 	if runCount > 1 {
 		testRunID += fmt.Sprintf("#%d", runNum)
 	}
-	if !teamCity {
-		shout(ctx, l, stdout, "=== RUN   %s", testRunID)
-	}
 
 	r.status.Lock()
 	r.status.running[t] = struct{}{}
@@ -966,8 +963,8 @@ func (r *testRunner) runTest(
 		if grafanaAvailable {
 			// Links to the dashboard overview for this test where a user can then navigate
 			// to a preferred dashboard. Add 2 minutes to show complete metrics in grafana.
-			l.Printf("grafana metrics available at: https://go.crdb.dev/roachtest-grafana/%s/%s/%d/%d",
-				vm.SanitizeLabel(runID), vm.SanitizeLabel(testRunID), t.start.UnixMilli(), t.end.Add(2*time.Minute).UnixMilli())
+			l.Printf("metrics: https://go.crdb.dev/roachtest-grafana/%s/%s/%d/%d", vm.SanitizeLabel(runID),
+				vm.SanitizeLabel(testRunID), t.start.UnixMilli(), t.end.Add(2*time.Minute).UnixMilli())
 		}
 		// We only have to record panics if the panic'd value is not the sentinel
 		// produced by t.Fatal*(). We may see calls to t.Fatal from this goroutine
@@ -1120,8 +1117,12 @@ func (r *testRunner) runTest(
 	if grafanaAvailable {
 		// Shout this to the log and stdout to make it available to anyone watching the test via CI or locally.
 		// At this point, we don't have an end time, so default to a 30 minute window from the start time.
-		shout(ctx, l, stdout, "grafana metrics available at: https://go.crdb.dev/roachtest-grafana/%s/%s/%d/%d",
-			vm.SanitizeLabel(runID), vm.SanitizeLabel(testRunID), t.start.UnixMilli(), t.start.Add(30*time.Minute).UnixMilli())
+		shout(ctx, l, stdout, "=== RUN   %s  [metrics: https://go.crdb.dev/roachtest-grafana/%s/%s/%d/%d]",
+			testRunID, vm.SanitizeLabel(runID), vm.SanitizeLabel(testRunID), t.start.UnixMilli(), t.start.Add(30*time.Minute).UnixMilli())
+	} else {
+		if !teamCity {
+			shout(ctx, l, stdout, "=== RUN   %s", testRunID)
+		}
 	}
 	select {
 	case <-testReturnedCh:

--- a/pkg/cmd/roachtest/testdata/help_command.txt
+++ b/pkg/cmd/roachtest/testdata/help_command.txt
@@ -11,7 +11,7 @@ See: [How To Investigate \(internal\)](https://cockroachlabs.atlassian.net/l/c/S
 
 
 
-See: [Grafana](https://go.crdb.dev/p/roachfana/foo-cluster/1689957243000/1689957733000)
+See: [Grafana](https://go.crdb.dev/roachtest-grafana//acceptance-gossip-locality-address/1689957243000/1689957853000)
 
 ----
 ----

--- a/pkg/cmd/roachtest/testdata/help_command_createpost_1.txt
+++ b/pkg/cmd/roachtest/testdata/help_command_createpost_1.txt
@@ -11,7 +11,7 @@ See: [How To Investigate \(internal\)](https://cockroachlabs.atlassian.net/l/c/S
 
 
 
-See: [Grafana](https://go.crdb.dev/p/roachfana/foo/1689957243000/1689957733000)
+See: [Grafana](https://go.crdb.dev/roachtest-grafana//github-test/1689957243000/1689957853000)
 
 ----
 ----

--- a/pkg/cmd/roachtest/testdata/help_command_createpost_5.txt
+++ b/pkg/cmd/roachtest/testdata/help_command_createpost_5.txt
@@ -11,7 +11,7 @@ See: [How To Investigate \(internal\)](https://cockroachlabs.atlassian.net/l/c/S
 
 
 
-See: [Grafana](https://go.crdb.dev/p/roachfana/foo/1689957243000/1689957733000)
+See: [Grafana](https://go.crdb.dev/roachtest-grafana//github-test/1689957243000/1689957853000)
 
 ----
 ----


### PR DESCRIPTION
Backport 1/1 commits from #110269.

/cc @cockroachdb/release

---

Small PR: 

Update the link posted to github issues to use the test name based dashboards. Also, print dashboard link inline with `===RUN <testname>`. This will reduce the noise when running roachtests locally (cc @renatolabs)

GCE nightly roachtest runs will now always see the `===RUN ... ` log statement which was previously suppressed.

Epic: none
Release note: None
Release justification: test-only change
