### PR TITLE
ctxgroup: panic in Wait() if task panics

### DIFF
--- a/pkg/util/ctxgroup/BUILD.bazel
+++ b/pkg/util/ctxgroup/BUILD.bazel
@@ -5,7 +5,11 @@ go_library(
     srcs = ["ctxgroup.go"],
     importpath = "github.com/cockroachdb/cockroach/pkg/util/ctxgroup",
     visibility = ["//visibility:public"],
-    deps = ["@org_golang_x_sync//errgroup"],
+    deps = [
+        "//pkg/util/syncutil",
+        "@com_github_cockroachdb_errors//:errors",
+        "@org_golang_x_sync//errgroup",
+    ],
 )
 
 go_test(
@@ -17,5 +21,6 @@ go_test(
         "//pkg/testutils",
         "//pkg/util/leaktest",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/util/ctxgroup/ctxgroup_test.go
+++ b/pkg/util/ctxgroup/ctxgroup_test.go
@@ -7,11 +7,13 @@ package ctxgroup
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
 )
 
 func TestErrorAfterCancel(t *testing.T) {
@@ -35,5 +37,31 @@ func TestErrorAfterCancel(t *testing.T) {
 		if err := g.Wait(); !errors.Is(err, expErr) {
 			t.Errorf("expected %v, got %v", expErr, err)
 		}
+	})
+}
+
+func funcThatPanics(x interface{}) {
+	panic(x)
+}
+
+func TestPanic(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	testutils.RunTrueAndFalse(t, "multi", func(t *testing.T, b bool) {
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Logf("recovered: %+v", r)
+					require.Contains(t, fmt.Sprintf("%+v", r), "funcThatPanics", "panic stack missing")
+				}
+			}()
+			g := WithContext(context.Background())
+			g.GoCtx(func(_ context.Context) error { funcThatPanics(1); return errors.New("unseen") })
+			if b {
+				g.GoCtx(func(_ context.Context) error { funcThatPanics(2); return nil })
+				g.GoCtx(func(_ context.Context) error { funcThatPanics(3); return nil })
+			}
+			t.Fatal(g.Wait(), "unreachable if we hit expected panic in Wait")
+		}()
 	})
 }


### PR DESCRIPTION
Previously if a caller were to pass some piece of code to a ctxgroup to execute and then wait on that execution, that caller would not see any panics in the execution of the task, as it is on a different goroutine.

For example, consider some function that does two steps and handles panics:

```
func f(ctx) {
  defer func() { if r := recover(); r != nil { handle(r) })()
  foo()
  bar()
}
```

A refactor may then opt to run foo and bar concurrently:

```
func f(ctx) {
  defer func() { if r := recover(); r != nil { handle(r) })()
  g := ctxgroup.WithContext(ctx)
  g.GoCtx(foo)
  g.GoCtx(bar)
  g.Wait()
}
```

However, when `foo` and `bar` were handed to the group, their panics are no longer visible to f and its recover/handling. Additionally, stack traces from these panics are also harder to attribute to f.

This change extends the ctxgroup to recover panics in tasks passed to it just long enough to transport them back to the group, where they are then re-thrown when Wait() is called. In our example above, f() would once again see the panic thrown in foo or bar be thrown when it calls Wait().

In general, this should make the behavior of panics, and what is or is not recovered or handles more predictable when code introduces uses of a ctxgroup, as the same panics should generally continue to be thrown on the same goroutines, instead of elsewhere.

Release note: none.
Epic: none.