### PR TITLE
release-22.2: tree: fix formatting of CreateChangefeed with predicate

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -4517,17 +4517,17 @@ func TestChangefeedDescription(t *testing.T) {
 		{
 			// TODO(#85143): remove schema_change_policy='stop' from this test.
 			create: "CREATE CHANGEFEED INTO $1 WITH updated, envelope = $2, schema_change_policy='stop' AS SELECT a FROM foo WHERE a % 2 = 0",
-			descr:  `CREATE CHANGEFEED INTO '` + redactedSink + `' WITH envelope = 'wrapped', schema_change_policy = 'stop', updated AS SELECT a FROM foo WHERE (a % 2) = 0`,
+			descr:  `CREATE CHANGEFEED INTO '` + redactedSink + `' WITH OPTIONS (envelope = 'wrapped', schema_change_policy = 'stop', updated) AS SELECT a FROM foo WHERE (a % 2) = 0`,
 		},
 		{
 			// TODO(#85143): remove schema_change_policy='stop' from this test.
 			create: "CREATE CHANGEFEED INTO $1 WITH updated, envelope = $2, schema_change_policy='stop' AS SELECT a FROM public.foo AS bar WHERE a % 2 = 0",
-			descr:  `CREATE CHANGEFEED INTO '` + redactedSink + `' WITH envelope = 'wrapped', schema_change_policy = 'stop', updated AS SELECT a FROM public.foo AS bar WHERE (a % 2) = 0`,
+			descr:  `CREATE CHANGEFEED INTO '` + redactedSink + `' WITH OPTIONS (envelope = 'wrapped', schema_change_policy = 'stop', updated) AS SELECT a FROM public.foo AS bar WHERE (a % 2) = 0`,
 		},
 		{
 			// TODO(#85143): remove schema_change_policy='stop' from this test.
 			create: "CREATE CHANGEFEED INTO $1 WITH updated, envelope = $2, schema_change_policy='stop' AS SELECT a FROM foo WHERE status IN ('open', 'closed')",
-			descr:  `CREATE CHANGEFEED INTO '` + redactedSink + `' WITH envelope = 'wrapped', schema_change_policy = 'stop', updated AS SELECT a FROM foo WHERE status IN ('open', 'closed')`,
+			descr:  `CREATE CHANGEFEED INTO '` + redactedSink + `' WITH OPTIONS (envelope = 'wrapped', schema_change_policy = 'stop', updated) AS SELECT a FROM foo WHERE status IN ('open', 'closed')`,
 		},
 	} {
 		t.Run(tc.create, func(t *testing.T) {

--- a/pkg/sql/parser/testdata/changefeed
+++ b/pkg/sql/parser/testdata/changefeed
@@ -110,15 +110,23 @@ CREATE CHANGEFEED AS SELECT * FROM _ WHERE _ > _ -- identifiers removed
 parse
 CREATE CHANGEFEED WITH opt='val' AS SELECT * FROM foo WHERE a  > b
 ----
-CREATE CHANGEFEED WITH opt = 'val' AS SELECT * FROM foo WHERE a > b -- normalized!
-CREATE CHANGEFEED WITH opt = ('val') AS SELECT (*) FROM foo WHERE ((a) > (b)) -- fully parenthesized
-CREATE CHANGEFEED WITH opt = '_' AS SELECT * FROM foo WHERE a > b -- literals removed
-CREATE CHANGEFEED WITH _ = 'val' AS SELECT * FROM _ WHERE _ > _ -- identifiers removed
+CREATE CHANGEFEED WITH OPTIONS (opt = 'val') AS SELECT * FROM foo WHERE a > b -- normalized!
+CREATE CHANGEFEED WITH OPTIONS (opt = ('val')) AS SELECT (*) FROM foo WHERE ((a) > (b)) -- fully parenthesized
+CREATE CHANGEFEED WITH OPTIONS (opt = '_') AS SELECT * FROM foo WHERE a > b -- literals removed
+CREATE CHANGEFEED WITH OPTIONS (_ = 'val') AS SELECT * FROM _ WHERE _ > _ -- identifiers removed
 
 parse
 CREATE CHANGEFEED INTO 'null://' WITH opt='val' AS SELECT * FROM foo WHERE a  > b
 ----
-CREATE CHANGEFEED INTO 'null://' WITH opt = 'val' AS SELECT * FROM foo WHERE a > b -- normalized!
-CREATE CHANGEFEED INTO ('null://') WITH opt = ('val') AS SELECT (*) FROM foo WHERE ((a) > (b)) -- fully parenthesized
-CREATE CHANGEFEED INTO '_' WITH opt = '_' AS SELECT * FROM foo WHERE a > b -- literals removed
-CREATE CHANGEFEED INTO 'null://' WITH _ = 'val' AS SELECT * FROM _ WHERE _ > _ -- identifiers removed
+CREATE CHANGEFEED INTO 'null://' WITH OPTIONS (opt = 'val') AS SELECT * FROM foo WHERE a > b -- normalized!
+CREATE CHANGEFEED INTO ('null://') WITH OPTIONS (opt = ('val')) AS SELECT (*) FROM foo WHERE ((a) > (b)) -- fully parenthesized
+CREATE CHANGEFEED INTO '_' WITH OPTIONS (opt = '_') AS SELECT * FROM foo WHERE a > b -- literals removed
+CREATE CHANGEFEED INTO 'null://' WITH OPTIONS (_ = 'val') AS SELECT * FROM _ WHERE _ > _ -- identifiers removed
+
+parse
+CREATE CHANGEFEED WITH OPTIONS ( BUCKET_COUNT = PLACEHOLDER ) AS SELECT * , * FROM FAMILY AS DECIMAL
+----
+CREATE CHANGEFEED WITH OPTIONS (bucket_count = 'placeholder') AS SELECT *, * FROM "family" AS "decimal" -- normalized!
+CREATE CHANGEFEED WITH OPTIONS (bucket_count = ('placeholder')) AS SELECT (*), (*) FROM "family" AS "decimal" -- fully parenthesized
+CREATE CHANGEFEED WITH OPTIONS (bucket_count = '_') AS SELECT *, * FROM "family" AS "decimal" -- literals removed
+CREATE CHANGEFEED WITH OPTIONS (_ = 'placeholder') AS SELECT *, * FROM _ AS _ -- identifiers removed

--- a/pkg/sql/sem/tree/changefeed.go
+++ b/pkg/sql/sem/tree/changefeed.go
@@ -62,8 +62,9 @@ func (node *CreateChangefeed) formatWithPredicates(ctx *FmtCtx) {
 		ctx.FormatNode(node.SinkURI)
 	}
 	if node.Options != nil {
-		ctx.WriteString(" WITH ")
+		ctx.WriteString(" WITH OPTIONS (")
 		ctx.FormatNode(&node.Options)
+		ctx.WriteString(")")
 	}
 	ctx.WriteString(" AS ")
 	node.Select.Format(ctx)


### PR DESCRIPTION
Backport 1/1 commits from #110301.

/cc @cockroachdb/release

---

Previously, some statements would not round-trip parsing and formatting.

Release justification: low risk bug fix
fixes https://github.com/cockroachdb/cockroach/issues/110234
Release note: None
