### PR TITLE
roachtest: fix NPE in test_runner

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -892,6 +892,10 @@ func (f *clusterFactory) newCluster(
 		}
 		return c, nil, nil
 	}
+	// Ensure an allocation is specified.
+	if cfg.alloc == nil {
+		return nil, nil, errors.New("no allocation specified; cfg.alloc must be set")
+	}
 
 	if cfg.localCluster {
 		// Local clusters never expire.
@@ -1096,7 +1100,7 @@ func (c *clusterImpl) StopCockroachGracefullyOnNode(
 func (c *clusterImpl) Save(ctx context.Context, msg string, l *logger.Logger) {
 	l.PrintfCtx(ctx, "saving cluster %s for debugging (--debug specified)", c)
 	// TODO(andrei): should we extend the cluster here? For how long?
-	if c.destroyState.owned { // we won't have an alloc for an unowned cluster
+	if c.destroyState.owned && c.destroyState.alloc != nil { // we won't have an alloc for an unowned cluster
 		c.destroyState.alloc.Freeze()
 	}
 	c.r.markClusterAsSaved(c, msg)

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -630,10 +630,19 @@ func (r *testRunner) runWorker(
 				// N.B. we do not count reuse attempt error toward clusterCreateErr.
 				// Let's attempt to create a fresh one.
 				testToRun.canReuseCluster = false
-			}
-			// sanity check
-			if c.spec.Cloud != spec.Local && c.spec.Arch != "" && c.arch != c.spec.Arch {
-				return errors.Newf("cluster arch %q does not match specified arch %q on cloud: %q", c.arch, c.spec.Arch, c.spec.Cloud)
+				// Destroy the cluster since we're unable to reuse it.
+				// NB: This is a hack. If we destroy the cluster, the allocation quota will get released back into the pool.
+				// Thus, we can't immediately create a fresh cluster since another worker might grab the quota before us.
+				// Instead, we transfer the allocation quota to the new cluster and pretend the old one didn't have any.
+				testToRun.alloc = c.destroyState.alloc
+				c.destroyState.alloc = nil
+				c.Destroy(context.Background(), closeLogger, l)
+				c = nil
+			} else {
+				// Reuse is possible, let's do a sanity check.
+				if c.spec.Cloud != spec.Local && c.spec.Arch != "" && c.arch != c.spec.Arch {
+					return errors.Newf("cluster arch %q does not match specified arch %q on cloud: %q", c.arch, c.spec.Arch, c.spec.Cloud)
+				}
 			}
 		}
 		arch := testToRun.spec.Cluster.Arch


### PR DESCRIPTION
Previously, an NPE discovered in [1] wasn't observed in any of the nightly runs, given the necessary conditions implied multiple, consecutive failures. As of recently, the NPE surfaced in nightlies.

This PR fixes the NPE, and a leaked cluster allocation. The fix is intended to be temporary since a refactored test runner in [2] had already addressed it; we plan to resurrect [2] in the coming weeks.

Epic: none
Fixes: #104385

Release note: None

[1] https://github.com/cockroachdb/cockroach/issues/104385
[2] https://github.com/cockroachdb/cockroach/pull/101814