### PR TITLE
sql/tests: deflake TestRandomSyntaxSchemaChangeColumn

### DIFF
--- a/pkg/sql/tests/rsg_test.go
+++ b/pkg/sql/tests/rsg_test.go
@@ -52,7 +52,7 @@ var (
 	flagRSGTime                    = flag.Duration("rsg", 0, "random syntax generator test duration")
 	flagRSGGoRoutines              = flag.Int("rsg-routines", 1, "number of Go routines executing random statements in each RSG test")
 	flagRSGExecTimeout             = flag.Duration("rsg-exec-timeout", 35*time.Second, "timeout duration when executing a statement")
-	flagRSGExecColumnChangeTimeout = flag.Duration("rsg-exec-column-change-timeout", 40*time.Second, "timeout duration when executing a statement for random column changes")
+	flagRSGExecColumnChangeTimeout = flag.Duration("rsg-exec-column-change-timeout", 50*time.Second, "timeout duration when executing a statement for random column changes")
 )
 
 func verifyFormat(sql string) error {


### PR DESCRIPTION
The schema changes in this test are expected to take a longer time than other randomized tests. Bump the timeout.

A CPU profile also showed that this test spends a lot of its time constructing the call stack, and this occurs while building an error message in GetAttribute. It turns out that production code never actually looks at this error, so we can make the message much simpler.

informs https://github.com/cockroachdb/cockroach/issues/109304
Release note: None