### PR TITLE
rangefeed: shard the rangefeed scheduler

### DIFF
--- a/pkg/kv/kvserver/rangefeed/scheduler.go
+++ b/pkg/kv/kvserver/rangefeed/scheduler.go
@@ -236,66 +236,35 @@ func (s *Scheduler) Start(ctx context.Context, stopper *stop.Stopper) error {
 // Scheduler is stopped.
 func (s *Scheduler) Register(f Callback) (int64, error) {
 	id := s.nextID.Add(1)
-	shard := s.shards[shardIndex(id, len(s.shards))]
-
-	shard.Lock()
-	defer shard.Unlock()
-	if shard.quiescing {
-		// Don't accept new registrations if quiesced.
-		return 0, errors.New("server stopping")
+	if err := s.shards[shardIndex(id, len(s.shards))].register(id, f); err != nil {
+		return 0, err
 	}
-	shard.procs[id] = f
 	return id, nil
 }
 
 // Unregister a processor. This function is removing processor callback and
 // status from scheduler. If processor is currently processing event it will
 // finish processing.
+//
 // Processor won't receive Stopped event if it wasn't explicitly sent.
 // To make sure processor performs cleanup, it is easier to send it Stopped
 // event first and let it remove itself from registration during event handling.
 // Any attempts to enqueue events for processor after this call will return an
 // error.
 func (s *Scheduler) Unregister(id int64) {
-	shard := s.shards[shardIndex(id, len(s.shards))]
-	shard.Lock()
-	defer shard.Unlock()
-
-	delete(shard.procs, id)
-	delete(shard.status, id)
+	s.shards[shardIndex(id, len(s.shards))].unregister(id)
 }
 
 func (s *Scheduler) Stop() {
-	// Stop all processors across all shards.
+	// Stop all shard workers.
 	for _, shard := range s.shards {
-		shard.Lock()
-		if !shard.quiescing {
-			// On first close attempt trigger termination of all unfinished callbacks,
-			// we only need to do that once to avoid closing s.drained channel multiple
-			// times.
-			shard.quiescing = true
-		}
-		shard.Unlock()
-		shard.cond.Broadcast()
+		shard.quiesce()
 	}
 	s.wg.Wait()
 
-	// Synchronously notify all non-stopped processors about stop.
+	// Synchronously notify processors about stop.
 	for _, shard := range s.shards {
-		shard.Lock()
-		for id, p := range shard.procs {
-			pending := shard.status[id]
-			// Ignore processors that already processed their stopped event.
-			if pending == Stopped {
-				continue
-			}
-			// Add stopped event on top of what was pending and remove queued.
-			pending = (^Queued & pending) | Stopped
-			shard.Unlock()
-			p(pending)
-			shard.Lock()
-		}
-		shard.Unlock()
+		shard.stop()
 	}
 }
 
@@ -306,42 +275,18 @@ func (s *Scheduler) StopProcessor(id int64) {
 	s.Enqueue(id, Stopped)
 }
 
-// Enqueue event for existing callback. Returns error if callback was not
-// registered for the id or if processor is stopping. Error doesn't guarantee
-// that processor actually handled stopped event it may either be pending or
-// processed.
+// Enqueue event for existing callback. The event is ignored if the processor
+// does not exist.
 func (s *Scheduler) Enqueue(id int64, evt processorEventType) {
-	shard := s.shards[shardIndex(id, len(s.shards))]
-
-	shard.Lock()
-	defer shard.Unlock()
-	if _, ok := shard.procs[id]; !ok {
-		return
-	}
-	newWork := shard.enqueueLocked(id, evt)
-	if newWork {
-		// Wake up potential waiting worker.
-		// We are allowed to do this under cond lock.
-		shard.cond.Signal()
-	}
+	s.shards[shardIndex(id, len(s.shards))].enqueue(id, evt)
 }
 
 // EnqueueBatch enqueues an event for a set of processors across all shards.
 // Using a batch allows efficient enqueueing with minimal lock contention.
 func (s *Scheduler) EnqueueBatch(batch *SchedulerBatch, evt processorEventType) {
 	for shardIdx, ids := range batch.ids {
-		if len(ids) == 0 {
-			continue // skip shards with no new work
-		}
-		shard := s.shards[shardIdx]
-		count := shard.enqueueN(ids, evt)
-
-		if count >= shard.numWorkers {
-			shard.cond.Broadcast()
-		} else {
-			for i := 0; i < count; i++ {
-				shard.cond.Signal()
-			}
+		if len(ids) > 0 {
+			s.shards[shardIdx].enqueueN(ids, evt)
 		}
 	}
 }
@@ -353,8 +298,46 @@ func (s *Scheduler) NewEnqueueBatch() *SchedulerBatch {
 	return newSchedulerBatch(len(s.shards))
 }
 
+// register registers a callback with the shard. The caller must not hold
+// the shard lock.
+func (ss *schedulerShard) register(id int64, f Callback) error {
+	ss.Lock()
+	defer ss.Unlock()
+	if ss.quiescing {
+		// Don't accept new registrations if quiesced.
+		return errors.New("server stopping")
+	}
+	ss.procs[id] = f
+	return nil
+}
+
+// unregister unregisters a callbak with the shard. The caller must not
+// hold the shard lock.
+func (ss *schedulerShard) unregister(id int64) {
+	ss.Lock()
+	defer ss.Unlock()
+	delete(ss.procs, id)
+	delete(ss.status, id)
+}
+
+// enqueue enqueues a single event for a given processor in this shard, and wakes
+// up a worker to process it. The caller must not hold the shard lock.
+func (ss *schedulerShard) enqueue(id int64, evt processorEventType) {
+	ss.Lock()
+	defer ss.Unlock()
+	if ss.enqueueLocked(id, evt) {
+		// Wake up potential waiting worker.
+		// We are allowed to do this under cond lock.
+		ss.cond.Signal()
+	}
+}
+
 // enqueueLocked enqueues a single event for a given processor in this shard.
+// Does not wake up a worker to process it.
 func (ss *schedulerShard) enqueueLocked(id int64, evt processorEventType) bool {
+	if _, ok := ss.procs[id]; !ok {
+		return false
+	}
 	pending := ss.status[id]
 	if pending&Stopped != 0 {
 		return false
@@ -371,8 +354,8 @@ func (ss *schedulerShard) enqueueLocked(id int64, evt processorEventType) bool {
 	return pending == 0
 }
 
-// enqueueN enqueues an event for multiple processors on this shard. The
-// caller must not hold the shard lock.
+// enqueueN enqueues an event for multiple processors on this shard, and wakes
+// up workers to process them. The caller must not hold the shard lock.
 func (ss *schedulerShard) enqueueN(ids []int64, evt processorEventType) int {
 	// Avoid locking for 0 new processors.
 	if len(ids) == 0 {
@@ -391,6 +374,14 @@ func (ss *schedulerShard) enqueueN(ids []int64, evt processorEventType) int {
 		}
 	}
 	ss.Unlock()
+
+	if count >= ss.numWorkers {
+		ss.cond.Broadcast()
+	} else {
+		for i := 0; i < count; i++ {
+			ss.cond.Signal()
+		}
+	}
 	return count
 }
 
@@ -462,6 +453,34 @@ func (ss *schedulerShard) processEvents(ctx context.Context) {
 			}
 		}
 		ss.Unlock()
+	}
+}
+
+// quiesce asks shard workers to terminate and stops accepting new work.
+func (ss *schedulerShard) quiesce() {
+	ss.Lock()
+	ss.quiescing = true
+	ss.Unlock()
+	ss.cond.Broadcast()
+}
+
+// stop synchronously stops processors by submitting and processing a stopped
+// event and any other pending work. quiesce() must be called first to stop
+// shard workers.
+func (ss *schedulerShard) stop() {
+	ss.Lock()
+	defer ss.Unlock()
+	for id, p := range ss.procs {
+		pending := ss.status[id]
+		// Ignore processors that already processed their stopped event.
+		if pending == Stopped {
+			continue
+		}
+		// Add stopped event on top of what was pending and remove queued.
+		pending = (^Queued & pending) | Stopped
+		ss.Unlock()
+		p(pending)
+		ss.Lock()
 	}
 }
 

--- a/pkg/kv/kvserver/rangefeed/scheduler.go
+++ b/pkg/kv/kvserver/rangefeed/scheduler.go
@@ -68,7 +68,7 @@ const (
 var eventNames = map[processorEventType]string{
 	Queued:        "Queued",
 	Stopped:       "Stopped",
-	EventQueued:   "Data",
+	EventQueued:   "Event",
 	RequestQueued: "Request",
 	PushTxnQueued: "PushTxn",
 }

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -185,6 +185,15 @@ var logStoreTelemetryTicks = envutil.EnvOrDefaultInt(
 var defaultRangefeedSchedulerConcurrency = envutil.EnvOrDefaultInt(
 	"COCKROACH_RANGEFEED_SCHEDULER_WORKERS", min(4*runtime.GOMAXPROCS(0), 64))
 
+// defaultRangefeedSchedulerShardSize specifies the default maximum number of
+// scheduler worker goroutines per mutex shard. By default, we spin up 4 workers
+// per CPU core, capped at 64, so 8 is equivalent to 2 CPUs per shard, or a
+// maximum of 8 shards. Since rangefeed processing is generally cheap, this
+// significantly relieves contention, while also avoiding starvation by
+// excessive sharding.
+var defaultRangefeedSchedulerShardSize = envutil.EnvOrDefaultInt(
+	"COCKROACH_RANGEFEED_SCHEDULER_SHARD_SIZE", 8)
+
 // bulkIOWriteLimit is defined here because it is used by BulkIOWriteLimiter.
 var bulkIOWriteLimit = settings.RegisterByteSizeSetting(
 	settings.SystemOnly,
@@ -1236,6 +1245,10 @@ type StoreConfig struct {
 	// RangeFeedSchedulerConcurrency specifies number of rangefeed scheduler
 	// workers for the store.
 	RangeFeedSchedulerConcurrency int
+
+	// RangeFeedSchedulerShardSize specifies the maximum number of workers per
+	// scheduler shard.
+	RangeFeedSchedulerShardSize int
 }
 
 // logRangeAndNodeEventsEnabled is used to enable or disable logging range events
@@ -1270,7 +1283,7 @@ func (sc *StoreConfig) Valid() bool {
 		sc.RaftElectionTimeoutTicks > 0 && sc.RaftReproposalTimeoutTicks > 0 &&
 		sc.RaftSchedulerConcurrency > 0 && sc.RaftSchedulerConcurrencyPriority > 0 &&
 		sc.RaftSchedulerShardSize > 0 && sc.ScanInterval >= 0 && sc.AmbientCtx.Tracer != nil &&
-		sc.RangeFeedSchedulerConcurrency > 0
+		sc.RangeFeedSchedulerConcurrency > 0 && sc.RangeFeedSchedulerShardSize > 0
 }
 
 // SetDefaults initializes unset fields in StoreConfig to values
@@ -1318,6 +1331,9 @@ func (sc *StoreConfig) SetDefaults(numStores int) {
 				(sc.RangeFeedSchedulerConcurrency-1)/numStores+1, // ceil division
 				2)
 		}
+	}
+	if sc.RangeFeedSchedulerShardSize == 0 {
+		sc.RangeFeedSchedulerShardSize = defaultRangefeedSchedulerShardSize
 	}
 }
 
@@ -1978,7 +1994,8 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 	}
 
 	rfs := rangefeed.NewScheduler(rangefeed.SchedulerConfig{
-		Workers: s.cfg.RangeFeedSchedulerConcurrency,
+		Workers:   s.cfg.RangeFeedSchedulerConcurrency,
+		ShardSize: s.cfg.RangeFeedSchedulerShardSize,
 	})
 	if err = rfs.Start(ctx, s.stopper); err != nil {
 		return err
@@ -2400,26 +2417,26 @@ func (s *Store) startRangefeedTxnPushNotifier(ctx context.Context) {
 		ctx, cancel := s.stopper.WithCancelOnQuiesce(ctx)
 		defer cancel()
 
-		var schedulerIDs []int64
-		updateSchedulerIDs := func() []int64 {
-			schedulerIDs = schedulerIDs[:0]
+		makeSchedulerBatch := func() *rangefeed.SchedulerBatch {
+			batch := s.rangefeedScheduler.NewEnqueueBatch()
 			s.rangefeedReplicas.Lock()
 			for _, id := range s.rangefeedReplicas.m {
 				if id != 0 {
 					// Only process ranges that use scheduler.
-					schedulerIDs = append(schedulerIDs, id)
+					batch.Add(id)
 				}
 			}
 			s.rangefeedReplicas.Unlock()
-			return schedulerIDs
+			return batch
 		}
 
 		ticker := time.NewTicker(rangefeed.DefaultPushTxnsInterval)
 		for {
 			select {
 			case <-ticker.C:
-				activeIDs := updateSchedulerIDs()
-				s.rangefeedScheduler.EnqueueAll(activeIDs, rangefeed.PushTxnQueued)
+				batch := makeSchedulerBatch()
+				s.rangefeedScheduler.EnqueueBatch(batch, rangefeed.PushTxnQueued)
+				batch.Close()
 			case <-ctx.Done():
 				ticker.Stop()
 				return

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -179,10 +179,10 @@ var logStoreTelemetryTicks = envutil.EnvOrDefaultInt(
 	6*60,
 )
 
-// defaultRangefeedSchedulerConcurency specifies how many workers rangefeed
+// defaultRangefeedSchedulerConcurrency specifies how many workers rangefeed
 // scheduler will use to perform rangefeed work. This number will be divided
 // between stores of the node.
-var defaultRangefeedSchedulerConcurency = envutil.EnvOrDefaultInt(
+var defaultRangefeedSchedulerConcurrency = envutil.EnvOrDefaultInt(
 	"COCKROACH_RANGEFEED_SCHEDULER_WORKERS", min(4*runtime.GOMAXPROCS(0), 64))
 
 // bulkIOWriteLimit is defined here because it is used by BulkIOWriteLimiter.
@@ -1311,7 +1311,7 @@ func (sc *StoreConfig) SetDefaults(numStores int) {
 		sc.TestingKnobs.DisableQuiescence = true
 	}
 	if sc.RangeFeedSchedulerConcurrency == 0 {
-		sc.RangeFeedSchedulerConcurrency = defaultRangefeedSchedulerConcurency
+		sc.RangeFeedSchedulerConcurrency = defaultRangefeedSchedulerConcurrency
 		if numStores > 1 && sc.RangeFeedSchedulerConcurrency > 1 {
 			// We want at least two workers per store to avoid any blocking.
 			sc.RangeFeedSchedulerConcurrency = min(

--- a/pkg/testutils/lint/gcassert_paths.txt
+++ b/pkg/testutils/lint/gcassert_paths.txt
@@ -5,6 +5,7 @@ kv/kvclient/kvcoord
 kv/kvclient/rangecache
 kv/kvpb
 kv/kvserver/intentresolver
+kv/kvserver/rangefeed
 roachpb
 sql/catalog/descs
 sql/colcontainer


### PR DESCRIPTION
This patch shards the rangefeed scheduler, to reduce contention on the scheduler mutex. Each shard has a separate mutex and worker pool, and processors are assigned round-robin to shards.

The default shard size is 8 workers, which corresponds to 2 CPUs with default settings. This is configurable via the environment variable `COCKROACH_RANGEFEED_SCHEDULER_SHARD_SIZE`.

Resolves #110427.

Epic: none
Release note: None