### PR TITLE
streamingccl: validate partition spec in stream_partition

### DIFF
--- a/pkg/ccl/streamingccl/streamclient/BUILD.bazel
+++ b/pkg/ccl/streamingccl/streamclient/BUILD.bazel
@@ -67,6 +67,7 @@ go_test(
         "//pkg/ccl/streamingccl/replicationtestutils",
         "//pkg/jobs",
         "//pkg/jobs/jobspb",
+        "//pkg/keys",
         "//pkg/repstream/streampb",
         "//pkg/roachpb",
         "//pkg/security/securityassets",

--- a/pkg/ccl/streamingccl/streamingest/ingest_span_configs_test.go
+++ b/pkg/ccl/streamingccl/streamingest/ingest_span_configs_test.go
@@ -340,7 +340,7 @@ func createDummySpanConfigIngestor(
 		true /* restoreTenantFromStream */)
 	require.NoError(t, err)
 
-	session, err := h.SysServer.SQLLivenessProvider().(sqlliveness.Provider).Session(ctx)
+	session, err := h.TestServer.StorageLayer().SQLLivenessProvider().(sqlliveness.Provider).Session(ctx)
 	require.NoError(t, err)
 
 	stopperCh := make(chan struct{})

--- a/pkg/ccl/streamingccl/streamproducer/event_stream.go
+++ b/pkg/ccl/streamingccl/streamproducer/event_stream.go
@@ -15,7 +15,9 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/streamingccl/replicationutils"
+	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/rangefeed"
@@ -23,6 +25,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/repstream/streampb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
@@ -45,7 +49,6 @@ type eventStream struct {
 	spec            streampb.StreamPartitionSpec
 	subscribedSpans roachpb.SpanGroup
 	mon             *mon.BytesMonitor
-	acc             mon.BoundAccount
 
 	data tree.Datums // Data to send to the consumer
 
@@ -57,6 +60,7 @@ type eventStream struct {
 	errCh       chan error                    // Signaled when error occurs in rangefeed.
 	streamCh    chan tree.Datums              // Channel signaled to forward datums to consumer.
 	sp          *tracing.Span                 // Span representing the lifetime of the eventStream.
+	acc         mon.BoundAccount
 }
 
 var _ eval.ValueGenerator = (*eventStream)(nil)
@@ -80,6 +84,14 @@ func (s *eventStream) Start(ctx context.Context, txn *kv.Txn) error {
 	if s.errCh != nil {
 		return errors.AssertionFailedf("expected to be started once")
 	}
+
+	sourceTenantID, err := s.validateProducerJobAndSpec(ctx)
+	if err != nil {
+		return err
+	}
+
+	log.Infof(ctx, "starting physical replication event stream: tenant=%s initial_scan_timestamp=%s previous_replicated_time=%s",
+		sourceTenantID, s.spec.InitialScanTimestamp, s.spec.PreviousReplicatedTimestamp)
 
 	s.acc = s.mon.MakeBoundAccount()
 
@@ -209,7 +221,6 @@ func (s *eventStream) startStreamProcessor(ctx context.Context, frontier *span.F
 	}))
 
 	// TODO(yevgeniy): Add go routine to monitor stream job liveness.
-	// TODO(yevgeniy): Add validation that partition spans are a subset of stream spans.
 }
 
 // Next implements tree.ValueGenerator interface.
@@ -231,15 +242,20 @@ func (s *eventStream) Values() (tree.Datums, error) {
 
 // Close implements tree.ValueGenerator interface.
 func (s *eventStream) Close(ctx context.Context) {
-	s.rf.Close()
+	if s.rf != nil {
+		s.rf.Close()
+	}
 	s.acc.Close(ctx)
-
-	close(s.doneChan)
+	if s.doneChan != nil {
+		close(s.doneChan)
+	}
 	if err := s.streamGroup.Wait(); err != nil {
 		// Note: error in close is normal; we expect to be terminated with context canceled.
 		log.Errorf(ctx, "partition stream %d terminated with error %v", s.streamID, err)
 	}
-	s.sp.Finish()
+	if s.sp != nil {
+		s.sp.Finish()
+	}
 }
 
 func (s *eventStream) onValue(ctx context.Context, value *kvpb.RangeFeedValue) {
@@ -482,6 +498,39 @@ func (s *eventStream) streamLoop(ctx context.Context, frontier *span.Frontier) e
 			}
 		}
 	}
+}
+
+func (s *eventStream) validateProducerJobAndSpec(ctx context.Context) (roachpb.TenantID, error) {
+	producerJobID := jobspb.JobID(s.streamID)
+	job, err := s.execCfg.JobRegistry.LoadJob(ctx, producerJobID)
+	if err != nil {
+		return roachpb.TenantID{}, err
+	}
+	payload := job.Payload()
+	sp, ok := payload.GetDetails().(*jobspb.Payload_StreamReplication)
+	if !ok {
+		return roachpb.TenantID{}, notAReplicationJobError(producerJobID)
+	}
+	if sp.StreamReplication == nil {
+		return roachpb.TenantID{}, errors.AssertionFailedf("unexpected nil StreamReplication in producer job %d payload", producerJobID)
+	}
+	if job.Status() != jobs.StatusRunning {
+		return roachpb.TenantID{}, jobIsNotRunningError(producerJobID, job.Status(), "stream events")
+	}
+
+	// Validate that the requested spans are a subset of the
+	// source tenant's keyspace.
+	sourceTenantID := sp.StreamReplication.TenantID
+	sourceTenantSpans := keys.MakeTenantSpan(sourceTenantID)
+	for _, sp := range s.spec.Spans {
+		if !sourceTenantSpans.Contains(sp) {
+			err := pgerror.Newf(pgcode.InvalidParameterValue, "requested span %s is not contained within the keyspace of source tenant %d",
+				sp,
+				sourceTenantID)
+			return roachpb.TenantID{}, err
+		}
+	}
+	return sourceTenantID, nil
 }
 
 const defaultBatchSize = 1 << 20

--- a/pkg/ccl/streamingccl/streamproducer/stream_lifetime.go
+++ b/pkg/ccl/streamingccl/streamproducer/stream_lifetime.go
@@ -26,6 +26,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/builtins"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -34,6 +36,20 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 )
+
+// notAReplicationJobError returns an error that is returned anytime
+// the user passes a job ID not related to a replication stream job.
+func notAReplicationJobError(id jobspb.JobID) error {
+	return pgerror.Newf(pgcode.InvalidParameterValue, "job %d is not a replication stream job", id)
+}
+
+// jobIsNotRunningError returns an error that is returned by
+// operations that require a running producer side job.
+func jobIsNotRunningError(id jobspb.JobID, status jobs.Status, op string) error {
+	return pgerror.Newf(pgcode.InvalidParameterValue, "replication job %d must be running (is %s) to %s",
+		id, status, op,
+	)
+}
 
 // startReplicationProducerJob initializes a replication stream producer job on
 // the source cluster that:
@@ -117,6 +133,9 @@ func updateReplicationStreamProgress(
 		if err != nil {
 			return status, err
 		}
+		if _, ok := j.Details().(jobspb.StreamReplicationDetails); !ok {
+			return status, notAReplicationJobError(jobspb.JobID(streamID))
+		}
 		if err := j.WithTxn(txn).Update(ctx, func(
 			txn isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater,
 		) error {
@@ -135,6 +154,7 @@ func updateReplicationStreamProgress(
 				return err
 			}
 			status.ProtectedTimestamp = &ptsRecord.Timestamp
+
 			if status.StreamStatus != streampb.StreamReplicationStatus_STREAM_ACTIVE {
 				return nil
 			}
@@ -222,17 +242,18 @@ func getReplicationStreamSpec(
 	ctx context.Context, evalCtx *eval.Context, txn isql.Txn, streamID streampb.StreamID,
 ) (*streampb.ReplicationStreamSpec, error) {
 	jobExecCtx := evalCtx.JobExecContext.(sql.JobExecContext)
+	jobID := jobspb.JobID(streamID)
 	// Returns error if the replication stream is not active
-	j, err := jobExecCtx.ExecCfg().JobRegistry.LoadJobWithTxn(ctx, jobspb.JobID(streamID), txn)
+	j, err := jobExecCtx.ExecCfg().JobRegistry.LoadJobWithTxn(ctx, jobID, txn)
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not load job for replication stream %d", streamID)
 	}
-	if j.Status() != jobs.StatusRunning {
-		return nil, errors.Errorf("replication stream %d is not running", streamID)
-	}
 	details, ok := j.Details().(jobspb.StreamReplicationDetails)
 	if !ok {
-		return nil, errors.Errorf("job with id %d is not a replication stream job", streamID)
+		return nil, notAReplicationJobError(jobspb.JobID(streamID))
+	}
+	if j.Status() != jobs.StatusRunning {
+		return nil, jobIsNotRunningError(jobID, j.Status(), "create stream spec")
 	}
 	return buildReplicationStreamSpec(ctx, evalCtx, details.TenantID, false, details.Spans)
 
@@ -300,6 +321,9 @@ func completeReplicationStream(
 	j, err := registry.LoadJobWithTxn(ctx, jobspb.JobID(streamID), txn)
 	if err != nil {
 		return err
+	}
+	if _, ok := j.Details().(jobspb.StreamReplicationDetails); !ok {
+		return notAReplicationJobError(jobspb.JobID(streamID))
 	}
 	return j.WithTxn(txn).Update(ctx, func(
 		txn isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater,


### PR DESCRIPTION
Previously, stream_partition assumed that the given partition spec was valid. Now, we check that both the related streamID is in a running state and that the requested spans are contained inside the source tenants key span.

Additionally, this fixes a few cases were we would previously allow the user to pass a job ID related to a different job type, resulting in crashes in some cases.

I've expanded the test coverage related to non-running job states. The tests live in the client package which is a little odd.

Epic: CRDB-26968

Release note: None