### PR TITLE
workflows: stale.yml: update action version

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -27,6 +27,7 @@ jobs:
         stale-pr-label: 'no-pr-activity'
         close-issue-label: 'X-stale'
         close-pr-label: 'X-stale'
+        close-issue-reason: 'not_planned'
         # Disable this for PR's, by setting a very high bar
         days-before-pr-stale: 99999
         days-before-issue-stale: 540


### PR DESCRIPTION
The stale bot closes issues as "completed" instead of "not planned".
More recent versions have added a configuration setting for this, and
it defaults to "not planned". This commit updates the action to the
latest version.

Epic: none
Release note: None
