### PR TITLE
ui: fix generated `DROP INDEX` statement on table details page

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/helperComponents.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/helperComponents.tsx
@@ -186,7 +186,9 @@ export const ActionCell = ({
   const query = indexStat.indexRecommendations.map(recommendation => {
     switch (recommendation.type) {
       case "DROP_UNUSED":
-        return `DROP INDEX ${QuoteIdentifier(tableName)}@${QuoteIdentifier(
+        // Here, `tableName` is a fully qualified name whose identifiers have already been quoted.
+        // See the QuoteIdentifier unit tests for more details.
+        return `DROP INDEX ${tableName}@${QuoteIdentifier(
           indexStat.indexName,
         )};`;
     }


### PR DESCRIPTION
This commit does two things:
1. Fixes the generated `DROP INDEX` statement by considering already quoted fully-qualified names.

2. Adds unit tests for the `QuoteIdentifier` utility to clarify its intended usage and limitations.

Epic: none
Release note (bug fix): Fixed a UI issue where the DROP_UNUSED index recommendations produced by the
table details page produced an invalid `DROP INDEX` statement.