### PR TITLE
roachtest: wait for 3x replication in load-split test

### DIFF
--- a/pkg/cmd/roachtest/tests/split.go
+++ b/pkg/cmd/roachtest/tests/split.go
@@ -461,6 +461,9 @@ func runLoadSplits(ctx context.Context, t test.Test, c cluster.Cluster, params s
 		// range unless split by load.
 		setRangeMaxBytes(params.maxSize)
 
+		require.NoError(t,
+			WaitForReplication(ctx, t, db, 3 /* repicationFactor */, exactlyReplicationFactor))
+
 		// Init the split workload.
 		if err := params.load.init(ctx, t, c); err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
Previously, the `splits/load/*` tests did not wait for up-replication before beginning the workload. This was problematic, as up-replication caused additional data movement, in conjunction with monitored splits.

Wait for full replication before beginning the workload.

Informs: #110312
Release note: None