### PR TITLE
streamingccl: remove special case in heartbeat code

### DIFF
--- a/pkg/ccl/streamingccl/replicationtestutils/testutils.go
+++ b/pkg/ccl/streamingccl/replicationtestutils/testutils.go
@@ -533,7 +533,7 @@ func GetStreamJobIds(
 		destTenantName).Scan(&tenantInfoBytes)
 	require.NoError(t, protoutil.Unmarshal(tenantInfoBytes, &tenantInfo))
 
-	stats := replicationutils.TestingGetStreamIngestionStatsNoHeartbeatFromReplicationJob(t, ctx, sqlRunner, int(tenantInfo.TenantReplicationJobID))
+	stats := replicationutils.TestingGetStreamIngestionStatsFromReplicationJob(t, ctx, sqlRunner, int(tenantInfo.TenantReplicationJobID))
 	return int(stats.IngestionDetails.StreamID), int(tenantInfo.TenantReplicationJobID)
 }
 

--- a/pkg/ccl/streamingccl/replicationutils/BUILD.bazel
+++ b/pkg/ccl/streamingccl/replicationutils/BUILD.bazel
@@ -6,7 +6,6 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/ccl/streamingccl/replicationutils",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/ccl/streamingccl/streamclient",
         "//pkg/jobs",
         "//pkg/jobs/jobspb",
         "//pkg/kv/kvpb",

--- a/pkg/ccl/streamingccl/replicationutils/utils.go
+++ b/pkg/ccl/streamingccl/replicationutils/utils.go
@@ -14,7 +14,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/cockroachdb/cockroach/pkg/ccl/streamingccl/streamclient"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
@@ -133,7 +132,7 @@ func ScanSST(
 	return nil
 }
 
-func GetStreamIngestionStatsNoHeartbeat(
+func GetStreamIngestionStats(
 	ctx context.Context,
 	streamIngestionDetails jobspb.StreamIngestionDetails,
 	jobProgress jobspb.Progress,
@@ -267,47 +266,6 @@ func fingerprintClustersByTable(
 	}
 	return fingerprintutils.CompareMultipleDatabaseFingerprints(srcFingerprints,
 		dstFingerprints)
-}
-
-func GetStreamIngestionStats(
-	ctx context.Context,
-	streamIngestionDetails jobspb.StreamIngestionDetails,
-	jobProgress jobspb.Progress,
-) (*streampb.StreamIngestionStats, error) {
-	stats, err := GetStreamIngestionStatsNoHeartbeat(ctx, streamIngestionDetails, jobProgress)
-	if err != nil {
-		return nil, err
-	}
-	// No need to pass a db into this call because the StreamAddresses do not have
-	// an external connection url scheme.
-	client, err := streamclient.GetFirstActiveClient(ctx, stats.IngestionProgress.StreamAddresses, nil)
-	if err != nil {
-		return nil, err
-	}
-	streamStatus, err := client.Heartbeat(ctx, streampb.StreamID(stats.IngestionDetails.StreamID), hlc.MaxTimestamp)
-	if err != nil {
-		stats.ProducerError = err.Error()
-	} else {
-		stats.ProducerStatus = &streamStatus
-	}
-	return stats, client.Close(ctx)
-}
-
-func TestingGetStreamIngestionStatsNoHeartbeatFromReplicationJob(
-	t *testing.T, ctx context.Context, sqlRunner *sqlutils.SQLRunner, ingestionJobID int,
-) *streampb.StreamIngestionStats {
-	var payloadBytes []byte
-	var progressBytes []byte
-	var payload jobspb.Payload
-	var progress jobspb.Progress
-	stmt := fmt.Sprintf(`SELECT payload, progress FROM (%s)`, jobutils.InternalSystemJobsBaseQuery)
-	sqlRunner.QueryRow(t, stmt, ingestionJobID).Scan(&payloadBytes, &progressBytes)
-	require.NoError(t, protoutil.Unmarshal(payloadBytes, &payload))
-	require.NoError(t, protoutil.Unmarshal(progressBytes, &progress))
-	details := payload.GetStreamIngestion()
-	stats, err := GetStreamIngestionStatsNoHeartbeat(ctx, *details, progress)
-	require.NoError(t, err)
-	return stats
 }
 
 func TestingGetStreamIngestionStatsFromReplicationJob(

--- a/pkg/ccl/streamingccl/streamingest/BUILD.bazel
+++ b/pkg/ccl/streamingccl/streamingest/BUILD.bazel
@@ -126,6 +126,7 @@ go_test(
         "//pkg/kv/kvpb",
         "//pkg/kv/kvserver",
         "//pkg/kv/kvserver/protectedts",
+        "//pkg/kv/kvserver/protectedts/ptpb",
         "//pkg/repstream/streampb",
         "//pkg/roachpb",
         "//pkg/security/securityassets",

--- a/pkg/ccl/streamingccl/streamingest/alter_replication_job.go
+++ b/pkg/ccl/streamingccl/streamingest/alter_replication_job.go
@@ -248,7 +248,7 @@ func alterTenantJobCutover(
 	// that embeds a priviledge check which is already completed.
 	//
 	// Check that the timestamp is above our retained timestamp.
-	stats, err := replicationutils.GetStreamIngestionStatsNoHeartbeat(ctx, details, progress)
+	stats, err := replicationutils.GetStreamIngestionStats(ctx, details, progress)
 	if err != nil {
 		return hlc.Timestamp{}, err
 	}

--- a/pkg/ccl/streamingccl/streamingest/stream_ingest_manager.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingest_manager.go
@@ -139,7 +139,7 @@ func getReplicationStatsAndStatus(
 		return nil, jobspb.ReplicationError.String(), err
 	}
 
-	stats, err := replicationutils.GetStreamIngestionStatsNoHeartbeat(ctx, details, job.Progress())
+	stats, err := replicationutils.GetStreamIngestionStats(ctx, details, job.Progress())
 	if err != nil {
 		return nil, jobspb.ReplicationError.String(), err
 	}

--- a/pkg/ccl/streamingccl/streamproducer/replication_stream_test.go
+++ b/pkg/ccl/streamingccl/streamproducer/replication_stream_test.go
@@ -232,10 +232,6 @@ func testStreamReplicationStatus(
 		expectedStreamStatus.ProtectedTimestamp = &updatedFrontier
 	}
 	checkStreamStatus(t, updatedFrontier, expectedStreamStatus)
-	// Send a query.
-	// The expected protected timestamp is still 'updatedFrontier' as the protected
-	// timestamp doesn't get updated when this is a query.
-	checkStreamStatus(t, hlc.MaxTimestamp, expectedStreamStatus)
 }
 
 func TestReplicationStreamInitialization(t *testing.T) {

--- a/pkg/repstream/streampb/stream.proto
+++ b/pkg/repstream/streampb/stream.proto
@@ -159,11 +159,8 @@ message StreamReplicationStatus {
 }
 
 message StreamIngestionStats {
-  // The status of current stream producer job.
-  StreamReplicationStatus producer_status = 1;
-
-  // The error when trying to reach the current stream producer job.
-  string producer_error = 2;
+  reserved 1;
+  reserved 2;
 
   // Stream ingestion details.
   cockroach.sql.jobs.jobspb.StreamIngestionDetails ingestion_details = 3;


### PR DESCRIPTION
Previously, you could poll the produce side job status via the builtin used for heartbeating by sending a frontier of MaxTimestamp.

Since the addition of SHOW TENANT WITH REPLICATION STATS no non-test facing code actually used this feature.

It was confusing to always have to call the "NoHeartbeat" version of a function. Further, the special case in the heartbeat code was something that required special care when modifying the function.

Here, we remove this unused feature.

Old versions may still use this feature via now-retired builtins, so we return an error if we see an attempt to heartbeat with a frontier of MaxTimestamp.

Epic: CRDB-26968

Release note: none