### PR TITLE
roachtest: add support for collecting Go coverage

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -683,6 +683,9 @@ type clusterImpl struct {
 
 	// clusterSettings are additional cluster settings set on cluster startup.
 	clusterSettings map[string]string
+	// goCoverDir is the directory for Go coverage data (if coverage is enabled).
+	// BAZEL_COVER_DIR will be set to this value when starting a node.
+	goCoverDir string
 
 	os   string     // OS of the cluster
 	arch vm.CPUArch // CPU architecture of the cluster
@@ -1975,6 +1978,10 @@ func (c *clusterImpl) StartE(
 		// This makes all roachtest use the new SHOW RANGES behavior,
 		// regardless of cluster settings.
 		settings.Env = append(settings.Env, "COCKROACH_FORCE_DEPRECATED_SHOW_RANGE_BEHAVIOR=false")
+	}
+
+	if c.goCoverDir != "" {
+		settings.Env = append(settings.Env, fmt.Sprintf("BAZEL_COVER_DIR=%s", c.goCoverDir))
 	}
 
 	clusterSettingsOpts := []install.ClusterSettingOption{

--- a/pkg/cmd/roachtest/cluster_test.go
+++ b/pkg/cmd/roachtest/cluster_test.go
@@ -122,6 +122,11 @@ func (t testWrapper) PerfArtifactsDir() string {
 	return ""
 }
 
+// GoCoverArtifactsDir is part of the test.Test interface.
+func (t testWrapper) GoCoverArtifactsDir() string {
+	return ""
+}
+
 // logger is part of the testI interface.
 func (t testWrapper) L() *logger.Logger {
 	return t.l

--- a/pkg/cmd/roachtest/run.go
+++ b/pkg/cmd/roachtest/run.go
@@ -58,6 +58,7 @@ var (
 	debugAlways            bool
 	runSkipped             bool
 	skipInit               bool
+	goCoverEnabled         bool
 	clusterID              string
 	count                  int
 	versionsBinaryOverride map[string]string
@@ -119,6 +120,8 @@ func addRunBenchCommonFlags(cmd *cobra.Command) {
 		&runSkipped, "run-skipped", runSkipped, "run skipped tests")
 	cmd.Flags().BoolVar(
 		&skipInit, "skip-init", false, "skip initialization step (imports, table creation, etc.) for tests that support it, useful when re-using clusters with --wipe=false")
+	cmd.Flags().BoolVar(
+		&goCoverEnabled, "go-cover", false, "enable collection of go coverage profiles (requires instrumented cockroach binary)")
 	cmd.Flags().IntVarP(
 		&parallelism, "parallelism", "p", 10, "number of tests to run in parallel")
 	cmd.Flags().StringVar(
@@ -274,6 +277,7 @@ func runTests(register func(registry.Registry), args []string, benchOnly bool) e
 		testOpts{
 			versionsBinaryOverride: versionsBinaryOverride,
 			skipInit:               skipInit,
+			goCoverEnabled:         goCoverEnabled,
 		},
 		lopt, nil /* clusterAllocator */)
 

--- a/pkg/cmd/roachtest/test/test_interface.go
+++ b/pkg/cmd/roachtest/test/test_interface.go
@@ -50,11 +50,20 @@ type Test interface {
 	Fatal(args ...interface{})
 	Fatalf(format string, args ...interface{})
 	Failed() bool
+
 	ArtifactsDir() string
+
 	// PerfArtifactsDir is the directory on cluster nodes in which perf artifacts
 	// reside. Upon success this directory is copied into test's ArtifactsDir from
 	// each node in the cluster.
 	PerfArtifactsDir() string
+
+	// GoCoverArtifactsDir is the directory on cluster nodes in which coverage
+	// profiles are dumped (or "" if go coverage is not enabled). At the end of
+	// this test, this directory is copied into the test's ArtifactsDir from each
+	// node in the cluster.
+	GoCoverArtifactsDir() string
+
 	L() *logger.Logger
 	Progress(float64)
 	Status(args ...interface{})

--- a/pkg/cmd/roachtest/test_impl.go
+++ b/pkg/cmd/roachtest/test_impl.go
@@ -29,9 +29,14 @@ import (
 )
 
 // perfArtifactsDir is the directory on cluster nodes in which perf artifacts
-// reside. Upon success this directory is copied into test artifactsDir from
+// reside. Upon success this directory is copied into the test's ArtifactsDir() from
 // each node in the cluster.
 const perfArtifactsDir = "perf"
+
+// goCoverArtifactsDir the directory on cluster nodes in which go coverage
+// profiles are dumped. At the end of a test this directory is copied into the
+// test's ArtifactsDir() from each node in the cluster.
+const goCoverArtifactsDir = "gocover"
 
 type testStatus struct {
 	msg      string
@@ -111,6 +116,9 @@ type testImpl struct {
 	// Version strings look like "20.1.4".
 	versionsBinaryOverride map[string]string
 	skipInit               bool
+	// If true, go coverage is enabled and the BAZEL_COVER_DIR env var will be set
+	// when starting nodes.
+	goCoverEnabled bool
 }
 
 func newFailure(squashedErr error, errs []error) failure {
@@ -432,6 +440,13 @@ func (t *testImpl) ArtifactsDir() string {
 
 func (t *testImpl) PerfArtifactsDir() string {
 	return perfArtifactsDir
+}
+
+func (t *testImpl) GoCoverArtifactsDir() string {
+	if t.goCoverEnabled {
+		return goCoverArtifactsDir
+	}
+	return ""
 }
 
 // IsBuildVersion returns true if the build version is greater than or equal to

--- a/pkg/roachprod/install/scripts/start.sh
+++ b/pkg/roachprod/install/scripts/start.sh
@@ -45,6 +45,10 @@ if [[ -n "${LOCAL}" || "${1-}" == "run" ]]; then
   fi
   # NB: ENV_VARS is never empty.
   export "${ENV_VARS[@]}"
+  # If we are collecting code coverage, make sure the directory exists.
+  if [ -n "${BAZEL_COVER_DIR:-}" ]; then
+    mkdir -p "${BAZEL_COVER_DIR}"
+  fi
   CODE=0
   "${BINARY}" "${ARGS[@]}" >> "${LOG_DIR}/cockroach.stdout.log" 2>> "${LOG_DIR}/cockroach.stderr.log" || CODE="$?"
   if [[ -z "${LOCAL}" || "${CODE}" -ne 0 ]]; then

--- a/pkg/roachprod/install/testdata/start/start.txt
+++ b/pkg/roachprod/install/testdata/start/start.txt
@@ -49,6 +49,10 @@ if [[ -n "${LOCAL}" || "${1-}" == "run" ]]; then
   fi
   # NB: ENV_VARS is never empty.
   export "${ENV_VARS[@]}"
+  # If we are collecting code coverage, make sure the directory exists.
+  if [ -n "${BAZEL_COVER_DIR:-}" ]; then
+    mkdir -p "${BAZEL_COVER_DIR}"
+  fi
   CODE=0
   "${BINARY}" "${ARGS[@]}" >> "${LOG_DIR}/cockroach.stdout.log" 2>> "${LOG_DIR}/cockroach.stderr.log" || CODE="$?"
   if [[ -z "${LOCAL}" || "${CODE}" -ne 0 ]]; then


### PR DESCRIPTION
PR #110280 added instrumentation to the cockroach binary. When built in this mode, cockroach dumps coverage counters to the directory specified in `BAZEL_COVER_DIR` env var. Note that this is similar to Go's recent support for binary instrumentation
(https://go.dev/testing/coverage/); we will eventually switch to using that when Bazel supports building in that mode.

This commit adds a `--go-cover` flag to `roachtest`. When this flag is set, the `BAZEL_COVER_DIR` env var is set and after the test completes we copy the contents to the artifacts (similar to the `perf` artifacts).

Epic: none
Release note: None