### PR TITLE
streamingccl: enable mux rangefeeds

### DIFF
--- a/pkg/ccl/streamingccl/streamproducer/event_stream.go
+++ b/pkg/ccl/streamingccl/streamproducer/event_stream.go
@@ -108,7 +108,7 @@ func (s *eventStream) Start(ctx context.Context, txn *kv.Txn) error {
 		rangefeed.WithMemoryMonitor(s.mon),
 
 		rangefeed.WithOnSSTable(s.onSSTable),
-
+		rangefeed.WithMuxRangefeed(true),
 		rangefeed.WithOnDeleteRange(s.onDeleteRange),
 	}
 


### PR DESCRIPTION
The MuxRangefeeds work offers substantial performance improvements over standard rangefeeds.  We want them.

Epic: none

Release note: None