### PR TITLE
roachprod-microbench: change sheet order

### DIFF
--- a/pkg/cmd/roachprod-microbench/google/service.go
+++ b/pkg/cmd/roachprod-microbench/google/service.go
@@ -84,12 +84,13 @@ func (srv *Service) CreateSheet(
 	var s sheets.Spreadsheet
 	s.Properties = &sheets.SpreadsheetProperties{Title: name}
 
-	// Sort sheets by name.
+	// Sort sheets by name in reverse order. This ensures `sec/op` is the first
+	// sheet and metric in the summary.
 	sheetNames := make([]string, 0, len(metricMap))
 	for sheetName := range metricMap {
 		sheetNames = append(sheetNames, sheetName)
 	}
-	sort.Strings(sheetNames)
+	sort.Sort(sort.Reverse(sort.StringSlice(sheetNames)))
 
 	// Raw data sheets.
 	sheetInfos := make([]rawSheetInfo, len(metricMap))


### PR DESCRIPTION
Previously metric units in the summary sheet, and on sheet tabs, were sorted alphabetically. Since `sec/op` is the most important metric it should be first. This change reverses the order to ensure it is.

Epic: None
Release note: None