### PR TITLE
acceptance: skip flakey test

### DIFF
--- a/pkg/cmd/roachtest/tests/acceptance.go
+++ b/pkg/cmd/roachtest/tests/acceptance.go
@@ -67,6 +67,7 @@ func registerAcceptance(r registry.Registry) {
 				fn:            runVersionUpgrade,
 				timeout:       30 * time.Minute,
 				defaultLeases: true,
+				skip:          "https://github.com/cockroachdb/cockroach/issues/110455",
 			},
 		},
 		registry.OwnerDisasterRecovery: {


### PR DESCRIPTION
This patch skips the acceptance/version-upgrade test, which has been flaking often for the past week.

Informs #110455

Release note: None