### PR TITLE
tenantcostclient: skip TestEstimateQueryRUConsumption

### DIFF
--- a/pkg/ccl/multitenantccl/tenantcostclient/query_ru_estimate_test.go
+++ b/pkg/ccl/multitenantccl/tenantcostclient/query_ru_estimate_test.go
@@ -49,6 +49,7 @@ func TestEstimateQueryRUConsumption(t *testing.T) {
 	// background load, so we disable running it under stress and/or race.
 	skip.UnderStress(t)
 	skip.UnderRace(t)
+	skip.WithIssue(t, 109179, "this test is flaky due to background activity when run during CI")
 
 	ctx := context.Background()
 


### PR DESCRIPTION
TestEstimateQueryRUConsumption was written to validate that the RU consumption estimate provided by EXPLAIN ANALYZE is reasonable. The estimate is vulnerable to large errors when there is significant background activity, so it can flake under CI builds even during non-stress + non-race runs. We have increased the allowed margin for error, but this only decreases the likelihood of flakes since the maximum error is unbounded.

Using the grunning library for the RU estimate will likely solve this for good, but this patch skips the test in the meantime to prevent further flakes.

Informs #109179

Release note: None