### PR TITLE
storage: release replicated locks during intent resolution

### DIFF
--- a/pkg/storage/mvcc_history_test.go
+++ b/pkg/storage/mvcc_history_test.go
@@ -379,6 +379,10 @@ func TestMVCCHistories(t *testing.T) {
 				if err != nil {
 					return errors.Wrapf(err, "decoding LockTable key: %v", eKey)
 				}
+				if ltKey.Strength == lock.Intent {
+					// Ignore intents, which are reported by reportDataEntries.
+					continue
+				}
 				// Unmarshal.
 				v, err := iter.UnsafeValue()
 				if err != nil {
@@ -601,11 +605,11 @@ func TestMVCCHistories(t *testing.T) {
 					}
 
 					cmd := e.getCmd()
-					txnChange = txnChange || cmd.typ == typTxnUpdate
-					dataChange = dataChange || cmd.typ == typDataUpdate
-					locksChange = locksChange || cmd.typ == typLocksUpdate
+					txnChange = txnChange || cmd.typ&typTxnUpdate != 0
+					dataChange = dataChange || cmd.typ&typDataUpdate != 0
+					locksChange = locksChange || cmd.typ&typLocksUpdate != 0
 
-					if trace || (stats && cmd.typ == typDataUpdate) {
+					if trace || (stats && cmd.typ&typDataUpdate != 0) {
 						// If tracing is also requested by the datadriven input,
 						// we'll trace the statement in the actual results too.
 						buf.Printf(">> %s", d.Cmd)
@@ -638,10 +642,10 @@ func TestMVCCHistories(t *testing.T) {
 						// If tracing is enabled, we report the intermediate results
 						// after each individual step in the script.
 						// This may modify foundErr too.
-						reportResults(cmd.typ == typTxnUpdate, cmd.typ == typDataUpdate, cmd.typ == typLocksUpdate)
+						reportResults(cmd.typ&typTxnUpdate != 0, cmd.typ&typDataUpdate != 0, cmd.typ&typLocksUpdate != 0)
 					}
 
-					if stats && cmd.typ == typDataUpdate {
+					if stats && cmd.typ&typDataUpdate != 0 {
 						// If stats are enabled, emit evaluated stats returned by the
 						// command, and compare them with the real computed stats diff.
 						var msEngineDiff enginepb.MVCCStats
@@ -753,7 +757,7 @@ type cmd struct {
 type cmdType int
 
 const (
-	typReadOnly cmdType = iota
+	typReadOnly cmdType = 1 << iota
 	typTxnUpdate
 	typDataUpdate
 	typLocksUpdate
@@ -770,8 +774,8 @@ var commands = map[string]cmd{
 	"txn_step":        {typTxnUpdate, cmdTxnStep},
 	"txn_update":      {typTxnUpdate, cmdTxnUpdate},
 
-	"resolve_intent":         {typDataUpdate, cmdResolveIntent},
-	"resolve_intent_range":   {typDataUpdate, cmdResolveIntentRange},
+	"resolve_intent":         {typDataUpdate | typLocksUpdate, cmdResolveIntent},
+	"resolve_intent_range":   {typDataUpdate | typLocksUpdate, cmdResolveIntentRange},
 	"check_intent":           {typReadOnly, cmdCheckIntent},
 	"add_unreplicated_lock":  {typLocksUpdate, cmdAddUnreplicatedLock},
 	"check_for_acquire_lock": {typReadOnly, cmdCheckForAcquireLock},

--- a/pkg/storage/testdata/mvcc_histories/ambiguous_writes
+++ b/pkg/storage/testdata/mvcc_histories/ambiguous_writes
@@ -42,6 +42,7 @@ with t=A k=a
   resolve_intent
   txn_remove
 ----
+resolve_intent: "a" -> resolved key = true
 >> at end:
 data: "a"/12.000000000,0 -> {localTs=11.000000000,0}/BYTES/first
 
@@ -66,6 +67,7 @@ with t=B k=k
   resolve_intent
   txn_remove
 ----
+resolve_intent: "k" -> resolved key = true
 >> at end:
 data: "a"/12.000000000,0 -> {localTs=11.000000000,0}/BYTES/first
 data: "k"/0,1 -> /BYTES/k1
@@ -105,6 +107,7 @@ with t=C k=k
   resolve_intent
   txn_remove
 ----
+resolve_intent: "k" -> resolved key = true
 >> at end:
 data: "a"/12.000000000,0 -> {localTs=11.000000000,0}/BYTES/first
 data: "k"/0,2 -> /BYTES/k2
@@ -152,6 +155,7 @@ with t=D k=k
   resolve_intent
   txn_remove
 ----
+resolve_intent: "k" -> resolved key = true
 >> at end:
 data: "a"/12.000000000,0 -> {localTs=11.000000000,0}/BYTES/first
 data: "k"/3.000000000,0 -> /BYTES/k3
@@ -167,6 +171,7 @@ with t=E k=k
 ----
 >> del resolve t=E k=k
 del: "k": found key true
+resolve_intent: "k" -> resolved key = true
 stats: key_bytes=+12 val_count=+1 live_count=-1 live_bytes=-21 gc_bytes_age=+3168
 >> at end:
 txn: "E" meta={id=00000005 key="k" iso=Serializable pri=0.00000000 epo=0 ts=4.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=4.000000000,0 wto=false gul=0,0
@@ -283,6 +288,7 @@ with t=F k=k
   resolve_intent status=ABORTED
   txn_remove
 ----
+resolve_intent: "k" -> resolved key = true
 >> at end:
 data: "a"/12.000000000,0 -> {localTs=11.000000000,0}/BYTES/first
 data: "k"/4.000000000,0 -> /<empty>
@@ -383,6 +389,8 @@ with t=G
   resolve_intent k=k
   txn_remove
 ----
+resolve_intent: "a" -> resolved key = true
+resolve_intent: "k" -> resolved key = true
 >> at end:
 data: "a"/12.000000000,2 -> {localTs=12.000000000,1}/<empty>
 data: "a"/12.000000000,0 -> {localTs=11.000000000,0}/BYTES/first

--- a/pkg/storage/testdata/mvcc_histories/clear_range
+++ b/pkg/storage/testdata/mvcc_histories/clear_range
@@ -9,6 +9,11 @@ with t=A v=abc resolve
   put  k=c
 put k=i v=inline
 ----
+resolve_intent: "a" -> resolved key = true
+resolve_intent: "a/123" -> resolved key = true
+resolve_intent: "b" -> resolved key = true
+resolve_intent: "b/123" -> resolved key = true
+resolve_intent: "c" -> resolved key = true
 >> at end:
 txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=44.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=44.000000000,0 wto=false gul=0,0
 data: "a"/44.000000000,0 -> /BYTES/abc

--- a/pkg/storage/testdata/mvcc_histories/conditional_put_with_txn_enable_separated
+++ b/pkg/storage/testdata/mvcc_histories/conditional_put_with_txn_enable_separated
@@ -60,6 +60,7 @@ with t=A
   txn_remove
 ----
 >> resolve_intent k=k t=A
+resolve_intent: "k" -> resolved key = true
 stats: val_bytes=-38 live_bytes=-38 intent_count=-1 intent_bytes=-19 lock_count=-1 lock_age=+23
 >> at end:
 data: "k"/124.000000000,0 -> {localTs=123.000000000,0}/BYTES/v3

--- a/pkg/storage/testdata/mvcc_histories/deletes
+++ b/pkg/storage/testdata/mvcc_histories/deletes
@@ -9,6 +9,7 @@ with t=A
 ----
 >> del k=a resolve t=A
 del: "a": found key false
+resolve_intent: "a" -> resolved key = true
 stats: key_count=+1 key_bytes=+14 val_count=+1 gc_bytes_age=+784
 >> at end:
 data: "a"/44.000000000,0 -> /<empty>
@@ -110,6 +111,7 @@ with t=A
   resolve_intent k=a status=ABORTED
   txn_remove
 ----
+resolve_intent: "a" -> resolved key = false
 >> at end:
 data: "a"/48.000000000,0 -> /<empty>
 data: "a"/47.000000000,0 -> /<empty>
@@ -138,6 +140,7 @@ with t=A
   resolve_intent k=a status=ABORTED
   txn_remove
 ----
+resolve_intent: "a" -> resolved key = false
 >> at end:
 data: "a"/48.000000000,0 -> /<empty>
 data: "a"/47.000000000,0 -> /<empty>
@@ -166,6 +169,7 @@ with t=A
   resolve_intent k=a status=ABORTED
   txn_remove
 ----
+resolve_intent: "a" -> resolved key = false
 >> at end:
 data: "a"/48.000000000,0 -> /<empty>
 data: "a"/47.000000000,0 -> /<empty>
@@ -194,6 +198,7 @@ with t=A
   resolve_intent k=a status=ABORTED
   txn_remove
 ----
+resolve_intent: "a" -> resolved key = false
 >> at end:
 data: "a"/48.000000000,0 -> /<empty>
 data: "a"/47.000000000,0 -> /<empty>

--- a/pkg/storage/testdata/mvcc_histories/ignored_seq_nums
+++ b/pkg/storage/testdata/mvcc_histories/ignored_seq_nums
@@ -161,6 +161,7 @@ with t=A
 meta: "k" -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=30} ts=11.000000000,0 del=false klen=12 vlen=6 ih={{10 /BYTES/a}{20 /BYTES/b}} mergeTs=<nil> txnDidNotUpdateMeta=false
 get: "k" -> /BYTES/b @11.000000000,0
 get: "k" -> /BYTES/b @11.000000000,0
+resolve_intent: "k" -> resolved key = true
 meta: "k" -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=20} ts=14.000000000,0 del=false klen=12 vlen=19 ih={{10 /BYTES/a}} mergeTs=<nil> txnDidNotUpdateMeta=false
 get: "k" -> /BYTES/b @14.000000000,0
 >> at end:
@@ -226,6 +227,7 @@ with t=B
   get        k=k
 ----
 meta: "k" -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=20} ts=14.000000000,0 del=false klen=12 vlen=19 ih={{10 /BYTES/a}} mergeTs=<nil> txnDidNotUpdateMeta=false
+resolve_intent: "k" -> resolved key = true
 get: "k" -> /BYTES/b @14.000000000,0
 >> at end:
 txn: "B" meta={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=20.000000000,0 wto=false gul=0,0
@@ -280,6 +282,7 @@ with t=B
 ----
 meta: "l" -> txn={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=30} ts=20.000000000,0 del=false klen=12 vlen=6 ih={{10 /BYTES/a}{20 /BYTES/b}} mergeTs=<nil> txnDidNotUpdateMeta=false
 get: "l" -> <no data>
+resolve_intent: "l" -> resolved key = true
 >> at end:
 txn: "B" meta={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=35} lock=true stat=PENDING rts=20.000000000,0 wto=false gul=0,0 isn=1
 data: "k"/14.000000000,0 -> {localTs=11.000000000,0}/BYTES/b
@@ -340,6 +343,7 @@ with t=C
 ----
 meta: "m" -> txn={id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=30.000000000,0 min=0,0 seq=30} ts=30.000000000,0 del=false klen=12 vlen=6 ih={{10 /BYTES/a}{20 /BYTES/b}} mergeTs=<nil> txnDidNotUpdateMeta=false
 get: "m" -> /BYTES/a @30.000000000,0
+resolve_intent: "m" -> resolved key = true
 >> at end:
 txn: "C" meta={id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=30.000000000,0 min=0,0 seq=30} lock=true stat=PENDING rts=30.000000000,0 wto=false gul=0,0 isn=1
 data: "k"/14.000000000,0 -> {localTs=11.000000000,0}/BYTES/b
@@ -394,6 +398,7 @@ with t=D
 ----
 meta: "n" -> txn={id=00000004 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=40.000000000,0 min=0,0 seq=30} ts=40.000000000,0 del=false klen=12 vlen=6 ih={{10 /BYTES/a}{20 /BYTES/b}} mergeTs=<nil> txnDidNotUpdateMeta=false
 get: "n" -> /BYTES/c @40.000000000,0
+resolve_intent: "n" -> resolved key = true
 meta: "n" -> txn={id=00000004 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=45.000000000,0 min=0,0 seq=30} ts=45.000000000,0 del=false klen=12 vlen=20 ih={{10 /BYTES/a}{20 /BYTES/b}} mergeTs=<nil> txnDidNotUpdateMeta=false
 get: "n" -> /BYTES/c @45.000000000,0
 >> at end:
@@ -423,6 +428,7 @@ with t=E
 ----
 meta: "n" -> txn={id=00000004 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=45.000000000,0 min=0,0 seq=30} ts=45.000000000,0 del=false klen=12 vlen=20 ih={{10 /BYTES/a}{20 /BYTES/b}} mergeTs=<nil> txnDidNotUpdateMeta=false
 get: "n" -> /BYTES/c @45.000000000,0
+resolve_intent: "n" -> resolved key = true
 get: "n" -> /BYTES/c @45.000000000,0
 >> at end:
 txn: "E" meta={id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=50.000000000,0 wto=false gul=0,0
@@ -483,6 +489,8 @@ with t=E
 ----
 get: "n" -> /BYTES/c @45.000000000,0
 get: "o" -> <no data>
+resolve_intent: "n" -> resolved key = true
+resolve_intent: "o" -> resolved key = true
 >> at end:
 txn: "E" meta={id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=30} lock=true stat=PENDING rts=50.000000000,0 wto=false gul=0,0 isn=1
 data: "k"/14.000000000,0 -> {localTs=11.000000000,0}/BYTES/b
@@ -553,6 +561,7 @@ with t=E
   resolve_intent  k=o status=PENDING
   get             k=o
 ----
+resolve_intent: "o" -> resolved key = true
 get: "o" -> <no data>
 >> at end:
 txn: "E" meta={id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=55.000000000,0 min=0,0 seq=30} lock=true stat=PENDING rts=50.000000000,0 wto=false gul=0,0 isn=1
@@ -614,6 +623,7 @@ with t=F k=o
   check_intent
   get
 ----
+resolve_intent: "o" -> resolved key = true
 meta: "o" -> txn={id=00000006 key="o" iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=10} ts=50.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=false
 get: "o" -> /BYTES/a @50.000000000,0
 >> at end:

--- a/pkg/storage/testdata/mvcc_histories/ignored_seq_nums_commit
+++ b/pkg/storage/testdata/mvcc_histories/ignored_seq_nums_commit
@@ -35,12 +35,16 @@ stats: val_bytes=+12 live_bytes=+12
 >> put k=k/30 v=30 t=A
 stats: key_count=+1 key_bytes=+17 val_count=+1 val_bytes=+57 live_count=+1 live_bytes=+74 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+89
 >> resolve_intent k=k t=A
+resolve_intent: "k" -> resolved key = true
 stats: val_bytes=-72 live_bytes=-72 intent_count=-1 intent_bytes=-18 lock_count=-1 lock_age=-89
 >> resolve_intent k=k/10 t=A
+resolve_intent: "k/10" -> resolved key = true
 stats: val_bytes=-50 live_bytes=-50 intent_count=-1 intent_bytes=-19 lock_count=-1 lock_age=-89
 >> resolve_intent k=k/20 t=A
+resolve_intent: "k/20" -> resolved key = true
 stats: val_bytes=-50 live_bytes=-50 intent_count=-1 intent_bytes=-19 lock_count=-1 lock_age=-89
 >> resolve_intent k=k/30 t=A
+resolve_intent: "k/30" -> resolved key = true
 stats: key_count=-1 key_bytes=-17 val_count=-1 val_bytes=-57 live_count=-1 live_bytes=-74 intent_count=-1 intent_bytes=-19 lock_count=-1 lock_age=-89
 >> at end:
 txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=40} lock=true stat=PENDING rts=11.000000000,0 wto=false gul=0,0 isn=1
@@ -97,12 +101,16 @@ stats: val_bytes=+12 live_bytes=+12
 >> put k=k/30 v=30 t=A
 stats: key_count=+1 key_bytes=+17 val_count=+1 val_bytes=+57 live_count=+1 live_bytes=+74 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+89
 >> resolve_intent k=k t=A
+resolve_intent: "k" -> resolved key = true
 stats: val_bytes=-72 live_bytes=-72 intent_count=-1 intent_bytes=-18 lock_count=-1 lock_age=-89
 >> resolve_intent k=k/10 t=A
+resolve_intent: "k/10" -> resolved key = true
 stats: val_bytes=-50 live_bytes=-50 intent_count=-1 intent_bytes=-19 lock_count=-1 lock_age=-89
 >> resolve_intent k=k/20 t=A
+resolve_intent: "k/20" -> resolved key = true
 stats: key_count=-1 key_bytes=-17 val_count=-1 val_bytes=-57 live_count=-1 live_bytes=-74 intent_count=-1 intent_bytes=-19 lock_count=-1 lock_age=-89
 >> resolve_intent k=k/30 t=A
+resolve_intent: "k/30" -> resolved key = true
 stats: val_bytes=-50 live_bytes=-50 intent_count=-1 intent_bytes=-19 lock_count=-1 lock_age=-89
 >> at end:
 txn: "A" meta={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=40} lock=true stat=PENDING rts=11.000000000,0 wto=false gul=0,0 isn=1

--- a/pkg/storage/testdata/mvcc_histories/ignored_seq_nums_with_local_timestamps
+++ b/pkg/storage/testdata/mvcc_histories/ignored_seq_nums_with_local_timestamps
@@ -26,6 +26,7 @@ with t=A
   get             k=k
 ----
 get: "k" -> /BYTES/b @50.000000000,0
+resolve_intent: "k" -> resolved key = true
 get: "k" -> /BYTES/b @50.000000000,0
 >> at end:
 txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=25} lock=true stat=PENDING rts=50.000000000,0 wto=false gul=0,0 isn=1
@@ -41,6 +42,7 @@ with t=A
   txn_ignore_seqs seqs=(20-20)
   resolve_intent k=k status=COMMITTED
 ----
+resolve_intent: "k" -> resolved key = true
 >> at end:
 txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=25} lock=true stat=PENDING rts=50.000000000,0 wto=false gul=0,0 isn=1
 data: "k"/50.000000000,0 -> {localTs=15.000000000,0}/BYTES/a

--- a/pkg/storage/testdata/mvcc_histories/intent_history_enable_separated
+++ b/pkg/storage/testdata/mvcc_histories/intent_history_enable_separated
@@ -7,6 +7,7 @@ with t=A
   txn_remove
 ----
 >> put k=a v=default resolve t=A
+resolve_intent: "a" -> resolved key = true
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+12 live_count=+1 live_bytes=+26
 >> at end:
 data: "a"/1.000000000,0 -> /BYTES/default
@@ -58,6 +59,7 @@ data: "a"/1.000000000,0 -> /BYTES/default
 stats: val_bytes=+16 live_count=+1 live_bytes=+111 gc_bytes_age=-9310 intent_bytes=+10
 >> resolve_intent k=a t=A
 called ClearEngineKey(/Local/Lock/Intent"a"/0300000002000000000000000000000000)
+resolve_intent: "a" -> resolved key = true
 data: "a"/2.000000000,0 -> /BYTES/first
 data: "a"/1.000000000,0 -> /BYTES/default
 stats: val_bytes=-87 live_bytes=-87 intent_count=-1 intent_bytes=-22 lock_count=-1 lock_age=-98

--- a/pkg/storage/testdata/mvcc_histories/intent_with_write_tracing_enable_separated
+++ b/pkg/storage/testdata/mvcc_histories/intent_with_write_tracing_enable_separated
@@ -73,6 +73,7 @@ with t=A
 ----
 >> resolve_intent k=k1 t=A
 called ClearEngineKey(/Local/Lock/Intent"k1"/0300000001000000000000000000000000)
+resolve_intent: "k1" -> resolved key = true
 data: "k1"/3.000000000,0 -> /BYTES/v1
 meta: "k2"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=1} ts=3.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k2"/3.000000000,0 -> /BYTES/v2
@@ -82,6 +83,7 @@ data: "k3"/1.000000000,0 -> /BYTES/v3
 stats: val_bytes=-61 live_bytes=-61 intent_count=-1 intent_bytes=-19 lock_count=-1 lock_age=-97
 >> resolve_intent k=k2 status=ABORTED t=A
 called ClearEngineKey(/Local/Lock/Intent"k2"/0300000001000000000000000000000000)
+resolve_intent: "k2" -> resolved key = true
 data: "k1"/3.000000000,0 -> /BYTES/v1
 meta: "k3"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=1} ts=3.000000000,0 del=false klen=12 vlen=8 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k3"/3.000000000,0 -> /BYTES/v33
@@ -89,6 +91,7 @@ data: "k3"/1.000000000,0 -> /BYTES/v3
 stats: key_count=-1 key_bytes=-15 val_count=-1 val_bytes=-57 live_count=-1 live_bytes=-72 intent_count=-1 intent_bytes=-19 lock_count=-1 lock_age=-97
 >> resolve_intent k=k3 status=ABORTED t=A
 called ClearEngineKey(/Local/Lock/Intent"k3"/0300000001000000000000000000000000)
+resolve_intent: "k3" -> resolved key = true
 data: "k1"/3.000000000,0 -> /BYTES/v1
 data: "k3"/1.000000000,0 -> /BYTES/v3
 stats: key_bytes=-12 val_count=-1 val_bytes=-58 live_bytes=-51 gc_bytes_age=-1843 intent_count=-1 intent_bytes=-20 lock_count=-1 lock_age=-97

--- a/pkg/storage/testdata/mvcc_histories/local_timestamp
+++ b/pkg/storage/testdata/mvcc_histories/local_timestamp
@@ -397,28 +397,40 @@ with t=A
   resolve_intent k=k12 status=COMMITTED clockWhilePending=40
 ----
 >> resolve_intent k=k1 status=ABORTED t=A
+resolve_intent: "k1" -> resolved key = true
 stats: key_count=-1 key_bytes=-15 val_count=-1 val_bytes=-93 live_count=-1 live_bytes=-108 intent_count=-1 intent_bytes=-32 lock_count=-1 lock_age=-70
 >> resolve_intent k=k2 status=ABORTED clockWhilePending=20 t=A
+resolve_intent: "k2" -> resolved key = true
 stats: key_count=-1 key_bytes=-15 val_count=-1 val_bytes=-93 live_count=-1 live_bytes=-108 intent_count=-1 intent_bytes=-32 lock_count=-1 lock_age=-70
 >> resolve_intent k=k3 status=ABORTED clockWhilePending=30 t=A
+resolve_intent: "k3" -> resolved key = true
 stats: key_count=-1 key_bytes=-15 val_count=-1 val_bytes=-93 live_count=-1 live_bytes=-108 intent_count=-1 intent_bytes=-32 lock_count=-1 lock_age=-70
 >> resolve_intent k=k4 status=ABORTED clockWhilePending=40 t=A
+resolve_intent: "k4" -> resolved key = true
 stats: key_count=-1 key_bytes=-15 val_count=-1 val_bytes=-93 live_count=-1 live_bytes=-108 intent_count=-1 intent_bytes=-32 lock_count=-1 lock_age=-70
 >> resolve_intent k=k5 status=PENDING t=A
+resolve_intent: "k5" -> resolved key = true
 stats: val_bytes=+2 live_bytes=+2 lock_age=-10
 >> resolve_intent k=k6 status=PENDING clockWhilePending=20 t=A
+resolve_intent: "k6" -> resolved key = true
 stats: val_bytes=+2 live_bytes=+2 lock_age=-10
 >> resolve_intent k=k7 status=PENDING clockWhilePending=30 t=A
+resolve_intent: "k7" -> resolved key = true
 stats: val_bytes=+2 live_bytes=+2 lock_age=-10
 >> resolve_intent k=k8 status=PENDING clockWhilePending=40 t=A
+resolve_intent: "k8" -> resolved key = true
 stats: val_bytes=-11 live_bytes=-11 intent_bytes=-13 lock_age=-10
 >> resolve_intent k=k9 status=COMMITTED t=A
+resolve_intent: "k9" -> resolved key = true
 stats: val_bytes=-73 live_bytes=-73 intent_count=-1 intent_bytes=-32 lock_count=-1 lock_age=-70
 >> resolve_intent k=k10 status=COMMITTED clockWhilePending=20 t=A
+resolve_intent: "k10" -> resolved key = true
 stats: val_bytes=-73 live_bytes=-73 intent_count=-1 intent_bytes=-32 lock_count=-1 lock_age=-70
 >> resolve_intent k=k11 status=COMMITTED clockWhilePending=30 t=A
+resolve_intent: "k11" -> resolved key = true
 stats: val_bytes=-73 live_bytes=-73 intent_count=-1 intent_bytes=-32 lock_count=-1 lock_age=-70
 >> resolve_intent k=k12 status=COMMITTED clockWhilePending=40 t=A
+resolve_intent: "k12" -> resolved key = true
 stats: val_bytes=-86 live_bytes=-86 intent_count=-1 intent_bytes=-32 lock_count=-1 lock_age=-70
 >> at end:
 txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=40.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=20.000000000,0 wto=false gul=0,0

--- a/pkg/storage/testdata/mvcc_histories/max_keys
+++ b/pkg/storage/testdata/mvcc_histories/max_keys
@@ -163,6 +163,10 @@ with t=A ts=11,0 max=3
   resolve_intent k=m status=COMMITTED
   resolve_intent k=n status=COMMITTED
 ----
+resolve_intent: "k" -> resolved key = true
+resolve_intent: "l" -> resolved key = true
+resolve_intent: "m" -> resolved key = true
+resolve_intent: "n" -> resolved key = true
 >> at end:
 txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=30} lock=true stat=PENDING rts=11.000000000,0 wto=false gul=0,0
 data: "a"/1.000000000,0 -> /BYTES/val-a

--- a/pkg/storage/testdata/mvcc_histories/merges
+++ b/pkg/storage/testdata/mvcc_histories/merges
@@ -11,6 +11,7 @@ with t=A
   put        k=a v=abc resolve
   txn_remove
 ----
+resolve_intent: "a" -> resolved key = true
 >> at end:
 data: "a"/11.000000000,0 -> /BYTES/abc
 

--- a/pkg/storage/testdata/mvcc_histories/no_read_after_abort_enable_separated
+++ b/pkg/storage/testdata/mvcc_histories/no_read_after_abort_enable_separated
@@ -14,6 +14,7 @@ meta: "a"/0,0 -> txn={id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 
 data: "a"/22.000000000,0 -> /BYTES/cde
 >> resolve_intent status=ABORTED t=A k=a
 called ClearEngineKey(/Local/Lock/Intent"a"/0300000001000000000000000000000000)
+resolve_intent: "a" -> resolved key = true
 <no data>
 >> txn_remove t=A k=a
 

--- a/pkg/storage/testdata/mvcc_histories/put_after_rollback
+++ b/pkg/storage/testdata/mvcc_histories/put_after_rollback
@@ -100,6 +100,7 @@ meta: "k5" -> txn={id=00000002 key="k5" iso=Serializable pri=0.00000000 epo=0 ts
 stats: no change
 meta: "k5" -> txn={id=00000002 key="k5" iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=40} ts=5.000000000,0 del=false klen=12 vlen=6 ih={{10 /BYTES/a}} mergeTs=<nil> txnDidNotUpdateMeta=false
 >> resolve_intent status=COMMITTED t=B k=k5
+resolve_intent: "k5" -> resolved key = true
 stats: val_bytes=-64 live_bytes=-64 intent_count=-1 intent_bytes=-18 lock_count=-1 lock_age=-95
 >> at end:
 txn: "B" meta={id=00000002 key="k5" iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=40} lock=true stat=PENDING rts=5.000000000,0 wto=false gul=0,0 isn=1

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_stats_intent_resolve_abort
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_stats_intent_resolve_abort
@@ -236,40 +236,58 @@ with t=A status=ABORTED
   resolve_intent k=r
 ----
 >> resolve_intent k=a t=A status=ABORTED
+resolve_intent: "a" -> resolved key = true
 stats: key_count=-1 key_bytes=-14 val_count=-1 val_bytes=-55 live_count=-1 live_bytes=-69 intent_count=-1 intent_bytes=-19 lock_count=-1 lock_age=-93
 >> resolve_intent k=b t=A status=ABORTED
+resolve_intent: "b" -> resolved key = true
 stats: key_bytes=-12 val_count=-1 val_bytes=-55 live_bytes=-48 gc_bytes_age=-1767 intent_count=-1 intent_bytes=-19 lock_count=-1 lock_age=-93
 >> resolve_intent k=c t=A status=ABORTED
+resolve_intent: "c" -> resolved key = true
 stats: key_bytes=-12 val_count=-1 val_bytes=-55 live_count=-1 live_bytes=-69 gc_bytes_age=+198 intent_count=-1 intent_bytes=-19 lock_count=-1 lock_age=-93
 >> resolve_intent k=d t=A status=ABORTED
+resolve_intent: "d" -> resolved key = true
 stats: key_count=-1 key_bytes=-14 val_count=-1 val_bytes=-48 gc_bytes_age=-5766 intent_count=-1 intent_bytes=-12 lock_count=-1 lock_age=-93
 >> resolve_intent k=e t=A status=ABORTED
+resolve_intent: "e" -> resolved key = true
 stats: key_bytes=-12 val_count=-1 val_bytes=-48 live_count=+1 live_bytes=+21 gc_bytes_age=-7533 intent_count=-1 intent_bytes=-12 lock_count=-1 lock_age=-93
 >> resolve_intent k=f t=A status=ABORTED
+resolve_intent: "f" -> resolved key = true
 stats: key_bytes=-12 val_count=-1 val_bytes=-61 gc_bytes_age=-6777 intent_count=-1 intent_bytes=-25 lock_count=-1 lock_age=-93
 >> resolve_intent k=g t=A status=ABORTED
+resolve_intent: "g" -> resolved key = true
 stats: key_count=-1 key_bytes=-14 val_count=-1 val_bytes=-55 live_count=-1 live_bytes=-69 intent_count=-1 intent_bytes=-19 lock_count=-1 lock_age=-93
 >> resolve_intent k=h t=A status=ABORTED
+resolve_intent: "h" -> resolved key = true
 stats: key_bytes=-12 val_count=-1 val_bytes=-55 live_count=-1 live_bytes=-69 gc_bytes_age=+194 intent_count=-1 intent_bytes=-19 lock_count=-1 lock_age=-93
 >> resolve_intent k=i t=A status=ABORTED
+resolve_intent: "i" -> resolved key = true
 stats: key_bytes=-12 val_count=-1 val_bytes=-55 live_count=-1 live_bytes=-69 gc_bytes_age=+198 intent_count=-1 intent_bytes=-19 lock_count=-1 lock_age=-93
 >> resolve_intent k=j t=A status=ABORTED
+resolve_intent: "j" -> resolved key = true
 stats: key_count=-1 key_bytes=-14 val_count=-1 val_bytes=-48 gc_bytes_age=-5766 intent_count=-1 intent_bytes=-12 lock_count=-1 lock_age=-93
 >> resolve_intent k=k t=A status=ABORTED
+resolve_intent: "k" -> resolved key = true
 stats: key_bytes=-12 val_count=-1 val_bytes=-48 gc_bytes_age=-5572 intent_count=-1 intent_bytes=-12 lock_count=-1 lock_age=-93
 >> resolve_intent k=l t=A status=ABORTED
+resolve_intent: "l" -> resolved key = true
 stats: key_bytes=-12 val_count=-1 val_bytes=-61 gc_bytes_age=-6777 intent_count=-1 intent_bytes=-25 lock_count=-1 lock_age=-93
 >> resolve_intent k=m t=A status=ABORTED
+resolve_intent: "m" -> resolved key = true
 stats: key_count=-1 key_bytes=-14 val_count=-1 val_bytes=-55 live_count=-1 live_bytes=-69 intent_count=-1 intent_bytes=-19 lock_count=-1 lock_age=-93
 >> resolve_intent k=n t=A status=ABORTED
+resolve_intent: "n" -> resolved key = true
 stats: key_bytes=-12 val_count=-1 val_bytes=-55 live_bytes=-48 gc_bytes_age=-1767 intent_count=-1 intent_bytes=-19 lock_count=-1 lock_age=-93
 >> resolve_intent k=o t=A status=ABORTED
+resolve_intent: "o" -> resolved key = true
 stats: key_bytes=-12 val_count=-1 val_bytes=-55 live_count=-1 live_bytes=-69 gc_bytes_age=+188 intent_count=-1 intent_bytes=-19 lock_count=-1 lock_age=-93
 >> resolve_intent k=p t=A status=ABORTED
+resolve_intent: "p" -> resolved key = true
 stats: key_count=-1 key_bytes=-14 val_count=-1 val_bytes=-48 gc_bytes_age=-5766 intent_count=-1 intent_bytes=-12 lock_count=-1 lock_age=-93
 >> resolve_intent k=q t=A status=ABORTED
+resolve_intent: "q" -> resolved key = true
 stats: key_bytes=-12 val_count=-1 val_bytes=-48 live_count=+1 live_bytes=+21 gc_bytes_age=-7533 intent_count=-1 intent_bytes=-12 lock_count=-1 lock_age=-93
 >> resolve_intent k=r t=A status=ABORTED
+resolve_intent: "r" -> resolved key = true
 stats: key_bytes=-12 val_count=-1 val_bytes=-61 gc_bytes_age=-6787 intent_count=-1 intent_bytes=-25 lock_count=-1 lock_age=-93
 >> at end:
 rangekey: g{-gg}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
@@ -307,16 +325,22 @@ with t=A status=ABORTED
   resolve_intent k=j
 ----
 >> resolve_intent k=aaa t=A status=ABORTED
+resolve_intent: "aaa" -> resolved key = false
 stats: no change
 >> resolve_intent k=a t=A status=ABORTED
+resolve_intent: "a" -> resolved key = false
 stats: no change
 >> resolve_intent k=d t=A status=ABORTED
+resolve_intent: "d" -> resolved key = false
 stats: no change
 >> resolve_intent k=ggg t=A status=ABORTED
+resolve_intent: "ggg" -> resolved key = false
 stats: no change
 >> resolve_intent k=g t=A status=ABORTED
+resolve_intent: "g" -> resolved key = false
 stats: no change
 >> resolve_intent k=j t=A status=ABORTED
+resolve_intent: "j" -> resolved key = false
 stats: no change
 >> at end:
 rangekey: g{-gg}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_stats_intent_resolve_commit
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_stats_intent_resolve_commit
@@ -236,40 +236,58 @@ with t=A status=COMMITTED
   resolve_intent k=r
 ----
 >> resolve_intent k=a t=A status=COMMITTED
+resolve_intent: "a" -> resolved key = true
 stats: val_bytes=-48 live_bytes=-48 intent_count=-1 intent_bytes=-19 lock_count=-1 lock_age=-93
 >> resolve_intent k=b t=A status=COMMITTED
+resolve_intent: "b" -> resolved key = true
 stats: val_bytes=-48 live_bytes=-48 intent_count=-1 intent_bytes=-19 lock_count=-1 lock_age=-93
 >> resolve_intent k=c t=A status=COMMITTED
+resolve_intent: "c" -> resolved key = true
 stats: val_bytes=-48 live_bytes=-48 intent_count=-1 intent_bytes=-19 lock_count=-1 lock_age=-93
 >> resolve_intent k=d t=A status=COMMITTED
+resolve_intent: "d" -> resolved key = true
 stats: val_bytes=-48 gc_bytes_age=-4464 intent_count=-1 intent_bytes=-12 lock_count=-1 lock_age=-93
 >> resolve_intent k=e t=A status=COMMITTED
+resolve_intent: "e" -> resolved key = true
 stats: val_bytes=-48 gc_bytes_age=-4464 intent_count=-1 intent_bytes=-12 lock_count=-1 lock_age=-93
 >> resolve_intent k=f t=A status=COMMITTED
+resolve_intent: "f" -> resolved key = true
 stats: val_bytes=-48 gc_bytes_age=-4464 intent_count=-1 intent_bytes=-25 lock_count=-1 lock_age=-93
 >> resolve_intent k=g t=A status=COMMITTED
+resolve_intent: "g" -> resolved key = true
 stats: val_bytes=-48 live_bytes=-48 intent_count=-1 intent_bytes=-19 lock_count=-1 lock_age=-93
 >> resolve_intent k=h t=A status=COMMITTED
+resolve_intent: "h" -> resolved key = true
 stats: val_bytes=-48 live_bytes=-48 intent_count=-1 intent_bytes=-19 lock_count=-1 lock_age=-93
 >> resolve_intent k=i t=A status=COMMITTED
+resolve_intent: "i" -> resolved key = true
 stats: val_bytes=-48 live_bytes=-48 intent_count=-1 intent_bytes=-19 lock_count=-1 lock_age=-93
 >> resolve_intent k=j t=A status=COMMITTED
+resolve_intent: "j" -> resolved key = true
 stats: val_bytes=-48 gc_bytes_age=-4464 intent_count=-1 intent_bytes=-12 lock_count=-1 lock_age=-93
 >> resolve_intent k=k t=A status=COMMITTED
+resolve_intent: "k" -> resolved key = true
 stats: val_bytes=-48 gc_bytes_age=-4464 intent_count=-1 intent_bytes=-12 lock_count=-1 lock_age=-93
 >> resolve_intent k=l t=A status=COMMITTED
+resolve_intent: "l" -> resolved key = true
 stats: val_bytes=-48 gc_bytes_age=-4464 intent_count=-1 intent_bytes=-25 lock_count=-1 lock_age=-93
 >> resolve_intent k=m t=A status=COMMITTED
+resolve_intent: "m" -> resolved key = true
 stats: val_bytes=-48 live_bytes=-48 intent_count=-1 intent_bytes=-19 lock_count=-1 lock_age=-93
 >> resolve_intent k=n t=A status=COMMITTED
+resolve_intent: "n" -> resolved key = true
 stats: val_bytes=-48 live_bytes=-48 intent_count=-1 intent_bytes=-19 lock_count=-1 lock_age=-93
 >> resolve_intent k=o t=A status=COMMITTED
+resolve_intent: "o" -> resolved key = true
 stats: val_bytes=-48 live_bytes=-48 intent_count=-1 intent_bytes=-19 lock_count=-1 lock_age=-93
 >> resolve_intent k=p t=A status=COMMITTED
+resolve_intent: "p" -> resolved key = true
 stats: val_bytes=-48 gc_bytes_age=-4464 intent_count=-1 intent_bytes=-12 lock_count=-1 lock_age=-93
 >> resolve_intent k=q t=A status=COMMITTED
+resolve_intent: "q" -> resolved key = true
 stats: val_bytes=-48 gc_bytes_age=-4464 intent_count=-1 intent_bytes=-12 lock_count=-1 lock_age=-93
 >> resolve_intent k=r t=A status=COMMITTED
+resolve_intent: "r" -> resolved key = true
 stats: val_bytes=-48 gc_bytes_age=-4464 intent_count=-1 intent_bytes=-25 lock_count=-1 lock_age=-93
 >> at end:
 rangekey: g{-gg}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
@@ -325,16 +343,22 @@ with t=A status=COMMITTED
   resolve_intent k=j
 ----
 >> resolve_intent k=aaa t=A status=COMMITTED
+resolve_intent: "aaa" -> resolved key = false
 stats: no change
 >> resolve_intent k=a t=A status=COMMITTED
+resolve_intent: "a" -> resolved key = false
 stats: no change
 >> resolve_intent k=d t=A status=COMMITTED
+resolve_intent: "d" -> resolved key = false
 stats: no change
 >> resolve_intent k=ggg t=A status=COMMITTED
+resolve_intent: "ggg" -> resolved key = false
 stats: no change
 >> resolve_intent k=g t=A status=COMMITTED
+resolve_intent: "g" -> resolved key = false
 stats: no change
 >> resolve_intent k=j t=A status=COMMITTED
+resolve_intent: "j" -> resolved key = false
 stats: no change
 >> at end:
 rangekey: g{-gg}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_stats_intent_resolve_pushed
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_stats_intent_resolve_pushed
@@ -237,40 +237,58 @@ with t=A status=COMMITTED
   resolve_intent k=r
 ----
 >> resolve_intent k=a t=A status=COMMITTED
+resolve_intent: "a" -> resolved key = true
 stats: val_bytes=-35 live_bytes=-35 intent_count=-1 intent_bytes=-19 lock_count=-1 lock_age=-93
 >> resolve_intent k=b t=A status=COMMITTED
+resolve_intent: "b" -> resolved key = true
 stats: val_bytes=-35 live_bytes=-35 gc_bytes_age=-19 intent_count=-1 intent_bytes=-19 lock_count=-1 lock_age=-93
 >> resolve_intent k=c t=A status=COMMITTED
+resolve_intent: "c" -> resolved key = true
 stats: val_bytes=-35 live_bytes=-35 intent_count=-1 intent_bytes=-19 lock_count=-1 lock_age=-93
 >> resolve_intent k=d t=A status=COMMITTED
+resolve_intent: "d" -> resolved key = true
 stats: val_bytes=-35 gc_bytes_age=-3282 intent_count=-1 intent_bytes=-12 lock_count=-1 lock_age=-93
 >> resolve_intent k=e t=A status=COMMITTED
+resolve_intent: "e" -> resolved key = true
 stats: val_bytes=-35 gc_bytes_age=-3301 intent_count=-1 intent_bytes=-12 lock_count=-1 lock_age=-93
 >> resolve_intent k=f t=A status=COMMITTED
+resolve_intent: "f" -> resolved key = true
 stats: val_bytes=-48 gc_bytes_age=-4491 intent_count=-1 intent_bytes=-25 lock_count=-1 lock_age=-93
 >> resolve_intent k=g t=A status=COMMITTED
+resolve_intent: "g" -> resolved key = true
 stats: val_bytes=-35 live_bytes=-35 intent_count=-1 intent_bytes=-19 lock_count=-1 lock_age=-93
 >> resolve_intent k=h t=A status=COMMITTED
+resolve_intent: "h" -> resolved key = true
 stats: val_bytes=-35 live_bytes=-35 intent_count=-1 intent_bytes=-19 lock_count=-1 lock_age=-93
 >> resolve_intent k=i t=A status=COMMITTED
+resolve_intent: "i" -> resolved key = true
 stats: val_bytes=-35 live_bytes=-35 intent_count=-1 intent_bytes=-19 lock_count=-1 lock_age=-93
 >> resolve_intent k=j t=A status=COMMITTED
+resolve_intent: "j" -> resolved key = true
 stats: val_bytes=-35 gc_bytes_age=-3282 intent_count=-1 intent_bytes=-12 lock_count=-1 lock_age=-93
 >> resolve_intent k=k t=A status=COMMITTED
+resolve_intent: "k" -> resolved key = true
 stats: val_bytes=-35 gc_bytes_age=-3282 intent_count=-1 intent_bytes=-12 lock_count=-1 lock_age=-93
 >> resolve_intent k=l t=A status=COMMITTED
+resolve_intent: "l" -> resolved key = true
 stats: val_bytes=-48 gc_bytes_age=-4491 intent_count=-1 intent_bytes=-25 lock_count=-1 lock_age=-93
 >> resolve_intent k=m t=A status=COMMITTED
+resolve_intent: "m" -> resolved key = true
 stats: val_bytes=-35 live_bytes=-35 intent_count=-1 intent_bytes=-19 lock_count=-1 lock_age=-93
 >> resolve_intent k=n t=A status=COMMITTED
+resolve_intent: "n" -> resolved key = true
 stats: val_bytes=-35 live_bytes=-35 gc_bytes_age=-19 intent_count=-1 intent_bytes=-19 lock_count=-1 lock_age=-93
 >> resolve_intent k=o t=A status=COMMITTED
+resolve_intent: "o" -> resolved key = true
 stats: val_bytes=-35 live_bytes=-35 intent_count=-1 intent_bytes=-19 lock_count=-1 lock_age=-93
 >> resolve_intent k=p t=A status=COMMITTED
+resolve_intent: "p" -> resolved key = true
 stats: val_bytes=-35 gc_bytes_age=-3282 intent_count=-1 intent_bytes=-12 lock_count=-1 lock_age=-93
 >> resolve_intent k=q t=A status=COMMITTED
+resolve_intent: "q" -> resolved key = true
 stats: val_bytes=-35 gc_bytes_age=-3301 intent_count=-1 intent_bytes=-12 lock_count=-1 lock_age=-93
 >> resolve_intent k=r t=A status=COMMITTED
+resolve_intent: "r" -> resolved key = true
 stats: val_bytes=-48 gc_bytes_age=-4491 intent_count=-1 intent_bytes=-25 lock_count=-1 lock_age=-93
 >> at end:
 txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=7.000000000,0 wto=false gul=0,0
@@ -328,16 +346,22 @@ with t=A status=COMMITTED
   resolve_intent k=j
 ----
 >> resolve_intent k=aaa t=A status=COMMITTED
+resolve_intent: "aaa" -> resolved key = false
 stats: no change
 >> resolve_intent k=a t=A status=COMMITTED
+resolve_intent: "a" -> resolved key = false
 stats: no change
 >> resolve_intent k=d t=A status=COMMITTED
+resolve_intent: "d" -> resolved key = false
 stats: no change
 >> resolve_intent k=ggg t=A status=COMMITTED
+resolve_intent: "ggg" -> resolved key = false
 stats: no change
 >> resolve_intent k=g t=A status=COMMITTED
+resolve_intent: "g" -> resolved key = false
 stats: no change
 >> resolve_intent k=j t=A status=COMMITTED
+resolve_intent: "j" -> resolved key = false
 stats: no change
 >> at end:
 txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=9.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=7.000000000,0 wto=false gul=0,0

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_stats_intent_resolve_range_abort
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_stats_intent_resolve_range_abort
@@ -218,6 +218,7 @@ run stats ok
 resolve_intent_range t=A k=a end=z status=ABORTED
 ----
 >> resolve_intent_range t=A k=a end=z status=ABORTED
+resolve_intent_range: "a"-"z" -> resolved 18 key(s)
 stats: key_count=-6 key_bytes=-228 val_count=-18 val_bytes=-966 live_count=-5 live_bytes=-537 gc_bytes_age=-61033 intent_count=-18 intent_bytes=-318 lock_count=-18 lock_age=-1674
 >> at end:
 rangekey: g{-gg}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
@@ -248,6 +249,7 @@ run stats ok
 resolve_intent_range t=A k=a end=z status=ABORTED
 ----
 >> resolve_intent_range t=A k=a end=z status=ABORTED
+resolve_intent_range: "a"-"z" -> resolved 0 key(s)
 stats: no change
 >> at end:
 rangekey: g{-gg}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_stats_intent_resolve_range_commit
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_stats_intent_resolve_range_commit
@@ -218,6 +218,7 @@ run stats ok
 resolve_intent_range t=A k=a end=z status=COMMITTED
 ----
 >> resolve_intent_range t=A k=a end=z status=COMMITTED
+resolve_intent_range: "a"-"z" -> resolved 18 key(s)
 stats: val_bytes=-864 live_bytes=-432 gc_bytes_age=-40176 intent_count=-18 intent_bytes=-318 lock_count=-18 lock_age=-1674
 >> at end:
 rangekey: g{-gg}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
@@ -266,6 +267,7 @@ run stats ok
 resolve_intent_range t=A k=a end=z status=COMMITTED
 ----
 >> resolve_intent_range t=A k=a end=z status=COMMITTED
+resolve_intent_range: "a"-"z" -> resolved 0 key(s)
 stats: no change
 >> at end:
 rangekey: g{-gg}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_stats_intent_resolve_range_pushed
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_stats_intent_resolve_range_pushed
@@ -219,6 +219,7 @@ txn_advance t=A ts=8
 resolve_intent_range t=A k=a end=z status=COMMITTED
 ----
 >> resolve_intent_range t=A k=a end=z status=COMMITTED
+resolve_intent_range: "a"-"z" -> resolved 18 key(s)
 stats: val_bytes=-669 live_bytes=-315 gc_bytes_age=-33241 intent_count=-18 intent_bytes=-318 lock_count=-18 lock_age=-1674
 >> at end:
 txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=7.000000000,0 wto=false gul=0,0
@@ -269,6 +270,7 @@ txn_advance t=A ts=9
 resolve_intent_range t=A k=a end=z status=COMMITTED
 ----
 >> resolve_intent_range t=A k=a end=z status=COMMITTED
+resolve_intent_range: "a"-"z" -> resolved 0 key(s)
 stats: no change
 >> at end:
 txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=9.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=7.000000000,0 wto=false gul=0,0

--- a/pkg/storage/testdata/mvcc_histories/read_after_write_enable_separated
+++ b/pkg/storage/testdata/mvcc_histories/read_after_write_enable_separated
@@ -17,6 +17,7 @@ data: "a"/11.000000000,0 -> /BYTES/abc
 get: "a" -> /BYTES/abc @11.000000000,0
 >> resolve_intent k=a t=A
 called SingleClearEngineKey(/Local/Lock/Intent"a"/0300000001000000000000000000000000)
+resolve_intent: "a" -> resolved key = true
 data: "a"/11.000000000,0 -> /BYTES/abc
 
 run ok
@@ -27,6 +28,10 @@ with t=A resolve
   put   k=c   v=hhh
   txn_remove
 ----
+resolve_intent: "a/1" -> resolved key = true
+resolve_intent: "b" -> resolved key = true
+resolve_intent: "b/2" -> resolved key = true
+resolve_intent: "c" -> resolved key = true
 >> at end:
 data: "a"/11.000000000,0 -> /BYTES/abc
 data: "a/1"/11.000000000,0 -> /BYTES/eee

--- a/pkg/storage/testdata/mvcc_histories/replicated_locks
+++ b/pkg/storage/testdata/mvcc_histories/replicated_locks
@@ -241,7 +241,6 @@ lock (Replicated): "k1"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri
 lock (Replicated): "k2"/Exclusive -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
 lock (Replicated): "k2"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
 lock (Replicated): "k3"/Exclusive -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
-lock (Replicated): "k4"/Intent -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=10.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 
 run error
 check_for_acquire_lock t=B k=k4 str=shared
@@ -257,7 +256,6 @@ lock (Replicated): "k1"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri
 lock (Replicated): "k2"/Exclusive -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
 lock (Replicated): "k2"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
 lock (Replicated): "k3"/Exclusive -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
-lock (Replicated): "k4"/Intent -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=10.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 error: (*kvpb.LockConflictError:) conflicting locks on "k4"
 
 # The intent history is considered when determining whether a reacquisition is
@@ -288,7 +286,6 @@ lock (Replicated): "k1"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri
 lock (Replicated): "k2"/Exclusive -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
 lock (Replicated): "k2"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
 lock (Replicated): "k3"/Exclusive -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
-lock (Replicated): "k4"/Intent -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=2} ts=10.000000000,0 del=false klen=12 vlen=13 ih={{1 /BYTES/v4}} mergeTs=<nil> txnDidNotUpdateMeta=false
 
 run
 with t=A
@@ -302,7 +299,6 @@ lock (Replicated): "k1"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri
 lock (Replicated): "k2"/Exclusive -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
 lock (Replicated): "k2"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
 lock (Replicated): "k3"/Exclusive -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
-lock (Replicated): "k4"/Intent -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=2} ts=10.000000000,0 del=false klen=12 vlen=13 ih={{1 /BYTES/v4}} mergeTs=<nil> txnDidNotUpdateMeta=false
 
 run
 with t=A
@@ -316,7 +312,6 @@ lock (Replicated): "k1"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri
 lock (Replicated): "k2"/Exclusive -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
 lock (Replicated): "k2"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
 lock (Replicated): "k3"/Exclusive -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
-lock (Replicated): "k4"/Intent -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=2} ts=10.000000000,0 del=false klen=12 vlen=13 ih={{1 /BYTES/v4}} mergeTs=<nil> txnDidNotUpdateMeta=false
 lock (Replicated): "k4"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=3} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
 
 # Replicated locks are ignored by non-locking scans by any transaction. Note
@@ -512,3 +507,259 @@ data: "k3"/10.000000000,0 -> /<empty>
 data: "k3"/5.000000000,0 -> /BYTES/v3
 meta: "k4"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=2} ts=10.000000000,0 del=false klen=12 vlen=13 ih={{1 /BYTES/v4}} mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "k4"/10.000000000,0 -> /BYTES/v4_prime
+
+# Release locks.
+
+# Reset ignored sequence numbers for now.
+run ok
+txn_ignore_seqs t=A seqs
+----
+>> at end:
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=4} lock=true stat=PENDING rts=10.000000000,0 wto=false gul=0,0
+
+# Pending resolution without epoch bump or savepoint rollback is a no-op.
+run ok
+resolve_intent t=A k=k1 status=PENDING
+----
+resolve_intent: "k1" -> resolved key = false
+>> at end:
+data: "k1"/5.000000000,0 -> /BYTES/v1
+meta: "k2"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=4} ts=10.000000000,0 del=true klen=12 vlen=0 ih={{3 /BYTES/v2}} mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "k2"/10.000000000,0 -> /<empty>
+data: "k2"/5.000000000,0 -> /BYTES/v2
+meta: "k3"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=4} ts=10.000000000,0 del=true klen=12 vlen=0 ih={{3 /BYTES/v3}} mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "k3"/10.000000000,0 -> /<empty>
+data: "k3"/5.000000000,0 -> /BYTES/v3
+meta: "k4"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=2} ts=10.000000000,0 del=false klen=12 vlen=13 ih={{1 /BYTES/v4}} mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "k4"/10.000000000,0 -> /BYTES/v4_prime
+lock (Replicated): "k1"/Shared -> txn={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+lock (Replicated): "k1"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+lock (Replicated): "k2"/Exclusive -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+lock (Replicated): "k2"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+lock (Replicated): "k3"/Exclusive -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+lock (Replicated): "k4"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=3} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+
+# Committed resolution releases the lock.
+run ok
+resolve_intent t=A k=k1 status=COMMITTED
+----
+resolve_intent: "k1" -> resolved key = true
+>> at end:
+data: "k1"/5.000000000,0 -> /BYTES/v1
+meta: "k2"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=4} ts=10.000000000,0 del=true klen=12 vlen=0 ih={{3 /BYTES/v2}} mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "k2"/10.000000000,0 -> /<empty>
+data: "k2"/5.000000000,0 -> /BYTES/v2
+meta: "k3"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=4} ts=10.000000000,0 del=true klen=12 vlen=0 ih={{3 /BYTES/v3}} mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "k3"/10.000000000,0 -> /<empty>
+data: "k3"/5.000000000,0 -> /BYTES/v3
+meta: "k4"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=2} ts=10.000000000,0 del=false klen=12 vlen=13 ih={{1 /BYTES/v4}} mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "k4"/10.000000000,0 -> /BYTES/v4_prime
+lock (Replicated): "k1"/Shared -> txn={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+lock (Replicated): "k2"/Exclusive -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+lock (Replicated): "k2"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+lock (Replicated): "k3"/Exclusive -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+lock (Replicated): "k4"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=3} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+
+# Re-acquire the lock.
+run ok
+acquire_lock t=A k=k1 str=shared
+----
+>> at end:
+lock (Replicated): "k1"/Shared -> txn={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+lock (Replicated): "k1"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=4} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+lock (Replicated): "k2"/Exclusive -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+lock (Replicated): "k2"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+lock (Replicated): "k3"/Exclusive -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+lock (Replicated): "k4"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=3} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+
+# Aborted resolution releases the lock.
+run ok
+resolve_intent t=A k=k1 status=ABORTED
+----
+resolve_intent: "k1" -> resolved key = true
+>> at end:
+data: "k1"/5.000000000,0 -> /BYTES/v1
+meta: "k2"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=4} ts=10.000000000,0 del=true klen=12 vlen=0 ih={{3 /BYTES/v2}} mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "k2"/10.000000000,0 -> /<empty>
+data: "k2"/5.000000000,0 -> /BYTES/v2
+meta: "k3"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=4} ts=10.000000000,0 del=true klen=12 vlen=0 ih={{3 /BYTES/v3}} mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "k3"/10.000000000,0 -> /<empty>
+data: "k3"/5.000000000,0 -> /BYTES/v3
+meta: "k4"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=2} ts=10.000000000,0 del=false klen=12 vlen=13 ih={{1 /BYTES/v4}} mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "k4"/10.000000000,0 -> /BYTES/v4_prime
+lock (Replicated): "k1"/Shared -> txn={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+lock (Replicated): "k2"/Exclusive -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+lock (Replicated): "k2"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+lock (Replicated): "k3"/Exclusive -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+lock (Replicated): "k4"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=3} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+
+# Re-acquire the lock.
+run ok
+acquire_lock t=A k=k1 str=shared
+----
+>> at end:
+lock (Replicated): "k1"/Shared -> txn={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+lock (Replicated): "k1"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=4} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+lock (Replicated): "k2"/Exclusive -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+lock (Replicated): "k2"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+lock (Replicated): "k3"/Exclusive -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+lock (Replicated): "k4"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=3} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+
+# Pending resolution with newer epoch releases the lock.
+run ok
+with t=A
+  txn_restart
+  resolve_intent k=k1 status=PENDING
+----
+resolve_intent: "k1" -> resolved key = true
+>> at end:
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=2 ts=10.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=10.000000000,0 wto=false gul=0,0
+data: "k1"/5.000000000,0 -> /BYTES/v1
+meta: "k2"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=4} ts=10.000000000,0 del=true klen=12 vlen=0 ih={{3 /BYTES/v2}} mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "k2"/10.000000000,0 -> /<empty>
+data: "k2"/5.000000000,0 -> /BYTES/v2
+meta: "k3"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=4} ts=10.000000000,0 del=true klen=12 vlen=0 ih={{3 /BYTES/v3}} mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "k3"/10.000000000,0 -> /<empty>
+data: "k3"/5.000000000,0 -> /BYTES/v3
+meta: "k4"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=2} ts=10.000000000,0 del=false klen=12 vlen=13 ih={{1 /BYTES/v4}} mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "k4"/10.000000000,0 -> /BYTES/v4_prime
+lock (Replicated): "k1"/Shared -> txn={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+lock (Replicated): "k2"/Exclusive -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+lock (Replicated): "k2"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+lock (Replicated): "k3"/Exclusive -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+lock (Replicated): "k4"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=3} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+
+# Re-acquire the lock at the new epoch.
+run ok
+acquire_lock t=A k=k1 str=shared
+----
+>> at end:
+lock (Replicated): "k1"/Shared -> txn={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+lock (Replicated): "k1"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=2 ts=10.000000000,0 min=0,0 seq=0} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+lock (Replicated): "k2"/Exclusive -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+lock (Replicated): "k2"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+lock (Replicated): "k3"/Exclusive -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+lock (Replicated): "k4"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=3} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+
+# Pending resolution with older epoch is a no-op, regardless of savepoint
+# rollback.
+run ok
+with t=A
+  txn_restart epoch=1
+  resolve_intent k=k1 status=PENDING
+----
+resolve_intent: "k1" -> resolved key = false
+>> at end:
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=10.000000000,0 wto=false gul=0,0
+data: "k1"/5.000000000,0 -> /BYTES/v1
+meta: "k2"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=4} ts=10.000000000,0 del=true klen=12 vlen=0 ih={{3 /BYTES/v2}} mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "k2"/10.000000000,0 -> /<empty>
+data: "k2"/5.000000000,0 -> /BYTES/v2
+meta: "k3"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=4} ts=10.000000000,0 del=true klen=12 vlen=0 ih={{3 /BYTES/v3}} mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "k3"/10.000000000,0 -> /<empty>
+data: "k3"/5.000000000,0 -> /BYTES/v3
+meta: "k4"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=2} ts=10.000000000,0 del=false klen=12 vlen=13 ih={{1 /BYTES/v4}} mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "k4"/10.000000000,0 -> /BYTES/v4_prime
+lock (Replicated): "k1"/Shared -> txn={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+lock (Replicated): "k1"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=2 ts=10.000000000,0 min=0,0 seq=0} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+lock (Replicated): "k2"/Exclusive -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+lock (Replicated): "k2"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+lock (Replicated): "k3"/Exclusive -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+lock (Replicated): "k4"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=3} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+
+run ok
+with t=A
+  txn_ignore_seqs seqs=0-0
+  resolve_intent k=k1 status=PENDING
+----
+resolve_intent: "k1" -> resolved key = false
+>> at end:
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=10.000000000,0 wto=false gul=0,0 isn=1
+data: "k1"/5.000000000,0 -> /BYTES/v1
+meta: "k2"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=4} ts=10.000000000,0 del=true klen=12 vlen=0 ih={{3 /BYTES/v2}} mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "k2"/10.000000000,0 -> /<empty>
+data: "k2"/5.000000000,0 -> /BYTES/v2
+meta: "k3"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=4} ts=10.000000000,0 del=true klen=12 vlen=0 ih={{3 /BYTES/v3}} mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "k3"/10.000000000,0 -> /<empty>
+data: "k3"/5.000000000,0 -> /BYTES/v3
+meta: "k4"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=2} ts=10.000000000,0 del=false klen=12 vlen=13 ih={{1 /BYTES/v4}} mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "k4"/10.000000000,0 -> /BYTES/v4_prime
+lock (Replicated): "k1"/Shared -> txn={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+lock (Replicated): "k1"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=2 ts=10.000000000,0 min=0,0 seq=0} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+lock (Replicated): "k2"/Exclusive -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+lock (Replicated): "k2"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+lock (Replicated): "k3"/Exclusive -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+lock (Replicated): "k4"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=3} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+
+# Pending resolution of the lock in the same epoch without a savepoint rollback
+# is a no-op.
+run ok
+with t=A
+  txn_restart epoch=2
+  resolve_intent k=k1 status=PENDING
+----
+resolve_intent: "k1" -> resolved key = false
+>> at end:
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=2 ts=10.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=10.000000000,0 wto=false gul=0,0
+data: "k1"/5.000000000,0 -> /BYTES/v1
+meta: "k2"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=4} ts=10.000000000,0 del=true klen=12 vlen=0 ih={{3 /BYTES/v2}} mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "k2"/10.000000000,0 -> /<empty>
+data: "k2"/5.000000000,0 -> /BYTES/v2
+meta: "k3"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=4} ts=10.000000000,0 del=true klen=12 vlen=0 ih={{3 /BYTES/v3}} mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "k3"/10.000000000,0 -> /<empty>
+data: "k3"/5.000000000,0 -> /BYTES/v3
+meta: "k4"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=2} ts=10.000000000,0 del=false klen=12 vlen=13 ih={{1 /BYTES/v4}} mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "k4"/10.000000000,0 -> /BYTES/v4_prime
+lock (Replicated): "k1"/Shared -> txn={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+lock (Replicated): "k1"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=2 ts=10.000000000,0 min=0,0 seq=0} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+lock (Replicated): "k2"/Exclusive -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+lock (Replicated): "k2"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+lock (Replicated): "k3"/Exclusive -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+lock (Replicated): "k4"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=3} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+
+# Pending resolution of the lock in the same epoch with savepoint rollback
+# releases the lock.
+run ok
+with t=A
+  txn_ignore_seqs seqs=0-0
+  resolve_intent k=k1 status=PENDING
+----
+resolve_intent: "k1" -> resolved key = true
+>> at end:
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=2 ts=10.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=10.000000000,0 wto=false gul=0,0 isn=1
+data: "k1"/5.000000000,0 -> /BYTES/v1
+meta: "k2"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=4} ts=10.000000000,0 del=true klen=12 vlen=0 ih={{3 /BYTES/v2}} mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "k2"/10.000000000,0 -> /<empty>
+data: "k2"/5.000000000,0 -> /BYTES/v2
+meta: "k3"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=4} ts=10.000000000,0 del=true klen=12 vlen=0 ih={{3 /BYTES/v3}} mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "k3"/10.000000000,0 -> /<empty>
+data: "k3"/5.000000000,0 -> /BYTES/v3
+meta: "k4"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=2} ts=10.000000000,0 del=false klen=12 vlen=13 ih={{1 /BYTES/v4}} mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "k4"/10.000000000,0 -> /BYTES/v4_prime
+lock (Replicated): "k1"/Shared -> txn={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+lock (Replicated): "k2"/Exclusive -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+lock (Replicated): "k2"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+lock (Replicated): "k3"/Exclusive -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
+lock (Replicated): "k4"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=3} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+
+# Ranged resolution behaves like single-key resolution.
+# As always, it also resolves intents in the range.
+run ok
+resolve_intent_range t=A k=k2 end=k5 status=COMMITTED
+----
+resolve_intent_range: "k2"-"k5" -> resolved 3 key(s)
+>> at end:
+data: "k1"/5.000000000,0 -> /BYTES/v1
+data: "k2"/5.000000000,0 -> /BYTES/v2
+data: "k3"/5.000000000,0 -> /BYTES/v3
+lock (Replicated): "k1"/Shared -> txn={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+
+# Aborted resolution for other transaction releases the lock.
+run ok
+resolve_intent t=B k=k1 status=ABORTED
+----
+resolve_intent: "k1" -> resolved key = true
+>> at end:
+data: "k1"/5.000000000,0 -> /BYTES/v1
+data: "k2"/5.000000000,0 -> /BYTES/v2
+data: "k3"/5.000000000,0 -> /BYTES/v3

--- a/pkg/storage/testdata/mvcc_histories/resolve_intent_pagination
+++ b/pkg/storage/testdata/mvcc_histories/resolve_intent_pagination
@@ -30,6 +30,8 @@ data: "f"/1.000000000,0 -> /BYTES/f
 run ok
 resolve_intent t=A k=c status=COMMITTED targetBytes=-1 batched
 ----
+resolve_intent: "c" -> resolved key = false, 0 bytes
+resolve_intent: resume span ["c",/Min)
 resolve_intent: batch after write is empty
 >> at end:
 meta: "a"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} ts=1.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
@@ -49,6 +51,7 @@ data: "f"/1.000000000,0 -> /BYTES/f
 run ok
 resolve_intent t=A k=b status=COMMITTED targetBytes=1 batched
 ----
+resolve_intent: "b" -> resolved key = true, 28 bytes
 resolve_intent: batch after write is non-empty
 >> at end:
 meta: "a"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} ts=1.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
@@ -67,6 +70,8 @@ data: "f"/1.000000000,0 -> /BYTES/f
 run ok
 resolve_intent_range t=A k=a end=z status=COMMITTED maxKeys=-1 batched
 ----
+resolve_intent_range: "a"-"z" -> resolved 0 key(s), 0 bytes
+resolve_intent_range: resume span ["a","z") RESUME_KEY_LIMIT
 resolve_intent_range: batch after write is empty
 >> at end:
 meta: "a"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} ts=1.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
@@ -85,6 +90,8 @@ data: "f"/1.000000000,0 -> /BYTES/f
 run ok
 resolve_intent_range t=A k=a end=z status=COMMITTED maxKeys=2 batched
 ----
+resolve_intent_range: "a"-"z" -> resolved 2 key(s), 56 bytes
+resolve_intent_range: resume span ["c\x00","z") RESUME_KEY_LIMIT
 resolve_intent_range: batch after write is non-empty
 >> at end:
 data: "a"/1.000000000,0 -> /BYTES/a
@@ -101,6 +108,8 @@ data: "f"/1.000000000,0 -> /BYTES/f
 run ok
 resolve_intent_range t=A k=a end=z status=COMMITTED targetBytes=-1 batched
 ----
+resolve_intent_range: "a"-"z" -> resolved 0 key(s), 0 bytes
+resolve_intent_range: resume span ["a","z") RESUME_BYTE_LIMIT
 resolve_intent_range: batch after write is empty
 >> at end:
 data: "a"/1.000000000,0 -> /BYTES/a
@@ -116,6 +125,8 @@ data: "f"/1.000000000,0 -> /BYTES/f
 run ok
 resolve_intent_range t=A k=a end=z status=COMMITTED targetBytes=99 batched
 ----
+resolve_intent_range: "a"-"z" -> resolved 2 key(s), 154 bytes
+resolve_intent_range: resume span ["eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee\x00","z") RESUME_BYTE_LIMIT
 resolve_intent_range: batch after write is non-empty
 >> at end:
 data: "a"/1.000000000,0 -> /BYTES/a

--- a/pkg/storage/testdata/mvcc_histories/resolve_intent_pagination
+++ b/pkg/storage/testdata/mvcc_histories/resolve_intent_pagination
@@ -136,3 +136,68 @@ data: "dddddddddddddddddddddddddddddddddddddddddddddddddd"/1.000000000,0 -> /BYT
 data: "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"/1.000000000,0 -> /BYTES/e
 meta: "f"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} ts=1.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "f"/1.000000000,0 -> /BYTES/f
+
+
+# Test MaxKeys and TargetBytes for resolve intent range with replicated locks.
+
+run ok
+clear_range k=a end=z
+----
+>> at end:
+<no data>
+
+# Put some test data with locks.
+run ok
+with t=B
+  txn_begin ts=1
+  acquire_lock k=a str=shared
+  put k=a v=a
+  acquire_lock k=b str=shared
+  acquire_lock k=b str=exclusive
+  put k=b v=b
+  acquire_lock k=c str=shared
+----
+>> at end:
+txn: "B" meta={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=1.000000000,0 wto=false gul=0,0
+meta: "a"/0,0 -> txn={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} ts=1.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "a"/1.000000000,0 -> /BYTES/a
+meta: "b"/0,0 -> txn={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} ts=1.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "b"/1.000000000,0 -> /BYTES/b
+lock (Replicated): "a"/Shared -> txn={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+lock (Replicated): "b"/Exclusive -> txn={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+lock (Replicated): "b"/Shared -> txn={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+lock (Replicated): "c"/Shared -> txn={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+
+run ok
+resolve_intent_range t=B k=a end=z status=COMMITTED maxKeys=1 batched
+----
+resolve_intent_range: "a"-"z" -> resolved 1 key(s), 56 bytes
+resolve_intent_range: resume span ["a\x00","z") RESUME_KEY_LIMIT
+resolve_intent_range: batch after write is non-empty
+>> at end:
+data: "a"/1.000000000,0 -> /BYTES/a
+meta: "b"/0,0 -> txn={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} ts=1.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "b"/1.000000000,0 -> /BYTES/b
+lock (Replicated): "b"/Exclusive -> txn={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+lock (Replicated): "b"/Shared -> txn={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+lock (Replicated): "c"/Shared -> txn={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+
+run ok
+resolve_intent_range t=B k=a end=z status=COMMITTED targetBytes=1 batched
+----
+resolve_intent_range: "a"-"z" -> resolved 1 key(s), 84 bytes
+resolve_intent_range: resume span ["b\x00","z") RESUME_BYTE_LIMIT
+resolve_intent_range: batch after write is non-empty
+>> at end:
+data: "a"/1.000000000,0 -> /BYTES/a
+data: "b"/1.000000000,0 -> /BYTES/b
+lock (Replicated): "c"/Shared -> txn={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+
+run ok
+resolve_intent_range t=B k=a end=z status=COMMITTED maxKeys=1 batched
+----
+resolve_intent_range: "a"-"z" -> resolved 1 key(s), 28 bytes
+resolve_intent_range: batch after write is non-empty
+>> at end:
+data: "a"/1.000000000,0 -> /BYTES/a
+data: "b"/1.000000000,0 -> /BYTES/b

--- a/pkg/storage/testdata/mvcc_histories/skip_locked
+++ b/pkg/storage/testdata/mvcc_histories/skip_locked
@@ -39,8 +39,6 @@ meta: "k3"/0,0 -> txn={id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=
 data: "k3"/14.000000000,0 -> /BYTES/v4
 data: "k4"/15.000000000,0 -> /BYTES/v5
 data: "k5"/17.000000000,0 -> /BYTES/v6
-lock (Replicated): "k2"/Intent -> txn={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0} ts=13.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
-lock (Replicated): "k3"/Intent -> txn={id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0} ts=14.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 lock (Unreplicated): k4/Exclusive -> id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=16.000000000,0 min=0,0 seq=0
 
 # Test cases:

--- a/pkg/storage/testdata/mvcc_histories/write_too_old
+++ b/pkg/storage/testdata/mvcc_histories/write_too_old
@@ -9,6 +9,7 @@ with t=A
   put  k=a v=abc resolve
   txn_remove
 ----
+resolve_intent: "a" -> resolved key = true
 >> at end:
 data: "a"/44.000000000,0 -> /BYTES/abc
 
@@ -28,6 +29,7 @@ error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "a" at timestam
 run ok
 resolve_intent t=A k=a status=ABORTED
 ----
+resolve_intent: "a" -> resolved key = false
 >> at end:
 data: "a"/44.000000000,0 -> /BYTES/abc
 
@@ -49,5 +51,6 @@ error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "a" at timestam
 run ok
 resolve_intent t=B k=a status=ABORTED
 ----
+resolve_intent: "a" -> resolved key = false
 >> at end:
 data: "a"/44.000000000,0 -> /BYTES/abc


### PR DESCRIPTION
Fixes #109648.
Informs #100193.

This commit adds support for releasing replicated locks during point and ranged intent resolution, if any are found. Replicated locks are released if the resolving transaction is finalized or if resolving transaction is pending and the lock has been rolled back through an epoch bump or savepoint rollback.

Release note: None