### PR TITLE
storage: mark as OK for remote execution

### DIFF
--- a/pkg/storage/BUILD.bazel
+++ b/pkg/storage/BUILD.bazel
@@ -142,7 +142,6 @@ go_test(
     embed = [":storage"],
     exec_properties = {"Pool": "medium"},
     shard_count = 2,
-    tags = ["no-remote-exec"],
     deps = [
         "//pkg/base",
         "//pkg/clusterversion",


### PR DESCRIPTION
Seems like this test has enough resources since #110371. A test in this package is still flaky (see #110403).

Closes #109176.

Epic: CRDB-8308
Release note: None