### PR TITLE
kvflowcontrol: performance optimizations in tracker.go 

### DIFF
--- a/pkg/kv/kvserver/kvflowcontrol/kvflowtokentracker/tracker.go
+++ b/pkg/kv/kvserver/kvflowcontrol/kvflowtokentracker/tracker.go
@@ -193,9 +193,6 @@ func (dt *Tracker) Untrack(
 		log.Infof(ctx, "released %s flow control tokens for %d out of %d tracked deductions for pri=%s stream=%s, up to %s; %d tracked deduction(s) remain%s",
 			tokens, untracked, trackedBefore, pri, dt.stream, upto, len(dt.trackedM[pri].items), remaining)
 	}
-	if len(dt.trackedM[pri].items) == 0 {
-		delete(dt.trackedM, pri)
-	}
 
 	if dt.lowerBound.Less(upto) {
 		dt.lowerBound = upto


### PR DESCRIPTION
This patch makes 2 main performance optimizations in the tracker
codepath:
1. Replace the trackedList with a struct that points to a list. This
   avoids map assignments each time anything is appended to the list.
2. We use a sync.Pool for tracked items to avoid frequent allocations
   and gc for the objects.

Informs https://github.com/cockroachdb/cockroach/issues/104154.

Release note: None