### PR TITLE
c2c: prevent slow quiesce failure in TestDataDriven/initial_scan_span_configs

### DIFF
--- a/pkg/ccl/streamingccl/streamingest/testdata/initial_scan_span_configs
+++ b/pkg/ccl/streamingccl/streamingest/testdata/initial_scan_span_configs
@@ -77,3 +77,13 @@ list-ttls as=destination-system min_table_id=$min_table_id max_table_id=$max_tab
 1234
 14400
 
+let $cutover as=source-system
+SELECT clock_timestamp()::timestamp::string
+----
+
+cutover ts=$cutover
+----
+
+start-replicated-tenant
+----
+


### PR DESCRIPTION
This small patch prevents a slow quiesce failure during test shutdown by manually closing the replication stream before test shutdown. #110350 observed this failure because the eventStream's underlying rangefeed would not close, implying there may still be some sort of deadlock within Rangefeed.Close(). This patch merely deflakes the TestDataDriven/initial_scan_span_configs test.

Informs #110350

Release note: None