### PR TITLE
kvserver: add unreplicated spans to EFOS snapshot for Raft snapshots

### DIFF
--- a/pkg/kv/kvserver/rditer/BUILD.bazel
+++ b/pkg/kv/kvserver/rditer/BUILD.bazel
@@ -15,7 +15,6 @@ go_library(
         "//pkg/roachpb",
         "//pkg/storage",
         "//pkg/storage/enginepb",
-        "//pkg/util/hlc",
         "//pkg/util/iterutil",
         "@com_github_cockroachdb_pebble//:pebble",
         "@com_github_cockroachdb_pebble//rangekey",

--- a/pkg/kv/kvserver/rditer/replica_data_iter_test.go
+++ b/pkg/kv/kvserver/rditer/replica_data_iter_test.go
@@ -464,7 +464,7 @@ func TestReplicaDataIteratorGlobalRangeKey(t *testing.T) {
 				if replicatedOnly {
 					expectedSpans = MakeReplicatedKeySpans(&desc)
 				} else {
-					expectedSpans = makeAllKeySpans(&desc)
+					expectedSpans = MakeAllKeySpans(&desc)
 				}
 
 				var actualSpans []roachpb.Span
@@ -500,7 +500,7 @@ func TestReplicaKeyRanges(t *testing.T) {
 		StartKey: roachpb.RKeyMin,
 		EndKey:   roachpb.RKeyMax,
 	}
-	checkOrdering(t, makeAllKeySpans(&desc))
+	checkOrdering(t, MakeAllKeySpans(&desc))
 	checkOrdering(t, MakeReplicatedKeySpans(&desc))
 	checkOrdering(t, makeReplicatedKeySpansExceptLockTable(&desc))
 }
@@ -554,7 +554,7 @@ func benchReplicaEngineDataIterator(b *testing.B, numRanges, numKeysPerRange, va
 
 	for _, desc := range descs {
 		var keyBuf roachpb.Key
-		keySpans := makeAllKeySpans(&desc)
+		keySpans := MakeAllKeySpans(&desc)
 		for i := 0; i < numKeysPerRange; i++ {
 			keyBuf = append(keyBuf[:0], keySpans[i%len(keySpans)].Key...)
 			keyBuf = append(keyBuf, 0, 0, 0, 0)

--- a/pkg/kv/kvserver/rditer/select.go
+++ b/pkg/kv/kvserver/rditer/select.go
@@ -26,6 +26,9 @@ const (
 	// ReplicatedSpansUserOnly includes just user keys, and no other replicated
 	// spans.
 	ReplicatedSpansUserOnly
+	// ReplicatedSpansExcludeLockTable includes all replicated spans except for the
+	// lock table.
+	ReplicatedSpansExcludeLocks
 )
 
 // SelectOpts configures which spans for a Replica to return from Select.
@@ -81,7 +84,7 @@ func Select(rangeID roachpb.RangeID, opts SelectOpts) []roachpb.Span {
 			sl = append(sl, makeRangeLocalKeySpan(in))
 
 			// Lock table.
-			{
+			if opts.ReplicatedSpansFilter != ReplicatedSpansExcludeLocks {
 				// Handle doubly-local lock table keys since range descriptor key
 				// is a range local key that can have a replicated lock acquired on it.
 				startRangeLocal, _ := keys.LockTableSingleKey(keys.MakeRangeKeyPrefix(in.Key), nil)

--- a/pkg/kv/kvserver/rditer/select_test.go
+++ b/pkg/kv/kvserver/rditer/select_test.go
@@ -69,6 +69,14 @@ func TestSelect(t *testing.T) {
 			filter: ReplicatedSpansUserOnly,
 		},
 		{
+			name: "r2_excludelocks",
+			sp: roachpb.RSpan{
+				Key:    roachpb.RKey("a"),
+				EndKey: roachpb.RKey("c"),
+			},
+			filter: ReplicatedSpansExcludeLocks,
+		},
+		{
 			name: "r3",
 			sp: roachpb.RSpan{
 				Key:    roachpb.RKey("a"),

--- a/pkg/kv/kvserver/rditer/testdata/TestSelect/r2_excludelocks
+++ b/pkg/kv/kvserver/rditer/testdata/TestSelect/r2_excludelocks
@@ -1,0 +1,18 @@
+echo
+----
+Select({ReplicatedBySpan:{a-c} ReplicatedSpansFilter:3 ReplicatedByRangeID:false UnreplicatedByRangeID:false}):
+  /Local/Range"{a"-c"}
+  {a-c}
+Select({ReplicatedBySpan:{a-c} ReplicatedSpansFilter:3 ReplicatedByRangeID:false UnreplicatedByRangeID:true}):
+  /Local/RangeID/123/{u""-v""}
+  /Local/Range"{a"-c"}
+  {a-c}
+Select({ReplicatedBySpan:{a-c} ReplicatedSpansFilter:3 ReplicatedByRangeID:true UnreplicatedByRangeID:false}):
+  /Local/RangeID/123/{r""-s""}
+  /Local/Range"{a"-c"}
+  {a-c}
+Select({ReplicatedBySpan:{a-c} ReplicatedSpansFilter:3 ReplicatedByRangeID:true UnreplicatedByRangeID:true}):
+  /Local/RangeID/123/{r""-s""}
+  /Local/RangeID/123/{u""-v""}
+  /Local/Range"{a"-c"}
+  {a-c}

--- a/pkg/kv/kvserver/replica_raftstorage.go
+++ b/pkg/kv/kvserver/replica_raftstorage.go
@@ -243,10 +243,10 @@ func (r *Replica) GetSnapshot(
 	if r.store.cfg.SharedStorageEnabled || storage.UseEFOS.Get(&r.ClusterSettings().SV) {
 		var ss *spanset.SpanSet
 		r.mu.RLock()
-		spans := rditer.MakeReplicatedKeySpans(r.mu.state.Desc)
+		spans := rditer.MakeAllKeySpans(r.mu.state.Desc) // needs unreplicated to access Raft state
 		startKey = r.mu.state.Desc.StartKey
 		if util.RaceEnabled {
-			ss = rditer.MakeReplicatedKeySpanSet(r.mu.state.Desc)
+			ss = rditer.MakeAllKeySpanSet(r.mu.state.Desc)
 			defer ss.Release()
 		}
 		r.mu.RUnlock()


### PR DESCRIPTION
Building a Raft snapshot needs to read unreplicated keys, e.g. the Raft truncated state.

Resolves #110416.
Touches #109276.

Epic: none
Release note: None