### PR TITLE
release-22.2: sql: use redactable type name in a few errors

### DIFF
--- a/pkg/sql/opt/invertedidx/trigram.go
+++ b/pkg/sql/opt/invertedidx/trigram.go
@@ -96,7 +96,7 @@ func (t *trigramFilterPlanner) extractInvertedFilterConditionFromLeaf(
 	d := memo.ExtractConstDatum(constantVal)
 	if d.ResolvedType() != types.String {
 		panic(errors.AssertionFailedf(
-			"trying to apply inverted index to unsupported type %s", d.ResolvedType(),
+			"trying to apply inverted index to unsupported type %s", d.ResolvedType().SQLStringForError(),
 		))
 	}
 	s := string(*d.(*tree.DString))

--- a/pkg/sql/rowenc/index_encoding.go
+++ b/pkg/sql/rowenc/index_encoding.go
@@ -619,7 +619,7 @@ func EncodeInvertedIndexTableKeys(
 		// here.
 		return encodeTrigramInvertedIndexTableKeys(string(*datum.(*tree.DString)), inKey, version, true /* pad */)
 	}
-	return nil, errors.AssertionFailedf("trying to apply inverted index to unsupported type %s", datum.ResolvedType())
+	return nil, errors.AssertionFailedf("trying to apply inverted index to unsupported type %s", datum.ResolvedType().SQLStringForError())
 }
 
 // EncodeContainingInvertedIndexSpans returns the spans that must be scanned in
@@ -647,7 +647,7 @@ func EncodeContainingInvertedIndexSpans(
 		return encodeContainingArrayInvertedIndexSpans(val.(*tree.DArray), nil /* inKey */)
 	default:
 		return nil, errors.AssertionFailedf(
-			"trying to apply inverted index to unsupported type %s", datum.ResolvedType(),
+			"trying to apply inverted index to unsupported type %s", datum.ResolvedType().SQLStringForError(),
 		)
 	}
 }
@@ -678,7 +678,7 @@ func EncodeContainedInvertedIndexSpans(
 		return json.EncodeContainedInvertedIndexSpans(nil /* inKey */, val.(*tree.DJSON).JSON)
 	default:
 		return nil, errors.AssertionFailedf(
-			"trying to apply inverted index to unsupported type %s", datum.ResolvedType(),
+			"trying to apply inverted index to unsupported type %s", datum.ResolvedType().SQLStringForError(),
 		)
 	}
 }
@@ -709,7 +709,7 @@ func EncodeExistsInvertedIndexSpans(
 	case types.ArrayFamily:
 		if val.ResolvedType().ArrayContents().Family() != types.StringFamily {
 			return nil, errors.AssertionFailedf(
-				"trying to apply inverted index to unsupported type %s", datum.ResolvedType(),
+				"trying to apply inverted index to unsupported type %s", datum.ResolvedType().SQLStringForError(),
 			)
 		}
 		var expr inverted.Expression
@@ -733,7 +733,7 @@ func EncodeExistsInvertedIndexSpans(
 		return expr, nil
 	default:
 		return nil, errors.AssertionFailedf(
-			"trying to apply inverted index to unsupported type %s", datum.ResolvedType(),
+			"trying to apply inverted index to unsupported type %s", datum.ResolvedType().SQLStringForError(),
 		)
 	}
 }
@@ -761,7 +761,7 @@ func EncodeOverlapsInvertedIndexSpans(
 		return encodeOverlapsArrayInvertedIndexSpans(val.(*tree.DArray), nil /* inKey */)
 	default:
 		return nil, errors.AssertionFailedf(
-			"trying to apply inverted index to unsupported type %s", datum.ResolvedType(),
+			"trying to apply inverted index to unsupported type %s", datum.ResolvedType().SQLStringForError(),
 		)
 	}
 }


### PR DESCRIPTION
Backport 1/1 commits from #110466.

/cc @cockroachdb/release

---

Epic: None

Release note: None

Release justification: low-risk debugging improvement.