### PR TITLE
copy: bump package timeout

### DIFF
--- a/pkg/sql/copy/BUILD.bazel
+++ b/pkg/sql/copy/BUILD.bazel
@@ -2,13 +2,14 @@ load("@io_bazel_rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "copy_test",
+    size = "large",
     srcs = [
         "copy_in_test.go",
         "copy_out_test.go",
         "copy_test.go",
         "main_test.go",
     ],
-    args = ["-test.timeout=295s"],
+    args = ["-test.timeout=895s"],
     data = glob(["testdata/**"]),
     deps = [
         "//pkg/base",


### PR DESCRIPTION
Just saw a failure in [CI](https://teamcity.cockroachdb.com/viewLog.html?buildId=11753396&buildTypeId=Cockroach_BazelEssentialCi) where the package timed out seemingly with nothing being stuck, so this commit bumps the size of the package which increases the test timeout.

Epic: None

Release note: None