### PR TITLE
roachtest: default logging to file instead of stderr

### DIFF
--- a/pkg/cmd/roachtest/BUILD.bazel
+++ b/pkg/cmd/roachtest/BUILD.bazel
@@ -40,6 +40,8 @@ go_library(
         "//pkg/util/httputil",
         "//pkg/util/leaktest",
         "//pkg/util/log",
+        "//pkg/util/log/logconfig",
+        "//pkg/util/log/logpb",
         "//pkg/util/quotapool",
         "//pkg/util/randutil",
         "//pkg/util/stop",


### PR DESCRIPTION
Previously, stderr/out would be cluttered by unuseful log statements from various components like `testutils` and `sarama`, which are configured to utilise the pkg/util/log. This is, by default, set to use a stderr sink. It makes parsing the TC roachtest build log especially cumbersome..

This PR introduces a roachtest specific configuration which filters all but FATAL events to stderr, and preserves what was previously being written, by including a file sink that writes to `artifactsDir`. 

Epic: none
Release note: None