### PR TITLE
storage: update TestMVCCHistories to pass upper/lower bounds

### DIFF
--- a/pkg/storage/mvcc_history_test.go
+++ b/pkg/storage/mvcc_history_test.go
@@ -2167,6 +2167,39 @@ func formatStats(ms enginepb.MVCCStats, delta bool) string {
 	return s
 }
 
+// boundSettingReader wraps a storage.Reader and sets unset bounds on
+// NewMVCCIterator.
+type boundSettingReader struct {
+	storage.Reader
+}
+
+// NewMVCCIterator implements the Reader interface.
+func (b boundSettingReader) NewMVCCIterator(
+	iterKind storage.MVCCIterKind, opts storage.IterOptions,
+) (storage.MVCCIterator, error) {
+	if !opts.Prefix {
+		if len(opts.LowerBound) == 0 {
+			// This logic exists because intentInterleavingIter does not support
+			// iterator bounds spanning the local and global keyspace.
+			if len(opts.UpperBound) != 0 && keys.IsLocal(opts.UpperBound) {
+				opts.LowerBound = keys.MinKey
+			} else {
+				opts.LowerBound = keys.LocalMax
+			}
+		}
+		if len(opts.UpperBound) == 0 {
+			// NB: The above conditional will force a LocalMax min key if lower bound
+			// was initially unset, and LocalMax is not local.
+			if len(opts.LowerBound) != 0 && keys.IsLocal(opts.LowerBound) {
+				opts.UpperBound = keys.LocalMax
+			} else {
+				opts.UpperBound = keys.MaxKey
+			}
+		}
+	}
+	return b.Reader.NewMVCCIterator(iterKind, opts)
+}
+
 // evalCtx stored the current state of the environment of a running
 // script.
 type evalCtx struct {
@@ -2330,7 +2363,7 @@ func (e *evalCtx) newReader() storage.Reader {
 	case "snapshot":
 		return e.engine.NewSnapshot()
 	case "efos":
-		return e.engine.NewEventuallyFileOnlySnapshot([]roachpb.Span{{Key: roachpb.KeyMin, EndKey: roachpb.KeyMax}})
+		return boundSettingReader{e.engine.NewEventuallyFileOnlySnapshot([]roachpb.Span{{Key: roachpb.KeyMin, EndKey: roachpb.KeyMax}})}
 	default:
 		e.t.Fatalf("unknown reader type %q", mvccHistoriesReader)
 		return nil

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -2832,22 +2832,11 @@ func (p *pebbleEFOS) NewMVCCIterator(
 	// check for non-prefix iterators as prefix iterators often don't specify
 	// any bounds.
 	if !opts.Prefix {
-		if opts.LowerBound == nil && opts.UpperBound == nil {
+		if opts.LowerBound == nil || opts.UpperBound == nil {
 			return nil, errors.AssertionFailedf("cannot create iterators on EFOS without bounds")
 		}
 		var found bool
-		// Note that this assertion checking is imperfect as it assumes that if
-		// only one of the bounds is specified, we will really only read that key.
-		// Fixing this is non-trivial as a lot of NewMVCCIterator calls only specify
-		// one bound. We rely on spanset assertions to more accurately track cases
-		// of iterator reads outside of EFOS spans.
 		boundSpan := roachpb.Span{Key: opts.LowerBound, EndKey: opts.UpperBound}
-		switch {
-		case len(boundSpan.Key) == 0:
-			boundSpan.Key = boundSpan.EndKey
-		case len(boundSpan.EndKey) == 0:
-			boundSpan.EndKey = boundSpan.Key
-		}
 		for i := range p.keyRanges {
 			if p.keyRanges[i].Contains(boundSpan) {
 				found = true


### PR DESCRIPTION
This change addresses a non-explicit TODO from #110490 at the same time as addressing the case where a MaxKey upper bound would get translated to a MaxKey-MaxKey boundSpan in the EFOS iterator assertions and be erroneously considered as being outside the MinKey-MaxKey bound of the EFOS.

Fixes #110520.

Epic: none

Release note: None