### PR TITLE
metric: remove Measurement() from Iterable interface

### DIFF
--- a/pkg/server/telemetry/features.go
+++ b/pkg/server/telemetry/features.go
@@ -149,11 +149,6 @@ func (c CounterWithMetric) GetHelp() string {
 	return c.metric.GetHelp()
 }
 
-// GetMeasurement implements metric.Iterable
-func (c CounterWithMetric) GetMeasurement() string {
-	return c.metric.GetMeasurement()
-}
-
 // GetUnit implements metric.Iterable
 func (c CounterWithMetric) GetUnit() metric.Unit {
 	return c.metric.GetUnit()

--- a/pkg/util/metric/aggmetric/counter.go
+++ b/pkg/util/metric/aggmetric/counter.go
@@ -44,9 +44,6 @@ func (c *AggCounter) GetName() string { return c.g.GetName() }
 // GetHelp is part of the metric.Iterable interface.
 func (c *AggCounter) GetHelp() string { return c.g.GetHelp() }
 
-// GetMeasurement is part of the metric.Iterable interface.
-func (c *AggCounter) GetMeasurement() string { return c.g.GetMeasurement() }
-
 // GetUnit is part of the metric.Iterable interface.
 func (c *AggCounter) GetUnit() metric.Unit { return c.g.GetUnit() }
 
@@ -152,9 +149,6 @@ func (c *AggCounterFloat64) GetName() string { return c.g.GetName() }
 
 // GetHelp is part of the metric.Iterable interface.
 func (c *AggCounterFloat64) GetHelp() string { return c.g.GetHelp() }
-
-// GetMeasurement is part of the metric.Iterable interface.
-func (c *AggCounterFloat64) GetMeasurement() string { return c.g.GetMeasurement() }
 
 // GetUnit is part of the metric.Iterable interface.
 func (c *AggCounterFloat64) GetUnit() metric.Unit { return c.g.GetUnit() }

--- a/pkg/util/metric/aggmetric/gauge.go
+++ b/pkg/util/metric/aggmetric/gauge.go
@@ -69,9 +69,6 @@ func (g *AggGauge) GetName() string { return g.g.GetName() }
 // GetHelp is part of the metric.Iterable interface.
 func (g *AggGauge) GetHelp() string { return g.g.GetHelp() }
 
-// GetMeasurement is part of the metric.Iterable interface.
-func (g *AggGauge) GetMeasurement() string { return g.g.GetMeasurement() }
-
 // GetUnit is part of the metric.Iterable interface.
 func (g *AggGauge) GetUnit() metric.Unit { return g.g.GetUnit() }
 
@@ -205,9 +202,6 @@ func (g *AggGaugeFloat64) GetName() string { return g.g.GetName() }
 
 // GetHelp is part of the metric.Iterable interface.
 func (g *AggGaugeFloat64) GetHelp() string { return g.g.GetHelp() }
-
-// GetMeasurement is part of the metric.Iterable interface.
-func (g *AggGaugeFloat64) GetMeasurement() string { return g.g.GetMeasurement() }
 
 // GetUnit is part of the metric.Iterable interface.
 func (g *AggGaugeFloat64) GetUnit() metric.Unit { return g.g.GetUnit() }

--- a/pkg/util/metric/aggmetric/histogram.go
+++ b/pkg/util/metric/aggmetric/histogram.go
@@ -49,9 +49,6 @@ func (a *AggHistogram) GetName() string { return a.h.GetName() }
 // GetHelp is part of the metric.Iterable interface.
 func (a *AggHistogram) GetHelp() string { return a.h.GetHelp() }
 
-// GetMeasurement is part of the metric.Iterable interface.
-func (a *AggHistogram) GetMeasurement() string { return a.h.GetMeasurement() }
-
 // GetUnit is part of the metric.Iterable interface.
 func (a *AggHistogram) GetUnit() metric.Unit { return a.h.GetUnit() }
 

--- a/pkg/util/metric/metric.go
+++ b/pkg/util/metric/metric.go
@@ -42,9 +42,6 @@ type Iterable interface {
 	GetName() string
 	// GetHelp returns the help text for the metric.
 	GetHelp() string
-	// GetMeasurement returns the label for the metric, which describes the entity
-	// it measures.
-	GetMeasurement() string
 	// GetUnit returns the unit that should be used to display the metric
 	// (e.g. in bytes).
 	GetUnit() Unit
@@ -119,11 +116,6 @@ func (m *Metadata) GetName() string {
 // GetHelp returns the metric's help string.
 func (m *Metadata) GetHelp() string {
 	return m.Help
-}
-
-// GetMeasurement returns the entity measured by the metric.
-func (m *Metadata) GetMeasurement() string {
-	return m.Measurement
 }
 
 // GetUnit returns the metric's unit of measurement.


### PR DESCRIPTION
This method is unused.

Epic: None
Release note: None