### PR TITLE
*: add back non-test usages of math/rand

### DIFF
--- a/pkg/cloud/cloudcheck/cloudcheck_processor.go
+++ b/pkg/cloud/cloudcheck/cloudcheck_processor.go
@@ -12,7 +12,6 @@ package cloudcheck
 
 import (
 	"context"
-	crypto_rand "crypto/rand"
 	"fmt"
 	"io"
 	"math/rand"
@@ -114,7 +113,10 @@ func checkStorage(
 	}
 
 	buf := make([]byte, chunkSize)
-	_, _ = crypto_rand.Read(buf)
+	// https://github.com/cockroachdb/cockroach/issues/110599 tracks this
+	// deprecated usage.
+	//lint:ignore SA1019 deprecated
+	_, _ = rand.Read(buf)
 
 	var res result
 

--- a/pkg/util/uuid/uuid_wrapper.go
+++ b/pkg/util/uuid/uuid_wrapper.go
@@ -11,10 +11,10 @@
 package uuid
 
 import (
-	"crypto/rand"
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
+	"math/rand"
 
 	"github.com/cockroachdb/cockroach/pkg/util/uint128"
 	"github.com/cockroachdb/errors"
@@ -114,6 +114,9 @@ func FastMakeV4() UUID {
 type defaultRandReader struct{}
 
 func (r defaultRandReader) Read(p []byte) (n int, err error) {
+	// https://github.com/cockroachdb/cockroach/issues/110597 tracks this
+	// deprecated usage.
+	//lint:ignore SA1019 deprecated
 	return rand.Read(p)
 }
 


### PR DESCRIPTION
78fee99 moved usages of math/rand to
crypto/rand. This has performance implications, as described in
https://github.com/cockroachdb/cockroach/issues/30236#issuecomment-434588162.

Rather than forcing a change, we mark the existing non-test usages of
math/rand as ignored by the linter so the appropriate engineering teams
can decide what to do.

informs https://github.com/cockroachdb/cockroach/issues/110597
informs https://github.com/cockroachdb/cockroach/issues/110599
Release note: None