### PR TITLE
release-23.1.11-rc: logictest: deflake zone_config_system_tenant

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/zone_config_system_tenant
+++ b/pkg/sql/logictest/testdata/logic_test/zone_config_system_tenant
@@ -122,13 +122,16 @@ ALTER DATABASE db2 CONFIGURE ZONE USING gc.ttlseconds = 90001;
 
 # Both the dropped and the new table should eventually have span configurations
 # and they should both inherit from the database's GC TTL setting.
-query T retry
-SELECT crdb_internal.pb_to_json('cockroach.roachpb.SpanConfig', config)
+query TT retry
+SELECT
+  crdb_internal.pretty_key(start_key, -1),
+  crdb_internal.pb_to_json('cockroach.roachpb.SpanConfig', config)
 FROM system.span_configurations
 WHERE end_key > (SELECT crdb_internal.table_span($t_id)[1])
+ORDER BY start_key
 ----
-{"gcPolicy": {"ttlSeconds": 90001}, "numReplicas": 3, "rangeMaxBytes": "16777216", "rangeMinBytes": "1048576"}
-{"gcPolicy": {"ttlSeconds": 90001}, "numReplicas": 3, "rangeMaxBytes": "1073741824", "rangeMinBytes": "67108864"}
+/Table/110  {"gcPolicy": {"ttlSeconds": 90001}, "numReplicas": 3, "rangeMaxBytes": "16777216", "rangeMinBytes": "1048576"}
+/Table/111  {"gcPolicy": {"ttlSeconds": 90001}, "numReplicas": 3, "rangeMaxBytes": "1073741824", "rangeMinBytes": "67108864"}
 
 # Check that dropped relations can have their GC TTLs altered.
 subtest dropped_relation_gc_ttl
@@ -149,16 +152,21 @@ t   25:00:01
 t2  25:00:01
 t3  04:00:00
 
-query T
-SELECT crdb_internal.pb_to_json('cockroach.roachpb.SpanConfig', config)->'gcPolicy'->>'ttlSeconds'
+# The tables in db2 should have a gc_ttl of 90001, while test.public.t3 should
+# have a gc_ttl of 14400.
+query TT retry
+SELECT
+  crdb_internal.pretty_key(start_key, -1),
+  crdb_internal.pb_to_json('cockroach.roachpb.SpanConfig', config)->'gcPolicy'->>'ttlSeconds'
 FROM system.span_configurations
 WHERE start_key >= (SELECT crdb_internal.table_span(100)[1])
 ORDER BY start_key
 ----
-14400
-14400
-90001
-90001
+/Table/106  14400
+/Table/107  14400
+/Table/110  90001
+/Table/111  90001
+/Table/112  14400
 
 query B
 SELECT crdb_internal.upsert_dropped_relation_gc_ttl(id, '1 second')
@@ -177,14 +185,16 @@ t3  00:00:01
 
 # Check that the zone config changes eventually get picked up by the span
 # config reconciler.
-query T retry
-SELECT crdb_internal.pb_to_json('cockroach.roachpb.SpanConfig', config)->'gcPolicy'->>'ttlSeconds'
+query TT retry
+SELECT
+  crdb_internal.pretty_key(start_key, -1),
+  crdb_internal.pb_to_json('cockroach.roachpb.SpanConfig', config)->'gcPolicy'->>'ttlSeconds'
 FROM system.span_configurations
 WHERE start_key >= (SELECT crdb_internal.table_span(100)[1])
 ORDER BY start_key
 ----
-14400
-14400
-90001
-1
-1
+/Table/106  14400
+/Table/107  14400
+/Table/110  90001
+/Table/111  1
+/Table/112  1


### PR DESCRIPTION
Backport of #109376.

Also, make the test more maintainable by including the pretty printed start keys in the results.

Fixes: #110544.

Release note: None

Release justification: test-only change.