### PR TITLE
bulk,*: add ProcessorID to the AggregatorEvent

### DIFF
--- a/pkg/ccl/backupccl/backup_processor.go
+++ b/pkg/ccl/backupccl/backup_processor.go
@@ -174,7 +174,7 @@ func newBackupDataProcessor(
 				bp.close()
 				if bp.agg != nil {
 					meta := bulk.ConstructTracingAggregatorProducerMeta(ctx,
-						bp.flowCtx.NodeID.SQLInstanceID(), bp.flowCtx.ID, bp.agg)
+						bp.flowCtx.NodeID.SQLInstanceID(), bp.flowCtx.ID, bp.ProcessorID, bp.agg)
 					return []execinfrapb.ProducerMetadata{*meta}
 				}
 				return nil
@@ -265,7 +265,7 @@ func (bp *backupDataProcessor) Next() (rowenc.EncDatumRow, *execinfrapb.Producer
 		bp.aggTimer.Read = true
 		bp.aggTimer.Reset(15 * time.Second)
 		return nil, bulk.ConstructTracingAggregatorProducerMeta(bp.Ctx(),
-			bp.flowCtx.NodeID.SQLInstanceID(), bp.flowCtx.ID, bp.agg)
+			bp.flowCtx.NodeID.SQLInstanceID(), bp.flowCtx.ID, bp.ProcessorID, bp.agg)
 	}
 }
 

--- a/pkg/ccl/backupccl/restore_data_processor.go
+++ b/pkg/ccl/backupccl/restore_data_processor.go
@@ -213,7 +213,7 @@ func newRestoreDataProcessor(
 				rd.ConsumerClosed()
 				if rd.agg != nil {
 					meta := bulkutil.ConstructTracingAggregatorProducerMeta(ctx,
-						rd.flowCtx.NodeID.SQLInstanceID(), rd.flowCtx.ID, rd.agg)
+						rd.flowCtx.NodeID.SQLInstanceID(), rd.flowCtx.ID, rd.ProcessorID, rd.agg)
 					return []execinfrapb.ProducerMetadata{*meta}
 				}
 				return nil
@@ -718,7 +718,7 @@ func (rd *restoreDataProcessor) Next() (rowenc.EncDatumRow, *execinfrapb.Produce
 		rd.aggTimer.Read = true
 		rd.aggTimer.Reset(15 * time.Second)
 		return nil, bulkutil.ConstructTracingAggregatorProducerMeta(rd.Ctx(),
-			rd.flowCtx.NodeID.SQLInstanceID(), rd.flowCtx.ID, rd.agg)
+			rd.flowCtx.NodeID.SQLInstanceID(), rd.flowCtx.ID, rd.ProcessorID, rd.agg)
 	case meta := <-rd.metaCh:
 		return nil, meta
 	case <-rd.Ctx().Done():

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor.go
@@ -336,7 +336,7 @@ func newStreamIngestionDataProcessor(
 				sip.close()
 				if sip.agg != nil {
 					meta := bulkutil.ConstructTracingAggregatorProducerMeta(ctx,
-						sip.flowCtx.NodeID.SQLInstanceID(), sip.flowCtx.ID, sip.agg)
+						sip.flowCtx.NodeID.SQLInstanceID(), sip.flowCtx.ID, sip.ProcessorID, sip.agg)
 					return []execinfrapb.ProducerMetadata{*meta}
 				}
 				return nil
@@ -498,7 +498,7 @@ func (sip *streamIngestionProcessor) Next() (rowenc.EncDatumRow, *execinfrapb.Pr
 		sip.aggTimer.Read = true
 		sip.aggTimer.Reset(15 * time.Second)
 		return nil, bulkutil.ConstructTracingAggregatorProducerMeta(sip.Ctx(),
-			sip.flowCtx.NodeID.SQLInstanceID(), sip.flowCtx.ID, sip.agg)
+			sip.flowCtx.NodeID.SQLInstanceID(), sip.flowCtx.ID, sip.ProcessorID, sip.agg)
 	case err := <-sip.errCh:
 		sip.MoveToDraining(err)
 		return nil, sip.DrainHelper()

--- a/pkg/sql/execinfrapb/data.proto
+++ b/pkg/sql/execinfrapb/data.proto
@@ -394,5 +394,10 @@ message TracingAggregatorEvents {
   optional bytes flow_id = 2 [(gogoproto.nullable) = false,
     (gogoproto.customname) = "FlowID",
     (gogoproto.customtype) = "FlowID"];
+  // Identifier of this component, within the domain of components of the same
+  // type.
+  optional int32 id = 4 [(gogoproto.nullable) = false,
+    (gogoproto.customname) = "ID"];
+
   map<string, bytes> events = 3;
 }

--- a/pkg/util/bulk/aggregator_stats.go
+++ b/pkg/util/bulk/aggregator_stats.go
@@ -31,11 +31,13 @@ func ConstructTracingAggregatorProducerMeta(
 	ctx context.Context,
 	sqlInstanceID base.SQLInstanceID,
 	flowID execinfrapb.FlowID,
+	processorID int32,
 	agg *TracingAggregator,
 ) *execinfrapb.ProducerMetadata {
 	aggEvents := &execinfrapb.TracingAggregatorEvents{
 		SQLInstanceID: sqlInstanceID,
 		FlowID:        flowID,
+		ID:            processorID,
 		Events:        make(map[string][]byte),
 	}
 
@@ -98,8 +100,8 @@ func FlushTracingAggregatorStats(
 				// Write a proto file per tag. This machine-readable file can be consumed
 				// by other places we want to display this information egs: annotated
 				// DistSQL diagrams, DBConsole etc.
-				filename := fmt.Sprintf("%s/%s",
-					component.SQLInstanceID.String(), asOf)
+				filename := fmt.Sprintf("%s/%d/%s",
+					component.SQLInstanceID.String(), component.ID, asOf)
 				msg, err := protoreflect.DecodeMessage(name, event)
 				if err != nil {
 					clusterWideSummary.WriteString(fmt.Sprintf("invalid protocol message: %v", err))


### PR DESCRIPTION
It is possible that a single node may run multiple distsql processors, each sending back their own aggregator stats. This has not been the case so far in backup, restore or c2c but we should be prepared for future changes that may introduce this. To that effect we add the ProcessorID to the AggregatorEvent, so that the events are namespaced by nodeID,flowID,processorID and events from different processors on the same node don't overwrite each other.

Epic: none
Release note: None