### PR TITLE
build: more resources for a couple more tests

### DIFF
--- a/pkg/ccl/sqlproxyccl/BUILD.bazel
+++ b/pkg/ccl/sqlproxyccl/BUILD.bazel
@@ -77,6 +77,7 @@ go_test(
     args = ["-test.timeout=895s"],
     data = glob(["testdata/**"]),
     embed = [":sqlproxyccl"],
+    exec_properties = {"Pool": "medium"},
     shard_count = 8,
     tags = ["ccl_test"],
     deps = [

--- a/pkg/sql/logictest/BUILD.bazel
+++ b/pkg/sql/logictest/BUILD.bazel
@@ -87,6 +87,7 @@ go_test(
     args = ["-test.timeout=295s"],
     data = [":testdata"],
     embed = [":logictest"],
+    exec_properties = {"Pool": "medium"},
     deps = [
         "//pkg/base",
         "//pkg/config/zonepb",


### PR DESCRIPTION
Both these timed out under remote execution.

Epic: CRDB-8308
Release note: None