### PR TITLE
kv: add ability to acquire shared locks using the KV client API

### DIFF
--- a/pkg/ccl/changefeedccl/kvfeed/scanner.go
+++ b/pkg/ccl/changefeedccl/kvfeed/scanner.go
@@ -188,7 +188,7 @@ func (p *scanRequestScanner) exportSpan(
 	for remaining := &span; remaining != nil; {
 		start := timeutil.Now()
 		b := txn.NewBatch()
-		r := kvpb.NewScan(remaining.Key, remaining.EndKey, false /* forUpdate */).(*kvpb.ScanRequest)
+		r := kvpb.NewScan(remaining.Key, remaining.EndKey, kvpb.NonLocking).(*kvpb.ScanRequest)
 		r.ScanFormat = kvpb.BATCH_RESPONSE
 		b.Header.TargetBytes = targetBytesPerScan
 		b.AdmissionHeader = kvpb.AdmissionHeader{

--- a/pkg/cli/debug_send_kv_batch_test.go
+++ b/pkg/cli/debug_send_kv_batch_test.go
@@ -37,7 +37,7 @@ func TestSendKVBatchExample(t *testing.T) {
 
 	var ba kvpb.BatchRequest
 	ba.Add(kvpb.NewPut(roachpb.Key("foo"), roachpb.MakeValueFromString("bar")))
-	ba.Add(kvpb.NewGet(roachpb.Key("foo"), false /* forUpdate */))
+	ba.Add(kvpb.NewGet(roachpb.Key("foo"), kvpb.NonLocking))
 
 	// NOTE: This cannot be marshaled using the standard Go JSON marshaler,
 	// since it does not correctly (un)marshal the JSON as mandated by the
@@ -72,7 +72,7 @@ func TestSendKVBatch(t *testing.T) {
 	// Protobuf spec. Instead, use the JSON marshaler shipped with Protobuf.
 	var ba kvpb.BatchRequest
 	ba.Add(kvpb.NewPut(roachpb.Key("foo"), roachpb.MakeValueFromString("bar")))
-	ba.Add(kvpb.NewGet(roachpb.Key("foo"), false /* forUpdate */))
+	ba.Add(kvpb.NewGet(roachpb.Key("foo"), kvpb.NonLocking))
 
 	jsonpb := protoutil.JSONPb{}
 	jsonProto, err := jsonpb.Marshal(&ba)

--- a/pkg/kv/kvclient/kvcoord/transport_test.go
+++ b/pkg/kv/kvclient/kvcoord/transport_test.go
@@ -154,7 +154,7 @@ func TestResponseVerifyFailure(t *testing.T) {
 	}
 
 	ba := &kvpb.BatchRequest{}
-	req := kvpb.NewScan(roachpb.KeyMin, roachpb.KeyMax, false /* forUpdate */)
+	req := kvpb.NewScan(roachpb.KeyMin, roachpb.KeyMax, kvpb.NonLocking)
 	ba.Add(req)
 	br := ba.CreateReply()
 	resp := br.Responses[0].GetInner().(*kvpb.ScanResponse)

--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender_test.go
@@ -1139,7 +1139,7 @@ func TestTxnCoordSenderNoDuplicateLockSpans(t *testing.T) {
 	txn := kv.NewTxn(ctx, db, 0 /* gatewayNodeID */)
 
 	// Acquire locks on a-b, c, m, u-w before the final batch.
-	_, pErr := txn.ReverseScanForUpdate(ctx, roachpb.Key("a"), roachpb.Key("b"), 0)
+	_, pErr := txn.ScanForShare(ctx, roachpb.Key("a"), roachpb.Key("b"), 0)
 	if pErr != nil {
 		t.Fatal(pErr)
 	}
@@ -1162,7 +1162,7 @@ func TestTxnCoordSenderNoDuplicateLockSpans(t *testing.T) {
 	b.Put(roachpb.Key("c"), []byte("value"))
 	b.Put(roachpb.Key("d"), []byte("value"))
 	b.GetForUpdate(roachpb.Key("n"))
-	b.ReverseScanForUpdate(roachpb.Key("v"), roachpb.Key("z"))
+	b.ReverseScanForShare(roachpb.Key("v"), roachpb.Key("z"))
 
 	// The expected locks are a-b, c, m, n, and u-z.
 	expectedLockSpans = []roachpb.Span{
@@ -2877,21 +2877,63 @@ func TestTxnTypeCompatibleWithBatchRequest(t *testing.T) {
 	require.NoError(t, err)
 	leafTxn := kv.NewLeafTxn(ctx, s.DB, 0 /* gatewayNodeID */, leafInputState)
 
-	// a LeafTxn is not compatible with a locking request
+	// A LeafTxn is not compatible with locking requests.
+	// 1. Locking Get requests.
 	_, err = leafTxn.GetForUpdate(ctx, roachpb.Key("a"))
 	require.Error(t, err)
 	require.Regexp(t, "LeafTxn .* incompatible with locking request .*", err)
+	_, err = leafTxn.GetForShare(ctx, roachpb.Key("a"))
+	require.Error(t, err)
+	require.Regexp(t, "LeafTxn .* incompatible with locking request .*", err)
+	// 2. Locking Scan requests.
+	_, err = leafTxn.ScanForUpdate(ctx, roachpb.Key("a"), roachpb.Key("d"), 0 /* maxRows */)
+	require.Error(t, err)
+	require.Regexp(t, "LeafTxn .* incompatible with locking request .*", err)
+	_, err = leafTxn.ScanForShare(ctx, roachpb.Key("a"), roachpb.Key("d"), 0 /* maxRows */)
+	require.Error(t, err)
+	require.Regexp(t, "LeafTxn .* incompatible with locking request .*", err)
+	// 3. Locking ReverseScan requests.
+	_, err = leafTxn.ReverseScanForUpdate(ctx, roachpb.Key("a"), roachpb.Key("d"), 0 /* maxRows */)
+	require.Error(t, err)
+	require.Regexp(t, "LeafTxn .* incompatible with locking request .*", err)
+	_, err = leafTxn.ReverseScanForShare(ctx, roachpb.Key("a"), roachpb.Key("d"), 0 /* maxRows */)
+	require.Error(t, err)
+	require.Regexp(t, "LeafTxn .* incompatible with locking request .*", err)
+	// 4. Writes.
 	err = leafTxn.Put(ctx, roachpb.Key("a"), []byte("b"))
 	require.Error(t, err)
 	require.Regexp(t, "LeafTxn .* incompatible with locking request .*", err)
-	// a LeafTxn is compatible with a non-locking request
+	// A LeafTxn is compatible with non-locking requests.
 	_, err = leafTxn.Get(ctx, roachpb.Key("a"))
 	require.NoError(t, err)
+	_, err = leafTxn.Scan(ctx, roachpb.Key("a"), roachpb.Key("d"), 0 /* maxRows */)
+	require.NoError(t, err)
+	_, err = leafTxn.ReverseScan(ctx, roachpb.Key("a"), roachpb.Key("d"), 0 /* maxRows */)
+	require.NoError(t, err)
 
-	// a RootTxn is compatible with all requests
+	// A RootTxn is compatible with all requests.
+	// 1. All types of Get requests.
 	_, err = rootTxn.GetForUpdate(ctx, roachpb.Key("a"))
 	require.NoError(t, err)
+	_, err = rootTxn.GetForShare(ctx, roachpb.Key("a"))
+	require.NoError(t, err)
 	_, err = rootTxn.Get(ctx, roachpb.Key("a"))
+	require.NoError(t, err)
+	// 2. All types of Scan requests.
+	_, err = rootTxn.ScanForUpdate(ctx, roachpb.Key("a"), roachpb.Key("d"), 0 /* maxRows */)
+	require.NoError(t, err)
+	_, err = rootTxn.ScanForShare(ctx, roachpb.Key("a"), roachpb.Key("d"), 0 /* maxRows */)
+	require.NoError(t, err)
+	_, err = rootTxn.Scan(ctx, roachpb.Key("a"), roachpb.Key("d"), 0 /* maxRows */)
+	require.NoError(t, err)
+	// 3. All types of ReverseScan requets.
+	_, err = rootTxn.ReverseScanForUpdate(ctx, roachpb.Key("a"), roachpb.Key("d"), 0 /* maxRows */)
+	require.NoError(t, err)
+	_, err = rootTxn.ReverseScanForShare(ctx, roachpb.Key("a"), roachpb.Key("d"), 0 /* maxRows */)
+	require.NoError(t, err)
+	_, err = rootTxn.ReverseScan(ctx, roachpb.Key("a"), roachpb.Key("d"), 0 /* maxRows */)
+	require.NoError(t, err)
+	// 4. And writes.
 	require.NoError(t, err)
 	err = rootTxn.Put(ctx, roachpb.Key("a"), []byte("b"))
 	require.NoError(t, err)

--- a/pkg/kv/kvclient/kvstreamer/streamer_test.go
+++ b/pkg/kv/kvclient/kvstreamer/streamer_test.go
@@ -90,7 +90,7 @@ func TestStreamerLimitations(t *testing.T) {
 		defer streamer.Close(ctx)
 		streamer.Init(kvstreamer.OutOfOrder, kvstreamer.Hints{UniqueRequests: true}, 1 /* maxKeysPerRow */, nil /* diskBuffer */)
 		k := append(s.Codec().TenantPrefix(), roachpb.Key("key")...)
-		get := kvpb.NewGet(k, false /* forUpdate */)
+		get := kvpb.NewGet(k, kvpb.NonLocking)
 		reqs := []kvpb.RequestUnion{{
 			Value: &kvpb.RequestUnion_Get{
 				Get: get.(*kvpb.GetRequest),

--- a/pkg/kv/kvpb/api.go
+++ b/pkg/kv/kvpb/api.go
@@ -1192,12 +1192,12 @@ func (r *IsSpanEmptyRequest) ShallowCopy() Request {
 // NewGet returns a Request initialized to get the value at key. If
 // forUpdate is true, an unreplicated, exclusive lock is acquired on on
 // the key, if it exists.
-func NewGet(key roachpb.Key, forUpdate bool) Request {
+func NewGet(key roachpb.Key, str KeyLockingStrengthType) Request {
 	return &GetRequest{
 		RequestHeader: RequestHeader{
 			Key: key,
 		},
-		KeyLockingStrength: scanLockStrength(forUpdate),
+		KeyLockingStrength: scanLockStrength(str),
 	}
 }
 
@@ -1317,34 +1317,62 @@ func NewDeleteRange(startKey, endKey roachpb.Key, returnKeys bool) Request {
 // NewScan returns a Request initialized to scan from start to end keys.
 // If forUpdate is true, unreplicated, exclusive locks are acquired on
 // each of the resulting keys.
-func NewScan(key, endKey roachpb.Key, forUpdate bool) Request {
+func NewScan(key, endKey roachpb.Key, str KeyLockingStrengthType) Request {
 	return &ScanRequest{
 		RequestHeader: RequestHeader{
 			Key:    key,
 			EndKey: endKey,
 		},
-		KeyLockingStrength: scanLockStrength(forUpdate),
+		KeyLockingStrength: scanLockStrength(str),
 	}
 }
 
 // NewReverseScan returns a Request initialized to reverse scan from end.
 // If forUpdate is true, unreplicated, exclusive locks are acquired on
 // each of the resulting keys.
-func NewReverseScan(key, endKey roachpb.Key, forUpdate bool) Request {
+func NewReverseScan(key, endKey roachpb.Key, str KeyLockingStrengthType) Request {
 	return &ReverseScanRequest{
 		RequestHeader: RequestHeader{
 			Key:    key,
 			EndKey: endKey,
 		},
-		KeyLockingStrength: scanLockStrength(forUpdate),
+		KeyLockingStrength: scanLockStrength(str),
 	}
 }
 
-func scanLockStrength(forUpdate bool) lock.Strength {
-	if forUpdate {
+// KeyLockingStrengthType is used to describe per-key locking strengths
+// associated with Get, Scan, and ReverseScan requests.
+type KeyLockingStrengthType int8
+
+const (
+	_ KeyLockingStrengthType = iota
+	// NonLocking indicates any keys returned will not be locked.
+	NonLocking
+	// ForShare indicates any keys returned will be locked for share; this means
+	// concurrent requests will be able to read the key or lock it ForShare
+	// themselves. Requests will not be allowed to write to the key. The semantics
+	// here correspond to acquiring a Read lock for a ReadWrite mutex.
+	ForShare
+	// ForUpdate indicates any keys returned will be locked for update; the
+	// transaction that holds the lock will have exclusive write access to the
+	// key. No other transaction is able to acquire a lock on the key; note that
+	// locking a key ForUpdate does not impact concurrent non-locking requests.
+	// The semantics here correspond to acquiring a Write lock in a ReadWrite
+	// mutex.
+	ForUpdate
+)
+
+func scanLockStrength(str KeyLockingStrengthType) lock.Strength {
+	switch str {
+	case NonLocking:
+		return lock.None
+	case ForShare:
+		return lock.Shared
+	case ForUpdate:
 		return lock.Exclusive
+	default:
+		panic(fmt.Sprintf("unknown strength type: %d", str))
 	}
-	return lock.None
 }
 
 func flagForLockStrength(l lock.Strength) flag {

--- a/pkg/kv/kvpb/batch_test.go
+++ b/pkg/kv/kvpb/batch_test.go
@@ -344,9 +344,9 @@ func TestRefreshSpanIterate(t *testing.T) {
 
 func TestRefreshSpanIterateSkipLocked(t *testing.T) {
 	ba := BatchRequest{}
-	ba.Add(NewGet(roachpb.Key("a"), false))
-	ba.Add(NewScan(roachpb.Key("b"), roachpb.Key("d"), false))
-	ba.Add(NewReverseScan(roachpb.Key("e"), roachpb.Key("g"), false))
+	ba.Add(NewGet(roachpb.Key("a"), NonLocking))
+	ba.Add(NewScan(roachpb.Key("b"), roachpb.Key("d"), NonLocking))
+	ba.Add(NewReverseScan(roachpb.Key("e"), roachpb.Key("g"), NonLocking))
 	br := ba.CreateReply()
 
 	// Without a SkipLocked wait policy.

--- a/pkg/kv/kvserver/client_replica_circuit_breaker_test.go
+++ b/pkg/kv/kvserver/client_replica_circuit_breaker_test.go
@@ -1069,14 +1069,14 @@ func (cbt *circuitBreakerTest) Write(idx int) error {
 func (cbt *circuitBreakerTest) Read(idx int) error {
 	cbt.t.Helper()
 	repl := cbt.repls[idx]
-	get := kvpb.NewGet(repl.Desc().StartKey.AsRawKey(), false /* forUpdate */)
+	get := kvpb.NewGet(repl.Desc().StartKey.AsRawKey(), kvpb.NonLocking)
 	return cbt.Send(idx, get)
 }
 
 func (cbt *circuitBreakerTest) FollowerRead(idx int) error {
 	cbt.t.Helper()
 	repl := cbt.repls[idx]
-	get := kvpb.NewGet(repl.Desc().StartKey.AsRawKey(), false /* forUpdate */)
+	get := kvpb.NewGet(repl.Desc().StartKey.AsRawKey(), kvpb.NonLocking)
 	ctx := context.Background()
 	ts := repl.GetCurrentClosedTimestamp(ctx)
 	return cbt.SendCtxTS(ctx, idx, get, ts)

--- a/pkg/kv/kvserver/replica_rankings_test.go
+++ b/pkg/kv/kvserver/replica_rankings_test.go
@@ -199,7 +199,7 @@ func TestAddSSTQPSStat(t *testing.T) {
 
 // genVariableRead returns a batch request containing, start-end sequential key reads.
 func genVariableRead(ctx context.Context, start, end roachpb.Key) *kvpb.BatchRequest {
-	scan := kvpb.NewScan(start, end, false)
+	scan := kvpb.NewScan(start, end, kvpb.NonLocking)
 	readBa := &kvpb.BatchRequest{}
 	readBa.Add(scan)
 	return readBa

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -11082,7 +11082,7 @@ func TestReplicaNotifyLockTableOn1PC(t *testing.T) {
 	txn := newTransaction("test", key, 1, tc.Clock())
 	ba := &kvpb.BatchRequest{}
 	ba.Header = kvpb.Header{Txn: txn}
-	ba.Add(kvpb.NewScan(key, key.Next(), true /* forUpdate */))
+	ba.Add(kvpb.NewScan(key, key.Next(), kvpb.ForUpdate))
 	if _, pErr := tc.Sender().Send(ctx, ba); pErr != nil {
 		t.Fatalf("unexpected error: %s", pErr)
 	}
@@ -11241,7 +11241,7 @@ func TestReplicaQueryLocks(t *testing.T) {
 			txn := newTransaction("test", keyA, 1, tc.Clock())
 			ba := &kvpb.BatchRequest{}
 			ba.Header = kvpb.Header{Txn: txn}
-			ba.Add(kvpb.NewScan(keyA, keyB.Next(), true /* forUpdate */))
+			ba.Add(kvpb.NewScan(keyA, keyB.Next(), kvpb.ForUpdate))
 			if _, pErr := tc.Sender().Send(ctx, ba); pErr != nil {
 				t.Fatalf("unexpected error: %s", pErr)
 			}

--- a/pkg/kv/txn.go
+++ b/pkg/kv/txn.go
@@ -486,6 +486,20 @@ func (txn *Txn) GetForUpdate(ctx context.Context, key interface{}) (KeyValue, er
 	return getOneRow(txn.Run(ctx, b), b)
 }
 
+// GetForShare retrieves the value for a key, returning the retrieved key/value
+// or an error. An unreplicated, shared lock is acquired on the key, if it
+// exists. It is not considered an error for the key to not exist.
+//
+//	r, err := txn.GetForShare("a")
+//	// string(r.Key) == "a"
+//
+// key can be either a byte slice or a string.
+func (txn *Txn) GetForShare(ctx context.Context, key interface{}) (KeyValue, error) {
+	b := txn.NewBatch()
+	b.GetForShare(key)
+	return getOneRow(txn.Run(ctx, b), b)
+}
+
 // GetProto retrieves the value for a key and decodes the result as a proto
 // message. If the key doesn't exist, the proto will simply be reset.
 //
@@ -576,13 +590,17 @@ func (txn *Txn) Inc(ctx context.Context, key interface{}, value int64) (KeyValue
 }
 
 func (txn *Txn) scan(
-	ctx context.Context, begin, end interface{}, maxRows int64, isReverse, forUpdate bool,
+	ctx context.Context,
+	begin, end interface{},
+	maxRows int64,
+	isReverse bool,
+	str kvpb.KeyLockingStrengthType,
 ) ([]KeyValue, error) {
 	b := txn.NewBatch()
 	if maxRows > 0 {
 		b.Header.MaxSpanRequestKeys = maxRows
 	}
-	b.scan(begin, end, isReverse, forUpdate)
+	b.scan(begin, end, isReverse, str)
 	r, err := getOneResult(txn.Run(ctx, b), b)
 	return r.Rows, err
 }
@@ -597,7 +615,7 @@ func (txn *Txn) scan(
 func (txn *Txn) Scan(
 	ctx context.Context, begin, end interface{}, maxRows int64,
 ) ([]KeyValue, error) {
-	return txn.scan(ctx, begin, end, maxRows, false /* isReverse */, false /* forUpdate */)
+	return txn.scan(ctx, begin, end, maxRows, false /* isReverse */, kvpb.NonLocking)
 }
 
 // ScanForUpdate retrieves the rows between begin (inclusive) and end
@@ -611,7 +629,21 @@ func (txn *Txn) Scan(
 func (txn *Txn) ScanForUpdate(
 	ctx context.Context, begin, end interface{}, maxRows int64,
 ) ([]KeyValue, error) {
-	return txn.scan(ctx, begin, end, maxRows, false /* isReverse */, true /* forUpdate */)
+	return txn.scan(ctx, begin, end, maxRows, false /* isReverse */, kvpb.ForUpdate)
+}
+
+// ScanForShare retrieves the rows between begin (inclusive) and end
+// (exclusive) in ascending order. Unreplicated, shared locks are acquired on
+// each of the returned keys.
+//
+// The returned []KeyValue will contain up to maxRows elements (or all results
+// when zero is supplied).
+//
+// key can be either a byte slice or a string.
+func (txn *Txn) ScanForShare(
+	ctx context.Context, begin, end interface{}, maxRows int64,
+) ([]KeyValue, error) {
+	return txn.scan(ctx, begin, end, maxRows, false /* isReverse */, kvpb.ForShare)
 }
 
 // ReverseScan retrieves the rows between begin (inclusive) and end (exclusive)
@@ -624,7 +656,7 @@ func (txn *Txn) ScanForUpdate(
 func (txn *Txn) ReverseScan(
 	ctx context.Context, begin, end interface{}, maxRows int64,
 ) ([]KeyValue, error) {
-	return txn.scan(ctx, begin, end, maxRows, true /* isReverse */, false /* forUpdate */)
+	return txn.scan(ctx, begin, end, maxRows, true /* isReverse */, kvpb.NonLocking)
 }
 
 // ReverseScanForUpdate retrieves the rows between begin (inclusive) and end
@@ -638,7 +670,21 @@ func (txn *Txn) ReverseScan(
 func (txn *Txn) ReverseScanForUpdate(
 	ctx context.Context, begin, end interface{}, maxRows int64,
 ) ([]KeyValue, error) {
-	return txn.scan(ctx, begin, end, maxRows, true /* isReverse */, true /* forUpdate */)
+	return txn.scan(ctx, begin, end, maxRows, true /* isReverse */, kvpb.ForUpdate)
+}
+
+// ReverseScanForShare retrieves the rows between begin (inclusive) and end
+// (exclusive) in descending order. Unreplicated, shared locks are acquired
+// on each of the returned keys.
+//
+// The returned []KeyValue will contain up to maxRows elements (or all results
+// when zero is supplied).
+//
+// key can be either a byte slice or a string.
+func (txn *Txn) ReverseScanForShare(
+	ctx context.Context, begin, end interface{}, maxRows int64,
+) ([]KeyValue, error) {
+	return txn.scan(ctx, begin, end, maxRows, true /* isReverse */, kvpb.ForShare)
 }
 
 // Iterate performs a paginated scan and applying the function f to every page.

--- a/pkg/kv/txn_test.go
+++ b/pkg/kv/txn_test.go
@@ -574,7 +574,7 @@ func TestTxnNegotiateAndSend(t *testing.T) {
 			MinTimestampBound: ts10,
 		}
 		ba.RoutingPolicy = kvpb.RoutingPolicy_NEAREST
-		ba.Add(kvpb.NewGet(roachpb.Key("a"), false))
+		ba.Add(kvpb.NewGet(roachpb.Key("a"), kvpb.NonLocking))
 		br, pErr := txn.NegotiateAndSend(ctx, ba)
 
 		if fastPath {
@@ -685,7 +685,7 @@ func TestTxnNegotiateAndSendWithDeadline(t *testing.T) {
 				MaxTimestampBound: test.maxTSBound,
 			}
 			ba.RoutingPolicy = kvpb.RoutingPolicy_NEAREST
-			ba.Add(kvpb.NewGet(roachpb.Key("a"), false))
+			ba.Add(kvpb.NewGet(roachpb.Key("a"), kvpb.NonLocking))
 			br, pErr := txn.NegotiateAndSend(ctx, ba)
 
 			if test.expErr == "" {
@@ -755,7 +755,7 @@ func TestTxnNegotiateAndSendWithResumeSpan(t *testing.T) {
 		}
 		ba.RoutingPolicy = kvpb.RoutingPolicy_NEAREST
 		ba.MaxSpanRequestKeys = 2
-		ba.Add(kvpb.NewScan(roachpb.Key("a"), roachpb.Key("d"), false /* forUpdate */))
+		ba.Add(kvpb.NewScan(roachpb.Key("a"), roachpb.Key("d"), kvpb.NonLocking))
 		br, pErr := txn.NegotiateAndSend(ctx, ba)
 
 		if fastPath {

--- a/pkg/server/node_test.go
+++ b/pkg/server/node_test.go
@@ -713,7 +713,7 @@ func TestNodeBatchRequestPProfLabels(t *testing.T) {
 		return labels
 	}()
 
-	gr := kvpb.NewGet(roachpb.Key("a"), false)
+	gr := kvpb.NewGet(roachpb.Key("a"), kvpb.NonLocking)
 	pr := kvpb.NewPut(gr.Header().Key, roachpb.Value{})
 	ba.Add(gr, pr)
 
@@ -748,7 +748,7 @@ func TestNodeBatchRequestMetricsInc(t *testing.T) {
 	ba.RangeID = 1
 	ba.Replica.StoreID = 1
 
-	gr := kvpb.NewGet(roachpb.Key("a"), false)
+	gr := kvpb.NewGet(roachpb.Key("a"), kvpb.NonLocking)
 	pr := kvpb.NewPut(gr.Header().Key, roachpb.Value{})
 	ba.Add(gr, pr)
 

--- a/pkg/server/systemconfigwatcher/systemconfigwatchertest/test_system_config_watcher.go
+++ b/pkg/server/systemconfigwatcher/systemconfigwatchertest/test_system_config_watcher.go
@@ -136,7 +136,7 @@ func getSystemDescriptorAndZonesSpans(
 			kvpb.NewScan(
 				append(codec.TenantPrefix(), startKey...),
 				append(codec.TenantPrefix(), endKey...),
-				false, // forUpdate
+				kvpb.NonLocking,
 			),
 		)
 		br, pErr := kvDB.NonTransactionalSender().Send(ctx, ba)

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -6406,7 +6406,7 @@ CREATE TABLE crdb_internal.lost_descriptors_with_data (
 			endPrefix := p.extendedEvalCtx.Codec.TablePrefix(uint32(endID - 1)).PrefixEnd()
 			b := p.Txn().NewBatch()
 			b.Header.MaxSpanRequestKeys = 1
-			scanRequest := kvpb.NewScan(startPrefix, endPrefix, false).(*kvpb.ScanRequest)
+			scanRequest := kvpb.NewScan(startPrefix, endPrefix, kvpb.NonLocking).(*kvpb.ScanRequest)
 			scanRequest.ScanFormat = kvpb.BATCH_RESPONSE
 			b.AddRawRequest(scanRequest)
 			err = p.execCfg.DB.Run(ctx, b)

--- a/pkg/ts/server.go
+++ b/pkg/ts/server.go
@@ -489,7 +489,7 @@ func dumpTimeseriesAllSources(
 
 	for span != nil {
 		b := &kv.Batch{}
-		scan := kvpb.NewScan(span.Key, span.EndKey, false /* forUpdate */)
+		scan := kvpb.NewScan(span.Key, span.EndKey, kvpb.NonLocking)
 		b.AddRawRequest(scan)
 		b.Header.MaxSpanRequestKeys = dumpBatchSize
 		err := db.Run(ctx, b)


### PR DESCRIPTION
This patch adds the ability to acquire shared locks using the KV client API. This can be done using 3 new methods, each of which are added to kv.DB, kv.Txn, and kv.Batch:

1. GetForShare
2. ScanForShare
3. ReverseScanForShare

We'll make use of these more prominently as we build tests for shared locks at various levels. Most notably, KVNemesis is going to make use of these shortly.

For now, `TestTxnCoordSenderNoDuplicateLockSpans` is slightly modified and `TestTxnTypeCompatibleWithBatchRequest` is enhanced to make use of these new methods.

Closes #110585

Release note: None