### PR TITLE
release-23.1: sql: fix system database survival on create or drop database

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_survial_goal
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_survial_goal
@@ -13,7 +13,7 @@ AS $$
  name,
  survival_goal
  FROM crdb_internal.databases
- WHERE name IN ('system', 'alter_survive_db', 'survive_zone_db')
+ WHERE name IN ('system', 'alter_survive_db', 'create_survive_db', 'survive_zone_db')
  ORDER BY name;
 $$;
 
@@ -76,6 +76,29 @@ statement ok
 ALTER DATABASE alter_survive_db SURVIVE ZONE FAILURE;
 
 query T
+SELECT get_db_survival_goal()
+----
+(alter_survive_db,zone)
+(survive_zone_db,zone)
+(system,zone)
+
+# Make sure a database created with a surival goal upgrades the systemdb.
+statement ok
+CREATE DATABASE create_survive_db PRIMARY REGION "us-east-1" REGIONS "ap-southeast-2", "ca-central-1" SURVIVE REGION FAILURE;
+
+query T nosort
+SELECT get_db_survival_goal()
+----
+(alter_survive_db,zone)
+(create_survive_db,region)
+(survive_zone_db,zone)
+(system,region)
+
+# Make sure dropping the database downgrades the survival goal.
+statement ok
+DROP DATABASE create_survive_db;
+
+query T nosort
 SELECT get_db_survival_goal()
 ----
 (alter_survive_db,zone)

--- a/pkg/sql/alter_database.go
+++ b/pkg/sql/alter_database.go
@@ -1336,6 +1336,9 @@ func (p *planner) maybeUpdateSystemDBSurvivalGoal(ctx context.Context) error {
 		if !db.IsMultiRegion() {
 			return
 		}
+		if db.Dropped() {
+			return
+		}
 		curGoal := db.GetRegionConfig().SurvivalGoal
 		if curGoal > maxSurvivalGoal {
 			maxSurvivalGoal = curGoal

--- a/pkg/sql/descriptor.go
+++ b/pkg/sql/descriptor.go
@@ -203,6 +203,11 @@ func (p *planner) createDatabase(
 
 	}
 
+	// TODO(jeffswenson): delete once region_livess is implemented (#107966)
+	if err := p.maybeUpdateSystemDBSurvivalGoal(ctx); err != nil {
+		return nil, false, err
+	}
+
 	return db, true, nil
 }
 

--- a/pkg/sql/drop_database.go
+++ b/pkg/sql/drop_database.go
@@ -215,6 +215,11 @@ func (n *dropDatabaseNode) startExec(params runParams) error {
 		return err
 	}
 
+	// TODO(jeffswenson): delete once region_livess is implemented (#107966)
+	if err := p.maybeUpdateSystemDBSurvivalGoal(ctx); err != nil {
+		return err
+	}
+
 	// Log Drop Database event. This is an auditable log event and is recorded
 	// in the same transaction as the table descriptor update.
 	return p.logEvent(ctx,

--- a/pkg/sql/schemachanger/scbuild/builder_test.go
+++ b/pkg/sql/schemachanger/scbuild/builder_test.go
@@ -86,6 +86,7 @@ func TestBuildDataDriven(t *testing.T) {
 					fn(
 						sctestdeps.NewTestDependencies(
 							sctestdeps.WithDescriptors(descriptorCatalog),
+							sctestdeps.WithSystemDatabaseDescriptor(),
 							sctestdeps.WithNamespace(sctestdeps.ReadNamespaceFromDB(t, tdb).Catalog),
 							sctestdeps.WithCurrentDatabase(sctestdeps.ReadCurrentDatabaseFromDB(t, tdb)),
 							sctestdeps.WithSessionData(

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/BUILD.bazel
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/BUILD.bazel
@@ -33,6 +33,7 @@ go_library(
         "//pkg/clusterversion",
         "//pkg/docs",
         "//pkg/geo/geoindex",
+        "//pkg/keys",
         "//pkg/security/username",
         "//pkg/server/telemetry",
         "//pkg/settings/cluster",

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/drop_database.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/drop_database.go
@@ -11,9 +11,11 @@
 package scbuildstmt
 
 import (
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scerrors"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catid"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -21,6 +23,8 @@ import (
 
 // DropDatabase implements DROP DATABASE.
 func DropDatabase(b BuildCtx, n *tree.DropDatabase) {
+	fallBackIfMRSystemDatabase(b, n)
+
 	elts := b.ResolveDatabase(n.Name, ResolveParams{
 		IsExistenceOptional: n.IfExists,
 		RequiredPrivilege:   privilege.DROP,
@@ -67,4 +71,12 @@ func DropDatabase(b BuildCtx, n *tree.DropDatabase) {
 	}
 	panic(pgerror.DangerousStatementf(
 		"DROP DATABASE on non-empty database without explicit CASCADE"))
+}
+
+func fallBackIfMRSystemDatabase(b BuildCtx, t *tree.DropDatabase) {
+	// TODO(jeffswenson): delete once region_livess is implemented (#107966)
+	_, _, dbRegionConfig := scpb.FindDatabaseRegionConfig(b.QueryByID(keys.SystemDatabaseID))
+	if dbRegionConfig != nil {
+		panic(scerrors.NotImplementedErrorf(t, "drop database not implemented when the system database is multi-region"))
+	}
 }

--- a/pkg/sql/schemachanger/scdeps/sctestdeps/BUILD.bazel
+++ b/pkg/sql/schemachanger/scdeps/sctestdeps/BUILD.bazel
@@ -30,6 +30,7 @@ go_library(
         "//pkg/sql/catalog/funcdesc",
         "//pkg/sql/catalog/nstree",
         "//pkg/sql/catalog/schemadesc",
+        "//pkg/sql/catalog/systemschema",
         "//pkg/sql/catalog/tabledesc",
         "//pkg/sql/catalog/typedesc",
         "//pkg/sql/catalog/zone",

--- a/pkg/sql/schemachanger/scdeps/sctestdeps/config.go
+++ b/pkg/sql/schemachanger/scdeps/sctestdeps/config.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkeys"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descidgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/nstree"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scbuild"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scexec"
@@ -68,6 +69,17 @@ func WithDescriptors(c nstree.Catalog) Option {
 			state.committed.UpsertDescriptor(desc)
 			return nil
 		})
+	})
+}
+
+// WithSystemDatabaseDescriptor adds the system database descriptor to the
+// catalog.
+//
+// TODO(jeffswenson): delete this once `DROP DATABASE` works with a
+// multi-region system database. (See PR #109844).
+func WithSystemDatabaseDescriptor() Option {
+	return optionFunc(func(state *TestState) {
+		state.committed.UpsertDescriptor(systemschema.MakeSystemDatabaseDesc())
 	})
 }
 

--- a/pkg/sql/schemachanger/sctest/end_to_end.go
+++ b/pkg/sql/schemachanger/sctest/end_to_end.go
@@ -226,6 +226,7 @@ func EndToEndSideEffects(t *testing.T, relPath string, newCluster NewClusterFunc
 
 			deps = sctestdeps.NewTestDependencies(
 				sctestdeps.WithDescriptors(sctestdeps.ReadDescriptorsFromDB(ctx, t, tdb).Catalog),
+				sctestdeps.WithSystemDatabaseDescriptor(),
 				sctestdeps.WithNamespace(sctestdeps.ReadNamespaceFromDB(t, tdb).Catalog),
 				sctestdeps.WithCurrentDatabase(sctestdeps.ReadCurrentDatabaseFromDB(t, tdb)),
 				sctestdeps.WithSessionData(sctestdeps.ReadSessionDataFromDB(t, tdb, func(


### PR DESCRIPTION
Backport 1/1 commits from #109844.

/cc @cockroachdb/release

---

Run the system database region survival promotion/demotion logic when creating or dropping databases. This fixes a bug where creating a database that survives region failures would not promote the system database to survive region.

This logic is temporary and should be removed once RFC #109843 allows us to configure the system database as a mix of survive zone and survive region.

Fixes: #109843

Release Justification: Fixes a bug impacting multi-region Serverless. The change is low risk because it only applies to MR Serverless clusters.
