### PR TITLE
storage: rename MVCCStats.{SeparatedIntentCount,IntentAge} to Lock{Count,Age}

### DIFF
--- a/docs/generated/metrics/metrics.html
+++ b/docs/generated/metrics/metrics.html
@@ -187,7 +187,7 @@
 <tr><td>STORAGE</td><td>gossip.connections.refused</td><td>Number of refused incoming gossip connections</td><td>Connections</td><td>COUNTER</td><td>COUNT</td><td>AVG</td><td>NON_NEGATIVE_DERIVATIVE</td></tr>
 <tr><td>STORAGE</td><td>gossip.infos.received</td><td>Number of received gossip Info objects</td><td>Infos</td><td>COUNTER</td><td>COUNT</td><td>AVG</td><td>NON_NEGATIVE_DERIVATIVE</td></tr>
 <tr><td>STORAGE</td><td>gossip.infos.sent</td><td>Number of sent gossip Info objects</td><td>Infos</td><td>COUNTER</td><td>COUNT</td><td>AVG</td><td>NON_NEGATIVE_DERIVATIVE</td></tr>
-<tr><td>STORAGE</td><td>intentage</td><td>Cumulative age of intents</td><td>Age</td><td>GAUGE</td><td>SECONDS</td><td>AVG</td><td>NONE</td></tr>
+<tr><td>STORAGE</td><td>intentage</td><td>Cumulative age of locks</td><td>Age</td><td>GAUGE</td><td>SECONDS</td><td>AVG</td><td>NONE</td></tr>
 <tr><td>STORAGE</td><td>intentbytes</td><td>Number of bytes in intent KV pairs</td><td>Storage</td><td>GAUGE</td><td>BYTES</td><td>AVG</td><td>NONE</td></tr>
 <tr><td>STORAGE</td><td>intentcount</td><td>Count of intent keys</td><td>Keys</td><td>GAUGE</td><td>COUNT</td><td>AVG</td><td>NONE</td></tr>
 <tr><td>STORAGE</td><td>intentresolver.async.throttled</td><td>Number of intent resolution attempts not run asynchronously due to throttling</td><td>Intent Resolutions</td><td>COUNTER</td><td>COUNT</td><td>AVG</td><td>NON_NEGATIVE_DERIVATIVE</td></tr>

--- a/pkg/cmd/roachtest/tests/mvcc_gc.go
+++ b/pkg/cmd/roachtest/tests/mvcc_gc.go
@@ -278,7 +278,7 @@ func checkRangesConsistentAndHaveNoData(totals enginepb.MVCCStats, details range
 		return errors.Errorf("table ranges contain garbage %s", totals.String())
 	}
 	if totals.LiveBytes > 0 || totals.LiveCount > 0 ||
-		totals.IntentBytes > 0 || totals.IntentCount > 0 || totals.SeparatedIntentCount > 0 {
+		totals.IntentBytes > 0 || totals.IntentCount > 0 || totals.LockCount > 0 {
 		return errors.Errorf("table ranges contain live data %s", totals.String())
 	}
 	if details.status != kvpb.CheckConsistencyResponse_RANGE_CONSISTENT.String() {

--- a/pkg/kv/kvserver/client_tenant_test.go
+++ b/pkg/kv/kvserver/client_tenant_test.go
@@ -114,7 +114,7 @@ func TestTenantsStorageMetricsOnSplit(t *testing.T) {
 		re := regexp.MustCompile(`^(\w+)\{.*,tenant_id="` + tenantID.String() + `"\} (\d+)`)
 		metricsToVal := map[string]int64{
 			"gcbytesage":    aggregateStats.GCBytesAge,
-			"intentage":     aggregateStats.IntentAge,
+			"intentage":     aggregateStats.LockAge,
 			"livebytes":     aggregateStats.LiveBytes,
 			"livecount":     aggregateStats.LiveCount,
 			"keybytes":      aggregateStats.KeyBytes,

--- a/pkg/kv/kvserver/gc/gc.go
+++ b/pkg/kv/kvserver/gc/gc.go
@@ -68,6 +68,7 @@ const (
 
 // IntentAgeThreshold is the threshold after which an extant intent
 // will be resolved.
+// TODO(nvanbenschoten): rename to LockAgeThreshold.
 var IntentAgeThreshold = settings.RegisterDurationSetting(
 	settings.SystemOnly,
 	"kv.gc.intent_age_threshold",

--- a/pkg/kv/kvserver/kvserverpb/state.proto
+++ b/pkg/kv/kvserver/kvserverpb/state.proto
@@ -255,7 +255,7 @@ message MVCCPersistentStats {
 
   int64 contains_estimates = 14; // must never go negative absent a bug
   sfixed64 last_update_nanos = 1;
-  sfixed64 intent_age = 2;
+  sfixed64 lock_age = 2;
   sfixed64 gc_bytes_age = 3 [(gogoproto.customname) = "GCBytesAge"];
   int64 live_bytes = 4;
   int64 live_count = 5;
@@ -265,7 +265,7 @@ message MVCCPersistentStats {
   int64 val_count = 9;
   int64 intent_bytes = 10;
   int64 intent_count = 11;
-  int64 separated_intent_count = 16;
+  int64 lock_count = 16;
   int64 range_key_count = 17;
   int64 range_key_bytes = 18;
   int64 range_val_count = 19;

--- a/pkg/kv/kvserver/metrics.go
+++ b/pkg/kv/kvserver/metrics.go
@@ -263,9 +263,11 @@ var (
 		Measurement: "Keys",
 		Unit:        metric.Unit_COUNT,
 	}
-	metaIntentAge = metric.Metadata{
+	// TODO(nvanbenschoten): add a "lockcount" metric.
+	// TODO(nvanbenschoten): rename "intentage" metric to "lockage".
+	metaLockAge = metric.Metadata{
 		Name:        "intentage",
-		Help:        "Cumulative age of intents",
+		Help:        "Cumulative age of locks",
 		Measurement: "Age",
 		Unit:        metric.Unit_SECONDS,
 	}
@@ -2581,7 +2583,7 @@ type TenantsStorageMetrics struct {
 	RangeKeyCount  *aggmetric.AggGauge
 	RangeValCount  *aggmetric.AggGauge
 	IntentCount    *aggmetric.AggGauge
-	IntentAge      *aggmetric.AggGauge
+	LockAge        *aggmetric.AggGauge
 	GcBytesAge     *aggmetric.AggGauge
 	SysBytes       *aggmetric.AggGauge
 	SysCount       *aggmetric.AggGauge
@@ -2615,7 +2617,7 @@ func tenantsStorageMetricsSet() map[string]struct{} {
 		metaRangeKeyCount.Name:  {},
 		metaRangeValCount.Name:  {},
 		metaIntentCount.Name:    {},
-		metaIntentAge.Name:      {},
+		metaLockAge.Name:        {},
 		metaGcBytesAge.Name:     {},
 		metaSysBytes.Name:       {},
 		metaSysCount.Name:       {},
@@ -2681,7 +2683,7 @@ func (sm *TenantsStorageMetrics) acquireTenant(tenantID roachpb.TenantID) *tenan
 			m.RangeKeyCount = sm.RangeKeyCount.AddChild(tenantIDStr)
 			m.RangeValCount = sm.RangeValCount.AddChild(tenantIDStr)
 			m.IntentCount = sm.IntentCount.AddChild(tenantIDStr)
-			m.IntentAge = sm.IntentAge.AddChild(tenantIDStr)
+			m.LockAge = sm.LockAge.AddChild(tenantIDStr)
 			m.GcBytesAge = sm.GcBytesAge.AddChild(tenantIDStr)
 			m.SysBytes = sm.SysBytes.AddChild(tenantIDStr)
 			m.SysCount = sm.SysCount.AddChild(tenantIDStr)
@@ -2732,7 +2734,7 @@ func (sm *TenantsStorageMetrics) releaseTenant(ctx context.Context, ref *tenantM
 		&m.RangeKeyCount,
 		&m.RangeValCount,
 		&m.IntentCount,
-		&m.IntentAge,
+		&m.LockAge,
 		&m.GcBytesAge,
 		&m.SysBytes,
 		&m.SysCount,
@@ -2779,7 +2781,7 @@ type tenantStorageMetrics struct {
 	RangeKeyCount  *aggmetric.Gauge
 	RangeValCount  *aggmetric.Gauge
 	IntentCount    *aggmetric.Gauge
-	IntentAge      *aggmetric.Gauge
+	LockAge        *aggmetric.Gauge
 	GcBytesAge     *aggmetric.Gauge
 	SysBytes       *aggmetric.Gauge
 	SysCount       *aggmetric.Gauge
@@ -2802,7 +2804,7 @@ func newTenantsStorageMetrics() *TenantsStorageMetrics {
 		RangeKeyCount:  b.Gauge(metaRangeKeyCount),
 		RangeValCount:  b.Gauge(metaRangeValCount),
 		IntentCount:    b.Gauge(metaIntentCount),
-		IntentAge:      b.Gauge(metaIntentAge),
+		LockAge:        b.Gauge(metaLockAge),
 		GcBytesAge:     b.Gauge(metaGcBytesAge),
 		SysBytes:       b.Gauge(metaSysBytes),
 		SysCount:       b.Gauge(metaSysCount),
@@ -3273,7 +3275,7 @@ func (sm *TenantsStorageMetrics) incMVCCGauges(
 	tm.RangeKeyCount.Inc(delta.RangeKeyCount)
 	tm.RangeValCount.Inc(delta.RangeValCount)
 	tm.IntentCount.Inc(delta.IntentCount)
-	tm.IntentAge.Inc(delta.IntentAge)
+	tm.LockAge.Inc(delta.LockAge)
 	tm.GcBytesAge.Inc(delta.GCBytesAge)
 	tm.SysBytes.Inc(delta.SysBytes)
 	tm.SysCount.Inc(delta.SysCount)

--- a/pkg/kv/kvserver/mvcc_gc_queue.go
+++ b/pkg/kv/kvserver/mvcc_gc_queue.go
@@ -465,7 +465,7 @@ func makeMVCCGCQueueScoreImpl(
 	// Intent score. This computes the average age of outstanding intents and
 	// normalizes. Note that at the time of writing this criterion hasn't
 	// undergone a reality check yet.
-	r.IntentScore = ms.AvgIntentAge(now.WallTime) / float64(intentAgeNormalization.Nanoseconds()/1e9)
+	r.IntentScore = ms.AvgLockAge(now.WallTime) / float64(intentAgeNormalization.Nanoseconds()/1e9)
 
 	// Randomly skew the score down a bit to cause decoherence of replicas with
 	// similar load. Note that we'll only ever reduce the score, never increase

--- a/pkg/kv/kvserver/mvcc_gc_queue_test.go
+++ b/pkg/kv/kvserver/mvcc_gc_queue_test.go
@@ -269,11 +269,11 @@ func newCachedWriteSimulator(t *testing.T) *cachedWriteSimulator {
 	cws.cache = map[gcTestCacheKey]gcTestCacheVal{
 		{enginepb.MVCCStats{LastUpdateNanos: 946684800000000000}, "1-1m0s-1.0 MiB"}: {
 			first: [cacheFirstLen]enginepb.MVCCStats{
-				{ContainsEstimates: 0, LastUpdateNanos: 946684800000000000, IntentAge: 0, GCBytesAge: 0, LiveBytes: 1048604, LiveCount: 1, KeyBytes: 23, KeyCount: 1, ValBytes: 1048581, ValCount: 1, IntentBytes: 0, IntentCount: 0, SysBytes: 0, SysCount: 0, AbortSpanBytes: 0},
-				{ContainsEstimates: 0, LastUpdateNanos: 946684801000000000, IntentAge: 0, GCBytesAge: 0, LiveBytes: 1048604, LiveCount: 1, KeyBytes: 35, KeyCount: 1, ValBytes: 2097162, ValCount: 2, IntentBytes: 0, IntentCount: 0, SysBytes: 0, SysCount: 0, AbortSpanBytes: 0},
-				{ContainsEstimates: 0, LastUpdateNanos: 946684802000000000, IntentAge: 0, GCBytesAge: 1048593, LiveBytes: 1048604, LiveCount: 1, KeyBytes: 47, KeyCount: 1, ValBytes: 3145743, ValCount: 3, IntentBytes: 0, IntentCount: 0, SysBytes: 0, SysCount: 0, AbortSpanBytes: 0},
+				{ContainsEstimates: 0, LastUpdateNanos: 946684800000000000, LockAge: 0, GCBytesAge: 0, LiveBytes: 1048604, LiveCount: 1, KeyBytes: 23, KeyCount: 1, ValBytes: 1048581, ValCount: 1, IntentBytes: 0, IntentCount: 0, SysBytes: 0, SysCount: 0, AbortSpanBytes: 0},
+				{ContainsEstimates: 0, LastUpdateNanos: 946684801000000000, LockAge: 0, GCBytesAge: 0, LiveBytes: 1048604, LiveCount: 1, KeyBytes: 35, KeyCount: 1, ValBytes: 2097162, ValCount: 2, IntentBytes: 0, IntentCount: 0, SysBytes: 0, SysCount: 0, AbortSpanBytes: 0},
+				{ContainsEstimates: 0, LastUpdateNanos: 946684802000000000, LockAge: 0, GCBytesAge: 1048593, LiveBytes: 1048604, LiveCount: 1, KeyBytes: 47, KeyCount: 1, ValBytes: 3145743, ValCount: 3, IntentBytes: 0, IntentCount: 0, SysBytes: 0, SysCount: 0, AbortSpanBytes: 0},
 			},
-			last: enginepb.MVCCStats{ContainsEstimates: 0, LastUpdateNanos: 946684860000000000, IntentAge: 0, GCBytesAge: 1856009610, LiveBytes: 1048604, LiveCount: 1, KeyBytes: 743, KeyCount: 1, ValBytes: 63963441, ValCount: 61, IntentBytes: 0, IntentCount: 0, SysBytes: 0, SysCount: 0, AbortSpanBytes: 0},
+			last: enginepb.MVCCStats{ContainsEstimates: 0, LastUpdateNanos: 946684860000000000, LockAge: 0, GCBytesAge: 1856009610, LiveBytes: 1048604, LiveCount: 1, KeyBytes: 743, KeyCount: 1, ValBytes: 63963441, ValCount: 61, IntentBytes: 0, IntentCount: 0, SysBytes: 0, SysCount: 0, AbortSpanBytes: 0},
 		},
 	}
 	return &cws

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -6451,15 +6451,15 @@ func TestRangeStatsComputation(t *testing.T) {
 	}
 	expMS = baseStats
 	expMS.Add(enginepb.MVCCStats{
-		LiveBytes:            103,
-		KeyBytes:             28,
-		ValBytes:             75,
-		IntentBytes:          23,
-		LiveCount:            2,
-		KeyCount:             2,
-		ValCount:             2,
-		IntentCount:          1,
-		SeparatedIntentCount: 1,
+		LiveBytes:   103,
+		KeyBytes:    28,
+		ValBytes:    75,
+		IntentBytes: 23,
+		LiveCount:   2,
+		KeyCount:    2,
+		ValCount:    2,
+		IntentCount: 1,
+		LockCount:   1,
 	})
 	if err := verifyRangeStats(tc.engine, tc.repl.RangeID, expMS); err != nil {
 		t.Fatal(err)

--- a/pkg/kv/kvserver/stats_test.go
+++ b/pkg/kv/kvserver/stats_test.go
@@ -44,7 +44,7 @@ func TestRangeStatsInit(t *testing.T) {
 		KeyCount:        6,
 		ValCount:        7,
 		IntentCount:     8,
-		IntentAge:       9,
+		LockAge:         9,
 		GCBytesAge:      10,
 		LastUpdateNanos: 11,
 	}

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -4005,7 +4005,8 @@ FROM crdb_internal.check_consistency(true, crdb_internal.tenant_span()[1], crdb_
 ORDER BY range_id
 LIMIT 1
 ----
-RANGE_CONSISTENT  stats: {ContainsEstimates: LastUpdateNanos: IntentAge: GCBytesAge: LiveBytes: LiveCount: KeyBytes: KeyCount: ValBytes: ValCount: IntentBytes: IntentCount: SeparatedIntentCount: RangeKeyCount: RangeKeyBytes: RangeValCount: RangeValBytes: SysBytes: SysCount: AbortSpanBytes:}
+RANGE_CONSISTENT  stats: {ContainsEstimates: LastUpdateNanos: LockAge: GCBytesAge: LiveBytes: LiveCount: KeyBytes: KeyCount: ValBytes: ValCount: IntentBytes: IntentCount: LockCount: RangeKeyCount: RangeKeyBytes: RangeValCount: RangeValBytes: SysBytes: SysCount: AbortSpanBytes:}
+
 
 # Fill a table with consistency check results. This used to panic.
 # See: https://github.com/cockroachdb/cockroach/issues/88222

--- a/pkg/storage/enginepb/mvcc.go
+++ b/pkg/storage/enginepb/mvcc.go
@@ -92,16 +92,16 @@ func (ms MVCCStats) HasNoUserData() bool {
 	return ms.ContainsEstimates == 0 && ms.RangeKeyCount == 0 && ms.KeyCount == 0 && ms.IntentCount == 0
 }
 
-// AvgIntentAge returns the average age of outstanding intents,
+// AvgLockAge returns the average age of outstanding locks,
 // based on current wall time specified via nowNanos.
-func (ms MVCCStats) AvgIntentAge(nowNanos int64) float64 {
+func (ms MVCCStats) AvgLockAge(nowNanos int64) float64 {
 	if ms.IntentCount == 0 {
 		return 0
 	}
 	// Advance age by any elapsed time since last computed. Note that
 	// we operate on a copy.
 	ms.AgeTo(nowNanos)
-	return float64(ms.IntentAge) / float64(ms.IntentCount)
+	return float64(ms.LockAge) / float64(ms.IntentCount)
 }
 
 // GCByteAge returns the total age of outstanding gc'able
@@ -134,7 +134,7 @@ func (ms *MVCCStats) AgeTo(nowNanos int64) {
 	diffSeconds := nowNanos/1e9 - ms.LastUpdateNanos/1e9
 
 	ms.GCBytesAge += ms.GCBytes() * diffSeconds
-	ms.IntentAge += ms.IntentCount * diffSeconds
+	ms.LockAge += ms.IntentCount * diffSeconds
 	ms.LastUpdateNanos = nowNanos
 }
 
@@ -149,7 +149,7 @@ func (ms *MVCCStats) Add(oms MVCCStats) {
 	ms.ContainsEstimates += oms.ContainsEstimates
 
 	// Now that we've done that, we may just add them.
-	ms.IntentAge += oms.IntentAge
+	ms.LockAge += oms.LockAge
 	ms.GCBytesAge += oms.GCBytesAge
 	ms.LiveBytes += oms.LiveBytes
 	ms.KeyBytes += oms.KeyBytes
@@ -159,7 +159,7 @@ func (ms *MVCCStats) Add(oms MVCCStats) {
 	ms.KeyCount += oms.KeyCount
 	ms.ValCount += oms.ValCount
 	ms.IntentCount += oms.IntentCount
-	ms.SeparatedIntentCount += oms.SeparatedIntentCount
+	ms.LockCount += oms.LockCount
 	ms.RangeKeyCount += oms.RangeKeyCount
 	ms.RangeKeyBytes += oms.RangeKeyBytes
 	ms.RangeValCount += oms.RangeValCount
@@ -180,7 +180,7 @@ func (ms *MVCCStats) Subtract(oms MVCCStats) {
 	ms.ContainsEstimates -= oms.ContainsEstimates
 
 	// Now that we've done that, we may subtract.
-	ms.IntentAge -= oms.IntentAge
+	ms.LockAge -= oms.LockAge
 	ms.GCBytesAge -= oms.GCBytesAge
 	ms.LiveBytes -= oms.LiveBytes
 	ms.KeyBytes -= oms.KeyBytes
@@ -190,7 +190,7 @@ func (ms *MVCCStats) Subtract(oms MVCCStats) {
 	ms.KeyCount -= oms.KeyCount
 	ms.ValCount -= oms.ValCount
 	ms.IntentCount -= oms.IntentCount
-	ms.SeparatedIntentCount -= oms.SeparatedIntentCount
+	ms.LockCount -= oms.LockCount
 	ms.RangeKeyCount -= oms.RangeKeyCount
 	ms.RangeKeyBytes -= oms.RangeKeyBytes
 	ms.RangeValCount -= oms.RangeValCount

--- a/pkg/storage/enginepb/mvcc.proto
+++ b/pkg/storage/enginepb/mvcc.proto
@@ -117,7 +117,7 @@ message MVCCMetadataSubsetForMergeSerialization {
 // running update) is added to the age.
 //
 // To give an example, if an intent is around from `t=2.5s` to `t=4.1s` (the
-// current time), then it contributes an intent age of two seconds (one second
+// current time), then it contributes a lock age of two seconds (one second
 // picked up when crossing `t=3s`, another one at `t=4s`). Similarly, if a
 // GC'able kv pair is around for this amount of time, it contributes two seconds
 // times its size in bytes.
@@ -160,9 +160,9 @@ message MVCCStats {
   // last_update_nanos is a timestamp at which the ages were last
   // updated. See the comment on MVCCStats.
   optional sfixed64 last_update_nanos = 1 [(gogoproto.nullable) = false];
-  // intent_age is the cumulative age of the tracked intents.
-  // See the comment on MVCCStats.
-  optional sfixed64 intent_age = 2 [(gogoproto.nullable) = false];
+  // lock_age is the cumulative age of the tracked locks (shared, exclusive,
+  // or intent strength). See the comment on MVCCStats.
+  optional sfixed64 lock_age = 2 [(gogoproto.nullable) = false];
   // gc_bytes_age is the cumulative age of the non-live data (i.e. data included
   // in key_bytes, val_bytes, and range_key_bytes, and range_val_bytes, but not
   // live_bytes). See the comment on MVCCStats.
@@ -195,12 +195,9 @@ message MVCCStats {
   // It is equal to the number of meta keys in the system with
   // a non-empty Transaction proto.
   optional sfixed64 intent_count = 11 [(gogoproto.nullable) = false];
-  // separated_intent_count is the number of intents that are in the separated
-  // lock table. It is <= intent_count. Separated intents will not be enabled
-  // in a cluster until all nodes in that cluster know how to read/write such
-  // intents, so mixed-version clusters with nodes preceding this knowledge
-  // will always have a 0 value for this field.
-  optional sfixed64 separated_intent_count = 16 [(gogoproto.nullable) = false];
+  // lock_count is the number of replicated locks (shared, exclusive, or
+  // intent strength) that are in the lock table. It is >= intent_count.
+  optional sfixed64 lock_count = 16 [(gogoproto.nullable) = false];
   // range_key_count is the number of range keys tracked under range_key_bytes.
   // Overlapping range keys may fragment into version stacks with the same
   // start/end bounds, thus writing a single range key may cause range_key_count

--- a/pkg/storage/enginepb/mvcc3.proto
+++ b/pkg/storage/enginepb/mvcc3.proto
@@ -223,7 +223,7 @@ message MVCCStatsDelta {
 
   int64 contains_estimates = 14;
   sfixed64 last_update_nanos = 1;
-  sfixed64 intent_age = 2;
+  sfixed64 lock_age = 2;
   sfixed64 gc_bytes_age = 3 [(gogoproto.customname) = "GCBytesAge"];
   sint64 live_bytes = 4;
   sint64 live_count = 5;
@@ -233,7 +233,7 @@ message MVCCStatsDelta {
   sint64 val_count = 9;
   sint64 intent_bytes = 10;
   sint64 intent_count = 11;
-  sint64 separated_intent_count = 16;
+  sint64 lock_count = 16;
   sint64 range_key_count = 17;
   sint64 range_key_bytes = 18;
   sint64 range_val_count = 19;

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -316,7 +316,7 @@ func updateStatsOnPut(
 			if orig.Txn != nil {
 				// If the original value was an intent, we're replacing the
 				// intent. Note that since it's a system key, it doesn't affect
-				// IntentByte, IntentCount, and correspondingly, IntentAge.
+				// IntentByte, IntentCount, and correspondingly, LockAge.
 				ms.SysBytes -= orig.KeyBytes + orig.ValBytes
 			}
 			ms.SysCount--
@@ -329,8 +329,8 @@ func updateStatsOnPut(
 	// Handle non-sys keys. This follows the same scheme: if there was a previous
 	// value, perhaps even an intent, subtract its contributions, and then add the
 	// new contributions. The complexity here is that we need to properly update
-	// GCBytesAge and IntentAge, which don't follow the same semantics. The difference
-	// between them is that an intent accrues IntentAge from its own timestamp on,
+	// GCBytesAge and LockAge, which don't follow the same semantics. The difference
+	// between them is that an intent accrues LockAge from its own timestamp on,
 	// while GCBytesAge is accrued by versions according to the following rules:
 	// 1. a (non-tombstone) value that is shadowed by a newer write accrues age at
 	// 	  the point in time at which it is shadowed (i.e. the newer write's timestamp).
@@ -358,7 +358,7 @@ func updateStatsOnPut(
 			ms.ValCount--
 			ms.IntentBytes -= (orig.KeyBytes + orig.ValBytes)
 			ms.IntentCount--
-			ms.SeparatedIntentCount--
+			ms.LockCount--
 		}
 
 		// If the original intent is a deletion, we're removing the intent. This
@@ -448,7 +448,7 @@ func updateStatsOnPut(
 	if meta.Txn != nil {
 		ms.IntentBytes += meta.KeyBytes + meta.ValBytes
 		ms.IntentCount++
-		ms.SeparatedIntentCount++
+		ms.LockCount++
 	}
 	return ms
 }
@@ -483,7 +483,7 @@ func updateStatsOnResolve(
 
 	// In the main case, we had an old intent at orig.Timestamp, and a new intent
 	// or value at meta.Timestamp. We'll walk through the contributions below,
-	// taking special care for IntentAge and GCBytesAge.
+	// taking special care for LockAge and GCBytesAge.
 	//
 	// Jump into the method below for extensive commentary on their semantics
 	// and "rules one and two".
@@ -509,10 +509,10 @@ func updateStatsOnResolve(
 		ms.LiveBytes -= orig.KeyBytes + orig.ValBytes
 	}
 
-	// IntentAge is always accrued from the intent's own timestamp on.
+	// LockAge is always accrued from the intent's own timestamp on.
 	ms.IntentBytes -= orig.KeyBytes + orig.ValBytes
 	ms.IntentCount--
-	ms.SeparatedIntentCount--
+	ms.LockCount--
 
 	// If there was a previous value (before orig.Timestamp), and it was not a
 	// deletion tombstone, then we have to adjust its GCBytesAge contribution
@@ -553,7 +553,7 @@ func updateStatsOnResolve(
 		// updateStatsOnPut, not this method).
 		ms.IntentBytes += meta.KeyBytes + meta.ValBytes
 		ms.IntentCount++
-		ms.SeparatedIntentCount++
+		ms.LockCount++
 	}
 	return ms
 }
@@ -774,7 +774,7 @@ func updateStatsOnClear(
 	if orig.Txn != nil {
 		ms.IntentBytes -= (orig.KeyBytes + orig.ValBytes)
 		ms.IntentCount--
-		ms.SeparatedIntentCount--
+		ms.LockCount--
 	}
 	return ms
 }
@@ -5826,8 +5826,8 @@ func MVCCGarbageCollectWholeRange(
 		// information was not accurate.
 		ms.IntentCount -= rangeStats.IntentCount
 		ms.IntentBytes -= rangeStats.IntentBytes
-		ms.IntentAge -= rangeStats.IntentAge
-		ms.SeparatedIntentCount -= rangeStats.SeparatedIntentCount
+		ms.LockAge -= rangeStats.LockAge
+		ms.LockCount -= rangeStats.LockCount
 	}
 	return nil
 }
@@ -6462,8 +6462,8 @@ func computeStatsForIterWithVisitors(
 				if meta.Txn != nil {
 					ms.IntentBytes += totalBytes
 					ms.IntentCount++
-					ms.SeparatedIntentCount++
-					ms.IntentAge += nowNanos/1e9 - meta.Timestamp.WallTime/1e9
+					ms.LockCount++
+					ms.LockAge += nowNanos/1e9 - meta.Timestamp.WallTime/1e9
 				}
 				if meta.KeyBytes != MVCCVersionTimestampSize {
 					return ms, errors.Errorf("expected mvcc metadata key bytes to equal %d; got %d "+

--- a/pkg/storage/mvcc_history_test.go
+++ b/pkg/storage/mvcc_history_test.go
@@ -2130,7 +2130,7 @@ func formatStats(ms enginepb.MVCCStats, delta bool) string {
 	order := []string{"key_count", "key_bytes", "val_count", "val_bytes",
 		"range_key_count", "range_key_bytes", "range_val_count", "range_val_bytes",
 		"live_count", "live_bytes", "gc_bytes_age",
-		"intent_count", "intent_bytes", "separated_intent_count", "intent_age"}
+		"intent_count", "intent_bytes", "lock_count", "lock_age"}
 	sort.SliceStable(fields, func(i, j int) bool {
 		for _, name := range order {
 			if fields[i][1] == name {

--- a/pkg/storage/mvcc_stats_test.go
+++ b/pkg/storage/mvcc_stats_test.go
@@ -206,17 +206,17 @@ func TestMVCCStatsPutCommitMovesTimestamp(t *testing.T) {
 	}
 
 	expMS := enginepb.MVCCStats{
-		LastUpdateNanos:      1e9,
-		LiveBytes:            mKeySize + mValSize + vKeySize + vValSize, // 2+(46[+2])+12+(10[+7]) = 68[+2][+7]
-		LiveCount:            1,
-		KeyBytes:             mKeySize + vKeySize, // 2+12 =14
-		KeyCount:             1,
-		ValBytes:             mValSize + vValSize, // (46[+2])+(10[+7]) = 54[+2][+7]
-		ValCount:             1,
-		IntentCount:          1,
-		SeparatedIntentCount: 1,
-		IntentBytes:          vKeySize + vValSize, // 12+(10[+7]) = 22[+7]
-		GCBytesAge:           0,
+		LastUpdateNanos: 1e9,
+		LiveBytes:       mKeySize + mValSize + vKeySize + vValSize, // 2+(46[+2])+12+(10[+7]) = 68[+2][+7]
+		LiveCount:       1,
+		KeyBytes:        mKeySize + vKeySize, // 2+12 =14
+		KeyCount:        1,
+		ValBytes:        mValSize + vValSize, // (46[+2])+(10[+7]) = 54[+2][+7]
+		ValCount:        1,
+		IntentCount:     1,
+		LockCount:       1,
+		IntentBytes:     vKeySize + vValSize, // 12+(10[+7]) = 22[+7]
+		GCBytesAge:      0,
 	}
 	assertEq(t, engine, "after put", aggMS, &expMS)
 
@@ -257,7 +257,7 @@ func TestMVCCStatsPutCommitMovesTimestamp(t *testing.T) {
 
 // TestMVCCStatsPutPushMovesTimestamp is similar to TestMVCCStatsPutCommitMovesTimestamp:
 // An intent is written and then re-written at a higher timestamp. This formerly messed up
-// the IntentAge computation.
+// the LockAge computation.
 func TestMVCCStatsPutPushMovesTimestamp(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -295,17 +295,17 @@ func TestMVCCStatsPutPushMovesTimestamp(t *testing.T) {
 	}
 
 	expMS := enginepb.MVCCStats{
-		LastUpdateNanos:      1e9,
-		LiveBytes:            mKeySize + mValSize + vKeySize + vValSize, // 2+(46[+2])+12+(10[+7]) = 70[+2][+7]
-		LiveCount:            1,
-		KeyBytes:             mKeySize + vKeySize, // 2+12 = 14
-		KeyCount:             1,
-		ValBytes:             mValSize + vValSize, // (46[+2])+(10[+7]) = 54[+2][+7]
-		ValCount:             1,
-		IntentAge:            0,
-		IntentCount:          1,
-		SeparatedIntentCount: 1,
-		IntentBytes:          vKeySize + vValSize, // 12+(10[+7]) = 22[+7]
+		LastUpdateNanos: 1e9,
+		LiveBytes:       mKeySize + mValSize + vKeySize + vValSize, // 2+(46[+2])+12+(10[+7]) = 70[+2][+7]
+		LiveCount:       1,
+		KeyBytes:        mKeySize + vKeySize, // 2+12 = 14
+		KeyCount:        1,
+		ValBytes:        mValSize + vValSize, // (46[+2])+(10[+7]) = 54[+2][+7]
+		ValCount:        1,
+		LockAge:         0,
+		IntentCount:     1,
+		LockCount:       1,
+		IntentBytes:     vKeySize + vValSize, // 12+(10[+7]) = 22[+7]
 	}
 	assertEq(t, engine, "after put", aggMS, &expMS)
 
@@ -339,11 +339,11 @@ func TestMVCCStatsPutPushMovesTimestamp(t *testing.T) {
 		// One versioned key counts for vKeySize.
 		KeyBytes: mKeySize + vKeySize,
 		// The intent is still there, so we see mValSize.
-		ValBytes:             mValSize + vValSize, // 54+23 = 69
-		IntentAge:            0,                   // this was once erroneously positive
-		IntentCount:          1,                   // still there
-		SeparatedIntentCount: 1,
-		IntentBytes:          vKeySize + vValSize, // still there
+		ValBytes:    mValSize + vValSize, // 54+23 = 69
+		LockAge:     0,                   // this was once erroneously positive
+		IntentCount: 1,                   // still there
+		LockCount:   1,
+		IntentBytes: vKeySize + vValSize, // still there
 	}
 
 	assertEq(t, engine, "after pushing", aggMS, &expAggMS)
@@ -410,17 +410,17 @@ func TestMVCCStatsDeleteMovesTimestamp(t *testing.T) {
 	}
 
 	expMS := enginepb.MVCCStats{
-		LastUpdateNanos:      1e9,
-		LiveBytes:            mKeySize + m1ValSize + vKeySize + vValSize, // 2+(46[+2])+12+(10[+7]) = 70[+2][+7]
-		LiveCount:            1,
-		KeyBytes:             mKeySize + vKeySize, // 2+12 = 14
-		KeyCount:             1,
-		ValBytes:             mVal1Size + vValSize, // (46[+2])+(10[+7]) = 56[+2][+7]
-		ValCount:             1,
-		IntentAge:            0,
-		IntentCount:          1,
-		SeparatedIntentCount: 1,
-		IntentBytes:          vKeySize + vValSize, // 12+(10[+7]) = 22[+7]
+		LastUpdateNanos: 1e9,
+		LiveBytes:       mKeySize + m1ValSize + vKeySize + vValSize, // 2+(46[+2])+12+(10[+7]) = 70[+2][+7]
+		LiveCount:       1,
+		KeyBytes:        mKeySize + vKeySize, // 2+12 = 14
+		KeyCount:        1,
+		ValBytes:        mVal1Size + vValSize, // (46[+2])+(10[+7]) = 56[+2][+7]
+		ValCount:        1,
+		LockAge:         0,
+		IntentCount:     1,
+		LockCount:       1,
+		IntentBytes:     vKeySize + vValSize, // 12+(10[+7]) = 22[+7]
 	}
 	assertEq(t, engine, "after put", aggMS, &expMS)
 
@@ -468,12 +468,12 @@ func TestMVCCStatsDeleteMovesTimestamp(t *testing.T) {
 		// One versioned key counts for vKeySize.
 		KeyBytes: mKeySize + vKeySize,
 		// The intent is still there, but this time with mVal2Size, and a zero vValSize.
-		ValBytes:             m2ValSize + vVal2Size,
-		IntentAge:            0,
-		IntentCount:          1, // still there
-		SeparatedIntentCount: 1,
-		IntentBytes:          vKeySize + vVal2Size, // still there, but now without vValSize
-		GCBytesAge:           0,                    // this was once erroneously negative
+		ValBytes:    m2ValSize + vVal2Size,
+		LockAge:     0,
+		IntentCount: 1, // still there
+		LockCount:   1,
+		IntentBytes: vKeySize + vVal2Size, // still there, but now without vValSize
+		GCBytesAge:  0,                    // this was once erroneously negative
 	}
 
 	assertEq(t, engine, "after deleting", aggMS, &expAggMS)
@@ -528,18 +528,18 @@ func TestMVCCStatsPutMovesDeletionTimestamp(t *testing.T) {
 	}
 
 	expMS := enginepb.MVCCStats{
-		LastUpdateNanos:      1e9,
-		LiveBytes:            0,
-		LiveCount:            0,
-		KeyBytes:             mKeySize + vKeySize, // 2 + 12 = 24
-		KeyCount:             1,
-		ValBytes:             mVal1Size + vVal1Size, // 46[+2] [+7]
-		ValCount:             1,
-		IntentAge:            0,
-		IntentCount:          1,
-		SeparatedIntentCount: 1,
-		IntentBytes:          vKeySize + vVal1Size, // 12 [+7]
-		GCBytesAge:           0,
+		LastUpdateNanos: 1e9,
+		LiveBytes:       0,
+		LiveCount:       0,
+		KeyBytes:        mKeySize + vKeySize, // 2 + 12 = 24
+		KeyCount:        1,
+		ValBytes:        mVal1Size + vVal1Size, // 46[+2] [+7]
+		ValCount:        1,
+		LockAge:         0,
+		IntentCount:     1,
+		LockCount:       1,
+		IntentBytes:     vKeySize + vVal1Size, // 12 [+7]
+		GCBytesAge:      0,
 	}
 	assertEq(t, engine, "after delete", aggMS, &expMS)
 
@@ -591,12 +591,12 @@ func TestMVCCStatsPutMovesDeletionTimestamp(t *testing.T) {
 		// One versioned key counts for vKeySize.
 		KeyBytes: mKeySize + vKeySize,
 		// The intent is still there, but this time with mVal2Size, and a zero vValSize.
-		ValBytes:             vVal2Size + mVal2Size, // (10[+7])+46 = 56[+7]
-		IntentAge:            0,
-		IntentCount:          1, // still there
-		SeparatedIntentCount: 1,
-		IntentBytes:          vKeySize + vVal2Size, // still there, now bigger
-		GCBytesAge:           0,                    // this was once erroneously negative
+		ValBytes:    vVal2Size + mVal2Size, // (10[+7])+46 = 56[+7]
+		LockAge:     0,
+		IntentCount: 1, // still there
+		LockCount:   1,
+		IntentBytes: vKeySize + vVal2Size, // still there, now bigger
+		GCBytesAge:  0,                    // this was once erroneously negative
 	}
 
 	assertEq(t, engine, "after put", aggMS, &expAggMS)
@@ -668,14 +668,14 @@ func TestMVCCStatsDelDelCommitMovesTimestamp(t *testing.T) {
 	mValSize += 2
 
 	expMS = enginepb.MVCCStats{
-		LastUpdateNanos:      2e9,
-		KeyBytes:             mKeySize + 2*vKeySize, // 2+2*12 = 26
-		KeyCount:             1,
-		ValBytes:             mValSize + 2*vValSize, // 46[+2] [+7]
-		ValCount:             2,
-		IntentCount:          1,
-		SeparatedIntentCount: 1,
-		IntentBytes:          vKeySize + vValSize,
+		LastUpdateNanos: 2e9,
+		KeyBytes:        mKeySize + 2*vKeySize, // 2+2*12 = 26
+		KeyCount:        1,
+		ValBytes:        mValSize + 2*vValSize, // 46[+2] [+7]
+		ValCount:        2,
+		IntentCount:     1,
+		LockCount:       1,
+		IntentBytes:     vKeySize + vValSize,
 		// The original non-transactional write (at 1s) has now aged one second.
 		GCBytesAge: 1 * (vKeySize + vValSize),
 	}
@@ -830,14 +830,14 @@ func TestMVCCStatsPutDelPutMovesTimestamp(t *testing.T) {
 	}
 
 	expMS = enginepb.MVCCStats{
-		LastUpdateNanos:      2e9,
-		KeyBytes:             mKeySize + 2*vKeySize, // 2+2*12 = 26
-		KeyCount:             1,
-		ValBytes:             mValSize + vValSize + vDelSize, // 46[+2]+10[+7] = 56[+2][+7]
-		ValCount:             2,
-		IntentCount:          1,
-		SeparatedIntentCount: 1,
-		IntentBytes:          vKeySize + vDelSize, // 12[+7]
+		LastUpdateNanos: 2e9,
+		KeyBytes:        mKeySize + 2*vKeySize, // 2+2*12 = 26
+		KeyCount:        1,
+		ValBytes:        mValSize + vValSize + vDelSize, // 46[+2]+10[+7] = 56[+2][+7]
+		ValCount:        2,
+		IntentCount:     1,
+		LockCount:       1,
+		IntentBytes:     vKeySize + vDelSize, // 12[+7]
 		// The original non-transactional write becomes non-live at 2s, so no age
 		// is accrued yet.
 		GCBytesAge: 0,
@@ -925,16 +925,16 @@ func TestMVCCStatsPutDelPutMovesTimestamp(t *testing.T) {
 		require.EqualValues(t, expMVal2Size, mVal2SizeWithHistory)
 
 		expAggMS := enginepb.MVCCStats{
-			LastUpdateNanos:      3e9,
-			KeyBytes:             mKeySize + 2*vKeySize, // 2+2*12 = 26
-			KeyCount:             1,
-			ValBytes:             mVal2SizeWithHistory + vValSize + vVal2Size,
-			ValCount:             2,
-			LiveCount:            1,
-			LiveBytes:            mKeySize + mVal2SizeWithHistory + vKeySize + vVal2Size,
-			IntentCount:          1,
-			SeparatedIntentCount: 1,
-			IntentBytes:          vKeySize + vVal2Size,
+			LastUpdateNanos: 3e9,
+			KeyBytes:        mKeySize + 2*vKeySize, // 2+2*12 = 26
+			KeyCount:        1,
+			ValBytes:        mVal2SizeWithHistory + vValSize + vVal2Size,
+			ValCount:        2,
+			LiveCount:       1,
+			LiveBytes:       mKeySize + mVal2SizeWithHistory + vKeySize + vVal2Size,
+			IntentCount:     1,
+			LockCount:       1,
+			IntentBytes:     vKeySize + vVal2Size,
 			// The original write was previously non-live at 2s because that's where the
 			// intent originally lived. But the intent has moved to 3s, and so has the
 			// moment in time at which the shadowed put became non-live; it's now 3s as
@@ -1063,16 +1063,16 @@ func TestMVCCStatsPutIntentTimestampNotPutTimestamp(t *testing.T) {
 	}
 
 	expMS := enginepb.MVCCStats{
-		LastUpdateNanos:      2e9 + 1,
-		LiveBytes:            mKeySize + m1ValSize + vKeySize + vValSize, // 2+(46[+2])+12+(10[+7]) = 68[+2][+7]
-		LiveCount:            1,
-		KeyBytes:             mKeySize + vKeySize, // 14
-		KeyCount:             1,
-		ValBytes:             m1ValSize + vValSize, // (46[+2])+(10[+7]) = 54[+2][+7]
-		ValCount:             1,
-		IntentCount:          1,
-		SeparatedIntentCount: 1,
-		IntentBytes:          vKeySize + vValSize, // 12+(10[+7]) = 22[+7]
+		LastUpdateNanos: 2e9 + 1,
+		LiveBytes:       mKeySize + m1ValSize + vKeySize + vValSize, // 2+(46[+2])+12+(10[+7]) = 68[+2][+7]
+		LiveCount:       1,
+		KeyBytes:        mKeySize + vKeySize, // 14
+		KeyCount:        1,
+		ValBytes:        m1ValSize + vValSize, // (46[+2])+(10[+7]) = 54[+2][+7]
+		ValCount:        1,
+		IntentCount:     1,
+		LockCount:       1,
+		IntentBytes:     vKeySize + vValSize, // 12+(10[+7]) = 22[+7]
 	}
 	assertEq(t, engine, "after first put", aggMS, &expMS)
 
@@ -1103,18 +1103,18 @@ func TestMVCCStatsPutIntentTimestampNotPutTimestamp(t *testing.T) {
 	expAggMS := enginepb.MVCCStats{
 		// Even though we tried to put a new intent at an older timestamp, it
 		// will have been written at 2E9+1, so the age will be 0.
-		IntentAge: 0,
+		LockAge: 0,
 
-		LastUpdateNanos:      2e9 + 1,
-		LiveBytes:            mKeySize + m2ValSize + vKeySize + vValSize, // 2+(46[+7])+12+(10[+7]) = 70[+14]
-		LiveCount:            1,
-		KeyBytes:             mKeySize + vKeySize, // 14
-		KeyCount:             1,
-		ValBytes:             m2ValSize + vValSize, // (46[+7])+(10[+7]) = 56[+14]
-		ValCount:             1,
-		IntentCount:          1,
-		SeparatedIntentCount: 1,
-		IntentBytes:          vKeySize + vValSize, // 12+(10[+7]) = 22[+7]
+		LastUpdateNanos: 2e9 + 1,
+		LiveBytes:       mKeySize + m2ValSize + vKeySize + vValSize, // 2+(46[+7])+12+(10[+7]) = 70[+14]
+		LiveCount:       1,
+		KeyBytes:        mKeySize + vKeySize, // 14
+		KeyCount:        1,
+		ValBytes:        m2ValSize + vValSize, // (46[+7])+(10[+7]) = 56[+14]
+		ValCount:        1,
+		IntentCount:     1,
+		LockCount:       1,
+		IntentBytes:     vKeySize + vValSize, // 12+(10[+7]) = 22[+7]
 	}
 
 	assertEq(t, engine, "after second put", aggMS, &expAggMS)

--- a/pkg/storage/mvcc_test.go
+++ b/pkg/storage/mvcc_test.go
@@ -114,26 +114,26 @@ func TestMVCCStatsAddSubForward(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	goldMS := enginepb.MVCCStats{
-		ContainsEstimates:    1,
-		KeyBytes:             1,
-		KeyCount:             1,
-		ValBytes:             1,
-		ValCount:             1,
-		IntentBytes:          1,
-		IntentCount:          1,
-		RangeKeyCount:        1,
-		RangeKeyBytes:        1,
-		RangeValCount:        1,
-		RangeValBytes:        1,
-		SeparatedIntentCount: 1,
-		IntentAge:            1,
-		GCBytesAge:           1,
-		LiveBytes:            1,
-		LiveCount:            1,
-		SysBytes:             1,
-		SysCount:             1,
-		LastUpdateNanos:      1,
-		AbortSpanBytes:       1,
+		ContainsEstimates: 1,
+		KeyBytes:          1,
+		KeyCount:          1,
+		ValBytes:          1,
+		ValCount:          1,
+		IntentBytes:       1,
+		IntentCount:       1,
+		RangeKeyCount:     1,
+		RangeKeyBytes:     1,
+		RangeValCount:     1,
+		RangeValBytes:     1,
+		LockCount:         1,
+		LockAge:           1,
+		GCBytesAge:        1,
+		LiveBytes:         1,
+		LiveCount:         1,
+		SysBytes:          1,
+		SysCount:          1,
+		LastUpdateNanos:   1,
+		AbortSpanBytes:    1,
 	}
 	require.NoError(t, zerofields.NoZeroField(&goldMS))
 
@@ -170,7 +170,7 @@ func TestMVCCStatsAddSubForward(t *testing.T) {
 		delta.AgeTo(ns)
 		require.GreaterOrEqual(t, delta.LastUpdateNanos, ns, "LastUpdateNanos")
 		shouldAge := ns/1e9-oldDelta.LastUpdateNanos/1e9 > 0
-		didAge := delta.IntentAge != oldDelta.IntentAge &&
+		didAge := delta.LockAge != oldDelta.LockAge &&
 			delta.GCBytesAge != oldDelta.GCBytesAge
 		require.Equal(t, shouldAge, didAge)
 	}
@@ -178,13 +178,13 @@ func TestMVCCStatsAddSubForward(t *testing.T) {
 	expDelta := goldDelta
 	expDelta.LastUpdateNanos = 2e9 - 1
 	expDelta.GCBytesAge = 42
-	expDelta.IntentAge = 11
+	expDelta.LockAge = 11
 	require.Equal(t, expDelta, delta)
 
 	delta.AgeTo(2e9)
 	expDelta.LastUpdateNanos = 2e9
 	expDelta.GCBytesAge += 42
-	expDelta.IntentAge += 11
+	expDelta.LockAge += 11
 	require.Equal(t, expDelta, delta)
 
 	{
@@ -196,7 +196,7 @@ func TestMVCCStatsAddSubForward(t *testing.T) {
 		tmpDelta.AgeTo(2e9 - 1)
 		expDelta.LastUpdateNanos = 2e9 - 1
 		expDelta.GCBytesAge -= 42
-		expDelta.IntentAge -= 11
+		expDelta.LockAge -= 11
 		require.Equal(t, expDelta, tmpDelta)
 	}
 
@@ -214,7 +214,7 @@ func TestMVCCStatsAddSubForward(t *testing.T) {
 	expMS := goldMS
 	expMS.Add(goldMS)
 	expMS.LastUpdateNanos = 10e9 + 1
-	expMS.IntentAge += 9      // from aging 9 ticks from 2E9-1 to 10E9+1
+	expMS.LockAge += 9        // from aging 9 ticks from 2E9-1 to 10E9+1
 	expMS.GCBytesAge += 3 * 9 // ditto
 
 	for i := range mss[:1] {
@@ -232,7 +232,7 @@ func TestMVCCStatsAddSubForward(t *testing.T) {
 
 	exp.LastUpdateNanos = 2e9
 	exp.GCBytesAge = -7
-	exp.IntentAge = -3
+	exp.LockAge = -3
 	require.Equal(t, exp, neg)
 }
 

--- a/pkg/storage/testdata/mvcc_histories/ambiguous_writes
+++ b/pkg/storage/testdata/mvcc_histories/ambiguous_writes
@@ -16,12 +16,12 @@ with t=A k=a
   put v=first
 ----
 >> put v=first t=A k=a
-stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+61 live_count=+1 live_bytes=+75 intent_count=+1 intent_bytes=+22 separated_intent_count=+1 intent_age=+89
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+61 live_count=+1 live_bytes=+75 intent_count=+1 intent_bytes=+22 lock_count=+1 lock_age=+89
 >> at end:
 txn: "A" meta={id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=11.000000000,0 wto=false gul=0,0
 meta: "a"/0,0 -> txn={id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0} ts=11.000000000,0 del=false klen=12 vlen=10 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "a"/11.000000000,0 -> /BYTES/first
-stats: key_count=1 key_bytes=14 val_count=1 val_bytes=61 live_count=1 live_bytes=75 intent_count=1 intent_bytes=22 separated_intent_count=1 intent_age=89
+stats: key_count=1 key_bytes=14 val_count=1 val_bytes=61 live_count=1 live_bytes=75 intent_count=1 intent_bytes=22 lock_count=1 lock_age=89
 
 run stats ok
 with t=A k=a
@@ -35,7 +35,7 @@ stats: no change
 txn: "A" meta={id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=12.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=11.000000000,0 wto=false gul=0,0
 meta: "a"/0,0 -> txn={id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0} ts=11.000000000,0 del=false klen=12 vlen=10 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "a"/11.000000000,0 -> /BYTES/first
-stats: key_count=1 key_bytes=14 val_count=1 val_bytes=61 live_count=1 live_bytes=75 intent_count=1 intent_bytes=22 separated_intent_count=1 intent_age=89
+stats: key_count=1 key_bytes=14 val_count=1 val_bytes=61 live_count=1 live_bytes=75 intent_count=1 intent_bytes=22 lock_count=1 lock_age=89
 
 run ok
 with t=A k=a
@@ -53,13 +53,13 @@ with t=B k=k
   initput k=k ts=0,1 v=k1 ambiguousReplay
 ----
 >> initput k=k ts=0,1 v=k1 ambiguousReplay t=B k=k
-stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+50 live_count=+1 live_bytes=+64 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+100
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+50 live_count=+1 live_bytes=+64 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+100
 >> at end:
 txn: "B" meta={id=00000002 key="k" iso=Serializable pri=0.00000000 epo=0 ts=0,1 min=0,0 seq=0} lock=true stat=PENDING rts=0,1 wto=false gul=0,0
 data: "a"/12.000000000,0 -> {localTs=11.000000000,0}/BYTES/first
 meta: "k"/0,0 -> txn={id=00000002 key="k" iso=Serializable pri=0.00000000 epo=0 ts=0,1 min=0,0 seq=0} ts=0,1 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k"/0,1 -> /BYTES/k1
-stats: key_count=2 key_bytes=28 val_count=2 val_bytes=73 live_count=2 live_bytes=101 intent_count=1 intent_bytes=19 separated_intent_count=1 intent_age=100
+stats: key_count=2 key_bytes=28 val_count=2 val_bytes=73 live_count=2 live_bytes=101 intent_count=1 intent_bytes=19 lock_count=1 lock_age=100
 
 run ok
 with t=B k=k
@@ -78,14 +78,14 @@ with t=C k=k
   cput v=k2 cond=k1
 ----
 >> cput v=k2 cond=k1 t=C k=k
-stats: key_bytes=+12 val_count=+1 val_bytes=+50 live_bytes=+43 gc_bytes_age=+1900 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+100
+stats: key_bytes=+12 val_count=+1 val_bytes=+50 live_bytes=+43 gc_bytes_age=+1900 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+100
 >> at end:
 txn: "C" meta={id=00000003 key="k" iso=Serializable pri=0.00000000 epo=0 ts=0,2 min=0,0 seq=0} lock=true stat=PENDING rts=0,2 wto=false gul=0,0
 data: "a"/12.000000000,0 -> {localTs=11.000000000,0}/BYTES/first
 meta: "k"/0,0 -> txn={id=00000003 key="k" iso=Serializable pri=0.00000000 epo=0 ts=0,2 min=0,0 seq=0} ts=0,2 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k"/0,2 -> /BYTES/k2
 data: "k"/0,1 -> /BYTES/k1
-stats: key_count=2 key_bytes=40 val_count=3 val_bytes=80 live_count=2 live_bytes=101 gc_bytes_age=1900 intent_count=1 intent_bytes=19 separated_intent_count=1 intent_age=100
+stats: key_count=2 key_bytes=40 val_count=3 val_bytes=80 live_count=2 live_bytes=101 gc_bytes_age=1900 intent_count=1 intent_bytes=19 lock_count=1 lock_age=100
 
 run stats ok
 with t=C k=k
@@ -98,7 +98,7 @@ data: "a"/12.000000000,0 -> {localTs=11.000000000,0}/BYTES/first
 meta: "k"/0,0 -> txn={id=00000003 key="k" iso=Serializable pri=0.00000000 epo=0 ts=0,2 min=0,0 seq=0} ts=0,2 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k"/0,2 -> /BYTES/k2
 data: "k"/0,1 -> /BYTES/k1
-stats: key_count=2 key_bytes=40 val_count=3 val_bytes=80 live_count=2 live_bytes=101 gc_bytes_age=1900 intent_count=1 intent_bytes=19 separated_intent_count=1 intent_age=100
+stats: key_count=2 key_bytes=40 val_count=3 val_bytes=80 live_count=2 live_bytes=101 gc_bytes_age=1900 intent_count=1 intent_bytes=19 lock_count=1 lock_age=100
 
 run ok
 with t=C k=k
@@ -118,7 +118,7 @@ with t=D k=k
   put v=k3
 ----
 >> put v=k3 t=D k=k
-stats: key_bytes=+12 val_count=+1 val_bytes=+58 live_bytes=+51 gc_bytes_age=+1843 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+97
+stats: key_bytes=+12 val_count=+1 val_bytes=+58 live_bytes=+51 gc_bytes_age=+1843 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+97
 >> at end:
 txn: "D" meta={id=00000004 key="k" iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=3.000000000,0 wto=false gul=0,0
 data: "a"/12.000000000,0 -> {localTs=11.000000000,0}/BYTES/first
@@ -126,7 +126,7 @@ meta: "k"/0,0 -> txn={id=00000004 key="k" iso=Serializable pri=0.00000000 epo=0 
 data: "k"/3.000000000,0 -> /BYTES/k3
 data: "k"/0,2 -> /BYTES/k2
 data: "k"/0,1 -> /BYTES/k1
-stats: key_count=2 key_bytes=52 val_count=4 val_bytes=95 live_count=2 live_bytes=109 gc_bytes_age=3743 intent_count=1 intent_bytes=19 separated_intent_count=1 intent_age=97
+stats: key_count=2 key_bytes=52 val_count=4 val_bytes=95 live_count=2 live_bytes=109 gc_bytes_age=3743 intent_count=1 intent_bytes=19 lock_count=1 lock_age=97
 
 run stats error
 with t=D k=k
@@ -142,7 +142,7 @@ meta: "k"/0,0 -> txn={id=00000004 key="k" iso=Serializable pri=0.00000000 epo=0 
 data: "k"/3.000000000,0 -> /BYTES/k3
 data: "k"/0,2 -> /BYTES/k2
 data: "k"/0,1 -> /BYTES/k1
-stats: key_count=2 key_bytes=52 val_count=4 val_bytes=95 live_count=2 live_bytes=109 gc_bytes_age=3743 intent_count=1 intent_bytes=19 separated_intent_count=1 intent_age=97
+stats: key_count=2 key_bytes=52 val_count=4 val_bytes=95 live_count=2 live_bytes=109 gc_bytes_age=3743 intent_count=1 intent_bytes=19 lock_count=1 lock_age=97
 error: (*withstack.withStack:) transaction 00000004-0000-0000-0000-000000000000 with sequence 0 prevented from changing write timestamp from 3.000000000,0 to 3.000000000,1 due to ambiguous replay protection
 
 run ok
@@ -207,7 +207,7 @@ with t=F k=k
   put v=k5
 ----
 >> put v=k5 t=F k=k
-stats: key_bytes=+12 val_count=+1 val_bytes=+58 live_count=+1 live_bytes=+72 gc_bytes_age=-192 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+95
+stats: key_bytes=+12 val_count=+1 val_bytes=+58 live_count=+1 live_bytes=+72 gc_bytes_age=-192 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+95
 >> at end:
 txn: "F" meta={id=00000006 key="k" iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=5.000000000,0 wto=false gul=0,0
 data: "a"/12.000000000,0 -> {localTs=11.000000000,0}/BYTES/first
@@ -217,7 +217,7 @@ data: "k"/4.000000000,0 -> /<empty>
 data: "k"/3.000000000,0 -> /BYTES/k3
 data: "k"/0,2 -> /BYTES/k2
 data: "k"/0,1 -> /BYTES/k1
-stats: key_count=2 key_bytes=76 val_count=6 val_bytes=102 live_count=2 live_bytes=109 gc_bytes_age=6719 intent_count=1 intent_bytes=19 separated_intent_count=1 intent_age=95
+stats: key_count=2 key_bytes=76 val_count=6 val_bytes=102 live_count=2 live_bytes=109 gc_bytes_age=6719 intent_count=1 intent_bytes=19 lock_count=1 lock_age=95
 
 run stats ok
 with t=F k=k
@@ -237,7 +237,7 @@ data: "k"/4.000000000,0 -> /<empty>
 data: "k"/3.000000000,0 -> /BYTES/k3
 data: "k"/0,2 -> /BYTES/k2
 data: "k"/0,1 -> /BYTES/k1
-stats: key_count=2 key_bytes=76 val_count=6 val_bytes=108 live_count=1 live_bytes=37 gc_bytes_age=14129 intent_count=1 intent_bytes=12 separated_intent_count=1 intent_age=95
+stats: key_count=2 key_bytes=76 val_count=6 val_bytes=108 live_count=1 live_bytes=37 gc_bytes_age=14129 intent_count=1 intent_bytes=12 lock_count=1 lock_age=95
 
 run stats ok
 with t=F k=k
@@ -256,7 +256,7 @@ data: "k"/4.000000000,0 -> /<empty>
 data: "k"/3.000000000,0 -> /BYTES/k3
 data: "k"/0,2 -> /BYTES/k2
 data: "k"/0,1 -> /BYTES/k1
-stats: key_count=2 key_bytes=76 val_count=6 val_bytes=108 live_count=1 live_bytes=37 gc_bytes_age=14129 intent_count=1 intent_bytes=12 separated_intent_count=1 intent_age=95
+stats: key_count=2 key_bytes=76 val_count=6 val_bytes=108 live_count=1 live_bytes=37 gc_bytes_age=14129 intent_count=1 intent_bytes=12 lock_count=1 lock_age=95
 
 run stats error
 with t=F k=k
@@ -275,7 +275,7 @@ data: "k"/4.000000000,0 -> /<empty>
 data: "k"/3.000000000,0 -> /BYTES/k3
 data: "k"/0,2 -> /BYTES/k2
 data: "k"/0,1 -> /BYTES/k1
-stats: key_count=2 key_bytes=76 val_count=6 val_bytes=108 live_count=1 live_bytes=37 gc_bytes_age=14129 intent_count=1 intent_bytes=12 separated_intent_count=1 intent_age=95
+stats: key_count=2 key_bytes=76 val_count=6 val_bytes=108 live_count=1 live_bytes=37 gc_bytes_age=14129 intent_count=1 intent_bytes=12 lock_count=1 lock_age=95
 error: (*withstack.withStack:) transaction 00000006-0000-0000-0000-000000000000 with sequence 1 prevented from changing write timestamp from 5.000000000,0 to 5.000000000,1 due to ambiguous replay protection
 
 run ok
@@ -312,7 +312,7 @@ with t=G k=k
 del_range: "a"-"z" -> deleted 2 key(s)
 del_range: returned "a"
 del_range: returned "k"
-stats: key_bytes=+24 val_count=+2 val_bytes=+106 live_count=-2 live_bytes=-58 gc_bytes_age=+16544 intent_count=+2 intent_bytes=+24 separated_intent_count=+2 intent_age=+176
+stats: key_bytes=+24 val_count=+2 val_bytes=+106 live_count=-2 live_bytes=-58 gc_bytes_age=+16544 intent_count=+2 intent_bytes=+24 lock_count=+2 lock_age=+176
 >> at end:
 txn: "G" meta={id=00000007 key="k" iso=Serializable pri=0.00000000 epo=0 ts=12.000000000,1 min=0,0 seq=0} lock=true stat=PENDING rts=12.000000000,1 wto=false gul=0,0
 meta: "a"/0,0 -> txn={id=00000007 key="k" iso=Serializable pri=0.00000000 epo=0 ts=12.000000000,1 min=0,0 seq=0} ts=12.000000000,1 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
@@ -325,7 +325,7 @@ data: "k"/4.000000000,0 -> /<empty>
 data: "k"/3.000000000,0 -> /BYTES/k3
 data: "k"/0,2 -> /BYTES/k2
 data: "k"/0,1 -> /BYTES/k1
-stats: key_count=2 key_bytes=100 val_count=8 val_bytes=157 gc_bytes_age=23263 intent_count=2 intent_bytes=24 separated_intent_count=2 intent_age=176
+stats: key_count=2 key_bytes=100 val_count=8 val_bytes=157 gc_bytes_age=23263 intent_count=2 intent_bytes=24 lock_count=2 lock_age=176
 
 run stats ok
 with t=G k=k
@@ -350,7 +350,7 @@ data: "k"/4.000000000,0 -> /<empty>
 data: "k"/3.000000000,0 -> /BYTES/k3
 data: "k"/0,2 -> /BYTES/k2
 data: "k"/0,1 -> /BYTES/k1
-stats: key_count=2 key_bytes=100 val_count=8 val_bytes=157 gc_bytes_age=23263 intent_count=2 intent_bytes=24 separated_intent_count=2 intent_age=176
+stats: key_count=2 key_bytes=100 val_count=8 val_bytes=157 gc_bytes_age=23263 intent_count=2 intent_bytes=24 lock_count=2 lock_age=176
 
 run stats error
 with t=G k=k
@@ -372,7 +372,7 @@ data: "k"/4.000000000,0 -> /<empty>
 data: "k"/3.000000000,0 -> /BYTES/k3
 data: "k"/0,2 -> /BYTES/k2
 data: "k"/0,1 -> /BYTES/k1
-stats: key_count=2 key_bytes=100 val_count=8 val_bytes=157 gc_bytes_age=23263 intent_count=2 intent_bytes=24 separated_intent_count=2 intent_age=176
+stats: key_count=2 key_bytes=100 val_count=8 val_bytes=157 gc_bytes_age=23263 intent_count=2 intent_bytes=24 lock_count=2 lock_age=176
 error: (*withstack.withStack:) transaction 00000007-0000-0000-0000-000000000000 with sequence 0 prevented from changing write timestamp from 12.000000000,1 to 12.000000000,3 due to ambiguous replay protection
 
 run ok

--- a/pkg/storage/testdata/mvcc_histories/conditional_put_with_txn_enable_separated
+++ b/pkg/storage/testdata/mvcc_histories/conditional_put_with_txn_enable_separated
@@ -12,12 +12,12 @@ with t=A
   cput k=k v=v
 ----
 >> cput k=k v=v t=A
-stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+58 live_count=+1 live_bytes=+72 intent_count=+1 intent_bytes=+18 separated_intent_count=+1 intent_age=-23
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+58 live_count=+1 live_bytes=+72 intent_count=+1 intent_bytes=+18 lock_count=+1 lock_age=-23
 >> at end:
 txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=123.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=123.000000000,0 wto=false gul=0,0
 meta: "k"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=123.000000000,0 min=0,0 seq=1} ts=123.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k"/123.000000000,0 -> /BYTES/v
-stats: key_count=1 key_bytes=14 val_count=1 val_bytes=58 live_count=1 live_bytes=72 intent_count=1 intent_bytes=18 separated_intent_count=1 intent_age=-23
+stats: key_count=1 key_bytes=14 val_count=1 val_bytes=58 live_count=1 live_bytes=72 intent_count=1 intent_bytes=18 lock_count=1 lock_age=-23
 
 # Now, overwrite value1 with value2 from same txn; should see value1
 # as pre-existing value.
@@ -33,7 +33,7 @@ stats: val_bytes=+11 live_bytes=+11 intent_bytes=+1
 txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=123.000000000,0 min=0,0 seq=2} lock=true stat=PENDING rts=123.000000000,0 wto=false gul=0,0
 meta: "k"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=123.000000000,0 min=0,0 seq=2} ts=123.000000000,0 del=false klen=12 vlen=7 ih={{1 /BYTES/v}} mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "k"/123.000000000,0 -> /BYTES/v2
-stats: key_count=1 key_bytes=14 val_count=1 val_bytes=69 live_count=1 live_bytes=83 intent_count=1 intent_bytes=19 separated_intent_count=1 intent_age=-23
+stats: key_count=1 key_bytes=14 val_count=1 val_bytes=69 live_count=1 live_bytes=83 intent_count=1 intent_bytes=19 lock_count=1 lock_age=-23
 
 # Writing value3 from a new epoch should see nil again.
 
@@ -49,7 +49,7 @@ stats: val_bytes=-10 live_bytes=-10
 txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=123.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=123.000000000,0 wto=false gul=0,0
 meta: "k"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=123.000000000,0 min=0,0 seq=1} ts=123.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "k"/123.000000000,0 -> /BYTES/v3
-stats: key_count=1 key_bytes=14 val_count=1 val_bytes=59 live_count=1 live_bytes=73 intent_count=1 intent_bytes=19 separated_intent_count=1 intent_age=-23
+stats: key_count=1 key_bytes=14 val_count=1 val_bytes=59 live_count=1 live_bytes=73 intent_count=1 intent_bytes=19 lock_count=1 lock_age=-23
 
 # Commit value3 at a later timestamp.
 
@@ -60,7 +60,7 @@ with t=A
   txn_remove
 ----
 >> resolve_intent k=k t=A
-stats: val_bytes=-38 live_bytes=-38 intent_count=-1 intent_bytes=-19 separated_intent_count=-1 intent_age=+23
+stats: val_bytes=-38 live_bytes=-38 intent_count=-1 intent_bytes=-19 lock_count=-1 lock_age=+23
 >> at end:
 data: "k"/124.000000000,0 -> {localTs=123.000000000,0}/BYTES/v3
 stats: key_count=1 key_bytes=14 val_count=1 val_bytes=21 live_count=1 live_bytes=35
@@ -99,13 +99,13 @@ with t=A
 >> put k=c v=value ts=1
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+10 live_count=+1 live_bytes=+24
 >> cput k=c v=cput cond=value t=A
-stats: key_bytes=+12 val_count=+1 val_bytes=+59 live_bytes=+49 gc_bytes_age=+2156 intent_count=+1 intent_bytes=+21 separated_intent_count=+1 intent_age=+98
+stats: key_bytes=+12 val_count=+1 val_bytes=+59 live_bytes=+49 gc_bytes_age=+2156 intent_count=+1 intent_bytes=+21 lock_count=+1 lock_age=+98
 >> at end:
 txn: "A" meta={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=2.000000000,0 wto=false gul=0,0
 meta: "c"/0,0 -> txn={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=1} ts=2.000000000,0 del=false klen=12 vlen=9 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "c"/2.000000000,0 -> /BYTES/cput
 data: "c"/1.000000000,0 -> /BYTES/value
-stats: key_count=1 key_bytes=26 val_count=2 val_bytes=69 live_count=1 live_bytes=73 gc_bytes_age=2156 intent_count=1 intent_bytes=21 separated_intent_count=1 intent_age=98
+stats: key_count=1 key_bytes=26 val_count=2 val_bytes=69 live_count=1 live_bytes=73 gc_bytes_age=2156 intent_count=1 intent_bytes=21 lock_count=1 lock_age=98
 
 # Restart and retry cput. It should succeed.
 
@@ -123,5 +123,5 @@ txn: "A" meta={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=3.0
 meta: "c"/0,0 -> txn={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=3.000000000,0 min=0,0 seq=1} ts=3.000000000,0 del=false klen=12 vlen=9 mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "c"/3.000000000,0 -> /BYTES/cput
 data: "c"/1.000000000,0 -> /BYTES/value
-stats: gc_bytes_age=-22 intent_age=-1
-stats: key_count=1 key_bytes=26 val_count=2 val_bytes=69 live_count=1 live_bytes=73 gc_bytes_age=2134 intent_count=1 intent_bytes=21 separated_intent_count=1 intent_age=97
+stats: gc_bytes_age=-22 lock_age=-1
+stats: key_count=1 key_bytes=26 val_count=2 val_bytes=69 live_count=1 live_bytes=73 gc_bytes_age=2134 intent_count=1 intent_bytes=21 lock_count=1 lock_age=97

--- a/pkg/storage/testdata/mvcc_histories/delete_range
+++ b/pkg/storage/testdata/mvcc_histories/delete_range
@@ -59,7 +59,7 @@ with t=A
 del_range: "b"-"c" -> deleted 2 key(s)
 del_range: returned "b"
 del_range: returned "b/123"
-stats: key_bytes=+24 val_count=+2 val_bytes=+100 live_count=-2 live_bytes=-48 gc_bytes_age=+9288 intent_count=+2 intent_bytes=+24 separated_intent_count=+2 intent_age=+108
+stats: key_bytes=+24 val_count=+2 val_bytes=+100 live_count=-2 live_bytes=-48 gc_bytes_age=+9288 intent_count=+2 intent_bytes=+24 lock_count=+2 lock_age=+108
 >> at end:
 data: "a"/45.000000000,0 -> /<empty>
 data: "a"/44.000000000,0 -> /BYTES/abc
@@ -75,7 +75,7 @@ data: "c"/44.000000000,0 -> /BYTES/abc
 data: "c/123"/44.000000000,0 -> /BYTES/abc
 data: "d"/44.000000000,0 -> /BYTES/abc
 data: "d/123"/44.000000000,0 -> /BYTES/abc
-stats: key_count=8 key_bytes=176 val_count=12 val_bytes=164 live_count=4 live_bytes=96 gc_bytes_age=13248 intent_count=2 intent_bytes=24 separated_intent_count=2 intent_age=108
+stats: key_count=8 key_bytes=176 val_count=12 val_bytes=164 live_count=4 live_bytes=96 gc_bytes_age=13248 intent_count=2 intent_bytes=24 lock_count=2 lock_age=108
 
 
 # A limited non-txn that deletes a range of keys.
@@ -108,7 +108,7 @@ data: "c/123"/47.000000000,0 -> /<empty>
 data: "c/123"/44.000000000,0 -> /BYTES/abc
 data: "d"/44.000000000,0 -> /BYTES/abc
 data: "d/123"/44.000000000,0 -> /BYTES/abc
-stats: key_count=8 key_bytes=200 val_count=14 val_bytes=164 live_count=2 live_bytes=48 gc_bytes_age=17064 intent_count=2 intent_bytes=24 separated_intent_count=2 intent_age=108
+stats: key_count=8 key_bytes=200 val_count=14 val_bytes=164 live_count=2 live_bytes=48 gc_bytes_age=17064 intent_count=2 intent_bytes=24 lock_count=2 lock_age=108
 
 
 # A txn that performs a delete range at a lower timestamp returns a WriteTooOld error.
@@ -157,7 +157,7 @@ with t=A
 del_range: "c"-"z" -> deleted 2 key(s)
 del_range: returned "d"
 del_range: returned "d/123"
-stats: key_bytes=+24 val_count=+2 val_bytes=+100 live_count=-2 live_bytes=-48 gc_bytes_age=+8944 intent_count=+2 intent_bytes=+24 separated_intent_count=+2 intent_age=+104
+stats: key_bytes=+24 val_count=+2 val_bytes=+100 live_count=-2 live_bytes=-48 gc_bytes_age=+8944 intent_count=+2 intent_bytes=+24 lock_count=+2 lock_age=+104
 >> at end:
 data: "a"/45.000000000,0 -> /<empty>
 data: "a"/44.000000000,0 -> /BYTES/abc
@@ -179,4 +179,4 @@ data: "d"/44.000000000,0 -> /BYTES/abc
 meta: "d/123"/0,0 -> txn={id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=48.000000000,0 min=0,0 seq=0} ts=48.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "d/123"/48.000000000,0 -> /<empty>
 data: "d/123"/44.000000000,0 -> /BYTES/abc
-stats: key_count=8 key_bytes=224 val_count=16 val_bytes=264 gc_bytes_age=26008 intent_count=4 intent_bytes=48 separated_intent_count=4 intent_age=212
+stats: key_count=8 key_bytes=224 val_count=16 val_bytes=264 gc_bytes_age=26008 intent_count=4 intent_bytes=48 lock_count=4 lock_age=212

--- a/pkg/storage/testdata/mvcc_histories/delete_range_predicate
+++ b/pkg/storage/testdata/mvcc_histories/delete_range_predicate
@@ -68,7 +68,7 @@ data: "g"/2.000000000,0 -> /BYTES/g2
 data: "h"/4.000000000,0 -> /BYTES/h4
 meta: "i"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "i"/7.000000000,0 -> /BYTES/i7
-stats: key_count=8 key_bytes=160 val_count=12 val_bytes=111 range_key_count=2 range_key_bytes=27 range_val_count=2 live_count=3 live_bytes=111 gc_bytes_age=17863 intent_count=1 intent_bytes=19 separated_intent_count=1 intent_age=93
+stats: key_count=8 key_bytes=160 val_count=12 val_bytes=111 range_key_count=2 range_key_bytes=27 range_val_count=2 live_count=3 live_bytes=111 gc_bytes_age=17863 intent_count=1 intent_bytes=19 lock_count=1 lock_age=93
 
 # Error on intent, no tombstones should be written. We try both the
 # point tombstone and range tombstone paths.
@@ -93,7 +93,7 @@ data: "g"/2.000000000,0 -> /BYTES/g2
 data: "h"/4.000000000,0 -> /BYTES/h4
 meta: "i"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "i"/7.000000000,0 -> /BYTES/i7
-stats: key_count=8 key_bytes=160 val_count=12 val_bytes=111 range_key_count=2 range_key_bytes=27 range_val_count=2 live_count=3 live_bytes=111 gc_bytes_age=17863 intent_count=1 intent_bytes=19 separated_intent_count=1 intent_age=93
+stats: key_count=8 key_bytes=160 val_count=12 val_bytes=111 range_key_count=2 range_key_bytes=27 range_val_count=2 live_count=3 live_bytes=111 gc_bytes_age=17863 intent_count=1 intent_bytes=19 lock_count=1 lock_age=93
 error: (*kvpb.LockConflictError:) conflicting locks on "i"
 
 run stats error
@@ -117,7 +117,7 @@ data: "g"/2.000000000,0 -> /BYTES/g2
 data: "h"/4.000000000,0 -> /BYTES/h4
 meta: "i"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "i"/7.000000000,0 -> /BYTES/i7
-stats: key_count=8 key_bytes=160 val_count=12 val_bytes=111 range_key_count=2 range_key_bytes=27 range_val_count=2 live_count=3 live_bytes=111 gc_bytes_age=17863 intent_count=1 intent_bytes=19 separated_intent_count=1 intent_age=93
+stats: key_count=8 key_bytes=160 val_count=12 val_bytes=111 range_key_count=2 range_key_bytes=27 range_val_count=2 live_count=3 live_bytes=111 gc_bytes_age=17863 intent_count=1 intent_bytes=19 lock_count=1 lock_age=93
 error: (*kvpb.LockConflictError:) conflicting locks on "i"
 
 # error encountering point key at d5.
@@ -148,7 +148,7 @@ data: "g"/2.000000000,0 -> /BYTES/g2
 data: "h"/4.000000000,0 -> /BYTES/h4
 meta: "i"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "i"/7.000000000,0 -> /BYTES/i7
-stats: key_count=9 key_bytes=174 val_count=13 val_bytes=118 range_key_count=2 range_key_bytes=27 range_val_count=2 live_count=4 live_bytes=132 gc_bytes_age=17863 intent_count=1 intent_bytes=19 separated_intent_count=1 intent_age=93
+stats: key_count=9 key_bytes=174 val_count=13 val_bytes=118 range_key_count=2 range_key_bytes=27 range_val_count=2 live_count=4 live_bytes=132 gc_bytes_age=17863 intent_count=1 intent_bytes=19 lock_count=1 lock_age=93
 error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "d" at timestamp 5.000000000,0 too old; must write at or above 5.000000000,1
 
 # error encountering range key at k4.
@@ -184,7 +184,7 @@ meta: "i"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0
 data: "i"/7.000000000,0 -> /BYTES/i7
 data: "j"/2.000000000,0 -> /BYTES/j2
 data: "q"/2.000000000,0 -> /BYTES/q2
-stats: key_count=11 key_bytes=202 val_count=15 val_bytes=132 range_key_count=2 range_key_bytes=27 range_val_count=2 live_count=6 live_bytes=174 gc_bytes_age=17863 intent_count=1 intent_bytes=19 separated_intent_count=1 intent_age=93
+stats: key_count=11 key_bytes=202 val_count=15 val_bytes=132 range_key_count=2 range_key_bytes=27 range_val_count=2 live_count=6 live_bytes=174 gc_bytes_age=17863 intent_count=1 intent_bytes=19 lock_count=1 lock_age=93
 error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k" at timestamp 4.000000000,0 too old; must write at or above 4.000000000,1
 
 # At this point the keyspace looks like this:
@@ -224,7 +224,7 @@ meta: "i"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0
 data: "i"/7.000000000,0 -> /BYTES/i7
 data: "j"/2.000000000,0 -> /BYTES/j2
 data: "q"/2.000000000,0 -> /BYTES/q2
-stats: key_count=11 key_bytes=202 val_count=15 val_bytes=132 range_key_count=2 range_key_bytes=27 range_val_count=2 live_count=6 live_bytes=174 gc_bytes_age=17863 intent_count=1 intent_bytes=19 separated_intent_count=1 intent_age=93
+stats: key_count=11 key_bytes=202 val_count=15 val_bytes=132 range_key_count=2 range_key_bytes=27 range_val_count=2 live_count=6 live_bytes=174 gc_bytes_age=17863 intent_count=1 intent_bytes=19 lock_count=1 lock_age=93
 
 # try the same call as above, except with startTime set to 1
 # check that delrange properly continues the run over a range tombstone
@@ -254,7 +254,7 @@ meta: "i"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0
 data: "i"/7.000000000,0 -> /BYTES/i7
 data: "j"/2.000000000,0 -> /BYTES/j2
 data: "q"/2.000000000,0 -> /BYTES/q2
-stats: key_count=11 key_bytes=202 val_count=15 val_bytes=132 range_key_count=4 range_key_bytes=63 range_val_count=5 live_count=4 live_bytes=132 gc_bytes_age=25269 intent_count=1 intent_bytes=19 separated_intent_count=1 intent_age=93
+stats: key_count=11 key_bytes=202 val_count=15 val_bytes=132 range_key_count=4 range_key_bytes=63 range_val_count=5 live_count=4 live_bytes=132 gc_bytes_age=25269 intent_count=1 intent_bytes=19 lock_count=1 lock_age=93
 
 # check that we flush with a range tombstone, if maxBytes is exceeded
 # even though range tombstone threshold has not been met.
@@ -289,7 +289,7 @@ meta: "i"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0
 data: "i"/7.000000000,0 -> /BYTES/i7
 data: "j"/2.000000000,0 -> /BYTES/j2
 data: "q"/2.000000000,0 -> /BYTES/q2
-stats: key_count=11 key_bytes=202 val_count=15 val_bytes=132 range_key_count=5 range_key_bytes=77 range_val_count=6 live_count=3 live_bytes=111 gc_bytes_age=28559 intent_count=1 intent_bytes=19 separated_intent_count=1 intent_age=93
+stats: key_count=11 key_bytes=202 val_count=15 val_bytes=132 range_key_count=5 range_key_bytes=77 range_val_count=6 live_count=3 live_bytes=111 gc_bytes_age=28559 intent_count=1 intent_bytes=19 lock_count=1 lock_age=93
 
 # check that we flush properly if maxBatchSize is exceeded.
 # Since max is 1, write a tombstone to e, and as soon as it sees the
@@ -328,7 +328,7 @@ meta: "i"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0
 data: "i"/7.000000000,0 -> /BYTES/i7
 data: "j"/2.000000000,0 -> /BYTES/j2
 data: "q"/2.000000000,0 -> /BYTES/q2
-stats: key_count=11 key_bytes=226 val_count=17 val_bytes=139 range_key_count=5 range_key_bytes=77 range_val_count=6 live_count=3 live_bytes=111 gc_bytes_age=31438 intent_count=1 intent_bytes=19 separated_intent_count=1 intent_age=93
+stats: key_count=11 key_bytes=226 val_count=17 val_bytes=139 range_key_count=5 range_key_bytes=77 range_val_count=6 live_count=3 live_bytes=111 gc_bytes_age=31438 intent_count=1 intent_bytes=19 lock_count=1 lock_age=93
 
 # Run the same DeleteRange as above at ts 8
 # No resume span should get returned because the iterator goes through
@@ -363,7 +363,7 @@ meta: "i"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0
 data: "i"/7.000000000,0 -> /BYTES/i7
 data: "j"/2.000000000,0 -> /BYTES/j2
 data: "q"/2.000000000,0 -> /BYTES/q2
-stats: key_count=11 key_bytes=238 val_count=18 val_bytes=139 range_key_count=5 range_key_bytes=77 range_val_count=6 live_count=2 live_bytes=90 gc_bytes_age=34474 intent_count=1 intent_bytes=19 separated_intent_count=1 intent_age=93
+stats: key_count=11 key_bytes=238 val_count=18 val_bytes=139 range_key_count=5 range_key_bytes=77 range_val_count=6 live_count=2 live_bytes=90 gc_bytes_age=34474 intent_count=1 intent_bytes=19 lock_count=1 lock_age=93
 
 # Write some new keys on a and b and ensure a run of point tombstones gets properly written
 run stats ok
@@ -406,4 +406,4 @@ meta: "i"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0
 data: "i"/7.000000000,0 -> /BYTES/i7
 data: "j"/2.000000000,0 -> /BYTES/j2
 data: "q"/2.000000000,0 -> /BYTES/q2
-stats: key_count=11 key_bytes=286 val_count=22 val_bytes=153 range_key_count=5 range_key_bytes=77 range_val_count=6 live_count=1 live_bytes=69 gc_bytes_age=42291 intent_count=1 intent_bytes=19 separated_intent_count=1 intent_age=93
+stats: key_count=11 key_bytes=286 val_count=22 val_bytes=153 range_key_count=5 range_key_bytes=77 range_val_count=6 live_count=1 live_bytes=69 gc_bytes_age=42291 intent_count=1 intent_bytes=19 lock_count=1 lock_age=93

--- a/pkg/storage/testdata/mvcc_histories/gc_clear_range
+++ b/pkg/storage/testdata/mvcc_histories/gc_clear_range
@@ -126,7 +126,7 @@ stats: key_bytes=-12 val_count=-1 val_bytes=-7 gc_bytes_age=-1805
 data: "a"/5.000000000,0 -> /BYTES/12
 meta: "c"/0,0 -> txn={id=00000001 key="c" iso=Serializable pri=0.00000000 epo=0 ts=4.000000000,0 min=0,0 seq=0} ts=4.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "c"/4.000000000,0 -> /BYTES/1
-stats: key_count=2 key_bytes=28 val_count=2 val_bytes=64 live_count=2 live_bytes=92 intent_count=1 intent_bytes=18 separated_intent_count=1 intent_age=96
+stats: key_count=2 key_bytes=28 val_count=2 val_bytes=64 live_count=2 live_bytes=92 intent_count=1 intent_bytes=18 lock_count=1 lock_age=96
 
 run ok
 clear_range k=a end=z

--- a/pkg/storage/testdata/mvcc_histories/idempotent_transactions
+++ b/pkg/storage/testdata/mvcc_histories/idempotent_transactions
@@ -7,14 +7,14 @@ with t=a k=a
   put v=first
 ----
 >> put v=first t=a k=a
-stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+61 live_count=+1 live_bytes=+75 intent_count=+1 intent_bytes=+22 separated_intent_count=+1 intent_age=+89
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+61 live_count=+1 live_bytes=+75 intent_count=+1 intent_bytes=+22 lock_count=+1 lock_age=+89
 >> put v=first t=a k=a
 stats: no change
 >> at end:
 txn: "a" meta={id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=11.000000000,0 wto=false gul=0,0
 meta: "a"/0,0 -> txn={id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0} ts=11.000000000,0 del=false klen=12 vlen=10 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "a"/11.000000000,0 -> /BYTES/first
-stats: key_count=1 key_bytes=14 val_count=1 val_bytes=61 live_count=1 live_bytes=75 intent_count=1 intent_bytes=22 separated_intent_count=1 intent_age=89
+stats: key_count=1 key_bytes=14 val_count=1 val_bytes=61 live_count=1 live_bytes=75 intent_count=1 intent_bytes=22 lock_count=1 lock_age=89
 
 # Lay down an intent without increasing the sequence but with a different value.
 # Expect an error.
@@ -48,7 +48,7 @@ meta: "a" -> txn={id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=1
 txn: "a" meta={id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=11.000000000,0 wto=false gul=0,0
 meta: "a"/0,0 -> txn={id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=1} ts=11.000000000,0 del=false klen=12 vlen=11 ih={{0 /BYTES/first}} mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "a"/11.000000000,0 -> /BYTES/second
-stats: key_count=1 key_bytes=14 val_count=1 val_bytes=78 live_count=1 live_bytes=92 intent_count=1 intent_bytes=23 separated_intent_count=1 intent_age=89
+stats: key_count=1 key_bytes=14 val_count=1 val_bytes=78 live_count=1 live_bytes=92 intent_count=1 intent_bytes=23 lock_count=1 lock_age=89
 
 run error
 with t=a k=a
@@ -74,7 +74,7 @@ with t=a k=i
 ----
 >> increment t=a k=i
 inc: current value = 1
-stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+59 live_count=+1 live_bytes=+73 intent_count=+1 intent_bytes=+18 separated_intent_count=+1 intent_age=+89
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+59 live_count=+1 live_bytes=+73 intent_count=+1 intent_bytes=+18 lock_count=+1 lock_age=+89
 >> increment t=a k=i
 inc: current value = 1
 stats: no change
@@ -90,7 +90,7 @@ meta: "a"/0,0 -> txn={id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 
 data: "a"/11.000000000,0 -> /BYTES/second
 meta: "i"/0,0 -> txn={id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=2} ts=11.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "i"/11.000000000,0 -> /INT/1
-stats: key_count=2 key_bytes=28 val_count=2 val_bytes=137 live_count=2 live_bytes=165 intent_count=2 intent_bytes=41 separated_intent_count=2 intent_age=178
+stats: key_count=2 key_bytes=28 val_count=2 val_bytes=137 live_count=2 live_bytes=165 intent_count=2 intent_bytes=41 lock_count=2 lock_age=178
 
 run stats ok
 with t=a k=i
@@ -130,7 +130,7 @@ meta: "a"/0,0 -> txn={id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 
 data: "a"/11.000000000,0 -> /BYTES/second
 meta: "i"/0,0 -> txn={id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=3} ts=11.000000000,0 del=false klen=12 vlen=6 ih={{2 /INT/1}} mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "i"/11.000000000,0 -> /INT/2
-stats: key_count=2 key_bytes=28 val_count=2 val_bytes=147 live_count=2 live_bytes=175 intent_count=2 intent_bytes=41 separated_intent_count=2 intent_age=178
+stats: key_count=2 key_bytes=28 val_count=2 val_bytes=147 live_count=2 live_bytes=175 intent_count=2 intent_bytes=41 lock_count=2 lock_age=178
 
 # Write a key outside of the transaction.
 run stats ok
@@ -145,7 +145,7 @@ data: "a"/11.000000000,0 -> /BYTES/second
 meta: "i"/0,0 -> txn={id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=3} ts=11.000000000,0 del=false klen=12 vlen=6 ih={{2 /INT/1}} mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "i"/11.000000000,0 -> /INT/2
 data: "i2"/10.000000000,0 -> /INT/1
-stats: key_count=3 key_bytes=43 val_count=3 val_bytes=153 live_count=3 live_bytes=196 intent_count=2 intent_bytes=41 separated_intent_count=2 intent_age=178
+stats: key_count=3 key_bytes=43 val_count=3 val_bytes=153 live_count=3 live_bytes=196 intent_count=2 intent_bytes=41 lock_count=2 lock_age=178
 
 run stats ok
 with t=a k=i2
@@ -159,7 +159,7 @@ with t=a k=i2
 ----
 >> increment t=a k=i2
 inc: current value = 2
-stats: key_bytes=+12 val_count=+1 val_bytes=+59 live_bytes=+53 gc_bytes_age=+1602 intent_count=+1 intent_bytes=+18 separated_intent_count=+1 intent_age=+89
+stats: key_bytes=+12 val_count=+1 val_bytes=+59 live_bytes=+53 gc_bytes_age=+1602 intent_count=+1 intent_bytes=+18 lock_count=+1 lock_age=+89
 >> increment t=a k=i2
 inc: current value = 2
 stats: no change
@@ -178,7 +178,7 @@ data: "i"/11.000000000,0 -> /INT/2
 meta: "i2"/0,0 -> txn={id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=4} ts=11.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "i2"/11.000000000,0 -> /INT/2
 data: "i2"/10.000000000,0 -> /INT/1
-stats: key_count=3 key_bytes=55 val_count=4 val_bytes=212 live_count=3 live_bytes=249 gc_bytes_age=1602 intent_count=3 intent_bytes=59 separated_intent_count=3 intent_age=267
+stats: key_count=3 key_bytes=55 val_count=4 val_bytes=212 live_count=3 live_bytes=249 gc_bytes_age=1602 intent_count=3 intent_bytes=59 lock_count=3 lock_age=267
 
 run stats ok
 with t=a k=i2
@@ -221,4 +221,4 @@ data: "i"/11.000000000,0 -> /INT/2
 meta: "i2"/0,0 -> txn={id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=5} ts=11.000000000,0 del=false klen=12 vlen=6 ih={{4 /INT/2}} mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "i2"/11.000000000,0 -> /INT/3
 data: "i2"/10.000000000,0 -> /INT/1
-stats: key_count=3 key_bytes=55 val_count=4 val_bytes=222 live_count=3 live_bytes=259 gc_bytes_age=1602 intent_count=3 intent_bytes=59 separated_intent_count=3 intent_age=267
+stats: key_count=3 key_bytes=55 val_count=4 val_bytes=222 live_count=3 live_bytes=259 gc_bytes_age=1602 intent_count=3 intent_bytes=59 lock_count=3 lock_age=267

--- a/pkg/storage/testdata/mvcc_histories/ignored_seq_nums_commit
+++ b/pkg/storage/testdata/mvcc_histories/ignored_seq_nums_commit
@@ -23,25 +23,25 @@ with t=A
   resolve_intent k=k/30
 ----
 >> put k=k v=a t=A
-stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+56 live_count=+1 live_bytes=+70 intent_count=+1 intent_bytes=+18 separated_intent_count=+1 intent_age=+89
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+56 live_count=+1 live_bytes=+70 intent_count=+1 intent_bytes=+18 lock_count=+1 lock_age=+89
 >> put k=k/10 v=10 t=A
-stats: key_count=+1 key_bytes=+17 val_count=+1 val_bytes=+57 live_count=+1 live_bytes=+74 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+89
+stats: key_count=+1 key_bytes=+17 val_count=+1 val_bytes=+57 live_count=+1 live_bytes=+74 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+89
 >> put k=k v=b t=A
 stats: val_bytes=+10 live_bytes=+10
 >> put k=k/20 v=20 t=A
-stats: key_count=+1 key_bytes=+17 val_count=+1 val_bytes=+57 live_count=+1 live_bytes=+74 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+89
+stats: key_count=+1 key_bytes=+17 val_count=+1 val_bytes=+57 live_count=+1 live_bytes=+74 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+89
 >> put k=k v=c t=A
 stats: val_bytes=+12 live_bytes=+12
 >> put k=k/30 v=30 t=A
-stats: key_count=+1 key_bytes=+17 val_count=+1 val_bytes=+57 live_count=+1 live_bytes=+74 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+89
+stats: key_count=+1 key_bytes=+17 val_count=+1 val_bytes=+57 live_count=+1 live_bytes=+74 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+89
 >> resolve_intent k=k t=A
-stats: val_bytes=-72 live_bytes=-72 intent_count=-1 intent_bytes=-18 separated_intent_count=-1 intent_age=-89
+stats: val_bytes=-72 live_bytes=-72 intent_count=-1 intent_bytes=-18 lock_count=-1 lock_age=-89
 >> resolve_intent k=k/10 t=A
-stats: val_bytes=-50 live_bytes=-50 intent_count=-1 intent_bytes=-19 separated_intent_count=-1 intent_age=-89
+stats: val_bytes=-50 live_bytes=-50 intent_count=-1 intent_bytes=-19 lock_count=-1 lock_age=-89
 >> resolve_intent k=k/20 t=A
-stats: val_bytes=-50 live_bytes=-50 intent_count=-1 intent_bytes=-19 separated_intent_count=-1 intent_age=-89
+stats: val_bytes=-50 live_bytes=-50 intent_count=-1 intent_bytes=-19 lock_count=-1 lock_age=-89
 >> resolve_intent k=k/30 t=A
-stats: key_count=-1 key_bytes=-17 val_count=-1 val_bytes=-57 live_count=-1 live_bytes=-74 intent_count=-1 intent_bytes=-19 separated_intent_count=-1 intent_age=-89
+stats: key_count=-1 key_bytes=-17 val_count=-1 val_bytes=-57 live_count=-1 live_bytes=-74 intent_count=-1 intent_bytes=-19 lock_count=-1 lock_age=-89
 >> at end:
 txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=40} lock=true stat=PENDING rts=11.000000000,0 wto=false gul=0,0 isn=1
 data: "k"/11.000000000,0 -> /BYTES/b
@@ -85,25 +85,25 @@ with t=A
   resolve_intent k=k/30
 ----
 >> put k=k v=a t=A
-stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+56 live_count=+1 live_bytes=+70 intent_count=+1 intent_bytes=+18 separated_intent_count=+1 intent_age=+89
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+56 live_count=+1 live_bytes=+70 intent_count=+1 intent_bytes=+18 lock_count=+1 lock_age=+89
 >> put k=k/10 v=10 t=A
-stats: key_count=+1 key_bytes=+17 val_count=+1 val_bytes=+57 live_count=+1 live_bytes=+74 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+89
+stats: key_count=+1 key_bytes=+17 val_count=+1 val_bytes=+57 live_count=+1 live_bytes=+74 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+89
 >> put k=k v=b t=A
 stats: val_bytes=+10 live_bytes=+10
 >> put k=k/20 v=20 t=A
-stats: key_count=+1 key_bytes=+17 val_count=+1 val_bytes=+57 live_count=+1 live_bytes=+74 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+89
+stats: key_count=+1 key_bytes=+17 val_count=+1 val_bytes=+57 live_count=+1 live_bytes=+74 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+89
 >> put k=k v=c t=A
 stats: val_bytes=+12 live_bytes=+12
 >> put k=k/30 v=30 t=A
-stats: key_count=+1 key_bytes=+17 val_count=+1 val_bytes=+57 live_count=+1 live_bytes=+74 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+89
+stats: key_count=+1 key_bytes=+17 val_count=+1 val_bytes=+57 live_count=+1 live_bytes=+74 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+89
 >> resolve_intent k=k t=A
-stats: val_bytes=-72 live_bytes=-72 intent_count=-1 intent_bytes=-18 separated_intent_count=-1 intent_age=-89
+stats: val_bytes=-72 live_bytes=-72 intent_count=-1 intent_bytes=-18 lock_count=-1 lock_age=-89
 >> resolve_intent k=k/10 t=A
-stats: val_bytes=-50 live_bytes=-50 intent_count=-1 intent_bytes=-19 separated_intent_count=-1 intent_age=-89
+stats: val_bytes=-50 live_bytes=-50 intent_count=-1 intent_bytes=-19 lock_count=-1 lock_age=-89
 >> resolve_intent k=k/20 t=A
-stats: key_count=-1 key_bytes=-17 val_count=-1 val_bytes=-57 live_count=-1 live_bytes=-74 intent_count=-1 intent_bytes=-19 separated_intent_count=-1 intent_age=-89
+stats: key_count=-1 key_bytes=-17 val_count=-1 val_bytes=-57 live_count=-1 live_bytes=-74 intent_count=-1 intent_bytes=-19 lock_count=-1 lock_age=-89
 >> resolve_intent k=k/30 t=A
-stats: val_bytes=-50 live_bytes=-50 intent_count=-1 intent_bytes=-19 separated_intent_count=-1 intent_age=-89
+stats: val_bytes=-50 live_bytes=-50 intent_count=-1 intent_bytes=-19 lock_count=-1 lock_age=-89
 >> at end:
 txn: "A" meta={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=40} lock=true stat=PENDING rts=11.000000000,0 wto=false gul=0,0 isn=1
 data: "k"/11.000000000,0 -> /BYTES/c

--- a/pkg/storage/testdata/mvcc_histories/increment
+++ b/pkg/storage/testdata/mvcc_histories/increment
@@ -38,7 +38,7 @@ with k=k t=a ts=0,1
 ----
 >> increment k=k t=a ts=0,1
 inc: current value = 1
-stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+51 live_count=+1 live_bytes=+65 intent_count=+1 intent_bytes=+18 separated_intent_count=+1 intent_age=+100
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+51 live_count=+1 live_bytes=+65 intent_count=+1 intent_bytes=+18 lock_count=+1 lock_age=+100
 >> increment k=k t=a ts=0,1
 inc: current value = 2
 stats: val_bytes=+10 live_bytes=+10
@@ -46,7 +46,7 @@ stats: val_bytes=+10 live_bytes=+10
 txn: "a" meta={id=00000001 key="k" iso=Serializable pri=0.00000000 epo=0 ts=0,1 min=0,0 seq=2} lock=true stat=PENDING rts=0,1 wto=false gul=0,0
 meta: "k"/0,0 -> txn={id=00000001 key="k" iso=Serializable pri=0.00000000 epo=0 ts=0,1 min=0,0 seq=2} ts=0,1 del=false klen=12 vlen=6 ih={{1 /INT/1}} mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "k"/0,1 -> /INT/2
-stats: key_count=1 key_bytes=14 val_count=1 val_bytes=61 live_count=1 live_bytes=75 intent_count=1 intent_bytes=18 separated_intent_count=1 intent_age=100
+stats: key_count=1 key_bytes=14 val_count=1 val_bytes=61 live_count=1 live_bytes=75 intent_count=1 intent_bytes=18 lock_count=1 lock_age=100
 
 
 # Increments at older timestamp generate WriteTooOld.

--- a/pkg/storage/testdata/mvcc_histories/intent_history_enable_separated
+++ b/pkg/storage/testdata/mvcc_histories/intent_history_enable_separated
@@ -33,7 +33,7 @@ txn: "A" meta={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=2.0
 meta: "a"/0,0 -> txn={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=0} ts=2.000000000,0 del=false klen=12 vlen=10 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "a"/2.000000000,0 -> /BYTES/first
 data: "a"/1.000000000,0 -> /BYTES/default
-stats: key_bytes=+12 val_count=+1 val_bytes=+58 live_bytes=+46 gc_bytes_age=+2352 intent_count=+1 intent_bytes=+22 separated_intent_count=+1 intent_age=+98
+stats: key_bytes=+12 val_count=+1 val_bytes=+58 live_bytes=+46 gc_bytes_age=+2352 intent_count=+1 intent_bytes=+22 lock_count=+1 lock_age=+98
 >> txn_step k=a t=A
 txn: "A" meta={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=2.000000000,0 wto=false gul=0,0
 >> put v=second k=a t=A
@@ -60,5 +60,5 @@ stats: val_bytes=+16 live_count=+1 live_bytes=+111 gc_bytes_age=-9310 intent_byt
 called ClearEngineKey(/Local/Lock/Intent"a"/0300000002000000000000000000000000)
 data: "a"/2.000000000,0 -> /BYTES/first
 data: "a"/1.000000000,0 -> /BYTES/default
-stats: val_bytes=-87 live_bytes=-87 intent_count=-1 intent_bytes=-22 separated_intent_count=-1 intent_age=-98
+stats: val_bytes=-87 live_bytes=-87 intent_count=-1 intent_bytes=-22 lock_count=-1 lock_age=-98
 stats: key_count=1 key_bytes=26 val_count=2 val_bytes=22 live_count=1 live_bytes=24 gc_bytes_age=2352

--- a/pkg/storage/testdata/mvcc_histories/intent_with_write_tracing_enable_separated
+++ b/pkg/storage/testdata/mvcc_histories/intent_with_write_tracing_enable_separated
@@ -8,8 +8,8 @@ txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=2.0
 >> put k=k1 v=v1 t=A
 meta: "k1"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=0} ts=2.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k1"/2.000000000,0 -> /BYTES/v1
-stats: key_count=+1 key_bytes=+15 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+70 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+98
-stats: key_count=1 key_bytes=15 val_count=1 val_bytes=55 live_count=1 live_bytes=70 intent_count=1 intent_bytes=19 separated_intent_count=1 intent_age=98
+stats: key_count=+1 key_bytes=+15 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+70 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+98
+stats: key_count=1 key_bytes=15 val_count=1 val_bytes=55 live_count=1 live_bytes=70 intent_count=1 intent_bytes=19 lock_count=1 lock_age=98
 
 run trace stats ok
 with t=A
@@ -25,14 +25,14 @@ txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=3.0
 >> put k=k1 v=v1 t=A
 meta: "k1"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=1} ts=3.000000000,0 del=false klen=12 vlen=7 ih={{0 /BYTES/v1}} mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "k1"/3.000000000,0 -> /BYTES/v1
-stats: val_bytes=+13 live_bytes=+13 intent_age=-1
+stats: val_bytes=+13 live_bytes=+13 lock_age=-1
 >> put k=k2 v=v2 t=A
 meta: "k1"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=1} ts=3.000000000,0 del=false klen=12 vlen=7 ih={{0 /BYTES/v1}} mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "k1"/3.000000000,0 -> /BYTES/v1
 meta: "k2"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=1} ts=3.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k2"/3.000000000,0 -> /BYTES/v2
-stats: key_count=+1 key_bytes=+15 val_count=+1 val_bytes=+57 live_count=+1 live_bytes=+72 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+97
-stats: key_count=2 key_bytes=30 val_count=2 val_bytes=125 live_count=2 live_bytes=155 intent_count=2 intent_bytes=38 separated_intent_count=2 intent_age=194
+stats: key_count=+1 key_bytes=+15 val_count=+1 val_bytes=+57 live_count=+1 live_bytes=+72 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+97
+stats: key_count=2 key_bytes=30 val_count=2 val_bytes=125 live_count=2 live_bytes=155 intent_count=2 intent_bytes=38 lock_count=2 lock_age=194
 
 run trace stats ok
 put k=k3 v=v3 ts=1
@@ -44,7 +44,7 @@ meta: "k2"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=
 data: "k2"/3.000000000,0 -> /BYTES/v2
 data: "k3"/1.000000000,0 -> /BYTES/v3
 stats: key_count=+1 key_bytes=+15 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+22
-stats: key_count=3 key_bytes=45 val_count=3 val_bytes=132 live_count=3 live_bytes=177 intent_count=2 intent_bytes=38 separated_intent_count=2 intent_age=194
+stats: key_count=3 key_bytes=45 val_count=3 val_bytes=132 live_count=3 live_bytes=177 intent_count=2 intent_bytes=38 lock_count=2 lock_age=194
 
 run trace stats ok
 with t=A
@@ -58,8 +58,8 @@ data: "k2"/3.000000000,0 -> /BYTES/v2
 meta: "k3"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=1} ts=3.000000000,0 del=false klen=12 vlen=8 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k3"/3.000000000,0 -> /BYTES/v33
 data: "k3"/1.000000000,0 -> /BYTES/v3
-stats: key_bytes=+12 val_count=+1 val_bytes=+58 live_bytes=+51 gc_bytes_age=+1843 intent_count=+1 intent_bytes=+20 separated_intent_count=+1 intent_age=+97
-stats: key_count=3 key_bytes=57 val_count=4 val_bytes=190 live_count=3 live_bytes=228 gc_bytes_age=1843 intent_count=3 intent_bytes=58 separated_intent_count=3 intent_age=291
+stats: key_bytes=+12 val_count=+1 val_bytes=+58 live_bytes=+51 gc_bytes_age=+1843 intent_count=+1 intent_bytes=+20 lock_count=+1 lock_age=+97
+stats: key_count=3 key_bytes=57 val_count=4 val_bytes=190 live_count=3 live_bytes=228 gc_bytes_age=1843 intent_count=3 intent_bytes=58 lock_count=3 lock_age=291
 
 # transactionDidNotUpdateMeta (TDNUM) is false below for k2 and k3 since
 # disallowSeparatedIntents=true causes mvcc.go to always set it to false to maintain
@@ -79,18 +79,18 @@ data: "k2"/3.000000000,0 -> /BYTES/v2
 meta: "k3"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=1} ts=3.000000000,0 del=false klen=12 vlen=8 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k3"/3.000000000,0 -> /BYTES/v33
 data: "k3"/1.000000000,0 -> /BYTES/v3
-stats: val_bytes=-61 live_bytes=-61 intent_count=-1 intent_bytes=-19 separated_intent_count=-1 intent_age=-97
+stats: val_bytes=-61 live_bytes=-61 intent_count=-1 intent_bytes=-19 lock_count=-1 lock_age=-97
 >> resolve_intent k=k2 status=ABORTED t=A
 called ClearEngineKey(/Local/Lock/Intent"k2"/0300000001000000000000000000000000)
 data: "k1"/3.000000000,0 -> /BYTES/v1
 meta: "k3"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=1} ts=3.000000000,0 del=false klen=12 vlen=8 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k3"/3.000000000,0 -> /BYTES/v33
 data: "k3"/1.000000000,0 -> /BYTES/v3
-stats: key_count=-1 key_bytes=-15 val_count=-1 val_bytes=-57 live_count=-1 live_bytes=-72 intent_count=-1 intent_bytes=-19 separated_intent_count=-1 intent_age=-97
+stats: key_count=-1 key_bytes=-15 val_count=-1 val_bytes=-57 live_count=-1 live_bytes=-72 intent_count=-1 intent_bytes=-19 lock_count=-1 lock_age=-97
 >> resolve_intent k=k3 status=ABORTED t=A
 called ClearEngineKey(/Local/Lock/Intent"k3"/0300000001000000000000000000000000)
 data: "k1"/3.000000000,0 -> /BYTES/v1
 data: "k3"/1.000000000,0 -> /BYTES/v3
-stats: key_bytes=-12 val_count=-1 val_bytes=-58 live_bytes=-51 gc_bytes_age=-1843 intent_count=-1 intent_bytes=-20 separated_intent_count=-1 intent_age=-97
+stats: key_bytes=-12 val_count=-1 val_bytes=-58 live_bytes=-51 gc_bytes_age=-1843 intent_count=-1 intent_bytes=-20 lock_count=-1 lock_age=-97
 >> txn_remove t=A
 stats: key_count=2 key_bytes=30 val_count=2 val_bytes=14 live_count=2 live_bytes=44

--- a/pkg/storage/testdata/mvcc_histories/local_timestamp
+++ b/pkg/storage/testdata/mvcc_histories/local_timestamp
@@ -255,29 +255,29 @@ with t=A ts=20 localTs=10
   put k=k12 v=v
 ----
 >> put k=k1 v=v t=A ts=20 localTs=10
-stats: key_count=+1 key_bytes=+15 val_count=+1 val_bytes=+67 live_count=+1 live_bytes=+82 intent_count=+1 intent_bytes=+31 separated_intent_count=+1 intent_age=+80
+stats: key_count=+1 key_bytes=+15 val_count=+1 val_bytes=+67 live_count=+1 live_bytes=+82 intent_count=+1 intent_bytes=+31 lock_count=+1 lock_age=+80
 >> put k=k2 v=v t=A ts=20 localTs=10
-stats: key_count=+1 key_bytes=+15 val_count=+1 val_bytes=+67 live_count=+1 live_bytes=+82 intent_count=+1 intent_bytes=+31 separated_intent_count=+1 intent_age=+80
+stats: key_count=+1 key_bytes=+15 val_count=+1 val_bytes=+67 live_count=+1 live_bytes=+82 intent_count=+1 intent_bytes=+31 lock_count=+1 lock_age=+80
 >> put k=k3 v=v t=A ts=20 localTs=10
-stats: key_count=+1 key_bytes=+15 val_count=+1 val_bytes=+67 live_count=+1 live_bytes=+82 intent_count=+1 intent_bytes=+31 separated_intent_count=+1 intent_age=+80
+stats: key_count=+1 key_bytes=+15 val_count=+1 val_bytes=+67 live_count=+1 live_bytes=+82 intent_count=+1 intent_bytes=+31 lock_count=+1 lock_age=+80
 >> put k=k4 v=v t=A ts=20 localTs=10
-stats: key_count=+1 key_bytes=+15 val_count=+1 val_bytes=+67 live_count=+1 live_bytes=+82 intent_count=+1 intent_bytes=+31 separated_intent_count=+1 intent_age=+80
+stats: key_count=+1 key_bytes=+15 val_count=+1 val_bytes=+67 live_count=+1 live_bytes=+82 intent_count=+1 intent_bytes=+31 lock_count=+1 lock_age=+80
 >> put k=k5 v=v t=A ts=20 localTs=10
-stats: key_count=+1 key_bytes=+15 val_count=+1 val_bytes=+67 live_count=+1 live_bytes=+82 intent_count=+1 intent_bytes=+31 separated_intent_count=+1 intent_age=+80
+stats: key_count=+1 key_bytes=+15 val_count=+1 val_bytes=+67 live_count=+1 live_bytes=+82 intent_count=+1 intent_bytes=+31 lock_count=+1 lock_age=+80
 >> put k=k6 v=v t=A ts=20 localTs=10
-stats: key_count=+1 key_bytes=+15 val_count=+1 val_bytes=+67 live_count=+1 live_bytes=+82 intent_count=+1 intent_bytes=+31 separated_intent_count=+1 intent_age=+80
+stats: key_count=+1 key_bytes=+15 val_count=+1 val_bytes=+67 live_count=+1 live_bytes=+82 intent_count=+1 intent_bytes=+31 lock_count=+1 lock_age=+80
 >> put k=k7 v=v t=A ts=20 localTs=10
-stats: key_count=+1 key_bytes=+15 val_count=+1 val_bytes=+67 live_count=+1 live_bytes=+82 intent_count=+1 intent_bytes=+31 separated_intent_count=+1 intent_age=+80
+stats: key_count=+1 key_bytes=+15 val_count=+1 val_bytes=+67 live_count=+1 live_bytes=+82 intent_count=+1 intent_bytes=+31 lock_count=+1 lock_age=+80
 >> put k=k8 v=v t=A ts=20 localTs=10
-stats: key_count=+1 key_bytes=+15 val_count=+1 val_bytes=+67 live_count=+1 live_bytes=+82 intent_count=+1 intent_bytes=+31 separated_intent_count=+1 intent_age=+80
+stats: key_count=+1 key_bytes=+15 val_count=+1 val_bytes=+67 live_count=+1 live_bytes=+82 intent_count=+1 intent_bytes=+31 lock_count=+1 lock_age=+80
 >> put k=k9 v=v t=A ts=20 localTs=10
-stats: key_count=+1 key_bytes=+15 val_count=+1 val_bytes=+67 live_count=+1 live_bytes=+82 intent_count=+1 intent_bytes=+31 separated_intent_count=+1 intent_age=+80
+stats: key_count=+1 key_bytes=+15 val_count=+1 val_bytes=+67 live_count=+1 live_bytes=+82 intent_count=+1 intent_bytes=+31 lock_count=+1 lock_age=+80
 >> put k=k10 v=v t=A ts=20 localTs=10
-stats: key_count=+1 key_bytes=+16 val_count=+1 val_bytes=+67 live_count=+1 live_bytes=+83 intent_count=+1 intent_bytes=+31 separated_intent_count=+1 intent_age=+80
+stats: key_count=+1 key_bytes=+16 val_count=+1 val_bytes=+67 live_count=+1 live_bytes=+83 intent_count=+1 intent_bytes=+31 lock_count=+1 lock_age=+80
 >> put k=k11 v=v t=A ts=20 localTs=10
-stats: key_count=+1 key_bytes=+16 val_count=+1 val_bytes=+67 live_count=+1 live_bytes=+83 intent_count=+1 intent_bytes=+31 separated_intent_count=+1 intent_age=+80
+stats: key_count=+1 key_bytes=+16 val_count=+1 val_bytes=+67 live_count=+1 live_bytes=+83 intent_count=+1 intent_bytes=+31 lock_count=+1 lock_age=+80
 >> put k=k12 v=v t=A ts=20 localTs=10
-stats: key_count=+1 key_bytes=+16 val_count=+1 val_bytes=+67 live_count=+1 live_bytes=+83 intent_count=+1 intent_bytes=+31 separated_intent_count=+1 intent_age=+80
+stats: key_count=+1 key_bytes=+16 val_count=+1 val_bytes=+67 live_count=+1 live_bytes=+83 intent_count=+1 intent_bytes=+31 lock_count=+1 lock_age=+80
 >> at end:
 txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=20.000000000,0 wto=false gul=0,0
 meta: "k1"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0} ts=20.000000000,0 del=false klen=12 vlen=19 mergeTs=<nil> txnDidNotUpdateMeta=true
@@ -304,7 +304,7 @@ meta: "k8"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=
 data: "k8"/20.000000000,0 -> {localTs=10.000000000,0}/BYTES/v
 meta: "k9"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0} ts=20.000000000,0 del=false klen=12 vlen=19 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k9"/20.000000000,0 -> {localTs=10.000000000,0}/BYTES/v
-stats: key_count=12 key_bytes=183 val_count=12 val_bytes=804 live_count=12 live_bytes=987 intent_count=12 intent_bytes=372 separated_intent_count=12 intent_age=960
+stats: key_count=12 key_bytes=183 val_count=12 val_bytes=804 live_count=12 live_bytes=987 intent_count=12 intent_bytes=372 lock_count=12 lock_age=960
 
 run ok
 with t=A
@@ -330,29 +330,29 @@ with t=A localTs=20
   put k=k12 v=v2
 ----
 >> put k=k1 v=v2 t=A localTs=20
-stats: val_bytes=+26 live_bytes=+26 intent_bytes=+1 intent_age=-10
+stats: val_bytes=+26 live_bytes=+26 intent_bytes=+1 lock_age=-10
 >> put k=k2 v=v2 t=A localTs=20
-stats: val_bytes=+26 live_bytes=+26 intent_bytes=+1 intent_age=-10
+stats: val_bytes=+26 live_bytes=+26 intent_bytes=+1 lock_age=-10
 >> put k=k3 v=v2 t=A localTs=20
-stats: val_bytes=+26 live_bytes=+26 intent_bytes=+1 intent_age=-10
+stats: val_bytes=+26 live_bytes=+26 intent_bytes=+1 lock_age=-10
 >> put k=k4 v=v2 t=A localTs=20
-stats: val_bytes=+26 live_bytes=+26 intent_bytes=+1 intent_age=-10
+stats: val_bytes=+26 live_bytes=+26 intent_bytes=+1 lock_age=-10
 >> put k=k5 v=v2 t=A localTs=20
-stats: val_bytes=+26 live_bytes=+26 intent_bytes=+1 intent_age=-10
+stats: val_bytes=+26 live_bytes=+26 intent_bytes=+1 lock_age=-10
 >> put k=k6 v=v2 t=A localTs=20
-stats: val_bytes=+26 live_bytes=+26 intent_bytes=+1 intent_age=-10
+stats: val_bytes=+26 live_bytes=+26 intent_bytes=+1 lock_age=-10
 >> put k=k7 v=v2 t=A localTs=20
-stats: val_bytes=+26 live_bytes=+26 intent_bytes=+1 intent_age=-10
+stats: val_bytes=+26 live_bytes=+26 intent_bytes=+1 lock_age=-10
 >> put k=k8 v=v2 t=A localTs=20
-stats: val_bytes=+26 live_bytes=+26 intent_bytes=+1 intent_age=-10
+stats: val_bytes=+26 live_bytes=+26 intent_bytes=+1 lock_age=-10
 >> put k=k9 v=v2 t=A localTs=20
-stats: val_bytes=+26 live_bytes=+26 intent_bytes=+1 intent_age=-10
+stats: val_bytes=+26 live_bytes=+26 intent_bytes=+1 lock_age=-10
 >> put k=k10 v=v2 t=A localTs=20
-stats: val_bytes=+26 live_bytes=+26 intent_bytes=+1 intent_age=-10
+stats: val_bytes=+26 live_bytes=+26 intent_bytes=+1 lock_age=-10
 >> put k=k11 v=v2 t=A localTs=20
-stats: val_bytes=+26 live_bytes=+26 intent_bytes=+1 intent_age=-10
+stats: val_bytes=+26 live_bytes=+26 intent_bytes=+1 lock_age=-10
 >> put k=k12 v=v2 t=A localTs=20
-stats: val_bytes=+26 live_bytes=+26 intent_bytes=+1 intent_age=-10
+stats: val_bytes=+26 live_bytes=+26 intent_bytes=+1 lock_age=-10
 >> at end:
 meta: "k1"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=30.000000000,0 min=0,0 seq=1} ts=30.000000000,0 del=false klen=12 vlen=20 ih={{0 {localTs=10.000000000,0}/BYTES/v}} mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "k1"/30.000000000,0 -> {localTs=20.000000000,0}/BYTES/v2
@@ -378,7 +378,7 @@ meta: "k8"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=
 data: "k8"/30.000000000,0 -> {localTs=20.000000000,0}/BYTES/v2
 meta: "k9"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=30.000000000,0 min=0,0 seq=1} ts=30.000000000,0 del=false klen=12 vlen=20 ih={{0 {localTs=10.000000000,0}/BYTES/v}} mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "k9"/30.000000000,0 -> {localTs=20.000000000,0}/BYTES/v2
-stats: key_count=12 key_bytes=183 val_count=12 val_bytes=1116 live_count=12 live_bytes=1299 intent_count=12 intent_bytes=384 separated_intent_count=12 intent_age=840
+stats: key_count=12 key_bytes=183 val_count=12 val_bytes=1116 live_count=12 live_bytes=1299 intent_count=12 intent_bytes=384 lock_count=12 lock_age=840
 
 run stats ok
 with t=A
@@ -397,29 +397,29 @@ with t=A
   resolve_intent k=k12 status=COMMITTED clockWhilePending=40
 ----
 >> resolve_intent k=k1 status=ABORTED t=A
-stats: key_count=-1 key_bytes=-15 val_count=-1 val_bytes=-93 live_count=-1 live_bytes=-108 intent_count=-1 intent_bytes=-32 separated_intent_count=-1 intent_age=-70
+stats: key_count=-1 key_bytes=-15 val_count=-1 val_bytes=-93 live_count=-1 live_bytes=-108 intent_count=-1 intent_bytes=-32 lock_count=-1 lock_age=-70
 >> resolve_intent k=k2 status=ABORTED clockWhilePending=20 t=A
-stats: key_count=-1 key_bytes=-15 val_count=-1 val_bytes=-93 live_count=-1 live_bytes=-108 intent_count=-1 intent_bytes=-32 separated_intent_count=-1 intent_age=-70
+stats: key_count=-1 key_bytes=-15 val_count=-1 val_bytes=-93 live_count=-1 live_bytes=-108 intent_count=-1 intent_bytes=-32 lock_count=-1 lock_age=-70
 >> resolve_intent k=k3 status=ABORTED clockWhilePending=30 t=A
-stats: key_count=-1 key_bytes=-15 val_count=-1 val_bytes=-93 live_count=-1 live_bytes=-108 intent_count=-1 intent_bytes=-32 separated_intent_count=-1 intent_age=-70
+stats: key_count=-1 key_bytes=-15 val_count=-1 val_bytes=-93 live_count=-1 live_bytes=-108 intent_count=-1 intent_bytes=-32 lock_count=-1 lock_age=-70
 >> resolve_intent k=k4 status=ABORTED clockWhilePending=40 t=A
-stats: key_count=-1 key_bytes=-15 val_count=-1 val_bytes=-93 live_count=-1 live_bytes=-108 intent_count=-1 intent_bytes=-32 separated_intent_count=-1 intent_age=-70
+stats: key_count=-1 key_bytes=-15 val_count=-1 val_bytes=-93 live_count=-1 live_bytes=-108 intent_count=-1 intent_bytes=-32 lock_count=-1 lock_age=-70
 >> resolve_intent k=k5 status=PENDING t=A
-stats: val_bytes=+2 live_bytes=+2 intent_age=-10
+stats: val_bytes=+2 live_bytes=+2 lock_age=-10
 >> resolve_intent k=k6 status=PENDING clockWhilePending=20 t=A
-stats: val_bytes=+2 live_bytes=+2 intent_age=-10
+stats: val_bytes=+2 live_bytes=+2 lock_age=-10
 >> resolve_intent k=k7 status=PENDING clockWhilePending=30 t=A
-stats: val_bytes=+2 live_bytes=+2 intent_age=-10
+stats: val_bytes=+2 live_bytes=+2 lock_age=-10
 >> resolve_intent k=k8 status=PENDING clockWhilePending=40 t=A
-stats: val_bytes=-11 live_bytes=-11 intent_bytes=-13 intent_age=-10
+stats: val_bytes=-11 live_bytes=-11 intent_bytes=-13 lock_age=-10
 >> resolve_intent k=k9 status=COMMITTED t=A
-stats: val_bytes=-73 live_bytes=-73 intent_count=-1 intent_bytes=-32 separated_intent_count=-1 intent_age=-70
+stats: val_bytes=-73 live_bytes=-73 intent_count=-1 intent_bytes=-32 lock_count=-1 lock_age=-70
 >> resolve_intent k=k10 status=COMMITTED clockWhilePending=20 t=A
-stats: val_bytes=-73 live_bytes=-73 intent_count=-1 intent_bytes=-32 separated_intent_count=-1 intent_age=-70
+stats: val_bytes=-73 live_bytes=-73 intent_count=-1 intent_bytes=-32 lock_count=-1 lock_age=-70
 >> resolve_intent k=k11 status=COMMITTED clockWhilePending=30 t=A
-stats: val_bytes=-73 live_bytes=-73 intent_count=-1 intent_bytes=-32 separated_intent_count=-1 intent_age=-70
+stats: val_bytes=-73 live_bytes=-73 intent_count=-1 intent_bytes=-32 lock_count=-1 lock_age=-70
 >> resolve_intent k=k12 status=COMMITTED clockWhilePending=40 t=A
-stats: val_bytes=-86 live_bytes=-86 intent_count=-1 intent_bytes=-32 separated_intent_count=-1 intent_age=-70
+stats: val_bytes=-86 live_bytes=-86 intent_count=-1 intent_bytes=-32 lock_count=-1 lock_age=-70
 >> at end:
 txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=40.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=20.000000000,0 wto=false gul=0,0
 data: "k10"/40.000000000,0 -> {localTs=20.000000000,0}/BYTES/v2
@@ -434,4 +434,4 @@ data: "k7"/40.000000000,0 -> {localTs=30.000000000,0}/BYTES/v2
 meta: "k8"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=40.000000000,0 min=0,0 seq=1} ts=40.000000000,0 del=false klen=12 vlen=7 ih={{0 {localTs=10.000000000,0}/BYTES/v}} mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "k8"/40.000000000,0 -> /BYTES/v2
 data: "k9"/40.000000000,0 -> {localTs=20.000000000,0}/BYTES/v2
-stats: key_count=8 key_bytes=123 val_count=8 val_bytes=434 live_count=8 live_bytes=557 intent_count=4 intent_bytes=115 separated_intent_count=4 intent_age=240
+stats: key_count=8 key_bytes=123 val_count=8 val_bytes=434 live_count=8 live_bytes=557 intent_count=4 intent_bytes=115 lock_count=4 lock_age=240

--- a/pkg/storage/testdata/mvcc_histories/put_after_rollback
+++ b/pkg/storage/testdata/mvcc_histories/put_after_rollback
@@ -11,7 +11,7 @@ with t=A k=k2
   get
 ----
 >> put v=a t=A k=k2
-stats: key_count=+1 key_bytes=+15 val_count=+1 val_bytes=+60 live_count=+1 live_bytes=+75 intent_count=+1 intent_bytes=+18 separated_intent_count=+1 intent_age=+99
+stats: key_count=+1 key_bytes=+15 val_count=+1 val_bytes=+60 live_count=+1 live_bytes=+75 intent_count=+1 intent_bytes=+18 lock_count=+1 lock_age=+99
 >> put v=b t=A k=k2
 stats: val_bytes=-2 live_bytes=-2
 get: "k2" -> /BYTES/b @1.000000000,0
@@ -20,7 +20,7 @@ get: "k2" -> <no data>
 txn: "A" meta={id=00000001 key="k2" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=20} lock=true stat=PENDING rts=1.000000000,0 wto=false gul=0,0 isn=1
 meta: "k2"/0,0 -> txn={id=00000001 key="k2" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=20} ts=1.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "k2"/1.000000000,0 -> /BYTES/b
-stats: key_count=1 key_bytes=15 val_count=1 val_bytes=58 live_count=1 live_bytes=73 intent_count=1 intent_bytes=18 separated_intent_count=1 intent_age=99
+stats: key_count=1 key_bytes=15 val_count=1 val_bytes=58 live_count=1 live_bytes=73 intent_count=1 intent_bytes=18 lock_count=1 lock_age=99
 
 run stats ok
 with t=A k=k3
@@ -31,7 +31,7 @@ with t=A k=k3
   del
 ----
 >> put v=a t=A k=k3
-stats: key_count=+1 key_bytes=+15 val_count=+1 val_bytes=+60 live_count=+1 live_bytes=+75 intent_count=+1 intent_bytes=+18 separated_intent_count=+1 intent_age=+99
+stats: key_count=+1 key_bytes=+15 val_count=+1 val_bytes=+60 live_count=+1 live_bytes=+75 intent_count=+1 intent_bytes=+18 lock_count=+1 lock_age=+99
 >> del t=A k=k3
 del: "k3": found key false
 stats: val_bytes=-8 live_count=-1 live_bytes=-75 gc_bytes_age=+6633 intent_bytes=-6
@@ -41,7 +41,7 @@ meta: "k2"/0,0 -> txn={id=00000001 key="k2" iso=Serializable pri=0.00000000 epo=
 data: "k2"/1.000000000,0 -> /BYTES/b
 meta: "k3"/0,0 -> txn={id=00000001 key="k2" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=40} ts=1.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "k3"/1.000000000,0 -> /<empty>
-stats: key_count=2 key_bytes=30 val_count=2 val_bytes=110 live_count=1 live_bytes=73 gc_bytes_age=6633 intent_count=2 intent_bytes=30 separated_intent_count=2 intent_age=198
+stats: key_count=2 key_bytes=30 val_count=2 val_bytes=110 live_count=1 live_bytes=73 gc_bytes_age=6633 intent_count=2 intent_bytes=30 lock_count=2 lock_age=198
 
 run stats ok
 with t=A k=k4
@@ -54,7 +54,7 @@ with t=A k=k4
   cput      v=c
 ----
 >> put v=a t=A k=k4
-stats: key_count=+1 key_bytes=+15 val_count=+1 val_bytes=+60 live_count=+1 live_bytes=+75 intent_count=+1 intent_bytes=+18 separated_intent_count=+1 intent_age=+99
+stats: key_count=+1 key_bytes=+15 val_count=+1 val_bytes=+60 live_count=+1 live_bytes=+75 intent_count=+1 intent_bytes=+18 lock_count=+1 lock_age=+99
 >> cput v=b cond=a t=A k=k4
 stats: val_bytes=+10 live_bytes=+10
 >> cput v=c t=A k=k4
@@ -67,7 +67,7 @@ meta: "k3"/0,0 -> txn={id=00000001 key="k2" iso=Serializable pri=0.00000000 epo=
 data: "k3"/1.000000000,0 -> /<empty>
 meta: "k4"/0,0 -> txn={id=00000001 key="k2" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=60} ts=1.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "k4"/1.000000000,0 -> /BYTES/c
-stats: key_count=3 key_bytes=45 val_count=3 val_bytes=168 live_count=2 live_bytes=146 gc_bytes_age=6633 intent_count=3 intent_bytes=48 separated_intent_count=3 intent_age=297
+stats: key_count=3 key_bytes=45 val_count=3 val_bytes=168 live_count=2 live_bytes=146 gc_bytes_age=6633 intent_count=3 intent_bytes=48 lock_count=3 lock_age=297
 
 run stats ok
 put k=k5 v=foo ts=3
@@ -90,7 +90,7 @@ with t=B k=k5
 >> put k=k5 v=foo ts=3
 stats: key_count=+1 key_bytes=+15 val_count=+1 val_bytes=+8 live_count=+1 live_bytes=+23
 >> put v=a t=B k=k5
-stats: key_bytes=+12 val_count=+1 val_bytes=+60 live_bytes=+52 gc_bytes_age=+1900 intent_count=+1 intent_bytes=+18 separated_intent_count=+1 intent_age=+95
+stats: key_bytes=+12 val_count=+1 val_bytes=+60 live_bytes=+52 gc_bytes_age=+1900 intent_count=+1 intent_bytes=+18 lock_count=+1 lock_age=+95
 >> put v=b t=B k=k5
 stats: val_bytes=+10 live_bytes=+10
 >> put v=c t=B k=k5
@@ -100,7 +100,7 @@ meta: "k5" -> txn={id=00000002 key="k5" iso=Serializable pri=0.00000000 epo=0 ts
 stats: no change
 meta: "k5" -> txn={id=00000002 key="k5" iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=40} ts=5.000000000,0 del=false klen=12 vlen=6 ih={{10 /BYTES/a}} mergeTs=<nil> txnDidNotUpdateMeta=false
 >> resolve_intent status=COMMITTED t=B k=k5
-stats: val_bytes=-64 live_bytes=-64 intent_count=-1 intent_bytes=-18 separated_intent_count=-1 intent_age=-95
+stats: val_bytes=-64 live_bytes=-64 intent_count=-1 intent_bytes=-18 lock_count=-1 lock_age=-95
 >> at end:
 txn: "B" meta={id=00000002 key="k5" iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=40} lock=true stat=PENDING rts=5.000000000,0 wto=false gul=0,0 isn=1
 meta: "k2"/0,0 -> txn={id=00000001 key="k2" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=20} ts=1.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=false
@@ -111,4 +111,4 @@ meta: "k4"/0,0 -> txn={id=00000001 key="k2" iso=Serializable pri=0.00000000 epo=
 data: "k4"/1.000000000,0 -> /BYTES/c
 data: "k5"/5.000000000,0 -> /BYTES/d
 data: "k5"/3.000000000,0 -> /BYTES/foo
-stats: key_count=4 key_bytes=72 val_count=5 val_bytes=182 live_count=3 live_bytes=167 gc_bytes_age=8533 intent_count=3 intent_bytes=48 separated_intent_count=3 intent_age=297
+stats: key_count=4 key_bytes=72 val_count=5 val_bytes=182 live_count=3 live_bytes=167 gc_bytes_age=8533 intent_count=3 intent_bytes=48 lock_count=3 lock_age=297

--- a/pkg/storage/testdata/mvcc_histories/put_out_of_order
+++ b/pkg/storage/testdata/mvcc_histories/put_out_of_order
@@ -10,12 +10,12 @@ with t=A
   put         ts=1 k=k v=v
 ----
 >> put ts=1 k=k v=v t=A
-stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+56 live_count=+1 live_bytes=+70 intent_count=+1 intent_bytes=+18 separated_intent_count=+1 intent_age=+98
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+56 live_count=+1 live_bytes=+70 intent_count=+1 intent_bytes=+18 lock_count=+1 lock_age=+98
 >> at end:
 txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,1 min=0,0 seq=0} lock=true stat=PENDING rts=1.000000000,0 wto=false gul=0,0
 meta: "k"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,1 min=0,0 seq=0} ts=2.000000000,1 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k"/2.000000000,1 -> /BYTES/v
-stats: key_count=1 key_bytes=14 val_count=1 val_bytes=56 live_count=1 live_bytes=70 intent_count=1 intent_bytes=18 separated_intent_count=1 intent_age=98
+stats: key_count=1 key_bytes=14 val_count=1 val_bytes=56 live_count=1 live_bytes=70 intent_count=1 intent_bytes=18 lock_count=1 lock_age=98
 
 # Put operation with earlier wall time. Will NOT be ignored.
 run stats ok
@@ -30,7 +30,7 @@ stats: val_bytes=+13 live_bytes=+13 intent_bytes=+1
 txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=1.000000000,0 wto=false gul=0,0
 meta: "k"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,1 min=0,0 seq=1} ts=2.000000000,1 del=false klen=12 vlen=7 ih={{0 /BYTES/v}} mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "k"/2.000000000,1 -> /BYTES/v2
-stats: key_count=1 key_bytes=14 val_count=1 val_bytes=69 live_count=1 live_bytes=83 intent_count=1 intent_bytes=19 separated_intent_count=1 intent_age=98
+stats: key_count=1 key_bytes=14 val_count=1 val_bytes=69 live_count=1 live_bytes=83 intent_count=1 intent_bytes=19 lock_count=1 lock_age=98
 
 # We're expecting v2 here.
 
@@ -53,7 +53,7 @@ stats: val_bytes=+13 live_bytes=+13
 txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=2} lock=true stat=PENDING rts=1.000000000,0 wto=false gul=0,0
 meta: "k"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,1 min=0,0 seq=2} ts=2.000000000,1 del=false klen=12 vlen=7 ih={{0 /BYTES/v}{1 /BYTES/v2}} mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "k"/2.000000000,1 -> /BYTES/v2
-stats: key_count=1 key_bytes=14 val_count=1 val_bytes=82 live_count=1 live_bytes=96 intent_count=1 intent_bytes=19 separated_intent_count=1 intent_age=98
+stats: key_count=1 key_bytes=14 val_count=1 val_bytes=82 live_count=1 live_bytes=96 intent_count=1 intent_bytes=19 lock_count=1 lock_age=98
 
 # We're expecting v2 here.
 

--- a/pkg/storage/testdata/mvcc_histories/put_with_txn
+++ b/pkg/storage/testdata/mvcc_histories/put_with_txn
@@ -7,7 +7,7 @@ with t=A k=k
   get  ts=1
 ----
 >> put v=v t=A k=k
-stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+49 live_count=+1 live_bytes=+63 intent_count=+1 intent_bytes=+18 separated_intent_count=+1 intent_age=+100
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+49 live_count=+1 live_bytes=+63 intent_count=+1 intent_bytes=+18 lock_count=+1 lock_age=+100
 get: "k" -> /BYTES/v @0,1
 get: "k" -> /BYTES/v @0,1
 get: "k" -> /BYTES/v @0,1
@@ -15,4 +15,4 @@ get: "k" -> /BYTES/v @0,1
 txn: "A" meta={id=00000001 key="k" iso=Serializable pri=0.00000000 epo=0 ts=0,1 min=0,0 seq=0} lock=true stat=PENDING rts=0,1 wto=false gul=0,0
 meta: "k"/0,0 -> txn={id=00000001 key="k" iso=Serializable pri=0.00000000 epo=0 ts=0,1 min=0,0 seq=0} ts=0,1 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k"/0,1 -> /BYTES/v
-stats: key_count=1 key_bytes=14 val_count=1 val_bytes=49 live_count=1 live_bytes=63 intent_count=1 intent_bytes=18 separated_intent_count=1 intent_age=100
+stats: key_count=1 key_bytes=14 val_count=1 val_bytes=49 live_count=1 live_bytes=63 intent_count=1 intent_bytes=18 lock_count=1 lock_age=100

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_conflicts
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_conflicts
@@ -45,7 +45,7 @@ stats: range_key_count=+1 range_key_bytes=+13 range_val_count=+1 live_count=-5 l
 >> del_range_ts k=c end=k ts=5
 stats: range_key_count=+1 range_key_bytes=+22 range_val_count=+2 gc_bytes_age=+2108
 >> put k=g v=7 t=A ts=7
-stats: key_bytes=+12 val_count=+1 val_bytes=+54 live_count=+1 live_bytes=+68 gc_bytes_age=-194 intent_count=+1 intent_bytes=+18 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+54 live_count=+1 live_bytes=+68 gc_bytes_age=-194 intent_count=+1 intent_bytes=+18 lock_count=+1 lock_age=+93
 >> at end:
 txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=7.000000000,0 wto=false gul=0,0
 rangekey: {a-c}/[3.000000000,0=/<empty>]
@@ -59,7 +59,7 @@ data: "g"/7.000000000,0 -> /BYTES/7
 data: "g"/1.000000000,0 -> /BYTES/g1
 data: "i"/1.000000000,0 -> /INT/1
 data: "j"/1.000000000,0 -> /INT/1
-stats: key_count=6 key_bytes=108 val_count=8 val_bytes=94 range_key_count=2 range_key_bytes=35 range_val_count=3 live_count=1 live_bytes=68 gc_bytes_age=16400 intent_count=1 intent_bytes=18 separated_intent_count=1 intent_age=93
+stats: key_count=6 key_bytes=108 val_count=8 val_bytes=94 range_key_count=2 range_key_bytes=35 range_val_count=3 live_count=1 live_bytes=68 gc_bytes_age=16400 intent_count=1 intent_bytes=18 lock_count=1 lock_age=93
 
 # Inline value or tombstone below range tombstone should error.
 run stats error
@@ -79,7 +79,7 @@ data: "g"/7.000000000,0 -> /BYTES/7
 data: "g"/1.000000000,0 -> /BYTES/g1
 data: "i"/1.000000000,0 -> /INT/1
 data: "j"/1.000000000,0 -> /INT/1
-stats: key_count=6 key_bytes=108 val_count=8 val_bytes=94 range_key_count=2 range_key_bytes=35 range_val_count=3 live_count=1 live_bytes=68 gc_bytes_age=16400 intent_count=1 intent_bytes=18 separated_intent_count=1 intent_age=93
+stats: key_count=6 key_bytes=108 val_count=8 val_bytes=94 range_key_count=2 range_key_bytes=35 range_val_count=3 live_count=1 live_bytes=68 gc_bytes_age=16400 intent_count=1 intent_bytes=18 lock_count=1 lock_age=93
 error: (*withstack.withStack:) "b"/0,0: put is inline=true, but existing value is inline=false
 
 run stats error
@@ -99,7 +99,7 @@ data: "g"/7.000000000,0 -> /BYTES/7
 data: "g"/1.000000000,0 -> /BYTES/g1
 data: "i"/1.000000000,0 -> /INT/1
 data: "j"/1.000000000,0 -> /INT/1
-stats: key_count=6 key_bytes=108 val_count=8 val_bytes=94 range_key_count=2 range_key_bytes=35 range_val_count=3 live_count=1 live_bytes=68 gc_bytes_age=16400 intent_count=1 intent_bytes=18 separated_intent_count=1 intent_age=93
+stats: key_count=6 key_bytes=108 val_count=8 val_bytes=94 range_key_count=2 range_key_bytes=35 range_val_count=3 live_count=1 live_bytes=68 gc_bytes_age=16400 intent_count=1 intent_bytes=18 lock_count=1 lock_age=93
 error: (*withstack.withStack:) "b"/0,0: put is inline=true, but existing value is inline=false
 
 # DeleteRange at ts=5 should error with WriteTooOldError.
@@ -120,7 +120,7 @@ data: "g"/7.000000000,0 -> /BYTES/7
 data: "g"/1.000000000,0 -> /BYTES/g1
 data: "i"/1.000000000,0 -> /INT/1
 data: "j"/1.000000000,0 -> /INT/1
-stats: key_count=6 key_bytes=108 val_count=8 val_bytes=94 range_key_count=2 range_key_bytes=35 range_val_count=3 live_count=1 live_bytes=68 gc_bytes_age=16400 intent_count=1 intent_bytes=18 separated_intent_count=1 intent_age=93
+stats: key_count=6 key_bytes=108 val_count=8 val_bytes=94 range_key_count=2 range_key_bytes=35 range_val_count=3 live_count=1 live_bytes=68 gc_bytes_age=16400 intent_count=1 intent_bytes=18 lock_count=1 lock_age=93
 error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "c" at timestamp 5.000000000,0 too old; must write at or above 5.000000000,1
 
 # Point key below range tombstones should error.
@@ -141,7 +141,7 @@ data: "g"/7.000000000,0 -> /BYTES/7
 data: "g"/1.000000000,0 -> /BYTES/g1
 data: "i"/1.000000000,0 -> /INT/1
 data: "j"/1.000000000,0 -> /INT/1
-stats: key_count=6 key_bytes=108 val_count=8 val_bytes=94 range_key_count=2 range_key_bytes=35 range_val_count=3 live_count=1 live_bytes=68 gc_bytes_age=16400 intent_count=1 intent_bytes=18 separated_intent_count=1 intent_age=93
+stats: key_count=6 key_bytes=108 val_count=8 val_bytes=94 range_key_count=2 range_key_bytes=35 range_val_count=3 live_count=1 live_bytes=68 gc_bytes_age=16400 intent_count=1 intent_bytes=18 lock_count=1 lock_age=93
 error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "c" at timestamp 3.000000000,0 too old; must write at or above 5.000000000,1
 
 run stats error
@@ -161,7 +161,7 @@ data: "g"/7.000000000,0 -> /BYTES/7
 data: "g"/1.000000000,0 -> /BYTES/g1
 data: "i"/1.000000000,0 -> /INT/1
 data: "j"/1.000000000,0 -> /INT/1
-stats: key_count=6 key_bytes=108 val_count=8 val_bytes=94 range_key_count=2 range_key_bytes=35 range_val_count=3 live_count=1 live_bytes=68 gc_bytes_age=16400 intent_count=1 intent_bytes=18 separated_intent_count=1 intent_age=93
+stats: key_count=6 key_bytes=108 val_count=8 val_bytes=94 range_key_count=2 range_key_bytes=35 range_val_count=3 live_count=1 live_bytes=68 gc_bytes_age=16400 intent_count=1 intent_bytes=18 lock_count=1 lock_age=93
 error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "d" at timestamp 3.000000000,0 too old; must write at or above 5.000000000,1
 
 run stats error
@@ -181,7 +181,7 @@ data: "g"/7.000000000,0 -> /BYTES/7
 data: "g"/1.000000000,0 -> /BYTES/g1
 data: "i"/1.000000000,0 -> /INT/1
 data: "j"/1.000000000,0 -> /INT/1
-stats: key_count=6 key_bytes=108 val_count=8 val_bytes=94 range_key_count=2 range_key_bytes=35 range_val_count=3 live_count=1 live_bytes=68 gc_bytes_age=16400 intent_count=1 intent_bytes=18 separated_intent_count=1 intent_age=93
+stats: key_count=6 key_bytes=108 val_count=8 val_bytes=94 range_key_count=2 range_key_bytes=35 range_val_count=3 live_count=1 live_bytes=68 gc_bytes_age=16400 intent_count=1 intent_bytes=18 lock_count=1 lock_age=93
 error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "e" at timestamp 3.000000000,0 too old; must write at or above 5.000000000,1
 
 # CPuts expecting a value covered by a range tombstone should error.
@@ -202,7 +202,7 @@ data: "g"/7.000000000,0 -> /BYTES/7
 data: "g"/1.000000000,0 -> /BYTES/g1
 data: "i"/1.000000000,0 -> /INT/1
 data: "j"/1.000000000,0 -> /INT/1
-stats: key_count=6 key_bytes=108 val_count=8 val_bytes=94 range_key_count=2 range_key_bytes=35 range_val_count=3 live_count=1 live_bytes=68 gc_bytes_age=16400 intent_count=1 intent_bytes=18 separated_intent_count=1 intent_age=93
+stats: key_count=6 key_bytes=108 val_count=8 val_bytes=94 range_key_count=2 range_key_bytes=35 range_val_count=3 live_count=1 live_bytes=68 gc_bytes_age=16400 intent_count=1 intent_bytes=18 lock_count=1 lock_age=93
 error: (*kvpb.ConditionFailedError:) unexpected value: timestamp:<wall_time:5000000000 > 
 
 # A CPut replay of an intent expecting a value covered by a range tombstone
@@ -225,7 +225,7 @@ data: "g"/7.000000000,0 -> /BYTES/7
 data: "g"/1.000000000,0 -> /BYTES/g1
 data: "i"/1.000000000,0 -> /INT/1
 data: "j"/1.000000000,0 -> /INT/1
-stats: key_count=6 key_bytes=108 val_count=8 val_bytes=94 range_key_count=2 range_key_bytes=35 range_val_count=3 live_count=1 live_bytes=68 gc_bytes_age=16400 intent_count=1 intent_bytes=18 separated_intent_count=1 intent_age=93
+stats: key_count=6 key_bytes=108 val_count=8 val_bytes=94 range_key_count=2 range_key_bytes=35 range_val_count=3 live_count=1 live_bytes=68 gc_bytes_age=16400 intent_count=1 intent_bytes=18 lock_count=1 lock_age=93
 error: (*kvpb.ConditionFailedError:) unexpected value: timestamp:<wall_time:5000000000 > 
 
 # A CPut replacing an existing but ignored intent expecting a value covered
@@ -251,7 +251,7 @@ data: "g"/7.000000000,0 -> /BYTES/7
 data: "g"/1.000000000,0 -> /BYTES/g1
 data: "i"/1.000000000,0 -> /INT/1
 data: "j"/1.000000000,0 -> /INT/1
-stats: key_count=6 key_bytes=108 val_count=8 val_bytes=94 range_key_count=2 range_key_bytes=35 range_val_count=3 live_count=1 live_bytes=68 gc_bytes_age=16400 intent_count=1 intent_bytes=18 separated_intent_count=1 intent_age=93
+stats: key_count=6 key_bytes=108 val_count=8 val_bytes=94 range_key_count=2 range_key_bytes=35 range_val_count=3 live_count=1 live_bytes=68 gc_bytes_age=16400 intent_count=1 intent_bytes=18 lock_count=1 lock_age=93
 error: (*kvpb.ConditionFailedError:) unexpected value: timestamp:<wall_time:5000000000 > 
 
 # An InitPut with failOnTombstones above a range tombstone should error.
@@ -272,7 +272,7 @@ data: "g"/7.000000000,0 -> /BYTES/7
 data: "g"/1.000000000,0 -> /BYTES/g1
 data: "i"/1.000000000,0 -> /INT/1
 data: "j"/1.000000000,0 -> /INT/1
-stats: key_count=6 key_bytes=108 val_count=8 val_bytes=94 range_key_count=2 range_key_bytes=35 range_val_count=3 live_count=1 live_bytes=68 gc_bytes_age=16400 intent_count=1 intent_bytes=18 separated_intent_count=1 intent_age=93
+stats: key_count=6 key_bytes=108 val_count=8 val_bytes=94 range_key_count=2 range_key_bytes=35 range_val_count=3 live_count=1 live_bytes=68 gc_bytes_age=16400 intent_count=1 intent_bytes=18 lock_count=1 lock_age=93
 error: (*kvpb.ConditionFailedError:) unexpected value: timestamp:<wall_time:5000000000 > 
 
 # An InitPut with a different value as an existing key should succeed when there's
@@ -295,7 +295,7 @@ data: "g"/7.000000000,0 -> /BYTES/7
 data: "g"/1.000000000,0 -> /BYTES/g1
 data: "i"/1.000000000,0 -> /INT/1
 data: "j"/1.000000000,0 -> /INT/1
-stats: key_count=6 key_bytes=120 val_count=9 val_bytes=101 range_key_count=2 range_key_bytes=35 range_val_count=3 live_count=2 live_bytes=89 gc_bytes_age=16206 intent_count=1 intent_bytes=18 separated_intent_count=1 intent_age=93
+stats: key_count=6 key_bytes=120 val_count=9 val_bytes=101 range_key_count=2 range_key_bytes=35 range_val_count=3 live_count=2 live_bytes=89 gc_bytes_age=16206 intent_count=1 intent_bytes=18 lock_count=1 lock_age=93
 
 # An increment below a range tombstone throw a WriteTooOldError.
 run stats error
@@ -316,7 +316,7 @@ data: "g"/7.000000000,0 -> /BYTES/7
 data: "g"/1.000000000,0 -> /BYTES/g1
 data: "i"/1.000000000,0 -> /INT/1
 data: "j"/1.000000000,0 -> /INT/1
-stats: key_count=6 key_bytes=120 val_count=9 val_bytes=101 range_key_count=2 range_key_bytes=35 range_val_count=3 live_count=2 live_bytes=89 gc_bytes_age=16206 intent_count=1 intent_bytes=18 separated_intent_count=1 intent_age=93
+stats: key_count=6 key_bytes=120 val_count=9 val_bytes=101 range_key_count=2 range_key_bytes=35 range_val_count=3 live_count=2 live_bytes=89 gc_bytes_age=16206 intent_count=1 intent_bytes=18 lock_count=1 lock_age=93
 error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "i" at timestamp 2.000000000,0 too old; must write at or above 5.000000000,1
 
 # An increment above a range tombstone should reset to 1.
@@ -340,4 +340,4 @@ data: "g"/1.000000000,0 -> /BYTES/g1
 data: "i"/1.000000000,0 -> /INT/1
 data: "j"/7.000000000,0 -> /INT/1
 data: "j"/1.000000000,0 -> /INT/1
-stats: key_count=6 key_bytes=132 val_count=10 val_bytes=107 range_key_count=2 range_key_bytes=35 range_val_count=3 live_count=3 live_bytes=109 gc_bytes_age=16012 intent_count=1 intent_bytes=18 separated_intent_count=1 intent_age=93
+stats: key_count=6 key_bytes=132 val_count=10 val_bytes=107 range_key_count=2 range_key_bytes=35 range_val_count=3 live_count=3 live_bytes=109 gc_bytes_age=16012 intent_count=1 intent_bytes=18 lock_count=1 lock_age=93

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_gets_complex
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_gets_complex
@@ -82,11 +82,11 @@ stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_b
 >> put k=k ts=5 v=k5
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21
 >> put k=d v=d7 t=A
-stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-190 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-190 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=f v=f7 t=A
-stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_bytes=+48 gc_bytes_age=+1767 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_bytes=+48 gc_bytes_age=+1767 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=j v=j7 t=A
-stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+93
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> at end:
 txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=7.000000000,0 wto=false gul=0,0
 rangekey: {a-b}/[1.000000000,0=/<empty>]
@@ -116,7 +116,7 @@ data: "h"/3.000000000,0 -> /BYTES/h3
 meta: "j"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "j"/7.000000000,0 -> /BYTES/j7
 data: "k"/5.000000000,0 -> /BYTES/k5
-stats: key_count=9 key_bytes=210 val_count=16 val_bytes=242 range_key_count=8 range_key_bytes=158 range_val_count=14 range_val_bytes=13 live_count=5 live_bytes=249 gc_bytes_age=35952 intent_count=3 intent_bytes=57 separated_intent_count=3 intent_age=279
+stats: key_count=9 key_bytes=210 val_count=16 val_bytes=242 range_key_count=8 range_key_bytes=158 range_val_count=14 range_val_bytes=13 live_count=5 live_bytes=249 gc_bytes_age=35952 intent_count=3 intent_bytes=57 lock_count=3 lock_age=279
 
 # Run gets for all keys at all timestamps, with tombstones and intents.
 run ok

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_iter
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_iter
@@ -80,17 +80,17 @@ stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_b
 >> del_range_ts k=m end=n ts=3 localTs=2
 stats: range_key_count=+1 range_key_bytes=+13 range_val_count=+1 range_val_bytes=+13 gc_bytes_age=+2522
 >> put k=a v=a7 t=A
-stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-192 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-192 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=d v=d7 t=A
-stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-190 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-190 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=j v=j7 t=A
-stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+93
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=l v=l7 t=A
-stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+93
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=m v=l7 t=A
-stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+93
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=o v=n7 t=A
-stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+93
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> at end:
 txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=7.000000000,0 wto=false gul=0,0
 rangekey: {a-b}/[1.000000000,0=/<empty>]
@@ -126,7 +126,7 @@ meta: "m"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0
 data: "m"/7.000000000,0 -> /BYTES/l7
 meta: "o"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "o"/7.000000000,0 -> /BYTES/n7
-stats: key_count=12 key_bytes=252 val_count=19 val_bytes=400 range_key_count=8 range_key_bytes=167 range_val_count=15 range_val_bytes=13 live_count=9 live_bytes=477 gc_bytes_age=34303 intent_count=6 intent_bytes=114 separated_intent_count=6 intent_age=558
+stats: key_count=12 key_bytes=252 val_count=19 val_bytes=400 range_key_count=8 range_key_bytes=167 range_val_count=15 range_val_bytes=13 live_count=9 live_bytes=477 gc_bytes_age=34303 intent_count=6 intent_bytes=114 lock_count=6 lock_age=558
 
 # Iterate across the entire span for all key types, and without intents.
 run ok

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_iter_incremental
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_iter_incremental
@@ -83,17 +83,17 @@ stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_b
 >> del_range_ts k=m end=n ts=3 localTs=2
 stats: range_key_count=+1 range_key_bytes=+13 range_val_count=+1 range_val_bytes=+13 gc_bytes_age=+2522
 >> put k=a v=a7 t=A
-stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-192 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-192 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=j v=j7 t=A
-stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+93
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=l v=l7 t=A
-stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+93
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=o v=o7 t=A
-stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+93
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=d v=d8 t=B
-stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-190 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+92
+stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-190 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+92
 >> put k=m v=m8 t=B
-stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+92
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+92
 >> at end:
 txn: "B" meta={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=8.000000000,0 wto=false gul=0,0
 rangekey: {a-b}/[1.000000000,0=/<empty>]
@@ -129,7 +129,7 @@ meta: "m"/0,0 -> txn={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0
 data: "m"/8.000000000,0 -> /BYTES/m8
 meta: "o"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "o"/7.000000000,0 -> /BYTES/o7
-stats: key_count=12 key_bytes=252 val_count=19 val_bytes=400 range_key_count=8 range_key_bytes=167 range_val_count=15 range_val_bytes=13 live_count=9 live_bytes=477 gc_bytes_age=34303 intent_count=6 intent_bytes=114 separated_intent_count=6 intent_age=556
+stats: key_count=12 key_bytes=252 val_count=19 val_bytes=400 range_key_count=8 range_key_bytes=167 range_val_count=15 range_val_bytes=13 live_count=9 live_bytes=477 gc_bytes_age=34303 intent_count=6 intent_bytes=114 lock_count=6 lock_age=556
 
 # Iterate across the entire span for all key types.
 run ok

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_scans_complex
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_scans_complex
@@ -82,11 +82,11 @@ stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_b
 >> put k=k ts=5 v=k5
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21
 >> put k=d v=d7 t=A
-stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-190 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-190 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=f v=f7 t=A
-stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_bytes=+48 gc_bytes_age=+1767 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_bytes=+48 gc_bytes_age=+1767 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=j v=j7 t=A
-stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+93
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> at end:
 txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=7.000000000,0 wto=false gul=0,0
 rangekey: {a-b}/[1.000000000,0=/<empty>]
@@ -116,7 +116,7 @@ data: "h"/3.000000000,0 -> /BYTES/h3
 meta: "j"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "j"/7.000000000,0 -> /BYTES/j7
 data: "k"/5.000000000,0 -> /BYTES/k5
-stats: key_count=9 key_bytes=210 val_count=16 val_bytes=242 range_key_count=8 range_key_bytes=158 range_val_count=14 range_val_bytes=13 live_count=5 live_bytes=249 gc_bytes_age=35952 intent_count=3 intent_bytes=57 separated_intent_count=3 intent_age=279
+stats: key_count=9 key_bytes=210 val_count=16 val_bytes=242 range_key_count=8 range_key_bytes=158 range_val_count=14 range_val_bytes=13 live_count=5 live_bytes=249 gc_bytes_age=35952 intent_count=3 intent_bytes=57 lock_count=3 lock_age=279
 
 # Forward scans at all timestamps.
 run ok

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_stats_intent_resolve_abort
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_stats_intent_resolve_abort
@@ -109,50 +109,50 @@ stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_b
 del: "r": found key false
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+9 gc_bytes_age=+2162
 >> put k=a v=a7 t=A
-stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+93
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=b v=b7 t=A
-stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_bytes=+48 gc_bytes_age=+1767 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_bytes=+48 gc_bytes_age=+1767 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=c v=c7 t=A
-stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-198 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-198 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> del k=d t=A
 del: "d": found key false
-stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5766 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+93
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5766 intent_count=+1 intent_bytes=+12 lock_count=+1 lock_age=+93
 >> del k=e t=A
 del: "e": found key true
-stats: key_bytes=+12 val_count=+1 val_bytes=+48 live_count=-1 live_bytes=-21 gc_bytes_age=+7533 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+48 live_count=-1 live_bytes=-21 gc_bytes_age=+7533 intent_count=+1 intent_bytes=+12 lock_count=+1 lock_age=+93
 >> del k=f localTs=5.9 t=A
 del: "f": found key false
-stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6777 intent_count=+1 intent_bytes=+25 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6777 intent_count=+1 intent_bytes=+25 lock_count=+1 lock_age=+93
 >> put k=g v=g7 t=A
-stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+93
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=h v=h7 t=A
-stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-194 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-194 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=i v=i7 t=A
-stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-198 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-198 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> del k=j t=A
 del: "j": found key false
-stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5766 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+93
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5766 intent_count=+1 intent_bytes=+12 lock_count=+1 lock_age=+93
 >> del k=k t=A
 del: "k": found key false
-stats: key_bytes=+12 val_count=+1 val_bytes=+48 gc_bytes_age=+5572 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+48 gc_bytes_age=+5572 intent_count=+1 intent_bytes=+12 lock_count=+1 lock_age=+93
 >> del k=l localTs=5.9 t=A
 del: "l": found key false
-stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6777 intent_count=+1 intent_bytes=+25 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6777 intent_count=+1 intent_bytes=+25 lock_count=+1 lock_age=+93
 >> put k=m v=m7 t=A
-stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+93
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=n v=n7 t=A
-stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_bytes=+48 gc_bytes_age=+1767 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_bytes=+48 gc_bytes_age=+1767 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=o v=o7 t=A
-stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-188 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-188 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> del k=p t=A
 del: "p": found key false
-stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5766 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+93
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5766 intent_count=+1 intent_bytes=+12 lock_count=+1 lock_age=+93
 >> del k=q t=A
 del: "q": found key true
-stats: key_bytes=+12 val_count=+1 val_bytes=+48 live_count=-1 live_bytes=-21 gc_bytes_age=+7533 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+48 live_count=-1 live_bytes=-21 gc_bytes_age=+7533 intent_count=+1 intent_bytes=+12 lock_count=+1 lock_age=+93
 >> del k=r localTs=5.9 t=A
 del: "r": found key false
-stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6787 intent_count=+1 intent_bytes=+25 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6787 intent_count=+1 intent_bytes=+25 lock_count=+1 lock_age=+93
 >> at end:
 txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=7.000000000,0 wto=false gul=0,0
 rangekey: g{-gg}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
@@ -212,7 +212,7 @@ data: "q"/6.000000000,0 -> /BYTES/q6
 meta: "r"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=true klen=12 vlen=13 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "r"/7.000000000,0 -> {localTs=5.000000009,0}/<empty>
 data: "r"/6.000000000,0 -> {localTs=0.000000009,0}/<empty>
-stats: key_count=18 key_bytes=396 val_count=30 val_bytes=1062 range_key_count=9 range_key_bytes=250 range_val_count=22 live_count=9 live_bytes=621 gc_bytes_age=102487 intent_count=18 intent_bytes=318 separated_intent_count=18 intent_age=1674
+stats: key_count=18 key_bytes=396 val_count=30 val_bytes=1062 range_key_count=9 range_key_bytes=250 range_val_count=22 live_count=9 live_bytes=621 gc_bytes_age=102487 intent_count=18 intent_bytes=318 lock_count=18 lock_age=1674
 
 run stats ok
 with t=A status=ABORTED
@@ -236,41 +236,41 @@ with t=A status=ABORTED
   resolve_intent k=r
 ----
 >> resolve_intent k=a t=A status=ABORTED
-stats: key_count=-1 key_bytes=-14 val_count=-1 val_bytes=-55 live_count=-1 live_bytes=-69 intent_count=-1 intent_bytes=-19 separated_intent_count=-1 intent_age=-93
+stats: key_count=-1 key_bytes=-14 val_count=-1 val_bytes=-55 live_count=-1 live_bytes=-69 intent_count=-1 intent_bytes=-19 lock_count=-1 lock_age=-93
 >> resolve_intent k=b t=A status=ABORTED
-stats: key_bytes=-12 val_count=-1 val_bytes=-55 live_bytes=-48 gc_bytes_age=-1767 intent_count=-1 intent_bytes=-19 separated_intent_count=-1 intent_age=-93
+stats: key_bytes=-12 val_count=-1 val_bytes=-55 live_bytes=-48 gc_bytes_age=-1767 intent_count=-1 intent_bytes=-19 lock_count=-1 lock_age=-93
 >> resolve_intent k=c t=A status=ABORTED
-stats: key_bytes=-12 val_count=-1 val_bytes=-55 live_count=-1 live_bytes=-69 gc_bytes_age=+198 intent_count=-1 intent_bytes=-19 separated_intent_count=-1 intent_age=-93
+stats: key_bytes=-12 val_count=-1 val_bytes=-55 live_count=-1 live_bytes=-69 gc_bytes_age=+198 intent_count=-1 intent_bytes=-19 lock_count=-1 lock_age=-93
 >> resolve_intent k=d t=A status=ABORTED
-stats: key_count=-1 key_bytes=-14 val_count=-1 val_bytes=-48 gc_bytes_age=-5766 intent_count=-1 intent_bytes=-12 separated_intent_count=-1 intent_age=-93
+stats: key_count=-1 key_bytes=-14 val_count=-1 val_bytes=-48 gc_bytes_age=-5766 intent_count=-1 intent_bytes=-12 lock_count=-1 lock_age=-93
 >> resolve_intent k=e t=A status=ABORTED
-stats: key_bytes=-12 val_count=-1 val_bytes=-48 live_count=+1 live_bytes=+21 gc_bytes_age=-7533 intent_count=-1 intent_bytes=-12 separated_intent_count=-1 intent_age=-93
+stats: key_bytes=-12 val_count=-1 val_bytes=-48 live_count=+1 live_bytes=+21 gc_bytes_age=-7533 intent_count=-1 intent_bytes=-12 lock_count=-1 lock_age=-93
 >> resolve_intent k=f t=A status=ABORTED
-stats: key_bytes=-12 val_count=-1 val_bytes=-61 gc_bytes_age=-6777 intent_count=-1 intent_bytes=-25 separated_intent_count=-1 intent_age=-93
+stats: key_bytes=-12 val_count=-1 val_bytes=-61 gc_bytes_age=-6777 intent_count=-1 intent_bytes=-25 lock_count=-1 lock_age=-93
 >> resolve_intent k=g t=A status=ABORTED
-stats: key_count=-1 key_bytes=-14 val_count=-1 val_bytes=-55 live_count=-1 live_bytes=-69 intent_count=-1 intent_bytes=-19 separated_intent_count=-1 intent_age=-93
+stats: key_count=-1 key_bytes=-14 val_count=-1 val_bytes=-55 live_count=-1 live_bytes=-69 intent_count=-1 intent_bytes=-19 lock_count=-1 lock_age=-93
 >> resolve_intent k=h t=A status=ABORTED
-stats: key_bytes=-12 val_count=-1 val_bytes=-55 live_count=-1 live_bytes=-69 gc_bytes_age=+194 intent_count=-1 intent_bytes=-19 separated_intent_count=-1 intent_age=-93
+stats: key_bytes=-12 val_count=-1 val_bytes=-55 live_count=-1 live_bytes=-69 gc_bytes_age=+194 intent_count=-1 intent_bytes=-19 lock_count=-1 lock_age=-93
 >> resolve_intent k=i t=A status=ABORTED
-stats: key_bytes=-12 val_count=-1 val_bytes=-55 live_count=-1 live_bytes=-69 gc_bytes_age=+198 intent_count=-1 intent_bytes=-19 separated_intent_count=-1 intent_age=-93
+stats: key_bytes=-12 val_count=-1 val_bytes=-55 live_count=-1 live_bytes=-69 gc_bytes_age=+198 intent_count=-1 intent_bytes=-19 lock_count=-1 lock_age=-93
 >> resolve_intent k=j t=A status=ABORTED
-stats: key_count=-1 key_bytes=-14 val_count=-1 val_bytes=-48 gc_bytes_age=-5766 intent_count=-1 intent_bytes=-12 separated_intent_count=-1 intent_age=-93
+stats: key_count=-1 key_bytes=-14 val_count=-1 val_bytes=-48 gc_bytes_age=-5766 intent_count=-1 intent_bytes=-12 lock_count=-1 lock_age=-93
 >> resolve_intent k=k t=A status=ABORTED
-stats: key_bytes=-12 val_count=-1 val_bytes=-48 gc_bytes_age=-5572 intent_count=-1 intent_bytes=-12 separated_intent_count=-1 intent_age=-93
+stats: key_bytes=-12 val_count=-1 val_bytes=-48 gc_bytes_age=-5572 intent_count=-1 intent_bytes=-12 lock_count=-1 lock_age=-93
 >> resolve_intent k=l t=A status=ABORTED
-stats: key_bytes=-12 val_count=-1 val_bytes=-61 gc_bytes_age=-6777 intent_count=-1 intent_bytes=-25 separated_intent_count=-1 intent_age=-93
+stats: key_bytes=-12 val_count=-1 val_bytes=-61 gc_bytes_age=-6777 intent_count=-1 intent_bytes=-25 lock_count=-1 lock_age=-93
 >> resolve_intent k=m t=A status=ABORTED
-stats: key_count=-1 key_bytes=-14 val_count=-1 val_bytes=-55 live_count=-1 live_bytes=-69 intent_count=-1 intent_bytes=-19 separated_intent_count=-1 intent_age=-93
+stats: key_count=-1 key_bytes=-14 val_count=-1 val_bytes=-55 live_count=-1 live_bytes=-69 intent_count=-1 intent_bytes=-19 lock_count=-1 lock_age=-93
 >> resolve_intent k=n t=A status=ABORTED
-stats: key_bytes=-12 val_count=-1 val_bytes=-55 live_bytes=-48 gc_bytes_age=-1767 intent_count=-1 intent_bytes=-19 separated_intent_count=-1 intent_age=-93
+stats: key_bytes=-12 val_count=-1 val_bytes=-55 live_bytes=-48 gc_bytes_age=-1767 intent_count=-1 intent_bytes=-19 lock_count=-1 lock_age=-93
 >> resolve_intent k=o t=A status=ABORTED
-stats: key_bytes=-12 val_count=-1 val_bytes=-55 live_count=-1 live_bytes=-69 gc_bytes_age=+188 intent_count=-1 intent_bytes=-19 separated_intent_count=-1 intent_age=-93
+stats: key_bytes=-12 val_count=-1 val_bytes=-55 live_count=-1 live_bytes=-69 gc_bytes_age=+188 intent_count=-1 intent_bytes=-19 lock_count=-1 lock_age=-93
 >> resolve_intent k=p t=A status=ABORTED
-stats: key_count=-1 key_bytes=-14 val_count=-1 val_bytes=-48 gc_bytes_age=-5766 intent_count=-1 intent_bytes=-12 separated_intent_count=-1 intent_age=-93
+stats: key_count=-1 key_bytes=-14 val_count=-1 val_bytes=-48 gc_bytes_age=-5766 intent_count=-1 intent_bytes=-12 lock_count=-1 lock_age=-93
 >> resolve_intent k=q t=A status=ABORTED
-stats: key_bytes=-12 val_count=-1 val_bytes=-48 live_count=+1 live_bytes=+21 gc_bytes_age=-7533 intent_count=-1 intent_bytes=-12 separated_intent_count=-1 intent_age=-93
+stats: key_bytes=-12 val_count=-1 val_bytes=-48 live_count=+1 live_bytes=+21 gc_bytes_age=-7533 intent_count=-1 intent_bytes=-12 lock_count=-1 lock_age=-93
 >> resolve_intent k=r t=A status=ABORTED
-stats: key_bytes=-12 val_count=-1 val_bytes=-61 gc_bytes_age=-6787 intent_count=-1 intent_bytes=-25 separated_intent_count=-1 intent_age=-93
+stats: key_bytes=-12 val_count=-1 val_bytes=-61 gc_bytes_age=-6787 intent_count=-1 intent_bytes=-25 lock_count=-1 lock_age=-93
 >> at end:
 rangekey: g{-gg}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
 rangekey: {ggg-i}/[5.000000000,0=/<empty> 4.000000000,0=/<empty> 3.000000000,0=/<empty>]

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_stats_intent_resolve_commit
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_stats_intent_resolve_commit
@@ -109,50 +109,50 @@ stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_b
 del: "r": found key false
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+9 gc_bytes_age=+2162
 >> put k=a v=a7 t=A
-stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+93
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=b v=b7 t=A
-stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_bytes=+48 gc_bytes_age=+1767 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_bytes=+48 gc_bytes_age=+1767 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=c v=c7 t=A
-stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-198 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-198 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> del k=d t=A
 del: "d": found key false
-stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5766 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+93
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5766 intent_count=+1 intent_bytes=+12 lock_count=+1 lock_age=+93
 >> del k=e t=A
 del: "e": found key true
-stats: key_bytes=+12 val_count=+1 val_bytes=+48 live_count=-1 live_bytes=-21 gc_bytes_age=+7533 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+48 live_count=-1 live_bytes=-21 gc_bytes_age=+7533 intent_count=+1 intent_bytes=+12 lock_count=+1 lock_age=+93
 >> del k=f localTs=5.9 t=A
 del: "f": found key false
-stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6777 intent_count=+1 intent_bytes=+25 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6777 intent_count=+1 intent_bytes=+25 lock_count=+1 lock_age=+93
 >> put k=g v=g7 t=A
-stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+93
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=h v=h7 t=A
-stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-194 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-194 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=i v=i7 t=A
-stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-198 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-198 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> del k=j t=A
 del: "j": found key false
-stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5766 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+93
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5766 intent_count=+1 intent_bytes=+12 lock_count=+1 lock_age=+93
 >> del k=k t=A
 del: "k": found key false
-stats: key_bytes=+12 val_count=+1 val_bytes=+48 gc_bytes_age=+5572 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+48 gc_bytes_age=+5572 intent_count=+1 intent_bytes=+12 lock_count=+1 lock_age=+93
 >> del k=l localTs=5.9 t=A
 del: "l": found key false
-stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6777 intent_count=+1 intent_bytes=+25 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6777 intent_count=+1 intent_bytes=+25 lock_count=+1 lock_age=+93
 >> put k=m v=m7 t=A
-stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+93
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=n v=n7 t=A
-stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_bytes=+48 gc_bytes_age=+1767 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_bytes=+48 gc_bytes_age=+1767 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=o v=o7 t=A
-stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-188 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-188 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> del k=p t=A
 del: "p": found key false
-stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5766 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+93
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5766 intent_count=+1 intent_bytes=+12 lock_count=+1 lock_age=+93
 >> del k=q t=A
 del: "q": found key true
-stats: key_bytes=+12 val_count=+1 val_bytes=+48 live_count=-1 live_bytes=-21 gc_bytes_age=+7533 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+48 live_count=-1 live_bytes=-21 gc_bytes_age=+7533 intent_count=+1 intent_bytes=+12 lock_count=+1 lock_age=+93
 >> del k=r localTs=5.9 t=A
 del: "r": found key false
-stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6787 intent_count=+1 intent_bytes=+25 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6787 intent_count=+1 intent_bytes=+25 lock_count=+1 lock_age=+93
 >> at end:
 txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=7.000000000,0 wto=false gul=0,0
 rangekey: g{-gg}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
@@ -212,7 +212,7 @@ data: "q"/6.000000000,0 -> /BYTES/q6
 meta: "r"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=true klen=12 vlen=13 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "r"/7.000000000,0 -> {localTs=5.000000009,0}/<empty>
 data: "r"/6.000000000,0 -> {localTs=0.000000009,0}/<empty>
-stats: key_count=18 key_bytes=396 val_count=30 val_bytes=1062 range_key_count=9 range_key_bytes=250 range_val_count=22 live_count=9 live_bytes=621 gc_bytes_age=102487 intent_count=18 intent_bytes=318 separated_intent_count=18 intent_age=1674
+stats: key_count=18 key_bytes=396 val_count=30 val_bytes=1062 range_key_count=9 range_key_bytes=250 range_val_count=22 live_count=9 live_bytes=621 gc_bytes_age=102487 intent_count=18 intent_bytes=318 lock_count=18 lock_age=1674
 
 run stats ok
 with t=A status=COMMITTED
@@ -236,41 +236,41 @@ with t=A status=COMMITTED
   resolve_intent k=r
 ----
 >> resolve_intent k=a t=A status=COMMITTED
-stats: val_bytes=-48 live_bytes=-48 intent_count=-1 intent_bytes=-19 separated_intent_count=-1 intent_age=-93
+stats: val_bytes=-48 live_bytes=-48 intent_count=-1 intent_bytes=-19 lock_count=-1 lock_age=-93
 >> resolve_intent k=b t=A status=COMMITTED
-stats: val_bytes=-48 live_bytes=-48 intent_count=-1 intent_bytes=-19 separated_intent_count=-1 intent_age=-93
+stats: val_bytes=-48 live_bytes=-48 intent_count=-1 intent_bytes=-19 lock_count=-1 lock_age=-93
 >> resolve_intent k=c t=A status=COMMITTED
-stats: val_bytes=-48 live_bytes=-48 intent_count=-1 intent_bytes=-19 separated_intent_count=-1 intent_age=-93
+stats: val_bytes=-48 live_bytes=-48 intent_count=-1 intent_bytes=-19 lock_count=-1 lock_age=-93
 >> resolve_intent k=d t=A status=COMMITTED
-stats: val_bytes=-48 gc_bytes_age=-4464 intent_count=-1 intent_bytes=-12 separated_intent_count=-1 intent_age=-93
+stats: val_bytes=-48 gc_bytes_age=-4464 intent_count=-1 intent_bytes=-12 lock_count=-1 lock_age=-93
 >> resolve_intent k=e t=A status=COMMITTED
-stats: val_bytes=-48 gc_bytes_age=-4464 intent_count=-1 intent_bytes=-12 separated_intent_count=-1 intent_age=-93
+stats: val_bytes=-48 gc_bytes_age=-4464 intent_count=-1 intent_bytes=-12 lock_count=-1 lock_age=-93
 >> resolve_intent k=f t=A status=COMMITTED
-stats: val_bytes=-48 gc_bytes_age=-4464 intent_count=-1 intent_bytes=-25 separated_intent_count=-1 intent_age=-93
+stats: val_bytes=-48 gc_bytes_age=-4464 intent_count=-1 intent_bytes=-25 lock_count=-1 lock_age=-93
 >> resolve_intent k=g t=A status=COMMITTED
-stats: val_bytes=-48 live_bytes=-48 intent_count=-1 intent_bytes=-19 separated_intent_count=-1 intent_age=-93
+stats: val_bytes=-48 live_bytes=-48 intent_count=-1 intent_bytes=-19 lock_count=-1 lock_age=-93
 >> resolve_intent k=h t=A status=COMMITTED
-stats: val_bytes=-48 live_bytes=-48 intent_count=-1 intent_bytes=-19 separated_intent_count=-1 intent_age=-93
+stats: val_bytes=-48 live_bytes=-48 intent_count=-1 intent_bytes=-19 lock_count=-1 lock_age=-93
 >> resolve_intent k=i t=A status=COMMITTED
-stats: val_bytes=-48 live_bytes=-48 intent_count=-1 intent_bytes=-19 separated_intent_count=-1 intent_age=-93
+stats: val_bytes=-48 live_bytes=-48 intent_count=-1 intent_bytes=-19 lock_count=-1 lock_age=-93
 >> resolve_intent k=j t=A status=COMMITTED
-stats: val_bytes=-48 gc_bytes_age=-4464 intent_count=-1 intent_bytes=-12 separated_intent_count=-1 intent_age=-93
+stats: val_bytes=-48 gc_bytes_age=-4464 intent_count=-1 intent_bytes=-12 lock_count=-1 lock_age=-93
 >> resolve_intent k=k t=A status=COMMITTED
-stats: val_bytes=-48 gc_bytes_age=-4464 intent_count=-1 intent_bytes=-12 separated_intent_count=-1 intent_age=-93
+stats: val_bytes=-48 gc_bytes_age=-4464 intent_count=-1 intent_bytes=-12 lock_count=-1 lock_age=-93
 >> resolve_intent k=l t=A status=COMMITTED
-stats: val_bytes=-48 gc_bytes_age=-4464 intent_count=-1 intent_bytes=-25 separated_intent_count=-1 intent_age=-93
+stats: val_bytes=-48 gc_bytes_age=-4464 intent_count=-1 intent_bytes=-25 lock_count=-1 lock_age=-93
 >> resolve_intent k=m t=A status=COMMITTED
-stats: val_bytes=-48 live_bytes=-48 intent_count=-1 intent_bytes=-19 separated_intent_count=-1 intent_age=-93
+stats: val_bytes=-48 live_bytes=-48 intent_count=-1 intent_bytes=-19 lock_count=-1 lock_age=-93
 >> resolve_intent k=n t=A status=COMMITTED
-stats: val_bytes=-48 live_bytes=-48 intent_count=-1 intent_bytes=-19 separated_intent_count=-1 intent_age=-93
+stats: val_bytes=-48 live_bytes=-48 intent_count=-1 intent_bytes=-19 lock_count=-1 lock_age=-93
 >> resolve_intent k=o t=A status=COMMITTED
-stats: val_bytes=-48 live_bytes=-48 intent_count=-1 intent_bytes=-19 separated_intent_count=-1 intent_age=-93
+stats: val_bytes=-48 live_bytes=-48 intent_count=-1 intent_bytes=-19 lock_count=-1 lock_age=-93
 >> resolve_intent k=p t=A status=COMMITTED
-stats: val_bytes=-48 gc_bytes_age=-4464 intent_count=-1 intent_bytes=-12 separated_intent_count=-1 intent_age=-93
+stats: val_bytes=-48 gc_bytes_age=-4464 intent_count=-1 intent_bytes=-12 lock_count=-1 lock_age=-93
 >> resolve_intent k=q t=A status=COMMITTED
-stats: val_bytes=-48 gc_bytes_age=-4464 intent_count=-1 intent_bytes=-12 separated_intent_count=-1 intent_age=-93
+stats: val_bytes=-48 gc_bytes_age=-4464 intent_count=-1 intent_bytes=-12 lock_count=-1 lock_age=-93
 >> resolve_intent k=r t=A status=COMMITTED
-stats: val_bytes=-48 gc_bytes_age=-4464 intent_count=-1 intent_bytes=-25 separated_intent_count=-1 intent_age=-93
+stats: val_bytes=-48 gc_bytes_age=-4464 intent_count=-1 intent_bytes=-25 lock_count=-1 lock_age=-93
 >> at end:
 rangekey: g{-gg}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
 rangekey: {ggg-i}/[5.000000000,0=/<empty> 4.000000000,0=/<empty> 3.000000000,0=/<empty>]

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_stats_intent_resolve_pushed
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_stats_intent_resolve_pushed
@@ -109,50 +109,50 @@ stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_b
 del: "r": found key false
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+9 gc_bytes_age=+2162
 >> put k=a v=a7 t=A
-stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+93
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=b v=b7 t=A
-stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_bytes=+48 gc_bytes_age=+1767 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_bytes=+48 gc_bytes_age=+1767 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=c v=c7 t=A
-stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-198 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-198 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> del k=d t=A
 del: "d": found key false
-stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5766 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+93
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5766 intent_count=+1 intent_bytes=+12 lock_count=+1 lock_age=+93
 >> del k=e t=A
 del: "e": found key true
-stats: key_bytes=+12 val_count=+1 val_bytes=+48 live_count=-1 live_bytes=-21 gc_bytes_age=+7533 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+48 live_count=-1 live_bytes=-21 gc_bytes_age=+7533 intent_count=+1 intent_bytes=+12 lock_count=+1 lock_age=+93
 >> del k=f localTs=5.9 t=A
 del: "f": found key false
-stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6777 intent_count=+1 intent_bytes=+25 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6777 intent_count=+1 intent_bytes=+25 lock_count=+1 lock_age=+93
 >> put k=g v=g7 t=A
-stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+93
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=h v=h7 t=A
-stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-194 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-194 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=i v=i7 t=A
-stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-198 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-198 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> del k=j t=A
 del: "j": found key false
-stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5766 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+93
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5766 intent_count=+1 intent_bytes=+12 lock_count=+1 lock_age=+93
 >> del k=k t=A
 del: "k": found key false
-stats: key_bytes=+12 val_count=+1 val_bytes=+48 gc_bytes_age=+5572 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+48 gc_bytes_age=+5572 intent_count=+1 intent_bytes=+12 lock_count=+1 lock_age=+93
 >> del k=l localTs=5.9 t=A
 del: "l": found key false
-stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6777 intent_count=+1 intent_bytes=+25 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6777 intent_count=+1 intent_bytes=+25 lock_count=+1 lock_age=+93
 >> put k=m v=m7 t=A
-stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+93
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=n v=n7 t=A
-stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_bytes=+48 gc_bytes_age=+1767 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_bytes=+48 gc_bytes_age=+1767 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=o v=o7 t=A
-stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-188 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-188 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> del k=p t=A
 del: "p": found key false
-stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5766 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+93
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5766 intent_count=+1 intent_bytes=+12 lock_count=+1 lock_age=+93
 >> del k=q t=A
 del: "q": found key true
-stats: key_bytes=+12 val_count=+1 val_bytes=+48 live_count=-1 live_bytes=-21 gc_bytes_age=+7533 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+48 live_count=-1 live_bytes=-21 gc_bytes_age=+7533 intent_count=+1 intent_bytes=+12 lock_count=+1 lock_age=+93
 >> del k=r localTs=5.9 t=A
 del: "r": found key false
-stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6787 intent_count=+1 intent_bytes=+25 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6787 intent_count=+1 intent_bytes=+25 lock_count=+1 lock_age=+93
 >> at end:
 txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=7.000000000,0 wto=false gul=0,0
 rangekey: g{-gg}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
@@ -212,7 +212,7 @@ data: "q"/6.000000000,0 -> /BYTES/q6
 meta: "r"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=true klen=12 vlen=13 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "r"/7.000000000,0 -> {localTs=5.000000009,0}/<empty>
 data: "r"/6.000000000,0 -> {localTs=0.000000009,0}/<empty>
-stats: key_count=18 key_bytes=396 val_count=30 val_bytes=1062 range_key_count=9 range_key_bytes=250 range_val_count=22 live_count=9 live_bytes=621 gc_bytes_age=102487 intent_count=18 intent_bytes=318 separated_intent_count=18 intent_age=1674
+stats: key_count=18 key_bytes=396 val_count=30 val_bytes=1062 range_key_count=9 range_key_bytes=250 range_val_count=22 live_count=9 live_bytes=621 gc_bytes_age=102487 intent_count=18 intent_bytes=318 lock_count=18 lock_age=1674
 
 run stats ok
 with t=A status=COMMITTED
@@ -237,41 +237,41 @@ with t=A status=COMMITTED
   resolve_intent k=r
 ----
 >> resolve_intent k=a t=A status=COMMITTED
-stats: val_bytes=-35 live_bytes=-35 intent_count=-1 intent_bytes=-19 separated_intent_count=-1 intent_age=-93
+stats: val_bytes=-35 live_bytes=-35 intent_count=-1 intent_bytes=-19 lock_count=-1 lock_age=-93
 >> resolve_intent k=b t=A status=COMMITTED
-stats: val_bytes=-35 live_bytes=-35 gc_bytes_age=-19 intent_count=-1 intent_bytes=-19 separated_intent_count=-1 intent_age=-93
+stats: val_bytes=-35 live_bytes=-35 gc_bytes_age=-19 intent_count=-1 intent_bytes=-19 lock_count=-1 lock_age=-93
 >> resolve_intent k=c t=A status=COMMITTED
-stats: val_bytes=-35 live_bytes=-35 intent_count=-1 intent_bytes=-19 separated_intent_count=-1 intent_age=-93
+stats: val_bytes=-35 live_bytes=-35 intent_count=-1 intent_bytes=-19 lock_count=-1 lock_age=-93
 >> resolve_intent k=d t=A status=COMMITTED
-stats: val_bytes=-35 gc_bytes_age=-3282 intent_count=-1 intent_bytes=-12 separated_intent_count=-1 intent_age=-93
+stats: val_bytes=-35 gc_bytes_age=-3282 intent_count=-1 intent_bytes=-12 lock_count=-1 lock_age=-93
 >> resolve_intent k=e t=A status=COMMITTED
-stats: val_bytes=-35 gc_bytes_age=-3301 intent_count=-1 intent_bytes=-12 separated_intent_count=-1 intent_age=-93
+stats: val_bytes=-35 gc_bytes_age=-3301 intent_count=-1 intent_bytes=-12 lock_count=-1 lock_age=-93
 >> resolve_intent k=f t=A status=COMMITTED
-stats: val_bytes=-48 gc_bytes_age=-4491 intent_count=-1 intent_bytes=-25 separated_intent_count=-1 intent_age=-93
+stats: val_bytes=-48 gc_bytes_age=-4491 intent_count=-1 intent_bytes=-25 lock_count=-1 lock_age=-93
 >> resolve_intent k=g t=A status=COMMITTED
-stats: val_bytes=-35 live_bytes=-35 intent_count=-1 intent_bytes=-19 separated_intent_count=-1 intent_age=-93
+stats: val_bytes=-35 live_bytes=-35 intent_count=-1 intent_bytes=-19 lock_count=-1 lock_age=-93
 >> resolve_intent k=h t=A status=COMMITTED
-stats: val_bytes=-35 live_bytes=-35 intent_count=-1 intent_bytes=-19 separated_intent_count=-1 intent_age=-93
+stats: val_bytes=-35 live_bytes=-35 intent_count=-1 intent_bytes=-19 lock_count=-1 lock_age=-93
 >> resolve_intent k=i t=A status=COMMITTED
-stats: val_bytes=-35 live_bytes=-35 intent_count=-1 intent_bytes=-19 separated_intent_count=-1 intent_age=-93
+stats: val_bytes=-35 live_bytes=-35 intent_count=-1 intent_bytes=-19 lock_count=-1 lock_age=-93
 >> resolve_intent k=j t=A status=COMMITTED
-stats: val_bytes=-35 gc_bytes_age=-3282 intent_count=-1 intent_bytes=-12 separated_intent_count=-1 intent_age=-93
+stats: val_bytes=-35 gc_bytes_age=-3282 intent_count=-1 intent_bytes=-12 lock_count=-1 lock_age=-93
 >> resolve_intent k=k t=A status=COMMITTED
-stats: val_bytes=-35 gc_bytes_age=-3282 intent_count=-1 intent_bytes=-12 separated_intent_count=-1 intent_age=-93
+stats: val_bytes=-35 gc_bytes_age=-3282 intent_count=-1 intent_bytes=-12 lock_count=-1 lock_age=-93
 >> resolve_intent k=l t=A status=COMMITTED
-stats: val_bytes=-48 gc_bytes_age=-4491 intent_count=-1 intent_bytes=-25 separated_intent_count=-1 intent_age=-93
+stats: val_bytes=-48 gc_bytes_age=-4491 intent_count=-1 intent_bytes=-25 lock_count=-1 lock_age=-93
 >> resolve_intent k=m t=A status=COMMITTED
-stats: val_bytes=-35 live_bytes=-35 intent_count=-1 intent_bytes=-19 separated_intent_count=-1 intent_age=-93
+stats: val_bytes=-35 live_bytes=-35 intent_count=-1 intent_bytes=-19 lock_count=-1 lock_age=-93
 >> resolve_intent k=n t=A status=COMMITTED
-stats: val_bytes=-35 live_bytes=-35 gc_bytes_age=-19 intent_count=-1 intent_bytes=-19 separated_intent_count=-1 intent_age=-93
+stats: val_bytes=-35 live_bytes=-35 gc_bytes_age=-19 intent_count=-1 intent_bytes=-19 lock_count=-1 lock_age=-93
 >> resolve_intent k=o t=A status=COMMITTED
-stats: val_bytes=-35 live_bytes=-35 intent_count=-1 intent_bytes=-19 separated_intent_count=-1 intent_age=-93
+stats: val_bytes=-35 live_bytes=-35 intent_count=-1 intent_bytes=-19 lock_count=-1 lock_age=-93
 >> resolve_intent k=p t=A status=COMMITTED
-stats: val_bytes=-35 gc_bytes_age=-3282 intent_count=-1 intent_bytes=-12 separated_intent_count=-1 intent_age=-93
+stats: val_bytes=-35 gc_bytes_age=-3282 intent_count=-1 intent_bytes=-12 lock_count=-1 lock_age=-93
 >> resolve_intent k=q t=A status=COMMITTED
-stats: val_bytes=-35 gc_bytes_age=-3301 intent_count=-1 intent_bytes=-12 separated_intent_count=-1 intent_age=-93
+stats: val_bytes=-35 gc_bytes_age=-3301 intent_count=-1 intent_bytes=-12 lock_count=-1 lock_age=-93
 >> resolve_intent k=r t=A status=COMMITTED
-stats: val_bytes=-48 gc_bytes_age=-4491 intent_count=-1 intent_bytes=-25 separated_intent_count=-1 intent_age=-93
+stats: val_bytes=-48 gc_bytes_age=-4491 intent_count=-1 intent_bytes=-25 lock_count=-1 lock_age=-93
 >> at end:
 txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=7.000000000,0 wto=false gul=0,0
 rangekey: g{-gg}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_stats_intent_resolve_range_abort
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_stats_intent_resolve_range_abort
@@ -109,50 +109,50 @@ stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_b
 del: "r": found key false
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+9 gc_bytes_age=+2162
 >> put k=a v=a7 t=A
-stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+93
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=b v=b7 t=A
-stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_bytes=+48 gc_bytes_age=+1767 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_bytes=+48 gc_bytes_age=+1767 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=c v=c7 t=A
-stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-198 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-198 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> del k=d t=A
 del: "d": found key false
-stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5766 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+93
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5766 intent_count=+1 intent_bytes=+12 lock_count=+1 lock_age=+93
 >> del k=e t=A
 del: "e": found key true
-stats: key_bytes=+12 val_count=+1 val_bytes=+48 live_count=-1 live_bytes=-21 gc_bytes_age=+7533 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+48 live_count=-1 live_bytes=-21 gc_bytes_age=+7533 intent_count=+1 intent_bytes=+12 lock_count=+1 lock_age=+93
 >> del k=f localTs=5.9 t=A
 del: "f": found key false
-stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6777 intent_count=+1 intent_bytes=+25 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6777 intent_count=+1 intent_bytes=+25 lock_count=+1 lock_age=+93
 >> put k=g v=g7 t=A
-stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+93
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=h v=h7 t=A
-stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-194 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-194 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=i v=i7 t=A
-stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-198 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-198 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> del k=j t=A
 del: "j": found key false
-stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5766 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+93
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5766 intent_count=+1 intent_bytes=+12 lock_count=+1 lock_age=+93
 >> del k=k t=A
 del: "k": found key false
-stats: key_bytes=+12 val_count=+1 val_bytes=+48 gc_bytes_age=+5572 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+48 gc_bytes_age=+5572 intent_count=+1 intent_bytes=+12 lock_count=+1 lock_age=+93
 >> del k=l localTs=5.9 t=A
 del: "l": found key false
-stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6777 intent_count=+1 intent_bytes=+25 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6777 intent_count=+1 intent_bytes=+25 lock_count=+1 lock_age=+93
 >> put k=m v=m7 t=A
-stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+93
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=n v=n7 t=A
-stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_bytes=+48 gc_bytes_age=+1767 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_bytes=+48 gc_bytes_age=+1767 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=o v=o7 t=A
-stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-188 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-188 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> del k=p t=A
 del: "p": found key false
-stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5766 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+93
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5766 intent_count=+1 intent_bytes=+12 lock_count=+1 lock_age=+93
 >> del k=q t=A
 del: "q": found key true
-stats: key_bytes=+12 val_count=+1 val_bytes=+48 live_count=-1 live_bytes=-21 gc_bytes_age=+7533 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+48 live_count=-1 live_bytes=-21 gc_bytes_age=+7533 intent_count=+1 intent_bytes=+12 lock_count=+1 lock_age=+93
 >> del k=r localTs=5.9 t=A
 del: "r": found key false
-stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6787 intent_count=+1 intent_bytes=+25 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6787 intent_count=+1 intent_bytes=+25 lock_count=+1 lock_age=+93
 >> at end:
 txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=7.000000000,0 wto=false gul=0,0
 rangekey: g{-gg}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
@@ -212,13 +212,13 @@ data: "q"/6.000000000,0 -> /BYTES/q6
 meta: "r"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=true klen=12 vlen=13 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "r"/7.000000000,0 -> {localTs=5.000000009,0}/<empty>
 data: "r"/6.000000000,0 -> {localTs=0.000000009,0}/<empty>
-stats: key_count=18 key_bytes=396 val_count=30 val_bytes=1062 range_key_count=9 range_key_bytes=250 range_val_count=22 live_count=9 live_bytes=621 gc_bytes_age=102487 intent_count=18 intent_bytes=318 separated_intent_count=18 intent_age=1674
+stats: key_count=18 key_bytes=396 val_count=30 val_bytes=1062 range_key_count=9 range_key_bytes=250 range_val_count=22 live_count=9 live_bytes=621 gc_bytes_age=102487 intent_count=18 intent_bytes=318 lock_count=18 lock_age=1674
 
 run stats ok
 resolve_intent_range t=A k=a end=z status=ABORTED
 ----
 >> resolve_intent_range t=A k=a end=z status=ABORTED
-stats: key_count=-6 key_bytes=-228 val_count=-18 val_bytes=-966 live_count=-5 live_bytes=-537 gc_bytes_age=-61033 intent_count=-18 intent_bytes=-318 separated_intent_count=-18 intent_age=-1674
+stats: key_count=-6 key_bytes=-228 val_count=-18 val_bytes=-966 live_count=-5 live_bytes=-537 gc_bytes_age=-61033 intent_count=-18 intent_bytes=-318 lock_count=-18 lock_age=-1674
 >> at end:
 rangekey: g{-gg}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
 rangekey: {ggg-i}/[5.000000000,0=/<empty> 4.000000000,0=/<empty> 3.000000000,0=/<empty>]

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_stats_intent_resolve_range_commit
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_stats_intent_resolve_range_commit
@@ -109,50 +109,50 @@ stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_b
 del: "r": found key false
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+9 gc_bytes_age=+2162
 >> put k=a v=a7 t=A
-stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+93
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=b v=b7 t=A
-stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_bytes=+48 gc_bytes_age=+1767 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_bytes=+48 gc_bytes_age=+1767 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=c v=c7 t=A
-stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-198 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-198 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> del k=d t=A
 del: "d": found key false
-stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5766 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+93
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5766 intent_count=+1 intent_bytes=+12 lock_count=+1 lock_age=+93
 >> del k=e t=A
 del: "e": found key true
-stats: key_bytes=+12 val_count=+1 val_bytes=+48 live_count=-1 live_bytes=-21 gc_bytes_age=+7533 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+48 live_count=-1 live_bytes=-21 gc_bytes_age=+7533 intent_count=+1 intent_bytes=+12 lock_count=+1 lock_age=+93
 >> del k=f localTs=5.9 t=A
 del: "f": found key false
-stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6777 intent_count=+1 intent_bytes=+25 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6777 intent_count=+1 intent_bytes=+25 lock_count=+1 lock_age=+93
 >> put k=g v=g7 t=A
-stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+93
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=h v=h7 t=A
-stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-194 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-194 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=i v=i7 t=A
-stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-198 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-198 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> del k=j t=A
 del: "j": found key false
-stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5766 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+93
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5766 intent_count=+1 intent_bytes=+12 lock_count=+1 lock_age=+93
 >> del k=k t=A
 del: "k": found key false
-stats: key_bytes=+12 val_count=+1 val_bytes=+48 gc_bytes_age=+5572 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+48 gc_bytes_age=+5572 intent_count=+1 intent_bytes=+12 lock_count=+1 lock_age=+93
 >> del k=l localTs=5.9 t=A
 del: "l": found key false
-stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6777 intent_count=+1 intent_bytes=+25 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6777 intent_count=+1 intent_bytes=+25 lock_count=+1 lock_age=+93
 >> put k=m v=m7 t=A
-stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+93
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=n v=n7 t=A
-stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_bytes=+48 gc_bytes_age=+1767 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_bytes=+48 gc_bytes_age=+1767 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=o v=o7 t=A
-stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-188 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-188 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> del k=p t=A
 del: "p": found key false
-stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5766 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+93
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5766 intent_count=+1 intent_bytes=+12 lock_count=+1 lock_age=+93
 >> del k=q t=A
 del: "q": found key true
-stats: key_bytes=+12 val_count=+1 val_bytes=+48 live_count=-1 live_bytes=-21 gc_bytes_age=+7533 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+48 live_count=-1 live_bytes=-21 gc_bytes_age=+7533 intent_count=+1 intent_bytes=+12 lock_count=+1 lock_age=+93
 >> del k=r localTs=5.9 t=A
 del: "r": found key false
-stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6787 intent_count=+1 intent_bytes=+25 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6787 intent_count=+1 intent_bytes=+25 lock_count=+1 lock_age=+93
 >> at end:
 txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=7.000000000,0 wto=false gul=0,0
 rangekey: g{-gg}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
@@ -212,13 +212,13 @@ data: "q"/6.000000000,0 -> /BYTES/q6
 meta: "r"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=true klen=12 vlen=13 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "r"/7.000000000,0 -> {localTs=5.000000009,0}/<empty>
 data: "r"/6.000000000,0 -> {localTs=0.000000009,0}/<empty>
-stats: key_count=18 key_bytes=396 val_count=30 val_bytes=1062 range_key_count=9 range_key_bytes=250 range_val_count=22 live_count=9 live_bytes=621 gc_bytes_age=102487 intent_count=18 intent_bytes=318 separated_intent_count=18 intent_age=1674
+stats: key_count=18 key_bytes=396 val_count=30 val_bytes=1062 range_key_count=9 range_key_bytes=250 range_val_count=22 live_count=9 live_bytes=621 gc_bytes_age=102487 intent_count=18 intent_bytes=318 lock_count=18 lock_age=1674
 
 run stats ok
 resolve_intent_range t=A k=a end=z status=COMMITTED
 ----
 >> resolve_intent_range t=A k=a end=z status=COMMITTED
-stats: val_bytes=-864 live_bytes=-432 gc_bytes_age=-40176 intent_count=-18 intent_bytes=-318 separated_intent_count=-18 intent_age=-1674
+stats: val_bytes=-864 live_bytes=-432 gc_bytes_age=-40176 intent_count=-18 intent_bytes=-318 lock_count=-18 lock_age=-1674
 >> at end:
 rangekey: g{-gg}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
 rangekey: {ggg-i}/[5.000000000,0=/<empty> 4.000000000,0=/<empty> 3.000000000,0=/<empty>]

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_stats_intent_resolve_range_pushed
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_stats_intent_resolve_range_pushed
@@ -109,50 +109,50 @@ stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_b
 del: "r": found key false
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+9 gc_bytes_age=+2162
 >> put k=a v=a7 t=A
-stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+93
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=b v=b7 t=A
-stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_bytes=+48 gc_bytes_age=+1767 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_bytes=+48 gc_bytes_age=+1767 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=c v=c7 t=A
-stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-198 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-198 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> del k=d t=A
 del: "d": found key false
-stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5766 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+93
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5766 intent_count=+1 intent_bytes=+12 lock_count=+1 lock_age=+93
 >> del k=e t=A
 del: "e": found key true
-stats: key_bytes=+12 val_count=+1 val_bytes=+48 live_count=-1 live_bytes=-21 gc_bytes_age=+7533 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+48 live_count=-1 live_bytes=-21 gc_bytes_age=+7533 intent_count=+1 intent_bytes=+12 lock_count=+1 lock_age=+93
 >> del k=f localTs=5.9 t=A
 del: "f": found key false
-stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6777 intent_count=+1 intent_bytes=+25 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6777 intent_count=+1 intent_bytes=+25 lock_count=+1 lock_age=+93
 >> put k=g v=g7 t=A
-stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+93
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=h v=h7 t=A
-stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-194 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-194 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=i v=i7 t=A
-stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-198 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-198 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> del k=j t=A
 del: "j": found key false
-stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5766 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+93
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5766 intent_count=+1 intent_bytes=+12 lock_count=+1 lock_age=+93
 >> del k=k t=A
 del: "k": found key false
-stats: key_bytes=+12 val_count=+1 val_bytes=+48 gc_bytes_age=+5572 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+48 gc_bytes_age=+5572 intent_count=+1 intent_bytes=+12 lock_count=+1 lock_age=+93
 >> del k=l localTs=5.9 t=A
 del: "l": found key false
-stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6777 intent_count=+1 intent_bytes=+25 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6777 intent_count=+1 intent_bytes=+25 lock_count=+1 lock_age=+93
 >> put k=m v=m7 t=A
-stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+93
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=n v=n7 t=A
-stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_bytes=+48 gc_bytes_age=+1767 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_bytes=+48 gc_bytes_age=+1767 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=o v=o7 t=A
-stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-188 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-188 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> del k=p t=A
 del: "p": found key false
-stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5766 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+93
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5766 intent_count=+1 intent_bytes=+12 lock_count=+1 lock_age=+93
 >> del k=q t=A
 del: "q": found key true
-stats: key_bytes=+12 val_count=+1 val_bytes=+48 live_count=-1 live_bytes=-21 gc_bytes_age=+7533 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+48 live_count=-1 live_bytes=-21 gc_bytes_age=+7533 intent_count=+1 intent_bytes=+12 lock_count=+1 lock_age=+93
 >> del k=r localTs=5.9 t=A
 del: "r": found key false
-stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6787 intent_count=+1 intent_bytes=+25 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6787 intent_count=+1 intent_bytes=+25 lock_count=+1 lock_age=+93
 >> at end:
 txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=7.000000000,0 wto=false gul=0,0
 rangekey: g{-gg}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
@@ -212,14 +212,14 @@ data: "q"/6.000000000,0 -> /BYTES/q6
 meta: "r"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=true klen=12 vlen=13 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "r"/7.000000000,0 -> {localTs=5.000000009,0}/<empty>
 data: "r"/6.000000000,0 -> {localTs=0.000000009,0}/<empty>
-stats: key_count=18 key_bytes=396 val_count=30 val_bytes=1062 range_key_count=9 range_key_bytes=250 range_val_count=22 live_count=9 live_bytes=621 gc_bytes_age=102487 intent_count=18 intent_bytes=318 separated_intent_count=18 intent_age=1674
+stats: key_count=18 key_bytes=396 val_count=30 val_bytes=1062 range_key_count=9 range_key_bytes=250 range_val_count=22 live_count=9 live_bytes=621 gc_bytes_age=102487 intent_count=18 intent_bytes=318 lock_count=18 lock_age=1674
 
 run stats ok
 txn_advance t=A ts=8
 resolve_intent_range t=A k=a end=z status=COMMITTED
 ----
 >> resolve_intent_range t=A k=a end=z status=COMMITTED
-stats: val_bytes=-669 live_bytes=-315 gc_bytes_age=-33241 intent_count=-18 intent_bytes=-318 separated_intent_count=-18 intent_age=-1674
+stats: val_bytes=-669 live_bytes=-315 gc_bytes_age=-33241 intent_count=-18 intent_bytes=-318 lock_count=-18 lock_age=-1674
 >> at end:
 txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=7.000000000,0 wto=false gul=0,0
 rangekey: g{-gg}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_stats_intent_rewrite
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_stats_intent_rewrite
@@ -109,50 +109,50 @@ stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_b
 del: "r": found key false
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+9 gc_bytes_age=+2162
 >> put k=a v=a7 t=A
-stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+93
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=b v=b7 t=A
-stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_bytes=+48 gc_bytes_age=+1767 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_bytes=+48 gc_bytes_age=+1767 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=c v=c7 t=A
-stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-198 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-198 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> del k=d t=A
 del: "d": found key false
-stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5766 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+93
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5766 intent_count=+1 intent_bytes=+12 lock_count=+1 lock_age=+93
 >> del k=e t=A
 del: "e": found key true
-stats: key_bytes=+12 val_count=+1 val_bytes=+48 live_count=-1 live_bytes=-21 gc_bytes_age=+7533 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+48 live_count=-1 live_bytes=-21 gc_bytes_age=+7533 intent_count=+1 intent_bytes=+12 lock_count=+1 lock_age=+93
 >> del k=f localTs=5.9 t=A
 del: "f": found key false
-stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6777 intent_count=+1 intent_bytes=+25 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6777 intent_count=+1 intent_bytes=+25 lock_count=+1 lock_age=+93
 >> put k=g v=g7 t=A
-stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+93
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=h v=h7 t=A
-stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-194 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-194 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=i v=i7 t=A
-stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-198 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-198 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> del k=j t=A
 del: "j": found key false
-stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5766 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+93
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5766 intent_count=+1 intent_bytes=+12 lock_count=+1 lock_age=+93
 >> del k=k t=A
 del: "k": found key false
-stats: key_bytes=+12 val_count=+1 val_bytes=+48 gc_bytes_age=+5572 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+48 gc_bytes_age=+5572 intent_count=+1 intent_bytes=+12 lock_count=+1 lock_age=+93
 >> del k=l localTs=5.9 t=A
 del: "l": found key false
-stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6777 intent_count=+1 intent_bytes=+25 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6777 intent_count=+1 intent_bytes=+25 lock_count=+1 lock_age=+93
 >> put k=m v=m7 t=A
-stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+93
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=n v=n7 t=A
-stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_bytes=+48 gc_bytes_age=+1767 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_bytes=+48 gc_bytes_age=+1767 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=o v=o7 t=A
-stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-188 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-188 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> del k=p t=A
 del: "p": found key false
-stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5766 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+93
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5766 intent_count=+1 intent_bytes=+12 lock_count=+1 lock_age=+93
 >> del k=q t=A
 del: "q": found key true
-stats: key_bytes=+12 val_count=+1 val_bytes=+48 live_count=-1 live_bytes=-21 gc_bytes_age=+7533 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+48 live_count=-1 live_bytes=-21 gc_bytes_age=+7533 intent_count=+1 intent_bytes=+12 lock_count=+1 lock_age=+93
 >> del k=r localTs=5.9 t=A
 del: "r": found key false
-stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6787 intent_count=+1 intent_bytes=+25 separated_intent_count=+1 intent_age=+93
+stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6787 intent_count=+1 intent_bytes=+25 lock_count=+1 lock_age=+93
 >> at end:
 txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=7.000000000,0 wto=false gul=0,0
 rangekey: g{-gg}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
@@ -212,7 +212,7 @@ data: "q"/6.000000000,0 -> /BYTES/q6
 meta: "r"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=true klen=12 vlen=13 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "r"/7.000000000,0 -> {localTs=5.000000009,0}/<empty>
 data: "r"/6.000000000,0 -> {localTs=0.000000009,0}/<empty>
-stats: key_count=18 key_bytes=396 val_count=30 val_bytes=1062 range_key_count=9 range_key_bytes=250 range_val_count=22 live_count=9 live_bytes=621 gc_bytes_age=102487 intent_count=18 intent_bytes=318 separated_intent_count=18 intent_age=1674
+stats: key_count=18 key_bytes=396 val_count=30 val_bytes=1062 range_key_count=9 range_key_bytes=250 range_val_count=22 live_count=9 live_bytes=621 gc_bytes_age=102487 intent_count=18 intent_bytes=318 lock_count=18 lock_age=1674
 
 # Rewrite the same keys at a higher timestamp.
 run stats ok
@@ -239,50 +239,50 @@ with t=A ts=8
   del k=r
 ----
 >> put k=a v=a8 t=A ts=8
-stats: intent_age=-1
+stats: lock_age=-1
 >> put k=b v=b8 t=A ts=8
-stats: gc_bytes_age=-19 intent_age=-1
+stats: gc_bytes_age=-19 lock_age=-1
 >> put k=c v=c8 t=A ts=8
-stats: intent_age=-1
+stats: lock_age=-1
 >> del k=d t=A ts=8
 del: "d": found key false
-stats: gc_bytes_age=-62 intent_age=-1
+stats: gc_bytes_age=-62 lock_age=-1
 >> del k=e t=A ts=8
 del: "e": found key true
-stats: gc_bytes_age=-81 intent_age=-1
+stats: gc_bytes_age=-81 lock_age=-1
 >> del k=f t=A ts=8
 del: "f": found key false
-stats: val_bytes=-13 gc_bytes_age=-1271 intent_bytes=-13 intent_age=-1
+stats: val_bytes=-13 gc_bytes_age=-1271 intent_bytes=-13 lock_age=-1
 >> put k=g v=g8 t=A ts=8
-stats: intent_age=-1
+stats: lock_age=-1
 >> put k=h v=h8 t=A ts=8
-stats: intent_age=-1
+stats: lock_age=-1
 >> put k=i v=i8 t=A ts=8
-stats: intent_age=-1
+stats: lock_age=-1
 >> del k=j t=A ts=8
 del: "j": found key false
-stats: gc_bytes_age=-62 intent_age=-1
+stats: gc_bytes_age=-62 lock_age=-1
 >> del k=k t=A ts=8
 del: "k": found key false
-stats: gc_bytes_age=-62 intent_age=-1
+stats: gc_bytes_age=-62 lock_age=-1
 >> del k=l t=A ts=8
 del: "l": found key false
-stats: val_bytes=-13 gc_bytes_age=-1271 intent_bytes=-13 intent_age=-1
+stats: val_bytes=-13 gc_bytes_age=-1271 intent_bytes=-13 lock_age=-1
 >> put k=m v=m8 t=A ts=8
-stats: intent_age=-1
+stats: lock_age=-1
 >> put k=n v=n8 t=A ts=8
-stats: gc_bytes_age=-19 intent_age=-1
+stats: gc_bytes_age=-19 lock_age=-1
 >> put k=o v=o8 t=A ts=8
-stats: intent_age=-1
+stats: lock_age=-1
 >> del k=p t=A ts=8
 del: "p": found key false
-stats: gc_bytes_age=-62 intent_age=-1
+stats: gc_bytes_age=-62 lock_age=-1
 >> del k=q t=A ts=8
 del: "q": found key true
-stats: gc_bytes_age=-81 intent_age=-1
+stats: gc_bytes_age=-81 lock_age=-1
 >> del k=r t=A ts=8
 del: "r": found key false
-stats: val_bytes=-13 gc_bytes_age=-1271 intent_bytes=-13 intent_age=-1
+stats: val_bytes=-13 gc_bytes_age=-1271 intent_bytes=-13 lock_age=-1
 >> at end:
 txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=8.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=8.000000000,0 wto=false gul=0,0
 rangekey: g{-gg}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
@@ -342,7 +342,7 @@ data: "q"/6.000000000,0 -> /BYTES/q6
 meta: "r"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "r"/8.000000000,0 -> /<empty>
 data: "r"/6.000000000,0 -> {localTs=0.000000009,0}/<empty>
-stats: key_count=18 key_bytes=396 val_count=30 val_bytes=1023 range_key_count=9 range_key_bytes=250 range_val_count=22 live_count=9 live_bytes=621 gc_bytes_age=98226 intent_count=18 intent_bytes=279 separated_intent_count=18 intent_age=1656
+stats: key_count=18 key_bytes=396 val_count=30 val_bytes=1023 range_key_count=9 range_key_bytes=250 range_val_count=22 live_count=9 live_bytes=621 gc_bytes_age=98226 intent_count=18 intent_bytes=279 lock_count=18 lock_age=1656
 
 # Rewrite keys<->tombstones at a higher timestamp.
 run stats ok
@@ -370,49 +370,49 @@ with t=A ts=9
 ----
 >> del k=a t=A ts=9
 del: "a": found key false
-stats: val_bytes=-7 live_count=-1 live_bytes=-69 gc_bytes_age=+5642 intent_bytes=-7 intent_age=-1
+stats: val_bytes=-7 live_count=-1 live_bytes=-69 gc_bytes_age=+5642 intent_bytes=-7 lock_age=-1
 >> del k=b t=A ts=9
 del: "b": found key true
-stats: val_bytes=-7 live_count=-1 live_bytes=-69 gc_bytes_age=+5623 intent_bytes=-7 intent_age=-1
+stats: val_bytes=-7 live_count=-1 live_bytes=-69 gc_bytes_age=+5623 intent_bytes=-7 lock_age=-1
 >> del k=c t=A ts=9
 del: "c": found key false
-stats: val_bytes=-7 live_count=-1 live_bytes=-69 gc_bytes_age=+5642 intent_bytes=-7 intent_age=-1
+stats: val_bytes=-7 live_count=-1 live_bytes=-69 gc_bytes_age=+5642 intent_bytes=-7 lock_age=-1
 >> put k=d v=d9 t=A ts=9
-stats: val_bytes=+7 live_count=+1 live_bytes=+69 gc_bytes_age=-5704 intent_bytes=+7 intent_age=-1
+stats: val_bytes=+7 live_count=+1 live_bytes=+69 gc_bytes_age=-5704 intent_bytes=+7 lock_age=-1
 >> put k=e v=e9 t=A ts=9
-stats: val_bytes=+7 live_count=+1 live_bytes=+69 gc_bytes_age=-5723 intent_bytes=+7 intent_age=-1
+stats: val_bytes=+7 live_count=+1 live_bytes=+69 gc_bytes_age=-5723 intent_bytes=+7 lock_age=-1
 >> put k=f v=f9 t=A ts=9
-stats: val_bytes=+7 live_count=+1 live_bytes=+69 gc_bytes_age=-5704 intent_bytes=+7 intent_age=-1
+stats: val_bytes=+7 live_count=+1 live_bytes=+69 gc_bytes_age=-5704 intent_bytes=+7 lock_age=-1
 >> del k=g t=A ts=9
 del: "g": found key false
-stats: val_bytes=-7 live_count=-1 live_bytes=-69 gc_bytes_age=+5642 intent_bytes=-7 intent_age=-1
+stats: val_bytes=-7 live_count=-1 live_bytes=-69 gc_bytes_age=+5642 intent_bytes=-7 lock_age=-1
 >> del k=h t=A ts=9
 del: "h": found key false
-stats: val_bytes=-7 live_count=-1 live_bytes=-69 gc_bytes_age=+5642 intent_bytes=-7 intent_age=-1
+stats: val_bytes=-7 live_count=-1 live_bytes=-69 gc_bytes_age=+5642 intent_bytes=-7 lock_age=-1
 >> del k=i t=A ts=9
 del: "i": found key false
-stats: val_bytes=-7 live_count=-1 live_bytes=-69 gc_bytes_age=+5642 intent_bytes=-7 intent_age=-1
+stats: val_bytes=-7 live_count=-1 live_bytes=-69 gc_bytes_age=+5642 intent_bytes=-7 lock_age=-1
 >> put k=j v=j9 t=A ts=9
-stats: val_bytes=+7 live_count=+1 live_bytes=+69 gc_bytes_age=-5704 intent_bytes=+7 intent_age=-1
+stats: val_bytes=+7 live_count=+1 live_bytes=+69 gc_bytes_age=-5704 intent_bytes=+7 lock_age=-1
 >> put k=k v=k9 t=A ts=9
-stats: val_bytes=+7 live_count=+1 live_bytes=+69 gc_bytes_age=-5704 intent_bytes=+7 intent_age=-1
+stats: val_bytes=+7 live_count=+1 live_bytes=+69 gc_bytes_age=-5704 intent_bytes=+7 lock_age=-1
 >> put k=l v=l9 t=A ts=9
-stats: val_bytes=+7 live_count=+1 live_bytes=+69 gc_bytes_age=-5704 intent_bytes=+7 intent_age=-1
+stats: val_bytes=+7 live_count=+1 live_bytes=+69 gc_bytes_age=-5704 intent_bytes=+7 lock_age=-1
 >> del k=m t=A ts=9
 del: "m": found key false
-stats: val_bytes=-7 live_count=-1 live_bytes=-69 gc_bytes_age=+5642 intent_bytes=-7 intent_age=-1
+stats: val_bytes=-7 live_count=-1 live_bytes=-69 gc_bytes_age=+5642 intent_bytes=-7 lock_age=-1
 >> del k=n t=A ts=9
 del: "n": found key true
-stats: val_bytes=-7 live_count=-1 live_bytes=-69 gc_bytes_age=+5623 intent_bytes=-7 intent_age=-1
+stats: val_bytes=-7 live_count=-1 live_bytes=-69 gc_bytes_age=+5623 intent_bytes=-7 lock_age=-1
 >> del k=o t=A ts=9
 del: "o": found key false
-stats: val_bytes=-7 live_count=-1 live_bytes=-69 gc_bytes_age=+5642 intent_bytes=-7 intent_age=-1
+stats: val_bytes=-7 live_count=-1 live_bytes=-69 gc_bytes_age=+5642 intent_bytes=-7 lock_age=-1
 >> put k=p v=p9 t=A ts=9
-stats: val_bytes=+7 live_count=+1 live_bytes=+69 gc_bytes_age=-5704 intent_bytes=+7 intent_age=-1
+stats: val_bytes=+7 live_count=+1 live_bytes=+69 gc_bytes_age=-5704 intent_bytes=+7 lock_age=-1
 >> put k=q v=q9 t=A ts=9
-stats: val_bytes=+7 live_count=+1 live_bytes=+69 gc_bytes_age=-5723 intent_bytes=+7 intent_age=-1
+stats: val_bytes=+7 live_count=+1 live_bytes=+69 gc_bytes_age=-5723 intent_bytes=+7 lock_age=-1
 >> put k=r v=r9 t=A ts=9
-stats: val_bytes=+7 live_count=+1 live_bytes=+69 gc_bytes_age=-5704 intent_bytes=+7 intent_age=-1
+stats: val_bytes=+7 live_count=+1 live_bytes=+69 gc_bytes_age=-5704 intent_bytes=+7 lock_age=-1
 >> at end:
 txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=2 ts=9.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=9.000000000,0 wto=false gul=0,0
 rangekey: g{-gg}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
@@ -472,4 +472,4 @@ data: "q"/6.000000000,0 -> /BYTES/q6
 meta: "r"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=2 ts=9.000000000,0 min=0,0 seq=0} ts=9.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "r"/9.000000000,0 -> /BYTES/r9
 data: "r"/6.000000000,0 -> {localTs=0.000000009,0}/<empty>
-stats: key_count=18 key_bytes=396 val_count=30 val_bytes=1023 range_key_count=9 range_key_bytes=250 range_val_count=22 live_count=9 live_bytes=621 gc_bytes_age=97592 intent_count=18 intent_bytes=279 separated_intent_count=18 intent_age=1638
+stats: key_count=18 key_bytes=396 val_count=30 val_bytes=1023 range_key_count=9 range_key_bytes=250 range_val_count=22 live_count=9 live_bytes=621 gc_bytes_age=97592 intent_count=18 intent_bytes=279 lock_count=18 lock_age=1638

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_writes_idempotent
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_writes_idempotent
@@ -210,7 +210,7 @@ data: "k"/3.000000000,0 -> /BYTES/k3
 data: "m"/1.000000000,0 -> /BYTES/m1
 data: "n"/3.000000000,0 -> /<empty>
 meta: "p"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/p0 mergeTs=<nil> txnDidNotUpdateMeta=false
-stats: key_count=10 key_bytes=140 val_count=11 val_bytes=118 range_key_count=3 range_key_bytes=48 range_val_count=4 live_count=5 live_bytes=155 gc_bytes_age=14602 intent_count=1 intent_bytes=19 separated_intent_count=1 intent_age=94
+stats: key_count=10 key_bytes=140 val_count=11 val_bytes=118 range_key_count=3 range_key_bytes=48 range_val_count=4 live_count=5 live_bytes=155 gc_bytes_age=14602 intent_count=1 intent_bytes=19 lock_count=1 lock_age=94
 
 # Non-idempotent writes above tombstone and point.
 run stats ok
@@ -239,7 +239,7 @@ data: "k"/3.000000000,0 -> /BYTES/k3
 data: "m"/1.000000000,0 -> /BYTES/m1
 data: "n"/3.000000000,0 -> /<empty>
 meta: "p"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/p0 mergeTs=<nil> txnDidNotUpdateMeta=false
-stats: key_count=10 key_bytes=140 val_count=11 val_bytes=118 range_key_count=5 range_key_bytes=92 range_val_count=8 live_count=4 live_bytes=134 gc_bytes_age=20813 intent_count=1 intent_bytes=19 separated_intent_count=1 intent_age=94
+stats: key_count=10 key_bytes=140 val_count=11 val_bytes=118 range_key_count=5 range_key_bytes=92 range_val_count=8 live_count=4 live_bytes=134 gc_bytes_age=20813 intent_count=1 intent_bytes=19 lock_count=1 lock_age=94
 
 # Writing on top of stacked range keys is also idempotent.
 run stats ok
@@ -265,7 +265,7 @@ data: "k"/3.000000000,0 -> /BYTES/k3
 data: "m"/1.000000000,0 -> /BYTES/m1
 data: "n"/3.000000000,0 -> /<empty>
 meta: "p"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/p0 mergeTs=<nil> txnDidNotUpdateMeta=false
-stats: key_count=10 key_bytes=140 val_count=11 val_bytes=118 range_key_count=5 range_key_bytes=92 range_val_count=8 live_count=4 live_bytes=134 gc_bytes_age=20813 intent_count=1 intent_bytes=19 separated_intent_count=1 intent_age=94
+stats: key_count=10 key_bytes=140 val_count=11 val_bytes=118 range_key_count=5 range_key_bytes=92 range_val_count=8 live_count=4 live_bytes=134 gc_bytes_age=20813 intent_count=1 intent_bytes=19 lock_count=1 lock_age=94
 
 # Non-idempotent writes on top of bare point keys.
 run stats ok
@@ -295,7 +295,7 @@ data: "k"/3.000000000,0 -> /BYTES/k3
 data: "m"/1.000000000,0 -> /BYTES/m1
 data: "n"/3.000000000,0 -> /<empty>
 meta: "p"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/p0 mergeTs=<nil> txnDidNotUpdateMeta=false
-stats: key_count=10 key_bytes=140 val_count=11 val_bytes=118 range_key_count=6 range_key_bytes=105 range_val_count=9 live_count=3 live_bytes=113 gc_bytes_age=24043 intent_count=1 intent_bytes=19 separated_intent_count=1 intent_age=94
+stats: key_count=10 key_bytes=140 val_count=11 val_bytes=118 range_key_count=6 range_key_bytes=105 range_val_count=9 live_count=3 live_bytes=113 gc_bytes_age=24043 intent_count=1 intent_bytes=19 lock_count=1 lock_age=94
 
 
 # Writes across empty key space is considered idempotent.
@@ -326,4 +326,4 @@ data: "k"/3.000000000,0 -> /BYTES/k3
 data: "m"/1.000000000,0 -> /BYTES/m1
 data: "n"/3.000000000,0 -> /<empty>
 meta: "p"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/p0 mergeTs=<nil> txnDidNotUpdateMeta=false
-stats: key_count=10 key_bytes=140 val_count=11 val_bytes=118 range_key_count=6 range_key_bytes=105 range_val_count=9 live_count=3 live_bytes=113 gc_bytes_age=24043 intent_count=1 intent_bytes=19 separated_intent_count=1 intent_age=94
+stats: key_count=10 key_bytes=140 val_count=11 val_bytes=118 range_key_count=6 range_key_bytes=105 range_val_count=9 live_count=3 live_bytes=113 gc_bytes_age=24043 intent_count=1 intent_bytes=19 lock_count=1 lock_age=94

--- a/pkg/storage/testdata/mvcc_histories/replace_point_tombstones_with_range_tombstones
+++ b/pkg/storage/testdata/mvcc_histories/replace_point_tombstones_with_range_tombstones
@@ -102,7 +102,7 @@ data: "k"/5.000000000,0 -> /BYTES/k5
 data: "k"/1.000000000,0 -> /<empty>
 data: "l"/1.000000000,0 -> /BYTES/l1
 data: "m"/5.000000000,0 -> /BYTES/m5
-stats: key_count=10 key_bytes=200 val_count=15 val_bytes=152 range_key_count=7 range_key_bytes=160 range_val_count=14 live_count=5 live_bytes=153 gc_bytes_age=34769 intent_count=2 intent_bytes=31 separated_intent_count=2 intent_age=190
+stats: key_count=10 key_bytes=200 val_count=15 val_bytes=152 range_key_count=7 range_key_bytes=160 range_val_count=14 live_count=5 live_bytes=153 gc_bytes_age=34769 intent_count=2 intent_bytes=31 lock_count=2 lock_age=190
 
 
 # Then, set the dataset up again and replace point keys.
@@ -241,4 +241,4 @@ data: "k"/5.000000000,0 -> /BYTES/k5
 data: "k"/1.000000000,0 -> /<empty>
 data: "l"/1.000000000,0 -> /BYTES/l1
 data: "m"/5.000000000,0 -> /BYTES/m5
-stats: key_count=10 key_bytes=200 val_count=15 val_bytes=152 range_key_count=7 range_key_bytes=160 range_val_count=14 live_count=5 live_bytes=153 gc_bytes_age=34769 intent_count=2 intent_bytes=31 separated_intent_count=2 intent_age=190
+stats: key_count=10 key_bytes=200 val_count=15 val_bytes=152 range_key_count=7 range_key_bytes=160 range_val_count=14 live_count=5 live_bytes=153 gc_bytes_age=34769 intent_count=2 intent_bytes=31 lock_count=2 lock_age=190

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/range/rangeTable.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/range/rangeTable.tsx
@@ -395,7 +395,7 @@ export default class RangeTable extends React.Component<RangeTableProps, {}> {
       return this.contentDuration(Long.fromNumber(0));
     }
     if (!mvcc.intent_count.eq(0)) {
-      const avgIntentAgeSec = mvcc.intent_age.div(mvcc.intent_count);
+      const avgIntentAgeSec = mvcc.lock_age.div(mvcc.intent_count);
       return this.contentDuration(
         Long.fromNumber(util.SecondsToNano(avgIntentAgeSec.toNumber())),
       );
@@ -827,14 +827,14 @@ export default class RangeTable extends React.Component<RangeTableProps, {}> {
           FixLong(mvcc.sys_count),
         ),
         rangeMaxBytes: this.contentBytes(FixLong(info.state.range_max_bytes)),
-        mvccIntentAge: this.contentDuration(FixLong(mvcc.intent_age)),
+        mvccIntentAge: this.contentDuration(FixLong(mvcc.lock_age)),
 
         gcAvgAge: this.contentGCAvgAge(mvcc),
         gcBytesAge: this.createContent(FixLong(mvcc.gc_bytes_age)),
 
         numIntents: this.createContent(FixLong(mvcc.intent_count)),
         intentAvgAge: this.createContentIntentAvgAge(mvcc),
-        intentAge: this.createContent(FixLong(mvcc.intent_age)),
+        intentAge: this.createContent(FixLong(mvcc.lock_age)),
 
         readLatches: this.createContent(FixLong(info.read_latches)),
         writeLatches: this.createContent(FixLong(info.write_latches)),


### PR DESCRIPTION
Informs #109645.

Simple rename of the fields. The new names incorporate the increased role that these fields will play with replicated locks.

Release note: None