### PR TITLE
storage: check for replicated locks in ScanIntents

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_add_sstable.go
+++ b/pkg/kv/kvserver/batcheval/cmd_add_sstable.go
@@ -265,15 +265,15 @@ func EvalAddSSTable(
 		}
 
 	} else {
-		// If not checking for MVCC conflicts, at least check for separated intents.
-		// The caller is expected to make sure there are no writers across the span,
-		// and thus no or few intents, so this is cheap in the common case.
-		log.VEventf(ctx, 2, "checking conflicting intents for SSTable [%s,%s)", start.Key, end.Key)
-		intents, err := storage.ScanIntents(ctx, readWriter, start.Key, end.Key, maxIntents, 0)
+		// If not checking for MVCC conflicts, at least check for locks. The
+		// caller is expected to make sure there are no writers across the span,
+		// and thus no or few locks, so this is cheap in the common case.
+		log.VEventf(ctx, 2, "checking conflicting locks for SSTable [%s,%s)", start.Key, end.Key)
+		locks, err := storage.ScanLocks(ctx, readWriter, start.Key, end.Key, maxIntents, 0)
 		if err != nil {
-			return result.Result{}, errors.Wrap(err, "scanning intents")
-		} else if len(intents) > 0 {
-			return result.Result{}, &kvpb.LockConflictError{Locks: roachpb.AsLocks(intents)}
+			return result.Result{}, errors.Wrap(err, "scanning locks")
+		} else if len(locks) > 0 {
+			return result.Result{}, &kvpb.LockConflictError{Locks: locks}
 		}
 	}
 

--- a/pkg/kv/kvserver/batcheval/cmd_clear_range.go
+++ b/pkg/kv/kvserver/batcheval/cmd_clear_range.go
@@ -107,17 +107,17 @@ func ClearRange(
 		},
 	}
 
-	// Check for any intents, and return them for the caller to resolve. This
+	// Check for any locks, and return them for the caller to resolve. This
 	// prevents removal of intents belonging to implicitly committed STAGING
 	// txns. Otherwise, txn recovery would fail to find these intents and
 	// consider the txn incomplete, uncommitting it and its writes (even those
 	// outside of the cleared range).
 	maxIntents := storage.MaxIntentsPerLockConflictError.Get(&cArgs.EvalCtx.ClusterSettings().SV)
-	intents, err := storage.ScanIntents(ctx, readWriter, from, to, maxIntents, 0)
+	locks, err := storage.ScanLocks(ctx, readWriter, from, to, maxIntents, 0)
 	if err != nil {
 		return result.Result{}, err
-	} else if len(intents) > 0 {
-		return result.Result{}, &kvpb.LockConflictError{Locks: roachpb.AsLocks(intents)}
+	} else if len(locks) > 0 {
+		return result.Result{}, &kvpb.LockConflictError{Locks: locks}
 	}
 
 	// Before clearing, compute the delta in MVCCStats.

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -1460,43 +1460,47 @@ func Scan(reader Reader, start, end roachpb.Key, max int64) ([]MVCCKeyValue, err
 	return kvs, err
 }
 
-// ScanIntents scans intents using only the separated intents lock table. It
-// does not take interleaved intents into account at all.
-func ScanIntents(
-	ctx context.Context, reader Reader, start, end roachpb.Key, maxIntents int64, targetBytes int64,
-) ([]roachpb.Intent, error) {
-	var intents []roachpb.Intent
+// ScanLocks scans locks (shared, exclusive, and intent) using only the lock
+// table keyspace. It does not scan over the MVCC keyspace.
+func ScanLocks(
+	ctx context.Context, reader Reader, start, end roachpb.Key, maxLocks int64, targetBytes int64,
+) ([]roachpb.Lock, error) {
+	var locks []roachpb.Lock
 
 	if bytes.Compare(start, end) >= 0 {
-		return intents, nil
+		return locks, nil
 	}
 
 	ltStart, _ := keys.LockTableSingleKey(start, nil)
 	ltEnd, _ := keys.LockTableSingleKey(end, nil)
-	iter, err := reader.NewEngineIterator(IterOptions{LowerBound: ltStart, UpperBound: ltEnd})
+	iter, err := NewLockTableIterator(reader, LockTableIteratorOptions{
+		LowerBound:  ltStart,
+		UpperBound:  ltEnd,
+		MatchMinStr: lock.Shared, // all locks
+	})
 	if err != nil {
 		return nil, err
 	}
 	defer iter.Close()
 
 	var meta enginepb.MVCCMetadata
-	var intentBytes int64
+	var lockBytes int64
 	var ok bool
 	for ok, err = iter.SeekEngineKeyGE(EngineKey{Key: ltStart}); ok; ok, err = iter.NextEngineKey() {
 		if err := ctx.Err(); err != nil {
 			return nil, err
 		}
-		if maxIntents != 0 && int64(len(intents)) >= maxIntents {
+		if maxLocks != 0 && int64(len(locks)) >= maxLocks {
 			break
 		}
-		if targetBytes != 0 && intentBytes >= targetBytes {
+		if targetBytes != 0 && lockBytes >= targetBytes {
 			break
 		}
 		key, err := iter.EngineKey()
 		if err != nil {
 			return nil, err
 		}
-		lockedKey, err := keys.DecodeLockTableSingleKey(key.Key)
+		ltKey, err := key.ToLockTableKey()
 		if err != nil {
 			return nil, err
 		}
@@ -1507,13 +1511,13 @@ func ScanIntents(
 		if err = protoutil.Unmarshal(v, &meta); err != nil {
 			return nil, err
 		}
-		intents = append(intents, roachpb.MakeIntent(meta.Txn, lockedKey))
-		intentBytes += int64(len(lockedKey)) + int64(len(v))
+		locks = append(locks, roachpb.MakeLock(meta.Txn, ltKey.Key, ltKey.Strength))
+		lockBytes += int64(len(ltKey.Key)) + int64(len(v))
 	}
 	if err != nil {
 		return nil, err
 	}
-	return intents, nil
+	return locks, nil
 }
 
 // WriteSyncNoop carries out a synchronous no-op write to the engine.

--- a/pkg/storage/engine_test.go
+++ b/pkg/storage/engine_test.go
@@ -1548,24 +1548,30 @@ func TestGetIntent(t *testing.T) {
 	}
 }
 
-func TestScanIntents(t *testing.T) {
+func TestScanLocks(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
 	maxKey := keys.MaxKey
 
-	keys := []roachpb.Key{
-		roachpb.Key("a"),
-		roachpb.Key("b"),
-		roachpb.Key("c"),
+	locks := map[string]lock.Strength{
+		"a": lock.Shared,
+		"b": lock.Exclusive,
+		"c": lock.Intent,
 	}
+	var keys []roachpb.Key
+	for k := range locks {
+		keys = append(keys, roachpb.Key(k))
+	}
+	sort.Slice(keys, func(i, j int) bool { return bytes.Compare(keys[i], keys[j]) < 0 })
+
 	testcases := map[string]struct {
-		from          roachpb.Key
-		to            roachpb.Key
-		max           int64
-		targetBytes   int64
-		expectIntents []roachpb.Key
+		from        roachpb.Key
+		to          roachpb.Key
+		max         int64
+		targetBytes int64
+		expectLocks []roachpb.Key
 	}{
 		"no keys":         {keys[0], keys[0], 0, 0, keys[:0]},
 		"one key":         {keys[0], keys[1], 0, 0, keys[0:1]},
@@ -1588,19 +1594,26 @@ func TestScanIntents(t *testing.T) {
 	require.NoError(t, err)
 	defer eng.Close()
 
-	for _, key := range keys {
-		err := MVCCPut(ctx, eng, key, txn1.ReadTimestamp, roachpb.Value{RawBytes: key}, MVCCWriteOptions{Txn: txn1})
+	for k, str := range locks {
+		var err error
+		if str == lock.Intent {
+			err = MVCCPut(ctx, eng, roachpb.Key(k), txn1.ReadTimestamp, roachpb.Value{RawBytes: roachpb.Key(k)}, MVCCWriteOptions{Txn: txn1})
+		} else {
+			err = MVCCAcquireLock(ctx, eng, txn1, str, roachpb.Key(k), nil, 0)
+		}
 		require.NoError(t, err)
 	}
 
 	for name, tc := range testcases {
 		tc := tc
 		t.Run(name, func(t *testing.T) {
-			intents, err := ScanIntents(ctx, eng, tc.from, tc.to, tc.max, tc.targetBytes)
+			scannedLocks, err := ScanLocks(ctx, eng, tc.from, tc.to, tc.max, tc.targetBytes)
 			require.NoError(t, err)
-			require.Len(t, intents, len(tc.expectIntents), "unexpected number of separated intents")
-			for i, intent := range intents {
-				require.Equal(t, tc.expectIntents[i], intent.Key)
+			require.Len(t, scannedLocks, len(tc.expectLocks), "unexpected number of locks")
+			for i, l := range scannedLocks {
+				require.Equal(t, tc.expectLocks[i], l.Key)
+				require.Equal(t, txn1.TxnMeta, l.Txn)
+				require.Equal(t, locks[string(l.Key)], l.Strength)
 			}
 		})
 	}
@@ -1827,11 +1840,11 @@ func TestEngineClearRange(t *testing.T) {
 
 				// Check intent clears.
 				if tc.clearsIntents {
-					require.Equal(t, []roachpb.Key{roachpb.Key("a"), roachpb.Key("g")}, scanIntentKeys(t, rw))
+					require.Equal(t, []roachpb.Key{roachpb.Key("a"), roachpb.Key("g")}, scanLockKeys(t, rw))
 				} else {
 					require.Equal(t, []roachpb.Key{
 						roachpb.Key("a"), roachpb.Key("b"), roachpb.Key("e"), roachpb.Key("g"),
-					}, scanIntentKeys(t, rw))
+					}, scanLockKeys(t, rw))
 				}
 
 				// Which range keys we find will depend on the clearer.
@@ -2675,18 +2688,18 @@ func scanPointKeys(t *testing.T, r Reader) []MVCCKey {
 	return pointKeys
 }
 
-// scanIntentKeys scans all separated intents from the reader, ignoring
-// provisional values.
-func scanIntentKeys(t *testing.T, r Reader) []roachpb.Key {
+// scanLockKeys scans all locks from the reader, ignoring the provisional values
+// of intents.
+func scanLockKeys(t *testing.T, r Reader) []roachpb.Key {
 	t.Helper()
 
-	var intentKeys []roachpb.Key
-	intents, err := ScanIntents(context.Background(), r, keys.LocalMax, keys.MaxKey, 0, 0)
+	var lockKeys []roachpb.Key
+	locks, err := ScanLocks(context.Background(), r, keys.LocalMax, keys.MaxKey, 0, 0)
 	require.NoError(t, err)
-	for _, intent := range intents {
-		intentKeys = append(intentKeys, intent.Key.Clone())
+	for _, l := range locks {
+		lockKeys = append(lockKeys, l.Key)
 	}
-	return intentKeys
+	return lockKeys
 }
 
 // scanIter scans all point/range keys from the iterator, and returns a combined


### PR DESCRIPTION
Fixes #109649.
Informs #100193.

This commit changes `storage.ScanIntents` to also check for replicated locks. While doing so, it also renames the function to `ScanLocks` to be more appropriately named.

Release note: None