### PR TITLE
norm: push Select into Ordinality

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/select
+++ b/pkg/sql/logictest/testdata/logic_test/select
@@ -862,3 +862,79 @@ SELECT -488 OF FROM t;
 ----
 of
 -488
+
+subtest push_ordinality_into_select
+
+statement ok
+CREATE TABLE trm (
+    id UUID NOT NULL,
+    trid UUID NOT NULL,
+    ts12 TIMESTAMP NOT NULL
+);
+INSERT INTO trm VALUES('5ebfedee-0dcf-41e6-a315-5fa0b51b9882',
+                       '5ebfedee-0dcf-41e6-a315-5fa0b51b9882',
+                       '1999-12-31 23:59:59');
+INSERT INTO trm VALUES('5ebfedee-0dcf-41e6-a315-5fa0b51b9883',
+                       '5ebfedee-0dcf-41e6-a315-5fa0b51b9883',
+                       '1999-12-31 23:59:58');
+INSERT INTO trm VALUES('5ebfedee-0dcf-41e6-a315-5fa0b51b9882',
+                       '5ebfedee-0dcf-41e6-a315-5fa0b51b9882',
+                       '1999-11-30 23:59:59');
+INSERT INTO trm VALUES('5ebfedee-0dcf-41e6-a315-5fa0b51b9883',
+                       '5ebfedee-0dcf-41e6-a315-5fa0b51b9883',
+                       '1999-11-30 23:59:58');
+INSERT INTO trm VALUES('5ebfedee-0dcf-41e6-a315-5fa0b51b9884',
+                       '5ebfedee-0dcf-41e6-a315-5fa0b51b9884',
+                       '1999-11-30 23:59:57');
+
+statement ok
+CREATE TABLE trrec (
+    id UUID NOT NULL,
+    trid STRING NOT NULL,
+    ts12 TIMESTAMP NOT NULL,
+    str16 STRING NULL,
+    INDEX trrec_idx5 (str16 ASC)
+);
+INSERT INTO trrec VALUES('5ebfedee-0dcf-41e6-a315-5fa0b51b9882', '1', '1999-12-31 23:59:59', '12345');
+INSERT INTO trrec VALUES('5ebfedee-0dcf-41e6-a315-5fa0b51b9883', '2', '1999-12-31 23:59:58', '12345');
+INSERT INTO trrec VALUES('5ebfedee-0dcf-41e6-a315-5fa0b51b9884', '3', '1999-12-31 23:59:57', '123456');
+
+statement ok
+CREATE TABLE trtab4 (
+    id UUID NOT NULL,
+    trid UUID NOT NULL,
+    dec1 DECIMAL(19,2) NOT NULL
+);
+INSERT INTO trtab4 VALUES('5ebfedee-0dcf-41e6-a315-5fa0b51b9882', '5ebfedee-0dcf-41e6-a315-5fa0b51b9882', 1.0);
+INSERT INTO trtab4 VALUES('5ebfedee-0dcf-41e6-a315-5fa0b51b9883', '5ebfedee-0dcf-41e6-a315-5fa0b51b9883', 2.0);
+INSERT INTO trtab4 VALUES('5ebfedee-0dcf-41e6-a315-5fa0b51b9884', '5ebfedee-0dcf-41e6-a315-5fa0b51b9884', 3.0);
+
+query TTT
+WITH
+  with2
+    AS (
+      SELECT
+        tq.trid, tq.dec1
+      FROM
+        trrec AS r INNER JOIN trtab4 AS tq ON r.id = tq.trid AND r.str16 = '12345'
+    )
+SELECT tr.id, tr.trid, val3.ts12
+FROM
+  trrec AS tr
+  INNER JOIN LATERAL (
+      SELECT  q.dec1 FROM with2 AS q WHERE tr.id = q.trid
+    ) AS q ON true
+  INNER JOIN LATERAL (
+      SELECT
+        m.ts12
+      FROM trm AS m WHERE tr.id = m.trid
+      ORDER BY m.ts12 ASC
+      LIMIT 1
+    ) AS val3 ON true
+WHERE
+  tr.str16 = '12345'
+ORDER BY 1 DESC
+;
+----
+5ebfedee-0dcf-41e6-a315-5fa0b51b9883  2  1999-11-30 23:59:58 +0000 +0000
+5ebfedee-0dcf-41e6-a315-5fa0b51b9882  1  1999-11-30 23:59:59 +0000 +0000

--- a/pkg/sql/opt/norm/decorrelate_funcs.go
+++ b/pkg/sql/opt/norm/decorrelate_funcs.go
@@ -394,7 +394,7 @@ func (c *CustomFuncs) EnsureKey(in memo.RelExpr) memo.RelExpr {
 
 	// Otherwise, wrap the input in an Ordinality operator.
 	colID := c.f.Metadata().AddColumn("rownum", types.Int)
-	private := memo.OrdinalityPrivate{ColID: colID}
+	private := memo.OrdinalityPrivate{ColID: colID, ForDuplicateRemoval: true}
 	return c.f.ConstructOrdinality(in, &private)
 }
 

--- a/pkg/sql/opt/norm/rules/select.opt
+++ b/pkg/sql/opt/norm/rules/select.opt
@@ -105,6 +105,37 @@ $input
     (ExtractUnboundConditions $filters $inputCols)
 )
 
+# PushSelectIntoOrdinality pushes the Select operator into its Ordinality input
+# if the Ordinality operation was built for the purposes of removing duplicate
+# rows, and the actual values returned by the Ordinality operation don't matter.
+# This is typically preferable because it allows the Select to be pushed into
+# operations beneath the Ordinality, minimizing the number of rows subsequent
+# operations need to process and potentially pushing the Select down far enough
+# to enable constrained scans. This may also enable other normalization rules
+# which match on Select expressions to fire.
+[PushSelectIntoOrdinality, Normalize]
+(Select
+    (Ordinality $input:* $private:*) &
+        (ForDuplicateRemoval $private)
+    $filters:[
+        ...
+        $item:* &
+            (IsBoundBy $item $inputCols:(OutputCols $input))
+        ...
+    ]
+)
+=>
+(Select
+    (Ordinality
+        (Select
+            $input
+            (ExtractBoundConditions $filters $inputCols)
+        )
+        $private
+    )
+    (ExtractUnboundConditions $filters $inputCols)
+)
+
 # MergeSelectInnerJoin merges a Select operator with an InnerJoin input by
 # AND'ing the filter conditions of each and creating a new InnerJoin with that
 # On condition. This is only safe to do with InnerJoin in the general case

--- a/pkg/sql/opt/norm/select_funcs.go
+++ b/pkg/sql/opt/norm/select_funcs.go
@@ -417,3 +417,10 @@ func (c *CustomFuncs) addConjuncts(
 	}
 	return filters, true
 }
+
+// ForDuplicateRemoval returns true if the Ordinality expression was constructed
+// for the purposes of duplicate removal, and the actual values returned does
+// not matter.
+func (c *CustomFuncs) ForDuplicateRemoval(private *memo.OrdinalityPrivate) (ok bool) {
+	return private.ForDuplicateRemoval
+}

--- a/pkg/sql/opt/norm/testdata/rules/decorrelate
+++ b/pkg/sql/opt/norm/testdata/rules/decorrelate
@@ -419,24 +419,22 @@ project
       ├── inner-join (cross)
       │    ├── columns: column1:1!null i:3 rownum:10!null
       │    ├── fd: (10)-->(1)
-      │    ├── select
+      │    ├── ordinality
       │    │    ├── columns: column1:1!null rownum:10!null
       │    │    ├── cardinality: [0 - 3]
       │    │    ├── key: (10)
       │    │    ├── fd: (10)-->(1)
-      │    │    ├── ordinality
-      │    │    │    ├── columns: column1:1!null rownum:10!null
-      │    │    │    ├── cardinality: [3 - 3]
-      │    │    │    ├── key: (10)
-      │    │    │    ├── fd: (10)-->(1)
-      │    │    │    └── values
-      │    │    │         ├── columns: column1:1!null
-      │    │    │         ├── cardinality: [3 - 3]
-      │    │    │         ├── (1,)
-      │    │    │         ├── (1,)
-      │    │    │         └── (1,)
-      │    │    └── filters
-      │    │         └── column1:1 > 3 [outer=(1), constraints=(/1: [/4 - ]; tight)]
+      │    │    └── select
+      │    │         ├── columns: column1:1!null
+      │    │         ├── cardinality: [0 - 3]
+      │    │         ├── values
+      │    │         │    ├── columns: column1:1!null
+      │    │         │    ├── cardinality: [3 - 3]
+      │    │         │    ├── (1,)
+      │    │         │    ├── (1,)
+      │    │         │    └── (1,)
+      │    │         └── filters
+      │    │              └── column1:1 > 3 [outer=(1), constraints=(/1: [/4 - ]; tight)]
       │    ├── scan a
       │    │    └── columns: i:3
       │    └── filters (true)

--- a/pkg/sql/opt/norm/testdata/rules/select
+++ b/pkg/sql/opt/norm/testdata/rules/select
@@ -2108,3 +2108,384 @@ except-all
       ├── key: ()
       ├── fd: ()-->(2)
       └── (1.00,)
+
+# --------------------------------------------------
+# PushOrdinalityIntoSelect
+# --------------------------------------------------
+
+exec-ddl
+CREATE TABLE trm (
+    id UUID NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+    trid UUID NOT NULL,
+    ts12 TIMESTAMP NOT NULL
+);
+----
+
+exec-ddl
+CREATE TABLE trrec (
+    id UUID NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+    trid STRING NOT NULL,
+    ts12 TIMESTAMP NOT NULL,
+    str16 STRING NULL,
+    INDEX trrec_idx5 (str16 ASC)
+);
+----
+
+exec-ddl
+CREATE TABLE trtab4 (
+    id UUID NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+    trid UUID NOT NULL,
+    dec1 DECIMAL(19,2) NOT NULL
+);
+----
+
+# A simple test case where the filter can be pushed through the ordinality.
+norm expect=PushSelectIntoOrdinality
+SELECT * FROM
+    (SELECT (SELECT x FROM xy WHERE y=version LIMIT 1), *
+        FROM information_schema.tables) WHERE table_name = 't1';
+----
+project
+ ├── columns: x:12 table_catalog:2!null table_schema:3!null table_name:4!null table_type:5!null is_insertable_into:6!null version:7
+ ├── fd: ()-->(4)
+ ├── distinct-on
+ │    ├── columns: table_catalog:2!null table_schema:3!null table_name:4!null table_type:5!null is_insertable_into:6!null version:7 xy.x:8 rownum:13!null
+ │    ├── grouping columns: rownum:13!null
+ │    ├── key: (13)
+ │    ├── fd: ()-->(4), (13)-->(2-8)
+ │    ├── left-join (hash)
+ │    │    ├── columns: table_catalog:2!null table_schema:3!null table_name:4!null table_type:5!null is_insertable_into:6!null version:7 xy.x:8 y:9 rownum:13!null
+ │    │    ├── key: (8,13)
+ │    │    ├── fd: ()-->(4), (13)-->(2,3,5-7), (8)-->(9)
+ │    │    ├── ordinality
+ │    │    │    ├── columns: table_catalog:2!null table_schema:3!null table_name:4!null table_type:5!null is_insertable_into:6!null version:7 rownum:13!null
+ │    │    │    ├── key: (13)
+ │    │    │    ├── fd: ()-->(4), (13)-->(2-7)
+ │    │    │    └── select
+ │    │    │         ├── columns: table_catalog:2!null table_schema:3!null table_name:4!null table_type:5!null is_insertable_into:6!null version:7
+ │    │    │         ├── fd: ()-->(4)
+ │    │    │         ├── scan tables
+ │    │    │         │    └── columns: table_catalog:2!null table_schema:3!null table_name:4!null table_type:5!null is_insertable_into:6!null version:7
+ │    │    │         └── filters
+ │    │    │              └── table_name:4 = 't1' [outer=(4), constraints=(/4: [/'t1' - /'t1']; tight), fd=()-->(4)]
+ │    │    ├── scan xy
+ │    │    │    ├── columns: xy.x:8!null y:9
+ │    │    │    ├── key: (8)
+ │    │    │    └── fd: (8)-->(9)
+ │    │    └── filters
+ │    │         └── y:9 = version:7 [outer=(7,9), constraints=(/7: (/NULL - ]; /9: (/NULL - ]), fd=(7)==(9), (9)==(7)]
+ │    └── aggregations
+ │         ├── const-agg [as=table_catalog:2, outer=(2)]
+ │         │    └── table_catalog:2
+ │         ├── const-agg [as=table_schema:3, outer=(3)]
+ │         │    └── table_schema:3
+ │         ├── const-agg [as=table_name:4, outer=(4)]
+ │         │    └── table_name:4
+ │         ├── const-agg [as=table_type:5, outer=(5)]
+ │         │    └── table_type:5
+ │         ├── const-agg [as=is_insertable_into:6, outer=(6)]
+ │         │    └── is_insertable_into:6
+ │         ├── const-agg [as=version:7, outer=(7)]
+ │         │    └── version:7
+ │         └── first-agg [as=xy.x:8, outer=(8)]
+ │              └── xy.x:8
+ └── projections
+      └── xy.x:8 [as=x:12, outer=(8)]
+
+# The filter on tr.str16 should be pushed into the val3 left lateral join.
+norm expect=PushSelectIntoOrdinality
+WITH
+  with2
+    AS (
+      SELECT
+        tq.trid, tq.dec1
+      FROM
+        trrec AS r INNER JOIN trtab4 AS tq ON r.id = tq.trid AND r.str16 = '12345'
+    )
+SELECT tr.id, tr.trid
+FROM
+  trrec AS tr
+  LEFT JOIN LATERAL (
+      SELECT  q.dec1 FROM with2 AS q WHERE tr.id = q.trid
+    ) AS q ON true
+  LEFT JOIN LATERAL (
+      SELECT
+        --tr.id, -- Previously, including this column allowed the filter on
+                 -- str16 to be pushed into the join, but this is no longer
+                 -- required.
+        m.ts12
+      FROM trm AS m WHERE tr.id = m.trid
+      ORDER BY m.ts12 DESC
+      LIMIT 1
+    ) AS val3 ON true
+WHERE
+  tr.str16 = '12345'
+;
+----
+project
+ ├── columns: id:12!null trid:13!null
+ ├── fd: (12)-->(13)
+ └── distinct-on
+      ├── columns: tr.id:12!null tr.trid:13!null rownum:25!null
+      ├── grouping columns: rownum:25!null
+      ├── internal-ordering: -22
+      ├── key: (25)
+      ├── fd: (12)-->(13), (25)-->(12,13)
+      ├── sort
+      │    ├── columns: tr.id:12!null tr.trid:13!null m.trid:21 m.ts12:22 rownum:25!null
+      │    ├── fd: (12)-->(13), (25)-->(12,13)
+      │    ├── ordering: -22
+      │    └── left-join (hash)
+      │         ├── columns: tr.id:12!null tr.trid:13!null m.trid:21 m.ts12:22 rownum:25!null
+      │         ├── fd: (12)-->(13), (25)-->(12,13)
+      │         ├── ordinality
+      │         │    ├── columns: tr.id:12!null tr.trid:13!null rownum:25!null
+      │         │    ├── key: (25)
+      │         │    ├── fd: (12)-->(13), (25)-->(12,13)
+      │         │    └── project
+      │         │         ├── columns: tr.id:12!null tr.trid:13!null
+      │         │         ├── fd: (12)-->(13)
+      │         │         └── left-join (hash)
+      │         │              ├── columns: tr.id:12!null tr.trid:13!null tr.str16:15!null trid:18
+      │         │              ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-one)
+      │         │              ├── fd: ()-->(15), (12)-->(13)
+      │         │              ├── select
+      │         │              │    ├── columns: tr.id:12!null tr.trid:13!null tr.str16:15!null
+      │         │              │    ├── key: (12)
+      │         │              │    ├── fd: ()-->(15), (12)-->(13)
+      │         │              │    ├── scan trrec [as=tr]
+      │         │              │    │    ├── columns: tr.id:12!null tr.trid:13!null tr.str16:15
+      │         │              │    │    ├── key: (12)
+      │         │              │    │    └── fd: (12)-->(13,15)
+      │         │              │    └── filters
+      │         │              │         └── tr.str16:15 = '12345' [outer=(15), constraints=(/15: [/'12345' - /'12345']; tight), fd=()-->(15)]
+      │         │              ├── project
+      │         │              │    ├── columns: trid:18!null
+      │         │              │    ├── inner-join (hash)
+      │         │              │    │    ├── columns: r.id:1!null r.str16:4!null tq.trid:8!null
+      │         │              │    │    ├── multiplicity: left-rows(zero-or-more), right-rows(zero-or-one)
+      │         │              │    │    ├── fd: ()-->(4), (1)==(8), (8)==(1)
+      │         │              │    │    ├── select
+      │         │              │    │    │    ├── columns: r.id:1!null r.str16:4!null
+      │         │              │    │    │    ├── key: (1)
+      │         │              │    │    │    ├── fd: ()-->(4)
+      │         │              │    │    │    ├── scan trrec [as=r]
+      │         │              │    │    │    │    ├── columns: r.id:1!null r.str16:4
+      │         │              │    │    │    │    ├── key: (1)
+      │         │              │    │    │    │    └── fd: (1)-->(4)
+      │         │              │    │    │    └── filters
+      │         │              │    │    │         └── r.str16:4 = '12345' [outer=(4), constraints=(/4: [/'12345' - /'12345']; tight), fd=()-->(4)]
+      │         │              │    │    ├── scan trtab4 [as=tq]
+      │         │              │    │    │    └── columns: tq.trid:8!null
+      │         │              │    │    └── filters
+      │         │              │    │         └── r.id:1 = tq.trid:8 [outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(8), (8)==(1)]
+      │         │              │    └── projections
+      │         │              │         └── tq.trid:8 [as=trid:18, outer=(8)]
+      │         │              └── filters
+      │         │                   └── tr.id:12 = trid:18 [outer=(12,18), constraints=(/12: (/NULL - ]; /18: (/NULL - ]), fd=(12)==(18), (18)==(12)]
+      │         ├── scan trm [as=m]
+      │         │    └── columns: m.trid:21!null m.ts12:22!null
+      │         └── filters
+      │              └── tr.id:12 = m.trid:21 [outer=(12,21), constraints=(/12: (/NULL - ]; /21: (/NULL - ]), fd=(12)==(21), (21)==(12)]
+      └── aggregations
+           ├── const-agg [as=tr.id:12, outer=(12)]
+           │    └── tr.id:12
+           └── const-agg [as=tr.trid:13, outer=(13)]
+                └── tr.trid:13
+
+# The filter on tr.str16 should be pushed into the val3 inner lateral join.
+norm expect=PushSelectIntoOrdinality
+WITH
+  with2
+    AS (
+      SELECT
+        tq.trid, tq.dec1
+      FROM
+        trrec AS r INNER JOIN trtab4 AS tq ON r.id = tq.trid AND r.str16 = '12345'
+    )
+SELECT tr.id, tr.trid
+FROM
+  trrec AS tr
+  INNER JOIN LATERAL (
+      SELECT  q.dec1 FROM with2 AS q WHERE tr.id = q.trid
+    ) AS q ON true
+  INNER JOIN LATERAL (
+      SELECT
+        --tr.id, -- Previously, including this column allowed the filter on
+                 -- str16 to be pushed into the join, but this is no longer
+                 -- required.
+        m.ts12
+      FROM trm AS m WHERE tr.id = m.trid
+      ORDER BY m.ts12 DESC
+      LIMIT 1
+    ) AS val3 ON true
+WHERE
+  tr.str16 = '12345'
+;
+----
+project
+ ├── columns: id:12!null trid:13!null
+ ├── fd: (12)-->(13)
+ └── distinct-on
+      ├── columns: tr.id:12!null tr.trid:13!null rownum:25!null
+      ├── grouping columns: rownum:25!null
+      ├── internal-ordering: -22 opt(12,13,21)
+      ├── key: (25)
+      ├── fd: (12)-->(13), (25)-->(12,13)
+      ├── sort
+      │    ├── columns: tr.id:12!null tr.trid:13!null m.trid:21!null m.ts12:22!null rownum:25!null
+      │    ├── fd: (12)-->(13), (25)-->(12,13), (12)==(21), (21)==(12)
+      │    ├── ordering: -22 opt(12,13,21) [actual: -22]
+      │    └── inner-join (hash)
+      │         ├── columns: tr.id:12!null tr.trid:13!null m.trid:21!null m.ts12:22!null rownum:25!null
+      │         ├── fd: (12)-->(13), (25)-->(12,13), (12)==(21), (21)==(12)
+      │         ├── ordinality
+      │         │    ├── columns: tr.id:12!null tr.trid:13!null rownum:25!null
+      │         │    ├── key: (25)
+      │         │    ├── fd: (12)-->(13), (25)-->(12,13)
+      │         │    └── project
+      │         │         ├── columns: tr.id:12!null tr.trid:13!null
+      │         │         ├── fd: (12)-->(13)
+      │         │         └── inner-join (hash)
+      │         │              ├── columns: tr.id:12!null tr.trid:13!null tr.str16:15!null trid:18!null
+      │         │              ├── multiplicity: left-rows(zero-or-more), right-rows(zero-or-one)
+      │         │              ├── fd: ()-->(15), (12)-->(13), (12)==(18), (18)==(12)
+      │         │              ├── select
+      │         │              │    ├── columns: tr.id:12!null tr.trid:13!null tr.str16:15!null
+      │         │              │    ├── key: (12)
+      │         │              │    ├── fd: ()-->(15), (12)-->(13)
+      │         │              │    ├── scan trrec [as=tr]
+      │         │              │    │    ├── columns: tr.id:12!null tr.trid:13!null tr.str16:15
+      │         │              │    │    ├── key: (12)
+      │         │              │    │    └── fd: (12)-->(13,15)
+      │         │              │    └── filters
+      │         │              │         └── tr.str16:15 = '12345' [outer=(15), constraints=(/15: [/'12345' - /'12345']; tight), fd=()-->(15)]
+      │         │              ├── project
+      │         │              │    ├── columns: trid:18!null
+      │         │              │    ├── inner-join (hash)
+      │         │              │    │    ├── columns: r.id:1!null r.str16:4!null tq.trid:8!null
+      │         │              │    │    ├── multiplicity: left-rows(zero-or-more), right-rows(zero-or-one)
+      │         │              │    │    ├── fd: ()-->(4), (1)==(8), (8)==(1)
+      │         │              │    │    ├── select
+      │         │              │    │    │    ├── columns: r.id:1!null r.str16:4!null
+      │         │              │    │    │    ├── key: (1)
+      │         │              │    │    │    ├── fd: ()-->(4)
+      │         │              │    │    │    ├── scan trrec [as=r]
+      │         │              │    │    │    │    ├── columns: r.id:1!null r.str16:4
+      │         │              │    │    │    │    ├── key: (1)
+      │         │              │    │    │    │    └── fd: (1)-->(4)
+      │         │              │    │    │    └── filters
+      │         │              │    │    │         └── r.str16:4 = '12345' [outer=(4), constraints=(/4: [/'12345' - /'12345']; tight), fd=()-->(4)]
+      │         │              │    │    ├── scan trtab4 [as=tq]
+      │         │              │    │    │    └── columns: tq.trid:8!null
+      │         │              │    │    └── filters
+      │         │              │    │         └── r.id:1 = tq.trid:8 [outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(8), (8)==(1)]
+      │         │              │    └── projections
+      │         │              │         └── tq.trid:8 [as=trid:18, outer=(8)]
+      │         │              └── filters
+      │         │                   └── tr.id:12 = trid:18 [outer=(12,18), constraints=(/12: (/NULL - ]; /18: (/NULL - ]), fd=(12)==(18), (18)==(12)]
+      │         ├── scan trm [as=m]
+      │         │    └── columns: m.trid:21!null m.ts12:22!null
+      │         └── filters
+      │              └── tr.id:12 = m.trid:21 [outer=(12,21), constraints=(/12: (/NULL - ]; /21: (/NULL - ]), fd=(12)==(21), (21)==(12)]
+      └── aggregations
+           ├── const-agg [as=tr.id:12, outer=(12)]
+           │    └── tr.id:12
+           └── const-agg [as=tr.trid:13, outer=(13)]
+                └── tr.trid:13
+
+# The filter on tr.str16 should be pushed into the val3 inner lateral join.
+norm expect=PushSelectIntoOrdinality
+WITH
+  with2
+    AS (
+      SELECT
+        tq.trid, tq.dec1
+      FROM
+        trrec AS r INNER JOIN trtab4 AS tq ON r.id = tq.trid AND r.str16 = '12345'
+    )
+SELECT tr.id, tr.trid
+FROM
+  trrec AS tr
+  INNER JOIN LATERAL (
+      SELECT  q.dec1 FROM with2 AS q WHERE tr.id = q.trid
+    ) AS q ON true
+  INNER JOIN LATERAL (
+      SELECT
+        --tr.id, -- Previously, including this column allowed the filter on
+                 -- str16 to be pushed into the join, but this is no longer
+                 -- required.
+        m.ts12
+      FROM trm AS m WHERE tr.id = m.trid
+      ORDER BY m.ts12 DESC
+      LIMIT 100
+    ) AS val3 ON true
+WHERE
+  tr.str16 = '12345'
+;
+----
+project
+ ├── columns: id:12!null trid:13!null
+ ├── fd: (12)-->(13)
+ └── select
+      ├── columns: tr.id:12!null tr.trid:13!null m.trid:21!null m.ts12:22!null row_num:25!null rownum:26!null
+      ├── fd: (12)-->(13), (26)-->(12,13), (12)==(21), (21)==(12)
+      ├── window partition=(26) ordering=-22 opt(12-17,19,21,26)
+      │    ├── columns: tr.id:12!null tr.trid:13!null m.trid:21!null m.ts12:22!null row_num:25 rownum:26!null
+      │    ├── fd: (12)-->(13), (26)-->(12,13), (12)==(21), (21)==(12)
+      │    ├── inner-join (hash)
+      │    │    ├── columns: tr.id:12!null tr.trid:13!null m.trid:21!null m.ts12:22!null rownum:26!null
+      │    │    ├── fd: (12)-->(13), (26)-->(12,13), (12)==(21), (21)==(12)
+      │    │    ├── ordinality
+      │    │    │    ├── columns: tr.id:12!null tr.trid:13!null rownum:26!null
+      │    │    │    ├── key: (26)
+      │    │    │    ├── fd: (12)-->(13), (26)-->(12,13)
+      │    │    │    └── project
+      │    │    │         ├── columns: tr.id:12!null tr.trid:13!null
+      │    │    │         ├── fd: (12)-->(13)
+      │    │    │         └── inner-join (hash)
+      │    │    │              ├── columns: tr.id:12!null tr.trid:13!null tr.str16:15!null trid:18!null
+      │    │    │              ├── multiplicity: left-rows(zero-or-more), right-rows(zero-or-one)
+      │    │    │              ├── fd: ()-->(15), (12)-->(13), (12)==(18), (18)==(12)
+      │    │    │              ├── select
+      │    │    │              │    ├── columns: tr.id:12!null tr.trid:13!null tr.str16:15!null
+      │    │    │              │    ├── key: (12)
+      │    │    │              │    ├── fd: ()-->(15), (12)-->(13)
+      │    │    │              │    ├── scan trrec [as=tr]
+      │    │    │              │    │    ├── columns: tr.id:12!null tr.trid:13!null tr.str16:15
+      │    │    │              │    │    ├── key: (12)
+      │    │    │              │    │    └── fd: (12)-->(13,15)
+      │    │    │              │    └── filters
+      │    │    │              │         └── tr.str16:15 = '12345' [outer=(15), constraints=(/15: [/'12345' - /'12345']; tight), fd=()-->(15)]
+      │    │    │              ├── project
+      │    │    │              │    ├── columns: trid:18!null
+      │    │    │              │    ├── inner-join (hash)
+      │    │    │              │    │    ├── columns: r.id:1!null r.str16:4!null tq.trid:8!null
+      │    │    │              │    │    ├── multiplicity: left-rows(zero-or-more), right-rows(zero-or-one)
+      │    │    │              │    │    ├── fd: ()-->(4), (1)==(8), (8)==(1)
+      │    │    │              │    │    ├── select
+      │    │    │              │    │    │    ├── columns: r.id:1!null r.str16:4!null
+      │    │    │              │    │    │    ├── key: (1)
+      │    │    │              │    │    │    ├── fd: ()-->(4)
+      │    │    │              │    │    │    ├── scan trrec [as=r]
+      │    │    │              │    │    │    │    ├── columns: r.id:1!null r.str16:4
+      │    │    │              │    │    │    │    ├── key: (1)
+      │    │    │              │    │    │    │    └── fd: (1)-->(4)
+      │    │    │              │    │    │    └── filters
+      │    │    │              │    │    │         └── r.str16:4 = '12345' [outer=(4), constraints=(/4: [/'12345' - /'12345']; tight), fd=()-->(4)]
+      │    │    │              │    │    ├── scan trtab4 [as=tq]
+      │    │    │              │    │    │    └── columns: tq.trid:8!null
+      │    │    │              │    │    └── filters
+      │    │    │              │    │         └── r.id:1 = tq.trid:8 [outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(8), (8)==(1)]
+      │    │    │              │    └── projections
+      │    │    │              │         └── tq.trid:8 [as=trid:18, outer=(8)]
+      │    │    │              └── filters
+      │    │    │                   └── tr.id:12 = trid:18 [outer=(12,18), constraints=(/12: (/NULL - ]; /18: (/NULL - ]), fd=(12)==(18), (18)==(12)]
+      │    │    ├── scan trm [as=m]
+      │    │    │    └── columns: m.trid:21!null m.ts12:22!null
+      │    │    └── filters
+      │    │         └── tr.id:12 = m.trid:21 [outer=(12,21), constraints=(/12: (/NULL - ]; /21: (/NULL - ]), fd=(12)==(21), (21)==(12)]
+      │    └── windows
+      │         └── row-number [as=row_num:25]
+      └── filters
+           └── row_num:25 <= 100 [outer=(25), constraints=(/25: (/NULL - /100]; tight)]

--- a/pkg/sql/opt/ops/relational.opt
+++ b/pkg/sql/opt/ops/relational.opt
@@ -1221,6 +1221,26 @@ define OrdinalityPrivate {
 
     # ColID holds the id of the column introduced by this operator.
     ColID ColumnID
+
+    # ForDuplicateRemoval is `true` when the Ordinality is built as part of a
+    # query rewrite in order to remove duplicate entries, and the value returned
+    # by the Ordinality operation does not matter, as long as it's unique. It is
+    # `false` if this is built from a WITH ORDINALITY clause, where the value
+    # returned does matter. For example, in the following case, pushing the `x=3`
+    # filter into the Ordinality would yield a value for the `ordinality` column
+    # of `1`, while the correct result is `3`:
+    #
+    # SELECT * FROM UNNEST(ARRAY[1, 2, 3]) WITH ORDINALITY AS foo(x) WHERE x = 3;
+    #   x | ordinality
+    # ----+-------------
+    #   3 |          3
+    #
+    # The `ForDuplicateRemoval` flag can be examined to avoid pushing the
+    # filter in such cases.
+    # TODO(msirek): The internally-generated unique tagging of rows for
+    # duplicate removal could be separated off into a new operator, such as
+    # `UniqueKey`, in the future.
+    ForDuplicateRemoval bool
 }
 
 # ProjectSet represents a relational operator which zips through a list of


### PR DESCRIPTION
A join query with LIMIT 1 and a WHERE clause filter which could enable
constrained scan on a table index may perform a full scan the table,
and the optimizer may never consider query plans where the table is
read via a constrained index scan. Similar queries which project more
columns or expressions do consider constrained scans, because
normalization of the LIMIT portion of the query is delayed in that case
until the input to the LIMIT is a join expression.

The issue is that normalization rules such as TryDecorrelateLimitOne
inject an Ordinality operation above a join, which prevents rules which
push a Select into a join from firing, such as PushSelectIntoJoinLeft,
which matches on a Select as the immediate parent of a join. The
expression tree may look like this:
expression tree may look like this:
```
├── select
│    ├── columns: tr.id:12!null tr.trid:13!null tr.str16:15!null rownum:25!null
│    ├── key: (25)
│    ├── fd: ()-->(15), (12)-->(13), (25)-->(12,13)
│    ├── ordinality
│    │    ├── columns: tr.id:12!null tr.trid:13!null tr.str16:15 rownum:25!null
│    │    ├── key: (25)
│    │    ├── fd: (12)-->(13,15), (25)-->(12,13,15)
│    │    └── project
│    │         ├── columns: tr.id:12!null tr.trid:13!null tr.str16:15
│    │         ├── fd: (12)-->(13,15)
│    │         └── left-join (hash)
│    │              ├── columns: tr.id:12!null tr.trid:13!null tr.str16:15 trid:18
│    │              ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-one)
│    │              ├── fd: (12)-->(13,15)
│    │              ├── scan trrec [as=tr]
│    │              │    ├── columns: tr.id:12!null tr.trid:13!null tr.str16:15
│    │              │    ├── key: (12)
│    │              │    └── fd: (12)-->(13,15)
│    │              ├── project
│    │              │    ├── columns: trid:18!null
...
│    │              │    └── projections
│    │└── tq.trid:8 [as=trid:18, outer=(8)]
│    │              └── filters
│    │                   └── tr.id:12 = trid:18 [outer=(12,18), constraints=(/12: (/NULL - ]; /18: (/NULL - ]), fd=(12)==(18), (18)==(12)]
│    └── filters
│         └── tr.str16:15 = '12345' [outer=(15), constraints=(/15: [/'12345' - /'12345']; tight), fd=()-->(15)]
```

The `ordinality` expression, in this case, was created by normalization
rule TryDecorrelateLimitOne to tag rows with a unique identifier so
duplicates can be removed later. We should be able to push the `select`
below this `ordinality`, because besides adding the unique identifier, it
is just passing rows through to the next operation.

The solution is to do just that, introduce a new normalization rule
which pushes a Select operation below an Ordinality operation which was
created for duplicate row removal if the selection filter applies to
columns in the Ordinality expression's input.

A new boolean flag is added to `OrdinalityPrivate` to distinguish an
Ordinality built for duplicate row remove, where the values produced
don't matter, as long as they're unique, from one built from
WITH ORDINALITY clause, where the actual values do matter.

Epic: none
Fixes: #109751

Release note (bug fix): This patch fixes a performance issue in join
queries with a LIMIT clause, where the optimizer may fail to push a
WHERE clause filter into a join due to how the Limit operation is
internally rewritten, causing a full scan of the table referenced in the
filter.