### PR TITLE
workload: unskip some tests against default test tenant

### DIFF
--- a/pkg/workload/bank/bank_test.go
+++ b/pkg/workload/bank/bank_test.go
@@ -42,11 +42,7 @@ func TestBank(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	srv, db, _ := serverutils.StartServer(t, base.TestServerArgs{
-		UseDatabase: `test`,
-
-		DefaultTestTenant: base.TestIsForStuffThatShouldWorkWithSecondaryTenantsButDoesntYet(109458),
-	})
+	srv, db, _ := serverutils.StartServer(t, base.TestServerArgs{UseDatabase: `test`})
 	defer srv.Stopper().Stop(ctx)
 
 	sqlutils.MakeSQLRunner(db).Exec(t, `CREATE DATABASE test`)

--- a/pkg/workload/insights/insights_test.go
+++ b/pkg/workload/insights/insights_test.go
@@ -43,11 +43,7 @@ func TestInsightsWorkload(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	srv, db, _ := serverutils.StartServer(t, base.TestServerArgs{
-		UseDatabase: `test`,
-
-		DefaultTestTenant: base.TestIsForStuffThatShouldWorkWithSecondaryTenantsButDoesntYet(109458),
-	})
+	srv, db, _ := serverutils.StartServer(t, base.TestServerArgs{UseDatabase: `test`})
 	defer srv.Stopper().Stop(ctx)
 
 	sqlutils.MakeSQLRunner(db).Exec(t, `CREATE DATABASE test`)

--- a/pkg/workload/workloadsql/workloadsql_test.go
+++ b/pkg/workload/workloadsql/workloadsql_test.go
@@ -81,11 +81,7 @@ func TestSplits(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	srv, db, _ := serverutils.StartServer(t, base.TestServerArgs{
-		UseDatabase: `test`,
-
-		DefaultTestTenant: base.TestIsForStuffThatShouldWorkWithSecondaryTenantsButDoesntYet(109458),
-	})
+	srv, db, _ := serverutils.StartServer(t, base.TestServerArgs{UseDatabase: `test`})
 	defer srv.Stopper().Stop(ctx)
 
 	sqlDB := sqlutils.MakeSQLRunner(db)


### PR DESCRIPTION
These tests were failing because we previously skipped splits if the tenant didn't have the SCATTER capability. That was recently enabled in tests, so the tests should now work. Note that this SCATTER capability check is currently needed for acceptance tests, so it's not removed entirely.

Fixes: #109458.

Release note: None