### PR TITLE
release-23.1: roachprod: add GCE DNS Provider

### DIFF
--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -867,7 +867,7 @@ var adminurlCmd = &cobra.Command{
 	Args: cobra.ExactArgs(1),
 	Run: wrap(func(cmd *cobra.Command, args []string) error {
 		urls, err := roachprod.AdminURL(
-			config.Logger, args[0], tenantName, tenantInstance, adminurlPath, adminurlIPs, adminurlOpen, secure,
+			context.Background(), config.Logger, args[0], tenantName, tenantInstance, adminurlPath, adminurlIPs, adminurlOpen, secure,
 		)
 		if err != nil {
 			return err

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -2340,24 +2340,24 @@ func addrToHostPort(addr string) (string, int, error) {
 // InternalAdminUIAddr returns the internal Admin UI address in the form host:port
 // for the specified node.
 func (c *clusterImpl) InternalAdminUIAddr(
-	_ context.Context, l *logger.Logger, node option.NodeListOption,
+	ctx context.Context, l *logger.Logger, node option.NodeListOption,
 ) ([]string, error) {
-	return c.adminUIAddr(l, node, false)
+	return c.adminUIAddr(ctx, l, node, false)
 }
 
 // ExternalAdminUIAddr returns the external Admin UI address in the form host:port
 // for the specified node.
 func (c *clusterImpl) ExternalAdminUIAddr(
-	_ context.Context, l *logger.Logger, node option.NodeListOption,
+	ctx context.Context, l *logger.Logger, node option.NodeListOption,
 ) ([]string, error) {
-	return c.adminUIAddr(l, node, true)
+	return c.adminUIAddr(ctx, l, node, true)
 }
 
 func (c *clusterImpl) adminUIAddr(
-	l *logger.Logger, node option.NodeListOption, external bool,
+	ctx context.Context, l *logger.Logger, node option.NodeListOption, external bool,
 ) ([]string, error) {
 	var addrs []string
-	adminURLs, err := roachprod.AdminURL(l, c.MakeNodes(node), "", 0, "",
+	adminURLs, err := roachprod.AdminURL(ctx, l, c.MakeNodes(node), "", 0, "",
 		external, false, false)
 	if err != nil {
 		return nil, err

--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -656,7 +656,7 @@ func (c *SyncedCluster) Monitor(
 			defer wg.Done()
 
 			node := nodes[i]
-			port, err := c.NodePort(node)
+			port, err := c.NodePort(ctx, node)
 			if err != nil {
 				err := errors.Wrap(err, "failed to get node port")
 				sendEvent(NodeMonitorInfo{Node: node, Event: MonitorError{err}})
@@ -2345,7 +2345,7 @@ func (c *SyncedCluster) pgurls(
 	}
 	m := make(map[Node]string, len(hosts))
 	for node, host := range hosts {
-		desc, err := c.DiscoverService(node, tenantName, ServiceTypeSQL, tenantInstance)
+		desc, err := c.DiscoverService(ctx, node, tenantName, ServiceTypeSQL, tenantInstance)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/roachprod/install/cockroach.go
+++ b/pkg/roachprod/install/cockroach.go
@@ -186,7 +186,7 @@ func (so StartOpts) GetJoinTargets() []Node {
 func (c *SyncedCluster) maybeRegisterServices(
 	ctx context.Context, l *logger.Logger, startOpts StartOpts,
 ) error {
-	serviceMap, err := c.MapServices(startOpts.TenantName, startOpts.TenantInstance)
+	serviceMap, err := c.MapServices(ctx, startOpts.TenantName, startOpts.TenantInstance)
 	if err != nil {
 		return err
 	}
@@ -254,7 +254,7 @@ func (c *SyncedCluster) maybeRegisterServices(
 	if err != nil {
 		return err
 	}
-	return c.RegisterServices(servicesToRegister)
+	return c.RegisterServices(ctx, servicesToRegister)
 }
 
 // Start the cockroach process on the cluster.
@@ -419,8 +419,8 @@ func (c *SyncedCluster) NodeURL(host string, port int, sharedTenantName string) 
 }
 
 // NodePort returns the system tenant's SQL port for the given node.
-func (c *SyncedCluster) NodePort(node Node) (int, error) {
-	desc, err := c.DiscoverService(node, SystemTenantName, ServiceTypeSQL, 0)
+func (c *SyncedCluster) NodePort(ctx context.Context, node Node) (int, error) {
+	desc, err := c.DiscoverService(ctx, node, SystemTenantName, ServiceTypeSQL, 0)
 	if err != nil {
 		return 0, err
 	}
@@ -428,8 +428,8 @@ func (c *SyncedCluster) NodePort(node Node) (int, error) {
 }
 
 // NodeUIPort returns the system tenant's AdminUI port for the given node.
-func (c *SyncedCluster) NodeUIPort(node Node) (int, error) {
-	desc, err := c.DiscoverService(node, SystemTenantName, ServiceTypeUI, 0)
+func (c *SyncedCluster) NodeUIPort(ctx context.Context, node Node) (int, error) {
+	desc, err := c.DiscoverService(ctx, node, SystemTenantName, ServiceTypeUI, 0)
 	if err != nil {
 		return 0, err
 	}
@@ -448,7 +448,7 @@ func (c *SyncedCluster) ExecOrInteractiveSQL(
 	if len(c.Nodes) != 1 {
 		return fmt.Errorf("invalid number of nodes for interactive sql: %d", len(c.Nodes))
 	}
-	desc, err := c.DiscoverService(c.Nodes[0], tenantName, ServiceTypeSQL, tenantInstance)
+	desc, err := c.DiscoverService(ctx, c.Nodes[0], tenantName, ServiceTypeSQL, tenantInstance)
 	if err != nil {
 		return err
 	}
@@ -478,7 +478,7 @@ func (c *SyncedCluster) ExecSQL(
 ) error {
 	display := fmt.Sprintf("%s: executing sql", c.Name)
 	results, _, err := c.ParallelE(ctx, l, nodes, func(ctx context.Context, node Node) (*RunResultDetails, error) {
-		desc, err := c.DiscoverService(node, tenantName, ServiceTypeSQL, tenantInstance)
+		desc, err := c.DiscoverService(ctx, node, tenantName, ServiceTypeSQL, tenantInstance)
 		if err != nil {
 			return nil, err
 		}
@@ -647,7 +647,7 @@ func (c *SyncedCluster) generateStartArgs(
 	instance := startOpts.TenantInstance
 	var sqlPort int
 	if startOpts.Target == StartTenantSQL {
-		desc, err := c.DiscoverService(node, tenantName, ServiceTypeSQL, instance)
+		desc, err := c.DiscoverService(ctx, node, tenantName, ServiceTypeSQL, instance)
 		if err != nil {
 			return nil, err
 		}
@@ -657,14 +657,14 @@ func (c *SyncedCluster) generateStartArgs(
 		tenantName = SystemTenantName
 		// System tenant instance is always 0.
 		instance = 0
-		desc, err := c.DiscoverService(node, tenantName, ServiceTypeSQL, instance)
+		desc, err := c.DiscoverService(ctx, node, tenantName, ServiceTypeSQL, instance)
 		if err != nil {
 			return nil, err
 		}
 		sqlPort = desc.Port
 		args = append(args, fmt.Sprintf("--listen-addr=%s:%d", listenHost, sqlPort))
 	}
-	desc, err := c.DiscoverService(node, tenantName, ServiceTypeUI, instance)
+	desc, err := c.DiscoverService(ctx, node, tenantName, ServiceTypeUI, instance)
 	if err != nil {
 		return nil, err
 	}
@@ -687,7 +687,7 @@ func (c *SyncedCluster) generateStartArgs(
 		joinTargets := startOpts.GetJoinTargets()
 		addresses := make([]string, len(joinTargets))
 		for i, joinNode := range startOpts.GetJoinTargets() {
-			desc, err := c.DiscoverService(joinNode, SystemTenantName, ServiceTypeSQL, 0)
+			desc, err := c.DiscoverService(ctx, joinNode, SystemTenantName, ServiceTypeSQL, 0)
 			if err != nil {
 				return nil, err
 			}
@@ -801,7 +801,7 @@ func (c *SyncedCluster) initializeCluster(
 	ctx context.Context, l *logger.Logger, node Node,
 ) (*RunResultDetails, error) {
 	l.Printf("%s: initializing cluster\n", c.Name)
-	cmd, err := c.generateInitCmd(node)
+	cmd, err := c.generateInitCmd(ctx, node)
 	if err != nil {
 		return nil, err
 	}
@@ -820,7 +820,7 @@ func (c *SyncedCluster) setClusterSettings(
 	ctx context.Context, l *logger.Logger, node Node,
 ) (*RunResultDetails, error) {
 	l.Printf("%s: setting cluster settings", c.Name)
-	cmd, err := c.generateClusterSettingCmd(l, node)
+	cmd, err := c.generateClusterSettingCmd(ctx, l, node)
 	if err != nil {
 		return nil, err
 	}
@@ -835,7 +835,9 @@ func (c *SyncedCluster) setClusterSettings(
 	return res, err
 }
 
-func (c *SyncedCluster) generateClusterSettingCmd(l *logger.Logger, node Node) (string, error) {
+func (c *SyncedCluster) generateClusterSettingCmd(
+	ctx context.Context, l *logger.Logger, node Node,
+) (string, error) {
 	if config.CockroachDevLicense == "" {
 		l.Printf("%s: COCKROACH_DEV_LICENSE unset: enterprise features will be unavailable\n",
 			c.Name)
@@ -860,7 +862,7 @@ func (c *SyncedCluster) generateClusterSettingCmd(l *logger.Logger, node Node) (
 
 	binary := cockroachNodeBinary(c, node)
 	path := fmt.Sprintf("%s/%s", c.NodeDir(node, 1 /* storeIndex */), "settings-initialized")
-	port, err := c.NodePort(node)
+	port, err := c.NodePort(ctx, node)
 	if err != nil {
 		return "", err
 	}
@@ -873,14 +875,14 @@ func (c *SyncedCluster) generateClusterSettingCmd(l *logger.Logger, node Node) (
 	return clusterSettingsCmd, nil
 }
 
-func (c *SyncedCluster) generateInitCmd(node Node) (string, error) {
+func (c *SyncedCluster) generateInitCmd(ctx context.Context, node Node) (string, error) {
 	var initCmd string
 	if c.IsLocal() {
 		initCmd = fmt.Sprintf(`cd %s ; `, c.localVMDir(node))
 	}
 
 	path := fmt.Sprintf("%s/%s", c.NodeDir(node, 1 /* storeIndex */), "cluster-bootstrapped")
-	port, err := c.NodePort(node)
+	port, err := c.NodePort(ctx, node)
 	if err != nil {
 		return "", err
 	}
@@ -1006,7 +1008,7 @@ func (c *SyncedCluster) createFixedBackupSchedule(
 
 	node := c.Nodes[0]
 	binary := cockroachNodeBinary(c, node)
-	port, err := c.NodePort(node)
+	port, err := c.NodePort(ctx, node)
 	if err != nil {
 		return err
 	}

--- a/pkg/roachprod/install/expander.go
+++ b/pkg/roachprod/install/expander.go
@@ -204,7 +204,7 @@ func (e *expander) maybeExpandPgPort(
 	if e.pgPorts == nil {
 		e.pgPorts = make(map[Node]string, len(c.VMs))
 		for _, node := range allNodes(len(c.VMs)) {
-			desc, err := c.DiscoverService(node, tenantName, ServiceTypeSQL, tenantInstance)
+			desc, err := c.DiscoverService(ctx, node, tenantName, ServiceTypeSQL, tenantInstance)
 			if err != nil {
 				return s, false, err
 			}
@@ -229,7 +229,7 @@ func (e *expander) maybeExpandUIPort(
 		e.uiPorts = make(map[Node]string, len(c.VMs))
 		for _, node := range allNodes(len(c.VMs)) {
 			// TODO(herko): Add support for external tenants.
-			e.uiPorts[node] = fmt.Sprint(c.NodeUIPort(node))
+			e.uiPorts[node] = fmt.Sprint(c.NodeUIPort(ctx, node))
 		}
 	}
 

--- a/pkg/roachprod/multitenant.go
+++ b/pkg/roachprod/multitenant.go
@@ -64,7 +64,7 @@ func StartTenant(
 	l.Printf("Starting tenant nodes")
 	var kvAddrs []string
 	for _, node := range hc.Nodes {
-		port, err := hc.NodePort(node)
+		port, err := hc.NodePort(ctx, node)
 		if err != nil {
 			return err
 		}

--- a/pkg/roachprod/vm/dns.go
+++ b/pkg/roachprod/vm/dns.go
@@ -11,6 +11,7 @@
 package vm
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"regexp"
@@ -47,8 +48,8 @@ type DNSRecord struct {
 // DNSProvider is an optional capability for a Provider that provides DNS
 // management services.
 type DNSProvider interface {
-	CreateRecords(records ...DNSRecord) error
-	LookupSRVRecords(service, proto, subdomain string) ([]DNSRecord, error)
+	CreateRecords(ctx context.Context, records ...DNSRecord) error
+	LookupSRVRecords(ctx context.Context, service, proto, subdomain string) ([]DNSRecord, error)
 	DeleteRecordsBySubdomain(subdomain string) error
 	Domain() string
 }

--- a/pkg/roachprod/vm/gce/BUILD.bazel
+++ b/pkg/roachprod/vm/gce/BUILD.bazel
@@ -18,7 +18,6 @@ go_library(
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_spf13_pflag//:pflag",
-        "@org_golang_google_api//cloudbilling/v1beta",
         "@org_golang_x_exp//maps",
         "@org_golang_x_sync//errgroup",
     ],

--- a/pkg/roachprod/vm/gce/BUILD.bazel
+++ b/pkg/roachprod/vm/gce/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "gce",
     srcs = [
+        "dns.go",
         "gcloud.go",
         "utils.go",
     ],
@@ -13,9 +14,12 @@ go_library(
         "//pkg/roachprod/logger",
         "//pkg/roachprod/vm",
         "//pkg/roachprod/vm/flagstub",
+        "//pkg/util/retry",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_spf13_pflag//:pflag",
+        "@org_golang_google_api//cloudbilling/v1beta",
+        "@org_golang_x_exp//maps",
         "@org_golang_x_sync//errgroup",
     ],
 )

--- a/pkg/roachprod/vm/gce/dns.go
+++ b/pkg/roachprod/vm/gce/dns.go
@@ -1,0 +1,263 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package gce
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
+	"github.com/cockroachdb/cockroach/pkg/util/retry"
+	"github.com/cockroachdb/errors"
+	"golang.org/x/exp/maps"
+)
+
+const (
+	dnsManagedZone = "roachprod-managed"
+	dnsDomain      = "roachprod-managed.crdb.io"
+	dnsServer      = "ns-cloud-a1.googledomains.com"
+	dnsMaxResults  = 1000
+)
+
+var _ vm.DNSProvider = &dnsProvider{}
+
+// dnsProvider implements the vm.DNSProvider interface.
+type dnsProvider struct {
+	resolver *net.Resolver
+}
+
+func NewDNSProvider() vm.DNSProvider {
+	resolver := new(net.Resolver)
+	resolver.StrictErrors = true
+	resolver.Dial = func(ctx context.Context, network, address string) (net.Conn, error) {
+		dialer := net.Dialer{}
+		// Prefer TCP over UDP. This is necessary because the DNS server
+		// will return a truncated response if the response is too large
+		// for a UDP packet, resulting in a "server misbehaving" error.
+		return dialer.DialContext(ctx, "tcp", dnsServer+":53")
+	}
+	return &dnsProvider{resolver: resolver}
+}
+
+// CreateRecords implements the vm.DNSProvider interface.
+func (n dnsProvider) CreateRecords(ctx context.Context, records ...vm.DNSRecord) error {
+	recordsByName := make(map[string][]vm.DNSRecord)
+	for _, record := range records {
+		recordsByName[record.Name] = append(recordsByName[record.Name], record)
+	}
+
+	for name, recordGroup := range recordsByName {
+		// No need to break the name down into components as the lookup command
+		// accepts a fully qualified name as the last parameter if the service and
+		// proto parameters are empty strings.
+		existingRecords, err := n.lookupSRVRecords(ctx, "", "", name)
+		if err != nil {
+			return err
+		}
+		dataSet := make(map[string]struct{})
+		for _, record := range existingRecords {
+			dataSet[record.Data] = struct{}{}
+		}
+
+		command := "create"
+		if len(existingRecords) > 0 {
+			command = "update"
+		}
+
+		// Add the new record data.
+		// TODO(Herko): Warn if the same record has been added twice
+		for _, record := range recordGroup {
+			dataSet[record.Data] = struct{}{}
+		}
+		// We assume that all records in a group have the same name, type, and ttl.
+		// TODO(herko): We should add error checking to ensure that the above is the case.
+		firstRecord := recordGroup[0]
+		data := maps.Keys(dataSet)
+		sort.Strings(data)
+		args := []string{"--project", dnsProject, "dns", "record-sets", command, name,
+			"--type", string(firstRecord.Type),
+			"--ttl", strconv.Itoa(firstRecord.TTL),
+			"--zone", dnsManagedZone,
+			"--rrdatas", strings.Join(data, ","),
+		}
+		cmd := exec.Command("gcloud", args...)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			return errors.Wrapf(err, "output: %s", out)
+		}
+	}
+	// The DNS records are not immediately available after creation. We wait until
+	// they are available before returning. This is necessary because the records
+	// are required for starting servers. The waiting period should usually be
+	// short (less than 30 seconds).
+	return n.waitForRecordsAvailable(ctx, records...)
+}
+
+// LookupSRVRecords implements the vm.DNSProvider interface.
+func (n dnsProvider) LookupSRVRecords(
+	ctx context.Context, service, proto, subdomain string,
+) ([]vm.DNSRecord, error) {
+	name := fmt.Sprintf(`%s.%s`, subdomain, n.Domain())
+	return n.lookupSRVRecords(ctx, service, proto, name)
+}
+
+// DeleteRecordsBySubdomain implements the vm.DNSProvider interface.
+func (n dnsProvider) DeleteRecordsBySubdomain(subdomain string) error {
+	suffix := fmt.Sprintf("%s.%s.", subdomain, n.Domain())
+	records, err := n.listSRVRecords(suffix, dnsMaxResults)
+	names := make(map[string]struct{})
+	for _, record := range records {
+		names[record.Name] = struct{}{}
+	}
+	if err != nil {
+		return err
+	}
+	for name := range names {
+		// Only delete records that match the subdomain. The initial filter by
+		// gcloud does not specifically match suffixes, hence we check here to
+		// make sure it's only the suffix and not a partial match.
+		if !strings.HasSuffix(name, suffix) {
+			continue
+		}
+		args := []string{"--project", dnsProject, "dns", "record-sets", "delete", name,
+			"--type", string(vm.SRV),
+			"--zone", dnsManagedZone,
+		}
+		cmd := exec.Command("gcloud", args...)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			return errors.Wrapf(err, "output: %s", out)
+		}
+	}
+	return nil
+}
+
+// Domain implements the vm.DNSProvider interface.
+func (n dnsProvider) Domain() string {
+	return dnsDomain
+}
+
+// lookupSRVRecords uses standard net tools to perform a DNS lookup. For
+// lookups, we prefer this to using the gcloud command as it is faster, and
+// preferable when service information is being queried regularly.
+func (n dnsProvider) lookupSRVRecords(
+	ctx context.Context, service, proto, name string,
+) ([]vm.DNSRecord, error) {
+	cName, srvRecords, err := n.resolver.LookupSRV(ctx, service, proto, name)
+	if dnsError := (*net.DNSError)(nil); errors.As(err, &dnsError) {
+		// We ignore some errors here as they are likely due to the record name not
+		// existing. The net.LookupSRV function tends to return "server misbehaving"
+		// and "no such host" errors when no record entries are found. Hence, making
+		// the errors ambiguous and not useful. The errors are not exported, so we
+		// have to check the error message.
+		if dnsError.Err != "server misbehaving" && dnsError.Err != "no such host" && !dnsError.IsNotFound {
+			return nil, err
+		}
+	}
+	records := make([]vm.DNSRecord, len(srvRecords))
+	for i, srvRecord := range srvRecords {
+		records[i] = vm.CreateSRVRecord(cName, *srvRecord)
+	}
+	return records, nil
+}
+
+// listSRVRecords returns all SRV records that match the given filter from Google Cloud DNS.
+// The data field of the records could be a comma-separated list of values if multiple
+// records are returned for the same name.
+func (n dnsProvider) listSRVRecords(filter string, limit int) ([]vm.DNSRecord, error) {
+	args := []string{"--project", dnsProject, "dns", "record-sets", "list",
+		"--filter", filter,
+		"--limit", strconv.Itoa(limit),
+		"--page-size", strconv.Itoa(limit),
+		"--zone", dnsManagedZone,
+		"--format", "json",
+	}
+	cmd := exec.Command("gcloud", args...)
+	res, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, errors.Wrapf(err, "output: %s", res)
+	}
+	var jsonList []struct {
+		Name       string   `json:"name"`
+		Kind       string   `json:"kind"`
+		RecordType string   `json:"type"`
+		TTL        int      `json:"ttl"`
+		RRDatas    []string `json:"rrdatas"`
+	}
+
+	err = json.Unmarshal(res, &jsonList)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error unmarshalling output: %s", res)
+	}
+
+	records := make([]vm.DNSRecord, 0)
+	for _, record := range jsonList {
+		if record.Kind != "dns#resourceRecordSet" {
+			continue
+		}
+		if record.RecordType != string(vm.SRV) {
+			continue
+		}
+		for _, data := range record.RRDatas {
+			records = append(records, vm.CreateDNSRecord(record.Name, vm.SRV, data, record.TTL))
+		}
+	}
+	return records, nil
+}
+
+// waitForRecordsAvailable waits for the DNS records to become available on the
+// DNS server through a standard net tools lookup.
+func (n dnsProvider) waitForRecordsAvailable(ctx context.Context, records ...vm.DNSRecord) error {
+	type recordKey struct {
+		name string
+		data string
+	}
+	trimName := func(name string) string {
+		return strings.TrimSuffix(name, ".")
+	}
+	notAvailable := make(map[recordKey]struct{})
+	for _, record := range records {
+		notAvailable[recordKey{
+			name: trimName(record.Name),
+			data: record.Data,
+		}] = struct{}{}
+	}
+
+	return retry.WithMaxAttempts(ctx, retry.Options{
+		InitialBackoff: 5 * time.Second,
+		Multiplier:     1,
+	}, 20, func() error {
+		for key := range notAvailable {
+			foundRecords, err := n.lookupSRVRecords(ctx, "", "", key.name)
+			if err != nil {
+				return err
+			}
+			for _, foundRecord := range foundRecords {
+				delete(notAvailable, recordKey{
+					name: trimName(foundRecord.Name),
+					data: foundRecord.Data,
+				})
+			}
+		}
+		if len(notAvailable) == 0 {
+			return nil
+		}
+		return errors.Newf("waiting for DNS records to become available: %d out of %d records not available",
+			len(notAvailable), len(records))
+	})
+}

--- a/pkg/roachprod/vm/gce/dns.go
+++ b/pkg/roachprod/vm/gce/dns.go
@@ -80,12 +80,11 @@ func (n dnsProvider) CreateRecords(ctx context.Context, records ...vm.DNSRecord)
 		}
 
 		// Add the new record data.
-		// TODO(Herko): Warn if the same record has been added twice
 		for _, record := range recordGroup {
 			dataSet[record.Data] = struct{}{}
 		}
 		// We assume that all records in a group have the same name, type, and ttl.
-		// TODO(herko): We should add error checking to ensure that the above is the case.
+		// TODO(herko): Add error checking to ensure that the above is the case.
 		firstRecord := recordGroup[0]
 		data := maps.Keys(dataSet)
 		sort.Strings(data)

--- a/pkg/roachprod/vm/gce/gcloud.go
+++ b/pkg/roachprod/vm/gce/gcloud.go
@@ -73,6 +73,7 @@ func Init() error {
 			"(https://cloud.google.com/sdk/downloads)")
 		return errors.New("gcloud not found")
 	}
+	providerInstance.DNSProvider = NewDNSProvider()
 	initialized = true
 	vm.Providers[ProviderName] = providerInstance
 	return nil
@@ -219,8 +220,10 @@ func (jsonVM *jsonVM) toVM(
 		Labels:                 jsonVM.Labels,
 		PrivateIP:              privateIP,
 		Provider:               ProviderName,
+		DNSProvider:            ProviderName,
 		ProviderID:             jsonVM.Name,
 		PublicIP:               publicIP,
+		PublicDNS:              fmt.Sprintf("%s.%s", jsonVM.Name, Subdomain),
 		RemoteUser:             remoteUser,
 		VPC:                    vpc,
 		MachineType:            machineType,
@@ -287,6 +290,7 @@ type ProviderOpts struct {
 
 // Provider is the GCE implementation of the vm.Provider interface.
 type Provider struct {
+	vm.DNSProvider
 	Projects       []string
 	ServiceAccount string
 }

--- a/pkg/roachprod/vm/local/dns.go
+++ b/pkg/roachprod/vm/local/dns.go
@@ -12,6 +12,7 @@ package local
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -44,7 +45,7 @@ func (n *dnsProvider) Domain() string {
 }
 
 // CreateRecords is part of the vm.DNSProvider interface.
-func (n *dnsProvider) CreateRecords(records ...vm.DNSRecord) error {
+func (n *dnsProvider) CreateRecords(_ context.Context, records ...vm.DNSRecord) error {
 	unlock, err := lock.AcquireFilesystemLock(n.lockFilePath)
 	if err != nil {
 		return err
@@ -63,7 +64,9 @@ func (n *dnsProvider) CreateRecords(records ...vm.DNSRecord) error {
 }
 
 // LookupSRVRecords is part of the vm.DNSProvider interface.
-func (n *dnsProvider) LookupSRVRecords(service, proto, subdomain string) ([]vm.DNSRecord, error) {
+func (n *dnsProvider) LookupSRVRecords(
+	_ context.Context, service, proto, subdomain string,
+) ([]vm.DNSRecord, error) {
 	records, err := n.loadRecords()
 	if err != nil {
 		return nil, err

--- a/pkg/roachprod/vm/local/local.go
+++ b/pkg/roachprod/vm/local/local.go
@@ -94,6 +94,9 @@ func DeleteCluster(l *logger.Logger, name string) error {
 
 	delete(p.clusters, name)
 
+	// Local clusters are expected to specifically use the local DNS provider
+	// implementation, and should clean up any DNS records in the local file
+	// system cache.
 	return p.DeleteRecordsBySubdomain(c.Name)
 }
 


### PR DESCRIPTION
Previously on PR #106497 an interface for DNS record management to extend
provider capabilities was introduced, as well as a local cluster only
implementation of that interface, to support port management of tenants in the
form of services.

This change adds a Google Cloud DNS implementation for the GCE Provider
utilising the same interface as mentioned above, to enable cloud clusters to
also utilise port management for tenants. It uses the commands available on the
`gcloud dns cli` to perform DNS operations required to register cockroach
services. All operational commands run through `gcloud` except for
`LookupSRVRecords` which relies on the standard `net` package.

`roachprod` operations are likely to invoke the lookup call frequently thus
using the standard net lookup yields better performance than going through the
`cli`. There is a small delay between management operations completing and the
records becoming available through standard lookup methods. A wait function is
provided to ensure all the records are available through a standard net lookup
after a create operation.

This implementation opted for the non-transactional gcloud dns cli. The
transaction operations are not allowed to overlap even if managing separate
records. A transaction will result in a "preconditions not met" error if any
other transaction completed on the same zone while this one is still in flight.
Due to the fact that `roachprod` can be used from various places concurrently
it's best to avoid this.

Epic: CRDB-18499
Release note: NoneBackport 2/2 commits from #107415.

/cc @cockroachdb/release

---

Previously on PR https://github.com/cockroachdb/cockroach/pull/106497 an interface for DNS record management to extend
provider capabilities was introduced, as well as a local cluster only
implementation of that interface, to support port management of tenants in the
form of services.

This change adds a Google Cloud DNS implementation for the GCE Provider
utilising the same interface as mentioned above, to enable cloud clusters to
also utilise port management for tenants. It uses the commands available on the
`gcloud dns cli` to perform DNS operations required to register cockroach
services. All operational commands run through `gcloud` except for
`LookupSRVRecords` which relies on the standard `net` package.

`roachprod` operations are likely to invoke the lookup call frequently thus
using the standard net lookup yields better performance than going through the
`cli`. There is a small delay between management operations completing and the
records becoming available through standard lookup methods. A wait function is
provided to ensure all the records are available through a standard net lookup
after a create operation.

This implementation opted for the non-transactional gcloud dns cli. The
transaction operations are not allowed to overlap even if managing separate
records. A transaction will result in a "preconditions not met" error if any
other transaction completed on the same zone while this one is still in flight.
Due to the fact that `roachprod` can be used from various places concurrently
it's best to avoid this.

Epic: [CRDB-18499](https://cockroachlabs.atlassian.net/browse/CRDB-18499)
Release note: None
Release justification: Test only change