### PR TITLE
    changefeedccl: Fix setting propagation flake

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -4867,13 +4867,12 @@ func TestChangefeedErrors(t *testing.T) {
 
 	// Feature flag for changefeeds is off — test that CREATE CHANGEFEED and
 	// EXPERIMENTAL CHANGEFEED FOR surface error.
-	sqlDB.Exec(t, `SET CLUSTER SETTING feature.changefeed.enabled = false`)
+	featureChangefeedEnabled.Override(ctx, &s.ClusterSettings().SV, false)
 	sqlDB.ExpectErr(t, `feature CHANGEFEED was disabled by the database administrator`,
 		`CREATE CHANGEFEED FOR foo`)
 	sqlDB.ExpectErr(t, `feature CHANGEFEED was disabled by the database administrator`,
 		`EXPERIMENTAL CHANGEFEED FOR foo`)
-
-	sqlDB.Exec(t, `SET CLUSTER SETTING feature.changefeed.enabled = true`)
+	featureChangefeedEnabled.Override(ctx, &s.ClusterSettings().SV, true)
 
 	sqlDB.ExpectErr(
 		t, `unknown format: nope`,

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -4867,12 +4867,12 @@ func TestChangefeedErrors(t *testing.T) {
 
 	// Feature flag for changefeeds is off — test that CREATE CHANGEFEED and
 	// EXPERIMENTAL CHANGEFEED FOR surface error.
-	featureChangefeedEnabled.Override(ctx, &s.ClusterSettings().SV, false)
+	featureChangefeedEnabled.Override(ctx, &s.ApplicationLayer().ClusterSettings().SV, false)
 	sqlDB.ExpectErr(t, `feature CHANGEFEED was disabled by the database administrator`,
 		`CREATE CHANGEFEED FOR foo`)
 	sqlDB.ExpectErr(t, `feature CHANGEFEED was disabled by the database administrator`,
 		`EXPERIMENTAL CHANGEFEED FOR foo`)
-	featureChangefeedEnabled.Override(ctx, &s.ClusterSettings().SV, true)
+	featureChangefeedEnabled.Override(ctx, &s.ApplicationLayer().ClusterSettings().SV, true)
 
 	sqlDB.ExpectErr(
 		t, `unknown format: nope`,


### PR DESCRIPTION
Setting changes are asynchronous, particularly in tenants.
Set the feature setting directly instead.

Fixes #110300

Release note: None