### PR TITLE
server: replace admin checks with VIEWCLUSTERMETADATA and REPAIRCLUSTERMETADATA

### DIFF
--- a/pkg/ccl/backupccl/testdata/backup-restore/schedule-privileges
+++ b/pkg/ccl/backupccl/testdata/backup-restore/schedule-privileges
@@ -108,7 +108,7 @@ foocluster_admin BACKUP INTO LATEST IN 'external://foo/cluster' WITH OPTIONS (de
 foocluster_admin BACKUP INTO 'external://foo/cluster' WITH OPTIONS (detached)
 
 # nonadmin testuser is not allowed to drop a schedule they do not own.
-exec-sql expect-error-regex=(must be admin or owner of the schedule [0-9]+ to DROP it) user=testuser
+exec-sql expect-error-regex=(must have REPAIRCLUSTERMETADATA privilege or be owner of the schedule [0-9]+ to DROP it) user=testuser
 DROP SCHEDULE $fullID
 ----
 regex matches error
@@ -141,7 +141,7 @@ let $otherFullID $otherIncID
 with schedules as (show schedules) select id from schedules where label='foocluster_admin_revoke' order by command->>'backup_type' asc;
 ----
 
-exec-sql expect-error-regex=(must be admin or owner of the schedule [0-9]+ to DROP it) user=testuser
+exec-sql expect-error-regex=(must have REPAIRCLUSTERMETADATA privilege or be owner of the schedule [0-9]+ to DROP it) user=testuser
 DROP SCHEDULE $otherFullID
 ----
 regex matches error
@@ -180,17 +180,17 @@ DROP SCHEDULE $testuserIncID;
 ----
 
 # But testuser can't drop, alter, resume or pause the root owned schedules.
-exec-sql expect-error-regex=(must be admin or owner of the schedule [0-9]+ to PAUSE it) user=testuser
+exec-sql expect-error-regex=(must have REPAIRCLUSTERMETADATA privilege or be owner of the schedule [0-9]+ to PAUSE it) user=testuser
 PAUSE SCHEDULE $otherFullID
 ----
 regex matches error
 
-exec-sql expect-error-regex=(must be admin or owner of the schedule [0-9]+ to RESUME it) user=testuser
+exec-sql expect-error-regex=(must have REPAIRCLUSTERMETADATA privilege or be owner of the schedule [0-9]+ to RESUME it) user=testuser
 RESUME SCHEDULE $otherFullID
 ----
 regex matches error
 
-exec-sql expect-error-regex=(must be admin or owner of the schedule [0-9]+ to DROP it) user=testuser
+exec-sql expect-error-regex=(must have REPAIRCLUSTERMETADATA privilege or be owner of the schedule [0-9]+ to DROP it) user=testuser
 DROP SCHEDULE $otherFullID;
 ----
 regex matches error

--- a/pkg/ccl/cloudccl/externalconn/testdata/multi-tenant/show_create_external_connections
+++ b/pkg/ccl/cloudccl/externalconn/testdata/multi-tenant/show_create_external_connections
@@ -80,12 +80,12 @@ GRANT SYSTEM EXTERNALCONNECTION TO testuser
 query-sql user=testuser
 SHOW CREATE ALL EXTERNAL CONNECTIONS
 ----
-pq: must be admin to run `SHOW CREATE ALL EXTERNAL CONNECTIONS
+pq: must have VIEWCLUSTERMETADATA privilege to run `SHOW CREATE ALL EXTERNAL CONNECTIONS`
 
 query-sql user=testuser
 SHOW CREATE EXTERNAL CONNECTION foo
 ----
-pq: must be admin or owner of the External Connection "foo"
+pq: must have VIEWCLUSTERMETADATA privilege or be owner of the External Connection "foo"
 
 # Create External Connection where testuser is the owner, they should be able to SHOW this object.
 exec-sql user=testuser
@@ -95,7 +95,7 @@ CREATE EXTERNAL CONNECTION bar AS 'nodelocal://1/foo'
 query-sql user=testuser
 SHOW CREATE ALL EXTERNAL CONNECTIONS
 ----
-pq: must be admin to run `SHOW CREATE ALL EXTERNAL CONNECTIONS
+pq: must have VIEWCLUSTERMETADATA privilege to run `SHOW CREATE ALL EXTERNAL CONNECTIONS`
 
 # TODO(aditymaru): Synthetic privileges do not have a concept of owners. Once they do, testuser will
 # be able to run this query successfully since they are the owner of the External Connection object.

--- a/pkg/ccl/cloudccl/externalconn/testdata/show_create_external_connections
+++ b/pkg/ccl/cloudccl/externalconn/testdata/show_create_external_connections
@@ -76,12 +76,12 @@ GRANT SYSTEM EXTERNALCONNECTION TO testuser
 query-sql user=testuser
 SHOW CREATE ALL EXTERNAL CONNECTIONS
 ----
-pq: must be admin to run `SHOW CREATE ALL EXTERNAL CONNECTIONS
+pq: must have VIEWCLUSTERMETADATA privilege to run `SHOW CREATE ALL EXTERNAL CONNECTIONS`
 
 query-sql user=testuser
 SHOW CREATE EXTERNAL CONNECTION foo
 ----
-pq: must be admin or owner of the External Connection "foo"
+pq: must have VIEWCLUSTERMETADATA privilege or be owner of the External Connection "foo"
 
 # Create External Connection where testuser is the owner, they should be able to SHOW this object.
 exec-sql user=testuser
@@ -91,7 +91,7 @@ CREATE EXTERNAL CONNECTION bar AS 'nodelocal://1/foo'
 query-sql user=testuser
 SHOW CREATE ALL EXTERNAL CONNECTIONS
 ----
-pq: must be admin to run `SHOW CREATE ALL EXTERNAL CONNECTIONS
+pq: must have VIEWCLUSTERMETADATA privilege to run `SHOW CREATE ALL EXTERNAL CONNECTIONS`
 
 # TODO(aditymaru): Synthetic privileges do not have a concept of owners. Once they do, testuser will
 # be able to run this query successfully since they are the owner of the External Connection object.

--- a/pkg/server/index_usage_stats.go
+++ b/pkg/server/index_usage_stats.go
@@ -136,7 +136,7 @@ func (s *statusServer) ResetIndexUsageStats(
 	ctx = authserver.ForwardSQLIdentityThroughRPCCalls(ctx)
 	ctx = s.AnnotateCtx(ctx)
 
-	if _, err := s.privilegeChecker.RequireAdminUser(ctx); err != nil {
+	if err := s.privilegeChecker.RequireRepairClusterMetadataPermission(ctx); err != nil {
 		return nil, err
 	}
 

--- a/pkg/server/privchecker/api.go
+++ b/pkg/server/privchecker/api.go
@@ -38,11 +38,6 @@ type CheckerForRPCHandlers interface {
 	// responsibility to convert them through srverrors.ServerError.
 	GetUserAndRole(ctx context.Context) (userName username.SQLUsername, isAdmin bool, err error)
 
-	// RequireAdminUser validates the current user is
-	// an admin user. It returns the current user's name.
-	// Its error return is a gRPC error.
-	RequireAdminUser(ctx context.Context) (userName username.SQLUsername, err error)
-
 	// RequireViewActivityPermission validates the current user has the VIEWACTIVITY
 	// privilege or role option.
 	// Its error return is a gRPC error.
@@ -52,6 +47,7 @@ type CheckerForRPCHandlers interface {
 	RequireViewClusterSettingOrModifyClusterSettingPermission(ctx context.Context) error
 	RequireViewActivityAndNoViewActivityRedactedPermission(ctx context.Context) error
 	RequireViewClusterMetadataPermission(ctx context.Context) error
+	RequireRepairClusterMetadataPermission(ctx context.Context) error
 	RequireViewDebugPermission(ctx context.Context) error
 }
 

--- a/pkg/server/sql_stats.go
+++ b/pkg/server/sql_stats.go
@@ -27,7 +27,7 @@ func (s *statusServer) ResetSQLStats(
 	ctx = authserver.ForwardSQLIdentityThroughRPCCalls(ctx)
 	ctx = s.AnnotateCtx(ctx)
 
-	if _, err := s.privilegeChecker.RequireAdminUser(ctx); err != nil {
+	if err := s.privilegeChecker.RequireRepairClusterMetadataPermission(ctx); err != nil {
 		return nil, err
 	}
 

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -713,7 +713,7 @@ func (s *systemStatusServer) Gossip(
 	ctx = authserver.ForwardSQLIdentityThroughRPCCalls(ctx)
 	ctx = s.AnnotateCtx(ctx)
 
-	if _, err := s.privilegeChecker.RequireAdminUser(ctx); err != nil {
+	if err := s.privilegeChecker.RequireViewClusterMetadataPermission(ctx); err != nil {
 		// NB: not using srverrors.ServerError() here since the priv checker
 		// already returns a proper gRPC error status.
 		return nil, err
@@ -741,7 +741,7 @@ func (s *systemStatusServer) EngineStats(
 	ctx = authserver.ForwardSQLIdentityThroughRPCCalls(ctx)
 	ctx = s.AnnotateCtx(ctx)
 
-	if _, err := s.privilegeChecker.RequireAdminUser(ctx); err != nil {
+	if err := s.privilegeChecker.RequireViewClusterMetadataPermission(ctx); err != nil {
 		// NB: not using srverrors.ServerError() here since the priv checker
 		// already returns a proper gRPC error status.
 		return nil, err
@@ -880,7 +880,7 @@ func (s *systemStatusServer) CriticalNodes(
 	ctx context.Context, req *serverpb.CriticalNodesRequest,
 ) (*serverpb.CriticalNodesResponse, error) {
 	ctx = s.AnnotateCtx(ctx)
-	if _, err := s.privilegeChecker.RequireAdminUser(ctx); err != nil {
+	if err := s.privilegeChecker.RequireViewClusterMetadataPermission(ctx); err != nil {
 		return nil, err
 	}
 	conformance, err := s.node.SpanConfigConformance(
@@ -1013,7 +1013,7 @@ func (s *statusServer) Certificates(
 	ctx = authserver.ForwardSQLIdentityThroughRPCCalls(ctx)
 	ctx = s.AnnotateCtx(ctx)
 
-	if _, err := s.privilegeChecker.RequireAdminUser(ctx); err != nil {
+	if err := s.privilegeChecker.RequireViewClusterMetadataPermission(ctx); err != nil {
 		// NB: not using srverrors.ServerError() here since the priv checker
 		// already returns a proper gRPC error status.
 		return nil, err
@@ -1134,7 +1134,7 @@ func (s *statusServer) Details(
 	ctx = authserver.ForwardSQLIdentityThroughRPCCalls(ctx)
 	ctx = s.AnnotateCtx(ctx)
 
-	if _, err := s.privilegeChecker.RequireAdminUser(ctx); err != nil {
+	if err := s.privilegeChecker.RequireViewClusterMetadataPermission(ctx); err != nil {
 		// NB: not using srverrors.ServerError() here since the priv checker
 		// already returns a proper gRPC error status.
 		return nil, err
@@ -1175,7 +1175,7 @@ func (s *statusServer) GetFiles(
 	ctx = authserver.ForwardSQLIdentityThroughRPCCalls(ctx)
 	ctx = s.AnnotateCtx(ctx)
 
-	if _, err := s.privilegeChecker.RequireAdminUser(ctx); err != nil {
+	if err := s.privilegeChecker.RequireViewClusterMetadataPermission(ctx); err != nil {
 		// NB: not using srverrors.ServerError() here since the priv checker
 		// already returns a proper gRPC error status.
 		return nil, err
@@ -1231,7 +1231,7 @@ func (s *statusServer) LogFilesList(
 	ctx = authserver.ForwardSQLIdentityThroughRPCCalls(ctx)
 	ctx = s.AnnotateCtx(ctx)
 
-	if _, err := s.privilegeChecker.RequireAdminUser(ctx); err != nil {
+	if err := s.privilegeChecker.RequireViewClusterMetadataPermission(ctx); err != nil {
 		// NB: not using srverrors.ServerError() here since the priv checker
 		// already returns a proper gRPC error status.
 		return nil, err
@@ -1266,7 +1266,7 @@ func (s *statusServer) LogFile(
 	ctx = authserver.ForwardSQLIdentityThroughRPCCalls(ctx)
 	ctx = s.AnnotateCtx(ctx)
 
-	if _, err := s.privilegeChecker.RequireAdminUser(ctx); err != nil {
+	if err := s.privilegeChecker.RequireViewClusterMetadataPermission(ctx); err != nil {
 		// NB: not using srverrors.ServerError() here since the priv checker
 		// already returns a proper gRPC error status.
 		return nil, err
@@ -1364,7 +1364,7 @@ func (s *statusServer) Logs(
 	ctx = authserver.ForwardSQLIdentityThroughRPCCalls(ctx)
 	ctx = s.AnnotateCtx(ctx)
 
-	if _, err := s.privilegeChecker.RequireAdminUser(ctx); err != nil {
+	if err := s.privilegeChecker.RequireViewClusterMetadataPermission(ctx); err != nil {
 		// NB: not using srverrors.ServerError() here since the priv checker
 		// already returns a proper gRPC error status.
 		return nil, err
@@ -1452,7 +1452,7 @@ func (s *statusServer) Stacks(
 	ctx = authserver.ForwardSQLIdentityThroughRPCCalls(ctx)
 	ctx = s.AnnotateCtx(ctx)
 
-	if _, err := s.privilegeChecker.RequireAdminUser(ctx); err != nil {
+	if err := s.privilegeChecker.RequireViewClusterMetadataPermission(ctx); err != nil {
 		// NB: not using srverrors.ServerError() here since the priv checker
 		// already returns a proper gRPC error status.
 		return nil, err
@@ -1680,7 +1680,7 @@ func (s *statusServer) Profile(
 	ctx = authserver.ForwardSQLIdentityThroughRPCCalls(ctx)
 	ctx = s.AnnotateCtx(ctx)
 
-	if _, err := s.privilegeChecker.RequireAdminUser(ctx); err != nil {
+	if err := s.privilegeChecker.RequireViewClusterMetadataPermission(ctx); err != nil {
 		// NB: not using srverrors.ServerError() here since the priv checker
 		// already returns a proper gRPC error status.
 		return nil, err
@@ -1736,8 +1736,8 @@ func (s *statusServer) NodesList(
 	ctx = s.AnnotateCtx(ctx)
 
 	// The node status contains details about the command line, network
-	// addresses, env vars etc which are admin-only.
-	if _, err := s.privilegeChecker.RequireAdminUser(ctx); err != nil {
+	// addresses, env vars etc which are privileged information.
+	if err := s.privilegeChecker.RequireViewClusterMetadataPermission(ctx); err != nil {
 		// NB: not using srverrors.ServerError() here since the priv checker
 		// already returns a proper gRPC error status.
 		return nil, err
@@ -1920,8 +1920,8 @@ func (s *statusServer) Node(
 	ctx = s.AnnotateCtx(ctx)
 
 	// The node status contains details about the command line, network
-	// addresses, env vars etc which are admin-only.
-	if _, err := s.privilegeChecker.RequireAdminUser(ctx); err != nil {
+	// addresses, env vars etc which are privileged information..
+	if err := s.privilegeChecker.RequireViewClusterMetadataPermission(ctx); err != nil {
 		// NB: not using srverrors.ServerError() here since the priv checker
 		// already returns a proper gRPC error status.
 		return nil, err
@@ -2445,8 +2445,8 @@ func (t *statusServer) TenantRanges(
 	ctx = authserver.ForwardSQLIdentityThroughRPCCalls(ctx)
 	ctx = t.AnnotateCtx(ctx)
 
-	// The tenant range report contains replica metadata which is admin-only.
-	if _, err := t.privilegeChecker.RequireAdminUser(ctx); err != nil {
+	// The tenant range report contains replica metadata which is privileged.
+	if err := t.privilegeChecker.RequireViewClusterMetadataPermission(ctx); err != nil {
 		return nil, err
 	}
 
@@ -2458,7 +2458,7 @@ func (s *systemStatusServer) TenantRanges(
 ) (*serverpb.TenantRangesResponse, error) {
 	authserver.ForwardSQLIdentityThroughRPCCalls(ctx)
 	ctx = s.AnnotateCtx(ctx)
-	if _, err := s.privilegeChecker.RequireAdminUser(ctx); err != nil {
+	if err := s.privilegeChecker.RequireViewClusterMetadataPermission(ctx); err != nil {
 		return nil, err
 	}
 
@@ -2923,7 +2923,7 @@ func (s *statusServer) KeyVisSamples(
 	ctx context.Context, req *serverpb.KeyVisSamplesRequest,
 ) (*serverpb.KeyVisSamplesResponse, error) {
 
-	if _, err := s.privilegeChecker.RequireAdminUser(ctx); err != nil {
+	if err := s.privilegeChecker.RequireViewClusterMetadataPermission(ctx); err != nil {
 		return nil, err
 	}
 
@@ -3628,7 +3628,7 @@ func (s *statusServer) SpanStats(
 	ctx context.Context, req *roachpb.SpanStatsRequest,
 ) (*roachpb.SpanStatsResponse, error) {
 	ctx = s.AnnotateCtx(ctx)
-	if _, err := s.privilegeChecker.RequireAdminUser(ctx); err != nil {
+	if err := s.privilegeChecker.RequireViewClusterMetadataPermission(ctx); err != nil {
 		// NB: not using srverrors.ServerError() here since the priv checker
 		// already returns a proper gRPC error status.
 		return nil, err
@@ -3647,7 +3647,7 @@ func (s *systemStatusServer) SpanStats(
 ) (*roachpb.SpanStatsResponse, error) {
 	ctx = authserver.ForwardSQLIdentityThroughRPCCalls(ctx)
 	ctx = s.AnnotateCtx(ctx)
-	if _, err := s.privilegeChecker.RequireAdminUser(ctx); err != nil {
+	if err := s.privilegeChecker.RequireViewClusterMetadataPermission(ctx); err != nil {
 		// NB: not using srverrors.ServerError() here since the priv checker
 		// already returns a proper gRPC error status.
 		return nil, err
@@ -3818,7 +3818,7 @@ func (s *statusServer) JobRegistryStatus(
 	ctx = authserver.ForwardSQLIdentityThroughRPCCalls(ctx)
 	ctx = s.AnnotateCtx(ctx)
 
-	if _, err := s.privilegeChecker.RequireAdminUser(ctx); err != nil {
+	if err := s.privilegeChecker.RequireViewClusterMetadataPermission(ctx); err != nil {
 		// NB: not using srverrors.ServerError() here since the priv checker
 		// already returns a proper gRPC error status.
 		return nil, err
@@ -3856,7 +3856,7 @@ func (s *statusServer) JobStatus(
 ) (*serverpb.JobStatusResponse, error) {
 	ctx = s.AnnotateCtx(authserver.ForwardSQLIdentityThroughRPCCalls(ctx))
 
-	if _, err := s.privilegeChecker.RequireAdminUser(ctx); err != nil {
+	if err := s.privilegeChecker.RequireViewClusterMetadataPermission(ctx); err != nil {
 		// NB: not using srverrors.ServerError() here since the priv checker
 		// already returns a proper gRPC error status.
 		return nil, err
@@ -3888,7 +3888,7 @@ func (s *statusServer) TxnIDResolution(
 	ctx context.Context, req *serverpb.TxnIDResolutionRequest,
 ) (*serverpb.TxnIDResolutionResponse, error) {
 	ctx = s.AnnotateCtx(authserver.ForwardSQLIdentityThroughRPCCalls(ctx))
-	if _, err := s.privilegeChecker.RequireAdminUser(ctx); err != nil {
+	if err := s.privilegeChecker.RequireViewClusterMetadataPermission(ctx); err != nil {
 		return nil, err
 	}
 
@@ -3994,8 +3994,7 @@ func (s *statusServer) GetJobProfilerExecutionDetails(
 	ctx context.Context, req *serverpb.GetJobProfilerExecutionDetailRequest,
 ) (*serverpb.GetJobProfilerExecutionDetailResponse, error) {
 	ctx = s.AnnotateCtx(ctx)
-	// TODO(adityamaru): Figure out the correct privileges required to get execution details.
-	_, err := s.privilegeChecker.RequireAdminUser(ctx)
+	err := s.privilegeChecker.RequireViewClusterMetadataPermission(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -4018,8 +4017,7 @@ func (s *statusServer) ListJobProfilerExecutionDetails(
 	ctx context.Context, req *serverpb.ListJobProfilerExecutionDetailsRequest,
 ) (*serverpb.ListJobProfilerExecutionDetailsResponse, error) {
 	ctx = s.AnnotateCtx(ctx)
-	// TODO(adityamaru): Figure out the correct privileges required to get execution details.
-	_, err := s.privilegeChecker.RequireAdminUser(ctx)
+	err := s.privilegeChecker.RequireViewClusterMetadataPermission(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/control_schedules.go
+++ b/pkg/sql/control_schedules.go
@@ -20,9 +20,11 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
+	"github.com/cockroachdb/cockroach/pkg/sql/syntheticprivilege"
 	"github.com/cockroachdb/errors"
 )
 
@@ -129,14 +131,17 @@ func (n *controlSchedulesNode) startExec(params runParams) error {
 			continue // not an error if schedule does not exist
 		}
 
-		isAdmin, err := params.p.UserHasAdminRole(params.ctx, params.p.User())
+		// Check that the user has privileges or is the owner of the schedules being altered.
+		hasPriv, err := params.p.HasPrivilege(
+			params.ctx, syntheticprivilege.GlobalPrivilegeObject, privilege.REPAIRCLUSTERMETADATA, params.p.User(),
+		)
 		if err != nil {
 			return err
 		}
 		isOwner := schedule.Owner() == params.p.User()
-		if !isAdmin && !isOwner {
-			return pgerror.Newf(pgcode.InsufficientPrivilege, "must be admin or owner of the "+
-				"schedule %d to %s it", schedule.ScheduleID(), n.command.String())
+		if !hasPriv && !isOwner {
+			return pgerror.Newf(pgcode.InsufficientPrivilege, "must have %s privilege or be owner of the "+
+				"schedule %d to %s it", privilege.REPAIRCLUSTERMETADATA, schedule.ScheduleID(), n.command.String())
 		}
 
 		switch n.command {

--- a/pkg/sql/repair.go
+++ b/pkg/sql/repair.go
@@ -712,12 +712,8 @@ func checkPlannerStateForRepairFunctions(ctx context.Context, p *planner, method
 	if p.extendedEvalCtx.TxnReadOnly {
 		return readOnlyError(method)
 	}
-	hasAdmin, err := p.UserHasAdminRole(ctx, p.User())
-	if err != nil {
+	if err := p.CheckPrivilege(ctx, syntheticprivilege.GlobalPrivilegeObject, privilege.REPAIRCLUSTERMETADATA); err != nil {
 		return err
-	}
-	if !hasAdmin {
-		return pgerror.Newf(pgcode.InsufficientPrivilege, "admin role required for %s", method)
 	}
 	return nil
 }

--- a/pkg/sql/show_create_external_connection.go
+++ b/pkg/sql/show_create_external_connection.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
@@ -74,12 +75,13 @@ func (p *planner) ShowCreateExternalConnection(
 ) (planNode, error) {
 	var hasPrivileges bool
 	var err error
-	if hasPrivileges, err = p.UserHasAdminRole(ctx, p.User()); err != nil {
+	if hasPrivileges, err = p.HasPrivilege(ctx, syntheticprivilege.GlobalPrivilegeObject, privilege.VIEWCLUSTERMETADATA, p.User()); err != nil {
 		return nil, err
 	}
 
-	// If the user is not admin, and is running a `SHOW CREATE EXTERNAL CONNECTION foo`
-	// check if the user is the owner of the object.
+	// If the user does not have VIEWCLUSTERMETADATA, and is running a `SHOW
+	// CREATE EXTERNAL CONNECTION foo` check if the user is the owner of the
+	// object.
 	exprEval := p.ExprEvaluator(externalConnectionOp)
 	if !hasPrivileges && n.ConnectionLabel != nil {
 		name, err := exprEval.String(ctx, n.ConnectionLabel)
@@ -94,10 +96,10 @@ func (p *planner) ShowCreateExternalConnection(
 			return nil, err
 		}
 		if !isOwner {
-			return nil, pgerror.Newf(pgcode.InsufficientPrivilege, "must be admin or owner of the External Connection %q", name)
+			return nil, pgerror.Newf(pgcode.InsufficientPrivilege, "must have %s privilege or be owner of the External Connection %q", privilege.VIEWCLUSTERMETADATA, name)
 		}
 	} else if !hasPrivileges {
-		return nil, pgerror.New(pgcode.InsufficientPrivilege, "must be admin to run `SHOW CREATE ALL EXTERNAL CONNECTIONS")
+		return nil, pgerror.Newf(pgcode.InsufficientPrivilege, "must have %s privilege to run `SHOW CREATE ALL EXTERNAL CONNECTIONS`", privilege.VIEWCLUSTERMETADATA)
 	}
 
 	sqltelemetry.IncrementShowCounter(sqltelemetry.CreateExternalConnection)


### PR DESCRIPTION
Release note (security update): Endpoints in the admin and status server
that previously required the admin role now can be used by users with
the VIEWCLUSTERMETADATA or REPAIRCLUSTERMETADATA system privilege,
depending on whether the endpoint is read-only or can modify state.

fixes https://github.com/cockroachdb/cockroach/issues/79571
fixes https://github.com/cockroachdb/cockroach/issues/109814
Release note: None