### PR TITLE
release-23.1: backupccl: add EXECUTION LOCALITY option to RESTORE

### DIFF
--- a/docs/generated/sql/bnf/restore_options.bnf
+++ b/docs/generated/sql/bnf/restore_options.bnf
@@ -19,3 +19,4 @@ restore_options ::=
 	| 'SCHEMA_ONLY'
 	| 'VERIFY_BACKUP_TABLE_DATA'
 	| 'UNSAFE_RESTORE_INCOMPATIBLE_VERSION'
+	| 'EXECUTION' 'LOCALITY' '=' string_or_placeholder

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -2618,6 +2618,7 @@ restore_options ::=
 	| 'SCHEMA_ONLY'
 	| 'VERIFY_BACKUP_TABLE_DATA'
 	| 'UNSAFE_RESTORE_INCOMPATIBLE_VERSION'
+	| 'EXECUTION' 'LOCALITY' '=' string_or_placeholder
 
 scrub_option_list ::=
 	( scrub_option ) ( ( ',' scrub_option ) )*

--- a/pkg/ccl/backupccl/backup_job.go
+++ b/pkg/ccl/backupccl/backup_job.go
@@ -481,7 +481,7 @@ func (b *backupResumer) Resume(ctx context.Context, execCtx interface{}) error {
 	details := b.job.Details().(jobspb.BackupDetails)
 	p := execCtx.(sql.JobExecContext)
 
-	if err := b.maybeRelocateJobExecution(ctx, p, details.ExecutionLocality); err != nil {
+	if err := maybeRelocateJobExecution(ctx, b.job.ID(), p, details.ExecutionLocality); err != nil {
 		return err
 	}
 
@@ -883,8 +883,8 @@ func (b *backupResumer) ReportResults(ctx context.Context, resultsCh chan<- tree
 	}
 }
 
-func (b *backupResumer) maybeRelocateJobExecution(
-	ctx context.Context, p sql.JobExecContext, locality roachpb.Locality,
+func maybeRelocateJobExecution(
+	ctx context.Context, jobID jobspb.JobID, p sql.JobExecContext, locality roachpb.Locality,
 ) error {
 	if locality.NonEmpty() {
 		current, err := p.DistSQLPlanner().GetSQLInstanceInfo(p.ExecCfg().JobRegistry.ID())
@@ -894,7 +894,7 @@ func (b *backupResumer) maybeRelocateJobExecution(
 		if ok, missedTier := current.Locality.Matches(locality); !ok {
 			log.Infof(ctx,
 				"BACKUP job %d initially adopted on instance %d but it does not match locality filter %s, finding a new coordinator",
-				b.job.ID(), current.NodeID, missedTier.String(),
+				jobID, current.NodeID, missedTier.String(),
 			)
 
 			instancesInRegion, err := p.DistSQLPlanner().GetAllInstancesByLocality(ctx, locality)
@@ -907,7 +907,7 @@ func (b *backupResumer) maybeRelocateJobExecution(
 			var res error
 			if err := p.ExecCfg().InternalDB.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
 				var err error
-				res, err = p.ExecCfg().JobRegistry.RelocateLease(ctx, txn, b.job.ID(), dest.InstanceID, dest.SessionID)
+				res, err = p.ExecCfg().JobRegistry.RelocateLease(ctx, txn, jobID, dest.InstanceID, dest.SessionID)
 				return err
 			}); err != nil {
 				return errors.Wrapf(err, "failed to relocate job coordinator to %d", dest.InstanceID)

--- a/pkg/ccl/backupccl/backup_job.go
+++ b/pkg/ccl/backupccl/backup_job.go
@@ -61,6 +61,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 	"github.com/gogo/protobuf/types"
 )
 
@@ -481,7 +482,7 @@ func (b *backupResumer) Resume(ctx context.Context, execCtx interface{}) error {
 	details := b.job.Details().(jobspb.BackupDetails)
 	p := execCtx.(sql.JobExecContext)
 
-	if err := maybeRelocateJobExecution(ctx, b.job.ID(), p, details.ExecutionLocality); err != nil {
+	if err := maybeRelocateJobExecution(ctx, b.job.ID(), p, details.ExecutionLocality, "BACKUP"); err != nil {
 		return err
 	}
 
@@ -884,7 +885,11 @@ func (b *backupResumer) ReportResults(ctx context.Context, resultsCh chan<- tree
 }
 
 func maybeRelocateJobExecution(
-	ctx context.Context, jobID jobspb.JobID, p sql.JobExecContext, locality roachpb.Locality,
+	ctx context.Context,
+	jobID jobspb.JobID,
+	p sql.JobExecContext,
+	locality roachpb.Locality,
+	jobDesc redact.SafeString,
 ) error {
 	if locality.NonEmpty() {
 		current, err := p.DistSQLPlanner().GetSQLInstanceInfo(p.ExecCfg().JobRegistry.ID())
@@ -893,8 +898,8 @@ func maybeRelocateJobExecution(
 		}
 		if ok, missedTier := current.Locality.Matches(locality); !ok {
 			log.Infof(ctx,
-				"BACKUP job %d initially adopted on instance %d but it does not match locality filter %s, finding a new coordinator",
-				jobID, current.NodeID, missedTier.String(),
+				"%s job %d initially adopted on instance %d but it does not match locality filter %s, finding a new coordinator",
+				jobDesc, jobID, current.NodeID, missedTier.String(),
 			)
 
 			instancesInRegion, err := p.DistSQLPlanner().GetAllInstancesByLocality(ctx, locality)

--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -1517,6 +1517,10 @@ func (r *restoreResumer) doResume(ctx context.Context, execCtx interface{}) erro
 	p := execCtx.(sql.JobExecContext)
 	r.execCfg = p.ExecCfg()
 
+	if err := maybeRelocateJobExecution(ctx, r.job.ID(), p, details.ExecutionLocality); err != nil {
+		return err
+	}
+
 	mem := p.ExecCfg().RootMemoryMonitor.MakeBoundAccount()
 	defer mem.Close(ctx)
 

--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -414,6 +414,7 @@ func restore(
 			numNodes,
 			numImportSpans,
 			simpleImportSpans,
+			details.ExecutionLocality,
 			progCh,
 		)
 	}
@@ -1517,7 +1518,7 @@ func (r *restoreResumer) doResume(ctx context.Context, execCtx interface{}) erro
 	p := execCtx.(sql.JobExecContext)
 	r.execCfg = p.ExecCfg()
 
-	if err := maybeRelocateJobExecution(ctx, r.job.ID(), p, details.ExecutionLocality); err != nil {
+	if err := maybeRelocateJobExecution(ctx, r.job.ID(), p, details.ExecutionLocality, "RESTORE"); err != nil {
 		return err
 	}
 

--- a/pkg/ccl/backupccl/restore_planning.go
+++ b/pkg/ccl/backupccl/restore_planning.go
@@ -1150,6 +1150,19 @@ func restorePlanHook(
 		}
 	}
 
+	var execLocality roachpb.Locality
+	if restoreStmt.Options.ExecutionLocality != nil {
+		loc, err := exprEval.String(ctx, restoreStmt.Options.ExecutionLocality)
+		if err != nil {
+			return nil, nil, nil, false, err
+		}
+		if loc != "" {
+			if err := execLocality.Set(loc); err != nil {
+				return nil, nil, nil, false, err
+			}
+		}
+	}
+
 	var newDBName string
 	if restoreStmt.Options.NewDBName != nil {
 		if restoreStmt.DescriptorCoverage == tree.AllDescriptors ||
@@ -1267,7 +1280,7 @@ func restorePlanHook(
 
 		return doRestorePlan(
 			ctx, restoreStmt, &exprEval, p, from, incStorage, pw, kms, restoreAllTenants, intoDB,
-			newDBName, newTenantID, newTenantName, endTime, resultsCh, subdir,
+			newDBName, newTenantID, newTenantName, endTime, resultsCh, subdir, execLocality,
 		)
 	}
 
@@ -1514,6 +1527,7 @@ func doRestorePlan(
 	endTime hlc.Timestamp,
 	resultsCh chan<- tree.Datums,
 	subdir string,
+	execLocality roachpb.Locality,
 ) error {
 	if len(from) == 0 || len(from[0]) == 0 {
 		return errors.New("invalid base backup specified")
@@ -2021,6 +2035,7 @@ func doRestorePlan(
 		SchemaOnly:          restoreStmt.Options.SchemaOnly,
 		VerifyData:          restoreStmt.Options.VerifyData,
 		SkipLocalitiesCheck: restoreStmt.Options.SkipLocalitiesCheck,
+		ExecutionLocality:   execLocality,
 	}
 
 	jr := jobs.Record{

--- a/pkg/ccl/backupccl/restore_planning.go
+++ b/pkg/ccl/backupccl/restore_planning.go
@@ -1023,6 +1023,7 @@ func restoreTypeCheck(
 			restoreStmt.Options.ForceTenantID,
 			restoreStmt.Options.AsTenant,
 			restoreStmt.Options.DebugPauseOn,
+			restoreStmt.Options.ExecutionLocality,
 		},
 	); err != nil {
 		return false, nil, err

--- a/pkg/jobs/jobspb/jobs.proto
+++ b/pkg/jobs/jobspb/jobs.proto
@@ -475,7 +475,9 @@ message RestoreDetails {
   // Disables loacality checking for zone configs.
   bool SkipLocalitiesCheck = 29;
 
-  // NEXT ID: 30.
+  roachpb.Locality execution_locality = 30 [(gogoproto.nullable) = false];
+  
+  // NEXT ID: 31.
 }
 
 

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -3781,6 +3781,11 @@ restore_options:
   {
     $$.val = &tree.RestoreOptions{UnsafeRestoreIncompatibleVersion: true}
   }
+| EXECUTION LOCALITY '=' string_or_placeholder
+  {
+    $$.val = &tree.RestoreOptions{ExecutionLocality: $4.expr()}
+  }
+
 
 virtual_cluster_opt:
   TENANT  { /* SKIP DOC */ }

--- a/pkg/sql/parser/testdata/backup_restore
+++ b/pkg/sql/parser/testdata/backup_restore
@@ -856,12 +856,13 @@ RESTORE FROM '_' IN '_' WITH OPTIONS (detached, include_all_virtual_clusters = $
 RESTORE FROM 'latest' IN 'bar' WITH OPTIONS (detached, include_all_virtual_clusters = $1) -- identifiers removed
 
 parse
-RESTORE FROM LATEST IN 'bar' WITH include_all_secondary_tenants = $1, detached
+RESTORE FROM LATEST IN 'bar' WITH include_all_virtual_clusters = $1, execution locality = $2, detached
 ----
-RESTORE FROM 'latest' IN 'bar' WITH OPTIONS (detached, include_all_virtual_clusters = $1) -- normalized!
-RESTORE FROM ('latest') IN ('bar') WITH OPTIONS (detached, include_all_virtual_clusters = ($1)) -- fully parenthesized
-RESTORE FROM '_' IN '_' WITH OPTIONS (detached, include_all_virtual_clusters = $1) -- literals removed
-RESTORE FROM 'latest' IN 'bar' WITH OPTIONS (detached, include_all_virtual_clusters = $1) -- identifiers removed
+RESTORE FROM 'latest' IN 'bar' WITH OPTIONS (detached, include_all_virtual_clusters = $1, execution locality = $2) -- normalized!
+RESTORE FROM ('latest') IN ('bar') WITH OPTIONS (detached, include_all_virtual_clusters = ($1), execution locality = ($2)) -- fully parenthesized
+RESTORE FROM '_' IN '_' WITH OPTIONS (detached, include_all_virtual_clusters = $1, execution locality = $1) -- literals removed
+RESTORE FROM 'latest' IN 'bar' WITH OPTIONS (detached, include_all_virtual_clusters = $1, execution locality = $2) -- identifiers removed
+
 
 parse
 RESTORE FROM LATEST IN 'bar' WITH include_all_virtual_clusters, detached
@@ -880,12 +881,12 @@ RESTORE FROM '_' IN '_' WITH OPTIONS (detached, include_all_virtual_clusters = _
 RESTORE FROM 'latest' IN 'bar' WITH OPTIONS (detached, include_all_virtual_clusters = true) -- identifiers removed
 
 parse
-RESTORE FROM LATEST IN 'bar' WITH unsafe_restore_incompatible_version, detached
+RESTORE FROM LATEST IN 'bar' WITH unsafe_restore_incompatible_version, execution locality = 'abc', detached
 ----
-RESTORE FROM 'latest' IN 'bar' WITH OPTIONS (detached, unsafe_restore_incompatible_version) -- normalized!
-RESTORE FROM ('latest') IN ('bar') WITH OPTIONS (detached, unsafe_restore_incompatible_version) -- fully parenthesized
-RESTORE FROM '_' IN '_' WITH OPTIONS (detached, unsafe_restore_incompatible_version) -- literals removed
-RESTORE FROM 'latest' IN 'bar' WITH OPTIONS (detached, unsafe_restore_incompatible_version) -- identifiers removed
+RESTORE FROM 'latest' IN 'bar' WITH OPTIONS (detached, unsafe_restore_incompatible_version, execution locality = 'abc') -- normalized!
+RESTORE FROM ('latest') IN ('bar') WITH OPTIONS (detached, unsafe_restore_incompatible_version, execution locality = ('abc')) -- fully parenthesized
+RESTORE FROM '_' IN '_' WITH OPTIONS (detached, unsafe_restore_incompatible_version, execution locality = '_') -- literals removed
+RESTORE FROM 'latest' IN 'bar' WITH OPTIONS (detached, unsafe_restore_incompatible_version, execution locality = 'abc') -- identifiers removed
 
 error
 BACKUP foo TO 'bar' WITH key1, key2 = 'value'

--- a/pkg/sql/sem/tree/backup.go
+++ b/pkg/sql/sem/tree/backup.go
@@ -146,6 +146,7 @@ type RestoreOptions struct {
 	SchemaOnly                       bool
 	VerifyData                       bool
 	UnsafeRestoreIncompatibleVersion bool
+	ExecutionLocality                Expr
 }
 
 var _ NodeFormatter = &RestoreOptions{}
@@ -494,6 +495,12 @@ func (o *RestoreOptions) Format(ctx *FmtCtx) {
 		maybeAddSep()
 		ctx.WriteString("unsafe_restore_incompatible_version")
 	}
+
+	if o.ExecutionLocality != nil {
+		maybeAddSep()
+		ctx.WriteString("execution locality = ")
+		ctx.FormatNode(o.ExecutionLocality)
+	}
 }
 
 // CombineWith merges other backup options into this backup options struct.
@@ -634,6 +641,12 @@ func (o *RestoreOptions) CombineWith(other *RestoreOptions) error {
 		o.UnsafeRestoreIncompatibleVersion = other.UnsafeRestoreIncompatibleVersion
 	}
 
+	if o.ExecutionLocality == nil {
+		o.ExecutionLocality = other.ExecutionLocality
+	} else if other.ExecutionLocality != nil {
+		return errors.New("execution locality option specified multiple times")
+	}
+
 	return nil
 }
 
@@ -658,7 +671,8 @@ func (o RestoreOptions) IsDefault() bool {
 		o.SchemaOnly == options.SchemaOnly &&
 		o.VerifyData == options.VerifyData &&
 		o.IncludeAllSecondaryTenants == options.IncludeAllSecondaryTenants &&
-		o.UnsafeRestoreIncompatibleVersion == options.UnsafeRestoreIncompatibleVersion
+		o.UnsafeRestoreIncompatibleVersion == options.UnsafeRestoreIncompatibleVersion &&
+		o.ExecutionLocality == options.ExecutionLocality
 }
 
 // BackupTargetList represents a list of targets.

--- a/pkg/sql/sem/tree/walk.go
+++ b/pkg/sql/sem/tree/walk.go
@@ -1263,6 +1263,16 @@ func (stmt *Backup) walkStmt(v Visitor) Statement {
 		}
 	}
 
+	if stmt.Options.ExecutionLocality != nil {
+		rh, changed := WalkExpr(v, stmt.Options.ExecutionLocality)
+		if changed {
+			if ret == stmt {
+				ret = stmt.copyNode()
+			}
+			ret.Options.ExecutionLocality = rh
+		}
+	}
+
 	return ret
 }
 
@@ -1538,6 +1548,16 @@ func (stmt *Restore) walkStmt(v Visitor) Statement {
 				ret = stmt.copyNode()
 			}
 			ret.Options.IncludeAllSecondaryTenants = include
+		}
+	}
+
+	if stmt.Options.ExecutionLocality != nil {
+		include, changed := WalkExpr(v, stmt.Options.ExecutionLocality)
+		if changed {
+			if ret == stmt {
+				ret = stmt.copyNode()
+			}
+			ret.Options.ExecutionLocality = include
 		}
 	}
 


### PR DESCRIPTION
Backport 3/3 commits from #104439.

/cc @cockroachdb/release

---

This mirrors the similar option to BACKUP and changefeeds, restricting the job coordinator and the worker processes planned by the job to executing on nodes which match the passed locality filter.

Release note (sql change): RESTORE can now be passed a WITH EXECUTION LOCALITY option similar to BACKUP, to restrict execution of the job to nodes with matching localities.

Epic: CRDB-28521

Release justification: customer requested feature to control placement of restore job coordinator and workers
