### PR TITLE
streamingccl: support multiple processors per machine

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1772,7 +1772,7 @@ type StreamingTestingKnobs struct {
 
 	// AfterReplicationFlowPlan allows the caller to inspect the ingestion and
 	// frontier specs generated for the replication job.
-	AfterReplicationFlowPlan func(map[base.SQLInstanceID]*execinfrapb.StreamIngestionDataSpec,
+	AfterReplicationFlowPlan func(map[base.SQLInstanceID][]*execinfrapb.StreamIngestionDataSpec,
 		*execinfrapb.StreamIngestionFrontierSpec)
 
 	// OverrideRevertRangeBatchSize allows overriding the `MaxSpanRequestKeys`


### PR DESCRIPTION
Each stream ingestion processor has a number of components that we may want to scale over time:

- The number of SQL connections used to stream data
- The number of goroutines used for key rewriting
- The number of goroutines used for batching and AddSSTabling keys

This PR gives us a rather inelegant hammer of scaling the whole lot at once by putting multiple ingestion procesosrs on a single node.

If the node has been assigned multiple sources, we first create additional workers by putting different source nodes on different processors.

If there are still workers left over, we then find the source with the most spans and divide up its work over the remaining workers.

In ad-hoc testing, this doesn't have a substantial impact on our TPCC test case, so I've left the worker count set to 1 by default.

Epic: CRDB-26968

Release note: None