### PR TITLE
roachtest: add c2c/multiregion/SameRegions/kv0 roachtest

### DIFF
--- a/pkg/ccl/streamingccl/streamingest/replication_stream_e2e_test.go
+++ b/pkg/ccl/streamingccl/streamingest/replication_stream_e2e_test.go
@@ -1197,4 +1197,31 @@ func TestStreamingRegionalConstraint(t *testing.T) {
 
 	testutils.SucceedsSoon(t,
 		checkLocalities(tableDesc.PrimaryIndexSpan(destCodec), rangedesc.NewScanner(c.DestSysServer.DB())))
+
+	tableName := "test"
+	tabledIDQuery := fmt.Sprintf(`SELECT id FROM system.namespace WHERE name ='%s'`, tableName)
+
+	var tableID uint32
+	c.SrcTenantSQL.QueryRow(t, tabledIDQuery).Scan(&tableID)
+	fmt.Printf("%d", tableID)
+
+	checkLocalityRanges(t, c.SrcSysSQL, srcCodec, uint32(tableDesc.GetID()), "mars")
+
+}
+
+func checkLocalityRanges(
+	t *testing.T, sysSQL *sqlutils.SQLRunner, codec keys.SQLCodec, tableID uint32, region string,
+) {
+	targetPrefix := codec.TablePrefix(tableID)
+	distinctQuery := fmt.Sprintf(`
+SELECT 
+  DISTINCT replica_localities
+FROM 
+  [SHOW CLUSTER RANGES]
+WHERE 
+  start_key ~ '%s'
+`, targetPrefix)
+	var locality string
+	sysSQL.QueryRow(t, distinctQuery).Scan(&locality)
+	require.Contains(t, locality, region)
 }

--- a/pkg/cmd/roachtest/tests/multitenant_utils.go
+++ b/pkg/cmd/roachtest/tests/multitenant_utils.go
@@ -366,6 +366,7 @@ func startInMemoryTenant(
 	sysSQL.Exec(t, `ALTER TENANT $1 SET CLUSTER SETTING sql.split_at.allow_for_secondary_tenant.enabled=true`, tenantName)
 	sysSQL.Exec(t, `ALTER TENANT $1 SET CLUSTER SETTING sql.scatter.allow_for_secondary_tenant.enabled=true`, tenantName)
 	sysSQL.Exec(t, `ALTER TENANT $1 SET CLUSTER SETTING sql.zone_configs.allow_for_secondary_tenant.enabled=true`, tenantName)
+	sysSQL.Exec(t, `ALTER TENANT $1 SET CLUSTER SETTING sql.virtual_cluster.feature_access.multiregion.enabled=true`, tenantName)
 	sysSQL.Exec(t, `ALTER TENANT $1 SET CLUSTER SETTING enterprise.license = $2`, tenantName, config.CockroachDevLicense)
 	sysSQL.Exec(t, `ALTER TENANT $1 SET CLUSTER SETTING cluster.organization = 'Cockroach Labs - Production Testing'`, tenantName)
 	removeTenantRateLimiters(t, sysSQL, tenantName)


### PR DESCRIPTION
This patch adds a new c2c roachtest that spins up multiregion source and destination clusters, constrains the kv database to the us-east1-b region, and asserts that the replicated span configuration enforces the regional constraint on the destination cluster during replication.

Informs #109059

Release note: None