### PR TITLE
uuid: avoid using deprecated math/rand.Read

### DIFF
--- a/pkg/util/uuid/generator.go
+++ b/pkg/util/uuid/generator.go
@@ -18,12 +18,13 @@ package uuid
 
 import (
 	"crypto/md5"
-	"crypto/rand"
+	crypto_rand "crypto/rand"
 	"crypto/sha1"
 	"encoding/binary"
 	"fmt"
 	"hash"
 	"io"
+	math_rand "math/rand"
 	"net"
 	"sync"
 	"time"
@@ -42,6 +43,7 @@ type epochFunc func() time.Time
 type HWAddrFunc func() (net.HardwareAddr, error)
 
 // DefaultGenerator is the default UUID Generator used by this package.
+// It uses crypto/rand as the source of entropy.
 var DefaultGenerator Generator = NewGen()
 
 // NewV1 returns a UUID based on the current timestamp and MAC address.
@@ -89,7 +91,8 @@ type Gen struct {
 	hardwareAddrOnce  sync.Once
 	storageMutex      syncutil.Mutex
 
-	rand io.Reader
+	usePRNG bool
+	rand    io.Reader
 
 	epochFunc     epochFunc
 	hwAddrFunc    HWAddrFunc
@@ -131,7 +134,7 @@ func NewGenWithHWAF(hwaf HWAddrFunc) *Gen {
 	return &Gen{
 		epochFunc:  time.Now,
 		hwAddrFunc: hwaf,
-		rand:       rand.Reader,
+		rand:       crypto_rand.Reader,
 	}
 }
 
@@ -172,12 +175,9 @@ func (g *Gen) NewV3(ns UUID, name string) UUID {
 // NewV4 returns a randomly generated UUID.
 func (g *Gen) NewV4() (UUID, error) {
 	u := UUID{}
-	if r, ok := g.rand.(defaultRandReader); ok {
-		if n, err := r.Read(u[:]); n != len(u) {
-			panic("math/rand.Read always returns len(p)")
-		} else if err != nil {
-			panic("math/rand.Read always returns a nil error")
-		}
+	if g.usePRNG {
+		binary.LittleEndian.PutUint64(u[:8], math_rand.Uint64())
+		binary.LittleEndian.PutUint64(u[8:], math_rand.Uint64())
 	} else {
 		willEscape := UUID{}
 		if _, err := io.ReadFull(g.rand, willEscape[:]); err != nil {
@@ -291,7 +291,7 @@ func defaultHWAddrFunc() (net.HardwareAddr, error) {
 func RandomHardwareAddrFunc() (net.HardwareAddr, error) {
 	var err error
 	var hardwareAddr = make(net.HardwareAddr, 6)
-	if _, err = io.ReadFull(rand.Reader, hardwareAddr[:]); err != nil {
+	if _, err = io.ReadFull(crypto_rand.Reader, hardwareAddr[:]); err != nil {
 		return []byte{}, err
 	}
 	// Set multicast bit and local-admin bit to match Postgres.

--- a/pkg/util/uuid/uuid_wrapper.go
+++ b/pkg/util/uuid/uuid_wrapper.go
@@ -125,11 +125,11 @@ var fastGen = NewGenWithReader(defaultRandReader{})
 
 // NewPopulatedUUID returns a populated UUID.
 func NewPopulatedUUID(r interface {
-	Int63() int64
+	Uint64() uint64
 }) *UUID {
 	var u UUID
-	binary.LittleEndian.PutUint64(u[:8], uint64(r.Int63()))
-	binary.LittleEndian.PutUint64(u[8:], uint64(r.Int63()))
+	binary.LittleEndian.PutUint64(u[:8], r.Uint64())
+	binary.LittleEndian.PutUint64(u[8:], r.Uint64())
 	return &u
 }
 

--- a/pkg/util/uuid/uuid_wrapper.go
+++ b/pkg/util/uuid/uuid_wrapper.go
@@ -14,7 +14,6 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
-	"math/rand"
 
 	"github.com/cockroachdb/cockroach/pkg/util/uint128"
 	"github.com/cockroachdb/errors"
@@ -109,19 +108,14 @@ func FastMakeV4() UUID {
 	return u
 }
 
-// defaultRandReader is an io.Reader that calls through to "math/rand".Read
-// which is safe for concurrent use.
-type defaultRandReader struct{}
+// fastGen is a non-cryptographically secure Generator. It uses math/rand
+// as the source of entropy.
+var fastGen *Gen
 
-func (r defaultRandReader) Read(p []byte) (n int, err error) {
-	// https://github.com/cockroachdb/cockroach/issues/110597 tracks this
-	// deprecated usage.
-	//lint:ignore SA1019 deprecated
-	return rand.Read(p)
+func init() {
+	fastGen = NewGen()
+	fastGen.usePRNG = true
 }
-
-// fastGen is a non-cryptographically secure Generator.
-var fastGen = NewGenWithReader(defaultRandReader{})
 
 // NewPopulatedUUID returns a populated UUID.
 func NewPopulatedUUID(r interface {


### PR DESCRIPTION
Now we generate uint64s instead and populate them into the UUID array.

```
goos: darwin
goarch: arm64
              │ /var/folders/p3/c61_z_vd3r7dr1_hnztm3ryr0000gq/T/tmp.BIfUofSiKJ/bench.0cde11b885a │ /var/folders/p3/c61_z_vd3r7dr1_hnztm3ryr0000gq/T/tmp.BIfUofSiKJ/bench.fbea7746013 │
              │                                      sec/op                                       │                          sec/op                            vs base                │
FastMakeV4-10                                                                         22.20n ± 0%                                                 28.34n ± 1%  +27.69% (p=0.000 n=10)

              │ /var/folders/p3/c61_z_vd3r7dr1_hnztm3ryr0000gq/T/tmp.BIfUofSiKJ/bench.0cde11b885a │ /var/folders/p3/c61_z_vd3r7dr1_hnztm3ryr0000gq/T/tmp.BIfUofSiKJ/bench.fbea7746013 │
              │                                       B/op                                        │                             B/op                               vs base            │
FastMakeV4-10                                                                          0.000 ± 0%                                                      0.000 ± 0%  ~ (p=1.000 n=10) ¹
¹ all samples are equal

              │ /var/folders/p3/c61_z_vd3r7dr1_hnztm3ryr0000gq/T/tmp.BIfUofSiKJ/bench.0cde11b885a │ /var/folders/p3/c61_z_vd3r7dr1_hnztm3ryr0000gq/T/tmp.BIfUofSiKJ/bench.fbea7746013 │
              │                                     allocs/op                                     │                           allocs/op                            vs base            │
FastMakeV4-10                                                                          0.000 ± 0%                                                      0.000 ± 0%  ~ (p=1.000 n=10) ¹
¹ all samples are equal
```

fixes https://github.com/cockroachdb/cockroach/issues/110597
Release note: None