### PR TITLE
docs-issue-generation: Add more detailed error messages

### DIFF
--- a/build/teamcity/cockroach/create-docs-issue.sh
+++ b/build/teamcity/cockroach/create-docs-issue.sh
@@ -9,7 +9,7 @@ dir="$(dirname $(dirname $(dirname "${0}")))"
 source "$dir/teamcity-support.sh"
 source "$dir/teamcity-bazel-support.sh"
 
-BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="-e GITHUB_API_TOKEN -e DOCS_ISSUE_GEN_END_TIME -e DOCS_ISSUE_GEN_START_TIME -e DRY_RUN_DOCS_ISSUE_GEN" run_bazel << 'EOF'
+BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="-e GITHUB_API_TOKEN -e JIRA_API_TOKEN -e DOCS_ISSUE_GEN_END_TIME -e DOCS_ISSUE_GEN_START_TIME -e DRY_RUN_DOCS_ISSUE_GEN" run_bazel << 'EOF'
 bazel build --config ci //pkg/cmd/docs-issue-generation
 BAZEL_BIN=$(bazel info bazel-bin --config ci)
 $BAZEL_BIN/pkg/cmd/docs-issue-generation/docs-issue-generation_/docs-issue-generation

--- a/pkg/cmd/docs-issue-generation/BUILD.bazel
+++ b/pkg/cmd/docs-issue-generation/BUILD.bazel
@@ -16,7 +16,6 @@ go_library(
     visibility = ["//visibility:private"],
     deps = [
         "//pkg/util/timeutil",
-        "@com_github_cockroachdb_errors//:errors",
         "@com_github_spf13_cobra//:cobra",
     ],
 )
@@ -36,6 +35,7 @@ go_test(
     embed = [":docs-issue-generation_lib"],
     deps = [
         "//pkg/testutils",
+        "//pkg/testutils/skip",
         "@com_github_stretchr_testify//assert",
     ],
 )

--- a/pkg/cmd/docs-issue-generation/docs_issue_generation_test.go
+++ b/pkg/cmd/docs-issue-generation/docs_issue_generation_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -192,7 +193,7 @@ func TestConstructDocsIssues(t *testing.T) {
 								},
 							},
 						},
-						DocType: jiraFieldId{Id: "10781"},
+						DocType: jiraFieldId{Id: "10779"},
 						FixVersions: []jiraFieldId{
 							{
 								Id: "10186",
@@ -332,7 +333,7 @@ func TestConstructDocsIssues(t *testing.T) {
 								},
 							},
 						},
-						DocType: jiraFieldId{Id: "10781"},
+						DocType: jiraFieldId{Id: "10779"},
 						FixVersions: []jiraFieldId{
 							{
 								Id: "10185",
@@ -427,7 +428,7 @@ func TestConstructDocsIssues(t *testing.T) {
 							},
 						},
 
-						DocType: jiraFieldId{Id: "10781"},
+						DocType: jiraFieldId{Id: "10779"},
 						FixVersions: []jiraFieldId{
 							{
 								Id: "10186",
@@ -521,7 +522,7 @@ func TestConstructDocsIssues(t *testing.T) {
 								},
 							},
 						},
-						DocType: jiraFieldId{Id: "10781"},
+						DocType: jiraFieldId{Id: "10779"},
 						FixVersions: []jiraFieldId{
 							{
 								Id: "10186",
@@ -625,7 +626,7 @@ func TestConstructDocsIssues(t *testing.T) {
 								},
 							},
 						},
-						DocType: jiraFieldId{Id: "10781"},
+						DocType: jiraFieldId{Id: "10779"},
 						FixVersions: []jiraFieldId{
 							{
 								Id: "10365",
@@ -739,7 +740,7 @@ func TestConstructDocsIssues(t *testing.T) {
 								},
 							},
 						},
-						DocType: jiraFieldId{Id: "10781"},
+						DocType: jiraFieldId{Id: "10779"},
 						FixVersions: []jiraFieldId{
 							{
 								Id: "10365",
@@ -843,15 +844,11 @@ func TestConstructDocsIssues(t *testing.T) {
 										Custom   string "json:\"custom\""
 										CustomId int    "json:\"customId\""
 									} "json:\"schema\""
-									Name            string   "json:\"name\""
-									Key             string   "json:\"key\""
-									HasDefaultValue bool     "json:\"hasDefaultValue\""
-									Operations      []string "json:\"operations\""
-									AllowedValues   []struct {
-										Self  string "json:\"self\""
-										Value string "json:\"value\""
-										Id    string "json:\"id\""
-									} "json:\"allowedValues\""
+									Name            string                                   "json:\"name\""
+									Key             string                                   "json:\"key\""
+									HasDefaultValue bool                                     "json:\"hasDefaultValue\""
+									Operations      []string                                 "json:\"operations\""
+									AllowedValues   []jiraCreateIssueMetaDocTypeAllowedValue "json:\"allowedValues\""
 								} "json:\"customfield_10175\""
 								FixVersions struct {
 									Required bool "json:\"required\""
@@ -1001,15 +998,11 @@ func TestConstructDocsIssues(t *testing.T) {
 											Custom   string "json:\"custom\""
 											CustomId int    "json:\"customId\""
 										} "json:\"schema\""
-										Name            string   "json:\"name\""
-										Key             string   "json:\"key\""
-										HasDefaultValue bool     "json:\"hasDefaultValue\""
-										Operations      []string "json:\"operations\""
-										AllowedValues   []struct {
-											Self  string "json:\"self\""
-											Value string "json:\"value\""
-											Id    string "json:\"id\""
-										} "json:\"allowedValues\""
+										Name            string                                   "json:\"name\""
+										Key             string                                   "json:\"key\""
+										HasDefaultValue bool                                     "json:\"hasDefaultValue\""
+										Operations      []string                                 "json:\"operations\""
+										AllowedValues   []jiraCreateIssueMetaDocTypeAllowedValue "json:\"allowedValues\""
 									} "json:\"customfield_10175\""
 									FixVersions struct {
 										Required bool "json:\"required\""
@@ -1157,15 +1150,11 @@ func TestConstructDocsIssues(t *testing.T) {
 												Custom   string "json:\"custom\""
 												CustomId int    "json:\"customId\""
 											} "json:\"schema\""
-											Name            string   "json:\"name\""
-											Key             string   "json:\"key\""
-											HasDefaultValue bool     "json:\"hasDefaultValue\""
-											Operations      []string "json:\"operations\""
-											AllowedValues   []struct {
-												Self  string "json:\"self\""
-												Value string "json:\"value\""
-												Id    string "json:\"id\""
-											} "json:\"allowedValues\""
+											Name            string                                   "json:\"name\""
+											Key             string                                   "json:\"key\""
+											HasDefaultValue bool                                     "json:\"hasDefaultValue\""
+											Operations      []string                                 "json:\"operations\""
+											AllowedValues   []jiraCreateIssueMetaDocTypeAllowedValue "json:\"allowedValues\""
 										} "json:\"customfield_10175\""
 										FixVersions struct {
 											Required bool "json:\"required\""
@@ -1421,15 +1410,11 @@ func TestConstructDocsIssues(t *testing.T) {
 												Custom   string "json:\"custom\""
 												CustomId int    "json:\"customId\""
 											} "json:\"schema\""
-											Name            string   "json:\"name\""
-											Key             string   "json:\"key\""
-											HasDefaultValue bool     "json:\"hasDefaultValue\""
-											Operations      []string "json:\"operations\""
-											AllowedValues   []struct {
-												Self  string "json:\"self\""
-												Value string "json:\"value\""
-												Id    string "json:\"id\""
-											} "json:\"allowedValues\""
+											Name            string                                   "json:\"name\""
+											Key             string                                   "json:\"key\""
+											HasDefaultValue bool                                     "json:\"hasDefaultValue\""
+											Operations      []string                                 "json:\"operations\""
+											AllowedValues   []jiraCreateIssueMetaDocTypeAllowedValue "json:\"allowedValues\""
 										}{
 											Required: false,
 											Schema: struct {
@@ -1445,15 +1430,11 @@ func TestConstructDocsIssues(t *testing.T) {
 											Key:             "customfield_10175",
 											HasDefaultValue: false,
 											Operations:      []string{"set"},
-											AllowedValues: []struct {
-												Self  string "json:\"self\""
-												Value string "json:\"value\""
-												Id    string "json:\"id\""
-											}{
+											AllowedValues: []jiraCreateIssueMetaDocTypeAllowedValue{
 												{
-													Self:  "https://cockroachlabs.atlassian.net/rest/api/3/customFieldOption/10781",
+													Self:  "https://cockroachlabs.atlassian.net/rest/api/3/customFieldOption/10779",
 													Value: "Doc Bug",
-													Id:    "10781",
+													Id:    "10779",
 												},
 												{
 													Self:  "https://cockroachlabs.atlassian.net/rest/api/3/customFieldOption/10780",
@@ -3040,6 +3021,7 @@ Release note (sql change): Something something something...`,
 }
 
 func TestExtractEpicIDs(t *testing.T) {
+	skip.WithIssue(t, 110682, "Flakes when run under stressful conditions")
 	testCases := []struct {
 		message  string
 		expected map[string]int

--- a/pkg/cmd/docs-issue-generation/extract.go
+++ b/pkg/cmd/docs-issue-generation/extract.go
@@ -229,3 +229,17 @@ func getJiraIssueFromRef(ref string) (string, error) {
 		return "", fmt.Errorf("error: Malformed epic/issue ref (%s)", ref)
 	}
 }
+
+func extractProductChangeDocTypeId(
+	allowedValues []jiraCreateIssueMetaDocTypeAllowedValue,
+) (string, error) {
+	for _, v := range allowedValues {
+		if v.Value == "Product Change" {
+			return v.Id, nil
+		}
+	}
+	return "", fmt.Errorf(
+		"unable to locate a doc type of 'Product Change' in the %s project",
+		jiraDocsProjectCode,
+	)
+}

--- a/pkg/cmd/docs-issue-generation/format.go
+++ b/pkg/cmd/docs-issue-generation/format.go
@@ -40,6 +40,10 @@ func constructDocsIssues(prs []cockroachPR) ([]docsIssue, error) {
 	if err != nil {
 		return []docsIssue{}, err
 	}
+	docTypeId, err := extractProductChangeDocTypeId(jiraIssueMeta.Projects[0].Issuetypes[0].Fields.DocType.AllowedValues)
+	if err != nil {
+		return []docsIssue{}, err
+	}
 	var result []docsIssue
 	for _, pr := range prs {
 		for _, commit := range pr.Commits {
@@ -69,7 +73,7 @@ func constructDocsIssues(prs []cockroachPR) ([]docsIssue, error) {
 						Description: rn,
 						EpicLink:    epicRef,
 						DocType: jiraFieldId{
-							Id: jiraIssueMeta.Projects[0].Issuetypes[0].Fields.DocType.AllowedValues[0].Id,
+							Id: docTypeId,
 						},
 						ProductChangeCommitSHA: commit.Sha,
 						ProductChangePrNumber:  strconv.Itoa(pr.Number),

--- a/pkg/cmd/docs-issue-generation/structs.go
+++ b/pkg/cmd/docs-issue-generation/structs.go
@@ -234,15 +234,11 @@ type jiraIssueCreateMeta struct {
 						Custom   string `json:"custom"`
 						CustomId int    `json:"customId"`
 					} `json:"schema"`
-					Name            string   `json:"name"`
-					Key             string   `json:"key"`
-					HasDefaultValue bool     `json:"hasDefaultValue"`
-					Operations      []string `json:"operations"`
-					AllowedValues   []struct {
-						Self  string `json:"self"`
-						Value string `json:"value"`
-						Id    string `json:"id"`
-					} `json:"allowedValues"`
+					Name            string                                   `json:"name"`
+					Key             string                                   `json:"key"`
+					HasDefaultValue bool                                     `json:"hasDefaultValue"`
+					Operations      []string                                 `json:"operations"`
+					AllowedValues   []jiraCreateIssueMetaDocTypeAllowedValue `json:"allowedValues"`
 				} `json:"customfield_10175"`
 				FixVersions struct {
 					Required bool `json:"required"`
@@ -319,6 +315,12 @@ type jiraIssueCreateMeta struct {
 			} `json:"fields"`
 		} `json:"issuetypes"`
 	} `json:"projects"`
+}
+
+type jiraCreateIssueMetaDocTypeAllowedValue struct {
+	Self  string `json:"self"`
+	Value string `json:"value"`
+	Id    string `json:"id"`
 }
 
 type jiraIssue struct {


### PR DESCRIPTION
Fast follow to [DOC-7066](https://cockroachlabs.atlassian.net/browse/DOC-7066).

- Add more detailed error handling for requests
- Skip a test that is now flaking under stress
- Fix the "Doc Type" being incorrect upon generation

Epic: none

Release note: none