### PR TITLE
cloud/kubernetes: advance CRDB version to 23.1.10

### DIFF
--- a/cloud/kubernetes/bring-your-own-certs/client.yaml
+++ b/cloud/kubernetes/bring-your-own-certs/client.yaml
@@ -1,4 +1,4 @@
-# Generated file, DO NOT EDIT. Source: cockroachdb_cockroach_master/cloud/kubernetes/templates/bring-your-own-certs/client.yaml
+# Generated file, DO NOT EDIT. Source: cloud/kubernetes/templates/bring-your-own-certs/client.yaml
 # This config file demonstrates how to connect to the CockroachDB StatefulSet
 # defined in bring-your-own-certs-statefulset.yaml that uses certificates
 # created outside of Kubernetes. See that file for why you may want to use it.
@@ -20,7 +20,7 @@ spec:
   serviceAccountName: cockroachdb
   containers:
   - name: cockroachdb-client
-    image: cockroachdb/cockroach:v23.1.9
+    image: cockroachdb/cockroach:v23.1.10
     # Keep a pod open indefinitely so kubectl exec can be used to get a shell to it
     # and run cockroach client commands, such as cockroach sql, cockroach node status, etc.
     command:

--- a/cloud/kubernetes/bring-your-own-certs/cockroachdb-statefulset.yaml
+++ b/cloud/kubernetes/bring-your-own-certs/cockroachdb-statefulset.yaml
@@ -1,4 +1,4 @@
-# Generated file, DO NOT EDIT. Source: cockroachdb_cockroach_master/cloud/kubernetes/templates/bring-your-own-certs/cockroachdb-statefulset.yaml
+# Generated file, DO NOT EDIT. Source: cloud/kubernetes/templates/bring-your-own-certs/cockroachdb-statefulset.yaml
 # This config file defines a CockroachDB StatefulSet that uses certificates
 # created outside of Kubernetes. You may want to use it if you want to use a
 # different certificate authority from the one being used by Kubernetes or if
@@ -153,7 +153,7 @@ spec:
               topologyKey: kubernetes.io/hostname
       containers:
       - name: cockroachdb
-        image: cockroachdb/cockroach:v23.1.9
+        image: cockroachdb/cockroach:v23.1.10
         imagePullPolicy: IfNotPresent
         # TODO: Change these to appropriate values for the hardware that you're running. You can see
         # the resources that can be allocated on each of your Kubernetes nodes by running:

--- a/cloud/kubernetes/client-secure.yaml
+++ b/cloud/kubernetes/client-secure.yaml
@@ -1,4 +1,4 @@
-# Generated file, DO NOT EDIT. Source: cockroachdb_cockroach_master/cloud/kubernetes/templates/client-secure.yaml
+# Generated file, DO NOT EDIT. Source: cloud/kubernetes/templates/client-secure.yaml
 apiVersion: v1
 kind: Pod
 metadata:
@@ -32,7 +32,7 @@ spec:
       mountPath: /cockroach-certs
   containers:
   - name: cockroachdb-client
-    image: cockroachdb/cockroach:v23.1.9
+    image: cockroachdb/cockroach:v23.1.10
     imagePullPolicy: IfNotPresent
     volumeMounts:
     - name: client-certs

--- a/cloud/kubernetes/cluster-init-secure.yaml
+++ b/cloud/kubernetes/cluster-init-secure.yaml
@@ -1,4 +1,4 @@
-# Generated file, DO NOT EDIT. Source: cockroachdb_cockroach_master/cloud/kubernetes/templates/cluster-init-secure.yaml
+# Generated file, DO NOT EDIT. Source: cloud/kubernetes/templates/cluster-init-secure.yaml
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -34,7 +34,7 @@ spec:
           mountPath: /cockroach-certs
       containers:
       - name: cluster-init
-        image: cockroachdb/cockroach:v23.1.9
+        image: cockroachdb/cockroach:v23.1.10
         imagePullPolicy: IfNotPresent
         volumeMounts:
         - name: client-certs

--- a/cloud/kubernetes/cluster-init.yaml
+++ b/cloud/kubernetes/cluster-init.yaml
@@ -1,4 +1,4 @@
-# Generated file, DO NOT EDIT. Source: cockroachdb_cockroach_master/cloud/kubernetes/templates/cluster-init.yaml
+# Generated file, DO NOT EDIT. Source: cloud/kubernetes/templates/cluster-init.yaml
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: cluster-init
-        image: cockroachdb/cockroach:v23.1.9
+        image: cockroachdb/cockroach:v23.1.10
         imagePullPolicy: IfNotPresent
         command:
           - "/cockroach/cockroach"

--- a/cloud/kubernetes/cockroachdb-statefulset-secure.yaml
+++ b/cloud/kubernetes/cockroachdb-statefulset-secure.yaml
@@ -1,4 +1,4 @@
-# Generated file, DO NOT EDIT. Source: cockroachdb_cockroach_master/cloud/kubernetes/templates/cockroachdb-statefulset-secure.yaml
+# Generated file, DO NOT EDIT. Source: cloud/kubernetes/templates/cockroachdb-statefulset-secure.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -195,7 +195,7 @@ spec:
               topologyKey: kubernetes.io/hostname
       containers:
       - name: cockroachdb
-        image: cockroachdb/cockroach:v23.1.9
+        image: cockroachdb/cockroach:v23.1.10
         imagePullPolicy: IfNotPresent
         # TODO: Change these to appropriate values for the hardware that you're running. You can see
         # the resources that can be allocated on each of your Kubernetes nodes by running:

--- a/cloud/kubernetes/cockroachdb-statefulset.yaml
+++ b/cloud/kubernetes/cockroachdb-statefulset.yaml
@@ -1,4 +1,4 @@
-# Generated file, DO NOT EDIT. Source: cockroachdb_cockroach_master/cloud/kubernetes/templates/cockroachdb-statefulset.yaml
+# Generated file, DO NOT EDIT. Source: cloud/kubernetes/templates/cockroachdb-statefulset.yaml
 apiVersion: v1
 kind: Service
 metadata:
@@ -98,7 +98,7 @@ spec:
               topologyKey: kubernetes.io/hostname
       containers:
       - name: cockroachdb
-        image: cockroachdb/cockroach:v23.1.9
+        image: cockroachdb/cockroach:v23.1.10
         imagePullPolicy: IfNotPresent
         # TODO: Change these to appropriate values for the hardware that you're running. You can see
         # the resources that can be allocated on each of your Kubernetes nodes by running:

--- a/cloud/kubernetes/multiregion/client-secure.yaml
+++ b/cloud/kubernetes/multiregion/client-secure.yaml
@@ -1,4 +1,4 @@
-# Generated file, DO NOT EDIT. Source: cockroachdb_cockroach_master/cloud/kubernetes/templates/multiregion/client-secure.yaml
+# Generated file, DO NOT EDIT. Source: cloud/kubernetes/templates/multiregion/client-secure.yaml
 apiVersion: v1
 kind: Pod
 metadata:
@@ -9,7 +9,7 @@ spec:
   serviceAccountName: cockroachdb
   containers:
   - name: cockroachdb-client
-    image: cockroachdb/cockroach:v23.1.9
+    image: cockroachdb/cockroach:v23.1.10
     imagePullPolicy: IfNotPresent
     volumeMounts:
     - name: client-certs

--- a/cloud/kubernetes/multiregion/cluster-init-secure.yaml
+++ b/cloud/kubernetes/multiregion/cluster-init-secure.yaml
@@ -1,4 +1,4 @@
-# Generated file, DO NOT EDIT. Source: cockroachdb_cockroach_master/cloud/kubernetes/templates/multiregion/cluster-init-secure.yaml
+# Generated file, DO NOT EDIT. Source: cloud/kubernetes/templates/multiregion/cluster-init-secure.yaml
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -11,7 +11,7 @@ spec:
       serviceAccountName: cockroachdb
       containers:
       - name: cluster-init
-        image: cockroachdb/cockroach:v23.1.9
+        image: cockroachdb/cockroach:v23.1.10
         imagePullPolicy: IfNotPresent
         volumeMounts:
         - name: client-certs

--- a/cloud/kubernetes/multiregion/cockroachdb-statefulset-secure.yaml
+++ b/cloud/kubernetes/multiregion/cockroachdb-statefulset-secure.yaml
@@ -1,4 +1,4 @@
-# Generated file, DO NOT EDIT. Source: cockroachdb_cockroach_master/cloud/kubernetes/templates/multiregion/cockroachdb-statefulset-secure.yaml
+# Generated file, DO NOT EDIT. Source: cloud/kubernetes/templates/multiregion/cockroachdb-statefulset-secure.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -167,7 +167,7 @@ spec:
               topologyKey: kubernetes.io/hostname
       containers:
       - name: cockroachdb
-        image: cockroachdb/cockroach:v23.1.9
+        image: cockroachdb/cockroach:v23.1.10
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 26257

--- a/cloud/kubernetes/multiregion/eks/cockroachdb-statefulset-secure-eks.yaml
+++ b/cloud/kubernetes/multiregion/eks/cockroachdb-statefulset-secure-eks.yaml
@@ -1,4 +1,4 @@
-# Generated file, DO NOT EDIT. Source: cockroachdb_cockroach_master/cloud/kubernetes/templates/multiregion/eks/cockroachdb-statefulset-secure-eks.yaml
+# Generated file, DO NOT EDIT. Source: cloud/kubernetes/templates/multiregion/eks/cockroachdb-statefulset-secure-eks.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -185,7 +185,7 @@ spec:
           name: cockroach-env
       containers:
       - name: cockroachdb
-        image: cockroachdb/cockroach:v23.1.9
+        image: cockroachdb/cockroach:v23.1.10
         imagePullPolicy: IfNotPresent
         # TODO: Change these to appropriate values for the hardware that you're running. You can see
         # the resources that can be allocated on each of your Kubernetes nodes by running:

--- a/cloud/kubernetes/performance/cockroachdb-daemonset-insecure.yaml
+++ b/cloud/kubernetes/performance/cockroachdb-daemonset-insecure.yaml
@@ -1,4 +1,4 @@
-# Generated file, DO NOT EDIT. Source: cockroachdb_cockroach_master/cloud/kubernetes/templates/performance/cockroachdb-daemonset-insecure.yaml
+# Generated file, DO NOT EDIT. Source: cloud/kubernetes/templates/performance/cockroachdb-daemonset-insecure.yaml
 # This configuration file sets up a DaemonSet running CockroachDB in insecure
 # mode. For more information on why you might want to use a DaemonSet instead
 # of a StatefulSet, see our docs:
@@ -82,7 +82,7 @@ spec:
       hostNetwork: true
       containers:
       - name: cockroachdb
-        image: cockroachdb/cockroach:v23.1.9
+        image: cockroachdb/cockroach:v23.1.10
         imagePullPolicy: IfNotPresent
         # TODO: If you configured taints to give CockroachDB exclusive access to nodes, feel free
         # to remove the requests and limits sections. If you didn't, you'll need to change these to

--- a/cloud/kubernetes/performance/cockroachdb-daemonset-secure.yaml
+++ b/cloud/kubernetes/performance/cockroachdb-daemonset-secure.yaml
@@ -1,4 +1,4 @@
-# Generated file, DO NOT EDIT. Source: cockroachdb_cockroach_master/cloud/kubernetes/templates/performance/cockroachdb-daemonset-secure.yaml
+# Generated file, DO NOT EDIT. Source: cloud/kubernetes/templates/performance/cockroachdb-daemonset-secure.yaml
 # This configuration file sets up a secure DaemonSet running CockroachDB.
 # For more information on why you might want to use a DaemonSet instead
 # of a StatefulSet, see our docs:
@@ -198,7 +198,7 @@ spec:
               topologyKey: kubernetes.io/hostname
       containers:
       - name: cockroachdb
-        image: cockroachdb/cockroach:v23.1.9
+        image: cockroachdb/cockroach:v23.1.10
         imagePullPolicy: IfNotPresent
         # TODO: If you configured taints to give CockroachDB exclusive access to nodes, feel free
         # to remove the requests and limits sections. If you didn't, you'll need to change these to

--- a/cloud/kubernetes/performance/cockroachdb-statefulset-insecure.yaml
+++ b/cloud/kubernetes/performance/cockroachdb-statefulset-insecure.yaml
@@ -1,4 +1,4 @@
-# Generated file, DO NOT EDIT. Source: cockroachdb_cockroach_master/cloud/kubernetes/templates/performance/cockroachdb-statefulset-insecure.yaml
+# Generated file, DO NOT EDIT. Source: cloud/kubernetes/templates/performance/cockroachdb-statefulset-insecure.yaml
 # This configuration file sets up an insecure StatefulSet running CockroachDB with
 # tweaks to make it more performant than our default configuration files. All
 # changes from the default insecure configuration have been marked with a comment
@@ -141,7 +141,7 @@ spec:
       - name: cockroachdb
         # NOTE: Always use the most recent version of CockroachDB for the best
         # performance and reliability.
-        image: cockroachdb/cockroach:v23.1.9
+        image: cockroachdb/cockroach:v23.1.10
         imagePullPolicy: IfNotPresent
         # TODO: Change these to appropriate values for the hardware that you're running. You can see
         # the resources that can be allocated on each of your Kubernetes nodes by running:

--- a/cloud/kubernetes/performance/cockroachdb-statefulset-secure.yaml
+++ b/cloud/kubernetes/performance/cockroachdb-statefulset-secure.yaml
@@ -1,4 +1,4 @@
-# Generated file, DO NOT EDIT. Source: cockroachdb_cockroach_master/cloud/kubernetes/templates/performance/cockroachdb-statefulset-secure.yaml
+# Generated file, DO NOT EDIT. Source: cloud/kubernetes/templates/performance/cockroachdb-statefulset-secure.yaml
 # This configuration file sets up a secure StatefulSet running CockroachDB with
 # tweaks to make it more performant than our default configuration files. All
 # changes from the default secure configuration have been marked with a comment
@@ -232,7 +232,7 @@ spec:
       - name: cockroachdb
         # NOTE: Always use the most recent version of CockroachDB for the best
         # performance and reliability.
-        image: cockroachdb/cockroach:v23.1.9
+        image: cockroachdb/cockroach:v23.1.10
         imagePullPolicy: IfNotPresent
         # TODO: Change these to appropriate values for the hardware that you're running. You can see
         # the resources that can be allocated on each of your Kubernetes nodes by running:

--- a/cloud/kubernetes/v1.6/client-secure.yaml
+++ b/cloud/kubernetes/v1.6/client-secure.yaml
@@ -1,4 +1,4 @@
-# Generated file, DO NOT EDIT. Source: cockroachdb_cockroach_master/cloud/kubernetes/templates/v1.6/client-secure.yaml
+# Generated file, DO NOT EDIT. Source: cloud/kubernetes/templates/v1.6/client-secure.yaml
 apiVersion: v1
 kind: Pod
 metadata:
@@ -32,7 +32,7 @@ spec:
       mountPath: /cockroach-certs
   containers:
   - name: cockroachdb-client
-    image: cockroachdb/cockroach:v23.1.9
+    image: cockroachdb/cockroach:v23.1.10
     imagePullPolicy: IfNotPresent
     volumeMounts:
     - name: client-certs

--- a/cloud/kubernetes/v1.6/cluster-init-secure.yaml
+++ b/cloud/kubernetes/v1.6/cluster-init-secure.yaml
@@ -1,4 +1,4 @@
-# Generated file, DO NOT EDIT. Source: cockroachdb_cockroach_master/cloud/kubernetes/templates/v1.6/cluster-init-secure.yaml
+# Generated file, DO NOT EDIT. Source: cloud/kubernetes/templates/v1.6/cluster-init-secure.yaml
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -34,7 +34,7 @@ spec:
           mountPath: /cockroach-certs
       containers:
       - name: cluster-init
-        image: cockroachdb/cockroach:v23.1.9
+        image: cockroachdb/cockroach:v23.1.10
         imagePullPolicy: IfNotPresent
         volumeMounts:
         - name: client-certs

--- a/cloud/kubernetes/v1.6/cluster-init.yaml
+++ b/cloud/kubernetes/v1.6/cluster-init.yaml
@@ -1,4 +1,4 @@
-# Generated file, DO NOT EDIT. Source: cockroachdb_cockroach_master/cloud/kubernetes/templates/v1.6/cluster-init.yaml
+# Generated file, DO NOT EDIT. Source: cloud/kubernetes/templates/v1.6/cluster-init.yaml
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: cluster-init
-        image: cockroachdb/cockroach:v23.1.9
+        image: cockroachdb/cockroach:v23.1.10
         imagePullPolicy: IfNotPresent
         command:
           - "/cockroach/cockroach"

--- a/cloud/kubernetes/v1.6/cockroachdb-statefulset-secure.yaml
+++ b/cloud/kubernetes/v1.6/cockroachdb-statefulset-secure.yaml
@@ -1,4 +1,4 @@
-# Generated file, DO NOT EDIT. Source: cockroachdb_cockroach_master/cloud/kubernetes/templates/v1.6/cockroachdb-statefulset-secure.yaml
+# Generated file, DO NOT EDIT. Source: cloud/kubernetes/templates/v1.6/cockroachdb-statefulset-secure.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -178,7 +178,7 @@ spec:
               topologyKey: kubernetes.io/hostname
       containers:
       - name: cockroachdb
-        image: cockroachdb/cockroach:v23.1.9
+        image: cockroachdb/cockroach:v23.1.10
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 26257

--- a/cloud/kubernetes/v1.6/cockroachdb-statefulset.yaml
+++ b/cloud/kubernetes/v1.6/cockroachdb-statefulset.yaml
@@ -1,4 +1,4 @@
-# Generated file, DO NOT EDIT. Source: cockroachdb_cockroach_master/cloud/kubernetes/templates/v1.6/cockroachdb-statefulset.yaml
+# Generated file, DO NOT EDIT. Source: cloud/kubernetes/templates/v1.6/cockroachdb-statefulset.yaml
 apiVersion: v1
 kind: Service
 metadata:
@@ -81,7 +81,7 @@ spec:
               topologyKey: kubernetes.io/hostname
       containers:
       - name: cockroachdb
-        image: cockroachdb/cockroach:v23.1.9
+        image: cockroachdb/cockroach:v23.1.10
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 26257

--- a/cloud/kubernetes/v1.7/client-secure.yaml
+++ b/cloud/kubernetes/v1.7/client-secure.yaml
@@ -1,4 +1,4 @@
-# Generated file, DO NOT EDIT. Source: cockroachdb_cockroach_master/cloud/kubernetes/templates/v1.7/client-secure.yaml
+# Generated file, DO NOT EDIT. Source: cloud/kubernetes/templates/v1.7/client-secure.yaml
 apiVersion: v1
 kind: Pod
 metadata:
@@ -32,7 +32,7 @@ spec:
       mountPath: /cockroach-certs
   containers:
   - name: cockroachdb-client
-    image: cockroachdb/cockroach:v23.1.9
+    image: cockroachdb/cockroach:v23.1.10
     imagePullPolicy: IfNotPresent
     volumeMounts:
     - name: client-certs

--- a/cloud/kubernetes/v1.7/cluster-init-secure.yaml
+++ b/cloud/kubernetes/v1.7/cluster-init-secure.yaml
@@ -1,4 +1,4 @@
-# Generated file, DO NOT EDIT. Source: cockroachdb_cockroach_master/cloud/kubernetes/templates/v1.7/cluster-init-secure.yaml
+# Generated file, DO NOT EDIT. Source: cloud/kubernetes/templates/v1.7/cluster-init-secure.yaml
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -34,7 +34,7 @@ spec:
           mountPath: /cockroach-certs
       containers:
       - name: cluster-init
-        image: cockroachdb/cockroach:v23.1.9
+        image: cockroachdb/cockroach:v23.1.10
         imagePullPolicy: IfNotPresent
         volumeMounts:
         - name: client-certs

--- a/cloud/kubernetes/v1.7/cluster-init.yaml
+++ b/cloud/kubernetes/v1.7/cluster-init.yaml
@@ -1,4 +1,4 @@
-# Generated file, DO NOT EDIT. Source: cockroachdb_cockroach_master/cloud/kubernetes/templates/v1.7/cluster-init.yaml
+# Generated file, DO NOT EDIT. Source: cloud/kubernetes/templates/v1.7/cluster-init.yaml
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: cluster-init
-        image: cockroachdb/cockroach:v23.1.9
+        image: cockroachdb/cockroach:v23.1.10
         imagePullPolicy: IfNotPresent
         command:
           - "/cockroach/cockroach"

--- a/cloud/kubernetes/v1.7/cockroachdb-statefulset-secure.yaml
+++ b/cloud/kubernetes/v1.7/cockroachdb-statefulset-secure.yaml
@@ -1,4 +1,4 @@
-# Generated file, DO NOT EDIT. Source: cockroachdb_cockroach_master/cloud/kubernetes/templates/v1.7/cockroachdb-statefulset-secure.yaml
+# Generated file, DO NOT EDIT. Source: cloud/kubernetes/templates/v1.7/cockroachdb-statefulset-secure.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -190,7 +190,7 @@ spec:
               topologyKey: kubernetes.io/hostname
       containers:
       - name: cockroachdb
-        image: cockroachdb/cockroach:v23.1.9
+        image: cockroachdb/cockroach:v23.1.10
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 26257

--- a/cloud/kubernetes/v1.7/cockroachdb-statefulset.yaml
+++ b/cloud/kubernetes/v1.7/cockroachdb-statefulset.yaml
@@ -1,4 +1,4 @@
-# Generated file, DO NOT EDIT. Source: cockroachdb_cockroach_master/cloud/kubernetes/templates/v1.7/cockroachdb-statefulset.yaml
+# Generated file, DO NOT EDIT. Source: cloud/kubernetes/templates/v1.7/cockroachdb-statefulset.yaml
 apiVersion: v1
 kind: Service
 metadata:
@@ -93,7 +93,7 @@ spec:
               topologyKey: kubernetes.io/hostname
       containers:
       - name: cockroachdb
-        image: cockroachdb/cockroach:v23.1.9
+        image: cockroachdb/cockroach:v23.1.10
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 26257


### PR DESCRIPTION
Release note: None
Epic: None
Release justification: non-production (release infra) change.
