### PR TITLE
storageparam: do not allow subqueries in storage param clause

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -3488,3 +3488,11 @@ statement error pgcode 2BP01 pq: cannot drop index "t_108974_v_pkey" because vie
 ALTER TABLE t_108974_v DROP COLUMN k;
 
 subtest end
+
+# Regression test for https://github.com/cockroachdb/cockroach/issues/110629.
+# Subqueries are not allowed in storage parameters.
+statement ok
+CREATE TABLE t_110629 (a INT PRIMARY KEY);
+
+statement error subqueries are not allowed in table storage parameters
+ALTER TABLE t SET ( 'string' = EXISTS ( TABLE error ) );

--- a/pkg/sql/storageparam/storage_param.go
+++ b/pkg/sql/storageparam/storage_param.go
@@ -65,6 +65,11 @@ func Set(
 		// Cast these as strings.
 		expr := paramparse.UnresolvedNameToStrVal(sp.Value)
 
+		// Storage params handle their own scalar arguments, with no help from the
+		// optimizer. As such, they cannot contain subqueries.
+		defer semaCtx.Properties.Restore(semaCtx.Properties)
+		semaCtx.Properties.Require("table storage parameters", tree.RejectSubqueries)
+
 		// Convert the expressions to a datum.
 		typedExpr, err := tree.TypeCheck(ctx, expr, semaCtx, types.Any)
 		if err != nil {


### PR DESCRIPTION
This would previously cause an internal error. Now it displays a feature not supported error.

fixes https://github.com/cockroachdb/cockroach/issues/110629
Release note: None