### PR TITLE
build: give a longer timeout to column changes in RSG tests

### DIFF
--- a/build/teamcity/cockroach/nightlies/random_syntax_tests_impl.sh
+++ b/build/teamcity/cockroach/nightlies/random_syntax_tests_impl.sh
@@ -10,7 +10,7 @@ BAZEL_BIN=$(bazel info bazel-bin --config=ci)
 exit_status=0
 $BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci -- test --config=ci \
     //pkg/sql/tests:tests_test \
-    --test_arg -rsg=5m --test_arg -rsg-routines=8 --test_arg -rsg-exec-timeout=1m \
+    --test_arg -rsg=5m --test_arg -rsg-routines=8 --test_arg -rsg-exec-timeout=1m --test_arg -rsg-exec-column-change-timeout=90s \
     --test_timeout 3600 --test_filter 'TestRandomSyntax' \
     --test_sharding_strategy=disabled \
     || exit_status=$?


### PR DESCRIPTION
The code intended for column change operations to have a longer timeout than others. However, this was not reflected in the script that runs the tests.

fixes https://github.com/cockroachdb/cockroach/issues/110630
Release note: None