### PR TITLE
sqlstats: fix TestInsightsIntegrationForContention

### DIFF
--- a/pkg/sql/sqlstats/insights/integration/insights_test.go
+++ b/pkg/sql/sqlstats/insights/integration/insights_test.go
@@ -569,8 +569,8 @@ func TestInsightsIntegrationForContention(t *testing.T) {
 	testutils.SucceedsSoon(t, func() error {
 		rows, err := conn.DB.QueryContext(ctx, `SELECT
 		query,
-		insight.contention::FLOAT,
-		sum(txn_contention.contention_duration)::FLOAT AS durationMs,
+		COALESCE(insight.contention, 0::INTERVAL)::FLOAT,
+		COALESCE(sum(txn_contention.contention_duration), 0::INTERVAL)::FLOAT AS durationMs,
 		txn_contention.schema_name,
 		txn_contention.database_name,
 		txn_contention.table_name,


### PR DESCRIPTION
Fix TestInsightsIntegrationForContention, by adding COALESCE on possible NULL values before conversion.

Fix #110661

Release note: None