### PR TITLE
roachtest: ensure export parquet roachtest runs nightly

### DIFF
--- a/pkg/cmd/roachtest/tests/export_parquet.go
+++ b/pkg/cmd/roachtest/tests/export_parquet.go
@@ -122,7 +122,6 @@ func registerExportParquet(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:            "export/parquet/tpcc-100",
 		Owner:           registry.OwnerCDC,
-		Tags:            registry.Tags("daily"),
 		Cluster:         r.MakeClusterSpec(4, spec.CPU(8)),
 		RequiresLicense: false,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {


### PR DESCRIPTION
Previously, the export parquet roachtest would not run because of the "daily" tag. This change removes tags from this roachtest so it runs nightly.

Release note: None
Epic: None

disable this commit template, run: git config --global --add cockroachdb.disable-commit-template true