### PR TITLE
roachtest: fix acceptance tests owner tags

### DIFF
--- a/pkg/cmd/roachtest/tests/acceptance.go
+++ b/pkg/cmd/roachtest/tests/acceptance.go
@@ -77,18 +77,6 @@ func registerAcceptance(r registry.Registry) {
 			},
 		},
 	}
-	specTemplate := registry.TestSpec{
-		// NB: teamcity-post-failures.py relies on the acceptance tests
-		// being named acceptance/<testname> and will avoid posting a
-		// blank issue for the "acceptance" parent test. Make sure to
-		// teach that script (if it's still used at that point) should
-		// this naming scheme ever change (or issues such as #33519)
-		// will be posted.
-		Name:    "acceptance",
-		Timeout: 10 * time.Minute,
-		Tags:    registry.Tags("default", "quick"),
-	}
-
 	for owner, tests := range testCases {
 		for _, tc := range tests {
 			tc := tc // copy for closure
@@ -97,15 +85,19 @@ func registerAcceptance(r registry.Registry) {
 				numNodes = tc.numNodes
 			}
 
-			spec := specTemplate
-			spec.Owner = owner
-			spec.Cluster = r.MakeClusterSpec(numNodes)
-			spec.Skip = tc.skip
-			spec.Name = specTemplate.Name + "/" + tc.name
+			spec := registry.TestSpec{
+				Name:              "acceptance/" + tc.name,
+				Owner:             owner,
+				Cluster:           r.MakeClusterSpec(numNodes),
+				Skip:              tc.skip,
+				EncryptionSupport: tc.encryptionSupport,
+				Timeout:           10 * time.Minute,
+				Tags:              registry.Tags("default", "quick"),
+			}
+
 			if tc.timeout != 0 {
 				spec.Timeout = tc.timeout
 			}
-			spec.EncryptionSupport = tc.encryptionSupport
 			if !tc.defaultLeases {
 				spec.Leases = registry.MetamorphicLeases
 			}


### PR DESCRIPTION
When we `Add` a test to the registry, an `owner-XX` tag is added. For the acceptance tests, we were aliasing the tags between all tests (effectively, all tests get all owner tags).

Epic: none
Release note: None