### PR TITLE
roachtest: fix export parquet tag

### DIFF
--- a/pkg/cmd/roachtest/tests/export_parquet.go
+++ b/pkg/cmd/roachtest/tests/export_parquet.go
@@ -122,7 +122,6 @@ func registerExportParquet(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:            "export/parquet/tpcc-100",
 		Owner:           registry.OwnerCDC,
-		Tags:            registry.Tags("daily"),
 		Cluster:         r.MakeClusterSpec(4, spec.CPU(8)),
 		RequiresLicense: false,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {


### PR DESCRIPTION
The `export/parquet/tpcc-100` test has a `"daily"` tag, which is not a tag that we use. Effectively this makes the test "manual only". The intention was for it to be part of the nightly GCE run (which is the default), so we remove all tags.

Epic: none
Release note: None