### PR TITLE
tabledesc: validate ForeignKey columns

### DIFF
--- a/pkg/sql/catalog/table_elements.go
+++ b/pkg/sql/catalog/table_elements.go
@@ -989,6 +989,17 @@ func ColumnTypesWithInvertedCol(columns []Column, invertedCol Column) []*types.T
 	return t
 }
 
+// ColumnsByIDs returns a map of Columns keyed by their ID for the given table.
+func ColumnsByIDs(tbl TableDescriptor) map[descpb.ColumnID]Column {
+	cols := tbl.AllColumns()
+	byID := make(map[descpb.ColumnID]Column, len(cols))
+	for i := range cols {
+		col := cols[i]
+		byID[col.GetID()] = col
+	}
+	return byID
+}
+
 // ColumnNeedsBackfill returns true if adding or dropping (according to
 // the direction) the given column requires backfill.
 func ColumnNeedsBackfill(col Column) bool {

--- a/pkg/sql/catalog/tabledesc/structured_test.go
+++ b/pkg/sql/catalog/tabledesc/structured_test.go
@@ -642,6 +642,7 @@ func TestUnvalidateConstraints(t *testing.T) {
 	ctx := context.Background()
 
 	desc := NewBuilder(&descpb.TableDescriptor{
+		ID:               2,
 		Name:             "test",
 		ParentID:         descpb.ID(1),
 		NextConstraintID: 2,
@@ -654,10 +655,13 @@ func TestUnvalidateConstraints(t *testing.T) {
 		Privileges:    catpb.NewBasePrivilegeDescriptor(username.AdminRoleName()),
 		OutboundFKs: []descpb.ForeignKeyConstraint{
 			{
-				Name:              "fk",
-				ReferencedTableID: descpb.ID(1),
-				Validity:          descpb.ConstraintValidity_Validated,
-				ConstraintID:      1,
+				Name:                "fk",
+				ReferencedTableID:   descpb.ID(1),
+				Validity:            descpb.ConstraintValidity_Validated,
+				ConstraintID:        1,
+				OriginTableID:       2,
+				OriginColumnIDs:     []descpb.ColumnID{1},
+				ReferencedColumnIDs: []descpb.ColumnID{1},
 			},
 		},
 	}).BuildCreatedMutableTable()

--- a/pkg/sql/catalog/tabledesc/validate_test.go
+++ b/pkg/sql/catalog/tabledesc/validate_test.go
@@ -213,20 +213,16 @@ var validationMap = []struct {
 	{
 		obj: descpb.ForeignKeyConstraint{},
 		fieldMap: map[string]validationStatusInfo{
-			"OriginTableID": {status: iSolemnlySwearThisFieldIsValidated},
-			"OriginColumnIDs": {
-				status: todoIAmKnowinglyAddingTechDebt,
-				reason: "initial import: TODO(schema): add validation"},
-			"ReferencedColumnIDs": {
-				status: todoIAmKnowinglyAddingTechDebt,
-				reason: "initial import: TODO(schema): add validation"},
-			"ReferencedTableID": {status: iSolemnlySwearThisFieldIsValidated},
-			"Name":              {status: thisFieldReferencesNoObjects},
-			"Validity":          {status: thisFieldReferencesNoObjects},
-			"OnDelete":          {status: thisFieldReferencesNoObjects},
-			"OnUpdate":          {status: thisFieldReferencesNoObjects},
-			"Match":             {status: thisFieldReferencesNoObjects},
-			"ConstraintID":      {status: iSolemnlySwearThisFieldIsValidated},
+			"OriginTableID":       {status: iSolemnlySwearThisFieldIsValidated},
+			"OriginColumnIDs":     {status: iSolemnlySwearThisFieldIsValidated},
+			"ReferencedColumnIDs": {status: iSolemnlySwearThisFieldIsValidated},
+			"ReferencedTableID":   {status: iSolemnlySwearThisFieldIsValidated},
+			"Name":                {status: thisFieldReferencesNoObjects},
+			"Validity":            {status: thisFieldReferencesNoObjects},
+			"OnDelete":            {status: thisFieldReferencesNoObjects},
+			"OnUpdate":            {status: thisFieldReferencesNoObjects},
+			"Match":               {status: thisFieldReferencesNoObjects},
+			"ConstraintID":        {status: iSolemnlySwearThisFieldIsValidated},
 		},
 	},
 	{
@@ -335,6 +331,60 @@ var validationMap = []struct {
 type validationStatusInfo struct {
 	status validateStatus
 	reason string
+}
+
+// ModifyDescriptor is a helper function that invokes the provided closure with
+// a predefined, valid, TableDescriptor and then returns the modified result.
+// Usage:
+//
+//	testCaseInvalidDecField: ModifyDescriptor(func(desc *descpb.TableDescriptor) {
+//		desc.InboundFKs = nil  // Clear InbounFKs to cause an error.
+//	})
+func ModifyDescriptor(fn func(*descpb.TableDescriptor)) descpb.TableDescriptor {
+	validDesc := descpb.TableDescriptor{
+		ID:            4,
+		ParentID:      1,
+		Name:          "bar",
+		FormatVersion: descpb.InterleavedFormatVersion,
+		Columns: []descpb.ColumnDescriptor{
+			{ID: 1, Name: "bar", Type: types.String},
+		},
+		Families: []descpb.ColumnFamilyDescriptor{
+			{ID: 0, Name: "primary", ColumnIDs: []descpb.ColumnID{1}, ColumnNames: []string{"bar"}},
+		},
+		PrimaryIndex: descpb.IndexDescriptor{ID: 1, Name: "bar", ConstraintID: 1,
+			KeyColumnIDs: []descpb.ColumnID{1}, KeyColumnNames: []string{"bar"},
+			KeyColumnDirections: []catenumpb.IndexColumn_Direction{catenumpb.IndexColumn_ASC},
+			EncodingType:        catenumpb.PrimaryIndexEncoding,
+			Version:             descpb.LatestIndexDescriptorVersion,
+		},
+		OutboundFKs: []descpb.ForeignKeyConstraint{
+			{
+				ConstraintID:        2,
+				Name:                "to_this_table",
+				OriginTableID:       4,
+				OriginColumnIDs:     []descpb.ColumnID{1},
+				ReferencedTableID:   25,
+				ReferencedColumnIDs: []descpb.ColumnID{2},
+			},
+		},
+		InboundFKs: []descpb.ForeignKeyConstraint{
+			{
+				ConstraintID:        2,
+				Name:                "from_this_table",
+				OriginTableID:       36,
+				OriginColumnIDs:     []descpb.ColumnID{3},
+				ReferencedTableID:   4,
+				ReferencedColumnIDs: []descpb.ColumnID{1},
+			},
+		},
+		NextColumnID:     2,
+		NextFamilyID:     1,
+		NextIndexID:      3,
+		NextConstraintID: 3,
+	}
+	fn(&validDesc)
+	return validDesc
 }
 
 // Hello! If you're seeing this test fail, you probably just added a new
@@ -2838,7 +2888,40 @@ func TestValidateTableDesc(t *testing.T) {
 				NextIndexID:      3,
 				NextConstraintID: 2,
 			}},
+		{err: `invalid outbound foreign key "to_this_table": origin table ID should be 4. got 99`,
+			desc: ModifyDescriptor(func(desc *descpb.TableDescriptor) {
+				desc.OutboundFKs[0].OriginTableID = 99
+			})},
+		{err: `invalid outbound foreign key "to_this_table": no origin columns`,
+			desc: ModifyDescriptor(func(desc *descpb.TableDescriptor) {
+				desc.OutboundFKs[0].OriginColumnIDs = nil
+			})},
+		{err: `invalid outbound foreign key "to_this_table": mismatched number of referenced and origin columns`,
+			desc: ModifyDescriptor(func(desc *descpb.TableDescriptor) {
+				desc.OutboundFKs[0].ReferencedColumnIDs = []descpb.ColumnID{1, 2, 3}
+			})},
+		{err: `invalid outbound foreign key "to_this_table" from table "bar" (4): missing origin column=13`,
+			desc: ModifyDescriptor(func(desc *descpb.TableDescriptor) {
+				desc.OutboundFKs[0].OriginColumnIDs = []descpb.ColumnID{13}
+			})},
+		{err: `invalid inbound foreign key "from_this_table": referenced table ID should be 4. got 99`,
+			desc: ModifyDescriptor(func(desc *descpb.TableDescriptor) {
+				desc.InboundFKs[0].ReferencedTableID = 99
+			})},
+		{err: `invalid inbound foreign key "from_this_table": no referenced columns`,
+			desc: ModifyDescriptor(func(desc *descpb.TableDescriptor) {
+				desc.InboundFKs[0].ReferencedColumnIDs = nil
+			})},
+		{err: `invalid inbound foreign key "from_this_table": mismatched number of referenced and origin columns`,
+			desc: ModifyDescriptor(func(desc *descpb.TableDescriptor) {
+				desc.InboundFKs[0].OriginColumnIDs = []descpb.ColumnID{1, 2, 3}
+			})},
+		{err: `invalid inbound foreign key "from_this_table" to table "bar" (4): missing referenced column=13`,
+			desc: ModifyDescriptor(func(desc *descpb.TableDescriptor) {
+				desc.InboundFKs[0].ReferencedColumnIDs = []descpb.ColumnID{13}
+			})},
 	}
+
 	for i, d := range testData {
 		t.Run(d.err, func(t *testing.T) {
 			d.desc.Privileges = catpb.NewBasePrivilegeDescriptor(username.RootUserName())
@@ -2906,6 +2989,9 @@ func TestValidateCrossTableReferences(t *testing.T) {
 				ParentID:                1,
 				UnexposedParentSchemaID: keys.PublicSchemaID,
 				FormatVersion:           descpb.InterleavedFormatVersion,
+				Columns: []descpb.ColumnDescriptor{
+					{ID: 1, Name: "foo_1", Type: types.String},
+				},
 				OutboundFKs: []descpb.ForeignKeyConstraint{
 					{
 						Name:                "fk",
@@ -2922,6 +3008,9 @@ func TestValidateCrossTableReferences(t *testing.T) {
 				ParentID:                1,
 				UnexposedParentSchemaID: keys.PublicSchemaID,
 				FormatVersion:           descpb.InterleavedFormatVersion,
+				Columns: []descpb.ColumnDescriptor{
+					{ID: 1, Name: "baz_1", Type: types.String},
+				},
 			}},
 		},
 		{ // 2
@@ -2955,6 +3044,9 @@ func TestValidateCrossTableReferences(t *testing.T) {
 					ID:   1,
 					Name: "bar",
 				},
+				Columns: []descpb.ColumnDescriptor{
+					{ID: 1, Type: types.String, Name: "foo_1"},
+				},
 				InboundFKs: []descpb.ForeignKeyConstraint{
 					{
 						Name:                "fk",
@@ -2971,6 +3063,9 @@ func TestValidateCrossTableReferences(t *testing.T) {
 				ParentID:                1,
 				UnexposedParentSchemaID: keys.PublicSchemaID,
 				FormatVersion:           descpb.InterleavedFormatVersion,
+				Columns: []descpb.ColumnDescriptor{
+					{ID: 1, Type: types.String, Name: "baz_1"},
+				},
 			}},
 		},
 		{ // 4
@@ -2995,8 +3090,86 @@ func TestValidateCrossTableReferences(t *testing.T) {
 				},
 			},
 		},
-		// Add some expressions with invalid type references.
 		{ // 5
+			err: `invalid foreign key backreference from table "baz" (52): missing origin column=2`,
+			desc: descpb.TableDescriptor{
+				ID:                      51,
+				Name:                    "foo",
+				ParentID:                1,
+				UnexposedParentSchemaID: keys.PublicSchemaID,
+				FormatVersion:           descpb.InterleavedFormatVersion,
+				PrimaryIndex: descpb.IndexDescriptor{
+					ID:   1,
+					Name: "bar",
+				},
+				InboundFKs: []descpb.ForeignKeyConstraint{
+					{
+						Name:                "fk",
+						ReferencedTableID:   51,
+						ReferencedColumnIDs: []descpb.ColumnID{1},
+						OriginTableID:       52,
+						OriginColumnIDs:     []descpb.ColumnID{2},
+					},
+				},
+			},
+			otherDescs: []descpb.TableDescriptor{{
+				ID:                      52,
+				Name:                    "baz",
+				ParentID:                1,
+				UnexposedParentSchemaID: keys.PublicSchemaID,
+				FormatVersion:           descpb.InterleavedFormatVersion,
+				OutboundFKs: []descpb.ForeignKeyConstraint{
+					{
+						Name:                "fk",
+						ReferencedTableID:   51,
+						ReferencedColumnIDs: []descpb.ColumnID{1},
+						OriginTableID:       52,
+						OriginColumnIDs:     []descpb.ColumnID{2},
+					},
+				},
+			}},
+		},
+		{ // 6
+			err: `invalid outbound foreign key backreference from table "baz" (52): missing referenced column=2`,
+			desc: descpb.TableDescriptor{
+				ID:                      51,
+				Name:                    "foo",
+				ParentID:                1,
+				UnexposedParentSchemaID: keys.PublicSchemaID,
+				FormatVersion:           descpb.InterleavedFormatVersion,
+				PrimaryIndex: descpb.IndexDescriptor{
+					ID:   1,
+					Name: "bar",
+				},
+				OutboundFKs: []descpb.ForeignKeyConstraint{
+					{
+						Name:                "fk",
+						ReferencedTableID:   52,
+						ReferencedColumnIDs: []descpb.ColumnID{2},
+						OriginTableID:       51,
+						OriginColumnIDs:     []descpb.ColumnID{1},
+					},
+				},
+			},
+			otherDescs: []descpb.TableDescriptor{{
+				ID:                      52,
+				Name:                    "baz",
+				ParentID:                1,
+				UnexposedParentSchemaID: keys.PublicSchemaID,
+				FormatVersion:           descpb.InterleavedFormatVersion,
+				InboundFKs: []descpb.ForeignKeyConstraint{
+					{
+						Name:                "fk",
+						ReferencedTableID:   52,
+						ReferencedColumnIDs: []descpb.ColumnID{2},
+						OriginTableID:       51,
+						OriginColumnIDs:     []descpb.ColumnID{1},
+					},
+				},
+			}},
+		},
+		// Add some expressions with invalid type references.
+		{ // 7
 			err: `referenced type ID 500: referenced descriptor not found`,
 			desc: descpb.TableDescriptor{
 				Name:                    "foo",
@@ -3019,7 +3192,7 @@ func TestValidateCrossTableReferences(t *testing.T) {
 				},
 			},
 		},
-		{ // 6
+		{ // 8
 			err: `referenced type ID 500: referenced descriptor not found`,
 			desc: descpb.TableDescriptor{
 				Name:                    "foo",
@@ -3042,7 +3215,7 @@ func TestValidateCrossTableReferences(t *testing.T) {
 				},
 			},
 		},
-		{ // 7
+		{ // 9
 			err: `referenced type ID 500: referenced descriptor not found`,
 			desc: descpb.TableDescriptor{
 				Name:                    "foo",
@@ -3056,7 +3229,7 @@ func TestValidateCrossTableReferences(t *testing.T) {
 				},
 			},
 		},
-		{ // 8
+		{ // 10
 			err: `referenced type ID 500: referenced descriptor not found`,
 			desc: descpb.TableDescriptor{
 				Name:                    "foo",
@@ -3080,7 +3253,7 @@ func TestValidateCrossTableReferences(t *testing.T) {
 			},
 		},
 		// Temporary tables.
-		{ // 9
+		{ // 11
 			err: "",
 			desc: descpb.TableDescriptor{
 				Name:                    "foo",
@@ -3092,7 +3265,7 @@ func TestValidateCrossTableReferences(t *testing.T) {
 			},
 		},
 		// Views.
-		{ // 10
+		{ // 12
 			err: ``,
 			desc: descpb.TableDescriptor{
 				Name:                    "foo",
@@ -3124,7 +3297,7 @@ func TestValidateCrossTableReferences(t *testing.T) {
 				},
 			}},
 		},
-		{ // 11
+		{ // 13
 			err: `depended-on-by view "bar" (52) has no corresponding depends-on forward reference`,
 			desc: descpb.TableDescriptor{
 				Name:                    "foo",
@@ -3155,7 +3328,7 @@ func TestValidateCrossTableReferences(t *testing.T) {
 				},
 			}},
 		},
-		{ // 12
+		{ // 14
 			err: `depends-on relation "bar" (52) has no corresponding depended-on-by back reference`,
 			desc: descpb.TableDescriptor{
 				Name:                    "foo",
@@ -3186,7 +3359,7 @@ func TestValidateCrossTableReferences(t *testing.T) {
 			}},
 		},
 		// Sequences.
-		{ // 13
+		{ // 15
 			err: `depended-on-by relation "bar" (52) does not have a column with ID 123`,
 			desc: descpb.TableDescriptor{
 				Name:                    "foo",
@@ -3216,7 +3389,7 @@ func TestValidateCrossTableReferences(t *testing.T) {
 				},
 			}},
 		},
-		{ // 14
+		{ // 16
 			// This case deals with a bug in version 21.1 and prior when
 			// ALTER TABLE ... ADD COLUMN ... DEFAULT nextval(...) would set the
 			// backreference ID to be 0 because it set up the backreference before
@@ -3250,7 +3423,7 @@ func TestValidateCrossTableReferences(t *testing.T) {
 				DependsOn: []descpb.ID{51},
 			}},
 		},
-		{ // 15
+		{ // 17
 			err: `invalid depended-on-by relation back reference: referenced descriptor ID 100: referenced descriptor not found`,
 			desc: descpb.TableDescriptor{
 				Name:                    "foo",
@@ -3262,7 +3435,7 @@ func TestValidateCrossTableReferences(t *testing.T) {
 				},
 			},
 		},
-		{ // 16
+		{ // 18
 			err: `depended-on-by function "f" (100) has no corresponding depends-on forward reference`,
 			desc: descpb.TableDescriptor{
 				Name:                    "foo",
@@ -3277,7 +3450,7 @@ func TestValidateCrossTableReferences(t *testing.T) {
 				{ID: 100, Name: "f"},
 			},
 		},
-		{ // 17
+		{ // 19
 			err: `depends-on function "f" (100) has no corresponding depended-on-by back reference`,
 			desc: descpb.TableDescriptor{
 				Name:                    "foo",
@@ -3291,7 +3464,7 @@ func TestValidateCrossTableReferences(t *testing.T) {
 				{ID: 100, Name: "f"},
 			},
 		},
-		{ // 18
+		{ // 20
 			err: `invalid depends-on function back reference: referenced function ID 100: referenced descriptor not found`,
 			desc: descpb.TableDescriptor{
 				Name:                    "foo",
@@ -3307,7 +3480,7 @@ func TestValidateCrossTableReferences(t *testing.T) {
 				},
 			},
 		},
-		{ // 19
+		{ // 21
 			err: `depends-on function "f" (100) has no corresponding depended-on-by back reference`,
 			desc: descpb.TableDescriptor{
 				Name:                    "foo",
@@ -3326,7 +3499,7 @@ func TestValidateCrossTableReferences(t *testing.T) {
 				{ID: 100, Name: "f"},
 			},
 		},
-		{ // 20
+		{ // 22
 			err: `depends-on function "f" (100) has no corresponding depended-on-by back reference`,
 			desc: descpb.TableDescriptor{
 				Name:                    "foo",
@@ -3351,7 +3524,7 @@ func TestValidateCrossTableReferences(t *testing.T) {
 				},
 			},
 		},
-		{ // 21
+		{ // 23
 			err: ``,
 			desc: descpb.TableDescriptor{
 				Name:                    "foo",
@@ -3377,7 +3550,7 @@ func TestValidateCrossTableReferences(t *testing.T) {
 			},
 		},
 		// Composite types.
-		{ // 22
+		{ // 24
 			err: `referenced type ID 500: referenced descriptor not found`,
 			desc: descpb.TableDescriptor{
 				Name:                    "foo",
@@ -3399,7 +3572,7 @@ func TestValidateCrossTableReferences(t *testing.T) {
 				},
 			},
 		},
-		{ // 23
+		{ // 25
 			err: `invalid depends-on function back reference: referenced function ID 100: referenced descriptor not found`,
 			desc: descpb.TableDescriptor{
 				Name:                    "foo",
@@ -3415,7 +3588,7 @@ func TestValidateCrossTableReferences(t *testing.T) {
 				},
 			},
 		},
-		{ // 24
+		{ // 26
 			err: `depends-on function "f" (100) has no corresponding depended-on-by back reference`,
 			desc: descpb.TableDescriptor{
 				Name:                    "foo",
@@ -3437,7 +3610,7 @@ func TestValidateCrossTableReferences(t *testing.T) {
 				},
 			},
 		},
-		{ // 25
+		{ // 27
 			err: `depends-on function "f" (100) has no corresponding depended-on-by back reference`,
 			desc: descpb.TableDescriptor{
 				Name:                    "foo",

--- a/pkg/upgrade/upgrades/first_upgrade_test.go
+++ b/pkg/upgrade/upgrades/first_upgrade_test.go
@@ -184,7 +184,7 @@ func TestFirstUpgradeRepair(t *testing.T) {
 		tbl := tabledesc.NewBuilder(tbl.TableDesc()).BuildExistingMutableTable()
 		tbl.InboundFKs = []descpb.ForeignKeyConstraint{{
 			OriginTableID:       123456789,
-			OriginColumnIDs:     []descpb.ColumnID{1},
+			OriginColumnIDs:     tbl.PublicColumnIDs(), // Used such that len(OriginColumnIDs) == len(PublicColumnIDs)
 			ReferencedColumnIDs: tbl.PublicColumnIDs(),
 			ReferencedTableID:   tbl.GetID(),
 			Name:                "corrupt_fk",


### PR DESCRIPTION
**tabledesc: validate ForeignKey columns (781018a4e52e4f389b19f125ec22505ffbd64dda)**
Neither `OriginColumnIDs` nor `ReferencedColumnIDs` where being
validated by the tabledesc validation methods. This commit updates
tabledesc's self, forward references, and backwards references
validation to ensure that both columnID fields are well formed.

Specifically, we now validate that:
* All Columns actually exist
* Origin/Referenced TableID is correctly set the table containing the FK
* Both ColumnID fields have at least 1 element and are the same length

Additionally, this commit updated a few tests that began to fail due to
having an invalid table descriptor hard coded.

Epic: CRDB-30352
Informs: #108449
Release note: None
