### PR TITLE
release: update predecessor map for 22.2.14

### DIFF
--- a/pkg/testutils/release/cockroach_releases.yaml
+++ b/pkg/testutils/release/cockroach_releases.yaml
@@ -8,7 +8,7 @@
   - 22.1.19
   predecessor: "21.2"
 "22.2":
-  latest: 22.2.13
+  latest: 22.2.14
   withdrawn:
   - 22.2.4
   - 22.2.8


### PR DESCRIPTION
Epic: None
Release justification: normal release process
Release note: None