### PR TITLE
sql: prototype of fast-path insert uniqueness checks

### DIFF
--- a/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
@@ -1017,6 +1017,13 @@ func TestTenantLogic_insert(
 	runLogicTest(t, "insert")
 }
 
+func TestTenantLogic_insert_fast_path_unique_checks(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "insert_fast_path_unique_checks")
+}
+
 func TestTenantLogic_int_size(
 	t *testing.T,
 ) {

--- a/pkg/sql/distsql_spec_exec_factory.go
+++ b/pkg/sql/distsql_spec_exec_factory.go
@@ -975,6 +975,7 @@ func (e *distSQLSpecExecFactory) ConstructInsertFastPath(
 	returnCols exec.TableColumnOrdinalSet,
 	checkCols exec.CheckOrdinalSet,
 	fkChecks []exec.InsertFastPathFKCheck,
+	uniqChecks []exec.InsertFastPathFKCheck,
 	autoCommit bool,
 ) (exec.Node, error) {
 	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning: insert fast path")

--- a/pkg/sql/logictest/testdata/logic_test/insert_fast_path_unique_checks
+++ b/pkg/sql/logictest/testdata/logic_test/insert_fast_path_unique_checks
@@ -1,0 +1,54 @@
+statement ok
+SET experimental_enable_unique_without_index_constraints = true;
+
+statement ok
+CREATE TABLE t (
+  r STRING,
+  k INT,
+  a INT,
+  b STRING,
+  c STRING,
+  PRIMARY KEY (r, k),
+  CHECK (r IN ('east', 'west')),
+  UNIQUE (r, a),
+  UNIQUE WITHOUT INDEX (a),
+  UNIQUE (r, b, c),
+  UNIQUE WITHOUT INDEX (b, c),
+  FAMILY (r, k, a, b, c)
+)
+
+query T
+EXPLAIN
+INSERT INTO t VALUES ('east', 1, 10, 'b', 'c')
+----
+distribution: local
+vectorized: true
+·
+• insert fast path
+  into: t(r, k, a, b, c)
+  auto commit
+  size: 6 columns, 1 row
+
+
+query T kvtrace
+INSERT INTO t VALUES ('east', 1, 10, 'b', 'c')
+----
+CPut /Table/106/1/"east"/1/0 -> /TUPLE/3:3:Int/10/1:4:Bytes/b/1:5:Bytes/c
+InitPut /Table/106/2/"east"/10/0 -> /BYTES/0x89
+InitPut /Table/106/3/"east"/"b"/"c"/0 -> /BYTES/0x89
+Scan /Table/106/2/"east"/10/{0-1}
+Scan /Table/106/2/"west"/10/{0-1}
+Scan /Table/106/3/"east"/"b"/"c"/{0-1}
+Scan /Table/106/3/"west"/"b"/"c"/{0-1}
+
+statement error duplicate key value violates unique constraint "unique_a"\nDETAIL: Key \(a\)=\(10\) already exists\.
+INSERT INTO t VALUES ('west', 2, 10, 'c', 'd')
+
+statement ok
+INSERT INTO t VALUES ('west', 2, 20, 'bb', 'cc')
+
+statement error duplicate key value violates unique constraint "unique_b_c"\nDETAIL: Key \(b, c\)=\('b', 'c'\) already exists\.
+INSERT INTO t VALUES ('west', 3, 30, 'b', 'c')
+
+statement error duplicate key value violates unique constraint "unique_b_c"\nDETAIL: Key \(b, c\)=\('b', 'c'\) already exists\.
+INSERT INTO t VALUES ('east', 4, 40, 'b', 'c')

--- a/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
@@ -995,6 +995,13 @@ func TestLogic_insert(
 	runLogicTest(t, "insert")
 }
 
+func TestLogic_insert_fast_path_unique_checks(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "insert_fast_path_unique_checks")
+}
+
 func TestLogic_int_size(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
@@ -995,6 +995,13 @@ func TestLogic_insert(
 	runLogicTest(t, "insert")
 }
 
+func TestLogic_insert_fast_path_unique_checks(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "insert_fast_path_unique_checks")
+}
+
 func TestLogic_int_size(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist/generated_test.go
@@ -1002,6 +1002,13 @@ func TestLogic_insert(
 	runLogicTest(t, "insert")
 }
 
+func TestLogic_insert_fast_path_unique_checks(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "insert_fast_path_unique_checks")
+}
+
 func TestLogic_int_size(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
+++ b/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
@@ -981,6 +981,13 @@ func TestLogic_insert(
 	runLogicTest(t, "insert")
 }
 
+func TestLogic_insert_fast_path_unique_checks(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "insert_fast_path_unique_checks")
+}
+
 func TestLogic_int_size(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-mixed-22.2-23.1/generated_test.go
+++ b/pkg/sql/logictest/tests/local-mixed-22.2-23.1/generated_test.go
@@ -981,6 +981,13 @@ func TestLogic_insert(
 	runLogicTest(t, "insert")
 }
 
+func TestLogic_insert_fast_path_unique_checks(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "insert_fast_path_unique_checks")
+}
+
 func TestLogic_int_size(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/local-vec-off/generated_test.go
@@ -1009,6 +1009,13 @@ func TestLogic_insert(
 	runLogicTest(t, "insert")
 }
 
+func TestLogic_insert_fast_path_unique_checks(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "insert_fast_path_unique_checks")
+}
+
 func TestLogic_int_size(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local/generated_test.go
+++ b/pkg/sql/logictest/tests/local/generated_test.go
@@ -1093,6 +1093,13 @@ func TestLogic_insert(
 	runLogicTest(t, "insert")
 }
 
+func TestLogic_insert_fast_path_unique_checks(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "insert_fast_path_unique_checks")
+}
+
 func TestLogic_int_size(
 	t *testing.T,
 ) {

--- a/pkg/sql/opt/exec/execbuilder/BUILD.bazel
+++ b/pkg/sql/opt/exec/execbuilder/BUILD.bazel
@@ -26,6 +26,7 @@ go_library(
         "//pkg/sql/opt/distribution",
         "//pkg/sql/opt/exec",
         "//pkg/sql/opt/exec/explain",
+        "//pkg/sql/opt/lookupjoin",
         "//pkg/sql/opt/memo",
         "//pkg/sql/opt/norm",
         "//pkg/sql/opt/ordering",

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -256,9 +256,17 @@ type InsertFastPathFKCheck struct {
 	ReferencedTable cat.Table
 	ReferencedIndex cat.Index
 
+	// These are constant values for the prefix of the lookup with which the
+	// spans are generated from. The suffix values come from values in
+	// InsertCols.
+	// TODO(mgartner): Document this better.
+	PrefixValues []tree.Datums
+
 	// InsertCols contains the FK columns from the origin table, in the order of
 	// the ReferencedIndex columns. For each, the value in the array indicates the
 	// index of the column in the input table.
+	// TODO(mgartner): Should this be as long as the index key columns, or
+	// should it be len(keyCols)-len(PrefixValues)?
 	InsertCols []TableColumnOrdinal
 
 	MatchMethod tree.CompositeKeyMatchMethod

--- a/pkg/sql/opt/exec/factory.opt
+++ b/pkg/sql/opt/exec/factory.opt
@@ -475,6 +475,7 @@ define InsertFastPath {
     ReturnCols exec.TableColumnOrdinalSet
     CheckCols exec.CheckOrdinalSet
     FkChecks []exec.InsertFastPathFKCheck
+    UniqChecks []exec.InsertFastPathFKCheck
 
     # If set, the operator will commit the transaction as part of its execution.
     # This is false when executing inside an explicit transaction.

--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -227,6 +227,15 @@ func (mb *mutationBuilder) init(b *Builder, opName string, tab cat.Table, alias 
 
 	// Add the table and its columns (including mutation columns) to metadata.
 	mb.tabID = mb.md.AddTable(tab, &mb.alias)
+	tabMeta := mb.md.TableMeta(mb.tabID)
+
+	// We must add check constraints to the table metadata in order to generate
+	// unique checks for fast path inserts.
+	// TODO(mgartner): Do we need to add computed column expressions too? I'm
+	// not sure.
+	// TODO(mgartner): We should avoid unnecessary computation by only doing
+	// this when there are UNIQUE WITHOUT INDEX constraints on the table.
+	mb.b.addCheckConstraintsForTable(tabMeta)
 }
 
 // setFetchColIDs sets the list of columns that are fetched in order to provide

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -1408,6 +1408,7 @@ func (ef *execFactory) ConstructInsertFastPath(
 	returnColOrdSet exec.TableColumnOrdinalSet,
 	checkOrdSet exec.CheckOrdinalSet,
 	fkChecks []exec.InsertFastPathFKCheck,
+	uniqChecks []exec.InsertFastPathFKCheck,
 	autoCommit bool,
 ) (exec.Node, error) {
 	// Derive insert table and column descriptors.
@@ -1451,6 +1452,13 @@ func (ef *execFactory) ConstructInsertFastPath(
 		ins.run.fkChecks = make([]insertFastPathFKCheck, len(fkChecks))
 		for i := range fkChecks {
 			ins.run.fkChecks[i].InsertFastPathFKCheck = fkChecks[i]
+		}
+	}
+
+	if len(uniqChecks) > 0 {
+		ins.run.uniqChecks = make([]insertFastPathFKCheck, len(uniqChecks))
+		for i := range uniqChecks {
+			ins.run.uniqChecks[i].InsertFastPathFKCheck = uniqChecks[i]
 		}
 	}
 


### PR DESCRIPTION
#### execbuilder: refactor mkUniqueCheckErr

This will simplify its use in future commits.

Release note: None

#### sql: prototype of fast-path insert uniqueness checks

This prototype is an experiment to see if we can determine a suitable
lookup index for uniqueness checks during a fast-path insert, as opposed
to searching the existing checks defined as optimizer expressions to
find a suitable index (this is the current method used by FK checks).

The advantage of the method presented here is that we don't have to rely
on the shape of the optimizer expression in order to find a suitable
index, so we are free to apply any optimizations to the original
uniqueness checks (e.g., the inlining we perform is an example of an
existing optimization that makes finding a lookup index from the
optimizer expression difficult). We can only determine if a fast-path
insert is possible after exploration, so a major hurdle in relying on
the shape of the expression was that it was impossible to know whether
or not an optimization should be applied during normalization or
exploration when applying it would prevent the fast-path and not
applying it would make inserts that could never use the fast-path
slower.

Another hurdle in relying on the shape of the optimizer expression is
that multi-row inserts require special logic, different than single-row
inserts. I believe this method handles both cases without special logic.

The main focus of this commit are the changes in
`pkg/sql/opt/exec/execbuilder/mutation.go`. It appears to be possible to
determine a suitable lookup index without relying on the uniqueness
checks in the memo. I've left a bunch of TODOs where there needs to be a
bit more thought to make sure we're doing this correctly, but I believe
the core logic is all there.

The execution changes in `pkg/sql/insert_fast_path.go` and other files
are quick-and-dirty hacks that need more attention. I think there's a
fair amount of refactoring and renaming to be done to clean this up and
make it more readable.

A bunch of tests will need to be added as well.

Please review thoroughly and raise any problems you see with this
approach.

Release note: None
