### PR TITLE
release: do not bump version if already bumped

### DIFF
--- a/pkg/cmd/release/git.go
+++ b/pkg/cmd/release/git.go
@@ -274,3 +274,13 @@ func fileExistsInGit(branch string, f string) (bool, error) {
 	}
 	return true, nil
 }
+
+// fileContent uses `git cat-file -p ref:file` to get to the file contents without `git checkout`.
+func fileContent(ref string, f string) (string, error) {
+	cmd := exec.Command("git", "cat-file", "-p", ref+":"+f)
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("git cat-file: %w", err)
+	}
+	return string(out), nil
+}


### PR DESCRIPTION
Previously, if the version was bumped manually, the automation would try to bump, write the same content to the file and fail committing changes.

This PR skips version bump in case it was already bumped. Additionally, some of the commit messages were adjusted.

Fixes: RE-468
Release note: None