### PR TITLE
release-22.2: tree: fix formatting of SHOW BACKUP WITH OPTIONS

### DIFF
--- a/pkg/sql/parser/testdata/backup_restore
+++ b/pkg/sql/parser/testdata/backup_restore
@@ -105,10 +105,10 @@ SHOW BACKUP 'bar' -- identifiers removed
 parse
 SHOW BACKUP 'bar' WITH foo = 'bar'
 ----
-SHOW BACKUP 'bar' WITH foo = 'bar'
-SHOW BACKUP ('bar') WITH foo = ('bar') -- fully parenthesized
-SHOW BACKUP '_' WITH foo = '_' -- literals removed
-SHOW BACKUP 'bar' WITH _ = 'bar' -- identifiers removed
+SHOW BACKUP 'bar' WITH OPTIONS (foo = 'bar') -- normalized!
+SHOW BACKUP ('bar') WITH OPTIONS (foo = ('bar')) -- fully parenthesized
+SHOW BACKUP '_' WITH OPTIONS (foo = '_') -- literals removed
+SHOW BACKUP 'bar' WITH OPTIONS (_ = 'bar') -- identifiers removed
 
 parse
 EXPLAIN SHOW BACKUP 'bar'
@@ -137,10 +137,10 @@ SHOW BACKUP FILES 'bar' -- identifiers removed
 parse
 SHOW BACKUP FILES 'bar' WITH foo = 'bar'
 ----
-SHOW BACKUP FILES 'bar' WITH foo = 'bar'
-SHOW BACKUP FILES ('bar') WITH foo = ('bar') -- fully parenthesized
-SHOW BACKUP FILES '_' WITH foo = '_' -- literals removed
-SHOW BACKUP FILES 'bar' WITH _ = 'bar' -- identifiers removed
+SHOW BACKUP FILES 'bar' WITH OPTIONS (foo = 'bar') -- normalized!
+SHOW BACKUP FILES ('bar') WITH OPTIONS (foo = ('bar')) -- fully parenthesized
+SHOW BACKUP FILES '_' WITH OPTIONS (foo = '_') -- literals removed
+SHOW BACKUP FILES 'bar' WITH OPTIONS (_ = 'bar') -- identifiers removed
 
 parse
 SHOW BACKUP CONNECTION 'bar'
@@ -153,18 +153,18 @@ SHOW BACKUP CONNECTION 'bar' -- identifiers removed
 parse
 SHOW BACKUP CONNECTION 'bar' WITH TRANSFER = '1KiB', TIME = '1h'
 ----
-SHOW BACKUP CONNECTION 'bar' WITH transfer = '1KiB', "time" = '1h' -- normalized!
-SHOW BACKUP CONNECTION ('bar') WITH transfer = ('1KiB'), "time" = ('1h') -- fully parenthesized
-SHOW BACKUP CONNECTION '_' WITH transfer = '_', "time" = '_' -- literals removed
-SHOW BACKUP CONNECTION 'bar' WITH _ = '1KiB', _ = '1h' -- identifiers removed
+SHOW BACKUP CONNECTION 'bar' WITH OPTIONS (transfer = '1KiB', "time" = '1h') -- normalized!
+SHOW BACKUP CONNECTION ('bar') WITH OPTIONS (transfer = ('1KiB'), "time" = ('1h')) -- fully parenthesized
+SHOW BACKUP CONNECTION '_' WITH OPTIONS (transfer = '_', "time" = '_') -- literals removed
+SHOW BACKUP CONNECTION 'bar' WITH OPTIONS (_ = '1KiB', _ = '1h') -- identifiers removed
 
 parse
 SHOW BACKUP CONNECTION 'bar' WITH TRANSFER = $1, TIME = $2
 ----
-SHOW BACKUP CONNECTION 'bar' WITH transfer = $1, "time" = $2 -- normalized!
-SHOW BACKUP CONNECTION ('bar') WITH transfer = ($1), "time" = ($2) -- fully parenthesized
-SHOW BACKUP CONNECTION '_' WITH transfer = $1, "time" = $1 -- literals removed
-SHOW BACKUP CONNECTION 'bar' WITH _ = $1, _ = $2 -- identifiers removed
+SHOW BACKUP CONNECTION 'bar' WITH OPTIONS (transfer = $1, "time" = $2) -- normalized!
+SHOW BACKUP CONNECTION ('bar') WITH OPTIONS (transfer = ($1), "time" = ($2)) -- fully parenthesized
+SHOW BACKUP CONNECTION '_' WITH OPTIONS (transfer = $1, "time" = $1) -- literals removed
+SHOW BACKUP CONNECTION 'bar' WITH OPTIONS (_ = $1, _ = $2) -- identifiers removed
 
 parse
 SHOW BACKUPS IN 'bar'
@@ -193,10 +193,10 @@ SHOW BACKUP 'foo' IN 'bar' -- identifiers removed
 parse
 SHOW BACKUP FROM $1 IN $2 WITH foo = 'bar'
 ----
-SHOW BACKUP FROM $1 IN $2 WITH foo = 'bar'
-SHOW BACKUP FROM ($1) IN ($2) WITH foo = ('bar') -- fully parenthesized
-SHOW BACKUP FROM $1 IN $1 WITH foo = '_' -- literals removed
-SHOW BACKUP FROM $1 IN $2 WITH _ = 'bar' -- identifiers removed
+SHOW BACKUP FROM $1 IN $2 WITH OPTIONS (foo = 'bar') -- normalized!
+SHOW BACKUP FROM ($1) IN ($2) WITH OPTIONS (foo = ('bar')) -- fully parenthesized
+SHOW BACKUP FROM $1 IN $1 WITH OPTIONS (foo = '_') -- literals removed
+SHOW BACKUP FROM $1 IN $2 WITH OPTIONS (_ = 'bar') -- identifiers removed
 
 parse
 SHOW BACKUP FILES FROM 'foo' IN 'bar'
@@ -225,10 +225,10 @@ SHOW BACKUP SCHEMAS FROM 'foo' IN 'bar' -- identifiers removed
 parse
 SHOW BACKUP $1 IN $2 WITH foo = 'bar'
 ----
-SHOW BACKUP $1 IN $2 WITH foo = 'bar'
-SHOW BACKUP ($1) IN ($2) WITH foo = ('bar') -- fully parenthesized
-SHOW BACKUP $1 IN $1 WITH foo = '_' -- literals removed
-SHOW BACKUP $1 IN $2 WITH _ = 'bar' -- identifiers removed
+SHOW BACKUP $1 IN $2 WITH OPTIONS (foo = 'bar') -- normalized!
+SHOW BACKUP ($1) IN ($2) WITH OPTIONS (foo = ('bar')) -- fully parenthesized
+SHOW BACKUP $1 IN $1 WITH OPTIONS (foo = '_') -- literals removed
+SHOW BACKUP $1 IN $2 WITH OPTIONS (_ = 'bar') -- identifiers removed
 
 parse
 BACKUP TABLE foo TO 'bar' AS OF SYSTEM TIME '1' INCREMENTAL FROM 'baz'
@@ -951,3 +951,12 @@ DETAIL: source SQL:
 RESTORE ROLE foo, bar FROM 'baz'
              ^
 HINT: try \h RESTORE
+
+# Regression test for https://github.com/cockroachdb/cockroach/issues/110411.
+parse
+SHOW BACKUP CONNECTION 'bar' WITH OPTIONS (TIME = '1h')
+----
+SHOW BACKUP CONNECTION 'bar' WITH OPTIONS ("time" = '1h') -- normalized!
+SHOW BACKUP CONNECTION ('bar') WITH OPTIONS ("time" = ('1h')) -- fully parenthesized
+SHOW BACKUP CONNECTION '_' WITH OPTIONS ("time" = '_') -- literals removed
+SHOW BACKUP CONNECTION 'bar' WITH OPTIONS (_ = '1h') -- identifiers removed

--- a/pkg/sql/sem/tree/show.go
+++ b/pkg/sql/sem/tree/show.go
@@ -134,8 +134,9 @@ func (node *ShowBackup) Format(ctx *FmtCtx) {
 		ctx.FormatNode(&node.InCollection)
 	}
 	if len(node.Options) > 0 {
-		ctx.WriteString(" WITH ")
+		ctx.WriteString(" WITH OPTIONS (")
 		ctx.FormatNode(&node.Options)
+		ctx.WriteString(")")
 	}
 }
 


### PR DESCRIPTION
Backport 1/1 commits from #110580.

/cc @cockroachdb/release

---

This avoids an ambiguity when formatting the statement.

Release justification: low risk bug fix
fixes https://github.com/cockroachdb/cockroach/issues/110411
Release note: None
