### PR TITLE
release-22.2: roachtest: remove old executables before installing ruby

### DIFF
--- a/pkg/cmd/roachtest/tests/ruby_pg.go
+++ b/pkg/cmd/roachtest/tests/ruby_pg.go
@@ -86,6 +86,7 @@ func registerRubyPG(r registry.Registry) {
 			"install ruby 3.1.2",
 			`mkdir -p ruby-install && \
         curl -fsSL https://github.com/postmodern/ruby-install/archive/v0.8.3.tar.gz | tar --strip-components=1 -C ruby-install -xz && \
+        sudo rm -rf /usr/local/bin/* && \
         sudo make -C ruby-install install && \
         sudo ruby-install --system ruby 3.1.2 && \
         sudo gem update --system`,


### PR DESCRIPTION
Backport 1/1 commits from #100764.

/cc @cockroachdb/release

---

This backport was already applied to 23.x where it fixed a specific ruby installation flake, which has continued occurring on 22.2

Release note: None
Release justification: test-only change

Fixes: #108661 
Fixes: #109145 