### PR TITLE
release-22.2: export: add memory monitoring for EXPORT INTO PARQUET

### DIFF
--- a/pkg/sql/execinfra/server_config.go
+++ b/pkg/sql/execinfra/server_config.go
@@ -280,6 +280,9 @@ type TestingKnobs struct {
 	// Changefeed contains testing knobs specific to the changefeed system.
 	Changefeed base.ModuleTestingKnobs
 
+	// Export contains testing knobs for `EXPORT INTO ...`.
+	Export base.ModuleTestingKnobs
+
 	// Flowinfra contains testing knobs specific to the flowinfra system
 	Flowinfra base.ModuleTestingKnobs
 

--- a/pkg/sql/importer/BUILD.bazel
+++ b/pkg/sql/importer/BUILD.bazel
@@ -10,6 +10,7 @@ filegroup(
 go_library(
     name = "importer",
     srcs = [
+        "export_base.go",
         "exportcsv.go",
         "exportparquet.go",
         "import_job.go",
@@ -105,6 +106,7 @@ go_library(
         "//pkg/util/log",
         "//pkg/util/log/eventpb",
         "//pkg/util/log/logutil",
+        "//pkg/util/mon",
         "//pkg/util/protoutil",
         "//pkg/util/retry",
         "//pkg/util/syncutil",
@@ -227,6 +229,7 @@ go_test(
         "//pkg/util/leaktest",
         "//pkg/util/log",
         "//pkg/util/log/eventpb",
+        "//pkg/util/mon",
         "//pkg/util/protoutil",
         "//pkg/util/randutil",
         "//pkg/util/retry",

--- a/pkg/sql/importer/export_base.go
+++ b/pkg/sql/importer/export_base.go
@@ -1,0 +1,43 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package importer
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
+	"github.com/cockroachdb/errors"
+)
+
+// eventMemoryMultipier is the multiplier for the amount of memory needed to
+// export a datum. Datums may be encoded into bytes and is buffered until the
+// export file is written out. Since it's difficult to calculate the number of
+// bytes that will be created, we use this multiplier for estimation.
+var eventMemoryMultipier = settings.RegisterFloatSetting(
+	settings.TenantWritable,
+	"export.event_memory_multiplier",
+	"the amount of memory required to export a datum is multiplied by this factor",
+	3,
+	func(v float64) error {
+		if v < 1 {
+			return errors.New("value must be at least 1")
+		}
+		return nil
+	},
+)
+
+// ExportTestingKnobs contains testing knobs for Export.
+type ExportTestingKnobs struct {
+	// MemoryMonitor is a test memory monitor to report allocations to.
+	MemoryMonitor *mon.BytesMonitor
+}
+
+// ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.
+func (*ExportTestingKnobs) ModuleTestingKnobs() {}

--- a/pkg/sql/importer/exportparquet_test.go
+++ b/pkg/sql/importer/exportparquet_test.go
@@ -23,8 +23,10 @@ import (
 	_ "github.com/cockroachdb/cockroach/pkg/ccl"
 	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/importer"
 	"github.com/cockroachdb/cockroach/pkg/sql/randgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
@@ -36,6 +38,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	goparquet "github.com/fraugster/parquet-go"
 	"github.com/fraugster/parquet-go/parquet"
@@ -415,4 +418,43 @@ INDEX (y))`)
 		err := validateParquetFile(t, ctx, ie, test)
 		require.NoError(t, err, "failed to validate parquet file")
 	}
+}
+
+func TestMemoryMonitor(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	// Arrange for a small memory budget.
+	budget := int64(4096)
+	mm := mon.NewMonitorWithLimit(
+		"test-mm", mon.MemoryResource, budget,
+		nil, nil,
+		128 /* small allocation increment */, 100,
+		cluster.MakeTestingClusterSettings())
+	ctx := context.Background()
+	mm.Start(ctx, nil, mon.NewStandaloneBudget(budget))
+	defer mm.Stop(ctx)
+
+	dir, dirCleanupFn := testutils.TempDir(t)
+	defer dirCleanupFn()
+
+	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{
+		ExternalIODir: dir,
+		Knobs: base.TestingKnobs{
+			DistSQL: &execinfra.TestingKnobs{
+				Export: &importer.ExportTestingKnobs{
+					MemoryMonitor: mm,
+				},
+			},
+		},
+	})
+	cleanup := func() {
+		s.Stopper().Stop(ctx)
+	}
+	defer cleanup()
+
+	sqlDB := sqlutils.MakeSQLRunner(db)
+	sqlDB.Exec(t, `CREATE TABLE foo(key INT PRIMARY KEY DEFAULT unique_rowid(), val INT)`)
+	sqlDB.Exec(t, `INSERT INTO foo (val) SELECT * FROM generate_series(1, 100)`)
+	sqlDB.ExpectErr(t, "memory budget exceeded", `EXPORT INTO PARQUET 'nodelocal://1/foo' FROM SELECT * FROM foo`)
 }


### PR DESCRIPTION
Backport 1/1 commits from https://github.com/cockroachdb/cockroach/pull/105064

---

This change introduces a simple memory monitoring scheme for `EXPORT INTO PARQUET`. For each datum, we now request an allocation of 3 times the size of the datum from the parent memory monitor. Any failure to allocate this will return an error instead of OOMing the node.

This multiplication factor of 3 can be changed via the cluster setting export.event_memory_multiplier.

Informs: #103317
Epic: None
Release note (general change): This change prevents OOMs from happening when
executing the "EXPORT INTO PARQUET" statement. Now, if memory
is exceeded, the "EXPORT INTO PARQUET" statement will return
an error. If one sees an error releated to memory, they can
retry the export using a smaller `chunk_rows` (see https://www.cockroachlabs.com/docs/stable/export#export-options).
The docs can mention that `chunk_rows` can be used to manage
memory.

It's also worth noting that using changefeeds to export data
into parquet files is more preferable because they are more
resilient, efficient, and scalable than `EXPORT INTO`.

Release justification: Bug fix.
