### PR TITLE
release-22.2: upgrade: include schema in search_path upgrading sequences

### DIFF
--- a/pkg/upgrade/tenant_upgrade.go
+++ b/pkg/upgrade/tenant_upgrade.go
@@ -50,7 +50,7 @@ type TenantDeps struct {
 
 	TestingKnobs              *TestingKnobs
 	SchemaResolverConstructor func( // A constructor that returns a schema resolver for `descriptors` in `currDb`.
-		txn *kv.Txn, descriptors *descs.Collection, currDb string,
+		txn *kv.Txn, descriptors *descs.Collection, currDb string, schemaName string,
 	) (resolver.SchemaResolver, func(), error)
 }
 

--- a/pkg/upgrade/upgradejob/BUILD.bazel
+++ b/pkg/upgrade/upgradejob/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "//pkg/sql",
         "//pkg/sql/catalog/descs",
         "//pkg/sql/catalog/resolver",
+        "//pkg/sql/sem/eval",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",
         "//pkg/sql/sessiondatapb",

--- a/pkg/upgrade/upgrades/upgrade_sequence_to_be_referenced_by_ID_external_test.go
+++ b/pkg/upgrade/upgrades/upgrade_sequence_to_be_referenced_by_ID_external_test.go
@@ -66,61 +66,92 @@ func TestUpgradeSeqToBeReferencedByID(t *testing.T) {
 	tdb := sqlutils.MakeSQLRunner(sqlDB)
 
 	/*
-		The hex for the descriptor to inject was created by running the following
-		commands in a 20.2 binary, in which sequences are referenced by name in
-		tables and views.
+			The hex for the descriptor to inject was created by running the following
+			commands in a 20.2 binary, in which sequences are referenced by name in
+			tables and views.
 
-				CREATE SEQUENCE s;
-				CREATE TABLE tbl (i INT PRIMARY KEY, j INT NOT NULL DEFAULT nextval('s'));
-				CREATE VIEW v AS (SELECT nextval('s'));
-				CREATE TABLE tbl2 (i INT PRIMARY KEY, j INT NOT NULL); -- a table which does not need to be upgraded
+					CREATE SEQUENCE s;
+					CREATE TABLE tbl (i INT PRIMARY KEY, j INT NOT NULL DEFAULT nextval('s'));
+					CREATE VIEW v AS (SELECT nextval('s'));
+					CREATE TABLE tbl2 (i INT PRIMARY KEY, j INT NOT NULL); -- a table which does not need to be upgraded
+					CREATE DATABASE db1;
+					use db1;
+					CREATE SCHEMA schema1;
+					set search_path='schema1';
+					create sequence schema1.s2;
+					CREATE TABLE schema1.tbl3 (i INT PRIMARY KEY, j INT NOT NULL DEFAULT nextval('s2'));
 
-				SELECT encode(descriptor, 'hex')
-				FROM system.descriptor
-				WHERE id = (
-						SELECT id
-						FROM system.namespace
-						WHERE name = 's'
-				);
+					SELECT encode(descriptor, 'hex')
+					FROM system.descriptor
+					WHERE id = (
+							SELECT id
+							FROM system.namespace
+							WHERE name = 's'
+					);
 
-				SELECT encode(descriptor, 'hex')
-				FROM system.descriptor
-				WHERE id = (
-						SELECT id
-						FROM system.namespace
-						WHERE name = 'tbl'
-				);
+					SELECT encode(descriptor, 'hex')
+					FROM system.descriptor
+					WHERE id = (
+							SELECT id
+							FROM system.namespace
+							WHERE name = 'tbl'
+					);
 
-				SELECT encode(descriptor, 'hex')
-				FROM system.descriptor
-				WHERE id = (
-						SELECT id
-						FROM system.namespace
-						WHERE name = 'v'
-				);
+					SELECT encode(descriptor, 'hex')
+					FROM system.descriptor
+					WHERE id = (
+							SELECT id
+							FROM system.namespace
+							WHERE name = 'v'
+					);
 
-				SELECT encode(descriptor, 'hex')
-				FROM system.descriptor
-				WHERE id = (
-						SELECT id
-						FROM system.namespace
-						WHERE name = 'tbl2'
-				);
+					SELECT encode(descriptor, 'hex')
+					FROM system.descriptor
+					WHERE id = (
+							SELECT id
+							FROM system.namespace
+							WHERE name = 'tbl2'
+					);
+
+		       SELECT encode(descriptor, 'hex')
+						FROM system.descriptor
+						WHERE id = (
+								SELECT id
+								FROM system.namespace
+								WHERE name = 's2'
+						);
+
+		       SELECT encode(descriptor, 'hex')
+						FROM system.descriptor
+						WHERE id = (
+								SELECT id
+								FROM system.namespace
+								WHERE name = 'tbl3'
+						);
 	*/
 
 	var parentID, parentSchemaID descpb.ID
+	var otherParentID, othrParentSchemaID descpb.ID
 	tdb.Exec(t, "CREATE TABLE temp_tbl()")
 	tdb.QueryRow(t, `SELECT "parentID", "parentSchemaID" FROM system.namespace WHERE name = 'temp_tbl'`).
 		Scan(&parentID, &parentSchemaID)
 	var table, createTable string
+	tdb.Exec(t, "CREATE DATABASE db1")
+	tdb.Exec(t, "CREATE SCHEMA db1.schema1")
+	tdb.Exec(t, "CREATE TABLE db1.schema1.temp_tbl2()")
+	tdb.QueryRow(t, `SELECT "parentID", "parentSchemaID" FROM system.namespace WHERE name = 'temp_tbl2'`).
+		Scan(&otherParentID, &othrParentSchemaID)
+
 	const sequenceDescriptorToInject = "0aa0020a01731834203228033a0042210a0576616c756510011a0c080110401800300050146000200030006800700078004800524e0a077072696d61727910011800220576616c7565300140004a10080010001a00200028003000380040005a007a020800800100880100900100980100a20106080012001800a80100b20100ba010060006a1d0a090a0561646d696e10020a080a04726f6f7410021204726f6f741801800100880103980100b201160a077072696d61727910001a0576616c756520012801b80100c20100d20106083510001802d2010408361000e201180801100118ffffffffffffffff7f20012800320408001000e80100f2010408001200f801008002009202009a020a08c0f0f4deb8b4f4f816b20200b80200c0021dc80200"
 	const tableDescriptorToInject = "0a9e020a0374626c1835203228013a00421d0a016910011a0c0801104018003000501460002000300068007000780042360a016a10021a0c08011040180030005014600020002a156e65787476616c282773273a3a3a535452494e4729300050346800700078004803524a0a077072696d61727910011801220169300140004a10080010001a00200028003000380040005a007a020800800100880100900101980100a20106080012001800a80100b20100ba010060026a1d0a090a0561646d696e10020a080a04726f6f7410021204726f6f741801800101880103980100b201170a077072696d61727910001a01691a016a200120022802b80101c20100e80100f2010408001200f801008002009202009a0200b20200b80200c0021dc80200"
 	const viewDescriptorToInject = "0ae3010a01761836203228013a0042230a076e65787476616c10011a0c080110401800300050146000200130006800700078004802523c0a00100018004a10080010001a00200028003000380040005a007a020800800100880100900100980100a20106080012001800a80100b20100ba010060006a1d0a090a0561646d696e10020a080a04726f6f7410021204726f6f741801800101880103980100b80100c2011e2853454c454354206e65787476616c282773273a3a3a535452494e472929c80134e80100f2010408001200f801008002009202009a0200b20200b80200c0021dc80200"
 	const table2DescriptorToInject = "0a86020a0474626c32183e203428013a00421d0a016910011a0c08011040180030005014600020003000680070007800421d0a016a10021a0c080110401800300050146000200030006800700078004803524a0a077072696d61727910011801220169300140004a10080010001a00200028003000380040005a007a020800800100880100900101980100a20106080012001800a80100b20100ba010060026a1d0a090a0561646d696e10020a080a04726f6f7410021204726f6f741801800101880103980100b201170a077072696d61727910001a01691a016a200120022802b80101c20100e80100f2010408001200f801008002009202009a0200b20200b80200c0021dc80200"
+	const sequenceSc2DescriptorToInject = "0a9a020a027332183a203828023a0042210a0576616c756510011a0c080110401800300050146000200030006800700078004800524e0a077072696d61727910011800220576616c7565300140004a10080010001a00200028003000380040005a007a020800800100880100900100980100a20106080012001800a80100b20100ba010060006a1d0a090a0561646d696e10020a080a04726f6f7410021204726f6f741801800100880103980100b201160a077072696d61727910001a0576616c756520012801b80100c20100d20106083b10001802e201180801100118ffffffffffffffff7f20012800320408001000e80100f2010408001200f801008002009202009a020a08f0e881b9a8b1bbc217b20200b80200c00239c80200"
+	const table3DescriptorToInject = "0aa0020a0474626c33183b203828013a00421d0a016910011a0c0801104018003000501460002000300068007000780042370a016a10021a0c08011040180030005014600020002a166e65787476616c28277332273a3a3a535452494e47293000503a6800700078004803524a0a077072696d61727910011801220169300140004a10080010001a00200028003000380040005a007a020800800100880100900101980100a20106080012001800a80100b20100ba010060026a1d0a090a0561646d696e10020a080a04726f6f7410021204726f6f741801800101880103980100b201170a077072696d61727910001a01691a016a200120022802b80101c20100e80100f2010408001200f801008002009202009a0200b20200b80200c00239c80200"
 
 	// A function that decode a table descriptor from a hex-encoded string and
 	// insert it into the test cluster.
-	decodeTableDescriptorAndInsert := func(hexEncodedDescriptor string) {
+	decodeTableDescriptorAndInsert := func(hexEncodedDescriptor string, parentID, parentSchemaID descpb.ID) {
 		decodedDescriptor, err := hex.DecodeString(hexEncodedDescriptor)
 		require.NoError(t, err)
 		b, err := descbuilder.FromBytesAndMVCCTimestamp(decodedDescriptor, hlc.Timestamp{WallTime: 1})
@@ -153,12 +184,17 @@ func TestUpgradeSeqToBeReferencedByID(t *testing.T) {
 	// Decode and insert all descriptors, and assert by-name sequence reference in
 	// some descriptors.
 	for _, descHexCode := range []string{sequenceDescriptorToInject, tableDescriptorToInject, viewDescriptorToInject, table2DescriptorToInject} {
-		decodeTableDescriptorAndInsert(descHexCode)
+		decodeTableDescriptorAndInsert(descHexCode, parentID, parentSchemaID)
+	}
+	for _, descHexCode := range []string{sequenceSc2DescriptorToInject, table3DescriptorToInject} {
+		decodeTableDescriptorAndInsert(descHexCode, otherParentID, othrParentSchemaID)
 	}
 	tdb.QueryRow(t, `SHOW CREATE tbl`).Scan(&table, &createTable)
 	require.True(t, strings.Contains(createTable, "j INT8 NOT NULL DEFAULT nextval('s':::STRING)"))
 	tdb.QueryRow(t, `SHOW CREATE v`).Scan(&table, &createTable)
 	require.True(t, strings.Contains(createTable, "SELECT nextval('s':::STRING)"))
+	tdb.QueryRow(t, `SHOW CREATE db1.schema1.tbl3`).Scan(&table, &createTable)
+	require.True(t, strings.Contains(createTable, "j INT8 NOT NULL DEFAULT nextval('s2':::STRING)"))
 
 	tblOldVersion := queryDescVersion("tbl")
 	viewOldVersion := queryDescVersion("v")
@@ -175,6 +211,8 @@ func TestUpgradeSeqToBeReferencedByID(t *testing.T) {
 	require.True(t, strings.Contains(createTable, "j INT8 NOT NULL DEFAULT nextval('public.s'::REGCLASS)"))
 	tdb.QueryRow(t, `SHOW CREATE v`).Scan(&table, &createTable)
 	require.True(t, strings.Contains(createTable, "SELECT nextval('public.s'::REGCLASS)"))
+	tdb.QueryRow(t, `SHOW CREATE db1.schema1.tbl3`).Scan(&table, &createTable)
+	require.True(t, strings.Contains(createTable, "j INT8 NOT NULL DEFAULT nextval('db1.schema1.s2'::REGCLASS)"))
 
 	// Assert the upgrade logic also correctly skip descriptors that do not
 	// reference sequences by name by checking its versions.
@@ -184,4 +222,5 @@ func TestUpgradeSeqToBeReferencedByID(t *testing.T) {
 	require.Equal(t, tblOldVersion+1, tblNewVersion)
 	require.Equal(t, viewOldVersion+1, viewNewVersion)
 	require.Equal(t, tbl2OldVersion, tbl2NewVersion)
+
 }


### PR DESCRIPTION
Previously, we only searched the public and user schemas for the possibility of a sequence existing when upgrading the name to be by ID. We would store sequence names without fully qualified names, which meant they could be in any potential search_path. This patch attempts to improve the situation by including the current schema of a relation in the search path because these references are ambiguous. Unfortunately, it is still possible to have cases where this upgrade may break, so the logging for failure scenarios is also enhanced.

Fixes: #110655

Release note (bug fix): When upgrading from older releases, it was possible that ambiguous sequences references would fail to be resolved by ID if they were in the same schema. Additionally, the logging is improved for ambiguous cases where the reference cannot be resolved.

Release justification: low risk and reduces risk of needing manual intervention for upgrades