### PR TITLE
release-23.1: roachtest: mark pgjdbc and npgsql test as flaky

### DIFF
--- a/pkg/cmd/roachtest/tests/npgsql_blocklist.go
+++ b/pkg/cmd/roachtest/tests/npgsql_blocklist.go
@@ -751,6 +751,7 @@ var npgsqlBlocklist = blocklist{
 }
 
 var npgsqlIgnoreList = blocklist{
+	`Npgsql.Tests.CommandTests(Multiplexing).Cursor_move_RecordsAffected `:                                 "flaky",
 	`Npgsql.Tests.CommandTests(Multiplexing).QueryNonQuery`:                                                "flaky",
 	`Npgsql.Tests.CommandTests(Multiplexing).SingleNonQuery`:                                               "flaky",
 	`Npgsql.Tests.CommandTests(Multiplexing).Statement_mapped_output_parameters(Default)`:                  "flaky",
@@ -793,6 +794,7 @@ var npgsqlIgnoreList = blocklist{
 	`Npgsql.Tests.CopyTests(NonMultiplexing).Import_string_array`:                                          "flaky",
 	`Npgsql.Tests.CopyTests(NonMultiplexing).Import_string_with_buffer_length`:                             "flaky",
 	`Npgsql.Tests.CopyTests(NonMultiplexing).Prepended_messages`:                                           "flaky",
+	`Npgsql.Tests.CopyTests(NonMultiplexing).Text_import_empty`:                                            "flaky",
 	`Npgsql.Tests.CopyTests(NonMultiplexing).Undefined_table_throws`:                                       "flaky",
 	`Npgsql.Tests.CopyTests(NonMultiplexing).Write_column_out_of_bounds_throws`:                            "flaky",
 	`Npgsql.Tests.CopyTests(NonMultiplexing).Write_null_values`:                                            "flaky",

--- a/pkg/cmd/roachtest/tests/pgjdbc_blocklist.go
+++ b/pkg/cmd/roachtest/tests/pgjdbc_blocklist.go
@@ -927,6 +927,7 @@ var pgjdbcIgnoreList = blocklist{
 	"org.postgresql.test.jdbc2.BatchedInsertReWriteEnabledTest.testReWriteDisabledForPlainBatch[3: autoCommit=NO, binary=FORCE]":                    "54477",
 	"org.postgresql.test.jdbc2.CursorFetchTest.testBasicFetch[binary = FORCE]":                                                                      "flaky",
 	"org.postgresql.test.jdbc2.CursorFetchTest.testBasicFetch[binary = REGULAR]":                                                                    "flaky",
+	"org.postgresql.test.jdbc2.CursorFetchTest.testMultiRowResultPositioning[binary = FORCE]":                                                       "flaky",
 	"org.postgresql.test.jdbc2.DatabaseEncodingTest.testBadUTF8Decode":                                                                              "54477",
 	"org.postgresql.test.jdbc2.DatabaseEncodingTest.testTruncatedUTF8Decode":                                                                        "54477",
 	"org.postgresql.test.jdbc2.DatabaseEncodingTest.testUTF8Decode":                                                                                 "54477",


### PR DESCRIPTION
Backport 2/2 commits from #110668.

/cc @cockroachdb/release

---

Release justification: test only change
fixes https://github.com/cockroachdb/cockroach/issues/110306
fixes https://github.com/cockroachdb/cockroach/issues/109979
Release note: None
