### PR TITLE
release-23.1: kv, storage: fix handling of ambiguous failures on commit

### DIFF
--- a/pkg/ccl/storageccl/engineccl/bench_test.go
+++ b/pkg/ccl/storageccl/engineccl/bench_test.go
@@ -110,7 +110,7 @@ func loadTestData(
 		timestamp := hlc.Timestamp{WallTime: minWallTime + rand.Int63n(int64(batchTimeSpan))}
 		value := roachpb.MakeValueFromBytes(randutil.RandBytes(rng, valueBytes))
 		value.InitChecksum(key)
-		if err := storage.MVCCPut(ctx, batch, nil, key, timestamp, hlc.ClockTimestamp{}, value, nil); err != nil {
+		if err := storage.MVCCPut(ctx, batch, key, timestamp, value, storage.MVCCWriteOptions{}); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/ccl/storageccl/engineccl/encrypted_fs_test.go
+++ b/pkg/ccl/storageccl/engineccl/encrypted_fs_test.go
@@ -397,12 +397,10 @@ func TestPebbleEncryption2(t *testing.T) {
 		err = storage.MVCCPut(
 			context.Background(),
 			db,
-			nil, /* ms */
 			roachpb.Key(key),
 			hlc.Timestamp{},
-			hlc.ClockTimestamp{},
 			roachpb.MakeValueFromBytes([]byte(val)),
-			nil, /* txn */
+			storage.MVCCWriteOptions{},
 		)
 		require.NoError(t, err)
 		require.NoError(t, db.Flush())

--- a/pkg/kv/kvclient/kvcoord/BUILD.bazel
+++ b/pkg/kv/kvclient/kvcoord/BUILD.bazel
@@ -122,6 +122,7 @@ go_test(
     srcs = [
         "batch_test.go",
         "condensable_span_set_test.go",
+        "dist_sender_ambiguous_test.go",
         "dist_sender_rangefeed_canceler_test.go",
         "dist_sender_rangefeed_mock_test.go",
         "dist_sender_rangefeed_test.go",
@@ -185,6 +186,7 @@ go_test(
         "//pkg/security/securitytest",
         "//pkg/server",
         "//pkg/settings/cluster",
+        "//pkg/sql/catalog/bootstrap",
         "//pkg/sql/catalog/desctestutils",
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
@@ -203,6 +205,7 @@ go_test(
         "//pkg/util/caller",
         "//pkg/util/contextutil",
         "//pkg/util/ctxgroup",
+        "//pkg/util/encoding",
         "//pkg/util/errorutil",
         "//pkg/util/grpcutil",
         "//pkg/util/hlc",

--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -1166,7 +1166,7 @@ func (ds *DistSender) detectIntentMissingDueToIntentResolution(
 		// We weren't able to determine whether the intent missing error is
 		// due to intent resolution or not, so it is still ambiguous whether
 		// the commit succeeded.
-		return false, kvpb.NewAmbiguousResultErrorf("error=%s [intent missing]", pErr)
+		return false, kvpb.NewAmbiguousResultErrorf("error=%v [intent missing]", pErr)
 	}
 	resp := br.Responses[0].GetQueryTxn()
 	respTxn := &resp.QueriedTxn
@@ -1980,7 +1980,8 @@ func maybeSetResumeSpan(
 // the error that the last attempt to execute the request returned.
 func noMoreReplicasErr(ambiguousErr, lastAttemptErr error) error {
 	if ambiguousErr != nil {
-		return kvpb.NewAmbiguousResultErrorf("error=%s [exhausted]", ambiguousErr)
+		return kvpb.NewAmbiguousResultErrorf("error=%v [exhausted] (last error: %v)",
+			ambiguousErr, lastAttemptErr)
 	}
 
 	// TODO(bdarnell): The error from the last attempt is not necessarily the best
@@ -2158,6 +2159,28 @@ func (ds *DistSender) sendToReplicas(
 		ba = ba.ShallowCopy()
 		ba.Replica = curReplica
 		ba.RangeID = desc.RangeID
+
+		// When a sub-batch from a batch containing a commit experiences an
+		// ambiguous error, it is critical to ensure subsequent replay attempts
+		// do not permit changing the write timestamp, as the transaction may
+		// already have been considered implicitly committed.
+		ba.AmbiguousReplayProtection = ambiguousError != nil
+
+		// In the case that the batch has already seen an ambiguous error, in
+		// addition to enabling ambiguous replay protection, we also need to
+		// disable the ability for the server to forward the read timestamp, as
+		// the transaction may have been implicitly committed. If the intents for
+		// the implicitly committed transaction were already resolved, on a replay
+		// attempt encountering committed values above the read timestamp the
+		// server will attempt to handle what seems to be a write-write conflict by
+		// throwing a WriteTooOld, which could be refreshed away on the server if
+		// the read timestamp can be moved. Disabling this ability protects against
+		// refreshing away the error when retrying the ambiguous operation, instead
+		// returning to the DistSender so the ambiguous error can be propagated.
+		if ambiguousError != nil && ba.CanForwardReadTimestamp {
+			ba.CanForwardReadTimestamp = false
+		}
+
 		// Communicate to the server the information our cache has about the
 		// range. If it's stale, the serve will return an update.
 		ba.ClientRangeInfo = roachpb.ClientRangeInfo{
@@ -2183,10 +2206,13 @@ func (ds *DistSender) sendToReplicas(
 		ds.maybeIncrementErrCounters(br, err)
 
 		if err != nil {
+			log.VErrEventf(ctx, 2, "RPC error: %s", err)
+
 			if grpcutil.IsAuthError(err) {
 				// Authentication or authorization error. Propagate.
 				if ambiguousError != nil {
-					return nil, kvpb.NewAmbiguousResultErrorf("error=%s [propagate]", ambiguousError)
+					return nil, kvpb.NewAmbiguousResultErrorf("error=%v [propagate] (last error: %v)",
+						ambiguousError, err)
 				}
 				return nil, err
 			}
@@ -2208,10 +2234,6 @@ func (ds *DistSender) sendToReplicas(
 			// ambiguity.
 			// 2) SQL recognizes AmbiguousResultErrors and gives them a special code
 			// (StatementCompletionUnknown).
-			// TODO(andrei): The use of this code is inconsistent because a) the
-			// DistSender tries to only return the code for commits, but it'll happily
-			// forward along AmbiguousResultErrors coming from the replica and b) we
-			// probably should be returning that code for non-commit statements too.
 			//
 			// We retry requests in order to avoid returning errors (in particular,
 			// AmbiguousResultError). Retrying the batch will either:
@@ -2226,6 +2248,12 @@ func (ds *DistSender) sendToReplicas(
 			//    can't claim success (and even if we could claim success, we still
 			//    wouldn't have the complete result of the successful evaluation).
 			//
+			// Note that in case c), a request is not idempotent if the retry finds
+			// the request succeeded the first time around, but requires a change to
+			// the transaction's write timestamp. This is guarded against by setting
+			// the AmbiguousReplayProtection flag, so that the replay is aware the
+			// batch has seen an ambiguous error.
+			//
 			// Case a) is great - the retry made the request succeed. Case b) is also
 			// good; due to idempotency we managed to swallow a communication error.
 			// Case c) is not great - we'll end up returning an error even though the
@@ -2238,10 +2266,12 @@ func (ds *DistSender) sendToReplicas(
 			// evaluating twice, overwriting another unrelated write that fell
 			// in-between.
 			//
+			// NB: If this partial batch does not contain the EndTxn request but the
+			// batch contains a commit, the ambiguous error should be caught on
+			// retrying the writes, should it need to be propagated.
 			if withCommit && !grpcutil.RequestDidNotStart(err) {
 				ambiguousError = err
 			}
-			log.VErrEventf(ctx, 2, "RPC error: %s", err)
 
 			// If the error wasn't just a context cancellation and the down replica
 			// is cached as the lease holder, evict it. The only other eviction
@@ -2397,7 +2427,8 @@ func (ds *DistSender) sendToReplicas(
 				}
 			default:
 				if ambiguousError != nil {
-					return nil, kvpb.NewAmbiguousResultErrorf("error=%s [propagate]", ambiguousError)
+					return nil, kvpb.NewAmbiguousResultErrorf("error=%v [propagate] (last error: %v)",
+						ambiguousError, br.Error.GoError())
 				}
 
 				// The error received is likely not specific to this

--- a/pkg/kv/kvclient/kvcoord/dist_sender_ambiguous_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_ambiguous_test.go
@@ -1,0 +1,621 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package kvcoord_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/closedts"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/rpc/nodedialer"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/bootstrap"
+	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/cockroach/pkg/util/encoding"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+)
+
+type interceptedReq struct {
+	ba *kvpb.BatchRequest
+
+	fromNodeID  roachpb.NodeID
+	toNodeID    roachpb.NodeID
+	toReplicaID roachpb.ReplicaID
+	toRangeID   roachpb.RangeID
+	txnName     string
+	txnMeta     *enginepb.TxnMeta
+	prefix      string // for logging
+}
+
+func (req *interceptedReq) String() string {
+	return fmt.Sprintf("(%s) n%d->n%d:r%d/%d",
+		req.txnName, req.fromNodeID, req.toNodeID, req.toRangeID, req.toReplicaID,
+	)
+}
+
+type interceptedResp struct {
+	br  *kvpb.BatchResponse
+	err error
+}
+
+func (resp *interceptedResp) String() string {
+	if resp.err != nil || resp.br == nil {
+		return fmt.Sprintf("err: %s", resp.err)
+	}
+
+	if resp.br.Error != nil {
+		return fmt.Sprintf("br.Error: %s", resp.br.Error)
+	}
+
+	var output strings.Builder
+	for i, response := range resp.br.Responses {
+		if i > 0 {
+			fmt.Fprintf(&output, ",")
+		}
+		fmt.Fprintf(&output, "%s", response.GetInner())
+	}
+	return output.String()
+}
+
+// interceptingTransport is a gRPC transport wrapper than can be returned from a
+// kvcoord.TransportFactory that is passed in to the KVClient testing knobs in
+// order to block requests/responses and inject RPC failures. It is used as
+// the transport for kvpb.BatchRequest in the kvcoord.DistSender.
+type interceptingTransport struct {
+	kvcoord.Transport
+	nID roachpb.NodeID
+
+	// beforeSend defines an optional function called before sending a
+	// kvpb.BatchRequest on the underlying transport. If a non-nil response
+	// is returned, it will be returned to the caller without sending the request.
+	beforeSend func(context.Context, *interceptedReq) (overrideResp *interceptedResp)
+
+	// afterSend defines an optional function called after sending a
+	// kvpb.BatchRequest on the underlying tranport, passing in both the request
+	// and response (*kvpb.BatchResponse, error). If a non-nil response is
+	// returned, it will be returned to the caller instead of the real response.
+	afterSend func(context.Context, *interceptedReq, *interceptedResp) (overrideResp *interceptedResp)
+}
+
+// SendNext implements the kvcoord.Transport interface.
+func (t *interceptingTransport) SendNext(
+	ctx context.Context, ba *kvpb.BatchRequest,
+) (*kvpb.BatchResponse, error) {
+	txnName := "_"
+	var txnMeta *enginepb.TxnMeta
+	if ba.Txn != nil {
+		txnName = ba.Txn.Name
+		txnMeta = &ba.Txn.TxnMeta
+	}
+
+	req := &interceptedReq{
+		ba:          ba,
+		fromNodeID:  t.nID,
+		toNodeID:    t.NextReplica().NodeID,
+		toReplicaID: t.NextReplica().ReplicaID,
+		toRangeID:   ba.RangeID,
+		txnName:     txnName,
+		txnMeta:     txnMeta,
+	}
+
+	if t.beforeSend != nil {
+		overrideResp := t.beforeSend(ctx, req)
+		if overrideResp != nil {
+			return overrideResp.br, overrideResp.err
+		}
+	}
+
+	resp := &interceptedResp{}
+	resp.br, resp.err = t.Transport.SendNext(ctx, ba)
+
+	if t.afterSend != nil {
+		overrideResp := t.afterSend(ctx, req, resp)
+		if overrideResp != nil {
+			return overrideResp.br, overrideResp.err
+		}
+	}
+
+	return resp.br, resp.err
+}
+
+type InterceptPoint int
+
+const (
+	BeforeSending InterceptPoint = iota
+	AfterSending
+)
+
+// interceptorHelperMutex represents a convenience structure so that tests or
+// subtests using the interceptingTransport can organize the interception and
+// request/response sequencing logic alongside the logic of the test itself.
+// The override functions are locked with a RWMutex since the transport is used
+// for the entire lifetime of the test cluster, but the logic of the overridden
+// functions is particular to the test/subtest; this way the logic can be
+// modified after the test cluster has started.
+type interceptorHelperMutex struct {
+	syncutil.RWMutex
+
+	// filter defines a function that should return true for requests the test
+	// cares about - this includes logging, blocking, or overriding responses. All
+	// requests that return true should be logged.
+	filter func(req *interceptedReq) (isObservedReq bool)
+
+	// willPause defines a function that should return true for the requests that
+	// will block before or after sending. Intended for logging purposes only.
+	willPause func(req *interceptedReq) (willBlock bool)
+
+	// maybeWait defines a function within which the actual sequencing of requests
+	// and responses can occur, by blocking until conditions are met. If a non-nil
+	// error is returned, it will be returned to the DistSender, otherwise the
+	// BatchResponse/error from the underlying transport will be returned.
+	maybeWait func(cp InterceptPoint, req *interceptedReq, resp *interceptedResp) (override error)
+}
+
+// TestTransactionUnexpectedlyCommitted validates the handling of the case where
+// a parallel commit transaction with an ambiguous error on a write races with
+// a contending transaction's recovery attempt. In the case that the recovery
+// succeeds prior to the original transaction's retries, an ambiguous error
+// should be raised.
+//
+// NB: This case encounters a known issue described in #103817 and seen in
+// #67765, where it currently is surfaced as an assertion failure that will
+// result in a node crash.
+//
+// TODO(sarkesian): Validate the ambiguous result error once the initial fix as
+// outlined in #103817 has been resolved.
+func TestTransactionUnexpectedlyCommitted(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	// This test depends on an intricate sequencing of events that can take
+	// several seconds, and requires maintaining expected leases.
+	skip.UnderShort(t)
+	skip.UnderStressRace(t)
+
+	succeedsSoonDuration := testutils.DefaultSucceedsSoonDuration
+	if util.RaceEnabled {
+		succeedsSoonDuration = testutils.RaceSucceedsSoonDuration
+	}
+
+	// Key constants.
+	tablePrefix := bootstrap.TestingUserTableDataMin()
+	keyA := roachpb.Key(encoding.EncodeBytesAscending(tablePrefix.Clone(), []byte("a")))
+	keyB := roachpb.Key(encoding.EncodeBytesAscending(tablePrefix.Clone(), []byte("b")))
+
+	// Test synchronization helpers.
+	// Handles all synchronization of KV operations at the transport level.
+	var tMu interceptorHelperMutex
+	var interceptedOpID int64
+	getInterceptingTransportFactory := func(nID roachpb.NodeID) kvcoord.TransportFactory {
+		return func(options kvcoord.SendOptions, dialer *nodedialer.Dialer, slice kvcoord.ReplicaSlice) (kvcoord.Transport, error) {
+			transport, tErr := kvcoord.GRPCTransportFactory(options, dialer, slice)
+			interceptor := &interceptingTransport{
+				Transport: transport,
+				nID:       nID,
+				beforeSend: func(ctx context.Context, req *interceptedReq) (overrideResp *interceptedResp) {
+					tMu.RLock()
+					defer tMu.RUnlock()
+
+					if tMu.filter != nil && tMu.filter(req) {
+						opID := atomic.AddInt64(&interceptedOpID, 1)
+						if tMu.willPause != nil && tMu.willPause(req) {
+							req.prefix = fmt.Sprintf("[paused %d] ", opID)
+						}
+						t.Logf("%s%s batchReq={%s}, meta={%s}", req.prefix, req, req.ba, req.txnMeta)
+
+						if tMu.maybeWait != nil {
+							err := tMu.maybeWait(BeforeSending, req, nil)
+							if err != nil {
+								return &interceptedResp{err: err}
+							}
+						}
+					}
+
+					return nil
+				},
+				afterSend: func(ctx context.Context, req *interceptedReq, resp *interceptedResp) (overrideResp *interceptedResp) {
+					tMu.RLock()
+					defer tMu.RUnlock()
+
+					if tMu.filter != nil && tMu.filter(req) && tMu.maybeWait != nil {
+						err := tMu.maybeWait(AfterSending, req, resp)
+						if err != nil {
+							return &interceptedResp{err: err}
+						}
+					}
+
+					return nil
+				},
+			}
+			return interceptor, tErr
+		}
+	}
+
+	ctx := context.Background()
+	st := cluster.MakeTestingClusterSettings()
+
+	// Disable closed timestamps for control over when transaction gets bumped.
+	closedts.TargetDuration.Override(ctx, &st.SV, 1*time.Hour)
+
+	tc := testcluster.StartTestCluster(t, 3, base.TestClusterArgs{
+		ServerArgs: base.TestServerArgs{
+			Settings: st,
+			Insecure: true,
+		},
+		ServerArgsPerNode: map[int]base.TestServerArgs{
+			0: {
+				Settings: st,
+				Insecure: true,
+				Knobs: base.TestingKnobs{
+					KVClient: &kvcoord.ClientTestingKnobs{
+						TransportFactory: getInterceptingTransportFactory(roachpb.NodeID(1)),
+					},
+					Store: &kvserver.StoreTestingKnobs{
+						EvalKnobs: kvserverbase.BatchEvalTestingKnobs{
+							// NB: This setting is critical to the test, as it ensures that
+							// a push will kick off recovery.
+							RecoverIndeterminateCommitsOnFailedPushes: true,
+						},
+					},
+				},
+			},
+		},
+	})
+	defer tc.Stopper().Stop(ctx)
+
+	requireRangeLease := func(desc roachpb.RangeDescriptor, serverIdx int) {
+		t.Helper()
+		testutils.SucceedsSoon(t, func() error {
+			hint := tc.Target(serverIdx)
+			li, _, err := tc.FindRangeLeaseEx(ctx, desc, &hint)
+			if err != nil {
+				return errors.Wrapf(err, "could not find lease for %s", desc)
+			}
+			curLease := li.Current()
+			if curLease.Empty() {
+				return errors.Errorf("could not find lease for %s", desc)
+			}
+			expStoreID := tc.Target(serverIdx).StoreID
+			if !curLease.OwnedBy(expStoreID) {
+				return errors.Errorf("expected s%d to own the lease for %s\n"+
+					"actual lease info: %s",
+					expStoreID, desc, curLease)
+			}
+			if curLease.Speculative() {
+				return errors.Errorf("only had speculative lease for %s", desc)
+			}
+			if !kvserver.ExpirationLeasesOnly.Get(&tc.Server(0).ClusterSettings().SV) &&
+				curLease.Type() != roachpb.LeaseEpoch {
+				return errors.Errorf("awaiting upgrade to epoch-based lease for %s", desc)
+			}
+			t.Logf("valid lease info for r%d: %v", desc.RangeID, curLease)
+			return nil
+		})
+	}
+
+	getInBatch := func(ctx context.Context, txn *kv.Txn, keys ...roachpb.Key) []int64 {
+		batch := txn.NewBatch()
+		for _, key := range keys {
+			batch.GetForUpdate(key)
+		}
+		assert.NoError(t, txn.Run(ctx, batch))
+		assert.Len(t, batch.Results, len(keys))
+		vals := make([]int64, len(keys))
+		for i, result := range batch.Results {
+			assert.Len(t, result.Rows, 1)
+			vals[i] = result.Rows[0].ValueInt()
+		}
+		return vals
+	}
+
+	db := tc.Server(0).DB()
+
+	initTest := func() {
+		// Write initial values, split ranges, and separate leases.
+		require.NoError(t, db.Put(ctx, keyA, 50))
+		require.NoError(t, db.Put(ctx, keyB, 50))
+
+		tc.SplitRangeOrFatal(t, keyA)
+		firstRange, secondRange := tc.SplitRangeOrFatal(t, keyB)
+		t.Logf("first range: %s", firstRange)
+		t.Logf("second range: %s", secondRange)
+
+		// Separate the leases for each range so they are not on the same node.
+		tc.TransferRangeLeaseOrFatal(t, firstRange, tc.Target(0))
+		requireRangeLease(firstRange, 0)
+		tc.TransferRangeLeaseOrFatal(t, secondRange, tc.Target(1))
+		requireRangeLease(secondRange, 1)
+	}
+
+	finishTest := func() {
+		// Dump KVs at end of test for debugging purposes on failure.
+		if t.Failed() {
+			scannedKVs, err := db.Scan(ctx, tablePrefix, tablePrefix.PrefixEnd(), 0)
+			require.NoError(t, err)
+			for _, scannedKV := range scannedKVs {
+				mvccValue, err := storage.DecodeMVCCValue(scannedKV.Value.RawBytes)
+				require.NoError(t, err)
+				t.Logf("key: %s, value: %s", scannedKV.Key, mvccValue)
+			}
+		}
+	}
+
+	// Filtering and logging annotations for the request interceptor.
+	tMu.Lock()
+	tMu.filter = func(req *interceptedReq) bool {
+		// Log all requests on txn1 or txn2, except for heartbeats.
+		if (req.txnName == "txn1" || req.txnName == "txn2") && !req.ba.IsSingleHeartbeatTxnRequest() {
+			return true
+		}
+
+		// Log recovery on txn1's txn record key.
+		if req.ba.IsSingleRecoverTxnRequest() && keyA.Equal(req.ba.Requests[0].GetRecoverTxn().Txn.Key) {
+			return true
+		}
+
+		// Log pushes to txn1's txn record key.
+		if req.ba.IsSinglePushTxnRequest() && keyA.Equal(req.ba.Requests[0].GetPushTxn().PusheeTxn.Key) {
+			return true
+		}
+
+		return false
+	}
+	tMu.willPause = func(req *interceptedReq) bool {
+		_, hasPut := req.ba.GetArg(kvpb.Put)
+
+		// txn1's writes to n2 will be paused.
+		if req.txnName == "txn1" && hasPut && req.toNodeID == tc.Server(1).NodeID() {
+			return true
+		}
+
+		// txn1's retried EndTxn will be paused.
+		if req.txnName == "txn1" && req.ba.IsSingleEndTxnRequest() {
+			return true
+		}
+
+		// The recovery operation on txn1 needs to be sequenced specifically.
+		if req.ba.IsSingleRecoverTxnRequest() {
+			return true
+		}
+
+		return false
+	}
+	tMu.Unlock()
+
+	// Test contending implicit transactions with distributed writes and parallel
+	// commits with injected RPC failures. As this test was modeled after a
+	// real-world failure seen in the "bank" workload, this corresponds to the
+	// following SQL operation:
+	_ = `
+	UPDATE bank SET balance =
+		CASE id
+			WHEN $1 THEN balance - $3
+			WHEN $2 THEN balance + $3
+		END
+		WHERE id IN ($1, $2)`
+	const xferAmount = 10
+
+	initTest()
+	defer finishTest()
+
+	// Checkpoints in test.
+	txn1Ready := make(chan struct{})
+	txn2Ready := make(chan struct{})
+	leaseMoveReady := make(chan struct{})
+	leaseMoveComplete := make(chan struct{})
+	receivedETRetry := make(chan struct{})
+	recoverComplete := make(chan struct{})
+	txn1Done := make(chan struct{})
+
+	// Final result.
+	txn1ResultCh := make(chan error, 1)
+
+	// Concurrent transactions.
+	var wg sync.WaitGroup
+	wg.Add(3)
+	go func() {
+		defer wg.Done()
+		defer close(txn1Done)
+		// Wait until txn1 is ready to start.
+		select {
+		case <-txn1Ready:
+		case <-time.After(succeedsSoonDuration):
+			t.Logf("txn1 timed out before start")
+			return
+		}
+		tCtx := context.Background()
+		txn := db.NewTxn(tCtx, "txn1")
+		vals := getInBatch(tCtx, txn, keyA, keyB)
+
+		batch := txn.NewBatch()
+		batch.Put(keyA, vals[0]-xferAmount)
+		batch.Put(keyB, vals[1]+xferAmount)
+		txn1ResultCh <- txn.CommitInBatch(tCtx, batch)
+	}()
+	go func() {
+		defer wg.Done()
+		// Wait until txn2 is ready to start.
+		select {
+		case <-txn2Ready:
+		case <-time.After(succeedsSoonDuration):
+			t.Logf("txn2 timed out before start")
+			return
+		}
+		tCtx := context.Background()
+		txn := db.NewTxn(tCtx, "txn2")
+		vals := getInBatch(tCtx, txn, keyA, keyB)
+
+		batch := txn.NewBatch()
+		batch.Put(keyA, vals[0]-xferAmount)
+		batch.Put(keyB, vals[1]+xferAmount)
+		assert.NoError(t, txn.CommitInBatch(tCtx, batch))
+	}()
+	go func() {
+		defer wg.Done()
+		// Wait until lease move is ready.
+		select {
+		case <-leaseMoveReady:
+		case <-time.After(succeedsSoonDuration):
+			t.Logf("lease mover timed out before start")
+			return
+		}
+
+		desc, err := tc.LookupRange(keyB)
+		assert.NoError(t, err)
+		t.Logf("Transferring r%d lease to n%d", desc.RangeID, tc.Target(0).NodeID)
+		assert.NoError(t, tc.TransferRangeLease(desc, tc.Target(0)))
+
+		close(leaseMoveComplete)
+	}()
+
+	// KV Request sequencing.
+	tMu.Lock()
+	tMu.maybeWait = func(cp InterceptPoint, req *interceptedReq, resp *interceptedResp) (override error) {
+		_, hasPut := req.ba.GetArg(kvpb.Put)
+
+		// These conditions are checked in order of expected operations of the test.
+
+		// 1. txn1->n1: Get(a)
+		// 2. txn1->n2: Get(b)
+		// 3. txn1->n1: Put(a), EndTxn(parallel commit) -- Puts txn1 in STAGING.
+		// 4. txn1->n2: Put(b) -- Send the request, but pause before returning the
+		// response so we can inject network failure.
+		if req.txnName == "txn1" && hasPut && req.toNodeID == tc.Server(1).NodeID() && cp == AfterSending {
+			// Once we have seen the write on txn1 to n2 that we will fail, txn2 can
+			// start.
+			close(txn2Ready)
+		}
+
+		// 5. txn2->n1: Get(a) -- Discovers txn1's locks, issues push request.
+		// 6. txn2->n2: Get(b)
+		// 7. _->n1: PushTxn(txn2->txn1) -- Discovers txn1 in STAGING and starts
+		// recovery.
+		// 8. _->n1: RecoverTxn(txn1) -- Before sending, pause the request so we
+		// can ensure it gets evaluated after txn1 retries (and refreshes), but
+		// before its final EndTxn.
+		if req.ba.IsSingleRecoverTxnRequest() && cp == BeforeSending {
+			// Once the RecoverTxn request is issued, as part of txn2's PushTxn
+			// request, the lease can be moved.
+			close(leaseMoveReady)
+		}
+
+		// <transfer b's lease to n1>
+		// <inject a network failure and finally allow (4) txn1->n2: Put(b) to
+		// return with error>
+		if req.txnName == "txn1" && hasPut && req.toNodeID == tc.Server(1).NodeID() && cp == AfterSending {
+			// Hold the operation open until we are ready to retry on the new
+			// replica, after which we will return the injected failure.
+			<-leaseMoveComplete
+			t.Logf("%s%s Put op unpaused (injected RPC error)", req.prefix, req)
+			return grpcstatus.Errorf(codes.Unavailable, "response jammed on n%d<-n%d", req.fromNodeID, req.toNodeID)
+		}
+
+		// -- NB: If ambiguous errors were propagated, txn1 would end here.
+		// -- NB: When ambiguous errors are not propagated, txn1 continues with:
+		//
+		// 9. txn1->n1: Put(b) -- Retry on new leaseholder sees new lease start
+		// timestamp, and attempts to evaluate it as an idempotent replay, but at a
+		// higher timestamp, which breaks idempotency due to being on commit.
+		// 10. txn1->n1: Refresh(a)
+		// 11. txn1->n1: Refresh(b)
+		// Note that if these refreshes fail, the transaction coordinator
+		// would return a retriable error, although the transaction could be
+		// actually committed during recovery - this is highly problematic.
+
+		// 12. txn1->n1: EndTxn(commit) -- Before sending, pause the request so that
+		// we can allow (8) RecoverTxn(txn1) to proceed, simulating a race in which
+		// the recovery wins.
+		if req.txnName == "txn1" && req.ba.IsSingleEndTxnRequest() && cp == BeforeSending {
+			close(receivedETRetry)
+		}
+
+		// <allow (8) RecoverTxn(txn1) to proceed and finish> -- because txn1
+		// is in STAGING and has all of its writes, it is implicitly committed,
+		// so the recovery will succeed in marking it explicitly committed.
+		if req.ba.IsSingleRecoverTxnRequest() && cp == BeforeSending {
+			// The RecoverTxn operation must be evaluated after txn1's Refreshes,
+			// or after txn1 completes with error.
+			select {
+			case <-receivedETRetry:
+			case <-txn1Done:
+			}
+			t.Logf("%s%s RecoverTxn op unpaused", req.prefix, req)
+		}
+		if req.ba.IsSingleRecoverTxnRequest() && cp == AfterSending {
+			t.Logf("%s RecoverTxn op complete, resp={%s}", req, resp)
+			close(recoverComplete)
+		}
+
+		// <allow (12) EndTxn(commit) to proceed and execute> -- Results in
+		// "transaction unexpectedly committed" due to the recovery completing
+		// first.
+		if req.txnName == "txn1" && req.ba.IsSingleEndTxnRequest() && cp == BeforeSending {
+			<-recoverComplete
+			t.Logf("%s%s EndTxn op unpaused", req.prefix, req)
+		}
+
+		// <allow txn2's Puts to execute>
+		if req.txnName == "txn2" && hasPut && cp == BeforeSending {
+			// While txn2's Puts can only occur after txn1 is marked as explicitly
+			// committed, if the Recovery and the subsequent txn2 Put(b) operations
+			// happen before txn1 retries its Put(b) on n1, it will encounter txn2's
+			// intent and get a WriteTooOld error instead of potentially being an
+			// idempotent replay.
+			<-txn1Done
+		}
+
+		return nil
+	}
+	tMu.Unlock()
+
+	// Start test, await concurrent operations and validate results.
+	close(txn1Ready)
+	err := <-txn1ResultCh
+	t.Logf("txn1 completed with err: %+v", err)
+	wg.Wait()
+
+	// TODO(sarkesian): While we expect an AmbiguousResultError once the
+	// immediate changes outlined in #103817 are implemented, right now this is
+	// essentially validating the existence of the bug. This needs to be fixed,
+	// and we should not see an assertion failure from the transaction coordinator
+	// once fixed.
+	tErr := (*kvpb.TransactionStatusError)(nil)
+	require.ErrorAsf(t, err, &tErr,
+		"expected TransactionStatusError due to being already committed")
+	require.Equalf(t, kvpb.TransactionStatusError_REASON_TXN_COMMITTED, tErr.Reason,
+		"expected TransactionStatusError due to being already committed")
+	require.Truef(t, errors.HasAssertionFailure(err),
+		"expected AssertionFailedError due to sanity check on transaction already committed")
+}

--- a/pkg/kv/kvclient/kvcoord/dist_sender_ambiguous_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_ambiguous_test.go
@@ -60,9 +60,26 @@ type interceptedReq struct {
 }
 
 func (req *interceptedReq) String() string {
-	return fmt.Sprintf("(%s) n%d->n%d:r%d/%d",
-		req.txnName, req.fromNodeID, req.toNodeID, req.toRangeID, req.toReplicaID,
+	return fmt.Sprintf("%s(%s) n%d->n%d:r%d/%d",
+		req.prefix, req.txnName, req.fromNodeID, req.toNodeID, req.toRangeID, req.toReplicaID,
 	)
+}
+
+// pauseUntil blocks on untilCh, logging before and after.
+func (req *interceptedReq) pauseUntil(t *testing.T, untilCh chan struct{}, cp InterceptPoint) {
+	t.Logf("%s ‹%s› paused %s", req, req.ba.Summary(), cp)
+	<-untilCh
+	t.Logf("%s ‹%s› unpaused", req, req.ba.Summary())
+}
+
+// pauseUntil blocks until the first of c1/2 is ready, logging before and after.
+func (req *interceptedReq) pauseUntilFirst(t *testing.T, c1, c2 chan struct{}, cp InterceptPoint) {
+	t.Logf("%s ‹%s› paused %s", req, req.ba.Summary(), cp)
+	select {
+	case <-c1:
+	case <-c2:
+	}
+	t.Logf("%s ‹%s› unpaused", req, req.ba.Summary())
 }
 
 type interceptedResp struct {
@@ -157,6 +174,17 @@ const (
 	AfterSending
 )
 
+func (cp InterceptPoint) String() string {
+	switch cp {
+	case BeforeSending:
+		return "before send"
+	case AfterSending:
+		return "after send"
+	default:
+		panic(fmt.Sprintf("unknown InterceptPoint: %d", cp))
+	}
+}
+
 // interceptorHelperMutex represents a convenience structure so that tests or
 // subtests using the interceptingTransport can organize the interception and
 // request/response sequencing logic alongside the logic of the test itself.
@@ -166,21 +194,48 @@ const (
 // modified after the test cluster has started.
 type interceptorHelperMutex struct {
 	syncutil.RWMutex
+	interceptorTestConfig
+}
+
+// interceptorTestConfig is the inner shared state of interceptorHelperMutex.
+type interceptorTestConfig struct {
+	*testing.T
+
+	// lastInterceptedOpID is a counter that is to be incremented by each
+	// request r for which filter(r) returns true, for the purposes of debugging.
+	// Incremented atomically by concurrent operations holding the read lock.
+	lastInterceptedOpID int64
 
 	// filter defines a function that should return true for requests the test
 	// cares about - this includes logging, blocking, or overriding responses. All
 	// requests that return true should be logged.
 	filter func(req *interceptedReq) (isObservedReq bool)
 
-	// willPause defines a function that should return true for the requests that
-	// will block before or after sending. Intended for logging purposes only.
-	willPause func(req *interceptedReq) (willBlock bool)
-
 	// maybeWait defines a function within which the actual sequencing of requests
 	// and responses can occur, by blocking until conditions are met. If a non-nil
 	// error is returned, it will be returned to the DistSender, otherwise the
 	// BatchResponse/error from the underlying transport will be returned.
 	maybeWait func(cp InterceptPoint, req *interceptedReq, resp *interceptedResp) (override error)
+}
+
+// configureSubTest is a utility for the interceptorHelperMutex so that all
+// test logging and assertions performed by the interceptor can be tied to the
+// particular active subtest. Returns a function to restore the original
+// configuration on teardown.
+func (tMu *interceptorHelperMutex) configureSubTest(t *testing.T) (restore func()) {
+	tMu.Lock()
+	defer tMu.Unlock()
+
+	origConfig := tMu.interceptorTestConfig
+	restore = func() {
+		tMu.Lock()
+		defer tMu.Unlock()
+		tMu.interceptorTestConfig = origConfig
+	}
+
+	tMu.T = t
+	tMu.lastInterceptedOpID = 0
+	return restore
 }
 
 // TestTransactionUnexpectedlyCommitted validates the handling of the case where
@@ -211,13 +266,17 @@ func TestTransactionUnexpectedlyCommitted(t *testing.T) {
 
 	// Key constants.
 	tablePrefix := bootstrap.TestingUserTableDataMin()
+	tableSpan := roachpb.Span{Key: tablePrefix, EndKey: tablePrefix.PrefixEnd()}
 	keyA := roachpb.Key(encoding.EncodeBytesAscending(tablePrefix.Clone(), []byte("a")))
 	keyB := roachpb.Key(encoding.EncodeBytesAscending(tablePrefix.Clone(), []byte("b")))
 
 	// Test synchronization helpers.
 	// Handles all synchronization of KV operations at the transport level.
-	var tMu interceptorHelperMutex
-	var interceptedOpID int64
+	tMu := interceptorHelperMutex{
+		interceptorTestConfig: interceptorTestConfig{
+			T: t,
+		},
+	}
 	getInterceptingTransportFactory := func(nID roachpb.NodeID) kvcoord.TransportFactory {
 		return func(options kvcoord.SendOptions, dialer *nodedialer.Dialer, slice kvcoord.ReplicaSlice) (kvcoord.Transport, error) {
 			transport, tErr := kvcoord.GRPCTransportFactory(options, dialer, slice)
@@ -229,11 +288,9 @@ func TestTransactionUnexpectedlyCommitted(t *testing.T) {
 					defer tMu.RUnlock()
 
 					if tMu.filter != nil && tMu.filter(req) {
-						opID := atomic.AddInt64(&interceptedOpID, 1)
-						if tMu.willPause != nil && tMu.willPause(req) {
-							req.prefix = fmt.Sprintf("[paused %d] ", opID)
-						}
-						t.Logf("%s%s batchReq={%s}, meta={%s}", req.prefix, req, req.ba, req.txnMeta)
+						opID := atomic.AddInt64(&tMu.lastInterceptedOpID, 1)
+						req.prefix = fmt.Sprintf("[op %d] ", opID)
+						tMu.Logf("%s batchReq={%s}, meta={%s}", req, req.ba, req.txnMeta)
 
 						if tMu.maybeWait != nil {
 							err := tMu.maybeWait(BeforeSending, req, nil)
@@ -295,7 +352,7 @@ func TestTransactionUnexpectedlyCommitted(t *testing.T) {
 	})
 	defer tc.Stopper().Stop(ctx)
 
-	requireRangeLease := func(desc roachpb.RangeDescriptor, serverIdx int) {
+	requireRangeLease := func(t *testing.T, desc roachpb.RangeDescriptor, serverIdx int) {
 		t.Helper()
 		testutils.SucceedsSoon(t, func() error {
 			hint := tc.Target(serverIdx)
@@ -342,32 +399,40 @@ func TestTransactionUnexpectedlyCommitted(t *testing.T) {
 
 	db := tc.Server(0).DB()
 
-	initTest := func() {
-		// Write initial values, split ranges, and separate leases.
-		require.NoError(t, db.Put(ctx, keyA, 50))
-		require.NoError(t, db.Put(ctx, keyB, 50))
-
+	// Perform initial range split.
+	{
 		tc.SplitRangeOrFatal(t, keyA)
 		firstRange, secondRange := tc.SplitRangeOrFatal(t, keyB)
 		t.Logf("first range: %s", firstRange)
 		t.Logf("second range: %s", secondRange)
-
-		// Separate the leases for each range so they are not on the same node.
-		tc.TransferRangeLeaseOrFatal(t, firstRange, tc.Target(0))
-		requireRangeLease(firstRange, 0)
-		tc.TransferRangeLeaseOrFatal(t, secondRange, tc.Target(1))
-		requireRangeLease(secondRange, 1)
 	}
 
-	finishTest := func() {
-		// Dump KVs at end of test for debugging purposes on failure.
-		if t.Failed() {
-			scannedKVs, err := db.Scan(ctx, tablePrefix, tablePrefix.PrefixEnd(), 0)
-			require.NoError(t, err)
-			for _, scannedKV := range scannedKVs {
-				mvccValue, err := storage.DecodeMVCCValue(scannedKV.Value.RawBytes)
+	initSubTest := func(t *testing.T) (finishSubTest func()) {
+		restoreAfterSubTest := tMu.configureSubTest(t)
+
+		// Write initial values and separate leases.
+		require.NoError(t, db.Put(ctx, keyA, 50))
+		require.NoError(t, db.Put(ctx, keyB, 50))
+
+		firstRange := tc.LookupRangeOrFatal(t, keyA)
+		secondRange := tc.LookupRangeOrFatal(t, keyB)
+		tc.TransferRangeLeaseOrFatal(t, firstRange, tc.Target(0))
+		requireRangeLease(t, firstRange, 0)
+		tc.TransferRangeLeaseOrFatal(t, secondRange, tc.Target(1))
+		requireRangeLease(t, secondRange, 1)
+
+		return func() {
+			defer restoreAfterSubTest()
+
+			// Dump KVs at end of test for debugging purposes on failure.
+			if t.Failed() {
+				scannedKVs, err := db.Scan(ctx, tablePrefix, tablePrefix.PrefixEnd(), 0)
 				require.NoError(t, err)
-				t.Logf("key: %s, value: %s", scannedKV.Key, mvccValue)
+				for _, scannedKV := range scannedKVs {
+					mvccValue, err := storage.DecodeMVCCValue(scannedKV.Value.RawBytes)
+					require.NoError(t, err)
+					t.Logf("key: %s, value: %s", scannedKV.Key, mvccValue)
+				}
 			}
 		}
 	}
@@ -390,23 +455,8 @@ func TestTransactionUnexpectedlyCommitted(t *testing.T) {
 			return true
 		}
 
-		return false
-	}
-	tMu.willPause = func(req *interceptedReq) bool {
-		_, hasPut := req.ba.GetArg(kvpb.Put)
-
-		// txn1's writes to n2 will be paused.
-		if req.txnName == "txn1" && hasPut && req.toNodeID == tc.Server(1).NodeID() {
-			return true
-		}
-
-		// txn1's retried EndTxn will be paused.
-		if req.txnName == "txn1" && req.ba.IsSingleEndTxnRequest() {
-			return true
-		}
-
-		// The recovery operation on txn1 needs to be sequenced specifically.
-		if req.ba.IsSingleRecoverTxnRequest() {
+		// Log intent resolution on the key span used in the test.
+		if riReq, ok := req.ba.GetArg(kvpb.ResolveIntent); ok && tableSpan.ContainsKey(riReq.Header().Key) {
 			return true
 		}
 
@@ -427,68 +477,47 @@ func TestTransactionUnexpectedlyCommitted(t *testing.T) {
 		WHERE id IN ($1, $2)`
 	const xferAmount = 10
 
-	initTest()
-	defer finishTest()
-
-	// Checkpoints in test.
-	txn1Ready := make(chan struct{})
-	txn2Ready := make(chan struct{})
-	leaseMoveReady := make(chan struct{})
-	leaseMoveComplete := make(chan struct{})
-	receivedETRetry := make(chan struct{})
-	recoverComplete := make(chan struct{})
-	txn1Done := make(chan struct{})
-
-	// Final result.
-	txn1ResultCh := make(chan error, 1)
-
-	// Concurrent transactions.
-	var wg sync.WaitGroup
-	wg.Add(3)
-	go func() {
-		defer wg.Done()
-		defer close(txn1Done)
-		// Wait until txn1 is ready to start.
-		select {
-		case <-txn1Ready:
-		case <-time.After(succeedsSoonDuration):
-			t.Logf("txn1 timed out before start")
-			return
-		}
+	execWorkloadTxn := func(t *testing.T, name string) error {
 		tCtx := context.Background()
-		txn := db.NewTxn(tCtx, "txn1")
+		txn := db.NewTxn(tCtx, name)
 		vals := getInBatch(tCtx, txn, keyA, keyB)
 
 		batch := txn.NewBatch()
 		batch.Put(keyA, vals[0]-xferAmount)
 		batch.Put(keyB, vals[1]+xferAmount)
-		txn1ResultCh <- txn.CommitInBatch(tCtx, batch)
-	}()
-	go func() {
-		defer wg.Done()
-		// Wait until txn2 is ready to start.
+		return txn.CommitInBatch(tCtx, batch)
+	}
+
+	waitUntilReady := func(t *testing.T, name string, readyCh chan struct{}) (finishedWithoutTimeout bool) {
 		select {
-		case <-txn2Ready:
+		case <-readyCh:
 		case <-time.After(succeedsSoonDuration):
-			t.Logf("txn2 timed out before start")
+			t.Logf("%s timed out before start", name)
+			return false
+		}
+
+		return true
+	}
+
+	runTxn := func(t *testing.T, name string, wg *sync.WaitGroup, readyCh, doneCh chan struct{}, resultCh chan error) {
+		defer wg.Done()
+		if doneCh != nil {
+			defer close(doneCh)
+		}
+		if !waitUntilReady(t, name, readyCh) {
 			return
 		}
-		tCtx := context.Background()
-		txn := db.NewTxn(tCtx, "txn2")
-		vals := getInBatch(tCtx, txn, keyA, keyB)
+		err := execWorkloadTxn(t, name)
+		if resultCh != nil {
+			resultCh <- err
+		} else {
+			assert.NoError(t, err)
+		}
+	}
 
-		batch := txn.NewBatch()
-		batch.Put(keyA, vals[0]-xferAmount)
-		batch.Put(keyB, vals[1]+xferAmount)
-		assert.NoError(t, txn.CommitInBatch(tCtx, batch))
-	}()
-	go func() {
+	runLeaseMover := func(t *testing.T, wg *sync.WaitGroup, readyCh chan struct{}, doneCh chan struct{}) {
 		defer wg.Done()
-		// Wait until lease move is ready.
-		select {
-		case <-leaseMoveReady:
-		case <-time.After(succeedsSoonDuration):
-			t.Logf("lease mover timed out before start")
+		if !waitUntilReady(t, "lease mover", readyCh) {
 			return
 		}
 
@@ -497,125 +526,140 @@ func TestTransactionUnexpectedlyCommitted(t *testing.T) {
 		t.Logf("Transferring r%d lease to n%d", desc.RangeID, tc.Target(0).NodeID)
 		assert.NoError(t, tc.TransferRangeLease(desc, tc.Target(0)))
 
-		close(leaseMoveComplete)
-	}()
-
-	// KV Request sequencing.
-	tMu.Lock()
-	tMu.maybeWait = func(cp InterceptPoint, req *interceptedReq, resp *interceptedResp) (override error) {
-		_, hasPut := req.ba.GetArg(kvpb.Put)
-
-		// These conditions are checked in order of expected operations of the test.
-
-		// 1. txn1->n1: Get(a)
-		// 2. txn1->n2: Get(b)
-		// 3. txn1->n1: Put(a), EndTxn(parallel commit) -- Puts txn1 in STAGING.
-		// 4. txn1->n2: Put(b) -- Send the request, but pause before returning the
-		// response so we can inject network failure.
-		if req.txnName == "txn1" && hasPut && req.toNodeID == tc.Server(1).NodeID() && cp == AfterSending {
-			// Once we have seen the write on txn1 to n2 that we will fail, txn2 can
-			// start.
-			close(txn2Ready)
-		}
-
-		// 5. txn2->n1: Get(a) -- Discovers txn1's locks, issues push request.
-		// 6. txn2->n2: Get(b)
-		// 7. _->n1: PushTxn(txn2->txn1) -- Discovers txn1 in STAGING and starts
-		// recovery.
-		// 8. _->n1: RecoverTxn(txn1) -- Before sending, pause the request so we
-		// can ensure it gets evaluated after txn1 retries (and refreshes), but
-		// before its final EndTxn.
-		if req.ba.IsSingleRecoverTxnRequest() && cp == BeforeSending {
-			// Once the RecoverTxn request is issued, as part of txn2's PushTxn
-			// request, the lease can be moved.
-			close(leaseMoveReady)
-		}
-
-		// <transfer b's lease to n1>
-		// <inject a network failure and finally allow (4) txn1->n2: Put(b) to
-		// return with error>
-		if req.txnName == "txn1" && hasPut && req.toNodeID == tc.Server(1).NodeID() && cp == AfterSending {
-			// Hold the operation open until we are ready to retry on the new
-			// replica, after which we will return the injected failure.
-			<-leaseMoveComplete
-			t.Logf("%s%s Put op unpaused (injected RPC error)", req.prefix, req)
-			return grpcstatus.Errorf(codes.Unavailable, "response jammed on n%d<-n%d", req.fromNodeID, req.toNodeID)
-		}
-
-		// -- NB: If ambiguous errors were propagated, txn1 would end here.
-		// -- NB: When ambiguous errors are not propagated, txn1 continues with:
-		//
-		// 9. txn1->n1: Put(b) -- Retry on new leaseholder sees new lease start
-		// timestamp, and attempts to evaluate it as an idempotent replay, but at a
-		// higher timestamp, which breaks idempotency due to being on commit.
-		// 10. txn1->n1: Refresh(a)
-		// 11. txn1->n1: Refresh(b)
-		// Note that if these refreshes fail, the transaction coordinator
-		// would return a retriable error, although the transaction could be
-		// actually committed during recovery - this is highly problematic.
-
-		// 12. txn1->n1: EndTxn(commit) -- Before sending, pause the request so that
-		// we can allow (8) RecoverTxn(txn1) to proceed, simulating a race in which
-		// the recovery wins.
-		if req.txnName == "txn1" && req.ba.IsSingleEndTxnRequest() && cp == BeforeSending {
-			close(receivedETRetry)
-		}
-
-		// <allow (8) RecoverTxn(txn1) to proceed and finish> -- because txn1
-		// is in STAGING and has all of its writes, it is implicitly committed,
-		// so the recovery will succeed in marking it explicitly committed.
-		if req.ba.IsSingleRecoverTxnRequest() && cp == BeforeSending {
-			// The RecoverTxn operation must be evaluated after txn1's Refreshes,
-			// or after txn1 completes with error.
-			select {
-			case <-receivedETRetry:
-			case <-txn1Done:
-			}
-			t.Logf("%s%s RecoverTxn op unpaused", req.prefix, req)
-		}
-		if req.ba.IsSingleRecoverTxnRequest() && cp == AfterSending {
-			t.Logf("%s RecoverTxn op complete, resp={%s}", req, resp)
-			close(recoverComplete)
-		}
-
-		// <allow (12) EndTxn(commit) to proceed and execute> -- Results in
-		// "transaction unexpectedly committed" due to the recovery completing
-		// first.
-		if req.txnName == "txn1" && req.ba.IsSingleEndTxnRequest() && cp == BeforeSending {
-			<-recoverComplete
-			t.Logf("%s%s EndTxn op unpaused", req.prefix, req)
-		}
-
-		// <allow txn2's Puts to execute>
-		if req.txnName == "txn2" && hasPut && cp == BeforeSending {
-			// While txn2's Puts can only occur after txn1 is marked as explicitly
-			// committed, if the Recovery and the subsequent txn2 Put(b) operations
-			// happen before txn1 retries its Put(b) on n1, it will encounter txn2's
-			// intent and get a WriteTooOld error instead of potentially being an
-			// idempotent replay.
-			<-txn1Done
-		}
-
-		return nil
+		close(doneCh)
 	}
-	tMu.Unlock()
 
-	// Start test, await concurrent operations and validate results.
-	close(txn1Ready)
-	err := <-txn1ResultCh
-	t.Logf("txn1 completed with err: %+v", err)
-	wg.Wait()
+	t.Run("workload conflict", func(t *testing.T) {
+		defer initSubTest(t)()
 
-	// TODO(sarkesian): While we expect an AmbiguousResultError once the
-	// immediate changes outlined in #103817 are implemented, right now this is
-	// essentially validating the existence of the bug. This needs to be fixed,
-	// and we should not see an assertion failure from the transaction coordinator
-	// once fixed.
-	tErr := (*kvpb.TransactionStatusError)(nil)
-	require.ErrorAsf(t, err, &tErr,
-		"expected TransactionStatusError due to being already committed")
-	require.Equalf(t, kvpb.TransactionStatusError_REASON_TXN_COMMITTED, tErr.Reason,
-		"expected TransactionStatusError due to being already committed")
-	require.Truef(t, errors.HasAssertionFailure(err),
-		"expected AssertionFailedError due to sanity check on transaction already committed")
+		// Checkpoints in test.
+		txn1Ready := make(chan struct{})
+		txn2Ready := make(chan struct{})
+		leaseMoveReady := make(chan struct{})
+		leaseMoveComplete := make(chan struct{})
+		receivedFinalET := make(chan struct{})
+		recoverComplete := make(chan struct{})
+		txn1Done := make(chan struct{})
+
+		// Final result.
+		txn1ResultCh := make(chan error, 1)
+
+		// Concurrent transactions.
+		var wg sync.WaitGroup
+		wg.Add(3)
+		go runTxn(t, "txn1", &wg, txn1Ready, txn1Done, txn1ResultCh)
+		go runTxn(t, "txn2", &wg, txn2Ready, nil /* doneCh */, nil /* resultCh */)
+		go runLeaseMover(t, &wg, leaseMoveReady, leaseMoveComplete)
+
+		// KV Request sequencing.
+		tMu.Lock()
+		tMu.maybeWait = func(cp InterceptPoint, req *interceptedReq, resp *interceptedResp) (override error) {
+			_, hasPut := req.ba.GetArg(kvpb.Put)
+
+			// These conditions are checked in order of expected operations of the
+			// test.
+
+			// 1. txn1->n1: Get(a)
+			// 2. txn1->n2: Get(b)
+			// 3. txn1->n1: Put(a), EndTxn(parallel commit) -- Puts txn1 in STAGING.
+			// 4. txn1->n2: Put(b) -- Send the request, but pause before returning
+			// the response so we can inject network failure.
+			if req.txnName == "txn1" && hasPut && req.toNodeID == tc.Server(1).NodeID() && cp == AfterSending {
+				// Once we have seen the write on txn1 to n2 that we will fail, txn2
+				// can start.
+				close(txn2Ready)
+			}
+
+			// 5. txn2->n1: Get(a) -- Discovers txn1's locks, issues push request.
+			// 6. txn2->n2: Get(b)
+			// 7. _->n1: PushTxn(txn2->txn1) -- Discovers txn1 in STAGING and starts
+			// recovery.
+			// 8. _->n1: RecoverTxn(txn1) -- Before sending, pause the request so we
+			// can ensure it gets evaluated after txn1 retries (and refreshes), but
+			// before its final EndTxn.
+			if req.ba.IsSingleRecoverTxnRequest() && cp == BeforeSending {
+				// Once the RecoverTxn request is issued, as part of txn2's PushTxn
+				// request, the lease can be moved.
+				close(leaseMoveReady)
+			}
+
+			// <transfer b's lease to n1>
+			// <inject a network failure and finally allow (4) txn1->n2: Put(b) to
+			// return with error>
+			if req.txnName == "txn1" && hasPut && req.toNodeID == tc.Server(1).NodeID() && cp == AfterSending {
+				// Hold the operation open until we are ready to retry on the new
+				// replica, after which we will return the injected failure.
+				req.pauseUntil(t, leaseMoveComplete, cp)
+				t.Logf("%s - injected RPC error", req.prefix)
+				return grpcstatus.Errorf(codes.Unavailable, "response jammed on n%d<-n%d", req.fromNodeID, req.toNodeID)
+			}
+
+			// -- NB: If ambiguous errors were propagated, txn1 would end here.
+			// -- NB: When ambiguous errors are not propagated, txn1 continues with:
+			//
+			// 9. txn1->n1: Put(b) -- Retry on new leaseholder sees new lease start
+			// timestamp, and attempts to evaluate it as an idempotent replay, but at
+			// a higher timestamp, which breaks idempotency due to being on commit.
+			// 10. txn1->n1: Refresh(a)
+			// 11. txn1->n1: Refresh(b)
+			// 12. txn1->n1: EndTxn(commit) -- Before sending, pause the request so
+			// that we can allow (8) RecoverTxn(txn1) to proceed, simulating a race
+			// in which the recovery wins.
+			if req.txnName == "txn1" && req.ba.IsSingleEndTxnRequest() && cp == BeforeSending {
+				close(receivedFinalET)
+			}
+
+			// <allow (8) RecoverTxn(txn1) to proceed and finish> -- because txn1
+			// is in STAGING and has all of its writes, it is implicitly committed,
+			// so the recovery will succeed in marking it explicitly committed.
+			if req.ba.IsSingleRecoverTxnRequest() && cp == BeforeSending {
+				// The RecoverTxn operation is evaluated after txn1's Refreshes,
+				// or after txn1 completes with error.
+				req.pauseUntilFirst(t, receivedFinalET, txn1Done, cp)
+			}
+			if req.ba.IsSingleRecoverTxnRequest() && cp == AfterSending {
+				t.Logf("%s - complete, resp={%s}", req.prefix, resp)
+				close(recoverComplete)
+			}
+
+			// <allow (12) EndTxn(commit) to proceed and execute> -- Results in
+			// "transaction unexpectedly committed" due to the recovery completing
+			// first.
+			if req.txnName == "txn1" && req.ba.IsSingleEndTxnRequest() && cp == BeforeSending {
+				req.pauseUntil(t, recoverComplete, cp)
+			}
+
+			// <allow txn2's Puts to execute>
+			if req.txnName == "txn2" && hasPut && cp == BeforeSending {
+				// While txn2's Puts can only occur after txn1 is marked as explicitly
+				// committed, if the Recovery and the subsequent txn2 Put(b) operations
+				// happen before txn1 retries its Put(b) on n1, it will encounter txn2's
+				// intent and get a WriteTooOld error instead of potentially being an
+				// idempotent replay.
+				<-txn1Done
+			}
+
+			return nil
+		}
+		tMu.Unlock()
+
+		// Start test, await concurrent operations and validate results.
+		close(txn1Ready)
+		err := <-txn1ResultCh
+		t.Logf("txn1 completed with err: %+v", err)
+		wg.Wait()
+
+		// TODO(sarkesian): While we expect an AmbiguousResultError once the
+		// immediate changes outlined in #103817 are implemented, right now this is
+		// essentially validating the existence of the bug. This needs to be fixed,
+		// and we should not see an assertion failure from the transaction
+		// coordinator once fixed.
+		tErr := (*kvpb.TransactionStatusError)(nil)
+		require.ErrorAsf(t, err, &tErr,
+			"expected TransactionStatusError due to being already committed")
+		require.Equalf(t, kvpb.TransactionStatusError_REASON_TXN_COMMITTED, tErr.Reason,
+			"expected TransactionStatusError due to being already committed")
+		require.Truef(t, errors.HasAssertionFailure(err),
+			"expected AssertionFailedError due to sanity check on transaction already committed")
+	})
 }

--- a/pkg/kv/kvclient/kvcoord/dist_sender_ambiguous_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_ambiguous_test.go
@@ -382,7 +382,7 @@ func TestTransactionUnexpectedlyCommitted(t *testing.T) {
 		})
 	}
 
-	getInBatch := func(ctx context.Context, txn *kv.Txn, keys ...roachpb.Key) []int64 {
+	getInBatch := func(t *testing.T, ctx context.Context, txn *kv.Txn, keys ...roachpb.Key) []int64 {
 		batch := txn.NewBatch()
 		for _, key := range keys {
 			batch.GetForUpdate(key)
@@ -440,8 +440,8 @@ func TestTransactionUnexpectedlyCommitted(t *testing.T) {
 	// Filtering and logging annotations for the request interceptor.
 	tMu.Lock()
 	tMu.filter = func(req *interceptedReq) bool {
-		// Log all requests on txn1 or txn2, except for heartbeats.
-		if (req.txnName == "txn1" || req.txnName == "txn2") && !req.ba.IsSingleHeartbeatTxnRequest() {
+		// Log all requests on txn1/txn2/txn3, except for heartbeats.
+		if (req.txnName == "txn1" || req.txnName == "txn2" || req.txnName == "txn3") && !req.ba.IsSingleHeartbeatTxnRequest() {
 			return true
 		}
 
@@ -477,15 +477,25 @@ func TestTransactionUnexpectedlyCommitted(t *testing.T) {
 		WHERE id IN ($1, $2)`
 	const xferAmount = 10
 
+	type opFn func(t *testing.T, name string) error
+
 	execWorkloadTxn := func(t *testing.T, name string) error {
 		tCtx := context.Background()
 		txn := db.NewTxn(tCtx, name)
-		vals := getInBatch(tCtx, txn, keyA, keyB)
+		vals := getInBatch(t, tCtx, txn, keyA, keyB)
 
 		batch := txn.NewBatch()
 		batch.Put(keyA, vals[0]-xferAmount)
 		batch.Put(keyB, vals[1]+xferAmount)
 		return txn.CommitInBatch(tCtx, batch)
+	}
+
+	execLeaseMover := func(t *testing.T, name string) error {
+		desc, err := tc.LookupRange(keyB)
+		assert.NoError(t, err)
+		t.Logf("Transferring r%d lease to n%d", desc.RangeID, tc.Target(0).NodeID)
+		assert.NoError(t, tc.TransferRangeLease(desc, tc.Target(0)))
+		return nil
 	}
 
 	waitUntilReady := func(t *testing.T, name string, readyCh chan struct{}) (finishedWithoutTimeout bool) {
@@ -499,7 +509,7 @@ func TestTransactionUnexpectedlyCommitted(t *testing.T) {
 		return true
 	}
 
-	runTxn := func(t *testing.T, name string, wg *sync.WaitGroup, readyCh, doneCh chan struct{}, resultCh chan error) {
+	runConcurrentOp := func(t *testing.T, name string, execOp opFn, wg *sync.WaitGroup, readyCh, doneCh chan struct{}, resultCh chan error) {
 		defer wg.Done()
 		if doneCh != nil {
 			defer close(doneCh)
@@ -507,7 +517,7 @@ func TestTransactionUnexpectedlyCommitted(t *testing.T) {
 		if !waitUntilReady(t, name, readyCh) {
 			return
 		}
-		err := execWorkloadTxn(t, name)
+		err := execOp(t, name)
 		if resultCh != nil {
 			resultCh <- err
 		} else {
@@ -515,21 +525,8 @@ func TestTransactionUnexpectedlyCommitted(t *testing.T) {
 		}
 	}
 
-	runLeaseMover := func(t *testing.T, wg *sync.WaitGroup, readyCh chan struct{}, doneCh chan struct{}) {
-		defer wg.Done()
-		if !waitUntilReady(t, "lease mover", readyCh) {
-			return
-		}
-
-		desc, err := tc.LookupRange(keyB)
-		assert.NoError(t, err)
-		t.Logf("Transferring r%d lease to n%d", desc.RangeID, tc.Target(0).NodeID)
-		assert.NoError(t, tc.TransferRangeLease(desc, tc.Target(0)))
-
-		close(doneCh)
-	}
-
-	t.Run("workload conflict", func(t *testing.T) {
+	// The "basic" test case, allowing for multiple variants of txn2.
+	runBasicTestCase := func(t *testing.T, txn2Ops opFn, txn2PutsAfterTxn1 bool) {
 		defer initSubTest(t)()
 
 		// Checkpoints in test.
@@ -547,9 +544,9 @@ func TestTransactionUnexpectedlyCommitted(t *testing.T) {
 		// Concurrent transactions.
 		var wg sync.WaitGroup
 		wg.Add(3)
-		go runTxn(t, "txn1", &wg, txn1Ready, txn1Done, txn1ResultCh)
-		go runTxn(t, "txn2", &wg, txn2Ready, nil /* doneCh */, nil /* resultCh */)
-		go runLeaseMover(t, &wg, leaseMoveReady, leaseMoveComplete)
+		go runConcurrentOp(t, "txn1", execWorkloadTxn, &wg, txn1Ready, txn1Done, txn1ResultCh)
+		go runConcurrentOp(t, "txn2", txn2Ops, &wg, txn2Ready, nil /* doneCh */, nil /* resultCh */)
+		go runConcurrentOp(t, "lease mover", execLeaseMover, &wg, leaseMoveReady, leaseMoveComplete, nil /* resultCh */)
 
 		// KV Request sequencing.
 		tMu.Lock()
@@ -570,8 +567,8 @@ func TestTransactionUnexpectedlyCommitted(t *testing.T) {
 				close(txn2Ready)
 			}
 
-			// 5. txn2->n1: Get(a) -- Discovers txn1's locks, issues push request.
-			// 6. txn2->n2: Get(b)
+			// 5. txn2->n1: Get(a) OR Put(a) -- Discovers txn1's locks, issues push request.
+			// 6. txn2->n2: Get(b) OR Put(b)
 			// 7. _->n1: PushTxn(txn2->txn1) -- Discovers txn1 in STAGING and starts
 			// recovery.
 			// 8. _->n1: RecoverTxn(txn1) -- Before sending, pause the request so we
@@ -630,12 +627,940 @@ func TestTransactionUnexpectedlyCommitted(t *testing.T) {
 			}
 
 			// <allow txn2's Puts to execute>
+			if txn2PutsAfterTxn1 && req.txnName == "txn2" && hasPut && cp == BeforeSending {
+				// While txn2's Puts can only occur after txn1 is marked as explicitly
+				// committed, if the Recovery and the subsequent txn2 Put(b) operations
+				// happen before txn1 retries its Put(b) on n1, it will encounter txn2's
+				// intent and get a WriteTooOld error instead of potentially being an
+				// idempotent replay.
+				<-txn1Done
+			}
+
+			return nil
+		}
+		tMu.Unlock()
+
+		// Start test, await concurrent operations and validate results.
+		close(txn1Ready)
+		err := <-txn1ResultCh
+		t.Logf("txn1 completed with err: %+v", err)
+		wg.Wait()
+
+		// TODO(sarkesian): While we expect an AmbiguousResultError once the
+		// immediate changes outlined in #103817 are implemented, right now this is
+		// essentially validating the existence of the bug. This needs to be fixed,
+		// and we should not see an assertion failure from the transaction
+		// coordinator once fixed.
+		tErr := (*kvpb.TransactionStatusError)(nil)
+		require.ErrorAsf(t, err, &tErr,
+			"expected TransactionStatusError due to being already committed")
+		require.Equalf(t, kvpb.TransactionStatusError_REASON_TXN_COMMITTED, tErr.Reason,
+			"expected TransactionStatusError due to being already committed")
+		require.Truef(t, errors.HasAssertionFailure(err),
+			"expected AssertionFailedError due to sanity check on transaction already committed")
+	}
+
+	// The set of test cases that use the same request scheduling.
+	basicVariants := []struct {
+		name              string
+		txn2Ops           opFn
+		txn2PutsAfterTxn1 bool
+	}{
+		{
+			name: "writer reader conflict",
+			txn2Ops: func(t *testing.T, name string) error {
+				tCtx := context.Background()
+
+				// txn2 just performs a simple Get on a conflicting key, causing
+				// it to issue a PushTxn for txn1 which will kick off recovery.
+				txn := db.NewTxn(tCtx, name)
+				_, err := txn.Get(tCtx, keyA)
+				assert.NoError(t, err)
+				assert.NoError(t, txn.Commit(ctx))
+				return nil
+			},
+		},
+		{
+			name: "writer writer conflict",
+			txn2Ops: func(t *testing.T, name string) error {
+				tCtx := context.Background()
+
+				// txn2 performs simple Puts on conflicting keys, causing it to issue a
+				// PushTxn for txn1 which will kick off recovery.
+				txn := db.NewTxn(tCtx, name)
+				batch := txn.NewBatch()
+				batch.Put(keyA, 0)
+				batch.Put(keyB, 0)
+				assert.NoError(t, txn.CommitInBatch(ctx, batch))
+				t.Logf("txn2 finished here")
+				return nil
+			},
+		},
+		{
+			name:              "workload conflict",
+			txn2Ops:           execWorkloadTxn,
+			txn2PutsAfterTxn1: true,
+		},
+	}
+
+	for _, variant := range basicVariants {
+		t.Run(variant.name, func(t *testing.T) {
+			runBasicTestCase(t, variant.txn2Ops, variant.txn2PutsAfterTxn1)
+		})
+	}
+
+	// Test cases with custom request scheduling.
+
+	// The txn coordinator shouldn't respond with an incorrect retryable failure
+	// based on a refresh as the transaction may have already been committed.
+	t.Run("recovery before refresh fails", func(t *testing.T) {
+		keyAPrime := roachpb.Key(encoding.EncodeBytesAscending(tablePrefix.Clone(), []byte("a'")))
+		defer func() {
+			_, err := db.Del(ctx, keyAPrime)
+			require.NoError(t, err)
+		}()
+
+		defer initSubTest(t)()
+
+		// Checkpoints in test.
+		txn1Ready := make(chan struct{})
+		txn2Ready := make(chan struct{})
+		leaseMoveReady := make(chan struct{})
+		leaseMoveComplete := make(chan struct{})
+		txn1Done := make(chan struct{})
+
+		// Final result.
+		txn1ResultCh := make(chan error, 1)
+
+		// Operation functions.
+		execTxn1 := func(t *testing.T, name string) error {
+			tCtx := context.Background()
+			txn := db.NewTxn(tCtx, name)
+			vals := getInBatch(t, tCtx, txn, keyA, keyB, keyAPrime)
+
+			batch := txn.NewBatch()
+			batch.Put(keyA, vals[0]-xferAmount)
+			batch.Put(keyB, vals[1]+xferAmount)
+			return txn.CommitInBatch(tCtx, batch)
+		}
+		execTxn2 := func(t *testing.T, name string) error {
+			tCtx := context.Background()
+			txn := db.NewTxn(tCtx, name)
+
+			// The intent from txn2 on a' will cause txn1's read refresh to fail.
+			assert.NoError(t, txn.Put(tCtx, keyAPrime, 100))
+			_ = getInBatch(t, tCtx, txn, keyA)
+			assert.NoError(t, txn.Commit(tCtx))
+			return nil
+		}
+
+		// Concurrent transactions.
+		var wg sync.WaitGroup
+		wg.Add(3)
+		go runConcurrentOp(t, "txn1", execTxn1, &wg, txn1Ready, txn1Done, txn1ResultCh)
+		go runConcurrentOp(t, "txn2", execTxn2, &wg, txn2Ready, nil /* doneCh */, nil /* resultCh */)
+		go runConcurrentOp(t, "lease mover", execLeaseMover, &wg, leaseMoveReady, leaseMoveComplete, nil /* resultCh */)
+
+		// KV Request sequencing.
+		tMu.Lock()
+		tMu.maybeWait = func(cp InterceptPoint, req *interceptedReq, resp *interceptedResp) (override error) {
+			_, hasPut := req.ba.GetArg(kvpb.Put)
+
+			// These conditions are checked in order of expected operations of the
+			// test.
+
+			// 1. txn1->n1: Get(a)
+			// 2. txn1->n2: Get(b)
+			// 3. txn1->n1: Put(a), EndTxn(parallel commit) -- Puts txn1 in STAGING.
+			// 4. txn1->n2: Put(b) -- Send the request, but pause before returning
+			// the response so we can inject network failure.
+			if req.txnName == "txn1" && hasPut && req.toNodeID == tc.Server(1).NodeID() && cp == AfterSending {
+				// Once we have seen the write on txn1 to n2 that we will fail, we can
+				// move the lease.
+				close(txn2Ready)
+			}
+
+			// 5. txn2->n1: Put(a')
+			// 6. txn2->n1: Get(a) -- Discovers txn1's locks, issues push request.
+			// 7. _->n1: PushTxn(txn2->txn1) -- Discovers txn1 in STAGING and starts
+			// recovery.
+			// 8. _->n1: RecoverTxn(txn1) -- Allow to proceed and finish. Since txn1
+			// is in STAGING and has all of its writes, it is implicitly committed,
+			// so the recovery will succeed in marking it explicitly committed.
+			if req.ba.IsSingleRecoverTxnRequest() && cp == AfterSending {
+				t.Logf("%s - complete, resp={%s}", req.prefix, resp)
+				close(leaseMoveReady)
+			}
+
+			// <transfer b's lease to n1>
+			// <inject a network failure and finally allow (4) txn1->n2: Put(b) to
+			// return with error>
+			if req.txnName == "txn1" && hasPut && req.toNodeID == tc.Server(1).NodeID() && cp == AfterSending {
+				// Hold the operation open until we are ready to retry on the new
+				// replica, after which we will return the injected failure.
+				req.pauseUntil(t, leaseMoveComplete, cp)
+				t.Logf("%s - injected RPC error", req.prefix)
+				return grpcstatus.Errorf(codes.Unavailable, "response jammed on n%d<-n%d", req.fromNodeID, req.toNodeID)
+			}
+
+			// -- NB: If ambiguous errors were propagated, txn1 would end here.
+			// -- NB: When ambiguous errors are not propagated, txn1 continues with:
+			//
+			// 9. txn1->n1: Put(b) -- Retry on new leaseholder sees new lease start
+			// timestamp, and attempts to evaluate it as an idempotent replay, but at
+			// a higher timestamp, which breaks idempotency due to being on commit.
+			// 10. txn1->n1: Refresh(a)
+			// 11. txn1->n1: Refresh(b,c) -- This fails due to txn2's intent on c.
+			// Causes the transaction coordinator to return a retriable error,
+			// although the transaction has been actually committed during recovery;
+			// a highly problematic bug.
+
+			// <Only allow txn2's successful push to return once txn1 has finished>
+			// This way we can prevent txn1's intents from being resolved too early.
+			if _, ok := req.ba.GetArg(kvpb.PushTxn); ok && cp == AfterSending &&
+				resp != nil && resp.err == nil {
+				req.pauseUntil(t, txn1Done, cp)
+			}
+
+			return nil
+		}
+		tMu.Unlock()
+
+		// Start test, await concurrent operations and validate results.
+		close(txn1Ready)
+		err := <-txn1ResultCh
+		t.Logf("txn1 completed with err: %+v", err)
+		wg.Wait()
+
+		// TODO(sarkesian): While we expect an AmbiguousResultError once the
+		// immediate changes outlined in #103817 are implemented, right now this is
+		// essentially validating the existence of the bug. This needs to be fixed,
+		// and we should not see an transaction retry error from the transaction
+		// coordinator once fixed.
+		tErr := (*kvpb.TransactionRetryWithProtoRefreshError)(nil)
+		require.ErrorAsf(t, err, &tErr,
+			"expected incorrect TransactionRetryWithProtoRefreshError due to failed refresh")
+		require.False(t, tErr.PrevTxnAborted())
+		require.Falsef(t, errors.HasAssertionFailure(err),
+			"expected no AssertionFailedError due to sanity check")
+	})
+
+	// The txn coordinator shouldn't respond with an incorrect retryable failure
+	// based on a refresh as the transaction may yet be recovered/committed.
+	t.Run("recovery after refresh fails", func(t *testing.T) {
+		keyC := roachpb.Key(encoding.EncodeBytesAscending(tablePrefix.Clone(), []byte("c")))
+		defer func() {
+			_, err := db.Del(ctx, keyC)
+			require.NoError(t, err)
+		}()
+
+		defer initSubTest(t)()
+
+		// Checkpoints in test.
+		txn1Ready := make(chan struct{})
+		otherTxnsReady := make(chan struct{})
+		leaseMoveReady := make(chan struct{})
+		leaseMoveComplete := make(chan struct{})
+		recoverComplete := make(chan struct{})
+		txn1Done := make(chan struct{})
+
+		// Final result.
+		txn1ResultCh := make(chan error, 1)
+
+		execTxn1 := func(t *testing.T, name string) error {
+			tCtx := context.Background()
+			txn := db.NewTxn(tCtx, name)
+			vals := getInBatch(t, tCtx, txn, keyA, keyB, keyC)
+
+			batch := txn.NewBatch()
+			batch.Put(keyA, vals[0]-xferAmount)
+			batch.Put(keyB, vals[1]+xferAmount)
+			return txn.CommitInBatch(tCtx, batch)
+		}
+		execOtherTxns := func(t *testing.T, name string) error {
+			tCtx := context.Background()
+
+			// The intent from txn3 will cause txn1's read refresh to fail.
+			txn3 := db.NewTxn(tCtx, "txn3")
+			batch := txn3.NewBatch()
+			batch.Put(keyC, 100)
+			assert.NoError(t, txn3.CommitInBatch(tCtx, batch))
+
+			txn2 := db.NewTxn(tCtx, "txn2")
+			vals := getInBatch(t, tCtx, txn2, keyA, keyB)
+
+			batch = txn2.NewBatch()
+			batch.Put(keyA, vals[0]-xferAmount)
+			batch.Put(keyB, vals[1]+xferAmount)
+			assert.NoError(t, txn2.CommitInBatch(tCtx, batch))
+			return nil
+		}
+
+		// Concurrent transactions.
+		var wg sync.WaitGroup
+		wg.Add(3)
+		go runConcurrentOp(t, "txn1", execTxn1, &wg, txn1Ready, txn1Done, txn1ResultCh)
+		go runConcurrentOp(t, "txn2/txn3", execOtherTxns, &wg, otherTxnsReady, nil /* doneCh */, nil /* resultCh */)
+		go runConcurrentOp(t, "lease mover", execLeaseMover, &wg, leaseMoveReady, leaseMoveComplete, nil /* resultCh */)
+
+		// KV Request sequencing.
+		tMu.Lock()
+		tMu.maybeWait = func(cp InterceptPoint, req *interceptedReq, resp *interceptedResp) (override error) {
+			_, hasPut := req.ba.GetArg(kvpb.Put)
+
+			// These conditions are checked in order of expected operations of the
+			// test.
+
+			// 1. txn1->n1: Get(a)
+			// 2. txn1->n2: Get(b), Get(c)
+			// 3. txn1->n1: Put(a), EndTxn(parallel commit) -- Puts txn1 in STAGING.
+			// 4. txn1->n2: Put(b) -- Send the request, but pause before returning the
+			// response so we can inject network failure.
+			if req.txnName == "txn1" && hasPut && req.toNodeID == tc.Server(1).NodeID() && cp == AfterSending {
+				// Once we have seen the write on txn1 to n2 that we will fail, txn2/txn3 can start.
+				close(otherTxnsReady)
+			}
+
+			// 5. txn3->n2: Put(c), EndTxn(parallel commit) -- Hits 1PC fast path.
+			// 6. txn2->n1: Get(a) -- Discovers txn1's locks, issues push request.
+			// 7. txn2->n2: Get(b)
+			// 8. _->n1: PushTxn(txn2->txn1) -- Discovers txn1 in STAGING and starts
+			// recovery.
+			// 9. _->n1: RecoverTxn(txn1) -- Before sending, pause the request so we
+			// can ensure it gets evaluated after txn1 retries (and refreshes), but
+			// before its final EndTxn.
+			if req.ba.IsSingleRecoverTxnRequest() && cp == BeforeSending {
+				// Once the RecoverTxn request is issued, as part of txn2's PushTxn
+				// request, the lease can be moved.
+				close(leaseMoveReady)
+			}
+
+			// <transfer b's lease to n1>
+			// <inject a network failure and finally allow (4) txn1->n2: Put(b) to
+			// return with error>
+			if req.txnName == "txn1" && hasPut && req.toNodeID == tc.Server(1).NodeID() && cp == AfterSending {
+				// Hold the operation open until we are ready to retry on the new
+				// replica, after which we will return the injected failure.
+				req.pauseUntil(t, leaseMoveComplete, cp)
+				t.Logf("%s - injected RPC error", req.prefix)
+				return grpcstatus.Errorf(codes.Unavailable, "response jammed on n%d<-n%d", req.fromNodeID, req.toNodeID)
+			}
+
+			// -- NB: If ambiguous errors were propagated, txn1 would end here.
+			// -- NB: When ambiguous errors are not propagated, txn1 continues with:
+			//
+			// 10. txn1->n1: Put(b) -- Retry on new leaseholder sees new lease start
+			// timestamp, and attempts to evaluate it as an idempotent replay, but at
+			// a higher timestamp, which breaks idempotency due to being on commit.
+			// 11. txn1->n1: Refresh(a)
+			// 12. txn1->n1: Refresh(b,c) -- This fails due to txn3's write on c.
+			// Causes the transaction coordinator to return a retriable error,
+			// although the transaction could be actually committed during recovery;
+			// a highly problematic bug.
+			// <allow (9) RecoverTxn(txn1) to proceed and finish> -- because txn1
+			// is in STAGING and has all of its writes, it is implicitly committed,
+			// so the recovery will succeed in marking it explicitly committed.
+			if req.ba.IsSingleRecoverTxnRequest() && cp == BeforeSending {
+				// The RecoverTxn operation should be evaluated after txn1 completes,
+				// in this case with a problematic retriable error.
+				req.pauseUntil(t, txn1Done, cp)
+			}
+			if req.ba.IsSingleRecoverTxnRequest() && cp == AfterSending {
+				t.Logf("%s - complete, resp={%s}", req.prefix, resp)
+				close(recoverComplete)
+			}
+
+			// <allow txn2's Puts to execute>
 			if req.txnName == "txn2" && hasPut && cp == BeforeSending {
 				// While txn2's Puts can only occur after txn1 is marked as explicitly
 				// committed, if the Recovery and the subsequent txn2 Put(b) operations
 				// happen before txn1 retries its Put(b) on n1, it will encounter txn2's
 				// intent and get a WriteTooOld error instead of potentially being an
 				// idempotent replay.
+				<-txn1Done
+			}
+
+			return nil
+		}
+		tMu.Unlock()
+
+		// Start test, await concurrent operations and validate results.
+		close(txn1Ready)
+		err := <-txn1ResultCh
+		t.Logf("txn1 completed with err: %+v", err)
+		wg.Wait()
+
+		// TODO(sarkesian): While we expect an AmbiguousResultError once the
+		// immediate changes outlined in #103817 are implemented, right now this is
+		// essentially validating the existence of the bug. This needs to be fixed,
+		// and we should not see an transaction retry error from the transaction
+		// coordinator once fixed.
+		tErr := (*kvpb.TransactionRetryWithProtoRefreshError)(nil)
+		require.ErrorAsf(t, err, &tErr,
+			"expected incorrect TransactionRetryWithProtoRefreshError due to failed refresh")
+		require.False(t, tErr.PrevTxnAborted())
+		require.Falsef(t, errors.HasAssertionFailure(err),
+			"expected no AssertionFailedError due to sanity check")
+	})
+
+	// This test is primarily included for completeness, in order to ensure the
+	// same behavior regardless of if the recovery occurs before or after the
+	// lease transfer.
+	t.Run("recovery after transfer lease", func(t *testing.T) {
+		defer initSubTest(t)()
+
+		// Checkpoints in test.
+		txn1Ready := make(chan struct{})
+		txn2Ready := make(chan struct{})
+		leaseMoveReady := make(chan struct{})
+		leaseMoveComplete := make(chan struct{})
+		recoverComplete := make(chan struct{})
+		txn1Done := make(chan struct{})
+
+		// Final result.
+		txn1ResultCh := make(chan error, 1)
+
+		// Concurrent transactions.
+		var wg sync.WaitGroup
+		wg.Add(3)
+		go runConcurrentOp(t, "txn1", execWorkloadTxn, &wg, txn1Ready, txn1Done, txn1ResultCh)
+		go runConcurrentOp(t, "txn2", execWorkloadTxn, &wg, txn2Ready, nil /* doneCh */, nil /* resultCh */)
+		go runConcurrentOp(t, "lease mover", execLeaseMover, &wg, leaseMoveReady, leaseMoveComplete, nil /* resultCh */)
+
+		// KV Request sequencing.
+		tMu.Lock()
+		tMu.maybeWait = func(cp InterceptPoint, req *interceptedReq, resp *interceptedResp) (override error) {
+			_, hasPut := req.ba.GetArg(kvpb.Put)
+
+			// These conditions are checked in order of expected operations of the
+			// test.
+
+			// 1. txn1->n1: Get(a)
+			// 2. txn1->n2: Get(b)
+			// 3. txn1->n1: Put(a), EndTxn(parallel commit) -- Puts txn1 in STAGING.
+			// 4. txn1->n2: Put(b) -- Send the request, but pause before returning the
+			// response so we can inject network failure.
+			// <transfer b's lease to n1>
+			if req.txnName == "txn1" && hasPut && req.toNodeID == tc.Server(1).NodeID() && cp == AfterSending {
+				close(leaseMoveReady)
+				req.pauseUntil(t, leaseMoveComplete, cp)
+				close(txn2Ready)
+			}
+
+			// 5. txn2->n1: Get(a) -- Discovers txn1's locks, issues push request.
+			// 6. txn2->n1: Get(b)
+			// 7. _->n1: PushTxn(txn2->txn1) -- Discovers txn1 in STAGING and starts
+			// recovery.
+			// 8. _->n1: RecoverTxn(txn1) -- Recovery should mark txn1 committed, but
+			// pauses before returning so that txn1's intents don't get cleaned up.
+			if req.ba.IsSingleRecoverTxnRequest() && cp == AfterSending {
+				close(recoverComplete)
+			}
+
+			// <inject a network failure and finally allow (4) txn1->n2: Put(b) to
+			// return with error>
+			if req.txnName == "txn1" && hasPut && req.toNodeID == tc.Server(1).NodeID() && cp == AfterSending {
+				// Hold the operation open until we are ready to retry on the new
+				// replica, after which we will return the injected failure.
+				req.pauseUntil(t, recoverComplete, cp)
+				t.Logf("%s - injected RPC error", req.prefix)
+				return grpcstatus.Errorf(codes.Unavailable, "response jammed on n%d<-n%d", req.fromNodeID, req.toNodeID)
+			}
+
+			// -- NB: If ambiguous errors were propagated, txn1 would end here.
+			// -- NB: When ambiguous errors are not propagated, txn1 continues with:
+			//
+			// 9. txn1->n1: Put(b) -- Retry on new leaseholder sees new lease start
+			// timestamp, and attempts to evaluate it as an idempotent replay, but at
+			// a higher timestamp, which breaks idempotency due to being on commit.
+			// 10. txn1->n1: Refresh(a)
+			// 11. txn1->n1: Refresh(b)
+			// 12. txn1->n1: EndTxn(commit) -- Recovery has already completed, so this
+			// request fails with "transaction unexpectedly committed".
+
+			// <allow (8) recovery to return and txn2 to continue>
+			if req.ba.IsSingleRecoverTxnRequest() && cp == AfterSending {
+				req.pauseUntil(t, txn1Done, cp)
+				t.Logf("%s - complete, resp={%s}", req.prefix, resp)
+			}
+
+			return nil
+		}
+		tMu.Unlock()
+
+		// Start test, await concurrent operations and validate results.
+		close(txn1Ready)
+		err := <-txn1ResultCh
+		t.Logf("txn1 completed with err: %+v", err)
+		wg.Wait()
+
+		// TODO(sarkesian): While we expect an AmbiguousResultError once the
+		// immediate changes outlined in #103817 are implemented, right now this is
+		// essentially validating the existence of the bug. This needs to be fixed,
+		// and we should not see an assertion failure from the transaction
+		// coordinator once fixed.
+		tErr := (*kvpb.TransactionStatusError)(nil)
+		require.ErrorAsf(t, err, &tErr,
+			"expected TransactionStatusError due to being already committed")
+		require.Equalf(t, kvpb.TransactionStatusError_REASON_TXN_COMMITTED, tErr.Reason,
+			"expected TransactionStatusError due to being already committed")
+		require.Truef(t, errors.HasAssertionFailure(err),
+			"expected AssertionFailedError due to sanity check on transaction already committed")
+	})
+
+	// When a retried write happens after another txn's intent already exists on
+	// the key, we expect to see a WriteTooOld error propagate an ambiguous error.
+	t.Run("retry sees other intent", func(t *testing.T) {
+		defer initSubTest(t)()
+
+		// Checkpoints in test.
+		txn1Ready := make(chan struct{})
+		txn2Ready := make(chan struct{})
+		leaseMoveReady := make(chan struct{})
+		leaseMoveComplete := make(chan struct{})
+		txn2ETReady := make(chan struct{})
+		txn1Done := make(chan struct{})
+
+		// Final result.
+		txn1ResultCh := make(chan error, 1)
+
+		// Concurrent transactions.
+		var wg sync.WaitGroup
+		wg.Add(3)
+		go runConcurrentOp(t, "txn1", execWorkloadTxn, &wg, txn1Ready, txn1Done, txn1ResultCh)
+		go runConcurrentOp(t, "txn2", execWorkloadTxn, &wg, txn2Ready, nil /* doneCh */, nil /* resultCh */)
+		go runConcurrentOp(t, "lease mover", execLeaseMover, &wg, leaseMoveReady, leaseMoveComplete, nil /* resultCh */)
+
+		// KV Request sequencing.
+		tMu.Lock()
+		tMu.maybeWait = func(cp InterceptPoint, req *interceptedReq, resp *interceptedResp) (override error) {
+			_, hasPut := req.ba.GetArg(kvpb.Put)
+
+			// These conditions are checked in order of expected operations of the test.
+
+			// 1. txn1->n1: Get(a)
+			// 2. txn1->n2: Get(b)
+			// 3. txn1->n1: Put(a), EndTxn(parallel commit) -- Puts txn1 in STAGING.
+			// 4. txn1->n2: Put(b) -- Send the request, but pause before returning the
+			// response so we can inject network failure.
+			// <transfer b's lease to n1>
+			if req.txnName == "txn1" && hasPut && req.toNodeID == tc.Server(1).NodeID() && cp == AfterSending {
+				close(leaseMoveReady)
+				req.pauseUntil(t, leaseMoveComplete, cp)
+				close(txn2Ready)
+			}
+
+			// 5. txn2->n1: Get(a) -- Discovers txn1's locks, issues push request.
+			// 6. txn2->n1: Get(b)
+			// 7. _->n1: PushTxn(txn2->txn1) -- Discovers txn1 in STAGING and starts
+			// recovery.
+			// 8. _->n1: RecoverTxn(txn1) -- Recovery should mark txn1 committed.
+			// 9. txn2->n1: Put(a), EndTxn(parallel commit) -- Writes intent.
+			// 10. txn2->n1: Put(b)
+			// 11. txn2->n1: EndTxn(commit) -- Happens asynchronously, so txn2's
+			// coordinator has already returned success, but we want recovery of txn1
+			// and txn1's retry to complete before txn2's intents have been resolved.
+			if req.txnName == "txn2" && req.ba.IsSingleEndTxnRequest() && cp == BeforeSending {
+				close(txn2ETReady)
+			}
+
+			// <inject a network failure and finally allow (4) txn1->n2: Put(b) to
+			// return with error>
+			if req.txnName == "txn1" && hasPut && req.toNodeID == tc.Server(1).NodeID() && cp == AfterSending {
+				// Hold the operation open until we are ready to retry on the new
+				// replica, after which we will return the injected failure.
+				req.pauseUntil(t, txn2ETReady, cp)
+				t.Logf("%s - injected RPC error", req.prefix)
+				return grpcstatus.Errorf(codes.Unavailable, "response jammed on n%d<-n%d", req.fromNodeID, req.toNodeID)
+			}
+
+			// 9. txn1->n1: Put(b) -- Retry sees intent, so returns a WriteTooOld
+			// error. Since the transaction had an earlier ambiguous failure on a
+			// batch with a commit, it should propagate the ambiguous error.
+
+			// <allow txn2 to complete>
+			if req.txnName == "txn2" && req.ba.IsSingleEndTxnRequest() && cp == BeforeSending {
+				req.pauseUntil(t, txn1Done, cp)
+			}
+
+			return nil
+		}
+		tMu.Unlock()
+
+		// Start test, await concurrent operations and validate results.
+		close(txn1Ready)
+		err := <-txn1ResultCh
+		t.Logf("txn1 completed with err: %+v", err)
+		wg.Wait()
+
+		aErr := (*kvpb.AmbiguousResultError)(nil)
+		tErr := (*kvpb.TransactionStatusError)(nil)
+		require.ErrorAsf(t, err, &aErr,
+			"expected AmbiguousResultError due to encountering an intent on retry")
+		require.Falsef(t, errors.As(err, &tErr),
+			"did not expect TransactionStatusError due to being already committed")
+		require.Falsef(t, errors.HasAssertionFailure(err),
+			"expected no AssertionFailedError due to sanity check on transaction already committed")
+	})
+
+	// When a retried write happens after our txn's intent has already been
+	// resolved post-recovery, even at the same timestamp we expect to see a
+	// WriteTooOld error propagate an ambiguous error.
+	t.Run("recovery before retry at same timestamp", func(t *testing.T) {
+		defer initSubTest(t)()
+
+		// Checkpoints in test.
+		txn1Ready := make(chan struct{})
+		txn2Ready := make(chan struct{})
+		recoverComplete := make(chan struct{})
+		resolveIntentComplete := make(chan struct{})
+		txn1Done := make(chan struct{})
+
+		// Final result.
+		txn1ResultCh := make(chan error, 1)
+
+		// Place second range on n1 (same as first).
+		secondRange := tc.LookupRangeOrFatal(t, keyB)
+		tc.TransferRangeLeaseOrFatal(t, secondRange, tc.Target(0))
+		requireRangeLease(t, secondRange, 0)
+
+		// Operation functions.
+		execTxn2 := func(t *testing.T, name string) error {
+			tCtx := context.Background()
+
+			// txn2 just performs a simple GetForUpdate on a conflicting key, causing
+			// it to issue a PushTxn for txn1 which will kick off recovery.
+			txn := db.NewTxn(tCtx, name)
+			_ = getInBatch(t, tCtx, txn, keyB)
+			assert.NoError(t, txn.Commit(ctx))
+			return nil
+		}
+
+		// Concurrent transactions.
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go runConcurrentOp(t, "txn1", execWorkloadTxn, &wg, txn1Ready, txn1Done, txn1ResultCh)
+		go runConcurrentOp(t, "txn2", execTxn2, &wg, txn2Ready, nil /* doneCh */, nil /* resultCh */)
+
+		// KV Request sequencing.
+		var txn1KeyBWriteCount int64
+		tMu.Lock()
+		tMu.maybeWait = func(cp InterceptPoint, req *interceptedReq, resp *interceptedResp) (override error) {
+			putReq, hasPut := req.ba.GetArg(kvpb.Put)
+			var keyBWriteCount int64 = -1
+
+			// These conditions are checked in order of expected operations of the
+			// test.
+
+			// 1. txn1->n1: Get(a)
+			// 2. txn1->n1: Get(b)
+			// 3. txn1->n1: Put(a), EndTxn(parallel commit) -- Puts txn1 in STAGING.
+			// 4. txn1->n1: Put(b) -- Send the request, but pause before returning
+			// the response so we can inject network failure.
+			if req.txnName == "txn1" && hasPut && putReq.Header().Key.Equal(keyB) && cp == AfterSending {
+				keyBWriteCount = atomic.AddInt64(&txn1KeyBWriteCount, 1)
+				if keyBWriteCount == 1 {
+					close(txn2Ready)
+				}
+			}
+
+			// 5. txn2->n1: Get(b) -- Discovers txn1's locks, issues push request.
+			// 6. _->n1: PushTxn(txn2->txn1) -- Discovers txn1 in STAGING and starts
+			// recovery.
+			// 7. _->n1: RecoverTxn(txn1) -- Allow to proceed.
+			if req.ba.IsSingleRecoverTxnRequest() && cp == AfterSending {
+				t.Logf("%s - complete, resp={%s}", req.prefix, resp)
+				close(recoverComplete)
+			}
+
+			// 8. _->n1: ResolveIntent(txn1, b)
+			if riReq, ok := req.ba.GetArg(kvpb.ResolveIntent); ok && riReq.Header().Key.Equal(keyB) && cp == AfterSending {
+				t.Logf("%s - complete", req.prefix)
+				close(resolveIntentComplete)
+			}
+
+			// <inject a network failure and finally allow (4) txn1->n1: Put(b) to
+			// return with error>
+			if req.txnName == "txn1" && keyBWriteCount == 1 && cp == AfterSending {
+				// Hold the operation open until we are ready to retry, after which we
+				// will return the injected failure.
+				req.pauseUntil(t, resolveIntentComplete, cp)
+				t.Logf("%s - injected RPC error", req.prefix)
+				return grpcstatus.Errorf(codes.Unavailable, "response jammed on n%d<-n%d", req.fromNodeID, req.toNodeID)
+			}
+
+			// 9. txn1->n1: Put(b) -- Retry gets WriteTooOld and cannot perform a
+			// serverside refresh as reads were already returned. Fails, and should
+			// propagate the ambiguous error.
+
+			// <allow txn2's Puts to execute>
+			if req.txnName == "txn2" && hasPut && cp == BeforeSending {
+				<-txn1Done
+			}
+
+			return nil
+		}
+		tMu.Unlock()
+
+		// Start test, await concurrent operations and validate results.
+		close(txn1Ready)
+		err := <-txn1ResultCh
+		t.Logf("txn1 completed with err: %+v", err)
+		wg.Wait()
+
+		// TODO(sarkesian): Once we incorporate secondary errors into the
+		// AmbiguousResultError, check that we see the WriteTooOldError.
+		aErr := (*kvpb.AmbiguousResultError)(nil)
+		tErr := (*kvpb.TransactionStatusError)(nil)
+		require.ErrorAsf(t, err, &aErr,
+			"expected AmbiguousResultError due to encountering an intent on retry")
+		require.Falsef(t, errors.As(err, &tErr),
+			"did not expect TransactionStatusError due to being already committed")
+		require.Falsef(t, errors.HasAssertionFailure(err),
+			"expected no AssertionFailedError due to sanity check on transaction already committed")
+	})
+
+	// This test is included for completeness, but tests expected behavior;
+	// when a retried write happens successfully at the same timestamp, and no
+	// refresh is required, the explicit commit can happen asynchronously and the
+	// txn coordinator can return early, reporting a successful commit.
+	// When this occurs, even if the recovery happens before the async EndTxn,
+	// it is expected behavior for the EndTxn to encounter an already committed
+	// txn record, and this is not treated as error.
+	t.Run("recovery after retry at same timestamp", func(t *testing.T) {
+		defer initSubTest(t)()
+
+		// Checkpoints in test.
+		txn1Ready := make(chan struct{})
+		txn2Ready := make(chan struct{})
+		putRetryReady := make(chan struct{})
+		receivedFinalET := make(chan struct{})
+		recoverComplete := make(chan struct{})
+		txn1Done := make(chan struct{})
+
+		// Final result.
+		txn1ResultCh := make(chan error, 1)
+
+		// Place second range on n1 (same as first).
+		secondRange := tc.LookupRangeOrFatal(t, keyB)
+		tc.TransferRangeLeaseOrFatal(t, secondRange, tc.Target(0))
+		requireRangeLease(t, secondRange, 0)
+
+		// Operation functions.
+		execTxn2 := func(t *testing.T, name string) error {
+			tCtx := context.Background()
+
+			// txn2 just performs a simple GetForUpdate on a conflicting key, causing
+			// it to issue a PushTxn for txn1 which will kick off recovery.
+			txn := db.NewTxn(tCtx, name)
+			_ = getInBatch(t, tCtx, txn, keyB)
+			assert.NoError(t, txn.Commit(ctx))
+			return nil
+		}
+
+		// Concurrent transactions.
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go runConcurrentOp(t, "txn1", execWorkloadTxn, &wg, txn1Ready, txn1Done, txn1ResultCh)
+		go runConcurrentOp(t, "txn2", execTxn2, &wg, txn2Ready, nil /* doneCh */, nil /* resultCh */)
+
+		// KV Request sequencing.
+		var txn1KeyBWriteCount int64
+		tMu.Lock()
+		tMu.maybeWait = func(cp InterceptPoint, req *interceptedReq, resp *interceptedResp) (override error) {
+			putReq, hasPut := req.ba.GetArg(kvpb.Put)
+			var keyBWriteCount int64 = -1
+
+			// These conditions are checked in order of expected operations of the
+			// test.
+
+			// 1. txn1->n1: Get(a)
+			// 2. txn1->n1: Get(b)
+			// 3. txn1->n1: Put(a), EndTxn(parallel commit) -- Puts txn1 in STAGING.
+			// 4. txn1->n1: Put(b) -- Send the request, but pause before returning
+			// the response so we can inject network failure.
+			if req.txnName == "txn1" && hasPut && putReq.Header().Key.Equal(keyB) && cp == AfterSending {
+				keyBWriteCount = atomic.AddInt64(&txn1KeyBWriteCount, 1)
+				if keyBWriteCount == 1 {
+					close(txn2Ready)
+				}
+			}
+
+			// 5. txn2->n1: Get(b) -- Discovers txn1's locks, issues push request.
+			// 6. _->n1: PushTxn(txn2->txn1) -- Discovers txn1 in STAGING and starts
+			// recovery.
+			// 7. _->n1: RecoverTxn(txn1) -- Before sending, pause the request so we
+			// can ensure it gets evaluated after txn1 retries, but before its final
+			// EndTxn.
+			if req.ba.IsSingleRecoverTxnRequest() && cp == BeforeSending {
+				close(putRetryReady)
+			}
+
+			// <inject a network failure and finally allow (4) txn1->n1: Put(b) to
+			// return with error>
+			if req.txnName == "txn1" && keyBWriteCount == 1 && cp == AfterSending {
+				// Hold the operation open until we are ready to retry, after which we
+				// will return the injected failure.
+				req.pauseUntil(t, putRetryReady, cp)
+				t.Logf("%s - injected RPC error", req.prefix)
+				return grpcstatus.Errorf(codes.Unavailable, "response jammed on n%d<-n%d", req.fromNodeID, req.toNodeID)
+			}
+
+			// 8. txn1->n1: Put(b) -- Retry gets evaluated as idempotent replay and
+			// correctly succeeds.
+			// -- NB: In this case, txn1 returns without error here, as there is no
+			// need to refresh and the final EndTxn can be split off and run
+			// asynchronously.
+
+			// 9. txn1->n1: EndTxn(commit) -- Before sending, pause the request so
+			// that we can allow (8) RecoverTxn(txn1) to proceed, simulating a race
+			// in which the recovery wins.
+			if req.txnName == "txn1" && req.ba.IsSingleEndTxnRequest() && cp == BeforeSending {
+				close(receivedFinalET)
+			}
+
+			// <allow (7) RecoverTxn(txn1) to proceed and finish> -- because txn1
+			// is in STAGING and has all of its writes, it is implicitly committed,
+			// so the recovery will succeed in marking it explicitly committed.
+			if req.ba.IsSingleRecoverTxnRequest() && cp == BeforeSending {
+				req.pauseUntilFirst(t, receivedFinalET, txn1Done, cp)
+			}
+			if req.ba.IsSingleRecoverTxnRequest() && cp == AfterSending {
+				t.Logf("%s - complete, resp={%s}", req.prefix, resp)
+				close(recoverComplete)
+			}
+
+			// <allow (9) EndTxn(commit) to proceed and execute> -- even though the
+			// recovery won, this is allowed. See makeTxnCommitExplicitLocked(..).
+			if req.txnName == "txn1" && req.ba.IsSingleEndTxnRequest() && cp == BeforeSending {
+				req.pauseUntil(t, recoverComplete, cp)
+			}
+
+			// <allow txn2's Puts to execute>
+			if req.txnName == "txn2" && hasPut && cp == BeforeSending {
+				<-txn1Done
+			}
+
+			return nil
+		}
+		tMu.Unlock()
+
+		// Start test, await concurrent operations and validate results.
+		close(txn1Ready)
+		err := <-txn1ResultCh
+		t.Logf("txn1 completed with err: %+v", err)
+		wg.Wait()
+
+		require.NoErrorf(t, err, "expected txn1 to succeed")
+	})
+
+	// When a retried write happens after our txn's intent has already been
+	// resolved post-recovery, it should not be able to perform a serverside
+	// refresh to "handle" the WriteTooOld error as it may already be committed.
+	t.Run("recovery before retry with serverside refresh", func(t *testing.T) {
+		defer initSubTest(t)()
+
+		// Checkpoints in test.
+		txn1Ready := make(chan struct{})
+		txn2Ready := make(chan struct{})
+		recoverComplete := make(chan struct{})
+		resolveIntentComplete := make(chan struct{})
+		txn1Done := make(chan struct{})
+
+		// Final result.
+		txn1ResultCh := make(chan error, 1)
+
+		// Place second range on n1 (same as first).
+		secondRange := tc.LookupRangeOrFatal(t, keyB)
+		tc.TransferRangeLeaseOrFatal(t, secondRange, tc.Target(0))
+		requireRangeLease(t, secondRange, 0)
+
+		// Operation functions.
+		execTxn1 := func(t *testing.T, name string) error {
+			tCtx := context.Background()
+
+			// txn2 just performs a simple GetForUpdate on a conflicting key, causing
+			// it to issue a PushTxn for txn1 which will kick off recovery.
+			txn := db.NewTxn(tCtx, name)
+			batch := txn.NewBatch()
+			batch.Put(keyA, 100)
+			batch.Put(keyB, 100)
+			return txn.CommitInBatch(tCtx, batch)
+		}
+		execTxn2 := func(t *testing.T, name string) error {
+			tCtx := context.Background()
+
+			// txn2 just performs a simple GetForUpdate on a conflicting key, causing
+			// it to issue a PushTxn for txn1 which will kick off recovery.
+			txn := db.NewTxn(tCtx, name)
+			_ = getInBatch(t, tCtx, txn, keyB)
+			assert.NoError(t, txn.Commit(ctx))
+			return nil
+		}
+
+		// Concurrent transactions.
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go runConcurrentOp(t, "txn1", execTxn1, &wg, txn1Ready, txn1Done, txn1ResultCh)
+		go runConcurrentOp(t, "txn2", execTxn2, &wg, txn2Ready, nil /* doneCh */, nil /* resultCh */)
+
+		// KV Request sequencing.
+		var txn1KeyBWriteCount int64
+		var txn1KeyBResolveIntentCount int64
+		tMu.Lock()
+		tMu.maybeWait = func(cp InterceptPoint, req *interceptedReq, resp *interceptedResp) (override error) {
+			putReq, hasPut := req.ba.GetArg(kvpb.Put)
+			var keyBWriteCount int64 = -1
+			var keyBResolveIntentCount int64 = -1
+
+			// These conditions are checked in order of expected operations of the
+			// test.
+
+			// 1. txn1->n1: Put(a), EndTxn(parallel commit) -- Puts txn1 in STAGING.
+			// 2. txn1->n1: Put(b) -- Send the request, but pause before returning
+			// the response so we can inject network failure.
+			if req.txnName == "txn1" && hasPut && putReq.Header().Key.Equal(keyB) && cp == AfterSending {
+				keyBWriteCount = atomic.AddInt64(&txn1KeyBWriteCount, 1)
+				if keyBWriteCount == 1 {
+					close(txn2Ready)
+				}
+			}
+
+			// 3. txn2->n1: Get(b) -- Discovers txn1's locks, issues push request.
+			// 4. _->n1: PushTxn(txn2->txn1) -- Discovers txn1 in STAGING and starts
+			// recovery.
+			// 5. _->n1: RecoverTxn(txn1) -- Allow to proceed.
+			if req.ba.IsSingleRecoverTxnRequest() && cp == AfterSending {
+				t.Logf("%s - complete, resp={%s}", req.prefix, resp)
+				close(recoverComplete)
+			}
+
+			// 6. _->n1: ResolveIntent(txn1, b)
+			if riReq, ok := req.ba.GetArg(kvpb.ResolveIntent); ok && riReq.Header().Key.Equal(keyB) && cp == AfterSending {
+				keyBResolveIntentCount = atomic.AddInt64(&txn1KeyBResolveIntentCount, 1)
+				if keyBResolveIntentCount == 1 {
+					t.Logf("%s - complete", req.prefix)
+					close(resolveIntentComplete)
+				}
+			}
+
+			// <inject a network failure and finally allow (2) txn1->n1: Put(b) to
+			// return with error>
+			if req.txnName == "txn1" && keyBWriteCount == 1 && cp == AfterSending {
+				// Hold the operation open until we are ready to retry, after which we
+				// will return the injected failure.
+				req.pauseUntil(t, resolveIntentComplete, cp)
+				t.Logf("%s - injected RPC error", req.prefix)
+				return grpcstatus.Errorf(codes.Unavailable, "response jammed on n%d<-n%d", req.fromNodeID, req.toNodeID)
+			}
+
+			// 7. txn1->n1: Put(b) -- Retry gets WriteTooOld, performs a
+			// serverside refresh, and succeeds.
+			// 8. txn1->n1: EndTxn(commit) -- Results in "transaction unexpectedly
+			// committed" due to the recovery completing first.
+
+			// <allow txn2's Puts to execute>
+			if req.txnName == "txn2" && hasPut && cp == BeforeSending {
 				<-txn1Done
 			}
 

--- a/pkg/kv/kvclient/kvcoord/dist_sender_ambiguous_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_ambiguous_test.go
@@ -245,18 +245,33 @@ func makeValueFromInt(val int64) roachpb.Value {
 	return v
 }
 
+// validateTxnCommitAmbiguousError checks that an error on txn commit is
+// ambiguous, rather than an assertion failure or a retryable error.
+func validateTxnCommitAmbiguousError(t *testing.T, err error, reason string) {
+	aErr := (*kvpb.AmbiguousResultError)(nil)
+	rErr := (*kvpb.TransactionRetryWithProtoRefreshError)(nil)
+	tErr := (*kvpb.TransactionStatusError)(nil)
+	require.Errorf(t, err, "expected an AmbiguousResultError")
+	require.ErrorAsf(t, err, &aErr,
+		"expected AmbiguousResultError due to %s", reason)
+	require.Falsef(t, errors.As(err, &tErr),
+		"did not expect TransactionStatusError due to being already committed")
+	require.Falsef(t, errors.As(err, &rErr),
+		"did not expect incorrect TransactionRetryWithProtoRefreshError due to failed refresh")
+	require.Falsef(t, errors.HasAssertionFailure(err),
+		"expected no AssertionFailedError due to sanity check on transaction already committed")
+	require.ErrorContainsf(t, aErr, reason,
+		"expected AmbiguousResultError to include message \"%s\"", reason)
+}
+
 // TestTransactionUnexpectedlyCommitted validates the handling of the case where
 // a parallel commit transaction with an ambiguous error on a write races with
 // a contending transaction's recovery attempt. In the case that the recovery
 // succeeds prior to the original transaction's retries, an ambiguous error
 // should be raised.
 //
-// NB: This case encounters a known issue described in #103817 and seen in
-// #67765, where it currently is surfaced as an assertion failure that will
-// result in a node crash.
-//
-// TODO(sarkesian): Validate the ambiguous result error once the initial fix as
-// outlined in #103817 has been resolved.
+// NB: These tests deal with a known issue described in #103817 and seen in
+// #67765.
 func TestTransactionUnexpectedlyCommitted(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -610,12 +625,13 @@ func TestTransactionUnexpectedlyCommitted(t *testing.T) {
 				return grpcstatus.Errorf(codes.Unavailable, "response jammed on n%d<-n%d", req.fromNodeID, req.toNodeID)
 			}
 
-			// -- NB: If ambiguous errors were propagated, txn1 would end here.
-			// -- NB: When ambiguous errors are not propagated, txn1 continues with:
-			//
 			// 9. txn1->n1: Put(b) -- Retry on new leaseholder sees new lease start
 			// timestamp, and attempts to evaluate it as an idempotent replay, but at
 			// a higher timestamp, which breaks idempotency due to being on commit.
+
+			// -- NB: With ambiguous replay protection, txn1 should end here.
+			// -- NB: Without ambiguous replay protection, txn1 would continue with:
+
 			// 10. txn1->n1: Refresh(a)
 			// 11. txn1->n1: Refresh(b)
 			// 12. txn1->n1: EndTxn(commit) -- Before sending, pause the request so
@@ -662,21 +678,13 @@ func TestTransactionUnexpectedlyCommitted(t *testing.T) {
 		// Start test, await concurrent operations and validate results.
 		close(txn1Ready)
 		err := <-txn1ResultCh
-		t.Logf("txn1 completed with err: %+v", err)
+		t.Logf("txn1 completed with err: %v", err)
 		wg.Wait()
 
-		// TODO(sarkesian): While we expect an AmbiguousResultError once the
-		// immediate changes outlined in #103817 are implemented, right now this is
-		// essentially validating the existence of the bug. This needs to be fixed,
-		// and we should not see an assertion failure from the transaction
-		// coordinator once fixed.
-		tErr := (*kvpb.TransactionStatusError)(nil)
-		require.ErrorAsf(t, err, &tErr,
-			"expected TransactionStatusError due to being already committed")
-		require.Equalf(t, kvpb.TransactionStatusError_REASON_TXN_COMMITTED, tErr.Reason,
-			"expected TransactionStatusError due to being already committed")
-		require.Truef(t, errors.HasAssertionFailure(err),
-			"expected AssertionFailedError due to sanity check on transaction already committed")
+		// NB: While ideally we would hope to see a successful commit without
+		// error, without querying txn record/intents from the txn coordinator we
+		// expect an AmbiguousResultError in this case (as outlined in #103817).
+		validateTxnCommitAmbiguousError(t, err, "replay protection" /* reason */)
 	}
 
 	// The set of test cases that use the same request scheduling.
@@ -822,15 +830,16 @@ func TestTransactionUnexpectedlyCommitted(t *testing.T) {
 				return grpcstatus.Errorf(codes.Unavailable, "response jammed on n%d<-n%d", req.fromNodeID, req.toNodeID)
 			}
 
-			// -- NB: If ambiguous errors were propagated, txn1 would end here.
-			// -- NB: When ambiguous errors are not propagated, txn1 continues with:
-			//
 			// 9. txn1->n1: Put(b) -- Retry on new leaseholder sees new lease start
 			// timestamp, and attempts to evaluate it as an idempotent replay, but at
 			// a higher timestamp, which breaks idempotency due to being on commit.
+
+			// -- NB: With ambiguous replay protection, txn1 should end here.
+			// -- NB: Without ambiguous replay protection, txn1 would continue with:
+
 			// 10. txn1->n1: Refresh(a)
 			// 11. txn1->n1: Refresh(b,c) -- This fails due to txn2's intent on c.
-			// Causes the transaction coordinator to return a retriable error,
+			// Causes the transaction coordinator to return a retryable error,
 			// although the transaction has been actually committed during recovery;
 			// a highly problematic bug.
 
@@ -848,20 +857,13 @@ func TestTransactionUnexpectedlyCommitted(t *testing.T) {
 		// Start test, await concurrent operations and validate results.
 		close(txn1Ready)
 		err := <-txn1ResultCh
-		t.Logf("txn1 completed with err: %+v", err)
+		t.Logf("txn1 completed with err: %v", err)
 		wg.Wait()
 
-		// TODO(sarkesian): While we expect an AmbiguousResultError once the
-		// immediate changes outlined in #103817 are implemented, right now this is
-		// essentially validating the existence of the bug. This needs to be fixed,
-		// and we should not see an transaction retry error from the transaction
-		// coordinator once fixed.
-		tErr := (*kvpb.TransactionRetryWithProtoRefreshError)(nil)
-		require.ErrorAsf(t, err, &tErr,
-			"expected incorrect TransactionRetryWithProtoRefreshError due to failed refresh")
-		require.False(t, tErr.PrevTxnAborted())
-		require.Falsef(t, errors.HasAssertionFailure(err),
-			"expected no AssertionFailedError due to sanity check")
+		// NB: While ideally we would hope to see a successful commit without
+		// error, without querying txn record/intents from the txn coordinator we
+		// expect an AmbiguousResultError in this case (as outlined in #103817).
+		validateTxnCommitAmbiguousError(t, err, "replay protection" /* reason */)
 	})
 
 	// The txn coordinator shouldn't respond with an incorrect retryable failure
@@ -965,15 +967,16 @@ func TestTransactionUnexpectedlyCommitted(t *testing.T) {
 				return grpcstatus.Errorf(codes.Unavailable, "response jammed on n%d<-n%d", req.fromNodeID, req.toNodeID)
 			}
 
-			// -- NB: If ambiguous errors were propagated, txn1 would end here.
-			// -- NB: When ambiguous errors are not propagated, txn1 continues with:
-			//
 			// 10. txn1->n1: Put(b) -- Retry on new leaseholder sees new lease start
 			// timestamp, and attempts to evaluate it as an idempotent replay, but at
 			// a higher timestamp, which breaks idempotency due to being on commit.
+
+			// -- NB: With ambiguous replay protection, txn1 should end here.
+			// -- NB: Without ambiguous replay protection, txn1 would continue with:
+
 			// 11. txn1->n1: Refresh(a)
 			// 12. txn1->n1: Refresh(b,c) -- This fails due to txn3's write on c.
-			// Causes the transaction coordinator to return a retriable error,
+			// Causes the transaction coordinator to return a retryable error,
 			// although the transaction could be actually committed during recovery;
 			// a highly problematic bug.
 			// <allow (9) RecoverTxn(txn1) to proceed and finish> -- because txn1
@@ -981,7 +984,7 @@ func TestTransactionUnexpectedlyCommitted(t *testing.T) {
 			// so the recovery will succeed in marking it explicitly committed.
 			if req.ba.IsSingleRecoverTxnRequest() && cp == BeforeSending {
 				// The RecoverTxn operation should be evaluated after txn1 completes,
-				// in this case with a problematic retriable error.
+				// in this case with a problematic retryable error.
 				req.pauseUntil(t, txn1Done, cp)
 			}
 			if req.ba.IsSingleRecoverTxnRequest() && cp == AfterSending {
@@ -1006,20 +1009,13 @@ func TestTransactionUnexpectedlyCommitted(t *testing.T) {
 		// Start test, await concurrent operations and validate results.
 		close(txn1Ready)
 		err := <-txn1ResultCh
-		t.Logf("txn1 completed with err: %+v", err)
+		t.Logf("txn1 completed with err: %v", err)
 		wg.Wait()
 
-		// TODO(sarkesian): While we expect an AmbiguousResultError once the
-		// immediate changes outlined in #103817 are implemented, right now this is
-		// essentially validating the existence of the bug. This needs to be fixed,
-		// and we should not see an transaction retry error from the transaction
-		// coordinator once fixed.
-		tErr := (*kvpb.TransactionRetryWithProtoRefreshError)(nil)
-		require.ErrorAsf(t, err, &tErr,
-			"expected incorrect TransactionRetryWithProtoRefreshError due to failed refresh")
-		require.False(t, tErr.PrevTxnAborted())
-		require.Falsef(t, errors.HasAssertionFailure(err),
-			"expected no AssertionFailedError due to sanity check")
+		// NB: While ideally we would hope to see a successful commit without
+		// error, without querying txn record/intents from the txn coordinator we
+		// expect an AmbiguousResultError in this case (as outlined in #103817).
+		validateTxnCommitAmbiguousError(t, err, "replay protection" /* reason */)
 	})
 
 	// This test is primarily included for completeness, in order to ensure the
@@ -1086,12 +1082,13 @@ func TestTransactionUnexpectedlyCommitted(t *testing.T) {
 				return grpcstatus.Errorf(codes.Unavailable, "response jammed on n%d<-n%d", req.fromNodeID, req.toNodeID)
 			}
 
-			// -- NB: If ambiguous errors were propagated, txn1 would end here.
-			// -- NB: When ambiguous errors are not propagated, txn1 continues with:
-			//
 			// 9. txn1->n1: Put(b) -- Retry on new leaseholder sees new lease start
 			// timestamp, and attempts to evaluate it as an idempotent replay, but at
 			// a higher timestamp, which breaks idempotency due to being on commit.
+
+			// -- NB: With ambiguous replay protection, txn1 should end here.
+			// -- NB: Without ambiguous replay protection, txn1 would continue with:
+
 			// 10. txn1->n1: Refresh(a)
 			// 11. txn1->n1: Refresh(b)
 			// 12. txn1->n1: EndTxn(commit) -- Recovery has already completed, so this
@@ -1110,21 +1107,13 @@ func TestTransactionUnexpectedlyCommitted(t *testing.T) {
 		// Start test, await concurrent operations and validate results.
 		close(txn1Ready)
 		err := <-txn1ResultCh
-		t.Logf("txn1 completed with err: %+v", err)
+		t.Logf("txn1 completed with err: %v", err)
 		wg.Wait()
 
-		// TODO(sarkesian): While we expect an AmbiguousResultError once the
-		// immediate changes outlined in #103817 are implemented, right now this is
-		// essentially validating the existence of the bug. This needs to be fixed,
-		// and we should not see an assertion failure from the transaction
-		// coordinator once fixed.
-		tErr := (*kvpb.TransactionStatusError)(nil)
-		require.ErrorAsf(t, err, &tErr,
-			"expected TransactionStatusError due to being already committed")
-		require.Equalf(t, kvpb.TransactionStatusError_REASON_TXN_COMMITTED, tErr.Reason,
-			"expected TransactionStatusError due to being already committed")
-		require.Truef(t, errors.HasAssertionFailure(err),
-			"expected AssertionFailedError due to sanity check on transaction already committed")
+		// NB: While ideally we would hope to see a successful commit without
+		// error, without querying txn record/intents from the txn coordinator we
+		// expect an AmbiguousResultError in this case (as outlined in #103817).
+		validateTxnCommitAmbiguousError(t, err, "replay protection" /* reason */)
 	})
 
 	// When a retried write happens after another txn's intent already exists on
@@ -1197,6 +1186,9 @@ func TestTransactionUnexpectedlyCommitted(t *testing.T) {
 			// error. Since the transaction had an earlier ambiguous failure on a
 			// batch with a commit, it should propagate the ambiguous error.
 
+			// -- NB: Ambiguous replay protection is not required, and should not
+			// come into play here.
+
 			// <allow txn2 to complete>
 			if req.txnName == "txn2" && req.ba.IsSingleEndTxnRequest() && cp == BeforeSending {
 				req.pauseUntil(t, txn1Done, cp)
@@ -1209,17 +1201,12 @@ func TestTransactionUnexpectedlyCommitted(t *testing.T) {
 		// Start test, await concurrent operations and validate results.
 		close(txn1Ready)
 		err := <-txn1ResultCh
-		t.Logf("txn1 completed with err: %+v", err)
+		t.Logf("txn1 completed with err: %v", err)
 		wg.Wait()
 
-		aErr := (*kvpb.AmbiguousResultError)(nil)
-		tErr := (*kvpb.TransactionStatusError)(nil)
-		require.ErrorAsf(t, err, &aErr,
-			"expected AmbiguousResultError due to encountering an intent on retry")
-		require.Falsef(t, errors.As(err, &tErr),
-			"did not expect TransactionStatusError due to being already committed")
-		require.Falsef(t, errors.HasAssertionFailure(err),
-			"expected no AssertionFailedError due to sanity check on transaction already committed")
+		// NB: It is likely not possible to eliminate ambiguity in this case, as
+		// the original intents were already cleaned up.
+		validateTxnCommitAmbiguousError(t, err, "WriteTooOld" /* reason */)
 	})
 
 	// When a retried write happens after our txn's intent has already been
@@ -1313,6 +1300,9 @@ func TestTransactionUnexpectedlyCommitted(t *testing.T) {
 			// serverside refresh as reads were already returned. Fails, and should
 			// propagate the ambiguous error.
 
+			// -- NB: Ambiguous replay protection is not required, and should not
+			// come into play here.
+
 			// <allow txn2's Puts to execute>
 			if req.txnName == "txn2" && hasPut && cp == BeforeSending {
 				<-txn1Done
@@ -1325,19 +1315,12 @@ func TestTransactionUnexpectedlyCommitted(t *testing.T) {
 		// Start test, await concurrent operations and validate results.
 		close(txn1Ready)
 		err := <-txn1ResultCh
-		t.Logf("txn1 completed with err: %+v", err)
+		t.Logf("txn1 completed with err: %v", err)
 		wg.Wait()
 
-		// TODO(sarkesian): Once we incorporate secondary errors into the
-		// AmbiguousResultError, check that we see the WriteTooOldError.
-		aErr := (*kvpb.AmbiguousResultError)(nil)
-		tErr := (*kvpb.TransactionStatusError)(nil)
-		require.ErrorAsf(t, err, &aErr,
-			"expected AmbiguousResultError due to encountering an intent on retry")
-		require.Falsef(t, errors.As(err, &tErr),
-			"did not expect TransactionStatusError due to being already committed")
-		require.Falsef(t, errors.HasAssertionFailure(err),
-			"expected no AssertionFailedError due to sanity check on transaction already committed")
+		// NB: It is likely not possible to eliminate ambiguity in this case, as
+		// the original intents were already cleaned up.
+		validateTxnCommitAmbiguousError(t, err, "WriteTooOld" /* reason */)
 	})
 
 	// This test is included for completeness, but tests expected behavior;
@@ -1427,7 +1410,9 @@ func TestTransactionUnexpectedlyCommitted(t *testing.T) {
 			}
 
 			// 8. txn1->n1: Put(b) -- Retry gets evaluated as idempotent replay and
-			// correctly succeeds.
+			// correctly succeeds. Ambiguous replay protection, though enabled,
+			// should not cause the retried write to error.
+
 			// -- NB: In this case, txn1 returns without error here, as there is no
 			// need to refresh and the final EndTxn can be split off and run
 			// asynchronously.
@@ -1468,7 +1453,7 @@ func TestTransactionUnexpectedlyCommitted(t *testing.T) {
 		// Start test, await concurrent operations and validate results.
 		close(txn1Ready)
 		err := <-txn1ResultCh
-		t.Logf("txn1 completed with err: %+v", err)
+		t.Logf("txn1 completed with err: %v", err)
 		wg.Wait()
 
 		require.NoErrorf(t, err, "expected txn1 to succeed")
@@ -1574,9 +1559,13 @@ func TestTransactionUnexpectedlyCommitted(t *testing.T) {
 				return grpcstatus.Errorf(codes.Unavailable, "response jammed on n%d<-n%d", req.fromNodeID, req.toNodeID)
 			}
 
-			// 7. txn1->n1: Put(b) -- Retry gets WriteTooOld, performs a
-			// serverside refresh, and succeeds.
-			// 8. txn1->n1: EndTxn(commit) -- Results in "transaction unexpectedly
+			// 7. txn1->n1: Put(b) -- Retry gets WriteTooOld; with ambiguous replay
+			// protection enabled, it should not be able to perform a serverside
+			// refresh. Fails, and should propagate the ambiguous error.
+
+			// -- NB: Without ambiguous replay protection, txn1 would continue with:
+
+			// 8. txn1->n1: EndTxn(commit) -- Would get "transaction unexpectedly
 			// committed" due to the recovery completing first.
 
 			// <allow txn2's Puts to execute>
@@ -1591,20 +1580,11 @@ func TestTransactionUnexpectedlyCommitted(t *testing.T) {
 		// Start test, await concurrent operations and validate results.
 		close(txn1Ready)
 		err := <-txn1ResultCh
-		t.Logf("txn1 completed with err: %+v", err)
+		t.Logf("txn1 completed with err: %v", err)
 		wg.Wait()
 
-		// TODO(sarkesian): While we expect an AmbiguousResultError once the
-		// immediate changes outlined in #103817 are implemented, right now this is
-		// essentially validating the existence of the bug. This needs to be fixed,
-		// and we should not see an assertion failure from the transaction
-		// coordinator once fixed.
-		tErr := (*kvpb.TransactionStatusError)(nil)
-		require.ErrorAsf(t, err, &tErr,
-			"expected TransactionStatusError due to being already committed")
-		require.Equalf(t, kvpb.TransactionStatusError_REASON_TXN_COMMITTED, tErr.Reason,
-			"expected TransactionStatusError due to being already committed")
-		require.Truef(t, errors.HasAssertionFailure(err),
-			"expected AssertionFailedError due to sanity check on transaction already committed")
+		// NB: It is likely not possible to eliminate ambiguity in this case, as
+		// the original intents were already cleaned up.
+		validateTxnCommitAmbiguousError(t, err, "WriteTooOld" /* reason */)
 	})
 }

--- a/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
@@ -77,7 +77,7 @@ func TestRangeLookupWithOpenTransaction(t *testing.T) {
 	key := testutils.MakeKey(keys.Meta1Prefix, roachpb.KeyMax)
 	now := s.Clock().Now()
 	txn := roachpb.MakeTransaction("txn", roachpb.Key("foobar"), 0, now, 0, int32(s.SQLInstanceID()))
-	if err := storage.MVCCPutProto(context.Background(), s.Engines()[0], nil, key, now, hlc.ClockTimestamp{}, &txn, &roachpb.RangeDescriptor{}); err != nil {
+	if err := storage.MVCCPutProto(context.Background(), s.Engines()[0], key, now, &roachpb.RangeDescriptor{}, storage.MVCCWriteOptions{Txn: &txn}); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/kv/kvpb/api.proto
+++ b/pkg/kv/kvpb/api.proto
@@ -2699,9 +2699,18 @@ message Header {
   // sender.
   repeated string profile_labels = 31 [(gogoproto.customname) = "ProfileLabels"];
 
+  // AmbiguousReplayProtection, if set, prevents a retried write operation
+  // from being considered an idempotent replay of a successful prior attempt
+  // (of the same operation) if the request's write timestamp is different from
+  // the prior attempt's. This protection is required when there has been an
+  // ambiguous write (i.e. RPC error) on a batch that contained a commit,
+  // as the transaction may have already been considered implicitly committed,
+  // and/or been explicitly committed by a RecoverTxn request. See #103817.
+  bool ambiguous_replay_protection = 32;
+
   reserved 7, 10, 12, 14, 20;
 
-  // Next ID: 32
+  // Next ID: 33
 }
 
 // BoundedStalenessHeader contains configuration values pertaining to bounded

--- a/pkg/kv/kvpb/batch.go
+++ b/pkg/kv/kvpb/batch.go
@@ -855,6 +855,9 @@ func (ba BatchRequest) SafeFormat(s redact.SafePrinter, _ rune) {
 	if ba.WaitPolicy != lock.WaitPolicy_Block {
 		s.Printf(", [wait-policy: %s]", ba.WaitPolicy)
 	}
+	if ba.AmbiguousReplayProtection {
+		s.Printf(", [protect-ambiguous-replay]")
+	}
 	if ba.CanForwardReadTimestamp {
 		s.Printf(", [can-forward-ts]")
 	}

--- a/pkg/kv/kvpb/batch.go
+++ b/pkg/kv/kvpb/batch.go
@@ -258,6 +258,12 @@ func (ba *BatchRequest) IsSinglePushTxnRequest() bool {
 	return ba.isSingleRequestWithMethod(PushTxn)
 }
 
+// IsSingleRecoverTxnRequest returns true iff the batch contains a single request,
+// and that request is a RecoverTxnRequest.
+func (ba *BatchRequest) IsSingleRecoverTxnRequest() bool {
+	return ba.isSingleRequestWithMethod(RecoverTxn)
+}
+
 // IsSingleHeartbeatTxnRequest returns true iff the batch contains a single
 // request, and that request is a HeartbeatTxn.
 func (ba *BatchRequest) IsSingleHeartbeatTxnRequest() bool {
@@ -818,6 +824,15 @@ func (ba BatchRequest) SafeFormat(s redact.SafePrinter, _ rune) {
 			}
 			if et.InternalCommitTrigger != nil {
 				s.Printf(" %s", et.InternalCommitTrigger.Kind())
+			}
+			s.Printf(") [%s]", h.Key)
+		} else if rt, ok := req.(*RecoverTxnRequest); ok {
+			h := req.Header()
+			s.Printf("%s(%s, ", req.Method(), rt.Txn.Short())
+			if rt.ImplicitlyCommitted {
+				s.Printf("commit")
+			} else {
+				s.Printf("abort")
 			}
 			s.Printf(") [%s]", h.Key)
 		} else {

--- a/pkg/kv/kvpb/string_test.go
+++ b/pkg/kv/kvpb/string_test.go
@@ -42,6 +42,7 @@ func TestBatchRequestString(t *testing.T) {
 	txn.ID = uuid.NamespaceDNS
 	ba.Txn = &txn
 	ba.WaitPolicy = lock.WaitPolicy_Error
+	ba.AmbiguousReplayProtection = true
 	ba.CanForwardReadTimestamp = true
 	ba.BoundedStaleness = &kvpb.BoundedStalenessHeader{
 		MinTimestampBound:       hlc.Timestamp{WallTime: 1},
@@ -58,7 +59,7 @@ func TestBatchRequestString(t *testing.T) {
 	ba.Requests = append(ba.Requests, ru)
 
 	{
-		exp := `Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min),... 76 skipped ..., Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), EndTxn(abort) [/Min], [txn: 6ba7b810], [wait-policy: Error], [can-forward-ts], [bounded-staleness, min_ts_bound: 0.000000001,0, min_ts_bound_strict, max_ts_bound: 0.000000002,0]`
+		exp := `Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min),... 76 skipped ..., Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), EndTxn(abort) [/Min], [txn: 6ba7b810], [wait-policy: Error], [protect-ambiguous-replay], [can-forward-ts], [bounded-staleness, min_ts_bound: 0.000000001,0, min_ts_bound_strict, max_ts_bound: 0.000000002,0]`
 		act := ba.String()
 		require.Equal(t, exp, act)
 	}

--- a/pkg/kv/kvserver/batch_spanset_test.go
+++ b/pkg/kv/kvserver/batch_spanset_test.go
@@ -545,12 +545,10 @@ func TestSpanSetMVCCResolveWriteIntentRange(t *testing.T) {
 	if err := storage.MVCCPut(
 		ctx,
 		eng,
-		nil, // ms
 		roachpb.Key("b"),
 		hlc.Timestamp{WallTime: 10}, // irrelevant
-		hlc.ClockTimestamp{},        // irrelevant
 		value,
-		nil, // txn
+		storage.MVCCWriteOptions{}, // irrelevant
 	); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/kv/kvserver/batcheval/cmd_add_sstable_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_add_sstable_test.go
@@ -1142,7 +1142,7 @@ func TestEvalAddSSTable(t *testing.T) {
 								kv.Key.Timestamp.WallTime *= 1e9
 								v, err := storage.DecodeMVCCValue(kv.Value)
 								require.NoError(t, err)
-								require.NoError(t, storage.MVCCPut(ctx, b, nil, kv.Key.Key, kv.Key.Timestamp, hlc.ClockTimestamp{}, v.Value, txn))
+								require.NoError(t, storage.MVCCPut(ctx, b, kv.Key.Key, kv.Key.Timestamp, v.Value, storage.MVCCWriteOptions{Txn: txn}))
 							case storage.MVCCRangeKeyValue:
 								v, err := storage.DecodeMVCCValue(kv.Value)
 								require.NoError(t, err)

--- a/pkg/kv/kvserver/batcheval/cmd_clear_range_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_clear_range_test.go
@@ -151,8 +151,8 @@ func TestCmdClearRange(t *testing.T) {
 				// Write some random point keys within the cleared span, above the range tombstones.
 				for i := 0; i < tc.keyCount; i++ {
 					key := roachpb.Key(fmt.Sprintf("%04d", i))
-					require.NoError(t, storage.MVCCPut(ctx, eng, nil, key,
-						hlc.Timestamp{WallTime: int64(4+i%2) * 1e9}, hlc.ClockTimestamp{}, value, nil))
+					require.NoError(t, storage.MVCCPut(ctx, eng, key,
+						hlc.Timestamp{WallTime: int64(4+i%2) * 1e9}, value, storage.MVCCWriteOptions{}))
 				}
 
 				// Calculate the range stats.

--- a/pkg/kv/kvserver/batcheval/cmd_conditional_put.go
+++ b/pkg/kv/kvserver/batcheval/cmd_conditional_put.go
@@ -55,13 +55,20 @@ func ConditionalPut(
 	}
 
 	handleMissing := storage.CPutMissingBehavior(args.AllowIfDoesNotExist)
+
+	opts := storage.MVCCWriteOptions{
+		Txn:            h.Txn,
+		LocalTimestamp: cArgs.Now,
+		Stats:          cArgs.Stats,
+	}
+
 	var err error
 	if args.Blind {
 		err = storage.MVCCBlindConditionalPut(
-			ctx, readWriter, cArgs.Stats, args.Key, ts, cArgs.Now, args.Value, args.ExpBytes, handleMissing, h.Txn)
+			ctx, readWriter, args.Key, ts, args.Value, args.ExpBytes, handleMissing, opts)
 	} else {
 		err = storage.MVCCConditionalPut(
-			ctx, readWriter, cArgs.Stats, args.Key, ts, cArgs.Now, args.Value, args.ExpBytes, handleMissing, h.Txn)
+			ctx, readWriter, args.Key, ts, args.Value, args.ExpBytes, handleMissing, opts)
 	}
 	// NB: even if MVCC returns an error, it may still have written an intent
 	// into the batch. This allows callers to consume errors like WriteTooOld

--- a/pkg/kv/kvserver/batcheval/cmd_conditional_put.go
+++ b/pkg/kv/kvserver/batcheval/cmd_conditional_put.go
@@ -57,9 +57,10 @@ func ConditionalPut(
 	handleMissing := storage.CPutMissingBehavior(args.AllowIfDoesNotExist)
 
 	opts := storage.MVCCWriteOptions{
-		Txn:            h.Txn,
-		LocalTimestamp: cArgs.Now,
-		Stats:          cArgs.Stats,
+		Txn:                            h.Txn,
+		LocalTimestamp:                 cArgs.Now,
+		Stats:                          cArgs.Stats,
+		ReplayWriteTimestampProtection: h.AmbiguousReplayProtection,
 	}
 
 	var err error

--- a/pkg/kv/kvserver/batcheval/cmd_delete.go
+++ b/pkg/kv/kvserver/batcheval/cmd_delete.go
@@ -32,9 +32,10 @@ func Delete(
 	reply := resp.(*kvpb.DeleteResponse)
 
 	opts := storage.MVCCWriteOptions{
-		Txn:            h.Txn,
-		LocalTimestamp: cArgs.Now,
-		Stats:          cArgs.Stats,
+		Txn:                            h.Txn,
+		LocalTimestamp:                 cArgs.Now,
+		Stats:                          cArgs.Stats,
+		ReplayWriteTimestampProtection: h.AmbiguousReplayProtection,
 	}
 
 	var err error

--- a/pkg/kv/kvserver/batcheval/cmd_delete.go
+++ b/pkg/kv/kvserver/batcheval/cmd_delete.go
@@ -31,9 +31,15 @@ func Delete(
 	h := cArgs.Header
 	reply := resp.(*kvpb.DeleteResponse)
 
+	opts := storage.MVCCWriteOptions{
+		Txn:            h.Txn,
+		LocalTimestamp: cArgs.Now,
+		Stats:          cArgs.Stats,
+	}
+
 	var err error
 	reply.FoundKey, err = storage.MVCCDelete(
-		ctx, readWriter, cArgs.Stats, args.Key, h.Timestamp, cArgs.Now, h.Txn,
+		ctx, readWriter, args.Key, h.Timestamp, opts,
 	)
 
 	// If requested, replace point tombstones with range tombstones.

--- a/pkg/kv/kvserver/batcheval/cmd_delete_range.go
+++ b/pkg/kv/kvserver/batcheval/cmd_delete_range.go
@@ -223,8 +223,10 @@ func DeleteRange(
 	// can update the Result's AcquiredLocks field.
 	returnKeys := args.ReturnKeys || h.Txn != nil
 	deleted, resumeSpan, num, err := storage.MVCCDeleteRange(
-		ctx, readWriter, cArgs.Stats, args.Key, args.EndKey,
-		h.MaxSpanRequestKeys, timestamp, cArgs.Now, h.Txn, returnKeys)
+		ctx, readWriter, args.Key, args.EndKey,
+		h.MaxSpanRequestKeys, timestamp,
+		storage.MVCCWriteOptions{Txn: h.Txn, LocalTimestamp: cArgs.Now, Stats: cArgs.Stats},
+		returnKeys)
 	if err == nil && args.ReturnKeys {
 		reply.Keys = deleted
 	}

--- a/pkg/kv/kvserver/batcheval/cmd_delete_range.go
+++ b/pkg/kv/kvserver/batcheval/cmd_delete_range.go
@@ -218,6 +218,14 @@ func DeleteRange(
 	if !args.Inline {
 		timestamp = h.Timestamp
 	}
+
+	opts := storage.MVCCWriteOptions{
+		Txn:                            h.Txn,
+		LocalTimestamp:                 cArgs.Now,
+		Stats:                          cArgs.Stats,
+		ReplayWriteTimestampProtection: h.AmbiguousReplayProtection,
+	}
+
 	// NB: Even if args.ReturnKeys is false, we want to know which intents were
 	// written if we're evaluating the DeleteRange for a transaction so that we
 	// can update the Result's AcquiredLocks field.
@@ -225,8 +233,7 @@ func DeleteRange(
 	deleted, resumeSpan, num, err := storage.MVCCDeleteRange(
 		ctx, readWriter, args.Key, args.EndKey,
 		h.MaxSpanRequestKeys, timestamp,
-		storage.MVCCWriteOptions{Txn: h.Txn, LocalTimestamp: cArgs.Now, Stats: cArgs.Stats},
-		returnKeys)
+		opts, returnKeys)
 	if err == nil && args.ReturnKeys {
 		reply.Keys = deleted
 	}

--- a/pkg/kv/kvserver/batcheval/cmd_delete_range_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_delete_range_test.go
@@ -58,12 +58,12 @@ func TestDeleteRangeTombstone(t *testing.T) {
 		var localTS hlc.ClockTimestamp
 
 		txn := roachpb.MakeTransaction("test", nil /* baseKey */, roachpb.NormalUserPriority, hlc.Timestamp{WallTime: 5e9}, 0, 0)
-		require.NoError(t, storage.MVCCPut(ctx, rw, nil, roachpb.Key("b"), hlc.Timestamp{WallTime: 2e9}, localTS, roachpb.MakeValueFromString("b2"), nil))
-		require.NoError(t, storage.MVCCPut(ctx, rw, nil, roachpb.Key("c"), hlc.Timestamp{WallTime: 4e9}, localTS, roachpb.MakeValueFromString("c4"), nil))
-		require.NoError(t, storage.MVCCPut(ctx, rw, nil, roachpb.Key("d"), hlc.Timestamp{WallTime: 2e9}, localTS, roachpb.MakeValueFromString("d2"), nil))
-		_, err := storage.MVCCDelete(ctx, rw, nil, roachpb.Key("d"), hlc.Timestamp{WallTime: 3e9}, localTS, nil)
+		require.NoError(t, storage.MVCCPut(ctx, rw, roachpb.Key("b"), hlc.Timestamp{WallTime: 2e9}, roachpb.MakeValueFromString("b2"), storage.MVCCWriteOptions{LocalTimestamp: localTS}))
+		require.NoError(t, storage.MVCCPut(ctx, rw, roachpb.Key("c"), hlc.Timestamp{WallTime: 4e9}, roachpb.MakeValueFromString("c4"), storage.MVCCWriteOptions{LocalTimestamp: localTS}))
+		require.NoError(t, storage.MVCCPut(ctx, rw, roachpb.Key("d"), hlc.Timestamp{WallTime: 2e9}, roachpb.MakeValueFromString("d2"), storage.MVCCWriteOptions{LocalTimestamp: localTS}))
+		_, err := storage.MVCCDelete(ctx, rw, roachpb.Key("d"), hlc.Timestamp{WallTime: 3e9}, storage.MVCCWriteOptions{LocalTimestamp: localTS})
 		require.NoError(t, err)
-		require.NoError(t, storage.MVCCPut(ctx, rw, nil, roachpb.Key("i"), hlc.Timestamp{WallTime: 5e9}, localTS, roachpb.MakeValueFromString("i5"), &txn))
+		require.NoError(t, storage.MVCCPut(ctx, rw, roachpb.Key("i"), hlc.Timestamp{WallTime: 5e9}, roachpb.MakeValueFromString("i5"), storage.MVCCWriteOptions{Txn: &txn, LocalTimestamp: localTS}))
 		require.NoError(t, storage.MVCCDeleteRangeUsingTombstone(ctx, rw, nil, roachpb.Key("f"), roachpb.Key("h"), hlc.Timestamp{WallTime: 3e9}, localTS, nil, nil, false, 0, nil))
 		require.NoError(t, storage.MVCCDeleteRangeUsingTombstone(ctx, rw, nil, roachpb.Key("Z"), roachpb.Key("a"), hlc.Timestamp{WallTime: 100e9}, localTS, nil, nil, false, 0, nil))
 		require.NoError(t, storage.MVCCDeleteRangeUsingTombstone(ctx, rw, nil, roachpb.Key("z"), roachpb.Key("|"), hlc.Timestamp{WallTime: 100e9}, localTS, nil, nil, false, 0, nil))

--- a/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
+++ b/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
@@ -690,7 +690,8 @@ func updateStagingTxn(
 	txn.LockSpans = args.LockSpans
 	txn.InFlightWrites = args.InFlightWrites
 	txnRecord := txn.AsRecord()
-	return storage.MVCCPutProto(ctx, readWriter, ms, key, hlc.Timestamp{}, hlc.ClockTimestamp{}, nil, &txnRecord)
+
+	return storage.MVCCPutProto(ctx, readWriter, key, hlc.Timestamp{}, &txnRecord, storage.MVCCWriteOptions{Stats: ms})
 }
 
 // updateFinalizedTxn persists the COMMITTED or ABORTED transaction record with
@@ -707,6 +708,7 @@ func updateFinalizedTxn(
 	recordAlreadyExisted bool,
 	externalLocks []roachpb.Span,
 ) error {
+	opts := storage.MVCCWriteOptions{Stats: ms}
 	if txnAutoGC && len(externalLocks) == 0 {
 		if log.V(2) {
 			log.Infof(ctx, "auto-gc'ed %s (%d locks)", txn.Short(), len(args.LockSpans))
@@ -717,13 +719,13 @@ func updateFinalizedTxn(
 			// BatchRequest writes.
 			return nil
 		}
-		_, err := storage.MVCCDelete(ctx, readWriter, ms, key, hlc.Timestamp{}, hlc.ClockTimestamp{}, nil)
+		_, err := storage.MVCCDelete(ctx, readWriter, key, hlc.Timestamp{}, opts)
 		return err
 	}
 	txn.LockSpans = externalLocks
 	txn.InFlightWrites = nil
 	txnRecord := txn.AsRecord()
-	return storage.MVCCPutProto(ctx, readWriter, ms, key, hlc.Timestamp{}, hlc.ClockTimestamp{}, nil, &txnRecord)
+	return storage.MVCCPutProto(ctx, readWriter, key, hlc.Timestamp{}, &txnRecord, opts)
 }
 
 // RunCommitTrigger runs the commit trigger from an end transaction request.
@@ -1080,7 +1082,7 @@ func splitTriggerHelper(
 	if err != nil {
 		return enginepb.MVCCStats{}, result.Result{}, errors.Wrap(err, "unable to fetch last replica GC timestamp")
 	}
-	if err := storage.MVCCPutProto(ctx, batch, nil, keys.RangeLastReplicaGCTimestampKey(split.RightDesc.RangeID), hlc.Timestamp{}, hlc.ClockTimestamp{}, nil, &replicaGCTS); err != nil {
+	if err := storage.MVCCPutProto(ctx, batch, keys.RangeLastReplicaGCTimestampKey(split.RightDesc.RangeID), hlc.Timestamp{}, &replicaGCTS, storage.MVCCWriteOptions{}); err != nil {
 		return enginepb.MVCCStats{}, result.Result{}, errors.Wrap(err, "unable to copy last replica GC timestamp")
 	}
 

--- a/pkg/kv/kvserver/batcheval/cmd_end_transaction_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_end_transaction_test.go
@@ -1011,7 +1011,7 @@ func TestEndTxnUpdatesTransactionRecord(t *testing.T) {
 			// Write the existing transaction record, if necessary.
 			txnKey := keys.TransactionKey(txn.Key, txn.ID)
 			if c.existingTxn != nil {
-				if err := storage.MVCCPutProto(ctx, batch, nil, txnKey, hlc.Timestamp{}, hlc.ClockTimestamp{}, nil, c.existingTxn); err != nil {
+				if err := storage.MVCCPutProto(ctx, batch, txnKey, hlc.Timestamp{}, c.existingTxn, storage.MVCCWriteOptions{}); err != nil {
 					t.Fatal(err)
 				}
 			}
@@ -1117,13 +1117,13 @@ func TestPartialRollbackOnEndTransaction(t *testing.T) {
 		// Write a first value at key.
 		v.SetString("a")
 		txn.Sequence = 1
-		if err := storage.MVCCPut(ctx, batch, nil, k, ts, hlc.ClockTimestamp{}, v, &txn); err != nil {
+		if err := storage.MVCCPut(ctx, batch, k, ts, v, storage.MVCCWriteOptions{Txn: &txn}); err != nil {
 			t.Fatal(err)
 		}
 		// Write another value.
 		v.SetString("b")
 		txn.Sequence = 2
-		if err := storage.MVCCPut(ctx, batch, nil, k, ts, hlc.ClockTimestamp{}, v, &txn); err != nil {
+		if err := storage.MVCCPut(ctx, batch, k, ts, v, storage.MVCCWriteOptions{Txn: &txn}); err != nil {
 			t.Fatal(err)
 		}
 
@@ -1136,7 +1136,7 @@ func TestPartialRollbackOnEndTransaction(t *testing.T) {
 		txnKey := keys.TransactionKey(txn.Key, txn.ID)
 		if storeTxnBeforeEndTxn {
 			txnRec := txn.AsRecord()
-			if err := storage.MVCCPutProto(ctx, batch, nil, txnKey, hlc.Timestamp{}, hlc.ClockTimestamp{}, nil, &txnRec); err != nil {
+			if err := storage.MVCCPutProto(ctx, batch, txnKey, hlc.Timestamp{}, &txnRec, storage.MVCCWriteOptions{}); err != nil {
 				t.Fatal(err)
 			}
 		}
@@ -1562,7 +1562,7 @@ func TestResolveLocalLocks(t *testing.T) {
 			txn.Status = roachpb.COMMITTED
 
 			for i := 0; i < numKeys; i++ {
-				err := storage.MVCCPut(ctx, batch, nil, intToKey(i), ts, hlc.ClockTimestamp{}, roachpb.MakeValueFromString("a"), &txn)
+				err := storage.MVCCPut(ctx, batch, intToKey(i), ts, roachpb.MakeValueFromString("a"), storage.MVCCWriteOptions{Txn: &txn})
 				require.NoError(t, err)
 			}
 			resolvedLocks, externalLocks, err := resolveLocalLocksWithPagination(

--- a/pkg/kv/kvserver/batcheval/cmd_export_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_export_test.go
@@ -808,7 +808,7 @@ func TestRandomKeyAndTimestampExport(t *testing.T) {
 			valueSize := randutil.RandIntInRange(rnd, averageValueSize-100, averageValueSize+100)
 			value := roachpb.MakeValueFromBytes(randutil.RandBytes(rnd, valueSize))
 			value.InitChecksum(key)
-			if err := storage.MVCCPut(ctx, batch, nil, key, ts, hlc.ClockTimestamp{}, value, nil); err != nil {
+			if err := storage.MVCCPut(ctx, batch, key, ts, value, storage.MVCCWriteOptions{}); err != nil {
 				t.Fatal(err)
 			}
 
@@ -819,7 +819,7 @@ func TestRandomKeyAndTimestampExport(t *testing.T) {
 				ts = hlc.Timestamp{WallTime: int64(curWallTime), Logical: int32(curLogical)}
 				value = roachpb.MakeValueFromBytes(randutil.RandBytes(rnd, 200))
 				value.InitChecksum(key)
-				if err := storage.MVCCPut(ctx, batch, nil, key, ts, hlc.ClockTimestamp{}, value, nil); err != nil {
+				if err := storage.MVCCPut(ctx, batch, key, ts, value, storage.MVCCWriteOptions{}); err != nil {
 					t.Fatal(err)
 				}
 			}

--- a/pkg/kv/kvserver/batcheval/cmd_heartbeat_txn.go
+++ b/pkg/kv/kvserver/batcheval/cmd_heartbeat_txn.go
@@ -91,7 +91,7 @@ func HeartbeatTxn(
 		// is up for debate.
 		txn.LastHeartbeat.Forward(args.Now)
 		txnRecord := txn.AsRecord()
-		if err := storage.MVCCPutProto(ctx, readWriter, cArgs.Stats, key, hlc.Timestamp{}, hlc.ClockTimestamp{}, nil, &txnRecord); err != nil {
+		if err := storage.MVCCPutProto(ctx, readWriter, key, hlc.Timestamp{}, &txnRecord, storage.MVCCWriteOptions{Stats: cArgs.Stats}); err != nil {
 			return result.Result{}, err
 		}
 	}

--- a/pkg/kv/kvserver/batcheval/cmd_increment.go
+++ b/pkg/kv/kvserver/batcheval/cmd_increment.go
@@ -33,9 +33,10 @@ func Increment(
 	reply := resp.(*kvpb.IncrementResponse)
 
 	opts := storage.MVCCWriteOptions{
-		Txn:            h.Txn,
-		LocalTimestamp: cArgs.Now,
-		Stats:          cArgs.Stats,
+		Txn:                            h.Txn,
+		LocalTimestamp:                 cArgs.Now,
+		Stats:                          cArgs.Stats,
+		ReplayWriteTimestampProtection: h.AmbiguousReplayProtection,
 	}
 
 	newVal, err := storage.MVCCIncrement(

--- a/pkg/kv/kvserver/batcheval/cmd_increment.go
+++ b/pkg/kv/kvserver/batcheval/cmd_increment.go
@@ -32,8 +32,14 @@ func Increment(
 	h := cArgs.Header
 	reply := resp.(*kvpb.IncrementResponse)
 
+	opts := storage.MVCCWriteOptions{
+		Txn:            h.Txn,
+		LocalTimestamp: cArgs.Now,
+		Stats:          cArgs.Stats,
+	}
+
 	newVal, err := storage.MVCCIncrement(
-		ctx, readWriter, cArgs.Stats, args.Key, h.Timestamp, cArgs.Now, h.Txn, args.Increment)
+		ctx, readWriter, args.Key, h.Timestamp, opts, args.Increment)
 	reply.NewValue = newVal
 	// NB: even if MVCC returns an error, it may still have written an intent
 	// into the batch. This allows callers to consume errors like WriteTooOld

--- a/pkg/kv/kvserver/batcheval/cmd_init_put.go
+++ b/pkg/kv/kvserver/batcheval/cmd_init_put.go
@@ -37,9 +37,10 @@ func InitPut(
 	}
 
 	opts := storage.MVCCWriteOptions{
-		Txn:            h.Txn,
-		LocalTimestamp: cArgs.Now,
-		Stats:          cArgs.Stats,
+		Txn:                            h.Txn,
+		LocalTimestamp:                 cArgs.Now,
+		Stats:                          cArgs.Stats,
+		ReplayWriteTimestampProtection: h.AmbiguousReplayProtection,
 	}
 
 	var err error

--- a/pkg/kv/kvserver/batcheval/cmd_init_put.go
+++ b/pkg/kv/kvserver/batcheval/cmd_init_put.go
@@ -36,13 +36,19 @@ func InitPut(
 		args.FailOnTombstones = false
 	}
 
+	opts := storage.MVCCWriteOptions{
+		Txn:            h.Txn,
+		LocalTimestamp: cArgs.Now,
+		Stats:          cArgs.Stats,
+	}
+
 	var err error
 	if args.Blind {
 		err = storage.MVCCBlindInitPut(
-			ctx, readWriter, cArgs.Stats, args.Key, h.Timestamp, cArgs.Now, args.Value, args.FailOnTombstones, h.Txn)
+			ctx, readWriter, args.Key, h.Timestamp, args.Value, args.FailOnTombstones, opts)
 	} else {
 		err = storage.MVCCInitPut(
-			ctx, readWriter, cArgs.Stats, args.Key, h.Timestamp, cArgs.Now, args.Value, args.FailOnTombstones, h.Txn)
+			ctx, readWriter, args.Key, h.Timestamp, args.Value, args.FailOnTombstones, opts)
 	}
 	// NB: even if MVCC returns an error, it may still have written an intent
 	// into the batch. This allows callers to consume errors like WriteTooOld

--- a/pkg/kv/kvserver/batcheval/cmd_lease_request.go
+++ b/pkg/kv/kvserver/batcheval/cmd_lease_request.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/spanset"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
 func init() {
@@ -157,6 +158,7 @@ func RequestLease(
 		priorReadSum = &worstCaseSum
 	}
 
+	log.VEventf(ctx, 2, "lease request: prev lease: %+v, new lease: %+v", prevLease, newLease)
 	return evalNewLease(ctx, cArgs.EvalCtx, readWriter, cArgs.Stats,
 		newLease, prevLease, priorReadSum, isExtension, false /* isTransfer */)
 }

--- a/pkg/kv/kvserver/batcheval/cmd_push_txn.go
+++ b/pkg/kv/kvserver/batcheval/cmd_push_txn.go
@@ -312,7 +312,7 @@ func PushTxn(
 		// in the timestamp cache.
 		if ok {
 			txnRecord := reply.PusheeTxn.AsRecord()
-			if err := storage.MVCCPutProto(ctx, readWriter, cArgs.Stats, key, hlc.Timestamp{}, hlc.ClockTimestamp{}, nil, &txnRecord); err != nil {
+			if err := storage.MVCCPutProto(ctx, readWriter, key, hlc.Timestamp{}, &txnRecord, storage.MVCCWriteOptions{Stats: cArgs.Stats}); err != nil {
 				return result.Result{}, err
 			}
 		}
@@ -333,7 +333,7 @@ func PushTxn(
 		// TODO(nvanbenschoten): remove this logic in v23.2.
 		if ok && !cArgs.EvalCtx.ClusterSettings().Version.IsActive(ctx, clusterversion.V23_1) {
 			txnRecord := reply.PusheeTxn.AsRecord()
-			if err := storage.MVCCPutProto(ctx, readWriter, cArgs.Stats, key, hlc.Timestamp{}, hlc.ClockTimestamp{}, nil, &txnRecord); err != nil {
+			if err := storage.MVCCPutProto(ctx, readWriter, key, hlc.Timestamp{}, &txnRecord, storage.MVCCWriteOptions{Stats: cArgs.Stats}); err != nil {
 				return result.Result{}, err
 			}
 		}

--- a/pkg/kv/kvserver/batcheval/cmd_put.go
+++ b/pkg/kv/kvserver/batcheval/cmd_put.go
@@ -53,9 +53,10 @@ func Put(
 	}
 
 	opts := storage.MVCCWriteOptions{
-		Txn:            h.Txn,
-		LocalTimestamp: cArgs.Now,
-		Stats:          cArgs.Stats,
+		Txn:                            h.Txn,
+		LocalTimestamp:                 cArgs.Now,
+		Stats:                          cArgs.Stats,
+		ReplayWriteTimestampProtection: h.AmbiguousReplayProtection,
 	}
 
 	var err error

--- a/pkg/kv/kvserver/batcheval/cmd_put.go
+++ b/pkg/kv/kvserver/batcheval/cmd_put.go
@@ -46,17 +46,23 @@ func Put(
 ) (result.Result, error) {
 	args := cArgs.Args.(*kvpb.PutRequest)
 	h := cArgs.Header
-	ms := cArgs.Stats
 
 	var ts hlc.Timestamp
 	if !args.Inline {
 		ts = h.Timestamp
 	}
+
+	opts := storage.MVCCWriteOptions{
+		Txn:            h.Txn,
+		LocalTimestamp: cArgs.Now,
+		Stats:          cArgs.Stats,
+	}
+
 	var err error
 	if args.Blind {
-		err = storage.MVCCBlindPut(ctx, readWriter, ms, args.Key, ts, cArgs.Now, args.Value, h.Txn)
+		err = storage.MVCCBlindPut(ctx, readWriter, args.Key, ts, args.Value, opts)
 	} else {
-		err = storage.MVCCPut(ctx, readWriter, ms, args.Key, ts, cArgs.Now, args.Value, h.Txn)
+		err = storage.MVCCPut(ctx, readWriter, args.Key, ts, args.Value, opts)
 	}
 	// NB: even if MVCC returns an error, it may still have written an intent
 	// into the batch. This allows callers to consume errors like WriteTooOld

--- a/pkg/kv/kvserver/batcheval/cmd_query_intent_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_query_intent_test.go
@@ -40,7 +40,7 @@ func TestQueryIntent(t *testing.T) {
 
 	writeIntent := func(k roachpb.Key, ts int64) roachpb.Transaction {
 		txn := roachpb.MakeTransaction("test", k, 0, makeTS(ts), 0, 1)
-		_, err := storage.MVCCDelete(ctx, db, nil, k, makeTS(ts), hlc.ClockTimestamp{}, &txn)
+		_, err := storage.MVCCDelete(ctx, db, k, makeTS(ts), storage.MVCCWriteOptions{Txn: &txn})
 		require.NoError(t, err)
 		return txn
 	}

--- a/pkg/kv/kvserver/batcheval/cmd_query_resolved_timestamp_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_query_resolved_timestamp_test.go
@@ -44,16 +44,16 @@ func TestQueryResolvedTimestamp(t *testing.T) {
 		return hlc.Timestamp{WallTime: ts}
 	}
 	writeValue := func(k string, ts int64) {
-		_, err := storage.MVCCDelete(ctx, db, nil, roachpb.Key(k), makeTS(ts), hlc.ClockTimestamp{}, nil)
+		_, err := storage.MVCCDelete(ctx, db, roachpb.Key(k), makeTS(ts), storage.MVCCWriteOptions{})
 		require.NoError(t, err)
 	}
 	writeIntent := func(k string, ts int64) {
 		txn := roachpb.MakeTransaction("test", roachpb.Key(k), 0, makeTS(ts), 0, 1)
-		_, err := storage.MVCCDelete(ctx, db, nil, roachpb.Key(k), makeTS(ts), hlc.ClockTimestamp{}, &txn)
+		_, err := storage.MVCCDelete(ctx, db, roachpb.Key(k), makeTS(ts), storage.MVCCWriteOptions{Txn: &txn})
 		require.NoError(t, err)
 	}
 	writeInline := func(k string) {
-		_, err := storage.MVCCDelete(ctx, db, nil, roachpb.Key(k), hlc.Timestamp{}, hlc.ClockTimestamp{}, nil)
+		_, err := storage.MVCCDelete(ctx, db, roachpb.Key(k), hlc.Timestamp{}, storage.MVCCWriteOptions{})
 		require.NoError(t, err)
 	}
 

--- a/pkg/kv/kvserver/batcheval/cmd_recover_txn.go
+++ b/pkg/kv/kvserver/batcheval/cmd_recover_txn.go
@@ -217,7 +217,7 @@ func RecoverTxn(
 		reply.RecoveredTxn.Status = roachpb.ABORTED
 	}
 	txnRecord := reply.RecoveredTxn.AsRecord()
-	if err := storage.MVCCPutProto(ctx, readWriter, cArgs.Stats, key, hlc.Timestamp{}, hlc.ClockTimestamp{}, nil, &txnRecord); err != nil {
+	if err := storage.MVCCPutProto(ctx, readWriter, key, hlc.Timestamp{}, &txnRecord, storage.MVCCWriteOptions{Stats: cArgs.Stats}); err != nil {
 		return result.Result{}, err
 	}
 

--- a/pkg/kv/kvserver/batcheval/cmd_recover_txn_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_recover_txn_test.go
@@ -49,7 +49,7 @@ func TestRecoverTxn(t *testing.T) {
 		// Write the transaction record.
 		txnKey := keys.TransactionKey(txn.Key, txn.ID)
 		txnRecord := txn.AsRecord()
-		if err := storage.MVCCPutProto(ctx, db, nil, txnKey, hlc.Timestamp{}, hlc.ClockTimestamp{}, nil, &txnRecord); err != nil {
+		if err := storage.MVCCPutProto(ctx, db, txnKey, hlc.Timestamp{}, &txnRecord, storage.MVCCWriteOptions{}); err != nil {
 			t.Fatal(err)
 		}
 
@@ -225,7 +225,7 @@ func TestRecoverTxnRecordChanged(t *testing.T) {
 			// request is evaluated.
 			txnKey := keys.TransactionKey(txn.Key, txn.ID)
 			txnRecord := c.changedTxn.AsRecord()
-			if err := storage.MVCCPutProto(ctx, db, nil, txnKey, hlc.Timestamp{}, hlc.ClockTimestamp{}, nil, &txnRecord); err != nil {
+			if err := storage.MVCCPutProto(ctx, db, txnKey, hlc.Timestamp{}, &txnRecord, storage.MVCCWriteOptions{}); err != nil {
 				t.Fatal(err)
 			}
 

--- a/pkg/kv/kvserver/batcheval/cmd_refresh_range_bench_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_refresh_range_bench_test.go
@@ -270,7 +270,7 @@ func setupData(
 		value := roachpb.MakeValueFromBytes(randutil.RandBytes(rng, opts.valueBytes))
 		value.InitChecksum(key)
 		ts := hlc.Timestamp{WallTime: int64((pos + 1) * 5)}
-		if err := storage.MVCCPut(ctx, batch, nil /* ms */, key, ts, hlc.ClockTimestamp{}, value, nil); err != nil {
+		if err := storage.MVCCPut(ctx, batch, key, ts, value, storage.MVCCWriteOptions{}); err != nil {
 			b.Fatal(err)
 		}
 	}

--- a/pkg/kv/kvserver/batcheval/cmd_refresh_range_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_refresh_range_test.go
@@ -39,9 +39,9 @@ func TestRefreshRange(t *testing.T) {
 	// Write an MVCC point key at b@3, MVCC point tombstone at b@5, and MVCC range
 	// tombstone at [d-f)@7.
 	require.NoError(t, storage.MVCCPut(
-		ctx, eng, nil, roachpb.Key("b"), hlc.Timestamp{WallTime: 3}, hlc.ClockTimestamp{}, roachpb.MakeValueFromString("value"), nil))
+		ctx, eng, roachpb.Key("b"), hlc.Timestamp{WallTime: 3}, roachpb.MakeValueFromString("value"), storage.MVCCWriteOptions{}))
 	require.NoError(t, storage.MVCCPut(
-		ctx, eng, nil, roachpb.Key("c"), hlc.Timestamp{WallTime: 5}, hlc.ClockTimestamp{}, roachpb.Value{}, nil))
+		ctx, eng, roachpb.Key("c"), hlc.Timestamp{WallTime: 5}, roachpb.Value{}, storage.MVCCWriteOptions{}))
 	require.NoError(t, storage.MVCCDeleteRangeUsingTombstone(
 		ctx, eng, nil, roachpb.Key("d"), roachpb.Key("f"), hlc.Timestamp{WallTime: 7}, hlc.ClockTimestamp{}, nil, nil, false, 0, nil))
 
@@ -155,10 +155,10 @@ func TestRefreshRangeTimeBoundIterator(t *testing.T) {
 		},
 		ReadTimestamp: ts1,
 	}
-	if err := storage.MVCCPut(ctx, db, nil, k, txn.ReadTimestamp, hlc.ClockTimestamp{}, v, txn); err != nil {
+	if err := storage.MVCCPut(ctx, db, k, txn.ReadTimestamp, v, storage.MVCCWriteOptions{Txn: txn}); err != nil {
 		t.Fatal(err)
 	}
-	if err := storage.MVCCPut(ctx, db, nil, roachpb.Key("unused1"), ts4, hlc.ClockTimestamp{}, v, nil); err != nil {
+	if err := storage.MVCCPut(ctx, db, roachpb.Key("unused1"), ts4, v, storage.MVCCWriteOptions{}); err != nil {
 		t.Fatal(err)
 	}
 	if err := db.Flush(); err != nil {
@@ -177,7 +177,7 @@ func TestRefreshRangeTimeBoundIterator(t *testing.T) {
 	if _, _, _, err := storage.MVCCResolveWriteIntent(ctx, db, nil, intent, storage.MVCCResolveWriteIntentOptions{}); err != nil {
 		t.Fatal(err)
 	}
-	if err := storage.MVCCPut(ctx, db, nil, roachpb.Key("unused2"), ts1, hlc.ClockTimestamp{}, v, nil); err != nil {
+	if err := storage.MVCCPut(ctx, db, roachpb.Key("unused2"), ts1, v, storage.MVCCWriteOptions{}); err != nil {
 		t.Fatal(err)
 	}
 	if err := db.Flush(); err != nil {
@@ -266,7 +266,7 @@ func TestRefreshRangeError(t *testing.T) {
 			},
 			ReadTimestamp: ts2,
 		}
-		if err := storage.MVCCPut(ctx, db, nil, k, txn.ReadTimestamp, hlc.ClockTimestamp{}, v, txn); err != nil {
+		if err := storage.MVCCPut(ctx, db, k, txn.ReadTimestamp, v, storage.MVCCWriteOptions{Txn: txn}); err != nil {
 			t.Fatal(err)
 		}
 

--- a/pkg/kv/kvserver/batcheval/cmd_refresh_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_refresh_test.go
@@ -60,7 +60,7 @@ func TestRefreshError(t *testing.T) {
 			},
 			ReadTimestamp: ts2,
 		}
-		if err := storage.MVCCPut(ctx, db, nil, k, txn.ReadTimestamp, hlc.ClockTimestamp{}, v, txn); err != nil {
+		if err := storage.MVCCPut(ctx, db, k, txn.ReadTimestamp, v, storage.MVCCWriteOptions{Txn: txn}); err != nil {
 			t.Fatal(err)
 		}
 
@@ -121,7 +121,7 @@ func TestRefreshTimestampBounds(t *testing.T) {
 	ts3 := hlc.Timestamp{WallTime: 3}
 
 	// Write to a key at time ts2.
-	require.NoError(t, storage.MVCCPut(ctx, db, nil, k, ts2, hlc.ClockTimestamp{}, v, nil))
+	require.NoError(t, storage.MVCCPut(ctx, db, k, ts2, v, storage.MVCCWriteOptions{}))
 
 	for _, tc := range []struct {
 		from, to hlc.Timestamp

--- a/pkg/kv/kvserver/batcheval/cmd_resolve_intent_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_resolve_intent_test.go
@@ -168,13 +168,13 @@ func TestResolveIntentAfterPartialRollback(t *testing.T) {
 		// Write a first value at key.
 		v.SetString("a")
 		txn.Sequence = 0
-		if err := storage.MVCCPut(ctx, batch, nil, k, ts, hlc.ClockTimestamp{}, v, &txn); err != nil {
+		if err := storage.MVCCPut(ctx, batch, k, ts, v, storage.MVCCWriteOptions{Txn: &txn}); err != nil {
 			t.Fatal(err)
 		}
 		// Write another value.
 		v.SetString("b")
 		txn.Sequence = 1
-		if err := storage.MVCCPut(ctx, batch, nil, k, ts, hlc.ClockTimestamp{}, v, &txn); err != nil {
+		if err := storage.MVCCPut(ctx, batch, k, ts, v, storage.MVCCWriteOptions{Txn: &txn}); err != nil {
 			t.Fatal(err)
 		}
 		if err := batch.Commit(true); err != nil {
@@ -304,7 +304,7 @@ func TestResolveIntentWithTargetBytes(t *testing.T) {
 		st := makeClusterSettingsUsingEngineIntentsSetting(db)
 
 		for i, testKey := range testKeys {
-			err := storage.MVCCPut(ctx, batch, nil, testKey, ts, hlc.ClockTimestamp{}, values[i], &txn)
+			err := storage.MVCCPut(ctx, batch, testKey, ts, values[i], storage.MVCCWriteOptions{Txn: &txn})
 			require.NoError(t, err)
 		}
 		initialBytes := batch.Len()

--- a/pkg/kv/kvserver/batcheval/cmd_revert_range_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_revert_range_test.go
@@ -68,7 +68,7 @@ func TestCmdRevertRange(t *testing.T) {
 		key := roachpb.Key(fmt.Sprintf("%04d", i))
 		var value roachpb.Value
 		value.SetString(fmt.Sprintf("%d", i))
-		if err := storage.MVCCPut(ctx, eng, &stats, key, baseTime.Add(int64(i%10), 0), hlc.ClockTimestamp{}, value, nil); err != nil {
+		if err := storage.MVCCPut(ctx, eng, key, baseTime.Add(int64(i%10), 0), value, storage.MVCCWriteOptions{Stats: &stats}); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -82,7 +82,7 @@ func TestCmdRevertRange(t *testing.T) {
 		key := roachpb.Key(fmt.Sprintf("%04d", i))
 		var value roachpb.Value
 		value.SetString(fmt.Sprintf("%d-rev-a", i))
-		if err := storage.MVCCPut(ctx, eng, &stats, key, tsA.Add(int64(i%5), 1), hlc.ClockTimestamp{}, value, nil); err != nil {
+		if err := storage.MVCCPut(ctx, eng, key, tsA.Add(int64(i%5), 1), value, storage.MVCCWriteOptions{Stats: &stats}); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -95,7 +95,7 @@ func TestCmdRevertRange(t *testing.T) {
 		key := roachpb.Key(fmt.Sprintf("%04d", i))
 		var value roachpb.Value
 		value.SetString(fmt.Sprintf("%d-rev-b", i))
-		if err := storage.MVCCPut(ctx, eng, &stats, key, tsB.Add(1, int32(i%5)), hlc.ClockTimestamp{}, value, nil); err != nil {
+		if err := storage.MVCCPut(ctx, eng, key, tsB.Add(1, int32(i%5)), value, storage.MVCCWriteOptions{Stats: &stats}); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -168,7 +168,7 @@ func TestCmdRevertRange(t *testing.T) {
 
 	txn := roachpb.MakeTransaction("test", nil, roachpb.NormalUserPriority, tsC, 1, 1)
 	if err := storage.MVCCPut(
-		ctx, eng, &stats, []byte("0012"), tsC, hlc.ClockTimestamp{}, roachpb.MakeValueFromBytes([]byte("i")), &txn,
+		ctx, eng, []byte("0012"), tsC, roachpb.MakeValueFromBytes([]byte("i")), storage.MVCCWriteOptions{Txn: &txn, Stats: &stats},
 	); err != nil {
 		t.Fatal(err)
 	}
@@ -179,7 +179,7 @@ func TestCmdRevertRange(t *testing.T) {
 		key := roachpb.Key(fmt.Sprintf("%04d", i))
 		var value roachpb.Value
 		value.SetString(fmt.Sprintf("%d-rev-b", i))
-		if err := storage.MVCCPut(ctx, eng, &stats, key, tsC.Add(10, int32(i%5)), hlc.ClockTimestamp{}, value, nil); err != nil {
+		if err := storage.MVCCPut(ctx, eng, key, tsC.Add(10, int32(i%5)), value, storage.MVCCWriteOptions{Stats: &stats}); err != nil {
 			t.Fatalf("writing key %s: %+v", key, err)
 		}
 	}

--- a/pkg/kv/kvserver/batcheval/cmd_scan_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_scan_test.go
@@ -88,7 +88,7 @@ func testScanReverseScanInner(
 
 	// Write to k1 and k2.
 	for _, k := range []roachpb.Key{k1, k2} {
-		err := storage.MVCCPut(ctx, eng, nil, k, ts, hlc.ClockTimestamp{}, roachpb.MakeValueFromString("value-"+string(k)), nil)
+		err := storage.MVCCPut(ctx, eng, k, ts, roachpb.MakeValueFromString("value-"+string(k)), storage.MVCCWriteOptions{})
 		require.NoError(t, err)
 	}
 
@@ -185,7 +185,7 @@ func TestScanReverseScanWholeRows(t *testing.T) {
 	for r := 0; r < 2; r++ {
 		for cf := uint32(0); cf < 3; cf++ {
 			key := makeRowKey(t, r, cf)
-			err := storage.MVCCPut(ctx, eng, nil, key, ts, hlc.ClockTimestamp{}, roachpb.MakeValueFromString("value"), nil)
+			err := storage.MVCCPut(ctx, eng, key, ts, roachpb.MakeValueFromString("value"), storage.MVCCWriteOptions{})
 			require.NoError(t, err)
 			rowKeys = append(rowKeys, key)
 		}

--- a/pkg/kv/kvserver/batcheval/cmd_truncate_log_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_truncate_log_test.go
@@ -31,8 +31,8 @@ func putTruncatedState(
 ) {
 	key := keys.RaftTruncatedStateKey(rangeID)
 	if err := storage.MVCCPutProto(
-		context.Background(), eng, nil, key,
-		hlc.Timestamp{}, hlc.ClockTimestamp{}, nil /* txn */, &truncState,
+		context.Background(), eng, key,
+		hlc.Timestamp{}, &truncState, storage.MVCCWriteOptions{},
 	); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/kv/kvserver/batcheval/intent_test.go
+++ b/pkg/kv/kvserver/batcheval/intent_test.go
@@ -130,9 +130,9 @@ func TestCollectIntentsUsesSameIterator(t *testing.T) {
 				txn := roachpb.MakeTransaction("test", key, roachpb.NormalUserPriority, ts, 0, 1)
 				var err error
 				if delete {
-					_, err = storage.MVCCDelete(ctx, db, nil, key, ts, hlc.ClockTimestamp{}, &txn)
+					_, err = storage.MVCCDelete(ctx, db, key, ts, storage.MVCCWriteOptions{Txn: &txn})
 				} else {
-					err = storage.MVCCPut(ctx, db, nil, key, ts, hlc.ClockTimestamp{}, val, &txn)
+					err = storage.MVCCPut(ctx, db, key, ts, val, storage.MVCCWriteOptions{Txn: &txn})
 				}
 				require.NoError(t, err)
 

--- a/pkg/kv/kvserver/batcheval/transaction_test.go
+++ b/pkg/kv/kvserver/batcheval/transaction_test.go
@@ -85,7 +85,7 @@ func TestUpdateAbortSpan(t *testing.T) {
 	type evalFn func(storage.ReadWriter, EvalContext, *enginepb.MVCCStats) error
 	addIntent := func(b storage.ReadWriter, _ EvalContext, ms *enginepb.MVCCStats) error {
 		val := roachpb.MakeValueFromString("val")
-		return storage.MVCCPut(ctx, b, ms, intentKey, txn.ReadTimestamp, hlc.ClockTimestamp{}, val, &txn)
+		return storage.MVCCPut(ctx, b, intentKey, txn.ReadTimestamp, val, storage.MVCCWriteOptions{Txn: &txn, Stats: ms})
 	}
 	addPrevAbortSpanEntry := func(b storage.ReadWriter, rec EvalContext, ms *enginepb.MVCCStats) error {
 		return UpdateAbortSpan(ctx, rec, b, ms, prevTxn.TxnMeta, true /* poison */)

--- a/pkg/kv/kvserver/client_merge_test.go
+++ b/pkg/kv/kvserver/client_merge_test.go
@@ -3888,7 +3888,7 @@ func TestStoreRangeMergeRaftSnapshot(t *testing.T) {
 			tombstoneKey := keys.RangeTombstoneKey(rangeID)
 			tombstoneValue := &roachpb.RangeTombstone{NextReplicaID: math.MaxInt32}
 			if err := storage.MVCCBlindPutProto(
-				context.Background(), &sst, nil, tombstoneKey, hlc.Timestamp{}, hlc.ClockTimestamp{}, tombstoneValue, nil,
+				context.Background(), &sst, tombstoneKey, hlc.Timestamp{}, tombstoneValue, storage.MVCCWriteOptions{},
 			); err != nil {
 				return err
 			}

--- a/pkg/kv/kvserver/consistency_queue_test.go
+++ b/pkg/kv/kvserver/consistency_queue_test.go
@@ -344,8 +344,8 @@ func TestCheckConsistencyInconsistent(t *testing.T) {
 	var val roachpb.Value
 	val.SetInt(42)
 	// Put an inconsistent key "e" to s2, and have s1 and s3 still agree.
-	require.NoError(t, storage.MVCCPut(context.Background(), s2.TODOEngine(), nil,
-		roachpb.Key("e"), tc.Server(0).Clock().Now(), hlc.ClockTimestamp{}, val, nil))
+	require.NoError(t, storage.MVCCPut(context.Background(), s2.TODOEngine(),
+		roachpb.Key("e"), tc.Server(0).Clock().Now(), val, storage.MVCCWriteOptions{}))
 
 	// Run consistency check again, this time it should find something.
 	resp = runConsistencyCheck()

--- a/pkg/kv/kvserver/gc/data_distribution_test.go
+++ b/pkg/kv/kvserver/gc/data_distribution_test.go
@@ -79,8 +79,8 @@ func (ds dataDistribution) setupTest(
 			if txn.WriteTimestamp.IsEmpty() {
 				txn.WriteTimestamp = ts
 			}
-			err := storage.MVCCPut(ctx, eng, &ms, kv.Key.Key, ts,
-				hlc.ClockTimestamp{}, roachpb.Value{RawBytes: kv.Value}, txn)
+			err := storage.MVCCPut(ctx, eng, kv.Key.Key, ts,
+				roachpb.Value{RawBytes: kv.Value}, storage.MVCCWriteOptions{Txn: txn, Stats: &ms})
 			require.NoError(t, err, "failed to insert value for key %s, value length=%d",
 				kv.Key.String(), len(kv.Value))
 		}

--- a/pkg/kv/kvserver/gc/gc_test.go
+++ b/pkg/kv/kvserver/gc/gc_test.go
@@ -135,7 +135,7 @@ func TestIntentAgeThresholdSetting(t *testing.T) {
 		WallTime: intentTs.Nanoseconds(),
 	}
 	txn := roachpb.MakeTransaction("txn", key, roachpb.NormalUserPriority, intentHlc, 1000, 0)
-	require.NoError(t, storage.MVCCPut(ctx, eng, nil, key, intentHlc, hlc.ClockTimestamp{}, value, &txn))
+	require.NoError(t, storage.MVCCPut(ctx, eng, key, intentHlc, value, storage.MVCCWriteOptions{Txn: &txn}))
 	require.NoError(t, eng.Flush())
 
 	// Prepare test fixtures for GC run.
@@ -196,7 +196,7 @@ func TestIntentCleanupBatching(t *testing.T) {
 		txn := roachpb.MakeTransaction("txn", key, roachpb.NormalUserPriority, intentHlc, 1000, 0)
 		for _, suffix := range objectKeys {
 			key := []byte{prefix, suffix}
-			require.NoError(t, storage.MVCCPut(ctx, eng, nil, key, intentHlc, hlc.ClockTimestamp{}, value, &txn))
+			require.NoError(t, storage.MVCCPut(ctx, eng, key, intentHlc, value, storage.MVCCWriteOptions{Txn: &txn}))
 		}
 		require.NoError(t, eng.Flush())
 	}

--- a/pkg/kv/kvserver/kvstorage/cluster_version.go
+++ b/pkg/kv/kvserver/kvstorage/cluster_version.go
@@ -35,12 +35,10 @@ func WriteClusterVersion(
 		if err := storage.MVCCPutProto(
 			ctx,
 			eng,
-			nil,
 			keys.DeprecatedStoreClusterVersionKey(),
 			hlc.Timestamp{},
-			hlc.ClockTimestamp{},
-			nil,
 			&cv,
+			storage.MVCCWriteOptions{},
 		); err != nil {
 			return err
 		}

--- a/pkg/kv/kvserver/kvstorage/destroy.go
+++ b/pkg/kv/kvserver/kvstorage/destroy.go
@@ -147,6 +147,6 @@ func DestroyReplica(
 
 	tombstone := roachpb.RangeTombstone{NextReplicaID: nextReplicaID}
 	// "Blind" because ms == nil and timestamp.IsEmpty().
-	return storage.MVCCBlindPutProto(ctx, writer, nil, tombstoneKey,
-		hlc.Timestamp{}, hlc.ClockTimestamp{}, &tombstone, nil)
+	return storage.MVCCBlindPutProto(ctx, writer, tombstoneKey,
+		hlc.Timestamp{}, &tombstone, storage.MVCCWriteOptions{})
 }

--- a/pkg/kv/kvserver/kvstorage/init.go
+++ b/pkg/kv/kvserver/kvstorage/init.go
@@ -62,12 +62,10 @@ func InitEngine(ctx context.Context, eng storage.Engine, ident roachpb.StoreIden
 	if err := storage.MVCCPutProto(
 		ctx,
 		batch,
-		nil,
 		keys.StoreIdentKey(),
 		hlc.Timestamp{},
-		hlc.ClockTimestamp{},
-		nil,
 		&ident,
+		storage.MVCCWriteOptions{},
 	); err != nil {
 		batch.Close()
 		return err

--- a/pkg/kv/kvserver/logstore/logstore.go
+++ b/pkg/kv/kvserver/logstore/logstore.go
@@ -379,6 +379,9 @@ func logAppend(
 		return prev, nil
 	}
 	var diff enginepb.MVCCStats
+	opts := storage.MVCCWriteOptions{
+		Stats: &diff,
+	}
 	value := valPool.Get().(*roachpb.Value)
 	value.RawBytes = value.RawBytes[:0]
 	defer valPool.Put(value)
@@ -392,9 +395,9 @@ func logAppend(
 		value.InitChecksum(key)
 		var err error
 		if ent.Index > prev.LastIndex {
-			err = storage.MVCCBlindPut(ctx, rw, &diff, key, hlc.Timestamp{}, hlc.ClockTimestamp{}, *value, nil /* txn */)
+			err = storage.MVCCBlindPut(ctx, rw, key, hlc.Timestamp{}, *value, opts)
 		} else {
-			err = storage.MVCCPut(ctx, rw, &diff, key, hlc.Timestamp{}, hlc.ClockTimestamp{}, *value, nil /* txn */)
+			err = storage.MVCCPut(ctx, rw, key, hlc.Timestamp{}, *value, opts)
 		}
 		if err != nil {
 			return RaftState{}, err
@@ -407,8 +410,8 @@ func logAppend(
 		for i := newLastIndex + 1; i <= prev.LastIndex; i++ {
 			// Note that the caller is in charge of deleting any sideloaded payloads
 			// (which they must only do *after* the batch has committed).
-			_, err := storage.MVCCDelete(ctx, rw, &diff, keys.RaftLogKeyFromPrefix(raftLogPrefix, i),
-				hlc.Timestamp{}, hlc.ClockTimestamp{}, nil)
+			_, err := storage.MVCCDelete(ctx, rw, keys.RaftLogKeyFromPrefix(raftLogPrefix, i),
+				hlc.Timestamp{}, opts)
 			if err != nil {
 				return RaftState{}, err
 			}

--- a/pkg/kv/kvserver/logstore/stateloader.go
+++ b/pkg/kv/kvserver/logstore/stateloader.go
@@ -103,16 +103,14 @@ func (sl StateLoader) SetRaftTruncatedState(
 	if (*truncState == roachpb.RaftTruncatedState{}) {
 		return errors.New("cannot persist empty RaftTruncatedState")
 	}
-	// "Blind" because ms == nil and timestamp.IsEmpty().
+	// "Blind" because opts.Stats == nil and timestamp.IsEmpty().
 	return storage.MVCCBlindPutProto(
 		ctx,
 		writer,
-		nil, /* ms */
 		sl.RaftTruncatedStateKey(),
-		hlc.Timestamp{},      /* timestamp */
-		hlc.ClockTimestamp{}, /* localTimestamp */
+		hlc.Timestamp{}, /* timestamp */
 		truncState,
-		nil, /* txn */
+		storage.MVCCWriteOptions{}, /* txn */
 	)
 }
 
@@ -134,16 +132,14 @@ func (sl StateLoader) LoadHardState(
 func (sl StateLoader) SetHardState(
 	ctx context.Context, writer storage.Writer, hs raftpb.HardState,
 ) error {
-	// "Blind" because ms == nil and timestamp.IsEmpty().
+	// "Blind" because opts.Stats == nil and timestamp.IsEmpty().
 	return storage.MVCCBlindPutProto(
 		ctx,
 		writer,
-		nil, /* ms */
 		sl.RaftHardStateKey(),
-		hlc.Timestamp{},      /* timestamp */
-		hlc.ClockTimestamp{}, /* localTimestamp */
+		hlc.Timestamp{}, /* timestamp */
 		&hs,
-		nil, /* txn */
+		storage.MVCCWriteOptions{}, /* opts */
 	)
 }
 
@@ -191,12 +187,10 @@ func (sl StateLoader) SetRaftReplicaID(
 	return storage.MVCCBlindPutProto(
 		ctx,
 		writer,
-		nil, /* ms */
 		sl.RaftReplicaIDKey(),
-		hlc.Timestamp{},      /* timestamp */
-		hlc.ClockTimestamp{}, /* localTimestamp */
+		hlc.Timestamp{}, /* timestamp */
 		&rid,
-		nil, /* txn */
+		storage.MVCCWriteOptions{}, /* opts */
 	)
 }
 

--- a/pkg/kv/kvserver/loqrecovery/apply.go
+++ b/pkg/kv/kvserver/loqrecovery/apply.go
@@ -266,7 +266,7 @@ func applyReplicaUpdate(
 		// A crude form of the intent resolution process: abort the
 		// transaction by deleting its record.
 		txnKey := keys.TransactionKey(res.Intent.Txn.Key, res.Intent.Txn.ID)
-		if _, err := storage.MVCCDelete(ctx, readWriter, &ms, txnKey, hlc.Timestamp{}, hlc.ClockTimestamp{}, nil); err != nil {
+		if _, err := storage.MVCCDelete(ctx, readWriter, txnKey, hlc.Timestamp{}, storage.MVCCWriteOptions{Stats: &ms}); err != nil {
 			return PrepareReplicaReport{}, err
 		}
 		update := roachpb.LockUpdate{
@@ -293,8 +293,8 @@ func applyReplicaUpdate(
 	newDesc.NextReplicaID = update.NextReplicaID
 
 	if err := storage.MVCCPutProto(
-		ctx, readWriter, &ms, key, clock.Now(),
-		hlc.ClockTimestamp{}, nil /* txn */, &newDesc,
+		ctx, readWriter, key, clock.Now(),
+		&newDesc, storage.MVCCWriteOptions{Stats: &ms},
 	); err != nil {
 		return PrepareReplicaReport{}, err
 	}

--- a/pkg/kv/kvserver/loqrecovery/apply_test.go
+++ b/pkg/kv/kvserver/loqrecovery/apply_test.go
@@ -92,7 +92,7 @@ func createEngineOrFatal(ctx context.Context, t *testing.T, uuid uuid.UUID, id i
 		StoreID:   roachpb.StoreID(id),
 	}
 	if err = storage.MVCCPutProto(
-		context.Background(), eng, nil, keys.StoreIdentKey(), hlc.Timestamp{}, hlc.ClockTimestamp{}, nil, &sIdent,
+		context.Background(), eng, keys.StoreIdentKey(), hlc.Timestamp{}, &sIdent, storage.MVCCWriteOptions{},
 	); err != nil {
 		t.Fatalf("failed to populate test store ident: %v", err)
 	}

--- a/pkg/kv/kvserver/loqrecovery/record.go
+++ b/pkg/kv/kvserver/loqrecovery/record.go
@@ -174,17 +174,17 @@ func writeNodeRecoveryResults(
 	actions loqrecoverypb.DeferredRecoveryActions,
 ) error {
 	var fullErr error
-	err := storage.MVCCPutProto(ctx, writer, nil, keys.StoreLossOfQuorumRecoveryStatusKey(),
-		hlc.Timestamp{}, hlc.ClockTimestamp{}, nil, &result)
+	err := storage.MVCCPutProto(ctx, writer, keys.StoreLossOfQuorumRecoveryStatusKey(),
+		hlc.Timestamp{}, &result, storage.MVCCWriteOptions{})
 	fullErr = errors.Wrap(err, "failed to write loss of quorum recovery plan application status")
 	if !actions.Empty() {
-		err = storage.MVCCPutProto(ctx, writer, nil, keys.StoreLossOfQuorumRecoveryCleanupActionsKey(),
-			hlc.Timestamp{}, hlc.ClockTimestamp{}, nil, &actions)
+		err = storage.MVCCPutProto(ctx, writer, keys.StoreLossOfQuorumRecoveryCleanupActionsKey(),
+			hlc.Timestamp{}, &actions, storage.MVCCWriteOptions{})
 		fullErr = errors.CombineErrors(fullErr,
 			errors.Wrap(err, "failed to write loss of quorum recovery cleanup action"))
 	} else {
-		_, err = storage.MVCCDelete(ctx, writer, nil, keys.StoreLossOfQuorumRecoveryCleanupActionsKey(),
-			hlc.Timestamp{}, hlc.ClockTimestamp{}, nil)
+		_, err = storage.MVCCDelete(ctx, writer, keys.StoreLossOfQuorumRecoveryCleanupActionsKey(),
+			hlc.Timestamp{}, storage.MVCCWriteOptions{})
 		fullErr = errors.CombineErrors(fullErr,
 			errors.Wrap(err, "failed to clean loss of quorum recovery cleanup action"))
 	}
@@ -222,7 +222,7 @@ func ReadCleanupActionsInfo(
 // RemoveCleanupActionsInfo removes cleanup actions info if it is present in the
 // reader.
 func RemoveCleanupActionsInfo(ctx context.Context, writer storage.ReadWriter) error {
-	_, err := storage.MVCCDelete(ctx, writer, nil, keys.StoreLossOfQuorumRecoveryCleanupActionsKey(),
-		hlc.Timestamp{}, hlc.ClockTimestamp{}, nil)
+	_, err := storage.MVCCDelete(ctx, writer, keys.StoreLossOfQuorumRecoveryCleanupActionsKey(),
+		hlc.Timestamp{}, storage.MVCCWriteOptions{})
 	return err
 }

--- a/pkg/kv/kvserver/loqrecovery/recovery_env_test.go
+++ b/pkg/kv/kvserver/loqrecovery/recovery_env_test.go
@@ -327,7 +327,7 @@ func (e *quorumRecoveryEnv) handleReplicationData(t *testing.T, d datadriven.Tes
 
 		eng := e.getOrCreateStore(ctx, t, replica.StoreID, replica.NodeID)
 		if err = storage.MVCCPutProto(
-			ctx, eng, nil, key, clock.Now(), hlc.ClockTimestamp{}, nil /* txn */, &desc,
+			ctx, eng, key, clock.Now(), &desc, storage.MVCCWriteOptions{},
 		); err != nil {
 			t.Fatalf("failed to write range descriptor into store: %v", err)
 		}
@@ -621,7 +621,7 @@ func (e *quorumRecoveryEnv) getOrCreateStore(
 			StoreID:   storeID,
 		}
 		if err = storage.MVCCPutProto(
-			context.Background(), eng, nil, keys.StoreIdentKey(), hlc.Timestamp{}, hlc.ClockTimestamp{}, nil, &sIdent,
+			context.Background(), eng, keys.StoreIdentKey(), hlc.Timestamp{}, &sIdent, storage.MVCCWriteOptions{},
 		); err != nil {
 			t.Fatalf("failed to populate test store ident: %v", err)
 		}

--- a/pkg/kv/kvserver/rangefeed/catchup_scan_bench_test.go
+++ b/pkg/kv/kvserver/rangefeed/catchup_scan_bench_test.go
@@ -307,7 +307,7 @@ func setupData(
 		value := roachpb.MakeValueFromBytes(randutil.RandBytes(rng, opts.valueBytes))
 		value.InitChecksum(key)
 		ts := hlc.Timestamp{WallTime: int64((pos + 1) * 5)}
-		if err := storage.MVCCPut(ctx, batch, nil /* ms */, key, ts, hlc.ClockTimestamp{}, value, nil); err != nil {
+		if err := storage.MVCCPut(ctx, batch, key, ts, value, storage.MVCCWriteOptions{}); err != nil {
 			b.Fatal(err)
 		}
 	}

--- a/pkg/kv/kvserver/rangefeed/catchup_scan_test.go
+++ b/pkg/kv/kvserver/rangefeed/catchup_scan_test.go
@@ -102,12 +102,12 @@ func TestCatchupScan(t *testing.T) {
 	// Put with no intent.
 	for _, kv := range []storage.MVCCKeyValue{kv1_1_1, kv1_2_2, kv1_3_3, kv2_1_1, kv2_2_2, kv2_5_3} {
 		v := roachpb.Value{RawBytes: kv.Value}
-		if err := storage.MVCCPut(ctx, eng, nil, kv.Key.Key, kv.Key.Timestamp, hlc.ClockTimestamp{}, v, nil); err != nil {
+		if err := storage.MVCCPut(ctx, eng, kv.Key.Key, kv.Key.Timestamp, v, storage.MVCCWriteOptions{}); err != nil {
 			t.Fatal(err)
 		}
 	}
 	// Put with an intent.
-	if err := storage.MVCCPut(ctx, eng, nil, kv1_4_4.Key.Key, txn.ReadTimestamp, hlc.ClockTimestamp{}, val, &txn); err != nil {
+	if err := storage.MVCCPut(ctx, eng, kv1_4_4.Key.Key, txn.ReadTimestamp, val, storage.MVCCWriteOptions{Txn: &txn}); err != nil {
 		t.Fatal(err)
 	}
 	testutils.RunTrueAndFalse(t, "withDiff", func(t *testing.T, withDiff bool) {
@@ -151,7 +151,7 @@ func TestCatchupScanInlineError(t *testing.T) {
 	defer eng.Close()
 
 	// Write an inline value.
-	require.NoError(t, storage.MVCCPut(ctx, eng, nil, roachpb.Key("inline"), hlc.Timestamp{}, hlc.ClockTimestamp{}, roachpb.MakeValueFromString("foo"), nil))
+	require.NoError(t, storage.MVCCPut(ctx, eng, roachpb.Key("inline"), hlc.Timestamp{}, roachpb.MakeValueFromString("foo"), storage.MVCCWriteOptions{}))
 
 	// Run a catchup scan across the span and watch it error.
 	span := roachpb.Span{Key: keys.LocalMax, EndKey: keys.MaxKey}
@@ -183,15 +183,15 @@ func TestCatchupScanSeesOldIntent(t *testing.T) {
 	tsIntent := tsCutoff.Add(-10, 0)          // the intent is below the lower bound
 	tsVersionInWindow := tsCutoff.Add(10, 0)  // an unrelated version is above the lower bound
 
-	require.NoError(t, storage.MVCCPut(ctx, eng, nil, roachpb.Key("b"),
-		tsVersionInWindow, hlc.ClockTimestamp{}, roachpb.MakeValueFromString("foo"), nil))
+	require.NoError(t, storage.MVCCPut(ctx, eng, roachpb.Key("b"),
+		tsVersionInWindow, roachpb.MakeValueFromString("foo"), storage.MVCCWriteOptions{}))
 
 	txn := roachpb.MakeTransaction("foo", roachpb.Key("d"), roachpb.NormalUserPriority, tsIntent, 100, 0)
-	require.NoError(t, storage.MVCCPut(ctx, eng, nil, roachpb.Key("d"),
-		tsIntent, hlc.ClockTimestamp{}, roachpb.MakeValueFromString("intent"), &txn))
+	require.NoError(t, storage.MVCCPut(ctx, eng, roachpb.Key("d"),
+		tsIntent, roachpb.MakeValueFromString("intent"), storage.MVCCWriteOptions{Txn: &txn}))
 
-	require.NoError(t, storage.MVCCPut(ctx, eng, nil, roachpb.Key("e"),
-		tsVersionInWindow, hlc.ClockTimestamp{}, roachpb.MakeValueFromString("bar"), nil))
+	require.NoError(t, storage.MVCCPut(ctx, eng, roachpb.Key("e"),
+		tsVersionInWindow, roachpb.MakeValueFromString("bar"), storage.MVCCWriteOptions{}))
 
 	// Run a catchup scan across the span and watch it succeed.
 	span := roachpb.Span{Key: keys.LocalMax, EndKey: keys.MaxKey}

--- a/pkg/kv/kvserver/rangefeed/task_test.go
+++ b/pkg/kv/kvserver/rangefeed/task_test.go
@@ -297,7 +297,7 @@ func TestInitResolvedTSScan(t *testing.T) {
 		}
 		for _, op := range testData {
 			kv := op.kv
-			err := storage.MVCCPut(ctx, engine, nil, kv.Key.Key, kv.Key.Timestamp, hlc.ClockTimestamp{}, roachpb.Value{RawBytes: kv.Value}, op.txn)
+			err := storage.MVCCPut(ctx, engine, kv.Key.Key, kv.Key.Timestamp, roachpb.Value{RawBytes: kv.Value}, storage.MVCCWriteOptions{Txn: op.txn})
 			require.NoError(t, err)
 		}
 		return engine

--- a/pkg/kv/kvserver/rditer/replica_data_iter_test.go
+++ b/pkg/kv/kvserver/rditer/replica_data_iter_test.go
@@ -126,7 +126,7 @@ func createRangeData(
 	})
 
 	for _, pk := range ps {
-		require.NoError(t, storage.MVCCPut(ctx, eng, nil, pk.Key, pk.Timestamp, localTS, value, nil))
+		require.NoError(t, storage.MVCCPut(ctx, eng, pk.Key, pk.Timestamp, value, storage.MVCCWriteOptions{LocalTimestamp: localTS}))
 	}
 	for _, rk := range rs {
 		require.NoError(t, eng.PutMVCCRangeKey(rk, storage.MVCCValue{}))

--- a/pkg/kv/kvserver/readsummary/persist.go
+++ b/pkg/kv/kvserver/readsummary/persist.go
@@ -44,5 +44,5 @@ func Set(
 	sum *rspb.ReadSummary,
 ) error {
 	key := keys.RangePriorReadSummaryKey(rangeID)
-	return storage.MVCCPutProto(ctx, readWriter, ms, key, hlc.Timestamp{}, hlc.ClockTimestamp{}, nil, sum)
+	return storage.MVCCPutProto(ctx, readWriter, key, hlc.Timestamp{}, sum, storage.MVCCWriteOptions{Stats: ms})
 }

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -1378,7 +1378,7 @@ func (r *Replica) GetLastReplicaGCTimestamp(ctx context.Context) (hlc.Timestamp,
 func (r *Replica) setLastReplicaGCTimestamp(ctx context.Context, timestamp hlc.Timestamp) error {
 	key := keys.RangeLastReplicaGCTimestampKey(r.RangeID)
 	return storage.MVCCPutProto(
-		ctx, r.store.TODOEngine(), nil, key, hlc.Timestamp{}, hlc.ClockTimestamp{}, nil, &timestamp)
+		ctx, r.store.TODOEngine(), key, hlc.Timestamp{}, &timestamp, storage.MVCCWriteOptions{})
 }
 
 // getQueueLastProcessed returns the last processed timestamp for the

--- a/pkg/kv/kvserver/replica_consistency_test.go
+++ b/pkg/kv/kvserver/replica_consistency_test.go
@@ -306,7 +306,7 @@ func TestReplicaChecksumSHA512(t *testing.T) {
 			require.NoError(t, storage.MVCCDeleteRangeUsingTombstone(
 				ctx, eng, nil, key, endKey, ts, localTS, nil, nil, false, 0, nil))
 		} else {
-			require.NoError(t, storage.MVCCPut(ctx, eng, nil, key, ts, localTS, value, nil))
+			require.NoError(t, storage.MVCCPut(ctx, eng, key, ts, value, storage.MVCCWriteOptions{LocalTimestamp: localTS}))
 		}
 
 		rd, err = CalcReplicaDigest(ctx, desc, eng, kvpb.ChecksumMode_CHECK_FULL, unlim)

--- a/pkg/kv/kvserver/replica_evaluate_test.go
+++ b/pkg/kv/kvserver/replica_evaluate_test.go
@@ -734,8 +734,8 @@ func writeABCDEFIntents(t *testing.T, d *data, txn *roachpb.Transaction) {
 func writeABCDEFWith(t *testing.T, eng storage.Engine, ts hlc.Timestamp, txn *roachpb.Transaction) {
 	for _, k := range []string{"a", "b", "c", "d", "e", "f"} {
 		require.NoError(t, storage.MVCCPut(
-			context.Background(), eng, nil /* ms */, roachpb.Key(k), ts, hlc.ClockTimestamp{},
-			roachpb.MakeValueFromString("value-"+k), txn))
+			context.Background(), eng, roachpb.Key(k), ts,
+			roachpb.MakeValueFromString("value-"+k), storage.MVCCWriteOptions{Txn: txn}))
 	}
 }
 

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -2429,12 +2429,10 @@ func handleTruncatedStateBelowRaftPreApply(
 	if err := storage.MVCCPutProto(
 		ctx,
 		readWriter,
-		nil, /* ms */
 		prefixBuf.RaftTruncatedStateKey(),
 		hlc.Timestamp{},
-		hlc.ClockTimestamp{},
-		nil, /* txn */
 		suggestedTruncatedState,
+		storage.MVCCWriteOptions{},
 	); err != nil {
 		return false, errors.Wrap(err, "unable to write RaftTruncatedState")
 	}

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -1793,8 +1793,8 @@ func TestOptimizePuts(t *testing.T) {
 			require.NoError(t, storage.MVCCDeleteRangeUsingTombstone(ctx, tc.engine, nil,
 				c.exKey, c.exEndKey, hlc.MinTimestamp, hlc.ClockTimestamp{}, nil, nil, false, 0, nil))
 		} else if c.exKey != nil {
-			require.NoError(t, storage.MVCCPut(ctx, tc.engine, nil, c.exKey,
-				hlc.Timestamp{}, hlc.ClockTimestamp{}, roachpb.MakeValueFromString("foo"), nil))
+			require.NoError(t, storage.MVCCPut(ctx, tc.engine, c.exKey,
+				hlc.Timestamp{}, roachpb.MakeValueFromString("foo"), storage.MVCCWriteOptions{}))
 		}
 		batch := kvpb.BatchRequest{}
 		for _, r := range c.reqs {
@@ -3453,7 +3453,7 @@ func TestReplicaAbortSpanReadError(t *testing.T) {
 
 	// Overwrite Abort span entry with garbage for the last op.
 	key := keys.AbortSpanKey(tc.repl.RangeID, txn.ID)
-	err := storage.MVCCPut(ctx, tc.engine, nil, key, hlc.Timestamp{}, hlc.ClockTimestamp{}, roachpb.MakeValueFromString("never read in this test"), nil)
+	err := storage.MVCCPut(ctx, tc.engine, key, hlc.Timestamp{}, roachpb.MakeValueFromString("never read in this test"), storage.MVCCWriteOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -4531,7 +4531,7 @@ func TestEndTxnWithErrors(t *testing.T) {
 			existTxnRecord := existTxn.AsRecord()
 			txnKey := keys.TransactionKey(test.key, txn.ID)
 			if err := storage.MVCCPutProto(
-				ctx, tc.repl.store.TODOEngine(), nil, txnKey, hlc.Timestamp{}, hlc.ClockTimestamp{}, nil, &existTxnRecord,
+				ctx, tc.repl.store.TODOEngine(), txnKey, hlc.Timestamp{}, &existTxnRecord, storage.MVCCWriteOptions{},
 			); err != nil {
 				t.Fatal(err)
 			}
@@ -4574,7 +4574,7 @@ func TestEndTxnWithErrorAndSyncIntentResolution(t *testing.T) {
 	existTxn.Status = roachpb.ABORTED
 	existTxnRec := existTxn.AsRecord()
 	txnKey := keys.TransactionKey(txn.Key, txn.ID)
-	err := storage.MVCCPutProto(ctx, tc.repl.store.TODOEngine(), nil, txnKey, hlc.Timestamp{}, hlc.ClockTimestamp{}, nil, &existTxnRec)
+	err := storage.MVCCPutProto(ctx, tc.repl.store.TODOEngine(), txnKey, hlc.Timestamp{}, &existTxnRec, storage.MVCCWriteOptions{})
 	require.NoError(t, err)
 
 	// End the transaction, verify expected error, shouldn't deadlock.
@@ -11141,7 +11141,7 @@ func TestReplicaPushed1PC(t *testing.T) {
 	// Write a value outside the transaction.
 	tc.manualClock.Advance(10)
 	ts2 := tc.Clock().Now()
-	if err := storage.MVCCPut(ctx, tc.engine, nil, k, ts2, hlc.ClockTimestamp{}, roachpb.MakeValueFromString("one"), nil); err != nil {
+	if err := storage.MVCCPut(ctx, tc.engine, k, ts2, roachpb.MakeValueFromString("one"), storage.MVCCWriteOptions{}); err != nil {
 		t.Fatalf("writing interfering value: %+v", err)
 	}
 
@@ -13729,10 +13729,10 @@ func setMockPutWithEstimates(containsEstimatesDelta int64) (undo func()) {
 		ctx context.Context, readWriter storage.ReadWriter, cArgs batcheval.CommandArgs, _ kvpb.Response,
 	) (result.Result, error) {
 		args := cArgs.Args.(*kvpb.PutRequest)
-		ms := cArgs.Stats
-		ms.ContainsEstimates += containsEstimatesDelta
+		opts := storage.MVCCWriteOptions{Txn: cArgs.Header.Txn, Stats: cArgs.Stats}
+		opts.Stats.ContainsEstimates += containsEstimatesDelta
 		ts := cArgs.Header.Timestamp
-		return result.Result{}, storage.MVCCBlindPut(ctx, readWriter, ms, args.Key, ts, hlc.ClockTimestamp{}, args.Value, cArgs.Header.Txn)
+		return result.Result{}, storage.MVCCBlindPut(ctx, readWriter, args.Key, ts, args.Value, opts)
 	}
 
 	batcheval.UnregisterCommand(kvpb.Put)

--- a/pkg/kv/kvserver/stateloader/stateloader.go
+++ b/pkg/kv/kvserver/stateloader/stateloader.go
@@ -165,8 +165,8 @@ func (rsl StateLoader) LoadLease(
 func (rsl StateLoader) SetLease(
 	ctx context.Context, readWriter storage.ReadWriter, ms *enginepb.MVCCStats, lease roachpb.Lease,
 ) error {
-	return storage.MVCCPutProto(ctx, readWriter, ms, rsl.RangeLeaseKey(),
-		hlc.Timestamp{}, hlc.ClockTimestamp{}, nil, &lease)
+	return storage.MVCCPutProto(ctx, readWriter, rsl.RangeLeaseKey(),
+		hlc.Timestamp{}, &lease, storage.MVCCWriteOptions{Stats: ms})
 }
 
 // LoadRangeAppliedState loads the Range applied state.
@@ -219,8 +219,8 @@ func (rsl StateLoader) SetRangeAppliedState(
 	// The RangeAppliedStateKey is not included in stats. This is also reflected
 	// in ComputeStats.
 	ms := (*enginepb.MVCCStats)(nil)
-	return storage.MVCCPutProto(ctx, readWriter, ms, rsl.RangeAppliedStateKey(),
-		hlc.Timestamp{}, hlc.ClockTimestamp{}, nil, as)
+	return storage.MVCCPutProto(ctx, readWriter, rsl.RangeAppliedStateKey(),
+		hlc.Timestamp{}, as, storage.MVCCWriteOptions{Stats: ms})
 }
 
 // SetMVCCStats overwrites the MVCC stats. This needs to perform a read on the
@@ -273,8 +273,8 @@ func (rsl StateLoader) SetGCThreshold(
 	if threshold == nil {
 		return errors.New("cannot persist nil GCThreshold")
 	}
-	return storage.MVCCPutProto(ctx, readWriter, ms, rsl.RangeGCThresholdKey(),
-		hlc.Timestamp{}, hlc.ClockTimestamp{}, nil, threshold)
+	return storage.MVCCPutProto(ctx, readWriter, rsl.RangeGCThresholdKey(),
+		hlc.Timestamp{}, threshold, storage.MVCCWriteOptions{Stats: ms})
 }
 
 // LoadGCHint loads GC hint.
@@ -297,8 +297,8 @@ func (rsl StateLoader) SetGCHint(
 	if hint == nil {
 		return false, errors.New("cannot persist nil GCHint")
 	}
-	if err := storage.MVCCPutProto(ctx, readWriter, ms, rsl.RangeGCHintKey(),
-		hlc.Timestamp{}, hlc.ClockTimestamp{}, nil, hint); err != nil {
+	if err := storage.MVCCPutProto(ctx, readWriter, rsl.RangeGCHintKey(),
+		hlc.Timestamp{}, hint, storage.MVCCWriteOptions{Stats: ms}); err != nil {
 		return false, err
 	}
 	return true, nil
@@ -321,8 +321,8 @@ func (rsl StateLoader) SetVersion(
 	ms *enginepb.MVCCStats,
 	version *roachpb.Version,
 ) error {
-	return storage.MVCCPutProto(ctx, readWriter, ms, rsl.RangeVersionKey(),
-		hlc.Timestamp{}, hlc.ClockTimestamp{}, nil, version)
+	return storage.MVCCPutProto(ctx, readWriter, rsl.RangeVersionKey(),
+		hlc.Timestamp{}, version, storage.MVCCWriteOptions{Stats: ms})
 }
 
 // UninitializedReplicaState returns the ReplicaState of an uninitialized

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -2547,12 +2547,10 @@ func (s *Store) WriteLastUpTimestamp(ctx context.Context, time hlc.Timestamp) er
 	return storage.MVCCPutProto(
 		ctx,
 		s.TODOEngine(), // TODO(sep-raft-log): probably state engine
-		nil,
 		keys.StoreLastUpKey(),
 		hlc.Timestamp{},
-		hlc.ClockTimestamp{},
-		nil,
 		&time,
+		storage.MVCCWriteOptions{},
 	)
 }
 
@@ -2583,12 +2581,10 @@ func (s *Store) WriteHLCUpperBound(ctx context.Context, time int64) error {
 	if err := storage.MVCCPutProto(
 		ctx,
 		batch,
-		nil,
 		keys.StoreHLCUpperBoundKey(),
 		hlc.Timestamp{},
-		hlc.ClockTimestamp{},
-		nil,
 		&ts,
+		storage.MVCCWriteOptions{},
 	); err != nil {
 		return err
 	}

--- a/pkg/kv/kvserver/store_init.go
+++ b/pkg/kv/kvserver/store_init.go
@@ -168,24 +168,24 @@ func WriteInitialClusterData(
 
 		// Range descriptor.
 		if err := storage.MVCCPutProto(
-			ctx, batch, nil /* ms */, keys.RangeDescriptorKey(desc.StartKey),
-			now, hlc.ClockTimestamp{}, nil /* txn */, desc,
+			ctx, batch, keys.RangeDescriptorKey(desc.StartKey),
+			now, desc, storage.MVCCWriteOptions{},
 		); err != nil {
 			return err
 		}
 
 		// Replica GC timestamp.
 		if err := storage.MVCCPutProto(
-			ctx, batch, nil /* ms */, keys.RangeLastReplicaGCTimestampKey(desc.RangeID),
-			hlc.Timestamp{}, hlc.ClockTimestamp{}, nil /* txn */, &now,
+			ctx, batch, keys.RangeLastReplicaGCTimestampKey(desc.RangeID),
+			hlc.Timestamp{}, &now, storage.MVCCWriteOptions{},
 		); err != nil {
 			return err
 		}
 		// Range addressing for meta2.
 		meta2Key := keys.RangeMetaKey(endKey)
 		if err := storage.MVCCPutProto(
-			ctx, batch, firstRangeMS, meta2Key.AsRawKey(),
-			now, hlc.ClockTimestamp{}, nil /* txn */, desc,
+			ctx, batch, meta2Key.AsRawKey(),
+			now, desc, storage.MVCCWriteOptions{Stats: firstRangeMS},
 		); err != nil {
 			return err
 		}
@@ -195,7 +195,7 @@ func WriteInitialClusterData(
 			// Range addressing for meta1.
 			meta1Key := keys.RangeMetaKey(keys.RangeMetaKey(roachpb.RKeyMax))
 			if err := storage.MVCCPutProto(
-				ctx, batch, nil /* ms */, meta1Key.AsRawKey(), now, hlc.ClockTimestamp{}, nil /* txn */, desc,
+				ctx, batch, meta1Key.AsRawKey(), now, desc, storage.MVCCWriteOptions{},
 			); err != nil {
 				return err
 			}
@@ -206,7 +206,7 @@ func WriteInitialClusterData(
 			// Initialize the checksums.
 			kv.Value.InitChecksum(kv.Key)
 			if err := storage.MVCCPut(
-				ctx, batch, nil /* ms */, kv.Key, now, hlc.ClockTimestamp{}, kv.Value, nil, /* txn */
+				ctx, batch, kv.Key, now, kv.Value, storage.MVCCWriteOptions{},
 			); err != nil {
 				return err
 			}

--- a/pkg/kv/kvserver/store_snapshot.go
+++ b/pkg/kv/kvserver/store_snapshot.go
@@ -1354,7 +1354,7 @@ func SendEmptySnapshot(
 	var ms enginepb.MVCCStats
 	// Seed an empty range into the new engine.
 	if err := storage.MVCCPutProto(
-		ctx, eng, &ms, keys.RangeDescriptorKey(desc.StartKey), now, hlc.ClockTimestamp{}, nil /* txn */, &desc,
+		ctx, eng, keys.RangeDescriptorKey(desc.StartKey), now, &desc, storage.MVCCWriteOptions{Stats: &ms},
 	); err != nil {
 		return err
 	}

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -371,12 +371,10 @@ func TestIterateIDPrefixKeys(t *testing.T) {
 			if err := storage.MVCCPut(
 				ctx,
 				eng,
-				nil, /* ms */
 				key,
 				hlc.Timestamp{},
-				hlc.ClockTimestamp{},
 				roachpb.MakeValueFromString("fake value for "+key.String()),
-				nil, /* txn */
+				storage.MVCCWriteOptions{},
 			); err != nil {
 				t.Fatal(err)
 			}
@@ -408,7 +406,7 @@ func TestIterateIDPrefixKeys(t *testing.T) {
 
 			t.Logf("writing tombstone at rangeID=%d", rangeID)
 			if err := storage.MVCCPutProto(
-				ctx, eng, nil /* ms */, keys.RangeTombstoneKey(rangeID), hlc.Timestamp{}, hlc.ClockTimestamp{}, nil /* txn */, &tombstone,
+				ctx, eng, keys.RangeTombstoneKey(rangeID), hlc.Timestamp{}, &tombstone, storage.MVCCWriteOptions{},
 			); err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/kv/kvserver/stores.go
+++ b/pkg/kv/kvserver/stores.go
@@ -297,7 +297,7 @@ func (ls *Stores) updateBootstrapInfoLocked(bi *gossip.BootstrapInfo) error {
 	ls.storeMap.Range(func(k int64, v unsafe.Pointer) bool {
 		s := (*Store)(v)
 		// TODO(sep-raft-log): see ReadBootstrapInfo.
-		err = storage.MVCCPutProto(ctx, s.TODOEngine(), nil, keys.StoreGossipKey(), hlc.Timestamp{}, hlc.ClockTimestamp{}, nil, bi)
+		err = storage.MVCCPutProto(ctx, s.TODOEngine(), keys.StoreGossipKey(), hlc.Timestamp{}, bi, storage.MVCCWriteOptions{})
 		return err == nil
 	})
 	return err

--- a/pkg/kv/kvserver/txn_wait_queue_test.go
+++ b/pkg/kv/kvserver/txn_wait_queue_test.go
@@ -39,9 +39,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func writeTxnRecord(ctx context.Context, tc *testContext, txn *roachpb.Transaction) error {
-	key := keys.TransactionKey(txn.Key, txn.ID)
-	return storage.MVCCPutProto(ctx, tc.store.TODOEngine(), nil, key, hlc.Timestamp{}, hlc.ClockTimestamp{}, nil, txn)
+func writeTxnRecord(ctx context.Context, tc *testContext, txnRecord *roachpb.Transaction) error {
+	key := keys.TransactionKey(txnRecord.Key, txnRecord.ID)
+	return storage.MVCCPutProto(ctx, tc.store.TODOEngine(), key, hlc.Timestamp{}, txnRecord, storage.MVCCWriteOptions{})
 }
 
 // createTxnForPushQueue creates a txn struct and writes a "fake"

--- a/pkg/server/node_test.go
+++ b/pkg/server/node_test.go
@@ -271,7 +271,7 @@ func TestCorruptedClusterID(t *testing.T) {
 		StoreID:   1,
 	}
 	if err := storage.MVCCPutProto(
-		ctx, e, nil /* ms */, keys.StoreIdentKey(), hlc.Timestamp{}, hlc.ClockTimestamp{}, nil /* txn */, &sIdent,
+		ctx, e, keys.StoreIdentKey(), hlc.Timestamp{}, &sIdent, storage.MVCCWriteOptions{},
 	); err != nil {
 		t.Fatal(err)
 	}
@@ -865,8 +865,8 @@ func TestDiskStatsMap(t *testing.T) {
 	engineIDs := []roachpb.StoreID{10, 5}
 	for i := range engines {
 		ident := roachpb.StoreIdent{StoreID: engineIDs[i]}
-		require.NoError(t, storage.MVCCBlindPutProto(ctx, engines[i], nil, keys.StoreIdentKey(),
-			hlc.Timestamp{}, hlc.ClockTimestamp{}, &ident, nil))
+		require.NoError(t, storage.MVCCBlindPutProto(ctx, engines[i], keys.StoreIdentKey(),
+			hlc.Timestamp{}, &ident, storage.MVCCWriteOptions{}))
 	}
 	var dsm diskStatsMap
 	clusterProvisionedBW := int64(150)

--- a/pkg/server/node_tombstone_storage.go
+++ b/pkg/server/node_tombstone_storage.go
@@ -136,7 +136,7 @@ func (s *nodeTombstoneStorage) SetDecommissioned(
 		}
 
 		if err := storage.MVCCPut(
-			ctx, eng, nil /* ms */, k, hlc.Timestamp{}, hlc.ClockTimestamp{}, v, nil, /* txn */
+			ctx, eng, k, hlc.Timestamp{}, v, storage.MVCCWriteOptions{},
 		); err != nil {
 			return err
 		}

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -482,9 +482,8 @@ func TestClusterIDMismatch(t *testing.T) {
 			StoreID:   roachpb.StoreID(i + 1),
 		}
 		if err := storage.MVCCPutProto(
-			context.Background(), e, nil, keys.StoreIdentKey(), hlc.Timestamp{}, hlc.ClockTimestamp{}, nil, &sIdent,
+			context.Background(), e, keys.StoreIdentKey(), hlc.Timestamp{}, &sIdent, storage.MVCCWriteOptions{},
 		); err != nil {
-
 			t.Fatal(err)
 		}
 		engines[i] = e
@@ -1081,8 +1080,8 @@ func TestAssertEnginesEmpty(t *testing.T) {
 
 	require.NoError(t, assertEnginesEmpty([]storage.Engine{eng}))
 
-	require.NoError(t, storage.MVCCPutProto(ctx, eng, nil, keys.DeprecatedStoreClusterVersionKey(),
-		hlc.Timestamp{}, hlc.ClockTimestamp{}, nil, &roachpb.Version{Major: 21, Minor: 1, Internal: 122}))
+	require.NoError(t, storage.MVCCPutProto(ctx, eng, keys.DeprecatedStoreClusterVersionKey(),
+		hlc.Timestamp{}, &roachpb.Version{Major: 21, Minor: 1, Internal: 122}, storage.MVCCWriteOptions{}))
 	require.NoError(t, assertEnginesEmpty([]storage.Engine{eng}))
 
 	batch := eng.NewBatch()

--- a/pkg/server/settings_cache.go
+++ b/pkg/server/settings_cache.go
@@ -102,7 +102,7 @@ func storeCachedSettingsKVs(ctx context.Context, eng storage.Engine, kvs []roach
 	for _, kv := range kvs {
 		kv.Value.Timestamp = hlc.Timestamp{} // nb: Timestamp is not part of checksum
 		if err := storage.MVCCPut(
-			ctx, batch, nil, keys.StoreCachedSettingsKey(kv.Key), hlc.Timestamp{}, hlc.ClockTimestamp{}, kv.Value, nil,
+			ctx, batch, keys.StoreCachedSettingsKey(kv.Key), hlc.Timestamp{}, kv.Value, storage.MVCCWriteOptions{},
 		); err != nil {
 			return err
 		}

--- a/pkg/storage/bench_data_test.go
+++ b/pkg/storage/bench_data_test.go
@@ -358,7 +358,7 @@ func (d mvccBenchData) Build(ctx context.Context, b *testing.B, eng Engine) erro
 			txn.ReadTimestamp = ts
 			txn.WriteTimestamp = ts
 		}
-		require.NoError(b, MVCCPut(ctx, batch, nil, key, ts, hlc.ClockTimestamp{}, value, txn))
+		require.NoError(b, MVCCPut(ctx, batch, key, ts, value, MVCCWriteOptions{Txn: txn}))
 	}
 
 	resolveLastIntent := func(batch Batch, idx int) {

--- a/pkg/storage/bench_pebble_test.go
+++ b/pkg/storage/bench_pebble_test.go
@@ -361,10 +361,10 @@ func BenchmarkMVCCPutDelete_Pebble(b *testing.B) {
 		key := encoding.EncodeVarintAscending(nil, blockID)
 		key = encoding.EncodeVarintAscending(key, blockNum)
 
-		if err := MVCCPut(ctx, db, nil, key, hlc.Timestamp{}, hlc.ClockTimestamp{}, value, nil); err != nil {
+		if err := MVCCPut(ctx, db, key, hlc.Timestamp{}, value, MVCCWriteOptions{}); err != nil {
 			b.Fatal(err)
 		}
-		if _, err := MVCCDelete(ctx, db, nil, key, hlc.Timestamp{}, hlc.ClockTimestamp{}, nil); err != nil {
+		if _, err := MVCCDelete(ctx, db, key, hlc.Timestamp{}, MVCCWriteOptions{}); err != nil {
 			b.Fatal(err)
 		}
 	}

--- a/pkg/storage/engine_test.go
+++ b/pkg/storage/engine_test.go
@@ -174,13 +174,13 @@ func TestEngineBatchStaleCachedIterator(t *testing.T) {
 
 		// Put a value so that the deletion below finds a value to seek
 		// to.
-		if err := MVCCPut(context.Background(), batch, nil, key, hlc.Timestamp{}, hlc.ClockTimestamp{}, roachpb.MakeValueFromString("x"), nil); err != nil {
+		if err := MVCCPut(context.Background(), batch, key, hlc.Timestamp{}, roachpb.MakeValueFromString("x"), MVCCWriteOptions{}); err != nil {
 			t.Fatal(err)
 		}
 
 		// Seek the iterator to `key` and clear the value (but without
 		// telling the iterator about that).
-		if _, err := MVCCDelete(context.Background(), batch, nil, key, hlc.Timestamp{}, hlc.ClockTimestamp{}, nil); err != nil {
+		if _, err := MVCCDelete(context.Background(), batch, key, hlc.Timestamp{}, MVCCWriteOptions{}); err != nil {
 			t.Fatal(err)
 		}
 
@@ -1472,7 +1472,7 @@ func TestGetIntent(t *testing.T) {
 
 	for _, keyName := range []string{"a", "aa"} {
 		key := roachpb.Key(keyName)
-		err := MVCCPut(ctx, reader, nil, key, txn1.ReadTimestamp, hlc.ClockTimestamp{}, roachpb.Value{RawBytes: key}, txn1)
+		err := MVCCPut(ctx, reader, key, txn1.ReadTimestamp, roachpb.Value{RawBytes: key}, MVCCWriteOptions{Txn: txn1})
 		require.NoError(t, err)
 	}
 
@@ -1481,7 +1481,7 @@ func TestGetIntent(t *testing.T) {
 	txn2 := &roachpb.Transaction{TxnMeta: enginepb.TxnMeta{Key: roachpb.Key("a"), ID: txn2ID, Epoch: 2, WriteTimestamp: txn2TS, MinTimestamp: txn2TS, CoordinatorNodeID: 2}, ReadTimestamp: txn2TS}
 
 	key := roachpb.Key("b")
-	err = MVCCPut(ctx, reader, nil, key, txn2.ReadTimestamp, hlc.ClockTimestamp{}, roachpb.Value{RawBytes: key}, txn2)
+	err = MVCCPut(ctx, reader, key, txn2.ReadTimestamp, roachpb.Value{RawBytes: key}, MVCCWriteOptions{Txn: txn2})
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -1556,7 +1556,7 @@ func TestScanIntents(t *testing.T) {
 	defer eng.Close()
 
 	for _, key := range keys {
-		err := MVCCPut(ctx, eng, nil, key, txn1.ReadTimestamp, hlc.ClockTimestamp{}, roachpb.Value{RawBytes: key}, txn1)
+		err := MVCCPut(ctx, eng, key, txn1.ReadTimestamp, roachpb.Value{RawBytes: key}, MVCCWriteOptions{Txn: txn1})
 		require.NoError(t, err)
 	}
 
@@ -1605,20 +1605,20 @@ func TestEngineClearRange(t *testing.T) {
 	writeInitialData := func(t *testing.T, rw ReadWriter) {
 		var localTS hlc.ClockTimestamp
 		txn := roachpb.MakeTransaction("test", nil, roachpb.NormalUserPriority, wallTS(6), 1, 1)
-		require.NoError(t, MVCCPut(ctx, rw, nil, roachpb.Key("c"), wallTS(1), localTS, stringValue("c1").Value, nil))
+		require.NoError(t, MVCCPut(ctx, rw, roachpb.Key("c"), wallTS(1), stringValue("c1").Value, MVCCWriteOptions{LocalTimestamp: localTS}))
 		require.NoError(t, rw.PutMVCCRangeKey(rangeKey("d", "h", 1), MVCCValue{}))
 		require.NoError(t, rw.PutMVCCRangeKey(rangeKey("a", "f", 2), MVCCValue{}))
-		require.NoError(t, MVCCPut(ctx, rw, nil, roachpb.Key("g"), wallTS(2), localTS, stringValue("g2").Value, nil))
-		require.NoError(t, MVCCPut(ctx, rw, nil, roachpb.Key("e"), wallTS(3), localTS, stringValue("e3").Value, nil))
+		require.NoError(t, MVCCPut(ctx, rw, roachpb.Key("g"), wallTS(2), stringValue("g2").Value, MVCCWriteOptions{}))
+		require.NoError(t, MVCCPut(ctx, rw, roachpb.Key("e"), wallTS(3), stringValue("e3").Value, MVCCWriteOptions{}))
 		require.NoError(t, rw.PutMVCCRangeKey(rangeKey("a", "f", 4), MVCCValue{}))
 		require.NoError(t, rw.PutMVCCRangeKey(rangeKey("g", "h", 4), MVCCValue{}))
-		require.NoError(t, MVCCPut(ctx, rw, nil, roachpb.Key("a"), wallTS(5), localTS, stringValue("a2").Value, nil))
-		require.NoError(t, MVCCPut(ctx, rw, nil, roachpb.Key("b"), wallTS(5), localTS, stringValue("b2").Value, nil))
-		require.NoError(t, MVCCPut(ctx, rw, nil, roachpb.Key("c"), wallTS(5), localTS, stringValue("c2").Value, nil))
-		require.NoError(t, MVCCPut(ctx, rw, nil, roachpb.Key("a"), wallTS(6), localTS, stringValue("a6").Value, &txn))
-		require.NoError(t, MVCCPut(ctx, rw, nil, roachpb.Key("b"), wallTS(6), localTS, stringValue("b6").Value, &txn))
-		require.NoError(t, MVCCPut(ctx, rw, nil, roachpb.Key("e"), wallTS(6), localTS, stringValue("e6").Value, &txn))
-		require.NoError(t, MVCCPut(ctx, rw, nil, roachpb.Key("g"), wallTS(6), localTS, stringValue("g6").Value, &txn))
+		require.NoError(t, MVCCPut(ctx, rw, roachpb.Key("a"), wallTS(5), stringValue("a2").Value, MVCCWriteOptions{}))
+		require.NoError(t, MVCCPut(ctx, rw, roachpb.Key("b"), wallTS(5), stringValue("b2").Value, MVCCWriteOptions{}))
+		require.NoError(t, MVCCPut(ctx, rw, roachpb.Key("c"), wallTS(5), stringValue("c2").Value, MVCCWriteOptions{}))
+		require.NoError(t, MVCCPut(ctx, rw, roachpb.Key("a"), wallTS(6), stringValue("a6").Value, MVCCWriteOptions{Txn: &txn}))
+		require.NoError(t, MVCCPut(ctx, rw, roachpb.Key("b"), wallTS(6), stringValue("b6").Value, MVCCWriteOptions{Txn: &txn}))
+		require.NoError(t, MVCCPut(ctx, rw, roachpb.Key("e"), wallTS(6), stringValue("e6").Value, MVCCWriteOptions{Txn: &txn}))
+		require.NoError(t, MVCCPut(ctx, rw, roachpb.Key("g"), wallTS(6), stringValue("g6").Value, MVCCWriteOptions{Txn: &txn}))
 	}
 	start, end := roachpb.Key("b"), roachpb.Key("g")
 
@@ -2081,7 +2081,7 @@ func TestScanConflictingIntentsForDroppingLatchesEarly(t *testing.T) {
 			setup: func(t *testing.T, rw ReadWriter, txn *roachpb.Transaction) {
 				conflictingTxn := newTxn(belowTxnTS) // test txn should see this intent
 				err := MVCCPut(
-					ctx, rw, nil, keyA, conflictingTxn.WriteTimestamp, hlc.ClockTimestamp{}, val, conflictingTxn,
+					ctx, rw, keyA, conflictingTxn.WriteTimestamp, val, MVCCWriteOptions{Txn: conflictingTxn},
 				)
 				require.NoError(t, err)
 			},
@@ -2095,7 +2095,7 @@ func TestScanConflictingIntentsForDroppingLatchesEarly(t *testing.T) {
 			setup: func(t *testing.T, rw ReadWriter, txn *roachpb.Transaction) {
 				conflictingTxn := newTxn(aboveTxnTS) // test txn shouldn't see this intent
 				err := MVCCPut(
-					ctx, rw, nil, keyA, conflictingTxn.WriteTimestamp, hlc.ClockTimestamp{}, val, conflictingTxn,
+					ctx, rw, keyA, conflictingTxn.WriteTimestamp, val, MVCCWriteOptions{Txn: conflictingTxn},
 				)
 				require.NoError(t, err)
 			},
@@ -2107,7 +2107,7 @@ func TestScanConflictingIntentsForDroppingLatchesEarly(t *testing.T) {
 		{
 			name: "bounds do not include (latest) own write",
 			setup: func(t *testing.T, rw ReadWriter, txn *roachpb.Transaction) {
-				err := MVCCPut(ctx, rw, nil, keyA, txn.WriteTimestamp, hlc.ClockTimestamp{}, val, txn)
+				err := MVCCPut(ctx, rw, keyA, txn.WriteTimestamp, val, MVCCWriteOptions{Txn: txn})
 				require.NoError(t, err)
 			},
 			start:                 keyB,
@@ -2338,7 +2338,7 @@ func TestScanConflictingIntentsForDroppingLatchesEarlyReadYourOwnWrites(t *testi
 			txn.Sequence = tc.intentSequenceNumber
 			txn.ReadTimestamp = tc.intentTS
 			txn.WriteTimestamp = tc.intentTS
-			err := MVCCPut(ctx, eng, nil, keyA, txn.WriteTimestamp, hlc.ClockTimestamp{}, val, txn)
+			err := MVCCPut(ctx, eng, keyA, txn.WriteTimestamp, val, MVCCWriteOptions{Txn: txn})
 			require.NoError(t, err)
 
 			// Set up the read.

--- a/pkg/storage/metamorphic/operations.go
+++ b/pkg/storage/metamorphic/operations.go
@@ -207,7 +207,7 @@ func (m mvccPutOp) run(ctx context.Context) string {
 	txn.Sequence++
 	writer := m.m.getReadWriter(m.writer)
 
-	err := storage.MVCCPut(ctx, writer, nil, m.key, txn.ReadTimestamp, hlc.ClockTimestamp{}, m.value, txn)
+	err := storage.MVCCPut(ctx, writer, m.key, txn.ReadTimestamp, m.value, storage.MVCCWriteOptions{Txn: txn})
 	if err != nil {
 		if writeTooOldErr := (*kvpb.WriteTooOldError)(nil); errors.As(err, &writeTooOldErr) {
 			txn.WriteTimestamp.Forward(writeTooOldErr.ActualTimestamp)
@@ -236,8 +236,8 @@ func (m mvccCPutOp) run(ctx context.Context) string {
 	writer := m.m.getReadWriter(m.writer)
 	txn.Sequence++
 
-	err := storage.MVCCConditionalPut(ctx, writer, nil, m.key,
-		txn.ReadTimestamp, hlc.ClockTimestamp{}, m.value, m.expVal, true, txn)
+	err := storage.MVCCConditionalPut(ctx, writer, m.key,
+		txn.ReadTimestamp, m.value, m.expVal, true, storage.MVCCWriteOptions{Txn: txn})
 	if err != nil {
 		if writeTooOldErr := (*kvpb.WriteTooOldError)(nil); errors.As(err, &writeTooOldErr) {
 			txn.WriteTimestamp.Forward(writeTooOldErr.ActualTimestamp)
@@ -265,7 +265,7 @@ func (m mvccInitPutOp) run(ctx context.Context) string {
 	writer := m.m.getReadWriter(m.writer)
 	txn.Sequence++
 
-	err := storage.MVCCInitPut(ctx, writer, nil, m.key, txn.ReadTimestamp, hlc.ClockTimestamp{}, m.value, false, txn)
+	err := storage.MVCCInitPut(ctx, writer, m.key, txn.ReadTimestamp, m.value, false, storage.MVCCWriteOptions{Txn: txn})
 	if err != nil {
 		if writeTooOldErr := (*kvpb.WriteTooOldError)(nil); errors.As(err, &writeTooOldErr) {
 			txn.WriteTimestamp.Forward(writeTooOldErr.ActualTimestamp)
@@ -298,8 +298,8 @@ func (m mvccDeleteRangeOp) run(ctx context.Context) string {
 
 	txn.Sequence++
 
-	keys, _, _, err := storage.MVCCDeleteRange(ctx, writer, nil, m.key, m.endKey,
-		0, txn.WriteTimestamp, hlc.ClockTimestamp{}, txn, true)
+	keys, _, _, err := storage.MVCCDeleteRange(ctx, writer, m.key, m.endKey,
+		0, txn.WriteTimestamp, storage.MVCCWriteOptions{Txn: txn}, true)
 	if err != nil {
 		return fmt.Sprintf("error: %s", err)
 	}
@@ -377,7 +377,7 @@ func (m mvccDeleteOp) run(ctx context.Context) string {
 	writer := m.m.getReadWriter(m.writer)
 	txn.Sequence++
 
-	_, err := storage.MVCCDelete(ctx, writer, nil, m.key, txn.ReadTimestamp, hlc.ClockTimestamp{}, txn)
+	_, err := storage.MVCCDelete(ctx, writer, m.key, txn.ReadTimestamp, storage.MVCCWriteOptions{Txn: txn})
 	if err != nil {
 		if writeTooOldErr := (*kvpb.WriteTooOldError)(nil); errors.As(err, &writeTooOldErr) {
 			txn.WriteTimestamp.Forward(writeTooOldErr.ActualTimestamp)

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -832,19 +832,17 @@ func MVCCGetProto(
 func MVCCPutProto(
 	ctx context.Context,
 	rw ReadWriter,
-	ms *enginepb.MVCCStats,
 	key roachpb.Key,
 	timestamp hlc.Timestamp,
-	localTimestamp hlc.ClockTimestamp,
-	txn *roachpb.Transaction,
 	msg protoutil.Message,
+	opts MVCCWriteOptions,
 ) error {
 	value := roachpb.Value{}
 	if err := value.SetProto(msg); err != nil {
 		return err
 	}
 	value.InitChecksum(key)
-	return MVCCPut(ctx, rw, ms, key, timestamp, localTimestamp, value, txn)
+	return MVCCPut(ctx, rw, key, timestamp, value, opts)
 }
 
 // MVCCBlindPutProto sets the given key to the protobuf-serialized byte string
@@ -853,19 +851,17 @@ func MVCCPutProto(
 func MVCCBlindPutProto(
 	ctx context.Context,
 	writer Writer,
-	ms *enginepb.MVCCStats,
 	key roachpb.Key,
 	timestamp hlc.Timestamp,
-	localTimestamp hlc.ClockTimestamp,
 	msg protoutil.Message,
-	txn *roachpb.Transaction,
+	opts MVCCWriteOptions,
 ) error {
 	value := roachpb.Value{}
 	if err := value.SetProto(msg); err != nil {
 		return err
 	}
 	value.InitChecksum(key)
-	return MVCCBlindPut(ctx, writer, ms, key, timestamp, localTimestamp, value, txn)
+	return MVCCBlindPut(ctx, writer, key, timestamp, value, opts)
 }
 
 // LockTableView is a transaction-bound view into an in-memory collections of
@@ -1442,17 +1438,15 @@ func (b *putBuffer) putIntentMeta(
 func MVCCPut(
 	ctx context.Context,
 	rw ReadWriter,
-	ms *enginepb.MVCCStats,
 	key roachpb.Key,
 	timestamp hlc.Timestamp,
-	localTimestamp hlc.ClockTimestamp,
 	value roachpb.Value,
-	txn *roachpb.Transaction,
+	opts MVCCWriteOptions,
 ) error {
 	// If we're not tracking stats for the key and we're writing a non-versioned
 	// key we can utilize a blind put to avoid reading any existing value.
 	var iter MVCCIterator
-	blind := ms == nil && timestamp.IsEmpty()
+	blind := opts.Stats == nil && timestamp.IsEmpty()
 	if !blind {
 		iter = newMVCCIterator(
 			rw, timestamp, false /* rangeKeyMasking */, false /* noInterleavedIntents */, IterOptions{
@@ -1462,7 +1456,7 @@ func MVCCPut(
 		)
 		defer iter.Close()
 	}
-	return mvccPutUsingIter(ctx, rw, iter, ms, key, timestamp, localTimestamp, value, txn, nil)
+	return mvccPutUsingIter(ctx, rw, iter, key, timestamp, value, nil, opts)
 }
 
 // MVCCBlindPut is a fast-path of MVCCPut. See the MVCCPut comments for details
@@ -1478,14 +1472,12 @@ func MVCCPut(
 func MVCCBlindPut(
 	ctx context.Context,
 	writer Writer,
-	ms *enginepb.MVCCStats,
 	key roachpb.Key,
 	timestamp hlc.Timestamp,
-	localTimestamp hlc.ClockTimestamp,
 	value roachpb.Value,
-	txn *roachpb.Transaction,
+	opts MVCCWriteOptions,
 ) error {
-	return mvccPutUsingIter(ctx, writer, nil, ms, key, timestamp, localTimestamp, value, txn, nil)
+	return mvccPutUsingIter(ctx, writer, nil, key, timestamp, value, nil, opts)
 }
 
 // MVCCDelete marks the key deleted so that it will not be returned in
@@ -1500,11 +1492,9 @@ func MVCCBlindPut(
 func MVCCDelete(
 	ctx context.Context,
 	rw ReadWriter,
-	ms *enginepb.MVCCStats,
 	key roachpb.Key,
 	timestamp hlc.Timestamp,
-	localTimestamp hlc.ClockTimestamp,
-	txn *roachpb.Transaction,
+	opts MVCCWriteOptions,
 ) (foundKey bool, err error) {
 	iter := newMVCCIterator(
 		rw, timestamp, false /* rangeKeyMasking */, false /* noInterleavedIntents */, IterOptions{
@@ -1519,7 +1509,7 @@ func MVCCDelete(
 
 	// TODO(yuzefovich): can we avoid the put if the key does not exist?
 	return mvccPutInternal(
-		ctx, rw, iter, ms, key, timestamp, localTimestamp, noValue, txn, buf, nil)
+		ctx, rw, iter, key, timestamp, noValue, buf, nil, opts)
 }
 
 var noValue = roachpb.Value{}
@@ -1532,13 +1522,11 @@ func mvccPutUsingIter(
 	ctx context.Context,
 	writer Writer,
 	iter MVCCIterator,
-	ms *enginepb.MVCCStats,
 	key roachpb.Key,
 	timestamp hlc.Timestamp,
-	localTimestamp hlc.ClockTimestamp,
 	value roachpb.Value,
-	txn *roachpb.Transaction,
 	valueFn func(optionalValue) (roachpb.Value, error),
+	opts MVCCWriteOptions,
 ) error {
 	buf := newPutBuffer()
 	defer buf.release()
@@ -1546,7 +1534,7 @@ func mvccPutUsingIter(
 	// Most callers don't care about the returned exReplaced value. The ones that
 	// do can call mvccPutInternal directly.
 	_, err := mvccPutInternal(
-		ctx, writer, iter, ms, key, timestamp, localTimestamp, value, txn, buf, valueFn)
+		ctx, writer, iter, key, timestamp, value, buf, valueFn, opts)
 	return err
 }
 
@@ -1706,6 +1694,7 @@ func replayTransactionalWrite(
 		return errors.AssertionFailedf("transaction %s with sequence %d has a different value %+v after recomputing from what was written: %+v",
 			txn.ID, txn.Sequence, value.RawBytes, writtenValue.RawBytes)
 	}
+
 	return nil
 }
 
@@ -1748,7 +1737,7 @@ func replayTransactionalWrite(
 // parameter be set to hlc.Timestamp{} when writing transactionally, but
 // hlc.Timestamp{} is already used as a sentinel for inline puts.)
 //
-// The local timestamp parameter dictates the local clock timestamp
+// The opts.LocalTimestamp parameter dictates the local clock timestamp
 // assigned to the key-value. It should be taken from the local HLC
 // clock on the leaseholder that is performing the write and must be
 // below the leaseholder's lease expiration. If the supplied local
@@ -1760,14 +1749,12 @@ func mvccPutInternal(
 	ctx context.Context,
 	writer Writer,
 	iter MVCCIterator,
-	ms *enginepb.MVCCStats,
 	key roachpb.Key,
 	timestamp hlc.Timestamp,
-	localTimestamp hlc.ClockTimestamp,
 	value roachpb.Value,
-	txn *roachpb.Transaction,
 	buf *putBuffer,
 	valueFn func(optionalValue) (roachpb.Value, error),
+	opts MVCCWriteOptions,
 ) (bool, error) {
 	if len(key) == 0 {
 		return false, emptyKeyError()
@@ -1796,7 +1783,7 @@ func mvccPutInternal(
 	// aren't allowed within transactions. MVCC range tombstones cannot exist
 	// across them either.
 	if putIsInline {
-		if txn != nil {
+		if opts.Txn != nil {
 			return false, errors.Errorf("%q: inline writes not allowed within transactions", metaKey)
 		}
 		var metaKeySize, metaValSize int64
@@ -1809,8 +1796,8 @@ func mvccPutInternal(
 			buf.meta = enginepb.MVCCMetadata{RawBytes: value.RawBytes}
 			metaKeySize, metaValSize, err = buf.putInlineMeta(writer, metaKey, &buf.meta)
 		}
-		if ms != nil {
-			updateStatsForInline(ms, key, origMetaKeySize, origMetaValSize, metaKeySize, metaValSize)
+		if opts.Stats != nil {
+			updateStatsForInline(opts.Stats, key, origMetaKeySize, origMetaValSize, metaKeySize, metaValSize)
 		}
 		return ok && !buf.meta.Deleted, err
 	}
@@ -1822,14 +1809,14 @@ func mvccPutInternal(
 	// definition for rationale.
 	readTimestamp := timestamp
 	writeTimestamp := timestamp
-	if txn != nil {
-		readTimestamp = txn.ReadTimestamp
+	if opts.Txn != nil {
+		readTimestamp = opts.Txn.ReadTimestamp
 		if readTimestamp != timestamp {
 			return false, errors.AssertionFailedf(
 				"mvccPutInternal: txn's read timestamp %s does not match timestamp %s",
 				readTimestamp, timestamp)
 		}
-		writeTimestamp = txn.WriteTimestamp
+		writeTimestamp = opts.Txn.WriteTimestamp
 	}
 
 	timestamp = hlc.Timestamp{} // prevent accidental use below
@@ -1837,7 +1824,7 @@ func mvccPutInternal(
 	// Determine what the logical operation is. Are we writing an intent
 	// or a value directly?
 	logicalOp := MVCCWriteValueOpType
-	if txn != nil {
+	if opts.Txn != nil {
 		logicalOp = MVCCWriteIntentOpType
 	}
 
@@ -1860,20 +1847,20 @@ func mvccPutInternal(
 		// handling, since they cannot be transactional.
 		if meta.Txn != nil {
 			// There is an uncommitted write intent.
-			if txn == nil || meta.Txn.ID != txn.ID {
+			if opts.Txn == nil || meta.Txn.ID != opts.Txn.ID {
 				// The current Put operation does not come from the same
 				// transaction.
 				return false, &kvpb.WriteIntentError{Intents: []roachpb.Intent{
 					roachpb.MakeIntent(meta.Txn, key),
 				}}
-			} else if txn.Epoch < meta.Txn.Epoch {
+			} else if opts.Txn.Epoch < meta.Txn.Epoch {
 				return false, errors.Errorf("put with epoch %d came after put with epoch %d in txn %s",
-					txn.Epoch, meta.Txn.Epoch, txn.ID)
-			} else if txn.Epoch == meta.Txn.Epoch && txn.Sequence <= meta.Txn.Sequence {
+					opts.Txn.Epoch, meta.Txn.Epoch, opts.Txn.ID)
+			} else if opts.Txn.Epoch == meta.Txn.Epoch && opts.Txn.Sequence <= meta.Txn.Sequence {
 				// The transaction has executed at this sequence before. This is merely a
 				// replay of the transactional write. Assert that all is in order and return
 				// early.
-				return false, replayTransactionalWrite(ctx, iter, meta, key, readTimestamp, value, txn, valueFn)
+				return false, replayTransactionalWrite(ctx, iter, meta, key, readTimestamp, value, opts.Txn, valueFn)
 			}
 
 			// We're overwriting the intent that was present at this key, before we do
@@ -1903,8 +1890,8 @@ func mvccPutInternal(
 			// Set when the current provisional value is not ignored due to a txn
 			// restart or a savepoint rollback. Represents an encoded MVCCValue.
 			var curProvValRaw []byte
-			if txn.Epoch == meta.Txn.Epoch /* last write inside txn */ {
-				if !enginepb.TxnSeqIsIgnored(meta.Txn.Sequence, txn.IgnoredSeqNums) {
+			if opts.Txn.Epoch == meta.Txn.Epoch /* last write inside txn */ {
+				if !enginepb.TxnSeqIsIgnored(meta.Txn.Sequence, opts.Txn.IgnoredSeqNums) {
 					// Seqnum of last write is not ignored. Retrieve the value.
 					iter.SeekGE(oldVersionKey)
 					var hasPoint bool
@@ -1930,7 +1917,7 @@ func mvccPutInternal(
 					exVal = makeOptionalValue(curIntentVal.Value)
 				} else {
 					// Seqnum of last write was ignored. Try retrieving the value from the history.
-					prevIntent, prevIntentOk := meta.GetPrevIntentSeq(txn.Sequence, txn.IgnoredSeqNums)
+					prevIntent, prevIntentOk := meta.GetPrevIntentSeq(opts.Txn.Sequence, opts.Txn.IgnoredSeqNums)
 					if prevIntentOk {
 						prevIntentVal, err := DecodeMVCCValue(prevIntent.Value)
 						if err != nil {
@@ -2047,7 +2034,7 @@ func mvccPutInternal(
 			// transaction are ignored, and there are no past committed values
 			// at this key. In that case, we can also blow up the intent
 			// history.
-			if txn.Epoch == meta.Txn.Epoch && exVal.exists {
+			if opts.Txn.Epoch == meta.Txn.Epoch && exVal.exists {
 				// Only add the current provisional value to the intent
 				// history if the current sequence number is not ignored. There's no
 				// reason to add past committed values or a value already in the intent
@@ -2090,7 +2077,7 @@ func mvccPutInternal(
 			// timestamp is returned to the caller in maybeTooOldErr. Because
 			// we're outside of a transaction, we'll never actually commit this
 			// value, but that's a concern of evaluateBatch and not here.
-			if txn == nil {
+			if opts.Txn == nil {
 				readTimestamp = writeTimestamp
 			}
 			// Inject a function to inspect the existing value at readTimestamp and
@@ -2126,7 +2113,7 @@ func mvccPutInternal(
 
 	versionValue := MVCCValue{}
 	versionValue.Value = value
-	versionValue.LocalTimestamp = localTimestamp
+	versionValue.LocalTimestamp = opts.LocalTimestamp
 
 	if buildutil.CrdbTestBuild {
 		if seq, seqOK := kvnemesisutil.FromContext(ctx); seqOK {
@@ -2146,8 +2133,8 @@ func mvccPutInternal(
 	newMeta := &buf.newMeta
 	{
 		var txnMeta *enginepb.TxnMeta
-		if txn != nil {
-			txnMeta = &txn.TxnMeta
+		if opts.Txn != nil {
+			txnMeta = &opts.Txn.TxnMeta
 			// If we bumped the WriteTimestamp, we update both the TxnMeta and the
 			// MVCCMetadata.Timestamp.
 			if txnMeta.WriteTimestamp != versionKey.Timestamp {
@@ -2197,7 +2184,7 @@ func mvccPutInternal(
 	}
 
 	// Update MVCC stats.
-	if ms != nil {
+	if opts.Stats != nil {
 		// Adjust the stats metadata for MVCC range tombstones. The MVCC stats
 		// update only cares about changes to real point keys, but the above logic
 		// needs to care about MVCC range tombstones for conflict purposes.
@@ -2213,7 +2200,7 @@ func mvccPutInternal(
 		if meta != nil {
 			meta.Timestamp = origRealKeyChanged.ToLegacyTimestamp()
 		}
-		ms.Add(updateStatsOnPut(key, prevIsValue, prevValSize, origMetaKeySize, origMetaValSize,
+		opts.Stats.Add(updateStatsOnPut(key, prevIsValue, prevValSize, origMetaKeySize, origMetaValSize,
 			metaKeySize, metaValSize, meta, newMeta))
 	}
 
@@ -2244,11 +2231,9 @@ func mvccPutInternal(
 func MVCCIncrement(
 	ctx context.Context,
 	rw ReadWriter,
-	ms *enginepb.MVCCStats,
 	key roachpb.Key,
 	timestamp hlc.Timestamp,
-	localTimestamp hlc.ClockTimestamp,
-	txn *roachpb.Transaction,
+	opts MVCCWriteOptions,
 	inc int64,
 ) (int64, error) {
 	iter := newMVCCIterator(
@@ -2286,7 +2271,8 @@ func MVCCIncrement(
 		newValue.InitChecksum(key)
 		return newValue, nil
 	}
-	err := mvccPutUsingIter(ctx, rw, iter, ms, key, timestamp, localTimestamp, noValue, txn, valueFn)
+
+	err := mvccPutUsingIter(ctx, rw, iter, key, timestamp, noValue, valueFn, opts)
 
 	return newInt64Val, err
 }
@@ -2321,14 +2307,12 @@ const (
 func MVCCConditionalPut(
 	ctx context.Context,
 	rw ReadWriter,
-	ms *enginepb.MVCCStats,
 	key roachpb.Key,
 	timestamp hlc.Timestamp,
-	localTimestamp hlc.ClockTimestamp,
 	value roachpb.Value,
 	expVal []byte,
 	allowIfDoesNotExist CPutMissingBehavior,
-	txn *roachpb.Transaction,
+	opts MVCCWriteOptions,
 ) error {
 	iter := newMVCCIterator(
 		rw, timestamp, false /* rangeKeyMasking */, false /* noInterleavedIntents */, IterOptions{
@@ -2339,7 +2323,7 @@ func MVCCConditionalPut(
 	defer iter.Close()
 
 	return mvccConditionalPutUsingIter(
-		ctx, rw, iter, ms, key, timestamp, localTimestamp, value, expVal, allowIfDoesNotExist, txn)
+		ctx, rw, iter, key, timestamp, value, expVal, allowIfDoesNotExist, opts)
 }
 
 // MVCCBlindConditionalPut is a fast-path of MVCCConditionalPut. See the
@@ -2354,31 +2338,27 @@ func MVCCConditionalPut(
 func MVCCBlindConditionalPut(
 	ctx context.Context,
 	writer Writer,
-	ms *enginepb.MVCCStats,
 	key roachpb.Key,
 	timestamp hlc.Timestamp,
-	localTimestamp hlc.ClockTimestamp,
 	value roachpb.Value,
 	expVal []byte,
 	allowIfDoesNotExist CPutMissingBehavior,
-	txn *roachpb.Transaction,
+	opts MVCCWriteOptions,
 ) error {
 	return mvccConditionalPutUsingIter(
-		ctx, writer, nil, ms, key, timestamp, localTimestamp, value, expVal, allowIfDoesNotExist, txn)
+		ctx, writer, nil, key, timestamp, value, expVal, allowIfDoesNotExist, opts)
 }
 
 func mvccConditionalPutUsingIter(
 	ctx context.Context,
 	writer Writer,
 	iter MVCCIterator,
-	ms *enginepb.MVCCStats,
 	key roachpb.Key,
 	timestamp hlc.Timestamp,
-	localTimestamp hlc.ClockTimestamp,
 	value roachpb.Value,
 	expBytes []byte,
 	allowNoExisting CPutMissingBehavior,
-	txn *roachpb.Transaction,
+	opts MVCCWriteOptions,
 ) error {
 	valueFn := func(existVal optionalValue) (roachpb.Value, error) {
 		if expValPresent, existValPresent := len(expBytes) != 0, existVal.IsPresent(); expValPresent && existValPresent {
@@ -2394,7 +2374,7 @@ func mvccConditionalPutUsingIter(
 		}
 		return value, nil
 	}
-	return mvccPutUsingIter(ctx, writer, iter, ms, key, timestamp, localTimestamp, noValue, txn, valueFn)
+	return mvccPutUsingIter(ctx, writer, iter, key, timestamp, noValue, valueFn, opts)
 }
 
 // MVCCInitPut sets the value for a specified key if the key doesn't exist. It
@@ -2409,13 +2389,11 @@ func mvccConditionalPutUsingIter(
 func MVCCInitPut(
 	ctx context.Context,
 	rw ReadWriter,
-	ms *enginepb.MVCCStats,
 	key roachpb.Key,
 	timestamp hlc.Timestamp,
-	localTimestamp hlc.ClockTimestamp,
 	value roachpb.Value,
 	failOnTombstones bool,
-	txn *roachpb.Transaction,
+	opts MVCCWriteOptions,
 ) error {
 	iter := newMVCCIterator(
 		rw, timestamp, false /* rangeKeyMasking */, false /* noInterleavedIntents */, IterOptions{
@@ -2424,7 +2402,7 @@ func MVCCInitPut(
 		},
 	)
 	defer iter.Close()
-	return mvccInitPutUsingIter(ctx, rw, iter, ms, key, timestamp, localTimestamp, value, failOnTombstones, txn)
+	return mvccInitPutUsingIter(ctx, rw, iter, key, timestamp, value, failOnTombstones, opts)
 }
 
 // MVCCBlindInitPut is a fast-path of MVCCInitPut. See the MVCCInitPut
@@ -2438,29 +2416,25 @@ func MVCCInitPut(
 func MVCCBlindInitPut(
 	ctx context.Context,
 	rw ReadWriter,
-	ms *enginepb.MVCCStats,
 	key roachpb.Key,
 	timestamp hlc.Timestamp,
-	localTimestamp hlc.ClockTimestamp,
 	value roachpb.Value,
 	failOnTombstones bool,
-	txn *roachpb.Transaction,
+	opts MVCCWriteOptions,
 ) error {
 	return mvccInitPutUsingIter(
-		ctx, rw, nil, ms, key, timestamp, localTimestamp, value, failOnTombstones, txn)
+		ctx, rw, nil, key, timestamp, value, failOnTombstones, opts)
 }
 
 func mvccInitPutUsingIter(
 	ctx context.Context,
 	rw ReadWriter,
 	iter MVCCIterator,
-	ms *enginepb.MVCCStats,
 	key roachpb.Key,
 	timestamp hlc.Timestamp,
-	localTimestamp hlc.ClockTimestamp,
 	value roachpb.Value,
 	failOnTombstones bool,
-	txn *roachpb.Transaction,
+	opts MVCCWriteOptions,
 ) error {
 	valueFn := func(existVal optionalValue) (roachpb.Value, error) {
 		if failOnTombstones && existVal.IsTombstone() {
@@ -2477,7 +2451,7 @@ func mvccInitPutUsingIter(
 		}
 		return value, nil
 	}
-	return mvccPutUsingIter(ctx, rw, iter, ms, key, timestamp, localTimestamp, noValue, txn, valueFn)
+	return mvccPutUsingIter(ctx, rw, iter, key, timestamp, noValue, valueFn, opts)
 }
 
 // mvccKeyFormatter is an fmt.Formatter for MVCC Keys.
@@ -2992,12 +2966,10 @@ func MVCCClearTimeRange(
 func MVCCDeleteRange(
 	ctx context.Context,
 	rw ReadWriter,
-	ms *enginepb.MVCCStats,
 	key, endKey roachpb.Key,
 	max int64,
 	timestamp hlc.Timestamp,
-	localTimestamp hlc.ClockTimestamp,
-	txn *roachpb.Transaction,
+	opts MVCCWriteOptions,
 	returnKeys bool,
 ) ([]roachpb.Key, *roachpb.Span, int64, error) {
 	// Scan to find the keys to delete.
@@ -3029,8 +3001,8 @@ func MVCCDeleteRange(
 	// need to perform the initial scan at the previous sequence number so that
 	// we don't see the result from equal or later sequences.
 	var scanTxn *roachpb.Transaction
-	if txn != nil {
-		prevSeqTxn := txn.Clone()
+	if opts.Txn != nil {
+		prevSeqTxn := opts.Txn.Clone()
 		prevSeqTxn.Sequence--
 		scanTxn = prevSeqTxn
 	}
@@ -3054,7 +3026,7 @@ func MVCCDeleteRange(
 	var keys []roachpb.Key
 	for i, kv := range res.KVs {
 		if _, err := mvccPutInternal(
-			ctx, rw, iter, ms, kv.Key, timestamp, localTimestamp, noValue, txn, buf, nil,
+			ctx, rw, iter, kv.Key, timestamp, noValue, buf, nil, opts,
 		); err != nil {
 			return nil, nil, 0, err
 		}
@@ -3235,8 +3207,8 @@ func MVCCPredicateDeleteRange(
 		} else {
 			// Use Point tombstones
 			for i := int64(0); i < runSize; i++ {
-				if _, err := mvccPutInternal(ctx, rw, pointTombstoneIter, ms, buf[i], endTime, localTimestamp, noValue,
-					nil, pointTombstoneBuf, nil); err != nil {
+				if _, err := mvccPutInternal(ctx, rw, pointTombstoneIter, buf[i], endTime, noValue,
+					pointTombstoneBuf, nil, MVCCWriteOptions{LocalTimestamp: localTimestamp, Stats: ms}); err != nil {
 					return err
 				}
 			}
@@ -3386,6 +3358,9 @@ func MVCCPredicateDeleteRange(
 // When deleting an entire Raft range, passing the current MVCCStats as
 // msCovered and setting left/rightPeekBound to start/endKey will make the
 // deletion significantly faster.
+//
+// TODO(sarkesian): Consider accepting MVCCWriteOptions for this function
+// and its relevant callers.
 func MVCCDeleteRangeUsingTombstone(
 	ctx context.Context,
 	rw ReadWriter,
@@ -3871,6 +3846,14 @@ func buildScanIntents(data []byte) ([]roachpb.Intent, error) {
 		return nil, err
 	}
 	return intents, nil
+}
+
+// MVCCWriteOptions bundles options for the MVCCPut and MVCCDelete families of functions.
+type MVCCWriteOptions struct {
+	// See the comment on mvccPutInternal for details on these parameters.
+	Txn            *roachpb.Transaction
+	LocalTimestamp hlc.ClockTimestamp
+	Stats          *enginepb.MVCCStats
 }
 
 // MVCCScanOptions bundles options for the MVCCScan family of functions.

--- a/pkg/storage/mvcc_history_test.go
+++ b/pkg/storage/mvcc_history_test.go
@@ -87,15 +87,14 @@ var (
 // check_intent   k=<key> [none]
 // add_lock       t=<name> k=<key>
 //
-// cput           [t=<name>] [ts=<int>[,<int>]] [localTs=<int>[,<int>]] [resolve [status=<txnstatus>]] k=<key> v=<string> [raw] [cond=<string>]
-// del            [t=<name>] [ts=<int>[,<int>]] [localTs=<int>[,<int>]] [resolve [status=<txnstatus>]] k=<key>
-// del_range      [t=<name>] [ts=<int>[,<int>]] [localTs=<int>[,<int>]] [resolve [status=<txnstatus>]] k=<key> [end=<key>] [max=<max>] [returnKeys]
+// cput           [t=<name>] [ts=<int>[,<int>]] [localTs=<int>[,<int>]] [resolve [status=<txnstatus>]] [ambiguousReplay] k=<key> v=<string> [raw] [cond=<string>]
+// del            [t=<name>] [ts=<int>[,<int>]] [localTs=<int>[,<int>]] [resolve [status=<txnstatus>]] [ambiguousReplay] k=<key>
+// del_range      [t=<name>] [ts=<int>[,<int>]] [localTs=<int>[,<int>]] [resolve [status=<txnstatus>]] [ambiguousReplay] k=<key> [end=<key>] [max=<max>] [returnKeys]
 // del_range_ts   [ts=<int>[,<int>]] [localTs=<int>[,<int>]] k=<key> end=<key> [idempotent] [noCoveredStats]
 // del_range_pred [ts=<int>[,<int>]] [localTs=<int>[,<int>]] k=<key> end=<key> [startTime=<int>,max=<int>,maxBytes=<int>,rangeThreshold=<int>]
-// increment      [t=<name>] [ts=<int>[,<int>]] [localTs=<int>[,<int>]] [resolve [status=<txnstatus>]] k=<key> [inc=<val>]
-// initput        [t=<name>] [ts=<int>[,<int>]] [resolve [status=<txnstatus>]] k=<key> v=<string> [raw] [failOnTombstones]
-// merge          [t=<name>] [ts=<int>[,<int>]] [resolve [status=<txnstatus>]] k=<key> v=<string> [raw]
-// put            [t=<name>] [ts=<int>[,<int>]] [localTs=<int>[,<int>]] [resolve [status=<txnstatus>]] k=<key> v=<string> [raw]
+// increment      [t=<name>] [ts=<int>[,<int>]] [localTs=<int>[,<int>]] [resolve [status=<txnstatus>]] [ambiguousReplay] k=<key> [inc=<val>]
+// initput        [t=<name>] [ts=<int>[,<int>]] [resolve [status=<txnstatus>]] [ambiguousReplay] k=<key> v=<string> [raw] [failOnTombstones]
+// put            [t=<name>] [ts=<int>[,<int>]] [localTs=<int>[,<int>]] [resolve [status=<txnstatus>]] [ambiguousReplay] k=<key> v=<string> [raw]
 // put_rangekey   ts=<int>[,<int>] [localTs=<int>[,<int>]] k=<key> end=<key>
 // get            [t=<name>] [ts=<int>[,<int>]]                         [resolve [status=<txnstatus>]] k=<key> [inconsistent] [skipLocked] [tombstones] [failOnMoreRecent] [localUncertaintyLimit=<int>[,<int>]] [globalUncertaintyLimit=<int>[,<int>]] [maxKeys=<int>] [targetBytes=<int>] [allowEmpty]
 // scan           [t=<name>] [ts=<int>[,<int>]]                         [resolve [status=<txnstatus>]] k=<key> [end=<key>] [inconsistent] [skipLocked] [tombstones] [reverse] [failOnMoreRecent] [localUncertaintyLimit=<int>[,<int>]] [globalUncertaintyLimit=<int>[,<int>]] [max=<max>] [targetbytes=<target>] [wholeRows[=<int>]] [allowEmpty]
@@ -1088,9 +1087,10 @@ func cmdCPut(e *evalCtx) error {
 
 	return e.withWriter("cput", func(rw storage.ReadWriter) error {
 		opts := storage.MVCCWriteOptions{
-			Txn:            txn,
-			LocalTimestamp: localTs,
-			Stats:          e.ms,
+			Txn:                            txn,
+			LocalTimestamp:                 localTs,
+			Stats:                          e.ms,
+			ReplayWriteTimestampProtection: e.getAmbiguousReplay(),
 		}
 		if err := storage.MVCCConditionalPut(e.ctx, rw, key, ts, val, expVal, behavior, opts); err != nil {
 			return err
@@ -1114,9 +1114,10 @@ func cmdInitPut(e *evalCtx) error {
 
 	return e.withWriter("initput", func(rw storage.ReadWriter) error {
 		opts := storage.MVCCWriteOptions{
-			Txn:            txn,
-			LocalTimestamp: localTs,
-			Stats:          e.ms,
+			Txn:                            txn,
+			LocalTimestamp:                 localTs,
+			Stats:                          e.ms,
+			ReplayWriteTimestampProtection: e.getAmbiguousReplay(),
 		}
 		if err := storage.MVCCInitPut(e.ctx, rw, key, ts, val, failOnTombstones, opts); err != nil {
 			return err
@@ -1136,9 +1137,10 @@ func cmdDelete(e *evalCtx) error {
 	resolve, resolveStatus := e.getResolve()
 	return e.withWriter("del", func(rw storage.ReadWriter) error {
 		opts := storage.MVCCWriteOptions{
-			Txn:            txn,
-			LocalTimestamp: localTs,
-			Stats:          e.ms,
+			Txn:                            txn,
+			LocalTimestamp:                 localTs,
+			Stats:                          e.ms,
+			ReplayWriteTimestampProtection: e.getAmbiguousReplay(),
 		}
 		foundKey, err := storage.MVCCDelete(e.ctx, rw, key, ts, opts)
 		if err == nil || errors.HasType(err, &kvpb.WriteTooOldError{}) {
@@ -1170,9 +1172,10 @@ func cmdDeleteRange(e *evalCtx) error {
 	resolve, resolveStatus := e.getResolve()
 	return e.withWriter("del_range", func(rw storage.ReadWriter) error {
 		opts := storage.MVCCWriteOptions{
-			Txn:            txn,
-			LocalTimestamp: localTs,
-			Stats:          e.ms,
+			Txn:                            txn,
+			LocalTimestamp:                 localTs,
+			Stats:                          e.ms,
+			ReplayWriteTimestampProtection: e.getAmbiguousReplay(),
 		}
 		deleted, resumeSpan, num, err := storage.MVCCDeleteRange(
 			e.ctx, rw, key, endKey, int64(max), ts, opts, returnKeys)
@@ -1329,9 +1332,10 @@ func cmdIncrement(e *evalCtx) error {
 
 	return e.withWriter("increment", func(rw storage.ReadWriter) error {
 		opts := storage.MVCCWriteOptions{
-			Txn:            txn,
-			LocalTimestamp: localTs,
-			Stats:          e.ms,
+			Txn:                            txn,
+			LocalTimestamp:                 localTs,
+			Stats:                          e.ms,
+			ReplayWriteTimestampProtection: e.getAmbiguousReplay(),
 		}
 		curVal, err := storage.MVCCIncrement(e.ctx, rw, key, ts, opts, inc)
 		if err != nil {
@@ -1370,9 +1374,10 @@ func cmdPut(e *evalCtx) error {
 
 	return e.withWriter("put", func(rw storage.ReadWriter) error {
 		opts := storage.MVCCWriteOptions{
-			Txn:            txn,
-			LocalTimestamp: localTs,
-			Stats:          e.ms,
+			Txn:                            txn,
+			LocalTimestamp:                 localTs,
+			Stats:                          e.ms,
+			ReplayWriteTimestampProtection: e.getAmbiguousReplay(),
 		}
 		if err := storage.MVCCPut(e.ctx, rw, key, ts, val, opts); err != nil {
 			return err
@@ -2206,6 +2211,10 @@ func (e *evalCtx) getResolve() (bool, roachpb.TransactionStatus) {
 		return false, roachpb.PENDING
 	}
 	return true, e.getTxnStatus()
+}
+
+func (e *evalCtx) getAmbiguousReplay() bool {
+	return e.hasArg("ambiguousReplay")
 }
 
 func (e *evalCtx) getTs(txn *roachpb.Transaction) hlc.Timestamp {

--- a/pkg/storage/mvcc_incremental_iterator_test.go
+++ b/pkg/storage/mvcc_incremental_iterator_test.go
@@ -466,7 +466,7 @@ func TestMVCCIncrementalIteratorNextIgnoringTime(t *testing.T) {
 
 	for _, kv := range kvs(kv1_1_1, kv1_2_2, kv2_2_2) {
 		v := roachpb.Value{RawBytes: kv.Value}
-		if err := MVCCPut(ctx, e, nil, kv.Key.Key, kv.Key.Timestamp, hlc.ClockTimestamp{}, v, nil); err != nil {
+		if err := MVCCPut(ctx, e, kv.Key.Key, kv.Key.Timestamp, v, MVCCWriteOptions{}); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -505,7 +505,7 @@ func TestMVCCIncrementalIteratorNextIgnoringTime(t *testing.T) {
 	})
 
 	// Exercise deletion.
-	if _, err := MVCCDelete(ctx, e, nil, testKey1, ts3, hlc.ClockTimestamp{}, nil); err != nil {
+	if _, err := MVCCDelete(ctx, e, testKey1, ts3, MVCCWriteOptions{}); err != nil {
 		t.Fatal(err)
 	}
 	// Returns the kv_1_1_1 even though it is outside (startTime, endTime].
@@ -525,7 +525,7 @@ func TestMVCCIncrementalIteratorNextIgnoringTime(t *testing.T) {
 		},
 		ReadTimestamp: ts4,
 	}
-	if err := MVCCPut(ctx, e, nil, txn1.TxnMeta.Key, txn1.ReadTimestamp, hlc.ClockTimestamp{}, testValue4, &txn1); err != nil {
+	if err := MVCCPut(ctx, e, txn1.TxnMeta.Key, txn1.ReadTimestamp, testValue4, MVCCWriteOptions{Txn: &txn1}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -602,7 +602,7 @@ func TestMVCCIncrementalIteratorNextKeyIgnoringTime(t *testing.T) {
 
 	for _, kv := range kvs(kv1_1_1, kv1_2_2, kv2_2_2) {
 		v := roachpb.Value{RawBytes: kv.Value}
-		if err := MVCCPut(ctx, e, nil, kv.Key.Key, kv.Key.Timestamp, hlc.ClockTimestamp{}, v, nil); err != nil {
+		if err := MVCCPut(ctx, e, kv.Key.Key, kv.Key.Timestamp, v, MVCCWriteOptions{}); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -638,7 +638,7 @@ func TestMVCCIncrementalIteratorNextKeyIgnoringTime(t *testing.T) {
 	})
 
 	// Exercise deletion.
-	if _, err := MVCCDelete(ctx, e, nil, testKey1, ts3, hlc.ClockTimestamp{}, nil); err != nil {
+	if _, err := MVCCDelete(ctx, e, testKey1, ts3, MVCCWriteOptions{}); err != nil {
 		t.Fatal(err)
 	}
 	// Returns the kv_1_1_1 even though it is outside (startTime, endTime].
@@ -658,7 +658,7 @@ func TestMVCCIncrementalIteratorNextKeyIgnoringTime(t *testing.T) {
 		},
 		ReadTimestamp: ts4,
 	}
-	if err := MVCCPut(ctx, e, nil, txn1.TxnMeta.Key, txn1.ReadTimestamp, hlc.ClockTimestamp{}, testValue4, &txn1); err != nil {
+	if err := MVCCPut(ctx, e, txn1.TxnMeta.Key, txn1.ReadTimestamp, testValue4, MVCCWriteOptions{Txn: &txn1}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -723,7 +723,7 @@ func TestMVCCIncrementalIteratorInlinePolicy(t *testing.T) {
 	defer e.Close()
 	for _, kv := range []MVCCKeyValue{inline1_1_1, kv2_1_1, kv2_2_2, inline3_2_1} {
 		v := roachpb.Value{RawBytes: kv.Value}
-		if err := MVCCPut(ctx, e, nil, kv.Key.Key, kv.Key.Timestamp, hlc.ClockTimestamp{}, v, nil); err != nil {
+		if err := MVCCPut(ctx, e, kv.Key.Key, kv.Key.Timestamp, v, MVCCWriteOptions{}); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -793,11 +793,11 @@ func TestMVCCIncrementalIteratorIntentPolicy(t *testing.T) {
 	defer e.Close()
 	for _, kv := range []MVCCKeyValue{kv1_1_1, kv1_2_2, kv1_3_3, kv2_1_1} {
 		v := roachpb.Value{RawBytes: kv.Value}
-		if err := MVCCPut(ctx, e, nil, kv.Key.Key, kv.Key.Timestamp, hlc.ClockTimestamp{}, v, nil); err != nil {
+		if err := MVCCPut(ctx, e, kv.Key.Key, kv.Key.Timestamp, v, MVCCWriteOptions{}); err != nil {
 			t.Fatal(err)
 		}
 	}
-	if err := MVCCPut(ctx, e, nil, txn.TxnMeta.Key, txn.ReadTimestamp, hlc.ClockTimestamp{}, testValue2, &txn); err != nil {
+	if err := MVCCPut(ctx, e, txn.TxnMeta.Key, txn.ReadTimestamp, testValue2, MVCCWriteOptions{Txn: &txn}); err != nil {
 		t.Fatal(err)
 	}
 	t.Run("PolicyError returns error if an intent is in the time range", func(t *testing.T) {
@@ -958,7 +958,7 @@ func TestMVCCIncrementalIterator(t *testing.T) {
 
 		for _, kv := range kvs(kv1_1_1, kv1_2_2, kv2_2_2) {
 			v := roachpb.Value{RawBytes: kv.Value}
-			if err := MVCCPut(ctx, e, nil, kv.Key.Key, kv.Key.Timestamp, hlc.ClockTimestamp{}, v, nil); err != nil {
+			if err := MVCCPut(ctx, e, kv.Key.Key, kv.Key.Timestamp, v, MVCCWriteOptions{}); err != nil {
 				t.Fatal(err)
 			}
 		}
@@ -976,18 +976,18 @@ func TestMVCCIncrementalIterator(t *testing.T) {
 		t.Run("kv [1-2)", assertEqualKVs(e, testKey1, testKey2, tsMin, tsMax, latest, kvs(kv1_2_2)))
 
 		// Exercise deletion.
-		if _, err := MVCCDelete(ctx, e, nil, testKey1, ts3, hlc.ClockTimestamp{}, nil); err != nil {
+		if _, err := MVCCDelete(ctx, e, testKey1, ts3, MVCCWriteOptions{}); err != nil {
 			t.Fatal(err)
 		}
 		t.Run("del", assertEqualKVs(e, localMax, keyMax, ts1, tsMax, latest, kvs(kv1Deleted3, kv2_2_2)))
 
 		// Exercise intent handling.
 		txn1, intentErr1 := makeKVTxn(testKey1, ts4)
-		if err := MVCCPut(ctx, e, nil, txn1.TxnMeta.Key, txn1.ReadTimestamp, hlc.ClockTimestamp{}, testValue4, &txn1); err != nil {
+		if err := MVCCPut(ctx, e, txn1.TxnMeta.Key, txn1.ReadTimestamp, testValue4, MVCCWriteOptions{Txn: &txn1}); err != nil {
 			t.Fatal(err)
 		}
 		txn2, intentErr2 := makeKVTxn(testKey2, ts4)
-		if err := MVCCPut(ctx, e, nil, txn2.TxnMeta.Key, txn2.ReadTimestamp, hlc.ClockTimestamp{}, testValue4, &txn2); err != nil {
+		if err := MVCCPut(ctx, e, txn2.TxnMeta.Key, txn2.ReadTimestamp, testValue4, MVCCWriteOptions{Txn: &txn2}); err != nil {
 			t.Fatal(err)
 		}
 		t.Run("intents-1",
@@ -1024,7 +1024,7 @@ func TestMVCCIncrementalIterator(t *testing.T) {
 
 		for _, kv := range kvs(kv1_1_1, kv1_2_2, kv2_2_2) {
 			v := roachpb.Value{RawBytes: kv.Value}
-			if err := MVCCPut(ctx, e, nil, kv.Key.Key, kv.Key.Timestamp, hlc.ClockTimestamp{}, v, nil); err != nil {
+			if err := MVCCPut(ctx, e, kv.Key.Key, kv.Key.Timestamp, v, MVCCWriteOptions{}); err != nil {
 				t.Fatal(err)
 			}
 		}
@@ -1042,18 +1042,18 @@ func TestMVCCIncrementalIterator(t *testing.T) {
 		t.Run("kv [1-2)", assertEqualKVs(e, testKey1, testKey2, tsMin, tsMax, all, kvs(kv1_2_2, kv1_1_1)))
 
 		// Exercise deletion.
-		if _, err := MVCCDelete(ctx, e, nil, testKey1, ts3, hlc.ClockTimestamp{}, nil); err != nil {
+		if _, err := MVCCDelete(ctx, e, testKey1, ts3, MVCCWriteOptions{}); err != nil {
 			t.Fatal(err)
 		}
 		t.Run("del", assertEqualKVs(e, localMax, keyMax, ts1, tsMax, all, kvs(kv1Deleted3, kv1_2_2, kv2_2_2)))
 
 		// Exercise intent handling.
 		txn1, intentErr1 := makeKVTxn(testKey1, ts4)
-		if err := MVCCPut(ctx, e, nil, txn1.TxnMeta.Key, txn1.ReadTimestamp, hlc.ClockTimestamp{}, testValue4, &txn1); err != nil {
+		if err := MVCCPut(ctx, e, txn1.TxnMeta.Key, txn1.ReadTimestamp, testValue4, MVCCWriteOptions{Txn: &txn1}); err != nil {
 			t.Fatal(err)
 		}
 		txn2, intentErr2 := makeKVTxn(testKey2, ts4)
-		if err := MVCCPut(ctx, e, nil, txn2.TxnMeta.Key, txn2.ReadTimestamp, hlc.ClockTimestamp{}, testValue4, &txn2); err != nil {
+		if err := MVCCPut(ctx, e, txn2.TxnMeta.Key, txn2.ReadTimestamp, testValue4, MVCCWriteOptions{Txn: &txn2}); err != nil {
 			t.Fatal(err)
 		}
 		// Single intent tests are verifying behavior when intent collection is not enabled.
@@ -1142,7 +1142,7 @@ func TestMVCCIncrementalIteratorIntentRewrittenConcurrently(t *testing.T) {
 		},
 		ReadTimestamp: ts1,
 	}
-	if err := MVCCPut(ctx, e, nil, kA, ts1, hlc.ClockTimestamp{}, vA1, txn); err != nil {
+	if err := MVCCPut(ctx, e, kA, ts1, vA1, MVCCWriteOptions{Txn: txn}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1160,7 +1160,7 @@ func TestMVCCIncrementalIteratorIntentRewrittenConcurrently(t *testing.T) {
 		// in intentInterleavingIter to be violated.
 		b := e.NewBatch()
 		defer b.Close()
-		if err := MVCCPut(ctx, b, nil, kA, ts1, hlc.ClockTimestamp{}, vA2, txn); err != nil {
+		if err := MVCCPut(ctx, b, kA, ts1, vA2, MVCCWriteOptions{Txn: txn}); err != nil {
 			return err
 		}
 		return b.Commit(false)
@@ -1255,17 +1255,17 @@ func TestMVCCIncrementalIteratorIntentDeletion(t *testing.T) {
 	// kA:3 -> vA3
 	// kA:2 -> vA2
 	// kB -> (intent deletion)
-	require.NoError(t, MVCCPut(ctx, db, nil, kA, txnA1.ReadTimestamp, hlc.ClockTimestamp{}, vA1, txnA1))
-	require.NoError(t, MVCCPut(ctx, db, nil, kB, txnB1.ReadTimestamp, hlc.ClockTimestamp{}, vB1, txnB1))
-	require.NoError(t, MVCCPut(ctx, db, nil, kC, txnC1.ReadTimestamp, hlc.ClockTimestamp{}, vC1, txnC1))
+	require.NoError(t, MVCCPut(ctx, db, kA, txnA1.ReadTimestamp, vA1, MVCCWriteOptions{Txn: txnA1}))
+	require.NoError(t, MVCCPut(ctx, db, kB, txnB1.ReadTimestamp, vB1, MVCCWriteOptions{Txn: txnB1}))
+	require.NoError(t, MVCCPut(ctx, db, kC, txnC1.ReadTimestamp, vC1, MVCCWriteOptions{Txn: txnC1}))
 	require.NoError(t, db.Flush())
 	require.NoError(t, db.Compact())
 	_, _, _, err := MVCCResolveWriteIntent(ctx, db, nil, intent(txnA1), MVCCResolveWriteIntentOptions{})
 	require.NoError(t, err)
 	_, _, _, err = MVCCResolveWriteIntent(ctx, db, nil, intent(txnB1), MVCCResolveWriteIntentOptions{})
 	require.NoError(t, err)
-	require.NoError(t, MVCCPut(ctx, db, nil, kA, ts2, hlc.ClockTimestamp{}, vA2, nil))
-	require.NoError(t, MVCCPut(ctx, db, nil, kA, txnA3.WriteTimestamp, hlc.ClockTimestamp{}, vA3, txnA3))
+	require.NoError(t, MVCCPut(ctx, db, kA, ts2, vA2, MVCCWriteOptions{}))
+	require.NoError(t, MVCCPut(ctx, db, kA, txnA3.WriteTimestamp, vA3, MVCCWriteOptions{Txn: txnA3}))
 	require.NoError(t, db.Flush())
 
 	// The kA ts1 intent has been resolved. There's now a new intent on kA, but
@@ -1314,7 +1314,7 @@ func TestMVCCIncrementalIteratorIntentStraddlesSStables(t *testing.T) {
 
 	put := func(key, value string, ts int64, txn *roachpb.Transaction) {
 		v := roachpb.MakeValueFromString(value)
-		if err := MVCCPut(ctx, db1, nil, roachpb.Key(key), hlc.Timestamp{WallTime: ts}, hlc.ClockTimestamp{}, v, txn); err != nil {
+		if err := MVCCPut(ctx, db1, roachpb.Key(key), hlc.Timestamp{WallTime: ts}, v, MVCCWriteOptions{Txn: txn}); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -1600,7 +1600,7 @@ func BenchmarkMVCCIncrementalIteratorForOldData(b *testing.B) {
 			value := roachpb.MakeValueFromBytes(randutil.RandBytes(rng, valueSize))
 			value.InitChecksum(key)
 			ts := hlc.Timestamp{WallTime: baseTimestamp + 100*int64(i%keyAgeInterval)}
-			if err := MVCCPut(context.Background(), batch, nil, key, ts, hlc.ClockTimestamp{}, value, nil); err != nil {
+			if err := MVCCPut(context.Background(), batch, key, ts, value, MVCCWriteOptions{}); err != nil {
 				b.Fatal(err)
 			}
 		}

--- a/pkg/storage/mvcc_logical_ops_test.go
+++ b/pkg/storage/mvcc_logical_ops_test.go
@@ -36,36 +36,36 @@ func TestMVCCOpLogWriter(t *testing.T) {
 	defer ol.Close()
 
 	// Write a value and an intent.
-	if err := MVCCPut(ctx, ol, nil, testKey1, hlc.Timestamp{Logical: 1}, hlc.ClockTimestamp{}, value1, nil); err != nil {
+	if err := MVCCPut(ctx, ol, testKey1, hlc.Timestamp{Logical: 1}, value1, MVCCWriteOptions{}); err != nil {
 		t.Fatal(err)
 	}
 	txn1ts := makeTxn(*txn1, hlc.Timestamp{Logical: 2})
-	if err := MVCCPut(ctx, ol, nil, testKey1, txn1ts.ReadTimestamp, hlc.ClockTimestamp{}, value2, txn1ts); err != nil {
+	if err := MVCCPut(ctx, ol, testKey1, txn1ts.ReadTimestamp, value2, MVCCWriteOptions{Txn: txn1ts}); err != nil {
 		t.Fatal(err)
 	}
 
 	// Write a value and an intent on local keys.
 	localKey := keys.MakeRangeIDPrefix(1)
-	if err := MVCCPut(ctx, ol, nil, localKey, hlc.Timestamp{Logical: 1}, hlc.ClockTimestamp{}, value1, nil); err != nil {
+	if err := MVCCPut(ctx, ol, localKey, hlc.Timestamp{Logical: 1}, value1, MVCCWriteOptions{}); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(ctx, ol, nil, localKey, txn1ts.ReadTimestamp, hlc.ClockTimestamp{}, value2, txn1ts); err != nil {
+	if err := MVCCPut(ctx, ol, localKey, txn1ts.ReadTimestamp, value2, MVCCWriteOptions{Txn: txn1ts}); err != nil {
 		t.Fatal(err)
 	}
 
 	// Update the intents and write another.
 	txn1ts.Sequence++
 	txn1ts.WriteTimestamp = hlc.Timestamp{Logical: 3}
-	if err := MVCCPut(ctx, ol, nil, testKey1, txn1ts.ReadTimestamp, hlc.ClockTimestamp{}, value2, txn1ts); err != nil {
+	if err := MVCCPut(ctx, ol, testKey1, txn1ts.ReadTimestamp, value2, MVCCWriteOptions{Txn: txn1ts}); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(ctx, ol, nil, localKey, txn1ts.ReadTimestamp, hlc.ClockTimestamp{}, value2, txn1ts); err != nil {
+	if err := MVCCPut(ctx, ol, localKey, txn1ts.ReadTimestamp, value2, MVCCWriteOptions{Txn: txn1ts}); err != nil {
 		t.Fatal(err)
 	}
 	// Set the txn timestamp to a larger value than the intent.
 	txn1LargerTS := makeTxn(*txn1, hlc.Timestamp{Logical: 4})
 	txn1LargerTS.WriteTimestamp = hlc.Timestamp{Logical: 4}
-	if err := MVCCPut(ctx, ol, nil, testKey2, txn1LargerTS.ReadTimestamp, hlc.ClockTimestamp{}, value3, txn1LargerTS); err != nil {
+	if err := MVCCPut(ctx, ol, testKey2, txn1LargerTS.ReadTimestamp, value3, MVCCWriteOptions{Txn: txn1LargerTS}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -89,7 +89,7 @@ func TestMVCCOpLogWriter(t *testing.T) {
 
 	// Write another intent, push it, then abort it.
 	txn2ts := makeTxn(*txn2, hlc.Timestamp{Logical: 5})
-	if err := MVCCPut(ctx, ol, nil, testKey3, txn2ts.ReadTimestamp, hlc.ClockTimestamp{}, value4, txn2ts); err != nil {
+	if err := MVCCPut(ctx, ol, testKey3, txn2ts.ReadTimestamp, value4, MVCCWriteOptions{Txn: txn2ts}); err != nil {
 		t.Fatal(err)
 	}
 	txn2Pushed := *txn2
@@ -110,7 +110,7 @@ func TestMVCCOpLogWriter(t *testing.T) {
 	}
 
 	// Write an inline value. This should be ignored by the log.
-	if err := MVCCPut(ctx, ol, nil, testKey6, hlc.Timestamp{}, hlc.ClockTimestamp{}, value6, nil); err != nil {
+	if err := MVCCPut(ctx, ol, testKey6, hlc.Timestamp{}, value6, MVCCWriteOptions{}); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/storage/mvcc_stats_test.go
+++ b/pkg/storage/mvcc_stats_test.go
@@ -98,7 +98,7 @@ func TestMVCCStatsDeleteCommitMovesTimestamp(t *testing.T) {
 	ts1 := hlc.Timestamp{WallTime: 1e9}
 	// Put a value.
 	value := roachpb.MakeValueFromString("value")
-	if err := MVCCPut(ctx, engine, aggMS, key, ts1, hlc.ClockTimestamp{}, value, nil); err != nil {
+	if err := MVCCPut(ctx, engine, key, ts1, value, MVCCWriteOptions{Stats: aggMS}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -126,7 +126,7 @@ func TestMVCCStatsDeleteCommitMovesTimestamp(t *testing.T) {
 		TxnMeta:       enginepb.TxnMeta{ID: uuid.MakeV4(), WriteTimestamp: ts3},
 		ReadTimestamp: ts3,
 	}
-	if _, err := MVCCDelete(ctx, engine, aggMS, key, txn.ReadTimestamp, hlc.ClockTimestamp{}, txn); err != nil {
+	if _, err := MVCCDelete(ctx, engine, key, txn.ReadTimestamp, MVCCWriteOptions{Txn: txn, Stats: aggMS}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -188,7 +188,7 @@ func TestMVCCStatsPutCommitMovesTimestamp(t *testing.T) {
 	}
 	// Write an intent at t=1s.
 	value := roachpb.MakeValueFromString("value")
-	if err := MVCCPut(ctx, engine, aggMS, key, ts1, hlc.ClockTimestamp{}, value, txn); err != nil {
+	if err := MVCCPut(ctx, engine, key, ts1, value, MVCCWriteOptions{Txn: txn, Stats: aggMS}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -277,7 +277,7 @@ func TestMVCCStatsPutPushMovesTimestamp(t *testing.T) {
 	}
 	// Write an intent.
 	value := roachpb.MakeValueFromString("value")
-	if err := MVCCPut(ctx, engine, aggMS, key, txn.ReadTimestamp, hlc.ClockTimestamp{}, value, txn); err != nil {
+	if err := MVCCPut(ctx, engine, key, txn.ReadTimestamp, value, MVCCWriteOptions{Txn: txn, Stats: aggMS}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -374,7 +374,7 @@ func TestMVCCStatsDeleteMovesTimestamp(t *testing.T) {
 
 	// Write an intent.
 	value := roachpb.MakeValueFromString("value")
-	if err := MVCCPut(ctx, engine, aggMS, key, txn.ReadTimestamp, hlc.ClockTimestamp{}, value, txn); err != nil {
+	if err := MVCCPut(ctx, engine, key, txn.ReadTimestamp, value, MVCCWriteOptions{Txn: txn, Stats: aggMS}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -449,7 +449,7 @@ func TestMVCCStatsDeleteMovesTimestamp(t *testing.T) {
 	}
 	require.EqualValues(t, expM2ValSize, m2ValSize)
 
-	if _, err := MVCCDelete(ctx, engine, aggMS, key, txn.ReadTimestamp, hlc.ClockTimestamp{}, txn); err != nil {
+	if _, err := MVCCDelete(ctx, engine, key, txn.ReadTimestamp, MVCCWriteOptions{Txn: txn, Stats: aggMS}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -504,7 +504,7 @@ func TestMVCCStatsPutMovesDeletionTimestamp(t *testing.T) {
 	}
 
 	// Write a deletion tombstone intent.
-	if _, err := MVCCDelete(ctx, engine, aggMS, key, txn.ReadTimestamp, hlc.ClockTimestamp{}, txn); err != nil {
+	if _, err := MVCCDelete(ctx, engine, key, txn.ReadTimestamp, MVCCWriteOptions{Txn: txn, Stats: aggMS}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -577,7 +577,7 @@ func TestMVCCStatsPutMovesDeletionTimestamp(t *testing.T) {
 		require.EqualValues(t, vVal2Size, 17)
 	}
 
-	if err := MVCCPut(ctx, engine, aggMS, key, txn.ReadTimestamp, hlc.ClockTimestamp{}, value, txn); err != nil {
+	if err := MVCCPut(ctx, engine, key, txn.ReadTimestamp, value, MVCCWriteOptions{Txn: txn, Stats: aggMS}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -625,7 +625,7 @@ func TestMVCCStatsDelDelCommitMovesTimestamp(t *testing.T) {
 	ts3 := hlc.Timestamp{WallTime: 3e9}
 
 	// Write a non-transactional tombstone at t=1s.
-	if _, err := MVCCDelete(ctx, engine, aggMS, key, ts1, hlc.ClockTimestamp{}, nil); err != nil {
+	if _, err := MVCCDelete(ctx, engine, key, ts1, MVCCWriteOptions{Stats: aggMS}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -654,7 +654,7 @@ func TestMVCCStatsDelDelCommitMovesTimestamp(t *testing.T) {
 		TxnMeta:       enginepb.TxnMeta{ID: uuid.MakeV4(), WriteTimestamp: ts2},
 		ReadTimestamp: ts2,
 	}
-	if _, err := MVCCDelete(ctx, engine, aggMS, key, txn.ReadTimestamp, hlc.ClockTimestamp{}, txn); err != nil {
+	if _, err := MVCCDelete(ctx, engine, key, txn.ReadTimestamp, MVCCWriteOptions{Txn: txn, Stats: aggMS}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -779,7 +779,7 @@ func TestMVCCStatsPutDelPutMovesTimestamp(t *testing.T) {
 
 	// Write a non-transactional value at t=1s.
 	value := roachpb.MakeValueFromString("value")
-	if err := MVCCPut(ctx, engine, aggMS, key, ts1, hlc.ClockTimestamp{}, value, nil); err != nil {
+	if err := MVCCPut(ctx, engine, key, ts1, value, MVCCWriteOptions{Stats: aggMS}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -812,7 +812,7 @@ func TestMVCCStatsPutDelPutMovesTimestamp(t *testing.T) {
 		TxnMeta:       enginepb.TxnMeta{ID: uuid.MakeV4(), WriteTimestamp: ts2},
 		ReadTimestamp: ts2,
 	}
-	if _, err := MVCCDelete(ctx, engine, aggMS, key, txn.ReadTimestamp, hlc.ClockTimestamp{}, txn); err != nil {
+	if _, err := MVCCDelete(ctx, engine, key, txn.ReadTimestamp, MVCCWriteOptions{Txn: txn, Stats: aggMS}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -903,7 +903,7 @@ func TestMVCCStatsPutDelPutMovesTimestamp(t *testing.T) {
 		}
 
 		txn.WriteTimestamp.Forward(ts3)
-		if err := MVCCPut(ctx, engine, &aggMS, key, txn.ReadTimestamp, hlc.ClockTimestamp{}, val2, txn); err != nil {
+		if err := MVCCPut(ctx, engine, key, txn.ReadTimestamp, val2, MVCCWriteOptions{Txn: txn, Stats: &aggMS}); err != nil {
 			t.Fatal(err)
 		}
 
@@ -963,10 +963,10 @@ func TestMVCCStatsDelDelGC(t *testing.T) {
 	ts2 := hlc.Timestamp{WallTime: 2e9}
 
 	// Write tombstones at ts1 and ts2.
-	if _, err := MVCCDelete(ctx, engine, aggMS, key, ts1, hlc.ClockTimestamp{}, nil); err != nil {
+	if _, err := MVCCDelete(ctx, engine, key, ts1, MVCCWriteOptions{Stats: aggMS}); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := MVCCDelete(ctx, engine, aggMS, key, ts2, hlc.ClockTimestamp{}, nil); err != nil {
+	if _, err := MVCCDelete(ctx, engine, key, ts2, MVCCWriteOptions{Stats: aggMS}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1046,7 +1046,7 @@ func TestMVCCStatsPutIntentTimestampNotPutTimestamp(t *testing.T) {
 	}
 	// Write an intent at 2s+1.
 	value := roachpb.MakeValueFromString("value")
-	if err := MVCCPut(ctx, engine, aggMS, key, txn.ReadTimestamp, hlc.ClockTimestamp{}, value, txn); err != nil {
+	if err := MVCCPut(ctx, engine, key, txn.ReadTimestamp, value, MVCCWriteOptions{Txn: txn, Stats: aggMS}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1096,7 +1096,7 @@ func TestMVCCStatsPutIntentTimestampNotPutTimestamp(t *testing.T) {
 			{Sequence: 0, Value: encValue},
 		},
 	}).Size())
-	if err := MVCCPut(ctx, engine, aggMS, key, txn.ReadTimestamp, hlc.ClockTimestamp{}, value, txn); err != nil {
+	if err := MVCCPut(ctx, engine, key, txn.ReadTimestamp, value, MVCCWriteOptions{Txn: txn, Stats: aggMS}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1141,7 +1141,7 @@ func TestMVCCStatsPutWaitDeleteGC(t *testing.T) {
 
 	// Write a value at ts1.
 	val1 := roachpb.MakeValueFromString("value")
-	if err := MVCCPut(ctx, engine, aggMS, key, ts1, hlc.ClockTimestamp{}, val1, nil); err != nil {
+	if err := MVCCPut(ctx, engine, key, ts1, val1, MVCCWriteOptions{Stats: aggMS}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1171,7 +1171,7 @@ func TestMVCCStatsPutWaitDeleteGC(t *testing.T) {
 
 	// Delete the value at ts5.
 
-	if _, err := MVCCDelete(ctx, engine, aggMS, key, ts2, hlc.ClockTimestamp{}, nil); err != nil {
+	if _, err := MVCCDelete(ctx, engine, key, ts2, MVCCWriteOptions{Stats: aggMS}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1240,7 +1240,7 @@ func TestMVCCStatsTxnSysPutPut(t *testing.T) {
 
 	// Write an intent at ts1.
 	val1 := roachpb.MakeValueFromString("value")
-	if err := MVCCPut(ctx, engine, aggMS, key, txn.ReadTimestamp, hlc.ClockTimestamp{}, val1, txn); err != nil {
+	if err := MVCCPut(ctx, engine, key, txn.ReadTimestamp, val1, MVCCWriteOptions{Txn: txn, Stats: aggMS}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1303,7 +1303,7 @@ func TestMVCCStatsTxnSysPutPut(t *testing.T) {
 	}
 	require.EqualValues(t, expMVal2Size, mVal2Size)
 
-	if err := MVCCPut(ctx, engine, aggMS, key, txn.ReadTimestamp, hlc.ClockTimestamp{}, val2, txn); err != nil {
+	if err := MVCCPut(ctx, engine, key, txn.ReadTimestamp, val2, MVCCWriteOptions{Txn: txn, Stats: aggMS}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1340,7 +1340,7 @@ func TestMVCCStatsTxnSysPutAbort(t *testing.T) {
 
 	// Write a system intent at ts1.
 	val1 := roachpb.MakeValueFromString("value")
-	if err := MVCCPut(ctx, engine, aggMS, key, txn.ReadTimestamp, hlc.ClockTimestamp{}, val1, txn); err != nil {
+	if err := MVCCPut(ctx, engine, key, txn.ReadTimestamp, val1, MVCCWriteOptions{Txn: txn, Stats: aggMS}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1415,7 +1415,7 @@ func TestMVCCStatsSysPutPut(t *testing.T) {
 
 	// Write a value at ts1.
 	val1 := roachpb.MakeValueFromString("value")
-	if err := MVCCPut(ctx, engine, aggMS, key, ts1, hlc.ClockTimestamp{}, val1, nil); err != nil {
+	if err := MVCCPut(ctx, engine, key, ts1, val1, MVCCWriteOptions{Stats: aggMS}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1449,7 +1449,7 @@ func TestMVCCStatsSysPutPut(t *testing.T) {
 
 	// Put another value at ts2.
 
-	if err := MVCCPut(ctx, engine, aggMS, key, ts2, hlc.ClockTimestamp{}, val2, nil); err != nil {
+	if err := MVCCPut(ctx, engine, key, ts2, val2, MVCCWriteOptions{Stats: aggMS}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1642,26 +1642,42 @@ func TestMVCCStatsRandomized(t *testing.T) {
 	}
 
 	actions["Put"] = func(s *state) (bool, string) {
-		if err := MVCCPut(ctx, s.batch, s.MSDelta, s.key, s.TS, hlc.ClockTimestamp{}, s.rngVal(), s.Txn); err != nil {
+		opts := MVCCWriteOptions{
+			Txn:   s.Txn,
+			Stats: s.MSDelta,
+		}
+		if err := MVCCPut(ctx, s.batch, s.key, s.TS, s.rngVal(), opts); err != nil {
 			return false, err.Error()
 		}
 		return true, ""
 	}
 	actions["InitPut"] = func(s *state) (bool, string) {
+		opts := MVCCWriteOptions{
+			Txn:   s.Txn,
+			Stats: s.MSDelta,
+		}
 		failOnTombstones := s.rng.Intn(2) == 0
 		desc := fmt.Sprintf("failOnTombstones=%t", failOnTombstones)
-		if err := MVCCInitPut(ctx, s.batch, s.MSDelta, s.key, s.TS, hlc.ClockTimestamp{}, s.rngVal(), failOnTombstones, s.Txn); err != nil {
+		if err := MVCCInitPut(ctx, s.batch, s.key, s.TS, s.rngVal(), failOnTombstones, opts); err != nil {
 			return false, desc + ": " + err.Error()
 		}
 		return true, desc
 	}
 	actions["Del"] = func(s *state) (bool, string) {
-		if _, err := MVCCDelete(ctx, s.batch, s.MSDelta, s.key, s.TS, hlc.ClockTimestamp{}, s.Txn); err != nil {
+		opts := MVCCWriteOptions{
+			Txn:   s.Txn,
+			Stats: s.MSDelta,
+		}
+		if _, err := MVCCDelete(ctx, s.batch, s.key, s.TS, opts); err != nil {
 			return false, err.Error()
 		}
 		return true, ""
 	}
 	actions["DelRange"] = func(s *state) (bool, string) {
+		opts := MVCCWriteOptions{
+			Txn:   s.Txn,
+			Stats: s.MSDelta,
+		}
 		keySpan := currentKeySpan(s)
 
 		mvccRangeDel := !s.isLocalKey && s.Txn == nil && s.rng.Intn(2) == 0
@@ -1699,7 +1715,7 @@ func TestMVCCStatsRandomized(t *testing.T) {
 		if !mvccRangeDel {
 			desc = fmt.Sprintf("mvccDeleteRange=%s, returnKeys=%t, max=%d", keySpan, returnKeys, max)
 			_, _, _, err = MVCCDeleteRange(
-				ctx, s.batch, s.MSDelta, keySpan.Key, keySpan.EndKey, max, s.TS, hlc.ClockTimestamp{}, s.Txn, returnKeys,
+				ctx, s.batch, keySpan.Key, keySpan.EndKey, max, s.TS, opts, returnKeys,
 			)
 		} else if predicates == (kvpb.DeleteRangePredicates{}) {
 			desc = fmt.Sprintf("mvccDeleteRangeUsingTombstone=%s",

--- a/pkg/storage/mvcc_test.go
+++ b/pkg/storage/mvcc_test.go
@@ -270,10 +270,10 @@ func TestMVCCGetNoMoreOldVersion(t *testing.T) {
 	// b<T=1>
 	//
 	// If we search for a<T=2>, the scan should not return "b".
-	if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 3}, hlc.ClockTimestamp{}, value1, nil); err != nil {
+	if err := MVCCPut(ctx, engine, testKey1, hlc.Timestamp{WallTime: 3}, value1, MVCCWriteOptions{}); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(ctx, engine, nil, testKey2, hlc.Timestamp{WallTime: 1}, hlc.ClockTimestamp{}, value2, nil); err != nil {
+	if err := MVCCPut(ctx, engine, testKey2, hlc.Timestamp{WallTime: 1}, value2, MVCCWriteOptions{}); err != nil {
 		t.Fatal(err)
 	}
 	valueRes, err := MVCCGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 2}, MVCCGetOptions{})
@@ -293,7 +293,7 @@ func TestMVCCGetWithValueHeader(t *testing.T) {
 	engine := NewDefaultInMemForTesting()
 	defer engine.Close()
 
-	if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 1, Logical: 1}, hlc.ClockTimestamp{WallTime: 1}, value1, nil); err != nil {
+	if err := MVCCPut(ctx, engine, testKey1, hlc.Timestamp{WallTime: 1, Logical: 1}, value1, MVCCWriteOptions{LocalTimestamp: hlc.ClockTimestamp{WallTime: 1}}); err != nil {
 		t.Fatal(err)
 	}
 	valueRes, vh, err := MVCCGetWithValueHeader(ctx, engine, testKey1, hlc.Timestamp{WallTime: 2}, MVCCGetOptions{})
@@ -305,7 +305,7 @@ func TestMVCCGetWithValueHeader(t *testing.T) {
 	}
 	require.Equal(t, hlc.ClockTimestamp{WallTime: 1}, vh.LocalTimestamp)
 
-	_, err = MVCCDelete(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 3}, hlc.ClockTimestamp{WallTime: 2, Logical: 1}, nil)
+	_, err = MVCCDelete(ctx, engine, testKey1, hlc.Timestamp{WallTime: 3}, MVCCWriteOptions{LocalTimestamp: hlc.ClockTimestamp{WallTime: 2, Logical: 1}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -354,11 +354,11 @@ func TestMVCCWriteWithOlderTimestampAfterDeletionOfNonexistentKey(t *testing.T) 
 	engine := NewDefaultInMemForTesting()
 	defer engine.Close()
 
-	if _, err := MVCCDelete(context.Background(), engine, nil, testKey1, hlc.Timestamp{WallTime: 3}, hlc.ClockTimestamp{}, nil); err != nil {
+	if _, err := MVCCDelete(context.Background(), engine, testKey1, hlc.Timestamp{WallTime: 3}, MVCCWriteOptions{}); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := MVCCPut(context.Background(), engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, hlc.ClockTimestamp{}, value1, nil); !testutils.IsError(
+	if err := MVCCPut(context.Background(), engine, testKey1, hlc.Timestamp{WallTime: 1}, value1, MVCCWriteOptions{}); !testutils.IsError(
 		err, "write for key \"/db1\" at timestamp 0.000000001,0 too old; wrote at 0.000000003,1",
 	) {
 		t.Fatal(err)
@@ -401,7 +401,7 @@ func TestMVCCInlineWithTxn(t *testing.T) {
 	defer engine.Close()
 
 	// Put an inline value.
-	if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{}, hlc.ClockTimestamp{}, value1, nil); err != nil {
+	if err := MVCCPut(ctx, engine, testKey1, hlc.Timestamp{}, value1, MVCCWriteOptions{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -423,7 +423,7 @@ func TestMVCCInlineWithTxn(t *testing.T) {
 	}
 
 	// Verify inline put with txn is an error.
-	err = MVCCPut(ctx, engine, nil, testKey2, hlc.Timestamp{}, hlc.ClockTimestamp{}, value2, txn2)
+	err = MVCCPut(ctx, engine, testKey2, hlc.Timestamp{}, value2, MVCCWriteOptions{Txn: txn2})
 	if !testutils.IsError(err, "writes not allowed within transactions") {
 		t.Errorf("unexpected error: %+v", err)
 	}
@@ -439,7 +439,7 @@ func TestMVCCDeleteMissingKey(t *testing.T) {
 	engine := NewDefaultInMemForTesting()
 	defer engine.Close()
 
-	if _, err := MVCCDelete(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, hlc.ClockTimestamp{}, nil); err != nil {
+	if _, err := MVCCDelete(ctx, engine, testKey1, hlc.Timestamp{WallTime: 1}, MVCCWriteOptions{}); err != nil {
 		t.Fatal(err)
 	}
 	require.Empty(t, mvccGetRaw(t, engine, mvccKey(testKey1)))
@@ -456,7 +456,7 @@ func TestMVCCGetAndDeleteInTxn(t *testing.T) {
 
 	txn := makeTxn(*txn1, hlc.Timestamp{WallTime: 1})
 	txn.Sequence++
-	if err := MVCCPut(ctx, engine, nil, testKey1, txn.ReadTimestamp, hlc.ClockTimestamp{}, value1, txn); err != nil {
+	if err := MVCCPut(ctx, engine, testKey1, txn.ReadTimestamp, value1, MVCCWriteOptions{Txn: txn}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -470,7 +470,7 @@ func TestMVCCGetAndDeleteInTxn(t *testing.T) {
 
 	txn.Sequence++
 	txn.WriteTimestamp = hlc.Timestamp{WallTime: 3}
-	if _, err := MVCCDelete(ctx, engine, nil, testKey1, txn.ReadTimestamp, hlc.ClockTimestamp{}, txn); err != nil {
+	if _, err := MVCCDelete(ctx, engine, testKey1, txn.ReadTimestamp, MVCCWriteOptions{Txn: txn}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -509,7 +509,7 @@ func TestMVCCGetWriteIntentError(t *testing.T) {
 	engine := NewDefaultInMemForTesting()
 	defer engine.Close()
 
-	if err := MVCCPut(ctx, engine, nil, testKey1, txn1.ReadTimestamp, hlc.ClockTimestamp{}, value1, txn1); err != nil {
+	if err := MVCCPut(ctx, engine, testKey1, txn1.ReadTimestamp, value1, MVCCWriteOptions{Txn: txn1}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -562,7 +562,7 @@ func TestMVCCScanWriteIntentError(t *testing.T) {
 	for i, kv := range fixtureKVs {
 		v := *protoutil.Clone(&kv.Value).(*roachpb.Value)
 		v.Timestamp = hlc.Timestamp{}
-		if err := MVCCPut(ctx, engine, nil, kv.Key, kv.Value.Timestamp, hlc.ClockTimestamp{}, v, txnMap[i]); err != nil {
+		if err := MVCCPut(ctx, engine, kv.Key, kv.Value.Timestamp, v, MVCCWriteOptions{Txn: txnMap[i]}); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -665,11 +665,11 @@ func TestMVCCGetInconsistent(t *testing.T) {
 	defer engine.Close()
 
 	// Put two values to key 1, the latest with a txn.
-	if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, hlc.ClockTimestamp{}, value1, nil); err != nil {
+	if err := MVCCPut(ctx, engine, testKey1, hlc.Timestamp{WallTime: 1}, value1, MVCCWriteOptions{}); err != nil {
 		t.Fatal(err)
 	}
 	txn1ts := makeTxn(*txn1, hlc.Timestamp{WallTime: 2})
-	if err := MVCCPut(ctx, engine, nil, testKey1, txn1ts.ReadTimestamp, hlc.ClockTimestamp{}, value2, txn1ts); err != nil {
+	if err := MVCCPut(ctx, engine, testKey1, txn1ts.ReadTimestamp, value2, MVCCWriteOptions{Txn: txn1ts}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -699,7 +699,7 @@ func TestMVCCGetInconsistent(t *testing.T) {
 	}
 
 	// Write a single intent for key 2 and verify get returns empty.
-	if err := MVCCPut(ctx, engine, nil, testKey2, txn2.ReadTimestamp, hlc.ClockTimestamp{}, value1, txn2); err != nil {
+	if err := MVCCPut(ctx, engine, testKey2, txn2.ReadTimestamp, value1, MVCCWriteOptions{Txn: txn2}); err != nil {
 		t.Fatal(err)
 	}
 	res, err := MVCCGet(ctx, engine, testKey2, hlc.Timestamp{WallTime: 2},
@@ -735,11 +735,11 @@ func TestMVCCGetProtoInconsistent(t *testing.T) {
 	v2 := roachpb.MakeValueFromBytes(bytes2)
 
 	// Put two values to key 1, the latest with a txn.
-	if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, hlc.ClockTimestamp{}, v1, nil); err != nil {
+	if err := MVCCPut(ctx, engine, testKey1, hlc.Timestamp{WallTime: 1}, v1, MVCCWriteOptions{}); err != nil {
 		t.Fatal(err)
 	}
 	txn1ts := makeTxn(*txn1, hlc.Timestamp{WallTime: 2})
-	if err := MVCCPut(ctx, engine, nil, testKey1, txn1ts.ReadTimestamp, hlc.ClockTimestamp{}, v2, txn1ts); err != nil {
+	if err := MVCCPut(ctx, engine, testKey1, txn1ts.ReadTimestamp, v2, MVCCWriteOptions{Txn: txn1ts}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -781,7 +781,7 @@ func TestMVCCGetProtoInconsistent(t *testing.T) {
 
 	{
 		// Write a single intent for key 2 and verify get returns empty.
-		if err := MVCCPut(ctx, engine, nil, testKey2, txn2.ReadTimestamp, hlc.ClockTimestamp{}, v1, txn2); err != nil {
+		if err := MVCCPut(ctx, engine, testKey2, txn2.ReadTimestamp, v1, MVCCWriteOptions{Txn: txn2}); err != nil {
 			t.Fatal(err)
 		}
 		val := roachpb.Value{}
@@ -800,10 +800,10 @@ func TestMVCCGetProtoInconsistent(t *testing.T) {
 		// Write a malformed value (not an encoded MVCCKeyValue) and a
 		// write intent to key 3; the parse error is returned instead of the
 		// write intent.
-		if err := MVCCPut(ctx, engine, nil, testKey3, hlc.Timestamp{WallTime: 1}, hlc.ClockTimestamp{}, value3, nil); err != nil {
+		if err := MVCCPut(ctx, engine, testKey3, hlc.Timestamp{WallTime: 1}, value3, MVCCWriteOptions{}); err != nil {
 			t.Fatal(err)
 		}
-		if err := MVCCPut(ctx, engine, nil, testKey3, txn1ts.ReadTimestamp, hlc.ClockTimestamp{}, v2, txn1ts); err != nil {
+		if err := MVCCPut(ctx, engine, testKey3, txn1ts.ReadTimestamp, v2, MVCCWriteOptions{Txn: txn1ts}); err != nil {
 			t.Fatal(err)
 		}
 		val := roachpb.Value{}
@@ -837,7 +837,7 @@ func TestMVCCInvalidateIterator(t *testing.T) {
 			ts2 := hlc.Timestamp{WallTime: 2}
 
 			key := roachpb.Key("a")
-			if err := MVCCPut(ctx, engine, nil, key, ts1, hlc.ClockTimestamp{}, value1, nil); err != nil {
+			if err := MVCCPut(ctx, engine, key, ts1, value1, MVCCWriteOptions{}); err != nil {
 				t.Fatal(err)
 			}
 
@@ -892,28 +892,28 @@ func TestMVCCInvalidateIterator(t *testing.T) {
 }
 
 func mvccScanTest(ctx context.Context, t *testing.T, engine Engine) {
-	if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, hlc.ClockTimestamp{}, value1, nil); err != nil {
+	if err := MVCCPut(ctx, engine, testKey1, hlc.Timestamp{WallTime: 1}, value1, MVCCWriteOptions{}); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 2}, hlc.ClockTimestamp{}, value4, nil); err != nil {
+	if err := MVCCPut(ctx, engine, testKey1, hlc.Timestamp{WallTime: 2}, value4, MVCCWriteOptions{}); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(ctx, engine, nil, testKey2, hlc.Timestamp{WallTime: 1}, hlc.ClockTimestamp{}, value2, nil); err != nil {
+	if err := MVCCPut(ctx, engine, testKey2, hlc.Timestamp{WallTime: 1}, value2, MVCCWriteOptions{}); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(ctx, engine, nil, testKey2, hlc.Timestamp{WallTime: 3}, hlc.ClockTimestamp{}, value3, nil); err != nil {
+	if err := MVCCPut(ctx, engine, testKey2, hlc.Timestamp{WallTime: 3}, value3, MVCCWriteOptions{}); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(ctx, engine, nil, testKey3, hlc.Timestamp{WallTime: 1}, hlc.ClockTimestamp{}, value3, nil); err != nil {
+	if err := MVCCPut(ctx, engine, testKey3, hlc.Timestamp{WallTime: 1}, value3, MVCCWriteOptions{}); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(ctx, engine, nil, testKey3, hlc.Timestamp{WallTime: 4}, hlc.ClockTimestamp{}, value2, nil); err != nil {
+	if err := MVCCPut(ctx, engine, testKey3, hlc.Timestamp{WallTime: 4}, value2, MVCCWriteOptions{}); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(ctx, engine, nil, testKey4, hlc.Timestamp{WallTime: 1}, hlc.ClockTimestamp{}, value4, nil); err != nil {
+	if err := MVCCPut(ctx, engine, testKey4, hlc.Timestamp{WallTime: 1}, value4, MVCCWriteOptions{}); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(ctx, engine, nil, testKey4, hlc.Timestamp{WallTime: 5}, hlc.ClockTimestamp{}, value1, nil); err != nil {
+	if err := MVCCPut(ctx, engine, testKey4, hlc.Timestamp{WallTime: 5}, value1, MVCCWriteOptions{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1006,19 +1006,19 @@ func TestMVCCScanMaxNum(t *testing.T) {
 	engine := NewDefaultInMemForTesting()
 	defer engine.Close()
 
-	if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, hlc.ClockTimestamp{}, value1, nil); err != nil {
+	if err := MVCCPut(ctx, engine, testKey1, hlc.Timestamp{WallTime: 1}, value1, MVCCWriteOptions{}); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(ctx, engine, nil, testKey2, hlc.Timestamp{WallTime: 1}, hlc.ClockTimestamp{}, value2, nil); err != nil {
+	if err := MVCCPut(ctx, engine, testKey2, hlc.Timestamp{WallTime: 1}, value2, MVCCWriteOptions{}); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(ctx, engine, nil, testKey3, hlc.Timestamp{WallTime: 1}, hlc.ClockTimestamp{}, value3, nil); err != nil {
+	if err := MVCCPut(ctx, engine, testKey3, hlc.Timestamp{WallTime: 1}, value3, MVCCWriteOptions{}); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(ctx, engine, nil, testKey4, hlc.Timestamp{WallTime: 1}, hlc.ClockTimestamp{}, value4, nil); err != nil {
+	if err := MVCCPut(ctx, engine, testKey4, hlc.Timestamp{WallTime: 1}, value4, MVCCWriteOptions{}); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(ctx, engine, nil, testKey6, hlc.Timestamp{WallTime: 1}, hlc.ClockTimestamp{}, value4, nil); err != nil {
+	if err := MVCCPut(ctx, engine, testKey6, hlc.Timestamp{WallTime: 1}, value4, MVCCWriteOptions{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1094,19 +1094,19 @@ func TestMVCCScanWithKeyPrefix(t *testing.T) {
 	// b<T=5>
 	// In this case, if we scan from "a"-"b", we wish to skip
 	// a<T=2> and a<T=1> and find "aa'.
-	if err := MVCCPut(ctx, engine, nil, roachpb.Key("/a"), hlc.Timestamp{WallTime: 1}, hlc.ClockTimestamp{}, value1, nil); err != nil {
+	if err := MVCCPut(ctx, engine, roachpb.Key("/a"), hlc.Timestamp{WallTime: 1}, value1, MVCCWriteOptions{}); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(ctx, engine, nil, roachpb.Key("/a"), hlc.Timestamp{WallTime: 2}, hlc.ClockTimestamp{}, value2, nil); err != nil {
+	if err := MVCCPut(ctx, engine, roachpb.Key("/a"), hlc.Timestamp{WallTime: 2}, value2, MVCCWriteOptions{}); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(ctx, engine, nil, roachpb.Key("/aa"), hlc.Timestamp{WallTime: 2}, hlc.ClockTimestamp{}, value2, nil); err != nil {
+	if err := MVCCPut(ctx, engine, roachpb.Key("/aa"), hlc.Timestamp{WallTime: 2}, value2, MVCCWriteOptions{}); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(ctx, engine, nil, roachpb.Key("/aa"), hlc.Timestamp{WallTime: 3}, hlc.ClockTimestamp{}, value3, nil); err != nil {
+	if err := MVCCPut(ctx, engine, roachpb.Key("/aa"), hlc.Timestamp{WallTime: 3}, value3, MVCCWriteOptions{}); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(ctx, engine, nil, roachpb.Key("/b"), hlc.Timestamp{WallTime: 1}, hlc.ClockTimestamp{}, value3, nil); err != nil {
+	if err := MVCCPut(ctx, engine, roachpb.Key("/b"), hlc.Timestamp{WallTime: 1}, value3, MVCCWriteOptions{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1132,17 +1132,17 @@ func TestMVCCScanInTxn(t *testing.T) {
 	engine := NewDefaultInMemForTesting()
 	defer engine.Close()
 
-	if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, hlc.ClockTimestamp{}, value1, nil); err != nil {
+	if err := MVCCPut(ctx, engine, testKey1, hlc.Timestamp{WallTime: 1}, value1, MVCCWriteOptions{}); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(ctx, engine, nil, testKey2, hlc.Timestamp{WallTime: 1}, hlc.ClockTimestamp{}, value2, nil); err != nil {
+	if err := MVCCPut(ctx, engine, testKey2, hlc.Timestamp{WallTime: 1}, value2, MVCCWriteOptions{}); err != nil {
 		t.Fatal(err)
 	}
 	txn := makeTxn(*txn1, hlc.Timestamp{WallTime: 1})
-	if err := MVCCPut(ctx, engine, nil, testKey3, txn.ReadTimestamp, hlc.ClockTimestamp{}, value3, txn); err != nil {
+	if err := MVCCPut(ctx, engine, testKey3, txn.ReadTimestamp, value3, MVCCWriteOptions{Txn: txn}); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(ctx, engine, nil, testKey4, hlc.Timestamp{WallTime: 1}, hlc.ClockTimestamp{}, value4, nil); err != nil {
+	if err := MVCCPut(ctx, engine, testKey4, hlc.Timestamp{WallTime: 1}, value4, MVCCWriteOptions{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1190,24 +1190,24 @@ func TestMVCCScanInconsistent(t *testing.T) {
 	ts4 := hlc.Timestamp{WallTime: 4}
 	ts5 := hlc.Timestamp{WallTime: 5}
 	ts6 := hlc.Timestamp{WallTime: 6}
-	if err := MVCCPut(ctx, engine, nil, testKey1, ts1, hlc.ClockTimestamp{}, value1, nil); err != nil {
+	if err := MVCCPut(ctx, engine, testKey1, ts1, value1, MVCCWriteOptions{}); err != nil {
 		t.Fatal(err)
 	}
 	txn1ts2 := makeTxn(*txn1, ts2)
-	if err := MVCCPut(ctx, engine, nil, testKey1, txn1ts2.ReadTimestamp, hlc.ClockTimestamp{}, value2, txn1ts2); err != nil {
+	if err := MVCCPut(ctx, engine, testKey1, txn1ts2.ReadTimestamp, value2, MVCCWriteOptions{Txn: txn1ts2}); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(ctx, engine, nil, testKey2, ts3, hlc.ClockTimestamp{}, value1, nil); err != nil {
+	if err := MVCCPut(ctx, engine, testKey2, ts3, value1, MVCCWriteOptions{}); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(ctx, engine, nil, testKey2, ts4, hlc.ClockTimestamp{}, value2, nil); err != nil {
+	if err := MVCCPut(ctx, engine, testKey2, ts4, value2, MVCCWriteOptions{}); err != nil {
 		t.Fatal(err)
 	}
 	txn2ts5 := makeTxn(*txn2, ts5)
-	if err := MVCCPut(ctx, engine, nil, testKey3, txn2ts5.ReadTimestamp, hlc.ClockTimestamp{}, value3, txn2ts5); err != nil {
+	if err := MVCCPut(ctx, engine, testKey3, txn2ts5.ReadTimestamp, value3, MVCCWriteOptions{Txn: txn2ts5}); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(ctx, engine, nil, testKey4, ts6, hlc.ClockTimestamp{}, value4, nil); err != nil {
+	if err := MVCCPut(ctx, engine, testKey4, ts6, value4, MVCCWriteOptions{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1264,28 +1264,28 @@ func TestMVCCDeleteRange(t *testing.T) {
 	engine := NewDefaultInMemForTesting()
 	defer engine.Close()
 
-	if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, hlc.ClockTimestamp{}, value1, nil); err != nil {
+	if err := MVCCPut(ctx, engine, testKey1, hlc.Timestamp{WallTime: 1}, value1, MVCCWriteOptions{}); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(ctx, engine, nil, testKey2, hlc.Timestamp{WallTime: 1}, hlc.ClockTimestamp{}, value2, nil); err != nil {
+	if err := MVCCPut(ctx, engine, testKey2, hlc.Timestamp{WallTime: 1}, value2, MVCCWriteOptions{}); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(ctx, engine, nil, testKey3, hlc.Timestamp{WallTime: 1}, hlc.ClockTimestamp{}, value3, nil); err != nil {
+	if err := MVCCPut(ctx, engine, testKey3, hlc.Timestamp{WallTime: 1}, value3, MVCCWriteOptions{}); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(ctx, engine, nil, testKey4, hlc.Timestamp{WallTime: 1}, hlc.ClockTimestamp{}, value4, nil); err != nil {
+	if err := MVCCPut(ctx, engine, testKey4, hlc.Timestamp{WallTime: 1}, value4, MVCCWriteOptions{}); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(ctx, engine, nil, testKey5, hlc.Timestamp{WallTime: 1}, hlc.ClockTimestamp{}, value5, nil); err != nil {
+	if err := MVCCPut(ctx, engine, testKey5, hlc.Timestamp{WallTime: 1}, value5, MVCCWriteOptions{}); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(ctx, engine, nil, testKey6, hlc.Timestamp{WallTime: 1}, hlc.ClockTimestamp{}, value6, nil); err != nil {
+	if err := MVCCPut(ctx, engine, testKey6, hlc.Timestamp{WallTime: 1}, value6, MVCCWriteOptions{}); err != nil {
 		t.Fatal(err)
 	}
 
 	// Attempt to delete two keys.
-	deleted, resumeSpan, num, err := MVCCDeleteRange(ctx, engine, nil, testKey2, testKey6,
-		2, hlc.Timestamp{WallTime: 2}, hlc.ClockTimestamp{}, nil, false)
+	deleted, resumeSpan, num, err := MVCCDeleteRange(ctx, engine, testKey2, testKey6,
+		2, hlc.Timestamp{WallTime: 2}, MVCCWriteOptions{}, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1340,8 +1340,8 @@ func TestMVCCDeleteRange(t *testing.T) {
 	}
 
 	// Attempt to delete no keys.
-	deleted, resumeSpan, num, err = MVCCDeleteRange(ctx, engine, nil, testKey2, testKey6,
-		-1, hlc.Timestamp{WallTime: 2}, hlc.ClockTimestamp{}, nil, false)
+	deleted, resumeSpan, num, err = MVCCDeleteRange(ctx, engine, testKey2, testKey6,
+		-1, hlc.Timestamp{WallTime: 2}, MVCCWriteOptions{}, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1368,8 +1368,8 @@ func TestMVCCDeleteRange(t *testing.T) {
 		t.Fatal("the value should not be empty")
 	}
 
-	deleted, resumeSpan, num, err = MVCCDeleteRange(ctx, engine, nil, testKey4, keyMax,
-		0, hlc.Timestamp{WallTime: 2}, hlc.ClockTimestamp{}, nil, false)
+	deleted, resumeSpan, num, err = MVCCDeleteRange(ctx, engine, testKey4, keyMax,
+		0, hlc.Timestamp{WallTime: 2}, MVCCWriteOptions{}, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1393,8 +1393,8 @@ func TestMVCCDeleteRange(t *testing.T) {
 		t.Fatalf("the value should not be empty: %+v", res.KVs)
 	}
 
-	deleted, resumeSpan, num, err = MVCCDeleteRange(ctx, engine, nil, localMax, testKey2,
-		0, hlc.Timestamp{WallTime: 2}, hlc.ClockTimestamp{}, nil, false)
+	deleted, resumeSpan, num, err = MVCCDeleteRange(ctx, engine, localMax, testKey2,
+		0, hlc.Timestamp{WallTime: 2}, MVCCWriteOptions{}, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1425,28 +1425,28 @@ func TestMVCCDeleteRangeReturnKeys(t *testing.T) {
 	engine := NewDefaultInMemForTesting()
 	defer engine.Close()
 
-	if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, hlc.ClockTimestamp{}, value1, nil); err != nil {
+	if err := MVCCPut(ctx, engine, testKey1, hlc.Timestamp{WallTime: 1}, value1, MVCCWriteOptions{}); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(ctx, engine, nil, testKey2, hlc.Timestamp{WallTime: 1}, hlc.ClockTimestamp{}, value2, nil); err != nil {
+	if err := MVCCPut(ctx, engine, testKey2, hlc.Timestamp{WallTime: 1}, value2, MVCCWriteOptions{}); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(ctx, engine, nil, testKey3, hlc.Timestamp{WallTime: 1}, hlc.ClockTimestamp{}, value3, nil); err != nil {
+	if err := MVCCPut(ctx, engine, testKey3, hlc.Timestamp{WallTime: 1}, value3, MVCCWriteOptions{}); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(ctx, engine, nil, testKey4, hlc.Timestamp{WallTime: 1}, hlc.ClockTimestamp{}, value4, nil); err != nil {
+	if err := MVCCPut(ctx, engine, testKey4, hlc.Timestamp{WallTime: 1}, value4, MVCCWriteOptions{}); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(ctx, engine, nil, testKey5, hlc.Timestamp{WallTime: 1}, hlc.ClockTimestamp{}, value5, nil); err != nil {
+	if err := MVCCPut(ctx, engine, testKey5, hlc.Timestamp{WallTime: 1}, value5, MVCCWriteOptions{}); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(ctx, engine, nil, testKey6, hlc.Timestamp{WallTime: 1}, hlc.ClockTimestamp{}, value6, nil); err != nil {
+	if err := MVCCPut(ctx, engine, testKey6, hlc.Timestamp{WallTime: 1}, value6, MVCCWriteOptions{}); err != nil {
 		t.Fatal(err)
 	}
 
 	// Attempt to delete two keys.
-	deleted, resumeSpan, num, err := MVCCDeleteRange(ctx, engine, nil, testKey2, testKey6,
-		2, hlc.Timestamp{WallTime: 2}, hlc.ClockTimestamp{}, nil, true)
+	deleted, resumeSpan, num, err := MVCCDeleteRange(ctx, engine, testKey2, testKey6,
+		2, hlc.Timestamp{WallTime: 2}, MVCCWriteOptions{}, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1480,8 +1480,8 @@ func TestMVCCDeleteRangeReturnKeys(t *testing.T) {
 	}
 
 	// Attempt to delete no keys.
-	deleted, resumeSpan, num, err = MVCCDeleteRange(ctx, engine, nil, testKey2, testKey6,
-		-1, hlc.Timestamp{WallTime: 2}, hlc.ClockTimestamp{}, nil, true)
+	deleted, resumeSpan, num, err = MVCCDeleteRange(ctx, engine, testKey2, testKey6,
+		-1, hlc.Timestamp{WallTime: 2}, MVCCWriteOptions{}, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1508,8 +1508,8 @@ func TestMVCCDeleteRangeReturnKeys(t *testing.T) {
 		t.Fatal("the value should not be empty")
 	}
 
-	deleted, resumeSpan, num, err = MVCCDeleteRange(ctx, engine, nil, testKey4, keyMax,
-		math.MaxInt64, hlc.Timestamp{WallTime: 2}, hlc.ClockTimestamp{}, nil, true)
+	deleted, resumeSpan, num, err = MVCCDeleteRange(ctx, engine, testKey4, keyMax,
+		math.MaxInt64, hlc.Timestamp{WallTime: 2}, MVCCWriteOptions{}, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1539,8 +1539,8 @@ func TestMVCCDeleteRangeReturnKeys(t *testing.T) {
 		t.Fatal("the value should not be empty")
 	}
 
-	deleted, resumeSpan, num, err = MVCCDeleteRange(ctx, engine, nil, localMax, testKey2,
-		math.MaxInt64, hlc.Timestamp{WallTime: 2}, hlc.ClockTimestamp{}, nil, true)
+	deleted, resumeSpan, num, err = MVCCDeleteRange(ctx, engine, localMax, testKey2,
+		math.MaxInt64, hlc.Timestamp{WallTime: 2}, MVCCWriteOptions{}, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1572,29 +1572,29 @@ func TestMVCCDeleteRangeFailed(t *testing.T) {
 	defer engine.Close()
 
 	txn := makeTxn(*txn1, hlc.Timestamp{WallTime: 1})
-	if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, hlc.ClockTimestamp{}, value1, nil); err != nil {
+	if err := MVCCPut(ctx, engine, testKey1, hlc.Timestamp{WallTime: 1}, value1, MVCCWriteOptions{}); err != nil {
 		t.Fatal(err)
 	}
 	txn.Sequence++
-	if err := MVCCPut(ctx, engine, nil, testKey2, txn.ReadTimestamp, hlc.ClockTimestamp{}, value2, txn); err != nil {
+	if err := MVCCPut(ctx, engine, testKey2, txn.ReadTimestamp, value2, MVCCWriteOptions{Txn: txn}); err != nil {
 		t.Fatal(err)
 	}
 	txn.Sequence++
-	if err := MVCCPut(ctx, engine, nil, testKey3, txn.ReadTimestamp, hlc.ClockTimestamp{}, value3, txn); err != nil {
+	if err := MVCCPut(ctx, engine, testKey3, txn.ReadTimestamp, value3, MVCCWriteOptions{Txn: txn}); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(ctx, engine, nil, testKey4, hlc.Timestamp{WallTime: 1}, hlc.ClockTimestamp{}, value4, nil); err != nil {
+	if err := MVCCPut(ctx, engine, testKey4, hlc.Timestamp{WallTime: 1}, value4, MVCCWriteOptions{}); err != nil {
 		t.Fatal(err)
 	}
 
-	if _, _, _, err := MVCCDeleteRange(ctx, engine, nil, testKey2, testKey4,
-		math.MaxInt64, hlc.Timestamp{WallTime: 1}, hlc.ClockTimestamp{}, nil, false); err == nil {
+	if _, _, _, err := MVCCDeleteRange(ctx, engine, testKey2, testKey4,
+		math.MaxInt64, hlc.Timestamp{WallTime: 1}, MVCCWriteOptions{}, false); err == nil {
 		t.Fatal("expected error on uncommitted write intent")
 	}
 
 	txn.Sequence++
-	if _, _, _, err := MVCCDeleteRange(ctx, engine, nil, testKey2, testKey4,
-		math.MaxInt64, txn.ReadTimestamp, hlc.ClockTimestamp{}, txn, false); err != nil {
+	if _, _, _, err := MVCCDeleteRange(ctx, engine, testKey2, testKey4,
+		math.MaxInt64, txn.ReadTimestamp, MVCCWriteOptions{Txn: txn}, false); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -1610,21 +1610,21 @@ func TestMVCCDeleteRangeConcurrentTxn(t *testing.T) {
 	txn1ts := makeTxn(*txn1, hlc.Timestamp{WallTime: 1})
 	txn2ts := makeTxn(*txn2, hlc.Timestamp{WallTime: 2})
 
-	if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, hlc.ClockTimestamp{}, value1, nil); err != nil {
+	if err := MVCCPut(ctx, engine, testKey1, hlc.Timestamp{WallTime: 1}, value1, MVCCWriteOptions{}); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(ctx, engine, nil, testKey2, txn1ts.ReadTimestamp, hlc.ClockTimestamp{}, value2, txn1ts); err != nil {
+	if err := MVCCPut(ctx, engine, testKey2, txn1ts.ReadTimestamp, value2, MVCCWriteOptions{Txn: txn1ts}); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(ctx, engine, nil, testKey3, txn2ts.ReadTimestamp, hlc.ClockTimestamp{}, value3, txn2ts); err != nil {
+	if err := MVCCPut(ctx, engine, testKey3, txn2ts.ReadTimestamp, value3, MVCCWriteOptions{Txn: txn2ts}); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(ctx, engine, nil, testKey4, hlc.Timestamp{WallTime: 1}, hlc.ClockTimestamp{}, value4, nil); err != nil {
+	if err := MVCCPut(ctx, engine, testKey4, hlc.Timestamp{WallTime: 1}, value4, MVCCWriteOptions{}); err != nil {
 		t.Fatal(err)
 	}
 
-	if _, _, _, err := MVCCDeleteRange(ctx, engine, nil, testKey2, testKey4,
-		math.MaxInt64, txn1ts.ReadTimestamp, hlc.ClockTimestamp{}, txn1ts, false,
+	if _, _, _, err := MVCCDeleteRange(ctx, engine, testKey2, testKey4,
+		math.MaxInt64, txn1ts.ReadTimestamp, MVCCWriteOptions{Txn: txn1ts}, false,
 	); err == nil {
 		t.Fatal("expected error on uncommitted write intent")
 	}
@@ -1640,23 +1640,23 @@ func TestMVCCUncommittedDeleteRangeVisible(t *testing.T) {
 	engine := NewDefaultInMemForTesting()
 	defer engine.Close()
 
-	if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, hlc.ClockTimestamp{}, value1, nil); err != nil {
+	if err := MVCCPut(ctx, engine, testKey1, hlc.Timestamp{WallTime: 1}, value1, MVCCWriteOptions{}); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(ctx, engine, nil, testKey2, hlc.Timestamp{WallTime: 1}, hlc.ClockTimestamp{}, value2, nil); err != nil {
+	if err := MVCCPut(ctx, engine, testKey2, hlc.Timestamp{WallTime: 1}, value2, MVCCWriteOptions{}); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(ctx, engine, nil, testKey3, hlc.Timestamp{WallTime: 1}, hlc.ClockTimestamp{}, value3, nil); err != nil {
+	if err := MVCCPut(ctx, engine, testKey3, hlc.Timestamp{WallTime: 1}, value3, MVCCWriteOptions{}); err != nil {
 		t.Fatal(err)
 	}
 
-	if _, err := MVCCDelete(ctx, engine, nil, testKey2, hlc.Timestamp{WallTime: 2, Logical: 1}, hlc.ClockTimestamp{}, nil); err != nil {
+	if _, err := MVCCDelete(ctx, engine, testKey2, hlc.Timestamp{WallTime: 2, Logical: 1}, MVCCWriteOptions{}); err != nil {
 		t.Fatal(err)
 	}
 
 	txn := makeTxn(*txn1, hlc.Timestamp{WallTime: 2, Logical: 2})
-	if _, _, _, err := MVCCDeleteRange(ctx, engine, nil, testKey1, testKey4,
-		math.MaxInt64, txn.ReadTimestamp, hlc.ClockTimestamp{}, txn, false,
+	if _, _, _, err := MVCCDeleteRange(ctx, engine, testKey1, testKey4,
+		math.MaxInt64, txn.ReadTimestamp, MVCCWriteOptions{Txn: txn}, false,
 	); err != nil {
 		t.Fatal(err)
 	}
@@ -1678,15 +1678,15 @@ func TestMVCCDeleteRangeOldTimestamp(t *testing.T) {
 	ctx := context.Background()
 	engine := NewDefaultInMemForTesting()
 	defer engine.Close()
-	err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, hlc.ClockTimestamp{}, value1, nil)
+	err := MVCCPut(ctx, engine, testKey1, hlc.Timestamp{WallTime: 1}, value1, MVCCWriteOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = MVCCPut(ctx, engine, nil, testKey2, hlc.Timestamp{WallTime: 3}, hlc.ClockTimestamp{}, value2, nil)
+	err = MVCCPut(ctx, engine, testKey2, hlc.Timestamp{WallTime: 3}, value2, MVCCWriteOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = MVCCDelete(ctx, engine, nil, testKey2, hlc.Timestamp{WallTime: 5}, hlc.ClockTimestamp{}, nil)
+	_, err = MVCCDelete(ctx, engine, testKey2, hlc.Timestamp{WallTime: 5}, MVCCWriteOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1694,8 +1694,8 @@ func TestMVCCDeleteRangeOldTimestamp(t *testing.T) {
 	// Delete at a time before the tombstone. Should return a WriteTooOld error.
 	b := engine.NewBatch()
 	defer b.Close()
-	keys, resume, keyCount, err := MVCCDeleteRange(ctx, b, nil, testKey1, testKey4,
-		math.MaxInt64, hlc.Timestamp{WallTime: 4}, hlc.ClockTimestamp{}, nil, true)
+	keys, resume, keyCount, err := MVCCDeleteRange(ctx, b, testKey1, testKey4,
+		math.MaxInt64, hlc.Timestamp{WallTime: 4}, MVCCWriteOptions{}, true)
 	require.Nil(t, keys)
 	require.Nil(t, resume)
 	require.Equal(t, int64(0), keyCount)
@@ -1705,8 +1705,8 @@ func TestMVCCDeleteRangeOldTimestamp(t *testing.T) {
 	// Delete at the same time as the tombstone. Should return a WriteTooOld error.
 	b = engine.NewBatch()
 	defer b.Close()
-	keys, resume, keyCount, err = MVCCDeleteRange(ctx, b, nil, testKey1, testKey4,
-		math.MaxInt64, hlc.Timestamp{WallTime: 5}, hlc.ClockTimestamp{}, nil, true)
+	keys, resume, keyCount, err = MVCCDeleteRange(ctx, b, testKey1, testKey4,
+		math.MaxInt64, hlc.Timestamp{WallTime: 5}, MVCCWriteOptions{}, true)
 	require.Nil(t, keys)
 	require.Nil(t, resume)
 	require.Equal(t, int64(0), keyCount)
@@ -1717,8 +1717,8 @@ func TestMVCCDeleteRangeOldTimestamp(t *testing.T) {
 	// include the tombstone in the returned keys.
 	b = engine.NewBatch()
 	defer b.Close()
-	keys, resume, keyCount, err = MVCCDeleteRange(ctx, b, nil, testKey1, testKey4,
-		math.MaxInt64, hlc.Timestamp{WallTime: 6}, hlc.ClockTimestamp{}, nil, true)
+	keys, resume, keyCount, err = MVCCDeleteRange(ctx, b, testKey1, testKey4,
+		math.MaxInt64, hlc.Timestamp{WallTime: 6}, MVCCWriteOptions{}, true)
 	require.Equal(t, []roachpb.Key{testKey1}, keys)
 	require.Nil(t, resume)
 	require.Equal(t, int64(1), keyCount)
@@ -1744,19 +1744,19 @@ func TestMVCCDeleteRangeInline(t *testing.T) {
 		{testKey4, value4},
 		{testKey5, value5},
 	} {
-		if err := MVCCPut(ctx, engine, nil, kv.key, hlc.Timestamp{Logical: 0}, hlc.ClockTimestamp{}, kv.value, nil); err != nil {
+		if err := MVCCPut(ctx, engine, kv.key, hlc.Timestamp{Logical: 0}, kv.value, MVCCWriteOptions{}); err != nil {
 			t.Fatalf("%d: %+v", i, err)
 		}
 	}
 
 	// Create one non-inline value (non-zero timestamp).
-	if err := MVCCPut(ctx, engine, nil, testKey6, hlc.Timestamp{WallTime: 1}, hlc.ClockTimestamp{}, value6, nil); err != nil {
+	if err := MVCCPut(ctx, engine, testKey6, hlc.Timestamp{WallTime: 1}, value6, MVCCWriteOptions{}); err != nil {
 		t.Fatal(err)
 	}
 
 	// Attempt to delete two inline keys, should succeed.
-	deleted, resumeSpan, num, err := MVCCDeleteRange(ctx, engine, nil, testKey2, testKey6,
-		2, hlc.Timestamp{Logical: 0}, hlc.ClockTimestamp{}, nil, true)
+	deleted, resumeSpan, num, err := MVCCDeleteRange(ctx, engine, testKey2, testKey6,
+		2, hlc.Timestamp{Logical: 0}, MVCCWriteOptions{}, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1772,22 +1772,22 @@ func TestMVCCDeleteRangeInline(t *testing.T) {
 
 	// Attempt to delete inline keys at a timestamp; should fail.
 	const inlineMismatchErrString = "put is inline"
-	if _, _, _, err := MVCCDeleteRange(ctx, engine, nil, testKey1, testKey6,
-		1, hlc.Timestamp{WallTime: 2}, hlc.ClockTimestamp{}, nil, true,
+	if _, _, _, err := MVCCDeleteRange(ctx, engine, testKey1, testKey6,
+		1, hlc.Timestamp{WallTime: 2}, MVCCWriteOptions{}, true,
 	); !testutils.IsError(err, inlineMismatchErrString) {
 		t.Fatalf("got error %v, expected error with text '%s'", err, inlineMismatchErrString)
 	}
 
 	// Attempt to delete non-inline key at zero timestamp; should fail.
-	if _, _, _, err := MVCCDeleteRange(ctx, engine, nil, testKey6, keyMax,
-		1, hlc.Timestamp{Logical: 0}, hlc.ClockTimestamp{}, nil, true,
+	if _, _, _, err := MVCCDeleteRange(ctx, engine, testKey6, keyMax,
+		1, hlc.Timestamp{Logical: 0}, MVCCWriteOptions{}, true,
 	); !testutils.IsError(err, inlineMismatchErrString) {
 		t.Fatalf("got error %v, expected error with text '%s'", err, inlineMismatchErrString)
 	}
 
 	// Attempt to delete inline keys in a transaction; should fail.
-	if _, _, _, err := MVCCDeleteRange(ctx, engine, nil, testKey2, testKey6,
-		2, hlc.Timestamp{Logical: 0}, hlc.ClockTimestamp{}, txn1, true,
+	if _, _, _, err := MVCCDeleteRange(ctx, engine, testKey2, testKey6,
+		2, hlc.Timestamp{Logical: 0}, MVCCWriteOptions{Txn: txn1}, true,
 	); !testutils.IsError(err, "writes not allowed within transactions") {
 		t.Errorf("unexpected error: %+v", err)
 	}
@@ -1876,12 +1876,12 @@ func TestMVCCClearTimeRange(t *testing.T) {
 	//                 keys
 	eng := NewDefaultInMemForTesting()
 	defer eng.Close()
-	require.NoError(t, MVCCPut(ctx, eng, nil, testKey2, ts1, hlc.ClockTimestamp{}, value1, nil))
-	require.NoError(t, MVCCPut(ctx, eng, nil, testKey2, ts2, hlc.ClockTimestamp{}, value2, nil))
-	require.NoError(t, MVCCPut(ctx, eng, nil, testKey5, ts2, hlc.ClockTimestamp{}, value2, nil))
-	require.NoError(t, MVCCPut(ctx, eng, nil, testKey1, ts3, hlc.ClockTimestamp{}, value3, nil))
-	require.NoError(t, MVCCPut(ctx, eng, nil, testKey5, ts4, hlc.ClockTimestamp{}, value4, nil))
-	require.NoError(t, MVCCPut(ctx, eng, nil, testKey2, ts4, hlc.ClockTimestamp{}, value4, nil))
+	require.NoError(t, MVCCPut(ctx, eng, testKey2, ts1, value1, MVCCWriteOptions{}))
+	require.NoError(t, MVCCPut(ctx, eng, testKey2, ts2, value2, MVCCWriteOptions{}))
+	require.NoError(t, MVCCPut(ctx, eng, testKey5, ts2, value2, MVCCWriteOptions{}))
+	require.NoError(t, MVCCPut(ctx, eng, testKey1, ts3, value3, MVCCWriteOptions{}))
+	require.NoError(t, MVCCPut(ctx, eng, testKey5, ts4, value4, MVCCWriteOptions{}))
+	require.NoError(t, MVCCPut(ctx, eng, testKey2, ts4, value4, MVCCWriteOptions{}))
 
 	assertKVs := func(t *testing.T, reader Reader, at hlc.Timestamp, expected []roachpb.KeyValue) {
 		t.Helper()
@@ -2024,7 +2024,7 @@ func TestMVCCClearTimeRange(t *testing.T) {
 	// Add an intent at k3@ts3.
 	txn := roachpb.MakeTransaction("test", nil, roachpb.NormalUserPriority, ts3, 1, 1)
 	addIntent := func(t *testing.T, rw ReadWriter) {
-		require.NoError(t, MVCCPut(ctx, rw, nil, testKey3, ts3, hlc.ClockTimestamp{}, value3, &txn))
+		require.NoError(t, MVCCPut(ctx, rw, testKey3, ts3, value3, MVCCWriteOptions{Txn: &txn}))
 	}
 	t.Run("clear everything hitting intent fails", func(t *testing.T) {
 		b := eng.NewBatch()
@@ -2119,25 +2119,25 @@ func TestMVCCClearTimeRangeOnRandomData(t *testing.T) {
 
 		key := roachpb.Key(fmt.Sprintf("%05d", k))
 		if rand.Float64() > 0.8 {
-			_, err := MVCCDelete(ctx, e, &ms, key, hlc.Timestamp{WallTime: ts}, hlc.ClockTimestamp{}, nil)
+			_, err := MVCCDelete(ctx, e, key, hlc.Timestamp{WallTime: ts}, MVCCWriteOptions{Stats: &ms})
 			require.NoError(t, err)
 		} else {
 			v := roachpb.MakeValueFromString(fmt.Sprintf("v-%d", i))
-			require.NoError(t, MVCCPut(ctx, e, &ms, key, hlc.Timestamp{WallTime: ts}, hlc.ClockTimestamp{}, v, nil))
+			require.NoError(t, MVCCPut(ctx, e, key, hlc.Timestamp{WallTime: ts}, v, MVCCWriteOptions{Stats: &ms}))
 		}
 	}
 	swathTime := rand.Intn(randTimeRange-100) + 100
 	for i := swathStart; i < swathEnd; i++ {
 		key := roachpb.Key(fmt.Sprintf("%05d", i))
 		v := roachpb.MakeValueFromString(fmt.Sprintf("v-%d", i))
-		require.NoError(t, MVCCPut(ctx, e, &ms, key, hlc.Timestamp{WallTime: int64(swathTime)}, hlc.ClockTimestamp{}, v, nil))
+		require.NoError(t, MVCCPut(ctx, e, key, hlc.Timestamp{WallTime: int64(swathTime)}, v, MVCCWriteOptions{Stats: &ms}))
 	}
 
 	// Add another swath of keys above to exercise an after-iteration range flush.
 	for i := keyRange; i < keyRange+200; i++ {
 		key := roachpb.Key(fmt.Sprintf("%05d", i))
 		v := roachpb.MakeValueFromString(fmt.Sprintf("v-%d", i))
-		require.NoError(t, MVCCPut(ctx, e, &ms, key, hlc.Timestamp{WallTime: int64(randTimeRange + 1)}, hlc.ClockTimestamp{}, v, nil))
+		require.NoError(t, MVCCPut(ctx, e, key, hlc.Timestamp{WallTime: int64(randTimeRange + 1)}, v, MVCCWriteOptions{Stats: &ms}))
 	}
 
 	ms.AgeTo(2000)
@@ -2202,25 +2202,25 @@ func TestMVCCInitPut(t *testing.T) {
 	engine := NewDefaultInMemForTesting()
 	defer engine.Close()
 
-	err := MVCCInitPut(ctx, engine, nil, testKey1, hlc.Timestamp{Logical: 1}, hlc.ClockTimestamp{}, value1, false, nil)
+	err := MVCCInitPut(ctx, engine, testKey1, hlc.Timestamp{Logical: 1}, value1, false, MVCCWriteOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// A repeat of the command will still succeed
-	err = MVCCInitPut(ctx, engine, nil, testKey1, hlc.Timestamp{Logical: 2}, hlc.ClockTimestamp{}, value1, false, nil)
+	err = MVCCInitPut(ctx, engine, testKey1, hlc.Timestamp{Logical: 2}, value1, false, MVCCWriteOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Delete.
-	_, err = MVCCDelete(ctx, engine, nil, testKey1, hlc.Timestamp{Logical: 3}, hlc.ClockTimestamp{}, nil)
+	_, err = MVCCDelete(ctx, engine, testKey1, hlc.Timestamp{Logical: 3}, MVCCWriteOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Reinserting the value fails if we fail on tombstones.
-	err = MVCCInitPut(ctx, engine, nil, testKey1, hlc.Timestamp{Logical: 4}, hlc.ClockTimestamp{}, value1, true, nil)
+	err = MVCCInitPut(ctx, engine, testKey1, hlc.Timestamp{Logical: 4}, value1, true, MVCCWriteOptions{})
 	if e := (*kvpb.ConditionFailedError)(nil); errors.As(err, &e) {
 		if !bytes.Equal(e.ActualValue.RawBytes, nil) {
 			t.Fatalf("the value %s in get result is not a tombstone", e.ActualValue.RawBytes)
@@ -2232,13 +2232,13 @@ func TestMVCCInitPut(t *testing.T) {
 	}
 
 	// But doesn't if we *don't* fail on tombstones.
-	err = MVCCInitPut(ctx, engine, nil, testKey1, hlc.Timestamp{Logical: 5}, hlc.ClockTimestamp{}, value1, false, nil)
+	err = MVCCInitPut(ctx, engine, testKey1, hlc.Timestamp{Logical: 5}, value1, false, MVCCWriteOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// A repeat of the command with a different value will fail.
-	err = MVCCInitPut(ctx, engine, nil, testKey1, hlc.Timestamp{Logical: 6}, hlc.ClockTimestamp{}, value2, false, nil)
+	err = MVCCInitPut(ctx, engine, testKey1, hlc.Timestamp{Logical: 6}, value2, false, MVCCWriteOptions{})
 	if e := (*kvpb.ConditionFailedError)(nil); errors.As(err, &e) {
 		if !bytes.Equal(e.ActualValue.RawBytes, value1.RawBytes) {
 			t.Fatalf("the value %s in get result does not match the value %s in request",
@@ -2294,14 +2294,14 @@ func TestMVCCInitPutWithTxn(t *testing.T) {
 
 	txn := *txn1
 	txn.Sequence++
-	err := MVCCInitPut(ctx, engine, nil, testKey1, txn.ReadTimestamp, hlc.ClockTimestamp{}, value1, false, &txn)
+	err := MVCCInitPut(ctx, engine, testKey1, txn.ReadTimestamp, value1, false, MVCCWriteOptions{Txn: &txn})
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// A repeat of the command will still succeed.
 	txn.Sequence++
-	err = MVCCInitPut(ctx, engine, nil, testKey1, txn.ReadTimestamp, hlc.ClockTimestamp{}, value1, false, &txn)
+	err = MVCCInitPut(ctx, engine, testKey1, txn.ReadTimestamp, value1, false, MVCCWriteOptions{Txn: &txn})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2310,7 +2310,7 @@ func TestMVCCInitPutWithTxn(t *testing.T) {
 	// will still succeed.
 	txn.Sequence++
 	txn.Epoch = 2
-	err = MVCCInitPut(ctx, engine, nil, testKey1, txn.ReadTimestamp, hlc.ClockTimestamp{}, value2, false, &txn)
+	err = MVCCInitPut(ctx, engine, testKey1, txn.ReadTimestamp, value2, false, MVCCWriteOptions{Txn: &txn})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2326,7 +2326,7 @@ func TestMVCCInitPutWithTxn(t *testing.T) {
 	}
 
 	// Write value4 with an old timestamp without txn...should get an error.
-	err = MVCCInitPut(ctx, engine, nil, testKey1, clock.Now(), hlc.ClockTimestamp{}, value4, false, nil)
+	err = MVCCInitPut(ctx, engine, testKey1, clock.Now(), value4, false, MVCCWriteOptions{})
 	if e := (*kvpb.ConditionFailedError)(nil); errors.As(err, &e) {
 		if !bytes.Equal(e.ActualValue.RawBytes, value2.RawBytes) {
 			t.Fatalf("the value %s in get result does not match the value %s in request",
@@ -2347,28 +2347,28 @@ func TestMVCCReverseScan(t *testing.T) {
 	engine := NewDefaultInMemForTesting()
 	defer engine.Close()
 
-	if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, hlc.ClockTimestamp{}, value1, nil); err != nil {
+	if err := MVCCPut(ctx, engine, testKey1, hlc.Timestamp{WallTime: 1}, value1, MVCCWriteOptions{}); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 2}, hlc.ClockTimestamp{}, value2, nil); err != nil {
+	if err := MVCCPut(ctx, engine, testKey1, hlc.Timestamp{WallTime: 2}, value2, MVCCWriteOptions{}); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(ctx, engine, nil, testKey2, hlc.Timestamp{WallTime: 1}, hlc.ClockTimestamp{}, value3, nil); err != nil {
+	if err := MVCCPut(ctx, engine, testKey2, hlc.Timestamp{WallTime: 1}, value3, MVCCWriteOptions{}); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(ctx, engine, nil, testKey2, hlc.Timestamp{WallTime: 3}, hlc.ClockTimestamp{}, value4, nil); err != nil {
+	if err := MVCCPut(ctx, engine, testKey2, hlc.Timestamp{WallTime: 3}, value4, MVCCWriteOptions{}); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(ctx, engine, nil, testKey3, hlc.Timestamp{WallTime: 1}, hlc.ClockTimestamp{}, value1, nil); err != nil {
+	if err := MVCCPut(ctx, engine, testKey3, hlc.Timestamp{WallTime: 1}, value1, MVCCWriteOptions{}); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(ctx, engine, nil, testKey4, hlc.Timestamp{WallTime: 1}, hlc.ClockTimestamp{}, value2, nil); err != nil {
+	if err := MVCCPut(ctx, engine, testKey4, hlc.Timestamp{WallTime: 1}, value2, MVCCWriteOptions{}); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(ctx, engine, nil, testKey5, hlc.Timestamp{WallTime: 3}, hlc.ClockTimestamp{}, value5, nil); err != nil {
+	if err := MVCCPut(ctx, engine, testKey5, hlc.Timestamp{WallTime: 3}, value5, MVCCWriteOptions{}); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(ctx, engine, nil, testKey6, hlc.Timestamp{WallTime: 3}, hlc.ClockTimestamp{}, value6, nil); err != nil {
+	if err := MVCCPut(ctx, engine, testKey6, hlc.Timestamp{WallTime: 3}, value6, MVCCWriteOptions{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2479,10 +2479,10 @@ func TestMVCCReverseScanFirstKeyInFuture(t *testing.T) {
 	// Before fixing #17825, the MVCC version scan on key3 would fall out of the
 	// scan bounds and if it never found another valid key before reaching
 	// KeyMax, would stop the ReverseScan from continuing.
-	if err := MVCCPut(ctx, engine, nil, testKey2, hlc.Timestamp{WallTime: 1}, hlc.ClockTimestamp{}, value2, nil); err != nil {
+	if err := MVCCPut(ctx, engine, testKey2, hlc.Timestamp{WallTime: 1}, value2, MVCCWriteOptions{}); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(ctx, engine, nil, testKey3, hlc.Timestamp{WallTime: 3}, hlc.ClockTimestamp{}, value3, nil); err != nil {
+	if err := MVCCPut(ctx, engine, testKey3, hlc.Timestamp{WallTime: 3}, value3, MVCCWriteOptions{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2515,12 +2515,12 @@ func TestMVCCReverseScanSeeksOverRepeatedKeys(t *testing.T) {
 	// written. Repeat the key enough times to make sure the `SeekForPrev()`
 	// optimization will be used.
 	for i := 1; i <= 10; i++ {
-		if err := MVCCPut(ctx, engine, nil, testKey2, hlc.Timestamp{WallTime: int64(i)}, hlc.ClockTimestamp{}, value2, nil); err != nil {
+		if err := MVCCPut(ctx, engine, testKey2, hlc.Timestamp{WallTime: int64(i)}, value2, MVCCWriteOptions{}); err != nil {
 			t.Fatal(err)
 		}
 	}
 	txn1ts := makeTxn(*txn1, hlc.Timestamp{WallTime: 11})
-	if err := MVCCPut(ctx, engine, nil, testKey2, txn1ts.ReadTimestamp, hlc.ClockTimestamp{}, value2, txn1ts); err != nil {
+	if err := MVCCPut(ctx, engine, testKey2, txn1ts.ReadTimestamp, value2, MVCCWriteOptions{Txn: txn1ts}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2565,7 +2565,7 @@ func TestMVCCReverseScanStopAtSmallestKey(t *testing.T) {
 		defer engine.Close()
 
 		for i := 1; i <= numPuts; i++ {
-			if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: int64(i)}, hlc.ClockTimestamp{}, value1, nil); err != nil {
+			if err := MVCCPut(ctx, engine, testKey1, hlc.Timestamp{WallTime: int64(i)}, value1, MVCCWriteOptions{}); err != nil {
 				t.Fatal(err)
 			}
 		}
@@ -2602,7 +2602,7 @@ func TestMVCCResolveTxn(t *testing.T) {
 	engine := NewDefaultInMemForTesting()
 	defer engine.Close()
 
-	if err := MVCCPut(ctx, engine, nil, testKey1, txn1.ReadTimestamp, hlc.ClockTimestamp{}, value1, txn1); err != nil {
+	if err := MVCCPut(ctx, engine, testKey1, txn1.ReadTimestamp, value1, MVCCWriteOptions{Txn: txn1}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2649,12 +2649,12 @@ func TestMVCCResolveNewerIntent(t *testing.T) {
 	defer engine.Close()
 
 	// Write first value.
-	if err := MVCCPut(ctx, engine, nil, testKey1, txn1Commit.WriteTimestamp, hlc.ClockTimestamp{}, value1, nil); err != nil {
+	if err := MVCCPut(ctx, engine, testKey1, txn1Commit.WriteTimestamp, value1, MVCCWriteOptions{}); err != nil {
 		t.Fatal(err)
 	}
 	// Now, put down an intent which should return a write too old error
 	// (but will still write the intent at tx1Commit.Timestamp+1.
-	err := MVCCPut(ctx, engine, nil, testKey1, txn1.ReadTimestamp, hlc.ClockTimestamp{}, value2, txn1)
+	err := MVCCPut(ctx, engine, testKey1, txn1.ReadTimestamp, value2, MVCCWriteOptions{Txn: txn1})
 	if !errors.HasType(err, (*kvpb.WriteTooOldError)(nil)) {
 		t.Fatalf("expected write too old error; got %s", err)
 	}
@@ -2805,7 +2805,7 @@ func TestMVCCResolveIntentTxnTimestampMismatch(t *testing.T) {
 	txn.TxnMeta.WriteTimestamp.Forward(tsEarly.Add(10, 0))
 
 	// Write an intent which has txn.WriteTimestamp > meta.timestamp.
-	if err := MVCCPut(ctx, engine, nil, testKey1, tsEarly, hlc.ClockTimestamp{}, value1, txn); err != nil {
+	if err := MVCCPut(ctx, engine, testKey1, tsEarly, value1, MVCCWriteOptions{Txn: txn}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2852,17 +2852,17 @@ func TestMVCCConditionalPutOldTimestamp(t *testing.T) {
 	ctx := context.Background()
 	engine := NewDefaultInMemForTesting()
 	defer engine.Close()
-	err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, hlc.ClockTimestamp{}, value1, nil)
+	err := MVCCPut(ctx, engine, testKey1, hlc.Timestamp{WallTime: 1}, value1, MVCCWriteOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 3}, hlc.ClockTimestamp{}, value2, nil)
+	err = MVCCPut(ctx, engine, testKey1, hlc.Timestamp{WallTime: 3}, value2, MVCCWriteOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Check nothing is written if the value doesn't match.
-	err = MVCCConditionalPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 2}, hlc.ClockTimestamp{}, value3, value1.TagAndDataBytes(), CPutFailIfMissing, nil)
+	err = MVCCConditionalPut(ctx, engine, testKey1, hlc.Timestamp{WallTime: 2}, value3, value1.TagAndDataBytes(), CPutFailIfMissing, MVCCWriteOptions{})
 	if err == nil {
 		t.Errorf("unexpected success on conditional put")
 	}
@@ -2872,7 +2872,7 @@ func TestMVCCConditionalPutOldTimestamp(t *testing.T) {
 
 	// But if value does match the most recently written version, we'll get
 	// a write too old error but still write updated value.
-	err = MVCCConditionalPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 2}, hlc.ClockTimestamp{}, value3, value2.TagAndDataBytes(), CPutFailIfMissing, nil)
+	err = MVCCConditionalPut(ctx, engine, testKey1, hlc.Timestamp{WallTime: 2}, value3, value2.TagAndDataBytes(), CPutFailIfMissing, MVCCWriteOptions{})
 	if err == nil {
 		t.Errorf("unexpected success on conditional put")
 	}
@@ -2901,7 +2901,7 @@ func TestMVCCMultiplePutOldTimestamp(t *testing.T) {
 	engine := NewDefaultInMemForTesting()
 	defer engine.Close()
 
-	err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 3}, hlc.ClockTimestamp{}, value1, nil)
+	err := MVCCPut(ctx, engine, testKey1, hlc.Timestamp{WallTime: 3}, value1, MVCCWriteOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2910,7 +2910,7 @@ func TestMVCCMultiplePutOldTimestamp(t *testing.T) {
 	// intent is written at the advanced timestamp.
 	txn := makeTxn(*txn1, hlc.Timestamp{WallTime: 1})
 	txn.Sequence++
-	err = MVCCPut(ctx, engine, nil, testKey1, txn.ReadTimestamp, hlc.ClockTimestamp{}, value2, txn)
+	err = MVCCPut(ctx, engine, testKey1, txn.ReadTimestamp, value2, MVCCWriteOptions{Txn: txn})
 	if !errors.HasType(err, (*kvpb.WriteTooOldError)(nil)) {
 		t.Errorf("expected WriteTooOldError on Put; got %v", err)
 	}
@@ -2928,7 +2928,7 @@ func TestMVCCMultiplePutOldTimestamp(t *testing.T) {
 	// Put again and verify no WriteTooOldError, but timestamp should continue
 	// to be set to (3,1).
 	txn.Sequence++
-	err = MVCCPut(ctx, engine, nil, testKey1, txn.ReadTimestamp, hlc.ClockTimestamp{}, value3, txn)
+	err = MVCCPut(ctx, engine, testKey1, txn.ReadTimestamp, value3, MVCCWriteOptions{Txn: txn})
 	if err != nil {
 		t.Error(err)
 	}
@@ -2953,7 +2953,7 @@ func TestMVCCPutNegativeTimestampError(t *testing.T) {
 
 	timestamp := hlc.Timestamp{WallTime: -1}
 	expectedErrorString := fmt.Sprintf("cannot write to %q at timestamp %s", testKey1, timestamp)
-	err := MVCCPut(ctx, engine, nil, testKey1, timestamp, hlc.ClockTimestamp{}, value1, nil)
+	err := MVCCPut(ctx, engine, testKey1, timestamp, value1, MVCCWriteOptions{})
 	require.EqualError(t, err, expectedErrorString)
 }
 
@@ -2971,7 +2971,7 @@ func TestMVCCPutOldOrigTimestampNewCommitTimestamp(t *testing.T) {
 	engine := NewDefaultInMemForTesting()
 	defer engine.Close()
 
-	err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 3}, hlc.ClockTimestamp{}, value1, nil)
+	err := MVCCPut(ctx, engine, testKey1, hlc.Timestamp{WallTime: 3}, value1, MVCCWriteOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2982,7 +2982,7 @@ func TestMVCCPutOldOrigTimestampNewCommitTimestamp(t *testing.T) {
 	txn := makeTxn(*txn1, hlc.Timestamp{WallTime: 1})
 	txn.WriteTimestamp = hlc.Timestamp{WallTime: 5}
 	txn.Sequence++
-	err = MVCCPut(ctx, engine, nil, testKey1, txn.ReadTimestamp, hlc.ClockTimestamp{}, value2, txn)
+	err = MVCCPut(ctx, engine, testKey1, txn.ReadTimestamp, value2, MVCCWriteOptions{Txn: txn})
 
 	// Verify that the Put returned a WriteTooOld with the ActualTime set to the
 	// transactions provisional commit timestamp.
@@ -3011,7 +3011,7 @@ func TestMVCCAbortTxn(t *testing.T) {
 	engine := NewDefaultInMemForTesting()
 	defer engine.Close()
 
-	if err := MVCCPut(ctx, engine, nil, testKey1, txn1.ReadTimestamp, hlc.ClockTimestamp{}, value1, txn1); err != nil {
+	if err := MVCCPut(ctx, engine, testKey1, txn1.ReadTimestamp, value1, MVCCWriteOptions{Txn: txn1}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -3043,14 +3043,14 @@ func TestMVCCAbortTxnWithPreviousVersion(t *testing.T) {
 	engine := NewDefaultInMemForTesting()
 	defer engine.Close()
 
-	if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{Logical: 1}, hlc.ClockTimestamp{}, value1, nil); err != nil {
+	if err := MVCCPut(ctx, engine, testKey1, hlc.Timestamp{Logical: 1}, value1, MVCCWriteOptions{}); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, hlc.ClockTimestamp{}, value2, nil); err != nil {
+	if err := MVCCPut(ctx, engine, testKey1, hlc.Timestamp{WallTime: 1}, value2, MVCCWriteOptions{}); err != nil {
 		t.Fatal(err)
 	}
 	txn1ts := makeTxn(*txn1, hlc.Timestamp{WallTime: 2})
-	if err := MVCCPut(ctx, engine, nil, testKey1, txn1ts.ReadTimestamp, hlc.ClockTimestamp{}, value3, txn1ts); err != nil {
+	if err := MVCCPut(ctx, engine, testKey1, txn1ts.ReadTimestamp, value3, MVCCWriteOptions{Txn: txn1ts}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -3095,32 +3095,34 @@ func TestMVCCWriteWithDiffTimestampsAndEpochs(t *testing.T) {
 	// Start with epoch 1.
 	txn := *txn1
 	txn.Sequence++
-	if err := MVCCPut(ctx, engine, nil, testKey1, txn.ReadTimestamp, hlc.ClockTimestamp{}, value1, &txn); err != nil {
+	if err := MVCCPut(ctx, engine, testKey1, txn.ReadTimestamp, value1, MVCCWriteOptions{Txn: &txn}); err != nil {
 		t.Fatal(err)
 	}
+
 	// Now write with greater timestamp and epoch 2.
 	txne2 := txn
 	txne2.Sequence++
 	txne2.Epoch = 2
 	txne2.WriteTimestamp = hlc.Timestamp{WallTime: 1}
-	if err := MVCCPut(ctx, engine, nil, testKey1, txne2.ReadTimestamp, hlc.ClockTimestamp{}, value2, &txne2); err != nil {
+	if err := MVCCPut(ctx, engine, testKey1, txne2.ReadTimestamp, value2, MVCCWriteOptions{Txn: &txne2}); err != nil {
 		t.Fatal(err)
 	}
 	// Try a write with an earlier timestamp; this is just ignored.
 	txne2.Sequence++
 	txne2.WriteTimestamp = hlc.Timestamp{WallTime: 1}
-	if err := MVCCPut(ctx, engine, nil, testKey1, txne2.ReadTimestamp, hlc.ClockTimestamp{}, value1, &txne2); err != nil {
+	if err := MVCCPut(ctx, engine, testKey1, txne2.ReadTimestamp, value1, MVCCWriteOptions{Txn: &txne2}); err != nil {
 		t.Fatal(err)
 	}
 	// Try a write with an earlier epoch; again ignored.
-	if err := MVCCPut(ctx, engine, nil, testKey1, txn.ReadTimestamp, hlc.ClockTimestamp{}, value1, &txn); err == nil {
+	if err := MVCCPut(ctx, engine, testKey1, txn.ReadTimestamp, value1, MVCCWriteOptions{Txn: &txn}); err == nil {
 		t.Fatal("unexpected success of a write with an earlier epoch")
 	}
 	// Try a write with different value using both later timestamp and epoch.
 	txne2.Sequence++
-	if err := MVCCPut(ctx, engine, nil, testKey1, txne2.ReadTimestamp, hlc.ClockTimestamp{}, value3, &txne2); err != nil {
+	if err := MVCCPut(ctx, engine, testKey1, txne2.ReadTimestamp, value3, MVCCWriteOptions{Txn: &txne2}); err != nil {
 		t.Fatal(err)
 	}
+
 	// Resolve the intent.
 	txne2Commit := txne2
 	txne2Commit.Status = roachpb.COMMITTED
@@ -3134,7 +3136,7 @@ func TestMVCCWriteWithDiffTimestampsAndEpochs(t *testing.T) {
 	expTS := txne2Commit.WriteTimestamp.Next()
 
 	// Now try writing an earlier value without a txn--should get WriteTooOldError.
-	err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{Logical: 1}, hlc.ClockTimestamp{}, value4, nil)
+	err := MVCCPut(ctx, engine, testKey1, hlc.Timestamp{Logical: 1}, value4, MVCCWriteOptions{})
 	if wtoErr := (*kvpb.WriteTooOldError)(nil); !errors.As(err, &wtoErr) {
 		t.Fatal("unexpected success")
 	} else if wtoErr.ActualTimestamp != expTS {
@@ -3147,7 +3149,7 @@ func TestMVCCWriteWithDiffTimestampsAndEpochs(t *testing.T) {
 			err, valueRes.Value.Timestamp, expTS, value4.RawBytes, valueRes.Value.RawBytes)
 	}
 	// Now write an intent with exactly the same timestamp--ties also get WriteTooOldError.
-	err = MVCCPut(ctx, engine, nil, testKey1, txn2.ReadTimestamp, hlc.ClockTimestamp{}, value5, txn2)
+	err = MVCCPut(ctx, engine, testKey1, txn2.ReadTimestamp, value5, MVCCWriteOptions{Txn: txn2})
 	intentTS := expTS.Next()
 	if wtoErr := (*kvpb.WriteTooOldError)(nil); !errors.As(err, &wtoErr) {
 		t.Fatal("unexpected success")
@@ -3160,6 +3162,7 @@ func TestMVCCWriteWithDiffTimestampsAndEpochs(t *testing.T) {
 		t.Fatalf("expected err=nil (got %s), timestamp=%s (got %s), value=%q (got %q)",
 			err, valueRes.Value.Timestamp, intentTS, value5.RawBytes, valueRes.Value.RawBytes)
 	}
+
 	// Attempt to read older timestamp; should fail.
 	valueRes, err = MVCCGet(ctx, engine, testKey1, hlc.Timestamp{Logical: 0}, MVCCGetOptions{})
 	if valueRes.Value != nil || err != nil {
@@ -3191,12 +3194,12 @@ func TestMVCCGetWithDiffEpochs(t *testing.T) {
 	defer engine.Close()
 
 	// Write initial value without a txn.
-	if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{Logical: 1}, hlc.ClockTimestamp{}, value1, nil); err != nil {
+	if err := MVCCPut(ctx, engine, testKey1, hlc.Timestamp{Logical: 1}, value1, MVCCWriteOptions{}); err != nil {
 		t.Fatal(err)
 	}
 	// Now write using txn1, epoch 1.
 	txn1ts := makeTxn(*txn1, hlc.Timestamp{WallTime: 1})
-	if err := MVCCPut(ctx, engine, nil, testKey1, txn1ts.ReadTimestamp, hlc.ClockTimestamp{}, value2, txn1ts); err != nil {
+	if err := MVCCPut(ctx, engine, testKey1, txn1ts.ReadTimestamp, value2, MVCCWriteOptions{Txn: txn1ts}); err != nil {
 		t.Fatal(err)
 	}
 	// Try reading using different txns & epochs.
@@ -3248,11 +3251,11 @@ func TestMVCCGetWithDiffEpochsAndTimestamps(t *testing.T) {
 	defer engine.Close()
 
 	// Write initial value without a txn at timestamp 1.
-	if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, hlc.ClockTimestamp{}, value1, nil); err != nil {
+	if err := MVCCPut(ctx, engine, testKey1, hlc.Timestamp{WallTime: 1}, value1, MVCCWriteOptions{}); err != nil {
 		t.Fatal(err)
 	}
 	// Write another value without a txn at timestamp 3.
-	if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 3}, hlc.ClockTimestamp{}, value2, nil); err != nil {
+	if err := MVCCPut(ctx, engine, testKey1, hlc.Timestamp{WallTime: 3}, value2, MVCCWriteOptions{}); err != nil {
 		t.Fatal(err)
 	}
 	// Now write using txn1, epoch 1.
@@ -3260,7 +3263,7 @@ func TestMVCCGetWithDiffEpochsAndTimestamps(t *testing.T) {
 	// Bump epoch 1's write timestamp to timestamp 4.
 	txn1ts.WriteTimestamp = hlc.Timestamp{WallTime: 4}
 	// Expected to hit WriteTooOld error but to still lay down intent.
-	err := MVCCPut(ctx, engine, nil, testKey1, txn1ts.ReadTimestamp, hlc.ClockTimestamp{}, value3, txn1ts)
+	err := MVCCPut(ctx, engine, testKey1, txn1ts.ReadTimestamp, value3, MVCCWriteOptions{Txn: txn1ts})
 	if wtoErr := (*kvpb.WriteTooOldError)(nil); !errors.As(err, &wtoErr) {
 		t.Fatalf("unexpectedly not WriteTooOld: %+v", err)
 	} else if expTS, actTS := txn1ts.WriteTimestamp, wtoErr.ActualTimestamp; expTS != actTS {
@@ -3313,7 +3316,7 @@ func TestMVCCGetWithOldEpoch(t *testing.T) {
 	engine := NewDefaultInMemForTesting()
 	defer engine.Close()
 
-	if err := MVCCPut(ctx, engine, nil, testKey1, txn1e2.ReadTimestamp, hlc.ClockTimestamp{}, value2, txn1e2); err != nil {
+	if err := MVCCPut(ctx, engine, testKey1, txn1e2.ReadTimestamp, value2, MVCCWriteOptions{Txn: txn1e2}); err != nil {
 		t.Fatal(err)
 	}
 	_, err := MVCCGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 2}, MVCCGetOptions{
@@ -3354,7 +3357,7 @@ func TestMVCCDeleteRangeWithSequence(t *testing.T) {
 			for i := enginepb.TxnSeq(0); i < 3; i++ {
 				key := append(prefix, []byte(strconv.Itoa(int(i)))...)
 				txn.Sequence = 2 + i
-				if err := MVCCPut(ctx, engine, nil, key, txn.WriteTimestamp, hlc.ClockTimestamp{}, value1, &txn); err != nil {
+				if err := MVCCPut(ctx, engine, key, txn.WriteTimestamp, value1, MVCCWriteOptions{Txn: &txn}); err != nil {
 					t.Fatal(err)
 				}
 			}
@@ -3362,15 +3365,15 @@ func TestMVCCDeleteRangeWithSequence(t *testing.T) {
 			// Perform the initial DeleteRange.
 			const origSeq = 6
 			txn.Sequence = origSeq
-			origDeleted, _, origNum, err := MVCCDeleteRange(ctx, engine, nil,
-				prefix, prefix.PrefixEnd(), math.MaxInt64, txn.WriteTimestamp, hlc.ClockTimestamp{}, &txn, true)
+			origDeleted, _, origNum, err := MVCCDeleteRange(ctx, engine, prefix, prefix.PrefixEnd(),
+				math.MaxInt64, txn.WriteTimestamp, MVCCWriteOptions{Txn: &txn}, true)
 			if err != nil {
 				t.Fatal(err)
 			}
 
 			txn.Sequence = tc.sequence
-			deleted, _, num, err := MVCCDeleteRange(ctx, engine, nil,
-				prefix, prefix.PrefixEnd(), math.MaxInt64, txn.WriteTimestamp, hlc.ClockTimestamp{}, &txn, true)
+			deleted, _, num, err := MVCCDeleteRange(ctx, engine, prefix, prefix.PrefixEnd(),
+				math.MaxInt64, txn.WriteTimestamp, MVCCWriteOptions{Txn: &txn}, true)
 			if tc.expErr != "" && err != nil {
 				if !testutils.IsError(err, tc.expErr) {
 					t.Fatalf("unexpected error: %+v", err)
@@ -3409,7 +3412,7 @@ func TestMVCCGetWithPushedTimestamp(t *testing.T) {
 	defer engine.Close()
 
 	// Start with epoch 1.
-	if err := MVCCPut(ctx, engine, nil, testKey1, txn1.ReadTimestamp, hlc.ClockTimestamp{}, value1, txn1); err != nil {
+	if err := MVCCPut(ctx, engine, testKey1, txn1.ReadTimestamp, value1, MVCCWriteOptions{Txn: txn1}); err != nil {
 		t.Fatal(err)
 	}
 	// Resolve the intent, pushing its timestamp forward.
@@ -3436,10 +3439,10 @@ func TestMVCCResolveWithDiffEpochs(t *testing.T) {
 	engine := NewDefaultInMemForTesting()
 	defer engine.Close()
 
-	if err := MVCCPut(ctx, engine, nil, testKey1, txn1.ReadTimestamp, hlc.ClockTimestamp{}, value1, txn1); err != nil {
+	if err := MVCCPut(ctx, engine, testKey1, txn1.ReadTimestamp, value1, MVCCWriteOptions{Txn: txn1}); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(ctx, engine, nil, testKey2, txn1e2.ReadTimestamp, hlc.ClockTimestamp{}, value2, txn1e2); err != nil {
+	if err := MVCCPut(ctx, engine, testKey2, txn1e2.ReadTimestamp, value2, MVCCWriteOptions{Txn: txn1e2}); err != nil {
 		t.Fatal(err)
 	}
 	numKeys, _, _, _, err := MVCCResolveWriteIntentRange(ctx, engine, nil,
@@ -3478,7 +3481,7 @@ func TestMVCCResolveWithUpdatedTimestamp(t *testing.T) {
 	engine := NewDefaultInMemForTesting()
 	defer engine.Close()
 
-	if err := MVCCPut(ctx, engine, nil, testKey1, txn1.ReadTimestamp, hlc.ClockTimestamp{}, value1, txn1); err != nil {
+	if err := MVCCPut(ctx, engine, testKey1, txn1.ReadTimestamp, value1, MVCCWriteOptions{Txn: txn1}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -3528,7 +3531,7 @@ func TestMVCCResolveWithPushedTimestamp(t *testing.T) {
 	engine := NewDefaultInMemForTesting()
 	defer engine.Close()
 
-	if err := MVCCPut(ctx, engine, nil, testKey1, txn1.ReadTimestamp, hlc.ClockTimestamp{}, value1, txn1); err != nil {
+	if err := MVCCPut(ctx, engine, testKey1, txn1.ReadTimestamp, value1, MVCCWriteOptions{Txn: txn1}); err != nil {
 		t.Fatal(err)
 	}
 	valueRes, err := MVCCGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 1}, MVCCGetOptions{
@@ -3588,7 +3591,7 @@ func TestMVCCResolveTxnNoOps(t *testing.T) {
 	}
 
 	// Add key and resolve despite there being no intent.
-	if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{Logical: 1}, hlc.ClockTimestamp{}, value1, nil); err != nil {
+	if err := MVCCPut(ctx, engine, testKey1, hlc.Timestamp{Logical: 1}, value1, MVCCWriteOptions{}); err != nil {
 		t.Fatal(err)
 	}
 	if _, _, _, err := MVCCResolveWriteIntent(ctx, engine, nil,
@@ -3598,7 +3601,7 @@ func TestMVCCResolveTxnNoOps(t *testing.T) {
 	}
 
 	// Write intent and resolve with different txn.
-	if err := MVCCPut(ctx, engine, nil, testKey2, txn1.ReadTimestamp, hlc.ClockTimestamp{}, value2, txn1); err != nil {
+	if err := MVCCPut(ctx, engine, testKey2, txn1.ReadTimestamp, value2, MVCCWriteOptions{Txn: txn1}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -3619,16 +3622,16 @@ func TestMVCCResolveTxnRange(t *testing.T) {
 	engine := NewDefaultInMemForTesting()
 	defer engine.Close()
 
-	if err := MVCCPut(ctx, engine, nil, testKey1, txn1.ReadTimestamp, hlc.ClockTimestamp{}, value1, txn1); err != nil {
+	if err := MVCCPut(ctx, engine, testKey1, txn1.ReadTimestamp, value1, MVCCWriteOptions{Txn: txn1}); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(ctx, engine, nil, testKey2, hlc.Timestamp{Logical: 1}, hlc.ClockTimestamp{}, value2, nil); err != nil {
+	if err := MVCCPut(ctx, engine, testKey2, hlc.Timestamp{Logical: 1}, value2, MVCCWriteOptions{}); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(ctx, engine, nil, testKey3, txn2.ReadTimestamp, hlc.ClockTimestamp{}, value3, txn2); err != nil {
+	if err := MVCCPut(ctx, engine, testKey3, txn2.ReadTimestamp, value3, MVCCWriteOptions{Txn: txn2}); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(ctx, engine, nil, testKey4, txn1.ReadTimestamp, hlc.ClockTimestamp{}, value4, txn1); err != nil {
+	if err := MVCCPut(ctx, engine, testKey4, txn1.ReadTimestamp, value4, MVCCWriteOptions{Txn: txn1}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -3705,14 +3708,14 @@ func TestMVCCResolveTxnRangeResume(t *testing.T) {
 		key0 := roachpb.Key(fmt.Sprintf("%02d%d", i+0, i+0))
 		key1 := roachpb.Key(fmt.Sprintf("%02d%d", i+1, i+1))
 		key2 := roachpb.Key(fmt.Sprintf("%02d%d", i+2, i+2))
-		if err := MVCCPut(ctx, engine, nil, key0, txn1.ReadTimestamp, hlc.ClockTimestamp{}, value1, txn1); err != nil {
+		if err := MVCCPut(ctx, engine, key0, txn1.ReadTimestamp, value1, MVCCWriteOptions{Txn: txn1}); err != nil {
 			t.Fatal(err)
 		}
 		txn2ts := makeTxn(*txn2, hlc.Timestamp{Logical: 2})
-		if err := MVCCPut(ctx, engine, nil, key1, txn2ts.ReadTimestamp, hlc.ClockTimestamp{}, value2, txn2ts); err != nil {
+		if err := MVCCPut(ctx, engine, key1, txn2ts.ReadTimestamp, value2, MVCCWriteOptions{Txn: txn2ts}); err != nil {
 			t.Fatal(err)
 		}
-		if err := MVCCPut(ctx, engine, nil, key2, hlc.Timestamp{Logical: 3}, hlc.ClockTimestamp{}, value3, nil); err != nil {
+		if err := MVCCPut(ctx, engine, key2, hlc.Timestamp{Logical: 3}, value3, MVCCWriteOptions{}); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -3825,7 +3828,7 @@ func writeToEngine(
 				log.Infof(ctx, "Put: %s, seq: %d, writets: %s",
 					p.key.String(), txn.Sequence, txn.WriteTimestamp.String())
 			}
-			require.NoError(t, MVCCPut(ctx, eng, nil, p.key, txn.ReadTimestamp, hlc.ClockTimestamp{}, p.values[i], txn))
+			require.NoError(t, MVCCPut(ctx, eng, p.key, txn.ReadTimestamp, p.values[i], MVCCWriteOptions{Txn: txn}))
 		}
 	}
 }
@@ -4224,7 +4227,7 @@ func TestFindSplitKey(t *testing.T) {
 		v := strings.Repeat("X", 10-len(k))
 		val := roachpb.MakeValueFromString(v)
 		// Write the key and value through MVCC
-		if err := MVCCPut(ctx, engine, ms, []byte(k), hlc.Timestamp{Logical: 1}, hlc.ClockTimestamp{}, val, nil); err != nil {
+		if err := MVCCPut(ctx, engine, []byte(k), hlc.Timestamp{Logical: 1}, val, MVCCWriteOptions{Stats: ms}); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -4589,7 +4592,7 @@ func TestFindBalancedSplitKeys(t *testing.T) {
 					expKey = key
 				}
 				val := roachpb.MakeValueFromString(strings.Repeat("X", test.valSizes[j]))
-				if err := MVCCPut(ctx, engine, ms, key, hlc.Timestamp{Logical: 1}, hlc.ClockTimestamp{}, val, nil); err != nil {
+				if err := MVCCPut(ctx, engine, key, hlc.Timestamp{Logical: 1}, val, MVCCWriteOptions{Stats: ms}); err != nil {
 					t.Fatal(err)
 				}
 			}
@@ -4636,7 +4639,7 @@ func testPopulateKeysWithVersions(
 			ts := hlc.Timestamp{Logical: int32(j)}
 			require.NoError(
 				t,
-				MVCCPut(ctx, engine, ms, []byte(k), ts, hlc.ClockTimestamp{}, val, nil),
+				MVCCPut(ctx, engine, []byte(k), ts, val, MVCCWriteOptions{Stats: ms}),
 			)
 		}
 	}
@@ -4870,16 +4873,15 @@ func TestMVCCGarbageCollect(t *testing.T) {
 			}
 			for _, val := range test.vals[i : i+1] {
 				if i == len(test.vals)-1 && test.isDeleted {
-					if _, err := MVCCDelete(ctx, engine, ms, test.key, val.Timestamp, hlc.ClockTimestamp{},
-						nil); err != nil {
+					if _, err := MVCCDelete(ctx, engine, test.key, val.Timestamp, MVCCWriteOptions{Stats: ms}); err != nil {
 						t.Fatal(err)
 					}
 					continue
 				}
 				valCpy := *protoutil.Clone(&val).(*roachpb.Value)
 				valCpy.Timestamp = hlc.Timestamp{}
-				if err := MVCCPut(ctx, engine, ms, test.key, val.Timestamp, hlc.ClockTimestamp{},
-					valCpy, nil); err != nil {
+				if err := MVCCPut(ctx, engine, test.key, val.Timestamp,
+					valCpy, MVCCWriteOptions{Stats: ms}); err != nil {
 					t.Fatal(err)
 				}
 			}
@@ -5016,7 +5018,7 @@ func TestMVCCGarbageCollectNonDeleted(t *testing.T) {
 		for _, val := range test.vals {
 			valCpy := *protoutil.Clone(&val).(*roachpb.Value)
 			valCpy.Timestamp = hlc.Timestamp{}
-			if err := MVCCPut(ctx, engine, nil, test.key, val.Timestamp, hlc.ClockTimestamp{}, valCpy, nil); err != nil {
+			if err := MVCCPut(ctx, engine, test.key, val.Timestamp, valCpy, MVCCWriteOptions{}); err != nil {
 				t.Fatal(err)
 			}
 		}
@@ -5046,7 +5048,7 @@ func TestMVCCGarbageCollectIntent(t *testing.T) {
 	key := roachpb.Key("a")
 	{
 		val1 := roachpb.MakeValueFromBytes(bytes)
-		if err := MVCCPut(ctx, engine, nil, key, ts1, hlc.ClockTimestamp{}, val1, nil); err != nil {
+		if err := MVCCPut(ctx, engine, key, ts1, val1, MVCCWriteOptions{}); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -5054,7 +5056,7 @@ func TestMVCCGarbageCollectIntent(t *testing.T) {
 		TxnMeta:       enginepb.TxnMeta{ID: uuid.MakeV4(), WriteTimestamp: ts2},
 		ReadTimestamp: ts2,
 	}
-	if _, err := MVCCDelete(ctx, engine, nil, key, txn.ReadTimestamp, hlc.ClockTimestamp{}, txn); err != nil {
+	if _, err := MVCCDelete(ctx, engine, key, txn.ReadTimestamp, MVCCWriteOptions{Txn: txn}); err != nil {
 		t.Fatal(err)
 	}
 	keys := []kvpb.GCRequest_GCKey{
@@ -5145,7 +5147,7 @@ func TestMVCCGarbageCollectUsesSeekLTAppropriately(t *testing.T) {
 			for _, seconds := range key.timestamps {
 				val := roachpb.MakeValueFromBytes(bytes)
 				ts := toHLC(seconds)
-				if err := MVCCPut(ctx, engine, ms, roachpb.Key(key.key), ts, hlc.ClockTimestamp{}, val, nil); err != nil {
+				if err := MVCCPut(ctx, engine, roachpb.Key(key.key), ts, val, MVCCWriteOptions{Stats: ms}); err != nil {
 					t.Fatal(err)
 				}
 			}
@@ -5285,11 +5287,11 @@ func (d rangeTestData) populateEngine(
 	for _, v := range d {
 		if v.rangeTombstone.Timestamp.IsEmpty() {
 			if v.point.Value != nil {
-				require.NoError(t, MVCCPut(ctx, engine, ms, v.point.Key.Key, v.point.Key.Timestamp,
-					hlc.ClockTimestamp{}, roachpb.MakeValueFromBytes(v.point.Value), v.txn),
+				require.NoError(t, MVCCPut(ctx, engine, v.point.Key.Key, v.point.Key.Timestamp,
+					roachpb.MakeValueFromBytes(v.point.Value), MVCCWriteOptions{Txn: v.txn, Stats: ms}),
 					"failed to insert test value into engine (%s)", v.point.Key.String())
 			} else {
-				_, err := MVCCDelete(ctx, engine, ms, v.point.Key.Key, v.point.Key.Timestamp, hlc.ClockTimestamp{}, v.txn)
+				_, err := MVCCDelete(ctx, engine, v.point.Key.Key, v.point.Key.Timestamp, MVCCWriteOptions{Txn: v.txn, Stats: ms})
 				require.NoError(t, err, "failed to insert tombstone value into engine (%s)", v.point.Key.String())
 			}
 			ts = v.point.Key.Timestamp
@@ -6183,7 +6185,7 @@ func TestResolveIntentWithLowerEpoch(t *testing.T) {
 	defer engine.Close()
 
 	// Lay down an intent with a high epoch.
-	if err := MVCCPut(ctx, engine, nil, testKey1, txn1e2.ReadTimestamp, hlc.ClockTimestamp{}, value1, txn1e2); err != nil {
+	if err := MVCCPut(ctx, engine, testKey1, txn1e2.ReadTimestamp, value1, MVCCWriteOptions{Txn: txn1e2}); err != nil {
 		t.Fatal(err)
 	}
 	// Resolve the intent with a low epoch.

--- a/pkg/storage/pebble_mvcc_scanner_test.go
+++ b/pkg/storage/pebble_mvcc_scanner_test.go
@@ -218,7 +218,7 @@ func TestMVCCScanWithMemoryAccounting(t *testing.T) {
 		defer batch.Close()
 		for i := 0; i < 10; i++ {
 			key := makeKey(nil, i)
-			require.NoError(t, MVCCPut(context.Background(), batch, nil, key, ts1, hlc.ClockTimestamp{}, val, &txn1))
+			require.NoError(t, MVCCPut(context.Background(), batch, key, ts1, val, MVCCWriteOptions{Txn: &txn1}))
 		}
 		require.NoError(t, batch.Commit(true))
 	}()

--- a/pkg/storage/pebble_test.go
+++ b/pkg/storage/pebble_test.go
@@ -472,7 +472,7 @@ func fillInData(ctx context.Context, engine Engine, data []testValue) error {
 	batch := engine.NewBatch()
 	defer batch.Close()
 	for _, val := range data {
-		if err := MVCCPut(ctx, batch, nil, val.key, val.timestamp, hlc.ClockTimestamp{}, val.value, val.txn); err != nil {
+		if err := MVCCPut(ctx, batch, val.key, val.timestamp, val.value, MVCCWriteOptions{Txn: val.txn}); err != nil {
 			return err
 		}
 	}

--- a/pkg/storage/sst_test.go
+++ b/pkg/storage/sst_test.go
@@ -79,7 +79,7 @@ func TestCheckSSTConflictsMaxIntents(t *testing.T) {
 		require.NoError(t, batch.PutMVCC(mvccKey, mvccValue))
 	}
 	for _, key := range intents {
-		require.NoError(t, MVCCPut(ctx, batch, nil, roachpb.Key(key), txn1TS, hlc.ClockTimestamp{}, roachpb.MakeValueFromString("intent"), txn1))
+		require.NoError(t, MVCCPut(ctx, batch, roachpb.Key(key), txn1TS, roachpb.MakeValueFromString("intent"), MVCCWriteOptions{Txn: txn1}))
 	}
 	require.NoError(t, batch.Commit(true))
 	batch.Close()

--- a/pkg/storage/testdata/mvcc_histories/ambiguous_writes
+++ b/pkg/storage/testdata/mvcc_histories/ambiguous_writes
@@ -1,0 +1,394 @@
+# Ambiguous replay protection is only valid on transactional writes.
+
+run error
+del   k=a ambiguousReplay
+----
+>> at end:
+<no data>
+error: (*withstack.withStack:) cannot enable replay protection without a transaction
+
+# Idempotent replays should normally be allowed, even if they move the timestamp.
+
+run stats ok
+with t=A k=a
+  txn_begin ts=11
+  # Lay down an intent.
+  put v=first
+----
+>> put v=first t=A k=a
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+61 live_count=+1 live_bytes=+75 intent_count=+1 intent_bytes=+22 separated_intent_count=+1 intent_age=+89
+>> at end:
+txn: "A" meta={id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=11.000000000,0 wto=false gul=0,0
+meta: "a"/0,0 -> txn={id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0} ts=11.000000000,0 del=false klen=12 vlen=10 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "a"/11.000000000,0 -> /BYTES/first
+stats: key_count=1 key_bytes=14 val_count=1 val_bytes=61 live_count=1 live_bytes=75 intent_count=1 intent_bytes=22 separated_intent_count=1 intent_age=89
+
+run stats ok
+with t=A k=a
+  # Perform an idempotent replay, but at a higher ts.
+  txn_advance ts=12
+  put v=first
+----
+>> put v=first t=A k=a
+stats: no change
+>> at end:
+txn: "A" meta={id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=12.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=11.000000000,0 wto=false gul=0,0
+meta: "a"/0,0 -> txn={id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0} ts=11.000000000,0 del=false klen=12 vlen=10 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "a"/11.000000000,0 -> /BYTES/first
+stats: key_count=1 key_bytes=14 val_count=1 val_bytes=61 live_count=1 live_bytes=75 intent_count=1 intent_bytes=22 separated_intent_count=1 intent_age=89
+
+run ok
+with t=A k=a
+  resolve_intent
+  txn_remove
+----
+>> at end:
+data: "a"/12.000000000,0 -> {localTs=11.000000000,0}/BYTES/first
+
+# Ambiguous replay protection should allow initial writes.
+
+run stats ok
+with t=B k=k
+  txn_begin ts=0,1
+  initput k=k ts=0,1 v=k1 ambiguousReplay
+----
+>> initput k=k ts=0,1 v=k1 ambiguousReplay t=B k=k
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+50 live_count=+1 live_bytes=+64 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+100
+>> at end:
+txn: "B" meta={id=00000002 key="k" iso=Serializable pri=0.00000000 epo=0 ts=0,1 min=0,0 seq=0} lock=true stat=PENDING rts=0,1 wto=false gul=0,0
+data: "a"/12.000000000,0 -> {localTs=11.000000000,0}/BYTES/first
+meta: "k"/0,0 -> txn={id=00000002 key="k" iso=Serializable pri=0.00000000 epo=0 ts=0,1 min=0,0 seq=0} ts=0,1 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "k"/0,1 -> /BYTES/k1
+stats: key_count=2 key_bytes=28 val_count=2 val_bytes=73 live_count=2 live_bytes=101 intent_count=1 intent_bytes=19 separated_intent_count=1 intent_age=100
+
+run ok
+with t=B k=k
+  resolve_intent
+  txn_remove
+----
+>> at end:
+data: "a"/12.000000000,0 -> {localTs=11.000000000,0}/BYTES/first
+data: "k"/0,1 -> /BYTES/k1
+
+# Ambiguous replay protection should not affect identically evaluating cputs.
+
+run stats ok
+with t=C k=k
+  txn_begin ts=0,2
+  cput v=k2 cond=k1
+----
+>> cput v=k2 cond=k1 t=C k=k
+stats: key_bytes=+12 val_count=+1 val_bytes=+50 live_bytes=+43 gc_bytes_age=+1900 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+100
+>> at end:
+txn: "C" meta={id=00000003 key="k" iso=Serializable pri=0.00000000 epo=0 ts=0,2 min=0,0 seq=0} lock=true stat=PENDING rts=0,2 wto=false gul=0,0
+data: "a"/12.000000000,0 -> {localTs=11.000000000,0}/BYTES/first
+meta: "k"/0,0 -> txn={id=00000003 key="k" iso=Serializable pri=0.00000000 epo=0 ts=0,2 min=0,0 seq=0} ts=0,2 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "k"/0,2 -> /BYTES/k2
+data: "k"/0,1 -> /BYTES/k1
+stats: key_count=2 key_bytes=40 val_count=3 val_bytes=80 live_count=2 live_bytes=101 gc_bytes_age=1900 intent_count=1 intent_bytes=19 separated_intent_count=1 intent_age=100
+
+run stats ok
+with t=C k=k
+  cput v=k2 cond=k1 ambiguousReplay
+----
+>> cput v=k2 cond=k1 ambiguousReplay t=C k=k
+stats: no change
+>> at end:
+data: "a"/12.000000000,0 -> {localTs=11.000000000,0}/BYTES/first
+meta: "k"/0,0 -> txn={id=00000003 key="k" iso=Serializable pri=0.00000000 epo=0 ts=0,2 min=0,0 seq=0} ts=0,2 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "k"/0,2 -> /BYTES/k2
+data: "k"/0,1 -> /BYTES/k1
+stats: key_count=2 key_bytes=40 val_count=3 val_bytes=80 live_count=2 live_bytes=101 gc_bytes_age=1900 intent_count=1 intent_bytes=19 separated_intent_count=1 intent_age=100
+
+run ok
+with t=C k=k
+  resolve_intent
+  txn_remove
+----
+>> at end:
+data: "a"/12.000000000,0 -> {localTs=11.000000000,0}/BYTES/first
+data: "k"/0,2 -> /BYTES/k2
+data: "k"/0,1 -> /BYTES/k1
+
+# Ambiguous replay protection should prevent a replay from evaluating at a higher timestamp.
+
+run stats ok
+with t=D k=k
+  txn_begin ts=3,0
+  put v=k3
+----
+>> put v=k3 t=D k=k
+stats: key_bytes=+12 val_count=+1 val_bytes=+58 live_bytes=+51 gc_bytes_age=+1843 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+97
+>> at end:
+txn: "D" meta={id=00000004 key="k" iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=3.000000000,0 wto=false gul=0,0
+data: "a"/12.000000000,0 -> {localTs=11.000000000,0}/BYTES/first
+meta: "k"/0,0 -> txn={id=00000004 key="k" iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} ts=3.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "k"/3.000000000,0 -> /BYTES/k3
+data: "k"/0,2 -> /BYTES/k2
+data: "k"/0,1 -> /BYTES/k1
+stats: key_count=2 key_bytes=52 val_count=4 val_bytes=95 live_count=2 live_bytes=109 gc_bytes_age=3743 intent_count=1 intent_bytes=19 separated_intent_count=1 intent_age=97
+
+run stats error
+with t=D k=k
+  txn_advance ts=3,1
+  put v=k3 ambiguousReplay
+----
+>> put v=k3 ambiguousReplay t=D k=k
+stats: no change
+>> at end:
+txn: "D" meta={id=00000004 key="k" iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,1 min=0,0 seq=0} lock=true stat=PENDING rts=3.000000000,0 wto=false gul=0,0
+data: "a"/12.000000000,0 -> {localTs=11.000000000,0}/BYTES/first
+meta: "k"/0,0 -> txn={id=00000004 key="k" iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} ts=3.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "k"/3.000000000,0 -> /BYTES/k3
+data: "k"/0,2 -> /BYTES/k2
+data: "k"/0,1 -> /BYTES/k1
+stats: key_count=2 key_bytes=52 val_count=4 val_bytes=95 live_count=2 live_bytes=109 gc_bytes_age=3743 intent_count=1 intent_bytes=19 separated_intent_count=1 intent_age=97
+error: (*withstack.withStack:) transaction 00000004-0000-0000-0000-000000000000 with sequence 0 prevented from changing write timestamp from 3.000000000,0 to 3.000000000,1 due to ambiguous replay protection
+
+run ok
+with t=D k=k
+  # Commit at the original timestamp (i.e. if committed by a recovery operation).
+  txn_advance ts=3,0
+  resolve_intent
+  txn_remove
+----
+>> at end:
+data: "a"/12.000000000,0 -> {localTs=11.000000000,0}/BYTES/first
+data: "k"/3.000000000,0 -> /BYTES/k3
+data: "k"/0,2 -> /BYTES/k2
+data: "k"/0,1 -> /BYTES/k1
+
+# Ambiguous replay protection still results in WriteTooOld errors after intent cleanup.
+
+run stats ok
+with t=E k=k
+  txn_begin ts=4,0
+  del resolve
+----
+>> del resolve t=E k=k
+del: "k": found key true
+stats: key_bytes=+12 val_count=+1 live_count=-1 live_bytes=-21 gc_bytes_age=+3168
+>> at end:
+txn: "E" meta={id=00000005 key="k" iso=Serializable pri=0.00000000 epo=0 ts=4.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=4.000000000,0 wto=false gul=0,0
+data: "a"/12.000000000,0 -> {localTs=11.000000000,0}/BYTES/first
+data: "k"/4.000000000,0 -> /<empty>
+data: "k"/3.000000000,0 -> /BYTES/k3
+data: "k"/0,2 -> /BYTES/k2
+data: "k"/0,1 -> /BYTES/k1
+stats: key_count=2 key_bytes=64 val_count=5 val_bytes=44 live_count=1 live_bytes=37 gc_bytes_age=6911
+
+run stats error
+with t=E k=k
+  del ambiguousReplay
+----
+>> del ambiguousReplay t=E k=k
+del: "k": found key false
+stats: no change
+>> at end:
+data: "a"/12.000000000,0 -> {localTs=11.000000000,0}/BYTES/first
+data: "k"/4.000000000,0 -> /<empty>
+data: "k"/3.000000000,0 -> /BYTES/k3
+data: "k"/0,2 -> /BYTES/k2
+data: "k"/0,1 -> /BYTES/k1
+stats: key_count=2 key_bytes=64 val_count=5 val_bytes=44 live_count=1 live_bytes=37 gc_bytes_age=6911
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k" at timestamp 4.000000000,0 too old; must write at or above 4.000000000,1
+
+run ok
+txn_remove t=E
+----
+>> at end:
+
+# Ambiguous replay protects against timestamp change on point delete.
+
+run stats ok
+with t=F k=k
+  txn_begin ts=5,0
+  # Write an initial value at the first sequence number.
+  put v=k5
+----
+>> put v=k5 t=F k=k
+stats: key_bytes=+12 val_count=+1 val_bytes=+58 live_count=+1 live_bytes=+72 gc_bytes_age=-192 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+95
+>> at end:
+txn: "F" meta={id=00000006 key="k" iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=5.000000000,0 wto=false gul=0,0
+data: "a"/12.000000000,0 -> {localTs=11.000000000,0}/BYTES/first
+meta: "k"/0,0 -> txn={id=00000006 key="k" iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} ts=5.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "k"/5.000000000,0 -> /BYTES/k5
+data: "k"/4.000000000,0 -> /<empty>
+data: "k"/3.000000000,0 -> /BYTES/k3
+data: "k"/0,2 -> /BYTES/k2
+data: "k"/0,1 -> /BYTES/k1
+stats: key_count=2 key_bytes=76 val_count=6 val_bytes=102 live_count=2 live_bytes=109 gc_bytes_age=6719 intent_count=1 intent_bytes=19 separated_intent_count=1 intent_age=95
+
+run stats ok
+with t=F k=k
+  txn_step
+  # Let's assume we had an RPC error prior to the first successful operation.
+  del ambiguousReplay
+----
+>> del ambiguousReplay t=F k=k
+del: "k": found key true
+stats: val_bytes=+6 live_count=-1 live_bytes=-72 gc_bytes_age=+7410 intent_bytes=-7
+>> at end:
+txn: "F" meta={id=00000006 key="k" iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=5.000000000,0 wto=false gul=0,0
+data: "a"/12.000000000,0 -> {localTs=11.000000000,0}/BYTES/first
+meta: "k"/0,0 -> txn={id=00000006 key="k" iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=1} ts=5.000000000,0 del=true klen=12 vlen=0 ih={{0 /BYTES/k5}} mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "k"/5.000000000,0 -> /<empty>
+data: "k"/4.000000000,0 -> /<empty>
+data: "k"/3.000000000,0 -> /BYTES/k3
+data: "k"/0,2 -> /BYTES/k2
+data: "k"/0,1 -> /BYTES/k1
+stats: key_count=2 key_bytes=76 val_count=6 val_bytes=108 live_count=1 live_bytes=37 gc_bytes_age=14129 intent_count=1 intent_bytes=12 separated_intent_count=1 intent_age=95
+
+run stats ok
+with t=F k=k
+  txn_step n=-1
+  # A replay of a lower sequence number with the same timestamp should be allowed.
+  put v=k5 ambiguousReplay
+----
+>> put v=k5 ambiguousReplay t=F k=k
+stats: no change
+>> at end:
+txn: "F" meta={id=00000006 key="k" iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=5.000000000,0 wto=false gul=0,0
+data: "a"/12.000000000,0 -> {localTs=11.000000000,0}/BYTES/first
+meta: "k"/0,0 -> txn={id=00000006 key="k" iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=1} ts=5.000000000,0 del=true klen=12 vlen=0 ih={{0 /BYTES/k5}} mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "k"/5.000000000,0 -> /<empty>
+data: "k"/4.000000000,0 -> /<empty>
+data: "k"/3.000000000,0 -> /BYTES/k3
+data: "k"/0,2 -> /BYTES/k2
+data: "k"/0,1 -> /BYTES/k1
+stats: key_count=2 key_bytes=76 val_count=6 val_bytes=108 live_count=1 live_bytes=37 gc_bytes_age=14129 intent_count=1 intent_bytes=12 separated_intent_count=1 intent_age=95
+
+run stats error
+with t=F k=k
+  txn_step
+  txn_advance ts=5,1
+  del ambiguousReplay
+----
+>> del ambiguousReplay t=F k=k
+stats: no change
+>> at end:
+txn: "F" meta={id=00000006 key="k" iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,1 min=0,0 seq=1} lock=true stat=PENDING rts=5.000000000,0 wto=false gul=0,0
+data: "a"/12.000000000,0 -> {localTs=11.000000000,0}/BYTES/first
+meta: "k"/0,0 -> txn={id=00000006 key="k" iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=1} ts=5.000000000,0 del=true klen=12 vlen=0 ih={{0 /BYTES/k5}} mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "k"/5.000000000,0 -> /<empty>
+data: "k"/4.000000000,0 -> /<empty>
+data: "k"/3.000000000,0 -> /BYTES/k3
+data: "k"/0,2 -> /BYTES/k2
+data: "k"/0,1 -> /BYTES/k1
+stats: key_count=2 key_bytes=76 val_count=6 val_bytes=108 live_count=1 live_bytes=37 gc_bytes_age=14129 intent_count=1 intent_bytes=12 separated_intent_count=1 intent_age=95
+error: (*withstack.withStack:) transaction 00000006-0000-0000-0000-000000000000 with sequence 1 prevented from changing write timestamp from 5.000000000,0 to 5.000000000,1 due to ambiguous replay protection
+
+run ok
+with t=F k=k
+  resolve_intent status=ABORTED
+  txn_remove
+----
+>> at end:
+data: "a"/12.000000000,0 -> {localTs=11.000000000,0}/BYTES/first
+data: "k"/4.000000000,0 -> /<empty>
+data: "k"/3.000000000,0 -> /BYTES/k3
+data: "k"/0,2 -> /BYTES/k2
+data: "k"/0,1 -> /BYTES/k1
+
+# Ambiguous replay protection prevents timestamp change on transactional DeleteRange.
+
+run ok
+put k=k v=k6 ts=6,0
+----
+>> at end:
+data: "a"/12.000000000,0 -> {localTs=11.000000000,0}/BYTES/first
+data: "k"/6.000000000,0 -> /BYTES/k6
+data: "k"/4.000000000,0 -> /<empty>
+data: "k"/3.000000000,0 -> /BYTES/k3
+data: "k"/0,2 -> /BYTES/k2
+data: "k"/0,1 -> /BYTES/k1
+
+run stats ok
+with t=G k=k
+  txn_begin ts=12,1
+  del_range k=a end=z returnKeys
+----
+>> del_range k=a end=z returnKeys t=G k=k
+del_range: "a"-"z" -> deleted 2 key(s)
+del_range: returned "a"
+del_range: returned "k"
+stats: key_bytes=+24 val_count=+2 val_bytes=+106 live_count=-2 live_bytes=-58 gc_bytes_age=+16544 intent_count=+2 intent_bytes=+24 separated_intent_count=+2 intent_age=+176
+>> at end:
+txn: "G" meta={id=00000007 key="k" iso=Serializable pri=0.00000000 epo=0 ts=12.000000000,1 min=0,0 seq=0} lock=true stat=PENDING rts=12.000000000,1 wto=false gul=0,0
+meta: "a"/0,0 -> txn={id=00000007 key="k" iso=Serializable pri=0.00000000 epo=0 ts=12.000000000,1 min=0,0 seq=0} ts=12.000000000,1 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "a"/12.000000000,1 -> /<empty>
+data: "a"/12.000000000,0 -> {localTs=11.000000000,0}/BYTES/first
+meta: "k"/0,0 -> txn={id=00000007 key="k" iso=Serializable pri=0.00000000 epo=0 ts=12.000000000,1 min=0,0 seq=0} ts=12.000000000,1 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "k"/12.000000000,1 -> /<empty>
+data: "k"/6.000000000,0 -> /BYTES/k6
+data: "k"/4.000000000,0 -> /<empty>
+data: "k"/3.000000000,0 -> /BYTES/k3
+data: "k"/0,2 -> /BYTES/k2
+data: "k"/0,1 -> /BYTES/k1
+stats: key_count=2 key_bytes=100 val_count=8 val_bytes=157 gc_bytes_age=23263 intent_count=2 intent_bytes=24 separated_intent_count=2 intent_age=176
+
+run stats ok
+with t=G k=k
+  # First attempt a standard idempotent replay at a higher timestamp.
+  txn_advance ts=12,2
+  del_range k=a end=z returnKeys
+----
+>> del_range k=a end=z returnKeys t=G k=k
+del_range: "a"-"z" -> deleted 2 key(s)
+del_range: returned "a"
+del_range: returned "k"
+stats: no change
+>> at end:
+txn: "G" meta={id=00000007 key="k" iso=Serializable pri=0.00000000 epo=0 ts=12.000000000,2 min=0,0 seq=0} lock=true stat=PENDING rts=12.000000000,1 wto=false gul=0,0
+meta: "a"/0,0 -> txn={id=00000007 key="k" iso=Serializable pri=0.00000000 epo=0 ts=12.000000000,1 min=0,0 seq=0} ts=12.000000000,1 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "a"/12.000000000,1 -> /<empty>
+data: "a"/12.000000000,0 -> {localTs=11.000000000,0}/BYTES/first
+meta: "k"/0,0 -> txn={id=00000007 key="k" iso=Serializable pri=0.00000000 epo=0 ts=12.000000000,1 min=0,0 seq=0} ts=12.000000000,1 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "k"/12.000000000,1 -> /<empty>
+data: "k"/6.000000000,0 -> /BYTES/k6
+data: "k"/4.000000000,0 -> /<empty>
+data: "k"/3.000000000,0 -> /BYTES/k3
+data: "k"/0,2 -> /BYTES/k2
+data: "k"/0,1 -> /BYTES/k1
+stats: key_count=2 key_bytes=100 val_count=8 val_bytes=157 gc_bytes_age=23263 intent_count=2 intent_bytes=24 separated_intent_count=2 intent_age=176
+
+run stats error
+with t=G k=k
+  txn_advance ts=12,3
+  # However with ambiguous replay protection, a timestamp change should error.
+  del_range k=a end=z ambiguousReplay returnKeys
+----
+>> del_range k=a end=z ambiguousReplay returnKeys t=G k=k
+stats: no change
+>> at end:
+txn: "G" meta={id=00000007 key="k" iso=Serializable pri=0.00000000 epo=0 ts=12.000000000,3 min=0,0 seq=0} lock=true stat=PENDING rts=12.000000000,1 wto=false gul=0,0
+meta: "a"/0,0 -> txn={id=00000007 key="k" iso=Serializable pri=0.00000000 epo=0 ts=12.000000000,1 min=0,0 seq=0} ts=12.000000000,1 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "a"/12.000000000,1 -> /<empty>
+data: "a"/12.000000000,0 -> {localTs=11.000000000,0}/BYTES/first
+meta: "k"/0,0 -> txn={id=00000007 key="k" iso=Serializable pri=0.00000000 epo=0 ts=12.000000000,1 min=0,0 seq=0} ts=12.000000000,1 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "k"/12.000000000,1 -> /<empty>
+data: "k"/6.000000000,0 -> /BYTES/k6
+data: "k"/4.000000000,0 -> /<empty>
+data: "k"/3.000000000,0 -> /BYTES/k3
+data: "k"/0,2 -> /BYTES/k2
+data: "k"/0,1 -> /BYTES/k1
+stats: key_count=2 key_bytes=100 val_count=8 val_bytes=157 gc_bytes_age=23263 intent_count=2 intent_bytes=24 separated_intent_count=2 intent_age=176
+error: (*withstack.withStack:) transaction 00000007-0000-0000-0000-000000000000 with sequence 0 prevented from changing write timestamp from 12.000000000,1 to 12.000000000,3 due to ambiguous replay protection
+
+run ok
+with t=G
+  # Commit at the last "correct" timestamp.
+  txn_advance ts=12,2
+  resolve_intent k=a
+  resolve_intent k=k
+  txn_remove
+----
+>> at end:
+data: "a"/12.000000000,2 -> {localTs=12.000000000,1}/<empty>
+data: "a"/12.000000000,0 -> {localTs=11.000000000,0}/BYTES/first
+data: "k"/12.000000000,2 -> {localTs=12.000000000,1}/<empty>
+data: "k"/6.000000000,0 -> /BYTES/k6
+data: "k"/4.000000000,0 -> /<empty>
+data: "k"/3.000000000,0 -> /BYTES/k3
+data: "k"/0,2 -> /BYTES/k2
+data: "k"/0,1 -> /BYTES/k1

--- a/pkg/storage/testdata/mvcc_histories/ambiguous_writes
+++ b/pkg/storage/testdata/mvcc_histories/ambiguous_writes
@@ -18,8 +18,8 @@ with t=A k=a
 >> put v=first t=A k=a
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+61 live_count=+1 live_bytes=+75 intent_count=+1 intent_bytes=+22 separated_intent_count=+1 intent_age=+89
 >> at end:
-txn: "A" meta={id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=11.000000000,0 wto=false gul=0,0
-meta: "a"/0,0 -> txn={id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0} ts=11.000000000,0 del=false klen=12 vlen=10 mergeTs=<nil> txnDidNotUpdateMeta=true
+txn: "A" meta={id=00000000 key="a" pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=11.000000000,0 wto=false gul=0,0
+meta: "a"/0,0 -> txn={id=00000000 key="a" pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0} ts=11.000000000,0 del=false klen=12 vlen=10 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "a"/11.000000000,0 -> /BYTES/first
 stats: key_count=1 key_bytes=14 val_count=1 val_bytes=61 live_count=1 live_bytes=75 intent_count=1 intent_bytes=22 separated_intent_count=1 intent_age=89
 
@@ -32,8 +32,8 @@ with t=A k=a
 >> put v=first t=A k=a
 stats: no change
 >> at end:
-txn: "A" meta={id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=12.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=11.000000000,0 wto=false gul=0,0
-meta: "a"/0,0 -> txn={id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0} ts=11.000000000,0 del=false klen=12 vlen=10 mergeTs=<nil> txnDidNotUpdateMeta=true
+txn: "A" meta={id=00000000 key="a" pri=0.00000000 epo=0 ts=12.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=11.000000000,0 wto=false gul=0,0
+meta: "a"/0,0 -> txn={id=00000000 key="a" pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0} ts=11.000000000,0 del=false klen=12 vlen=10 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "a"/11.000000000,0 -> /BYTES/first
 stats: key_count=1 key_bytes=14 val_count=1 val_bytes=61 live_count=1 live_bytes=75 intent_count=1 intent_bytes=22 separated_intent_count=1 intent_age=89
 
@@ -55,9 +55,9 @@ with t=B k=k
 >> initput k=k ts=0,1 v=k1 ambiguousReplay t=B k=k
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+50 live_count=+1 live_bytes=+64 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+100
 >> at end:
-txn: "B" meta={id=00000002 key="k" iso=Serializable pri=0.00000000 epo=0 ts=0,1 min=0,0 seq=0} lock=true stat=PENDING rts=0,1 wto=false gul=0,0
+txn: "B" meta={id=00000000 key="k" pri=0.00000000 epo=0 ts=0,1 min=0,0 seq=0} lock=true stat=PENDING rts=0,1 wto=false gul=0,0
 data: "a"/12.000000000,0 -> {localTs=11.000000000,0}/BYTES/first
-meta: "k"/0,0 -> txn={id=00000002 key="k" iso=Serializable pri=0.00000000 epo=0 ts=0,1 min=0,0 seq=0} ts=0,1 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+meta: "k"/0,0 -> txn={id=00000000 key="k" pri=0.00000000 epo=0 ts=0,1 min=0,0 seq=0} ts=0,1 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k"/0,1 -> /BYTES/k1
 stats: key_count=2 key_bytes=28 val_count=2 val_bytes=73 live_count=2 live_bytes=101 intent_count=1 intent_bytes=19 separated_intent_count=1 intent_age=100
 
@@ -80,9 +80,9 @@ with t=C k=k
 >> cput v=k2 cond=k1 t=C k=k
 stats: key_bytes=+12 val_count=+1 val_bytes=+50 live_bytes=+43 gc_bytes_age=+1900 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+100
 >> at end:
-txn: "C" meta={id=00000003 key="k" iso=Serializable pri=0.00000000 epo=0 ts=0,2 min=0,0 seq=0} lock=true stat=PENDING rts=0,2 wto=false gul=0,0
+txn: "C" meta={id=00000000 key="k" pri=0.00000000 epo=0 ts=0,2 min=0,0 seq=0} lock=true stat=PENDING rts=0,2 wto=false gul=0,0
 data: "a"/12.000000000,0 -> {localTs=11.000000000,0}/BYTES/first
-meta: "k"/0,0 -> txn={id=00000003 key="k" iso=Serializable pri=0.00000000 epo=0 ts=0,2 min=0,0 seq=0} ts=0,2 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+meta: "k"/0,0 -> txn={id=00000000 key="k" pri=0.00000000 epo=0 ts=0,2 min=0,0 seq=0} ts=0,2 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k"/0,2 -> /BYTES/k2
 data: "k"/0,1 -> /BYTES/k1
 stats: key_count=2 key_bytes=40 val_count=3 val_bytes=80 live_count=2 live_bytes=101 gc_bytes_age=1900 intent_count=1 intent_bytes=19 separated_intent_count=1 intent_age=100
@@ -95,7 +95,7 @@ with t=C k=k
 stats: no change
 >> at end:
 data: "a"/12.000000000,0 -> {localTs=11.000000000,0}/BYTES/first
-meta: "k"/0,0 -> txn={id=00000003 key="k" iso=Serializable pri=0.00000000 epo=0 ts=0,2 min=0,0 seq=0} ts=0,2 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+meta: "k"/0,0 -> txn={id=00000000 key="k" pri=0.00000000 epo=0 ts=0,2 min=0,0 seq=0} ts=0,2 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k"/0,2 -> /BYTES/k2
 data: "k"/0,1 -> /BYTES/k1
 stats: key_count=2 key_bytes=40 val_count=3 val_bytes=80 live_count=2 live_bytes=101 gc_bytes_age=1900 intent_count=1 intent_bytes=19 separated_intent_count=1 intent_age=100
@@ -120,9 +120,9 @@ with t=D k=k
 >> put v=k3 t=D k=k
 stats: key_bytes=+12 val_count=+1 val_bytes=+58 live_bytes=+51 gc_bytes_age=+1843 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+97
 >> at end:
-txn: "D" meta={id=00000004 key="k" iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=3.000000000,0 wto=false gul=0,0
+txn: "D" meta={id=00000000 key="k" pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=3.000000000,0 wto=false gul=0,0
 data: "a"/12.000000000,0 -> {localTs=11.000000000,0}/BYTES/first
-meta: "k"/0,0 -> txn={id=00000004 key="k" iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} ts=3.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+meta: "k"/0,0 -> txn={id=00000000 key="k" pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} ts=3.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k"/3.000000000,0 -> /BYTES/k3
 data: "k"/0,2 -> /BYTES/k2
 data: "k"/0,1 -> /BYTES/k1
@@ -136,14 +136,14 @@ with t=D k=k
 >> put v=k3 ambiguousReplay t=D k=k
 stats: no change
 >> at end:
-txn: "D" meta={id=00000004 key="k" iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,1 min=0,0 seq=0} lock=true stat=PENDING rts=3.000000000,0 wto=false gul=0,0
+txn: "D" meta={id=00000000 key="k" pri=0.00000000 epo=0 ts=3.000000000,1 min=0,0 seq=0} lock=true stat=PENDING rts=3.000000000,0 wto=false gul=0,0
 data: "a"/12.000000000,0 -> {localTs=11.000000000,0}/BYTES/first
-meta: "k"/0,0 -> txn={id=00000004 key="k" iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} ts=3.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+meta: "k"/0,0 -> txn={id=00000000 key="k" pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} ts=3.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k"/3.000000000,0 -> /BYTES/k3
 data: "k"/0,2 -> /BYTES/k2
 data: "k"/0,1 -> /BYTES/k1
 stats: key_count=2 key_bytes=52 val_count=4 val_bytes=95 live_count=2 live_bytes=109 gc_bytes_age=3743 intent_count=1 intent_bytes=19 separated_intent_count=1 intent_age=97
-error: (*withstack.withStack:) transaction 00000004-0000-0000-0000-000000000000 with sequence 0 prevented from changing write timestamp from 3.000000000,0 to 3.000000000,1 due to ambiguous replay protection
+error: (*withstack.withStack:) transaction 00000000-0000-0000-0000-000000000004 with sequence 0 prevented from changing write timestamp from 3.000000000,0 to 3.000000000,1 due to ambiguous replay protection
 
 run ok
 with t=D k=k
@@ -169,7 +169,7 @@ with t=E k=k
 del: "k": found key true
 stats: key_bytes=+12 val_count=+1 live_count=-1 live_bytes=-21 gc_bytes_age=+3168
 >> at end:
-txn: "E" meta={id=00000005 key="k" iso=Serializable pri=0.00000000 epo=0 ts=4.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=4.000000000,0 wto=false gul=0,0
+txn: "E" meta={id=00000000 key="k" pri=0.00000000 epo=0 ts=4.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=4.000000000,0 wto=false gul=0,0
 data: "a"/12.000000000,0 -> {localTs=11.000000000,0}/BYTES/first
 data: "k"/4.000000000,0 -> /<empty>
 data: "k"/3.000000000,0 -> /BYTES/k3
@@ -183,20 +183,30 @@ with t=E k=k
 ----
 >> del ambiguousReplay t=E k=k
 del: "k": found key false
-stats: no change
+stats: key_bytes=+12 val_count=+1 val_bytes=+53 gc_bytes_age=+6240 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+96
+>> at end:
+data: "a"/12.000000000,0 -> {localTs=11.000000000,0}/BYTES/first
+meta: "k"/0,0 -> txn={id=00000000 key="k" pri=0.00000000 epo=0 ts=4.000000000,1 min=0,0 seq=0} ts=4.000000000,1 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "k"/4.000000000,1 -> /<empty>
+data: "k"/4.000000000,0 -> /<empty>
+data: "k"/3.000000000,0 -> /BYTES/k3
+data: "k"/0,2 -> /BYTES/k2
+data: "k"/0,1 -> /BYTES/k1
+stats: key_count=2 key_bytes=76 val_count=6 val_bytes=97 live_count=1 live_bytes=37 gc_bytes_age=13151 intent_count=1 intent_bytes=12 separated_intent_count=1 intent_age=96
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k" at timestamp 4.000000000,0 too old; wrote at 4.000000000,1
+
+
+run ok
+with t=E k=k
+  resolve_intent status=ABORTED
+  txn_remove
+----
 >> at end:
 data: "a"/12.000000000,0 -> {localTs=11.000000000,0}/BYTES/first
 data: "k"/4.000000000,0 -> /<empty>
 data: "k"/3.000000000,0 -> /BYTES/k3
 data: "k"/0,2 -> /BYTES/k2
 data: "k"/0,1 -> /BYTES/k1
-stats: key_count=2 key_bytes=64 val_count=5 val_bytes=44 live_count=1 live_bytes=37 gc_bytes_age=6911
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k" at timestamp 4.000000000,0 too old; must write at or above 4.000000000,1
-
-run ok
-txn_remove t=E
-----
->> at end:
 
 # Ambiguous replay protects against timestamp change on point delete.
 
@@ -209,9 +219,9 @@ with t=F k=k
 >> put v=k5 t=F k=k
 stats: key_bytes=+12 val_count=+1 val_bytes=+58 live_count=+1 live_bytes=+72 gc_bytes_age=-192 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+95
 >> at end:
-txn: "F" meta={id=00000006 key="k" iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=5.000000000,0 wto=false gul=0,0
+txn: "F" meta={id=00000000 key="k" pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=5.000000000,0 wto=false gul=0,0
 data: "a"/12.000000000,0 -> {localTs=11.000000000,0}/BYTES/first
-meta: "k"/0,0 -> txn={id=00000006 key="k" iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} ts=5.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+meta: "k"/0,0 -> txn={id=00000000 key="k" pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} ts=5.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k"/5.000000000,0 -> /BYTES/k5
 data: "k"/4.000000000,0 -> /<empty>
 data: "k"/3.000000000,0 -> /BYTES/k3
@@ -229,9 +239,9 @@ with t=F k=k
 del: "k": found key true
 stats: val_bytes=+6 live_count=-1 live_bytes=-72 gc_bytes_age=+7410 intent_bytes=-7
 >> at end:
-txn: "F" meta={id=00000006 key="k" iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=5.000000000,0 wto=false gul=0,0
+txn: "F" meta={id=00000000 key="k" pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=5.000000000,0 wto=false gul=0,0
 data: "a"/12.000000000,0 -> {localTs=11.000000000,0}/BYTES/first
-meta: "k"/0,0 -> txn={id=00000006 key="k" iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=1} ts=5.000000000,0 del=true klen=12 vlen=0 ih={{0 /BYTES/k5}} mergeTs=<nil> txnDidNotUpdateMeta=false
+meta: "k"/0,0 -> txn={id=00000000 key="k" pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=1} ts=5.000000000,0 del=true klen=12 vlen=0 ih={{0 /BYTES/k5}} mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "k"/5.000000000,0 -> /<empty>
 data: "k"/4.000000000,0 -> /<empty>
 data: "k"/3.000000000,0 -> /BYTES/k3
@@ -248,9 +258,9 @@ with t=F k=k
 >> put v=k5 ambiguousReplay t=F k=k
 stats: no change
 >> at end:
-txn: "F" meta={id=00000006 key="k" iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=5.000000000,0 wto=false gul=0,0
+txn: "F" meta={id=00000000 key="k" pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=5.000000000,0 wto=false gul=0,0
 data: "a"/12.000000000,0 -> {localTs=11.000000000,0}/BYTES/first
-meta: "k"/0,0 -> txn={id=00000006 key="k" iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=1} ts=5.000000000,0 del=true klen=12 vlen=0 ih={{0 /BYTES/k5}} mergeTs=<nil> txnDidNotUpdateMeta=false
+meta: "k"/0,0 -> txn={id=00000000 key="k" pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=1} ts=5.000000000,0 del=true klen=12 vlen=0 ih={{0 /BYTES/k5}} mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "k"/5.000000000,0 -> /<empty>
 data: "k"/4.000000000,0 -> /<empty>
 data: "k"/3.000000000,0 -> /BYTES/k3
@@ -267,16 +277,16 @@ with t=F k=k
 >> del ambiguousReplay t=F k=k
 stats: no change
 >> at end:
-txn: "F" meta={id=00000006 key="k" iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,1 min=0,0 seq=1} lock=true stat=PENDING rts=5.000000000,0 wto=false gul=0,0
+txn: "F" meta={id=00000000 key="k" pri=0.00000000 epo=0 ts=5.000000000,1 min=0,0 seq=1} lock=true stat=PENDING rts=5.000000000,0 wto=false gul=0,0
 data: "a"/12.000000000,0 -> {localTs=11.000000000,0}/BYTES/first
-meta: "k"/0,0 -> txn={id=00000006 key="k" iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=1} ts=5.000000000,0 del=true klen=12 vlen=0 ih={{0 /BYTES/k5}} mergeTs=<nil> txnDidNotUpdateMeta=false
+meta: "k"/0,0 -> txn={id=00000000 key="k" pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=1} ts=5.000000000,0 del=true klen=12 vlen=0 ih={{0 /BYTES/k5}} mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "k"/5.000000000,0 -> /<empty>
 data: "k"/4.000000000,0 -> /<empty>
 data: "k"/3.000000000,0 -> /BYTES/k3
 data: "k"/0,2 -> /BYTES/k2
 data: "k"/0,1 -> /BYTES/k1
 stats: key_count=2 key_bytes=76 val_count=6 val_bytes=108 live_count=1 live_bytes=37 gc_bytes_age=14129 intent_count=1 intent_bytes=12 separated_intent_count=1 intent_age=95
-error: (*withstack.withStack:) transaction 00000006-0000-0000-0000-000000000000 with sequence 1 prevented from changing write timestamp from 5.000000000,0 to 5.000000000,1 due to ambiguous replay protection
+error: (*withstack.withStack:) transaction 00000000-0000-0000-0000-000000000006 with sequence 1 prevented from changing write timestamp from 5.000000000,0 to 5.000000000,1 due to ambiguous replay protection
 
 run ok
 with t=F k=k
@@ -314,11 +324,11 @@ del_range: returned "a"
 del_range: returned "k"
 stats: key_bytes=+24 val_count=+2 val_bytes=+106 live_count=-2 live_bytes=-58 gc_bytes_age=+16544 intent_count=+2 intent_bytes=+24 separated_intent_count=+2 intent_age=+176
 >> at end:
-txn: "G" meta={id=00000007 key="k" iso=Serializable pri=0.00000000 epo=0 ts=12.000000000,1 min=0,0 seq=0} lock=true stat=PENDING rts=12.000000000,1 wto=false gul=0,0
-meta: "a"/0,0 -> txn={id=00000007 key="k" iso=Serializable pri=0.00000000 epo=0 ts=12.000000000,1 min=0,0 seq=0} ts=12.000000000,1 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+txn: "G" meta={id=00000000 key="k" pri=0.00000000 epo=0 ts=12.000000000,1 min=0,0 seq=0} lock=true stat=PENDING rts=12.000000000,1 wto=false gul=0,0
+meta: "a"/0,0 -> txn={id=00000000 key="k" pri=0.00000000 epo=0 ts=12.000000000,1 min=0,0 seq=0} ts=12.000000000,1 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "a"/12.000000000,1 -> /<empty>
 data: "a"/12.000000000,0 -> {localTs=11.000000000,0}/BYTES/first
-meta: "k"/0,0 -> txn={id=00000007 key="k" iso=Serializable pri=0.00000000 epo=0 ts=12.000000000,1 min=0,0 seq=0} ts=12.000000000,1 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+meta: "k"/0,0 -> txn={id=00000000 key="k" pri=0.00000000 epo=0 ts=12.000000000,1 min=0,0 seq=0} ts=12.000000000,1 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k"/12.000000000,1 -> /<empty>
 data: "k"/6.000000000,0 -> /BYTES/k6
 data: "k"/4.000000000,0 -> /<empty>
@@ -339,11 +349,11 @@ del_range: returned "a"
 del_range: returned "k"
 stats: no change
 >> at end:
-txn: "G" meta={id=00000007 key="k" iso=Serializable pri=0.00000000 epo=0 ts=12.000000000,2 min=0,0 seq=0} lock=true stat=PENDING rts=12.000000000,1 wto=false gul=0,0
-meta: "a"/0,0 -> txn={id=00000007 key="k" iso=Serializable pri=0.00000000 epo=0 ts=12.000000000,1 min=0,0 seq=0} ts=12.000000000,1 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+txn: "G" meta={id=00000000 key="k" pri=0.00000000 epo=0 ts=12.000000000,2 min=0,0 seq=0} lock=true stat=PENDING rts=12.000000000,1 wto=false gul=0,0
+meta: "a"/0,0 -> txn={id=00000000 key="k" pri=0.00000000 epo=0 ts=12.000000000,1 min=0,0 seq=0} ts=12.000000000,1 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "a"/12.000000000,1 -> /<empty>
 data: "a"/12.000000000,0 -> {localTs=11.000000000,0}/BYTES/first
-meta: "k"/0,0 -> txn={id=00000007 key="k" iso=Serializable pri=0.00000000 epo=0 ts=12.000000000,1 min=0,0 seq=0} ts=12.000000000,1 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+meta: "k"/0,0 -> txn={id=00000000 key="k" pri=0.00000000 epo=0 ts=12.000000000,1 min=0,0 seq=0} ts=12.000000000,1 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k"/12.000000000,1 -> /<empty>
 data: "k"/6.000000000,0 -> /BYTES/k6
 data: "k"/4.000000000,0 -> /<empty>
@@ -361,11 +371,11 @@ with t=G k=k
 >> del_range k=a end=z ambiguousReplay returnKeys t=G k=k
 stats: no change
 >> at end:
-txn: "G" meta={id=00000007 key="k" iso=Serializable pri=0.00000000 epo=0 ts=12.000000000,3 min=0,0 seq=0} lock=true stat=PENDING rts=12.000000000,1 wto=false gul=0,0
-meta: "a"/0,0 -> txn={id=00000007 key="k" iso=Serializable pri=0.00000000 epo=0 ts=12.000000000,1 min=0,0 seq=0} ts=12.000000000,1 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+txn: "G" meta={id=00000000 key="k" pri=0.00000000 epo=0 ts=12.000000000,3 min=0,0 seq=0} lock=true stat=PENDING rts=12.000000000,1 wto=false gul=0,0
+meta: "a"/0,0 -> txn={id=00000000 key="k" pri=0.00000000 epo=0 ts=12.000000000,1 min=0,0 seq=0} ts=12.000000000,1 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "a"/12.000000000,1 -> /<empty>
 data: "a"/12.000000000,0 -> {localTs=11.000000000,0}/BYTES/first
-meta: "k"/0,0 -> txn={id=00000007 key="k" iso=Serializable pri=0.00000000 epo=0 ts=12.000000000,1 min=0,0 seq=0} ts=12.000000000,1 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+meta: "k"/0,0 -> txn={id=00000000 key="k" pri=0.00000000 epo=0 ts=12.000000000,1 min=0,0 seq=0} ts=12.000000000,1 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k"/12.000000000,1 -> /<empty>
 data: "k"/6.000000000,0 -> /BYTES/k6
 data: "k"/4.000000000,0 -> /<empty>
@@ -373,7 +383,7 @@ data: "k"/3.000000000,0 -> /BYTES/k3
 data: "k"/0,2 -> /BYTES/k2
 data: "k"/0,1 -> /BYTES/k1
 stats: key_count=2 key_bytes=100 val_count=8 val_bytes=157 gc_bytes_age=23263 intent_count=2 intent_bytes=24 separated_intent_count=2 intent_age=176
-error: (*withstack.withStack:) transaction 00000007-0000-0000-0000-000000000000 with sequence 0 prevented from changing write timestamp from 12.000000000,1 to 12.000000000,3 due to ambiguous replay protection
+error: (*withstack.withStack:) transaction 00000000-0000-0000-0000-000000000007 with sequence 0 prevented from changing write timestamp from 12.000000000,1 to 12.000000000,3 due to ambiguous replay protection
 
 run ok
 with t=G


### PR DESCRIPTION
Backport:
  * 1/1 commits from #107680
  * 1/1 commits from #107323
  * 1/1 commits from #108154
  * 1/1 commits from #108001
  * 1 new commit: **kvcoord: fix ambiguous commit tests for 23.1 behavior**
  * 1/1 commits from #107658
  * 1 new commit: **kvcoord: modify ambiguous commit tests for WTO deferral on 23.1**

Please see individual PRs for details.

/cc @cockroachdb/release

---

Release justification: Backporting fix for outstanding bug described in #103817.
