### PR TITLE
changefeedccl: Fix potential shutdown NPE

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -543,6 +543,11 @@ func (ca *changeAggregator) close() {
 	if ca.Closed {
 		return
 	}
+	if ca.cancel == nil {
+		// consumer close may be called even before Start is called.
+		// If that's the case, cancel is not initialized.
+		return
+	}
 	ca.cancel()
 	// Wait for the poller to finish shutting down.
 	ca.waitForKVFeedDone()


### PR DESCRIPTION
A flow may be cancelled immediately after it's created, before it has `Start`ed.  If this happens, change aggregator may panic because certain state may not be initialized.

Fixes #110772

Release note: None