### PR TITLE
pgcryptocipherccl: convert invariant errors into assertions

### DIFF
--- a/pkg/ccl/pgcryptoccl/pgcryptocipherccl/cipher.go
+++ b/pkg/ccl/pgcryptoccl/pgcryptocipherccl/cipher.go
@@ -88,7 +88,7 @@ func newCipher(method cipherMethod, key []byte) (cipher.Block, error) {
 		}
 		return aes.NewCipher(key)
 	default:
-		return nil, errors.Newf("cannot create new cipher for unknown algorithm: %d", a)
+		return nil, errors.AssertionFailedf("cannot create new cipher for unknown algorithm: %d", a)
 	}
 }
 
@@ -99,7 +99,7 @@ func padData(method cipherMethod, data []byte, blockSize int) ([]byte, error) {
 	case noPadding:
 		return data, nil
 	default:
-		return nil, errors.Newf("cannot pad for unknown padding: %d", p)
+		return nil, errors.AssertionFailedf("cannot pad for unknown padding: %d", p)
 	}
 }
 
@@ -110,7 +110,7 @@ func unpadData(method cipherMethod, data []byte) ([]byte, error) {
 	case noPadding:
 		return data, nil
 	default:
-		return nil, errors.Newf("cannot unpad for unknown padding: %d", p)
+		return nil, errors.AssertionFailedf("cannot unpad for unknown padding: %d", p)
 	}
 }
 
@@ -138,7 +138,7 @@ func encrypt(method cipherMethod, block cipher.Block, iv []byte, data []byte) ([
 		mode.CryptBlocks(ret, data)
 		return ret, nil
 	default:
-		return nil, errors.Newf("cannot encrypt for unknown mode: %d", m)
+		return nil, errors.AssertionFailedf("cannot encrypt for unknown mode: %d", m)
 	}
 }
 
@@ -155,6 +155,6 @@ func decrypt(method cipherMethod, block cipher.Block, iv []byte, data []byte) ([
 		mode.CryptBlocks(ret, data)
 		return ret, nil
 	default:
-		return nil, errors.Newf("cannot encrypt for unknown mode: %d", m)
+		return nil, errors.AssertionFailedf("cannot decrypt for unknown mode: %d", m)
 	}
 }

--- a/pkg/ccl/pgcryptoccl/pgcryptocipherccl/padding.go
+++ b/pkg/ccl/pgcryptoccl/pgcryptocipherccl/padding.go
@@ -20,7 +20,7 @@ import (
 // https://datatracker.ietf.org/doc/html/rfc5652#section-6.3.
 func pkcsPad(data []byte, blockSize int) ([]byte, error) {
 	if blockSize <= 0 || blockSize > math.MaxUint8 {
-		return nil, errors.Newf("invalid block size for PKCS padding: %d", blockSize)
+		return nil, errors.AssertionFailedf("invalid block size for PKCS padding: %d", blockSize)
 	}
 
 	paddedData := make([]byte, len(data))

--- a/pkg/ccl/pgcryptoccl/pgcryptocipherccl/padding.go
+++ b/pkg/ccl/pgcryptoccl/pgcryptocipherccl/padding.go
@@ -12,6 +12,8 @@ import (
 	"bytes"
 	"math"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/errors"
 )
 
@@ -36,16 +38,18 @@ func pkcsPad(data []byte, blockSize int) ([]byte, error) {
 // pkcsUnpad removes the padding added by pkcsPad.
 func pkcsUnpad(data []byte) ([]byte, error) {
 	if len(data) == 0 {
-		return nil, errors.New("PKCS-padded data is empty")
+		return nil, pgerror.New(pgcode.InvalidParameterValue, "PKCS-padded data is empty")
 	}
 
 	paddingLen := data[len(data)-1]
 	if paddingLen == 0 || int(paddingLen) > len(data) {
-		return nil, errors.Newf("invalid final byte found in PKCS-padded data: %d", paddingLen)
+		return nil, pgerror.Newf(pgcode.InvalidParameterValue,
+			"invalid final byte found in PKCS-padded data: %d", paddingLen)
 	}
 	for i := 1; i < int(paddingLen); i++ {
 		if b := data[len(data)-i-1]; b != paddingLen {
-			return nil, errors.Newf("invalid byte found in PKCS-padded data: expected %d, but found %d", paddingLen, b)
+			return nil, pgerror.Newf(pgcode.InvalidParameterValue,
+				"invalid byte found in PKCS-padded data: expected %d, but found %d", paddingLen, b)
 		}
 	}
 


### PR DESCRIPTION
This patch changes the checks for programmer error in the `pgcryptocipherccl` package to use `errors.AssertionFailedf` so that they are surfaced with greater visibility.

Epic: None

Release note: None