### PR TITLE
sql: remove accidental copy of inFlightTraceCollector

### DIFF
--- a/pkg/sql/instrumentation.go
+++ b/pkg/sql/instrumentation.go
@@ -311,7 +311,7 @@ func pollInFlightTrace(
 	return trace, err
 }
 
-func (c inFlightTraceCollector) finish() {
+func (c *inFlightTraceCollector) finish() {
 	if c.cancel == nil {
 		// The in-flight trace collector goroutine wasn't started.
 		return


### PR DESCRIPTION
The `finish` method of `inFlightTraceCollector` had a value receiver. I think we meant for this to be a pointer receiver, so that we didn't operate on a copy of the trace collector.

Fixes: #110186

Release note: None