### PR TITLE
server: sync on SQL setting overrides in testserver tenant init

### DIFF
--- a/pkg/server/tenantsettingswatcher/watcher.go
+++ b/pkg/server/tenantsettingswatcher/watcher.go
@@ -60,6 +60,10 @@ type Watcher struct {
 	// startCh is closed once the rangefeed starts.
 	startCh  chan struct{}
 	startErr error
+
+	// rfc provides access to the underlying rangefeedcache.Watcher for
+	// testing.
+	rfc *rangefeedcache.Watcher
 }
 
 // New constructs a new Watcher.
@@ -182,6 +186,7 @@ func (w *Watcher) startRangeFeed(
 		onUpdate,
 		nil, /* knobs */
 	)
+	w.rfc = c
 
 	// Kick off the rangefeedcache which will retry until the stopper stops.
 	if err := rangefeedcache.Start(ctx, w.stopper, c, onError); err != nil {
@@ -212,6 +217,12 @@ func (w *Watcher) WaitForStart(ctx context.Context) error {
 		return w.startErr
 	case <-ctx.Done():
 		return ctx.Err()
+	}
+}
+
+func (w *Watcher) TestingRestart() {
+	if w.rfc != nil {
+		w.rfc.TestingRestart()
 	}
 }
 

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -1335,6 +1335,10 @@ func (ts *testServer) waitForTenantReadinessImpl(
 	// waiting out the closed timestamp interval required to see new updates.
 	ts.node.tenantInfoWatcher.TestingRestart()
 
+	// Ditto for cluster settings and setting overrides.
+	ts.sqlServer.settingsWatcher.TestingRestart()
+	ts.node.tenantSettingsWatcher.TestingRestart()
+
 	log.Infof(ctx, "waiting for rangefeed to catch up with record for tenant %v", tenantID)
 
 	// Wait for the watcher to handle the complete update from the initial scan


### PR DESCRIPTION
Prerequisite for tests in #110758.
Fixes #110560.
Epic: CRDB-6671

Prior to this patch, if a test was running SET CLUSTER SETTING or ALTER VIRTUAL CLUSTER SET CLUSTER SETTING prior to starting the service for a virtual cluster, it wasn't guaranteed that the setting update had propagated (because it propagates via a rangefeed).

This commit fixes that.

Release note: None