### PR TITLE
changefeedccl: short-circuit close if Start was never called

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -542,7 +542,8 @@ func (ca *changeAggregator) setupSpansAndFrontier() (spans []roachpb.Span, err e
 // (*changeAggregator) Start() may encounter an error and move the processor to
 // draining before one of the fields below (ex. ca.drainDone) is set.
 func (ca *changeAggregator) close() {
-	if ca.Closed {
+	if ca.Closed || ca.cancel == nil {
+		// cancel is nil if Start() was never called.
 		return
 	}
 	ca.cancel()


### PR DESCRIPTION
In 7ea6764d1ed1325b792e55b6ee4007b71c3c8538 we made it more likely that `ConsumerClosed` is called on any processor even if `Start` was never called, and that exposed a minor bug in `close` method of the change aggregator. That method should be safe to be executed if `Start` was never called, but we forgot to check non-nillity of the cancel func, which this commit adds.

Epic: None

Release note: None