### PR TITLE
rangefeed: remove race between creation and shutdown

### DIFF
--- a/pkg/kv/kvserver/rangefeed/scheduled_processor.go
+++ b/pkg/kv/kvserver/rangefeed/scheduled_processor.go
@@ -69,7 +69,7 @@ func NewScheduledProcessor(cfg Config) *ScheduledProcessor {
 	cfg.AmbientContext.AddLogTag("rangefeed", nil)
 	p := &ScheduledProcessor{
 		Config:     cfg,
-		scheduler:  NewClientScheduler(cfg.Scheduler),
+		scheduler:  cfg.Scheduler.NewClientScheduler(),
 		reg:        makeRegistry(cfg.Metrics),
 		rts:        makeResolvedTimestamp(),
 		processCtx: cfg.AmbientContext.AnnotateCtx(context.Background()),


### PR DESCRIPTION
Previously there was a data race between creation of rangefeed processor and server shutdown. In that case rangefeed scheduler could call stop concurrently with register while scheduler id is being populated. This commit makes id allocation to happen before processor is created to avoid the race.

Epic: none

Release note: None

Fixes #110766