### PR TITLE
kvserver: fix Replica.tenantLimiter race

### DIFF
--- a/pkg/kv/kvserver/replica_rate_limit.go
+++ b/pkg/kv/kvserver/replica_rate_limit.go
@@ -16,6 +16,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/multitenant/tenantcostmodel"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/quotapool"
+	"github.com/cockroachdb/errors"
 )
 
 // maybeRateLimitBatch may block the batch waiting to be rate-limited. Note that
@@ -29,8 +31,23 @@ func (r *Replica) maybeRateLimitBatch(ctx context.Context, ba *kvpb.BatchRequest
 	if !ok || tenantID == roachpb.SystemTenantID {
 		return nil
 	}
+
 	// writeMultiplier isn't needed here since it's only used to calculate RUs.
-	return r.tenantLimiter.Wait(ctx, tenantcostmodel.MakeRequestInfo(ba, 1, 1))
+	err := r.tenantLimiter.Wait(ctx, tenantcostmodel.MakeRequestInfo(ba, 1, 1))
+
+	// For performance reasons, we do not hold any Replica's mutexes while waiting
+	// on the tenantLimiter, and so we are racing with the Replica lifecycle. The
+	// Replica can be destroyed and release the limiter before or during the Wait
+	// call. In this case Wait returns an ErrClosed error. Instead of ErrClosed,
+	// return the destruction status error which upper layers recognize.
+	if err != nil && errors.HasType(err, (*quotapool.ErrClosed)(nil)) {
+		if _, err := r.IsDestroyed(); err != nil {
+			return err
+		}
+		return errors.AssertionFailedf("replica not marked as destroyed but limiter is closed: %v", r)
+	}
+
+	return err
 }
 
 // recordImpactOnRateLimiter is used to record a read against the tenant rate

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -49,8 +49,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/rditer"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/spanset"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/stateloader"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/tenantrate"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/txnwait"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/uncertainty"
+	"github.com/cockroachdb/cockroach/pkg/multitenant/tenantcapabilities/tenantcapabilitiesauthorizer"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -59,6 +61,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb"
+	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -13918,6 +13921,92 @@ func TestStoreTenantMetricsAndRateLimiterRefcount(t *testing.T) {
 		}()
 		tc.store.tenantRateLimiters.Release(tenLimiter)
 	}()
+}
+
+// TestReplicaRateLimit verifies the behaviour of Replica.maybeRateLimitBatch
+// method which Replica.Send uses for rate limiting the incoming batch requests.
+//
+// In particular, it verifies that rate limiting blocks the flow when the limit
+// is reached, and unblocks it with time passage. It also verifies that the
+// method returns a correct error when it races with the Replica destruction,
+// which causes upper layers to retry the request.
+func TestReplicaRateLimit(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	stopper := stop.NewStopper()
+	defer stopper.Stop(ctx)
+
+	tc := testContext{manualClock: timeutil.NewManualTime(timeutil.Unix(0, 123))}
+	cfg := TestStoreConfig(hlc.NewClockForTesting(tc.manualClock))
+	// Set a low rate limit so that we saturate it quickly below.
+	tenantrate.KVCURateLimit.Override(ctx, &cfg.Settings.SV, 1)
+	cfg.TestingKnobs.DisableMergeWaitForReplicasInit = true
+	// Use time travel to control the rate limiter in this test. Set authorizer to
+	// engage the rate limiter, overriding the default allow-all policy in tests.
+	cfg.TestingKnobs.TenantRateKnobs.TimeSource = tc.manualClock
+	cfg.TestingKnobs.TenantRateKnobs.Authorizer = tenantcapabilitiesauthorizer.New(cfg.Settings, nil)
+	tc.StartWithStoreConfig(ctx, t, stopper, cfg)
+
+	// A range for tenant 123 appears via a split.
+	ten123 := roachpb.MustMakeTenantID(123)
+	splitKey := keys.MustAddr(keys.MakeSQLCodec(ten123).TenantPrefix())
+	leftRepl := tc.store.LookupReplica(splitKey)
+	require.NotNil(t, leftRepl)
+	splitTestRange(tc.store, splitKey, t)
+	tenRepl := tc.store.LookupReplica(splitKey)
+	require.NotNil(t, tenRepl)
+	require.NotNil(t, tenRepl.tenantMetricsRef)
+	require.NotNil(t, tenRepl.tenantLimiter)
+
+	tenCtx := roachpb.ContextWithClientTenant(ctx, ten123)
+	put := func(timeout time.Duration) error {
+		ba := &kvpb.BatchRequest{}
+		req := putArgs(splitKey.AsRawKey(), []byte{1, 2, 7})
+		ba.Add(&req)
+		ctx, cancel := context.WithTimeout(tenCtx, timeout)
+		defer cancel()
+		return tenRepl.maybeRateLimitBatch(ctx, ba)
+	}
+
+	// Verify that first few writes succeed fast, but eventually requests start
+	// timing out because of the rate limiter.
+	const timeout = 10 * time.Millisecond
+	require.NoError(t, put(timeout))
+	require.NoError(t, put(timeout))
+	block := func() bool {
+		for i := 0; i < 1000; i++ {
+			if err := put(timeout); errors.Is(err, context.DeadlineExceeded) {
+				return true
+			}
+		}
+		return false
+	}
+	require.True(t, block())
+
+	// Verify that the rate limiter eventually starts allowing requests again.
+	tc.manualClock.Advance(100 * time.Second)
+	require.NoError(t, put(timeout))
+	// But will block them again if there are too many.
+	require.True(t, block())
+
+	// Now the rate limiter is saturated. If we try to write a request to the
+	// replica now, the rate limiter will block it. If this races with a range
+	// destruction (for example, due to a merge like below), maybeRateLimitBatch()
+	// returns a quota pool closed error.
+	g := ctxgroup.WithContext(ctx)
+	g.Go(func() error {
+		_, pErr := leftRepl.AdminMerge(ctx, kvpb.AdminMergeRequest{
+			RequestHeader: kvpb.RequestHeader{
+				Key: leftRepl.Desc().StartKey.AsRawKey(),
+			},
+		}, "testing")
+		return pErr.GoError()
+	})
+	err := put(5 * time.Second)
+	require.True(t, testutils.IsError(err, "123 pool closed: released"), err)
+
+	require.NoError(t, g.Wait())
 }
 
 // TestRangeSplitRacesWithRead performs a range split and repeatedly reads a

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -14004,7 +14004,7 @@ func TestReplicaRateLimit(t *testing.T) {
 		return pErr.GoError()
 	})
 	err := put(5 * time.Second)
-	require.True(t, testutils.IsError(err, "123 pool closed: released"), err)
+	require.True(t, errors.Is(err, &kvpb.RangeNotFoundError{RangeID: 2, StoreID: 1}), err)
 
 	require.NoError(t, g.Wait())
 }

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -185,7 +185,10 @@ func createTestStoreWithoutStart(
 	rpcOpts.ToleratedOffset = cfg.Clock.ToleratedOffset()
 	rpcOpts.Stopper = stopper
 	rpcOpts.Settings = cfg.Settings
-	rpcOpts.TenantRPCAuthorizer = tenantcapabilitiesauthorizer.NewAllowEverythingAuthorizer()
+	rpcOpts.TenantRPCAuthorizer = cfg.TestingKnobs.TenantRateKnobs.Authorizer
+	if rpcOpts.TenantRPCAuthorizer == nil {
+		rpcOpts.TenantRPCAuthorizer = tenantcapabilitiesauthorizer.NewAllowEverythingAuthorizer()
+	}
 	rpcContext := rpc.NewContext(ctx, rpcOpts)
 	stopper.SetTracer(cfg.AmbientCtx.Tracer)
 	server, err := rpc.NewServer(ctx, rpcContext) // never started

--- a/pkg/kv/kvserver/tenantrate/settings.go
+++ b/pkg/kv/kvserver/tenantrate/settings.go
@@ -63,7 +63,7 @@ type Config struct {
 // whereas the tenant cost model is about pricing and takes into consideration
 // more costs (like network transfers, IOs).
 var (
-	// kvcuRateLimit specifies the limit of KV Compute Units / second that a
+	// KVCURateLimit specifies the limit of KV Compute Units / second that a
 	// single tenant is allowed to use on an individual KV node. This is
 	// intended to prevent a single tenant from harnessing a large fraction of a
 	// KV node, in order to avoid very significant fluctuations in performance
@@ -77,7 +77,7 @@ var (
 	// If the value is negative, then this setting is interpreted as a relative
 	// percentage of total CPU available. For example -200 means that we allow
 	// 200 KV Compute Units / second per vCPU, or roughly 20% of the machine.
-	kvcuRateLimit = settings.RegisterFloatSetting(
+	KVCURateLimit = settings.RegisterFloatSetting(
 		settings.SystemOnly,
 		"kv.tenant_rate_limiter.rate_limit",
 		"per-tenant rate limit in KV Compute Units per second if positive, "+
@@ -144,7 +144,7 @@ var (
 
 	// List of config settings, used to set up "on change" notifiers.
 	configSettings = [...]settings.NonMaskedSetting{
-		kvcuRateLimit,
+		KVCURateLimit,
 		kvcuBurstLimitSeconds,
 		readBatchCost,
 		readRequestCost,
@@ -168,7 +168,7 @@ func absoluteRateFromConfigValue(value float64) float64 {
 
 // ConfigFromSettings constructs a Config using the cluster setting values.
 func ConfigFromSettings(sv *settings.Values) Config {
-	rate := absoluteRateFromConfigValue(kvcuRateLimit.Get(sv))
+	rate := absoluteRateFromConfigValue(KVCURateLimit.Get(sv))
 	return Config{
 		Rate:              rate,
 		Burst:             rate * kvcuBurstLimitSeconds.Get(sv),
@@ -184,7 +184,7 @@ func ConfigFromSettings(sv *settings.Values) Config {
 // DefaultConfig returns the configuration that corresponds to the default
 // setting values.
 func DefaultConfig() Config {
-	rate := absoluteRateFromConfigValue(kvcuRateLimit.Default())
+	rate := absoluteRateFromConfigValue(KVCURateLimit.Default())
 	return Config{
 		Rate:              rate,
 		Burst:             rate * kvcuBurstLimitSeconds.Default(),


### PR DESCRIPTION
If a `Replica` is destroyed while or shortly before `Send` waits for the tenant rate limiter, the rate limiter returns a `quotapool.ErrClosed` which propagates all the way up to the SQL client. This commit fixes `maybeRateLimitBatch` to return the `Replica` destruction status error instead, so that the `Send` stack retries the request.

Release note (bug fix): fixed a race condition in `Replica` lifecycle which could result in a failed SQL request in cases where it could be successfully retried.

Fixes #109729
Epic: none