### PR TITLE
hlc: use struct comparison for Timestamp.IsEmpty

### DIFF
--- a/pkg/util/hlc/timestamp.go
+++ b/pkg/util/hlc/timestamp.go
@@ -202,7 +202,7 @@ func (t Timestamp) AsOfSystemTime() string {
 // IsEmpty returns true if t is an empty Timestamp.
 // gcassert:inline
 func (t Timestamp) IsEmpty() bool {
-	return t.WallTime == 0 && t.Logical == 0 && !t.Synthetic
+	return t == Timestamp{}
 }
 
 // IsSet returns true if t is not an empty Timestamp.


### PR DESCRIPTION
Use a struct comparison in Timestamp.IsEmpty. The IsEmpty implementation was modified to perform a field-by-field comparison in #88911 due to a regression in Go 1.19. The regression was fixed in Go 1.20.

```
goos: linux
goarch: amd64
cpu: Intel(R) Xeon(R) CPU @ 2.30GHz
                             │ old-hlc.txt  │             new-hlc.txt             │
                             │    sec/op    │    sec/op     vs base               │
TimestampIsEmpty/empty-24      0.9341n ± 0%   0.9350n ± 0%       ~ (p=0.197 n=10)
TimestampIsEmpty/walltime-24    1.370n ± 2%    1.367n ± 1%       ~ (p=0.617 n=10)
TimestampIsEmpty/all-24         1.362n ± 1%    1.374n ± 2%       ~ (p=0.092 n=10)
geomean                         1.203n         1.206n       +0.24%

goos: linux
goarch: amd64
cpu: Intel(R) Xeon(R) CPU @ 2.30GHz
                                               │   old.txt   │              new.txt               │
                                               │   sec/op    │   sec/op     vs base               │
EncodeMVCCKey/key=short/ts=empty-24              17.59n ± 0%   17.59n ± 0%       ~ (p=0.908 n=10)
EncodeMVCCKey/key=short/ts=walltime-24           19.93n ± 0%   19.90n ± 0%  -0.10% (p=0.043 n=10)
EncodeMVCCKey/key=short/ts=walltime+logical-24   20.89n ± 0%   20.91n ± 0%       ~ (p=1.000 n=10)
EncodeMVCCKey/key=long/ts=empty-24               68.58n ± 0%   68.44n ± 0%  -0.20% (p=0.037 n=10)
EncodeMVCCKey/key=long/ts=walltime-24            70.99n ± 1%   70.11n ± 0%  -1.24% (p=0.005 n=10)
EncodeMVCCKey/key=long/ts=walltime+logical-24    70.40n ± 0%   70.49n ± 0%  +0.14% (p=0.019 n=10)
EncodeMVCCKey/key=empty/ts=empty-24              17.23n ± 0%   17.24n ± 0%       ~ (p=0.290 n=10)
EncodeMVCCKey/key=empty/ts=walltime-24           19.53n ± 0%   19.54n ± 0%       ~ (p=0.362 n=10)
EncodeMVCCKey/key=empty/ts=walltime+logical-24   20.60n ± 0%   20.61n ± 0%       ~ (p=0.116 n=10)
geomean                                          29.59n        29.55n       -0.13%
```

Epic: None
Informs #89199.
Release note: None