### PR TITLE
storage: deflake TestMVCCIterateTimeBound

### DIFF
--- a/pkg/storage/bench_test.go
+++ b/pkg/storage/bench_test.go
@@ -720,7 +720,7 @@ func loadTestData(dir string, numKeys, numBatches, batchTimeSpan, valueBytes int
 			batch = eng.NewBatch()
 			minWallTime = sstTimestamps[i/batchSize]
 		}
-		timestamp := hlc.Timestamp{WallTime: minWallTime + rand.Int63n(int64(batchTimeSpan))}
+		timestamp := hlc.Timestamp{WallTime: minWallTime + rng.Int63n(int64(batchTimeSpan))}
 		value := roachpb.MakeValueFromBytes(randutil.RandBytes(rng, valueBytes))
 		value.InitChecksum(key)
 		if err := MVCCPut(ctx, batch, key, timestamp, value, MVCCWriteOptions{}); err != nil {

--- a/pkg/storage/mvcc_incremental_iterator_test.go
+++ b/pkg/storage/mvcc_incremental_iterator_test.go
@@ -1463,6 +1463,10 @@ func TestMVCCIterateTimeBound(t *testing.T) {
 	}
 	defer eng.Close()
 
+	// TODO(jackson): This test is tightly coupled with the prng seed constant
+	// in loadTestData. Some of the assertions below assume there exist keys
+	// within narrow bounds (eg, [19,20)). This is the case today for the
+	// current prng seed, but it's a bit too brittle.
 	for _, testCase := range []struct {
 		start hlc.Timestamp
 		end   hlc.Timestamp


### PR DESCRIPTION
The test TestMVCCIterateTimeBound generates a random data set from a fixed seed, and then asserts that a time-bound iterator and a non-time-bound iterator see the same keys within a few fixed bounds. This test would sometimes fail, finding no keys within the time bounds, even on the iterator that does not use time-bound iteration. This was because the dataset was unintentionally nondeterministic due to generating timestamps using outside randomness.  The outside randomness could result in no KVs within the provided time range.

Epic: none
Fixes: #110770.
Release note: none