### PR TITLE
server: create cluster setting for persisted insights

### DIFF
--- a/pkg/server/cluster_settings.go
+++ b/pkg/server/cluster_settings.go
@@ -42,3 +42,11 @@ var StatsActivityUIEnabled = settings.RegisterBoolSetting(
 	"sql.stats.activity.ui.enabled",
 	"enable the combined statistics endpoint to get data from the system activity tables",
 	true)
+
+// PersistedInsightsUIEnabled controls if the insights endpoint uses
+// the persisted statement_execution_insights and transaction_execution_insights tables.
+var PersistedInsightsUIEnabled = settings.RegisterBoolSetting(
+	settings.TenantWritable,
+	"sql.stats.persisted_insights.ui.enabled",
+	"enable the insights endpoint to get data from the persisted insights tables",
+	false)


### PR DESCRIPTION
A new table for persisted Insights will be created, and the endpoints to retrive Insights information will be able to use it. This commit creates a cluster settings that can be used to disabled its usage, in case there is a problem with its content.

Fixes #110813

Release note: None