### PR TITLE
release-23.1: storageparam: do not allow subqueries in storage param clause

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -3276,3 +3276,13 @@ set sql_safe_updates=false
 
 statement error pgcode 42P10 column "n" is referenced by.*
 alter table t_drop_cascade_with_key drop column n cascade;
+
+subtest end
+
+# Regression test for https://github.com/cockroachdb/cockroach/issues/110629.
+# Subqueries are not allowed in storage parameters.
+statement ok
+CREATE TABLE t_110629 (a INT PRIMARY KEY);
+
+statement error subqueries are not allowed in table storage parameters
+ALTER TABLE t SET ( 'string' = EXISTS ( TABLE error ) );

--- a/pkg/sql/storageparam/storage_param.go
+++ b/pkg/sql/storageparam/storage_param.go
@@ -65,6 +65,11 @@ func Set(
 		// Cast these as strings.
 		expr := paramparse.UnresolvedNameToStrVal(sp.Value)
 
+		// Storage params handle their own scalar arguments, with no help from the
+		// optimizer. As such, they cannot contain subqueries.
+		defer semaCtx.Properties.Restore(semaCtx.Properties)
+		semaCtx.Properties.Require("table storage parameters", tree.RejectSubqueries)
+
 		// Convert the expressions to a datum.
 		typedExpr, err := tree.TypeCheck(ctx, expr, semaCtx, types.Any)
 		if err != nil {


### PR DESCRIPTION
Backport 1/1 commits from #110664.

/cc @cockroachdb/release

fixes https://github.com/cockroachdb/cockroach/issues/110795

---

This would previously cause an internal error. Now it displays a feature not supported error.

Release justification: bug fix
fixes https://github.com/cockroachdb/cockroach/issues/110629
Release note: None
