### PR TITLE
testutils: Use correct context in ExpectErrWithTimeout

### DIFF
--- a/pkg/testutils/sqlutils/sql_runner.go
+++ b/pkg/testutils/sqlutils/sql_runner.go
@@ -216,7 +216,7 @@ func (sr *SQLRunner) ExpectErrWithTimeout(
 		d = testutils.DefaultSucceedsSoonDuration
 	}
 	_ = timeutil.RunWithTimeout(context.Background(), "expect-err", d, func(ctx context.Context) error {
-		_, err := sr.DB.ExecContext(context.Background(), query, args...)
+		_, err := sr.DB.ExecContext(ctx, query, args...)
 		if !testutils.IsError(err, errRE) {
 			return errors.Newf("expected error '%s', got: %s", errRE, pgerror.FullError(err))
 		}


### PR DESCRIPTION
Use correct context in ExpectErrWithTimeout.

Epic: None
Release note: None