### PR TITLE
acceptance: skip TestDockerCLI/test_demo_multitenant.tcl

### DIFF
--- a/pkg/acceptance/generated_cli_test.go
+++ b/pkg/acceptance/generated_cli_test.go
@@ -137,13 +137,6 @@ func TestDockerCLI_test_demo_memory_warning(t *testing.T) {
 	runTestDockerCLI(t, "test_demo_memory_warning", "../cli/interactive_tests/test_demo_memory_warning.tcl")
 }
 
-func TestDockerCLI_test_demo_multitenant(t *testing.T) {
-	s := log.Scope(t)
-	defer s.Close(t)
-
-	runTestDockerCLI(t, "test_demo_multitenant", "../cli/interactive_tests/test_demo_multitenant.tcl")
-}
-
 func TestDockerCLI_test_demo_networking(t *testing.T) {
 	s := log.Scope(t)
 	defer s.Close(t)

--- a/pkg/cli/interactive_tests/test_demo_multitenant.tcl.disabled
+++ b/pkg/cli/interactive_tests/test_demo_multitenant.tcl.disabled
@@ -2,7 +2,7 @@
 
 # This test is skipped -- its filename lets it hide from the selector in
 # TestDockerCLI. Unskip it by renaming after fixing
-# https://github.com/cockroachdb/cockroach/issues/96239.
+# https://github.com/cockroachdb/cockroach/issues/110748.
 
 source [file join [file dirname $argv0] common.tcl]
 


### PR DESCRIPTION
Epic: none
Informs #110748.
Release note: none.