### PR TITLE
kvserver: unskip TestMergeQueueWithSlowNonVoterSnaps

### DIFF
--- a/pkg/kv/kvserver/client_merge_test.go
+++ b/pkg/kv/kvserver/client_merge_test.go
@@ -4792,7 +4792,6 @@ func TestMergeQueueSeesNonVoters(t *testing.T) {
 func TestMergeQueueWithSlowNonVoterSnaps(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	skip.WithIssue(t, 85372)
 
 	skip.UnderShort(t, "this test sleeps for a few seconds")
 


### PR DESCRIPTION
The issue causing TestMergeQueueWithSlowNonVoterSnaps to flake was fixed in #106793.

Part of: #85372
Release note: None