### PR TITLE
storage: use correct strength for {Get,Scan,ReverseScan} for SKIP LOCKED 

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_get.go
+++ b/pkg/kv/kvserver/batcheval/cmd_get.go
@@ -38,6 +38,7 @@ func Get(
 		SkipLocked:            h.WaitPolicy == lock.WaitPolicy_SkipLocked,
 		Txn:                   h.Txn,
 		FailOnMoreRecent:      args.KeyLockingStrength != lock.None,
+		Strength:              args.KeyLockingStrength,
 		ScanStats:             cArgs.ScanStats,
 		Uncertainty:           cArgs.Uncertainty,
 		MemoryAccount:         cArgs.EvalCtx.GetResponseMemoryAccount(),

--- a/pkg/kv/kvserver/batcheval/cmd_reverse_scan.go
+++ b/pkg/kv/kvserver/batcheval/cmd_reverse_scan.go
@@ -51,6 +51,7 @@ func ReverseScan(
 		AllowEmpty:            h.AllowEmpty,
 		WholeRowsOfSize:       h.WholeRowsOfSize,
 		FailOnMoreRecent:      args.KeyLockingStrength != lock.None,
+		Strength:              args.KeyLockingStrength,
 		Reverse:               true,
 		MemoryAccount:         cArgs.EvalCtx.GetResponseMemoryAccount(),
 		LockTable:             cArgs.Concurrency,

--- a/pkg/kv/kvserver/batcheval/cmd_scan.go
+++ b/pkg/kv/kvserver/batcheval/cmd_scan.go
@@ -51,6 +51,7 @@ func Scan(
 		AllowEmpty:            h.AllowEmpty,
 		WholeRowsOfSize:       h.WholeRowsOfSize,
 		FailOnMoreRecent:      args.KeyLockingStrength != lock.None,
+		Strength:              args.KeyLockingStrength,
 		Reverse:               false,
 		MemoryAccount:         cArgs.EvalCtx.GetResponseMemoryAccount(),
 		LockTable:             cArgs.Concurrency,

--- a/pkg/kv/kvserver/concurrency/concurrency_manager_test.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager_test.go
@@ -416,7 +416,9 @@ func TestConcurrencyManagerBasic(t *testing.T) {
 				}
 				var str lock.Strength
 				if d.HasArg("str") {
-					str = concurrency.ScanLockStrength(t, d)
+					var strS string
+					d.ScanArgs(t, "str", &strS)
+					str = concurrency.GetStrength(t, d, strS)
 				} else {
 					// If no lock strength is provided in the test, infer it from the
 					// durability.

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/shared_locks_wait_policy_skip_locked
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/shared_locks_wait_policy_skip_locked
@@ -1,0 +1,159 @@
+new-txn name=txn1 ts=10,1 epoch=0
+----
+
+new-txn name=txn2 ts=11,1 epoch=0
+----
+
+new-txn name=txn3 ts=12,1 epoch=0
+----
+
+new-txn name=txn4 ts=13,1 epoch=0
+----
+
+# ------------------------------------------------------------------------------
+# Prep: Txn 1 acquires shared locks at key k1 and key k2
+#       Txn 2 acquires shared locks at key k2
+#       Txn 3 acquires exclusive locks at key k3
+# ------------------------------------------------------------------------------
+
+new-request name=req1 txn=txn1 ts=10,0
+  get key=k1 str=shared
+  get key=k2 str=shared
+----
+
+sequence req=req1
+----
+[1] sequence req1: sequencing request
+[1] sequence req1: acquiring latches
+[1] sequence req1: scanning lock table for conflicting locks
+[1] sequence req1: sequencing complete, returned guard
+
+on-lock-acquired req=req1 key=k1 str=shared
+----
+[-] acquire lock: txn 00000001 @ ‹k1›
+
+on-lock-acquired req=req1 key=k2 str=shared
+----
+[-] acquire lock: txn 00000001 @ ‹k2›
+
+finish req=req1
+----
+[-] finish req1: finishing request
+
+new-request name=req2 txn=txn2 ts=11,1
+  get key=k2 str=shared
+----
+
+sequence req=req2
+----
+[2] sequence req2: sequencing request
+[2] sequence req2: acquiring latches
+[2] sequence req2: scanning lock table for conflicting locks
+[2] sequence req2: sequencing complete, returned guard
+
+on-lock-acquired req=req2 key=k2 str=shared
+----
+[-] acquire lock: txn 00000002 @ ‹k2›
+
+new-request name=req3 txn=txn3 ts=12,1
+  get key=k3 str=exclusive
+----
+
+finish req=req2
+----
+[-] finish req2: finishing request
+
+sequence req=req3
+----
+[3] sequence req3: sequencing request
+[3] sequence req3: acquiring latches
+[3] sequence req3: scanning lock table for conflicting locks
+[3] sequence req3: sequencing complete, returned guard
+
+on-lock-acquired req=req3 key=k3 str=exclusive
+----
+[-] acquire lock: txn 00000003 @ ‹k3›
+
+finish req=req3
+----
+[-] finish req3: finishing request
+
+debug-lock-table
+----
+num=3
+ lock: "k1"
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
+ lock: "k2"
+  holders: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
+           txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
+ lock: "k3"
+  holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 12.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
+
+
+# ------------------------------------------------------------------------------
+# Prep: Test skip locked requests with locking strength None, Shared, and
+# Exclusive.
+# ------------------------------------------------------------------------------
+
+new-request name=reqSkipLocked txn=txn4 ts=13,0 wait-policy=skip-locked str=shared
+  scan key=k endkey=k5
+----
+
+sequence req=reqSkipLocked
+----
+[4] sequence reqSkipLocked: sequencing request
+[4] sequence reqSkipLocked: acquiring latches
+[4] sequence reqSkipLocked: scanning lock table for conflicting locks
+[4] sequence reqSkipLocked: sequencing complete, returned guard
+
+is-key-locked-by-conflicting-txn req=reqSkipLocked key=k1 strength=none
+----
+locked: false
+
+is-key-locked-by-conflicting-txn req=reqSkipLocked key=k2 strength=none
+----
+locked: false
+
+is-key-locked-by-conflicting-txn req=reqSkipLocked key=k3 strength=none
+----
+locked: true, holder: 00000003-0000-0000-0000-000000000000
+
+is-key-locked-by-conflicting-txn req=reqSkipLocked key=k4 strength=none
+----
+locked: false
+
+is-key-locked-by-conflicting-txn req=reqSkipLocked key=k1 strength=shared
+----
+locked: false
+
+is-key-locked-by-conflicting-txn req=reqSkipLocked key=k2 strength=shared
+----
+locked: false
+
+is-key-locked-by-conflicting-txn req=reqSkipLocked key=k3 strength=shared
+----
+locked: true, holder: 00000003-0000-0000-0000-000000000000
+
+is-key-locked-by-conflicting-txn req=reqSkipLocked key=k4 strength=shared
+----
+locked: false
+
+is-key-locked-by-conflicting-txn req=reqSkipLocked key=k1 strength=exclusive
+----
+locked: true, holder: 00000001-0000-0000-0000-000000000000
+
+is-key-locked-by-conflicting-txn req=reqSkipLocked key=k2 strength=exclusive
+----
+locked: true, holder: 00000001-0000-0000-0000-000000000000
+
+is-key-locked-by-conflicting-txn req=reqSkipLocked key=k3 strength=exclusive
+----
+locked: true, holder: 00000003-0000-0000-0000-000000000000
+
+is-key-locked-by-conflicting-txn req=reqSkipLocked key=k4 strength=exclusive
+----
+locked: false
+
+finish req=reqSkipLocked
+----
+[-] finish reqSkipLocked: finishing request

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -960,6 +960,7 @@ type MVCCGetOptions struct {
 	SkipLocked       bool
 	Tombstones       bool
 	FailOnMoreRecent bool
+	Strength         lock.Strength
 	Txn              *roachpb.Transaction
 	ScanStats        *kvpb.ScanStats
 	Uncertainty      uncertainty.Interval
@@ -1222,6 +1223,7 @@ func mvccGetWithValueHeader(
 		skipLocked:       opts.SkipLocked,
 		tombstones:       opts.Tombstones,
 		failOnMoreRecent: opts.FailOnMoreRecent,
+		strength:         opts.Strength,
 		keyBuf:           mvccScanner.keyBuf,
 	}
 
@@ -3863,6 +3865,7 @@ func mvccScanInit(
 		skipLocked:       opts.SkipLocked,
 		tombstones:       opts.Tombstones,
 		failOnMoreRecent: opts.FailOnMoreRecent,
+		strength:         opts.Strength,
 		keyBuf:           mvccScanner.keyBuf,
 		// NB: If the `results` argument passed to this function is a pointer to
 		// mvccScanner.alloc.pebbleResults, we don't want to overwrite any
@@ -4026,6 +4029,7 @@ type MVCCScanOptions struct {
 	Tombstones       bool
 	Reverse          bool
 	FailOnMoreRecent bool
+	Strength         lock.Strength
 	Txn              *roachpb.Transaction
 	ScanStats        *kvpb.ScanStats
 	Uncertainty      uncertainty.Interval

--- a/pkg/storage/mvcc_history_test.go
+++ b/pkg/storage/mvcc_history_test.go
@@ -1377,9 +1377,18 @@ func cmdGet(e *evalCtx) error {
 	if e.hasArg("failOnMoreRecent") {
 		opts.FailOnMoreRecent = true
 	}
-	str := lock.None
+	// If no str argument is provided, infer it from the failOnMoreRecent option
+	// to be lock.Exclusive. This is how things behaved prior to the introduction
+	// of Shared locks.
+	var str lock.Strength
 	if e.hasArg("str") {
 		str = e.getStrength()
+	} else {
+		if opts.FailOnMoreRecent {
+			str = lock.Exclusive
+		} else {
+			str = lock.None
+		}
 	}
 	opts.Strength = str
 	opts.Uncertainty = uncertainty.Interval{
@@ -1682,9 +1691,18 @@ func cmdScan(e *evalCtx) error {
 	if e.hasArg("failOnMoreRecent") {
 		opts.FailOnMoreRecent = true
 	}
-	str := lock.None
+	// If no str argument is provided, infer it from the failOnMoreRecent option
+	// to be lock.Exclusive. This is how things behaved prior to the introduction
+	// of Shared locks.
+	var str lock.Strength
 	if e.hasArg("str") {
 		str = e.getStrength()
+	} else {
+		if opts.FailOnMoreRecent {
+			str = lock.Exclusive
+		} else {
+			str = lock.None
+		}
 	}
 	opts.Strength = str
 	opts.Uncertainty = uncertainty.Interval{

--- a/pkg/storage/pebble_mvcc_scanner.go
+++ b/pkg/storage/pebble_mvcc_scanner.go
@@ -435,6 +435,7 @@ type pebbleMVCCScanner struct {
 	skipLocked       bool
 	tombstones       bool
 	failOnMoreRecent bool
+	strength         lock.Strength
 	keyBuf           []byte
 	savedBuf         []byte
 	lazyFetcherBuf   pebble.LazyFetcher
@@ -1805,11 +1806,7 @@ func (p *pebbleMVCCScanner) isKeyLockedByConflictingTxn(
 		p.err = err
 		return false, false
 	}
-	strength := lock.None
-	if p.failOnMoreRecent {
-		strength = lock.Exclusive
-	}
-	ok, txn, err := p.lockTable.IsKeyLockedByConflictingTxn(key, strength)
+	ok, txn, err := p.lockTable.IsKeyLockedByConflictingTxn(key, p.strength)
 	if err != nil {
 		p.err = err
 		return false, false

--- a/pkg/storage/testdata/mvcc_histories/skip_locked
+++ b/pkg/storage/testdata/mvcc_histories/skip_locked
@@ -2,14 +2,19 @@
 
 # Setup:
 #
-# k1: value   @ ts 11
-# k2: value   @ ts 12
-# k2: intent  @ ts 13
-# k3: intent  @ ts 14
-# k4: value   @ ts 15
-# k4: lock    @ ts 16
-# k5: value   @ ts 17
-#
+# k1: value                 @ ts 11
+# k2: value                 @ ts 12
+# k2: intent                @ ts 13
+# k3: intent                @ ts 14
+# k4: value                 @ ts 15
+# k4: [u] exclusive lock    @ ts 16
+# k5: value                 @ ts 17
+# k6: value                 @ ts 13
+# k6: [u] shared lock       @ ts 15
+# TODO(arul,nvanbenschoten): In the future, we should extend the test to
+# include:
+# k7: [r] exclusive lock    @ ts15
+# k8: [r] shared lock
 
 run ok
 txn_begin t=A ts=12,0
@@ -28,7 +33,9 @@ put k=k2 v=v3 ts=13,0 t=B
 put k=k3 v=v4 ts=14,0 t=C
 put k=k4 v=v5 ts=15,0
 put k=k5 v=v6 ts=17,0
-add_unreplicated_lock k=k4 t=E
+put k=k6 v=v7 ts=13,0
+add_unreplicated_lock k=k4 t=E str=exclusive
+add_unreplicated_lock k=k6 t=D str=shared
 ----
 >> at end:
 data: "k1"/11.000000000,0 -> /BYTES/v1
@@ -39,13 +46,15 @@ meta: "k3"/0,0 -> txn={id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=
 data: "k3"/14.000000000,0 -> /BYTES/v4
 data: "k4"/15.000000000,0 -> /BYTES/v5
 data: "k5"/17.000000000,0 -> /BYTES/v6
+data: "k6"/13.000000000,0 -> /BYTES/v7
 lock (Replicated): "k2"/Intent -> txn={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0} ts=13.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 lock (Replicated): "k3"/Intent -> txn={id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0} ts=14.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 lock (Unreplicated): k4/Exclusive -> id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=16.000000000,0 min=0,0 seq=0
+lock (Unreplicated): k6/Shared -> id=00000004 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=15.000000000,0 min=0,0 seq=0
 
 # Test cases:
 #
-# for failOnMoreRecent in (true, false):
+# for strength in (none, exclusive, shared):
 #   for ts in (10, 11, 12, 13, 14, 15, 16, 17, 18):
 #     for txn in (nil, A, B, C, D, E):
 #       if txn != nil && txn.read_ts != ts: continue
@@ -53,73 +62,87 @@ lock (Unreplicated): k4/Exclusive -> id=00000005 key=/Min iso=Serializable pri=0
 #         testCase()
 #
 
+#-------------------------------------------------------------------------------
+# str=none
+#-------------------------------------------------------------------------------
+
 run ok
-get ts=10 k=k1 skipLocked
+get ts=10 k=k1 skipLocked str=none
 ----
 get: "k1" -> <no data>
 
 run ok
-get ts=10 k=k2 skipLocked
+get ts=10 k=k2 skipLocked str=none
 ----
 get: "k2" -> <no data>
 
 run ok
-get ts=10 k=k3 skipLocked
+get ts=10 k=k3 skipLocked str=none
 ----
 get: "k3" -> <no data>
 
 run ok
-get ts=10 k=k4 skipLocked
+get ts=10 k=k4 skipLocked str=none
 ----
 get: "k4" -> <no data>
 
 run ok
-get ts=10 k=k5 skipLocked
+get ts=10 k=k5 skipLocked str=none
 ----
 get: "k5" -> <no data>
 
 run ok
-scan ts=10 k=k1 end=k6 skipLocked
+get ts=10 k=k6 skipLocked str=none
 ----
-scan: "k1"-"k6" -> <no data>
+get: "k6" -> <no data>
 
 run ok
-scan ts=10 k=k1 end=k6 reverse skipLocked
+scan ts=10 k=k1 end=k9 skipLocked str=none
 ----
-scan: "k1"-"k6" -> <no data>
+scan: "k1"-"k9" -> <no data>
 
 run ok
-get ts=11 k=k1 skipLocked
+scan ts=10 k=k1 end=k9 reverse skipLocked str=none
+----
+scan: "k1"-"k9" -> <no data>
+
+run ok
+get ts=11 k=k1 skipLocked str=none
 ----
 get: "k1" -> /BYTES/v1 @11.000000000,0
 
 run ok
-get ts=11 k=k2 skipLocked
+get ts=11 k=k2 skipLocked str=none
 ----
 get: "k2" -> <no data>
 
 run ok
-get ts=11 k=k3 skipLocked
+get ts=11 k=k3 skipLocked str=none
 ----
 get: "k3" -> <no data>
 
 run ok
-get ts=11 k=k4 skipLocked
+get ts=11 k=k4 skipLocked str=none
 ----
 get: "k4" -> <no data>
 
 run ok
-get ts=11 k=k5 skipLocked
+get ts=11 k=k5 skipLocked str=none
 ----
 get: "k5" -> <no data>
 
 run ok
-scan ts=11 k=k1 end=k6 skipLocked
+get ts=11 k=k6 skipLocked str=none
+----
+get: "k6" -> <no data>
+
+run ok
+scan ts=11 k=k1 end=k9 skipLocked str=none
 ----
 scan: "k1" -> /BYTES/v1 @11.000000000,0
 
 run ok
-scan ts=11 k=k1 end=k6 reverse skipLocked
+scan ts=11 k=k1 end=k9 reverse skipLocked str=none
 ----
 scan: "k1" -> /BYTES/v1 @11.000000000,0
 
@@ -129,119 +152,136 @@ get ts=12 k=k1 skipLocked
 get: "k1" -> /BYTES/v1 @11.000000000,0
 
 run ok
-get ts=12 k=k2 skipLocked
+get ts=12 k=k2 skipLocked str=none
 ----
 get: "k2" -> /BYTES/v2 @12.000000000,0
 
 run ok
-get ts=12 k=k3 skipLocked
+get ts=12 k=k3 skipLocked str=none
 ----
 get: "k3" -> <no data>
 
 run ok
-get ts=12 k=k4 skipLocked
+get ts=12 k=k4 skipLocked str=none
 ----
 get: "k4" -> <no data>
 
 run ok
-get ts=12 k=k5 skipLocked
+get ts=12 k=k5 skipLocked str=none
 ----
 get: "k5" -> <no data>
 
 run ok
-scan ts=12 k=k1 end=k6 skipLocked
+get ts=12 k=k6 skipLocked str=none
+----
+get: "k6" -> <no data>
+
+run ok
+scan ts=12 k=k1 end=k9 skipLocked str=none
 ----
 scan: "k1" -> /BYTES/v1 @11.000000000,0
 scan: "k2" -> /BYTES/v2 @12.000000000,0
 
 run ok
-scan ts=12 k=k1 end=k6 reverse skipLocked
+scan ts=12 k=k1 end=k9 reverse skipLocked str=none
 ----
 scan: "k2" -> /BYTES/v2 @12.000000000,0
 scan: "k1" -> /BYTES/v1 @11.000000000,0
 
 run ok
-get ts=12 t=A k=k1 skipLocked
+get ts=12 t=A k=k1 skipLocked str=none
 ----
 get: "k1" -> /BYTES/v1 @11.000000000,0
 
 run ok
-get ts=12 t=A k=k2 skipLocked
+get ts=12 t=A k=k2 skipLocked str=none
 ----
 get: "k2" -> /BYTES/v2 @12.000000000,0
 
 run ok
-get ts=12 t=A k=k3 skipLocked
+get ts=12 t=A k=k3 skipLocked str=none
 ----
 get: "k3" -> <no data>
 
 run ok
-get ts=12 t=A k=k4 skipLocked
+get ts=12 t=A k=k4 skipLocked str=none
 ----
 get: "k4" -> <no data>
 
 run ok
-get ts=12 t=A k=k5 skipLocked
+get ts=12 t=A k=k5 skipLocked str=none
 ----
 get: "k5" -> <no data>
 
 run ok
-scan ts=12 t=A k=k1 end=k6 skipLocked
+get ts=12 t=A k=k6 skipLocked str=none
+----
+get: "k6" -> <no data>
+
+run ok
+scan ts=12 t=A k=k1 end=k9 skipLocked str=none
 ----
 scan: "k1" -> /BYTES/v1 @11.000000000,0
 scan: "k2" -> /BYTES/v2 @12.000000000,0
 
 run ok
-scan ts=12 t=A k=k1 end=k6 reverse skipLocked
+scan ts=12 t=A k=k1 end=k9 reverse skipLocked str=none
 ----
 scan: "k2" -> /BYTES/v2 @12.000000000,0
 scan: "k1" -> /BYTES/v1 @11.000000000,0
 
 run ok
-get ts=13 k=k1 skipLocked
+get ts=13 k=k1 skipLocked str=none
 ----
 get: "k1" -> /BYTES/v1 @11.000000000,0
 
 run ok
-get ts=13 k=k2 skipLocked
+get ts=13 k=k2 skipLocked str=none
 ----
 get: "k2" -> intent {id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
 get: "k2" -> <no data>
 
 run ok
-get ts=13 k=k3 skipLocked
+get ts=13 k=k3 skipLocked str=none
 ----
 get: "k3" -> <no data>
 
 run ok
-get ts=13 k=k4 skipLocked
+get ts=13 k=k4 skipLocked str=none
 ----
 get: "k4" -> <no data>
 
 run ok
-get ts=13 k=k5 skipLocked
+get ts=13 k=k5 skipLocked str=none
 ----
 get: "k5" -> <no data>
 
 run ok
-scan ts=13 k=k1 end=k6 skipLocked
+get ts=13 k=k6 skipLocked str=none
+----
+get: "k6" -> /BYTES/v7 @13.000000000,0
+
+run ok
+scan ts=13 k=k1 end=k9 skipLocked str=none
 ----
 scan: intent "k2" {id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
 scan: "k1" -> /BYTES/v1 @11.000000000,0
+scan: "k6" -> /BYTES/v7 @13.000000000,0
 
 run ok
-scan ts=13 k=k1 end=k6 reverse skipLocked
+scan ts=13 k=k1 end=k9 reverse skipLocked str=none
 ----
 scan: intent "k2" {id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
+scan: "k6" -> /BYTES/v7 @13.000000000,0
 scan: "k1" -> /BYTES/v1 @11.000000000,0
 
 run ok
-get ts=13 t=B k=k1 skipLocked
+get ts=13 t=B k=k1 skipLocked str=none
 ----
 get: "k1" -> /BYTES/v1 @11.000000000,0
 
 run ok
-get ts=13 t=B k=k2 skipLocked
+get ts=13 t=B k=k2 skipLocked str=none
 ----
 get: "k2" -> /BYTES/v3 @13.000000000,0
 
@@ -251,945 +291,1757 @@ get ts=13 t=B k=k3 skipLocked
 get: "k3" -> <no data>
 
 run ok
-get ts=13 t=B k=k4 skipLocked
+get ts=13 t=B k=k4 skipLocked str=none
 ----
 get: "k4" -> <no data>
 
 run ok
-get ts=13 t=B k=k5 skipLocked
+get ts=13 t=B k=k5 skipLocked str=none
 ----
 get: "k5" -> <no data>
 
 run ok
-scan ts=13 t=B k=k1 end=k6 skipLocked
+get ts=13 t=B k=k6 skipLocked str=none
+----
+get: "k6" -> /BYTES/v7 @13.000000000,0
+
+run ok
+scan ts=13 t=B k=k1 end=k9 skipLocked str=none
 ----
 scan: "k1" -> /BYTES/v1 @11.000000000,0
 scan: "k2" -> /BYTES/v3 @13.000000000,0
+scan: "k6" -> /BYTES/v7 @13.000000000,0
 
 run ok
-scan ts=13 t=B k=k1 end=k6 reverse skipLocked
+scan ts=13 t=B k=k1 end=k9 reverse skipLocked str=none
 ----
+scan: "k6" -> /BYTES/v7 @13.000000000,0
 scan: "k2" -> /BYTES/v3 @13.000000000,0
 scan: "k1" -> /BYTES/v1 @11.000000000,0
 
 run ok
-get ts=14 k=k1 skipLocked
+get ts=14 k=k1 skipLocked str=none
 ----
 get: "k1" -> /BYTES/v1 @11.000000000,0
 
 run ok
-get ts=14 k=k2 skipLocked
+get ts=14 k=k2 skipLocked str=none
 ----
 get: "k2" -> intent {id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
 get: "k2" -> <no data>
 
 run ok
-get ts=14 k=k3 skipLocked
+get ts=14 k=k3 skipLocked str=none
 ----
 get: "k3" -> intent {id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0}
 get: "k3" -> <no data>
 
 run ok
-get ts=14 k=k4 skipLocked
+get ts=14 k=k4 skipLocked str=none
 ----
 get: "k4" -> <no data>
 
 run ok
-get ts=14 k=k5 skipLocked
+get ts=14 k=k5 skipLocked str=none
 ----
 get: "k5" -> <no data>
 
 run ok
-scan ts=14 k=k1 end=k6 skipLocked
+get ts=14 k=k6 skipLocked str=none
+----
+get: "k6" -> /BYTES/v7 @13.000000000,0
+
+run ok
+scan ts=14 k=k1 end=k9 skipLocked str=none
 ----
 scan: intent "k2" {id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
 scan: intent "k3" {id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0}
 scan: "k1" -> /BYTES/v1 @11.000000000,0
+scan: "k6" -> /BYTES/v7 @13.000000000,0
 
 run ok
-scan ts=14 k=k1 end=k6 reverse skipLocked
+scan ts=14 k=k1 end=k9 reverse skipLocked str=none
 ----
 scan: intent "k3" {id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0}
 scan: intent "k2" {id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
+scan: "k6" -> /BYTES/v7 @13.000000000,0
 scan: "k1" -> /BYTES/v1 @11.000000000,0
 
 run ok
-get ts=14 t=C k=k1 skipLocked
+get ts=14 t=C k=k1 skipLocked str=none
 ----
 get: "k1" -> /BYTES/v1 @11.000000000,0
 
 run ok
-get ts=14 t=C k=k2 skipLocked
+get ts=14 t=C k=k2 skipLocked str=none
 ----
 get: "k2" -> intent {id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
 get: "k2" -> <no data>
 
 run ok
-get ts=14 t=C k=k3 skipLocked
+get ts=14 t=C k=k3 skipLocked str=none
 ----
 get: "k3" -> /BYTES/v4 @14.000000000,0
 
 run ok
-get ts=14 t=C k=k4 skipLocked
+get ts=14 t=C k=k4 skipLocked str=none
 ----
 get: "k4" -> <no data>
 
 run ok
-get ts=14 t=C k=k5 skipLocked
+get ts=14 t=C k=k5 skipLocked str=none
 ----
 get: "k5" -> <no data>
 
 run ok
-scan ts=14 t=C k=k1 end=k6 skipLocked
+get ts=14 t=C k=k6 skipLocked str=none
+----
+get: "k6" -> /BYTES/v7 @13.000000000,0
+
+run ok
+scan ts=14 t=C k=k1 end=k9 skipLocked str=none
 ----
 scan: intent "k2" {id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
 scan: "k1" -> /BYTES/v1 @11.000000000,0
 scan: "k3" -> /BYTES/v4 @14.000000000,0
+scan: "k6" -> /BYTES/v7 @13.000000000,0
 
 run ok
-scan ts=14 t=C k=k1 end=k6 reverse skipLocked
+scan ts=14 t=C k=k1 end=k9 reverse skipLocked str=none
 ----
 scan: intent "k2" {id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
+scan: "k6" -> /BYTES/v7 @13.000000000,0
 scan: "k3" -> /BYTES/v4 @14.000000000,0
 scan: "k1" -> /BYTES/v1 @11.000000000,0
 
 run ok
-get ts=15 k=k1 skipLocked
+get ts=15 k=k1 skipLocked str=none
 ----
 get: "k1" -> /BYTES/v1 @11.000000000,0
 
 run ok
-get ts=15 k=k2 skipLocked
+get ts=15 k=k2 skipLocked str=none
 ----
 get: "k2" -> intent {id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
 get: "k2" -> <no data>
 
 run ok
-get ts=15 k=k3 skipLocked
+get ts=15 k=k3 skipLocked str=none
 ----
 get: "k3" -> intent {id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0}
 get: "k3" -> <no data>
 
 run ok
-get ts=15 k=k4 skipLocked
+get ts=15 k=k4 skipLocked str=none
 ----
 get: "k4" -> /BYTES/v5 @15.000000000,0
 
 run ok
-get ts=15 k=k5 skipLocked
+get ts=15 k=k5 skipLocked str=none
 ----
 get: "k5" -> <no data>
 
 run ok
-scan ts=15 k=k1 end=k6 skipLocked
+get ts=15 k=k6 skipLocked str=none
+----
+get: "k6" -> /BYTES/v7 @13.000000000,0
+
+run ok
+scan ts=15 k=k1 end=k9 skipLocked str=none
 ----
 scan: intent "k2" {id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
 scan: intent "k3" {id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0}
 scan: "k1" -> /BYTES/v1 @11.000000000,0
 scan: "k4" -> /BYTES/v5 @15.000000000,0
+scan: "k6" -> /BYTES/v7 @13.000000000,0
 
 run ok
-scan ts=15 k=k1 end=k6 reverse skipLocked
+scan ts=15 k=k1 end=k9 reverse skipLocked str=none
 ----
 scan: intent "k3" {id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0}
 scan: intent "k2" {id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
+scan: "k6" -> /BYTES/v7 @13.000000000,0
 scan: "k4" -> /BYTES/v5 @15.000000000,0
 scan: "k1" -> /BYTES/v1 @11.000000000,0
 
 run ok
-get ts=15 t=D k=k1 skipLocked
+get ts=15 t=D k=k1 skipLocked str=none
 ----
 get: "k1" -> /BYTES/v1 @11.000000000,0
 
 run ok
-get ts=15 t=D k=k2 skipLocked
+get ts=15 t=D k=k2 skipLocked str=none
 ----
 get: "k2" -> intent {id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
 get: "k2" -> <no data>
 
 run ok
-get ts=15 t=D k=k3 skipLocked
+get ts=15 t=D k=k3 skipLocked str=none
 ----
 get: "k3" -> intent {id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0}
 get: "k3" -> <no data>
 
 run ok
-get ts=15 t=D k=k4 skipLocked
+get ts=15 t=D k=k4 skipLocked str=none
 ----
 get: "k4" -> /BYTES/v5 @15.000000000,0
 
 run ok
-get ts=15 t=D k=k5 skipLocked
+get ts=15 t=D k=k5 skipLocked str=none
 ----
 get: "k5" -> <no data>
 
 run ok
-scan ts=15 t=D k=k1 end=k6 skipLocked
+get ts=15 t=D k=k6 skipLocked str=none
+----
+get: "k6" -> /BYTES/v7 @13.000000000,0
+
+run ok
+scan ts=15 t=D k=k1 end=k9 skipLocked str=none
 ----
 scan: intent "k2" {id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
 scan: intent "k3" {id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0}
 scan: "k1" -> /BYTES/v1 @11.000000000,0
 scan: "k4" -> /BYTES/v5 @15.000000000,0
+scan: "k6" -> /BYTES/v7 @13.000000000,0
 
 run ok
-scan ts=15 t=D k=k1 end=k6 reverse skipLocked
+scan ts=15 t=D k=k1 end=k9 reverse skipLocked str=none
 ----
 scan: intent "k3" {id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0}
 scan: intent "k2" {id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
+scan: "k6" -> /BYTES/v7 @13.000000000,0
 scan: "k4" -> /BYTES/v5 @15.000000000,0
 scan: "k1" -> /BYTES/v1 @11.000000000,0
 
 run ok
-get ts=16 k=k1 skipLocked
+get ts=16 k=k1 skipLocked str=none
 ----
 get: "k1" -> /BYTES/v1 @11.000000000,0
 
 run ok
-get ts=16 k=k2 skipLocked
+get ts=16 k=k2 skipLocked str=none
 ----
 get: "k2" -> intent {id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
 get: "k2" -> <no data>
 
 run ok
-get ts=16 k=k3 skipLocked
+get ts=16 k=k3 skipLocked str=none
 ----
 get: "k3" -> intent {id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0}
 get: "k3" -> <no data>
 
 run ok
-get ts=16 k=k4 skipLocked
+get ts=16 k=k4 skipLocked str=none
 ----
 get: "k4" -> intent {id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=16.000000000,0 min=0,0 seq=0}
 get: "k4" -> <no data>
 
 run ok
-get ts=16 k=k5 skipLocked
+get ts=16 k=k5 skipLocked str=none
 ----
 get: "k5" -> <no data>
 
 run ok
-scan ts=16 k=k1 end=k6 skipLocked
+get ts=16 k=k6 skipLocked str=none
+----
+get: "k6" -> /BYTES/v7 @13.000000000,0
+
+run ok
+scan ts=16 k=k1 end=k9 skipLocked str=none
 ----
 scan: intent "k2" {id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
 scan: intent "k3" {id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0}
 scan: intent "k4" {id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=16.000000000,0 min=0,0 seq=0}
 scan: "k1" -> /BYTES/v1 @11.000000000,0
+scan: "k6" -> /BYTES/v7 @13.000000000,0
 
 run ok
-scan ts=16 k=k1 end=k6 reverse skipLocked
+scan ts=16 k=k1 end=k9 reverse skipLocked str=none
 ----
 scan: intent "k4" {id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=16.000000000,0 min=0,0 seq=0}
 scan: intent "k3" {id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0}
 scan: intent "k2" {id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
+scan: "k6" -> /BYTES/v7 @13.000000000,0
 scan: "k1" -> /BYTES/v1 @11.000000000,0
 
 run ok
-get ts=16 t=E k=k1 skipLocked
+get ts=16 t=E k=k1 skipLocked str=none
 ----
 get: "k1" -> /BYTES/v1 @11.000000000,0
 
 run ok
-get ts=16 t=E k=k2 skipLocked
+get ts=16 t=E k=k2 skipLocked str=none
 ----
 get: "k2" -> intent {id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
 get: "k2" -> <no data>
 
 run ok
-get ts=16 t=E k=k3 skipLocked
+get ts=16 t=E k=k3 skipLocked str=none
 ----
 get: "k3" -> intent {id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0}
 get: "k3" -> <no data>
 
 run ok
-get ts=16 t=E k=k4 skipLocked
+get ts=16 t=E k=k4 skipLocked str=none
 ----
 get: "k4" -> /BYTES/v5 @15.000000000,0
 
 run ok
-get ts=16 t=E k=k5 skipLocked
+get ts=16 t=E k=k5 skipLocked str=none
 ----
 get: "k5" -> <no data>
 
 run ok
-scan ts=16 t=E k=k1 end=k6 skipLocked
+get ts=16 t=E k=k6 skipLocked str=none
+----
+get: "k6" -> /BYTES/v7 @13.000000000,0
+
+run ok
+scan ts=16 t=E k=k1 end=k9 skipLocked str=none
 ----
 scan: intent "k2" {id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
 scan: intent "k3" {id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0}
 scan: "k1" -> /BYTES/v1 @11.000000000,0
 scan: "k4" -> /BYTES/v5 @15.000000000,0
+scan: "k6" -> /BYTES/v7 @13.000000000,0
 
 run ok
-scan ts=16 t=E k=k1 end=k6 reverse skipLocked
+scan ts=16 t=E k=k1 end=k9 reverse skipLocked str=none
 ----
 scan: intent "k3" {id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0}
 scan: intent "k2" {id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
+scan: "k6" -> /BYTES/v7 @13.000000000,0
 scan: "k4" -> /BYTES/v5 @15.000000000,0
 scan: "k1" -> /BYTES/v1 @11.000000000,0
 
 run ok
-get ts=17 k=k1 skipLocked
+get ts=17 k=k1 skipLocked str=none
 ----
 get: "k1" -> /BYTES/v1 @11.000000000,0
 
 run ok
-get ts=17 k=k2 skipLocked
+get ts=17 k=k2 skipLocked str=none
 ----
 get: "k2" -> intent {id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
 get: "k2" -> <no data>
 
 run ok
-get ts=17 k=k3 skipLocked
+get ts=17 k=k3 skipLocked str=none
 ----
 get: "k3" -> intent {id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0}
 get: "k3" -> <no data>
 
 run ok
-get ts=17 k=k4 skipLocked
+get ts=17 k=k4 skipLocked str=none
 ----
 get: "k4" -> intent {id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=16.000000000,0 min=0,0 seq=0}
 get: "k4" -> <no data>
 
 run ok
-get ts=17 k=k5 skipLocked
+get ts=17 k=k5 skipLocked str=none
 ----
 get: "k5" -> /BYTES/v6 @17.000000000,0
 
 run ok
-scan ts=17 k=k1 end=k6 skipLocked
+get ts=17 k=k6 skipLocked str=none
+----
+get: "k6" -> /BYTES/v7 @13.000000000,0
+
+run ok
+scan ts=17 k=k1 end=k9 skipLocked str=none
 ----
 scan: intent "k2" {id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
 scan: intent "k3" {id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0}
 scan: intent "k4" {id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=16.000000000,0 min=0,0 seq=0}
 scan: "k1" -> /BYTES/v1 @11.000000000,0
 scan: "k5" -> /BYTES/v6 @17.000000000,0
+scan: "k6" -> /BYTES/v7 @13.000000000,0
 
 run ok
-scan ts=17 k=k1 end=k6 reverse skipLocked
+scan ts=17 k=k1 end=k9 reverse skipLocked str=none
 ----
 scan: intent "k4" {id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=16.000000000,0 min=0,0 seq=0}
 scan: intent "k3" {id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0}
 scan: intent "k2" {id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
+scan: "k6" -> /BYTES/v7 @13.000000000,0
 scan: "k5" -> /BYTES/v6 @17.000000000,0
 scan: "k1" -> /BYTES/v1 @11.000000000,0
 
 run ok
-get ts=18 k=k1 skipLocked
+get ts=18 k=k1 skipLocked str=none
 ----
 get: "k1" -> /BYTES/v1 @11.000000000,0
 
 run ok
-get ts=18 k=k2 skipLocked
+get ts=18 k=k2 skipLocked str=none
 ----
 get: "k2" -> intent {id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
 get: "k2" -> <no data>
 
 run ok
-get ts=18 k=k3 skipLocked
+get ts=18 k=k3 skipLocked str=none
 ----
 get: "k3" -> intent {id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0}
 get: "k3" -> <no data>
 
 run ok
-get ts=18 k=k4 skipLocked
+get ts=18 k=k4 skipLocked str=none
 ----
 get: "k4" -> intent {id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=16.000000000,0 min=0,0 seq=0}
 get: "k4" -> <no data>
 
 run ok
-get ts=18 k=k5 skipLocked
+get ts=18 k=k5 skipLocked str=none
 ----
 get: "k5" -> /BYTES/v6 @17.000000000,0
 
 run ok
-scan ts=18 k=k1 end=k6 skipLocked
+get ts=18 k=k6 skipLocked str=none
 ----
-scan: intent "k2" {id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
-scan: intent "k3" {id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0}
-scan: intent "k4" {id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=16.000000000,0 min=0,0 seq=0}
-scan: "k1" -> /BYTES/v1 @11.000000000,0
-scan: "k5" -> /BYTES/v6 @17.000000000,0
+get: "k6" -> /BYTES/v7 @13.000000000,0
 
 run ok
-scan ts=18 k=k1 end=k6 reverse skipLocked
+scan ts=18 k=k1 end=k9 skipLocked str=none
+----
+scan: intent "k2" {id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
+scan: intent "k3" {id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0}
+scan: intent "k4" {id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=16.000000000,0 min=0,0 seq=0}
+scan: "k1" -> /BYTES/v1 @11.000000000,0
+scan: "k5" -> /BYTES/v6 @17.000000000,0
+scan: "k6" -> /BYTES/v7 @13.000000000,0
+
+run ok
+scan ts=18 k=k1 end=k9 reverse skipLocked str=none
 ----
 scan: intent "k4" {id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=16.000000000,0 min=0,0 seq=0}
 scan: intent "k3" {id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0}
 scan: intent "k2" {id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
+scan: "k6" -> /BYTES/v7 @13.000000000,0
 scan: "k5" -> /BYTES/v6 @17.000000000,0
 scan: "k1" -> /BYTES/v1 @11.000000000,0
+
+#-------------------------------------------------------------------------------
+# str=shared
+#-------------------------------------------------------------------------------
 
 run error
-get ts=10 k=k1 skipLocked failOnMoreRecent
+get ts=10 k=k1 skipLocked failOnMoreRecent str=shared
 ----
 get: "k1" -> <no data>
 error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k1" at timestamp 10.000000000,0 too old; must write at or above 11.000000000,1
 
 run ok
-get ts=10 k=k2 skipLocked failOnMoreRecent
+get ts=10 k=k2 skipLocked failOnMoreRecent str=shared
 ----
 get: "k2" -> intent {id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
 get: "k2" -> <no data>
 
 run ok
-get ts=10 k=k3 skipLocked failOnMoreRecent
+get ts=10 k=k3 skipLocked failOnMoreRecent str=shared
 ----
 get: "k3" -> intent {id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0}
 get: "k3" -> <no data>
 
 run ok
-get ts=10 k=k4 skipLocked failOnMoreRecent
+get ts=10 k=k4 skipLocked failOnMoreRecent str=shared
 ----
 get: "k4" -> intent {id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=16.000000000,0 min=0,0 seq=0}
 get: "k4" -> <no data>
 
 run error
-get ts=10 k=k5 skipLocked failOnMoreRecent
+get ts=10 k=k5 skipLocked failOnMoreRecent str=shared
 ----
 get: "k5" -> <no data>
 error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 10.000000000,0 too old; must write at or above 17.000000000,1
 
 run error
-scan ts=10 k=k1 end=k6 skipLocked failOnMoreRecent
+get ts=10 k=k6 skipLocked failOnMoreRecent str=shared
 ----
-scan: "k1"-"k6" -> <no data>
+get: "k6" -> <no data>
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k6" at timestamp 10.000000000,0 too old; must write at or above 13.000000000,1
+
+run error
+scan ts=10 k=k1 end=k9 skipLocked failOnMoreRecent str=shared
+----
+scan: "k1"-"k9" -> <no data>
 error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k1" at timestamp 10.000000000,0 too old; must write at or above 17.000000000,1
 
 run error
-scan ts=10 k=k1 end=k6 reverse skipLocked failOnMoreRecent
+scan ts=10 k=k1 end=k9 reverse skipLocked failOnMoreRecent str=shared
 ----
-scan: "k1"-"k6" -> <no data>
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 10.000000000,0 too old; must write at or above 17.000000000,1
+scan: "k1"-"k9" -> <no data>
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k6" at timestamp 10.000000000,0 too old; must write at or above 17.000000000,1
 
 run error
-get ts=11 k=k1 skipLocked failOnMoreRecent
+get ts=11 k=k1 skipLocked failOnMoreRecent str=shared
 ----
 get: "k1" -> <no data>
 error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k1" at timestamp 11.000000000,0 too old; must write at or above 11.000000000,1
 
 run ok
-get ts=11 k=k2 skipLocked failOnMoreRecent
+get ts=11 k=k2 skipLocked failOnMoreRecent str=shared
 ----
 get: "k2" -> intent {id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
 get: "k2" -> <no data>
 
 run ok
-get ts=11 k=k3 skipLocked failOnMoreRecent
+get ts=11 k=k3 skipLocked failOnMoreRecent str=shared
 ----
 get: "k3" -> intent {id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0}
 get: "k3" -> <no data>
 
 run ok
-get ts=11 k=k4 skipLocked failOnMoreRecent
+get ts=11 k=k4 skipLocked failOnMoreRecent str=shared
 ----
 get: "k4" -> intent {id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=16.000000000,0 min=0,0 seq=0}
 get: "k4" -> <no data>
 
 run error
-get ts=11 k=k5 skipLocked failOnMoreRecent
+get ts=11 k=k5 skipLocked failOnMoreRecent str=shared
 ----
 get: "k5" -> <no data>
 error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 11.000000000,0 too old; must write at or above 17.000000000,1
 
 run error
-scan ts=11 k=k1 end=k6 skipLocked failOnMoreRecent
+get ts=11 k=k6 skipLocked failOnMoreRecent str=shared
 ----
-scan: "k1"-"k6" -> <no data>
+get: "k6" -> <no data>
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k6" at timestamp 11.000000000,0 too old; must write at or above 13.000000000,1
+
+run error
+scan ts=11 k=k1 end=k9 skipLocked failOnMoreRecent str=shared
+----
+scan: "k1"-"k9" -> <no data>
 error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k1" at timestamp 11.000000000,0 too old; must write at or above 17.000000000,1
 
 run error
-scan ts=11 k=k1 end=k6 reverse skipLocked failOnMoreRecent
+scan ts=11 k=k1 end=k9 reverse skipLocked failOnMoreRecent str=shared
 ----
-scan: "k1"-"k6" -> <no data>
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 11.000000000,0 too old; must write at or above 17.000000000,1
+scan: "k1"-"k9" -> <no data>
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k6" at timestamp 11.000000000,0 too old; must write at or above 17.000000000,1
 
 run ok
-get ts=12 k=k1 skipLocked failOnMoreRecent
+get ts=12 k=k1 skipLocked failOnMoreRecent str=shared
 ----
 get: "k1" -> /BYTES/v1 @11.000000000,0
 
 run ok
-get ts=12 k=k2 skipLocked failOnMoreRecent
+get ts=12 k=k2 skipLocked failOnMoreRecent str=shared
 ----
 get: "k2" -> intent {id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
 get: "k2" -> <no data>
 
 run ok
-get ts=12 k=k3 skipLocked failOnMoreRecent
+get ts=12 k=k3 skipLocked failOnMoreRecent str=shared
 ----
 get: "k3" -> intent {id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0}
 get: "k3" -> <no data>
 
 run ok
-get ts=12 k=k4 skipLocked failOnMoreRecent
+get ts=12 k=k4 skipLocked failOnMoreRecent str=shared
 ----
 get: "k4" -> intent {id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=16.000000000,0 min=0,0 seq=0}
 get: "k4" -> <no data>
 
 run error
-get ts=12 k=k5 skipLocked failOnMoreRecent
+get ts=12 k=k5 skipLocked failOnMoreRecent str=shared
 ----
 get: "k5" -> <no data>
 error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 12.000000000,0 too old; must write at or above 17.000000000,1
 
 run error
-scan ts=12 k=k1 end=k6 skipLocked failOnMoreRecent
+get ts=12 k=k6 skipLocked failOnMoreRecent str=shared
 ----
-scan: "k1"-"k6" -> <no data>
+get: "k6" -> <no data>
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k6" at timestamp 12.000000000,0 too old; must write at or above 13.000000000,1
+
+run error
+scan ts=12 k=k1 end=k9 skipLocked failOnMoreRecent str=shared
+----
+scan: "k1"-"k9" -> <no data>
 error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 12.000000000,0 too old; must write at or above 17.000000000,1
 
 run error
-scan ts=12 k=k1 end=k6 reverse skipLocked failOnMoreRecent
+scan ts=12 k=k1 end=k9 reverse skipLocked failOnMoreRecent str=shared
 ----
-scan: "k1"-"k6" -> <no data>
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 12.000000000,0 too old; must write at or above 17.000000000,1
+scan: "k1"-"k9" -> <no data>
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k6" at timestamp 12.000000000,0 too old; must write at or above 17.000000000,1
 
 run ok
-get ts=12 t=A k=k1 skipLocked failOnMoreRecent
+get ts=12 t=A k=k1 skipLocked failOnMoreRecent str=shared
 ----
 get: "k1" -> /BYTES/v1 @11.000000000,0
 
 run ok
-get ts=12 t=A k=k2 skipLocked failOnMoreRecent
+get ts=12 t=A k=k2 skipLocked failOnMoreRecent str=shared
 ----
 get: "k2" -> intent {id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
 get: "k2" -> <no data>
 
 run ok
-get ts=12 t=A k=k3 skipLocked failOnMoreRecent
+get ts=12 t=A k=k3 skipLocked failOnMoreRecent str=shared
 ----
 get: "k3" -> intent {id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0}
 get: "k3" -> <no data>
 
 run ok
-get ts=12 t=A k=k4 skipLocked failOnMoreRecent
+get ts=12 t=A k=k4 skipLocked failOnMoreRecent str=shared
 ----
 get: "k4" -> intent {id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=16.000000000,0 min=0,0 seq=0}
 get: "k4" -> <no data>
 
 run error
-get ts=12 t=A k=k5 skipLocked failOnMoreRecent
+get ts=12 t=A k=k5 skipLocked failOnMoreRecent str=shared
 ----
 get: "k5" -> <no data>
 error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 12.000000000,0 too old; must write at or above 17.000000000,1
 
 run error
-scan ts=12 t=A k=k1 end=k6 skipLocked failOnMoreRecent
+get ts=12 t=A k=k6 skipLocked failOnMoreRecent str=shared
 ----
-scan: "k1"-"k6" -> <no data>
+get: "k6" -> <no data>
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k6" at timestamp 12.000000000,0 too old; must write at or above 13.000000000,1
+
+run error
+scan ts=12 t=A k=k1 end=k9 skipLocked failOnMoreRecent str=shared
+----
+scan: "k1"-"k9" -> <no data>
 error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 12.000000000,0 too old; must write at or above 17.000000000,1
 
 run error
-scan ts=12 t=A k=k1 end=k6 reverse skipLocked failOnMoreRecent
+scan ts=12 t=A k=k1 end=k9 reverse skipLocked failOnMoreRecent str=shared
 ----
-scan: "k1"-"k6" -> <no data>
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 12.000000000,0 too old; must write at or above 17.000000000,1
+scan: "k1"-"k9" -> <no data>
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k6" at timestamp 12.000000000,0 too old; must write at or above 17.000000000,1
 
 run ok
-get ts=13 k=k1 skipLocked failOnMoreRecent
+get ts=13 k=k1 skipLocked failOnMoreRecent str=shared
 ----
 get: "k1" -> /BYTES/v1 @11.000000000,0
 
 run ok
-get ts=13 k=k2 skipLocked failOnMoreRecent
+get ts=13 k=k2 skipLocked failOnMoreRecent str=shared
 ----
 get: "k2" -> intent {id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
 get: "k2" -> <no data>
 
 run ok
-get ts=13 k=k3 skipLocked failOnMoreRecent
+get ts=13 k=k3 skipLocked failOnMoreRecent str=shared
 ----
 get: "k3" -> intent {id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0}
 get: "k3" -> <no data>
 
 run ok
-get ts=13 k=k4 skipLocked failOnMoreRecent
+get ts=13 k=k4 skipLocked failOnMoreRecent str=shared
 ----
 get: "k4" -> intent {id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=16.000000000,0 min=0,0 seq=0}
 get: "k4" -> <no data>
 
 run error
-get ts=13 k=k5 skipLocked failOnMoreRecent
+get ts=13 k=k5 skipLocked failOnMoreRecent str=shared
 ----
 get: "k5" -> <no data>
 error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 13.000000000,0 too old; must write at or above 17.000000000,1
 
 run error
-scan ts=13 k=k1 end=k6 skipLocked failOnMoreRecent
+get ts=13 k=k6 skipLocked failOnMoreRecent str=shared
 ----
-scan: "k1"-"k6" -> <no data>
+get: "k6" -> <no data>
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k6" at timestamp 13.000000000,0 too old; must write at or above 13.000000000,1
+
+run error
+scan ts=13 k=k1 end=k9 skipLocked failOnMoreRecent str=shared
+----
+scan: "k1"-"k9" -> <no data>
 error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 13.000000000,0 too old; must write at or above 17.000000000,1
 
 run error
-scan ts=13 k=k1 end=k6 reverse skipLocked failOnMoreRecent
+scan ts=13 k=k1 end=k9 reverse skipLocked failOnMoreRecent str=shared
 ----
-scan: "k1"-"k6" -> <no data>
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 13.000000000,0 too old; must write at or above 17.000000000,1
+scan: "k1"-"k9" -> <no data>
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k6" at timestamp 13.000000000,0 too old; must write at or above 17.000000000,1
 
 run ok
-get ts=13 t=B k=k1 skipLocked failOnMoreRecent
+get ts=13 t=B k=k1 skipLocked failOnMoreRecent str=shared
 ----
 get: "k1" -> /BYTES/v1 @11.000000000,0
 
 run ok
-get ts=13 t=B k=k2 skipLocked failOnMoreRecent
+get ts=13 t=B k=k2 skipLocked failOnMoreRecent str=shared
 ----
 get: "k2" -> /BYTES/v3 @13.000000000,0
 
 run ok
-get ts=13 t=B k=k3 skipLocked failOnMoreRecent
+get ts=13 t=B k=k3 skipLocked failOnMoreRecent str=shared
 ----
 get: "k3" -> intent {id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0}
 get: "k3" -> <no data>
 
 run ok
-get ts=13 t=B k=k4 skipLocked failOnMoreRecent
+get ts=13 t=B k=k4 skipLocked failOnMoreRecent str=shared
 ----
 get: "k4" -> intent {id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=16.000000000,0 min=0,0 seq=0}
 get: "k4" -> <no data>
 
 run error
-get ts=13 t=B k=k5 skipLocked failOnMoreRecent
+get ts=13 t=B k=k5 skipLocked failOnMoreRecent str=shared
 ----
 get: "k5" -> <no data>
 error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 13.000000000,0 too old; must write at or above 17.000000000,1
 
 run error
-scan ts=13 t=B k=k1 end=k6 skipLocked failOnMoreRecent
+get ts=13 t=B k=k6 skipLocked failOnMoreRecent str=shared
 ----
-scan: "k1"-"k6" -> <no data>
+get: "k6" -> <no data>
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k6" at timestamp 13.000000000,0 too old; must write at or above 13.000000000,1
+
+run error
+scan ts=13 t=B k=k1 end=k9 skipLocked failOnMoreRecent str=shared
+----
+scan: "k1"-"k9" -> <no data>
 error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 13.000000000,0 too old; must write at or above 17.000000000,1
 
 run error
-scan ts=13 t=B k=k1 end=k6 reverse skipLocked failOnMoreRecent
+scan ts=13 t=B k=k1 end=k9 reverse skipLocked failOnMoreRecent str=shared
 ----
-scan: "k1"-"k6" -> <no data>
-error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 13.000000000,0 too old; must write at or above 17.000000000,1
+scan: "k1"-"k9" -> <no data>
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k6" at timestamp 13.000000000,0 too old; must write at or above 17.000000000,1
 
 run ok
-get ts=14 k=k1 skipLocked failOnMoreRecent
+get ts=14 k=k1 skipLocked failOnMoreRecent str=shared
 ----
 get: "k1" -> /BYTES/v1 @11.000000000,0
 
 run ok
-get ts=14 k=k2 skipLocked failOnMoreRecent
+get ts=14 k=k2 skipLocked failOnMoreRecent str=shared
 ----
 get: "k2" -> intent {id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
 get: "k2" -> <no data>
 
 run ok
-get ts=14 k=k3 skipLocked failOnMoreRecent
+get ts=14 k=k3 skipLocked failOnMoreRecent str=shared
 ----
 get: "k3" -> intent {id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0}
 get: "k3" -> <no data>
 
 run ok
-get ts=14 k=k4 skipLocked failOnMoreRecent
+get ts=14 k=k4 skipLocked failOnMoreRecent str=shared
 ----
 get: "k4" -> intent {id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=16.000000000,0 min=0,0 seq=0}
 get: "k4" -> <no data>
 
 run error
-get ts=14 k=k5 skipLocked failOnMoreRecent
+get ts=14 k=k5 skipLocked failOnMoreRecent str=shared
 ----
 get: "k5" -> <no data>
 error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 14.000000000,0 too old; must write at or above 17.000000000,1
 
-run error
-scan ts=14 k=k1 end=k6 skipLocked failOnMoreRecent
+run ok
+get ts=14 k=k6 skipLocked failOnMoreRecent str=shared
 ----
-scan: "k1"-"k6" -> <no data>
+get: "k6" -> /BYTES/v7 @13.000000000,0
+
+run error
+scan ts=14 k=k1 end=k9 skipLocked failOnMoreRecent str=shared
+----
+scan: "k1"-"k9" -> <no data>
 error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 14.000000000,0 too old; must write at or above 17.000000000,1
 
 run error
-scan ts=14 k=k1 end=k6 reverse skipLocked failOnMoreRecent
+scan ts=14 k=k1 end=k9 reverse skipLocked failOnMoreRecent str=shared
 ----
-scan: "k1"-"k6" -> <no data>
+scan: "k1"-"k9" -> <no data>
 error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 14.000000000,0 too old; must write at or above 17.000000000,1
 
 run ok
-get ts=14 t=C k=k1 skipLocked failOnMoreRecent
+get ts=14 t=C k=k1 skipLocked failOnMoreRecent str=shared
 ----
 get: "k1" -> /BYTES/v1 @11.000000000,0
 
 run ok
-get ts=14 t=C k=k2 skipLocked failOnMoreRecent
+get ts=14 t=C k=k2 skipLocked failOnMoreRecent str=shared
 ----
 get: "k2" -> intent {id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
 get: "k2" -> <no data>
 
 run ok
-get ts=14 t=C k=k3 skipLocked failOnMoreRecent
+get ts=14 t=C k=k3 skipLocked failOnMoreRecent str=shared
 ----
 get: "k3" -> /BYTES/v4 @14.000000000,0
 
 run ok
-get ts=14 t=C k=k4 skipLocked failOnMoreRecent
+get ts=14 t=C k=k4 skipLocked failOnMoreRecent str=shared
 ----
 get: "k4" -> intent {id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=16.000000000,0 min=0,0 seq=0}
 get: "k4" -> <no data>
 
 run error
-get ts=14 t=C k=k5 skipLocked failOnMoreRecent
+get ts=14 t=C k=k5 skipLocked failOnMoreRecent str=shared
 ----
 get: "k5" -> <no data>
 error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 14.000000000,0 too old; must write at or above 17.000000000,1
 
-run error
-scan ts=14 t=C k=k1 end=k6 skipLocked failOnMoreRecent
+run ok
+get ts=14 t=C k=k6 skipLocked failOnMoreRecent str=shared
 ----
-scan: "k1"-"k6" -> <no data>
+get: "k6" -> /BYTES/v7 @13.000000000,0
+
+run error
+scan ts=14 t=C k=k1 end=k9 skipLocked failOnMoreRecent str=shared
+----
+scan: "k1"-"k9" -> <no data>
 error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 14.000000000,0 too old; must write at or above 17.000000000,1
 
 run error
-scan ts=14 t=C k=k1 end=k6 reverse skipLocked failOnMoreRecent
+scan ts=14 t=C k=k1 end=k9 reverse skipLocked failOnMoreRecent str=shared
 ----
-scan: "k1"-"k6" -> <no data>
+scan: "k1"-"k9" -> <no data>
 error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 14.000000000,0 too old; must write at or above 17.000000000,1
 
 run ok
-get ts=15 k=k1 skipLocked failOnMoreRecent
+get ts=15 k=k1 skipLocked failOnMoreRecent str=shared
 ----
 get: "k1" -> /BYTES/v1 @11.000000000,0
 
 run ok
-get ts=15 k=k2 skipLocked failOnMoreRecent
+get ts=15 k=k2 skipLocked failOnMoreRecent str=shared
 ----
 get: "k2" -> intent {id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
 get: "k2" -> <no data>
 
 run ok
-get ts=15 k=k3 skipLocked failOnMoreRecent
+get ts=15 k=k3 skipLocked failOnMoreRecent str=shared
 ----
 get: "k3" -> intent {id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0}
 get: "k3" -> <no data>
 
 run ok
-get ts=15 k=k4 skipLocked failOnMoreRecent
+get ts=15 k=k4 skipLocked failOnMoreRecent str=shared
 ----
 get: "k4" -> intent {id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=16.000000000,0 min=0,0 seq=0}
 get: "k4" -> <no data>
 
 run error
-get ts=15 k=k5 skipLocked failOnMoreRecent
+get ts=15 k=k5 skipLocked failOnMoreRecent str=shared
 ----
 get: "k5" -> <no data>
 error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 15.000000000,0 too old; must write at or above 17.000000000,1
 
-run error
-scan ts=15 k=k1 end=k6 skipLocked failOnMoreRecent
+run ok
+get ts=15 k=k6 skipLocked failOnMoreRecent str=shared
 ----
-scan: "k1"-"k6" -> <no data>
+get: "k6" -> /BYTES/v7 @13.000000000,0
+
+run error
+scan ts=15 k=k1 end=k9 skipLocked failOnMoreRecent str=shared
+----
+scan: "k1"-"k9" -> <no data>
 error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 15.000000000,0 too old; must write at or above 17.000000000,1
 
 run error
-scan ts=15 k=k1 end=k6 reverse skipLocked failOnMoreRecent
+scan ts=15 k=k1 end=k9 reverse skipLocked failOnMoreRecent str=shared
 ----
-scan: "k1"-"k6" -> <no data>
+scan: "k1"-"k9" -> <no data>
 error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 15.000000000,0 too old; must write at or above 17.000000000,1
 
 run ok
-get ts=15 t=D k=k1 skipLocked failOnMoreRecent
+get ts=15 t=D k=k1 skipLocked failOnMoreRecent str=shared
 ----
 get: "k1" -> /BYTES/v1 @11.000000000,0
 
 run ok
-get ts=15 t=D k=k2 skipLocked failOnMoreRecent
+get ts=15 t=D k=k2 skipLocked failOnMoreRecent str=shared
 ----
 get: "k2" -> intent {id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
 get: "k2" -> <no data>
 
 run ok
-get ts=15 t=D k=k3 skipLocked failOnMoreRecent
+get ts=15 t=D k=k3 skipLocked failOnMoreRecent str=shared
 ----
 get: "k3" -> intent {id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0}
 get: "k3" -> <no data>
 
 run ok
-get ts=15 t=D k=k4 skipLocked failOnMoreRecent
+get ts=15 t=D k=k4 skipLocked failOnMoreRecent str=shared
 ----
 get: "k4" -> intent {id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=16.000000000,0 min=0,0 seq=0}
 get: "k4" -> <no data>
 
 run error
-get ts=15 t=D k=k5 skipLocked failOnMoreRecent
+get ts=15 t=D k=k5 skipLocked failOnMoreRecent str=shared
 ----
 get: "k5" -> <no data>
 error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 15.000000000,0 too old; must write at or above 17.000000000,1
 
-run error
-scan ts=15 t=D k=k1 end=k6 skipLocked failOnMoreRecent
+run ok
+get ts=15 t=D k=k6 skipLocked failOnMoreRecent str=shared
 ----
-scan: "k1"-"k6" -> <no data>
+get: "k6" -> /BYTES/v7 @13.000000000,0
+
+run error
+scan ts=15 t=D k=k1 end=k9 skipLocked failOnMoreRecent str=shared
+----
+scan: "k1"-"k9" -> <no data>
 error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 15.000000000,0 too old; must write at or above 17.000000000,1
 
 run error
-scan ts=15 t=D k=k1 end=k6 reverse skipLocked failOnMoreRecent
+scan ts=15 t=D k=k1 end=k9 reverse skipLocked failOnMoreRecent str=shared
 ----
-scan: "k1"-"k6" -> <no data>
+scan: "k1"-"k9" -> <no data>
 error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 15.000000000,0 too old; must write at or above 17.000000000,1
 
 run ok
-get ts=16 k=k1 skipLocked failOnMoreRecent
+get ts=16 k=k1 skipLocked failOnMoreRecent str=shared
 ----
 get: "k1" -> /BYTES/v1 @11.000000000,0
 
 run ok
-get ts=16 k=k2 skipLocked failOnMoreRecent
+get ts=16 k=k2 skipLocked failOnMoreRecent str=shared
 ----
 get: "k2" -> intent {id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
 get: "k2" -> <no data>
 
 run ok
-get ts=16 k=k3 skipLocked failOnMoreRecent
+get ts=16 k=k3 skipLocked failOnMoreRecent str=shared
 ----
 get: "k3" -> intent {id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0}
 get: "k3" -> <no data>
 
 run ok
-get ts=16 k=k4 skipLocked failOnMoreRecent
+get ts=16 k=k4 skipLocked failOnMoreRecent str=shared
 ----
 get: "k4" -> intent {id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=16.000000000,0 min=0,0 seq=0}
 get: "k4" -> <no data>
 
 run error
-get ts=16 k=k5 skipLocked failOnMoreRecent
+get ts=16 k=k5 skipLocked failOnMoreRecent str=shared
 ----
 get: "k5" -> <no data>
 error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 16.000000000,0 too old; must write at or above 17.000000000,1
 
-run error
-scan ts=16 k=k1 end=k6 skipLocked failOnMoreRecent
+run ok
+get ts=16 k=k6 skipLocked failOnMoreRecent str=shared
 ----
-scan: "k1"-"k6" -> <no data>
+get: "k6" -> /BYTES/v7 @13.000000000,0
+
+run error
+scan ts=16 k=k1 end=k9 skipLocked failOnMoreRecent str=shared
+----
+scan: "k1"-"k9" -> <no data>
 error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 16.000000000,0 too old; must write at or above 17.000000000,1
 
 run error
-scan ts=16 k=k1 end=k6 reverse skipLocked failOnMoreRecent
+scan ts=16 k=k1 end=k9 reverse skipLocked failOnMoreRecent str=shared
 ----
-scan: "k1"-"k6" -> <no data>
+scan: "k1"-"k9" -> <no data>
 error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 16.000000000,0 too old; must write at or above 17.000000000,1
 
 run ok
-get ts=16 t=E k=k1 skipLocked failOnMoreRecent
+get ts=16 t=E k=k1 skipLocked failOnMoreRecent str=shared
 ----
 get: "k1" -> /BYTES/v1 @11.000000000,0
 
 run ok
-get ts=16 t=E k=k2 skipLocked failOnMoreRecent
+get ts=16 t=E k=k2 skipLocked failOnMoreRecent str=shared
 ----
 get: "k2" -> intent {id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
 get: "k2" -> <no data>
 
 run ok
-get ts=16 t=E k=k3 skipLocked failOnMoreRecent
+get ts=16 t=E k=k3 skipLocked failOnMoreRecent str=shared
 ----
 get: "k3" -> intent {id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0}
 get: "k3" -> <no data>
 
 run ok
-get ts=16 t=E k=k4 skipLocked failOnMoreRecent
+get ts=16 t=E k=k4 skipLocked failOnMoreRecent str=shared
 ----
 get: "k4" -> /BYTES/v5 @15.000000000,0
 
 run error
-get ts=16 t=E k=k5 skipLocked failOnMoreRecent
+get ts=16 t=E k=k5 skipLocked failOnMoreRecent str=shared
 ----
 get: "k5" -> <no data>
 error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 16.000000000,0 too old; must write at or above 17.000000000,1
 
-run error
-scan ts=16 t=E k=k1 end=k6 skipLocked failOnMoreRecent
+run ok
+get ts=16 t=E k=k6 skipLocked failOnMoreRecent str=shared
 ----
-scan: "k1"-"k6" -> <no data>
+get: "k6" -> /BYTES/v7 @13.000000000,0
+
+run error
+scan ts=16 t=E k=k1 end=k9 skipLocked failOnMoreRecent str=shared
+----
+scan: "k1"-"k9" -> <no data>
 error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 16.000000000,0 too old; must write at or above 17.000000000,1
 
 run error
-scan ts=16 t=E k=k1 end=k6 reverse skipLocked failOnMoreRecent
+scan ts=16 t=E k=k1 end=k9 reverse skipLocked failOnMoreRecent str=shared
 ----
-scan: "k1"-"k6" -> <no data>
+scan: "k1"-"k9" -> <no data>
 error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 16.000000000,0 too old; must write at or above 17.000000000,1
 
 run ok
-get ts=17 k=k1 skipLocked failOnMoreRecent
+get ts=17 k=k1 skipLocked failOnMoreRecent str=shared
 ----
 get: "k1" -> /BYTES/v1 @11.000000000,0
 
 run ok
-get ts=17 k=k2 skipLocked failOnMoreRecent
+get ts=17 k=k2 skipLocked failOnMoreRecent str=shared
 ----
 get: "k2" -> intent {id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
 get: "k2" -> <no data>
 
 run ok
-get ts=17 k=k3 skipLocked failOnMoreRecent
+get ts=17 k=k3 skipLocked failOnMoreRecent str=shared
 ----
 get: "k3" -> intent {id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0}
 get: "k3" -> <no data>
 
 run ok
-get ts=17 k=k4 skipLocked failOnMoreRecent
+get ts=17 k=k4 skipLocked failOnMoreRecent str=shared
 ----
 get: "k4" -> intent {id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=16.000000000,0 min=0,0 seq=0}
 get: "k4" -> <no data>
 
 run error
-get ts=17 k=k5 skipLocked failOnMoreRecent
+get ts=17 k=k5 skipLocked failOnMoreRecent str=shared
 ----
 get: "k5" -> <no data>
 error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 17.000000000,0 too old; must write at or above 17.000000000,1
 
-run error
-scan ts=17 k=k1 end=k6 skipLocked failOnMoreRecent
+run ok
+get ts=17 k=k6 skipLocked failOnMoreRecent str=shared
 ----
-scan: "k1"-"k6" -> <no data>
+get: "k6" -> /BYTES/v7 @13.000000000,0
+
+run error
+scan ts=17 k=k1 end=k9 skipLocked failOnMoreRecent str=shared
+----
+scan: "k1"-"k9" -> <no data>
 error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 17.000000000,0 too old; must write at or above 17.000000000,1
 
 run error
-scan ts=17 k=k1 end=k6 reverse skipLocked failOnMoreRecent
+scan ts=17 k=k1 end=k9 reverse skipLocked failOnMoreRecent str=shared
 ----
-scan: "k1"-"k6" -> <no data>
+scan: "k1"-"k9" -> <no data>
 error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 17.000000000,0 too old; must write at or above 17.000000000,1
 
 run ok
-get ts=18 k=k1 skipLocked failOnMoreRecent
+get ts=18 k=k1 skipLocked failOnMoreRecent str=shared
 ----
 get: "k1" -> /BYTES/v1 @11.000000000,0
 
 run ok
-get ts=18 k=k2 skipLocked failOnMoreRecent
+get ts=18 k=k2 skipLocked failOnMoreRecent str=shared
 ----
 get: "k2" -> intent {id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
 get: "k2" -> <no data>
 
 run ok
-get ts=18 k=k3 skipLocked failOnMoreRecent
+get ts=18 k=k3 skipLocked failOnMoreRecent str=shared
 ----
 get: "k3" -> intent {id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0}
 get: "k3" -> <no data>
 
 run ok
-get ts=18 k=k4 skipLocked failOnMoreRecent
+get ts=18 k=k4 skipLocked failOnMoreRecent str=shared
 ----
 get: "k4" -> intent {id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=16.000000000,0 min=0,0 seq=0}
 get: "k4" -> <no data>
 
 run ok
-get ts=18 k=k5 skipLocked failOnMoreRecent
+get ts=18 k=k5 skipLocked failOnMoreRecent str=shared
 ----
 get: "k5" -> /BYTES/v6 @17.000000000,0
 
 run ok
-scan ts=18 k=k1 end=k6 skipLocked failOnMoreRecent
+get ts=18 k=k6 skipLocked failOnMoreRecent str=shared
+----
+get: "k6" -> /BYTES/v7 @13.000000000,0
+
+run ok
+scan ts=18 k=k1 end=k9 skipLocked failOnMoreRecent str=shared
 ----
 scan: intent "k2" {id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
 scan: intent "k3" {id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0}
 scan: intent "k4" {id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=16.000000000,0 min=0,0 seq=0}
 scan: "k1" -> /BYTES/v1 @11.000000000,0
 scan: "k5" -> /BYTES/v6 @17.000000000,0
+scan: "k6" -> /BYTES/v7 @13.000000000,0
 
 run ok
-scan ts=18 k=k1 end=k6 reverse skipLocked failOnMoreRecent
+scan ts=18 k=k1 end=k9 reverse skipLocked failOnMoreRecent str=shared
 ----
+scan: intent "k4" {id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=16.000000000,0 min=0,0 seq=0}
+scan: intent "k3" {id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0}
+scan: intent "k2" {id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
+scan: "k6" -> /BYTES/v7 @13.000000000,0
+scan: "k5" -> /BYTES/v6 @17.000000000,0
+scan: "k1" -> /BYTES/v1 @11.000000000,0
+
+#-------------------------------------------------------------------------------
+# str=exclusive
+#-------------------------------------------------------------------------------
+
+run error
+get ts=10 k=k1 skipLocked failOnMoreRecent str=exclusive
+----
+get: "k1" -> <no data>
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k1" at timestamp 10.000000000,0 too old; must write at or above 11.000000000,1
+
+run ok
+get ts=10 k=k2 skipLocked failOnMoreRecent str=exclusive
+----
+get: "k2" -> intent {id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
+get: "k2" -> <no data>
+
+run ok
+get ts=10 k=k3 skipLocked failOnMoreRecent str=exclusive
+----
+get: "k3" -> intent {id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0}
+get: "k3" -> <no data>
+
+run ok
+get ts=10 k=k4 skipLocked failOnMoreRecent str=exclusive
+----
+get: "k4" -> intent {id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=16.000000000,0 min=0,0 seq=0}
+get: "k4" -> <no data>
+
+run error
+get ts=10 k=k5 skipLocked failOnMoreRecent str=exclusive
+----
+get: "k5" -> <no data>
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 10.000000000,0 too old; must write at or above 17.000000000,1
+
+run ok
+get ts=10 k=k6 skipLocked failOnMoreRecent str=exclusive
+----
+get: "k6" -> intent {id=00000004 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=15.000000000,0 min=0,0 seq=0}
+get: "k6" -> <no data>
+
+run error
+scan ts=10 k=k1 end=k9 skipLocked failOnMoreRecent str=exclusive
+----
+scan: "k1"-"k9" -> <no data>
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k1" at timestamp 10.000000000,0 too old; must write at or above 17.000000000,1
+
+run error
+scan ts=10 k=k1 end=k9 reverse skipLocked failOnMoreRecent str=exclusive
+----
+scan: "k1"-"k9" -> <no data>
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 10.000000000,0 too old; must write at or above 17.000000000,1
+
+run error
+get ts=11 k=k1 skipLocked failOnMoreRecent str=exclusive
+----
+get: "k1" -> <no data>
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k1" at timestamp 11.000000000,0 too old; must write at or above 11.000000000,1
+
+run ok
+get ts=11 k=k2 skipLocked failOnMoreRecent str=exclusive
+----
+get: "k2" -> intent {id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
+get: "k2" -> <no data>
+
+run ok
+get ts=11 k=k3 skipLocked failOnMoreRecent str=exclusive
+----
+get: "k3" -> intent {id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0}
+get: "k3" -> <no data>
+
+run ok
+get ts=11 k=k4 skipLocked failOnMoreRecent str=exclusive
+----
+get: "k4" -> intent {id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=16.000000000,0 min=0,0 seq=0}
+get: "k4" -> <no data>
+
+run error
+get ts=11 k=k5 skipLocked failOnMoreRecent str=exclusive
+----
+get: "k5" -> <no data>
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 11.000000000,0 too old; must write at or above 17.000000000,1
+
+run ok
+get ts=11 k=k6 skipLocked failOnMoreRecent str=exclusive
+----
+get: "k6" -> intent {id=00000004 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=15.000000000,0 min=0,0 seq=0}
+get: "k6" -> <no data>
+
+run error
+scan ts=11 k=k1 end=k9 skipLocked failOnMoreRecent str=exclusive
+----
+scan: "k1"-"k9" -> <no data>
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k1" at timestamp 11.000000000,0 too old; must write at or above 17.000000000,1
+
+run error
+scan ts=11 k=k1 end=k9 reverse skipLocked failOnMoreRecent str=exclusive
+----
+scan: "k1"-"k9" -> <no data>
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 11.000000000,0 too old; must write at or above 17.000000000,1
+
+run ok
+get ts=12 k=k1 skipLocked failOnMoreRecent str=exclusive
+----
+get: "k1" -> /BYTES/v1 @11.000000000,0
+
+run ok
+get ts=12 k=k2 skipLocked failOnMoreRecent str=exclusive
+----
+get: "k2" -> intent {id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
+get: "k2" -> <no data>
+
+run ok
+get ts=12 k=k3 skipLocked failOnMoreRecent str=exclusive
+----
+get: "k3" -> intent {id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0}
+get: "k3" -> <no data>
+
+run ok
+get ts=12 k=k4 skipLocked failOnMoreRecent str=exclusive
+----
+get: "k4" -> intent {id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=16.000000000,0 min=0,0 seq=0}
+get: "k4" -> <no data>
+
+run error
+get ts=12 k=k5 skipLocked failOnMoreRecent str=exclusive
+----
+get: "k5" -> <no data>
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 12.000000000,0 too old; must write at or above 17.000000000,1
+
+run ok
+get ts=12 k=k6 skipLocked failOnMoreRecent str=exclusive
+----
+get: "k6" -> intent {id=00000004 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=15.000000000,0 min=0,0 seq=0}
+get: "k6" -> <no data>
+
+run error
+scan ts=12 k=k1 end=k9 skipLocked failOnMoreRecent str=exclusive
+----
+scan: "k1"-"k9" -> <no data>
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 12.000000000,0 too old; must write at or above 17.000000000,1
+
+run error
+scan ts=12 k=k1 end=k9 reverse skipLocked failOnMoreRecent str=exclusive
+----
+scan: "k1"-"k9" -> <no data>
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 12.000000000,0 too old; must write at or above 17.000000000,1
+
+run ok
+get ts=12 t=A k=k1 skipLocked failOnMoreRecent str=exclusive
+----
+get: "k1" -> /BYTES/v1 @11.000000000,0
+
+run ok
+get ts=12 t=A k=k2 skipLocked failOnMoreRecent str=exclusive
+----
+get: "k2" -> intent {id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
+get: "k2" -> <no data>
+
+run ok
+get ts=12 t=A k=k3 skipLocked failOnMoreRecent str=exclusive
+----
+get: "k3" -> intent {id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0}
+get: "k3" -> <no data>
+
+run ok
+get ts=12 t=A k=k4 skipLocked failOnMoreRecent str=exclusive
+----
+get: "k4" -> intent {id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=16.000000000,0 min=0,0 seq=0}
+get: "k4" -> <no data>
+
+run error
+get ts=12 t=A k=k5 skipLocked failOnMoreRecent str=exclusive
+----
+get: "k5" -> <no data>
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 12.000000000,0 too old; must write at or above 17.000000000,1
+
+run ok
+get ts=12 t=A k=k6 skipLocked failOnMoreRecent str=exclusive
+----
+get: "k6" -> intent {id=00000004 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=15.000000000,0 min=0,0 seq=0}
+get: "k6" -> <no data>
+
+run error
+scan ts=12 t=A k=k1 end=k9 skipLocked failOnMoreRecent str=exclusive
+----
+scan: "k1"-"k9" -> <no data>
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 12.000000000,0 too old; must write at or above 17.000000000,1
+
+run error
+scan ts=12 t=A k=k1 end=k9 reverse skipLocked failOnMoreRecent str=exclusive
+----
+scan: "k1"-"k9" -> <no data>
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 12.000000000,0 too old; must write at or above 17.000000000,1
+
+run ok
+get ts=13 k=k1 skipLocked failOnMoreRecent str=exclusive
+----
+get: "k1" -> /BYTES/v1 @11.000000000,0
+
+run ok
+get ts=13 k=k2 skipLocked failOnMoreRecent str=exclusive
+----
+get: "k2" -> intent {id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
+get: "k2" -> <no data>
+
+run ok
+get ts=13 k=k3 skipLocked failOnMoreRecent str=exclusive
+----
+get: "k3" -> intent {id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0}
+get: "k3" -> <no data>
+
+run ok
+get ts=13 k=k4 skipLocked failOnMoreRecent str=exclusive
+----
+get: "k4" -> intent {id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=16.000000000,0 min=0,0 seq=0}
+get: "k4" -> <no data>
+
+run error
+get ts=13 k=k5 skipLocked failOnMoreRecent str=exclusive
+----
+get: "k5" -> <no data>
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 13.000000000,0 too old; must write at or above 17.000000000,1
+
+run ok
+get ts=13 k=k6 skipLocked failOnMoreRecent str=exclusive
+----
+get: "k6" -> intent {id=00000004 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=15.000000000,0 min=0,0 seq=0}
+get: "k6" -> <no data>
+
+run error
+scan ts=13 k=k1 end=k9 skipLocked failOnMoreRecent str=exclusive
+----
+scan: "k1"-"k9" -> <no data>
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 13.000000000,0 too old; must write at or above 17.000000000,1
+
+run error
+scan ts=13 k=k1 end=k9 reverse skipLocked failOnMoreRecent str=exclusive
+----
+scan: "k1"-"k9" -> <no data>
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 13.000000000,0 too old; must write at or above 17.000000000,1
+
+run ok
+get ts=13 t=B k=k1 skipLocked failOnMoreRecent str=exclusive
+----
+get: "k1" -> /BYTES/v1 @11.000000000,0
+
+run ok
+get ts=13 t=B k=k2 skipLocked failOnMoreRecent str=exclusive
+----
+get: "k2" -> /BYTES/v3 @13.000000000,0
+
+run ok
+get ts=13 t=B k=k3 skipLocked failOnMoreRecent str=exclusive
+----
+get: "k3" -> intent {id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0}
+get: "k3" -> <no data>
+
+run ok
+get ts=13 t=B k=k4 skipLocked failOnMoreRecent str=exclusive
+----
+get: "k4" -> intent {id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=16.000000000,0 min=0,0 seq=0}
+get: "k4" -> <no data>
+
+run error
+get ts=13 t=B k=k5 skipLocked failOnMoreRecent str=exclusive
+----
+get: "k5" -> <no data>
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 13.000000000,0 too old; must write at or above 17.000000000,1
+
+run ok
+get ts=13 t=B k=k6 skipLocked failOnMoreRecent str=exclusive
+----
+get: "k6" -> intent {id=00000004 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=15.000000000,0 min=0,0 seq=0}
+get: "k6" -> <no data>
+
+run error
+scan ts=13 t=B k=k1 end=k9 skipLocked failOnMoreRecent str=exclusive
+----
+scan: "k1"-"k9" -> <no data>
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 13.000000000,0 too old; must write at or above 17.000000000,1
+
+run error
+scan ts=13 t=B k=k1 end=k9 reverse skipLocked failOnMoreRecent str=exclusive
+----
+scan: "k1"-"k9" -> <no data>
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 13.000000000,0 too old; must write at or above 17.000000000,1
+
+run ok
+get ts=14 k=k1 skipLocked failOnMoreRecent str=exclusive
+----
+get: "k1" -> /BYTES/v1 @11.000000000,0
+
+run ok
+get ts=14 k=k2 skipLocked failOnMoreRecent str=exclusive
+----
+get: "k2" -> intent {id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
+get: "k2" -> <no data>
+
+run ok
+get ts=14 k=k3 skipLocked failOnMoreRecent str=exclusive
+----
+get: "k3" -> intent {id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0}
+get: "k3" -> <no data>
+
+run ok
+get ts=14 k=k4 skipLocked failOnMoreRecent str=exclusive
+----
+get: "k4" -> intent {id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=16.000000000,0 min=0,0 seq=0}
+get: "k4" -> <no data>
+
+run error
+get ts=14 k=k5 skipLocked failOnMoreRecent str=exclusive
+----
+get: "k5" -> <no data>
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 14.000000000,0 too old; must write at or above 17.000000000,1
+
+run ok
+get ts=14 k=k6 skipLocked failOnMoreRecent str=exclusive
+----
+get: "k6" -> intent {id=00000004 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=15.000000000,0 min=0,0 seq=0}
+get: "k6" -> <no data>
+
+run error
+scan ts=14 k=k1 end=k9 skipLocked failOnMoreRecent str=exclusive
+----
+scan: "k1"-"k9" -> <no data>
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 14.000000000,0 too old; must write at or above 17.000000000,1
+
+run error
+scan ts=14 k=k1 end=k9 reverse skipLocked failOnMoreRecent str=exclusive
+----
+scan: "k1"-"k9" -> <no data>
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 14.000000000,0 too old; must write at or above 17.000000000,1
+
+run ok
+get ts=14 t=C k=k1 skipLocked failOnMoreRecent str=exclusive
+----
+get: "k1" -> /BYTES/v1 @11.000000000,0
+
+run ok
+get ts=14 t=C k=k2 skipLocked failOnMoreRecent str=exclusive
+----
+get: "k2" -> intent {id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
+get: "k2" -> <no data>
+
+run ok
+get ts=14 t=C k=k3 skipLocked failOnMoreRecent str=exclusive
+----
+get: "k3" -> /BYTES/v4 @14.000000000,0
+
+run ok
+get ts=14 t=C k=k4 skipLocked failOnMoreRecent str=exclusive
+----
+get: "k4" -> intent {id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=16.000000000,0 min=0,0 seq=0}
+get: "k4" -> <no data>
+
+run error
+get ts=14 t=C k=k5 skipLocked failOnMoreRecent str=exclusive
+----
+get: "k5" -> <no data>
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 14.000000000,0 too old; must write at or above 17.000000000,1
+
+run ok
+get ts=14 t=C k=k6 skipLocked failOnMoreRecent str=exclusive
+----
+get: "k6" -> intent {id=00000004 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=15.000000000,0 min=0,0 seq=0}
+get: "k6" -> <no data>
+
+run error
+scan ts=14 t=C k=k1 end=k9 skipLocked failOnMoreRecent str=exclusive
+----
+scan: "k1"-"k9" -> <no data>
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 14.000000000,0 too old; must write at or above 17.000000000,1
+
+run error
+scan ts=14 t=C k=k1 end=k9 reverse skipLocked failOnMoreRecent str=exclusive
+----
+scan: "k1"-"k9" -> <no data>
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 14.000000000,0 too old; must write at or above 17.000000000,1
+
+run ok
+get ts=15 k=k1 skipLocked failOnMoreRecent str=exclusive
+----
+get: "k1" -> /BYTES/v1 @11.000000000,0
+
+run ok
+get ts=15 k=k2 skipLocked failOnMoreRecent str=exclusive
+----
+get: "k2" -> intent {id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
+get: "k2" -> <no data>
+
+run ok
+get ts=15 k=k3 skipLocked failOnMoreRecent str=exclusive
+----
+get: "k3" -> intent {id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0}
+get: "k3" -> <no data>
+
+run ok
+get ts=15 k=k4 skipLocked failOnMoreRecent str=exclusive
+----
+get: "k4" -> intent {id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=16.000000000,0 min=0,0 seq=0}
+get: "k4" -> <no data>
+
+run error
+get ts=15 k=k5 skipLocked failOnMoreRecent str=exclusive
+----
+get: "k5" -> <no data>
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 15.000000000,0 too old; must write at or above 17.000000000,1
+
+run ok
+get ts=15 k=k6 skipLocked failOnMoreRecent str=exclusive
+----
+get: "k6" -> intent {id=00000004 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=15.000000000,0 min=0,0 seq=0}
+get: "k6" -> <no data>
+
+run error
+scan ts=15 k=k1 end=k9 skipLocked failOnMoreRecent str=exclusive
+----
+scan: "k1"-"k9" -> <no data>
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 15.000000000,0 too old; must write at or above 17.000000000,1
+
+run error
+scan ts=15 k=k1 end=k9 reverse skipLocked failOnMoreRecent str=exclusive
+----
+scan: "k1"-"k9" -> <no data>
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 15.000000000,0 too old; must write at or above 17.000000000,1
+
+run ok
+get ts=15 t=D k=k1 skipLocked failOnMoreRecent str=exclusive
+----
+get: "k1" -> /BYTES/v1 @11.000000000,0
+
+run ok
+get ts=15 t=D k=k2 skipLocked failOnMoreRecent str=exclusive
+----
+get: "k2" -> intent {id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
+get: "k2" -> <no data>
+
+run ok
+get ts=15 t=D k=k3 skipLocked failOnMoreRecent str=exclusive
+----
+get: "k3" -> intent {id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0}
+get: "k3" -> <no data>
+
+run ok
+get ts=15 t=D k=k4 skipLocked failOnMoreRecent str=exclusive
+----
+get: "k4" -> intent {id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=16.000000000,0 min=0,0 seq=0}
+get: "k4" -> <no data>
+
+run error
+get ts=15 t=D k=k5 skipLocked failOnMoreRecent str=exclusive
+----
+get: "k5" -> <no data>
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 15.000000000,0 too old; must write at or above 17.000000000,1
+
+run ok
+get ts=15 t=D k=k6 skipLocked failOnMoreRecent str=exclusive
+----
+get: "k6" -> /BYTES/v7 @13.000000000,0
+
+run error
+scan ts=15 t=D k=k1 end=k9 skipLocked failOnMoreRecent str=exclusive
+----
+scan: "k1"-"k9" -> <no data>
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 15.000000000,0 too old; must write at or above 17.000000000,1
+
+run error
+scan ts=15 t=D k=k1 end=k9 reverse skipLocked failOnMoreRecent str=exclusive
+----
+scan: "k1"-"k9" -> <no data>
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 15.000000000,0 too old; must write at or above 17.000000000,1
+
+run ok
+get ts=16 k=k1 skipLocked failOnMoreRecent str=exclusive
+----
+get: "k1" -> /BYTES/v1 @11.000000000,0
+
+run ok
+get ts=16 k=k2 skipLocked failOnMoreRecent str=exclusive
+----
+get: "k2" -> intent {id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
+get: "k2" -> <no data>
+
+run ok
+get ts=16 k=k3 skipLocked failOnMoreRecent str=exclusive
+----
+get: "k3" -> intent {id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0}
+get: "k3" -> <no data>
+
+run ok
+get ts=16 k=k4 skipLocked failOnMoreRecent str=exclusive
+----
+get: "k4" -> intent {id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=16.000000000,0 min=0,0 seq=0}
+get: "k4" -> <no data>
+
+run error
+get ts=16 k=k5 skipLocked failOnMoreRecent str=exclusive
+----
+get: "k5" -> <no data>
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 16.000000000,0 too old; must write at or above 17.000000000,1
+
+run ok
+get ts=16 k=k6 skipLocked failOnMoreRecent str=exclusive
+----
+get: "k6" -> intent {id=00000004 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=15.000000000,0 min=0,0 seq=0}
+get: "k6" -> <no data>
+
+run error
+scan ts=16 k=k1 end=k9 skipLocked failOnMoreRecent str=exclusive
+----
+scan: "k1"-"k9" -> <no data>
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 16.000000000,0 too old; must write at or above 17.000000000,1
+
+run error
+scan ts=16 k=k1 end=k9 reverse skipLocked failOnMoreRecent str=exclusive
+----
+scan: "k1"-"k9" -> <no data>
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 16.000000000,0 too old; must write at or above 17.000000000,1
+
+run ok
+get ts=16 t=E k=k1 skipLocked failOnMoreRecent str=exclusive
+----
+get: "k1" -> /BYTES/v1 @11.000000000,0
+
+run ok
+get ts=16 t=E k=k2 skipLocked failOnMoreRecent str=exclusive
+----
+get: "k2" -> intent {id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
+get: "k2" -> <no data>
+
+run ok
+get ts=16 t=E k=k3 skipLocked failOnMoreRecent str=exclusive
+----
+get: "k3" -> intent {id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0}
+get: "k3" -> <no data>
+
+run ok
+get ts=16 t=E k=k4 skipLocked failOnMoreRecent str=exclusive
+----
+get: "k4" -> /BYTES/v5 @15.000000000,0
+
+run error
+get ts=16 t=E k=k5 skipLocked failOnMoreRecent str=exclusive
+----
+get: "k5" -> <no data>
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 16.000000000,0 too old; must write at or above 17.000000000,1
+
+run ok
+get ts=16 t=E k=k6 skipLocked failOnMoreRecent str=exclusive
+----
+get: "k6" -> intent {id=00000004 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=15.000000000,0 min=0,0 seq=0}
+get: "k6" -> <no data>
+
+run error
+scan ts=16 t=E k=k1 end=k9 skipLocked failOnMoreRecent str=exclusive
+----
+scan: "k1"-"k9" -> <no data>
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 16.000000000,0 too old; must write at or above 17.000000000,1
+
+run error
+scan ts=16 t=E k=k1 end=k9 reverse skipLocked failOnMoreRecent str=exclusive
+----
+scan: "k1"-"k9" -> <no data>
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 16.000000000,0 too old; must write at or above 17.000000000,1
+
+run ok
+get ts=17 k=k1 skipLocked failOnMoreRecent str=exclusive
+----
+get: "k1" -> /BYTES/v1 @11.000000000,0
+
+run ok
+get ts=17 k=k2 skipLocked failOnMoreRecent str=exclusive
+----
+get: "k2" -> intent {id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
+get: "k2" -> <no data>
+
+run ok
+get ts=17 k=k3 skipLocked failOnMoreRecent str=exclusive
+----
+get: "k3" -> intent {id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0}
+get: "k3" -> <no data>
+
+run ok
+get ts=17 k=k4 skipLocked failOnMoreRecent str=exclusive
+----
+get: "k4" -> intent {id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=16.000000000,0 min=0,0 seq=0}
+get: "k4" -> <no data>
+
+run error
+get ts=17 k=k5 skipLocked failOnMoreRecent str=exclusive
+----
+get: "k5" -> <no data>
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 17.000000000,0 too old; must write at or above 17.000000000,1
+
+run ok
+get ts=17 k=k6 skipLocked failOnMoreRecent str=exclusive
+----
+get: "k6" -> intent {id=00000004 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=15.000000000,0 min=0,0 seq=0}
+get: "k6" -> <no data>
+
+run error
+scan ts=17 k=k1 end=k9 skipLocked failOnMoreRecent str=exclusive
+----
+scan: "k1"-"k9" -> <no data>
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 17.000000000,0 too old; must write at or above 17.000000000,1
+
+run error
+scan ts=17 k=k1 end=k9 reverse skipLocked failOnMoreRecent str=exclusive
+----
+scan: "k1"-"k9" -> <no data>
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 17.000000000,0 too old; must write at or above 17.000000000,1
+
+run ok
+get ts=18 k=k1 skipLocked failOnMoreRecent str=exclusive
+----
+get: "k1" -> /BYTES/v1 @11.000000000,0
+
+run ok
+get ts=18 k=k2 skipLocked failOnMoreRecent str=exclusive
+----
+get: "k2" -> intent {id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
+get: "k2" -> <no data>
+
+run ok
+get ts=18 k=k3 skipLocked failOnMoreRecent str=exclusive
+----
+get: "k3" -> intent {id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0}
+get: "k3" -> <no data>
+
+run ok
+get ts=18 k=k4 skipLocked failOnMoreRecent str=exclusive
+----
+get: "k4" -> intent {id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=16.000000000,0 min=0,0 seq=0}
+get: "k4" -> <no data>
+
+run ok
+get ts=18 k=k5 skipLocked failOnMoreRecent str=exclusive
+----
+get: "k5" -> /BYTES/v6 @17.000000000,0
+
+run ok
+get ts=18 k=k6 skipLocked failOnMoreRecent str=exclusive
+----
+get: "k6" -> intent {id=00000004 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=15.000000000,0 min=0,0 seq=0}
+get: "k6" -> <no data>
+
+run ok
+scan ts=18 k=k1 end=k9 skipLocked failOnMoreRecent str=exclusive
+----
+scan: intent "k2" {id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
+scan: intent "k3" {id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0}
+scan: intent "k4" {id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=16.000000000,0 min=0,0 seq=0}
+scan: intent "k6" {id=00000004 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=15.000000000,0 min=0,0 seq=0}
+scan: "k1" -> /BYTES/v1 @11.000000000,0
+scan: "k5" -> /BYTES/v6 @17.000000000,0
+
+run ok
+scan ts=18 k=k1 end=k9 reverse skipLocked failOnMoreRecent str=exclusive
+----
+scan: intent "k6" {id=00000004 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=15.000000000,0 min=0,0 seq=0}
 scan: intent "k4" {id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=16.000000000,0 min=0,0 seq=0}
 scan: intent "k3" {id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0}
 scan: intent "k2" {id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}


### PR DESCRIPTION
Previously, we would infer the lock strength from `failOnMoreRecent`
when determining whether a key was locked by a conflicting transaction
when evaluating a SKIP LOCKED request -- we'd infer it to either be
lock.Exclusive or lock.None. The introduction of shared locks broke
this mapping, as now both lock.Shared and lock.Exclusive locking
requests map to failOnMoreRecent. This patch correctly plumbs down the
correct locking strength for Get/Scan/ReverseScan requests. It then uses
it when constructing a pebbleMVCCScanner, which in-turn uses it to
determine skip locked conflicts (or lack thereof).

Fixes https://github.com/cockroachdb/cockroach/issues/110743

Release note: None