### PR TITLE
kv/kvnemesis: copy value before holding a reference

### DIFF
--- a/pkg/kv/kvnemesis/validator.go
+++ b/pkg/kv/kvnemesis/validator.go
@@ -1383,6 +1383,7 @@ func validReadTimes(
 
 		// Handle a point key - put it into `hist`.
 		valB, err := iter.ValueAndErr()
+		valB = append([]byte{}, valB...)
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
Epic: none
Fixes: https://github.com/cockroachdb/cockroach/issues/110765