### PR TITLE
cli: add a SIGUSR1 handler for abrupt exit

### DIFF
--- a/pkg/cli/exit/codes.go
+++ b/pkg/cli/exit/codes.go
@@ -62,6 +62,12 @@ func LoggingNetCollectorUnavailable() Code { return Code{9} }
 // store's full disk.
 func DiskFull() Code { return Code{10} }
 
+// Killed (138) indicates the server process was terminated with SIGUSR1.
+//
+// Orchestration code should handle this exit code the same way it would handle
+// the process being killed via SIGKILL.
+func Killed() Code { return Code{138} }
+
 // Codes that are specific to client commands follow. It's possible
 // for codes to be reused across separate client or server commands.
 // Command-specific exit codes should be allocated down from 125.

--- a/pkg/cli/start_unix.go
+++ b/pkg/cli/start_unix.go
@@ -50,6 +50,11 @@ var quitSignal os.Signal = unix.SIGQUIT
 // debugSignal is the signal to open a pprof debugging server.
 var debugSignal os.Signal = unix.SIGUSR2
 
+// exitAbruptlySignal is the signal to make the process exit immediately. It is
+// preferable to SIGKILL when running with coverage instrumentation because the
+// coverage profile gets dumped on exit.
+var exitAbruptlySignal os.Signal = unix.SIGUSR1
+
 func handleSignalDuringShutdown(sig os.Signal) {
 	// On Unix, a signal that was not handled gracefully by the application
 	// should be reraised so it is visible in the exit code.

--- a/pkg/cli/start_windows.go
+++ b/pkg/cli/start_windows.go
@@ -29,6 +29,11 @@ var quitSignal os.Signal = nil
 // debugSignal is the signal to open a pprof debugging server.
 var debugSignal os.Signal = nil
 
+// exitAbruptlySignal is the signal to make the process exit immediately. It is
+// preferable to SIGKILL when running with coverage instrumentation because the
+// coverage profile gets dumped on exit.
+var exitAbruptlySignal os.Signal = nil
+
 const backgroundFlagDefined = false
 
 func handleSignalDuringShutdown(os.Signal) {


### PR DESCRIPTION
This commit adds a handler for `SIGUSR1` which exits immediately (with `os.Exit`). This is intended to be used instead of `SIGKILL` when using code coverage instrumentation (which is dumped in an exit hook).

Note that `SIGUSR1` is a termination signal when unhandled, so this doesn't change much functionally.

Epic: none
Release note: None