### PR TITLE
build/release: let `go_version` check be more flexible

### DIFF
--- a/build/release/teamcity-support.sh
+++ b/build/release/teamcity-support.sh
@@ -92,7 +92,7 @@ verify_docker_image(){
     error=1
   fi
   if [[ $fips_build == true ]]; then
-    if [[ "$go_version" != *"fips" ]]; then
+    if [[ "$go_version" != *"fips"* ]]; then
       echo "ERROR: Go version '$go_version' does not contain 'fips'"
       error=1
     fi


### PR DESCRIPTION
This code change lets the check confirm that
`go_version` contains `fips`. Previously, it required that `fips` is a suffix of `go_version`.

Epic: none
Release note: None