### PR TITLE
sql/pg_catalog: indkey for pg_index was implemented incorrectly

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/srfs
+++ b/pkg/sql/logictest/testdata/logic_test/srfs
@@ -867,9 +867,24 @@ CREATE TABLE uu (x INT AS (generate_series(1, 3)) STORED)
 
 subtest correlated_srf
 
+# Initially this table will have 3 columns:
+# x, y, rowid
 statement ok
 CREATE TABLE vals (x INT, y INT, INDEX woo (x, y));
-   INSERT INTO vals VALUES (3, 4), (NULL, NULL), (5, 6);
+
+statement ok
+ALTER TABLE vals DROP COLUMN y cascade;
+
+# Once the second column is and added dropped this table will have the format:
+# x, rowid, y
+statement ok
+ALTER TABLE vals ADD COLUMN y int;
+
+statement ok
+CREATE INDEX woo ON vals(x,y);
+
+statement ok
+INSERT INTO vals VALUES (3, 4), (NULL, NULL), (5, 6);
 
 query III colnames
 SELECT x, generate_series(1,x), generate_series(1,2) FROM vals ORDER BY 1,2,3
@@ -919,16 +934,17 @@ vals       1
 vals       2
 vals       3
 
+# We are going to order by the relname, indexrelid (index's OID), x and n (from pg_expandarray)
 query TT colnames
-SELECT relname, information_schema._pg_expandarray(indkey) FROM pg_class, pg_index WHERE pg_class.oid = pg_index.indrelid ORDER BY relname, x, n
+SELECT relname, information_schema._pg_expandarray(indkey) FROM pg_class, pg_index WHERE pg_class.oid = pg_index.indrelid ORDER BY relname, indexrelid, x, n
 ----
 relname    information_schema._pg_expandarray
 ordered_t  (1,1)
 t          (2,1)
 u          (2,1)
+vals       (2,1)
 vals       (1,1)
-vals       (2,2)
-vals       (3,1)
+vals       (3,2)
 
 # The following query needs indclass to become an oidvector.
 # See bug #26504.

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -1811,6 +1811,11 @@ https://www.postgresql.org/docs/9.5/catalog-pg-index.html`,
 		return forEachTableDesc(ctx, p, dbContext, hideVirtual, /* virtual tables do not have indexes */
 			func(db catalog.DatabaseDescriptor, sc catalog.SchemaDescriptor, table catalog.TableDescriptor) error {
 				tableOid := tableOid(table.GetID())
+
+				// Generate a map to determine the position of a column ID for creating
+				// the indkey.
+				colToOrdinal := catalog.ColumnIDToOrdinalMap(table.PublicColumns())
+
 				return catalog.ForEachIndex(table, catalog.IndexOpts{}, func(index catalog.Index) error {
 					isMutation, isWriteOnly :=
 						table.GetIndexMutationCapabilities(index.GetID())
@@ -1843,7 +1848,7 @@ https://www.postgresql.org/docs/9.5/catalog-pg-index.html`,
 							}
 							exprs = append(exprs, fmt.Sprintf("(%s)", formattedExpr))
 						} else {
-							colIDs = append(colIDs, columnID)
+							colIDs = append(colIDs, descpb.ColumnID(colToOrdinal.GetDefault(col.GetID())+1))
 						}
 						if err := collationOids.Append(typColl(col.GetType(), h)); err != nil {
 							return err
@@ -1863,7 +1868,7 @@ https://www.postgresql.org/docs/9.5/catalog-pg-index.html`,
 					// indnkeyatts is the number of attributes without INCLUDED columns.
 					indnkeyatts := len(colIDs)
 					for i := 0; i < index.NumSecondaryStoredColumns(); i++ {
-						colIDs = append(colIDs, index.GetStoredColumnID(i))
+						colIDs = append(colIDs, descpb.ColumnID(colToOrdinal.GetDefault(index.GetStoredColumnID(i))+1))
 					}
 					// indnatts is the number of attributes with INCLUDED columns.
 					indnatts := len(colIDs)


### PR DESCRIPTION
Previously, the indkey column for pg_index incorrectly returned the internal column IDs used by CRDB. This field was supposed to be the position of the column used by the index. The internal column IDs could end up with gaps or be sparse after a table goes through a schema change. To address this, this patch fixes indkey to be based on column positions.

Fixes: #110545

Release note (bug fix): The indkey column in pg_index was incorrectly implemented, so the returned value was improper after a table had undergone any DROP column operation.