### PR TITLE
sql: disallow explicit unique checks under read committed isolation

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_read_committed
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_read_committed
@@ -48,71 +48,155 @@ CREATE TABLE volcano (
 )
 LOCALITY REGIONAL BY ROW AS region
 
-# TODO(michae2): statement ok
-statement error pgcode 0A000 guaranteed-durable locking not yet implemented
+# Create a table without a unique constraint.
+
+statement ok
+CREATE TABLE city (
+  name STRING NOT NULL,
+  nickname STRING NOT NULL,
+  state_or_province CHAR(2) NOT NULL,
+  region crdb_internal_region NOT NULL AS (
+    CASE
+      WHEN lower(state_or_province) = 'or' THEN 'ca-central-1'   -- Oregon
+      WHEN lower(state_or_province) = 'wa' THEN 'ap-southeast-2' -- Washington
+      ELSE 'us-east-1'                                           -- British Columbia
+    END
+  ) STORED,
+  PRIMARY KEY (name, state_or_province),
+  FAMILY (name, nickname, state_or_province, region)
+)
+LOCALITY REGIONAL BY ROW AS region
+
+# Create a table with region included in all unique constraints.
+
+statement ok
+CREATE TABLE river (
+  region crdb_internal_region NOT NULL,
+  name STRING NOT NULL,
+  outlet STRING NOT NULL,
+  PRIMARY KEY (region, name),
+  UNIQUE INDEX (region, outlet),
+  FAMILY (region, name, outlet)
+)
+LOCALITY REGIONAL BY ROW AS region
+
+# Test non-conflicting INSERT.
+
+statement error pgcode 0A000 explicit unique checks are not yet supported under read committed isolation
 INSERT INTO university (name, mascot, postal_code) VALUES ('Western Oregon', 'wolves', '97361')
 
-# TODO(michae2): statement ok
-statement error pgcode 0A000 guaranteed-durable locking not yet implemented
+statement error pgcode 0A000 explicit unique checks are not yet supported under read committed isolation
 INSERT INTO volcano
 VALUES ('Mount Hood', 'Fought over Loowit and was transformed by Saghalie.', 'POINT(-121.695833 45.373611)', 'ca-central-1')
 
-# TODO(michae2): statement error pgcode 23505 pq: duplicate key value violates unique constraint "university_mascot_key"\nDETAIL: Key \(mascot\)=\('wolves'\) already exists.
-statement error pgcode 0A000 guaranteed-durable locking not yet implemented
+statement ok
+INSERT INTO city VALUES ('Vancouver', 'Hollywood North', 'BC')
+
+statement ok
+INSERT INTO river VALUES ('ap-southeast-2', 'Skykomish', 'Snohomish')
+
+# Test conflicting INSERT.
+
+statement error pgcode 0A000 explicit unique checks are not yet supported under read committed isolation
 INSERT INTO university (name, mascot, postal_code) VALUES ('Thompson Rivers', 'wolves', 'V2C 0C8')
 
-# TODO(michae2): statement error pgcode 23505 pq: duplicate key value violates unique constraint "volcano_origin_key"\nDETAIL: Key \(origin\)=\('Fought over Loowit and was transformed by Saghalie.'\) already exists.
-statement error pgcode 0A000 guaranteed-durable locking not yet implemented
+statement error pgcode 0A000 explicit unique checks are not yet supported under read committed isolation
 INSERT INTO volcano VALUES
 ('Mount Adams', 'Fought over Loowit and was transformed by Saghalie.', 'POINT(-121.490895 46.202412)', 'ap-southeast-2')
 
-# TODO(michae2): statement ok
-statement error pgcode 0A000 guaranteed-durable locking not yet implemented
+statement error pgcode 23505 pq: duplicate key value violates unique constraint "city_pkey"\nDETAIL: Key \(name, state_or_province\)=\('Vancouver', 'BC'\) already exists\.
+INSERT INTO city VALUES ('Vancouver', 'The ''Couve', 'BC')
+
+statement error pgcode 23505 pq: duplicate key value violates unique constraint "river_pkey"\nDETAIL: Key \(region, name\)=\('ap-southeast-2', 'Skykomish'\) already exists\.
+INSERT INTO river VALUES ('ap-southeast-2', 'Skykomish', 'Snoqualmie')
+
+# Test conflicting INSERT ON CONFLICT DO NOTHING.
+
+statement error pgcode 0A000 explicit unique checks are not yet supported under read committed isolation
 INSERT INTO university (name, mascot, postal_code)
 VALUES ('Thompson Rivers', 'wolves', 'V2C 0C8'), ('Evergreen State', 'geoducks', '98505')
 ON CONFLICT (mascot) DO NOTHING
 
-# TODO(michae2): statement ok
-statement error pgcode 0A000 guaranteed-durable locking not yet implemented
+query TTT
+SELECT name, mascot, postal_code FROM university ORDER BY name
+----
+
+statement error pgcode 0A000 explicit unique checks are not yet supported under read committed isolation
 INSERT INTO volcano VALUES
 ('Mount Adams', 'Fought over Loowit and was transformed by Saghalie.', 'POINT(-121.490895 46.202412)', 'ap-southeast-2'),
 ('Mount St. Helens', 'Fair maiden Loowit could not choose between Wyeast and Pahto and was transformed by Saghalie.', 'POINT(-122.1944 46.1912)', 'ap-southeast-2')
 ON CONFLICT (origin) DO NOTHING
 
 query TTT
-SELECT name, mascot, postal_code FROM university ORDER BY name
-----
-
-query TTT
 SELECT name, origin, location FROM volcano ORDER BY name
 ----
 
-# TODO(michae2): statement error pgcode 23505 pq: duplicate key value violates unique constraint "university_mascot_key"\nDETAIL: Key \(mascot\)=\('wolves'\) already exists.
-statement error pgcode 0A000 guaranteed-durable locking not yet implemented
+statement ok
+INSERT INTO city VALUES ('Vancouver', 'The Big Smoke', 'BC'), ('Salem', 'Cherry City', 'OR')
+ON CONFLICT (name, state_or_province) DO NOTHING
+
+query TTT
+SELECT name, nickname, state_or_province FROM city ORDER BY name
+----
+Salem      Cherry City      OR
+Vancouver  Hollywood North  BC
+
+statement ok
+INSERT INTO river VALUES ('ap-southeast-2', 'Snoqualmie', 'Snohomish'), ('us-east-1', 'Fraser', 'Strait of Georgia')
+ON CONFLICT (region, outlet) DO NOTHING
+
+query TTT
+SELECT region, name, outlet FROM river ORDER BY region, name
+----
+ap-southeast-2  Skykomish  Snohomish
+us-east-1       Fraser     Strait of Georgia
+
+# Test conflicting UPSERT.
+
+statement error pgcode 0A000 explicit unique checks are not yet supported under read committed isolation
 UPSERT INTO university (name, mascot, postal_code) VALUES ('Thompson Rivers', 'wolves', 'V2C 0C8')
 
-# TODO(michae2): statement error pgcode 23505 pq: duplicate key value violates unique constraint "volcano_origin_key"\nDETAIL: Key \(origin\)=\('Fought over Loowit and was transformed by Saghalie.'\) already exists.
-statement error pgcode 0A000 guaranteed-durable locking not yet implemented
+statement error pgcode 0A000 explicit unique checks are not yet supported under read committed isolation
 UPSERT INTO volcano VALUES
 ('Mount Adams', 'Fought over Loowit and was transformed by Saghalie.', 'POINT(-121.490895 46.202412)', 'ap-southeast-2')
 
-# TODO(michae2): statement error pgcode 23505 pq: duplicate key value violates unique constraint "university_mascot_key"\nDETAIL: Key \(mascot\)=\('wolves'\) already exists.
-statement error pgcode 0A000 guaranteed-durable locking not yet implemented
+statement ok
+UPSERT INTO city VALUES ('Vancouver', 'The Big Smoke', 'BC')
+
+statement ok
+UPSERT INTO river VALUES ('us-east-1', 'Fraser', 'Salish Sea')
+
+# Test conflicting UPDATE.
+
+statement error pgcode 0A000 explicit unique checks are not yet supported under read committed isolation
 UPDATE university SET mascot = 'wolves' WHERE name = 'Evergreen State'
 
-# TODO(michae2): statement error pgcode 23505 pq: duplicate key value violates unique constraint "volcano_origin_key"\nDETAIL: Key \(origin\)=\('Fought over Loowit and was transformed by Saghalie.'\) already exists.
-statement error pgcode 0A000 guaranteed-durable locking not yet implemented
+statement error pgcode 0A000 explicit unique checks are not yet supported under read committed isolation
 UPDATE volcano SET origin = 'Fought over Loowit and was transformed by Saghalie.' WHERE name = 'Mount St. Helens'
 
-# TODO(michae2): statement error pgcode 23505 pq: duplicate key value violates unique constraint "university_pkey"\nDETAIL: Key \(name\)=\('Evergreen State'\) already exists.
-statement error pgcode 0A000 guaranteed-durable locking not yet implemented
+statement error pgcode 23505 pq: duplicate key value violates unique constraint "city_pkey"\nDETAIL: Key \(name, state_or_province\)=\('Vancouver', 'BC'\) already exists\.
+UPDATE city SET name = 'Vancouver', state_or_province = 'BC' WHERE name = 'Salem'
+
+statement error pgcode 23505 pq: duplicate key value violates unique constraint "river_region_outlet_key"\nDETAIL: Key \(region, outlet\)=\('us-east-1', 'Salish Sea'\) already exists\.
+UPDATE river SET region = 'us-east-1', outlet = 'Salish Sea' WHERE name = 'Skykomish'
+
+# Test conflicting INSERT ON CONFLICT DO UPDATE.
+
+statement error pgcode 0A000 explicit unique checks are not yet supported under read committed isolation
 INSERT INTO university (name, mascot, postal_code)
 VALUES ('Thompson Rivers', 'wolves', 'V2C 0C8'), ('Oregon Tech', 'owls', '97601')
 ON CONFLICT (mascot) DO UPDATE SET name = 'Evergreen State', mascot = 'banana slugs'
 
-# TODO(michae2): statement error pgcode 23505 pq: duplicate key value violates unique constraint "volcano_pkey"\nDETAIL: Key \(name\)=\('Mount St. Helens'\) already exists.
-statement error pgcode 0A000 guaranteed-durable locking not yet implemented
+statement error pgcode 0A000 explicit unique checks are not yet supported under read committed isolation
 INSERT INTO volcano VALUES
 ('Mount Adams', 'Fought over Loowit and was transformed by Saghalie.', 'POINT(-121.490895 46.202412)', 'ap-southeast-2'),
 ('Mount Garibaldi', 'Lightning from thunderbird eyes struck the ground.', 'POINT(-123.004722 49.850278)', 'us-east-1')
 ON CONFLICT (origin) DO UPDATE SET name = 'Mount St. Helens', origin = 'Discovered by the Vancouver expedition in 1792.', region = 'us-east-1'
+
+statement error pgcode 23505 pq: duplicate key value violates unique constraint "city_pkey"\nDETAIL: Key \(name, state_or_province\)=\('Vancouver', 'BC'\) already exists\.
+INSERT INTO city VALUES ('Seattle', 'The Emerald City', 'WA'), ('Salem', 'The Witch City', 'OR')
+ON CONFLICT (name, state_or_province) DO UPDATE SET name = 'Vancouver', nickname = 'Land of the mud-turtles', state_or_province = 'BC'
+
+statement error pgcode 23505 pq: duplicate key value violates unique constraint "river_pkey"\nDETAIL: Key \(region, name\)=\('ap-southeast-2', 'Skykomish'\) already exists\.
+INSERT INTO river VALUES ('us-east-1', 'Squamish', 'Salish Sea'), ('ca-central-1', 'Rogue', 'Pacific Ocean')
+ON CONFLICT (region, outlet) DO UPDATE SET region = 'ap-southeast-2', name = 'Skykomish', outlet = 'Puget Sound'

--- a/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
@@ -968,6 +968,13 @@ func TestTenantLogic_hash_sharded_index(
 	runLogicTest(t, "hash_sharded_index")
 }
 
+func TestTenantLogic_hash_sharded_index_read_committed(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "hash_sharded_index_read_committed")
+}
+
 func TestTenantLogic_hidden_columns(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/testdata/logic_test/hash_sharded_index_read_committed
+++ b/pkg/sql/logictest/testdata/logic_test/hash_sharded_index_read_committed
@@ -1,0 +1,27 @@
+# LogicTest: !local-mixed-22.2-23.1
+
+statement ok
+SET CLUSTER SETTING sql.txn.read_committed_syntax.enabled = true
+
+statement ok
+SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL READ COMMITTED
+
+statement ok
+CREATE TABLE sharded_primary (
+  a INT NOT NULL,
+  PRIMARY KEY (a) USING HASH
+)
+
+statement ok
+CREATE TABLE sharded_unique (
+  a INT NOT NULL
+)
+
+statement ok
+CREATE UNIQUE INDEX ON sharded_unique (a) USING HASH
+
+statement ok
+INSERT INTO sharded_primary VALUES (1)
+
+statement ok
+INSERT INTO sharded_unique VALUES (1)

--- a/pkg/sql/logictest/testdata/logic_test/unique_read_committed
+++ b/pkg/sql/logictest/testdata/logic_test/unique_read_committed
@@ -28,20 +28,21 @@ CREATE TABLE voyage (
 statement ok
 SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL READ COMMITTED
 
-# TODO(michae2): statement ok
-statement error pgcode 0A000 guaranteed-durable locking not yet implemented
+# Test non-conflicting INSERT.
+
+statement error pgcode 0A000 explicit unique checks are not yet supported under read committed isolation
 INSERT INTO voyage VALUES ('caspian', 'hercules', 'argonauts', 'golden fleece')
+
+# Test the (quest, crew) uniqueness constraint.
 
 # The Argonauts searching for the golden fleece should fail the (quest, crew)
 # uniqueness check, even with a different sea.
-# TODO(michae2): statement error pgcode 23505 pq: duplicate key value violates unique constraint "unique_quest_crew"\nDETAIL: Key \(crew, quest\)=\('argonauts', 'golden fleece'\) already exists.
-statement error pgcode 0A000 guaranteed-durable locking not yet implemented
+statement error pgcode 0A000 explicit unique checks are not yet supported under read committed isolation
 INSERT INTO voyage
 VALUES (DEFAULT, 'odysseus', 'nobody', 'penelope'), ('black', 'jason', 'argonauts', 'golden fleece')
 
 # Only Odysseus should be inserted.
-# TODO(michae2): statement ok
-statement error pgcode 0A000 guaranteed-durable locking not yet implemented
+statement error pgcode 0A000 explicit unique checks are not yet supported under read committed isolation
 INSERT INTO voyage
 VALUES ('mediterranean', 'odysseus', 'nobody', 'penelope'), ('black', 'jason', 'argonauts', 'golden fleece')
 ON CONFLICT (quest, crew) DO NOTHING
@@ -50,14 +51,14 @@ query TTTT
 SELECT * FROM voyage ORDER BY hero, crew, quest
 ----
 
+# Test the (hero) uniqueness constraint.
+
 # Hercules should fail the (hero) uniqueness check, even with a different sea.
-# TODO(michae2): statement error pgcode 23505 pq: duplicate key value violates unique constraint "unique_hero"\nDETAIL: Key \(hero\)=\('hercules'\) already exists.
-statement error pgcode 0A000 guaranteed-durable locking not yet implemented
+statement error pgcode 0A000 explicit unique checks are not yet supported under read committed isolation
 INSERT INTO voyage (hero, quest) VALUES ('perseus', 'medusa'), ('hercules', 'geryon')
 
 # Only Perseus should be inserted.
-# TODO(michae2): statement ok
-statement error pgcode 0A000 guaranteed-durable locking not yet implemented
+statement error pgcode 0A000 explicit unique checks are not yet supported under read committed isolation
 INSERT INTO voyage (hero, quest) VALUES ('perseus', 'medusa'), ('hercules', 'geryon')
 ON CONFLICT (hero) DO NOTHING
 
@@ -65,29 +66,29 @@ query TTTT
 SELECT * FROM voyage ORDER BY hero, crew, quest
 ----
 
-# TODO(michae2): statement error pgcode 23505 pq: duplicate key value violates unique constraint "unique_quest_crew"\nDETAIL: Key \(crew, quest\)=\('argonauts', 'golden fleece'\) already exists.
-statement error pgcode 0A000 guaranteed-durable locking not yet implemented
+# Test conflicting UPSERT.
+
+statement error pgcode 0A000 explicit unique checks are not yet supported under read committed isolation
 UPSERT INTO voyage VALUES ('black', 'jason', 'argonauts', 'golden fleece')
 
-# TODO(michae2): statement error pgcode 23505 pq: duplicate key value violates unique constraint "unique_hero"\nDETAIL: Key \(hero\)=\('hercules'\) already exists.
-statement error pgcode 0A000 guaranteed-durable locking not yet implemented
+statement error pgcode 0A000 explicit unique checks are not yet supported under read committed isolation
 UPSERT INTO voyage (hero, quest) VALUES ('hercules', 'geryon')
 
-# TODO(michae2): statement error pgcode 23505 pq: duplicate key value violates unique constraint "unique_quest_crew"\nDETAIL: Key \(crew, quest\)=\('argonauts', 'golden fleece'\) already exists.
-statement error pgcode 0A000 guaranteed-durable locking not yet implemented
+# Test conflicting UPDATE.
+
+statement error pgcode 0A000 explicit unique checks are not yet supported under read committed isolation
 UPDATE voyage SET crew = 'argonauts', quest = 'golden fleece' WHERE hero = 'perseus'
 
-# TODO(michae2): statement error pgcode 23505 pq: duplicate key value violates unique constraint "unique_hero"\nDETAIL: Key \(hero\)=\('hercules'\) already exists.
-statement error pgcode 0A000 guaranteed-durable locking not yet implemented
+statement error pgcode 0A000 explicit unique checks are not yet supported under read committed isolation
 UPDATE voyage SET hero = 'hercules' WHERE hero = 'odysseus'
 
-# TODO(michae2): statement error pgcode 23505 pq: duplicate key value violates unique constraint "unique_quest_crew"\nDETAIL: Key \(crew, quest\)=\('nobody', 'penelope'\) already exists.
-statement error pgcode 0A000 guaranteed-durable locking not yet implemented
+# Test conflicting INSERT ON CONFLICT DO UPDATE.
+
+statement error pgcode 0A000 explicit unique checks are not yet supported under read committed isolation
 INSERT INTO voyage VALUES ('black', 'jason', 'argonauts', 'golden fleece')
 ON CONFLICT (quest, crew) DO UPDATE SET quest = 'penelope', crew = 'nobody'
 
-# TODO(michae2): statement error pgcode 23505 pq: duplicate key value violates unique constraint "unique_hero"\nDETAIL: Key \(hero\)=\('perseus'\) already exists.
-statement error pgcode 0A000 guaranteed-durable locking not yet implemented
+statement error pgcode 0A000 explicit unique checks are not yet supported under read committed isolation
 INSERT INTO voyage (hero, quest) VALUES ('hercules', 'geryon')
 ON CONFLICT (hero) DO UPDATE SET hero = 'perseus'
 
@@ -104,5 +105,5 @@ CREATE TABLE titan (
   FAMILY (name, domain, children)
 )
 
-statement error pgcode 0A000 guaranteed-durable locking not yet implemented
+statement error pgcode 0A000 explicit unique checks are not yet supported under read committed isolation
 INSERT INTO titan VALUES ('cronus', 'time', ARRAY['zeus', 'hera', 'hades', 'poseidon', 'demeter', 'hestia'])

--- a/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
@@ -939,6 +939,13 @@ func TestLogic_hash_sharded_index(
 	runLogicTest(t, "hash_sharded_index")
 }
 
+func TestLogic_hash_sharded_index_read_committed(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "hash_sharded_index_read_committed")
+}
+
 func TestLogic_hidden_columns(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
@@ -939,6 +939,13 @@ func TestLogic_hash_sharded_index(
 	runLogicTest(t, "hash_sharded_index")
 }
 
+func TestLogic_hash_sharded_index_read_committed(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "hash_sharded_index_read_committed")
+}
+
 func TestLogic_hidden_columns(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist/generated_test.go
@@ -946,6 +946,13 @@ func TestLogic_hash_sharded_index(
 	runLogicTest(t, "hash_sharded_index")
 }
 
+func TestLogic_hash_sharded_index_read_committed(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "hash_sharded_index_read_committed")
+}
+
 func TestLogic_hidden_columns(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
+++ b/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
@@ -932,6 +932,13 @@ func TestLogic_hash_sharded_index(
 	runLogicTest(t, "hash_sharded_index")
 }
 
+func TestLogic_hash_sharded_index_read_committed(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "hash_sharded_index_read_committed")
+}
+
 func TestLogic_hidden_columns(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/local-vec-off/generated_test.go
@@ -953,6 +953,13 @@ func TestLogic_hash_sharded_index(
 	runLogicTest(t, "hash_sharded_index")
 }
 
+func TestLogic_hash_sharded_index_read_committed(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "hash_sharded_index_read_committed")
+}
+
 func TestLogic_hidden_columns(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local/generated_test.go
+++ b/pkg/sql/logictest/tests/local/generated_test.go
@@ -1037,6 +1037,13 @@ func TestLogic_hash_sharded_index(
 	runLogicTest(t, "hash_sharded_index")
 }
 
+func TestLogic_hash_sharded_index_read_committed(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "hash_sharded_index_read_committed")
+}
+
 func TestLogic_hidden_columns(
 	t *testing.T,
 ) {

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -2911,6 +2911,11 @@ func (b *Builder) buildLocking(locking opt.Locking) (opt.Locking, error) {
 				"cannot execute %s in a read-only transaction", locking.Strength.String(),
 			)
 		}
+		if locking.Form == tree.LockPredicate {
+			return opt.Locking{}, unimplemented.NewWithIssuef(
+				110873, "explicit unique checks are not yet supported under read committed isolation",
+			)
+		}
 		if locking.Durability == tree.LockDurabilityGuaranteed {
 			return opt.Locking{}, unimplemented.NewWithIssuef(
 				100193, "guaranteed-durable locking not yet implemented",

--- a/pkg/sql/opt/optbuilder/arbiter_set.go
+++ b/pkg/sql/opt/optbuilder/arbiter_set.go
@@ -107,9 +107,15 @@ func (a *arbiterSet) ContainsUniqueConstraint(uniq cat.UniqueOrdinal) bool {
 //     constraint's table.
 //   - uniqueWithoutIndex is true if this is a unique constraint enforced
 //     without an index.
+//   - uniqueOrd is the ordinal of the unique constraint (-1 for index arbiters).
 func (a *arbiterSet) ForEach(
 	f func(
-		name string, conflictOrds intsets.Fast, pred tree.Expr, canaryOrd int, uniqueWithoutIndex bool,
+		name string,
+		conflictOrds intsets.Fast,
+		pred tree.Expr,
+		canaryOrd int,
+		uniqueWithoutIndex bool,
+		uniqueOrd int,
 	),
 ) {
 	// Call the callback for each index arbiter.
@@ -124,7 +130,7 @@ func (a *arbiterSet) ForEach(
 			pred = a.mb.parsePartialIndexPredicateExpr(i)
 		}
 
-		f(string(index.Name()), conflictOrds, pred, canaryOrd, false)
+		f(string(index.Name()), conflictOrds, pred, canaryOrd, false, -1)
 	})
 
 	// Call the callback for each unique constraint arbiter.
@@ -139,7 +145,7 @@ func (a *arbiterSet) ForEach(
 			pred = a.mb.parseUniqueConstraintPredicateExpr(i)
 		}
 
-		f(uniqueConstraint.Name(), conflictOrds, pred, canaryOrd, uniqueConstraint.WithoutIndex())
+		f(uniqueConstraint.Name(), conflictOrds, pred, canaryOrd, uniqueConstraint.WithoutIndex(), i)
 	})
 }
 

--- a/pkg/sql/opt/optbuilder/insert.go
+++ b/pkg/sql/opt/optbuilder/insert.go
@@ -712,16 +712,16 @@ func (mb *mutationBuilder) buildInputForDoNothing(inScope *scope, onConflict *tr
 
 	// Create an anti-join for each arbiter.
 	mb.arbiters.ForEach(func(
-		name string, conflictOrds intsets.Fast, pred tree.Expr, canaryOrd int, uniqueWithoutIndex bool,
+		name string, conflictOrds intsets.Fast, pred tree.Expr, canaryOrd int, uniqueWithoutIndex bool, uniqueOrd int,
 	) {
-		mb.buildAntiJoinForDoNothingArbiter(inScope, conflictOrds, pred, uniqueWithoutIndex)
+		mb.buildAntiJoinForDoNothingArbiter(inScope, conflictOrds, pred, uniqueWithoutIndex, uniqueOrd)
 	})
 
 	// Create an UpsertDistinctOn for each arbiter. This must happen after all
 	// conflicting rows are removed with the anti-joins created above, to avoid
 	// removing valid rows (see #59125).
 	mb.arbiters.ForEach(func(
-		name string, conflictOrds intsets.Fast, pred tree.Expr, canaryOrd int, uniqueWithoutIndex bool,
+		name string, conflictOrds intsets.Fast, pred tree.Expr, canaryOrd int, uniqueWithoutIndex bool, uniqueOrd int,
 	) {
 		// If the arbiter has a partial predicate, project a new column that
 		// allows the UpsertDistinctOn to only de-duplicate insert rows that
@@ -769,7 +769,7 @@ func (mb *mutationBuilder) buildInputForUpsert(
 	// Create an UpsertDistinctOn and a left-join for the single arbiter.
 	var canaryCol *scopeColumn
 	mb.arbiters.ForEach(func(
-		name string, conflictOrds intsets.Fast, pred tree.Expr, canaryOrd int, uniqueWithoutIndex bool,
+		name string, conflictOrds intsets.Fast, pred tree.Expr, canaryOrd int, uniqueWithoutIndex bool, uniqueOrd int,
 	) {
 		// If the arbiter has a partial predicate, project a new column that
 		// allows the UpsertDistinctOn to only de-duplicate insert rows that
@@ -800,7 +800,7 @@ func (mb *mutationBuilder) buildInputForUpsert(
 
 		// Create a left-join for the arbiter.
 		mb.buildLeftJoinForUpsertArbiter(
-			inScope, conflictOrds, pred, uniqueWithoutIndex,
+			inScope, conflictOrds, pred, uniqueWithoutIndex, uniqueOrd,
 		)
 
 		// Record a not-null "canary" column. After the left-join, this will be


### PR DESCRIPTION
(This is a follow-on PR after #107961.)

Because we do not yet support predicate locking, add a check to execbuilder that disallows any query using it (currently only unique checks under read committed isolation).

Informs: #110873

Release note (sql): We do not yet support explicit unique checks under Read Committed isolation. This means that some `INSERT`, `UPDATE`, and `UPSERT` statements against some `REGIONAL BY ROW` tables will fail under Read Committed isolation with the following error:

```
unimplemented: explicit unique checks are not yet supported under read committed isolation
SQLSTATE: 0A000
```

For more details about which `REGIONAL BY ROW` tables are affected, please see: https://go.crdb.dev/issue-v/110873/v23.2