### PR TITLE
kvserver: deflake `TestRangefeedCheckpointsRecoverFromLeaseExpiration`

### DIFF
--- a/pkg/kv/kvserver/replica_rangefeed_test.go
+++ b/pkg/kv/kvserver/replica_rangefeed_test.go
@@ -1312,6 +1312,7 @@ func TestRangefeedCheckpointsRecoverFromLeaseExpiration(t *testing.T) {
 				WallClock: manualClock,
 			},
 			Store: &kvserver.StoreTestingKnobs{
+				DisableMaxOffsetCheck: true, // has been seen to cause flakes
 				TestingRequestFilter: func(ctx context.Context, ba *kvpb.BatchRequest) *kvpb.Error {
 					// Once reject is set, the test wants full control over the requests
 					// evaluating on the scratch range. On that range, we'll reject


### PR DESCRIPTION
Messing with the clocks can trip clock offset checks with an ill-timed request. Disable them.

Resolves #110804.
Epic: none
Release note: None