### PR TITLE
sql, insights: record failed transactions due to commit

### DIFF
--- a/pkg/sql/sqlstats/insights/registry_test.go
+++ b/pkg/sql/sqlstats/insights/registry_test.go
@@ -43,9 +43,9 @@ func TestRegistry(t *testing.T) {
 	ctx := context.Background()
 
 	session := Session{ID: clusterunique.IDFromBytes([]byte("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"))}
-	transaction := &Transaction{ID: uuid.FastMakeV4()}
 
 	t.Run("slow detection", func(t *testing.T) {
+		transaction := &Transaction{ID: uuid.FastMakeV4()}
 		statement := &Statement{
 			Status:           Statement_Completed,
 			ID:               clusterunique.IDFromBytes([]byte("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")),
@@ -80,6 +80,9 @@ func TestRegistry(t *testing.T) {
 	})
 
 	t.Run("failure detection", func(t *testing.T) {
+		// Verify that statement error info gets bubbled up to the transaction
+		// when the transaction does not have this information.
+		transaction := &Transaction{ID: uuid.FastMakeV4()}
 		statement := &Statement{
 			ID:               clusterunique.IDFromBytes([]byte("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")),
 			FingerprintID:    appstatspb.StmtFingerprintID(100),
@@ -94,6 +97,11 @@ func TestRegistry(t *testing.T) {
 		store := newStore(st)
 		registry := newRegistry(st, &latencyThresholdDetector{st: st}, store)
 		registry.ObserveStatement(session.ID, statement)
+		// Transaction status is set during transaction stats recorded based on
+		// if the transaction committed. We'll inject the failure here to align
+		// it with the test. The insights integration tests will verify that this
+		// field is set properly.
+		transaction.Status = Transaction_Failed
 		registry.ObserveTransaction(session.ID, transaction)
 
 		expected := []*Insight{{
@@ -119,6 +127,7 @@ func TestRegistry(t *testing.T) {
 	})
 
 	t.Run("disabled", func(t *testing.T) {
+		transaction := &Transaction{ID: uuid.FastMakeV4()}
 		statement := &Statement{
 			Status:           Statement_Completed,
 			ID:               clusterunique.IDFromBytes([]byte("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")),
@@ -143,6 +152,7 @@ func TestRegistry(t *testing.T) {
 	})
 
 	t.Run("too fast", func(t *testing.T) {
+		transaction := &Transaction{ID: uuid.FastMakeV4()}
 		st := cluster.MakeTestingClusterSettings()
 		LatencyThreshold.Override(ctx, &st.SV, 1*time.Second)
 		statement2 := &Statement{
@@ -166,6 +176,7 @@ func TestRegistry(t *testing.T) {
 	})
 
 	t.Run("buffering statements per session", func(t *testing.T) {
+		transaction := &Transaction{ID: uuid.FastMakeV4()}
 		statement := &Statement{
 			Status:           Statement_Completed,
 			ID:               clusterunique.IDFromBytes([]byte("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")),
@@ -219,6 +230,7 @@ func TestRegistry(t *testing.T) {
 	})
 
 	t.Run("sibling statements without problems", func(t *testing.T) {
+		transaction := &Transaction{ID: uuid.FastMakeV4()}
 		statement := &Statement{
 			Status:           Statement_Completed,
 			ID:               clusterunique.IDFromBytes([]byte("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")),
@@ -261,12 +273,14 @@ func TestRegistry(t *testing.T) {
 	})
 
 	t.Run("txn with no stmts", func(t *testing.T) {
+		transaction := &Transaction{ID: uuid.FastMakeV4()}
 		st := cluster.MakeTestingClusterSettings()
 		registry := newRegistry(st, &latencyThresholdDetector{st: st}, newStore(st))
 		require.NotPanics(t, func() { registry.ObserveTransaction(session.ID, transaction) })
 	})
 
 	t.Run("txn with high accumulated contention without high single stmt contention", func(t *testing.T) {
+		transaction := &Transaction{ID: uuid.FastMakeV4()}
 		st := cluster.MakeTestingClusterSettings()
 		store := newStore(st)
 		registry := newRegistry(st, &latencyThresholdDetector{st: st}, store)
@@ -310,6 +324,7 @@ func TestRegistry(t *testing.T) {
 	})
 
 	t.Run("statement that is slow but should be ignored", func(t *testing.T) {
+		transaction := &Transaction{ID: uuid.FastMakeV4()}
 		statementNotIgnored := &Statement{
 			Status:           Statement_Completed,
 			ID:               clusterunique.IDFromBytes([]byte("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")),

--- a/pkg/sql/sqlstats/ssprovider.go
+++ b/pkg/sql/sqlstats/ssprovider.go
@@ -251,4 +251,5 @@ type RecordedTxnStats struct {
 	BytesRead               int64
 	Priority                roachpb.UserPriority
 	SessionData             *sessiondata.SessionData
+	TxnErr                  error
 }


### PR DESCRIPTION
Previously we did not record failed transactions due to a failed
commit in the insights system. This commit captures those transactions
in the insights system by propagating the payload error associated with
a failed commit to the stats recording step. If the transaction error
is nil, we will attempt to find the last statement error for scenarios
where the error is not propagated to the payload of TxnCommit/Aborted
states.

In addition, the `Status` (completed or failed) of a txn is now based
on whether the transaction has committed at the time of insights recording.
Previously it was also based on the presence of failed stmts.

Fixes: https://github.com/cockroachdb/cockroach/issues/110846

Release note (ui change): In the Insights page in DB Console, users can now see
failed transactions and their error messages when the transaction fails on the
COMMIT stage.

<img width="1909" alt="Pasted Graphic" src="https://github.com/cockroachdb/cockroach/assets/20136951/c75ca5b2-5c19-4f24-b66f-a0e1df381d9c">
