### PR TITLE
sql: fix builtin format_type for array types

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -3976,7 +3976,8 @@ CREATE TABLE default_arrays (
   id INT8 NOT NULL PRIMARY KEY,
   string_array text[] DEFAULT '{cat, dog}',
   weird_array text[] DEFAULT '{a,"", "b,c", "a''::string","''::string", "a''::string, ''::string",null}',
-  int_array int[] default '{1, 2}'
+  int_array int[] default '{1, 2}',
+  varchar_array varchar(32)[] DEFAULT '{cat, dog}'
 );
 
 query TTTBOI
@@ -3990,10 +3991,11 @@ WHERE a.attrelid = 'default_arrays'::regclass
   AND a.attnum > 0 AND NOT a.attisdropped
 ORDER BY a.attnum;
 ----
-id            bigint    NULL                                                                            true   20    -1
-string_array  text[]    '{cat,dog}'::STRING[]                                                           false  1009  -1
-weird_array   text[]    '{a,"","b,c",a''::string,''::string,"a''::string, ''::string",NULL}'::STRING[]  false  1009  -1
-int_array     bigint[]  '{1,2}'::INT8[]                                                                 false  1016  -1
+id             bigint                   NULL                                                                            true   20    -1
+string_array   text[]                   '{cat,dog}'::STRING[]                                                           false  1009  -1
+weird_array    text[]                   '{a,"","b,c",a''::string,''::string,"a''::string, ''::string",NULL}'::STRING[]  false  1009  -1
+int_array      bigint[]                 '{1,2}'::INT8[]                                                                 false  1016  -1
+varchar_array  character varying(32)[]  '{cat,dog}'::STRING[]                                                           false  1015  36
 
 # Regression test for limits on virtual index scans. (#53522)
 

--- a/pkg/sql/types/types.go
+++ b/pkg/sql/types/types.go
@@ -1647,7 +1647,14 @@ func (t *T) SQLStandardNameWithTypmod(haveTypmod bool, typmod int) string {
 		case oid.T_int2vector:
 			return "int2vector"
 		}
-		return t.ArrayContents().SQLStandardName() + "[]"
+		// If we have a typemod specified then pass it down when
+		// formatting the array type.
+		if !haveTypmod {
+			return t.ArrayContents().SQLStandardName() + "[]"
+		} else {
+			ac := t.ArrayContents()
+			return ac.SQLStandardNameWithTypmod(haveTypmod, typmod) + "[]"
+		}
 	case BitFamily:
 		if t.Oid() == oid.T_varbit {
 			buf.WriteString("bit varying")


### PR DESCRIPTION
Previously, the format_type builtin did not correctly include length information for the contents of an array.  So, if we formatted an array of VARCHAR(32) the length would not be included, which leads to an incompatibility with Postgres. This patch passes the typemod information down, formatting the array's contents, which leads to the correct behaviour.

Fixes: #110539

Release note (bug fix): format_type builtin did not honour typemod information for array types, leading to incorrect output.