### PR TITLE
storage: rename MaxIntentsPerLockConflictError to MaxConflictsPerLockConflictError

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_clear_range.go
+++ b/pkg/kv/kvserver/batcheval/cmd_clear_range.go
@@ -112,8 +112,8 @@ func ClearRange(
 	// txns. Otherwise, txn recovery would fail to find these intents and
 	// consider the txn incomplete, uncommitting it and its writes (even those
 	// outside of the cleared range).
-	maxIntents := storage.MaxIntentsPerLockConflictError.Get(&cArgs.EvalCtx.ClusterSettings().SV)
-	locks, err := storage.ScanLocks(ctx, readWriter, from, to, maxIntents, 0)
+	maxLockConflicts := storage.MaxConflictsPerLockConflictError.Get(&cArgs.EvalCtx.ClusterSettings().SV)
+	locks, err := storage.ScanLocks(ctx, readWriter, from, to, maxLockConflicts, 0)
 	if err != nil {
 		return result.Result{}, err
 	} else if len(locks) > 0 {

--- a/pkg/kv/kvserver/batcheval/cmd_delete_range.go
+++ b/pkg/kv/kvserver/batcheval/cmd_delete_range.go
@@ -152,7 +152,7 @@ func DeleteRange(
 
 		leftPeekBound, rightPeekBound := rangeTombstonePeekBounds(
 			args.Key, args.EndKey, desc.StartKey.AsRawKey(), desc.EndKey.AsRawKey())
-		maxIntents := storage.MaxIntentsPerLockConflictError.Get(&cArgs.EvalCtx.ClusterSettings().SV)
+		maxLockConflicts := storage.MaxConflictsPerLockConflictError.Get(&cArgs.EvalCtx.ClusterSettings().SV)
 
 		// If no predicate parameters are passed, use the fast path. If we're
 		// deleting the entire Raft range, use an even faster path that avoids a
@@ -167,7 +167,7 @@ func DeleteRange(
 			}
 			if err := storage.MVCCDeleteRangeUsingTombstone(ctx, readWriter, cArgs.Stats,
 				args.Key, args.EndKey, h.Timestamp, cArgs.Now, leftPeekBound, rightPeekBound,
-				args.IdempotentTombstone, maxIntents, statsCovered); err != nil {
+				args.IdempotentTombstone, maxLockConflicts, statsCovered); err != nil {
 				return result.Result{}, err
 			}
 			var res result.Result
@@ -197,7 +197,7 @@ func DeleteRange(
 		resumeSpan, err := storage.MVCCPredicateDeleteRange(ctx, readWriter, cArgs.Stats,
 			args.Key, args.EndKey, h.Timestamp, cArgs.Now, leftPeekBound, rightPeekBound,
 			args.Predicates, h.MaxSpanRequestKeys, maxDeleteRangeBatchBytes,
-			defaultRangeTombstoneThreshold, maxIntents)
+			defaultRangeTombstoneThreshold, maxLockConflicts)
 		if err != nil {
 			return result.Result{}, err
 		}

--- a/pkg/kv/kvserver/batcheval/cmd_export.go
+++ b/pkg/kv/kvserver/batcheval/cmd_export.go
@@ -154,9 +154,9 @@ func evalExport(
 		maxSize = targetSize + uint64(allowedOverage)
 	}
 
-	var maxIntents uint64
-	if m := storage.MaxIntentsPerLockConflictError.Get(&cArgs.EvalCtx.ClusterSettings().SV); m > 0 {
-		maxIntents = uint64(m)
+	var maxLockConflicts uint64
+	if m := storage.MaxConflictsPerLockConflictError.Get(&cArgs.EvalCtx.ClusterSettings().SV); m > 0 {
+		maxLockConflicts = uint64(m)
 	}
 
 	// Only use resume timestamp if splitting mid key is enabled.
@@ -184,7 +184,7 @@ func evalExport(
 			ExportAllRevisions: exportAllRevisions,
 			TargetSize:         targetSize,
 			MaxSize:            maxSize,
-			MaxIntents:         maxIntents,
+			MaxLockConflicts:   maxLockConflicts,
 			StopMidKey:         args.SplitMidKey,
 		}
 		var summary kvpb.BulkOpSummary

--- a/pkg/kv/kvserver/batcheval/cmd_reverse_scan.go
+++ b/pkg/kv/kvserver/batcheval/cmd_reverse_scan.go
@@ -46,7 +46,7 @@ func ReverseScan(
 		ScanStats:             cArgs.ScanStats,
 		Uncertainty:           cArgs.Uncertainty,
 		MaxKeys:               h.MaxSpanRequestKeys,
-		MaxIntents:            storage.MaxIntentsPerLockConflictError.Get(&cArgs.EvalCtx.ClusterSettings().SV),
+		MaxLockConflicts:      storage.MaxConflictsPerLockConflictError.Get(&cArgs.EvalCtx.ClusterSettings().SV),
 		TargetBytes:           h.TargetBytes,
 		AllowEmpty:            h.AllowEmpty,
 		WholeRowsOfSize:       h.WholeRowsOfSize,

--- a/pkg/kv/kvserver/batcheval/cmd_scan.go
+++ b/pkg/kv/kvserver/batcheval/cmd_scan.go
@@ -46,7 +46,7 @@ func Scan(
 		ScanStats:             cArgs.ScanStats,
 		Uncertainty:           cArgs.Uncertainty,
 		MaxKeys:               h.MaxSpanRequestKeys,
-		MaxIntents:            storage.MaxIntentsPerLockConflictError.Get(&cArgs.EvalCtx.ClusterSettings().SV),
+		MaxLockConflicts:      storage.MaxConflictsPerLockConflictError.Get(&cArgs.EvalCtx.ClusterSettings().SV),
 		TargetBytes:           h.TargetBytes,
 		AllowEmpty:            h.AllowEmpty,
 		WholeRowsOfSize:       h.WholeRowsOfSize,

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -1994,7 +1994,7 @@ func ScanConflictingIntentsForDroppingLatchesEarly(
 	ts hlc.Timestamp,
 	start, end roachpb.Key,
 	intents *[]roachpb.Intent,
-	maxIntents int64,
+	maxLockConflicts int64,
 ) (needIntentHistory bool, err error) {
 	if err := ctx.Err(); err != nil {
 		return false, err
@@ -2031,7 +2031,7 @@ func ScanConflictingIntentsForDroppingLatchesEarly(
 	var meta enginepb.MVCCMetadata
 	var ok bool
 	for ok, err = iter.SeekEngineKeyGE(EngineKey{Key: ltStart}); ok; ok, err = iter.NextEngineKey() {
-		if maxIntents != 0 && int64(len(*intents)) >= maxIntents {
+		if maxLockConflicts != 0 && int64(len(*intents)) >= maxLockConflicts {
 			// Return early if we're done accumulating intents; make no claims about
 			// not needing intent history.
 			return true /* needsIntentHistory */, nil

--- a/pkg/storage/engine_test.go
+++ b/pkg/storage/engine_test.go
@@ -2264,7 +2264,7 @@ func TestScanConflictingIntentsForDroppingLatchesEarly(t *testing.T) {
 				tc.start,
 				tc.end,
 				&intents,
-				0, /* maxIntents */
+				0, /* maxLockConflicts */
 			)
 			if tc.expErr != "" {
 				require.Error(t, err)
@@ -2486,7 +2486,7 @@ func TestScanConflictingIntentsForDroppingLatchesEarlyReadYourOwnWrites(t *testi
 				keyA,
 				nil,
 				&intents,
-				0, /* maxIntents */
+				0, /* maxLockConflicts */
 			)
 			require.NoError(t, err)
 			if alwaysFallbackToIntentInterleavingIteratorForReadYourOwnWrites {

--- a/pkg/storage/metamorphic/operations.go
+++ b/pkg/storage/metamorphic/operations.go
@@ -335,7 +335,7 @@ func (m mvccDeleteRangeUsingRangeTombstoneOp) run(ctx context.Context) string {
 	}
 
 	err := storage.MVCCDeleteRangeUsingTombstone(ctx, writer, nil, m.key, m.endKey, m.ts,
-		hlc.ClockTimestamp{}, m.key, m.endKey, false /* idempotent */, math.MaxInt64, /* maxIntents */
+		hlc.ClockTimestamp{}, m.key, m.endKey, false /* idempotent */, math.MaxInt64, /* maxLockConflicts */
 		nil /* msCovered */)
 	if err != nil {
 		return fmt.Sprintf("error: %s", err)

--- a/pkg/storage/mvcc_history_test.go
+++ b/pkg/storage/mvcc_history_test.go
@@ -101,7 +101,7 @@ var (
 // put_blind_inline	k=<key> v=<string> [prev=<string>]
 // get            [t=<name>] [ts=<int>[,<int>]]                         [resolve [status=<txnstatus>]] k=<key> [inconsistent] [skipLocked] [tombstones] [failOnMoreRecent] [localUncertaintyLimit=<int>[,<int>]] [globalUncertaintyLimit=<int>[,<int>]] [maxKeys=<int>] [targetBytes=<int>] [allowEmpty]
 // scan           [t=<name>] [ts=<int>[,<int>]]                         [resolve [status=<txnstatus>]] k=<key> [end=<key>] [inconsistent] [skipLocked] [tombstones] [reverse] [failOnMoreRecent] [localUncertaintyLimit=<int>[,<int>]] [globalUncertaintyLimit=<int>[,<int>]] [max=<max>] [targetbytes=<target>] [wholeRows[=<int>]] [allowEmpty]
-// export         [k=<key>] [end=<key>] [ts=<int>[,<int>]] [kTs=<int>[,<int>]] [startTs=<int>[,<int>]] [maxIntents=<int>] [allRevisions] [targetSize=<int>] [maxSize=<int>] [stopMidKey] [fingerprint]
+// export         [k=<key>] [end=<key>] [ts=<int>[,<int>]] [kTs=<int>[,<int>]] [startTs=<int>[,<int>]] [maxLockConflicts=<int>] [allRevisions] [targetSize=<int>] [maxSize=<int>] [stopMidKey] [fingerprint]
 //
 // iter_new       [k=<key>] [end=<key>] [prefix] [kind=key|keyAndIntents] [types=pointsOnly|pointsWithRanges|pointsAndRanges|rangesOnly] [maskBelow=<int>[,<int>]]
 // iter_new_incremental [k=<key>] [end=<key>] [startTs=<int>[,<int>]] [endTs=<int>[,<int>]] [types=pointsOnly|pointsWithRanges|pointsAndRanges|rangesOnly] [maskBelow=<int>[,<int>]] [intents=error|aggregate|emit]
@@ -1531,8 +1531,8 @@ func cmdExport(e *evalCtx) error {
 			StripIndexPrefixAndTimestamp: e.hasArg("stripped"),
 		},
 	}
-	if e.hasArg("maxIntents") {
-		e.scanArg("maxIntents", &opts.MaxIntents)
+	if e.hasArg("maxLockConflicts") {
+		e.scanArg("maxLockConflicts", &opts.MaxLockConflicts)
 	}
 	if e.hasArg("targetSize") {
 		e.scanArg("targetSize", &opts.TargetSize)

--- a/pkg/storage/mvcc_incremental_iterator_test.go
+++ b/pkg/storage/mvcc_incremental_iterator_test.go
@@ -201,7 +201,7 @@ func assertExportedErrs(
 		ExportAllRevisions: revisions,
 		TargetSize:         big,
 		MaxSize:            big,
-		MaxIntents:         uint64(MaxIntentsPerLockConflictError.Default()),
+		MaxLockConflicts:   uint64(MaxConflictsPerLockConflictError.Default()),
 		StopMidKey:         false,
 	}, &bytes.Buffer{})
 	require.Error(t, err)

--- a/pkg/storage/mvcc_stats_test.go
+++ b/pkg/storage/mvcc_stats_test.go
@@ -1724,20 +1724,20 @@ func TestMVCCStatsRandomized(t *testing.T) {
 			desc = fmt.Sprintf("mvccDeleteRangeUsingTombstone=%s",
 				roachpb.Span{Key: mvccRangeDelKey, EndKey: mvccRangeDelEndKey})
 			const idempotent = false
-			const maxIntents = 0 // unlimited
+			const maxLockConflicts = 0 // unlimited
 			msCovered := (*enginepb.MVCCStats)(nil)
 			err = MVCCDeleteRangeUsingTombstone(
 				ctx, s.batch, s.MSDelta, mvccRangeDelKey, mvccRangeDelEndKey, s.TS, hlc.ClockTimestamp{}, nil, /* leftPeekBound */
-				nil /* rightPeekBound */, idempotent, maxIntents, msCovered,
+				nil /* rightPeekBound */, idempotent, maxLockConflicts, msCovered,
 			)
 		} else {
 			rangeTombstoneThreshold := s.rng.Int63n(5)
 			desc = fmt.Sprintf("mvccPredicateDeleteRange=%s, predicates=%s, rangeTombstoneThreshold=%d",
 				roachpb.Span{Key: mvccRangeDelKey, EndKey: mvccRangeDelEndKey}, predicates, rangeTombstoneThreshold)
-			const maxIntents = 0 // unlimited
+			const maxLockConflicts = 0 // unlimited
 			_, err = MVCCPredicateDeleteRange(ctx, s.batch, s.MSDelta, mvccRangeDelKey, mvccRangeDelEndKey,
 				s.TS, hlc.ClockTimestamp{}, nil /* leftPeekBound */, nil, /* rightPeekBound */
-				predicates, 0, 0, rangeTombstoneThreshold, maxIntents)
+				predicates, 0, 0, rangeTombstoneThreshold, maxLockConflicts)
 		}
 		if err != nil {
 			return false, desc + ": " + err.Error()

--- a/pkg/storage/mvcc_test.go
+++ b/pkg/storage/mvcc_test.go
@@ -597,7 +597,7 @@ func TestMVCCScanLockConflictError(t *testing.T) {
 	for _, scan := range scanCases {
 		t.Run(scan.name, func(t *testing.T) {
 			res, err := MVCCScan(ctx, engine, testKey1, testKey6.Next(),
-				hlc.Timestamp{WallTime: 1}, MVCCScanOptions{Inconsistent: !scan.consistent, Txn: scan.txn, MaxIntents: 2})
+				hlc.Timestamp{WallTime: 1}, MVCCScanOptions{Inconsistent: !scan.consistent, Txn: scan.txn, MaxLockConflicts: 2})
 			var lcErr *kvpb.LockConflictError
 			_ = errors.As(err, &lcErr)
 			if (err == nil) != (lcErr == nil) {
@@ -6635,7 +6635,7 @@ func TestMVCCExportToSSTFailureIntentBatching(t *testing.T) {
 				ExportAllRevisions: true,
 				TargetSize:         0,
 				MaxSize:            0,
-				MaxIntents:         uint64(MaxIntentsPerLockConflictError.Default()),
+				MaxLockConflicts:   uint64(MaxConflictsPerLockConflictError.Default()),
 				StopMidKey:         false,
 			}, &bytes.Buffer{})
 			if len(expectedIntentIndices) == 0 {
@@ -6655,7 +6655,7 @@ func TestMVCCExportToSSTFailureIntentBatching(t *testing.T) {
 	}
 
 	// Export range is fixed to k:["00010", "10000"), ts:(999, 2000] for all tests.
-	testDataCount := int(MaxIntentsPerLockConflictError.Default() + 1)
+	testDataCount := int(MaxConflictsPerLockConflictError.Default() + 1)
 	testData := make([]testValue, testDataCount*2)
 	expectedErrors := make([]int, testDataCount)
 	for i := 0; i < testDataCount; i++ {
@@ -6663,7 +6663,7 @@ func TestMVCCExportToSSTFailureIntentBatching(t *testing.T) {
 		testData[i*2+1] = intent(key(i*2+12), "intent", ts(1001))
 		expectedErrors[i] = i*2 + 1
 	}
-	t.Run("Receive no more than limit intents", checkReportedErrors(testData, expectedErrors[:MaxIntentsPerLockConflictError.Default()]))
+	t.Run("Receive no more than limit intents", checkReportedErrors(testData, expectedErrors[:MaxConflictsPerLockConflictError.Default()]))
 }
 
 // TestMVCCExportToSSTSplitMidKey verifies that split mid key in exports will

--- a/pkg/storage/pebble_mvcc_scanner.go
+++ b/pkg/storage/pebble_mvcc_scanner.go
@@ -408,12 +408,12 @@ type pebbleMVCCScanner struct {
 	// allowEmpty is false, and the partial row is the first row in the result,
 	// the row will instead be completed by fetching additional KV pairs.
 	wholeRows bool
-	// Stop adding intents and abort scan once maxIntents threshold is reached.
-	// This limit is only applicable to consistent scans since they return
-	// intents as an error.
+	// Stop adding intents and abort scan once maxLockConflicts threshold is
+	// reached. This limit is only applicable to consistent scans since they
+	// return intents as an error.
 	// Not used in inconsistent scans.
 	// Ignored if zero.
-	maxIntents int64
+	maxLockConflicts int64
 	// Resume fields describe the resume span to return. resumeReason must be set
 	// to a non-zero value to return a resume span, the others are optional.
 	resumeReason    kvpb.ResumeReason
@@ -982,7 +982,7 @@ func (p *pebbleMVCCScanner) getOne(ctx context.Context) (ok, added bool) {
 			// may want to resolve it. Unlike below, this intent will not result in
 			// a LockConflictError because MVCC{Scan,Get}Options.errOnIntents returns
 			// false when skipLocked in enabled.
-			if p.maxIntents == 0 || int64(p.intents.Count()) < p.maxIntents {
+			if p.maxLockConflicts == 0 || int64(p.intents.Count()) < p.maxLockConflicts {
 				if !p.addCurIntent(ctx) {
 					return false, false
 				}
@@ -1005,7 +1005,7 @@ func (p *pebbleMVCCScanner) getOne(ctx context.Context) (ok, added bool) {
 			return false, false
 		}
 		// Limit number of intents returned in lock conflict error.
-		if p.maxIntents > 0 && int64(p.intents.Count()) >= p.maxIntents {
+		if p.maxLockConflicts > 0 && int64(p.intents.Count()) >= p.maxLockConflicts {
 			p.resumeReason = kvpb.RESUME_INTENT_LIMIT
 			return false, false
 		}
@@ -1816,7 +1816,7 @@ func (p *pebbleMVCCScanner) isKeyLockedByConflictingTxn(
 	}
 	if ok {
 		// The key is locked or reserved, so ignore it.
-		if txn != nil && (p.maxIntents == 0 || int64(p.intents.Count()) < p.maxIntents) {
+		if txn != nil && (p.maxLockConflicts == 0 || int64(p.intents.Count()) < p.maxLockConflicts) {
 			// However, if the key is locked, we return the lock holder separately
 			// (if we have room); the caller may want to resolve it.
 			if !p.addKeyAndMetaAsIntent(ctx, key, txn) {

--- a/pkg/storage/sst.go
+++ b/pkg/storage/sst.go
@@ -112,7 +112,7 @@ func CheckSSTConflicts(
 	disallowShadowing bool,
 	disallowShadowingBelow hlc.Timestamp,
 	sstTimestamp hlc.Timestamp,
-	maxIntents int64,
+	maxLockConflicts int64,
 	usePrefixSeek bool,
 ) (enginepb.MVCCStats, error) {
 
@@ -281,7 +281,7 @@ func CheckSSTConflicts(
 				// would be quadratic, so this significantly reduces the overall number
 				// of scans.
 				intents = append(intents, roachpb.MakeIntent(mvccMeta.Txn, extIter.UnsafeKey().Key.Clone()))
-				if int64(len(intents)) >= maxIntents {
+				if int64(len(intents)) >= maxLockConflicts {
 					return &kvpb.LockConflictError{Locks: roachpb.AsLocks(intents)}
 				}
 				return nil
@@ -531,7 +531,7 @@ func CheckSSTConflicts(
 					return enginepb.MVCCStats{}, err
 				}
 				intents = append(intents, roachpb.MakeIntent(mvccMeta.Txn, extIter.UnsafeKey().Key.Clone()))
-				if int64(len(intents)) >= maxIntents {
+				if int64(len(intents)) >= maxLockConflicts {
 					return statsDiff, &kvpb.LockConflictError{Locks: roachpb.AsLocks(intents)}
 				}
 				extIter.Next()

--- a/pkg/storage/testdata/mvcc_histories/export
+++ b/pkg/storage/testdata/mvcc_histories/export
@@ -84,12 +84,12 @@ export k=a end=z
 error: (*kvpb.LockConflictError:) conflicting locks on "a"
 
 run error
-export k=a end=z maxIntents=100
+export k=a end=z maxLockConflicts=100
 ----
 error: (*kvpb.LockConflictError:) conflicting locks on "a", "d", "j", "l", "o"
 
 run error
-export k=a end=z maxIntents=3
+export k=a end=z maxLockConflicts=3
 ----
 error: (*kvpb.LockConflictError:) conflicting locks on "a", "d", "j"
 

--- a/pkg/storage/testdata/mvcc_histories/export_fingerprint
+++ b/pkg/storage/testdata/mvcc_histories/export_fingerprint
@@ -84,12 +84,12 @@ export fingerprint k=a end=z
 error: (*kvpb.LockConflictError:) conflicting locks on "a"
 
 run error
-export fingerprint k=a end=z maxIntents=100
+export fingerprint k=a end=z maxLockConflicts=100
 ----
 error: (*kvpb.LockConflictError:) conflicting locks on "a", "d", "j", "l", "o"
 
 run error
-export fingerprint k=a end=z maxIntents=3
+export fingerprint k=a end=z maxLockConflicts=3
 ----
 error: (*kvpb.LockConflictError:) conflicting locks on "a", "d", "j"
 


### PR DESCRIPTION
Informs #110902.

This commit is a broad rename of "max intents" to "max lock conflicts", to better reflect the fact that locks of any strength can be returned in LockConflictErrors. The semantics of which locks conflict with which operations are unchanged.

Release note: None