### PR TITLE
storage: limit number of replicated lock conflicts returned by mutations

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_conditional_put.go
+++ b/pkg/kv/kvserver/batcheval/cmd_conditional_put.go
@@ -63,6 +63,7 @@ func ConditionalPut(
 		LocalTimestamp:                 cArgs.Now,
 		Stats:                          cArgs.Stats,
 		ReplayWriteTimestampProtection: h.AmbiguousReplayProtection,
+		MaxLockConflicts:               storage.MaxConflictsPerLockConflictError.Get(&cArgs.EvalCtx.ClusterSettings().SV),
 	}
 
 	var err error

--- a/pkg/kv/kvserver/batcheval/cmd_delete.go
+++ b/pkg/kv/kvserver/batcheval/cmd_delete.go
@@ -36,6 +36,7 @@ func Delete(
 		LocalTimestamp:                 cArgs.Now,
 		Stats:                          cArgs.Stats,
 		ReplayWriteTimestampProtection: h.AmbiguousReplayProtection,
+		MaxLockConflicts:               storage.MaxConflictsPerLockConflictError.Get(&cArgs.EvalCtx.ClusterSettings().SV),
 	}
 
 	var err error

--- a/pkg/kv/kvserver/batcheval/cmd_delete_range.go
+++ b/pkg/kv/kvserver/batcheval/cmd_delete_range.go
@@ -232,6 +232,7 @@ func DeleteRange(
 		LocalTimestamp:                 cArgs.Now,
 		Stats:                          cArgs.Stats,
 		ReplayWriteTimestampProtection: h.AmbiguousReplayProtection,
+		MaxLockConflicts:               storage.MaxConflictsPerLockConflictError.Get(&cArgs.EvalCtx.ClusterSettings().SV),
 	}
 
 	// NB: Even if args.ReturnKeys is false, we want to know which intents were

--- a/pkg/kv/kvserver/batcheval/cmd_get_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_get_test.go
@@ -37,8 +37,10 @@ func TestGetResumeSpan(t *testing.T) {
 
 	// This has a size of 11 bytes.
 	_, err := Put(ctx, db, CommandArgs{
-		EvalCtx: (&MockEvalCtx{}).EvalContext(),
-		Header:  kvpb.Header{TargetBytes: -1},
+		EvalCtx: (&MockEvalCtx{
+			ClusterSettings: cluster.MakeTestingClusterSettings(),
+		}).EvalContext(),
+		Header: kvpb.Header{TargetBytes: -1},
 		Args: &kvpb.PutRequest{
 			RequestHeader: kvpb.RequestHeader{
 				Key: key,

--- a/pkg/kv/kvserver/batcheval/cmd_increment.go
+++ b/pkg/kv/kvserver/batcheval/cmd_increment.go
@@ -37,6 +37,7 @@ func Increment(
 		LocalTimestamp:                 cArgs.Now,
 		Stats:                          cArgs.Stats,
 		ReplayWriteTimestampProtection: h.AmbiguousReplayProtection,
+		MaxLockConflicts:               storage.MaxConflictsPerLockConflictError.Get(&cArgs.EvalCtx.ClusterSettings().SV),
 	}
 
 	var err error

--- a/pkg/kv/kvserver/batcheval/cmd_init_put.go
+++ b/pkg/kv/kvserver/batcheval/cmd_init_put.go
@@ -41,6 +41,7 @@ func InitPut(
 		LocalTimestamp:                 cArgs.Now,
 		Stats:                          cArgs.Stats,
 		ReplayWriteTimestampProtection: h.AmbiguousReplayProtection,
+		MaxLockConflicts:               storage.MaxConflictsPerLockConflictError.Get(&cArgs.EvalCtx.ClusterSettings().SV),
 	}
 
 	var err error

--- a/pkg/kv/kvserver/batcheval/cmd_put.go
+++ b/pkg/kv/kvserver/batcheval/cmd_put.go
@@ -59,6 +59,7 @@ func Put(
 		LocalTimestamp:                 cArgs.Now,
 		Stats:                          cArgs.Stats,
 		ReplayWriteTimestampProtection: h.AmbiguousReplayProtection,
+		MaxLockConflicts:               storage.MaxConflictsPerLockConflictError.Get(&cArgs.EvalCtx.ClusterSettings().SV),
 	}
 
 	var err error

--- a/pkg/storage/testdata/mvcc_histories/replicated_locks
+++ b/pkg/storage/testdata/mvcc_histories/replicated_locks
@@ -431,6 +431,17 @@ data: "k4"/10.000000000,0 -> /BYTES/v4_prime
 error: (*kvpb.LockConflictError:) conflicting locks on "k3"
 
 run error
+del t=B k=k3
+----
+>> at end:
+data: "k1"/5.000000000,0 -> /BYTES/v1
+data: "k2"/5.000000000,0 -> /BYTES/v2
+data: "k3"/5.000000000,0 -> /BYTES/v3
+meta: "k4"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=2} ts=10.000000000,0 del=false klen=12 vlen=13 ih={{1 /BYTES/v4}} mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "k4"/10.000000000,0 -> /BYTES/v4_prime
+error: (*kvpb.LockConflictError:) conflicting locks on "k3"
+
+run error
 del_range t=B k=k3 k=k4
 ----
 >> at end:

--- a/pkg/storage/testdata/mvcc_histories/replicated_locks_max_conflicts
+++ b/pkg/storage/testdata/mvcc_histories/replicated_locks_max_conflicts
@@ -1,0 +1,116 @@
+# Set up a key with 3 shared locks.
+run ok
+put k=k1 v=v1 ts=5,0
+----
+>> at end:
+data: "k1"/5.000000000,0 -> /BYTES/v1
+
+run ok
+txn_begin t=A ts=10,0
+txn_begin t=B ts=11,0
+txn_begin t=C ts=12,0
+txn_begin t=D ts=13,0
+----
+>> at end:
+txn: "D" meta={id=00000004 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=13.000000000,0 wto=false gul=0,0
+
+run ok
+acquire_lock t=A k=k1 str=shared
+acquire_lock t=B k=k1 str=shared
+acquire_lock t=C k=k1 str=shared
+----
+>> at end:
+lock (Replicated): "k1"/Shared -> txn={id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=12.000000000,0 min=0,0 seq=0} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+lock (Replicated): "k1"/Shared -> txn={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+lock (Replicated): "k1"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=0} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+
+# Perform locking and mutation operations with maxLockConflicts set.
+run error
+check_for_acquire_lock t=D k=k1 str=exclusive maxLockConflicts=0
+----
+error: (*kvpb.LockConflictError:) conflicting locks on "k1", "k1", "k1"
+
+run error
+check_for_acquire_lock t=D k=k1 str=exclusive maxLockConflicts=1
+----
+error: (*kvpb.LockConflictError:) conflicting locks on "k1"
+
+run error
+check_for_acquire_lock t=D k=k1 str=exclusive maxLockConflicts=2
+----
+error: (*kvpb.LockConflictError:) conflicting locks on "k1", "k1"
+
+run error
+check_for_acquire_lock t=D k=k1 str=exclusive maxLockConflicts=3
+----
+error: (*kvpb.LockConflictError:) conflicting locks on "k1", "k1", "k1"
+
+run error
+check_for_acquire_lock t=D k=k1 str=exclusive maxLockConflicts=4
+----
+error: (*kvpb.LockConflictError:) conflicting locks on "k1", "k1", "k1"
+
+run error
+acquire_lock t=D k=k1 str=exclusive maxLockConflicts=2
+----
+>> at end:
+lock (Replicated): "k1"/Shared -> txn={id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=12.000000000,0 min=0,0 seq=0} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+lock (Replicated): "k1"/Shared -> txn={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+lock (Replicated): "k1"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=0} ts=0,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+error: (*kvpb.LockConflictError:) conflicting locks on "k1", "k1"
+
+run error
+put t=D k=k1 v=v1 maxLockConflicts=2
+----
+>> at end:
+data: "k1"/5.000000000,0 -> /BYTES/v1
+error: (*kvpb.LockConflictError:) conflicting locks on "k1", "k1"
+
+run error
+increment t=D k=k1 maxLockConflicts=2
+----
+>> at end:
+data: "k1"/5.000000000,0 -> /BYTES/v1
+error: (*kvpb.LockConflictError:) conflicting locks on "k1", "k1"
+
+run error
+cput t=D k=k1 v=v2 maxLockConflicts=2
+----
+>> at end:
+data: "k1"/5.000000000,0 -> /BYTES/v1
+error: (*kvpb.LockConflictError:) conflicting locks on "k1", "k1"
+
+run error
+initput t=D k=k1 v=v2 maxLockConflicts=2
+----
+>> at end:
+data: "k1"/5.000000000,0 -> /BYTES/v1
+error: (*kvpb.LockConflictError:) conflicting locks on "k1", "k1"
+
+run error
+del t=D k=k1 maxLockConflicts=2
+----
+>> at end:
+data: "k1"/5.000000000,0 -> /BYTES/v1
+error: (*kvpb.LockConflictError:) conflicting locks on "k1", "k1"
+
+run error
+del_range t=D k=k1 k=k2 maxLockConflicts=2
+----
+>> at end:
+data: "k1"/5.000000000,0 -> /BYTES/v1
+error: (*kvpb.LockConflictError:) conflicting locks on "k1", "k1"
+
+run error
+del_range_ts k=k1 k=k2 ts=10,0 maxLockConflicts=2
+----
+>> at end:
+data: "k1"/5.000000000,0 -> /BYTES/v1
+error: (*kvpb.LockConflictError:) conflicting locks on "k1", "k1"
+
+run error
+del_range_pred k=k1 k=k2 maxLockConflicts=2
+----
+>> at end:
+data: "k1"/5.000000000,0 -> /BYTES/v1
+error: (*kvpb.LockConflictError:) conflicting locks on "k1", "k1"


### PR DESCRIPTION
Closes #110902.

This commit limits the number of replicated lock conflicts returned by locking and mutation operations during evaluation to the value of the `storage.mvcc.max_conflicts_per_lock_conflict_error` cluster setting.

Release note: None