### PR TITLE
keysutil: make pretty key decoding a little more flexible

### DIFF
--- a/pkg/testutils/keysutils/pretty_scanner.go
+++ b/pkg/testutils/keysutils/pretty_scanner.go
@@ -12,6 +12,7 @@ package keysutils
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
@@ -73,7 +74,11 @@ func parseTableKeysAsAscendingInts(
 	tableName := input[:slashPos]
 	tableID, ok := tableNameToID[tableName]
 	if !ok {
-		panic(fmt.Sprintf("unknown table: %s", tableName))
+		i, err := strconv.Atoi(tableName)
+		if err != nil {
+			panic(fmt.Sprintf("unknown table: %s", tableName))
+		}
+		tableID = i
 	}
 	// We assume that the tenant prefix (if there was any) was already removed
 	// and included into the output by the caller, so we use the system codec
@@ -100,7 +105,11 @@ func parseTableKeysAsAscendingInts(
 	} else {
 		idxID, ok = idxNameToID[fmt.Sprintf("%s.%s", tableName, idxName)]
 		if !ok {
-			panic(fmt.Sprintf("unknown index: %s", idxName))
+			i, err := strconv.Atoi(idxName)
+			if err != nil {
+				panic(fmt.Sprintf("unknown index: %s", idxName))
+			}
+			idxID = i
 		}
 	}
 	output = encoding.EncodeUvarintAscending(output, uint64(idxID))

--- a/pkg/testutils/keysutils/pretty_scanner_test.go
+++ b/pkg/testutils/keysutils/pretty_scanner_test.go
@@ -33,9 +33,21 @@ func TestPrettyScanner(t *testing.T) {
 			},
 		},
 		{
+			prettyKey: "/Table/100",
+			expKey: func(tenantID roachpb.TenantID) roachpb.Key {
+				return keys.MakeSQLCodec(tenantID).TablePrefix(100)
+			},
+		},
+		{
 			prettyKey: "/Table/t1/pk",
 			expKey: func(tenantID roachpb.TenantID) roachpb.Key {
 				return keys.MakeSQLCodec(tenantID).IndexPrefix(50, 1)
+			},
+		},
+		{
+			prettyKey: "/Table/100/7",
+			expKey: func(tenantID roachpb.TenantID) roachpb.Key {
+				return keys.MakeSQLCodec(tenantID).IndexPrefix(100, 7)
 			},
 		},
 		{


### PR DESCRIPTION
Adds ability to decode string values rather than just ints and adds ability to decode  table/index IDs rather than just names.