### PR TITLE
sql: add libgeos runfile dependency for RSG tests

### DIFF
--- a/build/teamcity/cockroach/nightlies/random_syntax_tests_impl.sh
+++ b/build/teamcity/cockroach/nightlies/random_syntax_tests_impl.sh
@@ -4,7 +4,6 @@ set -xeuo pipefail
 
 dir="$(dirname $(dirname $(dirname $(dirname "${0}"))))"
 
-bazel build --config ci --config force_build_cdeps //c-deps:libgeos
 bazel build //pkg/cmd/bazci --config=ci
 BAZEL_BIN=$(bazel info bazel-bin --config=ci)
 exit_status=0

--- a/pkg/sql/tests/BUILD.bazel
+++ b/pkg/sql/tests/BUILD.bazel
@@ -62,7 +62,9 @@ go_test(
         "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
         "//conditions:default": ["-test.timeout=3595s"],
     }),
-    data = glob(["testdata/**"]),
+    data = glob(["testdata/**"]) + [
+        "//c-deps:libgeos",  # keep
+    ],
     embed = [":tests"],
     exec_properties = {"Pool": "large"},
     shard_count = 16,


### PR DESCRIPTION
In [1], we updated CI (nightly) to require a build step for `//c-deps:libgeos`. That didn't fix `rsg_test`'s implicit dependency on libgeos, since the produced artifacts are not reachable from the test sandbox.

Instead, we use a runfile dependency--same way other test packages specify libgeos dependency. This enables dynamic loading via `bazel.Runfile`.

[1] https://github.com/cockroachdb/cockroach/pull/110129

Epic: none
Fixes: #110780

Release note: None