### PR TITLE
ui: add plan gist as option on bundle collection

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/statementDiagnosticsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/statementDiagnosticsApi.ts
@@ -74,6 +74,7 @@ export type InsertStmtDiagnosticRequest = {
   samplingProbability?: number;
   minExecutionLatencySeconds?: number;
   expiresAfterSeconds?: number;
+  planGist: string;
 };
 
 export type InsertStmtDiagnosticResponse = {
@@ -85,8 +86,15 @@ export function createStatementDiagnosticsReport({
   samplingProbability,
   minExecutionLatencySeconds,
   expiresAfterSeconds,
+  planGist,
 }: InsertStmtDiagnosticRequest): Promise<InsertStmtDiagnosticResponse> {
   const args: any = [stmtFingerprint];
+  let query = `SELECT crdb_internal.request_statement_bundle($1, $2, $3::INTERVAL, $4::INTERVAL) as req_resp`;
+
+  if (planGist) {
+    args.push(planGist);
+    query = `SELECT crdb_internal.request_statement_bundle($1, $2, $3, $4::INTERVAL, $5::INTERVAL) as req_resp`;
+  }
 
   if (samplingProbability) {
     args.push(samplingProbability);
@@ -105,7 +113,7 @@ export function createStatementDiagnosticsReport({
   }
 
   const createStmtDiag = {
-    sql: `SELECT crdb_internal.request_statement_bundle($1, $2, $3::INTERVAL, $4::INTERVAL) as req_resp`,
+    sql: query,
     arguments: args,
   };
 

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/diagnostics/diagnosticsView.spec.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/diagnostics/diagnosticsView.spec.tsx
@@ -63,6 +63,7 @@ describe("DiagnosticsView", () => {
             requestTime={undefined}
             currentScale={ts}
             onChangeTimeScale={mockSetTimeScale}
+            planGists={["gist"]}
           />
         </MemoryRouter>,
       );
@@ -73,6 +74,7 @@ describe("DiagnosticsView", () => {
       activateButtonComponent.simulate("click");
       expect(activateDiagnosticsRef.current.showModalFor).toBeCalledWith(
         statementFingerprint,
+        ["gist"],
       );
     });
   });
@@ -94,6 +96,7 @@ describe("DiagnosticsView", () => {
             dismissAlertMessage={() => {}}
             currentScale={ts}
             onChangeTimeScale={mockSetTimeScale}
+            planGists={["gist"]}
           />
         </TestStoreProvider>,
       );
@@ -110,6 +113,7 @@ describe("DiagnosticsView", () => {
       activateButtonComponent.simulate("click");
       expect(activateDiagnosticsRef.current.showModalFor).toBeCalledWith(
         statementFingerprint,
+        ["gist"],
       );
     });
 
@@ -128,6 +132,7 @@ describe("DiagnosticsView", () => {
             currentScale={ts}
             requestTime={requestTime}
             onChangeTimeScale={mockSetTimeScale}
+            planGists={["gist"]}
           />
         </TestStoreProvider>,
       );
@@ -152,6 +157,7 @@ describe("DiagnosticsView", () => {
             currentScale={ts}
             requestTime={requestTime}
             onChangeTimeScale={mockSetTimeScale}
+            planGists={["gist"]}
           />
         </TestStoreProvider>,
       );

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/diagnostics/diagnosticsView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/diagnostics/diagnosticsView.tsx
@@ -60,6 +60,7 @@ export interface DiagnosticsViewDispatchProps {
 
 export interface DiagnosticsViewOwnProps {
   statementFingerprint?: string;
+  planGists?: string[];
 }
 
 export type DiagnosticsViewProps = DiagnosticsViewOwnProps &
@@ -80,6 +81,7 @@ const NavButton: React.FC = props => (
 
 export const EmptyDiagnosticsView = ({
   statementFingerprint,
+  planGists,
   showDiagnosticsViewLink,
   activateDiagnosticsRef,
 }: DiagnosticsViewProps): React.ReactElement => {
@@ -94,6 +96,7 @@ export const EmptyDiagnosticsView = ({
             onClick={() =>
               activateDiagnosticsRef?.current?.showModalFor(
                 statementFingerprint,
+                planGists,
               )
             }
           >
@@ -272,6 +275,7 @@ export class DiagnosticsView extends React.Component<
       activateDiagnosticsRef,
       currentScale,
       onChangeTimeScale,
+      planGists,
     } = this.props;
 
     const readyToRequestDiagnostics = diagnosticsReports.every(
@@ -329,6 +333,7 @@ export class DiagnosticsView extends React.Component<
               onClick={() =>
                 activateDiagnosticsRef?.current?.showModalFor(
                   statementFingerprint,
+                  planGists,
                 )
               }
               disabled={!readyToRequestDiagnostics}

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
@@ -1021,6 +1021,7 @@ export class StatementDetails extends React.Component<
         onSortingChange={this.props.onSortingChange}
         currentScale={this.props.timeScale}
         onChangeTimeScale={this.changeTimeScale}
+        planGists={this.props.statementDetails.statement.stats.plan_gists}
       />
     );
   };

--- a/pkg/ui/workspaces/cluster-ui/src/statementsDiagnostics/activateStatementDiagnosticsModal.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsDiagnostics/activateStatementDiagnosticsModal.scss
@@ -53,6 +53,10 @@
     font-weight: $font-weight--light;
   }
 
+  &__plan-gist-group {
+    margin-bottom: -25px;
+  }
+
   &__conditional-container {
     display: flex;
     flex-direction: column;
@@ -71,6 +75,14 @@
     flex-direction: row;
     margin-top: $spacing-smaller;
     margin-bottom: $spacing-smaller;
+  }
+
+  &__plan-gist-container {
+    display: flex;
+    flex-direction: row;
+    margin-top: $spacing-smaller;
+    margin-bottom: $spacing-smaller;
+    margin-left: $spacing-medium;
   }
 
   &__trace-warning {
@@ -131,6 +143,15 @@
         margin-top: 0;
       }
     }
+    &__plan-gist {
+      width: 400px;
+      height: 40px;
+      line-height: 40px;
+
+      .ant-select-selection__rendered {
+        margin-top: 0;
+      }
+    }
   }
 
   &__alert {
@@ -143,4 +164,8 @@
     margin: $spacing-xx-small 0px;
     white-space: normal;
   }
+}
+
+.margin-bottom {
+  margin-bottom: 10px;
 }

--- a/pkg/ui/workspaces/cluster-ui/src/statementsTable/statementsTableContent.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsTable/statementsTableContent.tsx
@@ -95,7 +95,10 @@ export const StatementTableCell = {
           {canActivateDiagnosticReport ? (
             <Button
               onClick={() =>
-                activateDiagnosticsRef?.current?.showModalFor(stmt.label)
+                activateDiagnosticsRef?.current?.showModalFor(
+                  stmt.label,
+                  stmt.stats.plan_gists,
+                )
               }
               type="secondary"
               size="small"

--- a/pkg/ui/workspaces/cluster-ui/src/store/statementDiagnostics/statementDiagnostics.sagas.spec.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/statementDiagnostics/statementDiagnostics.sagas.spec.ts
@@ -33,6 +33,7 @@ import moment from "moment-timezone";
 describe("statementsDiagnostics sagas", () => {
   describe("createDiagnosticsReportSaga", () => {
     const statementFingerprint = "SELECT * FROM table";
+    const planGist = "gist";
     const minExecLatency = 100; // num seconds
     const expiresAfter = 0; // num seconds, setting expiresAfter to 0 means the request won't expire.
 
@@ -40,6 +41,7 @@ describe("statementsDiagnostics sagas", () => {
       stmtFingerprint: statementFingerprint,
       minExecutionLatencySeconds: minExecLatency,
       expiresAfterSeconds: expiresAfter,
+      planGist: planGist,
     };
 
     const insertResponse: InsertStmtDiagnosticResponse = {

--- a/pkg/ui/workspaces/db-console/src/redux/statements/statementsSagas.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/statements/statementsSagas.spec.ts
@@ -37,12 +37,14 @@ describe("statementsSagas", () => {
   describe("requestDiagnostics generator", () => {
     it("calls api#createStatementDiagnosticsReport with statement fingerprint, min exec latency, and expires after fields as payload", () => {
       const statementFingerprint = "some-id";
+      const planGist = "gist";
       const minExecLatency = 10; // num seconds
       const expiresAfter = 15 * 60; // num seconds (num mins * num seconds per min)
       const insertStmtDiagnosticsRequest = {
         stmtFingerprint: statementFingerprint,
         minExecutionLatencySeconds: minExecLatency,
         expiresAfterSeconds: expiresAfter,
+        planGist: planGist,
       };
       const action = createStatementDiagnosticsReportAction(
         insertStmtDiagnosticsRequest,
@@ -66,12 +68,14 @@ describe("statementsSagas", () => {
 
   it("calls dispatched failed action if api#createStatementDiagnosticsReport request failed ", () => {
     const statementFingerprint = "some-id";
+    const planGist = "gist";
     const minExecLatency = 10; // num seconds
     const expiresAfter = 15 * 60; // num seconds (num mins * num seconds per min)
     const insertStmtDiagnosticsRequest = {
       stmtFingerprint: statementFingerprint,
       minExecutionLatencySeconds: minExecLatency,
       expiresAfterSeconds: expiresAfter,
+      planGist: planGist,
     };
     const action = createStatementDiagnosticsReportAction(
       insertStmtDiagnosticsRequest,


### PR DESCRIPTION
Note to reviewers: There is another option to get any plan _except_ from the selected gist, but that is not part of this PR. Once a design is created, this option can be added.

---
Part Of #103018

This commit adds an option to collect statement bundle based on a specific plan gist.

<img width="578" alt="Screenshot 2023-09-19 at 3 18 01 PM" src="https://github.com/cockroachdb/cockroach/assets/1017486/5ab807b7-08f4-49e7-b540-2dadface766d">


https://www.loom.com/share/59335438f0884b75a7d163d96effe5a8

Release note (ui change): Add option to filter out by specific plan gist when collecting a statement bundle.