### PR TITLE
release-23.1: sql: add libgeos runfile dependency for RSG tests

### DIFF
--- a/build/teamcity/cockroach/nightlies/random_syntax_tests_impl.sh
+++ b/build/teamcity/cockroach/nightlies/random_syntax_tests_impl.sh
@@ -4,7 +4,6 @@ set -xeuo pipefail
 
 dir="$(dirname $(dirname $(dirname $(dirname "${0}"))))"
 
-bazel build --config ci --config force_build_cdeps //c-deps:libgeos
 bazel build //pkg/cmd/bazci --config=ci
 BAZEL_BIN=$(bazel info bazel-bin --config=ci)
 exit_status=0

--- a/pkg/sql/tests/BUILD.bazel
+++ b/pkg/sql/tests/BUILD.bazel
@@ -61,7 +61,9 @@ go_test(
         "virtual_table_test.go",
     ],
     args = ["-test.timeout=3595s"],
-    data = glob(["testdata/**"]),
+    data = glob(["testdata/**"]) + [
+        "//c-deps:libgeos",  # keep
+    ],
     embed = [":tests"],
     shard_count = 16,
     deps = [


### PR DESCRIPTION
Backport 1/1 commits from #110926.

/cc @cockroachdb/release

---

In [1], we updated CI (nightly) to require a build step for `//c-deps:libgeos`. That didn't fix `rsg_test`'s implicit dependency on libgeos, since the produced artifacts are not reachable from the test sandbox.

Instead, we use a runfile dependency--same way other test packages specify libgeos dependency. This enables dynamic loading via `bazel.Runfile`.

[1] https://github.com/cockroachdb/cockroach/pull/110129

Epic: none
Fixes: #110780

Release note: None
Release justification: test-only change
