### PR TITLE
release-23.1: jobs: Use thread safe map to override resumer constructor

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -7677,15 +7677,14 @@ func TestRestoreTypeDescriptorsRollBack(t *testing.T) {
 
 	for _, server := range tc.Servers {
 		registry := server.JobRegistry().(*jobs.Registry)
-		registry.TestingResumerCreationKnobs = map[jobspb.Type]func(raw jobs.Resumer) jobs.Resumer{
-			jobspb.TypeRestore: func(raw jobs.Resumer) jobs.Resumer {
+		registry.TestingWrapResumerConstructor(jobspb.TypeRestore,
+			func(raw jobs.Resumer) jobs.Resumer {
 				r := raw.(*restoreResumer)
 				r.testingKnobs.beforePublishingDescriptors = func() error {
 					return errors.New("boom")
 				}
 				return r
-			},
-		}
+			})
 	}
 
 	sqlDB.Exec(t, `
@@ -7808,16 +7807,15 @@ func TestOfflineDescriptorsDuringRestore(t *testing.T) {
 
 		for _, server := range tc.Servers {
 			registry := server.JobRegistry().(*jobs.Registry)
-			registry.TestingResumerCreationKnobs = map[jobspb.Type]func(raw jobs.Resumer) jobs.Resumer{
-				jobspb.TypeRestore: func(raw jobs.Resumer) jobs.Resumer {
+			registry.TestingWrapResumerConstructor(
+				jobspb.TypeRestore, func(raw jobs.Resumer) jobs.Resumer {
 					r := raw.(*restoreResumer)
 					r.testingKnobs.beforePublishingDescriptors = func() error {
 						notifyBackfill(ctx)
 						return nil
 					}
 					return r
-				},
-			}
+				})
 		}
 
 		sqlDB.Exec(t, `
@@ -7904,16 +7902,15 @@ CREATE TYPE sc.typ AS ENUM ('hello');
 
 		for _, server := range tc.Servers {
 			registry := server.JobRegistry().(*jobs.Registry)
-			registry.TestingResumerCreationKnobs = map[jobspb.Type]func(raw jobs.Resumer) jobs.Resumer{
-				jobspb.TypeRestore: func(raw jobs.Resumer) jobs.Resumer {
+			registry.TestingWrapResumerConstructor(jobspb.TypeRestore,
+				func(raw jobs.Resumer) jobs.Resumer {
 					r := raw.(*restoreResumer)
 					r.testingKnobs.beforePublishingDescriptors = func() error {
 						notifyBackfill(ctx)
 						return nil
 					}
 					return r
-				},
-			}
+				})
 		}
 
 		sqlDB.Exec(t, `
@@ -8013,16 +8010,15 @@ CREATE TYPE sc.typ AS ENUM ('hello');
 
 		for _, server := range tc.Servers {
 			registry := server.JobRegistry().(*jobs.Registry)
-			registry.TestingResumerCreationKnobs = map[jobspb.Type]func(raw jobs.Resumer) jobs.Resumer{
-				jobspb.TypeRestore: func(raw jobs.Resumer) jobs.Resumer {
+			registry.TestingWrapResumerConstructor(jobspb.TypeRestore,
+				func(raw jobs.Resumer) jobs.Resumer {
 					r := raw.(*restoreResumer)
 					r.testingKnobs.beforePublishingDescriptors = func() error {
 						notifyBackfill(ctx)
 						return nil
 					}
 					return r
-				},
-			}
+				})
 		}
 
 		sqlDB.Exec(t, `
@@ -8147,16 +8143,15 @@ func TestCleanupDoesNotDeleteParentsWithChildObjects(t *testing.T) {
 
 		for _, server := range tc.Servers {
 			registry := server.JobRegistry().(*jobs.Registry)
-			registry.TestingResumerCreationKnobs = map[jobspb.Type]func(raw jobs.Resumer) jobs.Resumer{
-				jobspb.TypeRestore: func(raw jobs.Resumer) jobs.Resumer {
+			registry.TestingWrapResumerConstructor(jobspb.TypeRestore,
+				func(raw jobs.Resumer) jobs.Resumer {
 					r := raw.(*restoreResumer)
 					r.testingKnobs.afterPublishingDescriptors = func() error {
 						notifyContinue(ctx)
 						return errors.New("injected error")
 					}
 					return r
-				},
-			}
+				})
 		}
 
 		sqlDB.Exec(t, `
@@ -8209,16 +8204,15 @@ func TestCleanupDoesNotDeleteParentsWithChildObjects(t *testing.T) {
 
 		for _, server := range tc.Servers {
 			registry := server.JobRegistry().(*jobs.Registry)
-			registry.TestingResumerCreationKnobs = map[jobspb.Type]func(raw jobs.Resumer) jobs.Resumer{
-				jobspb.TypeRestore: func(raw jobs.Resumer) jobs.Resumer {
+			registry.TestingWrapResumerConstructor(jobspb.TypeRestore,
+				func(raw jobs.Resumer) jobs.Resumer {
 					r := raw.(*restoreResumer)
 					r.testingKnobs.afterPublishingDescriptors = func() error {
 						notifyContinue(ctx)
 						return errors.New("injected error")
 					}
 					return r
-				},
-			}
+				})
 		}
 
 		sqlDB.Exec(t, `
@@ -8273,16 +8267,15 @@ func TestCleanupDoesNotDeleteParentsWithChildObjects(t *testing.T) {
 
 		for _, server := range tc.Servers {
 			registry := server.JobRegistry().(*jobs.Registry)
-			registry.TestingResumerCreationKnobs = map[jobspb.Type]func(raw jobs.Resumer) jobs.Resumer{
-				jobspb.TypeRestore: func(raw jobs.Resumer) jobs.Resumer {
+			registry.TestingWrapResumerConstructor(jobspb.TypeRestore,
+				func(raw jobs.Resumer) jobs.Resumer {
 					r := raw.(*restoreResumer)
 					r.testingKnobs.afterPublishingDescriptors = func() error {
 						notifyContinue(ctx)
 						return errors.New("injected error")
 					}
 					return r
-				},
-			}
+				})
 		}
 
 		// Use the same connection throughout (except for the concurrent RESTORE) to
@@ -8342,16 +8335,15 @@ func TestCleanupDoesNotDeleteParentsWithChildObjects(t *testing.T) {
 
 		for _, server := range tc.Servers {
 			registry := server.JobRegistry().(*jobs.Registry)
-			registry.TestingResumerCreationKnobs = map[jobspb.Type]func(raw jobs.Resumer) jobs.Resumer{
-				jobspb.TypeRestore: func(raw jobs.Resumer) jobs.Resumer {
+			registry.TestingWrapResumerConstructor(jobspb.TypeRestore,
+				func(raw jobs.Resumer) jobs.Resumer {
 					r := raw.(*restoreResumer)
 					r.testingKnobs.afterPublishingDescriptors = func() error {
 						notifyContinue(ctx)
 						return errors.New("injected error")
 					}
 					return r
-				},
-			}
+				})
 		}
 
 		sqlDB.Exec(t, `
@@ -8649,9 +8641,9 @@ func TestRestoreJobEventLogging(t *testing.T) {
 
 	var forceFailure bool
 	for i := range tc.Servers {
-		tc.TenantOrServer(i).JobRegistry().(*jobs.Registry).TestingResumerCreationKnobs = map[jobspb.Type]func(
-			raw jobs.Resumer) jobs.Resumer{
-			jobspb.TypeRestore: func(raw jobs.Resumer) jobs.Resumer {
+		tc.TenantOrServer(i).JobRegistry().(*jobs.Registry).TestingWrapResumerConstructor(
+			jobspb.TypeRestore,
+			func(raw jobs.Resumer) jobs.Resumer {
 				r := raw.(*restoreResumer)
 				r.testingKnobs.beforePublishingDescriptors = func() error {
 					if forceFailure {
@@ -8660,8 +8652,7 @@ func TestRestoreJobEventLogging(t *testing.T) {
 					return nil
 				}
 				return r
-			},
-		}
+			})
 	}
 
 	sqlDB.Exec(t, `CREATE DATABASE r1`)
@@ -9106,9 +9097,9 @@ func TestRestorePauseOnError(t *testing.T) {
 			jobRegistry = tc.Servers[i].TestTenants()[0].JobRegistry()
 		}
 
-		jobRegistry.(*jobs.Registry).TestingResumerCreationKnobs = map[jobspb.Type]func(raw jobs.Resumer) jobs.
-			Resumer{
-			jobspb.TypeRestore: func(raw jobs.Resumer) jobs.Resumer {
+		jobRegistry.(*jobs.Registry).TestingWrapResumerConstructor(
+			jobspb.TypeRestore,
+			func(raw jobs.Resumer) jobs.Resumer {
 				r := raw.(*restoreResumer)
 				r.testingKnobs.beforePublishingDescriptors = func() error {
 					if forceFailure {
@@ -9117,8 +9108,7 @@ func TestRestorePauseOnError(t *testing.T) {
 					return nil
 				}
 				return r
-			},
-		}
+			})
 	}
 
 	sqlDB.Exec(t, `CREATE DATABASE r1`)
@@ -9362,15 +9352,14 @@ func TestRestoreSchemaDescriptorsRollBack(t *testing.T) {
 
 	for _, server := range tc.Servers {
 		registry := server.JobRegistry().(*jobs.Registry)
-		registry.TestingResumerCreationKnobs = map[jobspb.Type]func(raw jobs.Resumer) jobs.Resumer{
-			jobspb.TypeRestore: func(raw jobs.Resumer) jobs.Resumer {
+		registry.TestingWrapResumerConstructor(jobspb.TypeRestore,
+			func(raw jobs.Resumer) jobs.Resumer {
 				r := raw.(*restoreResumer)
 				r.testingKnobs.beforePublishingDescriptors = func() error {
 					return errors.New("boom")
 				}
 				return r
-			},
-		}
+			})
 	}
 
 	sqlDB.Exec(t, `
@@ -9593,13 +9582,12 @@ func TestExportRequestBelowGCThresholdOnDataExcludedFromBackup(t *testing.T) {
 
 	for _, server := range tc.Servers {
 		registry := server.JobRegistry().(*jobs.Registry)
-		registry.TestingResumerCreationKnobs = map[jobspb.Type]func(raw jobs.Resumer) jobs.Resumer{
-			jobspb.TypeBackup: func(raw jobs.Resumer) jobs.Resumer {
+		registry.TestingWrapResumerConstructor(jobspb.TypeBackup,
+			func(raw jobs.Resumer) jobs.Resumer {
 				r := raw.(*backupResumer)
 				r.testingKnobs.ignoreProtectedTimestamps = true
 				return r
-			},
-		}
+			})
 	}
 	conn := tc.ServerConn(0)
 	sqlDB := sqlutils.MakeSQLRunner(conn)
@@ -10514,8 +10502,9 @@ func TestBackupRestoreTelemetryEvents(t *testing.T) {
 
 	var forceFailure bool
 	for i := range tc.Servers {
-		tc.TenantOrServer(i).JobRegistry().(*jobs.Registry).TestingResumerCreationKnobs = map[jobspb.Type]func(raw jobs.Resumer) jobs.Resumer{
-			jobspb.TypeRestore: func(raw jobs.Resumer) jobs.Resumer {
+		tc.TenantOrServer(i).JobRegistry().(*jobs.Registry).TestingWrapResumerConstructor(
+			jobspb.TypeRestore,
+			func(raw jobs.Resumer) jobs.Resumer {
 				r := raw.(*restoreResumer)
 				r.testingKnobs.beforePublishingDescriptors = func() error {
 					if forceFailure {
@@ -10524,8 +10513,7 @@ func TestBackupRestoreTelemetryEvents(t *testing.T) {
 					return nil
 				}
 				return r
-			},
-		}
+			})
 	}
 
 	sqlDB.Exec(t, `SET application_name = 'backup_test'`)

--- a/pkg/ccl/changefeedccl/alter_changefeed_test.go
+++ b/pkg/ccl/changefeedccl/alter_changefeed_test.go
@@ -687,14 +687,13 @@ func TestAlterChangefeedPersistSinkURI(t *testing.T) {
 
 	doneCh := make(chan struct{})
 	defer close(doneCh)
-	registry.TestingResumerCreationKnobs = map[jobspb.Type]func(raw jobs.Resumer) jobs.Resumer{
-		jobspb.TypeChangefeed: func(raw jobs.Resumer) jobs.Resumer {
+	registry.TestingWrapResumerConstructor(jobspb.TypeChangefeed,
+		func(raw jobs.Resumer) jobs.Resumer {
 			r := fakeResumer{
 				done: doneCh,
 			}
 			return &r
-		},
-	}
+		})
 
 	sqlDB.QueryRow(t, `CREATE CHANGEFEED FOR TABLE foo, bar INTO $1`, unredactedSinkURI).Scan(&changefeedID)
 

--- a/pkg/ccl/changefeedccl/show_changefeed_jobs_test.go
+++ b/pkg/ccl/changefeedccl/show_changefeed_jobs_test.go
@@ -152,14 +152,13 @@ func TestShowChangefeedJobs(t *testing.T) {
 	doneCh := make(chan struct{})
 	defer close(doneCh)
 
-	registry.TestingResumerCreationKnobs = map[jobspb.Type]func(raw jobs.Resumer) jobs.Resumer{
-		jobspb.TypeChangefeed: func(raw jobs.Resumer) jobs.Resumer {
+	registry.TestingWrapResumerConstructor(jobspb.TypeChangefeed,
+		func(raw jobs.Resumer) jobs.Resumer {
 			r := fakeResumer{
 				done: doneCh,
 			}
 			return &r
-		},
-	}
+		})
 
 	query = `SET CLUSTER SETTING kv.rangefeed.enabled = true`
 	sqlDB.Exec(t, query)
@@ -253,14 +252,13 @@ func TestShowChangefeedJobsStatusChange(t *testing.T) {
 	doneCh := make(chan struct{})
 	defer close(doneCh)
 
-	registry.TestingResumerCreationKnobs = map[jobspb.Type]func(raw jobs.Resumer) jobs.Resumer{
-		jobspb.TypeChangefeed: func(raw jobs.Resumer) jobs.Resumer {
+	registry.TestingWrapResumerConstructor(jobspb.TypeChangefeed,
+		func(raw jobs.Resumer) jobs.Resumer {
 			r := fakeResumer{
 				done: doneCh,
 			}
 			return &r
-		},
-	}
+		})
 
 	query = `SET CLUSTER SETTING kv.rangefeed.enabled = true`
 	sqlDB.Exec(t, query)

--- a/pkg/ccl/changefeedccl/testfeed_test.go
+++ b/pkg/ccl/changefeedccl/testfeed_test.go
@@ -684,18 +684,18 @@ func newDepInjector(srvs ...feedInjectable) *depInjector {
 			}
 
 		// Arrange for error reporting resumer to be used.
-		s.JobRegistry().(*jobs.Registry).TestingResumerCreationKnobs =
-			map[jobspb.Type]func(raw jobs.Resumer) jobs.Resumer{
-				jobspb.TypeChangefeed: func(raw jobs.Resumer) jobs.Resumer {
-					f := di.getJobFeed(raw.(*changefeedResumer).job.ID())
-					return &reportErrorResumer{
-						wrapped: raw,
-						jobFailed: func() {
-							f.jobFailed(f.FetchTerminalJobErr())
-						},
-					}
-				},
-			}
+		s.JobRegistry().(*jobs.Registry).TestingWrapResumerConstructor(
+			jobspb.TypeChangefeed,
+			func(raw jobs.Resumer) jobs.Resumer {
+				f := di.getJobFeed(raw.(*changefeedResumer).job.ID())
+				return &reportErrorResumer{
+					wrapped: raw,
+					jobFailed: func() {
+						f.jobFailed(f.FetchTerminalJobErr())
+					},
+				}
+			},
+		)
 	}
 
 	return di

--- a/pkg/ccl/streamingccl/streamingest/alter_replication_job_test.go
+++ b/pkg/ccl/streamingccl/streamingest/alter_replication_job_test.go
@@ -303,8 +303,8 @@ func TestTenantStatusWithFutureCutoverTime(t *testing.T) {
 	waitBeforeCh := make(chan struct{})
 	waitAfterCh := make(chan struct{})
 	registry := c.DestSysServer.JobRegistry().(*jobs.Registry)
-	registry.TestingResumerCreationKnobs = map[jobspb.Type]func(raw jobs.Resumer) jobs.Resumer{
-		jobspb.TypeStreamIngestion: func(raw jobs.Resumer) jobs.Resumer {
+	registry.TestingWrapResumerConstructor(jobspb.TypeStreamIngestion,
+		func(raw jobs.Resumer) jobs.Resumer {
 			r := blockingResumer{
 				orig:       raw,
 				waitBefore: waitBeforeCh,
@@ -312,8 +312,7 @@ func TestTenantStatusWithFutureCutoverTime(t *testing.T) {
 				ctx:        ctx,
 			}
 			return &r
-		},
-	}
+		})
 	defer ctxCancel()
 	unblockResumerStart := func() {
 		waitBeforeCh <- struct{}{}
@@ -392,8 +391,8 @@ func TestTenantStatusWithLatestCutoverTime(t *testing.T) {
 	waitBeforeCh := make(chan struct{})
 	waitAfterCh := make(chan struct{})
 	registry := c.DestSysServer.JobRegistry().(*jobs.Registry)
-	registry.TestingResumerCreationKnobs = map[jobspb.Type]func(raw jobs.Resumer) jobs.Resumer{
-		jobspb.TypeStreamIngestion: func(raw jobs.Resumer) jobs.Resumer {
+	registry.TestingWrapResumerConstructor(jobspb.TypeStreamIngestion,
+		func(raw jobs.Resumer) jobs.Resumer {
 			r := blockingResumer{
 				orig:       raw,
 				waitBefore: waitBeforeCh,
@@ -401,8 +400,7 @@ func TestTenantStatusWithLatestCutoverTime(t *testing.T) {
 				ctx:        ctx,
 			}
 			return &r
-		},
-	}
+		})
 	defer ctxCancel()
 	unblockResumerStart := func() {
 		waitBeforeCh <- struct{}{}

--- a/pkg/jobs/helpers.go
+++ b/pkg/jobs/helpers.go
@@ -26,3 +26,9 @@ func ResetConstructors() func() {
 		globalMu.constructors = old
 	}
 }
+
+// TestingWrapResumerConstructor injects a wrapper around resumer creation for
+// the specified job type.
+func (r *Registry) TestingWrapResumerConstructor(typ jobspb.Type, wrap func(Resumer) Resumer) {
+	r.creationKnobs.Store(typ, wrap)
+}

--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -165,7 +165,8 @@ type Registry struct {
 	// is not too loud.
 	withSessionEvery log.EveryN
 
-	TestingResumerCreationKnobs map[jobspb.Type]func(Resumer) Resumer
+	// test only overrides for resumer creation.
+	creationKnobs sync.Map
 }
 
 func (r *Registry) UpdateJobWithTxn(
@@ -1562,7 +1563,8 @@ func (r *Registry) createResumer(job *Job, settings *cluster.Settings) (Resumer,
 	if fn == nil {
 		return nil, errors.Errorf("no resumer is available for %s", payload.Type())
 	}
-	if wrapper := r.TestingResumerCreationKnobs[payload.Type()]; wrapper != nil {
+	if v, ok := r.creationKnobs.Load(payload.Type()); ok {
+		wrapper := v.(func(Resumer) Resumer)
 		return wrapper(fn(job, settings)), nil
 	}
 	return fn(job, settings), nil

--- a/pkg/sql/crdb_internal_test.go
+++ b/pkg/sql/crdb_internal_test.go
@@ -1527,10 +1527,9 @@ func TestInternalSystemJobsAccess(t *testing.T) {
 	// users requires jobs to be created and run. Thus, this test only creates jobs of type
 	// jobspb.TypeImport and overrides the import resumer.
 	registry := s.JobRegistry().(*jobs.Registry)
-	registry.TestingResumerCreationKnobs = map[jobspb.Type]func(raw jobs.Resumer) jobs.Resumer{}
-	registry.TestingResumerCreationKnobs[jobspb.TypeImport] = func(r jobs.Resumer) jobs.Resumer {
+	registry.TestingWrapResumerConstructor(jobspb.TypeImport, func(r jobs.Resumer) jobs.Resumer {
 		return &fakeResumer{}
-	}
+	})
 
 	asUser := func(user string, f func(userDB *sqlutils.SQLRunner)) {
 		pgURL := url.URL{

--- a/pkg/sql/importer/import_processor_test.go
+++ b/pkg/sql/importer/import_processor_test.go
@@ -715,10 +715,10 @@ func TestCSVImportCanBeResumed(t *testing.T) {
 	var jobID jobspb.JobID = -1
 	var importSummary roachpb.RowCount
 
-	registry.TestingResumerCreationKnobs = map[jobspb.Type]func(raw jobs.Resumer) jobs.Resumer{
+	registry.TestingWrapResumerConstructor(jobspb.TypeImport,
 		// Arrange for our special job resumer to be
 		// returned the very first time we start the import.
-		jobspb.TypeImport: func(raw jobs.Resumer) jobs.Resumer {
+		func(raw jobs.Resumer) jobs.Resumer {
 			resumer := raw.(*importResumer)
 			resumer.testingKnobs.alwaysFlushJobProgress = true
 			resumer.testingKnobs.afterImport = func(summary roachpb.RowCount) error {
@@ -733,8 +733,7 @@ func TestCSVImportCanBeResumed(t *testing.T) {
 				}
 			}
 			return resumer
-		},
-	}
+		})
 
 	testBarrier, csvBarrier := newSyncBarrier()
 	csv1 := newCsvGenerator(0, 10*batchSize+1, &intGenerator{}, &strGenerator{})
@@ -823,10 +822,10 @@ func TestCSVImportMarksFilesFullyProcessed(t *testing.T) {
 	var jobID jobspb.JobID = -1
 	var importSummary roachpb.RowCount
 
-	registry.TestingResumerCreationKnobs = map[jobspb.Type]func(raw jobs.Resumer) jobs.Resumer{
+	registry.TestingWrapResumerConstructor(jobspb.TypeImport,
 		// Arrange for our special job resumer to be
 		// returned the very first time we start the import.
-		jobspb.TypeImport: func(raw jobs.Resumer) jobs.Resumer {
+		func(raw jobs.Resumer) jobs.Resumer {
 			resumer := raw.(*importResumer)
 			resumer.testingKnobs.alwaysFlushJobProgress = true
 			resumer.testingKnobs.afterImport = func(summary roachpb.RowCount) error {
@@ -842,8 +841,7 @@ func TestCSVImportMarksFilesFullyProcessed(t *testing.T) {
 				}
 			}
 			return resumer
-		},
-	}
+		})
 
 	csv1 := newCsvGenerator(0, 10*batchSize+1, &intGenerator{}, &strGenerator{})
 	csv2 := newCsvGenerator(0, 20*batchSize-1, &intGenerator{}, &strGenerator{})

--- a/pkg/upgrade/upgrades/alter_jobs_add_job_type_test.go
+++ b/pkg/upgrade/upgrades/alter_jobs_add_job_type_test.go
@@ -145,15 +145,13 @@ func TestAlterSystemJobsTableAddJobTypeColumn(t *testing.T) {
 
 	// Start a job of each type.
 	registry := s.JobRegistry().(*jobs.Registry)
-	registry.TestingResumerCreationKnobs = map[jobspb.Type]func(raw jobs.Resumer) jobs.Resumer{}
 	jobspb.ForEachType(func(typ jobspb.Type) {
 		// The upgrade creates migration and schemachange jobs, so we do not
 		// need to create more. We should not override resumers for these job types,
 		// otherwise the upgrade will hang.
 		if typ != jobspb.TypeMigration && typ != jobspb.TypeSchemaChange {
-			registry.TestingResumerCreationKnobs[typ] = func(r jobs.Resumer) jobs.Resumer {
-				return &fakeResumer{}
-			}
+			registry.TestingWrapResumerConstructor(
+				typ, func(r jobs.Resumer) jobs.Resumer { return &fakeResumer{} })
 
 			record := jobs.Record{
 				Details: jobspb.JobDetailsForEveryJobType[typ],


### PR DESCRIPTION
Backport 1/1 commits from #102439.

/cc @cockroachdb/release

---

Replace map with sync.Map to ensure the access to testing knob overrides is thread safe.

Fixes: #110783

Release note: None

Release justification: test-only change.