### PR TITLE
build: build only the necessary arch for roachtests

### DIFF
--- a/build/teamcity/cockroach/ci/tests/roachtest_stress_impl.sh
+++ b/build/teamcity/cockroach/ci/tests/roachtest_stress_impl.sh
@@ -10,7 +10,11 @@ if [[ ! -f ~/.ssh/id_rsa.pub ]]; then
   ssh-keygen -q -C "roachtest-stress $(date)" -N "" -f ~/.ssh/id_rsa
 fi
 
-source "$root/build/teamcity/cockroach/nightlies/roachtest_compile_bits.sh"
+arch=amd64
+if [[ ${FIPS_ENABLED:-0} == 1 ]]; then
+  arch=amd64-fips
+fi
+$root/build/teamcity/cockroach/nightlies/roachtest_compile_bits.sh $arch
 
 # NOTE: we use the GOOGLE_CREDENTIALS environment here, rather than the
 # "ephemeral" variant. The former is specific to the roachtest stress job,

--- a/build/teamcity/cockroach/nightlies/roachtest_nightly_impl.sh
+++ b/build/teamcity/cockroach/nightlies/roachtest_nightly_impl.sh
@@ -10,7 +10,11 @@ if [[ ! -f ~/.ssh/id_rsa.pub ]]; then
   ssh-keygen -q -C "roachtest-nightly-bazel $(date)" -N "" -f ~/.ssh/id_rsa
 fi
 
-source $root/build/teamcity/cockroach/nightlies/roachtest_compile_bits.sh
+arch=amd64
+if [[ ${FIPS_ENABLED:-0} == 1 ]]; then
+  arch=amd64-fips
+fi
+$root/build/teamcity/cockroach/nightlies/roachtest_compile_bits.sh $arch
 
 artifacts=/artifacts
 source $root/build/teamcity/util/roachtest_util.sh

--- a/build/teamcity/cockroach/nightlies/roachtest_weekly_aws_impl.sh
+++ b/build/teamcity/cockroach/nightlies/roachtest_weekly_aws_impl.sh
@@ -10,7 +10,11 @@ if [[ ! -f ~/.ssh/id_rsa.pub ]]; then
   ssh-keygen -q -C "roachtest-weekly-bazel $(date)" -N "" -f ~/.ssh/id_rsa
 fi
 
-source $root/build/teamcity/cockroach/nightlies/roachtest_compile_bits.sh
+arch=amd64
+if [[ ${FIPS_ENABLED:-0} == 1 ]]; then
+  arch=amd64-fips
+fi
+$root/build/teamcity/cockroach/nightlies/roachtest_compile_bits.sh $arch
 
 artifacts=/artifacts
 source $root/build/teamcity/util/roachtest_util.sh

--- a/build/teamcity/cockroach/nightlies/roachtest_weekly_impl.sh
+++ b/build/teamcity/cockroach/nightlies/roachtest_weekly_impl.sh
@@ -10,7 +10,11 @@ if [[ ! -f ~/.ssh/id_rsa.pub ]]; then
   ssh-keygen -q -C "roachtest-weekly-bazel $(date)" -N "" -f ~/.ssh/id_rsa
 fi
 
-source $root/build/teamcity/cockroach/nightlies/roachtest_compile_bits.sh
+arch=amd64
+if [[ ${FIPS_ENABLED:-0} == 1 ]]; then
+  arch=amd64-fips
+fi
+$root/build/teamcity/cockroach/nightlies/roachtest_compile_bits.sh $arch
 
 artifacts=/artifacts
 source $root/build/teamcity/util/roachtest_util.sh

--- a/build/teamcity/internal/cockroach/nightlies/private_roachtest_impl.sh
+++ b/build/teamcity/internal/cockroach/nightlies/private_roachtest_impl.sh
@@ -6,7 +6,7 @@ dir="$(dirname $(dirname $(dirname $(dirname $(dirname "${0}")))))"
 
 source "$dir/teamcity-support.sh"
 
-source $root/build/teamcity/cockroach/nightlies/roachtest_compile_bits.sh crosslinux
+$root/build/teamcity/cockroach/nightlies/roachtest_compile_bits.sh amd64
 
 artifacts=/artifacts
 source $root/build/teamcity/util/roachtest_util.sh


### PR DESCRIPTION
The nightly roachtests (and other builds) use
`roachtest_compile_bits.sh` to build the necessary roachtest binaries. This script builds them for three architectures (amd64, amd64-fips, arm64), which takes almost 1 hour. Only one architecture is used for any given build.

This commit updates the script to take the necessary arch as an argument.

Epic: none
Release note: None