### PR TITLE
release 23.1: changefeedccl: add `changefeed.lagging_ranges` metric

### DIFF
--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -229,6 +229,7 @@ go_test(
         "//pkg/kv/kvclient/kvcoord",
         "//pkg/kv/kvpb",
         "//pkg/kv/kvserver",
+        "//pkg/kv/kvserver/closedts",
         "//pkg/kv/kvserver/kvserverbase",
         "//pkg/kv/kvserver/protectedts",
         "//pkg/kv/kvserver/protectedts/ptstorage",

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -1736,6 +1736,8 @@ func TestNoBackfillAfterNonTargetColumnDrop(t *testing.T) {
 
 func TestChangefeedColumnDropsWithFamilyAndNonFamilyTargets(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
 	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
 		sqlDB := sqlutils.MakeSQLRunner(s.DB)
 

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -51,6 +51,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/closedts"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/protectedts"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/protectedts/ptstorage"
@@ -1354,6 +1355,123 @@ func TestChangefeedInitialScan(t *testing.T) {
 	}
 
 	cdcTest(t, testFn)
+}
+
+// TestChangefeedLaggingRangesMetrics tests the behavior of the
+// changefeed.lagging_ranges metric.
+func TestChangefeedLaggingRangesMetrics(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
+		sqlDB := sqlutils.MakeSQLRunner(s.DB)
+
+		// Ensure a fast closed timestamp interval so ranges can catch up fast.
+		kvserver.RangeFeedRefreshInterval.Override(
+			context.Background(), &s.Server.ClusterSettings().SV, 20*time.Millisecond)
+		closedts.SideTransportCloseInterval.Override(
+			context.Background(), &s.Server.ClusterSettings().SV, 20*time.Millisecond)
+		closedts.TargetDuration.Override(
+			context.Background(), &s.Server.ClusterSettings().SV, 20*time.Millisecond)
+
+		changefeedbase.LaggingRangesPollingInterval.Override(
+			context.Background(), &s.Server.ClusterSettings().SV, 25*time.Millisecond)
+		changefeedbase.LaggingRangesThreshold.Override(
+			context.Background(), &s.Server.ClusterSettings().SV, 250*time.Millisecond)
+
+		skipMu := syncutil.Mutex{}
+		skippedRanges := map[string]struct{}{}
+		numRanges := 10
+		numRangesToSkip := int64(4)
+		var stopSkip atomic.Bool
+		// `shouldSkip` continuously skips checkpoints for the first `numRangesToSkip` ranges it sees.
+		// skipping is disabled by setting `stopSkip` to true.
+		shouldSkip := func(event *kvpb.RangeFeedEvent) bool {
+			if stopSkip.Load() {
+				return false
+			}
+			switch event.GetValue().(type) {
+			case *kvpb.RangeFeedCheckpoint:
+				sp := event.Checkpoint.Span
+				skipMu.Lock()
+				defer skipMu.Unlock()
+				if _, ok := skippedRanges[sp.String()]; ok || int64(len(skippedRanges)) < numRangesToSkip {
+					skippedRanges[sp.String()] = struct{}{}
+					return true
+				}
+			}
+			return false
+		}
+
+		knobs := s.TestingKnobs.DistSQL.(*execinfra.TestingKnobs).Changefeed.(*TestingKnobs)
+
+		knobs.FeedKnobs.RangefeedOptions = append(knobs.FeedKnobs.RangefeedOptions, kvcoord.TestingWithOnRangefeedEvent(
+			func(ctx context.Context, s roachpb.Span, event *kvpb.RangeFeedEvent) (skip bool, _ error) {
+				return shouldSkip(event), nil
+			}),
+		)
+
+		registry := s.Server.JobRegistry().(*jobs.Registry)
+		sli1, err := registry.MetricsStruct().Changefeed.(*Metrics).getSLIMetrics("t1")
+		require.NoError(t, err)
+		laggingRangesTier1 := sli1.LaggingRanges
+		sli2, err := registry.MetricsStruct().Changefeed.(*Metrics).getSLIMetrics("t2")
+		require.NoError(t, err)
+		laggingRangesTier2 := sli2.LaggingRanges
+
+		assertLaggingRanges := func(tier string, expected int64) {
+			testutils.SucceedsWithin(t, func() error {
+				var laggingRangesObserved int64
+				if tier == "t1" {
+					laggingRangesObserved = laggingRangesTier1.Value()
+				} else {
+					laggingRangesObserved = laggingRangesTier2.Value()
+				}
+				if laggingRangesObserved != expected {
+					return fmt.Errorf("expected %d lagging ranges, but found %d", expected, laggingRangesObserved)
+				}
+				return nil
+			}, 10*time.Second)
+		}
+
+		sqlDB.Exec(t, fmt.Sprintf(`
+		  CREATE TABLE foo (key INT PRIMARY KEY);
+		  INSERT INTO foo (key) SELECT * FROM generate_series(1, %d);
+		  ALTER TABLE foo SPLIT AT (SELECT * FROM generate_series(1, %d, 1));
+  		`, numRanges, numRanges-1))
+		sqlDB.CheckQueryResults(t, `SELECT count(*) FROM [SHOW RANGES FROM TABLE foo]`,
+			[][]string{{fmt.Sprint(numRanges)}},
+		)
+
+		feed1Tier1 := feed(t, f, `CREATE CHANGEFEED FOR foo WITH initial_scan='no', metrics_label="t1"`)
+		feed2Tier1 := feed(t, f, `CREATE CHANGEFEED FOR foo WITH initial_scan='no', metrics_label="t1"`)
+		feed3Tier2 := feed(t, f, `CREATE CHANGEFEED FOR foo WITH initial_scan='no', metrics_label="t2"`)
+
+		assertLaggingRanges("t1", numRangesToSkip*2)
+		assertLaggingRanges("t2", numRangesToSkip)
+
+		stopSkip.Store(true)
+		assertLaggingRanges("t1", 0)
+		assertLaggingRanges("t2", 0)
+
+		stopSkip.Store(false)
+		assertLaggingRanges("t1", numRangesToSkip*2)
+		assertLaggingRanges("t2", numRangesToSkip)
+
+		require.NoError(t, feed1Tier1.Close())
+		assertLaggingRanges("t1", numRangesToSkip)
+		assertLaggingRanges("t2", numRangesToSkip)
+
+		require.NoError(t, feed2Tier1.Close())
+		assertLaggingRanges("t1", 0)
+		assertLaggingRanges("t2", numRangesToSkip)
+
+		require.NoError(t, feed3Tier2.Close())
+		assertLaggingRanges("t1", 0)
+		assertLaggingRanges("t2", 0)
+	}
+	// Can't run on tenants due to lack of SPLIT AT support (#54254)
+	cdcTest(t, testFn, feedTestNoTenants, feedTestEnterpriseSinks)
 }
 
 func TestChangefeedBackfillObservability(t *testing.T) {

--- a/pkg/ccl/changefeedccl/changefeedbase/options.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/options.go
@@ -597,6 +597,8 @@ func (s StatementOptions) getEnumValue(k string) (string, error) {
 	return rawVal, nil
 }
 
+// getDurationValue validates that the option `k` was supplied with a
+// valid duration.
 func (s StatementOptions) getDurationValue(k string) (*time.Duration, error) {
 	v, ok := s.m[k]
 	if !ok {

--- a/pkg/ccl/changefeedccl/changefeedbase/settings.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/settings.go
@@ -305,3 +305,31 @@ var SinkPacerRequestSize = settings.RegisterDurationSetting(
 	50*time.Millisecond,
 	settings.PositiveDuration,
 )
+
+var defaultLaggingRangesThreshold = 3 * time.Minute
+
+var defaultLaggingRangesPollingInterval = 1 * time.Minute
+
+// LaggingRangesThreshold specifies the duration by which a range must
+// be lagging behind the present to be considered as 'lagging' behind in
+// metrics.
+var LaggingRangesThreshold = settings.RegisterDurationSetting(
+	settings.TenantWritable,
+	"changefeed.lagging_ranges_threshold",
+	"specifies the duration by which a range must be lagging behind the "+
+		"present to be considered as 'lagging' behind in metrics. will be "+
+		"removed in v23.2 in favor of a changefeed option",
+	defaultLaggingRangesThreshold,
+	settings.PositiveDuration,
+)
+
+// LaggingRangesPollingInterval is the polling rate at which lagging ranges are
+// checked and metrics are updated.
+var LaggingRangesPollingInterval = settings.RegisterDurationSetting(
+	settings.TenantWritable,
+	"changefeed.lagging_ranges_polling_interval",
+	"the polling rate at which lagging ranges are checked and "+
+		"corresponding metrics are updated. will be removed in v23.2 onwards",
+	defaultLaggingRangesPollingInterval,
+	settings.PositiveDuration,
+)

--- a/pkg/ccl/changefeedccl/kvfeed/kv_feed.go
+++ b/pkg/ccl/changefeedccl/kvfeed/kv_feed.go
@@ -15,6 +15,7 @@ package kvfeed
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/kvevent"
@@ -31,29 +32,46 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/span"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 )
 
-// Config configures a kvfeed.
-type Config struct {
-	Settings                *cluster.Settings
-	DB                      *kv.DB
-	Codec                   keys.SQLCodec
-	Clock                   *hlc.Clock
-	Gossip                  gossip.OptionalGossip
-	Spans                   []roachpb.Span
-	CheckpointSpans         []roachpb.Span
-	CheckpointTimestamp     hlc.Timestamp
-	Targets                 changefeedbase.Targets
-	Writer                  kvevent.Writer
-	Metrics                 *kvevent.Metrics
+// MonitoringConfig is a set of callbacks which the kvfeed calls to provide
+// the caller with information about the state of the kvfeed.
+type MonitoringConfig struct {
+	// LaggingRangesCallback is called periodically with the number of lagging ranges
+	// in the kvfeed.
+	LaggingRangesCallback func(int64)
+	// LaggingRangesPollingInterval is how often the kv feed will poll for
+	// lagging ranges.
+	LaggingRangesPollingInterval time.Duration
+	// LaggingRangesThreshold is how far behind a range must be to be considered
+	// lagging.
+	LaggingRangesThreshold time.Duration
+
 	OnBackfillCallback      func() func()
 	OnBackfillRangeCallback func(int64) (func(), func())
-	MM                      *mon.BytesMonitor
-	WithDiff                bool
-	SchemaChangeEvents      changefeedbase.SchemaChangeEventClass
-	SchemaChangePolicy      changefeedbase.SchemaChangePolicy
-	SchemaFeed              schemafeed.SchemaFeed
+}
+
+// Config configures a kvfeed.
+type Config struct {
+	Settings            *cluster.Settings
+	DB                  *kv.DB
+	Codec               keys.SQLCodec
+	Clock               *hlc.Clock
+	Gossip              gossip.OptionalGossip
+	Spans               []roachpb.Span
+	CheckpointSpans     []roachpb.Span
+	CheckpointTimestamp hlc.Timestamp
+	Targets             changefeedbase.Targets
+	Writer              kvevent.Writer
+	Metrics             *kvevent.Metrics
+	MonitoringCfg       MonitoringConfig
+	MM                  *mon.BytesMonitor
+	WithDiff            bool
+	SchemaChangeEvents  changefeedbase.SchemaChangeEventClass
+	SchemaChangePolicy  changefeedbase.SchemaChangePolicy
+	SchemaFeed          schemafeed.SchemaFeed
 
 	// If true, the feed will begin with a dump of data at exactly the
 	// InitialHighWater. This is a peculiar behavior. In general the
@@ -87,7 +105,7 @@ func Run(ctx context.Context, cfg Config) error {
 			settings:                cfg.Settings,
 			gossip:                  cfg.Gossip,
 			db:                      cfg.DB,
-			onBackfillRangeCallback: cfg.OnBackfillRangeCallback,
+			onBackfillRangeCallback: cfg.MonitoringCfg.OnBackfillRangeCallback,
 		}
 	}
 	var pff physicalFeedFactory
@@ -101,6 +119,7 @@ func Run(ctx context.Context, cfg Config) error {
 		return kvevent.NewMemBuffer(cfg.MM.MakeBoundAccount(), &cfg.Settings.SV, cfg.Metrics)
 	}
 
+	g := ctxgroup.WithContext(ctx)
 	f := newKVFeed(
 		cfg.Writer, cfg.Spans, cfg.CheckpointSpans, cfg.CheckpointTimestamp,
 		cfg.SchemaChangeEvents, cfg.SchemaChangePolicy,
@@ -109,9 +128,10 @@ func Run(ctx context.Context, cfg Config) error {
 		cfg.Codec,
 		cfg.SchemaFeed,
 		sc, pff, bf, cfg.UseMux, cfg.Targets, cfg.Knobs)
-	f.onBackfillCallback = cfg.OnBackfillCallback
+	f.onBackfillCallback = cfg.MonitoringCfg.OnBackfillCallback
+	f.rangeObserver = startLaggingRangesObserver(g, cfg.MonitoringCfg.LaggingRangesCallback,
+		cfg.MonitoringCfg.LaggingRangesPollingInterval, cfg.MonitoringCfg.LaggingRangesThreshold)
 
-	g := ctxgroup.WithContext(ctx)
 	g.GoCtx(cfg.SchemaFeed.Run)
 	g.GoCtx(f.run)
 	err := g.Wait()
@@ -155,6 +175,59 @@ func Run(ctx context.Context, cfg Config) error {
 	return err
 }
 
+func startLaggingRangesObserver(
+	g ctxgroup.Group,
+	updateLaggingRanges func(int64),
+	pollingInterval time.Duration,
+	threshold time.Duration,
+) func(fn kvcoord.ForEachRangeFn) {
+	return func(fn kvcoord.ForEachRangeFn) {
+		g.GoCtx(func(ctx context.Context) error {
+			// Reset metrics on shutdown.
+			defer func() {
+				updateLaggingRanges(0)
+			}()
+
+			var timer timeutil.Timer
+			defer timer.Stop()
+			timer.Reset(pollingInterval)
+
+			for {
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				case <-timer.C:
+					timer.Read = true
+
+					count := int64(0)
+					thresholdTS := timeutil.Now().Add(-1 * threshold)
+					err := fn(func(rfCtx kvcoord.RangeFeedContext, feed kvcoord.PartialRangeFeed) error {
+						// The resolved timestamp of a range determines the timestamp which is caught up to.
+						// However, during catchup scans, this is not set. For catchup scans, we consider the
+						// time the partial rangefeed was created to be its resolved ts. Note that a range can
+						// restart due to a range split, transient error etc. In these cases you also expect
+						// to see a `CreatedTime` but no resolved timestamp.
+						ts := feed.Resolved
+						if ts.IsEmpty() {
+							ts = hlc.Timestamp{WallTime: feed.CreatedTime.UnixNano()}
+						}
+
+						if ts.Less(hlc.Timestamp{WallTime: thresholdTS.UnixNano()}) {
+							count += 1
+						}
+						return nil
+					})
+					if err != nil {
+						return err
+					}
+					updateLaggingRanges(count)
+					timer.Reset(pollingInterval)
+				}
+			}
+		})
+	}
+}
+
 // schemaChangeDetectedError is a sentinel error to indicate to Run() that the
 // schema change is stopping due to a schema change. This is handy to trigger
 // the context group to stop; the error is handled entirely in this package.
@@ -178,6 +251,7 @@ type kvFeed struct {
 	codec               keys.SQLCodec
 
 	onBackfillCallback func() func()
+	rangeObserver      func(fn kvcoord.ForEachRangeFn)
 	schemaChangeEvents changefeedbase.SchemaChangeEventClass
 	schemaChangePolicy changefeedbase.SchemaChangePolicy
 
@@ -488,11 +562,12 @@ func (f *kvFeed) runUntilTableEvent(
 
 	g := ctxgroup.WithContext(ctx)
 	physicalCfg := rangeFeedConfig{
-		Spans:    stps,
-		Frontier: resumeFrontier.Frontier(),
-		WithDiff: f.withDiff,
-		Knobs:    f.knobs,
-		UseMux:   f.useMux,
+		Spans:         stps,
+		Frontier:      resumeFrontier.Frontier(),
+		WithDiff:      f.withDiff,
+		Knobs:         f.knobs,
+		UseMux:        f.useMux,
+		RangeObserver: f.rangeObserver,
 	}
 
 	// The following two synchronous calls works as follows:

--- a/pkg/ccl/changefeedccl/kvfeed/testing_knobs.go
+++ b/pkg/ccl/changefeedccl/kvfeed/testing_knobs.go
@@ -33,6 +33,8 @@ type TestingKnobs struct {
 	// ModifyTimestamps is called on the timestamp for each RangefeedMessage
 	// before converting it into a kv event.
 	ModifyTimestamps func(*hlc.Timestamp)
+	// RangefeedOptions lets the kvfeed override rangefeed settings.
+	RangefeedOptions []kvcoord.RangeFeedOption
 }
 
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.

--- a/pkg/ccl/changefeedccl/metrics.go
+++ b/pkg/ccl/changefeedccl/metrics.go
@@ -804,10 +804,15 @@ func (s *sliMetrics) getLaggingRangesCallback() func(int64) {
 	// If 3 ranges catch up, last=10,i=7: X.Dec(10 - 7) = X.Dec(3)
 	// If 4 ranges fall behind, last=7,i=11: X.Dec(7 - 11) = X.Inc(4)
 	// If 1 lagging range is deleted, last=7,i=10: X.Dec(11-10) = X.Dec(1)
-	var last int64
+	last := struct {
+		syncutil.Mutex
+		v int64
+	}{}
 	return func(i int64) {
-		s.LaggingRanges.Dec(last - i)
-		last = i
+		last.Lock()
+		defer last.Unlock()
+		s.LaggingRanges.Dec(last.v - i)
+		last.v = i
 	}
 }
 

--- a/pkg/ccl/changefeedccl/metrics.go
+++ b/pkg/ccl/changefeedccl/metrics.go
@@ -70,6 +70,7 @@ type AggMetrics struct {
 	SchemaRegistryRetries     *aggmetric.AggCounter
 	AggregatorProgress        *aggmetric.AggGauge
 	CheckpointProgress        *aggmetric.AggGauge
+	LaggingRanges             *aggmetric.AggGauge
 
 	// There is always at least 1 sliMetrics created for defaultSLI scope.
 	mu struct {
@@ -132,6 +133,7 @@ type sliMetrics struct {
 	SchemaRegistryRetries     *aggmetric.Counter
 	AggregatorProgress        *aggmetric.Gauge
 	CheckpointProgress        *aggmetric.Gauge
+	LaggingRanges             *aggmetric.Gauge
 
 	mu struct {
 		syncutil.Mutex
@@ -614,6 +616,12 @@ func newAggregateMetrics(histogramWindow time.Duration) *AggMetrics {
 		Measurement: "Unix Timestamp Nanoseconds",
 		Unit:        metric.Unit_TIMESTAMP_NS,
 	}
+	metaLaggingRangePercentage := metric.Metadata{
+		Name:        "changefeed.lagging_ranges",
+		Help:        "The number of ranges considered to be lagging behind",
+		Measurement: "Ranges",
+		Unit:        metric.Unit_COUNT,
+	}
 
 	functionalGaugeMinFn := func(childValues []int64) int64 {
 		var min int64
@@ -688,6 +696,7 @@ func newAggregateMetrics(histogramWindow time.Duration) *AggMetrics {
 		SchemaRegistrations:       b.Counter(metaSchemaRegistryRegistrations),
 		AggregatorProgress:        b.FunctionalGauge(metaAggregatorProgress, functionalGaugeMinFn),
 		CheckpointProgress:        b.FunctionalGauge(metaCheckpointProgress, functionalGaugeMinFn),
+		LaggingRanges:             b.Gauge(metaLaggingRangePercentage),
 	}
 	a.mu.sliMetrics = make(map[string]*sliMetrics)
 	_, err := a.getOrCreateScope(defaultSLIScope)
@@ -747,6 +756,7 @@ func (a *AggMetrics) getOrCreateScope(scope string) (*sliMetrics, error) {
 		InternalRetryMessageCount: a.InternalRetryMessageCount.AddChild(scope),
 		SchemaRegistryRetries:     a.SchemaRegistryRetries.AddChild(scope),
 		SchemaRegistrations:       a.SchemaRegistrations.AddChild(scope),
+		LaggingRanges:             a.LaggingRanges.AddChild(scope),
 	}
 	sm.mu.resolved = make(map[int64]hlc.Timestamp)
 	sm.mu.checkpoint = make(map[int64]hlc.Timestamp)
@@ -774,6 +784,31 @@ func (a *AggMetrics) getOrCreateScope(scope string) (*sliMetrics, error) {
 
 	a.mu.sliMetrics[scope] = sm
 	return sm, nil
+}
+
+// getLaggingRangesCallback returns a function which can be called to update the
+// lagging ranges metric. It should be called with the current number of lagging
+// ranges.
+func (s *sliMetrics) getLaggingRangesCallback() func(int64) {
+	// Because this gauge is shared between changefeeds in the same metrics scope,
+	// we must instead modify it using `Inc` and `Dec` (as opposed to `Update`) to
+	// ensure values written by others are not overwritten. The code below is used
+	// to determine the deltas based on the last known number of lagging ranges.
+	//
+	// Example:
+	//
+	// Initially there are 0 lagging ranges, so `last` is 0. Assume the gauge
+	// has an arbitrary value X.
+	//
+	// If 10 ranges are behind, last=0,i=10: X.Dec(0 - 10) = X.Inc(10)
+	// If 3 ranges catch up, last=10,i=7: X.Dec(10 - 7) = X.Dec(3)
+	// If 4 ranges fall behind, last=7,i=11: X.Dec(7 - 11) = X.Inc(4)
+	// If 1 lagging range is deleted, last=7,i=10: X.Dec(11-10) = X.Dec(1)
+	var last int64
+	return func(i int64) {
+		s.LaggingRanges.Dec(last - i)
+		last = i
+	}
 }
 
 // Metrics are for production monitoring of changefeeds.

--- a/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed_test.go
@@ -12,6 +12,8 @@ package kvcoord_test
 
 import (
 	"context"
+	"fmt"
+	"reflect"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -800,5 +802,116 @@ func TestRangeFeedMetricsManagement(t *testing.T) {
 
 		// We also know that we have blocked numCatchupToBlock ranges in their catchup scan.
 		require.EqualValues(t, numCatchupToBlock, metrics.RangefeedCatchupRanges.Value())
+	})
+}
+
+// TestRangefeedRangeObserver ensures the kvcoord.WithRangeObserver option
+// works correctly.
+func TestRangefeedRangeObserver(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{})
+	defer tc.Stopper().Stop(ctx)
+
+	ts := tc.Server(0)
+	sqlDB := sqlutils.MakeSQLRunner(tc.ServerConn(0))
+
+	kvserver.RangefeedEnabled.Override(
+		context.Background(), &ts.ClusterSettings().SV, true)
+
+	testutils.RunTrueAndFalse(t, "mux", func(t *testing.T, useMux bool) {
+		sqlDB.ExecMultiple(t,
+			`CREATE TABLE foo (key INT PRIMARY KEY)`,
+			`INSERT INTO foo (key) SELECT * FROM generate_series(1, 4)`,
+			`ALTER TABLE foo SPLIT AT (SELECT * FROM generate_series(1, 4, 1))`,
+		)
+		defer func() {
+			sqlDB.Exec(t, `DROP TABLE foo`)
+		}()
+
+		fooDesc := desctestutils.TestingGetPublicTableDescriptor(
+			ts.DB(), keys.SystemSQLCodec, "defaultdb", "foo")
+		fooSpan := fooDesc.PrimaryIndexSpan(keys.SystemSQLCodec)
+
+		ignoreValues := func(event kvcoord.RangeFeedMessage) {}
+
+		// Set up an observer to continuously poll for the list of ranges
+		// being watched.
+		var observedRangesMu syncutil.Mutex
+		observedRanges := make(map[string]struct{})
+		ctx2, cancel := context.WithCancel(context.Background())
+		g := ctxgroup.WithContext(ctx2)
+		defer func() {
+			cancel()
+			err := g.Wait()
+			// Ensure the observer goroutine terminates gracefully via context cancellation.
+			require.True(t, testutils.IsError(err, "context canceled"))
+		}()
+		observer := func(fn kvcoord.ForEachRangeFn) {
+			g.GoCtx(func(ctx context.Context) error {
+				for {
+					select {
+					case <-ctx.Done():
+						return ctx.Err()
+					case <-time.After(200 * time.Millisecond):
+					}
+					observedRangesMu.Lock()
+					observedRanges = make(map[string]struct{})
+					err := fn(func(rfCtx kvcoord.RangeFeedContext, feed kvcoord.PartialRangeFeed) error {
+						observedRanges[feed.Span.String()] = struct{}{}
+						return nil
+					})
+					observedRangesMu.Unlock()
+					if err != nil {
+						return err
+					}
+				}
+			})
+		}
+
+		closeFeed := rangeFeed(ts.DistSenderI(), fooSpan, ts.Clock().Now(), ignoreValues, useMux,
+			kvcoord.WithRangeObserver(observer))
+		defer closeFeed()
+
+		makeSpan := func(suffix string) string {
+			return fmt.Sprintf("/Table/%d/%s", fooDesc.GetID(), suffix)
+		}
+
+		// The initial set of ranges we expect to observe.
+		expectedRanges := map[string]struct{}{
+			makeSpan("1{-/1}"):  {},
+			makeSpan("1/{1-2}"): {},
+			makeSpan("1/{2-3}"): {},
+			makeSpan("1/{3-4}"): {},
+			makeSpan("{1/4-2}"): {},
+		}
+		checkExpectedRanges := func() {
+			testutils.SucceedsWithin(t, func() error {
+				observedRangesMu.Lock()
+				defer observedRangesMu.Unlock()
+				if !reflect.DeepEqual(observedRanges, expectedRanges) {
+					return errors.Newf("expected ranges %v, but got %v", expectedRanges, observedRanges)
+				}
+				return nil
+			}, 10*time.Second)
+		}
+		checkExpectedRanges()
+
+		// Add another range and ensure we can observe it.
+		sqlDB.ExecMultiple(t,
+			`INSERT INTO FOO VALUES(5)`,
+			`ALTER TABLE foo SPLIT AT VALUES(5)`,
+		)
+		expectedRanges = map[string]struct{}{
+			makeSpan("1{-/1}"):  {},
+			makeSpan("1/{1-2}"): {},
+			makeSpan("1/{2-3}"): {},
+			makeSpan("1/{3-4}"): {},
+			makeSpan("1/{4-5}"): {},
+			makeSpan("{1/5-2}"): {},
+		}
+		checkExpectedRanges()
 	})
 }

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -1659,6 +1659,12 @@ var charts = []sectionDescription{
 					"changefeed.checkpoint_progress",
 				},
 			},
+			{
+				Title: "Changefeed Lagging Ranges",
+				Metrics: []string{
+					"changefeed.lagging_ranges",
+				},
+			},
 		},
 	},
 	{


### PR DESCRIPTION
Backport commits from https://github.com/cockroachdb/cockroach/pull/109835, https://github.com/cockroachdb/cockroach/pull/110250

---

This change is a backport of the commit from https://github.com/cockroachdb/cockroach/pull/109835. The original chance uses
changefeed options to configure lagging ranges metrics. Because changefeed options
require version gates, they cannot be backported. This change instead uses cluster
settings.

This change adds the `changefeed.lagging_ranges` metric which can be used to track
ranges which are behind. This metric is calculated based on a new changefeed option
`lagging_ranges_threshold` which is the amount of time that a range
checkpoint needs to be in the past to be considered lagging. This defaults to 3 minutes.
This change also adds the changefeed option `lagging_ranges_polling_interval` which is
the polling rate at which a rangefeed will poll for lagging ranges and update the metric.
This defaults to 1 minute.

Sometimes a range may not have any checkpoints for a while because the start time
may be far in the past (this causes a catchup scan during which no checkpoints are emitted).
In this case, the range is considered to the lagging if the created timestamp of the
rangefeed is older than `changefeed.lagging_ranges_threshold`. Note that this means that
any changefeed which starts with an initial scan containing a significant amount of data will
likely indicate nonzero `changefeed.lagging_ranges` until the initial scan is complete. This
is intentional.

Release note (ops change): A new metric `changefeed.lagging_ranges` is added to show the number of
ranges which are behind in changefeeds. This metric can be used with the `metrics_label` changefeed
option. A new cluser setting `changefeed.lagging_ranges_threshold` is added which is the amount of
time a range needs to be behind to be considered lagging. By default this is 3 minutes. There is also
a new cluster setting `changefeed.lagging_ranges_polling_interval` which controls how often
the lagging ranges calculation is done. This setting defaults to polling every 1 minute.

Note that polling adds latency to the metric being updated. For example, if a range falls behind
by 3 minutes, the metric may not update until an additional minute afterwards.

Also note that ranges undergoing an initial scan for longer than the threshold are considered to be
lagging. Starting a changefeed with an initial scan on a large table will likely increment the metric
for each range in the table. However, as ranges complete the initial scan, the number of ranges will
decrease.

Epic: [CRDB-9181](https://cockroachlabs.atlassian.net/browse/CRDB-9181)

Release justification: Customer ask.