### PR TITLE
concurrency: re-imagine tryFreeOnReplicatedAcquire

### DIFF
--- a/pkg/kv/kvserver/concurrency/lock_table.go
+++ b/pkg/kv/kvserver/concurrency/lock_table.go
@@ -3452,48 +3452,104 @@ func (kl *keyLocks) requestDone(g *lockTableGuardImpl) (gc bool) {
 	return kl.isEmptyLock()
 }
 
-// tryFreeLockOnReplicatedAcquire attempts to free a write-uncontended lock
-// during the state transition from the Unreplicated durability to the
-// Replicated durability. This is possible because a Replicated lock is also
-// stored as an MVCC intent, so it does not need to also be stored in the
-// lockTable if locking requests are not queuing on it. This is beneficial
-// because it serves as a mitigation for #49973. Since we aren't currently great
-// at avoiding excessive contention on limited scans when locks are in the
-// lockTable, it's better the keep locks out of the lockTable when possible.
+// tryFreeLockOnReplicatedAcquire attempts to free a lock on a write-uncontended
+// key during a re-acquisition. The lock is free-ed only if the replicated lock
+// provides sufficient protection, whereby tracking the replicated lock is
+// pointless.
 //
-// If any of the readers do truly contend with this lock even after their limit
-// has been applied, they will notice during their MVCC scan and re-enter the
-// queue (possibly recreating the lock through AddDiscoveredLock). Still, in
-// practice this seems to work well in avoiding most of the artificial
-// concurrency discussed in #49973.
+// A boolean indicating whether the lock was free-ed or not is returned to the
+// caller. If it was free-ed, the caller should not re-add the replicate lock
+// back to the lock table. Additionally, if the last lock on a key was cleared,
+// it's the caller's responsibility to remove the receiver from the lock table's
+// tree. A boolean, mustGC, is returned true in this case.
 //
-// Acquires l.mu.
-func (kl *keyLocks) tryFreeLockOnReplicatedAcquire() bool {
+// Historically, this served as a mitigation for #49973, prior to the
+// introduction of optimistic evaluation. The benefits of keeping this scheme
+// around today are less pronounced, and may be re-evaluated.
+//
+// Acquires kl.mu.
+func (kl *keyLocks) tryFreeLockOnReplicatedAcquire(
+	acq *roachpb.LockAcquisition,
+) (freed bool, mustGC bool) {
 	kl.mu.Lock()
 	defer kl.mu.Unlock()
 
-	// Bail if not locked with only the Unreplicated durability.
-	if anyReplicated, _ := kl.isAnyLockHeldReplicated(); !kl.isLocked() || anyReplicated {
-		return false
+	if !kl.isLockedBy(acq.Txn.ID) {
+		// The lock isn't held by the transaction that's acquiring the replicated
+		// lock. There's no opportunity to free anything up.
+		return false /* freed */, false /* mustGC */
 	}
 
-	// Bail if the lock has waiting locking requests. It is not uncontended.
+	// Bail if the lock has waiting locking requests. It isn't uncontended, so we
+	// can't free it, otherwise:
+	// 1. EITHER the request would proceed to evaluation and re-discover the
+	// (newly acquired) replicated lock and re-add it to the lock table,
+	// performing wasted work.
+	// 2. OR it would wait on a different lock and give up a (potential) claim on
+	// this one, thereby allowing other requests to potentially barge in front of
+	// it once this lock is actually released.
 	if kl.queuedLockingRequests.Len() != 0 {
-		return false
+		return false /* freed */, false /* mustGC */
 	}
 
-	// The lock is uncontended by other locking requests, so we're safe to drop
-	// it. This may release non-locking readers who were waiting on the lock.
-	//
-	// TODO(arul): Once we support replicated shared locks, we only want to clear
-	// the lock holder that's promoting its durability from unreplicated to
-	// replicated -- not all lock holders.
-	kl.clearAllLockHolders()
+	tl := kl.heldBy[acq.Txn.ID].Value
+
+	// Bail if the transaction doesn't hold just an unreplicated lock -- there's
+	// no potential to forget anything here.
+	if !tl.isHeldUnreplicated() || tl.isHeldReplicated() {
+		return false /* freed */, false /* mustGC */
+	}
+
+	// Bail if there's an epoch number mismatch, as we can't compare sequence
+	// numbers across epochs. Note that we're not making any effort to forget
+	// unreplicated locks if the replicated lock acquisition corresponds to a
+	// newer epoch -- we defer to acquireLock to handle epcoh bumps instead.
+	if tl.txn.Epoch != acq.Txn.Epoch {
+		return false /* freed */, false /* mustGC */
+	}
+
+	// The transaction is trying to re-acquire a replicated lock on this key, and
+	// it holds an unreplicated lock that we may be able to forget as the key is
+	// uncontended. However, to do so, the replicated lock must provide enough
+	// protection to subsume the unreplicated lock(s). Check that.
+	canFree := true
+	for _, str := range unreplicatedHolderStrengths {
+		if str > acq.Strength && tl.unreplicatedInfo.held(str) {
+			// The replicated lock isn't of sufficient lock strength.
+			canFree = false
+			break
+		}
+		// NB: Strictly speaking, we should also be checking if the sequence number
+		// of the unreplicated lock we're about to forget here is less than or equal
+		// to the replicated lock acquisition. Otherwise, a savepoint rollback could
+		// cause us to roll back the replicated lock (in favor of which we're
+		// deciding to no longer track this unreplicated lock). However, this would
+		// mean that the common case of unreplicated locks being re-acquired as
+		// replicated ones won't be able to take advantage of this optimization
+		// (think SELECT FOR UPDATE or implicit exclusive locks acquired as part of
+		// UPDATE statements). We thus decide to ignore sequence numbers in our
+		// determination here -- savepoint rollbacks are rare enough. It's also
+		// not like unreplicated locks can't be lost for other reasons.
+	}
+	if !canFree {
+		// The replicated lock acquisition doesn't offer sufficient protection
+		return false /* freed */, false /* mustGC */
+	}
+
+	kl.clearLockHeldBy(acq.Txn.ID)
+	if kl.isLocked() {
+		return true /* freed */, false /* mustGC */
+	}
+
+	// If this was the only transaction that held the lock, then the key is now
+	// unlocked. Note that the waiters being released here are necessarily
+	// waiting readers -- if there were any contending locking requests, we
+	// wouldn't have gotten here.
 	gc := kl.releaseWaitersOnKeyUnlocked()
 	if !gc {
 		panic("expected lockIsFree to return true")
 	}
-	return true
+	return true /* freed */, true /* mustGC */
 }
 
 // releaseWaitersOnKeyUnlocked is called when the key, referenced in the
@@ -3907,9 +3963,9 @@ func (t *lockTableImpl) AcquireLock(acq *roachpb.LockAcquisition) error {
 	default:
 		return errors.AssertionFailedf("unsupported lock strength %s", acq.Strength)
 	}
-	var l *keyLocks
+	var kl *keyLocks
 	t.locks.mu.Lock()
-	// Can't release tree.mu until call l.acquireLock() since someone may find
+	// Can't release tree.mu until call kl.acquireLock() since someone may find
 	// an empty lock and remove it from the tree. If we expect that keyLocks
 	// will already be in tree we can optimize this by first trying with a
 	// tree.mu.RLock().
@@ -3929,30 +3985,36 @@ func (t *lockTableImpl) AcquireLock(acq *roachpb.LockAcquisition) error {
 		}
 		var lockSeqNum uint64
 		lockSeqNum, checkMaxLocks = t.locks.nextLockSeqNum()
-		l = &keyLocks{id: lockSeqNum, key: acq.Key}
-		l.queuedLockingRequests.Init()
-		l.waitingReaders.Init()
-		l.holders.Init()
-		l.heldBy = make(map[uuid.UUID]*list.Element[*txnLock])
-		t.locks.Set(l)
+		kl = &keyLocks{id: lockSeqNum, key: acq.Key}
+		kl.queuedLockingRequests.Init()
+		kl.waitingReaders.Init()
+		kl.holders.Init()
+		kl.heldBy = make(map[uuid.UUID]*list.Element[*txnLock])
+		t.locks.Set(kl)
 		t.locks.numKeysLocked.Add(1)
 	} else {
-		l = iter.Cur()
-		if acq.Durability == lock.Replicated && l.tryFreeLockOnReplicatedAcquire() {
-			// Don't remember uncontended replicated locks. Just like in the
-			// case where the lock is initially added as replicated, we drop
-			// replicated locks from the lockTable when being upgraded from
-			// Unreplicated to Replicated, whenever possible.
-			// TODO(sumeer): now that limited scans evaluate optimistically, we
-			// should consider removing this hack. But see the comment in the
-			// preceding block about maxKeysLocked.
-			t.locks.Delete(l)
-			t.locks.mu.Unlock()
-			t.locks.numKeysLocked.Add(-1)
-			return nil
+		kl = iter.Cur()
+		if acq.Durability == lock.Replicated {
+			if freed, mustGC := kl.tryFreeLockOnReplicatedAcquire(acq); freed {
+				// Don't remember uncontended replicated locks. Just like in the case
+				// where the lock is initially added as replicated, we drop replicated
+				// locks from the lockTable when being upgraded from Unreplicated to
+				// Replicated, whenever possible.
+				//
+				// TODO(sumeer): now that limited scans evaluate optimistically, we should
+				// consider removing this hack. But see the comment in the preceding block
+				// about maxKeysLocked.
+				if mustGC {
+					// The key is no longer locked; it can be removed from the tree.
+					t.locks.Delete(kl)
+					t.locks.numKeysLocked.Add(-1)
+				}
+				t.locks.mu.Unlock()
+				return nil // don't remember the replicated lock
+			}
 		}
 	}
-	err := l.acquireLock(acq, t.clock, t.settings)
+	err := kl.acquireLock(acq, t.clock, t.settings)
 	t.locks.mu.Unlock()
 
 	if checkMaxLocks {

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/lock_dropped
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/lock_dropped
@@ -10,6 +10,9 @@ new-lock-table maxlocks=10000
 new-txn txn=txn1 ts=10 epoch=0 seq=2
 ----
 
+new-txn txn=txn2 ts=10 epoch=0 seq=1
+----
+
 new-request r=req1 txn=txn1 ts=10 spans=intent@a+exclusive@a
 ----
 
@@ -184,3 +187,269 @@ num=0
 guard-state r=req3
 ----
 new: state=doneWaiting
+
+# ------------------------------------------------------------------------------
+# Test locks are dropped regardless of the sequence number the replicated lock
+# is being acquired at. If the replicated lock is acquired at a higher sequence
+# number and we drop the lock, the replicaed lock may not provide sufficient
+# protection in the face of sequence number rollbacks. See
+# tryFreeOnReplicatedAcquire for details, but while we have this behavior, we
+# add tests for it.
+# ------------------------------------------------------------------------------
+
+clear
+----
+num=0
+
+new-request r=req4 txn=txn1 ts=10 spans=exclusive@a
+----
+
+scan r=req4
+----
+start-waiting: false
+
+acquire k=a r=req4 durability=u strength=exclusive
+----
+num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 2)]
+
+# Replicated re-acquisition at higher sequence number.
+new-txn txn=txn1 ts=10 epoch=0 seq=4
+----
+
+new-request r=req5 txn=txn1 ts=10 spans=exclusive@a
+----
+
+scan r=req5
+----
+start-waiting: false
+
+acquire k=a r=req5 durability=r strength=exclusive
+----
+num=0
+
+# Replicated re-acquisition at lower sequence number.
+acquire k=a r=req4 durability=u strength=exclusive
+----
+num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 2)]
+
+new-txn txn=txn1 ts=10 epoch=0 seq=1
+----
+
+new-request r=req6 txn=txn1 ts=10 spans=exclusive@a
+----
+
+scan r=req6
+----
+start-waiting: false
+
+acquire k=a r=req6 durability=r strength=exclusive
+----
+num=0
+
+# ------------------------------------------------------------------------------
+# Test unreplicated locks aren't dropped if the lock acquisition corresponds to
+# a weaker lock strength, as the lock doesn't offer enough protection. We check
+# for sequence numbers at, below, and above the unreplicated lock's sequence
+# number.
+# ------------------------------------------------------------------------------
+
+new-txn txn=txn1 ts=10 epoch=0 seq=2
+----
+
+new-request r=req7 txn=txn1 ts=10 spans=exclusive@a
+----
+
+scan r=req7
+----
+start-waiting: false
+
+acquire k=a r=req7 durability=u strength=exclusive
+----
+num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 2)]
+
+# At the unreplicated lock's sequence number.
+new-request r=req8 txn=txn1 ts=10 spans=shared@a
+----
+
+scan r=req8
+----
+start-waiting: false
+
+acquire k=a r=req8 durability=r strength=shared
+----
+num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Shared], unrepl [(str: Exclusive seq: 2)]
+
+# Lower sequence number.
+new-txn txn=txn1 ts=10 epoch=0 seq=1
+----
+
+new-request r=req9 txn=txn1 ts=10 spans=shared@a
+----
+
+scan r=req9
+----
+start-waiting: false
+
+acquire k=a r=req9 durability=r strength=shared
+----
+num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Shared], unrepl [(str: Exclusive seq: 2)]
+
+# Higher sequence number.
+new-txn txn=txn1 ts=10 epoch=0 seq=3
+----
+
+new-request r=req10 txn=txn1 ts=10 spans=shared@a
+----
+
+scan r=req10
+----
+start-waiting: false
+
+acquire k=a r=req10 durability=r strength=shared
+----
+num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Shared], unrepl [(str: Exclusive seq: 2)]
+
+# ------------------------------------------------------------------------------
+# Test interactions with shared locks. Each transaction's shared locks should be
+# handled independently. The key should only be unlocked once all shared locks
+# are released.
+# ------------------------------------------------------------------------------
+
+clear
+----
+num=0
+
+new-request r=req11 txn=txn1 ts=10 spans=shared@a
+----
+
+scan r=req11
+----
+start-waiting: false
+
+acquire k=a r=req11 durability=u strength=shared
+----
+num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 3)]
+
+
+new-request r=req12 txn=txn2 ts=10 spans=shared@a
+----
+
+scan r=req12
+----
+start-waiting: false
+
+acquire k=a r=req12 durability=u strength=shared
+----
+num=1
+ lock: "a"
+  holders: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 3)]
+           txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
+
+new-request r=req13 txn=txn1 ts=10 spans=shared@a
+----
+
+scan r=req13
+----
+start-waiting: false
+
+acquire k=a r=req13 durability=r strength=shared
+----
+num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
+
+# Ensure a replicated lock acquisition by a different txn (txn1) doesn't release
+# the shared lock.
+
+acquire k=a r=req13 durability=r strength=shared
+----
+num=1
+ lock: "a"
+  holders: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
+           txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, info: repl [Shared]
+
+release span=a txn=txn1
+----
+num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
+
+new-request r=req14 txn=txn2 ts=10 spans=shared@a
+----
+
+scan r=req14
+----
+start-waiting: false
+
+acquire k=a r=req14 durability=r strength=shared
+----
+num=0
+
+# ------------------------------------------------------------------------------
+# Ensure unreplicated locks aren't forgotten if the replicated lock acquisition
+# belongs to a different epoch.
+# ------------------------------------------------------------------------------
+
+new-txn txn=txn1 ts=10 epoch=1 seq=0
+----
+
+new-request r=req15 txn=txn1 ts=10 spans=shared@a
+----
+
+scan r=req15
+----
+start-waiting: false
+
+acquire k=a r=req15 durability=u strength=shared
+----
+num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
+
+# Lower epoch.
+new-txn txn=txn1 ts=10 epoch=0 seq=0
+----
+
+new-request r=req16 txn=txn1 ts=10 spans=shared@a
+----
+
+scan r=req16
+----
+start-waiting: false
+
+acquire k=a r=req16 durability=r strength=shared
+----
+num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, iso: Serializable, info: repl [Shared], unrepl [(str: Shared seq: 0)]
+
+# Higher epoch.
+new-txn txn=txn1 ts=10 epoch=2 seq=0
+----
+
+new-request r=req17 txn=txn1 ts=10 spans=shared@a
+----
+
+scan r=req17
+----
+start-waiting: false
+
+acquire k=a r=req17 durability=r strength=shared
+----
+num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 2, iso: Serializable, info: repl [Shared]


### PR DESCRIPTION
A lot has changed with locks recently. We now support shared locks and intents are no longer the only form of replicated locks. This requires a re-imagination of how tryFreeOnReplicatedAcquire works.

Epic: none

Release note: None