### PR TITLE
release-22.2: kv: wait on latches on each key in reverse acquisition order

### DIFF
--- a/pkg/kv/kvserver/spanlatch/manager.go
+++ b/pkg/kv/kvserver/spanlatch/manager.go
@@ -426,7 +426,16 @@ func (m *Manager) insertLocked(lg *Guard) {
 }
 
 func (m *Manager) nextIDLocked() uint64 {
-	m.idAlloc++
+	// We allocate IDs from the top of the uint64 space and in reverse order.
+	// This is done to order latches in the tree on a same key in reverse order
+	// of acquisition. Doing so ensures that when we iterate over the tree and
+	// see a key with many conflicting latches, we visit the latches on that key
+	// in the reverse order that they will be released. In doing so, we minimize
+	// the number of open channels that we wait on (calls to waitForSignal) and
+	// minimize the number of goroutine scheduling points. This is important to
+	// avoid spikes in runnable goroutine after each request completes, which
+	// can negatively affect node health.
+	m.idAlloc--
 	return m.idAlloc
 }
 


### PR DESCRIPTION
Backport 1/1 commits from #109349.

/cc @cockroachdb/release

---

This commit allocates latch IDs from the top of the uint64 space and in reverse order. This is done to order latches in the tree on the same key in reverse order of acquisition. Doing so ensures that when we iterate over the tree and see a key with many conflicting latches, we visit the latches on that key in the reverse order that they will be released. In doing so, we minimize the number of open channels that we wait on (calls to `waitForSignal`) and minimize the number of goroutine scheduling points. This is important to avoid spikes in runnable goroutine after each request completes, which can negatively affect node health.

See [experiments below](https://github.com/cockroachdb/cockroach/pull/109349#issuecomment-1690386251).

Epic: None
Release note (performance improvement): The impact of high concurrency blind writes to the same key on goroutine scheduling latency was reduced.

----

Release justification: small performance and stability improvement.
