### PR TITLE
syntheticprivilege: admin always has ALL global privileges

### DIFF
--- a/pkg/ccl/backupccl/testdata/backup-restore/backup-permissions
+++ b/pkg/ccl/backupccl/testdata/backup-restore/backup-permissions
@@ -46,7 +46,7 @@ REVOKE ADMIN FROM testuser
 exec-sql user=testuser
 BACKUP INTO 'userfile:///test-nonroot-cluster';
 ----
-pq: only users with the admin role or the BACKUP system privilege are allowed to perform full cluster backups: user testuser does not have BACKUP privilege on global 
+pq: only users with the admin role or the BACKUP system privilege are allowed to perform full cluster backups: user testuser does not have BACKUP system privilege
 
 # Grant system backup privilege and re-run the backup.
 exec-sql

--- a/pkg/ccl/backupccl/testdata/backup-restore/backup-permissions-deprecated
+++ b/pkg/ccl/backupccl/testdata/backup-restore/backup-permissions-deprecated
@@ -61,7 +61,7 @@ CREATE USER testuser
 exec-sql user=testuser
 BACKUP INTO 'nodelocal://1/test2'
 ----
-pq: only users with the admin role or the BACKUP system privilege are allowed to perform full cluster backups: user testuser does not have BACKUP privilege on global 
+pq: only users with the admin role or the BACKUP system privilege are allowed to perform full cluster backups: user testuser does not have BACKUP system privilege
 
 # Database backup as a non-admin user should have CONNECT on database and SELECT on tables.
 exec-sql user=testuser

--- a/pkg/ccl/backupccl/testdata/backup-restore/restore-permissions
+++ b/pkg/ccl/backupccl/testdata/backup-restore/restore-permissions
@@ -187,7 +187,7 @@ CREATE USER testuser;
 exec-sql user=testuser
 RESTORE FROM LATEST IN 'nodelocal://1/foo';
 ----
-pq: only users with the admin role or the RESTORE system privilege are allowed to perform a cluster restore: user testuser does not have RESTORE privilege on global 
+pq: only users with the admin role or the RESTORE system privilege are allowed to perform a cluster restore: user testuser does not have RESTORE system privilege
 
 exec-sql
 GRANT SYSTEM RESTORE TO testuser;

--- a/pkg/ccl/backupccl/testdata/backup-restore/restore-permissions-deprecated
+++ b/pkg/ccl/backupccl/testdata/backup-restore/restore-permissions-deprecated
@@ -38,7 +38,7 @@ CREATE USER testuser
 exec-sql cluster=s2 user=testuser
 RESTORE FROM LATEST IN 'nodelocal://1/test/'
 ----
-pq: only users with the admin role or the RESTORE system privilege are allowed to perform a cluster restore: user testuser does not have RESTORE privilege on global 
+pq: only users with the admin role or the RESTORE system privilege are allowed to perform a cluster restore: user testuser does not have RESTORE system privilege
 
 exec-sql cluster=s2 user=testuser
 RESTORE DATABASE d FROM LATEST IN 'nodelocal://1/test/'

--- a/pkg/ccl/backupccl/testdata/backup-restore/restore-schema-only
+++ b/pkg/ccl/backupccl/testdata/backup-restore/restore-schema-only
@@ -71,7 +71,7 @@ CREATE USER testuser
 exec-sql user=testuser
 RESTORE FROM LATEST IN 'nodelocal://1/full_cluster_backup/' with schema_only
 ----
-pq: only users with the admin role or the RESTORE system privilege are allowed to perform a cluster restore: user testuser does not have RESTORE privilege on global 
+pq: only users with the admin role or the RESTORE system privilege are allowed to perform a cluster restore: user testuser does not have RESTORE system privilege
 
 # Fail fast using a database backup
 exec-sql

--- a/pkg/ccl/backupccl/testdata/backup-restore/restore-validation-only
+++ b/pkg/ccl/backupccl/testdata/backup-restore/restore-validation-only
@@ -77,7 +77,7 @@ CREATE USER testuser
 exec-sql user=testuser
 RESTORE FROM LATEST IN 'nodelocal://1/full_cluster_backup/' with schema_only, verify_backup_table_data
 ----
-pq: only users with the admin role or the RESTORE system privilege are allowed to perform a cluster restore: user testuser does not have RESTORE privilege on global 
+pq: only users with the admin role or the RESTORE system privilege are allowed to perform a cluster restore: user testuser does not have RESTORE system privilege
 
 # Fail fast using a database backup
 exec-sql

--- a/pkg/ccl/backupccl/testdata/backup-restore/schedule-privileges
+++ b/pkg/ccl/backupccl/testdata/backup-restore/schedule-privileges
@@ -54,7 +54,7 @@ REVOKE ADMIN FROM testuser;
 exec-sql user=testuser
 CREATE SCHEDULE foocluster FOR BACKUP INTO 'external://foo/cluster' RECURRING '@hourly';
 ----
-pq: failed to dry run backup: only users with the admin role or the BACKUP system privilege are allowed to perform full cluster backups: user testuser does not have BACKUP privilege on global 
+pq: failed to dry run backup: only users with the admin role or the BACKUP system privilege are allowed to perform full cluster backups: user testuser does not have BACKUP system privilege
 
 exec-sql user=testuser
 CREATE SCHEDULE foodb FOR BACKUP DATABASE foo INTO 'external://foo/database' RECURRING '@hourly';

--- a/pkg/ccl/streamingccl/streamproducer/replication_manager_test.go
+++ b/pkg/ccl/streamingccl/streamproducer/replication_manager_test.go
@@ -78,12 +78,12 @@ func TestReplicationManagerRequiresReplicationPrivilege(t *testing.T) {
 		{user: "admin", expErr: "", isEnterprise: true},
 		{user: "root", expErr: "", isEnterprise: true},
 		{user: "somebody", expErr: "", isEnterprise: true},
-		{user: "nobody", expErr: "user nobody does not have REPLICATION privilege on global", isEnterprise: true},
+		{user: "nobody", expErr: "user nobody does not have REPLICATION system privilege", isEnterprise: true},
 
 		{user: "admin", expErr: "use of REPLICATION requires an enterprise license", isEnterprise: false},
 		{user: "root", expErr: " use of REPLICATION requires an enterprise license", isEnterprise: false},
 		{user: "somebody", expErr: "use of REPLICATION requires an enterprise license", isEnterprise: false},
-		{user: "nobody", expErr: "user nobody does not have REPLICATION privilege on global", isEnterprise: false},
+		{user: "nobody", expErr: "user nobody does not have REPLICATION system privilege", isEnterprise: false},
 	} {
 		t.Run(fmt.Sprintf("%s/ent=%t", tc.user, tc.isEnterprise), func(t *testing.T) {
 			if tc.isEnterprise {

--- a/pkg/sql/authorization.go
+++ b/pkg/sql/authorization.go
@@ -1069,6 +1069,14 @@ func insufficientPrivilegeError(
 			user, typeForError, object.GetName())
 	}
 
+	// Make a slightly different message for the global privilege object so that
+	// it uses more understandable user-facing language.
+	if object.GetObjectType() == privilege.Global {
+		return pgerror.Newf(pgcode.InsufficientPrivilege,
+			"user %s does not have %s system privilege",
+			user, kind)
+	}
+
 	return pgerror.Newf(pgcode.InsufficientPrivilege,
 		"user %s does not have %s privilege on %s %s",
 		user, kind, typeForError, object.GetName())

--- a/pkg/sql/logictest/testdata/logic_test/tenant
+++ b/pkg/sql/logictest/testdata/logic_test/tenant
@@ -142,7 +142,7 @@ set default_transaction_read_only = off;
 
 user testuser
 
-statement error user testuser does not have MANAGETENANT privilege on global
+statement error user testuser does not have MANAGETENANT system privilege
 CREATE TENANT four
 
 subtest drop_tenant
@@ -195,13 +195,13 @@ set default_transaction_read_only = off;
 
 user testuser
 
-statement error user testuser does not have MANAGETENANT privilege on global
+statement error user testuser does not have MANAGETENANT system privilege
 DROP TENANT three
 
-statement error user testuser does not have MANAGETENANT privilege on global
+statement error user testuser does not have MANAGETENANT system privilege
 SHOW TENANTS
 
-statement error user testuser does not have MANAGETENANT privilege on global
+statement error user testuser does not have MANAGETENANT system privilege
 SHOW TENANT 'two'
 
 user root

--- a/pkg/sql/logictest/testdata/logic_test/tenant_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/tenant_builtins
@@ -264,13 +264,13 @@ SELECT crdb_internal.update_tenant_resource_limits('tenant-number-ten', 1000, 10
 
 user testuser
 
-statement error user testuser does not have MANAGETENANT privilege on global
+statement error user testuser does not have MANAGETENANT system privilege
 SELECT crdb_internal.create_tenant(314)
 
-statement error user testuser does not have MANAGETENANT privilege on global
+statement error user testuser does not have MANAGETENANT system privilege
 SELECT crdb_internal.create_tenant('not-allowed')
 
-statement error user testuser does not have MANAGETENANT privilege on global
+statement error user testuser does not have MANAGETENANT system privilege
 DROP TENANT [1]
 
 statement error only users with the admin role are allowed to gc tenant

--- a/pkg/sql/syntheticprivilege/README.md
+++ b/pkg/sql/syntheticprivilege/README.md
@@ -361,7 +361,7 @@ See: `sql/logictest/testdata/logic_test/system_privileges`
 ```sql
 user testuser
 
-statement error pq: user testuser does not have MODIFYCLUSTERSETTING privilege on Global
+statement error pq: user testuser does not have MODIFYCLUSTERSETTING system privilege
 SELECT * FROM crdb_internal.cluster_settings;
 
 user root
@@ -386,7 +386,7 @@ REVOKE SYSTEM MODIFYCLUSTERSETTING FROM testuser
 
 user testuser
 
-statement error pq: user testuser does not have MODIFYCLUSTERSETTING privilege on Global
+statement error pq: user testuser does not have MODIFYCLUSTERSETTING system privilege
 SELECT * FROM crdb_internal.cluster_settings;
 
 user root

--- a/pkg/sql/syntheticprivilegecache/cache.go
+++ b/pkg/sql/syntheticprivilegecache/cache.go
@@ -171,6 +171,11 @@ func (c *Cache) readFromStorage(
 		}
 	}
 
+	// Admin always has ALL global privileges.
+	if spo.GetObjectType() == privilege.Global {
+		privDesc.Grant(username.AdminRoleName(), privilege.List{privilege.ALL}, true)
+	}
+
 	// We use InvalidID to skip checks on the root/admin roles having
 	// privileges.
 	validPrivs, err := privilege.GetValidPrivilegesForObject(spo.GetObjectType())


### PR DESCRIPTION
### syntheticprivilege: admin always has ALL global privileges

As we move away from requiring the admin role to perform cluster
debug/repair operations, we want to use a privilege instead. To
facilitate that, the admin role now implicitly has ALL global
privileges. The privilege for admins is not revokeable.

---

### sql: use better error message for missing system privilege

Since we document privileges on the GlobalPrivilegeObject using the
phrase "system privilege", we should make the error message say that
too.

informs https://github.com/cockroachdb/cockroach/issues/109814
Release note: None