### PR TITLE
kv: mark kvnemesis tests as "medium" sized

### DIFF
--- a/pkg/kv/kvnemesis/BUILD.bazel
+++ b/pkg/kv/kvnemesis/BUILD.bazel
@@ -58,7 +58,7 @@ go_library(
 
 go_test(
     name = "kvnemesis_test",
-    size = "small",
+    size = "medium",
     srcs = [
         "applier_test.go",
         "engine_test.go",
@@ -68,7 +68,7 @@ go_test(
         "operations_test.go",
         "validator_test.go",
     ],
-    args = ["-test.timeout=55s"],
+    args = ["-test.timeout=295s"],
     data = glob(["testdata/**"]),
     embed = [":kvnemesis"],
     deps = [


### PR DESCRIPTION
Fixes #110464.
Fixes #110519.

This commit marks the kvnemesis tests as "medium" size and increases their timeout from 55s to 295s, which is inline with other "medium" size tests. The slowest of the tests in this package is `TestKVNemesisMultiNode`, which regularly takes about 35s to run on a gceworker. It's not surprising that we were occasionally seeing timeouts in CI with the 55s timeout.

Release note: None