### PR TITLE
catpb: make JobID implement fmt.Stringer

### DIFF
--- a/pkg/sql/catalog/catpb/job_id.go
+++ b/pkg/sql/catalog/catpb/job_id.go
@@ -10,6 +10,8 @@
 
 package catpb
 
+import "strconv"
+
 // JobID is the ID of a job. It is defined here and imported in jobspb because
 // jobs are referenced in descriptors and also jobs reference parts of
 // descriptors. This avoids any dependency cycles.
@@ -20,3 +22,8 @@ const InvalidJobID JobID = 0
 
 // SafeValue implements the redact.SafeValue interface.
 func (j JobID) SafeValue() {}
+
+// String implements the fmt.Stringer interface.
+func (j JobID) String() string {
+	return strconv.Itoa(int(j))
+}


### PR DESCRIPTION
This will make some things nicer (e.g. in roachtest/tests/jobs.go we used %s format directive).

Touches: #110782.

Epic: None

Release note: None