### PR TITLE
roachtest: use correct format directive for job ID

### DIFF
--- a/pkg/cmd/roachtest/tests/jobs.go
+++ b/pkg/cmd/roachtest/tests/jobs.go
@@ -125,7 +125,7 @@ func executeNodeShutdown(
 					t.Status("job completed")
 					return nil
 				case jobs.StatusRunning:
-					t.L().Printf("job %s still running, waiting to succeed", jobID)
+					t.L().Printf("job %d still running, waiting to succeed", jobID)
 				default:
 					// Waiting for job to complete.
 					return errors.Newf("unexpectedly found job %s in state %s", jobID, status)


### PR DESCRIPTION
`catpb.JobID` doesn't implement `fmt.Stringer`.

Touches: #110782.

Epic: None

Release note: None