### PR TITLE
settings: retire changefeed lagging ranges settings

### DIFF
--- a/pkg/settings/registry.go
+++ b/pkg/settings/registry.go
@@ -189,6 +189,8 @@ var retiredSettings = map[InternalKey]struct{}{
 	"timeseries.storage.30m_resolution_ttl":                    {},
 	"server.cpu_profile.enabled":                               {},
 	"kv.rangefeed.catchup_scan_concurrency":                    {},
+	"changefeed.lagging_ranges_threshold":                      {},
+	"changefeed.lagging_ranges_polling_rate":                   {},
 }
 
 // sqlDefaultSettings is the list of "grandfathered" existing sql.defaults


### PR DESCRIPTION
These settings were added to 23.1 and 22.2 in patch versions via #110963 and #110970. These settings will not exists in 23.2 onwards, so this commit adds them to the retired settings list for 23.2.

Release note: None
Epic: None