### PR TITLE
release-23.1: roachtest: tolerate errors in clearrange workload

### DIFF
--- a/pkg/cmd/roachtest/tests/clearrange.go
+++ b/pkg/cmd/roachtest/tests/clearrange.go
@@ -160,7 +160,7 @@ ORDER BY raw_start_key ASC LIMIT 1`,
 	m := c.NewMonitor(ctx)
 	m.Go(func(ctx context.Context) error {
 		c.Run(ctx, c.Node(1), `./cockroach workload init kv`)
-		c.Run(ctx, c.All(), `./cockroach workload run kv --concurrency=32 --duration=1h`)
+		c.Run(ctx, c.All(), `./cockroach workload run kv --concurrency=32 --duration=1h --tolerate-errors`)
 		return nil
 	})
 	m.Go(func(ctx context.Context) error {


### PR DESCRIPTION
Backport 1/1 commits from #108304.

Fixes #110888.

/cc @cockroachdb/release

Release justification: Test-only change.

---

During the clearrange roachtest, a concurrent kv0 workload runs in the background. Previously, this background was not configured to `--tolerate-errors`.

Epic: none
Informs #108244.
Release note: None
