### PR TITLE
dev: create /artifacts directory with 0777 permissions

### DIFF
--- a/pkg/cmd/dev/builder.go
+++ b/pkg/cmd/dev/builder.go
@@ -133,6 +133,9 @@ func (d *dev) getDockerRunArgs(
 	if err != nil {
 		return
 	}
+	// We want to at least try to update the permissions here. If we fail to
+	// do so, there's not *necessarily* a reason to freak out yet.
+	_ = d.os.Chmod(artifacts, 0777)
 	args = append(args, "-v", artifacts+":/artifacts")
 	// The `delegated` switch ensures that the container's view of the cache
 	// is authoritative. This can result in writes to the actual underlying

--- a/pkg/cmd/dev/io/os/os.go
+++ b/pkg/cmd/dev/io/os/os.go
@@ -195,6 +195,19 @@ func (o *OS) Setenv(key, value string) error {
 	return err
 }
 
+func (o *OS) Chmod(filename string, mode uint32) error {
+	command := fmt.Sprintf("chmod %s %#o", filename, mode)
+	if !o.knobs.silent {
+		o.logger.Print(command)
+	}
+
+	_, err := o.Next(command, func() (string, error) {
+		err := os.Chmod(filename, fs.FileMode(mode))
+		return "", err
+	})
+	return err
+}
+
 // IsSymlink wraps around os.Lstat to determine if filename is a symbolic link
 // or not.
 func (o *OS) IsSymlink(filename string) (bool, error) {

--- a/pkg/cmd/dev/testdata/recorderdriven/builder
+++ b/pkg/cmd/dev/testdata/recorderdriven/builder
@@ -6,6 +6,7 @@ bazel info workspace --color=no
 cat crdb-checkout/build/.bazelbuilderversion
 docker volume inspect bzlhome
 mkdir crdb-checkout/artifacts
+chmod crdb-checkout/artifacts 0777
 docker run --rm -it -v crdb-checkout:/cockroach --workdir=/cockroach -v crdb-checkout/build/bazelutil/empty.bazelrc:/cockroach/.bazelrc.user -v crdb-checkout/artifacts:/artifacts -v bzlhome:/home/roach:delegated -u 502:502 cockroachdb/bazel:20220328-163955
 
 dev builder echo hi
@@ -16,4 +17,5 @@ bazel info workspace --color=no
 cat crdb-checkout/build/.bazelbuilderversion
 docker volume inspect bzlhome
 mkdir crdb-checkout/artifacts
+chmod crdb-checkout/artifacts 0777
 docker run --rm -i -v crdb-checkout:/cockroach --workdir=/cockroach -v crdb-checkout/build/bazelutil/empty.bazelrc:/cockroach/.bazelrc.user -v crdb-checkout/artifacts:/artifacts -v bzlhome:/home/roach:delegated -u 502:502 cockroachdb/bazel:20220328-163955 echo hi

--- a/pkg/cmd/dev/testdata/recorderdriven/builder.rec
+++ b/pkg/cmd/dev/testdata/recorderdriven/builder.rec
@@ -30,6 +30,9 @@ docker volume inspect bzlhome
 mkdir crdb-checkout/artifacts
 ----
 
+chmod crdb-checkout/artifacts 0777
+----
+
 docker run --rm -it -v crdb-checkout:/cockroach --workdir=/cockroach -v crdb-checkout/build/bazelutil/empty.bazelrc:/cockroach/.bazelrc.user -v crdb-checkout/artifacts:/artifacts -v bzlhome:/home/roach:delegated -u 502:502 cockroachdb/bazel:20220328-163955
 ----
 
@@ -63,6 +66,9 @@ docker volume inspect bzlhome
 ]
 
 mkdir crdb-checkout/artifacts
+----
+
+chmod crdb-checkout/artifacts 0777
 ----
 
 docker run --rm -i -v crdb-checkout:/cockroach --workdir=/cockroach -v crdb-checkout/build/bazelutil/empty.bazelrc:/cockroach/.bazelrc.user -v crdb-checkout/artifacts:/artifacts -v bzlhome:/home/roach:delegated -u 502:502 cockroachdb/bazel:20220328-163955 echo hi


### PR DESCRIPTION
On my machine using Podman I see the following error:

```
mv: cannot create regular file '/artifacts/cockroach': Permission denied
```

Avoid this by chmod'ing to 0777.

Part of DEVINF-522

Epic: none
Release note: None