### PR TITLE
changefeedccl: Fix test flake

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -7185,7 +7185,11 @@ func TestChangefeedEndTimeWithCursor(t *testing.T) {
 		defer closeFeed(t, feed)
 
 		// Don't care much about the values emitted (tested elsewhere) -- all
-		// we want to make sure is that the feed terminates.
+		// we want to make sure is that the feed terminates.  However, we do need
+		// to consume those values since some of the test sink implementations (kafka)
+		// will block.
+		defer DiscardMessages(feed)()
+
 		testFeed := feed.(cdctest.EnterpriseTestFeed)
 		require.NoError(t, testFeed.WaitForStatus(func(s jobs.Status) bool {
 			return s == jobs.StatusSucceeded

--- a/pkg/ccl/changefeedccl/testfeed_test.go
+++ b/pkg/ccl/changefeedccl/testfeed_test.go
@@ -1928,6 +1928,35 @@ func (k *kafkaFeed) Close() error {
 	return errors.CombineErrors(k.jobFeed.Close(), k.tg.wait())
 }
 
+// DiscardMessages spins up a goroutine to discard messages produced into the
+// sink. Returns cleanup function.
+func DiscardMessages(f cdctest.TestFeed) func() {
+	switch t := f.(type) {
+	case *kafkaFeed:
+		ctx, cancel := context.WithCancel(context.Background())
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case <-t.shutdown:
+					return
+				case <-t.source:
+				}
+			}
+		}()
+		return func() {
+			cancel()
+			wg.Wait()
+		}
+	default:
+		return func() {}
+	}
+}
+
 type webhookFeedFactory struct {
 	enterpriseFeedFactory
 	useSecureServer bool


### PR DESCRIPTION
Fixes #110372
Fix TestChangefeedEndTimeWithCursor test flake.  Ensure the test consumes and discards messages to ensure the test sink implementation (kafka) does not block.

Release note: None