### PR TITLE
changefeedccl: fix incorrect emitted_messages metric

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -204,8 +204,8 @@ func (ca *changeAggregator) MustBeStreaming() bool {
 	return true
 }
 
-// wrapMetricsController wraps the supplied metricsRecorder to emit metrics to telemetry.
-// This method modifies ca.cancel().
+// wrapMetricsController wraps the supplied metricsRecorder to emit metrics to
+// telemetry.
 func (ca *changeAggregator) wrapMetricsController(
 	ctx context.Context, recorder metricsRecorder,
 ) (metricsRecorder, error) {
@@ -220,6 +220,9 @@ func (ca *changeAggregator) wrapMetricsController(
 	}
 	ca.closeTelemetryRecorder = recorderWithTelemetry.close
 
+	if ca.knobs.WrapMetricsRecorder != nil {
+		return ca.knobs.WrapMetricsRecorder(recorderWithTelemetry), nil
+	}
 	return recorderWithTelemetry, nil
 }
 

--- a/pkg/ccl/changefeedccl/parquet_sink_cloudstorage.go
+++ b/pkg/ccl/changefeedccl/parquet_sink_cloudstorage.go
@@ -207,6 +207,7 @@ func (parquetSink *parquetCloudStorageSink) EncodeAndEmitRow(
 	if err := file.parquetCodec.addData(updatedRow, prevRow, updated, mvcc); err != nil {
 		return err
 	}
+	file.numMessages += 1
 
 	if int64(file.buf.Len()) > s.targetMaxFileSize {
 		s.metrics.recordSizeBasedFlush()

--- a/pkg/ccl/changefeedccl/sink.go
+++ b/pkg/ccl/changefeedccl/sink.go
@@ -29,7 +29,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/admission"
 	"github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb"
 	"github.com/cockroachdb/cockroach/pkg/util/bufalloc"
@@ -164,7 +163,7 @@ var WebhookV2Enabled = settings.RegisterBoolSetting(
 	"if enabled, this setting enables a new implementation of the webhook sink"+
 		" that allows for a much higher throughput",
 	// TODO: delete the original webhook sink code
-	util.ConstantWithMetamorphicTestBool("changefeed.new_webhook_sink.enabled", true),
+	false,
 	settings.WithName("changefeed.new_webhook_sink.enabled"),
 )
 
@@ -176,7 +175,7 @@ var PubsubV2Enabled = settings.RegisterBoolSetting(
 	"if enabled, this setting enables a new implementation of the pubsub sink"+
 		" that allows for a higher throughput",
 	// TODO: delete the original pubsub sink code
-	util.ConstantWithMetamorphicTestBool("changefeed.new_pubsub_sink.enabled", true),
+	false,
 	settings.WithName("changefeed.new_pubsub_sink.enabled"),
 )
 

--- a/pkg/ccl/changefeedccl/testfeed_test.go
+++ b/pkg/ccl/changefeedccl/testfeed_test.go
@@ -2574,3 +2574,13 @@ func stopFeedWhenDone(ctx context.Context, f cdctest.TestFeed) func() {
 		wg.Wait()
 	}
 }
+
+// metricsRecorderNoResolved wraps a metricsRecorder and overrides the
+// `recordResolvedCallback` method with a noop.
+type metricsRecorderNoResolved struct {
+	metricsRecorder
+}
+
+func (s *metricsRecorderNoResolved) recordResolvedCallback() func() {
+	return func() {}
+}

--- a/pkg/ccl/changefeedccl/testing_knobs.go
+++ b/pkg/ccl/changefeedccl/testing_knobs.go
@@ -77,6 +77,10 @@ type TestingKnobs struct {
 
 	// OnDrain returns the channel to select on to detect node drain
 	OnDrain func() <-chan struct{}
+
+	// WrapMetricsRecorder can be used to wrap the metricsRecorder
+	// to override certain methods.
+	WrapMetricsRecorder func(metricsRecorder) metricsRecorder
 }
 
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.


### PR DESCRIPTION
changefeedccl: fix incorrect emitted_messages metric #111005

This change ensures that the `emitted_messages` number is correct when
using format=parquet. Previously, this metric would not be updated.
This change also adds a unit test to test this metric.

Release note: None
Epic: None

---

do not merge: force TestChangefeedEmittedMessages to use all sinks
This commit will not be merged. This commit ensures that the
test passes with all sinks.

Release note: None