### PR TITLE
roachtest: use latest predecessor in acceptance test

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion.go
@@ -251,7 +251,7 @@ type (
 		predecessorFunc        predecessorFunc
 	}
 
-	customOption func(*testOptions)
+	CustomOption func(*testOptions)
 
 	predecessorFunc func(*rand.Rand, *version.Version, int) ([]string, error)
 
@@ -321,7 +321,7 @@ func AlwaysUseFixtures(opts *testOptions) {
 
 // UpgradeTimeout allows test authors to provide a different timeout
 // to apply when waiting for an upgrade to finish.
-func UpgradeTimeout(timeout time.Duration) customOption {
+func UpgradeTimeout(timeout time.Duration) CustomOption {
 	return func(opts *testOptions) {
 		opts.upgradeTimeout = timeout
 	}
@@ -329,7 +329,7 @@ func UpgradeTimeout(timeout time.Duration) customOption {
 
 // MinUpgrades allows callers to set a minimum number of upgrades each
 // test run should exercise.
-func MinUpgrades(n int) customOption {
+func MinUpgrades(n int) CustomOption {
 	return func(opts *testOptions) {
 		opts.minUpgrades = n
 	}
@@ -337,7 +337,7 @@ func MinUpgrades(n int) customOption {
 
 // MaxUpgrades allows callers to set a maximum number of upgrades to
 // be performed during a test run.
-func MaxUpgrades(n int) customOption {
+func MaxUpgrades(n int) CustomOption {
 	return func(opts *testOptions) {
 		opts.maxUpgrades = n
 	}
@@ -345,7 +345,7 @@ func MaxUpgrades(n int) customOption {
 
 // NumUpgrades allows callers to specify the exact number of upgrades
 // every test run should perform.
-func NumUpgrades(n int) customOption {
+func NumUpgrades(n int) CustomOption {
 	return func(opts *testOptions) {
 		opts.minUpgrades = n
 		opts.maxUpgrades = n
@@ -362,11 +362,9 @@ func NumUpgrades(n int) customOption {
 // subsequent patch releases. If possible, this option should be
 // avoided, but it might be necessary in certain cases to reduce noise
 // in case the test is more susceptible to fail due to known bugs.
-func AlwaysUseLatestPredecessors() customOption {
-	return func(opts *testOptions) {
-		opts.predecessorFunc = func(_ *rand.Rand, v *version.Version, n int) ([]string, error) {
-			return release.LatestPredecessorHistory(v, n)
-		}
+func AlwaysUseLatestPredecessors(opts *testOptions) {
+	opts.predecessorFunc = func(_ *rand.Rand, v *version.Version, n int) ([]string, error) {
+		return release.LatestPredecessorHistory(v, n)
 	}
 }
 
@@ -378,7 +376,7 @@ func NewTest(
 	l *logger.Logger,
 	c cluster.Cluster,
 	crdbNodes option.NodeListOption,
-	options ...customOption,
+	options ...CustomOption,
 ) *Test {
 	testLogger, err := prefixedLogger(l, logPrefix)
 	if err != nil {

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/planner_test.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/planner_test.go
@@ -359,7 +359,7 @@ func Test_upgradeTimeout(t *testing.T) {
 		return steps
 	}
 
-	assertTimeout := func(expectedTimeout time.Duration, opts ...customOption) {
+	assertTimeout := func(expectedTimeout time.Duration, opts ...CustomOption) {
 		mvt := newTest(opts...)
 		plan, err := mvt.plan()
 		require.NoError(t, err)
@@ -374,7 +374,7 @@ func Test_upgradeTimeout(t *testing.T) {
 	assertTimeout(30*time.Minute, UpgradeTimeout(30*time.Minute)) // custom timeout applies.
 }
 
-func newTest(options ...customOption) *Test {
+func newTest(options ...CustomOption) *Test {
 	testOptions := defaultTestOptions
 	for _, fn := range options {
 		fn(&testOptions)

--- a/pkg/cmd/roachtest/tests/mixed_version_backup.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_backup.go
@@ -2165,7 +2165,7 @@ func registerBackupMixedVersion(r registry.Registry) {
 				// that might exist in the cluster by the time the upgrade is
 				// attempted.
 				mixedversion.UpgradeTimeout(30*time.Minute),
-				mixedversion.AlwaysUseLatestPredecessors(),
+				mixedversion.AlwaysUseLatestPredecessors,
 			)
 			testRNG := mvt.RNG()
 


### PR DESCRIPTION
The `acceptance/version-upgrade` roachtest occasionally fails with an error like "deadline below read timestamp is nonsensical". This is due to a bug fixed in previous patch releases of Cockroach.

To avoid flakes in CI (which cause disruption in workflows), we opt to always use the latest predecessor when running this acceptance test locally.

Epic: none

Release note: None