### PR TITLE
settings: fix the override behavior for string and proto settings

### DIFF
--- a/pkg/settings/BUILD.bazel
+++ b/pkg/settings/BUILD.bazel
@@ -60,6 +60,7 @@ go_test(
         "//pkg/util/protoutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_redact//:redact",
+        "@com_github_gogo_protobuf//proto",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],

--- a/pkg/settings/protobuf.go
+++ b/pkg/settings/protobuf.go
@@ -108,6 +108,7 @@ func (s *ProtobufSetting) Validate(sv *Values, p protoutil.Message) error {
 // Override sets the setting to the given value, assuming it passes validation.
 func (s *ProtobufSetting) Override(ctx context.Context, sv *Values, p protoutil.Message) {
 	_ = s.set(ctx, sv, p)
+	sv.setDefaultOverride(s.slot, p)
 }
 
 func (s *ProtobufSetting) set(ctx context.Context, sv *Values, p protoutil.Message) error {
@@ -121,6 +122,13 @@ func (s *ProtobufSetting) set(ctx context.Context, sv *Values, p protoutil.Messa
 }
 
 func (s *ProtobufSetting) setToDefault(ctx context.Context, sv *Values) {
+	// See if the default value was overridden.
+	if val := sv.getDefaultOverride(s.slot); val != nil {
+		// As per the semantics of override, these values don't go through
+		// validation.
+		_ = s.set(ctx, sv, val.(protoutil.Message))
+		return
+	}
 	if err := s.set(ctx, sv, s.defaultValue); err != nil {
 		panic(err)
 	}

--- a/pkg/settings/string.go
+++ b/pkg/settings/string.go
@@ -82,6 +82,7 @@ func (s *StringSetting) Validate(sv *Values, v string) error {
 // it passes validation.
 func (s *StringSetting) Override(ctx context.Context, sv *Values, v string) {
 	_ = s.set(ctx, sv, v)
+	sv.setDefaultOverride(s.slot, v)
 }
 
 func (s *StringSetting) set(ctx context.Context, sv *Values, v string) error {
@@ -95,6 +96,13 @@ func (s *StringSetting) set(ctx context.Context, sv *Values, v string) error {
 }
 
 func (s *StringSetting) setToDefault(ctx context.Context, sv *Values) {
+	// See if the default value was overridden.
+	if val := sv.getDefaultOverride(s.slot); val != nil {
+		// As per the semantics of override, these values don't go through
+		// validation.
+		_ = s.set(ctx, sv, val.(string))
+		return
+	}
 	if err := s.set(ctx, sv, s.defaultValue); err != nil {
 		panic(err)
 	}

--- a/pkg/settings/version.go
+++ b/pkg/settings/version.go
@@ -174,9 +174,6 @@ func (v *VersionSetting) SetInternal(ctx context.Context, sv *Values, newVal int
 // setToDefault is part of the extendingSetting interface. This is a no-op for
 // VersionSetting. They don't have defaults that they can go back to at any
 // time.
-//
-// TODO(irfansharif): Is this true? Shouldn't the default here just the the
-// version we initialize with?
 func (v *VersionSetting) setToDefault(ctx context.Context, sv *Values) {}
 
 // RegisterVersionSetting adds the provided version setting to the global


### PR DESCRIPTION
Needed for #110758.
Epic: CRDB-6671

Somehow no test was setting overrides on string and protobuf settings. It would not have worked. With this patch, it would.

Release note: None