### PR TITLE
sql/pg_catalog: add dropped columns into pg_attribute

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -699,68 +699,71 @@ JOIN pg_catalog.pg_class c ON a.attrelid = c.oid
 JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
 WHERE n.nspname = 'public'
 ----
-attrelid    relname            attname                   atttypid  attstattarget  attlen  attnum  attndims  attcacheoff
-110         t1                 p                         701       0              8       1       0         -1
-110         t1                 a                         20        0              8       2       0         -1
-110         t1                 b                         20        0              8       3       0         -1
-110         t1                 c                         20        0              8       4       0         -1
-110         t1                 d                         1043      0              -1      5       0         -1
-110         t1                 e                         1560      0              -1      6       0         -1
-110         t1                 f                         1700      0              -1      7       0         -1
-110         t1                 g                         20        0              8       8       0         -1
-110         t1                 h                         1014      0              -1      9       0         -1
-110         t1                 i                         1015      0              -1      10      0         -1
-110         t1                 j                         18        0              1       11      0         -1
-110         t1                 k                         1043      0              -1      12      0         -1
-110         t1                 l                         20        0              8       13      0         -1
-110         t1                 m                         20        0              8       14      0         -1
-110         t1                 n                         20        0              8       15      0         -1
-3687884466  t1_pkey            p                         701       0              8       1       0         -1
-3687884465  t1_a_key           a                         20        0              8       1       0         -1
-3687884464  index_key          b                         20        0              8       1       0         -1
-3687884464  index_key          c                         20        0              8       2       0         -1
-111         t1_m_seq           value                     20        0              8       1       0         -1
-112         t1_n_seq           value                     20        0              8       1       0         -1
-113         t2                 t1_id                     20        0              8       1       0         -1
-113         t2                 rowid                     20        0              8       2       0         -1
-2955071325  t2_pkey            rowid                     20        0              8       1       0         -1
-2955071326  t2_t1_id_idx       t1_id                     20        0              8       1       0         -1
-114         t3                 a                         20        0              8       1       0         -1
-114         t3                 b                         20        0              8       2       0         -1
-114         t3                 c                         25        0              -1      3       0         -1
-114         t3                 rowid                     20        0              8       4       0         -1
-2695335054  t3_pkey            rowid                     20        0              8       1       0         -1
-2695335053  t3_a_b_idx         a                         20        0              8       1       0         -1
-2695335053  t3_a_b_idx         b                         20        0              8       2       0         -1
-2695335053  t3_a_b_idx         c                         25        0              -1      3       0         -1
-115         v1                 p                         701       0              8       1       0         -1
-115         v1                 a                         20        0              8       2       0         -1
-115         v1                 b                         20        0              8       3       0         -1
-115         v1                 c                         20        0              8       4       0         -1
-116         t4                 a                         20        0              8       1       0         -1
-116         t4                 b                         701       0              8       2       0         -1
-116         t4                 c                         25        0              -1      3       0         -1
-116         t4                 rowid                     20        0              8       4       0         -1
-3214807592  t4_pkey            rowid                     20        0              8       1       0         -1
-117         t5                 a                         20        0              8       1       0         -1
-117         t5                 b                         701       0              8       2       0         -1
-117         t5                 c                         25        0              -1      3       0         -1
-117         t5                 rowid                     20        0              8       4       0         -1
-1869730585  t5_pkey            rowid                     20        0              8       1       0         -1
-120         t6                 a                         20        0              8       1       0         -1
-120         t6                 b                         20        0              8       2       0         -1
-120         t6                 c                         25        0              -1      3       0         -1
-120         t6                 m                         100118    0              -1      4       0         -1
-120         t6                 rowid                     20        0              8       6       0         -1
-2129466852  t6_pkey            rowid                     20        0              8       1       0         -1
-2129466855  t6_expr_idx        crdb_internal_idx_expr    20        0              8       1       0         -1
-2129466854  t6_expr_expr1_idx  crdb_internal_idx_expr_1  25        0              -1      1       0         -1
-2129466854  t6_expr_expr1_idx  crdb_internal_idx_expr    20        0              8       2       0         -1
-2129466848  t6_expr_key        crdb_internal_idx_expr_1  25        0              -1      1       0         -1
-2129466850  t6_expr_idx1       crdb_internal_idx_expr_2  16        0              1       1       0         -1
-121         mv1                ?column?                  20        0              8       1       0         -1
-121         mv1                rowid                     20        0              8       2       0         -1
-784389845   mv1_pkey           rowid                     20        0              8       1       0         -1
+attrelid    relname            attname                      atttypid  attstattarget  attlen  attnum  attndims  attcacheoff
+110         t1                 p                            701       0              8       1       0         -1
+110         t1                 a                            20        0              8       2       0         -1
+110         t1                 b                            20        0              8       3       0         -1
+110         t1                 c                            20        0              8       4       0         -1
+110         t1                 d                            1043      0              -1      5       0         -1
+110         t1                 e                            1560      0              -1      6       0         -1
+110         t1                 f                            1700      0              -1      7       0         -1
+110         t1                 g                            20        0              8       8       0         -1
+110         t1                 h                            1014      0              -1      9       0         -1
+110         t1                 i                            1015      0              -1      10      0         -1
+110         t1                 j                            18        0              1       11      0         -1
+110         t1                 k                            1043      0              -1      12      0         -1
+110         t1                 l                            20        0              8       13      0         -1
+110         t1                 m                            20        0              8       14      0         -1
+110         t1                 n                            20        0              8       15      0         -1
+3687884466  t1_pkey            p                            701       0              8       1       0         -1
+3687884465  t1_a_key           a                            20        0              8       1       0         -1
+3687884464  index_key          b                            20        0              8       1       0         -1
+3687884464  index_key          c                            20        0              8       2       0         -1
+111         t1_m_seq           value                        20        0              8       1       0         -1
+112         t1_n_seq           value                        20        0              8       1       0         -1
+113         t2                 t1_id                        20        0              8       1       0         -1
+113         t2                 rowid                        20        0              8       2       0         -1
+2955071325  t2_pkey            rowid                        20        0              8       1       0         -1
+2955071326  t2_t1_id_idx       t1_id                        20        0              8       1       0         -1
+114         t3                 a                            20        0              8       1       0         -1
+114         t3                 b                            20        0              8       2       0         -1
+114         t3                 c                            25        0              -1      3       0         -1
+114         t3                 rowid                        20        0              8       4       0         -1
+2695335054  t3_pkey            rowid                        20        0              8       1       0         -1
+2695335053  t3_a_b_idx         a                            20        0              8       1       0         -1
+2695335053  t3_a_b_idx         b                            20        0              8       2       0         -1
+2695335053  t3_a_b_idx         c                            25        0              -1      3       0         -1
+115         v1                 p                            701       0              8       1       0         -1
+115         v1                 a                            20        0              8       2       0         -1
+115         v1                 b                            20        0              8       3       0         -1
+115         v1                 c                            20        0              8       4       0         -1
+116         t4                 a                            20        0              8       1       0         -1
+116         t4                 b                            701       0              8       2       0         -1
+116         t4                 c                            25        0              -1      3       0         -1
+116         t4                 rowid                        20        0              8       4       0         -1
+3214807592  t4_pkey            rowid                        20        0              8       1       0         -1
+117         t5                 a                            20        0              8       1       0         -1
+117         t5                 b                            701       0              8       2       0         -1
+117         t5                 c                            25        0              -1      3       0         -1
+117         t5                 rowid                        20        0              8       4       0         -1
+1869730585  t5_pkey            rowid                        20        0              8       1       0         -1
+120         t6                 a                            20        0              8       1       0         -1
+120         t6                 b                            20        0              8       2       0         -1
+120         t6                 c                            25        0              -1      3       0         -1
+120         t6                 m                            100118    0              -1      4       0         -1
+120         t6                 rowid                        20        0              8       6       0         -1
+120         t6                 ........pg.dropped.5.......  2283      0              -1      5       0         -1
+120         t6                 ........pg.dropped.7.......  2283      0              -1      7       0         -1
+120         t6                 ........pg.dropped.8.......  2283      0              -1      8       0         -1
+2129466852  t6_pkey            rowid                        20        0              8       1       0         -1
+2129466855  t6_expr_idx        crdb_internal_idx_expr       20        0              8       1       0         -1
+2129466854  t6_expr_expr1_idx  crdb_internal_idx_expr_1     25        0              -1      1       0         -1
+2129466854  t6_expr_expr1_idx  crdb_internal_idx_expr       20        0              8       2       0         -1
+2129466848  t6_expr_key        crdb_internal_idx_expr_1     25        0              -1      1       0         -1
+2129466850  t6_expr_idx1       crdb_internal_idx_expr_2     16        0              1       1       0         -1
+121         mv1                ?column?                     20        0              8       1       0         -1
+121         mv1                rowid                        20        0              8       2       0         -1
+784389845   mv1_pkey           rowid                        20        0              8       1       0         -1
 
 query TTIBTTBBTT colnames,rowsort
 SELECT c.relname, attname, atttypmod, attbyval, attstorage, attalign, attnotnull, atthasdef, attidentity, attgenerated
@@ -769,68 +772,71 @@ JOIN pg_catalog.pg_class c ON a.attrelid = c.oid
 JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
 WHERE n.nspname = 'public'
 ----
-relname            attname                   atttypmod  attbyval  attstorage  attalign  attnotnull  atthasdef  attidentity  attgenerated
-t1                 p                         -1         NULL      NULL        NULL      true        false      ·            ·
-t1                 a                         -1         NULL      NULL        NULL      false       false      ·            ·
-t1                 b                         -1         NULL      NULL        NULL      false       false      ·            ·
-t1                 c                         -1         NULL      NULL        NULL      false       true       ·            ·
-t1                 d                         9          NULL      NULL        NULL      false       false      ·            ·
-t1                 e                         5          NULL      NULL        NULL      false       false      ·            ·
-t1                 f                         655371     NULL      NULL        NULL      false       false      ·            ·
-t1                 g                         -1         NULL      NULL        NULL      false       true       ·            s
-t1                 h                         16         NULL      NULL        NULL      false       false      ·            ·
-t1                 i                         24         NULL      NULL        NULL      false       false      ·            ·
-t1                 j                         -1         NULL      NULL        NULL      false       false      ·            ·
-t1                 k                         14         NULL      NULL        NULL      false       false      ·            ·
-t1                 l                         -1         NULL      NULL        NULL      false       true       ·            v
-t1                 m                         -1         NULL      NULL        NULL      true        true       a            ·
-t1                 n                         -1         NULL      NULL        NULL      true        true       d            ·
-t1_pkey            p                         -1         NULL      NULL        NULL      true        false      ·            ·
-t1_a_key           a                         -1         NULL      NULL        NULL      false       false      ·            ·
-index_key          b                         -1         NULL      NULL        NULL      false       false      ·            ·
-index_key          c                         -1         NULL      NULL        NULL      false       true       ·            ·
-t1_m_seq           value                     -1         NULL      NULL        NULL      true        false      ·            ·
-t1_n_seq           value                     -1         NULL      NULL        NULL      true        false      ·            ·
-t2                 t1_id                     -1         NULL      NULL        NULL      false       false      ·            ·
-t2                 rowid                     -1         NULL      NULL        NULL      true        true       ·            ·
-t2_pkey            rowid                     -1         NULL      NULL        NULL      true        true       ·            ·
-t2_t1_id_idx       t1_id                     -1         NULL      NULL        NULL      false       false      ·            ·
-t3                 a                         -1         NULL      NULL        NULL      false       false      ·            ·
-t3                 b                         -1         NULL      NULL        NULL      false       false      ·            ·
-t3                 c                         -1         NULL      NULL        NULL      false       true       ·            ·
-t3                 rowid                     -1         NULL      NULL        NULL      true        true       ·            ·
-t3_pkey            rowid                     -1         NULL      NULL        NULL      true        true       ·            ·
-t3_a_b_idx         a                         -1         NULL      NULL        NULL      false       false      ·            ·
-t3_a_b_idx         b                         -1         NULL      NULL        NULL      false       false      ·            ·
-t3_a_b_idx         c                         -1         NULL      NULL        NULL      false       true       ·            ·
-v1                 p                         -1         NULL      NULL        NULL      false       false      ·            ·
-v1                 a                         -1         NULL      NULL        NULL      false       false      ·            ·
-v1                 b                         -1         NULL      NULL        NULL      false       false      ·            ·
-v1                 c                         -1         NULL      NULL        NULL      false       false      ·            ·
-t4                 a                         -1         NULL      NULL        NULL      false       false      ·            ·
-t4                 b                         -1         NULL      NULL        NULL      false       false      ·            ·
-t4                 c                         -1         NULL      NULL        NULL      false       false      ·            ·
-t4                 rowid                     -1         NULL      NULL        NULL      true        true       ·            ·
-t4_pkey            rowid                     -1         NULL      NULL        NULL      true        true       ·            ·
-t5                 a                         -1         NULL      NULL        NULL      false       false      ·            ·
-t5                 b                         -1         NULL      NULL        NULL      false       false      ·            ·
-t5                 c                         -1         NULL      NULL        NULL      false       false      ·            ·
-t5                 rowid                     -1         NULL      NULL        NULL      true        true       ·            ·
-t5_pkey            rowid                     -1         NULL      NULL        NULL      true        true       ·            ·
-t6                 a                         -1         NULL      NULL        NULL      false       false      ·            ·
-t6                 b                         -1         NULL      NULL        NULL      false       false      ·            ·
-t6                 c                         -1         NULL      NULL        NULL      false       false      ·            ·
-t6                 m                         -1         NULL      NULL        NULL      false       false      ·            ·
-t6                 rowid                     -1         NULL      NULL        NULL      true        true       ·            ·
-t6_pkey            rowid                     -1         NULL      NULL        NULL      true        true       ·            ·
-t6_expr_idx        crdb_internal_idx_expr    -1         NULL      NULL        NULL      false       true       ·            v
-t6_expr_expr1_idx  crdb_internal_idx_expr_1  -1         NULL      NULL        NULL      false       true       ·            v
-t6_expr_expr1_idx  crdb_internal_idx_expr    -1         NULL      NULL        NULL      false       true       ·            v
-t6_expr_key        crdb_internal_idx_expr_1  -1         NULL      NULL        NULL      false       true       ·            v
-t6_expr_idx1       crdb_internal_idx_expr_2  -1         NULL      NULL        NULL      false       true       ·            v
-mv1                ?column?                  -1         NULL      NULL        NULL      false       false      ·            ·
-mv1                rowid                     -1         NULL      NULL        NULL      true        true       ·            ·
-mv1_pkey           rowid                     -1         NULL      NULL        NULL      true        true       ·            ·
+relname            attname                      atttypmod  attbyval  attstorage  attalign  attnotnull  atthasdef  attidentity  attgenerated
+t1                 p                            -1         NULL      NULL        NULL      true        false      ·            ·
+t1                 a                            -1         NULL      NULL        NULL      false       false      ·            ·
+t1                 b                            -1         NULL      NULL        NULL      false       false      ·            ·
+t1                 c                            -1         NULL      NULL        NULL      false       true       ·            ·
+t1                 d                            9          NULL      NULL        NULL      false       false      ·            ·
+t1                 e                            5          NULL      NULL        NULL      false       false      ·            ·
+t1                 f                            655371     NULL      NULL        NULL      false       false      ·            ·
+t1                 g                            -1         NULL      NULL        NULL      false       true       ·            s
+t1                 h                            16         NULL      NULL        NULL      false       false      ·            ·
+t1                 i                            24         NULL      NULL        NULL      false       false      ·            ·
+t1                 j                            -1         NULL      NULL        NULL      false       false      ·            ·
+t1                 k                            14         NULL      NULL        NULL      false       false      ·            ·
+t1                 l                            -1         NULL      NULL        NULL      false       true       ·            v
+t1                 m                            -1         NULL      NULL        NULL      true        true       a            ·
+t1                 n                            -1         NULL      NULL        NULL      true        true       d            ·
+t1_pkey            p                            -1         NULL      NULL        NULL      true        false      ·            ·
+t1_a_key           a                            -1         NULL      NULL        NULL      false       false      ·            ·
+index_key          b                            -1         NULL      NULL        NULL      false       false      ·            ·
+index_key          c                            -1         NULL      NULL        NULL      false       true       ·            ·
+t1_m_seq           value                        -1         NULL      NULL        NULL      true        false      ·            ·
+t1_n_seq           value                        -1         NULL      NULL        NULL      true        false      ·            ·
+t2                 t1_id                        -1         NULL      NULL        NULL      false       false      ·            ·
+t2                 rowid                        -1         NULL      NULL        NULL      true        true       ·            ·
+t2_pkey            rowid                        -1         NULL      NULL        NULL      true        true       ·            ·
+t2_t1_id_idx       t1_id                        -1         NULL      NULL        NULL      false       false      ·            ·
+t3                 a                            -1         NULL      NULL        NULL      false       false      ·            ·
+t3                 b                            -1         NULL      NULL        NULL      false       false      ·            ·
+t3                 c                            -1         NULL      NULL        NULL      false       true       ·            ·
+t3                 rowid                        -1         NULL      NULL        NULL      true        true       ·            ·
+t3_pkey            rowid                        -1         NULL      NULL        NULL      true        true       ·            ·
+t3_a_b_idx         a                            -1         NULL      NULL        NULL      false       false      ·            ·
+t3_a_b_idx         b                            -1         NULL      NULL        NULL      false       false      ·            ·
+t3_a_b_idx         c                            -1         NULL      NULL        NULL      false       true       ·            ·
+v1                 p                            -1         NULL      NULL        NULL      false       false      ·            ·
+v1                 a                            -1         NULL      NULL        NULL      false       false      ·            ·
+v1                 b                            -1         NULL      NULL        NULL      false       false      ·            ·
+v1                 c                            -1         NULL      NULL        NULL      false       false      ·            ·
+t4                 a                            -1         NULL      NULL        NULL      false       false      ·            ·
+t4                 b                            -1         NULL      NULL        NULL      false       false      ·            ·
+t4                 c                            -1         NULL      NULL        NULL      false       false      ·            ·
+t4                 rowid                        -1         NULL      NULL        NULL      true        true       ·            ·
+t4_pkey            rowid                        -1         NULL      NULL        NULL      true        true       ·            ·
+t5                 a                            -1         NULL      NULL        NULL      false       false      ·            ·
+t5                 b                            -1         NULL      NULL        NULL      false       false      ·            ·
+t5                 c                            -1         NULL      NULL        NULL      false       false      ·            ·
+t5                 rowid                        -1         NULL      NULL        NULL      true        true       ·            ·
+t5_pkey            rowid                        -1         NULL      NULL        NULL      true        true       ·            ·
+t6                 a                            -1         NULL      NULL        NULL      false       false      ·            ·
+t6                 b                            -1         NULL      NULL        NULL      false       false      ·            ·
+t6                 c                            -1         NULL      NULL        NULL      false       false      ·            ·
+t6                 m                            -1         NULL      NULL        NULL      false       false      ·            ·
+t6                 rowid                        -1         NULL      NULL        NULL      true        true       ·            ·
+t6                 ........pg.dropped.5.......  -1         NULL      NULL        NULL      false       false      ·            ·
+t6                 ........pg.dropped.7.......  -1         NULL      NULL        NULL      false       false      ·            ·
+t6                 ........pg.dropped.8.......  -1         NULL      NULL        NULL      false       false      ·            ·
+t6_pkey            rowid                        -1         NULL      NULL        NULL      true        true       ·            ·
+t6_expr_idx        crdb_internal_idx_expr       -1         NULL      NULL        NULL      false       true       ·            v
+t6_expr_expr1_idx  crdb_internal_idx_expr_1     -1         NULL      NULL        NULL      false       true       ·            v
+t6_expr_expr1_idx  crdb_internal_idx_expr       -1         NULL      NULL        NULL      false       true       ·            v
+t6_expr_key        crdb_internal_idx_expr_1     -1         NULL      NULL        NULL      false       true       ·            v
+t6_expr_idx1       crdb_internal_idx_expr_2     -1         NULL      NULL        NULL      false       true       ·            v
+mv1                ?column?                     -1         NULL      NULL        NULL      false       false      ·            ·
+mv1                rowid                        -1         NULL      NULL        NULL      true        true       ·            ·
+mv1_pkey           rowid                        -1         NULL      NULL        NULL      true        true       ·            ·
 
 query TTBBITTT colnames,rowsort
 SELECT c.relname, attname, attisdropped, attislocal, attinhcount, attacl, attoptions, attfdwoptions
@@ -839,68 +845,71 @@ JOIN pg_catalog.pg_class c ON a.attrelid = c.oid
 JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
 WHERE n.nspname = 'public'
 ----
-relname            attname                   attisdropped  attislocal  attinhcount  attacl  attoptions  attfdwoptions
-t1                 p                         false         true        0            NULL    NULL        NULL
-t1                 a                         false         true        0            NULL    NULL        NULL
-t1                 b                         false         true        0            NULL    NULL        NULL
-t1                 c                         false         true        0            NULL    NULL        NULL
-t1                 d                         false         true        0            NULL    NULL        NULL
-t1                 e                         false         true        0            NULL    NULL        NULL
-t1                 f                         false         true        0            NULL    NULL        NULL
-t1                 g                         false         true        0            NULL    NULL        NULL
-t1                 h                         false         true        0            NULL    NULL        NULL
-t1                 i                         false         true        0            NULL    NULL        NULL
-t1                 j                         false         true        0            NULL    NULL        NULL
-t1                 k                         false         true        0            NULL    NULL        NULL
-t1                 l                         false         true        0            NULL    NULL        NULL
-t1                 m                         false         true        0            NULL    NULL        NULL
-t1                 n                         false         true        0            NULL    NULL        NULL
-t1_pkey            p                         false         true        0            NULL    NULL        NULL
-t1_a_key           a                         false         true        0            NULL    NULL        NULL
-index_key          b                         false         true        0            NULL    NULL        NULL
-index_key          c                         false         true        0            NULL    NULL        NULL
-t1_m_seq           value                     false         true        0            NULL    NULL        NULL
-t1_n_seq           value                     false         true        0            NULL    NULL        NULL
-t2                 t1_id                     false         true        0            NULL    NULL        NULL
-t2                 rowid                     false         true        0            NULL    NULL        NULL
-t2_pkey            rowid                     false         true        0            NULL    NULL        NULL
-t2_t1_id_idx       t1_id                     false         true        0            NULL    NULL        NULL
-t3                 a                         false         true        0            NULL    NULL        NULL
-t3                 b                         false         true        0            NULL    NULL        NULL
-t3                 c                         false         true        0            NULL    NULL        NULL
-t3                 rowid                     false         true        0            NULL    NULL        NULL
-t3_pkey            rowid                     false         true        0            NULL    NULL        NULL
-t3_a_b_idx         a                         false         true        0            NULL    NULL        NULL
-t3_a_b_idx         b                         false         true        0            NULL    NULL        NULL
-t3_a_b_idx         c                         false         true        0            NULL    NULL        NULL
-v1                 p                         false         true        0            NULL    NULL        NULL
-v1                 a                         false         true        0            NULL    NULL        NULL
-v1                 b                         false         true        0            NULL    NULL        NULL
-v1                 c                         false         true        0            NULL    NULL        NULL
-t4                 a                         false         true        0            NULL    NULL        NULL
-t4                 b                         false         true        0            NULL    NULL        NULL
-t4                 c                         false         true        0            NULL    NULL        NULL
-t4                 rowid                     false         true        0            NULL    NULL        NULL
-t4_pkey            rowid                     false         true        0            NULL    NULL        NULL
-t5                 a                         false         true        0            NULL    NULL        NULL
-t5                 b                         false         true        0            NULL    NULL        NULL
-t5                 c                         false         true        0            NULL    NULL        NULL
-t5                 rowid                     false         true        0            NULL    NULL        NULL
-t5_pkey            rowid                     false         true        0            NULL    NULL        NULL
-t6                 a                         false         true        0            NULL    NULL        NULL
-t6                 b                         false         true        0            NULL    NULL        NULL
-t6                 c                         false         true        0            NULL    NULL        NULL
-t6                 m                         false         true        0            NULL    NULL        NULL
-t6                 rowid                     false         true        0            NULL    NULL        NULL
-t6_pkey            rowid                     false         true        0            NULL    NULL        NULL
-t6_expr_idx        crdb_internal_idx_expr    false         true        0            NULL    NULL        NULL
-t6_expr_expr1_idx  crdb_internal_idx_expr_1  false         true        0            NULL    NULL        NULL
-t6_expr_expr1_idx  crdb_internal_idx_expr    false         true        0            NULL    NULL        NULL
-t6_expr_key        crdb_internal_idx_expr_1  false         true        0            NULL    NULL        NULL
-t6_expr_idx1       crdb_internal_idx_expr_2  false         true        0            NULL    NULL        NULL
-mv1                ?column?                  false         true        0            NULL    NULL        NULL
-mv1                rowid                     false         true        0            NULL    NULL        NULL
-mv1_pkey           rowid                     false         true        0            NULL    NULL        NULL
+relname            attname                      attisdropped  attislocal  attinhcount  attacl  attoptions  attfdwoptions
+t1                 p                            false         true        0            NULL    NULL        NULL
+t1                 a                            false         true        0            NULL    NULL        NULL
+t1                 b                            false         true        0            NULL    NULL        NULL
+t1                 c                            false         true        0            NULL    NULL        NULL
+t1                 d                            false         true        0            NULL    NULL        NULL
+t1                 e                            false         true        0            NULL    NULL        NULL
+t1                 f                            false         true        0            NULL    NULL        NULL
+t1                 g                            false         true        0            NULL    NULL        NULL
+t1                 h                            false         true        0            NULL    NULL        NULL
+t1                 i                            false         true        0            NULL    NULL        NULL
+t1                 j                            false         true        0            NULL    NULL        NULL
+t1                 k                            false         true        0            NULL    NULL        NULL
+t1                 l                            false         true        0            NULL    NULL        NULL
+t1                 m                            false         true        0            NULL    NULL        NULL
+t1                 n                            false         true        0            NULL    NULL        NULL
+t1_pkey            p                            false         true        0            NULL    NULL        NULL
+t1_a_key           a                            false         true        0            NULL    NULL        NULL
+index_key          b                            false         true        0            NULL    NULL        NULL
+index_key          c                            false         true        0            NULL    NULL        NULL
+t1_m_seq           value                        false         true        0            NULL    NULL        NULL
+t1_n_seq           value                        false         true        0            NULL    NULL        NULL
+t2                 t1_id                        false         true        0            NULL    NULL        NULL
+t2                 rowid                        false         true        0            NULL    NULL        NULL
+t2_pkey            rowid                        false         true        0            NULL    NULL        NULL
+t2_t1_id_idx       t1_id                        false         true        0            NULL    NULL        NULL
+t3                 a                            false         true        0            NULL    NULL        NULL
+t3                 b                            false         true        0            NULL    NULL        NULL
+t3                 c                            false         true        0            NULL    NULL        NULL
+t3                 rowid                        false         true        0            NULL    NULL        NULL
+t3_pkey            rowid                        false         true        0            NULL    NULL        NULL
+t3_a_b_idx         a                            false         true        0            NULL    NULL        NULL
+t3_a_b_idx         b                            false         true        0            NULL    NULL        NULL
+t3_a_b_idx         c                            false         true        0            NULL    NULL        NULL
+v1                 p                            false         true        0            NULL    NULL        NULL
+v1                 a                            false         true        0            NULL    NULL        NULL
+v1                 b                            false         true        0            NULL    NULL        NULL
+v1                 c                            false         true        0            NULL    NULL        NULL
+t4                 a                            false         true        0            NULL    NULL        NULL
+t4                 b                            false         true        0            NULL    NULL        NULL
+t4                 c                            false         true        0            NULL    NULL        NULL
+t4                 rowid                        false         true        0            NULL    NULL        NULL
+t4_pkey            rowid                        false         true        0            NULL    NULL        NULL
+t5                 a                            false         true        0            NULL    NULL        NULL
+t5                 b                            false         true        0            NULL    NULL        NULL
+t5                 c                            false         true        0            NULL    NULL        NULL
+t5                 rowid                        false         true        0            NULL    NULL        NULL
+t5_pkey            rowid                        false         true        0            NULL    NULL        NULL
+t6                 a                            false         true        0            NULL    NULL        NULL
+t6                 b                            false         true        0            NULL    NULL        NULL
+t6                 c                            false         true        0            NULL    NULL        NULL
+t6                 m                            false         true        0            NULL    NULL        NULL
+t6                 rowid                        false         true        0            NULL    NULL        NULL
+t6                 ........pg.dropped.5.......  true          true        0            NULL    NULL        NULL
+t6                 ........pg.dropped.7.......  true          true        0            NULL    NULL        NULL
+t6                 ........pg.dropped.8.......  true          true        0            NULL    NULL        NULL
+t6_pkey            rowid                        false         true        0            NULL    NULL        NULL
+t6_expr_idx        crdb_internal_idx_expr       false         true        0            NULL    NULL        NULL
+t6_expr_expr1_idx  crdb_internal_idx_expr_1     false         true        0            NULL    NULL        NULL
+t6_expr_expr1_idx  crdb_internal_idx_expr       false         true        0            NULL    NULL        NULL
+t6_expr_key        crdb_internal_idx_expr_1     false         true        0            NULL    NULL        NULL
+t6_expr_idx1       crdb_internal_idx_expr_2     false         true        0            NULL    NULL        NULL
+mv1                ?column?                     false         true        0            NULL    NULL        NULL
+mv1                rowid                        false         true        0            NULL    NULL        NULL
+mv1_pkey           rowid                        false         true        0            NULL    NULL        NULL
 
 # Check relkind codes.
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/privilege_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/privilege_builtins
@@ -1270,9 +1270,10 @@ ALTER TABLE hcp_test DROP COLUMN b
 query TI rowsort
 SELECT attname, attnum FROM pg_attribute WHERE attrelid = 'hcp_test'::REGCLASS
 ----
-a     1
-c     3
-rowid 4
+a                            1
+c                            3
+rowid                        4
+........pg.dropped.2.......  2
 
 query B
 SELECT has_column_privilege('hcp_test'::REGCLASS, 1, 'SELECT')

--- a/pkg/sql/logictest/testdata/logic_test/srfs
+++ b/pkg/sql/logictest/testdata/logic_test/srfs
@@ -867,9 +867,24 @@ CREATE TABLE uu (x INT AS (generate_series(1, 3)) STORED)
 
 subtest correlated_srf
 
+# Initially this table will have 3 columns:
+# x, y, rowid
 statement ok
 CREATE TABLE vals (x INT, y INT, INDEX woo (x, y));
-   INSERT INTO vals VALUES (3, 4), (NULL, NULL), (5, 6);
+
+statement ok
+ALTER TABLE vals DROP COLUMN y cascade;
+
+# Once the second column is and added dropped this table will have the format:
+# x, rowid, y
+statement ok
+ALTER TABLE vals ADD COLUMN y int;
+
+statement ok
+CREATE INDEX woo ON vals(x,y);
+
+statement ok
+INSERT INTO vals VALUES (3, 4), (NULL, NULL), (5, 6);
 
 query III colnames
 SELECT x, generate_series(1,x), generate_series(1,2) FROM vals ORDER BY 1,2,3
@@ -916,19 +931,20 @@ ordered_t  1
 t          2
 u          2
 vals       1
-vals       2
 vals       3
+vals       4
 
+# We are going to order by the relname, indexrelid (index's OID), x and n (from pg_expandarray)
 query TT colnames
-SELECT relname, information_schema._pg_expandarray(indkey) FROM pg_class, pg_index WHERE pg_class.oid = pg_index.indrelid ORDER BY relname, x, n
+SELECT relname, information_schema._pg_expandarray(indkey) FROM pg_class, pg_index WHERE pg_class.oid = pg_index.indrelid ORDER BY relname, indexrelid, x, n
 ----
 relname    information_schema._pg_expandarray
 ordered_t  (1,1)
 t          (2,1)
 u          (2,1)
-vals       (1,1)
-vals       (2,2)
 vals       (3,1)
+vals       (1,1)
+vals       (4,2)
 
 # The following query needs indclass to become an oidvector.
 # See bug #26504.

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -55,6 +55,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/vtable"
 	"github.com/cockroachdb/cockroach/pkg/util/collatedstring"
 	"github.com/cockroachdb/cockroach/pkg/util/duration"
+	"github.com/cockroachdb/cockroach/pkg/util/intsets"
 	"github.com/cockroachdb/cockroach/pkg/util/iterutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -408,8 +409,14 @@ https://www.postgresql.org/docs/12/catalog-pg-attribute.html`,
 		lookup simpleSchemaResolver,
 		addRow func(...tree.Datum) error,
 	) error {
+		populatedColumns := intsets.Fast{}
+		maxPGAttributeNum := 0
 		// addColumn adds either a table or an index column to the pg_attribute table.
 		addColumn := func(column catalog.Column, attRelID tree.Datum, attNum uint32) error {
+			if int(column.GetID()) > maxPGAttributeNum {
+				maxPGAttributeNum = int(column.GetPGAttributeNum())
+			}
+			populatedColumns.Add(int(column.GetPGAttributeNum()))
 			colTyp := column.GetType()
 			// Sets the attgenerated column to 's' if the column is generated/
 			// computed stored, "v" if virtual, zero byte otherwise.
@@ -474,10 +481,60 @@ https://www.postgresql.org/docs/12/catalog-pg-attribute.html`,
 		}
 
 		// Columns for table.
+		tableID := tableOid(table.GetID())
 		for _, column := range table.AccessibleColumns() {
-			tableID := tableOid(table.GetID())
 			if err := addColumn(column, tableID, uint32(column.GetPGAttributeNum())); err != nil {
 				return err
+			}
+		}
+		// The next column ID may not be populated on certain relations like
+		// sequences, so only use if it's available.
+		if int(table.GetNextColumnID()) > maxPGAttributeNum {
+			// We need to check the maximum in the table in case columns
+			// at the end were dropped.
+			maxPGAttributeNum = int(table.GetNextColumnID() - 1)
+		}
+		// Add a dropped entry for any attribute numbers in the middle that are
+		// missing, assuming there are any numeric gaps in the number of columns
+		// observed.
+		missingColumnType := types.Any
+		if populatedColumns.Len() != maxPGAttributeNum {
+			for colOrdinal := 1; colOrdinal <= maxPGAttributeNum; colOrdinal++ {
+				if populatedColumns.Contains(colOrdinal) {
+					continue
+				}
+				colName := strings.Replace(fmt.Sprintf("........pg.dropped.%-8d", colOrdinal), " ", ".", -1)
+				if err := addRow(
+					tableID,                             // attrelid
+					tree.NewDName(colName),              // attname
+					typOid(missingColumnType),           // atttypid
+					zeroVal,                             // attstattarget
+					typLen(missingColumnType),           // attlen
+					tree.NewDInt(tree.DInt(colOrdinal)), // attnum
+					zeroVal,                             // attndims
+					negOneVal,                           // attcacheoff
+					tree.NewDInt(tree.DInt(missingColumnType.TypeModifier())), // atttypmod
+					tree.DNull,                    // attbyval (see pg_type.typbyval)
+					tree.DNull,                    // attstorage
+					tree.DNull,                    // attalign
+					tree.DBoolFalse,               // attnotnull
+					tree.DBoolFalse,               // atthasdef
+					tree.NewDString(""),           // attidentity
+					tree.NewDString(""),           // attgenerated
+					tree.DBoolTrue,                // attisdropped
+					tree.DBoolTrue,                // attislocal
+					zeroVal,                       // attinhcount
+					typColl(missingColumnType, h), // attcollation
+					tree.DNull,                    // attacl
+					tree.DNull,                    // attoptions
+					tree.DNull,                    // attfdwoptions
+					// These columns were automatically created by pg_catalog_test's missing column generator.
+					tree.DNull, // atthasmissing
+					// These columns were automatically created by pg_catalog_test's missing column generator.
+					tree.DNull, // attmissingval
+				); err != nil {
+					return err
+				}
 			}
 		}
 
@@ -1811,6 +1868,7 @@ https://www.postgresql.org/docs/9.5/catalog-pg-index.html`,
 		return forEachTableDesc(ctx, p, dbContext, hideVirtual, /* virtual tables do not have indexes */
 			func(db catalog.DatabaseDescriptor, sc catalog.SchemaDescriptor, table catalog.TableDescriptor) error {
 				tableOid := tableOid(table.GetID())
+
 				return catalog.ForEachIndex(table, catalog.IndexOpts{}, func(index catalog.Index) error {
 					isMutation, isWriteOnly :=
 						table.GetIndexMutationCapabilities(index.GetID())
@@ -1823,7 +1881,7 @@ https://www.postgresql.org/docs/9.5/catalog-pg-index.html`,
 					collationOids := tree.NewDArray(types.Oid)
 					indoption := tree.NewDArray(types.Int)
 
-					colIDs := make([]descpb.ColumnID, 0, index.NumKeyColumns())
+					colAttNums := make([]descpb.ColumnID, 0, index.NumKeyColumns())
 					exprs := make([]string, 0, index.NumKeyColumns())
 					for i := index.IndexDesc().ExplicitColumnStartIdx(); i < index.NumKeyColumns(); i++ {
 						columnID := index.GetKeyColumnID(i)
@@ -1834,7 +1892,7 @@ https://www.postgresql.org/docs/9.5/catalog-pg-index.html`,
 						// The indkey for an expression element in an index
 						// should be 0.
 						if col.IsExpressionIndexColumn() {
-							colIDs = append(colIDs, 0)
+							colAttNums = append(colAttNums, 0)
 							formattedExpr, err := schemaexpr.FormatExprForDisplay(
 								ctx, table, col.GetComputeExpr(), p.SemaCtx(), p.SessionData(), tree.FmtPGCatalog,
 							)
@@ -1843,7 +1901,7 @@ https://www.postgresql.org/docs/9.5/catalog-pg-index.html`,
 							}
 							exprs = append(exprs, fmt.Sprintf("(%s)", formattedExpr))
 						} else {
-							colIDs = append(colIDs, columnID)
+							colAttNums = append(colAttNums, descpb.ColumnID(col.GetPGAttributeNum()))
 						}
 						if err := collationOids.Append(typColl(col.GetType(), h)); err != nil {
 							return err
@@ -1861,13 +1919,17 @@ https://www.postgresql.org/docs/9.5/catalog-pg-index.html`,
 						}
 					}
 					// indnkeyatts is the number of attributes without INCLUDED columns.
-					indnkeyatts := len(colIDs)
+					indnkeyatts := len(colAttNums)
 					for i := 0; i < index.NumSecondaryStoredColumns(); i++ {
-						colIDs = append(colIDs, index.GetStoredColumnID(i))
+						col, err := catalog.MustFindColumnByID(table, index.GetStoredColumnID(i))
+						if err != nil {
+							return err
+						}
+						colAttNums = append(colAttNums, descpb.ColumnID(col.GetPGAttributeNum()))
 					}
 					// indnatts is the number of attributes with INCLUDED columns.
-					indnatts := len(colIDs)
-					indkey, err := colIDArrayToVector(colIDs)
+					indnatts := len(colAttNums)
+					indkey, err := colIDArrayToVector(colAttNums)
 					if err != nil {
 						return err
 					}


### PR DESCRIPTION
Previously, the attribute number generated inside pg_attribute could be sparse because there would be gaps after columns were or dropped. This could be problematic for ORMs since this would mean that attribute numbers could be sparse, and they may not be designed to handle such gaps. To address this, this patch adds dropped synthetic columns into the pg_attribute table, which allows these tools to work correctly.

Fixes: #110545

Release note (bug fix): pg_attribute could have sparsely populated attnum's since dropped columns were not included.