### PR TITLE
sql: fix flaky TestHotRangesStats

### DIFF
--- a/pkg/server/structlogging/hot_ranges_log_test.go
+++ b/pkg/server/structlogging/hot_ranges_log_test.go
@@ -83,7 +83,7 @@ func TestHotRangesStats(t *testing.T) {
 		return nil
 	})
 
-	testutils.SucceedsWithin(t, func() error {
+	testutils.SucceedsSoon(t, func() error {
 		log.FlushFiles()
 		entries, err := log.FetchEntriesFromFiles(
 			0,
@@ -99,5 +99,5 @@ func TestHotRangesStats(t *testing.T) {
 			return errors.New("waiting for logs")
 		}
 		return nil
-	}, 5*time.Second)
+	})
 }


### PR DESCRIPTION
The test failed with timeouts under stress. The test is switched to use the SucceedsSoon which allows for more time when under stress.

Fixes: #111036

Release note: None