### PR TITLE
kvserver: deflake TestMergeQueueWithSlowNonVoterSnaps

### DIFF
--- a/pkg/kv/kvserver/client_merge_test.go
+++ b/pkg/kv/kvserver/client_merge_test.go
@@ -4808,6 +4808,13 @@ func TestMergeQueueWithSlowNonVoterSnaps(t *testing.T) {
 					// Disable load-based splitting, so that the absence of sufficient QPS
 					// measurements do not prevent ranges from merging.
 					DisableLoadBasedSplitting: true,
+					// Occasionally, the initial snapshot sent to the newly relocated
+					// non-voter replica can get rejected, prompting another snapshot to
+					// be sent via the snapshot queue. Because snapshots in this test are
+					// expensive/slow on purpose, this can cause the expected merge to
+					// time out. For more details on these circumstances, see the comment
+					// for DisableRaftSnapshotQueue.
+					DisableRaftSnapshotQueue: true,
 				},
 			},
 		},
@@ -4825,6 +4832,7 @@ func TestMergeQueueWithSlowNonVoterSnaps(t *testing.T) {
 						},
 						// See above.
 						DisableLoadBasedSplitting: true,
+						DisableRaftSnapshotQueue:  true,
 					},
 				},
 			},


### PR DESCRIPTION
Occasionally, the initial snapshot sent to the newly relocated non-voter replica can get rejected, prompting another snapshot to be sent via the snapshot queue. Because snapshots in this test are expensive/slow on purpose, this can cause the expected merge to time out. To circumvent the issue, this change turns on the DisableRaftSnapshotQueue testing knob.

Part of: #85372
Release note: None