### PR TITLE
release-23.1: changefeedccl: Fix test flake

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -7348,12 +7348,11 @@ func TestChangefeedEndTimeWithCursor(t *testing.T) {
 		feed := feed(t, f, "CREATE CHANGEFEED FOR foo WITH cursor = $1, end_time = $2, no_initial_scan", tsCursor, fakeEndTime)
 		defer closeFeed(t, feed)
 
-		assertPayloads(t, feed, []string{
-			`foo: [4]->{"after": {"a": 4}}`,
-			`foo: [5]->{"after": {"a": 5}}`,
-			`foo: [6]->{"after": {"a": 6}}`,
-		})
-		close(endTimeReached)
+		// Don't care much about the values emitted (tested elsewhere) -- all
+		// we want to make sure is that the feed terminates.  However, we do need
+		// to consume those values since some of the test sink implementations (kafka)
+		// will block.
+		defer DiscardMessages(feed)()
 
 		testFeed := feed.(cdctest.EnterpriseTestFeed)
 		require.NoError(t, testFeed.WaitForStatus(func(s jobs.Status) bool {

--- a/pkg/ccl/changefeedccl/testfeed_test.go
+++ b/pkg/ccl/changefeedccl/testfeed_test.go
@@ -1959,6 +1959,35 @@ func (k *kafkaFeed) Close() error {
 	return errors.CombineErrors(k.jobFeed.Close(), k.tg.wait())
 }
 
+// DiscardMessages spins up a goroutine to discard messages produced into the
+// sink. Returns cleanup function.
+func DiscardMessages(f cdctest.TestFeed) func() {
+	switch t := f.(type) {
+	case *kafkaFeed:
+		ctx, cancel := context.WithCancel(context.Background())
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case <-t.shutdown:
+					return
+				case <-t.source:
+				}
+			}
+		}()
+		return func() {
+			cancel()
+			wg.Wait()
+		}
+	default:
+		return func() {}
+	}
+}
+
 type webhookFeedFactory struct {
 	enterpriseFeedFactory
 	useSecureServer bool


### PR DESCRIPTION
Backport 1/1 commits from #111002.

/cc @cockroachdb/release

---

Fixes #110372
Fix TestChangefeedEndTimeWithCursor test flake.  Ensure the test consumes and discards messages to ensure the test sink implementation (kafka) does not block.

Release note: None

Release justification: flaky test fix
