### PR TITLE
ui: bump cluster-ui to 23.1.11

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/package.json
+++ b/pkg/ui/workspaces/cluster-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cockroachlabs/cluster-ui",
-  "version": "23.1.10",
+  "version": "23.1.11",
   "description": "Cluster UI is a library of large features shared between CockroachDB and CockroachCloud",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Bump cluster-ui to 23.1.11.

This version includes changes to view db pages with limited permissions on CC ([demo](https://www.loom.com/share/61ddc5a9999d449eb9dffdf32679fcba))

Epic: none

Release note: None