### PR TITLE
workload/schemachange: add support for ALTER TYPE ... DROP VALUE

### DIFF
--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catconstants"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"github.com/jackc/pgx/v5"
@@ -177,6 +178,7 @@ const (
 	dropIndex         // DROP INDEX <index>@<table>
 	dropSequence      // DROP SEQUENCE <sequence>
 	dropTable         // DROP TABLE <table>
+	dropEnumValue     // ALTER TYPE <type> DROP VALUE <value>
 	dropView          // DROP VIEW <view>
 	dropSchema        // DROP SCHEMA <schema>
 
@@ -226,6 +228,7 @@ var opFuncs = map[opType]func(*operationGenerator, context.Context, pgx.Tx) (*op
 	dropSequence:            (*operationGenerator).dropSequence,
 	dropTable:               (*operationGenerator).dropTable,
 	dropView:                (*operationGenerator).dropView,
+	dropEnumValue:           (*operationGenerator).dropTypeValue,
 	dropSchema:              (*operationGenerator).dropSchema,
 	primaryRegion:           (*operationGenerator).primaryRegion,
 	renameColumn:            (*operationGenerator).renameColumn,
@@ -272,6 +275,7 @@ var opWeights = []int{
 	dropSequence:            1,
 	dropTable:               1,
 	dropView:                1,
+	dropEnumValue:           1,
 	dropSchema:              1,
 	primaryRegion:           0, // Disabled and tracked with #83831
 	renameColumn:            1,
@@ -311,6 +315,7 @@ var opDeclarative = []bool{
 	dropSequence:            true,
 	dropTable:               true,
 	dropView:                true,
+	dropEnumValue:           false,
 	dropSchema:              true,
 	primaryRegion:           false,
 	renameColumn:            false,
@@ -344,6 +349,7 @@ var opDeclarativeVersion = []clusterversion.Key{
 	dropSequence:            clusterversion.BinaryMinSupportedVersionKey,
 	dropTable:               clusterversion.BinaryMinSupportedVersionKey,
 	dropView:                clusterversion.BinaryMinSupportedVersionKey,
+	dropEnumValue:           clusterversion.BinaryMinSupportedVersionKey,
 	dropSchema:              clusterversion.BinaryMinSupportedVersionKey,
 }
 
@@ -2155,6 +2161,39 @@ func (og *operationGenerator) dropView(ctx context.Context, tx pgx.Tx) (*opStmt,
 	return stmt, nil
 }
 
+func (og *operationGenerator) dropTypeValue(ctx context.Context, tx pgx.Tx) (*opStmt, error) {
+	enum, exists, err := og.randEnum(ctx, tx, og.pctExisting(true))
+	if err != nil {
+		return nil, err
+	}
+
+	validValue := false
+	value := "IrrelevantEnumValue"
+
+	if exists {
+		value, validValue, err = og.randEnumValue(ctx, tx, og.pctExisting(true), enum)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	valueDropping := false
+	if validValue {
+		valueDropping, err = og.enumValueIsBeingRemoved(ctx, tx, enum.String(), value)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	stmt := makeOpStmt(OpStmtDDL)
+	stmt.expectedExecErrors.addAll(codesWithConditions{
+		{pgcode.UndefinedObject, !exists || !validValue},
+		{pgcode.ObjectNotInPrerequisiteState, valueDropping},
+	})
+	stmt.sql = fmt.Sprintf(`ALTER TYPE %s DROP VALUE '%s'`, enum, value)
+	return stmt, nil
+}
+
 func (og *operationGenerator) renameColumn(ctx context.Context, tx pgx.Tx) (*opStmt, error) {
 	tableName, err := og.randTable(ctx, tx, og.pctExisting(true), "")
 	if err != nil {
@@ -3390,6 +3429,50 @@ ORDER BY random()
 	return &typeName, true, nil
 }
 
+func (og *operationGenerator) randEnumValue(
+	ctx context.Context, tx pgx.Tx, pctExisting int, enum *tree.TypeName,
+) (value string, exists bool, err error) {
+	const q = `SELECT unnest(values) FROM [SHOW ENUMS] WHERE schema = $1 AND name = $2`
+
+	rows, err := tx.Query(ctx, q, enum.Schema(), enum.Object())
+	if err != nil {
+		return "", false, err
+	}
+
+	defer rows.Close()
+
+	var values []string
+	for rows.Next() {
+		var v string
+		if err := rows.Scan(&v); err != nil {
+			return "", false, err
+		}
+		values = append(values, v)
+	}
+
+	if rows.Err() != nil {
+		return "", false, rows.Err()
+	}
+
+	if og.randIntn(100) >= pctExisting || len(values) == 0 {
+		valueSet := make(map[string]bool, len(values))
+		for _, v := range values {
+			valueSet[v] = true
+		}
+
+		// It's pretty unlikely that we'll generate conflicting values but better
+		// safe than sorry.
+		for {
+			nonExistentValue := og.randString(5, 5)
+			if !valueSet[nonExistentValue] {
+				return nonExistentValue, false, nil
+			}
+		}
+	}
+
+	return values[og.randIntn(len(values))], true, nil
+}
+
 // randTable returns a schema name along with a table name
 func (og *operationGenerator) randTable(
 	ctx context.Context, tx pgx.Tx, pctExisting int, desiredSchema string,
@@ -3820,9 +3903,24 @@ func (og *operationGenerator) produceError() bool {
 	return og.randIntn(100) < og.params.errorRate
 }
 
-// Returns an int in the range [0,topBound). It panics if topBound <= 0.
+// randIntn returns an int in the range [0,topBound). It panics if topBound <= 0.
 func (og *operationGenerator) randIntn(topBound int) int {
 	return og.params.rng.Intn(topBound)
+}
+
+// randString return a random string that matches the regex `[a-z_]{min,max}`.
+// It panics if min < 0 or min > max.
+func (og *operationGenerator) randString(min, max int) string {
+	if min < 0 || min > max {
+		panic("invalid arguments to randString")
+	}
+
+	// Use a more restricted alphabet here so we generate strings that are safe
+	// for values or identifiers.
+	const alphabet = "abcdefghijklmnopqrstuvwxyz_"
+
+	length := og.randIntn(max) + min
+	return randutil.RandString(og.params.rng, length, alphabet)
 }
 
 func (og *operationGenerator) newUniqueSeqNum() int64 {

--- a/pkg/workload/schemachange/optype_string.go
+++ b/pkg/workload/schemachange/optype_string.go
@@ -29,21 +29,22 @@ func _() {
 	_ = x[dropIndex-18]
 	_ = x[dropSequence-19]
 	_ = x[dropTable-20]
-	_ = x[dropView-21]
-	_ = x[dropSchema-22]
-	_ = x[primaryRegion-23]
-	_ = x[renameColumn-24]
-	_ = x[renameIndex-25]
-	_ = x[renameSequence-26]
-	_ = x[renameTable-27]
-	_ = x[renameView-28]
-	_ = x[setColumnDefault-29]
-	_ = x[setColumnNotNull-30]
-	_ = x[setColumnType-31]
-	_ = x[survive-32]
-	_ = x[insertRow-33]
-	_ = x[selectStmt-34]
-	_ = x[validate-35]
+	_ = x[dropEnumValue-21]
+	_ = x[dropView-22]
+	_ = x[dropSchema-23]
+	_ = x[primaryRegion-24]
+	_ = x[renameColumn-25]
+	_ = x[renameIndex-26]
+	_ = x[renameSequence-27]
+	_ = x[renameTable-28]
+	_ = x[renameView-29]
+	_ = x[setColumnDefault-30]
+	_ = x[setColumnNotNull-31]
+	_ = x[setColumnType-32]
+	_ = x[survive-33]
+	_ = x[insertRow-34]
+	_ = x[selectStmt-35]
+	_ = x[validate-36]
 }
 
 func (i opType) String() string {
@@ -90,6 +91,8 @@ func (i opType) String() string {
 		return "dropSequence"
 	case dropTable:
 		return "dropTable"
+	case dropEnumValue:
+		return "dropEnumValue"
 	case dropView:
 		return "dropView"
 	case dropSchema:

--- a/pkg/workload/schemachange/watch_dog.go
+++ b/pkg/workload/schemachange/watch_dog.go
@@ -69,7 +69,7 @@ func (w *schemaChangeWatchDog) isConnectionActive(ctx context.Context) bool {
 	}
 	lastNumRetries := w.numRetries
 	txnInfo := w.conn.QueryRow(ctx,
-		"SELECT sum(num_retries) + sum(num_auto_retries) FROM crdb_internal.cluster_transactions WHERE id=$1",
+		"SELECT coalesce(sum(num_retries),0) + coalesce(sum(num_auto_retries),0) FROM crdb_internal.cluster_transactions WHERE id=$1",
 		&w.txnID)
 	if err := txnInfo.Scan(&w.numRetries); err != nil {
 		w.logger.logWatchDog(fmt.Sprintf("failed to get transaction information: %v\n", err))


### PR DESCRIPTION
**workload/schemachange: fix Scan error in watchdog**
Previously, running the schemachange workload would intermittently log
errors about not being able to scan NULL into an *int. This was due to
an aggregation that would occasionally find no rows.

This commit wraps the `sum` aggregations in a `coalesce` to ensure an
integer is always returned.

Epic: none
Release note: None

**workload/schemachange: add support for ALTER TYPE ... DROP VALUE**
`ALTER TYPE ... DROP VALUE ...` has been implemented for quite some time
now. However, it was never implemented within `workload/schemachange`.
This commit adds a generator for said statment to `operationGenerator`.

Epic: CRDB-19168
Fixes: #59197
Release note: None
