### PR TITLE
roachtest: show informational message when grafana is not available

### DIFF
--- a/pkg/cmd/roachtest/github.go
+++ b/pkg/cmd/roachtest/github.go
@@ -64,15 +64,19 @@ func generateHelpCommand(
 		)(renderer)
 		// An empty clusterName corresponds to a cluster creation failure.
 		// We only scrape metrics from GCE clusters for now.
-		if spec.GCE == cloud && clusterName != "" {
-			// N.B. This assumes we are posting from a source that does not run a test more than once.
-			// Otherwise, we'd need to use `testRunId`, which encodes the run number and allows us
-			// to distinguish between multiple runs of the same test, instead of `testName`.
-			issues.HelpCommandAsLink(
-				"Grafana",
-				fmt.Sprintf("https://go.crdb.dev/roachtest-grafana/%s/%s/%d/%d", vm.SanitizeLabel(runID),
-					vm.SanitizeLabel(testName), start.UnixMilli(), end.Add(2*time.Minute).UnixMilli()),
-			)(renderer)
+		if clusterName != "" {
+			if spec.GCE == cloud {
+				// N.B. This assumes we are posting from a source that does not run a test more than once.
+				// Otherwise, we'd need to use `testRunId`, which encodes the run number and allows us
+				// to distinguish between multiple runs of the same test, instead of `testName`.
+				issues.HelpCommandAsLink(
+					"Grafana",
+					fmt.Sprintf("https://go.crdb.dev/roachtest-grafana/%s/%s/%d/%d", vm.SanitizeLabel(runID),
+						vm.SanitizeLabel(testName), start.UnixMilli(), end.Add(2*time.Minute).UnixMilli()),
+				)(renderer)
+			} else {
+				renderer.Escaped(fmt.Sprintf("_Grafana is not yet available for %s clusters_", cloud))
+			}
 		}
 	}
 }

--- a/pkg/cmd/roachtest/testdata/help_command_non_gce.txt
+++ b/pkg/cmd/roachtest/testdata/help_command_non_gce.txt
@@ -9,5 +9,6 @@ See: [roachtest README](https://github.com/cockroachdb/cockroach/blob/master/pkg
 
 See: [How To Investigate \(internal\)](https://cockroachlabs.atlassian.net/l/c/SSSBr8c7)
 
+_Grafana is not yet available for aws clusters_
 ----
 ----


### PR DESCRIPTION
When posting a roachtest github issue from AWS (or any non GCE cloud), a message stating that Grafana is not yet available is shown.

Epic: none
Release note: none