### PR TITLE
roachprod: add virtual cluster support to the monitor

### DIFF
--- a/pkg/cmd/roachprod/flags.go
+++ b/pkg/cmd/roachprod/flags.go
@@ -49,6 +49,7 @@ var (
 	secure                = false
 	virtualClusterName    string
 	sqlInstance           int
+	virtualClusterID      int
 	extraSSHOptions       = ""
 	nodeEnv               []string
 	tag                   string
@@ -216,9 +217,15 @@ Default is "RECURRING '*/15 * * * *' FULL BACKUP '@hourly' WITH SCHEDULE OPTIONS
 	startInstanceAsSeparateProcessCmd.Flags().IntVar(&startOpts.SQLInstance,
 		"sql-instance", 0, "specific SQL/HTTP instance to connect to (this is a roachprod abstraction distinct from the internal instance ID)")
 
-	stopCmd.Flags().IntVar(&sig, "sig", sig, "signal to pass to kill")
-	stopCmd.Flags().BoolVar(&waitFlag, "wait", waitFlag, "wait for processes to exit")
-	stopCmd.Flags().IntVar(&maxWait, "max-wait", maxWait, "approx number of seconds to wait for processes to exit")
+	// Flags for processes that stop (kill) processes.
+	for _, stopProcessesCmd := range []*cobra.Command{stopCmd, stopInstanceAsSeparateProcessCmd} {
+		stopProcessesCmd.Flags().IntVar(&sig, "sig", sig, "signal to pass to kill")
+		stopProcessesCmd.Flags().BoolVar(&waitFlag, "wait", waitFlag, "wait for processes to exit")
+		stopProcessesCmd.Flags().IntVar(&maxWait, "max-wait", maxWait, "approx number of seconds to wait for processes to exit")
+	}
+
+	stopInstanceAsSeparateProcessCmd.Flags().IntVarP(&virtualClusterID, "cluster-id", "t", virtualClusterID, "internal ID for the virtual cluster")
+	stopInstanceAsSeparateProcessCmd.Flags().IntVar(&sqlInstance, "sql-instance", 0, "specific SQL/HTTP instance to stop")
 
 	syncCmd.Flags().BoolVar(&listOpts.IncludeVolumes, "include-volumes", false, "Include volumes when syncing")
 

--- a/pkg/cmd/roachprod/flags.go
+++ b/pkg/cmd/roachprod/flags.go
@@ -337,7 +337,7 @@ Default is "RECURRING '*/15 * * * *' FULL BACKUP '@hourly' WITH SCHEDULE OPTIONS
 	}
 
 	for _, cmd := range []*cobra.Command{
-		startCmd, statusCmd, stopCmd, runCmd,
+		startCmd, startInstanceAsSeparateProcessCmd, statusCmd, stopCmd, runCmd,
 	} {
 		cmd.Flags().StringVar(&tag, "tag", "", "the process tag")
 	}

--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -510,6 +510,7 @@ shutdown cockroach. The --wait flag causes stop to loop waiting for all
 processes with the right ROACHPROD environment variable to exit. Note that stop
 will wait forever if you specify --wait with a non-terminating signal (e.g.
 SIGHUP), unless you also configure --max-wait.
+
 --wait defaults to true for signal 9 (SIGKILL) and false for all other signals.
 ` + tagHelp + `
 `,
@@ -568,6 +569,43 @@ environment variables to the cockroach process.
 		}
 		return roachprod.StartServiceForVirtualCluster(context.Background(),
 			config.Logger, targetRoachprodCluster, storageCluster, startOpts, clusterSettingsOpts...)
+	}),
+}
+
+var stopInstanceAsSeparateProcessCmd = &cobra.Command{
+	Use:   "stop-sql <virtual-cluster> --tenant-id <id> --sql-instance <instance> [--sig] [--wait]",
+	Short: "stop sql instances on a cluster",
+	Long: `Stop sql instances on a cluster.
+
+Stop roachprod created sql instances running on the nodes in a cluster. Every
+process started by roachprod is tagged with a ROACHPROD environment variable
+which is used by "stop-sql" to locate the processes and terminate them. By default,
+processes are killed with signal 9 (SIGKILL) giving them no chance for a graceful
+exit.
+
+The --sig flag will pass a signal to kill to allow us finer control over how we
+shutdown processes. The --wait flag causes stop to loop waiting for all
+processes with the right ROACHPROD environment variable to exit. Note that stop
+will wait forever if you specify --wait with a non-terminating signal (e.g.
+SIGHUP), unless you also configure --max-wait.
+
+--wait defaults to true for signal 9 (SIGKILL) and false for all other signals.
+`,
+	Args: cobra.ExactArgs(1),
+	Run: wrap(func(cmd *cobra.Command, args []string) error {
+		wait := waitFlag
+		if sig == 9 /* SIGKILL */ && !cmd.Flags().Changed("wait") {
+			wait = true
+		}
+		stopOpts := roachprod.StopOpts{
+			Wait:             wait,
+			MaxWait:          maxWait,
+			Sig:              sig,
+			VirtualClusterID: virtualClusterID,
+			SQLInstance:      sqlInstance,
+		}
+		virtualCluster := args[0]
+		return roachprod.StopServiceForVirtualCluster(context.Background(), config.Logger, virtualCluster, stopOpts)
 	}),
 }
 
@@ -679,7 +717,7 @@ of nodes, outputting a line whenever a change is detected:
 var signalCmd = &cobra.Command{
 	Use:   "signal <cluster> <signal>",
 	Short: "send signal to cluster",
-	Long:  "Send a POSIX signal to the nodes in a cluster, specified by its integer code.",
+	Long:  "Send a POSIX signal, specified by its integer code, to every process started via roachprod in a cluster.",
 	Args:  cobra.ExactArgs(2),
 	Run: wrap(func(cmd *cobra.Command, args []string) error {
 		sig, err := strconv.ParseInt(args[1], 10, 8)
@@ -1361,6 +1399,7 @@ func main() {
 		startCmd,
 		stopCmd,
 		startInstanceAsSeparateProcessCmd,
+		stopInstanceAsSeparateProcessCmd,
 		initCmd,
 		runCmd,
 		signalCmd,

--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -534,9 +534,8 @@ var startInstanceAsSeparateProcessCmd = &cobra.Command{
 The --storage-cluster flag must be used to specify a storage cluster
 (with optional node selector) which is already running. The command
 will create the virtual cluster on the storage cluster if it does not
-exist already. The storage cluster and virtual cluster can use the
-same underlying roachprod VM cluster, as long as different subsets of
-nodes are selected.
+exist already.  If creating multiple virtual clusters on the same
+node, the --sql-instance flag must be passed to differentiate them.
 
 The --tenant-id flag can be used to specify the tenant ID; it defaults to 2.
 

--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -567,6 +567,15 @@ environment variables to the cockroach process.
 			install.EnvOption(nodeEnv),
 			install.NumRacksOption(numRacks),
 		}
+
+		// Always pick a random available port when starting virtual
+		// clusters. We do not expose the functionality of choosing a
+		// specific port, so this is fine.
+		//
+		// TODO(renato): remove this once #111052 is addressed.
+		startOpts.SQLPort = 0
+		startOpts.AdminUIPort = 0
+
 		return roachprod.StartServiceForVirtualCluster(context.Background(),
 			config.Logger, targetRoachprodCluster, storageCluster, startOpts, clusterSettingsOpts...)
 	}),

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -1396,17 +1396,22 @@ func (c *clusterImpl) assertNoDeadNode(ctx context.Context, t test.Test) error {
 		return err
 	}
 
-	deadNodes := 0
+	deadProcesses := 0
 	for info := range eventsCh {
 		t.L().Printf("%s", info)
 
-		if _, isDeath := info.Event.(install.MonitorNodeDead); isDeath {
-			deadNodes++
+		if _, isDeath := info.Event.(install.MonitorProcessDead); isDeath {
+			deadProcesses++
 		}
 	}
 
-	if deadNodes > 0 {
-		return errors.Newf("%d dead node(s) detected", deadNodes)
+	var plural string
+	if deadProcesses > 1 {
+		plural = "es"
+	}
+
+	if deadProcesses > 0 {
+		return errors.Newf("%d dead cockroach process%s detected", deadProcesses, plural)
 	}
 	return nil
 }

--- a/pkg/cmd/roachtest/monitor.go
+++ b/pkg/cmd/roachtest/monitor.go
@@ -168,7 +168,7 @@ func (m *monitorImpl) startNodeMonitor() {
 			}
 
 			for info := range eventsCh {
-				_, isDeath := info.Event.(install.MonitorNodeDead)
+				_, isDeath := info.Event.(install.MonitorProcessDead)
 				isExpectedDeath := isDeath && atomic.AddInt32(&m.expDeaths, -1) >= 0
 				var expectedDeathStr string
 				if isExpectedDeath {

--- a/pkg/roachprod/install/BUILD.bazel
+++ b/pkg/roachprod/install/BUILD.bazel
@@ -51,6 +51,7 @@ go_test(
     name = "install_test",
     srcs = [
         "cluster_synced_test.go",
+        "cockroach_test.go",
         "services_test.go",
         "staging_test.go",
         "start_template_test.go",

--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -22,6 +22,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -414,7 +415,16 @@ func (c *SyncedCluster) Stop(
 	maxWait int,
 	virtualClusterLabel string,
 ) error {
-	display := fmt.Sprintf("%s: stopping", c.Name)
+	var virtualClusterDisplay string
+	if virtualClusterLabel != "" {
+		virtualClusterName, sqlInstance, err := VirtualClusterInfoFromLabel(virtualClusterLabel)
+		if err != nil {
+			return err
+		}
+
+		virtualClusterDisplay = fmt.Sprintf(" virtual cluster %q, instance %d", virtualClusterName, sqlInstance)
+	}
+	display := fmt.Sprintf("%s: stopping%s", c.Name, virtualClusterDisplay)
 	if wait {
 		display += " and waiting"
 	}
@@ -589,18 +599,26 @@ fi
 	return statuses, nil
 }
 
-// MonitorNodeSkipped represents a node whose status was not checked.
-type MonitorNodeSkipped struct{}
-
-// MonitorNodeRunning represents the cockroach process running on a
-// node.
-type MonitorNodeRunning struct {
-	PID string
+// MonitorProcessSkipped represents a cockroach process whose status
+// was not checked.
+type MonitorProcessSkipped struct {
+	VirtualClusterName string
+	SQLInstance        int
 }
 
-// MonitorNodeDead represents the cockroach process dying on a node.
-type MonitorNodeDead struct {
-	ExitCode string
+// MonitorProcessRunning represents the cockroach process running on a
+// node.
+type MonitorProcessRunning struct {
+	VirtualClusterName string
+	SQLInstance        int
+	PID                string
+}
+
+// MonitorProcessDead represents the cockroach process dying on a node.
+type MonitorProcessDead struct {
+	VirtualClusterName string
+	SQLInstance        int
+	ExitCode           string
 }
 
 type MonitorError struct {
@@ -612,24 +630,36 @@ type NodeMonitorInfo struct {
 	// The index of the node (in a SyncedCluster) at which the message originated.
 	Node Node
 	// Event describes what happened to the node; it is one of
-	// MonitorNodeSkipped (no store directory was found);
-	// MonitorNodeRunning, sent when cockroach is running on a node;
-	// MonitorNodeDead, when the cockroach process stops running on a
-	// node; or MonitorError, typically indicate networking issues
-	// or nodes that have (physically) shut down.
+	// MonitorProcessSkipped (no store directory was found);
+	// MonitorProcessRunning, sent when cockroach is running on a node;
+	// MonitorProcessDead, when the cockroach process stops running on a
+	// node; or MonitorError, typically indicate networking issues or
+	// nodes that have (physically) shut down.
 	Event interface{}
 }
 
 func (nmi NodeMonitorInfo) String() string {
 	var status string
 
+	virtualClusterDesc := func(name string, instance int) string {
+		if name == SystemInterfaceName {
+			return "system interface"
+		}
+
+		return fmt.Sprintf("virtual cluster %q, instance %d", name, instance)
+	}
+
 	switch event := nmi.Event.(type) {
-	case MonitorNodeRunning:
-		status = fmt.Sprintf("cockroach process is running (PID: %s)", event.PID)
-	case MonitorNodeSkipped:
-		status = "node skipped"
-	case MonitorNodeDead:
-		status = fmt.Sprintf("cockroach process died (exit code %s)", event.ExitCode)
+	case MonitorProcessRunning:
+		status = fmt.Sprintf("cockroach process for %s is running (PID: %s)",
+			virtualClusterDesc(event.VirtualClusterName, event.SQLInstance), event.PID,
+		)
+	case MonitorProcessSkipped:
+		status = fmt.Sprintf("%s was skipped", virtualClusterDesc(event.VirtualClusterName, event.SQLInstance))
+	case MonitorProcessDead:
+		status = fmt.Sprintf("cockroach process for %s died (exit code %s)",
+			virtualClusterDesc(event.VirtualClusterName, event.SQLInstance), event.ExitCode,
+		)
 	case MonitorError:
 		status = fmt.Sprintf("error: %s", event.Err.Error())
 	}
@@ -651,9 +681,14 @@ type MonitorOpts struct {
 // channel is subsequently closed; otherwise the process continues indefinitely
 // (emitting new information as the status of the cockroach process changes).
 //
-// If IgnoreEmptyNodes is true, nodes on which no CockroachDB data is found
-// (in {store-dir}) will not be probed and single event, MonitorNodeSkipped,
-// will be emitted for them.
+// If IgnoreEmptyNodes is true, tenants on which no CockroachDB data is found
+// (in {store-dir}) will not be probed and single event, MonitorTenantSkipped,
+// will be emitted for each tenant.
+//
+// Note that the monitor will only send events for tenants that exist
+// at the time this function is called. In other words, this function
+// will not emit events for tenants started *after* a call to
+// Monitor().
 func (c *SyncedCluster) Monitor(
 	l *logger.Logger, ctx context.Context, opts MonitorOpts,
 ) chan NodeMonitorInfo {
@@ -666,6 +701,13 @@ func (c *SyncedCluster) Monitor(
 	// that is listened to by the caller. Bails if the context is
 	// canceled.
 	sendEvent := func(info NodeMonitorInfo) {
+		// if the monitor's context is already canceled, do not attempt to
+		// send the error down the channel, as it is most likely *caused*
+		// by the cancelation itself.
+		if monitorCtx.Err() != nil {
+			return
+		}
+
 		select {
 		case ch <- info:
 			// We were able to send the info through the channel.
@@ -681,39 +723,87 @@ func (c *SyncedCluster) Monitor(
 		deadMsg    = "dead"
 	)
 
+	wg.Add(len(nodes))
 	for i := range nodes {
-		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
-
 			node := nodes[i]
-			port, err := c.NodePort(ctx, node)
-			if err != nil {
-				err := errors.Wrap(err, "failed to get node port")
+
+			// We first find out all cockroach processes that are currently
+			// running in this node.
+			cockroachProcessesCmd := fmt.Sprintf(`ps axeww -o command | `+
+				`grep -E '%s' | `+ // processes started by roachprod
+				`grep -E -o 'ROACHPROD_VIRTUAL_CLUSTER=[^ ]*' | `+ // ROACHPROD_VIRTUAL_CLUSTER indicates this is a cockroach process
+				`cut -d= -f2`, // grab the virtual cluster label
+				c.roachprodEnvRegex(node),
+			)
+
+			result, err := c.runCmdOnSingleNode(
+				ctx, l, node, cockroachProcessesCmd, defaultCmdOpts("list-processes"),
+			)
+			if err := errors.CombineErrors(err, result.Err); err != nil {
+				err := errors.Wrap(err, "failed to list cockroach processes")
 				sendEvent(NodeMonitorInfo{Node: node, Event: MonitorError{err}})
 				return
 			}
-			// On each monitored node, we loop looking for a cockroach process.
+
+			type virtualClusterInfo struct {
+				Name     string
+				Instance int
+			}
+
+			// Make the collection of virtual clusters a set to handle the
+			// unlikely but possible case that, in `local` runs, we'll find
+			// two processes associated with the same virtual cluster
+			// label. This can happen if we invoke the command above while the
+			// parent cockroach process already created the child,
+			// background process, but has not terminated yet.
+			vcs := map[virtualClusterInfo]struct{}{}
+			vcLines := strings.TrimSuffix(result.CombinedOut, "\n")
+			if vcLines == "" {
+				err := errors.New("no cockroach processes running")
+				sendEvent(NodeMonitorInfo{Node: node, Event: MonitorError{err}})
+				return
+			}
+			for _, label := range strings.Split(vcLines, "\n") {
+				name, instance, err := VirtualClusterInfoFromLabel(label)
+				if err != nil {
+					sendEvent(NodeMonitorInfo{Node: node, Event: MonitorError{err}})
+					return
+				}
+				vcs[virtualClusterInfo{name, instance}] = struct{}{}
+			}
+
 			data := struct {
 				OneShot     bool
+				Node        Node
 				IgnoreEmpty bool
 				Store       string
-				Port        int
 				Local       bool
 				Separator   string
 				SkippedMsg  string
 				RunningMsg  string
 				DeadMsg     string
+				Processes   []virtualClusterInfo
 			}{
 				OneShot:     opts.OneShot,
+				Node:        node,
 				IgnoreEmpty: opts.IgnoreEmptyNodes,
 				Store:       c.NodeDir(node, 1 /* storeIndex */),
-				Port:        port,
 				Local:       c.IsLocal(),
 				Separator:   separator,
 				SkippedMsg:  skippedMsg,
 				RunningMsg:  runningMsg,
 				DeadMsg:     deadMsg,
+				Processes:   maps.Keys(vcs),
+			}
+
+			storeFor := func(name string, instance int) string {
+				return c.InstanceStoreDir(node, name, instance)
+			}
+
+			localPIDFile := func(name string, instance int) string {
+				return filepath.Join(c.LogDir(node, name, instance), "cockroach.pid")
 			}
 
 			// NB.: we parse the output of every line this script
@@ -721,62 +811,86 @@ func (c *SyncedCluster) Monitor(
 			// down below in order to produce structured results to the
 			// caller.
 			snippet := `
-{{ if .IgnoreEmpty }}
-if ! ls {{.Store}}/marker.* 1> /dev/null 2>&1; then
-  echo "{{.SkippedMsg}}"
-  exit 0
-fi
-{{- end}}
-# Init with -1 so that when cockroach is initially dead, we print
-# a dead event for it.
-lastpid=-1
-while :; do
-{{ if .Local }}
-  pid=$(lsof -i :{{.Port}} -sTCP:LISTEN | awk '!/COMMAND/ {print $2}')
-	pid=${pid:-0} # default to 0
-	status="unknown"
-{{- else }}
-  # When CRDB is not running, this is zero.
-	pid=$(systemctl show cockroach --property MainPID --value)
-	status=$(systemctl show cockroach --property ExecMainStatus --value)
-{{- end }}
-  if [[ "${lastpid}" == -1 && "${pid}" != 0 ]]; then
-    # On the first iteration through the loop, if the process is running,
-    # don't register a PID change (which would trigger an erroneous dead
-    # event).
-    lastpid=0
+dead_parent() {
+  ! ps -p "$1" >/dev/null || ps -o ucomm -p "$1" | grep -q defunct
+}
+{{ range .Processes }}
+monitor_process_{{$.Node}}_{{.Name}}_{{.Instance}}() {
+  {{ if $.IgnoreEmpty }}
+  if ! ls {{storeFor .Name .Instance}}/marker.* 1> /dev/null 2>&1; then
+    echo "{{.Name}}{{$.Separator}}{{.Instance}}{{$.Separator}}{{$.SkippedMsg}}"
+    return 0
   fi
-  # Output a dead event whenever the PID changes from a nonzero value to
-  # any other value. In particular, we emit a dead event when the node stops
-  # (lastpid is nonzero, pid is zero), but not when the process then starts
-  # again (lastpid is zero, pid is nonzero).
-  if [ "${pid}" != "${lastpid}" ]; then
-    if [ "${lastpid}" != 0 ]; then
-      if [ "${pid}" != 0 ]; then
-        # If the PID changed but neither is zero, then the status refers to
-        # the new incarnation. We lost the actual exit status of the old PID.
-        status="unknown"
+  {{- end}}
+  # Init with -1 so that when cockroach is initially dead, we print
+  # a dead event for it.
+  lastpid=-1
+  while :; do
+    # if parent process terminated, quit as well.
+    if dead_parent "$1"; then
+      return 0
+    fi
+    {{ if $.Local }}
+    pidFile=$(cat "{{pidFile .Name .Instance}}")
+    # Make sure the process is still running
+    pid=$(test -n "${pidFile}" && ps -p "${pidFile}" >/dev/null && echo "${pidFile}")
+    pid=${pid:-0} # default to 0
+    status="unknown"
+    {{- else }}
+    # When CRDB is not running, this is zero.
+    pid=$(systemctl show "{{virtualClusterLabel .Name .Instance}}" --property MainPID --value)
+    status=$(systemctl show "{{virtualClusterLabel .Name .Instance}}" --property ExecMainStatus --value)
+    {{- end }}
+    if [[ "${lastpid}" == -1 && "${pid}" != 0 ]]; then
+      # On the first iteration through the loop, if the process is running,
+      # don't register a PID change (which would trigger an erroneous dead
+      # event).
+      lastpid=0
+    fi
+    # Output a dead event whenever the PID changes from a nonzero value to
+    # any other value. In particular, we emit a dead event when the node stops
+    # (lastpid is nonzero, pid is zero), but not when the process then starts
+    # again (lastpid is zero, pid is nonzero).
+    if [ "${pid}" != "${lastpid}" ]; then
+      if [ "${lastpid}" != 0 ]; then
+        if [ "${pid}" != 0 ]; then
+          # If the PID changed but neither is zero, then the status refers to
+          # the new incarnation. We lost the actual exit status of the old PID.
+          status="unknown"
+        fi
+    	  echo "{{.Name}}{{$.Separator}}{{.Instance}}{{$.Separator}}{{$.DeadMsg}}{{$.Separator}}${status}"
       fi
-    	echo "{{.DeadMsg}}{{.Separator}}${status}"
+  	  if [ "${pid}" != 0 ]; then
+  		  echo "{{.Name}}{{$.Separator}}{{.Instance}}{{$.Separator}}{{$.RunningMsg}}{{$.Separator}}${pid}"
+      fi
+      lastpid=${pid}
     fi
-		if [ "${pid}" != 0 ]; then
-			echo "{{.RunningMsg}}{{.Separator}}${pid}"
+    {{ if $.OneShot }}
+      return 0
+    {{- end }}
+    sleep 1
+    if [ "${pid}" != 0 ]; then
+      while kill -0 "${pid}" && ! dead_parent "$1"; do
+        sleep 1
+      done
     fi
-    lastpid=${pid}
-  fi
-{{ if .OneShot }}
-  exit 0
-{{- end }}
-  sleep 1
-  if [ "${pid}" != 0 ]; then
-    while kill -0 "${pid}"; do
-      sleep 1
-    done
-  fi
-done
+  done
+}
+{{ end }}
+
+# monitor every cockroach process in parallel.
+{{ range .Processes }}
+monitor_process_{{$.Node}}_{{.Name}}_{{.Instance}} $$ &
+{{ end }}
+
+wait
 `
 
-			t := template.Must(template.New("script").Parse(snippet))
+			t := template.Must(template.New("script").Funcs(template.FuncMap{
+				"storeFor":            storeFor,
+				"pidFile":             localPIDFile,
+				"virtualClusterLabel": VirtualClusterLabel,
+			}).Parse(snippet))
 			var buf bytes.Buffer
 			if err := t.Execute(&buf, data); err != nil {
 				err := errors.Wrap(err, "failed to execute template")
@@ -792,7 +906,6 @@ done
 			if err != nil {
 				err := errors.Wrap(err, "failed to read stdout pipe")
 				sendEvent(NodeMonitorInfo{Node: node, Event: MonitorError{err}})
-				wg.Done()
 				return
 			}
 			// Request a PTY so that the script will receive a SIGPIPE when the
@@ -816,20 +929,46 @@ done
 					if err != nil {
 						err := errors.Wrap(err, "error reading from session")
 						sendEvent(NodeMonitorInfo{Node: node, Event: MonitorError{err}})
+						return
 					}
 
 					parts := strings.Split(string(line), separator)
-					switch parts[0] {
+					ensureNumParts := func(n int) {
+						if len(parts) < n {
+							panic(fmt.Errorf("invalid output from monitor: %q", line))
+						}
+					}
+					// Every event is expected to have at least 3 parts. If
+					// that's not the case, panic explicitly below. Otherwise,
+					// we'd get a slice out of bounds error and the error
+					// message would not include the actual problematic line,
+					// which would make understanding the failure more
+					// difficult.
+					ensureNumParts(3) // name, instance, event
+
+					// Virtual cluster name and instance are the first fields of
+					// every event type.
+					name, instanceStr := parts[0], parts[1]
+					instance, _ := strconv.Atoi(instanceStr)
+					switch parts[2] {
 					case skippedMsg:
-						sendEvent(NodeMonitorInfo{Node: node, Event: MonitorNodeSkipped{}})
+						sendEvent(NodeMonitorInfo{Node: node, Event: MonitorProcessSkipped{
+							VirtualClusterName: name, SQLInstance: instance,
+						}})
 					case runningMsg:
-						pid := parts[1]
-						sendEvent(NodeMonitorInfo{Node: node, Event: MonitorNodeRunning{pid}})
+						ensureNumParts(4)
+						pid := parts[3]
+						sendEvent(NodeMonitorInfo{Node: node, Event: MonitorProcessRunning{
+							VirtualClusterName: name, SQLInstance: instance, PID: pid,
+						}})
 					case deadMsg:
-						exitCode := parts[1]
-						sendEvent(NodeMonitorInfo{Node: node, Event: MonitorNodeDead{exitCode}})
+						ensureNumParts(4)
+						exitCode := parts[3]
+						sendEvent(NodeMonitorInfo{Node: node, Event: MonitorProcessDead{
+							VirtualClusterName: name, SQLInstance: instance, ExitCode: exitCode,
+						}})
 					default:
-						err := fmt.Errorf("internal error: unrecognized output from monitor: %s", line)
+						err := fmt.Errorf("internal error: unrecognized output from monitor: %q", line)
 						sendEvent(NodeMonitorInfo{Node: node, Event: MonitorError{err}})
 					}
 				}
@@ -841,8 +980,8 @@ done
 				return
 			}
 
-			// Watch for context cancellation, which can happen either if
-			// the test fails, or if the monitor loop exits.
+			// Watch for context cancellation, which can happen if the test
+			// fails, or if the monitor loop exits.
 			go func() {
 				<-monitorCtx.Done()
 				sess.Close()

--- a/pkg/roachprod/install/cockroach.go
+++ b/pkg/roachprod/install/cockroach.go
@@ -19,6 +19,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"text/template"
 
@@ -596,6 +597,44 @@ func VirtualClusterLabel(virtualClusterName string, sqlInstance int) string {
 	}
 
 	return fmt.Sprintf("cockroach-%s_%d", virtualClusterName, sqlInstance)
+}
+
+// VirtualClusterInfoFromLabel takes as parameter a tenant label
+// produced with `VirtuaLClusterLabel()` and returns the corresponding
+// tenant name and instance.
+func VirtualClusterInfoFromLabel(virtualClusterLabel string) (string, int, error) {
+	var (
+		sqlInstance          int
+		sqlInstanceStr       string
+		labelWithoutInstance string
+		err                  error
+	)
+
+	sep := "_"
+	parts := strings.Split(virtualClusterLabel, sep)
+
+	// Note that this logic assumes that virtual cluster names cannot
+	// have a '_' character, which is currently (Sep 2023) the case.
+	switch len(parts) {
+	case 1:
+		// This should be a system tenant (no instance identifier)
+		labelWithoutInstance = parts[0]
+
+	case 2:
+		// SQL instance process: instance number is after the '_' character.
+		labelWithoutInstance, sqlInstanceStr = parts[0], parts[1]
+		sqlInstance, err = strconv.Atoi(sqlInstanceStr)
+		if err != nil {
+			return "", 0, fmt.Errorf("invalid virtual cluster label: %s", virtualClusterLabel)
+		}
+
+	default:
+		return "", 0, fmt.Errorf("invalid virtual cluster label: %s", virtualClusterLabel)
+	}
+
+	// Remove the "cockroach-" prefix added by VirtualClusterLabel.
+	virtualClusterName := strings.TrimPrefix(labelWithoutInstance, "cockroach-")
+	return virtualClusterName, sqlInstance, nil
 }
 
 func execStartTemplate(data startTemplateData) (string, error) {

--- a/pkg/roachprod/install/cockroach_test.go
+++ b/pkg/roachprod/install/cockroach_test.go
@@ -1,0 +1,67 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package install
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestVirtualClusterLabel(t *testing.T) {
+	testCases := []struct {
+		name               string
+		virtualClusterName string
+		sqlInstance        int
+		expectedLabel      string
+	}{
+		{
+			name:               "empty virtual cluster name",
+			virtualClusterName: "",
+			expectedLabel:      "cockroach-system",
+		},
+		{
+			name:               "system interface name",
+			virtualClusterName: "system",
+			expectedLabel:      "cockroach-system",
+		},
+		{
+			name:               "simple virtual cluster name",
+			virtualClusterName: "a",
+			sqlInstance:        1,
+			expectedLabel:      "cockroach-a_1",
+		},
+		{
+			name:               "virtual cluster name with hyphens",
+			virtualClusterName: "virtual-cluster-a-1",
+			sqlInstance:        1,
+			expectedLabel:      "cockroach-virtual-cluster-a-1_1",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			label := VirtualClusterLabel(tc.virtualClusterName, tc.sqlInstance)
+			require.Equal(t, tc.expectedLabel, label)
+
+			nameFromLabel, instanceFromLabel, err := VirtualClusterInfoFromLabel(label)
+			require.NoError(t, err)
+
+			expectedVirtualClusterName := tc.virtualClusterName
+			if tc.virtualClusterName == "" {
+				expectedVirtualClusterName = "system"
+			}
+			require.Equal(t, expectedVirtualClusterName, nameFromLabel)
+
+			require.Equal(t, tc.sqlInstance, instanceFromLabel)
+		})
+	}
+}

--- a/pkg/roachprod/install/scripts/start.sh
+++ b/pkg/roachprod/install/scripts/start.sh
@@ -20,6 +20,7 @@ BINARY=#{shesc .Binary#}
 KEY_CMD=#{.KeyCmd#}
 MEMORY_MAX=#{.MemoryMax#}
 NUM_FILES_LIMIT=#{.NumFilesLimit#}
+VIRTUAL_CLUSTER_LABEL=#{.VirtualClusterLabel#}
 ARGS=(
 #{range .Args -#}
 #{shesc .#}
@@ -50,7 +51,7 @@ if [[ -n "${LOCAL}" || "${1-}" == "run" ]]; then
     mkdir -p "${BAZEL_COVER_DIR}"
   fi
   CODE=0
-  "${BINARY}" "${ARGS[@]}" >> "${LOG_DIR}/cockroach.stdout.log" 2>> "${LOG_DIR}/cockroach.stderr.log" || CODE="$?"
+  ROACHPROD_VIRTUAL_CLUSTER="${VIRTUAL_CLUSTER_LABEL}" "${BINARY}" "${ARGS[@]}" >> "${LOG_DIR}/cockroach.stdout.log" 2>> "${LOG_DIR}/cockroach.stderr.log" || CODE="$?"
   if [[ -z "${LOCAL}" || "${CODE}" -ne 0 ]]; then
     echo "cockroach exited with code ${CODE}: $(date)" | tee -a "${LOG_DIR}"/{roachprod,cockroach.{exit,std{out,err}}}.log
   fi
@@ -73,18 +74,18 @@ sudo systemctl reset-failed cockroach 2>/dev/null || true
 # The first time we run, install a small script that shows some helpful
 # information when we ssh in.
 if [ ! -e "${HOME}/.profile-cockroach" ]; then
-  cat > "${HOME}/.profile-cockroach" <<'EOQ'
+  cat > "${HOME}/.profile-${VIRTUAL_CLUSTER_LABEL}" <<'EOQ'
 echo ""
-if systemctl is-active -q cockroach; then
-  echo "cockroach is running; see: systemctl status cockroach"
-elif systemctl is-failed -q cockroach; then
-  echo "cockroach stopped; see: systemctl status cockroach"
+if systemctl is-active -q ${VIRTUAL_CLUSTER_LABEL}; then
+  echo "${VIRTUAL_CLUSTER_LABEL} is running; see: systemctl status ${VIRTUAL_CLUSTER_LABEL}"
+elif systemctl is-failed -q ${VIRTUAL_CLUSTER_LABEL}; then
+  echo "${VIRTUAL_CLUSTER_LABEL} stopped; see: systemctl status ${VIRTUAL_CLUSTER_LABEL}"
 else
-  echo "cockroach not started"
+  echo "${VIRTUAL_CLUSTER_LABEL} not started"
 fi
 echo ""
 EOQ
-  echo ". ${HOME}/.profile-cockroach" >> "${HOME}/.profile"
+  echo ". ${HOME}/.profile-${VIRTUAL_CLUSTER_LABEL}" >> "${HOME}/.profile"
 fi
 
 # We run this script (with arg "run") as a service unit. We do not use --user
@@ -93,7 +94,7 @@ fi
 # The "notify" service type means that systemd-run waits until cockroach
 # notifies systemd that it is ready; NotifyAccess=all is needed because this
 # notification doesn't come from the main PID (which is bash).
-sudo systemd-run --unit cockroach \
+sudo systemd-run --unit "${VIRTUAL_CLUSTER_LABEL}" \
   --same-dir --uid "$(id -u)" --gid "$(id -g)" \
   --service-type=notify -p NotifyAccess=all \
   -p "MemoryMax=${MEMORY_MAX}" \

--- a/pkg/roachprod/install/session.go
+++ b/pkg/roachprod/install/session.go
@@ -18,6 +18,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"sync"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/roachprod/config"
 	rperrors "github.com/cockroachdb/cockroach/pkg/roachprod/errors"
@@ -214,7 +215,15 @@ func (s *remoteSession) StderrPipe() (io.Reader, error) {
 }
 
 func (s *remoteSession) RequestPty() error {
-	s.Cmd.Args = append(s.Cmd.Args, "-t")
+	if len(s.Cmd.Args) == 0 {
+		return fmt.Errorf("unexpected remote command: expected arguments, none found")
+	}
+
+	// Add the `-t` option after `ssh user@host`, otherwise, "-t" could
+	// confuse the underlying shell used when executing complex commands
+	// using `ssh`, leading to cryptic errors like: `bash: line 70:
+	// syntax error near -t`.
+	s.Cmd.Args = append(s.Cmd.Args[:1], append([]string{"-t"}, s.Cmd.Args[1:]...)...)
 	return nil
 }
 
@@ -237,6 +246,7 @@ type localSession struct {
 func newLocalSession(cmd string) *localSession {
 	ctx, cancel := context.WithCancel(context.Background())
 	fullCmd := exec.CommandContext(ctx, "/bin/bash", "-c", cmd)
+	fullCmd.WaitDelay = time.Second
 	return &localSession{fullCmd, cancel}
 }
 

--- a/pkg/roachprod/install/start_template_test.go
+++ b/pkg/roachprod/install/start_template_test.go
@@ -23,11 +23,12 @@ func TestExecStartTemplate(t *testing.T) {
 		LogDir: "./path with spaces/logs/$THIS_DOES_NOT_EVER_GET_EXPANDED",
 		KeyCmd: `echo foo && \
 echo bar $HOME`,
-		EnvVars:   []string{"ROACHPROD=1/tigtag", "COCKROACH=foo", "ROCKCOACH=17%"},
-		Binary:    "./cockroach",
-		Args:      []string{`start`, `--log`, `file-defaults: {dir: '/path with spaces/logs', exit-on-error: false}`},
-		MemoryMax: "81%",
-		Local:     true,
+		EnvVars:             []string{"ROACHPROD=1/tigtag", "COCKROACH=foo", "ROCKCOACH=17%"},
+		Binary:              "./cockroach",
+		Args:                []string{`start`, `--log`, `file-defaults: {dir: '/path with spaces/logs', exit-on-error: false}`},
+		MemoryMax:           "81%",
+		VirtualClusterLabel: "cockroach-system",
+		Local:               true,
 	}
 	datadriven.Walk(t, datapathutils.TestDataPath(t, "start"), func(t *testing.T, path string) {
 		datadriven.RunTest(t, path, func(t *testing.T, td *datadriven.TestData) string {

--- a/pkg/roachprod/install/testdata/start/start.txt
+++ b/pkg/roachprod/install/testdata/start/start.txt
@@ -24,6 +24,7 @@ KEY_CMD=echo foo && \
 echo bar $HOME
 MEMORY_MAX=81%
 NUM_FILES_LIMIT=0
+VIRTUAL_CLUSTER_LABEL=cockroach-system
 ARGS=(
 start
 --log
@@ -54,7 +55,7 @@ if [[ -n "${LOCAL}" || "${1-}" == "run" ]]; then
     mkdir -p "${BAZEL_COVER_DIR}"
   fi
   CODE=0
-  "${BINARY}" "${ARGS[@]}" >> "${LOG_DIR}/cockroach.stdout.log" 2>> "${LOG_DIR}/cockroach.stderr.log" || CODE="$?"
+  ROACHPROD_VIRTUAL_CLUSTER="${VIRTUAL_CLUSTER_LABEL}" "${BINARY}" "${ARGS[@]}" >> "${LOG_DIR}/cockroach.stdout.log" 2>> "${LOG_DIR}/cockroach.stderr.log" || CODE="$?"
   if [[ -z "${LOCAL}" || "${CODE}" -ne 0 ]]; then
     echo "cockroach exited with code ${CODE}: $(date)" | tee -a "${LOG_DIR}"/{roachprod,cockroach.{exit,std{out,err}}}.log
   fi
@@ -77,18 +78,18 @@ sudo systemctl reset-failed cockroach 2>/dev/null || true
 # The first time we run, install a small script that shows some helpful
 # information when we ssh in.
 if [ ! -e "${HOME}/.profile-cockroach" ]; then
-  cat > "${HOME}/.profile-cockroach" <<'EOQ'
+  cat > "${HOME}/.profile-${VIRTUAL_CLUSTER_LABEL}" <<'EOQ'
 echo ""
-if systemctl is-active -q cockroach; then
-  echo "cockroach is running; see: systemctl status cockroach"
-elif systemctl is-failed -q cockroach; then
-  echo "cockroach stopped; see: systemctl status cockroach"
+if systemctl is-active -q ${VIRTUAL_CLUSTER_LABEL}; then
+  echo "${VIRTUAL_CLUSTER_LABEL} is running; see: systemctl status ${VIRTUAL_CLUSTER_LABEL}"
+elif systemctl is-failed -q ${VIRTUAL_CLUSTER_LABEL}; then
+  echo "${VIRTUAL_CLUSTER_LABEL} stopped; see: systemctl status ${VIRTUAL_CLUSTER_LABEL}"
 else
-  echo "cockroach not started"
+  echo "${VIRTUAL_CLUSTER_LABEL} not started"
 fi
 echo ""
 EOQ
-  echo ". ${HOME}/.profile-cockroach" >> "${HOME}/.profile"
+  echo ". ${HOME}/.profile-${VIRTUAL_CLUSTER_LABEL}" >> "${HOME}/.profile"
 fi
 
 # We run this script (with arg "run") as a service unit. We do not use --user
@@ -97,7 +98,7 @@ fi
 # The "notify" service type means that systemd-run waits until cockroach
 # notifies systemd that it is ready; NotifyAccess=all is needed because this
 # notification doesn't come from the main PID (which is bash).
-sudo systemd-run --unit cockroach \
+sudo systemd-run --unit "${VIRTUAL_CLUSTER_LABEL}" \
   --same-dir --uid "$(id -u)" --gid "$(id -g)" \
   --service-type=notify -p NotifyAccess=all \
   -p "MemoryMax=${MEMORY_MAX}" \

--- a/pkg/roachprod/install/testdata/start/start.txt
+++ b/pkg/roachprod/install/testdata/start/start.txt
@@ -39,7 +39,11 @@ ROCKCOACH=17%
 # End of templated code.
 
 if [[ -n "${LOCAL}" ]]; then
-  ARGS+=("--background")
+  # Write to an empty pid file. This is referenced by the roachprod
+  # monitor to find the PID of cockroach processes running locally.
+  PID_FILE="${LOG_DIR}/cockroach.pid"
+  rm -f "${PID_FILE}"
+  ARGS+=("--background" "--pid-file" "${PID_FILE}")
 fi
 
 if [[ -n "${LOCAL}" || "${1-}" == "run" ]]; then
@@ -65,20 +69,20 @@ fi
 # Set up systemd unit and start it, which will recursively
 # invoke this script but hit the above conditional.
 
-if systemctl is-active -q cockroach; then
-  echo "cockroach service already active"
-  echo "To get more information: systemctl status cockroach"
+if systemctl is-active -q "${VIRTUAL_CLUSTER_LABEL}"; then
+  echo "${VIRTUAL_CLUSTER_LABEL} service already active"
+  echo "To get more information: systemctl status ${VIRTUAL_CLUSTER_LABEL}"
   exit 1
 fi
 
 # If cockroach failed, the service still exists; we need to clean it up before
 # we can start it again.
-sudo systemctl reset-failed cockroach 2>/dev/null || true
+sudo systemctl reset-failed "${VIRTUAL_CLUSTER_LABEL}" 2>/dev/null || true
 
 # The first time we run, install a small script that shows some helpful
 # information when we ssh in.
 if [ ! -e "${HOME}/.profile-cockroach" ]; then
-  cat > "${HOME}/.profile-${VIRTUAL_CLUSTER_LABEL}" <<'EOQ'
+  cat > "${HOME}/.profile-${VIRTUAL_CLUSTER_LABEL}" <<EOQ
 echo ""
 if systemctl is-active -q ${VIRTUAL_CLUSTER_LABEL}; then
   echo "${VIRTUAL_CLUSTER_LABEL} is running; see: systemctl status ${VIRTUAL_CLUSTER_LABEL}"

--- a/pkg/roachprod/multitenant.go
+++ b/pkg/roachprod/multitenant.go
@@ -33,12 +33,12 @@ import (
 func StartServiceForVirtualCluster(
 	ctx context.Context,
 	l *logger.Logger,
-	tenantCluster string,
+	virtualCluster string,
 	storageCluster string,
 	startOpts install.StartOpts,
 	clusterSettingsOpts ...install.ClusterSettingOption,
 ) error {
-	tc, err := newCluster(l, tenantCluster, clusterSettingsOpts...)
+	tc, err := newCluster(l, virtualCluster, clusterSettingsOpts...)
 	if err != nil {
 		return err
 	}
@@ -53,8 +53,7 @@ func StartServiceForVirtualCluster(
 	if startOpts.VirtualClusterID < 2 {
 		return errors.Errorf("invalid tenant ID %d (must be 2 or higher)", startOpts.VirtualClusterID)
 	}
-	// TODO(herko): Allow users to pass in a virtual cluster name.
-	startOpts.VirtualClusterName = fmt.Sprintf("tenant-%d", startOpts.VirtualClusterID)
+	startOpts.VirtualClusterName = defaultVirtualClusterName(startOpts.VirtualClusterID)
 
 	// Create virtual cluster, if necessary. We only need to run this
 	// SQL against a single connection to the storage cluster.
@@ -78,6 +77,28 @@ func StartServiceForVirtualCluster(
 	startOpts.KVAddrs = strings.Join(kvAddrs, ",")
 	startOpts.KVCluster = hc
 	return tc.Start(ctx, l, startOpts)
+}
+
+// StopServiceForVirtualCluster stops SQL instance processes on the virtualCluster given.
+func StopServiceForVirtualCluster(
+	ctx context.Context, l *logger.Logger, virtualCluster string, stopOpts StopOpts,
+) error {
+	tc, err := newCluster(l, virtualCluster)
+	if err != nil {
+		return err
+	}
+
+	stopOpts.VirtualClusterName = defaultVirtualClusterName(stopOpts.VirtualClusterID)
+	vc := install.VirtualClusterLabel(stopOpts.VirtualClusterName, stopOpts.SQLInstance)
+	return tc.Stop(ctx, l, stopOpts.Sig, stopOpts.Wait, stopOpts.MaxWait, vc)
+}
+
+// defaultVirtualClusterName returns the virtual cluster name used for
+// the virtual cluster with ID given.
+//
+// TODO(herko): Allow users to pass in a virtual cluster name.
+func defaultVirtualClusterName(virtualClusterID int) string {
+	return fmt.Sprintf("virtual-cluster-%d", virtualClusterID)
 }
 
 // createVirtualClusterIfNotExistsQuery is used to initialize the

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -666,8 +666,10 @@ func DefaultStartOpts() install.StartOpts {
 		ScheduleBackups:    false,
 		ScheduleBackupArgs: "",
 		InitTarget:         1,
-		SQLPort:            config.DefaultSQLPort,
-		AdminUIPort:        config.DefaultAdminUIPort,
+		// TODO(renato): change the defaults below to `0` (i.e., pick a
+		// random available port) once #111052 is addressed.
+		SQLPort:     config.DefaultSQLPort,
+		AdminUIPort: config.DefaultAdminUIPort,
 	}
 }
 

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -710,6 +710,11 @@ type StopOpts struct {
 	// If MaxWait is set, roachprod waits that approximate number of seconds
 	// until the PID disappears.
 	MaxWait int
+
+	// Options that only apply to StopServiceForVirtualCluster
+	VirtualClusterID   int
+	VirtualClusterName string
+	SQLInstance        int
 }
 
 // DefaultStopOpts returns StopOpts populated with the default values used by Stop.
@@ -731,7 +736,7 @@ func Stop(ctx context.Context, l *logger.Logger, clusterName string, opts StopOp
 	if err != nil {
 		return err
 	}
-	return c.Stop(ctx, l, opts.Sig, opts.Wait, opts.MaxWait)
+	return c.Stop(ctx, l, opts.Sig, opts.Wait, opts.MaxWait, "")
 }
 
 // Signal sends a signal to nodes in the cluster.


### PR DESCRIPTION
This PR makes the roachprod monitor aware of multi-tenancy. This means
that the monitor is able to identify scenarios where multiple tenants
are running on the same VM, and monitor the lifecycle of tenant
processes just like it does for non multi-tenant deployments.

Under the covers, this is achieved by leveraging the
"ROACHPROD_VIRTUAL_CLUSTER" environment variable that is
set when starting cockroach. The monitor then looks for processes
that have that environment variable set, and parses it to identify the
tenant name and instance corresponding to that cockroach process.

This change should go unnoticed by all current monitor callers: tests
that monitor cockroach processes will continue to be notified of
events just like they did before. The only thing that changes is that,
if a test uses roachprod to start and stop tenants, these events will
be available through the monitor.

This PR also adds a `stop-tenant` command that uses the same
`ROACHPROD_TENANT` environment variable to allow the caller to
stop a specific tenant process.

Epic: none

Release note: None