### PR TITLE
release-22.2: storageparam: do not allow subqueries in storage param clause

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -2862,3 +2862,13 @@ t_99764  CREATE TABLE public.t_99764 (
              i INT8 NOT NULL,
              CONSTRAINT t_99764_pkey PRIMARY KEY (i ASC)
          )
+
+subtest end
+
+# Regression test for https://github.com/cockroachdb/cockroach/issues/110629.
+# Subqueries are not allowed in storage parameters.
+statement ok
+CREATE TABLE t_110629 (a INT PRIMARY KEY);
+
+statement error subqueries are not allowed in table storage parameters
+ALTER TABLE t SET ( 'string' = EXISTS ( TABLE error ) );

--- a/pkg/sql/storageparam/storage_param.go
+++ b/pkg/sql/storageparam/storage_param.go
@@ -54,6 +54,11 @@ func Set(
 		// Cast these as strings.
 		expr := paramparse.UnresolvedNameToStrVal(sp.Value)
 
+		// Storage params handle their own scalar arguments, with no help from the
+		// optimizer. As such, they cannot contain subqueries.
+		defer semaCtx.Properties.Restore(semaCtx.Properties)
+		semaCtx.Properties.Require("table storage parameters", tree.RejectSubqueries)
+
 		// Convert the expressions to a datum.
 		typedExpr, err := tree.TypeCheck(evalCtx.Context, expr, semaCtx, types.Any)
 		if err != nil {


### PR DESCRIPTION
Backport 1/1 commits from #110664.

/cc @cockroachdb/release

Release justification: bug fix
fixes https://github.com/cockroachdb/cockroach/issues/111020

---

This would previously cause an internal error. Now it displays a feature not supported error.

fixes https://github.com/cockroachdb/cockroach/issues/110629
Release note: None
