### PR TITLE
teamcity-trigger: reduce streamingest paralleism

### DIFF
--- a/pkg/cmd/teamcity-trigger/main.go
+++ b/pkg/cmd/teamcity-trigger/main.go
@@ -159,7 +159,8 @@ func runTC(queueBuild func(string, map[string]string)) {
 
 		if testTarget == "//pkg/sql/logictest:logictest_test" ||
 			testTarget == "//pkg/kv/kvserver:kvserver_test" ||
-			testTarget == "//pkg/ccl/backupccl:backupccl_test" {
+			testTarget == "//pkg/ccl/backupccl:backupccl_test" ||
+			testTarget == "//pkg/ccl/streamingccl/streamingest:streamingest_test" {
 			// Stress heavy with reduced parallelism (to avoid overloading the
 			// machine, see https://github.com/cockroachdb/cockroach/pull/10966).
 			parallelism /= 2


### PR DESCRIPTION
This patch halves the cpu parallelism used for streamingest tests in the nightly stress job as an attempt to prevent test time outs that I suspect are due to resource exhaustion.

Fixes #111026
Fixes #110763

Release note: None