### PR TITLE
release-23.1: roachtest: codify longer ttl external storage buckets

### DIFF
--- a/pkg/cmd/roachtest/tests/mixed_version_backup.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_backup.go
@@ -943,10 +943,10 @@ func newBackupCollection(name string, btype backupType, options []backupOption) 
 
 func (bc *backupCollection) uri() string {
 	// Append the `nonce` to the backup name since we are now sharing a
-	// global namespace represented by the cockroachdb-backup-testing
+	// global namespace represented by the BACKUP_TESTING_BUCKET
 	// bucket. The nonce allows multiple people (or TeamCity builds) to
 	// be running this test without interfering with one another.
-	return fmt.Sprintf("gs://cockroachdb-backup-testing/mixed-version/%s_%s?AUTH=implicit", bc.name, bc.nonce)
+	return fmt.Sprintf("gs://%s/mixed-version/%s_%s?AUTH=implicit", testutils.BackupTestingBucketLongTTL(), bc.name, bc.nonce)
 }
 
 func (bc *backupCollection) encryptionOption() *encryptionPassphrase {
@@ -2136,8 +2136,8 @@ func registerBackupMixedVersion(r registry.Registry) {
 		EncryptionSupport: registry.EncryptionMetamorphic,
 		RequiresLicense:   true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-			if c.Spec().Cloud != spec.GCE {
-				t.Skip("uses gs://cockroachdb-backup-testing; see https://github.com/cockroachdb/cockroach/issues/105968")
+			if c.Spec().Cloud != spec.GCE && !c.IsLocal() {
+				t.Skip("uses gs://cockroachdb-backup-testing-long-ttl; see https://github.com/cockroachdb/cockroach/issues/105968")
 			}
 
 			roachNodes := c.Range(1, c.Spec().NodeCount-1)

--- a/pkg/testutils/BUILD.bazel
+++ b/pkg/testutils/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "testutils",
     srcs = [
+        "backup.go",
         "base.go",
         "dir.go",
         "error.go",

--- a/pkg/testutils/backup.go
+++ b/pkg/testutils/backup.go
@@ -1,0 +1,47 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package testutils
+
+import "os"
+
+const (
+	defaultBackupBucket              = "cockroachdb-backup-testing"
+	longTTLBackupTestingBucket       = "cockroachdb-backup-testing-long-ttl"
+	backupTestingBucketEnvVar        = "BACKUP_TESTING_BUCKET"
+	backupTestingBucketLongTTLEnvVar = "BACKUP_TESTING_BUCKET_LONG_TTL"
+)
+
+// BackupTestingBucket returns the name of the external storage bucket that
+// should be used in a test run. Most times, this will be the regular public
+// bucket. In private test runs, the name of the bucket is passed through an
+// environment variable.
+func BackupTestingBucket() string {
+	if bucket := os.Getenv(backupTestingBucketEnvVar); bucket != "" {
+		return bucket
+	}
+
+	return defaultBackupBucket
+}
+
+// BackupTestingBucketLongTTL returns the name of the external storage bucket
+// that should be used in a test run where the bucket's content may inform a
+// debugging investigation. At the time of this comment, the ttl for the s3 and
+// gcs buckets is 20 days.
+//
+// In private test runs, the name of the bucket is passed through an environment
+// variable.
+func BackupTestingBucketLongTTL() string {
+	if bucket := os.Getenv(backupTestingBucketLongTTLEnvVar); bucket != "" {
+		return bucket
+	}
+
+	return longTTLBackupTestingBucket
+}

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -507,6 +507,7 @@ func TestLint(t *testing.T) {
 					":!cli/start.go",                      // The CLI needs the GOMEMLIMIT variable.
 					":!internal/codeowners/codeowners.go", // For BAZEL_TEST.
 					":!internal/team/team.go",             // For BAZEL_TEST.
+					":!testutils/backup.go",               // For BACKUP_TESTING_BUCKET
 				},
 			},
 		} {


### PR DESCRIPTION
Backport of https://github.com/cockroachdb/cockroach/pull/110288

----
Previously, the only codified external buckets for roachtests to back up to was the `cockroachdb-backup-testing` buckets in s3 and gcs which each had a ttl of 1 day. This low ttl is not suitable for roachtests that produce backups that the test failure investigator may want to inspect. This patch codifies the new `cockroachdb-backup-testing-long-ttl` buckets in s3 and gcs, which currently have a ttl of 20 days, the same ttl that team city artifacts have.

This patch also points the c2c, backup-restore/mixed-version, and disagg-rebalance roachtests to use these new buckets.

Note this PR only points roachtests that run in public TC environments to the new buckets. A future PR will set the BACKUP_TESTING_BUCKET_LONG_TTL env var for private roacttests to a new bucket with a longer ttl.

Epic: none

Release note: none

Release justification: test only change