### PR TITLE
kvflowcontrol: signaling bug fix and per-stream stats

### DIFF
--- a/pkg/kv/kvserver/kvflowcontrol/kvflowcontrol.go
+++ b/pkg/kv/kvserver/kvflowcontrol/kvflowcontrol.go
@@ -115,7 +115,10 @@ type Controller interface {
 	// the given priority, create-time, and over the given stream. This blocks
 	// until there are flow tokens available or the stream disconnects, subject to
 	// context cancellation. This returns true if the request was admitted through
-	// flow control. Ignore the first return type if err != nil
+	// flow control. Ignore the first return type if err != nil. admitted ==
+	// false && err == nil is a valid return, when something (e.g.
+	// configuration) caused the callee to not care whether flow tokens were
+	// available.
 	Admit(context.Context, admissionpb.WorkPriority, time.Time, ConnectedStream) (admitted bool, _ error)
 	// DeductTokens deducts (without blocking) flow tokens for replicating work
 	// with given priority over the given stream. Requests are expected to
@@ -157,6 +160,9 @@ type Handle interface {
 	// the given priority and create-time. This blocks until there are flow tokens
 	// available for all connected streams. This returns true if the request was
 	// admitted through flow control. Ignore the first return type if err != nil.
+	// admitted == false && err == nil is a valid return, when something (e.g.
+	// configuration) caused the callee to not care whether flow tokens were
+	// available.
 	Admit(context.Context, admissionpb.WorkPriority, time.Time) (admitted bool, _ error)
 	// DeductTokensFor deducts (without blocking) flow tokens for replicating
 	// work with given priority along connected streams. The deduction is

--- a/pkg/kv/kvserver/kvflowcontrol/kvflowcontroller/BUILD.bazel
+++ b/pkg/kv/kvserver/kvflowcontrol/kvflowcontroller/BUILD.bazel
@@ -20,6 +20,9 @@ go_library(
         "//pkg/util/log",
         "//pkg/util/metric",
         "//pkg/util/syncutil",
+        "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
+        "@com_github_dustin_go_humanize//:go-humanize",
     ],
 )
 
@@ -39,6 +42,7 @@ go_test(
         "//pkg/util/leaktest",
         "//pkg/util/log",
         "//pkg/util/metric",
+        "//pkg/util/timeutil",
         "@com_github_cockroachdb_datadriven//:datadriven",
         "@com_github_dustin_go_humanize//:go-humanize",
         "@com_github_stretchr_testify//require",

--- a/pkg/kv/kvserver/kvflowcontrol/kvflowcontroller/kvflowcontroller.go
+++ b/pkg/kv/kvserver/kvflowcontrol/kvflowcontroller/kvflowcontroller.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/errors"
 )
 
 // regularTokensPerStream determines the flow tokens available for regular work
@@ -93,7 +94,7 @@ func New(registry *metric.Registry, settings *cluster.Settings, clock *hlc.Clock
 		elastic: elasticTokens,
 	}
 	c.mu.buckets = sync.Map{}
-	regularTokensPerStream.SetOnChange(&settings.SV, func(ctx context.Context) {
+	onChangeFunc := func(ctx context.Context) {
 		c.mu.Lock()
 		defer c.mu.Unlock()
 
@@ -112,17 +113,30 @@ func New(registry *metric.Registry, settings *cluster.Settings, clock *hlc.Clock
 			// new buckets being added, synchronization we don't get out of
 			// sync.Map.Range() directly.
 			b := value.(*bucket)
-			b.mu.Lock()
-			b.mu.tokensPerWorkClass.regular += adjustment.regular
-			b.mu.tokensPerWorkClass.elastic += adjustment.elastic
-			b.mu.Unlock()
-			c.metrics.onTokenAdjustment(adjustment)
-			if adjustment.regular > 0 || adjustment.elastic > 0 {
-				b.signal() // signal a waiter, if any
+			adj, _ := b.adjust(
+				ctx, admissionpb.RegularWorkClass, adjustment.regular, now, true, c.clock.PhysicalTime())
+			if adj.elastic != 0 {
+				panic(errors.AssertionFailedf("elastic should not be adjusted"))
 			}
+			if buildutil.CrdbTestBuild && adj.regular != adjustment.regular {
+				panic(errors.AssertionFailedf(
+					"unequal adjustments %d != %d", adj.regular, adjustment.regular))
+			}
+			adj, _ = b.adjust(
+				ctx, admissionpb.ElasticWorkClass, adjustment.elastic, now, true, c.clock.PhysicalTime())
+			if adj.regular != 0 {
+				panic(errors.AssertionFailedf("regular should not be adjusted"))
+			}
+			if buildutil.CrdbTestBuild && adj.elastic != adjustment.elastic {
+				panic(errors.AssertionFailedf(
+					"unequal adjustments %d != %d", adj.elastic, adjustment.elastic))
+			}
+			c.metrics.onTokenAdjustment(adjustment)
 			return true
 		})
-	})
+	}
+	regularTokensPerStream.SetOnChange(&settings.SV, onChangeFunc)
+	elasticTokensPerStream.SetOnChange(&settings.SV, onChangeFunc)
 	c.metrics = newMetrics(c)
 	registry.AddMetricStruct(c.metrics)
 	return c
@@ -144,84 +158,48 @@ func (c *Controller) Admit(
 	class := admissionpb.WorkClassFromPri(pri)
 	c.metrics.onWaiting(class)
 
-	// The value of logged transitions to true if there is any waiting.
-	logged := false
 	tstart := c.clock.PhysicalTime()
-	for {
+
+	// In addition to letting requests through when there are tokens
+	// being available, we'll also let them through if we're not
+	// applying flow control to their specific work class.
+	bypass := c.mode() == kvflowcontrol.ApplyToElastic && class == admissionpb.RegularWorkClass
+	waitEndState := waitSuccess
+	waited := false
+	if !bypass {
 		b := c.getBucket(connection.Stream())
-
-		tokens := b.tokens(class)
-		// In addition to letting requests through when there are tokens
-		// being available, we'll also let them through if we're not
-		// applying flow control to their specific work class.
-		bypass := c.mode() == kvflowcontrol.ApplyToElastic && class == admissionpb.RegularWorkClass
-		if tokens > 0 || bypass {
-			waitDuration := c.clock.PhysicalTime().Sub(tstart)
-			const formatStr = "admitted request (pri=%s stream=%s tokens=%s wait-duration=%s mode=%s)"
-			if logged {
-				// Always trace if there is any waiting.
-				log.VEventf(ctx, 2, formatStr, pri, connection.Stream(), tokens, waitDuration, c.mode())
-			} else if log.V(2) {
-				log.Infof(ctx, formatStr, pri, connection.Stream(), tokens, waitDuration, c.mode())
-			}
-			// Else, common case, no waiting and logging verbosity is not high.
-
-			// TODO(irfansharif): Right now we continue forwarding admission
-			// grants to request while the available tokens > 0, which can lead
-			// to over-admission since deduction is deferred (see
-			// testdata/simulation/over_admission).
-			// A. One mitigation could be terminating grant forwarding if the
-			//    'tentatively deducted tokens' exceeds some amount (say, 16
-			//    MiB). When tokens are actually deducted, we'll reduce from
-			//    this 'tentatively deducted' count. We can re-signal() on every
-			//    actual token deduction where available tokens is still > 0.
-			// B. The pathological case with A is when all these tentatively
-			//    deducted tokens are due to requests that are waiting on
-			//    latches and locks. And the next request that wants to be
-			//    admitted is not contending with those latches/locks but gets
-			//    stuck behind it anyway. We could instead count the # of
-			//    requests that go through this bucket and are also past the
-			//    latch/lock acquisition but not yet evaluated, and block if
-			//    that count is greater than some small multiple of GOMAXPROCS.
-
-			b.signal() // signal a waiter, if any
-			c.metrics.onAdmitted(class, waitDuration)
-			if bypass {
-				return false, nil
-			}
-			return true, nil
-		}
-
-		if !logged && log.V(2) {
-			log.Infof(ctx, "waiting for flow tokens (pri=%s stream=%s tokens=%s)",
-				pri, connection.Stream(), tokens)
-			logged = true
-		}
-
-		select {
-		case <-b.wait(): // wait for a signal
-		case <-connection.Disconnected():
-			waitDuration := c.clock.PhysicalTime().Sub(tstart)
-			log.VEventf(ctx, 2,
-				"bypassed as stream disconnected (pri=%s stream=%s tokens=%s wait-duration=%s mode=%s)",
-				pri, connection.Stream(), tokens, waitDuration, c.mode())
-			c.metrics.onBypassed(class, waitDuration)
-			return true, nil
-		case <-ctx.Done():
-			if ctx.Err() != nil {
-				waitDuration := c.clock.PhysicalTime().Sub(tstart)
-				log.VEventf(ctx, 2,
-					"canceled after waiting (pri=%s stream=%s tokens=%s wait-duration=%s mode=%s)",
-					pri, connection.Stream(), tokens, waitDuration, c.mode())
-				c.metrics.onErrored(class, waitDuration)
-			}
-			// Else ...
-			// TODO(sumeer): when would error be non-nil?
-
-			return false, ctx.Err()
-		}
+		waitEndState, waited = b.wait(ctx, class, connection.Disconnected())
 	}
+	waitDuration := c.clock.PhysicalTime().Sub(tstart)
+	if waitEndState == waitSuccess {
+		const formatStr = "admitted request (pri=%s stream=%s wait-duration=%s mode=%s)"
+		if waited {
+			// Always trace if there is any waiting.
+			log.VEventf(ctx, 2, formatStr, pri, connection.Stream(), waitDuration, c.mode())
+		} else if log.V(2) {
+			log.Infof(ctx, formatStr, pri, connection.Stream(), waitDuration, c.mode())
+		}
+		// Else, common case, did not wait and logging verbosity is not high.
 
+		c.metrics.onAdmitted(class, waitDuration)
+		if bypass {
+			return false, nil
+		} else {
+			return true, nil
+		}
+	} else if waitEndState == contextCanceled {
+		log.VEventf(ctx, 2,
+			"canceled after waiting (pri=%s stream=%s wait-duration=%s mode=%s)",
+			pri, connection.Stream(), waitDuration, c.mode())
+		c.metrics.onErrored(class, waitDuration)
+		return false, ctx.Err()
+	} else {
+		log.VEventf(ctx, 2,
+			"bypassed as stream disconnected (pri=%s stream=%s wait-duration=%s mode=%s)",
+			pri, connection.Stream(), waitDuration, c.mode())
+		c.metrics.onBypassed(class, waitDuration)
+		return true, nil
+	}
 	// TODO(irfansharif): Use CreateTime for ordering among waiting
 	// requests, integrate it with epoch-LIFO. See I12 from
 	// kvflowcontrol/doc.go.
@@ -313,13 +291,11 @@ func (c *Controller) adjustTokens(
 	// below) when running kv0/enc=false/nodes=3/cpu=96. Do this as part of
 	// #104154.
 	b := c.getBucket(stream)
-	adjustment, unaccounted := b.adjust(ctx, class, delta, c.mu.limit)
+	adjustment, unaccounted :=
+		b.adjust(ctx, class, delta, c.mu.limit, false, c.clock.PhysicalTime())
 	c.metrics.onTokenAdjustment(adjustment)
 	if unaccounted.regular > 0 || unaccounted.elastic > 0 {
 		c.metrics.onUnaccounted(unaccounted)
-	}
-	if adjustment.regular > 0 || adjustment.elastic > 0 {
-		b.signal() // signal a waiter, if any
 	}
 
 	if log.V(2) {
@@ -341,7 +317,7 @@ func (c *Controller) getBucket(stream kvflowcontrol.Stream) *bucket {
 	if !ok {
 		c.mu.Lock()
 		var loaded bool
-		b, loaded = c.mu.buckets.LoadOrStore(stream, newBucket(c.mu.limit))
+		b, loaded = c.mu.buckets.LoadOrStore(stream, newBucket(c.mu.limit, c.clock.PhysicalTime()))
 		if !loaded {
 			c.mu.bucketCount += 1
 		}
@@ -350,23 +326,20 @@ func (c *Controller) getBucket(stream kvflowcontrol.Stream) *bucket {
 	return b.(*bucket)
 }
 
-// bucket holds flow tokens for {regular,elastic} traffic over a
-// kvflowcontrol.Stream. It's used to synchronize handoff between threads
-// returning and waiting for flow tokens.
-type bucket struct {
-	mu struct {
-		syncutil.RWMutex
-		tokensPerWorkClass tokensPerWorkClass
-	}
-
-	// Waiting requests do so by waiting on signalCh without holding mutexes.
+// bucketPerWorkClass is a helper struct for implementing bucket. tokens and
+// stats are protected by the mutex in bucket. Operations on the signalCh may
+// not be protected by that mutex -- see the comment below.
+type bucketPerWorkClass struct {
+	wc     admissionpb.WorkClass
+	tokens kvflowcontrol.Tokens
+	// Waiting requests do so by waiting on signalCh without holding a mutex.
 	//
 	// Requests first check for available tokens (by acquiring and releasing the
 	// mutex), and then wait if tokens for their work class are unavailable. The
-	// risk in such waiting after releasing the mutex is the race where tokens
-	// become available after the waiter releases the mutex and before it starts
-	// waiting. We handle this race by ensuring that signalCh always has an
-	// entry if tokens are available:
+	// risk in such waiting after releasing the mutex is the following race:
+	// tokens become available after the waiter releases the mutex and before it
+	// starts waiting. We handle this race by ensuring that signalCh always has
+	// an entry if tokens are available:
 	//
 	// - Whenever tokens are returned, signalCh is signaled, waking up a single
 	//   waiting request. If the request finds no available tokens, it starts
@@ -374,15 +347,140 @@ type bucket struct {
 	// - Whenever a request gets admitted, it signals the next waiter if any.
 	//
 	// So at least one request that observed unavailable tokens will get
-	// unblocked, which will in turn unblock others.
+	// unblocked, which will in turn unblock others. This turn by turn admission
+	// provides some throttling to over-admission since the goroutine scheduler
+	// needs to schedule the goroutine that got the entry for it to unblock
+	// another. Hopefully, before we over-admit much, some of the scheduled
+	// goroutines will complete proposal evaluation and deduct the tokens they
+	// need.
+	//
+	// TODO(irfansharif): Right now we continue forwarding admission grants to
+	// request while the available tokens > 0, which can lead to over-admission
+	// since deduction is deferred (see testdata/simulation/over_admission).
+	//
+	// A. One mitigation could be terminating grant forwarding if the
+	//    'tentatively deducted tokens' exceeds some amount (say, 16
+	//    MiB). When tokens are actually deducted, we'll reduce from
+	//    this 'tentatively deducted' count. We can re-signal() on every
+	//    actual token deduction where available tokens is still > 0.
+	// B. The pathological case with A is when all these tentatively
+	//    deducted tokens are due to requests that are waiting on
+	//    latches and locks. And the next request that wants to be
+	//    admitted is not contending with those latches/locks but gets
+	//    stuck behind it anyway. We could instead count the # of
+	//    requests that go through this bucket and are also past the
+	//    latch/lock acquisition but not yet evaluated, and block if
+	//    that count is greater than some small multiple of GOMAXPROCS.
+
 	signalCh chan struct{}
+	stats    struct {
+		deltaStats
+		noTokenStartTime time.Time
+	}
 }
 
-func newBucket(tokensPerWorkClass tokensPerWorkClass) *bucket {
-	b := bucket{
+type deltaStats struct {
+	noTokenDuration time.Duration
+	tokensDeducted  kvflowcontrol.Tokens
+}
+
+func makeBucketPerWorkClass(
+	wc admissionpb.WorkClass, tokens kvflowcontrol.Tokens, now time.Time,
+) bucketPerWorkClass {
+	bwc := bucketPerWorkClass{
+		wc:       wc,
+		tokens:   tokens,
 		signalCh: make(chan struct{}, 1),
 	}
-	b.mu.tokensPerWorkClass = tokensPerWorkClass
+	bwc.stats.noTokenStartTime = now
+	return bwc
+}
+
+func (bwc *bucketPerWorkClass) adjustTokensLocked(
+	ctx context.Context,
+	delta kvflowcontrol.Tokens,
+	limit kvflowcontrol.Tokens,
+	admin bool,
+	now time.Time,
+) (adjustment, unaccounted kvflowcontrol.Tokens) {
+	before := bwc.tokens
+	bwc.tokens += delta
+	if delta > 0 {
+		if bwc.tokens > limit {
+			unaccounted = bwc.tokens - limit
+			bwc.tokens = limit
+		}
+		if before <= 0 && bwc.tokens > 0 {
+			bwc.signal()
+			bwc.stats.noTokenDuration += now.Sub(bwc.stats.noTokenStartTime)
+		}
+	} else {
+		bwc.stats.deltaStats.tokensDeducted -= delta
+		if before > 0 && bwc.tokens <= 0 {
+			bwc.stats.noTokenStartTime = now
+		}
+	}
+	if buildutil.CrdbTestBuild && !admin && unaccounted != 0 {
+		log.Fatalf(ctx, "unaccounted[%s]=%d delta=%d limit=%d", bwc.wc, unaccounted, delta, limit)
+	}
+	adjustment = bwc.tokens - before
+	return adjustment, unaccounted
+}
+
+func (bwc *bucketPerWorkClass) signal() {
+	select {
+	case bwc.signalCh <- struct{}{}: // non-blocking channel write that ensures it's topped up to 1 entry
+	default:
+	}
+}
+
+type waitEndState int32
+
+const (
+	waitSuccess waitEndState = iota
+	contextCanceled
+	stopWaitSignaled
+)
+
+func (bwc *bucketPerWorkClass) wait(ctx context.Context, stopWaitCh <-chan struct{}) waitEndState {
+	select {
+	case <-bwc.signalCh:
+		return waitSuccess
+	case <-stopWaitCh:
+		return stopWaitSignaled
+	case <-ctx.Done():
+		return contextCanceled
+	}
+}
+
+func (bwc *bucketPerWorkClass) getAndResetStats(now time.Time) deltaStats {
+	stats := bwc.stats.deltaStats
+	if bwc.tokens <= 0 {
+		stats.noTokenDuration += now.Sub(bwc.stats.noTokenStartTime)
+	}
+	bwc.stats.deltaStats = deltaStats{}
+	// Doesn't matter if bwc.tokens is actually > 0 since in that case we won't
+	// use this value.
+	bwc.stats.noTokenStartTime = now
+	return stats
+}
+
+// bucket holds flow tokens for {regular,elastic} traffic over a
+// kvflowcontrol.Stream. It's used to synchronize handoff between threads
+// returning and waiting for flow tokens.
+type bucket struct {
+	mu struct {
+		syncutil.RWMutex
+		buckets [admissionpb.NumWorkClasses]bucketPerWorkClass
+	}
+}
+
+func newBucket(tokensPerWorkClass tokensPerWorkClass, now time.Time) *bucket {
+	b := bucket{}
+	b.mu.buckets[admissionpb.RegularWorkClass] = makeBucketPerWorkClass(
+		admissionpb.RegularWorkClass, tokensPerWorkClass.regular, now)
+	b.mu.buckets[admissionpb.ElasticWorkClass] = makeBucketPerWorkClass(
+		admissionpb.ElasticWorkClass, tokensPerWorkClass.elastic, now)
 	return &b
 }
 
@@ -393,28 +491,65 @@ func (b *bucket) tokens(wc admissionpb.WorkClass) kvflowcontrol.Tokens {
 }
 
 func (b *bucket) tokensLocked(wc admissionpb.WorkClass) kvflowcontrol.Tokens {
-	if wc == regular {
-		return b.mu.tokensPerWorkClass.regular
+	return b.mu.buckets[wc].tokens
+}
+
+// wait causes the caller that has work with work class wc to wait until
+// either tokens are available for work class wc, or the context is cancelled,
+// or stopWaitCh is signaled. The waitEndState return value indicates which
+// one of these terminated the wait. The waited bool is set to true only if
+// there was some waiting, since the common case is that there will be tokens
+// available and there will be no waiting.
+//
+// The implementation of wait uses the bucketPerWorkClass instance for the
+// work class wc. The only reason we don't encapsulate the logic inside the
+// bucketPerWorkClass struct is the shared mutex (bucket.mu). See the long
+// comment in the bucketPerWorkClass declaration describing the waiting and
+// signaling scheme.
+func (b *bucket) wait(
+	ctx context.Context, wc admissionpb.WorkClass, stopWaitCh <-chan struct{},
+) (state waitEndState, waited bool) {
+	waitedWithWaitSuccess := false
+	for {
+		b.mu.RLock()
+		tokens := b.tokensLocked(wc)
+		b.mu.RUnlock()
+		if tokens > 0 {
+			// No need to wait.
+			if waitedWithWaitSuccess {
+				// Waited in a previous iteration of the loop, so must have consumed
+				// the entry in the channel. Unblock another waiter.
+				b.mu.buckets[wc].signal()
+			}
+			return waitSuccess, waited
+		}
+		waited = true
+		state = b.mu.buckets[wc].wait(ctx, stopWaitCh)
+		if state != waitSuccess {
+			// We could have previously removed the entry in the channel, if in a
+			// previous iteration waitedWithWaitSuccess became true. But we don't
+			// need to add an entry here, since we've sampled the tokens after
+			// consuming that entry and still found tokens <= 0. So whoever
+			// transitions tokens to a value greater than 0 will add an entry.
+			return state, waited
+		} else {
+			waitedWithWaitSuccess = true
+			// Continue in the loop to see if tokens are now available (common
+			// case).
+		}
 	}
-	return b.mu.tokensPerWorkClass.elastic
 }
 
-func (b *bucket) signal() {
-	select {
-	case b.signalCh <- struct{}{}: // non-blocking channel write that ensures it's topped up to 1 entry
-	default:
-	}
-}
-
-func (b *bucket) wait() chan struct{} {
-	return b.signalCh
-}
-
+// admin is set to true when this method is called because of a settings
+// change. In that case the class is interpreted narrowly as only updating the
+// tokens for that class.
 func (b *bucket) adjust(
 	ctx context.Context,
 	class admissionpb.WorkClass,
 	delta kvflowcontrol.Tokens,
 	limit tokensPerWorkClass,
+	admin bool,
+	now time.Time,
 ) (adjustment, unaccounted tokensPerWorkClass) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
@@ -448,41 +583,40 @@ func (b *bucket) adjust(
 	//		}()
 	//	}
 
-	unaccounted = tokensPerWorkClass{}
-	before := b.mu.tokensPerWorkClass
-
 	switch class {
+	case regular:
+		adjustment.regular, unaccounted.regular =
+			b.mu.buckets[admissionpb.RegularWorkClass].adjustTokensLocked(
+				ctx, delta, limit.regular, admin, now)
+		if !admin {
+			// Regular {deductions,returns} also affect elastic flow tokens.
+			adjustment.elastic, unaccounted.elastic =
+				b.mu.buckets[admissionpb.ElasticWorkClass].adjustTokensLocked(
+					ctx, delta, limit.elastic, admin, now)
+		}
 	case elastic:
 		// Elastic {deductions,returns} only affect elastic flow tokens.
-		b.mu.tokensPerWorkClass.elastic += delta
-		if delta > 0 && b.mu.tokensPerWorkClass.elastic > limit.elastic {
-			unaccounted.elastic = b.mu.tokensPerWorkClass.elastic - limit.elastic
-			b.mu.tokensPerWorkClass.elastic = limit.elastic // enforce ceiling
-		}
-	case regular:
-		b.mu.tokensPerWorkClass.regular += delta
-		if delta > 0 && b.mu.tokensPerWorkClass.regular > limit.regular {
-			unaccounted.regular = b.mu.tokensPerWorkClass.regular - limit.regular
-			b.mu.tokensPerWorkClass.regular = limit.regular // enforce ceiling
-		}
-
-		b.mu.tokensPerWorkClass.elastic += delta
-		if delta > 0 && b.mu.tokensPerWorkClass.elastic > limit.elastic {
-			unaccounted.elastic = b.mu.tokensPerWorkClass.elastic - limit.elastic
-			b.mu.tokensPerWorkClass.elastic = limit.elastic // enforce ceiling
-		}
-	}
-
-	if buildutil.CrdbTestBuild && (unaccounted.regular != 0 || unaccounted.elastic != 0) {
-		log.Fatalf(ctx, "unaccounted[regular]=%s unaccounted[elastic]=%s for class=%s delta=%s limit[regular]=%s limit[elastic]=%s",
-			unaccounted.regular, unaccounted.elastic, class, delta, limit.regular, limit.elastic)
-	}
-
-	adjustment = tokensPerWorkClass{
-		regular: b.mu.tokensPerWorkClass.regular - before.regular,
-		elastic: b.mu.tokensPerWorkClass.elastic - before.elastic,
+		adjustment.elastic, unaccounted.elastic =
+			b.mu.buckets[admissionpb.ElasticWorkClass].adjustTokensLocked(
+				ctx, delta, limit.elastic, admin, now)
 	}
 	return adjustment, unaccounted
+}
+
+func (b *bucket) getAndResetStats(now time.Time) (regularStats, elasticStats deltaStats) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	regularStats = b.mu.buckets[admissionpb.RegularWorkClass].getAndResetStats(now)
+	elasticStats = b.mu.buckets[admissionpb.ElasticWorkClass].getAndResetStats(now)
+	return regularStats, elasticStats
+}
+
+func (b *bucket) testingGetChannel(wc admissionpb.WorkClass) <-chan struct{} {
+	return b.mu.buckets[wc].signalCh
+}
+
+func (b *bucket) testingSignalChannel(wc admissionpb.WorkClass) {
+	b.mu.buckets[wc].signal()
 }
 
 type tokensPerWorkClass struct {
@@ -552,13 +686,13 @@ func (c *Controller) TestingNonBlockingAdmit(
 		}
 
 		b := c.getBucket(connection.Stream())
-
 		tokens := b.tokens(class)
 		if tokens <= 0 {
 			return false
 		}
-
-		b.signal() // signal a waiter, if any
+		// Signal a waiter, if any, since we may have removed an entry from the
+		// channel via testingSignaled.
+		b.testingSignalChannel(class)
 		c.metrics.onAdmitted(class, c.clock.PhysicalTime().Sub(tstart))
 		return true
 	}
@@ -568,7 +702,7 @@ func (c *Controller) TestingNonBlockingAdmit(
 	}
 
 	b := c.testingGetBucket(connection.Stream())
-	return false, b.testingSignaled(connection), admit
+	return false, b.testingSignaled(connection, class), admit
 }
 
 // TestingAdjustTokens exports adjustTokens for testing purposes.
@@ -590,12 +724,14 @@ func (c *Controller) testingGetBucket(stream kvflowcontrol.Stream) *bucket {
 	return c.getBucket(stream)
 }
 
-func (b *bucket) testingSignaled(connection kvflowcontrol.ConnectedStream) func() bool {
+func (b *bucket) testingSignaled(
+	connection kvflowcontrol.ConnectedStream, wc admissionpb.WorkClass,
+) func() bool {
 	return func() bool {
 		select {
 		case <-connection.Disconnected():
 			return true
-		case <-b.wait(): // check if signaled
+		case <-b.testingGetChannel(wc): // check if signaled
 			return true
 		default:
 			return false

--- a/pkg/kv/kvserver/kvflowcontrol/kvflowcontroller/kvflowcontroller_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/kvflowcontroller/kvflowcontroller_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/datadriven"
 	"github.com/dustin/go-humanize"
 	"github.com/stretchr/testify/require"
@@ -159,6 +160,140 @@ func (h adjustment) String() string {
 	)
 }
 
+func TestBucket(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	clock := timeutil.NewManualTime(timeutil.Unix(10, 0))
+	limit := tokensPerWorkClass{
+		regular: 10,
+		elastic: 5,
+	}
+	b := newBucket(limit, clock.Now())
+	stopWaitCh := make(chan struct{}, 1)
+	// No waiting for regular work.
+	state, waited := b.wait(ctx, admissionpb.RegularWorkClass, stopWaitCh)
+	require.Equal(t, waitSuccess, state)
+	require.False(t, waited)
+	// No waiting for elastic work.
+	state, waited = b.wait(ctx, admissionpb.ElasticWorkClass, stopWaitCh)
+	require.Equal(t, waitSuccess, state)
+	require.False(t, waited)
+
+	clock.Advance(10 * time.Second)
+	// regular: 4 tokens, elastic -1 tokens.
+	adj, unaccounted := b.adjust(
+		ctx, admissionpb.RegularWorkClass, -6, limit, false, clock.Now())
+	require.Equal(t, tokensPerWorkClass{
+		regular: -6,
+		elastic: -6,
+	}, adj)
+	require.Equal(t, tokensPerWorkClass{}, unaccounted)
+	// stopWaitCh has entry.
+	stopWaitCh <- struct{}{}
+	// No waiting for regular work.
+	state, waited = b.wait(ctx, admissionpb.RegularWorkClass, stopWaitCh)
+	require.Equal(t, waitSuccess, state)
+	require.False(t, waited)
+	// Elastic work returns since stopWaitCh has entry.
+	state, waited = b.wait(ctx, admissionpb.ElasticWorkClass, stopWaitCh)
+	require.Equal(t, stopWaitSignaled, state)
+	require.True(t, waited)
+
+	canceledCtx, cancelFunc := context.WithCancel(ctx)
+	cancelFunc()
+	// No waiting for regular work.
+	state, waited = b.wait(canceledCtx, admissionpb.RegularWorkClass, stopWaitCh)
+	require.Equal(t, waitSuccess, state)
+	require.False(t, waited)
+	// Elastic work returns since context is canceled.
+	state, waited = b.wait(canceledCtx, admissionpb.ElasticWorkClass, stopWaitCh)
+	require.Equal(t, contextCanceled, state)
+	require.True(t, waited)
+
+	clock.Advance(10 * time.Second)
+	// regular: 0 tokens, elastic -5 tokens.
+	adj, unaccounted = b.adjust(
+		ctx, admissionpb.RegularWorkClass, -4, limit, false, clock.Now())
+	require.Equal(t, tokensPerWorkClass{
+		regular: -4,
+		elastic: -4,
+	}, adj)
+	require.Equal(t, tokensPerWorkClass{}, unaccounted)
+	require.Equal(t, kvflowcontrol.Tokens(0), b.tokens(admissionpb.RegularWorkClass))
+	require.Equal(t, kvflowcontrol.Tokens(-5), b.tokens(admissionpb.ElasticWorkClass))
+
+	// Regular work waits. Have two waiting work requests to test the signal
+	// chaining.
+	workAdmitted := make(chan struct{}, 2)
+	go func() {
+		state, waited := b.wait(ctx, admissionpb.RegularWorkClass, stopWaitCh)
+		require.Equal(t, waitSuccess, state)
+		require.True(t, waited)
+		workAdmitted <- struct{}{}
+	}()
+	go func() {
+		state, waited := b.wait(ctx, admissionpb.RegularWorkClass, stopWaitCh)
+		require.Equal(t, waitSuccess, state)
+		require.True(t, waited)
+		workAdmitted <- struct{}{}
+	}()
+	// Sleep until they have started waiting.
+	time.Sleep(time.Second)
+	select {
+	case <-workAdmitted:
+		log.Fatalf(ctx, "should not be admitted")
+	default:
+	}
+	clock.Advance(10 * time.Second)
+	adj, unaccounted = b.adjust(
+		ctx, admissionpb.RegularWorkClass, +10, limit, false, clock.Now())
+	require.Equal(t, tokensPerWorkClass{
+		regular: 10,
+		elastic: 10,
+	}, adj)
+	require.Equal(t, tokensPerWorkClass{}, unaccounted)
+	// Sleep until they have stopped waiting.
+	time.Sleep(time.Second)
+	select {
+	case <-workAdmitted:
+	default:
+		log.Fatalf(ctx, "should be admitted")
+	}
+	select {
+	case <-workAdmitted:
+	default:
+		log.Fatalf(ctx, "should be admitted")
+	}
+
+	// Deduct 2 from elastic tokens
+	adj, unaccounted = b.adjust(
+		ctx, admissionpb.ElasticWorkClass, -2, limit, false, clock.Now())
+	require.Equal(t, tokensPerWorkClass{
+		regular: 0,
+		elastic: -2,
+	}, adj)
+	require.Equal(t, tokensPerWorkClass{}, unaccounted)
+
+	regularStats, elasticStats := b.getAndResetStats(clock.Now())
+	require.Equal(t, deltaStats{
+		noTokenDuration: 10 * time.Second,
+		tokensDeducted:  10,
+	}, regularStats)
+	require.Equal(t, deltaStats{
+		noTokenDuration: 20 * time.Second,
+		tokensDeducted:  12,
+	}, elasticStats)
+}
+
+// TestBucketSignalingBug triggers a bug in the code prior to
+// https://github.com/cockroachdb/cockroach/pull/111088. The bug was due to
+// using a shared `signalCh chan struct{}` inside the bucket struct for both
+// the work classes. This could result in a situation where an elastic request
+// consumed the entry in the channel that was added when the regular tokens
+// became greater than zero. This would prevent a waiting regular request from
+// getting unblocked.
 func TestBucketSignalingBug(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)


### PR DESCRIPTION
The signaling logic had a bug, which is demonstrated by
TestBucketSignalingBug: if an elastic waiter consumed the entry in
signalCh, a regular waiter would not get unblocked if regular tokens
became positive.

Per-stream stats are added for the duration when there were no tokens,
and the tokens deducted. These are reset every time the stats are
logged, so the caller can easily interpret the log entries as the
delta since the previous log entry. It will give us visibility into
per stream behavior at a 30s granularity.

The code abstractions are re-worked. More of the logic is abstracted
inside `bucket` and `bucketPerWorkClass` instead of exposing internals
to `Controller`.

Epic: none

Release note: None