### PR TITLE
lease: address warnings about implicit usage of some methods

### DIFF
--- a/pkg/sql/catalog/lease/lease_test.go
+++ b/pkg/sql/catalog/lease/lease_test.go
@@ -98,12 +98,13 @@ func init() {
 
 func newLeaseTest(tb testing.TB, params base.TestClusterArgs) *leaseTest {
 	c := serverutils.StartCluster(tb, 3, params)
+	s := c.Server(0).ApplicationLayer()
 	lt := &leaseTest{
 		TB:      tb,
 		cluster: c,
-		server:  c.Server(0).ApplicationLayer(),
-		db:      c.ServerConn(0),
-		kvDB:    c.Server(0).DB(),
+		server:  s,
+		db:      s.SQLConn(tb, ""),
+		kvDB:    s.DB(),
 		nodes:   map[uint32]*lease.Manager{},
 	}
 


### PR DESCRIPTION
Epic: None

Release note: None