### PR TITLE
roachprod: enhance/clarify terminology

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -2306,9 +2306,9 @@ func (c *clusterImpl) pgURLErr(
 	ctx context.Context, l *logger.Logger, node option.NodeListOption, external bool, tenant string,
 ) ([]string, error) {
 	urls, err := roachprod.PgURL(ctx, l, c.MakeNodes(node), c.localCertsDir, roachprod.PGURLOptions{
-		External:   external,
-		Secure:     c.localCertsDir != "",
-		TenantName: tenant})
+		External:           external,
+		Secure:             c.localCertsDir != "",
+		VirtualClusterName: tenant})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -421,7 +421,7 @@ func (c *SyncedCluster) Signal(ctx context.Context, l *logger.Logger, sig int) e
 // cmdName and display specify the roachprod subcommand and a status message,
 // for output/logging. If wait is true, the command will wait for the processes
 // to exit, up to maxWait seconds.
-// TODO(herko): This command does not support tenants yet.
+// TODO(herko): This command does not support virtual clusters yet.
 func (c *SyncedCluster) kill(
 	ctx context.Context, l *logger.Logger, cmdName, display string, sig int, wait bool, maxWait int,
 ) error {
@@ -1998,7 +1998,7 @@ func (c *SyncedCluster) Put(
 // <user> allows retrieval of logs from a roachprod cluster being run by another
 // user and assumes that the current user used to create c has the ability to
 // sudo into <user>.
-// TODO(herko): This command does not support tenants yet.
+// TODO(herko): This command does not support virtual clusters yet.
 func (c *SyncedCluster) Logs(
 	l *logger.Logger,
 	src, dest, user, filter, programFilter string,
@@ -2358,7 +2358,7 @@ func (c *SyncedCluster) Get(
 
 // pgurls returns a map of PG URLs for the given nodes.
 func (c *SyncedCluster) pgurls(
-	ctx context.Context, l *logger.Logger, nodes Nodes, tenantName string, tenantInstance int,
+	ctx context.Context, l *logger.Logger, nodes Nodes, virtualClusterName string, sqlInstance int,
 ) (map[Node]string, error) {
 	hosts, err := c.pghosts(ctx, l, nodes)
 	if err != nil {
@@ -2366,15 +2366,15 @@ func (c *SyncedCluster) pgurls(
 	}
 	m := make(map[Node]string, len(hosts))
 	for node, host := range hosts {
-		desc, err := c.DiscoverService(ctx, node, tenantName, ServiceTypeSQL, tenantInstance)
+		desc, err := c.DiscoverService(ctx, node, virtualClusterName, ServiceTypeSQL, sqlInstance)
 		if err != nil {
 			return nil, err
 		}
-		sharedTenantName := ""
+		sharedClusterName := ""
 		if desc.ServiceMode == ServiceModeShared {
-			sharedTenantName = tenantName
+			sharedClusterName = virtualClusterName
 		}
-		m[node] = c.NodeURL(host, desc.Port, sharedTenantName)
+		m[node] = c.NodeURL(host, desc.Port, sharedClusterName)
 	}
 	return m, nil
 }

--- a/pkg/roachprod/install/services_test.go
+++ b/pkg/roachprod/install/services_test.go
@@ -89,8 +89,8 @@ func TestStringToIntegers(t *testing.T) {
 func TestServiceNameComponents(t *testing.T) {
 	z := local.NewDNSProvider(t.TempDir(), "z1")
 	dnsName := serviceDNSName(z, "tenant-100", ServiceTypeSQL, "test-cluster")
-	tenantName, serviceType, err := serviceNameComponents(dnsName)
+	virtualClusterName, serviceType, err := serviceNameComponents(dnsName)
 	require.NoError(t, err)
-	require.Equal(t, "tenant-100", tenantName)
+	require.Equal(t, "tenant-100", virtualClusterName)
 	require.Equal(t, ServiceTypeSQL, serviceType)
 }

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -662,7 +662,7 @@ func DefaultStartOpts() install.StartOpts {
 		NumFilesLimit:      config.DefaultNumFilesLimit,
 		SkipInit:           false,
 		StoreCount:         1,
-		TenantID:           2,
+		VirtualClusterID:   2,
 		ScheduleBackups:    false,
 		ScheduleBackupArgs: "",
 		InitTarget:         1,
@@ -892,10 +892,10 @@ func Get(ctx context.Context, l *logger.Logger, clusterName, src, dest string) e
 }
 
 type PGURLOptions struct {
-	Secure         bool
-	External       bool
-	TenantName     string
-	TenantInstance int
+	Secure             bool
+	External           bool
+	VirtualClusterName string
+	SQLInstance        int
 }
 
 // PgURL generates pgurls for the nodes in a cluster.
@@ -927,14 +927,14 @@ func PgURL(
 
 	var urls []string
 	for i, ip := range ips {
-		desc, err := c.DiscoverService(ctx, nodes[i], opts.TenantName, install.ServiceTypeSQL, opts.TenantInstance)
+		desc, err := c.DiscoverService(ctx, nodes[i], opts.VirtualClusterName, install.ServiceTypeSQL, opts.SQLInstance)
 		if err != nil {
 			return nil, err
 		}
 		if ip == "" {
 			return nil, errors.Errorf("empty ip: %v", ips)
 		}
-		urls = append(urls, c.NodeURL(ip, desc.Port, opts.TenantName))
+		urls = append(urls, c.NodeURL(ip, desc.Port, opts.VirtualClusterName))
 	}
 	if len(urls) != len(nodes) {
 		return nil, errors.Errorf("have nodes %v, but urls %v from ips %v", nodes, urls, ips)


### PR DESCRIPTION
Fixes #111103.
Epic: CRDB-29380

We want to distinguish the concepts for "tenant", "virtual cluster", "SQL/HTTP instance" through the team. For this it is useful when the tools and their source code also reflect these concepts.

This commit achieves that.

Release note: None
