### PR TITLE
dbconsole: add tooltop to replication dash ranges chart

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/replication.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/replication.tsx
@@ -42,6 +42,9 @@ export default function (props: GraphDashboardProps) {
       title="Ranges"
       sources={storeSources}
       tenantSource={tenantSource}
+      tooltip={`Various details about the status of ranges. In the node view,
+        shows details about ranges the node is responsible for. In the cluster
+        view, shows details about ranges all across the cluster.`}
     >
       <Axis label="ranges">
         <Metric name="cr.store.ranges" title="Ranges" />


### PR DESCRIPTION
The Ranges chart in the replication dashboard can be easily misinterpreted when in a single node view, because the per-node metric is only reported by one node for each range. Most commonly, this is the leaseholder, and if not, the first replica in the range descriptor.

Add a tooltip which explains this nuance, taken from the [documentation](https://www.cockroachlabs.com/docs/stable/ui-replication-dashboard#ranges).

![image](https://github.com/cockroachdb/cockroach/assets/39606633/c2bcecd2-d8ed-46ec-b6f3-61927ecdce45)


Epic: None
Resolves: #111055

Release note (ui change): Added a tooltip to the ranges chart on the replication dashboard, describing the metric in single vs cluster view.