### PR TITLE
ui: fix statement diagnostics page on max size error

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/statementDiagnosticsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/statementDiagnosticsApi.ts
@@ -11,10 +11,12 @@
 import moment from "moment-timezone";
 import { Duration } from "src/util/format";
 import {
+  createSqlExecutionRequest,
   executeInternalSql,
-  LARGE_RESULT_SIZE,
+  executeInternalSqlHelper,
   SqlExecutionRequest,
-  sqlResultsAreEmpty,
+  SqlTxnResult,
+  txnResultSetIsEmpty,
 } from "src/api";
 
 export type StatementDiagnosticsReport = {
@@ -29,11 +31,20 @@ export type StatementDiagnosticsReport = {
 
 export type StatementDiagnosticsResponse = StatementDiagnosticsReport[];
 
-export function getStatementDiagnosticsReports(): Promise<StatementDiagnosticsResponse> {
-  const req: SqlExecutionRequest = {
-    statements: [
-      {
-        sql: `SELECT
+export async function getStatementDiagnosticsReports(): Promise<StatementDiagnosticsResponse> {
+  let result: StatementDiagnosticsResponse = [];
+
+  const createReq = () => {
+    let offset = "";
+    const args = [];
+    if (result.length > 0) {
+      // Using the id is more performant and reliable than offset.
+      // Schema is PRIMARY KEY (id) with INT8 DEFAULT unique_rowid() NOT NULL.
+      offset = " AND (id::STRING < $1) ";
+      const last = result[result.length - 1];
+      args.push(last.id);
+    }
+    const query = `SELECT
       id::STRING,
       statement_fingerprint,
       completed,
@@ -42,27 +53,43 @@ export function getStatementDiagnosticsReports(): Promise<StatementDiagnosticsRe
       min_execution_latency,
       expires_at
     FROM
-      system.statement_diagnostics_requests
+      system.statement_diagnostics_requests 
     WHERE
-      expires_at > now() OR expires_at IS NULL OR completed = true`,
+     (expires_at > now() OR expires_at IS NULL OR completed = true) ${offset}
+     order by id desc`;
+
+    return createSqlExecutionRequest(undefined, [
+      {
+        sql: query,
+        arguments: args,
       },
-    ],
-    execute: true,
-    max_result_size: LARGE_RESULT_SIZE,
+    ]);
   };
 
-  return executeInternalSql<StatementDiagnosticsReport>(req).then(res => {
-    // If request succeeded but query failed, throw error (caught by saga/cacheDataReducer).
-    if (res.error) {
-      throw res.error;
-    }
+  const err = await executeInternalSqlHelper<StatementDiagnosticsReport>(
+    createReq,
+    (response: SqlTxnResult<StatementDiagnosticsReport>[]) => {
+      if (!response) {
+        return;
+      }
 
-    if (sqlResultsAreEmpty(res)) {
-      return [];
-    }
+      if (txnResultSetIsEmpty(response)) {
+        return;
+      }
 
-    return res.execution.txn_results[0].rows;
-  });
+      response.forEach(x => {
+        if (x.rows && x.rows.length > 0) {
+          result = result.concat(x.rows);
+        }
+      });
+    },
+  );
+
+  if (err) {
+    throw err;
+  }
+
+  return result;
 }
 
 type CheckPendingStmtDiagnosticRow = {
@@ -138,9 +165,9 @@ function checkExistingDiagRequest(stmtFingerprint: string): Promise<void> {
   const checkPendingStmtDiag = {
     sql: `SELECT count(1) FROM system.statement_diagnostics_requests
         WHERE
-          completed = false AND
-          statement_fingerprint = $1 AND
-          (expires_at IS NULL OR expires_at > now())`,
+        completed = false AND
+        statement_fingerprint = $1 AND
+      (expires_at IS NULL OR expires_at > now())`,
     arguments: [stmtFingerprint],
   };
 


### PR DESCRIPTION
Problem:
The SQL API has a maximum size of 50KB. The statement diagnostics page can easily hit this limit with large queries and/or large number of statement diagnostics. The page would fail to load and show no results.

Fix:
Add a new method to the SQL API to keep pulling results until no more max size errors are returned.

Fixes: #108403

https://www.loom.com/share/8c88e44e03044eda8df06e23a3bc501a?sid=adc82737-1568-483d-bf48-6509779713e5

Release note (ui change): Fixes the statement diagnostics page when the response hit a max size error.