### PR TITLE
roachprod: fix symlink detection

### DIFF
--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -1734,15 +1734,24 @@ func (c *SyncedCluster) Put(
 	if potentialSymlinkPath, err = filepath.EvalSymlinks(src); err != nil {
 		return err
 	}
+
+	absSrc, err := filepath.Abs(src)
+	if err != nil {
+		return fmt.Errorf("error computing absolute path for %s: %w", src, err)
+	}
+	absSymlink, err := filepath.Abs(potentialSymlinkPath)
+	if err != nil {
+		return fmt.Errorf("error computing absolute path for %s: %w", potentialSymlinkPath, err)
+	}
 	// Different paths imply it is a symlink.
-	if potentialSymlinkPath != src {
+	if absSrc != absSymlink {
 		// Get target symlink access mode.
 		var symlinkTargetInfo fs.FileInfo
 		if symlinkTargetInfo, err = os.Stat(potentialSymlinkPath); err != nil {
 			return err
 		}
 		redColor, resetColor := "\033[31m", "\033[0m"
-		l.Printf(redColor + "WARNING: Source file is a symlink." + resetColor)
+		l.Printf(redColor+"WARNING: Source file is a symlink to %s"+resetColor, absSymlink)
 		l.Printf(redColor+"WARNING: Remote file will inherit the target permissions '%v'."+resetColor, symlinkTargetInfo.Mode())
 	}
 


### PR DESCRIPTION
Previously, roachprod `put` would complain about symlinks if `EvalSymlinks(src) != src`. However, that is not always a reliable way to determine if a file is a symbolic link. The documentation for `EvalSymlinks` states:

> If path is relative the result will be relative to the current
> directory.

Therefore, the condition mentioned above is not accurate. In particular, if one ran the command `roachprod put ./cockroach`, the symlink warning would always be displayed: `EvalSymlinks` would return `cockroach` (`./` prefix removed) and the paths would differ.

This commit updates that logic to check for absolute paths instead. If the absolute paths differ, we get the symlink warning, and the warning message now also includes the path to the file that the symlink resolves to.

Epic: none

Release note: None