### PR TITLE
settings: move the 'modified' map to valueContainer

### DIFF
--- a/pkg/settings/settings_test.go
+++ b/pkg/settings/settings_test.go
@@ -574,23 +574,19 @@ func TestCache(t *testing.T) {
 		if expected, actual := true, boolFA.Get(sv); expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
-		// If the updater doesn't have a key, e.g. if the setting has been deleted,
-		// Resetting it from the cache.
+		// The updated status remains in sv. A new updater is able to pick
+		// it up.
 		settings.NewUpdater(sv).ResetRemaining(ctx)
 
-		if expected, actual := 2, changes.boolTA; expected != actual {
+		if expected, actual := 1, changes.boolTA; expected != actual {
 			t.Fatalf("expected %d, got %d", expected, actual)
 		}
 
-		if expected, actual := 2, changes.i1A; expected != actual {
+		if expected, actual := 1, changes.i1A; expected != actual {
 			t.Fatalf("expected %d, got %d", expected, actual)
 		}
 
-		if expected, actual := false, boolFA.Get(sv); expected != actual {
-			t.Fatalf("expected %v, got %v", expected, actual)
-		}
-
-		if expected, actual := false, boolFA.Get(sv); expected != actual {
+		if expected, actual := true, boolFA.Get(sv); expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
 	})

--- a/pkg/settings/values.go
+++ b/pkg/settings/values.go
@@ -87,6 +87,11 @@ type valuesContainer struct {
 	forbidden [numSlots]bool
 
 	hasValue [numSlots]uint32
+
+	// modified is set when a setting is explictly set via Set()
+	// in the updater.
+	// TODO(knz): Check if this can be merged with hasValue above.
+	modified [numSlots]bool
 }
 
 func (c *valuesContainer) setGenericVal(slot slotIdx, newVal interface{}) {


### PR DESCRIPTION
Previous in sequence:
- [x] #110789 and #110947 
- [x] #110676
- [x] #111008

Needed for #110758
Epic: CRDB-6671

In a later commit, we will want to ensure that `.Override()` sets the modified bit. This is not possible if the modified bits are in the Updater. (The `Override` method is on the setting itself and has no access to the updater.)

Release note: None