### PR TITLE
settings,settingswatcher: simplify interfaces

### DIFF
--- a/pkg/server/settingswatcher/BUILD.bazel
+++ b/pkg/server/settingswatcher/BUILD.bazel
@@ -35,7 +35,6 @@ go_library(
         "//pkg/util/stop",
         "//pkg/util/syncutil",
         "@com_github_cockroachdb_errors//:errors",
-        "@com_github_cockroachdb_redact//:redact",
     ],
 )
 

--- a/pkg/settings/settings_test.go
+++ b/pkg/settings/settings_test.go
@@ -574,23 +574,19 @@ func TestCache(t *testing.T) {
 		if expected, actual := true, boolFA.Get(sv); expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
-		// If the updater doesn't have a key, e.g. if the setting has been deleted,
-		// Resetting it from the cache.
+		// The updated status remains in sv. A new updater is able to pick
+		// it up.
 		settings.NewUpdater(sv).ResetRemaining(ctx)
 
-		if expected, actual := 2, changes.boolTA; expected != actual {
+		if expected, actual := 1, changes.boolTA; expected != actual {
 			t.Fatalf("expected %d, got %d", expected, actual)
 		}
 
-		if expected, actual := 2, changes.i1A; expected != actual {
+		if expected, actual := 1, changes.i1A; expected != actual {
 			t.Fatalf("expected %d, got %d", expected, actual)
 		}
 
-		if expected, actual := false, boolFA.Get(sv); expected != actual {
-			t.Fatalf("expected %v, got %v", expected, actual)
-		}
-
-		if expected, actual := false, boolFA.Get(sv); expected != actual {
+		if expected, actual := true, boolFA.Get(sv); expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
 	})

--- a/pkg/settings/updater.go
+++ b/pkg/settings/updater.go
@@ -69,9 +69,19 @@ type updater struct {
 // wrapped atomic settings values as we go and note which settings were updated,
 // then set the rest to default in ResetRemaining().
 type Updater interface {
+	// Set is used by tests to configure overrides in a generic fashion.
 	Set(ctx context.Context, key InternalKey, value EncodedValue) error
+	// SetToDefault resets the setting to its default value.
+	SetToDefault(ctx context.Context, key InternalKey) error
+
+	// ResetRemaining loads the default values for all settings that
+	// were not updated by Set().
 	ResetRemaining(ctx context.Context)
-	SetValueOrigin(ctx context.Context, key InternalKey, origin ValueOrigin)
+
+	// SetFromStorage is called by the settings watcher to update the
+	// settings from either the rangefeed over system.settings, or
+	// overrides coming in over the network from the system tenant.
+	SetFromStorage(ctx context.Context, key InternalKey, value EncodedValue, origin ValueOrigin) error
 }
 
 // A NoopUpdater ignores all updates.
@@ -83,7 +93,15 @@ func (u NoopUpdater) Set(ctx context.Context, key InternalKey, value EncodedValu
 // ResetRemaining implements Updater. It is a no-op.
 func (u NoopUpdater) ResetRemaining(context.Context) {}
 
-func (u NoopUpdater) SetValueOrigin(ctx context.Context, key InternalKey, origin ValueOrigin) {}
+// SetToDefault implements Updater. It is a no-op.
+func (u NoopUpdater) SetToDefault(ctx context.Context, key InternalKey) error { return nil }
+
+// SetFromStorage implements Updater. It is a no-op.
+func (u NoopUpdater) SetFromStorage(
+	ctx context.Context, key InternalKey, value EncodedValue, origin ValueOrigin,
+) error {
+	return nil
+}
 
 // NewUpdater makes an Updater.
 func NewUpdater(sv *Values) Updater {
@@ -95,8 +113,102 @@ func NewUpdater(sv *Values) Updater {
 	}
 }
 
+// getSetting determines whether the target setting can
+// be set or overridden.
+func (u updater) getSetting(key InternalKey, value EncodedValue) (internalSetting, error) {
+	d, ok := registry[key]
+	if !ok {
+		if _, ok := retiredSettings[key]; ok {
+			return nil, nil
+		}
+		// Likely a new setting this old node doesn't know about.
+		return nil, errors.Errorf("unknown setting '%s'", key)
+	}
+	if expected := d.Typ(); value.Type != expected {
+		return nil, errors.Errorf("setting '%s' defined as type %s, not %s", d.Name(), expected, value.Type)
+	}
+	return d, nil
+}
+
 // Set attempts to parse and update a setting and notes that it was updated.
 func (u updater) Set(ctx context.Context, key InternalKey, value EncodedValue) error {
+	d, err := u.getSetting(key, value)
+	if err != nil || d == nil {
+		return err
+	}
+
+	return u.setInternal(ctx, key, value, d, OriginExplicitlySet)
+}
+
+func (u updater) setInternal(
+	ctx context.Context, key InternalKey, value EncodedValue, d internalSetting, origin ValueOrigin,
+) error {
+	// Mark the setting as modified, such that
+	// (updater).ResetRemaining() does not touch it.
+	u.sv.container.modified[d.getSlot()] = true
+	u.sv.setValueOrigin(ctx, d.getSlot(), origin)
+
+	switch setting := d.(type) {
+	case *StringSetting:
+		return setting.set(ctx, u.sv, value.Value)
+
+	case *ProtobufSetting:
+		p, err := setting.DecodeValue(value.Value)
+		if err != nil {
+			return err
+		}
+		return setting.set(ctx, u.sv, p)
+
+	case *BoolSetting:
+		b, err := setting.DecodeValue(value.Value)
+		if err != nil {
+			return err
+		}
+		setting.set(ctx, u.sv, b)
+		return nil
+
+	case numericSetting:
+		i, err := setting.DecodeValue(value.Value)
+		if err != nil {
+			return err
+		}
+		return setting.set(ctx, u.sv, i)
+
+	case *FloatSetting:
+		f, err := setting.DecodeValue(value.Value)
+		if err != nil {
+			return err
+		}
+		return setting.set(ctx, u.sv, f)
+
+	case *DurationSetting:
+		d, err := setting.DecodeValue(value.Value)
+		if err != nil {
+			return err
+		}
+		return setting.set(ctx, u.sv, d)
+
+	case *DurationSettingWithExplicitUnit:
+		d, err := setting.DecodeValue(value.Value)
+		if err != nil {
+			return err
+		}
+		return setting.set(ctx, u.sv, d)
+
+	case *VersionSetting:
+		// We intentionally avoid updating the setting through this code path.
+		// The specific setting backed by VersionSetting is the cluster version
+		// setting, changes to which are propagated through direct RPCs to each
+		// node in the cluster instead of gossip. This is done using the
+		// BumpClusterVersion RPC.
+		return nil
+
+	default:
+		return errors.AssertionFailedf("unhandled type: %T", d)
+	}
+}
+
+func (u updater) SetToDefault(ctx context.Context, key InternalKey) error {
 	d, ok := registry[key]
 	if !ok {
 		if _, ok := retiredSettings[key]; ok {
@@ -106,60 +218,9 @@ func (u updater) Set(ctx context.Context, key InternalKey, value EncodedValue) e
 		return errors.Errorf("unknown setting '%s'", key)
 	}
 
-	u.sv.container.modified[d.getSlot()] = true
-
-	if expected := d.Typ(); value.Type != expected {
-		return errors.Errorf("setting '%s' defined as type %s, not %s", d.Name(), expected, value.Type)
-	}
-
-	switch setting := d.(type) {
-	case *StringSetting:
-		return setting.set(ctx, u.sv, value.Value)
-	case *ProtobufSetting:
-		p, err := setting.DecodeValue(value.Value)
-		if err != nil {
-			return err
-		}
-		return setting.set(ctx, u.sv, p)
-	case *BoolSetting:
-		b, err := setting.DecodeValue(value.Value)
-		if err != nil {
-			return err
-		}
-		setting.set(ctx, u.sv, b)
-		return nil
-	case numericSetting:
-		i, err := setting.DecodeValue(value.Value)
-		if err != nil {
-			return err
-		}
-		return setting.set(ctx, u.sv, i)
-	case *FloatSetting:
-		f, err := setting.DecodeValue(value.Value)
-		if err != nil {
-			return err
-		}
-		return setting.set(ctx, u.sv, f)
-	case *DurationSetting:
-		d, err := setting.DecodeValue(value.Value)
-		if err != nil {
-			return err
-		}
-		return setting.set(ctx, u.sv, d)
-	case *DurationSettingWithExplicitUnit:
-		d, err := setting.DecodeValue(value.Value)
-		if err != nil {
-			return err
-		}
-		return setting.set(ctx, u.sv, d)
-	case *VersionSetting:
-		// We intentionally avoid updating the setting through this code path.
-		// The specific setting backed by VersionSetting is the cluster version
-		// setting, changes to which are propagated through direct RPCs to each
-		// node in the cluster instead of gossip. This is done using the
-		// BumpClusterVersion RPC.
-		return nil
-	}
+	u.sv.container.modified[d.getSlot()] = false
+	u.sv.setValueOrigin(ctx, d.getSlot(), OriginDefault)
+	d.setToDefault(ctx, u.sv)
 	return nil
 }
 
@@ -183,10 +244,14 @@ func (u updater) ResetRemaining(ctx context.Context) {
 	}
 }
 
-// SetValueOrigin sets the origin of the value of a given setting.
-func (u updater) SetValueOrigin(ctx context.Context, key InternalKey, origin ValueOrigin) {
-	d, ok := registry[key]
-	if ok {
-		u.sv.setValueOrigin(ctx, d.getSlot(), origin)
+// SetFromStorage loads the stored value into the setting.
+func (u updater) SetFromStorage(
+	ctx context.Context, key InternalKey, value EncodedValue, origin ValueOrigin,
+) error {
+	d, err := u.getSetting(key, value)
+	if err != nil || d == nil {
+		return err
 	}
+
+	return u.setInternal(ctx, key, value, d, origin)
 }

--- a/pkg/settings/values.go
+++ b/pkg/settings/values.go
@@ -87,6 +87,11 @@ type valuesContainer struct {
 	forbidden [numSlots]bool
 
 	hasValue [numSlots]uint32
+
+	// modified is set when a setting is explictly set via Set()
+	// in the updater.
+	// TODO(knz): Check if this can be merged with hasValue above.
+	modified [numSlots]bool
 }
 
 func (c *valuesContainer) setGenericVal(slot slotIdx, newVal interface{}) {


### PR DESCRIPTION
Previous in sequence:
- [x] #110789 and #110947 
- [x] #110676
- [x] #111008
- [x]  #111145

Needed for #110758
Epic: CRDB-6671

This commit simplifies the Updater interface as follows:

- it provides a new `SetFromStorage()` method which combines the
  effect of `Set()` and `SetValueOrigin()` into one method. The settings
  watcher is also modified to use this new method.

- it provides a new `SetToDefault()` method which resets a setting to
  its registered default. This is then used instead of
  `Set(s.EncodedDefault())` in the setting watcher. The benefit here
  is that `SetToDefault()` properly clears the 'modified' bit, which
  we plan to use in a later commit.