### PR TITLE
kv: ignore {exclusive,shared} locks in QueryIntent request

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_query_intent.go
+++ b/pkg/kv/kvserver/batcheval/cmd_query_intent.go
@@ -74,8 +74,6 @@ func QueryIntent(
 	}
 
 	// Read from the lock table to see if an intent exists.
-	// Iterate over the lock key space with this key as a lower bound.
-	// With prefix set to true there should be at most one result.
 	intent, err := storage.GetIntent(reader, args.Key)
 	if err != nil {
 		return result.Result{}, err


### PR DESCRIPTION
Informs #100193.

QueryIntent requests only care about intents, not about other locks. This commit updates the QueryIntent evaluation method to use a LockTableIterator configured to ignore Exclusive or Shared locks.

Release note: None