### PR TITLE
release-22.2: roachtest: allow running skipped tests

### DIFF
--- a/pkg/cmd/roachtest/registry/filter.go
+++ b/pkg/cmd/roachtest/registry/filter.go
@@ -21,14 +21,15 @@ type TestFilter struct {
 	Name *regexp.Regexp
 	Tag  *regexp.Regexp
 	// RawTag is the string representation of the regexps in tag.
-	RawTag []string
+	RawTag     []string
+	RunSkipped bool
 }
 
 // NewTestFilter initializes a new filter. The strings are interpreted
 // as regular expressions. As a special case, a `tag:` prefix implies
 // that the remainder of the string filters tests by tag, and not by
 // name.
-func NewTestFilter(filter []string) *TestFilter {
+func NewTestFilter(filter []string, runSkipped bool) *TestFilter {
 	var name []string
 	var tag []string
 	var rawTag []string
@@ -61,8 +62,9 @@ func NewTestFilter(filter []string) *TestFilter {
 	}
 
 	return &TestFilter{
-		Name:   makeRE(name),
-		Tag:    makeRE(tag),
-		RawTag: rawTag,
+		Name:       makeRE(name),
+		Tag:        makeRE(tag),
+		RawTag:     rawTag,
+		RunSkipped: runSkipped,
 	}
 }

--- a/pkg/cmd/roachtest/registry/test_spec.go
+++ b/pkg/cmd/roachtest/registry/test_spec.go
@@ -12,7 +12,6 @@ package registry
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
@@ -92,26 +91,36 @@ type TestSpec struct {
 	Run func(ctx context.Context, t test.Test, c cluster.Cluster)
 }
 
-// MatchOrSkip returns true if the filter matches the test. If the filter does
+// MatchType is the type of match a file has to a TestFilter.
+type MatchType int
+
+const (
+	// Matched means that the file passes the filter and the tags.
+	Matched MatchType = iota
+	// FailedFilter means that the file fails the filter.
+	FailedFilter
+	// FailedTags means that the file passed the filter but failed the tags
+	// match.
+	FailedTags
+)
+
+// Match returns Matched if the filter matches the test. If the filter does
 // not match the test because the tag filter does not match, the test is
-// matched, but marked as skipped.
-//
-// TODO(tbg): it's gross that this sets t.Skip, let the caller do this.
-func (t *TestSpec) MatchOrSkip(filter *TestFilter) bool {
+// marked as FailedTags.
+func (t *TestSpec) Match(filter *TestFilter) MatchType {
 	if !filter.Name.MatchString(t.Name) {
-		return false
+		return FailedFilter
 	}
 	if len(t.Tags) == 0 {
 		if !filter.Tag.MatchString("default") {
-			t.Skip = fmt.Sprintf("%s does not match [default]", filter.RawTag)
+			return FailedTags
 		}
-		return true
+		return Matched
 	}
 	for _, t := range t.Tags {
 		if filter.Tag.MatchString(t) {
-			return true
+			return Matched
 		}
 	}
-	t.Skip = fmt.Sprintf("%s does not match %s", filter.RawTag, t.Tags)
-	return true
+	return FailedTags
 }

--- a/pkg/cmd/roachtest/test_registry.go
+++ b/pkg/cmd/roachtest/test_registry.go
@@ -165,25 +165,33 @@ func (r *testRegistryImpl) prepareSpec(spec *registry.TestSpec) error {
 // GetTests returns all the tests that match the given regexp.
 // Skipped tests are included, and tests that don't match their minVersion spec
 // are also included but marked as skipped.
-func (r testRegistryImpl) GetTests(filter *registry.TestFilter) []registry.TestSpec {
-
+func (r testRegistryImpl) GetTests(
+	filter *registry.TestFilter,
+) ([]registry.TestSpec, []registry.TestSpec) {
 	var tests []registry.TestSpec
+	var tagMismatch []registry.TestSpec
 	for _, t := range r.m {
-		if !t.MatchOrSkip(filter) {
-			continue
+		switch t.Match(filter) {
+		case registry.Matched:
+			tests = append(tests, *t)
+		case registry.FailedTags:
+			tagMismatch = append(tagMismatch, *t)
+		case registry.FailedFilter:
 		}
-		tests = append(tests, *t)
 	}
 	sort.Slice(tests, func(i, j int) bool {
 		return tests[i].Name < tests[j].Name
 	})
-	return tests
+	sort.Slice(tagMismatch, func(i, j int) bool {
+		return tagMismatch[i].Name < tagMismatch[j].Name
+	})
+	return tests, tagMismatch
 }
 
 // List lists tests that match one of the filters.
 func (r testRegistryImpl) List(filters []string) []registry.TestSpec {
-	filter := registry.NewTestFilter(filters)
-	tests := r.GetTests(filter)
+	filter := registry.NewTestFilter(filters, true)
+	tests, _ := r.GetTests(filter)
 
 	sort.Slice(tests, func(i, j int) bool { return tests[i].Name < tests[j].Name })
 	return tests

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -848,9 +848,6 @@ func (r *testRunner) runTest(
 	l *logger.Logger,
 	github *githubIssues,
 ) error {
-	if t.Spec().(*registry.TestSpec).Skip != "" {
-		return fmt.Errorf("can't run skipped test: %s: %s", t.Name(), t.Spec().(*registry.TestSpec).Skip)
-	}
 
 	runID := t.Name()
 	if runCount > 1 {

--- a/pkg/cmd/roachtest/test_test.go
+++ b/pkg/cmd/roachtest/test_test.go
@@ -53,31 +53,28 @@ func mkReg(t *testing.T) testRegistryImpl {
 
 func TestMatchOrSkip(t *testing.T) {
 	testCases := []struct {
-		filter       []string
-		name         string
-		tags         []string
-		expected     bool
-		expectedSkip string
+		filter   []string
+		name     string
+		tags     []string
+		expected registry.MatchType
 	}{
-		{nil, "foo", nil, true, ""},
-		{nil, "foo", []string{"bar"}, true, "[tag:default] does not match [bar]"},
-		{[]string{"tag:b"}, "foo", []string{"bar"}, true, ""},
-		{[]string{"tag:b"}, "foo", nil, true, "[tag:b] does not match [default]"},
-		{[]string{"tag:default"}, "foo", nil, true, ""},
-		{[]string{"tag:f"}, "foo", []string{"bar"}, true, "[tag:f] does not match [bar]"},
-		{[]string{"f"}, "foo", []string{"bar"}, true, "[tag:default] does not match [bar]"},
-		{[]string{"f"}, "bar", []string{"bar"}, false, ""},
-		{[]string{"f", "tag:b"}, "foo", []string{"bar"}, true, ""},
-		{[]string{"f", "tag:f"}, "foo", []string{"bar"}, true, "[tag:f] does not match [bar]"},
+		{nil, "foo", nil, registry.Matched},
+		{nil, "foo", []string{"bar"}, registry.FailedTags},
+		{[]string{"tag:b"}, "foo", []string{"bar"}, registry.Matched},
+		{[]string{"tag:b"}, "foo", nil, registry.FailedTags},
+		{[]string{"tag:default"}, "foo", nil, registry.Matched},
+		{[]string{"tag:f"}, "foo", []string{"bar"}, registry.FailedTags},
+		{[]string{"f"}, "foo", []string{"bar"}, registry.FailedTags},
+		{[]string{"f"}, "bar", []string{"bar"}, registry.FailedFilter},
+		{[]string{"f", "tag:b"}, "foo", []string{"bar"}, registry.Matched},
+		{[]string{"f", "tag:f"}, "foo", []string{"bar"}, registry.FailedTags},
 	}
 	for _, c := range testCases {
 		t.Run("", func(t *testing.T) {
-			f := registry.NewTestFilter(c.filter)
+			f := registry.NewTestFilter(c.filter, false)
 			spec := &registry.TestSpec{Name: c.name, Owner: OwnerUnitTest, Tags: c.tags}
-			if value := spec.MatchOrSkip(f); c.expected != value {
-				t.Fatalf("expected %t, but found %t", c.expected, value)
-			} else if value && c.expectedSkip != spec.Skip {
-				t.Fatalf("expected %s, but found %s", c.expectedSkip, spec.Skip)
+			if value := spec.Match(f); c.expected != value {
+				t.Fatalf("expected %v, but found %v", c.expected, value)
 			}
 		})
 	}
@@ -246,7 +243,8 @@ type runnerTest struct {
 
 func setupRunnerTest(t *testing.T, r testRegistryImpl, testFilters []string) *runnerTest {
 	ctx := context.Background()
-	tests := testsToRun(r, registry.NewTestFilter(testFilters))
+
+	tests := testsToRun(r, registry.NewTestFilter(testFilters, false))
 	cr := newClusterRegistry()
 
 	stopper := stop.NewStopper()
@@ -441,8 +439,7 @@ func runExitCodeTest(t *testing.T, injectedError error) error {
 			}
 		},
 	})
-
-	tests := testsToRun(r, registry.NewTestFilter(nil))
+	tests := testsToRun(r, registry.NewTestFilter(nil, false))
 	lopt := loggingOpt{
 		l:            nilLogger(),
 		tee:          logger.NoTee,


### PR DESCRIPTION
Backport 1/1 commits from #90071.

/cc @cockroachdb/release

Release justification: test only change, policy is to try to keep roachtest in sync for the last two stable releases.

---

This commit adds the flag --run-skipped which allows running tests that are marked with `Skip`. Typically `Skip` is used for either tests that are flakey or otherwise fail. Prior to this commit a developer would be required to manually edit the test to comment out the Skip line to run a test which is inefficient.

Release note: None
Epic: None
