### PR TITLE
streamingccl: split destination based on source

### DIFF
--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_dist.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_dist.go
@@ -15,12 +15,15 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/ccl/backupccl"
 	"github.com/cockroachdb/cockroach/pkg/ccl/streamingccl"
 	"github.com/cockroachdb/cockroach/pkg/ccl/streamingccl/streamclient"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobsprofiler"
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/repstream/streampb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
@@ -33,6 +36,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
 	"github.com/cockroachdb/redact"
@@ -211,12 +215,160 @@ func startDistIngestion(
 		return rw.Err()
 	}
 
-	updateRunningStatus(ctx, ingestionJob, jobspb.Replicating, "physical replication running")
+	// We now attempt to create initial splits. We currently do
+	// this once during initial planning to avoid re-splitting on
+	// resume since it isn't clear to us at the moment whether
+	// re-splitting is always going to be useful.
+	if !streamProgress.InitialSplitComplete {
+		codec := execCtx.ExtendedEvalContext().Codec
+		splitter := &dbSplitAndScatter{db: execCtx.ExecCfg().DB}
+		if err := createInitialSplits(ctx, codec, splitter, planner.initialTopology, details.DestinationTenantID); err != nil {
+			return err
+		}
+	} else {
+		log.Infof(ctx, "initial splits already complete")
+	}
+
+	if err := ingestionJob.NoTxn().Update(ctx, func(txn isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
+		md.Progress.GetStreamIngest().ReplicationStatus = jobspb.Replicating
+		md.Progress.GetStreamIngest().InitialSplitComplete = true
+		md.Progress.RunningStatus = "physical replication running"
+		ju.UpdateProgress(md.Progress)
+		return nil
+	}); err != nil {
+		return err
+	}
+
 	err = ctxgroup.GoAndWait(ctx, execInitialPlan, replanner, tracingAggLoop, streamSpanConfigs)
 	if errors.Is(err, sql.ErrPlanChanged) {
 		execCtx.ExecCfg().JobRegistry.MetricsStruct().StreamIngest.(*Metrics).ReplanCount.Inc(1)
 	}
 	return err
+}
+
+// TODO(ssd): This is a duplicative with the split_and_scatter processor in
+// backupccl.
+type splitAndScatterer interface {
+	split(
+		ctx context.Context,
+		splitKey roachpb.Key,
+		expirationTime hlc.Timestamp,
+	) error
+
+	scatter(
+		ctx context.Context,
+		scatterKey roachpb.Key,
+	) error
+
+	now() hlc.Timestamp
+}
+
+type dbSplitAndScatter struct {
+	db *kv.DB
+}
+
+func (s *dbSplitAndScatter) split(
+	ctx context.Context, splitKey roachpb.Key, expirationTime hlc.Timestamp,
+) error {
+	return s.db.AdminSplit(ctx, splitKey, expirationTime)
+}
+
+func (s *dbSplitAndScatter) scatter(ctx context.Context, scatterKey roachpb.Key) error {
+	_, pErr := kv.SendWrapped(ctx, s.db.NonTransactionalSender(), &kvpb.AdminScatterRequest{
+		RequestHeader: kvpb.RequestHeaderFromSpan(roachpb.Span{
+			Key:    scatterKey,
+			EndKey: scatterKey.Next(),
+		}),
+		RandomizeLeases: true,
+		MaxSize:         1, // don't scatter non-empty ranges on resume.
+	})
+	return pErr.GoError()
+}
+
+func (s *dbSplitAndScatter) now() hlc.Timestamp {
+	return s.db.Clock().Now()
+}
+
+// createInitialSplits creates splits based on the given toplogy from the
+// source.
+//
+// The idea here is to use the information from the source cluster about
+// the distribution of the data to produce split points to help prevent
+// ingestion processors from pushing data into the same ranges during
+// the initial scan.
+func createInitialSplits(
+	ctx context.Context,
+	codec keys.SQLCodec,
+	splitter splitAndScatterer,
+	topology streamclient.Topology,
+	destTenantID roachpb.TenantID,
+) error {
+	ctx, sp := tracing.ChildSpan(ctx, "streamingest.createInitialSplits")
+	defer sp.Finish()
+
+	rekeyer, err := backupccl.MakeKeyRewriterFromRekeys(codec,
+		nil /* tableRekeys */, []execinfrapb.TenantRekey{
+			{
+				OldID: topology.SourceTenantID,
+				NewID: destTenantID,
+			}},
+		true /* restoreTenantFromStream */)
+	if err != nil {
+		return err
+	}
+	for _, partition := range topology.Partitions {
+		for _, span := range partition.Spans {
+			startKey := span.Key.Clone()
+			splitKey, _, err := rekeyer.RewriteKey(startKey, 0 /* walltimeForImportElision */)
+			if err != nil {
+				return err
+			}
+
+			// NOTE(ssd): EnsureSafeSplitKey called on an arbitrary
+			// key unfortunately results in many of our split keys
+			// mapping to the same key for workloads like TPCC where
+			// the schema of the table includes integers that will
+			// get erroneously treated as the column family length.
+			//
+			// Since the partitions are generated from a call to
+			// PartitionSpans on the source cluster, they should be
+			// aligned with the split points in the original cluster
+			// and thus should be valid split keys. But, we are
+			// opening ourselves up to replicating bad splits from
+			// the original cluster.
+			//
+			// if newSplitKey, err := keys.EnsureSafeSplitKey(splitKey); err != nil {
+			// 	// Ignore the error since keys such as
+			// 	// /Tenant/2/Table/13 is an OK start key but
+			// 	// returns an error.
+			// } else if len(newSplitKey) != 0 {
+			// 	splitKey = newSplitKey
+			// }
+			//
+			if err := splitAndScatter(ctx, roachpb.Key(splitKey), splitter); err != nil {
+				return err
+			}
+
+		}
+	}
+	return nil
+}
+
+var splitAndScatterSitckyBitDuration = time.Hour
+
+func splitAndScatter(
+	ctx context.Context, splitAndScatterKey roachpb.Key, s splitAndScatterer,
+) error {
+	log.Infof(ctx, "splitting and scattering at %s", splitAndScatterKey)
+	expirationTime := s.now().AddDuration(splitAndScatterSitckyBitDuration)
+	if err := s.split(ctx, splitAndScatterKey, expirationTime); err != nil {
+		return err
+	}
+	if err := s.scatter(ctx, splitAndScatterKey); err != nil {
+		log.Warningf(ctx, "failed to scatter span starting at %s: %v",
+			splitAndScatterKey, err)
+	}
+	return nil
 }
 
 // makeReplicationFlowPlanner creates a replicationFlowPlanner and the initial physical plan.
@@ -254,6 +406,7 @@ type replicationFlowPlanner struct {
 	initialPlanCtx *sql.PlanningCtx
 
 	initialStreamAddresses []string
+	initialTopology        streamclient.Topology
 
 	srcTenantID roachpb.TenantID
 }
@@ -287,6 +440,7 @@ func (p *replicationFlowPlanner) constructPlanGenerator(
 			return nil, nil, err
 		}
 		if !p.containsInitialStreamAddresses() {
+			p.initialTopology = topology
 			p.initialStreamAddresses = topology.StreamAddresses()
 		}
 

--- a/pkg/jobs/jobspb/jobs.proto
+++ b/pkg/jobs/jobspb/jobs.proto
@@ -179,7 +179,12 @@ message StreamIngestionProgress {
   // the cutover time gets set.
   repeated roachpb.Span remaining_cutover_spans = 8 [(gogoproto.nullable) = false];
 
-  // Next Id: 9
+  // InitialSplitComplete is true if the stream ingestion job has
+  // already split the tenant's keyspace according to the plan from
+  // the source tenant.
+  bool initial_split_complete = 9;
+
+  // Next Id: 10
 }
 
 message StreamReplicationDetails {


### PR DESCRIPTION
This adds initial splits and scatters to the stream ingestion job.  We split based on the topology delivered by the source to align our initial splits with the splits that are likely coming in from the source cluster.

These splits substantially improve the throughput of a stream's initial scan.

Careful reviewers may note that we are not calling EnsureSafeSplitKey here.  That is because the Spans in the source topology should already be safe split keys.  Since EnsureSafeSplitKey isn't idempotent, if we were ta call EnsureSafeSplitKey, we would end up creating splits at rather poor split locations since any key that ends in an integer would have components erroneously trimmed from it.

An alternative here would be to do what the buffering adder does and create an initial set of splits by distributing them over the keyspace of the first buffer. That has the advantage of allowing us to call EnsureSafeSplitKey at the cost of less effective splits.

Note that we face this same problem during bulk operations.  Perhaps in the future the source cluster should send some metadata about manual splits that are issued or _something_ that lets the destination know about the fact that we expect a large amount of data in a particular span.

Epic: none

Release note: None