### PR TITLE
sql: add composite types to pg_class and pg_attribute

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -3767,7 +3767,8 @@ CREATE TABLE crdb_internal.create_statements (
 			tree.MakeDBool(tree.DBool(table.IsVirtualTable())),
 			tree.MakeDBool(tree.DBool(table.IsTemporary())),
 		)
-	})
+	},
+	nil)
 
 func showAlterStatement(
 	ctx context.Context,

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -5001,3 +5001,84 @@ oid    lanname   lanowner    lanispl  lanpltrusted  lanplcallfoid  laninline  la
 12     internal  2310524507  false    false         0              0          0             NULL
 14     sql       2310524507  false    true          0              0          0             NULL
 14024  plpgsql   2310524507  true     true          0              0          0             NULL
+
+subtest pg_class_composite_types
+
+statement ok
+CREATE TYPE u AS (ufoo int, ubar int);
+
+query TTI colnames,rowsort
+SELECT
+    relname,
+    relkind,
+    relnatts
+FROM
+    pg_catalog.pg_class
+WHERE
+    relname = 'u';
+----
+relname  relkind  relnatts
+u        c        2
+
+query TTI colnames,rowsort
+SELECT
+    relname,
+    relkind,
+    relnatts
+FROM
+    pg_catalog.pg_class
+WHERE
+    oid = 'u'::regtype::oid;
+----
+relname  relkind  relnatts
+u        c        2
+
+subtest end
+
+subtest pg_attribute_composite_types
+
+query TII colnames,rowsort
+SELECT
+    attname,
+    attlen,
+    attnum
+FROM
+    pg_catalog.pg_attribute
+WHERE
+    attname IN ('ufoo', 'ubar');
+----
+attname  attlen  attnum
+ufoo     8       1
+ubar     8       2
+
+query TII colnames,rowsort
+SELECT
+    attname,
+    attlen,
+    attnum
+FROM
+    pg_catalog.pg_attribute
+WHERE
+    attrelid = 'u'::regtype::oid;
+----
+attname  attlen  attnum
+ufoo     8       1
+ubar     8       2
+
+subtest end
+
+subtest pg_type_composite_types
+
+query TO colnames,rowsort
+SELECT typname, typrelid FROM pg_catalog.pg_type WHERE typrelid = 'u'::regtype::oid;
+----
+typname  typrelid
+u        100207
+
+query TOO colnames,rowsort
+SELECT typname, typrelid, typarray FROM pg_catalog.pg_type WHERE oid = 'u[]'::regtype::oid;
+----
+typname  typrelid  typarray
+_u       0         0
+
+subtest end


### PR DESCRIPTION
Previously, user-defined composite types were not populated
in 2 of `pg_catalog`'s tables: `pg_class` and `pg_attribute`
(where the former's row entries pertain to the type and the latter's
pertain to the "columns" of the type). This patch addresses this
PostgreSQL-incompatible behavior by populating such tables with
user-defined composite types.

Epic: none
Fixes: #109675

Release note (sql change): `pg_catalog`'s `pg_class` and `pg_attribute`
tables now have context of user-defined composite types (in accordance
with PostgreSQL's corresponding `pg_catalog` tables).