### PR TITLE
optbuilder: only project needed columns for update

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/explain_redact
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain_redact
@@ -1141,7 +1141,7 @@ update ab
 query T
 EXPLAIN (OPT, MEMO, REDACT) UPDATE ab SET a = a || 'ab' WHERE a > 'a'
 ----
-memo (optimized, ~13KB, required=[presentation: info:11] [distribution: test])
+memo (optimized, ~12KB, required=[presentation: info:11] [distribution: test])
  ├── G1: (explain G2 [distribution: test])
  │    └── [presentation: info:11] [distribution: test]
  │         ├── best: (explain G2="[distribution: test]" [distribution: test])
@@ -1367,7 +1367,7 @@ update e
 query T
 EXPLAIN (OPT, MEMO, REDACT) UPDATE e SET e = 'eee' WHERE e > 'a'
 ----
-memo (optimized, ~16KB, required=[presentation: info:13] [distribution: test])
+memo (optimized, ~14KB, required=[presentation: info:13] [distribution: test])
  ├── G1: (explain G2 [distribution: test])
  │    └── [presentation: info:13] [distribution: test]
  │         ├── best: (explain G2="[distribution: test]" [distribution: test])

--- a/pkg/sql/opt/exec/execbuilder/testdata/update_from
+++ b/pkg/sql/opt/exec/execbuilder/testdata/update_from
@@ -17,13 +17,11 @@ vectorized: true
 │
 └── • render
     │
-    └── • render
-        │
-        └── • scan
-              missing stats
-              table: abc@abc_pkey
-              spans: FULL SCAN
-              locking strength: for update
+    └── • scan
+          missing stats
+          table: abc@abc_pkey
+          spans: FULL SCAN
+          locking strength: for update
 
 # Update from another table.
 statement ok

--- a/pkg/sql/opt/memo/testdata/logprops/update
+++ b/pkg/sql/opt/memo/testdata/logprops/update
@@ -30,23 +30,23 @@ update abcde
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  └── project
-      ├── columns: d_comp:19(int!null) a:9(int!null) b:10(int) c:11(int!null) d:12(int) rowid:13(int!null) e:14(int) crdb_internal_mvcc_timestamp:15(decimal) tableoid:16(oid) b_new:17(int!null) e_default:18(int!null)
+      ├── columns: d_comp:19(int!null) a:9(int!null) b:10(int) c:11(int!null) d:12(int) rowid:13(int!null) e:14(int) b_new:17(int!null) e_default:18(int!null)
       ├── immutable
       ├── key: (13)
-      ├── fd: ()-->(9,17,18), (13)-->(10-12,14-16), (10,11)-->(12), (11)-->(19)
-      ├── prune: (9-19)
+      ├── fd: ()-->(9,17,18), (13)-->(10-12,14), (10,11)-->(12), (11)-->(19)
+      ├── prune: (9-14,17-19)
       ├── interesting orderings: (+13 opt(9,17,18))
       ├── project
-      │    ├── columns: e_default:18(int!null) a:9(int!null) b:10(int) c:11(int!null) d:12(int) rowid:13(int!null) e:14(int) crdb_internal_mvcc_timestamp:15(decimal) tableoid:16(oid) b_new:17(int!null)
+      │    ├── columns: e_default:18(int!null) a:9(int!null) b:10(int) c:11(int!null) d:12(int) rowid:13(int!null) e:14(int) b_new:17(int!null)
       │    ├── key: (13)
-      │    ├── fd: ()-->(9,17,18), (13)-->(10-12,14-16), (10,11)-->(12)
-      │    ├── prune: (9-18)
+      │    ├── fd: ()-->(9,17,18), (13)-->(10-12,14), (10,11)-->(12)
+      │    ├── prune: (9-14,17,18)
       │    ├── interesting orderings: (+13 opt(9,17,18))
       │    ├── project
-      │    │    ├── columns: b_new:17(int!null) a:9(int!null) b:10(int) c:11(int!null) d:12(int) rowid:13(int!null) e:14(int) crdb_internal_mvcc_timestamp:15(decimal) tableoid:16(oid)
+      │    │    ├── columns: b_new:17(int!null) a:9(int!null) b:10(int) c:11(int!null) d:12(int) rowid:13(int!null) e:14(int)
       │    │    ├── key: (13)
-      │    │    ├── fd: ()-->(9,17), (13)-->(10-12,14-16), (10,11)-->(12)
-      │    │    ├── prune: (9-17)
+      │    │    ├── fd: ()-->(9,17), (13)-->(10-12,14), (10,11)-->(12)
+      │    │    ├── prune: (9-14,17)
       │    │    ├── interesting orderings: (+13 opt(9,17))
       │    │    ├── select
       │    │    │    ├── columns: a:9(int!null) b:10(int) c:11(int!null) d:12(int) rowid:13(int!null) e:14(int) crdb_internal_mvcc_timestamp:15(decimal) tableoid:16(oid)

--- a/pkg/sql/opt/optbuilder/fk_cascade.go
+++ b/pkg/sql/opt/optbuilder/fk_cascade.go
@@ -470,7 +470,7 @@ func (cb *onDeleteSetBuilder) Build(
 				updateExprs[i].Expr = tree.DefaultVal{}
 			}
 		}
-		mb.addUpdateCols(updateExprs)
+		mb.addUpdateCols(updateExprs, false /* skipProjectionPruning */)
 
 		// TODO(radu): consider plumbing a flag to prevent building the FK check
 		// against the parent we are cascading from. Need to investigate in which
@@ -692,7 +692,7 @@ func (cb *onUpdateCascadeBuilder) Build(
 				panic(errors.AssertionFailedf("unsupported action"))
 			}
 		}
-		mb.addUpdateCols(updateExprs)
+		mb.addUpdateCols(updateExprs, false /* skipProjectionPruning */)
 
 		mb.buildUpdate(nil /* returning */)
 		return mb.outScope.expr

--- a/pkg/sql/opt/optbuilder/insert.go
+++ b/pkg/sql/opt/optbuilder/insert.go
@@ -338,7 +338,7 @@ func (b *Builder) buildInsert(ins *tree.Insert, inScope *scope) (outScope *scope
 		mb.addTargetColsForUpdate(ins.OnConflict.Exprs)
 
 		// Build each of the SET expressions.
-		mb.addUpdateCols(ins.OnConflict.Exprs)
+		mb.addUpdateCols(ins.OnConflict.Exprs, true /* skipProjectionPruning */)
 
 		// Build the final upsert statement, including any returned expressions.
 		mb.buildUpsert(returning)

--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -271,6 +271,7 @@ func (mb *mutationBuilder) buildInputForUpdate(
 	where *tree.Where,
 	limit *tree.Limit,
 	orderBy tree.OrderBy,
+	returning tree.ReturningClause,
 ) {
 	var indexFlags *tree.IndexFlags
 	if source, ok := texpr.(*tree.AliasedTableExpr); ok && source.IndexFlags != nil {
@@ -313,7 +314,9 @@ func (mb *mutationBuilder) buildInputForUpdate(
 
 		// The FROM table columns can be accessed by the RETURNING clause of the
 		// query and so we have to make them accessible.
-		mb.extraAccessibleCols = fromScope.cols
+		if resultsNeeded(returning) {
+			mb.extraAccessibleCols = fromScope.cols
+		}
 
 		// Add the columns in the FROM scope.
 		// We create a new scope so that fetchScope is not modified. It will be

--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -220,6 +220,23 @@ func (s *scope) appendColumnsFromScope(src *scope) {
 	}
 }
 
+// appendColumnsFromScopeInColSet adds newly bound variables to this scope from
+// the `src` scope having column IDs in `colSet`. The expressions in the new
+// columns are reset to nil.
+func (s *scope) appendColumnsFromScopeInColSet(src *scope, colSet opt.ColSet) {
+	l := len(s.cols)
+	for _, col := range src.cols {
+		if colSet.Contains(col.id) {
+			s.appendColumn(&col)
+		}
+	}
+	// We want to reset the expressions, as these become pass-through columns in
+	// the new scope.
+	for i := l; i < len(s.cols); i++ {
+		s.cols[i].scalar = nil
+	}
+}
+
 // appendOrdinaryColumnsFromTable adds all non-mutation and non-system columns from the
 // given table metadata to this scope.
 func (s *scope) appendOrdinaryColumnsFromTable(tabMeta *opt.TableMeta, alias *tree.TableName) {

--- a/pkg/sql/opt/optbuilder/testdata/fk-checks-update
+++ b/pkg/sql/opt/optbuilder/testdata/fk-checks-update
@@ -16,7 +16,7 @@ update child
  │    └── p_new:9 => child.p:2
  ├── input binding: &1
  ├── project
- │    ├── columns: p_new:9!null c:5!null child.p:6!null child.crdb_internal_mvcc_timestamp:7 child.tableoid:8
+ │    ├── columns: p_new:9!null c:5!null child.p:6!null
  │    ├── scan child
  │    │    └── columns: c:5!null child.p:6!null child.crdb_internal_mvcc_timestamp:7 child.tableoid:8
  │    └── projections
@@ -45,7 +45,7 @@ update parent
  │    └── p_new:11 => parent.p:2
  ├── input binding: &1
  ├── project
- │    ├── columns: p_new:11!null x:6 parent.p:7!null other:8 parent.crdb_internal_mvcc_timestamp:9 parent.tableoid:10
+ │    ├── columns: p_new:11!null x:6 parent.p:7!null other:8
  │    ├── scan parent
  │    │    └── columns: x:6 parent.p:7!null other:8 parent.crdb_internal_mvcc_timestamp:9 parent.tableoid:10
  │    └── projections
@@ -86,7 +86,7 @@ update child
  │    └── c_new:9 => child.c:1
  ├── input binding: &1
  ├── project
- │    ├── columns: c_new:9!null child.c:5!null p:6!null child.crdb_internal_mvcc_timestamp:7 child.tableoid:8
+ │    ├── columns: c_new:9!null child.c:5!null p:6!null
  │    ├── scan child
  │    │    └── columns: child.c:5!null p:6!null child.crdb_internal_mvcc_timestamp:7 child.tableoid:8
  │    └── projections
@@ -124,7 +124,7 @@ update child
  │    └── p_new:9 => child.p:2
  ├── input binding: &1
  ├── project
- │    ├── columns: p_new:9!null c:5!null child.p:6!null child.crdb_internal_mvcc_timestamp:7 child.tableoid:8
+ │    ├── columns: p_new:9!null c:5!null child.p:6!null
  │    ├── scan child
  │    │    └── columns: c:5!null child.p:6!null child.crdb_internal_mvcc_timestamp:7 child.tableoid:8
  │    └── projections
@@ -152,8 +152,10 @@ update child
  ├── update-mapping:
  │    └── child.p:6 => child.p:2
  ├── input binding: &1
- ├── scan child
- │    └── columns: c:5!null child.p:6!null child.crdb_internal_mvcc_timestamp:7 child.tableoid:8
+ ├── project
+ │    ├── columns: c:5!null child.p:6!null
+ │    └── scan child
+ │         └── columns: c:5!null child.p:6!null child.crdb_internal_mvcc_timestamp:7 child.tableoid:8
  └── f-k-checks
       └── f-k-checks-item: child(p) -> parent(p)
            └── anti-join (hash)
@@ -179,7 +181,7 @@ update child
  │    └── p_new:9 => child.p:2
  ├── input binding: &1
  ├── project
- │    ├── columns: p_new:9!null c_new:10!null child.c:5!null child.p:6!null child.crdb_internal_mvcc_timestamp:7 child.tableoid:8
+ │    ├── columns: p_new:9!null c_new:10!null child.c:5!null child.p:6!null
  │    ├── scan child
  │    │    └── columns: child.c:5!null child.p:6!null child.crdb_internal_mvcc_timestamp:7 child.tableoid:8
  │    └── projections
@@ -234,7 +236,7 @@ update child_nullable
  ├── update-mapping:
  │    └── p_new:9 => p:2
  └── project
-      ├── columns: p_new:9 c:5!null p:6 crdb_internal_mvcc_timestamp:7 tableoid:8
+      ├── columns: p_new:9 c:5!null p:6
       ├── scan child_nullable
       │    └── columns: c:5!null p:6 crdb_internal_mvcc_timestamp:7 tableoid:8
       └── projections
@@ -255,7 +257,7 @@ update child
  │    └── p_new:9 => child.p:2
  ├── input binding: &1
  ├── project
- │    ├── columns: p_new:9!null c:5!null child.p:6!null child.crdb_internal_mvcc_timestamp:7 child.tableoid:8
+ │    ├── columns: p_new:9!null c:5!null child.p:6!null
  │    ├── scan child
  │    │    └── columns: c:5!null child.p:6!null child.crdb_internal_mvcc_timestamp:7 child.tableoid:8
  │    └── projections
@@ -288,7 +290,7 @@ update self
  │    └── y_new:9 => self.y:2
  ├── input binding: &1
  ├── project
- │    ├── columns: y_new:9!null x:5!null self.y:6!null crdb_internal_mvcc_timestamp:7 tableoid:8
+ │    ├── columns: y_new:9!null x:5!null self.y:6!null
  │    ├── scan self
  │    │    └── columns: x:5!null self.y:6!null crdb_internal_mvcc_timestamp:7 tableoid:8
  │    └── projections
@@ -317,7 +319,7 @@ update self
  │    └── x_new:9 => self.x:1
  ├── input binding: &1
  ├── project
- │    ├── columns: x_new:9!null self.x:5!null y:6!null crdb_internal_mvcc_timestamp:7 tableoid:8
+ │    ├── columns: x_new:9!null self.x:5!null y:6!null
  │    ├── scan self
  │    │    └── columns: self.x:5!null y:6!null crdb_internal_mvcc_timestamp:7 tableoid:8
  │    └── projections
@@ -368,7 +370,7 @@ update child_multicol_simple
  │    ├── b_new:14 => b:3
  │    └── a_new:13 => c:4
  └── project
-      ├── columns: a_new:13!null b_new:14 k:7!null a:8 b:9 c:10 crdb_internal_mvcc_timestamp:11 tableoid:12
+      ├── columns: a_new:13!null b_new:14 k:7!null a:8 b:9 c:10
       ├── select
       │    ├── columns: k:7!null a:8 b:9 c:10 crdb_internal_mvcc_timestamp:11 tableoid:12
       │    ├── scan child_multicol_simple
@@ -400,7 +402,7 @@ update child_multicol_full
  │    └── a_new:13 => child_multicol_full.c:4
  ├── input binding: &1
  ├── project
- │    ├── columns: a_new:13!null b_new:14 k:7!null child_multicol_full.a:8 child_multicol_full.b:9 child_multicol_full.c:10 child_multicol_full.crdb_internal_mvcc_timestamp:11 child_multicol_full.tableoid:12
+ │    ├── columns: a_new:13!null b_new:14 k:7!null child_multicol_full.a:8 child_multicol_full.b:9 child_multicol_full.c:10
  │    ├── select
  │    │    ├── columns: k:7!null child_multicol_full.a:8 child_multicol_full.b:9 child_multicol_full.c:10 child_multicol_full.crdb_internal_mvcc_timestamp:11 child_multicol_full.tableoid:12
  │    │    ├── scan child_multicol_full
@@ -439,7 +441,7 @@ update child_multicol_full
  │    ├── a_new:13 => b:3
  │    └── a_new:13 => c:4
  └── project
-      ├── columns: a_new:13 k:7!null a:8 b:9 c:10 crdb_internal_mvcc_timestamp:11 tableoid:12
+      ├── columns: a_new:13 k:7!null a:8 b:9 c:10
       ├── select
       │    ├── columns: k:7!null a:8 b:9 c:10 crdb_internal_mvcc_timestamp:11 tableoid:12
       │    ├── scan child_multicol_full
@@ -551,7 +553,7 @@ update child
  │    └── p_new:9 => child.p:2
  ├── input binding: &1
  ├── project
- │    ├── columns: p_new:9!null c:5!null child.p:6!null child.crdb_internal_mvcc_timestamp:7 child.tableoid:8
+ │    ├── columns: p_new:9!null c:5!null child.p:6!null
  │    ├── scan child
  │    │    └── columns: c:5!null child.p:6!null child.crdb_internal_mvcc_timestamp:7 child.tableoid:8
  │    └── projections
@@ -583,7 +585,7 @@ update child
  │    └── p_new:9 => child.p:2
  ├── input binding: &1
  ├── project
- │    ├── columns: p_new:9!null c_new:10!null child.c:5!null child.p:6!null child.crdb_internal_mvcc_timestamp:7 child.tableoid:8
+ │    ├── columns: p_new:9!null c_new:10!null child.c:5!null child.p:6!null
  │    ├── scan child
  │    │    └── columns: child.c:5!null child.p:6!null child.crdb_internal_mvcc_timestamp:7 child.tableoid:8
  │    └── projections
@@ -654,7 +656,7 @@ update self
  │    └── y_new:9 => self.y:2
  ├── input binding: &1
  ├── project
- │    ├── columns: y_new:9!null x:5!null self.y:6!null crdb_internal_mvcc_timestamp:7 tableoid:8
+ │    ├── columns: y_new:9!null x:5!null self.y:6!null
  │    ├── scan self
  │    │    └── columns: x:5!null self.y:6!null crdb_internal_mvcc_timestamp:7 tableoid:8
  │    └── projections
@@ -684,7 +686,7 @@ update self
  │    └── x_new:9 => self.x:1
  ├── input binding: &1
  ├── project
- │    ├── columns: x_new:9!null self.x:5!null y:6!null crdb_internal_mvcc_timestamp:7 tableoid:8
+ │    ├── columns: x_new:9!null self.x:5!null y:6!null
  │    ├── scan self
  │    │    └── columns: self.x:5!null y:6!null crdb_internal_mvcc_timestamp:7 tableoid:8
  │    └── projections

--- a/pkg/sql/opt/optbuilder/testdata/fk-on-update-cascade
+++ b/pkg/sql/opt/optbuilder/testdata/fk-on-update-cascade
@@ -19,7 +19,7 @@ root
  │    ├── cascades
  │    │    └── child_p_fkey
  │    └── project
- │         ├── columns: p_new:7!null p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+ │         ├── columns: p_new:7!null p:4!null
  │         ├── select
  │         │    ├── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
  │         │    ├── scan parent
@@ -35,22 +35,24 @@ root
            ├── update-mapping:
            │    └── p_new:17 => child.p:9
            ├── input binding: &2
-           ├── inner-join (hash)
-           │    ├── columns: c:12!null child.p:13!null p_old:16!null p_new:17!null
-           │    ├── scan child
-           │    │    ├── columns: c:12!null child.p:13!null
-           │    │    └── flags: disabled not visible index feature
-           │    ├── select
-           │    │    ├── columns: p_old:16!null p_new:17!null
-           │    │    ├── with-scan &1
-           │    │    │    ├── columns: p_old:16!null p_new:17!null
-           │    │    │    └── mapping:
-           │    │    │         ├──  parent.p:4 => p_old:16
-           │    │    │         └──  p_new:7 => p_new:17
-           │    │    └── filters
-           │    │         └── p_old:16 IS DISTINCT FROM p_new:17
-           │    └── filters
-           │         └── child.p:13 = p_old:16
+           ├── project
+           │    ├── columns: c:12!null child.p:13!null p_new:17!null
+           │    └── inner-join (hash)
+           │         ├── columns: c:12!null child.p:13!null p_old:16!null p_new:17!null
+           │         ├── scan child
+           │         │    ├── columns: c:12!null child.p:13!null
+           │         │    └── flags: disabled not visible index feature
+           │         ├── select
+           │         │    ├── columns: p_old:16!null p_new:17!null
+           │         │    ├── with-scan &1
+           │         │    │    ├── columns: p_old:16!null p_new:17!null
+           │         │    │    └── mapping:
+           │         │    │         ├──  parent.p:4 => p_old:16
+           │         │    │         └──  p_new:7 => p_new:17
+           │         │    └── filters
+           │         │         └── p_old:16 IS DISTINCT FROM p_new:17
+           │         └── filters
+           │              └── child.p:13 = p_old:16
            └── f-k-checks
                 └── f-k-checks-item: child(p) -> parent(p)
                      └── anti-join (hash)
@@ -99,7 +101,7 @@ root
  │    ├── cascades
  │    │    └── fk
  │    └── project
- │         ├── columns: p_new:11 q_new:12 pk:6!null p:7 q:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+ │         ├── columns: p_new:11 q_new:12 pk:6!null p:7 q:8
  │         ├── select
  │         │    ├── columns: pk:6!null p:7 q:8 crdb_internal_mvcc_timestamp:9 tableoid:10
  │         │    ├── scan parent_multi
@@ -117,25 +119,27 @@ root
            │    ├── p_new:24 => child_multi.p:14
            │    └── q_new:26 => child_multi.q:15
            ├── input binding: &2
-           ├── inner-join (hash)
-           │    ├── columns: c:18!null child_multi.p:19!null child_multi.q:20!null p_old:23!null p_new:24 q_old:25!null q_new:26
-           │    ├── scan child_multi
-           │    │    ├── columns: c:18!null child_multi.p:19 child_multi.q:20
-           │    │    └── flags: disabled not visible index feature
-           │    ├── select
-           │    │    ├── columns: p_old:23 p_new:24 q_old:25 q_new:26
-           │    │    ├── with-scan &1
-           │    │    │    ├── columns: p_old:23 p_new:24 q_old:25 q_new:26
-           │    │    │    └── mapping:
-           │    │    │         ├──  parent_multi.p:7 => p_old:23
-           │    │    │         ├──  parent_multi.q:8 => q_old:25
-           │    │    │         ├──  p_new:11 => p_new:24
-           │    │    │         └──  q_new:12 => q_new:26
-           │    │    └── filters
-           │    │         └── (p_old:23 IS DISTINCT FROM p_new:24) OR (q_old:25 IS DISTINCT FROM q_new:26)
-           │    └── filters
-           │         ├── child_multi.p:19 = p_old:23
-           │         └── child_multi.q:20 = q_old:25
+           ├── project
+           │    ├── columns: c:18!null child_multi.p:19!null child_multi.q:20!null p_new:24 q_new:26
+           │    └── inner-join (hash)
+           │         ├── columns: c:18!null child_multi.p:19!null child_multi.q:20!null p_old:23!null p_new:24 q_old:25!null q_new:26
+           │         ├── scan child_multi
+           │         │    ├── columns: c:18!null child_multi.p:19 child_multi.q:20
+           │         │    └── flags: disabled not visible index feature
+           │         ├── select
+           │         │    ├── columns: p_old:23 p_new:24 q_old:25 q_new:26
+           │         │    ├── with-scan &1
+           │         │    │    ├── columns: p_old:23 p_new:24 q_old:25 q_new:26
+           │         │    │    └── mapping:
+           │         │    │         ├──  parent_multi.p:7 => p_old:23
+           │         │    │         ├──  parent_multi.q:8 => q_old:25
+           │         │    │         ├──  p_new:11 => p_new:24
+           │         │    │         └──  q_new:12 => q_new:26
+           │         │    └── filters
+           │         │         └── (p_old:23 IS DISTINCT FROM p_new:24) OR (q_old:25 IS DISTINCT FROM q_new:26)
+           │         └── filters
+           │              ├── child_multi.p:19 = p_old:23
+           │              └── child_multi.q:20 = q_old:25
            └── f-k-checks
                 └── f-k-checks-item: child_multi(p,q) -> parent_multi(p,q)
                      └── anti-join (hash)
@@ -172,7 +176,7 @@ root
  │    ├── cascades
  │    │    └── fk
  │    └── project
- │         ├── columns: p_new:11!null pk:6!null p:7!null q:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+ │         ├── columns: p_new:11!null pk:6!null p:7!null q:8
  │         ├── select
  │         │    ├── columns: pk:6!null p:7!null q:8 crdb_internal_mvcc_timestamp:9 tableoid:10
  │         │    ├── scan parent_multi
@@ -189,25 +193,27 @@ root
            │    ├── p_new:23 => child_multi.p:13
            │    └── q_new:25 => child_multi.q:14
            ├── input binding: &2
-           ├── inner-join (hash)
-           │    ├── columns: c:17!null child_multi.p:18!null child_multi.q:19!null p_old:22!null p_new:23!null q_old:24!null q_new:25
-           │    ├── scan child_multi
-           │    │    ├── columns: c:17!null child_multi.p:18 child_multi.q:19
-           │    │    └── flags: disabled not visible index feature
-           │    ├── select
-           │    │    ├── columns: p_old:22!null p_new:23!null q_old:24 q_new:25
-           │    │    ├── with-scan &1
-           │    │    │    ├── columns: p_old:22!null p_new:23!null q_old:24 q_new:25
-           │    │    │    └── mapping:
-           │    │    │         ├──  parent_multi.p:7 => p_old:22
-           │    │    │         ├──  parent_multi.q:8 => q_old:24
-           │    │    │         ├──  p_new:11 => p_new:23
-           │    │    │         └──  parent_multi.q:8 => q_new:25
-           │    │    └── filters
-           │    │         └── (p_old:22 IS DISTINCT FROM p_new:23) OR (q_old:24 IS DISTINCT FROM q_new:25)
-           │    └── filters
-           │         ├── child_multi.p:18 = p_old:22
-           │         └── child_multi.q:19 = q_old:24
+           ├── project
+           │    ├── columns: c:17!null child_multi.p:18!null child_multi.q:19!null p_new:23!null q_new:25
+           │    └── inner-join (hash)
+           │         ├── columns: c:17!null child_multi.p:18!null child_multi.q:19!null p_old:22!null p_new:23!null q_old:24!null q_new:25
+           │         ├── scan child_multi
+           │         │    ├── columns: c:17!null child_multi.p:18 child_multi.q:19
+           │         │    └── flags: disabled not visible index feature
+           │         ├── select
+           │         │    ├── columns: p_old:22!null p_new:23!null q_old:24 q_new:25
+           │         │    ├── with-scan &1
+           │         │    │    ├── columns: p_old:22!null p_new:23!null q_old:24 q_new:25
+           │         │    │    └── mapping:
+           │         │    │         ├──  parent_multi.p:7 => p_old:22
+           │         │    │         ├──  parent_multi.q:8 => q_old:24
+           │         │    │         ├──  p_new:11 => p_new:23
+           │         │    │         └──  parent_multi.q:8 => q_new:25
+           │         │    └── filters
+           │         │         └── (p_old:22 IS DISTINCT FROM p_new:23) OR (q_old:24 IS DISTINCT FROM q_new:25)
+           │         └── filters
+           │              ├── child_multi.p:18 = p_old:22
+           │              └── child_multi.q:19 = q_old:24
            └── f-k-checks
                 └── f-k-checks-item: child_multi(p,q) -> parent_multi(p,q)
                      └── anti-join (hash)
@@ -278,25 +284,27 @@ root
            │    ├── p_new:26 => child_multi.p:16
            │    └── q_new:28 => child_multi.q:17
            ├── input binding: &2
-           ├── inner-join (hash)
-           │    ├── columns: c:20!null child_multi.p:21!null child_multi.q:22!null p_old:25!null p_new:26!null q_old:27!null q_new:28!null
-           │    ├── scan child_multi
-           │    │    ├── columns: c:20!null child_multi.p:21 child_multi.q:22
-           │    │    └── flags: disabled not visible index feature
-           │    ├── select
-           │    │    ├── columns: p_old:25 p_new:26!null q_old:27 q_new:28!null
-           │    │    ├── with-scan &1
-           │    │    │    ├── columns: p_old:25 p_new:26!null q_old:27 q_new:28!null
-           │    │    │    └── mapping:
-           │    │    │         ├──  parent_multi.p:10 => p_old:25
-           │    │    │         ├──  parent_multi.q:11 => q_old:27
-           │    │    │         ├──  column2:7 => p_new:26
-           │    │    │         └──  column3:8 => q_new:28
-           │    │    └── filters
-           │    │         └── (p_old:25 IS DISTINCT FROM p_new:26) OR (q_old:27 IS DISTINCT FROM q_new:28)
-           │    └── filters
-           │         ├── child_multi.p:21 = p_old:25
-           │         └── child_multi.q:22 = q_old:27
+           ├── project
+           │    ├── columns: c:20!null child_multi.p:21!null child_multi.q:22!null p_new:26!null q_new:28!null
+           │    └── inner-join (hash)
+           │         ├── columns: c:20!null child_multi.p:21!null child_multi.q:22!null p_old:25!null p_new:26!null q_old:27!null q_new:28!null
+           │         ├── scan child_multi
+           │         │    ├── columns: c:20!null child_multi.p:21 child_multi.q:22
+           │         │    └── flags: disabled not visible index feature
+           │         ├── select
+           │         │    ├── columns: p_old:25 p_new:26!null q_old:27 q_new:28!null
+           │         │    ├── with-scan &1
+           │         │    │    ├── columns: p_old:25 p_new:26!null q_old:27 q_new:28!null
+           │         │    │    └── mapping:
+           │         │    │         ├──  parent_multi.p:10 => p_old:25
+           │         │    │         ├──  parent_multi.q:11 => q_old:27
+           │         │    │         ├──  column2:7 => p_new:26
+           │         │    │         └──  column3:8 => q_new:28
+           │         │    └── filters
+           │         │         └── (p_old:25 IS DISTINCT FROM p_new:26) OR (q_old:27 IS DISTINCT FROM q_new:28)
+           │         └── filters
+           │              ├── child_multi.p:21 = p_old:25
+           │              └── child_multi.q:22 = q_old:27
            └── f-k-checks
                 └── f-k-checks-item: child_multi(p,q) -> parent_multi(p,q)
                      └── anti-join (hash)
@@ -368,25 +376,27 @@ root
            │    ├── p_new:27 => child_multi.p:17
            │    └── q_new:29 => child_multi.q:18
            ├── input binding: &2
-           ├── inner-join (hash)
-           │    ├── columns: c:21!null child_multi.p:22!null child_multi.q:23!null p_old:26!null p_new:27!null q_old:28!null q_new:29
-           │    ├── scan child_multi
-           │    │    ├── columns: c:21!null child_multi.p:22 child_multi.q:23
-           │    │    └── flags: disabled not visible index feature
-           │    ├── select
-           │    │    ├── columns: p_old:26 p_new:27!null q_old:28 q_new:29
-           │    │    ├── with-scan &1
-           │    │    │    ├── columns: p_old:26 p_new:27!null q_old:28 q_new:29
-           │    │    │    └── mapping:
-           │    │    │         ├──  parent_multi.p:10 => p_old:26
-           │    │    │         ├──  parent_multi.q:11 => q_old:28
-           │    │    │         ├──  column2:7 => p_new:27
-           │    │    │         └──  parent_multi.q:11 => q_new:29
-           │    │    └── filters
-           │    │         └── (p_old:26 IS DISTINCT FROM p_new:27) OR (q_old:28 IS DISTINCT FROM q_new:29)
-           │    └── filters
-           │         ├── child_multi.p:22 = p_old:26
-           │         └── child_multi.q:23 = q_old:28
+           ├── project
+           │    ├── columns: c:21!null child_multi.p:22!null child_multi.q:23!null p_new:27!null q_new:29
+           │    └── inner-join (hash)
+           │         ├── columns: c:21!null child_multi.p:22!null child_multi.q:23!null p_old:26!null p_new:27!null q_old:28!null q_new:29
+           │         ├── scan child_multi
+           │         │    ├── columns: c:21!null child_multi.p:22 child_multi.q:23
+           │         │    └── flags: disabled not visible index feature
+           │         ├── select
+           │         │    ├── columns: p_old:26 p_new:27!null q_old:28 q_new:29
+           │         │    ├── with-scan &1
+           │         │    │    ├── columns: p_old:26 p_new:27!null q_old:28 q_new:29
+           │         │    │    └── mapping:
+           │         │    │         ├──  parent_multi.p:10 => p_old:26
+           │         │    │         ├──  parent_multi.q:11 => q_old:28
+           │         │    │         ├──  column2:7 => p_new:27
+           │         │    │         └──  parent_multi.q:11 => q_new:29
+           │         │    └── filters
+           │         │         └── (p_old:26 IS DISTINCT FROM p_new:27) OR (q_old:28 IS DISTINCT FROM q_new:29)
+           │         └── filters
+           │              ├── child_multi.p:22 = p_old:26
+           │              └── child_multi.q:23 = q_old:28
            └── f-k-checks
                 └── f-k-checks-item: child_multi(p,q) -> parent_multi(p,q)
                      └── anti-join (hash)
@@ -461,25 +471,27 @@ root
            │    ├── p_new:29 => child_multi.p:19
            │    └── q_new:31 => child_multi.q:20
            ├── input binding: &2
-           ├── inner-join (hash)
-           │    ├── columns: c:23!null child_multi.p:24!null child_multi.q:25!null p_old:28!null p_new:29!null q_old:30!null q_new:31
-           │    ├── scan child_multi
-           │    │    ├── columns: c:23!null child_multi.p:24 child_multi.q:25
-           │    │    └── flags: disabled not visible index feature
-           │    ├── select
-           │    │    ├── columns: p_old:28 p_new:29!null q_old:30 q_new:31
-           │    │    ├── with-scan &1
-           │    │    │    ├── columns: p_old:28 p_new:29!null q_old:30 q_new:31
-           │    │    │    └── mapping:
-           │    │    │         ├──  parent_multi.p:10 => p_old:28
-           │    │    │         ├──  parent_multi.q:11 => q_old:30
-           │    │    │         ├──  upsert_p:16 => p_new:29
-           │    │    │         └──  parent_multi.q:11 => q_new:31
-           │    │    └── filters
-           │    │         └── (p_old:28 IS DISTINCT FROM p_new:29) OR (q_old:30 IS DISTINCT FROM q_new:31)
-           │    └── filters
-           │         ├── child_multi.p:24 = p_old:28
-           │         └── child_multi.q:25 = q_old:30
+           ├── project
+           │    ├── columns: c:23!null child_multi.p:24!null child_multi.q:25!null p_new:29!null q_new:31
+           │    └── inner-join (hash)
+           │         ├── columns: c:23!null child_multi.p:24!null child_multi.q:25!null p_old:28!null p_new:29!null q_old:30!null q_new:31
+           │         ├── scan child_multi
+           │         │    ├── columns: c:23!null child_multi.p:24 child_multi.q:25
+           │         │    └── flags: disabled not visible index feature
+           │         ├── select
+           │         │    ├── columns: p_old:28 p_new:29!null q_old:30 q_new:31
+           │         │    ├── with-scan &1
+           │         │    │    ├── columns: p_old:28 p_new:29!null q_old:30 q_new:31
+           │         │    │    └── mapping:
+           │         │    │         ├──  parent_multi.p:10 => p_old:28
+           │         │    │         ├──  parent_multi.q:11 => q_old:30
+           │         │    │         ├──  upsert_p:16 => p_new:29
+           │         │    │         └──  parent_multi.q:11 => q_new:31
+           │         │    └── filters
+           │         │         └── (p_old:28 IS DISTINCT FROM p_new:29) OR (q_old:30 IS DISTINCT FROM q_new:31)
+           │         └── filters
+           │              ├── child_multi.p:24 = p_old:28
+           │              └── child_multi.q:25 = q_old:30
            └── f-k-checks
                 └── f-k-checks-item: child_multi(p,q) -> parent_multi(p,q)
                      └── anti-join (hash)
@@ -522,7 +534,7 @@ root
  │    ├── cascades
  │    │    └── fk
  │    └── project
- │         ├── columns: q_new:11 pk:6!null p:7!null q:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+ │         ├── columns: q_new:11 pk:6!null p:7!null q:8
  │         ├── select
  │         │    ├── columns: pk:6!null p:7!null q:8 crdb_internal_mvcc_timestamp:9 tableoid:10
  │         │    ├── scan parent_multi
@@ -541,25 +553,27 @@ root
       │    ├── input binding: &2
       │    ├── cascades
       │    │    └── fk2
-      │    ├── inner-join (hash)
-      │    │    ├── columns: c:17!null child_multi.p:18!null child_multi.q:19!null p_old:22!null p_new:23!null q_old:24!null q_new:25
-      │    │    ├── scan child_multi
-      │    │    │    ├── columns: c:17!null child_multi.p:18 child_multi.q:19
-      │    │    │    └── flags: disabled not visible index feature
-      │    │    ├── select
-      │    │    │    ├── columns: p_old:22!null p_new:23!null q_old:24 q_new:25
-      │    │    │    ├── with-scan &1
-      │    │    │    │    ├── columns: p_old:22!null p_new:23!null q_old:24 q_new:25
-      │    │    │    │    └── mapping:
-      │    │    │    │         ├──  parent_multi.p:7 => p_old:22
-      │    │    │    │         ├──  parent_multi.q:8 => q_old:24
-      │    │    │    │         ├──  parent_multi.p:7 => p_new:23
-      │    │    │    │         └──  q_new:11 => q_new:25
-      │    │    │    └── filters
-      │    │    │         └── (p_old:22 IS DISTINCT FROM p_new:23) OR (q_old:24 IS DISTINCT FROM q_new:25)
-      │    │    └── filters
-      │    │         ├── child_multi.p:18 = p_old:22
-      │    │         └── child_multi.q:19 = q_old:24
+      │    ├── project
+      │    │    ├── columns: c:17!null child_multi.p:18!null child_multi.q:19!null p_new:23!null q_new:25
+      │    │    └── inner-join (hash)
+      │    │         ├── columns: c:17!null child_multi.p:18!null child_multi.q:19!null p_old:22!null p_new:23!null q_old:24!null q_new:25
+      │    │         ├── scan child_multi
+      │    │         │    ├── columns: c:17!null child_multi.p:18 child_multi.q:19
+      │    │         │    └── flags: disabled not visible index feature
+      │    │         ├── select
+      │    │         │    ├── columns: p_old:22!null p_new:23!null q_old:24 q_new:25
+      │    │         │    ├── with-scan &1
+      │    │         │    │    ├── columns: p_old:22!null p_new:23!null q_old:24 q_new:25
+      │    │         │    │    └── mapping:
+      │    │         │    │         ├──  parent_multi.p:7 => p_old:22
+      │    │         │    │         ├──  parent_multi.q:8 => q_old:24
+      │    │         │    │         ├──  parent_multi.p:7 => p_new:23
+      │    │         │    │         └──  q_new:11 => q_new:25
+      │    │         │    └── filters
+      │    │         │         └── (p_old:22 IS DISTINCT FROM p_new:23) OR (q_old:24 IS DISTINCT FROM q_new:25)
+      │    │         └── filters
+      │    │              ├── child_multi.p:18 = p_old:22
+      │    │              └── child_multi.q:19 = q_old:24
       │    └── f-k-checks
       │         └── f-k-checks-item: child_multi(p,q) -> parent_multi(p,q)
       │              └── anti-join (hash)
@@ -587,25 +601,27 @@ root
                 │    ├── c_new:44 => grandchild.c:34
                 │    └── q_new:46 => grandchild.q:35
                 ├── input binding: &3
-                ├── inner-join (hash)
-                │    ├── columns: g:38!null grandchild.c:39!null grandchild.q:40!null c_old:43!null c_new:44!null q_old:45!null q_new:46
-                │    ├── scan grandchild
-                │    │    ├── columns: g:38!null grandchild.c:39 grandchild.q:40
-                │    │    └── flags: disabled not visible index feature
-                │    ├── select
-                │    │    ├── columns: c_old:43!null c_new:44!null q_old:45!null q_new:46
-                │    │    ├── with-scan &2
-                │    │    │    ├── columns: c_old:43!null c_new:44!null q_old:45!null q_new:46
-                │    │    │    └── mapping:
-                │    │    │         ├──  child_multi.c:17 => c_old:43
-                │    │    │         ├──  child_multi.q:19 => q_old:45
-                │    │    │         ├──  child_multi.c:17 => c_new:44
-                │    │    │         └──  q_new:25 => q_new:46
-                │    │    └── filters
-                │    │         └── (c_old:43 IS DISTINCT FROM c_new:44) OR (q_old:45 IS DISTINCT FROM q_new:46)
-                │    └── filters
-                │         ├── grandchild.c:39 = c_old:43
-                │         └── grandchild.q:40 = q_old:45
+                ├── project
+                │    ├── columns: g:38!null grandchild.c:39!null grandchild.q:40!null c_new:44!null q_new:46
+                │    └── inner-join (hash)
+                │         ├── columns: g:38!null grandchild.c:39!null grandchild.q:40!null c_old:43!null c_new:44!null q_old:45!null q_new:46
+                │         ├── scan grandchild
+                │         │    ├── columns: g:38!null grandchild.c:39 grandchild.q:40
+                │         │    └── flags: disabled not visible index feature
+                │         ├── select
+                │         │    ├── columns: c_old:43!null c_new:44!null q_old:45!null q_new:46
+                │         │    ├── with-scan &2
+                │         │    │    ├── columns: c_old:43!null c_new:44!null q_old:45!null q_new:46
+                │         │    │    └── mapping:
+                │         │    │         ├──  child_multi.c:17 => c_old:43
+                │         │    │         ├──  child_multi.q:19 => q_old:45
+                │         │    │         ├──  child_multi.c:17 => c_new:44
+                │         │    │         └──  q_new:25 => q_new:46
+                │         │    └── filters
+                │         │         └── (c_old:43 IS DISTINCT FROM c_new:44) OR (q_old:45 IS DISTINCT FROM q_new:46)
+                │         └── filters
+                │              ├── grandchild.c:39 = c_old:43
+                │              └── grandchild.q:40 = q_old:45
                 └── f-k-checks
                      └── f-k-checks-item: grandchild(c,q) -> child_multi(c,q)
                           └── anti-join (hash)
@@ -678,25 +694,27 @@ root
       │    ├── input binding: &2
       │    ├── cascades
       │    │    └── fk2
-      │    ├── inner-join (hash)
-      │    │    ├── columns: c:20!null child_multi.p:21!null child_multi.q:22!null p_old:25!null p_new:26!null q_old:27!null q_new:28!null
-      │    │    ├── scan child_multi
-      │    │    │    ├── columns: c:20!null child_multi.p:21 child_multi.q:22
-      │    │    │    └── flags: disabled not visible index feature
-      │    │    ├── select
-      │    │    │    ├── columns: p_old:25 p_new:26!null q_old:27 q_new:28!null
-      │    │    │    ├── with-scan &1
-      │    │    │    │    ├── columns: p_old:25 p_new:26!null q_old:27 q_new:28!null
-      │    │    │    │    └── mapping:
-      │    │    │    │         ├──  parent_multi.p:10 => p_old:25
-      │    │    │    │         ├──  parent_multi.q:11 => q_old:27
-      │    │    │    │         ├──  column2:7 => p_new:26
-      │    │    │    │         └──  column3:8 => q_new:28
-      │    │    │    └── filters
-      │    │    │         └── (p_old:25 IS DISTINCT FROM p_new:26) OR (q_old:27 IS DISTINCT FROM q_new:28)
-      │    │    └── filters
-      │    │         ├── child_multi.p:21 = p_old:25
-      │    │         └── child_multi.q:22 = q_old:27
+      │    ├── project
+      │    │    ├── columns: c:20!null child_multi.p:21!null child_multi.q:22!null p_new:26!null q_new:28!null
+      │    │    └── inner-join (hash)
+      │    │         ├── columns: c:20!null child_multi.p:21!null child_multi.q:22!null p_old:25!null p_new:26!null q_old:27!null q_new:28!null
+      │    │         ├── scan child_multi
+      │    │         │    ├── columns: c:20!null child_multi.p:21 child_multi.q:22
+      │    │         │    └── flags: disabled not visible index feature
+      │    │         ├── select
+      │    │         │    ├── columns: p_old:25 p_new:26!null q_old:27 q_new:28!null
+      │    │         │    ├── with-scan &1
+      │    │         │    │    ├── columns: p_old:25 p_new:26!null q_old:27 q_new:28!null
+      │    │         │    │    └── mapping:
+      │    │         │    │         ├──  parent_multi.p:10 => p_old:25
+      │    │         │    │         ├──  parent_multi.q:11 => q_old:27
+      │    │         │    │         ├──  column2:7 => p_new:26
+      │    │         │    │         └──  column3:8 => q_new:28
+      │    │         │    └── filters
+      │    │         │         └── (p_old:25 IS DISTINCT FROM p_new:26) OR (q_old:27 IS DISTINCT FROM q_new:28)
+      │    │         └── filters
+      │    │              ├── child_multi.p:21 = p_old:25
+      │    │              └── child_multi.q:22 = q_old:27
       │    └── f-k-checks
       │         └── f-k-checks-item: child_multi(p,q) -> parent_multi(p,q)
       │              └── anti-join (hash)
@@ -720,25 +738,27 @@ root
                 │    ├── c_new:47 => grandchild.c:37
                 │    └── q_new:49 => grandchild.q:38
                 ├── input binding: &3
-                ├── inner-join (hash)
-                │    ├── columns: g:41!null grandchild.c:42!null grandchild.q:43!null c_old:46!null c_new:47!null q_old:48!null q_new:49!null
-                │    ├── scan grandchild
-                │    │    ├── columns: g:41!null grandchild.c:42 grandchild.q:43
-                │    │    └── flags: disabled not visible index feature
-                │    ├── select
-                │    │    ├── columns: c_old:46!null c_new:47!null q_old:48!null q_new:49!null
-                │    │    ├── with-scan &2
-                │    │    │    ├── columns: c_old:46!null c_new:47!null q_old:48!null q_new:49!null
-                │    │    │    └── mapping:
-                │    │    │         ├──  child_multi.c:20 => c_old:46
-                │    │    │         ├──  child_multi.q:22 => q_old:48
-                │    │    │         ├──  child_multi.c:20 => c_new:47
-                │    │    │         └──  q_new:28 => q_new:49
-                │    │    └── filters
-                │    │         └── (c_old:46 IS DISTINCT FROM c_new:47) OR (q_old:48 IS DISTINCT FROM q_new:49)
-                │    └── filters
-                │         ├── grandchild.c:42 = c_old:46
-                │         └── grandchild.q:43 = q_old:48
+                ├── project
+                │    ├── columns: g:41!null grandchild.c:42!null grandchild.q:43!null c_new:47!null q_new:49!null
+                │    └── inner-join (hash)
+                │         ├── columns: g:41!null grandchild.c:42!null grandchild.q:43!null c_old:46!null c_new:47!null q_old:48!null q_new:49!null
+                │         ├── scan grandchild
+                │         │    ├── columns: g:41!null grandchild.c:42 grandchild.q:43
+                │         │    └── flags: disabled not visible index feature
+                │         ├── select
+                │         │    ├── columns: c_old:46!null c_new:47!null q_old:48!null q_new:49!null
+                │         │    ├── with-scan &2
+                │         │    │    ├── columns: c_old:46!null c_new:47!null q_old:48!null q_new:49!null
+                │         │    │    └── mapping:
+                │         │    │         ├──  child_multi.c:20 => c_old:46
+                │         │    │         ├──  child_multi.q:22 => q_old:48
+                │         │    │         ├──  child_multi.c:20 => c_new:47
+                │         │    │         └──  q_new:28 => q_new:49
+                │         │    └── filters
+                │         │         └── (c_old:46 IS DISTINCT FROM c_new:47) OR (q_old:48 IS DISTINCT FROM q_new:49)
+                │         └── filters
+                │              ├── grandchild.c:42 = c_old:46
+                │              └── grandchild.q:43 = q_old:48
                 └── f-k-checks
                      └── f-k-checks-item: grandchild(c,q) -> child_multi(c,q)
                           └── anti-join (hash)
@@ -781,9 +801,9 @@ root
  │    ├── cascades
  │    │    └── child_assn_cast_p_fkey
  │    └── project
- │         ├── columns: p_cast:10!null p:5!null p2:6 crdb_internal_mvcc_timestamp:7 tableoid:8
+ │         ├── columns: p_cast:10!null p:5!null p2:6
  │         ├── project
- │         │    ├── columns: p_new:9!null p:5!null p2:6 crdb_internal_mvcc_timestamp:7 tableoid:8
+ │         │    ├── columns: p_new:9!null p:5!null p2:6
  │         │    ├── select
  │         │    │    ├── columns: p:5!null p2:6 crdb_internal_mvcc_timestamp:7 tableoid:8
  │         │    │    ├── scan parent_assn_cast
@@ -803,23 +823,25 @@ root
            │    └── p_cast:21 => child_assn_cast.p:12
            ├── input binding: &2
            ├── project
-           │    ├── columns: p_cast:21!null c:15!null child_assn_cast.p:16!null p_old:19!null p_new:20!null
-           │    ├── inner-join (hash)
-           │    │    ├── columns: c:15!null child_assn_cast.p:16!null p_old:19!null p_new:20!null
-           │    │    ├── scan child_assn_cast
-           │    │    │    ├── columns: c:15!null child_assn_cast.p:16
-           │    │    │    └── flags: disabled not visible index feature
-           │    │    ├── select
-           │    │    │    ├── columns: p_old:19!null p_new:20!null
-           │    │    │    ├── with-scan &1
-           │    │    │    │    ├── columns: p_old:19!null p_new:20!null
-           │    │    │    │    └── mapping:
-           │    │    │    │         ├──  parent_assn_cast.p:5 => p_old:19
-           │    │    │    │         └──  p_cast:10 => p_new:20
-           │    │    │    └── filters
-           │    │    │         └── p_old:19 IS DISTINCT FROM p_new:20
-           │    │    └── filters
-           │    │         └── child_assn_cast.p:16 = p_old:19
+           │    ├── columns: p_cast:21!null c:15!null child_assn_cast.p:16!null
+           │    ├── project
+           │    │    ├── columns: c:15!null child_assn_cast.p:16!null p_new:20!null
+           │    │    └── inner-join (hash)
+           │    │         ├── columns: c:15!null child_assn_cast.p:16!null p_old:19!null p_new:20!null
+           │    │         ├── scan child_assn_cast
+           │    │         │    ├── columns: c:15!null child_assn_cast.p:16
+           │    │         │    └── flags: disabled not visible index feature
+           │    │         ├── select
+           │    │         │    ├── columns: p_old:19!null p_new:20!null
+           │    │         │    ├── with-scan &1
+           │    │         │    │    ├── columns: p_old:19!null p_new:20!null
+           │    │         │    │    └── mapping:
+           │    │         │    │         ├──  parent_assn_cast.p:5 => p_old:19
+           │    │         │    │         └──  p_cast:10 => p_new:20
+           │    │         │    └── filters
+           │    │         │         └── p_old:19 IS DISTINCT FROM p_new:20
+           │    │         └── filters
+           │    │              └── child_assn_cast.p:16 = p_old:19
            │    └── projections
            │         └── assignment-cast: DECIMAL(10) [as=p_cast:21]
            │              └── p_new:20
@@ -896,23 +918,25 @@ root
            │    └── p2_cast:24 => child_assn_cast_p2.p2:15
            ├── input binding: &2
            ├── project
-           │    ├── columns: p2_cast:24!null c:18!null child_assn_cast_p2.p2:19!null p2_old:22!null p2_new:23!null
-           │    ├── inner-join (hash)
-           │    │    ├── columns: c:18!null child_assn_cast_p2.p2:19!null p2_old:22!null p2_new:23!null
-           │    │    ├── scan child_assn_cast_p2
-           │    │    │    ├── columns: c:18!null child_assn_cast_p2.p2:19
-           │    │    │    └── flags: disabled not visible index feature
-           │    │    ├── select
-           │    │    │    ├── columns: p2_old:22 p2_new:23!null
-           │    │    │    ├── with-scan &1
-           │    │    │    │    ├── columns: p2_old:22 p2_new:23!null
-           │    │    │    │    └── mapping:
-           │    │    │    │         ├──  parent_assn_cast.p2:10 => p2_old:22
-           │    │    │    │         └──  p2_cast:8 => p2_new:23
-           │    │    │    └── filters
-           │    │    │         └── p2_old:22 IS DISTINCT FROM p2_new:23
-           │    │    └── filters
-           │    │         └── child_assn_cast_p2.p2:19 = p2_old:22
+           │    ├── columns: p2_cast:24!null c:18!null child_assn_cast_p2.p2:19!null
+           │    ├── project
+           │    │    ├── columns: c:18!null child_assn_cast_p2.p2:19!null p2_new:23!null
+           │    │    └── inner-join (hash)
+           │    │         ├── columns: c:18!null child_assn_cast_p2.p2:19!null p2_old:22!null p2_new:23!null
+           │    │         ├── scan child_assn_cast_p2
+           │    │         │    ├── columns: c:18!null child_assn_cast_p2.p2:19
+           │    │         │    └── flags: disabled not visible index feature
+           │    │         ├── select
+           │    │         │    ├── columns: p2_old:22 p2_new:23!null
+           │    │         │    ├── with-scan &1
+           │    │         │    │    ├── columns: p2_old:22 p2_new:23!null
+           │    │         │    │    └── mapping:
+           │    │         │    │         ├──  parent_assn_cast.p2:10 => p2_old:22
+           │    │         │    │         └──  p2_cast:8 => p2_new:23
+           │    │         │    └── filters
+           │    │         │         └── p2_old:22 IS DISTINCT FROM p2_new:23
+           │    │         └── filters
+           │    │              └── child_assn_cast_p2.p2:19 = p2_old:22
            │    └── projections
            │         └── assignment-cast: DECIMAL(10) [as=p2_cast:24]
            │              └── p2_new:23
@@ -992,23 +1016,25 @@ root
            │    └── p2_cast:27 => child_assn_cast_p2.p2:18
            ├── input binding: &2
            ├── project
-           │    ├── columns: p2_cast:27!null c:21!null child_assn_cast_p2.p2:22!null p2_old:25!null p2_new:26!null
-           │    ├── inner-join (hash)
-           │    │    ├── columns: c:21!null child_assn_cast_p2.p2:22!null p2_old:25!null p2_new:26!null
-           │    │    ├── scan child_assn_cast_p2
-           │    │    │    ├── columns: c:21!null child_assn_cast_p2.p2:22
-           │    │    │    └── flags: disabled not visible index feature
-           │    │    ├── select
-           │    │    │    ├── columns: p2_old:25 p2_new:26!null
-           │    │    │    ├── with-scan &1
-           │    │    │    │    ├── columns: p2_old:25 p2_new:26!null
-           │    │    │    │    └── mapping:
-           │    │    │    │         ├──  parent_assn_cast.p2:10 => p2_old:25
-           │    │    │    │         └──  upsert_p2:16 => p2_new:26
-           │    │    │    └── filters
-           │    │    │         └── p2_old:25 IS DISTINCT FROM p2_new:26
-           │    │    └── filters
-           │    │         └── child_assn_cast_p2.p2:22 = p2_old:25
+           │    ├── columns: p2_cast:27!null c:21!null child_assn_cast_p2.p2:22!null
+           │    ├── project
+           │    │    ├── columns: c:21!null child_assn_cast_p2.p2:22!null p2_new:26!null
+           │    │    └── inner-join (hash)
+           │    │         ├── columns: c:21!null child_assn_cast_p2.p2:22!null p2_old:25!null p2_new:26!null
+           │    │         ├── scan child_assn_cast_p2
+           │    │         │    ├── columns: c:21!null child_assn_cast_p2.p2:22
+           │    │         │    └── flags: disabled not visible index feature
+           │    │         ├── select
+           │    │         │    ├── columns: p2_old:25 p2_new:26!null
+           │    │         │    ├── with-scan &1
+           │    │         │    │    ├── columns: p2_old:25 p2_new:26!null
+           │    │         │    │    └── mapping:
+           │    │         │    │         ├──  parent_assn_cast.p2:10 => p2_old:25
+           │    │         │    │         └──  upsert_p2:16 => p2_new:26
+           │    │         │    └── filters
+           │    │         │         └── p2_old:25 IS DISTINCT FROM p2_new:26
+           │    │         └── filters
+           │    │              └── child_assn_cast_p2.p2:22 = p2_old:25
            │    └── projections
            │         └── assignment-cast: DECIMAL(10) [as=p2_cast:27]
            │              └── p2_new:26
@@ -1054,7 +1080,7 @@ root
  │    ├── cascades
  │    │    └── child_partial_p_fkey
  │    └── project
- │         ├── columns: p_new:7!null p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+ │         ├── columns: p_new:7!null p:4!null
  │         ├── select
  │         │    ├── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
  │         │    ├── scan parent_partial
@@ -1073,28 +1099,30 @@ root
            ├── partial index del columns: partial_index_put1:20 partial_index_del2:22
            ├── input binding: &2
            ├── project
-           │    ├── columns: partial_index_put1:20 partial_index_put2:21!null partial_index_del2:22!null c:13!null child_partial.p:14!null i:15 p_old:18!null p_new:19!null
-           │    ├── inner-join (hash)
-           │    │    ├── columns: c:13!null child_partial.p:14!null i:15 p_old:18!null p_new:19!null
-           │    │    ├── scan child_partial
-           │    │    │    ├── columns: c:13!null child_partial.p:14 i:15
-           │    │    │    ├── partial index predicates
-           │    │    │    │    ├── child_partial_p_idx: filters
-           │    │    │    │    │    └── i:15 > 0
-           │    │    │    │    └── child_partial_i_idx: filters
-           │    │    │    │         └── child_partial.p:14 > 0
-           │    │    │    └── flags: disabled not visible index feature
-           │    │    ├── select
-           │    │    │    ├── columns: p_old:18!null p_new:19!null
-           │    │    │    ├── with-scan &1
-           │    │    │    │    ├── columns: p_old:18!null p_new:19!null
-           │    │    │    │    └── mapping:
-           │    │    │    │         ├──  parent_partial.p:4 => p_old:18
-           │    │    │    │         └──  p_new:7 => p_new:19
-           │    │    │    └── filters
-           │    │    │         └── p_old:18 IS DISTINCT FROM p_new:19
-           │    │    └── filters
-           │    │         └── child_partial.p:14 = p_old:18
+           │    ├── columns: partial_index_put1:20 partial_index_put2:21!null partial_index_del2:22!null c:13!null child_partial.p:14!null i:15 p_new:19!null
+           │    ├── project
+           │    │    ├── columns: c:13!null child_partial.p:14!null i:15 p_new:19!null
+           │    │    └── inner-join (hash)
+           │    │         ├── columns: c:13!null child_partial.p:14!null i:15 p_old:18!null p_new:19!null
+           │    │         ├── scan child_partial
+           │    │         │    ├── columns: c:13!null child_partial.p:14 i:15
+           │    │         │    ├── partial index predicates
+           │    │         │    │    ├── child_partial_p_idx: filters
+           │    │         │    │    │    └── i:15 > 0
+           │    │         │    │    └── child_partial_i_idx: filters
+           │    │         │    │         └── child_partial.p:14 > 0
+           │    │         │    └── flags: disabled not visible index feature
+           │    │         ├── select
+           │    │         │    ├── columns: p_old:18!null p_new:19!null
+           │    │         │    ├── with-scan &1
+           │    │         │    │    ├── columns: p_old:18!null p_new:19!null
+           │    │         │    │    └── mapping:
+           │    │         │    │         ├──  parent_partial.p:4 => p_old:18
+           │    │         │    │         └──  p_new:7 => p_new:19
+           │    │         │    └── filters
+           │    │         │         └── p_old:18 IS DISTINCT FROM p_new:19
+           │    │         └── filters
+           │    │              └── child_partial.p:14 = p_old:18
            │    └── projections
            │         ├── i:15 > 0 [as=partial_index_put1:20]
            │         ├── p_new:19 > 0 [as=partial_index_put2:21]
@@ -1140,7 +1168,7 @@ root
  │    ├── cascades
  │    │    └── child_partial_ambig_p_new_fkey
  │    └── project
- │         ├── columns: p_new:7!null p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+ │         ├── columns: p_new:7!null p:4!null
  │         ├── select
  │         │    ├── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
  │         │    ├── scan parent_partial_ambig
@@ -1159,26 +1187,28 @@ root
            ├── partial index del columns: partial_index_del1:21
            ├── input binding: &2
            ├── project
-           │    ├── columns: partial_index_put1:20!null partial_index_del1:21!null c:13!null child_partial_ambig.p_new:14!null i:15 p_new_old:18!null p_new_new:19!null
-           │    ├── inner-join (hash)
-           │    │    ├── columns: c:13!null child_partial_ambig.p_new:14!null i:15 p_new_old:18!null p_new_new:19!null
-           │    │    ├── scan child_partial_ambig
-           │    │    │    ├── columns: c:13!null child_partial_ambig.p_new:14 i:15
-           │    │    │    ├── partial index predicates
-           │    │    │    │    └── child_partial_ambig_i_idx: filters
-           │    │    │    │         └── child_partial_ambig.p_new:14 > 0
-           │    │    │    └── flags: disabled not visible index feature
-           │    │    ├── select
-           │    │    │    ├── columns: p_new_old:18!null p_new_new:19!null
-           │    │    │    ├── with-scan &1
-           │    │    │    │    ├── columns: p_new_old:18!null p_new_new:19!null
-           │    │    │    │    └── mapping:
-           │    │    │    │         ├──  p:4 => p_new_old:18
-           │    │    │    │         └──  p_new:7 => p_new_new:19
-           │    │    │    └── filters
-           │    │    │         └── p_new_old:18 IS DISTINCT FROM p_new_new:19
-           │    │    └── filters
-           │    │         └── child_partial_ambig.p_new:14 = p_new_old:18
+           │    ├── columns: partial_index_put1:20!null partial_index_del1:21!null c:13!null child_partial_ambig.p_new:14!null i:15 p_new_new:19!null
+           │    ├── project
+           │    │    ├── columns: c:13!null child_partial_ambig.p_new:14!null i:15 p_new_new:19!null
+           │    │    └── inner-join (hash)
+           │    │         ├── columns: c:13!null child_partial_ambig.p_new:14!null i:15 p_new_old:18!null p_new_new:19!null
+           │    │         ├── scan child_partial_ambig
+           │    │         │    ├── columns: c:13!null child_partial_ambig.p_new:14 i:15
+           │    │         │    ├── partial index predicates
+           │    │         │    │    └── child_partial_ambig_i_idx: filters
+           │    │         │    │         └── child_partial_ambig.p_new:14 > 0
+           │    │         │    └── flags: disabled not visible index feature
+           │    │         ├── select
+           │    │         │    ├── columns: p_new_old:18!null p_new_new:19!null
+           │    │         │    ├── with-scan &1
+           │    │         │    │    ├── columns: p_new_old:18!null p_new_new:19!null
+           │    │         │    │    └── mapping:
+           │    │         │    │         ├──  p:4 => p_new_old:18
+           │    │         │    │         └──  p_new:7 => p_new_new:19
+           │    │         │    └── filters
+           │    │         │         └── p_new_old:18 IS DISTINCT FROM p_new_new:19
+           │    │         └── filters
+           │    │              └── child_partial_ambig.p_new:14 = p_new_old:18
            │    └── projections
            │         ├── p_new_new:19 > 0 [as=partial_index_put1:20]
            │         └── child_partial_ambig.p_new:14 > 0 [as=partial_index_del1:21]
@@ -1275,31 +1305,33 @@ root
            ├── partial index del columns: partial_index_put1:30 partial_index_del2:32
            ├── input binding: &2
            ├── project
-           │    ├── columns: partial_index_put1:30 partial_index_put2:31 partial_index_del2:32!null c:20!null child_multi_partial.p:21!null child_multi_partial.q:22!null i:23 p_old:26!null p_new:27 q_old:28!null q_new:29
-           │    ├── inner-join (hash)
-           │    │    ├── columns: c:20!null child_multi_partial.p:21!null child_multi_partial.q:22!null i:23 p_old:26!null p_new:27 q_old:28!null q_new:29
-           │    │    ├── scan child_multi_partial
-           │    │    │    ├── columns: c:20!null child_multi_partial.p:21 child_multi_partial.q:22 i:23
-           │    │    │    ├── partial index predicates
-           │    │    │    │    ├── child_multi_partial_p_q_idx: filters
-           │    │    │    │    │    └── i:23 > 0
-           │    │    │    │    └── child_multi_partial_i_idx: filters
-           │    │    │    │         └── (child_multi_partial.p:21 > 0) AND (child_multi_partial.q:22 > 0)
-           │    │    │    └── flags: disabled not visible index feature
-           │    │    ├── select
-           │    │    │    ├── columns: p_old:26 p_new:27 q_old:28 q_new:29
-           │    │    │    ├── with-scan &1
-           │    │    │    │    ├── columns: p_old:26 p_new:27 q_old:28 q_new:29
-           │    │    │    │    └── mapping:
-           │    │    │    │         ├──  parent_multi_partial.p:9 => p_old:26
-           │    │    │    │         ├──  parent_multi_partial.q:10 => q_old:28
-           │    │    │    │         ├──  p_default:7 => p_new:27
-           │    │    │    │         └──  p_default:7 => q_new:29
-           │    │    │    └── filters
-           │    │    │         └── (p_old:26 IS DISTINCT FROM p_new:27) OR (q_old:28 IS DISTINCT FROM q_new:29)
-           │    │    └── filters
-           │    │         ├── child_multi_partial.p:21 = p_old:26
-           │    │         └── child_multi_partial.q:22 = q_old:28
+           │    ├── columns: partial_index_put1:30 partial_index_put2:31 partial_index_del2:32!null c:20!null child_multi_partial.p:21!null child_multi_partial.q:22!null i:23 p_new:27 q_new:29
+           │    ├── project
+           │    │    ├── columns: c:20!null child_multi_partial.p:21!null child_multi_partial.q:22!null i:23 p_new:27 q_new:29
+           │    │    └── inner-join (hash)
+           │    │         ├── columns: c:20!null child_multi_partial.p:21!null child_multi_partial.q:22!null i:23 p_old:26!null p_new:27 q_old:28!null q_new:29
+           │    │         ├── scan child_multi_partial
+           │    │         │    ├── columns: c:20!null child_multi_partial.p:21 child_multi_partial.q:22 i:23
+           │    │         │    ├── partial index predicates
+           │    │         │    │    ├── child_multi_partial_p_q_idx: filters
+           │    │         │    │    │    └── i:23 > 0
+           │    │         │    │    └── child_multi_partial_i_idx: filters
+           │    │         │    │         └── (child_multi_partial.p:21 > 0) AND (child_multi_partial.q:22 > 0)
+           │    │         │    └── flags: disabled not visible index feature
+           │    │         ├── select
+           │    │         │    ├── columns: p_old:26 p_new:27 q_old:28 q_new:29
+           │    │         │    ├── with-scan &1
+           │    │         │    │    ├── columns: p_old:26 p_new:27 q_old:28 q_new:29
+           │    │         │    │    └── mapping:
+           │    │         │    │         ├──  parent_multi_partial.p:9 => p_old:26
+           │    │         │    │         ├──  parent_multi_partial.q:10 => q_old:28
+           │    │         │    │         ├──  p_default:7 => p_new:27
+           │    │         │    │         └──  p_default:7 => q_new:29
+           │    │         │    └── filters
+           │    │         │         └── (p_old:26 IS DISTINCT FROM p_new:27) OR (q_old:28 IS DISTINCT FROM q_new:29)
+           │    │         └── filters
+           │    │              ├── child_multi_partial.p:21 = p_old:26
+           │    │              └── child_multi_partial.q:22 = q_old:28
            │    └── projections
            │         ├── i:23 > 0 [as=partial_index_put1:30]
            │         ├── (p_new:27 > 0) AND (q_new:29 > 0) [as=partial_index_put2:31]
@@ -1356,7 +1388,7 @@ root
  │    ├── cascades
  │    │    └── child_check_ambig_p_new_fkey
  │    └── project
- │         ├── columns: p_new:7!null p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+ │         ├── columns: p_new:7!null p:4!null
  │         ├── select
  │         │    ├── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
  │         │    ├── scan parent_check_ambig
@@ -1375,28 +1407,30 @@ root
            ├── check columns: check1:21
            ├── input binding: &2
            ├── project
-           │    ├── columns: check1:21!null c:13!null child_check_ambig.p_new:14!null i:15 p_new_old:18!null p_new_new:19!null i_comp:20!null
+           │    ├── columns: check1:21!null c:13!null child_check_ambig.p_new:14!null i:15 p_new_new:19!null i_comp:20!null
            │    ├── project
-           │    │    ├── columns: i_comp:20!null c:13!null child_check_ambig.p_new:14!null i:15 p_new_old:18!null p_new_new:19!null
-           │    │    ├── inner-join (hash)
-           │    │    │    ├── columns: c:13!null child_check_ambig.p_new:14!null i:15 p_new_old:18!null p_new_new:19!null
-           │    │    │    ├── scan child_check_ambig
-           │    │    │    │    ├── columns: c:13!null child_check_ambig.p_new:14 i:15
-           │    │    │    │    ├── computed column expressions
-           │    │    │    │    │    └── i:15
-           │    │    │    │    │         └── child_check_ambig.p_new:14 * 2
-           │    │    │    │    └── flags: disabled not visible index feature
-           │    │    │    ├── select
-           │    │    │    │    ├── columns: p_new_old:18!null p_new_new:19!null
-           │    │    │    │    ├── with-scan &1
-           │    │    │    │    │    ├── columns: p_new_old:18!null p_new_new:19!null
-           │    │    │    │    │    └── mapping:
-           │    │    │    │    │         ├──  p:4 => p_new_old:18
-           │    │    │    │    │         └──  p_new:7 => p_new_new:19
-           │    │    │    │    └── filters
-           │    │    │    │         └── p_new_old:18 IS DISTINCT FROM p_new_new:19
-           │    │    │    └── filters
-           │    │    │         └── child_check_ambig.p_new:14 = p_new_old:18
+           │    │    ├── columns: i_comp:20!null c:13!null child_check_ambig.p_new:14!null i:15 p_new_new:19!null
+           │    │    ├── project
+           │    │    │    ├── columns: c:13!null child_check_ambig.p_new:14!null i:15 p_new_new:19!null
+           │    │    │    └── inner-join (hash)
+           │    │    │         ├── columns: c:13!null child_check_ambig.p_new:14!null i:15 p_new_old:18!null p_new_new:19!null
+           │    │    │         ├── scan child_check_ambig
+           │    │    │         │    ├── columns: c:13!null child_check_ambig.p_new:14 i:15
+           │    │    │         │    ├── computed column expressions
+           │    │    │         │    │    └── i:15
+           │    │    │         │    │         └── child_check_ambig.p_new:14 * 2
+           │    │    │         │    └── flags: disabled not visible index feature
+           │    │    │         ├── select
+           │    │    │         │    ├── columns: p_new_old:18!null p_new_new:19!null
+           │    │    │         │    ├── with-scan &1
+           │    │    │         │    │    ├── columns: p_new_old:18!null p_new_new:19!null
+           │    │    │         │    │    └── mapping:
+           │    │    │         │    │         ├──  p:4 => p_new_old:18
+           │    │    │         │    │         └──  p_new:7 => p_new_new:19
+           │    │    │         │    └── filters
+           │    │    │         │         └── p_new_old:18 IS DISTINCT FROM p_new_new:19
+           │    │    │         └── filters
+           │    │    │              └── child_check_ambig.p_new:14 = p_new_old:18
            │    │    └── projections
            │    │         └── p_new_new:19 * 2 [as=i_comp:20]
            │    └── projections
@@ -1441,7 +1475,7 @@ root
  │    ├── cascades
  │    │    └── child_virt_p_fkey
  │    └── project
- │         ├── columns: p_new:7!null p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+ │         ├── columns: p_new:7!null p:4!null
  │         ├── select
  │         │    ├── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
  │         │    ├── scan parent_virt
@@ -1458,29 +1492,31 @@ root
            │    ├── p_new:19 => child_virt.p:9
            │    └── p_new:19 => v:10
            ├── input binding: &2
-           ├── inner-join (hash)
-           │    ├── columns: c:13!null child_virt.p:14!null v:15 p_old:18!null p_new:19!null
-           │    ├── project
-           │    │    ├── columns: v:15 c:13!null child_virt.p:14
-           │    │    ├── scan child_virt
-           │    │    │    ├── columns: c:13!null child_virt.p:14
-           │    │    │    ├── computed column expressions
-           │    │    │    │    └── v:15
-           │    │    │    │         └── child_virt.p:14
-           │    │    │    └── flags: disabled not visible index feature
-           │    │    └── projections
-           │    │         └── child_virt.p:14 [as=v:15]
-           │    ├── select
-           │    │    ├── columns: p_old:18!null p_new:19!null
-           │    │    ├── with-scan &1
-           │    │    │    ├── columns: p_old:18!null p_new:19!null
-           │    │    │    └── mapping:
-           │    │    │         ├──  parent_virt.p:4 => p_old:18
-           │    │    │         └──  p_new:7 => p_new:19
-           │    │    └── filters
-           │    │         └── p_old:18 IS DISTINCT FROM p_new:19
-           │    └── filters
-           │         └── child_virt.p:14 = p_old:18
+           ├── project
+           │    ├── columns: c:13!null child_virt.p:14!null v:15 p_new:19!null
+           │    └── inner-join (hash)
+           │         ├── columns: c:13!null child_virt.p:14!null v:15 p_old:18!null p_new:19!null
+           │         ├── project
+           │         │    ├── columns: v:15 c:13!null child_virt.p:14
+           │         │    ├── scan child_virt
+           │         │    │    ├── columns: c:13!null child_virt.p:14
+           │         │    │    ├── computed column expressions
+           │         │    │    │    └── v:15
+           │         │    │    │         └── child_virt.p:14
+           │         │    │    └── flags: disabled not visible index feature
+           │         │    └── projections
+           │         │         └── child_virt.p:14 [as=v:15]
+           │         ├── select
+           │         │    ├── columns: p_old:18!null p_new:19!null
+           │         │    ├── with-scan &1
+           │         │    │    ├── columns: p_old:18!null p_new:19!null
+           │         │    │    └── mapping:
+           │         │    │         ├──  parent_virt.p:4 => p_old:18
+           │         │    │         └──  p_new:7 => p_new:19
+           │         │    └── filters
+           │         │         └── p_old:18 IS DISTINCT FROM p_new:19
+           │         └── filters
+           │              └── child_virt.p:14 = p_old:18
            └── f-k-checks
                 └── f-k-checks-item: child_virt(p) -> parent_virt(p)
                      └── anti-join (hash)
@@ -1523,12 +1559,12 @@ root
  │    ├── volatile, mutations
  │    ├── stats: [rows=0]
  │    └── project
- │         ├── columns: p_new:7(int!null) t.public.parent_diff_type.p:4(int!null) t.public.parent_diff_type.crdb_internal_mvcc_timestamp:5(decimal) t.public.parent_diff_type.tableoid:6(oid)
+ │         ├── columns: p_new:7(int!null) t.public.parent_diff_type.p:4(int!null)
  │         ├── cardinality: [0 - 1]
  │         ├── stats: [rows=1]
  │         ├── key: ()
- │         ├── fd: ()-->(4-7)
- │         ├── prune: (4-7)
+ │         ├── fd: ()-->(4,7)
+ │         ├── prune: (4,7)
  │         ├── select
  │         │    ├── columns: t.public.parent_diff_type.p:4(int!null) t.public.parent_diff_type.crdb_internal_mvcc_timestamp:5(decimal) t.public.parent_diff_type.tableoid:6(oid)
  │         │    ├── cardinality: [0 - 1]
@@ -1558,50 +1594,56 @@ root
            ├── volatile, mutations
            ├── stats: [rows=0]
            ├── project
-           │    ├── columns: p_cast:18(int2!null) t.public.child_diff_type.c:12(int!null) t.public.child_diff_type.p:13(int2!null) p_old:16(int!null) p_new:17(int!null)
+           │    ├── columns: p_cast:18(int2!null) t.public.child_diff_type.c:12(int!null) t.public.child_diff_type.p:13(int2!null)
            │    ├── immutable
            │    ├── stats: [rows=3.3, distinct(18)=0.333317, null(18)=0]
            │    ├── key: (12)
-           │    ├── fd: ()-->(13,16-18), (13)==(16), (16)==(13)
-           │    ├── prune: (12,13,16-18)
-           │    ├── inner-join (hash)
-           │    │    ├── columns: t.public.child_diff_type.c:12(int!null) t.public.child_diff_type.p:13(int2!null) p_old:16(int!null) p_new:17(int!null)
-           │    │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
-           │    │    ├── stats: [rows=3.3, distinct(13)=0.333333, null(13)=0, distinct(16)=0.333333, null(16)=0, distinct(17)=0.333317, null(17)=0]
+           │    ├── fd: ()-->(13,18)
+           │    ├── prune: (12,13,18)
+           │    ├── project
+           │    │    ├── columns: t.public.child_diff_type.c:12(int!null) t.public.child_diff_type.p:13(int2!null) p_new:17(int!null)
+           │    │    ├── stats: [rows=3.3, distinct(17)=0.333317, null(17)=0]
            │    │    ├── key: (12)
-           │    │    ├── fd: ()-->(13,16,17), (13)==(16), (16)==(13)
-           │    │    ├── scan t.public.child_diff_type
-           │    │    │    ├── columns: t.public.child_diff_type.c:12(int!null) t.public.child_diff_type.p:13(int2)
-           │    │    │    ├── flags: disabled not visible index feature
-           │    │    │    ├── stats: [rows=1000, distinct(12)=1000, null(12)=0, distinct(13)=100, null(13)=10]
-           │    │    │    ├── key: (12)
-           │    │    │    ├── fd: (12)-->(13)
-           │    │    │    ├── prune: (12,13)
-           │    │    │    └── unfiltered-cols: (12-15)
-           │    │    ├── select
-           │    │    │    ├── columns: p_old:16(int!null) p_new:17(int!null)
-           │    │    │    ├── cardinality: [0 - 1]
-           │    │    │    ├── stats: [rows=0.3333333, distinct(16)=0.333333, null(16)=0, distinct(17)=0.333333, null(17)=0]
-           │    │    │    ├── key: ()
-           │    │    │    ├── fd: ()-->(16,17)
-           │    │    │    ├── with-scan &1
-           │    │    │    │    ├── columns: p_old:16(int!null) p_new:17(int!null)
-           │    │    │    │    ├── mapping:
-           │    │    │    │    │    ├──  t.public.parent_diff_type.p:4(int) => p_old:16(int)
-           │    │    │    │    │    └──  p_new:7(int) => p_new:17(int)
-           │    │    │    │    ├── cardinality: [0 - 1]
-           │    │    │    │    ├── stats: [rows=1, distinct(16)=1, null(16)=0, distinct(17)=1, null(17)=0]
-           │    │    │    │    ├── key: ()
-           │    │    │    │    ├── fd: ()-->(16,17)
-           │    │    │    │    └── prune: (16,17)
-           │    │    │    └── filters
-           │    │    │         └── is-not [type=bool, outer=(16,17)]
-           │    │    │              ├── variable: p_old:16 [type=int]
-           │    │    │              └── variable: p_new:17 [type=int]
-           │    │    └── filters
-           │    │         └── eq [type=bool, outer=(13,16), constraints=(/13: (/NULL - ]; /16: (/NULL - ]), fd=(13)==(16), (16)==(13)]
-           │    │              ├── variable: t.public.child_diff_type.p:13 [type=int2]
-           │    │              └── variable: p_old:16 [type=int]
+           │    │    ├── fd: ()-->(13,17)
+           │    │    ├── prune: (12,13,17)
+           │    │    └── inner-join (hash)
+           │    │         ├── columns: t.public.child_diff_type.c:12(int!null) t.public.child_diff_type.p:13(int2!null) p_old:16(int!null) p_new:17(int!null)
+           │    │         ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+           │    │         ├── stats: [rows=3.3, distinct(13)=0.333333, null(13)=0, distinct(16)=0.333333, null(16)=0, distinct(17)=0.333317, null(17)=0]
+           │    │         ├── key: (12)
+           │    │         ├── fd: ()-->(13,16,17), (13)==(16), (16)==(13)
+           │    │         ├── scan t.public.child_diff_type
+           │    │         │    ├── columns: t.public.child_diff_type.c:12(int!null) t.public.child_diff_type.p:13(int2)
+           │    │         │    ├── flags: disabled not visible index feature
+           │    │         │    ├── stats: [rows=1000, distinct(12)=1000, null(12)=0, distinct(13)=100, null(13)=10]
+           │    │         │    ├── key: (12)
+           │    │         │    ├── fd: (12)-->(13)
+           │    │         │    ├── prune: (12,13)
+           │    │         │    └── unfiltered-cols: (12-15)
+           │    │         ├── select
+           │    │         │    ├── columns: p_old:16(int!null) p_new:17(int!null)
+           │    │         │    ├── cardinality: [0 - 1]
+           │    │         │    ├── stats: [rows=0.3333333, distinct(16)=0.333333, null(16)=0, distinct(17)=0.333333, null(17)=0]
+           │    │         │    ├── key: ()
+           │    │         │    ├── fd: ()-->(16,17)
+           │    │         │    ├── with-scan &1
+           │    │         │    │    ├── columns: p_old:16(int!null) p_new:17(int!null)
+           │    │         │    │    ├── mapping:
+           │    │         │    │    │    ├──  t.public.parent_diff_type.p:4(int) => p_old:16(int)
+           │    │         │    │    │    └──  p_new:7(int) => p_new:17(int)
+           │    │         │    │    ├── cardinality: [0 - 1]
+           │    │         │    │    ├── stats: [rows=1, distinct(16)=1, null(16)=0, distinct(17)=1, null(17)=0]
+           │    │         │    │    ├── key: ()
+           │    │         │    │    ├── fd: ()-->(16,17)
+           │    │         │    │    └── prune: (16,17)
+           │    │         │    └── filters
+           │    │         │         └── is-not [type=bool, outer=(16,17)]
+           │    │         │              ├── variable: p_old:16 [type=int]
+           │    │         │              └── variable: p_new:17 [type=int]
+           │    │         └── filters
+           │    │              └── eq [type=bool, outer=(13,16), constraints=(/13: (/NULL - ]; /16: (/NULL - ]), fd=(13)==(16), (16)==(13)]
+           │    │                   ├── variable: t.public.child_diff_type.p:13 [type=int2]
+           │    │                   └── variable: p_old:16 [type=int]
            │    └── projections
            │         └── assignment-cast: INT2 [as=p_cast:18, type=int2, outer=(17), immutable]
            │              └── variable: p_new:17 [type=int]
@@ -1689,23 +1731,25 @@ root
            │    └── p_cast:20 => child_diff_type.p:11
            ├── input binding: &2
            ├── project
-           │    ├── columns: p_cast:20!null c:14!null child_diff_type.p:15!null p_old:18!null p_new:19!null
-           │    ├── inner-join (hash)
-           │    │    ├── columns: c:14!null child_diff_type.p:15!null p_old:18!null p_new:19!null
-           │    │    ├── scan child_diff_type
-           │    │    │    ├── columns: c:14!null child_diff_type.p:15
-           │    │    │    └── flags: disabled not visible index feature
-           │    │    ├── select
-           │    │    │    ├── columns: p_old:18 p_new:19!null
-           │    │    │    ├── with-scan &1
-           │    │    │    │    ├── columns: p_old:18 p_new:19!null
-           │    │    │    │    └── mapping:
-           │    │    │    │         ├──  parent_diff_type.p:5 => p_old:18
-           │    │    │    │         └──  upsert_p:9 => p_new:19
-           │    │    │    └── filters
-           │    │    │         └── p_old:18 IS DISTINCT FROM p_new:19
-           │    │    └── filters
-           │    │         └── child_diff_type.p:15 = p_old:18
+           │    ├── columns: p_cast:20!null c:14!null child_diff_type.p:15!null
+           │    ├── project
+           │    │    ├── columns: c:14!null child_diff_type.p:15!null p_new:19!null
+           │    │    └── inner-join (hash)
+           │    │         ├── columns: c:14!null child_diff_type.p:15!null p_old:18!null p_new:19!null
+           │    │         ├── scan child_diff_type
+           │    │         │    ├── columns: c:14!null child_diff_type.p:15
+           │    │         │    └── flags: disabled not visible index feature
+           │    │         ├── select
+           │    │         │    ├── columns: p_old:18 p_new:19!null
+           │    │         │    ├── with-scan &1
+           │    │         │    │    ├── columns: p_old:18 p_new:19!null
+           │    │         │    │    └── mapping:
+           │    │         │    │         ├──  parent_diff_type.p:5 => p_old:18
+           │    │         │    │         └──  upsert_p:9 => p_new:19
+           │    │         │    └── filters
+           │    │         │         └── p_old:18 IS DISTINCT FROM p_new:19
+           │    │         └── filters
+           │    │              └── child_diff_type.p:15 = p_old:18
            │    └── projections
            │         └── assignment-cast: INT2 [as=p_cast:20]
            │              └── p_new:19

--- a/pkg/sql/opt/optbuilder/testdata/fk-on-update-set-default
+++ b/pkg/sql/opt/optbuilder/testdata/fk-on-update-set-default
@@ -19,7 +19,7 @@ root
  │    ├── cascades
  │    │    └── child_p_fkey
  │    └── project
- │         ├── columns: p_new:7!null p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+ │         ├── columns: p_new:7!null p:4!null
  │         ├── select
  │         │    ├── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
  │         │    ├── scan parent
@@ -36,7 +36,7 @@ root
            │    └── p_new:18 => child.p:9
            ├── input binding: &2
            ├── project
-           │    ├── columns: p_new:18!null c:12!null child.p:13!null p_old:16!null p_new:17!null
+           │    ├── columns: p_new:18!null c:12!null child.p:13!null
            │    ├── inner-join (hash)
            │    │    ├── columns: c:12!null child.p:13!null p_old:16!null p_new:17!null
            │    │    ├── scan child
@@ -104,7 +104,7 @@ root
  │    ├── cascades
  │    │    └── fk
  │    └── project
- │         ├── columns: p_new:11 q_new:12 pk:6!null p:7 q:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+ │         ├── columns: p_new:11 q_new:12 pk:6!null p:7 q:8
  │         ├── select
  │         │    ├── columns: pk:6!null p:7 q:8 crdb_internal_mvcc_timestamp:9 tableoid:10
  │         │    ├── scan parent_multi
@@ -123,7 +123,7 @@ root
            │    └── q_new:28 => child_multi.q:15
            ├── input binding: &2
            ├── project
-           │    ├── columns: p_new:27!null q_new:28!null c:18!null child_multi.p:19!null child_multi.q:20!null p_old:23!null p_new:24 q_old:25!null q_new:26
+           │    ├── columns: p_new:27!null q_new:28!null c:18!null child_multi.p:19!null child_multi.q:20!null
            │    ├── inner-join (hash)
            │    │    ├── columns: c:18!null child_multi.p:19!null child_multi.q:20!null p_old:23!null p_new:24 q_old:25!null q_new:26
            │    │    ├── scan child_multi
@@ -177,7 +177,7 @@ root
  │    ├── cascades
  │    │    └── fk
  │    └── project
- │         ├── columns: p_new:11!null pk:6!null p:7!null q:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+ │         ├── columns: p_new:11!null pk:6!null p:7!null q:8
  │         ├── select
  │         │    ├── columns: pk:6!null p:7!null q:8 crdb_internal_mvcc_timestamp:9 tableoid:10
  │         │    ├── scan parent_multi
@@ -195,7 +195,7 @@ root
            │    └── q_new:27 => child_multi.q:14
            ├── input binding: &2
            ├── project
-           │    ├── columns: p_new:26!null q_new:27!null c:17!null child_multi.p:18!null child_multi.q:19!null p_old:22!null p_new:23!null q_old:24!null q_new:25
+           │    ├── columns: p_new:26!null q_new:27!null c:17!null child_multi.p:18!null child_multi.q:19!null
            │    ├── inner-join (hash)
            │    │    ├── columns: c:17!null child_multi.p:18!null child_multi.q:19!null p_old:22!null p_new:23!null q_old:24!null q_new:25
            │    │    ├── scan child_multi
@@ -256,7 +256,7 @@ root
  │    ├── cascades
  │    │    └── fk
  │    └── project
- │         ├── columns: q_new:11 pk:6!null p:7!null q:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+ │         ├── columns: q_new:11 pk:6!null p:7!null q:8
  │         ├── select
  │         │    ├── columns: pk:6!null p:7!null q:8 crdb_internal_mvcc_timestamp:9 tableoid:10
  │         │    ├── scan parent_multi
@@ -276,7 +276,7 @@ root
       │    ├── cascades
       │    │    └── fk2
       │    ├── project
-      │    │    ├── columns: p_new:26!null q_new:27!null c:17!null child_multi.p:18!null child_multi.q:19!null p_old:22!null p_new:23!null q_old:24!null q_new:25
+      │    │    ├── columns: p_new:26!null q_new:27!null c:17!null child_multi.p:18!null child_multi.q:19!null
       │    │    ├── inner-join (hash)
       │    │    │    ├── columns: c:17!null child_multi.p:18!null child_multi.q:19!null p_old:22!null p_new:23!null q_old:24!null q_new:25
       │    │    │    ├── scan child_multi
@@ -323,7 +323,7 @@ root
                 │    └── q_new:50 => grandchild.q:37
                 ├── input binding: &3
                 ├── project
-                │    ├── columns: c_new:49!null q_new:50!null g:40!null grandchild.c:41!null grandchild.q:42!null c_old:45!null c_new:46!null q_old:47!null q_new:48!null
+                │    ├── columns: c_new:49!null q_new:50!null g:40!null grandchild.c:41!null grandchild.q:42!null
                 │    ├── inner-join (hash)
                 │    │    ├── columns: g:40!null grandchild.c:41!null grandchild.q:42!null c_old:45!null c_new:46!null q_old:47!null q_new:48!null
                 │    │    ├── scan grandchild
@@ -415,7 +415,7 @@ root
       │    ├── cascades
       │    │    └── fk2
       │    ├── project
-      │    │    ├── columns: p_new:29!null q_new:30!null c:20!null child_multi.p:21!null child_multi.q:22!null p_old:25!null p_new:26!null q_old:27!null q_new:28!null
+      │    │    ├── columns: p_new:29!null q_new:30!null c:20!null child_multi.p:21!null child_multi.q:22!null
       │    │    ├── inner-join (hash)
       │    │    │    ├── columns: c:20!null child_multi.p:21!null child_multi.q:22!null p_old:25!null p_new:26!null q_old:27!null q_new:28!null
       │    │    │    ├── scan child_multi
@@ -462,7 +462,7 @@ root
                 │    └── q_new:53 => grandchild.q:40
                 ├── input binding: &3
                 ├── project
-                │    ├── columns: c_new:52!null q_new:53!null g:43!null grandchild.c:44!null grandchild.q:45!null c_old:48!null c_new:49!null q_old:50!null q_new:51!null
+                │    ├── columns: c_new:52!null q_new:53!null g:43!null grandchild.c:44!null grandchild.q:45!null
                 │    ├── inner-join (hash)
                 │    │    ├── columns: g:43!null grandchild.c:44!null grandchild.q:45!null c_old:48!null c_new:49!null q_old:50!null q_new:51!null
                 │    │    ├── scan grandchild
@@ -559,7 +559,7 @@ root
       │    ├── cascades
       │    │    └── fk2
       │    ├── project
-      │    │    ├── columns: p_new:30!null q_new:31!null c:21!null child_multi.p:22!null child_multi.q:23!null p_old:26!null p_new:27!null q_old:28!null q_new:29
+      │    │    ├── columns: p_new:30!null q_new:31!null c:21!null child_multi.p:22!null child_multi.q:23!null
       │    │    ├── inner-join (hash)
       │    │    │    ├── columns: c:21!null child_multi.p:22!null child_multi.q:23!null p_old:26!null p_new:27!null q_old:28!null q_new:29
       │    │    │    ├── scan child_multi
@@ -606,7 +606,7 @@ root
                 │    └── q_new:54 => grandchild.q:41
                 ├── input binding: &3
                 ├── project
-                │    ├── columns: c_new:53!null q_new:54!null g:44!null grandchild.c:45!null grandchild.q:46!null c_old:49!null c_new:50!null q_old:51!null q_new:52!null
+                │    ├── columns: c_new:53!null q_new:54!null g:44!null grandchild.c:45!null grandchild.q:46!null
                 │    ├── inner-join (hash)
                 │    │    ├── columns: g:44!null grandchild.c:45!null grandchild.q:46!null c_old:49!null c_new:50!null q_old:51!null q_new:52!null
                 │    │    ├── scan grandchild
@@ -702,7 +702,7 @@ root
       │    ├── cascades
       │    │    └── fk2
       │    ├── project
-      │    │    ├── columns: p_new:32!null q_new:33!null c:23!null child_multi.p:24!null child_multi.q:25!null p_old:28!null p_new:29!null q_old:30!null q_new:31
+      │    │    ├── columns: p_new:32!null q_new:33!null c:23!null child_multi.p:24!null child_multi.q:25!null
       │    │    ├── inner-join (hash)
       │    │    │    ├── columns: c:23!null child_multi.p:24!null child_multi.q:25!null p_old:28!null p_new:29!null q_old:30!null q_new:31
       │    │    │    ├── scan child_multi
@@ -749,7 +749,7 @@ root
                 │    └── q_new:56 => grandchild.q:43
                 ├── input binding: &3
                 ├── project
-                │    ├── columns: c_new:55!null q_new:56!null g:46!null grandchild.c:47!null grandchild.q:48!null c_old:51!null c_new:52!null q_old:53!null q_new:54!null
+                │    ├── columns: c_new:55!null q_new:56!null g:46!null grandchild.c:47!null grandchild.q:48!null
                 │    ├── inner-join (hash)
                 │    │    ├── columns: g:46!null grandchild.c:47!null grandchild.q:48!null c_old:51!null c_new:52!null q_old:53!null q_new:54!null
                 │    │    ├── scan grandchild
@@ -815,7 +815,7 @@ root
  │    ├── cascades
  │    │    └── child_assn_cast_p_fkey
  │    └── project
- │         ├── columns: p_new:9!null p:5!null p2:6 crdb_internal_mvcc_timestamp:7 tableoid:8
+ │         ├── columns: p_new:9!null p:5!null p2:6
  │         ├── select
  │         │    ├── columns: p:5!null p2:6 crdb_internal_mvcc_timestamp:7 tableoid:8
  │         │    ├── scan parent_assn_cast
@@ -832,9 +832,9 @@ root
            │    └── p_cast:21 => child_assn_cast.p:11
            ├── input binding: &2
            ├── project
-           │    ├── columns: p_cast:21!null c:14!null child_assn_cast.p:15!null p_old:18!null p_new:19!null
+           │    ├── columns: p_cast:21!null c:14!null child_assn_cast.p:15!null
            │    ├── project
-           │    │    ├── columns: p_new:20!null c:14!null child_assn_cast.p:15!null p_old:18!null p_new:19!null
+           │    │    ├── columns: p_new:20!null c:14!null child_assn_cast.p:15!null
            │    │    ├── inner-join (cross)
            │    │    │    ├── columns: c:14!null child_assn_cast.p:15!null p_old:18!null p_new:19!null
            │    │    │    ├── scan child_assn_cast
@@ -922,9 +922,9 @@ root
            │    └── p2_cast:23 => child_assn_cast_p2.p2:13
            ├── input binding: &2
            ├── project
-           │    ├── columns: p2_cast:23!null c:16!null child_assn_cast_p2.p2:17!null p2_old:20!null p2_new:21!null
+           │    ├── columns: p2_cast:23!null c:16!null child_assn_cast_p2.p2:17!null
            │    ├── project
-           │    │    ├── columns: p2_new:22!null c:16!null child_assn_cast_p2.p2:17!null p2_old:20!null p2_new:21!null
+           │    │    ├── columns: p2_new:22!null c:16!null child_assn_cast_p2.p2:17!null
            │    │    ├── inner-join (cross)
            │    │    │    ├── columns: c:16!null child_assn_cast_p2.p2:17!null p2_old:20!null p2_new:21!null
            │    │    │    ├── scan child_assn_cast_p2
@@ -1010,9 +1010,9 @@ root
            │    └── p2_cast:25 => child_assn_cast_p2.p2:15
            ├── input binding: &2
            ├── project
-           │    ├── columns: p2_cast:25!null c:18!null child_assn_cast_p2.p2:19!null p2_old:22!null p2_new:23!null
+           │    ├── columns: p2_cast:25!null c:18!null child_assn_cast_p2.p2:19!null
            │    ├── project
-           │    │    ├── columns: p2_new:24!null c:18!null child_assn_cast_p2.p2:19!null p2_old:22!null p2_new:23!null
+           │    │    ├── columns: p2_new:24!null c:18!null child_assn_cast_p2.p2:19!null
            │    │    ├── inner-join (cross)
            │    │    │    ├── columns: c:18!null child_assn_cast_p2.p2:19!null p2_old:22!null p2_new:23!null
            │    │    │    ├── scan child_assn_cast_p2
@@ -1076,7 +1076,7 @@ root
  │    ├── cascades
  │    │    └── child_partial_p_fkey
  │    └── project
- │         ├── columns: p_new:7!null p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+ │         ├── columns: p_new:7!null p:4!null
  │         ├── select
  │         │    ├── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
  │         │    ├── scan parent_partial
@@ -1095,9 +1095,9 @@ root
            ├── partial index del columns: partial_index_put1:21 partial_index_del2:23
            ├── input binding: &2
            ├── project
-           │    ├── columns: partial_index_put1:21 partial_index_put2:22!null partial_index_del2:23!null c:13!null child_partial.p:14!null i:15 p_old:18!null p_new:19!null p_new:20!null
+           │    ├── columns: partial_index_put1:21 partial_index_put2:22!null partial_index_del2:23!null c:13!null child_partial.p:14!null i:15 p_new:20!null
            │    ├── project
-           │    │    ├── columns: p_new:20!null c:13!null child_partial.p:14!null i:15 p_old:18!null p_new:19!null
+           │    │    ├── columns: p_new:20!null c:13!null child_partial.p:14!null i:15
            │    │    ├── inner-join (hash)
            │    │    │    ├── columns: c:13!null child_partial.p:14!null i:15 p_old:18!null p_new:19!null
            │    │    │    ├── scan child_partial
@@ -1165,7 +1165,7 @@ root
  │    ├── cascades
  │    │    └── child_virt_p_fkey
  │    └── project
- │         ├── columns: p_new:7!null p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+ │         ├── columns: p_new:7!null p:4!null
  │         ├── select
  │         │    ├── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
  │         │    ├── scan parent_virt
@@ -1183,7 +1183,7 @@ root
            │    └── p_new:20 => v:10
            ├── input binding: &2
            ├── project
-           │    ├── columns: p_new:20!null c:13!null child_virt.p:14!null v:15!null p_old:18!null p_new:19!null
+           │    ├── columns: p_new:20!null c:13!null child_virt.p:14!null v:15!null
            │    ├── inner-join (hash)
            │    │    ├── columns: c:13!null child_virt.p:14!null v:15!null p_old:18!null p_new:19!null
            │    │    ├── project

--- a/pkg/sql/opt/optbuilder/testdata/fk-on-update-set-null
+++ b/pkg/sql/opt/optbuilder/testdata/fk-on-update-set-null
@@ -19,7 +19,7 @@ root
  │    ├── cascades
  │    │    └── child_p_fkey
  │    └── project
- │         ├── columns: p_new:7!null p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+ │         ├── columns: p_new:7!null p:4!null
  │         ├── select
  │         │    ├── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
  │         │    ├── scan parent
@@ -35,7 +35,7 @@ root
            ├── update-mapping:
            │    └── p_new:18 => child.p:9
            └── project
-                ├── columns: p_new:18 c:12!null child.p:13!null p_old:16!null p_new:17!null
+                ├── columns: p_new:18 c:12!null child.p:13!null
                 ├── inner-join (hash)
                 │    ├── columns: c:12!null child.p:13!null p_old:16!null p_new:17!null
                 │    ├── scan child
@@ -89,7 +89,7 @@ root
  │    ├── cascades
  │    │    └── fk
  │    └── project
- │         ├── columns: p_new:11 q_new:12 pk:6!null p:7 q:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+ │         ├── columns: p_new:11 q_new:12 pk:6!null p:7 q:8
  │         ├── select
  │         │    ├── columns: pk:6!null p:7 q:8 crdb_internal_mvcc_timestamp:9 tableoid:10
  │         │    ├── scan parent_multi
@@ -107,7 +107,7 @@ root
            │    ├── p_new:27 => child_multi.p:14
            │    └── p_new:27 => child_multi.q:15
            └── project
-                ├── columns: p_new:27 c:18!null child_multi.p:19!null child_multi.q:20!null p_old:23!null p_new:24 q_old:25!null q_new:26
+                ├── columns: p_new:27 c:18!null child_multi.p:19!null child_multi.q:20!null
                 ├── inner-join (hash)
                 │    ├── columns: c:18!null child_multi.p:19!null child_multi.q:20!null p_old:23!null p_new:24 q_old:25!null q_new:26
                 │    ├── scan child_multi
@@ -144,7 +144,7 @@ root
  │    ├── cascades
  │    │    └── fk
  │    └── project
- │         ├── columns: p_new:11!null pk:6!null p:7!null q:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+ │         ├── columns: p_new:11!null pk:6!null p:7!null q:8
  │         ├── select
  │         │    ├── columns: pk:6!null p:7!null q:8 crdb_internal_mvcc_timestamp:9 tableoid:10
  │         │    ├── scan parent_multi
@@ -161,7 +161,7 @@ root
            │    ├── p_new:26 => child_multi.p:13
            │    └── p_new:26 => child_multi.q:14
            └── project
-                ├── columns: p_new:26 c:17!null child_multi.p:18!null child_multi.q:19!null p_old:22!null p_new:23!null q_old:24!null q_new:25
+                ├── columns: p_new:26 c:17!null child_multi.p:18!null child_multi.q:19!null
                 ├── inner-join (hash)
                 │    ├── columns: c:17!null child_multi.p:18!null child_multi.q:19!null p_old:22!null p_new:23!null q_old:24!null q_new:25
                 │    ├── scan child_multi
@@ -206,7 +206,7 @@ root
  │    ├── cascades
  │    │    └── fk
  │    └── project
- │         ├── columns: q_new:11 pk:6!null p:7!null q:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+ │         ├── columns: q_new:11 pk:6!null p:7!null q:8
  │         ├── select
  │         │    ├── columns: pk:6!null p:7!null q:8 crdb_internal_mvcc_timestamp:9 tableoid:10
  │         │    ├── scan parent_multi
@@ -226,7 +226,7 @@ root
       │    ├── cascades
       │    │    └── fk2
       │    └── project
-      │         ├── columns: p_new:26 c:17!null child_multi.p:18!null child_multi.q:19!null p_old:22!null p_new:23!null q_old:24!null q_new:25
+      │         ├── columns: p_new:26 c:17!null child_multi.p:18!null child_multi.q:19!null
       │         ├── inner-join (hash)
       │         │    ├── columns: c:17!null child_multi.p:18!null child_multi.q:19!null p_old:22!null p_new:23!null q_old:24!null q_new:25
       │         │    ├── scan child_multi
@@ -256,7 +256,7 @@ root
                 │    ├── c_new:41 => grandchild.c:28
                 │    └── c_new:41 => grandchild.q:29
                 └── project
-                     ├── columns: c_new:41 g:32!null grandchild.c:33!null grandchild.q:34!null c_old:37!null c_new:38!null q_old:39!null q_new:40
+                     ├── columns: c_new:41 g:32!null grandchild.c:33!null grandchild.q:34!null
                      ├── inner-join (hash)
                      │    ├── columns: g:32!null grandchild.c:33!null grandchild.q:34!null c_old:37!null c_new:38!null q_old:39!null q_new:40
                      │    ├── scan grandchild
@@ -332,7 +332,7 @@ root
       │    ├── cascades
       │    │    └── fk2
       │    └── project
-      │         ├── columns: p_new:29 c:20!null child_multi.p:21!null child_multi.q:22!null p_old:25!null p_new:26!null q_old:27!null q_new:28!null
+      │         ├── columns: p_new:29 c:20!null child_multi.p:21!null child_multi.q:22!null
       │         ├── inner-join (hash)
       │         │    ├── columns: c:20!null child_multi.p:21!null child_multi.q:22!null p_old:25!null p_new:26!null q_old:27!null q_new:28!null
       │         │    ├── scan child_multi
@@ -362,7 +362,7 @@ root
                 │    ├── c_new:44 => grandchild.c:31
                 │    └── c_new:44 => grandchild.q:32
                 └── project
-                     ├── columns: c_new:44 g:35!null grandchild.c:36!null grandchild.q:37!null c_old:40!null c_new:41!null q_old:42!null q_new:43
+                     ├── columns: c_new:44 g:35!null grandchild.c:36!null grandchild.q:37!null
                      ├── inner-join (hash)
                      │    ├── columns: g:35!null grandchild.c:36!null grandchild.q:37!null c_old:40!null c_new:41!null q_old:42!null q_new:43
                      │    ├── scan grandchild
@@ -443,7 +443,7 @@ root
       │    ├── cascades
       │    │    └── fk2
       │    └── project
-      │         ├── columns: p_new:30 c:21!null child_multi.p:22!null child_multi.q:23!null p_old:26!null p_new:27!null q_old:28!null q_new:29
+      │         ├── columns: p_new:30 c:21!null child_multi.p:22!null child_multi.q:23!null
       │         ├── inner-join (hash)
       │         │    ├── columns: c:21!null child_multi.p:22!null child_multi.q:23!null p_old:26!null p_new:27!null q_old:28!null q_new:29
       │         │    ├── scan child_multi
@@ -473,7 +473,7 @@ root
                 │    ├── c_new:45 => grandchild.c:32
                 │    └── c_new:45 => grandchild.q:33
                 └── project
-                     ├── columns: c_new:45 g:36!null grandchild.c:37!null grandchild.q:38!null c_old:41!null c_new:42!null q_old:43!null q_new:44
+                     ├── columns: c_new:45 g:36!null grandchild.c:37!null grandchild.q:38!null
                      ├── inner-join (hash)
                      │    ├── columns: g:36!null grandchild.c:37!null grandchild.q:38!null c_old:41!null c_new:42!null q_old:43!null q_new:44
                      │    ├── scan grandchild
@@ -553,7 +553,7 @@ root
       │    ├── cascades
       │    │    └── fk2
       │    └── project
-      │         ├── columns: p_new:32 c:23!null child_multi.p:24!null child_multi.q:25!null p_old:28!null p_new:29!null q_old:30!null q_new:31
+      │         ├── columns: p_new:32 c:23!null child_multi.p:24!null child_multi.q:25!null
       │         ├── inner-join (hash)
       │         │    ├── columns: c:23!null child_multi.p:24!null child_multi.q:25!null p_old:28!null p_new:29!null q_old:30!null q_new:31
       │         │    ├── scan child_multi
@@ -583,7 +583,7 @@ root
                 │    ├── c_new:47 => grandchild.c:34
                 │    └── c_new:47 => grandchild.q:35
                 └── project
-                     ├── columns: c_new:47 g:38!null grandchild.c:39!null grandchild.q:40!null c_old:43!null c_new:44!null q_old:45!null q_new:46
+                     ├── columns: c_new:47 g:38!null grandchild.c:39!null grandchild.q:40!null
                      ├── inner-join (hash)
                      │    ├── columns: g:38!null grandchild.c:39!null grandchild.q:40!null c_old:43!null c_new:44!null q_old:45!null q_new:46
                      │    ├── scan grandchild
@@ -634,7 +634,7 @@ root
  │    ├── cascades
  │    │    └── child_partial_p_fkey
  │    └── project
- │         ├── columns: p_new:7!null p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+ │         ├── columns: p_new:7!null p:4!null
  │         ├── select
  │         │    ├── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
  │         │    ├── scan parent_partial
@@ -652,9 +652,9 @@ root
            ├── partial index put columns: partial_index_put1:21 partial_index_put2:22
            ├── partial index del columns: partial_index_put1:21 partial_index_del2:23
            └── project
-                ├── columns: partial_index_put1:21 partial_index_put2:22 partial_index_del2:23!null c:13!null child_partial.p:14!null i:15 p_old:18!null p_new:19!null p_new:20
+                ├── columns: partial_index_put1:21 partial_index_put2:22 partial_index_del2:23!null c:13!null child_partial.p:14!null i:15 p_new:20
                 ├── project
-                │    ├── columns: p_new:20 c:13!null child_partial.p:14!null i:15 p_old:18!null p_new:19!null
+                │    ├── columns: p_new:20 c:13!null child_partial.p:14!null i:15
                 │    ├── inner-join (hash)
                 │    │    ├── columns: c:13!null child_partial.p:14!null i:15 p_old:18!null p_new:19!null
                 │    │    ├── scan child_partial
@@ -709,7 +709,7 @@ root
  │    ├── cascades
  │    │    └── child_virt_p_fkey
  │    └── project
- │         ├── columns: p_new:7!null p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+ │         ├── columns: p_new:7!null p:4!null
  │         ├── select
  │         │    ├── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
  │         │    ├── scan parent_virt
@@ -726,7 +726,7 @@ root
            │    ├── p_new:20 => child_virt.p:9
            │    └── p_new:20 => v:10
            └── project
-                ├── columns: p_new:20 c:13!null child_virt.p:14!null v:15!null p_old:18!null p_new:19!null
+                ├── columns: p_new:20 c:13!null child_virt.p:14!null v:15!null
                 ├── inner-join (hash)
                 │    ├── columns: c:13!null child_virt.p:14!null v:15!null p_old:18!null p_new:19!null
                 │    ├── project

--- a/pkg/sql/opt/optbuilder/testdata/inverted-indexes
+++ b/pkg/sql/opt/optbuilder/testdata/inverted-indexes
@@ -158,7 +158,7 @@ update kj
  ├── update-mapping:
  │    └── j_new:11 => j:2
  └── project
-      ├── columns: j_new:11!null k:6!null j:7 crdb_internal_mvcc_timestamp:8 tableoid:9
+      ├── columns: j_new:11!null k:6!null j:7
       ├── select
       │    ├── columns: k:6!null j:7 crdb_internal_mvcc_timestamp:8 tableoid:9
       │    ├── scan kj

--- a/pkg/sql/opt/optbuilder/testdata/partial-indexes
+++ b/pkg/sql/opt/optbuilder/testdata/partial-indexes
@@ -294,9 +294,9 @@ update partial_indexes
  ├── partial index put columns: partial_index_put1:12 partial_index_put2:13 partial_index_put3:15 partial_index_put4:16
  ├── partial index del columns: partial_index_put1:12 partial_index_del2:14 partial_index_put3:15 partial_index_put4:16
  └── project
-      ├── columns: partial_index_put1:12 partial_index_put2:13 partial_index_del2:14 partial_index_put3:15 partial_index_put4:16 a:6!null b:7 c:8 crdb_internal_mvcc_timestamp:9 tableoid:10 a_new:11!null
+      ├── columns: partial_index_put1:12 partial_index_put2:13 partial_index_del2:14 partial_index_put3:15 partial_index_put4:16 a:6!null b:7 c:8 a_new:11!null
       ├── project
-      │    ├── columns: a_new:11!null a:6!null b:7 c:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+      │    ├── columns: a_new:11!null a:6!null b:7 c:8
       │    ├── scan partial_indexes
       │    │    ├── columns: a:6!null b:7 c:8 crdb_internal_mvcc_timestamp:9 tableoid:10
       │    │    └── partial index predicates
@@ -361,49 +361,50 @@ UPDATE partial_indexes SET a = v.a FROM (VALUES (1), (2)) AS v(a) WHERE partial_
 update partial_indexes
  ├── columns: <none>
  ├── fetch columns: a:6 b:7 c:8
- ├── passthrough columns: column1:11
  ├── update-mapping:
  │    └── column1:11 => a:1
  ├── partial index put columns: partial_index_put1:12 partial_index_put2:13 partial_index_put3:15 partial_index_put4:16
  ├── partial index del columns: partial_index_put1:12 partial_index_del2:14 partial_index_put3:15 partial_index_put4:16
  └── project
-      ├── columns: partial_index_put1:12 partial_index_put2:13 partial_index_del2:14 partial_index_put3:15 partial_index_put4:16 a:6!null b:7 c:8 crdb_internal_mvcc_timestamp:9 tableoid:10 column1:11!null
-      ├── distinct-on
-      │    ├── columns: a:6!null b:7 c:8 crdb_internal_mvcc_timestamp:9 tableoid:10 column1:11!null
-      │    ├── grouping columns: a:6!null
-      │    ├── select
-      │    │    ├── columns: a:6!null b:7 c:8 crdb_internal_mvcc_timestamp:9 tableoid:10 column1:11!null
-      │    │    ├── inner-join (cross)
-      │    │    │    ├── columns: a:6!null b:7 c:8 crdb_internal_mvcc_timestamp:9 tableoid:10 column1:11!null
-      │    │    │    ├── scan partial_indexes
-      │    │    │    │    ├── columns: a:6!null b:7 c:8 crdb_internal_mvcc_timestamp:9 tableoid:10
-      │    │    │    │    └── partial index predicates
-      │    │    │    │         ├── partial_indexes_b_idx1: filters
-      │    │    │    │         │    └── c:8 = 'foo'
-      │    │    │    │         ├── partial_indexes_c_idx: filters
-      │    │    │    │         │    └── (a:6 > b:7) AND (c:8 = 'bar')
-      │    │    │    │         ├── b: filters
-      │    │    │    │         │    └── c:8 = 'delete-only'
-      │    │    │    │         └── b: filters
-      │    │    │    │              └── c:8 = 'write-only'
-      │    │    │    ├── values
-      │    │    │    │    ├── columns: column1:11!null
-      │    │    │    │    ├── (1,)
-      │    │    │    │    └── (2,)
-      │    │    │    └── filters (true)
-      │    │    └── filters
-      │    │         └── a:6 = column1:11
-      │    └── aggregations
-      │         ├── first-agg [as=b:7]
-      │         │    └── b:7
-      │         ├── first-agg [as=c:8]
-      │         │    └── c:8
-      │         ├── first-agg [as=crdb_internal_mvcc_timestamp:9]
-      │         │    └── crdb_internal_mvcc_timestamp:9
-      │         ├── first-agg [as=tableoid:10]
-      │         │    └── tableoid:10
-      │         └── first-agg [as=column1:11]
-      │              └── column1:11
+      ├── columns: partial_index_put1:12 partial_index_put2:13 partial_index_del2:14 partial_index_put3:15 partial_index_put4:16 a:6!null b:7 c:8 column1:11!null
+      ├── project
+      │    ├── columns: a:6!null b:7 c:8 column1:11!null
+      │    └── distinct-on
+      │         ├── columns: a:6!null b:7 c:8 crdb_internal_mvcc_timestamp:9 tableoid:10 column1:11!null
+      │         ├── grouping columns: a:6!null
+      │         ├── select
+      │         │    ├── columns: a:6!null b:7 c:8 crdb_internal_mvcc_timestamp:9 tableoid:10 column1:11!null
+      │         │    ├── inner-join (cross)
+      │         │    │    ├── columns: a:6!null b:7 c:8 crdb_internal_mvcc_timestamp:9 tableoid:10 column1:11!null
+      │         │    │    ├── scan partial_indexes
+      │         │    │    │    ├── columns: a:6!null b:7 c:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+      │         │    │    │    └── partial index predicates
+      │         │    │    │         ├── partial_indexes_b_idx1: filters
+      │         │    │    │         │    └── c:8 = 'foo'
+      │         │    │    │         ├── partial_indexes_c_idx: filters
+      │         │    │    │         │    └── (a:6 > b:7) AND (c:8 = 'bar')
+      │         │    │    │         ├── b: filters
+      │         │    │    │         │    └── c:8 = 'delete-only'
+      │         │    │    │         └── b: filters
+      │         │    │    │              └── c:8 = 'write-only'
+      │         │    │    ├── values
+      │         │    │    │    ├── columns: column1:11!null
+      │         │    │    │    ├── (1,)
+      │         │    │    │    └── (2,)
+      │         │    │    └── filters (true)
+      │         │    └── filters
+      │         │         └── a:6 = column1:11
+      │         └── aggregations
+      │              ├── first-agg [as=b:7]
+      │              │    └── b:7
+      │              ├── first-agg [as=c:8]
+      │              │    └── c:8
+      │              ├── first-agg [as=crdb_internal_mvcc_timestamp:9]
+      │              │    └── crdb_internal_mvcc_timestamp:9
+      │              ├── first-agg [as=tableoid:10]
+      │              │    └── tableoid:10
+      │              └── first-agg [as=column1:11]
+      │                   └── column1:11
       └── projections
            ├── c:8 = 'foo' [as=partial_index_put1:12]
            ├── (column1:11 > b:7) AND (c:8 = 'bar') [as=partial_index_put2:13]
@@ -426,11 +427,11 @@ update ambig
  ├── partial index put columns: partial_index_put1:16 partial_index_put2:18 partial_index_put3:20
  ├── partial index del columns: partial_index_del1:17 partial_index_del2:19 partial_index_put3:20
  └── project
-      ├── columns: partial_index_put1:16!null partial_index_del1:17!null partial_index_put2:18!null partial_index_del2:19!null partial_index_put3:20 ambig.partial_index_put1:7!null ambig.partial_index_del1:8!null ambig.check1:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12 partial_index_put1_new:13!null partial_index_del1_new:14!null check1:15!null
+      ├── columns: partial_index_put1:16!null partial_index_del1:17!null partial_index_put2:18!null partial_index_del2:19!null partial_index_put3:20 ambig.partial_index_put1:7!null ambig.partial_index_del1:8!null ambig.check1:9 rowid:10!null partial_index_put1_new:13!null partial_index_del1_new:14!null check1:15!null
       ├── project
-      │    ├── columns: check1:15!null ambig.partial_index_put1:7!null ambig.partial_index_del1:8!null ambig.check1:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12 partial_index_put1_new:13!null partial_index_del1_new:14!null
+      │    ├── columns: check1:15!null ambig.partial_index_put1:7!null ambig.partial_index_del1:8!null ambig.check1:9 rowid:10!null partial_index_put1_new:13!null partial_index_del1_new:14!null
       │    ├── project
-      │    │    ├── columns: partial_index_put1_new:13!null partial_index_del1_new:14!null ambig.partial_index_put1:7!null ambig.partial_index_del1:8!null ambig.check1:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    │    ├── columns: partial_index_put1_new:13!null partial_index_del1_new:14!null ambig.partial_index_put1:7!null ambig.partial_index_del1:8!null ambig.check1:9 rowid:10!null
       │    │    ├── select
       │    │    │    ├── columns: ambig.partial_index_put1:7!null ambig.partial_index_del1:8!null ambig.check1:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
       │    │    │    ├── scan ambig
@@ -467,11 +468,11 @@ update comp
  ├── partial index put columns: partial_index_put1:18 partial_index_put2:19
  ├── partial index del columns: partial_index_put1:18 partial_index_put2:19
  └── project
-      ├── columns: partial_index_put1:18 partial_index_put2:19 a:8!null b:9 c:10 d:11 e:12 crdb_internal_mvcc_timestamp:13 tableoid:14 b_new:15!null d_comp:16 e_comp:17
+      ├── columns: partial_index_put1:18 partial_index_put2:19 a:8!null b:9 c:10 d:11 e:12 b_new:15!null d_comp:16 e_comp:17
       ├── project
-      │    ├── columns: d_comp:16 e_comp:17 a:8!null b:9 c:10 d:11 e:12 crdb_internal_mvcc_timestamp:13 tableoid:14 b_new:15!null
+      │    ├── columns: d_comp:16 e_comp:17 a:8!null b:9 c:10 d:11 e:12 b_new:15!null
       │    ├── project
-      │    │    ├── columns: b_new:15!null a:8!null b:9 c:10 d:11 e:12 crdb_internal_mvcc_timestamp:13 tableoid:14
+      │    │    ├── columns: b_new:15!null a:8!null b:9 c:10 d:11 e:12
       │    │    ├── project
       │    │    │    ├── columns: d:11 a:8!null b:9 c:10 e:12 crdb_internal_mvcc_timestamp:13 tableoid:14
       │    │    │    ├── scan comp
@@ -510,11 +511,11 @@ update comp
  ├── partial index put columns: partial_index_put1:18 partial_index_put2:20
  ├── partial index del columns: partial_index_del1:19 partial_index_del2:21
  └── project
-      ├── columns: partial_index_put1:18 partial_index_del1:19 partial_index_put2:20 partial_index_del2:21 a:8!null b:9 c:10 d:11 e:12 crdb_internal_mvcc_timestamp:13 tableoid:14 c_new:15!null d_comp:16 e_comp:17
+      ├── columns: partial_index_put1:18 partial_index_del1:19 partial_index_put2:20 partial_index_del2:21 a:8!null b:9 c:10 d:11 e:12 c_new:15!null d_comp:16 e_comp:17
       ├── project
-      │    ├── columns: d_comp:16 e_comp:17 a:8!null b:9 c:10 d:11 e:12 crdb_internal_mvcc_timestamp:13 tableoid:14 c_new:15!null
+      │    ├── columns: d_comp:16 e_comp:17 a:8!null b:9 c:10 d:11 e:12 c_new:15!null
       │    ├── project
-      │    │    ├── columns: c_new:15!null a:8!null b:9 c:10 d:11 e:12 crdb_internal_mvcc_timestamp:13 tableoid:14
+      │    │    ├── columns: c_new:15!null a:8!null b:9 c:10 d:11 e:12
       │    │    ├── project
       │    │    │    ├── columns: d:11 a:8!null b:9 c:10 e:12 crdb_internal_mvcc_timestamp:13 tableoid:14
       │    │    │    ├── scan comp

--- a/pkg/sql/opt/optbuilder/testdata/projection-reuse
+++ b/pkg/sql/opt/optbuilder/testdata/projection-reuse
@@ -196,7 +196,7 @@ update abcd
  │    ├── a_new:15 => a:1
  │    └── b_new:16 => b:2
  └── project
-      ├── columns: a_new:15 b_new:16 a:8!null b:9 c:10 d:11 rowid:12!null crdb_internal_mvcc_timestamp:13 tableoid:14
+      ├── columns: a_new:15 b_new:16 a:8!null b:9 c:10 d:11 rowid:12!null
       ├── select
       │    ├── columns: a:8!null b:9 c:10 d:11 rowid:12!null crdb_internal_mvcc_timestamp:13 tableoid:14
       │    ├── scan abcd

--- a/pkg/sql/opt/optbuilder/testdata/select
+++ b/pkg/sql/opt/optbuilder/testdata/select
@@ -1496,7 +1496,7 @@ update inaccessible
  ├── update-mapping:
  │    └── k_new:9 => k:1
  └── project
-      ├── columns: k_new:9!null k:5!null v:6 crdb_internal_mvcc_timestamp:7 tableoid:8
+      ├── columns: k_new:9!null k:5!null v:6
       ├── scan inaccessible
       │    └── columns: k:5!null v:6 crdb_internal_mvcc_timestamp:7 tableoid:8
       └── projections

--- a/pkg/sql/opt/optbuilder/testdata/udf
+++ b/pkg/sql/opt/optbuilder/testdata/udf
@@ -1701,7 +1701,7 @@ update abc
  ├── update-mapping:
  │    └── c_new:23 => c:3
  └── project
-      ├── columns: c_new:23!null a:6!null b:7 c:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+      ├── columns: c_new:23!null a:6!null b:7 c:8
       ├── select
       │    ├── columns: a:6!null b:7 c:8 crdb_internal_mvcc_timestamp:9 tableoid:10
       │    ├── scan abc

--- a/pkg/sql/opt/optbuilder/testdata/unique-checks-update
+++ b/pkg/sql/opt/optbuilder/testdata/unique-checks-update
@@ -21,7 +21,7 @@ update uniq
  │    └── x_new:16 => uniq.x:4
  ├── input binding: &1
  ├── project
- │    ├── columns: w_new:15!null x_new:16!null uniq.k:8!null uniq.v:9 uniq.w:10 uniq.x:11 uniq.y:12 crdb_internal_mvcc_timestamp:13 tableoid:14
+ │    ├── columns: w_new:15!null x_new:16!null uniq.k:8!null uniq.v:9 uniq.w:10 uniq.x:11 uniq.y:12
  │    ├── scan uniq
  │    │    └── columns: uniq.k:8!null uniq.v:9 uniq.w:10 uniq.x:11 uniq.y:12 crdb_internal_mvcc_timestamp:13 tableoid:14
  │    └── projections
@@ -80,7 +80,7 @@ update uniq
  │    └── x_new:16 => uniq.x:4
  ├── input binding: &1
  ├── project
- │    ├── columns: w_new:15 x_new:16!null uniq.k:8!null uniq.v:9 uniq.w:10 uniq.x:11 uniq.y:12 crdb_internal_mvcc_timestamp:13 tableoid:14
+ │    ├── columns: w_new:15 x_new:16!null uniq.k:8!null uniq.v:9 uniq.w:10 uniq.x:11 uniq.y:12
  │    ├── scan uniq
  │    │    └── columns: uniq.k:8!null uniq.v:9 uniq.w:10 uniq.x:11 uniq.y:12 crdb_internal_mvcc_timestamp:13 tableoid:14
  │    └── projections
@@ -122,7 +122,7 @@ update uniq
  │    └── x_new:17 => uniq.x:4
  ├── input binding: &1
  ├── project
- │    ├── columns: k_new:15!null w_new:16!null x_new:17 uniq.k:8!null uniq.v:9 uniq.w:10 uniq.x:11 uniq.y:12 crdb_internal_mvcc_timestamp:13 tableoid:14
+ │    ├── columns: k_new:15!null w_new:16!null x_new:17 uniq.k:8!null uniq.v:9 uniq.w:10 uniq.x:11 uniq.y:12
  │    ├── scan uniq
  │    │    └── columns: uniq.k:8!null uniq.v:9 uniq.w:10 uniq.x:11 uniq.y:12 crdb_internal_mvcc_timestamp:13 tableoid:14
  │    └── projections
@@ -162,7 +162,7 @@ update uniq
  │    └── y_new:16 => uniq.y:5
  ├── input binding: &1
  ├── project
- │    ├── columns: w_new:15!null y_new:16 uniq.k:8!null uniq.v:9 uniq.w:10 uniq.x:11 uniq.y:12 crdb_internal_mvcc_timestamp:13 tableoid:14
+ │    ├── columns: w_new:15!null y_new:16 uniq.k:8!null uniq.v:9 uniq.w:10 uniq.x:11 uniq.y:12
  │    ├── select
  │    │    ├── columns: uniq.k:8!null uniq.v:9 uniq.w:10 uniq.x:11 uniq.y:12 crdb_internal_mvcc_timestamp:13 tableoid:14
  │    │    ├── scan uniq
@@ -204,7 +204,7 @@ update uniq
  │    ├── k_new:15 => k:1
  │    └── v_new:16 => v:2
  └── project
-      ├── columns: k_new:15!null v_new:16!null k:8!null v:9 w:10 x:11 y:12 crdb_internal_mvcc_timestamp:13 tableoid:14
+      ├── columns: k_new:15!null v_new:16!null k:8!null v:9 w:10 x:11 y:12
       ├── scan uniq
       │    └── columns: k:8!null v:9 w:10 x:11 y:12 crdb_internal_mvcc_timestamp:13 tableoid:14
       └── projections
@@ -222,50 +222,51 @@ UPDATE uniq SET w = other.w, x = other.x FROM other
 update uniq
  ├── columns: <none>
  ├── fetch columns: uniq.k:8 uniq.v:9 uniq.w:10 uniq.x:11 uniq.y:12
- ├── passthrough columns: other.k:15 other.v:16 other.w:17 other.x:18 other.y:19 rowid:20 other.crdb_internal_mvcc_timestamp:21 other.tableoid:22
  ├── update-mapping:
  │    ├── other.w:17 => uniq.w:3
  │    └── other.x:18 => uniq.x:4
  ├── input binding: &1
- ├── distinct-on
- │    ├── columns: uniq.k:8!null uniq.v:9 uniq.w:10 uniq.x:11 uniq.y:12 uniq.crdb_internal_mvcc_timestamp:13 uniq.tableoid:14 other.k:15 other.v:16 other.w:17!null other.x:18 other.y:19 rowid:20!null other.crdb_internal_mvcc_timestamp:21 other.tableoid:22
- │    ├── grouping columns: uniq.k:8!null
- │    ├── inner-join (cross)
- │    │    ├── columns: uniq.k:8!null uniq.v:9 uniq.w:10 uniq.x:11 uniq.y:12 uniq.crdb_internal_mvcc_timestamp:13 uniq.tableoid:14 other.k:15 other.v:16 other.w:17!null other.x:18 other.y:19 rowid:20!null other.crdb_internal_mvcc_timestamp:21 other.tableoid:22
- │    │    ├── scan uniq
- │    │    │    └── columns: uniq.k:8!null uniq.v:9 uniq.w:10 uniq.x:11 uniq.y:12 uniq.crdb_internal_mvcc_timestamp:13 uniq.tableoid:14
- │    │    ├── scan other
- │    │    │    └── columns: other.k:15 other.v:16 other.w:17!null other.x:18 other.y:19 rowid:20!null other.crdb_internal_mvcc_timestamp:21 other.tableoid:22
- │    │    └── filters (true)
- │    └── aggregations
- │         ├── first-agg [as=uniq.v:9]
- │         │    └── uniq.v:9
- │         ├── first-agg [as=uniq.w:10]
- │         │    └── uniq.w:10
- │         ├── first-agg [as=uniq.x:11]
- │         │    └── uniq.x:11
- │         ├── first-agg [as=uniq.y:12]
- │         │    └── uniq.y:12
- │         ├── first-agg [as=uniq.crdb_internal_mvcc_timestamp:13]
- │         │    └── uniq.crdb_internal_mvcc_timestamp:13
- │         ├── first-agg [as=uniq.tableoid:14]
- │         │    └── uniq.tableoid:14
- │         ├── first-agg [as=other.k:15]
- │         │    └── other.k:15
- │         ├── first-agg [as=other.v:16]
- │         │    └── other.v:16
- │         ├── first-agg [as=other.w:17]
- │         │    └── other.w:17
- │         ├── first-agg [as=other.x:18]
- │         │    └── other.x:18
- │         ├── first-agg [as=other.y:19]
- │         │    └── other.y:19
- │         ├── first-agg [as=rowid:20]
- │         │    └── rowid:20
- │         ├── first-agg [as=other.crdb_internal_mvcc_timestamp:21]
- │         │    └── other.crdb_internal_mvcc_timestamp:21
- │         └── first-agg [as=other.tableoid:22]
- │              └── other.tableoid:22
+ ├── project
+ │    ├── columns: uniq.k:8!null uniq.v:9 uniq.w:10 uniq.x:11 uniq.y:12 other.w:17!null other.x:18
+ │    └── distinct-on
+ │         ├── columns: uniq.k:8!null uniq.v:9 uniq.w:10 uniq.x:11 uniq.y:12 uniq.crdb_internal_mvcc_timestamp:13 uniq.tableoid:14 other.k:15 other.v:16 other.w:17!null other.x:18 other.y:19 rowid:20!null other.crdb_internal_mvcc_timestamp:21 other.tableoid:22
+ │         ├── grouping columns: uniq.k:8!null
+ │         ├── inner-join (cross)
+ │         │    ├── columns: uniq.k:8!null uniq.v:9 uniq.w:10 uniq.x:11 uniq.y:12 uniq.crdb_internal_mvcc_timestamp:13 uniq.tableoid:14 other.k:15 other.v:16 other.w:17!null other.x:18 other.y:19 rowid:20!null other.crdb_internal_mvcc_timestamp:21 other.tableoid:22
+ │         │    ├── scan uniq
+ │         │    │    └── columns: uniq.k:8!null uniq.v:9 uniq.w:10 uniq.x:11 uniq.y:12 uniq.crdb_internal_mvcc_timestamp:13 uniq.tableoid:14
+ │         │    ├── scan other
+ │         │    │    └── columns: other.k:15 other.v:16 other.w:17!null other.x:18 other.y:19 rowid:20!null other.crdb_internal_mvcc_timestamp:21 other.tableoid:22
+ │         │    └── filters (true)
+ │         └── aggregations
+ │              ├── first-agg [as=uniq.v:9]
+ │              │    └── uniq.v:9
+ │              ├── first-agg [as=uniq.w:10]
+ │              │    └── uniq.w:10
+ │              ├── first-agg [as=uniq.x:11]
+ │              │    └── uniq.x:11
+ │              ├── first-agg [as=uniq.y:12]
+ │              │    └── uniq.y:12
+ │              ├── first-agg [as=uniq.crdb_internal_mvcc_timestamp:13]
+ │              │    └── uniq.crdb_internal_mvcc_timestamp:13
+ │              ├── first-agg [as=uniq.tableoid:14]
+ │              │    └── uniq.tableoid:14
+ │              ├── first-agg [as=other.k:15]
+ │              │    └── other.k:15
+ │              ├── first-agg [as=other.v:16]
+ │              │    └── other.v:16
+ │              ├── first-agg [as=other.w:17]
+ │              │    └── other.w:17
+ │              ├── first-agg [as=other.x:18]
+ │              │    └── other.x:18
+ │              ├── first-agg [as=other.y:19]
+ │              │    └── other.y:19
+ │              ├── first-agg [as=rowid:20]
+ │              │    └── rowid:20
+ │              ├── first-agg [as=other.crdb_internal_mvcc_timestamp:21]
+ │              │    └── other.crdb_internal_mvcc_timestamp:21
+ │              └── first-agg [as=other.tableoid:22]
+ │                   └── other.tableoid:22
  └── unique-checks
       ├── unique-checks-item: uniq(w)
       │    └── project
@@ -337,7 +338,7 @@ update uniq_overlaps_pk
  │    └── d_new:16 => uniq_overlaps_pk.d:4
  ├── input binding: &1
  ├── project
- │    ├── columns: a_new:13!null b_new:14!null c_new:15!null d_new:16!null uniq_overlaps_pk.a:7!null uniq_overlaps_pk.b:8!null uniq_overlaps_pk.c:9 uniq_overlaps_pk.d:10 crdb_internal_mvcc_timestamp:11 tableoid:12
+ │    ├── columns: a_new:13!null b_new:14!null c_new:15!null d_new:16!null uniq_overlaps_pk.a:7!null uniq_overlaps_pk.b:8!null uniq_overlaps_pk.c:9 uniq_overlaps_pk.d:10
  │    ├── select
  │    │    ├── columns: uniq_overlaps_pk.a:7!null uniq_overlaps_pk.b:8!null uniq_overlaps_pk.c:9 uniq_overlaps_pk.d:10 crdb_internal_mvcc_timestamp:11 tableoid:12
  │    │    ├── scan uniq_overlaps_pk
@@ -417,46 +418,47 @@ UPDATE uniq_overlaps_pk SET a = k, d = v FROM other
 update uniq_overlaps_pk
  ├── columns: <none>
  ├── fetch columns: uniq_overlaps_pk.a:7 uniq_overlaps_pk.b:8 uniq_overlaps_pk.c:9 uniq_overlaps_pk.d:10
- ├── passthrough columns: k:13 v:14 w:15 x:16 y:17 rowid:18 other.crdb_internal_mvcc_timestamp:19 other.tableoid:20
  ├── update-mapping:
  │    ├── k:13 => uniq_overlaps_pk.a:1
  │    └── v:14 => uniq_overlaps_pk.d:4
  ├── input binding: &1
- ├── distinct-on
- │    ├── columns: uniq_overlaps_pk.a:7!null uniq_overlaps_pk.b:8!null uniq_overlaps_pk.c:9 uniq_overlaps_pk.d:10 uniq_overlaps_pk.crdb_internal_mvcc_timestamp:11 uniq_overlaps_pk.tableoid:12 k:13 v:14 w:15!null x:16 y:17 rowid:18!null other.crdb_internal_mvcc_timestamp:19 other.tableoid:20
- │    ├── grouping columns: uniq_overlaps_pk.a:7!null uniq_overlaps_pk.b:8!null
- │    ├── inner-join (cross)
- │    │    ├── columns: uniq_overlaps_pk.a:7!null uniq_overlaps_pk.b:8!null uniq_overlaps_pk.c:9 uniq_overlaps_pk.d:10 uniq_overlaps_pk.crdb_internal_mvcc_timestamp:11 uniq_overlaps_pk.tableoid:12 k:13 v:14 w:15!null x:16 y:17 rowid:18!null other.crdb_internal_mvcc_timestamp:19 other.tableoid:20
- │    │    ├── scan uniq_overlaps_pk
- │    │    │    └── columns: uniq_overlaps_pk.a:7!null uniq_overlaps_pk.b:8!null uniq_overlaps_pk.c:9 uniq_overlaps_pk.d:10 uniq_overlaps_pk.crdb_internal_mvcc_timestamp:11 uniq_overlaps_pk.tableoid:12
- │    │    ├── scan other
- │    │    │    └── columns: k:13 v:14 w:15!null x:16 y:17 rowid:18!null other.crdb_internal_mvcc_timestamp:19 other.tableoid:20
- │    │    └── filters (true)
- │    └── aggregations
- │         ├── first-agg [as=uniq_overlaps_pk.c:9]
- │         │    └── uniq_overlaps_pk.c:9
- │         ├── first-agg [as=uniq_overlaps_pk.d:10]
- │         │    └── uniq_overlaps_pk.d:10
- │         ├── first-agg [as=uniq_overlaps_pk.crdb_internal_mvcc_timestamp:11]
- │         │    └── uniq_overlaps_pk.crdb_internal_mvcc_timestamp:11
- │         ├── first-agg [as=uniq_overlaps_pk.tableoid:12]
- │         │    └── uniq_overlaps_pk.tableoid:12
- │         ├── first-agg [as=k:13]
- │         │    └── k:13
- │         ├── first-agg [as=v:14]
- │         │    └── v:14
- │         ├── first-agg [as=w:15]
- │         │    └── w:15
- │         ├── first-agg [as=x:16]
- │         │    └── x:16
- │         ├── first-agg [as=y:17]
- │         │    └── y:17
- │         ├── first-agg [as=rowid:18]
- │         │    └── rowid:18
- │         ├── first-agg [as=other.crdb_internal_mvcc_timestamp:19]
- │         │    └── other.crdb_internal_mvcc_timestamp:19
- │         └── first-agg [as=other.tableoid:20]
- │              └── other.tableoid:20
+ ├── project
+ │    ├── columns: uniq_overlaps_pk.a:7!null uniq_overlaps_pk.b:8!null uniq_overlaps_pk.c:9 uniq_overlaps_pk.d:10 k:13 v:14
+ │    └── distinct-on
+ │         ├── columns: uniq_overlaps_pk.a:7!null uniq_overlaps_pk.b:8!null uniq_overlaps_pk.c:9 uniq_overlaps_pk.d:10 uniq_overlaps_pk.crdb_internal_mvcc_timestamp:11 uniq_overlaps_pk.tableoid:12 k:13 v:14 w:15!null x:16 y:17 rowid:18!null other.crdb_internal_mvcc_timestamp:19 other.tableoid:20
+ │         ├── grouping columns: uniq_overlaps_pk.a:7!null uniq_overlaps_pk.b:8!null
+ │         ├── inner-join (cross)
+ │         │    ├── columns: uniq_overlaps_pk.a:7!null uniq_overlaps_pk.b:8!null uniq_overlaps_pk.c:9 uniq_overlaps_pk.d:10 uniq_overlaps_pk.crdb_internal_mvcc_timestamp:11 uniq_overlaps_pk.tableoid:12 k:13 v:14 w:15!null x:16 y:17 rowid:18!null other.crdb_internal_mvcc_timestamp:19 other.tableoid:20
+ │         │    ├── scan uniq_overlaps_pk
+ │         │    │    └── columns: uniq_overlaps_pk.a:7!null uniq_overlaps_pk.b:8!null uniq_overlaps_pk.c:9 uniq_overlaps_pk.d:10 uniq_overlaps_pk.crdb_internal_mvcc_timestamp:11 uniq_overlaps_pk.tableoid:12
+ │         │    ├── scan other
+ │         │    │    └── columns: k:13 v:14 w:15!null x:16 y:17 rowid:18!null other.crdb_internal_mvcc_timestamp:19 other.tableoid:20
+ │         │    └── filters (true)
+ │         └── aggregations
+ │              ├── first-agg [as=uniq_overlaps_pk.c:9]
+ │              │    └── uniq_overlaps_pk.c:9
+ │              ├── first-agg [as=uniq_overlaps_pk.d:10]
+ │              │    └── uniq_overlaps_pk.d:10
+ │              ├── first-agg [as=uniq_overlaps_pk.crdb_internal_mvcc_timestamp:11]
+ │              │    └── uniq_overlaps_pk.crdb_internal_mvcc_timestamp:11
+ │              ├── first-agg [as=uniq_overlaps_pk.tableoid:12]
+ │              │    └── uniq_overlaps_pk.tableoid:12
+ │              ├── first-agg [as=k:13]
+ │              │    └── k:13
+ │              ├── first-agg [as=v:14]
+ │              │    └── v:14
+ │              ├── first-agg [as=w:15]
+ │              │    └── w:15
+ │              ├── first-agg [as=x:16]
+ │              │    └── x:16
+ │              ├── first-agg [as=y:17]
+ │              │    └── y:17
+ │              ├── first-agg [as=rowid:18]
+ │              │    └── rowid:18
+ │              ├── first-agg [as=other.crdb_internal_mvcc_timestamp:19]
+ │              │    └── other.crdb_internal_mvcc_timestamp:19
+ │              └── first-agg [as=other.tableoid:20]
+ │                   └── other.tableoid:20
  └── unique-checks
       ├── unique-checks-item: uniq_overlaps_pk(a)
       │    └── project
@@ -521,7 +523,7 @@ update uniq_hidden_pk
  │    └── a_new:15 => uniq_hidden_pk.a:1
  ├── input binding: &1
  ├── project
- │    ├── columns: a_new:15!null uniq_hidden_pk.a:8 uniq_hidden_pk.b:9 uniq_hidden_pk.c:10 uniq_hidden_pk.d:11 uniq_hidden_pk.rowid:12!null crdb_internal_mvcc_timestamp:13 tableoid:14
+ │    ├── columns: a_new:15!null uniq_hidden_pk.a:8 uniq_hidden_pk.b:9 uniq_hidden_pk.c:10 uniq_hidden_pk.d:11 uniq_hidden_pk.rowid:12!null
  │    ├── scan uniq_hidden_pk
  │    │    └── columns: uniq_hidden_pk.a:8 uniq_hidden_pk.b:9 uniq_hidden_pk.c:10 uniq_hidden_pk.d:11 uniq_hidden_pk.rowid:12!null crdb_internal_mvcc_timestamp:13 tableoid:14
  │    └── projections
@@ -577,49 +579,50 @@ UPDATE uniq_hidden_pk SET a = k FROM other
 update uniq_hidden_pk
  ├── columns: <none>
  ├── fetch columns: uniq_hidden_pk.a:8 uniq_hidden_pk.b:9 uniq_hidden_pk.c:10 uniq_hidden_pk.d:11 uniq_hidden_pk.rowid:12
- ├── passthrough columns: k:15 v:16 w:17 x:18 y:19 other.rowid:20 other.crdb_internal_mvcc_timestamp:21 other.tableoid:22
  ├── update-mapping:
  │    └── k:15 => uniq_hidden_pk.a:1
  ├── input binding: &1
- ├── distinct-on
- │    ├── columns: uniq_hidden_pk.a:8 uniq_hidden_pk.b:9 uniq_hidden_pk.c:10 uniq_hidden_pk.d:11 uniq_hidden_pk.rowid:12!null uniq_hidden_pk.crdb_internal_mvcc_timestamp:13 uniq_hidden_pk.tableoid:14 k:15 v:16 w:17!null x:18 y:19 other.rowid:20!null other.crdb_internal_mvcc_timestamp:21 other.tableoid:22
- │    ├── grouping columns: uniq_hidden_pk.rowid:12!null
- │    ├── inner-join (cross)
- │    │    ├── columns: uniq_hidden_pk.a:8 uniq_hidden_pk.b:9 uniq_hidden_pk.c:10 uniq_hidden_pk.d:11 uniq_hidden_pk.rowid:12!null uniq_hidden_pk.crdb_internal_mvcc_timestamp:13 uniq_hidden_pk.tableoid:14 k:15 v:16 w:17!null x:18 y:19 other.rowid:20!null other.crdb_internal_mvcc_timestamp:21 other.tableoid:22
- │    │    ├── scan uniq_hidden_pk
- │    │    │    └── columns: uniq_hidden_pk.a:8 uniq_hidden_pk.b:9 uniq_hidden_pk.c:10 uniq_hidden_pk.d:11 uniq_hidden_pk.rowid:12!null uniq_hidden_pk.crdb_internal_mvcc_timestamp:13 uniq_hidden_pk.tableoid:14
- │    │    ├── scan other
- │    │    │    └── columns: k:15 v:16 w:17!null x:18 y:19 other.rowid:20!null other.crdb_internal_mvcc_timestamp:21 other.tableoid:22
- │    │    └── filters (true)
- │    └── aggregations
- │         ├── first-agg [as=uniq_hidden_pk.a:8]
- │         │    └── uniq_hidden_pk.a:8
- │         ├── first-agg [as=uniq_hidden_pk.b:9]
- │         │    └── uniq_hidden_pk.b:9
- │         ├── first-agg [as=uniq_hidden_pk.c:10]
- │         │    └── uniq_hidden_pk.c:10
- │         ├── first-agg [as=uniq_hidden_pk.d:11]
- │         │    └── uniq_hidden_pk.d:11
- │         ├── first-agg [as=uniq_hidden_pk.crdb_internal_mvcc_timestamp:13]
- │         │    └── uniq_hidden_pk.crdb_internal_mvcc_timestamp:13
- │         ├── first-agg [as=uniq_hidden_pk.tableoid:14]
- │         │    └── uniq_hidden_pk.tableoid:14
- │         ├── first-agg [as=k:15]
- │         │    └── k:15
- │         ├── first-agg [as=v:16]
- │         │    └── v:16
- │         ├── first-agg [as=w:17]
- │         │    └── w:17
- │         ├── first-agg [as=x:18]
- │         │    └── x:18
- │         ├── first-agg [as=y:19]
- │         │    └── y:19
- │         ├── first-agg [as=other.rowid:20]
- │         │    └── other.rowid:20
- │         ├── first-agg [as=other.crdb_internal_mvcc_timestamp:21]
- │         │    └── other.crdb_internal_mvcc_timestamp:21
- │         └── first-agg [as=other.tableoid:22]
- │              └── other.tableoid:22
+ ├── project
+ │    ├── columns: uniq_hidden_pk.a:8 uniq_hidden_pk.b:9 uniq_hidden_pk.c:10 uniq_hidden_pk.d:11 uniq_hidden_pk.rowid:12!null k:15
+ │    └── distinct-on
+ │         ├── columns: uniq_hidden_pk.a:8 uniq_hidden_pk.b:9 uniq_hidden_pk.c:10 uniq_hidden_pk.d:11 uniq_hidden_pk.rowid:12!null uniq_hidden_pk.crdb_internal_mvcc_timestamp:13 uniq_hidden_pk.tableoid:14 k:15 v:16 w:17!null x:18 y:19 other.rowid:20!null other.crdb_internal_mvcc_timestamp:21 other.tableoid:22
+ │         ├── grouping columns: uniq_hidden_pk.rowid:12!null
+ │         ├── inner-join (cross)
+ │         │    ├── columns: uniq_hidden_pk.a:8 uniq_hidden_pk.b:9 uniq_hidden_pk.c:10 uniq_hidden_pk.d:11 uniq_hidden_pk.rowid:12!null uniq_hidden_pk.crdb_internal_mvcc_timestamp:13 uniq_hidden_pk.tableoid:14 k:15 v:16 w:17!null x:18 y:19 other.rowid:20!null other.crdb_internal_mvcc_timestamp:21 other.tableoid:22
+ │         │    ├── scan uniq_hidden_pk
+ │         │    │    └── columns: uniq_hidden_pk.a:8 uniq_hidden_pk.b:9 uniq_hidden_pk.c:10 uniq_hidden_pk.d:11 uniq_hidden_pk.rowid:12!null uniq_hidden_pk.crdb_internal_mvcc_timestamp:13 uniq_hidden_pk.tableoid:14
+ │         │    ├── scan other
+ │         │    │    └── columns: k:15 v:16 w:17!null x:18 y:19 other.rowid:20!null other.crdb_internal_mvcc_timestamp:21 other.tableoid:22
+ │         │    └── filters (true)
+ │         └── aggregations
+ │              ├── first-agg [as=uniq_hidden_pk.a:8]
+ │              │    └── uniq_hidden_pk.a:8
+ │              ├── first-agg [as=uniq_hidden_pk.b:9]
+ │              │    └── uniq_hidden_pk.b:9
+ │              ├── first-agg [as=uniq_hidden_pk.c:10]
+ │              │    └── uniq_hidden_pk.c:10
+ │              ├── first-agg [as=uniq_hidden_pk.d:11]
+ │              │    └── uniq_hidden_pk.d:11
+ │              ├── first-agg [as=uniq_hidden_pk.crdb_internal_mvcc_timestamp:13]
+ │              │    └── uniq_hidden_pk.crdb_internal_mvcc_timestamp:13
+ │              ├── first-agg [as=uniq_hidden_pk.tableoid:14]
+ │              │    └── uniq_hidden_pk.tableoid:14
+ │              ├── first-agg [as=k:15]
+ │              │    └── k:15
+ │              ├── first-agg [as=v:16]
+ │              │    └── v:16
+ │              ├── first-agg [as=w:17]
+ │              │    └── w:17
+ │              ├── first-agg [as=x:18]
+ │              │    └── x:18
+ │              ├── first-agg [as=y:19]
+ │              │    └── y:19
+ │              ├── first-agg [as=other.rowid:20]
+ │              │    └── other.rowid:20
+ │              ├── first-agg [as=other.crdb_internal_mvcc_timestamp:21]
+ │              │    └── other.crdb_internal_mvcc_timestamp:21
+ │              └── first-agg [as=other.tableoid:22]
+ │                   └── other.tableoid:22
  └── unique-checks
       ├── unique-checks-item: uniq_hidden_pk(a,b,d)
       │    └── project
@@ -683,7 +686,7 @@ update uniq_partial
  │    └── a_new:13 => uniq_partial.a:2
  ├── input binding: &1
  ├── project
- │    ├── columns: a_new:13!null uniq_partial.k:7!null uniq_partial.a:8 uniq_partial.b:9 uniq_partial.c:10 crdb_internal_mvcc_timestamp:11 tableoid:12
+ │    ├── columns: a_new:13!null uniq_partial.k:7!null uniq_partial.a:8 uniq_partial.b:9 uniq_partial.c:10
  │    ├── scan uniq_partial
  │    │    └── columns: uniq_partial.k:7!null uniq_partial.a:8 uniq_partial.b:9 uniq_partial.c:10 crdb_internal_mvcc_timestamp:11 tableoid:12
  │    └── projections
@@ -721,7 +724,7 @@ update uniq_partial
  │    └── b_new:13 => uniq_partial.b:3
  ├── input binding: &1
  ├── project
- │    ├── columns: b_new:13!null uniq_partial.k:7!null uniq_partial.a:8 uniq_partial.b:9 uniq_partial.c:10 crdb_internal_mvcc_timestamp:11 tableoid:12
+ │    ├── columns: b_new:13!null uniq_partial.k:7!null uniq_partial.a:8 uniq_partial.b:9 uniq_partial.c:10
  │    ├── scan uniq_partial
  │    │    └── columns: uniq_partial.k:7!null uniq_partial.a:8 uniq_partial.b:9 uniq_partial.c:10 crdb_internal_mvcc_timestamp:11 tableoid:12
  │    └── projections
@@ -759,7 +762,7 @@ update uniq_partial
  │    ├── a_new:13 => a:2
  │    └── b_new:14 => b:3
  └── project
-      ├── columns: a_new:13 b_new:14!null k:7!null a:8 b:9 c:10 crdb_internal_mvcc_timestamp:11 tableoid:12
+      ├── columns: a_new:13 b_new:14!null k:7!null a:8 b:9 c:10
       ├── scan uniq_partial
       │    └── columns: k:7!null a:8 b:9 c:10 crdb_internal_mvcc_timestamp:11 tableoid:12
       └── projections
@@ -779,7 +782,7 @@ update uniq_partial
  │    ├── a_new:14 => a:2
  │    └── k_new:13 => b:3
  └── project
-      ├── columns: k_new:13!null a_new:14 k:7!null a:8 b:9 c:10 crdb_internal_mvcc_timestamp:11 tableoid:12
+      ├── columns: k_new:13!null a_new:14 k:7!null a:8 b:9 c:10
       ├── scan uniq_partial
       │    └── columns: k:7!null a:8 b:9 c:10 crdb_internal_mvcc_timestamp:11 tableoid:12
       └── projections
@@ -797,7 +800,7 @@ update uniq_partial
  ├── update-mapping:
  │    └── c_new:13 => c:4
  └── project
-      ├── columns: c_new:13!null k:7!null a:8 b:9 c:10 crdb_internal_mvcc_timestamp:11 tableoid:12
+      ├── columns: c_new:13!null k:7!null a:8 b:9 c:10
       ├── scan uniq_partial
       │    └── columns: k:7!null a:8 b:9 c:10 crdb_internal_mvcc_timestamp:11 tableoid:12
       └── projections
@@ -810,48 +813,49 @@ UPDATE uniq_partial SET a = other.w, b = other.x FROM other
 update uniq_partial
  ├── columns: <none>
  ├── fetch columns: uniq_partial.k:7 uniq_partial.a:8 uniq_partial.b:9 uniq_partial.c:10
- ├── passthrough columns: other.k:13 v:14 w:15 x:16 y:17 rowid:18 other.crdb_internal_mvcc_timestamp:19 other.tableoid:20
  ├── update-mapping:
  │    ├── w:15 => uniq_partial.a:2
  │    └── x:16 => uniq_partial.b:3
  ├── input binding: &1
- ├── distinct-on
- │    ├── columns: uniq_partial.k:7!null uniq_partial.a:8 uniq_partial.b:9 uniq_partial.c:10 uniq_partial.crdb_internal_mvcc_timestamp:11 uniq_partial.tableoid:12 other.k:13 v:14 w:15!null x:16 y:17 rowid:18!null other.crdb_internal_mvcc_timestamp:19 other.tableoid:20
- │    ├── grouping columns: uniq_partial.k:7!null
- │    ├── inner-join (cross)
- │    │    ├── columns: uniq_partial.k:7!null uniq_partial.a:8 uniq_partial.b:9 uniq_partial.c:10 uniq_partial.crdb_internal_mvcc_timestamp:11 uniq_partial.tableoid:12 other.k:13 v:14 w:15!null x:16 y:17 rowid:18!null other.crdb_internal_mvcc_timestamp:19 other.tableoid:20
- │    │    ├── scan uniq_partial
- │    │    │    └── columns: uniq_partial.k:7!null uniq_partial.a:8 uniq_partial.b:9 uniq_partial.c:10 uniq_partial.crdb_internal_mvcc_timestamp:11 uniq_partial.tableoid:12
- │    │    ├── scan other
- │    │    │    └── columns: other.k:13 v:14 w:15!null x:16 y:17 rowid:18!null other.crdb_internal_mvcc_timestamp:19 other.tableoid:20
- │    │    └── filters (true)
- │    └── aggregations
- │         ├── first-agg [as=uniq_partial.a:8]
- │         │    └── uniq_partial.a:8
- │         ├── first-agg [as=uniq_partial.b:9]
- │         │    └── uniq_partial.b:9
- │         ├── first-agg [as=uniq_partial.c:10]
- │         │    └── uniq_partial.c:10
- │         ├── first-agg [as=uniq_partial.crdb_internal_mvcc_timestamp:11]
- │         │    └── uniq_partial.crdb_internal_mvcc_timestamp:11
- │         ├── first-agg [as=uniq_partial.tableoid:12]
- │         │    └── uniq_partial.tableoid:12
- │         ├── first-agg [as=other.k:13]
- │         │    └── other.k:13
- │         ├── first-agg [as=v:14]
- │         │    └── v:14
- │         ├── first-agg [as=w:15]
- │         │    └── w:15
- │         ├── first-agg [as=x:16]
- │         │    └── x:16
- │         ├── first-agg [as=y:17]
- │         │    └── y:17
- │         ├── first-agg [as=rowid:18]
- │         │    └── rowid:18
- │         ├── first-agg [as=other.crdb_internal_mvcc_timestamp:19]
- │         │    └── other.crdb_internal_mvcc_timestamp:19
- │         └── first-agg [as=other.tableoid:20]
- │              └── other.tableoid:20
+ ├── project
+ │    ├── columns: uniq_partial.k:7!null uniq_partial.a:8 uniq_partial.b:9 uniq_partial.c:10 w:15!null x:16
+ │    └── distinct-on
+ │         ├── columns: uniq_partial.k:7!null uniq_partial.a:8 uniq_partial.b:9 uniq_partial.c:10 uniq_partial.crdb_internal_mvcc_timestamp:11 uniq_partial.tableoid:12 other.k:13 v:14 w:15!null x:16 y:17 rowid:18!null other.crdb_internal_mvcc_timestamp:19 other.tableoid:20
+ │         ├── grouping columns: uniq_partial.k:7!null
+ │         ├── inner-join (cross)
+ │         │    ├── columns: uniq_partial.k:7!null uniq_partial.a:8 uniq_partial.b:9 uniq_partial.c:10 uniq_partial.crdb_internal_mvcc_timestamp:11 uniq_partial.tableoid:12 other.k:13 v:14 w:15!null x:16 y:17 rowid:18!null other.crdb_internal_mvcc_timestamp:19 other.tableoid:20
+ │         │    ├── scan uniq_partial
+ │         │    │    └── columns: uniq_partial.k:7!null uniq_partial.a:8 uniq_partial.b:9 uniq_partial.c:10 uniq_partial.crdb_internal_mvcc_timestamp:11 uniq_partial.tableoid:12
+ │         │    ├── scan other
+ │         │    │    └── columns: other.k:13 v:14 w:15!null x:16 y:17 rowid:18!null other.crdb_internal_mvcc_timestamp:19 other.tableoid:20
+ │         │    └── filters (true)
+ │         └── aggregations
+ │              ├── first-agg [as=uniq_partial.a:8]
+ │              │    └── uniq_partial.a:8
+ │              ├── first-agg [as=uniq_partial.b:9]
+ │              │    └── uniq_partial.b:9
+ │              ├── first-agg [as=uniq_partial.c:10]
+ │              │    └── uniq_partial.c:10
+ │              ├── first-agg [as=uniq_partial.crdb_internal_mvcc_timestamp:11]
+ │              │    └── uniq_partial.crdb_internal_mvcc_timestamp:11
+ │              ├── first-agg [as=uniq_partial.tableoid:12]
+ │              │    └── uniq_partial.tableoid:12
+ │              ├── first-agg [as=other.k:13]
+ │              │    └── other.k:13
+ │              ├── first-agg [as=v:14]
+ │              │    └── v:14
+ │              ├── first-agg [as=w:15]
+ │              │    └── w:15
+ │              ├── first-agg [as=x:16]
+ │              │    └── x:16
+ │              ├── first-agg [as=y:17]
+ │              │    └── y:17
+ │              ├── first-agg [as=rowid:18]
+ │              │    └── rowid:18
+ │              ├── first-agg [as=other.crdb_internal_mvcc_timestamp:19]
+ │              │    └── other.crdb_internal_mvcc_timestamp:19
+ │              └── first-agg [as=other.tableoid:20]
+ │                   └── other.tableoid:20
  └── unique-checks
       └── unique-checks-item: uniq_partial(a)
            └── project
@@ -907,7 +911,7 @@ update uniq_partial_overlaps_pk
  │    └── d_new:16 => uniq_partial_overlaps_pk.d:4
  ├── input binding: &1
  ├── project
- │    ├── columns: a_new:13!null b_new:14!null c_new:15!null d_new:16!null uniq_partial_overlaps_pk.a:7!null uniq_partial_overlaps_pk.b:8!null uniq_partial_overlaps_pk.c:9 uniq_partial_overlaps_pk.d:10 crdb_internal_mvcc_timestamp:11 tableoid:12
+ │    ├── columns: a_new:13!null b_new:14!null c_new:15!null d_new:16!null uniq_partial_overlaps_pk.a:7!null uniq_partial_overlaps_pk.b:8!null uniq_partial_overlaps_pk.c:9 uniq_partial_overlaps_pk.d:10
  │    ├── select
  │    │    ├── columns: uniq_partial_overlaps_pk.a:7!null uniq_partial_overlaps_pk.b:8!null uniq_partial_overlaps_pk.c:9 uniq_partial_overlaps_pk.d:10 crdb_internal_mvcc_timestamp:11 tableoid:12
  │    │    ├── scan uniq_partial_overlaps_pk
@@ -994,45 +998,46 @@ UPDATE uniq_partial_overlaps_pk SET a = k FROM other
 update uniq_partial_overlaps_pk
  ├── columns: <none>
  ├── fetch columns: uniq_partial_overlaps_pk.a:7 uniq_partial_overlaps_pk.b:8 uniq_partial_overlaps_pk.c:9 uniq_partial_overlaps_pk.d:10
- ├── passthrough columns: k:13 v:14 w:15 x:16 y:17 rowid:18 other.crdb_internal_mvcc_timestamp:19 other.tableoid:20
  ├── update-mapping:
  │    └── k:13 => uniq_partial_overlaps_pk.a:1
  ├── input binding: &1
- ├── distinct-on
- │    ├── columns: uniq_partial_overlaps_pk.a:7!null uniq_partial_overlaps_pk.b:8!null uniq_partial_overlaps_pk.c:9 uniq_partial_overlaps_pk.d:10 uniq_partial_overlaps_pk.crdb_internal_mvcc_timestamp:11 uniq_partial_overlaps_pk.tableoid:12 k:13 v:14 w:15!null x:16 y:17 rowid:18!null other.crdb_internal_mvcc_timestamp:19 other.tableoid:20
- │    ├── grouping columns: uniq_partial_overlaps_pk.a:7!null uniq_partial_overlaps_pk.b:8!null
- │    ├── inner-join (cross)
- │    │    ├── columns: uniq_partial_overlaps_pk.a:7!null uniq_partial_overlaps_pk.b:8!null uniq_partial_overlaps_pk.c:9 uniq_partial_overlaps_pk.d:10 uniq_partial_overlaps_pk.crdb_internal_mvcc_timestamp:11 uniq_partial_overlaps_pk.tableoid:12 k:13 v:14 w:15!null x:16 y:17 rowid:18!null other.crdb_internal_mvcc_timestamp:19 other.tableoid:20
- │    │    ├── scan uniq_partial_overlaps_pk
- │    │    │    └── columns: uniq_partial_overlaps_pk.a:7!null uniq_partial_overlaps_pk.b:8!null uniq_partial_overlaps_pk.c:9 uniq_partial_overlaps_pk.d:10 uniq_partial_overlaps_pk.crdb_internal_mvcc_timestamp:11 uniq_partial_overlaps_pk.tableoid:12
- │    │    ├── scan other
- │    │    │    └── columns: k:13 v:14 w:15!null x:16 y:17 rowid:18!null other.crdb_internal_mvcc_timestamp:19 other.tableoid:20
- │    │    └── filters (true)
- │    └── aggregations
- │         ├── first-agg [as=uniq_partial_overlaps_pk.c:9]
- │         │    └── uniq_partial_overlaps_pk.c:9
- │         ├── first-agg [as=uniq_partial_overlaps_pk.d:10]
- │         │    └── uniq_partial_overlaps_pk.d:10
- │         ├── first-agg [as=uniq_partial_overlaps_pk.crdb_internal_mvcc_timestamp:11]
- │         │    └── uniq_partial_overlaps_pk.crdb_internal_mvcc_timestamp:11
- │         ├── first-agg [as=uniq_partial_overlaps_pk.tableoid:12]
- │         │    └── uniq_partial_overlaps_pk.tableoid:12
- │         ├── first-agg [as=k:13]
- │         │    └── k:13
- │         ├── first-agg [as=v:14]
- │         │    └── v:14
- │         ├── first-agg [as=w:15]
- │         │    └── w:15
- │         ├── first-agg [as=x:16]
- │         │    └── x:16
- │         ├── first-agg [as=y:17]
- │         │    └── y:17
- │         ├── first-agg [as=rowid:18]
- │         │    └── rowid:18
- │         ├── first-agg [as=other.crdb_internal_mvcc_timestamp:19]
- │         │    └── other.crdb_internal_mvcc_timestamp:19
- │         └── first-agg [as=other.tableoid:20]
- │              └── other.tableoid:20
+ ├── project
+ │    ├── columns: uniq_partial_overlaps_pk.a:7!null uniq_partial_overlaps_pk.b:8!null uniq_partial_overlaps_pk.c:9 uniq_partial_overlaps_pk.d:10 k:13
+ │    └── distinct-on
+ │         ├── columns: uniq_partial_overlaps_pk.a:7!null uniq_partial_overlaps_pk.b:8!null uniq_partial_overlaps_pk.c:9 uniq_partial_overlaps_pk.d:10 uniq_partial_overlaps_pk.crdb_internal_mvcc_timestamp:11 uniq_partial_overlaps_pk.tableoid:12 k:13 v:14 w:15!null x:16 y:17 rowid:18!null other.crdb_internal_mvcc_timestamp:19 other.tableoid:20
+ │         ├── grouping columns: uniq_partial_overlaps_pk.a:7!null uniq_partial_overlaps_pk.b:8!null
+ │         ├── inner-join (cross)
+ │         │    ├── columns: uniq_partial_overlaps_pk.a:7!null uniq_partial_overlaps_pk.b:8!null uniq_partial_overlaps_pk.c:9 uniq_partial_overlaps_pk.d:10 uniq_partial_overlaps_pk.crdb_internal_mvcc_timestamp:11 uniq_partial_overlaps_pk.tableoid:12 k:13 v:14 w:15!null x:16 y:17 rowid:18!null other.crdb_internal_mvcc_timestamp:19 other.tableoid:20
+ │         │    ├── scan uniq_partial_overlaps_pk
+ │         │    │    └── columns: uniq_partial_overlaps_pk.a:7!null uniq_partial_overlaps_pk.b:8!null uniq_partial_overlaps_pk.c:9 uniq_partial_overlaps_pk.d:10 uniq_partial_overlaps_pk.crdb_internal_mvcc_timestamp:11 uniq_partial_overlaps_pk.tableoid:12
+ │         │    ├── scan other
+ │         │    │    └── columns: k:13 v:14 w:15!null x:16 y:17 rowid:18!null other.crdb_internal_mvcc_timestamp:19 other.tableoid:20
+ │         │    └── filters (true)
+ │         └── aggregations
+ │              ├── first-agg [as=uniq_partial_overlaps_pk.c:9]
+ │              │    └── uniq_partial_overlaps_pk.c:9
+ │              ├── first-agg [as=uniq_partial_overlaps_pk.d:10]
+ │              │    └── uniq_partial_overlaps_pk.d:10
+ │              ├── first-agg [as=uniq_partial_overlaps_pk.crdb_internal_mvcc_timestamp:11]
+ │              │    └── uniq_partial_overlaps_pk.crdb_internal_mvcc_timestamp:11
+ │              ├── first-agg [as=uniq_partial_overlaps_pk.tableoid:12]
+ │              │    └── uniq_partial_overlaps_pk.tableoid:12
+ │              ├── first-agg [as=k:13]
+ │              │    └── k:13
+ │              ├── first-agg [as=v:14]
+ │              │    └── v:14
+ │              ├── first-agg [as=w:15]
+ │              │    └── w:15
+ │              ├── first-agg [as=x:16]
+ │              │    └── x:16
+ │              ├── first-agg [as=y:17]
+ │              │    └── y:17
+ │              ├── first-agg [as=rowid:18]
+ │              │    └── rowid:18
+ │              ├── first-agg [as=other.crdb_internal_mvcc_timestamp:19]
+ │              │    └── other.crdb_internal_mvcc_timestamp:19
+ │              └── first-agg [as=other.tableoid:20]
+ │                   └── other.tableoid:20
  └── unique-checks
       └── unique-checks-item: uniq_partial_overlaps_pk(a)
            └── project
@@ -1075,7 +1080,7 @@ update uniq_partial_hidden_pk
  │    └── a_new:11 => uniq_partial_hidden_pk.a:1
  ├── input binding: &1
  ├── project
- │    ├── columns: a_new:11!null uniq_partial_hidden_pk.a:6 uniq_partial_hidden_pk.b:7 uniq_partial_hidden_pk.rowid:8!null crdb_internal_mvcc_timestamp:9 tableoid:10
+ │    ├── columns: a_new:11!null uniq_partial_hidden_pk.a:6 uniq_partial_hidden_pk.b:7 uniq_partial_hidden_pk.rowid:8!null
  │    ├── scan uniq_partial_hidden_pk
  │    │    └── columns: uniq_partial_hidden_pk.a:6 uniq_partial_hidden_pk.b:7 uniq_partial_hidden_pk.rowid:8!null crdb_internal_mvcc_timestamp:9 tableoid:10
  │    └── projections
@@ -1109,45 +1114,46 @@ UPDATE uniq_partial_hidden_pk SET a = k FROM other
 update uniq_partial_hidden_pk
  ├── columns: <none>
  ├── fetch columns: uniq_partial_hidden_pk.a:6 uniq_partial_hidden_pk.b:7 uniq_partial_hidden_pk.rowid:8
- ├── passthrough columns: k:11 v:12 w:13 x:14 y:15 other.rowid:16 other.crdb_internal_mvcc_timestamp:17 other.tableoid:18
  ├── update-mapping:
  │    └── k:11 => uniq_partial_hidden_pk.a:1
  ├── input binding: &1
- ├── distinct-on
- │    ├── columns: uniq_partial_hidden_pk.a:6 uniq_partial_hidden_pk.b:7 uniq_partial_hidden_pk.rowid:8!null uniq_partial_hidden_pk.crdb_internal_mvcc_timestamp:9 uniq_partial_hidden_pk.tableoid:10 k:11 v:12 w:13!null x:14 y:15 other.rowid:16!null other.crdb_internal_mvcc_timestamp:17 other.tableoid:18
- │    ├── grouping columns: uniq_partial_hidden_pk.rowid:8!null
- │    ├── inner-join (cross)
- │    │    ├── columns: uniq_partial_hidden_pk.a:6 uniq_partial_hidden_pk.b:7 uniq_partial_hidden_pk.rowid:8!null uniq_partial_hidden_pk.crdb_internal_mvcc_timestamp:9 uniq_partial_hidden_pk.tableoid:10 k:11 v:12 w:13!null x:14 y:15 other.rowid:16!null other.crdb_internal_mvcc_timestamp:17 other.tableoid:18
- │    │    ├── scan uniq_partial_hidden_pk
- │    │    │    └── columns: uniq_partial_hidden_pk.a:6 uniq_partial_hidden_pk.b:7 uniq_partial_hidden_pk.rowid:8!null uniq_partial_hidden_pk.crdb_internal_mvcc_timestamp:9 uniq_partial_hidden_pk.tableoid:10
- │    │    ├── scan other
- │    │    │    └── columns: k:11 v:12 w:13!null x:14 y:15 other.rowid:16!null other.crdb_internal_mvcc_timestamp:17 other.tableoid:18
- │    │    └── filters (true)
- │    └── aggregations
- │         ├── first-agg [as=uniq_partial_hidden_pk.a:6]
- │         │    └── uniq_partial_hidden_pk.a:6
- │         ├── first-agg [as=uniq_partial_hidden_pk.b:7]
- │         │    └── uniq_partial_hidden_pk.b:7
- │         ├── first-agg [as=uniq_partial_hidden_pk.crdb_internal_mvcc_timestamp:9]
- │         │    └── uniq_partial_hidden_pk.crdb_internal_mvcc_timestamp:9
- │         ├── first-agg [as=uniq_partial_hidden_pk.tableoid:10]
- │         │    └── uniq_partial_hidden_pk.tableoid:10
- │         ├── first-agg [as=k:11]
- │         │    └── k:11
- │         ├── first-agg [as=v:12]
- │         │    └── v:12
- │         ├── first-agg [as=w:13]
- │         │    └── w:13
- │         ├── first-agg [as=x:14]
- │         │    └── x:14
- │         ├── first-agg [as=y:15]
- │         │    └── y:15
- │         ├── first-agg [as=other.rowid:16]
- │         │    └── other.rowid:16
- │         ├── first-agg [as=other.crdb_internal_mvcc_timestamp:17]
- │         │    └── other.crdb_internal_mvcc_timestamp:17
- │         └── first-agg [as=other.tableoid:18]
- │              └── other.tableoid:18
+ ├── project
+ │    ├── columns: uniq_partial_hidden_pk.a:6 uniq_partial_hidden_pk.b:7 uniq_partial_hidden_pk.rowid:8!null k:11
+ │    └── distinct-on
+ │         ├── columns: uniq_partial_hidden_pk.a:6 uniq_partial_hidden_pk.b:7 uniq_partial_hidden_pk.rowid:8!null uniq_partial_hidden_pk.crdb_internal_mvcc_timestamp:9 uniq_partial_hidden_pk.tableoid:10 k:11 v:12 w:13!null x:14 y:15 other.rowid:16!null other.crdb_internal_mvcc_timestamp:17 other.tableoid:18
+ │         ├── grouping columns: uniq_partial_hidden_pk.rowid:8!null
+ │         ├── inner-join (cross)
+ │         │    ├── columns: uniq_partial_hidden_pk.a:6 uniq_partial_hidden_pk.b:7 uniq_partial_hidden_pk.rowid:8!null uniq_partial_hidden_pk.crdb_internal_mvcc_timestamp:9 uniq_partial_hidden_pk.tableoid:10 k:11 v:12 w:13!null x:14 y:15 other.rowid:16!null other.crdb_internal_mvcc_timestamp:17 other.tableoid:18
+ │         │    ├── scan uniq_partial_hidden_pk
+ │         │    │    └── columns: uniq_partial_hidden_pk.a:6 uniq_partial_hidden_pk.b:7 uniq_partial_hidden_pk.rowid:8!null uniq_partial_hidden_pk.crdb_internal_mvcc_timestamp:9 uniq_partial_hidden_pk.tableoid:10
+ │         │    ├── scan other
+ │         │    │    └── columns: k:11 v:12 w:13!null x:14 y:15 other.rowid:16!null other.crdb_internal_mvcc_timestamp:17 other.tableoid:18
+ │         │    └── filters (true)
+ │         └── aggregations
+ │              ├── first-agg [as=uniq_partial_hidden_pk.a:6]
+ │              │    └── uniq_partial_hidden_pk.a:6
+ │              ├── first-agg [as=uniq_partial_hidden_pk.b:7]
+ │              │    └── uniq_partial_hidden_pk.b:7
+ │              ├── first-agg [as=uniq_partial_hidden_pk.crdb_internal_mvcc_timestamp:9]
+ │              │    └── uniq_partial_hidden_pk.crdb_internal_mvcc_timestamp:9
+ │              ├── first-agg [as=uniq_partial_hidden_pk.tableoid:10]
+ │              │    └── uniq_partial_hidden_pk.tableoid:10
+ │              ├── first-agg [as=k:11]
+ │              │    └── k:11
+ │              ├── first-agg [as=v:12]
+ │              │    └── v:12
+ │              ├── first-agg [as=w:13]
+ │              │    └── w:13
+ │              ├── first-agg [as=x:14]
+ │              │    └── x:14
+ │              ├── first-agg [as=y:15]
+ │              │    └── y:15
+ │              ├── first-agg [as=other.rowid:16]
+ │              │    └── other.rowid:16
+ │              ├── first-agg [as=other.crdb_internal_mvcc_timestamp:17]
+ │              │    └── other.crdb_internal_mvcc_timestamp:17
+ │              └── first-agg [as=other.tableoid:18]
+ │                   └── other.tableoid:18
  └── unique-checks
       └── unique-checks-item: uniq_partial_hidden_pk(a)
            └── project
@@ -1206,9 +1212,9 @@ update uniq_computed_pk
  │    └── c_d_expr_comp:23 => uniq_computed_pk.c_d_expr:7
  ├── input binding: &1
  ├── project
- │    ├── columns: c_i_expr_comp:22!null c_d_expr_comp:23!null uniq_computed_pk.i:10!null uniq_computed_pk.s:11 uniq_computed_pk.d:12 uniq_computed_pk.c_i_expr:13!null uniq_computed_pk.c_s:14 uniq_computed_pk.c_d:15 uniq_computed_pk.c_d_expr:16 crdb_internal_mvcc_timestamp:17 tableoid:18 i_new:19!null s_new:20!null d_new:21!null
+ │    ├── columns: c_i_expr_comp:22!null c_d_expr_comp:23!null uniq_computed_pk.i:10!null uniq_computed_pk.s:11 uniq_computed_pk.d:12 uniq_computed_pk.c_i_expr:13!null uniq_computed_pk.c_s:14 uniq_computed_pk.c_d:15 uniq_computed_pk.c_d_expr:16 i_new:19!null s_new:20!null d_new:21!null
  │    ├── project
- │    │    ├── columns: i_new:19!null s_new:20!null d_new:21!null uniq_computed_pk.i:10!null uniq_computed_pk.s:11 uniq_computed_pk.d:12 uniq_computed_pk.c_i_expr:13!null uniq_computed_pk.c_s:14 uniq_computed_pk.c_d:15 uniq_computed_pk.c_d_expr:16 crdb_internal_mvcc_timestamp:17 tableoid:18
+ │    │    ├── columns: i_new:19!null s_new:20!null d_new:21!null uniq_computed_pk.i:10!null uniq_computed_pk.s:11 uniq_computed_pk.d:12 uniq_computed_pk.c_i_expr:13!null uniq_computed_pk.c_s:14 uniq_computed_pk.c_d:15 uniq_computed_pk.c_d_expr:16
  │    │    ├── project
  │    │    │    ├── columns: uniq_computed_pk.c_s:14 uniq_computed_pk.i:10!null uniq_computed_pk.s:11 uniq_computed_pk.d:12 uniq_computed_pk.c_i_expr:13!null uniq_computed_pk.c_d:15 uniq_computed_pk.c_d_expr:16 crdb_internal_mvcc_timestamp:17 tableoid:18
  │    │    │    ├── scan uniq_computed_pk

--- a/pkg/sql/opt/optbuilder/testdata/update
+++ b/pkg/sql/opt/optbuilder/testdata/update
@@ -112,9 +112,9 @@ update abcde
  │    ├── a_new:17 => a:1
  │    └── a_new:17 => e:5
  └── project
-      ├── columns: d_comp:18 a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16 a_new:17!null
+      ├── columns: d_comp:18 a:9!null b:10 c:11 d:12 e:13 rowid:14!null a_new:17!null
       ├── project
-      │    ├── columns: a_new:17!null a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
+      │    ├── columns: a_new:17!null a:9!null b:10 c:11 d:12 e:13 rowid:14!null
       │    ├── select
       │    │    ├── columns: a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
       │    │    ├── scan abcde
@@ -146,9 +146,9 @@ update abcde
  │    ├── a_new:17 => e:5
  │    └── rowid_new:20 => rowid:6
  └── project
-      ├── columns: d_comp:21!null a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16 a_new:17!null b_new:18!null c_new:19!null rowid_new:20!null
+      ├── columns: d_comp:21!null a:9!null b:10 c:11 d:12 e:13 rowid:14!null a_new:17!null b_new:18!null c_new:19!null rowid_new:20!null
       ├── project
-      │    ├── columns: a_new:17!null b_new:18!null c_new:19!null rowid_new:20!null a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
+      │    ├── columns: a_new:17!null b_new:18!null c_new:19!null rowid_new:20!null a:9!null b:10 c:11 d:12 e:13 rowid:14!null
       │    ├── scan abcde
       │    │    ├── columns: a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
       │    │    └── computed column expressions
@@ -179,9 +179,9 @@ update abcde
  │    ├── a_new:20 => e:5
  │    └── rowid_new:17 => rowid:6
  └── project
-      ├── columns: d_comp:21!null a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16 rowid_new:17!null c_new:18!null b_new:19!null a_new:20!null
+      ├── columns: d_comp:21!null a:9!null b:10 c:11 d:12 e:13 rowid:14!null rowid_new:17!null c_new:18!null b_new:19!null a_new:20!null
       ├── project
-      │    ├── columns: rowid_new:17!null c_new:18!null b_new:19!null a_new:20!null a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
+      │    ├── columns: rowid_new:17!null c_new:18!null b_new:19!null a_new:20!null a:9!null b:10 c:11 d:12 e:13 rowid:14!null
       │    ├── scan abcde
       │    │    ├── columns: a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
       │    │    └── computed column expressions
@@ -212,9 +212,9 @@ update abcde
  │    ├── a_new:17 => e:5
  │    └── a_new:17 => rowid:6
  └── project
-      ├── columns: d_comp:18 a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16 a_new:17
+      ├── columns: d_comp:18 a:9!null b:10 c:11 d:12 e:13 rowid:14!null a_new:17
       ├── project
-      │    ├── columns: a_new:17 a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
+      │    ├── columns: a_new:17 a:9!null b:10 c:11 d:12 e:13 rowid:14!null
       │    ├── scan abcde
       │    │    ├── columns: a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
       │    │    └── computed column expressions
@@ -240,9 +240,9 @@ update abcde
  │    ├── d_comp:19 => d:4
  │    └── a_new:17 => e:5
  └── project
-      ├── columns: d_comp:19 a:9!null b:10!null c:11 d:12 e:13!null rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16 a_new:17!null b_new:18
+      ├── columns: d_comp:19 a:9!null b:10!null c:11 d:12 e:13!null rowid:14!null a_new:17!null b_new:18
       ├── project
-      │    ├── columns: a_new:17!null b_new:18 a:9!null b:10!null c:11 d:12 e:13!null rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
+      │    ├── columns: a_new:17!null b_new:18 a:9!null b:10!null c:11 d:12 e:13!null rowid:14!null
       │    ├── select
       │    │    ├── columns: a:9!null b:10!null c:11 d:12 e:13!null rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
       │    │    ├── scan abcde
@@ -273,14 +273,16 @@ update abcde [as=foo]
  │    ├── d_comp:17 => d:4
  │    └── b:10 => e:5
  └── project
-      ├── columns: d_comp:17 a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
-      ├── scan abcde [as=foo]
-      │    ├── columns: a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
-      │    └── computed column expressions
-      │         ├── d:12
-      │         │    └── (b:10 + c:11) + 1
-      │         └── e:13
-      │              └── a:9
+      ├── columns: d_comp:17 a:9!null b:10 c:11 d:12 e:13 rowid:14!null
+      ├── project
+      │    ├── columns: a:9!null b:10 c:11 d:12 e:13 rowid:14!null
+      │    └── scan abcde [as=foo]
+      │         ├── columns: a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
+      │         └── computed column expressions
+      │              ├── d:12
+      │              │    └── (b:10 + c:11) + 1
+      │              └── e:13
+      │                   └── a:9
       └── projections
            └── (c:11 + c:11) + 1 [as=d_comp:17]
 
@@ -295,9 +297,9 @@ update abcde
  │    ├── b_new:17 => b:2
  │    └── d_comp:18 => d:4
  └── project
-      ├── columns: d_comp:18 a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16 b_new:17!null
+      ├── columns: d_comp:18 a:9!null b:10 c:11 d:12 e:13 rowid:14!null b_new:17!null
       ├── project
-      │    ├── columns: b_new:17!null a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
+      │    ├── columns: b_new:17!null a:9!null b:10 c:11 d:12 e:13 rowid:14!null
       │    ├── limit
       │    │    ├── columns: a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
       │    │    ├── internal-ordering: +9
@@ -342,7 +344,7 @@ update xyzw
  ├── update-mapping:
  │    └── x_new:13 => x:1
  └── project
-      ├── columns: x_new:13!null x:7!null y:8 z:9!null w:10 crdb_internal_mvcc_timestamp:11 tableoid:12
+      ├── columns: x_new:13!null x:7!null y:8 z:9!null w:10
       ├── select
       │    ├── columns: x:7!null y:8 z:9!null w:10 crdb_internal_mvcc_timestamp:11 tableoid:12
       │    ├── scan xyzw
@@ -362,7 +364,7 @@ update xyzw
  ├── update-mapping:
  │    └── x_new:13 => x:1
  └── project
-      ├── columns: x_new:13!null x:7!null y:8 z:9!null w:10 crdb_internal_mvcc_timestamp:11 tableoid:12
+      ├── columns: x_new:13!null x:7!null y:8 z:9!null w:10
       ├── select
       │    ├── columns: x:7!null y:8 z:9!null w:10 crdb_internal_mvcc_timestamp:11 tableoid:12
       │    ├── scan xyzw
@@ -382,7 +384,7 @@ update xyzw
  ├── update-mapping:
  │    └── x_new:13 => x:1
  └── project
-      ├── columns: x_new:13!null x:7!null y:8 z:9!null w:10 crdb_internal_mvcc_timestamp:11 tableoid:12
+      ├── columns: x_new:13!null x:7!null y:8 z:9!null w:10
       ├── select
       │    ├── columns: x:7!null y:8 z:9!null w:10 crdb_internal_mvcc_timestamp:11 tableoid:12
       │    ├── scan xyzw
@@ -402,7 +404,7 @@ update xyzw
  ├── update-mapping:
  │    └── x_new:13 => x:1
  └── project
-      ├── columns: x_new:13!null x:7!null y:8 z:9!null w:10 crdb_internal_mvcc_timestamp:11 tableoid:12
+      ├── columns: x_new:13!null x:7!null y:8 z:9!null w:10
       ├── select
       │    ├── columns: x:7!null y:8 z:9!null w:10 crdb_internal_mvcc_timestamp:11 tableoid:12
       │    ├── scan xyzw,rev
@@ -422,7 +424,7 @@ update xyzw
  ├── update-mapping:
  │    └── x_new:13 => x:1
  └── project
-      ├── columns: x_new:13!null x:7!null y:8 z:9!null w:10 crdb_internal_mvcc_timestamp:11 tableoid:12
+      ├── columns: x_new:13!null x:7!null y:8 z:9!null w:10
       ├── select
       │    ├── columns: x:7!null y:8 z:9!null w:10 crdb_internal_mvcc_timestamp:11 tableoid:12
       │    ├── scan xyzw
@@ -450,7 +452,7 @@ update xyz
  │    ├── y_new:11 => y:2
  │    └── z_new:12 => z:3
  └── project
-      ├── columns: y_new:11!null z_new:12!null x:6!null y:7 z:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+      ├── columns: y_new:11!null z_new:12!null x:6!null y:7 z:8
       ├── scan xyz
       │    └── columns: x:6!null y:7 z:8 crdb_internal_mvcc_timestamp:9 tableoid:10
       └── projections
@@ -469,7 +471,7 @@ update xyz
  │    ├── y_new:12 => y:2
  │    └── z_new:13 => z:3
  └── project
-      ├── columns: x_new:11 y_new:12 z_new:13 x:6!null y:7 z:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+      ├── columns: x_new:11 y_new:12 z_new:13 x:6!null y:7 z:8
       ├── scan xyz
       │    └── columns: x:6!null y:7 z:8 crdb_internal_mvcc_timestamp:9 tableoid:10
       └── projections
@@ -490,9 +492,9 @@ update abcde
  │    ├── d_comp:18 => d:4
  │    └── a_new:17 => e:5
  └── project
-      ├── columns: d_comp:18 a:9!null b:10 c:11!null d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16 a_new:17
+      ├── columns: d_comp:18 a:9!null b:10 c:11!null d:12 e:13 rowid:14!null a_new:17
       ├── project
-      │    ├── columns: a_new:17 a:9!null b:10 c:11!null d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
+      │    ├── columns: a_new:17 a:9!null b:10 c:11!null d:12 e:13 rowid:14!null
       │    ├── select
       │    │    ├── columns: a:9!null b:10 c:11!null d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
       │    │    ├── scan abcde
@@ -534,9 +536,9 @@ update xyz
  │    ├── x_new:11 => y:2
  │    └── z_new:12 => z:3
  └── project
-      ├── columns: x_cast:13!null x:6!null y:7 z:8 crdb_internal_mvcc_timestamp:9 tableoid:10 x_new:11!null z_new:12!null
+      ├── columns: x_cast:13!null x:6!null y:7 z:8 x_new:11!null z_new:12!null
       ├── project
-      │    ├── columns: x_new:11!null z_new:12!null x:6!null y:7 z:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+      │    ├── columns: x_new:11!null z_new:12!null x:6!null y:7 z:8
       │    ├── scan xyz
       │    │    └── columns: x:6!null y:7 z:8 crdb_internal_mvcc_timestamp:9 tableoid:10
       │    └── projections
@@ -594,14 +596,16 @@ with &1
            │    ├── d_comp:31 => d:18
            │    └── b:24 => e:19
            └── project
-                ├── columns: d_comp:31 a:23!null b:24 c:25 d:26 e:27 rowid:28!null abcde.crdb_internal_mvcc_timestamp:29 abcde.tableoid:30
-                ├── scan abcde
-                │    ├── columns: a:23!null b:24 c:25 d:26 e:27 rowid:28!null abcde.crdb_internal_mvcc_timestamp:29 abcde.tableoid:30
-                │    └── computed column expressions
-                │         ├── d:26
-                │         │    └── (b:24 + c:25) + 1
-                │         └── e:27
-                │              └── a:23
+                ├── columns: d_comp:31 a:23!null b:24 c:25 d:26 e:27 rowid:28!null
+                ├── project
+                │    ├── columns: a:23!null b:24 c:25 d:26 e:27 rowid:28!null
+                │    └── scan abcde
+                │         ├── columns: a:23!null b:24 c:25 d:26 e:27 rowid:28!null abcde.crdb_internal_mvcc_timestamp:29 abcde.tableoid:30
+                │         └── computed column expressions
+                │              ├── d:26
+                │              │    └── (b:24 + c:25) + 1
+                │              └── e:27
+                │                   └── a:23
                 └── projections
                      └── (b:24 + c:25) + 1 [as=d_comp:31]
 
@@ -829,9 +833,9 @@ update abcde
  │    ├── c_new:18 => c:3
  │    └── d_comp:19 => d:4
  └── project
-      ├── columns: d_comp:19 a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16 b_new:17 c_new:18!null
+      ├── columns: d_comp:19 a:9!null b:10 c:11 d:12 e:13 rowid:14!null b_new:17 c_new:18!null
       ├── project
-      │    ├── columns: b_new:17 c_new:18!null a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
+      │    ├── columns: b_new:17 c_new:18!null a:9!null b:10 c:11 d:12 e:13 rowid:14!null
       │    ├── scan abcde
       │    │    ├── columns: a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
       │    │    └── computed column expressions
@@ -857,9 +861,9 @@ update abcde
  │    ├── a_new:17 => a:1
  │    └── a_new:17 => e:5
  └── project
-      ├── columns: d_comp:18 a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16 a_new:17
+      ├── columns: d_comp:18 a:9!null b:10 c:11 d:12 e:13 rowid:14!null a_new:17
       ├── project
-      │    ├── columns: a_new:17 a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
+      │    ├── columns: a_new:17 a:9!null b:10 c:11 d:12 e:13 rowid:14!null
       │    ├── scan abcde
       │    │    ├── columns: a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
       │    │    └── computed column expressions
@@ -894,9 +898,9 @@ update abcde
  │    ├── d_comp:20 => d:4
  │    └── a_new:17 => e:5
  └── project
-      ├── columns: d_comp:20!null a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16 a_new:17!null b_new:18!null c_new:19!null
+      ├── columns: d_comp:20!null a:9!null b:10 c:11 d:12 e:13 rowid:14!null a_new:17!null b_new:18!null c_new:19!null
       ├── project
-      │    ├── columns: a_new:17!null b_new:18!null c_new:19!null a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
+      │    ├── columns: a_new:17!null b_new:18!null c_new:19!null a:9!null b:10 c:11 d:12 e:13 rowid:14!null
       │    ├── scan abcde
       │    │    ├── columns: a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
       │    │    └── computed column expressions
@@ -924,9 +928,9 @@ update abcde
  │    ├── d_comp:20 => d:4
  │    └── a_new:19 => e:5
  └── project
-      ├── columns: d_comp:20 a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16 c_new:17 b_new:18!null a_new:19!null
+      ├── columns: d_comp:20 a:9!null b:10 c:11 d:12 e:13 rowid:14!null c_new:17 b_new:18!null a_new:19!null
       ├── project
-      │    ├── columns: c_new:17 b_new:18!null a_new:19!null a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
+      │    ├── columns: c_new:17 b_new:18!null a_new:19!null a:9!null b:10 c:11 d:12 e:13 rowid:14!null
       │    ├── scan abcde
       │    │    ├── columns: a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
       │    │    └── computed column expressions
@@ -953,9 +957,9 @@ update abcde
  │    ├── c_new:18 => c:3
  │    └── d_comp:19 => d:4
  └── project
-      ├── columns: d_comp:19 a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16 b_new:17 c_new:18!null
+      ├── columns: d_comp:19 a:9!null b:10 c:11 d:12 e:13 rowid:14!null b_new:17 c_new:18!null
       ├── project
-      │    ├── columns: b_new:17 c_new:18!null a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
+      │    ├── columns: b_new:17 c_new:18!null a:9!null b:10 c:11 d:12 e:13 rowid:14!null
       │    ├── scan abcde
       │    │    ├── columns: a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
       │    │    └── computed column expressions
@@ -982,9 +986,9 @@ update abcde
  │    ├── d_comp:18 => d:4
  │    └── a_new:17 => e:5
  └── project
-      ├── columns: d_comp:18 a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16 a_new:17
+      ├── columns: d_comp:18 a:9!null b:10 c:11 d:12 e:13 rowid:14!null a_new:17
       ├── project
-      │    ├── columns: a_new:17 a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
+      │    ├── columns: a_new:17 a:9!null b:10 c:11 d:12 e:13 rowid:14!null
       │    ├── scan abcde
       │    │    ├── columns: a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
       │    │    └── computed column expressions
@@ -1032,25 +1036,27 @@ update abcde
  │    ├── one:17 => a:1
  │    └── one:17 => e:5
  └── project
-      ├── columns: d_comp:18 a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16 one:17
-      ├── left-join-apply
-      │    ├── columns: a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16 one:17
-      │    ├── scan abcde
-      │    │    ├── columns: a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
-      │    │    └── computed column expressions
-      │    │         ├── d:12
-      │    │         │    └── (b:10 + c:11) + 1
-      │    │         └── e:13
-      │    │              └── a:9
-      │    ├── max1-row
-      │    │    ├── columns: one:17!null
-      │    │    └── project
-      │    │         ├── columns: one:17!null
-      │    │         ├── values
-      │    │         │    └── ()
-      │    │         └── projections
-      │    │              └── 1 [as=one:17]
-      │    └── filters (true)
+      ├── columns: d_comp:18 a:9!null b:10 c:11 d:12 e:13 rowid:14!null one:17
+      ├── project
+      │    ├── columns: a:9!null b:10 c:11 d:12 e:13 rowid:14!null one:17
+      │    └── left-join-apply
+      │         ├── columns: a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16 one:17
+      │         ├── scan abcde
+      │         │    ├── columns: a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
+      │         │    └── computed column expressions
+      │         │         ├── d:12
+      │         │         │    └── (b:10 + c:11) + 1
+      │         │         └── e:13
+      │         │              └── a:9
+      │         ├── max1-row
+      │         │    ├── columns: one:17!null
+      │         │    └── project
+      │         │         ├── columns: one:17!null
+      │         │         ├── values
+      │         │         │    └── ()
+      │         │         └── projections
+      │         │              └── 1 [as=one:17]
+      │         └── filters (true)
       └── projections
            └── (b:10 + c:11) + 1 [as=d_comp:18]
 
@@ -1069,27 +1075,29 @@ update abcde
  │    ├── x:22 => e:5
  │    └── y1:24 => rowid:6
  └── project
-      ├── columns: d_comp:25 a:9!null b:10 c:11 d:12 e:13 rowid:14!null abcde.crdb_internal_mvcc_timestamp:15 abcde.tableoid:16 y:18 x:22 z:23 y1:24
-      ├── left-join-apply
-      │    ├── columns: a:9!null b:10 c:11 d:12 e:13 rowid:14!null abcde.crdb_internal_mvcc_timestamp:15 abcde.tableoid:16 y:18 x:22 z:23 y1:24
-      │    ├── scan abcde
-      │    │    ├── columns: a:9!null b:10 c:11 d:12 e:13 rowid:14!null abcde.crdb_internal_mvcc_timestamp:15 abcde.tableoid:16
-      │    │    └── computed column expressions
-      │    │         ├── d:12
-      │    │         │    └── (b:10 + c:11) + 1
-      │    │         └── e:13
-      │    │              └── a:9
-      │    ├── max1-row
-      │    │    ├── columns: y:18 x:22!null z:23 y1:24
-      │    │    └── project
-      │    │         ├── columns: x:22!null z:23 y1:24 y:18
-      │    │         ├── scan xyz
-      │    │         │    └── columns: xyz.x:17!null y:18 xyz.z:19 xyz.crdb_internal_mvcc_timestamp:20 xyz.tableoid:21
-      │    │         └── projections
-      │    │              ├── xyz.x:17::INT8 [as=x:22]
-      │    │              ├── xyz.z:19::INT8 [as=z:23]
-      │    │              └── y:18 + 1 [as=y1:24]
-      │    └── filters (true)
+      ├── columns: d_comp:25 a:9!null b:10 c:11 d:12 e:13 rowid:14!null y:18 x:22 z:23 y1:24
+      ├── project
+      │    ├── columns: a:9!null b:10 c:11 d:12 e:13 rowid:14!null y:18 x:22 z:23 y1:24
+      │    └── left-join-apply
+      │         ├── columns: a:9!null b:10 c:11 d:12 e:13 rowid:14!null abcde.crdb_internal_mvcc_timestamp:15 abcde.tableoid:16 y:18 x:22 z:23 y1:24
+      │         ├── scan abcde
+      │         │    ├── columns: a:9!null b:10 c:11 d:12 e:13 rowid:14!null abcde.crdb_internal_mvcc_timestamp:15 abcde.tableoid:16
+      │         │    └── computed column expressions
+      │         │         ├── d:12
+      │         │         │    └── (b:10 + c:11) + 1
+      │         │         └── e:13
+      │         │              └── a:9
+      │         ├── max1-row
+      │         │    ├── columns: y:18 x:22!null z:23 y1:24
+      │         │    └── project
+      │         │         ├── columns: x:22!null z:23 y1:24 y:18
+      │         │         ├── scan xyz
+      │         │         │    └── columns: xyz.x:17!null y:18 xyz.z:19 xyz.crdb_internal_mvcc_timestamp:20 xyz.tableoid:21
+      │         │         └── projections
+      │         │              ├── xyz.x:17::INT8 [as=x:22]
+      │         │              ├── xyz.z:19::INT8 [as=z:23]
+      │         │              └── y:18 + 1 [as=y1:24]
+      │         └── filters (true)
       └── projections
            └── (y:18 + z:23) + 1 [as=d_comp:25]
 
@@ -1108,9 +1116,9 @@ update abcde
  │    ├── y:18 => e:5
  │    └── rowid_new:24 => rowid:6
  └── project
-      ├── columns: d_comp:25 a:9!null b:10 c:11 d:12 e:13 rowid:14!null abcde.crdb_internal_mvcc_timestamp:15 abcde.tableoid:16 y:18 y1:22 c_new:23!null rowid_new:24!null
+      ├── columns: d_comp:25 a:9!null b:10 c:11 d:12 e:13 rowid:14!null y:18 y1:22 c_new:23!null rowid_new:24!null
       ├── project
-      │    ├── columns: c_new:23!null rowid_new:24!null a:9!null b:10 c:11 d:12 e:13 rowid:14!null abcde.crdb_internal_mvcc_timestamp:15 abcde.tableoid:16 y:18 y1:22
+      │    ├── columns: c_new:23!null rowid_new:24!null a:9!null b:10 c:11 d:12 e:13 rowid:14!null y:18 y1:22
       │    ├── left-join-apply
       │    │    ├── columns: a:9!null b:10 c:11 d:12 e:13 rowid:14!null abcde.crdb_internal_mvcc_timestamp:15 abcde.tableoid:16 y:18 y1:22
       │    │    ├── scan abcde
@@ -1150,9 +1158,9 @@ update abcde
  │    ├── a_new:23 => e:5
  │    └── y1:22 => rowid:6
  └── project
-      ├── columns: d_comp:25 a:9!null b:10 c:11 d:12 e:13 rowid:14!null abcde.crdb_internal_mvcc_timestamp:15 abcde.tableoid:16 y:18 y1:22 a_new:23!null b_new:24!null
+      ├── columns: d_comp:25 a:9!null b:10 c:11 d:12 e:13 rowid:14!null y:18 y1:22 a_new:23!null b_new:24!null
       ├── project
-      │    ├── columns: a_new:23!null b_new:24!null a:9!null b:10 c:11 d:12 e:13 rowid:14!null abcde.crdb_internal_mvcc_timestamp:15 abcde.tableoid:16 y:18 y1:22
+      │    ├── columns: a_new:23!null b_new:24!null a:9!null b:10 c:11 d:12 e:13 rowid:14!null y:18 y1:22
       │    ├── left-join-apply
       │    │    ├── columns: a:9!null b:10 c:11 d:12 e:13 rowid:14!null abcde.crdb_internal_mvcc_timestamp:15 abcde.tableoid:16 y:18 y1:22
       │    │    ├── scan abcde
@@ -1192,37 +1200,39 @@ update abcde
  │    ├── y1:22 => e:5
  │    └── two:24 => rowid:6
  └── project
-      ├── columns: d_comp:25 a:9!null b:10 c:11 d:12 e:13 rowid:14!null abcde.crdb_internal_mvcc_timestamp:15 abcde.tableoid:16 y:18 y1:22 one:23 two:24
-      ├── left-join-apply
-      │    ├── columns: a:9!null b:10 c:11 d:12 e:13 rowid:14!null abcde.crdb_internal_mvcc_timestamp:15 abcde.tableoid:16 y:18 y1:22 one:23 two:24
-      │    ├── left-join-apply
-      │    │    ├── columns: a:9!null b:10 c:11 d:12 e:13 rowid:14!null abcde.crdb_internal_mvcc_timestamp:15 abcde.tableoid:16 y:18 y1:22
-      │    │    ├── scan abcde
-      │    │    │    ├── columns: a:9!null b:10 c:11 d:12 e:13 rowid:14!null abcde.crdb_internal_mvcc_timestamp:15 abcde.tableoid:16
-      │    │    │    └── computed column expressions
-      │    │    │         ├── d:12
-      │    │    │         │    └── (b:10 + c:11) + 1
-      │    │    │         └── e:13
-      │    │    │              └── a:9
-      │    │    ├── max1-row
-      │    │    │    ├── columns: y:18 y1:22
-      │    │    │    └── project
-      │    │    │         ├── columns: y1:22 y:18
-      │    │    │         ├── scan xyz
-      │    │    │         │    └── columns: x:17!null y:18 z:19 xyz.crdb_internal_mvcc_timestamp:20 xyz.tableoid:21
-      │    │    │         └── projections
-      │    │    │              └── y:18 + 1 [as=y1:22]
-      │    │    └── filters (true)
-      │    ├── max1-row
-      │    │    ├── columns: one:23!null two:24!null
-      │    │    └── project
-      │    │         ├── columns: one:23!null two:24!null
-      │    │         ├── values
-      │    │         │    └── ()
-      │    │         └── projections
-      │    │              ├── 1 [as=one:23]
-      │    │              └── 2 [as=two:24]
-      │    └── filters (true)
+      ├── columns: d_comp:25 a:9!null b:10 c:11 d:12 e:13 rowid:14!null y:18 y1:22 one:23 two:24
+      ├── project
+      │    ├── columns: a:9!null b:10 c:11 d:12 e:13 rowid:14!null y:18 y1:22 one:23 two:24
+      │    └── left-join-apply
+      │         ├── columns: a:9!null b:10 c:11 d:12 e:13 rowid:14!null abcde.crdb_internal_mvcc_timestamp:15 abcde.tableoid:16 y:18 y1:22 one:23 two:24
+      │         ├── left-join-apply
+      │         │    ├── columns: a:9!null b:10 c:11 d:12 e:13 rowid:14!null abcde.crdb_internal_mvcc_timestamp:15 abcde.tableoid:16 y:18 y1:22
+      │         │    ├── scan abcde
+      │         │    │    ├── columns: a:9!null b:10 c:11 d:12 e:13 rowid:14!null abcde.crdb_internal_mvcc_timestamp:15 abcde.tableoid:16
+      │         │    │    └── computed column expressions
+      │         │    │         ├── d:12
+      │         │    │         │    └── (b:10 + c:11) + 1
+      │         │    │         └── e:13
+      │         │    │              └── a:9
+      │         │    ├── max1-row
+      │         │    │    ├── columns: y:18 y1:22
+      │         │    │    └── project
+      │         │    │         ├── columns: y1:22 y:18
+      │         │    │         ├── scan xyz
+      │         │    │         │    └── columns: x:17!null y:18 z:19 xyz.crdb_internal_mvcc_timestamp:20 xyz.tableoid:21
+      │         │    │         └── projections
+      │         │    │              └── y:18 + 1 [as=y1:22]
+      │         │    └── filters (true)
+      │         ├── max1-row
+      │         │    ├── columns: one:23!null two:24!null
+      │         │    └── project
+      │         │         ├── columns: one:23!null two:24!null
+      │         │         ├── values
+      │         │         │    └── ()
+      │         │         └── projections
+      │         │              ├── 1 [as=one:23]
+      │         │              └── 2 [as=two:24]
+      │         └── filters (true)
       └── projections
            └── (y:18 + one:23) + 1 [as=d_comp:25]
 
@@ -1238,7 +1248,7 @@ update xyz
  │    ├── three:12 => y:2
  │    └── two:11 => z:3
  └── project
-      ├── columns: x_new:13!null x:6!null y:7 z:8 crdb_internal_mvcc_timestamp:9 tableoid:10 two:11 three:12
+      ├── columns: x_new:13!null x:6!null y:7 z:8 two:11 three:12
       ├── left-join-apply
       │    ├── columns: x:6!null y:7 z:8 crdb_internal_mvcc_timestamp:9 tableoid:10 two:11 three:12
       │    ├── scan xyz
@@ -1351,22 +1361,24 @@ with &1 (cte)
       │    ├── d_comp:23 => d:9
       │    └── b:15 => e:10
       └── project
-           ├── columns: d_comp:23 a:14!null b:15 c:16 d:17 e:18 rowid:19!null abcde.crdb_internal_mvcc_timestamp:20 abcde.tableoid:21
-           ├── select
-           │    ├── columns: a:14!null b:15 c:16 d:17 e:18 rowid:19!null abcde.crdb_internal_mvcc_timestamp:20 abcde.tableoid:21
-           │    ├── scan abcde
-           │    │    ├── columns: a:14!null b:15 c:16 d:17 e:18 rowid:19!null abcde.crdb_internal_mvcc_timestamp:20 abcde.tableoid:21
-           │    │    └── computed column expressions
-           │    │         ├── d:17
-           │    │         │    └── (b:15 + c:16) + 1
-           │    │         └── e:18
-           │    │              └── a:14
-           │    └── filters
-           │         └── exists
-           │              └── with-scan &1 (cte)
-           │                   ├── columns: x:22!null
-           │                   └── mapping:
-           │                        └──  xyz.x:1 => x:22
+           ├── columns: d_comp:23 a:14!null b:15 c:16 d:17 e:18 rowid:19!null
+           ├── project
+           │    ├── columns: a:14!null b:15 c:16 d:17 e:18 rowid:19!null
+           │    └── select
+           │         ├── columns: a:14!null b:15 c:16 d:17 e:18 rowid:19!null abcde.crdb_internal_mvcc_timestamp:20 abcde.tableoid:21
+           │         ├── scan abcde
+           │         │    ├── columns: a:14!null b:15 c:16 d:17 e:18 rowid:19!null abcde.crdb_internal_mvcc_timestamp:20 abcde.tableoid:21
+           │         │    └── computed column expressions
+           │         │         ├── d:17
+           │         │         │    └── (b:15 + c:16) + 1
+           │         │         └── e:18
+           │         │              └── a:14
+           │         └── filters
+           │              └── exists
+           │                   └── with-scan &1 (cte)
+           │                        ├── columns: x:22!null
+           │                        └── mapping:
+           │                             └──  xyz.x:1 => x:22
            └── projections
                 └── (b:15 + c:16) + 1 [as=d_comp:23]
 
@@ -1390,24 +1402,26 @@ with &1 (a)
       │    ├── d_comp:25 => d:10
       │    └── y:23 => e:11
       └── project
-           ├── columns: d_comp:25 a:15!null b:16 c:17 d:18 e:19 rowid:20!null abcde.crdb_internal_mvcc_timestamp:21 abcde.tableoid:22 y:23 y1:24
-           ├── left-join-apply
-           │    ├── columns: a:15!null b:16 c:17 d:18 e:19 rowid:20!null abcde.crdb_internal_mvcc_timestamp:21 abcde.tableoid:22 y:23 y1:24
-           │    ├── scan abcde
-           │    │    ├── columns: a:15!null b:16 c:17 d:18 e:19 rowid:20!null abcde.crdb_internal_mvcc_timestamp:21 abcde.tableoid:22
-           │    │    └── computed column expressions
-           │    │         ├── d:18
-           │    │         │    └── (b:16 + c:17) + 1
-           │    │         └── e:19
-           │    │              └── a:15
-           │    ├── max1-row
-           │    │    ├── columns: y:23 y1:24
-           │    │    └── with-scan &1 (a)
-           │    │         ├── columns: y:23 y1:24
-           │    │         └── mapping:
-           │    │              ├──  xyz.y:2 => y:23
-           │    │              └──  y1:6 => y1:24
-           │    └── filters (true)
+           ├── columns: d_comp:25 a:15!null b:16 c:17 d:18 e:19 rowid:20!null y:23 y1:24
+           ├── project
+           │    ├── columns: a:15!null b:16 c:17 d:18 e:19 rowid:20!null y:23 y1:24
+           │    └── left-join-apply
+           │         ├── columns: a:15!null b:16 c:17 d:18 e:19 rowid:20!null abcde.crdb_internal_mvcc_timestamp:21 abcde.tableoid:22 y:23 y1:24
+           │         ├── scan abcde
+           │         │    ├── columns: a:15!null b:16 c:17 d:18 e:19 rowid:20!null abcde.crdb_internal_mvcc_timestamp:21 abcde.tableoid:22
+           │         │    └── computed column expressions
+           │         │         ├── d:18
+           │         │         │    └── (b:16 + c:17) + 1
+           │         │         └── e:19
+           │         │              └── a:15
+           │         ├── max1-row
+           │         │    ├── columns: y:23 y1:24
+           │         │    └── with-scan &1 (a)
+           │         │         ├── columns: y:23 y1:24
+           │         │         └── mapping:
+           │         │              ├──  xyz.y:2 => y:23
+           │         │              └──  y1:6 => y1:24
+           │         └── filters (true)
            └── projections
                 └── (y1:24 + c:17) + 1 [as=d_comp:25]
 
@@ -1428,13 +1442,13 @@ update mutation
  │    └── p_comp:17 => p:4
  ├── check columns: check1:18
  └── project
-      ├── columns: check1:18!null m:8!null n:9 o:10 p:11 q:12 crdb_internal_mvcc_timestamp:13 tableoid:14 m_new:15!null o_default:16!null p_comp:17
+      ├── columns: check1:18!null m:8!null n:9 o:10 p:11 q:12 m_new:15!null o_default:16!null p_comp:17
       ├── project
-      │    ├── columns: p_comp:17 m:8!null n:9 o:10 p:11 q:12 crdb_internal_mvcc_timestamp:13 tableoid:14 m_new:15!null o_default:16!null
+      │    ├── columns: p_comp:17 m:8!null n:9 o:10 p:11 q:12 m_new:15!null o_default:16!null
       │    ├── project
-      │    │    ├── columns: o_default:16!null m:8!null n:9 o:10 p:11 q:12 crdb_internal_mvcc_timestamp:13 tableoid:14 m_new:15!null
+      │    │    ├── columns: o_default:16!null m:8!null n:9 o:10 p:11 q:12 m_new:15!null
       │    │    ├── project
-      │    │    │    ├── columns: m_new:15!null m:8!null n:9 o:10 p:11 q:12 crdb_internal_mvcc_timestamp:13 tableoid:14
+      │    │    │    ├── columns: m_new:15!null m:8!null n:9 o:10 p:11 q:12
       │    │    │    ├── scan mutation
       │    │    │    │    ├── columns: m:8!null n:9 o:10 p:11 q:12 crdb_internal_mvcc_timestamp:13 tableoid:14
       │    │    │    │    └── check constraint expressions
@@ -1462,13 +1476,13 @@ update mutation
  │    └── p_comp:18 => p:4
  ├── check columns: check1:19
  └── project
-      ├── columns: check1:19!null m:8!null n:9 o:10 p:11 q:12 crdb_internal_mvcc_timestamp:13 tableoid:14 m_new:15!null n_new:16!null o_default:17!null p_comp:18!null
+      ├── columns: check1:19!null m:8!null n:9 o:10 p:11 q:12 m_new:15!null n_new:16!null o_default:17!null p_comp:18!null
       ├── project
-      │    ├── columns: p_comp:18!null m:8!null n:9 o:10 p:11 q:12 crdb_internal_mvcc_timestamp:13 tableoid:14 m_new:15!null n_new:16!null o_default:17!null
+      │    ├── columns: p_comp:18!null m:8!null n:9 o:10 p:11 q:12 m_new:15!null n_new:16!null o_default:17!null
       │    ├── project
-      │    │    ├── columns: o_default:17!null m:8!null n:9 o:10 p:11 q:12 crdb_internal_mvcc_timestamp:13 tableoid:14 m_new:15!null n_new:16!null
+      │    │    ├── columns: o_default:17!null m:8!null n:9 o:10 p:11 q:12 m_new:15!null n_new:16!null
       │    │    ├── project
-      │    │    │    ├── columns: m_new:15!null n_new:16!null m:8!null n:9 o:10 p:11 q:12 crdb_internal_mvcc_timestamp:13 tableoid:14
+      │    │    │    ├── columns: m_new:15!null n_new:16!null m:8!null n:9 o:10 p:11 q:12
       │    │    │    ├── scan mutation
       │    │    │    │    ├── columns: m:8!null n:9 o:10 p:11 q:12 crdb_internal_mvcc_timestamp:13 tableoid:14
       │    │    │    │    └── check constraint expressions
@@ -1496,13 +1510,13 @@ update mutation
  │    └── p_comp:17 => p:4
  ├── check columns: check1:18
  └── project
-      ├── columns: check1:18!null m:8!null n:9 o:10 p:11 q:12 crdb_internal_mvcc_timestamp:13 tableoid:14 m_new:15!null o_default:16!null p_comp:17
+      ├── columns: check1:18!null m:8!null n:9 o:10 p:11 q:12 m_new:15!null o_default:16!null p_comp:17
       ├── project
-      │    ├── columns: p_comp:17 m:8!null n:9 o:10 p:11 q:12 crdb_internal_mvcc_timestamp:13 tableoid:14 m_new:15!null o_default:16!null
+      │    ├── columns: p_comp:17 m:8!null n:9 o:10 p:11 q:12 m_new:15!null o_default:16!null
       │    ├── project
-      │    │    ├── columns: o_default:16!null m:8!null n:9 o:10 p:11 q:12 crdb_internal_mvcc_timestamp:13 tableoid:14 m_new:15!null
+      │    │    ├── columns: o_default:16!null m:8!null n:9 o:10 p:11 q:12 m_new:15!null
       │    │    ├── project
-      │    │    │    ├── columns: m_new:15!null m:8!null n:9 o:10 p:11 q:12 crdb_internal_mvcc_timestamp:13 tableoid:14
+      │    │    │    ├── columns: m_new:15!null m:8!null n:9 o:10 p:11 q:12
       │    │    │    ├── limit
       │    │    │    │    ├── columns: m:8!null n:9 o:10 p:11 q:12 crdb_internal_mvcc_timestamp:13 tableoid:14
       │    │    │    │    ├── internal-ordering: +8,+9
@@ -1573,11 +1587,11 @@ update checks
  │    └── d_comp:16 => d:4
  ├── check columns: check1:17 check2:18
  └── project
-      ├── columns: check1:17!null check2:18!null a:7!null b:8 c:9 d:10 crdb_internal_mvcc_timestamp:11 tableoid:12 a_new:13!null b_new:14!null c_new:15!null d_comp:16!null
+      ├── columns: check1:17!null check2:18!null a:7!null b:8 c:9 d:10 a_new:13!null b_new:14!null c_new:15!null d_comp:16!null
       ├── project
-      │    ├── columns: d_comp:16!null a:7!null b:8 c:9 d:10 crdb_internal_mvcc_timestamp:11 tableoid:12 a_new:13!null b_new:14!null c_new:15!null
+      │    ├── columns: d_comp:16!null a:7!null b:8 c:9 d:10 a_new:13!null b_new:14!null c_new:15!null
       │    ├── project
-      │    │    ├── columns: a_new:13!null b_new:14!null c_new:15!null a:7!null b:8 c:9 d:10 crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    │    ├── columns: a_new:13!null b_new:14!null c_new:15!null a:7!null b:8 c:9 d:10
       │    │    ├── scan checks
       │    │    │    ├── columns: a:7!null b:8 c:9 d:10 crdb_internal_mvcc_timestamp:11 tableoid:12
       │    │    │    ├── check constraint expressions
@@ -1606,11 +1620,11 @@ update checks
  │    └── a_new:13 => a:1
  ├── check columns: check2:16
  └── project
-      ├── columns: check1:15 check2:16!null a:7!null b:8 c:9 d:10 crdb_internal_mvcc_timestamp:11 tableoid:12 a_new:13!null d_comp:14
+      ├── columns: check1:15 check2:16!null a:7!null b:8 c:9 d:10 a_new:13!null d_comp:14
       ├── project
-      │    ├── columns: d_comp:14 a:7!null b:8 c:9 d:10 crdb_internal_mvcc_timestamp:11 tableoid:12 a_new:13!null
+      │    ├── columns: d_comp:14 a:7!null b:8 c:9 d:10 a_new:13!null
       │    ├── project
-      │    │    ├── columns: a_new:13!null a:7!null b:8 c:9 d:10 crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    │    ├── columns: a_new:13!null a:7!null b:8 c:9 d:10
       │    │    ├── scan checks
       │    │    │    ├── columns: a:7!null b:8 c:9 d:10 crdb_internal_mvcc_timestamp:11 tableoid:12
       │    │    │    ├── check constraint expressions
@@ -1637,11 +1651,11 @@ update checks
  │    └── b_new:13 => b:2
  ├── check columns: check1:15
  └── project
-      ├── columns: check1:15 check2:16!null a:7!null b:8 c:9 d:10 crdb_internal_mvcc_timestamp:11 tableoid:12 b_new:13!null d_comp:14
+      ├── columns: check1:15 check2:16!null a:7!null b:8 c:9 d:10 b_new:13!null d_comp:14
       ├── project
-      │    ├── columns: d_comp:14 a:7!null b:8 c:9 d:10 crdb_internal_mvcc_timestamp:11 tableoid:12 b_new:13!null
+      │    ├── columns: d_comp:14 a:7!null b:8 c:9 d:10 b_new:13!null
       │    ├── project
-      │    │    ├── columns: b_new:13!null a:7!null b:8 c:9 d:10 crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    │    ├── columns: b_new:13!null a:7!null b:8 c:9 d:10
       │    │    ├── scan checks
       │    │    │    ├── columns: a:7!null b:8 c:9 d:10 crdb_internal_mvcc_timestamp:11 tableoid:12
       │    │    │    ├── check constraint expressions
@@ -1669,34 +1683,36 @@ update checks
  │    └── abcde.b:14 => checks.b:2
  ├── check columns: check1:22 check2:23
  └── project
-      ├── columns: check1:22 check2:23 checks.a:7!null checks.b:8 checks.c:9 checks.d:10 checks.crdb_internal_mvcc_timestamp:11 checks.tableoid:12 abcde.a:13 abcde.b:14 d_comp:21
+      ├── columns: check1:22 check2:23 checks.a:7!null checks.b:8 checks.c:9 checks.d:10 abcde.a:13 abcde.b:14 d_comp:21
       ├── project
-      │    ├── columns: d_comp:21 checks.a:7!null checks.b:8 checks.c:9 checks.d:10 checks.crdb_internal_mvcc_timestamp:11 checks.tableoid:12 abcde.a:13 abcde.b:14
-      │    ├── left-join-apply
-      │    │    ├── columns: checks.a:7!null checks.b:8 checks.c:9 checks.d:10 checks.crdb_internal_mvcc_timestamp:11 checks.tableoid:12 abcde.a:13 abcde.b:14
-      │    │    ├── scan checks
-      │    │    │    ├── columns: checks.a:7!null checks.b:8 checks.c:9 checks.d:10 checks.crdb_internal_mvcc_timestamp:11 checks.tableoid:12
-      │    │    │    ├── check constraint expressions
-      │    │    │    │    └── checks.a:7 > 0
-      │    │    │    └── computed column expressions
-      │    │    │         └── checks.d:10
-      │    │    │              └── checks.c:9 + 1
-      │    │    ├── max1-row
-      │    │    │    ├── columns: abcde.a:13!null abcde.b:14
-      │    │    │    └── project
-      │    │    │         ├── columns: abcde.a:13!null abcde.b:14
-      │    │    │         └── select
-      │    │    │              ├── columns: abcde.a:13!null abcde.b:14 abcde.c:15 abcde.d:16 e:17 rowid:18!null abcde.crdb_internal_mvcc_timestamp:19 abcde.tableoid:20
-      │    │    │              ├── scan abcde
-      │    │    │              │    ├── columns: abcde.a:13!null abcde.b:14 abcde.c:15 abcde.d:16 e:17 rowid:18!null abcde.crdb_internal_mvcc_timestamp:19 abcde.tableoid:20
-      │    │    │              │    └── computed column expressions
-      │    │    │              │         ├── abcde.d:16
-      │    │    │              │         │    └── (abcde.b:14 + abcde.c:15) + 1
-      │    │    │              │         └── e:17
-      │    │    │              │              └── abcde.a:13
-      │    │    │              └── filters
-      │    │    │                   └── abcde.a:13 = checks.a:7
-      │    │    └── filters (true)
+      │    ├── columns: d_comp:21 checks.a:7!null checks.b:8 checks.c:9 checks.d:10 abcde.a:13 abcde.b:14
+      │    ├── project
+      │    │    ├── columns: checks.a:7!null checks.b:8 checks.c:9 checks.d:10 abcde.a:13 abcde.b:14
+      │    │    └── left-join-apply
+      │    │         ├── columns: checks.a:7!null checks.b:8 checks.c:9 checks.d:10 checks.crdb_internal_mvcc_timestamp:11 checks.tableoid:12 abcde.a:13 abcde.b:14
+      │    │         ├── scan checks
+      │    │         │    ├── columns: checks.a:7!null checks.b:8 checks.c:9 checks.d:10 checks.crdb_internal_mvcc_timestamp:11 checks.tableoid:12
+      │    │         │    ├── check constraint expressions
+      │    │         │    │    └── checks.a:7 > 0
+      │    │         │    └── computed column expressions
+      │    │         │         └── checks.d:10
+      │    │         │              └── checks.c:9 + 1
+      │    │         ├── max1-row
+      │    │         │    ├── columns: abcde.a:13!null abcde.b:14
+      │    │         │    └── project
+      │    │         │         ├── columns: abcde.a:13!null abcde.b:14
+      │    │         │         └── select
+      │    │         │              ├── columns: abcde.a:13!null abcde.b:14 abcde.c:15 abcde.d:16 e:17 rowid:18!null abcde.crdb_internal_mvcc_timestamp:19 abcde.tableoid:20
+      │    │         │              ├── scan abcde
+      │    │         │              │    ├── columns: abcde.a:13!null abcde.b:14 abcde.c:15 abcde.d:16 e:17 rowid:18!null abcde.crdb_internal_mvcc_timestamp:19 abcde.tableoid:20
+      │    │         │              │    └── computed column expressions
+      │    │         │              │         ├── abcde.d:16
+      │    │         │              │         │    └── (abcde.b:14 + abcde.c:15) + 1
+      │    │         │              │         └── e:17
+      │    │         │              │              └── abcde.a:13
+      │    │         │              └── filters
+      │    │         │                   └── abcde.a:13 = checks.a:7
+      │    │         └── filters (true)
       │    └── projections
       │         └── checks.c:9 + 1 [as=d_comp:21]
       └── projections
@@ -1720,15 +1736,15 @@ update decimals
  │    └── d_cast:18 => d:4
  ├── check columns: check1:19 check2:20
  └── project
-      ├── columns: check1:19 check2:20 a:7!null b:8 c:9 d:10 crdb_internal_mvcc_timestamp:11 tableoid:12 a_cast:15!null b_cast:16 d_cast:18
+      ├── columns: check1:19 check2:20 a:7!null b:8 c:9 d:10 a_cast:15!null b_cast:16 d_cast:18
       ├── project
-      │    ├── columns: d_cast:18 a:7!null b:8 c:9 d:10 crdb_internal_mvcc_timestamp:11 tableoid:12 a_cast:15!null b_cast:16
+      │    ├── columns: d_cast:18 a:7!null b:8 c:9 d:10 a_cast:15!null b_cast:16
       │    ├── project
-      │    │    ├── columns: d_comp:17 a:7!null b:8 c:9 d:10 crdb_internal_mvcc_timestamp:11 tableoid:12 a_cast:15!null b_cast:16
+      │    │    ├── columns: d_comp:17 a:7!null b:8 c:9 d:10 a_cast:15!null b_cast:16
       │    │    ├── project
-      │    │    │    ├── columns: a_cast:15!null b_cast:16 a:7!null b:8 c:9 d:10 crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    │    │    ├── columns: a_cast:15!null b_cast:16 a:7!null b:8 c:9 d:10
       │    │    │    ├── project
-      │    │    │    │    ├── columns: a_new:13!null b_new:14 a:7!null b:8 c:9 d:10 crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    │    │    │    ├── columns: a_new:13!null b_new:14 a:7!null b:8 c:9 d:10
       │    │    │    │    ├── scan decimals
       │    │    │    │    │    ├── columns: a:7!null b:8 c:9 d:10 crdb_internal_mvcc_timestamp:11 tableoid:12
       │    │    │    │    │    └── computed column expressions
@@ -1765,15 +1781,15 @@ update decimals
  │    └── d_cast:18 => d:4
  ├── check columns: check1:19 check2:20
  └── project
-      ├── columns: check1:19 check2:20 a:7!null b:8 c:9 d:10 crdb_internal_mvcc_timestamp:11 tableoid:12 a_cast:15!null b_cast:16!null d_cast:18
+      ├── columns: check1:19 check2:20 a:7!null b:8 c:9 d:10 a_cast:15!null b_cast:16!null d_cast:18
       ├── project
-      │    ├── columns: d_cast:18 a:7!null b:8 c:9 d:10 crdb_internal_mvcc_timestamp:11 tableoid:12 a_cast:15!null b_cast:16!null
+      │    ├── columns: d_cast:18 a:7!null b:8 c:9 d:10 a_cast:15!null b_cast:16!null
       │    ├── project
-      │    │    ├── columns: d_comp:17 a:7!null b:8 c:9 d:10 crdb_internal_mvcc_timestamp:11 tableoid:12 a_cast:15!null b_cast:16!null
+      │    │    ├── columns: d_comp:17 a:7!null b:8 c:9 d:10 a_cast:15!null b_cast:16!null
       │    │    ├── project
-      │    │    │    ├── columns: a_cast:15!null b_cast:16!null a:7!null b:8 c:9 d:10 crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    │    │    ├── columns: a_cast:15!null b_cast:16!null a:7!null b:8 c:9 d:10
       │    │    │    ├── project
-      │    │    │    │    ├── columns: a_new:13!null b_new:14!null a:7!null b:8 c:9 d:10 crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    │    │    │    ├── columns: a_new:13!null b_new:14!null a:7!null b:8 c:9 d:10
       │    │    │    │    ├── scan decimals
       │    │    │    │    │    ├── columns: a:7!null b:8 c:9 d:10 crdb_internal_mvcc_timestamp:11 tableoid:12
       │    │    │    │    │    └── computed column expressions
@@ -1809,11 +1825,11 @@ update assn_cast
  │    ├── i_new:21 => i:3
  │    └── s_cast:25 => s:4
  └── project
-      ├── columns: d_comp_comp:26 c:10 qc:11 i:12 s:13 d:14 d_comp:15 rowid:16!null crdb_internal_mvcc_timestamp:17 tableoid:18 i_new:21!null c_cast:23!null qc_cast:24!null s_cast:25!null
+      ├── columns: d_comp_comp:26 c:10 qc:11 i:12 s:13 d:14 d_comp:15 rowid:16!null i_new:21!null c_cast:23!null qc_cast:24!null s_cast:25!null
       ├── project
-      │    ├── columns: c_cast:23!null qc_cast:24!null s_cast:25!null c:10 qc:11 i:12 s:13 d:14 d_comp:15 rowid:16!null crdb_internal_mvcc_timestamp:17 tableoid:18 i_new:21!null
+      │    ├── columns: c_cast:23!null qc_cast:24!null s_cast:25!null c:10 qc:11 i:12 s:13 d:14 d_comp:15 rowid:16!null i_new:21!null
       │    ├── project
-      │    │    ├── columns: c_new:19!null qc_new:20!null i_new:21!null s_new:22!null c:10 qc:11 i:12 s:13 d:14 d_comp:15 rowid:16!null crdb_internal_mvcc_timestamp:17 tableoid:18
+      │    │    ├── columns: c_new:19!null qc_new:20!null i_new:21!null s_new:22!null c:10 qc:11 i:12 s:13 d:14 d_comp:15 rowid:16!null
       │    │    ├── scan assn_cast
       │    │    │    ├── columns: c:10 qc:11 i:12 s:13 d:14 d_comp:15 rowid:16!null crdb_internal_mvcc_timestamp:17 tableoid:18
       │    │    │    └── computed column expressions
@@ -1846,11 +1862,11 @@ update assn_cast
  │    ├── qc_cast:23 => qc:2
  │    └── i_new:21 => i:3
  └── project
-      ├── columns: d_comp_comp:24 c:10 qc:11 i:12 s:13 d:14 d_comp:15 rowid:16!null crdb_internal_mvcc_timestamp:17 tableoid:18 i_new:21!null c_cast:22!null qc_cast:23!null
+      ├── columns: d_comp_comp:24 c:10 qc:11 i:12 s:13 d:14 d_comp:15 rowid:16!null i_new:21!null c_cast:22!null qc_cast:23!null
       ├── project
-      │    ├── columns: c_cast:22!null qc_cast:23!null c:10 qc:11 i:12 s:13 d:14 d_comp:15 rowid:16!null crdb_internal_mvcc_timestamp:17 tableoid:18 i_new:21!null
+      │    ├── columns: c_cast:22!null qc_cast:23!null c:10 qc:11 i:12 s:13 d:14 d_comp:15 rowid:16!null i_new:21!null
       │    ├── project
-      │    │    ├── columns: c_new:19!null qc_new:20!null i_new:21!null c:10 qc:11 i:12 s:13 d:14 d_comp:15 rowid:16!null crdb_internal_mvcc_timestamp:17 tableoid:18
+      │    │    ├── columns: c_new:19!null qc_new:20!null i_new:21!null c:10 qc:11 i:12 s:13 d:14 d_comp:15 rowid:16!null
       │    │    ├── scan assn_cast
       │    │    │    ├── columns: c:10 qc:11 i:12 s:13 d:14 d_comp:15 rowid:16!null crdb_internal_mvcc_timestamp:17 tableoid:18
       │    │    │    └── computed column expressions
@@ -1878,11 +1894,11 @@ update assn_cast
  ├── update-mapping:
  │    └── i_cast:20 => i:3
  └── project
-      ├── columns: d_comp_comp:21 c:10 qc:11 i:12 s:13 d:14 d_comp:15 rowid:16!null crdb_internal_mvcc_timestamp:17 tableoid:18 i_cast:20!null
+      ├── columns: d_comp_comp:21 c:10 qc:11 i:12 s:13 d:14 d_comp:15 rowid:16!null i_cast:20!null
       ├── project
-      │    ├── columns: i_cast:20!null c:10 qc:11 i:12 s:13 d:14 d_comp:15 rowid:16!null crdb_internal_mvcc_timestamp:17 tableoid:18
+      │    ├── columns: i_cast:20!null c:10 qc:11 i:12 s:13 d:14 d_comp:15 rowid:16!null
       │    ├── project
-      │    │    ├── columns: i_new:19!null c:10 qc:11 i:12 s:13 d:14 d_comp:15 rowid:16!null crdb_internal_mvcc_timestamp:17 tableoid:18
+      │    │    ├── columns: i_new:19!null c:10 qc:11 i:12 s:13 d:14 d_comp:15 rowid:16!null
       │    │    ├── scan assn_cast
       │    │    │    ├── columns: c:10 qc:11 i:12 s:13 d:14 d_comp:15 rowid:16!null crdb_internal_mvcc_timestamp:17 tableoid:18
       │    │    │    └── computed column expressions
@@ -1908,13 +1924,13 @@ update assn_cast
  │    ├── d_cast:20 => d:5
  │    └── d_comp_cast:22 => d_comp:6
  └── project
-      ├── columns: d_comp_cast:22!null c:10 qc:11 i:12 s:13 d:14 d_comp:15 rowid:16!null crdb_internal_mvcc_timestamp:17 tableoid:18 d_cast:20!null
+      ├── columns: d_comp_cast:22!null c:10 qc:11 i:12 s:13 d:14 d_comp:15 rowid:16!null d_cast:20!null
       ├── project
-      │    ├── columns: d_comp_comp:21!null c:10 qc:11 i:12 s:13 d:14 d_comp:15 rowid:16!null crdb_internal_mvcc_timestamp:17 tableoid:18 d_cast:20!null
+      │    ├── columns: d_comp_comp:21!null c:10 qc:11 i:12 s:13 d:14 d_comp:15 rowid:16!null d_cast:20!null
       │    ├── project
-      │    │    ├── columns: d_cast:20!null c:10 qc:11 i:12 s:13 d:14 d_comp:15 rowid:16!null crdb_internal_mvcc_timestamp:17 tableoid:18
+      │    │    ├── columns: d_cast:20!null c:10 qc:11 i:12 s:13 d:14 d_comp:15 rowid:16!null
       │    │    ├── project
-      │    │    │    ├── columns: d_new:19!null c:10 qc:11 i:12 s:13 d:14 d_comp:15 rowid:16!null crdb_internal_mvcc_timestamp:17 tableoid:18
+      │    │    │    ├── columns: d_new:19!null c:10 qc:11 i:12 s:13 d:14 d_comp:15 rowid:16!null
       │    │    │    ├── scan assn_cast
       │    │    │    │    ├── columns: c:10 qc:11 i:12 s:13 d:14 d_comp:15 rowid:16!null crdb_internal_mvcc_timestamp:17 tableoid:18
       │    │    │    │    └── computed column expressions
@@ -1943,13 +1959,13 @@ update assn_cast
  │    ├── d_cast:20 => d:5
  │    └── d_comp_cast:22 => d_comp:6
  └── project
-      ├── columns: d_comp_cast:22!null c:10 qc:11 i:12 s:13 d:14 d_comp:15 rowid:16!null crdb_internal_mvcc_timestamp:17 tableoid:18 d_cast:20!null
+      ├── columns: d_comp_cast:22!null c:10 qc:11 i:12 s:13 d:14 d_comp:15 rowid:16!null d_cast:20!null
       ├── project
-      │    ├── columns: d_comp_comp:21!null c:10 qc:11 i:12 s:13 d:14 d_comp:15 rowid:16!null crdb_internal_mvcc_timestamp:17 tableoid:18 d_cast:20!null
+      │    ├── columns: d_comp_comp:21!null c:10 qc:11 i:12 s:13 d:14 d_comp:15 rowid:16!null d_cast:20!null
       │    ├── project
-      │    │    ├── columns: d_cast:20!null c:10 qc:11 i:12 s:13 d:14 d_comp:15 rowid:16!null crdb_internal_mvcc_timestamp:17 tableoid:18
+      │    │    ├── columns: d_cast:20!null c:10 qc:11 i:12 s:13 d:14 d_comp:15 rowid:16!null
       │    │    ├── project
-      │    │    │    ├── columns: d_new:19!null c:10 qc:11 i:12 s:13 d:14 d_comp:15 rowid:16!null crdb_internal_mvcc_timestamp:17 tableoid:18
+      │    │    │    ├── columns: d_new:19!null c:10 qc:11 i:12 s:13 d:14 d_comp:15 rowid:16!null
       │    │    │    ├── scan assn_cast
       │    │    │    │    ├── columns: c:10 qc:11 i:12 s:13 d:14 d_comp:15 rowid:16!null crdb_internal_mvcc_timestamp:17 tableoid:18
       │    │    │    │    └── computed column expressions
@@ -1979,15 +1995,15 @@ update decimals
  │    └── d_cast:18 => d:4
  ├── check columns: check1:19 check2:20
  └── project
-      ├── columns: check1:19 check2:20 a:7!null b:8 c:9 d:10 crdb_internal_mvcc_timestamp:11 tableoid:12 a_cast:15!null b_cast:16 d_cast:18
+      ├── columns: check1:19 check2:20 a:7!null b:8 c:9 d:10 a_cast:15!null b_cast:16 d_cast:18
       ├── project
-      │    ├── columns: d_cast:18 a:7!null b:8 c:9 d:10 crdb_internal_mvcc_timestamp:11 tableoid:12 a_cast:15!null b_cast:16
+      │    ├── columns: d_cast:18 a:7!null b:8 c:9 d:10 a_cast:15!null b_cast:16
       │    ├── project
-      │    │    ├── columns: d_comp:17 a:7!null b:8 c:9 d:10 crdb_internal_mvcc_timestamp:11 tableoid:12 a_cast:15!null b_cast:16
+      │    │    ├── columns: d_comp:17 a:7!null b:8 c:9 d:10 a_cast:15!null b_cast:16
       │    │    ├── project
-      │    │    │    ├── columns: a_cast:15!null b_cast:16 a:7!null b:8 c:9 d:10 crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    │    │    ├── columns: a_cast:15!null b_cast:16 a:7!null b:8 c:9 d:10
       │    │    │    ├── project
-      │    │    │    │    ├── columns: a_new:13!null b_new:14 a:7!null b:8 c:9 d:10 crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    │    │    │    ├── columns: a_new:13!null b_new:14 a:7!null b:8 c:9 d:10
       │    │    │    │    ├── scan decimals
       │    │    │    │    │    ├── columns: a:7!null b:8 c:9 d:10 crdb_internal_mvcc_timestamp:11 tableoid:12
       │    │    │    │    │    └── computed column expressions
@@ -2023,15 +2039,15 @@ update decimals
  │    └── d_cast:18 => d:4
  ├── check columns: check1:19 check2:20
  └── project
-      ├── columns: check1:19 check2:20 a:7!null b:8 c:9 d:10 crdb_internal_mvcc_timestamp:11 tableoid:12 a_cast:15!null b_cast:16!null d_cast:18
+      ├── columns: check1:19 check2:20 a:7!null b:8 c:9 d:10 a_cast:15!null b_cast:16!null d_cast:18
       ├── project
-      │    ├── columns: d_cast:18 a:7!null b:8 c:9 d:10 crdb_internal_mvcc_timestamp:11 tableoid:12 a_cast:15!null b_cast:16!null
+      │    ├── columns: d_cast:18 a:7!null b:8 c:9 d:10 a_cast:15!null b_cast:16!null
       │    ├── project
-      │    │    ├── columns: d_comp:17 a:7!null b:8 c:9 d:10 crdb_internal_mvcc_timestamp:11 tableoid:12 a_cast:15!null b_cast:16!null
+      │    │    ├── columns: d_comp:17 a:7!null b:8 c:9 d:10 a_cast:15!null b_cast:16!null
       │    │    ├── project
-      │    │    │    ├── columns: a_cast:15!null b_cast:16!null a:7!null b:8 c:9 d:10 crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    │    │    ├── columns: a_cast:15!null b_cast:16!null a:7!null b:8 c:9 d:10
       │    │    │    ├── project
-      │    │    │    │    ├── columns: a_new:13!null b_new:14!null a:7!null b:8 c:9 d:10 crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    │    │    │    ├── columns: a_new:13!null b_new:14!null a:7!null b:8 c:9 d:10
       │    │    │    │    ├── scan decimals
       │    │    │    │    │    ├── columns: a:7!null b:8 c:9 d:10 crdb_internal_mvcc_timestamp:11 tableoid:12
       │    │    │    │    │    └── computed column expressions
@@ -2065,11 +2081,11 @@ update assn_cast
  │    ├── c_cast:21 => c:1
  │    └── i_cast:22 => i:3
  └── project
-      ├── columns: d_comp_comp:23 c:10 qc:11 i:12 s:13 d:14 d_comp:15 rowid:16!null crdb_internal_mvcc_timestamp:17 tableoid:18 c_cast:21!null i_cast:22!null
+      ├── columns: d_comp_comp:23 c:10 qc:11 i:12 s:13 d:14 d_comp:15 rowid:16!null c_cast:21!null i_cast:22!null
       ├── project
-      │    ├── columns: c_cast:21!null i_cast:22!null c:10 qc:11 i:12 s:13 d:14 d_comp:15 rowid:16!null crdb_internal_mvcc_timestamp:17 tableoid:18
+      │    ├── columns: c_cast:21!null i_cast:22!null c:10 qc:11 i:12 s:13 d:14 d_comp:15 rowid:16!null
       │    ├── project
-      │    │    ├── columns: c_new:19!null i_new:20!null c:10 qc:11 i:12 s:13 d:14 d_comp:15 rowid:16!null crdb_internal_mvcc_timestamp:17 tableoid:18
+      │    │    ├── columns: c_new:19!null i_new:20!null c:10 qc:11 i:12 s:13 d:14 d_comp:15 rowid:16!null
       │    │    ├── scan assn_cast
       │    │    │    ├── columns: c:10 qc:11 i:12 s:13 d:14 d_comp:15 rowid:16!null crdb_internal_mvcc_timestamp:17 tableoid:18
       │    │    │    └── computed column expressions
@@ -2097,11 +2113,11 @@ update assn_cast
  │    ├── c_cast:21 => c:1
  │    └── i_cast:22 => i:3
  └── project
-      ├── columns: d_comp_comp:23 c:10 qc:11 i:12 s:13 d:14 d_comp:15 rowid:16!null crdb_internal_mvcc_timestamp:17 tableoid:18 c_cast:21!null i_cast:22!null
+      ├── columns: d_comp_comp:23 c:10 qc:11 i:12 s:13 d:14 d_comp:15 rowid:16!null c_cast:21!null i_cast:22!null
       ├── project
-      │    ├── columns: c_cast:21!null i_cast:22!null c:10 qc:11 i:12 s:13 d:14 d_comp:15 rowid:16!null crdb_internal_mvcc_timestamp:17 tableoid:18
+      │    ├── columns: c_cast:21!null i_cast:22!null c:10 qc:11 i:12 s:13 d:14 d_comp:15 rowid:16!null
       │    ├── project
-      │    │    ├── columns: c_new:19!null i_new:20!null c:10 qc:11 i:12 s:13 d:14 d_comp:15 rowid:16!null crdb_internal_mvcc_timestamp:17 tableoid:18
+      │    │    ├── columns: c_new:19!null i_new:20!null c:10 qc:11 i:12 s:13 d:14 d_comp:15 rowid:16!null
       │    │    ├── scan assn_cast
       │    │    │    ├── columns: c:10 qc:11 i:12 s:13 d:14 d_comp:15 rowid:16!null crdb_internal_mvcc_timestamp:17 tableoid:18
       │    │    │    └── computed column expressions
@@ -2130,29 +2146,31 @@ update decimals
  │    └── d_cast:16 => d:4
  ├── check columns: check1:17
  └── project
-      ├── columns: check1:17 check2:18 a:7!null b:8 c:9 d:10 crdb_internal_mvcc_timestamp:11 tableoid:12 a_cast:14 d_cast:16
+      ├── columns: check1:17 check2:18 a:7!null b:8 c:9 d:10 a_cast:14 d_cast:16
       ├── project
-      │    ├── columns: d_cast:16 a:7!null b:8 c:9 d:10 crdb_internal_mvcc_timestamp:11 tableoid:12 a_cast:14
+      │    ├── columns: d_cast:16 a:7!null b:8 c:9 d:10 a_cast:14
       │    ├── project
-      │    │    ├── columns: d_comp:15 a:7!null b:8 c:9 d:10 crdb_internal_mvcc_timestamp:11 tableoid:12 a_cast:14
+      │    │    ├── columns: d_comp:15 a:7!null b:8 c:9 d:10 a_cast:14
       │    │    ├── project
-      │    │    │    ├── columns: a_cast:14 a:7!null b:8 c:9 d:10 crdb_internal_mvcc_timestamp:11 tableoid:12
-      │    │    │    ├── left-join-apply
-      │    │    │    │    ├── columns: a:7!null b:8 c:9 d:10 crdb_internal_mvcc_timestamp:11 tableoid:12 n:13
-      │    │    │    │    ├── scan decimals
-      │    │    │    │    │    ├── columns: a:7!null b:8 c:9 d:10 crdb_internal_mvcc_timestamp:11 tableoid:12
-      │    │    │    │    │    └── computed column expressions
-      │    │    │    │    │         └── d:10
-      │    │    │    │    │              └── (a:7 + c:9)::DECIMAL(10,1)
-      │    │    │    │    ├── max1-row
-      │    │    │    │    │    ├── columns: n:13!null
-      │    │    │    │    │    └── project
-      │    │    │    │    │         ├── columns: n:13!null
-      │    │    │    │    │         ├── values
-      │    │    │    │    │         │    └── ()
-      │    │    │    │    │         └── projections
-      │    │    │    │    │              └── 1.45 [as=n:13]
-      │    │    │    │    └── filters (true)
+      │    │    │    ├── columns: a_cast:14 a:7!null b:8 c:9 d:10
+      │    │    │    ├── project
+      │    │    │    │    ├── columns: a:7!null b:8 c:9 d:10 n:13
+      │    │    │    │    └── left-join-apply
+      │    │    │    │         ├── columns: a:7!null b:8 c:9 d:10 crdb_internal_mvcc_timestamp:11 tableoid:12 n:13
+      │    │    │    │         ├── scan decimals
+      │    │    │    │         │    ├── columns: a:7!null b:8 c:9 d:10 crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    │    │    │         │    └── computed column expressions
+      │    │    │    │         │         └── d:10
+      │    │    │    │         │              └── (a:7 + c:9)::DECIMAL(10,1)
+      │    │    │    │         ├── max1-row
+      │    │    │    │         │    ├── columns: n:13!null
+      │    │    │    │         │    └── project
+      │    │    │    │         │         ├── columns: n:13!null
+      │    │    │    │         │         ├── values
+      │    │    │    │         │         │    └── ()
+      │    │    │    │         │         └── projections
+      │    │    │    │         │              └── 1.45 [as=n:13]
+      │    │    │    │         └── filters (true)
       │    │    │    └── projections
       │    │    │         └── assignment-cast: DECIMAL(10) [as=a_cast:14]
       │    │    │              └── n:13
@@ -2178,33 +2196,35 @@ update decimals
  │    └── d_cast:22 => d:4
  ├── check columns: check1:23
  └── project
-      ├── columns: check1:23 check2:24 a:7!null b:8 c:9 d:10 decimals.crdb_internal_mvcc_timestamp:11 decimals.tableoid:12 a_cast:19 c_cast:20 d_cast:22
+      ├── columns: check1:23 check2:24 a:7!null b:8 c:9 d:10 a_cast:19 c_cast:20 d_cast:22
       ├── project
-      │    ├── columns: d_cast:22 a:7!null b:8 c:9 d:10 decimals.crdb_internal_mvcc_timestamp:11 decimals.tableoid:12 a_cast:19 c_cast:20
+      │    ├── columns: d_cast:22 a:7!null b:8 c:9 d:10 a_cast:19 c_cast:20
       │    ├── project
-      │    │    ├── columns: d_comp:21 a:7!null b:8 c:9 d:10 decimals.crdb_internal_mvcc_timestamp:11 decimals.tableoid:12 a_cast:19 c_cast:20
+      │    │    ├── columns: d_comp:21 a:7!null b:8 c:9 d:10 a_cast:19 c_cast:20
       │    │    ├── project
-      │    │    │    ├── columns: a_cast:19 c_cast:20 a:7!null b:8 c:9 d:10 decimals.crdb_internal_mvcc_timestamp:11 decimals.tableoid:12
-      │    │    │    ├── left-join-apply
-      │    │    │    │    ├── columns: a:7!null b:8 c:9 d:10 decimals.crdb_internal_mvcc_timestamp:11 decimals.tableoid:12 u:13 "?column?":18
-      │    │    │    │    ├── scan decimals
-      │    │    │    │    │    ├── columns: a:7!null b:8 c:9 d:10 decimals.crdb_internal_mvcc_timestamp:11 decimals.tableoid:12
-      │    │    │    │    │    └── computed column expressions
-      │    │    │    │    │         └── d:10
-      │    │    │    │    │              └── (a:7 + c:9)::DECIMAL(10,1)
-      │    │    │    │    ├── max1-row
-      │    │    │    │    │    ├── columns: u:13!null "?column?":18!null
-      │    │    │    │    │    └── project
-      │    │    │    │    │         ├── columns: "?column?":18!null u:13!null
-      │    │    │    │    │         ├── select
-      │    │    │    │    │         │    ├── columns: u:13!null v:14 rowid:15!null uv.crdb_internal_mvcc_timestamp:16 uv.tableoid:17
-      │    │    │    │    │         │    ├── scan uv
-      │    │    │    │    │         │    │    └── columns: u:13 v:14 rowid:15!null uv.crdb_internal_mvcc_timestamp:16 uv.tableoid:17
-      │    │    │    │    │         │    └── filters
-      │    │    │    │    │         │         └── c:9 = u:13
-      │    │    │    │    │         └── projections
-      │    │    │    │    │              └── u:13 * 10.0 [as="?column?":18]
-      │    │    │    │    └── filters (true)
+      │    │    │    ├── columns: a_cast:19 c_cast:20 a:7!null b:8 c:9 d:10
+      │    │    │    ├── project
+      │    │    │    │    ├── columns: a:7!null b:8 c:9 d:10 u:13 "?column?":18
+      │    │    │    │    └── left-join-apply
+      │    │    │    │         ├── columns: a:7!null b:8 c:9 d:10 decimals.crdb_internal_mvcc_timestamp:11 decimals.tableoid:12 u:13 "?column?":18
+      │    │    │    │         ├── scan decimals
+      │    │    │    │         │    ├── columns: a:7!null b:8 c:9 d:10 decimals.crdb_internal_mvcc_timestamp:11 decimals.tableoid:12
+      │    │    │    │         │    └── computed column expressions
+      │    │    │    │         │         └── d:10
+      │    │    │    │         │              └── (a:7 + c:9)::DECIMAL(10,1)
+      │    │    │    │         ├── max1-row
+      │    │    │    │         │    ├── columns: u:13!null "?column?":18!null
+      │    │    │    │         │    └── project
+      │    │    │    │         │         ├── columns: "?column?":18!null u:13!null
+      │    │    │    │         │         ├── select
+      │    │    │    │         │         │    ├── columns: u:13!null v:14 rowid:15!null uv.crdb_internal_mvcc_timestamp:16 uv.tableoid:17
+      │    │    │    │         │         │    ├── scan uv
+      │    │    │    │         │         │    │    └── columns: u:13 v:14 rowid:15!null uv.crdb_internal_mvcc_timestamp:16 uv.tableoid:17
+      │    │    │    │         │         │    └── filters
+      │    │    │    │         │         │         └── c:9 = u:13
+      │    │    │    │         │         └── projections
+      │    │    │    │         │              └── u:13 * 10.0 [as="?column?":18]
+      │    │    │    │         └── filters (true)
       │    │    │    └── projections
       │    │    │         ├── assignment-cast: DECIMAL(10) [as=a_cast:19]
       │    │    │         │    └── u:13
@@ -2231,11 +2251,11 @@ update assn_cast
  │    ├── qc_cast:28 => qc:2
  │    └── "?column?":25 => i:3
  └── project
-      ├── columns: d_comp_comp:29 c:10 qc:11 i:12 s:13 d:14 d_comp:15 assn_cast.rowid:16!null assn_cast.crdb_internal_mvcc_timestamp:17 assn_cast.tableoid:18 "?column?":25 c_cast:27!null qc_cast:28
+      ├── columns: d_comp_comp:29 c:10 qc:11 i:12 s:13 d:14 d_comp:15 assn_cast.rowid:16!null "?column?":25 c_cast:27!null qc_cast:28
       ├── project
-      │    ├── columns: c_cast:27!null qc_cast:28 c:10 qc:11 i:12 s:13 d:14 d_comp:15 assn_cast.rowid:16!null assn_cast.crdb_internal_mvcc_timestamp:17 assn_cast.tableoid:18 "?column?":25
+      │    ├── columns: c_cast:27!null qc_cast:28 c:10 qc:11 i:12 s:13 d:14 d_comp:15 assn_cast.rowid:16!null "?column?":25
       │    ├── project
-      │    │    ├── columns: c_new:26!null c:10 qc:11 i:12 s:13 d:14 d_comp:15 assn_cast.rowid:16!null assn_cast.crdb_internal_mvcc_timestamp:17 assn_cast.tableoid:18 "?column?":24 "?column?":25
+      │    │    ├── columns: c_new:26!null c:10 qc:11 i:12 s:13 d:14 d_comp:15 assn_cast.rowid:16!null "?column?":24 "?column?":25
       │    │    ├── left-join-apply
       │    │    │    ├── columns: c:10 qc:11 i:12 s:13 d:14 d_comp:15 assn_cast.rowid:16!null assn_cast.crdb_internal_mvcc_timestamp:17 assn_cast.tableoid:18 "?column?":24 "?column?":25
       │    │    │    ├── scan assn_cast
@@ -2278,13 +2298,13 @@ update assn_cast_on_update
  │    ├── d_comp_cast:27 => d_comp:5
  │    └── b_new:20 => b:6
  └── project
-      ├── columns: d_comp_cast:27!null i:10 i2:11 d:12 d2:13 d_comp:14 b:15 rowid:16!null crdb_internal_mvcc_timestamp:17 tableoid:18 i_new:19!null b_new:20!null i2_cast:24!null d_cast:25!null d2_cast:26!null
+      ├── columns: d_comp_cast:27!null i:10 i2:11 d:12 d2:13 d_comp:14 b:15 rowid:16!null i_new:19!null b_new:20!null i2_cast:24!null d_cast:25!null d2_cast:26!null
       ├── project
-      │    ├── columns: i2_cast:24!null d_cast:25!null d2_cast:26!null i:10 i2:11 d:12 d2:13 d_comp:14 b:15 rowid:16!null crdb_internal_mvcc_timestamp:17 tableoid:18 i_new:19!null b_new:20!null
+      │    ├── columns: i2_cast:24!null d_cast:25!null d2_cast:26!null i:10 i2:11 d:12 d2:13 d_comp:14 b:15 rowid:16!null i_new:19!null b_new:20!null
       │    ├── project
-      │    │    ├── columns: i2_on_update:21!null d_on_update:22!null d2_on_update:23!null i:10 i2:11 d:12 d2:13 d_comp:14 b:15 rowid:16!null crdb_internal_mvcc_timestamp:17 tableoid:18 i_new:19!null b_new:20!null
+      │    │    ├── columns: i2_on_update:21!null d_on_update:22!null d2_on_update:23!null i:10 i2:11 d:12 d2:13 d_comp:14 b:15 rowid:16!null i_new:19!null b_new:20!null
       │    │    ├── project
-      │    │    │    ├── columns: i_new:19!null b_new:20!null i:10 i2:11 d:12 d2:13 d_comp:14 b:15 rowid:16!null crdb_internal_mvcc_timestamp:17 tableoid:18
+      │    │    │    ├── columns: i_new:19!null b_new:20!null i:10 i2:11 d:12 d2:13 d_comp:14 b:15 rowid:16!null
       │    │    │    ├── scan assn_cast_on_update
       │    │    │    │    ├── columns: i:10 i2:11 d:12 d2:13 d_comp:14 b:15 rowid:16!null crdb_internal_mvcc_timestamp:17 tableoid:18
       │    │    │    │    └── computed column expressions
@@ -2328,9 +2348,9 @@ update on_update_bare
  │    ├── a_new:11 => a:1
  │    └── v_on_update:12 => v:2
  └── project
-      ├── columns: v_on_update:12!null a:6!null v:7 rowid:8!null crdb_internal_mvcc_timestamp:9 tableoid:10 a_new:11!null
+      ├── columns: v_on_update:12!null a:6!null v:7 rowid:8!null a_new:11!null
       ├── project
-      │    ├── columns: a_new:11!null a:6!null v:7 rowid:8!null crdb_internal_mvcc_timestamp:9 tableoid:10
+      │    ├── columns: a_new:11!null a:6!null v:7 rowid:8!null
       │    ├── select
       │    │    ├── columns: a:6!null v:7 rowid:8!null crdb_internal_mvcc_timestamp:9 tableoid:10
       │    │    ├── scan on_update_bare
@@ -2352,7 +2372,7 @@ update on_update_bare
  │    ├── a_new:11 => a:1
  │    └── v_new:12 => v:2
  └── project
-      ├── columns: a_new:11!null v_new:12!null a:6!null v:7 rowid:8!null crdb_internal_mvcc_timestamp:9 tableoid:10
+      ├── columns: a_new:11!null v_new:12!null a:6!null v:7 rowid:8!null
       ├── select
       │    ├── columns: a:6!null v:7 rowid:8!null crdb_internal_mvcc_timestamp:9 tableoid:10
       │    ├── scan on_update_bare
@@ -2373,9 +2393,9 @@ update on_update_with_default
  │    ├── a_new:11 => a:1
  │    └── v_on_update:12 => v:2
  └── project
-      ├── columns: v_on_update:12!null a:6!null v:7 rowid:8!null crdb_internal_mvcc_timestamp:9 tableoid:10 a_new:11!null
+      ├── columns: v_on_update:12!null a:6!null v:7 rowid:8!null a_new:11!null
       ├── project
-      │    ├── columns: a_new:11!null a:6!null v:7 rowid:8!null crdb_internal_mvcc_timestamp:9 tableoid:10
+      │    ├── columns: a_new:11!null a:6!null v:7 rowid:8!null
       │    ├── select
       │    │    ├── columns: a:6!null v:7 rowid:8!null crdb_internal_mvcc_timestamp:9 tableoid:10
       │    │    ├── scan on_update_with_default
@@ -2397,7 +2417,7 @@ update on_update_with_default
  │    ├── a_new:11 => a:1
  │    └── v_new:12 => v:2
  └── project
-      ├── columns: a_new:11!null v_new:12!null a:6!null v:7 rowid:8!null crdb_internal_mvcc_timestamp:9 tableoid:10
+      ├── columns: a_new:11!null v_new:12!null a:6!null v:7 rowid:8!null
       ├── select
       │    ├── columns: a:6!null v:7 rowid:8!null crdb_internal_mvcc_timestamp:9 tableoid:10
       │    ├── scan on_update_with_default
@@ -2428,7 +2448,7 @@ update generated_as_identity
  ├── update-mapping:
  │    └── b_new:13 => b:2
  └── project
-      ├── columns: b_new:13 a:7 b:8!null c:9!null rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
+      ├── columns: b_new:13 a:7 b:8!null c:9!null rowid:10!null
       ├── scan generated_as_identity
       │    └── columns: a:7 b:8!null c:9!null rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
       └── projections
@@ -2444,7 +2464,7 @@ update generated_as_identity
  │    ├── a_new:13 => a:1
  │    └── b_new:14 => b:2
  └── project
-      ├── columns: a_new:13!null b_new:14 a:7 b:8!null c:9!null rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
+      ├── columns: a_new:13!null b_new:14 a:7 b:8!null c:9!null rowid:10!null
       ├── scan generated_as_identity
       │    └── columns: a:7 b:8!null c:9!null rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
       └── projections
@@ -2460,7 +2480,7 @@ update generated_as_identity
  ├── update-mapping:
  │    └── c_new:13 => c:3
  └── project
-      ├── columns: c_new:13!null a:7 b:8!null c:9!null rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
+      ├── columns: c_new:13!null a:7 b:8!null c:9!null rowid:10!null
       ├── scan generated_as_identity
       │    └── columns: a:7 b:8!null c:9!null rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
       └── projections
@@ -2476,7 +2496,7 @@ update generated_as_identity
  │    ├── a_new:13 => a:1
  │    └── c_new:14 => c:3
  └── project
-      ├── columns: a_new:13!null c_new:14!null a:7 b:8!null c:9!null rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
+      ├── columns: a_new:13!null c_new:14!null a:7 b:8!null c:9!null rowid:10!null
       ├── scan generated_as_identity
       │    └── columns: a:7 b:8!null c:9!null rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
       └── projections
@@ -2492,7 +2512,7 @@ update generated_as_identity
  ├── update-mapping:
  │    └── c_new:13 => c:3
  └── project
-      ├── columns: c_new:13 a:7 b:8!null c:9!null rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
+      ├── columns: c_new:13 a:7 b:8!null c:9!null rowid:10!null
       ├── scan generated_as_identity
       │    └── columns: a:7 b:8!null c:9!null rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
       └── projections
@@ -2508,7 +2528,7 @@ update generated_as_identity
  │    ├── a_new:13 => a:1
  │    └── c_new:14 => c:3
  └── project
-      ├── columns: a_new:13!null c_new:14 a:7 b:8!null c:9!null rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
+      ├── columns: a_new:13!null c_new:14 a:7 b:8!null c:9!null rowid:10!null
       ├── scan generated_as_identity
       │    └── columns: a:7 b:8!null c:9!null rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
       └── projections
@@ -2532,7 +2552,7 @@ update serial_t
  ├── update-mapping:
  │    └── a_new:11 => a:1
  └── project
-      ├── columns: a_new:11!null a:6 b:7 rowid:8!null crdb_internal_mvcc_timestamp:9 tableoid:10
+      ├── columns: a_new:11!null a:6 b:7 rowid:8!null
       ├── scan serial_t
       │    └── columns: a:6 b:7 rowid:8!null crdb_internal_mvcc_timestamp:9 tableoid:10
       └── projections
@@ -2547,7 +2567,7 @@ update serial_t
  ├── update-mapping:
  │    └── a_new:11 => a:1
  └── project
-      ├── columns: a_new:11 a:6 b:7 rowid:8!null crdb_internal_mvcc_timestamp:9 tableoid:10
+      ├── columns: a_new:11 a:6 b:7 rowid:8!null
       ├── scan serial_t
       │    └── columns: a:6 b:7 rowid:8!null crdb_internal_mvcc_timestamp:9 tableoid:10
       └── projections

--- a/pkg/sql/opt/optbuilder/testdata/update-col-cast-bug
+++ b/pkg/sql/opt/optbuilder/testdata/update-col-cast-bug
@@ -19,11 +19,11 @@ with &1 (cte)
       │    ├── a_new:16 => a:1
       │    └── c_cast:18 => t.c:3
       └── project
-           ├── columns: c_cast:18(int2) a:7(int2) b:8(int2) t.c:9(int2) rowid:10(int!null) crdb_internal_mvcc_timestamp:11(decimal) tableoid:12(oid) a_new:16(int2)
+           ├── columns: c_cast:18(int2) a:7(int2) b:8(int2) t.c:9(int2) rowid:10(int!null) a_new:16(int2)
            ├── project
-           │    ├── columns: c_comp:17(int) a:7(int2) b:8(int2) t.c:9(int2) rowid:10(int!null) crdb_internal_mvcc_timestamp:11(decimal) tableoid:12(oid) a_new:16(int2)
+           │    ├── columns: c_comp:17(int) a:7(int2) b:8(int2) t.c:9(int2) rowid:10(int!null) a_new:16(int2)
            │    ├── project
-           │    │    ├── columns: a_new:16(int2) a:7(int2) b:8(int2) t.c:9(int2) rowid:10(int!null) crdb_internal_mvcc_timestamp:11(decimal) tableoid:12(oid)
+           │    │    ├── columns: a_new:16(int2) a:7(int2) b:8(int2) t.c:9(int2) rowid:10(int!null)
            │    │    ├── project
            │    │    │    ├── columns: t.c:9(int2) a:7(int2) b:8(int2) rowid:10(int!null) crdb_internal_mvcc_timestamp:11(decimal) tableoid:12(oid)
            │    │    │    ├── scan t

--- a/pkg/sql/opt/optbuilder/testdata/update_from
+++ b/pkg/sql/opt/optbuilder/testdata/update_from
@@ -17,25 +17,16 @@ UPDATE abc SET b = other.b + 1, c = other.c + 1 FROM abc AS other WHERE abc.a = 
 update abc
  ├── columns: <none>
  ├── fetch columns: abc.a:6 abc.b:7 abc.c:8
- ├── passthrough columns: other.a:11 other.b:12 other.c:13 other.crdb_internal_mvcc_timestamp:14 other.tableoid:15
  ├── update-mapping:
  │    ├── b_new:16 => abc.b:2
  │    └── c_new:17 => abc.c:3
  └── project
-      ├── columns: b_new:16 c_new:17 abc.a:6!null abc.b:7 abc.c:8 other.a:11!null other.b:12 other.c:13 other.crdb_internal_mvcc_timestamp:14 other.tableoid:15
-      ├── project
-      │    ├── columns: other.a:11!null other.b:12 other.c:13 other.crdb_internal_mvcc_timestamp:14 other.tableoid:15 abc.a:6!null abc.b:7 abc.c:8
-      │    ├── scan abc
-      │    │    └── columns: abc.a:6!null abc.b:7 abc.c:8 abc.crdb_internal_mvcc_timestamp:9 abc.tableoid:10
-      │    └── projections
-      │         ├── abc.a:6 [as=other.a:11]
-      │         ├── abc.b:7 [as=other.b:12]
-      │         ├── abc.c:8 [as=other.c:13]
-      │         ├── abc.crdb_internal_mvcc_timestamp:9 [as=other.crdb_internal_mvcc_timestamp:14]
-      │         └── abc.tableoid:10 [as=other.tableoid:15]
+      ├── columns: b_new:16 c_new:17 abc.a:6!null abc.b:7 abc.c:8
+      ├── scan abc
+      │    └── columns: abc.a:6!null abc.b:7 abc.c:8
       └── projections
-           ├── other.b:12 + 1 [as=b_new:16]
-           └── other.c:13 + 1 [as=c_new:17]
+           ├── abc.b:7 + 1 [as=b_new:16]
+           └── abc.c:8 + 1 [as=c_new:17]
 
 # Test when Update uses multiple tables.
 opt
@@ -44,19 +35,18 @@ UPDATE abc SET b = other.b, c = other.c FROM new_abc AS other WHERE abc.a = othe
 update abc
  ├── columns: <none>
  ├── fetch columns: abc.a:6 abc.b:7 abc.c:8
- ├── passthrough columns: other.a:11 other.b:12 other.c:13 rowid:14 other.crdb_internal_mvcc_timestamp:15 other.tableoid:16
  ├── update-mapping:
  │    ├── other.b:12 => abc.b:2
  │    └── other.c:13 => abc.c:3
  └── distinct-on
-      ├── columns: abc.a:6!null abc.b:7 abc.c:8 other.a:11!null other.b:12 other.c:13 rowid:14!null other.crdb_internal_mvcc_timestamp:15 other.tableoid:16
+      ├── columns: abc.a:6!null abc.b:7 abc.c:8 other.b:12 other.c:13
       ├── grouping columns: abc.a:6!null
       ├── inner-join (hash)
-      │    ├── columns: abc.a:6!null abc.b:7 abc.c:8 other.a:11!null other.b:12 other.c:13 rowid:14!null other.crdb_internal_mvcc_timestamp:15 other.tableoid:16
+      │    ├── columns: abc.a:6!null abc.b:7 abc.c:8 other.a:11!null other.b:12 other.c:13
       │    ├── scan abc
       │    │    └── columns: abc.a:6!null abc.b:7 abc.c:8
       │    ├── scan new_abc [as=other]
-      │    │    └── columns: other.a:11 other.b:12 other.c:13 rowid:14!null other.crdb_internal_mvcc_timestamp:15 other.tableoid:16
+      │    │    └── columns: other.a:11 other.b:12 other.c:13
       │    └── filters
       │         └── abc.a:6 = other.a:11
       └── aggregations
@@ -64,18 +54,10 @@ update abc
            │    └── abc.b:7
            ├── first-agg [as=abc.c:8]
            │    └── abc.c:8
-           ├── first-agg [as=other.a:11]
-           │    └── other.a:11
            ├── first-agg [as=other.b:12]
            │    └── other.b:12
-           ├── first-agg [as=other.c:13]
-           │    └── other.c:13
-           ├── first-agg [as=rowid:14]
-           │    └── rowid:14
-           ├── first-agg [as=other.crdb_internal_mvcc_timestamp:15]
-           │    └── other.crdb_internal_mvcc_timestamp:15
-           └── first-agg [as=other.tableoid:16]
-                └── other.tableoid:16
+           └── first-agg [as=other.c:13]
+                └── other.c:13
 
 # Check if UPDATE FROM works well with RETURNING expressions that reference the FROM tables.
 opt
@@ -149,19 +131,18 @@ UPDATE abc SET b = old.b + 1, c = old.c + 2 FROM abc AS old WHERE abc.a = old.a 
 update abc
  ├── columns: <none>
  ├── fetch columns: abc.a:6 abc.b:7 abc.c:8
- ├── passthrough columns: old.a:11 old.b:12 old.c:13 old.crdb_internal_mvcc_timestamp:14 old.tableoid:15
  ├── update-mapping:
  │    ├── b_new:16 => abc.b:2
  │    └── c_new:17 => abc.c:3
  └── project
-      ├── columns: b_new:16 c_new:17 abc.a:6!null abc.b:7 abc.c:8 old.a:11!null old.b:12 old.c:13 old.crdb_internal_mvcc_timestamp:14 old.tableoid:15
+      ├── columns: b_new:16 c_new:17 abc.a:6!null abc.b:7 abc.c:8
       ├── inner-join (cross)
-      │    ├── columns: abc.a:6!null abc.b:7 abc.c:8 old.a:11!null old.b:12 old.c:13 old.crdb_internal_mvcc_timestamp:14 old.tableoid:15
+      │    ├── columns: abc.a:6!null abc.b:7 abc.c:8 old.a:11!null old.b:12 old.c:13
       │    ├── scan abc
       │    │    ├── columns: abc.a:6!null abc.b:7 abc.c:8
       │    │    └── constraint: /6: [/2 - /2]
       │    ├── scan abc [as=old]
-      │    │    ├── columns: old.a:11!null old.b:12 old.c:13 old.crdb_internal_mvcc_timestamp:14 old.tableoid:15
+      │    │    ├── columns: old.a:11!null old.b:12 old.c:13
       │    │    └── constraint: /11: [/2 - /2]
       │    └── filters (true)
       └── projections
@@ -175,12 +156,11 @@ UPDATE abc SET b = other.b, c = other.c FROM (values (1, 2, 3), (2, 3, 4)) as ot
 update abc
  ├── columns: <none>
  ├── fetch columns: a:6 b:7 c:8
- ├── passthrough columns: column1:11 column2:12 column3:13
  ├── update-mapping:
  │    ├── column2:12 => b:2
  │    └── column3:13 => c:3
  └── distinct-on
-      ├── columns: a:6!null b:7 c:8 column1:11!null column2:12!null column3:13!null
+      ├── columns: a:6!null b:7 c:8 column2:12!null column3:13!null
       ├── grouping columns: a:6!null
       ├── inner-join (lookup abc)
       │    ├── columns: a:6!null b:7 c:8 column1:11!null column2:12!null column3:13!null
@@ -196,8 +176,6 @@ update abc
            │    └── b:7
            ├── first-agg [as=c:8]
            │    └── c:8
-           ├── first-agg [as=column1:11]
-           │    └── column1:11
            ├── first-agg [as=column2:12]
            │    └── column2:12
            └── first-agg [as=column3:13]
@@ -218,23 +196,22 @@ UPDATE abc SET b = ab.b, c = ac.c FROM ab, ac WHERE abc.a = ab.a AND abc.a = ac.
 update abc
  ├── columns: <none>
  ├── fetch columns: abc.a:6 abc.b:7 abc.c:8
- ├── passthrough columns: ab.a:11 ab.b:12 ab.rowid:13 ab.crdb_internal_mvcc_timestamp:14 ab.tableoid:15 ac.a:16 ac.c:17 ac.rowid:18 ac.crdb_internal_mvcc_timestamp:19 ac.tableoid:20
  ├── update-mapping:
  │    ├── ab.b:12 => abc.b:2
  │    └── ac.c:17 => abc.c:3
  └── distinct-on
-      ├── columns: abc.a:6!null abc.b:7 abc.c:8 ab.a:11!null ab.b:12 ab.rowid:13!null ab.crdb_internal_mvcc_timestamp:14 ab.tableoid:15 ac.a:16!null ac.c:17 ac.rowid:18!null ac.crdb_internal_mvcc_timestamp:19 ac.tableoid:20
+      ├── columns: abc.a:6!null abc.b:7 abc.c:8 ab.b:12 ac.c:17
       ├── grouping columns: abc.a:6!null
       ├── inner-join (hash)
-      │    ├── columns: abc.a:6!null abc.b:7 abc.c:8 ab.a:11!null ab.b:12 ab.rowid:13!null ab.crdb_internal_mvcc_timestamp:14 ab.tableoid:15 ac.a:16!null ac.c:17 ac.rowid:18!null ac.crdb_internal_mvcc_timestamp:19 ac.tableoid:20
+      │    ├── columns: abc.a:6!null abc.b:7 abc.c:8 ab.a:11!null ab.b:12 ac.a:16!null ac.c:17
       │    ├── scan ab
-      │    │    └── columns: ab.a:11 ab.b:12 ab.rowid:13!null ab.crdb_internal_mvcc_timestamp:14 ab.tableoid:15
+      │    │    └── columns: ab.a:11 ab.b:12
       │    ├── inner-join (hash)
-      │    │    ├── columns: abc.a:6!null abc.b:7 abc.c:8 ac.a:16!null ac.c:17 ac.rowid:18!null ac.crdb_internal_mvcc_timestamp:19 ac.tableoid:20
+      │    │    ├── columns: abc.a:6!null abc.b:7 abc.c:8 ac.a:16!null ac.c:17
       │    │    ├── scan abc
       │    │    │    └── columns: abc.a:6!null abc.b:7 abc.c:8
       │    │    ├── scan ac
-      │    │    │    └── columns: ac.a:16 ac.c:17 ac.rowid:18!null ac.crdb_internal_mvcc_timestamp:19 ac.tableoid:20
+      │    │    │    └── columns: ac.a:16 ac.c:17
       │    │    └── filters
       │    │         └── abc.a:6 = ac.a:16
       │    └── filters
@@ -244,26 +221,10 @@ update abc
            │    └── abc.b:7
            ├── first-agg [as=abc.c:8]
            │    └── abc.c:8
-           ├── first-agg [as=ab.a:11]
-           │    └── ab.a:11
            ├── first-agg [as=ab.b:12]
            │    └── ab.b:12
-           ├── first-agg [as=ab.rowid:13]
-           │    └── ab.rowid:13
-           ├── first-agg [as=ab.crdb_internal_mvcc_timestamp:14]
-           │    └── ab.crdb_internal_mvcc_timestamp:14
-           ├── first-agg [as=ab.tableoid:15]
-           │    └── ab.tableoid:15
-           ├── first-agg [as=ac.a:16]
-           │    └── ac.a:16
-           ├── first-agg [as=ac.c:17]
-           │    └── ac.c:17
-           ├── first-agg [as=ac.rowid:18]
-           │    └── ac.rowid:18
-           ├── first-agg [as=ac.crdb_internal_mvcc_timestamp:19]
-           │    └── ac.crdb_internal_mvcc_timestamp:19
-           └── first-agg [as=ac.tableoid:20]
-                └── ac.tableoid:20
+           └── first-agg [as=ac.c:17]
+                └── ac.c:17
 
 # Make sure UPDATE ... FROM works with LATERAL.
 opt
@@ -384,20 +345,19 @@ UPDATE abc SET b = other.d FROM dec AS other WHERE abc.a = other.k
 update abc
  ├── columns: <none>
  ├── fetch columns: a:6 b:7 c:8
- ├── passthrough columns: k:11 d:12 other.crdb_internal_mvcc_timestamp:13 other.tableoid:14
  ├── update-mapping:
  │    └── b_cast:15 => b:2
  └── project
-      ├── columns: b_cast:15 a:6!null b:7 c:8 k:11!null d:12 other.crdb_internal_mvcc_timestamp:13 other.tableoid:14
+      ├── columns: b_cast:15 a:6!null b:7 c:8
       ├── inner-join (merge)
-      │    ├── columns: a:6!null b:7 c:8 k:11!null d:12 other.crdb_internal_mvcc_timestamp:13 other.tableoid:14
+      │    ├── columns: a:6!null b:7 c:8 k:11!null d:12
       │    ├── left ordering: +6
       │    ├── right ordering: +11
       │    ├── scan abc
       │    │    ├── columns: a:6!null b:7 c:8
       │    │    └── ordering: +6
       │    ├── scan dec [as=other]
-      │    │    ├── columns: k:11!null d:12 other.crdb_internal_mvcc_timestamp:13 other.tableoid:14
+      │    │    ├── columns: k:11!null d:12
       │    │    └── ordering: +11
       │    └── filters (true)
       └── projections

--- a/pkg/sql/opt/optbuilder/testdata/virtual-columns
+++ b/pkg/sql/opt/optbuilder/testdata/virtual-columns
@@ -505,9 +505,9 @@ update t
  │    ├── a_new:11 => a:1
  │    └── v_comp:12 => v:3
  └── project
-      ├── columns: v_comp:12 a:6!null b:7 v:8 crdb_internal_mvcc_timestamp:9 tableoid:10 a_new:11!null
+      ├── columns: v_comp:12 a:6!null b:7 v:8 a_new:11!null
       ├── project
-      │    ├── columns: a_new:11!null a:6!null b:7 v:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+      │    ├── columns: a_new:11!null a:6!null b:7 v:8
       │    ├── project
       │    │    ├── columns: v:8 a:6!null b:7 crdb_internal_mvcc_timestamp:9 tableoid:10
       │    │    ├── scan t
@@ -532,9 +532,9 @@ update t
  │    ├── a_new:11 => a:1
  │    └── v_comp:12 => v:3
  └── project
-      ├── columns: v_comp:12 a:6!null b:7 v:8!null crdb_internal_mvcc_timestamp:9 tableoid:10 a_new:11!null
+      ├── columns: v_comp:12 a:6!null b:7 v:8!null a_new:11!null
       ├── project
-      │    ├── columns: a_new:11!null a:6!null b:7 v:8!null crdb_internal_mvcc_timestamp:9 tableoid:10
+      │    ├── columns: a_new:11!null a:6!null b:7 v:8!null
       │    ├── select
       │    │    ├── columns: a:6!null b:7 v:8!null crdb_internal_mvcc_timestamp:9 tableoid:10
       │    │    ├── project
@@ -563,9 +563,9 @@ update t
  │    ├── a_new:11 => a:1
  │    └── v_comp:12 => v:3
  └── project
-      ├── columns: v_comp:12 a:6!null b:7 v:8 crdb_internal_mvcc_timestamp:9 tableoid:10 a_new:11!null
+      ├── columns: v_comp:12 a:6!null b:7 v:8 a_new:11!null
       ├── project
-      │    ├── columns: a_new:11!null a:6!null b:7 v:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+      │    ├── columns: a_new:11!null a:6!null b:7 v:8
       │    ├── select
       │    │    ├── columns: a:6!null b:7 v:8 crdb_internal_mvcc_timestamp:9 tableoid:10
       │    │    ├── project
@@ -628,9 +628,9 @@ update t_idx
  │    ├── a_new:11 => a:1
  │    └── v_comp:12 => v:3
  └── project
-      ├── columns: v_comp:12 a:6!null b:7 v:8 crdb_internal_mvcc_timestamp:9 tableoid:10 a_new:11!null
+      ├── columns: v_comp:12 a:6!null b:7 v:8 a_new:11!null
       ├── project
-      │    ├── columns: a_new:11!null a:6!null b:7 v:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+      │    ├── columns: a_new:11!null a:6!null b:7 v:8
       │    ├── project
       │    │    ├── columns: v:8 a:6!null b:7 crdb_internal_mvcc_timestamp:9 tableoid:10
       │    │    ├── scan t_idx
@@ -655,9 +655,9 @@ update t_idx
  │    ├── a_new:11 => a:1
  │    └── v_comp:12 => v:3
  └── project
-      ├── columns: v_comp:12 a:6!null b:7 v:8!null crdb_internal_mvcc_timestamp:9 tableoid:10 a_new:11!null
+      ├── columns: v_comp:12 a:6!null b:7 v:8!null a_new:11!null
       ├── project
-      │    ├── columns: a_new:11!null a:6!null b:7 v:8!null crdb_internal_mvcc_timestamp:9 tableoid:10
+      │    ├── columns: a_new:11!null a:6!null b:7 v:8!null
       │    ├── select
       │    │    ├── columns: a:6!null b:7 v:8!null crdb_internal_mvcc_timestamp:9 tableoid:10
       │    │    ├── project
@@ -686,9 +686,9 @@ update t_idx
  │    ├── a_new:11 => a:1
  │    └── v_comp:12 => v:3
  └── project
-      ├── columns: v_comp:12 a:6!null b:7 v:8 crdb_internal_mvcc_timestamp:9 tableoid:10 a_new:11!null
+      ├── columns: v_comp:12 a:6!null b:7 v:8 a_new:11!null
       ├── project
-      │    ├── columns: a_new:11!null a:6!null b:7 v:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+      │    ├── columns: a_new:11!null a:6!null b:7 v:8
       │    ├── select
       │    │    ├── columns: a:6!null b:7 v:8 crdb_internal_mvcc_timestamp:9 tableoid:10
       │    │    ├── project
@@ -791,11 +791,11 @@ update t_check
  │    └── w_comp:15 => w:4
  ├── check columns: check1:16 check2:17
  └── project
-      ├── columns: check1:16 check2:17 a:7!null b:8 v:9 w:10 crdb_internal_mvcc_timestamp:11 tableoid:12 b_new:13 v_comp:14 w_comp:15
+      ├── columns: check1:16 check2:17 a:7!null b:8 v:9 w:10 b_new:13 v_comp:14 w_comp:15
       ├── project
-      │    ├── columns: v_comp:14 w_comp:15 a:7!null b:8 v:9 w:10 crdb_internal_mvcc_timestamp:11 tableoid:12 b_new:13
+      │    ├── columns: v_comp:14 w_comp:15 a:7!null b:8 v:9 w:10 b_new:13
       │    ├── project
-      │    │    ├── columns: b_new:13 a:7!null b:8 v:9 w:10 crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    │    ├── columns: b_new:13 a:7!null b:8 v:9 w:10
       │    │    ├── project
       │    │    │    ├── columns: v:9 w:10 a:7!null b:8 crdb_internal_mvcc_timestamp:11 tableoid:12
       │    │    │    ├── scan t_check

--- a/pkg/sql/opt/xform/testdata/external/tpce
+++ b/pkg/sql/opt/xform/testdata/external/tpce
@@ -5279,23 +5279,22 @@ UPDATE settlement
 update settlement
  ├── columns: <none>
  ├── fetch columns: se_t_id:7 se_cash_type:8 se_cash_due_date:9 se_amt:10
- ├── passthrough columns: unnest:13 unnest:14
  ├── update-mapping:
  │    └── se_cash_type_cast:16 => se_cash_type:2
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  └── project
-      ├── columns: se_cash_type_cast:16!null se_t_id:7!null se_cash_type:8!null se_cash_due_date:9!null se_amt:10!null unnest:13!null unnest:14!null
+      ├── columns: se_cash_type_cast:16!null se_t_id:7!null se_cash_type:8!null se_cash_due_date:9!null se_amt:10!null
       ├── cardinality: [0 - 4]
       ├── immutable
       ├── key: (7)
-      ├── fd: (7)-->(8-10,13,14), (7)==(13), (13)==(7), (8,14)-->(16)
+      ├── fd: (7)-->(8-10,16)
       ├── distinct-on
-      │    ├── columns: se_t_id:7!null se_cash_type:8!null se_cash_due_date:9!null se_amt:10!null unnest:13!null unnest:14!null
+      │    ├── columns: se_t_id:7!null se_cash_type:8!null se_cash_due_date:9!null se_amt:10!null unnest:14!null
       │    ├── grouping columns: se_t_id:7!null
       │    ├── cardinality: [0 - 4]
       │    ├── key: (7)
-      │    ├── fd: (7)-->(8-10,13,14), (7)==(13), (13)==(7)
+      │    ├── fd: (7)-->(8-10,14)
       │    ├── inner-join (lookup settlement)
       │    │    ├── columns: se_t_id:7!null se_cash_type:8!null se_cash_due_date:9!null se_amt:10!null unnest:13!null unnest:14!null
       │    │    ├── key columns: [13] = [7]
@@ -5317,8 +5316,6 @@ update settlement
       │         │    └── se_cash_due_date:9
       │         ├── first-agg [as=se_amt:10, outer=(10)]
       │         │    └── se_amt:10
-      │         ├── first-agg [as=unnest:13, outer=(13)]
-      │         │    └── unnest:13
       │         └── first-agg [as=unnest:14, outer=(14)]
       │              └── unnest:14
       └── projections
@@ -5542,23 +5539,22 @@ UPDATE cash_transaction
 update cash_transaction
  ├── columns: <none>
  ├── fetch columns: ct_t_id:7 ct_dts:8 ct_amt:9 ct_name:10
- ├── passthrough columns: unnest:13 unnest:14 unnest:15 unnest:16
  ├── update-mapping:
  │    └── ct_name_cast:18 => ct_name:4
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  └── project
-      ├── columns: ct_name_cast:18 ct_t_id:7!null ct_dts:8!null ct_amt:9!null ct_name:10 unnest:13!null unnest:14!null unnest:15!null unnest:16!null
+      ├── columns: ct_name_cast:18 ct_t_id:7!null ct_dts:8!null ct_amt:9!null ct_name:10
       ├── cardinality: [0 - 4]
       ├── immutable
       ├── key: (7)
-      ├── fd: (7)-->(8-10,13-16), (7)==(13), (13)==(7), (10,14-16)-->(18)
+      ├── fd: (7)-->(8-10,18)
       ├── distinct-on
-      │    ├── columns: ct_t_id:7!null ct_dts:8!null ct_amt:9!null ct_name:10 unnest:13!null unnest:14!null unnest:15!null unnest:16!null
+      │    ├── columns: ct_t_id:7!null ct_dts:8!null ct_amt:9!null ct_name:10 unnest:14!null unnest:15!null unnest:16!null
       │    ├── grouping columns: ct_t_id:7!null
       │    ├── cardinality: [0 - 4]
       │    ├── key: (7)
-      │    ├── fd: (7)-->(8-10,13-16), (7)==(13), (13)==(7)
+      │    ├── fd: (7)-->(8-10,14-16)
       │    ├── inner-join (lookup cash_transaction)
       │    │    ├── columns: ct_t_id:7!null ct_dts:8!null ct_amt:9!null ct_name:10 unnest:13!null unnest:14!null unnest:15!null unnest:16!null
       │    │    ├── key columns: [13] = [7]
@@ -5580,8 +5576,6 @@ update cash_transaction
       │         │    └── ct_amt:9
       │         ├── first-agg [as=ct_name:10, outer=(10)]
       │         │    └── ct_name:10
-      │         ├── first-agg [as=unnest:13, outer=(13)]
-      │         │    └── unnest:13
       │         ├── first-agg [as=unnest:14, outer=(14)]
       │         │    └── unnest:14
       │         ├── first-agg [as=unnest:15, outer=(15)]
@@ -6144,35 +6138,30 @@ UPDATE watch_item
 update watch_item
  ├── columns: <none>
  ├── fetch columns: wi_wl_id:5 watch_item.wi_s_symb:6
- ├── passthrough columns: wl_id:9 wl_c_id:10 watch_list.crdb_internal_mvcc_timestamp:11 watch_list.tableoid:12
  ├── update-mapping:
  │    └── wi_s_symb_cast:14 => watch_item.wi_s_symb:2
  ├── input binding: &1
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── project
- │    ├── columns: wi_s_symb_cast:14!null wi_wl_id:5!null watch_item.wi_s_symb:6!null wl_id:9!null wl_c_id:10!null watch_list.crdb_internal_mvcc_timestamp:11 watch_list.tableoid:12
- │    ├── key: (9)
- │    ├── fd: ()-->(6,10,14), (9)-->(11,12), (5)==(9), (9)==(5)
+ │    ├── columns: wi_s_symb_cast:14!null wi_wl_id:5!null watch_item.wi_s_symb:6!null
+ │    ├── key: (5)
+ │    ├── fd: ()-->(6,14)
  │    ├── inner-join (lookup watch_item)
- │    │    ├── columns: wi_wl_id:5!null watch_item.wi_s_symb:6!null wl_id:9!null wl_c_id:10!null watch_list.crdb_internal_mvcc_timestamp:11 watch_list.tableoid:12
+ │    │    ├── columns: wi_wl_id:5!null watch_item.wi_s_symb:6!null wl_id:9!null wl_c_id:10!null
  │    │    ├── key columns: [9 35] = [5 6]
  │    │    ├── lookup columns are key
  │    │    ├── key: (9)
- │    │    ├── fd: ()-->(6,10), (9)-->(11,12), (5)==(9), (9)==(5)
+ │    │    ├── fd: ()-->(6,10), (5)==(9), (9)==(5)
  │    │    ├── project
- │    │    │    ├── columns: "lookup_join_const_col_@6":35!null wl_id:9!null wl_c_id:10!null watch_list.crdb_internal_mvcc_timestamp:11 watch_list.tableoid:12
+ │    │    │    ├── columns: "lookup_join_const_col_@6":35!null wl_id:9!null wl_c_id:10!null
  │    │    │    ├── key: (9)
- │    │    │    ├── fd: ()-->(10,35), (9)-->(11,12)
- │    │    │    ├── index-join watch_list
- │    │    │    │    ├── columns: wl_id:9!null wl_c_id:10!null watch_list.crdb_internal_mvcc_timestamp:11 watch_list.tableoid:12
+ │    │    │    ├── fd: ()-->(10,35)
+ │    │    │    ├── scan watch_list@watch_list_wl_c_id_idx
+ │    │    │    │    ├── columns: wl_id:9!null wl_c_id:10!null
+ │    │    │    │    ├── constraint: /10/9: [/0 - /0]
  │    │    │    │    ├── key: (9)
- │    │    │    │    ├── fd: ()-->(10), (9)-->(11,12)
- │    │    │    │    └── scan watch_list@watch_list_wl_c_id_idx
- │    │    │    │         ├── columns: wl_id:9!null wl_c_id:10!null
- │    │    │    │         ├── constraint: /10/9: [/0 - /0]
- │    │    │    │         ├── key: (9)
- │    │    │    │         └── fd: ()-->(10)
+ │    │    │    │    └── fd: ()-->(10)
  │    │    │    └── projections
  │    │    │         └── 'ROACH' [as="lookup_join_const_col_@6":35]
  │    │    └── filters (true)

--- a/pkg/sql/opt/xform/testdata/external/tpce-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpce-no-stats
@@ -5297,23 +5297,22 @@ UPDATE settlement
 update settlement
  ├── columns: <none>
  ├── fetch columns: se_t_id:7 se_cash_type:8 se_cash_due_date:9 se_amt:10
- ├── passthrough columns: unnest:13 unnest:14
  ├── update-mapping:
  │    └── se_cash_type_cast:16 => se_cash_type:2
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  └── project
-      ├── columns: se_cash_type_cast:16!null se_t_id:7!null se_cash_type:8!null se_cash_due_date:9!null se_amt:10!null unnest:13!null unnest:14!null
+      ├── columns: se_cash_type_cast:16!null se_t_id:7!null se_cash_type:8!null se_cash_due_date:9!null se_amt:10!null
       ├── cardinality: [0 - 4]
       ├── immutable
       ├── key: (7)
-      ├── fd: (7)-->(8-10,13,14), (7)==(13), (13)==(7), (8,14)-->(16)
+      ├── fd: (7)-->(8-10,16)
       ├── distinct-on
-      │    ├── columns: se_t_id:7!null se_cash_type:8!null se_cash_due_date:9!null se_amt:10!null unnest:13!null unnest:14!null
+      │    ├── columns: se_t_id:7!null se_cash_type:8!null se_cash_due_date:9!null se_amt:10!null unnest:14!null
       │    ├── grouping columns: se_t_id:7!null
       │    ├── cardinality: [0 - 4]
       │    ├── key: (7)
-      │    ├── fd: (7)-->(8-10,13,14), (7)==(13), (13)==(7)
+      │    ├── fd: (7)-->(8-10,14)
       │    ├── inner-join (lookup settlement)
       │    │    ├── columns: se_t_id:7!null se_cash_type:8!null se_cash_due_date:9!null se_amt:10!null unnest:13!null unnest:14!null
       │    │    ├── key columns: [13] = [7]
@@ -5335,8 +5334,6 @@ update settlement
       │         │    └── se_cash_due_date:9
       │         ├── first-agg [as=se_amt:10, outer=(10)]
       │         │    └── se_amt:10
-      │         ├── first-agg [as=unnest:13, outer=(13)]
-      │         │    └── unnest:13
       │         └── first-agg [as=unnest:14, outer=(14)]
       │              └── unnest:14
       └── projections
@@ -5559,23 +5556,22 @@ UPDATE cash_transaction
 update cash_transaction
  ├── columns: <none>
  ├── fetch columns: ct_t_id:7 ct_dts:8 ct_amt:9 ct_name:10
- ├── passthrough columns: unnest:13 unnest:14 unnest:15 unnest:16
  ├── update-mapping:
  │    └── ct_name_cast:18 => ct_name:4
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  └── project
-      ├── columns: ct_name_cast:18 ct_t_id:7!null ct_dts:8!null ct_amt:9!null ct_name:10 unnest:13!null unnest:14!null unnest:15!null unnest:16!null
+      ├── columns: ct_name_cast:18 ct_t_id:7!null ct_dts:8!null ct_amt:9!null ct_name:10
       ├── cardinality: [0 - 4]
       ├── immutable
       ├── key: (7)
-      ├── fd: (7)-->(8-10,13-16), (7)==(13), (13)==(7), (10,14-16)-->(18)
+      ├── fd: (7)-->(8-10,18)
       ├── distinct-on
-      │    ├── columns: ct_t_id:7!null ct_dts:8!null ct_amt:9!null ct_name:10 unnest:13!null unnest:14!null unnest:15!null unnest:16!null
+      │    ├── columns: ct_t_id:7!null ct_dts:8!null ct_amt:9!null ct_name:10 unnest:14!null unnest:15!null unnest:16!null
       │    ├── grouping columns: ct_t_id:7!null
       │    ├── cardinality: [0 - 4]
       │    ├── key: (7)
-      │    ├── fd: (7)-->(8-10,13-16), (7)==(13), (13)==(7)
+      │    ├── fd: (7)-->(8-10,14-16)
       │    ├── inner-join (lookup cash_transaction)
       │    │    ├── columns: ct_t_id:7!null ct_dts:8!null ct_amt:9!null ct_name:10 unnest:13!null unnest:14!null unnest:15!null unnest:16!null
       │    │    ├── key columns: [13] = [7]
@@ -5597,8 +5593,6 @@ update cash_transaction
       │         │    └── ct_amt:9
       │         ├── first-agg [as=ct_name:10, outer=(10)]
       │         │    └── ct_name:10
-      │         ├── first-agg [as=unnest:13, outer=(13)]
-      │         │    └── unnest:13
       │         ├── first-agg [as=unnest:14, outer=(14)]
       │         │    └── unnest:14
       │         ├── first-agg [as=unnest:15, outer=(15)]
@@ -6161,35 +6155,30 @@ UPDATE watch_item
 update watch_item
  ├── columns: <none>
  ├── fetch columns: wi_wl_id:5 watch_item.wi_s_symb:6
- ├── passthrough columns: wl_id:9 wl_c_id:10 watch_list.crdb_internal_mvcc_timestamp:11 watch_list.tableoid:12
  ├── update-mapping:
  │    └── wi_s_symb_cast:14 => watch_item.wi_s_symb:2
  ├── input binding: &1
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── project
- │    ├── columns: wi_s_symb_cast:14!null wi_wl_id:5!null watch_item.wi_s_symb:6!null wl_id:9!null wl_c_id:10!null watch_list.crdb_internal_mvcc_timestamp:11 watch_list.tableoid:12
- │    ├── key: (9)
- │    ├── fd: ()-->(6,10,14), (9)-->(11,12), (5)==(9), (9)==(5)
+ │    ├── columns: wi_s_symb_cast:14!null wi_wl_id:5!null watch_item.wi_s_symb:6!null
+ │    ├── key: (5)
+ │    ├── fd: ()-->(6,14)
  │    ├── inner-join (lookup watch_item)
- │    │    ├── columns: wi_wl_id:5!null watch_item.wi_s_symb:6!null wl_id:9!null wl_c_id:10!null watch_list.crdb_internal_mvcc_timestamp:11 watch_list.tableoid:12
+ │    │    ├── columns: wi_wl_id:5!null watch_item.wi_s_symb:6!null wl_id:9!null wl_c_id:10!null
  │    │    ├── key columns: [9 35] = [5 6]
  │    │    ├── lookup columns are key
  │    │    ├── key: (9)
- │    │    ├── fd: ()-->(6,10), (9)-->(11,12), (5)==(9), (9)==(5)
+ │    │    ├── fd: ()-->(6,10), (5)==(9), (9)==(5)
  │    │    ├── project
- │    │    │    ├── columns: "lookup_join_const_col_@6":35!null wl_id:9!null wl_c_id:10!null watch_list.crdb_internal_mvcc_timestamp:11 watch_list.tableoid:12
+ │    │    │    ├── columns: "lookup_join_const_col_@6":35!null wl_id:9!null wl_c_id:10!null
  │    │    │    ├── key: (9)
- │    │    │    ├── fd: ()-->(10,35), (9)-->(11,12)
- │    │    │    ├── index-join watch_list
- │    │    │    │    ├── columns: wl_id:9!null wl_c_id:10!null watch_list.crdb_internal_mvcc_timestamp:11 watch_list.tableoid:12
+ │    │    │    ├── fd: ()-->(10,35)
+ │    │    │    ├── scan watch_list@watch_list_wl_c_id_idx
+ │    │    │    │    ├── columns: wl_id:9!null wl_c_id:10!null
+ │    │    │    │    ├── constraint: /10/9: [/0 - /0]
  │    │    │    │    ├── key: (9)
- │    │    │    │    ├── fd: ()-->(10), (9)-->(11,12)
- │    │    │    │    └── scan watch_list@watch_list_wl_c_id_idx
- │    │    │    │         ├── columns: wl_id:9!null wl_c_id:10!null
- │    │    │    │         ├── constraint: /10/9: [/0 - /0]
- │    │    │    │         ├── key: (9)
- │    │    │    │         └── fd: ()-->(10)
+ │    │    │    │    └── fd: ()-->(10)
  │    │    │    └── projections
  │    │    │         └── 'ROACH' [as="lookup_join_const_col_@6":35]
  │    │    └── filters (true)

--- a/pkg/sql/opt/xform/testdata/external/trading
+++ b/pkg/sql/opt/xform/testdata/external/trading
@@ -1442,50 +1442,49 @@ WHERE ci.cardid = Updates.c AND ci.dealerid = 1
 update cardsinfo [as=ci]
  ├── columns: <none>
  ├── fetch columns: ci.dealerid:17 ci.cardid:18 buyprice:19 sellprice:20 discount:21 desiredinventory:22 actualinventory:23 maxinventory:24 ci.version:25
- ├── passthrough columns: c:28 q:29
  ├── update-mapping:
  │    └── actualinventory_new:39 => actualinventory:12
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  └── project
-      ├── columns: actualinventory_new:39 ci.dealerid:17!null ci.cardid:18!null buyprice:19!null sellprice:20!null discount:21!null desiredinventory:22!null actualinventory:23!null maxinventory:24!null ci.version:25!null c:28!null q:29!null
+      ├── columns: actualinventory_new:39 ci.dealerid:17!null ci.cardid:18!null buyprice:19!null sellprice:20!null discount:21!null desiredinventory:22!null actualinventory:23!null maxinventory:24!null ci.version:25!null
       ├── key: (18)
-      ├── fd: ()-->(17), (18)-->(19-25,28,29,39), (25)-->(18-24), (18)==(28), (28)==(18)
+      ├── fd: ()-->(17), (18)-->(19-25,39), (25)-->(18-24)
       ├── group-by (hash)
-      │    ├── columns: ci.dealerid:17!null ci.cardid:18!null buyprice:19!null sellprice:20!null discount:21!null desiredinventory:22!null actualinventory:23!null maxinventory:24!null ci.version:25!null c:28!null q:29!null sum_int:37
+      │    ├── columns: ci.dealerid:17!null ci.cardid:18!null buyprice:19!null sellprice:20!null discount:21!null desiredinventory:22!null actualinventory:23!null maxinventory:24!null ci.version:25!null sum_int:37
       │    ├── grouping columns: ci.cardid:18!null
       │    ├── key: (18)
-      │    ├── fd: ()-->(17), (18)-->(17,19-25,28,29,37), (25)-->(18-24), (18)==(28), (28)==(18)
+      │    ├── fd: ()-->(17), (18)-->(17,19-25,37), (25)-->(18-24)
       │    ├── left-join (lookup inventorydetails [as=id])
-      │    │    ├── columns: ci.dealerid:17!null ci.cardid:18!null buyprice:19!null sellprice:20!null discount:21!null desiredinventory:22!null actualinventory:23!null maxinventory:24!null ci.version:25!null c:28!null q:29!null id.dealerid:30 id.cardid:31 quantity:33
+      │    │    ├── columns: ci.dealerid:17!null ci.cardid:18!null buyprice:19!null sellprice:20!null discount:21!null desiredinventory:22!null actualinventory:23!null maxinventory:24!null ci.version:25!null id.dealerid:30 id.cardid:31 quantity:33
       │    │    ├── key columns: [42 18] = [30 31]
-      │    │    ├── fd: ()-->(17), (18)-->(19-25,28,29), (25)-->(18-24), (18)==(28), (28)==(18)
+      │    │    ├── fd: ()-->(17), (18)-->(19-25), (25)-->(18-24)
       │    │    ├── project
-      │    │    │    ├── columns: "lookup_join_const_col_@30":42!null ci.dealerid:17!null ci.cardid:18!null buyprice:19!null sellprice:20!null discount:21!null desiredinventory:22!null actualinventory:23!null maxinventory:24!null ci.version:25!null c:28!null q:29!null
+      │    │    │    ├── columns: "lookup_join_const_col_@30":42!null ci.dealerid:17!null ci.cardid:18!null buyprice:19!null sellprice:20!null discount:21!null desiredinventory:22!null actualinventory:23!null maxinventory:24!null ci.version:25!null
       │    │    │    ├── cardinality: [0 - 2]
       │    │    │    ├── key: (18)
-      │    │    │    ├── fd: ()-->(17,42), (18)-->(19-25,28,29), (25)-->(18-24), (18)==(28), (28)==(18)
+      │    │    │    ├── fd: ()-->(17,42), (18)-->(19-25), (25)-->(18-24)
       │    │    │    ├── distinct-on
-      │    │    │    │    ├── columns: ci.dealerid:17!null ci.cardid:18!null buyprice:19!null sellprice:20!null discount:21!null desiredinventory:22!null actualinventory:23!null maxinventory:24!null ci.version:25!null c:28!null q:29!null
+      │    │    │    │    ├── columns: ci.dealerid:17!null ci.cardid:18!null buyprice:19!null sellprice:20!null discount:21!null desiredinventory:22!null actualinventory:23!null maxinventory:24!null ci.version:25!null
       │    │    │    │    ├── grouping columns: ci.cardid:18!null
       │    │    │    │    ├── cardinality: [0 - 2]
       │    │    │    │    ├── key: (18)
-      │    │    │    │    ├── fd: ()-->(17), (18)-->(17,19-25,28,29), (25)-->(18-24), (18)==(28), (28)==(18)
+      │    │    │    │    ├── fd: ()-->(17), (18)-->(17,19-25), (25)-->(18-24)
       │    │    │    │    ├── inner-join (lookup cardsinfo [as=ci])
-      │    │    │    │    │    ├── columns: ci.dealerid:17!null ci.cardid:18!null buyprice:19!null sellprice:20!null discount:21!null desiredinventory:22!null actualinventory:23!null maxinventory:24!null ci.version:25!null c:28!null q:29!null
+      │    │    │    │    │    ├── columns: ci.dealerid:17!null ci.cardid:18!null buyprice:19!null sellprice:20!null discount:21!null desiredinventory:22!null actualinventory:23!null maxinventory:24!null ci.version:25!null c:28!null
       │    │    │    │    │    ├── key columns: [40 28] = [17 18]
       │    │    │    │    │    ├── lookup columns are key
       │    │    │    │    │    ├── cardinality: [0 - 2]
       │    │    │    │    │    ├── fd: ()-->(17), (18)-->(19-25), (25)-->(18-24), (18)==(28), (28)==(18)
       │    │    │    │    │    ├── project
-      │    │    │    │    │    │    ├── columns: "lookup_join_const_col_@17":40!null c:28!null q:29!null
+      │    │    │    │    │    │    ├── columns: "lookup_join_const_col_@17":40!null c:28!null
       │    │    │    │    │    │    ├── cardinality: [2 - 2]
       │    │    │    │    │    │    ├── fd: ()-->(40)
       │    │    │    │    │    │    ├── values
-      │    │    │    │    │    │    │    ├── columns: c:28!null q:29!null
+      │    │    │    │    │    │    │    ├── columns: c:28!null
       │    │    │    │    │    │    │    ├── cardinality: [2 - 2]
-      │    │    │    │    │    │    │    ├── (42948, 3)
-      │    │    │    │    │    │    │    └── (24924, 4)
+      │    │    │    │    │    │    │    ├── (42948,)
+      │    │    │    │    │    │    │    └── (24924,)
       │    │    │    │    │    │    └── projections
       │    │    │    │    │    │         └── 1 [as="lookup_join_const_col_@17":40]
       │    │    │    │    │    └── filters (true)
@@ -1504,10 +1503,6 @@ update cardsinfo [as=ci]
       │    │    │    │         │    └── maxinventory:24
       │    │    │    │         ├── first-agg [as=ci.version:25, outer=(25)]
       │    │    │    │         │    └── ci.version:25
-      │    │    │    │         ├── first-agg [as=c:28, outer=(28)]
-      │    │    │    │         │    └── c:28
-      │    │    │    │         ├── first-agg [as=q:29, outer=(29)]
-      │    │    │    │         │    └── q:29
       │    │    │    │         └── const-agg [as=ci.dealerid:17, outer=(17)]
       │    │    │    │              └── ci.dealerid:17
       │    │    │    └── projections
@@ -1530,11 +1525,7 @@ update cardsinfo [as=ci]
       │         │    └── actualinventory:23
       │         ├── const-agg [as=maxinventory:24, outer=(24)]
       │         │    └── maxinventory:24
-      │         ├── const-agg [as=ci.version:25, outer=(25)]
-      │         │    └── ci.version:25
-      │         ├── const-agg [as=c:28, outer=(28)]
-      │         │    └── c:28
-      │         └── const-agg [as=q:29, outer=(29)]
-      │              └── q:29
+      │         └── const-agg [as=ci.version:25, outer=(25)]
+      │              └── ci.version:25
       └── projections
            └── COALESCE(sum_int:37, 0) [as=actualinventory_new:39, outer=(37)]

--- a/pkg/sql/opt/xform/testdata/external/trading-mutation
+++ b/pkg/sql/opt/xform/testdata/external/trading-mutation
@@ -1454,7 +1454,6 @@ WHERE ci.cardid = Updates.c AND ci.dealerid = 1
 update cardsinfo [as=ci]
  ├── columns: <none>
  ├── fetch columns: ci.dealerid:21 ci.cardid:22 buyprice:23 sellprice:24 discount:25 desiredinventory:26 actualinventory:27 maxinventory:28 ci.version:29 discountbuyprice:30 notes:31 oldinventory:32 ci.extra:33
- ├── passthrough columns: c:36 q:37
  ├── update-mapping:
  │    ├── actualinventory_new:49 => actualinventory:12
  │    ├── discountbuyprice_cast:53 => discountbuyprice:15
@@ -1463,45 +1462,45 @@ update cardsinfo [as=ci]
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  └── project
-      ├── columns: discountbuyprice_cast:53!null notes_default:50 oldinventory_default:51!null actualinventory_new:49 ci.dealerid:21!null ci.cardid:22!null buyprice:23!null sellprice:24!null discount:25!null desiredinventory:26!null actualinventory:27!null maxinventory:28!null ci.version:29!null discountbuyprice:30 notes:31 oldinventory:32 ci.extra:33 c:36!null q:37!null
+      ├── columns: discountbuyprice_cast:53!null notes_default:50 oldinventory_default:51!null actualinventory_new:49 ci.dealerid:21!null ci.cardid:22!null buyprice:23!null sellprice:24!null discount:25!null desiredinventory:26!null actualinventory:27!null maxinventory:28!null ci.version:29!null discountbuyprice:30 notes:31 oldinventory:32 ci.extra:33
       ├── immutable
       ├── key: (22)
-      ├── fd: ()-->(21,50,51), (22)-->(23-33,36,37,49,53), (29)-->(22-28,30-33), (22)==(36), (36)==(22)
+      ├── fd: ()-->(21,50,51), (22)-->(23-33,49,53), (29)-->(22-28,30-33)
       ├── group-by (hash)
-      │    ├── columns: ci.dealerid:21!null ci.cardid:22!null buyprice:23!null sellprice:24!null discount:25!null desiredinventory:26!null actualinventory:27!null maxinventory:28!null ci.version:29!null discountbuyprice:30 notes:31 oldinventory:32 ci.extra:33 c:36!null q:37!null sum_int:47
+      │    ├── columns: ci.dealerid:21!null ci.cardid:22!null buyprice:23!null sellprice:24!null discount:25!null desiredinventory:26!null actualinventory:27!null maxinventory:28!null ci.version:29!null discountbuyprice:30 notes:31 oldinventory:32 ci.extra:33 sum_int:47
       │    ├── grouping columns: ci.cardid:22!null
       │    ├── key: (22)
-      │    ├── fd: ()-->(21), (22)-->(21,23-33,36,37,47), (29)-->(22-28,30-33), (22)==(36), (36)==(22)
+      │    ├── fd: ()-->(21), (22)-->(21,23-33,47), (29)-->(22-28,30-33)
       │    ├── left-join (lookup inventorydetails [as=id])
-      │    │    ├── columns: ci.dealerid:21!null ci.cardid:22!null buyprice:23!null sellprice:24!null discount:25!null desiredinventory:26!null actualinventory:27!null maxinventory:28!null ci.version:29!null discountbuyprice:30 notes:31 oldinventory:32 ci.extra:33 c:36!null q:37!null id.dealerid:38 id.cardid:39 quantity:41
+      │    │    ├── columns: ci.dealerid:21!null ci.cardid:22!null buyprice:23!null sellprice:24!null discount:25!null desiredinventory:26!null actualinventory:27!null maxinventory:28!null ci.version:29!null discountbuyprice:30 notes:31 oldinventory:32 ci.extra:33 id.dealerid:38 id.cardid:39 quantity:41
       │    │    ├── key columns: [56 22] = [38 39]
-      │    │    ├── fd: ()-->(21), (22)-->(23-33,36,37), (29)-->(22-28,30-33), (22)==(36), (36)==(22)
+      │    │    ├── fd: ()-->(21), (22)-->(23-33), (29)-->(22-28,30-33)
       │    │    ├── project
-      │    │    │    ├── columns: "lookup_join_const_col_@38":56!null ci.dealerid:21!null ci.cardid:22!null buyprice:23!null sellprice:24!null discount:25!null desiredinventory:26!null actualinventory:27!null maxinventory:28!null ci.version:29!null discountbuyprice:30 notes:31 oldinventory:32 ci.extra:33 c:36!null q:37!null
+      │    │    │    ├── columns: "lookup_join_const_col_@38":56!null ci.dealerid:21!null ci.cardid:22!null buyprice:23!null sellprice:24!null discount:25!null desiredinventory:26!null actualinventory:27!null maxinventory:28!null ci.version:29!null discountbuyprice:30 notes:31 oldinventory:32 ci.extra:33
       │    │    │    ├── cardinality: [0 - 2]
       │    │    │    ├── key: (22)
-      │    │    │    ├── fd: ()-->(21,56), (22)-->(23-33,36,37), (29)-->(22-28,30-33), (22)==(36), (36)==(22)
+      │    │    │    ├── fd: ()-->(21,56), (22)-->(23-33), (29)-->(22-28,30-33)
       │    │    │    ├── distinct-on
-      │    │    │    │    ├── columns: ci.dealerid:21!null ci.cardid:22!null buyprice:23!null sellprice:24!null discount:25!null desiredinventory:26!null actualinventory:27!null maxinventory:28!null ci.version:29!null discountbuyprice:30 notes:31 oldinventory:32 ci.extra:33 c:36!null q:37!null
+      │    │    │    │    ├── columns: ci.dealerid:21!null ci.cardid:22!null buyprice:23!null sellprice:24!null discount:25!null desiredinventory:26!null actualinventory:27!null maxinventory:28!null ci.version:29!null discountbuyprice:30 notes:31 oldinventory:32 ci.extra:33
       │    │    │    │    ├── grouping columns: ci.cardid:22!null
       │    │    │    │    ├── cardinality: [0 - 2]
       │    │    │    │    ├── key: (22)
-      │    │    │    │    ├── fd: ()-->(21), (22)-->(21,23-33,36,37), (29)-->(22-28,30-33), (22)==(36), (36)==(22)
+      │    │    │    │    ├── fd: ()-->(21), (22)-->(21,23-33), (29)-->(22-28,30-33)
       │    │    │    │    ├── inner-join (lookup cardsinfo [as=ci])
-      │    │    │    │    │    ├── columns: ci.dealerid:21!null ci.cardid:22!null buyprice:23!null sellprice:24!null discount:25!null desiredinventory:26!null actualinventory:27!null maxinventory:28!null ci.version:29!null discountbuyprice:30 notes:31 oldinventory:32 ci.extra:33 c:36!null q:37!null
+      │    │    │    │    │    ├── columns: ci.dealerid:21!null ci.cardid:22!null buyprice:23!null sellprice:24!null discount:25!null desiredinventory:26!null actualinventory:27!null maxinventory:28!null ci.version:29!null discountbuyprice:30 notes:31 oldinventory:32 ci.extra:33 c:36!null
       │    │    │    │    │    ├── key columns: [54 36] = [21 22]
       │    │    │    │    │    ├── lookup columns are key
       │    │    │    │    │    ├── cardinality: [0 - 2]
       │    │    │    │    │    ├── fd: ()-->(21), (22)-->(23-33), (29)-->(22-28,30-33), (22)==(36), (36)==(22)
       │    │    │    │    │    ├── project
-      │    │    │    │    │    │    ├── columns: "lookup_join_const_col_@21":54!null c:36!null q:37!null
+      │    │    │    │    │    │    ├── columns: "lookup_join_const_col_@21":54!null c:36!null
       │    │    │    │    │    │    ├── cardinality: [2 - 2]
       │    │    │    │    │    │    ├── fd: ()-->(54)
       │    │    │    │    │    │    ├── values
-      │    │    │    │    │    │    │    ├── columns: c:36!null q:37!null
+      │    │    │    │    │    │    │    ├── columns: c:36!null
       │    │    │    │    │    │    │    ├── cardinality: [2 - 2]
-      │    │    │    │    │    │    │    ├── (42948, 3)
-      │    │    │    │    │    │    │    └── (24924, 4)
+      │    │    │    │    │    │    │    ├── (42948,)
+      │    │    │    │    │    │    │    └── (24924,)
       │    │    │    │    │    │    └── projections
       │    │    │    │    │    │         └── 1 [as="lookup_join_const_col_@21":54]
       │    │    │    │    │    └── filters (true)
@@ -1528,10 +1527,6 @@ update cardsinfo [as=ci]
       │    │    │    │         │    └── oldinventory:32
       │    │    │    │         ├── first-agg [as=ci.extra:33, outer=(33)]
       │    │    │    │         │    └── ci.extra:33
-      │    │    │    │         ├── first-agg [as=c:36, outer=(36)]
-      │    │    │    │         │    └── c:36
-      │    │    │    │         ├── first-agg [as=q:37, outer=(37)]
-      │    │    │    │         │    └── q:37
       │    │    │    │         └── const-agg [as=ci.dealerid:21, outer=(21)]
       │    │    │    │              └── ci.dealerid:21
       │    │    │    └── projections
@@ -1562,12 +1557,8 @@ update cardsinfo [as=ci]
       │         │    └── notes:31
       │         ├── const-agg [as=oldinventory:32, outer=(32)]
       │         │    └── oldinventory:32
-      │         ├── const-agg [as=ci.extra:33, outer=(33)]
-      │         │    └── ci.extra:33
-      │         ├── const-agg [as=c:36, outer=(36)]
-      │         │    └── c:36
-      │         └── const-agg [as=q:37, outer=(37)]
-      │              └── q:37
+      │         └── const-agg [as=ci.extra:33, outer=(33)]
+      │              └── ci.extra:33
       └── projections
            ├── assignment-cast: DECIMAL(10,4) [as=discountbuyprice_cast:53, outer=(23,25), immutable]
            │    └── buyprice:23 - discount:25


### PR DESCRIPTION
optbuilder: only project needed columns for update

Previously, UPDATE ... FROM statements would not project away columns
unreferenced in the SET or RETURNING clauses of the UPDATE statement,
leading to the unnecessary allocation of memory for columns which are
not used. This could lead to high processing times and possible OOM
conditions.

The problem is due to unconditionally adding all columns from the input
scope of the update to the projection scope of update. Only the columns
which are needed to perform the update should be included, except when
there is a RETURNING clause. The fix is to build the build the
projection with only the rows needed for the update row. These
projections are then pushed into the input expressions by query rewrite
rules, and the unneeded columns are pruned away as early as possible.

Epic: none
Informs: #109309

Release note (bug fix): This patch reduces memory allocations in
UPDATE ... FROM statements involving tables with many columns in
the FROM clause.