### PR TITLE
loqrecovery: reproduce test failure from #111163

### DIFF
--- a/pkg/base/config.go
+++ b/pkg/base/config.go
@@ -153,7 +153,7 @@ var (
 	// second in order to fail fast, but with large default timeouts to tolerate
 	// high-latency multiregion clusters. The gRPC server keepalive interval is
 	// also affected by this.
-	PingInterval = envutil.EnvOrDefaultDuration("COCKROACH_PING_INTERVAL", time.Second)
+	PingInterval = envutil.EnvOrDefaultDuration("COCKROACH_PING_INTERVAL", 10*time.Second)
 
 	// defaultRangeLeaseDuration specifies the default range lease duration.
 	//

--- a/pkg/kv/kvserver/loqrecovery/server_integration_test.go
+++ b/pkg/kv/kvserver/loqrecovery/server_integration_test.go
@@ -649,6 +649,7 @@ func TestRejectBadVersionApplication(t *testing.T) {
 	tc.StopServer(1)
 	require.NoError(t, pss[1].SavePlan(plan), "failed to inject plan into storage")
 	require.NoError(t, tc.RestartServer(1), "failed to restart server")
+	time.Sleep(5 * time.Second)
 
 	r, err := adm.RecoveryVerify(ctx, &serverpb.RecoveryVerifyRequest{})
 	require.NoError(t, err, "failed to run recovery verify")

--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -1787,6 +1787,7 @@ func (tc *TestCluster) RestartServerWithInspect(
 	// node. This is useful to avoid flakes: the newly restarted node is now on a
 	// different port, and a cycle of gossip is necessary to make all other nodes
 	// aware.
+	s.NodeID()
 	return timeutil.RunWithTimeout(
 		ctx, "check-conn", 15*time.Second,
 		func(ctx context.Context) error {


### PR DESCRIPTION
TestRejectBadVersionApplication fails eagerly under --stress.

Informs #111163
Epic: none
Release note: none