### PR TITLE
asim: remove extra new line in PrintSpanConfigConformanceList 

### DIFF
--- a/pkg/kv/kvserver/asim/assertion/assert.go
+++ b/pkg/kv/kvserver/asim/assertion/assert.go
@@ -405,8 +405,11 @@ func PrintSpanConfigConformanceList(tag string, ranges []roachpb.ConformanceRepo
 		if i == 0 {
 			buf.WriteString(fmt.Sprintf("%s:\n", tag))
 		}
-		buf.WriteString(fmt.Sprintf("  %s applying %s\n", printRangeDesc(r.RangeDescriptor),
+		buf.WriteString(fmt.Sprintf("  %s applying %s", printRangeDesc(r.RangeDescriptor),
 			spanconfigtestutils.PrintSpanConfigDiffedAgainstDefaults(r.Config)))
+		if i != len(ranges)-1 {
+			buf.WriteString("\n")
+		}
 	}
 	return buf.String()
 }

--- a/pkg/kv/kvserver/asim/tests/output.go
+++ b/pkg/kv/kvserver/asim/tests/output.go
@@ -169,7 +169,7 @@ func (tr testResultsReport) String() string {
 			buf.WriteString(output.eventExecutor.PrintEventsExecuted())
 		}
 		if failed {
-			buf.WriteString(fmt.Sprintf("sample%d: failed assertion\n%s", nthSample, output.reason))
+			buf.WriteString(fmt.Sprintf("sample%d: failed assertion\n%s\n", nthSample, output.reason))
 		} else {
 			buf.WriteString(fmt.Sprintf("sample%d: pass\n", nthSample))
 		}


### PR DESCRIPTION
Previously, PrintSpanConfigConformanceList included an extra line at the end.
Following the asim output convention, most output functions defer the decision
to include this extra line to caller  (top level) rather than the callee
functions. This patch removes the extra line in PrintSpanConfigConformanceList.

Epic: None

Release Note: None