### PR TITLE
release: fix roachtest artifacts name

### DIFF
--- a/build/teamcity/internal/release/process/roachtest-release-qualification.sh
+++ b/build/teamcity/internal/release/process/roachtest-release-qualification.sh
@@ -21,7 +21,7 @@ if [[ ! -f ~/.ssh/id_rsa.pub ]]; then
   ssh-keygen -q -N "" -f ~/.ssh/id_rsa
 fi
 
-artifacts=$PWD/artifacts/$(date +"%%Y%%m%%d")-${TC_BUILD_ID}
+artifacts=$PWD/artifacts/$(date +"%Y%m%d")-${TC_BUILD_ID}
 mkdir -p "$artifacts"
 
 if [[ ${FIPS_ENABLED:-0} == 1 ]]; then


### PR DESCRIPTION
This fixes the roachtest artifacts directory name.

Epic: none
Release note: None