### PR TITLE
rangefeed: don't advance resolved ts on txn abort

### DIFF
--- a/pkg/kv/kvserver/rangefeed/processor.go
+++ b/pkg/kv/kvserver/rangefeed/processor.go
@@ -808,9 +808,6 @@ func (p *LegacyProcessor) consumeLogicalOps(
 		case *enginepb.MVCCAbortIntentOp:
 			// No updates to publish.
 
-		case *enginepb.MVCCAbortTxnOp:
-			// No updates to publish.
-
 		default:
 			panic(errors.AssertionFailedf("unknown logical op %T", t))
 		}

--- a/pkg/kv/kvserver/rangefeed/resolved_timestamp.go
+++ b/pkg/kv/kvserver/rangefeed/resolved_timestamp.go
@@ -165,51 +165,6 @@ func (rts *resolvedTimestamp) consumeLogicalOp(op enginepb.MVCCLogicalOp) bool {
 		// about the transaction other than to decrement its reference count.
 		return rts.intentQ.DecrRef(t.TxnID, hlc.Timestamp{})
 
-	case *enginepb.MVCCAbortTxnOp:
-		// Unlike the previous case, an aborted transaction does indicate
-		// that none of the transaction's intents will ever be committed.
-		// This means that we can stop tracking the transaction entirely.
-		// Doing so is critical to ensure forward progress of the resolved
-		// timestamp in situtations where the oldest transaction on a range
-		// is abandoned and the locations of its intents are unknown.
-		//
-		// However, the transaction may also still be writing, updating, and
-		// resolving (aborting) its intents, so we need to be careful with
-		// how we handle any future operations from this transaction. There
-		// are three different operations we could see the zombie transaction
-		// perform:
-		//
-		// - MVCCWriteIntentOp: it could write another intent. This could result
-		//     in "reintroducing" the transaction to the queue. We allow this
-		//     to happen and rely on pushing the transaction again, eventually
-		//     evicting the transaction from the queue for good.
-		//
-		//     Just like any other transaction, this new intent will necessarily
-		//     be pushed above the closed timestamp, so we don't need to worry
-		//     about resolved timestamp regressions.
-		//
-		// - MVCCUpdateIntentOp: it could update one of its intents. If we're
-		//     not already tracking the transaction then the queue will ignore
-		//     the intent update.
-		//
-		// - MVCCAbortIntentOp: it could resolve one of its intents as aborted.
-		//     This is the most likely case. Again, if we're not already tracking
-		//     the transaction then the queue will ignore the intent abort.
-		//
-		if !rts.IsInit() {
-			// We ignore MVCCAbortTxnOp operations until the queue is
-			// initialized. This is necessary because we allow txn reference
-			// counts to drop below zero before the queue is initialized and
-			// expect that all reference count decrements be balanced by a
-			// corresponding reference count increment.
-			//
-			// We could remove this restriction if we evicted all transactions
-			// with negative reference counts after initialization, but this is
-			// easier and more clear.
-			return false
-		}
-		return rts.intentQ.Del(t.TxnID)
-
 	default:
 		panic(errors.AssertionFailedf("unknown logical op %T", t))
 	}

--- a/pkg/kv/kvserver/rangefeed/scheduled_processor.go
+++ b/pkg/kv/kvserver/rangefeed/scheduled_processor.go
@@ -652,9 +652,6 @@ func (p *ScheduledProcessor) consumeLogicalOps(
 		case *enginepb.MVCCAbortIntentOp:
 			// No updates to publish.
 
-		case *enginepb.MVCCAbortTxnOp:
-			// No updates to publish.
-
 		default:
 			panic(errors.AssertionFailedf("unknown logical op %T", t))
 		}

--- a/pkg/kv/kvserver/rangefeed/task_test.go
+++ b/pkg/kv/kvserver/rangefeed/task_test.go
@@ -523,8 +523,8 @@ func TestTxnPushAttempt(t *testing.T) {
 		{ops: []enginepb.MVCCLogicalOp{
 			updateIntentOp(txn1, hlc.Timestamp{WallTime: 15}),
 			updateIntentOp(txn2, hlc.Timestamp{WallTime: 2}),
-			abortTxnOp(txn3),
-			abortTxnOp(txn4),
+			// abortTxnOp(txn3),
+			// abortTxnOp(txn4),
 		}},
 	}
 	require.Equal(t, len(expEvents), len(p.eventC))

--- a/pkg/kv/kvserver/replica_rangefeed.go
+++ b/pkg/kv/kvserver/replica_rangefeed.go
@@ -594,7 +594,6 @@ func populatePrevValsInLogicalOpLog(
 		case *enginepb.MVCCWriteIntentOp,
 			*enginepb.MVCCUpdateIntentOp,
 			*enginepb.MVCCAbortIntentOp,
-			*enginepb.MVCCAbortTxnOp,
 			*enginepb.MVCCDeleteRangeOp:
 			// Nothing to do.
 			continue
@@ -668,8 +667,7 @@ func (r *Replica) handleLogicalOpLogRaftMuLocked(
 			key, ts, valPtr = t.Key, t.Timestamp, &t.Value
 		case *enginepb.MVCCWriteIntentOp,
 			*enginepb.MVCCUpdateIntentOp,
-			*enginepb.MVCCAbortIntentOp,
-			*enginepb.MVCCAbortTxnOp:
+			*enginepb.MVCCAbortIntentOp:
 			// Nothing to do.
 			continue
 		case *enginepb.MVCCDeleteRangeOp:

--- a/pkg/storage/enginepb/mvcc3.proto
+++ b/pkg/storage/enginepb/mvcc3.proto
@@ -306,16 +306,6 @@ message MVCCAbortIntentOp {
     (gogoproto.nullable) = false];
 }
 
-// MVCCAbortTxnOp corresponds to an entire transaction being aborted. The
-// operation indicates that none of the transaction's intents will ever be
-// committed.
-message MVCCAbortTxnOp {
-  bytes txn_id = 1 [
-    (gogoproto.customtype) = "github.com/cockroachdb/cockroach/pkg/util/uuid.UUID",
-    (gogoproto.customname) = "TxnID",
-    (gogoproto.nullable) = false];
-}
-
 // MVCCDeleteRangeOp corresponds to a range deletion using an MVCC range
 // tombstone.
 message MVCCDeleteRangeOp {
@@ -334,6 +324,6 @@ message MVCCLogicalOp {
   MVCCUpdateIntentOp update_intent = 3;
   MVCCCommitIntentOp commit_intent = 4;
   MVCCAbortIntentOp  abort_intent  = 5;
-  MVCCAbortTxnOp     abort_txn     = 6;
   MVCCDeleteRangeOp  delete_range  = 7;
+  reserved 6;
 }


### PR DESCRIPTION
Previously when rangefeed received aborted status for pushed transaction it would eagerly dropped all known intents that belonged to the transactions from its cache.
This was proven incorrect because we can get ABORTED status event when transaction is comitted if leaseholder already removed transaction record.
This commit removes the shortcut and always relies on intent operations to advance resolved timestamp.

This is largely a revert of https://github.com/cockroachdb/cockroach/pull/35889

Epic: none

Fixes: #104309

Release note: None