### PR TITLE
backupccl: add missing ctx cancel check

### DIFF
--- a/pkg/ccl/backupccl/restore_span_covering.go
+++ b/pkg/ccl/backupccl/restore_span_covering.go
@@ -519,7 +519,11 @@ func generateAndSendImportSpans(
 			return err
 		}
 		for _, sp := range importSpans {
-			spanCh <- sp
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case spanCh <- sp:
+			}
 		}
 		return nil
 	}


### PR DESCRIPTION
In #111159 we deduced from the stacks a
situation in which the goroutine draining `spanCh` had exited due to a context cancelation but the
writer was not listening for a ctx cancelation.
This manifests as a stuck restore when using
the non-default make simple import spans implementation.

Fixes: #111159
Release note: None