### PR TITLE
kv: deflake TestLeaseExpirationBasedDrainTransferWithExtension

### DIFF
--- a/pkg/kv/kvserver/client_replica_test.go
+++ b/pkg/kv/kvserver/client_replica_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/isolation"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/protectedts"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/protectedts/ptpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/protectedts/ptutil"
@@ -1434,23 +1435,36 @@ func setupLeaseTransferTest(t *testing.T) *leaseTransferTest {
 		}
 	}
 
-	l.tc = testcluster.StartTestCluster(t, 2,
-		base.TestClusterArgs{
-			ReplicationMode: base.ReplicationManual,
-			ServerArgs: base.TestServerArgs{
-				Knobs: base.TestingKnobs{
-					Store: &kvserver.StoreTestingKnobs{
-						EvalKnobs: kvserverbase.BatchEvalTestingKnobs{
-							TestingEvalFilter: testingEvalFilter,
-						},
-						TestingProposalFilter:                testingProposalFilter,
-						LeaseTransferBlockedOnExtensionEvent: leaseTransferBlockedOnExtensionEvent,
+	const numNodes = 2
+	serverArgs := make(map[int]base.TestServerArgs, numNodes)
+	for i := 0; i < numNodes; i++ {
+		st := cluster.MakeClusterSettings()
+		// leaseTransferTest tests manually control the clock and may induce clock
+		// jumps. Disable the suspect timer to prevent nodes from becoming suspect
+		// and being excluded as lease transfer targets when we bump clocks.
+		liveness.TimeAfterNodeSuspect.Override(context.Background(), &st.SV, 0)
+
+		serverArgs[i] = base.TestServerArgs{
+			Settings: st,
+			Knobs: base.TestingKnobs{
+				Store: &kvserver.StoreTestingKnobs{
+					EvalKnobs: kvserverbase.BatchEvalTestingKnobs{
+						TestingEvalFilter: testingEvalFilter,
 					},
-					Server: &server.TestingKnobs{
-						WallClock: l.manualClock,
-					},
+					TestingProposalFilter:                testingProposalFilter,
+					LeaseTransferBlockedOnExtensionEvent: leaseTransferBlockedOnExtensionEvent,
+				},
+				Server: &server.TestingKnobs{
+					WallClock: l.manualClock,
 				},
 			},
+		}
+	}
+
+	l.tc = testcluster.StartTestCluster(t, numNodes,
+		base.TestClusterArgs{
+			ReplicationMode:   base.ReplicationManual,
+			ServerArgsPerNode: serverArgs,
 		})
 	key := l.tc.ScratchRangeWithExpirationLease(t)
 	l.tc.AddVotersOrFatal(t, key, l.tc.Target(1))


### PR DESCRIPTION
Informs #110715, which will be fixed by a non-clean backport (see 42e45b4b) of this commit.

This commit deflakes `TestLeaseExpirationBasedDrainTransferWithExtension` by disabling the node suspect timer in leaseTransferTest tests. These tests manually control the clock and have a habit of inducing destabilizing clock jumps. In this case, if n2 looked at liveness immediately after one of these manual clock jumps, it would mark n1 as suspect and refuse to transfer it the lease for the 30 second `server.time_after_store_suspect`, which is longer than the 5 second `server.shutdown.lease_transfer_wait`. This would cause the test to fail.

Before this patch, the test would fail under stress race in about 8 minutes. Since the patch, it hasn't failed in over 30 minutes.

Release note: None