### PR TITLE
release-22.2: roachtest: expand tag functionality to allow filtering by conjunctive…

### DIFF
--- a/build/teamcity/cockroach/nightlies/roachtest_nightly_impl.sh
+++ b/build/teamcity/cockroach/nightlies/roachtest_nightly_impl.sh
@@ -25,4 +25,4 @@ build/teamcity-roachtest-invoke.sh \
   --artifacts=/artifacts \
   --artifacts-literal="${LITERAL_ARTIFACTS_DIR:-}" \
   --slack-token="${SLACK_TOKEN}" \
-  "${TESTS}"
+  "${TESTS}" "${FILTER}"

--- a/build/teamcity/cockroach/nightlies/roachtest_nightly_impl.sh
+++ b/build/teamcity/cockroach/nightlies/roachtest_nightly_impl.sh
@@ -25,4 +25,4 @@ build/teamcity-roachtest-invoke.sh \
   --artifacts=/artifacts \
   --artifacts-literal="${LITERAL_ARTIFACTS_DIR:-}" \
   --slack-token="${SLACK_TOKEN}" \
-  "${TESTS}" "${FILTER}"
+  "${TESTS}" ${FILTER}

--- a/build/teamcity/util/roachtest_util.sh
+++ b/build/teamcity/util/roachtest_util.sh
@@ -57,16 +57,15 @@ trap upload_stats EXIT
 PARALLELISM=16
 CPUQUOTA=1024
 TESTS="${TESTS-}"
+FILTER="${FILTER-}"
 case "${CLOUD}" in
   gce)
     ;;
   aws)
     PARALLELISM=3
     CPUQUOTA=384
-    if [ -z "${TESTS}" ]; then
-      # NB: anchor ycsb to beginning of line to avoid matching `zfs/ycsb/*` which
-      # isn't supported on AWS at time of writing.
-      TESTS="awsdms|kv(0|95)|^ycsb|tpcc/(headroom/n4cpu16)|tpccbench/(nodes=3/cpu=16)|scbench/randomload/(nodes=3/ops=2000/conc=1)|backup/(KMS/AWS/n3cpu4)"
+    if [ -z "${FILTER}" ]; then
+      FILTER="tag:aws"
     fi
     ;;
   *)

--- a/build/teamcity/util/roachtest_util.sh
+++ b/build/teamcity/util/roachtest_util.sh
@@ -60,6 +60,13 @@ TESTS="${TESTS-}"
 FILTER="${FILTER-}"
 case "${CLOUD}" in
   gce)
+      # Confusing due to how we've handled tags in the past where it has been assumed that all tests should
+      # be run on GCE. Now with refactoring of how tags are handled, we need:
+      # - "default" to ensure we select tests that don't have any user specified tags (preserve old behavior)
+      # - "aws" to ensure we select tests that now no longer have "default" because they have the "aws" tag
+      # Ideally, refactor the tags themselves to be explicit about what cloud they are for and when they can run.
+      # https://github.com/cockroachdb/cockroach/issues/100605
+      FILTER="tag:aws tag:default"
     ;;
   aws)
     PARALLELISM=3

--- a/pkg/cmd/roachtest/README.md
+++ b/pkg/cmd/roachtest/README.md
@@ -27,6 +27,15 @@ acceptance/cli/node-status [server]
 [...]
 ```
 
+The list can be filtered by passing a regular expression to the `list` command which will match against the test name.
+Multiple `tag:` prefixed args can be specified to further narrow by which tags are present for a test. The following 
+will list all tests with name containing `admission` where test tags match `(weekly && aws) || my-tag`
+
+```
+roachtest list admission tag:weekly,aws tag:my-tag
+```
+
+
 ## Getting the binaries
 
 To run a test, the `roachtest run` command is used. Since a test typically

--- a/pkg/cmd/roachtest/main.go
+++ b/pkg/cmd/roachtest/main.go
@@ -210,15 +210,25 @@ Use --bench to list benchmarks instead of tests.
 
 Each test has a set of tags. The tags are used to skip tests which don't match
 the tag filter. The tag filter is specified by specifying a pattern with the
-"tag:" prefix. The default tag filter is "tag:default" which matches any test
-that has the "default" tag. Note that tests are selected based on their name,
-and skipped based on their tag.
+"tag:" prefix. 
+
+If multiple "tag:" patterns are specified, the test must match at
+least one of them.
+
+Within a single "tag:" pattern, multiple tags can be specified by separating them
+with a comma. In this case, the test must match all of the tags.
 
 Examples:
 
    roachtest list acceptance copy/bank/.*false
-   roachtest list tag:acceptance
+   roachtest list tag:owner-kv
    roachtest list tag:weekly
+
+   # match weekly kv owned tests
+   roachtest list tag:owner-kv,weekly
+
+   # match weekly kv owner tests or aws tests
+   roachtest list tag:owner-kv,weekly tag:aws
 `,
 		RunE: func(_ *cobra.Command, args []string) error {
 			r, err := makeTestRegistry(cloud, instanceType, zonesF, localSSDArg, listBench)

--- a/pkg/cmd/roachtest/main.go
+++ b/pkg/cmd/roachtest/main.go
@@ -250,6 +250,8 @@ Examples:
 	}
 	listCmd.Flags().BoolVar(
 		&listBench, "bench", false, "list benchmarks instead of tests")
+	listCmd.Flags().StringVar(
+		&cloud, "cloud", cloud, "cloud provider to use (aws, azure, or gce)")
 
 	runFn := func(args []string, benchOnly bool) error {
 		if literalArtifacts == "" {

--- a/pkg/cmd/roachtest/registry/test_spec.go
+++ b/pkg/cmd/roachtest/registry/test_spec.go
@@ -51,7 +51,7 @@ type TestSpec struct {
 	// Tags is a set of tags associated with the test that allow grouping
 	// tests. If no tags are specified, the set ["default"] is automatically
 	// given.
-	Tags []string
+	Tags map[string]struct{}
 	// Cluster provides the specification for the cluster to use for the test.
 	Cluster spec.ClusterSpec
 	// NativeLibs specifies the native libraries required to be present on
@@ -117,10 +117,9 @@ func (t *TestSpec) Match(filter *TestFilter) MatchType {
 		return Matched
 	}
 
-	testTags := stringSliceToSet(t.Tags)
 	for tag := range filter.Tags {
 		// If the tag is a single CSV e.g. "foo,bar,baz", we match all the tags
-		if matchesAll(testTags, strings.Split(tag, ",")) {
+		if matchesAll(t.Tags, strings.Split(tag, ",")) {
 			return Matched
 		}
 	}
@@ -144,9 +143,10 @@ func matchesAll(testTags map[string]struct{}, filterTags []string) bool {
 	return true
 }
 
-func stringSliceToSet(slice []string) map[string]struct{} {
+// Tags returns a set of strings.
+func Tags(values ...string) map[string]struct{} {
 	set := make(map[string]struct{})
-	for _, s := range slice {
+	for _, s := range values {
 		set[s] = struct{}{}
 	}
 	return set

--- a/pkg/cmd/roachtest/registry/test_spec.go
+++ b/pkg/cmd/roachtest/registry/test_spec.go
@@ -12,6 +12,7 @@ package registry
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
@@ -111,16 +112,42 @@ func (t *TestSpec) Match(filter *TestFilter) MatchType {
 	if !filter.Name.MatchString(t.Name) {
 		return FailedFilter
 	}
-	if len(t.Tags) == 0 {
-		if !filter.Tag.MatchString("default") {
-			return FailedTags
-		}
+
+	if len(filter.Tags) == 0 {
 		return Matched
 	}
-	for _, t := range t.Tags {
-		if filter.Tag.MatchString(t) {
+
+	testTags := stringSliceToSet(t.Tags)
+	for tag := range filter.Tags {
+		// If the tag is a single CSV e.g. "foo,bar,baz", we match all the tags
+		if matchesAll(testTags, strings.Split(tag, ",")) {
 			return Matched
 		}
 	}
+
 	return FailedTags
+}
+
+func matchesAll(testTags map[string]struct{}, filterTags []string) bool {
+	for _, tag := range filterTags {
+		negate := false
+		if tag[0] == '!' {
+			negate = true
+			tag = tag[1:]
+		}
+		_, tagExists := testTags[tag]
+
+		if negate == tagExists {
+			return false
+		}
+	}
+	return true
+}
+
+func stringSliceToSet(slice []string) map[string]struct{} {
+	set := make(map[string]struct{})
+	for _, s := range slice {
+		set[s] = struct{}{}
+	}
+	return set
 }

--- a/pkg/cmd/roachtest/test_registry.go
+++ b/pkg/cmd/roachtest/test_registry.go
@@ -135,9 +135,9 @@ func (r *testRegistryImpl) prepareSpec(spec *registry.TestSpec) error {
 		return fmt.Errorf(`%s: unknown owner [%s]`, spec.Name, spec.Owner)
 	}
 	if len(spec.Tags) == 0 {
-		spec.Tags = []string{registry.DefaultTag}
+		spec.Tags = registry.Tags(registry.DefaultTag)
 	}
-	spec.Tags = append(spec.Tags, "owner-"+string(spec.Owner))
+	spec.Tags["owner-"+string(spec.Owner)] = struct{}{}
 
 	// At the time of writing, we expect the roachtest job to finish within 24h
 	// and have corresponding timeouts set up in CI. Since each individual test
@@ -147,10 +147,8 @@ func (r *testRegistryImpl) prepareSpec(spec *registry.TestSpec) error {
 	const maxTimeout = 18 * time.Hour
 	if spec.Timeout > maxTimeout {
 		var weekly bool
-		for _, tag := range spec.Tags {
-			if tag == "weekly" {
-				weekly = true
-			}
+		if _, ok := spec.Tags["weekly"]; ok {
+			weekly = true
 		}
 		if !weekly {
 			return fmt.Errorf(

--- a/pkg/cmd/roachtest/test_test.go
+++ b/pkg/cmd/roachtest/test_test.go
@@ -59,15 +59,24 @@ func TestMatchOrSkip(t *testing.T) {
 		expected registry.MatchType
 	}{
 		{nil, "foo", nil, registry.Matched},
-		{nil, "foo", []string{"bar"}, registry.FailedTags},
-		{[]string{"tag:b"}, "foo", []string{"bar"}, registry.Matched},
+		{nil, "foo", []string{"bar"}, registry.Matched},
+		{[]string{"tag:bar"}, "foo", []string{"bar"}, registry.Matched},
+		// Partial tag match is not supported
+		{[]string{"tag:b"}, "foo", []string{"bar"}, registry.FailedTags},
 		{[]string{"tag:b"}, "foo", nil, registry.FailedTags},
-		{[]string{"tag:default"}, "foo", nil, registry.Matched},
 		{[]string{"tag:f"}, "foo", []string{"bar"}, registry.FailedTags},
-		{[]string{"f"}, "foo", []string{"bar"}, registry.FailedTags},
+		// Specifying no tag filters matches all tags.
+		{[]string{"f"}, "foo", []string{"bar"}, registry.Matched},
 		{[]string{"f"}, "bar", []string{"bar"}, registry.FailedFilter},
-		{[]string{"f", "tag:b"}, "foo", []string{"bar"}, registry.Matched},
+		{[]string{"f", "tag:bar"}, "foo", []string{"bar"}, registry.Matched},
+		{[]string{"f", "tag:b"}, "foo", []string{"bar"}, registry.FailedTags},
 		{[]string{"f", "tag:f"}, "foo", []string{"bar"}, registry.FailedTags},
+		// Match tests that have both tags 'abc' and 'bar'
+		{[]string{"f", "tag:abc,bar"}, "foo", []string{"abc", "bar"}, registry.Matched},
+		{[]string{"f", "tag:abc,bar"}, "foo", []string{"abc"}, registry.FailedTags},
+		// Match tests that have tag 'abc' but not 'bar'
+		{[]string{"f", "tag:abc,!bar"}, "foo", []string{"abc"}, registry.Matched},
+		{[]string{"f", "tag:abc,!bar"}, "foo", []string{"abc", "bar"}, registry.FailedTags},
 	}
 	for _, c := range testCases {
 		t.Run("", func(t *testing.T) {

--- a/pkg/cmd/roachtest/test_test.go
+++ b/pkg/cmd/roachtest/test_test.go
@@ -55,28 +55,28 @@ func TestMatchOrSkip(t *testing.T) {
 	testCases := []struct {
 		filter   []string
 		name     string
-		tags     []string
+		tags     map[string]struct{}
 		expected registry.MatchType
 	}{
 		{nil, "foo", nil, registry.Matched},
-		{nil, "foo", []string{"bar"}, registry.Matched},
-		{[]string{"tag:bar"}, "foo", []string{"bar"}, registry.Matched},
+		{nil, "foo", registry.Tags("bar"), registry.Matched},
+		{[]string{"tag:bar"}, "foo", registry.Tags("bar"), registry.Matched},
 		// Partial tag match is not supported
-		{[]string{"tag:b"}, "foo", []string{"bar"}, registry.FailedTags},
+		{[]string{"tag:b"}, "foo", registry.Tags("bar"), registry.FailedTags},
 		{[]string{"tag:b"}, "foo", nil, registry.FailedTags},
-		{[]string{"tag:f"}, "foo", []string{"bar"}, registry.FailedTags},
+		{[]string{"tag:f"}, "foo", registry.Tags("bar"), registry.FailedTags},
 		// Specifying no tag filters matches all tags.
-		{[]string{"f"}, "foo", []string{"bar"}, registry.Matched},
-		{[]string{"f"}, "bar", []string{"bar"}, registry.FailedFilter},
-		{[]string{"f", "tag:bar"}, "foo", []string{"bar"}, registry.Matched},
-		{[]string{"f", "tag:b"}, "foo", []string{"bar"}, registry.FailedTags},
-		{[]string{"f", "tag:f"}, "foo", []string{"bar"}, registry.FailedTags},
+		{[]string{"f"}, "foo", registry.Tags("bar"), registry.Matched},
+		{[]string{"f"}, "bar", registry.Tags("bar"), registry.FailedFilter},
+		{[]string{"f", "tag:bar"}, "foo", registry.Tags("bar"), registry.Matched},
+		{[]string{"f", "tag:b"}, "foo", registry.Tags("bar"), registry.FailedTags},
+		{[]string{"f", "tag:f"}, "foo", registry.Tags("bar"), registry.FailedTags},
 		// Match tests that have both tags 'abc' and 'bar'
-		{[]string{"f", "tag:abc,bar"}, "foo", []string{"abc", "bar"}, registry.Matched},
-		{[]string{"f", "tag:abc,bar"}, "foo", []string{"abc"}, registry.FailedTags},
+		{[]string{"f", "tag:abc,bar"}, "foo", registry.Tags("abc", "bar"), registry.Matched},
+		{[]string{"f", "tag:abc,bar"}, "foo", registry.Tags("abc"), registry.FailedTags},
 		// Match tests that have tag 'abc' but not 'bar'
-		{[]string{"f", "tag:abc,!bar"}, "foo", []string{"abc"}, registry.Matched},
-		{[]string{"f", "tag:abc,!bar"}, "foo", []string{"abc", "bar"}, registry.FailedTags},
+		{[]string{"f", "tag:abc,!bar"}, "foo", registry.Tags("abc"), registry.Matched},
+		{[]string{"f", "tag:abc,!bar"}, "foo", registry.Tags("abc", "bar"), registry.FailedTags},
 	}
 	for _, c := range testCases {
 		t.Run("", func(t *testing.T) {

--- a/pkg/cmd/roachtest/tests/acceptance.go
+++ b/pkg/cmd/roachtest/tests/acceptance.go
@@ -77,7 +77,6 @@ func registerAcceptance(r registry.Registry) {
 			},
 		},
 	}
-	tags := []string{"default", "quick"}
 	specTemplate := registry.TestSpec{
 		// NB: teamcity-post-failures.py relies on the acceptance tests
 		// being named acceptance/<testname> and will avoid posting a
@@ -87,7 +86,7 @@ func registerAcceptance(r registry.Registry) {
 		// will be posted.
 		Name:    "acceptance",
 		Timeout: 10 * time.Minute,
-		Tags:    tags,
+		Tags:    registry.Tags("default", "quick"),
 	}
 
 	for owner, tests := range testCases {

--- a/pkg/cmd/roachtest/tests/activerecord.go
+++ b/pkg/cmd/roachtest/tests/activerecord.go
@@ -250,7 +250,7 @@ func registerActiveRecord(r registry.Registry) {
 		Owner:      registry.OwnerSQLFoundations,
 		Cluster:    r.MakeClusterSpec(1),
 		NativeLibs: registry.LibGEOS,
-		Tags:       []string{`default`, `orm`},
+		Tags:       registry.Tags(`default`, `orm`),
 		Run:        runActiveRecord,
 	})
 }

--- a/pkg/cmd/roachtest/tests/asyncpg.go
+++ b/pkg/cmd/roachtest/tests/asyncpg.go
@@ -141,7 +141,7 @@ func registerAsyncpg(r registry.Registry) {
 		Name:    "asyncpg",
 		Owner:   registry.OwnerSQLFoundations,
 		Cluster: r.MakeClusterSpec(1, spec.CPU(16)),
-		Tags:    []string{`default`, `orm`},
+		Tags:    registry.Tags(`default`, `orm`),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runAsyncpg(ctx, t, c)
 		},

--- a/pkg/cmd/roachtest/tests/awsdms.go
+++ b/pkg/cmd/roachtest/tests/awsdms.go
@@ -128,7 +128,7 @@ func registerAWSDMS(r registry.Registry) {
 		Name:    "awsdms",
 		Owner:   registry.OwnerMigrations,
 		Cluster: r.MakeClusterSpec(1),
-		Tags:    []string{`weekly`, `aws-weekly`},
+		Tags:    registry.Tags(`weekly`, `aws-weekly`),
 		Run:     runAWSDMS,
 	})
 }

--- a/pkg/cmd/roachtest/tests/backup.go
+++ b/pkg/cmd/roachtest/tests/backup.go
@@ -762,9 +762,10 @@ func registerBackup(r registry.Registry) {
 	for _, item := range []struct {
 		kmsProvider string
 		machine     string
+		tags        []string
 	}{
 		{kmsProvider: "GCS", machine: spec.GCE},
-		{kmsProvider: "AWS", machine: spec.AWS},
+		{kmsProvider: "AWS", machine: spec.AWS, tags: []string{"aws"}},
 	} {
 		item := item
 		r.Add(registry.TestSpec{
@@ -772,6 +773,7 @@ func registerBackup(r registry.Registry) {
 			Owner:             registry.OwnerDisasterRecovery,
 			Cluster:           KMSSpec,
 			EncryptionSupport: registry.EncryptionMetamorphic,
+			Tags:              item.tags,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				if c.Spec().Cloud != item.machine {
 					t.Skip("backupKMS roachtest is only configured to run on "+item.machine, "")

--- a/pkg/cmd/roachtest/tests/backup.go
+++ b/pkg/cmd/roachtest/tests/backup.go
@@ -762,10 +762,10 @@ func registerBackup(r registry.Registry) {
 	for _, item := range []struct {
 		kmsProvider string
 		machine     string
-		tags        []string
+		tags        map[string]struct{}
 	}{
 		{kmsProvider: "GCS", machine: spec.GCE},
-		{kmsProvider: "AWS", machine: spec.AWS, tags: []string{"aws"}},
+		{kmsProvider: "AWS", machine: spec.AWS, tags: registry.Tags("aws")},
 	} {
 		item := item
 		r.Add(registry.TestSpec{

--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -707,7 +707,7 @@ func registerCDC(r registry.Registry) {
 		Owner:           registry.OwnerCDC,
 		Benchmark:       true,
 		Cluster:         r.MakeClusterSpec(4, spec.CPU(16)),
-		Tags:            []string{"manual"},
+		Tags:            registry.Tags("manual"),
 		RequiresLicense: true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			cdcBasicTest(ctx, t, c, cdcTestArgs{

--- a/pkg/cmd/roachtest/tests/django.go
+++ b/pkg/cmd/roachtest/tests/django.go
@@ -217,7 +217,7 @@ func registerDjango(r registry.Registry) {
 		Name:    "django",
 		Owner:   registry.OwnerSQLFoundations,
 		Cluster: r.MakeClusterSpec(1, spec.CPU(16)),
-		Tags:    []string{`default`, `orm`},
+		Tags:    registry.Tags(`default`, `orm`),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runDjango(ctx, t, c)
 		},

--- a/pkg/cmd/roachtest/tests/fixtures.go
+++ b/pkg/cmd/roachtest/tests/fixtures.go
@@ -65,7 +65,7 @@ func registerFixtures(r registry.Registry) {
 	spec := registry.TestSpec{
 		Name:    "generate-fixtures",
 		Timeout: 30 * time.Minute,
-		Tags:    []string{"fixtures"},
+		Tags:    registry.Tags("fixtures"),
 		Owner:   registry.OwnerDevInf,
 		Cluster: r.MakeClusterSpec(4),
 		Run:     runFixtures,

--- a/pkg/cmd/roachtest/tests/gopg.go
+++ b/pkg/cmd/roachtest/tests/gopg.go
@@ -166,7 +166,7 @@ func registerGopg(r registry.Registry) {
 		Name:    "gopg",
 		Owner:   registry.OwnerSQLFoundations,
 		Cluster: r.MakeClusterSpec(1),
-		Tags:    []string{`default`, `orm`},
+		Tags:    registry.Tags(`default`, `orm`),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runGopg(ctx, t, c)
 		},

--- a/pkg/cmd/roachtest/tests/gorm.go
+++ b/pkg/cmd/roachtest/tests/gorm.go
@@ -136,7 +136,7 @@ func registerGORM(r registry.Registry) {
 		Name:    "gorm",
 		Owner:   registry.OwnerSQLFoundations,
 		Cluster: r.MakeClusterSpec(1),
-		Tags:    []string{`default`, `orm`},
+		Tags:    registry.Tags(`default`, `orm`),
 		Run:     runGORM,
 	})
 }

--- a/pkg/cmd/roachtest/tests/hibernate.go
+++ b/pkg/cmd/roachtest/tests/hibernate.go
@@ -238,7 +238,7 @@ func registerHibernate(r registry.Registry, opt hibernateOptions) {
 		Owner:      registry.OwnerSQLFoundations,
 		Cluster:    r.MakeClusterSpec(1),
 		NativeLibs: registry.LibGEOS,
-		Tags:       []string{`default`, `orm`},
+		Tags:       registry.Tags(`default`, `orm`),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runHibernate(ctx, t, c)
 		},

--- a/pkg/cmd/roachtest/tests/jasyncsql.go
+++ b/pkg/cmd/roachtest/tests/jasyncsql.go
@@ -150,7 +150,7 @@ func registerJasyncSQL(r registry.Registry) {
 		Name:    "jasync",
 		Owner:   registry.OwnerSQLFoundations,
 		Cluster: r.MakeClusterSpec(1),
-		Tags:    []string{`default`, `orm`},
+		Tags:    registry.Tags(`default`, `orm`),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runJasyncSQL(ctx, t, c)
 		},

--- a/pkg/cmd/roachtest/tests/knex.go
+++ b/pkg/cmd/roachtest/tests/knex.go
@@ -151,7 +151,7 @@ func registerKnex(r registry.Registry) {
 		Owner:      registry.OwnerSQLFoundations,
 		Cluster:    r.MakeClusterSpec(1),
 		NativeLibs: registry.LibGEOS,
-		Tags:       []string{`default`, `orm`},
+		Tags:       registry.Tags(`default`, `orm`),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runKnex(ctx, t, c)
 		},

--- a/pkg/cmd/roachtest/tests/kv.go
+++ b/pkg/cmd/roachtest/tests/kv.go
@@ -63,7 +63,7 @@ func registerKV(r registry.Registry) {
 		raid0                    bool
 		duration                 time.Duration
 		tracing                  bool // `trace.debug.enable`
-		tags                     []string
+		tags                     map[string]struct{}
 		owner                    registry.Owner // defaults to KV
 	}
 	computeNumSplits := func(opts kvOptions) int {
@@ -231,8 +231,8 @@ func registerKV(r registry.Registry) {
 		{nodes: 1, cpus: 32, readPercent: 95, spanReads: true, splits: -1 /* no splits */, disableLoadSplits: true, sequential: true},
 
 		// Weekly larger scale configurations.
-		{nodes: 32, cpus: 8, readPercent: 0, tags: []string{"weekly"}, duration: time.Hour},
-		{nodes: 32, cpus: 8, readPercent: 95, tags: []string{"weekly"}, duration: time.Hour},
+		{nodes: 32, cpus: 8, readPercent: 0, tags: registry.Tags("weekly"), duration: time.Hour},
+		{nodes: 32, cpus: 8, readPercent: 95, tags: registry.Tags("weekly"), duration: time.Hour},
 	} {
 		opts := opts
 
@@ -243,7 +243,11 @@ func registerKV(r registry.Registry) {
 		}
 		nameParts = append(nameParts, fmt.Sprintf("kv%d%s", opts.readPercent, limitedSpanStr))
 		if len(opts.tags) > 0 {
-			nameParts = append(nameParts, strings.Join(opts.tags, "/"))
+			var keys []string
+			for k := range opts.tags {
+				keys = append(keys, k)
+			}
+			nameParts = append(nameParts, strings.Join(keys, "/"))
 		}
 		nameParts = append(nameParts, fmt.Sprintf("enc=%t", opts.encryption))
 		nameParts = append(nameParts, fmt.Sprintf("nodes=%d", opts.nodes))
@@ -293,9 +297,9 @@ func registerKV(r registry.Registry) {
 		}
 		cSpec := r.MakeClusterSpec(opts.nodes+1, spec.CPU(opts.cpus), spec.SSD(opts.ssds), spec.RAID0(opts.raid0))
 
-		// All the kv0|95 tests not using ssd should run on AWS by default
+		// All the kv0|95 tests should run on AWS by default
 		if opts.tags == nil && opts.ssds == 0 && (opts.readPercent == 95 || opts.readPercent == 0) {
-			opts.tags = []string{"aws"}
+			opts.tags = registry.Tags("aws")
 		}
 
 		var skip string

--- a/pkg/cmd/roachtest/tests/kv.go
+++ b/pkg/cmd/roachtest/tests/kv.go
@@ -292,6 +292,12 @@ func registerKV(r registry.Registry) {
 			encryption = registry.EncryptionAlwaysEnabled
 		}
 		cSpec := r.MakeClusterSpec(opts.nodes+1, spec.CPU(opts.cpus), spec.SSD(opts.ssds), spec.RAID0(opts.raid0))
+
+		// All the kv0|95 tests not using ssd should run on AWS by default
+		if opts.tags == nil && opts.ssds == 0 && (opts.readPercent == 95 || opts.readPercent == 0) {
+			opts.tags = []string{"aws"}
+		}
+
 		var skip string
 		if opts.ssds != 0 && cSpec.Cloud != spec.GCE {
 			skip = fmt.Sprintf("multi-store tests are not supported on cloud %s", cSpec.Cloud)

--- a/pkg/cmd/roachtest/tests/kvbench.go
+++ b/pkg/cmd/roachtest/tests/kvbench.go
@@ -92,7 +92,7 @@ func registerKVBenchSpec(r registry.Registry, b kvBenchSpec) {
 		// for --max-rate.
 		// TODO(andrei): output something to roachperf and start running them
 		// nightly.
-		Tags:    []string{"manual"},
+		Tags:    registry.Tags("manual"),
 		Owner:   registry.OwnerKV,
 		Cluster: nodes,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {

--- a/pkg/cmd/roachtest/tests/libpq.go
+++ b/pkg/cmd/roachtest/tests/libpq.go
@@ -142,7 +142,7 @@ func registerLibPQ(r registry.Registry) {
 		Name:    "lib/pq",
 		Owner:   registry.OwnerSQLFoundations,
 		Cluster: r.MakeClusterSpec(1),
-		Tags:    []string{`default`, `driver`},
+		Tags:    registry.Tags(`default`, `driver`),
 		Run:     runLibPQ,
 	})
 }

--- a/pkg/cmd/roachtest/tests/liquibase.go
+++ b/pkg/cmd/roachtest/tests/liquibase.go
@@ -134,7 +134,7 @@ func registerLiquibase(r registry.Registry) {
 		Name:    "liquibase",
 		Owner:   registry.OwnerSQLFoundations,
 		Cluster: r.MakeClusterSpec(1),
-		Tags:    []string{`default`, `tool`},
+		Tags:    registry.Tags(`default`, `tool`),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runLiquibase(ctx, t, c)
 		},

--- a/pkg/cmd/roachtest/tests/loss_of_quorum_recovery.go
+++ b/pkg/cmd/roachtest/tests/loss_of_quorum_recovery.go
@@ -64,7 +64,7 @@ func registerLOQRecovery(r registry.Registry) {
 			Name:              s.String(),
 			Owner:             registry.OwnerReplication,
 			Benchmark:         true,
-			Tags:              []string{`default`},
+			Tags:              registry.Tags(`default`),
 			Cluster:           spec,
 			NonReleaseBlocker: true,
 

--- a/pkg/cmd/roachtest/tests/nodejs_postgres.go
+++ b/pkg/cmd/roachtest/tests/nodejs_postgres.go
@@ -170,7 +170,7 @@ PGSSLCERT=$HOME/certs/client.%s.crt PGSSLKEY=$HOME/certs/client.%s.key PGSSLROOT
 		Name:    "node-postgres",
 		Owner:   registry.OwnerSQLFoundations,
 		Cluster: r.MakeClusterSpec(1),
-		Tags:    []string{`default`, `driver`},
+		Tags:    registry.Tags(`default`, `driver`),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runNodeJSPostgres(ctx, t, c)
 		},

--- a/pkg/cmd/roachtest/tests/pebble_write_throughput.go
+++ b/pkg/cmd/roachtest/tests/pebble_write_throughput.go
@@ -36,7 +36,7 @@ func registerPebbleWriteThroughput(r registry.Registry) {
 		Owner:   registry.OwnerStorage,
 		Timeout: 10 * time.Hour,
 		Cluster: r.MakeClusterSpec(5, spec.CPU(16), spec.SSD(16), spec.RAID0(true)),
-		Tags:    []string{"pebble_nightly_write"},
+		Tags:    registry.Tags("pebble_nightly_write"),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runPebbleWriteBenchmark(ctx, t, c, size, pebble)
 		},

--- a/pkg/cmd/roachtest/tests/pebble_ycsb.go
+++ b/pkg/cmd/roachtest/tests/pebble_ycsb.go
@@ -55,7 +55,7 @@ func registerPebbleYCSB(r registry.Registry) {
 				Owner:   registry.OwnerStorage,
 				Timeout: 12 * time.Hour,
 				Cluster: r.MakeClusterSpec(5, spec.CPU(16)),
-				Tags:    []string{tag},
+				Tags:    registry.Tags(tag),
 				Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 					runPebbleYCSB(ctx, t, c, size, pebble, d, nil, true /* artifacts */)
 				},
@@ -69,7 +69,7 @@ func registerPebbleYCSB(r registry.Registry) {
 		Owner:   registry.OwnerStorage,
 		Timeout: 12 * time.Hour,
 		Cluster: r.MakeClusterSpec(5, spec.CPU(16)),
-		Tags:    []string{"pebble_nightly_ycsb_race"},
+		Tags:    registry.Tags("pebble_nightly_ycsb_race"),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runPebbleYCSB(ctx, t, c, 64, pebble, 30, []string{"A"}, false /* artifacts */)
 		},

--- a/pkg/cmd/roachtest/tests/pgjdbc.go
+++ b/pkg/cmd/roachtest/tests/pgjdbc.go
@@ -213,7 +213,7 @@ func registerPgjdbc(r registry.Registry) {
 		Name:    "pgjdbc",
 		Owner:   registry.OwnerSQLFoundations,
 		Cluster: r.MakeClusterSpec(1),
-		Tags:    []string{`default`, `driver`},
+		Tags:    registry.Tags(`default`, `driver`),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runPgjdbc(ctx, t, c)
 		},

--- a/pkg/cmd/roachtest/tests/pgx.go
+++ b/pkg/cmd/roachtest/tests/pgx.go
@@ -142,7 +142,7 @@ func registerPgx(r registry.Registry) {
 		Name:    "pgx",
 		Owner:   registry.OwnerSQLFoundations,
 		Cluster: r.MakeClusterSpec(1),
-		Tags:    []string{`default`, `driver`},
+		Tags:    registry.Tags(`default`, `driver`),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runPgx(ctx, t, c)
 		},

--- a/pkg/cmd/roachtest/tests/pop.go
+++ b/pkg/cmd/roachtest/tests/pop.go
@@ -102,7 +102,7 @@ func registerPop(r registry.Registry) {
 		Name:    "pop",
 		Owner:   registry.OwnerSQLFoundations,
 		Cluster: r.MakeClusterSpec(1),
-		Tags:    []string{`default`, `orm`},
+		Tags:    registry.Tags(`default`, `orm`),
 		Run:     runPop,
 	})
 }

--- a/pkg/cmd/roachtest/tests/psycopg.go
+++ b/pkg/cmd/roachtest/tests/psycopg.go
@@ -150,7 +150,7 @@ func registerPsycopg(r registry.Registry) {
 		Name:    "psycopg",
 		Owner:   registry.OwnerSQLFoundations,
 		Cluster: r.MakeClusterSpec(1),
-		Tags:    []string{`default`, `driver`},
+		Tags:    registry.Tags(`default`, `driver`),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runPsycopg(ctx, t, c)
 		},

--- a/pkg/cmd/roachtest/tests/restore.go
+++ b/pkg/cmd/roachtest/tests/restore.go
@@ -648,7 +648,7 @@ func registerRestore(r registry.Registry) {
 		Cluster:   r.MakeClusterSpec(10),
 		Benchmark: true,
 		Timeout:   withPauseTimeout,
-		Tags:      []string{`aws`},
+		Tags:      registry.Tags("aws"),
 
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			c.Put(ctx, t.Cockroach(), "./cockroach")

--- a/pkg/cmd/roachtest/tests/restore.go
+++ b/pkg/cmd/roachtest/tests/restore.go
@@ -648,6 +648,7 @@ func registerRestore(r registry.Registry) {
 		Cluster:   r.MakeClusterSpec(10),
 		Benchmark: true,
 		Timeout:   withPauseTimeout,
+		Tags:      []string{`aws`},
 
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			c.Put(ctx, t.Cockroach(), "./cockroach")

--- a/pkg/cmd/roachtest/tests/roachtest.go
+++ b/pkg/cmd/roachtest/tests/roachtest.go
@@ -25,14 +25,14 @@ import (
 func registerRoachtest(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:    "roachtest/noop",
-		Tags:    []string{"roachtest"},
+		Tags:    registry.Tags("roachtest"),
 		Owner:   registry.OwnerTestEng,
 		Run:     func(_ context.Context, _ test.Test, _ cluster.Cluster) {},
 		Cluster: r.MakeClusterSpec(0),
 	})
 	r.Add(registry.TestSpec{
 		Name:  "roachtest/noop-maybefail",
-		Tags:  []string{"roachtest"},
+		Tags:  registry.Tags("roachtest"),
 		Owner: registry.OwnerTestEng,
 		Run: func(_ context.Context, t test.Test, _ cluster.Cluster) {
 			if rand.Float64() <= 0.2 {
@@ -45,7 +45,7 @@ func registerRoachtest(r registry.Registry) {
 	// In particular, can manually verify that suitable artifacts are created.
 	r.Add(registry.TestSpec{
 		Name:  "roachtest/hang",
-		Tags:  []string{"roachtest"},
+		Tags:  registry.Tags("roachtest"),
 		Owner: registry.OwnerTestEng,
 		Run: func(_ context.Context, t test.Test, c cluster.Cluster) {
 			ctx := context.Background() // intentional

--- a/pkg/cmd/roachtest/tests/ruby_pg.go
+++ b/pkg/cmd/roachtest/tests/ruby_pg.go
@@ -231,7 +231,7 @@ func registerRubyPG(r registry.Registry) {
 		Owner:      registry.OwnerSQLFoundations,
 		Cluster:    r.MakeClusterSpec(1),
 		NativeLibs: registry.LibGEOS,
-		Tags:       []string{`default`, `orm`},
+		Tags:       registry.Tags(`default`, `orm`),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runRubyPGTest(ctx, t, c)
 		},

--- a/pkg/cmd/roachtest/tests/rust_postgres.go
+++ b/pkg/cmd/roachtest/tests/rust_postgres.go
@@ -165,7 +165,7 @@ func registerRustPostgres(r registry.Registry) {
 		Name:    "rust-postgres",
 		Owner:   registry.OwnerSQLFoundations,
 		Cluster: r.MakeClusterSpec(1, spec.CPU(16)),
-		Tags:    []string{`default`, `orm`},
+		Tags:    registry.Tags(`default`, `orm`),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runRustPostgres(ctx, t, c)
 		},

--- a/pkg/cmd/roachtest/tests/schemachange_random_load.go
+++ b/pkg/cmd/roachtest/tests/schemachange_random_load.go
@@ -29,7 +29,7 @@ type randomLoadBenchSpec struct {
 	Nodes       int
 	Ops         int
 	Concurrency int
-	Tags        []string
+	Tags        map[string]struct{}
 }
 
 func registerSchemaChangeRandomLoad(r registry.Registry) {
@@ -64,7 +64,7 @@ func registerSchemaChangeRandomLoad(r registry.Registry) {
 		Nodes:       3,
 		Ops:         2000,
 		Concurrency: 1,
-		Tags:        []string{"aws"},
+		Tags:        registry.Tags("aws"),
 	})
 
 	registerRandomLoadBenchSpec(r, randomLoadBenchSpec{

--- a/pkg/cmd/roachtest/tests/schemachange_random_load.go
+++ b/pkg/cmd/roachtest/tests/schemachange_random_load.go
@@ -29,6 +29,7 @@ type randomLoadBenchSpec struct {
 	Nodes       int
 	Ops         int
 	Concurrency int
+	Tags        []string
 }
 
 func registerSchemaChangeRandomLoad(r registry.Registry) {
@@ -63,6 +64,7 @@ func registerSchemaChangeRandomLoad(r registry.Registry) {
 		Nodes:       3,
 		Ops:         2000,
 		Concurrency: 1,
+		Tags:        []string{"aws"},
 	})
 
 	registerRandomLoadBenchSpec(r, randomLoadBenchSpec{
@@ -95,6 +97,7 @@ func registerRandomLoadBenchSpec(r registry.Registry, b randomLoadBenchSpec) {
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runSchemaChangeRandomLoad(ctx, t, c, b.Ops, b.Concurrency)
 		},
+		Tags: b.Tags,
 	})
 }
 

--- a/pkg/cmd/roachtest/tests/sequelize.go
+++ b/pkg/cmd/roachtest/tests/sequelize.go
@@ -158,7 +158,7 @@ func registerSequelize(r registry.Registry) {
 		Owner:      registry.OwnerSQLFoundations,
 		Cluster:    r.MakeClusterSpec(1),
 		NativeLibs: registry.LibGEOS,
-		Tags:       []string{`default`, `orm`},
+		Tags:       registry.Tags(`default`, `orm`),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runSequelize(ctx, t, c)
 		},

--- a/pkg/cmd/roachtest/tests/smoketest_secure.go
+++ b/pkg/cmd/roachtest/tests/smoketest_secure.go
@@ -28,7 +28,7 @@ func registerSecure(r registry.Registry) {
 	for _, numNodes := range []int{1, 3} {
 		r.Add(registry.TestSpec{
 			Name:    fmt.Sprintf("smoketest/secure/nodes=%d", numNodes),
-			Tags:    []string{"smoketest", "weekly"},
+			Tags:    registry.Tags("smoketest", "weekly"),
 			Owner:   registry.OwnerTestEng,
 			Cluster: r.MakeClusterSpec(numNodes),
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {

--- a/pkg/cmd/roachtest/tests/sqlalchemy.go
+++ b/pkg/cmd/roachtest/tests/sqlalchemy.go
@@ -39,7 +39,7 @@ func registerSQLAlchemy(r registry.Registry) {
 		Name:    "sqlalchemy",
 		Owner:   registry.OwnerSQLFoundations,
 		Cluster: r.MakeClusterSpec(1),
-		Tags:    []string{`default`, `orm`},
+		Tags:    registry.Tags(`default`, `orm`),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runSQLAlchemy(ctx, t, c)
 		},

--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -472,7 +472,7 @@ func registerTPCC(r registry.Registry) {
 		// running with the max supported warehouses.
 		Name:              "tpcc/headroom/" + headroomSpec.String(),
 		Owner:             registry.OwnerTestEng,
-		Tags:              []string{`default`, `release_qualification`, `aws`},
+		Tags:              registry.Tags(`default`, `release_qualification`, `aws`),
 		Cluster:           headroomSpec,
 		EncryptionSupport: registry.EncryptionMetamorphic,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
@@ -498,7 +498,7 @@ func registerTPCC(r registry.Registry) {
 		Owner: registry.OwnerTestEng,
 		// TODO(tbg): add release_qualification tag once we know the test isn't
 		// buggy.
-		Tags:              []string{`default`},
+		Tags:              registry.Tags(`default`),
 		Cluster:           mixedHeadroomSpec,
 		EncryptionSupport: registry.EncryptionMetamorphic,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
@@ -510,7 +510,7 @@ func registerTPCC(r registry.Registry) {
 		// run the same mixed-headroom test, but going back two versions
 		Name:              "tpcc/mixed-headroom/multiple-upgrades/" + mixedHeadroomSpec.String(),
 		Owner:             registry.OwnerTestEng,
-		Tags:              []string{`default`},
+		Tags:              registry.Tags(`default`),
 		Cluster:           mixedHeadroomSpec,
 		EncryptionSupport: registry.EncryptionMetamorphic,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
@@ -534,7 +534,7 @@ func registerTPCC(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:    "weekly/tpcc/headroom",
 		Owner:   registry.OwnerTestEng,
-		Tags:    []string{`weekly`},
+		Tags:    registry.Tags(`weekly`),
 		Cluster: r.MakeClusterSpec(4, spec.CPU(16)),
 		// Give the test a generous extra 10 hours to load the dataset and
 		// slowly ramp up the load.
@@ -807,7 +807,7 @@ func registerTPCC(r registry.Registry) {
 
 		LoadWarehouses: gceOrAws(cloud, 3000, 3500),
 		EstimatedMax:   gceOrAws(cloud, 2400, 3000),
-		Tags:           []string{`aws`},
+		Tags:           registry.Tags(`aws`),
 	})
 	registerTPCCBenchSpec(r, tpccBenchSpec{
 		Nodes:                    3,
@@ -824,7 +824,7 @@ func registerTPCC(r registry.Registry) {
 		LoadWarehouses: gceOrAws(cloud, 10000, 10000),
 		EstimatedMax:   gceOrAws(cloud, 8000, 8000),
 
-		Tags: []string{`weekly`},
+		Tags: registry.Tags(`weekly`),
 	})
 	registerTPCCBenchSpec(r, tpccBenchSpec{
 		Nodes:        6,
@@ -942,7 +942,7 @@ type tpccBenchSpec struct {
 	// MinVersion to pass to testRegistryImpl.Add.
 	MinVersion string
 	// Tags to pass to testRegistryImpl.Add.
-	Tags []string
+	Tags map[string]struct{}
 }
 
 // partitions returns the number of partitions specified to the load generator.

--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -472,7 +472,7 @@ func registerTPCC(r registry.Registry) {
 		// running with the max supported warehouses.
 		Name:              "tpcc/headroom/" + headroomSpec.String(),
 		Owner:             registry.OwnerTestEng,
-		Tags:              []string{`default`, `release_qualification`},
+		Tags:              []string{`default`, `release_qualification`, `aws`},
 		Cluster:           headroomSpec,
 		EncryptionSupport: registry.EncryptionMetamorphic,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
@@ -807,6 +807,7 @@ func registerTPCC(r registry.Registry) {
 
 		LoadWarehouses: gceOrAws(cloud, 3000, 3500),
 		EstimatedMax:   gceOrAws(cloud, 2400, 3000),
+		Tags:           []string{`aws`},
 	})
 	registerTPCCBenchSpec(r, tpccBenchSpec{
 		Nodes:                    3,

--- a/pkg/cmd/roachtest/tests/tpce.go
+++ b/pkg/cmd/roachtest/tests/tpce.go
@@ -33,7 +33,7 @@ func registerTPCE(r registry.Registry) {
 		cpus      int
 		ssds      int
 
-		tags    []string
+		tags    map[string]struct{}
 		timeout time.Duration
 	}
 
@@ -110,7 +110,7 @@ func registerTPCE(r registry.Registry) {
 		// Nightly, small scale configurations.
 		{customers: 5_000, nodes: 3, cpus: 4, ssds: 1},
 		// Weekly, large scale configurations.
-		{customers: 100_000, nodes: 5, cpus: 32, ssds: 2, tags: []string{"weekly"}, timeout: 36 * time.Hour},
+		{customers: 100_000, nodes: 5, cpus: 32, ssds: 2, tags: registry.Tags("weekly"), timeout: 36 * time.Hour},
 	} {
 		opts := opts
 		owner := registry.OwnerTestEng

--- a/pkg/cmd/roachtest/tests/typeorm.go
+++ b/pkg/cmd/roachtest/tests/typeorm.go
@@ -198,7 +198,7 @@ func registerTypeORM(r registry.Registry) {
 		Name:    "typeorm",
 		Owner:   registry.OwnerSQLFoundations,
 		Cluster: r.MakeClusterSpec(1),
-		Tags:    []string{`default`, `orm`},
+		Tags:    registry.Tags(`default`, `orm`),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runTypeORM(ctx, t, c)
 		},

--- a/pkg/cmd/roachtest/tests/ycsb.go
+++ b/pkg/cmd/roachtest/tests/ycsb.go
@@ -109,6 +109,7 @@ func registerYCSB(r registry.Registry) {
 				Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 					runYCSB(ctx, t, c, wl, cpus, false /* rangeTombstone */)
 				},
+				Tags: []string{`aws`},
 			})
 
 			if wl == "A" {
@@ -132,6 +133,7 @@ func registerYCSB(r registry.Registry) {
 					Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 						runYCSB(ctx, t, c, wl, cpus, true /* rangeTombstone */)
 					},
+					Tags: []string{`aws`},
 				})
 			}
 		}

--- a/pkg/cmd/roachtest/tests/ycsb.go
+++ b/pkg/cmd/roachtest/tests/ycsb.go
@@ -109,7 +109,7 @@ func registerYCSB(r registry.Registry) {
 				Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 					runYCSB(ctx, t, c, wl, cpus, false /* rangeTombstone */)
 				},
-				Tags: []string{`aws`},
+				Tags: registry.Tags(`aws`),
 			})
 
 			if wl == "A" {
@@ -133,7 +133,7 @@ func registerYCSB(r registry.Registry) {
 					Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 						runYCSB(ctx, t, c, wl, cpus, true /* rangeTombstone */)
 					},
-					Tags: []string{`aws`},
+					Tags: registry.Tags(`aws`),
 				})
 			}
 		}


### PR DESCRIPTION
Backport 3/3 commits from #111137.

/cc @cockroachdb/release

---

Backport 4/4 commits from #99402.

/cc @cockroachdb/release

Release justification: test-only change, keep roachtest in sync

---

… tags.

oday, tests are matched if they have any of the specified tags. This patch introduces the ability to match tests which have all specified tags, whilst attempting to maintain backward compatibility.

Commits
1 - expand tag filtering (AND, !)
2 - convert `TestSpec.Tags` to `map[string]struct{}`
3 - suppress TeamCity log statement


Epic: none
Fixes: #96655

Release note: None

