### PR TITLE
log: add filepath in headers config to http servers

### DIFF
--- a/docs/generated/logsinks.md
+++ b/docs/generated/logsinks.md
@@ -223,6 +223,7 @@ Type-specific configuration options:
 | `timeout` | the HTTP timeout. Defaults to 0 for no timeout. Inherited from `http-defaults.timeout` if not specified. |
 | `disable-keep-alives` | causes the logging sink to re-establish a new connection for every outgoing log message. This option is intended for testing only and can cause excessive network overhead in production systems. Inherited from `http-defaults.disable-keep-alives` if not specified. |
 | `headers` | a list of headers to attach to each HTTP request Inherited from `http-defaults.headers` if not specified. |
+| `file-based-headers` | a list of headers with filepaths whose contents are attached to each HTTP request Inherited from `http-defaults.file-based-headers` if not specified. |
 | `compression` | can be "none" or "gzip" to enable gzip compression. Set to "gzip" by default. Inherited from `http-defaults.compression` if not specified. |
 
 

--- a/pkg/util/log/BUILD.bazel
+++ b/pkg/util/log/BUILD.bazel
@@ -193,6 +193,7 @@ go_test(
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
         "@org_golang_x_net//trace",
+        "@org_golang_x_sys//unix",
     ],
 )
 

--- a/pkg/util/log/logconfig/config.go
+++ b/pkg/util/log/logconfig/config.go
@@ -513,6 +513,10 @@ type HTTPDefaults struct {
 	// Headers is a list of headers to attach to each HTTP request
 	Headers map[string]string `yaml:",omitempty,flow"`
 
+	// FileBasedHeaders is a list of headers with filepaths whose contents are
+	// attached to each HTTP request
+	FileBasedHeaders map[string]string `yaml:"file-based-headers,omitempty,flow"`
+
 	// Compression can be "none" or "gzip" to enable gzip compression.
 	// Set to "gzip" by default.
 	Compression *string `yaml:",omitempty"`

--- a/pkg/util/log/logconfig/testdata/validate
+++ b/pkg/util/log/logconfig/testdata/validate
@@ -598,12 +598,14 @@ sinks:
       address: a
       channels: STORAGE
       headers: {X-CRDB-HEADER: header-value-a}
+      file-based-headers: {X-CRDB-FILE-HEADER: /a/path/to/file}
       buffering:
         max-staleness: 10s
     b:
       address: b
       channels: OPS
       headers: {X-CRDB-HEADER: header-value-b, X-ANOTHER-HEADER: zz-yy-bb}
+      file-based-headers: {X-ANOTHER-FILE-HEADER: /other/path/to/file, X-CRDB-FILE-HEADER: /some/path/to/file}
       buffering:
         flush-trigger-size: 5.0KiB
     c:
@@ -630,6 +632,7 @@ sinks:
       timeout: 2s
       disable-keep-alives: false
       headers: {X-CRDB-HEADER: header-value-a}
+      file-based-headers: {X-CRDB-FILE-HEADER: /a/path/to/file}
       compression: gzip
       filter: INFO
       format: json-compact
@@ -650,6 +653,7 @@ sinks:
       timeout: 2s
       disable-keep-alives: false
       headers: {X-ANOTHER-HEADER: zz-yy-bb, X-CRDB-HEADER: header-value-b}
+      file-based-headers: {X-ANOTHER-FILE-HEADER: /other/path/to/file, X-CRDB-FILE-HEADER: /some/path/to/file}
       compression: gzip
       filter: INFO
       format: json-compact

--- a/pkg/util/log/logconfig/validate.go
+++ b/pkg/util/log/logconfig/validate.go
@@ -461,6 +461,14 @@ func (c *Config) validateHTTPSinkConfig(hsc *HTTPSinkConfig) error {
 	if *hsc.Compression != GzipCompression && *hsc.Compression != NoneCompression {
 		return errors.New("compression must be 'gzip' or 'none'")
 	}
+	// If both header types are populated, make sure theres no duplicate keys
+	if hsc.Headers != nil && hsc.FileBasedHeaders != nil {
+		for key := range hsc.Headers {
+			if _, exists := hsc.FileBasedHeaders[key]; exists {
+				return errors.Newf("headers and file-based-headers have the same key %s", key)
+			}
+		}
+	}
 	return c.ValidateCommonSinkConfig(hsc.CommonSinkConfig)
 }
 

--- a/pkg/util/log/registry.go
+++ b/pkg/util/log/registry.go
@@ -102,6 +102,19 @@ func (r *sinkInfoRegistry) iterBufferedSinks(fn func(bs *bufferedSink) error) er
 	})
 }
 
+// iterHttpSink iterates over all the http sinks and stops at the first error
+// encountered.
+func (r *sinkInfoRegistry) iterHttpSinks(fn func(hs *httpSink) error) error {
+	return r.iter(func(si *sinkInfo) error {
+		if hs, ok := si.sink.(*httpSink); ok {
+			if err := fn(hs); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
 // put adds a sinkInfo into the registry.
 func (r *sinkInfoRegistry) put(l *sinkInfo) {
 	r.mu.Lock()


### PR DESCRIPTION
This change adds new custom headers, `file-based-headers` in http-defaults in the logging configuration. These headers support key-filepath pairs. When a key-filepath pair is provided
the values are retrieved from the filepath on sink initialization and whenever SIGHUP is received so that a cluster restart is not needed to update those values.

Example usage with the new filepath: headers
headers:
  {X-CRDB-HEADER-A: filepath: path/to/file}

Release note (ops change): Added a new `file-based-headers` field found in `http-defaults` section of the log config which accepts key-filepath pairs. This allows values found at filepaths to be updated without restarting the cluster by sending SIGHUP to notify that values need to be refreshed.

Epic: CRDB-25399
Fixes: CRDB-31521