### PR TITLE
lint: allow builtin calls in deferunlock linter

### DIFF
--- a/pkg/testutils/lint/passes/deferunlockcheck/BUILD.bazel
+++ b/pkg/testutils/lint/passes/deferunlockcheck/BUILD.bazel
@@ -6,7 +6,6 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/testutils/lint/passes/deferunlockcheck",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/testutils/lint/passes/loopvarcapture",
         "//pkg/testutils/lint/passes/passesutil",
         "@org_golang_x_tools//go/analysis",
         "@org_golang_x_tools//go/analysis/passes/inspect",

--- a/pkg/testutils/lint/passes/deferunlockcheck/testdata/src/a/a.go
+++ b/pkg/testutils/lint/passes/deferunlockcheck/testdata/src/a/a.go
@@ -10,15 +10,14 @@
 
 package a
 
-import (
-	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
-)
+import "github.com/cockroachdb/cockroach/pkg/util/syncutil"
 
 type TestUnlockLint struct {
 	mu struct {
 		syncutil.Mutex
 		foo string
 		too bool
+		boo []string
 	}
 	amended bool
 }
@@ -93,6 +92,10 @@ func basicCases() {
 	// Function calls between lock/unlock pair.
 	t.mu.Lock()
 	testFnCall() // want `function call between Lock and Unlock may be unsafe, move Unlock to a defer statement after Lock`
+	t.mu.Unlock()
+
+	t.mu.Lock()
+	t.mu.boo = append(t.mu.boo, "heyo")
 	t.mu.Unlock()
 
 	t.mu.Lock()


### PR DESCRIPTION
I wanted to write code like:

    mu.Lock()
    mu.s = append(mu.s, 1)
    mu.Unlock()

without running afoul of the linter.

Here we allow calls to builtins and provide the ability to allow calls to other known-safe functions in the future.

Epic: none

Release note: None