### PR TITLE
c2c: allow span config event stream rangefeed cache to retry

### DIFF
--- a/pkg/ccl/streamingccl/streamingest/BUILD.bazel
+++ b/pkg/ccl/streamingccl/streamingest/BUILD.bazel
@@ -124,6 +124,7 @@ go_test(
         "//pkg/jobs",
         "//pkg/jobs/jobspb",
         "//pkg/keys",
+        "//pkg/kv/kvclient/rangefeed/rangefeedcache",
         "//pkg/kv/kvpb",
         "//pkg/kv/kvserver",
         "//pkg/kv/kvserver/protectedts",

--- a/pkg/repstream/streampb/stream.proto
+++ b/pkg/repstream/streampb/stream.proto
@@ -115,6 +115,7 @@ message ReplicationStreamSpec {
 message StreamedSpanConfigEntry {
   roachpb.SpanConfigEntry span_config = 1 [(gogoproto.nullable) = false];
   util.hlc.Timestamp timestamp = 2 [(gogoproto.nullable) = false];
+  bool from_full_scan = 3;
 }
 
 // StreamEvent describes a replication stream event

--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -321,6 +321,7 @@ go_library(
         "//pkg/kv/kvclient/kvtenant",
         "//pkg/kv/kvclient/rangecache",
         "//pkg/kv/kvclient/rangefeed",
+        "//pkg/kv/kvclient/rangefeed/rangefeedcache",
         "//pkg/kv/kvpb",
         "//pkg/kv/kvserver/concurrency/isolation",
         "//pkg/kv/kvserver/concurrency/lock",

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cockroachdb/apd/v3"
+	apd "github.com/cockroachdb/apd/v3"
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/cloud/externalconn"
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
@@ -42,6 +42,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvtenant"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/rangecache"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/rangefeed"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/rangefeed/rangefeedcache"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/protectedts"
@@ -1797,6 +1798,8 @@ type StreamingTestingKnobs struct {
 	AfterResumerJobLoad func(err error) error
 
 	SkipSpanConfigReplication bool
+
+	SpanConfigRangefeedCacheKnobs *rangefeedcache.TestingKnobs
 }
 
 var _ base.ModuleTestingKnobs = &StreamingTestingKnobs{}


### PR DESCRIPTION
This patch configures the rangefeedache which produces span config updates to retry automatically on rangefeed errors. Previously, the span config client would observe a single full scan of the span config table at initialization and then receive incremental updates until an error surfaced, which would then shut down the whole c2c distsql flow.

With this new internal retry behavior, the span config client may observe subsequent full scans of the span config table after the initial scan. Given this, the span config ingestor conducts the following while ingesting a full scan:
 - If it observes the first update from a full scan, it immediately flushes its buffer.
 - If it observes subsequent updates from the full scan at higher timestamps, it always buffers the update and never flushes.
 - the span config event stream never emits a checkpoint while it processes full scan updates; therefore, the span config ingestor will only flush the full scan updates once it has observed this full scan checkpoint.

Informs #109059

Release note: none