### PR TITLE
oidc: use relative paths in db-console

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/jwt/jwtAuthToken.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/jwt/jwtAuthToken.tsx
@@ -25,7 +25,7 @@ import {
 import ErrorCircle from "assets/error-circle.svg";
 import "./jwtAuthToken.styl";
 
-const OIDC_LOGIN_PATH_WITH_JWT = "/oidc/v1/login?jwt";
+const OIDC_LOGIN_PATH_WITH_JWT = "oidc/v1/login?jwt";
 
 type Params = {
   oidc: string;

--- a/pkg/ui/workspaces/db-console/src/views/login/oidc.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/login/oidc.tsx
@@ -14,8 +14,8 @@ import { LoginAPIState } from "oss/src/redux/login";
 import { Button } from "src/components";
 import { RouteComponentProps, withRouter } from "react-router-dom";
 
-const OIDC_LOGIN_PATH = "/oidc/v1/login";
-const OIDC_LOGIN_PATH_WITH_JWT = "/oidc/v1/login?jwt";
+const OIDC_LOGIN_PATH = "oidc/v1/login";
+const OIDC_LOGIN_PATH_WITH_JWT = "oidc/v1/login?jwt";
 
 const OIDCLoginButton = ({ loginState }: { loginState: LoginAPIState }) => {
   return (


### PR DESCRIPTION
Previous changes to make all DB Console paths relative overlooked the OIDC URLs.

Epic: None
Part of: #91429

Release note (ui change): DB Console instances proxied at different subpaths, that use OIDC will point to the correct relative path when attempting to use OIDC login.