### PR TITLE
sql: use precise capacity for row container in a few places

### DIFF
--- a/pkg/sql/explain_plan.go
+++ b/pkg/sql/explain_plan.go
@@ -162,7 +162,7 @@ func (e *explainPlanNode) startExec(params runParams) error {
 			rows = append(rows, fmt.Sprintf("   SQL command%s: %s", plural, recs[i].SQL))
 		}
 	}
-	v := params.p.newContainerValuesNode(colinfo.ExplainPlanColumns, 0)
+	v := params.p.newContainerValuesNode(colinfo.ExplainPlanColumns, len(rows))
 	datums := make([]tree.DString, len(rows))
 	for i, row := range rows {
 		datums[i] = tree.DString(row)

--- a/pkg/sql/show_cluster_setting.go
+++ b/pkg/sql/show_cluster_setting.go
@@ -284,7 +284,7 @@ func planShowClusterSetting(
 				}
 			}
 
-			v := p.newContainerValuesNode(columns, 0)
+			v := p.newContainerValuesNode(columns, 1)
 			if _, err := v.rows.AddRow(ctx, tree.Datums{d}); err != nil {
 				v.rows.Close(ctx)
 				return nil, err

--- a/pkg/sql/show_histogram.go
+++ b/pkg/sql/show_histogram.go
@@ -75,7 +75,7 @@ func (p *planner) ShowHistogram(ctx context.Context, n *tree.ShowHistogram) (pla
 				return nil, err
 			}
 
-			v := p.newContainerValuesNode(showHistogramColumns, 0)
+			v := p.newContainerValuesNode(showHistogramColumns, len(histogram.Buckets))
 			resolver := descs.NewDistSQLTypeResolver(p.descCollection, p.InternalSQLTxn().KV())
 			if err := typedesc.EnsureTypeIsHydrated(ctx, histogram.ColumnType, &resolver); err != nil {
 				return nil, err

--- a/pkg/sql/show_stats.go
+++ b/pkg/sql/show_stats.go
@@ -258,7 +258,11 @@ func (p *planner) ShowTableStats(ctx context.Context, n *tree.ShowTableStats) (p
 				}
 			}
 
-			v := p.newContainerValuesNode(columns, 0)
+			rowContainerCap := len(rows)
+			if n.UsingJSON {
+				rowContainerCap = 1
+			}
+			v := p.newContainerValuesNode(columns, rowContainerCap)
 			if n.UsingJSON {
 				result := make([]stats.JSONStatistic, 0, len(rows))
 				for _, r := range rows {

--- a/pkg/sql/show_zone_config.go
+++ b/pkg/sql/show_zone_config.go
@@ -68,7 +68,7 @@ func (p *planner) ShowZoneConfig(ctx context.Context, n *tree.ShowZoneConfig) (p
 		name:    n.String(),
 		columns: showZoneConfigColumns,
 		constructor: func(ctx context.Context, p *planner) (planNode, error) {
-			v := p.newContainerValuesNode(showZoneConfigColumns, 0)
+			v := p.newContainerValuesNode(showZoneConfigColumns, 1)
 
 			// This signifies SHOW ALL.
 			// However, SHOW ALL should be handled by the delegate.


### PR DESCRIPTION
This commit audits all callers of `newContainerValuesNode` to specify the precise capacity of the underlying row container since in all places we know upfront how many rows the valuesNode will have. (Just happened to notice it while working around one of those places.)

Epic: None

Release note: None