### PR TITLE
Roachtest retry api

### DIFF
--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -745,7 +745,7 @@ var runCmd = &cobra.Command{
 	Args: cobra.MinimumNArgs(1),
 	Run: wrap(func(_ *cobra.Command, args []string) error {
 		return roachprod.Run(context.Background(), config.Logger, args[0], extraSSHOptions, tag,
-			secure, os.Stdout, os.Stderr, args[1:], install.WithWaitOnFail())
+			secure, os.Stdout, os.Stderr, args[1:], install.WithFailSlow(true))
 	}),
 }
 

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -2182,7 +2182,7 @@ func (c *clusterImpl) RunEExt(
 	cmd := strings.Join(args, " ")
 	c.t.L().Printf("running cmd `%s` on nodes [%v]; details in %s.log", roachprod.TruncateString(cmd, 30), nodes, logFile)
 	l.Printf("> %s", cmd)
-	if err := roachprod.Run(ctx, l, c.MakeNodes(nodes), "", "", c.IsSecure(), l.Stdout, l.Stderr, args); err != nil {
+	if err := roachprod.Run(ctx, l, c.MakeNodes(nodes), "", "", c.IsSecure(), l.Stdout, l.Stderr, args, opts...); err != nil {
 		if err := ctx.Err(); err != nil {
 			l.Printf("(note: incoming context was canceled: %s)", err)
 			return err
@@ -2216,7 +2216,7 @@ func (c *clusterImpl) RunWithDetailsSingleNodeExt(
 	if len(nodes) != 1 {
 		return install.RunResultDetails{}, errors.Newf("RunWithDetailsSingleNode received %d nodes. Use RunWithDetails if you need to run on multiple nodes.", len(nodes))
 	}
-	results, err := c.RunWithDetails(ctx, testLogger, nodes, args...)
+	results, err := c.RunWithDetailsExt(ctx, testLogger, nodes, args, opts...)
 	return results[0], errors.CombineErrors(err, results[0].Err)
 }
 

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -2150,8 +2150,10 @@ func (c *clusterImpl) Run(ctx context.Context, node option.NodeListOption, args 
 }
 
 // Run a command on the specified nodes and call test.Fatal if there is an error.
-func (c *clusterImpl) RunExt(ctx context.Context, node option.NodeListOption, args []string) {
-	err := c.RunEExt(ctx, node, args)
+func (c *clusterImpl) RunExt(
+	ctx context.Context, node option.NodeListOption, args []string, opts ...install.RunOption,
+) {
+	err := c.RunEExt(ctx, node, args, opts...)
 	if err != nil {
 		c.t.Fatal(err)
 	}
@@ -2165,7 +2167,9 @@ func (c *clusterImpl) RunE(ctx context.Context, node option.NodeListOption, args
 // will be redirected to a file which is logged via the cluster-wide logger in
 // case of an error. Logs will sort chronologically. Failing invocations will
 // have an additional marker file with a `.failed` extension instead of `.log`.
-func (c *clusterImpl) RunEExt(ctx context.Context, nodes option.NodeListOption, args []string) error {
+func (c *clusterImpl) RunEExt(
+	ctx context.Context, nodes option.NodeListOption, args []string, opts ...install.RunOption,
+) error {
 	if len(args) == 0 {
 		return errors.New("No command passed")
 	}
@@ -2203,7 +2207,11 @@ func (c *clusterImpl) RunWithDetailsSingleNode(
 // you treat an error from the command. This makes error checking easier / friendlier
 // and helps us avoid code replication.
 func (c *clusterImpl) RunWithDetailsSingleNodeExt(
-	ctx context.Context, testLogger *logger.Logger, nodes option.NodeListOption, args []string,
+	ctx context.Context,
+	testLogger *logger.Logger,
+	nodes option.NodeListOption,
+	args []string,
+	opts ...install.RunOption,
 ) (install.RunResultDetails, error) {
 	if len(nodes) != 1 {
 		return install.RunResultDetails{}, errors.Newf("RunWithDetailsSingleNode received %d nodes. Use RunWithDetails if you need to run on multiple nodes.", len(nodes))
@@ -2223,7 +2231,11 @@ func (c *clusterImpl) RunWithDetails(
 // via the cluster-wide logger in case of an error. Failing invocations will have
 // an additional marker file with a `.failed` extension instead of `.log`.
 func (c *clusterImpl) RunWithDetailsExt(
-	ctx context.Context, testLogger *logger.Logger, nodes option.NodeListOption, args []string,
+	ctx context.Context,
+	testLogger *logger.Logger,
+	nodes option.NodeListOption,
+	args []string,
+	opts ...install.RunOption,
 ) ([]install.RunResultDetails, error) {
 	if len(args) == 0 {
 		return nil, errors.New("No command passed")
@@ -2242,7 +2254,7 @@ func (c *clusterImpl) RunWithDetailsExt(
 	}
 
 	l.Printf("> %s", cmd)
-	results, err := roachprod.RunWithDetails(ctx, l, c.MakeNodes(nodes), "" /* SSHOptions */, "" /* processTag */, c.IsSecure(), args)
+	results, err := roachprod.RunWithDetails(ctx, l, c.MakeNodes(nodes), "" /* SSHOptions */, "" /* processTag */, c.IsSecure(), args, opts...)
 
 	logFileFull := l.File.Name()
 	if err != nil {

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -2145,19 +2145,27 @@ func (c *clusterImpl) Wipe(ctx context.Context, preserveCerts bool, nodes ...opt
 	}
 }
 
-// Run a command on the specified nodes and call test.Fatal if there is an error.
 func (c *clusterImpl) Run(ctx context.Context, node option.NodeListOption, args ...string) {
-	err := c.RunE(ctx, node, args...)
+	c.RunExt(ctx, node, args)
+}
+
+// Run a command on the specified nodes and call test.Fatal if there is an error.
+func (c *clusterImpl) RunExt(ctx context.Context, node option.NodeListOption, args []string) {
+	err := c.RunEExt(ctx, node, args)
 	if err != nil {
 		c.t.Fatal(err)
 	}
+}
+
+func (c *clusterImpl) RunE(ctx context.Context, node option.NodeListOption, args ...string) error {
+	return c.RunEExt(ctx, node, args)
 }
 
 // RunE runs a command on the specified node, returning an error. The output
 // will be redirected to a file which is logged via the cluster-wide logger in
 // case of an error. Logs will sort chronologically. Failing invocations will
 // have an additional marker file with a `.failed` extension instead of `.log`.
-func (c *clusterImpl) RunE(ctx context.Context, nodes option.NodeListOption, args ...string) error {
+func (c *clusterImpl) RunEExt(ctx context.Context, nodes option.NodeListOption, args []string) error {
 	if len(args) == 0 {
 		return errors.New("No command passed")
 	}
@@ -2184,12 +2192,18 @@ func (c *clusterImpl) RunE(ctx context.Context, nodes option.NodeListOption, arg
 	return nil
 }
 
+func (c *clusterImpl) RunWithDetailsSingleNode(
+	ctx context.Context, testLogger *logger.Logger, nodes option.NodeListOption, args ...string,
+) (install.RunResultDetails, error) {
+	return c.RunWithDetailsSingleNodeExt(ctx, testLogger, nodes, args)
+}
+
 // RunWithDetailsSingleNode is just like RunWithDetails but used when 1) operating
 // on a single node AND 2) an error from roachprod itself would be treated the same way
 // you treat an error from the command. This makes error checking easier / friendlier
 // and helps us avoid code replication.
-func (c *clusterImpl) RunWithDetailsSingleNode(
-	ctx context.Context, testLogger *logger.Logger, nodes option.NodeListOption, args ...string,
+func (c *clusterImpl) RunWithDetailsSingleNodeExt(
+	ctx context.Context, testLogger *logger.Logger, nodes option.NodeListOption, args []string,
 ) (install.RunResultDetails, error) {
 	if len(nodes) != 1 {
 		return install.RunResultDetails{}, errors.Newf("RunWithDetailsSingleNode received %d nodes. Use RunWithDetails if you need to run on multiple nodes.", len(nodes))
@@ -2198,12 +2212,18 @@ func (c *clusterImpl) RunWithDetailsSingleNode(
 	return results[0], errors.CombineErrors(err, results[0].Err)
 }
 
+func (c *clusterImpl) RunWithDetails(
+	ctx context.Context, testLogger *logger.Logger, nodes option.NodeListOption, args ...string,
+) ([]install.RunResultDetails, error) {
+	return c.RunWithDetailsExt(ctx, testLogger, nodes, args)
+}
+
 // RunWithDetails runs a command on the specified nodes, returning the results
 // details and a `roachprod` error. The output will be redirected to a file which is logged
 // via the cluster-wide logger in case of an error. Failing invocations will have
 // an additional marker file with a `.failed` extension instead of `.log`.
-func (c *clusterImpl) RunWithDetails(
-	ctx context.Context, testLogger *logger.Logger, nodes option.NodeListOption, args ...string,
+func (c *clusterImpl) RunWithDetailsExt(
+	ctx context.Context, testLogger *logger.Logger, nodes option.NodeListOption, args []string,
 ) ([]install.RunResultDetails, error) {
 	if len(args) == 0 {
 		return nil, errors.New("No command passed")

--- a/pkg/cmd/roachtest/cluster/cluster_interface.go
+++ b/pkg/cmd/roachtest/cluster/cluster_interface.go
@@ -90,19 +90,19 @@ type Cluster interface {
 	// Use it when you need output details such as stdout or stderr, or remote exit status.
 	RunWithDetails(ctx context.Context, testLogger *logger.Logger, nodes option.NodeListOption, args ...string) ([]install.RunResultDetails, error)
 
-	RunWithDetailsExt(ctx context.Context, testLogger *logger.Logger, nodes option.NodeListOption, args []string) ([]install.RunResultDetails, error)
+	RunWithDetailsExt(ctx context.Context, testLogger *logger.Logger, nodes option.NodeListOption, args []string, opts ...install.RunOption) ([]install.RunResultDetails, error)
 
 	// Run is fatal on errors.
 	// Use it when an error means the test should fail.
 	Run(ctx context.Context, node option.NodeListOption, args ...string)
 
-	RunExt(ctx context.Context, node option.NodeListOption, args []string)
+	RunExt(ctx context.Context, node option.NodeListOption, args []string, opts ...install.RunOption)
 
 	// RunE runs a command on the specified nodes and returns an error.
 	// Use it when you need to run a command and only care if it ran successfully or not.
 	RunE(ctx context.Context, node option.NodeListOption, args ...string) error
 
-	RunEExt(ctx context.Context, node option.NodeListOption, args []string) error
+	RunEExt(ctx context.Context, node option.NodeListOption, args []string, opts ...install.RunOption) error
 
 	// RunWithDetailsSingleNode is just like RunWithDetails but used when 1) operating
 	// on a single node AND 2) an error from roachprod itself would be treated the same way
@@ -110,7 +110,7 @@ type Cluster interface {
 	// and helps us avoid code replication.
 	RunWithDetailsSingleNode(ctx context.Context, testLogger *logger.Logger, nodes option.NodeListOption, args ...string) (install.RunResultDetails, error)
 
-	RunWithDetailsSingleNodeExt(ctx context.Context, testLogger *logger.Logger, nodes option.NodeListOption, args []string) (install.RunResultDetails, error)
+	RunWithDetailsSingleNodeExt(ctx context.Context, testLogger *logger.Logger, nodes option.NodeListOption, args []string, opts ...install.RunOption) (install.RunResultDetails, error)
 
 	// Metadata about the provisioned nodes.
 

--- a/pkg/cmd/roachtest/cluster/cluster_interface.go
+++ b/pkg/cmd/roachtest/cluster/cluster_interface.go
@@ -90,19 +90,27 @@ type Cluster interface {
 	// Use it when you need output details such as stdout or stderr, or remote exit status.
 	RunWithDetails(ctx context.Context, testLogger *logger.Logger, nodes option.NodeListOption, args ...string) ([]install.RunResultDetails, error)
 
+	RunWithDetailsExt(ctx context.Context, testLogger *logger.Logger, nodes option.NodeListOption, args []string) ([]install.RunResultDetails, error)
+
 	// Run is fatal on errors.
 	// Use it when an error means the test should fail.
 	Run(ctx context.Context, node option.NodeListOption, args ...string)
 
+	RunExt(ctx context.Context, node option.NodeListOption, args []string)
+
 	// RunE runs a command on the specified nodes and returns an error.
 	// Use it when you need to run a command and only care if it ran successfully or not.
 	RunE(ctx context.Context, node option.NodeListOption, args ...string) error
+
+	RunEExt(ctx context.Context, node option.NodeListOption, args []string) error
 
 	// RunWithDetailsSingleNode is just like RunWithDetails but used when 1) operating
 	// on a single node AND 2) an error from roachprod itself would be treated the same way
 	// you treat an error from the command. This makes error checking easier / friendlier
 	// and helps us avoid code replication.
 	RunWithDetailsSingleNode(ctx context.Context, testLogger *logger.Logger, nodes option.NodeListOption, args ...string) (install.RunResultDetails, error)
+
+	RunWithDetailsSingleNodeExt(ctx context.Context, testLogger *logger.Logger, nodes option.NodeListOption, args []string) (install.RunResultDetails, error)
 
 	// Metadata about the provisioned nodes.
 

--- a/pkg/roachprod/install/BUILD.bazel
+++ b/pkg/roachprod/install/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "install.go",
         "iterm2.go",
         "nodes.go",
+        "run_options.go",
         "services.go",
         "session.go",
         "staging.go",

--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -104,7 +104,7 @@ func NewSyncedCluster(
 var ErrAfterRetry = errors.New("error occurred after retries")
 
 // The first retry is after 5s, the second and final is after 25s
-var defaultRetryOpt = retry.Options{
+var DefaultRetryOpt = &retry.Options{
 	InitialBackoff: 5 * time.Second,
 	Multiplier:     5,
 	MaxBackoff:     1 * time.Minute,
@@ -112,29 +112,27 @@ var defaultRetryOpt = retry.Options{
 	MaxRetries: 2,
 }
 
-var DefaultSSHRetryOpts = NewRetryOpts(defaultRetryOpt, func(res *RunResultDetails) bool { return errors.Is(res.Err, rperrors.ErrSSH255) })
+var DefaultShouldRetryFn = func(res *RunResultDetails) bool { return errors.Is(res.Err, rperrors.ErrSSH255) }
 
 // defaultSCPRetry won't retry if the error output contains any of the following
 // substrings, in which cases retries are unlikely to help.
 var noScpRetrySubstrings = []string{"no such file or directory", "permission denied", "connection timed out"}
-var defaultSCPRetry = NewRetryOpts(defaultRetryOpt,
-	func(res *RunResultDetails) bool {
-		out := strings.ToLower(res.Output(false))
-		for _, s := range noScpRetrySubstrings {
-			if strings.Contains(out, s) {
-				return false
-			}
+var defaulSCPShouldRetryFn = func(res *RunResultDetails) bool {
+	out := strings.ToLower(res.Output(false))
+	for _, s := range noScpRetrySubstrings {
+		if strings.Contains(out, s) {
+			return false
 		}
-		return true
-	},
-)
+	}
+	return true
+}
 
 // runWithMaybeRetry will run the specified function `f` at least once, or only
 // once if `runRetryOpts` is nil
 //
-// Any RunResultDetails containing a non nil err from `f` is passed to `runRetryOpts.ShouldRetryFn` which,
-// if it returns true, will result in `f` being retried using the `retryOpts`
-// If the `ShouldRetryFn` is not specified (nil), then retries will be performed
+// Any RunResultDetails containing a non nil err from `f` is passed to `shouldRetryFn` which,
+// if it returns true, will result in `f` being retried using the `RetryOpts`
+// If the `shouldRetryFn` is not specified (nil), then retries will be performed
 // regardless of the previous result / error.
 //
 // If a non-nil error (as opposed to the result containing a non-nil error) is returned,
@@ -146,7 +144,8 @@ var defaultSCPRetry = NewRetryOpts(defaultRetryOpt,
 func runWithMaybeRetry(
 	ctx context.Context,
 	l *logger.Logger,
-	retryOpts *RetryOpts,
+	retryOpts *retry.Options,
+	shouldRetryFn func(*RunResultDetails) bool,
 	f func(ctx context.Context) (*RunResultDetails, error),
 ) (*RunResultDetails, error) {
 	if retryOpts == nil {
@@ -161,7 +160,7 @@ func runWithMaybeRetry(
 	var res = &RunResultDetails{}
 	var cmdErr, err error
 
-	for r := retry.StartWithCtx(ctx, retryOpts.Options); r.Next(); {
+	for r := retry.StartWithCtx(ctx, *retryOpts); r.Next(); {
 		res, err = f(ctx)
 		if err != nil {
 			// non retryable roachprod error
@@ -170,7 +169,7 @@ func runWithMaybeRetry(
 		res.Attempt = r.CurrentAttempt() + 1
 		if res.Err != nil {
 			cmdErr = errors.CombineErrors(cmdErr, res.Err)
-			if retryOpts.ShouldRetryFn == nil || retryOpts.ShouldRetryFn(res) {
+			if shouldRetryFn == nil || shouldRetryFn(res) {
 				l.Printf("encountered [%v] on attempt %v of %v", res.Err, r.CurrentAttempt()+1, retryOpts.MaxRetries+1)
 				continue
 			}
@@ -193,7 +192,8 @@ func runWithMaybeRetry(
 func scpWithRetry(
 	ctx context.Context, l *logger.Logger, src, dest string,
 ) (*RunResultDetails, error) {
-	return runWithMaybeRetry(ctx, l, defaultSCPRetry, func(ctx context.Context) (*RunResultDetails, error) { return scp(l, src, dest) })
+	return runWithMaybeRetry(ctx, l, DefaultRetryOpt, defaulSCPShouldRetryFn,
+		func(ctx context.Context) (*RunResultDetails, error) { return scp(l, src, dest) })
 }
 
 // Host returns the public IP of a node.
@@ -461,7 +461,7 @@ fi`,
 		)
 
 		return c.runCmdOnSingleNode(ctx, l, node, cmd, defaultCmdOpts("kill"))
-	}, WithDisplay(display), WithRetryOpts(nil)) // Disable SSH Retries
+	}, WithDisplay(display), WithRetryDisabled()) // Disable SSH Retries
 }
 
 // Wipe TODO(peter): document
@@ -1034,7 +1034,7 @@ func (c *SyncedCluster) Run(
 	if !stream {
 		display = fmt.Sprintf("%s:%v: %s", c.Name, nodes, title)
 	}
-
+	defaultOpts := []RunOption{WithDisplay(display)}
 	results, _, err := c.ParallelE(ctx, l, nodes, func(ctx context.Context, node Node) (*RunResultDetails, error) {
 		opts := RunCmdOptions{
 			combinedOut:             !stream,
@@ -1044,7 +1044,7 @@ func (c *SyncedCluster) Run(
 		}
 		result, err := c.runCmdOnSingleNode(ctx, l, node, cmd, opts)
 		return result, err
-	}, append(opts, WithDisplay(display))...)
+	}, append(defaultOpts, opts...)...)
 
 	if err != nil {
 		return err
@@ -1103,11 +1103,12 @@ func processResults(results []*RunResultDetails, stream bool, stdout io.Writer) 
 }
 
 // RunWithDetails runs a command on the specified nodes and returns results details and an error.
-// This will wait for all commands to complete before returning unless encountering a roachprod error.
+// By default, this will wait for all commands to complete before returning unless encountering a roachprod error.
 func (c *SyncedCluster) RunWithDetails(
-	ctx context.Context, l *logger.Logger, nodes Nodes, title, cmd string,
+	ctx context.Context, l *logger.Logger, nodes Nodes, title, cmd string, opts ...RunOption,
 ) ([]RunResultDetails, error) {
 	display := fmt.Sprintf("%s:%v: %s", c.Name, nodes, title)
+	defaultOpts := []RunOption{WithDisplay(display), WithFailSlow(true)}
 
 	// Failing slow here allows us to capture the output of all nodes even if one fails with a command error.
 	resultPtrs, _, err := c.ParallelE(ctx, l, nodes, func(ctx context.Context, node Node) (*RunResultDetails, error) {
@@ -1118,7 +1119,7 @@ func (c *SyncedCluster) RunWithDetails(
 		}
 		result, err := c.runCmdOnSingleNode(ctx, l, node, cmd, opts)
 		return result, err
-	}, WithDisplay(display), WithWaitOnFail())
+	}, append(defaultOpts, opts...)...)
 
 	if err != nil {
 		return nil, err
@@ -1186,7 +1187,7 @@ func (c *SyncedCluster) Wait(ctx context.Context, l *logger.Logger) error {
 		res.Err = errors.New("timed out after 5m")
 		l.Printf("  %2d: %v", node, res.Err)
 		return res, nil
-	}, WithDisplay(display), WithRetryOpts(nil))
+	}, WithDisplay(display), WithRetryDisabled())
 
 	if err != nil {
 		return err
@@ -2558,7 +2559,7 @@ type ParallelResult struct {
 //
 // By default, this will fail fast if a command error occurs on any node, and return
 // a slice containing all results up to that point, along with a boolean indicating
-// that at least one error occurred. If `WithWaitOnFail()` is passed in, then the function
+// that at least one error occurred. If `WithFailSlow(true)` is passed in, then the function
 // will wait for all invocations to complete before returning.
 //
 // ParallelE only returns an error for roachprod itself, not any command errors run
@@ -2582,7 +2583,11 @@ func (c *SyncedCluster) ParallelE(
 	fn func(ctx context.Context, n Node) (*RunResultDetails, error),
 	opts ...RunOption,
 ) ([]*RunResultDetails, bool, error) {
-	options := RunOptions{RetryOpts: DefaultSSHRetryOpts}
+	// Default options, which can be overridden by those passed in
+	options := RunOptions{
+		RetryOptions:  DefaultRetryOpt,
+		ShouldRetryFn: DefaultShouldRetryFn,
+	}
 	for _, opt := range opts {
 		opt(&options)
 	}
@@ -2613,7 +2618,7 @@ func (c *SyncedCluster) ParallelE(
 			defer wg.Done()
 			// This is rarely expected to return an error, but we fail fast in case.
 			// Command errors, which are far more common, will be contained within the result.
-			res, err := runWithMaybeRetry(groupCtx, l, options.RetryOpts, func(ctx context.Context) (*RunResultDetails, error) { return fn(ctx, nodes[i]) })
+			res, err := runWithMaybeRetry(groupCtx, l, options.RetryOptions, options.ShouldRetryFn, func(ctx context.Context) (*RunResultDetails, error) { return fn(ctx, nodes[i]) })
 			if err != nil {
 				errorChannel <- err
 				return
@@ -2670,7 +2675,7 @@ func (c *SyncedCluster) ParallelE(
 				n++
 				if r.Err != nil { // Command error
 					hasError = true
-					if !options.WaitOnFail {
+					if !options.FailSlow {
 						groupCancel()
 						return results, true, nil
 					}

--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -112,26 +112,12 @@ var defaultRetryOpt = retry.Options{
 	MaxRetries: 2,
 }
 
-type RunRetryOpts struct {
-	retry.Options
-	shouldRetryFn func(*RunResultDetails) bool
-}
-
-func newRunRetryOpts(
-	retryOpts retry.Options, shouldRetryFn func(*RunResultDetails) bool,
-) *RunRetryOpts {
-	return &RunRetryOpts{
-		Options:       retryOpts,
-		shouldRetryFn: shouldRetryFn,
-	}
-}
-
-var DefaultSSHRetryOpts = newRunRetryOpts(defaultRetryOpt, func(res *RunResultDetails) bool { return errors.Is(res.Err, rperrors.ErrSSH255) })
+var DefaultSSHRetryOpts = NewRetryOpts(defaultRetryOpt, func(res *RunResultDetails) bool { return errors.Is(res.Err, rperrors.ErrSSH255) })
 
 // defaultSCPRetry won't retry if the error output contains any of the following
 // substrings, in which cases retries are unlikely to help.
 var noScpRetrySubstrings = []string{"no such file or directory", "permission denied", "connection timed out"}
-var defaultSCPRetry = newRunRetryOpts(defaultRetryOpt,
+var defaultSCPRetry = NewRetryOpts(defaultRetryOpt,
 	func(res *RunResultDetails) bool {
 		out := strings.ToLower(res.Output(false))
 		for _, s := range noScpRetrySubstrings {
@@ -146,9 +132,9 @@ var defaultSCPRetry = newRunRetryOpts(defaultRetryOpt,
 // runWithMaybeRetry will run the specified function `f` at least once, or only
 // once if `runRetryOpts` is nil
 //
-// Any RunResultDetails containing a non nil err from `f` is passed to `runRetryOpts.shouldRetryFn` which,
+// Any RunResultDetails containing a non nil err from `f` is passed to `runRetryOpts.ShouldRetryFn` which,
 // if it returns true, will result in `f` being retried using the `retryOpts`
-// If the `shouldRetryFn` is not specified (nil), then retries will be performed
+// If the `ShouldRetryFn` is not specified (nil), then retries will be performed
 // regardless of the previous result / error.
 //
 // If a non-nil error (as opposed to the result containing a non-nil error) is returned,
@@ -160,7 +146,7 @@ var defaultSCPRetry = newRunRetryOpts(defaultRetryOpt,
 func runWithMaybeRetry(
 	ctx context.Context,
 	l *logger.Logger,
-	retryOpts *RunRetryOpts,
+	retryOpts *RetryOpts,
 	f func(ctx context.Context) (*RunResultDetails, error),
 ) (*RunResultDetails, error) {
 	if retryOpts == nil {
@@ -184,7 +170,7 @@ func runWithMaybeRetry(
 		res.Attempt = r.CurrentAttempt() + 1
 		if res.Err != nil {
 			cmdErr = errors.CombineErrors(cmdErr, res.Err)
-			if retryOpts.shouldRetryFn == nil || retryOpts.shouldRetryFn(res) {
+			if retryOpts.ShouldRetryFn == nil || retryOpts.ShouldRetryFn(res) {
 				l.Printf("encountered [%v] on attempt %v of %v", res.Err, r.CurrentAttempt()+1, retryOpts.MaxRetries+1)
 				continue
 			}
@@ -1040,7 +1026,7 @@ func (c *SyncedCluster) Run(
 	stdout, stderr io.Writer,
 	nodes Nodes,
 	title, cmd string,
-	opts ...ParallelOption,
+	opts ...RunOption,
 ) error {
 	// Stream output if we're running the command on only 1 node.
 	stream := len(nodes) == 1
@@ -2524,48 +2510,11 @@ func scp(l *logger.Logger, src, dest string) (*RunResultDetails, error) {
 	return res, nil
 }
 
-type ParallelOptions struct {
-	concurrency int
-	display     string
-	retryOpts   *RunRetryOpts
-	// waitOnFail will cause the Parallel function to wait for all nodes to
-	// finish when encountering a command error on any node. The default
-	// behaviour is to exit immediately on the first error, in which case the
-	// slice of ParallelResults will only contain the one error result.
-	waitOnFail bool
-}
-
-type ParallelOption func(result *ParallelOptions)
-
-func WithConcurrency(concurrency int) ParallelOption {
-	return func(result *ParallelOptions) {
-		result.concurrency = concurrency
-	}
-}
-
-func WithRetryOpts(retryOpts *RunRetryOpts) ParallelOption {
-	return func(result *ParallelOptions) {
-		result.retryOpts = retryOpts
-	}
-}
-
-func WithWaitOnFail() ParallelOption {
-	return func(result *ParallelOptions) {
-		result.waitOnFail = true
-	}
-}
-
-func WithDisplay(display string) ParallelOption {
-	return func(result *ParallelOptions) {
-		result.display = display
-	}
-}
-
 // Parallel runs a user-defined function across the nodes in the
 // cluster. If any of the commands fail, Parallel will log each failure
 // and return an error.
 //
-// A user may also pass in a RunRetryOpts to control how the function is retried
+// A user may also pass in a RetryOpts to control how the function is retried
 // in the case of a failure.
 //
 // See ParallelE for more information.
@@ -2574,7 +2523,7 @@ func (c *SyncedCluster) Parallel(
 	l *logger.Logger,
 	nodes Nodes,
 	fn func(ctx context.Context, n Node) (*RunResultDetails, error),
-	opts ...ParallelOption,
+	opts ...RunOption,
 ) error {
 	results, hasError, err := c.ParallelE(ctx, l, nodes, fn, opts...)
 	// `err` is an unexpected roachprod error, which we return immediately.
@@ -2621,7 +2570,7 @@ type ParallelResult struct {
 // The function returns pointers to *RunResultDetails as we may enrich
 // the result with retry information (attempt number, wrapper error).
 //
-// RunRetryOpts controls the retry behavior in the case that
+// RetryOpts controls the retry behavior in the case that
 // the function fails, but returns a nil error. A non-nil error returned by the
 // function denotes a roachprod error and will not be retried regardless of the
 // retry options.
@@ -2631,19 +2580,19 @@ func (c *SyncedCluster) ParallelE(
 	l *logger.Logger,
 	nodes Nodes,
 	fn func(ctx context.Context, n Node) (*RunResultDetails, error),
-	opts ...ParallelOption,
+	opts ...RunOption,
 ) ([]*RunResultDetails, bool, error) {
-	options := ParallelOptions{retryOpts: DefaultSSHRetryOpts}
+	options := RunOptions{RetryOpts: DefaultSSHRetryOpts}
 	for _, opt := range opts {
 		opt(&options)
 	}
 
 	count := len(nodes)
-	if options.concurrency == 0 || options.concurrency > count {
-		options.concurrency = count
+	if options.Concurrency == 0 || options.Concurrency > count {
+		options.Concurrency = count
 	}
-	if config.MaxConcurrency > 0 && options.concurrency > config.MaxConcurrency {
-		options.concurrency = config.MaxConcurrency
+	if config.MaxConcurrency > 0 && options.Concurrency > config.MaxConcurrency {
+		options.Concurrency = config.MaxConcurrency
 	}
 
 	completed := make(chan ParallelResult, count)
@@ -2664,7 +2613,7 @@ func (c *SyncedCluster) ParallelE(
 			defer wg.Done()
 			// This is rarely expected to return an error, but we fail fast in case.
 			// Command errors, which are far more common, will be contained within the result.
-			res, err := runWithMaybeRetry(groupCtx, l, options.retryOpts, func(ctx context.Context) (*RunResultDetails, error) { return fn(ctx, nodes[i]) })
+			res, err := runWithMaybeRetry(groupCtx, l, options.RetryOpts, func(ctx context.Context) (*RunResultDetails, error) { return fn(ctx, nodes[i]) })
 			if err != nil {
 				errorChannel <- err
 				return
@@ -2675,7 +2624,7 @@ func (c *SyncedCluster) ParallelE(
 		index++
 	}
 
-	for index < options.concurrency {
+	for index < options.Concurrency {
 		startNext()
 	}
 
@@ -2687,7 +2636,7 @@ func (c *SyncedCluster) ParallelE(
 
 	var writer ui.Writer
 	out := l.Stdout
-	if options.display == "" {
+	if options.Display == "" {
 		out = io.Discard
 	}
 
@@ -2696,7 +2645,7 @@ func (c *SyncedCluster) ParallelE(
 		ticker = time.NewTicker(100 * time.Millisecond)
 	} else {
 		ticker = time.NewTicker(1000 * time.Millisecond)
-		fmt.Fprintf(out, "%s", options.display)
+		fmt.Fprintf(out, "%s", options.Display)
 		if l.File != nil {
 			fmt.Fprintf(out, "\n")
 		}
@@ -2721,7 +2670,7 @@ func (c *SyncedCluster) ParallelE(
 				n++
 				if r.Err != nil { // Command error
 					hasError = true
-					if !options.waitOnFail {
+					if !options.WaitOnFail {
 						groupCancel()
 						return results, true, nil
 					}
@@ -2739,7 +2688,7 @@ func (c *SyncedCluster) ParallelE(
 		}
 
 		if !config.Quiet && l.File == nil {
-			fmt.Fprint(&writer, options.display)
+			fmt.Fprint(&writer, options.Display)
 			fmt.Fprintf(&writer, " %d/%d", n, count)
 			if !done {
 				fmt.Fprintf(&writer, " %s", spinner[spinnerIdx%len(spinner)])

--- a/pkg/roachprod/install/cluster_synced_test.go
+++ b/pkg/roachprod/install/cluster_synced_test.go
@@ -97,58 +97,58 @@ func TestRunWithMaybeRetry(t *testing.T) {
 
 	attempt := 0
 	cases := []struct {
-		f                func(ctx context.Context) (*RunResultDetails, error)
-		shouldRetryFn    func(*RunResultDetails) bool
+		f                func(ctx context.Context) (*install.RunResultDetails, error)
+		shouldRetryFn    func(*install.RunResultDetails) bool
 		nilRetryOpts     bool
 		expectedAttempts int
 		shouldError      bool
 	}{
 		{ // 1. Happy path: no error, no retry required
-			f: func(ctx context.Context) (*RunResultDetails, error) {
+			f: func(ctx context.Context) (*install.RunResultDetails, error) {
 				return newResult(0), nil
 			},
 			expectedAttempts: 1,
 			shouldError:      false,
 		},
 		{ // 2. Error, but with no retries
-			f: func(ctx context.Context) (*RunResultDetails, error) {
+			f: func(ctx context.Context) (*install.RunResultDetails, error) {
 				return newResult(1), nil
 			},
-			shouldRetryFn: func(*RunResultDetails) bool {
+			shouldRetryFn: func(*install.RunResultDetails) bool {
 				return false
 			},
 			expectedAttempts: 1,
 			shouldError:      true,
 		},
 		{ // 3. Error, but no retry function specified
-			f: func(ctx context.Context) (*RunResultDetails, error) {
+			f: func(ctx context.Context) (*install.RunResultDetails, error) {
 				return newResult(1), nil
 			},
 			expectedAttempts: 3,
 			shouldError:      true,
 		},
 		{ // 4. Error, with retries exhausted
-			f: func(ctx context.Context) (*RunResultDetails, error) {
+			f: func(ctx context.Context) (*install.RunResultDetails, error) {
 				return newResult(255), nil
 			},
-			shouldRetryFn:    func(d *RunResultDetails) bool { return d.RemoteExitStatus == 255 },
+			shouldRetryFn:    func(d *install.RunResultDetails) bool { return d.RemoteExitStatus == 255 },
 			expectedAttempts: 3,
 			shouldError:      true,
 		},
 		{ // 5. Eventual success after retries
-			f: func(ctx context.Context) (*RunResultDetails, error) {
+			f: func(ctx context.Context) (*install.RunResultDetails, error) {
 				attempt++
 				if attempt == 3 {
 					return newResult(0), nil
 				}
 				return newResult(255), nil
 			},
-			shouldRetryFn:    func(d *RunResultDetails) bool { return d.RemoteExitStatus == 255 },
+			shouldRetryFn:    func(d *install.RunResultDetails) bool { return d.RemoteExitStatus == 255 },
 			expectedAttempts: 3,
 			shouldError:      false,
 		},
 		{ // 6. Error, runs once because nil retryOpts
-			f: func(ctx context.Context) (*RunResultDetails, error) {
+			f: func(ctx context.Context) (*install.RunResultDetails, error) {
 				return newResult(255), nil
 			},
 			nilRetryOpts:     true,
@@ -160,9 +160,9 @@ func TestRunWithMaybeRetry(t *testing.T) {
 	for idx, tc := range cases {
 		attempt = 0
 		t.Run(fmt.Sprintf("%d", idx+1), func(t *testing.T) {
-			var retryOpts *RunRetryOpts
+			var retryOpts *RetryOpts
 			if !tc.nilRetryOpts {
-				retryOpts = newRunRetryOpts(testRetryOpts, tc.shouldRetryFn)
+				retryOpts = NewRetryOpts(testRetryOpts, tc.shouldRetryFn)
 			}
 			res, _ := runWithMaybeRetry(context.Background(), l, retryOpts, tc.f)
 
@@ -176,12 +176,12 @@ func TestRunWithMaybeRetry(t *testing.T) {
 	}
 }
 
-func newResult(exitCode int) *RunResultDetails {
+func newResult(exitCode int) *install.RunResultDetails {
 	var err error
 	if exitCode != 0 {
 		err = errors.Newf("Error with exit code %v", exitCode)
 	}
-	return &RunResultDetails{RemoteExitStatus: exitCode, Err: err}
+	return &install.RunResultDetails{RemoteExitStatus: exitCode, Err: err}
 }
 
 func nilLogger() *logger.Logger {

--- a/pkg/roachprod/install/cockroach.go
+++ b/pkg/roachprod/install/cockroach.go
@@ -504,7 +504,7 @@ func (c *SyncedCluster) ExecSQL(
 			ssh.Escape(args)
 
 		return c.runCmdOnSingleNode(ctx, l, node, cmd, defaultCmdOpts("run-sql"))
-	}, WithDisplay(display), WithWaitOnFail())
+	}, WithDisplay(display), WithFailSlow(true))
 
 	if err != nil {
 		return err

--- a/pkg/roachprod/install/cockroach.go
+++ b/pkg/roachprod/install/cockroach.go
@@ -311,7 +311,7 @@ func (c *SyncedCluster) Start(ctx context.Context, l *logger.Logger, startOpts S
 
 	l.Printf("%s: starting nodes", c.Name)
 
-	// SSH retries are disabled by passing nil RunRetryOpts
+	// SSH retries are disabled by passing nil RetryOpts
 	if err := c.Parallel(ctx, l, nodes, func(ctx context.Context, node Node) (*RunResultDetails, error) {
 		// NB: if cockroach started successfully, we ignore the output as it is
 		// some harmless start messaging.

--- a/pkg/roachprod/install/run_options.go
+++ b/pkg/roachprod/install/run_options.go
@@ -1,0 +1,63 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package install
+
+import "github.com/cockroachdb/cockroach/pkg/util/retry"
+
+type RunOptions struct {
+	*RetryOpts
+	// WaitOnFail will cause the Parallel function to wait for all nodes to
+	// finish when encountering a command error on any node. The default
+	// behaviour is to exit immediately on the first error, in which case the
+	// slice of ParallelResults will only contain the one error result.
+	WaitOnFail bool
+	// These are private to roachprod
+	Concurrency int
+	Display     string
+}
+
+type RunOption func(runOpts *RunOptions)
+
+func WithRetryOpts(retryOpts *RetryOpts) RunOption {
+	return func(runOpts *RunOptions) {
+		runOpts.RetryOpts = retryOpts
+	}
+}
+
+func WithWaitOnFail() RunOption {
+	return func(runOpts *RunOptions) {
+		runOpts.WaitOnFail = true
+	}
+}
+
+func WithConcurrency(concurrency int) RunOption {
+	return func(runOpts *RunOptions) {
+		runOpts.Concurrency = concurrency
+	}
+}
+
+func WithDisplay(display string) RunOption {
+	return func(runOpts *RunOptions) {
+		runOpts.Display = display
+	}
+}
+
+type RetryOpts struct {
+	retry.Options
+	ShouldRetryFn func(*RunResultDetails) bool
+}
+
+func NewRetryOpts(retryOpts retry.Options, shouldRetryFn func(*RunResultDetails) bool) *RetryOpts {
+	return &RetryOpts{
+		Options:       retryOpts,
+		ShouldRetryFn: shouldRetryFn,
+	}
+}

--- a/pkg/roachprod/install/run_options.go
+++ b/pkg/roachprod/install/run_options.go
@@ -13,12 +13,20 @@ package install
 import "github.com/cockroachdb/cockroach/pkg/util/retry"
 
 type RunOptions struct {
-	*RetryOpts
-	// WaitOnFail will cause the Parallel function to wait for all nodes to
+	// RetryOptions are the retry options
+	RetryOptions *retry.Options
+	// ShouldRetryFn is only applciable when RetryOptions is not nil
+	// and specifies a function to be called in the case that a retry
+	// is about to be performed. A user can provide a function which, for
+	// example, inspects the previous result's output, and decides not to
+	// retry any further, by returning false.
+	ShouldRetryFn func(*RunResultDetails) bool
+	// FailSlow will cause the Parallel function to wait for all nodes to
 	// finish when encountering a command error on any node. The default
 	// behaviour is to exit immediately on the first error, in which case the
 	// slice of ParallelResults will only contain the one error result.
-	WaitOnFail bool
+	// Named as such to make clear that this is not eneabled by default.
+	FailSlow bool
 	// These are private to roachprod
 	Concurrency int
 	Display     string
@@ -26,15 +34,31 @@ type RunOptions struct {
 
 type RunOption func(runOpts *RunOptions)
 
-func WithRetryOpts(retryOpts *RetryOpts) RunOption {
+// WithRetryOpts specifies retry behaviour
+func WithRetryOpts(retryOpts retry.Options) RunOption {
 	return func(runOpts *RunOptions) {
-		runOpts.RetryOpts = retryOpts
+		runOpts.RetryOptions = &retryOpts
 	}
 }
 
-func WithWaitOnFail() RunOption {
+// WithRetryDisabled disables retries for a command,
+// and is a friendly equivalent to `WithRetryOpts(nil)`
+func WithRetryDisabled() RunOption {
 	return func(runOpts *RunOptions) {
-		runOpts.WaitOnFail = true
+		runOpts.RetryOptions = nil
+	}
+}
+
+// WithRetryFn is only applicable when retryOpts is not nil
+func WithRetryFn(fn func(*RunResultDetails) bool) RunOption {
+	return func(runOpts *RunOptions) {
+		runOpts.ShouldRetryFn = fn
+	}
+}
+
+func WithFailSlow(failSlow bool) RunOption {
+	return func(runOpts *RunOptions) {
+		runOpts.FailSlow = failSlow
 	}
 }
 
@@ -47,17 +71,5 @@ func WithConcurrency(concurrency int) RunOption {
 func WithDisplay(display string) RunOption {
 	return func(runOpts *RunOptions) {
 		runOpts.Display = display
-	}
-}
-
-type RetryOpts struct {
-	retry.Options
-	ShouldRetryFn func(*RunResultDetails) bool
-}
-
-func NewRetryOpts(retryOpts retry.Options, shouldRetryFn func(*RunResultDetails) bool) *RetryOpts {
-	return &RetryOpts{
-		Options:       retryOpts,
-		ShouldRetryFn: shouldRetryFn,
 	}
 }

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -403,7 +403,7 @@ func RunWithDetails(
 	}
 
 	cmd := strings.TrimSpace(strings.Join(cmdArray, " "))
-	return c.RunWithDetails(ctx, l, c.Nodes, TruncateString(cmd, 30), cmd)
+	return c.RunWithDetails(ctx, l, c.Nodes, TruncateString(cmd, 30), cmd, opts...)
 }
 
 // SQL runs `cockroach sql` on a remote cluster. If a single node is passed,

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -359,7 +359,7 @@ func Run(
 	secure bool,
 	stdout, stderr io.Writer,
 	cmdArray []string,
-	opts ...install.ParallelOption,
+	opts ...install.RunOption,
 ) error {
 	if err := LoadClusters(); err != nil {
 		return err
@@ -386,6 +386,7 @@ func RunWithDetails(
 	clusterName, SSHOptions, processTag string,
 	secure bool,
 	cmdArray []string,
+	opts ...install.RunOption,
 ) ([]install.RunResultDetails, error) {
 	if err := LoadClusters(); err != nil {
 		return nil, err


### PR DESCRIPTION
SSH retries are implemented when executing commands via roachprod, transparent to the user. i.e. As a result, today, commands executed via `c.Run` retry automatically if the error has an exit code of `255` (ssh issue). 

The 3 commits introduce changes as follows:

1. The existing API functions, left untouched to reduce the surface area of changes, are now delegated to new functions of the same name with a `Ext` suffix (`RunExt`, `RunEExt`, `RunWithDetailsExt`, `RunWithDetailsSingleNodeExt`), which instead of `...string`, now accept `[]string` args. This sets up the possibility of further parameters.
2. Implement functional options
   * `install.RunOptions` implemented
   * The new `*Ext` functions now accept another parameter `...install.RunOption` which allows callers to specify retry options; e.g., `c.RunEExt(ctx, nodes, []string{"mkdir -p test"}, WithRetryOpts(myOpts))`
3. Refactor existing 
   * Remove `install.RetryOpts` which contains `retry.Options` and `func(*RunResultDetails) bool` into separately specifiable options. This exposes the more familiar `retry.Options` directly to callers.
   * Expose `WithRetryOpts(...)` and `WithRetryFn(...)`
   * Set retry defaults in `c.Parallel` which are overridable by callers.


The goal is to introduce the new API without changing any of the tests (via preserving the existing API). A future change will remove the old functions, and rename the new ones.

Follow up PRs to
- Remove custom retry logic in favour of roachprod retries
- Disable retries on certain long running tests such as `weekly/tpcc/headroom`
- Update the default roachprod ssh retry, which is enabled automatically
- Rename new API functions to the old names, and update all references to use a `[]string` over `...string`


Epic: none
Release note: none
Fixes: #105753 