### PR TITLE
server: fix a buglet about cluster settings

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -244,6 +244,12 @@ func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterf
 	// across servers (e.g. misuse of TestServer API).
 	st.SV.SpecializeForSystemInterface()
 
+	// Load the global (build-time) setting defaults into the in-RAM
+	// cache, for use by the init code below until the call to
+	// initializeCachedSettings() during PreStart().
+	settingUpdater := st.MakeUpdater()
+	settingUpdater.ResetRemaining(ctx)
+
 	if cfg.AmbientCtx.Tracer == nil {
 		panic(errors.New("no tracer set in AmbientCtx"))
 	}

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -1028,6 +1028,12 @@ func makeTenantSQLServerArgs(
 	// the instance ID (once known) as a tag.
 	startupCtx = baseCfg.AmbientCtx.AnnotateCtx(startupCtx)
 
+	// Load the global (build-time) setting defaults into the in-RAM
+	// cache, for use by the init code below until the settings watcher
+	// is started during PreStart().
+	settingUpdater := st.MakeUpdater()
+	settingUpdater.ResetRemaining(startupCtx)
+
 	clock, err := newClockFromConfig(startupCtx, baseCfg)
 	if err != nil {
 		return sqlServerArgs{}, err


### PR DESCRIPTION
Prior to this patch, the default cluster setting values were not
available to `.Get()` calls on setting objects until the cluster
initialization completed (i.e. `cockroach init`). They were also not
available to the code run very early during server startup, for
example the initial HTTP server spawned to serve health probes.
Only after a certain point (the call to `initializeCachedSettings()`)
would the defaults be loaded to the in-RAM cache and become available
to `.Get()` calls.

Any setting `.Get()` call before that point would use the Go zero
value, instead of the build-time configured default value. In some
cases, the Go zero value is even invalid.

This commit fixes that.

As of this writing, I believe there is no actual bug incurred by this,
as there are very few `.Get()` calls in the code run before cluster
initialization and these few `.Get()` calls can deal with the Go zero
value reasonably well.


Release note: None

Needed for #110758
Epic: CRDB-6671