### PR TITLE
util: add generic slice utilities Filter, Map, MapBy

### DIFF
--- a/pkg/util/BUILD.bazel
+++ b/pkg/util/BUILD.bazel
@@ -38,6 +38,7 @@ go_library(
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_redact//:redact",
         "@org_golang_x_exp//constraints",
+        "@org_golang_x_exp//slices",
     ],
 )
 

--- a/pkg/util/slices.go
+++ b/pkg/util/slices.go
@@ -10,7 +10,10 @@
 
 package util
 
-import "golang.org/x/exp/constraints"
+import (
+	"golang.org/x/exp/constraints"
+	"golang.org/x/exp/slices"
+)
 
 // CombineUnique merges two ordered slices. If both slices have unique elements
 // then so does the resulting slice. More generally, each element is present
@@ -47,4 +50,58 @@ func CombineUnique[T constraints.Ordered](a, b []T) []T {
 		a = append(a, b[bIter:]...)
 	}
 	return a
+}
+
+// Filter returns a new slice that only contains elements from collection that
+// satisfy predicate.
+//
+//	// Filter in place
+//	numbers = Filter(numbers, isEven)
+//	// Filter into a new slice
+//	odds := Filter(numbers, isEven)
+func Filter[T any](collection []T, predicate func(T) bool) []T {
+	i := 0
+	out := make([]T, len(collection))
+	for j := range collection {
+		if predicate(collection[j]) {
+			out[i] = collection[j]
+			i++
+		}
+	}
+	return slices.Clip(out[:i])
+}
+
+// Map returns a new slice containing the results of fn for each element within
+// collection. Usage:
+//
+//	Map([]int{1, 2, 3}, func(i int) int {
+//		return i
+//	})
+func Map[T, K any](collection []T, fn func(T) K) []K {
+	out := make([]K, len(collection))
+	for i, el := range collection {
+		out[i] = fn(el)
+	}
+	return out
+}
+
+// MapFrom returns a map populated with keys and values returned by fn.
+// Usage:
+//
+//	// Construct a set.
+//	MapFrom(numbers, func(i int) (int, struct{}) {
+//		return i, struct{}{}
+//	})
+//
+//	// Construct a map of numbers to their square.
+//	MapFrom(numbers, func(i int) (int, int) {
+//		return i, i * i
+//	})
+func MapFrom[T any, K comparable, V any](collection []T, fn func(T) (K, V)) map[K]V {
+	out := make(map[K]V, len(collection))
+	for _, el := range collection {
+		key, value := fn(el)
+		out[key] = value
+	}
+	return out
 }

--- a/pkg/util/slices_test.go
+++ b/pkg/util/slices_test.go
@@ -79,3 +79,71 @@ func TestCombinesUniqueStrings(t *testing.T) {
 		require.Equal(t, tc.expected, output)
 	}
 }
+
+func TestFilter(t *testing.T) {
+	numbers := []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
+	evens := Filter(numbers, func(i int) bool {
+		return i%2 == 0
+	})
+	odds := Filter(numbers, func(i int) bool {
+		return i%2 == 1
+	})
+
+	// Assert filtering works.
+	require.Equal(t, []int{1, 3, 5, 7, 9}, odds)
+	require.Equal(t, []int{0, 2, 4, 6, 8}, evens)
+
+	// Assert/demonstrate that filtering does not mutate the original slice.
+	require.Equal(t, []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, numbers)
+
+	// The filtered slices' capacity is correctly set and the original slice's
+	// capacity is unmodified.
+	require.Equal(t, len(odds), cap(odds))
+	require.Equal(t, len(evens), cap(evens))
+	require.Equal(t, len(numbers), cap(numbers))
+
+	// And some weird cases.
+	require.Equal(t, []int{}, Filter(nil, func(i int) bool {
+		return true
+	}))
+	require.Equal(t, []int{}, Filter([]int{}, func(i int) bool {
+		return true
+	}))
+	require.Equal(t, []int{}, Filter(numbers, func(i int) bool {
+		return false
+	}))
+}
+
+func TestMap(t *testing.T) {
+	require.Equal(t, []bool{}, Map(nil, func(i int) bool {
+		require.Fail(t, "should not be called")
+		return true
+	}))
+	require.Equal(t, []bool{}, Map([]int{}, func(i int) bool {
+		require.Fail(t, "should not be called")
+		return true
+	}))
+	require.Equal(t, []bool{false, true, false, true, false}, Map([]int{1, 2, 3, 4, 5}, func(i int) bool {
+		return i%2 == 0
+	}))
+}
+
+func TestMapFrom(t *testing.T) {
+	require.Equal(t, map[int]bool{}, MapFrom(nil, func(i int) (int, bool) {
+		require.Fail(t, "should not be called")
+		return 0, false
+	}))
+	require.Equal(t, map[int]bool{}, MapFrom([]int{}, func(i int) (int, bool) {
+		require.Fail(t, "should not be called")
+		return 0, false
+	}))
+	require.Equal(t, map[int]int{
+		1: 1,
+		2: 4,
+		3: 9,
+		4: 16,
+		5: 25,
+	}, MapFrom([]int{1, 1, 2, 3, 4, 5, 5}, func(i int) (int, int) {
+		return i, i * i
+	}))
+}


### PR DESCRIPTION
**util: add generic slice utilities Filter, Map, MapBy**
Devs will often find themselves repeating the same code within go due to the
lack of functional helpers like filter, map, and reduce. This can lead
to mistakes in the form of typos or overly terse naming, especially when
these operations need to be performed multiple times in a row.

This commit adds a minimal set of productivity helpers that are notably
missing from go's `exp/slices` packages.

In performance critical code, it may be undesirable to utilize generic
functions. It is also possible to overuse functional patterns and write
less understandable code. Devs will be ultimately responsible for
deciding when to wield these functional helpers.

Epic: none
Release note: None
