### PR TITLE
sql/copy: fix planning for vectorized COPY with nested renderNodes

### DIFF
--- a/pkg/sql/copy/testdata/copy_from
+++ b/pkg/sql/copy/testdata/copy_from
@@ -724,3 +724,13 @@ n1
 12.123
 ----
 1
+
+exec-ddl
+CREATE TABLE thash (i INT, j INT, k INT, CONSTRAINT "primary" PRIMARY KEY(i) USING HASH WITH BUCKET_COUNT=8)
+----
+
+copy-from
+COPY thash FROM STDIN WITH CSV
+1,2,3
+----
+1

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -3494,14 +3494,12 @@ func (dsp *DistSQLPlanner) createPhysPlanForPlanNode(
 
 	case *rowCountNode:
 		if in, ok := n.source.(*insertNode); ok {
-			var valNode planNode
-			// We support two cases, a render around a values and a straight values.
-			if r, ok := in.source.(*renderNode); ok {
-				valNode = r.source.plan
-			} else {
-				valNode = in.source
+			// Skip over any renderNodes.
+			nod := in.source
+			for r, ok := nod.(*renderNode); ok; r, ok = r.source.plan.(*renderNode) {
+				nod = r.source.plan
 			}
-			if v, ok := valNode.(*valuesNode); ok {
+			if v, ok := nod.(*valuesNode); ok {
 				if v.coldataBatch != nil {
 					planCtx.isVectorInsert = true
 				}

--- a/pkg/sql/values.go
+++ b/pkg/sql/values.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/rowcontainer"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/errors"
 )
 
 type valuesNode struct {
@@ -61,6 +62,10 @@ type valuesRun struct {
 }
 
 func (n *valuesNode) startExec(params runParams) error {
+	if n.coldataBatch != nil {
+		return errors.AssertionFailedf("planning error: valuesNode started with coldata.Batch")
+	}
+
 	if n.rows != nil {
 		// n.rows was already created in newContainerValuesNode.
 		// Nothing to do here.


### PR DESCRIPTION
A COPY insert statement can produce a plan with zero or more renderNodes
and we were only allowing zero or one. An example of multiple render
nodes is a table with a hash shared primary key.

Fixes: #104662
Release note (sql change): Vectorized COPY FROM support didn't properly
handle schemas hash sharded primary keys.
Epic: none
