### PR TITLE
release-23.1: rpc: permit gRPC stream window sizes up to 64 MB

### DIFF
--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -77,15 +77,16 @@ const (
 )
 
 const (
-	defaultWindowSize = 65535
+	defaultWindowSize        = 65535                         // from gRPC
+	defaultInitialWindowSize = defaultWindowSize * 32        // 2MB
+	maximumWindowSize        = defaultInitialWindowSize * 32 // 64MB
 )
 
 func getWindowSize(name string, c ConnectionClass, defaultSize int) int32 {
-	const maxWindowSize = defaultWindowSize * 32
 	s := envutil.EnvOrDefaultInt(name, defaultSize)
-	if s > maxWindowSize {
-		log.Warningf(context.Background(), "%s value too large; trimmed to %d", name, maxWindowSize)
-		s = maxWindowSize
+	if s > maximumWindowSize {
+		log.Warningf(context.Background(), "%s value too large; trimmed to %d", name, maximumWindowSize)
+		s = maximumWindowSize
 	}
 	if s <= defaultWindowSize {
 		log.Warningf(context.Background(),
@@ -97,8 +98,15 @@ func getWindowSize(name string, c ConnectionClass, defaultSize int) int32 {
 var (
 	// for an RPC
 	initialWindowSize = getWindowSize(
-		"COCKROACH_RPC_INITIAL_WINDOW_SIZE", DefaultClass, defaultWindowSize*32)
-	initialConnWindowSize = initialWindowSize * 16 // for a connection
+		"COCKROACH_RPC_INITIAL_WINDOW_SIZE", DefaultClass, defaultInitialWindowSize)
+	// for a connection
+	initialConnWindowSize = func() int32 {
+		s := initialWindowSize * 16
+		if s > maximumWindowSize {
+			s = maximumWindowSize
+		}
+		return s
+	}()
 
 	// for RangeFeed RPC
 	rangefeedInitialWindowSize = getWindowSize(


### PR DESCRIPTION
Backport 1/1 commits from #111255.

/cc @cockroachdb/release

---

Informs #111238.
Informs #111241.

CockroachDB accepts a COCKROACH_RPC_INITIAL_WINDOW_SIZE environment variable that can be used to set the initial window size for gRPC streams. However, the setting could previously only be used to reduce the initial window size, not to increase it.

This commit fixes that, allowing the initial window size to be increased up to 64 MB. This is useful for multi-region clusters that want to push high volumes of writes over high-latency WAN links.

Release note (general change): Increased the maximum permitted value of the COCKROACH_RPC_INITIAL_WINDOW_SIZE environment variable to 64MB. When used in conjunction with a tuned OS-level maximum TCP window size, this can increase the throughput that Raft replication can sustain over high-latency network links.

Release justification: makes an env var more flexible. No change to defaults.