### PR TITLE
config: add a flag to allow disabling SQL services

### DIFF
--- a/pkg/base/test_server_args.go
+++ b/pkg/base/test_server_args.go
@@ -129,6 +129,9 @@ type TestServerArgs struct {
 	// If set, the recording of events to the event log tables is disabled.
 	DisableEventLog bool
 
+	// If set, don't start the SQL service for this test.
+	DisableSQLServer bool
+
 	// If set, web session authentication will be disabled, even if the server
 	// is running in secure mode.
 	InsecureWebAccess bool

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -247,6 +247,12 @@ type BaseConfig struct {
 	// route requests instead.
 	DisableHTTPListener bool
 
+	// DisableSQLServer disables starting the SQL service for the given test. This
+	// also disables all upgrades as they rely on SQL and typically reduces test
+	// start time significantly. This flag can only be used in tests that don't
+	// issue any SQL commands.
+	DisableSQLServer bool
+
 	// DisableSQLListener prevents this server from starting a TCP
 	// listener for the SQL service. Instead, it is expected that some
 	// other service (typically, the serverController) will accept and

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -2049,14 +2049,16 @@ func (s *topLevelServer) PreStart(ctx context.Context) error {
 	// executes a SQL query, this must be done after the SQL layer is ready.
 	s.node.recordJoinEvent(ctx)
 
-	// Start the SQL subsystem.
-	if err := s.sqlServer.preStart(
-		workersCtx,
-		s.stopper,
-		s.cfg.TestingKnobs,
-		orphanedLeasesTimeThresholdNanos,
-	); err != nil {
-		return err
+	if !s.cfg.DisableSQLServer {
+		// Start the SQL subsystem.
+		if err := s.sqlServer.preStart(
+			workersCtx,
+			s.stopper,
+			s.cfg.TestingKnobs,
+			orphanedLeasesTimeThresholdNanos,
+		); err != nil {
+			return err
+		}
 	}
 
 	// Initialize the external storage builders configuration params now that the
@@ -2202,6 +2204,10 @@ func (s *topLevelServer) PreStart(ctx context.Context) error {
 // This mirrors the implementation of (*SQLServerWrapper).AcceptClients.
 // TODO(knz): Find a way to implement this method only once for both.
 func (s *topLevelServer) AcceptClients(ctx context.Context) error {
+	// Don't listen on the SQL port if the SQL Server is not starting.
+	if s.cfg.DisableSQLServer {
+		return nil
+	}
 	workersCtx := s.AnnotateCtx(context.Background())
 
 	if err := startServeSQL(
@@ -2234,6 +2240,10 @@ func (s *topLevelServer) AcceptClients(ctx context.Context) error {
 // AcceptInternalClients starts listening for incoming SQL connections on the
 // internal loopback interface.
 func (s *topLevelServer) AcceptInternalClients(ctx context.Context) error {
+	// Don't listen on the SQL port if the SQL Server is not starting.
+	if s.cfg.DisableSQLServer {
+		return nil
+	}
 	connManager := netutil.MakeTCPServer(ctx, s.stopper)
 
 	return s.stopper.RunAsyncTaskEx(ctx,

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -169,6 +169,7 @@ func TestServerStartClock(t *testing.T) {
 				MaxOffset: time.Second,
 			},
 		},
+		DisableSQLServer: true,
 	}
 	s := serverutils.StartServerOnly(t, params)
 	defer s.Stopper().Stop(context.Background())

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -67,6 +67,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sessionprotectedts"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlinstance"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/ts"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/admission"
@@ -905,6 +906,10 @@ func (s *SQLServerWrapper) serveConn(
 // This mirrors the implementation of (*Server).AcceptClients.
 // TODO(knz): Find a way to implement this method only once for both.
 func (s *SQLServerWrapper) AcceptClients(ctx context.Context) error {
+	if s.sqlServer.cfg.DisableSQLServer {
+		return serverutils.PreventDisableSQLForTenantError()
+	}
+
 	if !s.sqlServer.cfg.DisableSQLListener {
 		if err := startServeSQL(
 			s.AnnotateCtx(context.Background()),
@@ -937,6 +942,10 @@ func (s *SQLServerWrapper) AcceptClients(ctx context.Context) error {
 // AcceptInternalClients starts listening for incoming SQL connections on the
 // internal loopback interface.
 func (s *SQLServerWrapper) AcceptInternalClients(ctx context.Context) error {
+	if s.sqlServer.cfg.DisableSQLServer {
+		return serverutils.PreventDisableSQLForTenantError()
+	}
+
 	connManager := netutil.MakeTCPServer(ctx, s.stopper)
 
 	return s.stopper.RunAsyncTaskEx(ctx,

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -176,6 +176,7 @@ func makeTestConfigFromParams(params base.TestServerArgs) Config {
 	cfg.RetryOptions = params.RetryOptions
 	cfg.Locality = params.Locality
 	cfg.StartDiagnosticsReporting = params.StartDiagnosticsReporting
+	cfg.DisableSQLServer = params.DisableSQLServer
 	if params.TraceDir != "" {
 		if err := initTraceDir(params.TraceDir); err == nil {
 			cfg.InflightTraceDirName = params.TraceDir
@@ -583,6 +584,10 @@ func (ts *testServer) maybeStartDefaultTestTenant(ctx context.Context) error {
 	// it here.
 	if ts.params.DefaultTestTenant.TestTenantAlwaysDisabled() {
 		return nil
+	}
+
+	if ts.params.DisableSQLServer {
+		return serverutils.PreventDisableSQLForTenantError()
 	}
 
 	tenantSettings := cluster.MakeTestingClusterSettings()

--- a/pkg/sql/logictest/testdata/logic_test/event_log
+++ b/pkg/sql/logictest/testdata/logic_test/event_log
@@ -478,7 +478,6 @@ AND info NOT LIKE '%sql.stats%'
 ORDER BY "timestamp", info
 ----
 1  {"ApplicationName": "$ internal-optInToDiagnosticsStatReporting", "EventType": "set_cluster_setting", "SettingName": "diagnostics.reporting.enabled", "Statement": "SET CLUSTER SETTING \"diagnostics.reporting.enabled\" = true", "Tag": "SET CLUSTER SETTING", "User": "root", "Value": "true"}
-1  {"ApplicationName": "$ internal-enable-merge-queue", "EventType": "set_cluster_setting", "SettingName": "kv.range_merge.queue.enabled", "Statement": "SET CLUSTER SETTING \"kv.range_merge.queue.enabled\" = false", "Tag": "SET CLUSTER SETTING", "User": "root", "Value": "false"}
 1  {"EventType": "set_cluster_setting", "SettingName": "sql.crdb_internal.table_row_statistics.as_of_time", "Statement": "SET CLUSTER SETTING \"sql.crdb_internal.table_row_statistics.as_of_time\" = e'-1\\u00B5s'", "Tag": "SET CLUSTER SETTING", "User": "root", "Value": "-00:00:00.000001"}
 1  {"EventType": "set_cluster_setting", "SettingName": "kv.allocator.load_based_lease_rebalancing.enabled", "Statement": "SET CLUSTER SETTING \"kv.allocator.load_based_lease_rebalancing.enabled\" = false", "Tag": "SET CLUSTER SETTING", "User": "root", "Value": "false"}
 1  {"EventType": "set_cluster_setting", "SettingName": "kv.allocator.load_based_lease_rebalancing.enabled", "Statement": "SET CLUSTER SETTING \"kv.allocator.load_based_lease_rebalancing.enabled\" = DEFAULT", "Tag": "SET CLUSTER SETTING", "User": "root", "Value": "DEFAULT"}

--- a/pkg/testutils/serverutils/test_tenant_shim.go
+++ b/pkg/testutils/serverutils/test_tenant_shim.go
@@ -13,7 +13,11 @@
 
 package serverutils
 
-import "net/url"
+import (
+	"net/url"
+
+	"github.com/cockroachdb/errors"
+)
 
 type SessionType int
 
@@ -22,6 +26,14 @@ const (
 	SingleTenantSession
 	MultiTenantSession
 )
+
+// PreventDisableSQLForTenantError is thrown by tests that attempt to set
+// DisableSQLServer but run with cluster virtualization. These modes are
+// incompatible since tenant operations require SQL during initialization.
+func PreventDisableSQLForTenantError() error {
+	return errors.New("programming error: DisableSQLServer is incompatible with cluster virtualization\n" +
+		"Consider using TestServerArgs{DefaultTestTenant: base.TestIsSpecificToStorageLayerAndNeedsASystemTenant}")
+}
 
 type TestURL struct {
 	*url.URL

--- a/pkg/testutils/testcluster/BUILD.bazel
+++ b/pkg/testutils/testcluster/BUILD.bazel
@@ -66,6 +66,7 @@ go_test(
         "//pkg/testutils",
         "//pkg/testutils/listenerutil",
         "//pkg/testutils/serverutils",
+        "//pkg/testutils/skip",
         "//pkg/testutils/sqlutils",
         "//pkg/util/httputil",
         "//pkg/util/leaktest",

--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -431,22 +431,6 @@ func (tc *TestCluster) Start(t serverutils.TestFataler) {
 		tc.WaitForNStores(t, tc.NumServers(), tc.Servers[0].StorageLayer().GossipI().(*gossip.Gossip))
 	}
 
-	if tc.clusterArgs.ReplicationMode == base.ReplicationManual {
-		// We've already disabled the merge queue via testing knobs above, but ALTER
-		// TABLE ... SPLIT AT will throw an error unless we also disable merges via
-		// the cluster setting.
-		//
-		// TODO(benesch): this won't be necessary once we have sticky bits for
-		// splits.
-		if _, err := tc.Servers[0].SystemLayer().
-			InternalExecutor().(isql.Executor).
-			Exec(ctx, "enable-merge-queue", nil, /* txn */
-				`SET CLUSTER SETTING kv.range_merge.queue.enabled = false`); err != nil {
-			tc.Stopper().Stop(ctx)
-			t.Fatal(err)
-		}
-	}
-
 	if disableLBS {
 		if _, err := tc.Servers[0].SystemLayer().
 			InternalExecutor().(isql.Executor).


### PR DESCRIPTION
This change reduces the long startup time waiting for SQL services to start for tests that are KV layer and below.

Epic: CRDB-28893

Release note: None