### PR TITLE
persistedsqlstats: fix setting of `lastFlushStarted`

### DIFF
--- a/pkg/sql/sqlstats/persistedsqlstats/flush.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/flush.go
@@ -68,9 +68,9 @@ func (s *PersistedSQLStats) Flush(ctx context.Context) {
 		return
 	}
 
-	s.lastFlushStarted = now
 	log.Infof(ctx, "flushing %d stmt/txn fingerprints (%d bytes) after %s",
 		s.SQLStats.GetTotalFingerprintCount(), s.SQLStats.GetTotalFingerprintBytes(), timeutil.Since(s.lastFlushStarted))
+	s.lastFlushStarted = now
 
 	aggregatedTs := s.ComputeAggregatedTs()
 


### PR DESCRIPTION
Previously, this field would be set prior to logging that the flushing of sql stats was beginning. This would lead to incorrect intervals being logged, such as:

```
flushing 100 stmt/txn fingerprints (200 bytes) after 735ns
```

Which makes it look like it's been 735ns since the last flushing.

Epic: none

Release note: None