### PR TITLE
workload/schemachange: implement `ALTER DATABASE ... ADD/DROP SUPER REGION`

### DIFF
--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -40,6 +40,7 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
+	"golang.org/x/exp/slices"
 )
 
 // seqNum may be shared across multiple instances of this, so it should only
@@ -479,112 +480,83 @@ func (og *operationGenerator) alterTableLocality(ctx context.Context, tx pgx.Tx)
 	return stmt, nil
 }
 
-func (og *operationGenerator) getClusterRegionNames(
-	ctx context.Context, tx pgx.Tx,
-) (catpb.RegionNames, error) {
-	return og.scanRegionNames(ctx, tx, "SELECT region FROM [SHOW REGIONS FROM CLUSTER]")
-}
-
 func (og *operationGenerator) getDatabaseRegionNames(
 	ctx context.Context, tx pgx.Tx,
 ) (catpb.RegionNames, error) {
-	return og.scanRegionNames(ctx, tx, "SELECT region FROM [SHOW REGIONS FROM DATABASE]")
+	return Collect(ctx, og, tx, pgx.RowTo[catpb.RegionName], "SELECT region FROM [SHOW REGIONS FROM DATABASE]")
 }
 
 func (og *operationGenerator) getDatabase(ctx context.Context, tx pgx.Tx) (string, error) {
 	return Scan[string](ctx, og, tx, `SHOW DATABASE`)
 }
 
-type getRegionsResult struct {
-	regionNamesInDatabase catpb.RegionNames
-	regionNamesInCluster  catpb.RegionNames
-
-	regionNamesNotInDatabase catpb.RegionNames
+type regionInfo struct {
+	Name        tree.Name
+	InUse       bool
+	IsPrimary   bool
+	IsSecondary bool
+	SuperRegion *tree.Name
 }
 
-func (og *operationGenerator) getRegions(ctx context.Context, tx pgx.Tx) (getRegionsResult, error) {
-	regionNamesInCluster, err := og.getClusterRegionNames(ctx, tx)
-	if err != nil {
-		return getRegionsResult{}, err
-	}
-	regionNamesNotInDatabaseSet := make(map[catpb.RegionName]struct{}, len(regionNamesInCluster))
-	for _, clusterRegionName := range regionNamesInCluster {
-		regionNamesNotInDatabaseSet[clusterRegionName] = struct{}{}
-	}
-	regionNamesInDatabase, err := og.getDatabaseRegionNames(ctx, tx)
-	if err != nil {
-		return getRegionsResult{}, err
-	}
-	for _, databaseRegionName := range regionNamesInDatabase {
-		delete(regionNamesNotInDatabaseSet, databaseRegionName)
-	}
-
-	regionNamesNotInDatabase := make(catpb.RegionNames, 0, len(regionNamesNotInDatabaseSet))
-	for regionName := range regionNamesNotInDatabaseSet {
-		regionNamesNotInDatabase = append(regionNamesNotInDatabase, regionName)
-	}
-	return getRegionsResult{
-		regionNamesInDatabase:    regionNamesInDatabase,
-		regionNamesInCluster:     regionNamesInCluster,
-		regionNamesNotInDatabase: regionNamesNotInDatabase,
-	}, nil
-}
-
-func (og *operationGenerator) scanRegionNames(
-	ctx context.Context, tx pgx.Tx, query string,
-) (catpb.RegionNames, error) {
-	var regionNames catpb.RegionNames
-	var regionNamesForLog []string
-	rows, err := tx.Query(ctx, query)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-
-	for rows.Next() {
-		var regionName catpb.RegionName
-		if err := rows.Scan(&regionName); err != nil {
-			return nil, err
-		}
-		regionNames = append(regionNames, regionName)
-		regionNamesForLog = append(regionNamesForLog, regionName.String())
-	}
-	if rows.Err() != nil {
-		return nil, errors.Wrapf(rows.Err(), "failed to get regions: %s", query)
-	}
-	og.LogQueryResults(query, regionNamesForLog)
-	return regionNames, nil
+func (og *operationGenerator) getRegionInfo(
+	ctx context.Context, tx pgx.Tx, database string,
+) ([]regionInfo, error) {
+	return Collect(ctx, og, tx, pgx.RowToStructByPos[regionInfo], With([]CTE{
+		{"cluster_regions", regionsFromClusterQuery},
+		{"database_regions", regionsFromDatabaseQuery(database)},
+		{"super_regions", superRegionsFromDatabaseQuery(database)},
+	}, `
+		SELECT
+			cr.region,
+			dr IS NOT NULL,
+			COALESCE(dr.primary, false),
+			COALESCE(dr.secondary, false),
+			sr.super_region_name
+		FROM cluster_regions cr
+		LEFT JOIN database_regions dr ON cr.region = dr.region
+		LEFT JOIN (SELECT super_region_name, unnest(regions) as region FROM super_regions) sr ON sr.region = dr.region
+	`))
 }
 
 func (og *operationGenerator) addRegion(ctx context.Context, tx pgx.Tx) (*opStmt, error) {
-	regionResult, err := og.getRegions(ctx, tx)
-	if err != nil {
-		return nil, err
-	}
 	database, err := og.getDatabase(ctx, tx)
 	if err != nil {
 		return nil, err
 	}
+
+	regions, err := og.getRegionInfo(ctx, tx, database)
+	if err != nil {
+		return nil, err
+	}
+
+	clusterHasRegions := len(regions) > 0
+	regionsInDatabase := util.Filter(regions, func(r regionInfo) bool {
+		return r.InUse
+	})
+	regionsNotInDatabase := util.Filter(regions, func(r regionInfo) bool {
+		return !r.InUse
+	})
+
 	// No regions in cluster, try add an invalid region and expect an error.
-	if len(regionResult.regionNamesInCluster) == 0 {
+	if !clusterHasRegions {
 		return makeOpStmtForSingleError(OpStmtDDL,
 			fmt.Sprintf(`ALTER DATABASE %s ADD REGION "invalid-region"`, database),
-			pgcode.InvalidDatabaseDefinition), nil
+			pgcode.InvalidName, pgcode.InvalidDatabaseDefinition), nil
 	}
 	// No regions in database, add a random region from the cluster and expect an error.
-	if len(regionResult.regionNamesInDatabase) == 0 {
-		idx := og.params.rng.Intn(len(regionResult.regionNamesInCluster))
+	if len(regionsInDatabase) == 0 {
+		idx := og.params.rng.Intn(len(regionsNotInDatabase))
 		return makeOpStmtForSingleError(OpStmtDDL,
 			fmt.Sprintf(
 				`ALTER DATABASE %s ADD REGION "%s"`,
 				database,
-				regionResult.regionNamesInCluster[idx],
+				regionsNotInDatabase[idx].Name,
 			),
 			pgcode.InvalidDatabaseDefinition), nil
 	}
 	// If the database is undergoing a regional by row related change on the
 	// database, error out.
-	if len(regionResult.regionNamesInDatabase) > 0 {
+	if len(regionsInDatabase) > 0 {
 		databaseHasRegionalByRowChange, err := og.databaseHasRegionalByRowChange(ctx, tx)
 		if err != nil {
 			return nil, err
@@ -602,22 +574,22 @@ func (og *operationGenerator) addRegion(ctx context.Context, tx pgx.Tx) (*opStmt
 		}
 	}
 	// All regions are already in the database, expect an error with adding an existing one.
-	if len(regionResult.regionNamesNotInDatabase) == 0 {
-		idx := og.params.rng.Intn(len(regionResult.regionNamesInDatabase))
+	if len(regionsNotInDatabase) == 0 {
+		idx := og.params.rng.Intn(len(regionsInDatabase))
 		return makeOpStmtForSingleError(OpStmtDDL,
 			fmt.Sprintf(
 				`ALTER DATABASE %s ADD REGION "%s"`,
 				database,
-				regionResult.regionNamesInDatabase[idx],
+				regionsInDatabase[idx].Name,
 			),
 			pgcode.DuplicateObject), nil
 	}
 	// Here we have a region that is not yet marked as public on the enum.
 	// Double check this first.
 	stmt := makeOpStmt(OpStmtDDL)
-	idx := og.params.rng.Intn(len(regionResult.regionNamesNotInDatabase))
-	region := regionResult.regionNamesNotInDatabase[idx]
-	valuePresent, err := og.enumMemberPresent(ctx, tx, tree.RegionEnum, string(region))
+	idx := og.params.rng.Intn(len(regionsNotInDatabase))
+	region := regionsNotInDatabase[idx]
+	valuePresent, err := og.enumMemberPresent(ctx, tx, tree.RegionEnum, string(region.Name))
 	if err != nil {
 		return nil, err
 	}
@@ -627,26 +599,160 @@ func (og *operationGenerator) addRegion(ctx context.Context, tx pgx.Tx) (*opStmt
 	stmt.sql = fmt.Sprintf(
 		`ALTER DATABASE %s ADD REGION "%s"`,
 		database,
-		region,
+		region.Name,
 	)
 	return stmt, nil
 }
 
-func (og *operationGenerator) primaryRegion(ctx context.Context, tx pgx.Tx) (*opStmt, error) {
-	regionResult, err := og.getRegions(ctx, tx)
-	if err != nil {
-		return nil, err
-	}
+func (og *operationGenerator) alterDatabaseAddSuperRegion(
+	ctx context.Context, tx pgx.Tx,
+) (*opStmt, error) {
 	database, err := og.getDatabase(ctx, tx)
 	if err != nil {
 		return nil, err
 	}
 
+	isMultiRegion, err := og.databaseIsMultiRegion(ctx, tx)
+	if err != nil {
+		return nil, err
+	}
+
+	regionInfos, err := og.getRegionInfo(ctx, tx, database)
+	if err != nil {
+		return nil, err
+	}
+
+	hasPrimaryRegion := false
+	var superRegions []*tree.Name
+	var superRegionRegions []tree.NodeFormatter
+	var regionsNotInDatabase []tree.NodeFormatter
+	var nonSuperRegionRegions []tree.NodeFormatter
+
+	for _, region := range regionInfos {
+		region := region
+		hasPrimaryRegion = hasPrimaryRegion || region.IsPrimary
+
+		if !region.InUse {
+			regionsNotInDatabase = append(regionsNotInDatabase, &region.Name)
+			continue
+		}
+
+		if region.SuperRegion == nil {
+			nonSuperRegionRegions = append(nonSuperRegionRegions, &region.Name)
+		} else {
+			superRegionRegions = append(superRegionRegions, &region.Name)
+
+			if !slices.Contains(superRegions, region.SuperRegion) {
+				superRegions = append(superRegions, region.SuperRegion)
+			}
+		}
+	}
+
+	stmt, expectedCode, err := Generate[*tree.AlterDatabaseAddSuperRegion](og.params.rng, og.produceError(), []GenerationCase{
+		// Alter a database that doesn't exist.
+		{pgcode.InvalidCatalogName, `ALTER DATABASE "NonExistentDatabase" ADD SUPER REGION "Irrelevant" VALUES Irrelevant`},
+		// Use a super region name that already exists.
+		{pgcode.Uncategorized, `ALTER DATABASE {Database} ADD SUPER REGION {ExistingSuperRegion} VALUES {NonSuperRegionRegions}`},
+		// Use regions that are part of another super region.
+		{pgcode.Uncategorized, `ALTER DATABASE {Database} ADD SUPER REGION {UniqueName} VALUES {SuperRegionRegions}`},
+		// Use regions that haven't been added to that database.
+		{pgcode.Uncategorized, `ALTER DATABASE {Database} ADD SUPER REGION {UniqueName} VALUES {RegionsNotPartOfDatabase}`},
+		// Successful case.
+		{pgcode.SuccessfulCompletion, `ALTER DATABASE {Database} ADD SUPER REGION {UniqueName} VALUES {NonSuperRegionRegions}`},
+	}, map[string]any{
+		"Database": func() *tree.Name {
+			db := tree.Name(database)
+			return &db
+		},
+		"ExistingSuperRegion": func() (*tree.Name, error) {
+			return PickOne(og.params.rng, superRegions)
+		},
+		"SuperRegionRegions": func() (Values, error) {
+			return PickAtLeast(og.params.rng, 1, superRegionRegions)
+		},
+		"NonSuperRegionRegions": func() (Values, error) {
+			return PickAtLeast(og.params.rng, 1, nonSuperRegionRegions)
+		},
+		"UniqueName": func() *tree.Name {
+			name := tree.Name(fmt.Sprintf("super_region_%d", og.newUniqueSeqNum()))
+			return &name
+		},
+		"RegionsNotPartOfDatabase": func() (Values, error) {
+			return PickAtLeast(og.params.rng, 1, regionsNotInDatabase)
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return newOpStmt(stmt, codesWithConditions{
+		{expectedCode, true},
+		{pgcode.InvalidName, !isMultiRegion},
+	}), nil
+}
+
+func (og *operationGenerator) alterDatabaseDropSuperRegion(
+	ctx context.Context, tx pgx.Tx,
+) (*opStmt, error) {
+	database, err := og.getDatabase(ctx, tx)
+	if err != nil {
+		return nil, err
+	}
+
+	isMultiRegion, err := og.databaseIsMultiRegion(ctx, tx)
+	if err != nil {
+		return nil, err
+	}
+
+	superRegions, err := Collect(ctx, og, tx, pgx.RowTo[tree.Name], fmt.Sprintf(`
+		SELECT super_region_name FROM [SHOW SUPER REGIONS FROM DATABASE %q]
+	`, database))
+	if err != nil {
+		return nil, err
+	}
+
+	superRegion := tree.Name("IrrelevantSuperRegion")
+	if !og.produceError() && len(superRegions) > 0 {
+		superRegion = superRegions[og.randIntn(len(superRegions))]
+	}
+
+	stmt := makeOpStmt(OpStmtDDL)
+	stmt.sql = tree.Serialize(&tree.AlterDatabaseDropSuperRegion{
+		DatabaseName:    tree.Name(database),
+		SuperRegionName: superRegion,
+	})
+	stmt.expectedExecErrors.addAll(codesWithConditions{
+		{pgcode.InvalidName, !isMultiRegion},
+		{pgcode.Uncategorized, superRegion == "IrrelevantSuperRegion"},
+	})
+	return stmt, nil
+}
+
+func (og *operationGenerator) primaryRegion(ctx context.Context, tx pgx.Tx) (*opStmt, error) {
+	// Allow changing the primary region even if it's part of a super region.
+	if _, err := tx.Exec(ctx, `SET alter_primary_region_super_region_override = 'on'`); err != nil {
+		return nil, err
+	}
+
+	database, err := og.getDatabase(ctx, tx)
+	if err != nil {
+		return nil, err
+	}
+
+	regionInfos, err := og.getRegionInfo(ctx, tx, database)
+	if err != nil {
+		return nil, err
+	}
+
+	regionsInDB := util.Filter(regionInfos, func(r regionInfo) bool {
+		return r.InUse
+	})
+
 	// No regions in cluster, try PRIMARY REGION an invalid region and expect an error.
-	if len(regionResult.regionNamesInCluster) == 0 {
+	if len(regionInfos) == 0 {
 		return makeOpStmtForSingleError(OpStmtDDL,
 			fmt.Sprintf(`ALTER DATABASE %s PRIMARY REGION "invalid-region"`, database),
-			pgcode.InvalidDatabaseDefinition), nil
+			pgcode.InvalidName, pgcode.InvalidDatabaseDefinition), nil
 	}
 
 	// Conversion to multi-region is only allowed if the data is not already
@@ -661,22 +767,22 @@ func (og *operationGenerator) primaryRegion(ctx context.Context, tx pgx.Tx) (*op
 	}
 
 	// No regions in database, set a random region to be the PRIMARY REGION.
-	if len(regionResult.regionNamesInDatabase) == 0 {
-		idx := og.params.rng.Intn(len(regionResult.regionNamesInCluster))
+	if len(regionsInDB) == 0 {
+		idx := og.params.rng.Intn(len(regionInfos))
 		stmt.sql = fmt.Sprintf(
 			`ALTER DATABASE %s PRIMARY REGION "%s"`,
 			database,
-			regionResult.regionNamesInCluster[idx],
+			regionInfos[idx].Name,
 		)
 		return stmt, nil
 	}
 
 	// Regions exist in database, so set a random region to be the primary region.
-	idx := og.params.rng.Intn(len(regionResult.regionNamesInDatabase))
+	idx := og.params.rng.Intn(len(regionsInDB))
 	stmt.sql = fmt.Sprintf(
 		`ALTER DATABASE %s PRIMARY REGION "%s"`,
 		database,
-		regionResult.regionNamesInDatabase[idx],
+		regionsInDB[idx].Name,
 	)
 	return stmt, nil
 }
@@ -3366,7 +3472,7 @@ func (og *operationGenerator) randEnumValue(
 		// It's pretty unlikely that we'll generate conflicting values but better
 		// safe than sorry.
 		for {
-			nonExistentValue := og.randString(5, 5)
+			nonExistentValue := og.randString(5, 6)
 			if !valueSet[nonExistentValue] {
 				return nonExistentValue, false, nil
 			}
@@ -3802,10 +3908,10 @@ func (og *operationGenerator) randIntn(topBound int) int {
 	return og.params.rng.Intn(topBound)
 }
 
-// randString return a random string that matches the regex `[a-z_]{min,max}`.
-// It panics if min < 0 or min > max.
+// randString return a random string that matches the regex `[a-z_]{min,max-1}`.
+// It panics if min < 0 or min >= max.
 func (og *operationGenerator) randString(min, max int) string {
-	if min < 0 || min > max {
+	if min < 0 || min >= max {
 		panic("invalid arguments to randString")
 	}
 
@@ -3813,7 +3919,7 @@ func (og *operationGenerator) randString(min, max int) string {
 	// for values or identifiers.
 	const alphabet = "abcdefghijklmnopqrstuvwxyz_"
 
-	length := og.randIntn(max) + min
+	length := og.randIntn(max-min) + min
 	return randutil.RandString(og.params.rng, length, alphabet)
 }
 

--- a/pkg/workload/schemachange/optype.go
+++ b/pkg/workload/schemachange/optype.go
@@ -83,9 +83,11 @@ const (
 
 	// ALTER DATABASE ...
 
-	alterDatabaseAddRegion     // ALTER DATABASE <db> ADD REGION <region>
-	alterDatabasePrimaryRegion //  ALTER DATABASE <db> PRIMARY REGION <region>
-	alterDatabaseSurvivalGoal  // ALTER DATABASE <db> SURVIVE <failure_mode>
+	alterDatabaseAddRegion       // ALTER DATABASE <db> ADD REGION <region>
+	alterDatabasePrimaryRegion   // ALTER DATABASE <db> PRIMARY REGION <region>
+	alterDatabaseSurvivalGoal    // ALTER DATABASE <db> SURVIVE <failure_mode>
+	alterDatabaseAddSuperRegion  // ALTER DATABASE <db> ADD SUPER REGION <region> VALUES ...
+	alterDatabaseDropSuperRegion // ALTER DATABASE <db> DROP SUPER REGION <region>
 
 	// ALTER TABLE <table> ...
 
@@ -128,14 +130,8 @@ const (
 	dropView     // DROP VIEW <view>
 
 	// Unimplemented operations. TODO(sql-foundations): Audit and/or implement these operations.
-	// alterDatabaseAddSuperRegion
-	// alterDatabaseAlterSuperRegion
-	// alterDatabaseDropRegion
-	// alterDatabaseDropSecondaryRegion
-	// alterDatabaseDropSuperRegion
 	// alterDatabaseOwner
 	// alterDatabasePlacement
-	// alterDatabaseSecondaryRegion
 	// alterDatabaseSetZoneConfigExtension
 	// alterDefaultPrivileges
 	// alterFunctionDepExtension
@@ -211,6 +207,8 @@ var opFuncs = []func(*operationGenerator, context.Context, pgx.Tx) (*opStmt, err
 	alterDatabaseAddRegion:            (*operationGenerator).addRegion,
 	alterDatabasePrimaryRegion:        (*operationGenerator).primaryRegion,
 	alterDatabaseSurvivalGoal:         (*operationGenerator).survive,
+	alterDatabaseAddSuperRegion:       (*operationGenerator).alterDatabaseAddSuperRegion,
+	alterDatabaseDropSuperRegion:      (*operationGenerator).alterDatabaseDropSuperRegion,
 	alterTableAddColumn:               (*operationGenerator).addColumn,
 	alterTableAddConstraint:           (*operationGenerator).addConstraint,
 	alterTableAddConstraintForeignKey: (*operationGenerator).addForeignKeyConstraint,
@@ -256,6 +254,10 @@ var opWeights = []int{
 	alterTableDropConstraint:          0, // TODO(spaskob): unimplemented
 	alterTableAddConstraintForeignKey: 0, // Disabled and tracked with #91195
 	alterDatabaseAddRegion:            1,
+	alterDatabaseAddSuperRegion:       0, // Disabled and tracked with #111299
+	alterDatabaseDropSuperRegion:      0, // Disabled and tracked with #111299
+	alterDatabasePrimaryRegion:        0, // Disabled and tracked with #83831
+	alterDatabaseSurvivalGoal:         0, // Disabled and tracked with #83831
 	alterTableAddConstraintUnique:     0,
 	alterTableLocality:                1,
 	createIndex:                       1,
@@ -275,7 +277,6 @@ var opWeights = []int{
 	dropView:                          1,
 	alterTypeDropValue:                1,
 	dropSchema:                        1,
-	alterDatabasePrimaryRegion:        0, // Disabled and tracked with #83831
 	alterTableRenameColumn:            1,
 	renameIndex:                       1,
 	renameSequence:                    1,
@@ -285,7 +286,6 @@ var opWeights = []int{
 	alterTableSetColumnNotNull:        1,
 	alterTableAlterPrimaryKey:         1,
 	alterTableAlterColumnType:         0, // Disabled and tracked with #66662.
-	alterDatabaseSurvivalGoal:         0, // Disabled and tracked with #83831
 }
 
 // This workload will maintain its own list of minimal supported versions for

--- a/pkg/workload/schemachange/optype_string.go
+++ b/pkg/workload/schemachange/optype_string.go
@@ -18,34 +18,36 @@ func _() {
 	_ = x[alterDatabaseAddRegion-7]
 	_ = x[alterDatabasePrimaryRegion-8]
 	_ = x[alterDatabaseSurvivalGoal-9]
-	_ = x[alterTableAddColumn-10]
-	_ = x[alterTableAddConstraint-11]
-	_ = x[alterTableAddConstraintForeignKey-12]
-	_ = x[alterTableAddConstraintUnique-13]
-	_ = x[alterTableAlterColumnType-14]
-	_ = x[alterTableAlterPrimaryKey-15]
-	_ = x[alterTableDropColumn-16]
-	_ = x[alterTableDropColumnDefault-17]
-	_ = x[alterTableDropConstraint-18]
-	_ = x[alterTableDropNotNull-19]
-	_ = x[alterTableDropStored-20]
-	_ = x[alterTableLocality-21]
-	_ = x[alterTableRenameColumn-22]
-	_ = x[alterTableSetColumnDefault-23]
-	_ = x[alterTableSetColumnNotNull-24]
-	_ = x[alterTypeDropValue-25]
-	_ = x[createTypeEnum-26]
-	_ = x[createIndex-27]
-	_ = x[createSchema-28]
-	_ = x[createSequence-29]
-	_ = x[createTable-30]
-	_ = x[createTableAs-31]
-	_ = x[createView-32]
-	_ = x[dropIndex-33]
-	_ = x[dropSchema-34]
-	_ = x[dropSequence-35]
-	_ = x[dropTable-36]
-	_ = x[dropView-37]
+	_ = x[alterDatabaseAddSuperRegion-10]
+	_ = x[alterDatabaseDropSuperRegion-11]
+	_ = x[alterTableAddColumn-12]
+	_ = x[alterTableAddConstraint-13]
+	_ = x[alterTableAddConstraintForeignKey-14]
+	_ = x[alterTableAddConstraintUnique-15]
+	_ = x[alterTableAlterColumnType-16]
+	_ = x[alterTableAlterPrimaryKey-17]
+	_ = x[alterTableDropColumn-18]
+	_ = x[alterTableDropColumnDefault-19]
+	_ = x[alterTableDropConstraint-20]
+	_ = x[alterTableDropNotNull-21]
+	_ = x[alterTableDropStored-22]
+	_ = x[alterTableLocality-23]
+	_ = x[alterTableRenameColumn-24]
+	_ = x[alterTableSetColumnDefault-25]
+	_ = x[alterTableSetColumnNotNull-26]
+	_ = x[alterTypeDropValue-27]
+	_ = x[createTypeEnum-28]
+	_ = x[createIndex-29]
+	_ = x[createSchema-30]
+	_ = x[createSequence-31]
+	_ = x[createTable-32]
+	_ = x[createTableAs-33]
+	_ = x[createView-34]
+	_ = x[dropIndex-35]
+	_ = x[dropSchema-36]
+	_ = x[dropSequence-37]
+	_ = x[dropTable-38]
+	_ = x[dropView-39]
 }
 
 func (i opType) String() string {
@@ -70,6 +72,10 @@ func (i opType) String() string {
 		return "alterDatabasePrimaryRegion"
 	case alterDatabaseSurvivalGoal:
 		return "alterDatabaseSurvivalGoal"
+	case alterDatabaseAddSuperRegion:
+		return "alterDatabaseAddSuperRegion"
+	case alterDatabaseDropSuperRegion:
+		return "alterDatabaseDropSuperRegion"
 	case alterTableAddColumn:
 		return "alterTableAddColumn"
 	case alterTableAddConstraint:

--- a/pkg/workload/schemachange/query_util.go
+++ b/pkg/workload/schemachange/query_util.go
@@ -18,9 +18,18 @@ import (
 	"github.com/jackc/pgx/v5"
 )
 
-const (
-	descJSONQuery = `SELECT id, crdb_internal.pb_to_json('desc', descriptor) AS descriptor FROM system.descriptor`
+var (
+	regionsFromClusterQuery = `SELECT * FROM [SHOW REGIONS FROM CLUSTER]`
+	descJSONQuery           = `SELECT id, crdb_internal.pb_to_json('desc', descriptor) AS descriptor FROM system.descriptor`
 )
+
+func regionsFromDatabaseQuery(database string) string {
+	return fmt.Sprintf(`SELECT * FROM [SHOW REGIONS FROM DATABASE %q]`, database)
+}
+
+func superRegionsFromDatabaseQuery(database string) string {
+	return fmt.Sprintf(`SELECT * FROM [SHOW SUPER REGIONS FROM DATABASE %q]`, database)
+}
 
 type CTE struct {
 	As    string


### PR DESCRIPTION
#### ce49b52d4b4819738a873cac7ad36f3f5e71cea9 workload/schemachange: implement `ALTER DATABASE ... ADD/DROP SUPER REGION`

This commit adds support for generating `ADD and DROP SUPER REGION`
related DDL operations to the schemachange workload.

By default these operations are disabled as they discovered an
underlying bug. See #111299.

Epic: CRDB-19168
Informs: #59595
Release note: None