### PR TITLE
server: fix hot ranges logging scheduling interval change

### DIFF
--- a/pkg/server/structlogging/BUILD.bazel
+++ b/pkg/server/structlogging/BUILD.bazel
@@ -39,7 +39,6 @@ go_test(
         "//pkg/server/serverpb",
         "//pkg/testutils",
         "//pkg/testutils/serverutils",
-        "//pkg/testutils/skip",
         "//pkg/testutils/testcluster",
         "//pkg/util/leaktest",
         "//pkg/util/log",

--- a/pkg/server/structlogging/hot_ranges_log_test.go
+++ b/pkg/server/structlogging/hot_ranges_log_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server/structlogging"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
-	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/log/logcrash"
@@ -39,9 +38,6 @@ func TestHotRangesStats(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	sc := log.ScopeWithoutShowLogs(t)
 	defer sc.Close(t)
-	// This test is currently being investigated for failing under stress
-	// with the deadlock flag.
-	skip.UnderStressWithIssue(t, 111104)
 
 	ctx := context.Background()
 	cleanup := logtestutils.InstallLogFileSink(sc, t, logpb.Channel_TELEMETRY)


### PR DESCRIPTION
Hot ranges telemetry events are on a logging schedule controlled by the cluster setting `TelemetryHotRangesStatsInterval`. A ticker init'd with this interval duration is used to control the logging cycles.

After the ticker is initialized, callback fn is registered at the scheduler startup to reset the ticker on any interval setting changes. The scheduler start is part of the async tenant server startup process which means we could run into a scenario where the interval is changed before we register the callback to reset the ticker. If this occurs the ticker will never get updated with the new duration.

More concretely, the following can happen:

1. Hot ranges scheduler starts
2. Ticker is initialized with `TelemetryHotRangesStatsInterval` val
3. `TelemetryHotRangesStatsInterval` setting is changed
4. Callback fn registered to watch for `TelemetryHotRangesStatsInterval` changes and reset ticker
5. Scheduler waits for ticker notifications
6. Ticker will never update with the new duration

To fix this we ensure we register the callback fn before the ticker is started. The fn is changed to send a chan notification. This ensures that the ticker will always be updated with the most recent interval value.

Release note (bug fix): Fixes a potential bug where changing the setting
`server.telemetry.hot_ranges_stats.interval` directly after startup is
a no-op.
Fixes: https://github.com/cockroachdb/cockroach/issues/111104