### PR TITLE
release: don not update releases.yaml files on forked repos

### DIFF
--- a/.github/workflows/update_releases.yaml
+++ b/.github/workflows/update_releases.yaml
@@ -22,6 +22,7 @@ on:
 name: Update pkg/testutils/release/cockroach_releases.yaml
 jobs:
   update-crdb-releases-yaml:
+    if: github.repository == 'cockroachdb/cockroach'
     strategy:
       matrix:
         branch: ["master", "release-23.1"]


### PR DESCRIPTION
Previously, the update release.yaml GitHub Action workflow ran on forked repos. The job relies on existence of some release branches, which are not copied to the forked repos by default. This caused unnecessary runs on the forked repos, that failed.

This PR runs the workflow only against the main repository.

Epic: none
Release note: None