### PR TITLE
roachtest: stop using ClusterSpec.Cloud in test code

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -1764,7 +1764,7 @@ func (c *clusterImpl) CreateSnapshot(
 func (c *clusterImpl) ApplySnapshots(ctx context.Context, snapshots []vm.VolumeSnapshot) error {
 	opts := vm.VolumeCreateOpts{
 		Size: c.spec.VolumeSize,
-		Type: c.spec.GCEVolumeType, // TODO(irfansharif): This is only applicable to GCE. Change that.
+		Type: c.spec.GCE.VolumeType, // TODO(irfansharif): This is only applicable to GCE. Change that.
 		Labels: map[string]string{
 			vm.TagUsage: "roachtest",
 		},

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -1742,11 +1742,11 @@ func (c *clusterImpl) removeLabels(labels []string) error {
 func (c *clusterImpl) ListSnapshots(
 	ctx context.Context, vslo vm.VolumeSnapshotListOpts,
 ) ([]vm.VolumeSnapshot, error) {
-	return roachprod.ListSnapshots(ctx, c.l, c.spec.Cloud, vslo)
+	return roachprod.ListSnapshots(ctx, c.l, c.Cloud(), vslo)
 }
 
 func (c *clusterImpl) DeleteSnapshots(ctx context.Context, snapshots ...vm.VolumeSnapshot) error {
-	return roachprod.DeleteSnapshots(ctx, c.l, c.spec.Cloud, snapshots...)
+	return roachprod.DeleteSnapshots(ctx, c.l, c.Cloud(), snapshots...)
 }
 
 func (c *clusterImpl) CreateSnapshot(
@@ -2548,7 +2548,7 @@ func (c *clusterImpl) ConnE(
 	// for cloud runs, we use the connection pool's default behaviour.
 	//
 	// https://github.com/lib/pq/issues/835
-	if c.spec.Cloud == spec.Local {
+	if c.Cloud() == spec.Local {
 		localConnLifetime := 10 * time.Second
 		db.SetConnMaxLifetime(localConnLifetime)
 	}

--- a/pkg/cmd/roachtest/cluster_test.go
+++ b/pkg/cmd/roachtest/cluster_test.go
@@ -320,15 +320,15 @@ func TestAWSMachineTypeNew(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("%d/%s/%t/%s", tc.cpus, tc.mem, tc.localSSD, tc.arch), func(t *testing.T) {
-			machineType, selectedArch := spec.AWSMachineTypeNew(tc.cpus, tc.mem, tc.localSSD, tc.arch)
+			machineType, selectedArch := spec.SelectAWSMachineTypeNew(tc.cpus, tc.mem, tc.localSSD, tc.arch)
 
 			require.Equal(t, tc.expectedMachineType, machineType)
 			require.Equal(t, tc.expectedArch, selectedArch)
 		})
 	}
 	// spec.Low is not supported.
-	require.Panics(t, func() { spec.AWSMachineTypeNew(4, spec.Low, false, vm.ArchAMD64) })
-	require.Panics(t, func() { spec.AWSMachineTypeNew(16, spec.Low, false, vm.ArchARM64) })
+	require.Panics(t, func() { spec.SelectAWSMachineTypeNew(4, spec.Low, false, vm.ArchAMD64) })
+	require.Panics(t, func() { spec.SelectAWSMachineTypeNew(16, spec.Low, false, vm.ArchARM64) })
 }
 
 // TODO(srosenberg): restore the change in https://github.com/cockroachdb/cockroach/pull/111140 after 23.2 branch cut.
@@ -415,7 +415,7 @@ func TestGCEMachineTypeNew(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("%d/%s/%s", tc.cpus, tc.mem, tc.arch), func(t *testing.T) {
-			machineType, selectedArch := spec.GCEMachineTypeNew(tc.cpus, tc.mem, tc.arch)
+			machineType, selectedArch := spec.SelectGCEMachineTypeNew(tc.cpus, tc.mem, tc.arch)
 
 			require.Equal(t, tc.expectedMachineType, machineType)
 			require.Equal(t, tc.expectedArch, selectedArch)

--- a/pkg/cmd/roachtest/spec/cluster_spec.go
+++ b/pkg/cmd/roachtest/spec/cluster_spec.go
@@ -65,11 +65,14 @@ type ClusterSpec struct {
 	// TODO(#104029): We should remove the Cloud field; the tests now specify
 	// their compatible clouds.
 	Cloud string
-	Arch  vm.CPUArch // CPU architecture; auto-chosen if left empty
-	// TODO(radu): An InstanceType can only make sense in the context of a
-	// specific cloud. We should replace this with cloud-specific arguments.
-	InstanceType string // auto-chosen if left empty
-	NodeCount    int
+
+	// TODO(radu): defaultInstanceType is the default machine type used (unless
+	// overridden by GCE.MachineType or AWS.MachineType); it does not belong in
+	// the spec.
+	defaultInstanceType string
+
+	Arch      vm.CPUArch // CPU architecture; auto-chosen if left empty
+	NodeCount int
 	// CPUs is the number of CPUs per node.
 	CPUs                 int
 	Mem                  MemPerCPU
@@ -93,12 +96,14 @@ type ClusterSpec struct {
 
 	// GCE-specific arguments. These values apply only on clusters instantiated on GCE.
 	GCE struct {
+		MachineType    string
 		MinCPUPlatform string
 		VolumeType     string
 	}
 
 	// AWS-specific arguments. These values apply only on clusters instantiated on AWS.
 	AWS struct {
+		MachineType string
 		// VolumeThroughput is the min provisioned EBS volume throughput.
 		VolumeThroughput int
 	}
@@ -106,7 +111,7 @@ type ClusterSpec struct {
 
 // MakeClusterSpec makes a ClusterSpec.
 func MakeClusterSpec(cloud string, instanceType string, nodeCount int, opts ...Option) ClusterSpec {
-	spec := ClusterSpec{Cloud: cloud, InstanceType: instanceType, NodeCount: nodeCount}
+	spec := ClusterSpec{Cloud: cloud, defaultInstanceType: instanceType, NodeCount: nodeCount}
 	defaultOpts := []Option{CPU(4), nodeLifetime(12 * time.Hour), ReuseAny()}
 	for _, o := range append(defaultOpts, opts...) {
 		o(&spec)
@@ -257,31 +262,42 @@ func (s *ClusterSpec) RoachprodOpts(
 
 	createVMOpts.GeoDistributed = s.Geo
 	createVMOpts.Arch = string(arch)
-	machineType := s.InstanceType
 	ssdCount := s.SSDs
+
+	machineType := s.defaultInstanceType
+	switch s.Cloud {
+	case AWS:
+		if s.AWS.MachineType != "" {
+			machineType = s.AWS.MachineType
+		}
+	case GCE:
+		if s.GCE.MachineType != "" {
+			machineType = s.GCE.MachineType
+		}
+	}
 
 	if s.CPUs != 0 {
 		// Default to the user-supplied machine type, if any.
 		// Otherwise, pick based on requested CPU count.
 		var selectedArch vm.CPUArch
 
-		if len(machineType) == 0 {
+		if machineType == "" {
 			// If no machine type was specified, choose one
 			// based on the cloud and CPU count.
 			switch s.Cloud {
 			case AWS:
-				machineType, selectedArch = AWSMachineType(s.CPUs, s.Mem, s.PreferLocalSSD && s.VolumeSize == 0, arch)
+				machineType, selectedArch = SelectAWSMachineType(s.CPUs, s.Mem, s.PreferLocalSSD && s.VolumeSize == 0, arch)
 			case GCE:
-				machineType, selectedArch = GCEMachineType(s.CPUs, s.Mem, arch)
+				machineType, selectedArch = SelectGCEMachineType(s.CPUs, s.Mem, arch)
 			case Azure:
-				machineType = AzureMachineType(s.CPUs, s.Mem)
+				machineType = SelectAzureMachineType(s.CPUs, s.Mem)
 			}
-		}
-		if selectedArch != "" && selectedArch != arch {
-			// TODO(srosenberg): we need a better way to monitor the rate of this mismatch, i.e.,
-			// other than grepping cluster creation logs.
-			fmt.Printf("WARN: requested arch %s for machineType %s, but selected %s\n", arch, machineType, selectedArch)
-			createVMOpts.Arch = string(selectedArch)
+			if selectedArch != "" && selectedArch != arch {
+				// TODO(srosenberg): we need a better way to monitor the rate of this mismatch, i.e.,
+				// other than grepping cluster creation logs.
+				fmt.Printf("WARN: requested arch %s for machineType %s, but selected %s\n", arch, machineType, selectedArch)
+				createVMOpts.Arch = string(selectedArch)
+			}
 		}
 
 		// Local SSD can only be requested

--- a/pkg/cmd/roachtest/spec/cluster_spec.go
+++ b/pkg/cmd/roachtest/spec/cluster_spec.go
@@ -91,16 +91,17 @@ type ClusterSpec struct {
 
 	GatherCores bool
 
-	// GCE-specific arguments.
-	//
-	// TODO(irfansharif): This cluster spec type suffers the curse of
-	// generality. Make it easier to just inject cloud-specific arguments.
-	GCEMinCPUPlatform string
-	GCEVolumeType     string
-	// AWS-specific arguments.
-	//
-	// AWSVolumeThroughput is the min provisioned EBS volume throughput.
-	AWSVolumeThroughput int
+	// GCE-specific arguments. These values apply only on clusters instantiated on GCE.
+	GCE struct {
+		MinCPUPlatform string
+		VolumeType     string
+	}
+
+	// AWS-specific arguments. These values apply only on clusters instantiated on AWS.
+	AWS struct {
+		// VolumeThroughput is the min provisioned EBS volume throughput.
+		VolumeThroughput int
+	}
 }
 
 // MakeClusterSpec makes a ClusterSpec.
@@ -330,12 +331,12 @@ func (s *ClusterSpec) RoachprodOpts(
 	var providerOpts vm.ProviderOpts
 	switch s.Cloud {
 	case AWS:
-		providerOpts = getAWSOpts(machineType, zones, s.VolumeSize, s.AWSVolumeThroughput,
+		providerOpts = getAWSOpts(machineType, zones, s.VolumeSize, s.AWS.VolumeThroughput,
 			createVMOpts.SSDOpts.UseLocalSSD)
 	case GCE:
 		providerOpts = getGCEOpts(machineType, zones, s.VolumeSize, ssdCount,
 			createVMOpts.SSDOpts.UseLocalSSD, s.RAID0, s.TerminateOnMigration,
-			s.GCEMinCPUPlatform, vm.ParseArch(createVMOpts.Arch), s.GCEVolumeType,
+			s.GCE.MinCPUPlatform, vm.ParseArch(createVMOpts.Arch), s.GCE.VolumeType,
 		)
 	case Azure:
 		providerOpts = getAzureOpts(machineType, zones)

--- a/pkg/cmd/roachtest/spec/cluster_spec.go
+++ b/pkg/cmd/roachtest/spec/cluster_spec.go
@@ -106,9 +106,9 @@ type ClusterSpec struct {
 // MakeClusterSpec makes a ClusterSpec.
 func MakeClusterSpec(cloud string, instanceType string, nodeCount int, opts ...Option) ClusterSpec {
 	spec := ClusterSpec{Cloud: cloud, InstanceType: instanceType, NodeCount: nodeCount}
-	defaultOpts := []Option{CPU(4), nodeLifetimeOption(12 * time.Hour), ReuseAny()}
+	defaultOpts := []Option{CPU(4), nodeLifetime(12 * time.Hour), ReuseAny()}
 	for _, o := range append(defaultOpts, opts...) {
-		o.apply(&spec)
+		o(&spec)
 	}
 	return spec
 }

--- a/pkg/cmd/roachtest/spec/cluster_spec.go
+++ b/pkg/cmd/roachtest/spec/cluster_spec.go
@@ -71,6 +71,10 @@ type ClusterSpec struct {
 	// the spec.
 	defaultInstanceType string
 
+	// TODO(radu): defaultZones is the default zones specification (unless
+	// overridden by GCE.Zones or AWS.Zones); it does not belong in the spec.
+	defaultZones string
+
 	Arch      vm.CPUArch // CPU architecture; auto-chosen if left empty
 	NodeCount int
 	// CPUs is the number of CPUs per node.
@@ -80,7 +84,6 @@ type ClusterSpec struct {
 	RAID0                bool
 	VolumeSize           int
 	PreferLocalSSD       bool
-	Zones                string
 	Geo                  bool
 	Lifetime             time.Duration
 	ReusePolicy          clusterReusePolicy
@@ -99,6 +102,7 @@ type ClusterSpec struct {
 		MachineType    string
 		MinCPUPlatform string
 		VolumeType     string
+		Zones          string
 	}
 
 	// AWS-specific arguments. These values apply only on clusters instantiated on AWS.
@@ -106,6 +110,7 @@ type ClusterSpec struct {
 		MachineType string
 		// VolumeThroughput is the min provisioned EBS volume throughput.
 		VolumeThroughput int
+		Zones            string
 	}
 }
 
@@ -331,9 +336,21 @@ func (s *ClusterSpec) RoachprodOpts(
 			createVMOpts.SSDOpts.FileSystem = vm.Zfs
 		}
 	}
+
+	zonesStr := s.defaultZones
+	switch s.Cloud {
+	case AWS:
+		if s.AWS.Zones != "" {
+			zonesStr = s.AWS.Zones
+		}
+	case GCE:
+		if s.GCE.Zones != "" {
+			zonesStr = s.GCE.Zones
+		}
+	}
 	var zones []string
-	if s.Zones != "" {
-		zones = strings.Split(s.Zones, ",")
+	if zonesStr != "" {
+		zones = strings.Split(zonesStr, ",")
 		if !s.Geo {
 			zones = zones[:1]
 		}

--- a/pkg/cmd/roachtest/spec/machine_type.go
+++ b/pkg/cmd/roachtest/spec/machine_type.go
@@ -17,20 +17,21 @@ import (
 )
 
 // TODO(srosenberg): restore the change in https://github.com/cockroachdb/cockroach/pull/111140 after 23.2 branch cut.
-func AWSMachineType(
+func SelectAWSMachineType(
 	cpus int, mem MemPerCPU, shouldSupportLocalSSD bool, arch vm.CPUArch,
 ) (string, vm.CPUArch) {
-	return AWSMachineTypeOld(cpus, mem, arch)
+	return SelectAWSMachineTypeOld(cpus, mem, arch)
 }
 
 // TODO(srosenberg): restore the change in https://github.com/cockroachdb/cockroach/pull/111140 after 23.2 branch cut.
-func GCEMachineType(cpus int, mem MemPerCPU, arch vm.CPUArch) (string, vm.CPUArch) {
-	return GCEMachineTypeOld(cpus, mem, arch)
+func SelectGCEMachineType(cpus int, mem MemPerCPU, arch vm.CPUArch) (string, vm.CPUArch) {
+	return SelectGCEMachineTypeOld(cpus, mem, arch)
 }
 
-// AWSMachineType selects a machine type given the desired number of CPUs and
-// memory per CPU ratio. Also returns the architecture of the selected machine type.
-func AWSMachineTypeOld(cpus int, mem MemPerCPU, arch vm.CPUArch) (string, vm.CPUArch) {
+// SelectAWSMachineType selects a machine type given the desired number of CPUs
+// and memory per CPU ratio. Also returns the architecture of the selected
+// machine type.
+func SelectAWSMachineTypeOld(cpus int, mem MemPerCPU, arch vm.CPUArch) (string, vm.CPUArch) {
 	// TODO(erikgrinaker): These have significantly less RAM than
 	// their GCE counterparts. Consider harmonizing them.
 	family := "c6id" // 2 GB RAM per CPU
@@ -87,8 +88,9 @@ func AWSMachineTypeOld(cpus int, mem MemPerCPU, arch vm.CPUArch) (string, vm.CPU
 	return fmt.Sprintf("%s.%s", family, size), selectedArch
 }
 
-// AWSMachineType selects a machine type given the desired number of CPUs, memory per CPU,
-// support for locally-attached SSDs and CPU architecture. It returns a compatible machine type and its architecture.
+// SelectAWSMachineType selects a machine type given the desired number of CPUs,
+// memory per CPU, support for locally-attached SSDs and CPU architecture. It
+// returns a compatible machine type and its architecture.
 //
 // When MemPerCPU is Standard, the memory per CPU ratio is 4 GB. For High, it is 8 GB.
 // For Auto, it's 4 GB up to and including 16 CPUs, then 2 GB. Low is not supported.
@@ -99,7 +101,7 @@ func AWSMachineTypeOld(cpus int, mem MemPerCPU, arch vm.CPUArch) (string, vm.CPU
 //
 // At the time of writing, the intel machines are all third-generation Xeon, "Ice Lake" which are isomorphic to
 // GCE's n2-(standard|highmem|custom) _with_ --minimum-cpu-platform="Intel Ice Lake" (roachprod's default).
-func AWSMachineTypeNew(
+func SelectAWSMachineTypeNew(
 	cpus int, mem MemPerCPU, shouldSupportLocalSSD bool, arch vm.CPUArch,
 ) (string, vm.CPUArch) {
 	family := "m6i" // 4 GB RAM per CPU
@@ -176,9 +178,10 @@ func AWSMachineTypeNew(
 	return fmt.Sprintf("%s.%s", family, size), selectedArch
 }
 
-// GCEMachineType selects a machine type given the desired number of CPUs and
-// memory per CPU ratio. Also returns the architecture of the selected machine type.
-func GCEMachineTypeOld(cpus int, mem MemPerCPU, arch vm.CPUArch) (string, vm.CPUArch) {
+// SelectGCEMachineType selects a machine type given the desired number of CPUs
+// and memory per CPU ratio. Also returns the architecture of the selected
+// machine type.
+func SelectGCEMachineTypeOld(cpus int, mem MemPerCPU, arch vm.CPUArch) (string, vm.CPUArch) {
 	// TODO(peter): This is awkward: at or below 16 cpus, use n2-standard so that
 	// the machines have a decent amount of RAM. We could use custom machine
 	// configurations, but the rules for the amount of RAM per CPU need to be
@@ -215,8 +218,9 @@ func GCEMachineTypeOld(cpus int, mem MemPerCPU, arch vm.CPUArch) (string, vm.CPU
 	return fmt.Sprintf("%s-%s-%d", series, kind, cpus), selectedArch
 }
 
-// GCEMachineType selects a machine type given the desired number of CPUs, memory per CPU, and CPU architecture.
-// It returns a compatible machine type and its architecture.
+// SelectGCEMachineType selects a machine type given the desired number of CPUs,
+// memory per CPU, and CPU architecture.  It returns a compatible machine type
+// and its architecture.
 //
 // When MemPerCPU is Standard, the memory per CPU ratio is 4 GB. For High, it is 8 GB.
 // For Auto, it's 4 GB up to and including 16 CPUs, then 2 GB. Low is 1 GB.
@@ -228,7 +232,7 @@ func GCEMachineTypeOld(cpus int, mem MemPerCPU, arch vm.CPUArch) (string, vm.CPU
 // At the time of writing, the intel machines are all third-generation xeon, "Ice Lake" assuming
 // --minimum-cpu-platform="Intel Ice Lake" (roachprod's default). This is isomorphic to AWS's m6i or c6i.
 // The only exception is low memory machines (n2-highcpu-xxx), which aren't available in AWS.
-func GCEMachineTypeNew(cpus int, mem MemPerCPU, arch vm.CPUArch) (string, vm.CPUArch) {
+func SelectGCEMachineTypeNew(cpus int, mem MemPerCPU, arch vm.CPUArch) (string, vm.CPUArch) {
 	series := "n2"
 	selectedArch := vm.ArchAMD64
 
@@ -286,9 +290,9 @@ func GCEMachineTypeNew(cpus int, mem MemPerCPU, arch vm.CPUArch) (string, vm.CPU
 	return fmt.Sprintf("%s-%s-%d", series, kind, cpus), selectedArch
 }
 
-// AzureMachineType selects a machine type given the desired number of CPUs and
+// SelectAzureMachineType selects a machine type given the desired number of CPUs and
 // memory per CPU ratio.
-func AzureMachineType(cpus int, mem MemPerCPU) string {
+func SelectAzureMachineType(cpus int, mem MemPerCPU) string {
 	if mem != Auto && mem != Standard {
 		panic(fmt.Sprintf("custom memory per CPU not implemented for Azure, memory ratio requested: %d", mem))
 	}

--- a/pkg/cmd/roachtest/spec/option.go
+++ b/pkg/cmd/roachtest/spec/option.go
@@ -198,6 +198,13 @@ func RandomlyUseZfs() Option {
 	}
 }
 
+// GCEMachineType sets the machine (instance) type when the cluster is on GCE.
+func GCEMachineType(machineType string) Option {
+	return func(spec *ClusterSpec) {
+		spec.GCE.MachineType = machineType
+	}
+}
+
 // GCEMinCPUPlatform sets the minimum CPU platform when the cluster is on GCE.
 func GCEMinCPUPlatform(platform string) Option {
 	return func(spec *ClusterSpec) {
@@ -209,6 +216,13 @@ func GCEMinCPUPlatform(platform string) Option {
 func GCEVolumeType(volumeType string) Option {
 	return func(spec *ClusterSpec) {
 		spec.GCE.VolumeType = volumeType
+	}
+}
+
+// AWSMachineType sets the machine (instance) type when the cluster is on AWS.
+func AWSMachineType(machineType string) Option {
+	return func(spec *ClusterSpec) {
+		spec.AWS.MachineType = machineType
 	}
 }
 

--- a/pkg/cmd/roachtest/spec/option.go
+++ b/pkg/cmd/roachtest/spec/option.go
@@ -197,3 +197,25 @@ func RandomlyUseZfs() Option {
 		spec.RandomlyUseZfs = true
 	}
 }
+
+// GCEMinCPUPlatform sets the minimum CPU platform when the cluster is on GCE.
+func GCEMinCPUPlatform(platform string) Option {
+	return func(spec *ClusterSpec) {
+		spec.GCE.MinCPUPlatform = platform
+	}
+}
+
+// GCEVolumeType sets the volume type when the cluster is on GCE.
+func GCEVolumeType(volumeType string) Option {
+	return func(spec *ClusterSpec) {
+		spec.GCE.VolumeType = volumeType
+	}
+}
+
+// AWSVolumeThroughput sets the minimum provisioned EBS volume throughput when
+// the cluster is on AWS.
+func AWSVolumeThroughput(throughput int) Option {
+	return func(spec *ClusterSpec) {
+		spec.AWS.VolumeThroughput = throughput
+	}
+}

--- a/pkg/cmd/roachtest/spec/option.go
+++ b/pkg/cmd/roachtest/spec/option.go
@@ -80,12 +80,10 @@ func Geo() Option {
 	}
 }
 
-// Zones is a node option which requests Geo-distributed nodes. Note that this
-// overrides the --zones flag and is useful for tests that require running on
-// specific Zones.
-func Zones(zones string) Option {
+// DefaultZones sets the default zones (set with the --zones flag).
+func DefaultZones(zones string) Option {
 	return func(spec *ClusterSpec) {
-		spec.Zones = zones
+		spec.defaultZones = zones
 	}
 }
 
@@ -219,6 +217,17 @@ func GCEVolumeType(volumeType string) Option {
 	}
 }
 
+// GCEZones is a node option which requests Geo-distributed nodes; only applies
+// when the test runs on GCE.
+//
+// Note that this overrides the --zones flag and is useful for tests that
+// require running on specific zones.
+func GCEZones(zones string) Option {
+	return func(spec *ClusterSpec) {
+		spec.GCE.Zones = zones
+	}
+}
+
 // AWSMachineType sets the machine (instance) type when the cluster is on AWS.
 func AWSMachineType(machineType string) Option {
 	return func(spec *ClusterSpec) {
@@ -231,5 +240,16 @@ func AWSMachineType(machineType string) Option {
 func AWSVolumeThroughput(throughput int) Option {
 	return func(spec *ClusterSpec) {
 		spec.AWS.VolumeThroughput = throughput
+	}
+}
+
+// AWSZones is a node option which requests Geo-distributed nodes; only applies
+// when the test runs on AWS.
+//
+// Note that this overrides the --zones flag and is useful for tests that
+// require running on specific zones.
+func AWSZones(zones string) Option {
+	return func(spec *ClusterSpec) {
+		spec.AWS.Zones = zones
 	}
 }

--- a/pkg/cmd/roachtest/spec/option.go
+++ b/pkg/cmd/roachtest/spec/option.go
@@ -16,127 +16,90 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
 )
 
-// Option is the interface satisfied by options to MakeClusterSpec.
-type Option interface {
-	apply(spec *ClusterSpec)
-}
-
-type cloudOption string
-
-func (o cloudOption) apply(spec *ClusterSpec) {
-	spec.Cloud = string(o)
-}
+// Option for MakeClusterSpec.
+type Option func(spec *ClusterSpec)
 
 // Cloud controls what cloud is used to create the cluster.
 func Cloud(s string) Option {
-	return cloudOption(s)
+	return func(spec *ClusterSpec) {
+		spec.Cloud = s
+	}
 }
 
-type archOption string
-
-func (o archOption) apply(spec *ClusterSpec) {
-	spec.Arch = vm.CPUArch(o)
-}
-
-// Request specific CPU architecture.
+// Arch requests a specific CPU architecture.
+//
+// Note that it is not guaranteed that this architecture will be used (e.g. if
+// the requested machine size isn't available in this architecture).
+//
+// TODO(radu): add a flag to indicate whether it's a preference or a requirement.
 func Arch(arch vm.CPUArch) Option {
-	return archOption(arch)
+	return func(spec *ClusterSpec) {
+		spec.Arch = arch
+	}
 }
 
-type nodeCPUOption int
-
-func (o nodeCPUOption) apply(spec *ClusterSpec) {
-	spec.CPUs = int(o)
-}
-
-// CPU is a node option which requests nodes with the specified number of CPUs.
+// CPU sets the number of CPUs for each node.
 func CPU(n int) Option {
-	return nodeCPUOption(n)
-}
-
-type nodeMemOption MemPerCPU
-
-func (o nodeMemOption) apply(spec *ClusterSpec) {
-	spec.Mem = MemPerCPU(o)
+	return func(spec *ClusterSpec) {
+		spec.CPUs = n
+	}
 }
 
 // Mem requests nodes with low/standard/high ratio of memory per CPU.
 func Mem(level MemPerCPU) Option {
-	return nodeMemOption(level)
-}
-
-type volumeSizeOption int
-
-func (o volumeSizeOption) apply(spec *ClusterSpec) {
-	spec.VolumeSize = int(o)
+	return func(spec *ClusterSpec) {
+		spec.Mem = level
+	}
 }
 
 // VolumeSize is the size in GB of the disk volume.
 func VolumeSize(n int) Option {
-	return volumeSizeOption(n)
-}
-
-type nodeSSDOption int
-
-func (o nodeSSDOption) apply(spec *ClusterSpec) {
-	spec.SSDs = int(o)
+	return func(spec *ClusterSpec) {
+		spec.VolumeSize = n
+	}
 }
 
 // SSD is a node option which requests nodes with the specified number of SSDs.
 func SSD(n int) Option {
-	return nodeSSDOption(n)
-}
-
-type raid0Option bool
-
-func (o raid0Option) apply(spec *ClusterSpec) {
-	spec.RAID0 = bool(o)
+	return func(spec *ClusterSpec) {
+		spec.SSDs = n
+	}
 }
 
 // RAID0 enables RAID 0 striping across all disks on the node.
 func RAID0(enabled bool) Option {
-	return raid0Option(enabled)
+	return func(spec *ClusterSpec) {
+		spec.RAID0 = enabled
+	}
 }
 
-type nodeGeoOption struct{}
-
-func (o nodeGeoOption) apply(spec *ClusterSpec) {
-	spec.Geo = true
-}
-
-// Geo is a node option which requests Geo-distributed nodes.
+// Geo requests Geo-distributed nodes.
 func Geo() Option {
-	return nodeGeoOption{}
-}
-
-type nodeZonesOption string
-
-func (o nodeZonesOption) apply(spec *ClusterSpec) {
-	spec.Zones = string(o)
+	return func(spec *ClusterSpec) {
+		spec.Geo = true
+	}
 }
 
 // Zones is a node option which requests Geo-distributed nodes. Note that this
 // overrides the --zones flag and is useful for tests that require running on
 // specific Zones.
-func Zones(s string) Option {
-	return nodeZonesOption(s)
+func Zones(zones string) Option {
+	return func(spec *ClusterSpec) {
+		spec.Zones = zones
+	}
 }
 
-type nodeLifetimeOption time.Duration
-
-func (o nodeLifetimeOption) apply(spec *ClusterSpec) {
-	spec.Lifetime = time.Duration(o)
-}
-
-type gatherCoresOption struct{}
-
-func (o gatherCoresOption) apply(spec *ClusterSpec) {
-	spec.GatherCores = true
+func nodeLifetime(lifetime time.Duration) Option {
+	return func(spec *ClusterSpec) {
+		spec.Lifetime = lifetime
+	}
 }
 
 // GatherCores enables core gathering after test runs.
 func GatherCores() Option {
-	return gatherCoresOption{}
+	return func(spec *ClusterSpec) {
+		spec.GatherCores = true
+	}
 }
 
 // clusterReusePolicy indicates what clusters a particular test can run on and
@@ -182,69 +145,47 @@ func (ReusePolicyAny) clusterReusePolicy()    {}
 func (ReusePolicyNone) clusterReusePolicy()   {}
 func (ReusePolicyTagged) clusterReusePolicy() {}
 
-type clusterReusePolicyOption struct {
-	p clusterReusePolicy
-}
-
 // ReuseAny is an Option that specifies a cluster with ReusePolicyAny.
 func ReuseAny() Option {
-	return clusterReusePolicyOption{p: ReusePolicyAny{}}
+	return func(spec *ClusterSpec) {
+		spec.ReusePolicy = ReusePolicyAny{}
+	}
 }
 
 // ReuseNone is an Option that specifies a cluster with ReusePolicyNone.
 func ReuseNone() Option {
-	return clusterReusePolicyOption{p: ReusePolicyNone{}}
+	return func(spec *ClusterSpec) {
+		spec.ReusePolicy = ReusePolicyNone{}
+	}
 }
 
 // ReuseTagged is an Option that specifies a cluster with ReusePolicyTagged.
 func ReuseTagged(tag string) Option {
-	return clusterReusePolicyOption{p: ReusePolicyTagged{Tag: tag}}
-}
-
-func (p clusterReusePolicyOption) apply(spec *ClusterSpec) {
-	spec.ReusePolicy = p.p
-}
-
-type preferLocalSSDOption bool
-
-func (o preferLocalSSDOption) apply(spec *ClusterSpec) {
-	spec.PreferLocalSSD = bool(o)
+	return func(spec *ClusterSpec) {
+		spec.ReusePolicy = ReusePolicyTagged{Tag: tag}
+	}
 }
 
 // PreferLocalSSD specifies whether to prefer using local SSD, when possible.
 func PreferLocalSSD(prefer bool) Option {
-	return preferLocalSSDOption(prefer)
-}
-
-type terminateOnMigrationOption struct{}
-
-func (o terminateOnMigrationOption) apply(spec *ClusterSpec) {
-	spec.TerminateOnMigration = true
+	return func(spec *ClusterSpec) {
+		spec.PreferLocalSSD = prefer
+	}
 }
 
 // TerminateOnMigration ensures VM is terminated in case GCE triggers a live migration.
 func TerminateOnMigration() Option {
-	return &terminateOnMigrationOption{}
-}
-
-type setFileSystem struct {
-	fs fileSystemType
-}
-
-func (s *setFileSystem) apply(spec *ClusterSpec) {
-	spec.FileSystem = s.fs
+	return func(spec *ClusterSpec) {
+		spec.TerminateOnMigration = true
+	}
 }
 
 // SetFileSystem is an Option which can be used to set
 // the underlying file system to be used.
 func SetFileSystem(fs fileSystemType) Option {
-	return &setFileSystem{fs}
-}
-
-type randomlyUseZfs struct{}
-
-func (r *randomlyUseZfs) apply(spec *ClusterSpec) {
-	spec.RandomlyUseZfs = true
+	return func(spec *ClusterSpec) {
+		spec.FileSystem = fs
+	}
 }
 
 // RandomlyUseZfs is an Option which randomly picks
@@ -252,5 +193,7 @@ func (r *randomlyUseZfs) apply(spec *ClusterSpec) {
 // about 20% of the time.
 // Zfs is only picked if the cloud is gce.
 func RandomlyUseZfs() Option {
-	return &randomlyUseZfs{}
+	return func(spec *ClusterSpec) {
+		spec.RandomlyUseZfs = true
+	}
 }

--- a/pkg/cmd/roachtest/test_registry.go
+++ b/pkg/cmd/roachtest/test_registry.go
@@ -100,7 +100,7 @@ func (r *testRegistryImpl) MakeClusterSpec(nodeCount int, opts ...spec.Option) s
 		finalOpts = append(finalOpts, spec.PreferLocalSSD(true))
 	}
 	if r.zones != "" {
-		finalOpts = append(finalOpts, spec.Zones(r.zones))
+		finalOpts = append(finalOpts, spec.DefaultZones(r.zones))
 	}
 	finalOpts = append(finalOpts, opts...)
 	return spec.MakeClusterSpec(r.cloud, r.instanceType, nodeCount, finalOpts...)

--- a/pkg/cmd/roachtest/test_registry_test.go
+++ b/pkg/cmd/roachtest/test_registry_test.go
@@ -29,11 +29,10 @@ func TestMakeTestRegistry(t *testing.T) {
 		require.Equal(t, "foo", r.instanceType)
 		require.Equal(t, spec.AWS, r.cloud)
 
-		s := r.MakeClusterSpec(100, spec.Geo(), spec.Zones("zone99"), spec.CPU(12),
+		s := r.MakeClusterSpec(100, spec.Geo(), spec.CPU(12),
 			spec.PreferLocalSSD(true))
 		require.EqualValues(t, 100, s.NodeCount)
 		require.True(t, s.Geo)
-		require.Equal(t, "zone99", s.Zones)
 		require.EqualValues(t, 12, s.CPUs)
 		require.True(t, s.PreferLocalSSD)
 

--- a/pkg/cmd/roachtest/test_registry_test.go
+++ b/pkg/cmd/roachtest/test_registry_test.go
@@ -32,7 +32,6 @@ func TestMakeTestRegistry(t *testing.T) {
 		s := r.MakeClusterSpec(100, spec.Geo(), spec.Zones("zone99"), spec.CPU(12),
 			spec.PreferLocalSSD(true))
 		require.EqualValues(t, 100, s.NodeCount)
-		require.Equal(t, "foo", s.InstanceType)
 		require.True(t, s.Geo)
 		require.Equal(t, "zone99", s.Zones)
 		require.EqualValues(t, 12, s.CPUs)
@@ -40,13 +39,11 @@ func TestMakeTestRegistry(t *testing.T) {
 
 		s = r.MakeClusterSpec(100, spec.CPU(4), spec.TerminateOnMigration())
 		require.EqualValues(t, 100, s.NodeCount)
-		require.Equal(t, "foo", s.InstanceType)
 		require.EqualValues(t, 4, s.CPUs)
 		require.True(t, s.TerminateOnMigration)
 
 		s = r.MakeClusterSpec(10, spec.CPU(16), spec.Arch(vm.ArchARM64))
 		require.EqualValues(t, 10, s.NodeCount)
-		require.Equal(t, "foo", s.InstanceType)
 		require.EqualValues(t, 16, s.CPUs)
 		require.EqualValues(t, vm.ArchARM64, s.Arch)
 	})

--- a/pkg/cmd/roachtest/tests/admission_control_database_drop.go
+++ b/pkg/cmd/roachtest/tests/admission_control_database_drop.go
@@ -34,10 +34,10 @@ func registerDatabaseDrop(r registry.Registry) {
 		spec.Zones("us-east1-b"),
 		spec.VolumeSize(500),
 		spec.Cloud(spec.GCE),
+		spec.GCEMinCPUPlatform("Intel Ice Lake"),
+		spec.GCEVolumeType("pd-ssd"),
 	)
 	clusterSpec.InstanceType = "n2-standard-8"
-	clusterSpec.GCEMinCPUPlatform = "Intel Ice Lake"
-	clusterSpec.GCEVolumeType = "pd-ssd"
 
 	r.Add(registry.TestSpec{
 		Name:             "admission-control/database-drop",

--- a/pkg/cmd/roachtest/tests/admission_control_database_drop.go
+++ b/pkg/cmd/roachtest/tests/admission_control_database_drop.go
@@ -36,15 +36,15 @@ func registerDatabaseDrop(r registry.Registry) {
 		spec.Cloud(spec.GCE),
 		spec.GCEMinCPUPlatform("Intel Ice Lake"),
 		spec.GCEVolumeType("pd-ssd"),
+		spec.GCEMachineType("n2-standard-8"),
 	)
-	clusterSpec.InstanceType = "n2-standard-8"
 
 	r.Add(registry.TestSpec{
 		Name:             "admission-control/database-drop",
 		Timeout:          10 * time.Hour,
 		Owner:            registry.OwnerAdmissionControl,
 		Benchmark:        true,
-		CompatibleClouds: registry.AllExceptAWS,
+		CompatibleClouds: registry.OnlyGCE,
 		Suites:           registry.Suites(registry.Weekly),
 		Tags:             registry.Tags(`weekly`),
 		Cluster:          clusterSpec,

--- a/pkg/cmd/roachtest/tests/admission_control_database_drop.go
+++ b/pkg/cmd/roachtest/tests/admission_control_database_drop.go
@@ -31,12 +31,12 @@ func registerDatabaseDrop(r registry.Registry) {
 	clusterSpec := r.MakeClusterSpec(
 		10, /* nodeCount */
 		spec.CPU(8),
-		spec.Zones("us-east1-b"),
 		spec.VolumeSize(500),
 		spec.Cloud(spec.GCE),
 		spec.GCEMinCPUPlatform("Intel Ice Lake"),
 		spec.GCEVolumeType("pd-ssd"),
 		spec.GCEMachineType("n2-standard-8"),
+		spec.GCEZones("us-east1-b"),
 	)
 
 	r.Add(registry.TestSpec{

--- a/pkg/cmd/roachtest/tests/admission_control_index_backfill.go
+++ b/pkg/cmd/roachtest/tests/admission_control_index_backfill.go
@@ -32,12 +32,12 @@ func registerIndexBackfill(r registry.Registry) {
 	clusterSpec := r.MakeClusterSpec(
 		10, /* nodeCount */
 		spec.CPU(8),
-		spec.Zones("us-east1-b"),
 		spec.VolumeSize(500),
 		spec.Cloud(spec.GCE),
 		spec.GCEMinCPUPlatform("Intel Ice Lake"),
 		spec.GCEVolumeType("pd-ssd"),
 		spec.GCEMachineType("n2-standard-8"),
+		spec.GCEZones("us-east1-b"),
 	)
 
 	r.Add(registry.TestSpec{

--- a/pkg/cmd/roachtest/tests/admission_control_index_backfill.go
+++ b/pkg/cmd/roachtest/tests/admission_control_index_backfill.go
@@ -37,15 +37,15 @@ func registerIndexBackfill(r registry.Registry) {
 		spec.Cloud(spec.GCE),
 		spec.GCEMinCPUPlatform("Intel Ice Lake"),
 		spec.GCEVolumeType("pd-ssd"),
+		spec.GCEMachineType("n2-standard-8"),
 	)
-	clusterSpec.InstanceType = "n2-standard-8"
 
 	r.Add(registry.TestSpec{
 		Name:             "admission-control/index-backfill",
 		Timeout:          6 * time.Hour,
 		Owner:            registry.OwnerAdmissionControl,
 		Benchmark:        true,
-		CompatibleClouds: registry.AllExceptAWS,
+		CompatibleClouds: registry.OnlyGCE,
 		Suites:           registry.ManualOnly,
 		Tags:             registry.Tags(`manual`),
 		// TODO(aaditya): Revisit this as part of #111614.

--- a/pkg/cmd/roachtest/tests/admission_control_index_backfill.go
+++ b/pkg/cmd/roachtest/tests/admission_control_index_backfill.go
@@ -35,10 +35,10 @@ func registerIndexBackfill(r registry.Registry) {
 		spec.Zones("us-east1-b"),
 		spec.VolumeSize(500),
 		spec.Cloud(spec.GCE),
+		spec.GCEMinCPUPlatform("Intel Ice Lake"),
+		spec.GCEVolumeType("pd-ssd"),
 	)
 	clusterSpec.InstanceType = "n2-standard-8"
-	clusterSpec.GCEMinCPUPlatform = "Intel Ice Lake"
-	clusterSpec.GCEVolumeType = "pd-ssd"
 
 	r.Add(registry.TestSpec{
 		Name:             "admission-control/index-backfill",

--- a/pkg/cmd/roachtest/tests/awsdms.go
+++ b/pkg/cmd/roachtest/tests/awsdms.go
@@ -210,7 +210,7 @@ func runAWSDMS(ctx context.Context, t test.Test, c cluster.Cluster) {
 		t.Fatal("cannot be run in local mode")
 	}
 	// We may not have the requisite certificates to start DMS/RDS on non-AWS invocations.
-	if cloud := c.Spec().Cloud; cloud != spec.AWS {
+	if cloud := c.Cloud(); cloud != spec.AWS {
 		t.Skipf("skipping test on cloud %s", cloud)
 		return
 	}

--- a/pkg/cmd/roachtest/tests/backup.go
+++ b/pkg/cmd/roachtest/tests/backup.go
@@ -454,7 +454,7 @@ func registerBackup(r registry.Registry) {
 			CompatibleClouds:  registry.AllExceptAWS,
 			Suites:            registry.Suites(registry.Nightly),
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-				if c.Spec().Cloud != item.machine {
+				if c.Cloud() != item.machine {
 					t.Skip("backup assumeRole is only configured to run on "+item.machine, "")
 				}
 
@@ -565,7 +565,7 @@ func registerBackup(r registry.Registry) {
 			Suites:            registry.Suites(registry.Nightly),
 			Tags:              item.tags,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-				if c.Spec().Cloud != item.machine {
+				if c.Cloud() != item.machine {
 					t.Skip("backupKMS roachtest is only configured to run on "+item.machine, "")
 				}
 
@@ -910,7 +910,7 @@ func registerBackup(r registry.Registry) {
 		CompatibleClouds:  registry.AllExceptAWS,
 		Suites:            registry.Suites(registry.Nightly),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-			if c.Spec().Cloud != spec.GCE && !c.IsLocal() {
+			if c.Cloud() != spec.GCE && !c.IsLocal() {
 				t.Skip("uses gs://cockroach-fixtures; see https://github.com/cockroachdb/cockroach/issues/105968")
 			}
 			runBackupMVCCRangeTombstones(ctx, t, c, mvccRangeTombstoneConfig{})

--- a/pkg/cmd/roachtest/tests/backup_fixtures.go
+++ b/pkg/cmd/roachtest/tests/backup_fixtures.go
@@ -129,7 +129,7 @@ type backupDriver struct {
 
 func (bd *backupDriver) prepareCluster(ctx context.Context) {
 
-	if bd.c.Spec().Cloud != bd.sp.backup.cloud {
+	if bd.c.Cloud() != bd.sp.backup.cloud {
 		// For now, only run the test on the cloud provider that also stores the backup.
 		bd.t.Skip(fmt.Sprintf("test configured to run on %s", bd.sp.backup.cloud))
 	}

--- a/pkg/cmd/roachtest/tests/cluster_to_cluster.go
+++ b/pkg/cmd/roachtest/tests/cluster_to_cluster.go
@@ -818,7 +818,7 @@ func (rd *replicationDriver) backupAfterFingerprintMismatch(
 		return nil
 	}
 	prefix := "gs"
-	if rd.c.Spec().Cloud == spec.AWS {
+	if rd.c.Cloud() == spec.AWS {
 		prefix = "s3"
 	}
 	collection := fmt.Sprintf("%s://%s/c2c-fingerprint-mismatch/%s/%s/%s?AUTH=implicit", prefix, testutils.BackupTestingBucketLongTTL(), rd.rs.name, rd.c.Name(), tenantName)

--- a/pkg/cmd/roachtest/tests/cluster_to_cluster.go
+++ b/pkg/cmd/roachtest/tests/cluster_to_cluster.go
@@ -1002,7 +1002,7 @@ func c2cRegisterWrapper(
 		allZones = append(allZones, sp.multiregion.srcLocalities...)
 		allZones = append(allZones, sp.multiregion.destLocalities...)
 		allZones = append(allZones, sp.multiregion.workloadNodeZone)
-		clusterOps = append(clusterOps, spec.Zones(strings.Join(allZones, ",")))
+		clusterOps = append(clusterOps, spec.GCEZones(strings.Join(allZones, ",")))
 		clusterOps = append(clusterOps, spec.Geo())
 	}
 
@@ -1175,7 +1175,7 @@ func registerClusterToCluster(r registry.Registry) {
 				destLocalities:   []string{"us-central1-b", "us-west1-b", "us-west1-b", "us-west1-b"},
 				workloadNodeZone: "us-west1-b",
 			},
-			clouds: registry.AllExceptAWS,
+			clouds: registry.OnlyGCE,
 			suites: registry.Suites("nightly"),
 		},
 		{

--- a/pkg/cmd/roachtest/tests/connection_latency.go
+++ b/pkg/cmd/roachtest/tests/connection_latency.go
@@ -122,8 +122,8 @@ func registerConnectionLatencyTest(r registry.Registry) {
 		Owner:     registry.OwnerSQLFoundations,
 		Benchmark: true,
 		// Add one more node for load node.
-		Cluster:          r.MakeClusterSpec(numNodes+1, spec.Zones(regionUsCentral)),
-		CompatibleClouds: registry.AllExceptAWS,
+		Cluster:          r.MakeClusterSpec(numNodes+1, spec.GCEZones(regionUsCentral)),
+		CompatibleClouds: registry.OnlyGCE,
 		Suites:           registry.Suites(registry.Nightly),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runConnectionLatencyTest(ctx, t, c, numNodes, 1, false /*password*/)
@@ -140,8 +140,8 @@ func registerConnectionLatencyTest(r registry.Registry) {
 		Name:             fmt.Sprintf("connection_latency/nodes=%d/multiregion/certs", numMultiRegionNodes),
 		Owner:            registry.OwnerSQLFoundations,
 		Benchmark:        true,
-		Cluster:          r.MakeClusterSpec(numMultiRegionNodes+loadNodes, spec.Geo(), spec.Zones(geoZonesStr)),
-		CompatibleClouds: registry.AllExceptAWS,
+		Cluster:          r.MakeClusterSpec(numMultiRegionNodes+loadNodes, spec.Geo(), spec.GCEZones(geoZonesStr)),
+		CompatibleClouds: registry.OnlyGCE,
 		Suites:           registry.Suites(registry.Nightly),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runConnectionLatencyTest(ctx, t, c, numMultiRegionNodes, numZones, false /*password*/)
@@ -152,8 +152,8 @@ func registerConnectionLatencyTest(r registry.Registry) {
 		Name:             fmt.Sprintf("connection_latency/nodes=%d/multiregion/password", numMultiRegionNodes),
 		Owner:            registry.OwnerSQLFoundations,
 		Benchmark:        true,
-		Cluster:          r.MakeClusterSpec(numMultiRegionNodes+loadNodes, spec.Geo(), spec.Zones(geoZonesStr)),
-		CompatibleClouds: registry.AllExceptAWS,
+		Cluster:          r.MakeClusterSpec(numMultiRegionNodes+loadNodes, spec.Geo(), spec.GCEZones(geoZonesStr)),
+		CompatibleClouds: registry.OnlyGCE,
 		Suites:           registry.Suites(registry.Nightly),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runConnectionLatencyTest(ctx, t, c, numMultiRegionNodes, numZones, true /*password*/)

--- a/pkg/cmd/roachtest/tests/copy.go
+++ b/pkg/cmd/roachtest/tests/copy.go
@@ -187,7 +187,7 @@ func registerCopy(r registry.Registry) {
 			Suites:           registry.Suites(registry.Nightly),
 			Leases:           registry.MetamorphicLeases,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-				if c.Spec().Cloud != spec.GCE && !c.IsLocal() {
+				if c.Cloud() != spec.GCE && !c.IsLocal() {
 					t.Skip("uses gs://cockroach-fixtures; see https://github.com/cockroachdb/cockroach/issues/105968")
 				}
 				runCopy(ctx, t, c, tc.rows, tc.txn)

--- a/pkg/cmd/roachtest/tests/decommissionbench.go
+++ b/pkg/cmd/roachtest/tests/decommissionbench.go
@@ -271,7 +271,7 @@ func registerDecommissionBenchSpec(r registry.Registry, benchSpec decommissionBe
 
 	if benchSpec.multiregion {
 		geoZones := []string{regionUsEast, regionUsWest, regionUsCentral}
-		specOptions = append(specOptions, spec.Zones(strings.Join(geoZones, ",")))
+		specOptions = append(specOptions, spec.GCEZones(strings.Join(geoZones, ",")))
 		specOptions = append(specOptions, spec.Geo())
 		extraNameParts = append(extraNameParts, "multi-region")
 	}

--- a/pkg/cmd/roachtest/tests/disagg_rebalance.go
+++ b/pkg/cmd/roachtest/tests/disagg_rebalance.go
@@ -37,7 +37,7 @@ func registerDisaggRebalance(r registry.Registry) {
 		EncryptionSupport: registry.EncryptionAlwaysDisabled,
 		Timeout:           1 * time.Hour,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-			if c.Spec().Cloud != spec.AWS {
+			if c.Cloud() != spec.AWS {
 				t.Skip("disagg-rebalance is only configured to run on AWS")
 			}
 			c.Put(ctx, t.Cockroach(), "./cockroach")

--- a/pkg/cmd/roachtest/tests/disk_stall.go
+++ b/pkg/cmd/roachtest/tests/disk_stall.go
@@ -294,7 +294,7 @@ type dmsetupDiskStaller struct {
 
 var _ diskStaller = (*dmsetupDiskStaller)(nil)
 
-func (s *dmsetupDiskStaller) device() string { return getDevice(s.t, s.c.Spec()) }
+func (s *dmsetupDiskStaller) device() string { return getDevice(s.t, s.c) }
 
 func (s *dmsetupDiskStaller) Setup(ctx context.Context) {
 	dev := s.device()
@@ -363,15 +363,15 @@ func (s *cgroupDiskStaller) Unstall(ctx context.Context, nodes option.NodeListOp
 func (s *cgroupDiskStaller) device() (major, minor int) {
 	// TODO(jackson): Programmatically determine the device major,minor numbers.
 	// eg,:
-	//    deviceName := getDevice(s.t, s.c.Spec())
+	//    deviceName := getDevice(s.t, s.c)
 	//    `cat /proc/partitions` and find `deviceName`
-	switch s.c.Spec().Cloud {
+	switch s.c.Cloud() {
 	case spec.GCE:
 		// ls -l /dev/sdb
 		// brw-rw---- 1 root disk 8, 16 Mar 27 22:08 /dev/sdb
 		return 8, 16
 	default:
-		s.t.Fatalf("unsupported cloud %q", s.c.Spec().Cloud)
+		s.t.Fatalf("unsupported cloud %q", s.c.Cloud())
 		return 0, 0
 	}
 }
@@ -389,14 +389,14 @@ func (s *cgroupDiskStaller) setThroughput(
 	))
 }
 
-func getDevice(t test.Test, s spec.ClusterSpec) string {
-	switch s.Cloud {
+func getDevice(t test.Test, c cluster.Cluster) string {
+	switch c.Cloud() {
 	case spec.GCE:
 		return "/dev/sdb"
 	case spec.AWS:
 		return "/dev/nvme1n1"
 	default:
-		t.Fatalf("unsupported cloud %q", s.Cloud)
+		t.Fatalf("unsupported cloud %q", c.Cloud())
 		return ""
 	}
 }

--- a/pkg/cmd/roachtest/tests/follower_reads.go
+++ b/pkg/cmd/roachtest/tests/follower_reads.go
@@ -62,9 +62,9 @@ func registerFollowerReads(r registry.Registry) {
 				6, /* nodeCount */
 				spec.CPU(4),
 				spec.Geo(),
-				spec.Zones("us-east1-b,us-east1-b,us-east1-b,us-west1-b,us-west1-b,europe-west2-b"),
+				spec.GCEZones("us-east1-b,us-east1-b,us-east1-b,us-west1-b,us-west1-b,europe-west2-b"),
 			),
-			CompatibleClouds: registry.AllExceptAWS,
+			CompatibleClouds: registry.OnlyGCE,
 			Suites:           registry.Suites(registry.Nightly),
 			Leases:           registry.MetamorphicLeases,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {

--- a/pkg/cmd/roachtest/tests/follower_reads.go
+++ b/pkg/cmd/roachtest/tests/follower_reads.go
@@ -68,7 +68,7 @@ func registerFollowerReads(r registry.Registry) {
 			Suites:           registry.Suites(registry.Nightly),
 			Leases:           registry.MetamorphicLeases,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-				if c.Spec().Cloud == spec.GCE && c.Spec().Arch == vm.ArchARM64 {
+				if c.Cloud() == spec.GCE && c.Spec().Arch == vm.ArchARM64 {
 					t.Skip("arm64 in GCE is available only in us-central1")
 				}
 				c.Put(ctx, t.Cockroach(), "./cockroach")

--- a/pkg/cmd/roachtest/tests/import.go
+++ b/pkg/cmd/roachtest/tests/import.go
@@ -195,8 +195,8 @@ func registerImportTPCC(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:              fmt.Sprintf("import/tpcc/warehouses=%d/geo", geoWarehouses),
 		Owner:             registry.OwnerSQLQueries,
-		Cluster:           r.MakeClusterSpec(8, spec.CPU(16), spec.Geo(), spec.Zones(geoZones)),
-		CompatibleClouds:  registry.AllExceptAWS,
+		Cluster:           r.MakeClusterSpec(8, spec.CPU(16), spec.Geo(), spec.GCEZones(geoZones)),
+		CompatibleClouds:  registry.OnlyGCE,
 		Suites:            registry.Suites(registry.Nightly),
 		Timeout:           5 * time.Hour,
 		EncryptionSupport: registry.EncryptionMetamorphic,

--- a/pkg/cmd/roachtest/tests/import.go
+++ b/pkg/cmd/roachtest/tests/import.go
@@ -95,7 +95,7 @@ func registerImportNodeShutdown(r registry.Registry) {
 		Suites:           registry.Suites(registry.Nightly),
 		Leases:           registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-			if c.Spec().Cloud != spec.GCE && !c.IsLocal() {
+			if c.Cloud() != spec.GCE && !c.IsLocal() {
 				t.Skip("uses gs://cockroach-fixtures; see https://github.com/cockroachdb/cockroach/issues/105968")
 			}
 			c.Put(ctx, t.Cockroach(), "./cockroach")
@@ -115,7 +115,7 @@ func registerImportNodeShutdown(r registry.Registry) {
 		Suites:           registry.Suites(registry.Nightly),
 		Leases:           registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-			if c.Spec().Cloud != spec.GCE && !c.IsLocal() {
+			if c.Cloud() != spec.GCE && !c.IsLocal() {
 				t.Skip("uses gs://cockroach-fixtures; see https://github.com/cockroachdb/cockroach/issues/105968")
 			}
 			c.Put(ctx, t.Cockroach(), "./cockroach")
@@ -238,7 +238,7 @@ func registerImportTPCH(r registry.Registry) {
 			EncryptionSupport: registry.EncryptionMetamorphic,
 			Leases:            registry.MetamorphicLeases,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-				if c.Spec().Cloud != spec.GCE && !c.IsLocal() {
+				if c.Cloud() != spec.GCE && !c.IsLocal() {
 					t.Skip("uses gs://cockroach-fixtures; see https://github.com/cockroachdb/cockroach/issues/105968")
 				}
 				tick, perfBuf := initBulkJobPerfArtifacts(t.Name(), item.timeout)

--- a/pkg/cmd/roachtest/tests/import_cancellation.go
+++ b/pkg/cmd/roachtest/tests/import_cancellation.go
@@ -39,7 +39,7 @@ func registerImportCancellation(r registry.Registry) {
 		Suites:           registry.Suites(registry.Nightly),
 		Leases:           registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-			if c.Spec().Cloud != spec.GCE && !c.IsLocal() {
+			if c.Cloud() != spec.GCE && !c.IsLocal() {
 				t.Skip("uses gs://cockroach-fixtures; see https://github.com/cockroachdb/cockroach/issues/105968")
 			}
 			runImportCancellation(ctx, t, c)

--- a/pkg/cmd/roachtest/tests/indexes.go
+++ b/pkg/cmd/roachtest/tests/indexes.go
@@ -28,21 +28,28 @@ import (
 
 func registerNIndexes(r registry.Registry, secondaryIndexes int) {
 	const nodes = 6
-	geoZones := []string{"us-east1-b", "us-west1-b", "europe-west2-b"}
-	if r.MakeClusterSpec(1).Cloud == spec.AWS {
-		geoZones = []string{"us-east-2b", "us-west-1a", "eu-west-1a"}
-	}
-	geoZonesStr := strings.Join(geoZones, ",")
+	gceGeoZones := []string{"us-east1-b", "us-west1-b", "europe-west2-b"}
+	awsGeoZones := []string{"us-east-2b", "us-west-1a", "eu-west-1a"}
 	r.Add(registry.TestSpec{
-		Name:             fmt.Sprintf("indexes/%d/nodes=%d/multi-region", secondaryIndexes, nodes),
-		Owner:            registry.OwnerKV,
-		Benchmark:        true,
-		Cluster:          r.MakeClusterSpec(nodes+1, spec.CPU(16), spec.Geo(), spec.Zones(geoZonesStr)),
+		Name:      fmt.Sprintf("indexes/%d/nodes=%d/multi-region", secondaryIndexes, nodes),
+		Owner:     registry.OwnerKV,
+		Benchmark: true,
+		Cluster: r.MakeClusterSpec(
+			nodes+1,
+			spec.CPU(16),
+			spec.Geo(),
+			spec.GCEZones(strings.Join(gceGeoZones, ",")),
+			spec.AWSZones(strings.Join(awsGeoZones, ",")),
+		),
+		// TODO(radu): enable this test on AWS.
 		CompatibleClouds: registry.AllExceptAWS,
 		Suites:           registry.Suites(registry.Nightly),
 		// Uses CONFIGURE ZONE USING ... COPY FROM PARENT syntax.
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-			firstAZ := geoZones[0]
+			firstAZ := gceGeoZones[0]
+			if c.Spec().Cloud == spec.AWS {
+				firstAZ = awsGeoZones[0]
+			}
 			roachNodes := c.Range(1, nodes)
 			gatewayNodes := c.Range(1, nodes/3)
 			loadNode := c.Node(nodes + 1)

--- a/pkg/cmd/roachtest/tests/indexes.go
+++ b/pkg/cmd/roachtest/tests/indexes.go
@@ -47,7 +47,7 @@ func registerNIndexes(r registry.Registry, secondaryIndexes int) {
 		// Uses CONFIGURE ZONE USING ... COPY FROM PARENT syntax.
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			firstAZ := gceGeoZones[0]
-			if c.Spec().Cloud == spec.AWS {
+			if c.Cloud() == spec.AWS {
 				firstAZ = awsGeoZones[0]
 			}
 			roachNodes := c.Range(1, nodes)

--- a/pkg/cmd/roachtest/tests/ledger.go
+++ b/pkg/cmd/roachtest/tests/ledger.go
@@ -31,8 +31,8 @@ func registerLedger(r registry.Registry) {
 		Name:             fmt.Sprintf("ledger/nodes=%d/multi-az", nodes),
 		Owner:            registry.OwnerKV,
 		Benchmark:        true,
-		Cluster:          r.MakeClusterSpec(nodes+1, spec.CPU(16), spec.Geo(), spec.Zones(azs)),
-		CompatibleClouds: registry.AllExceptAWS,
+		Cluster:          r.MakeClusterSpec(nodes+1, spec.CPU(16), spec.Geo(), spec.GCEZones(azs)),
+		CompatibleClouds: registry.OnlyGCE,
 		Suites:           registry.Suites(registry.Nightly),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			roachNodes := c.Range(1, nodes)

--- a/pkg/cmd/roachtest/tests/mixed_version_backup.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_backup.go
@@ -2154,7 +2154,7 @@ func registerBackupMixedVersion(r registry.Registry) {
 		CompatibleClouds:  registry.AllExceptAWS,
 		Suites:            registry.Suites(registry.Nightly),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-			if c.Spec().Cloud != spec.GCE && !c.IsLocal() {
+			if c.Cloud() != spec.GCE && !c.IsLocal() {
 				t.Skip("uses gs://cockroachdb-backup-testing-long-ttl; see https://github.com/cockroachdb/cockroach/issues/105968")
 			}
 

--- a/pkg/cmd/roachtest/tests/mixed_version_cdc.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_cdc.go
@@ -67,18 +67,13 @@ var (
 )
 
 func registerCDCMixedVersions(r registry.Registry) {
-	var zones string
-	if r.MakeClusterSpec(1).Cloud == spec.GCE {
-		// see rationale in definition of `teamcityAgentZone`
-		zones = teamcityAgentZone
-	}
 	r.Add(registry.TestSpec{
 		Name:  "cdc/mixed-versions",
 		Owner: registry.OwnerCDC,
 		// N.B. ARM64 is not yet supported, see https://github.com/cockroachdb/cockroach/issues/103888.
-		Cluster:          r.MakeClusterSpec(5, spec.Zones(zones), spec.Arch(vm.ArchAMD64)),
+		Cluster:          r.MakeClusterSpec(5, spec.GCEZones(teamcityAgentZone), spec.Arch(vm.ArchAMD64)),
 		Timeout:          60 * time.Minute,
-		CompatibleClouds: registry.AllExceptAWS,
+		CompatibleClouds: registry.OnlyGCE,
 		Suites:           registry.Suites(registry.Nightly),
 		RequiresLicense:  true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {

--- a/pkg/cmd/roachtest/tests/mixed_version_decl_schemachange_compat.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_decl_schemachange_compat.go
@@ -34,7 +34,7 @@ func registerDeclSchemaChangeCompatMixedVersions(r registry.Registry) {
 		CompatibleClouds: registry.AllExceptAWS,
 		Suites:           registry.Suites(registry.Nightly),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-			if c.Spec().Cloud != spec.GCE && !c.IsLocal() {
+			if c.Cloud() != spec.GCE && !c.IsLocal() {
 				t.Skip("uses gs://cockroach-corpus; see https://github.com/cockroachdb/cockroach/issues/105968")
 			}
 			runDeclSchemaChangeCompatMixedVersions(ctx, t, c, t.BuildVersion())

--- a/pkg/cmd/roachtest/tests/rebalance_load.go
+++ b/pkg/cmd/roachtest/tests/rebalance_load.go
@@ -268,17 +268,12 @@ func registerRebalanceLoad(r registry.Registry) {
 		},
 	)
 	cSpec := r.MakeClusterSpec(7, spec.SSD(2)) // the last node is just used to generate load
-	var skip string
-	if cSpec.Cloud != spec.GCE {
-		skip = fmt.Sprintf("multi-store tests are not supported on cloud %s", cSpec.Cloud)
-	}
 	r.Add(
 		registry.TestSpec{
-			Skip:             skip,
 			Name:             `rebalance/by-load/replicas/ssds=2`,
 			Owner:            registry.OwnerKV,
 			Cluster:          cSpec,
-			CompatibleClouds: registry.AllExceptAWS,
+			CompatibleClouds: registry.OnlyGCE,
 			Suites:           registry.Suites(registry.Nightly),
 			Leases:           registry.MetamorphicLeases,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {

--- a/pkg/cmd/roachtest/tests/restore.go
+++ b/pkg/cmd/roachtest/tests/restore.go
@@ -537,13 +537,13 @@ func (hw hardwareSpecs) makeClusterSpecs(r registry.Registry, backupCloud string
 	}
 	s := r.MakeClusterSpec(hw.nodes+addWorkloadNode, clusterOpts...)
 
-	if backupCloud == spec.AWS && s.Cloud == spec.AWS && s.VolumeSize != 0 {
+	if backupCloud == spec.AWS && s.VolumeSize != 0 {
 		// Work around an issue that RAID0s local NVMe and GP3 storage together:
 		// https://github.com/cockroachdb/cockroach/issues/98783.
 		//
 		// TODO(srosenberg): Remove this workaround when 98783 is addressed.
-		s.InstanceType, _ = spec.AWSMachineType(s.CPUs, s.Mem, s.PreferLocalSSD && s.VolumeSize == 0, vm.ArchAMD64)
-		s.InstanceType = strings.Replace(s.InstanceType, "d.", ".", 1)
+		s.AWS.MachineType, _ = spec.SelectAWSMachineType(s.CPUs, s.Mem, s.PreferLocalSSD && s.VolumeSize == 0, vm.ArchAMD64)
+		s.AWS.MachineType = strings.Replace(s.AWS.MachineType, "d.", ".", 1)
 		s.Arch = vm.ArchAMD64
 	}
 	return s

--- a/pkg/cmd/roachtest/tests/restore.go
+++ b/pkg/cmd/roachtest/tests/restore.go
@@ -532,11 +532,10 @@ func (hw hardwareSpecs) makeClusterSpecs(r registry.Registry, backupCloud string
 		clusterOpts = append(clusterOpts, spec.Zones(strings.Join(hw.zones, ",")))
 		clusterOpts = append(clusterOpts, spec.Geo())
 	}
-	s := r.MakeClusterSpec(hw.nodes+addWorkloadNode, clusterOpts...)
-
 	if hw.ebsThroughput != 0 {
-		s.AWSVolumeThroughput = hw.ebsThroughput
+		clusterOpts = append(clusterOpts, spec.AWSVolumeThroughput(hw.ebsThroughput))
 	}
+	s := r.MakeClusterSpec(hw.nodes+addWorkloadNode, clusterOpts...)
 
 	if backupCloud == spec.AWS && s.Cloud == spec.AWS && s.VolumeSize != 0 {
 		// Work around an issue that RAID0s local NVMe and GP3 storage together:

--- a/pkg/cmd/roachtest/tests/restore.go
+++ b/pkg/cmd/roachtest/tests/restore.go
@@ -862,7 +862,7 @@ func makeRestoreDriver(t test.Test, c cluster.Cluster, sp restoreSpecs) restoreD
 }
 
 func (rd *restoreDriver) prepareCluster(ctx context.Context) {
-	if rd.c.Spec().Cloud != rd.sp.backup.cloud {
+	if rd.c.Cloud() != rd.sp.backup.cloud {
 		// For now, only run the test on the cloud provider that also stores the backup.
 		rd.t.Skipf("test configured to run on %s", rd.sp.backup.cloud)
 	}

--- a/pkg/cmd/roachtest/tests/restore.go
+++ b/pkg/cmd/roachtest/tests/restore.go
@@ -529,7 +529,11 @@ func (hw hardwareSpecs) makeClusterSpecs(r registry.Registry, backupCloud string
 		addWorkloadNode++
 	}
 	if len(hw.zones) > 0 {
-		clusterOpts = append(clusterOpts, spec.Zones(strings.Join(hw.zones, ",")))
+		// Each test is set up to run on one specific cloud, so it's ok that the
+		// zones will only make sense for one of them.
+		// TODO(radu): clean this up.
+		clusterOpts = append(clusterOpts, spec.GCEZones(strings.Join(hw.zones, ",")))
+		clusterOpts = append(clusterOpts, spec.AWSZones(strings.Join(hw.zones, ",")))
 		clusterOpts = append(clusterOpts, spec.Geo())
 	}
 	if hw.ebsThroughput != 0 {

--- a/pkg/cmd/roachtest/tests/roachmart.go
+++ b/pkg/cmd/roachtest/tests/roachmart.go
@@ -74,8 +74,8 @@ func registerRoachmart(r registry.Registry) {
 		r.Add(registry.TestSpec{
 			Name:             fmt.Sprintf("roachmart/partition=%v", v),
 			Owner:            registry.OwnerKV,
-			Cluster:          r.MakeClusterSpec(9, spec.Geo(), spec.Zones("us-central1-b,us-west1-b,europe-west2-b")),
-			CompatibleClouds: registry.AllExceptAWS,
+			Cluster:          r.MakeClusterSpec(9, spec.Geo(), spec.GCEZones("us-central1-b,us-west1-b,europe-west2-b")),
+			CompatibleClouds: registry.OnlyGCE,
 			Suites:           registry.Suites(registry.Nightly),
 			Leases:           registry.MetamorphicLeases,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {

--- a/pkg/cmd/roachtest/tests/schemachange.go
+++ b/pkg/cmd/roachtest/tests/schemachange.go
@@ -36,7 +36,7 @@ func registerSchemaChangeDuringKV(r registry.Registry) {
 		Suites:           registry.Suites(registry.Nightly),
 		Leases:           registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-			if c.Spec().Cloud != spec.GCE && !c.IsLocal() {
+			if c.Cloud() != spec.GCE && !c.IsLocal() {
 				t.Skip("uses gs://cockroach-fixtures; see https://github.com/cockroachdb/cockroach/issues/105968")
 			}
 			const fixturePath = `gs://cockroach-fixtures/workload/tpch/scalefactor=10/backup?AUTH=implicit`

--- a/pkg/cmd/roachtest/tests/schemachange_random_load.go
+++ b/pkg/cmd/roachtest/tests/schemachange_random_load.go
@@ -15,7 +15,6 @@ import (
 	gosql "database/sql"
 	"fmt"
 	"path/filepath"
-	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
@@ -30,11 +29,6 @@ const (
 )
 
 func registerSchemaChangeRandomLoad(r registry.Registry) {
-	geoZones := []string{"us-east1-b", "us-west1-b", "europe-west2-b"}
-	if r.MakeClusterSpec(1).Cloud == spec.AWS {
-		geoZones = []string{"us-east-2b", "us-west-1a", "eu-west-1a"}
-	}
-	geoZonesStr := strings.Join(geoZones, ",")
 	r.Add(registry.TestSpec{
 		Name:      "schemachange/random-load",
 		Owner:     registry.OwnerSQLFoundations,
@@ -42,8 +36,10 @@ func registerSchemaChangeRandomLoad(r registry.Registry) {
 		Cluster: r.MakeClusterSpec(
 			3,
 			spec.Geo(),
-			spec.Zones(geoZonesStr),
+			spec.GCEZones("us-east1-b,us-west1-b,europe-west2-b"),
+			spec.AWSZones("us-east-2b,us-west-1a,eu-west-1a"),
 		),
+		// TODO(radu): enable this test on AWS.
 		CompatibleClouds: registry.AllExceptAWS,
 		Suites:           registry.Suites(registry.Nightly),
 		Leases:           registry.MetamorphicLeases,

--- a/pkg/cmd/roachtest/tests/sqlsmith.go
+++ b/pkg/cmd/roachtest/tests/sqlsmith.go
@@ -319,7 +319,7 @@ WITH into_db = 'defaultdb', unsafe_restore_incompatible_version;
 			// NB: sqlsmith failures should never block a release.
 			NonReleaseBlocker: true,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-				if c.Spec().Cloud != spec.GCE && !c.IsLocal() {
+				if c.Cloud() != spec.GCE && !c.IsLocal() {
 					t.Skip("uses gs://cockroach-fixtures; see https://github.com/cockroachdb/cockroach/issues/105968")
 				}
 				runSQLSmith(ctx, t, c, setup, setting)

--- a/pkg/cmd/roachtest/tests/tpc_utils.go
+++ b/pkg/cmd/roachtest/tests/tpc_utils.go
@@ -44,7 +44,7 @@ func loadTPCHDataset(
 	disableMergeQueue bool,
 	secure bool,
 ) (retErr error) {
-	if c.Spec().Cloud != spec.GCE && !c.IsLocal() {
+	if c.Cloud() != spec.GCE && !c.IsLocal() {
 		t.Skip("uses gs://cockroach-fixtures; see https://github.com/cockroachdb/cockroach/issues/105968")
 	}
 

--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -743,8 +743,8 @@ func registerTPCC(r registry.Registry) {
 				Name:  tc.name,
 				Owner: registry.OwnerSQLFoundations,
 				// Add an extra node which serves as the workload nodes.
-				Cluster:           r.MakeClusterSpec(len(regions)*nodesPerRegion+1, spec.Geo(), spec.Zones(strings.Join(zs, ","))),
-				CompatibleClouds:  registry.AllExceptAWS,
+				Cluster:           r.MakeClusterSpec(len(regions)*nodesPerRegion+1, spec.Geo(), spec.GCEZones(strings.Join(zs, ","))),
+				CompatibleClouds:  registry.OnlyGCE,
 				Suites:            registry.Suites(registry.Nightly),
 				EncryptionSupport: registry.EncryptionMetamorphic,
 				Leases:            registry.MetamorphicLeases,
@@ -953,7 +953,7 @@ func registerTPCC(r registry.Registry) {
 		EstimatedMaxGCE:   5000,
 		EstimatedMaxAWS:   5000,
 
-		Clouds: registry.AllExceptAWS,
+		Clouds: registry.OnlyGCE,
 		Suites: registry.Suites(registry.Nightly),
 	})
 	registerTPCCBenchSpec(r, tpccBenchSpec{
@@ -968,7 +968,7 @@ func registerTPCC(r registry.Registry) {
 		EstimatedMaxGCE:   2000,
 		EstimatedMaxAWS:   2000,
 
-		Clouds: registry.AllExceptAWS,
+		Clouds: registry.OnlyGCE,
 		Suites: registry.Suites(registry.Nightly),
 	})
 	registerTPCCBenchSpec(r, tpccBenchSpec{
@@ -1238,10 +1238,10 @@ func registerTPCCBenchSpec(r registry.Registry, b tpccBenchSpec) {
 		// No specifier.
 	case multiZone:
 		nameParts = append(nameParts, "multi-az")
-		opts = append(opts, spec.Geo(), spec.Zones(strings.Join(b.Distribution.zones(), ",")))
+		opts = append(opts, spec.Geo(), spec.GCEZones(strings.Join(b.Distribution.zones(), ",")))
 	case multiRegion:
 		nameParts = append(nameParts, "multi-region")
-		opts = append(opts, spec.Geo(), spec.Zones(strings.Join(b.Distribution.zones(), ",")))
+		opts = append(opts, spec.Geo(), spec.GCEZones(strings.Join(b.Distribution.zones(), ",")))
 	default:
 		panic("unexpected")
 	}

--- a/pkg/cmd/roachtest/tests/tpcdsvec.go
+++ b/pkg/cmd/roachtest/tests/tpcdsvec.go
@@ -193,7 +193,7 @@ WITH unsafe_restore_incompatible_version;
 		CompatibleClouds: registry.AllExceptAWS,
 		Suites:           registry.Suites(registry.Nightly),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-			if c.Spec().Cloud != spec.GCE && !c.IsLocal() {
+			if c.Cloud() != spec.GCE && !c.IsLocal() {
 				t.Skip("uses gs://cockroach-fixtures; see https://github.com/cockroachdb/cockroach/issues/105968")
 			}
 			runTPCDSVec(ctx, t, c)

--- a/pkg/cmd/roachtest/tests/ycsb.go
+++ b/pkg/cmd/roachtest/tests/ycsb.go
@@ -50,7 +50,7 @@ func registerYCSB(r registry.Registry) {
 	) {
 		// For now, we only want to run the zfs tests on GCE, since only GCE supports
 		// starting roachprod instances on zfs.
-		if c.Spec().FileSystem == spec.Zfs && c.Spec().Cloud != spec.GCE {
+		if c.Spec().FileSystem == spec.Zfs && c.Cloud() != spec.GCE {
 			t.Skip("YCSB zfs benchmark can only be run on GCE", "")
 		}
 


### PR DESCRIPTION
In this PR we fix all test registration code which was depending on the flags passed to `roachtest` (indirectly, through TestSpec). In the process, I tried to clean up various things I had to touch.

This makes progress in the direction of #104029 and of making the registry and `TestSpec` not depend at all on the flags (the flags should come in later, when we create an actual cluster from the spec).

#### roachtest: spec: simplify Option

This commit reduces boilerplate in the `Option` code by making it a
func instead of an interface with an apply func. This way each option
can define the function inline instead of having to define a type.

Epic: none
Release note: None

#### roachtest: spec: provide options for GCE/AWS settings

This commit moves GCE and AWS specific settings to their own
inline structs and adds Options for them.

Epic: none
Release note: None

#### roachtest: clean up instance type specification

`ClusterSpec` now provides options for GCE and AWS machine types.

Epic: none
Release note: None

#### roachtest: clean up zones specification

`ClusterSpec` now provides options for GCE and AWS zones
specification.

Epic: none
Release note: None

#### roachtest: stop using ClusterSpec.Cloud in test code

This change removes all remaining uses of `ClusterSpec.Cloud` except
those internal to roachtest. Code that is part of running a test now
uses `Cluster.Cloud()` instead.

Informs: #104029
Release note: None