### PR TITLE
plpgsql: add support for unnamed cursors

### DIFF
--- a/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
@@ -1381,6 +1381,13 @@ func TestTenantLogic_pgoidtype(
 	runLogicTest(t, "pgoidtype")
 }
 
+func TestTenantLogic_plpgsql_builtins(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "plpgsql_builtins")
+}
+
 func TestTenantLogic_plpgsql_cursor(
 	t *testing.T,
 ) {

--- a/pkg/sql/faketreeeval/evalctx.go
+++ b/pkg/sql/faketreeeval/evalctx.go
@@ -333,6 +333,11 @@ func (*DummyEvalPlanner) Optimizer() interface{} {
 	return nil
 }
 
+// GenUniqueCursorName is part of the eval.Planner interface.
+func (*DummyEvalPlanner) GenUniqueCursorName() tree.Name {
+	return ""
+}
+
 var _ eval.Planner = &DummyEvalPlanner{}
 
 var errEvalPlanner = pgerror.New(pgcode.ScalarOperationCannotRunWithoutFullSessionContext,

--- a/pkg/sql/logictest/testdata/logic_test/plpgsql_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/plpgsql_builtins
@@ -1,0 +1,95 @@
+# Testing crdb_internal.plpgsql_gen_cursor_name.
+query T
+SELECT crdb_internal.plpgsql_gen_cursor_name(NULL);
+----
+<unnamed portal 1>
+
+query T
+SELECT crdb_internal.plpgsql_gen_cursor_name(NULL);
+----
+<unnamed portal 2>
+
+statement ok
+BEGIN;
+DECLARE "<unnamed portal 3>" CURSOR FOR SELECT 1;
+
+query T
+SELECT name FROM pg_cursors;
+----
+<unnamed portal 3>
+
+# Skip manually generated duplicate names.
+query T
+SELECT crdb_internal.plpgsql_gen_cursor_name(NULL);
+----
+<unnamed portal 4>
+
+query T
+SELECT crdb_internal.plpgsql_gen_cursor_name(NULL);
+----
+<unnamed portal 5>
+
+statement ok
+CLOSE "<unnamed portal 3>";
+
+# Keep incrementing after a "gap" opens.
+query T
+SELECT crdb_internal.plpgsql_gen_cursor_name(NULL);
+----
+<unnamed portal 6>
+
+statement ok;
+ABORT;
+
+# Continue incrementing over transaction boundaries.
+query T
+SELECT crdb_internal.plpgsql_gen_cursor_name(NULL);
+----
+<unnamed portal 7>
+
+# If the name is already set, don't generate a new one.
+query T
+SELECT crdb_internal.plpgsql_gen_cursor_name('foo');
+----
+foo
+
+query T
+SELECT crdb_internal.plpgsql_gen_cursor_name('bar');
+----
+bar
+
+query T
+SELECT crdb_internal.plpgsql_gen_cursor_name('');
+----
+·
+
+query T
+SELECT crdb_internal.plpgsql_gen_cursor_name(NULL);
+----
+<unnamed portal 8>
+
+# Starting a new session restarts the counter.
+user testuser
+
+query T
+SELECT crdb_internal.plpgsql_gen_cursor_name(NULL);
+----
+<unnamed portal 1>
+
+query T
+SELECT crdb_internal.plpgsql_gen_cursor_name(NULL);
+----
+<unnamed portal 2>
+
+# Returning to the old session continues the old counter.
+user root
+
+query T
+SELECT crdb_internal.plpgsql_gen_cursor_name(NULL);
+----
+<unnamed portal 9>
+
+query T
+SELECT crdb_internal.plpgsql_gen_cursor_name(NULL);
+----
+<unnamed portal 10>

--- a/pkg/sql/logictest/testdata/logic_test/plpgsql_cursor
+++ b/pkg/sql/logictest/testdata/logic_test/plpgsql_cursor
@@ -138,25 +138,6 @@ FETCH FORWARD 3 FROM foo;
 ----
 1
 
-# Cursor with empty-string name.
-statement ok
-ABORT;
-CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$
-  DECLARE
-    curs STRING := '';
-  BEGIN
-    OPEN curs FOR SELECT 1;
-    RETURN 0;
-  END
-$$ LANGUAGE PLpgSQL;
-BEGIN;
-SELECT f();
-
-query I
-FETCH FORWARD 3 FROM "";
-----
-1
-
 # Multiple cursors.
 statement ok
 ABORT;
@@ -232,14 +213,28 @@ SELECT * FROM xy;
 1  2
 3  4
 
+# The empty string conflicts with the unnamed portal, which always exists.
 statement ok
 ABORT;
+CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$
+  DECLARE
+    curs STRING := '';
+  BEGIN
+    OPEN curs FOR SELECT 1;
+    RETURN 0;
+  END
+$$ LANGUAGE PLpgSQL;
+BEGIN;
+
+statement error pgcode 42P03 pq: cursor \"\" already in use
+SELECT f();
 
 # It is possible to use the OPEN statement in an implicit transaction, but the
 # cursor is closed at the end of the transaction when the statement execution
 # finishes. So, until FETCH is implemented, we can't actually read from the
 # cursor.
 statement ok
+ABORT;
 CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$
   DECLARE
     curs STRING := 'foo';
@@ -306,23 +301,6 @@ CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$
     RETURN 0;
   END
 $$ LANGUAGE PLpgSQL;
-
-statement ok
-CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$
-  DECLARE
-    curs STRING;
-  BEGIN
-    OPEN curs FOR SELECT 1;
-    RETURN 0;
-  END
-$$ LANGUAGE PLpgSQL;
-BEGIN;
-
-statement error pgcode 0A000 pq: unimplemented: opening an unnamed cursor is not yet supported
-SELECT f();
-
-statement ok
-ABORT;
 
 statement error pgcode 0A000 pq: unimplemented: opening a cursor in a routine with an exception block is not yet supported
 CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$
@@ -636,23 +614,6 @@ SELECT count(*) FROM pg_cursors;
 ----
 0
 
-# It is currently necessary to assign the cursor a name, since one is not
-# automatically generated.
-statement ok
-ABORT;
-CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$
-  DECLARE
-    curs CURSOR FOR SELECT 1;
-  BEGIN
-    OPEN curs;
-    RETURN 0;
-  END
-$$ LANGUAGE PLpgSQL;
-BEGIN;
-
-statement error pgcode 0A000 pq: unimplemented: opening an unnamed cursor is not yet supported
-SELECT f();
-
 statement ok
 ABORT;
 
@@ -691,3 +652,210 @@ CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$
     RETURN 0;
   END
 $$ LANGUAGE PLpgSQL;
+
+statement ok
+DELETE FROM xy WHERE x <> 1 AND x <> 3;
+
+# Testing unnamed cursors.
+statement ok
+DROP FUNCTION f();
+CREATE OR REPLACE FUNCTION f() RETURNS STRING AS $$
+  DECLARE
+    curs STRING;
+  BEGIN
+    OPEN curs FOR SELECT 1;
+    RETURN curs;
+  END
+$$ LANGUAGE PLpgSQL;
+
+statement ok
+BEGIN;
+
+query T rowsort
+SELECT name FROM pg_cursors;
+----
+
+query T
+SELECT f();
+----
+<unnamed portal 1>
+
+query I
+FETCH FORWARD 3 FROM "<unnamed portal 1>";
+----
+1
+
+query T rowsort
+SELECT name FROM pg_cursors;
+----
+<unnamed portal 1>
+
+query T
+SELECT f();
+----
+<unnamed portal 2>
+
+query I
+FETCH FORWARD 3 FROM "<unnamed portal 2>";
+----
+1
+
+query T
+SELECT f();
+----
+<unnamed portal 3>
+
+query I
+FETCH FORWARD 3 FROM "<unnamed portal 3>";
+----
+1
+
+query T rowsort
+SELECT name FROM pg_cursors;
+----
+<unnamed portal 1>
+<unnamed portal 2>
+<unnamed portal 3>
+
+# The generated name does not "fill in gaps".
+statement ok
+CLOSE "<unnamed portal 2>";
+CLOSE "<unnamed portal 1>";
+
+query T
+SELECT f();
+----
+<unnamed portal 4>
+
+query T
+SELECT f();
+----
+<unnamed portal 5>
+
+query T rowsort
+SELECT name FROM pg_cursors;
+----
+<unnamed portal 4>
+<unnamed portal 5>
+<unnamed portal 3>
+
+statement ok
+ABORT;
+BEGIN;
+
+query T
+SELECT f();
+----
+<unnamed portal 6>
+
+# The counter for the generated name keeps incrementing as long as the session
+# is open.
+query T rowsort
+SELECT name FROM pg_cursors;
+----
+<unnamed portal 6>
+
+# The generated name will not conflict with manually created cursors.
+statement ok
+DECLARE "<unnamed portal 7>" CURSOR FOR SELECT 1;
+DECLARE "<unnamed portal 8>" CURSOR FOR SELECT 1;
+
+query T rowsort
+SELECT name FROM pg_cursors;
+----
+<unnamed portal 7>
+<unnamed portal 8>
+<unnamed portal 6>
+
+query T
+SELECT f();
+----
+<unnamed portal 9>
+
+query T rowsort
+SELECT name FROM pg_cursors;
+----
+<unnamed portal 6>
+<unnamed portal 7>
+<unnamed portal 8>
+<unnamed portal 9>
+
+# Do not generate a new name if one was supplied.
+statement ok
+ABORT;
+CREATE OR REPLACE FUNCTION f() RETURNS STRING AS $$
+  DECLARE
+    curs STRING := 'foo';
+  BEGIN
+    OPEN curs FOR SELECT 1;
+    RETURN curs;
+  END
+$$ LANGUAGE PLpgSQL;
+BEGIN;
+
+query T rowsort
+SELECT name FROM pg_cursors;
+----
+
+query T
+SELECT f();
+----
+foo
+
+query T rowsort
+SELECT name FROM pg_cursors;
+----
+foo
+
+# The unnamed portal counter shouldn't have incremented for the named cursor,
+# since no name was generated.
+statement ok
+CREATE OR REPLACE FUNCTION f_unnamed() RETURNS STRING AS $$
+  DECLARE
+    curs STRING;
+  BEGIN
+    OPEN curs FOR SELECT 2;
+    RETURN curs;
+  END
+$$ LANGUAGE PLpgSQL;
+
+query T
+SELECT f_unnamed();
+----
+<unnamed portal 10>
+
+query T rowsort
+SELECT name FROM pg_cursors;
+----
+<unnamed portal 10>
+foo
+
+query I
+FETCH FORWARD 3 FROM "<unnamed portal 10>";
+----
+2
+
+# A bound, unnamed cursor.
+statement ok
+ABORT;
+DROP FUNCTION f();
+CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$
+  DECLARE
+    curs CURSOR FOR SELECT 100;
+  BEGIN
+    OPEN curs;
+    RETURN 0;
+  END
+$$ LANGUAGE PLpgSQL;
+BEGIN;
+
+statement ok
+SELECT f();
+
+query I
+FETCH FORWARD 3 FROM "<unnamed portal 11>";
+----
+100
+
+statement ok
+ABORT;

--- a/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
@@ -1359,6 +1359,13 @@ func TestLogic_pgoidtype(
 	runLogicTest(t, "pgoidtype")
 }
 
+func TestLogic_plpgsql_builtins(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "plpgsql_builtins")
+}
+
 func TestLogic_plpgsql_cursor(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
@@ -1359,6 +1359,13 @@ func TestLogic_pgoidtype(
 	runLogicTest(t, "pgoidtype")
 }
 
+func TestLogic_plpgsql_builtins(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "plpgsql_builtins")
+}
+
 func TestLogic_plpgsql_cursor(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist/generated_test.go
@@ -1373,6 +1373,13 @@ func TestLogic_pgoidtype(
 	runLogicTest(t, "pgoidtype")
 }
 
+func TestLogic_plpgsql_builtins(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "plpgsql_builtins")
+}
+
 func TestLogic_plpgsql_cursor(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
+++ b/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
@@ -1345,6 +1345,13 @@ func TestLogic_pgoidtype(
 	runLogicTest(t, "pgoidtype")
 }
 
+func TestLogic_plpgsql_builtins(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "plpgsql_builtins")
+}
+
 func TestLogic_plpgsql_cursor(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-mixed-22.2-23.1/generated_test.go
+++ b/pkg/sql/logictest/tests/local-mixed-22.2-23.1/generated_test.go
@@ -1338,6 +1338,13 @@ func TestLogic_pgoidtype(
 	runLogicTest(t, "pgoidtype")
 }
 
+func TestLogic_plpgsql_builtins(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "plpgsql_builtins")
+}
+
 func TestLogic_plpgsql_cursor(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/local-vec-off/generated_test.go
@@ -1373,6 +1373,13 @@ func TestLogic_pgoidtype(
 	runLogicTest(t, "pgoidtype")
 }
 
+func TestLogic_plpgsql_builtins(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "plpgsql_builtins")
+}
+
 func TestLogic_plpgsql_cursor(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local/generated_test.go
+++ b/pkg/sql/logictest/tests/local/generated_test.go
@@ -1499,6 +1499,13 @@ func TestLogic_pgoidtype(
 	runLogicTest(t, "pgoidtype")
 }
 
+func TestLogic_plpgsql_builtins(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "plpgsql_builtins")
+}
+
 func TestLogic_plpgsql_cursor(
 	t *testing.T,
 ) {

--- a/pkg/sql/opt/optbuilder/plpgsql.go
+++ b/pkg/sql/opt/optbuilder/plpgsql.go
@@ -539,6 +539,12 @@ func (b *plpgsqlBuilder) buildPLpgSQLStatements(stmts []ast.Statement, s *scope)
 				}
 				panic(err)
 			}
+			// TODO(drewk): this should check REFCURSOR.
+			if !source.(*scopeColumn).typ.Equivalent(types.String) {
+				panic(pgerror.Newf(pgcode.DatatypeMismatch,
+					"variable \"%s\" must be of type cursor or refcursor", t.CurVar,
+				))
+			}
 			// Initialize the routine with the information needed to pipe the first
 			// body statement into a cursor.
 			query := b.resolveOpenQuery(t)
@@ -558,7 +564,16 @@ func (b *plpgsqlBuilder) buildPLpgSQLStatements(stmts []ast.Statement, s *scope)
 			}
 			b.appendBodyStmt(&openCon, openScope)
 			b.appendPlpgSQLStmts(&openCon, stmts[i+1:])
-			return b.callContinuation(&openCon, s)
+
+			// Build a statement to generate a unique name for the cursor if one
+			// was not supplied. Add this to its own volatile routine to ensure that
+			// the name generation isn't reordered with other operations. Use the
+			// resulting projected column as input to the OPEN continuation.
+			nameCon := b.makeContinuation("_gen_cursor_name")
+			nameCon.def.Volatility = volatility.Volatile
+			nameScope := b.buildCursorNameGen(&nameCon, t.CurVar)
+			b.appendBodyStmt(&nameCon, b.callContinuation(&openCon, nameScope))
+			return b.callContinuation(&nameCon, s)
 
 		default:
 			panic(unimplemented.New(
@@ -607,6 +622,44 @@ func (b *plpgsqlBuilder) resolveOpenQuery(open *ast.Open) tree.Statement {
 		))
 	}
 	return stmt
+}
+
+// buildCursorNameGen builds a statement that generates a unique name for the
+// cursor if the variable containing the name is unset. The unique name
+// generation is implemented by the crdb_internal.plpgsql_gen_cursor_name
+// builtin function.
+func (b *plpgsqlBuilder) buildCursorNameGen(nameCon *continuation, nameVar ast.Variable) *scope {
+	_, source, _, _ := nameCon.s.FindSourceProvidingColumn(b.ob.ctx, nameVar)
+	const nameFnName = "crdb_internal.plpgsql_gen_cursor_name"
+	props, overloads := builtinsregistry.GetBuiltinProperties(nameFnName)
+	if len(overloads) != 1 {
+		panic(errors.AssertionFailedf("expected one overload for %s", nameFnName))
+	}
+	nameCall := b.ob.factory.ConstructFunction(
+		memo.ScalarListExpr{b.ob.factory.ConstructVariable(source.(*scopeColumn).id)},
+		&memo.FunctionPrivate{
+			Name:       nameFnName,
+			Typ:        types.String,
+			Properties: props,
+			Overload:   &overloads[0],
+		},
+	)
+	// Build an expression that calls the builtin function if the name is unset.
+	scalar := b.ob.factory.ConstructCase(memo.TrueSingleton,
+		memo.ScalarListExpr{
+			b.ob.factory.ConstructWhen(
+				b.ob.factory.ConstructIs(
+					b.ob.factory.ConstructVariable(source.(*scopeColumn).id), memo.NullSingleton,
+				),
+				nameCall,
+			),
+		},
+		b.ob.factory.ConstructVariable(source.(*scopeColumn).id),
+	)
+	nameScope := nameCon.s.push()
+	b.ob.synthesizeColumn(nameScope, scopeColName(nameVar), types.String, nil /* expr */, scalar)
+	b.ob.constructProjectForScope(nameCon.s, nameScope)
+	return nameScope
 }
 
 // addPLpgSQLAssign adds a PL/pgSQL assignment to the current scope as a

--- a/pkg/sql/opt/optbuilder/testdata/udf_plpgsql
+++ b/pkg/sql/opt/optbuilder/testdata/udf_plpgsql
@@ -4620,16 +4620,16 @@ build format=show-scalars
 SELECT f();
 ----
 project
- ├── columns: f:6
+ ├── columns: f:9
  ├── values
  │    └── tuple
  └── projections
-      └── udf: f [as=f:6]
+      └── udf: f [as=f:9]
            └── body
                 └── limit
-                     ├── columns: "_stmt_open_1":5
+                     ├── columns: "_gen_cursor_name_3":8
                      ├── project
-                     │    ├── columns: "_stmt_open_1":5
+                     │    ├── columns: "_gen_cursor_name_3":8
                      │    ├── project
                      │    │    ├── columns: curs:1!null
                      │    │    ├── values
@@ -4637,24 +4637,46 @@ project
                      │    │    └── projections
                      │    │         └── const: 'foo' [as=curs:1]
                      │    └── projections
-                     │         └── udf: _stmt_open_1 [as="_stmt_open_1":5]
+                     │         └── udf: _gen_cursor_name_3 [as="_gen_cursor_name_3":8]
                      │              ├── args
                      │              │    └── variable: curs:1
-                     │              ├── params: curs:2
+                     │              ├── params: curs:5
                      │              └── body
-                     │                   ├── open-cursor
-                     │                   │    └── project
-                     │                   │         ├── columns: "?column?":3!null
-                     │                   │         ├── values
-                     │                   │         │    └── tuple
-                     │                   │         └── projections
-                     │                   │              └── const: 1 [as="?column?":3]
                      │                   └── project
-                     │                        ├── columns: stmt_return_2:4!null
-                     │                        ├── values
-                     │                        │    └── tuple
+                     │                        ├── columns: "_stmt_open_1":7
+                     │                        ├── project
+                     │                        │    ├── columns: curs:6
+                     │                        │    ├── values
+                     │                        │    │    └── tuple
+                     │                        │    └── projections
+                     │                        │         └── case [as=curs:6]
+                     │                        │              ├── true
+                     │                        │              ├── when
+                     │                        │              │    ├── is
+                     │                        │              │    │    ├── variable: curs:5
+                     │                        │              │    │    └── null
+                     │                        │              │    └── function: crdb_internal.plpgsql_gen_cursor_name
+                     │                        │              │         └── variable: curs:5
+                     │                        │              └── variable: curs:5
                      │                        └── projections
-                     │                             └── const: 0 [as=stmt_return_2:4]
+                     │                             └── udf: _stmt_open_1 [as="_stmt_open_1":7]
+                     │                                  ├── args
+                     │                                  │    └── variable: curs:6
+                     │                                  ├── params: curs:2
+                     │                                  └── body
+                     │                                       ├── open-cursor
+                     │                                       │    └── project
+                     │                                       │         ├── columns: "?column?":3!null
+                     │                                       │         ├── values
+                     │                                       │         │    └── tuple
+                     │                                       │         └── projections
+                     │                                       │              └── const: 1 [as="?column?":3]
+                     │                                       └── project
+                     │                                            ├── columns: stmt_return_2:4!null
+                     │                                            ├── values
+                     │                                            │    └── tuple
+                     │                                            └── projections
+                     │                                                 └── const: 0 [as=stmt_return_2:4]
                      └── const: 1
 
 exec-ddl
@@ -4673,16 +4695,16 @@ build format=show-scalars
 SELECT f();
 ----
 project
- ├── columns: f:12
+ ├── columns: f:16
  ├── values
  │    └── tuple
  └── projections
-      └── udf: f [as=f:12]
+      └── udf: f [as=f:16]
            └── body
                 └── limit
-                     ├── columns: "_stmt_open_1":11
+                     ├── columns: "_gen_cursor_name_3":15
                      ├── project
-                     │    ├── columns: "_stmt_open_1":11
+                     │    ├── columns: "_gen_cursor_name_3":15
                      │    ├── project
                      │    │    ├── columns: curs:2!null i:1!null
                      │    │    ├── project
@@ -4694,29 +4716,52 @@ project
                      │    │    └── projections
                      │    │         └── const: 'foo' [as=curs:2]
                      │    └── projections
-                     │         └── udf: _stmt_open_1 [as="_stmt_open_1":11]
+                     │         └── udf: _gen_cursor_name_3 [as="_gen_cursor_name_3":15]
                      │              ├── args
                      │              │    ├── variable: i:1
                      │              │    └── variable: curs:2
-                     │              ├── params: i:3 curs:4
+                     │              ├── params: i:11 curs:12
                      │              └── body
-                     │                   ├── open-cursor
-                     │                   │    └── project
-                     │                   │         ├── columns: x:5!null y:6
-                     │                   │         └── select
-                     │                   │              ├── columns: x:5!null y:6 rowid:7!null crdb_internal_mvcc_timestamp:8 tableoid:9
-                     │                   │              ├── scan xy
-                     │                   │              │    └── columns: x:5 y:6 rowid:7!null crdb_internal_mvcc_timestamp:8 tableoid:9
-                     │                   │              └── filters
-                     │                   │                   └── eq
-                     │                   │                        ├── variable: x:5
-                     │                   │                        └── variable: i:3
                      │                   └── project
-                     │                        ├── columns: stmt_return_2:10!null
-                     │                        ├── values
-                     │                        │    └── tuple
+                     │                        ├── columns: "_stmt_open_1":14
+                     │                        ├── project
+                     │                        │    ├── columns: curs:13
+                     │                        │    ├── values
+                     │                        │    │    └── tuple
+                     │                        │    └── projections
+                     │                        │         └── case [as=curs:13]
+                     │                        │              ├── true
+                     │                        │              ├── when
+                     │                        │              │    ├── is
+                     │                        │              │    │    ├── variable: curs:12
+                     │                        │              │    │    └── null
+                     │                        │              │    └── function: crdb_internal.plpgsql_gen_cursor_name
+                     │                        │              │         └── variable: curs:12
+                     │                        │              └── variable: curs:12
                      │                        └── projections
-                     │                             └── const: 0 [as=stmt_return_2:10]
+                     │                             └── udf: _stmt_open_1 [as="_stmt_open_1":14]
+                     │                                  ├── args
+                     │                                  │    ├── variable: i:11
+                     │                                  │    └── variable: curs:13
+                     │                                  ├── params: i:3 curs:4
+                     │                                  └── body
+                     │                                       ├── open-cursor
+                     │                                       │    └── project
+                     │                                       │         ├── columns: x:5!null y:6
+                     │                                       │         └── select
+                     │                                       │              ├── columns: x:5!null y:6 rowid:7!null crdb_internal_mvcc_timestamp:8 tableoid:9
+                     │                                       │              ├── scan xy
+                     │                                       │              │    └── columns: x:5 y:6 rowid:7!null crdb_internal_mvcc_timestamp:8 tableoid:9
+                     │                                       │              └── filters
+                     │                                       │                   └── eq
+                     │                                       │                        ├── variable: x:5
+                     │                                       │                        └── variable: i:3
+                     │                                       └── project
+                     │                                            ├── columns: stmt_return_2:10!null
+                     │                                            ├── values
+                     │                                            │    └── tuple
+                     │                                            └── projections
+                     │                                                 └── const: 0 [as=stmt_return_2:10]
                      └── const: 1
 
 exec-ddl
@@ -4738,16 +4783,16 @@ build format=show-scalars
 SELECT f();
 ----
 project
- ├── columns: f:20
+ ├── columns: f:35
  ├── values
  │    └── tuple
  └── projections
-      └── udf: f [as=f:20]
+      └── udf: f [as=f:35]
            └── body
                 └── limit
-                     ├── columns: "_stmt_open_1":19
+                     ├── columns: "_gen_cursor_name_7":34
                      ├── project
-                     │    ├── columns: "_stmt_open_1":19
+                     │    ├── columns: "_gen_cursor_name_7":34
                      │    ├── project
                      │    │    ├── columns: curs3:3!null curs:1!null curs2:2!null
                      │    │    ├── project
@@ -4763,62 +4808,134 @@ project
                      │    │    └── projections
                      │    │         └── const: 'baz' [as=curs3:3]
                      │    └── projections
-                     │         └── udf: _stmt_open_1 [as="_stmt_open_1":19]
+                     │         └── udf: _gen_cursor_name_7 [as="_gen_cursor_name_7":34]
                      │              ├── args
                      │              │    ├── variable: curs:1
                      │              │    ├── variable: curs2:2
                      │              │    └── variable: curs3:3
-                     │              ├── params: curs:4 curs2:5 curs3:6
+                     │              ├── params: curs:29 curs2:30 curs3:31
                      │              └── body
-                     │                   ├── open-cursor
-                     │                   │    └── project
-                     │                   │         ├── columns: "?column?":7!null
-                     │                   │         ├── values
-                     │                   │         │    └── tuple
-                     │                   │         └── projections
-                     │                   │              └── const: 1 [as="?column?":7]
                      │                   └── project
-                     │                        ├── columns: "_stmt_open_2":18
-                     │                        ├── values
-                     │                        │    └── tuple
+                     │                        ├── columns: "_stmt_open_1":33
+                     │                        ├── project
+                     │                        │    ├── columns: curs:32
+                     │                        │    ├── values
+                     │                        │    │    └── tuple
+                     │                        │    └── projections
+                     │                        │         └── case [as=curs:32]
+                     │                        │              ├── true
+                     │                        │              ├── when
+                     │                        │              │    ├── is
+                     │                        │              │    │    ├── variable: curs:29
+                     │                        │              │    │    └── null
+                     │                        │              │    └── function: crdb_internal.plpgsql_gen_cursor_name
+                     │                        │              │         └── variable: curs:29
+                     │                        │              └── variable: curs:29
                      │                        └── projections
-                     │                             └── udf: _stmt_open_2 [as="_stmt_open_2":18]
+                     │                             └── udf: _stmt_open_1 [as="_stmt_open_1":33]
                      │                                  ├── args
-                     │                                  │    ├── variable: curs:4
-                     │                                  │    ├── variable: curs2:5
-                     │                                  │    └── variable: curs3:6
-                     │                                  ├── params: curs:8 curs2:9 curs3:10
+                     │                                  │    ├── variable: curs:32
+                     │                                  │    ├── variable: curs2:30
+                     │                                  │    └── variable: curs3:31
+                     │                                  ├── params: curs:4 curs2:5 curs3:6
                      │                                  └── body
                      │                                       ├── open-cursor
                      │                                       │    └── project
-                     │                                       │         ├── columns: "?column?":11!null
+                     │                                       │         ├── columns: "?column?":7!null
                      │                                       │         ├── values
                      │                                       │         │    └── tuple
                      │                                       │         └── projections
-                     │                                       │              └── const: 2 [as="?column?":11]
+                     │                                       │              └── const: 1 [as="?column?":7]
                      │                                       └── project
-                     │                                            ├── columns: "_stmt_open_3":17
+                     │                                            ├── columns: "_gen_cursor_name_6":28
                      │                                            ├── values
                      │                                            │    └── tuple
                      │                                            └── projections
-                     │                                                 └── udf: _stmt_open_3 [as="_stmt_open_3":17]
+                     │                                                 └── udf: _gen_cursor_name_6 [as="_gen_cursor_name_6":28]
                      │                                                      ├── args
-                     │                                                      │    ├── variable: curs:8
-                     │                                                      │    ├── variable: curs2:9
-                     │                                                      │    └── variable: curs3:10
-                     │                                                      ├── params: curs:12 curs2:13 curs3:14
+                     │                                                      │    ├── variable: curs:4
+                     │                                                      │    ├── variable: curs2:5
+                     │                                                      │    └── variable: curs3:6
+                     │                                                      ├── params: curs:23 curs2:24 curs3:25
                      │                                                      └── body
-                     │                                                           ├── open-cursor
-                     │                                                           │    └── project
-                     │                                                           │         ├── columns: "?column?":15!null
-                     │                                                           │         ├── values
-                     │                                                           │         │    └── tuple
-                     │                                                           │         └── projections
-                     │                                                           │              └── const: 3 [as="?column?":15]
                      │                                                           └── project
-                     │                                                                ├── columns: stmt_return_4:16!null
-                     │                                                                ├── values
-                     │                                                                │    └── tuple
+                     │                                                                ├── columns: "_stmt_open_2":27
+                     │                                                                ├── project
+                     │                                                                │    ├── columns: curs2:26
+                     │                                                                │    ├── values
+                     │                                                                │    │    └── tuple
+                     │                                                                │    └── projections
+                     │                                                                │         └── case [as=curs2:26]
+                     │                                                                │              ├── true
+                     │                                                                │              ├── when
+                     │                                                                │              │    ├── is
+                     │                                                                │              │    │    ├── variable: curs2:24
+                     │                                                                │              │    │    └── null
+                     │                                                                │              │    └── function: crdb_internal.plpgsql_gen_cursor_name
+                     │                                                                │              │         └── variable: curs2:24
+                     │                                                                │              └── variable: curs2:24
                      │                                                                └── projections
-                     │                                                                     └── const: 0 [as=stmt_return_4:16]
+                     │                                                                     └── udf: _stmt_open_2 [as="_stmt_open_2":27]
+                     │                                                                          ├── args
+                     │                                                                          │    ├── variable: curs:23
+                     │                                                                          │    ├── variable: curs2:26
+                     │                                                                          │    └── variable: curs3:25
+                     │                                                                          ├── params: curs:8 curs2:9 curs3:10
+                     │                                                                          └── body
+                     │                                                                               ├── open-cursor
+                     │                                                                               │    └── project
+                     │                                                                               │         ├── columns: "?column?":11!null
+                     │                                                                               │         ├── values
+                     │                                                                               │         │    └── tuple
+                     │                                                                               │         └── projections
+                     │                                                                               │              └── const: 2 [as="?column?":11]
+                     │                                                                               └── project
+                     │                                                                                    ├── columns: "_gen_cursor_name_5":22
+                     │                                                                                    ├── values
+                     │                                                                                    │    └── tuple
+                     │                                                                                    └── projections
+                     │                                                                                         └── udf: _gen_cursor_name_5 [as="_gen_cursor_name_5":22]
+                     │                                                                                              ├── args
+                     │                                                                                              │    ├── variable: curs:8
+                     │                                                                                              │    ├── variable: curs2:9
+                     │                                                                                              │    └── variable: curs3:10
+                     │                                                                                              ├── params: curs:17 curs2:18 curs3:19
+                     │                                                                                              └── body
+                     │                                                                                                   └── project
+                     │                                                                                                        ├── columns: "_stmt_open_3":21
+                     │                                                                                                        ├── project
+                     │                                                                                                        │    ├── columns: curs3:20
+                     │                                                                                                        │    ├── values
+                     │                                                                                                        │    │    └── tuple
+                     │                                                                                                        │    └── projections
+                     │                                                                                                        │         └── case [as=curs3:20]
+                     │                                                                                                        │              ├── true
+                     │                                                                                                        │              ├── when
+                     │                                                                                                        │              │    ├── is
+                     │                                                                                                        │              │    │    ├── variable: curs3:19
+                     │                                                                                                        │              │    │    └── null
+                     │                                                                                                        │              │    └── function: crdb_internal.plpgsql_gen_cursor_name
+                     │                                                                                                        │              │         └── variable: curs3:19
+                     │                                                                                                        │              └── variable: curs3:19
+                     │                                                                                                        └── projections
+                     │                                                                                                             └── udf: _stmt_open_3 [as="_stmt_open_3":21]
+                     │                                                                                                                  ├── args
+                     │                                                                                                                  │    ├── variable: curs:17
+                     │                                                                                                                  │    ├── variable: curs2:18
+                     │                                                                                                                  │    └── variable: curs3:20
+                     │                                                                                                                  ├── params: curs:12 curs2:13 curs3:14
+                     │                                                                                                                  └── body
+                     │                                                                                                                       ├── open-cursor
+                     │                                                                                                                       │    └── project
+                     │                                                                                                                       │         ├── columns: "?column?":15!null
+                     │                                                                                                                       │         ├── values
+                     │                                                                                                                       │         │    └── tuple
+                     │                                                                                                                       │         └── projections
+                     │                                                                                                                       │              └── const: 3 [as="?column?":15]
+                     │                                                                                                                       └── project
+                     │                                                                                                                            ├── columns: stmt_return_4:16!null
+                     │                                                                                                                            ├── values
+                     │                                                                                                                            │    └── tuple
+                     │                                                                                                                            └── projections
+                     │                                                                                                                                 └── const: 0 [as=stmt_return_4:16]
                      └── const: 1

--- a/pkg/sql/routine.go
+++ b/pkg/sql/routine.go
@@ -24,7 +24,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util"
-	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
@@ -383,16 +382,20 @@ func (g *routineGenerator) newCursorHelper(plan *planComponents) (*plpgsqlCursor
 		panic(errors.AssertionFailedf("unexpected name argument index: %d", open.NameArgIdx))
 	}
 	if g.args[open.NameArgIdx] == tree.DNull {
-		return nil, unimplemented.New("unnamed cursor",
-			"opening an unnamed cursor is not yet supported",
-		)
+		return nil, errors.AssertionFailedf("expected non-null cursor name")
+	}
+	cursorName := tree.Name(tree.MustBeDString(g.args[open.NameArgIdx]))
+	if cursorName == "" {
+		// Specifying the empty string as a cursor name conflicts with the
+		// "unnamed" portal, which always exists.
+		return nil, pgerror.Newf(pgcode.DuplicateCursor, "cursor \"\" already in use")
 	}
 	// Use context.Background(), since the cursor can outlive the context in which
 	// it was created.
 	planCols := plan.main.planColumns()
 	cursorHelper := &plpgsqlCursorHelper{
 		ctx:        context.Background(),
-		cursorName: tree.Name(tree.MustBeDString(g.args[open.NameArgIdx])),
+		cursorName: cursorName,
 		resultCols: make(colinfo.ResultColumns, len(planCols)),
 	}
 	copy(cursorHelper.resultCols, planCols)

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -8442,6 +8442,27 @@ specified store on the node it's run from. One of 'mvccGC', 'merge', 'split',
 			Volatility: volatility.Immutable,
 		},
 	),
+	"crdb_internal.plpgsql_gen_cursor_name": makeBuiltin(tree.FunctionProperties{
+		Category:     builtinconstants.CategoryIDGeneration,
+		Undocumented: true,
+	},
+		tree.Overload{
+			Types: tree.ParamTypes{
+				{Name: "name", Typ: types.String},
+			},
+			ReturnType: tree.FixedReturnType(types.String),
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				if args[0] == tree.DNull {
+					name := evalCtx.Planner.GenUniqueCursorName()
+					return tree.NewDString(string(name)), nil
+				}
+				return args[0], nil
+			},
+			Info:              "This function is used internally to generate unique names for PLpgSQL cursors.",
+			Volatility:        volatility.Volatile,
+			CalledOnNullInput: true,
+		},
+	),
 }
 
 var lengthImpls = func(incBitOverload bool) builtinDefinition {

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -2463,6 +2463,7 @@ var builtinOidsArray = []string{
 	2492: `make_timestamptz(year: int, month: int, day: int, hour: int, min: int, sec: float, timezone: string) -> timestamptz`,
 	2493: `date_trunc(element: string, input: timestamptz, timezone: string) -> timestamptz`,
 	2494: `make_date(year: int, month: int, day: int) -> date`,
+	2495: `crdb_internal.plpgsql_gen_cursor_name(name: string) -> string`,
 }
 
 var builtinOidsBySignature map[string]oid.Oid

--- a/pkg/sql/sem/eval/deps.go
+++ b/pkg/sql/sem/eval/deps.go
@@ -410,6 +410,11 @@ type Planner interface {
 
 	// Optimizer returns the optimizer associated with this Planner, if any.
 	Optimizer() interface{}
+
+	// GenUniqueCursorName returns a name that is guaranteed to be unique among
+	// the current list of cursors and portals. It is used to implement PLpgSQL
+	// OPEN statements when used with an unnamed cursor.
+	GenUniqueCursorName() tree.Name
 }
 
 // InternalRows is an iterator interface that's exposed by the internal

--- a/pkg/sql/sql_cursor.go
+++ b/pkg/sql/sql_cursor.go
@@ -12,6 +12,7 @@ package sql
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/kv"
@@ -267,6 +268,11 @@ func (p *planner) CloseCursor(ctx context.Context, n *tree.CloseCursor) (planNod
 	}, nil
 }
 
+// GenUniqueCursorName implements the eval.Planner interface.
+func (p *planner) GenUniqueCursorName() tree.Name {
+	return p.sqlCursors.genUniqueName()
+}
+
 type sqlCursor struct {
 	isql.Rows
 	// txn is the transaction object that the internal executor for this cursor
@@ -307,6 +313,9 @@ type sqlCursors interface {
 	addCursor(tree.Name, *sqlCursor) error
 	// list returns all open cursors in the set.
 	list() map[tree.Name]*sqlCursor
+	// genUniqueName is used to generate a name for an unnamed PLpgSQL cursor that
+	// will not conflict with other cursors currently defined on the session.
+	genUniqueName() tree.Name
 }
 
 // emptySqlCursors is the default impl used by the planner when the
@@ -335,9 +344,16 @@ func (e emptySqlCursors) list() map[tree.Name]*sqlCursor {
 	return nil
 }
 
+func (e emptySqlCursors) genUniqueName() tree.Name {
+	return ""
+}
+
 // cursorMap is a sqlCursors that's backed by an actual map.
 type cursorMap struct {
 	cursors map[tree.Name]*sqlCursor
+	// nameCounter is used to help generate unique names for unnamed PLpgSQL
+	// cursors.
+	nameCounter int
 }
 
 func (c *cursorMap) closeAll(errorOnWithHold bool) error {
@@ -382,6 +398,17 @@ func (c *cursorMap) list() map[tree.Name]*sqlCursor {
 	return c.cursors
 }
 
+func (c *cursorMap) genUniqueName() tree.Name {
+	for {
+		c.nameCounter++
+		name := tree.Name(fmt.Sprintf("<unnamed portal %d>", c.nameCounter))
+		if _, ok := c.cursors[name]; !ok {
+			// This name is unique.
+			return name
+		}
+	}
+}
+
 // connExCursorAccessor is a sqlCursors that delegates to a connExecutor's
 // extraTxnState.
 type connExCursorAccessor struct {
@@ -406,6 +433,10 @@ func (c connExCursorAccessor) addCursor(s tree.Name, cursor *sqlCursor) error {
 
 func (c connExCursorAccessor) list() map[tree.Name]*sqlCursor {
 	return c.ex.extraTxnState.sqlCursors.list()
+}
+
+func (c connExCursorAccessor) genUniqueName() tree.Name {
+	return c.ex.extraTxnState.sqlCursors.genUniqueName()
 }
 
 // checkNoConflictingCursors returns an error if the input schema changing


### PR DESCRIPTION
#### plpgsql: add builtin to generate unique cursor names

This patch adds a builtin function `crdb_internal.plpgsql_gen_cursor_name`
that generates a unique name for a PLpgSQL cursor if the supplied name
is NULL. It then returns the resulting name to be used when opening
a cursor. This will be used in a following commit to implement unnamed
PLpgSQL cursors.

Informs #109709

Release note: None

#### plpgsql: add support for unnamed cursors

This patch adds support for opening an "unnamed" cursor in a PLpgSQL
routine. A PLpgSQL cursor is unnamed when the value for the cursor
variable is `NULL`. When an unnamed cursor is opened, a name will be
generated for it like `<unnamed portal 1>` that is guaranteed not to
conflict with an existing cursor or portal name. The PLpgSQL variable
that represents the cursor's name is updated to reflect the generated
name.

Informs #109709

Release note (sql change): Added support for unnamed PLpgSQL cursors,
which generate a unique name when no cursor name was specified.