### PR TITLE
plpgsql: implement CLOSE statements

### DIFF
--- a/pkg/sql/faketreeeval/evalctx.go
+++ b/pkg/sql/faketreeeval/evalctx.go
@@ -338,6 +338,11 @@ func (*DummyEvalPlanner) GenUniqueCursorName() tree.Name {
 	return ""
 }
 
+// PLpgSQLCloseCursor is part of the eval.Planner interface.
+func (*DummyEvalPlanner) PLpgSQLCloseCursor(_ tree.Name) error {
+	return errors.WithStack(errEvalPlanner)
+}
+
 var _ eval.Planner = &DummyEvalPlanner{}
 
 var errEvalPlanner = pgerror.New(pgcode.ScalarOperationCannotRunWithoutFullSessionContext,

--- a/pkg/sql/logictest/testdata/logic_test/plpgsql_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/plpgsql_builtins
@@ -93,3 +93,26 @@ query T
 SELECT crdb_internal.plpgsql_gen_cursor_name(NULL);
 ----
 <unnamed portal 10>
+
+# Testing crdb_internal.plpgsql_close.
+statement ok
+BEGIN;
+DECLARE foo CURSOR FOR SELECT generate_series(1, 5);
+
+query T
+SELECT name FROM pg_cursors;
+----
+foo
+
+statement ok
+SELECT crdb_internal.plpgsql_close('foo');
+
+query T
+SELECT name FROM pg_cursors;
+----
+
+statement ok
+ABORT;
+
+statement error pgcode 34000 pq: cursor \"foo\" does not exist
+SELECT crdb_internal.plpgsql_close('foo');

--- a/pkg/sql/logictest/testdata/logic_test/plpgsql_cursor
+++ b/pkg/sql/logictest/testdata/logic_test/plpgsql_cursor
@@ -857,5 +857,98 @@ FETCH FORWARD 3 FROM "<unnamed portal 11>";
 ----
 100
 
+# Testing CLOSE statements.
+#
+# Test CLOSE within the scope of a routine.
 statement ok
 ABORT;
+DROP FUNCTION f();
+CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$
+  DECLARE
+    curs STRING := 'foo';
+    curs2 STRING := 'bar';
+  BEGIN
+    RAISE NOTICE 'cursors: %', (SELECT count(*) FROM pg_cursors);
+    OPEN curs FOR SELECT 1;
+    RAISE NOTICE 'cursors: %', (SELECT count(*) FROM pg_cursors);
+    OPEN curs2 FOR SELECT 2;
+    RAISE NOTICE 'cursors: %', (SELECT count(*) FROM pg_cursors);
+    CLOSE curs;
+    RAISE NOTICE 'cursors: %', (SELECT count(*) FROM pg_cursors);
+    OPEN curs FOR SELECT 3;
+    RAISE NOTICE 'cursors: %', (SELECT count(*) FROM pg_cursors);
+    CLOSE curs;
+    CLOSE curs2;
+    RAISE NOTICE 'cursors: %', (SELECT count(*) FROM pg_cursors);
+    RETURN 0;
+  END
+$$ LANGUAGE PLpgSQL;
+
+query T noticetrace
+SELECT f();
+----
+NOTICE: cursors: 0
+NOTICE: cursors: 1
+NOTICE: cursors: 2
+NOTICE: cursors: 1
+NOTICE: cursors: 2
+NOTICE: cursors: 0
+
+# Test CLOSE across statement boundaries.
+statement ok
+CREATE OR REPLACE FUNCTION f(curs STRING) RETURNS INT AS $$
+  BEGIN
+    CLOSE curs;
+    RETURN 0;
+  END
+$$ LANGUAGE PLpgSQL;
+
+statement ok
+BEGIN;
+
+statement ok
+DECLARE foo CURSOR FOR SELECT 1;
+
+query T
+SELECT name FROM pg_cursors;
+----
+foo
+
+statement ok
+SELECT f('foo');
+
+query T
+SELECT name FROM pg_cursors;
+----
+
+statement ok
+DECLARE foo CURSOR FOR SELECT 1;
+DECLARE bar CURSOR FOR SELECT 2;
+
+query T rowsort
+SELECT name FROM pg_cursors;
+----
+foo
+bar
+
+statement ok
+SELECT f('bar');
+
+query T
+SELECT name FROM pg_cursors;
+----
+foo
+
+statement ok
+SELECT f('foo');
+
+query T
+SELECT name FROM pg_cursors;
+----
+
+statement ok
+ABORT;
+
+# Test attempting to CLOSE a nonexistent cursor.
+statement error pgcode 34000 pq: cursor \"foo\" does not exist
+SELECT f('foo');

--- a/pkg/sql/opt/optbuilder/testdata/udf_plpgsql
+++ b/pkg/sql/opt/optbuilder/testdata/udf_plpgsql
@@ -4939,3 +4939,173 @@ project
                      │                                                                                                                            └── projections
                      │                                                                                                                                 └── const: 0 [as=stmt_return_4:16]
                      └── const: 1
+
+# Testing CLOSE statement.
+exec-ddl
+CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$
+  DECLARE
+    curs STRING := 'foo';
+  BEGIN
+    OPEN curs FOR SELECT 1;
+    CLOSE curs;
+    RETURN 0;
+  END
+$$ LANGUAGE PLpgSQL;
+----
+
+build format=show-all
+SELECT f();
+----
+project
+ ├── columns: f:12(int)
+ ├── cardinality: [1 - 1]
+ ├── volatile
+ ├── stats: [rows=1]
+ ├── cost: 0.05
+ ├── key: ()
+ ├── fd: ()-->(12)
+ ├── prune: (12)
+ ├── values
+ │    ├── cardinality: [1 - 1]
+ │    ├── stats: [rows=1]
+ │    ├── cost: 0.02
+ │    ├── key: ()
+ │    └── tuple [type=tuple]
+ └── projections
+      └── udf: f [as=f:12, type=int, volatile, udf]
+           └── body
+                └── limit
+                     ├── columns: "_gen_cursor_name_5":11(int)
+                     ├── cardinality: [1 - 1]
+                     ├── volatile
+                     ├── stats: [rows=1]
+                     ├── key: ()
+                     ├── fd: ()-->(11)
+                     ├── project
+                     │    ├── columns: "_gen_cursor_name_5":11(int)
+                     │    ├── cardinality: [1 - 1]
+                     │    ├── volatile
+                     │    ├── stats: [rows=1]
+                     │    ├── key: ()
+                     │    ├── fd: ()-->(11)
+                     │    ├── project
+                     │    │    ├── columns: curs:1(string!null)
+                     │    │    ├── cardinality: [1 - 1]
+                     │    │    ├── stats: [rows=1]
+                     │    │    ├── key: ()
+                     │    │    ├── fd: ()-->(1)
+                     │    │    ├── prune: (1)
+                     │    │    ├── values
+                     │    │    │    ├── cardinality: [1 - 1]
+                     │    │    │    ├── stats: [rows=1]
+                     │    │    │    ├── key: ()
+                     │    │    │    └── tuple [type=tuple]
+                     │    │    └── projections
+                     │    │         └── const: 'foo' [as=curs:1, type=string]
+                     │    └── projections
+                     │         └── udf: _gen_cursor_name_5 [as="_gen_cursor_name_5":11, type=int, outer=(1), volatile, udf]
+                     │              ├── args
+                     │              │    └── variable: curs:1 [type=string]
+                     │              ├── params: curs:8(string)
+                     │              └── body
+                     │                   └── project
+                     │                        ├── columns: "_stmt_open_1":10(int)
+                     │                        ├── outer: (8)
+                     │                        ├── cardinality: [1 - 1]
+                     │                        ├── volatile
+                     │                        ├── stats: [rows=1]
+                     │                        ├── key: ()
+                     │                        ├── fd: ()-->(10)
+                     │                        ├── project
+                     │                        │    ├── columns: curs:9(string)
+                     │                        │    ├── outer: (8)
+                     │                        │    ├── cardinality: [1 - 1]
+                     │                        │    ├── volatile
+                     │                        │    ├── stats: [rows=1]
+                     │                        │    ├── key: ()
+                     │                        │    ├── fd: ()-->(9)
+                     │                        │    ├── prune: (9)
+                     │                        │    ├── values
+                     │                        │    │    ├── cardinality: [1 - 1]
+                     │                        │    │    ├── stats: [rows=1]
+                     │                        │    │    ├── key: ()
+                     │                        │    │    └── tuple [type=tuple]
+                     │                        │    └── projections
+                     │                        │         └── case [as=curs:9, type=string, outer=(8), volatile]
+                     │                        │              ├── true [type=bool]
+                     │                        │              ├── when [type=string]
+                     │                        │              │    ├── is [type=bool]
+                     │                        │              │    │    ├── variable: curs:8 [type=string]
+                     │                        │              │    │    └── null [type=unknown]
+                     │                        │              │    └── function: crdb_internal.plpgsql_gen_cursor_name [type=string]
+                     │                        │              │         └── variable: curs:8 [type=string]
+                     │                        │              └── variable: curs:8 [type=string]
+                     │                        └── projections
+                     │                             └── udf: _stmt_open_1 [as="_stmt_open_1":10, type=int, outer=(9), volatile, udf]
+                     │                                  ├── args
+                     │                                  │    └── variable: curs:9 [type=string]
+                     │                                  ├── params: curs:2(string)
+                     │                                  └── body
+                     │                                       ├── open-cursor
+                     │                                       │    └── project
+                     │                                       │         ├── columns: "?column?":3(int!null)
+                     │                                       │         ├── cardinality: [1 - 1]
+                     │                                       │         ├── stats: [rows=1]
+                     │                                       │         ├── key: ()
+                     │                                       │         ├── fd: ()-->(3)
+                     │                                       │         ├── values
+                     │                                       │         │    ├── cardinality: [1 - 1]
+                     │                                       │         │    ├── stats: [rows=1]
+                     │                                       │         │    ├── key: ()
+                     │                                       │         │    └── tuple [type=tuple]
+                     │                                       │         └── projections
+                     │                                       │              └── const: 1 [as="?column?":3, type=int]
+                     │                                       └── project
+                     │                                            ├── columns: "_stmt_close_2":7(int)
+                     │                                            ├── outer: (2)
+                     │                                            ├── cardinality: [1 - 1]
+                     │                                            ├── volatile
+                     │                                            ├── stats: [rows=1]
+                     │                                            ├── key: ()
+                     │                                            ├── fd: ()-->(7)
+                     │                                            ├── values
+                     │                                            │    ├── cardinality: [1 - 1]
+                     │                                            │    ├── stats: [rows=1]
+                     │                                            │    ├── key: ()
+                     │                                            │    └── tuple [type=tuple]
+                     │                                            └── projections
+                     │                                                 └── udf: _stmt_close_2 [as="_stmt_close_2":7, type=int, outer=(2), volatile, udf]
+                     │                                                      ├── args
+                     │                                                      │    └── variable: curs:2 [type=string]
+                     │                                                      ├── params: curs:4(string)
+                     │                                                      └── body
+                     │                                                           ├── project
+                     │                                                           │    ├── columns: stmt_close_3:5(int)
+                     │                                                           │    ├── outer: (4)
+                     │                                                           │    ├── cardinality: [1 - 1]
+                     │                                                           │    ├── volatile
+                     │                                                           │    ├── stats: [rows=1]
+                     │                                                           │    ├── key: ()
+                     │                                                           │    ├── fd: ()-->(5)
+                     │                                                           │    ├── values
+                     │                                                           │    │    ├── cardinality: [1 - 1]
+                     │                                                           │    │    ├── stats: [rows=1]
+                     │                                                           │    │    ├── key: ()
+                     │                                                           │    │    └── tuple [type=tuple]
+                     │                                                           │    └── projections
+                     │                                                           │         └── function: crdb_internal.plpgsql_close [as=stmt_close_3:5, type=int, outer=(4), volatile]
+                     │                                                           │              └── variable: curs:4 [type=string]
+                     │                                                           └── project
+                     │                                                                ├── columns: stmt_return_4:6(int!null)
+                     │                                                                ├── cardinality: [1 - 1]
+                     │                                                                ├── stats: [rows=1]
+                     │                                                                ├── key: ()
+                     │                                                                ├── fd: ()-->(6)
+                     │                                                                ├── values
+                     │                                                                │    ├── cardinality: [1 - 1]
+                     │                                                                │    ├── stats: [rows=1]
+                     │                                                                │    ├── key: ()
+                     │                                                                │    └── tuple [type=tuple]
+                     │                                                                └── projections
+                     │                                                                     └── const: 0 [as=stmt_return_4:6, type=int]
+                     └── const: 1 [type=int]

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -8463,6 +8463,24 @@ specified store on the node it's run from. One of 'mvccGC', 'merge', 'split',
 			CalledOnNullInput: true,
 		},
 	),
+	"crdb_internal.plpgsql_close": makeBuiltin(tree.FunctionProperties{
+		Category:     builtinconstants.CategoryString,
+		Undocumented: true,
+	},
+		tree.Overload{
+			Types:      tree.ParamTypes{{Name: "name", Typ: types.String}},
+			ReturnType: tree.FixedReturnType(types.Int),
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				if args[0] == tree.DNull {
+					return nil, errors.AssertionFailedf("expected non-null argument for plpgsql_close")
+				}
+				return tree.DNull, evalCtx.Planner.PLpgSQLCloseCursor(tree.Name(tree.MustBeDString(args[0])))
+			},
+			Info:              "This function is used internally to implement the PLpgSQL CLOSE statement.",
+			Volatility:        volatility.Volatile,
+			CalledOnNullInput: true,
+		},
+	),
 }
 
 var lengthImpls = func(incBitOverload bool) builtinDefinition {

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -2464,6 +2464,7 @@ var builtinOidsArray = []string{
 	2493: `date_trunc(element: string, input: timestamptz, timezone: string) -> timestamptz`,
 	2494: `make_date(year: int, month: int, day: int) -> date`,
 	2495: `crdb_internal.plpgsql_gen_cursor_name(name: string) -> string`,
+	2496: `crdb_internal.plpgsql_close(name: string) -> int`,
 }
 
 var builtinOidsBySignature map[string]oid.Oid

--- a/pkg/sql/sem/eval/deps.go
+++ b/pkg/sql/sem/eval/deps.go
@@ -415,6 +415,11 @@ type Planner interface {
 	// the current list of cursors and portals. It is used to implement PLpgSQL
 	// OPEN statements when used with an unnamed cursor.
 	GenUniqueCursorName() tree.Name
+
+	// PLpgSQLCloseCursor closes the cursor with the given name, returning an
+	// error if the cursor doesn't exist. It is used to implement the PLpgSQL
+	// CLOSE statement.
+	PLpgSQLCloseCursor(cursorName tree.Name) error
 }
 
 // InternalRows is an iterator interface that's exposed by the internal

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -2052,7 +2052,8 @@ func (e *MultipleResultsError) Error() string {
 func (expr *FuncExpr) MaybeWrapError(err error) error {
 	// If we are facing an explicit error, propagate it unchanged.
 	fName := expr.Func.String()
-	if fName == `crdb_internal.force_error` || fName == `crdb_internal.plpgsql_raise` {
+	if fName == `crdb_internal.force_error` || fName == `crdb_internal.plpgsql_raise` ||
+		fName == `crdb_internal.plpgsql_close` {
 		return err
 	}
 	// Otherwise, wrap it with context.

--- a/pkg/sql/sql_cursor.go
+++ b/pkg/sql/sql_cursor.go
@@ -273,6 +273,11 @@ func (p *planner) GenUniqueCursorName() tree.Name {
 	return p.sqlCursors.genUniqueName()
 }
 
+// PLpgSQLCloseCursor implements the eval.Planner interface.
+func (p *planner) PLpgSQLCloseCursor(cursorName tree.Name) error {
+	return p.sqlCursors.closeCursor(cursorName)
+}
+
 type sqlCursor struct {
 	isql.Rows
 	// txn is the transaction object that the internal executor for this cursor


### PR DESCRIPTION
#### plpgsql: add builtin function for closing cursors

This patch adds the `crdb_internal.plpgsql_close` builtin, which closes
the cursor with the given name. It returns a `34000` error if there is
no cursor with the given name. A following commit will use this to
implement the PLpgSQL CLOSE statement.

Informs #109709

Release note: None

#### plpgsql: implement CLOSE statements

This patch implements the PLpgSQL CLOSE statement, which allows a
PLpgSQL routine to close a cursor with the name specified by a cursor
variable. Closing the cursor is handled by the internal builtin function
`crdb_internal.plpgsql_close`.

Informs #109709

Release note (sql change): Added support for the PLpgSQL CLOSE statement.