### PR TITLE
roachprod-microbench: update error tolerance

### DIFF
--- a/pkg/cmd/roachprod-microbench/executor.go
+++ b/pkg/cmd/roachprod-microbench/executor.go
@@ -439,11 +439,7 @@ func (e *executor) executeBenchmarks() error {
 
 	e.log.Printf("Completed benchmarks, results located at %s", e.outputDir)
 	if errorCount != 0 {
-		if e.lenient {
-			e.log.Printf("Ignoring errors in benchmark results (lenient flag was set)")
-		} else {
-			return errors.Newf("Found %d errors during remote execution", errorCount)
-		}
+		return errors.Newf("Found %d errors during remote execution", errorCount)
 	}
 	return nil
 }

--- a/pkg/cmd/roachprod-microbench/main.go
+++ b/pkg/cmd/roachprod-microbench/main.go
@@ -92,7 +92,7 @@ func makeRunCommand() *cobra.Command {
 	cmd.Flags().StringSliceVar(&config.excludeList, "exclude", []string{}, "comma-separated regex of packages and benchmarks to exclude e.g. 'pkg/util/.*:BenchmarkIntPool,pkg/sql:.*'")
 	cmd.Flags().IntVar(&config.iterations, "iterations", config.iterations, "number of iterations to run each benchmark")
 	cmd.Flags().BoolVar(&config.copyBinaries, "copy", config.copyBinaries, "copy and extract test binaries and libraries to the target cluster")
-	cmd.Flags().BoolVar(&config.lenient, "lenient", config.lenient, "tolerate errors in the benchmark results")
+	cmd.Flags().BoolVar(&config.lenient, "lenient", config.lenient, "tolerate errors while running benchmarks")
 	cmd.Flags().BoolVar(&config.affinity, "affinity", config.affinity, "run benchmarks with iterations and binaries having affinity to the same node, only applies when more than one archive is specified")
 	cmd.Flags().BoolVar(&config.quiet, "quiet", config.quiet, "suppress roachprod progress output")
 


### PR DESCRIPTION
Previously the `lenient` flag that allowed errors during microbenchmarks to be tolerated would also result in the exit status being 0 even if errors occurred.

The error tolerance should only allow the run to continue, if errors are encountered, but still report the failures by signalling an exit code 1 so that failures can be tracked and reported on.

Release Note: None
Epic: None