### PR TITLE
storage: strengthen time-bound iteration guarantees

### DIFF
--- a/pkg/ccl/storageccl/engineccl/bench_test.go
+++ b/pkg/ccl/storageccl/engineccl/bench_test.go
@@ -187,9 +187,9 @@ func BenchmarkTimeBoundIterate(b *testing.B) {
 			b.Run("TimeBoundIterator", func(b *testing.B) {
 				runIterate(b, loadFactor, func(e storage.Engine, startTime, endTime hlc.Timestamp) (storage.MVCCIterator, error) {
 					return e.NewMVCCIterator(storage.MVCCKeyIterKind, storage.IterOptions{
-						MinTimestampHint: startTime,
-						MaxTimestampHint: endTime,
-						UpperBound:       roachpb.KeyMax,
+						MinTimestamp: startTime,
+						MaxTimestamp: endTime,
+						UpperBound:   roachpb.KeyMax,
 					})
 				})
 			})

--- a/pkg/kv/kvserver/batcheval/cmd_revert_range.go
+++ b/pkg/kv/kvserver/batcheval/cmd_revert_range.go
@@ -83,11 +83,11 @@ func isEmptyKeyTimeRange(
 	// that there is *a* key in the SST that is in the time range. Thus we should
 	// proceed to iteration that actually checks timestamps on each key.
 	iter, err := readWriter.NewMVCCIterator(storage.MVCCKeyIterKind, storage.IterOptions{
-		KeyTypes:         storage.IterKeyTypePointsAndRanges,
-		LowerBound:       from,
-		UpperBound:       to,
-		MinTimestampHint: since.Next(), // make exclusive
-		MaxTimestampHint: until,
+		KeyTypes:     storage.IterKeyTypePointsAndRanges,
+		LowerBound:   from,
+		UpperBound:   to,
+		MinTimestamp: since.Next(), // make exclusive
+		MaxTimestamp: until,
 	})
 	if err != nil {
 		return false, err

--- a/pkg/storage/batch_test.go
+++ b/pkg/storage/batch_test.go
@@ -192,9 +192,9 @@ func TestReadOnlyBasics(t *testing.T) {
 		},
 		func() {
 			iter, _ := ro.NewMVCCIterator(MVCCKeyIterKind, IterOptions{
-				MinTimestampHint: hlc.MinTimestamp,
-				MaxTimestampHint: hlc.MaxTimestamp,
-				UpperBound:       roachpb.KeyMax,
+				MinTimestamp: hlc.MinTimestamp,
+				MaxTimestamp: hlc.MaxTimestamp,
+				UpperBound:   roachpb.KeyMax,
 			})
 			iter.Close()
 		},

--- a/pkg/storage/intent_interleaving_iter.go
+++ b/pkg/storage/intent_interleaving_iter.go
@@ -69,7 +69,7 @@ var intentInterleavingReaderPool = sync.Pool{
 func (imr *intentInterleavingReader) NewMVCCIterator(
 	iterKind MVCCIterKind, opts IterOptions,
 ) (MVCCIterator, error) {
-	if (!opts.MinTimestampHint.IsEmpty() || !opts.MaxTimestampHint.IsEmpty()) &&
+	if (!opts.MinTimestamp.IsEmpty() || !opts.MaxTimestamp.IsEmpty()) &&
 		iterKind == MVCCKeyAndIntentsIterKind {
 		panic("cannot ask for interleaved intents when specifying timestamp hints")
 	}
@@ -233,7 +233,7 @@ func isLocal(k roachpb.Key) bool {
 }
 
 func newIntentInterleavingIterator(reader Reader, opts IterOptions) (MVCCIterator, error) {
-	if !opts.MinTimestampHint.IsEmpty() || !opts.MaxTimestampHint.IsEmpty() {
+	if !opts.MinTimestamp.IsEmpty() || !opts.MaxTimestamp.IsEmpty() {
 		panic("intentInterleavingIter must not be used with timestamp hints")
 	}
 	var lowerIsLocal, upperIsLocal bool

--- a/pkg/storage/mvcc_incremental_iterator.go
+++ b/pkg/storage/mvcc_incremental_iterator.go
@@ -219,9 +219,9 @@ func NewMVCCIncrementalIterator(
 			LowerBound: opts.StartKey,
 			UpperBound: opts.EndKey,
 			// The call to startTime.Next() converts our exclusive start bound into
-			// the inclusive start bound that MinTimestampHint expects.
-			MinTimestampHint:     opts.StartTime.Next(),
-			MaxTimestampHint:     opts.EndTime,
+			// the inclusive start bound that MinTimestampt expects.
+			MinTimestamp:         opts.StartTime.Next(),
+			MaxTimestamp:         opts.EndTime,
 			RangeKeyMaskingBelow: tbiRangeKeyMasking,
 		})
 		if err != nil {

--- a/pkg/storage/pebble_iterator_test.go
+++ b/pkg/storage/pebble_iterator_test.go
@@ -13,6 +13,8 @@ package storage
 import (
 	"bytes"
 	"context"
+	"encoding/hex"
+	"fmt"
 	"io/fs"
 	"math/rand"
 	"os"
@@ -23,8 +25,11 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/testutils/datapathutils"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/datadriven"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble"
 	"github.com/cockroachdb/pebble/sstable"
@@ -143,4 +148,56 @@ func TestPebbleIterator_ExternalCorruption(t *testing.T) {
 		require.True(t, errors.Is(err, pebble.ErrCorruption))
 	}
 	it.Close()
+}
+
+func TestPebbleIterator_SkipPointIfOutsideTimeBounds(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	var iter pebbleIterator
+	var sb strings.Builder
+	datadriven.RunTest(t, datapathutils.TestDataPath(t, "skip_point_if_outside_time_bounds"), func(t *testing.T, d *datadriven.TestData) string {
+		sb.Reset()
+		var minStr, maxStr string
+		d.ScanArgs(t, "min", &minStr)
+		d.ScanArgs(t, "max", &maxStr)
+		min, err := hlc.ParseTimestamp(minStr)
+		require.NoError(t, err)
+		max, err := hlc.ParseTimestamp(maxStr)
+		require.NoError(t, err)
+
+		iter.setOptions(IterOptions{
+			LowerBound:   []byte{0x00}, // so setOptions doesn't complain
+			MinTimestamp: min,
+			MaxTimestamp: max,
+		}, StandardDurability)
+		fmt.Fprintf(&sb, "min: 0x%x\nmax: 0x%x\n", iter.minTimestamp, iter.maxTimestamp)
+		for _, line := range strings.Split(strings.TrimSpace(d.Input), "\n") {
+			if i := strings.IndexByte(line, '#'); i >= 0 {
+				line = line[:i]
+			}
+			if line == "" {
+				continue
+			}
+			var key []byte
+			switch {
+			case strings.HasPrefix(line, "0x:"):
+				line = line[len("0x:"):]
+				line = strings.Replace(line, " ", "", -1)
+				var err error
+				key, err = hex.DecodeString(line)
+				if err != nil {
+					return err.Error()
+				}
+			default:
+				return fmt.Sprintf("unrecognized key format %q", line)
+			}
+			fmt.Fprintf(&sb, "%s : ", line)
+			if iter.skipPointIfOutsideTimeBounds(key) {
+				fmt.Fprintln(&sb, "skip")
+			} else {
+				fmt.Fprintln(&sb, "don't skip")
+			}
+		}
+		return sb.String()
+	})
 }

--- a/pkg/storage/testdata/mvcc_histories/time_bounds
+++ b/pkg/storage/testdata/mvcc_histories/time_bounds
@@ -1,0 +1,45 @@
+run ok
+with k=k1
+  put v=k1v1 ts=10,0
+  put v=k1v2 ts=20,0
+put k=k2 v=k2v1 ts=5,0
+put k=k3 v=k3v1 ts=5,0
+----
+>> at end:
+data: "k1"/20.000000000,0 -> /BYTES/k1v2
+data: "k1"/10.000000000,0 -> /BYTES/k1v1
+data: "k2"/5.000000000,0 -> /BYTES/k2v1
+data: "k3"/5.000000000,0 -> /BYTES/k3v1
+
+# With wide bounds, all the keys should be visible.
+
+run ok
+iter_new kind=keys minTimestamp=1,0 maxTimestamp=30,0
+iter_seek_ge k=k1
+iter_next
+iter_next
+iter_next
+----
+iter_seek_ge: "k1"/20.000000000,0=/BYTES/k1v2
+iter_next: "k1"/10.000000000,0=/BYTES/k1v1
+iter_next: "k2"/5.000000000,0=/BYTES/k2v1
+iter_next: "k3"/5.000000000,0=/BYTES/k3v1
+
+# With narrow bounds [@10,@10], only 1 key should be visible. Note min and max
+# timestamp are both inclusive.
+
+run ok
+iter_new kind=keys minTimestamp=10,0 maxTimestamp=10,0
+iter_seek_ge k=k1
+iter_next
+----
+iter_seek_ge: "k1"/10.000000000,0=/BYTES/k1v1
+iter_next: .
+
+# Nothing visible within [@8,@9].
+
+run ok
+iter_new kind=keys minTimestamp=8,0 maxTimestamp=9,0
+iter_seek_ge k=k1
+----
+iter_seek_ge: .

--- a/pkg/storage/testdata/skip_point_if_outside_time_bounds
+++ b/pkg/storage/testdata/skip_point_if_outside_time_bounds
@@ -1,0 +1,213 @@
+check min=0,0 max=6000.000000000,0
+# Test a series of 8-byte MVCC keys that all fall within bounds.
+#
+#      user key
+#    /     sentinel byte
+#    |   /         encoded 8-byte WallTime timestamp
+#    |   |          /         timestamp length
+#    |   |          |         |
+0x: FFFF 00 0000000000000000 09    # WallTime=0
+0x: FFFF 00 0000000000000001 09    # WallTime=1
+0x: FFFF 00 00000574fbde5fff 09    # WallTime=<max>-1
+0x: FFFF 00 00000574fbde6000 09    # WallTime=<max>
+#
+# Test a series of 8-byte MVCC keys that all contain TS > max.
+#
+0x: FFFF 00 00000574fbde6001 09    # WallTime=<max>+1
+0x: FFFF 00 ffffffffffffffff 09    # WallTime=MaxUint64
+#
+# Test a series of 12-byte MVCC keys that all fall within bounds.
+#
+#       user key
+#     /    sentinel byte
+#    |   /             8-byte WallTime timestamp
+#    |   |           /             4-byte Logical timestamp
+#    |   |          |            /     timestamp length
+#    |   |          |           |     |
+0x: FFFF 00 0000000000000000 00000000 0d    # 0,0
+0x: FFFF 00 0000000000000001 00000001 0d    # 1,1
+0x: FFFF 00 00000574fbde5fff 00000001 0d    # <max>-1,1
+0x: FFFF 00 00000574fbde5fff ffffffff 0d    # <max>-1,MaxUint32
+#
+# Test a series of 12-byte MVCC keys that all contain TS > max.
+#
+0x: FFFF 00 00000574fbde6000 00000001 0d    # <max>,1
+0x: FFFF 00 00000574fbde6000 00000005 0d    # <max>,5
+0x: FFFF 00 00000574fbde6000 ffffffff 0d    # <max>,MaxUint32
+0x: FFFF 00 00000574fbde6001 00000001 0d    # <max>+1,1
+0x: FFFF 00 ffffffffffffffff ffffffff 0d    # MaxUint64,MaxUint32
+#
+# Test the same keys as above but with 13-byte MVCC keys (including the
+# synthetic bit).
+#
+#       user key
+#     /    sentinel byte
+#    |   /             8-byte WallTime timestamp
+#    |   |           /             4-byte Logical timestamp
+#    |   |          |            /     synthetic bit
+#    |   |          |           |     /  timestamp length
+#    |   |          |           |    |  |
+0x: FFFF 00 0000000000000000 00000000 01 0e    # 0,0?
+0x: FFFF 00 0000000000000001 00000001 01 0e    # 1,1?
+0x: FFFF 00 00000574fbde5fff 00000001 01 0e    # <max>-1,1?
+0x: FFFF 00 00000574fbde5fff ffffffff 01 0e    # <max>-1,MaxUint32?
+#
+# Test a series of 13-byte MVCC keys that all contain TS > max.
+#
+0x: FFFF 00 00000574fbde6000 00000001 01 0e    # <max>,1?
+0x: FFFF 00 00000574fbde6000 00000005 01 0e    # <max>,5?
+0x: FFFF 00 00000574fbde6000 ffffffff 01 0e    # <max>,MaxUint32?
+0x: FFFF 00 00000574fbde6001 00000001 01 0e    # <max>+1,1?
+0x: FFFF 00 ffffffffffffffff ffffffff 01 0e    # MaxUint64,MaxUint32?
+----
+min: 0x
+max: 0x00000574fbde600001
+FFFF00000000000000000009 : don't skip
+FFFF00000000000000000109 : don't skip
+FFFF0000000574fbde5fff09 : don't skip
+FFFF0000000574fbde600009 : don't skip
+FFFF0000000574fbde600109 : skip
+FFFF00ffffffffffffffff09 : skip
+FFFF000000000000000000000000000d : don't skip
+FFFF000000000000000001000000010d : don't skip
+FFFF0000000574fbde5fff000000010d : don't skip
+FFFF0000000574fbde5fffffffffff0d : don't skip
+FFFF0000000574fbde6000000000010d : don't skip
+FFFF0000000574fbde6000000000050d : don't skip
+FFFF0000000574fbde6000ffffffff0d : skip
+FFFF0000000574fbde6001000000010d : skip
+FFFF00ffffffffffffffffffffffff0d : skip
+FFFF00000000000000000000000000010e : don't skip
+FFFF00000000000000000100000001010e : don't skip
+FFFF0000000574fbde5fff00000001010e : don't skip
+FFFF0000000574fbde5fffffffffff010e : don't skip
+FFFF0000000574fbde600000000001010e : don't skip
+FFFF0000000574fbde600000000005010e : don't skip
+FFFF0000000574fbde6000ffffffff010e : skip
+FFFF0000000574fbde600100000001010e : skip
+FFFF00ffffffffffffffffffffffff010e : skip
+
+#
+# The next test case is adjusted from the above test case, but this time the max
+# has a non-zero logical bit, and so the max itself should be 12 or 13 bit
+# timestamp.
+#
+
+check min=0,0 max=6000.000000000,1
+# Test a series of 8-byte MVCC keys that all fall within bounds.
+#
+#      user key
+#    /     sentinel byte
+#    |   /         encoded 8-byte WallTime timestamp
+#    |   |          /         timestamp length
+#    |   |          |         |
+0x: FFFF 00 0000000000000000 09    # WallTime=0
+0x: FFFF 00 0000000000000001 09    # WallTime=1
+0x: FFFF 00 00000574fbde5fff 09    # WallTime=<max.WallTime>-1
+0x: FFFF 00 00000574fbde6000 09    # WallTime=<max.WallTime>
+#
+# Test a series of 8-byte MVCC keys that all contain TS > max.
+#
+0x: FFFF 00 00000574fbde6001 09    # WallTime=<max.WallTime>+1
+0x: FFFF 00 ffffffffffffffff 09    # WallTime=MaxUint64
+#
+# Test a series of 12-byte MVCC keys that all fall within bounds.
+#
+#       user key
+#     /    sentinel byte
+#    |   /             8-byte WallTime timestamp
+#    |   |           /             4-byte Logical timestamp
+#    |   |          |            /     timestamp length
+#    |   |          |           |     |
+0x: FFFF 00 0000000000000000 00000000 0d    # 0,0
+0x: FFFF 00 0000000000000001 00000001 0d    # 1,1
+0x: FFFF 00 00000574fbde5fff 00000001 0d    # <max.WallTime>-1,1
+0x: FFFF 00 00000574fbde5fff ffffffff 0d    # <max.WallTime>-1,MaxUint32
+0x: FFFF 00 00000574fbde6000 00000001 0d    # <max>
+#
+# Test a series of 12-byte MVCC keys that all contain TS > max.
+#
+0x: FFFF 00 00000574fbde6000 00000002 0d    # <max.WallTime>,<max.LogicalTime>+1
+0x: FFFF 00 00000574fbde6000 00000005 0d    # <max.WallTime>,5
+0x: FFFF 00 00000574fbde6000 ffffffff 0d    # <max.WallTime>,MaxUint32
+0x: FFFF 00 00000574fbde6001 00000001 0d    # <max.WallTime>+1,1
+0x: FFFF 00 ffffffffffffffff ffffffff 0d    # MaxUint64,MaxUint32
+#
+# Test the same keys as above but with 13-byte MVCC keys (including the
+# synthetic bit).
+#
+#       user key
+#     /    sentinel byte
+#    |   /             8-byte WallTime timestamp
+#    |   |           /             4-byte Logical timestamp
+#    |   |          |            /     synthetic bit
+#    |   |          |           |     /  timestamp length
+#    |   |          |           |    |  |
+0x: FFFF 00 0000000000000000 00000000 01 0e    # 0,0?
+0x: FFFF 00 0000000000000001 00000001 01 0e    # 1,1?
+0x: FFFF 00 00000574fbde5fff 00000001 01 0e    # <max.WallTime>-1,1?
+0x: FFFF 00 00000574fbde5fff ffffffff 01 0e    # <max.WallTime>-1,MaxUint32?
+0x: FFFF 00 00000574fbde6000 00000001 01 0e    # <max>?
+#
+# Test a series of 13-byte MVCC keys that all contain TS > max.
+#
+0x: FFFF 00 00000574fbde6000 00000002 01 0e    # <max.WallTime>,<max.LogicalTime>+1
+0x: FFFF 00 00000574fbde6000 00000005 01 0e    # <max.WallTime>,5?
+0x: FFFF 00 00000574fbde6000 ffffffff 01 0e    # <max.WallTime>,MaxUint32?
+0x: FFFF 00 00000574fbde6001 00000001 01 0e    # <max.WallTime>+1,1?
+0x: FFFF 00 ffffffffffffffff ffffffff 01 0e    # MaxUint64,MaxUint32?
+----
+min: 0x
+max: 0x00000574fbde60000000000101
+FFFF00000000000000000009 : don't skip
+FFFF00000000000000000109 : don't skip
+FFFF0000000574fbde5fff09 : don't skip
+FFFF0000000574fbde600009 : don't skip
+FFFF0000000574fbde600109 : skip
+FFFF00ffffffffffffffff09 : skip
+FFFF000000000000000000000000000d : don't skip
+FFFF000000000000000001000000010d : don't skip
+FFFF0000000574fbde5fff000000010d : don't skip
+FFFF0000000574fbde5fffffffffff0d : don't skip
+FFFF0000000574fbde6000000000010d : don't skip
+FFFF0000000574fbde6000000000020d : skip
+FFFF0000000574fbde6000000000050d : skip
+FFFF0000000574fbde6000ffffffff0d : skip
+FFFF0000000574fbde6001000000010d : skip
+FFFF00ffffffffffffffffffffffff0d : skip
+FFFF00000000000000000000000000010e : don't skip
+FFFF00000000000000000100000001010e : don't skip
+FFFF0000000574fbde5fff00000001010e : don't skip
+FFFF0000000574fbde5fffffffffff010e : don't skip
+FFFF0000000574fbde600000000001010e : don't skip
+FFFF0000000574fbde600000000002010e : skip
+FFFF0000000574fbde600000000005010e : skip
+FFFF0000000574fbde6000ffffffff010e : skip
+FFFF0000000574fbde600100000001010e : skip
+FFFF00ffffffffffffffffffffffff010e : skip
+
+# Test invalid keys, like keys with lock table suffixes
+
+check min=10.000000000,0 max=25.000000000,0
+# Test lock table keys. They just shouldn't be skipped, even if a lexiccographic
+# comparison alone would've skipped them.
+#
+#       key "prefix"
+#     /     sentinel byte
+#    |    /   lock strength    transaction UUID       timestamp length (17+1)
+#    |   |  /                 /                      /
+0x: FFFF 00 03 000000000000000000000000000000000000 12
+0x: FFFF 00 02 000000000000000000000000000000000000 12
+0x: FFFF 00 01 000000000000000000000000000000000000 12
+0x: FFFF 00 03 ffffffffffffffffffffffffffffffffffff 12
+0x: FFFF 00 02 ffffffffffffffffffffffffffffffffffff 12
+0x: FFFF 00 01 ffffffffffffffffffffffffffffffffffff 12
+----
+min: 0x00000002540be400
+max: 0x00000005d21dba0001
+FFFF000300000000000000000000000000000000000012 : don't skip
+FFFF000200000000000000000000000000000000000012 : don't skip
+FFFF000100000000000000000000000000000000000012 : don't skip
+FFFF0003ffffffffffffffffffffffffffffffffffff12 : don't skip
+FFFF0002ffffffffffffffffffffffffffffffffffff12 : don't skip
+FFFF0001ffffffffffffffffffffffffffffffffffff12 : don't skip


### PR DESCRIPTION
Previously, the minimum and maximum timestamps used to configure a "time-bound" iterator were only hints. The iterator would surface keys outside those bounds frequently if the keys were contained within a sstable block that also contained keys within bounds. This commit adapts the iterator construction to use Pebble's IterOptions.SkipPoint option to filter out-of-range keys without yielding them to the caller.

This adds a small additional overhead to processing KVs that are ultimately yielded to the user of a MVCCIncrementalIterator, but removes a large overhead to proessing KVs that are ultimately skipped. In the current MVCCIncrementalIterator implementation, keys that are outside the time range still reposition the iterator without time bounds. This repositioning no longer happens, and removing this overhead more than reclaims the RefreshRange benchmark's regression from value blocks packing keys more densely.

This also serves as a step towards #66869.

```
goos: linux
goarch: amd64
cpu: Intel(R) Xeon(R) CPU @ 2.80GHz
                                                         │    old.txt    │               new.txt               │
                                                         │    sec/op     │   sec/op     vs base                │
RefreshRange/linear-keys/refresh_window=[0.00,0.00]-24      150.73µ ± 1%   55.75µ ± 1%  -63.01% (p=0.000 n=10)
RefreshRange/linear-keys/refresh_window=[0.00,50.00]-24      16.52µ ± 1%   16.19µ ± 2%   -2.00% (p=0.005 n=10)
RefreshRange/linear-keys/refresh_window=[0.00,75.00]-24      13.94µ ± 1%   13.59µ ± 1%   -2.55% (p=0.000 n=10)
RefreshRange/linear-keys/refresh_window=[0.00,95.00]-24      13.97µ ± 1%   13.56µ ± 3%   -2.99% (p=0.002 n=10)
RefreshRange/linear-keys/refresh_window=[0.00,99.00]-24      13.96µ ± 1%   13.45µ ± 3%   -3.69% (p=0.000 n=10)
RefreshRange/linear-keys/refresh_window=[50.00,50.00]-24    149.95µ ± 1%   55.67µ ± 1%  -62.88% (p=0.000 n=10)
RefreshRange/linear-keys/refresh_window=[50.00,75.00]-24     22.05µ ± 1%   21.70µ ± 0%   -1.57% (p=0.000 n=10)
RefreshRange/linear-keys/refresh_window=[50.00,95.00]-24     22.08µ ± 1%   21.61µ ± 0%   -2.14% (p=0.000 n=10)
RefreshRange/linear-keys/refresh_window=[50.00,99.00]-24     21.91µ ± 1%   21.69µ ± 1%   -0.99% (p=0.000 n=10)
RefreshRange/linear-keys/refresh_window=[75.00,75.00]-24    139.27µ ± 1%   55.82µ ± 1%  -59.92% (p=0.000 n=10)
RefreshRange/linear-keys/refresh_window=[75.00,95.00]-24     23.76µ ± 1%   23.36µ ± 0%   -1.66% (p=0.000 n=10)
RefreshRange/linear-keys/refresh_window=[75.00,99.00]-24     23.85µ ± 1%   23.25µ ± 1%   -2.48% (p=0.000 n=10)
RefreshRange/linear-keys/refresh_window=[95.00,95.00]-24    138.94µ ± 1%   55.52µ ± 0%  -60.04% (p=0.000 n=10)
RefreshRange/linear-keys/refresh_window=[95.00,99.00]-24     26.68µ ± 1%   26.30µ ± 1%   -1.42% (p=0.005 n=10)
RefreshRange/linear-keys/refresh_window=[99.00,99.00]-24    141.39µ ± 1%   55.02µ ± 1%  -61.09% (p=0.000 n=10)
RefreshRange/random-keys/refresh_window=[0.00,0.00]-24      322.35µ ± 0%   51.21µ ± 0%  -84.11% (p=0.000 n=10)
RefreshRange/random-keys/refresh_window=[0.00,50.00]-24      16.35µ ± 1%   16.63µ ± 2%        ~ (p=0.105 n=10)
RefreshRange/random-keys/refresh_window=[0.00,75.00]-24      17.42µ ± 1%   17.29µ ± 3%        ~ (p=0.796 n=10)
RefreshRange/random-keys/refresh_window=[0.00,95.00]-24      13.40µ ± 1%   13.45µ ± 1%        ~ (p=0.529 n=10)
RefreshRange/random-keys/refresh_window=[0.00,99.00]-24      13.59µ ± 2%   13.41µ ± 0%        ~ (p=0.239 n=10)
RefreshRange/random-keys/refresh_window=[50.00,50.00]-24     707.5m ± 1%   111.7m ± 1%  -84.21% (p=0.000 n=10)
RefreshRange/random-keys/refresh_window=[50.00,75.00]-24     21.94µ ± 1%   17.86µ ± 0%  -18.59% (p=0.000 n=10)
RefreshRange/random-keys/refresh_window=[50.00,95.00]-24     13.95µ ± 1%   13.54µ ± 1%   -2.94% (p=0.000 n=10)
RefreshRange/random-keys/refresh_window=[50.00,99.00]-24     13.96µ ± 0%   13.53µ ± 1%   -3.06% (p=0.000 n=10)
RefreshRange/random-keys/refresh_window=[75.00,75.00]-24    395.22m ± 0%   33.81m ± 1%  -91.45% (p=0.000 n=10)
RefreshRange/random-keys/refresh_window=[75.00,95.00]-24     19.42µ ± 1%   19.40µ ± 1%        ~ (p=0.912 n=10)
RefreshRange/random-keys/refresh_window=[75.00,99.00]-24     19.37µ ± 1%   19.42µ ± 1%        ~ (p=0.247 n=10)
RefreshRange/random-keys/refresh_window=[95.00,95.00]-24    546.66m ± 3%   48.48m ± 3%  -91.13% (p=0.000 n=10)
RefreshRange/random-keys/refresh_window=[95.00,99.00]-24     21.69µ ± 1%   19.68µ ± 1%   -9.24% (p=0.000 n=10)
RefreshRange/random-keys/refresh_window=[99.00,99.00]-24    546.27m ± 0%   48.73m ± 3%  -91.08% (p=0.000 n=10)
RefreshRange/mixed-case/refresh_window=[0.00,0.00]-24        410.1µ ± 0%   221.1µ ± 1%  -46.09% (p=0.000 n=10)
RefreshRange/mixed-case/refresh_window=[0.00,50.00]-24       14.84µ ± 1%   14.84µ ± 1%        ~ (p=0.739 n=10)
RefreshRange/mixed-case/refresh_window=[0.00,75.00]-24       14.84µ ± 1%   14.83µ ± 1%        ~ (p=0.615 n=10)
RefreshRange/mixed-case/refresh_window=[0.00,95.00]-24       17.39µ ± 2%   17.51µ ± 2%   +0.68% (p=0.029 n=10)
RefreshRange/mixed-case/refresh_window=[0.00,99.00]-24       16.41µ ± 1%   16.38µ ± 1%        ~ (p=0.971 n=10)
RefreshRange/mixed-case/refresh_window=[50.00,50.00]-24      660.9m ± 0%   140.6m ± 3%  -78.73% (p=0.000 n=10)
RefreshRange/mixed-case/refresh_window=[50.00,75.00]-24      20.43µ ± 1%   15.46µ ± 1%  -24.31% (p=0.000 n=10)
RefreshRange/mixed-case/refresh_window=[50.00,95.00]-24      18.03µ ± 1%   17.66µ ± 1%   -2.01% (p=0.000 n=10)
RefreshRange/mixed-case/refresh_window=[50.00,99.00]-24      16.86µ ± 1%   16.70µ ± 1%   -0.93% (p=0.011 n=10)
RefreshRange/mixed-case/refresh_window=[75.00,75.00]-24      659.5m ± 1%   137.1m ± 3%  -79.21% (p=0.000 n=10)
RefreshRange/mixed-case/refresh_window=[75.00,95.00]-24      17.96µ ± 1%   17.65µ ± 1%   -1.77% (p=0.000 n=10)
RefreshRange/mixed-case/refresh_window=[75.00,99.00]-24      16.86µ ± 1%   16.66µ ± 1%   -1.23% (p=0.008 n=10)
RefreshRange/mixed-case/refresh_window=[95.00,95.00]-24     900.95µ ± 0%   32.18µ ± 0%  -96.43% (p=0.000 n=10)
RefreshRange/mixed-case/refresh_window=[95.00,99.00]-24      14.35µ ± 1%   14.50µ ± 2%   +1.03% (p=0.002 n=10)
RefreshRange/mixed-case/refresh_window=[99.00,99.00]-24    227.235m ± 1%   3.361m ± 1%  -98.52% (p=0.000 n=10)
geomean                                                      136.9µ        73.57µ       -46.24%

goos: linux
goarch: amd64
cpu: Intel(R) Xeon(R) CPU @ 2.80GHz
                                                    │  old2.txt   │              new2.txt               │
                                                    │   sec/op    │   sec/op     vs base                │
MVCCIncrementalIterator/ts=5-24                       24.93m ± 3%   24.53m ± 2%   -1.61% (p=0.004 n=10)
MVCCIncrementalIterator/ts=480-24                     560.4µ ± 1%   453.8µ ± 0%  -19.02% (p=0.000 n=10)
MVCCIncrementalIteratorForOldData/valueSize=100-24    1.444m ± 0%   1.434m ± 0%   -0.72% (p=0.000 n=10)
MVCCIncrementalIteratorForOldData/valueSize=500-24    1.994m ± 0%   1.974m ± 1%   -1.02% (p=0.000 n=10)
MVCCIncrementalIteratorForOldData/valueSize=1000-24   2.672m ± 1%   2.649m ± 1%        ~ (p=0.063 n=10)
MVCCIncrementalIteratorForOldData/valueSize=2000-24   4.059m ± 1%   4.009m ± 1%   -1.23% (p=0.011 n=10)
geomean                                               2.754m        2.635m        -4.33%
```

Epic: none
Informs #66869
Close #98881
Release note: none