### PR TITLE
nightlies: Collect logictest statements and store them onto GCS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -428,6 +428,7 @@
 /pkg/cmd/generate-bazel-extra/ @cockroachdb/dev-inf
 /pkg/cmd/generate-staticcheck/ @cockroachdb/dev-inf
 /pkg/cmd/generate-cgo/       @cockroachdb/dev-inf
+/pkg/cmd/generate-logictest-corpus/ @cockroachdb/sql-foundations
 /pkg/cmd/geoviz/             @cockroachdb/spatial
 /pkg/cmd/github-post/        @cockroachdb/test-eng
 /pkg/cmd/github-pull-request-make/ @cockroachdb/dev-inf

--- a/build/teamcity/cockroach/nightlies/sqllogic_statements_corpus_nightly.sh
+++ b/build/teamcity/cockroach/nightlies/sqllogic_statements_corpus_nightly.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+dir="$(dirname $(dirname $(dirname $(dirname "${0}"))))"
+
+source "$dir/teamcity-support.sh"  # For $root
+source "$dir/teamcity-bazel-support.sh"  # For run_bazel
+
+tc_start_block "Collect SQL Logic Tests Statements"
+BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="-e TC_BUILD_BRANCH -e GITHUB_API_TOKEN -e GOOGLE_EPHEMERAL_CREDENTIALS -e BUILD_VCS_NUMBER -e TC_BUILD_ID -e TC_SERVER_URL -e TC_BUILDTYPE_ID -e GITHUB_REPO" \
+  run_bazel build/teamcity/cockroach/nightlies/sqllogic_statements_corpus_nightly_impl.sh
+tc_end_block "Collect SQL Logic Tests Statements"

--- a/build/teamcity/cockroach/nightlies/sqllogic_statements_corpus_nightly_impl.sh
+++ b/build/teamcity/cockroach/nightlies/sqllogic_statements_corpus_nightly_impl.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -xeuo pipefail
+
+dir="$(dirname $(dirname $(dirname $(dirname "${0}"))))"
+source "$dir/teamcity-support.sh"
+
+google_credentials="$GOOGLE_EPHEMERAL_CREDENTIALS"
+log_into_gcloud
+
+CORPUS_DIR=/artifacts/logictest-stmts-corpus-dir # dir to store all collected corpus file(s)
+exit_status=0
+
+# Collect sql logic tests statements corpus.
+bazel run -- //pkg/cmd/generate-logictest-corpus:generate-logictest-corpus \
+-out-dir=$CORPUS_DIR  \
+|| exit_status=$?
+
+# Persist the validated corpus to GCS.
+if [ $exit_status = 0 ]; then
+  gsutil cp  $CORPUS_DIR/* gs://cockroach-corpus/corpus-$TC_BUILD_BRANCH/
+fi

--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -1056,6 +1056,8 @@ GO_TARGETS = [
     "//pkg/cmd/generate-cgo:generate-cgo_lib",
     "//pkg/cmd/generate-distdir:generate-distdir",
     "//pkg/cmd/generate-distdir:generate-distdir_lib",
+    "//pkg/cmd/generate-logictest-corpus:generate-logictest-corpus",
+    "//pkg/cmd/generate-logictest-corpus:generate-logictest-corpus_lib",
     "//pkg/cmd/generate-logictest:generate-logictest",
     "//pkg/cmd/generate-logictest:generate-logictest_lib",
     "//pkg/cmd/generate-metadata-tables/rdbms:generate-metadata-tables-rdbms_lib",

--- a/pkg/cmd/generate-logictest-corpus/BUILD.bazel
+++ b/pkg/cmd/generate-logictest-corpus/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "generate-logictest-corpus_lib",
+    srcs = ["main.go"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/cmd/generate-logictest-corpus",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//pkg/build/bazel",
+        "//pkg/sql/schemachanger/scpb",
+        "//pkg/util/protoutil",
+        "@com_github_cockroachdb_errors//:errors",
+    ],
+)
+
+go_binary(
+    name = "generate-logictest-corpus",
+    data = [
+        "//pkg/sql/logictest:testdata",
+    ],
+    embed = [":generate-logictest-corpus_lib"],
+    visibility = ["//visibility:public"],
+)

--- a/pkg/cmd/generate-logictest-corpus/main.go
+++ b/pkg/cmd/generate-logictest-corpus/main.go
@@ -1,0 +1,160 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package main
+
+import (
+	"bufio"
+	"flag"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/cockroachdb/cockroach/pkg/build/bazel"
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/cockroachdb/errors"
+)
+
+var outDir = flag.String("out-dir", "",
+	"directory path in which corpus files of logic tests stmts are stored")
+
+func collectLogicTestsStmts() error {
+	err := createOutDirIfNotExists()
+	if err != nil {
+		return err
+	}
+	logicTestDir, err := getLogicTestDir()
+	if err != nil {
+		return err
+	}
+
+	corpus := scpb.LogicTestStmtsCorpus{}
+	err = filepath.WalkDir(logicTestDir, func(inPath string, d fs.DirEntry, err error) error {
+		if inPath == logicTestDir || err != nil || d.IsDir() {
+			return err
+		}
+		stmts, err := collectCorpusEntryFrom(inPath)
+		if err != nil {
+			return err
+		}
+		corpus.Entries = append(corpus.Entries, &scpb.LogicTestStmtsCorpus_Entry{
+			Name:       d.Name(),
+			Statements: stmts,
+		})
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	// Serialize corpus to output file.
+	corpusFilePath := filepath.Join(*outDir, "logictest-stmts-corpus")
+	corpusFile, err := os.OpenFile(corpusFilePath, os.O_WRONLY|os.O_CREATE, os.ModePerm)
+	if err != nil {
+		return err
+	}
+	defer corpusFile.Close()
+	corpusBytes, err := protoutil.Marshal(&corpus)
+	if err != nil {
+		return err
+	}
+	_, err = corpusFile.Write(corpusBytes)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func createOutDirIfNotExists() error {
+	if *outDir == "" {
+		return errors.New("please specify a output directory for corpus files via `-out-dir=[some-output-directory]`")
+	}
+	return os.MkdirAll(*outDir, os.ModePerm)
+}
+
+func getLogicTestDir() (logicTestDir string, err error) {
+	if bazel.BuiltWithBazel() {
+		logicTestDir, err = bazel.Runfile("pkg/sql/logictest/testdata/logic_test")
+		return logicTestDir, err
+	}
+	return "", errors.New("non-bazel builds not supported.")
+}
+
+func collectCorpusEntryFrom(inPath string) (stmts []string, err error) {
+	logicTestFile, err := os.OpenFile(inPath, os.O_RDONLY, os.ModePerm)
+	if err != nil {
+		return nil, err
+	}
+	defer logicTestFile.Close()
+
+	// Logictest framework initializes the cluster with a database `test` and an
+	// user `testuser`.
+	stmts = append(stmts, "CREATE DATABASE IF NOT EXISTS test;")
+	stmts = append(stmts, "CREATE USER testuser;")
+
+	// Collect statements from logic test `inPath` into `stmts`.
+	s := bufio.NewScanner(logicTestFile)
+	for s.Scan() {
+		line := s.Text()
+		fields := strings.Fields(line)
+		if len(fields) == 0 {
+			continue
+		}
+		cmd := fields[0]
+		if strings.HasPrefix(cmd, "#") {
+			// Skip comment lines.
+			continue
+		}
+		var stmt string
+		switch cmd {
+		case "statement":
+			stmt = readLinesUntilSeparatorLine(s, false /* is4DashesSepLine */)
+		case "query":
+			stmt = readLinesUntilSeparatorLine(s, true /* is4DashesSepLine */)
+		}
+		if stmt != "" {
+			stmts = append(stmts, stmt)
+		}
+	}
+
+	return stmts, nil
+}
+
+// Accumulate lines until we hit a "separator line".
+//   - An empty line is always a separator line.
+//   - If `is4DashesSepLine` is true, a line of "----" is also considered a separator line.
+func readLinesUntilSeparatorLine(s *bufio.Scanner, is4DashesSepLine bool) string {
+	isSepLine := func(line string) bool {
+		if line == "" || (is4DashesSepLine && line == "----") {
+			return true
+		}
+		return false
+	}
+
+	var sb strings.Builder
+	for s.Scan() {
+		line := strings.TrimSpace(s.Text())
+		if isSepLine(line) {
+			break
+		}
+		sb.WriteString(line + "\n")
+	}
+
+	return sb.String()
+}
+
+func main() {
+	flag.Parse()
+	if err := collectLogicTestsStmts(); err != nil {
+		panic(err)
+	}
+}

--- a/pkg/sql/logictest/BUILD.bazel
+++ b/pkg/sql/logictest/BUILD.bazel
@@ -22,6 +22,7 @@ filegroup(
     visibility = [
         "//pkg/ccl/logictestccl:__subpackages__",
         "//pkg/cmd/generate-logictest:__pkg__",
+        "//pkg/cmd/generate-logictest-corpus:__pkg__",
         "//pkg/sql/logictest:__subpackages__",
     ],
 )

--- a/pkg/sql/schemachanger/scpb/scpb.proto
+++ b/pkg/sql/schemachanger/scpb/scpb.proto
@@ -207,3 +207,15 @@ message CorpusDisk {
   repeated CorpusState corpus_array = 1;
 }
 
+// LogicTestStmtsCorpus is used to serialize statements collected from logic
+// tests. Each entry in the corpus corresponds to statements collected from one
+// logic test.
+message LogicTestStmtsCorpus {
+  message Entry {
+    string name = 1;
+    repeated string statements = 2;
+  }
+
+  repeated Entry entries = 1;
+}
+


### PR DESCRIPTION
This PR adds a nightly task for TC to collect all statements in logictests and store them onto GCS.

Informs: #108183
Epic: [CRDB-30346](https://cockroachlabs.atlassian.net/browse/CRDB-30346)
Release note: None