### PR TITLE
kvserver: hook up {shared, exclusive} replicated locks end to end

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_get.go
+++ b/pkg/kv/kvserver/batcheval/cmd_get.go
@@ -85,7 +85,7 @@ func Get(
 	var res result.Result
 	if args.KeyLockingStrength != lock.None && h.Txn != nil && getRes.Value != nil {
 		acq, err := acquireLockOnKey(ctx, readWriter, h.Txn, args.KeyLockingStrength,
-			args.KeyLockingDurability, args.Key)
+			args.KeyLockingDurability, args.Key, cArgs.Stats, cArgs.EvalCtx.ClusterSettings())
 		if err != nil {
 			return result.Result{}, err
 		}

--- a/pkg/kv/kvserver/batcheval/cmd_reverse_scan.go
+++ b/pkg/kv/kvserver/batcheval/cmd_reverse_scan.go
@@ -110,8 +110,9 @@ func ReverseScan(
 	}
 
 	if args.KeyLockingStrength != lock.None && h.Txn != nil {
-		acquiredLocks, err := acquireLocksOnKeys(ctx, readWriter, h.Txn, args.KeyLockingStrength,
-			args.KeyLockingDurability, args.ScanFormat, &scanRes)
+		acquiredLocks, err := acquireLocksOnKeys(
+			ctx, readWriter, h.Txn, args.KeyLockingStrength, args.KeyLockingDurability,
+			args.ScanFormat, &scanRes, cArgs.Stats, cArgs.EvalCtx.ClusterSettings())
 		if err != nil {
 			return result.Result{}, err
 		}

--- a/pkg/kv/kvserver/batcheval/cmd_scan.go
+++ b/pkg/kv/kvserver/batcheval/cmd_scan.go
@@ -110,8 +110,9 @@ func Scan(
 	}
 
 	if args.KeyLockingStrength != lock.None && h.Txn != nil {
-		acquiredLocks, err := acquireLocksOnKeys(ctx, readWriter, h.Txn, args.KeyLockingStrength,
-			args.KeyLockingDurability, args.ScanFormat, &scanRes)
+		acquiredLocks, err := acquireLocksOnKeys(
+			ctx, readWriter, h.Txn, args.KeyLockingStrength, args.KeyLockingDurability,
+			args.ScanFormat, &scanRes, cArgs.Stats, cArgs.EvalCtx.ClusterSettings())
 		if err != nil {
 			return result.Result{}, err
 		}


### PR DESCRIPTION
Now that both the storage layer and the concurrency manager have been taught about {shared, exclusive} replicated locks, we can hook things up end to end. This patch does so by:

- Checking for conflicts with replicated locks during lock acquisition of an unreplicated lock.
- Checking for conflicts and acquiring a replicated lock during lock acquisition of a replicated lock.

Closes #109672
Informs #100193

Release note: None