### PR TITLE
.github: project automation for admission control

### DIFF
--- a/.github/workflows/add-issues-to-project.yml
+++ b/.github/workflows/add-issues-to-project.yml
@@ -9,27 +9,35 @@ jobs:
     name: Add issues to project boards
     runs-on: ubuntu-latest
     steps:
+      # NOTE: when adding a new mapping, clone the following block, and fill in
+      # the blanks.
+      #- uses: actions/add-to-project@v0.4.0
+      #  with:
+      #    # URL of the project to add issues to
+      #    project-url: https://github.com/orgs/cockroachdb/projects/XXX
+      #    github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+      #    # A comma-separated list of labels to use as a filter for issue to be added
+      #    labeled: A-foo,T-bar
       - uses: actions/add-to-project@v0.4.0
         with:
-          # URL of the project to add issues to
-          project-url: https://github.com/orgs/cockroachdb/projects/36
-          # A GitHub personal access token with write access to the project
+          project-url: https://github.com/orgs/cockroachdb/projects/32
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
-          # A comma-separated list of labels to use as a filter for issue to be added
-          labeled: T-multitenant
+          labeled: A-admission-control,T-admission-control
       - uses: actions/add-to-project@v0.4.0
         with:
-          # URL of the project to add issues to
           project-url: https://github.com/orgs/cockroachdb/projects/38
-          # A GitHub personal access token with write access to the project
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
-          # A comma-separated list of labels to use as a filter for issue to be added
           labeled: T-cdc
       - uses: actions/add-to-project@v0.4.0
         with:
           project-url: https://github.com/orgs/cockroachdb/projects/35
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
           labeled: T-jobs
+      - uses: actions/add-to-project@v0.4.0
+        with:
+          project-url: https://github.com/orgs/cockroachdb/projects/36
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          labeled: T-multitenant
       - uses: actions/add-to-project@v0.4.0
         with:
           project-url: https://github.com/orgs/cockroachdb/projects/45


### PR DESCRIPTION
Add GitHub Action automation to move issues labelled as `{A,T}-admission-control` to the Admission Control project.

Alphabetize projects.

Release note: None.

Epic: None.