### PR TITLE
kvserver: enable server side refreshes for shared locking requests

### DIFF
--- a/pkg/kv/kvnemesis/validator.go
+++ b/pkg/kv/kvnemesis/validator.go
@@ -1208,12 +1208,6 @@ func (v *validator) checkError(
 		exceptAmbiguous, exceptOmitted, exceptRetry,
 		exceptDelRangeUsingTombstoneStraddlesRangeBoundary,
 		exceptSharedLockPromotionError,
-		// TODO(arul): Once https://github.com/cockroachdb/cockroach/issues/110650
-		// is addressed, we would no longer expect unhandled retryable errors to
-		// bubble back up to the client for batches that acquire shared locks;
-		// they'll be server-side refreshed instead. We should be able to get rid of
-		// this at that point.
-		exceptUnhandledRetry,
 	}
 	sl = append(sl, extraExceptions...)
 	return v.failIfError(op, r, sl...)

--- a/pkg/kv/kvserver/concurrency/concurrency_manager.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager.go
@@ -723,16 +723,33 @@ func (g *Guard) AssertNoLatches() {
 // before the request can evaluate at that later timestamp.
 func (g *Guard) IsolatedAtLaterTimestamps() bool {
 	// If the request acquired any read latches with bounded (MVCC) timestamps
-	// then it can not trivially bump its timestamp without dropping and
-	// re-acquiring those latches. Doing so could allow the request to read at an
-	// unprotected timestamp. We only look at global latch spans because local
+	// then it cannot trivially bump its timestamp without dropping and
+	// re-acquiring those latches. Doing so could allow the request to read at
+	// an unprotected timestamp. We only look at global latch spans because local
 	// latch spans always use unbounded (NonMVCC) timestamps.
-	return len(g.Req.LatchSpans.GetSpans(spanset.SpanReadOnly, spanset.SpanGlobal)) == 0 &&
-		// Similarly, if the request intends to perform any non-locking reads, it
-		// cannot trivially bump its timestamp and expect to be isolated at the
-		// higher timestamp. Bumping its timestamp could cause the request to
-		// conflict with locks that it previously did not conflict with. It must
-		// drop its lockTableGuard and re-scan the lockTable.
+	//
+	// Even still, the existence of read only global latch spans is not enough for
+	// us to determine that the request is not isolated at higher timestamps -- we
+	// must check the timestamps at which the latches are declared as well. That's
+	// because if a read latch is declared at hlc.MaxTimestamp, it is isolated at
+	// higher timestamps; shared locking requests do exactly this.
+	readLatchesIsolatedAtHigherTimestamp := true
+	for _, l := range g.Req.LatchSpans.GetSpans(spanset.SpanReadOnly, spanset.SpanGlobal) {
+		if !l.Timestamp.Equal(hlc.MaxTimestamp) {
+			readLatchesIsolatedAtHigherTimestamp = false
+			break
+		}
+	}
+	// If read latches are isolated at higher timestamps then the request can
+	// trivially bump its timestamp without dropping and re-acquiring those
+	// latches. There's no need to check write latches, as they're always isolated
+	// at higher timestamps.
+	return readLatchesIsolatedAtHigherTimestamp &&
+		// If the request intends to perform any non-locking reads, it cannot
+		// trivially bump its timestamp and expect to be isolated at the higher
+		// timestamp. Bumping its timestamp could cause the request to conflict with
+		// locks that it previously did not conflict with. It must drop its
+		// lockTableGuard and re-scan the lockTable.
 		len(g.Req.LockSpans.GetSpans(lock.None)) == 0
 }
 


### PR DESCRIPTION
Previously, shared locking requests were not able to hit the server side refresh optimization because we incorrectly determined their latches were not isolated at higher timestamps (which they are).

Fixes #110650

Release note: None