### PR TITLE
testcluster: remove unnecessary merge queue disabling

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/event_log
+++ b/pkg/sql/logictest/testdata/logic_test/event_log
@@ -478,7 +478,6 @@ AND info NOT LIKE '%sql.stats%'
 ORDER BY "timestamp", info
 ----
 1  {"ApplicationName": "$ internal-optInToDiagnosticsStatReporting", "EventType": "set_cluster_setting", "SettingName": "diagnostics.reporting.enabled", "Statement": "SET CLUSTER SETTING \"diagnostics.reporting.enabled\" = true", "Tag": "SET CLUSTER SETTING", "User": "root", "Value": "true"}
-1  {"ApplicationName": "$ internal-enable-merge-queue", "EventType": "set_cluster_setting", "SettingName": "kv.range_merge.queue.enabled", "Statement": "SET CLUSTER SETTING \"kv.range_merge.queue.enabled\" = false", "Tag": "SET CLUSTER SETTING", "User": "root", "Value": "false"}
 1  {"EventType": "set_cluster_setting", "SettingName": "sql.crdb_internal.table_row_statistics.as_of_time", "Statement": "SET CLUSTER SETTING \"sql.crdb_internal.table_row_statistics.as_of_time\" = e'-1\\u00B5s'", "Tag": "SET CLUSTER SETTING", "User": "root", "Value": "-00:00:00.000001"}
 1  {"EventType": "set_cluster_setting", "SettingName": "kv.allocator.load_based_lease_rebalancing.enabled", "Statement": "SET CLUSTER SETTING \"kv.allocator.load_based_lease_rebalancing.enabled\" = false", "Tag": "SET CLUSTER SETTING", "User": "root", "Value": "false"}
 1  {"EventType": "set_cluster_setting", "SettingName": "kv.allocator.load_based_lease_rebalancing.enabled", "Statement": "SET CLUSTER SETTING \"kv.allocator.load_based_lease_rebalancing.enabled\" = DEFAULT", "Tag": "SET CLUSTER SETTING", "User": "root", "Value": "DEFAULT"}

--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -431,22 +431,6 @@ func (tc *TestCluster) Start(t serverutils.TestFataler) {
 		tc.WaitForNStores(t, tc.NumServers(), tc.Servers[0].StorageLayer().GossipI().(*gossip.Gossip))
 	}
 
-	if tc.clusterArgs.ReplicationMode == base.ReplicationManual {
-		// We've already disabled the merge queue via testing knobs above, but ALTER
-		// TABLE ... SPLIT AT will throw an error unless we also disable merges via
-		// the cluster setting.
-		//
-		// TODO(benesch): this won't be necessary once we have sticky bits for
-		// splits.
-		if _, err := tc.Servers[0].SystemLayer().
-			InternalExecutor().(isql.Executor).
-			Exec(ctx, "enable-merge-queue", nil, /* txn */
-				`SET CLUSTER SETTING kv.range_merge.queue.enabled = false`); err != nil {
-			tc.Stopper().Stop(ctx)
-			t.Fatal(err)
-		}
-	}
-
 	if disableLBS {
 		if _, err := tc.Servers[0].SystemLayer().
 			InternalExecutor().(isql.Executor).


### PR DESCRIPTION
The flag DisableSQLServer was added as part of #111298. In order to use it in more places requires that SQL is not called from KV or below tests. However testcluster was calling SQL as part of Start. This change removes the now unnecessary call to set `kv.range_merge.queue.enabled`.

Epic: none

Release note: None