### PR TITLE
changefeedccl: support confluent-cloud sink scheme

### DIFF
--- a/pkg/ccl/changefeedccl/changefeedbase/options.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/options.go
@@ -217,6 +217,10 @@ const (
 	SinkParamSASLScopes             = `sasl_scopes`
 	SinkParamSASLGrantType          = `sasl_grant_type`
 
+	SinkSchemeConfluentKafka    = `confluent-cloud`
+	SinkParamConfluentAPIKey    = `api_key`
+	SinkParamConfluentAPISecret = `api_secret`
+
 	RegistryParamCACert     = `ca_cert`
 	RegistryParamClientCert = `client_cert`
 	RegistryParamClientKey  = `client_key`

--- a/pkg/ccl/changefeedccl/sink.go
+++ b/pkg/ccl/changefeedccl/sink.go
@@ -232,7 +232,7 @@ func getSink(
 				nullIsAccounted = knobs.NullSinkIsExternalIOAccounted
 			}
 			return makeNullSink(sinkURL{URL: u}, metricsBuilder(nullIsAccounted))
-		case u.Scheme == changefeedbase.SinkSchemeKafka:
+		case isKafkaSink(u):
 			return validateOptionsAndMakeSink(changefeedbase.KafkaValidOptions, func() (Sink, error) {
 				return makeKafkaSink(ctx, sinkURL{URL: u}, AllTargets(feedCfg), opts.GetKafkaConfigJSON(), serverCfg.Settings, metricsBuilder)
 			})

--- a/pkg/ccl/changefeedccl/sink_external_connection.go
+++ b/pkg/ccl/changefeedccl/sink_external_connection.go
@@ -99,6 +99,7 @@ var supportedExternalConnectionTypes = map[string]connectionpb.ConnectionProvide
 	changefeedbase.SinkSchemeKafka:                 connectionpb.ConnectionProvider_kafka,
 	changefeedbase.SinkSchemeWebhookHTTP:           connectionpb.ConnectionProvider_webhookhttp,
 	changefeedbase.SinkSchemeWebhookHTTPS:          connectionpb.ConnectionProvider_webhookhttps,
+	changefeedbase.SinkSchemeConfluentKafka:        connectionpb.ConnectionProvider_kafka,
 	// TODO (zinger): Not including SinkSchemeExperimentalSQL for now because A: it's undocumented
 	// and B, in tests it leaks a *gosql.DB and I can't figure out why.
 }

--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -981,6 +981,10 @@ func runCDCKafkaAuth(ctx context.Context, t test.Test, c cluster.Cluster) {
 			"create changefeed with TLS transport and SASL/SCRAM-SHA-512",
 			fmt.Sprintf("%s?tls_enabled=true&ca_cert=%s&sasl_enabled=true&sasl_user=scram512&sasl_password=scram512-secret&sasl_mechanism=SCRAM-SHA-512", saslURL, caCert),
 		},
+		{
+			"create changefeed with confluent-cloud scheme",
+			fmt.Sprintf("%s&api_key=plain&api_secret=plain-secret", kafka.sinkURLAsConfluentCloudUrl(ctx)),
+		},
 	}
 
 	for _, f := range feeds {
@@ -2286,6 +2290,20 @@ func (k kafkaManager) sinkURLSASL(ctx context.Context) string {
 		k.t.Fatal(err)
 	}
 	return `kafka://` + ips[0] + `:9094`
+}
+
+// sinkURLAsConfluentCloudUrl allows the test to connect to the kafka brokers
+// as if it was connecting to kafka hosted in confluent cloud.
+func (k kafkaManager) sinkURLAsConfluentCloudUrl(ctx context.Context) string {
+	ips, err := k.c.InternalIP(ctx, k.t.L(), k.nodes)
+	if err != nil {
+		k.t.Fatal(err)
+	}
+	// Confluent cloud does not use TLS 1.2 and instead uses PLAIN username/password
+	// authentication (see https://docs.confluent.io/platform/current/security/security_tutorial.html#overview).
+	// Because the kafka manager has certs configured, connecting without a ca_cert will raise an error.
+	// To connect without a cert, we set insecure_tls_skip_verify=true.
+	return `confluent-cloud://` + ips[0] + `:9094?insecure_tls_skip_verify=true`
 }
 
 func (k kafkaManager) sinkURLOAuth(ctx context.Context, creds clientcredentials.Config) string {


### PR DESCRIPTION
### changefeedccl: support confluent-cloud sink scheme

This change lets users create kafka changefeeds with the `confluent-cloud://`
sink scheme. This scheme can be used to connect to kafka hosted on confluent cloud.
The required parameters are `api_key` and `api_secret` which are passed in as the
`sasl_user` and `sasl_password` of the kafka connection.

The options `tls_enabled=true`, `sasl_enabled=true`, `sasl_handshake=true`, and
`sasl_mechanism=PLAIN` are also needed, so they are set by default.

Release note (enterprise change): Changefeeds now support the `confluent-cloud://`
sink scheme. This scheme can be used to connect to kafka hosted on confluent cloud.
The scheme functions identically to kafka, but it has it's own authentication
parameters. Namely, it requires `api_key` and `api_secret` to be passed as
parameters in the sink URI. They must be URL encoded. An example URI is:
```
'confluent-cloud://pkc-lzvrd.us-west4.gcp.confluent.cloud:9092?api_key=<KEY>&api_secret=<SECRET>'
```
By default the options `tls_enabled=true`, `sasl_handshake=true`, `sasl_enabled=true`,
and `sasl_mechanism=PLAIN`, are applied. There is more information about authenticating
with confluent cloud, see https://docs.confluent.io/platform/current/security/security_tutorial.html#overview.

The sink scheme still supports non-authentication parameters such as `topic_name` and `topic_prefix`.
It also supports the standard kafka changefeed options (ex. `kafka_sink_config`).

Closes: https://github.com/cockroachdb/cockroach/issues/105226
Epic: [CRDB-28929](https://cockroachlabs.atlassian.net/browse/CRDB-28929)

---

### roachtest/cdc: test confluent-cloud scheme in cdc/kafka-auth roachtest
This change updates the `cdc/kafka-auth` roachtest to create a changefeed
with the `confluent-cloud` scheme.

Epic: None
Release note: None