### PR TITLE
jobs: set clusterID and clusterVersion during schedule creation

### DIFF
--- a/pkg/ccl/backupccl/create_scheduled_backup.go
+++ b/pkg/ccl/backupccl/create_scheduled_backup.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/ccl/backupccl/backuppb"
 	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
 	"github.com/cockroachdb/cockroach/pkg/cloud"
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/scheduledjobs"
@@ -34,12 +35,15 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 	pbtypes "github.com/gogo/protobuf/types"
 	cron "github.com/robfig/cron/v3"
 )
 
 const (
+	// TODO(msbutler): move these three constants to scheduleBase package to
+	// remove duplication with changefeed schedules.
 	optFirstRun                = "first_run"
 	optOnExecFailure           = "on_execution_failure"
 	optOnPreviousRunning       = "on_previous_running"
@@ -91,7 +95,10 @@ type scheduledBackupSpec struct {
 	updatesMetrics             *bool
 }
 
-func makeScheduleDetails(opts map[string]string) (jobspb.ScheduleDetails, error) {
+// TODO(msbutler): move this function into scheduleBase and remove duplicate function in scheduled changefeeds.
+func makeScheduleDetails(
+	opts map[string]string, clusterID uuid.UUID, version clusterversion.ClusterVersion,
+) (jobspb.ScheduleDetails, error) {
 	var details jobspb.ScheduleDetails
 	if v, ok := opts[optOnExecFailure]; ok {
 		if err := schedulebase.ParseOnError(v, &details); err != nil {
@@ -104,6 +111,8 @@ func makeScheduleDetails(opts map[string]string) (jobspb.ScheduleDetails, error)
 			return details, err
 		}
 	}
+	details.ClusterID = clusterID
+	details.CreationClusterVersion = version
 	return details, nil
 }
 
@@ -302,8 +311,8 @@ func doCreateBackupSchedules(
 	if err != nil {
 		return err
 	}
-
-	details, err := makeScheduleDetails(scheduleOptions)
+	clusterVersion := p.ExecCfg().Settings.Version.ActiveVersion(ctx)
+	details, err := makeScheduleDetails(scheduleOptions, evalCtx.ClusterID, clusterVersion)
 	if err != nil {
 		return err
 	}

--- a/pkg/ccl/backupccl/create_scheduled_backup_test.go
+++ b/pkg/ccl/backupccl/create_scheduled_backup_test.go
@@ -1146,9 +1146,9 @@ INSERT INTO t values (1), (10), (100);
 			s := th.loadSchedule(t, id)
 			s.SetNextRun(s.NextRun().Add(-365 * 24 * time.Hour))
 			// Set onError policy to the specified value.
-			s.SetScheduleDetails(jobspb.ScheduleDetails{
+			s.SetScheduleDetails(jobstest.AddDummyScheduleDetails(jobspb.ScheduleDetails{
 				OnError: onError,
-			})
+			}))
 			schedules := jobs.ScheduledJobDB(th.internalDB())
 			require.NoError(t, schedules.Update(context.Background(), s))
 		}

--- a/pkg/ccl/jobsccl/jobsprotectedtsccl/BUILD.bazel
+++ b/pkg/ccl/jobsccl/jobsprotectedtsccl/BUILD.bazel
@@ -15,6 +15,7 @@ go_test(
         "//pkg/jobs",
         "//pkg/jobs/jobspb",
         "//pkg/jobs/jobsprotectedts",
+        "//pkg/jobs/jobstest",
         "//pkg/keys",
         "//pkg/kv/kvserver/protectedts",
         "//pkg/kv/kvserver/protectedts/ptpb",

--- a/pkg/ccl/jobsccl/jobsprotectedtsccl/jobs_protected_ts_test.go
+++ b/pkg/ccl/jobsccl/jobsprotectedtsccl/jobs_protected_ts_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobsprotectedts"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobstest"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/protectedts"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/protectedts/ptpb"
@@ -219,6 +220,7 @@ func testSchedulesProtectedTimestamp(
 		j.SetOwner(username.TestUserName())
 		any, err := types.MarshalAny(&jobspb.SqlStatementExecutionArg{Statement: ""})
 		require.NoError(t, err)
+		j.SetScheduleDetails(jobstest.AddDummyScheduleDetails(jobspb.ScheduleDetails{}))
 		j.SetExecutionDetails(jobs.InlineExecutorName, jobspb.ExecutionArguments{Args: any})
 		return j
 	}

--- a/pkg/jobs/BUILD.bazel
+++ b/pkg/jobs/BUILD.bazel
@@ -74,6 +74,7 @@ go_library(
         "//pkg/util/timeutil",
         "//pkg/util/tracing",
         "//pkg/util/tracing/tracingpb",
+        "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_errors//oserror",
         "@com_github_cockroachdb_logtags//:logtags",

--- a/pkg/jobs/executor_impl_test.go
+++ b/pkg/jobs/executor_impl_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobstest"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -58,7 +59,7 @@ func TestInlineExecutorFailedJobsHandling(t *testing.T) {
 			j.rec.ExecutorType = InlineExecutorName
 
 			require.NoError(t, j.SetSchedule("@daily"))
-			j.SetScheduleDetails(jobspb.ScheduleDetails{OnError: test.onError})
+			j.SetScheduleDetails(jobstest.AddDummyScheduleDetails(jobspb.ScheduleDetails{OnError: test.onError}))
 
 			ctx := context.Background()
 			require.NoError(t, ScheduledJobDB(h.cfg.DB).Create(ctx, j))

--- a/pkg/jobs/job_scheduler_test.go
+++ b/pkg/jobs/job_scheduler_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobstest"
 	"github.com/cockroachdb/cockroach/pkg/scheduledjobs"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/settings"
@@ -64,7 +65,7 @@ func TestJobSchedulerReschedulesRunning(t *testing.T) {
 		t.Run(wait.String(), func(t *testing.T) {
 			// Create job with the target wait behavior.
 			j := h.newScheduledJob(t, "j", "j sql")
-			j.SetScheduleDetails(jobspb.ScheduleDetails{Wait: wait})
+			j.SetScheduleDetails(jobstest.AddDummyScheduleDetails(jobspb.ScheduleDetails{Wait: wait}))
 			require.NoError(t, j.SetSchedule("@hourly"))
 
 			require.NoError(t,
@@ -121,7 +122,7 @@ func TestJobSchedulerExecutesAfterTerminal(t *testing.T) {
 		t.Run(wait.String(), func(t *testing.T) {
 			// Create job that waits for the previous runs to finish.
 			j := h.newScheduledJob(t, "j", "SELECT 42 AS meaning_of_life;")
-			j.SetScheduleDetails(jobspb.ScheduleDetails{Wait: wait})
+			j.SetScheduleDetails(jobstest.AddDummyScheduleDetails(jobspb.ScheduleDetails{Wait: wait}))
 			require.NoError(t, j.SetSchedule("@hourly"))
 
 			require.NoError(t,
@@ -559,7 +560,7 @@ func TestJobSchedulerRetriesFailed(t *testing.T) {
 	} {
 		t.Run(tc.onError.String(), func(t *testing.T) {
 			h.env.SetTime(startTime)
-			schedule.SetScheduleDetails(jobspb.ScheduleDetails{OnError: tc.onError})
+			schedule.SetScheduleDetails(jobstest.AddDummyScheduleDetails(jobspb.ScheduleDetails{OnError: tc.onError}))
 			require.NoError(t, schedule.SetSchedule("@hourly"))
 			require.NoError(t, schedules.Update(ctx, schedule))
 
@@ -597,6 +598,7 @@ func TestJobSchedulerDaemonUsesSystemTables(t *testing.T) {
 	schedule.SetScheduleLabel("test schedule")
 	schedule.SetOwner(username.TestUserName())
 	schedule.SetNextRun(timeutil.Now())
+	schedule.SetScheduleDetails(jobstest.AddDummyScheduleDetails(jobspb.ScheduleDetails{}))
 	any, err := types.MarshalAny(
 		&jobspb.SqlStatementExecutionArg{Statement: "INSERT INTO defaultdb.foo VALUES (1), (2), (3)"})
 	require.NoError(t, err)
@@ -699,6 +701,7 @@ INSERT INTO defaultdb.foo VALUES(1, 1)
 	nextRun := h.env.Now().Add(time.Hour)
 	schedule.SetNextRun(nextRun)
 	schedule.SetExecutionDetails(execName, jobspb.ExecutionArguments{})
+	schedule.SetScheduleDetails(jobstest.AddDummyScheduleDetails(jobspb.ScheduleDetails{}))
 	require.NoError(t, schedules.Create(ctx, schedule))
 
 	// Execute schedule on another thread.
@@ -821,6 +824,7 @@ func TestDisablingSchedulerCancelsSchedules(t *testing.T) {
 	schedule.SetOwner(username.TestUserName())
 	schedule.SetNextRun(timeutil.Now())
 	schedule.SetExecutionDetails(executorName, jobspb.ExecutionArguments{})
+	schedule.SetScheduleDetails(jobstest.AddDummyScheduleDetails(jobspb.ScheduleDetails{}))
 	require.NoError(t, schedules.Create(context.Background(), schedule))
 
 	readWithTimeout(t, ex.started)
@@ -859,6 +863,7 @@ func TestSchedulePlanningRespectsTimeout(t *testing.T) {
 	schedule.SetOwner(username.TestUserName())
 	schedule.SetNextRun(timeutil.Now())
 	schedule.SetExecutionDetails(executorName, jobspb.ExecutionArguments{})
+	schedule.SetScheduleDetails(jobstest.AddDummyScheduleDetails(jobspb.ScheduleDetails{}))
 	require.NoError(t, schedules.Create(context.Background(), schedule))
 
 	readWithTimeout(t, ex.started)

--- a/pkg/jobs/jobspb/schedule.proto
+++ b/pkg/jobs/jobspb/schedule.proto
@@ -12,7 +12,10 @@ syntax = "proto3";
 package cockroach.jobs.jobspb;
 option go_package = "github.com/cockroachdb/cockroach/pkg/jobs/jobspb";
 
+import "gogoproto/gogo.proto";
 import "google/protobuf/any.proto";
+import "clusterversion/cluster_version.proto";
+
 
 // ScheduleDetails describes how to schedule and execute the job.
 message ScheduleDetails {
@@ -44,6 +47,19 @@ message ScheduleDetails {
 
   // How to handle failed jobs.
   ErrorHandlingBehavior on_error = 2;
+
+  // ClusterID is populated at schedule creation with the ClusterID, in case a
+  // schedule resuming later, needs to use this information, e.g. to determine if it
+  // has been restored into a different cluster, which might mean it should
+  // terminate, pause or update some other state.
+  //
+  // A resuming schedule may change the cluster_id
+  // on resumption.
+  bytes cluster_id = 3 [(gogoproto.nullable) = false, (gogoproto.customname) = "ClusterID",
+    (gogoproto.customtype) = "github.com/cockroachdb/cockroach/pkg/util/uuid.UUID"];
+
+  // CreationClusterVersion documents the cluster version this schedule was created on.
+  clusterversion.ClusterVersion creation_cluster_version = 4 [(gogoproto.nullable) = false];
 }
 
 // ExecutionArguments describes data needed to execute scheduled jobs.

--- a/pkg/jobs/jobstest/BUILD.bazel
+++ b/pkg/jobs/jobstest/BUILD.bazel
@@ -9,6 +9,8 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/jobs/jobstest",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/clusterversion",
+        "//pkg/jobs/jobspb",
         "//pkg/scheduledjobs",
         "//pkg/sql/catalog/systemschema",
         "//pkg/sql/sem/tree",
@@ -16,6 +18,7 @@ go_library(
         "//pkg/util/log",
         "//pkg/util/log/eventpb",
         "//pkg/util/syncutil",
+        "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",
     ],

--- a/pkg/jobs/jobstest/utils.go
+++ b/pkg/jobs/jobstest/utils.go
@@ -15,10 +15,13 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/scheduledjobs"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 )
 
 // EnvTablesType tells JobSchedulerTestEnv whether to use the system tables,
@@ -139,4 +142,18 @@ func GetJobsTableSchema(env scheduledjobs.JobSchedulerEnv) string {
 	}
 	return strings.Replace(systemschema.JobsTableSchema,
 		"system.jobs", env.SystemJobsTableName(), 1)
+}
+
+// DummyClusterID is used while instantiating dummy schedules
+var DummyClusterID = uuid.UUID{1}
+
+// DummyClusterVersion is used while instantiating dummy schedules
+var DummyClusterVersion = clusterversion.ClusterVersion{Version: clusterversion.TestingBinaryVersion}
+
+// AddDummyScheduleDetails augments passed in details with a dummy clusterID and CreationClusterVersion.
+func AddDummyScheduleDetails(details jobspb.ScheduleDetails) jobspb.ScheduleDetails {
+	dummyDetails := details
+	dummyDetails.ClusterID = DummyClusterID
+	dummyDetails.CreationClusterVersion = DummyClusterVersion
+	return dummyDetails
 }

--- a/pkg/jobs/scheduled_job_test.go
+++ b/pkg/jobs/scheduled_job_test.go
@@ -15,9 +15,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobstest"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/stretchr/testify/require"
 )
 
@@ -120,4 +123,37 @@ func TestPauseUnpauseJob(t *testing.T) {
 	// Running schedules have nextRun set to non-null value
 	require.False(t, loaded.IsPaused())
 	require.False(t, loaded.NextRun().Equal(time.Time{}))
+}
+
+// TestScheduleMustHaveClusterVersionAndID tests that the ClusterID and version
+// in the cluster details can be accessed. Further it tests that a schedule
+// cannot be created without these fields.
+func TestScheduleMustHaveClusterVersionAndID(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+
+	h, cleanup := newTestHelper(t)
+	defer cleanup()
+
+	sj := h.newScheduledJob(t, "test_job", "test sql")
+	schedules := ScheduledJobDB(h.cfg.DB)
+
+	// Fail without a Cluster version
+	sj.SetScheduleDetails(jobspb.ScheduleDetails{ClusterID: jobstest.DummyClusterID})
+	require.ErrorContains(t, schedules.Create(ctx, sj), "scheduled job created without a cluster version")
+
+	// Fail without a Cluster ID
+	sj.SetScheduleDetails(jobspb.ScheduleDetails{
+		CreationClusterVersion: jobstest.DummyClusterVersion,
+		ClusterID:              uuid.UUID{},
+	})
+	require.ErrorContains(t, schedules.Create(ctx, sj), "scheduled job created without a cluster ID")
+
+	// Succeed with both.
+	sj.SetScheduleDetails(jobstest.AddDummyScheduleDetails(jobspb.ScheduleDetails{}))
+	require.NoError(t, schedules.Create(ctx, sj))
+	loaded := h.loadSchedule(t, sj.ScheduleID())
+	require.EqualValues(t, jobstest.DummyClusterID, loaded.ScheduleDetails().ClusterID)
+	require.EqualValues(t, jobstest.DummyClusterVersion, loaded.ScheduleDetails().CreationClusterVersion)
 }

--- a/pkg/jobs/testutils_test.go
+++ b/pkg/jobs/testutils_test.go
@@ -115,6 +115,7 @@ func (h *testHelper) newScheduledJob(t *testing.T, scheduleLabel, sql string) *S
 	j.SetOwner(username.TestUserName())
 	any, err := types.MarshalAny(&jobspb.SqlStatementExecutionArg{Statement: sql})
 	require.NoError(t, err)
+	j.SetScheduleDetails(jobstest.AddDummyScheduleDetails(jobspb.ScheduleDetails{}))
 	j.SetExecutionDetails(InlineExecutorName, jobspb.ExecutionArguments{Args: any})
 	return j
 }
@@ -128,6 +129,7 @@ func (h *testHelper) newScheduledJobForExecutor(
 	j.SetScheduleLabel(scheduleLabel)
 	j.SetOwner(username.TestUserName())
 	j.SetExecutionDetails(executorName, jobspb.ExecutionArguments{Args: executorArgs})
+	j.SetScheduleDetails(jobstest.AddDummyScheduleDetails(jobspb.ScheduleDetails{}))
 	return j
 }
 

--- a/pkg/sql/check.go
+++ b/pkg/sql/check.go
@@ -805,6 +805,8 @@ func (p *planner) RepairTTLScheduledJobForTable(ctx context.Context, tableID int
 		jobs.ScheduledJobTxn(p.InternalSQLTxn()),
 		p.User(),
 		tableDesc,
+		p.extendedEvalCtx.ClusterID,
+		p.extendedEvalCtx.Settings.Version.ActiveVersion(ctx),
 	)
 	if err != nil {
 		return err

--- a/pkg/sql/crdb_internal_test.go
+++ b/pkg/sql/crdb_internal_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobsprotectedts"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobstest"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/keyvisualizer"
 	"github.com/cockroachdb/cockroach/pkg/kv"
@@ -1832,6 +1833,7 @@ func TestVirtualPTSTable(t *testing.T) {
 		sj.SetOwner(username.TestUserName())
 		sj.SetScheduleLabel("test-schedule")
 		sj.SetExecutionDetails(tree.ScheduledBackupExecutor.InternalName(), jobspb.ExecutionArguments{})
+		sj.SetScheduleDetails(jobstest.AddDummyScheduleDetails(jobspb.ScheduleDetails{}))
 
 		err := internalDB.Txn(ctx2, func(ctx3 context.Context, txn isql.Txn) error {
 			err2 := jobs.ScheduledJobTxn(txn).Create(ctx3, sj)

--- a/pkg/sql/logictest/testdata/logic_test/mixed_version_schedule_details
+++ b/pkg/sql/logictest/testdata/logic_test/mixed_version_schedule_details
@@ -1,0 +1,81 @@
+# LogicTest: cockroach-go-testserver-upgrade-to-master
+
+# This test verifies the scheduleDetails proto in the scheduled job record can
+# be read and written to in a mixed version state, given the 23.2 version has
+# new fields.
+
+# Verify that all nodes are running previous version binaries.
+
+query T nodeidx=0
+SELECT crdb_internal.node_executable_version()
+----
+23.1
+
+query T nodeidx=1
+SELECT crdb_internal.node_executable_version()
+----
+23.1
+
+query T nodeidx=2
+SELECT crdb_internal.node_executable_version()
+----
+23.1
+
+# Upgrade a node and create a schedule through it
+upgrade 0
+
+statement ok nodeidx=0
+CREATE SCHEDULE test FOR BACKUP INTO 'userfile:///1/example' RECURRING '@weekly' FULL BACKUP ALWAYS
+
+# Remember the full backup schedule
+let $fullID
+WITH SCHEDULES AS (SHOW SCHEDULES FOR BACKUP) SELECT id FROM schedules WHERE label='test'
+
+# Read from the scheduleDetails protobuf that stores the clusterID and Version from the updated node
+query TT nodeidx=0
+SELECT on_execution_failure, on_previous_running FROM [SHOW SCHEDULES FOR BACKUP] WHERE id = $fullID;
+----
+RETRY_SCHED WAIT
+
+
+# Read from the protobuf that stores the clusterID and Version an an old node.
+# Note that SHOW SCHEDULES on 23.1 does not read from the ScheduleDetails proto,
+# so we use pb_to_json to validate the read works.
+query T nodeidx=2
+SELECT crdb_internal.pb_to_json('cockroach.jobs.jobspb.ScheduleDetails', schedule_details, true) FROM system.scheduled_jobs WHERE schedule_id=$fullID;
+----
+{"onError": "RETRY_SCHED", "wait": "WAIT"}
+
+# Just for kicks, ensure SHOW SCHEDULES works on 23.1
+query T nodeidx=2
+SELECT schedule_status FROM [SHOW SCHEDULES FOR BACKUP] WHERE id = $fullID;
+----
+ACTIVE
+
+# Verify we can alter the schedule details on the old node and read this from the old and new nodes.
+statement ok nodeidx=2
+ALTER BACKUP SCHEDULE $fullID SET SCHEDULE OPTION on_previous_running = 'skip';
+
+query T nodeidx=2
+SELECT crdb_internal.pb_to_json('cockroach.jobs.jobspb.ScheduleDetails', schedule_details, true) FROM system.scheduled_jobs WHERE schedule_id=$fullID;
+----
+{"onError": "RETRY_SCHED", "wait": "SKIP"}
+
+query TT nodeidx=0
+SELECT on_execution_failure, on_previous_running FROM [SHOW SCHEDULES FOR BACKUP] WHERE id = $fullID;
+----
+RETRY_SCHED SKIP
+
+# Verify we can alter the schedule details on the new node and read it from the old and new nodes.
+statement ok nodeidx=2
+ALTER BACKUP SCHEDULE $fullID SET SCHEDULE OPTION on_previous_running = 'wait';
+
+query T nodeidx=2
+SELECT crdb_internal.pb_to_json('cockroach.jobs.jobspb.ScheduleDetails', schedule_details, true) FROM system.scheduled_jobs WHERE schedule_id=$fullID;
+----
+{"onError": "RETRY_SCHED", "wait": "WAIT"}
+
+query TT nodeidx=0
+SELECT on_execution_failure, on_previous_running FROM [SHOW SCHEDULES FOR BACKUP] WHERE id = $fullID;
+----
+RETRY_SCHED WAIT

--- a/pkg/sql/logictest/tests/cockroach-go-testserver-upgrade-to-master/BUILD.bazel
+++ b/pkg/sql/logictest/tests/cockroach-go-testserver-upgrade-to-master/BUILD.bazel
@@ -15,7 +15,7 @@ go_test(
         "//pkg/sql/logictest:testdata",  # keep
     ],
     exec_properties = {"Pool": "large"},
-    shard_count = 11,
+    shard_count = 12,
     tags = [
         "cpu:2",
     ],

--- a/pkg/sql/logictest/tests/cockroach-go-testserver-upgrade-to-master/generated_test.go
+++ b/pkg/sql/logictest/tests/cockroach-go-testserver-upgrade-to-master/generated_test.go
@@ -134,6 +134,13 @@ func TestLogic_mixed_version_role_members_user_ids(
 	runLogicTest(t, "mixed_version_role_members_user_ids")
 }
 
+func TestLogic_mixed_version_schedule_details(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "mixed_version_schedule_details")
+}
+
 func TestLogic_mixed_version_system_privileges_user_id(
 	t *testing.T,
 ) {

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -1627,6 +1627,8 @@ func (sc *SchemaChanger) done(ctx context.Context) error {
 							scheduledJobs,
 							scTable.GetPrivileges().Owner(),
 							scTable,
+							sc.execCfg.NodeInfo.LogicalClusterID(),
+							sc.settings.Version.ActiveVersion(ctx),
 						)
 						if err != nil {
 							return err

--- a/pkg/sql/sqlstats/persistedsqlstats/compaction_scheduling.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/compaction_scheduling.go
@@ -57,8 +57,10 @@ func CreateSQLStatsCompactionScheduleIfNotYetExist(
 	}
 
 	compactionSchedule.SetScheduleDetails(jobspb.ScheduleDetails{
-		Wait:    jobspb.ScheduleDetails_SKIP,
-		OnError: jobspb.ScheduleDetails_RETRY_SCHED,
+		Wait:                   jobspb.ScheduleDetails_SKIP,
+		OnError:                jobspb.ScheduleDetails_RETRY_SCHED,
+		ClusterID:              clusterID,
+		CreationClusterVersion: st.Version.ActiveVersion(ctx),
 	})
 
 	compactionSchedule.SetScheduleLabel(compactionScheduleName)

--- a/pkg/upgrade/BUILD.bazel
+++ b/pkg/upgrade/BUILD.bazel
@@ -29,6 +29,7 @@ go_library(
         "//pkg/upgrade/upgradebase",
         "//pkg/util/log",
         "//pkg/util/stop",
+        "//pkg/util/uuid",
         "@com_github_cockroachdb_logtags//:logtags",
     ],
 )

--- a/pkg/upgrade/tenant_upgrade.go
+++ b/pkg/upgrade/tenant_upgrade.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/upgrade/upgradebase"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/logtags"
 )
 
@@ -39,6 +40,7 @@ type TenantDeps struct {
 	LeaseManager *lease.Manager
 	JobRegistry  *jobs.Registry
 	SessionData  *sessiondata.SessionData
+	ClusterID    uuid.UUID
 
 	// TODO(ajwerner): Remove this in favor of the descs.DB above.
 	InternalExecutor isql.Executor

--- a/pkg/upgrade/upgradejob/upgrade_job.go
+++ b/pkg/upgrade/upgradejob/upgrade_job.go
@@ -96,6 +96,7 @@ func (r resumer) Resume(ctx context.Context, execCtxI interface{}) error {
 			JobRegistry:      execCtx.ExecCfg().JobRegistry,
 			TestingKnobs:     execCtx.ExecCfg().UpgradeTestingKnobs,
 			SessionData:      execCtx.SessionData(),
+			ClusterID:        execCtx.ExtendedEvalContext().ClusterID,
 		}
 
 		tenantDeps.SchemaResolverConstructor = func(

--- a/pkg/upgrade/upgrademanager/manager.go
+++ b/pkg/upgrade/upgrademanager/manager.go
@@ -702,6 +702,7 @@ func (m *Manager) runMigration(
 				InternalExecutor: m.ie,
 				JobRegistry:      m.jr,
 				TestingKnobs:     &m.knobs,
+				ClusterID:        m.clusterID,
 			}); err != nil {
 				return err
 			}
@@ -889,6 +890,7 @@ func (m *Manager) checkPreconditions(ctx context.Context, versions []roachpb.Ver
 			LeaseManager:     m.lm,
 			InternalExecutor: m.ie,
 			JobRegistry:      m.jr,
+			ClusterID:        m.clusterID,
 		}); err != nil {
 			return errors.Wrapf(
 				err,

--- a/pkg/upgrade/upgrades/ensure_sql_schema_telemetry_schedule.go
+++ b/pkg/upgrade/upgrades/ensure_sql_schema_telemetry_schedule.go
@@ -25,7 +25,7 @@ func ensureSQLSchemaTelemetrySchedule(
 ) error {
 	return d.DB.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
 		_, err := schematelemetrycontroller.CreateSchemaTelemetrySchedule(
-			ctx, txn, d.Settings,
+			ctx, txn, d.Settings, d.ClusterID,
 		)
 		// If the schedule already exists, we have nothing more to do. This
 		// logic makes the upgrade idempotent.


### PR DESCRIPTION
upgrade: pass ClusterID to tenantDeps
Release note: None

----

jobs: set clusterID and clusterVersion during schedule creation
This patch adds two new fields to the ScheduleDetails proto, apart of the
schedule record:
- ClusterID: the cluster that created the schedule. Note that in a future PR,
  we will allow the backup schedule to alter this field on resume.
- CreationClusterVersion: the cluster version the schedule was created on.

This patch ensures that these fields must be set during schedule creation.

In the future, schedules after RESTORE and C2C cutover will pause themselves to
prevent conflicting with schedules potentially running on the backup/source
cluster.

Informs https://github.com/cockroachdb/cockroach/issues/108028

Release note: None