### PR TITLE
enginepb: use struct equality comparison in MVCCValueHeader.IsEmpty

### DIFF
--- a/pkg/storage/enginepb/mvcc3_valueheader.go
+++ b/pkg/storage/enginepb/mvcc3_valueheader.go
@@ -15,10 +15,7 @@ import "github.com/cockroachdb/cockroach/pkg/util/buildutil"
 // IsEmpty returns true if the header is empty.
 // gcassert:inline
 func (h MVCCValueHeader) IsEmpty() bool {
-	// NB: We don't use a struct comparison like h == MVCCValueHeader{} due to a
-	// Go 1.19 performance regression, see:
-	// https://github.com/cockroachdb/cockroach/issues/88818
-	return h.LocalTimestamp.IsEmpty() && h.KVNemesisSeq.Get() == 0
+	return h == MVCCValueHeader{}
 }
 
 func (h *MVCCValueHeader) pure() MVCCValueHeaderPure {


### PR DESCRIPTION
Now that we're on Go 1.20, the regression is gone.

```
goos: linux
goarch: amd64
cpu: Intel(R) Xeon(R) CPU @ 2.80GHz
                                                                 │   old.txt   │              new.txt               │
                                                                 │   sec/op    │   sec/op     vs base               │
EncodeMVCCValue/header=empty/value=tombstone-24                    4.797n ± 0%   4.809n ± 0%  +0.26% (p=0.000 n=10)
EncodeMVCCValue/header=empty/value=short-24                        4.796n ± 0%   4.809n ± 0%  +0.27% (p=0.000 n=10)
EncodeMVCCValue/header=empty/value=long-24                         4.797n ± 0%   4.809n ± 0%  +0.26% (p=0.000 n=10)
EncodeMVCCValue/header=local_walltime/value=tombstone-24           54.16n ± 1%   53.56n ± 0%  -1.10% (p=0.000 n=10)
EncodeMVCCValue/header=local_walltime/value=short-24               56.71n ± 1%   56.02n ± 1%  -1.22% (p=0.001 n=10)
EncodeMVCCValue/header=local_walltime/value=long-24                1.371µ ± 3%   1.314µ ± 1%  -4.16% (p=0.000 n=10)
EncodeMVCCValue/header=local_walltime+logical/value=long-24        1.346µ ± 2%   1.323µ ± 4%       ~ (p=0.160 n=10)
EncodeMVCCValue/header=local_walltime+logical/value=tombstone-24   57.56n ± 2%   57.09n ± 1%  -0.83% (p=0.029 n=10)
EncodeMVCCValue/header=local_walltime+logical/value=short-24       60.61n ± 1%   60.05n ± 1%  -0.92% (p=0.001 n=10)
geomean                                                            50.62n        50.10n       -1.02%
```

Epic: none
Resolves #89199.
Release note: None