### PR TITLE
build: add roachtest nightlies coverage scripts

### DIFF
--- a/build/teamcity/cockroach/coverage/roachtest_nightly_gce.sh
+++ b/build/teamcity/cockroach/coverage/roachtest_nightly_gce.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -exuo pipefail
+
+dir="$(dirname $(dirname $(dirname $(dirname "${0}"))))"
+
+source "$dir/teamcity-support.sh"  # For $root
+source "$dir/teamcity-bazel-support.sh"  # For run_bazel
+
+CLOUD=gce
+BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="-e LITERAL_ARTIFACTS_DIR=$root/artifacts -e BUILD_VCS_NUMBER -e CLOUD -e COCKROACH_DEV_LICENSE -e TESTS -e COUNT -e GITHUB_API_TOKEN -e GITHUB_ORG -e GITHUB_REPO -e GOOGLE_EPHEMERAL_CREDENTIALS -e GOOGLE_KMS_KEY_A -e GOOGLE_KMS_KEY_B -e GOOGLE_CREDENTIALS_ASSUME_ROLE -e GOOGLE_SERVICE_ACCOUNT -e SLACK_TOKEN -e TC_BUILDTYPE_ID -e TC_BUILD_BRANCH -e TC_BUILD_ID -e TC_SERVER_URL -e SELECT_PROBABILITY" \
+			       run_bazel build/teamcity/cockroach/coverage/roachtest_nightly_gce_impl.sh

--- a/build/teamcity/cockroach/coverage/roachtest_nightly_gce_impl.sh
+++ b/build/teamcity/cockroach/coverage/roachtest_nightly_gce_impl.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+set -exuo pipefail
+
+dir="$(dirname $(dirname $(dirname $(dirname "${0}"))))"
+
+source "$dir/teamcity-support.sh"
+
+if [[ ! -f ~/.ssh/id_rsa.pub ]]; then
+  ssh-keygen -q -C "roachtest-nightly-bazel $(date)" -N "" -f ~/.ssh/id_rsa
+fi
+
+# We will only spin up AMD64 clusters. Note that the TeamCity runner (this host)
+# doesn't need to be AMD64; the roachtest binary is always built for the host
+# architecture.
+$root/build/teamcity/cockroach/nightlies/roachtest_compile_bits.sh --with-code-coverage amd64
+
+echo "$GOOGLE_EPHEMERAL_CREDENTIALS" > creds.json
+gcloud auth activate-service-account --key-file=creds.json
+export ROACHPROD_USER=teamcity
+
+# See build/teamcity/util/roachtest_util.sh.
+PARALLELISM=16
+CPUQUOTA=1024
+FILTER="tag:aws tag:default"
+
+build/teamcity-roachtest-invoke.sh \
+  --metamorphic-encryption-probability=0.5 \
+  --select-probability="${SELECT_PROBABILITY:-1.0}" \
+  --cloud="${CLOUD}" \
+  --count="${COUNT-1}" \
+  --parallelism="${PARALLELISM}" \
+  --cpu-quota="${CPUQUOTA}" \
+  --cluster-id="${TC_BUILD_ID}" \
+  --artifacts=/artifacts \
+  --artifacts-literal="${LITERAL_ARTIFACTS_DIR:-}" \
+  --slack-token="${SLACK_TOKEN:-}" \
+  --go-cover \
+  ${TESTS:-} ${FILTER}


### PR DESCRIPTION
This script will be used in a coverage build that runs the nightlies
on GCE and collects coverage data.

Epic: none
Release note: None