### PR TITLE
release-22.2: roachtest: introduce `grafana-dump`, `--skip-init`

### DIFF
--- a/pkg/cmd/roachprod/flags.go
+++ b/pkg/cmd/roachprod/flags.go
@@ -246,8 +246,6 @@ func initFlags() {
 	cachedHostsCmd.Flags().StringVar(&cachedHostsCluster,
 		"cluster", "", "print hosts matching cluster")
 
-	// TODO (msbutler): this flag should instead point to a relative file path that's check into
-	// the repo, not some random URL.
 	grafanaStartCmd.Flags().StringVar(&grafanaConfig,
 		"grafana-config", "", "URL to grafana json config")
 
@@ -257,10 +255,8 @@ func initFlags() {
 	grafanaURLCmd.Flags().BoolVar(&grafanaurlOpen,
 		"open", false, "open the grafana dashboard url on the browser")
 
-	grafanaStopCmd.Flags().StringVar(&grafanaDumpDir, "dump-dir", "",
-		"the absolute path, on the machine running roachprod, to dump prometheus data to.\n"+
-			"In the dump-dir, the 'prometheus-docker-run.sh' script spins up a prometheus UI accessible on \n"+
-			" 0.0.0.0:9090. If dump-dir is empty, no data will get dumped.")
+	grafanaDumpCmd.Flags().StringVar(&grafanaDumpDir, "dump-dir", "",
+		"the absolute path to dump prometheus data to (use the contained 'prometheus-docker-run.sh' to visualize")
 
 	for _, cmd := range []*cobra.Command{createCmd, destroyCmd, extendCmd, logsCmd} {
 		cmd.Flags().StringVarP(&username, "username", "u", os.Getenv("ROACHPROD_USER"),

--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -920,10 +920,21 @@ and will scrape from all nodes in the cluster; NOTE: for arm64 clusters, use --a
 var grafanaStopCmd = &cobra.Command{
 	Use:   `grafana-stop <cluster>`,
 	Short: `spins down prometheus and grafana instances on the last node in the cluster`,
-	Long:  `spins down the prometheus and grafana instances on the last node in the cluster`,
 	Args:  cobra.ExactArgs(1),
 	Run: wrap(func(cmd *cobra.Command, args []string) error {
-		return roachprod.StopGrafana(context.Background(), roachprodLibraryLogger, args[0], grafanaDumpDir)
+		return roachprod.StopGrafana(context.Background(), roachprodLibraryLogger, args[0], "")
+	}),
+}
+
+var grafanaDumpCmd = &cobra.Command{
+	Use:   `grafana-dump <cluster>`,
+	Short: `dump prometheus data to the specified directory`,
+	Args:  cobra.ExactArgs(1),
+	Run: wrap(func(cmd *cobra.Command, args []string) error {
+		if grafanaDumpDir == "" {
+			return errors.New("--dump-dir unspecified")
+		}
+		return roachprod.PrometheusSnapshot(context.Background(), roachprodLibraryLogger, args[0], grafanaDumpDir)
 	}),
 }
 
@@ -1023,6 +1034,7 @@ func main() {
 		getProvidersCmd,
 		grafanaStartCmd,
 		grafanaStopCmd,
+		grafanaDumpCmd,
 		grafanaURLCmd,
 	)
 	setBashCompletionFunction()

--- a/pkg/cmd/roachtest/cluster_test.go
+++ b/pkg/cmd/roachtest/cluster_test.go
@@ -87,6 +87,10 @@ func (t testWrapper) VersionsBinaryOverride() map[string]string {
 	panic("implement me")
 }
 
+func (t testWrapper) SkipInit() bool {
+	panic("implement me")
+}
+
 func (t testWrapper) Progress(f float64) {
 	panic("implement me")
 }

--- a/pkg/cmd/roachtest/main.go
+++ b/pkg/cmd/roachtest/main.go
@@ -88,6 +88,7 @@ func main() {
 	var httpPort int
 	var debugEnabled bool
 	var runSkipped bool
+	var skipInit bool
 	var clusterID string
 	var count = 1
 	var versionsBinaryOverride map[string]string
@@ -263,6 +264,7 @@ Examples:
 			cpuQuota:               cpuQuota,
 			debugEnabled:           debugEnabled,
 			runSkipped:             runSkipped,
+			skipInit:               skipInit,
 			httpPort:               httpPort,
 			parallelism:            parallelism,
 			artifactsDir:           artifacts,
@@ -333,6 +335,8 @@ runner itself.
 			&debugEnabled, "debug", "d", debugEnabled, "don't wipe and destroy cluster if test fails")
 		cmd.Flags().BoolVar(
 			&runSkipped, "run-skipped", runSkipped, "run skipped tests")
+		cmd.Flags().BoolVar(
+			&skipInit, "skip-init", false, "skip initialization step (imports, table creation, etc.) for tests that support it, useful when re-using clusters with --wipe=false")
 		cmd.Flags().IntVarP(
 			&parallelism, "parallelism", "p", parallelism, "number of tests to run in parallel")
 		cmd.Flags().StringVar(
@@ -400,6 +404,7 @@ type cliCfg struct {
 	count                  int
 	cpuQuota               int
 	debugEnabled           bool
+	skipInit               bool
 	runSkipped             bool
 	httpPort               int
 	parallelism            int
@@ -486,7 +491,10 @@ func runTests(register func(registry.Registry), cfg cliCfg, benchOnly bool) erro
 	CtrlC(ctx, l, cancel, cr)
 	err = runner.Run(
 		ctx, tests, cfg.count, cfg.parallelism, opt,
-		testOpts{versionsBinaryOverride: cfg.versionsBinaryOverride},
+		testOpts{
+			versionsBinaryOverride: cfg.versionsBinaryOverride,
+			skipInit:               cfg.skipInit,
+		},
 		lopt, nil /* clusterAllocator */)
 
 	// Make sure we attempt to clean up. We run with a non-canceled ctx; the

--- a/pkg/cmd/roachtest/test/test_interface.go
+++ b/pkg/cmd/roachtest/test/test_interface.go
@@ -35,6 +35,7 @@ type Test interface {
 	// through all registered roachtests to change how they register the test.
 	Spec() interface{}
 	VersionsBinaryOverride() map[string]string
+	SkipInit() bool
 	Skip(args ...interface{})
 	Skipf(format string, args ...interface{})
 	Error(args ...interface{})

--- a/pkg/cmd/roachtest/test_impl.go
+++ b/pkg/cmd/roachtest/test_impl.go
@@ -110,6 +110,7 @@ type testImpl struct {
 	//
 	// Version strings look like "20.1.4".
 	versionsBinaryOverride map[string]string
+	skipInit               bool
 }
 
 func newFailure(squashedErr error, errs []error) failure {
@@ -137,6 +138,10 @@ func (t *testImpl) DeprecatedWorkload() string {
 
 func (t *testImpl) VersionsBinaryOverride() map[string]string {
 	return t.versionsBinaryOverride
+}
+
+func (t *testImpl) SkipInit() bool {
+	return t.skipInit
 }
 
 // Spec returns the TestSpec.

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -180,6 +180,7 @@ func (c clustersOpt) validate() error {
 
 type testOpts struct {
 	versionsBinaryOverride map[string]string
+	skipInit               bool
 }
 
 // Run runs tests.
@@ -690,6 +691,7 @@ func (r *testRunner) runWorker(
 			artifactsSpec:          artifactsSpec,
 			l:                      testL,
 			versionsBinaryOverride: topt.versionsBinaryOverride,
+			skipInit:               topt.skipInit,
 			debug:                  debug,
 		}
 		// Now run the test.

--- a/pkg/roachprod/prometheus/prometheus.go
+++ b/pkg/roachprod/prometheus/prometheus.go
@@ -375,7 +375,7 @@ func Snapshot(
 		os.Stderr,
 		promNode,
 		"prometheus snapshot",
-		`curl -XPOST http://localhost:9090/api/v1/admin/tsdb/snapshot &&
+		`sudo rm -rf /tmp/prometheus/data/snapshots/* && curl -XPOST http://localhost:9090/api/v1/admin/tsdb/snapshot &&
 	cd /tmp/prometheus && tar cvf prometheus-snapshot.tar.gz data/snapshots`,
 	); err != nil {
 		return err
@@ -383,6 +383,7 @@ func Snapshot(
 	if err := os.WriteFile(filepath.Join(dir, "prometheus-docker-run.sh"), []byte(`#!/bin/sh
 set -eu
 
+rm -rf data/snapshots
 tar xf prometheus-snapshot.tar.gz
 snapdir=$(find data/snapshots -mindepth 1 -maxdepth 1 -type d)
 promyml=$(mktemp)

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -1531,3 +1531,32 @@ func GrafanaURL(
 	}
 	return urls[0], nil
 }
+
+// PrometheusSnapshot takes a snapshot of prometheus and stores the snapshot and
+// a script to spin up a docker instance for it to the given directory. We
+// assume the last node contains the prometheus server.
+func PrometheusSnapshot(
+	ctx context.Context, l *logger.Logger, clusterName string, dumpDir string,
+) error {
+	if err := LoadClusters(); err != nil {
+		return err
+	}
+	c, err := newCluster(l, clusterName)
+	if err != nil {
+		return err
+	}
+	nodes, err := install.ListNodes("all", len(c.VMs))
+	if err != nil {
+		return err
+	}
+
+	promNode := install.Nodes{nodes[len(nodes)-1]}
+
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+	defer cancel()
+	if err := prometheus.Snapshot(ctx, c, l, promNode, dumpDir); err != nil {
+		l.Printf("failed to get prometheus snapshot: %v", err)
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
Backport 3/6 commits from #89191.

/cc @cockroachdb/release

Release justification: test only change, keep roachtest in sync.

Epic: none
Release note: None

---

#### roachprod: skip login step for `roachprod grafana-start`

Release note: None

#### roachtest: introduce a `grafana-dump` subcommand

This lets one create data dumps off of roachprod clusters that have been
collecting data using `roachprod grafana-start`. To use:
```
  roachprod grafana-dump $CLUSTER --dump-dir ./
  ./prometheus-docker-run.sh
```
The latter sets up a prometheus server on localhost:9090. To point your
grafana server to it, you can:

```
  brew install grafana
  brew services start grafana
  # navigate to localhost:3000
```

#### roachtest: introduce a --skip-init flag

For some tests to do have expensive initialization steps (large imports
for ex.), when iterating on them it's often useful to recycle roachtest
created clusters without re-running the full gamut. Introduce this flag
to let test authors define such fast paths.

Release note: None
