### PR TITLE
backup: align worker count with number of export requests

### DIFF
--- a/pkg/ccl/backupccl/backup_processor.go
+++ b/pkg/ccl/backupccl/backup_processor.go
@@ -659,7 +659,7 @@ func reserveWorkerMemory(
 ) (int, func(), error) {
 	// TODO(pbardea): Check to see if this benefits from any tuning (e.g. +1, or
 	//  *2). See #49798.
-	maxWorkerCount := int(kvserver.ExportRequestsLimit.Get(&settings.SV)) * 2
+	maxWorkerCount := kvserver.BackupRequestLimit(&settings.SV) * 2
 	// We assume that each worker needs at least enough memory to hold onto
 	// 1 buffer used by the external storage.
 	perWorkerMemory := cloud.WriteChunkSize.Get(&settings.SV)

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -1549,17 +1549,8 @@ func NewStore(
 	s.protectedtsReader = cfg.ProtectedTimestampReader
 	s.raftTransportForFlowControl = cfg.Transport
 
-	// On low-CPU instances, a default limit value may still allow ExportRequests
-	// to tie up all cores so cap limiter at cores-1 when setting value is higher.
-	exportCores := runtime.GOMAXPROCS(0) - 1
-	if exportCores < 1 {
-		exportCores = 1
-	}
 	ExportRequestsLimit.SetOnChange(&cfg.Settings.SV, func(ctx context.Context) {
-		limit := int(ExportRequestsLimit.Get(&cfg.Settings.SV))
-		if limit > exportCores {
-			limit = exportCores
-		}
+		limit := BackupRequestLimit(&cfg.Settings.SV)
 		s.limiters.ConcurrentExportRequests.SetLimit(limit)
 	})
 	s.limiters.ConcurrentAddSSTableRequests = limit.MakeConcurrentRequestLimiter(
@@ -3846,4 +3837,20 @@ func min(a, b int) int {
 		return a
 	}
 	return b
+}
+
+// BackupRequestLimit returns max number of concurrent export requests that
+// store can handle.
+func BackupRequestLimit(sv *settings.Values) int {
+	// On low-CPU instances, a default limit value may still allow ExportRequests
+	// to tie up all cores so cap limiter at cores-1 when setting value is higher.
+	exportCores := runtime.GOMAXPROCS(0) - 1
+	if exportCores < 1 {
+		exportCores = 1
+	}
+	maxExportRequests := int(ExportRequestsLimit.Get(sv))
+	if maxExportRequests > exportCores {
+		maxExportRequests = exportCores
+	}
+	return maxExportRequests
 }


### PR DESCRIPTION
Previously server will use minimum of
`kv.bulk_io_write.concurrent_export_requests` and number of CPU cores -1 to determine max number of concurrent export requests allowed. At the same time, backup processor used this setting only and didn't take CPU core count into account.
If setting was set higher than core count then number of inflight waiting requests would grow without any improvement potentially causing timeouts. This commit adds core count cap to backup processor.

Epic: none
Fixes: #111406

Release note (ops change): Number of backup processors per node will take number of CPU cores into account on top of `kv.bulk_io_write.concurrent_export_requests` setting.