### PR TITLE
multitenant,server: allow a secondary tenant to listen at known port

### DIFF
--- a/pkg/configprofiles/profiles.go
+++ b/pkg/configprofiles/profiles.go
@@ -94,6 +94,7 @@ var virtClusterInitTasks = []autoconfigpb.Task{
 			"SET CLUSTER SETTING spanconfig.range_coalescing.application.enabled = false",
 			// Make the operator double-check virtual cluster deletions.
 			"SET CLUSTER SETTING sql.drop_virtual_cluster.enabled = false",
+			"SET CLUSTER SETTING server.controller.reserved_port_cluster='application'",
 		},
 		nil, /* txnSQL */
 	),

--- a/pkg/multitenant/tenant_config.go
+++ b/pkg/multitenant/tenant_config.go
@@ -30,6 +30,13 @@ var DefaultTenantSelect = settings.RegisterStringSetting(
 	settings.WithName(DefaultClusterSelectSettingName),
 )
 
+var DefaultPortClusterName = settings.RegisterStringSetting(
+	settings.SystemOnly,
+	"server.controller.reserved_port_cluster",
+	"when a port offset has been given, name of the virtual cluster to assign the port exactly at the port offset",
+	"",
+)
+
 // VerifyTenantService determines whether there should be an advisory
 // interlock between changes to the tenant service and changes to the
 // above cluster setting.


### PR DESCRIPTION
This provides a basic mechanism for a given tenant to listen at a known port.

The goal of this is to lower firewall configuration overhead until CRDB-26690 is fixed.

Epic: CRDB-26690

Release note: None