### PR TITLE
build: improve roachtest build scripts

### DIFF
--- a/build/teamcity/cockroach/nightlies/roachtest_arch_util.sh
+++ b/build/teamcity/cockroach/nightlies/roachtest_arch_util.sh
@@ -1,0 +1,27 @@
+# arch_to_config returns the bazel config for the given arch.
+function arch_to_config() {
+  case "$1" in
+    amd64)
+      echo "crosslinux"
+      ;;
+    arm64)
+      echo "crosslinuxarm"
+      ;;
+    amd64-fips)
+      echo "crosslinuxfips"
+      ;;
+    *)
+      echo "Error: invalid arch '$1'" >&2
+      exit 1
+      ;;
+  esac
+}
+
+# get_host_arch determines the current host's CPU architecture.
+function get_host_arch() {
+  if [[ "$(uname -m)" =~ (arm64|aarch64)$ ]]; then
+    echo "arm64"
+  else
+    echo "amd64"
+  fi
+}

--- a/build/teamcity/cockroach/nightlies/roachtest_compile_component.sh
+++ b/build/teamcity/cockroach/nightlies/roachtest_compile_component.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source "$(dirname $0)/roachtest_arch_util.sh"
+
+if [ "$#" -eq 0 ]; then
+  echo "Builds components necessary for roachtests and stages them in bin/ and/or lib/."
+  echo ""
+  echo "Usage: $(basename $0) [--with-coverage] <os/arch/component>"
+  echo "  where os is one of: linux"
+  echo "        arch is one of: amd64, arm64, amd64-fips"
+  echo "        component is one of: cockroach, cockroach-ea, workload, libgeos, roachtest"
+  echo "  --with-coverage enables go code coverage instrumentation (only applies to cockroach binaries)"
+  exit 1
+fi
+
+crdb_extra_flags=""
+target=""
+
+for arg in "$@"; do
+  case "$arg" in
+    --with-code-coverage)
+      crdb_extra_flags="--collect_code_coverage --bazel_code_coverage"
+      ;;
+    *)
+      if [ -n "$target" ]; then
+        echo "Error: too many arguments"
+        exit 1
+      fi
+      target=$arg
+      ;;
+  esac
+done
+
+# Split $target into $os/$arch/$component.
+os=${target%%/*}
+arch_and_comp=${target#*/}
+arch=${arch_and_comp%%/*}
+component=${arch_and_comp#*/}
+
+if [ -z $os -o -z $arch -o -z $component ]; then
+  echo "Invalid target: $target; syntax is os/arch/component"
+  exit 1
+fi
+
+if [ "$os" != linux ]; then
+  echo "Invalid os; only linux supported"
+  exit 1
+fi
+
+config=$(arch_to_config $arch)
+
+# Array of arguments to be passed to bazel for the component.
+bazel_args=()
+# Array of build artifacts. Each item has format "src:dest"; src is relative to
+# the bazel-bin directory, dst is relative to cwd.
+artifacts=()
+
+case "$component" in
+  cockroach)
+    # Cockroach binary.
+    bazel_args=(--config force_build_cdeps //pkg/cmd/cockroach $crdb_extra_flags)
+    artifacts=("pkg/cmd/cockroach/cockroach_/cockroach:bin/cockroach.$os-$arch")
+    ;;
+  cockroach-ea)
+    # Cockroach-short with enabled assertions (EA).
+    bazel_args=(--config force_build_cdeps //pkg/cmd/cockroach-short --crdb_test $crdb_extra_flags)
+    artifacts=("pkg/cmd/cockroach-short/cockroach-short_/cockroach-short:bin/cockroach-ea.$os-$arch")
+    ;;
+  workload)
+    # Workload binary.
+    bazel_args=(--config force_build_cdeps //pkg/cmd/workload)
+    artifacts=("pkg/cmd/workload/workload_/workload:bin/workload.$os-$arch")
+    ;;
+  libgeos)
+    # Geos libs.
+    bazel_args=(--config force_build_cdeps //c-deps:libgeos)
+    artifacts=(
+      "c-deps/libgeos_foreign/lib/libgeos.so:lib/libgeos.$os-$arch.so"
+      "c-deps/libgeos_foreign/lib/libgeos_c.so:lib/libgeos_c.$os-$arch.so"
+    )
+    ;;
+  roachtest)
+    # Roachtest binary.
+    bazel_args=(//pkg/cmd/roachtest)
+    artifacts=("pkg/cmd/roachtest/roachtest_/roachtest:bin/roachtest.$os-$arch")
+    ;;
+  *)
+    echo "Unknown component '$component'"
+    exit 1
+    ;;
+esac
+
+echo "Building $os/$arch/$component..."
+
+bazel build --config $config --config ci -c opt "${bazel_args[@]}"
+BAZEL_BIN=$(bazel info bazel-bin --config $config --config ci -c opt)
+for artifact in "${artifacts[@]}"; do
+  src=${artifact%%:*}
+  dst=${artifact#*:}
+  cp "$BAZEL_BIN/$src" "$dst"
+  # Make files writable to simplify cleanup and copying (e.g., scp retry).
+  chmod a+w "$dst"
+done


### PR DESCRIPTION
We improve the roachtest scripts to support building finer-grained
components: the `roachtest_compile_component.sh` script builds a
single component (cockroach, cockroach-ea, workload, libgeos,
roachtest). For each component we define the bazel arguments and build
products, minimizing duplication of other code. There should be no
functional changes.

Epic: none
Release note: None
