### PR TITLE
roachtest: remove backup creation during node upgrades

### DIFF
--- a/pkg/cmd/roachtest/tests/versionupgrade.go
+++ b/pkg/cmd/roachtest/tests/versionupgrade.go
@@ -304,7 +304,7 @@ func uploadAndStart(nodes option.NodeListOption, v string) versionStep {
 func binaryUpgradeStep(nodes option.NodeListOption, newVersion string) versionStep {
 	return func(ctx context.Context, t test.Test, u *versionUpgradeTest) {
 		if err := clusterupgrade.RestartNodesWithNewBinary(
-			ctx, t, t.L(), u.c, nodes, option.DefaultStartOpts(), newVersion,
+			ctx, t, t.L(), u.c, nodes, option.DefaultStartOptsNoBackups(), newVersion,
 		); err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
In upgrade tests existing nodes try to start backup schedule on every binary restart. This is not adding any value as this feature tests that cluster will run backups created at initial cluster start.
At the same time those checks pollute logs constantly. This commit changes options for node restarts in upgrade tests to exclude backups.

Epic: none

Release note: None