### PR TITLE
sql: add deprecation notice when using EXPORT

### DIFF
--- a/pkg/ccl/backupccl/datadriven_test.go
+++ b/pkg/ccl/backupccl/datadriven_test.go
@@ -435,6 +435,7 @@ func runTestDataDriven(t *testing.T, testFilePathFromWorkspace string) {
 	defer ds.cleanup(ctx, t)
 	datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {
 		execWithTagAndPausePoint := func(jobType jobspb.Type) string {
+			ds.noticeBuffer = nil
 			const user = "root"
 			sqlDB := ds.getSQLDB(t, lastCreatedCluster, user)
 			// First, run the schema change.

--- a/pkg/ccl/backupccl/testdata/backup-restore/import-start-time
+++ b/pkg/ccl/backupccl/testdata/backup-restore/import-start-time
@@ -30,6 +30,7 @@ ON sys.id = tbls.id;
 exec-sql
 EXPORT INTO CSV 'nodelocal://1/export1/' FROM SELECT * FROM baz WHERE i = 1;
 ----
+NOTICE: EXPORT is not the recommended way to move data out of CockroachDB and may be deprecated in the future. Please consider exporting data with changefeeds instead: https://www.cockroachlabs.com/docs/stable/export-data-with-changefeeds
 
 exec-sql
 SET CLUSTER SETTING jobs.debug.pausepoints = 'import.after_ingest';
@@ -81,6 +82,7 @@ SELECT * FROM import_time
 exec-sql
 EXPORT INTO CSV 'nodelocal://1/export2/' FROM SELECT * FROM baz WHERE i = 2;
 ----
+NOTICE: EXPORT is not the recommended way to move data out of CockroachDB and may be deprecated in the future. Please consider exporting data with changefeeds instead: https://www.cockroachlabs.com/docs/stable/export-data-with-changefeeds
 
 exec-sql
 SET CLUSTER SETTING jobs.debug.pausepoints = 'import.after_ingest';

--- a/pkg/ccl/backupccl/testdata/backup-restore/in-progress-import-rollback
+++ b/pkg/ccl/backupccl/testdata/backup-restore/in-progress-import-rollback
@@ -37,6 +37,7 @@ SET CLUSTER SETTING kv.bulkio.write_metadata_sst.enabled = false;
 exec-sql
 EXPORT INTO CSV 'nodelocal://1/export1/' FROM SELECT * FROM baz;
 ----
+NOTICE: EXPORT is not the recommended way to move data out of CockroachDB and may be deprecated in the future. Please consider exporting data with changefeeds instead: https://www.cockroachlabs.com/docs/stable/export-data-with-changefeeds
 
 
 # Pause the import job, in order to back up the importing data.

--- a/pkg/ccl/backupccl/testdata/backup-restore/in-progress-imports
+++ b/pkg/ccl/backupccl/testdata/backup-restore/in-progress-imports
@@ -28,7 +28,7 @@ SET CLUSTER SETTING jobs.debug.pausepoints = 'import.after_ingest';
 exec-sql
 EXPORT INTO CSV 'nodelocal://1/export1/' FROM SELECT * FROM baz WHERE i = 1;
 ----
-
+NOTICE: EXPORT is not the recommended way to move data out of CockroachDB and may be deprecated in the future. Please consider exporting data with changefeeds instead: https://www.cockroachlabs.com/docs/stable/export-data-with-changefeeds
 
 # Pause the import job, in order to back up the importing data.
 import expect-pausepoint tag=a

--- a/pkg/sql/logictest/testdata/logic_test/export
+++ b/pkg/sql/logictest/testdata/logic_test/export
@@ -8,3 +8,8 @@ WITH cte AS (EXPORT INTO CSV 'nodelocal://1/export1/' FROM SELECT * FROM t) SELE
 
 statement ok
 WITH cte AS (EXPORT INTO PARQUET 'nodelocal://1/export1/' FROM SELECT * FROM t) SELECT filename FROM cte;
+
+query T noticetrace
+WITH cte AS (EXPORT INTO CSV 'nodelocal://1/export1/' FROM SELECT * FROM t) SELECT filename FROM cte;
+----
+NOTICE: EXPORT is not the recommended way to move data out of CockroachDB and may be deprecated in the future. Please consider exporting data with changefeeds instead: https://www.cockroachlabs.com/docs/stable/export-data-with-changefeeds


### PR DESCRIPTION
### sql: add deprecation notice when using EXPORT #111415

This change adds a notice to EXPORT which says "EXPORT is not the recommended way to move data out of CockroachDB and may be deprecated in the future. Please consider exporting data with changefeeds instead:
https://www.cockroachlabs.com/docs/stable/export-data-with-changefeeds"

Closes: https://github.com/cockroachdb/cockroach/issues/111363

---

### backupccl: start with empty notice buffer in datadriven tests

Before this change, notices from previous commands (ex. EXPORT)
would stay in the buffer when running the IMPORT command (and
a few other commands).

This change updates the commands affected by this issue to clear
the notice buffer before starting.

Release note: None
Epic: None