### PR TITLE
kvserver: don't call Replica.State unnecessarily 

### DIFF
--- a/pkg/kv/kvserver/client_raft_test.go
+++ b/pkg/kv/kvserver/client_raft_test.go
@@ -5652,7 +5652,7 @@ func TestElectionAfterRestart(t *testing.T) {
 								return
 							}
 
-							cur := replica.State(ctx).LastIndex
+							cur := replica.GetLastIndex()
 							if lastIndex == 0 {
 								lastIndex = cur
 							}

--- a/pkg/kv/kvserver/client_tenant_test.go
+++ b/pkg/kv/kvserver/client_tenant_test.go
@@ -91,12 +91,12 @@ func TestTenantsStorageMetricsOnSplit(t *testing.T) {
 		var aggregateStats enginepb.MVCCStats
 		var seen int
 		store.VisitReplicas(func(replica *kvserver.Replica) (wantMore bool) {
-			ri := replica.State(ctx)
-			if ri.TenantID != tenantID.ToUint64() {
+			id, _ := replica.TenantID() // now initialized
+			if id != tenantID {
 				return true
 			}
 			seen++
-			aggregateStats.Add(*ri.Stats)
+			aggregateStats.Add(replica.GetMVCCStats())
 			return true
 		})
 		ex := metric.MakePrometheusExporter()

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -2899,7 +2899,8 @@ func (s *systemStatusServer) localHotRanges(
 		for i, r := range ranges {
 			replica, err := store.GetReplica(r.Desc.GetRangeID())
 			if err == nil {
-				storeResp.HotRanges[i].LeaseholderNodeID = replica.State(ctx).Lease.Replica.NodeID
+				lease, _ := replica.GetLease()
+				storeResp.HotRanges[i].LeaseholderNodeID = lease.Replica.NodeID
 			}
 			storeResp.HotRanges[i].Desc = *r.Desc
 			storeResp.HotRanges[i].QueriesPerSecond = r.QPS


### PR DESCRIPTION
Replica.State is an expensive method that should only be used for the
Status interface. This PR removes the unnecessary uses of it by instead
calling targeted methods.

Epic: none

Release note: None