### PR TITLE
changefeedccl: fix data race with wrap sink knob

### DIFF
--- a/pkg/ccl/changefeedccl/sink_external_connection.go
+++ b/pkg/ccl/changefeedccl/sink_external_connection.go
@@ -67,12 +67,6 @@ func validateExternalConnectionSinkURI(
 		serverCfg = s
 	}
 
-	if knobs, ok := serverCfg.TestingKnobs.Changefeed.(*TestingKnobs); ok && knobs.WrapSink != nil {
-		wrapSink := knobs.WrapSink
-		knobs.WrapSink = nil
-		defer func() { knobs.WrapSink = wrapSink }()
-	}
-
 	// Validate the URI by creating a canary sink.
 	//
 	// TODO(adityamaru): When we add `CREATE EXTERNAL CONNECTION ... WITH` support


### PR DESCRIPTION
Previously, there was a data race which occurred with a testing knob when a changefeed was running concurrently to an external connection being created. The reason for this is that the external connection validation would set the wrap sink knob to nil while it created the canary sink and tested the external connection.

This change removes the logic which overrides the wrap sink knob during validation. Any test which uses the wrap sink knob should consider that it affects external connection validation.

Closes: https://github.com/cockroachdb/cockroach/issues/111381