### PR TITLE
kvserver: add Context to several methods

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -9365,13 +9365,13 @@ func TestExcludeDataFromBackupAndRestore(t *testing.T) {
 	// should be a noop and backup no data.
 	sqlDB.Exec(t, `ALTER TABLE data.foo SET (exclude_data_from_backup = true)`)
 	waitForReplicaFieldToBeSet(t, tc, conn, "foo", "data", func(r *kvserver.Replica) (bool, error) {
-		if !r.ExcludeDataFromBackup() {
+		if !r.ExcludeDataFromBackup(context.Background()) {
 			return false, errors.New("waiting for the range containing table data.foo to split")
 		}
 		return true, nil
 	})
 	waitForReplicaFieldToBeSet(t, tc, conn, "bar", "data", func(r *kvserver.Replica) (bool, error) {
-		if r.ExcludeDataFromBackup() {
+		if r.ExcludeDataFromBackup(context.Background()) {
 			return false, errors.New("waiting for the range containing table data.bar to split")
 		}
 		return true, nil
@@ -9383,7 +9383,7 @@ func TestExcludeDataFromBackupAndRestore(t *testing.T) {
 	sqlDB.Exec(t, `INSERT INTO data.baz select * from generate_series(1,10)`)
 
 	waitForReplicaFieldToBeSet(t, tc, conn, "baz", "data", func(r *kvserver.Replica) (bool, error) {
-		if !r.ExcludeDataFromBackup() {
+		if !r.ExcludeDataFromBackup(context.Background()) {
 			return false, errors.New("waiting for the range containing table data.foo to split")
 		}
 		return true, nil
@@ -9461,7 +9461,11 @@ func TestExportRequestBelowGCThresholdOnDataExcludedFromBackup(t *testing.T) {
 	rRand, _ := randutil.NewTestRand()
 	waitForTableSplit(t, conn, "foo", "defaultdb")
 	waitForReplicaFieldToBeSet(t, tc, conn, "foo", "defaultdb", func(r *kvserver.Replica) (bool, error) {
-		if r.GetMaxBytes() != tableRangeMaxBytes {
+		conf, err := r.LoadSpanConfig(ctx)
+		if err != nil {
+			return false, err
+		}
+		if conf.RangeMaxBytes != tableRangeMaxBytes {
 			return false, errors.New("waiting for range_max_bytes to be applied")
 		}
 		return true, nil
@@ -9486,7 +9490,7 @@ func TestExportRequestBelowGCThresholdOnDataExcludedFromBackup(t *testing.T) {
 	_, err = conn.Exec(`ALTER TABLE foo SET (exclude_data_from_backup = true)`)
 	require.NoError(t, err)
 	waitForReplicaFieldToBeSet(t, tc, conn, "foo", "defaultdb", func(r *kvserver.Replica) (bool, error) {
-		if !r.ExcludeDataFromBackup() {
+		if !r.ExcludeDataFromBackup(ctx) {
 			return false, errors.New("waiting for exclude_data_from_backup to be applied")
 		}
 		return true, nil
@@ -9502,6 +9506,8 @@ func TestExportRequestBelowGCThresholdOnDataExcludedFromBackup(t *testing.T) {
 func TestExcludeDataFromBackupDoesNotHoldupGC(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
+	skip.UnderStressRace(t, "test is too slow under stressrace, it fails in the upsert loop")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -9544,14 +9550,18 @@ func TestExcludeDataFromBackupDoesNotHoldupGC(t *testing.T) {
 	// Wait for the span config fields to apply.
 	waitForTableSplit(t, conn, "foo", "test")
 	waitForReplicaFieldToBeSet(t, tc, conn, "foo", "test", func(r *kvserver.Replica) (bool, error) {
-		if !r.ExcludeDataFromBackup() {
+		conf, err := r.LoadSpanConfig(ctx)
+		if err != nil {
+			return false, err
+		}
+		if !conf.ExcludeDataFromBackup {
 			return false, errors.New("waiting for exclude_data_from_backup to be applied")
 		}
-		conf := r.SpanConfig()
+
 		if conf.TTL() != 1*time.Second {
 			return false, errors.New("waiting for gc.ttlseconds to be applied")
 		}
-		if r.GetMaxBytes() != tableRangeMaxBytes {
+		if conf.RangeMaxBytes != tableRangeMaxBytes {
 			return false, errors.New("waiting for range_max_bytes to be applied")
 		}
 		return true, nil
@@ -9572,7 +9582,8 @@ func TestExcludeDataFromBackupDoesNotHoldupGC(t *testing.T) {
 
 	// Ensure that the replica sees the ProtectionPolicies.
 	waitForReplicaFieldToBeSet(t, tc, conn, "foo", "test", func(r *kvserver.Replica) (bool, error) {
-		if len(r.SpanConfig().GCPolicy.ProtectionPolicies) == 0 {
+		conf, err := r.LoadSpanConfig(ctx)
+		if err != nil || len(conf.GCPolicy.ProtectionPolicies) == 0 {
 			return false, errors.New("no protection policy applied to replica")
 		}
 		return true, nil

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_manager_test.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_manager_test.go
@@ -202,7 +202,10 @@ func TestRevertTenantToTimestampPTS(t *testing.T) {
 	waitForGCTTL := func(t *testing.T, tablePrefix roachpb.Key) {
 		testutils.SucceedsSoon(t, func() error {
 			_, r := getFirstStoreAndReplica(t, tablePrefix)
-			conf := r.SpanConfig()
+			conf, err := r.LoadSpanConfig(ctx)
+			if err == nil {
+				return err
+			}
 			if conf.GCPolicy.TTLSeconds != 1 {
 				return fmt.Errorf("expected %d, got %d", 1, conf.GCPolicy.TTLSeconds)
 			}
@@ -212,7 +215,10 @@ func TestRevertTenantToTimestampPTS(t *testing.T) {
 	waitForGCProtection := func(t *testing.T, tablePrefix roachpb.Key) {
 		testutils.SucceedsSoon(t, func() error {
 			_, r := getFirstStoreAndReplica(t, tablePrefix)
-			conf := r.SpanConfig()
+			conf, err := r.LoadSpanConfig(ctx)
+			if err == nil {
+				return err
+			}
 			if len(conf.GCPolicy.ProtectionPolicies) == 0 {
 				return fmt.Errorf("expected policies, got %d", len(conf.GCPolicy.ProtectionPolicies))
 			}

--- a/pkg/kv/kvclient/rangefeed/rangefeed_external_test.go
+++ b/pkg/kv/kvclient/rangefeed/rangefeed_external_test.go
@@ -1023,7 +1023,7 @@ func TestUnrecoverableErrors(t *testing.T) {
 
 		testutils.SucceedsSoon(t, func() error {
 			repl := store.LookupReplica(roachpb.RKey(scratchKey))
-			if repl.SpanConfig().GCPolicy.IgnoreStrictEnforcement {
+			if conf, err := repl.LoadSpanConfig(ctx); err != nil || conf.GCPolicy.IgnoreStrictEnforcement {
 				return errors.New("waiting for span config to apply")
 			}
 			require.NoError(t, repl.ReadProtectedTimestampsForTesting(ctx))

--- a/pkg/kv/kvserver/batcheval/cmd_add_sstable.go
+++ b/pkg/kv/kvserver/batcheval/cmd_add_sstable.go
@@ -397,7 +397,7 @@ func EvalAddSSTable(
 
 	reply := resp.(*kvpb.AddSSTableResponse)
 	reply.RangeSpan = cArgs.EvalCtx.Desc().KeySpan().AsRawSpanWithNoLocals()
-	reply.AvailableBytes = cArgs.EvalCtx.GetMaxBytes() - cArgs.EvalCtx.GetMVCCStats().Total() - stats.Total()
+	reply.AvailableBytes = cArgs.EvalCtx.GetMaxBytes(ctx) - cArgs.EvalCtx.GetMVCCStats().Total() - stats.Total()
 
 	// If requested, locate and return the start of the span following the file
 	// span which may be non-empty, that is, the first key after the file's end

--- a/pkg/kv/kvserver/batcheval/cmd_export.go
+++ b/pkg/kv/kvserver/batcheval/cmd_export.go
@@ -108,7 +108,7 @@ func evalExport(
 	// ExportRequest is likely to find its target data has been GC'ed at this
 	// point, and so if the range being exported is part of such a table, we do
 	// not want to send back any row data to be backed up.
-	if cArgs.EvalCtx.ExcludeDataFromBackup() {
+	if cArgs.EvalCtx.ExcludeDataFromBackup(ctx) {
 		log.Infof(ctx, "[%s, %s) is part of a table excluded from backup, returning empty ExportResponse", args.Key, args.EndKey)
 		return result.Result{}, nil
 	}

--- a/pkg/kv/kvserver/batcheval/eval_context.go
+++ b/pkg/kv/kvserver/batcheval/eval_context.go
@@ -103,7 +103,7 @@ type EvalContext interface {
 	GetMaxSplitCPU(context.Context) (float64, bool)
 
 	GetGCThreshold() hlc.Timestamp
-	ExcludeDataFromBackup() bool
+	ExcludeDataFromBackup(ctx context.Context) bool
 	GetLastReplicaGCTimestamp(context.Context) (hlc.Timestamp, error)
 	GetLease() (roachpb.Lease, roachpb.Lease)
 	GetRangeInfo(context.Context) roachpb.RangeInfo
@@ -130,7 +130,7 @@ type EvalContext interface {
 	// as an unlimited account).
 	GetResponseMemoryAccount() *mon.BoundAccount
 
-	GetMaxBytes() int64
+	GetMaxBytes(context.Context) int64
 
 	// GetEngineCapacity returns the store's underlying engine capacity; other
 	// StoreCapacity fields not related to engine capacity are not populated.
@@ -273,7 +273,7 @@ func (m *mockEvalCtxImpl) MinTxnCommitTS(
 func (m *mockEvalCtxImpl) GetGCThreshold() hlc.Timestamp {
 	return m.GCThreshold
 }
-func (m *mockEvalCtxImpl) ExcludeDataFromBackup() bool {
+func (m *mockEvalCtxImpl) ExcludeDataFromBackup(context.Context) bool {
 	return false
 }
 func (m *mockEvalCtxImpl) GetLastReplicaGCTimestamp(context.Context) (hlc.Timestamp, error) {
@@ -305,7 +305,7 @@ func (m *mockEvalCtxImpl) GetResponseMemoryAccount() *mon.BoundAccount {
 	// No limits.
 	return nil
 }
-func (m *mockEvalCtxImpl) GetMaxBytes() int64 {
+func (m *mockEvalCtxImpl) GetMaxBytes(context.Context) int64 {
 	if m.MaxBytes != 0 {
 		return m.MaxBytes
 	}

--- a/pkg/kv/kvserver/client_protectedts_test.go
+++ b/pkg/kv/kvserver/client_protectedts_test.go
@@ -140,7 +140,7 @@ ORDER BY raw_start_key ASC LIMIT 1`)
 	waitForRangeMaxBytes := func(maxBytes int64) {
 		testutils.SucceedsSoon(t, func() error {
 			_, r := getStoreAndReplica()
-			if r.GetMaxBytes() != maxBytes {
+			if r.GetMaxBytes(ctx) != maxBytes {
 				return errors.New("waiting for range_max_bytes to be applied")
 			}
 			return nil

--- a/pkg/kv/kvserver/client_raft_test.go
+++ b/pkg/kv/kvserver/client_raft_test.go
@@ -2953,7 +2953,7 @@ func TestReplicateAfterSplit(t *testing.T) {
 	// Now add the second replica.
 	tc.AddVotersOrFatal(t, splitKey, tc.Target(1))
 
-	if tc.GetFirstStoreFromServer(t, 1).LookupReplica(roachpb.RKey(key)).GetMaxBytes() == 0 {
+	if tc.GetFirstStoreFromServer(t, 1).LookupReplica(roachpb.RKey(key)).GetMaxBytes(ctx) == 0 {
 		t.Error("Range MaxBytes is not set after snapshot applied")
 	}
 	// Once it catches up, the effects of increment commands can be seen.

--- a/pkg/kv/kvserver/client_rangefeed_test.go
+++ b/pkg/kv/kvserver/client_rangefeed_test.go
@@ -129,7 +129,11 @@ func TestRangefeedWorksOnSystemRangesUnconditionally(t *testing.T) {
 				if repl == nil {
 					return fmt.Errorf("replica not found on n%d", i)
 				}
-				if repl.SpanConfig().RangefeedEnabled {
+				conf, err := repl.LoadSpanConfig(ctx)
+				if err != nil {
+					return err
+				}
+				if conf.RangefeedEnabled {
 					return errors.New("waiting for span configs")
 				}
 			}

--- a/pkg/kv/kvserver/client_replica_test.go
+++ b/pkg/kv/kvserver/client_replica_test.go
@@ -4156,7 +4156,11 @@ func TestStrictGCEnforcement(t *testing.T) {
 				for i := 0; i < tc.NumServers(); i++ {
 					s := tc.Server(i)
 					_, r := getFirstStoreReplica(t, s, tableKey)
-					if c := r.SpanConfig(); c.TTL().Seconds() != (time.Duration(exp) * time.Second).Seconds() {
+					c, err := r.LoadSpanConfig(ctx)
+					if err != nil {
+						return err
+					}
+					if c.TTL().Seconds() != (time.Duration(exp) * time.Second).Seconds() {
 						return errors.Errorf("expected %d, got %f", exp, c.TTL().Seconds())
 					}
 				}
@@ -4484,7 +4488,11 @@ func TestProposalOverhead(t *testing.T) {
 			if repl == nil {
 				return errors.New("scratch range replica not found")
 			}
-			if repl.SpanConfig().RangefeedEnabled {
+			conf, err := repl.LoadSpanConfig(ctx)
+			if err != nil {
+				return err
+			}
+			if conf.RangefeedEnabled {
 				return errors.New("waiting for span configs to apply")
 			}
 			return nil

--- a/pkg/kv/kvserver/client_spanconfigs_test.go
+++ b/pkg/kv/kvserver/client_spanconfigs_test.go
@@ -87,7 +87,8 @@ func TestSpanConfigUpdateAppliedToReplica(t *testing.T) {
 	mockSubscriber.callback(ctx, span) // invoke the callback
 	testutils.SucceedsSoon(t, func() error {
 		repl := store.LookupReplica(keys.MustAddr(key))
-		gotConfig := repl.SpanConfig()
+		gotConfig, err := repl.LoadSpanConfig(ctx)
+		require.NoError(t, err)
 		if !gotConfig.Equal(conf) {
 			return errors.Newf("expected config=%s, got config=%s", conf.String(), gotConfig.String())
 		}
@@ -140,7 +141,8 @@ func TestFallbackSpanConfigOverride(t *testing.T) {
 	mockSubscriber.callback(ctx, span) // invoke the callback
 	testutils.SucceedsSoon(t, func() error {
 		repl := store.LookupReplica(keys.MustAddr(key))
-		gotConfig := repl.SpanConfig()
+		gotConfig, err := repl.LoadSpanConfig(ctx)
+		require.NoError(t, err)
 		if !gotConfig.Equal(conf) {
 			return errors.Newf("expected config=%s, got config=%s", conf.String(), gotConfig.String())
 		}

--- a/pkg/kv/kvserver/client_split_test.go
+++ b/pkg/kv/kvserver/client_split_test.go
@@ -1114,7 +1114,7 @@ func TestStoreZoneUpdateAndRangeSplit(t *testing.T) {
 				return errors.Errorf("expected range %s to span %s", repl, expectedRSpan)
 			}
 			// Check range's max bytes settings.
-			if actualMaxBytes := repl.GetMaxBytes(); actualMaxBytes != maxBytes {
+			if actualMaxBytes := repl.GetMaxBytes(ctx); actualMaxBytes != maxBytes {
 				return errors.Errorf("range %s max bytes mismatch, got: %d, expected: %d", repl, actualMaxBytes, maxBytes)
 			}
 			return nil
@@ -1188,9 +1188,9 @@ func TestStoreRangeSplitWithMaxBytesUpdate(t *testing.T) {
 		if newRng.RangeID == origRng.RangeID {
 			return errors.Errorf("expected new range created by split")
 		}
-		if newRng.GetMaxBytes() != maxBytes {
+		if newRng.GetMaxBytes(ctx) != maxBytes {
 			return errors.Errorf("expected %d max bytes for the new range, but got %d",
-				maxBytes, newRng.GetMaxBytes())
+				maxBytes, newRng.GetMaxBytes(ctx))
 		}
 		return nil
 	})
@@ -1296,7 +1296,7 @@ func TestStoreRangeSplitBackpressureWrites(t *testing.T) {
 			singleKey := tc.splitImpossible
 			fillRange(t, store, repl.RangeID, splitKey.AsRawKey(), 2*maxBytes+1, singleKey)
 
-			if !repl.ShouldBackpressureWrites() {
+			if !repl.ShouldBackpressureWrites(ctx) {
 				t.Fatal("expected ShouldBackpressureWrites=true, found false")
 			}
 

--- a/pkg/kv/kvserver/client_store_test.go
+++ b/pkg/kv/kvserver/client_store_test.go
@@ -61,7 +61,7 @@ func TestStoreSetRangesMaxBytes(t *testing.T) {
 	testKey := tc.ScratchRange(t)
 	testutils.SucceedsSoon(t, func() error {
 		repl := store.LookupReplica(roachpb.RKey(testKey))
-		if got := repl.GetMaxBytes(); got != defaultMaxBytes {
+		if got := repl.GetMaxBytes(ctx); got != defaultMaxBytes {
 			return errors.Errorf("range max bytes values did not start at %d; got %d", defaultMaxBytes, got)
 		}
 		return nil
@@ -71,7 +71,7 @@ func TestStoreSetRangesMaxBytes(t *testing.T) {
 
 	testutils.SucceedsSoon(t, func() error {
 		repl := store.LookupReplica(roachpb.RKey(testKey))
-		if got := repl.GetMaxBytes(); got != expMaxBytes {
+		if got := repl.GetMaxBytes(ctx); got != expMaxBytes {
 			return errors.Errorf("range max bytes values did not change to %d; got %d", expMaxBytes, got)
 		}
 		return nil

--- a/pkg/kv/kvserver/helpers_test.go
+++ b/pkg/kv/kvserver/helpers_test.go
@@ -419,7 +419,7 @@ func (r *Replica) GetTSCacheHighWater() hlc.Timestamp {
 
 // ShouldBackpressureWrites returns whether writes to the range should be
 // subject to backpressure.
-func (r *Replica) ShouldBackpressureWrites() bool {
+func (r *Replica) ShouldBackpressureWrites(_ context.Context) bool {
 	return r.shouldBackpressureWrites()
 }
 

--- a/pkg/kv/kvserver/merge_queue.go
+++ b/pkg/kv/kvserver/merge_queue.go
@@ -157,7 +157,7 @@ func (mq *mergeQueue) shouldQueue(
 		return false, 0
 	}
 
-	sizeRatio := float64(repl.GetMVCCStats().Total()) / float64(repl.GetMinBytes())
+	sizeRatio := float64(repl.GetMVCCStats().Total()) / float64(repl.GetMinBytes(ctx))
 	if math.IsNaN(sizeRatio) || sizeRatio >= 1 {
 		// This range is above the minimum size threshold. It does not need to be
 		// merged.
@@ -239,7 +239,7 @@ func (mq *mergeQueue) process(
 
 	lhsDesc := lhsRepl.Desc()
 	lhsStats := lhsRepl.GetMVCCStats()
-	minBytes := lhsRepl.GetMinBytes()
+	minBytes := lhsRepl.GetMinBytes(ctx)
 	if lhsStats.Total() >= minBytes {
 		log.VEventf(ctx, 2, "skipping merge: LHS meets minimum size threshold %d with %d bytes",
 			minBytes, lhsStats.Total())
@@ -286,7 +286,7 @@ func (mq *mergeQueue) process(
 	}
 
 	shouldSplit, _ := shouldSplitRange(ctx, mergedDesc, mergedStats,
-		lhsRepl.GetMaxBytes(), lhsRepl.shouldBackpressureWrites(), confReader)
+		lhsRepl.GetMaxBytes(ctx), lhsRepl.shouldBackpressureWrites(), confReader)
 	if shouldSplit {
 		log.VEventf(ctx, 2,
 			"skipping merge to avoid thrashing: merged range %s may split "+

--- a/pkg/kv/kvserver/mvcc_gc_queue.go
+++ b/pkg/kv/kvserver/mvcc_gc_queue.go
@@ -265,7 +265,11 @@ func (mgcq *mvccGCQueue) shouldQueue(
 ) (bool, float64) {
 	// Consult the protected timestamp state to determine whether we can GC and
 	// the timestamp which can be used to calculate the score.
-	conf := repl.SpanConfig()
+	conf, err := repl.LoadSpanConfig(ctx)
+	if err != nil {
+		log.VErrEventf(ctx, 2, "failed to load span config: %v", err)
+		return false, 0
+	}
 	canGC, _, gcTimestamp, oldThreshold, newThreshold, err := repl.checkProtectedTimestampsForGC(ctx, conf.TTL())
 	if err != nil {
 		log.VErrEventf(ctx, 2, "failed to check protected timestamp for gc: %v", err)

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -946,14 +946,14 @@ func (r *Replica) cleanupFailedProposalLocked(p *ProposalData) {
 }
 
 // GetMinBytes gets the replica's minimum byte threshold.
-func (r *Replica) GetMinBytes() int64 {
+func (r *Replica) GetMinBytes(_ context.Context) int64 {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	return r.mu.conf.RangeMinBytes
 }
 
 // GetMaxBytes gets the replica's maximum byte threshold.
-func (r *Replica) GetMaxBytes() int64 {
+func (r *Replica) GetMaxBytes(_ context.Context) int64 {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	return r.mu.conf.RangeMaxBytes
@@ -1070,14 +1070,14 @@ func (r *Replica) DescAndSpanConfig() (*roachpb.RangeDescriptor, *roachpb.SpanCo
 	return r.mu.state.Desc, &conf
 }
 
-// SpanConfig returns the authoritative span config for the replica.
-func (r *Replica) SpanConfig() *roachpb.SpanConfig {
+// LoadSpanConfig loads the authoritative span config for the replica.
+func (r *Replica) LoadSpanConfig(_ context.Context) (*roachpb.SpanConfig, error) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	// This method is being removed shortly. We can't pass out a pointer to the
 	// underlying replica's SpanConfig.
 	conf := r.mu.conf
-	return &conf
+	return &conf, nil
 }
 
 // Desc returns the authoritative range descriptor, acquiring a replica lock in
@@ -1177,7 +1177,7 @@ func (r *Replica) GetGCHint() roachpb.GCHint {
 
 // ExcludeDataFromBackup returns whether the replica is to be excluded from a
 // backup.
-func (r *Replica) ExcludeDataFromBackup() bool {
+func (r *Replica) ExcludeDataFromBackup(_ context.Context) bool {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	return r.mu.conf.ExcludeDataFromBackup

--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -322,7 +322,7 @@ func (r *Replica) adminSplitWithDescriptor(
 		if len(args.SplitKey) == 0 {
 			// Find a key to split by size.
 			var err error
-			targetSize := r.GetMaxBytes() / 2
+			targetSize := r.GetMaxBytes(ctx) / 2
 			foundSplitKey, err = storage.MVCCFindSplitKey(
 				ctx, r.store.TODOEngine(), desc.StartKey, desc.EndKey, targetSize)
 			if err != nil {

--- a/pkg/kv/kvserver/replica_eval_context_span.go
+++ b/pkg/kv/kvserver/replica_eval_context_span.go
@@ -178,8 +178,8 @@ func (rec SpanSetReplicaEvalContext) GetGCThreshold() hlc.Timestamp {
 
 // ExcludeDataFromBackup returns whether the replica is to be excluded from a
 // backup.
-func (rec SpanSetReplicaEvalContext) ExcludeDataFromBackup() bool {
-	return rec.i.ExcludeDataFromBackup()
+func (rec SpanSetReplicaEvalContext) ExcludeDataFromBackup(ctx context.Context) bool {
+	return rec.i.ExcludeDataFromBackup(ctx)
 }
 
 // String implements Stringer.
@@ -261,8 +261,8 @@ func (rec *SpanSetReplicaEvalContext) GetResponseMemoryAccount() *mon.BoundAccou
 }
 
 // GetMaxBytes implements the batcheval.EvalContext interface.
-func (rec *SpanSetReplicaEvalContext) GetMaxBytes() int64 {
-	return rec.i.GetMaxBytes()
+func (rec *SpanSetReplicaEvalContext) GetMaxBytes(ctx context.Context) int64 {
+	return rec.i.GetMaxBytes(ctx)
 }
 
 // GetEngineCapacity implements the batcheval.EvalContext interface.

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -13516,11 +13516,13 @@ func TestReplicateQueueProcessOne(t *testing.T) {
 	tc.repl.mu.destroyStatus.Set(errBoom, destroyReasonMergePending)
 	tc.repl.mu.Unlock()
 
+	conf, err := tc.repl.LoadSpanConfig(ctx)
+	require.NoError(t, err)
 	requeue, err := tc.store.replicateQueue.processOneChange(
 		ctx,
 		tc.repl,
 		tc.repl.Desc(),
-		tc.repl.SpanConfig(),
+		conf,
 		func(ctx context.Context, repl plan.LeaseCheckReplica, conf *roachpb.SpanConfig) bool { return false },
 		false, /* scatter */
 		true,  /* dryRun */

--- a/pkg/kv/kvserver/split_queue.go
+++ b/pkg/kv/kvserver/split_queue.go
@@ -186,7 +186,7 @@ func (sq *splitQueue) shouldQueue(
 	ctx context.Context, now hlc.ClockTimestamp, repl *Replica, confReader spanconfig.StoreReader,
 ) (shouldQ bool, priority float64) {
 	shouldQ, priority = shouldSplitRange(ctx, repl.Desc(), repl.GetMVCCStats(),
-		repl.GetMaxBytes(), repl.shouldBackpressureWrites(), confReader)
+		repl.GetMaxBytes(ctx), repl.shouldBackpressureWrites(), confReader)
 
 	if !shouldQ && repl.SplitByLoadEnabled() {
 		if splitKey := repl.loadSplitKey(ctx, repl.Clock().PhysicalTime()); splitKey != nil {
@@ -258,7 +258,7 @@ func (sq *splitQueue) processAttempt(
 	// size-based splitting if maxBytes is 0 (happens in certain test
 	// situations).
 	size := r.GetMVCCStats().Total()
-	maxBytes := r.GetMaxBytes()
+	maxBytes := r.GetMaxBytes(ctx)
 	if maxBytes > 0 && size > maxBytes {
 		if _, err := r.adminSplitWithDescriptor(
 			ctx,

--- a/pkg/kv/kvserver/split_queue_test.go
+++ b/pkg/kv/kvserver/split_queue_test.go
@@ -116,7 +116,7 @@ func TestSplitQueueShouldQueue(t *testing.T) {
 		// This tests the merge queue behavior too as a result. For splitFinder tests,
 		// see split/split_test.go.
 		shouldQ, priority := shouldSplitRange(ctx, repl.Desc(), repl.GetMVCCStats(),
-			repl.GetMaxBytes(), repl.ShouldBackpressureWrites(), cfg)
+			repl.GetMaxBytes(ctx), repl.ShouldBackpressureWrites(ctx), cfg)
 		if shouldQ != test.shouldQ {
 			t.Errorf("%d: should queue expected %t; got %t", i, test.shouldQ, shouldQ)
 		}

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -3479,8 +3479,12 @@ func (s *Store) ReplicateQueueDryRun(
 		return true
 	}
 	desc := repl.Desc()
-	conf := repl.SpanConfig()
-	_, err := s.replicateQueue.processOneChange(
+	conf, err := repl.LoadSpanConfig(ctx)
+	if err != nil {
+		log.Eventf(ctx, "error simulating allocator unable to load span config %s: %s", repl, err)
+		return collectAndFinish(), nil
+	}
+	_, err = s.replicateQueue.processOneChange(
 		ctx, repl, desc, conf, canTransferLease, false /* scatter */, true, /* dryRun */
 	)
 	if err != nil {


### PR DESCRIPTION
Add the context to a number of methods in preparation for them not using
the cached span config. This also renames the method
`Replica.SpanConfig` to `Replica.LoadSpanConfig` and changes it to allow
it to return an error if it can't get the SpanConfig for the replica.

Epic: none

Release note: None