### PR TITLE
pkg/monitoring: README for grafana dashboards

### DIFF
--- a/monitoring/grafana-dashboards/by-cluster/README.md
+++ b/monitoring/grafana-dashboards/by-cluster/README.md
@@ -1,0 +1,21 @@
+# Grafana Dashboards
+
+The files in this directory contain example Grafana dashboard configurations to act as a starting point for users 
+looking to monitor CockroachDB via Grafana. 
+
+Note that while the CockroachDB team provides these dashboards as an example, these dashboards are not guaranteed to
+function out of the box with all deployment modes for Prometheus/Grafana/etc., and the CockroachDB team does not offer 
+support as such.
+
+Note that the dashboards assume the presence of the following labels on each CockroachDB metric:
+
+- `job="cockroachdb"`: to denote the CockroachDB job that the metrics belong to. 
+- `cluster`: to identify the specific cluster that the metrics belong to.
+- `instance`: to identify the specific node/instance that the metrics belong to.
+
+Users may have to modify the dashboards according to their own deployment configurations, such as the metric label selectors
+used, before they function properly.
+
+Please refer to the
+[documentation on how to monitor CockroachDB with Prometheus](https://www.cockroachlabs.com/docs/stable/monitor-cockroachdb-with-prometheus)
+for more details. 


### PR DESCRIPTION
The grafana dashboards provided in `pkg/monitoring` have caused some confusion for users, as the expected label sets are not defined clearly anywhere.

This patch adds a README to the by-cluster directory (which is the one we should expect customers to try out) explaining the expected label set, supportability of the dashboards, and pointing back to the documentation.

The aim is to reduce confusion moving forward.

Release note: none

Fixes: https://github.com/cockroachdb/cockroach/issues/110778