### PR TITLE
kv: do not panic when non-locking read requests ask for replicated locks

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_add_sstable.go
+++ b/pkg/kv/kvserver/batcheval/cmd_add_sstable.go
@@ -49,9 +49,11 @@ func declareKeysAddSSTable(
 	latchSpans *spanset.SpanSet,
 	lockSpans *lockspanset.LockSpanSet,
 	maxOffset time.Duration,
-) {
+) error {
 	args := req.(*kvpb.AddSSTableRequest)
-	DefaultDeclareIsolatedKeys(rs, header, req, latchSpans, lockSpans, maxOffset)
+	if err := DefaultDeclareIsolatedKeys(rs, header, req, latchSpans, lockSpans, maxOffset); err != nil {
+		return err
+	}
 	// We look up the range descriptor key to return its span.
 	latchSpans.AddNonMVCC(spanset.SpanReadOnly, roachpb.Span{Key: keys.RangeDescriptorKey(rs.GetStartKey())})
 
@@ -72,6 +74,7 @@ func declareKeysAddSSTable(
 			Key: keys.MVCCRangeKeyGCKey(rs.GetRangeID()),
 		})
 	}
+	return nil
 }
 
 // AddSSTableRewriteConcurrency sets the concurrency of a single SST rewrite.

--- a/pkg/kv/kvserver/batcheval/cmd_barrier.go
+++ b/pkg/kv/kvserver/batcheval/cmd_barrier.go
@@ -32,7 +32,7 @@ func declareKeysBarrier(
 	latchSpans *spanset.SpanSet,
 	_ *lockspanset.LockSpanSet,
 	_ time.Duration,
-) {
+) error {
 	// Barrier is special-cased in the concurrency manager to *not* actually
 	// grab these latches. Instead, any conflicting latches with these are waited
 	// on, but new latches aren't inserted.
@@ -44,6 +44,7 @@ func declareKeysBarrier(
 	// follower. We don't currently need any guarantees regarding concurrent
 	// reads, so this is acceptable.
 	latchSpans.AddNonMVCC(spanset.SpanReadWrite, req.Header().Span())
+	return nil
 }
 
 // Barrier evaluation is a no-op, as all the latch waiting happens in

--- a/pkg/kv/kvserver/batcheval/cmd_clear_range.go
+++ b/pkg/kv/kvserver/batcheval/cmd_clear_range.go
@@ -46,8 +46,11 @@ func declareKeysClearRange(
 	latchSpans *spanset.SpanSet,
 	lockSpans *lockspanset.LockSpanSet,
 	maxOffset time.Duration,
-) {
-	DefaultDeclareIsolatedKeys(rs, header, req, latchSpans, lockSpans, maxOffset)
+) error {
+	err := DefaultDeclareIsolatedKeys(rs, header, req, latchSpans, lockSpans, maxOffset)
+	if err != nil {
+		return err
+	}
 	// We look up the range descriptor key to check whether the span
 	// is equal to the entire range for fast stats updating.
 	latchSpans.AddNonMVCC(spanset.SpanReadOnly, roachpb.Span{Key: keys.RangeDescriptorKey(rs.GetStartKey())})
@@ -71,6 +74,7 @@ func declareKeysClearRange(
 	latchSpans.AddNonMVCC(spanset.SpanReadOnly, roachpb.Span{
 		Key: keys.MVCCRangeKeyGCKey(rs.GetRangeID()),
 	})
+	return nil
 }
 
 // ClearRange wipes all MVCC versions of keys covered by the specified

--- a/pkg/kv/kvserver/batcheval/cmd_clear_range_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_clear_range_test.go
@@ -189,7 +189,9 @@ func TestCmdClearRange(t *testing.T) {
 				// should not cross the range bounds.
 				var latchSpans spanset.SpanSet
 				var lockSpans lockspanset.LockSpanSet
-				declareKeysClearRange(&desc, &cArgs.Header, cArgs.Args, &latchSpans, &lockSpans, 0)
+				require.NoError(t,
+					declareKeysClearRange(&desc, &cArgs.Header, cArgs.Args, &latchSpans, &lockSpans, 0),
+				)
 				batch := &wrappedBatch{Batch: spanset.NewBatchAt(eng.NewBatch(), &latchSpans, cArgs.Header.Timestamp)}
 				defer batch.Close()
 

--- a/pkg/kv/kvserver/batcheval/cmd_compute_checksum.go
+++ b/pkg/kv/kvserver/batcheval/cmd_compute_checksum.go
@@ -36,7 +36,7 @@ func declareKeysComputeChecksum(
 	latchSpans *spanset.SpanSet,
 	_ *lockspanset.LockSpanSet,
 	_ time.Duration,
-) {
+) error {
 	// The correctness of range merges depends on the lease applied index of a
 	// range not being bumped while the RHS is subsumed. ComputeChecksum bumps a
 	// range's LAI and thus needs to be serialized with Subsume requests, in order
@@ -47,6 +47,7 @@ func declareKeysComputeChecksum(
 	// declare access over at least one key. We choose to declare read-only access
 	// over the range descriptor key.
 	latchSpans.AddNonMVCC(spanset.SpanReadOnly, roachpb.Span{Key: keys.RangeDescriptorKey(rs.GetStartKey())})
+	return nil
 }
 
 // ReplicaChecksumVersion versions the checksum computation. Requests silently no-op

--- a/pkg/kv/kvserver/batcheval/cmd_conditional_put.go
+++ b/pkg/kv/kvserver/batcheval/cmd_conditional_put.go
@@ -33,12 +33,12 @@ func declareKeysConditionalPut(
 	latchSpans *spanset.SpanSet,
 	lockSpans *lockspanset.LockSpanSet,
 	maxOffset time.Duration,
-) {
+) error {
 	args := req.(*kvpb.ConditionalPutRequest)
 	if args.Inline {
-		DefaultDeclareKeys(rs, header, req, latchSpans, lockSpans, maxOffset)
+		return DefaultDeclareKeys(rs, header, req, latchSpans, lockSpans, maxOffset)
 	} else {
-		DefaultDeclareIsolatedKeys(rs, header, req, latchSpans, lockSpans, maxOffset)
+		return DefaultDeclareIsolatedKeys(rs, header, req, latchSpans, lockSpans, maxOffset)
 	}
 }
 

--- a/pkg/kv/kvserver/batcheval/cmd_delete_range.go
+++ b/pkg/kv/kvserver/batcheval/cmd_delete_range.go
@@ -38,12 +38,17 @@ func declareKeysDeleteRange(
 	latchSpans *spanset.SpanSet,
 	lockSpans *lockspanset.LockSpanSet,
 	maxOffset time.Duration,
-) {
+) error {
 	args := req.(*kvpb.DeleteRangeRequest)
 	if args.Inline {
-		DefaultDeclareKeys(rs, header, req, latchSpans, lockSpans, maxOffset)
+		if err := DefaultDeclareKeys(rs, header, req, latchSpans, lockSpans, maxOffset); err != nil {
+			return err
+		}
 	} else {
-		DefaultDeclareIsolatedKeys(rs, header, req, latchSpans, lockSpans, maxOffset)
+		err := DefaultDeclareIsolatedKeys(rs, header, req, latchSpans, lockSpans, maxOffset)
+		if err != nil {
+			return err
+		}
 	}
 
 	// When writing range tombstones, we must look for adjacent range tombstones
@@ -77,6 +82,7 @@ func declareKeysDeleteRange(
 			})
 		}
 	}
+	return nil
 }
 
 const maxDeleteRangeBatchBytes = 32 << 20

--- a/pkg/kv/kvserver/batcheval/cmd_delete_range_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_delete_range_test.go
@@ -254,7 +254,9 @@ func TestDeleteRangeTombstone(t *testing.T) {
 					// bounds.
 					var latchSpans spanset.SpanSet
 					var lockSpans lockspanset.LockSpanSet
-					declareKeysDeleteRange(evalCtx.Desc, &h, req, &latchSpans, &lockSpans, 0)
+					require.NoError(t,
+						declareKeysDeleteRange(evalCtx.Desc, &h, req, &latchSpans, &lockSpans, 0),
+					)
 					batch := spanset.NewBatchAt(engine.NewBatch(), &latchSpans, h.Timestamp)
 					defer batch.Close()
 

--- a/pkg/kv/kvserver/batcheval/cmd_export.go
+++ b/pkg/kv/kvserver/batcheval/cmd_export.go
@@ -76,14 +76,18 @@ func declareKeysExport(
 	latchSpans *spanset.SpanSet,
 	lockSpans *lockspanset.LockSpanSet,
 	maxOffset time.Duration,
-) {
-	DefaultDeclareIsolatedKeys(rs, header, req, latchSpans, lockSpans, maxOffset)
+) error {
+	err := DefaultDeclareIsolatedKeys(rs, header, req, latchSpans, lockSpans, maxOffset)
+	if err != nil {
+		return err
+	}
 	latchSpans.AddNonMVCC(spanset.SpanReadOnly, roachpb.Span{Key: keys.RangeGCThresholdKey(header.RangeID)})
 	// Export requests will usually not hold latches during their evaluation.
 	//
 	// See call to `AssertAllowed()` in GetGCThreshold() to understand why we need
 	// to disable these assertions for export requests.
 	latchSpans.DisableUndeclaredAccessAssertions()
+	return nil
 }
 
 // evalExport dumps the requested keys into files of non-overlapping key ranges

--- a/pkg/kv/kvserver/batcheval/cmd_gc.go
+++ b/pkg/kv/kvserver/batcheval/cmd_gc.go
@@ -38,7 +38,7 @@ func declareKeysGC(
 	latchSpans *spanset.SpanSet,
 	_ *lockspanset.LockSpanSet,
 	_ time.Duration,
-) {
+) error {
 	gcr := req.(*kvpb.GCRequest)
 	if gcr.RangeKeys != nil {
 		// When GC-ing MVCC range key tombstones, we need to serialize with
@@ -112,6 +112,7 @@ func declareKeysGC(
 	// Needed for updating optional GC hint.
 	latchSpans.AddNonMVCC(spanset.SpanReadWrite, roachpb.Span{Key: keys.RangeGCHintKey(rs.GetRangeID())})
 	latchSpans.DisableUndeclaredAccessAssertions()
+	return nil
 }
 
 // Create latches and merge adjacent.

--- a/pkg/kv/kvserver/batcheval/cmd_heartbeat_txn.go
+++ b/pkg/kv/kvserver/batcheval/cmd_heartbeat_txn.go
@@ -36,8 +36,8 @@ func declareKeysHeartbeatTransaction(
 	latchSpans *spanset.SpanSet,
 	_ *lockspanset.LockSpanSet,
 	_ time.Duration,
-) {
-	declareKeysWriteTransaction(rs, header, req, latchSpans)
+) error {
+	return declareKeysWriteTransaction(rs, header, req, latchSpans)
 }
 
 // HeartbeatTxn updates the transaction status and heartbeat

--- a/pkg/kv/kvserver/batcheval/cmd_lease_info.go
+++ b/pkg/kv/kvserver/batcheval/cmd_lease_info.go
@@ -34,8 +34,9 @@ func declareKeysLeaseInfo(
 	latchSpans *spanset.SpanSet,
 	_ *lockspanset.LockSpanSet,
 	_ time.Duration,
-) {
+) error {
 	latchSpans.AddNonMVCC(spanset.SpanReadOnly, roachpb.Span{Key: keys.RangeLeaseKey(rs.GetRangeID())})
+	return nil
 }
 
 // LeaseInfo returns information about the lease holder for the range.

--- a/pkg/kv/kvserver/batcheval/cmd_lease_request.go
+++ b/pkg/kv/kvserver/batcheval/cmd_lease_request.go
@@ -35,12 +35,13 @@ func declareKeysRequestLease(
 	latchSpans *spanset.SpanSet,
 	_ *lockspanset.LockSpanSet,
 	_ time.Duration,
-) {
+) error {
 	// NOTE: RequestLease is run on replicas that do not hold the lease, so
 	// acquiring latches would not help synchronize with other requests. As
 	// such, the request does not declare latches. See also
 	// concurrency.shouldIgnoreLatches().
 	latchSpans.DisableUndeclaredAccessAssertions()
+	return nil
 }
 
 // RequestLease sets the range lease for this range. The command fails

--- a/pkg/kv/kvserver/batcheval/cmd_lease_transfer.go
+++ b/pkg/kv/kvserver/batcheval/cmd_lease_transfer.go
@@ -35,7 +35,7 @@ func declareKeysTransferLease(
 	latchSpans *spanset.SpanSet,
 	_ *lockspanset.LockSpanSet,
 	_ time.Duration,
-) {
+) error {
 	// TransferLease must not run concurrently with any other request so it uses
 	// latches to synchronize with all other reads and writes on the outgoing
 	// leaseholder. Additionally, it observes the state of the timestamp cache
@@ -56,6 +56,7 @@ func declareKeysTransferLease(
 	// reads. We'd need to be careful here, so we should only pull on this if we
 	// decide that doing so is important.
 	declareAllKeys(latchSpans)
+	return nil
 }
 
 // TransferLease sets the lease holder for the range.

--- a/pkg/kv/kvserver/batcheval/cmd_migrate.go
+++ b/pkg/kv/kvserver/batcheval/cmd_migrate.go
@@ -36,7 +36,7 @@ func declareKeysMigrate(
 	latchSpans *spanset.SpanSet,
 	_ *lockspanset.LockSpanSet,
 	_ time.Duration,
-) {
+) error {
 	// TODO(irfansharif): This will eventually grow to capture the super set of
 	// all keys accessed by all migrations defined here. That could get
 	// cumbersome. We could spruce up the migration type and allow authors to
@@ -45,6 +45,7 @@ func declareKeysMigrate(
 
 	latchSpans.AddNonMVCC(spanset.SpanReadWrite, roachpb.Span{Key: keys.RangeVersionKey(rs.GetRangeID())})
 	latchSpans.AddNonMVCC(spanset.SpanReadOnly, roachpb.Span{Key: keys.RangeDescriptorKey(rs.GetStartKey())})
+	return nil
 }
 
 // migrationRegistry is a global registry of all KV-level migrations. See

--- a/pkg/kv/kvserver/batcheval/cmd_probe.go
+++ b/pkg/kv/kvserver/batcheval/cmd_probe.go
@@ -29,13 +29,14 @@ func declareKeysProbe(
 	_ *spanset.SpanSet,
 	_ *lockspanset.LockSpanSet,
 	_ time.Duration,
-) {
+) error {
 	// Declare no keys. This means that we're not even serializing with splits
 	// (i.e. a probe could be directed at a key that will become the right-hand
 	// side of the split, and the split races ahead of the probe though the probe
 	// will still execute on the left-hand side). This is acceptable; we want the
 	// probe to bypass as much of the above-raft machinery as possible so that it
 	// gives us a signal on the replication layer alone.
+	return nil
 }
 
 func init() {

--- a/pkg/kv/kvserver/batcheval/cmd_push_txn.go
+++ b/pkg/kv/kvserver/batcheval/cmd_push_txn.go
@@ -42,10 +42,11 @@ func declareKeysPushTransaction(
 	latchSpans *spanset.SpanSet,
 	_ *lockspanset.LockSpanSet,
 	_ time.Duration,
-) {
+) error {
 	pr := req.(*kvpb.PushTxnRequest)
 	latchSpans.AddNonMVCC(spanset.SpanReadWrite, roachpb.Span{Key: keys.TransactionKey(pr.PusheeTxn.Key, pr.PusheeTxn.ID)})
 	latchSpans.AddNonMVCC(spanset.SpanReadWrite, roachpb.Span{Key: keys.AbortSpanKey(rs.GetRangeID(), pr.PusheeTxn.ID)})
+	return nil
 }
 
 // PushTxn resolves conflicts between concurrent txns (or between

--- a/pkg/kv/kvserver/batcheval/cmd_put.go
+++ b/pkg/kv/kvserver/batcheval/cmd_put.go
@@ -33,12 +33,12 @@ func declareKeysPut(
 	latchSpans *spanset.SpanSet,
 	lockSpans *lockspanset.LockSpanSet,
 	maxOffset time.Duration,
-) {
+) error {
 	args := req.(*kvpb.PutRequest)
 	if args.Inline {
-		DefaultDeclareKeys(rs, header, req, latchSpans, lockSpans, maxOffset)
+		return DefaultDeclareKeys(rs, header, req, latchSpans, lockSpans, maxOffset)
 	} else {
-		DefaultDeclareIsolatedKeys(rs, header, req, latchSpans, lockSpans, maxOffset)
+		return DefaultDeclareIsolatedKeys(rs, header, req, latchSpans, lockSpans, maxOffset)
 	}
 }
 

--- a/pkg/kv/kvserver/batcheval/cmd_query_intent.go
+++ b/pkg/kv/kvserver/batcheval/cmd_query_intent.go
@@ -34,11 +34,12 @@ func declareKeysQueryIntent(
 	latchSpans *spanset.SpanSet,
 	_ *lockspanset.LockSpanSet,
 	_ time.Duration,
-) {
+) error {
 	// QueryIntent requests read the specified keys at the maximum timestamp in
 	// order to read any intent present, if one exists, regardless of the
 	// timestamp it was written at.
 	latchSpans.AddNonMVCC(spanset.SpanReadOnly, req.Header().Span())
+	return nil
 }
 
 // QueryIntent checks if an intent exists for the specified transaction at the

--- a/pkg/kv/kvserver/batcheval/cmd_query_locks.go
+++ b/pkg/kv/kvserver/batcheval/cmd_query_locks.go
@@ -35,9 +35,10 @@ func declareKeysQueryLocks(
 	latchSpans *spanset.SpanSet,
 	_ *lockspanset.LockSpanSet,
 	_ time.Duration,
-) {
+) error {
 	// Latch on the range descriptor during evaluation of query locks.
 	latchSpans.AddNonMVCC(spanset.SpanReadOnly, roachpb.Span{Key: keys.RangeDescriptorKey(rs.GetStartKey())})
+	return nil
 }
 
 // QueryLocks uses the concurrency manager to query the state of locks

--- a/pkg/kv/kvserver/batcheval/cmd_query_txn.go
+++ b/pkg/kv/kvserver/batcheval/cmd_query_txn.go
@@ -36,9 +36,10 @@ func declareKeysQueryTransaction(
 	latchSpans *spanset.SpanSet,
 	_ *lockspanset.LockSpanSet,
 	_ time.Duration,
-) {
+) error {
 	qr := req.(*kvpb.QueryTxnRequest)
 	latchSpans.AddNonMVCC(spanset.SpanReadOnly, roachpb.Span{Key: keys.TransactionKey(qr.Txn.Key, qr.Txn.ID)})
+	return nil
 }
 
 // QueryTxn fetches the current state of a transaction.

--- a/pkg/kv/kvserver/batcheval/cmd_range_stats.go
+++ b/pkg/kv/kvserver/batcheval/cmd_range_stats.go
@@ -34,11 +34,15 @@ func declareKeysRangeStats(
 	latchSpans *spanset.SpanSet,
 	lockSpans *lockspanset.LockSpanSet,
 	maxOffset time.Duration,
-) {
-	DefaultDeclareKeys(rs, header, req, latchSpans, lockSpans, maxOffset)
+) error {
+	err := DefaultDeclareKeys(rs, header, req, latchSpans, lockSpans, maxOffset)
+	if err != nil {
+		return err
+	}
 	// The request will return the descriptor and lease.
 	latchSpans.AddNonMVCC(spanset.SpanReadOnly, roachpb.Span{Key: keys.RangeDescriptorKey(rs.GetStartKey())})
 	latchSpans.AddNonMVCC(spanset.SpanReadOnly, roachpb.Span{Key: keys.RangeLeaseKey(rs.GetRangeID())})
+	return nil
 }
 
 // RangeStats returns the MVCC statistics for a range.

--- a/pkg/kv/kvserver/batcheval/cmd_recompute_stats.go
+++ b/pkg/kv/kvserver/batcheval/cmd_recompute_stats.go
@@ -38,7 +38,7 @@ func declareKeysRecomputeStats(
 	latchSpans *spanset.SpanSet,
 	_ *lockspanset.LockSpanSet,
 	_ time.Duration,
-) {
+) error {
 	// We don't declare any user key in the range. This is OK since all we're doing is computing a
 	// stats delta, and applying this delta commutes with other operations on the same key space.
 	//
@@ -58,6 +58,7 @@ func declareKeysRecomputeStats(
 	latchSpans.AddNonMVCC(spanset.SpanReadWrite, roachpb.Span{Key: keys.TransactionKey(rdKey, uuid.Nil)})
 	// Disable the assertions which check that all reads were previously declared.
 	latchSpans.DisableUndeclaredAccessAssertions()
+	return nil
 }
 
 // RecomputeStats recomputes the MVCCStats stored for this range and adjust them accordingly,

--- a/pkg/kv/kvserver/batcheval/cmd_recover_txn.go
+++ b/pkg/kv/kvserver/batcheval/cmd_recover_txn.go
@@ -36,10 +36,11 @@ func declareKeysRecoverTransaction(
 	latchSpans *spanset.SpanSet,
 	_ *lockspanset.LockSpanSet,
 	_ time.Duration,
-) {
+) error {
 	rr := req.(*kvpb.RecoverTxnRequest)
 	latchSpans.AddNonMVCC(spanset.SpanReadWrite, roachpb.Span{Key: keys.TransactionKey(rr.Txn.Key, rr.Txn.ID)})
 	latchSpans.AddNonMVCC(spanset.SpanReadWrite, roachpb.Span{Key: keys.AbortSpanKey(rs.GetRangeID(), rr.Txn.ID)})
+	return nil
 }
 
 // RecoverTxn attempts to recover the specified transaction from an

--- a/pkg/kv/kvserver/batcheval/cmd_resolve_intent.go
+++ b/pkg/kv/kvserver/batcheval/cmd_resolve_intent.go
@@ -31,7 +31,7 @@ func init() {
 
 func declareKeysResolveIntentCombined(
 	rs ImmutableRangeState, req kvpb.Request, latchSpans *spanset.SpanSet,
-) {
+) error {
 	var status roachpb.TransactionStatus
 	var txnID uuid.UUID
 	var minTxnTS hlc.Timestamp
@@ -51,6 +51,7 @@ func declareKeysResolveIntentCombined(
 		// intent, but we can't tell whether we will or not ahead of time.
 		latchSpans.AddNonMVCC(spanset.SpanReadWrite, roachpb.Span{Key: keys.AbortSpanKey(rs.GetRangeID(), txnID)})
 	}
+	return nil
 }
 
 func declareKeysResolveIntent(
@@ -60,8 +61,8 @@ func declareKeysResolveIntent(
 	latchSpans *spanset.SpanSet,
 	_ *lockspanset.LockSpanSet,
 	_ time.Duration,
-) {
-	declareKeysResolveIntentCombined(rs, req, latchSpans)
+) error {
+	return declareKeysResolveIntentCombined(rs, req, latchSpans)
 }
 
 func resolveToMetricType(status roachpb.TransactionStatus, poison bool) *result.Metrics {

--- a/pkg/kv/kvserver/batcheval/cmd_resolve_intent_range.go
+++ b/pkg/kv/kvserver/batcheval/cmd_resolve_intent_range.go
@@ -33,8 +33,8 @@ func declareKeysResolveIntentRange(
 	latchSpans *spanset.SpanSet,
 	_ *lockspanset.LockSpanSet,
 	_ time.Duration,
-) {
-	declareKeysResolveIntentCombined(rs, req, latchSpans)
+) error {
+	return declareKeysResolveIntentCombined(rs, req, latchSpans)
 }
 
 // ResolveIntentRange resolves write intents in the specified

--- a/pkg/kv/kvserver/batcheval/cmd_resolve_intent_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_resolve_intent_test.go
@@ -111,7 +111,7 @@ func TestDeclareKeysResolveIntent(t *testing.T) {
 
 				if !ranged {
 					cArgs.Args = &ri
-					declareKeysResolveIntent(&desc, &h, &ri, &latchSpans, &lockSpans, 0)
+					require.NoError(t, declareKeysResolveIntent(&desc, &h, &ri, &latchSpans, &lockSpans, 0))
 					batch := spanset.NewBatch(engine.NewBatch(), &latchSpans)
 					defer batch.Close()
 					if _, err := ResolveIntent(ctx, batch, cArgs, &kvpb.ResolveIntentResponse{}); err != nil {
@@ -119,7 +119,9 @@ func TestDeclareKeysResolveIntent(t *testing.T) {
 					}
 				} else {
 					cArgs.Args = &rir
-					declareKeysResolveIntentRange(&desc, &h, &rir, &latchSpans, &lockSpans, 0)
+					require.NoError(
+						t, declareKeysResolveIntentRange(&desc, &h, &rir, &latchSpans, &lockSpans, 0),
+					)
 					batch := spanset.NewBatch(engine.NewBatch(), &latchSpans)
 					defer batch.Close()
 					if _, err := ResolveIntentRange(ctx, batch, cArgs, &kvpb.ResolveIntentRangeResponse{}); err != nil {
@@ -205,7 +207,7 @@ func TestResolveIntentAfterPartialRollback(t *testing.T) {
 			}
 			ri.Key = k
 
-			declareKeysResolveIntent(&desc, &h, &ri, &spans, nil, 0)
+			require.NoError(t, declareKeysResolveIntent(&desc, &h, &ri, &spans, nil, 0))
 			rbatch = spanset.NewBatch(db.NewBatch(), &spans)
 			defer rbatch.Close()
 
@@ -229,7 +231,7 @@ func TestResolveIntentAfterPartialRollback(t *testing.T) {
 			rir.Key = k
 			rir.EndKey = endKey
 
-			declareKeysResolveIntentRange(&desc, &h, &rir, &spans, nil, 0)
+			require.NoError(t, declareKeysResolveIntentRange(&desc, &h, &rir, &spans, nil, 0))
 			rbatch = spanset.NewBatch(db.NewBatch(), &spans)
 			defer rbatch.Close()
 

--- a/pkg/kv/kvserver/batcheval/cmd_revert_range.go
+++ b/pkg/kv/kvserver/batcheval/cmd_revert_range.go
@@ -43,9 +43,12 @@ func declareKeysRevertRange(
 	latchSpans *spanset.SpanSet,
 	lockSpans *lockspanset.LockSpanSet,
 	maxOffset time.Duration,
-) {
+) error {
 	args := req.(*kvpb.RevertRangeRequest)
-	DefaultDeclareIsolatedKeys(rs, header, req, latchSpans, lockSpans, maxOffset)
+	err := DefaultDeclareIsolatedKeys(rs, header, req, latchSpans, lockSpans, maxOffset)
+	if err != nil {
+		return err
+	}
 	// We look up the range descriptor key to check whether the span
 	// is equal to the entire range for fast stats updating.
 	latchSpans.AddNonMVCC(spanset.SpanReadOnly, roachpb.Span{Key: keys.RangeDescriptorKey(rs.GetStartKey())})
@@ -68,6 +71,7 @@ func declareKeysRevertRange(
 	latchSpans.AddNonMVCC(spanset.SpanReadOnly, roachpb.Span{
 		Key: keys.MVCCRangeKeyGCKey(rs.GetRangeID()),
 	})
+	return nil
 }
 
 // isEmptyKeyTimeRange checks if the span has no writes in (since,until].

--- a/pkg/kv/kvserver/batcheval/cmd_subsume.go
+++ b/pkg/kv/kvserver/batcheval/cmd_subsume.go
@@ -37,13 +37,14 @@ func declareKeysSubsume(
 	latchSpans *spanset.SpanSet,
 	_ *lockspanset.LockSpanSet,
 	_ time.Duration,
-) {
+) error {
 	// Subsume must not run concurrently with any other command. It declares a
 	// non-MVCC write over every addressable key in the range; this guarantees
 	// that it conflicts with any other command because every command must
 	// declare at least one addressable key. It does not, in fact, write any
 	// keys.
 	declareAllKeys(latchSpans)
+	return nil
 }
 
 // Subsume freezes a range for merging with its left-hand neighbor. When called

--- a/pkg/kv/kvserver/batcheval/cmd_truncate_log.go
+++ b/pkg/kv/kvserver/batcheval/cmd_truncate_log.go
@@ -37,9 +37,10 @@ func declareKeysTruncateLog(
 	latchSpans *spanset.SpanSet,
 	_ *lockspanset.LockSpanSet,
 	_ time.Duration,
-) {
+) error {
 	prefix := keys.RaftLogPrefix(rs.GetRangeID())
 	latchSpans.AddNonMVCC(spanset.SpanReadWrite, roachpb.Span{Key: prefix, EndKey: prefix.PrefixEnd()})
+	return nil
 }
 
 // TruncateLog discards a prefix of the raft log. Truncating part of a log that

--- a/pkg/kv/kvserver/batcheval/command.go
+++ b/pkg/kv/kvserver/batcheval/command.go
@@ -33,7 +33,7 @@ type DeclareKeysFunc func(
 	latchSpans *spanset.SpanSet,
 	lockSpans *lockspanset.LockSpanSet,
 	maxOffset time.Duration,
-)
+) error
 
 // ImmutableRangeState exposes the properties of a Range that cannot change
 // across a Range's lifetime. The interface is used to manage the visibility

--- a/pkg/kv/kvserver/batcheval/declare_test.go
+++ b/pkg/kv/kvserver/batcheval/declare_test.go
@@ -82,7 +82,10 @@ func TestRequestsSerializeWithAllKeys(t *testing.T) {
 				Sequence: 0,
 			})
 
-			command.DeclareKeys(desc, &header, otherRequest, &otherLatchSpans, &otherLockSpans, 0)
+			err := command.DeclareKeys(desc, &header, otherRequest, &otherLatchSpans, &otherLockSpans, 0)
+			if err != nil {
+				t.Error(err)
+			}
 			if !allLatchSpans.Intersects(&otherLatchSpans) {
 				t.Errorf("%s does not serialize with declareAllKeys", method)
 			}

--- a/pkg/kv/kvserver/concurrency/concurrency_manager_test.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager_test.go
@@ -1048,7 +1048,10 @@ func (c *cluster) collectSpans(
 	h := kvpb.Header{Txn: txn, Timestamp: ts, WaitPolicy: wp}
 	for _, req := range reqs {
 		if cmd, ok := batcheval.LookupCommand(req.Method()); ok {
-			cmd.DeclareKeys(c.rangeDesc, &h, req, latchSpans, lockSpans, 0)
+			err := cmd.DeclareKeys(c.rangeDesc, &h, req, latchSpans, lockSpans, 0)
+			if err != nil {
+				t.Fatal(err)
+			}
 		} else {
 			t.Fatalf("unrecognized command %s", req.Method())
 		}

--- a/pkg/kv/kvserver/replica_send.go
+++ b/pkg/kv/kvserver/replica_send.go
@@ -1185,11 +1185,17 @@ func (r *Replica) collectSpans(
 	// than the request timestamp, and may have to retry at a higher timestamp.
 	// This is still safe as we're only ever writing at timestamps higher than the
 	// timestamp any write latch would be declared at.
-	batcheval.DeclareKeysForBatch(desc, &ba.Header, latchSpans)
+	err := batcheval.DeclareKeysForBatch(desc, &ba.Header, latchSpans)
+	if err != nil {
+		return nil, nil, concurrency.PessimisticEval, err
+	}
 	for _, union := range ba.Requests {
 		inner := union.GetInner()
 		if cmd, ok := batcheval.LookupCommand(inner.Method()); ok {
-			cmd.DeclareKeys(desc, &ba.Header, inner, latchSpans, lockSpans, r.Clock().MaxOffset())
+			err := cmd.DeclareKeys(desc, &ba.Header, inner, latchSpans, lockSpans, r.Clock().MaxOffset())
+			if err != nil {
+				return nil, nil, concurrency.PessimisticEval, err
+			}
 			if considerOptEvalForLimit {
 				switch inner.(type) {
 				case *kvpb.ScanRequest, *kvpb.ReverseScanRequest:

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -2736,7 +2736,7 @@ func TestReplicaLatchingSplitDeclaresWrites(t *testing.T) {
 
 	var spans spanset.SpanSet
 	cmd, _ := batcheval.LookupCommand(kvpb.EndTxn)
-	cmd.DeclareKeys(
+	err := cmd.DeclareKeys(
 		&roachpb.RangeDescriptor{StartKey: roachpb.RKey("a"), EndKey: roachpb.RKey("e")},
 		&kvpb.Header{},
 		&kvpb.EndTxnRequest{
@@ -2757,6 +2757,7 @@ func TestReplicaLatchingSplitDeclaresWrites(t *testing.T) {
 		nil,
 		0,
 	)
+	require.NoError(t, err)
 	for _, tc := range []struct {
 		access       spanset.SpanAccess
 		key          roachpb.Key


### PR DESCRIPTION
Over in https://github.com/cockroachdb/cockroach/issues/111429, we saw a non-locking read request which specified
a key locking durability of lock.Replicated. This is not allowed --
however, it doesn't warrant a panic on the server. We fix this and
improve the error message.

Epic: none

Release note: None