### PR TITLE
clusterversion: update comment, rename permanent upgrade keys

### DIFF
--- a/pkg/clusterversion/cockroach_versions.go
+++ b/pkg/clusterversion/cockroach_versions.go
@@ -19,8 +19,8 @@ import (
 type Key int
 
 // Version constants. These drive compatibility between versions as well as
-// migrations. Before you add a version or consider removing one, please
-// familiarize yourself with the rules below.
+// upgrades (formerly "migrations"). Before you add a version or consider
+// removing one, please familiarize yourself with the rules below.
 //
 // # Adding Versions
 //
@@ -40,7 +40,7 @@ type Key int
 //			// this feature.
 //		}
 //
-//	Authors of migrations need to be careful in ensuring that end-users
+//	Authors of upgrades need to be careful in ensuring that end-users
 //	aren't able to enable feature gates before they're active. This is fine:
 //
 //		func handleSomeNewStatement() error {
@@ -114,38 +114,45 @@ type Key int
 //	    two.
 //	(3) Add it at the end of the `versionsSingleton` block below.
 //
-// # Migrations
+// # Upgrades
 //
-// Migrations are idempotent functions that can be attached to versions and will
+// Upgrades are idempotent functions that can be attached to versions and will
 // be rolled out before the respective cluster version gets rolled out. They are
-// primarily a means to remove legacy state from the cluster. For example, a
-// migration might scan the cluster for an outdated type of table descriptor and
-// rewrite it into a new format. Migrations are tricky to get right and they have
-// their own documentation in ./pkg/upgrade, which you should peruse should you
-// feel that a migration is necessary for your use case.
+// primarily a means to remove legacy state from the cluster. For example, an
+// upgrade might scan the cluster for an outdated type of table descriptor and
+// rewrite it into a new format. Upgrade are tricky to get right and have their
+// own documentation in ./pkg/upgrade, which you should peruse should you feel
+// that an upgrade is necessary for your use case.
 //
-// # Phasing out Versions and Migrations
+// ## Permanent upgrades
 //
-// Versions and Migrations can be removed once they are no longer going to be
-// exercised. This is primarily driven by the BinaryMinSupportedVersion, which
-// declares the oldest *cluster* (not binary) version of CockroachDB that may
-// interface with the running node. It typically trails the current version by
-// one release. For example, if the current branch is a `21.1.x` release, you
-// will have a BinaryMinSupportedVersion of `21.0`, meaning that the versions
-// 20.2.0-1, 20.2.0-2, etc are always going to be active on any peer and thus
-// can be "baked in"; similarly all migrations attached to any of these versions
-// can be assumed to have run (or not having been necessary due to the cluster
-// having been initialized at a higher version in the first place). Note that
-// this implies that all peers will have a *binary* version of at least the
-// MinSupportedVersion as well, as this is a prerequisite for running at that
-// cluster version. Finally, note that even when all cluster versions known
-// to the current binary are active (i.e. most of the time), you still need
-// to be able to inter-op with older *binary* and/or *cluster* versions. This
-// is because *tenants* are allowed to run at any binary version compatible
-// with (i.e. greater than or equal to) the MinSupportedVersion. To give a
-// concrete example, a fully up-to-date v21.1 KV host cluster can have tenants
-// running against it that use the v21.0 binary and any cluster version known
-// to that binary (v20.2-0 ... v20.2-50 or thereabouts).
+// Permanent upgrades are upgrades that double as initialization steps when
+// bootstrapping a new cluster. As such, they cannot be removed even as the
+// version they are tied to becomes unsupported.
+//
+// # Phasing out Versions and Upgrades
+//
+// Versions and non-permanent upgrades can be removed once they are no longer
+// going to be exercised. This is primarily driven by the
+// BinaryMinSupportedVersion, which declares the oldest *cluster* (not binary)
+// version of CockroachDB that may interface with the running node. It typically
+// trails the current version by one release. For example, if the current branch
+// is a `21.1.x` release, you will have a BinaryMinSupportedVersion of `21.0`,
+// meaning that the versions 20.2.0-1, 20.2.0-2, etc are always going to be
+// active on any peer and thus can be "baked in"; similarly all upgrades
+// attached to any of these versions can be assumed to have run (or not having
+// been necessary due to the cluster having been initialized at a higher version
+// in the first place). Note that this implies that all peers will have a
+// *binary* version of at least the MinSupportedVersion as well, as this is a
+// prerequisite for running at that cluster version. Finally, note that even
+// when all cluster versions known to the current binary are active (i.e. most
+// of the time), you still need to be able to inter-op with older *binary*
+// and/or *cluster* versions. This is because *tenants* are allowed to run at
+// any binary version compatible with (i.e. greater than or equal to) the
+// MinSupportedVersion. To give a concrete example, a fully up-to-date v21.1 KV
+// host cluster can have tenants running against it that use the v21.0 binary
+// and any cluster version known to that binary (v20.2-0 ... v20.2-50 or
+// thereabouts).
 //
 // You'll want to delete versions from this list after cutting a major release.
 // Once the development for 21.1 begins, after step (ii) from above, all
@@ -156,11 +163,19 @@ type Key int
 // All "is active" checks for the key will always evaluate to true. You'll also
 // want to delete the constant and remove its entry in the `versionsSingleton`
 // block below.
+//
+// Permanent upgrades and their associated version key cannot be removed (even
+// if it is below the BinaryMinSupportedVersion). The version key should start
+// with `Permanent_` to make this more explicit. The version numbers should not
+// be changed - we want all nodes in a mixed-version cluster to agree on what
+// version a certain upgrade step is tied to (in the unlikely scenario that we
+// have mixed-version nodes while bootstrapping a cluster).
 const (
 	invalidVersionKey Key = iota - 1 // want first named one to start at zero
 
-	// VPrimordial versions are used by upgrades below BinaryMinSupportedVersion,
-	// for whom the exact version they were associated with no longer matters.
+	// VPrimordial versions are associated with permanent upgrades that exist for
+	// historical reasons; no new primordial versions should be added, and no new
+	// upgrades should be tied to existing primordial versions.
 
 	VPrimordial1
 	VPrimordial2
@@ -168,10 +183,9 @@ const (
 	VPrimordial4
 	VPrimordial5
 	VPrimordial6
-	// NOTE(andrei): Do not introduce new upgrades corresponding to VPrimordial
-	// versions. Old-version nodes might try to run the jobs created for such
-	// upgrades, but they won't know about the respective upgrade, causing the job
-	// to succeed without actually performing the update.
+
+	// No new VPrimordial versions should be added.
+
 	VPrimordialMax
 
 	// TODODelete_V22_1 is CockroachDB v22.1. It's used for all v22.1.x patch releases.
@@ -348,8 +362,9 @@ const (
 	// chagnefeeds created prior to this version.
 	V23_1_ChangefeedExpressionProductionReady
 
-	// V23_1KeyVisualizerTablesAndJobs adds the system tables that support the key visualizer.
-	V23_1KeyVisualizerTablesAndJobs
+	// Permanent_V23_1KeyVisualizerTablesAndJobs adds the system tables that
+	// support the key visualizer.
+	Permanent_V23_1KeyVisualizerTablesAndJobs
 
 	// V23_1_KVDirectColumnarScans introduces the support of the "direct"
 	// columnar scans in the KV layer.
@@ -357,9 +372,9 @@ const (
 
 	V23_1_DeleteDroppedFunctionDescriptors
 
-	// V23_1_CreateJobsMetricsPollingJob creates the permanent job
+	// Permanent_V23_1_CreateJobsMetricsPollingJob creates the permanent job
 	// responsible for polling the jobs table for metrics.
-	V23_1_CreateJobsMetricsPollingJob
+	Permanent_V23_1_CreateJobsMetricsPollingJob
 
 	// V23_1AllocatorCPUBalancing adds balancing CPU usage among stores using
 	// the allocator and store rebalancer. It assumes that at this version,
@@ -480,9 +495,9 @@ const (
 	// task_payloads and tenant_tasks have been created.
 	V23_1_TaskSystemTables
 
-	// V23_1_CreateAutoConfigRunnerJob is the version where the auto
+	// Permanent_V23_1_CreateAutoConfigRunnerJob is the version where the auto
 	// config runner persistent job has been created.
-	V23_1_CreateAutoConfigRunnerJob
+	Permanent_V23_1_CreateAutoConfigRunnerJob
 
 	// V23_1AddSQLStatsComputedIndexes is the version at which Cockroach adds new
 	// computed columns and indexes to the statement_statistics and
@@ -500,18 +515,18 @@ const (
 	// payload and progress columns are no longer written to system.jobs.
 	V23_1StopWritingPayloadAndProgressToSystemJobs
 
-	// V23_1ChangeSQLStatsTTL is the version where the gc TTL was updated to all
-	// SQL Stats tables.
-	V23_1ChangeSQLStatsTTL
+	// Permanent_V23_1ChangeSQLStatsTTL is the version where the gc TTL was
+	// updated to all SQL Stats tables.
+	Permanent_V23_1ChangeSQLStatsTTL
 
 	// V23_1_TenantIDSequence is the version where system.tenant_id_seq
 	// was introduced.
 	V23_1_TenantIDSequence
 
-	// V23_1CreateSystemActivityUpdateJob is the version at which Cockroach adds a
-	// job that periodically updates the statement_activity and transaction_activity.
-	// tables.
-	V23_1CreateSystemActivityUpdateJob
+	// Permanent_V23_1CreateSystemActivityUpdateJob is the version at which
+	// Cockroach adds a job that periodically updates the statement_activity and
+	// transaction_activity tables.
+	Permanent_V23_1CreateSystemActivityUpdateJob
 
 	// V23_1 is CockroachDB v23.1. It's used for all v23.1.x patch releases.
 	V23_1
@@ -802,7 +817,7 @@ var rawVersionsSingleton = keyedVersions{
 		Version: roachpb.Version{Major: 22, Minor: 2, Internal: 30},
 	},
 	{
-		Key:     V23_1KeyVisualizerTablesAndJobs,
+		Key:     Permanent_V23_1KeyVisualizerTablesAndJobs,
 		Version: roachpb.Version{Major: 22, Minor: 2, Internal: 32},
 	},
 	{
@@ -814,7 +829,7 @@ var rawVersionsSingleton = keyedVersions{
 		Version: roachpb.Version{Major: 22, Minor: 2, Internal: 36},
 	},
 	{
-		Key:     V23_1_CreateJobsMetricsPollingJob,
+		Key:     Permanent_V23_1_CreateJobsMetricsPollingJob,
 		Version: roachpb.Version{Major: 22, Minor: 2, Internal: 38},
 	},
 	{
@@ -918,7 +933,7 @@ var rawVersionsSingleton = keyedVersions{
 		Version: roachpb.Version{Major: 22, Minor: 2, Internal: 88},
 	},
 	{
-		Key:     V23_1_CreateAutoConfigRunnerJob,
+		Key:     Permanent_V23_1_CreateAutoConfigRunnerJob,
 		Version: roachpb.Version{Major: 22, Minor: 2, Internal: 90},
 	},
 	{
@@ -934,7 +949,7 @@ var rawVersionsSingleton = keyedVersions{
 		Version: roachpb.Version{Major: 22, Minor: 2, Internal: 96},
 	},
 	{
-		Key:     V23_1ChangeSQLStatsTTL,
+		Key:     Permanent_V23_1ChangeSQLStatsTTL,
 		Version: roachpb.Version{Major: 22, Minor: 2, Internal: 98},
 	},
 	{
@@ -942,7 +957,7 @@ var rawVersionsSingleton = keyedVersions{
 		Version: roachpb.Version{Major: 22, Minor: 2, Internal: 100},
 	},
 	{
-		Key:     V23_1CreateSystemActivityUpdateJob,
+		Key:     Permanent_V23_1CreateSystemActivityUpdateJob,
 		Version: roachpb.Version{Major: 22, Minor: 2, Internal: 102},
 	},
 	{

--- a/pkg/sql/sqlstats/persistedsqlstats/controller.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/controller.go
@@ -76,7 +76,7 @@ func (s *Controller) ResetClusterSQLStats(ctx context.Context) error {
 // ResetActivityTables implements the tree.SQLStatsController interface. This
 // method resets the {statement|transaction}_activity system tables.
 func (s *Controller) ResetActivityTables(ctx context.Context) error {
-	if !s.st.Version.IsActive(ctx, clusterversion.V23_1CreateSystemActivityUpdateJob) {
+	if !s.st.Version.IsActive(ctx, clusterversion.Permanent_V23_1CreateSystemActivityUpdateJob) {
 		return nil
 	}
 

--- a/pkg/upgrade/upgrades/create_auto_config_runner_job_test.go
+++ b/pkg/upgrade/upgrades/create_auto_config_runner_job_test.go
@@ -35,7 +35,7 @@ func TestCreateAutoConfigRunnerJob(t *testing.T) {
 				Server: &server.TestingKnobs{
 					DisableAutomaticVersionUpgrade: make(chan struct{}),
 					BinaryVersionOverride: clusterversion.ByKey(
-						clusterversion.V23_1_CreateAutoConfigRunnerJob - 1),
+						clusterversion.Permanent_V23_1_CreateAutoConfigRunnerJob - 1),
 				},
 			},
 		},
@@ -57,7 +57,7 @@ func TestCreateAutoConfigRunnerJob(t *testing.T) {
 	upgrades.Upgrade(
 		t,
 		sqlDB,
-		clusterversion.V23_1_CreateAutoConfigRunnerJob,
+		clusterversion.Permanent_V23_1_CreateAutoConfigRunnerJob,
 		nil,   /* done */
 		false, /* expectError */
 	)

--- a/pkg/upgrade/upgrades/create_jobs_metrics_polling_job_test.go
+++ b/pkg/upgrade/upgrades/create_jobs_metrics_polling_job_test.go
@@ -35,7 +35,7 @@ func TestCreateJobsMetricsPollingJob(t *testing.T) {
 				Server: &server.TestingKnobs{
 					DisableAutomaticVersionUpgrade: make(chan struct{}),
 					BinaryVersionOverride: clusterversion.ByKey(
-						clusterversion.V23_1_CreateJobsMetricsPollingJob - 1),
+						clusterversion.Permanent_V23_1_CreateJobsMetricsPollingJob - 1),
 				},
 			},
 		},
@@ -57,7 +57,7 @@ func TestCreateJobsMetricsPollingJob(t *testing.T) {
 	upgrades.Upgrade(
 		t,
 		sqlDB,
-		clusterversion.V23_1_CreateJobsMetricsPollingJob,
+		clusterversion.Permanent_V23_1_CreateJobsMetricsPollingJob,
 		nil,   /* done */
 		false, /* expectError */
 	)

--- a/pkg/upgrade/upgrades/key_visualizer_migration_test.go
+++ b/pkg/upgrade/upgrades/key_visualizer_migration_test.go
@@ -35,7 +35,7 @@ func TestKeyVisualizerTablesMigration(t *testing.T) {
 				Server: &server.TestingKnobs{
 					DisableAutomaticVersionUpgrade: make(chan struct{}),
 					BinaryVersionOverride: clusterversion.ByKey(
-						clusterversion.V23_1KeyVisualizerTablesAndJobs - 1),
+						clusterversion.Permanent_V23_1KeyVisualizerTablesAndJobs - 1),
 				},
 			},
 		},
@@ -50,7 +50,7 @@ func TestKeyVisualizerTablesMigration(t *testing.T) {
 	upgrades.Upgrade(
 		t,
 		db,
-		clusterversion.V23_1KeyVisualizerTablesAndJobs,
+		clusterversion.Permanent_V23_1KeyVisualizerTablesAndJobs,
 		nil,
 		false,
 	)

--- a/pkg/upgrade/upgrades/sql_stats_ttl_test.go
+++ b/pkg/upgrade/upgrades/sql_stats_ttl_test.go
@@ -37,7 +37,7 @@ func TestSQLStatsTTLChange(t *testing.T) {
 				Server: &server.TestingKnobs{
 					DisableAutomaticVersionUpgrade: make(chan struct{}),
 					BinaryVersionOverride: clusterversion.ByKey(
-						clusterversion.V23_1ChangeSQLStatsTTL - 1),
+						clusterversion.Permanent_V23_1ChangeSQLStatsTTL - 1),
 				},
 			},
 		},
@@ -52,7 +52,7 @@ func TestSQLStatsTTLChange(t *testing.T) {
 	upgrades.Upgrade(
 		t,
 		db,
-		clusterversion.V23_1ChangeSQLStatsTTL,
+		clusterversion.Permanent_V23_1ChangeSQLStatsTTL,
 		nil,
 		false,
 	)

--- a/pkg/upgrade/upgrades/system_activity_update_job_test.go
+++ b/pkg/upgrade/upgrades/system_activity_update_job_test.go
@@ -58,7 +58,7 @@ func TestCreateActivityUpdateJobMigration(t *testing.T) {
 	upgrades.Upgrade(
 		t,
 		db,
-		clusterversion.V23_1CreateSystemActivityUpdateJob,
+		clusterversion.Permanent_V23_1CreateSystemActivityUpdateJob,
 		nil,
 		false,
 	)

--- a/pkg/upgrade/upgrades/upgrades.go
+++ b/pkg/upgrade/upgrades/upgrades.go
@@ -85,8 +85,6 @@ var upgrades = []upgradebase.Upgrade{
 		updateSystemLocationData,
 		"update system.locations with default location data", // v22_2StartupMigrationName
 	),
-	// Introduced in v2.1.
-	// TODO(knz): bake this migration into v19.1.
 	upgrade.NewPermanentTenantUpgrade(
 		"create default databases",
 		toCV(clusterversion.VPrimordial6),
@@ -163,7 +161,7 @@ var upgrades = []upgradebase.Upgrade{
 		alterSystemSQLInstancesAddSqlAddr,
 	),
 	upgrade.NewPermanentSystemUpgrade("add tables and jobs to support persisting key visualizer samples",
-		toCV(clusterversion.V23_1KeyVisualizerTablesAndJobs),
+		toCV(clusterversion.Permanent_V23_1KeyVisualizerTablesAndJobs),
 		keyVisualizerTablesMigration,
 		"initialize key visualizer tables and jobs",
 	),
@@ -173,7 +171,7 @@ var upgrades = []upgradebase.Upgrade{
 		deleteDescriptorsOfDroppedFunctions,
 	),
 	upgrade.NewPermanentTenantUpgrade("create jobs metrics polling job",
-		toCV(clusterversion.V23_1_CreateJobsMetricsPollingJob),
+		toCV(clusterversion.Permanent_V23_1_CreateJobsMetricsPollingJob),
 		createJobsMetricsPollingJob,
 		"create jobs metrics polling job",
 	),
@@ -266,7 +264,7 @@ var upgrades = []upgradebase.Upgrade{
 		createTaskSystemTables,
 	),
 	upgrade.NewPermanentTenantUpgrade("create auto config runner job",
-		toCV(clusterversion.V23_1_CreateAutoConfigRunnerJob),
+		toCV(clusterversion.Permanent_V23_1_CreateAutoConfigRunnerJob),
 		createAutoConfigRunnerJob,
 		"create auto config runner job",
 	),
@@ -284,7 +282,7 @@ var upgrades = []upgradebase.Upgrade{
 	),
 	upgrade.NewPermanentSystemUpgrade(
 		"change TTL for SQL Stats system tables",
-		toCV(clusterversion.V23_1ChangeSQLStatsTTL),
+		toCV(clusterversion.Permanent_V23_1ChangeSQLStatsTTL),
 		sqlStatsTTLChange,
 		"change TTL for SQL Stats system tables",
 	),
@@ -301,7 +299,7 @@ var upgrades = []upgradebase.Upgrade{
 	),
 	upgrade.NewPermanentTenantUpgrade(
 		"create sql activity updater job",
-		toCV(clusterversion.V23_1CreateSystemActivityUpdateJob),
+		toCV(clusterversion.Permanent_V23_1CreateSystemActivityUpdateJob),
 		createActivityUpdateJobMigration,
 		"create statement_activity and transaction_activity job",
 	),


### PR DESCRIPTION
This commit updates the comment around versions, adding info around permanent upgrades.

We add the guidance that version keys associated with permanent upgrades should start with `Permanent_` (so it's less likely we remove them by accident) and we rename existing keys for permanent upgrades accordingly.

Epic: none
Release note: None