### PR TITLE
clusterversion: bump min version to 23.1, allow 22.2 for testing

### DIFF
--- a/pkg/clusterversion/cockroach_versions.go
+++ b/pkg/clusterversion/cockroach_versions.go
@@ -1078,9 +1078,12 @@ var versionsSingleton = func() keyedVersions {
 // simply need to check is that the cluster has upgraded to 23.2.
 var V23_2 = versionsSingleton[len(versionsSingleton)-1].Key
 
-const (
-	BinaryMinSupportedVersionKey = V22_2
-)
+// BinaryMinSupportedVersionKey specifies the minimum binary version from which the current version can be upgraded from.
+var BinaryMinSupportedVersionKey = V23_1
+
+// minBinaryVersionForVersionSkippingTesting sets the version that can be used in testing to allow tests with version skipping enabled.
+// Set the `COCKROACH_TESTING_ALLOW_VERSION_SKIPPING` environment variable to true to override BinaryMinSupportedVersionKey with this value.
+const minBinaryVersionForVersionSkippingTesting = V22_2
 
 // TODO(irfansharif): clusterversion.binary{,MinimumSupported}Version
 // feels out of place. A "cluster version" and a "binary version" are two
@@ -1101,6 +1104,9 @@ var (
 )
 
 func init() {
+	if envutil.EnvOrDefaultBool("COCKROACH_TESTING_ALLOW_VERSION_SKIPPING", false) {
+		BinaryMinSupportedVersionKey = minBinaryVersionForVersionSkippingTesting
+	}
 	if finalVersion > invalidVersionKey {
 		if binaryVersion != ByKey(finalVersion) {
 			panic("binary version does not match final version")

--- a/pkg/sql/schemachanger/sctest/test_server_factory.go
+++ b/pkg/sql/schemachanger/sctest/test_server_factory.go
@@ -105,7 +105,7 @@ func (f SingleNodeTestClusterFactory) Run(
 
 // OldVersionKey is the version key used by the WithMixedVersion method
 // in the TestServerFactory interface.
-const OldVersionKey = clusterversion.BinaryMinSupportedVersionKey
+var OldVersionKey = clusterversion.BinaryMinSupportedVersionKey
 
 // newJobsKnobs constructs jobs.TestingKnobs for the end-to-end tests.
 func newJobsKnobs() *jobs.TestingKnobs {


### PR DESCRIPTION
Previously, we used the same minimum version for production upgrades and testing. In 23.2 we will be able to upgrade from 22.2, but this is not yet a stable feature.

In order to allow version skipping in tests, but not in normal situation, this PR adds a new environment variable. If the `COCKROACH_TESTING_ALLOW_VERSION_SKIPPING` environment variable is set to `true`, the minimum binary version is set to `22.2`.

Fixes: RE-477
Release note: None