### PR TITLE
release-22.2: jobs,backupccl,importer: avoid job failure during drain

### DIFF
--- a/pkg/ccl/backupccl/backup_job.go
+++ b/pkg/ccl/backupccl/backup_job.go
@@ -655,7 +655,14 @@ func (b *backupResumer) Resume(ctx context.Context, execCtx interface{}) error {
 			return errors.Wrap(err, "failed to run backup")
 		}
 
-		log.Warningf(ctx, `BACKUP job encountered retryable error: %+v`, err)
+		// If we are draining, it is unlikely we can start a
+		// new DistSQL flow. Exit with a retryable error so
+		// that another node can pick up the job.
+		if p.ExecCfg().JobRegistry.IsDraining() {
+			return jobs.MarkAsRetryJobError(errors.Wrapf(err, "job encountered retryable error on draining node"))
+		}
+
+		log.Warningf(ctx, "encountered retryable error: %+v", err)
 
 		// Reload the backup manifest to pick up any spans we may have completed on
 		// previous attempts.

--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -183,7 +183,14 @@ func restoreWithRetry(
 			return roachpb.RowCount{}, err
 		}
 
-		log.Warningf(restoreCtx, `encountered retryable error: %+v`, err)
+		// If we are draining, it is unlikely we can start a
+		// new DistSQL flow. Exit with a retryable error so
+		// that another node can pick up the job.
+		if execCtx.ExecCfg().JobRegistry.IsDraining() {
+			return roachpb.RowCount{}, jobs.MarkAsRetryJobError(errors.Wrapf(err, "job encountered retryable error on draining node"))
+		}
+
+		log.Warningf(restoreCtx, "encountered retryable error: %+v", err)
 	}
 
 	// We have exhausted retries, but we have not seen a "PermanentBulkJobError" so

--- a/pkg/jobs/joberror/errors.go
+++ b/pkg/jobs/joberror/errors.go
@@ -57,9 +57,9 @@ func IsPermanentBulkJobError(err error) bool {
 	if err == nil {
 		return false
 	}
-
 	return !IsDistSQLRetryableError(err) &&
 		!grpcutil.IsClosedConnection(err) &&
+		!flowinfra.IsFlowRetryableError(err) &&
 		!flowinfra.IsNoInboundStreamConnectionError(err) &&
 		!kvcoord.IsSendError(err) &&
 		!isBreakerOpenError(err) &&

--- a/pkg/server/drain.go
+++ b/pkg/server/drain.go
@@ -344,6 +344,9 @@ func (s *drainServer) drainClients(
 		s.drainSleepFn(drainWait.Get(&s.sqlServer.execCfg.Settings.SV))
 	}
 
+	// Inform the job system that the node is draining.
+	s.sqlServer.jobRegistry.SetDraining(true)
+
 	// Wait for users to close the existing SQL connections.
 	// During this phase, the server is rejecting new SQL connections.
 	// The server exits this phase either once all SQL connections are closed,

--- a/pkg/sql/flowinfra/flow_registry.go
+++ b/pkg/sql/flowinfra/flow_registry.go
@@ -301,7 +301,8 @@ func (fr *FlowRegistry) RegisterFlow(
 
 	if draining {
 		return &flowRetryableError{cause: errors.Errorf(
-			"could not register flowID because the registry is draining",
+			"could not register flowID %s because the registry is draining",
+			id,
 		)}
 	}
 	entry := fr.getEntryLocked(id)

--- a/pkg/sql/importer/import_job.go
+++ b/pkg/sql/importer/import_job.go
@@ -1316,19 +1316,26 @@ func ingestWithRetry(
 			return res, err
 		}
 
-		// Re-load the job in order to update our progress object, which may have
-		// been updated by the changeFrontier processor since the flow started.
+		// If we are draining, it is unlikely we can start a new DistSQL
+		// flow. Exit with a retryable error so that another node can
+		// pick up the job.
+		if execCtx.ExecCfg().JobRegistry.IsDraining() {
+			return res, jobs.MarkAsRetryJobError(errors.Wrapf(err, "job encountered retryable error on draining node"))
+		}
+
+		// Re-load the job in order to update our progress object, which
+		// may have been updated since the flow started.
 		reloadedJob, reloadErr := execCtx.ExecCfg().JobRegistry.LoadClaimedJob(ctx, job.ID())
 		if reloadErr != nil {
 			if ctx.Err() != nil {
 				return res, ctx.Err()
 			}
-			log.Warningf(ctx, `IMPORT job %d could not reload job progress when retrying: %+v`,
-				int64(job.ID()), reloadErr)
+			log.Warningf(ctx, "IMPORT job %d could not reload job progress when retrying: %+v",
+				job.ID(), reloadErr)
 		} else {
 			job = reloadedJob
 		}
-		log.Warningf(ctx, `encountered retryable error: %+v`, err)
+		log.Warningf(ctx, "encountered retryable error: %+v", err)
 	}
 
 	// We have exhausted retries, but we have not seen a "PermanentBulkJobError" so


### PR DESCRIPTION
Backport 1/1 commits from #97033.

/cc @cockroachdb/release

---

In BACKUP, RESTORE, and IMPORT, the DistSQL flow started from the coordinator return with a retryable context cancellation during node draining.

The in-job retry loop will attempt to construct the flow again, but as the distsql server has already moved to a draining state, it immediately returns an error.

Previously, this error was permanent since our IsPermanentBulkJobError function was not checking flowinfra.IsFlowRetryableError. While this change fixes that, simply retrying the error is not sufficient. Since we are draining, the job will never succeed on this node.

To address this, the drain server now informs the job registry of the fact that it is draining. Our jobs check this state and return a retryable error, allowing another job to adopt the job.

Epic: None

Release note: Fix a bug in which RESTORE, BACKUP, and IMPORT jobs would fail if the coordinator node of the job was drained.

Release justification: bug fix where a backup, restore or import would fail if the coordinator node of the job was being drained.