### PR TITLE
ui: eslint should error on eqeqeq violation

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/.eslintrc.json
+++ b/pkg/ui/workspaces/cluster-ui/.eslintrc.json
@@ -14,6 +14,7 @@
     "@cockroachlabs/crdb/require-antd-style-import": "error",
     // Instead of using console log methods directly, cluster-ui code should
     // call the getLogger() method to provide the appropriate logger.
-    "no-console": "error"
+    "no-console": "error",
+    "eqeqeq": ["error", "smart"]
   }
 }

--- a/pkg/ui/workspaces/cluster-ui/src/api/contentionApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/contentionApi.ts
@@ -134,21 +134,21 @@ function getContentionWhereClause(filters?: ContentionFilters): string {
   }
 
   if (filters?.waitingTxnID) {
-    if (whereClause != defaultWhereClause) {
+    if (whereClause !== defaultWhereClause) {
       whereClause += " and ";
     }
     whereClause = whereClause + ` waiting_txn_id >= '${filters.waitingTxnID}' `;
   }
 
   if (filters?.start) {
-    if (whereClause != defaultWhereClause) {
+    if (whereClause !== defaultWhereClause) {
       whereClause += " and ";
     }
     whereClause =
       whereClause + ` collection_ts >= '${filters.start.toISOString()}' `;
   }
   if (filters?.end) {
-    if (whereClause != defaultWhereClause) {
+    if (whereClause !== defaultWhereClause) {
       whereClause += " and ";
     }
 

--- a/pkg/ui/workspaces/cluster-ui/src/api/indexActionsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/indexActionsApi.ts
@@ -27,7 +27,7 @@ export function executeIndexRecAction(
 ): Promise<IndexActionResponse> {
   const statements = stmts
     .split(";")
-    .filter(stmt => stmt.trim().length != 0)
+    .filter(stmt => stmt.trim().length !== 0)
     .map(stmt => {
       return { sql: stmt.trim() };
     });

--- a/pkg/ui/workspaces/cluster-ui/src/api/safesql.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/safesql.ts
@@ -178,7 +178,7 @@ export function Format(format: string, args?: any[]): string {
 
     if (i > 0) {
       const lastChar = format.substring(0, i).slice(-1);
-      if (!(lastChar == "=" || isPunct(lastChar) || isSpace(lastChar))) {
+      if (!(lastChar === "=" || isPunct(lastChar) || isSpace(lastChar))) {
         throw new Error(
           `invalid separator: '${lastChar}' is not punctuation or whitespace`,
         );

--- a/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/databaseDetailsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/databaseDetailsPage.tsx
@@ -230,13 +230,13 @@ export class DatabaseDetailsPage extends React.Component<
     // View Mode.
     const view = searchParams.get("viewMode") || undefined;
     let viewMode = ViewMode.Tables;
-    if (view == ViewMode.Grants.toString()) {
+    if (view === ViewMode.Grants.toString()) {
       viewMode = ViewMode.Grants;
     }
     if (
       this.props.onViewModeChange &&
       view &&
-      viewMode != this.props.viewMode
+      viewMode !== this.props.viewMode
     ) {
       this.props.onViewModeChange(viewMode);
     }
@@ -245,19 +245,19 @@ export class DatabaseDetailsPage extends React.Component<
     const ascending = (searchParams.get("ascending") || undefined) === "true";
     const columnTitle = searchParams.get("columnTitle") || undefined;
     const sortSetting =
-      viewMode == ViewMode.Tables
+      viewMode === ViewMode.Tables
         ? this.props.sortSettingTables
         : this.props.sortSettingGrants;
     const onSortingChange =
-      viewMode == ViewMode.Tables
+      viewMode === ViewMode.Tables
         ? this.props.onSortingTablesChange
         : this.props.onSortingGrantsChange;
 
     if (
       onSortingChange &&
       columnTitle &&
-      (sortSetting.columnTitle != columnTitle ||
-        sortSetting.ascending != ascending)
+      (sortSetting.columnTitle !== columnTitle ||
+        sortSetting.ascending !== ascending)
     ) {
       onSortingChange(columnTitle, ascending);
     }
@@ -293,17 +293,17 @@ export class DatabaseDetailsPage extends React.Component<
     // No new tables to update
     if (
       !this.props.tables ||
-      this.props.tables.length == 0 ||
+      this.props.tables.length === 0 ||
       this.props.tables.every(x => x.loaded || x.loading)
     ) {
       return false;
     }
 
-    if (this.state.pagination.current != prevState.pagination.current) {
+    if (this.state.pagination.current !== prevState.pagination.current) {
       return true;
     }
 
-    if (prevProps && this.props.search != prevProps.search) {
+    if (prevProps && this.props.search !== prevProps.search) {
       return true;
     }
 
@@ -314,7 +314,7 @@ export class DatabaseDetailsPage extends React.Component<
       i++
     ) {
       const table = filteredTables[i];
-      if (!table.loaded && !table.loading && table.requestError == undefined) {
+      if (!table.loaded && !table.loading && table.requestError == null) {
         return true;
       }
     }
@@ -371,7 +371,7 @@ export class DatabaseDetailsPage extends React.Component<
       this.props.history,
     );
     const onSortingChange =
-      this.props.viewMode == ViewMode.Tables
+      this.props.viewMode === ViewMode.Tables
         ? this.props.onSortingTablesChange
         : this.props.onSortingGrantsChange;
 
@@ -470,9 +470,9 @@ export class DatabaseDetailsPage extends React.Component<
 
     // Avoid the loop if no filters/search are applied
     if (
-      (!search || search.length == 0) &&
-      regionsSelected.length == 0 &&
-      nodesSelected.length == 0
+      (!search || search.length === 0) &&
+      regionsSelected.length === 0 &&
+      nodesSelected.length === 0
     ) {
       return tables;
     }
@@ -480,11 +480,11 @@ export class DatabaseDetailsPage extends React.Component<
     return tables
       .filter(table => (search ? filterBySearchQuery(table, search) : true))
       .filter(table => {
-        if (regionsSelected.length == 0 && nodesSelected.length == 0)
+        if (regionsSelected.length === 0 && nodesSelected.length === 0)
           return true;
 
-        let foundRegion = regionsSelected.length == 0;
-        let foundNode = nodesSelected.length == 0;
+        let foundRegion = regionsSelected.length === 0;
+        let foundNode = nodesSelected.length === 0;
 
         table.details.nodes?.forEach(node => {
           const n = node?.toString() || "";
@@ -791,7 +791,7 @@ export class DatabaseDetailsPage extends React.Component<
     const regions = unique(Object.values(nodeRegions));
 
     const sortSetting =
-      this.props.viewMode == ViewMode.Tables
+      this.props.viewMode === ViewMode.Tables
         ? this.props.sortSettingTables
         : this.props.sortSettingGrants;
 
@@ -801,7 +801,7 @@ export class DatabaseDetailsPage extends React.Component<
     // Only show the filter component when the viewMode is Tables and if at
     // least one of drop-down is shown.
     const filterComponent =
-      this.props.viewMode == ViewMode.Tables && (showNodes || showRegions) ? (
+      this.props.viewMode === ViewMode.Tables && (showNodes || showRegions) ? (
         <PageConfigItem>
           <Filter
             hideAppNames={true}

--- a/pkg/ui/workspaces/cluster-ui/src/databasesPage/databasesPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databasesPage/databasesPage.tsx
@@ -211,8 +211,8 @@ export class DatabasesPage extends React.Component<
     if (
       this.props.onSortingChange &&
       columnTitle &&
-      (sortSetting.columnTitle != columnTitle ||
-        sortSetting.ascending != ascending)
+      (sortSetting.columnTitle !== columnTitle ||
+        sortSetting.ascending !== ascending)
     ) {
       this.props.onSortingChange("Databases", columnTitle, ascending);
     }
@@ -232,7 +232,7 @@ export class DatabasesPage extends React.Component<
     const searchParams = new URLSearchParams(history.location.search);
 
     const searchQuery = searchParams.get("q") || undefined;
-    if (onSearchComplete && searchQuery && search != searchQuery) {
+    if (onSearchComplete && searchQuery && search !== searchQuery) {
       onSearchComplete(searchQuery);
     }
 
@@ -284,7 +284,7 @@ export class DatabasesPage extends React.Component<
     // Search
     const searchParams = new URLSearchParams(history.location.search);
     const searchQueryString = searchParams.get("q") || "";
-    if (search && search != searchQueryString) {
+    if (search && search !== searchQueryString) {
       syncHistory(
         {
           q: search,
@@ -459,11 +459,11 @@ export class DatabasesPage extends React.Component<
     return databases
       .filter(db => (search ? filterBySearchQuery(db, search) : true))
       .filter(db => {
-        if (regionsSelected.length == 0 && nodesSelected.length == 0)
+        if (regionsSelected.length === 0 && nodesSelected.length === 0)
           return true;
 
-        let foundRegion = regionsSelected.length == 0;
-        let foundNode = nodesSelected.length == 0;
+        let foundRegion = regionsSelected.length === 0;
+        let foundNode = nodesSelected.length === 0;
 
         db.nodes?.forEach(node => {
           const n = node?.toString() || "";
@@ -487,17 +487,17 @@ export class DatabasesPage extends React.Component<
     // No new dbs to update
     if (
       !this.props.databases ||
-      this.props.databases.length == 0 ||
+      this.props.databases.length === 0 ||
       this.props.databases.every(x => x.loaded || x.loading)
     ) {
       return false;
     }
 
-    if (this.state.pagination.current != prevState.pagination.current) {
+    if (this.state.pagination.current !== prevState.pagination.current) {
       return true;
     }
 
-    if (prevProps && this.props.search != prevProps.search) {
+    if (prevProps && this.props.search !== prevProps.search) {
       return true;
     }
 
@@ -508,7 +508,7 @@ export class DatabasesPage extends React.Component<
       i++
     ) {
       const db = filteredDatabases[i];
-      if (db.loaded || db.loading || db.requestError != undefined) {
+      if (db.loaded || db.loading || db.requestError != null) {
         continue;
       }
       // Info is not loaded for a visible database.

--- a/pkg/ui/workspaces/cluster-ui/src/insights/indexActionBtn.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/indexActionBtn.tsx
@@ -53,7 +53,7 @@ const IdxRecAction = (props: idxRecProps): React.ReactElement => {
         setApplying(false);
         let foundError = false;
         for (let i = 0; i < r.length; i++) {
-          if (r[i].status == "FAILED") {
+          if (r[i].status === "FAILED") {
             foundError = true;
             setError(r[i].error);
             break;
@@ -202,7 +202,7 @@ function addIdxName(statement: string): string {
   for (let i = 0; i < statements.length; i++) {
     if (statements[i].trim().toUpperCase().startsWith("CREATE INDEX ON ")) {
       result = `${result}${createIdxName(statements[i])}; `;
-    } else if (statements[i].length != 0) {
+    } else if (statements[i].length !== 0) {
       result = `${result}${statements[i]};`;
     }
   }
@@ -231,10 +231,10 @@ export function createIdxName(statement: string): string {
   let parenthesis = 1;
   let i = 0;
   while (parenthesis > 0 && i < info.length) {
-    if (info[i] == "(") {
+    if (info[i] === "(") {
       parenthesis++;
     }
-    if (info[i] == ")") {
+    if (info[i] === ")") {
       parenthesis--;
     }
     i++;

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/transactionInsightDetailsOverviewTab.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/transactionInsightDetailsOverviewTab.tsx
@@ -96,7 +96,7 @@ the maximum number of statements was reached in the console.`;
   const blockingExecutions: ContentionEvent[] = contentionDetails?.map(
     event => {
       const stmtInsight = statements.find(
-        stmt => stmt.statementExecutionID == event.waitingStmtID,
+        stmt => stmt.statementExecutionID === event.waitingStmtID,
       );
       return {
         executionID: event.blockingExecutionID,

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/util/insightsColumns.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/util/insightsColumns.tsx
@@ -123,7 +123,7 @@ export const insightsTableTitles: InsightsTableTitleType = {
   },
   query: (execType: InsightExecEnum) => {
     let tooltipText = `The ${execType} query.`;
-    if (execType == InsightExecEnum.TRANSACTION) {
+    if (execType === InsightExecEnum.TRANSACTION) {
       tooltipText = "The queries attempted in the transaction.";
     }
     return makeToolTip(<p>{tooltipText}</p>, "query", execType);

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/util/queriesCell.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/util/queriesCell.tsx
@@ -37,9 +37,9 @@ export function QueriesCell(
 
   const combinedQuery = transactionQueries?.map((query, idx, arr) => (
     <div key={idx}>
-      {idx != 0 && <br />}
+      {idx !== 0 && <br />}
       {query}
-      {idx != arr.length - 1 && <br />}
+      {idx !== arr.length - 1 && <br />}
     </div>
   ));
 

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/workloadInsightRootControl.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/workloadInsightRootControl.tsx
@@ -65,7 +65,7 @@ export const WorkloadInsightsRootControl = ({
     />
   );
 
-  if (selectedInsightView == InsightExecEnum.TRANSACTION) {
+  if (selectedInsightView === InsightExecEnum.TRANSACTION) {
     return (
       <div>
         <TransactionInsightsView

--- a/pkg/ui/workspaces/cluster-ui/src/jobs/util/duration.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/jobs/util/duration.tsx
@@ -46,7 +46,7 @@ export class Duration extends React.PureComponent<{
         );
       }
       return null;
-    } else if (job.status == JOB_STATUS_SUCCEEDED) {
+    } else if (job.status === JOB_STATUS_SUCCEEDED) {
       return (
         <span className={className}>
           {"Duration: " +

--- a/pkg/ui/workspaces/cluster-ui/src/jobs/util/jobOptions.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/jobs/util/jobOptions.tsx
@@ -44,7 +44,7 @@ export function jobToVisual(job: Job): JobStatusVisual {
     case JOB_STATUS_CANCELED:
     case JOB_STATUS_CANCEL_REQUESTED:
     case JOB_STATUS_PAUSED:
-      return job.error == ""
+      return job.error === ""
         ? JobStatusVisual.BadgeOnly
         : JobStatusVisual.BadgeWithErrorMessage;
     case JOB_STATUS_PAUSE_REQUESTED:
@@ -55,7 +55,7 @@ export function jobToVisual(job: Job): JobStatusVisual {
 }
 
 function jobToVisualForReplicationIngestion(job: Job): JobStatusVisual {
-  if (job.fraction_completed > 0 && job.status == JOB_STATUS_RUNNING) {
+  if (job.fraction_completed > 0 && job.status === JOB_STATUS_RUNNING) {
     return JobStatusVisual.ProgressBarWithDuration;
   }
   return JobStatusVisual.BadgeOnly;

--- a/pkg/ui/workspaces/cluster-ui/src/queryFilter/filter.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/queryFilter/filter.tsx
@@ -751,7 +751,7 @@ export class Filter extends React.Component<QueryFilter, FilterState> {
                       <Select
                         options={timeUnit}
                         value={timeUnit.filter(
-                          unit => unit.label == filters.timeUnit,
+                          unit => unit.label === filters.timeUnit,
                         )}
                         onChange={e => this.handleSelectChange(e, "timeUnit")}
                         className={timePair.timeUnit}

--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsPage.tsx
@@ -155,8 +155,8 @@ export class SessionsPage extends React.Component<
     if (
       this.props.onSortingChange &&
       columnTitle &&
-      (sortSetting.columnTitle != columnTitle ||
-        sortSetting.ascending != ascending)
+      (sortSetting.columnTitle !== columnTitle ||
+        sortSetting.ascending !== ascending)
     ) {
       this.props.onSortingChange("Sessions", columnTitle, ascending);
     }
@@ -298,7 +298,7 @@ export class SessionsPage extends React.Component<
       .filter((s: SessionInfo) => {
         const isInternal = (s: SessionInfo) =>
           s.session.application_name.startsWith(internalAppNamePrefix);
-        if (filters.app && filters.app != "All") {
+        if (filters.app && filters.app !== "All") {
           const apps = filters.app.split(",");
           let showInternal = false;
           if (apps.includes(internalAppNamePrefix)) {
@@ -324,14 +324,14 @@ export class SessionsPage extends React.Component<
         return timeValue === "empty" || sessionTime >= Number(timeValue);
       })
       .filter((s: SessionInfo) => {
-        if (filters.username && filters.username != "All") {
+        if (filters.username && filters.username !== "All") {
           const usernames = filters.username.split(",");
           return usernames.includes(s.session.username);
         }
         return true;
       })
       .filter((s: SessionInfo) => {
-        if (filters.sessionStatus && filters.sessionStatus != "All") {
+        if (filters.sessionStatus && filters.sessionStatus !== "All") {
           const statuses = filters.sessionStatus.split(",");
           return statuses.includes(getStatusString(s.session.status));
         }

--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsTable.tsx
@@ -85,7 +85,7 @@ const StatementTableCell = (props: { session: ISession }) => {
   const { session } = props;
 
   if (!(session.active_queries?.length > 0)) {
-    if (session.last_active_query == "") {
+    if (session.last_active_query === "") {
       return <div>{"N/A"}</div>;
     }
     return <div>{session.last_active_query}</div>;
@@ -111,7 +111,7 @@ function formatSessionStart(session: ISession) {
 }
 
 function formatStatementStart(session: ISession) {
-  if (session.active_queries.length == 0) {
+  if (session.active_queries.length === 0) {
     return <>N/A</>;
   }
   const start = moment

--- a/pkg/ui/workspaces/cluster-ui/src/sortedtable/sortedtable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sortedtable/sortedtable.tsx
@@ -461,8 +461,8 @@ export const handleSortSettingFromQueryString = (
   if (
     onSortingChange &&
     columnTitle &&
-    (sortSetting.columnTitle != columnTitle ||
-      sortSetting.ascending != ascending)
+    (sortSetting.columnTitle !== columnTitle ||
+      sortSetting.ascending !== ascending)
   ) {
     onSortingChange(page, columnTitle, ascending);
   }
@@ -495,8 +495,8 @@ export const updateSortSettingQueryParamsOnTab = (
     searchParams.get("columnTitle") || defaultSortSetting.columnTitle;
   if (
     currentTab === tab &&
-    (sortSetting.columnTitle != columnTitle ||
-      sortSetting.ascending != ascending)
+    (sortSetting.columnTitle !== columnTitle ||
+      sortSetting.ascending !== ascending)
   ) {
     const params = {
       ascending: sortSetting.ascending.toString(),

--- a/pkg/ui/workspaces/cluster-ui/src/sqlActivity/errorComponent.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sqlActivity/errorComponent.tsx
@@ -78,7 +78,7 @@ const LoadingError: React.FC<SQLActivityErrorProps> = props => {
     : "an unexpected error";
 
   const tablesInfo =
-    props.sourceTables?.length == 1
+    props.sourceTables?.length === 1
       ? `Source Table: ${props.sourceTables[0]}`
       : props.sourceTables?.length > 1
       ? `Source Tables: ${props.sourceTables.join(", ")}`

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/planDetails/planDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/planDetails/planDetails.tsx
@@ -301,7 +301,8 @@ export function Insights({
   onChangeSortSetting,
   hasAdminRole,
 }: InsightsProps): React.ReactElement {
-  const hideAction = useContext(CockroachCloudContext) || database?.length == 0;
+  const hideAction =
+    useContext(CockroachCloudContext) || database?.length === 0;
   const insightsColumns = makeInsightsColumns(hideAction, hasAdminRole, true);
   const data = formatIdxRecommendations(
     idxRecommendations,

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/planDetails/plansTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/planDetails/plansTable.tsx
@@ -249,17 +249,17 @@ export const planDetailsTableTitles: PlanDetailsTableTitleType = {
 };
 
 function formatInsights(recommendations: string[]): string {
-  if (!recommendations || recommendations.length == 0) {
+  if (!recommendations || recommendations.length === 0) {
     return "None";
   }
-  if (recommendations.length == 1) {
+  if (recommendations.length === 1) {
     return "1 Insight";
   }
   return `${recommendations.length} Insights`;
 }
 
 export function formatIndexes(indexes: string[], database: string): ReactNode {
-  if (indexes.length == 0) {
+  if (indexes.length === 0) {
     return <></>;
   }
   const indexMap: Map<string, Array<string>> = new Map<string, Array<string>>();

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
@@ -359,7 +359,9 @@ export class StatementDetails extends React.Component<
     // This is necessary for when the new statementFingerprintID does not have data for the given time frame.
     // The new query text and the formatted query text would be an empty string, and we need to invalidate the old
     // query text and formatted query text.
-    if (this.props.statementFingerprintID != prevProps.statementFingerprintID) {
+    if (
+      this.props.statementFingerprintID !== prevProps.statementFingerprintID
+    ) {
       this.setState({ query: null, formattedQuery: null });
     }
   }

--- a/pkg/ui/workspaces/cluster-ui/src/statementsDiagnostics/activateStatementDiagnosticsModal.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsDiagnostics/activateStatementDiagnosticsModal.tsx
@@ -65,7 +65,7 @@ export const ActivateStatementDiagnosticsModal = React.forwardRef(
       value: number,
       unit: string,
     ) => {
-      const multiplier = unit == "milliseconds" ? 0.001 : 1;
+      const multiplier = unit === "milliseconds" ? 0.001 : 1;
       return conditional ? value * multiplier : 0; // num seconds
     };
 
@@ -126,7 +126,7 @@ export const ActivateStatementDiagnosticsModal = React.forwardRef(
       };
     });
 
-    if (planGists && selectedPlanGist == "") {
+    if (planGists && selectedPlanGist === "") {
       setSelectedPlanGist(planGists[0]);
     }
 
@@ -183,7 +183,7 @@ export const ActivateStatementDiagnosticsModal = React.forwardRef(
                       performance.
                     </span>
                   </div>
-                  {getTraceSampleRate(conditional, traceSampleRate) == 1 && (
+                  {getTraceSampleRate(conditional, traceSampleRate) === 1 && (
                     <div className={cx("diagnostic__warning")}>
                       <InlineAlert
                         intent="warning"

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/activeStatementsView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/activeStatementsView.tsx
@@ -239,7 +239,7 @@ export const ActiveStatementsView: React.FC<ActiveStatementsViewProps> = ({
   const countActiveFilters = calculateActiveFilters(filters);
   // The "Idle" execution status does not apply to statements.
   const executionStatuses = Object.values(ExecutionStatus).filter(
-    status => status != ExecutionStatus.Idle,
+    status => status !== ExecutionStatus.Idle,
   );
   const filteredStatements = filterActiveStatements(
     statements,

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
@@ -221,7 +221,7 @@ export class StatementsPage extends React.Component<
 
     // Search query.
     const searchQuery = searchParams.get("q") || undefined;
-    if (onSearchComplete && searchQuery && search != searchQuery) {
+    if (onSearchComplete && searchQuery && search !== searchQuery) {
       onSearchComplete(searchQuery);
     }
 
@@ -261,7 +261,7 @@ export class StatementsPage extends React.Component<
 
   isSortSettingSameAsReqSort = (): boolean => {
     return (
-      getSortColumn(this.props.reqSortSetting) ==
+      getSortColumn(this.props.reqSortSetting) ===
       this.props.sortSetting.columnTitle
     );
   };
@@ -369,7 +369,7 @@ export class StatementsPage extends React.Component<
     const searchParams = new URLSearchParams(history.location.search);
     const currentTab = searchParams.get("tab") || "";
     const searchQueryString = searchParams.get("q") || "";
-    if (currentTab === tab && search && search != searchQueryString) {
+    if (currentTab === tab && search && search !== searchQueryString) {
       syncHistory(
         {
           q: search,
@@ -506,7 +506,7 @@ export class StatementsPage extends React.Component<
   hasReqSortOption = (): boolean => {
     let found = false;
     Object.values(SqlStatsSortOptions).forEach((option: SqlStatsSortType) => {
-      if (getSortColumn(option) == this.props.sortSetting.columnTitle) {
+      if (getSortColumn(option) === this.props.sortSetting.columnTitle) {
         found = true;
       }
     });
@@ -594,7 +594,7 @@ export class StatementsPage extends React.Component<
     const showSortWarning =
       !this.isSortSettingSameAsReqSort() &&
       this.hasReqSortOption() &&
-      data.length == this.props.limit;
+      data.length === this.props.limit;
 
     return (
       <>
@@ -771,7 +771,7 @@ export class StatementsPage extends React.Component<
             }
           />
           {this.props.statementsResponse.inFlight &&
-            getValidErrorsList(this.props.statementsResponse.error) == null &&
+            getValidErrorsList(this.props.statementsResponse.error) === null &&
             longLoadingMessage}
           <ActivateStatementDiagnosticsModal
             ref={this.activateDiagnosticsRef}

--- a/pkg/ui/workspaces/cluster-ui/src/statementsTable/statementsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsTable/statementsTable.tsx
@@ -144,7 +144,7 @@ export function makeStatementsColumns(
     {
       classes: defaultBarChartOptions.classes,
       displayNoSamples: (d: ICollectedStatementStatistics) => {
-        return longToInt(d.stats.exec_stats?.count) == 0;
+        return longToInt(d.stats.exec_stats?.count) === 0;
       },
     };
 

--- a/pkg/ui/workspaces/cluster-ui/src/tracez/snapshot/spanComponent.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/tracez/snapshot/spanComponent.tsx
@@ -48,7 +48,7 @@ const SpanStatus: React.FC<{
   const spanID = span?.span_id;
   const [recordingInFlight, setRecordingInFlight] = useState(false);
   const traceID = span?.trace_id;
-  const recording = span?.current_recording_mode != RecordingMode.OFF;
+  const recording = span?.current_recording_mode !== RecordingMode.OFF;
 
   const toggleRecording = useCallback(() => {
     setRecordingInFlight(true);

--- a/pkg/ui/workspaces/cluster-ui/src/tracez/snapshot/spanTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/tracez/snapshot/spanTable.tsx
@@ -179,7 +179,7 @@ const makeColumns = (
       name: "icons",
       title: "",
       cell: span => {
-        return span.current_recording_mode != RecordingMode.OFF ? (
+        return span.current_recording_mode !== RecordingMode.OFF ? (
           // Use a viewbox to shrink the icon just a bit while leaving it centered.
           <CircleFilled className={cx("icon-red")} viewBox={"-1 -1 12 12"} />
         ) : span.current ? (

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
@@ -182,7 +182,7 @@ export class TransactionsPage extends React.Component<
 
     // Search query.
     const searchQuery = searchParams.get("q") || undefined;
-    if (onSearchComplete && searchQuery && search != searchQuery) {
+    if (onSearchComplete && searchQuery && search !== searchQuery) {
       onSearchComplete(searchQuery);
     }
 
@@ -245,7 +245,7 @@ export class TransactionsPage extends React.Component<
     const searchParams = new URLSearchParams(history.location.search);
     const currentTab = searchParams.get("tab") || "";
     const searchQueryString = searchParams.get("q") || "";
-    if (currentTab === tab && search && search != searchQueryString) {
+    if (currentTab === tab && search && search !== searchQueryString) {
       syncHistory(
         {
           q: search,
@@ -291,7 +291,7 @@ export class TransactionsPage extends React.Component<
 
   isSortSettingSameAsReqSort = (): boolean => {
     return (
-      getSortColumn(this.props.reqSortSetting) ==
+      getSortColumn(this.props.reqSortSetting) ===
       this.props.sortSetting.columnTitle
     );
   };
@@ -442,7 +442,7 @@ export class TransactionsPage extends React.Component<
   hasReqSortOption = (): boolean => {
     let found = false;
     Object.values(SqlStatsSortOptions).forEach((option: SqlStatsSortType) => {
-      if (getSortColumn(option) == this.props.sortSetting.columnTitle) {
+      if (getSortColumn(option) === this.props.sortSetting.columnTitle) {
         found = true;
       }
     });
@@ -543,7 +543,7 @@ export class TransactionsPage extends React.Component<
     const showSortWarning =
       !this.isSortSettingSameAsReqSort() &&
       this.hasReqSortOption() &&
-      transactionsToDisplay.length == this.props.limit;
+      transactionsToDisplay.length === this.props.limit;
 
     return (
       <>

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/utils.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/utils.ts
@@ -177,7 +177,7 @@ export const filterTransactions = (
       const app = t.stats_data.app;
       const isInternal = app.startsWith(internalAppNamePrefix);
 
-      if (filters.app && filters.app != "All") {
+      if (filters.app && filters.app !== "All") {
         const apps = filters.app.split(",");
         let showInternal = false;
         if (apps.includes(internalAppNamePrefix)) {
@@ -205,7 +205,7 @@ export const filterTransactions = (
     .filter((t: Transaction) => {
       // The transaction must contain at least one value of the regions list
       // (if the list is not empty).
-      if (regions.length == 0) return true;
+      if (regions.length === 0) return true;
 
       return getStatementsByFingerprintId(
         t.stats_data.statement_fingerprint_ids,
@@ -217,7 +217,7 @@ export const filterTransactions = (
     .filter((t: Transaction) => {
       // The transaction must contain at least one value of the nodes list
       // (if the list is not empty).
-      if (nodes.length == 0) return true;
+      if (nodes.length === 0) return true;
 
       // If the cluster is a tenant cluster we don't care about nodes.
       if (isTenant) return true;

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsTable/transactionsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsTable/transactionsTable.tsx
@@ -107,7 +107,7 @@ export function makeTransactionsColumns(
   const sampledExecStatsBarChartOptions: BarChartOptions<TransactionInfo> = {
     classes: defaultBarChartOptions.classes,
     displayNoSamples: (d: TransactionInfo) => {
-      return longToInt(d.stats_data.stats.exec_stats?.count) == 0;
+      return longToInt(d.stats_data.stats.exec_stats?.count) === 0;
     },
   };
 

--- a/pkg/ui/workspaces/cluster-ui/src/util/appStats/appStats.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/appStats/appStats.ts
@@ -62,7 +62,7 @@ export function aggregateLatencyInfo(
   b: StatementStatistics,
 ): cockroach.sql.ILatencyInfo {
   const min =
-    a.latency_info?.min == 0 || a.latency_info?.min > b.latency_info?.min
+    a.latency_info?.min === 0 || a.latency_info?.min > b.latency_info?.min
       ? b.latency_info?.min
       : a.latency_info?.min;
   const max =
@@ -76,7 +76,7 @@ export function aggregateLatencyInfo(
   // Use the latest value we have that is not zero.
   if (
     b.last_exec_timestamp < a.last_exec_timestamp &&
-    b.latency_info?.p50 != 0
+    b.latency_info?.p50 !== 0
   ) {
     p50 = a.latency_info?.p50;
     p90 = a.latency_info?.p90;

--- a/pkg/ui/workspaces/cluster-ui/src/util/format.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/format.ts
@@ -168,7 +168,7 @@ export function PercentageCustom(
   let found = false;
   for (let index = 2; index < pctString.length && !found; index++) {
     finalPct = `${finalPct}${pctString[index]}`;
-    if (pctString[index] != "0") {
+    if (pctString[index] !== "0") {
       found = true;
     }
   }
@@ -184,7 +184,7 @@ export function PercentageCustom(
  */
 export function ComputeDurationScale(ns: number): UnitValue {
   return durationUnitsDescending.find(
-    ({ value }) => ns / value >= 1 || value == 1,
+    ({ value }) => ns / value >= 1 || value === 1,
   );
 }
 
@@ -206,7 +206,7 @@ export function Duration(nanoseconds: number): string {
  * If the value is 0, return "no samples".
  */
 export function DurationCheckSample(nanoseconds: number): string {
-  if (nanoseconds == 0) {
+  if (nanoseconds === 0) {
     return "no samples";
   }
   return Duration(nanoseconds);
@@ -233,10 +233,10 @@ export function FormatWithTimezone(
 }
 
 export function RenderCount(yesCount: Long, totalCount: Long): string {
-  if (longToInt(yesCount) == 0) {
+  if (longToInt(yesCount) === 0) {
     return "No";
   }
-  if (longToInt(yesCount) == longToInt(totalCount)) {
+  if (longToInt(yesCount) === longToInt(totalCount)) {
     return "Yes";
   }
   const noCount = longToInt(totalCount) - longToInt(yesCount);
@@ -275,17 +275,17 @@ export const limitText = (text: string, limit: number): string => {
 
 // limitStringArray returns a shortened form of text that surpasses a given limit
 export const limitStringArray = (arr: string[], limit: number): string => {
-  if (!arr || arr.length == 0) {
+  if (!arr || arr.length === 0) {
     return "";
   }
 
   // Remove null and undefined entries in the array.
   arr = arr.filter(n => n);
-  if (arr.length == 0) {
+  if (arr.length === 0) {
     return "";
   }
 
-  if (arr.length == 1 || arr[0]?.length > limit) {
+  if (arr.length === 1 || arr[0]?.length > limit) {
     return limitText(arr[0], limit);
   }
 
@@ -408,7 +408,7 @@ const breakLinesKeywords: BreakLineReplacement = {
 const LINE_BREAK_LIMIT = 100;
 
 export function FormatQuery(query: string): string {
-  if (query == null) {
+  if (query === null) {
     return "";
   }
   Object.keys(breakLinesKeywords).forEach(key => {
@@ -429,7 +429,7 @@ function breakLongLine(line: string, limit: number): string {
     return line;
   }
   const idxComma = line.indexOf(",", limit);
-  if (idxComma == -1) {
+  if (idxComma === -1) {
     return line;
   }
 

--- a/pkg/ui/workspaces/db-console/.eslintrc.json
+++ b/pkg/ui/workspaces/db-console/.eslintrc.json
@@ -14,6 +14,7 @@
     "no-restricted-imports": ["error", {
       "patterns": ["@cockroachlabs/cluster-ui/src/*"]
     }],
-    "@cockroachlabs/crdb/require-antd-style-import": "error"
+    "@cockroachlabs/crdb/require-antd-style-import": "error",
+    "eqeqeq": ["error", "smart"]
   }
 }

--- a/pkg/ui/workspaces/db-console/src/redux/alerts.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/alerts.ts
@@ -731,7 +731,7 @@ export function alertDataSync(store: Store<AdminUIState>) {
       if (
         !state.login ||
         !state.login.loggedInUser ||
-        state.login.loggedInUser == ``
+        state.login.loggedInUser === ``
       ) {
         return;
       }

--- a/pkg/ui/workspaces/db-console/src/redux/cookies.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/cookies.ts
@@ -36,7 +36,7 @@ export const selectTenantsFromMultitenantSessionCookie = (): string[] => {
     ? sessionsStr
         .replace(/["]/g, "")
         .split(/[,]/g)
-        .filter((_, idx) => idx % 2 == 1)
+        .filter((_, idx) => idx % 2 === 1)
     : [];
 };
 

--- a/pkg/ui/workspaces/db-console/src/views/databases/databasesPage/redux.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/views/databases/databasesPage/redux.spec.ts
@@ -67,7 +67,7 @@ class TestDriver {
   }
 
   private findDatabase(name: string) {
-    return _.find(this.properties().databases, row => row.name == name);
+    return _.find(this.properties().databases, row => row.name === name);
   }
 }
 

--- a/pkg/ui/workspaces/db-console/src/views/keyVisualizer/keyVisualizer.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/keyVisualizer/keyVisualizer.tsx
@@ -327,7 +327,7 @@ export default class KeyVisualizer extends React.PureComponent<
   componentDidUpdate(prevProps: KeyVisualizerProps) {
     // only render if the sample window changes.
     // prevent render if there's a tooltip state change.
-    if (prevProps != this.props) {
+    if (prevProps !== this.props) {
       this.renderKeyVisualizer();
     }
   }

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/hotranges/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/hotranges/index.tsx
@@ -39,7 +39,7 @@ const HotRanges = (props: HotRangesProps) => {
       page_token: pageToken,
     });
     getHotRanges(request, moment.duration(30, "minutes")).then(response => {
-      if (response.ranges.length == 0) {
+      if (response.ranges.length === 0) {
         return;
       }
       setPageToken(response.next_page_token);

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/range/rangeTable.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/range/rangeTable.tsx
@@ -861,7 +861,7 @@ export default class RangeTable extends React.Component<RangeTableProps, {}> {
           cockroach.roachpb.RangeClosedTimestampPolicy[
             info.state.closed_timestamp_policy
           ],
-          info.state.closed_timestamp_policy ==
+          info.state.closed_timestamp_policy ===
             cockroach.roachpb.RangeClosedTimestampPolicy.LEAD_FOR_GLOBAL_READS
             ? "range-table__cell--global-range"
             : "",


### PR DESCRIPTION
Add eqeqeq eslint rule for cluster-ui. This rule is on 'smart' mode, meaning we must use triple equals unless:
- comparing two literal values
- evaluating the value of typeof
- comparing against null

Epic: none

Release note: None