### PR TITLE
kvcoord: provide local node ID to DistSender in shared-process mode

### DIFF
--- a/pkg/ccl/kvccl/kvfollowerreadsccl/BUILD.bazel
+++ b/pkg/ccl/kvccl/kvfollowerreadsccl/BUILD.bazel
@@ -48,7 +48,6 @@ go_test(
     deps = [
         "//pkg/base",
         "//pkg/ccl",
-        "//pkg/ccl/kvccl/kvtenantccl",
         "//pkg/ccl/utilccl",
         "//pkg/keys",
         "//pkg/kv",

--- a/pkg/ccl/kvccl/kvfollowerreadsccl/followerreads_test.go
+++ b/pkg/ccl/kvccl/kvfollowerreadsccl/followerreads_test.go
@@ -19,11 +19,10 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
-	// Blank import kvtenantccl so that we can create a tenant.
-	_ "github.com/cockroachdb/cockroach/pkg/ccl/kvccl/kvtenantccl"
 	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvbase"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
@@ -872,195 +871,245 @@ func TestFollowerReadsWithStaleDescriptor(t *testing.T) {
 }
 
 // TestSecondaryTenantFollowerReadsRouting ensures that secondary tenants route
-// their requests to the nearest replica. The test runs two versions -- one
-// where accurate latency information between nodes is available and another
-// where it needs to be estimated using node localities.
+// their requests to the nearest replica. The test exercises three
+// configurations:
+//   - shared-process multi-tenancy
+//   - separate-process multi-tenancy, with accurate latency information between
+//     nodes available
+//   - separate-process multi-tenancy, with accurate latency information between
+//     nodes unavailable which requires the fallback to estimates using node
+//     localities.
+//
+// For the shared-process multi-tenancy we set up a single region cluster so
+// that locality information didn't come into play when choosing the replica. We
+// use n2 as the gateway for the query and expect that its replica will serve
+// the follower read.
+//
+// For the separate-process multi-tenancy we set up a three region cluster where
+// n2 and n4 are in the same region, and we use n4 as the gateway and expect
+// that n2 serves the follower read.
 func TestSecondaryTenantFollowerReadsRouting(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
 	defer utilccl.TestingEnableEnterprise()()
 
 	skip.UnderStressRace(t, "times out")
 
-	testutils.RunTrueAndFalse(t, "valid-latency-func", func(t *testing.T, validLatencyFunc bool) {
-		const numNodes = 4
-
-		serverArgs := make(map[int]base.TestServerArgs)
-		localities := make(map[int]roachpb.Locality)
-		for i := 0; i < numNodes; i++ {
-			regionName := fmt.Sprintf("region_%d", i)
-			if i == 3 {
-				// Make it such that n4 and n2 are in the same region. Below, we'll
-				// expect a follower read from n4 to be served by n2 because they're
-				// in the same locality (when validLatencyFunc is false).
-				regionName = fmt.Sprintf("region_%d", 1)
+	for _, testCase := range []struct {
+		name             string
+		sharedProcess    bool
+		validLatencyFunc bool
+	}{
+		{name: "shared-process", sharedProcess: true},
+		{name: "latency-based", sharedProcess: false, validLatencyFunc: true},
+		{name: "locality-based", sharedProcess: false, validLatencyFunc: false},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			const numNodes = 4
+			gatewayNode := 3
+			if testCase.sharedProcess {
+				gatewayNode = 1
 			}
-			locality := roachpb.Locality{
-				Tiers: []roachpb.Tier{{Key: "region", Value: regionName}},
-			}
-			localities[i] = locality
-			serverArgs[i] = base.TestServerArgs{
-				Locality: localities[i],
-			}
-		}
-		tc := testcluster.StartTestCluster(t, numNodes, base.TestClusterArgs{
-			ReplicationMode:   base.ReplicationManual,
-			ServerArgsPerNode: serverArgs,
-			ServerArgs: base.TestServerArgs{
-				DefaultTestTenant: base.TODOTestTenantDisabled, // we'll create one ourselves below.
-			},
-		})
-		ctx := context.Background()
-		defer tc.Stopper().Stop(ctx)
 
-		historicalQuery := `SELECT * FROM t.test AS OF SYSTEM TIME follower_read_timestamp() WHERE k=2`
-		recCh := make(chan tracingpb.Recording, 1)
-
-		var tenants [numNodes]serverutils.ApplicationLayerInterface
-		for i := 0; i < numNodes; i++ {
-			knobs := base.TestingKnobs{}
-			if i == 3 { // n4
-				knobs = base.TestingKnobs{
-					KVClient: &kvcoord.ClientTestingKnobs{
-						DontConsiderConnHealth: true,
-						// For the validLatencyFunc=true version of the test, the client
-						// pretends to have a low latency connection to n2. As a result, we
-						// expect n2 to be used for follower reads originating from n4.
-						//
-						// For the variant where no latency information is available, we
-						// expect n2 to serve follower reads as well, but because it
-						// is in the same locality as the client.
-						LatencyFunc: func(id roachpb.NodeID) (time.Duration, bool) {
-							if !validLatencyFunc {
-								return 0, false
-							}
-							if id == 2 {
-								return time.Millisecond, true
-							}
-							return 100 * time.Millisecond, true
-						},
-					},
-					SQLExecutor: &sql.ExecutorTestingKnobs{
-						WithStatementTrace: func(trace tracingpb.Recording, stmt string) {
-							if stmt == historicalQuery {
-								recCh <- trace
-							}
-						},
-					},
+			serverArgs := make(map[int]base.TestServerArgs)
+			localities := make(map[int]roachpb.Locality)
+			for i := 0; i < numNodes; i++ {
+				regionName := fmt.Sprintf("region_%d", i)
+				if i == gatewayNode {
+					// Make it such that n4 and n2 are in the same region.
+					// Below, we'll expect a follower read from n4 to be served
+					// by n2 because they're in the same locality (when
+					// validLatencyFunc is false).
+					regionName = fmt.Sprintf("region_%d", 1)
+				}
+				if testCase.sharedProcess {
+					// In shared-process config we want all nodes to be in the
+					// same region so that other considerations (like latency
+					// function and locality matching don't come into play).
+					regionName = "test_region"
+				}
+				locality := roachpb.Locality{
+					Tiers: []roachpb.Tier{{Key: "region", Value: regionName}},
+				}
+				localities[i] = locality
+				serverArgs[i] = base.TestServerArgs{
+					Locality: localities[i],
 				}
 			}
-			tt, err := tc.Server(i).TenantController().StartTenant(ctx, base.TestTenantArgs{
-				TenantID:     serverutils.TestTenantID(),
-				Locality:     localities[i],
-				TestingKnobs: knobs,
+			tc := testcluster.StartTestCluster(t, numNodes, base.TestClusterArgs{
+				ReplicationMode:   base.ReplicationManual,
+				ServerArgsPerNode: serverArgs,
+				ServerArgs: base.TestServerArgs{
+					DefaultTestTenant: base.TestControlsTenantsExplicitly,
+				},
 			})
-			require.NoError(t, err)
-			tenants[i] = tt
-		}
+			ctx := context.Background()
+			defer tc.Stopper().Stop(ctx)
 
-		// Speed up closing of timestamps in order to sleep less below before we can
-		// use follower_read_timestamp(). Note that we need to override the setting
-		// for the tenant as well, because the builtin is run in the tenant's sql pod.
-		systemSQL := sqlutils.MakeSQLRunner(tc.Conns[0])
-		systemSQL.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.target_duration = '0.1s'`)
-		systemSQL.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.side_transport_interval = '0.1s'`)
-		systemSQL.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.propagation_slack = '0.1s'`)
-		// We're making assertions on traces collected by the tenant using log lines
-		// in KV so we must ensure they're not redacted.
-		systemSQL.Exec(t, `SET CLUSTER SETTING trace.redact_at_virtual_cluster_boundary.enabled = 'false'`)
+			// Speed up closing of timestamps in order to sleep less below
+			// before we can use follower_read_timestamp(). Note that we need to
+			// override the setting for the tenant as well, because the builtin
+			// is run in the tenant's sql pod.
+			systemSQL := sqlutils.MakeSQLRunner(tc.Conns[0])
+			systemSQL.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.target_duration = '0.1s'`)
+			systemSQL.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.side_transport_interval = '0.1s'`)
+			systemSQL.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.propagation_slack = '0.1s'`)
+			// We're making assertions on traces collected by the tenant using
+			// log lines in KV so we must ensure they're not redacted.
+			systemSQL.Exec(t, `SET CLUSTER SETTING trace.redact_at_virtual_cluster_boundary.enabled = 'false'`)
 
-		dbs := make([]*gosql.DB, numNodes)
-		for i := 0; i < numNodes; i++ {
-			dbs[i] = tenants[i].SQLConn(t, "")
-		}
+			historicalQuery := `SELECT * FROM t.test AS OF SYSTEM TIME follower_read_timestamp() WHERE k=2`
+			recCh := make(chan tracingpb.Recording, 1)
 
-		// Wait until all tenant servers are aware of the setting override.
-		testutils.SucceedsSoon(t, func() error {
-			settingNames := []string{
-				"kv.closed_timestamp.target_duration", "kv.closed_timestamp.side_transport_interval", "kv.closed_timestamp.propagation_slack",
+			var tenants [numNodes]serverutils.ApplicationLayerInterface
+			dbs := make([]*gosql.DB, numNodes)
+			// In shared-process multi-tenancy we must initialize the tenant
+			// server on the gateway first in order to guarantee that the knobs
+			// are used (otherwise we have a race between the tenant server
+			// being started by the server controller and us explicitly starting
+			// the shared-process tenant server).
+			initOrder := []int{gatewayNode}
+			for i := 0; i < numNodes; i++ {
+				if i != gatewayNode {
+					initOrder = append(initOrder, i)
+				}
 			}
-			for _, settingName := range settingNames {
-				for i := 0; i < numNodes; i++ {
-					db := dbs[i]
+			for _, i := range initOrder {
+				knobs := base.TestingKnobs{}
+				if i == gatewayNode {
+					knobs = base.TestingKnobs{
+						KVClient: &kvcoord.ClientTestingKnobs{
+							DontConsiderConnHealth: true,
+							// For the validLatencyFunc=true version of the
+							// test, the client pretends to have a low latency
+							// connection to n2. As a result, we expect n2 to be
+							// used for follower reads originating from n4.
+							//
+							// For the variant where no latency information is
+							// available, we expect n2 to serve follower reads
+							// as well, but because it is in the same locality
+							// as the client.
+							//
+							// Note that this latency func doesn't matter in the
+							// shared-process config.
+							LatencyFunc: func(id roachpb.NodeID) (time.Duration, bool) {
+								if !testCase.validLatencyFunc {
+									return 0, false
+								}
+								if id == 2 {
+									return time.Millisecond, true
+								}
+								return 100 * time.Millisecond, true
+							},
+						},
+						SQLExecutor: &sql.ExecutorTestingKnobs{
+							WithStatementTrace: func(trace tracingpb.Recording, stmt string) {
+								if stmt == historicalQuery {
+									recCh <- trace
+								}
+							},
+						},
+					}
+				}
+				var err error
+				if testCase.sharedProcess {
+					tenants[i], dbs[i], err = tc.Server(i).TenantController().StartSharedProcessTenant(ctx, base.TestSharedProcessTenantArgs{
+						TenantName: "test",
+						TenantID:   serverutils.TestTenantID(),
+						Knobs:      knobs,
+					})
+				} else {
+					tenants[i], err = tc.Server(i).TenantController().StartTenant(ctx, base.TestTenantArgs{
+						TenantID:     serverutils.TestTenantID(),
+						Locality:     localities[i],
+						TestingKnobs: knobs,
+					})
+					dbs[i] = tenants[i].SQLConn(t, "")
+				}
+				require.NoError(t, err)
+			}
 
-					var val string
-					err := db.QueryRow(
-						fmt.Sprintf("SHOW CLUSTER SETTING %s", settingName),
-					).Scan(&val)
-					require.NoError(t, err)
-					if val != "00:00:00.1" {
-						return errors.Errorf("tenant server %d is still waiting for %s update: currently %s",
-							i,
-							settingName,
-							val,
-						)
+			// Wait until all tenant servers are aware of the setting override.
+			testutils.SucceedsSoon(t, func() error {
+				settingNames := []string{
+					"kv.closed_timestamp.target_duration", "kv.closed_timestamp.side_transport_interval", "kv.closed_timestamp.propagation_slack",
+				}
+				for _, settingName := range settingNames {
+					for i := 0; i < numNodes; i++ {
+						db := dbs[i]
+
+						var val string
+						err := db.QueryRow(
+							fmt.Sprintf("SHOW CLUSTER SETTING %s", settingName),
+						).Scan(&val)
+						require.NoError(t, err)
+						if val != "00:00:00.1" {
+							return errors.Errorf("tenant server %d is still waiting for %s update: currently %s",
+								i,
+								settingName,
+								val,
+							)
+						}
+					}
+				}
+				return nil
+			})
+
+			tenantSQLDB := dbs[gatewayNode]
+			tenantSQL := sqlutils.MakeSQLRunner(tenantSQLDB)
+
+			tenantSQL.Exec(t, `CREATE DATABASE t`)
+			tenantSQL.Exec(t, `CREATE TABLE t.test (k INT PRIMARY KEY)`)
+
+			codec := tenants[gatewayNode].Codec()
+			startKey := codec.TenantPrefix()
+			tc.AddVotersOrFatal(t, startKey, tc.Target(1), tc.Target(2))
+			tc.WaitForVotersOrFatal(t, startKey, tc.Target(1), tc.Target(2))
+			desc := tc.LookupRangeOrFatal(t, startKey)
+			require.Equal(t, []roachpb.ReplicaDescriptor{
+				{NodeID: 1, StoreID: 1, ReplicaID: 1},
+				{NodeID: 2, StoreID: 2, ReplicaID: 2},
+				{NodeID: 3, StoreID: 3, ReplicaID: 3},
+			}, desc.Replicas().Descriptors())
+
+			// Sleep so that we can perform follower reads. The read timestamp
+			// needs to be above the timestamp when the table was created.
+			log.Infof(ctx, "test sleeping for the follower read timestamps to pass the table creation timestamp...")
+			time.Sleep(500 * time.Millisecond)
+			log.Infof(ctx, "test sleeping... done")
+
+			// Check that the cache was indeed populated.
+			tenantSQL.Exec(t, `SELECT * FROM t.test WHERE k = 1`)
+			tablePrefix := keys.MustAddr(codec.TenantPrefix())
+			cache := tenants[gatewayNode].DistSenderI().(*kvcoord.DistSender).RangeDescriptorCache()
+			entry := cache.GetCached(ctx, tablePrefix, false /* inverted */)
+			require.NotNil(t, entry)
+			require.False(t, entry.Lease().Empty())
+			require.Equal(t, roachpb.StoreID(1), entry.Lease().Replica.StoreID)
+			require.Equal(t, []roachpb.ReplicaDescriptor{
+				{NodeID: 1, StoreID: 1, ReplicaID: 1},
+				{NodeID: 2, StoreID: 2, ReplicaID: 2},
+				{NodeID: 3, StoreID: 3, ReplicaID: 3},
+			}, entry.Desc().Replicas().Descriptors())
+
+			tenantSQL.Exec(t, historicalQuery)
+			rec := <-recCh
+
+			// Look at the trace and check that the follower read was served by
+			// n2.
+			var numFRs, numN2FRs int
+			for _, sp := range rec {
+				for _, l := range sp.Logs {
+					if msg := l.Message.StripMarkers(); strings.Contains(msg, kvbase.FollowerReadServingMsg) {
+						numFRs++
+						if strings.Contains(msg, "n2") {
+							numN2FRs++
+						}
 					}
 				}
 			}
-			return nil
+			require.Equal(t, numFRs, 1, "query wasn't served through follower reads: %s", rec)
+			require.Equal(t, numN2FRs, 1, "follower read wasn't served by n2: %s", rec)
 		})
-
-		tenantSQLDB := dbs[3]
-		tenantSQL := sqlutils.MakeSQLRunner(tenantSQLDB)
-
-		tenantSQL.Exec(t, `CREATE DATABASE t`)
-		tenantSQL.Exec(t, `CREATE TABLE t.test (k INT PRIMARY KEY)`)
-
-		startKey := keys.MakeSQLCodec(serverutils.TestTenantID()).TenantPrefix()
-		tc.AddVotersOrFatal(t, startKey, tc.Target(1), tc.Target(2))
-		tc.WaitForVotersOrFatal(t, startKey, tc.Target(1), tc.Target(2))
-		desc := tc.LookupRangeOrFatal(t, startKey)
-		require.Equal(t, []roachpb.ReplicaDescriptor{
-			{NodeID: 1, StoreID: 1, ReplicaID: 1},
-			{NodeID: 2, StoreID: 2, ReplicaID: 2},
-			{NodeID: 3, StoreID: 3, ReplicaID: 3},
-		}, desc.Replicas().Descriptors())
-
-		// Sleep so that we can perform follower reads. The read timestamp needs to be
-		// above the timestamp when the table was created.
-		log.Infof(ctx, "test sleeping for the follower read timestamps to pass the table creation timestamp...")
-		time.Sleep(500 * time.Millisecond)
-		log.Infof(ctx, "test sleeping... done")
-
-		getFollowerReadCounts := func() [numNodes]int64 {
-			var counts [numNodes]int64
-			for i := range tc.Servers {
-				err := tc.Servers[i].GetStores().(*kvserver.Stores).VisitStores(func(s *kvserver.Store) error {
-					counts[i] = s.Metrics().FollowerReadsCount.Count()
-					return nil
-				})
-				require.NoError(t, err)
-			}
-			return counts
-		}
-
-		// Check that the cache was indeed populated.
-		tenantSQL.Exec(t, `SELECT * FROM t.test WHERE k = 1`)
-		tablePrefix := keys.MustAddr(keys.MakeSQLCodec(serverutils.TestTenantID()).TenantPrefix())
-		cache := tenants[3].DistSenderI().(*kvcoord.DistSender).RangeDescriptorCache()
-		entry := cache.GetCached(ctx, tablePrefix, false /* inverted */)
-		require.NotNil(t, entry)
-		require.False(t, entry.Lease().Empty())
-		require.Equal(t, roachpb.StoreID(1), entry.Lease().Replica.StoreID)
-		require.Equal(t, []roachpb.ReplicaDescriptor{
-			{NodeID: 1, StoreID: 1, ReplicaID: 1},
-			{NodeID: 2, StoreID: 2, ReplicaID: 2},
-			{NodeID: 3, StoreID: 3, ReplicaID: 3},
-		}, entry.Desc().Replicas().Descriptors())
-
-		followerReadCountsBefore := getFollowerReadCounts()
-		tenantSQL.Exec(t, historicalQuery)
-		followerReadsCountsAfter := getFollowerReadCounts()
-
-		rec := <-recCh
-		// Look at the trace and check that we've served a follower read.
-		require.True(t, kv.OnlyFollowerReads(rec), "query was served through follower reads: %s", rec)
-
-		for i := 0; i < numNodes; i++ {
-			if i == 1 { // n2
-				require.Greater(t, followerReadsCountsAfter[i], followerReadCountsBefore[i])
-				continue
-			}
-			require.Equal(t, followerReadsCountsAfter[i], followerReadCountsBefore[i])
-		}
-	})
+	}
 }

--- a/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed.go
@@ -720,7 +720,7 @@ func newTransportForRange(
 	if err != nil {
 		return nil, err
 	}
-	replicas.OptimizeReplicaOrder(ds.getNodeID(), latencyFn, ds.locality)
+	replicas.OptimizeReplicaOrder(ds.nodeIDGetter(), latencyFn, ds.locality)
 	opts := SendOptions{class: connectionClass(&ds.st.SV)}
 	return ds.transportFactory(opts, ds.nodeDialer, replicas)
 }

--- a/pkg/kv/kvclient/kvcoord/dist_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_test.go
@@ -617,7 +617,7 @@ func TestImmutableBatchArgs(t *testing.T) {
 
 	txn := roachpb.MakeTransaction(
 		"test", nil /* baseKey */, isolation.Serializable, roachpb.NormalUserPriority,
-		clock.Now(), clock.MaxOffset().Nanoseconds(), int32(ds.getNodeID()), 0,
+		clock.Now(), clock.MaxOffset().Nanoseconds(), int32(ds.nodeIDGetter()), 0,
 	)
 	origTxnTs := txn.WriteTimestamp
 


### PR DESCRIPTION
This commit makes it so that the DistSender of SQL pods running in shared-process mode have access to the node ID of the local KV node. The node ID is used to preferentially route requests to replicas available on the local node. Previously, this optimization was only available in single-tenant mode, and now it'll be also available in shared-process multi-tenant. The optimization doesn't exist in separate-process multi-tenant, so in that mode we continue to return `0` as the node ID which makes it so that replicas are picked randomly.

For testing, this commit extends existing `TestSecondaryTenantFollowerReadsRouting` to also have a shared-process test configuration. There were a few gotchas in that adjustment:
- for simplicity, we need to create a single region cluster so that latency and locality don't come into consideration when choosing the replica (we want to make sure that the local replica is used if available)
- starting shared-process virtual cluster on a multi node cluster can be racy if we want to provide testing knobs, so we have to start the service on the gateway node first. (If we don't start with the gateway, then the server controller on the gateway could start the tenant server with empty knobs _before_ we explicitly start the service there.)
- previously the test relied on retrieving the follower reads metric counters from all nodes and asserting only for `n2` it increased. However, in shared-process config it is now possible for an internal query (e.g. issued by auto stats collection) to be served via follower reads too, which would increment the counter confusing the test. As a result, this commit adjusts the test to audit the trace of the query and verify that the single follower read was served specifically by `n2`.

Fixes: #109522.

Release note: None