### PR TITLE
bazelcodecover: add "mode" line

### DIFF
--- a/pkg/testutils/bazelcodecover/code_cover_on.go
+++ b/pkg/testutils/bazelcodecover/code_cover_on.go
@@ -77,6 +77,11 @@ func emitCoverageCountersImpl(dir string) (err error) {
 		return err
 	}
 
+	if _, err := fmt.Fprintf(file, "mode: set\n"); err != nil {
+		file.Close()
+		return err
+	}
+
 	for name, counts := range coverdata.Counters {
 		if strings.HasPrefix(name, "external/") ||
 			strings.HasPrefix(name, "bazel-out/") {


### PR DESCRIPTION
Adding "mode" line to the code coverage output, otherwise the
`golang.org/x/tools/cover` library complains when opening the file.

Epic: none
Release note: None