### PR TITLE
ui: allow custom color on metric

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/replication.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/replication.tsx
@@ -55,7 +55,11 @@ export default function (props: GraphDashboardProps) {
           name="cr.store.replicas.leaders_not_leaseholders"
           title="Leaders w/o Lease"
         />
-        <Metric name="cr.store.ranges.unavailable" title="Unavailable" />
+        <Metric
+          name="cr.store.ranges.unavailable"
+          title="Unavailable"
+          color="#F16969"
+        />
         <Metric
           name="cr.store.ranges.underreplicated"
           title="Under-replicated"

--- a/pkg/ui/workspaces/db-console/src/views/cluster/util/graphs.ts
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/util/graphs.ts
@@ -46,6 +46,7 @@ export type formattedSeries = {
   key: string;
   area: boolean;
   fillOpacity: number;
+  color?: string;
 };
 
 export function formatMetricData(
@@ -68,6 +69,7 @@ export function formatMetricData(
         key: s.props.title || s.props.name,
         area: true,
         fillOpacity: 0.1,
+        color: s.props.color,
       });
     }
   });
@@ -95,7 +97,11 @@ export function configureUPlotLineChart(
   // below to cycle through the colors. This ensures that we always
   // start from the same color for each graph so a single-series
   // graph will always have the first color, etc.
-  const strokeColors = [...seriesPalette];
+  const strokeColors = _.without(
+    seriesPalette,
+    // Exclude custom colors provided in metrics from default list of colors.
+    ...formattedRaw.filter(r => !!r.color).map(r => r.color),
+  );
 
   const tooltipPlugin = () => {
     return {
@@ -179,8 +185,16 @@ export function configureUPlotLineChart(
       // Generate a series object for reach of our results
       // picking colors from our palette.
       ...formattedRaw.map(result => {
-        const color = strokeColors.shift();
-        strokeColors.push(color);
+        let color: string;
+        // Assign custom provided color, otherwise assign from
+        // the list of default colors.
+        if (result.color) {
+          color = result.color;
+        } else {
+          color = strokeColors.shift();
+          strokeColors.push(color);
+        }
+
         return {
           show: true,
           scale: "yAxis",

--- a/pkg/ui/workspaces/db-console/src/views/shared/components/metricQuery/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/shared/components/metricQuery/index.tsx
@@ -90,6 +90,7 @@ export interface MetricProps {
   tenantSource?: string;
   title?: string;
   rate?: boolean;
+  color?: string;
 
   // How much to multiply the value of the underlying metric, for example if the
   // metric was a duration stored in seconds you'd need a scale of 1_000_000_000


### PR DESCRIPTION
Add the ability to choose a color for specific metric series on
Metric charts.

On chart Replication -> Ranges, specify the color so it will be red.
Otherwise could be confusing seeing any other as Red, and
the `Unavailable` as green.

Fixes #107637

Release note: None

Before
<img width="857" alt="Screenshot 2023-09-28 at 7 49 55 PM" src="https://github.com/cockroachdb/cockroach/assets/1017486/88af7e07-3c58-463d-963c-d47a3dd3f7c3">


After
<img width="897" alt="Screenshot 2023-10-03 at 12 27 00 PM" src="https://github.com/cockroachdb/cockroach/assets/1017486/cfe3c2f8-4038-412f-908c-3ca51a82d720">


Release note: None