### PR TITLE
ui: show metric on charts tooltip

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/cluster/components/linegraph/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/components/linegraph/index.tsx
@@ -67,6 +67,7 @@ export interface OwnProps extends MetricsDataComponentProps {
   hoverState?: HoverState;
   preCalcGraphSize?: boolean;
   legendAsTooltip?: boolean;
+  showMetricsInTooltip?: boolean;
 }
 
 export type LineGraphProps = OwnProps & WithTimezoneProps;
@@ -381,7 +382,41 @@ export class InternalLineGraph extends React.Component<LineGraphProps, {}> {
       tenantSource,
       preCalcGraphSize,
       legendAsTooltip,
+      showMetricsInTooltip,
     } = this.props;
+    let tt = tooltip;
+    const addLines: React.ReactNode = tooltip ? (
+      <>
+        <br />
+        <br />
+      </>
+    ) : null;
+    // Extend tooltip to include metrics names
+    if (showMetricsInTooltip) {
+      if (data?.results?.length === 1) {
+        tt = (
+          <>
+            {tt}
+            {addLines}
+            Metric: {data.results[0].query.name}
+          </>
+        );
+      } else if (data?.results?.length > 1) {
+        tt = (
+          <>
+            {tt}
+            {addLines}
+            Metrics:
+            <ul>
+              {data.results.map(m => (
+                <li key={m.query.name}>{m.query.name}</li>
+              ))}
+            </ul>
+          </>
+        );
+      }
+    }
+
     if (!this.hasDataPoints(data) && isSecondaryTenant(tenantSource)) {
       return (
         <div className="linegraph-empty">
@@ -404,7 +439,7 @@ export class InternalLineGraph extends React.Component<LineGraphProps, {}> {
       <Visualization
         title={title}
         subtitle={subtitle}
-        tooltip={tooltip}
+        tooltip={tt}
         loading={!data}
         preCalcGraphSize={preCalcGraphSize}
       >

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/changefeeds.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/changefeeds.tsx
@@ -37,6 +37,7 @@ export default function (props: GraphDashboardProps) {
       isKvGraph={false}
       sources={storeSources}
       tenantSource={tenantSource}
+      showMetricsInTooltip={true}
     >
       <Axis units={AxisUnits.Count} label="count">
         <Metric
@@ -53,7 +54,9 @@ export default function (props: GraphDashboardProps) {
 
     <LineGraph
       title="Commit Latency"
-      tooltip={`The difference between an event's MVCC timestamp and the time it was acknowledged as received by the downstream sink.`}
+      tooltip={`The difference between an event's MVCC timestamp and the time it was
+          acknowledged as received by the downstream sink.`}
+      showMetricsInTooltip={true}
       isKvGraph={false}
       sources={storeSources}
       tenantSource={tenantSource}
@@ -77,7 +80,12 @@ export default function (props: GraphDashboardProps) {
       </Axis>
     </LineGraph>,
 
-    <LineGraph title="Emitted Bytes" isKvGraph={false} sources={storeSources}>
+    <LineGraph
+      title="Emitted Bytes"
+      isKvGraph={false}
+      sources={storeSources}
+      showMetricsInTooltip={true}
+    >
       <Axis units={AxisUnits.Bytes} label="bytes">
         <Metric
           name="cr.node.changefeed.emitted_bytes"
@@ -92,6 +100,7 @@ export default function (props: GraphDashboardProps) {
       isKvGraph={false}
       sources={storeSources}
       tenantSource={tenantSource}
+      showMetricsInTooltip={true}
     >
       <Axis units={AxisUnits.Count} label="actions">
         <Metric
@@ -110,7 +119,12 @@ export default function (props: GraphDashboardProps) {
     <LineGraph
       title="Max Checkpoint Latency"
       isKvGraph={false}
-      tooltip={`The most any changefeed's persisted checkpoint is behind the present.  Larger values indicate issues with successfully ingesting or emitting changes.  If errors cause a changefeed to restart, or the changefeed is paused and unpaused, emitted data up to the last checkpoint may be re-emitted.`}
+      tooltip={`The most any changefeed's persisted checkpoint is behind the present.
+          Larger values indicate issues with successfully ingesting or emitting
+          changes. If errors cause a changefeed to restart, or the changefeed is
+          paused and unpaused, emitted data up to the last checkpoint may be
+          re-emitted.`}
+      showMetricsInTooltip={true}
       tenantSource={tenantSource}
     >
       <Axis units={AxisUnits.Duration} label="time">
@@ -125,7 +139,10 @@ export default function (props: GraphDashboardProps) {
 
     <LineGraph
       title="Changefeed Restarts"
-      tooltip={`The rate of transient non-fatal errors, such as temporary connectivity issues or a rolling upgrade. This rate constantly becoming non-zero may indicate a more persistent issue.`}
+      tooltip={`The rate of transient non-fatal errors, such as temporary connectivity
+          issues or a rolling upgrade. This rate constantly becoming non-zero
+          may indicate a more persistent issue.`}
+      showMetricsInTooltip={true}
       isKvGraph={false}
       sources={storeSources}
       tenantSource={tenantSource}
@@ -141,7 +158,9 @@ export default function (props: GraphDashboardProps) {
 
     <LineGraph
       title="Oldest Protected Timestamp"
-      tooltip={`The oldest data that any changefeed is protecting from being able to be automatically garbage collected.`}
+      tooltip={`The oldest data that any changefeed is protecting from being able to
+          be automatically garbage collected.`}
+      showMetricsInTooltip={true}
       isKvGraph={false}
       sources={storeSources}
     >
@@ -157,7 +176,10 @@ export default function (props: GraphDashboardProps) {
 
     <LineGraph
       title="Backfill Pending Ranges"
-      tooltip={`The number of ranges being backfilled (ex: due to an initial scan or schema change) that are yet to completely enter the Changefeed pipeline.`}
+      tooltip={`The number of ranges being backfilled (ex: due to an initial scan or
+          schema change) that are yet to completely enter the Changefeed
+          pipeline.`}
+      showMetricsInTooltip={true}
       isKvGraph={false}
       sources={storeSources}
     >
@@ -171,13 +193,16 @@ export default function (props: GraphDashboardProps) {
 
     <LineGraph
       title="Schema Registry Registrations"
-      tooltip={`The rate of schema registration requests made by CockroachDB nodes to a configured schema registry endpoint (ex: A Kafka feed pointing to a Confluent Schema Registry)`}
+      tooltip={`The rate of schema registration requests made by CockroachDB nodes to
+          a configured schema registry endpoint (ex: A Kafka feed pointing to a
+          Confluent Schema Registry)`}
+      showMetricsInTooltip={true}
       isKvGraph={false}
       sources={storeSources}
     >
       <Axis units={AxisUnits.Count} label="action">
         <Metric
-          name="cr.node.changefeed.schema_registry_registrations"
+          name="cr.node.changefeed.schema_registry.registrations"
           title="Schema Registry Registrations"
           nonNegativeRate
         />
@@ -188,7 +213,9 @@ export default function (props: GraphDashboardProps) {
       title="Ranges in catchup mode"
       isKvGraph={false}
       sources={storeSources}
-      tooltip="Total number of ranges with an active rangefeed that are performing catchup scan"
+      tooltip={`Total number of ranges with an active rangefeed that are performing
+          catchup scan`}
+      showMetricsInTooltip={true}
     >
       <Axis units={AxisUnits.Count} label="ranges">
         <Metric
@@ -203,6 +230,7 @@ export default function (props: GraphDashboardProps) {
       title="RangeFeed catchup scans duration"
       isKvGraph={false}
       sources={storeSources}
+      showMetricsInTooltip={true}
     >
       <Axis units={AxisUnits.Duration} label="duration">
         {nodeIDs.map(nid => (

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/distributed.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/distributed.tsx
@@ -25,6 +25,7 @@ export default function (props: GraphDashboardProps) {
       title="Batches"
       sources={nodeSources}
       tenantSource={tenantSource}
+      showMetricsInTooltip={true}
     >
       <Axis label="batches">
         <Metric
@@ -40,7 +41,12 @@ export default function (props: GraphDashboardProps) {
       </Axis>
     </LineGraph>,
 
-    <LineGraph title="RPCs" sources={nodeSources} tenantSource={tenantSource}>
+    <LineGraph
+      title="RPCs"
+      sources={nodeSources}
+      tenantSource={tenantSource}
+      showMetricsInTooltip={true}
+    >
       <Axis label="rpcs">
         <Metric
           name="cr.node.distsender.rpc.sent"
@@ -59,6 +65,7 @@ export default function (props: GraphDashboardProps) {
       title="RPC Errors"
       sources={nodeSources}
       tenantSource={tenantSource}
+      showMetricsInTooltip={true}
     >
       <Axis label="errors">
         <Metric
@@ -83,6 +90,7 @@ export default function (props: GraphDashboardProps) {
       title="KV Transactions"
       sources={nodeSources}
       tenantSource={tenantSource}
+      showMetricsInTooltip={true}
     >
       <Axis label="transactions">
         <Metric name="cr.node.txn.commits" title="Committed" nonNegativeRate />
@@ -99,7 +107,8 @@ export default function (props: GraphDashboardProps) {
       title="KV Transaction Durations: 99th percentile"
       tenantSource={tenantSource}
       tooltip={`The 99th percentile of transaction durations over a 1 minute period.
-                              Values are displayed individually for each node.`}
+          Values are displayed individually for each node.`}
+      showMetricsInTooltip={true}
     >
       <Axis units={AxisUnits.Duration} label="transaction duration">
         {_.map(nodeIDs, node => (
@@ -118,7 +127,8 @@ export default function (props: GraphDashboardProps) {
       title="KV Transaction Durations: 90th percentile"
       tenantSource={tenantSource}
       tooltip={`The 90th percentile of transaction durations over a 1 minute period.
-                              Values are displayed individually for each node.`}
+          Values are displayed individually for each node.`}
+      showMetricsInTooltip={true}
     >
       <Axis units={AxisUnits.Duration} label="transaction duration">
         {_.map(nodeIDs, node => (
@@ -136,8 +146,10 @@ export default function (props: GraphDashboardProps) {
     <LineGraph
       title="Node Heartbeat Latency: 99th percentile"
       tenantSource={tenantSource}
-      tooltip={`The 99th percentile of latency to heartbeat a node's internal liveness record over a 1 minute period.
-                              Values are displayed individually for each node.`}
+      tooltip={`The 99th percentile of latency to heartbeat a node's internal liveness
+          record over a 1 minute period. Values are displayed individually for
+          each node.`}
+      showMetricsInTooltip={true}
     >
       <Axis units={AxisUnits.Duration} label="heartbeat latency">
         {_.map(nodeIDs, node => (
@@ -155,8 +167,10 @@ export default function (props: GraphDashboardProps) {
     <LineGraph
       title="Node Heartbeat Latency: 90th percentile"
       tenantSource={tenantSource}
-      tooltip={`The 90th percentile of latency to heartbeat a node's internal liveness record over a 1 minute period.
-                              Values are displayed individually for each node.`}
+      tooltip={`The 90th percentile of latency to heartbeat a node's internal liveness
+          record over a 1 minute period. Values are displayed individually for
+          each node.`}
+      showMetricsInTooltip={true}
     >
       <Axis units={AxisUnits.Duration} label="heartbeat latency">
         {_.map(nodeIDs, node => (

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/graphTooltips.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/graphTooltips.tsx
@@ -152,25 +152,25 @@ export const TransactionRestartsToolTip: React.FC<{
   </div>
 );
 
-export const CircuitBreakerTrippedReplicasTooltip: React.FC = () => (
+export const CircuitBreakerTrippedReplicasTooltip: React.ReactNode = (
   <div>
     Number of Replicas for which the per-Replica circuit breaker is currently
     tripped.
   </div>
 );
 
-export const CircuitBreakerTrippedEventsTooltip: React.FC = () => (
+export const CircuitBreakerTrippedEventsTooltip: React.ReactNode = (
   <div>
     The number of circuit breaker events occurred per aggregated interval of
     time across all nodes since the process started.
   </div>
 );
 
-export const PausedFollowersTooltip: React.FC = () => (
+export const PausedFollowersTooltip: React.ReactNode = (
   <div>The number of nonessential followers that have replication paused.</div>
 );
 
-export const ReceiverSnapshotsQueuedTooltip: React.FC = () => (
+export const ReceiverSnapshotsQueuedTooltip: React.ReactNode = (
   <div>
     The number of snapshots queued to be applied on a receiver which can only{" "}
     accept 1 at a time per store.

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/hardware.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/hardware.tsx
@@ -40,6 +40,7 @@ export default function (props: GraphDashboardProps) {
       sources={nodeSources}
       tenantSource={tenantSource}
       tooltip={<div>CPU usage for the CRDB nodes {tooltipSelection}</div>}
+      showMetricsInTooltip={true}
     >
       <Axis units={AxisUnits.Percentage} label="CPU">
         {nodeIDs.map(nid => (
@@ -57,6 +58,7 @@ export default function (props: GraphDashboardProps) {
       sources={nodeSources}
       tenantSource={tenantSource}
       tooltip={<div>Machine-wide CPU usage {tooltipSelection}</div>}
+      showMetricsInTooltip={true}
     >
       <Axis units={AxisUnits.Percentage} label="CPU">
         {nodeIDs.map(nid => (
@@ -74,6 +76,7 @@ export default function (props: GraphDashboardProps) {
       sources={nodeSources}
       tenantSource={tenantSource}
       tooltip={<div>Memory in use {tooltipSelection}</div>}
+      showMetricsInTooltip={true}
     >
       <Axis units={AxisUnits.Bytes} label="memory usage">
         {nodeIDs.map(nid => (
@@ -90,6 +93,7 @@ export default function (props: GraphDashboardProps) {
       title="Disk Read MiB/s"
       sources={nodeSources}
       tenantSource={tenantSource}
+      showMetricsInTooltip={true}
     >
       <Axis units={AxisUnits.Bytes} label="bytes">
         {nodeIDs.map(nid => (
@@ -107,6 +111,7 @@ export default function (props: GraphDashboardProps) {
       title="Disk Write MiB/s"
       sources={nodeSources}
       tenantSource={tenantSource}
+      showMetricsInTooltip={true}
     >
       <Axis units={AxisUnits.Bytes} label="bytes">
         {nodeIDs.map(nid => (
@@ -124,6 +129,7 @@ export default function (props: GraphDashboardProps) {
       title="Disk Read IOPS"
       sources={nodeSources}
       tenantSource={tenantSource}
+      showMetricsInTooltip={true}
     >
       <Axis units={AxisUnits.Count} label="IOPS">
         {nodeIDs.map(nid => (
@@ -141,6 +147,7 @@ export default function (props: GraphDashboardProps) {
       title="Disk Write IOPS"
       sources={nodeSources}
       tenantSource={tenantSource}
+      showMetricsInTooltip={true}
     >
       <Axis units={AxisUnits.Count} label="IOPS">
         {nodeIDs.map(nid => (
@@ -158,6 +165,7 @@ export default function (props: GraphDashboardProps) {
       title="Disk Ops In Progress"
       sources={nodeSources}
       tenantSource={tenantSource}
+      showMetricsInTooltip={true}
     >
       <Axis units={AxisUnits.Count} label="Ops">
         {nodeIDs.map(nid => (
@@ -175,6 +183,7 @@ export default function (props: GraphDashboardProps) {
       sources={storeSources}
       tenantSource={tenantSource}
       tooltip={<AvailableDiscCapacityGraphTooltip />}
+      showMetricsInTooltip={true}
     >
       <Axis units={AxisUnits.Bytes} label="capacity">
         {nodeIDs.map(nid => (

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/networking.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/networking.tsx
@@ -25,7 +25,7 @@ export default function (props: GraphDashboardProps) {
     props;
 
   return [
-    <LineGraph title="Network Bytes Received">
+    <LineGraph title="Network Bytes Received" showMetricsInTooltip={true}>
       <Axis units={AxisUnits.Bytes} label="bytes">
         {nodeIDs.map(nid => (
           <Metric
@@ -39,7 +39,7 @@ export default function (props: GraphDashboardProps) {
       </Axis>
     </LineGraph>,
 
-    <LineGraph title="Network Bytes Sent">
+    <LineGraph title="Network Bytes Sent" showMetricsInTooltip={true}>
       <Axis units={AxisUnits.Bytes} label="bytes">
         {nodeIDs.map(nid => (
           <Metric
@@ -57,6 +57,7 @@ export default function (props: GraphDashboardProps) {
       title="RPC Heartbeat Latency: 50th percentile"
       isKvGraph={false}
       tooltip={`Round-trip latency for recent successful outgoing heartbeats.`}
+      showMetricsInTooltip={true}
     >
       <Axis units={AxisUnits.Duration} label="latency">
         {nodeIDs.map(nid => (
@@ -75,6 +76,7 @@ export default function (props: GraphDashboardProps) {
       title="RPC Heartbeat Latency: 99th percentile"
       isKvGraph={false}
       tooltip={`Round-trip latency for recent successful outgoing heartbeats.`}
+      showMetricsInTooltip={true}
     >
       <Axis units={AxisUnits.Duration} label="latency">
         {nodeIDs.map(nid => (
@@ -91,7 +93,9 @@ export default function (props: GraphDashboardProps) {
 
     <LineGraph
       title="Unhealthy RPC Connections"
-      tooltip={`The number of outgoing connections on each node that are in an unhealthy state.`}
+      tooltip={`The number of outgoing connections on each node that are in an
+          unhealthy state.`}
+      showMetricsInTooltip={true}
     >
       <Axis label="connections">
         {nodeIDs.map(nid => (

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/overload.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/overload.tsx
@@ -35,6 +35,7 @@ export default function (props: GraphDashboardProps) {
       title="CPU Percent"
       sources={nodeSources}
       tenantSource={tenantSource}
+      showMetricsInTooltip={true}
     >
       <Axis units={AxisUnits.Percentage} label="CPU">
         {nodeIDs.map(nid => (
@@ -52,6 +53,7 @@ export default function (props: GraphDashboardProps) {
       sources={nodeSources}
       tenantSource={tenantSource}
       tooltip={`P99 scheduling latency for goroutines`}
+      showMetricsInTooltip={true}
     >
       <Axis units={AxisUnits.Duration} label="latency">
         {nodeIDs.map(nid => (
@@ -73,6 +75,7 @@ export default function (props: GraphDashboardProps) {
       sources={nodeSources}
       tenantSource={tenantSource}
       tooltip={`The number of Goroutines waiting per CPU.`}
+      showMetricsInTooltip={true}
     >
       <Axis label="goroutines">
         {nodeIDs.map(nid => (
@@ -90,6 +93,7 @@ export default function (props: GraphDashboardProps) {
       sources={storeSources}
       tenantSource={tenantSource}
       tooltip={`The number of sublevels/files in L0 normalized by admission thresholds.`}
+      showMetricsInTooltip={true}
     >
       <Axis label="IO Overload">
         {nodeIDs.map(nid => (
@@ -109,6 +113,7 @@ export default function (props: GraphDashboardProps) {
       title="KV Admission Slots"
       sources={nodeSources}
       tenantSource={tenantSource}
+      showMetricsInTooltip={true}
     >
       <Axis label="slots">
         {nodeIDs.map(nid => (
@@ -134,6 +139,7 @@ export default function (props: GraphDashboardProps) {
       title="KV Admission IO Tokens Exhausted Duration Per Second"
       sources={nodeSources}
       tenantSource={tenantSource}
+      showMetricsInTooltip={true}
     >
       <Axis label="duration (micros/sec)">
         {nodeIDs.map(nid => (
@@ -152,6 +158,7 @@ export default function (props: GraphDashboardProps) {
       title="Flow Tokens Wait Time: 75th percentile"
       sources={nodeSources}
       tenantSource={tenantSource}
+      showMetricsInTooltip={true}
     >
       <Axis units={AxisUnits.Duration} label="p75 flow token wait duration">
         {nodeIDs.map(nid => (
@@ -185,6 +192,7 @@ export default function (props: GraphDashboardProps) {
       title="Requests Waiting For Flow Tokens"
       sources={nodeSources}
       tenantSource={tenantSource}
+      showMetricsInTooltip={true}
     >
       <Axis label="Count">
         {nodeIDs.map(nid => (
@@ -216,6 +224,7 @@ export default function (props: GraphDashboardProps) {
       title="Blocked Replication Streams"
       sources={nodeSources}
       tenantSource={tenantSource}
+      showMetricsInTooltip={true}
     >
       <Axis label="Count">
         {nodeIDs.map(nid => (
@@ -247,6 +256,7 @@ export default function (props: GraphDashboardProps) {
       title="Admission Work Rate"
       sources={nodeSources}
       tenantSource={tenantSource}
+      showMetricsInTooltip={true}
     >
       <Axis label="work rate">
         {nodeIDs.map(nid => (
@@ -299,6 +309,7 @@ export default function (props: GraphDashboardProps) {
       title="Admission Delay Rate"
       sources={nodeSources}
       tenantSource={tenantSource}
+      showMetricsInTooltip={true}
     >
       <Axis label="delay rate (micros/sec)">
         {nodeIDs.map(nid => (
@@ -344,6 +355,7 @@ export default function (props: GraphDashboardProps) {
       title="Admission Delay: 75th percentile"
       sources={nodeSources}
       tenantSource={tenantSource}
+      showMetricsInTooltip={true}
     >
       <Axis units={AxisUnits.Duration} label="delay for requests that waited">
         {nodeIDs.map(nid => (

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/overview.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/overview.tsx
@@ -39,8 +39,9 @@ export default function (props: GraphDashboardProps) {
       isKvGraph={false}
       sources={nodeSources}
       tenantSource={tenantSource}
-      tooltip={`A moving average of the number of SELECT, INSERT, UPDATE, and DELETE statements
-        successfully executed per second ${tooltipSelection}.`}
+      tooltip={`A moving average of the number of SELECT, INSERT, UPDATE, and DELETE
+          statements successfully executed per second ${tooltipSelection}.`}
+      showMetricsInTooltip={true}
       preCalcGraphSize={true}
     >
       <Axis label="queries">
@@ -81,6 +82,7 @@ export default function (props: GraphDashboardProps) {
           </em>
         </div>
       }
+      showMetricsInTooltip={true}
       preCalcGraphSize={true}
     >
       <Axis units={AxisUnits.Duration} label="latency">
@@ -100,7 +102,9 @@ export default function (props: GraphDashboardProps) {
       isKvGraph={false}
       sources={nodeSources}
       tenantSource={tenantSource}
-      tooltip={`A moving average of the number of SQL statements executed per second that experienced contention ${tooltipSelection}.`}
+      tooltip={`A moving average of the number of SQL statements executed per second
+          that experienced contention ${tooltipSelection}.`}
+      showMetricsInTooltip={true}
       preCalcGraphSize={true}
     >
       <Axis label="Average number of queries per second">
@@ -124,6 +128,7 @@ export default function (props: GraphDashboardProps) {
           </em>
         </div>
       }
+      showMetricsInTooltip={true}
       preCalcGraphSize={true}
     >
       <Axis label="replicas">
@@ -144,6 +149,7 @@ export default function (props: GraphDashboardProps) {
       sources={storeSources}
       tenantSource={tenantSource}
       tooltip={<CapacityGraphTooltip tooltipSelection={tooltipSelection} />}
+      showMetricsInTooltip={true}
       preCalcGraphSize={true}
     >
       <Axis units={AxisUnits.Bytes} label="capacity">

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/queues.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/queues.tsx
@@ -30,6 +30,7 @@ export default function (props: GraphDashboardProps) {
       title="Queue Processing Failures"
       sources={storeSources}
       tenantSource={tenantSource}
+      showMetricsInTooltip={true}
     >
       <Axis units={AxisUnits.Count} label="failures">
         <Metric
@@ -84,6 +85,7 @@ export default function (props: GraphDashboardProps) {
       title="Queue Processing Times"
       sources={storeSources}
       tenantSource={tenantSource}
+      showMetricsInTooltip={true}
     >
       <Axis units={AxisUnits.Duration} label="processing time">
         <Metric
@@ -141,6 +143,7 @@ export default function (props: GraphDashboardProps) {
       title="Replica GC Queue"
       sources={storeSources}
       tenantSource={tenantSource}
+      showMetricsInTooltip={true}
     >
       <Axis units={AxisUnits.Count} label="actions">
         <Metric
@@ -165,6 +168,7 @@ export default function (props: GraphDashboardProps) {
       title="Replication Queue"
       sources={storeSources}
       tenantSource={tenantSource}
+      showMetricsInTooltip={true}
     >
       <Axis units={AxisUnits.Count} label="actions">
         <Metric
@@ -218,6 +222,7 @@ export default function (props: GraphDashboardProps) {
       title="Split Queue"
       sources={storeSources}
       tenantSource={tenantSource}
+      showMetricsInTooltip={true}
     >
       <Axis units={AxisUnits.Count} label="actions">
         <Metric
@@ -237,6 +242,7 @@ export default function (props: GraphDashboardProps) {
       title="Merge Queue"
       sources={storeSources}
       tenantSource={tenantSource}
+      showMetricsInTooltip={true}
     >
       <Axis units={AxisUnits.Count} label="actions">
         <Metric
@@ -256,6 +262,7 @@ export default function (props: GraphDashboardProps) {
       title="Raft Log Queue"
       sources={storeSources}
       tenantSource={tenantSource}
+      showMetricsInTooltip={true}
     >
       <Axis units={AxisUnits.Count} label="actions">
         <Metric
@@ -275,6 +282,7 @@ export default function (props: GraphDashboardProps) {
       title="Raft Snapshot Queue"
       sources={storeSources}
       tenantSource={tenantSource}
+      showMetricsInTooltip={true}
     >
       <Axis units={AxisUnits.Count} label="actions">
         <Metric
@@ -294,6 +302,7 @@ export default function (props: GraphDashboardProps) {
       title="Consistency Checker Queue"
       sources={storeSources}
       tenantSource={tenantSource}
+      showMetricsInTooltip={true}
     >
       <Axis units={AxisUnits.Count} label="actions">
         <Metric
@@ -313,6 +322,7 @@ export default function (props: GraphDashboardProps) {
       title="Time Series Maintenance Queue"
       sources={storeSources}
       tenantSource={tenantSource}
+      showMetricsInTooltip={true}
     >
       <Axis units={AxisUnits.Count} label="actions">
         <Metric
@@ -332,6 +342,7 @@ export default function (props: GraphDashboardProps) {
       title="MVCC GC Queue"
       sources={storeSources}
       tenantSource={tenantSource}
+      showMetricsInTooltip={true}
     >
       <Axis units={AxisUnits.Count} label="actions">
         <Metric
@@ -351,7 +362,9 @@ export default function (props: GraphDashboardProps) {
       title="Protected Timestamp Records"
       sources={nodeSources}
       tenantSource={tenantSource}
-      tooltip={`Number of protected timestamp records (used by backups, changefeeds, etc. to prevent MVCC GC)`}
+      tooltip={`Number of protected timestamp records (used by backups, changefeeds,
+          etc. to prevent MVCC GC)`}
+      showMetricsInTooltip={true}
     >
       <Axis units={AxisUnits.Count} label="Records">
         {nodeIDs.map(nid => (

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/replication.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/replication.tsx
@@ -42,9 +42,10 @@ export default function (props: GraphDashboardProps) {
       title="Ranges"
       sources={storeSources}
       tenantSource={tenantSource}
-      tooltip={`Various details about the status of ranges. In the node view,
-        shows details about ranges the node is responsible for. In the cluster
-        view, shows details about ranges all across the cluster.`}
+      tooltip={`Various details about the status of ranges. In the node view, shows
+          details about ranges the node is responsible for. In the cluster view,
+          shows details about ranges all across the cluster.`}
+      showMetricsInTooltip={true}
     >
       <Axis label="ranges">
         <Metric name="cr.store.ranges" title="Ranges" />
@@ -67,6 +68,7 @@ export default function (props: GraphDashboardProps) {
       title="Replicas per Node"
       tenantSource={tenantSource}
       tooltip={`The number of replicas on each node.`}
+      showMetricsInTooltip={true}
     >
       <Axis label="replicas">
         {nodeIDs.map(nid => (
@@ -83,8 +85,10 @@ export default function (props: GraphDashboardProps) {
     <LineGraph
       title="Leaseholders per Node"
       tenantSource={tenantSource}
-      tooltip={`The number of leaseholder replicas on each node. A leaseholder replica is the one that
-          receives and coordinates all read and write requests for its range.`}
+      tooltip={`The number of leaseholder replicas on each node. A leaseholder replica
+          is the one that receives and coordinates all read and write requests
+          for its range.`}
+      showMetricsInTooltip={true}
     >
       <Axis label="leaseholders">
         {nodeIDs.map(nid => (
@@ -102,8 +106,9 @@ export default function (props: GraphDashboardProps) {
       title="Average Replica Queries per Node"
       tenantSource={tenantSource}
       tooltip={`Moving average of the number of KV batch requests processed by
-         leaseholder replicas on each node per second. Tracks roughly the last
-         30 minutes of requests. Used for load-based rebalancing decisions.`}
+          leaseholder replicas on each node per second. Tracks roughly the last
+          30 minutes of requests. Used for load-based rebalancing decisions.`}
+      showMetricsInTooltip={true}
     >
       <Axis label="queries">
         {nodeIDs.map(nid => (
@@ -121,8 +126,9 @@ export default function (props: GraphDashboardProps) {
       title="Average Replica CPU per Node"
       tenantSource={tenantSource}
       tooltip={`Moving average of all replica CPU usage on each node per second.
-         Tracks roughly the last 30 minutes of usage. Used for load-based
-         rebalancing decisions.`}
+          Tracks roughly the last 30 minutes of usage. Used for load-based
+          rebalancing decisions.`}
+      showMetricsInTooltip={true}
     >
       <Axis units={AxisUnits.Duration} label="CPU time">
         {nodeIDs.map(nid => (
@@ -140,6 +146,7 @@ export default function (props: GraphDashboardProps) {
       title="Logical Bytes per Node"
       tenantSource={tenantSource}
       tooltip={<LogicalBytesGraphTooltip />}
+      showMetricsInTooltip={true}
     >
       <Axis units={AxisUnits.Bytes} label="logical store size">
         {nodeIDs.map(nid => (
@@ -157,6 +164,7 @@ export default function (props: GraphDashboardProps) {
       title="Replica Quiescence"
       sources={storeSources}
       tenantSource={tenantSource}
+      showMetricsInTooltip={true}
     >
       <Axis label="replicas">
         <Metric name="cr.store.replicas" title="Replicas" />
@@ -168,6 +176,7 @@ export default function (props: GraphDashboardProps) {
       title="Range Operations"
       sources={storeSources}
       tenantSource={tenantSource}
+      showMetricsInTooltip={true}
     >
       <Axis label="ranges">
         <Metric name="cr.store.range.splits" title="Splits" nonNegativeRate />
@@ -196,6 +205,7 @@ export default function (props: GraphDashboardProps) {
       title="Snapshots"
       sources={storeSources}
       tenantSource={tenantSource}
+      showMetricsInTooltip={true}
     >
       <Axis label="snapshots">
         <Metric
@@ -230,6 +240,7 @@ export default function (props: GraphDashboardProps) {
       title="Snapshot Data Received"
       sources={storeSources}
       tenantSource={tenantSource}
+      showMetricsInTooltip={true}
     >
       <Axis label="bytes" units={AxisUnits.Bytes}>
         {nodeIDs.map(nid => (
@@ -257,6 +268,7 @@ export default function (props: GraphDashboardProps) {
       sources={storeSources}
       tenantSource={tenantSource}
       tooltip={ReceiverSnapshotsQueuedTooltip}
+      showMetricsInTooltip={true}
     >
       <Axis label="snapshots" units={AxisUnits.Count}>
         {nodeIDs.map(nid => (
@@ -274,6 +286,7 @@ export default function (props: GraphDashboardProps) {
       title="Circuit Breaker Tripped Replicas"
       tenantSource={tenantSource}
       tooltip={CircuitBreakerTrippedReplicasTooltip}
+      showMetricsInTooltip={true}
     >
       <Axis label="replicas">
         {nodeIDs.map(nid => (
@@ -292,6 +305,7 @@ export default function (props: GraphDashboardProps) {
       sources={storeSources}
       tenantSource={tenantSource}
       tooltip={PausedFollowersTooltip}
+      showMetricsInTooltip={true}
     >
       <Axis label="replicas">
         {nodeIDs.map(nid => (
@@ -309,6 +323,7 @@ export default function (props: GraphDashboardProps) {
       title="Replicate Queue Actions: Successes"
       sources={storeSources}
       tenantSource={tenantSource}
+      showMetricsInTooltip={true}
     >
       <Axis label="replicas" units={AxisUnits.Count}>
         <Metric
@@ -347,6 +362,7 @@ export default function (props: GraphDashboardProps) {
       title="Replicate Queue Actions: Failures"
       sources={storeSources}
       tenantSource={tenantSource}
+      showMetricsInTooltip={true}
     >
       <Axis label="replicas" units={AxisUnits.Count}>
         <Metric
@@ -385,6 +401,7 @@ export default function (props: GraphDashboardProps) {
       title="Decommissioning Errors"
       sources={storeSources}
       tenantSource={tenantSource}
+      showMetricsInTooltip={true}
     >
       <Axis label="replicas" units={AxisUnits.Count}>
         {nodeIDs.map(nid => (

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/requests.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/requests.tsx
@@ -23,6 +23,7 @@ export default function (props: GraphDashboardProps) {
       title="Slow Raft Proposals"
       sources={storeSources}
       tenantSource={tenantSource}
+      showMetricsInTooltip={true}
     >
       <Axis label="proposals">
         <Metric
@@ -37,6 +38,7 @@ export default function (props: GraphDashboardProps) {
       title="Slow DistSender RPCs"
       sources={storeSources}
       tenantSource={tenantSource}
+      showMetricsInTooltip={true}
     >
       <Axis label="proposals">
         <Metric
@@ -51,6 +53,7 @@ export default function (props: GraphDashboardProps) {
       title="Slow Lease Acquisitions"
       sources={storeSources}
       tenantSource={tenantSource}
+      showMetricsInTooltip={true}
     >
       <Axis label="lease acquisitions">
         <Metric
@@ -65,6 +68,7 @@ export default function (props: GraphDashboardProps) {
       title="Slow Latch Acquisitions"
       sources={storeSources}
       tenantSource={tenantSource}
+      showMetricsInTooltip={true}
     >
       <Axis label="latch acquisitions">
         <Metric

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/runtime.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/runtime.tsx
@@ -30,7 +30,8 @@ export default function (props: GraphDashboardProps) {
     <LineGraph
       title="Live Node Count"
       tenantSource={tenantSource}
-      tooltip="The number of live nodes in the cluster."
+      tooltip={`The number of live nodes in the cluster.`}
+      showMetricsInTooltip={true}
     >
       <Axis label="nodes">
         <Metric
@@ -62,6 +63,7 @@ export default function (props: GraphDashboardProps) {
           </dl>
         </div>
       }
+      showMetricsInTooltip={true}
     >
       <Axis units={AxisUnits.Bytes} label="memory usage">
         <Metric name="cr.node.sys.rss" title="Total memory (RSS)" />
@@ -76,8 +78,9 @@ export default function (props: GraphDashboardProps) {
       title="Goroutine Count"
       sources={nodeSources}
       tenantSource={tenantSource}
-      tooltip={`The number of Goroutines ${tooltipSelection}.
-           This count should rise and fall based on load.`}
+      tooltip={`The number of Goroutines ${tooltipSelection}. This count should rise
+          and fall based on load.`}
+      showMetricsInTooltip={true}
     >
       <Axis label="goroutines">
         <Metric name="cr.node.sys.goroutines" title="Goroutine Count" />
@@ -88,8 +91,9 @@ export default function (props: GraphDashboardProps) {
       title="Runnable Goroutines per CPU"
       sources={nodeSources}
       tenantSource={tenantSource}
-      tooltip={`The number of Goroutines waiting for CPU ${tooltipSelection}.
-           This count should rise and fall based on load.`}
+      tooltip={`The number of Goroutines waiting for CPU ${tooltipSelection}. This
+          count should rise and fall based on load.`}
+      showMetricsInTooltip={true}
     >
       <Axis label="goroutines">
         {nodeIDs.map(nid => (
@@ -109,6 +113,7 @@ export default function (props: GraphDashboardProps) {
       sources={nodeSources}
       tenantSource={tenantSource}
       tooltip={`The number of times that Go’s garbage collector was invoked per second ${tooltipSelection}.`}
+      showMetricsInTooltip={true}
     >
       <Axis label="runs">
         <Metric name="cr.node.sys.gc.count" title="GC Runs" nonNegativeRate />
@@ -119,9 +124,10 @@ export default function (props: GraphDashboardProps) {
       title="GC Pause Time"
       sources={nodeSources}
       tenantSource={tenantSource}
-      tooltip={`The amount of processor time used by Go’s garbage collector
-           per second ${tooltipSelection}.
-           During garbage collection, application code execution is paused.`}
+      tooltip={`The amount of processor time used by Go’s garbage collector per second
+          ${tooltipSelection}. During garbage collection, application code
+          execution is paused.`}
+      showMetricsInTooltip={true}
     >
       <Axis units={AxisUnits.Duration} label="pause time">
         <Metric
@@ -136,8 +142,9 @@ export default function (props: GraphDashboardProps) {
       title="CPU Time"
       sources={nodeSources}
       tenantSource={tenantSource}
-      tooltip={`The amount of CPU time used by CockroachDB (User)
-           and system-level operations (Sys) ${tooltipSelection}.`}
+      tooltip={`The amount of CPU time used by CockroachDB (User) and system-level
+          operations (Sys) ${tooltipSelection}.`}
+      showMetricsInTooltip={true}
     >
       <Axis units={AxisUnits.Duration} label="cpu time">
         <Metric
@@ -158,6 +165,7 @@ export default function (props: GraphDashboardProps) {
       sources={nodeSources}
       tenantSource={tenantSource}
       tooltip={`Mean clock offset of each node against the rest of the cluster.`}
+      showMetricsInTooltip={true}
     >
       <Axis label="offset" units={AxisUnits.Duration}>
         {_.map(nodeIDs, nid => (

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/sql.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/sql.tsx
@@ -39,6 +39,7 @@ export default function (props: GraphDashboardProps) {
       sources={nodeSources}
       tenantSource={tenantSource}
       tooltip={`The total number of open SQL Sessions ${tooltipSelection}.`}
+      showMetricsInTooltip={true}
     >
       <Axis label="connections">
         {_.map(nodeIDs, node => (
@@ -58,6 +59,7 @@ export default function (props: GraphDashboardProps) {
       isKvGraph={false}
       sources={nodeSources}
       tooltip={`Rate of SQL connection attempts ${tooltipSelection}`}
+      showMetricsInTooltip={true}
     >
       <Axis label="connections per second">
         {_.map(nodeIDs, node => (
@@ -78,7 +80,8 @@ export default function (props: GraphDashboardProps) {
       isKvGraph={false}
       sources={nodeSources}
       tenantSource={tenantSource}
-      tooltip={`The total number of open SQL transactions  ${tooltipSelection}.`}
+      tooltip={`The total number of open SQL transactions ${tooltipSelection}.`}
+      showMetricsInTooltip={true}
     >
       <Axis label="transactions">
         <Metric
@@ -95,6 +98,7 @@ export default function (props: GraphDashboardProps) {
       sources={nodeSources}
       tenantSource={tenantSource}
       tooltip={`The total number of running SQL statements ${tooltipSelection}.`}
+      showMetricsInTooltip={true}
     >
       <Axis label="queries">
         <Metric
@@ -111,6 +115,7 @@ export default function (props: GraphDashboardProps) {
       sources={nodeSources}
       tenantSource={tenantSource}
       tooltip={`The total amount of SQL client network traffic in bytes per second ${tooltipSelection}.`}
+      showMetricsInTooltip={true}
     >
       <Axis units={AxisUnits.Bytes} label="byte traffic">
         <Metric name="cr.node.sql.bytesin" title="Bytes In" nonNegativeRate />
@@ -123,8 +128,9 @@ export default function (props: GraphDashboardProps) {
       isKvGraph={false}
       sources={nodeSources}
       tenantSource={tenantSource}
-      tooltip={`A ten-second moving average of the # of SELECT, INSERT, UPDATE, and DELETE statements
-        successfully executed per second ${tooltipSelection}.`}
+      tooltip={`A ten-second moving average of the # of SELECT, INSERT, UPDATE, and
+          DELETE statements successfully executed per second ${tooltipSelection}.`}
+      showMetricsInTooltip={true}
     >
       <Axis label="queries">
         <Metric
@@ -155,9 +161,9 @@ export default function (props: GraphDashboardProps) {
       isKvGraph={false}
       sources={nodeSources}
       tenantSource={tenantSource}
-      tooltip={
-        "The number of statements which returned a planning, runtime, or client-side retry error."
-      }
+      tooltip={`The number of statements which returned a planning, runtime, or
+          client-side retry error.`}
+      showMetricsInTooltip={true}
     >
       <Axis label="errors">
         <Metric
@@ -174,6 +180,7 @@ export default function (props: GraphDashboardProps) {
       sources={nodeSources}
       tenantSource={tenantSource}
       tooltip={`The total number of SQL statements that experienced contention ${tooltipSelection}.`}
+      showMetricsInTooltip={true}
     >
       <Axis label="queries">
         <Metric
@@ -190,6 +197,7 @@ export default function (props: GraphDashboardProps) {
       sources={nodeSources}
       tenantSource={tenantSource}
       tooltip={`The total number of full table/index scans ${tooltipSelection}.`}
+      showMetricsInTooltip={true}
     >
       <Axis label="full scans">
         {_.map(nodeIDs, node => (
@@ -208,7 +216,9 @@ export default function (props: GraphDashboardProps) {
       title="Active Flows for Distributed SQL Statements"
       isKvGraph={false}
       tenantSource={tenantSource}
-      tooltip="The number of flows on each node contributing to currently running distributed SQL statements."
+      tooltip={`The number of flows on each node contributing to currently running
+          distributed SQL statements.`}
+      showMetricsInTooltip={true}
     >
       <Axis label="flows">
         {_.map(nodeIDs, node => (
@@ -226,7 +236,9 @@ export default function (props: GraphDashboardProps) {
       title="Connection Latency: 99th percentile"
       isKvGraph={false}
       tenantSource={tenantSource}
-      tooltip={`Over the last minute, this node established and authenticated 99% of connections within this time.`}
+      tooltip={`Over the last minute, this node established and authenticated 99% of
+          connections within this time.`}
+      showMetricsInTooltip={true}
     >
       <Axis units={AxisUnits.Duration} label="latency">
         {_.map(nodeIDs, node => (
@@ -245,7 +257,9 @@ export default function (props: GraphDashboardProps) {
       title="Connection Latency: 90th percentile"
       isKvGraph={false}
       tenantSource={tenantSource}
-      tooltip={`Over the last minute, this node established and authenticated 90% of connections within this time.`}
+      tooltip={`Over the last minute, this node established and authenticated 90% of
+          connections within this time.`}
+      showMetricsInTooltip={true}
     >
       <Axis units={AxisUnits.Duration} label="latency">
         {_.map(nodeIDs, node => (
@@ -274,6 +288,7 @@ export default function (props: GraphDashboardProps) {
           </em>
         </div>
       }
+      showMetricsInTooltip={true}
     >
       <Axis units={AxisUnits.Duration} label="latency">
         {_.map(nodeIDs, node => (
@@ -302,6 +317,7 @@ export default function (props: GraphDashboardProps) {
           </em>
         </div>
       }
+      showMetricsInTooltip={true}
     >
       <Axis units={AxisUnits.Duration} label="latency">
         {_.map(nodeIDs, node => (
@@ -330,6 +346,7 @@ export default function (props: GraphDashboardProps) {
           </em>
         </div>
       }
+      showMetricsInTooltip={true}
     >
       <Axis units={AxisUnits.Duration} label="latency">
         {_.map(nodeIDs, node => (
@@ -358,6 +375,7 @@ export default function (props: GraphDashboardProps) {
           </em>
         </div>
       }
+      showMetricsInTooltip={true}
     >
       <Axis units={AxisUnits.Duration} label="latency">
         {_.map(nodeIDs, node => (
@@ -376,8 +394,10 @@ export default function (props: GraphDashboardProps) {
       title="KV Execution Latency: 99th percentile"
       isKvGraph={true}
       tenantSource={tenantSource}
-      tooltip={`The 99th percentile of latency between query requests and responses over a
-          1 minute period. Values are displayed individually for each node.`}
+      tooltip={`The 99th percentile of latency between query requests and responses
+          over a 1 minute period. Values are displayed individually for each
+          node.`}
+      showMetricsInTooltip={true}
     >
       <Axis units={AxisUnits.Duration} label="latency">
         {_.map(nodeIDs, node => (
@@ -396,8 +416,10 @@ export default function (props: GraphDashboardProps) {
       title="KV Execution Latency: 90th percentile"
       isKvGraph={true}
       tenantSource={tenantSource}
-      tooltip={`The 90th percentile of latency between query requests and responses over a
-           1 minute period. Values are displayed individually for each node.`}
+      tooltip={`The 90th percentile of latency between query requests and responses
+          over a 1 minute period. Values are displayed individually for each
+          node.`}
+      showMetricsInTooltip={true}
     >
       <Axis units={AxisUnits.Duration} label="latency">
         {_.map(nodeIDs, node => (
@@ -417,8 +439,9 @@ export default function (props: GraphDashboardProps) {
       isKvGraph={false}
       sources={nodeSources}
       tenantSource={tenantSource}
-      tooltip={`The total number of transactions initiated, committed, rolled back,
-           or aborted per second ${tooltipSelection}.`}
+      tooltip={`The total number of transactions initiated, committed, rolled back, or
+          aborted per second ${tooltipSelection}.`}
+      showMetricsInTooltip={true}
     >
       <Axis label="transactions">
         <Metric
@@ -452,6 +475,7 @@ export default function (props: GraphDashboardProps) {
       tooltip={
         <TransactionRestartsToolTip tooltipSelection={tooltipSelection} />
       }
+      showMetricsInTooltip={true}
     >
       <Axis label="restarts">
         <Metric
@@ -511,6 +535,7 @@ export default function (props: GraphDashboardProps) {
           </em>
         </div>
       }
+      showMetricsInTooltip={true}
     >
       <Axis units={AxisUnits.Duration} label="latency">
         {_.map(nodeIDs, node => (
@@ -539,6 +564,7 @@ export default function (props: GraphDashboardProps) {
           </em>
         </div>
       }
+      showMetricsInTooltip={true}
     >
       <Axis units={AxisUnits.Duration} label="latency">
         {_.map(nodeIDs, node => (
@@ -557,8 +583,9 @@ export default function (props: GraphDashboardProps) {
       title="SQL Memory"
       isKvGraph={false}
       tenantSource={tenantSource}
-      tooltip={`The current amount of allocated SQL memory. This amount is
-         compared against the node's --max-sql-memory flag.`}
+      tooltip={`The current amount of allocated SQL memory. This amount is compared
+          against the node's --max-sql-memory flag.`}
+      showMetricsInTooltip={true}
     >
       <Axis units={AxisUnits.Bytes} label="allocated bytes">
         {_.map(nodeIDs, node => (
@@ -579,6 +606,7 @@ export default function (props: GraphDashboardProps) {
       sources={nodeSources}
       tenantSource={tenantSource}
       tooltip={`The total number of DDL statements per second ${tooltipSelection}.`}
+      showMetricsInTooltip={true}
     >
       <Axis label="statements">
         <Metric
@@ -599,6 +627,7 @@ export default function (props: GraphDashboardProps) {
           tooltipSelection={tooltipSelection}
         />
       }
+      showMetricsInTooltip={true}
     >
       <Axis label="statements">
         <Metric
@@ -614,7 +643,9 @@ export default function (props: GraphDashboardProps) {
       isKvGraph={false}
       sources={nodeSources}
       tenantSource={tenantSource}
-      tooltip={`The total number of times the distributed query errors were rerun as local ${tooltipSelection}.`}
+      tooltip={`The total number of times the distributed query errors were rerun as
+          local ${tooltipSelection}.`}
+      showMetricsInTooltip={true}
     >
       <Axis label="queries">
         <Metric

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/storage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/storage.tsx
@@ -45,6 +45,7 @@ export default function (props: GraphDashboardProps) {
       sources={storeSources}
       tenantSource={tenantSource}
       tooltip={<CapacityGraphTooltip tooltipSelection={tooltipSelection} />}
+      showMetricsInTooltip={true}
     >
       <Axis units={AxisUnits.Bytes} label="capacity">
         <Metric name="cr.store.capacity" title="Max" />
@@ -59,6 +60,7 @@ export default function (props: GraphDashboardProps) {
       sources={storeSources}
       tenantSource={tenantSource}
       tooltip={<LiveBytesGraphTooltip tooltipSelection={tooltipSelection} />}
+      showMetricsInTooltip={true}
     >
       <Axis units={AxisUnits.Bytes} label="live bytes">
         <Metric name="cr.store.livebytes" title="Live" />
@@ -70,8 +72,9 @@ export default function (props: GraphDashboardProps) {
       title="Log Commit Latency: 99th Percentile"
       sources={storeSources}
       tenantSource={tenantSource}
-      tooltip={`The 99th %ile latency for commits to the Raft Log.
-        This measures essentially an fdatasync to the storage engine's write-ahead log.`}
+      tooltip={`The 99th %ile latency for commits to the Raft Log. This measures
+          essentially an fdatasync to the storage engine's write-ahead log.`}
+      showMetricsInTooltip={true}
     >
       <Axis units={AxisUnits.Duration} label="latency">
         {_.map(nodeIDs, nid => (
@@ -89,8 +92,9 @@ export default function (props: GraphDashboardProps) {
       title="Log Commit Latency: 50th Percentile"
       sources={storeSources}
       tenantSource={tenantSource}
-      tooltip={`The 50th %ile latency for commits to the Raft Log.
-        This measures essentially an fdatasync to the storage engine's write-ahead log.`}
+      tooltip={`The 50th %ile latency for commits to the Raft Log. This measures
+          essentially an fdatasync to the storage engine's write-ahead log.`}
+      showMetricsInTooltip={true}
     >
       <Axis units={AxisUnits.Duration} label="latency">
         {_.map(nodeIDs, nid => (
@@ -108,9 +112,10 @@ export default function (props: GraphDashboardProps) {
       title="Command Commit Latency: 99th Percentile"
       sources={storeSources}
       tenantSource={tenantSource}
-      tooltip={`The 99th %ile latency for commits of Raft commands.
-        This measures applying a batch to the storage engine
-        (including writes to the write-ahead log), but no fsync.`}
+      tooltip={`The 99th %ile latency for commits of Raft commands. This measures
+          applying a batch to the storage engine (including writes to the
+          write-ahead log), but no fsync.`}
+      showMetricsInTooltip={true}
     >
       <Axis units={AxisUnits.Duration} label="latency">
         {_.map(nodeIDs, nid => (
@@ -128,9 +133,10 @@ export default function (props: GraphDashboardProps) {
       title="Command Commit Latency: 50th Percentile"
       sources={storeSources}
       tenantSource={tenantSource}
-      tooltip={`The 50th %ile latency for commits of Raft commands.
-        This measures applying a batch to the storage engine
-        (including writes to the write-ahead log), but no fsync.`}
+      tooltip={`The 50th %ile latency for commits of Raft commands. This measures
+          applying a batch to the storage engine (including writes to the
+          write-ahead log), but no fsync.`}
+      showMetricsInTooltip={true}
     >
       <Axis units={AxisUnits.Duration} label="latency">
         {_.map(nodeIDs, nid => (
@@ -148,7 +154,9 @@ export default function (props: GraphDashboardProps) {
       title="Read Amplification"
       sources={storeSources}
       tenantSource={tenantSource}
-      tooltip={`The average number of real read operations executed per logical read operation ${tooltipSelection}.`}
+      tooltip={`The average number of real read operations executed per logical read
+          operation ${tooltipSelection}.`}
+      showMetricsInTooltip={true}
     >
       <Axis label="factor">
         {_.map(nodeIDs, nid => (
@@ -167,6 +175,7 @@ export default function (props: GraphDashboardProps) {
       sources={storeSources}
       tenantSource={tenantSource}
       tooltip={`The number of SSTables in use ${tooltipSelection}.`}
+      showMetricsInTooltip={true}
     >
       <Axis label="sstables">
         {_.map(nodeIDs, nid => (
@@ -184,8 +193,9 @@ export default function (props: GraphDashboardProps) {
       title="File Descriptors"
       sources={nodeSources}
       tenantSource={tenantSource}
-      tooltip={`The number of open file descriptors ${tooltipSelection}, compared with the
-          file descriptor limit.`}
+      tooltip={`The number of open file descriptors ${tooltipSelection}, compared with
+          the file descriptor limit.`}
+      showMetricsInTooltip={true}
     >
       <Axis label="descriptors">
         <Metric name="cr.node.sys.fd.open" title="Open" />
@@ -198,6 +208,7 @@ export default function (props: GraphDashboardProps) {
       sources={storeSources}
       tenantSource={tenantSource}
       tooltip={`Bytes written by memtable flushes ${tooltipSelection}.`}
+      showMetricsInTooltip={true}
     >
       <Axis units={AxisUnits.Bytes} label="written bytes">
         {_.map(nodeIDs, nid => (
@@ -217,6 +228,7 @@ export default function (props: GraphDashboardProps) {
       sources={storeSources}
       tenantSource={tenantSource}
       tooltip={`Bytes written to WAL files ${tooltipSelection}.`}
+      showMetricsInTooltip={true}
     >
       <Axis units={AxisUnits.Bytes} label="written bytes">
         {_.map(nodeIDs, nid => (
@@ -236,6 +248,7 @@ export default function (props: GraphDashboardProps) {
       sources={storeSources}
       tenantSource={tenantSource}
       tooltip={`Bytes written by compactions ${tooltipSelection}.`}
+      showMetricsInTooltip={true}
     >
       <Axis units={AxisUnits.Bytes} label="written bytes">
         {_.map(nodeIDs, nid => (
@@ -255,6 +268,7 @@ export default function (props: GraphDashboardProps) {
       sources={storeSources}
       tenantSource={tenantSource}
       tooltip={`Bytes written by sstable ingestions ${tooltipSelection}.`}
+      showMetricsInTooltip={true}
     >
       <Axis units={AxisUnits.Bytes} label="written bytes">
         {_.map(nodeIDs, nid => (
@@ -273,8 +287,10 @@ export default function (props: GraphDashboardProps) {
       title="Write Stalls"
       sources={storeSources}
       tenantSource={tenantSource}
-      tooltip={`The number of intentional write stalls per second ${tooltipSelection}. Write stalls
-        are used to backpressure incoming writes during periods of heavy write traffic.`}
+      tooltip={`The number of intentional write stalls per second ${tooltipSelection}.
+          Write stalls are used to backpressure incoming writes during periods
+          of heavy write traffic.`}
+      showMetricsInTooltip={true}
     >
       <Axis label="count">
         <Metric
@@ -289,8 +305,9 @@ export default function (props: GraphDashboardProps) {
       title="Time Series Writes"
       sources={nodeSources}
       tenantSource={tenantSource}
-      tooltip={`The number of successfully written time series samples, and number of errors attempting
-        to write time series, per second ${tooltipSelection}.`}
+      tooltip={`The number of successfully written time series samples, and number of
+          errors attempting to write time series, per second ${tooltipSelection}.`}
+      showMetricsInTooltip={true}
     >
       <Axis label="count">
         <Metric
@@ -324,6 +341,7 @@ export default function (props: GraphDashboardProps) {
           data.
         </div>
       }
+      showMetricsInTooltip={true}
     >
       <Axis units={AxisUnits.Bytes}>
         <Metric

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/ttl.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/ttl.tsx
@@ -28,6 +28,7 @@ export default function (props: GraphDashboardProps) {
       isKvGraph={false}
       sources={nodeSources}
       tenantSource={tenantSource}
+      showMetricsInTooltip={true}
     >
       <Axis label="rows per second" units={AxisUnits.Count}>
         <Metric
@@ -47,6 +48,7 @@ export default function (props: GraphDashboardProps) {
       isKvGraph={false}
       sources={nodeSources}
       tenantSource={tenantSource}
+      showMetricsInTooltip={true}
     >
       <Axis label="row count" units={AxisUnits.Count}>
         <Metric
@@ -67,6 +69,7 @@ export default function (props: GraphDashboardProps) {
       sources={nodeSources}
       tenantSource={tenantSource}
       tooltip={`Latency of scanning and deleting within the job.`}
+      showMetricsInTooltip={true}
     >
       <Axis label="latency" units={AxisUnits.Duration}>
         {_.map(percentiles, p => (
@@ -91,6 +94,7 @@ export default function (props: GraphDashboardProps) {
       sources={nodeSources}
       tenantSource={tenantSource}
       tooltip={`Number of active spans being processed by TTL.`}
+      showMetricsInTooltip={true}
     >
       <Axis label="span count" units={AxisUnits.Count}>
         <Metric


### PR DESCRIPTION
To make it easier to identify the metric being used to generate charts, this commit adds the metric to the tooltip of all charts on the Metrics page.

Fixes #109277

This also fix the metric name for `Schema Registry Registrations`.

Fixes #108095

Release note (ui change): On the Metric page, now the information about which metric is used to create each chart is available on the chart's tooltip.

Release note (bug fix): Fix metric name for `Schema Registry Registrations`.