### PR TITLE
ui: add check for value

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/planDetails/planDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/planDetails/planDetails.tsx
@@ -173,7 +173,7 @@ function ExplainPlan({
             />
             <SummaryCardItem
               label="Average Execution Time"
-              value={formatNumberForDisplay(plan.stats.run_lat.mean, duration)}
+              value={formatNumberForDisplay(plan.stats.run_lat?.mean, duration)}
             />
             <SummaryCardItem
               label="Execution Count"
@@ -181,7 +181,7 @@ function ExplainPlan({
             />
             <SummaryCardItem
               label="Average Rows Read"
-              value={formatNumberForDisplay(plan.stats.rows_read.mean, count)}
+              value={formatNumberForDisplay(plan.stats.rows_read?.mean, count)}
             />
           </SummaryCard>
         </Col>


### PR DESCRIPTION
Reading value `mean` of undefined was causing a crash.

Fixes #107906

Release note (bug fix): Add check for values before using `mean` on Plan Details page, no longer causing a crash.