### PR TITLE
cli: remove last_retry_reason from redacted debug zips

### DIFF
--- a/pkg/cli/zip_table_registry.go
+++ b/pkg/cli/zip_table_registry.go
@@ -161,7 +161,6 @@ var zipInternalTablesPerCluster = DebugZipTableRegistry{
 			"contention",
 			"index_recommendations",
 			"retries",
-			"last_retry_reason",
 			"error_code",
 			"crdb_internal.redact(last_error_redactable) as last_error_redactable",
 		},


### PR DESCRIPTION
The column last_retry_reason was incorrectly added into redacted zips, which could leak PII data. To address this, this patch removes this column again.

Fixes: #110938
Release note: None