### PR TITLE
clusterversion: bump binaryMinSupportedVersion to 23.1, allowing 22.2 for testing

### DIFF
--- a/pkg/clusterversion/cockroach_versions.go
+++ b/pkg/clusterversion/cockroach_versions.go
@@ -902,21 +902,33 @@ const (
 // feels out of place. A "cluster version" and a "binary version" are two
 // separate concepts.
 var (
+	TestingBinaryMinSupportedVersionKey = V23_1
 	// binaryMinSupportedVersion is the earliest version of data supported by
 	// this binary. If this binary is started using a store marked with an older
 	// version than binaryMinSupportedVersion, then the binary will exit with
 	// an error. This typically trails the current release by one (see top-level
 	// comment).
-	binaryMinSupportedVersion = ByKey(BinaryMinSupportedVersionKey)
+	// Note: this variable is used for tests, and it is not the source of truth.
+	// See BinaryMinSupportedVersionKey for source of truth.
+	// If the `COCKROACH_ALLOW_VERSION_SKIPPING` environment variable is set to `true`,
+	// binaryMinSupportedVersion is set to BinaryMinSupportedVersionKey.
+	binaryMinSupportedVersion = ByKey(TestingBinaryMinSupportedVersionKey)
 
 	BinaryVersionKey = V23_2
 	// binaryVersion is the version of this binary.
 	//
 	// This is the version that a new cluster will use when created.
 	binaryVersion = ByKey(BinaryVersionKey)
+	// AllowVersionSkipping indicates if version skipping is enabled.
+	AllowVersionSkipping = false
 )
 
 func init() {
+	if envutil.EnvOrDefaultBool("COCKROACH_ALLOW_VERSION_SKIPPING", false) {
+		AllowVersionSkipping = true
+		TestingBinaryMinSupportedVersionKey = BinaryMinSupportedVersionKey
+		binaryMinSupportedVersion = ByKey(TestingBinaryMinSupportedVersionKey)
+	}
 	if finalVersion > invalidVersionKey {
 		if binaryVersion != ByKey(finalVersion) {
 			panic("binary version does not match final version")

--- a/pkg/clusterversion/cockroach_versions_test.go
+++ b/pkg/clusterversion/cockroach_versions_test.go
@@ -165,5 +165,8 @@ func TestEnsureConsistentBinaryVersion(t *testing.T) {
 // TestEnsureConsistentMinBinaryVersion ensures that BinaryMinSupportedVersionKey
 // maps to a version equal to binaryMinSupportedVersion.
 func TestEnsureConsistentMinBinaryVersion(t *testing.T) {
+	if !AllowVersionSkipping {
+		t.Skip("not applicable without version skipping enabled")
+	}
 	require.Equal(t, ByKey(BinaryMinSupportedVersionKey), binaryMinSupportedVersion)
 }

--- a/pkg/sql/logictest/logictestbase/logictestbase.go
+++ b/pkg/sql/logictest/logictestbase/logictestbase.go
@@ -472,7 +472,7 @@ var LogicTestConfigs = []TestClusterConfig{
 		Name:                        "local-mixed-22.2-23.1",
 		NumNodes:                    1,
 		OverrideDistSQLMode:         "off",
-		BootstrapVersion:            clusterversion.V22_2,
+		BootstrapVersion:            clusterversion.TestingBinaryMinSupportedVersionKey,
 		DisableUpgrade:              true,
 		DeclarativeCorpusCollection: true,
 	},

--- a/pkg/sql/sqlinstance/instancestorage/instancecache_test.go
+++ b/pkg/sql/sqlinstance/instancestorage/instancecache_test.go
@@ -124,6 +124,9 @@ func TestRangeFeed(t *testing.T) {
 }
 
 func TestMigrationCache(t *testing.T) {
+	if clusterversion.ByKey(clusterversion.V23_1).LessEq(clusterversion.TestingBinaryMinSupportedVersion) {
+		t.Skip("not applicable for 23.1+")
+	}
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 

--- a/pkg/storage/min_version_test.go
+++ b/pkg/storage/min_version_test.go
@@ -93,6 +93,11 @@ func TestMinVersion(t *testing.T) {
 }
 
 func TestSetMinVersion(t *testing.T) {
+	// TODO: the test can be removed when we stop supporting testing 22.2? Figure out a way to mark them as deletable?
+	// TODO: implement skip.WithClusterVersionGreaterEq maygbe?
+	if clusterversion.ByKey(clusterversion.V23_1).LessEq(clusterversion.TestingBinaryMinSupportedVersion) {
+		t.Skip("not applicable for 23.1+")
+	}
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 

--- a/pkg/upgrade/upgrademanager/manager_external_test.go
+++ b/pkg/upgrade/upgrademanager/manager_external_test.go
@@ -72,6 +72,9 @@ func TestAlreadyRunningJobsAreHandledProperly(t *testing.T) {
 	// be changed to V23_2Start and updated to the next Start key everytime the
 	// compatability window moves forward.
 	startCV := clusterversion.V23_1StopWritingPayloadAndProgressToSystemJobs
+	if clusterversion.ByKey(clusterversion.V23_1StopWritingPayloadAndProgressToSystemJobs).Less(clusterversion.TestingBinaryMinSupportedVersion) {
+		startCV = clusterversion.V23_2Start
+	}
 	endCV := startCV + 1
 
 	ch := make(chan chan error)
@@ -85,7 +88,7 @@ func TestAlreadyRunningJobsAreHandledProperly(t *testing.T) {
 			Knobs: base.TestingKnobs{
 				JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
 				Server: &server.TestingKnobs{
-					BootstrapVersionKeyOverride:    clusterversion.BinaryMinSupportedVersionKey,
+					BootstrapVersionKeyOverride:    clusterversion.TestingBinaryMinSupportedVersionKey,
 					BinaryVersionOverride:          clusterversion.ByKey(startCV),
 					DisableAutomaticVersionUpgrade: make(chan struct{}),
 				},

--- a/pkg/upgrade/upgrades/create_index_usage_statement_statistics_test.go
+++ b/pkg/upgrade/upgrades/create_index_usage_statement_statistics_test.go
@@ -26,6 +26,9 @@ import (
 )
 
 func TestCreateIndexOnIndexUsageOnSystemStatementStatistics(t *testing.T) {
+	if clusterversion.ByKey(clusterversion.V23_1).LessEq(clusterversion.TestingBinaryMinSupportedVersion) {
+		t.Skip("not applicable for 23.1+")
+	}
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 

--- a/pkg/upgrade/upgrades/create_jobs_metrics_polling_job_test.go
+++ b/pkg/upgrade/upgrades/create_jobs_metrics_polling_job_test.go
@@ -26,6 +26,9 @@ import (
 )
 
 func TestCreateJobsMetricsPollingJob(t *testing.T) {
+	if clusterversion.ByKey(clusterversion.V23_1).LessEq(clusterversion.TestingBinaryMinSupportedVersion) {
+		t.Skip("not applicable for 23.1+")
+	}
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 

--- a/pkg/upgrade/upgrades/create_task_system_tables_test.go
+++ b/pkg/upgrade/upgrades/create_task_system_tables_test.go
@@ -25,6 +25,9 @@ import (
 )
 
 func TestTaskTablesMigration(t *testing.T) {
+	if clusterversion.ByKey(clusterversion.V23_1).LessEq(clusterversion.TestingBinaryMinSupportedVersion) {
+		t.Skip("not applicable for 23.1+")
+	}
 	skip.UnderStressRace(t)
 	defer leaktest.AfterTest(t)()
 	ctx := context.Background()

--- a/pkg/upgrade/upgrades/database_role_settings_table_user_id_migration_test.go
+++ b/pkg/upgrade/upgrades/database_role_settings_table_user_id_migration_test.go
@@ -44,6 +44,9 @@ func TestDatabaseRoleSettingsUserIDMigration1500Users(t *testing.T) {
 }
 
 func runTestDatabaseRoleSettingsUserIDMigration(t *testing.T, numUsers int) {
+	if clusterversion.ByKey(clusterversion.V23_1).LessEq(clusterversion.TestingBinaryMinSupportedVersion) {
+		t.Skip("not applicable for 23.1+")
+	}
 	defer leaktest.AfterTest(t)()
 	ctx := context.Background()
 


### PR DESCRIPTION
Previously, we used the same minimum version for production upgrades and testing. In 23.2 we will be able to upgrade from 22.2, but this is not yet a stable feature.

This PR bumps the default version used for tests to 23.1, allowing using 22.2 if the `COCKROACH_ALLOW_VERSION_SKIPPING` environment variable is set to true.

Fixes: RE-477
Release note: None