### PR TITLE
api: increase timeout to request execution details

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/jobProfilerApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/jobProfilerApi.ts
@@ -10,7 +10,11 @@
 
 import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
 import { fetchData } from "./fetchData";
-import { SqlExecutionRequest, executeInternalSql } from "./sqlApi";
+import {
+  SqlExecutionRequest,
+  executeInternalSql,
+  LONG_TIMEOUT,
+} from "./sqlApi";
 import { propsToQueryString } from "../util";
 
 const JOB_PROFILER_PATH = "_status/job_profiler_execution_details";
@@ -75,6 +79,7 @@ export function collectExecutionDetails({
   const req: SqlExecutionRequest = {
     execute: true,
     statements: [collectExecutionDetails],
+    timeout: LONG_TIMEOUT,
   };
 
   return executeInternalSql<CollectExecutionDetailsResponse>(req).then(res => {


### PR DESCRIPTION
In large clusters requesting execution details can definitely take longer than 5 seconds. This is because it involves collecting cluster wide traces, goroutines and contacting the coordinator node of the job to dump its execution details. Since this is a debug only tool we bump the timeout to 300s to give it all the time it needs.

Epic: none
Release note: None