### PR TITLE
kv: correctly handle shared lock replays in KVNemesis

### DIFF
--- a/pkg/kv/kvnemesis/applier.go
+++ b/pkg/kv/kvnemesis/applier.go
@@ -115,6 +115,10 @@ func exceptSharedLockPromotionError(err error) bool { // true if lock promotion 
 	return errors.Is(err, &concurrency.LockPromotionError{})
 }
 
+func exceptSkipLockedReplayError(err error) bool { // true if skip locked replay error
+	return errors.Is(err, &concurrency.SkipLockedReplayError{})
+}
+
 func applyOp(ctx context.Context, env *Env, db *kv.DB, op *Operation) {
 	switch o := op.GetValue().(type) {
 	case *GetOperation,

--- a/pkg/kv/kvnemesis/validator.go
+++ b/pkg/kv/kvnemesis/validator.go
@@ -705,7 +705,10 @@ func (v *validator) processOp(op Operation) {
 		//
 		// So we ignore the results of failIfError, calling it only for its side
 		// effect of perhaps registering a failure with the validator.
-		v.failIfError(op, t.Result, exceptRollback, exceptAmbiguous, exceptSharedLockPromotionError)
+		v.failIfError(
+			op, t.Result,
+			exceptRollback, exceptAmbiguous, exceptSharedLockPromotionError, exceptSkipLockedReplayError,
+		)
 
 		ops := t.Ops
 		if t.CommitInBatch != nil {
@@ -1208,6 +1211,7 @@ func (v *validator) checkError(
 		exceptAmbiguous, exceptOmitted, exceptRetry,
 		exceptDelRangeUsingTombstoneStraddlesRangeBoundary,
 		exceptSharedLockPromotionError,
+		exceptSkipLockedReplayError,
 	}
 	sl = append(sl, extraExceptions...)
 	return v.failIfError(op, r, sl...)

--- a/pkg/kv/kvserver/concurrency/lock_table.go
+++ b/pkg/kv/kvserver/concurrency/lock_table.go
@@ -747,9 +747,22 @@ func (g *lockTableGuardImpl) IsKeyLockedByConflictingTxn(
 			break
 		}
 		if g.isSameTxn(qqg.guard.txnMeta()) {
-			return false, nil, errors.AssertionFailedf(
-				"SKIP LOCKED request should not find another waiting request from the same transaction",
-			)
+			// A SKIP LOCKED request should not find another waiting request from its
+			// own transaction, at least not in the way that SQL uses KV. The only way
+			// we can end up finding another request in the lock's wait queue from our
+			// own transaction is if we're a replay.  We could handle this case by
+			// treating it as a non-conflict, but doing so expands the testing surface
+			// area -- we would want to include tests for:
+			// 1. Just our own request in the wait queue, treated as a non-conflict.
+			// 2. A request from a different transaction in the wait queue, with a
+			// lower sequence number, that conflicts.
+			// 3. A request from a different transaction in the wait queue, with a
+			// higher sequence number, that conflicts.
+			// 4. A request from a different transaction in the wait queue, with a
+			// lower sequence number, that does not conflict.
+			// For now, we simply return an error, and mark it for the benefit of
+			// KVNemesis.
+			return false, nil, MarkSkipLockedReplayError(errors.Errorf("SKIP LOCKED request should not find another waiting request from the same transaction"))
 		}
 		if lock.Conflicts(qqg.mode, makeLockMode(str, g.txnMeta(), g.ts), &g.lt.settings.SV) {
 			return true, nil, nil // the conflict isn't with a lock holder, nil is returned
@@ -4277,4 +4290,22 @@ func MarkLockPromotionError(cause error) error {
 		return nil
 	}
 	return errors.Mark(cause, &LockPromotionError{})
+}
+
+// SkipLockedReplayError is used to mark errors resulting from replayed SKIP
+// LOCKED requests that discover other requests from their own transactions in
+// a lock's wait queue. We mark such errors for the benefit of KVNemesis.
+type SkipLockedReplayError struct{}
+
+func (e *SkipLockedReplayError) Error() string {
+	return "skip locked replay error"
+}
+
+// MarkSkipLockedReplayError wraps the given error, if non-nil, as a skip locked
+// replay error.
+func MarkSkipLockedReplayError(cause error) error {
+	if cause == nil {
+		return nil
+	}
+	return errors.Mark(cause, &SkipLockedReplayError{})
 }


### PR DESCRIPTION
Previously, we'd return an AssertionFailed error if a SKIP LOCKED request discovered another request from its own transaction waiting in a lock's wait queue. In SQL's use of KV, this can only happen if the SKIP LOCKED request is being replayed -- so returning an error here is fine. However, this tripped KVNemesis up.

This patch marks such errors, for the benefit of KVNemesis, and doesn't call them assertion failed errors.

Fixes #111426
Fixes #111506
Fixes #111513

Release note: None