### PR TITLE
kvserver: stop using the cached span config

### DIFF
--- a/pkg/kv/kvserver/asim/op/relocate_range.go
+++ b/pkg/kv/kvserver/asim/op/relocate_range.go
@@ -69,8 +69,8 @@ func (s *SimRelocateOneOptions) StorePool() storepool.AllocatorStorePool {
 	return s.storePool
 }
 
-// SpanConfig returns the span configuration for the range with start key.
-func (s *SimRelocateOneOptions) SpanConfig(
+// LoadSpanConfig returns the span configuration for the range with start key.
+func (s *SimRelocateOneOptions) LoadSpanConfig(
 	ctx context.Context, startKey roachpb.RKey,
 ) (*roachpb.SpanConfig, error) {
 	return s.state.RangeFor(state.ToKey(startKey.AsRawKey())).SpanConfig(), nil

--- a/pkg/kv/kvserver/asim/storerebalancer/candidate_replica.go
+++ b/pkg/kv/kvserver/asim/storerebalancer/candidate_replica.go
@@ -77,10 +77,10 @@ func (sr *simulatorReplica) GetFirstIndex() kvpb.RaftIndex {
 	return 2
 }
 
-// DescAndSpanConfig returns the authoritative range descriptor as well
+// LoadSpanConfig returns the authoritative range descriptor as well
 // as the span config for the replica.
-func (sr *simulatorReplica) DescAndSpanConfig() (*roachpb.RangeDescriptor, *roachpb.SpanConfig) {
-	return sr.rng.Descriptor(), sr.rng.SpanConfig()
+func (sr *simulatorReplica) LoadSpanConfig(ctx context.Context) (*roachpb.SpanConfig, error) {
+	return sr.rng.SpanConfig(), nil
 }
 
 // Desc returns the authoritative range descriptor, acquiring a replica lock in

--- a/pkg/kv/kvserver/client_merge_test.go
+++ b/pkg/kv/kvserver/client_merge_test.go
@@ -46,6 +46,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/rpc/nodedialer"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/storage/fs"
@@ -4229,6 +4230,60 @@ func verifyUnmergedSoon(
 	})
 }
 
+// Utility to allow manually setting a span config that is used for all ranges.
+type spanConfigInterceptor struct {
+	syncutil.Mutex
+	spanConfig roachpb.SpanConfig
+	clock      *hlc.Clock
+}
+
+func (s *spanConfigInterceptor) NeedsSplit(
+	ctx context.Context, start, end roachpb.RKey,
+) (bool, error) {
+	// Never require a span config based split. Splits and merges can still
+	// happen for size based reasons.
+	return false, nil
+}
+
+func (s *spanConfigInterceptor) ComputeSplitKey(
+	ctx context.Context, start, end roachpb.RKey,
+) (roachpb.RKey, error) {
+	panic("test should not be computing a split key")
+}
+
+func (s *spanConfigInterceptor) GetSpanConfigForKey(
+	ctx context.Context, key roachpb.RKey,
+) (roachpb.SpanConfig, error) {
+	s.Lock()
+	defer s.Unlock()
+	return s.spanConfig, nil
+}
+
+func (s *spanConfigInterceptor) GetProtectionTimestamps(
+	ctx context.Context, sp roachpb.Span,
+) (protectionTimestamps []hlc.Timestamp, asOf hlc.Timestamp, _ error) {
+	return []hlc.Timestamp{}, s.clock.Now(), nil
+}
+
+func (s *spanConfigInterceptor) LastUpdated() hlc.Timestamp {
+	// Return a non-zero timestamp. This is typically used in the context of "has at least one update".
+	return hlc.Timestamp{
+		WallTime:  1,
+		Logical:   1,
+		Synthetic: false,
+	}
+}
+
+func (s *spanConfigInterceptor) Subscribe(f func(ctx context.Context, updated roachpb.Span)) {
+	// ignore
+}
+
+func (s *spanConfigInterceptor) set(config roachpb.SpanConfig) {
+	s.Lock()
+	defer s.Unlock()
+	s.spanConfig = config
+}
+
 func TestMergeQueue(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -4241,6 +4296,9 @@ func TestMergeQueue(t *testing.T) {
 
 	zoneConfig := zonepb.DefaultZoneConfig()
 	zoneConfig.RangeMinBytes = proto.Int64(1 << 10) // 1KB
+	conf := zoneConfig.AsSpanConfig()
+	interceptor := spanConfigInterceptor{spanConfig: conf, clock: hlc.NewClockForTesting(manualClock)}
+
 	tc := testcluster.StartTestCluster(t, 2,
 		base.TestClusterArgs{
 			ReplicationMode: base.ReplicationManual,
@@ -4248,24 +4306,20 @@ func TestMergeQueue(t *testing.T) {
 				Settings: settings,
 				Knobs: base.TestingKnobs{
 					Server: &server.TestingKnobs{
-						WallClock:                 manualClock,
-						DefaultZoneConfigOverride: &zoneConfig,
+						WallClock: manualClock,
 					},
-					Store: &kvserver.StoreTestingKnobs{
-						DisableScanner: true,
+					SpanConfig: &spanconfig.TestingKnobs{
+						StoreKVSubscriberOverride: &interceptor,
 					},
 				},
+				DisableSQLServer: true,
 			},
 		})
 	defer tc.Stopper().Stop(ctx)
 
-	conf := zoneConfig.AsSpanConfig()
 	store := tc.GetFirstStoreFromServer(t, 0)
-	// The cluster with manual replication disables the merge queue,
-	// so we need to re-enable.
-	_, err := tc.ServerConn(0).Exec(`SET CLUSTER SETTING kv.range_merge.queue.enabled = true`)
-	require.NoError(t, err)
 	store.SetMergeQueueActive(true)
+	kvserverbase.MergeQueueEnabled.Override(ctx, sv, true)
 
 	split := func(t *testing.T, key roachpb.Key, expirationTime hlc.Timestamp) {
 		t.Helper()
@@ -4277,11 +4331,9 @@ func TestMergeQueue(t *testing.T) {
 	}
 
 	clearRange := func(t *testing.T, start, end roachpb.RKey) {
-		if _, pErr := kv.SendWrapped(ctx, store.DB().NonTransactionalSender(), &kvpb.ClearRangeRequest{
-			RequestHeader: kvpb.RequestHeader{Key: start.AsRawKey(), EndKey: end.AsRawKey()},
-		}); pErr != nil {
-			t.Fatal(pErr)
-		}
+		_, pErr := kv.SendWrapped(ctx, store.DB().NonTransactionalSender(), &kvpb.ClearRangeRequest{
+			RequestHeader: kvpb.RequestHeader{Key: start.AsRawKey(), EndKey: end.AsRawKey()}})
+		require.Nil(t, pErr)
 	}
 	rng, _ := randutil.NewTestRand()
 	randBytes := randutil.RandBytes(rng, int(conf.RangeMinBytes))
@@ -4296,31 +4348,13 @@ func TestMergeQueue(t *testing.T) {
 	lhs := func() *kvserver.Replica { return store.LookupReplica(lhsStartKey) }
 	rhs := func() *kvserver.Replica { return store.LookupReplica(rhsStartKey) }
 
-	// setThresholds simulates a zone config update that updates the ranges'
-	// minimum and maximum sizes.
-	setSpanConfigs := func(t *testing.T, conf roachpb.SpanConfig) {
-		t.Helper()
-		if l := lhs(); l == nil {
-			t.Fatal("left-hand side range not found")
-		} else {
-			l.SetSpanConfig(conf)
-		}
-		if r := rhs(); r == nil {
-			t.Fatal("right-hand side range not found")
-		} else {
-			r.SetSpanConfig(conf)
-		}
-	}
-
 	reset := func(t *testing.T) {
 		t.Helper()
 		clearRange(t, lhsStartKey, rhsEndKey)
 		for _, k := range []roachpb.RKey{lhsStartKey, rhsStartKey} {
-			if err := store.DB().Put(ctx, k, randBytes); err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, store.DB().Put(ctx, k, randBytes))
 		}
-		setSpanConfigs(t, conf)
+		interceptor.set(conf)
 		// Disable load-based splitting, so that the absence of sufficient QPS
 		// measurements do not prevent ranges from merging. Certain subtests
 		// re-enable the functionality.
@@ -4345,9 +4379,9 @@ func TestMergeQueue(t *testing.T) {
 
 	t.Run("lhs-undersize", func(t *testing.T) {
 		reset(t)
-		conf := conf
-		conf.RangeMinBytes *= 2
-		lhs().SetSpanConfig(conf)
+		testConf := conf
+		testConf.RangeMinBytes *= 2
+		interceptor.set(testConf)
 		verifyMergedSoon(t, store, lhsStartKey, rhsStartKey)
 	})
 
@@ -4356,15 +4390,15 @@ func TestMergeQueue(t *testing.T) {
 
 		// The ranges are individually beneath the minimum size threshold, but
 		// together they'll exceed the maximum size threshold.
-		conf := conf
-		conf.RangeMinBytes = rhs().GetMVCCStats().Total() + 1
-		conf.RangeMaxBytes = lhs().GetMVCCStats().Total() + rhs().GetMVCCStats().Total() - 1
-		setSpanConfigs(t, conf)
+		testConf := conf
+		testConf.RangeMinBytes = rhs().GetMVCCStats().Total() + 1
+		testConf.RangeMaxBytes = lhs().GetMVCCStats().Total() + rhs().GetMVCCStats().Total() - 1
+		interceptor.set(testConf)
 		verifyUnmergedSoon(t, store, lhsStartKey, rhsStartKey)
 
 		// Once the maximum size threshold is increased, the merge can occur.
-		conf.RangeMaxBytes += 1
-		setSpanConfigs(t, conf)
+		testConf.RangeMaxBytes += 1
+		interceptor.set(testConf)
 		verifyMergedSoon(t, store, lhsStartKey, rhsStartKey)
 	})
 

--- a/pkg/kv/kvserver/client_spanconfigs_test.go
+++ b/pkg/kv/kvserver/client_spanconfigs_test.go
@@ -58,6 +58,7 @@ func TestSpanConfigUpdateAppliedToReplica(t *testing.T) {
 				StoreKVSubscriberOverride: mockSubscriber,
 			},
 		},
+		DisableSQLServer: true,
 	}
 	s := serverutils.StartServerOnly(t, args)
 	defer s.Stopper().Stop(context.Background())
@@ -82,60 +83,6 @@ func TestSpanConfigUpdateAppliedToReplica(t *testing.T) {
 	require.True(t, added[0].GetTarget().GetSpan().Equal(span))
 	addedCfg := added[0].GetConfig()
 	require.True(t, addedCfg.Equal(conf))
-
-	require.NotNil(t, mockSubscriber.callback)
-	mockSubscriber.callback(ctx, span) // invoke the callback
-	testutils.SucceedsSoon(t, func() error {
-		repl := store.LookupReplica(keys.MustAddr(key))
-		gotConfig, err := repl.LoadSpanConfig(ctx)
-		require.NoError(t, err)
-		if !gotConfig.Equal(conf) {
-			return errors.Newf("expected config=%s, got config=%s", conf.String(), gotConfig.String())
-		}
-		return nil
-	})
-}
-
-// TestFallbackSpanConfigOverride ensures that
-// spanconfig.store.fallback_config_override works as expected.
-func TestFallbackSpanConfigOverride(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-
-	st := cluster.MakeTestingClusterSettings()
-	spanConfigStore := spanconfigstore.New(
-		roachpb.TestingDefaultSpanConfig(),
-		st,
-		spanconfigstore.NewEmptyBoundsReader(),
-		nil,
-	)
-	var t0 = time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC)
-	mockSubscriber := newMockSpanConfigSubscriber(t0, spanConfigStore)
-
-	ctx := context.Background()
-	args := base.TestServerArgs{
-		Knobs: base.TestingKnobs{
-			Store: &kvserver.StoreTestingKnobs{
-				DisableMergeQueue: true,
-				DisableSplitQueue: true,
-				DisableGCQueue:    true,
-			},
-			SpanConfig: &spanconfig.TestingKnobs{
-				StoreKVSubscriberOverride: mockSubscriber,
-			},
-		},
-	}
-	s := serverutils.StartServerOnly(t, args)
-	defer s.Stopper().Stop(context.Background())
-
-	key, err := s.ScratchRange()
-	require.NoError(t, err)
-	store, err := s.GetStores().(*kvserver.Stores).GetStore(s.GetFirstStoreID())
-	require.NoError(t, err)
-	repl := store.LookupReplica(keys.MustAddr(key))
-	span := repl.Desc().RSpan().AsRawSpanWithNoLocals()
-
-	conf := roachpb.SpanConfig{NumReplicas: 5, NumVoters: 3}
-	spanconfigstore.FallbackConfigOverride.Override(ctx, &st.SV, &conf)
 
 	require.NotNil(t, mockSubscriber.callback)
 	mockSubscriber.callback(ctx, span) // invoke the callback

--- a/pkg/kv/kvserver/client_split_test.go
+++ b/pkg/kv/kvserver/client_split_test.go
@@ -1130,7 +1130,8 @@ func TestStoreZoneUpdateAndRangeSplit(t *testing.T) {
 		rngDesc := repl.Desc()
 		rngStart, rngEnd := rngDesc.StartKey, rngDesc.EndKey
 		if rngStart.Equal(tableBoundary) || !rngEnd.Equal(roachpb.RKeyMax) {
-			return errors.Errorf("range %s has not yet split", repl)
+			_, _, _ = store.Enqueue(ctx, "split", repl, false, false)
+			return errors.Errorf("range %s has not yet split expected %s-Max", repl, tableBoundary)
 		}
 		return nil
 	})
@@ -3633,8 +3634,11 @@ func TestStoreRangeSplitAndMergeWithGlobalReads(t *testing.T) {
 	zoneConfig := zonepb.DefaultZoneConfig()
 	zoneConfig.GlobalReads = proto.Bool(true)
 
+	st := cluster.MakeTestingClusterSettings()
+
 	ctx := context.Background()
 	s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{
+		Settings: st,
 		Knobs: base.TestingKnobs{
 			Server: &server.TestingKnobs{
 				DefaultZoneConfigOverride: &zoneConfig,
@@ -3657,7 +3661,6 @@ func TestStoreRangeSplitAndMergeWithGlobalReads(t *testing.T) {
 	clock.Store(s.Clock())
 	store, err := s.GetStores().(*kvserver.Stores).GetStore(s.GetFirstStoreID())
 	require.NoError(t, err)
-	config.TestingSetupZoneConfigHook(s.Stopper())
 
 	// Split off the range for the test.
 	descID := bootstrap.TestingUserDescID(0)

--- a/pkg/kv/kvserver/consistency_queue.go
+++ b/pkg/kv/kvserver/consistency_queue.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness/livenesspb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
-	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/grpcutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -110,7 +109,7 @@ func newConsistencyQueue(store *Store) *consistencyQueue {
 }
 
 func (q *consistencyQueue) shouldQueue(
-	ctx context.Context, now hlc.ClockTimestamp, repl *Replica, _ spanconfig.StoreReader,
+	ctx context.Context, now hlc.ClockTimestamp, repl *Replica, _ *roachpb.SpanConfig,
 ) (bool, float64) {
 	return consistencyQueueShouldQueueImpl(ctx, now,
 		consistencyShouldQueueData{
@@ -160,7 +159,7 @@ func consistencyQueueShouldQueueImpl(
 
 // process() is called on every range for which this node is a lease holder.
 func (q *consistencyQueue) process(
-	ctx context.Context, repl *Replica, _ spanconfig.StoreReader,
+	ctx context.Context, repl *Replica, _ *roachpb.SpanConfig,
 ) (bool, error) {
 	if q.interval() <= 0 {
 		return false, nil
@@ -208,7 +207,7 @@ func (q *consistencyQueue) process(
 }
 
 func (*consistencyQueue) postProcessScheduled(
-	ctx context.Context, replica replicaInQueue, priority float64,
+	ctx context.Context, replica replicaInQueue, _ *roachpb.SpanConfig, priority float64,
 ) {
 }
 

--- a/pkg/kv/kvserver/helpers_test.go
+++ b/pkg/kv/kvserver/helpers_test.go
@@ -17,7 +17,6 @@ package kvserver
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -194,12 +193,12 @@ func (s *Store) EnqueueRaftUpdateCheck(rangeID roachpb.RangeID) {
 }
 
 func manualQueue(s *Store, q queueImpl, repl *Replica) error {
-	cfg := s.cfg.SystemConfigProvider.GetSystemConfig()
-	if cfg == nil {
-		return fmt.Errorf("%s: system config not yet available", s)
-	}
 	ctx := repl.AnnotateCtx(context.Background())
-	_, err := q.process(ctx, repl, cfg)
+	conf, err := repl.LoadSpanConfig(ctx)
+	if err != nil {
+		return err
+	}
+	_, err = q.process(ctx, repl, conf)
 	return err
 }
 
@@ -419,7 +418,7 @@ func (r *Replica) GetTSCacheHighWater() hlc.Timestamp {
 
 // ShouldBackpressureWrites returns whether writes to the range should be
 // subject to backpressure.
-func (r *Replica) ShouldBackpressureWrites(_ context.Context) bool {
+func (r *Replica) ShouldBackpressureWrites(ctx context.Context) bool {
 	return r.shouldBackpressureWrites()
 }
 

--- a/pkg/kv/kvserver/merge_queue.go
+++ b/pkg/kv/kvserver/merge_queue.go
@@ -22,7 +22,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/split"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
-	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
@@ -131,12 +130,17 @@ func newMergeQueue(store *Store, db *kv.DB) *mergeQueue {
 }
 
 func (mq *mergeQueue) shouldQueue(
-	ctx context.Context, now hlc.ClockTimestamp, repl *Replica, confReader spanconfig.StoreReader,
+	ctx context.Context, now hlc.ClockTimestamp, repl *Replica, conf *roachpb.SpanConfig,
 ) (shouldQueue bool, priority float64) {
 	desc := repl.Desc()
 
 	if desc.EndKey.Equal(roachpb.RKeyMax) {
 		// The last range has no right-hand neighbor to merge with.
+		return false, 0
+	}
+	confReader, err := repl.store.GetConfReader(ctx)
+	if err != nil {
+		log.Infof(ctx, "unable to load the span config (err=%v) for range %d", err, desc.RangeID)
 		return false, 0
 	}
 
@@ -157,7 +161,7 @@ func (mq *mergeQueue) shouldQueue(
 		return false, 0
 	}
 
-	sizeRatio := float64(repl.GetMVCCStats().Total()) / float64(repl.GetMinBytes(ctx))
+	sizeRatio := float64(repl.GetMVCCStats().Total()) / float64(conf.RangeMinBytes)
 	if math.IsNaN(sizeRatio) || sizeRatio >= 1 {
 		// This range is above the minimum size threshold. It does not need to be
 		// merged.
@@ -234,12 +238,17 @@ func (mq *mergeQueue) requestRangeStats(
 }
 
 func (mq *mergeQueue) process(
-	ctx context.Context, lhsRepl *Replica, confReader spanconfig.StoreReader,
+	ctx context.Context, lhsRepl *Replica, conf *roachpb.SpanConfig,
 ) (processed bool, err error) {
+
+	confReader, err := lhsRepl.store.GetConfReader(ctx)
+	if err != nil {
+		return false, errors.Wrapf(err, "unable to load conf reader")
+	}
 
 	lhsDesc := lhsRepl.Desc()
 	lhsStats := lhsRepl.GetMVCCStats()
-	minBytes := lhsRepl.GetMinBytes(ctx)
+	minBytes := conf.RangeMinBytes
 	if lhsStats.Total() >= minBytes {
 		log.VEventf(ctx, 2, "skipping merge: LHS meets minimum size threshold %d with %d bytes",
 			minBytes, lhsStats.Total())
@@ -286,7 +295,7 @@ func (mq *mergeQueue) process(
 	}
 
 	shouldSplit, _ := shouldSplitRange(ctx, mergedDesc, mergedStats,
-		lhsRepl.GetMaxBytes(ctx), lhsRepl.shouldBackpressureWrites(), confReader)
+		conf.RangeMaxBytes, lhsRepl.shouldBackpressureWrites(), confReader)
 	if shouldSplit {
 		log.VEventf(ctx, 2,
 			"skipping merge to avoid thrashing: merged range %s may split "+
@@ -415,7 +424,7 @@ func (mq *mergeQueue) process(
 		return false, rangeMergePurgatoryError{err}
 	}
 	if testingAggressiveConsistencyChecks {
-		if _, err := mq.store.consistencyQueue.process(ctx, lhsRepl, confReader); err != nil {
+		if _, err := mq.store.consistencyQueue.process(ctx, lhsRepl, conf); err != nil {
 			log.Warningf(ctx, "%v", err)
 		}
 	}
@@ -430,7 +439,7 @@ func (mq *mergeQueue) process(
 }
 
 func (*mergeQueue) postProcessScheduled(
-	ctx context.Context, replica replicaInQueue, priority float64,
+	ctx context.Context, replica replicaInQueue, conf *roachpb.SpanConfig, priority float64,
 ) {
 }
 

--- a/pkg/kv/kvserver/merge_queue_test.go
+++ b/pkg/kv/kvserver/merge_queue_test.go
@@ -156,8 +156,8 @@ func TestMergeQueueShouldQueue(t *testing.T) {
 			repl.mu.state.Stats = &enginepb.MVCCStats{KeyBytes: tc.bytes}
 			zoneConfig := zonepb.DefaultZoneConfigRef()
 			zoneConfig.RangeMinBytes = proto.Int64(tc.minBytes)
-			repl.SetSpanConfig(zoneConfig.AsSpanConfig())
-			shouldQ, priority := mq.shouldQueue(ctx, hlc.ClockTimestamp{}, repl, config.NewSystemConfig(zoneConfig))
+			conf := zoneConfig.AsSpanConfig()
+			shouldQ, priority := mq.shouldQueue(ctx, hlc.ClockTimestamp{}, repl, &conf)
 			if tc.expShouldQ != shouldQ {
 				t.Errorf("incorrect shouldQ: expected %v but got %v", tc.expShouldQ, shouldQ)
 			}

--- a/pkg/kv/kvserver/mvcc_gc_queue_test.go
+++ b/pkg/kv/kvserver/mvcc_gc_queue_test.go
@@ -914,7 +914,11 @@ func testMVCCGCQueueProcessImpl(t *testing.T, useEfos bool) {
 
 	// Process through a scan queue.
 	mgcq := newMVCCGCQueue(tc.store)
-	processed, err := mgcq.process(ctx, tc.repl, cfg)
+	conf, err := tc.repl.LoadSpanConfig(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	processed, err := mgcq.process(ctx, tc.repl, conf)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1160,12 +1164,8 @@ func TestMVCCGCQueueTransactionTable(t *testing.T) {
 
 	// Run GC.
 	mgcq := newMVCCGCQueue(tc.store)
-	cfg, err := tc.store.GetConfReader(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	processed, err := mgcq.process(ctx, tc.repl, cfg)
+	conf := &roachpb.SpanConfig{GCPolicy: roachpb.GCPolicy{TTLSeconds: 100}}
+	processed, err := mgcq.process(ctx, tc.repl, conf)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1294,12 +1294,9 @@ func TestMVCCGCQueueIntentResolution(t *testing.T) {
 	}
 
 	// Process through GC queue.
-	confReader, err := tc.store.GetConfReader(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
 	mgcq := newMVCCGCQueue(tc.store)
-	processed, err := mgcq.process(ctx, tc.repl, confReader)
+	conf := &roachpb.SpanConfig{GCPolicy: roachpb.GCPolicy{TTLSeconds: 100}}
+	processed, err := mgcq.process(ctx, tc.repl, conf)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1357,14 +1354,10 @@ func TestMVCCGCQueueLastProcessedTimestamps(t *testing.T) {
 		}
 	}
 
-	confReader, err := tc.store.GetConfReader(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	// Process through a scan queue.
 	mgcq := newMVCCGCQueue(tc.store)
-	processed, err := mgcq.process(ctx, tc.repl, confReader)
+	conf := &roachpb.SpanConfig{GCPolicy: roachpb.GCPolicy{TTLSeconds: 100}}
+	processed, err := mgcq.process(ctx, tc.repl, conf)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1462,17 +1455,13 @@ func TestMVCCGCQueueChunkRequests(t *testing.T) {
 	}
 
 	// Forward the clock past the default GC time.
-	confReader, err := tc.store.GetConfReader(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
-	conf, err := confReader.GetSpanConfigForKey(ctx, roachpb.RKey("key"))
+	conf, err := tc.store.GetSpanConfigForKey(ctx, roachpb.RKey("key"))
 	if err != nil {
 		t.Fatalf("could not find span config for range %s", err)
 	}
 	tc.manualClock.Advance(conf.TTL() + 1)
 	mgcq := newMVCCGCQueue(tc.store)
-	processed, err := mgcq.process(ctx, tc.repl, confReader)
+	processed, err := mgcq.process(ctx, tc.repl, conf)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1520,42 +1509,42 @@ func TestMVCCGCQueueGroupsRangeDeletions(t *testing.T) {
 	require.NoError(t, store.AddReplica(r2))
 	r2.RaftStatus()
 	r2.handleGCHintResult(ctx, &roachpb.GCHint{LatestRangeDeleteTimestamp: hlc.Timestamp{WallTime: 1}})
-	r2.SetSpanConfig(roachpb.SpanConfig{GCPolicy: roachpb.GCPolicy{TTLSeconds: 100}})
+	conf := &roachpb.SpanConfig{GCPolicy: roachpb.GCPolicy{TTLSeconds: 100}}
 
 	gcQueue := newMVCCGCQueue(store)
 
 	// Check that low priority replicas doesn't cause hint scan.
-	gcQueue.postProcessScheduled(ctx, r1, 1)
+	gcQueue.postProcessScheduled(ctx, r1, conf, 1)
 	qr, _ := gcQueue.pop()
 	require.Nil(t, qr, "unexpected enqueued replica")
 
 	// Check that high priority replica is not added if GC hint time didn't exceed
 	// ttl.
-	gcQueue.postProcessScheduled(ctx, r1, deleteRangePriority)
+	gcQueue.postProcessScheduled(ctx, r1, conf, deleteRangePriority)
 	qr, _ = gcQueue.pop()
 	require.Nil(t, qr, "unexpected enqueued replica")
 
 	// Check that replica is not queued if sequence of hi-pri replicas are being
 	// processed.
 	clock.Advance(200 * time.Second)
-	gcQueue.postProcessScheduled(ctx, r1, deleteRangePriority)
+	gcQueue.postProcessScheduled(ctx, r1, conf, deleteRangePriority)
 	qr, _ = gcQueue.pop()
 	require.Nil(t, qr, "unexpected enqueued replica")
 
 	// Reset sequence by running a lo pri replica.
-	gcQueue.postProcessScheduled(ctx, r1, 1)
+	gcQueue.postProcessScheduled(ctx, r1, conf, 1)
 	qr, _ = gcQueue.pop()
 	require.Nil(t, qr, "unexpected enqueued replica")
 
 	// Check that replica is processed when hint criteria is met.
-	gcQueue.postProcessScheduled(ctx, r1, deleteRangePriority)
+	gcQueue.postProcessScheduled(ctx, r1, conf, deleteRangePriority)
 	qr, prio := gcQueue.pop()
 	require.NotNil(t, qr, "unexpected nil replica")
 	require.Equal(t, deleteRangePriority, prio, "expected high priority")
 
 	// Check that non leaseholder replicas are ignored.
 	leaseError = false
-	gcQueue.postProcessScheduled(ctx, r1, deleteRangePriority)
+	gcQueue.postProcessScheduled(ctx, r1, conf, deleteRangePriority)
 	qr, _ = gcQueue.pop()
 	require.Nil(t, qr, "unexpected nil replica")
 }

--- a/pkg/kv/kvserver/queue.go
+++ b/pkg/kv/kvserver/queue.go
@@ -253,7 +253,7 @@ type replicaInQueue interface {
 	IsDestroyed() (DestroyReason, error)
 	Desc() *roachpb.RangeDescriptor
 	redirectOnOrAcquireLease(context.Context) (kvserverpb.LeaseStatus, *kvpb.Error)
-	LeaseStatusAt(context.Context, hlc.ClockTimestamp) kvserverpb.LeaseStatus
+	CurrentLeaseStatus(context.Context) kvserverpb.LeaseStatus
 }
 
 type queueImpl interface {
@@ -322,7 +322,8 @@ type queueConfig struct {
 	// This is to avoid giving the queue a replica that spans multiple config
 	// zones (which might make the action of the queue ambiguous - e.g. we don't
 	// want to try to replicate a range until we know which zone it is in and
-	// therefore how many replicas are required).
+	// therefore how many replicas are required). If needsSpanConfig is not set
+	// then this setting is ignored.
 	acceptsUnsplitRanges bool
 	// processDestroyedReplicas controls whether or not we want to process
 	// replicas that have been destroyed but not GCed.
@@ -645,19 +646,6 @@ func (bq *baseQueue) maybeAdd(ctx context.Context, repl replicaInQueue, now hlc.
 		fn(ctx, bq)
 	}
 
-	// Load the system config if it's needed.
-	var confReader spanconfig.StoreReader
-	if bq.needsSpanConfigs {
-		var err error
-		confReader, err = bq.store.GetConfReader(ctx)
-		if err != nil {
-			if errors.Is(err, errSpanConfigsUnavailable) && log.V(1) {
-				log.Warningf(ctx, "unable to retrieve span configs, skipping: %v", err)
-			}
-			return
-		}
-	}
-
 	bq.mu.Lock()
 	stopped := bq.mu.stopped
 	disabled := bq.mu.disabled
@@ -677,46 +665,21 @@ func (bq *baseQueue) maybeAdd(ctx context.Context, repl replicaInQueue, now hlc.
 		}
 	}
 
-	if !repl.IsInitialized() {
+	// Load the system config if it's needed.
+	conf, err := bq.replicaCanBeProcessed(ctx, repl, false /* acquireLeaseIfNeeded */)
+	if err != nil {
 		return
 	}
 
-	if !bq.acceptsUnsplitRanges {
-		// Queue does not accept unsplit ranges. Check to see if the range needs to
-		// be split because of spanconfigs.
-		needsSplit, err := confReader.NeedsSplit(ctx, repl.Desc().StartKey, repl.Desc().EndKey)
-		if err != nil {
-			log.Warningf(ctx, "unable to compute whether split is needed; not adding")
-			return
-		}
-		if needsSplit {
-			if log.V(1) {
-				log.Infof(ctx, "split needed; not adding")
-			}
-			return
-		}
-	}
-
-	if bq.needsLease {
-		// Check to see if either we own the lease or do not know who the lease
-		// holder is.
-		st := repl.LeaseStatusAt(ctx, now)
-		if st.IsValid() && !st.OwnedBy(repl.StoreID()) {
-			if log.V(1) {
-				log.Infof(ctx, "needs lease; not adding: %v", st.Lease)
-			}
-			return
-		}
-	}
 	// NB: in production code, this type assertion is always true. In tests,
 	// it may not be and shouldQueue will be passed a nil realRepl. These tests
 	// know what they're getting into so that's fine.
 	realRepl, _ := repl.(*Replica)
-	should, priority := bq.impl.shouldQueue(ctx, now, realRepl, confReader)
+	should, priority := bq.impl.shouldQueue(ctx, now, realRepl, conf)
 	if !should {
 		return
 	}
-	_, err := bq.addInternal(ctx, repl.Desc(), repl.ReplicaID(), priority)
+	_, err = bq.addInternal(ctx, repl.Desc(), repl.ReplicaID(), priority)
 	if !isExpectedQueueError(err) {
 		log.Errorf(ctx, "unable to add: %+v", err)
 	}
@@ -895,6 +858,13 @@ func (bq *baseQueue) processLoop(stopper *stop.Stopper) {
 					repl, priority := bq.pop()
 					if repl != nil {
 						annotatedCtx := repl.AnnotateCtx(ctx)
+						_, err := bq.replicaCanBeProcessed(annotatedCtx, repl, false /*acquireLeaseIfNeeded */)
+						if err != nil {
+							log.Infof(ctx, "skipping since replica can't be processed %v", err)
+							// Release semaphore if it can't be processed.
+							<-bq.processSem
+							continue
+						}
 						if stopper.RunAsyncTaskEx(annotatedCtx, stop.TaskOpts{
 							TaskName: bq.processOpName() + " [outer]",
 						},
@@ -960,35 +930,6 @@ func (bq *baseQueue) recordProcessDuration(ctx context.Context, dur time.Duratio
 // ctx should already be annotated by both bq.AnnotateCtx() and
 // repl.AnnotateCtx().
 func (bq *baseQueue) processReplica(ctx context.Context, repl replicaInQueue) error {
-	// Load the system config if it's needed.
-	var confReader spanconfig.StoreReader
-	if bq.needsSpanConfigs {
-		var err error
-		confReader, err = bq.store.GetConfReader(ctx)
-		if errors.Is(err, errSpanConfigsUnavailable) {
-			if log.V(1) {
-				log.Warningf(ctx, "unable to retrieve conf reader, skipping: %v", err)
-			}
-			return nil
-		}
-		if err != nil {
-			return err
-		}
-	}
-
-	if !bq.acceptsUnsplitRanges {
-		// Queue does not accept unsplit ranges. Check to see if the range needs to
-		// be spilt because of a span config.
-		needsSplit, err := confReader.NeedsSplit(ctx, repl.Desc().StartKey, repl.Desc().EndKey)
-		if err != nil {
-			log.Warningf(ctx, "unable to compute NeedsSplit, skipping: %v", err)
-			return nil
-		}
-		if needsSplit {
-			log.VEventf(ctx, 3, "split needed; skipping")
-			return nil
-		}
-	}
 
 	ctx, span := tracing.EnsureChildSpan(ctx, bq.Tracer, bq.processOpName())
 	defer span.Finish()
@@ -996,36 +937,14 @@ func (bq *baseQueue) processReplica(ctx context.Context, repl replicaInQueue) er
 		bq.processTimeoutFunc(bq.store.ClusterSettings(), repl), func(ctx context.Context) error {
 			log.VEventf(ctx, 1, "processing replica")
 
-			if !repl.IsInitialized() {
-				// We checked this when adding the replica, but we need to check it again
-				// in case this is a different replica with the same range ID (see #14193).
-				// This is possible in the case where the replica was enqueued while not
-				// having a replica ID, perhaps due to a pre-emptive snapshot, and has
-				// since been removed and re-added at a different replica ID.
-				return errors.New("cannot process uninitialized replica")
-			}
-
-			if reason, err := repl.IsDestroyed(); err != nil {
-				if !bq.queueConfig.processDestroyedReplicas || reason == destroyReasonRemoved {
-					log.VEventf(ctx, 3, "replica destroyed (%s); skipping", err)
+			// Load the system config if it's needed.
+			conf, err := bq.replicaCanBeProcessed(ctx, repl, true /* acquireLeaseIfNeeded */)
+			if err != nil {
+				if errors.Is(err, errMarkNotAcquirableLease) {
 					return nil
 				}
-			}
-
-			// If the queue requires a replica to have the range lease in
-			// order to be processed, check whether this replica has range lease
-			// and renew or acquire if necessary.
-			if bq.needsLease {
-				if _, pErr := repl.redirectOnOrAcquireLease(ctx); pErr != nil {
-					switch v := pErr.GetDetail().(type) {
-					case *kvpb.NotLeaseHolderError, *kvpb.RangeNotFoundError:
-						log.VEventf(ctx, 3, "%s; skipping", v)
-						return nil
-					default:
-						log.VErrEventf(ctx, 2, "could not obtain lease: %s", pErr)
-						return errors.Wrapf(pErr.GoError(), "%s: could not obtain lease", repl)
-					}
-				}
+				log.VErrEventf(ctx, 2, "replica can not be processed now: %s", err)
+				return err
 			}
 
 			log.VEventf(ctx, 3, "processing...")
@@ -1033,7 +952,7 @@ func (bq *baseQueue) processReplica(ctx context.Context, repl replicaInQueue) er
 			// it may not be and shouldQueue will be passed a nil realRepl. These tests
 			// know what they're getting into so that's fine.
 			realRepl, _ := repl.(*Replica)
-			processed, err := bq.impl.process(ctx, realRepl, confReader)
+			processed, err := bq.impl.process(ctx, realRepl, conf)
 			if err != nil {
 				return err
 			}
@@ -1043,6 +962,98 @@ func (bq *baseQueue) processReplica(ctx context.Context, repl replicaInQueue) er
 			}
 			return nil
 		})
+}
+
+// Special case lease acquisition errors for cases where it can't be acquired.
+var errMarkNotAcquirableLease = errors.New("lease can't be acquired")
+
+// replicaCanBeProcessed validates that all the conditions for running this
+// queue are satisfied according to the queue configuration and the status of
+// the replica and its span config. This normalizes the logic for deciding
+// whether a queue can be processed. It returns an err if the replica can not be
+// processed right now. In some cases we want to attempt to acquire or renew a
+// lease if we don't currently have it and the queue requires a lease. This will
+// only return a nil SpanConfig if the queue does not require span configs.
+func (bq *baseQueue) replicaCanBeProcessed(
+	ctx context.Context, repl replicaInQueue, acquireLeaseIfNeeded bool,
+) (spanconfig.StoreReader, error) {
+	if !repl.IsInitialized() {
+		// We checked this when adding the replica, but we need to check it again
+		// in case this is a different replica with the same range ID (see #14193).
+		// This is possible in the case where the replica was enqueued while not
+		// having a replica ID, perhaps due to a pre-emptive snapshot, and has
+		// since been removed and re-added at a different replica ID.
+		return nil, errors.New("cannot process uninitialized replica")
+	}
+
+	if reason, err := repl.IsDestroyed(); err != nil && reason == destroyReasonRemoved {
+		// Only the replica GC queue can process destroyed replicas.
+		if !bq.queueConfig.processDestroyedReplicas {
+			log.VEventf(ctx, 3, "replica destroyed (%s); skipping", err)
+			return nil, errors.New("cannot process uninitialized replica")
+		}
+	}
+
+	// The conf is only populated if the queue requires a span config. Otherwise
+	// nil is always returned.
+	var confReader spanconfig.StoreReader
+	if bq.needsSpanConfigs {
+		var err error
+		confReader, err = bq.store.GetConfReader(ctx)
+		if err != nil {
+			if log.V(1) || !errors.Is(err, errSpanConfigsUnavailable) {
+				log.Warningf(ctx, "unable to retrieve conf reader, skipping: %v", err)
+			}
+			return nil, err
+		}
+
+		if !bq.acceptsUnsplitRanges {
+			// Queue does not accept unsplit ranges. Check to see if the range needs to
+			// be spilt because of a span config.
+			needsSplit, err := confReader.NeedsSplit(ctx, repl.Desc().StartKey, repl.Desc().EndKey)
+			if err != nil {
+				log.Warningf(ctx, "unable to compute NeedsSplit, skipping: %v", err)
+				return nil, err
+			}
+			if needsSplit {
+				log.VEventf(ctx, 3, "split needed; skipping")
+				return nil, errors.New("split needed; skipping")
+			}
+		}
+	}
+
+	// If the queue requires a replica to have the range lease in
+	// order to be processed, check whether this replica has range lease
+	// and renew or acquire if necessary.
+	if bq.needsLease {
+		if acquireLeaseIfNeeded {
+			leaseStatus, pErr := repl.redirectOnOrAcquireLease(ctx)
+			if pErr != nil {
+				switch v := pErr.GetDetail().(type) {
+				case *kvpb.NotLeaseHolderError, *kvpb.RangeNotFoundError:
+					log.VEventf(ctx, 3, "%s; skipping", v)
+					return nil, errMarkNotAcquirableLease
+				}
+				log.VErrEventf(ctx, 2, "could not obtain lease: %s", pErr)
+				return nil, errors.Wrapf(pErr.GoError(), "%s: could not obtain lease", repl)
+			}
+
+			// TODO(baptist): Should this be added to replicaInQueue?
+			realRepl, _ := repl.(*Replica)
+			pErr = realRepl.maybeSwitchLeaseType(ctx, leaseStatus)
+			if pErr != nil {
+				return nil, pErr.GoError()
+			}
+		} else {
+			// Don't process if we don't own the lease.
+			st := repl.CurrentLeaseStatus(ctx)
+			if st.IsValid() && !st.OwnedBy(repl.StoreID()) {
+				log.VEventf(ctx, 1, "needs lease; not adding: %v", st.Lease)
+				return nil, errors.Newf("needs lease, not adding: %v", st.Lease)
+			}
+		}
+	}
+	return confReader, nil
 }
 
 // IsPurgatoryError returns true iff the given error is a purgatory error.
@@ -1277,8 +1288,12 @@ func (bq *baseQueue) processReplicasInPurgatory(
 			annotatedCtx := repl.AnnotateCtx(ctx)
 			if stopper.RunTask(
 				annotatedCtx, bq.processOpName(), func(ctx context.Context) {
-					err := bq.processReplica(ctx, repl)
-					bq.finishProcessingReplica(ctx, stopper, repl, err)
+					if _, err := bq.replicaCanBeProcessed(ctx, repl, false); err != nil {
+						bq.finishProcessingReplica(ctx, stopper, repl, err)
+					} else {
+						err = bq.processReplica(ctx, repl)
+						bq.finishProcessingReplica(ctx, stopper, repl, err)
+					}
 				},
 			) != nil {
 				return
@@ -1386,18 +1401,21 @@ func (bq *baseQueue) removeFromReplicaSetLocked(rangeID roachpb.RangeID) {
 // DrainQueue locks the queue and processes the remaining queued replicas. It
 // processes the replicas in the order they're queued in, one at a time.
 // Exposed for testing only.
-func (bq *baseQueue) DrainQueue(stopper *stop.Stopper) {
+func (bq *baseQueue) DrainQueue(ctx context.Context, stopper *stop.Stopper) {
 	// Lock processing while draining. This prevents the main process
 	// loop from racing with this method and ensures that any replicas
 	// queued up when this method was called will be processed by the
 	// time it returns.
 	defer bq.lockProcessing()()
 
-	ctx := bq.AnnotateCtx(context.Background())
 	for repl, _ := bq.pop(); repl != nil; repl, _ = bq.pop() {
 		annotatedCtx := repl.AnnotateCtx(ctx)
-		err := bq.processReplica(annotatedCtx, repl)
-		bq.finishProcessingReplica(annotatedCtx, stopper, repl, err)
+		if _, err := bq.replicaCanBeProcessed(annotatedCtx, repl, false); err != nil {
+			bq.finishProcessingReplica(annotatedCtx, stopper, repl, err)
+		} else {
+			err = bq.processReplica(annotatedCtx, repl)
+			bq.finishProcessingReplica(annotatedCtx, stopper, repl, err)
+		}
 	}
 }
 

--- a/pkg/kv/kvserver/queue.go
+++ b/pkg/kv/kvserver/queue.go
@@ -23,7 +23,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
-	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -260,19 +259,19 @@ type queueImpl interface {
 	// shouldQueue accepts current time, a replica, and the system config
 	// and returns whether it should be queued and if so, at what priority.
 	// The Replica is guaranteed to be initialized.
-	shouldQueue(context.Context, hlc.ClockTimestamp, *Replica, spanconfig.StoreReader) (shouldQueue bool, priority float64)
+	shouldQueue(context.Context, hlc.ClockTimestamp, *Replica, *roachpb.SpanConfig) (shouldQueue bool, priority float64)
 
 	// process accepts a replica, and the system config and executes
 	// queue-specific work on it. The Replica is guaranteed to be initialized.
 	// We return a boolean to indicate if the Replica was processed successfully
 	// (vs. it being a no-op or an error).
-	process(context.Context, *Replica, spanconfig.StoreReader) (processed bool, err error)
+	process(context.Context, *Replica, *roachpb.SpanConfig) (processed bool, err error)
 
 	// processScheduled is called after async task was created to run process.
 	// This function is called by the process loop synchronously. This method is
 	// called regardless of process being called or not since replica validity
 	// checks are done asynchronously.
-	postProcessScheduled(ctx context.Context, replica replicaInQueue, priority float64)
+	postProcessScheduled(ctx context.Context, replica replicaInQueue, span *roachpb.SpanConfig, priority float64)
 
 	// timer returns a duration to wait between processing the next item
 	// from the queue. The duration of the last processing of a replica
@@ -858,7 +857,7 @@ func (bq *baseQueue) processLoop(stopper *stop.Stopper) {
 					repl, priority := bq.pop()
 					if repl != nil {
 						annotatedCtx := repl.AnnotateCtx(ctx)
-						_, err := bq.replicaCanBeProcessed(annotatedCtx, repl, false /*acquireLeaseIfNeeded */)
+						conf, err := bq.replicaCanBeProcessed(annotatedCtx, repl, false /*acquireLeaseIfNeeded */)
 						if err != nil {
 							log.Infof(ctx, "skipping since replica can't be processed %v", err)
 							// Release semaphore if it can't be processed.
@@ -873,7 +872,7 @@ func (bq *baseQueue) processLoop(stopper *stop.Stopper) {
 								defer func() { <-bq.processSem }()
 
 								start := timeutil.Now()
-								err := bq.processReplica(ctx, repl)
+								err := bq.processReplica(ctx, repl, conf)
 
 								duration := timeutil.Since(start)
 								bq.recordProcessDuration(ctx, duration)
@@ -884,7 +883,7 @@ func (bq *baseQueue) processLoop(stopper *stop.Stopper) {
 							<-bq.processSem
 							return
 						}
-						bq.impl.postProcessScheduled(ctx, repl, priority)
+						bq.impl.postProcessScheduled(ctx, repl, conf, priority)
 					} else {
 						// Release semaphore if no replicas were available.
 						<-bq.processSem
@@ -929,7 +928,9 @@ func (bq *baseQueue) recordProcessDuration(ctx context.Context, dur time.Duratio
 //
 // ctx should already be annotated by both bq.AnnotateCtx() and
 // repl.AnnotateCtx().
-func (bq *baseQueue) processReplica(ctx context.Context, repl replicaInQueue) error {
+func (bq *baseQueue) processReplica(
+	ctx context.Context, repl replicaInQueue, conf *roachpb.SpanConfig,
+) error {
 
 	ctx, span := tracing.EnsureChildSpan(ctx, bq.Tracer, bq.processOpName())
 	defer span.Finish()
@@ -976,7 +977,7 @@ var errMarkNotAcquirableLease = errors.New("lease can't be acquired")
 // only return a nil SpanConfig if the queue does not require span configs.
 func (bq *baseQueue) replicaCanBeProcessed(
 	ctx context.Context, repl replicaInQueue, acquireLeaseIfNeeded bool,
-) (spanconfig.StoreReader, error) {
+) (*roachpb.SpanConfig, error) {
 	if !repl.IsInitialized() {
 		// We checked this when adding the replica, but we need to check it again
 		// in case this is a different replica with the same range ID (see #14193).
@@ -996,16 +997,26 @@ func (bq *baseQueue) replicaCanBeProcessed(
 
 	// The conf is only populated if the queue requires a span config. Otherwise
 	// nil is always returned.
-	var confReader spanconfig.StoreReader
+	var conf *roachpb.SpanConfig
 	if bq.needsSpanConfigs {
 		var err error
-		confReader, err = bq.store.GetConfReader(ctx)
+		confReader, err := bq.store.GetConfReader(ctx)
 		if err != nil {
 			if log.V(1) || !errors.Is(err, errSpanConfigsUnavailable) {
 				log.Warningf(ctx, "unable to retrieve conf reader, skipping: %v", err)
 			}
 			return nil, err
 		}
+		conf, err = bq.store.GetSpanConfigForKey(ctx, repl.Desc().GetStartKey())
+		if err != nil {
+			log.Infof(ctx, "unable to retrieve conf reader, skipping: %v", err)
+			return nil, err
+		}
+
+		// TODO(baptist): Remove setting the span config once the cached span
+		// config is removed from the replica.
+		realRepl, _ := repl.(*Replica)
+		realRepl.SetSpanConfig(*conf)
 
 		if !bq.acceptsUnsplitRanges {
 			// Queue does not accept unsplit ranges. Check to see if the range needs to
@@ -1053,7 +1064,7 @@ func (bq *baseQueue) replicaCanBeProcessed(
 			}
 		}
 	}
-	return confReader, nil
+	return conf, nil
 }
 
 // IsPurgatoryError returns true iff the given error is a purgatory error.
@@ -1288,10 +1299,10 @@ func (bq *baseQueue) processReplicasInPurgatory(
 			annotatedCtx := repl.AnnotateCtx(ctx)
 			if stopper.RunTask(
 				annotatedCtx, bq.processOpName(), func(ctx context.Context) {
-					if _, err := bq.replicaCanBeProcessed(ctx, repl, false); err != nil {
+					if conf, err := bq.replicaCanBeProcessed(ctx, repl, false); err != nil {
 						bq.finishProcessingReplica(ctx, stopper, repl, err)
 					} else {
-						err = bq.processReplica(ctx, repl)
+						err = bq.processReplica(ctx, repl, conf)
 						bq.finishProcessingReplica(ctx, stopper, repl, err)
 					}
 				},
@@ -1410,10 +1421,10 @@ func (bq *baseQueue) DrainQueue(ctx context.Context, stopper *stop.Stopper) {
 
 	for repl, _ := bq.pop(); repl != nil; repl, _ = bq.pop() {
 		annotatedCtx := repl.AnnotateCtx(ctx)
-		if _, err := bq.replicaCanBeProcessed(annotatedCtx, repl, false); err != nil {
+		if conf, err := bq.replicaCanBeProcessed(annotatedCtx, repl, false); err != nil {
 			bq.finishProcessingReplica(annotatedCtx, stopper, repl, err)
 		} else {
-			err = bq.processReplica(annotatedCtx, repl)
+			err = bq.processReplica(annotatedCtx, repl, conf)
 			bq.finishProcessingReplica(annotatedCtx, stopper, repl, err)
 		}
 	}

--- a/pkg/kv/kvserver/queue_concurrency_test.go
+++ b/pkg/kv/kvserver/queue_concurrency_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
-	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -85,7 +84,7 @@ func TestBaseQueueConcurrent(t *testing.T) {
 
 	// Set up a queue impl that will return random results from processing.
 	impl := fakeQueueImpl{
-		pr: func(context.Context, *Replica, spanconfig.StoreReader) (bool, error) {
+		pr: func(context.Context, *Replica) (bool, error) {
 			n := rand.Intn(4)
 			if n == 0 {
 				return true, nil
@@ -135,25 +134,25 @@ func TestBaseQueueConcurrent(t *testing.T) {
 }
 
 type fakeQueueImpl struct {
-	pr func(context.Context, *Replica, spanconfig.StoreReader) (processed bool, err error)
+	pr func(context.Context, *Replica) (processed bool, err error)
 }
 
 var _ queueImpl = &fakeQueueImpl{}
 
 func (fakeQueueImpl) shouldQueue(
-	context.Context, hlc.ClockTimestamp, *Replica, spanconfig.StoreReader,
+	context.Context, hlc.ClockTimestamp, *Replica, *roachpb.SpanConfig,
 ) (shouldQueue bool, priority float64) {
 	return rand.Intn(5) != 0, 1.0
 }
 
 func (fq fakeQueueImpl) process(
-	ctx context.Context, repl *Replica, confReader spanconfig.StoreReader,
+	ctx context.Context, repl *Replica, config *roachpb.SpanConfig,
 ) (bool, error) {
-	return fq.pr(ctx, repl, confReader)
+	return fq.pr(ctx, repl)
 }
 
 func (fakeQueueImpl) postProcessScheduled(
-	ctx context.Context, replica replicaInQueue, priority float64,
+	ctx context.Context, replica replicaInQueue, config *roachpb.SpanConfig, priority float64,
 ) {
 }
 

--- a/pkg/kv/kvserver/queue_concurrency_test.go
+++ b/pkg/kv/kvserver/queue_concurrency_test.go
@@ -191,6 +191,6 @@ func (fr *fakeReplica) redirectOnOrAcquireLease(
 	// baseQueue only checks that the returned error is nil.
 	return kvserverpb.LeaseStatus{}, nil
 }
-func (fr *fakeReplica) LeaseStatusAt(context.Context, hlc.ClockTimestamp) kvserverpb.LeaseStatus {
+func (fr *fakeReplica) CurrentLeaseStatus(context.Context) kvserverpb.LeaseStatus {
 	return kvserverpb.LeaseStatus{}
 }

--- a/pkg/kv/kvserver/queue_helpers_testutil.go
+++ b/pkg/kv/kvserver/queue_helpers_testutil.go
@@ -39,7 +39,7 @@ func forceScanAndProcess(ctx context.Context, s *Store, q *baseQueue) error {
 		return true
 	})
 
-	q.DrainQueue(s.stopper)
+	q.DrainQueue(ctx, s.stopper)
 	return nil
 }
 

--- a/pkg/kv/kvserver/queue_test.go
+++ b/pkg/kv/kvserver/queue_test.go
@@ -1409,11 +1409,11 @@ func TestBaseQueueChangeReplicaID(t *testing.T) {
 	bq.mu.Unlock()
 	require.Equal(t, 0, testQueue.getProcessed())
 	bq.maybeAdd(ctx, r, tc.store.Clock().NowAsClockTimestamp())
-	bq.DrainQueue(tc.store.Stopper())
+	bq.DrainQueue(ctx, tc.store.Stopper())
 	require.Equal(t, 1, testQueue.getProcessed())
 	bq.maybeAdd(ctx, r, tc.store.Clock().NowAsClockTimestamp())
 	r.replicaID = 2
-	bq.DrainQueue(tc.store.Stopper())
+	bq.DrainQueue(ctx, tc.store.Stopper())
 	require.Equal(t, 1, testQueue.getProcessed())
 	require.Equal(t, 0, bq.Length())
 	require.Equal(t, 0, bq.PurgatoryLength())

--- a/pkg/kv/kvserver/queue_test.go
+++ b/pkg/kv/kvserver/queue_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
-	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/bootstrap"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -57,13 +56,13 @@ type testQueueImpl struct {
 var _ queueImpl = &testQueueImpl{}
 
 func (tq *testQueueImpl) shouldQueue(
-	_ context.Context, now hlc.ClockTimestamp, r *Replica, _ spanconfig.StoreReader,
+	_ context.Context, now hlc.ClockTimestamp, r *Replica, _ *roachpb.SpanConfig,
 ) (bool, float64) {
 	return tq.shouldQueueFn(now, r)
 }
 
 func (tq *testQueueImpl) process(
-	_ context.Context, _ *Replica, _ spanconfig.StoreReader,
+	_ context.Context, _ *Replica, _ *roachpb.SpanConfig,
 ) (bool, error) {
 	atomic.AddInt32(&tq.processed, 1)
 	if tq.err != nil {
@@ -77,7 +76,7 @@ func (tq *testQueueImpl) getProcessed() int {
 }
 
 func (*testQueueImpl) postProcessScheduled(
-	ctx context.Context, replica replicaInQueue, priority float64,
+	ctx context.Context, replica replicaInQueue, _ *roachpb.SpanConfig, priority float64,
 ) {
 }
 
@@ -945,7 +944,7 @@ type processTimeoutQueueImpl struct {
 var _ queueImpl = &processTimeoutQueueImpl{}
 
 func (pq *processTimeoutQueueImpl) process(
-	ctx context.Context, r *Replica, _ spanconfig.StoreReader,
+	ctx context.Context, r *Replica, conf *roachpb.SpanConfig,
 ) (processed bool, err error) {
 	<-ctx.Done()
 	atomic.AddInt32(&pq.processed, 1)
@@ -1075,7 +1074,7 @@ type processTimeQueueImpl struct {
 var _ queueImpl = &processTimeQueueImpl{}
 
 func (pq *processTimeQueueImpl) process(
-	_ context.Context, _ *Replica, _ spanconfig.StoreReader,
+	context.Context, *Replica, *roachpb.SpanConfig,
 ) (processed bool, err error) {
 	time.Sleep(5 * time.Millisecond)
 	return true, nil
@@ -1299,13 +1298,13 @@ type parallelQueueImpl struct {
 var _ queueImpl = &parallelQueueImpl{}
 
 func (pq *parallelQueueImpl) process(
-	ctx context.Context, repl *Replica, confReader spanconfig.StoreReader,
+	ctx context.Context, repl *Replica, spanConfig *roachpb.SpanConfig,
 ) (processed bool, err error) {
 	atomic.AddInt32(&pq.processing, 1)
 	if pq.processBlocker != nil {
 		<-pq.processBlocker
 	}
-	processed, err = pq.testQueueImpl.process(ctx, repl, confReader)
+	processed, err = pq.testQueueImpl.process(ctx, repl, spanConfig)
 	atomic.AddInt32(&pq.processing, -1)
 	return processed, err
 }

--- a/pkg/kv/kvserver/raft_log_queue.go
+++ b/pkg/kv/kvserver/raft_log_queue.go
@@ -22,7 +22,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
-	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -176,7 +175,7 @@ func newRaftLogQueue(store *Store, db *kv.DB) *raftLogQueue {
 			maxSize:              defaultQueueMaxSize,
 			maxConcurrency:       raftLogQueueConcurrency,
 			needsLease:           false,
-			needsSpanConfigs:     false,
+			needsSpanConfigs:     true,
 			acceptsUnsplitRanges: true,
 			successes:            store.metrics.RaftLogQueueSuccesses,
 			failures:             store.metrics.RaftLogQueueFailures,
@@ -244,7 +243,9 @@ func newRaftLogQueue(store *Store, db *kv.DB) *raftLogQueue {
 // nodes with sufficient disk space. Also, IMPORT/RESTORE's split/scatter
 // phase interacts poorly with overly aggressive truncations and can DDOS the
 // Raft snapshot queue.
-func newTruncateDecision(ctx context.Context, r *Replica) (truncateDecision, error) {
+func newTruncateDecision(
+	ctx context.Context, r *Replica, conf *roachpb.SpanConfig,
+) (truncateDecision, error) {
 	rangeID := r.RangeID
 	now := timeutil.Now()
 
@@ -263,8 +264,8 @@ func newTruncateDecision(ctx context.Context, r *Replica) (truncateDecision, err
 	// efficient to catch up via a snapshot than via applying a long tail of log
 	// entries.
 	targetSize := r.store.cfg.RaftLogTruncationThreshold
-	if targetSize > r.mu.conf.RangeMaxBytes {
-		targetSize = r.mu.conf.RangeMaxBytes
+	if targetSize > conf.RangeMaxBytes {
+		targetSize = conf.RangeMaxBytes
 	}
 	raftStatus := r.raftStatusRLocked()
 
@@ -635,15 +636,15 @@ func computeTruncateDecision(input truncateDecisionInput) truncateDecision {
 // is true only if the replica is the raft leader and if the total number of
 // the range's raft log's stale entries exceeds RaftLogQueueStaleThreshold.
 func (rlq *raftLogQueue) shouldQueue(
-	ctx context.Context, now hlc.ClockTimestamp, r *Replica, _ spanconfig.StoreReader,
+	ctx context.Context, now hlc.ClockTimestamp, r *Replica, conf *roachpb.SpanConfig,
 ) (shouldQueue bool, priority float64) {
-	decision, err := newTruncateDecision(ctx, r)
+	decision, err := newTruncateDecision(ctx, r, conf)
 	if err != nil {
 		log.Warningf(ctx, "%v", err)
 		return false, 0
 	}
 
-	shouldQ, _, prio := rlq.shouldQueueImpl(ctx, decision)
+	shouldQ, _, prio := rlq.shouldQueueImpl(ctx, decision, conf)
 	return shouldQ, prio
 }
 
@@ -652,7 +653,7 @@ func (rlq *raftLogQueue) shouldQueue(
 // we want to recompute the log size (in which case `recomputeRaftLogSize` and
 // `shouldQ` are both true and a reasonable priority is returned).
 func (rlq *raftLogQueue) shouldQueueImpl(
-	ctx context.Context, decision truncateDecision,
+	ctx context.Context, decision truncateDecision, conf *roachpb.SpanConfig,
 ) (shouldQ bool, recomputeRaftLogSize bool, priority float64) {
 	if decision.ShouldTruncate() {
 		return true, !decision.Input.LogSizeTrusted, float64(decision.Input.LogSize)
@@ -678,14 +679,14 @@ func (rlq *raftLogQueue) shouldQueueImpl(
 // leader and if the total number of the range's raft log's stale entries
 // exceeds RaftLogQueueStaleThreshold.
 func (rlq *raftLogQueue) process(
-	ctx context.Context, r *Replica, _ spanconfig.StoreReader,
+	ctx context.Context, r *Replica, conf *roachpb.SpanConfig,
 ) (processed bool, err error) {
-	decision, err := newTruncateDecision(ctx, r)
+	decision, err := newTruncateDecision(ctx, r, conf)
 	if err != nil {
 		return false, err
 	}
 
-	if _, recompute, _ := rlq.shouldQueueImpl(ctx, decision); recompute {
+	if _, recompute, _ := rlq.shouldQueueImpl(ctx, decision, conf); recompute {
 		log.VEventf(ctx, 2, "recomputing raft log based on decision %+v", decision)
 
 		// We need to hold raftMu both to access the sideloaded storage and to
@@ -709,7 +710,7 @@ func (rlq *raftLogQueue) process(
 		log.VEventf(ctx, 2, "recomputed raft log size to %s", humanizeutil.IBytes(n))
 
 		// Override the decision, now that an accurate log size is available.
-		decision, err = newTruncateDecision(ctx, r)
+		decision, err = newTruncateDecision(ctx, r, conf)
 		if err != nil {
 			return false, err
 		}
@@ -742,7 +743,7 @@ func (rlq *raftLogQueue) process(
 }
 
 func (*raftLogQueue) postProcessScheduled(
-	ctx context.Context, replica replicaInQueue, priority float64,
+	ctx context.Context, replica replicaInQueue, conf *roachpb.SpanConfig, priority float64,
 ) {
 }
 

--- a/pkg/kv/kvserver/raft_log_queue_test.go
+++ b/pkg/kv/kvserver/raft_log_queue_test.go
@@ -204,7 +204,7 @@ func TestComputeTruncateDecision(t *testing.T) {
 			// we'll just see the decision play out as before.
 			// The real tests for this are in TestRaftLogQueueShouldQueue, but this is
 			// some nice extra coverage.
-			should, recompute, prio := (*raftLogQueue)(nil).shouldQueueImpl(ctx, decision)
+			should, recompute, prio := (*raftLogQueue)(nil).shouldQueueImpl(ctx, decision, nil)
 			assert.Equal(t, decision.ShouldTruncate(), should)
 			assert.False(t, recompute)
 			assert.Equal(t, decision.ShouldTruncate(), prio != 0)
@@ -214,7 +214,7 @@ func TestComputeTruncateDecision(t *testing.T) {
 				input.LastIndex = input.FirstIndex + 1
 			}
 			decision = computeTruncateDecision(input)
-			should, recompute, prio = (*raftLogQueue)(nil).shouldQueueImpl(ctx, decision)
+			should, recompute, prio = (*raftLogQueue)(nil).shouldQueueImpl(ctx, decision, nil)
 			assert.True(t, should)
 			assert.True(t, prio > 0)
 			assert.True(t, recompute)
@@ -433,7 +433,7 @@ func TestNewTruncateDecisionMaxSize(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	td, err := newTruncateDecision(ctx, repl)
+	td, err := newTruncateDecision(ctx, repl, &cfg.DefaultSpanConfig)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -469,7 +469,7 @@ func TestNewTruncateDecision(t *testing.T) {
 	}
 
 	getIndexes := func() (kvpb.RaftIndex, int, kvpb.RaftIndex, error) {
-		d, err := newTruncateDecision(ctx, r)
+		d, err := newTruncateDecision(ctx, r, &cfg.DefaultSpanConfig)
 		if err != nil {
 			return 0, 0, 0, err
 		}
@@ -820,7 +820,7 @@ func TestRaftLogQueueShouldQueueRecompute(t *testing.T) {
 
 	verify := func(shouldQ bool, recompute bool, prio float64) {
 		t.Helper()
-		isQ, isR, isP := rlq.shouldQueueImpl(ctx, decision)
+		isQ, isR, isP := rlq.shouldQueueImpl(ctx, decision, nil)
 		assert.Equal(t, shouldQ, isQ)
 		assert.Equal(t, recompute, isR)
 		assert.Equal(t, prio, isP)
@@ -883,7 +883,7 @@ func TestTruncateLogRecompute(t *testing.T) {
 
 	put()
 
-	decision, err := newTruncateDecision(ctx, repl)
+	decision, err := newTruncateDecision(ctx, repl, &cfg.DefaultSpanConfig)
 	assert.NoError(t, err)
 	assert.True(t, decision.ShouldTruncate())
 	// Should never trust initially, until recomputed at least once.

--- a/pkg/kv/kvserver/raft_snapshot_queue.go
+++ b/pkg/kv/kvserver/raft_snapshot_queue.go
@@ -17,7 +17,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
@@ -66,7 +65,7 @@ func newRaftSnapshotQueue(store *Store) *raftSnapshotQueue {
 }
 
 func (rq *raftSnapshotQueue) shouldQueue(
-	ctx context.Context, now hlc.ClockTimestamp, repl *Replica, _ spanconfig.StoreReader,
+	ctx context.Context, now hlc.ClockTimestamp, repl *Replica, _ *roachpb.SpanConfig,
 ) (shouldQueue bool, priority float64) {
 	// If a follower needs a snapshot, enqueue at the highest priority.
 	if status := repl.RaftStatus(); status != nil {
@@ -84,7 +83,7 @@ func (rq *raftSnapshotQueue) shouldQueue(
 }
 
 func (rq *raftSnapshotQueue) process(
-	ctx context.Context, repl *Replica, _ spanconfig.StoreReader,
+	ctx context.Context, repl *Replica, _ *roachpb.SpanConfig,
 ) (anyProcessed bool, _ error) {
 	// If a follower requires a Raft snapshot, perform it.
 	if status := repl.RaftStatus(); status != nil {
@@ -171,7 +170,7 @@ func (rq *raftSnapshotQueue) processRaftSnapshot(
 }
 
 func (*raftSnapshotQueue) postProcessScheduled(
-	ctx context.Context, replica replicaInQueue, priority float64,
+	ctx context.Context, replica replicaInQueue, _ *roachpb.SpanConfig, priority float64,
 ) {
 }
 

--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -3994,7 +3994,6 @@ func (r *Replica) adminScatter(
 	// Note that we disable lease transfers until the final step as transferring
 	// the lease prevents any further action on this node.
 	var allowLeaseTransfer bool
-	var err error
 	requeue := true
 	canTransferLease := func(ctx context.Context, repl plan.LeaseCheckReplica, conf *roachpb.SpanConfig) bool {
 		return allowLeaseTransfer
@@ -4007,6 +4006,11 @@ func (r *Replica) adminScatter(
 			allowLeaseTransfer = true
 		}
 		desc, conf := r.DescAndSpanConfig()
+		_, err := rq.replicaCanBeProcessed(ctx, r, false /* acquireLeaseIfNeeded */)
+		if err != nil {
+			// The replica can not be processed, so skip it.
+			break
+		}
 		requeue, err = rq.processOneChange(
 			ctx, r, desc, conf, canTransferLease, true /* scatter */, false, /* dryRun */
 		)

--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -75,13 +75,17 @@ func (r *Replica) AdminSplit(
 	if len(args.SplitKey) == 0 {
 		return kvpb.AdminSplitResponse{}, kvpb.NewErrorf("cannot split range with no key provided")
 	}
+	conf, err := r.LoadSpanConfig(ctx)
+	if err != nil {
+		return kvpb.AdminSplitResponse{}, kvpb.NewError(err)
+	}
 
-	err := r.executeAdminCommandWithDescriptor(ctx, func(desc *roachpb.RangeDescriptor) error {
+	kvErr := r.executeAdminCommandWithDescriptor(ctx, func(desc *roachpb.RangeDescriptor) error {
 		var err error
-		reply, err = r.adminSplitWithDescriptor(ctx, args, desc, true /* delayable */, reason, false /* findFirstSafeKey */)
+		reply, err = r.adminSplitWithDescriptor(ctx, args, desc, conf, true /* delayable */, reason, false /* findFirstSafeKey */)
 		return err
 	})
-	return reply, err
+	return reply, kvErr
 }
 
 func maybeDescriptorChangedError(
@@ -297,6 +301,7 @@ func (r *Replica) adminSplitWithDescriptor(
 	ctx context.Context,
 	args kvpb.AdminSplitRequest,
 	desc *roachpb.RangeDescriptor,
+	conf *roachpb.SpanConfig,
 	delayable bool,
 	reason string,
 	findFirstSafeKey bool,
@@ -322,7 +327,7 @@ func (r *Replica) adminSplitWithDescriptor(
 		if len(args.SplitKey) == 0 {
 			// Find a key to split by size.
 			var err error
-			targetSize := r.GetMaxBytes(ctx) / 2
+			targetSize := conf.RangeMaxBytes / 2
 			foundSplitKey, err = storage.MVCCFindSplitKey(
 				ctx, r.store.TODOEngine(), desc.StartKey, desc.EndKey, targetSize)
 			if err != nil {
@@ -3560,8 +3565,8 @@ type RelocateOneOptions interface {
 	Allocator() allocatorimpl.Allocator
 	// StorePool returns the store's configured store pool.
 	StorePool() storepool.AllocatorStorePool
-	// SpanConfig returns the span configuration for the range with start key.
-	SpanConfig(ctx context.Context, startKey roachpb.RKey) (*roachpb.SpanConfig, error)
+	// LoadSpanConfig returns the span configuration for the range with start key.
+	LoadSpanConfig(ctx context.Context, startKey roachpb.RKey) (*roachpb.SpanConfig, error)
 	// LeaseHolder returns the descriptor of the replica which holds the lease
 	// on the range with start key.
 	Leaseholder(ctx context.Context, startKey roachpb.RKey) (roachpb.ReplicaDescriptor, error)
@@ -3581,19 +3586,11 @@ func (roo *replicaRelocateOneOptions) StorePool() storepool.AllocatorStorePool {
 	return roo.store.cfg.StorePool
 }
 
-// SpanConfig returns the span configuration for the range with start key.
-func (roo *replicaRelocateOneOptions) SpanConfig(
+// LoadSpanConfig returns the span configuration for the range with start key.
+func (roo *replicaRelocateOneOptions) LoadSpanConfig(
 	ctx context.Context, startKey roachpb.RKey,
 ) (*roachpb.SpanConfig, error) {
-	confReader, err := roo.store.GetConfReader(ctx)
-	if err != nil {
-		return nil, errors.Wrap(err, "can't relocate range")
-	}
-	conf, err := confReader.GetSpanConfigForKey(ctx, startKey)
-	if err != nil {
-		return nil, err
-	}
-	return &conf, nil
+	return roo.store.GetSpanConfigForKey(ctx, startKey)
 }
 
 // Leaseholder returns the descriptor of the replica which holds the lease on
@@ -3633,7 +3630,7 @@ func RelocateOne(
 	allocator := options.Allocator()
 	storePool := options.StorePool()
 
-	conf, err := options.SpanConfig(ctx, desc.StartKey)
+	conf, err := options.LoadSpanConfig(ctx, desc.StartKey)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -4005,8 +4002,8 @@ func (r *Replica) adminScatter(
 		if currentAttempt == maxAttempts-1 || !requeue {
 			allowLeaseTransfer = true
 		}
-		desc, conf := r.DescAndSpanConfig()
-		_, err := rq.replicaCanBeProcessed(ctx, r, false /* acquireLeaseIfNeeded */)
+		desc := r.Desc()
+		conf, err := rq.replicaCanBeProcessed(ctx, r, false /* acquireLeaseIfNeeded */)
 		if err != nil {
 			// The replica can not be processed, so skip it.
 			break
@@ -4030,7 +4027,12 @@ func (r *Replica) adminScatter(
 	// done by transferring the lease to any of the given N replicas with
 	// probability 1/N of choosing each.
 	if args.RandomizeLeases && r.OwnsValidLease(ctx, r.store.Clock().NowAsClockTimestamp()) {
-		desc, conf := r.DescAndSpanConfig()
+		desc := r.Desc()
+		conf, err := r.LoadSpanConfig(ctx)
+		if err != nil {
+			// We don't have the span config for this range.
+			return kvpb.AdminScatterResponse{}, err
+		}
 		potentialLeaseTargets := r.store.allocator.ValidLeaseTargets(
 			ctx, r.store.cfg.StorePool, desc, conf, desc.Replicas().VoterDescriptors(), r, allocator.TransferLeaseOptions{})
 		if len(potentialLeaseTargets) > 0 {

--- a/pkg/kv/kvserver/replica_gc_queue.go
+++ b/pkg/kv/kvserver/replica_gc_queue.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/log/logcrash"
@@ -121,7 +120,7 @@ func newReplicaGCQueue(store *Store, db *kv.DB) *replicaGCQueue {
 // check must have occurred more than ReplicaGCQueueInactivityThreshold
 // in the past.
 func (rgcq *replicaGCQueue) shouldQueue(
-	ctx context.Context, now hlc.ClockTimestamp, repl *Replica, _ spanconfig.StoreReader,
+	ctx context.Context, now hlc.ClockTimestamp, repl *Replica, _ *roachpb.SpanConfig,
 ) (shouldQueue bool, priority float64) {
 	if _, currentMember := repl.Desc().GetReplicaDescriptor(repl.store.StoreID()); !currentMember {
 		return true, replicaGCPriorityRemoved
@@ -221,7 +220,7 @@ func replicaGCShouldQueueImpl(now, lastCheck hlc.Timestamp, isSuspect bool) (boo
 // process performs a consistent lookup on the range descriptor to see if we are
 // still a member of the range.
 func (rgcq *replicaGCQueue) process(
-	ctx context.Context, repl *Replica, _ spanconfig.StoreReader,
+	ctx context.Context, repl *Replica, _ *roachpb.SpanConfig,
 ) (processed bool, err error) {
 	// Note that the Replicas field of desc is probably out of date, so
 	// we should only use `desc` for its static fields like RangeID and
@@ -375,7 +374,7 @@ func (rgcq *replicaGCQueue) process(
 }
 
 func (*replicaGCQueue) postProcessScheduled(
-	ctx context.Context, replica replicaInQueue, priority float64,
+	ctx context.Context, replica replicaInQueue, _ *roachpb.SpanConfig, priority float64,
 ) {
 }
 

--- a/pkg/kv/kvserver/replica_rankings.go
+++ b/pkg/kv/kvserver/replica_rankings.go
@@ -45,9 +45,9 @@ type CandidateReplica interface {
 	// GetFirstIndex returns the index of the first entry in the replica's Raft
 	// log.
 	GetFirstIndex() kvpb.RaftIndex
-	// DescAndSpanConfig returns the authoritative range descriptor as well
-	// as the span config for the replica.
-	DescAndSpanConfig() (*roachpb.RangeDescriptor, *roachpb.SpanConfig)
+	// LoadSpanConfig returns the span config for the replica or an error if it can't
+	// be determined.
+	LoadSpanConfig(context.Context) (*roachpb.SpanConfig, error)
 	// Desc returns the authoritative range descriptor.
 	Desc() *roachpb.RangeDescriptor
 	// RangeUsageInfo returns usage information (sizes and traffic) needed by
@@ -77,7 +77,7 @@ func (cr candidateReplica) RangeUsageInfo() allocator.RangeUsageInfo {
 	return cr.usage
 }
 
-// Replica returns the underlying replica for this CandidateReplica. It is
+// Repl returns the underlying replica for this CandidateReplica. It is
 // only used for determining timeouts in production code and not the
 // simulator.
 func (cr candidateReplica) Repl() *Replica {

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -10349,13 +10349,11 @@ func TestConsistenctQueueErrorFromCheckConsistency(t *testing.T) {
 	tc := testContext{}
 	tc.StartWithStoreConfig(ctx, t, stopper, cfg)
 
-	confReader, err := tc.store.GetConfReader(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
+	conf, err := tc.repl.LoadSpanConfig(ctx)
+	require.NoError(t, err)
 	for i := 0; i < 2; i++ {
 		// Do this twice because it used to deadlock. See #25456.
-		processed, err := tc.store.consistencyQueue.process(ctx, tc.repl, confReader)
+		processed, err := tc.store.consistencyQueue.process(ctx, tc.repl, conf)
 		if !testutils.IsError(err, "boom") {
 			t.Fatal(err)
 		}

--- a/pkg/kv/kvserver/replicate_queue.go
+++ b/pkg/kv/kvserver/replicate_queue.go
@@ -939,6 +939,7 @@ func (rq *replicateQueue) processOneChange(
 // preProcessCheck checks the lease  and destroy status of the replica. This is
 // done to ensure that the replica has a valid lease, correct lease type and is
 // not destroyed.
+// TODO(baptist): Remove this check. It is redundant with Queue.replicaCanBeProcessed
 func (rq *replicateQueue) preProcessCheck(ctx context.Context, repl *Replica) error {
 	// Check lease and destroy status here. The queue does this higher up already, but
 	// adminScatter (and potential other future callers) also call this method and don't

--- a/pkg/kv/kvserver/replicate_queue.go
+++ b/pkg/kv/kvserver/replicate_queue.go
@@ -27,7 +27,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness/livenesspb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
-	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
@@ -578,7 +577,7 @@ func newReplicateQueue(store *Store, allocator allocatorimpl.Allocator) *replica
 			maxSize:              defaultQueueMaxSize,
 			needsLease:           true,
 			needsSpanConfigs:     true,
-			acceptsUnsplitRanges: store.TestingKnobs().ReplicateQueueAcceptsUnsplit,
+			acceptsUnsplitRanges: false,
 			// The processing of the replicate queue often needs to send snapshots
 			// so we use the raftSnapshotQueueTimeoutFunc. This function sets a
 			// timeout based on the range size and the sending rate in addition
@@ -626,27 +625,21 @@ func newReplicateQueue(store *Store, allocator allocatorimpl.Allocator) *replica
 }
 
 func (rq *replicateQueue) shouldQueue(
-	ctx context.Context, now hlc.ClockTimestamp, repl *Replica, confReader spanconfig.StoreReader,
+	ctx context.Context, now hlc.ClockTimestamp, repl *Replica, conf *roachpb.SpanConfig,
 ) (shouldQueue bool, priority float64) {
-	// TODO(baptist): Change to Replica.SpanConfig() once the refactor is done to
-	// have that use the confReader.
-	conf, err := confReader.GetSpanConfigForKey(ctx, repl.startKey)
-	if err != nil {
-		return false, 0
-	}
 	desc := repl.Desc()
 	return rq.planner.ShouldPlanChange(
 		ctx,
 		now,
 		repl,
 		desc,
-		&conf,
+		conf,
 		rq.canTransferLeaseFrom,
 	)
 }
 
 func (rq *replicateQueue) process(
-	ctx context.Context, repl *Replica, confReader spanconfig.StoreReader,
+	ctx context.Context, repl *Replica, conf *roachpb.SpanConfig,
 ) (processed bool, err error) {
 	retryOpts := retry.Options{
 		InitialBackoff: 50 * time.Millisecond,
@@ -654,18 +647,12 @@ func (rq *replicateQueue) process(
 		Multiplier:     2,
 		MaxRetries:     5,
 	}
-	// TODO(baptist): Change to Replica.SpanConfig() once the refactor is done to
-	// have that use the confReader.
-	conf, err := confReader.GetSpanConfigForKey(ctx, repl.startKey)
-	if err != nil {
-		return false, err
-	}
 	desc := repl.Desc()
 	// Use a retry loop in order to backoff in the case of snapshot errors,
 	// usually signaling that a rebalancing reservation could not be made with the
 	// selected target.
 	for r := retry.StartWithCtx(ctx, retryOpts); r.Next(); {
-		requeue, err := rq.processOneChangeWithTracing(ctx, repl, desc, &conf)
+		requeue, err := rq.processOneChangeWithTracing(ctx, repl, desc, conf)
 		if isSnapshotError(err) {
 			// If ChangeReplicas failed because the snapshot failed, we attempt to
 			// retry the operation. The most likely causes of the snapshot failing
@@ -690,7 +677,7 @@ func (rq *replicateQueue) process(
 		}
 
 		if testingAggressiveConsistencyChecks {
-			if _, err := rq.store.consistencyQueue.process(ctx, repl, confReader); err != nil {
+			if _, err := rq.store.consistencyQueue.process(ctx, repl, conf); err != nil {
 				log.KvDistribution.Warningf(ctx, "%v", err)
 			}
 		}
@@ -1143,7 +1130,7 @@ func (rq *replicateQueue) canTransferLeaseFrom(
 }
 
 func (*replicateQueue) postProcessScheduled(
-	ctx context.Context, replica replicaInQueue, priority float64,
+	ctx context.Context, replica replicaInQueue, conf *roachpb.SpanConfig, priority float64,
 ) {
 }
 

--- a/pkg/kv/kvserver/replicate_queue_test.go
+++ b/pkg/kv/kvserver/replicate_queue_test.go
@@ -777,7 +777,10 @@ func TestReplicateQueueDecommissioningNonVoters(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			_, conf := repl.DescAndSpanConfig()
+			conf, err := repl.LoadSpanConfig(ctx)
+			if err != nil {
+				return false
+			}
 			return conf.GetNumNonVoters() == 0
 		}, testutils.DefaultSucceedsSoonDuration, 100*time.Millisecond)
 
@@ -1204,7 +1207,10 @@ func TestReplicateQueueDeadNonVoters(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			_, conf := repl.DescAndSpanConfig()
+			conf, err := repl.LoadSpanConfig(ctx)
+			if err != nil {
+				return false
+			}
 			return conf.GetNumNonVoters() == 0
 		}, testutils.DefaultSucceedsSoonDuration, 100*time.Millisecond)
 
@@ -2030,23 +2036,26 @@ func TestTransferLeaseToLaggingNode(t *testing.T) {
 		time.Sleep(13 * time.Millisecond)
 	}
 
-	// Set the zone preference for the replica to show that it has to be moved
-	// to the remote node.
-	desc, conf := leaseHolderRepl.DescAndSpanConfig()
-	newConf := conf
-	newConf.LeasePreferences = []roachpb.LeasePreference{
-		{
-			Constraints: []roachpb.Constraint{
-				{
-					Type:  roachpb.Constraint_REQUIRED,
-					Value: fmt.Sprintf("n%d", remoteNodeID),
-				},
-			},
-		},
-	}
-
 	// By now the lease holder may have changed.
 	testutils.SucceedsSoon(t, func() error {
+		conf, err := leaseHolderRepl.LoadSpanConfig(ctx)
+		if err != nil {
+			return err
+		}
+		newConf := conf
+
+		// Set the zone preference for the replica to show that it has to be moved
+		// to the remote node.
+		newConf.LeasePreferences = []roachpb.LeasePreference{
+			{
+				Constraints: []roachpb.Constraint{
+					{
+						Type:  roachpb.Constraint_REQUIRED,
+						Value: fmt.Sprintf("n%d", remoteNodeID),
+					},
+				},
+			},
+		}
 		leaseBefore, _ := leaseHolderRepl.GetLease()
 		log.Infof(ctx, "Lease before transfer %+v\n", leaseBefore)
 
@@ -2068,7 +2077,7 @@ func TestTransferLeaseToLaggingNode(t *testing.T) {
 			return err
 		}
 		transferred, err := leaseStore.FindTargetAndTransferLease(
-			ctx, leaseRepl, desc, newConf)
+			ctx, leaseRepl, leaseHolderRepl.Desc(), newConf)
 		if err != nil {
 			return err
 		}

--- a/pkg/kv/kvserver/split_queue.go
+++ b/pkg/kv/kvserver/split_queue.go
@@ -183,10 +183,14 @@ func shouldSplitRange(
 // prefix or if the range's size in bytes exceeds the limit for the zone,
 // or if the range has too much load on it.
 func (sq *splitQueue) shouldQueue(
-	ctx context.Context, now hlc.ClockTimestamp, repl *Replica, confReader spanconfig.StoreReader,
+	ctx context.Context, now hlc.ClockTimestamp, repl *Replica, conf *roachpb.SpanConfig,
 ) (shouldQ bool, priority float64) {
+	confReader, err := repl.store.GetConfReader(ctx)
+	if err != nil {
+		return false, 0
+	}
 	shouldQ, priority = shouldSplitRange(ctx, repl.Desc(), repl.GetMVCCStats(),
-		repl.GetMaxBytes(ctx), repl.shouldBackpressureWrites(), confReader)
+		conf.RangeMaxBytes, repl.shouldBackpressureWrites(), confReader)
 
 	if !shouldQ && repl.SplitByLoadEnabled() {
 		if splitKey := repl.loadSplitKey(ctx, repl.Clock().PhysicalTime()); splitKey != nil {
@@ -208,9 +212,9 @@ var _ PurgatoryError = unsplittableRangeError{}
 
 // process synchronously invokes admin split for each proposed split key.
 func (sq *splitQueue) process(
-	ctx context.Context, r *Replica, confReader spanconfig.StoreReader,
+	ctx context.Context, r *Replica, conf *roachpb.SpanConfig,
 ) (processed bool, err error) {
-	processed, err = sq.processAttempt(ctx, r, confReader)
+	processed, err = sq.processAttempt(ctx, r, conf)
 	if errors.HasType(err, (*kvpb.ConditionFailedError)(nil)) {
 		// ConditionFailedErrors are an expected outcome for range split
 		// attempts because splits can race with other descriptor modifications.
@@ -225,9 +229,13 @@ func (sq *splitQueue) process(
 }
 
 func (sq *splitQueue) processAttempt(
-	ctx context.Context, r *Replica, confReader spanconfig.StoreReader,
+	ctx context.Context, r *Replica, conf *roachpb.SpanConfig,
 ) (processed bool, err error) {
 	desc := r.Desc()
+	confReader, err := r.store.GetConfReader(ctx)
+	if err != nil {
+		return false, errors.Wrapf(err, "unable to load conf reader")
+	}
 	// First handle the case of splitting due to span config maps.
 	splitKey, err := confReader.ComputeSplitKey(ctx, desc.StartKey, desc.EndKey)
 	if err != nil {
@@ -244,6 +252,7 @@ func (sq *splitQueue) processAttempt(
 				ExpirationTime: hlc.Timestamp{},
 			},
 			desc,
+			conf,
 			false, /* delayable */
 			"span config",
 			false, /* findFirstSafeSplitKey */
@@ -258,12 +267,13 @@ func (sq *splitQueue) processAttempt(
 	// size-based splitting if maxBytes is 0 (happens in certain test
 	// situations).
 	size := r.GetMVCCStats().Total()
-	maxBytes := r.GetMaxBytes(ctx)
+	maxBytes := conf.RangeMaxBytes
 	if maxBytes > 0 && size > maxBytes {
 		if _, err := r.adminSplitWithDescriptor(
 			ctx,
 			kvpb.AdminSplitRequest{},
 			desc,
+			conf,
 			false, /* delayable */
 			fmt.Sprintf("%s above threshold size %s", humanizeutil.IBytes(size), humanizeutil.IBytes(maxBytes)),
 			false, /* findFirstSafeSplitKey */
@@ -316,6 +326,7 @@ func (sq *splitQueue) processAttempt(
 				ExpirationTime: expTime,
 			},
 			desc,
+			conf,
 			false, /* delayable */
 			reason,
 			true, /* findFirstSafeSplitKey */
@@ -335,7 +346,7 @@ func (sq *splitQueue) processAttempt(
 }
 
 func (*splitQueue) postProcessScheduled(
-	ctx context.Context, replica replicaInQueue, priority float64,
+	ctx context.Context, replica replicaInQueue, config *roachpb.SpanConfig, priority float64,
 ) {
 }
 

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -2466,6 +2466,32 @@ func (s *Store) removeReplicaWithRangefeed(rangeID roachpb.RangeID) {
 	s.rangefeedReplicas.Unlock()
 }
 
+// GetSpanConfigForKey loads the span config starting at the given key. This
+// allows inserting test configurations through knobs.
+func (s *Store) GetSpanConfigForKey(
+	ctx context.Context, key roachpb.RKey,
+) (*roachpb.SpanConfig, error) {
+	if s.cfg.TestingKnobs.MakeSystemConfigSpanUnavailableToQueues {
+		return nil, errSpanConfigsUnavailable
+	}
+
+	// TODO(baptist): Tests should correctly set the span configs.
+	if s.cfg.SpanConfigsDisabled {
+		return &s.cfg.DefaultSpanConfig, nil
+	}
+	confReader, err := s.GetConfReader(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if s.cfg.TestingKnobs.ConfReaderInterceptor != nil {
+		if reader := s.cfg.TestingKnobs.ConfReaderInterceptor(); reader != nil {
+			confReader = reader
+		}
+	}
+	conf, err := confReader.GetSpanConfigForKey(ctx, key)
+	return &conf, err
+}
+
 // onSpanConfigUpdate is the callback invoked whenever this store learns of a
 // span config update.
 func (s *Store) onSpanConfigUpdate(ctx context.Context, updated roachpb.Span) {
@@ -3522,13 +3548,7 @@ func (s *Store) AllocatorCheckRange(
 	}
 	ctx, sp := tracing.EnsureChildSpan(ctx, s.cfg.AmbientCtx.Tracer, "allocator check range", spanOptions...)
 
-	confReader, err := s.GetConfReader(ctx)
-	if err != nil {
-		log.Eventf(ctx, "span configs unavailable: %s", err)
-		return allocatorimpl.AllocatorNoop, roachpb.ReplicationTarget{}, sp.FinishAndGetConfiguredRecording(), err
-	}
-
-	conf, err := confReader.GetSpanConfigForKey(ctx, desc.StartKey)
+	conf, err := s.GetSpanConfigForKey(ctx, desc.StartKey)
 	if err != nil {
 		log.Eventf(ctx, "error retrieving span config for range %s: %s", desc, err)
 		return allocatorimpl.AllocatorNoop, roachpb.ReplicationTarget{}, sp.FinishAndGetConfiguredRecording(), err
@@ -3543,7 +3563,7 @@ func (s *Store) AllocatorCheckRange(
 		storePool = s.cfg.StorePool
 	}
 
-	action, _ := s.allocator.ComputeAction(ctx, storePool, &conf, desc)
+	action, _ := s.allocator.ComputeAction(ctx, storePool, conf, desc)
 
 	// In the case that the action does not require a target, return immediately.
 	if !(action.Add() || action.Replace()) {
@@ -3557,7 +3577,7 @@ func (s *Store) AllocatorCheckRange(
 		return action, roachpb.ReplicationTarget{}, sp.FinishAndGetConfiguredRecording(), err
 	}
 
-	target, _, err := s.allocator.AllocateTarget(ctx, storePool, &conf,
+	target, _, err := s.allocator.AllocateTarget(ctx, storePool, conf,
 		filteredVoters, filteredNonVoters, replacing, action.ReplicaStatus(), action.TargetReplicaType(),
 	)
 	if err == nil {
@@ -3568,7 +3588,7 @@ func (s *Store) AllocatorCheckRange(
 		fragileQuorumErr := s.allocator.CheckAvoidsFragileQuorum(
 			ctx,
 			storePool,
-			&conf,
+			conf,
 			desc.Replicas().VoterDescriptors(),
 			filteredVoters,
 			action.ReplicaStatus(),
@@ -3621,7 +3641,16 @@ func (s *Store) Enqueue(
 		return nil, nil, errors.Errorf("unknown queue type %q", queueName)
 	}
 
-	confReader, err := s.GetConfReader(ctx)
+	// TODO(baptist): Remove this check. We read the conf reader just to see if
+	// we can without error. Once we load the SpanConfig from the Reader instead
+	// of the cached version, these two checks are the same.
+	_, err := s.GetConfReader(ctx)
+	if err != nil {
+		return nil, nil, errors.Wrap(err,
+			"unable to retrieve conf reader, cannot run queue; make sure "+
+				"the cluster has been initialized and all nodes connected to it")
+	}
+	conf, err := repl.LoadSpanConfig(ctx)
 	if err != nil {
 		return nil, nil, errors.Wrap(err,
 			"unable to retrieve conf reader, cannot run queue; make sure "+
@@ -3660,7 +3689,7 @@ func (s *Store) Enqueue(
 
 	if !skipShouldQueue {
 		log.Eventf(ctx, "running %s.shouldQueue", queueName)
-		shouldQueue, priority := qImpl.shouldQueue(ctx, s.cfg.Clock.NowAsClockTimestamp(), repl, confReader)
+		shouldQueue, priority := qImpl.shouldQueue(ctx, s.cfg.Clock.NowAsClockTimestamp(), repl, conf)
 		log.Eventf(ctx, "shouldQueue=%v, priority=%f", shouldQueue, priority)
 		if !shouldQueue {
 			return collectAndFinish(), nil, nil
@@ -3668,7 +3697,7 @@ func (s *Store) Enqueue(
 	}
 
 	log.Eventf(ctx, "running %s.process", queueName)
-	processed, processErr := qImpl.process(ctx, repl, confReader)
+	processed, processErr := qImpl.process(ctx, repl, conf)
 	log.Eventf(ctx, "processed: %t (err: %v)", processed, processErr)
 	return collectAndFinish(), processErr, nil
 }

--- a/pkg/kv/kvserver/store_rebalancer.go
+++ b/pkg/kv/kvserver/store_rebalancer.go
@@ -654,7 +654,7 @@ func (sr *StoreRebalancer) applyRangeRebalance(
 	candidateReplica CandidateReplica,
 	voterTargets, nonVoterTargets []roachpb.ReplicationTarget,
 ) bool {
-	descBeforeRebalance, _ := candidateReplica.DescAndSpanConfig()
+	descBeforeRebalance := candidateReplica.Desc()
 	log.KvDistribution.Infof(
 		ctx,
 		"rebalancing r%d (%s load) to better balance load: voters from %v to %v; non-voters from %v to %v",
@@ -740,7 +740,12 @@ func (sr *StoreRebalancer) chooseLeaseToTransfer(
 			continue
 		}
 
-		desc, conf := candidateReplica.DescAndSpanConfig()
+		desc := candidateReplica.Desc()
+		conf, err := candidateReplica.LoadSpanConfig(ctx)
+		if err != nil {
+			log.KvDistribution.VEventf(ctx, 2, "unable to load span config: %v", err)
+			continue
+		}
 		log.KvDistribution.VEventf(ctx, 3, "considering lease transfer for r%d with %s load",
 			desc.RangeID, candidateReplica.RangeUsageInfo().TransferImpact())
 
@@ -867,7 +872,12 @@ func (sr *StoreRebalancer) chooseRangeToRebalance(
 			continue
 		}
 
-		rangeDesc, conf := candidateReplica.DescAndSpanConfig()
+		rangeDesc := candidateReplica.Desc()
+		conf, err := candidateReplica.LoadSpanConfig(ctx)
+		if err != nil {
+			log.KvDistribution.VEventf(ctx, 2, "unable to load span config: %v", err)
+			continue
+		}
 		clusterNodes := sr.storePool.ClusterNodeCount()
 		numDesiredVoters := allocatorimpl.GetNeededVoters(conf.GetNumVoters(), clusterNodes)
 		numDesiredNonVoters := allocatorimpl.GetNeededNonVoters(numDesiredVoters, int(conf.GetNumNonVoters()), clusterNodes)

--- a/pkg/kv/kvserver/store_rebalancer_test.go
+++ b/pkg/kv/kvserver/store_rebalancer_test.go
@@ -509,7 +509,6 @@ func loadRanges(rr *ReplicaRankings, s *Store, ranges []testRange) {
 		rangeID := roachpb.RangeID(i + 1)
 		repl := &Replica{store: s, RangeID: rangeID}
 		repl.mu.state.Desc = &roachpb.RangeDescriptor{RangeID: rangeID}
-		repl.mu.conf = s.cfg.DefaultSpanConfig
 		for _, storeID := range r.voters {
 			repl.mu.state.Desc.InternalReplicas = append(repl.mu.state.Desc.InternalReplicas, roachpb.ReplicaDescriptor{
 				NodeID:    roachpb.NodeID(storeID),
@@ -1279,6 +1278,12 @@ func TestChooseRangeToRebalanceAcrossHeterogeneousZones(t *testing.T) {
 			)
 
 			hottestRanges := sr.replicaRankings.TopLoad(lbRebalanceDimension)
+			// TODO(baptist): Remove this once the cached span conf is removed
+			// from the replica. The DefaultSpanConfig can be removed also once
+			// this change is made.
+			for _, replica := range hottestRanges {
+				replica.Repl().SetSpanConfig(s.cfg.DefaultSpanConfig)
+			}
 			options := sr.scorerOptions(ctx, lbRebalanceDimension)
 			rctx := sr.NewRebalanceContext(ctx, options, hottestRanges, LBRebalancingLeasesAndReplicas)
 			rctx.options.IOOverloadOptions = allocatorimpl.IOOverloadOptions{
@@ -1535,6 +1540,12 @@ func TestChooseRangeToRebalanceOffHotNodes(t *testing.T) {
 			)
 
 			hottestRanges := sr.replicaRankings.TopLoad(lbRebalanceDimension)
+			// TODO(baptist): Remove this once the cached span conf is removed
+			// from the replica. The DefaultSpanConfig can be removed also once
+			// this change is made.
+			for _, replica := range hottestRanges {
+				replica.Repl().SetSpanConfig(s.cfg.DefaultSpanConfig)
+			}
 			options := sr.scorerOptions(ctx, lbRebalanceDimension)
 			rctx := sr.NewRebalanceContext(ctx, options, hottestRanges, sr.RebalanceMode())
 			rctx.options.IOOverloadOptions = allocatorimpl.IOOverloadOptions{
@@ -1802,6 +1813,12 @@ func TestStoreRebalancerIOOverloadCheck(t *testing.T) {
 			loadRanges(rr, s, []testRange{{voters: []roachpb.StoreID{1, 3, 5}, qps: 100, reqCPU: 100 * float64(time.Millisecond)}})
 
 			hottestRanges := sr.replicaRankings.TopLoad(lbRebalanceDimension)
+			// TODO(baptist): Remove this once the cached span conf is removed
+			// from the replica. The DefaultSpanConfig can be removed also once
+			// this change is made.
+			for _, replica := range hottestRanges {
+				replica.Repl().SetSpanConfig(s.cfg.DefaultSpanConfig)
+			}
 			options := sr.scorerOptions(ctx, lbRebalanceDimension)
 			rctx := sr.NewRebalanceContext(ctx, options, hottestRanges, sr.RebalanceMode())
 			require.Greater(t, len(rctx.hottestRanges), 0)

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -52,7 +52,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/rpc/nodedialer"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
-	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/bootstrap"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
@@ -3505,34 +3504,6 @@ func TestSnapshotRateLimit(t *testing.T) {
 	require.Equal(t, int64(32<<20), limit)
 }
 
-type mockSpanConfigReader struct {
-	real      spanconfig.StoreReader
-	overrides map[string]roachpb.SpanConfig
-}
-
-func (m *mockSpanConfigReader) NeedsSplit(
-	ctx context.Context, start, end roachpb.RKey,
-) (bool, error) {
-	panic("unimplemented")
-}
-
-func (m *mockSpanConfigReader) ComputeSplitKey(
-	ctx context.Context, start, end roachpb.RKey,
-) (roachpb.RKey, error) {
-	panic("unimplemented")
-}
-
-func (m *mockSpanConfigReader) GetSpanConfigForKey(
-	ctx context.Context, key roachpb.RKey,
-) (roachpb.SpanConfig, error) {
-	if conf, ok := m.overrides[string(key)]; ok {
-		return conf, nil
-	}
-	return m.GetSpanConfigForKey(ctx, key)
-}
-
-var _ spanconfig.StoreReader = &mockSpanConfigReader{}
-
 // TestAllocatorCheckRangeUnconfigured tests evaluating the allocation decisions
 // for a range with a single replica using the default system configuration and
 // no other available allocation targets.
@@ -3684,7 +3655,6 @@ func TestAllocatorCheckRange(t *testing.T) {
 				{NodeID: 4, StoreID: 4, ReplicaID: 4},
 				{NodeID: 5, StoreID: 5, ReplicaID: 5},
 			},
-			spanConfig: &defaultSystemSpanConfig,
 			livenessOverrides: map[roachpb.NodeID]livenesspb.NodeLivenessStatus{
 				3: livenesspb.NodeLivenessStatus_DECOMMISSIONING,
 			},
@@ -3702,7 +3672,6 @@ func TestAllocatorCheckRange(t *testing.T) {
 				{NodeID: 4, StoreID: 4, ReplicaID: 4},
 				{NodeID: 5, StoreID: 5, ReplicaID: 5},
 			},
-			spanConfig: &defaultSystemSpanConfig,
 			livenessOverrides: map[roachpb.NodeID]livenesspb.NodeLivenessStatus{
 				3: livenesspb.NodeLivenessStatus_DECOMMISSIONING,
 				4: livenesspb.NodeLivenessStatus_DECOMMISSIONING,
@@ -3726,7 +3695,6 @@ func TestAllocatorCheckRange(t *testing.T) {
 				// Region "c"
 				{NodeID: 7, StoreID: 7, ReplicaID: 5},
 			},
-			spanConfig: &defaultSystemSpanConfig,
 			livenessOverrides: map[roachpb.NodeID]livenesspb.NodeLivenessStatus{
 				// Downsize to one node per region: 3,6,9.
 				1: livenesspb.NodeLivenessStatus_DECOMMISSIONING,
@@ -3979,16 +3947,8 @@ func TestAllocatorCheckRange(t *testing.T) {
 			cfg.Gossip = g
 			cfg.StorePool = sp
 			if tc.spanConfig != nil {
-				mockSr := &mockSpanConfigReader{
-					real: cfg.SystemConfigProvider.GetSystemConfig(),
-					overrides: map[string]roachpb.SpanConfig{
-						"a": *tc.spanConfig,
-					},
-				}
-
-				cfg.TestingKnobs.ConfReaderInterceptor = func() spanconfig.StoreReader {
-					return mockSr
-				}
+				cfg.SpanConfigsDisabled = true
+				cfg.DefaultSpanConfig = *tc.spanConfig
 			}
 
 			s := createTestStoreWithoutStart(ctx, t, stopper, testStoreOpts{createSystemRanges: true}, &cfg)

--- a/pkg/kv/kvserver/ts_maintenance_queue.go
+++ b/pkg/kv/kvserver/ts_maintenance_queue.go
@@ -17,7 +17,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -128,7 +127,7 @@ func newTimeSeriesMaintenanceQueue(
 }
 
 func (q *timeSeriesMaintenanceQueue) shouldQueue(
-	ctx context.Context, now hlc.ClockTimestamp, repl *Replica, _ spanconfig.StoreReader,
+	ctx context.Context, now hlc.ClockTimestamp, repl *Replica, conf *roachpb.SpanConfig,
 ) (shouldQ bool, priority float64) {
 	if !repl.store.cfg.TestingKnobs.DisableLastProcessedCheck {
 		lpTS, err := repl.getQueueLastProcessed(ctx, q.name)
@@ -148,7 +147,7 @@ func (q *timeSeriesMaintenanceQueue) shouldQueue(
 }
 
 func (q *timeSeriesMaintenanceQueue) process(
-	ctx context.Context, repl *Replica, _ spanconfig.StoreReader,
+	ctx context.Context, repl *Replica, conf *roachpb.SpanConfig,
 ) (processed bool, err error) {
 	desc := repl.Desc()
 	eng := repl.store.StateEngine()
@@ -166,7 +165,7 @@ func (q *timeSeriesMaintenanceQueue) process(
 }
 
 func (*timeSeriesMaintenanceQueue) postProcessScheduled(
-	ctx context.Context, replica replicaInQueue, priority float64,
+	ctx context.Context, replica replicaInQueue, conf *roachpb.SpanConfig, priority float64,
 ) {
 }
 


### PR DESCRIPTION
This change removes almost all uses of the cached span config from the
replica. The cached span config is removed in a future commit.

Epic: none

Release note: None
