### PR TITLE
sql: temporarily use background ctx when close plpgsql cursor

### DIFF
--- a/pkg/sql/routine.go
+++ b/pkg/sql/routine.go
@@ -469,7 +469,9 @@ func (h *plpgsqlCursorHelper) Close() error {
 		h.iter.Close()
 		h.iter = nil
 	}
-	h.container.Close(h.ctx)
+	// TODO(#111485): use proper context, perhaps by changing `Close` signature
+	// to take it.
+	h.container.Close(context.Background())
 	return h.lastErr
 }
 


### PR DESCRIPTION
This commit is a quick fix to avoid failures with high verbosity due to use of span after finish. For now we just use the background context, but the proper fix would probably be to change the signature of `Close` to take context as the argument. That is left as a TODO.

Informes: #111485.
Epic: None

Release note: None