### PR TITLE
roachtest: upgrade roachtest ubuntu images to 22.04 

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -929,6 +929,10 @@ func (f *clusterFactory) newCluster(
 		providerOptsContainer.SetProviderOpts(cfg.spec.Cloud, providerOpts)
 	}
 
+	if cfg.spec.UbuntuVersion.IsOverridden() {
+		createVMOpts.UbuntuVersion = cfg.spec.UbuntuVersion
+	}
+
 	createFlagsOverride(overrideFlagset, &createVMOpts)
 	// Make sure expiration is changed if --lifetime override flag
 	// is passed.

--- a/pkg/cmd/roachtest/spec/cluster_spec.go
+++ b/pkg/cmd/roachtest/spec/cluster_spec.go
@@ -88,6 +88,7 @@ type ClusterSpec struct {
 	Lifetime             time.Duration
 	ReusePolicy          clusterReusePolicy
 	TerminateOnMigration bool
+	UbuntuVersion        vm.UbuntuVersion
 
 	// FileSystem determines the underlying FileSystem
 	// to be used. The default is ext4.

--- a/pkg/cmd/roachtest/spec/option.go
+++ b/pkg/cmd/roachtest/spec/option.go
@@ -253,3 +253,10 @@ func AWSZones(zones string) Option {
 		spec.AWS.Zones = zones
 	}
 }
+
+// UbuntuVersion controls what Ubuntu Version is used to create the cluster.
+func UbuntuVersion(version vm.UbuntuVersion) Option {
+	return func(spec *ClusterSpec) {
+		spec.UbuntuVersion = version
+	}
+}

--- a/pkg/cmd/roachtest/tests/activerecord.go
+++ b/pkg/cmd/roachtest/tests/activerecord.go
@@ -114,11 +114,11 @@ func registerActiveRecord(r registry.Registry) {
 			t,
 			c,
 			node,
-			"install ruby 2.7",
+			"install ruby 3.1",
 			`mkdir -p ruby-install && \
-        curl -fsSL https://github.com/postmodern/ruby-install/archive/v0.6.1.tar.gz | tar --strip-components=1 -C ruby-install -xz && \
+        curl -fsSL https://github.com/postmodern/ruby-install/archive/v0.9.1.tar.gz | tar --strip-components=1 -C ruby-install -xz && \
         sudo make -C ruby-install install && \
-        sudo ruby-install --system ruby 2.7.1 && \
+        sudo ruby-install --system ruby 3.1.4 && \
         sudo gem update --system`,
 		); err != nil {
 			t.Fatal(err)

--- a/pkg/cmd/roachtest/tests/asyncpg.go
+++ b/pkg/cmd/roachtest/tests/asyncpg.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
 )
 
 const asyncpgRunTestCmd = `
@@ -146,9 +147,12 @@ func registerAsyncpg(r registry.Registry) {
 	}
 
 	r.Add(registry.TestSpec{
-		Name:             "asyncpg",
-		Owner:            registry.OwnerSQLFoundations,
-		Cluster:          r.MakeClusterSpec(1, spec.CPU(16)),
+		Name:  "asyncpg",
+		Owner: registry.OwnerSQLFoundations,
+		// TODO(DarrylWong): This test currently fails on Ubuntu 22.04 so we run it on 20.04.
+		// See https://github.com/cockroachdb/cockroach/issues/112108.
+		// Once this issue is fixed we should remove this Ubuntu Version override.
+		Cluster:          r.MakeClusterSpec(1, spec.CPU(16), spec.UbuntuVersion(vm.FocalFossa)),
 		CompatibleClouds: registry.AllExceptAWS,
 		Suites:           registry.Suites(registry.Nightly, registry.ORM),
 		Tags:             registry.Tags(`default`, `orm`),

--- a/pkg/cmd/roachtest/tests/disk_stall.go
+++ b/pkg/cmd/roachtest/tests/disk_stall.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/stretchr/testify/require"
 )
@@ -46,7 +47,10 @@ func registerDiskStalledDetection(r registry.Registry) {
 		},
 	}
 	makeSpec := func() spec.ClusterSpec {
-		s := r.MakeClusterSpec(4, spec.ReuseNone())
+		// TODO(DarrylWong): This test currently fails on Ubuntu 22.04 so we run it on 20.04.
+		// See: https://github.com/cockroachdb/cockroach/issues/112111.
+		// Once this issue is fixed we should remove this Ubuntu Version override.
+		s := r.MakeClusterSpec(4, spec.ReuseNone(), spec.UbuntuVersion(vm.FocalFossa))
 		// Use PDs in an attempt to work around flakes encountered when using SSDs.
 		// See #97968.
 		s.PreferLocalSSD = false

--- a/pkg/cmd/roachtest/tests/ruby_pg.go
+++ b/pkg/cmd/roachtest/tests/ruby_pg.go
@@ -22,9 +22,11 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	rperrors "github.com/cockroachdb/cockroach/pkg/roachprod/errors"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
@@ -235,10 +237,13 @@ func registerRubyPG(r registry.Registry) {
 	}
 
 	r.Add(registry.TestSpec{
-		Name:             "ruby-pg",
-		Timeout:          1 * time.Hour,
-		Owner:            registry.OwnerSQLFoundations,
-		Cluster:          r.MakeClusterSpec(1),
+		Name:    "ruby-pg",
+		Timeout: 1 * time.Hour,
+		Owner:   registry.OwnerSQLFoundations,
+		// TODO(DarrylWong): This test currently fails on Ubuntu 22.04 so we run it on 20.04.
+		// See: https://github.com/cockroachdb/cockroach/issues/112109
+		// Once this issue is fixed we should remove this Ubuntu Version override.
+		Cluster:          r.MakeClusterSpec(1, spec.UbuntuVersion(vm.FocalFossa)),
 		Leases:           registry.MetamorphicLeases,
 		NativeLibs:       registry.LibGEOS,
 		CompatibleClouds: registry.AllExceptAWS,

--- a/pkg/cmd/roachtest/tests/sequelize.go
+++ b/pkg/cmd/roachtest/tests/sequelize.go
@@ -87,7 +87,7 @@ func registerSequelize(r registry.Registry) {
 			c,
 			node,
 			"install dependencies",
-			`sudo apt-get -qq install make python3 libpq-dev python-dev gcc g++ `+
+			`sudo apt-get -qq install make python3 libpq-dev gcc g++ `+
 				`software-properties-common build-essential`,
 		); err != nil {
 			t.Fatal(err)

--- a/pkg/cmd/roachtest/tests/sqlalchemy.go
+++ b/pkg/cmd/roachtest/tests/sqlalchemy.go
@@ -72,7 +72,7 @@ func runSQLAlchemy(ctx context.Context, t test.Test, c cluster.Cluster) {
 	}
 
 	if err := repeatRunE(ctx, t, c, node, "install dependencies", `
-		sudo apt-get -qq install make python3.7 libpq-dev python3.7-dev gcc python3-setuptools python-setuptools build-essential python3.7-distutils python3-virtualenv
+		sudo apt-get -qq install make python3.7 libpq-dev python3.7-dev gcc python3-setuptools python-setuptools build-essential python3.7-distutils python3-virtualenv python3-typing-extensions
 	`); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/cmd/roachtest/tests/typeorm.go
+++ b/pkg/cmd/roachtest/tests/typeorm.go
@@ -83,7 +83,7 @@ func registerTypeORM(r registry.Registry) {
 			c,
 			node,
 			"install dependencies",
-			`sudo apt-get install -y make python3 libpq-dev python-dev gcc g++ `+
+			`sudo apt-get install -y make python3 libpq-dev gcc g++ `+
 				`software-properties-common build-essential`,
 		); err != nil {
 			t.Fatal(err)

--- a/pkg/roachprod/install/install.go
+++ b/pkg/roachprod/install/install.go
@@ -119,7 +119,6 @@ sudo apt-get install -y \
 `,
 
 	"sysbench": `
-curl -s https://packagecloud.io/install/repositories/akopytov/sysbench/script.deb.sh | sudo bash;
 sudo apt-get update;
 sudo apt-get install -y sysbench;
 `,

--- a/pkg/roachprod/vm/aws/config.json
+++ b/pkg/roachprod/vm/aws/config.json
@@ -20,187 +20,187 @@
     ],
     "value": [
       {
-        "ami_id": "ami-0ba151ad81cdd97be",
-        "ami_id_arm64": "ami-0769d298068e19af3",
+        "ami_id": "ami-09a81b370b76de6a2",
+        "ami_id_arm64": "ami-09b23e84684bb7149",
         "ami_id_fips": "ami-09bfd307c31e4669c",
         "region": "ap-northeast-1",
-        "security_group": "sg-0006e480d77a10104",
+        "security_group": "sg-05ab4b547f9ab7d4d",
         "subnets": {
-          "ap-northeast-1a": "subnet-0d144db3c9e47edf5",
-          "ap-northeast-1c": "subnet-02fcaaa6212fc3c1a",
-          "ap-northeast-1d": "subnet-0e9006ef8b3bef61f"
+          "ap-northeast-1a": "subnet-01c12840a09b589dd",
+          "ap-northeast-1c": "subnet-0b2c542334bbfeec1",
+          "ap-northeast-1d": "subnet-075d8e5225b2f33de"
         }
       },
       {
-        "ami_id": "ami-0970cc54a3aa77466",
-        "ami_id_arm64": "ami-078dacb0982ba1acd",
+        "ami_id": "ami-086cae3329a3f7d75",
+        "ami_id_arm64": "ami-0f8536fc6ad2ba267",
         "ami_id_fips": "ami-0dd93e9ad24d01f62",
         "region": "ap-northeast-2",
-        "security_group": "sg-0e00c2f8f274a0fea",
+        "security_group": "sg-0830cc9735e5c8ba9",
         "subnets": {
-          "ap-northeast-2a": "subnet-0d24440b29a76b724",
-          "ap-northeast-2b": "subnet-0b049a35364cc9d28",
-          "ap-northeast-2c": "subnet-0261535876b726680",
-          "ap-northeast-2d": "subnet-049feccf9cc9895f1"
+          "ap-northeast-2a": "subnet-09616ba053dcf01ae",
+          "ap-northeast-2b": "subnet-03ddfbab86c40cb20",
+          "ap-northeast-2c": "subnet-0a8311dd953f70ec3",
+          "ap-northeast-2d": "subnet-082bd8f4021a77da9"
         }
       },
       {
-        "ami_id": "ami-01e436b65d641478d",
-        "ami_id_arm64": "ami-09f75d98d6c93b280",
+        "ami_id": "ami-0287a05f0ef0e9d9a",
+        "ami_id_arm64": "ami-0b6581fde9e6e7779",
         "ami_id_fips": "ami-04ea778eedaf3a8df",
         "region": "ap-south-1",
-        "security_group": "sg-03a68bb0d765c135e",
+        "security_group": "sg-01efad44634ab8fe4",
         "subnets": {
-          "ap-south-1a": "subnet-0286d3ac1095fc6f1",
-          "ap-south-1b": "subnet-012666900a3627088",
-          "ap-south-1c": "subnet-014859824b1b1365d"
+          "ap-south-1a": "subnet-095c3d3f8bf2ca848",
+          "ap-south-1b": "subnet-06b33291e4a3afda2",
+          "ap-south-1c": "subnet-035114dbfd9520a53"
         }
       },
       {
-        "ami_id": "ami-00def9d5d68359454",
-        "ami_id_arm64": "ami-0ad955f11ef16a0b1",
+        "ami_id": "ami-078c1149d8ad719a7",
+        "ami_id_arm64": "ami-0977667a17a0fa88c",
         "ami_id_fips": "ami-0145aa2d8188220bc",
         "region": "ap-southeast-1",
-        "security_group": "sg-089484fc595751cf7",
+        "security_group": "sg-083edfd46fceb1253",
         "subnets": {
-          "ap-southeast-1a": "subnet-0885896a131051303",
-          "ap-southeast-1b": "subnet-000bab51dbf4e8110",
-          "ap-southeast-1c": "subnet-066c7a79def4e9a5e"
+          "ap-southeast-1a": "subnet-0c65c145593aa5d03",
+          "ap-southeast-1b": "subnet-0223276834c21c554",
+          "ap-southeast-1c": "subnet-06367aac2c2bbf205"
         }
       },
       {
-        "ami_id": "ami-0bd8241d9d44dc95f",
-        "ami_id_arm64": "ami-08943cd23ef30fe09",
+        "ami_id": "ami-0df4b2961410d4cff",
+        "ami_id_arm64": "ami-0c595b8bc24551ef4",
         "ami_id_fips": "ami-066f9bd76e75011be",
         "region": "ap-southeast-2",
-        "security_group": "sg-00bbe741d9d00fd3a",
+        "security_group": "sg-095d6c8fccf08e948",
         "subnets": {
-          "ap-southeast-2a": "subnet-02a776afc9c67cfe8",
-          "ap-southeast-2b": "subnet-0a74fe6561a3d8763",
-          "ap-southeast-2c": "subnet-0ac068637efd31ea7"
+          "ap-southeast-2a": "subnet-03decc6865bc74da5",
+          "ap-southeast-2b": "subnet-0c7c1188406b8c21b",
+          "ap-southeast-2c": "subnet-0bf4ff119b235638c"
         }
       },
       {
-        "ami_id": "ami-0c0ef44e5ccbd075f",
-        "ami_id_arm64": "ami-02512a306f25c39fa",
+        "ami_id": "ami-06873c81b882339ac",
+        "ami_id_arm64": "ami-01a786eb497a27d2a",
         "ami_id_fips": "ami-0713fd833b63915e3",
         "region": "ca-central-1",
-        "security_group": "sg-0d97f7ec3edc8f7c1",
+        "security_group": "sg-0dcf7eede3017b0aa",
         "subnets": {
-          "ca-central-1a": "subnet-02ef88f3eb706271e",
-          "ca-central-1b": "subnet-072be60d12ab9cc6c",
-          "ca-central-1d": "subnet-0a75f397c5f90c490"
+          "ca-central-1a": "subnet-00096e4d45fcd7cd5",
+          "ca-central-1b": "subnet-0c0e1cf25e564df91",
+          "ca-central-1d": "subnet-0e222d35b978eb76c"
         }
       },
       {
-        "ami_id": "ami-05fc4b58217803cb7",
-        "ami_id_arm64": "ami-0f5a401591c7610e3",
+        "ami_id": "ami-06dd92ecc74fdfb36",
+        "ami_id_arm64": "ami-0479653c00e0a5e59",
         "ami_id_fips": "ami-02cc4114e1c012f9c",
         "region": "eu-central-1",
-        "security_group": "sg-05979c18ed21a6757",
+        "security_group": "sg-0276f961a8324e3eb",
         "subnets": {
-          "eu-central-1a": "subnet-0d8cd910b6fd633ae",
-          "eu-central-1b": "subnet-06f3f2617af43d9e4",
-          "eu-central-1c": "subnet-0ffb5b1d20ef5d971"
+          "eu-central-1a": "subnet-02684c5c3de4a9cad",
+          "eu-central-1b": "subnet-0d87f296184a906f7",
+          "eu-central-1c": "subnet-0bc52385bea055213"
         }
       },
       {
-        "ami_id": "ami-05f1fedd8287cef0b",
-        "ami_id_arm64": "ami-0bd686ee970df20b0",
+        "ami_id": "ami-0694d931cee176e7d",
+        "ami_id_arm64": "ami-0d3407241b2b6ec62",
         "ami_id_fips": "ami-014603057f9da7d50",
         "region": "eu-west-1",
-        "security_group": "sg-033eb468bf7e3c6b5",
+        "security_group": "sg-0a087a28f17cfcbd8",
         "subnets": {
-          "eu-west-1a": "subnet-092adeba3986a0218",
-          "eu-west-1b": "subnet-0d05781a8ca47b75c",
-          "eu-west-1c": "subnet-063ba44da52a59451"
+          "eu-west-1a": "subnet-0da087e986d8dadff",
+          "eu-west-1b": "subnet-0aceaf476f90b6649",
+          "eu-west-1c": "subnet-05d998c6fd257856e"
         }
       },
       {
-        "ami_id": "ami-015891366865ea5ca",
-        "ami_id_arm64": "ami-035941b2f8b915be7",
+        "ami_id": "ami-0505148b3591e4c07",
+        "ami_id_arm64": "ami-025db40ba9581d621",
         "ami_id_fips": "ami-0fcf0f89559d79e80",
         "region": "eu-west-2",
-        "security_group": "sg-0cb561f660955a29c",
+        "security_group": "sg-00d75d0d2b71ac876",
         "subnets": {
-          "eu-west-2a": "subnet-0436d5b881fb395cc",
-          "eu-west-2b": "subnet-0fe8957e966a05aee",
-          "eu-west-2c": "subnet-048129c61d1de7102"
+          "eu-west-2a": "subnet-0124b2bb23beee340",
+          "eu-west-2b": "subnet-0c9509cfb4ee9f8f2",
+          "eu-west-2c": "subnet-055a2eeea9d5e7386"
         }
       },
       {
-        "ami_id": "ami-05262a4bcea6f9fa2",
-        "ami_id_arm64": "ami-08d47ac63ccfce6e8",
+        "ami_id": "ami-00983e8a26e4c9bd9",
+        "ami_id_arm64": "ami-07461eab9cc80a86e",
         "ami_id_fips": "ami-03ecf0588cc1bd0f4",
         "region": "eu-west-3",
-        "security_group": "sg-032bca7008934e2ce",
+        "security_group": "sg-0c763f12b1308c24d",
         "subnets": {
-          "eu-west-3a": "subnet-02cf1181611f9c066",
-          "eu-west-3b": "subnet-02cc8d4f386067c1d",
-          "eu-west-3c": "subnet-0c5fe59cb2def6587"
+          "eu-west-3a": "subnet-02d0a9af3b8e44023",
+          "eu-west-3b": "subnet-0f305009c9c68ad84",
+          "eu-west-3c": "subnet-02e7085c60820f35e"
         }
       },
       {
-        "ami_id": "ami-0ac6b9321493324ee",
-        "ami_id_arm64": "ami-082d7ebf7429845d6",
+        "ami_id": "ami-0b6c2d49148000cd5",
+        "ami_id_arm64": "ami-04c2ca7ffc29a0b58",
         "ami_id_fips": "ami-0977da93caf83799e",
         "region": "sa-east-1",
-        "security_group": "sg-0e7fdf92c3b1dbd11",
+        "security_group": "sg-030f43c863595e7b0",
         "subnets": {
-          "sa-east-1a": "subnet-04812b53b10beee8f",
-          "sa-east-1b": "subnet-09cc8fccd8457f85a",
-          "sa-east-1c": "subnet-06239fca3bea45f07"
+          "sa-east-1a": "subnet-021bd19df012184d7",
+          "sa-east-1b": "subnet-0c7694071842eb61b",
+          "sa-east-1c": "subnet-017058cce79c06633"
         }
       },
       {
-        "ami_id": "ami-0481e8ba7f486bd99",
-        "ami_id_arm64": "ami-07cd31309bf4e22f9",
+        "ami_id": "ami-0fc5d935ebf8bc3bc",
+        "ami_id_arm64": "ami-016485166ec7fa705",
         "ami_id_fips": "ami-03cf7ddd346310b5f",
         "region": "us-east-1",
-        "security_group": "sg-09730a5bc7432abe7",
+        "security_group": "sg-0dd4865c73fd585c2",
         "subnets": {
-          "us-east-1a": "subnet-0f4bc88ed9fac8d23",
-          "us-east-1b": "subnet-070901299c800c14d",
-          "us-east-1c": "subnet-0ae3a52e63e771bff",
-          "us-east-1d": "subnet-0f1105fb57f950f6a",
-          "us-east-1e": "subnet-027cccc2cccb7dde0",
-          "us-east-1f": "subnet-0195bd208310cd301"
+          "us-east-1a": "subnet-0560d7062fb02e276",
+          "us-east-1b": "subnet-0bfa201907daab558",
+          "us-east-1c": "subnet-0f879ea6843a7c630",
+          "us-east-1d": "subnet-03eaf37f7018998c1",
+          "us-east-1e": "subnet-06d483faf560526a1",
+          "us-east-1f": "subnet-0b26d5a46d11af17c"
         }
       },
       {
-        "ami_id": "ami-0a14db46282743a66",
-        "ami_id_arm64": "ami-0a929adc7bbccddfa",
+        "ami_id": "ami-0e83be366243f524a",
+        "ami_id_arm64": "ami-05983a09f7dc1c18f",
         "ami_id_fips": "ami-08692707dfc6f8b64",
         "region": "us-east-2",
-        "security_group": "sg-0319fc9c9599a6145",
+        "security_group": "sg-04d72b57e29d671f1",
         "subnets": {
-          "us-east-2a": "subnet-004c6ad7121a8d5a7",
-          "us-east-2b": "subnet-0775beaa2f4c74f1c",
-          "us-east-2c": "subnet-09065271eb9d0144d"
+          "us-east-2a": "subnet-0258dc9d1b6473d84",
+          "us-east-2b": "subnet-0e3d146e87ebc5a2c",
+          "us-east-2c": "subnet-0e71591c1fe06645e"
         }
       },
       {
-        "ami_id": "ami-0a417a9f917183811",
-        "ami_id_arm64": "ami-0dd984c94127082f0",
+        "ami_id": "ami-0cbd40f694b804622",
+        "ami_id_arm64": "ami-0728ec0041b1d38ac",
         "ami_id_fips": "ami-026c3cf51388880d6",
         "region": "us-west-1",
-        "security_group": "sg-0d1ae4a3dc5d6040e",
+        "security_group": "sg-04d73ccef8fff27f2",
         "subnets": {
-          "us-west-1a": "subnet-0fa88a6224978e522",
-          "us-west-1c": "subnet-0a8ad0edbf8e34cfd"
+          "us-west-1a": "subnet-0250e0ff075aa008e",
+          "us-west-1c": "subnet-098cbc8a194a7ed05"
         }
       },
       {
-        "ami_id": "ami-088b024fca114855d",
-        "ami_id_arm64": "ami-015d5804bb67c6f5d",
+        "ami_id": "ami-0efcece6bed30fd98",
+        "ami_id_arm64": "ami-03fd0aa14bd102718",
         "ami_id_fips": "ami-0dc12dcaaa9dcf99d",
         "region": "us-west-2",
-        "security_group": "sg-067af4f878a9f27e3",
+        "security_group": "sg-091c4d21907a35150",
         "subnets": {
-          "us-west-2a": "subnet-04f7b1c6cb5f88766",
-          "us-west-2b": "subnet-0ca7c2b93a469a27f",
-          "us-west-2c": "subnet-0f69a9226c563a232",
-          "us-west-2d": "subnet-01b72477937bc7293"
+          "us-west-2a": "subnet-067f0e23115a07de7",
+          "us-west-2b": "subnet-07f5ae40e74ae789c",
+          "us-west-2c": "subnet-02b83a44fefb4341d",
+          "us-west-2d": "subnet-0ad4e5f30ba9f5c0a"
         }
       }
     ]

--- a/pkg/roachprod/vm/aws/terraform/aws-region/main.tf
+++ b/pkg/roachprod/vm/aws/terraform/aws-region/main.tf
@@ -17,14 +17,15 @@ terraform {
 variable "region" { description = "AWS Region name" }
 variable "image_name" {
   description = "CockroachDB base x86_64 image name"
-  default     = "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20230502"
+  default     = "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20230919"
 }
 
 variable "image_name_arm64" {
   description = "CockroachDB base arm64 image name"
-  default     = "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-20230502"
+  default     = "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20230919"
 }
 
+# TODO: Upgrade FIPS to Ubuntu 22 when it is available.
 variable "image_name_fips" {
   description = "CockroachDB base x86_64 image name"
   default     = "ubuntu-pro-fips-server/images/hvm-ssd/ubuntu-focal-20.04-amd64-pro-fips-server-20221121-7bc828d1-c072-4d33-a989-fbad50380cfb"

--- a/pkg/roachprod/vm/gce/gcloud.go
+++ b/pkg/roachprod/vm/gce/gcloud.go
@@ -36,10 +36,11 @@ import (
 )
 
 const (
-	defaultProject      = "cockroach-ephemeral"
-	ProviderName        = "gce"
-	DefaultImage        = "ubuntu-2004-focal-v20230817"
-	ARM64Image          = "ubuntu-2004-focal-arm64-v20230817"
+	defaultProject = "cockroach-ephemeral"
+	ProviderName   = "gce"
+	DefaultImage   = "ubuntu-2204-jammy-v20230727"
+	ARM64Image     = "ubuntu-2204-jammy-arm64-v20230727"
+	// TODO(DarrylWong): Upgrade FIPS to Ubuntu 22 when it is available.
 	FIPSImage           = "ubuntu-pro-fips-2004-focal-v20230811"
 	defaultImageProject = "ubuntu-os-cloud"
 	FIPSImageProject    = "ubuntu-os-pro-cloud"
@@ -1005,6 +1006,14 @@ func (p *Provider) Create(
 		imageProject = FIPSImageProject
 		l.Printf("Using FIPS-enabled AMI: %s for machine type: %s", image, providerOpts.MachineType)
 	}
+	// If a non default Ubuntu version was specified, we want to use that instead.
+	if opts.UbuntuVersion.IsOverridden() {
+		image, err = getUbuntuImage(opts.UbuntuVersion, opts.Arch)
+		if err != nil {
+			return err
+		}
+		l.Printf("Overriding default Ubuntu image with %s", image)
+	}
 	args := []string{
 		"compute", "instances", "create",
 		"--subnet", "default",
@@ -1079,7 +1088,7 @@ func (p *Provider) Create(
 	}
 
 	// Create GCE startup script file.
-	filename, err := writeStartupScript(extraMountOpts, opts.SSDOpts.FileSystem, providerOpts.UseMultipleDisks, opts.Arch == string(vm.ArchFIPS))
+	filename, err := writeStartupScript(extraMountOpts, opts.SSDOpts.FileSystem, providerOpts.UseMultipleDisks, opts.Arch == string(vm.ArchFIPS), !shouldEnableRSAForSSH(opts.UbuntuVersion, opts.Arch))
 	if err != nil {
 		return errors.Wrapf(err, "could not write GCE startup script to temp file")
 	}
@@ -1664,4 +1673,46 @@ func (p *Provider) ProjectActive(project string) bool {
 func lastComponent(url string) string {
 	s := strings.Split(url, "/")
 	return s[len(s)-1]
+}
+
+var (
+	// We define the actual image here because it's different for every provider.
+	focalFossa = vm.UbuntuImages{
+		DefaultImage: "ubuntu-2004-focal-v20230817",
+		ARM64Image:   "ubuntu-2004-focal-arm64-v20230817",
+		FIPSImage:    "ubuntu-pro-fips-2004-focal-v20230811",
+	}
+
+	gceUbuntuImages = map[vm.UbuntuVersion]vm.UbuntuImages{
+		vm.FocalFossa: focalFossa,
+	}
+)
+
+// getUbuntuImage returns the correct Ubuntu image for the specified Ubuntu version and architecture.
+func getUbuntuImage(version vm.UbuntuVersion, arch string) (string, error) {
+	image, ok := gceUbuntuImages[version]
+	if ok {
+		switch arch {
+		case string(vm.ArchAMD64):
+			return image.DefaultImage, nil
+		case string(vm.ArchARM64):
+			return image.ARM64Image, nil
+		case string(vm.ArchFIPS):
+			return image.FIPSImage, nil
+		default:
+			return "", errors.Errorf("Unknown architecture specified.")
+		}
+	}
+
+	return "", errors.Errorf("Unknown Ubuntu version specified.")
+}
+
+// Returns true if the current Ubuntu image is 22.04. RSA SHA1 is no longer supported
+// in 22.04, but is required by Jepsen tests so we enable it. However, some tests are
+// still on Ubuntu 20.04, which will break sshd if we try to enable.
+// TODO(DarrylWong): In the future, when all tests are run on Ubuntu 22.04, we can remove this check and default true.
+// See: https://github.com/cockroachdb/cockroach/issues/112112
+func shouldEnableRSAForSSH(version vm.UbuntuVersion, arch string) bool {
+	// FIPS is not yet available on 22.04, it's still using Ubuntu 20.04.
+	return version.IsOverridden() || arch == string(vm.ArchFIPS)
 }

--- a/pkg/roachprod/vm/gce/utils.go
+++ b/pkg/roachprod/vm/gce/utils.go
@@ -142,11 +142,22 @@ sudo sh -c 'echo "MaxStartups 64:30:128" >> /etc/ssh/sshd_config'
 # Crank up the logging for issues such as:
 # https://github.com/cockroachdb/cockroach/issues/36929
 sudo sed -i'' 's/LogLevel.*$/LogLevel DEBUG3/' /etc/ssh/sshd_config
+# N.B. RSA SHA1 is no longer supported in the latest versions of OpenSSH. Existing tooling, e.g.,
+# jepsen still relies on it for authentication. If we are on Ubuntu 22.04 or newer, we need to enable it.
+{{ if .EnableRSAForSSH }}
+sudo sh -c 'echo "PubkeyAcceptedAlgorithms +ssh-rsa" >> /etc/ssh/sshd_config'
+{{ end }}
 sudo service sshd restart
 # increase the default maximum number of open file descriptors for
 # root and non-root users. Load generators running a lot of concurrent
 # workers bump into this often.
 sudo sh -c 'echo "root - nofile 1048576\n* - nofile 1048576" > /etc/security/limits.d/10-roachprod-nofiles.conf'
+
+# N.B. Ubuntu 22.04 changed the location of tcpdump to /usr/bin. Since existing tooling, e.g.,
+# jepsen uses /usr/sbin, we create a symlink.
+# See https://ubuntu.pkgs.org/22.04/ubuntu-main-amd64/tcpdump_4.99.1-3build2_amd64.deb.html
+#
+sudo ln -s /usr/bin/tcpdump /usr/sbin/tcpdump
 
 # Send TCP keepalives every minute since GCE will terminate idle connections
 # after 10m. Note that keepalives still need to be requested by the application
@@ -237,13 +248,16 @@ sudo touch /mnt/data1/.roachprod-initialized
 // extraMountOpts, if not empty, is appended to the default mount options. It is
 // a comma-separated list of options for the "mount -o" flag.
 func writeStartupScript(
-	extraMountOpts string, fileSystem string, useMultiple bool, enableFIPS bool,
+	extraMountOpts string, fileSystem string, useMultiple bool, enableFIPS bool, enableRSAForSSH bool,
 ) (string, error) {
 	type tmplParams struct {
 		ExtraMountOpts   string
 		UseMultipleDisks bool
 		Zfs              bool
 		EnableFIPS       bool
+		// TODO(DarrylWong): In the future, when all tests are run on Ubuntu 22.04, we can remove this check and default true.
+		// See: https://github.com/cockroachdb/cockroach/issues/112112
+		EnableRSAForSSH bool
 	}
 
 	args := tmplParams{
@@ -251,6 +265,7 @@ func writeStartupScript(
 		UseMultipleDisks: useMultiple,
 		Zfs:              fileSystem == vm.Zfs,
 		EnableFIPS:       enableFIPS,
+		EnableRSAForSSH:  enableRSAForSSH,
 	}
 
 	tmpfile, err := os.CreateTemp("", "gce-startup-script")

--- a/pkg/roachprod/vm/vm.go
+++ b/pkg/roachprod/vm/vm.go
@@ -278,6 +278,7 @@ type CreateOpts struct {
 
 	GeoDistributed bool
 	Arch           string
+	UbuntuVersion  UbuntuVersion
 	VMProviders    []string
 	SSDOpts        struct {
 		UseLocalSSD bool
@@ -693,4 +694,25 @@ func SanitizeLabel(label string) string {
 	// Remove any leading or trailing hyphens
 	label = strings.Trim(label, "-")
 	return label
+}
+
+// UbuntuVersion specifies the version of Ubuntu used. Note that a default
+// version is already provided and this is only for overriding that default.
+// TODO(Darryl): Remove after all tests are upgraded to Ubuntu 22.04.
+// See: https://github.com/cockroachdb/cockroach/issues/112112.
+type UbuntuVersion string
+
+type UbuntuImages struct {
+	DefaultImage string
+	ARM64Image   string
+	FIPSImage    string
+}
+
+const (
+	FocalFossa UbuntuVersion = "20.04"
+)
+
+// IsOverridden returns true if an Ubuntu version was specified.
+func (u UbuntuVersion) IsOverridden() bool {
+	return u != ""
 }


### PR DESCRIPTION
Previously roachtests were running on Ubuntu 20. However,
most of our customers likely run on Ubuntu 22. Using Ubuntu
22 should better reflect the enviroment our customers
are working in.

However, a few roachtests are unable to run on Ubuntu 22 as is,
so a new Cluster.spec option, UbuntuVersion, was added to let
those tests temporarily run on Ubuntu 20 until fixed.

Epic: CRDB-30962
Fixes: https://github.com/cockroachdb/cockroach/issues/109519
Release note: None