### PR TITLE
sqlproxyccl: fix test scripts

### DIFF
--- a/pkg/ccl/sqlproxyccl/run_proxy_direct_crdb.sh
+++ b/pkg/ccl/sqlproxyccl/run_proxy_direct_crdb.sh
@@ -95,6 +95,6 @@ $COCKROACH mt start-proxy  --listen-addr=localhost:$PROXY_P --listen-cert=* --li
 
 echo "All files are in $BASE"
 echo "To connect:"
-echo "  $COCKROACH sql --url=\"postgresql://root:secret@127.0.0.1:$PROXY_P?sslmode=require&sslrootcert=a&options=--cluster%3Dtenant-cluster-123\""
+echo "  $COCKROACH sql --url=\"postgresql://root:secret@127.0.0.1:$PROXY_P?sslmode=require&options=--cluster%3Dtenant-cluster-123\""
 echo "Press any key to shutdown all processes and cleanup."
 read -r

--- a/pkg/ccl/sqlproxyccl/run_proxy_indirect_crdb.sh
+++ b/pkg/ccl/sqlproxyccl/run_proxy_indirect_crdb.sh
@@ -55,9 +55,6 @@ mv "$TENANT"/ca-client-tenant.crt "$TENANT"/ca.crt
 cp "$TENANT"/ca.crt "$HOST"/ca-client-tenant.crt
 cat "$HOST"/ca.crt >> "$TENANT"/ca.crt
 
-echo Create client tenant root cert
-COCKROACH_CA_KEY=$TENANT/ca.key COCKROACH_CERTS_DIR=$TENANT $COCKROACH cert create-client root
-
 echo Start KV layer
 $COCKROACH start-single-node --listen-addr=localhost:$HOST_P --http-addr=:$HOST_HTTP_P --background --certs-dir="$HOST" --store="$HOST"/store
 
@@ -72,6 +69,6 @@ $COCKROACH mt start-proxy  --listen-addr=localhost:$PROXY_P --listen-cert=* --li
 
 echo "All files are in $BASE"
 echo "To connect to a specific tenant (123 for example):"
-echo "  $COCKROACH sql --url=\"postgresql://root:secret@127.0.0.1:$PROXY_P?sslmode=require&sslrootcert=a&options=--cluster%3Dtenant-cluster-123\""
+echo "  $COCKROACH sql --url=\"postgresql://root:secret@127.0.0.1:$PROXY_P?sslmode=require&options=--cluster=tenant-cluster-123\""
 echo "Press any key to shutdown all processes and cleanup."
 read -r

--- a/pkg/ccl/sqlproxyccl/run_tenant.sh
+++ b/pkg/ccl/sqlproxyccl/run_tenant.sh
@@ -53,8 +53,11 @@ $COCKROACH mt start-sql --certs-dir="$TENANT" --store="$TENANT"/$TENANT_ID/"$ORD
 
 if [ "$PASSWORD_UNSET" -eq "1" ]
 then
+  echo Create root user cert for the tenant
+  COCKROACH_CA_KEY=$TENANT/ca.key COCKROACH_CERTS_DIR=$TENANT cockroach cert create-client root --tenant-scope=$TENANT_ID
+  mv $TENANT/client.root.* $TENANT/$TENANT_ID/
   echo Set the password
-  COCKROACH_CA_KEY=$TENANT/ca.key COCKROACH_CERTS_DIR=$TENANT $COCKROACH sql --host=$SQL_ADDR -e "alter user root with password 'secret'" > "$TENANT"/$TENANT_ID/alter_root.log
+  COCKROACH_CERTS_DIR=$TENANT/$TENANT_ID $COCKROACH sql --url="postgres://root@$SQL_ADDR?sslmode=verify-full&sslrootcert=$TENANT/ca.crt" -e "alter user root with password 'secret'" > "$TENANT"/$TENANT_ID/alter_root.log 2>&1
 fi
 
 wait


### PR DESCRIPTION
This PR fixes the test scripts used by developers to quickly setup a multitenant test environment. The changes in cockroachdb since these were created broke them.

Epic: none

Release note: None