### PR TITLE
roachprod: fix createTenantCertBundle script

### DIFF
--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -1548,9 +1548,9 @@ if [[ $VERSION = v22 ]]; then
 fi
 %[1]s cert create-node %[2]s $SHARED_ARGS
 %[1]s cert create-tenant-client %[3]d %[2]s $SHARED_ARGS
-+%[1]s cert create-client root $TENANT_SCOPE_OPT $SHARED_ARGS
-+%[1]s cert create-client testuser $TENANT_SCOPE_OPT $SHARED_ARGS
-+tar cvf %[4]s $CERT_DIR
+%[1]s cert create-client root $TENANT_SCOPE_OPT $SHARED_ARGS
+%[1]s cert create-client testuser $TENANT_SCOPE_OPT $SHARED_ARGS
+tar cvf %[4]s $CERT_DIR
 `,
 			cockroachNodeBinary(c, node),
 			strings.Join(nodeNames, " "),


### PR DESCRIPTION
The `createTenantCertBundle` function has a script in it that has erroneous "+" characters which results in an error when trying to start a secure cluster. This change removes those characters.

Epic: None
Release Note: None