### PR TITLE
kv/spanset: permit writes to lock table by shared lock latching configuration

### DIFF
--- a/pkg/kv/kvserver/spanset/BUILD.bazel
+++ b/pkg/kv/kvserver/spanset/BUILD.bazel
@@ -33,6 +33,7 @@ go_test(
     embed = [":spanset"],
     deps = [
         "//pkg/keys",
+        "//pkg/kv/kvserver/concurrency/lock",
         "//pkg/roachpb",
         "//pkg/storage",
         "//pkg/testutils",

--- a/pkg/kv/kvserver/spanset/batch_test.go
+++ b/pkg/kv/kvserver/spanset/batch_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/lock"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/spanset"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
@@ -46,13 +47,31 @@ func TestReadWriterDeclareLockTable(t *testing.T) {
 		},
 	}
 	for fnName, fn := range fns {
-		for _, sa := range []spanset.SpanAccess{spanset.SpanReadOnly, spanset.SpanReadWrite} {
+		for _, str := range []lock.Strength{lock.None, lock.Shared, lock.Exclusive, lock.Intent} {
 			for _, mvcc := range []bool{false, true} {
-				t.Run(fmt.Sprintf("%s,access=%s,mvcc=%t", fnName, sa, mvcc), func(t *testing.T) {
+				if !mvcc && (str == lock.Shared || str == lock.Exclusive) {
+					// Invalid combination.
+					continue
+				}
+				t.Run(fmt.Sprintf("%s,strength=%s,mvcc=%t", fnName, str, mvcc), func(t *testing.T) {
 					span := roachpb.Span{Key: startKey, EndKey: endKey}
+					var sa spanset.SpanAccess
+					var latchTs hlc.Timestamp
+					switch str {
+					case lock.None:
+						sa, latchTs = spanset.SpanReadOnly, ts
+					case lock.Shared:
+						sa, latchTs = spanset.SpanReadOnly, hlc.MaxTimestamp
+					case lock.Exclusive:
+						sa, latchTs = spanset.SpanReadWrite, ts
+					case lock.Intent:
+						sa, latchTs = spanset.SpanReadWrite, ts
+					default:
+						t.Fatal("unexpected")
+					}
 					ss := spanset.New()
 					if mvcc {
-						ss.AddMVCC(sa, span, ts)
+						ss.AddMVCC(sa, span, latchTs)
 					} else {
 						ss.AddNonMVCC(sa, span)
 					}
@@ -64,10 +83,10 @@ func TestReadWriterDeclareLockTable(t *testing.T) {
 					require.Error(t, rw.MVCCIterate(ltEndKey, ltEndKey.Next(), storage.MVCCKeyIterKind, storage.IterKeyTypePointsOnly, nil))
 
 					err := rw.PutUnversioned(ltStartKey, []byte("value"))
-					if sa == spanset.SpanReadWrite {
-						require.NoError(t, err)
-					} else {
+					if str == lock.None {
 						require.Error(t, err)
+					} else {
+						require.NoError(t, err)
 					}
 					require.Error(t, rw.PutUnversioned(ltEndKey, []byte("value")))
 				})


### PR DESCRIPTION
Fixes #111409.
Fixes #111492.

This commit updates addLockTableSpans to account for the way that shared locking requests declare their latches. Even though they declare a "read" latch, they do so at max timestamp, which gives them sufficient isolation to write to the lock table without having to declare a write latch and be serialized with other shared lock acquisitions.

Release note: None