### PR TITLE
roachtest/cdc: add vmodule=1 for parquet roachtest

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -654,6 +654,9 @@ func (ca *changeAggregator) Next() (rowenc.EncDatumRow, *execinfrapb.ProducerMet
 				// If the poller errored first, that's the
 				// interesting one, so overwrite `err`.
 				if kvFeedErr := ca.checkKVFeedErr(); kvFeedErr != nil {
+					if log.V(1) {
+						log.Infof(ca.Ctx(), "overwriting error %s", err)
+					}
 					err = kvFeedErr
 				}
 			}
@@ -1386,6 +1389,9 @@ func (cf *changeFrontier) forwardFrontier(resolved jobspb.ResolvedSpan) error {
 		return err
 	}
 
+	if log.V(1) {
+		log.Infof(cf.Ctx(), "forwarding frontier. changed: %t, resolved: %s", frontierChanged, resolved)
+	}
 	cf.maybeLogBehindSpan(frontierChanged)
 
 	// If frontier changed, we emit resolved timestamp.
@@ -1472,12 +1478,21 @@ func (cf *changeFrontier) maybeCheckpointJob(
 		checkpoint.Spans, checkpoint.Timestamp = cf.frontier.getCheckpointSpans(maxBytes)
 	}
 
+	if log.V(1) {
+		log.Infof(cf.Ctx(), "maybe checkpointing job. updateCheckpoint: %t, updateHighWater: %t",
+			updateCheckpoint, updateHighWater)
+	}
+
 	if updateCheckpoint || updateHighWater {
 		if cf.knobs.ShouldCheckpointToJobRecord != nil && !cf.knobs.ShouldCheckpointToJobRecord(cf.frontier.Frontier()) {
 			return false, nil
 		}
 		checkpointStart := timeutil.Now()
 		updated, err := cf.checkpointJobProgress(cf.frontier.Frontier(), checkpoint)
+		if log.V(1) {
+			log.Infof(cf.Ctx(), "checkpointed job progress: updated: %t, highwater: %s, err: %v",
+				updated, cf.frontier.Frontier(), err)
+		}
 		if err != nil {
 			return false, err
 		}

--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -1064,6 +1064,11 @@ func registerCDC(r registry.Registry) {
 		CompatibleClouds: registry.AllExceptAWS,
 		Suites:           registry.Suites(registry.Nightly),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			vmoduleLevel = 1
+			defer func() {
+				vmoduleLevel = 0
+			}()
+
 			ct := newCDCTester(ctx, t, c)
 			defer ct.Close()
 

--- a/pkg/cmd/roachtest/tests/cdc_bench.go
+++ b/pkg/cmd/roachtest/tests/cdc_bench.go
@@ -166,6 +166,8 @@ func formatSI(num int64) string {
 	return fmt.Sprintf("%d%s", int64(numSI), suffix)
 }
 
+var vmoduleLevel = 0
+
 // makeCDCBenchOptions creates common cluster options for CDC benchmarks.
 func makeCDCBenchOptions() (option.StartOpts, install.ClusterSettings) {
 	opts := option.DefaultStartOpts()
@@ -220,6 +222,10 @@ func makeCDCBenchOptions() (option.StartOpts, install.ClusterSettings) {
 	// due to elevated goroutine scheduling latency.
 	// Current default is 4s which should be sufficient.
 	// settings.Env = append(settings.Env, "COCKROACH_NETWORK_TIMEOUT=6s")
+
+	if vmoduleLevel > 0 {
+		opts.RoachprodOpts.ExtraArgs = []string{"--vmodule=changefeed_processors=2"}
+	}
 
 	return opts, settings
 }


### PR DESCRIPTION
https://github.com/cockroachdb/cockroach/issues/111495 shows that the roachtest is not correctly setting the highwater when the initial scan finishes. This change adds some v-logging and vmodule=1 for the roachtest.

Release note: None
Epic: None