### PR TITLE
roachprod: support managing shared process virtual clusters

### DIFF
--- a/pkg/cmd/roachprod/flags.go
+++ b/pkg/cmd/roachprod/flags.go
@@ -49,7 +49,6 @@ var (
 	secure                = false
 	virtualClusterName    string
 	sqlInstance           int
-	virtualClusterID      int
 	extraSSHOptions       = ""
 	nodeEnv               []string
 	tag                   string
@@ -214,8 +213,6 @@ Default is "RECURRING '*/15 * * * *' FULL BACKUP '@hourly' WITH SCHEDULE OPTIONS
 
 	startInstanceCmd.Flags().StringVarP(&storageCluster, "storage-cluster", "S", "", "storage cluster")
 	_ = startInstanceCmd.MarkFlagRequired("storage-cluster")
-	startInstanceCmd.Flags().IntVarP(&startOpts.VirtualClusterID,
-		"cluster-id", "i", startOpts.VirtualClusterID, "internal ID for the virtual cluster")
 	startInstanceCmd.Flags().IntVar(&startOpts.SQLInstance,
 		"sql-instance", 0, "specific SQL/HTTP instance to connect to (this is a roachprod abstraction for separate-process deployments distinct from the internal instance ID)")
 	startInstanceCmd.Flags().StringVar(&externalProcessNodes, "external-cluster", externalProcessNodes, "start service in external mode, as a separate process in the given nodes")
@@ -226,9 +223,6 @@ Default is "RECURRING '*/15 * * * *' FULL BACKUP '@hourly' WITH SCHEDULE OPTIONS
 		stopProcessesCmd.Flags().BoolVar(&waitFlag, "wait", waitFlag, "wait for processes to exit")
 		stopProcessesCmd.Flags().IntVar(&maxWait, "max-wait", maxWait, "approx number of seconds to wait for processes to exit")
 	}
-
-	stopInstanceCmd.Flags().IntVarP(&virtualClusterID, "cluster-id", "t", virtualClusterID, "internal ID for the virtual cluster")
-	stopInstanceCmd.Flags().IntVar(&sqlInstance, "sql-instance", 0, "specific SQL/HTTP instance to stop")
 
 	syncCmd.Flags().BoolVar(&listOpts.IncludeVolumes, "include-volumes", false, "Include volumes when syncing")
 
@@ -367,7 +361,7 @@ Default is "RECURRING '*/15 * * * *' FULL BACKUP '@hourly' WITH SCHEDULE OPTIONS
 		cmd.Flags().BoolVar(&secure,
 			"secure", false, "use a secure cluster")
 	}
-	for _, cmd := range []*cobra.Command{pgurlCmd, sqlCmd, adminurlCmd} {
+	for _, cmd := range []*cobra.Command{pgurlCmd, sqlCmd, adminurlCmd, stopInstanceCmd} {
 		cmd.Flags().StringVar(&virtualClusterName,
 			"cluster", "", "specific virtual cluster to connect to")
 		cmd.Flags().IntVar(&sqlInstance,

--- a/pkg/cmd/roachprod/flags.go
+++ b/pkg/cmd/roachprod/flags.go
@@ -221,14 +221,14 @@ Default is "RECURRING '*/15 * * * *' FULL BACKUP '@hourly' WITH SCHEDULE OPTIONS
 	startInstanceCmd.Flags().StringVar(&externalProcessNodes, "external-cluster", externalProcessNodes, "start service in external mode, as a separate process in the given nodes")
 
 	// Flags for processes that stop (kill) processes.
-	for _, stopProcessesCmd := range []*cobra.Command{stopCmd, stopInstanceAsSeparateProcessCmd} {
+	for _, stopProcessesCmd := range []*cobra.Command{stopCmd, stopInstanceCmd} {
 		stopProcessesCmd.Flags().IntVar(&sig, "sig", sig, "signal to pass to kill")
 		stopProcessesCmd.Flags().BoolVar(&waitFlag, "wait", waitFlag, "wait for processes to exit")
 		stopProcessesCmd.Flags().IntVar(&maxWait, "max-wait", maxWait, "approx number of seconds to wait for processes to exit")
 	}
 
-	stopInstanceAsSeparateProcessCmd.Flags().IntVarP(&virtualClusterID, "cluster-id", "t", virtualClusterID, "internal ID for the virtual cluster")
-	stopInstanceAsSeparateProcessCmd.Flags().IntVar(&sqlInstance, "sql-instance", 0, "specific SQL/HTTP instance to stop")
+	stopInstanceCmd.Flags().IntVarP(&virtualClusterID, "cluster-id", "t", virtualClusterID, "internal ID for the virtual cluster")
+	stopInstanceCmd.Flags().IntVar(&sqlInstance, "sql-instance", 0, "specific SQL/HTTP instance to stop")
 
 	syncCmd.Flags().BoolVar(&listOpts.IncludeVolumes, "include-volumes", false, "Include volumes when syncing")
 

--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -526,7 +526,7 @@ SIGHUP), unless you also configure --max-wait.
 }
 
 var startInstanceCmd = &cobra.Command{
-	Use:   "start-sql --storage-cluster <storage-cluster> [--external-cluster <virtual-cluster-nodes]",
+	Use:   "start-sql <name> --storage-cluster <storage-cluster> [--external-cluster <virtual-cluster-nodes]",
 	Short: "start the SQL/HTTP service for a virtual cluster as a separate process",
 	Long: `Start SQL/HTTP instances for a virtual cluster as separate processes.
 
@@ -535,8 +535,6 @@ The --storage-cluster flag must be used to specify a storage cluster
 will create the virtual cluster on the storage cluster if it does not
 exist already.  If creating multiple virtual clusters on the same
 node, the --sql-instance flag must be passed to differentiate them.
-
-The --cluster-id flag can be used to specify the tenant ID; it defaults to 2.
 
 The instance is started in shared process (in memory) mode by
 default. To start an external process instance, pass the
@@ -560,7 +558,7 @@ The --args and --env flags can be used to pass arbitrary command line flags and
 environment variables to the cockroach process.
 ` + tagHelp + `
 `,
-	Args: cobra.NoArgs,
+	Args: cobra.ExactArgs(1),
 	Run: wrap(func(cmd *cobra.Command, args []string) error {
 		clusterSettingsOpts := []install.ClusterSettingOption{
 			install.TagOption(tag),
@@ -586,13 +584,14 @@ environment variables to the cockroach process.
 			startOpts.Target = install.StartServiceForVirtualCluster
 		}
 
+		startOpts.VirtualClusterName = args[0]
 		return roachprod.StartServiceForVirtualCluster(context.Background(),
 			config.Logger, externalProcessNodes, storageCluster, startOpts, clusterSettingsOpts...)
 	}),
 }
 
 var stopInstanceCmd = &cobra.Command{
-	Use:   "stop-sql <cluster> --cluster-id <id> --sql-instance <instance> [--sig] [--wait]",
+	Use:   "stop-sql <cluster> --cluster <name> --sql-instance <instance> [--sig] [--wait]",
 	Short: "stop sql instances on a cluster",
 	Long: `Stop sql instances on a cluster.
 
@@ -614,11 +613,11 @@ non-terminating signal (e.g. SIGHUP), unless you also configure --max-wait.
 			wait = true
 		}
 		stopOpts := roachprod.StopOpts{
-			Wait:             wait,
-			MaxWait:          maxWait,
-			Sig:              sig,
-			VirtualClusterID: virtualClusterID,
-			SQLInstance:      sqlInstance,
+			Wait:               wait,
+			MaxWait:            maxWait,
+			Sig:                sig,
+			VirtualClusterName: virtualClusterName,
+			SQLInstance:        sqlInstance,
 		}
 		clusterName := args[0]
 		return roachprod.StopServiceForVirtualCluster(context.Background(), config.Logger, clusterName, stopOpts)

--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -591,22 +591,19 @@ environment variables to the cockroach process.
 	}),
 }
 
-var stopInstanceAsSeparateProcessCmd = &cobra.Command{
-	Use:   "stop-sql <virtual-cluster> --tenant-id <id> --sql-instance <instance> [--sig] [--wait]",
+var stopInstanceCmd = &cobra.Command{
+	Use:   "stop-sql <cluster> --cluster-id <id> --sql-instance <instance> [--sig] [--wait]",
 	Short: "stop sql instances on a cluster",
 	Long: `Stop sql instances on a cluster.
 
-Stop roachprod created sql instances running on the nodes in a cluster. Every
-process started by roachprod is tagged with a ROACHPROD environment variable
-which is used by "stop-sql" to locate the processes and terminate them. By default,
-processes are killed with signal 9 (SIGKILL) giving them no chance for a graceful
-exit.
+Stop roachprod created virtual clusters (shared or separate process). By default,
+separate processes are killed with signal 9 (SIGKILL) giving them no chance for a
+graceful exit.
 
 The --sig flag will pass a signal to kill to allow us finer control over how we
 shutdown processes. The --wait flag causes stop to loop waiting for all
-processes with the right ROACHPROD environment variable to exit. Note that stop
-will wait forever if you specify --wait with a non-terminating signal (e.g.
-SIGHUP), unless you also configure --max-wait.
+processes to exit. Note that stop will wait forever if you specify --wait with a
+non-terminating signal (e.g. SIGHUP), unless you also configure --max-wait.
 
 --wait defaults to true for signal 9 (SIGKILL) and false for all other signals.
 `,
@@ -623,8 +620,8 @@ SIGHUP), unless you also configure --max-wait.
 			VirtualClusterID: virtualClusterID,
 			SQLInstance:      sqlInstance,
 		}
-		virtualCluster := args[0]
-		return roachprod.StopServiceForVirtualCluster(context.Background(), config.Logger, virtualCluster, stopOpts)
+		clusterName := args[0]
+		return roachprod.StopServiceForVirtualCluster(context.Background(), config.Logger, clusterName, stopOpts)
 	}),
 }
 
@@ -1418,7 +1415,7 @@ func main() {
 		startCmd,
 		stopCmd,
 		startInstanceCmd,
-		stopInstanceAsSeparateProcessCmd,
+		stopInstanceCmd,
 		initCmd,
 		runCmd,
 		signalCmd,

--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -528,7 +528,7 @@ SIGHUP), unless you also configure --max-wait.
 // TODO(herko/renato): maybe also support adding SQL instances to a
 // shared-process node.
 var startInstanceAsSeparateProcessCmd = &cobra.Command{
-	Use:   "start-sql <virtual-cluster> --storage-cluster <storage-cluster>",
+	Use:   "start-sql <virtual-cluster-nodes> --storage-cluster <storage-cluster>",
 	Short: "start the SQL/HTTP service for a virtual cluster as a separate process",
 	Long: `Start SQL/HTTP instances for a virtual cluster as separate processes.
 
@@ -538,7 +538,7 @@ will create the virtual cluster on the storage cluster if it does not
 exist already.  If creating multiple virtual clusters on the same
 node, the --sql-instance flag must be passed to differentiate them.
 
-The --tenant-id flag can be used to specify the tenant ID; it defaults to 2.
+The --cluster-id flag can be used to specify the tenant ID; it defaults to 2.
 
 The --secure flag can be used to start nodes in secure mode (i.e. using
 certs). When specified, there is a one time initialization for the cluster to

--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -2925,7 +2925,7 @@ func (c *SyncedCluster) Init(ctx context.Context, l *logger.Logger, node Node) e
 		return errors.WithDetail(errors.CombineErrors(err, res.Err), "install.Init() failed: unable to initialize cluster.")
 	}
 
-	if res, err := c.setClusterSettings(ctx, l, node); err != nil || (res != nil && res.Err != nil) {
+	if res, err := c.setClusterSettings(ctx, l, node, ""); err != nil || (res != nil && res.Err != nil) {
 		return errors.WithDetail(errors.CombineErrors(err, res.Err), "install.Init() failed: unable to set cluster settings.")
 	}
 

--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -2543,11 +2543,7 @@ func (c *SyncedCluster) pgurls(
 		if err != nil {
 			return nil, err
 		}
-		sharedClusterName := ""
-		if desc.ServiceMode == ServiceModeShared {
-			sharedClusterName = virtualClusterName
-		}
-		m[node] = c.NodeURL(host, desc.Port, sharedClusterName)
+		m[node] = c.NodeURL(host, desc.Port, virtualClusterName, desc.ServiceMode)
 	}
 	return m, nil
 }

--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -1693,7 +1693,7 @@ tar cvf %[3]s certs
 // DistributeTenantCerts will generate and distribute certificates to all of the
 // nodes, using the host cluster to generate tenant certificates.
 func (c *SyncedCluster) DistributeTenantCerts(
-	ctx context.Context, l *logger.Logger, hostCluster *SyncedCluster, tenantID int,
+	ctx context.Context, l *logger.Logger, hostCluster *SyncedCluster, virtualClusterID int,
 ) error {
 	if hostCluster.checkForTenantCertificates(ctx, l) {
 		return nil
@@ -1708,7 +1708,7 @@ func (c *SyncedCluster) DistributeTenantCerts(
 		return err
 	}
 
-	if err := hostCluster.createTenantCertBundle(ctx, l, tenantCertsTarName, tenantID, nodeNames); err != nil {
+	if err := hostCluster.createTenantCertBundle(ctx, l, tenantCertsTarName, virtualClusterID, nodeNames); err != nil {
 		return err
 	}
 
@@ -1727,7 +1727,11 @@ func (c *SyncedCluster) DistributeTenantCerts(
 // This function assumes it is running on a host cluster node that already has
 // had the main cert bundle created.
 func (c *SyncedCluster) createTenantCertBundle(
-	ctx context.Context, l *logger.Logger, bundleName string, tenantID int, nodeNames []string,
+	ctx context.Context,
+	l *logger.Logger,
+	bundleName string,
+	virtualClusterID int,
+	nodeNames []string,
 ) error {
 	display := fmt.Sprintf("%s: initializing tenant certs", c.Name)
 	return c.Parallel(ctx, l, c.Nodes[0:1], func(ctx context.Context, node Node) (*RunResultDetails, error) {
@@ -1757,7 +1761,7 @@ tar cvf %[4]s $CERT_DIR
 `,
 			cockroachNodeBinary(c, node),
 			strings.Join(nodeNames, " "),
-			tenantID,
+			virtualClusterID,
 			bundleName,
 		)
 

--- a/pkg/roachprod/install/cockroach.go
+++ b/pkg/roachprod/install/cockroach.go
@@ -476,8 +476,9 @@ func (c *SyncedCluster) ExecOrInteractiveSQL(
 	return c.SSH(ctx, l, []string{"-t"}, allArgs)
 }
 
-// ExecSQL runs a `cockroach sql` .
-// It is assumed that the args include the -e flag.
+// ExecSQL runs a `cockroach sql` and returns the output.  If the call
+// is intended to run a SQL statement, the caller must pass the "-e"
+// (or "--execute") flag explicitly.
 func (c *SyncedCluster) ExecSQL(
 	ctx context.Context,
 	l *logger.Logger,
@@ -485,7 +486,7 @@ func (c *SyncedCluster) ExecSQL(
 	virtualClusterName string,
 	sqlInstance int,
 	args []string,
-) error {
+) ([]*RunResultDetails, error) {
 	display := fmt.Sprintf("%s: executing sql", c.Name)
 	results, _, err := c.ParallelE(ctx, l, nodes, func(ctx context.Context, node Node) (*RunResultDetails, error) {
 		desc, err := c.DiscoverService(ctx, node, virtualClusterName, ServiceTypeSQL, sqlInstance)
@@ -507,15 +508,7 @@ func (c *SyncedCluster) ExecSQL(
 		return c.runCmdOnSingleNode(ctx, l, node, cmd, defaultCmdOpts("run-sql"))
 	}, WithDisplay(display), WithWaitOnFail())
 
-	if err != nil {
-		return err
-	}
-
-	for _, r := range results {
-		l.Printf("node %d:\n%s", r.Node, r.CombinedOut)
-	}
-
-	return nil
+	return results, err
 }
 
 func (c *SyncedCluster) startNode(

--- a/pkg/roachprod/install/cockroach.go
+++ b/pkg/roachprod/install/cockroach.go
@@ -37,6 +37,14 @@ import (
 //go:embed scripts/start.sh
 var startScript string
 
+// sharedProcessVirtualClusterNode is a constant node that is used
+// whenever we register a service descriptor for a shared-process
+// virtual cluster. Since these virtual clusters use the system
+// interface process, the service descriptor just represents the
+// existence of the virtual cluster; at service discovery time, ports
+// are resolved based on existing services for the system interface.
+var sharedProcessVirtualClusterNode = Node(1)
+
 func cockroachNodeBinary(c *SyncedCluster, node Node) string {
 	if filepath.IsAbs(c.Binary) {
 		return c.Binary
@@ -133,6 +141,10 @@ type StartOpts struct {
 	KVCluster          *SyncedCluster
 }
 
+func (s *StartOpts) IsVirtualCluster() bool {
+	return s.Target == StartSharedProcessForVirtualCluster || s.Target == StartServiceForVirtualCluster
+}
+
 // startSQLTimeout identifies the COCKROACH_CONNECT_TIMEOUT to use (in seconds)
 // for sql cmds within syncedCluster.Start().
 const startSQLTimeout = 1200
@@ -143,6 +155,9 @@ type StartTarget int
 const (
 	// StartDefault starts a "full" (KV+SQL) node (the default).
 	StartDefault StartTarget = iota
+	// StartSharedProcessForVirtualCluster starts an in-memory tenant
+	// (shared process) for a virtual cluster.
+	StartSharedProcessForVirtualCluster
 	// StartServiceForVirtualCluster starts a SQL/HTTP-only server
 	// process for a virtual cluster.
 	StartServiceForVirtualCluster
@@ -196,23 +211,67 @@ func (c *SyncedCluster) maybeRegisterServices(
 	if err != nil {
 		return err
 	}
-	virtualClusterName := SystemInterfaceName
-	serviceMode := ServiceModeShared
-	if startOpts.Target == StartServiceForVirtualCluster {
-		virtualClusterName = startOpts.VirtualClusterName
-		serviceMode = ServiceModeExternal
+
+	var servicesToRegister ServiceDescriptors
+	switch startOpts.Target {
+	case StartDefault:
+		startOpts.VirtualClusterName = SystemInterfaceName
+		servicesToRegister, err = c.servicesWithOpenPortSelection(
+			ctx, l, startOpts, ServiceModeShared, serviceMap,
+		)
+	case StartSharedProcessForVirtualCluster:
+		// Specifying a sql instance for shared process virtual clusters
+		// doesn't make sense, so return an error in that case to make it
+		// explicit.
+		if startOpts.SQLInstance != 0 {
+			err = fmt.Errorf("sql instance must be unset for shared process deployments")
+			break
+		}
+
+		for _, serviceType := range []ServiceType{ServiceTypeSQL, ServiceTypeUI} {
+			if _, ok := serviceMap[sharedProcessVirtualClusterNode][serviceType]; !ok {
+				servicesToRegister = append(servicesToRegister, ServiceDesc{
+					VirtualClusterName: startOpts.VirtualClusterName,
+					ServiceType:        serviceType,
+					ServiceMode:        ServiceModeShared,
+					Node:               sharedProcessVirtualClusterNode,
+				})
+			}
+		}
+	case StartServiceForVirtualCluster:
+		servicesToRegister, err = c.servicesWithOpenPortSelection(
+			ctx, l, startOpts, ServiceModeExternal, serviceMap,
+		)
 	}
 
-	mu := syncutil.Mutex{}
-	servicesToRegister := make(ServiceDescriptors, 0)
-	err = c.Parallel(ctx, l, c.Nodes, func(ctx context.Context, node Node) (*RunResultDetails, error) {
+	if err != nil {
+		return err
+	}
+	return c.RegisterServices(ctx, servicesToRegister)
+}
+
+// servicesWithOpenPortSelection returns services to be registered for
+// cases where a new cockroach process is being instantiated and needs
+// to being to available ports. This happens when we start the system
+// interface process, or when we start SQL servers for separate
+// process virtual clusters.
+func (c *SyncedCluster) servicesWithOpenPortSelection(
+	ctx context.Context,
+	l *logger.Logger,
+	startOpts StartOpts,
+	serviceMode ServiceMode,
+	serviceMap NodeServiceMap,
+) (ServiceDescriptors, error) {
+	var mu syncutil.Mutex
+	var servicesToRegister ServiceDescriptors
+	err := c.Parallel(ctx, l, c.Nodes, func(ctx context.Context, node Node) (*RunResultDetails, error) {
 		services := make(ServiceDescriptors, 0)
 		res := &RunResultDetails{Node: node}
 		if _, ok := serviceMap[node][ServiceTypeSQL]; !ok {
 			services = append(services, ServiceDesc{
-				VirtualClusterName: virtualClusterName,
+				VirtualClusterName: startOpts.VirtualClusterName,
 				ServiceType:        ServiceTypeSQL,
-				ServiceMode:        serviceMode,
+				ServiceMode:        ServiceModeExternal,
 				Node:               node,
 				Port:               startOpts.SQLPort,
 				Instance:           startOpts.SQLInstance,
@@ -220,9 +279,9 @@ func (c *SyncedCluster) maybeRegisterServices(
 		}
 		if _, ok := serviceMap[node][ServiceTypeUI]; !ok {
 			services = append(services, ServiceDesc{
-				VirtualClusterName: virtualClusterName,
+				VirtualClusterName: startOpts.VirtualClusterName,
 				ServiceType:        ServiceTypeUI,
-				ServiceMode:        serviceMode,
+				ServiceMode:        ServiceModeExternal,
 				Node:               node,
 				Port:               startOpts.AdminUIPort,
 				Instance:           startOpts.SQLInstance,
@@ -248,9 +307,6 @@ func (c *SyncedCluster) maybeRegisterServices(
 				openPorts = openPorts[1:]
 			}
 		}
-		if err != nil {
-			return nil, err
-		}
 
 		mu.Lock()
 		defer mu.Unlock()
@@ -258,12 +314,17 @@ func (c *SyncedCluster) maybeRegisterServices(
 		return res, nil
 	})
 	if err != nil {
-		return err
+		return nil, fmt.Errorf("failed to find services to register: %w", err)
 	}
-	return c.RegisterServices(ctx, servicesToRegister)
+
+	return servicesToRegister, nil
 }
 
-// Start the cockroach process on the cluster.
+// Start cockroach on the cluster. For non-multitenant deployments or
+// SQL instances that are deployed as external services, this will
+// start a cockroach process on the nodes. For shared-process
+// virtualization, this creates the virtual cluster metadata (if
+// necessary) but does not create any new processes.
 //
 // Starting the first node is special-cased quite a bit, it's used to distribute
 // certs, set cluster settings, and initialize the cluster. Also, if we're only
@@ -293,19 +354,14 @@ func (c *SyncedCluster) Start(ctx context.Context, l *logger.Logger, startOpts S
 		return err
 	}
 
-	switch startOpts.Target {
-	case StartDefault:
-		if err := c.distributeCerts(ctx, l); err != nil {
+	if startOpts.IsVirtualCluster() {
+		if err := c.createVirtualClusterMetadata(ctx, l, startOpts); err != nil {
 			return err
 		}
-	case StartServiceForVirtualCluster:
-		if err := c.createTenantMetadata(ctx, l, startOpts.VirtualClusterName, startOpts.KVCluster); err != nil {
-			return err
-		}
+	}
 
-		if err := c.distributeTenantCerts(ctx, l, startOpts.KVCluster, startOpts.VirtualClusterID); err != nil {
-			return err
-		}
+	if err := c.distributeTenantCerts(ctx, l, startOpts.KVCluster, startOpts.VirtualClusterID); err != nil {
+		return err
 	}
 
 	nodes := c.TargetNodes()
@@ -326,26 +382,25 @@ func (c *SyncedCluster) Start(ctx context.Context, l *logger.Logger, startOpts S
 			return res, err
 		}
 
-		// Code that follows applies only for regular nodes.
 		// We reserve a few special operations (bootstrapping, and setting
 		// cluster settings) to the InitTarget.
-		if startOpts.Target != StartDefault || startOpts.GetInitTarget() != node || startOpts.SkipInit {
-			return res, nil
+		if startOpts.Target == StartDefault {
+			if startOpts.GetInitTarget() != node || startOpts.SkipInit {
+				return res, nil
+			}
 		}
 
-		// NB: The code blocks below are not parallelized, so it's safe for us
-		// to use fmt.Printf style logging.
-
-		// For single node clusters, this can be skipped because during the c.StartNode call above,
-		// the `--start-single-node` flag will handle all of this for us.
-		shouldInit := !c.useStartSingleNode()
+		// For single node non-virtual clusters, this can be skipped
+		// because during the c.StartNode call above, the
+		// `--start-single-node` flag will handle all of this for us.
+		shouldInit := startOpts.Target == StartDefault && !c.useStartSingleNode()
 		if shouldInit {
 			if res, err := c.initializeCluster(ctx, l, node); err != nil || res.Err != nil {
 				// If err is non-nil, then this will not be retried, but if res.Err is non-nil, it will be.
 				return res, err
 			}
 		}
-		return c.setClusterSettings(ctx, l, node)
+		return c.setClusterSettings(ctx, l, node, startOpts.VirtualClusterName)
 	}, WithConcurrency(parallelism)); err != nil {
 		return err
 	}
@@ -427,7 +482,7 @@ func (c *SyncedCluster) NodeURL(
 	} else {
 		v.Add("sslmode", "disable")
 	}
-	if serviceMode == ServiceModeShared && virtualClusterName != "" {
+	if serviceMode == ServiceModeShared && virtualClusterName != "" && virtualClusterName != "system" {
 		v.Add("options", fmt.Sprintf("-ccluster=%s", virtualClusterName))
 	}
 	u.RawQuery = v.Encode()
@@ -512,6 +567,10 @@ func (c *SyncedCluster) ExecSQL(
 func (c *SyncedCluster) startNode(
 	ctx context.Context, l *logger.Logger, node Node, startOpts StartOpts,
 ) (*RunResultDetails, error) {
+	if startOpts.Target == StartSharedProcessForVirtualCluster {
+		return &RunResultDetails{}, nil
+	}
+
 	startCmd, err := c.generateStartCmd(ctx, l, node, startOpts)
 	if err != nil {
 		return nil, err
@@ -871,10 +930,10 @@ func (c *SyncedCluster) initializeCluster(
 }
 
 func (c *SyncedCluster) setClusterSettings(
-	ctx context.Context, l *logger.Logger, node Node,
+	ctx context.Context, l *logger.Logger, node Node, virtualCluster string,
 ) (*RunResultDetails, error) {
 	l.Printf("%s: setting cluster settings", c.Name)
-	cmd, err := c.generateClusterSettingCmd(ctx, l, node)
+	cmd, err := c.generateClusterSettingCmd(ctx, l, node, virtualCluster)
 	if err != nil {
 		return nil, err
 	}
@@ -890,11 +949,16 @@ func (c *SyncedCluster) setClusterSettings(
 }
 
 func (c *SyncedCluster) generateClusterSettingCmd(
-	ctx context.Context, l *logger.Logger, node Node,
+	ctx context.Context, l *logger.Logger, node Node, virtualCluster string,
 ) (string, error) {
 	if config.CockroachDevLicense == "" {
 		l.Printf("%s: COCKROACH_DEV_LICENSE unset: enterprise features will be unavailable\n",
 			c.Name)
+	}
+
+	var tenantPrefix string
+	if virtualCluster != "" && virtualCluster != SystemInterfaceName {
+		tenantPrefix = fmt.Sprintf("ALTER TENANT '%s' ", virtualCluster)
 	}
 
 	clusterSettings := map[string]string{
@@ -906,7 +970,7 @@ func (c *SyncedCluster) generateClusterSettingCmd(
 	}
 	var clusterSettingsString string
 	for name, value := range clusterSettings {
-		clusterSettingsString += fmt.Sprintf("SET CLUSTER SETTING %s = '%s';\n", name, value)
+		clusterSettingsString += fmt.Sprintf("%sSET CLUSTER SETTING %s = '%s';\n", tenantPrefix, name, value)
 	}
 
 	var clusterSettingsCmd string
@@ -915,7 +979,11 @@ func (c *SyncedCluster) generateClusterSettingCmd(
 	}
 
 	binary := cockroachNodeBinary(c, node)
-	path := fmt.Sprintf("%s/%s", c.NodeDir(node, 1 /* storeIndex */), "settings-initialized")
+	var pathPrefix string
+	if virtualCluster != "" {
+		pathPrefix = fmt.Sprintf("%s_", virtualCluster)
+	}
+	path := fmt.Sprintf("%s/%ssettings-initialized", c.NodeDir(node, 1 /* storeIndex */), pathPrefix)
 	port, err := c.NodePort(ctx, node)
 	if err != nil {
 		return "", err
@@ -1010,25 +1078,28 @@ func (c *SyncedCluster) distributeCerts(ctx context.Context, l *logger.Logger) e
 	return nil
 }
 
-// createTenantMetadata creates the virtual cluster, if necessary. We
-// only need to run the statements in this function against a single
-// connection to the storage cluster.
-func (c *SyncedCluster) createTenantMetadata(
-	ctx context.Context, l *logger.Logger, virtualClusterName string, storageCluster *SyncedCluster,
+// createVirtualClusterMetadata creates the virtual cluster, if
+// necessary. We only need to run the statements in this function
+// against a single connection to the storage cluster.
+func (c *SyncedCluster) createVirtualClusterMetadata(
+	ctx context.Context, l *logger.Logger, startOpts StartOpts,
 ) error {
 	runSQL := func(stmt string) (string, error) {
-		results, err := storageCluster.ExecSQL(ctx, l, storageCluster.Nodes[:1], "", 0, []string{
+		results, err := startOpts.KVCluster.ExecSQL(ctx, l, startOpts.KVCluster.Nodes[:1], "", 0, []string{
 			"--format", "raw", "-e", stmt,
 		})
 		if err != nil {
 			return "", err
+		}
+		if results[0].Err != nil {
+			return "", results[0].Err
 		}
 
 		return results[0].CombinedOut, nil
 	}
 
 	tenantExistsQuery := fmt.Sprintf(
-		"SELECT 1 FROM system.tenants WHERE name = '%s'", virtualClusterName,
+		"SELECT 1 FROM system.tenants WHERE name = '%s'", startOpts.VirtualClusterName,
 	)
 
 	existsOut, err := runSQL(tenantExistsQuery)
@@ -1042,10 +1113,15 @@ func (c *SyncedCluster) createTenantMetadata(
 		return nil
 	}
 
-	l.Printf("Creating tenant metadata")
+	l.Printf("Creating virtual cluster metadata")
+	serviceMode := "SHARED"
+	if startOpts.Target == StartServiceForVirtualCluster {
+		serviceMode = "EXTERNAL"
+	}
+
 	createTenantStmts := []string{
-		fmt.Sprintf("CREATE TENANT '%s'", virtualClusterName),
-		fmt.Sprintf("ALTER TENANT '%s' START SERVICE EXTERNAL", virtualClusterName),
+		fmt.Sprintf("CREATE TENANT '%s'", startOpts.VirtualClusterName),
+		fmt.Sprintf("ALTER TENANT '%s' START SERVICE %s", startOpts.VirtualClusterName, serviceMode),
 	}
 
 	_, err = runSQL(strings.Join(createTenantStmts, "; "))

--- a/pkg/roachprod/multitenant.go
+++ b/pkg/roachprod/multitenant.go
@@ -80,16 +80,16 @@ func StartServiceForVirtualCluster(
 
 // StopServiceForVirtualCluster stops SQL instance processes on the virtualCluster given.
 func StopServiceForVirtualCluster(
-	ctx context.Context, l *logger.Logger, virtualCluster string, stopOpts StopOpts,
+	ctx context.Context, l *logger.Logger, clusterName string, stopOpts StopOpts,
 ) error {
-	tc, err := newCluster(l, virtualCluster)
+	c, err := newCluster(l, clusterName)
 	if err != nil {
 		return err
 	}
 
 	stopOpts.VirtualClusterName = defaultVirtualClusterName(stopOpts.VirtualClusterID)
-	vc := install.VirtualClusterLabel(stopOpts.VirtualClusterName, stopOpts.SQLInstance)
-	return tc.Stop(ctx, l, stopOpts.Sig, stopOpts.Wait, stopOpts.MaxWait, vc)
+	label := install.VirtualClusterLabel(stopOpts.VirtualClusterName, stopOpts.SQLInstance)
+	return c.Stop(ctx, l, stopOpts.Sig, stopOpts.Wait, stopOpts.MaxWait, label)
 }
 
 // defaultVirtualClusterName returns the virtual cluster name used for

--- a/pkg/roachprod/multitenant.go
+++ b/pkg/roachprod/multitenant.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
-	"github.com/cockroachdb/errors"
 )
 
 // StartServiceForVirtualCluster starts SQL/HTTP instances for a
@@ -67,11 +66,6 @@ func StartServiceForVirtualCluster(
 		startCluster = ec
 	}
 
-	if startOpts.VirtualClusterID < 2 {
-		return errors.Errorf("invalid virtual cluster ID %d (must be 2 or higher)", startOpts.VirtualClusterID)
-	}
-	startOpts.VirtualClusterName = defaultVirtualClusterName(startOpts.VirtualClusterID)
-
 	if startOpts.Target == install.StartServiceForVirtualCluster {
 		l.Printf("Starting SQL/HTTP instances for the virtual cluster")
 	}
@@ -87,15 +81,6 @@ func StopServiceForVirtualCluster(
 		return err
 	}
 
-	stopOpts.VirtualClusterName = defaultVirtualClusterName(stopOpts.VirtualClusterID)
 	label := install.VirtualClusterLabel(stopOpts.VirtualClusterName, stopOpts.SQLInstance)
 	return c.Stop(ctx, l, stopOpts.Sig, stopOpts.Wait, stopOpts.MaxWait, label)
-}
-
-// defaultVirtualClusterName returns the virtual cluster name used for
-// the virtual cluster with ID given.
-//
-// TODO(herko): Allow users to pass in a virtual cluster name.
-func defaultVirtualClusterName(virtualClusterID int) string {
-	return fmt.Sprintf("virtual-cluster-%d", virtualClusterID)
 }

--- a/pkg/roachprod/multitenant.go
+++ b/pkg/roachprod/multitenant.go
@@ -58,7 +58,7 @@ func StartServiceForVirtualCluster(
 	// Create virtual cluster, if necessary. We only need to run this
 	// SQL against a single connection to the storage cluster.
 	l.Printf("Creating tenant metadata")
-	if err := hc.ExecSQL(ctx, l, hc.Nodes[:1], "", 0, []string{
+	if _, err := hc.ExecSQL(ctx, l, hc.Nodes[:1], "", 0, []string{
 		`-e`,
 		fmt.Sprintf(createVirtualClusterIfNotExistsQuery, startOpts.VirtualClusterID),
 	}); err != nil {

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -950,7 +950,7 @@ func PgURL(
 		if ip == "" {
 			return nil, errors.Errorf("empty ip: %v", ips)
 		}
-		urls = append(urls, c.NodeURL(ip, desc.Port, opts.VirtualClusterName))
+		urls = append(urls, c.NodeURL(ip, desc.Port, opts.VirtualClusterName, desc.ServiceMode))
 	}
 	if len(urls) != len(nodes) {
 		return nil, errors.Errorf("have nodes %v, but urls %v from ips %v", nodes, urls, ips)

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -433,7 +433,15 @@ func SQL(
 	if len(c.Nodes) == 1 {
 		return c.ExecOrInteractiveSQL(ctx, l, tenantName, tenantInstance, cmdArray)
 	}
-	return c.ExecSQL(ctx, l, c.Nodes, tenantName, tenantInstance, cmdArray)
+	results, err := c.ExecSQL(ctx, l, c.Nodes, tenantName, tenantInstance, cmdArray)
+	if err != nil {
+		return err
+	}
+
+	for _, r := range results {
+		l.Printf("node %d:\n%s", r.Node, r.CombinedOut)
+	}
+	return nil
 }
 
 // IP gets the ip addresses of the nodes in a cluster.


### PR DESCRIPTION
This PR adds support for shared process virtual clusters using `start-sql` and `stop-sql`; previously, these subcommands would always create separate process virtual clusters. After this PR, `start-sql` will create shared process tenants by default. Alternatively, the `--external-cluster` command line flag can be used to indicate where the separate processes should be deployed. Similarly, `stop-sql` may be used to stop separate process virtual clusters, as before, by killing the corresponding OS process; or shared process virtual clusters by using SQL (`STOP SERVICE`).

A few other changes introduced in this PR, done to support this work:

* Made `ExecSQL` more flexible;
* Fixed a bug in `pgurl`, where we would include the virtual cluster name in the connection url returned by `roachprod pgurl`. This is not allowed since the URL pointed to the SQL server process, which does not handle that option.
* Remove ability to create tenants by specifying a tenant ID. We are now creating tenants with `CREATE TENANT` instead of `crdb_internal.create_tenant`. The tenant ID is computed automatically and used when starting the cockroach process for separate process deployments.

Epic: none

Release note: None