### PR TITLE
testserver: make implicit usages of TenantController methods explicit

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -3365,7 +3365,7 @@ func TestBackupTenantsWithRevisionHistory(t *testing.T) {
 	tc, sqlDB, _, cleanupFn := backupRestoreTestSetup(t, singleNode, numAccounts, InitManualReplication)
 	defer cleanupFn()
 
-	_, err := tc.Servers[0].StartTenant(ctx, base.TestTenantArgs{TenantID: roachpb.MustMakeTenantID(10)})
+	_, err := tc.Servers[0].TenantController().StartTenant(ctx, base.TestTenantArgs{TenantID: roachpb.MustMakeTenantID(10)})
 	require.NoError(t, err)
 
 	const msg = "can not backup tenants with revision history"
@@ -9628,7 +9628,7 @@ func TestProtectRestoreTargets(t *testing.T) {
 
 	ctx := context.Background()
 	if !tc.StartedDefaultTestTenant() {
-		_, err := tc.Servers[0].StartTenant(ctx, base.TestTenantArgs{TenantID: roachpb.
+		_, err := tc.Servers[0].TenantController().StartTenant(ctx, base.TestTenantArgs{TenantID: roachpb.
 			MustMakeTenantID(10)})
 		require.NoError(t, err)
 	}

--- a/pkg/ccl/backupccl/backupinfo/backup_metadata_test.go
+++ b/pkg/ccl/backupccl/backupinfo/backup_metadata_test.go
@@ -77,7 +77,7 @@ func TestMetadataSST(t *testing.T) {
 
 	// Check for correct backup metadata on tenant backups.
 	userfile2 := "userfile:///2"
-	_, err := tc.Servers[0].StartTenant(ctx, base.TestTenantArgs{TenantID: roachpb.MustMakeTenantID(10)})
+	_, err := tc.Servers[0].TenantController().StartTenant(ctx, base.TestTenantArgs{TenantID: roachpb.MustMakeTenantID(10)})
 	require.NoError(t, err)
 	sqlDB.Exec(t, `BACKUP TENANT 10 TO $1`, userfile2)
 	checkMetadata(ctx, t, tc, userfile2)

--- a/pkg/ccl/backupccl/tenant_backup_nemesis_test.go
+++ b/pkg/ccl/backupccl/tenant_backup_nemesis_test.go
@@ -71,7 +71,7 @@ func TestTenantBackupWithCanceledImport(t *testing.T) {
 	)
 	defer hostClusterCleanupFn()
 
-	tenant10, err := tc.Servers[0].StartTenant(ctx, base.TestTenantArgs{
+	tenant10, err := tc.Servers[0].TenantController().StartTenant(ctx, base.TestTenantArgs{
 		TenantID: roachpb.MustMakeTenantID(10),
 		TestingKnobs: base.TestingKnobs{
 			JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
@@ -100,7 +100,7 @@ func TestTenantBackupWithCanceledImport(t *testing.T) {
 	hostSQLDB.Exec(t, "BACKUP TENANT 10 INTO LATEST IN 'nodelocal://1/tenant-backup'")
 	hostSQLDB.Exec(t, "RESTORE TENANT 10 FROM LATEST IN 'nodelocal://1/tenant-backup' WITH virtual_cluster_name = 'cluster-11'")
 
-	tenant11, err := tc.Servers[0].StartTenant(ctx, base.TestTenantArgs{
+	tenant11, err := tc.Servers[0].TenantController().StartTenant(ctx, base.TestTenantArgs{
 		TenantName:          "cluster-11",
 		DisableCreateTenant: true,
 	})

--- a/pkg/ccl/kvccl/kvfollowerreadsccl/followerreads_test.go
+++ b/pkg/ccl/kvccl/kvfollowerreadsccl/followerreads_test.go
@@ -948,7 +948,7 @@ func TestSecondaryTenantFollowerReadsRouting(t *testing.T) {
 					},
 				}
 			}
-			tt, err := tc.Server(i).StartTenant(ctx, base.TestTenantArgs{
+			tt, err := tc.Server(i).TenantController().StartTenant(ctx, base.TestTenantArgs{
 				TenantID:     serverutils.TestTenantID(),
 				Locality:     localities[i],
 				TestingKnobs: knobs,

--- a/pkg/ccl/kvccl/kvtenantccl/upgradeccl/tenant_upgrade_test.go
+++ b/pkg/ccl/kvccl/kvtenantccl/upgradeccl/tenant_upgrade_test.go
@@ -96,7 +96,7 @@ func TestTenantUpgrade(t *testing.T) {
 			},
 			Settings: settings,
 		}
-		tenant, err := ts.StartTenant(ctx, tenantArgs)
+		tenant, err := ts.TenantController().StartTenant(ctx, tenantArgs)
 		require.NoError(t, err)
 		return tenant, tenant.SQLConn(t, "")
 	}
@@ -128,7 +128,7 @@ func TestTenantUpgrade(t *testing.T) {
 
 		t.Log("restart the tenant")
 		tenantServer.AppStopper().Stop(ctx)
-		tenantServer, err := ts.StartTenant(ctx, base.TestTenantArgs{
+		tenantServer, err := ts.TenantController().StartTenant(ctx, base.TestTenantArgs{
 			TenantID: roachpb.MustMakeTenantID(initialTenantID),
 		})
 		require.NoError(t, err)
@@ -152,7 +152,7 @@ func TestTenantUpgrade(t *testing.T) {
 		t.Log("restart the new tenant")
 		tenant.AppStopper().Stop(ctx)
 		var err error
-		tenant, err = ts.StartTenant(ctx, base.TestTenantArgs{
+		tenant, err = ts.TenantController().StartTenant(ctx, base.TestTenantArgs{
 			TenantID: roachpb.MustMakeTenantID(postUpgradeTenantID),
 		})
 		require.NoError(t, err)
@@ -291,7 +291,7 @@ func TestTenantUpgradeFailure(t *testing.T) {
 			},
 			Settings: settings,
 		}
-		tenant, err := ts.StartTenant(ctx, tenantArgs)
+		tenant, err := ts.TenantController().StartTenant(ctx, tenantArgs)
 		require.NoError(t, err)
 		tenantDB := tenant.SQLConn(t, "")
 		return tenant, tenantDB

--- a/pkg/ccl/kvccl/kvtenantccl/upgradeinterlockccl/local_test_util_test.go
+++ b/pkg/ccl/kvccl/kvtenantccl/upgradeinterlockccl/local_test_util_test.go
@@ -159,7 +159,7 @@ func runTest(t *testing.T, variant sharedtestutil.TestVariant, test sharedtestut
 			},
 			Settings: settings,
 		}
-		tenant, err := tc.Server(0).StartTenant(ctx, tenantArgs)
+		tenant, err := tc.Server(0).TenantController().StartTenant(ctx, tenantArgs)
 		require.NoError(t, err)
 		return tenant.SQLConn(t, ""), func() { tenant.AppStopper().Stop(ctx) }
 	}
@@ -278,7 +278,7 @@ func runTest(t *testing.T, variant sharedtestutil.TestVariant, test sharedtestut
 	}
 	require.NoError(t, clusterversion.Initialize(ctx, otherMsv, &otherServerSettings.SV))
 	otherServerStopper := stop.NewStopper()
-	otherServer, otherServerStartError := tc.Server(0).StartTenant(ctx,
+	otherServer, otherServerStartError := tc.Server(0).TenantController().StartTenant(ctx,
 		base.TestTenantArgs{
 			Stopper:  otherServerStopper,
 			TenantID: tenantID,

--- a/pkg/ccl/multiregionccl/cold_start_latency_test.go
+++ b/pkg/ccl/multiregionccl/cold_start_latency_test.go
@@ -316,7 +316,7 @@ SELECT checkpoint > extract(epoch from after)
 		defer r.Release()
 		start := timeutil.Now()
 		sn := tenantServerKnobs(i)
-		tenant, err := tc.Server(i).StartTenant(ctx, base.TestTenantArgs{
+		tenant, err := tc.Server(i).TenantController().StartTenant(ctx, base.TestTenantArgs{
 			TenantID:            serverutils.TestTenantID(),
 			DisableCreateTenant: true,
 			SkipTenantCheck:     true,

--- a/pkg/ccl/multitenantccl/tenantcapabilitiesccl/capabilities_test.go
+++ b/pkg/ccl/multitenantccl/tenantcapabilitiesccl/capabilities_test.go
@@ -88,7 +88,7 @@ func TestDataDriven(t *testing.T) {
 		tenantArgs := base.TestTenantArgs{
 			TenantID: serverutils.TestTenantID(),
 		}
-		testTenantInterface, err := tc.Server(0).StartTenant(ctx, tenantArgs)
+		testTenantInterface, err := tc.Server(0).TenantController().StartTenant(ctx, tenantArgs)
 		require.NoError(t, err)
 
 		tenantSQLDB := testTenantInterface.SQLConn(t, "")

--- a/pkg/ccl/serverccl/server_controller_test.go
+++ b/pkg/ccl/serverccl/server_controller_test.go
@@ -313,7 +313,7 @@ func TestServerControllerDefaultHTTPTenant(t *testing.T) {
 	})
 	defer s.Stopper().Stop(ctx)
 
-	_, sql, err := s.StartSharedProcessTenant(ctx, base.TestSharedProcessTenantArgs{
+	_, sql, err := s.TenantController().StartSharedProcessTenant(ctx, base.TestSharedProcessTenantArgs{
 		TenantName: "hello",
 		TenantID:   roachpb.MustMakeTenantID(10),
 	})

--- a/pkg/ccl/serverccl/server_sql_test.go
+++ b/pkg/ccl/serverccl/server_sql_test.go
@@ -131,7 +131,7 @@ func TestTenantUnauthenticatedAccess(t *testing.T) {
 	})
 	defer s.Stopper().Stop(ctx)
 
-	_, err := s.StartTenant(ctx,
+	_, err := s.TenantController().StartTenant(ctx,
 		base.TestTenantArgs{
 			TenantID: roachpb.MustMakeTenantID(securitytest.EmbeddedTenantIDs()[0]),
 			TestingKnobs: base.TestingKnobs{
@@ -200,7 +200,7 @@ func TestTenantProcessDebugging(t *testing.T) {
 	})
 	defer s.Stopper().Stop(ctx)
 
-	tenant, _, err := s.StartSharedProcessTenant(ctx,
+	tenant, _, err := s.TenantController().StartSharedProcessTenant(ctx,
 		base.TestSharedProcessTenantArgs{
 			TenantID:   serverutils.TestTenantID(),
 			TenantName: "processdebug",
@@ -325,7 +325,7 @@ func TestNonExistentTenant(t *testing.T) {
 	})
 	defer s.Stopper().Stop(ctx)
 
-	_, err := s.StartTenant(ctx,
+	_, err := s.TenantController().StartTenant(ctx,
 		base.TestTenantArgs{
 			TenantID:            serverutils.TestTenantID(),
 			DisableCreateTenant: true,

--- a/pkg/ccl/serverccl/server_startup_guardrails_test.go
+++ b/pkg/ccl/serverccl/server_startup_guardrails_test.go
@@ -110,7 +110,7 @@ func TestServerStartupGuardrails(t *testing.T) {
 			// to succeed for all test cases but server creation is expected to succeed
 			// only if tenantBinaryVersion is at least equal to the version corresponding
 			// to TenantLogicalVersionKey.
-			_, err := s.StartTenant(context.Background(),
+			_, err := s.TenantController().StartTenant(context.Background(),
 				base.TestTenantArgs{
 					Settings: tenantSettings,
 					TenantID: serverutils.TestTenantID(),

--- a/pkg/ccl/serverccl/tenant_migration_test.go
+++ b/pkg/ccl/serverccl/tenant_migration_test.go
@@ -101,7 +101,7 @@ func TestValidateTargetTenantClusterVersion(t *testing.T) {
 			defer s.Stopper().Stop(context.Background())
 
 			ctx := context.Background()
-			upgradePod, err := s.StartTenant(ctx,
+			upgradePod, err := s.TenantController().StartTenant(ctx,
 				base.TestTenantArgs{
 					Settings: makeSettings(),
 					TenantID: serverutils.TestTenantID(),

--- a/pkg/ccl/spanconfigccl/spanconfiglimiterccl/drop_table_test.go
+++ b/pkg/ccl/spanconfigccl/spanconfiglimiterccl/drop_table_test.go
@@ -42,7 +42,7 @@ func TestDropTableLowersSpanCount(t *testing.T) {
 	ts := tc.Server(0)
 
 	tenantID := roachpb.MustMakeTenantID(10)
-	tenant, err := ts.StartTenant(ctx, base.TestTenantArgs{
+	tenant, err := ts.TenantController().StartTenant(ctx, base.TestTenantArgs{
 		TenantID: tenantID,
 		TestingKnobs: base.TestingKnobs{
 			GCJob: &sql.GCJobTestingKnobs{

--- a/pkg/ccl/sqlproxyccl/tenant/directory_cache_test.go
+++ b/pkg/ccl/sqlproxyccl/tenant/directory_cache_test.go
@@ -642,7 +642,7 @@ func destroyTenant(tc serverutils.TestClusterInterface, id roachpb.TenantID) err
 func startTenant(
 	ctx context.Context, tenantStopper *stop.Stopper, srv serverutils.TestServerInterface, id uint64,
 ) (string, error) {
-	t, err := srv.StartTenant(
+	t, err := srv.TenantController().StartTenant(
 		ctx,
 		base.TestTenantArgs{
 			TenantID: roachpb.MustMakeTenantID(id),

--- a/pkg/cli/democluster/demo_cluster.go
+++ b/pkg/cli/democluster/demo_cluster.go
@@ -534,7 +534,7 @@ func (c *transientCluster) startTenantService(
 		}
 
 		var err error
-		ts, err = c.servers[serverIdx].StartTenant(ctx, args)
+		ts, err = c.servers[serverIdx].TenantController().StartTenant(ctx, args)
 		if err != nil {
 			return err
 		}
@@ -547,7 +547,7 @@ func (c *transientCluster) startTenantService(
 		}))
 	} else {
 		var err error
-		ts, _, err = c.servers[serverIdx].StartSharedProcessTenant(ctx,
+		ts, _, err = c.servers[serverIdx].TenantController().StartSharedProcessTenant(ctx,
 			base.TestSharedProcessTenantArgs{
 				TenantID:   roachpb.MustMakeTenantID(secondaryTenantID),
 				TenantName: demoTenantName,

--- a/pkg/cli/testutils.go
+++ b/pkg/cli/testutils.go
@@ -192,14 +192,14 @@ func newCLITestWithArgs(params TestCLIParams, argsFn func(args *base.TestServerA
 		if params.Insecure {
 			params.TenantArgs.ForceInsecure = true
 		}
-		c.tenant, err = c.Server.StartTenant(context.Background(), *params.TenantArgs)
+		c.tenant, err = c.Server.TenantController().StartTenant(context.Background(), *params.TenantArgs)
 		if err != nil {
 			c.fail(err)
 		}
 	}
 
 	if params.SharedProcessTenantArgs != nil {
-		c.tenant, _, err = c.Server.StartSharedProcessTenant(context.Background(), *params.SharedProcessTenantArgs)
+		c.tenant, _, err = c.Server.TenantController().StartSharedProcessTenant(context.Background(), *params.SharedProcessTenantArgs)
 		if err != nil {
 			c.fail(err)
 		}

--- a/pkg/kv/kvclient/kvtenant/tenant_range_lookup_test.go
+++ b/pkg/kv/kvclient/kvtenant/tenant_range_lookup_test.go
@@ -46,7 +46,7 @@ func TestRangeLookupPrefetchFiltering(t *testing.T) {
 	defer tc.Stopper().Stop(ctx)
 
 	ten2ID := roachpb.MustMakeTenantID(2)
-	tenant2, err := tc.Server(0).StartTenant(ctx, base.TestTenantArgs{
+	tenant2, err := tc.Server(0).TenantController().StartTenant(ctx, base.TestTenantArgs{
 		TenantID: ten2ID,
 	})
 	require.NoError(t, err)

--- a/pkg/kv/kvclient/kvtenant/tenant_scan_range_descriptors_test.go
+++ b/pkg/kv/kvclient/kvtenant/tenant_scan_range_descriptors_test.go
@@ -41,7 +41,7 @@ func setup(
 	})
 
 	ten2ID := roachpb.MustMakeTenantID(2)
-	tenant2, err := tc.Server(0).StartTenant(ctx, base.TestTenantArgs{
+	tenant2, err := tc.Server(0).TenantController().StartTenant(ctx, base.TestTenantArgs{
 		TenantID: ten2ID,
 	})
 	require.NoError(t, err)

--- a/pkg/kv/kvserver/client_tenant_test.go
+++ b/pkg/kv/kvserver/client_tenant_test.go
@@ -189,7 +189,7 @@ func TestTenantRateLimiter(t *testing.T) {
 	})
 	ctx := context.Background()
 	tenantID := serverutils.TestTenantID()
-	ts, err := s.StartTenant(ctx, base.TestTenantArgs{
+	ts, err := s.TenantController().StartTenant(ctx, base.TestTenantArgs{
 		TenantID: tenantID,
 		TestingKnobs: base.TestingKnobs{
 			JobsTestingKnobs: &jobs.TestingKnobs{
@@ -385,7 +385,7 @@ func TestTenantCtx(t *testing.T) {
 		var tsql *gosql.DB
 		if sharedProcess {
 			var err error
-			_, tsql, err = s.StartSharedProcessTenant(ctx, base.TestSharedProcessTenantArgs{
+			_, tsql, err = s.TenantController().StartSharedProcessTenant(ctx, base.TestSharedProcessTenantArgs{
 				TenantName: "test",
 				TenantID:   tenantID,
 			})

--- a/pkg/server/authserver/authentication_test.go
+++ b/pkg/server/authserver/authentication_test.go
@@ -635,7 +635,7 @@ func TestLogoutClearsCookies(t *testing.T) {
 	})
 
 	t.Run("secondary tenant", func(t *testing.T) {
-		ts, err := s.StartTenant(context.Background(), base.TestTenantArgs{TenantID: roachpb.MustMakeTenantID(10)})
+		ts, err := s.TenantController().StartTenant(context.Background(), base.TestTenantArgs{TenantID: roachpb.MustMakeTenantID(10)})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -790,7 +790,7 @@ func TestAuthenticationMux(t *testing.T) {
 		{"POST", ts.URLPrefix + "query", tsReqBuffer.Bytes(), ""},
 	} {
 		t.Run("path="+tc.path, func(t *testing.T) {
-			if s.StartedDefaultTestTenant() && strings.HasPrefix(tc.path, ts.URLPrefix) {
+			if s.TenantController().StartedDefaultTestTenant() && strings.HasPrefix(tc.path, ts.URLPrefix) {
 				// As of this writing, timeseries requests to secondary
 				// tenants are overly restricted. This is a feature gap. See
 				// issue #102378.
@@ -899,7 +899,7 @@ func TestGRPCAuthentication(t *testing.T) {
 		_ = conn.Close() // nolint:grpcconnclose
 	}(conn)
 	for _, subsystem := range subsystems {
-		if subsystem.storageOnly && s.StartedDefaultTestTenant() {
+		if subsystem.storageOnly && s.TenantController().StartedDefaultTestTenant() {
 			// Subsystem only available on the system tenant.
 			continue
 		}
@@ -928,7 +928,7 @@ func TestGRPCAuthentication(t *testing.T) {
 		_ = conn.Close() // nolint:grpcconnclose
 	}(conn)
 	for _, subsystem := range subsystems {
-		if subsystem.storageOnly && s.StartedDefaultTestTenant() {
+		if subsystem.storageOnly && s.TenantController().StartedDefaultTestTenant() {
 			// Subsystem only available on the system tenant.
 			continue
 		}

--- a/pkg/server/drain_test.go
+++ b/pkg/server/drain_test.go
@@ -329,7 +329,7 @@ func TestServerShutdownReleasesSession(t *testing.T) {
 		return 0 < len(rows)
 	}
 
-	tmpTenant, err := s.StartTenant(ctx, tenantArgs)
+	tmpTenant, err := s.TenantController().StartTenant(ctx, tenantArgs)
 	require.NoError(t, err)
 
 	tmpSQLInstance := tmpTenant.SQLInstanceID()

--- a/pkg/server/server_controller_test.go
+++ b/pkg/server/server_controller_test.go
@@ -107,7 +107,7 @@ func TestSharedProcessServerInheritsTempStorageLimit(t *testing.T) {
 	defer s.Stopper().Stop(ctx)
 
 	// Start a shared process tenant server.
-	ts, _, err := s.StartSharedProcessTenant(ctx, base.TestSharedProcessTenantArgs{
+	ts, _, err := s.TenantController().StartSharedProcessTenant(ctx, base.TestSharedProcessTenantArgs{
 		TenantName: "hello",
 	})
 	require.NoError(t, err)
@@ -131,18 +131,18 @@ func TestServerSQLConn(t *testing.T) {
 	systemTenant := s.SystemLayer()
 
 	// Start some secondary tenant servers.
-	secondaryTenantExtNoName, err := s.StartTenant(ctx, base.TestTenantArgs{
+	secondaryTenantExtNoName, err := s.TenantController().StartTenant(ctx, base.TestTenantArgs{
 		TenantID: roachpb.MustMakeTenantID(2),
 	})
 	require.NoError(t, err)
 
-	secondaryTenantExtNamed, err := s.StartTenant(ctx, base.TestTenantArgs{
+	secondaryTenantExtNamed, err := s.TenantController().StartTenant(ctx, base.TestTenantArgs{
 		TenantName: "hello",
 		TenantID:   roachpb.MustMakeTenantID(10),
 	})
 	require.NoError(t, err)
 
-	secondaryTenantSh, _, err := s.StartSharedProcessTenant(ctx, base.TestSharedProcessTenantArgs{
+	secondaryTenantSh, _, err := s.TenantController().StartSharedProcessTenant(ctx, base.TestSharedProcessTenantArgs{
 		TenantName: "world",
 	})
 	require.NoError(t, err)

--- a/pkg/sql/catalog/tabledesc/index_test.go
+++ b/pkg/sql/catalog/tabledesc/index_test.go
@@ -394,7 +394,7 @@ func TestIndexStrictColumnIDs(t *testing.T) {
 	err = rows.Scan(&msg)
 	require.NoError(t, err)
 	var tenantPrefix string
-	if srv.StartedDefaultTestTenant() {
+	if srv.TenantController().StartedDefaultTestTenant() {
 		tenantPrefix = codec.TenantPrefix().String()
 	}
 	expected := fmt.Sprintf(`InitPut %s/Table/%d/2/0/0/0/0/0/0 -> /BYTES/0x2300030003000300`, tenantPrefix, mut.GetID())

--- a/pkg/sql/conn_executor_test.go
+++ b/pkg/sql/conn_executor_test.go
@@ -315,7 +315,7 @@ func TestErrorOnRollback(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	getTargetKey := func(s serverutils.TestServerInterface, tableID uint32) string {
-		if s.StartedDefaultTestTenant() {
+		if s.TenantController().StartedDefaultTestTenant() {
 			return fmt.Sprintf("/Tenant/%d/Table/%d/1/1/0", serverutils.TestTenantID().ToUint64(), tableID)
 		}
 		return fmt.Sprintf("/Table/%d/1/1/0", tableID)

--- a/pkg/sql/create_as_test.go
+++ b/pkg/sql/create_as_test.go
@@ -78,7 +78,7 @@ func TestCreateAsVTable(t *testing.T) {
 			}
 
 			fqName := name.FQString()
-			if s.StartedDefaultTestTenant() {
+			if s.TenantController().StartedDefaultTestTenant() {
 				// Some of the virtual tables are currently only available in
 				// the system tenant.
 				// TODO(yuzefovich): update this list when #54252 is addressed.
@@ -295,7 +295,7 @@ func TestCreateAsShow(t *testing.T) {
 	for i, testCase := range testCases {
 		t.Run(testCase.sql, func(t *testing.T) {
 			if testCase.setup != "" {
-				if s.StartedDefaultTestTenant() && strings.Contains(testCase.setup, "create_tenant") {
+				if s.TenantController().StartedDefaultTestTenant() && strings.Contains(testCase.setup, "create_tenant") {
 					// Only the system tenant has the ability to create other
 					// tenants.
 					return

--- a/pkg/sql/execstats/traceanalyzer_test.go
+++ b/pkg/sql/execstats/traceanalyzer_test.go
@@ -81,7 +81,7 @@ func TestTraceAnalyzer(t *testing.T) {
 
 	const gatewayNode = 0
 	srv, s := tc.Server(gatewayNode), tc.ApplicationLayer(gatewayNode)
-	if srv.StartedDefaultTestTenant() {
+	if srv.TenantController().StartedDefaultTestTenant() {
 		systemSqlDB := srv.SystemLayer().SQLConn(t, "system")
 		_, err := systemSqlDB.Exec(`ALTER TENANT [$1] GRANT CAPABILITY can_admin_relocate_range=true`, serverutils.TestTenantID().ToUint64())
 		require.NoError(t, err)

--- a/pkg/sql/flowinfra/cluster_test.go
+++ b/pkg/sql/flowinfra/cluster_test.go
@@ -596,7 +596,7 @@ func TestEvalCtxTxnOnRemoteNodes(t *testing.T) {
 		})
 	defer tc.Stopper().Stop(ctx)
 
-	if srv := tc.Server(0); srv.StartedDefaultTestTenant() {
+	if srv := tc.Server(0); srv.TenantController().StartedDefaultTestTenant() {
 		systemSqlDB := srv.SystemLayer().SQLConn(t, "system")
 		_, err := systemSqlDB.Exec(`ALTER TENANT [$1] GRANT CAPABILITY can_admin_relocate_range=true`, serverutils.TestTenantID().ToUint64())
 		require.NoError(t, err)

--- a/pkg/sql/opt/exec/explain/output_test.go
+++ b/pkg/sql/opt/exec/explain/output_test.go
@@ -185,7 +185,7 @@ func TestCPUTimeEndToEnd(t *testing.T) {
 	ctx := context.Background()
 	defer tc.Stopper().Stop(ctx)
 
-	if srv := tc.Server(0); srv.StartedDefaultTestTenant() {
+	if srv := tc.Server(0); srv.TenantController().StartedDefaultTestTenant() {
 		systemSqlDB := srv.SystemLayer().SQLConn(t, "system")
 		_, err := systemSqlDB.Exec(`ALTER TENANT [$1] GRANT CAPABILITY can_admin_relocate_range=true`, serverutils.TestTenantID().ToUint64())
 		require.NoError(t, err)

--- a/pkg/sql/stats/automatic_stats_test.go
+++ b/pkg/sql/stats/automatic_stats_test.go
@@ -202,7 +202,7 @@ func TestEnsureAllTablesQueries(t *testing.T) {
 
 	// Exclude the 3 system tables which don't use autostats.
 	systemTablesWithStats := bootstrap.NumSystemTablesForSystemTenant - 3
-	if srv.StartedDefaultTestTenant() {
+	if srv.TenantController().StartedDefaultTestTenant() {
 		// Exclude system tables that are not present in the tenant key space.
 		systemTablesWithStats -= 6
 	}

--- a/pkg/sql/stats/delete_stats_test.go
+++ b/pkg/sql/stats/delete_stats_test.go
@@ -690,7 +690,7 @@ func TestStatsAreDeletedForDroppedTables(t *testing.T) {
 	// Cached protected timestamp state delays MVCC GC, update it every second.
 	runner.Exec(t, "SET CLUSTER SETTING kv.protectedts.poll_interval = '1s';")
 
-	if s.StartedDefaultTestTenant() {
+	if s.TenantController().StartedDefaultTestTenant() {
 		systemDB.Exec(t, "SET CLUSTER SETTING sql.zone_configs.allow_for_secondary_tenant.enabled = true")
 		// Block until we see that zone configs are enabled.
 		testutils.SucceedsSoon(t, func() error {

--- a/pkg/upgrade/upgrademanager/manager_external_test.go
+++ b/pkg/upgrade/upgrademanager/manager_external_test.go
@@ -347,7 +347,7 @@ FROM system.job_info WHERE job_id = $1 AND info_key = 'legacy_payload')`, jobID)
 		runTestForDB(t, systemSQLDB)
 	})
 	t.Run("tenant", func(t *testing.T) {
-		tenant, err := ts.StartTenant(ctx, base.TestTenantArgs{
+		tenant, err := ts.TenantController().StartTenant(ctx, base.TestTenantArgs{
 			TenantID: roachpb.MustMakeTenantID(10),
 			TestingKnobs: base.TestingKnobs{
 				Server: &server.TestingKnobs{

--- a/pkg/util/tracing/collector/collector_test.go
+++ b/pkg/util/tracing/collector/collector_test.go
@@ -256,7 +256,7 @@ func TestClusterInflightTraces(t *testing.T) {
 				tenants := make([]serverutils.ApplicationLayerInterface, len(tc.Servers))
 				dbs := make([]*gosql.DB, len(tc.Servers))
 				for i, s := range tc.Servers {
-					tenant, db, err := s.StartSharedProcessTenant(ctx, base.TestSharedProcessTenantArgs{TenantName: "app"})
+					tenant, db, err := s.TenantController().StartSharedProcessTenant(ctx, base.TestSharedProcessTenantArgs{TenantName: "app"})
 					require.NoError(t, err)
 					tenants[i] = tenant
 					dbs[i] = db
@@ -279,7 +279,7 @@ func TestClusterInflightTraces(t *testing.T) {
 				tenants := make([]serverutils.ApplicationLayerInterface, len(tc.Servers))
 				dbs := make([]*gosql.DB, len(tc.Servers))
 				for i := range tc.Servers {
-					tenant, err := tc.Servers[i].StartTenant(ctx, base.TestTenantArgs{TenantID: tenantID})
+					tenant, err := tc.Servers[i].TenantController().StartTenant(ctx, base.TestTenantArgs{TenantID: tenantID})
 					require.NoError(t, err)
 					tenants[i] = tenant
 					dbs[i] = tenant.SQLConn(t, "")

--- a/pkg/util/tracing/tracer_external_test.go
+++ b/pkg/util/tracing/tracer_external_test.go
@@ -116,7 +116,7 @@ func TestTraceForTenantWithLocalKVServer(t *testing.T) {
 	testStmt := "SELECT 1 FROM t WHERE id=1"
 	var testStmtTrace tracingpb.Recording
 
-	_, tenantDB, err := s.StartSharedProcessTenant(ctx,
+	_, tenantDB, err := s.TenantController().StartSharedProcessTenant(ctx,
 		base.TestSharedProcessTenantArgs{
 			TenantName:  tenantName,
 			UseDatabase: "test",


### PR DESCRIPTION
I was annoyed by the warning in the logic test failures, so I decided to audit all usages of `TenantController` methods to make them "explicit".

Epic: None

Release note: None