### PR TITLE
colexecjoin: short-circuit cross join with empty right side if possible

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/vectorize_local
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize_local
@@ -1,0 +1,15 @@
+# LogicTest: local
+
+# Regression test for vectorized cross join consuming the left source for INNER
+# join type when the right input is empty (#111474).
+statement ok
+CREATE TABLE t111474_0 (c0 INT);
+CREATE TABLE t111474_1 (c0 INT);
+INSERT INTO t111474_0 (c0) VALUES (1);
+
+# If the cross joiner doesn't short-circuit, then this query would result in an
+# error. The error could still occur if the plan is distributed, so we only run
+# this in the local config.
+query II
+SELECT * FROM t111474_0, t111474_1 WHERE ascii('') > 0;
+----

--- a/pkg/sql/logictest/tests/local/generated_test.go
+++ b/pkg/sql/logictest/tests/local/generated_test.go
@@ -2605,6 +2605,13 @@ func TestLogic_vectorize_agg(
 	runLogicTest(t, "vectorize_agg")
 }
 
+func TestLogic_vectorize_local(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "vectorize_local")
+}
+
 func TestLogic_vectorize_overloads(
 	t *testing.T,
 ) {


### PR DESCRIPTION
This commit makes it so that the vectorized cross joiner doesn't consume any batches from the left source if the right source is empty for INNER, RIGHT OUTER, and INTERSECT ALL joins. For these join types we know that the result is empty, so this can be a nice speedup.

Fixes: #111474.

Release note: None