### PR TITLE
streamingccl: clarify that license is needed on both clusters

### DIFF
--- a/pkg/ccl/streamingccl/streamingest/stream_ingest_manager.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingest_manager.go
@@ -66,7 +66,7 @@ func newStreamIngestManagerWithPrivilegesCheck(
 		execCfg.Settings, execCfg.NodeInfo.LogicalClusterID(), "REPLICATION")
 	if enterpriseCheckErr != nil {
 		return nil, pgerror.Wrap(enterpriseCheckErr,
-			pgcode.InsufficientPrivilege, "replication requires enterprise license")
+			pgcode.InsufficientPrivilege, "physical replication requires an enterprise license on the secondary (and primary) cluster")
 	}
 
 	isAdmin, err := evalCtx.SessionAccessor.HasAdminRole(ctx)

--- a/pkg/ccl/streamingccl/streamproducer/replication_manager.go
+++ b/pkg/ccl/streamingccl/streamproducer/replication_manager.go
@@ -92,7 +92,7 @@ func newReplicationStreamManagerWithPrivilegesCheck(
 		execCfg.Settings, execCfg.NodeInfo.LogicalClusterID(), "REPLICATION")
 	if enterpriseCheckErr != nil {
 		return nil, pgerror.Wrap(enterpriseCheckErr,
-			pgcode.InsufficientPrivilege, "replication requires enterprise license")
+			pgcode.InsufficientPrivilege, "physical replication requires an enterprise license on the primary (and secondary) cluster")
 	}
 
 	return &replicationStreamManagerImpl{evalCtx: evalCtx, txn: txn}, nil


### PR DESCRIPTION
At least one user was confused by this. Perhaps this small update will make it more clear.

Fixes #111525

Release note: None