### PR TITLE
kv: bump timestamp cache when resolving replicated locks

### DIFF
--- a/pkg/kv/kvpb/api.go
+++ b/pkg/kv/kvpb/api.go
@@ -1622,8 +1622,8 @@ func (*QueryIntentRequest) flags() flag {
 	return isRead | isPrefix | updatesTSCache | updatesTSCacheOnErr
 }
 func (*QueryLocksRequest) flags() flag         { return isRead | isRange }
-func (*ResolveIntentRequest) flags() flag      { return isWrite }
-func (*ResolveIntentRangeRequest) flags() flag { return isWrite | isRange }
+func (*ResolveIntentRequest) flags() flag      { return isWrite | updatesTSCache }
+func (*ResolveIntentRangeRequest) flags() flag { return isWrite | isRange | updatesTSCache }
 func (*TruncateLogRequest) flags() flag        { return isWrite }
 func (*MergeRequest) flags() flag              { return isWrite | canBackpressure }
 func (*RequestLeaseRequest) flags() flag {

--- a/pkg/kv/kvpb/api.proto
+++ b/pkg/kv/kvpb/api.proto
@@ -1479,6 +1479,17 @@ message ResolveIntentRequest {
 // ResolveIntent() method.
 message ResolveIntentResponse {
   ResponseHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+  // ReplicatedLocksReleasedCommitTimestamp, if non-empty, indicates that a
+  // replicated lock with strength Shared or Exclusive was released by a
+  // transaction who committed at this timestamp. Notably, this field is left
+  // unset if only a write intent was resolved. The field is also left unset for
+  // transactions who aborted.
+  //
+  // The caller must bump the timestamp cache across the resolution span to this
+  // commit timestamp. Doing so ensures that the released lock (acquired by a
+  // now committed transaction) continues to provide protection against other
+  // writers up to the commit timestamp, even after the lock has been released.
+  util.hlc.Timestamp replicated_locks_released_commit_timestamp = 2 [(gogoproto.nullable) = false];
 }
 
 // A ResolveIntentRangeRequest is arguments to the ResolveIntentRange() method.
@@ -1523,6 +1534,17 @@ message ResolveIntentRangeRequest {
 // ResolveIntent() method.
 message ResolveIntentRangeResponse {
   ResponseHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+  // ReplicatedLocksReleasedCommitTimestamp, if non-empty, indicates that at
+  // least one replicated lock with strength Shared or Exclusive was released by
+  // a transaction who committed at this timestamp. Notably, this field is left
+  // unset if only a write intent was resolved. The field is also left unset for
+  // transactions who aborted.
+  //
+  // The caller must bump the timestamp cache across the resolution span to this
+  // commit timestamp. Doing so ensures that the released lock (acquired by a
+  // now committed transaction) continues to provide protection against other
+  // writers up to the commit timestamp, even after the lock has been released.
+  util.hlc.Timestamp replicated_locks_released_commit_timestamp = 2 [(gogoproto.nullable) = false];
 }
 
 // A MergeRequest contains arguments to the Merge() method. It

--- a/pkg/kv/kvserver/batch_spanset_test.go
+++ b/pkg/kv/kvserver/batch_spanset_test.go
@@ -585,7 +585,7 @@ func TestSpanSetMVCCResolveWriteIntentRange(t *testing.T) {
 		Txn:    enginepb.TxnMeta{ID: uuid.MakeV4()}, // unused
 		Status: roachpb.PENDING,
 	}
-	if _, _, _, _, err := storage.MVCCResolveWriteIntentRange(
+	if _, _, _, _, _, err := storage.MVCCResolveWriteIntentRange(
 		ctx, batch, nil /* ms */, intent, storage.MVCCResolveWriteIntentRangeOptions{},
 	); err != nil {
 		t.Fatal(err)

--- a/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
+++ b/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
@@ -595,7 +595,7 @@ func resolveLocalLocksWithPagination(
 			//
 			// Note that the underlying pebbleIterator will still be reused
 			// since readWriter is a pebbleBatch in the typical case.
-			ok, numBytes, resumeSpan, err := storage.MVCCResolveWriteIntent(ctx, readWriter, ms, update,
+			ok, numBytes, resumeSpan, _, err := storage.MVCCResolveWriteIntent(ctx, readWriter, ms, update,
 				storage.MVCCResolveWriteIntentOptions{TargetBytes: targetBytes})
 			if err != nil {
 				return 0, 0, 0, errors.Wrapf(err, "resolving write intent at %s on end transaction [%s]", span, txn.Status)
@@ -630,8 +630,10 @@ func resolveLocalLocksWithPagination(
 		externalLocks = append(externalLocks, outSpans...)
 		if inSpan != nil {
 			update.Span = *inSpan
-			numKeys, numBytes, resumeSpan, resumeReason, err := storage.MVCCResolveWriteIntentRange(ctx, readWriter, ms, update,
-				storage.MVCCResolveWriteIntentRangeOptions{MaxKeys: maxKeys, TargetBytes: targetBytes})
+			numKeys, numBytes, resumeSpan, resumeReason, _, err :=
+				storage.MVCCResolveWriteIntentRange(ctx, readWriter, ms, update,
+					storage.MVCCResolveWriteIntentRangeOptions{MaxKeys: maxKeys, TargetBytes: targetBytes},
+				)
 			if err != nil {
 				return 0, 0, 0, errors.Wrapf(err, "resolving write intent range at %s on end transaction [%s]", span, txn.Status)
 			}

--- a/pkg/kv/kvserver/batcheval/cmd_refresh_range_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_refresh_range_test.go
@@ -175,7 +175,9 @@ func TestRefreshRangeTimeBoundIterator(t *testing.T) {
 	// would not have any timestamp bounds and would be selected for every read.
 	intent := roachpb.MakeLockUpdate(txn, roachpb.Span{Key: k})
 	intent.Status = roachpb.COMMITTED
-	if _, _, _, err := storage.MVCCResolveWriteIntent(ctx, db, nil, intent, storage.MVCCResolveWriteIntentOptions{}); err != nil {
+	if _, _, _, _, err := storage.MVCCResolveWriteIntent(
+		ctx, db, nil, intent, storage.MVCCResolveWriteIntentOptions{},
+	); err != nil {
 		t.Fatal(err)
 	}
 	if err := storage.MVCCPut(ctx, db, roachpb.Key("unused2"), ts1, v, storage.MVCCWriteOptions{}); err != nil {
@@ -278,7 +280,7 @@ func TestRefreshRangeError(t *testing.T) {
 			if resolveIntent {
 				intent := roachpb.MakeLockUpdate(txn, roachpb.Span{Key: k})
 				intent.Status = roachpb.COMMITTED
-				if _, _, _, err := storage.MVCCResolveWriteIntent(ctx, db, nil, intent, storage.MVCCResolveWriteIntentOptions{}); err != nil {
+				if _, _, _, _, err := storage.MVCCResolveWriteIntent(ctx, db, nil, intent, storage.MVCCResolveWriteIntentOptions{}); err != nil {
 					t.Fatal(err)
 				}
 			}

--- a/pkg/kv/kvserver/batcheval/cmd_refresh_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_refresh_test.go
@@ -72,7 +72,9 @@ func TestRefreshError(t *testing.T) {
 			if resolveIntent {
 				intent := roachpb.MakeLockUpdate(txn, roachpb.Span{Key: k})
 				intent.Status = roachpb.COMMITTED
-				if _, _, _, err := storage.MVCCResolveWriteIntent(ctx, db, nil, intent, storage.MVCCResolveWriteIntentOptions{}); err != nil {
+				if _, _, _, _, err := storage.MVCCResolveWriteIntent(
+					ctx, db, nil, intent, storage.MVCCResolveWriteIntentOptions{},
+				); err != nil {
 					t.Fatal(err)
 				}
 			}

--- a/pkg/kv/kvserver/batcheval/cmd_resolve_intent.go
+++ b/pkg/kv/kvserver/batcheval/cmd_resolve_intent.go
@@ -97,8 +97,8 @@ func ResolveIntent(
 		// The observation was from the wrong node. Ignore.
 		update.ClockWhilePending = roachpb.ObservedTimestamp{}
 	}
-	ok, numBytes, resumeSpan, _, err := storage.MVCCResolveWriteIntent(ctx, readWriter, ms, update,
-		storage.MVCCResolveWriteIntentOptions{TargetBytes: h.TargetBytes})
+	ok, numBytes, resumeSpan, replLocksReleased, err := storage.MVCCResolveWriteIntent(
+		ctx, readWriter, ms, update, storage.MVCCResolveWriteIntentOptions{TargetBytes: h.TargetBytes})
 	if err != nil {
 		return result.Result{}, err
 	}
@@ -113,6 +113,17 @@ func ResolveIntent(
 	var res result.Result
 	res.Local.ResolvedLocks = []roachpb.LockUpdate{update}
 	res.Local.Metrics = resolveToMetricType(args.Status, args.Poison)
+
+	// Handle replicated lock releases.
+	if replLocksReleased && update.Status == roachpb.COMMITTED {
+		// A replicated {shared, exclusive} lock was released for a committed
+		// transaction. Now that the lock is no longer there, we still need to make
+		// sure other transactions can't write underneath the transaction's commit
+		// timestamp to the key. We return the transaction's commit timestamp on the
+		// response and update the timestamp cache a few layers above to ensure
+		// this.
+		reply.ReplicatedLocksReleasedCommitTimestamp = update.Txn.WriteTimestamp
+	}
 
 	if WriteAbortSpanOnResolve(args.Status, args.Poison, ok) {
 		if err := UpdateAbortSpan(ctx, cArgs.EvalCtx, readWriter, ms, args.IntentTxn, args.Poison); err != nil {

--- a/pkg/kv/kvserver/batcheval/cmd_resolve_intent.go
+++ b/pkg/kv/kvserver/batcheval/cmd_resolve_intent.go
@@ -97,7 +97,7 @@ func ResolveIntent(
 		// The observation was from the wrong node. Ignore.
 		update.ClockWhilePending = roachpb.ObservedTimestamp{}
 	}
-	ok, numBytes, resumeSpan, err := storage.MVCCResolveWriteIntent(ctx, readWriter, ms, update,
+	ok, numBytes, resumeSpan, _, err := storage.MVCCResolveWriteIntent(ctx, readWriter, ms, update,
 		storage.MVCCResolveWriteIntentOptions{TargetBytes: h.TargetBytes})
 	if err != nil {
 		return result.Result{}, err

--- a/pkg/kv/kvserver/batcheval/cmd_resolve_intent_range.go
+++ b/pkg/kv/kvserver/batcheval/cmd_resolve_intent_range.go
@@ -55,8 +55,10 @@ func ResolveIntentRange(
 		// The observation was from the wrong node. Ignore.
 		update.ClockWhilePending = roachpb.ObservedTimestamp{}
 	}
-	numKeys, numBytes, resumeSpan, resumeReason, err := storage.MVCCResolveWriteIntentRange(ctx, readWriter, ms, update,
-		storage.MVCCResolveWriteIntentRangeOptions{MaxKeys: h.MaxSpanRequestKeys, TargetBytes: h.TargetBytes})
+	numKeys, numBytes, resumeSpan, resumeReason, _, err :=
+		storage.MVCCResolveWriteIntentRange(ctx, readWriter, ms, update,
+			storage.MVCCResolveWriteIntentRangeOptions{MaxKeys: h.MaxSpanRequestKeys, TargetBytes: h.TargetBytes},
+		)
 	if err != nil {
 		return result.Result{}, err
 	}

--- a/pkg/kv/kvserver/batcheval/cmd_resolve_intent_range.go
+++ b/pkg/kv/kvserver/batcheval/cmd_resolve_intent_range.go
@@ -55,7 +55,7 @@ func ResolveIntentRange(
 		// The observation was from the wrong node. Ignore.
 		update.ClockWhilePending = roachpb.ObservedTimestamp{}
 	}
-	numKeys, numBytes, resumeSpan, resumeReason, _, err :=
+	numKeys, numBytes, resumeSpan, resumeReason, replLocksReleased, err :=
 		storage.MVCCResolveWriteIntentRange(ctx, readWriter, ms, update,
 			storage.MVCCResolveWriteIntentRangeOptions{MaxKeys: h.MaxSpanRequestKeys, TargetBytes: h.TargetBytes},
 		)
@@ -78,6 +78,22 @@ func ResolveIntentRange(
 	var res result.Result
 	res.Local.ResolvedLocks = []roachpb.LockUpdate{update}
 	res.Local.Metrics = resolveToMetricType(args.Status, args.Poison)
+
+	// Handle replicated lock releases.
+	if replLocksReleased && update.Status == roachpb.COMMITTED {
+		// A replicated {shared, exclusive} lock was released for a committed
+		// transaction. Now that the lock is no longer there, we still need to make
+		// sure other transactions can't write underneath the transaction's commit
+		// timestamp to the key. We return the transaction's commit timestamp on the
+		// response and update the timestamp cache a few layers above to ensure
+		// this.
+		//
+		// NB: Doing so will update the timestamp cache over the entire key span the
+		// request operated over -- we're losing fidelity about which key(s) had
+		// locks. We could do a better job tracking and plumbing this information
+		// up, but we choose not to.
+		reply.ReplicatedLocksReleasedCommitTimestamp = update.Txn.WriteTimestamp
+	}
 
 	if WriteAbortSpanOnResolve(args.Status, args.Poison, numKeys > 0) {
 		if err := UpdateAbortSpan(ctx, cArgs.EvalCtx, readWriter, ms, args.IntentTxn, args.Poison); err != nil {

--- a/pkg/kv/kvserver/gc/gc_random_test.go
+++ b/pkg/kv/kvserver/gc/gc_random_test.go
@@ -366,7 +366,9 @@ func TestNewVsInvariants(t *testing.T) {
 					Txn:    i.Txn,
 					Status: roachpb.ABORTED,
 				}
-				_, _, _, err := storage.MVCCResolveWriteIntent(ctx, eng, &stats, l, storage.MVCCResolveWriteIntentOptions{})
+				_, _, _, _, err := storage.MVCCResolveWriteIntent(
+					ctx, eng, &stats, l, storage.MVCCResolveWriteIntentOptions{},
+				)
 				require.NoError(t, err, "failed to resolve intent")
 			}
 			for _, cr := range gcer.clearRanges() {

--- a/pkg/kv/kvserver/loqrecovery/apply.go
+++ b/pkg/kv/kvserver/loqrecovery/apply.go
@@ -274,7 +274,7 @@ func applyReplicaUpdate(
 			Txn:    res.Intent.Txn,
 			Status: roachpb.ABORTED,
 		}
-		if _, _, _, err := storage.MVCCResolveWriteIntent(ctx, readWriter, &ms, update, storage.MVCCResolveWriteIntentOptions{}); err != nil {
+		if _, _, _, _, err := storage.MVCCResolveWriteIntent(ctx, readWriter, &ms, update, storage.MVCCResolveWriteIntentOptions{}); err != nil {
 			return PrepareReplicaReport{}, err
 		}
 		report.AbortedTransaction = true

--- a/pkg/storage/bench_data_test.go
+++ b/pkg/storage/bench_data_test.go
@@ -333,7 +333,7 @@ func (d mvccBenchData) Build(ctx context.Context, b *testing.B, eng Engine) erro
 		key := keySlice[idx]
 		txnMeta := txn.TxnMeta
 		txnMeta.WriteTimestamp = hlc.Timestamp{WallTime: int64(counts[idx]) * 5}
-		if _, _, _, err := MVCCResolveWriteIntent(ctx, batch, nil /* ms */, roachpb.LockUpdate{
+		if _, _, _, _, err := MVCCResolveWriteIntent(ctx, batch, nil /* ms */, roachpb.LockUpdate{
 			Span:   roachpb.Span{Key: key},
 			Status: roachpb.COMMITTED,
 			Txn:    txnMeta,

--- a/pkg/storage/bench_test.go
+++ b/pkg/storage/bench_test.go
@@ -339,7 +339,7 @@ func setupKeysWithIntent(
 					// is not one that should be resolved.
 					continue
 				}
-				found, _, _, err := MVCCResolveWriteIntent(context.Background(), batch, nil, lu, MVCCResolveWriteIntentOptions{})
+				found, _, _, _, err := MVCCResolveWriteIntent(context.Background(), batch, nil, lu, MVCCResolveWriteIntentOptions{})
 				require.Equal(b, true, found)
 				require.NoError(b, err)
 			}
@@ -567,7 +567,7 @@ func BenchmarkIntentResolution(b *testing.B) {
 							b.StartTimer()
 						}
 						lockUpdate.Key = keys[i%numIntentKeys]
-						found, _, _, err := MVCCResolveWriteIntent(context.Background(), batch, nil, lockUpdate, MVCCResolveWriteIntentOptions{})
+						found, _, _, _, err := MVCCResolveWriteIntent(context.Background(), batch, nil, lockUpdate, MVCCResolveWriteIntentOptions{})
 						if !found || err != nil {
 							b.Fatalf("intent not found or err %s", err)
 						}
@@ -627,7 +627,7 @@ func BenchmarkIntentRangeResolution(b *testing.B) {
 										rangeNum := i % numRanges
 										lockUpdate.Key = keys[rangeNum*numKeysPerRange]
 										lockUpdate.EndKey = keys[(rangeNum+1)*numKeysPerRange]
-										resolved, _, span, _, err := MVCCResolveWriteIntentRange(
+										resolved, _, span, _, _, err := MVCCResolveWriteIntentRange(
 											context.Background(), batch, nil, lockUpdate,
 											MVCCResolveWriteIntentRangeOptions{MaxKeys: 1000})
 										if err != nil {
@@ -1901,7 +1901,7 @@ func BenchmarkMVCCScannerWithIntentsAndVersions(b *testing.B) {
 			key := makeKey(nil, j)
 			lu := lockUpdate
 			lu.Key = key
-			found, _, _, err := MVCCResolveWriteIntent(
+			found, _, _, _, err := MVCCResolveWriteIntent(
 				ctx, batch, nil, lu, MVCCResolveWriteIntentOptions{})
 			require.Equal(b, true, found)
 			require.NoError(b, err)

--- a/pkg/storage/metamorphic/operations.go
+++ b/pkg/storage/metamorphic/operations.go
@@ -487,7 +487,7 @@ func (t txnCommitOp) run(ctx context.Context) string {
 	for _, span := range txn.LockSpans {
 		intent := roachpb.MakeLockUpdate(txn, span)
 		intent.Status = roachpb.COMMITTED
-		_, _, _, err := storage.MVCCResolveWriteIntent(context.TODO(), t.m.engine, nil, intent, storage.MVCCResolveWriteIntentOptions{})
+		_, _, _, _, err := storage.MVCCResolveWriteIntent(context.TODO(), t.m.engine, nil, intent, storage.MVCCResolveWriteIntentOptions{})
 		if err != nil {
 			panic(err)
 		}
@@ -510,7 +510,7 @@ func (t txnAbortOp) run(ctx context.Context) string {
 	for _, span := range txn.LockSpans {
 		intent := roachpb.MakeLockUpdate(txn, span)
 		intent.Status = roachpb.ABORTED
-		_, _, _, err := storage.MVCCResolveWriteIntent(context.TODO(), t.m.engine, nil, intent, storage.MVCCResolveWriteIntentOptions{})
+		_, _, _, _, err := storage.MVCCResolveWriteIntent(context.TODO(), t.m.engine, nil, intent, storage.MVCCResolveWriteIntentOptions{})
 		if err != nil {
 			panic(err)
 		}

--- a/pkg/storage/mvcc_incremental_iterator_test.go
+++ b/pkg/storage/mvcc_incremental_iterator_test.go
@@ -1026,12 +1026,12 @@ func TestMVCCIncrementalIterator(t *testing.T) {
 
 		intent1 := roachpb.MakeLockUpdate(&txn1, roachpb.Span{Key: testKey1})
 		intent1.Status = roachpb.COMMITTED
-		if _, _, _, err := MVCCResolveWriteIntent(ctx, e, nil, intent1, MVCCResolveWriteIntentOptions{}); err != nil {
+		if _, _, _, _, err := MVCCResolveWriteIntent(ctx, e, nil, intent1, MVCCResolveWriteIntentOptions{}); err != nil {
 			t.Fatal(err)
 		}
 		intent2 := roachpb.MakeLockUpdate(&txn2, roachpb.Span{Key: testKey2})
 		intent2.Status = roachpb.ABORTED
-		if _, _, _, err := MVCCResolveWriteIntent(ctx, e, nil, intent2, MVCCResolveWriteIntentOptions{}); err != nil {
+		if _, _, _, _, err := MVCCResolveWriteIntent(ctx, e, nil, intent2, MVCCResolveWriteIntentOptions{}); err != nil {
 			t.Fatal(err)
 		}
 		t.Run("intents-resolved", assertEqualKVs(e, localMax, keyMax, tsMin, tsMax, latest, kvs(kv1_4_4, kv2_2_2)))
@@ -1093,12 +1093,12 @@ func TestMVCCIncrementalIterator(t *testing.T) {
 
 		intent1 := roachpb.MakeLockUpdate(&txn1, roachpb.Span{Key: testKey1})
 		intent1.Status = roachpb.COMMITTED
-		if _, _, _, err := MVCCResolveWriteIntent(ctx, e, nil, intent1, MVCCResolveWriteIntentOptions{}); err != nil {
+		if _, _, _, _, err := MVCCResolveWriteIntent(ctx, e, nil, intent1, MVCCResolveWriteIntentOptions{}); err != nil {
 			t.Fatal(err)
 		}
 		intent2 := roachpb.MakeLockUpdate(&txn2, roachpb.Span{Key: testKey2})
 		intent2.Status = roachpb.ABORTED
-		if _, _, _, err := MVCCResolveWriteIntent(ctx, e, nil, intent2, MVCCResolveWriteIntentOptions{}); err != nil {
+		if _, _, _, _, err := MVCCResolveWriteIntent(ctx, e, nil, intent2, MVCCResolveWriteIntentOptions{}); err != nil {
 			t.Fatal(err)
 		}
 		t.Run("intents-resolved", assertEqualKVs(e, localMax, keyMax, tsMin, tsMax, all, kvs(kv1_4_4, kv1Deleted3, kv1_2_2, kv1_1_1, kv2_2_2)))
@@ -1284,9 +1284,9 @@ func TestMVCCIncrementalIteratorIntentDeletion(t *testing.T) {
 	require.NoError(t, MVCCPut(ctx, db, kC, txnC1.ReadTimestamp, vC1, MVCCWriteOptions{Txn: txnC1}))
 	require.NoError(t, db.Flush())
 	require.NoError(t, db.Compact())
-	_, _, _, err := MVCCResolveWriteIntent(ctx, db, nil, intent(txnA1), MVCCResolveWriteIntentOptions{})
+	_, _, _, _, err := MVCCResolveWriteIntent(ctx, db, nil, intent(txnA1), MVCCResolveWriteIntentOptions{})
 	require.NoError(t, err)
-	_, _, _, err = MVCCResolveWriteIntent(ctx, db, nil, intent(txnB1), MVCCResolveWriteIntentOptions{})
+	_, _, _, _, err = MVCCResolveWriteIntent(ctx, db, nil, intent(txnB1), MVCCResolveWriteIntentOptions{})
 	require.NoError(t, err)
 	require.NoError(t, MVCCPut(ctx, db, kA, ts2, vA2, MVCCWriteOptions{}))
 	require.NoError(t, MVCCPut(ctx, db, kA, txnA3.WriteTimestamp, vA3, MVCCWriteOptions{Txn: txnA3}))

--- a/pkg/storage/mvcc_logical_ops_test.go
+++ b/pkg/storage/mvcc_logical_ops_test.go
@@ -73,14 +73,14 @@ func TestMVCCOpLogWriter(t *testing.T) {
 	// Resolve all three intent.
 	txn1CommitTS := *txn1Commit
 	txn1CommitTS.WriteTimestamp = hlc.Timestamp{Logical: 4}
-	if _, _, _, _, err := MVCCResolveWriteIntentRange(ctx, ol, nil,
+	if _, _, _, _, _, err := MVCCResolveWriteIntentRange(ctx, ol, nil,
 		roachpb.MakeLockUpdate(
 			&txn1CommitTS,
 			roachpb.Span{Key: testKey1, EndKey: testKey2.Next()}),
 		MVCCResolveWriteIntentRangeOptions{}); err != nil {
 		t.Fatal(err)
 	}
-	if _, _, _, _, err := MVCCResolveWriteIntentRange(ctx, ol, nil,
+	if _, _, _, _, _, err := MVCCResolveWriteIntentRange(ctx, ol, nil,
 		roachpb.MakeLockUpdate(
 			&txn1CommitTS,
 			roachpb.Span{Key: localKey, EndKey: localKey.Next()}),
@@ -96,7 +96,7 @@ func TestMVCCOpLogWriter(t *testing.T) {
 	}
 	txn2Pushed := *txn2
 	txn2Pushed.WriteTimestamp = hlc.Timestamp{Logical: 6}
-	if _, _, _, err := MVCCResolveWriteIntent(ctx, ol, nil,
+	if _, _, _, _, err := MVCCResolveWriteIntent(ctx, ol, nil,
 		roachpb.MakeLockUpdate(&txn2Pushed, roachpb.Span{Key: testKey3}),
 		MVCCResolveWriteIntentOptions{},
 	); err != nil {
@@ -104,7 +104,7 @@ func TestMVCCOpLogWriter(t *testing.T) {
 	}
 	txn2Abort := txn2Pushed
 	txn2Abort.Status = roachpb.ABORTED
-	if _, _, _, err := MVCCResolveWriteIntent(ctx, ol, nil,
+	if _, _, _, _, err := MVCCResolveWriteIntent(ctx, ol, nil,
 		roachpb.MakeLockUpdate(&txn2Abort, roachpb.Span{Key: testKey3}),
 		MVCCResolveWriteIntentOptions{},
 	); err != nil {

--- a/pkg/storage/mvcc_stats_test.go
+++ b/pkg/storage/mvcc_stats_test.go
@@ -145,7 +145,7 @@ func TestMVCCStatsDeleteCommitMovesTimestamp(t *testing.T) {
 	ts4 := hlc.Timestamp{WallTime: 4 * 1e9}
 	txn.Status = roachpb.COMMITTED
 	txn.WriteTimestamp.Forward(ts4)
-	if _, _, _, err := MVCCResolveWriteIntent(ctx, engine, aggMS,
+	if _, _, _, _, err := MVCCResolveWriteIntent(ctx, engine, aggMS,
 		roachpb.MakeLockUpdate(txn, roachpb.Span{Key: key}),
 		MVCCResolveWriteIntentOptions{},
 	); err != nil {
@@ -235,7 +235,7 @@ func TestMVCCStatsPutCommitMovesTimestamp(t *testing.T) {
 	ts4 := hlc.Timestamp{WallTime: 4 * 1e9}
 	txn.Status = roachpb.COMMITTED
 	txn.WriteTimestamp.Forward(ts4)
-	if _, _, _, err := MVCCResolveWriteIntent(ctx, engine, aggMS,
+	if _, _, _, _, err := MVCCResolveWriteIntent(ctx, engine, aggMS,
 		roachpb.MakeLockUpdate(txn, roachpb.Span{Key: key}),
 		MVCCResolveWriteIntentOptions{},
 	); err != nil {
@@ -323,7 +323,7 @@ func TestMVCCStatsPutPushMovesTimestamp(t *testing.T) {
 	// push as it would happen for a SNAPSHOT txn)
 	ts4 := hlc.Timestamp{WallTime: 4 * 1e9}
 	txn.WriteTimestamp.Forward(ts4)
-	if _, _, _, err := MVCCResolveWriteIntent(ctx, engine, aggMS,
+	if _, _, _, _, err := MVCCResolveWriteIntent(ctx, engine, aggMS,
 		roachpb.MakeLockUpdate(txn, roachpb.Span{Key: key}),
 		MVCCResolveWriteIntentOptions{},
 	); err != nil {
@@ -701,7 +701,7 @@ func TestMVCCStatsDelDelCommitMovesTimestamp(t *testing.T) {
 		txnCommit := txn.Clone()
 		txnCommit.Status = roachpb.COMMITTED
 		txnCommit.WriteTimestamp.Forward(ts3)
-		if _, _, _, err := MVCCResolveWriteIntent(ctx, engine, &aggMS,
+		if _, _, _, _, err := MVCCResolveWriteIntent(ctx, engine, &aggMS,
 			roachpb.MakeLockUpdate(txnCommit, roachpb.Span{Key: key}),
 			MVCCResolveWriteIntentOptions{},
 		); err != nil {
@@ -738,7 +738,7 @@ func TestMVCCStatsDelDelCommitMovesTimestamp(t *testing.T) {
 		txnAbort := txn.Clone()
 		txnAbort.Status = roachpb.ABORTED
 		txnAbort.WriteTimestamp.Forward(ts3)
-		if _, _, _, err := MVCCResolveWriteIntent(ctx, engine, &aggMS,
+		if _, _, _, _, err := MVCCResolveWriteIntent(ctx, engine, &aggMS,
 			roachpb.MakeLockUpdate(txnAbort, roachpb.Span{Key: key}),
 			MVCCResolveWriteIntentOptions{},
 		); err != nil {
@@ -876,7 +876,7 @@ func TestMVCCStatsPutDelPutMovesTimestamp(t *testing.T) {
 
 		txnAbort := txn.Clone()
 		txnAbort.Status = roachpb.ABORTED // doesn't change m2ValSize, fortunately
-		if _, _, _, err := MVCCResolveWriteIntent(ctx, engine, &aggMS,
+		if _, _, _, _, err := MVCCResolveWriteIntent(ctx, engine, &aggMS,
 			roachpb.MakeLockUpdate(txnAbort, roachpb.Span{Key: key}),
 			MVCCResolveWriteIntentOptions{},
 		); err != nil {
@@ -1392,7 +1392,7 @@ func TestMVCCStatsTxnSysPutAbort(t *testing.T) {
 
 	// Now abort the intent.
 	txn.Status = roachpb.ABORTED
-	if _, _, _, err := MVCCResolveWriteIntent(ctx, engine, aggMS,
+	if _, _, _, _, err := MVCCResolveWriteIntent(ctx, engine, aggMS,
 		roachpb.MakeLockUpdate(txn, roachpb.Span{Key: key}),
 		MVCCResolveWriteIntentOptions{},
 	); err != nil {
@@ -1811,13 +1811,13 @@ func TestMVCCStatsRandomized(t *testing.T) {
 		desc := fmt.Sprintf("ranged=%t", ranged)
 		if s.Txn != nil {
 			if !ranged {
-				if _, _, _, err := MVCCResolveWriteIntent(ctx, s.batch, s.MSDelta, s.intent(status), MVCCResolveWriteIntentOptions{}); err != nil {
+				if _, _, _, _, err := MVCCResolveWriteIntent(ctx, s.batch, s.MSDelta, s.intent(status), MVCCResolveWriteIntentOptions{}); err != nil {
 					return false, desc + ": " + err.Error()
 				}
 			} else {
 				max := s.rng.Int63n(5)
 				desc += fmt.Sprintf(", max=%d", max)
-				if _, _, _, _, err := MVCCResolveWriteIntentRange(
+				if _, _, _, _, _, err := MVCCResolveWriteIntentRange(
 					ctx, s.batch, s.MSDelta, s.intentRange(status),
 					MVCCResolveWriteIntentRangeOptions{}); err != nil {
 					return false, desc + ": " + err.Error()

--- a/pkg/storage/mvcc_test.go
+++ b/pkg/storage/mvcc_test.go
@@ -2303,7 +2303,7 @@ func TestMVCCInitPutWithTxn(t *testing.T) {
 	txnCommit := txn
 	txnCommit.Status = roachpb.COMMITTED
 	txnCommit.WriteTimestamp = clock.Now().Add(1, 0)
-	_, _, _, err = MVCCResolveWriteIntent(ctx, engine, nil,
+	_, _, _, _, err = MVCCResolveWriteIntent(ctx, engine, nil,
 		roachpb.MakeLockUpdate(&txnCommit, roachpb.Span{Key: testKey1}),
 		MVCCResolveWriteIntentOptions{})
 	require.NoError(t, err)
@@ -2596,7 +2596,7 @@ func TestMVCCResolveTxn(t *testing.T) {
 	}
 
 	// Resolve will write with txn1's timestamp which is 0,1.
-	if _, _, _, err := MVCCResolveWriteIntent(ctx, engine, nil,
+	if _, _, _, _, err := MVCCResolveWriteIntent(ctx, engine, nil,
 		roachpb.MakeLockUpdate(txn1Commit, roachpb.Span{Key: testKey1}),
 		MVCCResolveWriteIntentOptions{}); err != nil {
 		t.Fatal(err)
@@ -2636,7 +2636,7 @@ func TestMVCCResolveNewerIntent(t *testing.T) {
 	}
 
 	// Resolve will succeed but should remove the intent.
-	if _, _, _, err := MVCCResolveWriteIntent(ctx, engine, nil,
+	if _, _, _, _, err := MVCCResolveWriteIntent(ctx, engine, nil,
 		roachpb.MakeLockUpdate(txn1Commit, roachpb.Span{Key: testKey1}),
 		MVCCResolveWriteIntentOptions{}); err != nil {
 		t.Fatal(err)
@@ -2794,7 +2794,7 @@ func TestMVCCResolveIntentTxnTimestampMismatch(t *testing.T) {
 
 	// A bug (see #7654) caused intents to just stay where they were instead
 	// of being moved forward in the situation set up above.
-	if _, _, _, err := MVCCResolveWriteIntent(ctx, engine, nil, intent, MVCCResolveWriteIntentOptions{}); err != nil {
+	if _, _, _, _, err := MVCCResolveWriteIntent(ctx, engine, nil, intent, MVCCResolveWriteIntentOptions{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2957,7 +2957,7 @@ func TestMVCCAbortTxn(t *testing.T) {
 	txn1AbortWithTS := txn1Abort.Clone()
 	txn1AbortWithTS.WriteTimestamp = hlc.Timestamp{Logical: 1}
 
-	if _, _, _, err := MVCCResolveWriteIntent(ctx, engine, nil,
+	if _, _, _, _, err := MVCCResolveWriteIntent(ctx, engine, nil,
 		roachpb.MakeLockUpdate(txn1AbortWithTS, roachpb.Span{Key: testKey1}),
 		MVCCResolveWriteIntentOptions{},
 	); err != nil {
@@ -2996,7 +2996,7 @@ func TestMVCCAbortTxnWithPreviousVersion(t *testing.T) {
 	txn1AbortWithTS := txn1Abort.Clone()
 	txn1AbortWithTS.WriteTimestamp = hlc.Timestamp{WallTime: 2}
 
-	if _, _, _, err := MVCCResolveWriteIntent(ctx, engine, nil,
+	if _, _, _, _, err := MVCCResolveWriteIntent(ctx, engine, nil,
 		roachpb.MakeLockUpdate(txn1AbortWithTS, roachpb.Span{Key: testKey1}),
 		MVCCResolveWriteIntentOptions{},
 	); err != nil {
@@ -3060,7 +3060,7 @@ func TestMVCCWriteWithDiffTimestampsAndEpochs(t *testing.T) {
 	txne2Commit := txne2
 	txne2Commit.Status = roachpb.COMMITTED
 	txne2Commit.WriteTimestamp = hlc.Timestamp{WallTime: 1}
-	_, _, _, err = MVCCResolveWriteIntent(ctx, engine, nil,
+	_, _, _, _, err = MVCCResolveWriteIntent(ctx, engine, nil,
 		roachpb.MakeLockUpdate(&txne2Commit, roachpb.Span{Key: testKey1}),
 		MVCCResolveWriteIntentOptions{})
 	require.NoError(t, err)
@@ -3315,7 +3315,7 @@ func TestMVCCGetWithPushedTimestamp(t *testing.T) {
 	}
 	// Resolve the intent, pushing its timestamp forward.
 	txn := makeTxn(*txn1, hlc.Timestamp{WallTime: 1})
-	if _, _, _, err := MVCCResolveWriteIntent(ctx, engine, nil,
+	if _, _, _, _, err := MVCCResolveWriteIntent(ctx, engine, nil,
 		roachpb.MakeLockUpdate(txn, roachpb.Span{Key: testKey1}),
 		MVCCResolveWriteIntentOptions{}); err != nil {
 		t.Fatal(err)
@@ -3343,7 +3343,7 @@ func TestMVCCResolveWithDiffEpochs(t *testing.T) {
 	if err := MVCCPut(ctx, engine, testKey2, txn1e2.ReadTimestamp, value2, MVCCWriteOptions{Txn: txn1e2}); err != nil {
 		t.Fatal(err)
 	}
-	numKeys, _, _, _, err := MVCCResolveWriteIntentRange(ctx, engine, nil,
+	numKeys, _, _, _, _, err := MVCCResolveWriteIntentRange(ctx, engine, nil,
 		roachpb.MakeLockUpdate(txn1e2Commit, roachpb.Span{Key: testKey1, EndKey: testKey2.Next()}),
 		MVCCResolveWriteIntentRangeOptions{MaxKeys: 2})
 	if err != nil {
@@ -3397,7 +3397,7 @@ func TestMVCCResolveWithUpdatedTimestamp(t *testing.T) {
 	// Resolve with a higher commit timestamp -- this should rewrite the
 	// intent when making it permanent.
 	txn := makeTxn(*txn1Commit, hlc.Timestamp{WallTime: 1})
-	if _, _, _, err = MVCCResolveWriteIntent(ctx, engine, nil,
+	if _, _, _, _, err = MVCCResolveWriteIntent(ctx, engine, nil,
 		roachpb.MakeLockUpdate(txn, roachpb.Span{Key: testKey1}),
 		MVCCResolveWriteIntentOptions{}); err != nil {
 		t.Fatal(err)
@@ -3446,7 +3446,7 @@ func TestMVCCResolveWithPushedTimestamp(t *testing.T) {
 	// Resolve with a higher commit timestamp, but with still-pending transaction.
 	// This represents a straightforward push (i.e. from a read/write conflict).
 	txn := makeTxn(*txn1, hlc.Timestamp{WallTime: 1})
-	if _, _, _, err = MVCCResolveWriteIntent(ctx, engine, nil,
+	if _, _, _, _, err = MVCCResolveWriteIntent(ctx, engine, nil,
 		roachpb.MakeLockUpdate(txn, roachpb.Span{Key: testKey1}),
 		MVCCResolveWriteIntentOptions{}); err != nil {
 		t.Fatal(err)
@@ -3482,7 +3482,7 @@ func TestMVCCResolveTxnNoOps(t *testing.T) {
 	defer engine.Close()
 
 	// Resolve a non existent key; noop.
-	if _, _, _, err := MVCCResolveWriteIntent(ctx, engine, nil,
+	if _, _, _, _, err := MVCCResolveWriteIntent(ctx, engine, nil,
 		roachpb.MakeLockUpdate(txn1Commit, roachpb.Span{Key: testKey1}),
 		MVCCResolveWriteIntentOptions{}); err != nil {
 		t.Fatal(err)
@@ -3492,7 +3492,7 @@ func TestMVCCResolveTxnNoOps(t *testing.T) {
 	if err := MVCCPut(ctx, engine, testKey1, hlc.Timestamp{Logical: 1}, value1, MVCCWriteOptions{}); err != nil {
 		t.Fatal(err)
 	}
-	if _, _, _, err := MVCCResolveWriteIntent(ctx, engine, nil,
+	if _, _, _, _, err := MVCCResolveWriteIntent(ctx, engine, nil,
 		roachpb.MakeLockUpdate(txn2Commit, roachpb.Span{Key: testKey1}),
 		MVCCResolveWriteIntentOptions{}); err != nil {
 		t.Fatal(err)
@@ -3505,7 +3505,7 @@ func TestMVCCResolveTxnNoOps(t *testing.T) {
 
 	txn1CommitWithTS := txn2Commit.Clone()
 	txn1CommitWithTS.WriteTimestamp = hlc.Timestamp{WallTime: 1}
-	if _, _, _, err := MVCCResolveWriteIntent(ctx, engine, nil,
+	if _, _, _, _, err := MVCCResolveWriteIntent(ctx, engine, nil,
 		roachpb.MakeLockUpdate(txn1CommitWithTS, roachpb.Span{Key: testKey2}),
 		MVCCResolveWriteIntentOptions{}); err != nil {
 		t.Fatal(err)
@@ -3533,7 +3533,7 @@ func TestMVCCResolveTxnRange(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	numKeys, _, resumeSpan, _, err := MVCCResolveWriteIntentRange(ctx, engine, nil,
+	numKeys, _, resumeSpan, _, _, err := MVCCResolveWriteIntentRange(ctx, engine, nil,
 		roachpb.MakeLockUpdate(txn1Commit, roachpb.Span{Key: testKey1, EndKey: testKey4.Next()}),
 		MVCCResolveWriteIntentRangeOptions{})
 	if err != nil {
@@ -3622,7 +3622,7 @@ func TestMVCCResolveTxnRangeResume(t *testing.T) {
 	defer rw.Close()
 
 	// Resolve up to 6 intents: the keys are 000, 033, 066, 099, 1212, 1515.
-	numKeys, _, resumeSpan, _, err := MVCCResolveWriteIntentRange(ctx, rw, nil,
+	numKeys, _, resumeSpan, _, _, err := MVCCResolveWriteIntentRange(ctx, rw, nil,
 		roachpb.MakeLockUpdate(txn1Commit, roachpb.Span{Key: roachpb.Key("00"), EndKey: roachpb.Key("33")}),
 		MVCCResolveWriteIntentRangeOptions{MaxKeys: 6})
 	if err != nil {
@@ -3667,7 +3667,7 @@ func TestMVCCResolveTxnRangeResumeWithManyVersions(t *testing.T) {
 	i := 0
 	for {
 		// Resolve up to 20 intents.
-		numKeys, _, resumeSpan, _, err := MVCCResolveWriteIntentRange(ctx, engine, nil, lockUpdate,
+		numKeys, _, resumeSpan, _, _, err := MVCCResolveWriteIntentRange(ctx, engine, nil, lockUpdate,
 			MVCCResolveWriteIntentRangeOptions{MaxKeys: 20})
 		require.NoError(t, err)
 		require.Equal(t, int64(20), numKeys)
@@ -3893,7 +3893,7 @@ func TestRandomizedMVCCResolveWriteIntentRange(t *testing.T) {
 		func() {
 			batch := engs[i].eng.NewBatch()
 			defer batch.Close()
-			_, _, _, _, err := MVCCResolveWriteIntentRange(ctx, batch, &engs[i].stats, lu, MVCCResolveWriteIntentRangeOptions{})
+			_, _, _, _, _, err := MVCCResolveWriteIntentRange(ctx, batch, &engs[i].stats, lu, MVCCResolveWriteIntentRangeOptions{})
 			require.NoError(t, err)
 			require.NoError(t, batch.Commit(false))
 		}()
@@ -3911,7 +3911,7 @@ func TestRandomizedMVCCResolveWriteIntentRange(t *testing.T) {
 			func() {
 				batch := engs[i].eng.NewBatch()
 				defer batch.Close()
-				_, _, _, _, err := MVCCResolveWriteIntentRange(ctx, batch, &engs[i].stats, lu, MVCCResolveWriteIntentRangeOptions{})
+				_, _, _, _, _, err := MVCCResolveWriteIntentRange(ctx, batch, &engs[i].stats, lu, MVCCResolveWriteIntentRangeOptions{})
 				require.NoError(t, err)
 				require.NoError(t, batch.Commit(false))
 			}()
@@ -4002,7 +4002,7 @@ func TestRandomizedSavepointRollbackAndIntentResolution(t *testing.T) {
 	}
 	// All the writes are ignored, so DEL is written for the intent. These
 	// should be buffered in the memtable.
-	_, _, _, _, err = MVCCResolveWriteIntentRange(ctx, eng, nil, lu, MVCCResolveWriteIntentRangeOptions{})
+	_, _, _, _, _, err = MVCCResolveWriteIntentRange(ctx, eng, nil, lu, MVCCResolveWriteIntentRangeOptions{})
 	require.NoError(t, err)
 	{
 		iter, err := eng.NewMVCCIterator(MVCCKeyAndIntentsIterKind,
@@ -4037,7 +4037,7 @@ func TestRandomizedSavepointRollbackAndIntentResolution(t *testing.T) {
 	if debug {
 		log.Infof(ctx, "LockUpdate: %s", lu.String())
 	}
-	_, _, _, _, err = MVCCResolveWriteIntentRange(ctx, eng, nil, lu, MVCCResolveWriteIntentRangeOptions{})
+	_, _, _, _, _, err = MVCCResolveWriteIntentRange(ctx, eng, nil, lu, MVCCResolveWriteIntentRangeOptions{})
 	require.NoError(t, err)
 	// Compact the engine so that SINGLEDEL consumes the SETWITHDEL, becoming a
 	// DEL.
@@ -6123,7 +6123,7 @@ func TestResolveIntentWithLowerEpoch(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Resolve the intent with a low epoch.
-	if _, _, _, err := MVCCResolveWriteIntent(ctx, engine, nil,
+	if _, _, _, _, err := MVCCResolveWriteIntent(ctx, engine, nil,
 		roachpb.MakeLockUpdate(txn1, roachpb.Span{Key: testKey1}),
 		MVCCResolveWriteIntentOptions{}); err != nil {
 		t.Fatal(err)

--- a/pkg/storage/testdata/mvcc_histories/replicated_locks
+++ b/pkg/storage/testdata/mvcc_histories/replicated_locks
@@ -631,6 +631,7 @@ resolve_intent t=A k=k1 status=COMMITTED
 ----
 >> resolve_intent t=A k=k1 status=COMMITTED
 resolve_intent: "k1" -> resolved key = true
+resolve_intent: released shared or exclusive locks
 stats: lock_count=-1 lock_bytes=-69 lock_age=-90
 >> at end:
 data: "k1"/5.000000000,0 -> /BYTES/v1
@@ -670,6 +671,7 @@ resolve_intent t=A k=k1 status=ABORTED
 ----
 >> resolve_intent t=A k=k1 status=ABORTED
 resolve_intent: "k1" -> resolved key = true
+resolve_intent: released shared or exclusive locks
 stats: lock_count=-1 lock_bytes=-71 lock_age=-90
 >> at end:
 data: "k1"/5.000000000,0 -> /BYTES/v1
@@ -711,6 +713,7 @@ with t=A
 ----
 >> resolve_intent k=k1 status=PENDING t=A
 resolve_intent: "k1" -> resolved key = true
+resolve_intent: released shared or exclusive locks
 stats: lock_count=-1 lock_bytes=-71 lock_age=-90
 >> at end:
 txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=2 ts=10.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=10.000000000,0 wto=false gul=0,0
@@ -839,6 +842,7 @@ with t=A
 ----
 >> resolve_intent k=k1 status=PENDING t=A
 resolve_intent: "k1" -> resolved key = true
+resolve_intent: released shared or exclusive locks
 stats: lock_count=-1 lock_bytes=-69 lock_age=-90
 >> at end:
 txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=2 ts=10.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=10.000000000,0 wto=false gul=0,0 isn=1
@@ -865,6 +869,7 @@ resolve_intent_range t=A k=k2 end=k5 status=COMMITTED
 ----
 >> resolve_intent_range t=A k=k2 end=k5 status=COMMITTED
 resolve_intent_range: "k2"-"k5" -> resolved 3 key(s)
+resolve_intent_range: released shared or exclusive locks
 stats: key_count=-1 key_bytes=-39 val_count=-3 val_bytes=-202 live_count=+1 live_bytes=-47 gc_bytes_age=-17460 intent_count=-3 intent_bytes=-49 lock_count=-7 lock_bytes=-278 lock_age=-630
 >> at end:
 data: "k1"/5.000000000,0 -> /BYTES/v1
@@ -879,6 +884,7 @@ resolve_intent t=B k=k1 status=ABORTED
 ----
 >> resolve_intent t=B k=k1 status=ABORTED
 resolve_intent: "k1" -> resolved key = true
+resolve_intent: released shared or exclusive locks
 stats: lock_count=-1 lock_bytes=-67 lock_age=-89
 >> at end:
 data: "k1"/5.000000000,0 -> /BYTES/v1

--- a/pkg/storage/testdata/mvcc_histories/resolve_intent_pagination
+++ b/pkg/storage/testdata/mvcc_histories/resolve_intent_pagination
@@ -192,6 +192,7 @@ resolve_intent_range t=B k=a end=z status=COMMITTED maxKeys=1 batched
 >> resolve_intent_range t=B k=a end=z status=COMMITTED maxKeys=1 batched
 resolve_intent_range: "a"-"z" -> resolved 1 key(s), 56 bytes
 resolve_intent_range: resume span ["a\x00","z") RESUME_KEY_LIMIT
+resolve_intent_range: released shared or exclusive locks
 resolve_intent_range: batch after write is non-empty
 stats: val_bytes=-48 live_bytes=-48 intent_count=-1 intent_bytes=-18 lock_count=-2 lock_bytes=-66 lock_age=-198
 >> at end:
@@ -209,6 +210,7 @@ resolve_intent_range t=B k=a end=z status=COMMITTED targetBytes=1 batched
 >> resolve_intent_range t=B k=a end=z status=COMMITTED targetBytes=1 batched
 resolve_intent_range: "a"-"z" -> resolved 1 key(s), 84 bytes
 resolve_intent_range: resume span ["b\x00","z") RESUME_BYTE_LIMIT
+resolve_intent_range: released shared or exclusive locks
 resolve_intent_range: batch after write is non-empty
 stats: val_bytes=-48 live_bytes=-48 intent_count=-1 intent_bytes=-18 lock_count=-3 lock_bytes=-132 lock_age=-297
 >> at end:
@@ -222,6 +224,7 @@ resolve_intent_range t=B k=a end=z status=COMMITTED maxKeys=1 batched
 ----
 >> resolve_intent_range t=B k=a end=z status=COMMITTED maxKeys=1 batched
 resolve_intent_range: "a"-"z" -> resolved 1 key(s), 28 bytes
+resolve_intent_range: released shared or exclusive locks
 resolve_intent_range: batch after write is non-empty
 stats: lock_count=-1 lock_bytes=-66 lock_age=-99
 >> at end:


### PR DESCRIPTION
This patch teaches ResolveIntent and ResolveIntentRange requests to
bump the timestamp cache if any replicated shared/exclusive locks were
resolved by them (if the transaction that held the lock was committed).
In all other cases (only unreplicated locks, no shared or exclusive
locks, or aborted lock holder transaction) the timestamp cache is not
bumped.

The handling of ResolveIntentRange requests deserves some words -- for
these, we choose to bump the timestamp cache over the entire keyspan
they operated over if there's a single replicated {shared, exclusive}
lock. This means we're losing fidelity over specific keys that had point
locks on them; we choose this approach instead of trying to plumb high
fidelity information back up.

Lastly, it's worth noting that `EndTxn` requests also resolve local
locks. As such, any replicated {shared, exclusive} locks resolved by a
EndTxn request also need to be handled in similar fashion. This patch
does not do that -- we leave that to an subsequent patch, at which point
the linked issue can be closed.

Informs https://github.com/cockroachdb/cockroach/issues/111536

Release note: None