### PR TITLE
clusterversion: export binary{,MinSupported}Version

### DIFF
--- a/pkg/ccl/serverccl/server_startup_guardrails_test.go
+++ b/pkg/ccl/serverccl/server_startup_guardrails_test.go
@@ -34,9 +34,8 @@ func TestServerStartupGuardrails(t *testing.T) {
 	// returned by this function to work both on master (where the dev
 	// offset applies) and on release branches (where it doesn't).
 	v := func(major, minor int32) roachpb.Version {
-		binaryVersion := clusterversion.ByKey(clusterversion.BinaryVersionKey)
 		var offset int32
-		if binaryVersion.Major > clusterversion.DevOffset {
+		if clusterversion.BinaryVersion.Major > clusterversion.DevOffset {
 			offset = clusterversion.DevOffset
 		}
 		return roachpb.Version{Major: offset + major, Minor: minor}

--- a/pkg/cli/debug_recover_loss_of_quorum_test.go
+++ b/pkg/cli/debug_recover_loss_of_quorum_test.go
@@ -92,7 +92,7 @@ func TestCollectInfoFromMultipleStores(t *testing.T) {
 		stores[r.StoreID] = struct{}{}
 	}
 	require.Equal(t, 2, len(stores), "collected replicas from stores")
-	require.Equal(t, clusterversion.ByKey(clusterversion.BinaryVersionKey), replicas.Version,
+	require.Equal(t, clusterversion.BinaryVersion, replicas.Version,
 		"collected version info from stores")
 }
 
@@ -157,7 +157,7 @@ func TestCollectInfoFromOnlineCluster(t *testing.T) {
 	require.Equal(t, totalRanges*2, totalReplicas, "number of collected replicas")
 	require.Equal(t, totalRanges, len(replicas.Descriptors),
 		"number of collected descriptors from metadata")
-	require.Equal(t, clusterversion.ByKey(clusterversion.BinaryVersionKey), replicas.Version,
+	require.Equal(t, clusterversion.BinaryVersion, replicas.Version,
 		"collected version info from stores")
 }
 
@@ -371,7 +371,7 @@ func TestStageVersionCheck(t *testing.T) {
 	tc.StopServer(3)
 
 	adminClient := tc.Server(0).GetAdminClient(t)
-	v := clusterversion.ByKey(clusterversion.BinaryVersionKey)
+	v := clusterversion.BinaryVersion
 	v.Internal++
 	// To avoid crafting real replicas we use StaleLeaseholderNodeIDs to force
 	// node to stage plan for verification.
@@ -403,7 +403,7 @@ func TestStageVersionCheck(t *testing.T) {
 	p, ok, err := ps.LoadPlan()
 	require.NoError(t, err, "failed to read node 0 plan")
 	require.True(t, ok, "plan was not staged")
-	require.Equal(t, clusterversion.ByKey(clusterversion.BinaryVersionKey), p.Version,
+	require.Equal(t, clusterversion.BinaryVersion, p.Version,
 		"plan version was not updated")
 }
 

--- a/pkg/clusterversion/clusterversion.go
+++ b/pkg/clusterversion/clusterversion.go
@@ -171,7 +171,7 @@ var _ Handle = (*handleImpl)(nil)
 // supported versions initialized to this binary's build and it's minimum
 // supported versions respectively.
 func MakeVersionHandle(sv *settings.Values) Handle {
-	return MakeVersionHandleWithOverride(sv, binaryVersion, binaryMinSupportedVersion)
+	return MakeVersionHandleWithOverride(sv, BinaryVersion, BinaryMinSupportedVersion)
 }
 
 // MakeVersionHandleWithOverride returns a Handle that has its

--- a/pkg/clusterversion/clusterversion_test.go
+++ b/pkg/clusterversion/clusterversion_test.go
@@ -34,7 +34,7 @@ func TestClusterVersionOnChange(t *testing.T) {
 		"test description",
 		&cvs.VersionSetting)
 
-	handle := newHandleImpl(cvs, &sv, binaryVersion, binaryMinSupportedVersion)
+	handle := newHandleImpl(cvs, &sv, BinaryVersion, BinaryMinSupportedVersion)
 	newCV := ClusterVersion{
 		Version: roachpb.Version{
 			Major:    1,

--- a/pkg/clusterversion/cockroach_versions.go
+++ b/pkg/clusterversion/cockroach_versions.go
@@ -93,7 +93,7 @@ type Key int
 //	   (ii) V21_1Start (keyed to v20.2.0-1})
 //
 //	You'll then want to backport (i) to the release branch itself (i.e.
-//	release-20.2). You'll also want to bump binaryMinSupportedVersion. In the
+//	release-20.2). You'll also want to bump BinaryMinSupportedVersion. In the
 //	example above, you'll set it to V20_2. This indicates that the
 //	minimum binary version required in a cluster with nodes running
 //	v21.1 binaries (including pre-release alphas) is v20.2, i.e. that an
@@ -917,26 +917,26 @@ const (
 // feels out of place. A "cluster version" and a "binary version" are two
 // separate concepts.
 var (
-	// binaryMinSupportedVersion is the earliest version of data supported by
+	// BinaryMinSupportedVersion is the earliest version of data supported by
 	// this binary. If this binary is started using a store marked with an older
-	// version than binaryMinSupportedVersion, then the binary will exit with
+	// version than BinaryMinSupportedVersion, then the binary will exit with
 	// an error. This typically trails the current release by one (see top-level
 	// comment).
-	binaryMinSupportedVersion = ByKey(BinaryMinSupportedVersionKey)
+	BinaryMinSupportedVersion = ByKey(BinaryMinSupportedVersionKey)
 
 	BinaryVersionKey = V23_2
-	// binaryVersion is the version of this binary.
+	// BinaryVersion is the version of this binary.
 	//
 	// This is the version that a new cluster will use when created.
-	binaryVersion = ByKey(BinaryVersionKey)
+	BinaryVersion = ByKey(BinaryVersionKey)
 )
 
 func init() {
 	if finalVersion > invalidVersionKey {
-		if binaryVersion != ByKey(finalVersion) {
+		if BinaryVersion != ByKey(finalVersion) {
 			panic("binary version does not match final version")
 		}
-	} else if binaryVersion.Internal == 0 {
+	} else if BinaryVersion.Internal == 0 {
 		panic("a non-upgrade cluster version must be the final version")
 	}
 }

--- a/pkg/clusterversion/cockroach_versions_test.go
+++ b/pkg/clusterversion/cockroach_versions_test.go
@@ -27,7 +27,7 @@ func TestVersionsAreValid(t *testing.T) {
 }
 
 // TestPreserveVersionsForMinBinaryVersion ensures that versions
-// at or above binaryMinSupportedVersion are not deleted.
+// at or above BinaryMinSupportedVersion are not deleted.
 func TestPreserveVersionsForMinBinaryVersion(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
@@ -37,7 +37,7 @@ func TestPreserveVersionsForMinBinaryVersion(t *testing.T) {
 	}
 	for _, namedVersion := range versionsSingleton {
 		v := namedVersion.Version
-		if v.Less(binaryMinSupportedVersion) {
+		if v.Less(BinaryMinSupportedVersion) {
 			prevVersion = namedVersion
 			continue
 		}
@@ -46,7 +46,7 @@ func TestPreserveVersionsForMinBinaryVersion(t *testing.T) {
 				"version(s) between %s (%s) and %s (%s) is(are) at or above minBinaryVersion (%s) and should not be removed",
 				prevVersion.Key, prevVersion.Version,
 				namedVersion.Key, namedVersion.Version,
-				binaryMinSupportedVersion)
+				BinaryMinSupportedVersion)
 		}
 		prevVersion = namedVersion
 	}
@@ -157,13 +157,13 @@ func TestGetVersionsBetween(t *testing.T) {
 }
 
 // TestEnsureConsistentBinaryVersion ensures that BinaryVersionKey maps to a
-// version equal to binaryVersion.
+// version equal to BinaryVersion.
 func TestEnsureConsistentBinaryVersion(t *testing.T) {
-	require.Equal(t, ByKey(BinaryVersionKey), binaryVersion)
+	require.Equal(t, ByKey(BinaryVersionKey), BinaryVersion)
 }
 
 // TestEnsureConsistentMinBinaryVersion ensures that BinaryMinSupportedVersionKey
-// maps to a version equal to binaryMinSupportedVersion.
+// maps to a version equal to BinaryMinSupportedVersion.
 func TestEnsureConsistentMinBinaryVersion(t *testing.T) {
-	require.Equal(t, ByKey(BinaryMinSupportedVersionKey), binaryMinSupportedVersion)
+	require.Equal(t, ByKey(BinaryMinSupportedVersionKey), BinaryMinSupportedVersion)
 }

--- a/pkg/clusterversion/setting.go
+++ b/pkg/clusterversion/setting.go
@@ -41,9 +41,9 @@ const KeyVersionSetting = "version"
 // the version setting without looking at what's been persisted: The setting
 // specifies the minimum binary version we have to expect to be in a mixed
 // cluster with. We can't assume it is this binary's
-// binaryMinSupportedVersion as the cluster could've started up earlier and
+// BinaryMinSupportedVersion as the cluster could've started up earlier and
 // enabled features that are no longer compatible it; we can't assume it's our
-// binaryVersion as that would enable features that may trip up older versions
+// BinaryVersion as that would enable features that may trip up older versions
 // running in the same cluster. Hence, only once we get word of the "safe"
 // version to use can we allow moving parts that actually need to know what's
 // going on.
@@ -218,7 +218,7 @@ func (cv *clusterVersionSetting) ValidateBinaryVersions(
 
 // SettingsListDefault is part of the VersionSettingImpl interface.
 func (cv *clusterVersionSetting) SettingsListDefault() string {
-	return binaryVersion.String()
+	return BinaryVersion.String()
 }
 
 func (cv *clusterVersionSetting) validateBinaryVersions(

--- a/pkg/clusterversion/testutils.go
+++ b/pkg/clusterversion/testutils.go
@@ -12,11 +12,11 @@ package clusterversion
 
 // TestingBinaryVersion is a binary version that tests can use when they don't
 // want to go through a Settings object.
-var TestingBinaryVersion = binaryVersion
+var TestingBinaryVersion = BinaryVersion
 
 // TestingBinaryMinSupportedVersion is a minimum supported version that
 // tests can use when they don't want to go through a Settings object.
-var TestingBinaryMinSupportedVersion = binaryMinSupportedVersion
+var TestingBinaryMinSupportedVersion = BinaryMinSupportedVersion
 
 // TestingClusterVersion is a ClusterVersion that tests can use when they don't
 // want to go through a Settings object.

--- a/pkg/clusterversion/utilversions.go
+++ b/pkg/clusterversion/utilversions.go
@@ -11,4 +11,4 @@
 package clusterversion
 
 // DoctorBinaryVersion level used by the debug doctor when validating any files.
-var DoctorBinaryVersion = binaryVersion
+var DoctorBinaryVersion = BinaryVersion

--- a/pkg/configprofiles/profiles.go
+++ b/pkg/configprofiles/profiles.go
@@ -158,7 +158,7 @@ func makeTask(description string, nonTxnSQL, txnSQL []string) autoconfigpb.Task 
 		// We set MinVersion to BinaryVersionKey to ensure the tasks only
 		// start executing after all other version migrations have been
 		// completed.
-		MinVersion: clusterversion.ByKey(clusterversion.BinaryVersionKey),
+		MinVersion: clusterversion.BinaryVersion,
 		Payload: &autoconfigpb.Task_SimpleSQL{
 			SimpleSQL: &autoconfigpb.SimpleSQL{
 				NonTransactionalStatements: nonTxnSQL,

--- a/pkg/configprofiles/setter.go
+++ b/pkg/configprofiles/setter.go
@@ -87,7 +87,7 @@ func (ps *profileSetter) Set(v string) error {
 var endProfileTask = autoconfigpb.Task{
 	TaskID:      autoconfigpb.TaskID(math.MaxUint64),
 	Description: "end of configuration profile",
-	MinVersion:  clusterversion.ByKey(clusterversion.BinaryVersionKey),
+	MinVersion:  clusterversion.BinaryVersion,
 	Payload: &autoconfigpb.Task_SimpleSQL{
 		SimpleSQL: &autoconfigpb.SimpleSQL{},
 	},

--- a/pkg/jobs/job_info_storage_test.go
+++ b/pkg/jobs/job_info_storage_test.go
@@ -312,7 +312,7 @@ func TestJobInfoUpgradeRegressionTests(t *testing.T) {
 		Knobs: base.TestingKnobs{
 			Server: &server.TestingKnobs{
 				DisableAutomaticVersionUpgrade: make(chan struct{}),
-				BinaryVersionOverride:          clusterversion.ByKey(clusterversion.BinaryMinSupportedVersionKey),
+				BinaryVersionOverride:          clusterversion.BinaryMinSupportedVersion,
 				BootstrapVersionKeyOverride:    clusterversion.BinaryMinSupportedVersionKey,
 			},
 			JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),

--- a/pkg/kv/kvserver/kvstorage/cluster_version_test.go
+++ b/pkg/kv/kvserver/kvstorage/cluster_version_test.go
@@ -34,8 +34,8 @@ func TestStoresClusterVersionIncompatible(t *testing.T) {
 
 	ctx := context.Background()
 
-	current := clusterversion.ByKey(clusterversion.BinaryVersionKey)
-	minSupported := clusterversion.ByKey(clusterversion.BinaryMinSupportedVersionKey)
+	current := clusterversion.BinaryVersion
+	minSupported := clusterversion.BinaryMinSupportedVersion
 
 	future := current
 	future.Major++

--- a/pkg/kv/kvserver/loqrecovery/apply.go
+++ b/pkg/kv/kvserver/loqrecovery/apply.go
@@ -448,10 +448,8 @@ func CheckEnginesVersion(
 	plan loqrecoverypb.ReplicaUpdatePlan,
 	ignoreInternal bool,
 ) error {
-	binaryVersion := clusterversion.ByKey(clusterversion.BinaryVersionKey)
-	binaryMinSupportedVersion := clusterversion.ByKey(clusterversion.BinaryMinSupportedVersionKey)
 	clusterVersion, err := kvstorage.SynthesizeClusterVersionFromEngines(
-		ctx, engines, binaryVersion, binaryMinSupportedVersion,
+		ctx, engines, clusterversion.BinaryVersion, clusterversion.BinaryMinSupportedVersion,
 	)
 	if err != nil {
 		return errors.Wrap(err, "failed to get cluster version from storage")

--- a/pkg/kv/kvserver/loqrecovery/apply_test.go
+++ b/pkg/kv/kvserver/loqrecovery/apply_test.go
@@ -56,7 +56,7 @@ func TestApplyVerifiesVersion(t *testing.T) {
 	}
 
 	t.Run("apply plan version is higher than cluster", func(t *testing.T) {
-		aboveCurrent := clusterversion.ByKey(clusterversion.BinaryVersionKey)
+		aboveCurrent := clusterversion.BinaryVersion
 		aboveCurrent.Major += 1
 		plan := loqrecoverypb.ReplicaUpdatePlan{
 			PlanID:    uuid.MakeV4(),
@@ -67,7 +67,7 @@ func TestApplyVerifiesVersion(t *testing.T) {
 	})
 
 	t.Run("apply plan version lower than current", func(t *testing.T) {
-		belowMin := clusterversion.ByKey(clusterversion.BinaryMinSupportedVersionKey)
+		belowMin := clusterversion.BinaryMinSupportedVersion
 		belowMin.Minor -= 1
 		plan := loqrecoverypb.ReplicaUpdatePlan{
 			PlanID:    uuid.MakeV4(),

--- a/pkg/kv/kvserver/loqrecovery/collect.go
+++ b/pkg/kv/kvserver/loqrecovery/collect.go
@@ -113,10 +113,8 @@ func CollectStoresReplicaInfo(
 
 	// Synthesizing version from engine ensures that binary is compatible with
 	// the store, so we don't need to do any extra checks.
-	binaryVersion := clusterversion.ByKey(clusterversion.BinaryVersionKey)
-	binaryMinSupportedVersion := clusterversion.ByKey(clusterversion.BinaryMinSupportedVersionKey)
 	version, err := kvstorage.SynthesizeClusterVersionFromEngines(
-		ctx, stores, binaryVersion, binaryMinSupportedVersion,
+		ctx, stores, clusterversion.BinaryVersion, clusterversion.BinaryMinSupportedVersion,
 	)
 	if err != nil {
 		return loqrecoverypb.ClusterReplicaInfo{}, CollectionStats{}, errors.WithHint(err,

--- a/pkg/kv/kvserver/loqrecovery/marshalling_test.go
+++ b/pkg/kv/kvserver/loqrecovery/marshalling_test.go
@@ -31,7 +31,7 @@ import (
 func TestJsonSerialization(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	newVersion := clusterversion.ByKey(clusterversion.BinaryVersionKey)
+	newVersion := clusterversion.BinaryVersion
 
 	rs := []loqrecoverypb.ReplicaInfo{
 		{

--- a/pkg/kv/kvserver/loqrecovery/plan_test.go
+++ b/pkg/kv/kvserver/loqrecovery/plan_test.go
@@ -26,7 +26,7 @@ func TestVersionIsPreserved(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	ctx := context.Background()
 
-	current := clusterversion.ByKey(clusterversion.BinaryVersionKey)
+	current := clusterversion.BinaryVersion
 	current.Patch += 1
 
 	replicaInfo := infoWithVersion(current)

--- a/pkg/kv/kvserver/loqrecovery/recovery_env_test.go
+++ b/pkg/kv/kvserver/loqrecovery/recovery_env_test.go
@@ -626,7 +626,7 @@ func (e *quorumRecoveryEnv) getOrCreateStore(
 		); err != nil {
 			t.Fatalf("failed to populate test store ident: %v", err)
 		}
-		v := clusterversion.ByKey(clusterversion.BinaryVersionKey)
+		v := clusterversion.BinaryVersion
 		if err := kvstorage.WriteClusterVersionToEngines(ctx, []storage.Engine{eng}, clusterversion.ClusterVersion{Version: v}); err != nil {
 			t.Fatalf("failed to populate test store cluster version: %v", err)
 		}
@@ -658,7 +658,7 @@ func (e *quorumRecoveryEnv) handleCollectReplicas(
 		// This is unrealistic as we don't have metadata. We need to fake it here
 		// to pass planner checks.
 		e.replicas.ClusterID = e.clusterID.String()
-		e.replicas.Version = clusterversion.ByKey(clusterversion.BinaryVersionKey)
+		e.replicas.Version = clusterversion.BinaryVersion
 	}
 	e.replicas.Descriptors = e.meta
 	return "ok", nil

--- a/pkg/kv/kvserver/loqrecovery/server_integration_test.go
+++ b/pkg/kv/kvserver/loqrecovery/server_integration_test.go
@@ -99,7 +99,7 @@ func TestReplicaCollection(t *testing.T) {
 		}
 		require.NotEqual(t, replicas.ClusterID, uuid.UUID{}.String(), "cluster UUID must not be empty")
 		require.Equal(t, replicas.Version,
-			clusterversion.ByKey(clusterversion.BinaryVersionKey),
+			clusterversion.BinaryVersion,
 			"replica info version must match current binary version")
 	}
 
@@ -305,7 +305,7 @@ func TestStageBadVersions(t *testing.T) {
 	plan.Updates = []loqrecoverypb.ReplicaUpdate{
 		createRecoveryForRange(t, tc, sk, 1),
 	}
-	plan.Version = clusterversion.ByKey(clusterversion.BinaryMinSupportedVersionKey)
+	plan.Version = clusterversion.BinaryMinSupportedVersion
 	plan.Version.Major -= 1
 
 	_, err := adm.RecoveryStagePlan(ctx, &serverpb.RecoveryStagePlanRequest{Plan: &plan, AllNodes: true})
@@ -738,6 +738,6 @@ func makeTestRecoveryPlan(
 	return loqrecoverypb.ReplicaUpdatePlan{
 		PlanID:    uuid.MakeV4(),
 		ClusterID: cr.ClusterID,
-		Version:   clusterversion.ByKey(clusterversion.BinaryVersionKey),
+		Version:   clusterversion.BinaryVersion,
 	}
 }

--- a/pkg/kv/kvserver/loqrecovery/version.go
+++ b/pkg/kv/kvserver/loqrecovery/version.go
@@ -66,8 +66,8 @@ var legacyInfoFormatVersion = clusterversion.ByKey(clusterversion.V22_2)
 // could be either loaded from files or received from cluster.
 func checkVersionAllowedByBinary(version roachpb.Version) error {
 	return checkVersionAllowedImpl(version,
-		clusterversion.ByKey(clusterversion.BinaryMinSupportedVersionKey),
-		clusterversion.ByKey(clusterversion.BinaryVersionKey))
+		clusterversion.BinaryMinSupportedVersion,
+		clusterversion.BinaryVersion)
 }
 
 func checkVersionAllowedImpl(version, minSupported, binaryVersion roachpb.Version) error {

--- a/pkg/server/init.go
+++ b/pkg/server/init.go
@@ -665,8 +665,8 @@ func newInitServerConfig(
 		//
 		// Refer to the header comment on BinaryVersionOverride for more details.
 		if ov := knobs.(*TestingKnobs).BinaryVersionOverride; ov != (roachpb.Version{}) {
-			if binaryMinSupportedVersion.Equal(clusterversion.ByKey(clusterversion.BinaryMinSupportedVersionKey)) {
-				binaryVersion = clusterversion.ByKey(clusterversion.BinaryMinSupportedVersionKey)
+			if binaryMinSupportedVersion.Equal(clusterversion.BinaryMinSupportedVersion) {
+				binaryVersion = clusterversion.BinaryMinSupportedVersion
 			} else {
 				binaryVersion = ov
 			}

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -499,7 +499,7 @@ func bootstrapCluster(
 				// ready to use in the test.
 				if knobs.BinaryVersionOverride != (roachpb.Version{}) {
 					if initCfg.binaryMinSupportedVersion.Equal(
-						clusterversion.ByKey(clusterversion.BinaryMinSupportedVersionKey)) {
+						clusterversion.BinaryMinSupportedVersion) {
 						initialValuesOpts.OverrideKey = clusterversion.BinaryMinSupportedVersionKey
 					}
 				}

--- a/pkg/sql/catalog/bootstrap/bootstrap_test.go
+++ b/pkg/sql/catalog/bootstrap/bootstrap_test.go
@@ -40,8 +40,8 @@ func TestSupportedReleases(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	expected := make(map[roachpb.Version]struct{})
-	earliest := clusterversion.ByKey(clusterversion.BinaryMinSupportedVersionKey)
-	latest := clusterversion.ByKey(clusterversion.BinaryVersionKey)
+	earliest := clusterversion.BinaryMinSupportedVersion
+	latest := clusterversion.BinaryVersion
 	var incumbent roachpb.Version
 	for _, v := range clusterversion.ListBetween(earliest, latest) {
 		if v.Major != incumbent.Major && v.Minor != incumbent.Minor {

--- a/pkg/sql/tenant_creation.go
+++ b/pkg/sql/tenant_creation.go
@@ -177,7 +177,7 @@ func (p *planner) createTenantInternal(
 		// The cluster is running the latest version.
 		// Use this version to create the tenant and bootstrap it using the host
 		// cluster's bootstrapping logic.
-		tenantVersion.Version = clusterversion.ByKey(clusterversion.BinaryVersionKey)
+		tenantVersion.Version = clusterversion.BinaryVersion
 		bootstrapVersionOverride = 0
 	}
 

--- a/pkg/upgrade/upgrademanager/manager_external_test.go
+++ b/pkg/upgrade/upgrademanager/manager_external_test.go
@@ -263,7 +263,7 @@ func TestPostJobInfoTableQueryDuplicateJobInfo(t *testing.T) {
 			false, // initializeVersion
 		)
 		require.NoError(t, clusterversion.Initialize(ctx,
-			clusterversion.ByKey(clusterversion.BinaryMinSupportedVersionKey), &settings.SV))
+			clusterversion.BinaryMinSupportedVersion, &settings.SV))
 		return settings
 	}
 

--- a/pkg/upgrade/upgrades/first_upgrade_test.go
+++ b/pkg/upgrade/upgrades/first_upgrade_test.go
@@ -44,7 +44,7 @@ func TestFirstUpgrade(t *testing.T) {
 
 	var (
 		v0 = clusterversion.TestingBinaryMinSupportedVersion
-		v1 = clusterversion.ByKey(clusterversion.BinaryVersionKey)
+		v1 = clusterversion.BinaryVersion
 	)
 
 	ctx := context.Background()
@@ -140,7 +140,7 @@ func TestFirstUpgradeRepair(t *testing.T) {
 
 	var (
 		v0 = clusterversion.TestingBinaryMinSupportedVersion
-		v1 = clusterversion.ByKey(clusterversion.BinaryVersionKey)
+		v1 = clusterversion.BinaryVersion
 	)
 
 	ctx := context.Background()

--- a/pkg/upgrade/upgrades/grant_execute_to_public_test.go
+++ b/pkg/upgrade/upgrades/grant_execute_to_public_test.go
@@ -41,7 +41,7 @@ func TestGrantExecuteToPublicOnAllFunctions(t *testing.T) {
 
 	var (
 		v0 = clusterversion.TestingBinaryMinSupportedVersion
-		v1 = clusterversion.ByKey(clusterversion.BinaryVersionKey)
+		v1 = clusterversion.BinaryVersion
 	)
 	ctx := context.Background()
 
@@ -120,7 +120,7 @@ func BenchmarkGrantExecuteToPublicOnAllFunctions(b *testing.B) {
 
 	var (
 		v0 = clusterversion.TestingBinaryMinSupportedVersion
-		v1 = clusterversion.ByKey(clusterversion.BinaryVersionKey)
+		v1 = clusterversion.BinaryVersion
 	)
 
 	ctx := context.Background()

--- a/pkg/upgrade/upgrades/system_job_info_test.go
+++ b/pkg/upgrade/upgrades/system_job_info_test.go
@@ -36,7 +36,7 @@ func TestSystemJobInfoMigration(t *testing.T) {
 			Knobs: base.TestingKnobs{
 				Server: &server.TestingKnobs{
 					DisableAutomaticVersionUpgrade: make(chan struct{}),
-					BinaryVersionOverride:          clusterversion.ByKey(clusterversion.BinaryMinSupportedVersionKey),
+					BinaryVersionOverride:          clusterversion.BinaryMinSupportedVersion,
 					BootstrapVersionKeyOverride:    clusterversion.BinaryMinSupportedVersionKey,
 				},
 			},

--- a/pkg/upgrade/upgrades/tenant_id_sequence_for_system_tenant_test.go
+++ b/pkg/upgrade/upgrades/tenant_id_sequence_for_system_tenant_test.go
@@ -34,7 +34,7 @@ func TestTenantIDSequenceForSystemTenant(t *testing.T) {
 			Knobs: base.TestingKnobs{
 				Server: &server.TestingKnobs{
 					DisableAutomaticVersionUpgrade: make(chan struct{}),
-					BinaryVersionOverride:          clusterversion.ByKey(clusterversion.BinaryMinSupportedVersionKey),
+					BinaryVersionOverride:          clusterversion.BinaryMinSupportedVersion,
 					BootstrapVersionKeyOverride:    clusterversion.BinaryMinSupportedVersionKey,
 				},
 			},

--- a/pkg/upgrade/upgrades/upgrades_test.go
+++ b/pkg/upgrade/upgrades/upgrades_test.go
@@ -37,8 +37,8 @@ func TestFirstUpgradesAfterPreExistingRelease(t *testing.T) {
 	// Compute the set of pre-existing releases supported by this binary.
 	// This excludes the latest release if the binary version is a release.
 	preExistingReleases := make(map[roachpb.Version]struct{})
-	minBinaryVersion := clusterversion.ByKey(clusterversion.BinaryMinSupportedVersionKey)
-	binaryVersion := clusterversion.ByKey(clusterversion.BinaryVersionKey)
+	minBinaryVersion := clusterversion.BinaryMinSupportedVersion
+	binaryVersion := clusterversion.BinaryVersion
 	for _, v := range clusterversion.ListBetween(minBinaryVersion, binaryVersion) {
 		preExistingReleases[roachpb.Version{Major: v.Major, Minor: v.Minor}] = struct{}{}
 	}


### PR DESCRIPTION
**clusterversion: export binary{,MinSupported}Version**

This patch exports the `binary{,MinSupported}Version` variables so that
we can remove redundant `clusterversion.ByKey` calls for these keys.

Release note: None

---

***: replace usages of clusterversion.ByKey for special binary versions**

This patch replaces usages of `clusterversion.ByKey` for
`clusterversion.Binary{,MinSupported}VersionKey` since
the corresponding version vars have now been exported.

Release note: None

---

Epic: None