### PR TITLE
release-22.2: kv: fix data race in `TestReplicaTxnIdempotency`

### DIFF
--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -3711,12 +3711,12 @@ func TestReplicaTxnIdempotency(t *testing.T) {
 				return runWithTxn(nil, &args)
 			},
 			afterTxnStart: func(txn *roachpb.Transaction, key []byte) error {
-				args := deleteRangeArgs(key, append(key, 0))
+				args := deleteRangeArgs(key, roachpb.Key(key).Clone().Next())
 				args.Sequence = 2
 				return runWithTxn(txn, &args)
 			},
 			run: func(txn *roachpb.Transaction, key []byte) error {
-				args := deleteRangeArgs(key, append(key, 0))
+				args := deleteRangeArgs(key, roachpb.Key(key).Clone().Next())
 				args.Sequence = 2
 				return runWithTxn(txn, &args)
 			},


### PR DESCRIPTION
Backport 1/1 commits from #107502.

/cc @cockroachdb/release

Release justification: testing only

---

Fixes #107435.

This commit deflakes `TestReplicaTxnIdempotency`. The race seen in the test was between an asynchronous read of a key attached to a raft proposal during a timestamp cache update and a mutation of that same underlying byte buffer by the test harness. We now make sure to clone the key before mutating the buffer.

Release note: None
