### PR TITLE
rangefeed: evict descriptors for StoreNotFoundError errors

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed.go
@@ -626,11 +626,10 @@ func handleRangefeedError(
 		// If we got an EOF, treat it as a signal to restart single range feed.
 		return rangefeedErrorInfo{}, nil
 	case errors.HasType(err, (*kvpb.StoreNotFoundError)(nil)):
-		// These errors are likely to be unique to the replica that
-		// reported them, so no action is required before the next
-		// retry.
+		// We shouldn't be seeing these errors if descriptors are correct, but if
+		// we do, we'd rather evict descriptor before retrying.
 		metrics.Errors.StoreNotFound.Inc(1)
-		return rangefeedErrorInfo{}, nil
+		return rangefeedErrorInfo{evict: true}, nil
 	case errors.HasType(err, (*kvpb.NodeUnavailableError)(nil)):
 		// These errors are likely to be unique to the replica that
 		// reported them, so no action is required before the next


### PR DESCRIPTION
Previously if StoreNotFoundError is returned on rangefeed call client moved to another replica. This is not the best approach as we should only get this error if descriptor is wront. This commit changes behaviour to refresh descriptor before retrying.

Epic: none
Fixes: #107610

Release note: None