### PR TITLE
configprofiles: avoid slices stomping each other

### DIFF
--- a/pkg/configprofiles/profiles.go
+++ b/pkg/configprofiles/profiles.go
@@ -141,7 +141,7 @@ var virtClusterWithAppServiceInitTasks = append(
 )
 
 func enableReplication(baseTasks []autoconfigpb.Task) []autoconfigpb.Task {
-	return append(baseTasks,
+	return append(baseTasks[:len(baseTasks):len(baseTasks)],
 		makeTask("enable rangefeeds and replication",
 			/* nonTxnSQL */ []string{
 				"SET CLUSTER SETTING kv.rangefeed.enabled = true",

--- a/pkg/configprofiles/profiles.go
+++ b/pkg/configprofiles/profiles.go
@@ -112,7 +112,7 @@ var virtClusterInitTasks = []autoconfigpb.Task{
 		},
 	),
 	// Finally.
-	makeTask("use the application virtual cluster template by default in CREATE VIRTUAL CLSUTER",
+	makeTask("use the application virtual cluster template by default in CREATE VIRTUAL CLUSTER",
 		/* nonTxnSQL */ []string{
 			"SET CLUSTER SETTING sql.create_virtual_cluster.default_template = 'template'",
 		},

--- a/pkg/configprofiles/testdata/virtual-app-repl
+++ b/pkg/configprofiles/testdata/virtual-app-repl
@@ -27,8 +27,8 @@ WHERE variable IN (
 )
 ORDER BY variable
 ----
-cross_cluster_replication.enabled false
-kv.rangefeed.enabled false
+cross_cluster_replication.enabled true
+kv.rangefeed.enabled true
 server.controller.default_target_cluster application
 spanconfig.range_coalescing.application.enabled false
 spanconfig.range_coalescing.system.enabled false


### PR DESCRIPTION
Epic: CRDB-26691

This patch ensures that each config profile has its distinct task
slice.

(I'm somewhat surprised this fix only affects the test outputs. I have
tried manually to set up a cluster with either profile and the
settings were right. I think it will only trigger with any subsequent
reuse of the slice.)

Release note: None