### PR TITLE
sql: use 'cluster-NNN' for virtual cluster records without a name

### DIFF
--- a/pkg/ccl/backupccl/restore_old_versions_test.go
+++ b/pkg/ccl/backupccl/restore_old_versions_test.go
@@ -474,8 +474,8 @@ func fullClusterRestoreWithTenants(exportDir string) func(t *testing.T) {
 		sqlDB.Exec(t, fmt.Sprintf("RESTORE FROM LATEST IN '%s' WITH UNSAFE_RESTORE_INCOMPATIBLE_VERSION, include_all_virtual_clusters", localFoo))
 		sqlDB.CheckQueryResults(t, "SHOW TENANTS", [][]string{
 			{"1", "system", "ready", "shared"},
-			{"5", "tenant-5", "ready", "none"},
-			{"6", "tenant-6", "ready", "none"},
+			{"5", "cluster-5", "ready", "none"},
+			{"6", "cluster-6", "ready", "none"},
 		})
 	}
 }

--- a/pkg/ccl/backupccl/tenant_backup_nemesis_test.go
+++ b/pkg/ccl/backupccl/tenant_backup_nemesis_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
@@ -97,10 +98,10 @@ func TestTenantBackupWithCanceledImport(t *testing.T) {
 	tenant10DB.Exec(t, "SHOW JOBS WHEN COMPLETE (SELECT job_id FROM [SHOW JOBS] WHERE job_type = 'IMPORT')")
 
 	hostSQLDB.Exec(t, "BACKUP TENANT 10 INTO LATEST IN 'nodelocal://1/tenant-backup'")
-	hostSQLDB.Exec(t, "RESTORE TENANT 10 FROM LATEST IN 'nodelocal://1/tenant-backup' WITH virtual_cluster_name = 'tenant-11'")
+	hostSQLDB.Exec(t, "RESTORE TENANT 10 FROM LATEST IN 'nodelocal://1/tenant-backup' WITH virtual_cluster_name = 'cluster-11'")
 
 	tenant11, err := tc.Servers[0].StartTenant(ctx, base.TestTenantArgs{
-		TenantName:          "tenant-11",
+		TenantName:          "cluster-11",
 		DisableCreateTenant: true,
 	})
 	require.NoError(t, err)
@@ -117,6 +118,8 @@ func TestTenantBackupWithCanceledImport(t *testing.T) {
 func TestTenantBackupNemesis(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
+	skip.UnderRace(t, "slow test") // take >1mn under race
 
 	ctx := context.Background()
 	tempDir, tempDirCleanupFn := testutils.TempDir(t)
@@ -233,7 +236,7 @@ func TestTenantBackupNemesis(t *testing.T) {
 	})
 
 	require.NoError(t, g.Wait())
-	restoreQuery := fmt.Sprintf("RESTORE TENANT 10 FROM LATEST IN '%s' AS OF SYSTEM TIME %s WITH virtual_cluster_name = 'tenant-11'", backupLoc, aost)
+	restoreQuery := fmt.Sprintf("RESTORE TENANT 10 FROM LATEST IN '%s' AS OF SYSTEM TIME %s WITH virtual_cluster_name = 'cluster-11'", backupLoc, aost)
 	t.Logf("backup-nemesis: restoring tenant 10 into 11: %s", restoreQuery)
 	hostSQLDB.Exec(t, restoreQuery)
 
@@ -242,7 +245,7 @@ func TestTenantBackupNemesis(t *testing.T) {
 	// We check bank.bank which has had the workload running against it
 	// and any table from a completed nemesis.
 	tenant11, err := tc.Servers[0].StartTenant(ctx, base.TestTenantArgs{
-		TenantName:          "tenant-11",
+		TenantName:          "cluster-11",
 		DisableCreateTenant: true,
 	})
 	require.NoError(t, err)

--- a/pkg/ccl/backupccl/testdata/backup-restore/restore-tenants
+++ b/pkg/ccl/backupccl/testdata/backup-restore/restore-tenants
@@ -30,8 +30,8 @@ query-sql
 SELECT id,name,data_state,service_mode,active,json_extract_path_text(crdb_internal.pb_to_json('cockroach.multitenant.ProtoInfo', info, true), 'deprecatedDataState'),json_extract_path_text(crdb_internal.pb_to_json('cockroach.multitenant.ProtoInfo', info, true), 'droppedName') FROM system.tenants;
 ----
 1 system 1 2 true READY 
-5 <nil> 2 0 false DROP tenant-5
-6 tenant-6 1 1 true READY 
+5 <nil> 2 0 false DROP cluster-5
+6 cluster-6 1 1 true READY 
 
 exec-sql
 BACKUP INTO 'nodelocal://1/cluster_without_tenants'
@@ -103,7 +103,7 @@ query-sql
 SELECT id,name,data_state,service_mode,active,json_extract_path_text(crdb_internal.pb_to_json('cockroach.multitenant.ProtoInfo', info, true), 'deprecatedDataState'),json_extract_path_text(crdb_internal.pb_to_json('cockroach.multitenant.ProtoInfo', info, true), 'droppedName') FROM system.tenants;
 ----
 1 system 1 2 true READY 
-6 tenant-6 1 1 true READY 
+6 cluster-6 1 1 true READY 
 
 
 exec-sql expect-error-regex=(tenant 6 not in backup)
@@ -121,8 +121,8 @@ RESTORE TENANT 6 FROM LATEST IN 'nodelocal://1/tenant6' WITH virtual_cluster_nam
 ----
 regex matches error
 
-exec-sql expect-error-regex=(tenant with name "tenant-6" already exists)
-RESTORE TENANT 6 FROM LATEST IN 'nodelocal://1/tenant6' WITH virtual_cluster_name = 'tenant-6';
+exec-sql expect-error-regex=(tenant with name "cluster-6" already exists)
+RESTORE TENANT 6 FROM LATEST IN 'nodelocal://1/tenant6' WITH virtual_cluster_name = 'cluster-6';
 ----
 regex matches error
 
@@ -135,7 +135,7 @@ SELECT id,name,data_state,service_mode,active,json_extract_path_text(crdb_intern
 ----
 1 system 1 2 true READY 
 2 newname 1 1 true READY 
-6 tenant-6 1 1 true READY 
+6 cluster-6 1 1 true READY 
 
 # Check that another service mode is also preserved.
 exec-sql

--- a/pkg/ccl/multitenantccl/tenantcapabilitiesccl/testdata/can_admin_scatter
+++ b/pkg/ccl/multitenantccl/tenantcapabilitiesccl/testdata/can_admin_scatter
@@ -1,7 +1,7 @@
 query-sql-system
 SELECT * FROM [SHOW TENANT [10] WITH CAPABILITIES] WHERE capability_name = 'can_admin_scatter'
 ----
-10 tenant-10 ready external can_admin_scatter true
+10 cluster-10 ready external can_admin_scatter true
 
 exec-sql-tenant
 CREATE TABLE t(a INT)

--- a/pkg/ccl/multitenantccl/tenantcapabilitiesccl/testdata/can_admin_split
+++ b/pkg/ccl/multitenantccl/tenantcapabilitiesccl/testdata/can_admin_split
@@ -1,7 +1,7 @@
 query-sql-system
 SELECT * FROM [SHOW TENANT [10] WITH CAPABILITIES] WHERE capability_name = 'can_admin_split'
 ----
-10 tenant-10 ready external can_admin_split true
+10 cluster-10 ready external can_admin_split true
 
 exec-sql-tenant
 CREATE TABLE t(a INT)

--- a/pkg/ccl/multitenantccl/tenantcapabilitiesccl/testdata/can_admin_unsplit
+++ b/pkg/ccl/multitenantccl/tenantcapabilitiesccl/testdata/can_admin_unsplit
@@ -1,7 +1,7 @@
 query-sql-system
 SELECT * FROM [SHOW TENANT [10] WITH CAPABILITIES] WHERE capability_name = 'can_admin_unsplit'
 ----
-10 tenant-10 ready external can_admin_unsplit false
+10 cluster-10 ready external can_admin_unsplit false
 
 exec-sql-tenant
 CREATE TABLE t(a INT)

--- a/pkg/sql/logictest/testdata/logic_test/cluster_settings
+++ b/pkg/sql/logictest/testdata/logic_test/cluster_settings
@@ -307,7 +307,7 @@ SELECT crdb_internal.create_tenant(10)
 skipif config 3node-tenant-default-configs
 skipif config local-mixed-22.2-23.1
 statement ok
-ALTER TENANT "tenant-10" SET CLUSTER SETTING server.mem_profile.total_dump_size_limit='5M'
+ALTER TENANT "cluster-10" SET CLUSTER SETTING server.mem_profile.total_dump_size_limit='5M'
 
 skipif config 3node-tenant-default-configs
 skipif config local-mixed-22.2-23.1
@@ -327,7 +327,7 @@ ALTER TENANT [10] RESET CLUSTER SETTING server.mem_profile.total_dump_size_limit
 skipif config 3node-tenant-default-configs
 skipif config local-mixed-22.2-23.1
 statement ok
-ALTER TENANT "tenant-10" RESET CLUSTER SETTING server.mem_profile.total_dump_size_limit
+ALTER TENANT "cluster-10" RESET CLUSTER SETTING server.mem_profile.total_dump_size_limit
 
 skipif config 3node-tenant-default-configs
 skipif config local-mixed-22.2-23.1
@@ -363,7 +363,7 @@ NULL
 skipif config 3node-tenant-default-configs
 skipif config local-mixed-22.2-23.1
 query T
-SHOW CLUSTER SETTING server.mem_profile.total_dump_size_limit FOR TENANT "tenant-10"
+SHOW CLUSTER SETTING server.mem_profile.total_dump_size_limit FOR TENANT "cluster-10"
 ----
 NULL
 
@@ -398,7 +398,7 @@ jobs.retention_time  d  no-override
 skipif config 3node-tenant-default-configs
 skipif config local-mixed-22.2-23.1
 query TTT
-SELECT variable, type, origin FROM [SHOW CLUSTER SETTINGS FOR TENANT "tenant-10"]
+SELECT variable, type, origin FROM [SHOW CLUSTER SETTINGS FOR TENANT "cluster-10"]
 WHERE variable IN ('jobs.scheduler.enabled', 'jobs.retention_time') ORDER BY 1
 ----
 jobs.retention_time  d  no-override
@@ -415,7 +415,7 @@ jobs.scheduler.enabled  b  false  no-override
 skipif config 3node-tenant-default-configs
 skipif config local-mixed-22.2-23.1
 query TTBT
-SELECT variable, type, public, origin FROM [SHOW ALL CLUSTER SETTINGS FOR TENANT "tenant-10"]
+SELECT variable, type, public, origin FROM [SHOW ALL CLUSTER SETTINGS FOR TENANT "cluster-10"]
 WHERE variable IN ('jobs.scheduler.enabled', 'jobs.retention_time') ORDER BY 1
 ----
 jobs.retention_time     d  true   no-override

--- a/pkg/sql/logictest/testdata/logic_test/tenant_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/tenant_builtins
@@ -59,7 +59,7 @@ ORDER BY id
 ----
 id  active  name                  data_state  service_mode  deprecated_data_state  dropped_name
 1   true    system                1           2             READY                  ·
-5   true    tenant-5              1           0             READY                  ·
+5   true    cluster-5              1           0             READY                  ·
 10  true    tenant-number-ten     1           0             READY                  ·
 11  true    tenant-number-eleven  1           0             READY                  ·
 
@@ -143,10 +143,10 @@ id  active  name                  data_state  service_mode  deprecated_data_stat
 
 # Try to recreate an existing tenant.
 # GC job for tenant 5 has not run yet.
-query error pgcode 42710 a tenant with ID 5 or with name "tenant-5" already exists
+query error pgcode 42710 a tenant with ID 5 or with name "cluster-5" already exists
 SELECT crdb_internal.create_tenant(5)
 
-query error pgcode 42710 a tenant with ID 10 or with name "tenant-10" already exists
+query error pgcode 42710 a tenant with ID 10 or with name "cluster-10" already exists
 SELECT crdb_internal.create_tenant(10)
 
 query error pgcode 42710 a tenant with ID 11 or with name "tenant-number-ten" already exists
@@ -331,7 +331,7 @@ SELECT id, name, data_state FROM system.tenants ORDER BY id
 1    system             1
 10   tenant-number-ten  1
 12   anothertenant      1
-123  tenant-123         1
+123  cluster-123         1
 124  yetanotherone      1
 
 subtest multiple_tenants_in_txn
@@ -348,9 +348,9 @@ SELECT id, name, data_state FROM system.tenants ORDER BY id
 1    system             1
 10   tenant-number-ten  1
 12   anothertenant      1
-123  tenant-123         1
+123  cluster-123         1
 124  yetanotherone      1
-200  tenant-200         1
+200  cluster-200         1
 201  hello              1
 
 subtest regression_97873
@@ -369,7 +369,7 @@ SELECT crdb_internal.destroy_tenant(97873)
 
 subtest if_not_exists
 
-query error pgcode 42710 a tenant with ID 10 or with name "tenant-10" already exists
+query error pgcode 42710 a tenant with ID 10 or with name "cluster-10" already exists
 SELECT crdb_internal.create_tenant('{"id":10}'::JSONB)
 
 query error pgcode 42710 tenant with name "tenant-number-ten" already exists

--- a/pkg/sql/tenant_creation.go
+++ b/pkg/sql/tenant_creation.go
@@ -308,7 +308,7 @@ func CreateTenantRecord(
 	if info.Name == "" {
 		// No name: generate one if we are at the appropriate version.
 		if settings.Version.IsActive(ctx, clusterversion.V23_1TenantNamesStateAndServiceMode) {
-			info.Name = roachpb.TenantName(fmt.Sprintf("tenant-%d", info.ID))
+			info.Name = roachpb.TenantName(fmt.Sprintf("cluster-%d", info.ID))
 		}
 	}
 


### PR DESCRIPTION
Epic: CRDB-29380

Prior to this patch, when a virtual cluster was created without a name, a default name was generated with structure `tenant-NNN`. To avoid emphasizing multi-tenancy, this commit changes this to `cluster-NNN`.

(No release note because there is no user-facing way to create a record without a name.)

Release note: None