### PR TITLE
github-pull-request-make: longer overall timeout for `stressrace`

### DIFF
--- a/pkg/cmd/github-pull-request-make/main.go
+++ b/pkg/cmd/github-pull-request-make/main.go
@@ -276,7 +276,13 @@ func main() {
 		for name, pkg := range pkgs {
 			// 20 minutes total seems OK, but at least 2 minutes per test.
 			// This should be reduced. See #46941.
-			duration := (20 * time.Minute) / time.Duration(len(pkgs))
+			target, ok := os.LookupEnv(targetEnv)
+			var duration time.Duration
+			if ok && target == "stressrace" {
+				duration = (30 * time.Minute) / time.Duration(len(pkgs))
+			} else {
+				duration = (20 * time.Minute) / time.Duration(len(pkgs))
+			}
 			minDuration := (2 * time.Minute) * time.Duration(len(pkg.tests))
 			if duration < minDuration {
 				duration = minDuration


### PR DESCRIPTION
Multiple people have seen this timeout for `race`. Let's bump this timeout only for `race`.

Epic: none
Release note: None