### PR TITLE
coverage: add scripts for publish build

### DIFF
--- a/build/teamcity/cockroach/coverage/publish_finalize.sh
+++ b/build/teamcity/cockroach/coverage/publish_finalize.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# This script is the final step of the "Publish Coverage" build.
+#
+# It moves the HTML mini-websites into archives, so that it's easy to download
+# them individually from the artifacts.
+
+set -euo pipefail
+
+for dir in $(find output/html -mindepth 1 -maxdepth 1 -type d); do
+  name=$(basename "$dir")
+  echo "Archiving $name.."
+  pushd "$dir" > /dev/null
+  tar czf "../$name.tar.gz" *
+  popd > /dev/null
+  rm -rf "$dir"
+done

--- a/build/teamcity/cockroach/coverage/publish_gen_html.sh
+++ b/build/teamcity/cockroach/coverage/publish_gen_html.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+# This script is the second step of the "Publish Coverage" build.
+#
+# It takes some of the lcov files produced by the previous step and generates
+# HTML mini-websites.
+#
+# The inputs expected by this script:
+#  - output/unit_tests.lcov
+#  - output/roachtests.lcov
+#  - output/unit_tests_and_roachtests.lcov
+#
+# The outputs of this script are:
+#  - output/html/unit_tests
+#  - output/html/roachtests
+#  - output/html/unit_tests_and_roachtests
+
+set -euo pipefail
+
+
+echo "Downloading lcov..."
+curl -fsSL https://github.com/linux-test-project/lcov/releases/download/v2.0/lcov-2.0.tar.gz | tar xz
+
+PATH="$(pwd)/lcov-2.0/bin:$PATH"
+
+profiles=(
+  unit_tests
+  roachtests
+  unit_tests_and_roachtests
+)
+
+for p in "${profiles[@]}"; do
+  dir="output/html/$p"
+  log="output/logs/genhtml-$p.log"
+  mkdir -p "$dir"
+  echo "Running genhtml for $p (logs in $log)..."
+  genhtml --ignore-errors source,unmapped,unused --synthesize-missing \
+    --exclude 'external/**' --num-spaces 2 \
+    --substitute 's#^#'$(pwd)'/#' --hierarchical \
+    "output/$p.lcov" -o "$dir" > "$log" 2>&1
+done

--- a/build/teamcity/cockroach/coverage/publish_gen_lcov.sh
+++ b/build/teamcity/cockroach/coverage/publish_gen_lcov.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+# This script is the first step of the "Publish Coverage" build.
+#
+# It takes coverage data from dependent builds and generates lcov files.
+#
+# The inputs expected by this script:
+#  - input/unit_tests_nonccl.lcov - from Collect Coverage Unit Tests non-CCL
+#  - input/unit_tests_ccl.lcov - from Collect Coverage Unit Tests CCL
+#  - input/roachtests/**/gocover.zip - from Collect Coverage Roachtest Nightly
+#
+# The outputs of this script are:
+#  - output/unit_tests_nonccl.lcov
+#  - output/unit_tests_nccl.lcov
+#  - output/unit_tests.lcov - Unit test coverage for both CCL and non-CCL.
+#  - output/roachtests/<escaped-test-path>.lcov - Combined coverage from all nodes in the test.
+#  - output/roachtests.lcov - Combined coverage across all roachtests.
+#  - output/unit_tests_and_roachtests.lcov - Combined coverage across unit tests and roachtests.
+
+set -euxo pipefail
+
+function run_convert() {
+  go run github.com/cockroachdb/code-cov-utils/convert@v1.1.0 "$@"
+}
+
+tmpdir=$(mktemp -d)
+trap "rm -rf $tmpdir" EXIT
+
+# Delete the output directory in case it's left over from a previous build.
+rm -rf output
+mkdir output
+mkdir output/logs
+
+cp input/unit_tests_ccl.lcov output/
+cp input/unit_tests_nonccl.lcov output/
+# Generate combined unit test coverage.
+run_convert -out output/unit_tests.lcov input/unit_tests_ccl.lcov input/unit_tests_nonccl.lcov
+
+# Generate one lcov file for each roachtest.
+mkdir output/roachtests
+for zipfile in `find input/roachtests -name gocover.zip`; do
+  # Generate a name by replacing slashes with _.
+  name=${zipfile//\//_}
+  # Remove input_ prefix.
+  name=${name#input_}
+  # Remove _gocover.zip suffix.
+  name=${name%_gocover.zip}
+
+  echo Generating "roachtests/$name.lcov..."
+
+  rm -rf "$tmpdir"/*
+  unzip -q "$zipfile" -d "$tmpdir"
+  run_convert -out output/roachtests/$name.lcov $(find "$tmpdir" -type f -name '*.gocov')
+done
+
+# Generate combined roachtest coverage.
+run_convert -out output/roachtests.lcov $(find output/roachtests -name '*.lcov')
+
+# Generate unit test + roachtest combined coverage.
+run_convert -out output/unit_tests_and_roachtests.lcov output/unit_tests.lcov output/roachtests.lcov

--- a/build/teamcity/cockroach/coverage/publish_upload.sh
+++ b/build/teamcity/cockroach/coverage/publish_upload.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+# This script is the third step of the "Publish Coverage" build.
+#
+# It takes the HTML mini-websites produced by the previous step and uploads them
+# to GCE. It also updates the index.html file listing all uploaded profiles.
+# The index can be accessed at:
+#   https://storage.googleapis.com/crl-codecover-public/cockroach/index.html
+
+BUCKET=crl-codecover-public
+
+set -euo pipefail
+
+source "build/teamcity-support.sh" # for log_into_gcloud
+
+google_credentials="$GOOGLE_CREDENTIALS"
+log_into_gcloud
+
+gsutil ls gs://$BUCKET/
+
+TIMESTAMP=$(date -u '+%Y-%m-%d %H:%MZ')
+
+publish() {
+  PROFILE="$1"
+
+  DIR="$TIMESTAMP $(git rev-parse --short=8 HEAD) - $PROFILE"
+  echo "Uploading to $DIR.."
+  gsutil -m cp -Z -r "output/html/$PROFILE" "gs://$BUCKET/cockroach/$DIR" > "output/logs/upload-$PROFILE.log" 2>&1
+}
+
+for dir in $(find output/html -mindepth 1 -maxdepth 1 -type d); do
+  publish $(basename "$dir")
+done
+
+# Regenerate index.html.
+INDEX=$(mktemp)
+trap "rm -f $INDEX" EXIT
+
+echo '<title>Cockroach coverage</title><body><h2>Cockroach coverage runs:</h2><ul>' > "$INDEX"
+gsutil ls "gs://$BUCKET/cockroach" |
+  sed "s#gs://$BUCKET/cockroach/##" |
+  sed 's#/$##' |
+  grep -v index.html |
+  sort -r |
+  while read -r d; do
+    echo "<li><a href=\"$d/index.html\">$d</a>" >> "$INDEX"
+  done
+
+echo '</ul></body>' >> "$INDEX"
+
+gsutil \
+  -h "Cache-Control:public, max-age=300, no-transform" \
+  -h "Content-Type:text/html" \
+  cp "$INDEX" "gs://$BUCKET/cockroach/index.html"


### PR DESCRIPTION
These scripts are for the coverage publish build which produces the final artifacts.

There are four scripts, one for each step of the build:
 - 1. Generate consolidated LCOV files
 - 2. Generate HTML pages (runs in cpan/perl-common:5.24 container)
 - 3. Upload HTML pages, update index.html
 - 4. Move HTML pages to archives.

I have a build that ran successfully with these scripts (except they were directly used in TeamCity rather than invoked from the repo).

Epic: none
Release note: None