### PR TITLE
row: add missing three dots to var arg

### DIFF
--- a/pkg/sql/row/putter.go
+++ b/pkg/sql/row/putter.go
@@ -59,7 +59,7 @@ func (t *TracePutter) InitPut(key, value interface{}, failOnTombstones bool) {
 
 }
 func (t *TracePutter) Del(key ...interface{}) {
-	log.VEventfDepth(t.Ctx, 1, 2, "Del %v", key)
+	log.VEventfDepth(t.Ctx, 1, 2, "Del %v", key...)
 	t.Putter.Del(key...)
 }
 


### PR DESCRIPTION
For some reason after an update GoLand stopped compiling because of this.

Epic: None

Release note: None