### PR TITLE
allocator: prioritize non-voter promotion to satisfy voter constraints

### DIFF
--- a/pkg/ccl/multiregionccl/testdata/secondary_region
+++ b/pkg/ccl/multiregionccl/testdata/secondary_region
@@ -1,6 +1,3 @@
-skip issue-num=98020
-----
-
 new-cluster localities=us-east-1,us-east-1,us-west-1,us-west-1,us-central-1,us-central-1,us-central-1,eu-west-1,eu-west-1,eu-west-1
 ----
 

--- a/pkg/kv/kvserver/allocator/allocatorimpl/allocator_scorer_test.go
+++ b/pkg/kv/kvserver/allocator/allocatorimpl/allocator_scorer_test.go
@@ -1248,6 +1248,7 @@ func TestShouldRebalanceDiversity(t *testing.T) {
 			rebalanceConstraintsChecker,
 			replicas,
 			nil,
+			VoterTarget,
 			existingStoreLocalities,
 			func(context.Context, roachpb.StoreID) bool { return true },
 			options,

--- a/pkg/kv/kvserver/asim/tests/datadriven_simulation_test.go
+++ b/pkg/kv/kvserver/asim/tests/datadriven_simulation_test.go
@@ -47,7 +47,7 @@ import (
 //     simulation. The default values are: rw_ratio=0 rate=0 min_block=1
 //     max_block=1 min_key=1 max_key=10_000 access_skew=false.
 //
-//   - "ken_cluster" [nodes=<int>] [stores_per_node=<int>]
+//   - "gen_cluster" [nodes=<int>] [stores_per_node=<int>]
 //     Initialize the cluster generator parameters. On the next call to eval,
 //     the cluster generator is called to create the initial state used in the
 //     simulation. The default values are: nodes=3 stores_per_node=1.
@@ -73,6 +73,11 @@ import (
 //     Set the liveness status of the node with ID NodeID. This applies at the
 //     start of the simulation or with some delay after the simulation starts,
 //     if specified.
+//
+//   - set_locality node=<int> [delay=<duration] locality=string
+//     Sets the locality of the node with ID NodeID. This applies at the start
+//     of the simulation or with some delay after the simulation stats, if
+//     specified.
 //
 //   - add_node: [stores=<int>] [locality=<string>] [delay=<duration>]
 //     Add a node to the cluster after initial generation with some delay,
@@ -283,6 +288,19 @@ func TestDataDriven(t *testing.T) {
 				eventGen.ScheduleEvent(settingsGen.Settings.StartTime, delay, event.SetNodeLivenessEvent{
 					NodeId:         state.NodeID(nodeID),
 					LivenessStatus: livenessStatus,
+				})
+				return ""
+			case "set_locality":
+				var nodeID int
+				var localityString string
+				var delay time.Duration
+				scanArg(t, d, "node", &nodeID)
+				scanArg(t, d, "locality", &localityString)
+				scanIfExists(t, d, "delay", &delay)
+
+				eventGen.ScheduleEvent(settingsGen.Settings.StartTime, delay, event.SetNodeLocalityEvent{
+					NodeID:         state.NodeID(nodeID),
+					LocalityString: localityString,
 				})
 				return ""
 			case "set_capacity":

--- a/pkg/kv/kvserver/asim/tests/testdata/non_rand/example_conformance
+++ b/pkg/kv/kvserver/asim/tests/testdata/non_rand/example_conformance
@@ -1,0 +1,64 @@
+# This test reproduces #106559 in a simpler format, where a (satisfiable) voter
+# constraint will never be satisfied if every existing replica is necessary to
+# satisfy either a voter or non-voter constraint. See the topology below.
+gen_cluster nodes=5
+----
+
+# TODO(kvoli): Update gen_cluster to take in localities for this purpose.
+set_locality node=1 locality=region=a
+----
+
+set_locality node=2 locality=region=a
+----
+
+set_locality node=3 locality=region=b
+----
+
+set_locality node=4 locality=region=b
+----
+
+set_locality node=5 locality=region=b
+----
+
+# Generate 10 ranges, one replica will be placed on each node initially.
+gen_ranges ranges=5 repl_factor=4
+----
+
+# Update the span config to require a non-voter in the `region=a` locality.
+# There should be the following replica localities for voters and non-voters:
+#   voters      [a,b,b]
+#   non_voters  [a]
+set_span_config 
+[0,10000): num_replicas=4 num_voters=3 constraints={'+region=a':2,'+region=b':2} voter_constraints={'+region=a':1,'+region=b':2}
+----
+
+# Switch the span config to require the non-voter be placed in the 'region=b'
+# locality. This will require a swap between one of the voting replicas in b,
+# and the non-voter a.
+set_span_config delay=5m
+[0,10000): num_replicas=4 num_voters=3 constraints={'+region=a':2,'+region=b':2} voter_constraints={'+region=a':2,'+region=b':1}
+----
+
+assertion type=conformance under=0 over=0 unavailable=0 violating=0
+----
+
+eval duration=10m
+----
+failed assertion sample 1
+  conformance unavailable=0 under=0 over=0 violating=0 
+  actual unavailable=0 under=0, over=0 violating=5
+violating constraints:
+  r1:000000{0000-2000} [(n1,s1):1, (n4,s4):4, (n3,s3):3, (n2,s2):5NON_VOTER] applying num_replicas=4 num_voters=3 constraints=[+region=a:2 +region=b:2] voter_constraints=[+region=a:2 +region=b:1]
+  r2:000000{2000-4000} [(n5,s5):1, (n1,s1):2, (n3,s3):4, (n2,s2):5NON_VOTER] applying num_replicas=4 num_voters=3 constraints=[+region=a:2 +region=b:2] voter_constraints=[+region=a:2 +region=b:1]
+  r3:000000{4000-6000} [(n5,s5):1, (n4,s4):2, (n2,s2):4, (n1,s1):5NON_VOTER] applying num_replicas=4 num_voters=3 constraints=[+region=a:2 +region=b:2] voter_constraints=[+region=a:2 +region=b:1]
+  r4:000000{6000-8000} [(n1,s1):4, (n4,s4):2, (n3,s3):3, (n2,s2):5NON_VOTER] applying num_replicas=4 num_voters=3 constraints=[+region=a:2 +region=b:2] voter_constraints=[+region=a:2 +region=b:1]
+  r5:00000{08000-10000} [(n2,s2):4, (n4,s4):2, (n3,s3):3, (n1,s1):5NON_VOTER] applying num_replicas=4 num_voters=3 constraints=[+region=a:2 +region=b:2] voter_constraints=[+region=a:2 +region=b:1]
+
+topology
+----
+a
+  └── [1 2]
+b
+  └── [3 4 5]
+
+# vim:ft=sh

--- a/pkg/kv/kvserver/asim/tests/testdata/non_rand/example_conformance
+++ b/pkg/kv/kvserver/asim/tests/testdata/non_rand/example_conformance
@@ -44,15 +44,7 @@ assertion type=conformance under=0 over=0 unavailable=0 violating=0
 
 eval duration=10m
 ----
-failed assertion sample 1
-  conformance unavailable=0 under=0 over=0 violating=0 
-  actual unavailable=0 under=0, over=0 violating=5
-violating constraints:
-  r1:000000{0000-2000} [(n1,s1):1, (n4,s4):4, (n3,s3):3, (n2,s2):5NON_VOTER] applying num_replicas=4 num_voters=3 constraints=[+region=a:2 +region=b:2] voter_constraints=[+region=a:2 +region=b:1]
-  r2:000000{2000-4000} [(n5,s5):1, (n1,s1):2, (n3,s3):4, (n2,s2):5NON_VOTER] applying num_replicas=4 num_voters=3 constraints=[+region=a:2 +region=b:2] voter_constraints=[+region=a:2 +region=b:1]
-  r3:000000{4000-6000} [(n5,s5):1, (n4,s4):2, (n2,s2):4, (n1,s1):5NON_VOTER] applying num_replicas=4 num_voters=3 constraints=[+region=a:2 +region=b:2] voter_constraints=[+region=a:2 +region=b:1]
-  r4:000000{6000-8000} [(n1,s1):4, (n4,s4):2, (n3,s3):3, (n2,s2):5NON_VOTER] applying num_replicas=4 num_voters=3 constraints=[+region=a:2 +region=b:2] voter_constraints=[+region=a:2 +region=b:1]
-  r5:00000{08000-10000} [(n2,s2):4, (n4,s4):2, (n3,s3):3, (n1,s1):5NON_VOTER] applying num_replicas=4 num_voters=3 constraints=[+region=a:2 +region=b:2] voter_constraints=[+region=a:2 +region=b:1]
+OK
 
 topology
 ----

--- a/pkg/kv/kvserver/replicate_queue_test.go
+++ b/pkg/kv/kvserver/replicate_queue_test.go
@@ -1646,6 +1646,7 @@ func TestReplicateQueueShouldQueueNonVoter(t *testing.T) {
 		" constraints='{\"+rack=3\": 1}', voter_constraints='{\"+rack=1\": 1}'")
 	require.NoError(t, err)
 
+	matchString := "rebalance target found for non-voter, enqueuing"
 	require.Eventually(t, func() bool {
 		// NB: Manually enqueuing the replica on server 0 (i.e. rack 1) is copacetic
 		// because we know that it is the leaseholder (since it is the only voting
@@ -1662,8 +1663,10 @@ func TestReplicateQueueShouldQueueNonVoter(t *testing.T) {
 			log.Errorf(ctx, "processErr: %s", processErr.Error())
 			return false
 		}
-		if matched, err := regexp.Match("rebalance target found for non-voter, enqueuing",
+		if matched, err := regexp.Match(matchString,
 			[]byte(recording.String())); !matched {
+			log.Infof(ctx, "didn't find matching string '%s' in trace %s",
+				matchString, recording.String())
 			require.NoError(t, err)
 			return false
 		}

--- a/pkg/kv/kvserver/replicate_queue_test.go
+++ b/pkg/kv/kvserver/replicate_queue_test.go
@@ -1578,6 +1578,10 @@ func TestReplicateQueueShouldQueueNonVoter(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	// The zone config change leads to snapshot timeouts under stress race which
+	// make the test take 300+s.
+	skip.UnderStressRace(t)
+
 	ctx := context.Background()
 	serverArgs := make(map[int]base.TestServerArgs)
 	// Assign each store a rack number so we can constrain individual voting and


### PR DESCRIPTION
Previously, it was possible for a satisfiable voter constraint to never
be satisfied when:

1. There were a correct number of `VOTER` and `NON_VOTER` replicas.
2. All existing replicas were necessary to satisfy a replica constraint,
   or voter constraint.

The allocator relies on the `RebalanceVoter` path to resolve voter
constraint violations when there are a correct number of each replica
type.

Candidates which are `necessary` to satisfy a constraint are
ranked higher as rebalance targets than those which are not. Under most
circumstances this leads to constraint conformance. However, when every
existing replica is necessary to satisfy a replica constraint, and a
voter constraint is unsatisfied -- `RebalanceVoter` would not consider
swapping a `VOTER` and `NON_VOTER` to satisfy the constraint.

For example, consider a setup where there are two stores, one in
locality `a` and the other `b`, where some range has the following
config and initial placement:

```
replicas          = a(non-voter) b(voter)
constraints       = a:1 b:1
voter_constraints = a:1
```

In this example, the only satisfiable placement is `a(voter)`
`b(non-voter)`, which would require promoting `a(non-voter) ->
a(voter)`, and demoting `b(voter)->b(non-voter)`. However, both are
necessary to satisfy `constraints` leading to no rebalance occurring.

Add an additional field to the allocator candidate struct, which is used
to sort rebalance candidates. The new field, `voterNecessary` is sorted
strictly after `necessary`, but before `diversityScore`.

The `voterNecessary` field can be true only when rebalancing voters, and
when the rebalance candidate is necessary to satisfy a voter constraint,
the rebalance candidate already has a non-voter, and the existing voter
is not necessary to satisfy *any* voter constraint.

Note these rebalances are turned into swaps (promotion and demotion) in
`plan.ReplicationChangesForRebalance`, so incur no snapshots.

Fixes: https://github.com/cockroachdb/cockroach/issues/98020
Fixes: https://github.com/cockroachdb/cockroach/issues/106559
Fixes: https://github.com/cockroachdb/cockroach/issues/108127

Release note (bug fix): Voter constraints which were never satisfied due
to all existing replicas being considered necessary to satisfy a replica
constraint, will now be satisfied by promoting existing non-voters.