### PR TITLE
sqlstats: fix counter for in-memory fingerprints

### DIFF
--- a/pkg/sql/sqlstats/sslocal/sql_stats_test.go
+++ b/pkg/sql/sqlstats/sslocal/sql_stats_test.go
@@ -499,6 +499,17 @@ func TestExplicitTxnFingerprintAccounting(t *testing.T) {
 		require.Equal(t, tc.curFingerprintCount, sqlStats.GetTotalFingerprintCount(),
 			"testCase: %+v", tc)
 	}
+
+	// Verify reset works correctly.
+	require.NoError(t, sqlStats.Reset(ctx))
+	require.Zero(t, sqlStats.GetTotalFingerprintCount())
+
+	// Verify the count again after the reset.
+	for _, tc := range testCases {
+		recordStats(&tc)
+		require.Equal(t, tc.curFingerprintCount, sqlStats.GetTotalFingerprintCount(),
+			"testCase: %+v", tc)
+	}
 }
 
 func TestAssociatingStmtStatsWithTxnFingerprint(t *testing.T) {
@@ -627,6 +638,9 @@ func TestAssociatingStmtStatsWithTxnFingerprint(t *testing.T) {
 			}
 			require.Equal(t, expectedCount, len(stats), "testCase: %+v, stats: %+v", txn, stats)
 		}
+
+		require.NoError(t, sqlStats.Reset(ctx))
+		require.Zero(t, sqlStats.GetTotalFingerprintCount())
 	})
 }
 

--- a/pkg/sql/sqlstats/ssmemstorage/ss_mem_counter.go
+++ b/pkg/sql/sqlstats/ssmemstorage/ss_mem_counter.go
@@ -166,8 +166,8 @@ func (s *SQLStatsAtomicCounters) tryAddTxnFingerprint() (ok bool) {
 func (s *SQLStatsAtomicCounters) freeByCnt(
 	uniqueStmtFingerprintCount, uniqueTxnFingerprintCount int64,
 ) {
-	atomic.AddInt64(&s.uniqueStmtFingerprintCount, uniqueStmtFingerprintCount)
-	atomic.AddInt64(&s.uniqueTxnFingerprintCount, uniqueTxnFingerprintCount)
+	atomic.AddInt64(&s.uniqueStmtFingerprintCount, -uniqueStmtFingerprintCount)
+	atomic.AddInt64(&s.uniqueTxnFingerprintCount, -uniqueTxnFingerprintCount)
 }
 
 // GetTotalFingerprintCount returns total number of unique statement and


### PR DESCRIPTION
Problem:
The counters used to track the number of unique fingerprints we store in-memory for sql stats were refactored in #110805. In change #110805 a bug was introduced where it incresease the memory instead of resetting the counts. This causes the statstics to stop calculating new stats once the limit is hit.

Solution:
Fix the bug by resetting the counters instead of increasing them. Added new test to test the reset functionality.

Fixes: #111583

Release note (sql change): Fix a bug that causes the sql stats to stop collecting new stats.