### PR TITLE
roachtest: skip admission-control/index-backfill from weekly runs

### DIFF
--- a/pkg/cmd/roachtest/tests/admission_control_index_backfill.go
+++ b/pkg/cmd/roachtest/tests/admission_control_index_backfill.go
@@ -45,11 +45,14 @@ func registerIndexBackfill(r registry.Registry) {
 		Owner:            registry.OwnerAdmissionControl,
 		Benchmark:        true,
 		CompatibleClouds: registry.AllExceptAWS,
-		Suites:           registry.Suites(registry.Weekly),
-		Tags:             registry.Tags(`weekly`),
-		Cluster:          clusterSpec,
-		RequiresLicense:  true,
-		SnapshotPrefix:   "index-backfill-tpce-100k",
+		Suites:           registry.ManualOnly,
+		Tags:             registry.Tags(`manual`),
+		// TODO(aaditya): Revisit this as part of #111614.
+		//Suites:           registry.Suites(registry.Weekly),
+		//Tags:             registry.Tags(`weekly`),
+		Cluster:         clusterSpec,
+		RequiresLicense: true,
+		SnapshotPrefix:  "index-backfill-tpce-100k",
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			crdbNodes := c.Spec().NodeCount - 1
 			workloadNode := c.Spec().NodeCount


### PR DESCRIPTION
This test is currently only used for manual benchmarking. It will revisited later as part of
https://github.com/cockroachdb/cockroach/issues/111614.

We should skip it to avoid noise in test failures.

Fixes: #111542.

Release note: None