### PR TITLE
server: exit logging goroutine if work is done

### DIFF
--- a/pkg/server/drain.go
+++ b/pkg/server/drain.go
@@ -492,7 +492,11 @@ func (s *drainServer) logOpenConns(ctx context.Context) error {
 		for {
 			select {
 			case <-ticker.C:
-				log.Ops.Infof(ctx, "number of open connections: %d\n", s.sqlServer.pgServer.GetConnCancelMapLen())
+				openConns := s.sqlServer.pgServer.GetConnCancelMapLen()
+				log.Ops.Infof(ctx, "number of open connections: %d\n", openConns)
+				if openConns == 0 {
+					return
+				}
 			case <-s.stopper.ShouldQuiesce():
 				return
 			case <-ctx.Done():


### PR DESCRIPTION
Previously, this goroutine would remain open even after the number of open connections reached 0. Now, once it reaches 0, the logging goroutine will exit.

Epic: None
Release note: None