### PR TITLE
storage: reduce MVCCValueMerger allocations

### DIFF
--- a/pkg/storage/pebble_merge.go
+++ b/pkg/storage/pebble_merge.go
@@ -294,7 +294,8 @@ func (t *MVCCValueMerger) Finish(includesBase bool) ([]byte, io.Closer, error) {
 		StartTimestampNanos: t.timeSeriesOps[0].StartTimestampNanos,
 		SampleDurationNanos: t.timeSeriesOps[0].SampleDurationNanos,
 	}
-	for _, timeSeriesOp := range t.timeSeriesOps {
+	for i := range t.timeSeriesOps {
+		timeSeriesOp := &t.timeSeriesOps[i]
 		if timeSeriesOp.StartTimestampNanos != merged.StartTimestampNanos {
 			return nil, nil, errors.Errorf("start timestamp mismatch")
 		}
@@ -303,12 +304,12 @@ func (t *MVCCValueMerger) Finish(includesBase bool) ([]byte, io.Closer, error) {
 		}
 		if !isColumnar && len(timeSeriesOp.Offset) > 0 {
 			ensureColumnar(merged)
-			ensureColumnar(&timeSeriesOp)
+			ensureColumnar(timeSeriesOp)
 			isColumnar = true
 		} else if isColumnar {
-			ensureColumnar(&timeSeriesOp)
+			ensureColumnar(timeSeriesOp)
 		}
-		proto.Merge(merged, &timeSeriesOp)
+		proto.Merge(merged, timeSeriesOp)
 	}
 	if isColumnar {
 		sortAndDeduplicateColumns(merged)

--- a/pkg/storage/pebble_merge.go
+++ b/pkg/storage/pebble_merge.go
@@ -176,6 +176,8 @@ type MVCCValueMerger struct {
 
 	// Used to avoid heap allocations when passing pointer to `Unmarshal()`.
 	meta enginepb.MVCCMetadata
+	// Used to avoid heap allocations in Finish().
+	merged roachpb.InternalTimeSeriesData
 }
 
 const (
@@ -287,9 +289,11 @@ func (t *MVCCValueMerger) Finish(includesBase bool) ([]byte, io.Closer, error) {
 	// compatible with any version that supports row format only. Then we can drop support
 	// for row format entirely. It requires significant cleanup effort as many tests target
 	// the row format.
-	var merged roachpb.InternalTimeSeriesData
-	merged.StartTimestampNanos = t.timeSeriesOps[0].StartTimestampNanos
-	merged.SampleDurationNanos = t.timeSeriesOps[0].SampleDurationNanos
+	merged := &t.merged // avoid allocation
+	*merged = roachpb.InternalTimeSeriesData{
+		StartTimestampNanos: t.timeSeriesOps[0].StartTimestampNanos,
+		SampleDurationNanos: t.timeSeriesOps[0].SampleDurationNanos,
+	}
 	for _, timeSeriesOp := range t.timeSeriesOps {
 		if timeSeriesOp.StartTimestampNanos != merged.StartTimestampNanos {
 			return nil, nil, errors.Errorf("start timestamp mismatch")
@@ -298,20 +302,20 @@ func (t *MVCCValueMerger) Finish(includesBase bool) ([]byte, io.Closer, error) {
 			return nil, nil, errors.Errorf("sample duration mismatch")
 		}
 		if !isColumnar && len(timeSeriesOp.Offset) > 0 {
-			ensureColumnar(&merged)
+			ensureColumnar(merged)
 			ensureColumnar(&timeSeriesOp)
 			isColumnar = true
 		} else if isColumnar {
 			ensureColumnar(&timeSeriesOp)
 		}
-		proto.Merge(&merged, &timeSeriesOp)
+		proto.Merge(merged, &timeSeriesOp)
 	}
 	if isColumnar {
-		sortAndDeduplicateColumns(&merged)
+		sortAndDeduplicateColumns(merged)
 	} else {
-		sortAndDeduplicateRows(&merged)
+		sortAndDeduplicateRows(merged)
 	}
-	tsBytes, err := protoutil.Marshal(&merged)
+	tsBytes, err := protoutil.Marshal(merged)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
These commits address the first four items of #106567.

```
               │   old.txt    │               new.txt               │
               │    sec/op    │    sec/op     vs base               │
ServerQuery-10   1.484m ± ∞ ¹   1.180m ± ∞ ¹  -20.49% (p=0.008 n=5)
¹ need >= 6 samples for confidence interval at level 0.95

               │    old.txt    │               new.txt               │
               │     B/op      │     B/op       vs base              │
ServerQuery-10   1.581Mi ± ∞ ¹   1.434Mi ± ∞ ¹  -9.27% (p=0.008 n=5)
¹ need >= 6 samples for confidence interval at level 0.95

               │   old.txt    │               new.txt               │
               │  allocs/op   │  allocs/op    vs base               │
ServerQuery-10   18.55k ± ∞ ¹   15.98k ± ∞ ¹  -13.89% (p=0.008 n=5)
```

