### PR TITLE
oidc: add interface and improve testing

### DIFF
--- a/pkg/ccl/oidcccl/BUILD.bazel
+++ b/pkg/ccl/oidcccl/BUILD.bazel
@@ -52,6 +52,7 @@ go_test(
         "//pkg/security/securitytest",
         "//pkg/security/username",
         "//pkg/server",
+        "//pkg/server/authserver",
         "//pkg/server/serverpb",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/sqlutils",
@@ -59,6 +60,8 @@ go_test(
         "//pkg/util/leaktest",
         "//pkg/util/log",
         "//pkg/util/randutil",
+        "@com_github_coreos_go_oidc//:go-oidc",
         "@com_github_stretchr_testify//require",
+        "@org_golang_x_oauth2//:oauth2",
     ],
 )

--- a/pkg/ccl/oidcccl/authentication_oidc.go
+++ b/pkg/ccl/oidcccl/authentication_oidc.go
@@ -123,10 +123,9 @@ var (
 //     manner, bypassing any password validation requirements, and redirect them to `/` so they can
 //     enjoy a logged-in experience in the Admin UI.
 type oidcAuthenticationServer struct {
-	mutex        syncutil.RWMutex
-	conf         oidcAuthenticationConf
-	oauth2Config oauth2.Config
-	verifier     *oidc.IDTokenVerifier
+	mutex   syncutil.RWMutex
+	conf    oidcAuthenticationConf
+	manager IOIDCManager
 	// enabled is used to store whether the user has flipped the enabled flag in the cluster settings
 	// if enabled is true and initialized is false, the code will continue to attempt to re-initialize
 	// the OIDC server every time a handler is invoked for the login or callback endpoints. This is
@@ -164,6 +163,93 @@ func (s *oidcAuthenticationServer) GetOIDCConf() ui.OIDCUIConf {
 
 		GenerateJWTAuthTokenEnabled: s.conf.generateJWTAuthTokenEnabled,
 	}
+}
+
+type oidcManager struct {
+	oauth2Config *oauth2.Config
+	verifier     *oidc.IDTokenVerifier
+}
+
+func (o *oidcManager) ExchangeVerifyGetClaims(
+	ctx context.Context, code string, idTokenKey string,
+) (map[string]json.RawMessage, error) {
+	credentials, err := o.Exchange(ctx, code)
+	if err != nil {
+		log.Errorf(ctx, "OIDC: failed to exchange code for token: %v", err)
+		return nil, err
+	}
+
+	rawIDToken, ok := credentials.Extra(idTokenKey).(string)
+	if !ok {
+		err := errors.New("OIDC: failed to extract ID token from the token credentials")
+		log.Error(ctx, "OIDC: failed to extract ID token from the token credentials")
+		return nil, err
+	}
+
+	idToken, err := o.Verify(ctx, rawIDToken)
+	if err != nil {
+		log.Errorf(ctx, "OIDC: unable to verify ID token: %v", err)
+		return nil, err
+	}
+
+	var claims map[string]json.RawMessage
+	if err := idToken.Claims(&claims); err != nil {
+		log.Errorf(ctx, "OIDC: unable to deserialize token claims: %v", err)
+		return nil, err
+	}
+
+	return claims, nil
+}
+
+func (o *oidcManager) Verify(ctx context.Context, s string) (*oidc.IDToken, error) {
+	return o.verifier.Verify(ctx, s)
+}
+
+func (o *oidcManager) Exchange(
+	ctx context.Context, s string, option ...oauth2.AuthCodeOption,
+) (*oauth2.Token, error) {
+	return o.oauth2Config.Exchange(ctx, s, option...)
+}
+
+func (o oidcManager) AuthCodeURL(s string, option ...oauth2.AuthCodeOption) string {
+	return o.oauth2Config.AuthCodeURL(s, option...)
+}
+
+type IOIDCManager interface {
+	Verify(context.Context, string) (*oidc.IDToken, error)
+	Exchange(context.Context, string, ...oauth2.AuthCodeOption) (*oauth2.Token, error)
+	AuthCodeURL(string, ...oauth2.AuthCodeOption) string
+	ExchangeVerifyGetClaims(context.Context, string, string) (map[string]json.RawMessage, error)
+}
+
+var _ IOIDCManager = &oidcManager{}
+
+var NewOIDCManager func(context.Context, oidcAuthenticationConf, string, []string) (IOIDCManager, error) = func(
+	ctx context.Context,
+	conf oidcAuthenticationConf,
+	redirectURL string,
+	scopes []string,
+) (IOIDCManager, error) {
+	provider, err := oidc.NewProvider(ctx, conf.providerURL)
+	if err != nil {
+		return nil, err
+	}
+
+	oauth2Config := &oauth2.Config{
+		ClientID:     conf.clientID,
+		ClientSecret: conf.clientSecret,
+		RedirectURL:  redirectURL,
+
+		Endpoint: provider.Endpoint(),
+		Scopes:   scopes,
+	}
+
+	verifier := provider.Verifier(&oidc.Config{ClientID: conf.clientID})
+
+	return &oidcManager{
+		verifier:     verifier,
+		oauth2Config: oauth2Config,
+	}, nil
 }
 
 func reloadConfig(
@@ -221,15 +307,6 @@ func reloadConfigLocked(
 		return
 	}
 
-	provider, err := oidc.NewProvider(ctx, server.conf.providerURL)
-	if err != nil {
-		log.Warningf(ctx, "unable to initialize OIDC server, disabling OIDC: %v", err)
-		if log.V(1) {
-			log.Infof(ctx, "check provider URL OIDC cluster setting: "+OIDCProviderURLSettingName)
-		}
-		return
-	}
-
 	// Validation of the scope setting will require that we have the `openid` scope.
 	scopesForOauth := strings.Split(server.conf.scopes, " ")
 
@@ -242,16 +319,16 @@ func reloadConfigLocked(
 		return
 	}
 
-	server.oauth2Config = oauth2.Config{
-		ClientID:     server.conf.clientID,
-		ClientSecret: server.conf.clientSecret,
-		RedirectURL:  redirectURL,
-
-		Endpoint: provider.Endpoint(),
-		Scopes:   scopesForOauth,
+	manager, err := NewOIDCManager(ctx, server.conf, redirectURL, scopesForOauth)
+	if err != nil {
+		log.Warningf(ctx, "unable to initialize OIDC server, disabling OIDC: %v", err)
+		if log.V(1) {
+			log.Infof(ctx, "check provider URL OIDC cluster setting: "+OIDCProviderURLSettingName)
+		}
+		return
 	}
 
-	server.verifier = provider.Verifier(&oidc.Config{ClientID: server.conf.clientID})
+	server.manager = manager
 	server.initialized = true
 	log.Infof(ctx, "initialized OIDC server")
 }
@@ -364,30 +441,8 @@ var ConfigureOIDC = func(
 			return
 		}
 
-		credentials, err := oidcAuthentication.oauth2Config.Exchange(ctx, r.URL.Query().Get(codeKey))
+		claims, err := oidcAuthentication.manager.ExchangeVerifyGetClaims(ctx, r.URL.Query().Get(codeKey), idTokenKey)
 		if err != nil {
-			log.Errorf(ctx, "OIDC: failed to exchange code for token: %v", err)
-			http.Error(w, genericCallbackHTTPError, http.StatusInternalServerError)
-			return
-		}
-
-		rawIDToken, ok := credentials.Extra(idTokenKey).(string)
-		if !ok {
-			log.Error(ctx, "OIDC: failed to extract ID token from the token credentials")
-			http.Error(w, genericCallbackHTTPError, http.StatusInternalServerError)
-			return
-		}
-
-		idToken, err := oidcAuthentication.verifier.Verify(ctx, rawIDToken)
-		if err != nil {
-			log.Errorf(ctx, "OIDC: unable to verify ID token: %v", err)
-			http.Error(w, genericCallbackHTTPError, http.StatusInternalServerError)
-			return
-		}
-
-		var claims map[string]json.RawMessage
-		if err := idToken.Claims(&claims); err != nil {
-			log.Errorf(ctx, "OIDC: unable to deserialize token claims: %v", err)
 			http.Error(w, genericCallbackHTTPError, http.StatusInternalServerError)
 			return
 		}
@@ -479,7 +534,7 @@ var ConfigureOIDC = func(
 			return
 		}
 
-		credentials, err := oidcAuthentication.oauth2Config.Exchange(ctx, r.URL.Query().Get(codeKey))
+		credentials, err := oidcAuthentication.manager.Exchange(ctx, r.URL.Query().Get(codeKey))
 		if err != nil {
 			log.Errorf(ctx, "OIDC: failed to exchange code for token: %v", err)
 			log.Errorf(ctx, "%v", r.URL.Query().Get(codeKey))
@@ -498,7 +553,7 @@ var ConfigureOIDC = func(
 			rawToken = rawIDToken
 		}
 
-		token, err := oidcAuthentication.verifier.Verify(ctx, rawToken)
+		token, err := oidcAuthentication.manager.Verify(ctx, rawToken)
 		if err != nil {
 			log.Errorf(ctx, "OIDC: unable to verify ID token: %v", err)
 			http.Error(w, genericCallbackHTTPError, http.StatusInternalServerError)
@@ -667,7 +722,7 @@ var ConfigureOIDC = func(
 		}
 
 		http.SetCookie(w, kast.secretKeyCookie)
-		http.Redirect(w, r, oidcAuthentication.oauth2Config.AuthCodeURL(kast.signedTokenEncoded), http.StatusFound)
+		http.Redirect(w, r, oidcAuthentication.manager.AuthCodeURL(kast.signedTokenEncoded), http.StatusFound)
 	}))
 
 	reloadConfig(serverCtx, oidcAuthentication, locality, st)


### PR DESCRIPTION
Previously, the OIDC implementation directly invoked 3rd party libraries to do various operations. This made the implementation difficult to test unless we had a working HTTP server configured in our tests. It has led to continued test flakes as a result of starting up a test http server in CI.

This commit refactors the implementation to invoke 3rd party libraries via an interface that is mocked in tests. This allows us to finally test the callback login in addition to the login endpoint.

Resolves: #111185
Epic: None

Release note: None