### PR TITLE
schema: add insert/update/delete DML injection test

### DIFF
--- a/pkg/sql/schemachanger/BUILD.bazel
+++ b/pkg/sql/schemachanger/BUILD.bazel
@@ -24,6 +24,7 @@ go_test(
     name = "schemachanger_test",
     size = "enormous",
     srcs = [
+        "dml_injection_test.go",
         "main_test.go",
         "schemachanger_test.go",
         ":test_gen",  # keep
@@ -60,6 +61,7 @@ go_test(
         "//pkg/testutils/serverutils",
         "//pkg/testutils/skip",
         "//pkg/testutils/sqlutils",
+        "//pkg/testutils/testcluster",
         "//pkg/util/ctxgroup",
         "//pkg/util/leaktest",
         "//pkg/util/log",
@@ -70,6 +72,7 @@ go_test(
         "@com_github_lib_pq//:pq",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
+        "@org_golang_x_exp//slices",
     ],
 )
 

--- a/pkg/sql/schemachanger/dml_injection_test.go
+++ b/pkg/sql/schemachanger/dml_injection_test.go
@@ -1,0 +1,558 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package schemachanger_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scexec"
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scop"
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scplan"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/slices"
+)
+
+// phaseOrdinal uniquely identifies a stage. The stageIdx cannot be used
+// because the number of stages in the plan changes between stages.
+type phaseOrdinal struct {
+	phase   scop.Phase
+	ordinal int
+}
+
+func toPhaseOrdinal(stage scplan.Stage) phaseOrdinal {
+	return phaseOrdinal{
+		phase:   stage.Phase,
+		ordinal: stage.Ordinal,
+	}
+}
+
+func (po phaseOrdinal) String() string {
+	return fmt.Sprintf("%s:%d", po.phase, po.ordinal)
+}
+
+func toAnySlice(strings []string) []any {
+	result := make([]any, 0, len(strings))
+	for _, s := range strings {
+		result = append(result, s)
+	}
+	return result
+}
+
+const (
+	valInitial = "1"
+	valUpdated = "2"
+	opDelete   = "delete"
+	opUpdate   = "update"
+	na         = "n/a"
+	// insert_phase_ordinal is the phaseOrdinal the record was inserted by
+	// operation_phase_ordinal is the phaseOrdinal that will modify the record
+	// operation is the operation the operation_phase_ordinal will do to the record
+	// val gets updated for 'update' operations
+	createTable = `
+CREATE TABLE tbl (
+	insert_phase_ordinal TEXT NOT NULL,
+	operation_phase_ordinal TEXT NOT NULL,
+	operation TEXT NOT NULL,
+	val INT,
+	PRIMARY KEY (insert_phase_ordinal, operation_phase_ordinal, operation)
+)`
+	createTableNoPK = `
+CREATE TABLE tbl (
+	insert_phase_ordinal TEXT NOT NULL,
+	operation_phase_ordinal TEXT NOT NULL,
+	operation TEXT NOT NULL,
+	val INT
+)`
+)
+
+func (po phaseOrdinal) noopRow() []string {
+	return []string{
+		po.String(),
+		na,
+		na,
+		valInitial,
+	}
+}
+
+func (po phaseOrdinal) deleteRow(operationPO phaseOrdinal) []string {
+	return []string{
+		po.String(),
+		operationPO.String(),
+		opDelete,
+		valInitial,
+	}
+}
+
+func (po phaseOrdinal) updateRow(operationPO phaseOrdinal, isUpdated bool) []string {
+	val := valInitial
+	if isUpdated {
+		val = valUpdated
+	}
+	return []string{
+		po.String(),
+		operationPO.String(),
+		opUpdate,
+		val,
+	}
+}
+
+type testCase struct {
+	desc         string
+	setup        []string
+	createTable  string
+	schemaChange string
+	expectedErr  string
+	skipIssue    int
+}
+
+// Captures testCase before t.Parallel is called.
+func (tc testCase) capture(f func(*testing.T, testCase)) func(*testing.T) {
+	return func(t *testing.T) {
+		f(t, tc)
+	}
+}
+
+// TestAlterTableDMLInjection creates a table, runs optional setup DDL, then
+// runs a schema change. Before the schema change a single record is inserted
+// so that the table is not empty. During each schema change stage, the
+// expected state of the table is verified and records are
+// inserted/updated/deleted as follows:
+//   - insert an immutable operation="n/a" row that later stages will never
+//     modify
+//   - insert an operation="delete" row for each later stage - each later stage
+//     will delete these rows that previous stages inserted for it
+//   - insert an operation="update" row for each later stage - each later stage
+//     will update these rows that previous stages inserted for it
+func TestAlterTableDMLInjection(t *testing.T) {
+	t.Cleanup(leaktest.AfterTest(t))
+	scope := log.Scope(t)
+	t.Cleanup(func() {
+		scope.Close(t)
+	})
+
+	skip.UnderStressWithIssue(t, 111663)
+
+	testCases := []testCase{
+		{
+			desc:         "add column",
+			schemaChange: "ALTER TABLE tbl ADD COLUMN new_col INT",
+		},
+		{
+			desc:         "drop column",
+			setup:        []string{"ALTER TABLE tbl ADD COLUMN new_col INT"},
+			schemaChange: "ALTER TABLE tbl DROP COLUMN new_col",
+		},
+		{
+			desc:         "add column default value",
+			schemaChange: "ALTER TABLE tbl ADD COLUMN new_col INT NOT NULL DEFAULT 1",
+		},
+		{
+			desc:         "add column default sequence",
+			setup:        []string{"CREATE SEQUENCE seq"},
+			schemaChange: "ALTER TABLE tbl ADD COLUMN new_col INT NOT NULL DEFAULT nextval('seq')",
+			expectedErr:  "cannot evaluate scalar expressions containing sequence operations in this context",
+		},
+		{
+			desc:         "add column default udf",
+			setup:        []string{"CREATE FUNCTION f() RETURNS INT LANGUAGE SQL AS $$ SELECT 1 $$"},
+			schemaChange: "ALTER TABLE tbl ADD COLUMN new_col INT NOT NULL DEFAULT f()",
+			skipIssue:    87699,
+		},
+		{
+			desc: "drop column default udf",
+			setup: []string{
+				"CREATE FUNCTION f() RETURNS INT LANGUAGE SQL AS $$ SELECT 1 $$",
+				"ALTER TABLE tbl ADD COLUMN new_col INT NOT NULL DEFAULT f()",
+			},
+			schemaChange: "ALTER TABLE tbl DROP COLUMN new_col",
+			skipIssue:    87699,
+		},
+		{
+			desc:         "add column default unique",
+			schemaChange: "ALTER TABLE tbl ADD COLUMN new_col TEXT NOT NULL UNIQUE DEFAULT insert_phase_ordinal || operation_phase_ordinal || operation",
+			expectedErr:  "variable sub-expressions are not allowed in DEFAULT",
+		},
+		{
+			desc:         "add column stored",
+			schemaChange: "ALTER TABLE tbl ADD COLUMN new_col TEXT NOT NULL AS (insert_phase_ordinal) STORED",
+		},
+		{
+			desc:         "drop column stored",
+			setup:        []string{"ALTER TABLE tbl ADD COLUMN new_col TEXT NOT NULL AS (insert_phase_ordinal) STORED"},
+			schemaChange: "ALTER TABLE tbl DROP COLUMN new_col",
+		},
+		{
+			desc:         "add column stored family",
+			schemaChange: "ALTER TABLE tbl ADD COLUMN new_col TEXT NOT NULL AS (insert_phase_ordinal) STORED CREATE FAMILY fam",
+		},
+		{
+			desc:         "drop column stored family",
+			setup:        []string{"ALTER TABLE tbl ADD COLUMN new_col TEXT NOT NULL AS (insert_phase_ordinal) STORED CREATE FAMILY fam"},
+			schemaChange: "ALTER TABLE tbl DROP COLUMN new_col",
+		},
+		{
+			desc:         "add column virtual",
+			schemaChange: "ALTER TABLE tbl ADD COLUMN new_col TEXT NOT NULL AS (insert_phase_ordinal) VIRTUAL",
+		},
+		{
+			desc:         "drop column virtual",
+			setup:        []string{"ALTER TABLE tbl ADD COLUMN new_col TEXT NOT NULL AS (insert_phase_ordinal) VIRTUAL"},
+			schemaChange: "ALTER TABLE tbl DROP COLUMN new_col",
+		},
+		{
+			desc:         "add constraint check",
+			schemaChange: "ALTER TABLE tbl ADD CONSTRAINT c CHECK (val > -1)",
+		},
+		{
+			desc:         "drop constraint check",
+			setup:        []string{"ALTER TABLE tbl ADD CONSTRAINT c CHECK (val > -1)"},
+			schemaChange: "ALTER TABLE tbl DROP CONSTRAINT c",
+		},
+		{
+			desc:         "add constraint check udf",
+			setup:        []string{"CREATE FUNCTION f(i INT) RETURNS INT LANGUAGE SQL AS $$ SELECT i $$"},
+			schemaChange: "ALTER TABLE tbl ADD CONSTRAINT c CHECK (f(val) > -1)",
+		},
+		{
+			desc:         "add constraint check not valid",
+			schemaChange: "ALTER TABLE tbl ADD CONSTRAINT c CHECK (val > -1) NOT VALID",
+		},
+		{
+			desc:         "validate constraint",
+			setup:        []string{"ALTER TABLE tbl ADD CONSTRAINT c CHECK (val > -1) NOT VALID"},
+			schemaChange: "ALTER TABLE tbl VALIDATE CONSTRAINT c",
+		},
+		{
+			desc:         "add constraint check udt",
+			setup:        []string{"CREATE TYPE udt AS ENUM ('1', '2')"},
+			schemaChange: "ALTER TABLE tbl ADD CONSTRAINT c CHECK (val::text::udt IN ('1', '2'))",
+		},
+		{
+			desc: "add constraint foreign key",
+			setup: []string{
+				"CREATE TABLE tbl2 (val INT PRIMARY KEY)",
+				"INSERT INTO tbl2 VALUES (1), (2)",
+			},
+			schemaChange: "ALTER TABLE tbl ADD CONSTRAINT fk FOREIGN KEY (val) REFERENCES tbl2 (val)",
+		},
+		{
+			desc: "drop constraint foreign key",
+			setup: []string{
+				"CREATE TABLE tbl2 (val INT PRIMARY KEY)",
+				"INSERT INTO tbl2 VALUES (1), (2)",
+				"ALTER TABLE tbl ADD CONSTRAINT fk FOREIGN KEY (val) REFERENCES tbl2 (val)",
+			},
+			schemaChange: "ALTER TABLE tbl DROP CONSTRAINT fk",
+		},
+		{
+			desc:         "add primary key",
+			createTable:  createTableNoPK,
+			schemaChange: "ALTER TABLE tbl ADD PRIMARY KEY (insert_phase_ordinal, operation_phase_ordinal, operation)",
+		},
+		{
+			desc:         "add constraint unique without index",
+			setup:        []string{"SET experimental_enable_unique_without_index_constraints = true"},
+			schemaChange: "ALTER TABLE tbl ADD CONSTRAINT c UNIQUE WITHOUT INDEX (insert_phase_ordinal, operation_phase_ordinal, operation)",
+		},
+		{
+			desc: "drop constraint unique without index",
+			setup: []string{
+				"SET experimental_enable_unique_without_index_constraints = true",
+				"ALTER TABLE tbl ADD CONSTRAINT c UNIQUE WITHOUT INDEX (insert_phase_ordinal, operation_phase_ordinal, operation)",
+			},
+			schemaChange: "ALTER TABLE tbl DROP CONSTRAINT c",
+		},
+		{
+			desc:        "alter primary key using columns",
+			createTable: createTableNoPK,
+			setup: []string{
+				"ALTER TABLE tbl ADD COLUMN id SERIAL NOT NULL",
+				"ALTER TABLE tbl ADD PRIMARY KEY (id)",
+			},
+			schemaChange: "ALTER TABLE tbl ALTER PRIMARY KEY USING COLUMNS (insert_phase_ordinal, operation_phase_ordinal, operation)",
+		},
+		{
+			desc:        "alter primary key using columns using hash",
+			createTable: createTableNoPK,
+			setup: []string{
+				"ALTER TABLE tbl ADD COLUMN id SERIAL NOT NULL",
+				"ALTER TABLE tbl ADD PRIMARY KEY (id)",
+			},
+			schemaChange: "ALTER TABLE tbl ALTER PRIMARY KEY USING COLUMNS (insert_phase_ordinal, operation_phase_ordinal, operation) USING HASH",
+			skipIssue:    111570,
+		},
+		{
+			desc:         "create index",
+			schemaChange: "CREATE INDEX idx ON tbl (val)",
+		},
+		{
+			desc:         "drop index",
+			setup:        []string{"CREATE INDEX idx ON tbl (val)"},
+			schemaChange: "DROP INDEX idx",
+		},
+		{
+			desc: "drop column with index",
+			setup: []string{
+				"ALTER TABLE tbl ADD COLUMN i INT NOT NULL DEFAULT 1",
+				"CREATE INDEX idx ON tbl (i)",
+			},
+			schemaChange: "ALTER TABLE tbl DROP COLUMN i",
+		},
+		{
+			desc:         "create index using hash",
+			schemaChange: "CREATE INDEX idx ON tbl (val) USING HASH",
+			skipIssue:    111621,
+		},
+		{
+			desc:         "drop index using hash",
+			setup:        []string{"CREATE INDEX idx ON tbl (val) USING HASH"},
+			schemaChange: "DROP INDEX idx",
+		},
+		{
+			desc: "drop column with index using hash cascade",
+			setup: []string{
+				"ALTER TABLE tbl ADD COLUMN i INT NOT NULL DEFAULT 1",
+				"CREATE INDEX idx ON tbl (i) USING HASH",
+			},
+			schemaChange: "ALTER TABLE tbl DROP COLUMN i CASCADE",
+			skipIssue:    111619,
+		},
+		{
+			desc:         "create unique index",
+			schemaChange: "CREATE UNIQUE INDEX idx ON tbl (insert_phase_ordinal, operation_phase_ordinal, operation)",
+		},
+		{
+			desc:         "drop unique index",
+			setup:        []string{"CREATE UNIQUE INDEX idx ON tbl (insert_phase_ordinal, operation_phase_ordinal, operation)"},
+			schemaChange: "DROP INDEX idx",
+		},
+		{
+			desc: "drop column with unique index",
+			setup: []string{
+				"ALTER TABLE tbl ADD COLUMN i INT NOT NULL DEFAULT 1",
+				"CREATE UNIQUE INDEX idx ON tbl (insert_phase_ordinal, operation_phase_ordinal, operation, i)",
+			},
+			schemaChange: "ALTER TABLE tbl DROP COLUMN i",
+		},
+		{
+			desc:         "create partial index",
+			schemaChange: "CREATE INDEX idx ON tbl (val) WHERE val > 1",
+		},
+		{
+			desc:         "drop partial index",
+			setup:        []string{"CREATE INDEX idx ON tbl (val) WHERE val > 1"},
+			schemaChange: "DROP INDEX idx",
+		},
+		{
+			desc: "drop column with partial index",
+			setup: []string{
+				"ALTER TABLE tbl ADD COLUMN i INT NOT NULL DEFAULT 1",
+				"CREATE INDEX idx ON tbl (val) WHERE i > 1",
+			},
+			schemaChange: "ALTER TABLE tbl DROP COLUMN i",
+			skipIssue:    97813,
+		},
+		{
+			desc:         "create expression index",
+			schemaChange: "CREATE INDEX idx ON tbl ((val + 1))",
+		},
+		{
+			desc:         "drop expression index",
+			setup:        []string{"CREATE INDEX idx ON tbl ((val + 1))"},
+			schemaChange: "DROP INDEX idx",
+		},
+		{
+			desc: "drop column with expression index cascade",
+			setup: []string{
+				"ALTER TABLE tbl ADD COLUMN i INT NOT NULL DEFAULT 1",
+				"CREATE INDEX idx ON tbl ((i + 1))",
+			},
+			schemaChange: "ALTER TABLE tbl DROP COLUMN i CASCADE",
+			skipIssue:    111608,
+		},
+		{
+			desc:         "create materialized view from index",
+			schemaChange: "CREATE MATERIALIZED VIEW mv AS SELECT * FROM tbl@tbl_pkey",
+		},
+		{
+			desc: "drop index cascade to materialized view",
+			setup: []string{
+				"CREATE INDEX idx ON tbl (val)",
+				"CREATE MATERIALIZED VIEW mv AS SELECT * FROM tbl@idx",
+			},
+			schemaChange: "DROP INDEX idx CASCADE",
+		},
+	}
+
+	ctx := context.Background()
+	for _, tc := range testCases {
+		t.Run(tc.desc, tc.capture(func(t *testing.T, tc testCase) {
+			t.Parallel() // SAFE FOR TESTING
+			if issue := tc.skipIssue; issue != 0 {
+				skip.WithIssue(t, issue)
+			}
+			const insert = `INSERT INTO tbl VALUES ($1, $2, $3, $4)`
+			preSchemaChangeRow := []string{
+				"pre-schema-change",
+				na,
+				na,
+				valInitial,
+			}
+			var sqlDB *sqlutils.SQLRunner
+			var clusterCreated atomic.Bool
+			poMap := make(map[phaseOrdinal]int)
+			var poSlice []phaseOrdinal
+			testCluster := serverutils.StartCluster(t, 1, base.TestClusterArgs{
+				ServerArgs: base.TestServerArgs{
+					Knobs: base.TestingKnobs{
+						SQLDeclarativeSchemaChanger: &scexec.TestingKnobs{
+							BeforeStage: func(p scplan.Plan, stageIdx int) error {
+								if !clusterCreated.Load() {
+									// Do nothing if cluster creation isn't finished. Certain schema
+									// changes are run during cluster creation (e.g. `CREATE DATABASE
+									// defaultdb`) and we don't want those to hijack this knob.
+									return nil
+								}
+
+								// Cannot verify DML injection for unsupported schema changes.
+								if tc.expectedErr != "" {
+									return nil
+								}
+
+								if t.Failed() {
+									return errors.New("terminating schema change due to test failure")
+								}
+
+								currentStage := p.Stages[stageIdx]
+								currentPO := toPhaseOrdinal(currentStage)
+								errorMessage := fmt.Sprintf("phaseOrdinal=%s", currentPO)
+
+								// Capture all stages in the StatementPhase before they disappear.
+								if currentStage.Phase == scop.StatementPhase {
+									require.Empty(t, poMap, errorMessage)
+									require.Empty(t, poSlice, errorMessage)
+									for i, s := range p.Stages {
+										po := toPhaseOrdinal(s)
+										poMap[po] = i
+										poSlice = append(poSlice, po)
+									}
+								}
+
+								numStages := len(poMap)
+								poIdx := poMap[currentPO]
+
+								require.NotNil(t, sqlDB, errorMessage)
+
+								// Add preSchemaChangeRow.
+								expectedResults := [][]string{preSchemaChangeRow}
+								for i := 0; i < poIdx; i++ {
+									// Add no-op rows from previous stages.
+									expectedResults = append(expectedResults, poSlice[i].noopRow())
+
+									// Add update rows from previous stages for all stages.
+									for j := i + 1; j < numStages; j++ {
+										isJPrev := false
+										if j < poIdx {
+											isJPrev = true
+										}
+										expectedResults = append(expectedResults, poSlice[i].updateRow(poSlice[j], isJPrev))
+									}
+
+									// Add delete rows from previous stages for this and later stages.
+									for j := poIdx; j < numStages; j++ {
+										expectedResults = append(expectedResults, poSlice[i].deleteRow(poSlice[j]))
+									}
+								}
+								// Sort expectedResults to match order returned by SELECT.
+								slices.SortFunc(expectedResults, func(a, b []string) bool {
+									require.Equal(t, len(a), len(b), errorMessage)
+									for i := 0; i < len(a); i++ {
+										switch strings.Compare(a[i], b[i]) {
+										case -1:
+											return true
+										case 1:
+											return false
+										}
+									}
+									panic(fmt.Sprintf("slice contains duplicate elements a=%s b=%s %s", a, b, errorMessage))
+								})
+								actualResults := sqlDB.QueryStr(t, `SELECT 	insert_phase_ordinal, operation_phase_ordinal, operation, val FROM tbl`)
+								// Use subset instead of equals for better error output.
+								require.Subset(t, expectedResults, actualResults, errorMessage)
+								require.Subset(t, actualResults, expectedResults, errorMessage)
+
+								for i := 0; i < poIdx; i++ {
+									insertPO := poSlice[i]
+									// Verify 1 row is correctly deleted.
+									sqlDB.ExecRowsAffectedWithMessage(
+										t,
+										1,
+										errorMessage,
+										`DELETE FROM tbl WHERE insert_phase_ordinal = $1 AND operation_phase_ordinal = $2 AND operation = $3`,
+										insertPO.String(), currentPO.String(), opDelete,
+									)
+									// Verify 1 row is correctly updated.
+									sqlDB.ExecRowsAffectedWithMessage(
+										t,
+										1,
+										errorMessage,
+										`UPDATE tbl SET val = 2 WHERE insert_phase_ordinal = $1 AND operation_phase_ordinal = $2 AND operation = $3`,
+										insertPO.String(), currentPO.String(), opUpdate,
+									)
+								}
+
+								// This record should not be modified by any stage.
+								sqlDB.ExecWithMessage(t, errorMessage, insert, toAnySlice(currentPO.noopRow())...)
+								for i := poIdx + 1; i < numStages; i++ {
+									// These records should be modified by later stages.
+									//  'delete' should be deleted at operation_stage.
+									//  'update' should have its val updated at operation_stage.
+									sqlDB.ExecWithMessage(t, errorMessage, insert, toAnySlice(currentPO.deleteRow(poSlice[i]))...)
+									sqlDB.ExecWithMessage(t, errorMessage, insert, toAnySlice(currentPO.updateRow(poSlice[i], false))...)
+								}
+								return nil
+							},
+						},
+					},
+				},
+			})
+			defer testCluster.Stopper().Stop(ctx)
+			sqlDB = sqlutils.MakeSQLRunner(testCluster.ServerConn(0))
+			create := tc.createTable
+			if create == "" {
+				create = createTable
+			}
+			sqlDB.Exec(t, create)
+			sqlDB.Exec(t, insert, toAnySlice(preSchemaChangeRow)...)
+			for i, setup := range tc.setup {
+				sqlDB.ExecWithMessage(t, fmt.Sprintf("i=%d", i), setup)
+			}
+			clusterCreated.Store(true)
+			_, err := sqlDB.DB.ExecContext(ctx, tc.schemaChange)
+			if expectedErr := tc.expectedErr; expectedErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, expectedErr)
+			}
+		}))
+	}
+}

--- a/pkg/sql/schemachanger/main_test.go
+++ b/pkg/sql/schemachanger/main_test.go
@@ -18,12 +18,14 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 )
 
 func TestMain(m *testing.M) {
 	securityassets.SetLoader(securitytest.EmbeddedAssets)
 	randutil.SeedForTests()
+	serverutils.InitTestClusterFactory(testcluster.TestClusterFactory)
 	serverutils.InitTestServerFactory(server.TestServerFactory)
 	os.Exit(m.Run())
 }


### PR DESCRIPTION
Fixes #108181

Adds a new test that runs insert/update/delete statements during
every phase and stage of a schema change and verifies that correct
DML changes can be seen externally.

Each subtest creates a table, runs optional setup DDL, then runs a schema
change. Before the schema change a single record is inserted so that the
table is not empty. During each schema change stage, the expected state of
the table is verified and records are inserted/updated/deleted as follows:
- insert an immutable operation="n/a" row that later stages will never modify
- insert an operation="delete" row for each later stage - each later stage
  will delete these rows that previous stages inserted for it
- insert an operation="update" row for each later stage - each later stage
  will update these rows that previous stages inserted for it

A new test is added instead of changing existing tests to avoid needing to
manually specify the expected output and DML injection at each stage as it
is determined programatically.

Release note: None
