### PR TITLE
encoding: fix UnsafeConvertStringToBytes to work with large input strings

### DIFF
--- a/pkg/util/encoding/BUILD.bazel
+++ b/pkg/util/encoding/BUILD.bazel
@@ -46,6 +46,7 @@ go_test(
         "//pkg/geo/geographiclib",
         "//pkg/geo/geopb",
         "//pkg/roachpb",
+        "//pkg/testutils/skip",
         "//pkg/util/bitarray",
         "//pkg/util/duration",
         "//pkg/util/ipaddr",

--- a/pkg/util/encoding/encoding_test.go
+++ b/pkg/util/encoding/encoding_test.go
@@ -26,6 +26,7 @@ import (
 	// Blank import so projections are initialized correctly.
 	_ "github.com/cockroachdb/cockroach/pkg/geo/geographiclib"
 	"github.com/cockroachdb/cockroach/pkg/geo/geopb"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/bitarray"
 	"github.com/cockroachdb/cockroach/pkg/util/duration"
 	"github.com/cockroachdb/cockroach/pkg/util/ipaddr"
@@ -831,7 +832,7 @@ func TestEncodeBitArray(t *testing.T) {
 				0, 0xba}},
 		{bitarray.MakeZeroBitArray(62),
 			[]byte{0x3a,
-				0x88, //word 0
+				0x88, // word 0
 				0, 0xc6}},
 		{bitarray.Not(bitarray.MakeZeroBitArray(62)),
 			[]byte{0x3a,
@@ -2620,6 +2621,36 @@ func TestPrettyPrintValueEncoded(t *testing.T) {
 		if str != test.expected {
 			t.Errorf("%d: got %q expected %q", i, str, test.expected)
 		}
+	}
+}
+
+func TestUnsafeConvertStringToBytes(t *testing.T) {
+	// Large input runs slowly.
+	skip.UnderStress(t)
+
+	testCases := []struct {
+		desc     string
+		input    string
+		expected []byte
+	}{
+		{
+			desc:     "empty",
+			input:    "",
+			expected: nil,
+		},
+		{
+			// Previous impl could not handle strings longer than math.MaxInt32.
+			// See https://github.com/cockroachdb/cockroach/issues/111626
+			desc:     "large input",
+			input:    string(make([]byte, math.MaxInt32+1)),
+			expected: make([]byte, math.MaxInt32+1),
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			actual := UnsafeConvertStringToBytes(tc.input)
+			require.Equal(t, tc.expected, actual)
+		})
 	}
 }
 


### PR DESCRIPTION
Fixes #111626

The previous impl assumed input string length <= math.MaxInt32. Go 1.20 added unsafe.StringData (https://pkg.go.dev/unsafe#StringData) which properly handles longer strings. This changes the impl to use unsafe.StringData and adds a unit test.

Release note (bug fix): Fixed a panic that could occur if a query uses a string
larger than 2^31-1 bytes.