### PR TITLE
sql: prevent corruption of spans in the TableReaderSpec proto

### DIFF
--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -2317,6 +2317,9 @@ const SpansOverhead = int64(unsafe.Sizeof(Spans{}))
 func (a Spans) MemUsage() int64 {
 	// Slice the full capacity of a so we can account for the memory
 	// used by spans past the length of a.
+	// TODO(yuzefovich): we expect that all spans in [len:cap] range don't have
+	// any keys set (we can assert this in test builds), so we could calculate
+	// memory usage of those only as SpanOverhead * (cap-len).
 	aCap := a[:cap(a)]
 	size := SpansOverhead
 	for i := range aCap {

--- a/pkg/sql/backfill/backfill.go
+++ b/pkg/sql/backfill/backfill.go
@@ -334,7 +334,7 @@ func (cb *ColumnBackfiller) RunColumnBackfillChunk(
 	// populated and deleted by the OLTP commands but not otherwise
 	// read or used
 	if err := cb.fetcher.StartScan(
-		ctx, []roachpb.Span{sp}, nil, /* spanIDs */
+		ctx, []roachpb.Span{sp}, nil /* spanIDs */, row.DoNotModifySpans,
 		rowinfra.GetDefaultBatchBytesLimit(cb.evalCtx.TestingKnobs.ForceProductionValues),
 		chunkSize,
 	); err != nil {
@@ -863,7 +863,7 @@ func (ib *IndexBackfiller) BuildIndexEntriesChunk(
 	}
 	defer fetcher.Close(ctx)
 	if err := fetcher.StartScan(
-		ctx, []roachpb.Span{sp}, nil, /* spanIDs */
+		ctx, []roachpb.Span{sp}, nil /* spanIDs */, row.DoNotModifySpans,
 		rowinfra.GetDefaultBatchBytesLimit(ib.evalCtx.TestingKnobs.ForceProductionValues),
 		initBufferSize,
 	); err != nil {

--- a/pkg/sql/colfetcher/colbatch_direct_scan.go
+++ b/pkg/sql/colfetcher/colbatch_direct_scan.go
@@ -61,9 +61,13 @@ func (s *ColBatchDirectScan) Init(ctx context.Context) {
 		s.Ctx, s.flowCtx, "colbatchdirectscan", s.processorID,
 		&s.contentionEventsListener, &s.scanStatsListener, &s.tenantConsumptionListener,
 	)
+	// Since the spans come directly from the proto, we don't want to modify
+	// the spans slice.
+	spansMode := row.DoNotModifySpans
 	firstBatchLimit := cFetcherFirstBatchLimit(s.limitHint, s.spec.MaxKeysPerRow)
 	err := s.fetcher.SetupNextFetch(
-		ctx, s.Spans, nil /* spanIDs */, s.batchBytesLimit, firstBatchLimit, false, /* spansCanOverlap */
+		ctx, s.Spans, nil /* spanIDs */, spansMode,
+		s.batchBytesLimit, firstBatchLimit, false, /* spansCanOverlap */
 	)
 	if err != nil {
 		colexecerror.InternalError(err)

--- a/pkg/sql/colfetcher/colbatch_scan.go
+++ b/pkg/sql/colfetcher/colbatch_scan.go
@@ -241,10 +241,14 @@ func (s *ColBatchScan) Init(ctx context.Context) {
 		s.Ctx, s.flowCtx, "colbatchscan", s.processorID,
 		&s.contentionEventsListener, &s.scanStatsListener, &s.tenantConsumptionListener,
 	)
+	// Since the spans come directly from the proto, we don't want to modify
+	// the spans slice.
+	spansMode := row.DoNotModifySpans
 	limitBatches := !s.parallelize
 	if err := s.cf.StartScan(
 		s.Ctx,
 		s.Spans,
+		spansMode,
 		limitBatches,
 		s.batchBytesLimit,
 		s.limitHint,

--- a/pkg/sql/colfetcher/index_join.go
+++ b/pkg/sql/colfetcher/index_join.go
@@ -210,15 +210,14 @@ func (s *ColIndexJoin) Next() coldata.Batch {
 
 			// Index joins will always return exactly one output row per input row.
 			s.cf.setEstimatedRowCount(uint64(rowCount))
-			// Note that the fetcher takes ownership of the spans slice - it
-			// will modify it and perform the memory accounting. We don't care
-			// about the modification here, but we want to be conscious about
-			// the memory accounting - we don't double count for any memory of
-			// spans because the spanAssembler released all of the relevant
-			// memory from its account in GetSpans().
+			// Note that the fetcher will perform the memory accounting for the
+			// spans. We don't want to double count for any memory of spans
+			// because the spanAssembler released all the relevant memory from
+			// its account in GetSpans(), so we do nothing with accounting here.
 			if err := s.cf.StartScan(
 				s.Ctx,
 				spans,
+				row.CanModifySpans,
 				false, /* limitBatches */
 				rowinfra.NoBytesLimit,
 				rowinfra.NoRowLimit,

--- a/pkg/sql/delete_preserving_index_test.go
+++ b/pkg/sql/delete_preserving_index_test.go
@@ -797,7 +797,7 @@ func fetchIndex(
 	))
 
 	require.NoError(t, fetcher.StartScan(
-		ctx, spans, nil /* spanIDs */, rowinfra.NoBytesLimit, 0,
+		ctx, spans, nil /* spanIDs */, row.DoNotModifySpans, rowinfra.NoBytesLimit, 0,
 	))
 	var rows []tree.Datums
 	for {

--- a/pkg/sql/indexbackfiller_test.go
+++ b/pkg/sql/indexbackfiller_test.go
@@ -411,7 +411,7 @@ INSERT INTO foo VALUES (1), (10), (100);
 		))
 
 		require.NoError(t, fetcher.StartScan(
-			ctx, spans, nil /* spanIDs */, rowinfra.NoBytesLimit, 0,
+			ctx, spans, nil /* spanIDs */, row.DoNotModifySpans, rowinfra.NoBytesLimit, 0,
 		))
 		var rows []tree.Datums
 		for {

--- a/pkg/sql/row/kv_batch_streamer.go
+++ b/pkg/sql/row/kv_batch_streamer.go
@@ -74,6 +74,7 @@ func (f *txnKVStreamer) SetupNextFetch(
 	ctx context.Context,
 	spans roachpb.Spans,
 	spanIDs []int,
+	_ SpansHandlingMode,
 	bytesLimit rowinfra.BytesLimit,
 	_ rowinfra.KeyLimit,
 	_ bool,
@@ -101,6 +102,10 @@ func (f *txnKVStreamer) SetupNextFetch(
 	for i := len(spans); i < len(reqsScratch); i++ {
 		reqsScratch[i] = kvpb.RequestUnion{}
 	}
+	// TODO(yuzefovich): I think we're missing memory accounting for the
+	// overhead of roachpb.Span objects for 'spans' (i.e. the streamer properly
+	// accounts for the keys, but not for the roachpb.Span objects, and the
+	// caller doesn't account for those either).
 	// TODO(yuzefovich): consider supporting COL_BATCH_RESPONSE scan format.
 	reqs := spansToRequests(spans, kvpb.BATCH_RESPONSE, false /* reverse */, f.lockStrength, f.lockDurability, reqsScratch)
 	if err := f.streamer.Enqueue(ctx, reqs); err != nil {

--- a/pkg/sql/rowexec/inverted_joiner.go
+++ b/pkg/sql/rowexec/inverted_joiner.go
@@ -134,9 +134,8 @@ type invertedJoiner struct {
 
 	// indexSpans are the roachpb.Spans generated based on the inverted spans.
 	// The slice is reused between different input batches.
-	// NB: the row fetcher takes ownership of the slice and deeply resets each
-	// element of the slice once the fetcher is done with it, so we don't need
-	// to do ourselves.
+	// NB: the row fetcher performs the memory accounting for it, so we don't
+	// need to do it ourselves.
 	indexSpans roachpb.Spans
 
 	// emitCursor contains information about where the next row to emit is within
@@ -490,7 +489,8 @@ func (ij *invertedJoiner) readInput() (invertedJoinerState, *execinfrapb.Produce
 		return ijEmittingRows, nil
 	}
 	// NB: spans is already sorted, and that sorting is preserved when
-	// generating ij.indexSpans.
+	// generating ij.indexSpans. Also, the memory accounting is done by the
+	// fetcher in StartScan, so we don't do it here.
 	ij.indexSpans, err = ij.spanBuilder.SpansFromInvertedSpans(spans, nil /* constraint */, ij.indexSpans)
 	if err != nil {
 		ij.MoveToDraining(err)
@@ -499,7 +499,7 @@ func (ij *invertedJoiner) readInput() (invertedJoinerState, *execinfrapb.Produce
 
 	log.VEventf(ij.Ctx(), 1, "scanning %d spans", len(ij.indexSpans))
 	if err = ij.fetcher.StartScan(
-		ij.Ctx(), ij.indexSpans, nil, /* spanIDs */
+		ij.Ctx(), ij.indexSpans, nil /* spanIDs */, row.CanModifySpans,
 		rowinfra.NoBytesLimit, rowinfra.NoRowLimit,
 	); err != nil {
 		ij.MoveToDraining(err)

--- a/pkg/sql/rowexec/joinreader.go
+++ b/pkg/sql/rowexec/joinreader.go
@@ -1031,13 +1031,9 @@ func (jr *joinReader) readInput() (
 	}
 
 	log.VEventf(jr.Ctx(), 1, "scanning %d spans", len(spans))
-	// Note that the fetcher takes ownership of the spans slice - it will modify
-	// it and perform the memory accounting. We don't care about the
-	// modification here, but we want to be conscious about the memory
-	// accounting - we don't double count for any memory of spans because the
-	// joinReaderStrategy doesn't account for any memory used by the spans.
+	// Note that the fetcher will perform the memory accounting for the spans.
 	if err = jr.fetcher.StartScan(
-		jr.Ctx(), spans, spanIDs, jr.getBatchBytesLimit(), rowinfra.NoRowLimit,
+		jr.Ctx(), spans, spanIDs, row.CanModifySpans, jr.getBatchBytesLimit(), rowinfra.NoRowLimit,
 	); err != nil {
 		jr.MoveToDraining(err)
 		return jrStateUnknown, nil, jr.DrainHelper()
@@ -1104,7 +1100,7 @@ func (jr *joinReader) fetchLookupRow() (joinReaderState, *execinfrapb.ProducerMe
 
 			log.VEventf(jr.Ctx(), 1, "scanning %d remote spans", len(spans))
 			if err := jr.fetcher.StartScan(
-				jr.Ctx(), spans, spanIDs, jr.getBatchBytesLimit(), rowinfra.NoRowLimit,
+				jr.Ctx(), spans, spanIDs, row.CanModifySpans, jr.getBatchBytesLimit(), rowinfra.NoRowLimit,
 			); err != nil {
 				jr.MoveToDraining(err)
 				return jrStateUnknown, jr.DrainHelper()

--- a/pkg/sql/rowexec/rowfetcher.go
+++ b/pkg/sql/rowexec/rowfetcher.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
+	"github.com/cockroachdb/cockroach/pkg/sql/row"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
@@ -27,7 +28,7 @@ import (
 // collector wrapper can be plugged in.
 type rowFetcher interface {
 	StartScan(
-		_ context.Context, _ roachpb.Spans, spanIDs []int,
+		_ context.Context, _ roachpb.Spans, spanIDs []int, _ row.SpansHandlingMode,
 		batchBytesLimit rowinfra.BytesLimit, rowLimitHint rowinfra.RowLimit,
 	) error
 	StartInconsistentScan(

--- a/pkg/sql/rowexec/stats.go
+++ b/pkg/sql/rowexec/stats.go
@@ -99,12 +99,13 @@ func (c *rowFetcherStatCollector) StartScan(
 	ctx context.Context,
 	spans roachpb.Spans,
 	spanIDs []int,
+	spansMode row.SpansHandlingMode,
 	batchBytesLimit rowinfra.BytesLimit,
 	limitHint rowinfra.RowLimit,
 ) error {
 	start := timeutil.Now()
 	c.cpuStopWatch.Start()
-	err := c.Fetcher.StartScan(ctx, spans, spanIDs, batchBytesLimit, limitHint)
+	err := c.Fetcher.StartScan(ctx, spans, spanIDs, spansMode, batchBytesLimit, limitHint)
 	c.startScanStallTime += timeutil.Since(start)
 	c.cpuStopWatch.Stop()
 	return err

--- a/pkg/sql/rowexec/tablereader.go
+++ b/pkg/sql/rowexec/tablereader.go
@@ -216,8 +216,11 @@ func (tr *tableReader) startScan(ctx context.Context) error {
 	log.VEventf(ctx, 1, "starting scan with limitBatches %t", limitBatches)
 	var err error
 	if tr.maxTimestampAge == 0 {
+		// Since the spans come directly from the proto, we don't want to modify
+		// the spans slice.
+		spansMode := row.DoNotModifySpans
 		err = tr.fetcher.StartScan(
-			ctx, tr.Spans, nil /* spanIDs */, bytesLimit, tr.limitHint,
+			ctx, tr.Spans, nil /* spanIDs */, spansMode, bytesLimit, tr.limitHint,
 		)
 	} else {
 		initialTS := tr.FlowCtx.Txn.ReadTimestamp()

--- a/pkg/sql/rowexec/zigzagjoiner.go
+++ b/pkg/sql/rowexec/zigzagjoiner.go
@@ -660,6 +660,7 @@ func (z *zigzagJoiner) nextRow(ctx context.Context) (rowenc.EncDatumRow, error) 
 			ctx,
 			roachpb.Spans{roachpb.Span{Key: curInfo.key, EndKey: curInfo.endKey}},
 			nil, /* spanIDs */
+			row.CanModifySpans,
 			rowinfra.GetDefaultBatchBytesLimit(z.EvalCtx.TestingKnobs.ForceProductionValues),
 			zigzagJoinerBatchSize,
 		)
@@ -799,6 +800,7 @@ func (z *zigzagJoiner) maybeFetchInitialRow() error {
 			z.Ctx(),
 			roachpb.Spans{roachpb.Span{Key: curInfo.key, EndKey: curInfo.endKey}},
 			nil, /* spanIDs */
+			row.CanModifySpans,
 			rowinfra.GetDefaultBatchBytesLimit(z.EvalCtx.TestingKnobs.ForceProductionValues),
 			zigzagJoinerBatchSize,
 		)


### PR DESCRIPTION
This commit fixes the "spans" corruption in the TableReaderSpec proto
which can make it so that retry-as-local mechanism returns incorrect
results. In particular, the corruption occurs in the following case:
- the table reader takes the spans directly from the proto and passes it
(eventually) into `txnKVFetcher`
- `txnKVFetcher` currently always takes "full" ownership of the spans
slice and can modify it as it pleases
- during the execution, that spans slice can have each individual span
be nil'ed out or different keys written into (note that the keys aren't
mutated, only `roachpb.Span` objects are)
- as a result, it is now possible to mutate the TableReaderSpec proto in
such a manner that if the query happens to run into an error during the
distributed execution and then retried-as-local, that local physical
plan will have incorrect spans, meaning that it'll produce incorrect
results.

This problem is fixed by adjusting the `KVBatchFetcher` interface to
indicate whether the spans can be mutated or not. They cannot be mutated
only when they come directly from the proto, which is the case only for
the table readers; all other processors directly create and "own" the
spans, so those can be modified during the execution to reduce memory
footprint.

When the spans modification is not allowed, then the `txnKVFetcher`
simply allocates its own scratch space that is reused and mutated from
that point going forward.

Care has been taken to ensure that all memory is accounted for properly.
It is still the responsibility of the `KVBatchFetcher` to account for
the spans slice (it's just a convenient place to do so), but it now
additionally might need to account for another slice (i.e. account for
two slices if spans modification is disallowed and some resume spans
occurred).

Fixes: #110712.

Release note: None