### PR TITLE
backfill: force batch bytes limit production value if knob is set

### DIFF
--- a/pkg/sql/backfill/backfill.go
+++ b/pkg/sql/backfill/backfill.go
@@ -335,7 +335,7 @@ func (cb *ColumnBackfiller) RunColumnBackfillChunk(
 	// read or used
 	if err := cb.fetcher.StartScan(
 		ctx, []roachpb.Span{sp}, nil, /* spanIDs */
-		rowinfra.GetDefaultBatchBytesLimit(false /* forceProductionValue */),
+		rowinfra.GetDefaultBatchBytesLimit(cb.evalCtx.TestingKnobs.ForceProductionValues),
 		chunkSize,
 	); err != nil {
 		log.Errorf(ctx, "scan error: %s", err)
@@ -864,7 +864,7 @@ func (ib *IndexBackfiller) BuildIndexEntriesChunk(
 	defer fetcher.Close(ctx)
 	if err := fetcher.StartScan(
 		ctx, []roachpb.Span{sp}, nil, /* spanIDs */
-		rowinfra.GetDefaultBatchBytesLimit(false /* forceProductionValue */),
+		rowinfra.GetDefaultBatchBytesLimit(ib.evalCtx.TestingKnobs.ForceProductionValues),
 		initBufferSize,
 	); err != nil {
 		log.Errorf(ctx, "scan error: %s", err)


### PR DESCRIPTION
This commit is similar in spirit to f6b7969068f7c7b793f8453f71790bf87b7dbd3c, and although I'm not sure whether it matters, it seems nice to apply the testing knob override everywhere. (I just happened to notice this while modifying some adjacent code.)

Epic: None

Release note: None