### PR TITLE
kvserver: use `SystemVisible` for `kv.raft.command.max_size`

### DIFF
--- a/pkg/kv/kvserver/kvserverbase/base.go
+++ b/pkg/kv/kvserver/kvserverbase/base.go
@@ -298,7 +298,7 @@ const (
 
 // MaxCommandSize wraps "kv.raft.command.max_size".
 var MaxCommandSize = settings.RegisterByteSizeSetting(
-	settings.ApplicationLevel,
+	settings.SystemVisible, // used by SQL/bulk to determine mutation batch sizes
 	"kv.raft.command.max_size",
 	"maximum size of a raft command",
 	MaxCommandSizeDefault,

--- a/pkg/sql/copy/BUILD.bazel
+++ b/pkg/sql/copy/BUILD.bazel
@@ -16,6 +16,7 @@ go_test(
         "//pkg/base",
         "//pkg/cli/clisqlclient",
         "//pkg/kv/kvpb",
+        "//pkg/kv/kvserver/kvserverbase",
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",
         "//pkg/security/username",

--- a/pkg/sql/importer/import_stmt_test.go
+++ b/pkg/sql/importer/import_stmt_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keyvisualizer"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/rpc/nodedialer"
@@ -7122,7 +7123,9 @@ func TestImportRowErrorLargeRows(t *testing.T) {
 	defer tc.Stopper().Stop(ctx)
 	sqlDB := sqlutils.MakeSQLRunner(connDB)
 	// Our input file has an 8MB row
-	sqlDB.Exec(t, `SET CLUSTER SETTING kv.raft.command.max_size = '4MiB'`)
+	for _, l := range []serverutils.ApplicationLayerInterface{tc.Server(0), tc.Server(0).SystemLayer()} {
+		kvserverbase.MaxCommandSize.Override(ctx, &l.ClusterSettings().SV, 4<<20)
+	}
 	sqlDB.Exec(t, `CREATE DATABASE foo; SET DATABASE = foo`)
 	sqlDB.Exec(t, "CREATE TABLE simple (s string)")
 	defer sqlDB.Exec(t, "DROP table simple")

--- a/pkg/sql/logictest/testdata/logic_test/upsert
+++ b/pkg/sql/logictest/testdata/logic_test/upsert
@@ -1213,8 +1213,12 @@ statement ok
 DROP TABLE target
 
 # Regression test for UPSERT batching logic (#51391).
+user host-cluster-root
+
 statement ok
 SET CLUSTER SETTING kv.raft.command.max_size='4MiB';
+
+user root
 
 statement ok
 CREATE TABLE src (s STRING);
@@ -1230,8 +1234,12 @@ FROM
 statement ok
 UPSERT INTO dest (s) (SELECT s FROM src)
 
+user host-cluster-root
+
 statement ok
 RESET CLUSTER SETTING kv.raft.command.max_size;
+
+user root
 
 statement ok
 DROP TABLE src;

--- a/pkg/sql/logictest/testdata/logic_test/upsert_non_metamorphic
+++ b/pkg/sql/logictest/testdata/logic_test/upsert_non_metamorphic
@@ -7,8 +7,12 @@ CREATE TABLE src (s STRING);
 CREATE TABLE dest (s STRING);
 INSERT INTO src SELECT repeat('a', 100000) FROM generate_series(1, 60)
 
+user host-cluster-root
+
 statement ok
 SET CLUSTER SETTING kv.raft.command.max_size='4MiB';
+
+user root
 
 statement ok
 SET CLUSTER SETTING sql.mutations.mutation_batch_byte_size='1MiB';
@@ -21,8 +25,12 @@ UPSERT INTO dest (s) (SELECT s FROM src)
 statement ok
 RESET CLUSTER SETTING sql.mutations.mutation_batch_byte_size;
 
+user host-cluster-root
+
 statement ok
 RESET CLUSTER SETTING kv.raft.command.max_size;
+
+user root
 
 statement ok
 DROP TABLE src;


### PR DESCRIPTION
Epic: none
Release note: None