### PR TITLE
roachtest: show running test in teamcity logs

### DIFF
--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -1149,9 +1149,7 @@ func (r *testRunner) runTest(
 		shout(ctx, l, stdout, "=== RUN   %s  [metrics: https://go.crdb.dev/roachtest-grafana/%s/%s/%d/%d]",
 			testRunID, vm.SanitizeLabel(runID), vm.SanitizeLabel(testRunID), t.start.UnixMilli(), t.start.Add(30*time.Minute).UnixMilli())
 	} else {
-		if !teamCity {
-			shout(ctx, l, stdout, "=== RUN   %s", testRunID)
-		}
+		shout(ctx, l, stdout, "=== RUN   %s", testRunID)
 	}
 	select {
 	case <-testReturnedCh:


### PR DESCRIPTION
In the TC log, we currently show when a test has finished. Now that stderr/out has been cleaned up, it would be useful to also show when a test has begun running. We already do this in GCE (with a grafana link). 

Epic: none

Release note: None