### PR TITLE
release-23.1: log: add filepath in headers config to http servers

### DIFF
--- a/docs/generated/logsinks.md
+++ b/docs/generated/logsinks.md
@@ -221,6 +221,7 @@ Type-specific configuration options:
 | `timeout` | the HTTP timeout. Defaults to 0 for no timeout. Inherited from `http-defaults.timeout` if not specified. |
 | `disable-keep-alives` | causes the logging sink to re-establish a new connection for every outgoing log message. This option is intended for testing only and can cause excessive network overhead in production systems. Inherited from `http-defaults.disable-keep-alives` if not specified. |
 | `headers` | a list of headers to attach to each HTTP request Inherited from `http-defaults.headers` if not specified. |
+| `file-based-headers` | a list of headers with filepaths whose contents are attached to each HTTP request Inherited from `http-defaults.file-based-headers` if not specified. |
 | `compression` | can be "none" or "gzip" to enable gzip compression. Set to "gzip" by default. Inherited from `http-defaults.compression` if not specified. |
 
 

--- a/pkg/util/log/BUILD.bazel
+++ b/pkg/util/log/BUILD.bazel
@@ -190,6 +190,7 @@ go_test(
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
         "@org_golang_x_net//trace",
+        "@org_golang_x_sys//unix",
     ],
 )
 

--- a/pkg/util/log/http_sink.go
+++ b/pkg/util/log/http_sink.go
@@ -17,10 +17,12 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"os"
 
 	"github.com/cockroachdb/cockroach/pkg/cli/exit"
 	"github.com/cockroachdb/cockroach/pkg/util/httputil"
 	"github.com/cockroachdb/cockroach/pkg/util/log/logconfig"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/errors"
 )
 
@@ -61,6 +63,24 @@ func newHTTPSink(c logconfig.HTTPSinkConfig) (*httpSink, error) {
 
 	hs.config = &c
 
+	staticHeaders := make(map[string]string, len(c.Headers))
+	dhFilepaths := make(map[string]string, len(c.Headers))
+	for key, val := range c.Headers {
+		staticHeaders[key] = val
+	}
+	for key, val := range c.FileBasedHeaders {
+		dhFilepaths[key] = val
+	}
+	hs.staticHeaders = staticHeaders
+	if len(dhFilepaths) > 0 {
+		hs.dynamicHeaders = &dynamicHeaders{
+			headerToFilepath: dhFilepaths,
+		}
+		err := hs.RefreshDynamicHeaders()
+		if err != nil {
+			return nil, err
+		}
+	}
 	return hs, nil
 }
 
@@ -70,6 +90,19 @@ type httpSink struct {
 	contentType string
 	doRequest   func(sink *httpSink, logEntry []byte) (*http.Response, error)
 	config      *logconfig.HTTPSinkConfig
+	// staticHeaders holds all the config headers defined by direct values.
+	staticHeaders map[string]string
+	// dynamicHeaders holds all the config headers defined by values from files.
+	// It will be nil if there are no filepaths provided.
+	dynamicHeaders *dynamicHeaders
+}
+
+type dynamicHeaders struct {
+	headerToFilepath map[string]string
+	mu               struct {
+		syncutil.Mutex
+		headerToValue map[string]string
+	}
 }
 
 // output emits some formatted bytes to this sink.
@@ -122,8 +155,19 @@ func doPost(hs *httpSink, b []byte) (*http.Response, error) {
 		req.Header.Add(httputil.ContentEncodingHeader, httputil.GzipEncoding)
 	}
 
-	for k, v := range hs.config.Headers {
+	// Add both the staticHeaders and dynamicHeaders to the request.
+	for k, v := range hs.staticHeaders {
 		req.Header.Add(k, v)
+	}
+	// If the filepathMap was populated we know to check the values.
+	if hs.dynamicHeaders != nil {
+		func() {
+			hs.dynamicHeaders.mu.Lock()
+			defer hs.dynamicHeaders.mu.Unlock()
+			for k, v := range hs.dynamicHeaders.mu.headerToValue {
+				req.Header.Add(k, v)
+			}
+		}()
 	}
 	req.Header.Add(httputil.ContentTypeHeader, hs.contentType)
 	resp, err := hs.client.Do(req)
@@ -170,4 +214,25 @@ func (e HTTPLogError) Error() string {
 	return fmt.Sprintf(
 		"received %v response attempting to log to [%v]",
 		e.StatusCode, e.Address)
+}
+
+// RefreshDynamicHeaders loads and sets the new dynamic headers for a given sink.
+// It iterates over dynamicHeaders.filepath reading each file for contents and then
+// updating dynamicHeaders.mu.value.
+func (hs *httpSink) RefreshDynamicHeaders() error {
+	if hs.dynamicHeaders == nil {
+		return nil
+	}
+	dhVals := make(map[string]string, len(hs.dynamicHeaders.headerToFilepath))
+	for key, filepath := range hs.dynamicHeaders.headerToFilepath {
+		data, err := os.ReadFile(filepath)
+		if err != nil {
+			return err
+		}
+		dhVals[key] = string(data)
+	}
+	hs.dynamicHeaders.mu.Lock()
+	defer hs.dynamicHeaders.mu.Unlock()
+	hs.dynamicHeaders.mu.headerToValue = dhVals
+	return nil
 }

--- a/pkg/util/log/log_flush.go
+++ b/pkg/util/log/log_flush.go
@@ -91,12 +91,17 @@ func flushDaemon() {
 	}
 }
 
-// signalFlusher flushes the log(s) every time SIGHUP is received.
+// signalFlusher updates any header values from files in the http sinks
+// and also flushes the log(s) every time SIGHUP is received.
 // This handles both the primary and secondary loggers.
 func signalFlusher() {
 	ch := sysutil.RefreshSignaledChan()
 	for sig := range ch {
 		Ops.Infof(context.Background(), "%s received, flushing logs", sig)
+		err := RefreshHttpSinkHeaders()
+		if err != nil {
+			Ops.Infof(context.Background(), "error while refreshing http sink headers: %s", err)
+		}
 		Flush()
 	}
 }
@@ -110,4 +115,12 @@ func StartAlwaysFlush() {
 	logging.flushWrites.Set(true)
 	// There may be something in the buffers already; flush it.
 	Flush()
+}
+
+// RefreshHttpSinkHeaders will iterate over all http sinks and replace the sink's
+// dynamicHeaders with newly generated dynamicHeaders.
+func RefreshHttpSinkHeaders() error {
+	return logging.allSinkInfos.iterHttpSinks(func(hs *httpSink) error {
+		return hs.RefreshDynamicHeaders()
+	})
 }

--- a/pkg/util/log/logconfig/config.go
+++ b/pkg/util/log/logconfig/config.go
@@ -508,6 +508,10 @@ type HTTPDefaults struct {
 	// Headers is a list of headers to attach to each HTTP request
 	Headers map[string]string `yaml:",omitempty,flow"`
 
+	// FileBasedHeaders is a list of headers with filepaths whose contents are
+	// attached to each HTTP request
+	FileBasedHeaders map[string]string `yaml:"file-based-headers,omitempty,flow"`
+
 	// Compression can be "none" or "gzip" to enable gzip compression.
 	// Set to "gzip" by default.
 	Compression *string `yaml:",omitempty"`

--- a/pkg/util/log/logconfig/testdata/validate
+++ b/pkg/util/log/logconfig/testdata/validate
@@ -551,12 +551,14 @@ sinks:
       address: a
       channels: STORAGE
       headers: {X-CRDB-HEADER: header-value-a}
+      file-based-headers: {X-CRDB-FILE-HEADER: /a/path/to/file}
       buffering:
         max-staleness: 10s
     b:
       address: b
       channels: OPS
       headers: {X-CRDB-HEADER: header-value-b, X-ANOTHER-HEADER: zz-yy-bb}
+      file-based-headers: {X-ANOTHER-FILE-HEADER: /other/path/to/file, X-CRDB-FILE-HEADER: /some/path/to/file}
       buffering:
         flush-trigger-size: 5.0KiB
     c:
@@ -583,6 +585,7 @@ sinks:
       timeout: 0s
       disable-keep-alives: false
       headers: {X-CRDB-HEADER: header-value-a}
+      file-based-headers: {X-CRDB-FILE-HEADER: /a/path/to/file}
       compression: gzip
       filter: INFO
       format: json-compact
@@ -603,6 +606,7 @@ sinks:
       timeout: 0s
       disable-keep-alives: false
       headers: {X-ANOTHER-HEADER: zz-yy-bb, X-CRDB-HEADER: header-value-b}
+      file-based-headers: {X-ANOTHER-FILE-HEADER: /other/path/to/file, X-CRDB-FILE-HEADER: /some/path/to/file}
       compression: gzip
       filter: INFO
       format: json-compact

--- a/pkg/util/log/logconfig/validate.go
+++ b/pkg/util/log/logconfig/validate.go
@@ -458,6 +458,14 @@ func (c *Config) validateHTTPSinkConfig(hsc *HTTPSinkConfig) error {
 	if *hsc.Compression != GzipCompression && *hsc.Compression != NoneCompression {
 		return errors.New("compression must be 'gzip' or 'none'")
 	}
+	// If both header types are populated, make sure theres no duplicate keys
+	if hsc.Headers != nil && hsc.FileBasedHeaders != nil {
+		for key := range hsc.Headers {
+			if _, exists := hsc.FileBasedHeaders[key]; exists {
+				return errors.Newf("headers and file-based-headers have the same key %s", key)
+			}
+		}
+	}
 	return c.ValidateCommonSinkConfig(hsc.CommonSinkConfig)
 }
 

--- a/pkg/util/log/registry.go
+++ b/pkg/util/log/registry.go
@@ -89,6 +89,19 @@ func (r *sinkInfoRegistry) iterFileSinks(fn func(l *fileSink) error) error {
 	})
 }
 
+// iterHttpSink iterates over all the http sinks and stops at the first error
+// encountered.
+func (r *sinkInfoRegistry) iterHttpSinks(fn func(hs *httpSink) error) error {
+	return r.iter(func(si *sinkInfo) error {
+		if hs, ok := si.sink.(*httpSink); ok {
+			if err := fn(hs); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
 // put adds a sinkInfo into the registry.
 func (r *sinkInfoRegistry) put(l *sinkInfo) {
 	r.mu.Lock()


### PR DESCRIPTION
Backport 1/1 commits from #111235.

/cc @cockroachdb/release

---

This change adds new custom headers, `file-based-headers` in http-defaults in the logging configuration. These headers support key-filepath pairs. When a key-filepath pair is provided
the values are retrieved from the filepath on sink initialization and whenever SIGHUP is received so that a cluster restart is not needed to update those values.

Example usage with the new filepath: headers
headers:
  {X-CRDB-HEADER-A: filepath: path/to/file}

Release note (ops change): Added a new `file-based-headers` field found in `http-defaults` section of the log config which accepts key-filepath pairs. This allows values found at filepaths to be updated without restarting the cluster by sending SIGHUP to notify that values need to be refreshed.

Epic: CRDB-25399
Fixes: CRDB-31521

Release justification: Customer requirement
