### PR TITLE
cli: support OpenMetrics in tsdump

### DIFF
--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -1539,6 +1539,8 @@ func init() {
 	f.Var(&debugTimeSeriesDumpOpts.format, "format", "output format (text, csv, tsv, raw)")
 	f.Var(&debugTimeSeriesDumpOpts.from, "from", "oldest timestamp to include (inclusive)")
 	f.Var(&debugTimeSeriesDumpOpts.to, "to", "newest timestamp to include (inclusive)")
+	f.StringVar(&debugTimeSeriesDumpOpts.clusterLabel, "cluster-label",
+		"", "prometheus label for cluster name")
 
 	f = debugSendKVBatchCmd.Flags()
 	f.StringVar(&debugSendKVBatchContext.traceFormat, "trace", debugSendKVBatchContext.traceFormat,

--- a/pkg/cli/tsdump.go
+++ b/pkg/cli/tsdump.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"regexp"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/cli/clierrorplus"
@@ -95,6 +96,8 @@ output.
 			w = cw
 		case tsDumpText:
 			w = defaultTSWriter{w: os.Stdout}
+		case tsDumpOpenMetrics:
+			w = &openMetricsWriter{out: os.Stdout}
 		default:
 			return errors.Newf("unknown output format: %v", debugTimeSeriesDumpOpts.format)
 		}
@@ -123,6 +126,39 @@ output.
 type tsWriter interface {
 	Emit(*tspb.TimeSeriesData) error
 	Flush() error
+}
+
+type openMetricsWriter struct {
+	out io.Writer
+}
+
+var reCrStoreNode = regexp.MustCompile(`^cr\.([^\.]+)\.(.*)$`)
+var rePromTSName = regexp.MustCompile(`[^a-z0-9]`)
+
+func (w *openMetricsWriter) Emit(data *tspb.TimeSeriesData) error {
+	name := data.Name
+	sl := reCrStoreNode.FindStringSubmatch(data.Name)
+	label := "node"
+	value := "0"
+	if len(sl) != 0 {
+		label = sl[1]
+		name = sl[2]
+		value = data.Source
+	}
+	name = rePromTSName.ReplaceAllLiteralString(name, `_`)
+	for _, pt := range data.Datapoints {
+		if _, err := fmt.Fprintf(
+			w.out, "%s{%s=%q} %f %d.%d\n", name, label, value, pt.Value, pt.TimestampNanos/1e9, pt.TimestampNanos%1e6,
+		); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (w *openMetricsWriter) Flush() error {
+	fmt.Fprintln(w.out, `# EOF`)
+	return nil
 }
 
 type csvTSWriter struct {
@@ -172,6 +208,7 @@ const (
 	tsDumpCSV
 	tsDumpTSV
 	tsDumpRaw
+	tsDumpOpenMetrics
 )
 
 // Type implements the pflag.Value interface.
@@ -188,6 +225,8 @@ func (m *tsDumpFormat) String() string {
 		return "text"
 	case tsDumpRaw:
 		return "raw"
+	case tsDumpOpenMetrics:
+		return "openmetrics"
 	}
 	return ""
 }
@@ -203,6 +242,8 @@ func (m *tsDumpFormat) Set(s string) error {
 		*m = tsDumpTSV
 	case "raw":
 		*m = tsDumpRaw
+	case "openmetrics":
+		*m = tsDumpOpenMetrics
 	default:
 		return fmt.Errorf("invalid value for --format: %s", s)
 	}


### PR DESCRIPTION
This PR continues #97411 from @tbg.

Fixes https://github.com/cockroachdb/cockroach/issues/97120.

See individual commit messages for details.

----
*From #97411 on the first two commits:*

Touches https://github.com/cockroachdb/cockroach/issues/97120.

    $ cockroach debug tsdump --insecure --format=openmetrics > tsdump.om

    $ tail -n 3 tsdump.om
    valcount{store="1"} 9841.000000 1677012190.0
    valcount{store="1"} 9847.000000 1677012200.0
    # EOF

    $ docker run -v $PWD/tsdump.om:/tsdump.om -v $PWD/data:/data --entrypoint /bin/promtool prom/prometheus tsdb create-blocks-from openmetrics /tsdump.om /data
    BLOCK ULID                  MIN TIME       MAX TIME       DURATION     NUM SAMPLES  NUM CHUNKS   NUM SERIES   SIZE
    01GSTVJG4QMBSQ4ACPK80FFDJ9  1676544540000  1676544940001  6m40.001s    10598        1514         1514         261097
    01GSTVJGWM2CX1AA56QSSZ9T2R  1677009150000  1677009590001  7m20.001s    68130        1514         1514         305952
    01GSTVJHT2TWTZGCPE52AE1T95  1677009600000  1677012200001  43m20.001s   394093       4542         1514         692053

    $ ls data
    01GSTVJG4QMBSQ4ACPK80FFDJ9	01GSTVJGWM2CX1AA56QSSZ9T2R	01GSTVJHT2TWTZGCPE52AE1T95

    $ docker run -p 9090:9090 -v $PWD/data:/data prom/prometheus --storage.tsdb.path=/data --web.enable-admin-api --config.file=/etc/prometheus/prometheus.yml

<img width="1689" alt="image" src="https://user-images.githubusercontent.com/5076964/220455288-e29147d7-c2f6-49dc-bb1d-5be3b28d958f.png">

----

Second commit, convert existing raw tsdump and look at it through Grafana/prom:

`./cockroach debug tsdump --format=openmetrics tsdump.gob > tsdump.om`

For demonstration purposes one can then:

- clone dockprom[^1]
- add `uid: v9Zz2K6nz` to the prometheus datasource[^2]
- run:

  ```
  for d in grafana_data prometheus_data; do
    docker volume create --driver local --opt type=none --opt device=$PWD/$d--opt o=bind $d
  done
  promtool tsdb create-blocks-from openmetrics tsdump.om prometheus_data/
  docker-compose up -d
  ```
- http://localhost:3000 admin/admin
- import the L2 dashboard[^3]
- view the tsdump![^4]

Note that all of the histograms are missing because the internal timeseries
data doesn't support histograms (records just a few quantiles).

[^1]: https://github.com/stefanprodan/dockprom
[^2]: grafana/provisioning/datasources/datasource.yml
[^3]: https://grafana.testeng.crdb.io/d/CAvWxELVz/l2-drill-down?orgId=1&from=now-1h&to=now&refresh=1m&var-cluster=grinaker-231&var-instances=All
[^4]: <img width="1664" alt="image" src="https://user-images.githubusercontent.com/5076964/233642565-175fec77-1bff-4a75-af98-b9bdc6748f78.png">

----
*re: additons to #97411:*

The last two commits enable tsdump raw -> openmetrics conversion offline and add additional labels to the metrics, for parity with cloud metrics.

With a single-node, insecure cluster:

```
➜  cockroach git:(tsdump-openmetrics) ./cockroach debug tsdump --insecure --host=localhost:26258 --format=raw --from="2023-09-29 15:27:03" --to="2023-09-29 20:57:03" > tsdump.gob
 
... shut down cluster...

➜  cockroach git:(tsdump-openmetrics) ✗ ./cockroach debug tsdump --format=openmetrics tsdump.gob --cluster-label="my-cluster" > tsdump_converted.om
➜  cockroach git:(tsdump-openmetrics) ✗ open ./tsdump_converted.om

``` 

```
admission_admitted_elastic_cpu{instance="",organization_id="",organization_label="",node_id="1",sla_type="",tenant_id="",cluster="my-cluster",cluster_type="SELF_HOSTED",job="cockroachdb",region="local",node=""} 0.000000 1696013730.0
admission_admitted_elastic_cpu{instance="",organization_id="",organization_label="",node_id="1",sla_type="",tenant_id="",cluster="my-cluster",cluster_type="SELF_HOSTED",job="cockroachdb",region="local",node=""} 0.000000 1696013740.0
admission_admitted_elastic_cpu{instance="",organization_id="",organization_label="",node_id="1",sla_type="",tenant_id="",cluster="my-cluster",cluster_type="SELF_HOSTED",job="cockroachdb",region="local",node=""} 0.000000 1696013750.0
....
```
 
Tests forthcoming...

----

Epic: None