### PR TITLE
kvnemesis: use correct probability for invalid lease

### DIFF
--- a/pkg/kv/kvnemesis/kvnemesis_test.go
+++ b/pkg/kv/kvnemesis/kvnemesis_test.go
@@ -102,7 +102,7 @@ func (cfg kvnemesisTestCfg) testClusterArgs(tr *SeqTracker) base.TestClusterArgs
 		}
 	}
 
-	if p := cfg.injectReproposalErrorProb; p > 0 {
+	if p := cfg.invalidLeaseAppliedIndexProb; p > 0 {
 		var mu syncutil.Mutex
 		seen := map[string]int{}
 		storeKnobs.LeaseIndexFilter = func(pd *kvserver.ProposalData) kvpb.LeaseAppliedIndex {


### PR DESCRIPTION
Fix test to use correct config for injecting invalid lease indexes.

Epic: none

Release note: None