### PR TITLE
cluster-ui: pin `pnpm` to `8.6.10` for cluster-ui-release workflow

### DIFF
--- a/.github/workflows/cluster-ui-release-next.yml
+++ b/.github/workflows/cluster-ui-release-next.yml
@@ -29,7 +29,7 @@ jobs:
 
     - uses: pnpm/action-setup@v2
       with:
-        version: ">=8.6.10"
+        version: "8.6.10"
 
     - name: Setup NodeJS
       uses: actions/setup-node@v3

--- a/.github/workflows/cluster-ui-release.yml
+++ b/.github/workflows/cluster-ui-release.yml
@@ -29,7 +29,7 @@ jobs:
 
     - uses: pnpm/action-setup@v2
       with:
-        version: ">=8.6.10"
+        version: "8.6.10"
 
     - name: Setup NodeJS
       uses: actions/setup-node@v3


### PR DESCRIPTION
Epic: none
This change pins `pnpm` to `8.6.10` for the cluster-ui release (and release-next) workflow(s) to prevent not up-to-date lockfiles when installing cluster-ui dependencies with pnpm.

Release note: None