### PR TITLE
catalog/lease: add support for dual writing session based leases

### DIFF
--- a/pkg/server/drain.go
+++ b/pkg/server/drain.go
@@ -442,7 +442,10 @@ func (s *drainServer) drainClients(
 
 	// Flush in-memory SQL stats into the statement stats system table.
 	statsProvider := s.sqlServer.pgServer.SQLServer.GetSQLStatsProvider().(*persistedsqlstats.PersistedSQLStats)
-	statsProvider.Flush(ctx)
+	// If the SQL server is disabled there is nothing to drain here.
+	if !s.sqlServer.cfg.DisableSQLServer {
+		statsProvider.Flush(ctx)
+	}
 	statsProvider.Stop(ctx)
 
 	// Inform the async tasks for table stats that the node is draining

--- a/pkg/server/initial_sql.go
+++ b/pkg/server/initial_sql.go
@@ -43,7 +43,7 @@ func (s *topLevelServer) RunInitialSQL(
 	}
 
 	newCluster := s.InitialStart() && s.NodeID() == kvstorage.FirstNodeID
-	if !newCluster {
+	if !newCluster || s.cfg.DisableSQLServer {
 		// The initial SQL code only runs the first time the cluster is initialized.
 		return nil
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1227,6 +1227,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterf
 		systemTenantNameContainer,
 		pgPreServer.SendRoutingError,
 		tenantCapabilitiesWatcher,
+		cfg.DisableSQLServer,
 	)
 	drain.serverCtl = sc
 

--- a/pkg/server/server_controller.go
+++ b/pkg/server/server_controller.go
@@ -85,6 +85,9 @@ type serverController struct {
 	draining syncutil.AtomicBool
 	drainCh  chan struct{}
 
+	// disableSQLServer disables starting the SQL service.
+	disableSQLServer bool
+
 	// orchestrator is the orchestration method to use.
 	orchestrator serverOrchestrator
 
@@ -124,6 +127,7 @@ func newServerController(
 	systemTenantNameContainer *roachpb.TenantNameContainer,
 	sendSQLRoutingError func(ctx context.Context, conn net.Conn, tenantName roachpb.TenantName),
 	watcher *tenantcapabilitieswatcher.Watcher,
+	disableSQLServer bool,
 ) *serverController {
 	c := &serverController{
 		AmbientContext:      ambientCtx,
@@ -136,6 +140,7 @@ func newServerController(
 		watcher:             watcher,
 		tenantWaiter:        singleflight.NewGroup("tenant server poller", "poll"),
 		drainCh:             make(chan struct{}),
+		disableSQLServer:    disableSQLServer,
 	}
 	c.orchestrator = newServerOrchestrator(parentStopper, c)
 	c.mu.servers = map[roachpb.TenantName]serverState{

--- a/pkg/server/server_controller_orchestration.go
+++ b/pkg/server/server_controller_orchestration.go
@@ -34,11 +34,15 @@ import (
 // start monitors changes to the service mode and updates
 // the running servers accordingly.
 func (c *serverController) start(ctx context.Context, ie isql.Executor) error {
-	// We perform one round of updates synchronously, to ensure that
-	// any tenants already in service mode SHARED get a chance to boot
-	// up before we signal readiness.
-	if err := c.startInitialSecondaryTenantServers(ctx, ie); err != nil {
-		return err
+	// If the SQL server is disabled there are no initial secondary tenants to
+	// start.
+	if !c.disableSQLServer {
+		// We perform one round of updates synchronously, to ensure that
+		// any tenants already in service mode SHARED get a chance to boot
+		// up before we signal readiness.
+		if err := c.startInitialSecondaryTenantServers(ctx, ie); err != nil {
+			return err
+		}
 	}
 
 	// Run the detection of which servers should be started or stopped.

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -679,6 +679,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 		cfg.clock,
 		cfg.Settings,
 		settingsWatcher,
+		cfg.sqlLivenessProvider,
 		codec,
 		lmKnobs,
 		cfg.stopper,

--- a/pkg/sql/catalog/lease/BUILD.bazel
+++ b/pkg/sql/catalog/lease/BUILD.bazel
@@ -47,6 +47,7 @@ go_library(
         "//pkg/sql/regionliveness",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",
+        "//pkg/sql/sqlliveness",
         "//pkg/storage",
         "//pkg/util/grpcutil",
         "//pkg/util/hlc",

--- a/pkg/sql/catalog/lease/BUILD.bazel
+++ b/pkg/sql/catalog/lease/BUILD.bazel
@@ -121,6 +121,7 @@ go_test(
         "//pkg/sql/rowenc/keyside",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",
+        "//pkg/sql/sqlliveness/slprovider",
         "//pkg/sql/types",
         "//pkg/storage",
         "//pkg/testutils",

--- a/pkg/sql/catalog/lease/descriptor_state.go
+++ b/pkg/sql/catalog/lease/descriptor_state.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
@@ -131,7 +132,11 @@ func (t *descriptorState) findForTimestamp(
 // it and returns it. The regionEnumPrefix is used if the cluster is configured
 // for multi-region system tables.
 func (t *descriptorState) upsertLeaseLocked(
-	ctx context.Context, desc catalog.Descriptor, expiration hlc.Timestamp, regionEnumPrefix []byte,
+	ctx context.Context,
+	desc catalog.Descriptor,
+	expiration hlc.Timestamp,
+	session sqlliveness.Session,
+	regionEnumPrefix []byte,
 ) (createdDescriptorVersionState *descriptorVersionState, toRelease *storedLease, _ error) {
 	if t.mu.maxVersionSeen < desc.GetVersion() {
 		t.mu.maxVersionSeen = desc.GetVersion()
@@ -141,7 +146,7 @@ func (t *descriptorState) upsertLeaseLocked(
 		if t.mu.active.findNewest() != nil {
 			log.Infof(ctx, "new lease: %s", desc)
 		}
-		descState := newDescriptorVersionState(t, desc, expiration, regionEnumPrefix, true /* isLease */)
+		descState := newDescriptorVersionState(t, desc, expiration, session, regionEnumPrefix, true /* isLease */)
 		t.mu.active.insert(descState)
 		return descState, nil, nil
 	}
@@ -162,6 +167,7 @@ func (t *descriptorState) upsertLeaseLocked(
 	// released! This is because the new lease is valid at the same desc
 	// version at a greater expiration.
 	s.mu.expiration = expiration
+	s.mu.session = session
 	toRelease = s.mu.lease
 	s.mu.lease = &storedLease{
 		prefix:     regionEnumPrefix,
@@ -169,9 +175,17 @@ func (t *descriptorState) upsertLeaseLocked(
 		version:    int(desc.GetVersion()),
 		expiration: storedLeaseExpiration(expiration),
 	}
+	if session != nil {
+		s.mu.lease.sessionID = session.ID().UnsafeBytes()
+	}
 	if log.ExpensiveLogEnabled(ctx, 2) {
 		log.VEventf(ctx, 2, "replaced lease: %s with %s", toRelease, s.mu.lease)
 	}
+	// For session based leases there is no expiry, so when the lease
+	// is subsumed we have nothing to delete. In dual-write mode clearing
+	// this guarantees only the old expiry based lease is cleaned up. In
+	// Session only clearing this means the release is a no-op.
+	toRelease.sessionID = nil
 	return nil, toRelease, nil
 }
 
@@ -181,6 +195,7 @@ func newDescriptorVersionState(
 	t *descriptorState,
 	desc catalog.Descriptor,
 	expiration hlc.Timestamp,
+	session sqlliveness.Session,
 	prefix []byte,
 	isLease bool,
 ) *descriptorVersionState {
@@ -195,6 +210,10 @@ func newDescriptorVersionState(
 			prefix:     prefix,
 			version:    int(desc.GetVersion()),
 			expiration: storedLeaseExpiration(expiration),
+		}
+		if session != nil {
+			descState.mu.lease.sessionID = session.ID().UnsafeBytes()
+			descState.mu.session = session
 		}
 	}
 	return descState
@@ -274,6 +293,10 @@ func (t *descriptorState) release(ctx context.Context, s *descriptorVersionState
 		defer t.mu.Unlock()
 		if l := maybeMarkRemoveStoredLease(s); l != nil {
 			t.mu.active.remove(s)
+			if t.m.storage.testingKnobs.RemoveOnceDereferenced {
+				releaseLease(ctx, l, t.m)
+				l = nil
+			}
 			return l
 		}
 		return nil

--- a/pkg/sql/catalog/lease/descriptor_version_state.go
+++ b/pkg/sql/catalog/lease/descriptor_version_state.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
@@ -30,6 +31,7 @@ type storedLease struct {
 	prefix     []byte
 	version    int
 	expiration tree.DTimestamp
+	sessionID  []byte
 }
 
 func (s *storedLease) String() string {
@@ -64,6 +66,11 @@ type descriptorVersionState struct {
 		// is associated with the version, or the ModificationTime of the next version
 		// when the version isn't associated with a lease.
 		expiration hlc.Timestamp
+
+		// The session that was used to acquire this descriptor version, which is
+		// only populated when the session based leasing mode is *at least* dual
+		// write.
+		session sqlliveness.Session
 
 		refcount int
 		// Set if the node has a lease on this descriptor version.
@@ -101,7 +108,11 @@ func (s *descriptorVersionState) String() string {
 
 // stringLocked reads mu.refcount and thus needs to have mu held.
 func (s *descriptorVersionState) stringLocked() redact.RedactableString {
-	return redact.Sprintf("%d(%q) ver=%d:%s, refcount=%d", s.GetID(), s.GetName(), s.GetVersion(), s.mu.expiration, s.mu.refcount)
+	var sessionID string
+	if s.mu.session != nil {
+		sessionID = s.mu.session.ID().String()
+	}
+	return redact.Sprintf("%d(%q,%s) ver=%d:%s, refcount=%d", s.GetID(), s.GetName(), redact.SafeString(sessionID), s.GetVersion(), s.mu.expiration, s.mu.refcount)
 }
 
 // hasExpired checks if the descriptor is too old to be used (by a txn
@@ -115,7 +126,7 @@ func (s *descriptorVersionState) hasExpired(timestamp hlc.Timestamp) bool {
 // hasExpired checks if the descriptor is too old to be used (by a txn
 // operating) at the given timestamp.
 func (s *descriptorVersionState) hasExpiredLocked(timestamp hlc.Timestamp) bool {
-	return s.mu.expiration.LessEq(timestamp)
+	return s.getExpirationLocked().LessEq(timestamp)
 }
 
 func (s *descriptorVersionState) incRefCount(ctx context.Context, expensiveLogEnabled bool) {
@@ -131,10 +142,45 @@ func (s *descriptorVersionState) incRefCountLocked(ctx context.Context, expensiv
 	}
 }
 
+func (s *descriptorVersionState) getExpirationLocked() hlc.Timestamp {
+	// A descriptor version state can now potentially contain two different types
+	// of expiration:
+	// 1) Fixed expirations, which will be based on some timestamp in the future,
+	//   that will need to be renewed to keep a descriptor as "active"
+	// 2) Session-based expirations, which say that a descriptor is in use,
+	//    as long as the sqlliveness exists for it.
+	// We are going to pick the longest possible leases between these two options,
+	// assuming that session-based leases are being enforced. Session-based leases
+	// will only be enforced once the Drain leasing mode is reached, which will stop
+	// allowing fixed expiration leases from renewing (i.e. those leases will
+	// eventually be *drained*.
+	expiration := s.mu.expiration
+	if s.mu.session != nil &&
+		s.t.m.sessionBasedLeasingModeAtLeast(SessionBasedDrain) {
+		sessionExpiry := s.mu.session.Expiration()
+		if expiration.Less(sessionExpiry) {
+			expiration = sessionExpiry
+		}
+	}
+	return expiration
+}
+
 func (s *descriptorVersionState) getExpiration() hlc.Timestamp {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return s.mu.expiration
+
+	return s.getExpirationLocked()
+}
+
+// getStoredLease returns a copy of the stored lease.
+func (s *descriptorVersionState) getStoredLease() *storedLease {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.mu.lease == nil {
+		return nil
+	}
+	leaseCopy := *s.mu.lease
+	return &leaseCopy
 }
 
 // The lease expiration stored in the database is of a different type.

--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -39,6 +39,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/sql/regionliveness"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness"
 	kvstorage "github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -506,7 +507,7 @@ func (m *Manager) insertDescriptorVersions(id descpb.ID, versions []historicalDe
 		existingVersion := t.mu.active.findVersion(versions[i].desc.GetVersion())
 		if existingVersion == nil {
 			t.mu.active.insert(
-				newDescriptorVersionState(t, versions[i].desc, versions[i].expiration, nil, false))
+				newDescriptorVersionState(t, versions[i].desc, versions[i].expiration, nil, nil, false))
 		}
 	}
 }
@@ -575,10 +576,25 @@ func acquireNodeLease(
 			}
 			newest := m.findNewest(id)
 			var minExpiration hlc.Timestamp
+			var lastLease *storedLease
 			if newest != nil {
 				minExpiration = newest.getExpiration()
+				lastLease = newest.getStoredLease()
 			}
-			desc, expiration, regionPrefix, err := m.storage.acquire(ctx, minExpiration, id)
+			// A session will be populated within the leasing infrastructure only when
+			// session based leasing is enabled. This session will be stored both inside
+			// the leases table and descriptor version states in memory, and can be
+			// consulted for the expiry depending on the mode
+			// (see SessionBasedLeasingMode).
+			var session sqlliveness.Session
+			if m.sessionBasedLeasingModeAtLeast(SessionBasedDualWrite) {
+				var err error
+				session, err = m.livenessProvider.Session(ctx)
+				if err != nil {
+					return false, errors.Wrapf(err, "lease acquisition was unable to resolve liveness session")
+				}
+			}
+			desc, expiration, regionPrefix, err := m.storage.acquire(ctx, minExpiration, session, id, lastLease)
 			if err != nil {
 				return nil, err
 			}
@@ -590,7 +606,7 @@ func acquireNodeLease(
 			t.mu.takenOffline = false
 			defer t.mu.Unlock()
 			var newDescVersionState *descriptorVersionState
-			newDescVersionState, toRelease, err = t.upsertLeaseLocked(ctx, desc, expiration, regionPrefix)
+			newDescVersionState, toRelease, err = t.upsertLeaseLocked(ctx, desc, expiration, session, regionPrefix)
 			if err != nil {
 				return nil, err
 			}
@@ -615,7 +631,14 @@ func acquireNodeLease(
 
 // releaseLease deletes an entry from system.lease.
 func releaseLease(ctx context.Context, lease *storedLease, m *Manager) {
-	if m.IsDraining() {
+	// Force the release to happen synchronously, if we are draining or, when we
+	// force removals for unit tests. This didn't matter with expiration based leases
+	// since each renewal would have a different expiry (but the same version in
+	// synthetic scenarios). In the session based model renewals will come in with
+	// the same session ID, and potentially we can end up racing with inserts and
+	// deletes on the storage side. For real world scenario, this never happens
+	// because we release only if a new version exists.
+	if m.IsDraining() || m.removeOnceDereferenced() {
 		// Release synchronously to guarantee release before exiting.
 		m.storage.release(ctx, m.stopper, lease)
 		return
@@ -735,6 +758,7 @@ type Manager struct {
 	rangeFeedFactory *rangefeed.Factory
 	storage          storage
 	settings         *cluster.Settings
+	livenessProvider sqlliveness.Provider
 	mu               struct {
 		syncutil.Mutex
 		// TODO(james): Track size of leased descriptors in memory.
@@ -773,6 +797,7 @@ func NewLeaseManager(
 	clock *hlc.Clock,
 	settings *cluster.Settings,
 	settingsWatcher *settingswatcher.SettingsWatcher,
+	livenessProvider sqlliveness.Provider,
 	codec keys.SQLCodec,
 	testingKnobs ManagerTestingKnobs,
 	stopper *stop.Stopper,
@@ -796,6 +821,7 @@ func NewLeaseManager(
 			}),
 		},
 		settings:         settings,
+		livenessProvider: livenessProvider,
 		rangeFeedFactory: rangeFeedFactory,
 		testingKnobs:     testingKnobs,
 		names:            makeNameCache(),

--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -1430,11 +1430,17 @@ func (m *Manager) DeleteOrphanedLeases(ctx context.Context, timeThreshold int64)
 		// This could have been implemented using DELETE WHERE, but DELETE WHERE
 		// doesn't implement AS OF SYSTEM TIME.
 
-		// Read orphaned leases.
+		// Read orphaned leases, and join against the internal session
+		// table in case we have dual written leases.
 		query := `
-SELECT "descID", version, expiration, crdb_region FROM system.public.lease AS OF SYSTEM TIME %d WHERE "nodeID" = %d
+SELECT COALESCE(l."descID", s."desc_id") as "descID", COALESCE(l.version, s.version), l.expiration, s."session_id", l.crdb_region, s.crdb_region FROM 
+	 system.public.lease as l FULL OUTER JOIN "".crdb_internal.kv_session_based_leases as s ON l."nodeID"=s."sql_instance_id" AND
+	  l."descID"=s."desc_id" AND l.version=s.version
+	  AS OF SYSTEM TIME %d 
+		WHERE COALESCE(l."nodeID", s."sql_instance_id") =%d
 `
 		sqlQuery := fmt.Sprintf(query, timeThreshold, instanceID)
+
 		var rows []tree.Datums
 		retryOptions := base.DefaultRetryOptions()
 		retryOptions.Closer = m.stopper.ShouldQuiesce()
@@ -1457,14 +1463,23 @@ SELECT "descID", version, expiration, crdb_region FROM system.public.lease AS OF
 			row := rows[i]
 			wg.Add(1)
 			lease := storedLease{
-				id:         descpb.ID(tree.MustBeDInt(row[0])),
-				version:    int(tree.MustBeDInt(row[1])),
-				expiration: tree.MustBeDTimestamp(row[2]),
+				id:      descpb.ID(tree.MustBeDInt(row[0])),
+				version: int(tree.MustBeDInt(row[1])),
 			}
-			if len(row) == 4 {
-				if ed, ok := row[3].(*tree.DEnum); ok {
-					lease.prefix = ed.PhysicalRep
-				} else if bd, ok := row[3].(*tree.DBytes); ok {
+			// Session based leases will not have a timestamp.
+			if row[2] != tree.DNull {
+				lease.expiration = tree.MustBeDTimestamp(row[2])
+			}
+			if row[3] != tree.DNull {
+				lease.sessionID = []byte(tree.MustBeDBytes(row[3]))
+			}
+			if ed, ok := row[4].(*tree.DEnum); ok {
+				lease.prefix = ed.PhysicalRep
+			} else if bd, ok := row[4].(*tree.DBytes); ok {
+				lease.prefix = []byte((*bd))
+			}
+			if len(row) >= 6 && lease.prefix == nil {
+				if bd, ok := row[5].(*tree.DBytes); ok {
 					lease.prefix = []byte((*bd))
 				}
 			}

--- a/pkg/sql/catalog/lease/lease_test.go
+++ b/pkg/sql/catalog/lease/lease_test.go
@@ -99,6 +99,10 @@ func init() {
 }
 
 func newLeaseTest(tb testing.TB, params base.TestClusterArgs) *leaseTest {
+	if params.ServerArgs.Settings == nil {
+		params.ServerArgs.Settings = cluster.MakeTestingClusterSettings()
+	}
+	lease.LeaseEnableSessionBasedLeasing.Override(context.Background(), &params.ServerArgs.Settings.SV, int64(lease.SessionBasedDualWrite))
 	c := serverutils.StartCluster(tb, 3, params)
 	s := c.Server(0).ApplicationLayer()
 	lt := &leaseTest{
@@ -123,9 +127,11 @@ func (t *leaseTest) cleanup() {
 
 func (t *leaseTest) getLeases(descID descpb.ID) string {
 	const sql = `
-  SELECT version, "nodeID"
-    FROM system.lease
-   WHERE "descID" = $1 AND "nodeID" > $2
+  SELECT COALESCE(l.version, s.version) as version, COALESCE(l."nodeID", s.sql_instance_id) as "nodeID"
+    FROM system.lease as l
+		FULL OUTER JOIN  "".crdb_internal.kv_session_based_leases as s
+		ON l."descID" = s.desc_id AND l."nodeID" = s.sql_instance_id AND l.version=s.version
+   WHERE COALESCE("descID", s.desc_id) = $1 AND COALESCE("nodeID", s.sql_instance_id) > $2
 ORDER BY version, "nodeID";
 `
 	rows, err := t.db.Query(sql, descID, baseIDForLeaseTest)
@@ -256,6 +262,7 @@ func (t *leaseTest) node(nodeID uint32) *lease.Manager {
 			cfgCpy.Clock,
 			cfgCpy.Settings,
 			t.server.SettingsWatcher().(*settingswatcher.SettingsWatcher),
+			cfgCpy.SQLLiveness,
 			cfgCpy.Codec,
 			t.leaseManagerTestingKnobs,
 			t.server.AppStopper(),
@@ -2101,6 +2108,9 @@ func TestDeleteOrphanedLeases(testingT *testing.T) {
 
 	ctx := context.Background()
 	t := newLeaseTest(testingT, params)
+	// Force dual writing, so that entries exist within both versions of the
+	// leasing table to clean up.
+	lease.LeaseEnableSessionBasedLeasing.Override(ctx, &t.server.ClusterSettings().SV, int64(lease.SessionBasedDualWrite))
 	defer t.cleanup()
 
 	if _, err := t.db.Exec(`
@@ -3479,13 +3489,19 @@ func TestDescriptorRemovedFromCacheWhenLeaseRenewalForThisDescriptorFails(t *tes
 
 // TestSessionLeasingTable validates that we can use an internal table
 // to read new system.leases table format (which will use synthetic
-// descriptors).
+// descriptors). Additionally, basic sanity checking with dual writes,
+// enabled, since rows should appear in both tables
 func TestSessionLeasingTable(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	srv, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	st := cluster.MakeClusterSettings()
+	lease.LeaseEnableSessionBasedLeasing.Override(ctx, &st.SV, int64(lease.SessionBasedDualWrite))
+	srv, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{
+		Settings:          st,
+		DefaultTestTenant: base.TestNeedsTightIntegrationBetweenAPIsAndTestingKnobs,
+	})
 	defer srv.Stopper().Stop(ctx)
 	runner := sqlutils.MakeSQLRunner(sqlDB)
 
@@ -3499,6 +3515,42 @@ func TestSessionLeasingTable(t *testing.T) {
 	})
 	require.NoError(t, err)
 	// Validate the new crdb_internal function can read the contents back.
-	res := runner.QueryStr(t, "SELECT * FROM crdb_internal.kv_session_based_leases;")
+	res := runner.QueryStr(t, "SELECT * FROM crdb_internal.kv_session_based_leases WHERE crdb_region='region';")
 	require.Equal(t, [][]string{{"1", "-1", "1", "some session id", "region"}}, res)
+	// Validate that we wrote rows from the leasing mechanism in both tables.
+	res = runner.QueryStr(t, `
+WITH
+	joined_count
+		AS (
+			SELECT
+				count(*) AS common_count
+			FROM
+				crdb_internal.kv_session_based_leases AS s,
+				system.lease AS l
+			WHERE
+				l."descID" = s.desc_id
+				AND l.version = s.version
+				AND l."nodeID" = s.sql_instance_id
+		),
+	system_count_tbl
+		AS (
+			SELECT
+				count(*) AS system_count
+			FROM
+				system.lease
+		),
+	kv_session_count_tbl
+		AS (
+			SELECT
+				count(*) - 1 AS kv_session_count -- subract one row added above
+			FROM
+				crdb_internal.kv_session_based_leases
+		)
+SELECT
+	common_count = kv_session_count,
+	common_count = system_count
+FROM
+	joined_count, system_count_tbl, kv_session_count_tbl;
+`)
+	require.Equal(t, [][]string{{"true", "true"}}, res)
 }

--- a/pkg/sql/catalog/lease/storage.go
+++ b/pkg/sql/catalog/lease/storage.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness"
 	"github.com/cockroachdb/cockroach/pkg/util/grpcutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -121,12 +122,19 @@ func (s storage) crossValidateDuringRenewal() bool {
 // acquire a lease on the most recent version of a descriptor. If the lease
 // cannot be obtained because the descriptor is in the process of being dropped
 // or offline (currently only applicable to tables), the error will be of type
-// inactiveTableError. The expiration time set for the lease > minExpiration.
+// inactiveTableError. The expiration time set for the lease > minExpiration. A
+// non-nil session should be provided when session based leasing is enabled,
+// which will cause stored leases to populated sessionIDs.
 func (s storage) acquire(
-	ctx context.Context, minExpiration hlc.Timestamp, id descpb.ID,
+	ctx context.Context,
+	minExpiration hlc.Timestamp,
+	session sqlliveness.Session,
+	id descpb.ID,
+	lastLease *storedLease,
 ) (desc catalog.Descriptor, expiration hlc.Timestamp, prefix []byte, _ error) {
 	ctx = multitenant.WithTenantCostControlExemption(ctx)
 	prefix = s.getRegionPrefix()
+	var sessionID []byte
 	acquireInTxn := func(ctx context.Context, txn *kv.Txn) (err error) {
 
 		// Run the descriptor read as high-priority, thereby pushing any intents out
@@ -147,7 +155,7 @@ func (s storage) acquire(
 		// written a value to the database, which we'd leak if we did not delete it.
 		// Note that the expiration is part of the primary key in the table, so we
 		// would not overwrite the old entry if we just were to do another insert.
-		if !expiration.IsEmpty() && desc != nil {
+		if (!expiration.IsEmpty() || sessionID != nil) && desc != nil {
 			prevExpirationTS := storedLeaseExpiration(expiration)
 			if err := s.writer.deleteLease(ctx, txn, leaseFields{
 				regionPrefix: prefix,
@@ -155,6 +163,7 @@ func (s storage) acquire(
 				version:      desc.GetVersion(),
 				instanceID:   instanceID,
 				expiration:   prevExpirationTS,
+				sessionID:    sessionID,
 			}); err != nil {
 				return errors.Wrap(err, "deleting ambiguously created lease")
 			}
@@ -180,12 +189,35 @@ func (s storage) acquire(
 		log.VEventf(ctx, 2, "storage attempting to acquire lease %v@%v", desc, expiration)
 
 		ts := storedLeaseExpiration(expiration)
+
+		var isLeaseRenewal bool
+		var lastLeaseWasWrittenWithSessionID bool
+		// If there was a previous lease then determine if this a renewal and
+		// if it was written with a session ID.
+		if lastLease != nil {
+			isLeaseRenewal = descpb.DescriptorVersion(lastLease.version) == desc.GetVersion()
+			lastLeaseWasWrittenWithSessionID = lastLease.sessionID != nil
+		}
+		// Populate the session the ID for the lease if it has been provided (i.e.
+		// session based leasing is enabled), since the KV writer below will use it
+		// for generating session based leases.
+		// In dual write mode if we know there is lease renewal happening and the
+		// previous lease was written with a session ID, we will intentionally not
+		// set the session ID. This will cause the KV writer to only generate an expiry
+		// based lease row, since we already have a valid session based lease from earlier.
+		// We do not expect lease renewals to happen at all once session based leasing
+		// is fully adopted.
+		if !(isLeaseRenewal && lastLeaseWasWrittenWithSessionID) &&
+			session != nil {
+			sessionID = session.ID().UnsafeBytes()
+		}
 		lf := leaseFields{
 			regionPrefix: prefix,
 			descID:       desc.GetID(),
 			version:      desc.GetVersion(),
 			instanceID:   s.nodeIDContainer.SQLInstanceID(),
 			expiration:   ts,
+			sessionID:    sessionID,
 		}
 		return s.writer.insertLease(ctx, txn, lf)
 	}
@@ -239,6 +271,7 @@ func (s storage) release(ctx context.Context, stopper *stop.Stopper, lease *stor
 			version:      descpb.DescriptorVersion(lease.version),
 			instanceID:   instanceID,
 			expiration:   lease.expiration,
+			sessionID:    lease.sessionID,
 		}
 		err := s.writer.deleteLease(ctx, nil /* txn */, lf)
 		if err != nil {

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -105,6 +105,7 @@ func TestSchemaChangeProcess(t *testing.T) {
 		execCfg.Clock,
 		execCfg.Settings,
 		s.SettingsWatcher().(*settingswatcher.SettingsWatcher),
+		execCfg.SQLLiveness,
 		execCfg.Codec,
 		lease.ManagerTestingKnobs{},
 		stopper,


### PR DESCRIPTION
This patch supports writing session-based leases from the lease manager when the dual_write or higher modes are enabled using an experimental setting. It also supports cleaning orphaned session-based leases on startup, which allows them to be cleaned up. It makes no functional changes to the leasing manager to utilize the session-based lease information, enables the dual write mode for the leasing package, and metamorphically enables dual writes.


The first four commits can be ignored and belong to the following PRs:
https://github.com/cockroachdb/cockroach/pull/111345
https://github.com/cockroachdb/cockroach/pull/111427
https://github.com/cockroachdb/cockroach/pull/111462

informs: https://github.com/cockroachdb/cockroach/issues/95765