### PR TITLE
sctest: Fix a few flaws in the comparator testing framework

### DIFF
--- a/pkg/sql/schemachanger/schemachanger_test.go
+++ b/pkg/sql/schemachanger/schemachanger_test.go
@@ -828,12 +828,17 @@ func TestCompareLegacyAndDeclarative(t *testing.T) {
 			"ALTER TABLE t2 ADD COLUMN p INT DEFAULT 50;",
 			"ALTER TABLE t2 DROP COLUMN p;",
 			"ALTER TABLE t2 ALTER PRIMARY KEY USING COLUMNS (j);",
+			"DROP TABLE IF EXISTS t1, t2;",
+			"CREATE TABLE t1 (rowid INT NOT NULL);",
+			"ALTER TABLE t1 ALTER PRIMARY KEY USING COLUMNS (rowid); -- special case where column name `rowid` is used",
 
 			// Statements expected to fail.
 			"CREATE TABLE t1 (); -- expect a DuplicateRelation error",
 			"ALTER TABLE t1 DROP COLUMN xyz; -- expect a rejected (sql_safe_updates = true) warning",
 			"ALTER TABLE t1 DROP COLUMN xyz; -- expect a UndefinedColumn error",
 			"ALTER TABLE txyz ADD COLUMN i INT DEFAULT 30; -- expect a UndefinedTable error",
+			"SELECT (*) FROM t1; -- expect to be skipped because of the syntax error",
+			"FROM t1 SELECT *; -- ditto",
 
 			// statements with TCL commands or empty content.
 			"",
@@ -847,7 +852,8 @@ func TestCompareLegacyAndDeclarative(t *testing.T) {
 			"COMMIT;",
 			"BEGIN;",
 			"SELECT 1/0;",
-			"INSERT INTO t2 VALUES (1002, 1003); INSERT INTO t1 VALUES (1001, 1002); -- expect to be skipped",
+			"DROP TABLE IF EXISTS t2  -- expect to be ignored",
+			"INSERT INTO t2 VALUES (1002, 1003); INSERT INTO t1 VALUES (1001, 1002);  -- expect to be ignored",
 			"ROLLBACK;",
 
 			// statements that will be altered due to known behavioral differences in LSC vs DSC.


### PR DESCRIPTION
1. the input sql stmt(s) have syntax errors: we now skip those lines
2. a table like `create table t (rowid int not null)` where the name `rowid` is used and thus the implicitly created primary index column will be suffixed by a number (such as `rowid_1`): ALTER PRIMARY KEY stmt will now be properly rewritten to correctly recognize the hidden, old primary key column.
3. when a transaction is in "ERROR" state (and will thus ignore any subsequent stmts), we will not perform any identity checks

Epic: None
Release note: None