### PR TITLE
opt: add lock operator

### DIFF
--- a/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
@@ -1724,6 +1724,13 @@ func TestTenantLogic_select_for_update(
 	runLogicTest(t, "select_for_update")
 }
 
+func TestTenantLogic_select_for_update_read_committed(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "select_for_update_read_committed")
+}
+
 func TestTenantLogic_select_index(
 	t *testing.T,
 ) {

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -3667,6 +3667,10 @@ func (m *sessionDataMutator) SetUnsafeSettingInterlockKey(val string) {
 	m.data.UnsafeSettingInterlockKey = val
 }
 
+func (m *sessionDataMutator) SetOptimizerUseLockOpForSerializable(val bool) {
+	m.data.OptimizerUseLockOpForSerializable = val
+}
+
 // Utility functions related to scrubbing sensitive information on SQL Stats.
 
 // quantizeCounts ensures that the Count field in the

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -5568,6 +5568,7 @@ optimizer_use_improved_disjunction_stats                   on
 optimizer_use_improved_join_elimination                    on
 optimizer_use_improved_split_disjunction_for_joins         on
 optimizer_use_limit_ordering_for_streaming_group_by        on
+optimizer_use_lock_op_for_serializable                     off
 optimizer_use_multicol_stats                               on
 optimizer_use_not_visible_indexes                          off
 override_multi_region_zone_config                          off

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -2886,6 +2886,7 @@ optimizer_use_improved_disjunction_stats                   on                  N
 optimizer_use_improved_join_elimination                    on                  NULL      NULL        NULL        string
 optimizer_use_improved_split_disjunction_for_joins         on                  NULL      NULL        NULL        string
 optimizer_use_limit_ordering_for_streaming_group_by        on                  NULL      NULL        NULL        string
+optimizer_use_lock_op_for_serializable                     off                 NULL      NULL        NULL        string
 optimizer_use_multicol_stats                               on                  NULL      NULL        NULL        string
 optimizer_use_not_visible_indexes                          off                 NULL      NULL        NULL        string
 override_multi_region_zone_config                          off                 NULL      NULL        NULL        string
@@ -3048,6 +3049,7 @@ optimizer_use_improved_disjunction_stats                   on                  N
 optimizer_use_improved_join_elimination                    on                  NULL  user     NULL      on                  on
 optimizer_use_improved_split_disjunction_for_joins         on                  NULL  user     NULL      on                  on
 optimizer_use_limit_ordering_for_streaming_group_by        on                  NULL  user     NULL      on                  on
+optimizer_use_lock_op_for_serializable                     off                 NULL  user     NULL      off                 off
 optimizer_use_multicol_stats                               on                  NULL  user     NULL      on                  on
 optimizer_use_not_visible_indexes                          off                 NULL  user     NULL      off                 off
 override_multi_region_zone_config                          off                 NULL  user     NULL      off                 off
@@ -3209,6 +3211,7 @@ optimizer_use_improved_disjunction_stats                   NULL    NULL     NULL
 optimizer_use_improved_join_elimination                    NULL    NULL     NULL     NULL        NULL
 optimizer_use_improved_split_disjunction_for_joins         NULL    NULL     NULL     NULL        NULL
 optimizer_use_limit_ordering_for_streaming_group_by        NULL    NULL     NULL     NULL        NULL
+optimizer_use_lock_op_for_serializable                     NULL    NULL     NULL     NULL        NULL
 optimizer_use_multicol_stats                               NULL    NULL     NULL     NULL        NULL
 optimizer_use_not_visible_indexes                          NULL    NULL     NULL     NULL        NULL
 override_multi_region_zone_config                          NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/prepare
+++ b/pkg/sql/logictest/testdata/logic_test/prepare
@@ -1301,7 +1301,7 @@ PREPARE a1 AS SELECT * FROM t3 FOR UPDATE
 statement ok
 BEGIN READ ONLY
 
-statement error cannot execute FOR UPDATE in a read-only transaction
+statement error cannot execute SELECT FOR UPDATE in a read-only transaction
 EXECUTE a1
 
 statement ok
@@ -1316,7 +1316,7 @@ PREPARE a1 AS SELECT * FROM t3 FOR NO KEY UPDATE
 statement ok
 BEGIN READ ONLY
 
-statement error cannot execute FOR NO KEY UPDATE in a read-only transaction
+statement error cannot execute SELECT FOR NO KEY UPDATE in a read-only transaction
 EXECUTE a1
 
 statement ok
@@ -1331,7 +1331,7 @@ PREPARE a1 AS SELECT * FROM t3 FOR SHARE
 statement ok
 BEGIN READ ONLY
 
-statement error cannot execute FOR SHARE in a read-only transaction
+statement error cannot execute SELECT FOR SHARE in a read-only transaction
 EXECUTE a1
 
 statement ok
@@ -1346,7 +1346,7 @@ PREPARE a1 AS SELECT * FROM t3 FOR KEY SHARE
 statement ok
 BEGIN READ ONLY
 
-statement error cannot execute FOR KEY SHARE in a read-only transaction
+statement error cannot execute SELECT FOR KEY SHARE in a read-only transaction
 EXECUTE a1
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/select_for_update
+++ b/pkg/sql/logictest/testdata/logic_test/select_for_update
@@ -409,7 +409,7 @@ user root
 statement ok
 BEGIN READ ONLY
 
-statement error cannot execute FOR UPDATE in a read-only transaction
+statement error cannot execute SELECT FOR UPDATE in a read-only transaction
 SELECT * FROM t FOR UPDATE
 
 statement ok
@@ -418,7 +418,7 @@ ROLLBACK
 statement ok
 BEGIN READ ONLY
 
-statement error cannot execute FOR NO KEY UPDATE in a read-only transaction
+statement error cannot execute SELECT FOR NO KEY UPDATE in a read-only transaction
 SELECT * FROM t FOR NO KEY UPDATE
 
 statement ok
@@ -428,7 +428,7 @@ statement ok
 BEGIN READ ONLY
 
 skipif config local-mixed-22.2-23.1
-statement error cannot execute FOR SHARE in a read-only transaction
+statement error cannot execute SELECT FOR SHARE in a read-only transaction
 SELECT * FROM t FOR SHARE
 
 statement ok
@@ -438,7 +438,7 @@ statement ok
 BEGIN READ ONLY
 
 skipif config local-mixed-22.2-23.1
-statement error cannot execute FOR KEY SHARE in a read-only transaction
+statement error cannot execute SELECT FOR KEY SHARE in a read-only transaction
 SELECT * FROM t FOR KEY SHARE
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/select_for_update_read_committed
+++ b/pkg/sql/logictest/testdata/logic_test/select_for_update_read_committed
@@ -1,0 +1,182 @@
+# LogicTest: !local-mixed-22.2-23.1
+
+statement ok
+SET CLUSTER SETTING sql.txn.read_committed_syntax.enabled = true
+
+statement ok
+SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL READ COMMITTED
+
+statement ok
+CREATE TABLE abc (a INT PRIMARY KEY, b INT, c INT, INDEX (b), FAMILY (a, b, c))
+
+statement ok
+INSERT INTO abc VALUES (1, 10, 100), (2, 20, 200), (3, 30, 300)
+
+statement ok
+CREATE TABLE bcd (b INT PRIMARY KEY, c INT, d INT, INDEX (c), FAMILY (b, c, d))
+
+statement ok
+INSERT INTO bcd VALUES (20, 200, 2000), (30, 300, 3000), (40, 400, 4000)
+
+statement ok
+GRANT ALL on abc TO testuser
+
+statement ok
+GRANT ALL on bcd TO testuser
+
+# First, hold locks on some rows of abc and bcd. We'll update abc at the end.
+
+user testuser
+
+statement ok
+BEGIN
+
+query III rowsort
+SELECT * FROM abc WHERE a != 3 FOR UPDATE
+----
+1  10  100
+2  20  200
+
+query III
+SELECT * FROM bcd ORDER BY c DESC LIMIT 2 FOR SHARE
+----
+40  400  4000
+30  300  3000
+
+# Then ensure we wait on the locks and see the updated rows after commit.
+
+user root
+
+# Normal reads do not block.
+
+query III rowsort
+SELECT * FROM abc
+----
+1  10  100
+2  20  200
+3  30  300
+
+query III rowsort
+SELECT * FROM bcd
+----
+20  200  2000
+30  300  3000
+40  400  4000
+
+# SKIP LOCKED reads do not block.
+
+query III rowsort
+SELECT * FROM abc FOR UPDATE SKIP LOCKED
+----
+3  30  300
+
+query III rowsort
+SELECT * FROM bcd FOR UPDATE SKIP LOCKED
+----
+20  200  2000
+30  300  3000
+40  400  4000
+
+# Shared reads block on exclusive locks but not on shared locks.
+
+query III async,rowsort q00
+SELECT * FROM abc FOR SHARE
+----
+1  11  101
+2  21  201
+3  30  300
+
+query III rowsort
+SELECT * FROM bcd FOR SHARE
+----
+20  200  2000
+30  300  3000
+40  400  4000
+
+# Exclusive reads block on both.
+
+query III async,rowsort q01
+SELECT * FROM abc FOR UPDATE
+----
+1  11  101
+2  21  201
+3  30  300
+
+query III async,rowsort q02
+SELECT * FROM bcd FOR UPDATE
+----
+20  200  2000
+30  300  3000
+40  400  4000
+
+# Try more exclusive-locking queries.
+
+query I async q03
+SELECT a FROM abc WHERE a = 2 FOR UPDATE
+----
+2
+
+query I async q04
+SELECT b FROM abc WHERE a = 2 FOR UPDATE
+----
+21
+
+query I async q05
+SELECT c FROM abc WHERE a = 2 FOR UPDATE
+----
+201
+
+query I async q06
+SELECT c FROM abc ORDER BY a DESC LIMIT 2 FOR UPDATE
+----
+300
+201
+
+query I async,rowsort q07
+SELECT a + b + c FROM abc FOR UPDATE
+----
+113
+224
+333
+
+# Try some joins
+
+query IIIII async q08
+SELECT * FROM abc JOIN bcd USING (b) FOR SHARE
+----
+30  3  300  300  3000
+
+query IIIII async q09
+SELECT * FROM abc JOIN bcd USING (c) FOR UPDATE
+----
+300  3  30  30  3000
+
+user testuser
+
+statement ok
+UPDATE abc SET b = b + 1, c = c + 1 WHERE a != 3
+
+statement ok
+COMMIT
+
+user root
+
+awaitquery q00
+
+awaitquery q01
+
+awaitquery q02
+
+awaitquery q03
+
+awaitquery q04
+
+awaitquery q05
+
+awaitquery q06
+
+awaitquery q07
+
+awaitquery q08
+
+awaitquery q09

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -124,6 +124,7 @@ optimizer_use_improved_disjunction_stats                   on
 optimizer_use_improved_join_elimination                    on
 optimizer_use_improved_split_disjunction_for_joins         on
 optimizer_use_limit_ordering_for_streaming_group_by        on
+optimizer_use_lock_op_for_serializable                     off
 optimizer_use_multicol_stats                               on
 optimizer_use_not_visible_indexes                          off
 override_multi_region_zone_config                          off

--- a/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
@@ -1702,6 +1702,13 @@ func TestLogic_select_for_update(
 	runLogicTest(t, "select_for_update")
 }
 
+func TestLogic_select_for_update_read_committed(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "select_for_update_read_committed")
+}
+
 func TestLogic_select_index(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
@@ -1702,6 +1702,13 @@ func TestLogic_select_for_update(
 	runLogicTest(t, "select_for_update")
 }
 
+func TestLogic_select_for_update_read_committed(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "select_for_update_read_committed")
+}
+
 func TestLogic_select_index(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist/generated_test.go
@@ -1716,6 +1716,13 @@ func TestLogic_select_for_update(
 	runLogicTest(t, "select_for_update")
 }
 
+func TestLogic_select_for_update_read_committed(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "select_for_update_read_committed")
+}
+
 func TestLogic_select_index(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
+++ b/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
@@ -1688,6 +1688,13 @@ func TestLogic_select_for_update(
 	runLogicTest(t, "select_for_update")
 }
 
+func TestLogic_select_for_update_read_committed(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "select_for_update_read_committed")
+}
+
 func TestLogic_select_index(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/local-vec-off/generated_test.go
@@ -1716,6 +1716,13 @@ func TestLogic_select_for_update(
 	runLogicTest(t, "select_for_update")
 }
 
+func TestLogic_select_for_update_read_committed(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "select_for_update_read_committed")
+}
+
 func TestLogic_select_index(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local/generated_test.go
+++ b/pkg/sql/logictest/tests/local/generated_test.go
@@ -1863,6 +1863,13 @@ func TestLogic_select_for_update(
 	runLogicTest(t, "select_for_update")
 }
 
+func TestLogic_select_for_update_read_committed(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "select_for_update_read_committed")
+}
+
 func TestLogic_select_index(
 	t *testing.T,
 ) {

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -2911,7 +2911,7 @@ func (b *Builder) buildLocking(locking opt.Locking) (opt.Locking, error) {
 		// Raise error if row-level locking is part of a read-only transaction.
 		if b.evalCtx.TxnReadOnly {
 			return opt.Locking{}, pgerror.Newf(pgcode.ReadOnlySQLTransaction,
-				"cannot execute %s in a read-only transaction", locking.Strength.String(),
+				"cannot execute SELECT %s in a read-only transaction", locking.Strength.String(),
 			)
 		}
 		if locking.Form == tree.LockPredicate {

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -292,6 +292,9 @@ func (b *Builder) buildRelational(e memo.RelExpr) (execPlan, error) {
 	case *memo.DeleteExpr:
 		ep, err = b.buildDelete(t)
 
+	case *memo.LockExpr:
+		ep, err = b.buildLock(t)
+
 	case *memo.CreateTableExpr:
 		ep, err = b.buildCreateTable(t)
 
@@ -3626,7 +3629,8 @@ func (b *Builder) statementTag(expr memo.RelExpr) string {
 	switch expr.Op() {
 	case opt.OpaqueRelOp, opt.OpaqueMutationOp, opt.OpaqueDDLOp:
 		return expr.Private().(*memo.OpaqueRelPrivate).Metadata.String()
-
+	case opt.LockOp:
+		return "SELECT " + expr.Private().(*memo.LockPrivate).Locking.Strength.String()
 	default:
 		return expr.Op().SyntaxTag()
 	}

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_for_update_read_committed
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_for_update_read_committed
@@ -24,10 +24,10 @@ SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL READ COMMITTED
 query T
 EXPLAIN (OPT) SELECT aisle FROM supermarket WHERE person = 'matilda' FOR UPDATE
 ----
-project
+lock supermarket
+ ├── locking: for-update,durability-guaranteed
  └── scan supermarket
-      ├── constraint: /1: [/'matilda' - /'matilda']
-      └── locking: for-update,durability-guaranteed
+      └── constraint: /1: [/'matilda' - /'matilda']
 
 query T
 EXPLAIN (VERBOSE) SELECT aisle FROM supermarket WHERE person = 'matilda' FOR UPDATE
@@ -38,13 +38,20 @@ vectorized: true
 • project
 │ columns: (aisle)
 │
-└── • scan
-      columns: (person, aisle)
-      estimated row count: 1 (missing stats)
-      table: supermarket@supermarket_pkey
-      spans: /"matilda"/0
-      locking strength: for update
-      locking durability: guaranteed
+└── • lookup join (semi)
+    │ columns: (person, aisle)
+    │ estimated row count: 1 (missing stats)
+    │ table: supermarket@supermarket_pkey
+    │ equality: (person) = (person)
+    │ equality cols are key
+    │ locking strength: for update
+    │ locking durability: guaranteed
+    │
+    └── • scan
+          columns: (person, aisle)
+          estimated row count: 1 (missing stats)
+          table: supermarket@supermarket_pkey
+          spans: /"matilda"/0
 
 query T
 EXPLAIN (OPT)
@@ -59,9 +66,10 @@ update supermarket
       └── projections
            └── subquery
                 └── project
-                     └── scan supermarket
-                          ├── constraint: /13: [/'matilda' - /'matilda']
-                          └── locking: for-update,durability-guaranteed
+                     └── lock supermarket
+                          ├── locking: for-update,durability-guaranteed
+                          └── scan supermarket
+                               └── constraint: /13: [/'matilda' - /'matilda']
 
 query T
 EXPLAIN (VERBOSE)
@@ -80,7 +88,6 @@ vectorized: true
 │   │ estimated row count: 0 (missing stats)
 │   │ table: supermarket
 │   │ set: aisle
-│   │ auto commit
 │   │
 │   └── • render
 │       │ columns: (person, aisle, starts_with, ends_with, aisle_new)
@@ -105,13 +112,21 @@ vectorized: true
     └── • project
         │ columns: (aisle)
         │
-        └── • scan
-              columns: (person, aisle)
-              estimated row count: 1 (missing stats)
-              table: supermarket@supermarket_pkey
-              spans: /"matilda"/0
-              locking strength: for update
-              locking durability: guaranteed
+        └── • lookup join (semi)
+            │ columns: (person, aisle)
+            │ estimated row count: 1 (missing stats)
+            │ table: supermarket@supermarket_pkey
+            │ equality: (person) = (person)
+            │ equality cols are key
+            │ locking strength: for update
+            │ locking durability: guaranteed
+            │
+            └── • scan
+                  columns: (person, aisle)
+                  estimated row count: 1 (missing stats)
+                  table: supermarket@supermarket_pkey
+                  spans: /"matilda"/0
+                  locking strength: for update
 
 query T
 EXPLAIN (OPT)
@@ -121,9 +136,10 @@ SELECT aisle + 1 FROM s
 ----
 with &1 (s)
  ├── project
- │    └── scan supermarket
- │         ├── constraint: /1: [/'matilda' - /'matilda']
- │         └── locking: for-update,durability-guaranteed
+ │    └── lock supermarket
+ │         ├── locking: for-update,durability-guaranteed
+ │         └── scan supermarket
+ │              └── constraint: /1: [/'matilda' - /'matilda']
  └── project
       ├── with-scan &1 (s)
       └── projections
@@ -162,13 +178,20 @@ vectorized: true
         └── • project
             │ columns: (aisle)
             │
-            └── • scan
-                  columns: (person, aisle)
-                  estimated row count: 1 (missing stats)
-                  table: supermarket@supermarket_pkey
-                  spans: /"matilda"/0
-                  locking strength: for update
-                  locking durability: guaranteed
+            └── • lookup join (semi)
+                │ columns: (person, aisle)
+                │ estimated row count: 1 (missing stats)
+                │ table: supermarket@supermarket_pkey
+                │ equality: (person) = (person)
+                │ equality cols are key
+                │ locking strength: for update
+                │ locking durability: guaranteed
+                │
+                └── • scan
+                      columns: (person, aisle)
+                      estimated row count: 1 (missing stats)
+                      table: supermarket@supermarket_pkey
+                      spans: /"matilda"/0
 
 query T
 EXPLAIN (OPT)
@@ -183,13 +206,14 @@ with &1 (names)
  ├── materialized
  ├── values
  │    └── ('matilda',)
- └── project
-      └── inner-join (lookup supermarket)
-           ├── flags: force lookup join (into right side)
-           ├── lookup columns are key
-           ├── locking: for-update,durability-guaranteed
-           ├── with-scan &1 (names)
-           └── filters (true)
+ └── lock supermarket
+      ├── locking: for-update,durability-guaranteed
+      └── project
+           └── inner-join (lookup supermarket)
+                ├── flags: force lookup join (into right side)
+                ├── lookup columns are key
+                ├── with-scan &1 (names)
+                └── filters (true)
 
 query T
 EXPLAIN (VERBOSE)
@@ -209,8 +233,8 @@ vectorized: true
 ├── • project
 │   │ columns: (aisle)
 │   │
-│   └── • lookup join (inner)
-│       │ columns: (person, person, aisle)
+│   └── • lookup join (semi)
+│       │ columns: (person, aisle)
 │       │ estimated row count: 1 (missing stats)
 │       │ table: supermarket@supermarket_pkey
 │       │ equality: (person) = (person)
@@ -218,10 +242,20 @@ vectorized: true
 │       │ locking strength: for update
 │       │ locking durability: guaranteed
 │       │
-│       └── • scan buffer
-│             columns: (person)
-│             estimated row count: 1
-│             label: buffer 1 (names)
+│       └── • project
+│           │ columns: (person, aisle)
+│           │
+│           └── • lookup join (inner)
+│               │ columns: (person, person, aisle)
+│               │ estimated row count: 1 (missing stats)
+│               │ table: supermarket@supermarket_pkey
+│               │ equality: (person) = (person)
+│               │ equality cols are key
+│               │
+│               └── • scan buffer
+│                     columns: (person)
+│                     estimated row count: 1
+│                     label: buffer 1 (names)
 │
 └── • subquery
     │ id: @S1
@@ -244,13 +278,13 @@ SELECT aisle
   WHERE starts_with = 'm'
   FOR UPDATE
 ----
-project
- └── index-join supermarket
-      ├── locking: for-update,durability-guaranteed
-      └── scan supermarket@supermarket_starts_with_idx
-           ├── constraint: /3/1: [/'m' - /'m']
-           ├── flags: force-index=supermarket_starts_with_idx
-           └── locking: for-update,durability-guaranteed
+lock supermarket
+ ├── locking: for-update,durability-guaranteed
+ └── project
+      └── index-join supermarket
+           └── scan supermarket@supermarket_starts_with_idx
+                ├── constraint: /3/1: [/'m' - /'m']
+                └── flags: force-index=supermarket_starts_with_idx
 
 query T
 EXPLAIN (VERBOSE)
@@ -265,21 +299,29 @@ vectorized: true
 • project
 │ columns: (aisle)
 │
-└── • index join
-    │ columns: (aisle, starts_with)
+└── • lookup join (semi)
+    │ columns: (person, aisle)
     │ estimated row count: 10 (missing stats)
     │ table: supermarket@supermarket_pkey
-    │ key columns: person
+    │ equality: (person) = (person)
+    │ equality cols are key
     │ locking strength: for update
     │ locking durability: guaranteed
     │
-    └── • scan
-          columns: (person, starts_with)
-          estimated row count: 10 (missing stats)
-          table: supermarket@supermarket_starts_with_idx
-          spans: /"m"-/"m"/PrefixEnd
-          locking strength: for update
-          locking durability: guaranteed
+    └── • project
+        │ columns: (person, aisle)
+        │
+        └── • index join
+            │ columns: (person, aisle, starts_with)
+            │ estimated row count: 10 (missing stats)
+            │ table: supermarket@supermarket_pkey
+            │ key columns: person
+            │
+            └── • scan
+                  columns: (person, starts_with)
+                  estimated row count: 10 (missing stats)
+                  table: supermarket@supermarket_starts_with_idx
+                  spans: /"m"-/"m"/PrefixEnd
 
 statement ok
 SET enable_zigzag_join = true
@@ -291,17 +333,16 @@ SELECT aisle
   WHERE starts_with = 'm' AND ends_with = 'lda'
   FOR UPDATE
 ----
-project
- └── inner-join (lookup supermarket)
-      ├── lookup columns are key
-      ├── locking: for-update,durability-guaranteed
-      ├── inner-join (zigzag supermarket@supermarket_starts_with_idx supermarket@supermarket_ends_with_idx)
-      │    ├── left locking: for-update,durability-guaranteed
-      │    ├── right locking: for-update,durability-guaranteed
-      │    └── filters
-      │         ├── starts_with = 'm'
-      │         └── ends_with = 'lda'
-      └── filters (true)
+lock supermarket
+ ├── locking: for-update,durability-guaranteed
+ └── project
+      └── inner-join (lookup supermarket)
+           ├── lookup columns are key
+           ├── inner-join (zigzag supermarket@supermarket_starts_with_idx supermarket@supermarket_ends_with_idx)
+           │    └── filters
+           │         ├── starts_with = 'm'
+           │         └── ends_with = 'lda'
+           └── filters (true)
 
 query T
 EXPLAIN (VERBOSE)
@@ -316,35 +357,38 @@ vectorized: true
 • project
 │ columns: (aisle)
 │
-└── • project
-    │ columns: (aisle, starts_with, ends_with)
+└── • lookup join (semi)
+    │ columns: (person, aisle)
+    │ estimated row count: 1 (missing stats)
+    │ table: supermarket@supermarket_pkey
+    │ equality: (person) = (person)
+    │ equality cols are key
+    │ locking strength: for update
+    │ locking durability: guaranteed
     │
-    └── • lookup join (inner)
-        │ columns: (person, starts_with, ends_with, aisle)
-        │ estimated row count: 1 (missing stats)
-        │ table: supermarket@supermarket_pkey
-        │ equality: (person) = (person)
-        │ equality cols are key
-        │ locking strength: for update
-        │ locking durability: guaranteed
+    └── • project
+        │ columns: (person, aisle)
         │
-        └── • project
-            │ columns: (person, starts_with, ends_with)
+        └── • lookup join (inner)
+            │ columns: (person, starts_with, ends_with, aisle)
+            │ estimated row count: 1 (missing stats)
+            │ table: supermarket@supermarket_pkey
+            │ equality: (person) = (person)
+            │ equality cols are key
             │
-            └── • zigzag join
-                  columns: (person, starts_with, person, ends_with)
-                  estimated row count: 1 (missing stats)
-                  pred: (starts_with = 'm') AND (ends_with = 'lda')
-                  left table: supermarket@supermarket_starts_with_idx
-                  left columns: (person, starts_with)
-                  left fixed values: 1 column
-                  left locking strength: for update
-                  left locking durability: guaranteed
-                  right table: supermarket@supermarket_ends_with_idx
-                  right columns: (person, ends_with)
-                  right fixed values: 1 column
-                  right locking strength: for update
-                  right locking durability: guaranteed
+            └── • project
+                │ columns: (person, starts_with, ends_with)
+                │
+                └── • zigzag join
+                      columns: (person, starts_with, person, ends_with)
+                      estimated row count: 1 (missing stats)
+                      pred: (starts_with = 'm') AND (ends_with = 'lda')
+                      left table: supermarket@supermarket_starts_with_idx
+                      left columns: (person, starts_with)
+                      left fixed values: 1 column
+                      right table: supermarket@supermarket_ends_with_idx
+                      right columns: (person, ends_with)
+                      right fixed values: 1 column
 
 statement ok
 RESET enable_zigzag_join

--- a/pkg/sql/opt/memo/check_expr.go
+++ b/pkg/sql/opt/memo/check_expr.go
@@ -306,6 +306,12 @@ func (m *Memo) CheckExpr(e opt.Expr) {
 		m.checkColListLen(t.UpdateCols, tab.ColumnCount(), "UpdateCols")
 		m.checkMutationExpr(t, &t.MutationPrivate)
 
+	case *LockExpr:
+		tab := m.Metadata().Table(t.Table)
+		m.checkColListLen(
+			opt.OptionalColList(t.KeyCols), tab.Index(cat.PrimaryIndex).KeyColumnCount(), "KeyCols",
+		)
+
 	case *ZigzagJoinExpr:
 		if len(t.LeftEqCols) != len(t.RightEqCols) {
 			panic(errors.AssertionFailedf("zigzag join with mismatching eq columns"))

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -274,7 +274,7 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 		f.Buffer.WriteByte(')')
 
 	case *ScanExpr, *PlaceholderScanExpr, *IndexJoinExpr, *ShowTraceForSessionExpr,
-		*InsertExpr, *UpdateExpr, *UpsertExpr, *DeleteExpr, *SequenceSelectExpr,
+		*InsertExpr, *UpdateExpr, *UpsertExpr, *DeleteExpr, *LockExpr, *SequenceSelectExpr,
 		*WindowExpr, *OpaqueRelExpr, *OpaqueMutationExpr, *OpaqueDDLExpr,
 		*AlterTableSplitExpr, *AlterTableUnsplitExpr, *AlterTableUnsplitAllExpr,
 		*AlterTableRelocateExpr, *AlterRangeRelocateExpr, *ControlJobsExpr, *CancelQueriesExpr,
@@ -696,6 +696,9 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 			f.formatOptionalColList(e, tp, "partial index del columns:", t.PartialIndexDelCols)
 			f.formatMutationCommon(tp, &t.MutationPrivate)
 		}
+
+	case *LockExpr:
+		f.formatLocking(tp, t.Locking)
 
 	case *WithExpr:
 		switch t.Mtr {
@@ -1693,6 +1696,9 @@ func FormatPrivate(f *ExprFmtCtx, private interface{}, physProps *physical.Requi
 		fmt.Fprintf(f.Buffer, " %s", seq.Name())
 
 	case *MutationPrivate:
+		f.formatIndex(t.Table, cat.PrimaryIndex, false /* reverse */)
+
+	case *LockPrivate:
 		f.formatIndex(t.Table, cat.PrimaryIndex, false /* reverse */)
 
 	case *OrdinalityPrivate:

--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -1516,6 +1516,25 @@ func (b *logicalPropsBuilder) buildMutationProps(mutation RelExpr, rel *props.Re
 	}
 }
 
+func (b *logicalPropsBuilder) buildLockProps(lock *LockExpr, rel *props.Relational) {
+	BuildSharedProps(lock, &rel.Shared, b.evalCtx)
+
+	private := lock.Private().(*LockPrivate)
+	inputProps := lock.Child(0).(RelExpr).Relational()
+
+	rel.OutputCols = inputProps.OutputCols.Copy()
+	rel.NotNullCols = inputProps.NotNullCols.Copy()
+	rel.FuncDeps.CopyFrom(&inputProps.FuncDeps)
+	rel.Cardinality = inputProps.Cardinality
+	if private.Locking.WaitPolicy == tree.LockWaitSkipLocked {
+		// SKIP LOCKED can act like a filter.
+		rel.Cardinality = rel.Cardinality.AsLowAs(0)
+	}
+	if !b.disableStats {
+		b.sb.buildLock(lock, rel)
+	}
+}
+
 func (b *logicalPropsBuilder) buildCreateTableProps(ct *CreateTableExpr, rel *props.Relational) {
 	BuildSharedProps(ct, &rel.Shared, b.evalCtx)
 }

--- a/pkg/sql/opt/memo/memo_test.go
+++ b/pkg/sql/opt/memo/memo_test.go
@@ -406,6 +406,12 @@ func TestMemoIsStale(t *testing.T) {
 	evalCtx.SessionData().SharedLockingForSerializable = false
 	notStale()
 
+	// Stale optimizer_use_lock_op_for_serializable.
+	evalCtx.SessionData().OptimizerUseLockOpForSerializable = true
+	stale()
+	evalCtx.SessionData().OptimizerUseLockOpForSerializable = false
+	notStale()
+
 	// Stale txn isolation level.
 	evalCtx.TxnIsoLevel = isolation.ReadCommitted
 	stale()

--- a/pkg/sql/opt/ops/README.md
+++ b/pkg/sql/opt/ops/README.md
@@ -73,4 +73,3 @@ Tags for relational operators:
  - `WithBinding`: used for operators which associate a `WithID` with the
    expression in the first child. Such expressions must implement a
    `WithBindingID()` method.
-

--- a/pkg/sql/opt/ops/mutation.opt
+++ b/pkg/sql/opt/ops/mutation.opt
@@ -346,3 +346,50 @@ define UniqueChecksItemPrivate {
     # in the error message.
     KeyCols ColList
 }
+
+# Lock evaluates a relational input expression, and locks rows in the given
+# table based on primary key columns provided by the input expression. Lock is
+# produced by FOR UPDATE and FOR SHARE clauses on SELECT statements:
+#
+#   SELECT * FROM ab WHERE a > 0 ORDER BY b LIMIT 10 FOR UPDATE
+#
+# The locking strength, wait policy, form, and durability are specified by the
+# operator, meaning that a single Lock operator represents locking one table at
+# one strength. A single statement using FOR UPDATE or FOR SHARE may require
+# multiple Lock operators in order to lock multiple tables, or even to lock the
+# same table at multiple different strengths.
+#
+# The input expression is prohibited from using certain operations such as outer
+# joins and aggregations in order to clarify the semantics of which rows are
+# locked. Outside of these prohibitions the input can be arbitrary, including
+# inner joins and subqueries, but must provide the primary key columns of the
+# table being locked.
+#
+# The Lock operator does not necessarily have to be at the top of a plan. It
+# could appear within a subtree of the plan, and in this case acts as an
+# optimization barrier to ensure the correct rows are locked.
+[Relational, Mutation]
+define Lock {
+    Input RelExpr
+    _ LockPrivate
+}
+
+[Private]
+define LockPrivate {
+    # Table identifies the table to lock. Currently only the primary index of
+    # the table is locked.
+    Table TableID
+
+    # Locking represents the row-level locking mode to use when locking the
+    # primary index.
+    Locking Locking
+
+    # KeyCols are the primary key columns produced by the input, used to lookup
+    # into the primary index of the table. They must be in the same order as the
+    # primary key columns of the table.
+    KeyCols ColList
+
+    # Cols is the set of columns from the input expression returned by the Lock
+    # operator. Cols contains all of the KeyCols.
+    Cols ColSet
+}

--- a/pkg/sql/opt/optbuilder/join.go
+++ b/pkg/sql/opt/optbuilder/join.go
@@ -33,6 +33,8 @@ import (
 func (b *Builder) buildJoin(
 	join *tree.JoinTableExpr, lockCtx lockingContext, inScope *scope,
 ) (outScope *scope) {
+	// TODO(michae2, 97434): Poison the lockCtx for the null-extended side(s) if
+	// this is an outer join.
 	leftScope := b.buildDataSource(join.Left, nil /* indexFlags */, lockCtx, inScope)
 
 	inScopeRight := inScope

--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -72,8 +72,9 @@ type scope struct {
 	// distinctOnCols records the DISTINCT ON columns by ID.
 	distinctOnCols opt.ColSet
 
-	// extraCols contains columns specified by the ORDER BY or DISTINCT ON clauses
-	// which don't appear in cols.
+	// extraCols contains columns specified by the ORDER BY or DISTINCT ON
+	// clauses, or needed by FOR UPDATE or FOR SHARE clauses, which don't appear
+	// in cols.
 	extraCols []scopeColumn
 
 	// expr is the SQL node built with this scope.
@@ -569,7 +570,8 @@ func (s *scope) hasSameColumns(other *scope) bool {
 }
 
 // removeHiddenCols removes hidden columns from the scope (and moves them to
-// extraCols, in case they are referenced by ORDER BY or DISTINCT ON).
+// extraCols, in case they are referenced by ORDER BY or DISTINCT ON or needed
+// by FOR UPDATE or FOR SHARE).
 func (s *scope) removeHiddenCols() {
 	n := 0
 	for i := range s.cols {

--- a/pkg/sql/opt/optbuilder/testdata/select_for_update
+++ b/pkg/sql/opt/optbuilder/testdata/select_for_update
@@ -27,6 +27,17 @@ project
       ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
       └── locking: for-update
 
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT * FROM t FOR UPDATE
+----
+lock t
+ ├── columns: a:1!null b:2
+ ├── locking: for-update
+ └── project
+      ├── columns: a:1!null b:2
+      └── scan t
+           └── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+
 build
 SELECT * FROM t FOR NO KEY UPDATE
 ----
@@ -35,6 +46,17 @@ project
  └── scan t
       ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
       └── locking: for-no-key-update
+
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT * FROM t FOR NO KEY UPDATE
+----
+lock t
+ ├── columns: a:1!null b:2
+ ├── locking: for-no-key-update
+ └── project
+      ├── columns: a:1!null b:2
+      └── scan t
+           └── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
 
 build
 SELECT * FROM t FOR SHARE
@@ -45,6 +67,17 @@ project
       ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
       └── locking: for-share
 
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT * FROM t FOR SHARE
+----
+lock t
+ ├── columns: a:1!null b:2
+ ├── locking: for-share
+ └── project
+      ├── columns: a:1!null b:2
+      └── scan t
+           └── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+
 build
 SELECT * FROM t FOR KEY SHARE
 ----
@@ -53,6 +86,17 @@ project
  └── scan t
       ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
       └── locking: for-key-share
+
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT * FROM t FOR KEY SHARE
+----
+lock t
+ ├── columns: a:1!null b:2
+ ├── locking: for-key-share
+ └── project
+      ├── columns: a:1!null b:2
+      └── scan t
+           └── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
 
 build
 SELECT * FROM t FOR KEY SHARE FOR SHARE
@@ -63,6 +107,20 @@ project
       ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
       └── locking: for-share
 
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT * FROM t FOR KEY SHARE FOR SHARE
+----
+lock t
+ ├── columns: a:1!null b:2
+ ├── locking: for-share
+ └── lock t
+      ├── columns: a:1!null b:2
+      ├── locking: for-key-share
+      └── project
+           ├── columns: a:1!null b:2
+           └── scan t
+                └── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+
 build
 SELECT * FROM t FOR KEY SHARE FOR SHARE FOR NO KEY UPDATE
 ----
@@ -71,6 +129,23 @@ project
  └── scan t
       ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
       └── locking: for-no-key-update
+
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT * FROM t FOR KEY SHARE FOR SHARE FOR NO KEY UPDATE
+----
+lock t
+ ├── columns: a:1!null b:2
+ ├── locking: for-no-key-update
+ └── lock t
+      ├── columns: a:1!null b:2
+      ├── locking: for-share
+      └── lock t
+           ├── columns: a:1!null b:2
+           ├── locking: for-key-share
+           └── project
+                ├── columns: a:1!null b:2
+                └── scan t
+                     └── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
 
 build
 SELECT * FROM t FOR KEY SHARE FOR SHARE FOR NO KEY UPDATE FOR UPDATE
@@ -81,6 +156,26 @@ project
       ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
       └── locking: for-update
 
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT * FROM t FOR KEY SHARE FOR SHARE FOR NO KEY UPDATE FOR UPDATE
+----
+lock t
+ ├── columns: a:1!null b:2
+ ├── locking: for-update
+ └── lock t
+      ├── columns: a:1!null b:2
+      ├── locking: for-no-key-update
+      └── lock t
+           ├── columns: a:1!null b:2
+           ├── locking: for-share
+           └── lock t
+                ├── columns: a:1!null b:2
+                ├── locking: for-key-share
+                └── project
+                     ├── columns: a:1!null b:2
+                     └── scan t
+                          └── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+
 build
 SELECT * FROM t FOR UPDATE OF t
 ----
@@ -90,7 +185,23 @@ project
       ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
       └── locking: for-update
 
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT * FROM t FOR UPDATE OF t
+----
+lock t
+ ├── columns: a:1!null b:2
+ ├── locking: for-update
+ └── project
+      ├── columns: a:1!null b:2
+      └── scan t
+           └── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+
 build
+SELECT * FROM t FOR UPDATE OF t2
+----
+error (42P01): relation "t2" in FOR UPDATE clause not found in FROM clause
+
+build set=optimizer_use_lock_op_for_serializable=true
 SELECT * FROM t FOR UPDATE OF t2
 ----
 error (42P01): relation "t2" in FOR UPDATE clause not found in FROM clause
@@ -106,6 +217,19 @@ project
  └── projections
       └── 1 [as="?column?":5]
 
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT 1 FROM t FOR UPDATE OF t
+----
+lock t
+ ├── columns: "?column?":5!null  [hidden: a:1!null]
+ ├── locking: for-update
+ └── project
+      ├── columns: "?column?":5!null a:1!null
+      ├── scan t
+      │    └── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+      └── projections
+           └── 1 [as="?column?":5]
+
 # ------------------------------------------------------------------------------
 # Tests with table aliases.
 # ------------------------------------------------------------------------------
@@ -119,7 +243,23 @@ project
       ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
       └── locking: for-update
 
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT * FROM t AS t2 FOR UPDATE
+----
+lock t [as=t2]
+ ├── columns: a:1!null b:2
+ ├── locking: for-update
+ └── project
+      ├── columns: a:1!null b:2
+      └── scan t [as=t2]
+           └── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+
 build
+SELECT * FROM t AS t2 FOR UPDATE OF t
+----
+error (42P01): relation "t" in FOR UPDATE clause not found in FROM clause
+
+build set=optimizer_use_lock_op_for_serializable=true
 SELECT * FROM t AS t2 FOR UPDATE OF t
 ----
 error (42P01): relation "t" in FOR UPDATE clause not found in FROM clause
@@ -132,6 +272,17 @@ project
  └── scan t [as=t2]
       ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
       └── locking: for-update
+
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT * FROM t AS t2 FOR UPDATE OF t2
+----
+lock t [as=t2]
+ ├── columns: a:1!null b:2
+ ├── locking: for-update
+ └── project
+      ├── columns: a:1!null b:2
+      └── scan t [as=t2]
+           └── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
 
 # ------------------------------------------------------------------------------
 # Tests with numeric table references.
@@ -147,6 +298,17 @@ project
       ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
       └── locking: for-update
 
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT * FROM [53 AS t] FOR UPDATE
+----
+lock t
+ ├── columns: a:1!null b:2
+ ├── locking: for-update
+ └── project
+      ├── columns: a:1!null b:2
+      └── scan t
+           └── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+
 build
 SELECT * FROM [53 AS t] FOR UPDATE OF t
 ----
@@ -156,7 +318,23 @@ project
       ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
       └── locking: for-update
 
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT * FROM [53 AS t] FOR UPDATE OF t
+----
+lock t
+ ├── columns: a:1!null b:2
+ ├── locking: for-update
+ └── project
+      ├── columns: a:1!null b:2
+      └── scan t
+           └── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+
 build
+SELECT * FROM [53 AS t] FOR UPDATE OF t2
+----
+error (42P01): relation "t2" in FOR UPDATE clause not found in FROM clause
+
+build set=optimizer_use_lock_op_for_serializable=true
 SELECT * FROM [53 AS t] FOR UPDATE OF t2
 ----
 error (42P01): relation "t2" in FOR UPDATE clause not found in FROM clause
@@ -174,6 +352,17 @@ project
       ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
       └── locking: for-update
 
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT * FROM v FOR UPDATE
+----
+lock t [as=t2]
+ ├── columns: a:1!null
+ ├── locking: for-update
+ └── project
+      ├── columns: a:1!null
+      └── scan t [as=t2]
+           └── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+
 build
 SELECT * FROM v FOR UPDATE OF v
 ----
@@ -183,7 +372,23 @@ project
       ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
       └── locking: for-update
 
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT * FROM v FOR UPDATE OF v
+----
+lock t [as=t2]
+ ├── columns: a:1!null
+ ├── locking: for-update
+ └── project
+      ├── columns: a:1!null
+      └── scan t [as=t2]
+           └── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+
 build
+SELECT * FROM v FOR UPDATE OF v2
+----
+error (42P01): relation "v2" in FOR UPDATE clause not found in FROM clause
+
+build set=optimizer_use_lock_op_for_serializable=true
 SELECT * FROM v FOR UPDATE OF v2
 ----
 error (42P01): relation "v2" in FOR UPDATE clause not found in FROM clause
@@ -193,7 +398,17 @@ SELECT * FROM v FOR UPDATE OF t
 ----
 error (42P01): relation "t" in FOR UPDATE clause not found in FROM clause
 
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT * FROM v FOR UPDATE OF t
+----
+error (42P01): relation "t" in FOR UPDATE clause not found in FROM clause
+
 build
+SELECT * FROM v FOR UPDATE OF t2
+----
+error (42P01): relation "t2" in FOR UPDATE clause not found in FROM clause
+
+build set=optimizer_use_lock_op_for_serializable=true
 SELECT * FROM v FOR UPDATE OF t2
 ----
 error (42P01): relation "t2" in FOR UPDATE clause not found in FROM clause
@@ -211,7 +426,23 @@ project
       ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
       └── locking: for-update
 
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT * FROM v AS v2 FOR UPDATE
+----
+lock t [as=t2]
+ ├── columns: a:1!null
+ ├── locking: for-update
+ └── project
+      ├── columns: a:1!null
+      └── scan t [as=t2]
+           └── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+
 build
+SELECT * FROM v AS v2 FOR UPDATE OF v
+----
+error (42P01): relation "v" in FOR UPDATE clause not found in FROM clause
+
+build set=optimizer_use_lock_op_for_serializable=true
 SELECT * FROM v AS v2 FOR UPDATE OF v
 ----
 error (42P01): relation "v" in FOR UPDATE clause not found in FROM clause
@@ -224,6 +455,17 @@ project
  └── scan t [as=t2]
       ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
       └── locking: for-update
+
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT * FROM v AS v2 FOR UPDATE OF v2
+----
+lock t [as=t2]
+ ├── columns: a:1!null
+ ├── locking: for-update
+ └── project
+      ├── columns: a:1!null
+      └── scan t [as=t2]
+           └── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
 
 # ------------------------------------------------------------------------------
 # Tests with subqueries.
@@ -242,6 +484,17 @@ project
       ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
       └── locking: for-update
 
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT * FROM (SELECT a FROM t) FOR UPDATE
+----
+lock t
+ ├── columns: a:1!null
+ ├── locking: for-update
+ └── project
+      ├── columns: a:1!null
+      └── scan t
+           └── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+
 build
 SELECT * FROM (SELECT a FROM t FOR UPDATE)
 ----
@@ -250,6 +503,17 @@ project
  └── scan t
       ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
       └── locking: for-update
+
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT * FROM (SELECT a FROM t FOR UPDATE)
+----
+lock t
+ ├── columns: a:1!null
+ ├── locking: for-update
+ └── project
+      ├── columns: a:1!null
+      └── scan t
+           └── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
 
 build
 SELECT * FROM (SELECT a FROM t FOR NO KEY UPDATE) FOR KEY SHARE
@@ -260,6 +524,20 @@ project
       ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
       └── locking: for-no-key-update
 
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT * FROM (SELECT a FROM t FOR NO KEY UPDATE) FOR KEY SHARE
+----
+lock t
+ ├── columns: a:1!null
+ ├── locking: for-key-share
+ └── lock t
+      ├── columns: a:1!null
+      ├── locking: for-no-key-update
+      └── project
+           ├── columns: a:1!null
+           └── scan t
+                └── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+
 build
 SELECT * FROM (SELECT a FROM t FOR KEY SHARE) FOR NO KEY UPDATE
 ----
@@ -269,7 +547,26 @@ project
       ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
       └── locking: for-no-key-update
 
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT * FROM (SELECT a FROM t FOR KEY SHARE) FOR NO KEY UPDATE
+----
+lock t
+ ├── columns: a:1!null
+ ├── locking: for-no-key-update
+ └── lock t
+      ├── columns: a:1!null
+      ├── locking: for-key-share
+      └── project
+           ├── columns: a:1!null
+           └── scan t
+                └── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+
 build
+SELECT * FROM (SELECT a FROM t) FOR UPDATE OF t
+----
+error (42P01): relation "t" in FOR UPDATE clause not found in FROM clause
+
+build set=optimizer_use_lock_op_for_serializable=true
 SELECT * FROM (SELECT a FROM t) FOR UPDATE OF t
 ----
 error (42P01): relation "t" in FOR UPDATE clause not found in FROM clause
@@ -283,6 +580,17 @@ project
       ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
       └── locking: for-update
 
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT * FROM (SELECT a FROM t FOR UPDATE OF t)
+----
+lock t
+ ├── columns: a:1!null
+ ├── locking: for-update
+ └── project
+      ├── columns: a:1!null
+      └── scan t
+           └── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+
 build
 SELECT * FROM (SELECT a FROM t) AS r FOR UPDATE
 ----
@@ -291,6 +599,17 @@ project
  └── scan t
       ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
       └── locking: for-update
+
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT * FROM (SELECT a FROM t) AS r FOR UPDATE
+----
+lock t
+ ├── columns: a:1!null
+ ├── locking: for-update
+ └── project
+      ├── columns: a:1!null
+      └── scan t
+           └── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
 
 build
 SELECT * FROM (SELECT a FROM t FOR UPDATE) AS r
@@ -301,7 +620,23 @@ project
       ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
       └── locking: for-update
 
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT * FROM (SELECT a FROM t FOR UPDATE) AS r
+----
+lock t
+ ├── columns: a:1!null
+ ├── locking: for-update
+ └── project
+      ├── columns: a:1!null
+      └── scan t
+           └── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+
 build
+SELECT * FROM (SELECT a FROM t) AS r FOR UPDATE OF t
+----
+error (42P01): relation "t" in FOR UPDATE clause not found in FROM clause
+
+build set=optimizer_use_lock_op_for_serializable=true
 SELECT * FROM (SELECT a FROM t) AS r FOR UPDATE OF t
 ----
 error (42P01): relation "t" in FOR UPDATE clause not found in FROM clause
@@ -315,7 +650,34 @@ project
       ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
       └── locking: for-update
 
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT * FROM (SELECT a FROM t FOR UPDATE OF t) AS r
+----
+lock t
+ ├── columns: a:1!null
+ ├── locking: for-update
+ └── project
+      ├── columns: a:1!null
+      └── scan t
+           └── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+
 build
+SELECT (SELECT a FROM t) FOR UPDATE
+----
+project
+ ├── columns: a:5
+ ├── values
+ │    └── ()
+ └── projections
+      └── subquery [as=a:5]
+           └── max1-row
+                ├── columns: t.a:1!null
+                └── project
+                     ├── columns: t.a:1!null
+                     └── scan t
+                          └── columns: t.a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+
+build set=optimizer_use_lock_op_for_serializable=true
 SELECT (SELECT a FROM t) FOR UPDATE
 ----
 project
@@ -348,7 +710,31 @@ project
                           ├── columns: t.a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
                           └── locking: for-update
 
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT (SELECT a FROM t FOR UPDATE)
+----
+project
+ ├── columns: a:5
+ ├── values
+ │    └── ()
+ └── projections
+      └── subquery [as=a:5]
+           └── max1-row
+                ├── columns: t.a:1!null
+                └── lock t
+                     ├── columns: t.a:1!null
+                     ├── locking: for-update
+                     └── project
+                          ├── columns: t.a:1!null
+                          └── scan t
+                               └── columns: t.a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+
 build
+SELECT (SELECT a FROM t) FOR UPDATE OF t
+----
+error (42P01): relation "t" in FOR UPDATE clause not found in FROM clause
+
+build set=optimizer_use_lock_op_for_serializable=true
 SELECT (SELECT a FROM t) FOR UPDATE OF t
 ----
 error (42P01): relation "t" in FOR UPDATE clause not found in FROM clause
@@ -370,7 +756,42 @@ project
                           ├── columns: t.a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
                           └── locking: for-update
 
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT (SELECT a FROM t FOR UPDATE OF t)
+----
+project
+ ├── columns: a:5
+ ├── values
+ │    └── ()
+ └── projections
+      └── subquery [as=a:5]
+           └── max1-row
+                ├── columns: t.a:1!null
+                └── lock t
+                     ├── columns: t.a:1!null
+                     ├── locking: for-update
+                     └── project
+                          ├── columns: t.a:1!null
+                          └── scan t
+                               └── columns: t.a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+
 build
+SELECT (SELECT a FROM t) AS r FOR UPDATE
+----
+project
+ ├── columns: r:5
+ ├── values
+ │    └── ()
+ └── projections
+      └── subquery [as=r:5]
+           └── max1-row
+                ├── columns: a:1!null
+                └── project
+                     ├── columns: a:1!null
+                     └── scan t
+                          └── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+
+build set=optimizer_use_lock_op_for_serializable=true
 SELECT (SELECT a FROM t) AS r FOR UPDATE
 ----
 project
@@ -403,7 +824,31 @@ project
                           ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
                           └── locking: for-update
 
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT (SELECT a FROM t FOR UPDATE) AS r
+----
+project
+ ├── columns: r:5
+ ├── values
+ │    └── ()
+ └── projections
+      └── subquery [as=r:5]
+           └── max1-row
+                ├── columns: a:1!null
+                └── lock t
+                     ├── columns: a:1!null
+                     ├── locking: for-update
+                     └── project
+                          ├── columns: a:1!null
+                          └── scan t
+                               └── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+
 build
+SELECT (SELECT a FROM t) AS r FOR UPDATE OF t
+----
+error (42P01): relation "t" in FOR UPDATE clause not found in FROM clause
+
+build set=optimizer_use_lock_op_for_serializable=true
 SELECT (SELECT a FROM t) AS r FOR UPDATE OF t
 ----
 error (42P01): relation "t" in FOR UPDATE clause not found in FROM clause
@@ -425,6 +870,25 @@ project
                           ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
                           └── locking: for-update
 
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT (SELECT a FROM t FOR UPDATE OF t) AS r
+----
+project
+ ├── columns: r:5
+ ├── values
+ │    └── ()
+ └── projections
+      └── subquery [as=r:5]
+           └── max1-row
+                ├── columns: a:1!null
+                └── lock t
+                     ├── columns: a:1!null
+                     ├── locking: for-update
+                     └── project
+                          ├── columns: a:1!null
+                          └── scan t
+                               └── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+
 build
 SELECT * FROM t WHERE a IN (SELECT a FROM t) FOR UPDATE
 ----
@@ -443,6 +907,26 @@ project
                 │         └── columns: a:5!null b:6 crdb_internal_mvcc_timestamp:7 tableoid:8
                 └── a:1
 
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT * FROM t WHERE a IN (SELECT a FROM t) FOR UPDATE
+----
+lock t
+ ├── columns: a:1!null b:2
+ ├── locking: for-update
+ └── project
+      ├── columns: a:1!null b:2
+      └── select
+           ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+           ├── scan t
+           │    └── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+           └── filters
+                └── any: eq
+                     ├── project
+                     │    ├── columns: a:5!null
+                     │    └── scan t
+                     │         └── columns: a:5!null b:6 crdb_internal_mvcc_timestamp:7 tableoid:8
+                     └── a:1
+
 build
 SELECT * FROM t WHERE a IN (SELECT a FROM t FOR UPDATE)
 ----
@@ -459,6 +943,26 @@ project
                 │    └── scan t
                 │         ├── columns: a:5!null b:6 crdb_internal_mvcc_timestamp:7 tableoid:8
                 │         └── locking: for-update
+                └── a:1
+
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT * FROM t WHERE a IN (SELECT a FROM t FOR UPDATE)
+----
+project
+ ├── columns: a:1!null b:2
+ └── select
+      ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+      ├── scan t
+      │    └── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+      └── filters
+           └── any: eq
+                ├── lock t
+                │    ├── columns: a:5!null
+                │    ├── locking: for-update
+                │    └── project
+                │         ├── columns: a:5!null
+                │         └── scan t
+                │              └── columns: a:5!null b:6 crdb_internal_mvcc_timestamp:7 tableoid:8
                 └── a:1
 
 build
@@ -479,6 +983,26 @@ project
                 │         └── columns: a:5!null b:6 crdb_internal_mvcc_timestamp:7 tableoid:8
                 └── a:1
 
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT * FROM t WHERE a IN (SELECT a FROM t) FOR UPDATE OF t
+----
+lock t
+ ├── columns: a:1!null b:2
+ ├── locking: for-update
+ └── project
+      ├── columns: a:1!null b:2
+      └── select
+           ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+           ├── scan t
+           │    └── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+           └── filters
+                └── any: eq
+                     ├── project
+                     │    ├── columns: a:5!null
+                     │    └── scan t
+                     │         └── columns: a:5!null b:6 crdb_internal_mvcc_timestamp:7 tableoid:8
+                     └── a:1
+
 build
 SELECT * FROM t WHERE a IN (SELECT a FROM t FOR UPDATE OF t)
 ----
@@ -495,6 +1019,26 @@ project
                 │    └── scan t
                 │         ├── columns: a:5!null b:6 crdb_internal_mvcc_timestamp:7 tableoid:8
                 │         └── locking: for-update
+                └── a:1
+
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT * FROM t WHERE a IN (SELECT a FROM t FOR UPDATE OF t)
+----
+project
+ ├── columns: a:1!null b:2
+ └── select
+      ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+      ├── scan t
+      │    └── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+      └── filters
+           └── any: eq
+                ├── lock t
+                │    ├── columns: a:5!null
+                │    ├── locking: for-update
+                │    └── project
+                │         ├── columns: a:5!null
+                │         └── scan t
+                │              └── columns: a:5!null b:6 crdb_internal_mvcc_timestamp:7 tableoid:8
                 └── a:1
 
 build
@@ -515,6 +1059,26 @@ project
                 │         └── columns: a:5!null b:6 crdb_internal_mvcc_timestamp:7 tableoid:8
                 └── a:1
 
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT * FROM t WHERE a IN (SELECT b FROM t) FOR UPDATE
+----
+lock t
+ ├── columns: a:1!null b:2
+ ├── locking: for-update
+ └── project
+      ├── columns: a:1!null b:2
+      └── select
+           ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+           ├── scan t
+           │    └── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+           └── filters
+                └── any: eq
+                     ├── project
+                     │    ├── columns: b:6
+                     │    └── scan t
+                     │         └── columns: a:5!null b:6 crdb_internal_mvcc_timestamp:7 tableoid:8
+                     └── a:1
+
 build
 SELECT * FROM t WHERE a IN (SELECT b FROM t FOR UPDATE)
 ----
@@ -531,6 +1095,28 @@ project
                 │    └── scan t
                 │         ├── columns: a:5!null b:6 crdb_internal_mvcc_timestamp:7 tableoid:8
                 │         └── locking: for-update
+                └── a:1
+
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT * FROM t WHERE a IN (SELECT b FROM t FOR UPDATE)
+----
+project
+ ├── columns: a:1!null b:2
+ └── select
+      ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+      ├── scan t
+      │    └── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+      └── filters
+           └── any: eq
+                ├── project
+                │    ├── columns: b:6
+                │    └── lock t
+                │         ├── columns: a:5!null b:6
+                │         ├── locking: for-update
+                │         └── project
+                │              ├── columns: a:5!null b:6
+                │              └── scan t
+                │                   └── columns: a:5!null b:6 crdb_internal_mvcc_timestamp:7 tableoid:8
                 └── a:1
 
 build
@@ -551,6 +1137,26 @@ project
                 │         └── columns: a:5!null b:6 crdb_internal_mvcc_timestamp:7 tableoid:8
                 └── a:1
 
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT * FROM t WHERE a IN (SELECT b FROM t) FOR UPDATE OF t
+----
+lock t
+ ├── columns: a:1!null b:2
+ ├── locking: for-update
+ └── project
+      ├── columns: a:1!null b:2
+      └── select
+           ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+           ├── scan t
+           │    └── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+           └── filters
+                └── any: eq
+                     ├── project
+                     │    ├── columns: b:6
+                     │    └── scan t
+                     │         └── columns: a:5!null b:6 crdb_internal_mvcc_timestamp:7 tableoid:8
+                     └── a:1
+
 build
 SELECT * FROM t WHERE a IN (SELECT b FROM t FOR UPDATE OF t)
 ----
@@ -567,6 +1173,28 @@ project
                 │    └── scan t
                 │         ├── columns: a:5!null b:6 crdb_internal_mvcc_timestamp:7 tableoid:8
                 │         └── locking: for-update
+                └── a:1
+
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT * FROM t WHERE a IN (SELECT b FROM t FOR UPDATE OF t)
+----
+project
+ ├── columns: a:1!null b:2
+ └── select
+      ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+      ├── scan t
+      │    └── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+      └── filters
+           └── any: eq
+                ├── project
+                │    ├── columns: b:6
+                │    └── lock t
+                │         ├── columns: a:5!null b:6
+                │         ├── locking: for-update
+                │         └── project
+                │              ├── columns: a:5!null b:6
+                │              └── scan t
+                │                   └── columns: a:5!null b:6 crdb_internal_mvcc_timestamp:7 tableoid:8
                 └── a:1
 
 # ------------------------------------------------------------------------------
@@ -591,7 +1219,35 @@ with &1
       └── mapping:
            └──  t.a:1 => a:5
 
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT * FROM [SELECT a FROM t] FOR UPDATE
+----
+with &1
+ ├── columns: a:5!null
+ ├── project
+ │    ├── columns: t.a:1!null
+ │    └── scan t
+ │         └── columns: t.a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+ └── with-scan &1
+      ├── columns: a:5!null
+      └── mapping:
+           └──  t.a:1 => a:5
+
 build
+WITH cte AS (SELECT a FROM t) SELECT * FROM cte FOR UPDATE
+----
+with &1 (cte)
+ ├── columns: a:5!null
+ ├── project
+ │    ├── columns: t.a:1!null
+ │    └── scan t
+ │         └── columns: t.a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+ └── with-scan &1 (cte)
+      ├── columns: a:5!null
+      └── mapping:
+           └──  t.a:1 => a:5
+
+build set=optimizer_use_lock_op_for_serializable=true
 WITH cte AS (SELECT a FROM t) SELECT * FROM cte FOR UPDATE
 ----
 with &1 (cte)
@@ -620,6 +1276,23 @@ with &1
       └── mapping:
            └──  t.a:1 => a:5
 
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT * FROM [SELECT a FROM t FOR UPDATE]
+----
+with &1
+ ├── columns: a:5!null
+ ├── lock t
+ │    ├── columns: t.a:1!null
+ │    ├── locking: for-update
+ │    └── project
+ │         ├── columns: t.a:1!null
+ │         └── scan t
+ │              └── columns: t.a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+ └── with-scan &1
+      ├── columns: a:5!null
+      └── mapping:
+           └──  t.a:1 => a:5
+
 build
 WITH cte AS (SELECT a FROM t FOR UPDATE) SELECT * FROM cte
 ----
@@ -630,6 +1303,23 @@ with &1 (cte)
  │    └── scan t
  │         ├── columns: t.a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
  │         └── locking: for-update
+ └── with-scan &1 (cte)
+      ├── columns: a:5!null
+      └── mapping:
+           └──  t.a:1 => a:5
+
+build set=optimizer_use_lock_op_for_serializable=true
+WITH cte AS (SELECT a FROM t FOR UPDATE) SELECT * FROM cte
+----
+with &1 (cte)
+ ├── columns: a:5!null
+ ├── lock t
+ │    ├── columns: t.a:1!null
+ │    ├── locking: for-update
+ │    └── project
+ │         ├── columns: t.a:1!null
+ │         └── scan t
+ │              └── columns: t.a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
  └── with-scan &1 (cte)
       ├── columns: a:5!null
       └── mapping:
@@ -655,6 +1345,26 @@ project
       └── filters
            └── t.a:1 = u.a:5
 
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT * FROM t JOIN u USING (a) FOR UPDATE
+----
+lock u
+ ├── columns: a:1!null b:2 c:6  [hidden: u.a:5!null]
+ ├── locking: for-update
+ └── lock t
+      ├── columns: t.a:1!null b:2 u.a:5!null c:6
+      ├── locking: for-update
+      └── project
+           ├── columns: t.a:1!null b:2 u.a:5!null c:6
+           └── inner-join (hash)
+                ├── columns: t.a:1!null b:2 t.crdb_internal_mvcc_timestamp:3 t.tableoid:4 u.a:5!null c:6 u.crdb_internal_mvcc_timestamp:7 u.tableoid:8
+                ├── scan t
+                │    └── columns: t.a:1!null b:2 t.crdb_internal_mvcc_timestamp:3 t.tableoid:4
+                ├── scan u
+                │    └── columns: u.a:5!null c:6 u.crdb_internal_mvcc_timestamp:7 u.tableoid:8
+                └── filters
+                     └── t.a:1 = u.a:5
+
 build
 SELECT * FROM t JOIN u USING (a) FOR UPDATE OF t
 ----
@@ -670,6 +1380,23 @@ project
       └── filters
            └── t.a:1 = u.a:5
 
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT * FROM t JOIN u USING (a) FOR UPDATE OF t
+----
+lock t
+ ├── columns: a:1!null b:2 c:6
+ ├── locking: for-update
+ └── project
+      ├── columns: t.a:1!null b:2 c:6
+      └── inner-join (hash)
+           ├── columns: t.a:1!null b:2 t.crdb_internal_mvcc_timestamp:3 t.tableoid:4 u.a:5!null c:6 u.crdb_internal_mvcc_timestamp:7 u.tableoid:8
+           ├── scan t
+           │    └── columns: t.a:1!null b:2 t.crdb_internal_mvcc_timestamp:3 t.tableoid:4
+           ├── scan u
+           │    └── columns: u.a:5!null c:6 u.crdb_internal_mvcc_timestamp:7 u.tableoid:8
+           └── filters
+                └── t.a:1 = u.a:5
+
 build
 SELECT * FROM t JOIN u USING (a) FOR UPDATE OF u
 ----
@@ -684,6 +1411,23 @@ project
       │    └── locking: for-update
       └── filters
            └── t.a:1 = u.a:5
+
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT * FROM t JOIN u USING (a) FOR UPDATE OF u
+----
+lock u
+ ├── columns: a:1!null b:2 c:6  [hidden: u.a:5!null]
+ ├── locking: for-update
+ └── project
+      ├── columns: t.a:1!null b:2 u.a:5!null c:6
+      └── inner-join (hash)
+           ├── columns: t.a:1!null b:2 t.crdb_internal_mvcc_timestamp:3 t.tableoid:4 u.a:5!null c:6 u.crdb_internal_mvcc_timestamp:7 u.tableoid:8
+           ├── scan t
+           │    └── columns: t.a:1!null b:2 t.crdb_internal_mvcc_timestamp:3 t.tableoid:4
+           ├── scan u
+           │    └── columns: u.a:5!null c:6 u.crdb_internal_mvcc_timestamp:7 u.tableoid:8
+           └── filters
+                └── t.a:1 = u.a:5
 
 build
 SELECT * FROM t JOIN u USING (a) FOR UPDATE OF t, u
@@ -701,6 +1445,26 @@ project
       └── filters
            └── t.a:1 = u.a:5
 
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT * FROM t JOIN u USING (a) FOR UPDATE OF t, u
+----
+lock u
+ ├── columns: a:1!null b:2 c:6  [hidden: u.a:5!null]
+ ├── locking: for-update
+ └── lock t
+      ├── columns: t.a:1!null b:2 u.a:5!null c:6
+      ├── locking: for-update
+      └── project
+           ├── columns: t.a:1!null b:2 u.a:5!null c:6
+           └── inner-join (hash)
+                ├── columns: t.a:1!null b:2 t.crdb_internal_mvcc_timestamp:3 t.tableoid:4 u.a:5!null c:6 u.crdb_internal_mvcc_timestamp:7 u.tableoid:8
+                ├── scan t
+                │    └── columns: t.a:1!null b:2 t.crdb_internal_mvcc_timestamp:3 t.tableoid:4
+                ├── scan u
+                │    └── columns: u.a:5!null c:6 u.crdb_internal_mvcc_timestamp:7 u.tableoid:8
+                └── filters
+                     └── t.a:1 = u.a:5
+
 build
 SELECT * FROM t JOIN u USING (a) FOR UPDATE OF t FOR SHARE OF u
 ----
@@ -717,7 +1481,32 @@ project
       └── filters
            └── t.a:1 = u.a:5
 
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT * FROM t JOIN u USING (a) FOR UPDATE OF t FOR SHARE OF u
+----
+lock u
+ ├── columns: a:1!null b:2 c:6  [hidden: u.a:5!null]
+ ├── locking: for-share
+ └── lock t
+      ├── columns: t.a:1!null b:2 u.a:5!null c:6
+      ├── locking: for-update
+      └── project
+           ├── columns: t.a:1!null b:2 u.a:5!null c:6
+           └── inner-join (hash)
+                ├── columns: t.a:1!null b:2 t.crdb_internal_mvcc_timestamp:3 t.tableoid:4 u.a:5!null c:6 u.crdb_internal_mvcc_timestamp:7 u.tableoid:8
+                ├── scan t
+                │    └── columns: t.a:1!null b:2 t.crdb_internal_mvcc_timestamp:3 t.tableoid:4
+                ├── scan u
+                │    └── columns: u.a:5!null c:6 u.crdb_internal_mvcc_timestamp:7 u.tableoid:8
+                └── filters
+                     └── t.a:1 = u.a:5
+
 build
+SELECT * FROM t JOIN u USING (a) FOR UPDATE OF t2 FOR SHARE OF u2
+----
+error (42P01): relation "t2" in FOR UPDATE clause not found in FROM clause
+
+build set=optimizer_use_lock_op_for_serializable=true
 SELECT * FROM t JOIN u USING (a) FOR UPDATE OF t2 FOR SHARE OF u2
 ----
 error (42P01): relation "t2" in FOR UPDATE clause not found in FROM clause
@@ -738,6 +1527,26 @@ project
       └── filters
            └── t2.a:1 = u2.a:5
 
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT * FROM t AS t2 JOIN u AS u2 USING (a) FOR UPDATE OF t2 FOR SHARE OF u2
+----
+lock u [as=u2]
+ ├── columns: a:1!null b:2 c:6  [hidden: u2.a:5!null]
+ ├── locking: for-share
+ └── lock t [as=t2]
+      ├── columns: t2.a:1!null b:2 u2.a:5!null c:6
+      ├── locking: for-update
+      └── project
+           ├── columns: t2.a:1!null b:2 u2.a:5!null c:6
+           └── inner-join (hash)
+                ├── columns: t2.a:1!null b:2 t2.crdb_internal_mvcc_timestamp:3 t2.tableoid:4 u2.a:5!null c:6 u2.crdb_internal_mvcc_timestamp:7 u2.tableoid:8
+                ├── scan t [as=t2]
+                │    └── columns: t2.a:1!null b:2 t2.crdb_internal_mvcc_timestamp:3 t2.tableoid:4
+                ├── scan u [as=u2]
+                │    └── columns: u2.a:5!null c:6 u2.crdb_internal_mvcc_timestamp:7 u2.tableoid:8
+                └── filters
+                     └── t2.a:1 = u2.a:5
+
 build
 SELECT * FROM t JOIN u USING (a) FOR KEY SHARE FOR UPDATE
 ----
@@ -753,6 +1562,32 @@ project
       │    └── locking: for-update
       └── filters
            └── t.a:1 = u.a:5
+
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT * FROM t JOIN u USING (a) FOR KEY SHARE FOR UPDATE
+----
+lock u
+ ├── columns: a:1!null b:2 c:6  [hidden: u.a:5!null]
+ ├── locking: for-update
+ └── lock t
+      ├── columns: t.a:1!null b:2 u.a:5!null c:6
+      ├── locking: for-update
+      └── lock u
+           ├── columns: t.a:1!null b:2 u.a:5!null c:6
+           ├── locking: for-key-share
+           └── lock t
+                ├── columns: t.a:1!null b:2 u.a:5!null c:6
+                ├── locking: for-key-share
+                └── project
+                     ├── columns: t.a:1!null b:2 u.a:5!null c:6
+                     └── inner-join (hash)
+                          ├── columns: t.a:1!null b:2 t.crdb_internal_mvcc_timestamp:3 t.tableoid:4 u.a:5!null c:6 u.crdb_internal_mvcc_timestamp:7 u.tableoid:8
+                          ├── scan t
+                          │    └── columns: t.a:1!null b:2 t.crdb_internal_mvcc_timestamp:3 t.tableoid:4
+                          ├── scan u
+                          │    └── columns: u.a:5!null c:6 u.crdb_internal_mvcc_timestamp:7 u.tableoid:8
+                          └── filters
+                               └── t.a:1 = u.a:5
 
 build
 SELECT * FROM t JOIN u USING (a) FOR KEY SHARE FOR NO KEY UPDATE OF t
@@ -770,6 +1605,29 @@ project
       └── filters
            └── t.a:1 = u.a:5
 
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT * FROM t JOIN u USING (a) FOR KEY SHARE FOR NO KEY UPDATE OF t
+----
+lock t
+ ├── columns: a:1!null b:2 c:6  [hidden: u.a:5!null]
+ ├── locking: for-no-key-update
+ └── lock u
+      ├── columns: t.a:1!null b:2 u.a:5!null c:6
+      ├── locking: for-key-share
+      └── lock t
+           ├── columns: t.a:1!null b:2 u.a:5!null c:6
+           ├── locking: for-key-share
+           └── project
+                ├── columns: t.a:1!null b:2 u.a:5!null c:6
+                └── inner-join (hash)
+                     ├── columns: t.a:1!null b:2 t.crdb_internal_mvcc_timestamp:3 t.tableoid:4 u.a:5!null c:6 u.crdb_internal_mvcc_timestamp:7 u.tableoid:8
+                     ├── scan t
+                     │    └── columns: t.a:1!null b:2 t.crdb_internal_mvcc_timestamp:3 t.tableoid:4
+                     ├── scan u
+                     │    └── columns: u.a:5!null c:6 u.crdb_internal_mvcc_timestamp:7 u.tableoid:8
+                     └── filters
+                          └── t.a:1 = u.a:5
+
 build
 SELECT * FROM t JOIN u USING (a) FOR SHARE FOR NO KEY UPDATE OF t FOR UPDATE OF u
 ----
@@ -785,6 +1643,32 @@ project
       │    └── locking: for-update
       └── filters
            └── t.a:1 = u.a:5
+
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT * FROM t JOIN u USING (a) FOR SHARE FOR NO KEY UPDATE OF t FOR UPDATE OF u
+----
+lock u
+ ├── columns: a:1!null b:2 c:6  [hidden: u.a:5!null]
+ ├── locking: for-update
+ └── lock t
+      ├── columns: t.a:1!null b:2 u.a:5!null c:6
+      ├── locking: for-no-key-update
+      └── lock u
+           ├── columns: t.a:1!null b:2 u.a:5!null c:6
+           ├── locking: for-share
+           └── lock t
+                ├── columns: t.a:1!null b:2 u.a:5!null c:6
+                ├── locking: for-share
+                └── project
+                     ├── columns: t.a:1!null b:2 u.a:5!null c:6
+                     └── inner-join (hash)
+                          ├── columns: t.a:1!null b:2 t.crdb_internal_mvcc_timestamp:3 t.tableoid:4 u.a:5!null c:6 u.crdb_internal_mvcc_timestamp:7 u.tableoid:8
+                          ├── scan t
+                          │    └── columns: t.a:1!null b:2 t.crdb_internal_mvcc_timestamp:3 t.tableoid:4
+                          ├── scan u
+                          │    └── columns: u.a:5!null c:6 u.crdb_internal_mvcc_timestamp:7 u.tableoid:8
+                          └── filters
+                               └── t.a:1 = u.a:5
 
 # ------------------------------------------------------------------------------
 # Tests with joins of aliased tables and aliased joins.
@@ -806,7 +1690,32 @@ project
       └── filters
            └── t2.a:1 = u2.a:5
 
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT * FROM t AS t2 JOIN u AS u2 USING (a) FOR UPDATE
+----
+lock u [as=u2]
+ ├── columns: a:1!null b:2 c:6  [hidden: u2.a:5!null]
+ ├── locking: for-update
+ └── lock t [as=t2]
+      ├── columns: t2.a:1!null b:2 u2.a:5!null c:6
+      ├── locking: for-update
+      └── project
+           ├── columns: t2.a:1!null b:2 u2.a:5!null c:6
+           └── inner-join (hash)
+                ├── columns: t2.a:1!null b:2 t2.crdb_internal_mvcc_timestamp:3 t2.tableoid:4 u2.a:5!null c:6 u2.crdb_internal_mvcc_timestamp:7 u2.tableoid:8
+                ├── scan t [as=t2]
+                │    └── columns: t2.a:1!null b:2 t2.crdb_internal_mvcc_timestamp:3 t2.tableoid:4
+                ├── scan u [as=u2]
+                │    └── columns: u2.a:5!null c:6 u2.crdb_internal_mvcc_timestamp:7 u2.tableoid:8
+                └── filters
+                     └── t2.a:1 = u2.a:5
+
 build
+SELECT * FROM t AS t2 JOIN u AS u2 USING (a) FOR UPDATE OF t
+----
+error (42P01): relation "t" in FOR UPDATE clause not found in FROM clause
+
+build set=optimizer_use_lock_op_for_serializable=true
 SELECT * FROM t AS t2 JOIN u AS u2 USING (a) FOR UPDATE OF t
 ----
 error (42P01): relation "t" in FOR UPDATE clause not found in FROM clause
@@ -816,7 +1725,17 @@ SELECT * FROM t AS t2 JOIN u AS u2 USING (a) FOR UPDATE OF u
 ----
 error (42P01): relation "u" in FOR UPDATE clause not found in FROM clause
 
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT * FROM t AS t2 JOIN u AS u2 USING (a) FOR UPDATE OF u
+----
+error (42P01): relation "u" in FOR UPDATE clause not found in FROM clause
+
 build
+SELECT * FROM t AS t2 JOIN u AS u2 USING (a) FOR UPDATE OF t, u
+----
+error (42P01): relation "t" in FOR UPDATE clause not found in FROM clause
+
+build set=optimizer_use_lock_op_for_serializable=true
 SELECT * FROM t AS t2 JOIN u AS u2 USING (a) FOR UPDATE OF t, u
 ----
 error (42P01): relation "t" in FOR UPDATE clause not found in FROM clause
@@ -836,6 +1755,23 @@ project
       └── filters
            └── t2.a:1 = u2.a:5
 
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT * FROM t AS t2 JOIN u AS u2 USING (a) FOR UPDATE OF t2
+----
+lock t [as=t2]
+ ├── columns: a:1!null b:2 c:6
+ ├── locking: for-update
+ └── project
+      ├── columns: t2.a:1!null b:2 c:6
+      └── inner-join (hash)
+           ├── columns: t2.a:1!null b:2 t2.crdb_internal_mvcc_timestamp:3 t2.tableoid:4 u2.a:5!null c:6 u2.crdb_internal_mvcc_timestamp:7 u2.tableoid:8
+           ├── scan t [as=t2]
+           │    └── columns: t2.a:1!null b:2 t2.crdb_internal_mvcc_timestamp:3 t2.tableoid:4
+           ├── scan u [as=u2]
+           │    └── columns: u2.a:5!null c:6 u2.crdb_internal_mvcc_timestamp:7 u2.tableoid:8
+           └── filters
+                └── t2.a:1 = u2.a:5
+
 build
 SELECT * FROM t AS t2 JOIN u AS u2 USING (a) FOR UPDATE OF u2
 ----
@@ -850,6 +1786,23 @@ project
       │    └── locking: for-update
       └── filters
            └── t2.a:1 = u2.a:5
+
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT * FROM t AS t2 JOIN u AS u2 USING (a) FOR UPDATE OF u2
+----
+lock u [as=u2]
+ ├── columns: a:1!null b:2 c:6  [hidden: u2.a:5!null]
+ ├── locking: for-update
+ └── project
+      ├── columns: t2.a:1!null b:2 u2.a:5!null c:6
+      └── inner-join (hash)
+           ├── columns: t2.a:1!null b:2 t2.crdb_internal_mvcc_timestamp:3 t2.tableoid:4 u2.a:5!null c:6 u2.crdb_internal_mvcc_timestamp:7 u2.tableoid:8
+           ├── scan t [as=t2]
+           │    └── columns: t2.a:1!null b:2 t2.crdb_internal_mvcc_timestamp:3 t2.tableoid:4
+           ├── scan u [as=u2]
+           │    └── columns: u2.a:5!null c:6 u2.crdb_internal_mvcc_timestamp:7 u2.tableoid:8
+           └── filters
+                └── t2.a:1 = u2.a:5
 
 build
 SELECT * FROM t AS t2 JOIN u AS u2 USING (a) FOR UPDATE OF t2, u2
@@ -872,6 +1825,31 @@ project
 # queries all return the error: "FOR UPDATE cannot be applied to a join".
 # We could do the same, but it's not hard to support these, so we do.
 
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT * FROM t AS t2 JOIN u AS u2 USING (a) FOR UPDATE OF t2, u2
+----
+lock u [as=u2]
+ ├── columns: a:1!null b:2 c:6  [hidden: u2.a:5!null]
+ ├── locking: for-update
+ └── lock t [as=t2]
+      ├── columns: t2.a:1!null b:2 u2.a:5!null c:6
+      ├── locking: for-update
+      └── project
+           ├── columns: t2.a:1!null b:2 u2.a:5!null c:6
+           └── inner-join (hash)
+                ├── columns: t2.a:1!null b:2 t2.crdb_internal_mvcc_timestamp:3 t2.tableoid:4 u2.a:5!null c:6 u2.crdb_internal_mvcc_timestamp:7 u2.tableoid:8
+                ├── scan t [as=t2]
+                │    └── columns: t2.a:1!null b:2 t2.crdb_internal_mvcc_timestamp:3 t2.tableoid:4
+                ├── scan u [as=u2]
+                │    └── columns: u2.a:5!null c:6 u2.crdb_internal_mvcc_timestamp:7 u2.tableoid:8
+                └── filters
+                     └── t2.a:1 = u2.a:5
+
+
+# Postgres doesn't support applying locking clauses to joins. The following
+# queries all return the error: "FOR UPDATE cannot be applied to a join".
+# We could do the same, but it's not hard to support these, so we do.
+
 build
 SELECT * FROM (t JOIN u AS u2 USING (a)) j FOR UPDATE
 ----
@@ -888,7 +1866,32 @@ project
       └── filters
            └── t.a:1 = u2.a:5
 
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT * FROM (t JOIN u AS u2 USING (a)) j FOR UPDATE
+----
+lock u [as=u2]
+ ├── columns: a:1!null b:2 c:6  [hidden: u2.a:5!null]
+ ├── locking: for-update
+ └── lock t
+      ├── columns: t.a:1!null b:2 u2.a:5!null c:6
+      ├── locking: for-update
+      └── project
+           ├── columns: t.a:1!null b:2 u2.a:5!null c:6
+           └── inner-join (hash)
+                ├── columns: t.a:1!null b:2 t.crdb_internal_mvcc_timestamp:3 t.tableoid:4 u2.a:5!null c:6 u2.crdb_internal_mvcc_timestamp:7 u2.tableoid:8
+                ├── scan t
+                │    └── columns: t.a:1!null b:2 t.crdb_internal_mvcc_timestamp:3 t.tableoid:4
+                ├── scan u [as=u2]
+                │    └── columns: u2.a:5!null c:6 u2.crdb_internal_mvcc_timestamp:7 u2.tableoid:8
+                └── filters
+                     └── t.a:1 = u2.a:5
+
 build
+SELECT * FROM (t JOIN u AS u2 USING (a)) j FOR UPDATE OF t
+----
+error (42P01): relation "t" in FOR UPDATE clause not found in FROM clause
+
+build set=optimizer_use_lock_op_for_serializable=true
 SELECT * FROM (t JOIN u AS u2 USING (a)) j FOR UPDATE OF t
 ----
 error (42P01): relation "t" in FOR UPDATE clause not found in FROM clause
@@ -898,7 +1901,17 @@ SELECT * FROM (t JOIN u AS u2 USING (a)) j FOR UPDATE OF u
 ----
 error (42P01): relation "u" in FOR UPDATE clause not found in FROM clause
 
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT * FROM (t JOIN u AS u2 USING (a)) j FOR UPDATE OF u
+----
+error (42P01): relation "u" in FOR UPDATE clause not found in FROM clause
+
 build
+SELECT * FROM (t JOIN u AS u2 USING (a)) j FOR UPDATE OF u2
+----
+error (42P01): relation "u2" in FOR UPDATE clause not found in FROM clause
+
+build set=optimizer_use_lock_op_for_serializable=true
 SELECT * FROM (t JOIN u AS u2 USING (a)) j FOR UPDATE OF u2
 ----
 error (42P01): relation "u2" in FOR UPDATE clause not found in FROM clause
@@ -919,6 +1932,26 @@ project
       └── filters
            └── t.a:1 = u2.a:5
 
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT * FROM (t JOIN u AS u2 USING (a)) j FOR UPDATE OF j
+----
+lock u [as=u2]
+ ├── columns: a:1!null b:2 c:6  [hidden: u2.a:5!null]
+ ├── locking: for-update
+ └── lock t
+      ├── columns: t.a:1!null b:2 u2.a:5!null c:6
+      ├── locking: for-update
+      └── project
+           ├── columns: t.a:1!null b:2 u2.a:5!null c:6
+           └── inner-join (hash)
+                ├── columns: t.a:1!null b:2 t.crdb_internal_mvcc_timestamp:3 t.tableoid:4 u2.a:5!null c:6 u2.crdb_internal_mvcc_timestamp:7 u2.tableoid:8
+                ├── scan t
+                │    └── columns: t.a:1!null b:2 t.crdb_internal_mvcc_timestamp:3 t.tableoid:4
+                ├── scan u [as=u2]
+                │    └── columns: u2.a:5!null c:6 u2.crdb_internal_mvcc_timestamp:7 u2.tableoid:8
+                └── filters
+                     └── t.a:1 = u2.a:5
+
 # ------------------------------------------------------------------------------
 # Tests with lateral joins.
 # ------------------------------------------------------------------------------
@@ -938,6 +1971,25 @@ project
       │    └── locking: for-update
       └── filters (true)
 
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT * FROM t, u FOR UPDATE
+----
+lock u
+ ├── columns: a:1!null b:2 a:5!null c:6
+ ├── locking: for-update
+ └── lock t
+      ├── columns: t.a:1!null b:2 u.a:5!null c:6
+      ├── locking: for-update
+      └── project
+           ├── columns: t.a:1!null b:2 u.a:5!null c:6
+           └── inner-join (cross)
+                ├── columns: t.a:1!null b:2 t.crdb_internal_mvcc_timestamp:3 t.tableoid:4 u.a:5!null c:6 u.crdb_internal_mvcc_timestamp:7 u.tableoid:8
+                ├── scan t
+                │    └── columns: t.a:1!null b:2 t.crdb_internal_mvcc_timestamp:3 t.tableoid:4
+                ├── scan u
+                │    └── columns: u.a:5!null c:6 u.crdb_internal_mvcc_timestamp:7 u.tableoid:8
+                └── filters (true)
+
 build
 SELECT * FROM t, u FOR UPDATE OF t
 ----
@@ -951,6 +2003,22 @@ project
       ├── scan u
       │    └── columns: u.a:5!null c:6 u.crdb_internal_mvcc_timestamp:7 u.tableoid:8
       └── filters (true)
+
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT * FROM t, u FOR UPDATE OF t
+----
+lock t
+ ├── columns: a:1!null b:2 a:5!null c:6
+ ├── locking: for-update
+ └── project
+      ├── columns: t.a:1!null b:2 u.a:5!null c:6
+      └── inner-join (cross)
+           ├── columns: t.a:1!null b:2 t.crdb_internal_mvcc_timestamp:3 t.tableoid:4 u.a:5!null c:6 u.crdb_internal_mvcc_timestamp:7 u.tableoid:8
+           ├── scan t
+           │    └── columns: t.a:1!null b:2 t.crdb_internal_mvcc_timestamp:3 t.tableoid:4
+           ├── scan u
+           │    └── columns: u.a:5!null c:6 u.crdb_internal_mvcc_timestamp:7 u.tableoid:8
+           └── filters (true)
 
 build
 SELECT * FROM t, u FOR SHARE OF t FOR UPDATE OF u
@@ -966,6 +2034,25 @@ project
       │    ├── columns: u.a:5!null c:6 u.crdb_internal_mvcc_timestamp:7 u.tableoid:8
       │    └── locking: for-update
       └── filters (true)
+
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT * FROM t, u FOR SHARE OF t FOR UPDATE OF u
+----
+lock u
+ ├── columns: a:1!null b:2 a:5!null c:6
+ ├── locking: for-update
+ └── lock t
+      ├── columns: t.a:1!null b:2 u.a:5!null c:6
+      ├── locking: for-share
+      └── project
+           ├── columns: t.a:1!null b:2 u.a:5!null c:6
+           └── inner-join (cross)
+                ├── columns: t.a:1!null b:2 t.crdb_internal_mvcc_timestamp:3 t.tableoid:4 u.a:5!null c:6 u.crdb_internal_mvcc_timestamp:7 u.tableoid:8
+                ├── scan t
+                │    └── columns: t.a:1!null b:2 t.crdb_internal_mvcc_timestamp:3 t.tableoid:4
+                ├── scan u
+                │    └── columns: u.a:5!null c:6 u.crdb_internal_mvcc_timestamp:7 u.tableoid:8
+                └── filters (true)
 
 build
 SELECT * FROM t, LATERAL (SELECT * FROM u) sub FOR UPDATE
@@ -984,7 +2071,33 @@ project
       │         └── locking: for-update
       └── filters (true)
 
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT * FROM t, LATERAL (SELECT * FROM u) sub FOR UPDATE
+----
+lock u
+ ├── columns: a:1!null b:2 a:5!null c:6
+ ├── locking: for-update
+ └── lock t
+      ├── columns: t.a:1!null b:2 u.a:5!null c:6
+      ├── locking: for-update
+      └── project
+           ├── columns: t.a:1!null b:2 u.a:5!null c:6
+           └── inner-join-apply
+                ├── columns: t.a:1!null b:2 t.crdb_internal_mvcc_timestamp:3 t.tableoid:4 u.a:5!null c:6
+                ├── scan t
+                │    └── columns: t.a:1!null b:2 t.crdb_internal_mvcc_timestamp:3 t.tableoid:4
+                ├── project
+                │    ├── columns: u.a:5!null c:6
+                │    └── scan u
+                │         └── columns: u.a:5!null c:6 u.crdb_internal_mvcc_timestamp:7 u.tableoid:8
+                └── filters (true)
+
 build
+SELECT * FROM t, LATERAL (SELECT * FROM u) sub FOR UPDATE OF u
+----
+error (42P01): relation "u" in FOR UPDATE clause not found in FROM clause
+
+build set=optimizer_use_lock_op_for_serializable=true
 SELECT * FROM t, LATERAL (SELECT * FROM u) sub FOR UPDATE OF u
 ----
 error (42P01): relation "u" in FOR UPDATE clause not found in FROM clause
@@ -1004,6 +2117,24 @@ project
       │         ├── columns: u.a:5!null c:6 u.crdb_internal_mvcc_timestamp:7 u.tableoid:8
       │         └── locking: for-update
       └── filters (true)
+
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT * FROM t, LATERAL (SELECT * FROM u) sub FOR UPDATE OF sub
+----
+lock u
+ ├── columns: a:1!null b:2 a:5!null c:6
+ ├── locking: for-update
+ └── project
+      ├── columns: t.a:1!null b:2 u.a:5!null c:6
+      └── inner-join-apply
+           ├── columns: t.a:1!null b:2 t.crdb_internal_mvcc_timestamp:3 t.tableoid:4 u.a:5!null c:6
+           ├── scan t
+           │    └── columns: t.a:1!null b:2 t.crdb_internal_mvcc_timestamp:3 t.tableoid:4
+           ├── project
+           │    ├── columns: u.a:5!null c:6
+           │    └── scan u
+           │         └── columns: u.a:5!null c:6 u.crdb_internal_mvcc_timestamp:7 u.tableoid:8
+           └── filters (true)
 
 # ------------------------------------------------------------------------------
 # Tests with index joins.
@@ -1031,6 +2162,21 @@ project
       └── filters
            └── b:2 = 2
 
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT * FROM indexed WHERE b = 2 FOR UPDATE
+----
+lock indexed
+ ├── columns: a:1!null b:2!null c:3
+ ├── locking: for-update
+ └── project
+      ├── columns: a:1!null b:2!null c:3
+      └── select
+           ├── columns: a:1!null b:2!null c:3 crdb_internal_mvcc_timestamp:4 tableoid:5
+           ├── scan indexed
+           │    └── columns: a:1!null b:2 c:3 crdb_internal_mvcc_timestamp:4 tableoid:5
+           └── filters
+                └── b:2 = 2
+
 build
 SELECT * FROM indexed WHERE b BETWEEN 2 AND 10 FOR UPDATE
 ----
@@ -1043,6 +2189,21 @@ project
       │    └── locking: for-update
       └── filters
            └── (b:2 >= 2) AND (b:2 <= 10)
+
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT * FROM indexed WHERE b BETWEEN 2 AND 10 FOR UPDATE
+----
+lock indexed
+ ├── columns: a:1!null b:2!null c:3
+ ├── locking: for-update
+ └── project
+      ├── columns: a:1!null b:2!null c:3
+      └── select
+           ├── columns: a:1!null b:2!null c:3 crdb_internal_mvcc_timestamp:4 tableoid:5
+           ├── scan indexed
+           │    └── columns: a:1!null b:2 c:3 crdb_internal_mvcc_timestamp:4 tableoid:5
+           └── filters
+                └── (b:2 >= 2) AND (b:2 <= 10)
 
 # ------------------------------------------------------------------------------
 # Tests with lookup joins.
@@ -1068,6 +2229,30 @@ project
       └── filters
            └── t.a:1 = 2
 
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT c FROM t JOIN u ON t.b = u.a WHERE t.a = 2 FOR UPDATE
+----
+lock u
+ ├── columns: c:6  [hidden: t.a:1!null u.a:5!null]
+ ├── locking: for-update
+ └── lock t
+      ├── columns: t.a:1!null u.a:5!null c:6
+      ├── locking: for-update
+      └── project
+           ├── columns: t.a:1!null u.a:5!null c:6
+           └── select
+                ├── columns: t.a:1!null b:2!null t.crdb_internal_mvcc_timestamp:3 t.tableoid:4 u.a:5!null c:6 u.crdb_internal_mvcc_timestamp:7 u.tableoid:8
+                ├── inner-join (hash)
+                │    ├── columns: t.a:1!null b:2!null t.crdb_internal_mvcc_timestamp:3 t.tableoid:4 u.a:5!null c:6 u.crdb_internal_mvcc_timestamp:7 u.tableoid:8
+                │    ├── scan t
+                │    │    └── columns: t.a:1!null b:2 t.crdb_internal_mvcc_timestamp:3 t.tableoid:4
+                │    ├── scan u
+                │    │    └── columns: u.a:5!null c:6 u.crdb_internal_mvcc_timestamp:7 u.tableoid:8
+                │    └── filters
+                │         └── b:2 = u.a:5
+                └── filters
+                     └── t.a:1 = 2
+
 build
 SELECT c FROM t JOIN u ON t.b = u.a WHERE t.a BETWEEN 2 AND 10 FOR UPDATE
 ----
@@ -1088,6 +2273,30 @@ project
       └── filters
            └── (t.a:1 >= 2) AND (t.a:1 <= 10)
 
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT c FROM t JOIN u ON t.b = u.a WHERE t.a BETWEEN 2 AND 10 FOR UPDATE
+----
+lock u
+ ├── columns: c:6  [hidden: t.a:1!null u.a:5!null]
+ ├── locking: for-update
+ └── lock t
+      ├── columns: t.a:1!null u.a:5!null c:6
+      ├── locking: for-update
+      └── project
+           ├── columns: t.a:1!null u.a:5!null c:6
+           └── select
+                ├── columns: t.a:1!null b:2!null t.crdb_internal_mvcc_timestamp:3 t.tableoid:4 u.a:5!null c:6 u.crdb_internal_mvcc_timestamp:7 u.tableoid:8
+                ├── inner-join (hash)
+                │    ├── columns: t.a:1!null b:2!null t.crdb_internal_mvcc_timestamp:3 t.tableoid:4 u.a:5!null c:6 u.crdb_internal_mvcc_timestamp:7 u.tableoid:8
+                │    ├── scan t
+                │    │    └── columns: t.a:1!null b:2 t.crdb_internal_mvcc_timestamp:3 t.tableoid:4
+                │    ├── scan u
+                │    │    └── columns: u.a:5!null c:6 u.crdb_internal_mvcc_timestamp:7 u.tableoid:8
+                │    └── filters
+                │         └── b:2 = u.a:5
+                └── filters
+                     └── (t.a:1 >= 2) AND (t.a:1 <= 10)
+
 build
 SELECT * FROM t JOIN indexed ON t.b = indexed.b WHERE t.a = 2 FOR UPDATE
 ----
@@ -1107,6 +2316,30 @@ project
       │         └── t.b:2 = indexed.b:6
       └── filters
            └── t.a:1 = 2
+
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT * FROM t JOIN indexed ON t.b = indexed.b WHERE t.a = 2 FOR UPDATE
+----
+lock indexed
+ ├── columns: a:1!null b:2!null a:5!null b:6!null c:7
+ ├── locking: for-update
+ └── lock t
+      ├── columns: t.a:1!null t.b:2!null indexed.a:5!null indexed.b:6!null c:7
+      ├── locking: for-update
+      └── project
+           ├── columns: t.a:1!null t.b:2!null indexed.a:5!null indexed.b:6!null c:7
+           └── select
+                ├── columns: t.a:1!null t.b:2!null t.crdb_internal_mvcc_timestamp:3 t.tableoid:4 indexed.a:5!null indexed.b:6!null c:7 indexed.crdb_internal_mvcc_timestamp:8 indexed.tableoid:9
+                ├── inner-join (hash)
+                │    ├── columns: t.a:1!null t.b:2!null t.crdb_internal_mvcc_timestamp:3 t.tableoid:4 indexed.a:5!null indexed.b:6!null c:7 indexed.crdb_internal_mvcc_timestamp:8 indexed.tableoid:9
+                │    ├── scan t
+                │    │    └── columns: t.a:1!null t.b:2 t.crdb_internal_mvcc_timestamp:3 t.tableoid:4
+                │    ├── scan indexed
+                │    │    └── columns: indexed.a:5!null indexed.b:6 c:7 indexed.crdb_internal_mvcc_timestamp:8 indexed.tableoid:9
+                │    └── filters
+                │         └── t.b:2 = indexed.b:6
+                └── filters
+                     └── t.a:1 = 2
 
 # ------------------------------------------------------------------------------
 # Tests with inverted filters and joins.
@@ -1134,6 +2367,21 @@ project
       └── filters
            └── b:2 @> ARRAY[1,2]
 
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT * FROM inverted WHERE b @> '{1, 2}' FOR UPDATE
+----
+lock inverted
+ ├── columns: a:1!null b:2!null c:3
+ ├── locking: for-update
+ └── project
+      ├── columns: a:1!null b:2!null c:3
+      └── select
+           ├── columns: a:1!null b:2!null c:3 crdb_internal_mvcc_timestamp:4 tableoid:5
+           ├── scan inverted
+           │    └── columns: a:1!null b:2 c:3 crdb_internal_mvcc_timestamp:4 tableoid:5
+           └── filters
+                └── b:2 @> ARRAY[1,2]
+
 build
 SELECT * FROM inverted WHERE b <@ '{1, 2}' FOR UPDATE
 ----
@@ -1146,6 +2394,21 @@ project
       │    └── locking: for-update
       └── filters
            └── b:2 <@ ARRAY[1,2]
+
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT * FROM inverted WHERE b <@ '{1, 2}' FOR UPDATE
+----
+lock inverted
+ ├── columns: a:1!null b:2 c:3
+ ├── locking: for-update
+ └── project
+      ├── columns: a:1!null b:2 c:3
+      └── select
+           ├── columns: a:1!null b:2 c:3 crdb_internal_mvcc_timestamp:4 tableoid:5
+           ├── scan inverted
+           │    └── columns: a:1!null b:2 c:3 crdb_internal_mvcc_timestamp:4 tableoid:5
+           └── filters
+                └── b:2 <@ ARRAY[1,2]
 
 build
 SELECT * FROM inverted@b_inv AS i1, inverted AS i2 WHERE i1.b @> i2.b FOR UPDATE
@@ -1166,6 +2429,30 @@ project
       │    └── filters (true)
       └── filters
            └── i1.b:2 @> i2.b:8
+
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT * FROM inverted@b_inv AS i1, inverted AS i2 WHERE i1.b @> i2.b FOR UPDATE
+----
+lock inverted [as=i2]
+ ├── columns: a:1!null b:2 c:3 a:7!null b:8 c:9
+ ├── locking: for-update
+ └── lock inverted [as=i1]
+      ├── columns: i1.a:1!null i1.b:2 i1.c:3 i2.a:7!null i2.b:8 i2.c:9
+      ├── locking: for-update
+      └── project
+           ├── columns: i1.a:1!null i1.b:2 i1.c:3 i2.a:7!null i2.b:8 i2.c:9
+           └── select
+                ├── columns: i1.a:1!null i1.b:2 i1.c:3 i1.crdb_internal_mvcc_timestamp:4 i1.tableoid:5 i2.a:7!null i2.b:8 i2.c:9 i2.crdb_internal_mvcc_timestamp:10 i2.tableoid:11
+                ├── inner-join (cross)
+                │    ├── columns: i1.a:1!null i1.b:2 i1.c:3 i1.crdb_internal_mvcc_timestamp:4 i1.tableoid:5 i2.a:7!null i2.b:8 i2.c:9 i2.crdb_internal_mvcc_timestamp:10 i2.tableoid:11
+                │    ├── scan inverted [as=i1]
+                │    │    ├── columns: i1.a:1!null i1.b:2 i1.c:3 i1.crdb_internal_mvcc_timestamp:4 i1.tableoid:5
+                │    │    └── flags: force-index=b_inv
+                │    ├── scan inverted [as=i2]
+                │    │    └── columns: i2.a:7!null i2.b:8 i2.c:9 i2.crdb_internal_mvcc_timestamp:10 i2.tableoid:11
+                │    └── filters (true)
+                └── filters
+                     └── i1.b:2 @> i2.b:8
 
 # ------------------------------------------------------------------------------
 # Tests with zigzag joins.
@@ -1196,6 +2483,21 @@ project
       └── filters
            └── (b:2 = 5) AND (c:3 = 6.0)
 
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT a,b,c FROM zigzag WHERE b = 5 AND c = 6.0 FOR UPDATE
+----
+lock zigzag
+ ├── columns: a:1!null b:2!null c:3!null
+ ├── locking: for-update
+ └── project
+      ├── columns: a:1!null b:2!null c:3!null
+      └── select
+           ├── columns: a:1!null b:2!null c:3!null d:4 crdb_internal_mvcc_timestamp:5 tableoid:6
+           ├── scan zigzag
+           │    └── columns: a:1!null b:2 c:3 d:4 crdb_internal_mvcc_timestamp:5 tableoid:6
+           └── filters
+                └── (b:2 = 5) AND (c:3 = 6.0)
+
 build
 SELECT * from zigzag where d @> '{"a": {"b": "c"}, "f": "g"}' FOR UPDATE
 ----
@@ -1209,6 +2511,21 @@ project
       └── filters
            └── d:4 @> '{"a": {"b": "c"}, "f": "g"}'
 
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT * from zigzag where d @> '{"a": {"b": "c"}, "f": "g"}' FOR UPDATE
+----
+lock zigzag
+ ├── columns: a:1!null b:2 c:3 d:4!null
+ ├── locking: for-update
+ └── project
+      ├── columns: a:1!null b:2 c:3 d:4!null
+      └── select
+           ├── columns: a:1!null b:2 c:3 d:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+           ├── scan zigzag
+           │    └── columns: a:1!null b:2 c:3 d:4 crdb_internal_mvcc_timestamp:5 tableoid:6
+           └── filters
+                └── d:4 @> '{"a": {"b": "c"}, "f": "g"}'
+
 # ------------------------------------------------------------------------------
 # Tests with virtual tables.
 # ------------------------------------------------------------------------------
@@ -1217,6 +2534,15 @@ build
 SELECT * FROM information_schema.columns FOR UPDATE
 ----
 error (42601): FOR UPDATE not allowed with virtual tables
+
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT * FROM information_schema.columns FOR UPDATE
+----
+lock columns
+ ├── columns: table_catalog:2!null table_schema:3!null table_name:4!null column_name:5!null column_comment:6 ordinal_position:7!null column_default:8 is_nullable:9!null data_type:10!null character_maximum_length:11 character_octet_length:12 numeric_precision:13 numeric_precision_radix:14 numeric_scale:15 datetime_precision:16 interval_type:17 interval_precision:18 character_set_catalog:19 character_set_schema:20 character_set_name:21 collation_catalog:22 collation_schema:23 collation_name:24 domain_catalog:25 domain_schema:26 domain_name:27 udt_catalog:28 udt_schema:29 udt_name:30 scope_catalog:31 scope_schema:32 scope_name:33 maximum_cardinality:34 dtd_identifier:35 is_self_referencing:36 is_identity:37 identity_generation:38 identity_start:39 identity_increment:40 identity_maximum:41 identity_minimum:42 identity_cycle:43 is_generated:44 generation_expression:45 is_updatable:46 is_hidden:47!null crdb_sql_type:48!null  [hidden: crdb_internal_vtable_pk:1!null]
+ ├── locking: for-update
+ └── scan columns
+      └── columns: crdb_internal_vtable_pk:1!null table_catalog:2!null table_schema:3!null table_name:4!null column_name:5!null column_comment:6 ordinal_position:7!null column_default:8 is_nullable:9!null data_type:10!null character_maximum_length:11 character_octet_length:12 numeric_precision:13 numeric_precision_radix:14 numeric_scale:15 datetime_precision:16 interval_type:17 interval_precision:18 character_set_catalog:19 character_set_schema:20 character_set_name:21 collation_catalog:22 collation_schema:23 collation_name:24 domain_catalog:25 domain_schema:26 domain_name:27 udt_catalog:28 udt_schema:29 udt_name:30 scope_catalog:31 scope_schema:32 scope_name:33 maximum_cardinality:34 dtd_identifier:35 is_self_referencing:36 is_identity:37 identity_generation:38 identity_start:39 identity_increment:40 identity_maximum:41 identity_minimum:42 identity_cycle:43 is_generated:44 generation_expression:45 is_updatable:46 is_hidden:47!null crdb_sql_type:48!null
 
 # ------------------------------------------------------------------------------
 # Tests with the NOWAIT lock wait policy.
@@ -1231,6 +2557,17 @@ project
       ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
       └── locking: for-update,nowait
 
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT * FROM t FOR UPDATE NOWAIT
+----
+lock t
+ ├── columns: a:1!null b:2
+ ├── locking: for-update,nowait
+ └── project
+      ├── columns: a:1!null b:2
+      └── scan t
+           └── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+
 build
 SELECT * FROM t FOR NO KEY UPDATE NOWAIT
 ----
@@ -1239,6 +2576,17 @@ project
  └── scan t
       ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
       └── locking: for-no-key-update,nowait
+
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT * FROM t FOR NO KEY UPDATE NOWAIT
+----
+lock t
+ ├── columns: a:1!null b:2
+ ├── locking: for-no-key-update,nowait
+ └── project
+      ├── columns: a:1!null b:2
+      └── scan t
+           └── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
 
 build
 SELECT * FROM t FOR SHARE NOWAIT
@@ -1249,6 +2597,17 @@ project
       ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
       └── locking: for-share,nowait
 
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT * FROM t FOR SHARE NOWAIT
+----
+lock t
+ ├── columns: a:1!null b:2
+ ├── locking: for-share,nowait
+ └── project
+      ├── columns: a:1!null b:2
+      └── scan t
+           └── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+
 build
 SELECT * FROM t FOR KEY SHARE NOWAIT
 ----
@@ -1257,6 +2616,17 @@ project
  └── scan t
       ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
       └── locking: for-key-share,nowait
+
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT * FROM t FOR KEY SHARE NOWAIT
+----
+lock t
+ ├── columns: a:1!null b:2
+ ├── locking: for-key-share,nowait
+ └── project
+      ├── columns: a:1!null b:2
+      └── scan t
+           └── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
 
 build
 SELECT * FROM t FOR KEY SHARE FOR SHARE NOWAIT
@@ -1267,6 +2637,20 @@ project
       ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
       └── locking: for-share,nowait
 
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT * FROM t FOR KEY SHARE FOR SHARE NOWAIT
+----
+lock t
+ ├── columns: a:1!null b:2
+ ├── locking: for-share,nowait
+ └── lock t
+      ├── columns: a:1!null b:2
+      ├── locking: for-key-share
+      └── project
+           ├── columns: a:1!null b:2
+           └── scan t
+                └── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+
 build
 SELECT * FROM t FOR KEY SHARE FOR SHARE NOWAIT FOR NO KEY UPDATE
 ----
@@ -1275,6 +2659,23 @@ project
  └── scan t
       ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
       └── locking: for-no-key-update,nowait
+
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT * FROM t FOR KEY SHARE FOR SHARE NOWAIT FOR NO KEY UPDATE
+----
+lock t
+ ├── columns: a:1!null b:2
+ ├── locking: for-no-key-update
+ └── lock t
+      ├── columns: a:1!null b:2
+      ├── locking: for-share,nowait
+      └── lock t
+           ├── columns: a:1!null b:2
+           ├── locking: for-key-share
+           └── project
+                ├── columns: a:1!null b:2
+                └── scan t
+                     └── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
 
 build
 SELECT * FROM t FOR KEY SHARE FOR SHARE NOWAIT FOR NO KEY UPDATE FOR UPDATE NOWAIT
@@ -1285,6 +2686,26 @@ project
       ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
       └── locking: for-update,nowait
 
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT * FROM t FOR KEY SHARE FOR SHARE NOWAIT FOR NO KEY UPDATE FOR UPDATE NOWAIT
+----
+lock t
+ ├── columns: a:1!null b:2
+ ├── locking: for-update,nowait
+ └── lock t
+      ├── columns: a:1!null b:2
+      ├── locking: for-no-key-update
+      └── lock t
+           ├── columns: a:1!null b:2
+           ├── locking: for-share,nowait
+           └── lock t
+                ├── columns: a:1!null b:2
+                ├── locking: for-key-share
+                └── project
+                     ├── columns: a:1!null b:2
+                     └── scan t
+                          └── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+
 build
 SELECT * FROM t FOR UPDATE OF t NOWAIT
 ----
@@ -1294,7 +2715,23 @@ project
       ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
       └── locking: for-update,nowait
 
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT * FROM t FOR UPDATE OF t NOWAIT
+----
+lock t
+ ├── columns: a:1!null b:2
+ ├── locking: for-update,nowait
+ └── project
+      ├── columns: a:1!null b:2
+      └── scan t
+           └── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+
 build
+SELECT * FROM t FOR UPDATE OF t2 NOWAIT
+----
+error (42P01): relation "t2" in FOR UPDATE clause not found in FROM clause
+
+build set=optimizer_use_lock_op_for_serializable=true
 SELECT * FROM t FOR UPDATE OF t2 NOWAIT
 ----
 error (42P01): relation "t2" in FOR UPDATE clause not found in FROM clause
@@ -1310,6 +2747,19 @@ project
  └── projections
       └── 1 [as="?column?":5]
 
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT 1 FROM t FOR UPDATE OF t NOWAIT
+----
+lock t
+ ├── columns: "?column?":5!null  [hidden: a:1!null]
+ ├── locking: for-update,nowait
+ └── project
+      ├── columns: "?column?":5!null a:1!null
+      ├── scan t
+      │    └── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+      └── projections
+           └── 1 [as="?column?":5]
+
 # ------------------------------------------------------------------------------
 # Tests with the SKIP LOCKED lock wait policy.
 # ------------------------------------------------------------------------------
@@ -1323,6 +2773,17 @@ project
       ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
       └── locking: for-update,skip-locked
 
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT * FROM t FOR UPDATE SKIP LOCKED
+----
+lock t
+ ├── columns: a:1!null b:2
+ ├── locking: for-update,skip-locked
+ └── project
+      ├── columns: a:1!null b:2
+      └── scan t
+           └── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+
 build
 SELECT * FROM t FOR NO KEY UPDATE SKIP LOCKED
 ----
@@ -1331,6 +2792,17 @@ project
  └── scan t
       ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
       └── locking: for-no-key-update,skip-locked
+
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT * FROM t FOR NO KEY UPDATE SKIP LOCKED
+----
+lock t
+ ├── columns: a:1!null b:2
+ ├── locking: for-no-key-update,skip-locked
+ └── project
+      ├── columns: a:1!null b:2
+      └── scan t
+           └── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
 
 build
 SELECT * FROM t FOR SHARE SKIP LOCKED
@@ -1341,6 +2813,17 @@ project
       ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
       └── locking: for-share,skip-locked
 
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT * FROM t FOR SHARE SKIP LOCKED
+----
+lock t
+ ├── columns: a:1!null b:2
+ ├── locking: for-share,skip-locked
+ └── project
+      ├── columns: a:1!null b:2
+      └── scan t
+           └── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+
 build
 SELECT * FROM t FOR KEY SHARE SKIP LOCKED
 ----
@@ -1349,6 +2832,17 @@ project
  └── scan t
       ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
       └── locking: for-key-share,skip-locked
+
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT * FROM t FOR KEY SHARE SKIP LOCKED
+----
+lock t
+ ├── columns: a:1!null b:2
+ ├── locking: for-key-share,skip-locked
+ └── project
+      ├── columns: a:1!null b:2
+      └── scan t
+           └── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
 
 build
 SELECT * FROM t FOR KEY SHARE FOR SHARE SKIP LOCKED
@@ -1359,6 +2853,20 @@ project
       ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
       └── locking: for-share,skip-locked
 
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT * FROM t FOR KEY SHARE FOR SHARE SKIP LOCKED
+----
+lock t
+ ├── columns: a:1!null b:2
+ ├── locking: for-share,skip-locked
+ └── lock t
+      ├── columns: a:1!null b:2
+      ├── locking: for-key-share
+      └── project
+           ├── columns: a:1!null b:2
+           └── scan t
+                └── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+
 build
 SELECT * FROM t FOR KEY SHARE FOR SHARE SKIP LOCKED FOR NO KEY UPDATE
 ----
@@ -1367,6 +2875,23 @@ project
  └── scan t
       ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
       └── locking: for-no-key-update,skip-locked
+
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT * FROM t FOR KEY SHARE FOR SHARE SKIP LOCKED FOR NO KEY UPDATE
+----
+lock t
+ ├── columns: a:1!null b:2
+ ├── locking: for-no-key-update
+ └── lock t
+      ├── columns: a:1!null b:2
+      ├── locking: for-share,skip-locked
+      └── lock t
+           ├── columns: a:1!null b:2
+           ├── locking: for-key-share
+           └── project
+                ├── columns: a:1!null b:2
+                └── scan t
+                     └── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
 
 build
 SELECT * FROM t FOR KEY SHARE FOR SHARE SKIP LOCKED FOR NO KEY UPDATE FOR UPDATE SKIP LOCKED
@@ -1377,6 +2902,26 @@ project
       ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
       └── locking: for-update,skip-locked
 
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT * FROM t FOR KEY SHARE FOR SHARE SKIP LOCKED FOR NO KEY UPDATE FOR UPDATE SKIP LOCKED
+----
+lock t
+ ├── columns: a:1!null b:2
+ ├── locking: for-update,skip-locked
+ └── lock t
+      ├── columns: a:1!null b:2
+      ├── locking: for-no-key-update
+      └── lock t
+           ├── columns: a:1!null b:2
+           ├── locking: for-share,skip-locked
+           └── lock t
+                ├── columns: a:1!null b:2
+                ├── locking: for-key-share
+                └── project
+                     ├── columns: a:1!null b:2
+                     └── scan t
+                          └── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+
 build
 SELECT * FROM t FOR UPDATE OF t SKIP LOCKED
 ----
@@ -1386,7 +2931,23 @@ project
       ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
       └── locking: for-update,skip-locked
 
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT * FROM t FOR UPDATE OF t SKIP LOCKED
+----
+lock t
+ ├── columns: a:1!null b:2
+ ├── locking: for-update,skip-locked
+ └── project
+      ├── columns: a:1!null b:2
+      └── scan t
+           └── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+
 build
+SELECT * FROM t FOR UPDATE OF t2 SKIP LOCKED
+----
+error (42P01): relation "t2" in FOR UPDATE clause not found in FROM clause
+
+build set=optimizer_use_lock_op_for_serializable=true
 SELECT * FROM t FOR UPDATE OF t2 SKIP LOCKED
 ----
 error (42P01): relation "t2" in FOR UPDATE clause not found in FROM clause
@@ -1402,13 +2963,36 @@ project
  └── projections
       └── 1 [as="?column?":5]
 
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT 1 FROM t FOR UPDATE OF t SKIP LOCKED
+----
+lock t
+ ├── columns: "?column?":5!null  [hidden: a:1!null]
+ ├── locking: for-update,skip-locked
+ └── project
+      ├── columns: "?column?":5!null a:1!null
+      ├── scan t
+      │    └── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+      └── projections
+           └── 1 [as="?column?":5]
+
 # SKIP LOCKED cannot be used with multiple column families.
 build
 SELECT 1 FROM families FOR UPDATE OF families SKIP LOCKED
 ----
 error (0A000): SKIP LOCKED cannot be used for tables with multiple column families
 
+build set=optimizer_use_lock_op_for_serializable=true
+SELECT 1 FROM families FOR UPDATE OF families SKIP LOCKED
+----
+error (0A000): SKIP LOCKED cannot be used for tables with multiple column families
+
 build
+SELECT 1 FROM families FOR SHARE SKIP LOCKED
+----
+error (0A000): SKIP LOCKED cannot be used for tables with multiple column families
+
+build set=optimizer_use_lock_op_for_serializable=true
 SELECT 1 FROM families FOR SHARE SKIP LOCKED
 ----
 error (0A000): SKIP LOCKED cannot be used for tables with multiple column families

--- a/pkg/sql/opt/ordering/mutation.go
+++ b/pkg/sql/opt/ordering/mutation.go
@@ -57,3 +57,22 @@ func mutationBuildProvided(expr memo.RelExpr, required *props.OrderingChoice) op
 	// Ensure that provided ordering only uses projected columns.
 	return remapProvided(provided, &fdset, expr.Relational().OutputCols)
 }
+
+func lockCanProvideOrdering(expr memo.RelExpr, required *props.OrderingChoice) bool {
+	// The lock operator can always pass through ordering to its input.
+	return true
+}
+
+func lockBuildChildReqOrdering(
+	parent memo.RelExpr, required *props.OrderingChoice, childIdx int,
+) props.OrderingChoice {
+	if childIdx != 0 {
+		return props.OrderingChoice{}
+	}
+	return *required
+}
+
+func lockBuildProvided(expr memo.RelExpr, required *props.OrderingChoice) opt.Ordering {
+	lock := expr.(*memo.LockExpr)
+	return lock.Input.ProvidedPhysical().Ordering
+}

--- a/pkg/sql/opt/ordering/ordering.go
+++ b/pkg/sql/opt/ordering/ordering.go
@@ -266,6 +266,11 @@ func init() {
 		buildChildReqOrdering: mutationBuildChildReqOrdering,
 		buildProvidedOrdering: mutationBuildProvided,
 	}
+	funcMap[opt.LockOp] = funcs{
+		canProvideOrdering:    lockCanProvideOrdering,
+		buildChildReqOrdering: lockBuildChildReqOrdering,
+		buildProvidedOrdering: lockBuildProvided,
+	}
 	funcMap[opt.ExplainOp] = funcs{
 		canProvideOrdering:    canNeverProvideOrdering,
 		buildChildReqOrdering: explainBuildChildReqOrdering,

--- a/pkg/sql/opt/xform/physical_props.go
+++ b/pkg/sql/opt/xform/physical_props.go
@@ -108,7 +108,7 @@ func BuildChildPhysicalProps(
 			}
 		}
 
-	case opt.IndexJoinOp:
+	case opt.IndexJoinOp, opt.LockOp:
 		// For an index join, every input row results in exactly one output row.
 		childProps.LimitHint = parentProps.LimitHint
 

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -435,7 +435,6 @@ message LocalOnlySessionData {
   // automatic retries to perform for statements in explicit READ COMMITTED
   // transactions that see a transaction retry error.
   int32 max_retries_for_read_committed = 110;
-
   // StrictDDLAtomicity causes errors when the client attempts DDL
   // operations inside an explicit txn and CockroachDB cannot
   // guarantee the DDL to be performed atomically.
@@ -448,10 +447,17 @@ message LocalOnlySessionData {
   // not occur any more (at the expense of disabling certain
   // forms of DDL inside explicit txns).
   bool strict_ddl_atomicity = 111 [(gogoproto.customname) = "StrictDDLAtomicity"];
-
   // UnsafeSettingInterlockKey needs to be set to a special string
   // before SET CLUSTER SETTING is allowed on an unsafe setting.
   string unsafe_setting_interlock_key = 113;
+  // OptimizerUseLockOpForSerializable, when true, instructs the optimizer to
+  // implement SELECT FOR UPDATE and SELECT FOR SHARE statements using the Lock
+  // operator under serializable isolation.
+  //
+  // For correctness, under weaker isolation levels the optimizer always
+  // implements SELECT FOR UPDATE and SELECT FOR SHARE using the Lock operator,
+  // regardless of this setting.
+  bool optimizer_use_lock_op_for_serializable = 114;
 
   ///////////////////////////////////////////////////////////////////////////
   // WARNING: consider whether a session parameter you're adding needs to  //

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -2947,6 +2947,23 @@ var varGen = map[string]sessionVar{
 		},
 		GlobalDefault: func(_ *settings.Values) string { return "" },
 	},
+
+	// CockroachDB extension.
+	`optimizer_use_lock_op_for_serializable`: {
+		GetStringVal: makePostgresBoolGetStringValFn(`optimizer_use_lock_op_for_serializable`),
+		Set: func(_ context.Context, m sessionDataMutator, s string) error {
+			b, err := paramparse.ParseBoolVar("optimizer_use_lock_op_for_serializable", s)
+			if err != nil {
+				return err
+			}
+			m.SetOptimizerUseLockOpForSerializable(b)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().OptimizerUseLockOpForSerializable), nil
+		},
+		GlobalDefault: globalFalse,
+	},
 }
 
 func ReplicationModeFromString(s string) (sessiondatapb.ReplicationMode, error) {


### PR DESCRIPTION
**execbuilder: change error message to match PostgreSQL**

Release note (sql change): Change the following error message:

```
statement error cannot execute FOR UPDATE in a read-only transaction
```

to this to match PostgreSQL:

```
statement error cannot execute SELECT FOR UPDATE in a read-only transaction
```

**opt: add lock operator**

Add a new implementation of `SELECT FOR UPDATE` and `SELECT FOR SHARE`
statements. Instead of locking during the initial row fetch, this new
implementation constructs a `Lock` operator on the top of the query plan
which performs the locking phase using a locking semi-join lookup.

During optbuilder we build plans with both `Lock` operators and
initial-row-fetch locking. During execbuilder we decide which
implementation to use based on the isolation level and whether
`optimizer_use_lock_op_for_serializable` is set. If the new
implementation is chosen, `Lock` operators become locking
semi-LookupJoins.

In some cases these new plans will have superfluous lookup joins. A
future PR will optimize away some of these superfluous lookup joins.

Fixes: #57031, #75457

Epic: CRDB-25322

Release note (sql change): Add a new session variable,
`optimizer_use_lock_op_for_serializable`, which when set enables a new
implementation of `SELECT FOR UPDATE`. This new implementation of
`SELECT FOR UPDATE` acquires row locks *after* any joins and filtering,
and always acquires row locks on the primary index of the table being
locked. This more closely matches `SELECT FOR UPDATE` behavior in
PostgreSQL, but at the cost of more round trips from gateway node to
replica leaseholder.

Under read committed isolation (and other isolation levels weaker than
serializable) we will always use this new implementation of `SELECT FOR
UPDATE` regardless of the value of
`optimizer_use_lock_op_for_serializable` to ensure correctness.