### PR TITLE
kv: speed up `TestNewVsInvariants` under race

### DIFF
--- a/pkg/kv/kvserver/gc/gc_random_test.go
+++ b/pkg/kv/kvserver/gc/gc_random_test.go
@@ -241,7 +241,11 @@ func BenchmarkRun(b *testing.B) {
 
 func TestNewVsInvariants(t *testing.T) {
 	ctx := context.Background()
-	const N = 100000
+	N := 100000
+	if util.RaceEnabled {
+		// Reduce the row count under race. Otherwise, the test takes >5m.
+		N /= 100
+	}
 
 	for _, tc := range []randomRunGCTestSpec{
 		{


### PR DESCRIPTION
The test regularly took about 7m under race. This commit drops down the size of the test under race so that it runs in about the same time as the non-race test.

Epic: None
Release note: None