### PR TITLE
roachtest: remove aws tag from restore test

### DIFF
--- a/pkg/cmd/roachtest/tests/restore.go
+++ b/pkg/cmd/roachtest/tests/restore.go
@@ -648,7 +648,6 @@ func registerRestore(r registry.Registry) {
 		Cluster:   r.MakeClusterSpec(10),
 		Benchmark: true,
 		Timeout:   withPauseTimeout,
-		Tags:      registry.Tags("aws"),
 
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			c.Put(ctx, t.Cockroach(), "./cockroach")


### PR DESCRIPTION
This was incorrectly added as part of backporting an older change.

Fixes: #111425
Release note: None

Release justification: test only change.