### PR TITLE
ttljob: increase test timeout

### DIFF
--- a/pkg/sql/ttl/ttljob/BUILD.bazel
+++ b/pkg/sql/ttl/ttljob/BUILD.bazel
@@ -56,13 +56,14 @@ go_library(
 
 go_test(
     name = "ttljob_test",
+    size = "large",
     srcs = [
         "main_test.go",
         "ttljob_processor_test.go",
         "ttljob_query_builder_test.go",
         "ttljob_test.go",
     ],
-    args = ["-test.timeout=295s"],
+    args = ["-test.timeout=895s"],
     exec_properties = {"Pool": "medium"},
     deps = [
         ":ttljob",


### PR DESCRIPTION
The stats in TeamCity show that the time it takes to run all the tests in this package can frequently get very close to the existing timeout.

fixes https://github.com/cockroachdb/cockroach/issues/111364
Release note: None