### PR TITLE
kv/gc: resolve abandoned replicated locks during MVCC GC

### DIFF
--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -793,14 +793,14 @@ func runDebugGCCmd(cmd *cobra.Command, args []string) error {
 
 	var rangeID roachpb.RangeID
 	gcTTL := 24 * time.Hour
-	intentAgeThreshold := gc.IntentAgeThreshold.Default()
-	intentBatchSize := gc.MaxIntentsPerCleanupBatch.Default()
+	lockAgeThreshold := gc.LockAgeThreshold.Default()
+	lockBatchSize := gc.MaxLocksPerCleanupBatch.Default()
 	txnCleanupThreshold := gc.TxnCleanupThreshold.Default()
 
 	if len(args) > 3 {
 		var err error
-		if intentAgeThreshold, err = parsePositiveDuration(args[3]); err != nil {
-			return errors.Wrapf(err, "unable to parse %v as intent age threshold", args[3])
+		if lockAgeThreshold, err = parsePositiveDuration(args[3]); err != nil {
+			return errors.Wrapf(err, "unable to parse %v as lock age threshold", args[3])
 		}
 	}
 	if len(args) > 2 {
@@ -865,9 +865,9 @@ func runDebugGCCmd(cmd *cobra.Command, args []string) error {
 			&desc, snap,
 			now, thresh,
 			gc.RunOptions{
-				IntentAgeThreshold:              intentAgeThreshold,
-				MaxIntentsPerIntentCleanupBatch: intentBatchSize,
-				TxnCleanupThreshold:             txnCleanupThreshold,
+				LockAgeThreshold:              lockAgeThreshold,
+				MaxLocksPerIntentCleanupBatch: lockBatchSize,
+				TxnCleanupThreshold:           txnCleanupThreshold,
 			},
 			gcTTL, gc.NoopGCer{},
 			func(_ context.Context, _ []roachpb.Lock) error { return nil },

--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -870,7 +870,7 @@ func runDebugGCCmd(cmd *cobra.Command, args []string) error {
 				TxnCleanupThreshold:             txnCleanupThreshold,
 			},
 			gcTTL, gc.NoopGCer{},
-			func(_ context.Context, _ []roachpb.Intent) error { return nil },
+			func(_ context.Context, _ []roachpb.Lock) error { return nil },
 			func(_ context.Context, _ *roachpb.Transaction) error { return nil },
 		)
 		if err != nil {

--- a/pkg/kv/kvserver/batcheval/cmd_query_resolved_timestamp.go
+++ b/pkg/kv/kvserver/batcheval/cmd_query_resolved_timestamp.go
@@ -69,8 +69,8 @@ func QueryResolvedTimestamp(
 	// (or until the GC runs). We cap the maximum size of this set to limit its
 	// cost, since this is all best-effort anyway.
 	st := cArgs.EvalCtx.ClusterSettings()
-	maxEncounteredIntents := gc.MaxIntentsPerCleanupBatch.Get(&st.SV)
-	maxEncounteredIntentKeyBytes := gc.MaxIntentKeyBytesPerCleanupBatch.Get(&st.SV)
+	maxEncounteredIntents := gc.MaxLocksPerCleanupBatch.Get(&st.SV)
+	maxEncounteredIntentKeyBytes := gc.MaxLockKeyBytesPerCleanupBatch.Get(&st.SV)
 	intentCleanupAge := QueryResolvedTimestampIntentCleanupAge.Get(&st.SV)
 	intentCleanupThresh := cArgs.EvalCtx.Clock().Now().Add(-intentCleanupAge.Nanoseconds(), 0)
 	minIntentTS, encounteredIntents, err := computeMinIntentTimestamp(

--- a/pkg/kv/kvserver/batcheval/cmd_query_resolved_timestamp_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_query_resolved_timestamp_test.go
@@ -192,8 +192,8 @@ func TestQueryResolvedTimestamp(t *testing.T) {
 			}
 
 			st := cluster.MakeTestingClusterSettings()
-			gc.MaxIntentsPerCleanupBatch.Override(ctx, &st.SV, cfg.maxEncounteredIntents)
-			gc.MaxIntentKeyBytesPerCleanupBatch.Override(ctx, &st.SV, cfg.maxEncounteredIntentKeyBytes)
+			gc.MaxLocksPerCleanupBatch.Override(ctx, &st.SV, cfg.maxEncounteredIntents)
+			gc.MaxLockKeyBytesPerCleanupBatch.Override(ctx, &st.SV, cfg.maxEncounteredIntentKeyBytes)
 			QueryResolvedTimestampIntentCleanupAge.Override(ctx, &st.SV, cfg.intentCleanupAge)
 
 			clock := hlc.NewClockForTesting(timeutil.NewManualTime(timeutil.Unix(0, 10)))

--- a/pkg/kv/kvserver/gc/BUILD.bazel
+++ b/pkg/kv/kvserver/gc/BUILD.bazel
@@ -53,6 +53,7 @@ go_test(
         "//pkg/kv/kvpb",
         "//pkg/kv/kvserver",
         "//pkg/kv/kvserver/concurrency/isolation",
+        "//pkg/kv/kvserver/concurrency/lock",
         "//pkg/kv/kvserver/rditer",
         "//pkg/roachpb",
         "//pkg/security/securityassets",

--- a/pkg/kv/kvserver/gc/gc_old_test.go
+++ b/pkg/kv/kvserver/gc/gc_old_test.go
@@ -58,8 +58,8 @@ func runGCOld(
 	})
 	defer iter.Close()
 
-	// Compute intent expiration (intent age at which we attempt to resolve).
-	intentExp := now.Add(-options.IntentAgeThreshold.Nanoseconds(), 0)
+	// Compute lock expiration (lock age at which we attempt to resolve).
+	lockExp := now.Add(-options.LockAgeThreshold.Nanoseconds(), 0)
 	txnExp := now.Add(-TxnCleanupThreshold.Default().Nanoseconds(), 0)
 
 	gc := makeGarbageCollector(now, gcTTL)
@@ -89,7 +89,7 @@ func runGCOld(
 	intentKeyMap := map[uuid.UUID][]roachpb.Key{}
 
 	// processKeysAndValues is invoked with each key and its set of
-	// values. Intents older than the intent age threshold are sent for
+	// values. Intents older than the lock age threshold are sent for
 	// resolution and values after the MVCC metadata, and possible
 	// intent, are sent for garbage collection.
 	processKeysAndValues := func() {
@@ -105,24 +105,24 @@ func runGCOld(
 				if meta.Txn != nil {
 					// Keep track of intent to resolve if older than the intent
 					// expiration threshold.
-					if meta.Timestamp.ToTimestamp().Less(intentExp) {
+					if meta.Timestamp.ToTimestamp().Less(lockExp) {
 						txnID := meta.Txn.ID
 						if _, ok := txnMap[txnID]; !ok {
 							txnMap[txnID] = &roachpb.Transaction{
 								TxnMeta: *meta.Txn,
 							}
-							// IntentTxns and PushTxn will be equal here, since
+							// LockTxns and PushTxn will be equal here, since
 							// pushes to transactions whose record lies in this
 							// range (but which are not associated to a remaining
 							// intent on it) happen asynchronously and are accounted
 							// for separately. Thus higher up in the stack, we
-							// expect PushTxn > IntentTxns.
-							info.IntentTxns++
+							// expect PushTxn > LockTxns.
+							info.LockTxns++
 							// All transactions in txnMap may be PENDING and
 							// cleanupIntentsFn will push them to finalize them.
 							info.PushTxn++
 						}
-						info.IntentsConsidered++
+						info.LocksConsidered++
 						intentKeyMap[txnID] = append(intentKeyMap[txnID], expBaseKey)
 					}
 					// With an active intent, GC ignores MVCC metadata & intent value.

--- a/pkg/kv/kvserver/gc/gc_old_test.go
+++ b/pkg/kv/kvserver/gc/gc_old_test.go
@@ -238,14 +238,14 @@ func runGCOld(
 
 	log.Eventf(ctx, "GC'ed keys; stats %+v", info)
 
-	// Push transactions (if pending) and resolve intents.
-	var intents []roachpb.Intent
+	// Push transactions (if pending) and resolve locks.
+	var locks []roachpb.Lock
 	for txnID, txn := range txnMap {
-		intents = append(intents, roachpb.AsIntents(&txn.TxnMeta, intentKeyMap[txnID])...)
+		locks = append(locks, roachpb.AsLocks(roachpb.AsIntents(&txn.TxnMeta, intentKeyMap[txnID]))...)
 	}
-	info.ResolveTotal += len(intents)
-	log.Eventf(ctx, "cleanup of %d intents", len(intents))
-	if err := cleanupIntentsFn(ctx, intents); err != nil {
+	info.ResolveTotal += len(locks)
+	log.Eventf(ctx, "cleanup of %d locks", len(locks))
+	if err := cleanupIntentsFn(ctx, locks); err != nil {
 		return Info{}, err
 	}
 

--- a/pkg/kv/kvserver/gc/gc_random_test.go
+++ b/pkg/kv/kvserver/gc/gc_random_test.go
@@ -96,7 +96,7 @@ var (
 	smallEngineBlocks = util.ConstantWithMetamorphicTestBool("small-engine-blocks", false)
 )
 
-const intentAgeThreshold = 2 * time.Hour
+const lockAgeThreshold = 2 * time.Hour
 const txnCleanupThreshold = time.Hour
 
 // TestRunNewVsOld exercises the behavior of Run relative to the old
@@ -111,10 +111,10 @@ func TestRunNewVsOld(t *testing.T) {
 			ds: someVersionsMidSizeRowsLotsOfIntents,
 			// Current time in the future enough for intents to get resolved
 			now: hlc.Timestamp{
-				WallTime: (intentAgeThreshold + 100*time.Second).Nanoseconds(),
+				WallTime: (lockAgeThreshold + 100*time.Second).Nanoseconds(),
 			},
 			// GC everything beyond intent resolution threshold
-			ttlSec: int32(intentAgeThreshold.Seconds()),
+			ttlSec: int32(lockAgeThreshold.Seconds()),
 		},
 		{
 			ds: someVersionsMidSizeRows,
@@ -140,7 +140,7 @@ func TestRunNewVsOld(t *testing.T) {
 			newThreshold := CalculateThreshold(tc.now, ttl)
 			gcInfoOld, err := runGCOld(ctx, tc.ds.desc(), snap, tc.now,
 				newThreshold, RunOptions{
-					IntentAgeThreshold:  intentAgeThreshold,
+					LockAgeThreshold:    lockAgeThreshold,
 					TxnCleanupThreshold: txnCleanupThreshold,
 				}, ttl,
 				&oldGCer,
@@ -151,7 +151,7 @@ func TestRunNewVsOld(t *testing.T) {
 			newGCer := makeFakeGCer()
 			gcInfoNew, err := Run(ctx, tc.ds.desc(), snap, tc.now,
 				newThreshold, RunOptions{
-					IntentAgeThreshold:  intentAgeThreshold,
+					LockAgeThreshold:    lockAgeThreshold,
 					TxnCleanupThreshold: txnCleanupThreshold,
 				}, ttl,
 				&newGCer,
@@ -179,13 +179,13 @@ func BenchmarkRun(b *testing.B) {
 		snap := eng.NewSnapshot()
 		defer snap.Close()
 		ttl := time.Duration(spec.ttlSec) * time.Second
-		intentThreshold := intentAgeThreshold
+		intentThreshold := lockAgeThreshold
 		if spec.intentAgeSec > 0 {
 			intentThreshold = time.Duration(spec.intentAgeSec) * time.Second
 		}
 		return runGCFunc(ctx, spec.ds.desc(), snap, spec.now,
 			CalculateThreshold(spec.now, ttl), RunOptions{
-				IntentAgeThreshold:  intentThreshold,
+				LockAgeThreshold:    intentThreshold,
 				TxnCleanupThreshold: txnCleanupThreshold,
 				ClearRangeMinKeys:   defaultClearRangeMinKeys,
 			},
@@ -252,10 +252,10 @@ func TestNewVsInvariants(t *testing.T) {
 			ds: someVersionsMidSizeRowsLotsOfIntents,
 			// Current time in the future enough for intents to get resolved
 			now: hlc.Timestamp{
-				WallTime: (intentAgeThreshold + 100*time.Second).Nanoseconds(),
+				WallTime: (lockAgeThreshold + 100*time.Second).Nanoseconds(),
 			},
 			// GC everything beyond intent resolution threshold
-			ttlSec: int32(intentAgeThreshold.Seconds()),
+			ttlSec: int32(lockAgeThreshold.Seconds()),
 		},
 		{
 			ds: someVersionsMidSizeRows,
@@ -342,12 +342,12 @@ func TestNewVsInvariants(t *testing.T) {
 			// Run GCer over snapshot.
 			ttl := time.Duration(tc.ttlSec) * time.Second
 			gcThreshold := CalculateThreshold(tc.now, ttl)
-			intentThreshold := tc.now.Add(-intentAgeThreshold.Nanoseconds(), 0)
+			intentThreshold := tc.now.Add(-lockAgeThreshold.Nanoseconds(), 0)
 
 			gcer := makeFakeGCer()
 			gcInfoNew, err := Run(ctx, desc, beforeGC, tc.now,
 				gcThreshold, RunOptions{
-					IntentAgeThreshold:  intentAgeThreshold,
+					LockAgeThreshold:    lockAgeThreshold,
 					TxnCleanupThreshold: txnCleanupThreshold,
 					ClearRangeMinKeys:   clearRangeMinKeys,
 				}, ttl,
@@ -617,10 +617,10 @@ func getExpectationsGenerator(
 						"failed to unmarshal txn metadata")
 					if meta.Timestamp.ToTimestamp().Less(intentThreshold) {
 						// This is an old intent. Skip intent with proposed value and continue.
-						expInfo.IntentsConsidered++
+						expInfo.LocksConsidered++
 						// We always use a new transaction for each intent and consider
 						// operations successful in testGCer.
-						expInfo.IntentTxns++
+						expInfo.LockTxns++
 						expInfo.PushTxn++
 						expInfo.ResolveTotal++
 					} else {

--- a/pkg/kv/kvserver/mvcc_gc_queue.go
+++ b/pkg/kv/kvserver/mvcc_gc_queue.go
@@ -657,7 +657,7 @@ func (r *replicaGCer) GC(
 // If it is safe to GC, process iterates through all keys in a replica's range,
 // calling the garbage collector for each key and associated set of
 // values. GC'd keys are batched into GC calls. Extant intents are resolved if
-// intents are older than intentAgeThreshold. The transaction and AbortSpan
+// intents are older than lockAgeThreshold. The transaction and AbortSpan
 // records are also scanned and old entries evicted. During normal operation,
 // both of these records are cleaned up when their respective transaction
 // finishes, so the amount of work done here is expected to be small.
@@ -734,9 +734,9 @@ func (mgcq *mvccGCQueue) process(
 	}
 	defer snap.Close()
 
-	intentAgeThreshold := gc.IntentAgeThreshold.Get(&repl.store.ClusterSettings().SV)
-	maxIntentsPerCleanupBatch := gc.MaxIntentsPerCleanupBatch.Get(&repl.store.ClusterSettings().SV)
-	maxIntentKeyBytesPerCleanupBatch := gc.MaxIntentKeyBytesPerCleanupBatch.Get(&repl.store.ClusterSettings().SV)
+	lockAgeThreshold := gc.LockAgeThreshold.Get(&repl.store.ClusterSettings().SV)
+	maxLocksPerCleanupBatch := gc.MaxLocksPerCleanupBatch.Get(&repl.store.ClusterSettings().SV)
+	maxLocksKeyBytesPerCleanupBatch := gc.MaxLockKeyBytesPerCleanupBatch.Get(&repl.store.ClusterSettings().SV)
 	txnCleanupThreshold := gc.TxnCleanupThreshold.Get(&repl.store.ClusterSettings().SV)
 	var clearRangeMinKeys int64 = 0
 	if repl.store.ClusterSettings().Version.IsActive(ctx, clusterversion.V23_1) {
@@ -745,13 +745,13 @@ func (mgcq *mvccGCQueue) process(
 
 	info, err := gc.Run(ctx, desc, snap, gcTimestamp, newThreshold,
 		gc.RunOptions{
-			IntentAgeThreshold:                     intentAgeThreshold,
-			MaxIntentsPerIntentCleanupBatch:        maxIntentsPerCleanupBatch,
-			MaxIntentKeyBytesPerIntentCleanupBatch: maxIntentKeyBytesPerCleanupBatch,
-			TxnCleanupThreshold:                    txnCleanupThreshold,
-			MaxTxnsPerIntentCleanupBatch:           intentresolver.MaxTxnsPerIntentCleanupBatch,
-			IntentCleanupBatchTimeout:              mvccGCQueueIntentBatchTimeout,
-			ClearRangeMinKeys:                      clearRangeMinKeys,
+			LockAgeThreshold:                     lockAgeThreshold,
+			MaxLocksPerIntentCleanupBatch:        maxLocksPerCleanupBatch,
+			MaxLockKeyBytesPerIntentCleanupBatch: maxLocksKeyBytesPerCleanupBatch,
+			TxnCleanupThreshold:                  txnCleanupThreshold,
+			MaxTxnsPerIntentCleanupBatch:         intentresolver.MaxTxnsPerIntentCleanupBatch,
+			IntentCleanupBatchTimeout:            mvccGCQueueIntentBatchTimeout,
+			ClearRangeMinKeys:                    clearRangeMinKeys,
 		},
 		conf.TTL(),
 		&replicaGCer{
@@ -840,8 +840,8 @@ func (mgcq *mvccGCQueue) process(
 func updateStoreMetricsWithGCInfo(metrics *StoreMetrics, info gc.Info) {
 	metrics.GCNumKeysAffected.Inc(int64(info.NumKeysAffected))
 	metrics.GCNumRangeKeysAffected.Inc(int64(info.NumRangeKeysAffected))
-	metrics.GCIntentsConsidered.Inc(int64(info.IntentsConsidered))
-	metrics.GCIntentTxns.Inc(int64(info.IntentTxns))
+	metrics.GCIntentsConsidered.Inc(int64(info.LocksConsidered))
+	metrics.GCIntentTxns.Inc(int64(info.LockTxns))
 	metrics.GCTransactionSpanScanned.Inc(int64(info.TransactionSpanTotal))
 	metrics.GCTransactionSpanGCAborted.Inc(int64(info.TransactionSpanGCAborted))
 	metrics.GCTransactionSpanGCCommitted.Inc(int64(info.TransactionSpanGCCommitted))

--- a/pkg/kv/kvserver/mvcc_gc_queue_test.go
+++ b/pkg/kv/kvserver/mvcc_gc_queue_test.go
@@ -670,18 +670,18 @@ func testMVCCGCQueueProcessImpl(t *testing.T, useEfos bool) {
 	defer stopper.Stop(ctx)
 	tc.Start(ctx, t, stopper)
 
-	const intentAgeThreshold = 2 * time.Hour
+	const lockAgeThreshold = 2 * time.Hour
 	const txnCleanupThreshold = time.Hour
 
 	tc.manualClock.Advance(48 * 60 * 60 * 1e9) // 2d past the epoch
 	now := tc.Clock().Now().WallTime
 
-	ts1 := makeTS(now-2*24*60*60*1e9+1, 0)                     // 2d old (add one nanosecond so we're not using zero timestamp)
-	ts2 := makeTS(now-25*60*60*1e9, 0)                         // GC will occur at time=25 hours
-	ts2m1 := ts2.Prev()                                        // ts2 - 1 so we have something not right at the GC time
-	ts3 := makeTS(now-intentAgeThreshold.Nanoseconds(), 0)     // 2h old
-	ts4 := makeTS(now-(intentAgeThreshold.Nanoseconds()-1), 0) // 2h-1ns old
-	ts5 := makeTS(now-1e9, 0)                                  // 1s old
+	ts1 := makeTS(now-2*24*60*60*1e9+1, 0)                   // 2d old (add one nanosecond so we're not using zero timestamp)
+	ts2 := makeTS(now-25*60*60*1e9, 0)                       // GC will occur at time=25 hours
+	ts2m1 := ts2.Prev()                                      // ts2 - 1 so we have something not right at the GC time
+	ts3 := makeTS(now-lockAgeThreshold.Nanoseconds(), 0)     // 2h old
+	ts4 := makeTS(now-(lockAgeThreshold.Nanoseconds()-1), 0) // 2h-1ns old
+	ts5 := makeTS(now-1e9, 0)                                // 1s old
 	mkKey := func(suff string) roachpb.Key {
 		var k roachpb.Key
 		k = append(k, keys.ScratchRangeMin...)
@@ -878,7 +878,7 @@ func testMVCCGCQueueProcessImpl(t *testing.T, useEfos bool) {
 		now := tc.Clock().Now()
 		newThreshold := gc.CalculateThreshold(now, conf.TTL())
 		return gc.Run(ctx, desc, snap, now, newThreshold, gc.RunOptions{
-			IntentAgeThreshold:  intentAgeThreshold,
+			LockAgeThreshold:    lockAgeThreshold,
 			TxnCleanupThreshold: txnCleanupThreshold,
 		},
 			conf.TTL(), gc.NoopGCer{},
@@ -1268,8 +1268,8 @@ func TestMVCCGCQueueIntentResolution(t *testing.T) {
 		newTransaction("txn1", roachpb.Key("0-0"), 1, tc.Clock()),
 		newTransaction("txn2", roachpb.Key("1-0"), 1, tc.Clock()),
 	}
-	intentAgeThreshold := gc.IntentAgeThreshold.Get(&tc.repl.store.ClusterSettings().SV)
-	intentResolveTS := makeTS(now-intentAgeThreshold.Nanoseconds(), 0)
+	lockAgeThreshold := gc.LockAgeThreshold.Get(&tc.repl.store.ClusterSettings().SV)
+	intentResolveTS := makeTS(now-lockAgeThreshold.Nanoseconds(), 0)
 	txns[0].ReadTimestamp = intentResolveTS
 	txns[0].WriteTimestamp = intentResolveTS
 	// The MinTimestamp is used by pushers that don't find a transaction record to

--- a/pkg/kv/kvserver/mvcc_gc_queue_test.go
+++ b/pkg/kv/kvserver/mvcc_gc_queue_test.go
@@ -882,7 +882,7 @@ func testMVCCGCQueueProcessImpl(t *testing.T, useEfos bool) {
 			TxnCleanupThreshold: txnCleanupThreshold,
 		},
 			conf.TTL(), gc.NoopGCer{},
-			func(ctx context.Context, intents []roachpb.Intent) error {
+			func(ctx context.Context, locks []roachpb.Lock) error {
 				return nil
 			},
 			func(ctx context.Context, txn *roachpb.Transaction) error {


### PR DESCRIPTION
Fixes #111215.

This PR teaches MVCC GC to resolve abandoned replicated locks of any strength, instead of just those with Intent strength. The change itself is a one-liner to adjust the MatchMinStr filter supplied to the LockTableIterator. It then includes a bit of type refactoring to use `roachpb.Lock` in place of `roachpb.Intent`.

In the second commit, this PR then performs a series of renames from "intent" to "lock" where appropriate in the `pkg/kv/kvserver/gc` package. However, it does not change all references to "intent". Notably, references to the "intent resolver" are retained, because that structure has not yet been renamed to account for its more general role of resolving locks with any strength.

Release note: None