### PR TITLE
sql: copy scanNode.spans for local flows of distributed plans

### DIFF
--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -995,7 +995,8 @@ type DistSQLReceiver struct {
 	testingKnobs struct {
 		// pushCallback, if set, will be called every time DistSQLReceiver.Push
 		// or DistSQLReceiver.PushBatch is called, with the same arguments.
-		pushCallback func(rowenc.EncDatumRow, coldata.Batch, *execinfrapb.ProducerMetadata)
+		// Possibly updated arguments are returned.
+		pushCallback func(rowenc.EncDatumRow, coldata.Batch, *execinfrapb.ProducerMetadata) (rowenc.EncDatumRow, coldata.Batch, *execinfrapb.ProducerMetadata)
 	}
 }
 
@@ -1440,7 +1441,7 @@ func (r *DistSQLReceiver) Push(
 ) execinfra.ConsumerStatus {
 	r.checkConcurrentError()
 	if r.testingKnobs.pushCallback != nil {
-		r.testingKnobs.pushCallback(row, nil /* batch */, meta)
+		row, _, meta = r.testingKnobs.pushCallback(row, nil /* batch */, meta)
 	}
 	if meta != nil {
 		return r.pushMeta(meta)
@@ -1521,7 +1522,7 @@ func (r *DistSQLReceiver) PushBatch(
 ) execinfra.ConsumerStatus {
 	r.checkConcurrentError()
 	if r.testingKnobs.pushCallback != nil {
-		r.testingKnobs.pushCallback(nil /* row */, batch, meta)
+		_, batch, meta = r.testingKnobs.pushCallback(nil /* row */, batch, meta)
 	}
 	if meta != nil {
 		return r.pushMeta(meta)

--- a/pkg/sql/distsql_running_test.go
+++ b/pkg/sql/distsql_running_test.go
@@ -610,14 +610,15 @@ func TestDistSQLReceiverDrainsMeta(t *testing.T) {
 			UseDatabase: "test",
 			Knobs: base.TestingKnobs{
 				SQLExecutor: &ExecutorTestingKnobs{
-					DistSQLReceiverPushCallbackFactory: func(query string) func(rowenc.EncDatumRow, coldata.Batch, *execinfrapb.ProducerMetadata) {
+					DistSQLReceiverPushCallbackFactory: func(query string) func(rowenc.EncDatumRow, coldata.Batch, *execinfrapb.ProducerMetadata) (rowenc.EncDatumRow, coldata.Batch, *execinfrapb.ProducerMetadata) {
 						if query != testQuery {
 							return nil
 						}
-						return func(_ rowenc.EncDatumRow, _ coldata.Batch, meta *execinfrapb.ProducerMetadata) {
+						return func(row rowenc.EncDatumRow, batch coldata.Batch, meta *execinfrapb.ProducerMetadata) (rowenc.EncDatumRow, coldata.Batch, *execinfrapb.ProducerMetadata) {
 							if meta != nil {
 								accumulatedMeta = append(accumulatedMeta, *meta)
 							}
+							return row, batch, meta
 						}
 					},
 				},

--- a/pkg/sql/distsql_running_test.go
+++ b/pkg/sql/distsql_running_test.go
@@ -1096,3 +1096,123 @@ func TestDistributedQueryErrorIsRetriedLocally(t *testing.T) {
 		require.True(t, strings.Contains(err.Error(), getError(nodeID).Error()))
 	}
 }
+
+// TestLogicalPlanCorruptionBeforeRetryingLocally verifies that if a distributed
+// query (that has a TableReader in the local flow) fails with such an error
+// that gets retried via the "retry-as-local" mechanism, the query still
+// produces the correct result. This is a regression test for #110712 which
+// occurred because of the logical plan corruption during the distributed plan
+// run (namely, scanNode.spans slice was being corrupted).
+func TestLogicalPlanCorruptionBeforeRetryingLocally(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	// Use a query such that
+	// - it is distributed (because it has a join)
+	// - it has a TableReader on the local node
+	// - that TableReader takes over the whole spans slice assigned to it
+	//   (because it has a LIMIT 1, so the spans aren't partitioned).
+	targetQuery := `WITH cte1 AS (SELECT job_id, details FROM job_info WHERE (job_id = 1) ORDER BY info_key DESC LIMIT 1)
+SELECT id, details FROM jobs AS j INNER JOIN cte1 ON id = job_id WHERE id = 1;
+`
+	errToInject := errors.Newf("connection refused: n2")
+	// Sanity check that this error will be treated as retryable for
+	// rerun-as-local mechanism.
+	require.True(t, pgerror.IsSQLRetryableError(errToInject))
+
+	// Create a three node cluster that has a special "push callback" which
+	// injects the error on the first call to DistSQLReceiver.PushBatch. This
+	// particular point during the execution is crucial for reproducing #110721:
+	// - the distributed physical planning has been performed,
+	// - all TableReaders have fetched some data,
+	// - any resume spans in the local TableReader would previously corrupt the
+	//   spans stored in the logical plan.
+	tc := serverutils.StartCluster(t, 3, base.TestClusterArgs{
+		ReplicationMode: base.ReplicationManual,
+		ServerArgs: base.TestServerArgs{
+			Knobs: base.TestingKnobs{
+				SQLExecutor: &ExecutorTestingKnobs{
+					DistSQLReceiverPushCallbackFactory: func(query string) func(rowenc.EncDatumRow, coldata.Batch, *execinfrapb.ProducerMetadata) (rowenc.EncDatumRow, coldata.Batch, *execinfrapb.ProducerMetadata) {
+						if !strings.HasPrefix(query, targetQuery[:20]) {
+							return nil
+						}
+						var injected bool
+						return func(row rowenc.EncDatumRow, batch coldata.Batch, meta *execinfrapb.ProducerMetadata) (rowenc.EncDatumRow, coldata.Batch, *execinfrapb.ProducerMetadata) {
+							if !injected {
+								// Inject the error only once so that when we
+								// retry the query as local, it succeeds.
+								row, batch = nil, nil
+								meta = &execinfrapb.ProducerMetadata{Err: errToInject}
+								injected = true
+							}
+							return row, batch, meta
+						}
+					},
+				},
+			},
+		}})
+	defer tc.Stopper().Stop(context.Background())
+
+	db := tc.ServerConn(0 /* idx */)
+	sqlDB := sqlutils.MakeSQLRunner(db)
+	sqlDB.Exec(t, "CREATE TABLE job_info(job_id INT, info_key INT, details INT, PRIMARY KEY (job_id, info_key));")
+	sqlDB.Exec(t, "CREATE TABLE jobs(id INT PRIMARY KEY);")
+	sqlDB.Exec(t, "INSERT INTO job_info VALUES (1, 1, 1);")
+	sqlDB.Exec(t, "INSERT INTO jobs VALUES (1);")
+	sqlDB.Exec(t, "ALTER TABLE job_info SPLIT AT VALUES (1, 1);")
+	sqlDB.Exec(t, "ALTER TABLE jobs SPLIT AT VALUES (1);")
+	sqlDB.Exec(t, "ALTER TABLE job_info EXPERIMENTAL_RELOCATE VALUES (ARRAY[1], 1, 1);")
+	sqlDB.Exec(t, "ALTER TABLE jobs EXPERIMENTAL_RELOCATE VALUES (ARRAY[2], 1);")
+
+	// Sanity check that the query gets the distributed plan as we expect.
+	//
+	// (Note that ideally we would have used EXPLAIN (DISTSQL) and compared the
+	// diagrams, but for some reason the encoded urls differ slightly between
+	// runs although visible diagrams remain the same, so we use EXPLAIN (VEC)
+	// below.)
+	expectedPlan := `
+│
+├ Node 1
+│ └ *colexec.ParallelUnorderedSynchronizer
+│   ├ *colrpc.Inbox
+│   └ *colexecjoin.mergeJoinInnerOp
+│     ├ *colrpc.Inbox
+│     └ *colflow.routerOutputOp
+│       └ *colflow.HashRouter
+│         └ *colexecsel.selEQInt64Int64ConstOp
+│           └ *colexec.limitOp
+│             └ *colfetcher.ColBatchScan
+└ Node 2
+  └ *colrpc.Outbox
+    └ *colexecjoin.mergeJoinInnerOp
+      ├ *colflow.routerOutputOp
+      │ └ *colflow.HashRouter
+      │   └ *colfetcher.ColBatchScan
+      └ *colrpc.Inbox
+`
+	expectedPlanRows := strings.Split(expectedPlan, "\n")
+	// Skip the first empty line.
+	expectedPlanRows = expectedPlanRows[1:]
+	// Make sure that "regular" ColBatchScans are used to make the output of
+	// EXPLAIN (VEC) constant.
+	sqlDB.Exec(t, "SET direct_columnar_scans_enabled = false")
+	actualPlanRows := sqlDB.QueryStr(t, "EXPLAIN (VEC) "+targetQuery)
+	for i, r := range actualPlanRows {
+		if expectedPlanRows[i] != r[0] {
+			var actualPlan string
+			for _, r := range actualPlanRows {
+				actualPlan += "\n" + r[0]
+			}
+			t.Fatalf("expected plan: %s\nactual plan: %s", expectedPlan, actualPlan)
+		}
+	}
+
+	// Now the meat of the test - run the query that gets an error injected
+	// during the distributed execution, then automatically is retried as local,
+	// and produces the correct output.
+	r := sqlDB.QueryRow(t, targetQuery)
+	var id, details int
+	r.Scan(&id, &details)
+	require.Equal(t, 1, id)
+	require.Equal(t, 1, details)
+}

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1603,8 +1603,9 @@ type ExecutorTestingKnobs struct {
 	// DistSQLReceiverPushCallbackFactory, if set, will be called every time a
 	// DistSQLReceiver is created for a new query execution, and it should
 	// return, possibly nil, a callback that will be called every time
-	// DistSQLReceiver.Push or DistSQLReceiver.PushBatch is called.
-	DistSQLReceiverPushCallbackFactory func(query string) func(rowenc.EncDatumRow, coldata.Batch, *execinfrapb.ProducerMetadata)
+	// DistSQLReceiver.Push or DistSQLReceiver.PushBatch is called. Possibly
+	// updated arguments are returned.
+	DistSQLReceiverPushCallbackFactory func(query string) func(rowenc.EncDatumRow, coldata.Batch, *execinfrapb.ProducerMetadata) (rowenc.EncDatumRow, coldata.Batch, *execinfrapb.ProducerMetadata)
 
 	// OnTxnRetry, if set, will be called if there is a transaction retry.
 	OnTxnRetry func(autoRetryReason error, evalCtx *eval.Context)

--- a/pkg/sql/importer/exportcsv_test.go
+++ b/pkg/sql/importer/exportcsv_test.go
@@ -611,14 +611,15 @@ func TestProcessorEncountersUncertaintyError(t *testing.T) {
 				0: {
 					Knobs: base.TestingKnobs{
 						SQLExecutor: &sql.ExecutorTestingKnobs{
-							DistSQLReceiverPushCallbackFactory: func(query string) func(rowenc.EncDatumRow, coldata.Batch, *execinfrapb.ProducerMetadata) {
+							DistSQLReceiverPushCallbackFactory: func(query string) func(rowenc.EncDatumRow, coldata.Batch, *execinfrapb.ProducerMetadata) (rowenc.EncDatumRow, coldata.Batch, *execinfrapb.ProducerMetadata) {
 								if strings.Contains(query, "EXPORT") {
-									return func(_ rowenc.EncDatumRow, _ coldata.Batch, meta *execinfrapb.ProducerMetadata) {
+									return func(row rowenc.EncDatumRow, batch coldata.Batch, meta *execinfrapb.ProducerMetadata) (rowenc.EncDatumRow, coldata.Batch, *execinfrapb.ProducerMetadata) {
 										if meta != nil && meta.Err != nil {
 											if testutils.IsError(meta.Err, "ReadWithinUncertaintyIntervalError") {
 												close(gotRWUIOnGateway)
 											}
 										}
+										return row, batch, meta
 									}
 								}
 								return nil


### PR DESCRIPTION
This commit makes it so that we perform a copy of `scanNode.spans` slice
when putting it into `TableReaderSpec` for local flows of distributed
plans. This prevents corruption of the logical plans (namely,
modification of `scanNode.spans`) that later could lead to incorrect
results in case the distributed query results in an error and is then
retried-as-local.

This corruption could occur because the following memory aliasing chain
is possible:
- `tableReaderPlanningInfo.spans` is set to `scanNode.spans` in
`DistSQLPlanner.createTableReaders`
- `SpanPartition.Spans` is set to `tableReaderPlanningInfo.spans`
directly in some cases in `DistSQLPlanner.planTableReaders`
- `TableReaderSpec.Spans` is set to `SpanPartition.Spans`
- `colBatchScanBase.SpansWithCopy.Spans` is set to
`TableReaderSpec.Spans`
- those spans are then passed as an argument to `cFetcher.StartScan`
which is then passed to `KVFetcher.SetupNextFetcher` and then to
`txnKVFetcher.SetupNextFetch`.

The contract of `SetupNextFetch` is such that the fetcher takes
ownership of the spans slice and can modify it as it pleases (it reuses
the slice for resume spans that are encountered during the fetch; this
has been the case for about two years and was done as a performance
optimization that we don't want to lose). (Note that the keys themselves
aren't mutated (which KV layer wouldn't approve of) - only
`[]roachpb.Span` slice can be changed.)

However, this modification of the spans can propagate all the way up to
the logical plan in some cases which (as of introducing the
retry-as-local mechanism) can lead to real problems. This commit
detects the scenario when this corruption would matter and allocates a
fresh slice for `TableReaderSpec.Spans`. In particular, this is done when
- the plan might be distributed (if it's local, the corruption will
still occur, but we don't care about that)
- the `SpanPartition` is assigned to the local node (for remote nodes
the spec will be serialized, thus, aliasing is not possible).

Note that we might copy the slice in more cases than strictly necessary,
but we choose to be a bit conservative here since this allocation
shouldn't matter that much for distributed queries in the grand scheme
of things.

(The bug is only present on master, so there is no release note.)

Fixes: #110712.

Release note: None