### PR TITLE
sql: fix nil-pointer error in local retry

### DIFF
--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -1243,7 +1243,9 @@ func (r *DistSQLReceiver) resetForLocalRerun(stats topLevelQueryStats) {
 	r.closed = false
 	r.stats = stats
 	r.egressCounter = nil
-	atomic.StoreUint64(r.progressAtomic, math.Float64bits(0))
+	if r.progressAtomic != nil {
+		atomic.StoreUint64(r.progressAtomic, math.Float64bits(0))
+	}
 }
 
 // Release releases this DistSQLReceiver back to the pool.

--- a/pkg/sql/logictest/testdata/logic_test/apply_join
+++ b/pkg/sql/logictest/testdata/logic_test/apply_join
@@ -665,3 +665,74 @@ CREATE MATERIALIZED VIEW v1 AS
             UNION
             SELECT aid, pid FROM cte2
         );
+
+# Regression test for #111327 - the query shouldn't cause a nil-pointer error.
+statement ok
+CREATE TYPE greeting AS ENUM ('hello', 'howdy', 'hi', 'good day', 'morning');
+
+statement ok
+CREATE TABLE IF NOT EXISTS seed AS
+SELECT
+  g :: INT2 AS _int2,
+  g :: INT4 AS _int4,
+  g :: INT8 AS _int8,
+  g :: FLOAT4 AS _float4,
+  g :: FLOAT8 AS _float8,
+  '2001-01-01' :: DATE + g AS _date,
+  '2001-01-01' :: TIMESTAMP + g * '1 day'::INTERVAL AS _timestamp,
+  '2001-01-01' :: TIMESTAMPTZ + g * '1 day'::INTERVAL AS _timestamptz,
+  g * '1 day' :: INTERVAL AS _interval,
+  g % 2 = 1 AS _bool,
+  g :: DECIMAL AS _decimal,
+  g :: STRING AS _string,
+  g :: STRING :: BYTES AS _bytes,
+  substring('00000000-0000-0000-0000-' || g :: STRING || '00000000000', 1, 36):: UUID AS _uuid,
+  '0.0.0.0' :: INET + g AS _inet,
+  g :: STRING :: JSONB AS _jsonb,
+  enum_range('hello' :: greeting) [g] as _enum
+FROM
+  generate_series(1, 5) AS g;
+
+statement ok
+INSERT INTO seed DEFAULT VALUES;
+
+statement ok
+CREATE INDEX on seed (_int8, _float8, _date);
+
+statement ok
+CREATE INVERTED INDEX on seed (_jsonb);
+
+skipif config local-mixed-23.1
+statement error pgcode 22P02 pq: pg_lsn\(\): invalid input syntax for type pg_lsn: \"1\"
+SELECT
+  tab378984.crdb_internal_mvcc_timestamp AS "%pcol857759",
+  '48 years 7 mons 894 days 13:39:26.674765':::INTERVAL AS col857760,
+  tab378983.tableoid AS "coL857761",
+  tab378983.crdb_internal_mvcc_timestamp AS col857762,
+  (SELECT (-4999644074744333745):::INT8 AS "co""l857763" LIMIT 1:::INT8) AS col857764,
+  tab378983._inet AS col857765,
+  '2011-06-28 16:37:44.000635+00':::TIMESTAMPTZ AS col857766,
+  tab378984._bool AS col857767,
+  tab378983.tableoid AS col857768,
+  tab378984._timestamptz AS col857769,
+  NULL AS "Co😽l857770",
+  tab378984._string AS "c)ol857771",
+  NULL AS col857772,
+  tab378983._int4 AS c🙃ol857773,
+  tab378984._interval AS " col857774",
+  tab378984.crdb_internal_mvcc_timestamp AS "c%69ol'857775"
+FROM
+  seed@seed__int8__float8__date_idx AS tab378983,
+  seed@[0] AS tab378984
+WHERE
+  (
+    true
+    AND (
+      '9E82DF40/BC8A8379':::PG_LSN::PG_LSN NOT IN (
+        SELECT pg_lsn(tab378984._string::STRING)::PG_LSN::PG_LSN AS col857758
+        FROM seed@[0] AS "%ptAb%v378985" WHERE "%ptAb%v378985"._bool LIMIT 22:::INT8
+      )
+    )
+  )
+ORDER BY tab378983._timestamptz ASC NULLS FIRST
+LIMIT 78:::INT8;

--- a/pkg/sql/logictest/testdata/logic_test/pg_lsn
+++ b/pkg/sql/logictest/testdata/logic_test/pg_lsn
@@ -4,12 +4,6 @@ SELECT 'A01F0/1AAA'::pg_lsn
 ----
 A01F0/1AAA
 
-statement error could not parse pg_lsn
-SELECT 'A/G'::pg_lsn
-
-statement error could not parse pg_lsn
-SELECT '0G'::pg_lsn
-
 statement ok
 CREATE TABLE pg_lsn_table(id pg_lsn PRIMARY KEY, val pg_lsn)
 
@@ -80,3 +74,22 @@ SELECT * FROM ( VALUES
 23021024706816
 18446744073709551615
 -18446744073709551615
+
+statement error pgcode 22P02 pq: invalid input syntax for type pg_lsn: \"A/G\"
+SELECT 'A/G'::pg_lsn
+
+statement error pgcode 22P02 pq: invalid input syntax for type pg_lsn: \"0G\"
+SELECT '0G'::pg_lsn
+
+statement error pgcode 22P02 pq: invalid input syntax for type pg_lsn: \"ab\"
+SELECT 'ab'::PG_LSN;
+
+statement error pgcode 22P02 pq: pg_lsn\(\): invalid input syntax for type pg_lsn: \"ab\"
+SELECT pg_lsn('ab');
+
+statement error pgcode 22P02 pq: invalid input syntax for type pg_lsn: \"1\"
+SELECT '1'::PG_LSN;
+
+statement error pgcode 22P02 pq: invalid input syntax for type pg_lsn: \"\"
+SELECT ''::PG_LSN;
+

--- a/pkg/sql/sem/tree/constant_test.go
+++ b/pkg/sql/sem/tree/constant_test.go
@@ -221,7 +221,8 @@ func TestStringConstantVerifyAvailableTypes(t *testing.T) {
 
 			semaCtx := tree.MakeSemaContext()
 			if _, err := test.c.ResolveAsType(context.Background(), &semaCtx, availType); err != nil {
-				if !strings.Contains(err.Error(), "could not parse") {
+				if !strings.Contains(err.Error(), "could not parse") &&
+					!strings.Contains(err.Error(), "invalid input syntax") {
 					// Parsing errors are permitted for this test, as proper tree.StrVal parsing
 					// is tested in TestStringConstantTypeResolution. Any other error should
 					// throw a failure.
@@ -693,7 +694,8 @@ func TestStringConstantResolveAvailableTypes(t *testing.T) {
 					if !strings.Contains(err.Error(), "could not parse") &&
 						!strings.Contains(err.Error(), "parsing") &&
 						!strings.Contains(err.Error(), "out of range") &&
-						!strings.Contains(err.Error(), "exceeds supported") {
+						!strings.Contains(err.Error(), "exceeds supported") &&
+						!strings.Contains(err.Error(), "invalid input syntax") {
 						// Parsing errors are permitted for this test, but the number of correctly
 						// parseable types will be verified. Any other error should throw a failure.
 						t.Errorf("%d: expected resolving %v as available type %s would either succeed"+

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -3629,7 +3629,9 @@ func NewDPGLSN(l lsn.LSN) *DPGLSN {
 func ParseDPGLSN(str string) (*DPGLSN, error) {
 	v, err := lsn.ParseLSN(str)
 	if err != nil {
-		return nil, errors.Wrapf(err, "could not parse pg_lsn")
+		return nil, pgerror.Newf(pgcode.InvalidTextRepresentation,
+			"invalid input syntax for type pg_lsn: \"%s\"", str,
+		)
 	}
 	return NewDPGLSN(v), nil
 }


### PR DESCRIPTION
#### tree: return correct parse error for pg_lsn

This patch changes the error returned upon failing to parse a PG_LSN
value to match postgres. Previously, the error was an internal error.

Informs #111327

Release note: None

#### sql: fix nil-pointer error in local retry

In #105451, we added logic to locally retry a distributed query
after an error. However, the retry logic unconditionally updated a
field of `DistSQLReceiver` that may be nil, which could cause a
nil-pointer error in some code paths (e.g. apply-join). This patch
adds a check that the field is non-nil, as is done for other places
where it is updated.

There is no release note because the change has not yet made it into
a release.

Fixes #111327

Release note: None