### PR TITLE
sql: switch DistSQLReceiver.status to using atomics

### DIFF
--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -625,12 +625,7 @@ func (dsp *DistSQLPlanner) setupFlows(
 					}
 					// First, we update the DistSQL receiver with the error to
 					// be returned to the client eventually.
-					//
-					// In order to not protect DistSQLReceiver.status with a
-					// mutex, we do not update the status here and, instead,
-					// rely on the DistSQLReceiver detecting the error the next
-					// time an object is pushed into it.
-					recv.setErrorWithoutStatusUpdate(res.err, true /* willDeferStatusUpdate */)
+					recv.SetError(res.err)
 					// Now explicitly cancel the local flow.
 					flow.Cancel()
 				}()
@@ -925,11 +920,9 @@ type DistSQLReceiver struct {
 		row   rowResultWriter
 		batch batchResultWriter
 	}
-	// updateStatus, if true, indicates that a concurrent goroutine has set an
-	// error on the rowResultWriter without updating status, so the main
-	// goroutine needs to update the status.
-	updateStatus atomic.Bool
-	status       execinfra.ConsumerStatus
+	// status is execinfra.ConsumerStatus of the receiver. It should not be
+	// accessed directly - use getStatus() and setStatus() helpers instead.
+	status atomic.Uint32
 
 	stmtType tree.StatementReturnType
 
@@ -997,6 +990,14 @@ type DistSQLReceiver struct {
 		// or DistSQLReceiver.PushBatch is called, with the same arguments.
 		pushCallback func(rowenc.EncDatumRow, coldata.Batch, *execinfrapb.ProducerMetadata)
 	}
+}
+
+func (r *DistSQLReceiver) getStatus() execinfra.ConsumerStatus {
+	return execinfra.ConsumerStatus(r.status.Load())
+}
+
+func (r *DistSQLReceiver) setStatus(s execinfra.ConsumerStatus) {
+	r.status.Store(uint32(s))
 }
 
 // rowResultWriter is a subset of CommandResult to be used with the
@@ -1236,8 +1237,7 @@ func MakeDistSQLReceiver(
 // fashion - locally.
 func (r *DistSQLReceiver) resetForLocalRerun(stats topLevelQueryStats) {
 	r.resultWriterMu.row.SetError(nil)
-	r.updateStatus.Store(false)
-	r.status = execinfra.NeedMoreRows
+	r.setStatus(execinfra.NeedMoreRows)
 	r.dataPushed = false
 	r.closed = false
 	r.stats = stats
@@ -1275,13 +1275,12 @@ func (r *DistSQLReceiver) getError() error {
 	return r.resultWriterMu.row.Err()
 }
 
-// setErrorWithoutStatusUpdate sets the error in the rowResultWriter but does
-// **not** update the status of the DistSQLReceiver. willDeferStatusUpdate
-// indicates whether the main goroutine should update the status the next time
-// it pushes something into the DistSQLReceiver.
+// SetError provides a convenient way for a client to pass in an error, thus
+// pretending that a query execution error happened. The error is passed along
+// to the resultWriter.
 //
-// NOTE: consider using SetError() instead.
-func (r *DistSQLReceiver) setErrorWithoutStatusUpdate(err error, willDeferStatusUpdate bool) {
+// The status of DistSQLReceiver is updated accordingly.
+func (r *DistSQLReceiver) SetError(err error) {
 	r.resultWriterMu.Lock()
 	defer r.resultWriterMu.Unlock()
 	// Check if the error we just received should take precedence over a
@@ -1306,47 +1305,16 @@ func (r *DistSQLReceiver) setErrorWithoutStatusUpdate(err error, willDeferStatus
 			}
 		}
 		r.resultWriterMu.row.SetError(err)
-		r.updateStatus.Store(willDeferStatusUpdate)
 	}
-}
-
-// updateStatusAfterError updates the status of the DistSQLReceiver after it
-// has received an error.
-func (r *DistSQLReceiver) updateStatusAfterError(err error) {
 	// If we encountered an error, we will transition to draining unless we were
 	// canceled.
 	if r.ctx.Err() != nil {
 		log.VEventf(r.ctx, 1, "encountered error (transitioning to shutting down): %v", r.ctx.Err())
-		r.status = execinfra.ConsumerClosed
+		r.setStatus(execinfra.ConsumerClosed)
 	} else {
 		log.VEventf(r.ctx, 1, "encountered error (transitioning to draining): %v", err)
-		r.status = execinfra.DrainRequested
+		r.setStatus(execinfra.DrainRequested)
 	}
-}
-
-// SetError provides a convenient way for a client to pass in an error, thus
-// pretending that a query execution error happened. The error is passed along
-// to the resultWriter.
-//
-// The status of DistSQLReceiver is updated accordingly.
-func (r *DistSQLReceiver) SetError(err error) {
-	r.setErrorWithoutStatusUpdate(err, false /* willDeferStatusUpdate */)
-	r.updateStatusAfterError(err)
-}
-
-// checkConcurrentError sets the status if an error has been set by another
-// goroutine that did not also update the status.
-func (r *DistSQLReceiver) checkConcurrentError() {
-	if r.status != execinfra.NeedMoreRows || !r.updateStatus.Load() {
-		// If the status already is not NeedMoreRows, then it doesn't matter if
-		// there was a concurrent error set.
-		return
-	}
-	previousErr := r.getError()
-	if previousErr == nil {
-		previousErr = errors.AssertionFailedf("unexpectedly updateStatus is set but there is no error")
-	}
-	r.updateStatusAfterError(previousErr)
 }
 
 // pushMeta takes in non-empty metadata object and pushes it to the result
@@ -1393,7 +1361,7 @@ func (r *DistSQLReceiver) pushMeta(meta *execinfrapb.ProducerMetadata) execinfra
 	}
 	// Release the meta object. It is unsafe for use after this call.
 	meta.Release()
-	return r.status
+	return r.getStatus()
 }
 
 // handleCommErr handles the communication error (the one returned when
@@ -1404,12 +1372,12 @@ func (r *DistSQLReceiver) handleCommErr(commErr error) {
 	// client (that's why we don't set the error on the resultWriter).
 	if errors.Is(commErr, ErrLimitedResultClosed) {
 		log.VEvent(r.ctx, 1, "encountered ErrLimitedResultClosed (transitioning to draining)")
-		r.status = execinfra.DrainRequested
+		r.setStatus(execinfra.DrainRequested)
 	} else if errors.Is(commErr, errIEResultChannelClosed) {
 		log.VEvent(r.ctx, 1, "encountered errIEResultChannelClosed (transitioning to draining)")
-		r.status = execinfra.DrainRequested
+		r.setStatus(execinfra.DrainRequested)
 	} else if errors.Is(commErr, ErrPortalLimitHasBeenReached) {
-		r.status = execinfra.SwitchToAnotherPortal
+		r.setStatus(execinfra.SwitchToAnotherPortal)
 	} else {
 		// Set the error on the resultWriter to notify the consumer about
 		// it. Most clients don't care to differentiate between
@@ -1438,18 +1406,17 @@ func (r *DistSQLReceiver) handleCommErr(commErr error) {
 func (r *DistSQLReceiver) Push(
 	row rowenc.EncDatumRow, meta *execinfrapb.ProducerMetadata,
 ) execinfra.ConsumerStatus {
-	r.checkConcurrentError()
 	if r.testingKnobs.pushCallback != nil {
 		r.testingKnobs.pushCallback(row, nil /* batch */, meta)
 	}
 	if meta != nil {
 		return r.pushMeta(meta)
 	}
-	if r.ctx.Err() != nil && r.status != execinfra.ConsumerClosed {
+	if r.ctx.Err() != nil && r.getStatus() != execinfra.ConsumerClosed {
 		r.SetError(r.ctx.Err())
 	}
-	if r.status != execinfra.NeedMoreRows {
-		return r.status
+	if status := r.getStatus(); status != execinfra.NeedMoreRows {
+		return status
 	}
 
 	if r.stmtType != tree.Rows {
@@ -1458,7 +1425,7 @@ func (r *DistSQLReceiver) Push(
 		// ensuring that the last stage in the pipeline will return a single-column
 		// row with the row count in it, so just grab that and exit.
 		r.resultWriterMu.row.SetRowsAffected(r.ctx, n)
-		return r.status
+		return r.getStatus()
 	}
 
 	ensureDecodedRow := func() error {
@@ -1478,11 +1445,11 @@ func (r *DistSQLReceiver) Push(
 	if r.isTenantExplainAnalyze {
 		if err := ensureDecodedRow(); err != nil {
 			r.SetError(err)
-			return r.status
+			return r.getStatus()
 		}
 		if len(r.row) != len(r.outputTypes) {
 			r.SetError(errors.Errorf("expected number of columns and output types to be the same"))
-			return r.status
+			return r.getStatus()
 		}
 		if r.egressCounter == nil {
 			r.egressCounter = NewTenantNetworkEgressCounter()
@@ -1492,7 +1459,7 @@ func (r *DistSQLReceiver) Push(
 
 	if r.discardRows {
 		// Discard rows.
-		return r.status
+		return r.getStatus()
 	}
 
 	if r.existsMode {
@@ -1500,11 +1467,11 @@ func (r *DistSQLReceiver) Push(
 		// row is pushed or not, so the contents do not matter.
 		r.row = []tree.Datum{}
 		log.VEvent(r.ctx, 2, `a row is pushed in "exists" mode, so transition to draining`)
-		r.status = execinfra.DrainRequested
+		r.setStatus(execinfra.DrainRequested)
 	} else {
 		if err := ensureDecodedRow(); err != nil {
 			r.SetError(err)
-			return r.status
+			return r.getStatus()
 		}
 	}
 	r.tracing.TraceExecRowsResult(r.ctx, r.row)
@@ -1512,30 +1479,29 @@ func (r *DistSQLReceiver) Push(
 		r.handleCommErr(commErr)
 	}
 	r.dataPushed = true
-	return r.status
+	return r.getStatus()
 }
 
 // PushBatch is part of the execinfra.BatchReceiver interface.
 func (r *DistSQLReceiver) PushBatch(
 	batch coldata.Batch, meta *execinfrapb.ProducerMetadata,
 ) execinfra.ConsumerStatus {
-	r.checkConcurrentError()
 	if r.testingKnobs.pushCallback != nil {
 		r.testingKnobs.pushCallback(nil /* row */, batch, meta)
 	}
 	if meta != nil {
 		return r.pushMeta(meta)
 	}
-	if r.ctx.Err() != nil && r.status != execinfra.ConsumerClosed {
+	if r.ctx.Err() != nil && r.getStatus() != execinfra.ConsumerClosed {
 		r.SetError(r.ctx.Err())
 	}
-	if r.status != execinfra.NeedMoreRows {
-		return r.status
+	if status := r.getStatus(); status != execinfra.NeedMoreRows {
+		return status
 	}
 
 	if batch.Length() == 0 {
 		// Nothing to do on the zero-length batch.
-		return r.status
+		return r.getStatus()
 	}
 
 	if r.stmtType != tree.Rows {
@@ -1543,7 +1509,7 @@ func (r *DistSQLReceiver) PushBatch(
 		// ensuring that the last stage in the pipeline will return a single-column
 		// row with the row count in it, so just grab that and exit.
 		r.resultWriterMu.row.SetRowsAffected(r.ctx, int(batch.ColVec(0).Int64()[0]))
-		return r.status
+		return r.getStatus()
 	}
 
 	if r.isTenantExplainAnalyze {
@@ -1555,7 +1521,7 @@ func (r *DistSQLReceiver) PushBatch(
 
 	if r.discardRows {
 		// Discard rows.
-		return r.status
+		return r.getStatus()
 	}
 
 	if r.existsMode {
@@ -1568,7 +1534,7 @@ func (r *DistSQLReceiver) PushBatch(
 		r.handleCommErr(commErr)
 	}
 	r.dataPushed = true
-	return r.status
+	return r.getStatus()
 }
 
 var (


### PR DESCRIPTION
This commit switches `DistSQLReceiver.status` to use the atomic instead
of having a delayed update. The access to this field needs to be
synchronized as of https://github.com/cockroachdb/cockroach/commit/0c1095e31cf93ea7f177f8bf1750ebab188e02d7 which
introduced a way for a concurrent goroutine to set an error on the
receiver. That commit implemented it by deferring the status update to
the main goroutine in order to not protect the status field by a mutex
(for performance reasons), but using the atomic should be quick enough
to be negligible in comparison to no synchronization and deferred
update. In return, this commit simplifies the code a bit.

The worse performance hit could be observed when we have a simple
`SELECT *` query, and the microbenchmarks don't show any difference
```
name                                   old time/op    new time/op    delta
Scan/Cockroach/count=10000/limit=0-24    3.91ms ± 3%    3.90ms ± 1%   ~     (p=0.631 n=10+10)

name                                   old alloc/op   new alloc/op   delta
Scan/Cockroach/count=10000/limit=0-24    1.30MB ± 8%    1.31MB ± 7%   ~     (p=0.579 n=10+10)

name                                   old allocs/op  new allocs/op  delta
Scan/Cockroach/count=10000/limit=0-24     10.4k ± 3%     10.4k ± 2%   ~     (p=0.523 n=8+8)
```
confirming no perf impact. Full benchmark run is available
[here](https://gist.github.com/yuzefovich/de6c153edaf21bc23e84193b6dc20dee).

Epic: None

Release note: None