### PR TITLE
roachpb: optimize Spans.MemUsage

### DIFF
--- a/pkg/roachpb/BUILD.bazel
+++ b/pkg/roachpb/BUILD.bazel
@@ -34,6 +34,7 @@ go_library(
         "//pkg/util",
         "//pkg/util/admission/admissionpb",
         "//pkg/util/bitarray",
+        "//pkg/util/buildutil",
         "//pkg/util/duration",
         "//pkg/util/encoding",
         "//pkg/util/hlc",

--- a/pkg/roachpb/data_test.go
+++ b/pkg/roachpb/data_test.go
@@ -1441,15 +1441,9 @@ func TestSpansMemUsage(t *testing.T) {
 			s[j].Key = []byte(test.spans[j].start)
 			s[j].EndKey = []byte(test.spans[j].end)
 		}
-		for j := 0; j <= len(s); j++ {
-			// Test that we account for all memory used even when we reduce the length
-			// below the capacity.
-			reduced := s[:j]
-
-			if actual := reduced.MemUsage(); test.expected != actual {
-				t.Errorf("%d.%d: expected spans %v (sliced from %v) to return %d for MemUsage, instead got %d",
-					i, j, reduced, test.spans, test.expected, actual)
-			}
+		if actual := s.MemUsageUpToLen(); test.expected != actual {
+			t.Errorf("%d: expected spans %v to return %d for MemUsageUpToLen, instead got %d",
+				i, test.spans, test.expected, actual)
 		}
 	}
 }

--- a/pkg/sql/colexec/colexecutils/utils.go
+++ b/pkg/sql/colexec/colexecutils/utils.go
@@ -327,7 +327,7 @@ func AccountForMetadata(allocator *colmem.Allocator, meta []execinfrapb.Producer
 		// Perform the memory accounting for the LeafTxnFinalState metadata
 		// since it might be of non-trivial size.
 		if ltfs := meta[i].LeafTxnFinalState; ltfs != nil {
-			memUsage := roachpb.Spans(ltfs.RefreshSpans).MemUsage()
+			memUsage := roachpb.Spans(ltfs.RefreshSpans).MemUsageUpToLen()
 			allocator.AdjustMemoryUsageAfterAllocation(memUsage)
 		}
 	}

--- a/pkg/sql/colfetcher/colbatch_scan.go
+++ b/pkg/sql/colfetcher/colbatch_scan.go
@@ -183,7 +183,7 @@ func newColBatchScanBase(
 		// (because the cFetcher requires that its allocator is not shared with
 		// any other component), but we can use the memory account of the KV
 		// fetcher.
-		if err = kvFetcherMemAcc.Grow(ctx, s.Spans.MemUsage()); err != nil {
+		if err = kvFetcherMemAcc.Grow(ctx, s.Spans.MemUsageUpToLen()); err != nil {
 			return nil, nil, nil, err
 		}
 		s.MakeSpansCopy()

--- a/pkg/sql/row/kv_batch_fetcher.go
+++ b/pkg/sql/row/kv_batch_fetcher.go
@@ -491,7 +491,7 @@ func (f *txnKVFetcher) SetupNextFetch(
 
 	// Account for the memory of the spans that we're taking the ownership of.
 	if f.acc != nil {
-		newSpansAccountedFor := spans.MemUsage()
+		newSpansAccountedFor := spans.MemUsageUpToLen()
 		if err := f.acc.Grow(ctx, newSpansAccountedFor); err != nil {
 			return err
 		}
@@ -846,7 +846,7 @@ func (f *txnKVFetcher) nextBatch(ctx context.Context) (resp KVBatchFetcherRespon
 		// We have some resume spans.
 		f.spans = f.scratchSpans
 		if f.acc != nil {
-			newSpansMemUsage := f.spans.MemUsage()
+			newSpansMemUsage := f.spans.MemUsageUpToLen()
 			if err := f.acc.Resize(ctx, f.spansAccountedFor, newSpansMemUsage); err != nil {
 				return KVBatchFetcherResponse{}, err
 			}


### PR DESCRIPTION
In `Spans.MemUsage` I think we can assume that spans past the length (i.e. in `[len, cap]` range) are empty, so we can optimize `MemUsage` function a bit. This is also now enforced in the test builds.

Epic: None

Release note: None