### PR TITLE
plpgsql: integrate exception-handling with the OPEN statement

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/plpgsql_cursor
+++ b/pkg/sql/logictest/testdata/logic_test/plpgsql_cursor
@@ -302,20 +302,6 @@ CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$
   END
 $$ LANGUAGE PLpgSQL;
 
-statement error pgcode 0A000 pq: unimplemented: opening a cursor in a routine with an exception block is not yet supported
-CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$
-  DECLARE
-    curs STRING;
-  BEGIN
-    OPEN curs FOR SELECT 1;
-    RETURN 0;
-  EXCEPTION
-    WHEN division_by_zero THEN
-      RETURN -1;
-  END
-$$ LANGUAGE PLpgSQL;
-BEGIN;
-
 statement ok
 CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$
   DECLARE
@@ -952,3 +938,218 @@ ABORT;
 # Test attempting to CLOSE a nonexistent cursor.
 statement error pgcode 34000 pq: cursor \"foo\" does not exist
 SELECT f('foo');
+
+# Testing cursors with exception handling.
+#
+# Cursors are allowed in routines with an exception block.
+statement ok
+CREATE OR REPLACE FUNCTION f(n INT) RETURNS INT AS $$
+  DECLARE
+    curs CURSOR FOR SELECT 100;
+  BEGIN
+    curs := 'foo' || n::STRING;
+    OPEN curs;
+    RETURN 1 // n;
+  EXCEPTION
+    WHEN division_by_zero THEN
+      RETURN -1;
+  END
+$$ LANGUAGE PLpgSQL;
+BEGIN;
+
+# Successful cursor creation.
+query I
+SELECT f(1);
+----
+1
+
+query I
+FETCH foo1;
+----
+100
+
+# The cursor should be rolled back.
+query I
+SELECT f(0);
+----
+-1
+
+statement error pgcode 34000 pq: cursor \"foo0\" does not exist
+FETCH foo0;
+
+# The cursors opened within a block should be closed before exception-handling.
+statement ok
+ABORT;
+DROP FUNCTION f();
+CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$
+  DECLARE
+    curs CURSOR FOR SELECT 1;
+  BEGIN
+    curs := 'foo';
+    OPEN curs;
+    RAISE NOTICE '%', (SELECT array_agg(name) FROM pg_cursors)::STRING;
+    RETURN 1 // 0;
+  EXCEPTION
+    WHEN division_by_zero THEN
+      RAISE NOTICE '%', (SELECT array_agg(name) FROM pg_cursors)::STRING;
+      RETURN -1;
+  END
+$$ LANGUAGE PLpgSQL;
+
+query T noticetrace
+SELECT f();
+----
+NOTICE: {foo}
+NOTICE: <NULL>
+
+statement error pgcode 34000 pq: cursor \"foo\" does not exist
+FETCH foo;
+
+# The exception block can catch an error thrown as the cursor is being opened.
+statement ok
+BEGIN;
+DECLARE dup CURSOR FOR SELECT 0;
+
+statement ok
+CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$
+  DECLARE
+    curs STRING := 'foo';
+    curs2 STRING := 'dup';
+  BEGIN
+    OPEN curs FOR SELECT 100;
+    OPEN curs2 FOR SELECT 200;
+  EXCEPTION
+    WHEN duplicate_cursor THEN
+      RETURN -1;
+  END
+$$ LANGUAGE PLpgSQL;
+
+query I
+SELECT f();
+----
+-1
+
+# The first cursor should have been rolled back, but the original 'dup' cursor
+# should still be open.
+query T
+SELECT name FROM pg_cursors;
+----
+dup
+
+query I
+FETCH 3 FROM dup;
+----
+0
+
+# The exception handler can catch an error thrown as the cursor executes.
+statement ok
+ABORT;
+CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$
+  DECLARE
+    curs STRING := 'foo';
+  BEGIN
+    OPEN curs FOR SELECT 1 // 0;
+  EXCEPTION
+    WHEN division_by_zero THEN
+      RETURN -1;
+  END
+$$ LANGUAGE PLpgSQL;
+BEGIN;
+
+query I
+SELECT f();
+----
+-1
+
+# The cursor should have been rolled back (or not created in the first place).
+statement error pgcode 34000 pq: cursor \"foo\" does not exist
+FETCH foo;
+
+# It is possible to open a cursor within the exception block.
+statement ok
+ABORT;
+CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$
+  DECLARE
+    curs STRING := 'foo';
+  BEGIN
+    OPEN curs FOR SELECT 1;
+    RETURN 1 // 0;
+  EXCEPTION
+    WHEN division_by_zero THEN
+      OPEN curs FOR SELECT 2;
+      RETURN -1;
+  END
+$$ LANGUAGE PLpgSQL;
+BEGIN;
+
+query I
+SELECT f();
+----
+-1
+
+# Should retrieve "2" from the second OPEN.
+query I
+FETCH 3 FROM foo;
+----
+2
+
+# The exception handler should not catch a duplicate cursor error thrown from
+# within the exception handler itself.
+statement ok
+ABORT;
+BEGIN;
+DECLARE dup CURSOR FOR SELECT 0;
+
+statement ok
+CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$
+  DECLARE
+    curs STRING := 'foo';
+    curs2 STRING := 'dup';
+  BEGIN
+    OPEN curs FOR SELECT 100;
+    RETURN 1 // 0;
+  EXCEPTION
+    WHEN division_by_zero THEN
+      OPEN curs2 FOR SELECT 300;
+    WHEN duplicate_cursor THEN
+      RETURN -1;
+  END
+$$ LANGUAGE PLpgSQL;
+
+statement error pgcode 42P03 pq: cursor \"dup\" already exists
+SELECT f();
+
+# Case where the cursor is opened and then closed before control reaches teh
+# exception handler.
+statement ok
+ABORT;
+CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$
+  DECLARE
+    curs STRING := 'foo';
+  BEGIN
+    OPEN curs FOR SELECT * FROM (VALUES (100), (200), (300));
+    RAISE NOTICE 'opened %', (SELECT array_agg(name) FROM pg_cursors)::STRING;
+    CLOSE curs;
+    RAISE NOTICE 'closed %', (SELECT array_agg(name) FROM pg_cursors)::STRING;
+    RETURN 1 // 0;
+  EXCEPTION
+    WHEN division_by_zero THEN
+      RAISE NOTICE 'exception %', (SELECT array_agg(name) FROM pg_cursors)::STRING;
+      RETURN -1;
+  END
+$$ LANGUAGE PLpgSQL;
+BEGIN;
+
+query T noticetrace
+SELECT f();
+----
+NOTICE: opened {foo}
+NOTICE: closed <NULL>
+NOTICE: exception <NULL>
+
+query T
+SELECT name FROM pg_cursors;
+----
+
+statement ok
+ABORT;

--- a/pkg/sql/opt/optbuilder/plpgsql.go
+++ b/pkg/sql/opt/optbuilder/plpgsql.go
@@ -528,11 +528,6 @@ func (b *plpgsqlBuilder) buildPLpgSQLStatements(stmts []ast.Statement, s *scope)
 			// This is handled by calling the plpgsql_open_cursor internal builtin
 			// function in a separate body statement that returns no results, similar
 			// to the RAISE implementation.
-			if b.hasExceptionBlock {
-				panic(unimplemented.New("open with exception block",
-					"opening a cursor in a routine with an exception block is not yet supported",
-				))
-			}
 			if t.Scroll == tree.Scroll {
 				panic(unimplemented.NewWithIssue(77102, "DECLARE SCROLL CURSOR"))
 			}

--- a/pkg/sql/opt/optbuilder/testdata/udf_plpgsql
+++ b/pkg/sql/opt/optbuilder/testdata/udf_plpgsql
@@ -5109,3 +5109,141 @@ project
                      │                                                                └── projections
                      │                                                                     └── const: 0 [as=stmt_return_4:6, type=int]
                      └── const: 1 [type=int]
+
+# Combined exception block and cursors.
+exec-ddl
+CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$
+  DECLARE
+    curs STRING := 'foo';
+  BEGIN
+    OPEN curs FOR SELECT 1;
+    RETURN 1 // 0;
+  EXCEPTION
+    WHEN division_by_zero THEN
+      OPEN curs FOR SELECT 2;
+      RETURN -1;
+  END
+$$ LANGUAGE PLpgSQL;
+----
+
+build format=show-scalars
+SELECT f();
+----
+project
+ ├── columns: f:19
+ ├── values
+ │    └── tuple
+ └── projections
+      └── udf: f [as=f:19]
+           └── body
+                └── limit
+                     ├── columns: exception_block_5:18
+                     ├── project
+                     │    ├── columns: exception_block_5:18
+                     │    ├── project
+                     │    │    ├── columns: curs:1!null
+                     │    │    ├── values
+                     │    │    │    └── tuple
+                     │    │    └── projections
+                     │    │         └── const: 'foo' [as=curs:1]
+                     │    └── projections
+                     │         └── udf: exception_block_5 [as=exception_block_5:18]
+                     │              ├── args
+                     │              │    └── variable: curs:1
+                     │              ├── params: curs:10
+                     │              ├── body
+                     │              │    └── project
+                     │              │         ├── columns: "_gen_cursor_name_8":17
+                     │              │         ├── values
+                     │              │         │    └── tuple
+                     │              │         └── projections
+                     │              │              └── udf: _gen_cursor_name_8 [as="_gen_cursor_name_8":17]
+                     │              │                   ├── args
+                     │              │                   │    └── variable: curs:10
+                     │              │                   ├── params: curs:14
+                     │              │                   └── body
+                     │              │                        └── project
+                     │              │                             ├── columns: "_stmt_open_6":16
+                     │              │                             ├── project
+                     │              │                             │    ├── columns: curs:15
+                     │              │                             │    ├── values
+                     │              │                             │    │    └── tuple
+                     │              │                             │    └── projections
+                     │              │                             │         └── case [as=curs:15]
+                     │              │                             │              ├── true
+                     │              │                             │              ├── when
+                     │              │                             │              │    ├── is
+                     │              │                             │              │    │    ├── variable: curs:14
+                     │              │                             │              │    │    └── null
+                     │              │                             │              │    └── function: crdb_internal.plpgsql_gen_cursor_name
+                     │              │                             │              │         └── variable: curs:14
+                     │              │                             │              └── variable: curs:14
+                     │              │                             └── projections
+                     │              │                                  └── udf: _stmt_open_6 [as="_stmt_open_6":16]
+                     │              │                                       ├── args
+                     │              │                                       │    └── variable: curs:15
+                     │              │                                       ├── params: curs:11
+                     │              │                                       └── body
+                     │              │                                            ├── open-cursor
+                     │              │                                            │    └── project
+                     │              │                                            │         ├── columns: "?column?":12!null
+                     │              │                                            │         ├── values
+                     │              │                                            │         │    └── tuple
+                     │              │                                            │         └── projections
+                     │              │                                            │              └── const: 1 [as="?column?":12]
+                     │              │                                            └── project
+                     │              │                                                 ├── columns: stmt_return_7:13!null
+                     │              │                                                 ├── values
+                     │              │                                                 │    └── tuple
+                     │              │                                                 └── projections
+                     │              │                                                      └── floor-div [as=stmt_return_7:13]
+                     │              │                                                           ├── const: 1
+                     │              │                                                           └── const: 0
+                     │              └── exception-handler
+                     │                   └── SQLSTATE '22012'
+                     │                        └── project
+                     │                             ├── columns: "_gen_cursor_name_4":9
+                     │                             ├── values
+                     │                             │    └── tuple
+                     │                             └── projections
+                     │                                  └── udf: _gen_cursor_name_4 [as="_gen_cursor_name_4":9]
+                     │                                       ├── args
+                     │                                       │    └── variable: curs:2
+                     │                                       ├── params: curs:6
+                     │                                       └── body
+                     │                                            └── project
+                     │                                                 ├── columns: "_stmt_open_2":8
+                     │                                                 ├── project
+                     │                                                 │    ├── columns: curs:7
+                     │                                                 │    ├── values
+                     │                                                 │    │    └── tuple
+                     │                                                 │    └── projections
+                     │                                                 │         └── case [as=curs:7]
+                     │                                                 │              ├── true
+                     │                                                 │              ├── when
+                     │                                                 │              │    ├── is
+                     │                                                 │              │    │    ├── variable: curs:6
+                     │                                                 │              │    │    └── null
+                     │                                                 │              │    └── function: crdb_internal.plpgsql_gen_cursor_name
+                     │                                                 │              │         └── variable: curs:6
+                     │                                                 │              └── variable: curs:6
+                     │                                                 └── projections
+                     │                                                      └── udf: _stmt_open_2 [as="_stmt_open_2":8]
+                     │                                                           ├── args
+                     │                                                           │    └── variable: curs:7
+                     │                                                           ├── params: curs:3
+                     │                                                           └── body
+                     │                                                                ├── open-cursor
+                     │                                                                │    └── project
+                     │                                                                │         ├── columns: "?column?":4!null
+                     │                                                                │         ├── values
+                     │                                                                │         │    └── tuple
+                     │                                                                │         └── projections
+                     │                                                                │              └── const: 2 [as="?column?":4]
+                     │                                                                └── project
+                     │                                                                     ├── columns: stmt_return_3:5!null
+                     │                                                                     ├── values
+                     │                                                                     │    └── tuple
+                     │                                                                     └── projections
+                     │                                                                          └── const: -1 [as=stmt_return_3:5]
+                     └── const: 1

--- a/pkg/sql/sem/tree/routine.go
+++ b/pkg/sql/sem/tree/routine.go
@@ -225,4 +225,11 @@ type BlockState struct {
 	// kv.SavepointToken. We use the empty interface here rather than
 	// kv.SavepointToken to avoid import cycles.
 	SavepointTok interface{}
+
+	// Cursors is a list of the names of cursors that have been opened within the
+	// current block. If the exception handler catches an exception, these cursors
+	// must be closed before the handler can proceed.
+	// TODO(111139): Once we support nested routine calls, we may have to track
+	// newly opened cursors differently.
+	Cursors []Name
 }


### PR DESCRIPTION
This patch integrates the PLpgSQL `OPEN` statement, which opens a cursor, with PLpgSQL exception handling. When a cursor is opened in a routine with an exception handler, its name is tracked in the shared block state of the routine. In the event of an error, all tracked cursors are closed before control reaches the exception handler. This mirrors the rollback of changes to the database state that also happens during exception handling.

Informs #109709

Release note (sql change): It is now possible to open a cursor within a PLpgSQL function or procedure with an exception block. If an error occurs, creation of the cursor is rolled back before control reaches the exception handler.