### PR TITLE
server: increase span config buffer sizes from 1MB to 4MB

### DIFF
--- a/pkg/kv/kvclient/rangefeed/rangefeedcache/watcher.go
+++ b/pkg/kv/kvclient/rangefeed/rangefeedcache/watcher.go
@@ -57,8 +57,9 @@ import (
 // The expectation is that the caller will use a mutex to update an underlying
 // data structure.
 //
-// NOTE (for emphasis): Update events after the initial scan published at a
-// delay corresponding to kv.closed_timestamp.target_duration (default 3s).
+// NOTE (for emphasis): Update events after the initial scan are published at a
+// delay corresponding to kv.closed_timestamp.target_duration (default 3s) with
+// an interval of kv.rangefeed.closed_timestamp_refresh_interval (default 3s).
 // Users seeking to leverage the Updates which arrive with that delay but also
 // react to the row-level events as they arrive can hijack the translateEvent
 // function to trigger some non-blocking action.

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -776,7 +776,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterf
 			clock,
 			rangeFeedFactory,
 			keys.SpanConfigurationsTableID,
-			1<<20, /* 1 MB */
+			4<<20, /* 4 MB */
 			fallbackConf,
 			cfg.Settings,
 			spanconfigstore.NewBoundsReader(tenantCapabilitiesWatcher),

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -1281,7 +1281,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 		codec,
 		cfg.Settings,
 		cfg.rangeFeedFactory,
-		1<<20, /* 1 MB bufferMemLimit */
+		4<<20, /* 4 MB bufferMemLimit */
 		cfg.stopper,
 		// TODO(irfansharif): What should this no-op cadence be?
 		30*time.Second, /* checkpointNoopsEvery */


### PR DESCRIPTION
This patch increases the span config buffer sizes from 1MB to 4MB.  This is used to buffer span config rangefeed updates above the rangefeed frontier, until the frontier advances and buffered entries are flushed.

The rangefeed closed timestamp interval was recently increased from 200ms to 3s, with a 3s closed timestamp target duration, which can double the amount of buffered data. We have seen this buffer overflow in tests, requiring a rangefeed restart.

Touches #111195.
Epic: none
Release note: None