### PR TITLE
tests: accelerate tests whose latency is sensitive to rangefeeds

### DIFF
--- a/pkg/base/test_server_args.go
+++ b/pkg/base/test_server_args.go
@@ -169,6 +169,10 @@ type TestServerArgs struct {
 	// AutoConfigProvider provides auto-configuration tasks to apply on
 	// the cluster during server initialization.
 	AutoConfigProvider acprovider.Provider
+
+	// FastRangefeeds, if set, lowers the latency at which rangefeeds
+	// report changes.
+	FastRangefeeds bool
 }
 
 // TestClusterArgs contains the parameters one can set when creating a test

--- a/pkg/ccl/backupccl/alter_backup_schedule_test.go
+++ b/pkg/ccl/backupccl/alter_backup_schedule_test.go
@@ -72,6 +72,8 @@ func newAlterSchedulesTestHelper(t *testing.T) (*alterSchedulesTestHelper, func(
 		Knobs: base.TestingKnobs{
 			JobsTestingKnobs: knobs,
 		},
+		// Speeds up test.
+		FastRangefeeds: true,
 	}
 	s, db, _ := serverutils.StartServer(t, args)
 	require.NotNil(t, th.cfg)
@@ -79,7 +81,6 @@ func newAlterSchedulesTestHelper(t *testing.T) (*alterSchedulesTestHelper, func(
 	th.server = s
 	th.sqlDB.Exec(t, `SET CLUSTER SETTING bulkio.backup.merge_file_buffer_size = '1MiB'`)
 	sysDB := sqlutils.MakeSQLRunner(s.SystemLayer().SQLConn(t, ""))
-	sysDB.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.target_duration = '100ms'`) // speeds up test
 
 	return th, func() {
 		dirCleanupFn()

--- a/pkg/ccl/backupccl/create_scheduled_backup_test.go
+++ b/pkg/ccl/backupccl/create_scheduled_backup_test.go
@@ -105,6 +105,8 @@ func newTestHelper(t *testing.T) (*testHelper, func()) {
 		Knobs: base.TestingKnobs{
 			JobsTestingKnobs: knobs,
 		},
+		// Make test faster.
+		FastRangefeeds: true,
 	}
 	jobs.PollJobsMetricsInterval.Override(context.Background(), &args.Settings.SV, 250*time.Millisecond)
 	s, db, _ := serverutils.StartServer(t, args)
@@ -112,7 +114,6 @@ func newTestHelper(t *testing.T) (*testHelper, func()) {
 	th.sqlDB = sqlutils.MakeSQLRunner(db)
 	th.server = s
 	th.sqlDB.Exec(t, `SET CLUSTER SETTING bulkio.backup.merge_file_buffer_size = '1MiB'`)
-	th.sqlDB.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.target_duration = '100ms'`) // speeds up test
 
 	return th, func() {
 		dirCleanupFn()

--- a/pkg/ccl/backupccl/utils_test.go
+++ b/pkg/ccl/backupccl/utils_test.go
@@ -92,6 +92,8 @@ func backupRestoreTestSetup(
 		base.TestClusterArgs{
 			ServerArgs: base.TestServerArgs{
 				DefaultTestTenant: base.TODOTestTenantDisabled,
+				// Make tests faster.
+				FastRangefeeds: true,
 			}})
 }
 

--- a/pkg/ccl/multiregionccl/cold_start_latency_test.go
+++ b/pkg/ccl/multiregionccl/cold_start_latency_test.go
@@ -114,6 +114,9 @@ func TestColdStartLatency(t *testing.T) {
 			},
 		}
 		args.Knobs.Server = serverKnobs
+		// Make span configs propagate more rapidly.
+		args.FastRangefeeds = true
+
 		perServerArgs[i] = args
 	}
 	tc := testcluster.NewTestCluster(t, numNodes, base.TestClusterArgs{
@@ -145,10 +148,7 @@ func TestColdStartLatency(t *testing.T) {
 	}
 	tdb := sqlutils.MakeSQLRunner(tc.ServerConn(1))
 
-	// Shorten the closed timestamp target duration so that span configs
-	// propagate more rapidly.
-	tdb.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.target_duration = '200ms'`)
-	tdb.Exec(t, `SET CLUSTER SETTING kv.rangefeed.closed_timestamp_refresh_interval = '200ms'`)
+	// Make the allocator faster.
 	tdb.Exec(t, "SET CLUSTER SETTING kv.allocator.load_based_rebalancing = off")
 	tdb.Exec(t, "SET CLUSTER SETTING kv.allocator.min_lease_transfer_interval = '10ms'")
 	// Lengthen the lead time for the global tables to prevent overload from

--- a/pkg/ccl/serverccl/statusccl/tenant_status_test.go
+++ b/pkg/ccl/serverccl/statusccl/tenant_status_test.go
@@ -69,9 +69,6 @@ func TestTenantStatusAPI(t *testing.T) {
 	// Speed up propagation of tenant capability changes.
 	db := testHelper.HostCluster().ServerConn(0)
 	tdb := sqlutils.MakeSQLRunner(db)
-	tdb.Exec(t, "SET CLUSTER SETTING kv.closed_timestamp.target_duration = '10ms'")
-	tdb.Exec(t, "SET CLUSTER SETTING kv.closed_timestamp.side_transport_interval = '10 ms'")
-	tdb.Exec(t, "SET CLUSTER SETTING kv.rangefeed.closed_timestamp_refresh_interval = '10 ms'")
 
 	t.Run("reset_sql_stats", func(t *testing.T) {
 		skip.UnderDeadlockWithIssue(t, 99559)

--- a/pkg/ccl/serverccl/tenant_test_utils.go
+++ b/pkg/ccl/serverccl/tenant_test_utils.go
@@ -147,6 +147,9 @@ func NewTestTenantHelper(
 		ServerArgs: base.TestServerArgs{
 			Knobs:             knobs,
 			DefaultTestTenant: base.TestControlsTenantsExplicitly,
+
+			// Make tests faster.
+			FastRangefeeds: true,
 		},
 	})
 	server := testCluster.Server(0)

--- a/pkg/ccl/spanconfigccl/spanconfiglimiterccl/datadriven_test.go
+++ b/pkg/ccl/spanconfigccl/spanconfiglimiterccl/datadriven_test.go
@@ -77,10 +77,13 @@ func TestDataDriven(t *testing.T) {
 				Knobs: base.TestingKnobs{
 					SpanConfig: scKnobs,
 				},
+				// Make tests faster overall.
+				FastRangefeeds: true,
 			},
 		})
 		defer tc.Stopper().Stop(ctx)
 		{
+			// Lower the closed ts target duration even further than what FastRangefeeds does.
 			sysDB := sqlutils.MakeSQLRunner(tc.SystemLayer(0).SQLConn(t, ""))
 			sysDB.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.target_duration = '20ms'`)
 		}

--- a/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/datadriven_test.go
+++ b/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/datadriven_test.go
@@ -107,6 +107,8 @@ func TestDataDriven(t *testing.T) {
 					JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(), // speeds up test
 					SpanConfig:       scKnobs,
 				},
+				// Make tests faster.
+				FastRangefeeds: true,
 			},
 		})
 		defer tc.Stopper().Stop(ctx)
@@ -114,7 +116,6 @@ func TestDataDriven(t *testing.T) {
 		{
 			tdb := sqlutils.MakeSQLRunner(tc.ServerConn(0))
 			tdb.Exec(t, `SET CLUSTER SETTING kv.rangefeed.enabled = true`)
-			tdb.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.target_duration = '100ms'`)
 		}
 
 		spanConfigTestCluster := spanconfigtestcluster.NewHandle(t, tc, scKnobs)

--- a/pkg/ccl/spanconfigccl/spanconfigsqlwatcherccl/sqlwatcher_test.go
+++ b/pkg/ccl/spanconfigccl/spanconfigsqlwatcherccl/sqlwatcher_test.go
@@ -68,6 +68,7 @@ func TestSQLWatcherReactsToUpdates(t *testing.T) {
 				},
 				JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(), // speed up schema changes.
 			},
+			FastRangefeeds: true,
 		},
 	})
 	defer tc.Stopper().Stop(context.Background())
@@ -77,9 +78,6 @@ func TestSQLWatcherReactsToUpdates(t *testing.T) {
 	tdb := sqlutils.MakeSQLRunner(tc.ServerConn(0 /* idx */))
 	tdb.QueryRow(t, `SELECT max(id) FROM system.descriptor`).Scan(&idBase)
 	tdb.Exec(t, `SET CLUSTER SETTING kv.rangefeed.enabled = true`)
-	tdb.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.target_duration = '50ms'`)
-	tdb.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.side_transport_interval = '50ms'`)
-	tdb.Exec(t, `SET CLUSTER SETTING kv.rangefeed.closed_timestamp_refresh_interval = '50ms'`)
 
 	noopCheckpointDuration := 100 * time.Millisecond
 	sqlWatcher := spanconfigsqlwatcher.New(
@@ -294,6 +292,7 @@ func TestSQLWatcherMultiple(t *testing.T) {
 				},
 				JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(), // speed up schema changes.
 			},
+			FastRangefeeds: true,
 		},
 	})
 	ctx := context.Background()
@@ -302,7 +301,6 @@ func TestSQLWatcherMultiple(t *testing.T) {
 	tdb := sqlutils.MakeSQLRunner(tc.ServerConn(0 /* idx */))
 	sdb := sqlutils.MakeSQLRunner(tc.SystemLayer(0).SQLConn(t, ""))
 	sdb.Exec(t, `SET CLUSTER SETTING kv.rangefeed.enabled = true`)
-	sdb.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.target_duration = '100ms'`)
 
 	noopCheckpointDuration := 100 * time.Millisecond
 	sqlWatcher := spanconfigsqlwatcher.New(
@@ -426,6 +424,7 @@ func TestSQLWatcherOnEventError(t *testing.T) {
 				},
 				JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(), // speed up schema changes.
 			},
+			FastRangefeeds: true,
 		},
 	})
 	ctx := context.Background()
@@ -433,7 +432,6 @@ func TestSQLWatcherOnEventError(t *testing.T) {
 	ts := tc.Server(0 /* idx */)
 	tdb := sqlutils.MakeSQLRunner(tc.ServerConn(0 /* idx */))
 	tdb.Exec(t, `SET CLUSTER SETTING kv.rangefeed.enabled = true`)
-	tdb.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.target_duration = '100ms'`)
 
 	sqlWatcher := spanconfigsqlwatcher.New(
 		ts.Codec(),
@@ -476,6 +474,7 @@ func TestSQLWatcherHandlerError(t *testing.T) {
 				},
 				JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(), // speed up schema changes.
 			},
+			FastRangefeeds: true,
 		},
 	})
 	ctx := context.Background()
@@ -483,7 +482,6 @@ func TestSQLWatcherHandlerError(t *testing.T) {
 	ts := tc.Server(0 /* idx */)
 	tdb := sqlutils.MakeSQLRunner(tc.ServerConn(0 /* idx */))
 	tdb.Exec(t, `SET CLUSTER SETTING kv.rangefeed.enabled = true`)
-	tdb.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.target_duration = '100ms'`)
 
 	noopCheckpointDuration := 100 * time.Millisecond
 	sqlWatcher := spanconfigsqlwatcher.New(
@@ -553,6 +551,7 @@ func TestWatcherReceivesNoopCheckpoints(t *testing.T) {
 				},
 				JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(), // speed up schema changes.
 			},
+			FastRangefeeds: true,
 		},
 	})
 	ctx := context.Background()
@@ -560,7 +559,6 @@ func TestWatcherReceivesNoopCheckpoints(t *testing.T) {
 	ts := tc.Server(0 /* idx */)
 	tdb := sqlutils.MakeSQLRunner(tc.ServerConn(0 /* idx */))
 	tdb.Exec(t, `SET CLUSTER SETTING kv.rangefeed.enabled = true`)
-	tdb.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.target_duration = '100ms'`)
 
 	noopCheckpointDuration := 25 * time.Millisecond
 	sqlWatcher := spanconfigsqlwatcher.New(

--- a/pkg/ccl/streamingccl/replicationtestutils/replication_helpers.go
+++ b/pkg/ccl/streamingccl/replicationtestutils/replication_helpers.go
@@ -215,7 +215,10 @@ func NewReplicationHelper(
 ) (*ReplicationHelper, func()) {
 	ctx := context.Background()
 
-	// Start server
+	// Speed up the tests.
+	serverArgs.FastRangefeeds = true
+
+	// Start server.
 	srv, db, _ := serverutils.StartServer(t, serverArgs)
 	s := srv.SystemLayer()
 
@@ -226,9 +229,6 @@ func NewReplicationHelper(
 		`SET CLUSTER SETTING cross_cluster_replication.enabled = true`,
 
 		// Speeds up the tests a bit.
-		`SET CLUSTER SETTING kv.rangefeed.closed_timestamp_refresh_interval = '200ms'`,
-		`SET CLUSTER SETTING kv.closed_timestamp.target_duration = '50ms'`,
-		`SET CLUSTER SETTING kv.closed_timestamp.side_transport_interval = '10ms'`,
 		`SET CLUSTER SETTING stream_replication.min_checkpoint_frequency = '10ms'`)
 
 	// Sink to read data from.

--- a/pkg/ccl/streamingccl/replicationtestutils/testutils.go
+++ b/pkg/ccl/streamingccl/replicationtestutils/testutils.go
@@ -303,6 +303,8 @@ func CreateServerArgs(args TenantStreamingClustersArgs) base.TestServerArgs {
 				EnableTenantIDReuse: true,
 			},
 		},
+		// Make the tests faster overall.
+		FastRangefeeds: true,
 	}
 }
 
@@ -499,6 +501,8 @@ var defaultSrcClusterSetting = map[string]string{
 	`kv.rangefeed.enabled`: `true`,
 	// Speed up the rangefeed. These were set by squinting at the settings set in
 	// the changefeed integration tests.
+	// TODO(ssd,knz): this seems to be redundant with the "FastRangefeeds"
+	// argument on TestServerArgs.
 	`kv.closed_timestamp.target_duration`:            `'100ms'`,
 	`kv.rangefeed.closed_timestamp_refresh_interval`: `'200ms'`,
 	`kv.closed_timestamp.side_transport_interval`:    `'50ms'`,
@@ -509,7 +513,7 @@ var defaultSrcClusterSetting = map[string]string{
 	// Make all AddSSTable operation to trigger AddSSTable events.
 	`kv.bulk_io_write.small_write_size`: `'1'`,
 	`jobs.registry.interval.adopt`:      `'1s'`,
-	// Speed up span reconciliation
+	// Speed up span reconciliation.
 	`spanconfig.reconciliation_job.checkpoint_interval`: `'100ms'`,
 }
 

--- a/pkg/ccl/streamingccl/streamingest/replication_stream_e2e_test.go
+++ b/pkg/ccl/streamingccl/streamingest/replication_stream_e2e_test.go
@@ -432,9 +432,6 @@ func TestTenantStreamingDropTenantCancelsStream(t *testing.T) {
 		defer cleanup()
 		producerJobID, ingestionJobID := c.StartStreamReplication(ctx)
 
-		c.DestSysSQL.Exec(t, "SET CLUSTER SETTING kv.closed_timestamp.target_duration = '100ms'")
-		c.DestSysSQL.Exec(t, "SET CLUSTER SETTING kv.protectedts.reconciliation.interval = '1ms';")
-
 		jobutils.WaitForJobToRun(c.T, c.SrcSysSQL, jobspb.JobID(producerJobID))
 		jobutils.WaitForJobToRun(c.T, c.DestSysSQL, jobspb.JobID(ingestionJobID))
 
@@ -876,9 +873,6 @@ func TestProtectedTimestampManagement(t *testing.T) {
 
 			c, cleanup := replicationtestutils.CreateTenantStreamingClusters(ctx, t, args)
 			defer cleanup()
-
-			c.DestSysSQL.Exec(t, "SET CLUSTER SETTING kv.closed_timestamp.target_duration = '100ms'")
-			c.DestSysSQL.Exec(t, "SET CLUSTER SETTING kv.protectedts.reconciliation.interval = '1ms';")
 
 			producerJobID, replicationJobID := c.StartStreamReplication(ctx)
 

--- a/pkg/ccl/testccl/sqlccl/gc_job_test.go
+++ b/pkg/ccl/testccl/sqlccl/gc_job_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
-	"github.com/cockroachdb/cockroach/pkg/sql/sqltestutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
@@ -34,8 +33,8 @@ func TestGCJobGetsMarkedIdle(t *testing.T) {
 	ctx := context.Background()
 	s, mainDB, _ := serverutils.StartServer(t, base.TestServerArgs{
 		DefaultTestTenant: base.TestControlsTenantsExplicitly,
+		FastRangefeeds:    true,
 	})
-	sqltestutils.SetShortRangeFeedIntervals(t, mainDB)
 	defer s.Stopper().Stop(ctx)
 	tenant, tenantDB := serverutils.StartTenant(t, s, base.TestTenantArgs{
 		TenantID: serverutils.TestTenantID(),

--- a/pkg/ccl/testccl/sqlccl/tenant_gc_test.go
+++ b/pkg/ccl/testccl/sqlccl/tenant_gc_test.go
@@ -163,11 +163,11 @@ func TestGCTenantJobWaitsForProtectedTimestamps(t *testing.T) {
 		Knobs: base.TestingKnobs{
 			JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
 		},
+		// Make the tests faster.
+		FastRangefeeds: true,
 	}
 	srv, sqlDBRaw, _ := serverutils.StartServer(t, args)
 	sqlDB := sqlutils.MakeSQLRunner(sqlDBRaw)
-
-	sqlDB.Exec(t, "SET CLUSTER SETTING kv.closed_timestamp.target_duration = '100ms'")
 
 	execCfg := srv.ExecutorConfig().(sql.ExecutorConfig)
 	jobRegistry := execCfg.JobRegistry

--- a/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed_test.go
@@ -865,6 +865,9 @@ func TestMuxRangeFeedCanCloseStream(t *testing.T) {
 	ctx := context.Background()
 	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{
 		ReplicationMode: base.ReplicationManual,
+		ServerArgs: base.TestServerArgs{
+			FastRangefeeds: true,
+		},
 	})
 	defer tc.Stopper().Stop(ctx)
 
@@ -874,7 +877,6 @@ func TestMuxRangeFeedCanCloseStream(t *testing.T) {
 	// Insert 1000 rows, and split them into 10 ranges.
 	sqlDB.ExecMultiple(t,
 		`SET CLUSTER SETTING kv.rangefeed.enabled = true`,
-		`SET CLUSTER SETTING kv.closed_timestamp.target_duration='100ms'`,
 		`ALTER DATABASE defaultdb  CONFIGURE ZONE USING num_replicas = 1`,
 		`CREATE TABLE foo (key INT PRIMARY KEY)`,
 		`INSERT INTO foo (key) SELECT * FROM generate_series(1, 1000)`,
@@ -1011,6 +1013,9 @@ func TestMuxRangeFeedDoesNotDeadlockWithLocalStreams(t *testing.T) {
 	ctx := context.Background()
 	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{
 		ReplicationMode: base.ReplicationManual,
+		ServerArgs: base.TestServerArgs{
+			FastRangefeeds: true,
+		},
 	})
 	defer tc.Stopper().Stop(ctx)
 
@@ -1020,7 +1025,6 @@ func TestMuxRangeFeedDoesNotDeadlockWithLocalStreams(t *testing.T) {
 	// Insert 1000 rows, and split them into many ranges.
 	sqlDB.ExecMultiple(t,
 		`SET CLUSTER SETTING kv.rangefeed.enabled = true`,
-		`SET CLUSTER SETTING kv.closed_timestamp.target_duration='100ms'`,
 		`ALTER DATABASE defaultdb  CONFIGURE ZONE USING num_replicas = 1`,
 		`CREATE TABLE foo (key INT PRIMARY KEY)`,
 	)

--- a/pkg/multitenant/tenantcapabilities/tenantcapabilitieswatcher/watcher_test.go
+++ b/pkg/multitenant/tenantcapabilities/tenantcapabilitieswatcher/watcher_test.go
@@ -80,12 +80,13 @@ func TestDataDriven(t *testing.T) {
 		ctx := context.Background()
 		ts, db, _ := serverutils.StartServer(t, base.TestServerArgs{
 			DefaultTestTenant: base.TestIsSpecificToStorageLayerAndNeedsASystemTenant,
+			// Make tests faster.
+			FastRangefeeds: true,
 		})
 		defer ts.Stopper().Stop(ctx)
 
 		tdb := sqlutils.MakeSQLRunner(db)
 		tdb.Exec(t, `SET CLUSTER SETTING kv.rangefeed.enabled = true`)
-		tdb.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.target_duration = '100ms'`)
 
 		const dummyTableName = "dummy_system_tenants"
 		tdb.Exec(t, fmt.Sprintf("CREATE TABLE %s (LIKE system.tenants INCLUDING ALL)", dummyTableName))

--- a/pkg/server/systemconfigwatcher/cache_test.go
+++ b/pkg/server/systemconfigwatcher/cache_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server/systemconfigwatcher"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
-	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
@@ -34,14 +33,12 @@ func TestNewWithAdditionalProvider(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	s, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{
+	s, _, kvDB := serverutils.StartServer(t, base.TestServerArgs{
 		DefaultTestTenant: base.TestIsSpecificToStorageLayerAndNeedsASystemTenant,
+		FastRangefeeds:    true,
 	})
 	defer s.Stopper().Stop(ctx)
-	tdb := sqlutils.MakeSQLRunner(sqlDB)
-	tdb.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.target_duration = '20ms'`)
-	tdb.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.side_transport_interval = '20ms'`)
-	tdb.Exec(t, `SET CLUSTER SETTING kv.rangefeed.closed_timestamp_refresh_interval = '20ms'`)
+
 	fakeTenant := roachpb.MustMakeTenantID(10)
 	codec := keys.MakeSQLCodec(fakeTenant)
 	fp := &fakeProvider{

--- a/pkg/server/systemconfigwatcher/system_config_watcher_test.go
+++ b/pkg/server/systemconfigwatcher/system_config_watcher_test.go
@@ -46,15 +46,12 @@ func TestSystemConfigWatcher(t *testing.T) {
 	s, sqlDB, kvDB := serverutils.StartServer(t,
 		base.TestServerArgs{
 			DefaultTestTenant: base.TestControlsTenantsExplicitly,
+			// Shorten the closed timestamp duration as a cheeky way to check the
+			// checkpointing code while also speeding up the test.
+			FastRangefeeds: true,
 		},
 	)
 	defer s.Stopper().Stop(ctx)
-	tdb := sqlutils.MakeSQLRunner(sqlDB)
-	// Shorten the closed timestamp duration as a cheeky way to check the
-	// checkpointing code while also speeding up the test.
-	tdb.Exec(t, "SET CLUSTER SETTING kv.closed_timestamp.target_duration = '10 ms'")
-	tdb.Exec(t, "SET CLUSTER SETTING kv.closed_timestamp.side_transport_interval = '10 ms'")
-	tdb.Exec(t, "SET CLUSTER SETTING kv.rangefeed.closed_timestamp_refresh_interval = '10 ms'")
 
 	t.Run("system", func(t *testing.T) {
 		runTest(t, s, sqlDB, nil)

--- a/pkg/settings/integration_tests/propagation_test.go
+++ b/pkg/settings/integration_tests/propagation_test.go
@@ -85,13 +85,14 @@ func runSettingDefaultPropagationTest(
 	ctx := context.Background()
 	s := serverutils.StartServerOnly(t, base.TestServerArgs{
 		DefaultTestTenant: base.TestControlsTenantsExplicitly,
+		// Speed up the tests.
+		FastRangefeeds: true,
 	})
 	defer s.Stopper().Stop(ctx)
 
 	sysDB := sqlutils.MakeSQLRunner(s.SystemLayer().SQLConn(t, ""))
 	sysDB.Exec(t, "SELECT crdb_internal.create_tenant($1, 'test')", serverutils.TestTenantID().ToUint64())
-	// Speed up the tests.
-	sysDB.Exec(t, "SET CLUSTER SETTING kv.closed_timestamp.target_duration = '10ms'")
+	sysDB.Exec(t, `SET CLUSTER SETTING kv.rangefeed.enabled = true`)
 
 	expectation := func(setting settings.Setting, sysOverride, tenantOverride, tenantAllOverride string) string {
 		if tenantOverride != "" {

--- a/pkg/settings/integration_tests/settings_test.go
+++ b/pkg/settings/integration_tests/settings_test.go
@@ -308,11 +308,14 @@ func TestSettingsPersistenceEndToEnd(t *testing.T) {
 		Knobs: base.TestingKnobs{
 			Server: serverKnobs,
 		},
+		FastRangefeeds: true,
 	}
 
 	ts, sqlDB, _ := serverutils.StartServer(t, serverArgs)
 	defer ts.Stopper().Stop(ctx)
 	db := sqlutils.MakeSQLRunner(sqlDB)
+
+	db.Exec(t, `SET CLUSTER SETTING kv.rangefeed.enabled = true`)
 
 	// We need a custom value for the cluster setting that's guaranteed
 	// to be different from the default. So check that it's not equal to

--- a/pkg/spanconfig/spanconfigkvsubscriber/datadriven_test.go
+++ b/pkg/spanconfig/spanconfigkvsubscriber/datadriven_test.go
@@ -113,12 +113,13 @@ func TestDataDriven(t *testing.T) {
 		defer cancel()
 		ts, db, kvDB := serverutils.StartServer(t, base.TestServerArgs{
 			DefaultTestTenant: base.TestIsSpecificToStorageLayerAndNeedsASystemTenant,
+			// Make the tests faster.
+			FastRangefeeds: true,
 		})
 		defer ts.Stopper().Stop(ctx)
 
 		tdb := sqlutils.MakeSQLRunner(db)
 		tdb.Exec(t, `SET CLUSTER SETTING kv.rangefeed.enabled = true`)
-		tdb.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.target_duration = '100ms'`)
 
 		const dummyTableName = "dummy_span_configurations"
 		tdb.Exec(t, fmt.Sprintf("CREATE TABLE %s (LIKE system.span_configurations INCLUDING ALL)", dummyTableName))

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -1499,6 +1499,10 @@ func (t *logicTest) newCluster(
 		nodeParams.TempStorageConfig = base.DefaultTestTempStorageConfigWithSize(
 			nodeParams.Settings, tempStorageDiskLimit,
 		)
+
+		// Make the tests faster overall.
+		nodeParams.FastRangefeeds = true
+
 		paramsPerNode[i] = nodeParams
 	}
 	params.ServerArgsPerNode = paramsPerNode
@@ -1591,23 +1595,6 @@ func (t *logicTest) newCluster(
 
 		clusterSettings := toa.clusterSettings
 		if len(clusterSettings) > 0 {
-			// We reduce the closed timestamp duration on the host tenant so that the
-			// setting override can propagate to the tenant faster.
-			if _, err := conn.Exec(
-				"SET CLUSTER SETTING kv.closed_timestamp.target_duration = '50ms'",
-			); err != nil {
-				t.Fatal(err)
-			}
-			if _, err := conn.Exec(
-				"SET CLUSTER SETTING kv.closed_timestamp.side_transport_interval = '50ms'",
-			); err != nil {
-				t.Fatal(err)
-			}
-			if _, err := conn.Exec(
-				"SET CLUSTER SETTING kv.rangefeed.closed_timestamp_refresh_interval = '50ms'",
-			); err != nil {
-				t.Fatal(err)
-			}
 			for settingName, value := range clusterSettings {
 				query := fmt.Sprintf("ALTER TENANT [$1] SET CLUSTER SETTING %s = $2", settingName)
 				if _, err := conn.Exec(query, tenantID.ToUint64(), value); err != nil {

--- a/pkg/sql/sqltestutils/sql_test_utils.go
+++ b/pkg/sql/sqltestutils/sql_test_utils.go
@@ -26,8 +26,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/desctestutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
-	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
-	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/errors"
 	"github.com/jackc/pgx/v4"
@@ -57,20 +55,6 @@ func DisableGCTTLStrictEnforcement(t *testing.T, db *gosql.DB) (cleanup func()) 
 		_, err := db.Exec(`SET CLUSTER SETTING kv.gc_ttl.strict_enforcement.enabled = DEFAULT`)
 		require.NoError(t, err)
 	}
-}
-
-// SetShortRangeFeedIntervals is a helper to set the cluster settings
-// pertaining to rangefeeds to short durations. This is helps tests which
-// rely on zone/span configuration changes to propagate.
-func SetShortRangeFeedIntervals(t *testing.T, db sqlutils.DBHandle) {
-	tdb := sqlutils.MakeSQLRunner(db)
-	short := "'20ms'"
-	if util.RaceEnabled {
-		short = "'200ms'"
-	}
-	tdb.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.target_duration = `+short)
-	tdb.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.side_transport_interval = `+short)
-	tdb.Exec(t, `SET CLUSTER SETTING kv.rangefeed.closed_timestamp_refresh_interval = `+short)
 }
 
 // AddDefaultZoneConfig adds an entry for the given id into system.zones.

--- a/pkg/sql/tests/split_test.go
+++ b/pkg/sql/tests/split_test.go
@@ -31,14 +31,11 @@ func TestSplitOnTableBoundaries(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{
+		// Speeds up test.
+		FastRangefeeds: true,
+	})
 	defer s.Stopper().Stop(context.Background())
-
-	// speeds up test
-	{
-		sysDB := sqlutils.MakeSQLRunner(s.SystemLayer().SQLConn(t, ""))
-		sysDB.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.target_duration = '100ms'`)
-	}
 
 	sqlConn := sqlutils.MakeSQLRunner(sqlDB)
 	sqlConn.Exec(t, `CREATE DATABASE test`)

--- a/pkg/sql/tests/truncate_test.go
+++ b/pkg/sql/tests/truncate_test.go
@@ -393,22 +393,18 @@ func TestTruncatePreservesSplitPoints(t *testing.T) {
 							DisableMergeQueue: true,
 						},
 					},
+					// This test asserts on KV-internal effects (i.e. range splits
+					// and their boundaries) as a result of configs and manually
+					// installed splits. To ensure it works with the span configs
+					// infrastructure quickly enough, we set a low closed timestamp
+					// target duration.
+					FastRangefeeds: true,
 				},
 			})
 			defer tc.Stopper().Stop(ctx)
 			s := tc.ApplicationLayer(0)
 			tenantSettings := s.ClusterSettings()
 			conn := s.SQLConn(t, "defaultdb")
-
-			{
-				// This test asserts on KV-internal effects (i.e. range splits
-				// and their boundaries) as a result of configs and manually
-				// installed splits. To ensure it works with the span configs
-				// infrastructure quickly enough, we set a low closed timestamp
-				// target duration.
-				sysDB := sqlutils.MakeSQLRunner(tc.SystemLayer(0).SQLConn(t, ""))
-				sysDB.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.target_duration = '100ms'`)
-			}
 
 			var err error
 			_, err = conn.ExecContext(ctx, `

--- a/pkg/sql/unsplit_range_test.go
+++ b/pkg/sql/unsplit_range_test.go
@@ -273,14 +273,13 @@ func TestUnsplitRanges(t *testing.T) {
 		params.Knobs.GCJob = &sql.GCJobTestingKnobs{
 			SkipWaitingForMVCCGC: true,
 		}
+		// Speed up how long it takes for the zone config changes to propagate.
+		params.FastRangefeeds = true
 
 		defer gcjob.SetSmallMaxGCIntervalForTest()()
 
 		s, sqlDB, kvDB := serverutils.StartServer(t, params)
 		defer s.Stopper().Stop(context.Background())
-
-		// Speed up how long it takes for the zone config changes to propagate.
-		sqltestutils.SetShortRangeFeedIntervals(t, sqlDB)
 
 		// Disable strict GC TTL enforcement because we're going to shove a zero-value
 		// TTL into the system with AddImmediateGCZoneConfig.

--- a/pkg/sql/zone_config_test.go
+++ b/pkg/sql/zone_config_test.go
@@ -101,14 +101,11 @@ func TestGetZoneConfig(t *testing.T) {
 		DefaultZoneConfigOverride:       &defaultZoneConfig,
 		DefaultSystemZoneConfigOverride: &defaultZoneConfig,
 	}
+	// Set the closed_timestamp interval to be short to shorten the test duration.
+	params.FastRangefeeds = true
 
 	s, sqlDB, _ := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(context.Background())
-	// Set the closed_timestamp interval to be short to shorten the test duration.
-	tdb := sqlutils.MakeSQLRunner(sqlDB)
-	tdb.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.target_duration = '20ms'`)
-	tdb.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.side_transport_interval = '20ms'`)
-	tdb.Exec(t, `SET CLUSTER SETTING kv.rangefeed.closed_timestamp_refresh_interval = '20ms'`)
 
 	type testCase struct {
 		objectID uint32
@@ -337,14 +334,11 @@ func TestCascadingZoneConfig(t *testing.T) {
 		DefaultZoneConfigOverride:       &defaultZoneConfig,
 		DefaultSystemZoneConfigOverride: &defaultZoneConfig,
 	}
+	// Set the closed_timestamp interval to be short to shorten the test duration.
+	params.FastRangefeeds = true
 
 	s, sqlDB, _ := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(context.Background())
-	// Set the closed_timestamp interval to be short to shorten the test duration.
-	tdb := sqlutils.MakeSQLRunner(sqlDB)
-	tdb.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.target_duration = '20ms'`)
-	tdb.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.side_transport_interval = '20ms'`)
-	tdb.Exec(t, `SET CLUSTER SETTING kv.rangefeed.closed_timestamp_refresh_interval = '20ms'`)
 
 	type testCase struct {
 		objectID uint32
@@ -650,13 +644,11 @@ func BenchmarkGetZoneConfig(b *testing.B) {
 	defer log.Scope(b).Close(b)
 
 	params, _ := createTestServerParams()
+	// Set the closed_timestamp interval to be short to shorten the test duration.
+	params.FastRangefeeds = true
+
 	s, sqlDB, _ := serverutils.StartServer(b, params)
 	defer s.Stopper().Stop(context.Background())
-	// Set the closed_timestamp interval to be short to shorten the test duration.
-	tdb := sqlutils.MakeSQLRunner(sqlDB)
-	tdb.Exec(b, `SET CLUSTER SETTING kv.closed_timestamp.target_duration = '20ms'`)
-	tdb.Exec(b, `SET CLUSTER SETTING kv.closed_timestamp.side_transport_interval = '20ms'`)
-	tdb.Exec(b, `SET CLUSTER SETTING kv.rangefeed.closed_timestamp_refresh_interval = '20ms'`)
 	cfg := forceNewConfig(b, s)
 
 	key := roachpb.RKey(keys.SystemSQLCodec.TablePrefix(bootstrap.TestingUserDescID(0)))


### PR DESCRIPTION
For context, the latency of some unit tests is indirectly largely influenced by the closed timestamp target duration and other rangefeed-related configuration knobs; while not having specific requirements about them.

Prior to this patch, a subset of these tests were trying to decrease their overall run time by tuning some of these knobs. There were two problems with this approach: this was a lot of boilerplate; and the test code was not consistent in updating _all_ the relevant tuning knobs.

This patch fixes it by introducing a new `FastRangefeed` parameter on TestServerArgs which tunes all the configuration knobs to sensible lower values.

Release note: None
Epic: CRDB-28893