### PR TITLE
roachtest: allow caller to specify nodes to fetch debug zips from

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -1332,7 +1332,14 @@ COCKROACH_DEBUG_TS_IMPORT_FILE=tsdump.gob cockroach start-single-node --insecure
 
 // FetchDebugZip downloads the debug zip from the cluster using `roachprod ssh`.
 // The logs will be placed at `dest`, relative to the test's artifacts dir.
-func (c *clusterImpl) FetchDebugZip(ctx context.Context, l *logger.Logger, dest string) error {
+//
+// By default, FetchDebugZip will attempt to download the zip from the first
+// node, and if that fails, it will try subsequent nodes. The caller may pass a
+// list of nodes via opts if they want to target which node(s) to grab the debug
+// zip from.
+func (c *clusterImpl) FetchDebugZip(
+	ctx context.Context, l *logger.Logger, dest string, opts ...option.Option,
+) error {
 	if c.spec.NodeCount == 0 {
 		// No nodes can happen during unit tests and implies nothing to do.
 		return nil
@@ -1340,6 +1347,16 @@ func (c *clusterImpl) FetchDebugZip(ctx context.Context, l *logger.Logger, dest 
 
 	l.Printf("fetching debug zip\n")
 	c.status("fetching debug zip")
+
+	var nodes option.NodeListOption
+	for _, o := range opts {
+		if s, ok := o.(nodeSelector); ok {
+			nodes = s.Merge(nodes)
+		}
+	}
+	if len(nodes) == 0 {
+		nodes = c.All()
+	}
 
 	// Don't hang forever if we can't fetch the debug zip.
 	return timeutil.RunWithTimeout(ctx, "debug zip", 5*time.Minute, func(ctx context.Context) error {
@@ -1351,7 +1368,7 @@ func (c *clusterImpl) FetchDebugZip(ctx context.Context, l *logger.Logger, dest 
 		// Some nodes might be down, so try to find one that works. We make the
 		// assumption that a down node will refuse the connection, so it won't
 		// waste our time.
-		for i := 1; i <= c.spec.NodeCount; i++ {
+		for _, node := range nodes {
 			// `cockroach debug zip` is noisy. Suppress the output unless it fails.
 			//
 			// Ignore the files in the the log directory; we pull the logs separately anyway
@@ -1360,18 +1377,15 @@ func (c *clusterImpl) FetchDebugZip(ctx context.Context, l *logger.Logger, dest 
 			cmd := roachtestutil.NewCommand("%s debug zip", test.DefaultCockroachPath).
 				Option("include-range-info").
 				Flag("exclude-files", fmt.Sprintf("'%s'", excludeFiles)).
-				Flag("url", fmt.Sprintf("{pgurl:%d}", i)).
+				Flag("url", fmt.Sprintf("{pgurl:%d}", node)).
 				MaybeFlag(c.IsSecure(), "certs-dir", "certs").
 				Arg(zipName).
 				String()
-			if err := c.RunE(ctx, c.Node(i), cmd); err != nil {
-				l.Printf("%s debug zip failed on node %d: %v", test.DefaultCockroachPath, i, err)
-				if i < c.spec.NodeCount {
-					continue
-				}
-				return err
+			if err := c.RunE(ctx, c.Node(node), cmd); err != nil {
+				l.Printf("%s debug zip failed on node %d: %v", test.DefaultCockroachPath, node, err)
+				continue
 			}
-			return errors.Wrap(c.Get(ctx, c.l, zipName /* src */, path /* dest */, c.Node(i)), "cluster.FetchDebugZip")
+			return errors.Wrap(c.Get(ctx, c.l, zipName /* src */, path /* dest */, c.Node(node)), "cluster.FetchDebugZip")
 		}
 		return nil
 	})

--- a/pkg/cmd/roachtest/cluster/cluster_interface.go
+++ b/pkg/cmd/roachtest/cluster/cluster_interface.go
@@ -136,7 +136,7 @@ type Cluster interface {
 	) error
 
 	FetchTimeseriesData(ctx context.Context, l *logger.Logger) error
-	FetchDebugZip(ctx context.Context, l *logger.Logger, dest string) error
+	FetchDebugZip(ctx context.Context, l *logger.Logger, dest string, opts ...option.Option) error
 	RefetchCertsFromNode(ctx context.Context, node int) error
 
 	StartGrafana(ctx context.Context, l *logger.Logger, promCfg *prometheus.Config) error

--- a/pkg/cmd/roachtest/tests/cluster_to_cluster.go
+++ b/pkg/cmd/roachtest/tests/cluster_to_cluster.go
@@ -588,8 +588,18 @@ func (rd *replicationDriver) setupC2C(
 		rd.t.L().Printf("Prom has started")
 	}
 	return func() {
+		rd.fetchDebugZip(ctx, rd.setup.src.nodes, "source_debug.zip")
+		rd.fetchDebugZip(ctx, rd.setup.dst.nodes, "dest_debug.zip")
 		srcDB.Close()
 		destDB.Close()
+	}
+}
+
+func (rd *replicationDriver) fetchDebugZip(
+	ctx context.Context, nodes option.NodeListOption, filename string,
+) {
+	if err := rd.c.FetchDebugZip(ctx, rd.t.L(), filename, nodes); err != nil {
+		rd.t.L().Printf("Failed to download debug zip to %s from node %s", filename, nodes)
 	}
 }
 


### PR DESCRIPTION
This patch enables the caller of cluster.FetchDebugZip to specifiy which node(s) they want to collect a debug zip from. This allows the c2c roachtests to grab a debug zip from the source and destination clusters.

Fixes #111268

Release note: None