### PR TITLE
streamingccl: disable dumping frontier entries

### DIFF
--- a/pkg/ccl/streamingccl/settings.go
+++ b/pkg/ccl/streamingccl/settings.go
@@ -108,6 +108,6 @@ var DumpFrontierEntries = settings.RegisterDurationSetting(
 	settings.ApplicationLevel,
 	"physical_replication.consumer.dump_frontier_entries_frequency",
 	"controls the frequency with which the frontier entries are persisted; if 0, disabled",
-	10*time.Minute,
+	0,
 	settings.NonNegativeDuration,
 )


### PR DESCRIPTION
Recently we added logic to the C2C job to be able to dump a replication-frontier.txt file. As part of that file generation we would periodically dump the state of the replication frontier. We want this disabled by default to prevent growth of job_info rows.

This is new feature work on master so no release note needed.

Epic: none
Release note: None