### PR TITLE
backupccl,delegate: change SHOW SCHEDULES columns for schedule options

### DIFF
--- a/pkg/ccl/backupccl/testdata/backup-restore/alter-schedule/schedule-options
+++ b/pkg/ccl/backupccl/testdata/backup-restore/alter-schedule/schedule-options
@@ -44,7 +44,7 @@ alter backup schedule $fullID set schedule option on_previous_running = 'start';
 ----
 
 query-sql
-select on_error, on_wait
+select on_execution_failure, on_previous_running
 from [show schedules for backup]
 where id in ($fullID, $incID)
 order by backup_type asc;
@@ -57,7 +57,7 @@ alter backup schedule $fullID set schedule option on_previous_running = 'skip';
 ----
 
 query-sql
-select on_error, on_wait
+select on_execution_failure, on_previous_running
 from [show schedules for backup]
 where id in ($fullID, $incID)
 order by backup_type asc;
@@ -70,7 +70,7 @@ alter backup schedule $fullID set schedule option on_previous_running = 'wait';
 ----
 
 query-sql
-select on_error, on_wait
+select on_execution_failure, on_previous_running
 from [show schedules for backup]
 where id in ($fullID, $incID)
 order by backup_type asc;

--- a/pkg/sql/delegate/show_schedules.go
+++ b/pkg/sql/delegate/show_schedules.go
@@ -38,8 +38,8 @@ WHERE status='%s' AND created_by_type='%s' AND created_by_id=schedule_id
 ) AS jobsRunning`, jobs.StatusRunning, jobs.CreatedByScheduledJobs),
 		"owner",
 		"created",
-		"crdb_internal.pb_to_json('cockroach.jobs.jobspb.ScheduleDetails', schedule_details, true)->>'wait' as on_wait",
-		"crdb_internal.pb_to_json('cockroach.jobs.jobspb.ScheduleDetails', schedule_details, true)->>'onError' as on_error",
+		"crdb_internal.pb_to_json('cockroach.jobs.jobspb.ScheduleDetails', schedule_details, true)->>'wait' as on_previous_running",
+		"crdb_internal.pb_to_json('cockroach.jobs.jobspb.ScheduleDetails', schedule_details, true)->>'onError' as on_execution_failure",
 	}
 
 	var whereExprs []string


### PR DESCRIPTION
For 23.2 we added two columns to `SHOW SCHEDULES` that surfaces the values for the schedule options corresponding to `on_previous_running` and `on_execution_failure`. These column names were previously named `on_wait` and `on_error` since those were the internal proto names. It makes more sense to align these with the publically documented option names.

Epic: none
Release note (sql change): `SHOW SCHEDULES` has two columns that surface the schedule options. These columns have been renamed to align with the documented option names namely `on_previous_running` and `on_execution_failure`.