### PR TITLE
sql: create cluster setting to control insights flush

### DIFF
--- a/pkg/sql/sqlstats/insights/insights.go
+++ b/pkg/sql/sqlstats/insights/insights.go
@@ -89,6 +89,13 @@ var HighRetryCountThreshold = settings.RegisterIntSetting(
 	settings.NonNegativeInt,
 	settings.WithPublic)
 
+// sqlInsightsFlushEnabled the insights flush job.
+var sqlInsightsFlushEnabled = settings.RegisterBoolSetting(
+	settings.ApplicationLevel,
+	"sql.insights.flush.enabled",
+	"enable the flush to the system statement and transaction insights tables",
+	false)
+
 // Metrics holds running measurements of various insights-related runtime stats.
 type Metrics struct {
 	// Fingerprints measures the number of statement fingerprints being monitored for


### PR DESCRIPTION
A new job to flush the insights form memory to persisted will be created. This commit creates a cluster setting that can control if that job should be enable/disabled.

Fixes #111756

Release note (sql change): Cluster setting `sql.insights.flush.enabled` to enable/disable the Insights flush job form memory to persisted.