### PR TITLE
kv: set long lease duration in TestStoreCapacityAfterSplit

### DIFF
--- a/pkg/kv/kvserver/client_split_test.go
+++ b/pkg/kv/kvserver/client_split_test.go
@@ -2821,6 +2821,10 @@ func TestStoreCapacityAfterSplit(t *testing.T) {
 			ReplicationMode: base.ReplicationManual,
 			ServerArgs: base.TestServerArgs{
 				Settings: st,
+				RaftConfig: base.RaftConfig{
+					// Don't expire leases, even when manually adjusting clocks.
+					RangeLeaseDuration: time.Hour,
+				},
 				Knobs: base.TestingKnobs{
 					Server: &server.TestingKnobs{
 						WallClock: manualClock,


### PR DESCRIPTION
Fixes #111439 (hopefully).

The test manually increments the clock by 5 seconds, which can allow the lease to expire. We increase the lease duration to avoid this.

Release note: None