### PR TITLE
kv: set long lease duration in TestTimeSeriesMaintenanceQueue

### DIFF
--- a/pkg/kv/kvserver/ts_maintenance_queue_test.go
+++ b/pkg/kv/kvserver/ts_maintenance_queue_test.go
@@ -107,6 +107,10 @@ func TestTimeSeriesMaintenanceQueue(t *testing.T) {
 
 	ctx := context.Background()
 	s := serverutils.StartServerOnly(t, base.TestServerArgs{
+		RaftConfig: base.RaftConfig{
+			// Don't expire leases, even when manually adjusting clocks.
+			RangeLeaseDuration: time.Hour,
+		},
 		Knobs: base.TestingKnobs{
 			Server: &server.TestingKnobs{
 				WallClock: manual,


### PR DESCRIPTION
Fixes #109100 (hopefully).
Fixes https://github.com/cockroachdb/cockroach/issues/127693 (hopefully as well)

The test manually increments the clock by 24 hours, which can allow the lease to expire. We increase the lease duration to avoid this.

Release note: None