### PR TITLE
ccl: deflake regionless restore mixed version test

### DIFF
--- a/pkg/ccl/backupccl/testdata/backup-restore/restore-regionless-mixed-version
+++ b/pkg/ccl/backupccl/testdata/backup-restore/restore-regionless-mixed-version
@@ -32,10 +32,10 @@ new-cluster name=s2 beforeVersion=23_2_Start share-io-dir=s1 disable-tenant
 ----
 
 # restore fails when cluster is in mixed version state while upgrading to 23.2
-exec-sql
+exec-sql expect-error-regex=(cluster version must be >= *)
 RESTORE FROM LATEST IN 'nodelocal://1/cluster_backup/' WITH remove_regions;
 ----
-pq: to set the remove_regions option, cluster version must be >= 1000023.1-26
+regex matches error
 
 # upgrade cluster
 upgrade-cluster version=23_2


### PR DESCRIPTION
This patch deflakes the regionless restore mixed version test that was added recently. This test expected an exact error message to occur when a cluster that is not on 23.2 performed a restore with the `remove_regions` option; however, the error message itself uses `clusterversion.V23_2` - which currently points to the latest key. As this key is something that changes until it points to the actual version key of V23.2, an `expect-error-regex` should be used in the test.

Epic: none
Fixes: #111789

Release note: None