### PR TITLE
roachtest: fix typeorm setup

### DIFF
--- a/pkg/cmd/roachtest/tests/typeorm.go
+++ b/pkg/cmd/roachtest/tests/typeorm.go
@@ -25,7 +25,10 @@ import (
 )
 
 var typeORMReleaseTagRegex = regexp.MustCompile(`^(?P<major>\d+)\.(?P<minor>\d+)\.(?P<point>\d+)$`)
-var supportedTypeORMRelease = "0.3.17"
+
+// Use 0.3.18 from the upstream repo once it is released.
+const supportedTypeORMRelease = "remove-unsafe-crdb-setting"
+const typeORMRepo = "https://github.com/rafiss/typeorm.git"
 
 // This test runs TypeORM's full test suite against a single cockroach node.
 func registerTypeORM(r registry.Registry) {
@@ -117,7 +120,7 @@ func registerTypeORM(r registry.Registry) {
 			ctx,
 			t,
 			c,
-			"https://github.com/typeorm/typeorm.git",
+			typeORMRepo,
 			"/mnt/data1/typeorm",
 			supportedTypeORMRelease,
 			node,


### PR DESCRIPTION
Use an upstream PR that fixes the test setup. Once the project releases it, this test can be updated to use the official release.

fixes https://github.com/cockroachdb/cockroach/issues/110136
fixes https://github.com/cockroachdb/cockroach/issues/110233
fixes https://github.com/cockroachdb/cockroach/issues/110203

Release note: None