### PR TITLE
catalog/lease: add session based leasing active modes

### DIFF
--- a/docs/generated/metrics/metrics.html
+++ b/docs/generated/metrics/metrics.html
@@ -1360,6 +1360,8 @@
 <tr><td>APPLICATION</td><td>sql.insights.anomaly_detection.fingerprints</td><td>Current number of statement fingerprints being monitored for anomaly detection</td><td>Fingerprints</td><td>GAUGE</td><td>COUNT</td><td>AVG</td><td>NONE</td></tr>
 <tr><td>APPLICATION</td><td>sql.insights.anomaly_detection.memory</td><td>Current memory used to support anomaly detection</td><td>Memory</td><td>GAUGE</td><td>BYTES</td><td>AVG</td><td>NONE</td></tr>
 <tr><td>APPLICATION</td><td>sql.leases.active</td><td>The number of outstanding SQL schema leases.</td><td>Outstanding leases</td><td>GAUGE</td><td>COUNT</td><td>AVG</td><td>NONE</td></tr>
+<tr><td>APPLICATION</td><td>sql.leases.expired</td><td>The number of outstanding session based SQL schema leases expired.</td><td>Leases expired because of a new version</td><td>GAUGE</td><td>COUNT</td><td>AVG</td><td>NONE</td></tr>
+<tr><td>APPLICATION</td><td>sql.leases.waiting_to_expire</td><td>The number of outstanding session based SQL schema leases with expiry.</td><td>Outstanding Leases Waiting to Expire</td><td>GAUGE</td><td>COUNT</td><td>AVG</td><td>NONE</td></tr>
 <tr><td>APPLICATION</td><td>sql.mem.bulk.current</td><td>Current sql statement memory usage for bulk operations</td><td>Memory</td><td>GAUGE</td><td>BYTES</td><td>AVG</td><td>NONE</td></tr>
 <tr><td>APPLICATION</td><td>sql.mem.bulk.max</td><td>Memory usage per sql statement for bulk operations</td><td>Memory</td><td>HISTOGRAM</td><td>BYTES</td><td>AVG</td><td>NONE</td></tr>
 <tr><td>APPLICATION</td><td>sql.mem.conns.current</td><td>Current sql statement memory usage for conns</td><td>Memory</td><td>GAUGE</td><td>BYTES</td><td>AVG</td><td>NONE</td></tr>

--- a/pkg/sql/catalog/lease/BUILD.bazel
+++ b/pkg/sql/catalog/lease/BUILD.bazel
@@ -49,6 +49,7 @@ go_library(
         "//pkg/sql/sessiondata",
         "//pkg/sql/sqlliveness",
         "//pkg/storage",
+        "//pkg/util",
         "//pkg/util/grpcutil",
         "//pkg/util/hlc",
         "//pkg/util/log",

--- a/pkg/sql/catalog/lease/BUILD.bazel
+++ b/pkg/sql/catalog/lease/BUILD.bazel
@@ -121,6 +121,7 @@ go_test(
         "//pkg/sql/rowenc/keyside",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",
+        "//pkg/sql/sqlliveness/slbase",
         "//pkg/sql/sqlliveness/slprovider",
         "//pkg/sql/types",
         "//pkg/storage",

--- a/pkg/sql/catalog/lease/count.go
+++ b/pkg/sql/catalog/lease/count.go
@@ -17,6 +17,8 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	clustersettings "github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/sql/regionliveness"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -39,16 +41,32 @@ func CountLeases(
 	at hlc.Timestamp,
 	forAnyVersion bool,
 ) (int, error) {
-	var whereClauses []string
+	leasingMode := SessionBasedLeasingMode(LeaseEnableSessionBasedLeasing.Get(&settings.SV))
+	whereClauses := make([][]string, 2)
 	for _, t := range versions {
 		versionClause := ""
 		if !forAnyVersion {
 			versionClause = fmt.Sprintf("AND version = %d", t.Version)
 		}
-		whereClauses = append(
-			whereClauses,
+		whereClauses[0] = append(
+			whereClauses[0],
 			fmt.Sprintf(`("descID" = %d %s AND expiration > $1)`, t.ID, versionClause),
 		)
+		whereClauses[1] = append(whereClauses[1],
+			fmt.Sprintf(`(desc_id = %d %s AND (crdb_internal.sql_liveness_is_alive(session_id)))`,
+				t.ID, versionClause),
+		)
+	}
+
+	whereClauseIdx := make([]int, 0, 2)
+	syntheticDescriptors := make(catalog.Descriptors, 0, 2)
+	if leasingMode != SessionBasedOnly {
+		syntheticDescriptors = append(syntheticDescriptors, nil)
+		whereClauseIdx = append(whereClauseIdx, 0)
+	}
+	if leasingMode >= SessionBasedDrain {
+		syntheticDescriptors = append(syntheticDescriptors, systemschema.LeaseTable_V24_1())
+		whereClauseIdx = append(whereClauseIdx, 1)
 	}
 
 	var count int
@@ -64,15 +82,32 @@ func CountLeases(
 		}
 		// Depending on the database configuration query by region or the
 		// entire table.
-		if cachedDatabaseRegions != nil && cachedDatabaseRegions.IsMultiRegion() {
-			count, err = countLeasesByRegion(ctx, txn, prober, regionMap, at, whereClauses)
-		} else {
-			count, err = countLeasesNonMultiRegion(ctx, txn, at, whereClauses)
+		for i := range syntheticDescriptors {
+			whereClause := whereClauses[whereClauseIdx[i]]
+			var descsToInject catalog.Descriptors
+			if syntheticDescriptors[i] != nil {
+				descsToInject = append(descsToInject, syntheticDescriptors[i])
+			}
+			err := txn.WithSyntheticDescriptors(descsToInject,
+				func() error {
+					var err error
+					if cachedDatabaseRegions != nil && cachedDatabaseRegions.IsMultiRegion() {
+						// If we are injecting a raw leases descriptors, that will not have the enum
+						// type set, so convert the region to byte equivalent physical representation.
+						count, err = countLeasesByRegion(ctx, txn, prober, regionMap, cachedDatabaseRegions, len(descsToInject) > 0, at, whereClause)
+					} else {
+						count, err = countLeasesNonMultiRegion(ctx, txn, at, whereClause)
+					}
+					return err
+				})
+			if err != nil {
+				return err
+			}
+			// Exit if either the session or expiry based counts are zero.
+			if count > 0 {
+				return nil
+			}
 		}
-		if err != nil {
-			return err
-		}
-
 		return nil
 	}); err != nil {
 		return 0, err
@@ -109,22 +144,43 @@ func countLeasesByRegion(
 	txn isql.Txn,
 	prober regionliveness.Prober,
 	regionMap regionliveness.LiveRegions,
+	cachedDBRegions regionliveness.CachedDatabaseRegions,
+	convertRegionsToBytes bool,
 	at hlc.Timestamp,
 	whereClauses []string,
 ) (int, error) {
+	regionClause := "crdb_region=$2::system.crdb_internal_region"
+	if convertRegionsToBytes {
+		regionClause = "crdb_region=$2"
+	}
 	stmt := fmt.Sprintf(
 		`SELECT count(1) FROM system.public.lease AS OF SYSTEM TIME '%s' WHERE `,
 		at.AsOfSystemTime(),
-	) + `crdb_region=$2::system.crdb_internal_region AND (` + strings.Join(whereClauses, " OR ") + ")"
+	) + regionClause + ` AND (` + strings.Join(whereClauses, " OR ") + ")"
 	var count int
 	if err := regionMap.ForEach(func(region string) error {
+		regionEnumValue := region
+		// The leases table descriptor injected does not have the type of the column
+		// set to the region enum type. So, instead convert the logical value to
+		// the physical one for comparison.
+		// TODO(fqazi): In 24.2 when this table format is default we can stop using
+		// synthetic descriptors and use the first code path.
+		if convertRegionsToBytes {
+			regionTypeDesc := cachedDBRegions.GetRegionEnumTypeDesc().AsRegionEnumTypeDescriptor()
+			for i := 0; i < regionTypeDesc.NumEnumMembers(); i++ {
+				if regionTypeDesc.GetMemberLogicalRepresentation(i) == region {
+					regionEnumValue = string(regionTypeDesc.GetMemberPhysicalRepresentation(i))
+					break
+				}
+			}
+		}
 		var values tree.Datums
 		queryRegionRows := func(countCtx context.Context) error {
 			var err error
 			values, err = txn.QueryRowEx(
 				countCtx, "count-leases", txn.KV(),
 				sessiondata.NodeUserSessionDataOverride,
-				stmt, at.GoTime(), region,
+				stmt, at.GoTime(), regionEnumValue,
 			)
 			return err
 		}

--- a/pkg/sql/catalog/lease/helpers_test.go
+++ b/pkg/sql/catalog/lease/helpers_test.go
@@ -122,6 +122,8 @@ func (m *Manager) ExpireLeases(clock *hlc.Clock) {
 		desc.mu.Lock()
 		defer desc.mu.Unlock()
 		desc.mu.expiration = past
+		// Wipe the session as if this is an expired version
+		desc.mu.session = nil
 		return nil
 	})
 }

--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -99,7 +99,7 @@ var LeaseEnableSessionBasedLeasing = settings.RegisterEnumSetting(
 	"sql.catalog.experimental_use_session_based_leasing",
 	"enables session based leasing for internal testing.",
 	util.ConstantWithMetamorphicTestChoice("experimental_use_session_based_leasing",
-		"off", "session").(string),
+		"off", "dual_write").(string),
 	map[int64]string{
 		int64(SessionBasedLeasingOff): "off",
 		int64(SessionBasedDualWrite):  "dual_write",
@@ -1405,7 +1405,12 @@ func (m *Manager) PeriodicallyRefreshSomeLeases(ctx context.Context) {
 				// Clean up session based leases that have expired.
 				m.cleanupExpiredSessionLeases(ctx)
 
-				m.refreshSomeLeases(ctx)
+				// Refreshing leases is enabled unless we are past the drain mode,
+				// after which no expiry based leases should be created or updated.
+				// Existing ones can still be queried by schema changes.
+				if !m.sessionBasedLeasingModeAtLeast(SessionBasedDrain) {
+					m.refreshSomeLeases(ctx)
+				}
 			}
 		}
 	})

--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -99,7 +99,7 @@ var LeaseEnableSessionBasedLeasing = settings.RegisterEnumSetting(
 	"sql.catalog.experimental_use_session_based_leasing",
 	"enables session based leasing for internal testing.",
 	util.ConstantWithMetamorphicTestChoice("experimental_use_session_based_leasing",
-		"off", "dual_write").(string),
+		"off", "dual_write", "drain", "session").(string),
 	map[int64]string{
 		int64(SessionBasedLeasingOff): "off",
 		int64(SessionBasedDualWrite):  "dual_write",
@@ -724,9 +724,11 @@ func purgeOldVersions(
 					// duration. If the session lifetime had been longer then use
 					// that. We will only expire later into the future, then what
 					// was previously observed, since transactions may have already
-					// picked this time.
-					leaseToExpire.mu.expiration = m.storage.db.KV().Clock().Now().AddDuration(LeaseDuration.Get(&m.storage.settings.SV))
-					if sessionExpiry := leaseToExpire.mu.session.Expiration(); leaseToExpire.mu.expiration.Less(sessionExpiry) {
+					// picked this time. If the lease duration is zero, then we are
+					// looking at instant expiration for testing.
+					leaseDuration := LeaseDuration.Get(&m.storage.settings.SV)
+					leaseToExpire.mu.expiration = m.storage.db.KV().Clock().Now().AddDuration(leaseDuration)
+					if sessionExpiry := leaseToExpire.mu.session.Expiration(); leaseDuration > 0 && leaseToExpire.mu.expiration.Less(sessionExpiry) {
 						leaseToExpire.mu.expiration = sessionExpiry
 					}
 				}
@@ -1386,13 +1388,19 @@ var leaseRefreshLimit = settings.RegisterIntSetting(
 // TODO(vivek): Remove once epoch based table leases are implemented.
 func (m *Manager) PeriodicallyRefreshSomeLeases(ctx context.Context) {
 	_ = m.stopper.RunAsyncTask(ctx, "lease-refresher", func(ctx context.Context) {
-		leaseDuration := LeaseDuration.Get(&m.storage.settings.SV)
-		if leaseDuration <= 0 {
-			return
+		refreshTimerDuration := LeaseDuration.Get(&m.storage.settings.SV)
+		renewalsDisabled := false
+		if refreshTimerDuration <= 0 {
+			// Session based leasing still needs a refresh loop to expire
+			// leases, so we will execute that without any renewals.
+			refreshTimerDuration = time.Millisecond * 200
+			renewalsDisabled = true
+		} else {
+			refreshTimerDuration = m.storage.jitteredLeaseDuration()
 		}
 		refreshTimer := timeutil.NewTimer()
 		defer refreshTimer.Stop()
-		refreshTimer.Reset(m.storage.jitteredLeaseDuration() / 2)
+		refreshTimer.Reset(refreshTimerDuration / 2)
 		for {
 			select {
 			case <-m.stopper.ShouldQuiesce():
@@ -1408,7 +1416,8 @@ func (m *Manager) PeriodicallyRefreshSomeLeases(ctx context.Context) {
 				// Refreshing leases is enabled unless we are past the drain mode,
 				// after which no expiry based leases should be created or updated.
 				// Existing ones can still be queried by schema changes.
-				if !m.sessionBasedLeasingModeAtLeast(SessionBasedDrain) {
+				if !m.sessionBasedLeasingModeAtLeast(SessionBasedDrain) &&
+					!renewalsDisabled {
 					m.refreshSomeLeases(ctx)
 				}
 			}

--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -692,14 +692,43 @@ func purgeOldVersions(
 	}
 
 	removeInactives := func(dropped bool) {
-		leases := func() []*storedLease {
+		leases, leaseToExpire := func() (leasesToRemove []*storedLease, leasesToExpire *descriptorVersionState) {
 			t.mu.Lock()
 			defer t.mu.Unlock()
 			t.mu.takenOffline = dropped
-			return t.removeInactiveVersions()
+			return t.removeInactiveVersions(), t.mu.active.findPreviousToExpire(dropped)
 		}()
 		for _, l := range leases {
 			releaseLease(ctx, l, m)
+		}
+		// If there are old versions with an active refcount, we cannot allow
+		// these to stay forever. So, setup an expiry on them, which is required
+		// for session based leases.
+		if leaseToExpire != nil {
+			func() {
+				m.mu.Lock()
+				leaseToExpire.mu.Lock()
+				defer leaseToExpire.mu.Unlock()
+				defer m.mu.Unlock()
+				// In dual-write mode there will already be an expiration set,
+				// so we don't need to modify it if it's valid.
+				if leaseToExpire.mu.expiration.Less(m.storage.db.KV().Clock().Now()) {
+					// Expire any active old versions into the future based on the lease
+					// duration. If the session lifetime had been longer then use
+					// that. We will only expire later into the future, then what
+					// was previously observed, since transactions may have already
+					// picked this time.
+					leaseToExpire.mu.expiration = m.storage.db.KV().Clock().Now().AddDuration(LeaseDuration.Get(&m.storage.settings.SV))
+					if sessionExpiry := leaseToExpire.mu.session.Expiration(); leaseToExpire.mu.expiration.Less(sessionExpiry) {
+						leaseToExpire.mu.expiration = sessionExpiry
+					}
+				}
+				leaseToExpire.mu.session = nil
+				if leaseToExpire.mu.lease != nil {
+					m.storage.sessionBasedLeasesWaitingToExpire.Inc(1)
+					m.mu.leasesToExpire = append(m.mu.leasesToExpire, leaseToExpire)
+				}
+			}()
 		}
 	}
 
@@ -764,6 +793,10 @@ type Manager struct {
 		// TODO(james): Track size of leased descriptors in memory.
 		descriptors map[descpb.ID]*descriptorState
 
+		// Session based leases that will be removed with expiry, since
+		// a new version has arrived.
+		leasesToExpire []*descriptorVersionState
+
 		// updatesResolvedTimestamp keeps track of a timestamp before which all
 		// descriptor updates have already been seen.
 		updatesResolvedTimestamp hlc.Timestamp
@@ -817,6 +850,18 @@ func NewLeaseManager(
 				Name:        "sql.leases.active",
 				Help:        "The number of outstanding SQL schema leases.",
 				Measurement: "Outstanding leases",
+				Unit:        metric.Unit_COUNT,
+			}),
+			sessionBasedLeasesWaitingToExpire: metric.NewGauge(metric.Metadata{
+				Name:        "sql.leases.waiting_to_expire",
+				Help:        "The number of outstanding session based SQL schema leases with expiry.",
+				Measurement: "Outstanding Leases Waiting to Expire",
+				Unit:        metric.Unit_COUNT,
+			}),
+			sessionBasedLeasesExpired: metric.NewGauge(metric.Metadata{
+				Name:        "sql.leases.expired",
+				Help:        "The number of outstanding session based SQL schema leases expired.",
+				Measurement: "Leases expired because of a new version",
 				Unit:        metric.Unit_COUNT,
 			}),
 		},
@@ -1188,10 +1233,23 @@ func (m *Manager) findDescriptorState(id descpb.ID, create bool) *descriptorStat
 // RangefeedLeases is not active.
 func (m *Manager) RefreshLeases(ctx context.Context, s *stop.Stopper, db *kv.DB) {
 	descUpdateCh := make(chan catalog.Descriptor)
-	m.watchForUpdates(ctx, descUpdateCh)
+	descDelCh := make(chan descpb.ID)
+	m.watchForUpdates(ctx, descUpdateCh, descDelCh)
 	_ = s.RunAsyncTask(ctx, "refresh-leases", func(ctx context.Context) {
 		for {
 			select {
+			case id := <-descDelCh:
+				// Descriptor is marked as deleted, so mark it for deletion or
+				// remove it if it's no longer in use.
+				_ = s.RunAsyncTask(ctx, "purge deleted descriptor", func(ctx context.Context) {
+					state := m.findNewest(id)
+					if state != nil {
+						if err := purgeOldVersions(ctx, db, id, true /* dropped */, state.GetVersion(), m); err != nil {
+							log.Warningf(ctx, "error purging leases for deleted descriptor %d",
+								id)
+						}
+					}
+				})
 			case desc := <-descUpdateCh:
 				// NB: We allow nil descriptors to be sent to synchronize the updating of
 				// descriptors.
@@ -1254,7 +1312,9 @@ func (m *Manager) RefreshLeases(ctx context.Context, s *stop.Stopper, db *kv.DB)
 
 // watchForUpdates will watch a rangefeed on the system.descriptor table for
 // updates.
-func (m *Manager) watchForUpdates(ctx context.Context, descUpdateCh chan<- catalog.Descriptor) {
+func (m *Manager) watchForUpdates(
+	ctx context.Context, descUpdateCh chan<- catalog.Descriptor, descDelCh chan<- descpb.ID,
+) {
 	if log.V(1) {
 		log.Infof(ctx, "using rangefeeds for lease manager updates")
 	}
@@ -1267,6 +1327,15 @@ func (m *Manager) watchForUpdates(ctx context.Context, descUpdateCh chan<- catal
 		ctx context.Context, ev *kvpb.RangeFeedValue,
 	) {
 		if len(ev.Value.RawBytes) == 0 {
+			id, err := m.Codec().DecodeDescMetadataID(ev.Key)
+			if err != nil {
+				log.Infof(ctx, "unable to decode metadata key %v", ev.Key)
+				return
+			}
+			select {
+			case <-ctx.Done():
+			case descDelCh <- descpb.ID(id):
+			}
 			return
 		}
 		b, err := descbuilder.FromSerializedValue(&ev.Value)
@@ -1326,10 +1395,67 @@ func (m *Manager) PeriodicallyRefreshSomeLeases(ctx context.Context) {
 				refreshTimer.Read = true
 				refreshTimer.Reset(m.storage.jitteredLeaseDuration() / 2)
 
+				// Clean up session based leases that have expired.
+				m.cleanupExpiredSessionLeases(ctx)
+
 				m.refreshSomeLeases(ctx)
 			}
 		}
 	})
+}
+
+// cleanupExpiredSessionLeases expires session based leases marked for removal,
+// which will happen when a new version is published.
+func (m *Manager) cleanupExpiredSessionLeases(ctx context.Context) {
+	now := m.storage.db.KV().Clock().Now()
+	latest := -1
+	// Leases which have hit their expiry time, which will be finally discarded
+	// from the storage layer.
+	var leasesToDiscard []*descriptorVersionState
+	func() {
+		m.mu.Lock()
+		defer m.mu.Unlock()
+		// First go through the leases which have an expiry set and find out which
+		// ones have expired. The slice is sorted by the expiry time, so once we
+		// find the first non-expired lease we are done.
+		for i, desc := range m.mu.leasesToExpire {
+			if desc.hasExpired(now) {
+				latest = i
+			} else {
+				break
+			}
+		}
+		// Next extract the slice of the leases that needed to be removed from
+		// storage.
+		if latest >= 0 {
+			leasesToDiscard = m.mu.leasesToExpire[0 : latest+1]
+			m.storage.sessionBasedLeasesWaitingToExpire.Dec(int64(len(leasesToDiscard)))
+			m.mu.leasesToExpire = m.mu.leasesToExpire[latest+1:]
+		}
+	}()
+
+	// Finally for each lease that has expired we can discard it from the storage
+	// layer.
+	if len(leasesToDiscard) > 0 {
+		if err := m.stopper.RunAsyncTask(ctx, "clearing expired session based leases from storage", func(ctx context.Context) {
+			for _, l := range leasesToDiscard {
+				l.mu.Lock()
+				leaseToDelete := l.mu.lease
+				l.mu.lease = nil
+				l.mu.Unlock()
+				// Its possible the reference count has concurrently hit
+				// zero and been cleaned up, so check if there is a lease
+				// to delete first.
+				if leaseToDelete != nil {
+					m.storage.release(ctx, m.stopper, leaseToDelete)
+					m.storage.sessionBasedLeasesExpired.Inc(1)
+				}
+
+			}
+		}); err != nil {
+			log.Infof(ctx, "unable to delete leases from storage %s", err)
+		}
+	}
 }
 
 // Refresh some of the current leases.
@@ -1514,13 +1640,17 @@ func (m *Manager) SystemDatabaseCache() *catkv.SystemDatabaseCache {
 // Metrics contains a pointer to all relevant lease.Manager metrics, for
 // registration.
 type Metrics struct {
-	OutstandingLeases *metric.Gauge
+	OutstandingLeases                 *metric.Gauge
+	SessionBasedLeasesWaitingToExpire *metric.Gauge
+	SessionBasedLeasesExpired         *metric.Gauge
 }
 
 // MetricsStruct returns a struct containing all of this Manager's metrics.
 func (m *Manager) MetricsStruct() Metrics {
 	return Metrics{
-		OutstandingLeases: m.storage.outstandingLeases,
+		OutstandingLeases:                 m.storage.outstandingLeases,
+		SessionBasedLeasesExpired:         m.storage.sessionBasedLeasesExpired,
+		SessionBasedLeasesWaitingToExpire: m.storage.sessionBasedLeasesWaitingToExpire,
 	}
 }
 

--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -41,6 +41,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness"
 	kvstorage "github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/log/logcrash"
@@ -97,7 +98,8 @@ var LeaseEnableSessionBasedLeasing = settings.RegisterEnumSetting(
 	settings.ApplicationLevel,
 	"sql.catalog.experimental_use_session_based_leasing",
 	"enables session based leasing for internal testing.",
-	"off",
+	util.ConstantWithMetamorphicTestChoice("experimental_use_session_based_leasing",
+		"off", "session").(string),
 	map[int64]string{
 		int64(SessionBasedLeasingOff): "off",
 		int64(SessionBasedDualWrite):  "dual_write",
@@ -117,6 +119,8 @@ func (m *Manager) getSessionBasedLeasingMode() SessionBasedLeasingMode {
 	return SessionBasedLeasingMode(LeaseEnableSessionBasedLeasing.Get(&m.settings.SV))
 }
 
+// WaitForNoVersion returns once there are no unexpired leases left
+// for any version of the descriptor.
 // WaitForNoVersion returns once there are no unexpired leases left
 // for any version of the descriptor.
 func (m *Manager) WaitForNoVersion(
@@ -144,6 +148,9 @@ func (m *Manager) WaitForNoVersion(
 		if count != lastCount {
 			lastCount = count
 			log.Infof(ctx, "waiting for %d leases to expire: desc=%d", count, id)
+		}
+		if lastCount == 0 {
+			break
 		}
 	}
 	return nil

--- a/pkg/sql/catalog/lease/storage.go
+++ b/pkg/sql/catalog/lease/storage.go
@@ -62,9 +62,11 @@ type storage struct {
 	// concurrent lease acquisitions from the store.
 	group *singleflight.Group
 
-	outstandingLeases *metric.Gauge
-	testingKnobs      StorageTestingKnobs
-	writer            writer
+	outstandingLeases                 *metric.Gauge
+	sessionBasedLeasesWaitingToExpire *metric.Gauge
+	sessionBasedLeasesExpired         *metric.Gauge
+	testingKnobs                      StorageTestingKnobs
+	writer                            writer
 }
 
 type leaseFields struct {

--- a/pkg/sql/catalog/lease/testutils.go
+++ b/pkg/sql/catalog/lease/testutils.go
@@ -98,3 +98,15 @@ func (m *Manager) TestingAcquireAndAssertMinVersion(
 func (m *Manager) TestingOutstandingLeasesGauge() *metric.Gauge {
 	return m.storage.outstandingLeases
 }
+
+// TestingSessionBasedLeasesExpiredGauge returns the session based leases
+// expired gauge that is used by this lease manager.
+func (m *Manager) TestingSessionBasedLeasesExpiredGauge() *metric.Gauge {
+	return m.storage.sessionBasedLeasesExpired
+}
+
+// TestingSessionBasedLeasesWaitingToExpireGauge returns the session based leases
+// waiting to expire gauge that is used by this lease manager.
+func (m *Manager) TestingSessionBasedLeasesWaitingToExpireGauge() *metric.Gauge {
+	return m.storage.sessionBasedLeasesWaitingToExpire
+}


### PR DESCRIPTION
These commits will do the following:

1. Add support for expiring session-based leases, which is a necessity before schema changes can start counting them
2. Add support for counting session-based leases so that schema changes can be blocked based on them waiting for a new version. Depending on the mode, both the new and old table formats will be queried.
3. Add support for the drain mode of session-based leases, where lease renewals
4. Enable metamorphic testing of the new leasing modes to properly test this code.

informs: https://github.com/cockroachdb/cockroach/issues/95765


