### PR TITLE
sql: add telemetry to cryptographic builtin functions

### DIFF
--- a/pkg/ccl/telemetryccl/testdata/telemetry/builtins
+++ b/pkg/ccl/telemetryccl/testdata/telemetry/builtins
@@ -1,0 +1,23 @@
+feature-allowlist
+sql.builtins.*
+----
+
+feature-usage
+SELECT encrypt('abc', 'key', 'aes')
+----
+sql.builtins.crypto.encrypt
+
+feature-usage
+SELECT encrypt_iv('abc', 'key', '123', 'aes')
+----
+sql.builtins.crypto.encrypt_iv
+
+feature-usage
+SELECT decrypt('\xdb5f149a7caf0cd275ca18c203a212c9', 'key', 'aes')
+----
+sql.builtins.crypto.decrypt
+
+feature-usage
+SELECT decrypt_iv('\x91b4ef63852013c8da53829da662b871', 'key', '123', 'aes')
+----
+sql.builtins.crypto.decrypt_iv

--- a/pkg/sql/sqltelemetry/function.go
+++ b/pkg/sql/sqltelemetry/function.go
@@ -10,10 +10,54 @@
 
 package sqltelemetry
 
-import "github.com/cockroachdb/cockroach/pkg/server/telemetry"
+import (
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
+)
 
 // IncrementPlpgsqlStmtCounter is to be incremented every time a new plpgsql stmt is
 // used for a newly created function.
 func IncrementPlpgsqlStmtCounter(stmtTag string) {
 	telemetry.Inc(telemetry.GetCounter("sql.plpgsql." + stmtTag))
+}
+
+const builtinFunctionTelemetryPrefix = "sql.builtins"
+
+// BuiltinFunctionTelemetryType is an enum for the type of builtin function
+// that we are collecting telemetry for.
+type BuiltinFunctionTelemetryType int
+
+const (
+	_ BuiltinFunctionTelemetryType = iota
+)
+
+var builtinFunctionTelemetryNameMap = map[BuiltinFunctionTelemetryType]string{}
+
+var builtinFunctionTelemetryCounters map[BuiltinFunctionTelemetryType]map[string]telemetry.Counter
+
+func init() {
+	builtinFunctionTelemetryCounters = make(map[BuiltinFunctionTelemetryType]map[string]telemetry.Counter)
+	for typ := range builtinFunctionTelemetryNameMap {
+		builtinFunctionTelemetryCounters[typ] = make(map[string]telemetry.Counter)
+	}
+}
+
+// IncBuiltinFunctionCounter increments counter for the specified builtin.
+func IncBuiltinFunctionCounter(builtinType BuiltinFunctionTelemetryType, builtinName string) {
+	builtinTypeName := builtinFunctionTelemetryNameMap[builtinType]
+	builtinTypeCounters := builtinFunctionTelemetryCounters[builtinType]
+	if builtinTypeName == "" || builtinTypeCounters == nil {
+		// If the builtin type is missing from either map then it must be invalid.
+		return
+	}
+
+	counter, ok := builtinTypeCounters[builtinName]
+	if !ok {
+		counter = telemetry.GetCounter(fmt.Sprintf("%s.%s.%s",
+			builtinFunctionTelemetryPrefix, builtinTypeName, builtinName))
+		builtinTypeCounters[builtinName] = counter
+	}
+
+	telemetry.Inc(counter)
 }

--- a/pkg/sql/sqltelemetry/function.go
+++ b/pkg/sql/sqltelemetry/function.go
@@ -30,9 +30,13 @@ type BuiltinFunctionTelemetryType int
 
 const (
 	_ BuiltinFunctionTelemetryType = iota
+	// CryptoBuiltinFunction is used for cryptographic builtin functions.
+	CryptoBuiltinFunction
 )
 
-var builtinFunctionTelemetryNameMap = map[BuiltinFunctionTelemetryType]string{}
+var builtinFunctionTelemetryNameMap = map[BuiltinFunctionTelemetryType]string{
+	CryptoBuiltinFunction: "crypto",
+}
 
 var builtinFunctionTelemetryCounters map[BuiltinFunctionTelemetryType]map[string]telemetry.Counter
 

--- a/pkg/sql/testdata/telemetry/builtins
+++ b/pkg/sql/testdata/telemetry/builtins
@@ -1,0 +1,33 @@
+feature-allowlist
+sql.builtins.*
+----
+
+feature-usage
+SELECT crypt('password', '$1$aRnqRmeP')
+----
+sql.builtins.crypto.crypt
+
+feature-usage
+SELECT digest('hello', 'sha256')
+----
+sql.builtins.crypto.digest
+
+feature-usage
+SELECT gen_random_bytes(64)
+----
+sql.builtins.crypto.gen_random_bytes
+
+feature-usage
+SELECT gen_salt('xdes')
+----
+sql.builtins.crypto.gen_salt
+
+feature-usage
+SELECT gen_salt('xdes', 1)
+----
+sql.builtins.crypto.gen_salt
+
+feature-usage
+SELECT hmac('hello', 'key', 'sha256')
+----
+sql.builtins.crypto.hmac


### PR DESCRIPTION
**sqltelemetry: add framework to count builtin function calls**

This patch adds a framework to collect telemetry for builtin function
calls. The counters will have a prefix of `sql.builtins` followed by
the builtin type and then the builtin name.

Release note: None

---

**sql: add telemetry to cryptographic builtin functions**

This patch adds telemetry to count the number of times any of the
cryptographic builtin functions are called.

Release note: None

---

Fixes #111323