### PR TITLE
catalog: don't set modification time for offline descriptors

### DIFF
--- a/pkg/sql/catalog/dbdesc/database_desc_builder.go
+++ b/pkg/sql/catalog/dbdesc/database_desc_builder.go
@@ -99,7 +99,7 @@ func (ddb *databaseDescriptorBuilder) RunPostDeserializationChanges() (err error
 	// Set the ModificationTime field before doing anything else.
 	// Other changes may depend on it.
 	mustSetModTime, err := descpb.MustSetModificationTime(
-		ddb.original.ModificationTime, ddb.mvccTimestamp, ddb.original.Version,
+		ddb.original.ModificationTime, ddb.mvccTimestamp, ddb.original.Version, ddb.original.State,
 	)
 	if err != nil {
 		return err

--- a/pkg/sql/catalog/descpb/descriptor.go
+++ b/pkg/sql/catalog/descpb/descriptor.go
@@ -87,8 +87,14 @@ func GetDescriptors(
 // field must be set to the given MVCC timestamp. An error is returned if the
 // argument values are inconsistent.
 func MustSetModificationTime(
-	modTime hlc.Timestamp, mvccTimestamp hlc.Timestamp, version DescriptorVersion,
+	modTime hlc.Timestamp,
+	mvccTimestamp hlc.Timestamp,
+	version DescriptorVersion,
+	state DescriptorState,
 ) (bool, error) {
+	if state == DescriptorState_OFFLINE {
+		return false, nil
+	}
 	// Set the ModificationTime based on the passed mvccTimestamp if we should.
 	// Table descriptors can be updated in place after their version has been
 	// incremented (e.g. to include a schema change lease).

--- a/pkg/sql/catalog/funcdesc/func_desc_builder.go
+++ b/pkg/sql/catalog/funcdesc/func_desc_builder.go
@@ -92,7 +92,7 @@ func (fdb *functionDescriptorBuilder) RunPostDeserializationChanges() (err error
 	// Set the ModificationTime field before doing anything else.
 	// Other changes may depend on it.
 	mustSetModTime, err := descpb.MustSetModificationTime(
-		fdb.original.ModificationTime, fdb.mvccTimestamp, fdb.original.Version,
+		fdb.original.ModificationTime, fdb.mvccTimestamp, fdb.original.Version, fdb.original.State,
 	)
 	if err != nil {
 		return err

--- a/pkg/sql/catalog/schemadesc/schema_desc_builder.go
+++ b/pkg/sql/catalog/schemadesc/schema_desc_builder.go
@@ -94,7 +94,7 @@ func (sdb *schemaDescriptorBuilder) RunPostDeserializationChanges() (err error) 
 	// Set the ModificationTime field before doing anything else.
 	// Other changes may depend on it.
 	mustSetModTime, err := descpb.MustSetModificationTime(
-		sdb.original.ModificationTime, sdb.mvccTimestamp, sdb.original.Version,
+		sdb.original.ModificationTime, sdb.mvccTimestamp, sdb.original.Version, sdb.original.State,
 	)
 	if err != nil {
 		return err

--- a/pkg/sql/catalog/tabledesc/table_desc_builder.go
+++ b/pkg/sql/catalog/tabledesc/table_desc_builder.go
@@ -134,7 +134,7 @@ func (tdb *tableDescriptorBuilder) RunPostDeserializationChanges() (err error) {
 	// Set the ModificationTime field before doing anything else.
 	// Other changes may depend on it.
 	mustSetModTime, err := descpb.MustSetModificationTime(
-		tdb.original.ModificationTime, tdb.mvccTimestamp, tdb.original.Version,
+		tdb.original.ModificationTime, tdb.mvccTimestamp, tdb.original.Version, tdb.original.State,
 	)
 	if err != nil {
 		return err

--- a/pkg/sql/catalog/typedesc/type_desc_builder.go
+++ b/pkg/sql/catalog/typedesc/type_desc_builder.go
@@ -95,7 +95,7 @@ func (tdb *typeDescriptorBuilder) RunPostDeserializationChanges() (err error) {
 	// Set the ModificationTime field before doing anything else.
 	// Other changes may depend on it.
 	mustSetModTime, err := descpb.MustSetModificationTime(
-		tdb.original.ModificationTime, tdb.mvccTimestamp, tdb.original.Version,
+		tdb.original.ModificationTime, tdb.mvccTimestamp, tdb.original.Version, tdb.original.State,
 	)
 	if err != nil {
 		return err


### PR DESCRIPTION
There is a post-deserialization change that automatically sets the
modification time for all descriptors if it is not present. Notably,
there is also a cluster upgrade step that rewrites all descriptors with
post-deserialization changes, and bumps their version.

If a RESTORE is running during an upgrade, the descriptors it tries to
rewrite could have been also bumped by the upgrade step. That
would cause the RESTORE to fail.

Now, the change to automatically set the modification time is disabled
if the descriptor is on the offline state, as it is during RESTORE.

fixes https://github.com/cockroachdb/cockroach/issues/109976

Release note (bug fix): Fixed a bug that could prevent RESTORE from
working if it was performed during a cluster upgrade.