### PR TITLE
release-23.1: roachprod: enhance/clarify terminology

### DIFF
--- a/pkg/cmd/roachprod/flags.go
+++ b/pkg/cmd/roachprod/flags.go
@@ -47,8 +47,8 @@ var (
 	listMine              bool
 	listPattern           string
 	secure                = false
-	tenantName            string
-	tenantInstance        int
+	virtualClusterName    string
+	sqlInstance           int
 	extraSSHOptions       = ""
 	nodeEnv               []string
 	tag                   string
@@ -78,8 +78,8 @@ var (
 	monitorOpts        install.MonitorOpts
 	cachedHostsCluster string
 
-	// hostCluster is used for multi-tenant functionality.
-	hostCluster string
+	// storageCluster is used for cluster virtualization and multi-tenant functionality.
+	storageCluster string
 )
 
 func initFlags() {
@@ -206,13 +206,13 @@ func initFlags() {
 		`Recurrence and scheduled backup options specification.
 Default is "RECURRING '*/15 * * * *' FULL BACKUP '@hourly' WITH SCHEDULE OPTIONS first_run = 'now'"`)
 
-	startTenantCmd.Flags().StringVarP(&hostCluster,
-		"host-cluster", "H", "", "host cluster")
-	_ = startTenantCmd.MarkFlagRequired("host-cluster")
-	startTenantCmd.Flags().IntVarP(&startOpts.TenantID,
-		"tenant-id", "t", startOpts.TenantID, "tenant ID")
-	startTenantCmd.Flags().IntVar(&startOpts.TenantInstance,
-		"tenant-instance", 0, "specific tenant instance to connect to")
+	startInstanceAsSeparateProcessCmd.Flags().StringVarP(&storageCluster,
+		"storage-cluster", "S", "", "storage cluster")
+	_ = startInstanceAsSeparateProcessCmd.MarkFlagRequired("storage-cluster")
+	startInstanceAsSeparateProcessCmd.Flags().IntVarP(&startOpts.VirtualClusterID,
+		"cluster-id", "i", startOpts.VirtualClusterID, "internal ID for the virtual cluster")
+	startInstanceAsSeparateProcessCmd.Flags().IntVar(&startOpts.SQLInstance,
+		"sql-instance", 0, "specific SQL/HTTP instance to connect to (this is a roachprod abstraction distinct from the internal instance ID)")
 
 	stopCmd.Flags().IntVar(&sig, "sig", sig, "signal to pass to kill")
 	stopCmd.Flags().BoolVar(&waitFlag, "wait", waitFlag, "wait for processes to exit")
@@ -317,7 +317,7 @@ Default is "RECURRING '*/15 * * * *' FULL BACKUP '@hourly' WITH SCHEDULE OPTIONS
 			&ssh.InsecureIgnoreHostKey, "insecure-ignore-host-key", true, "don't check ssh host keys")
 	}
 
-	for _, cmd := range []*cobra.Command{startCmd, startTenantCmd} {
+	for _, cmd := range []*cobra.Command{startCmd, startInstanceAsSeparateProcessCmd} {
 		cmd.Flags().BoolVar(&startOpts.Sequential,
 			"sequential", startOpts.Sequential, "start nodes sequentially so node IDs match hostnames")
 		cmd.Flags().Int64Var(&startOpts.NumFilesLimit, "num-files-limit", startOpts.NumFilesLimit,
@@ -341,15 +341,15 @@ Default is "RECURRING '*/15 * * * *' FULL BACKUP '@hourly' WITH SCHEDULE OPTIONS
 		cmd.Flags().StringVarP(&config.Binary,
 			"binary", "b", config.Binary, "the remote cockroach binary to use")
 	}
-	for _, cmd := range []*cobra.Command{startCmd, startTenantCmd, sqlCmd, pgurlCmd, adminurlCmd, runCmd} {
+	for _, cmd := range []*cobra.Command{startCmd, startInstanceAsSeparateProcessCmd, sqlCmd, pgurlCmd, adminurlCmd, runCmd} {
 		cmd.Flags().BoolVar(&secure,
 			"secure", false, "use a secure cluster")
 	}
 	for _, cmd := range []*cobra.Command{pgurlCmd, sqlCmd, adminurlCmd} {
-		cmd.Flags().StringVar(&tenantName,
-			"tenant-name", "", "specific tenant to connect to")
-		cmd.Flags().IntVar(&tenantInstance,
-			"tenant-instance", 0, "specific tenant instance to connect to")
+		cmd.Flags().StringVar(&virtualClusterName,
+			"cluster", "", "specific virtual cluster to connect to")
+		cmd.Flags().IntVar(&sqlInstance,
+			"sql-instance", 0, "specific SQL/HTTP instance to connect to (this is a roachprod abstraction distinct from the internal instance ID)")
 	}
 
 }

--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -435,15 +435,19 @@ SIGHUP), unless you also configure --max-wait.
 	}),
 }
 
-var startTenantCmd = &cobra.Command{
-	Use:   "start-tenant <tenant-cluster> --host-cluster <host-cluster>",
-	Short: "start a tenant",
-	Long: `Start SQL instances for a non-system tenant.
+// TODO(herko/renato): maybe also support adding SQL instances to a
+// shared-process node.
+var startInstanceAsSeparateProcessCmd = &cobra.Command{
+	Use:   "start-sql <virtual-cluster> --storage-cluster <storage-cluster>",
+	Short: "start the SQL/HTTP service for a virtual cluster as a separate process",
+	Long: `Start SQL/HTTP instances for a virtual cluster as separate processes.
 
-The --host-cluster flag must be used to specify a host cluster (with optional
-node selector) which is already running. The command will create the tenant on
-the host cluster if it does not exist already. The host and tenant can use the
-same underlying cluster, as long as different subsets of nodes are selected.
+The --storage-cluster flag must be used to specify a storage cluster
+(with optional node selector) which is already running. The command
+will create the virtual cluster on the storage cluster if it does not
+exist already. The storage cluster and virtual cluster can use the
+same underlying roachprod VM cluster, as long as different subsets of
+nodes are selected.
 
 The --tenant-id flag can be used to specify the tenant ID; it defaults to 2.
 
@@ -465,7 +469,7 @@ environment variables to the cockroach process.
 `,
 	Args: cobra.ExactArgs(1),
 	Run: wrap(func(cmd *cobra.Command, args []string) error {
-		tenantCluster := args[0]
+		targetRoachprodCluster := args[0]
 		clusterSettingsOpts := []install.ClusterSettingOption{
 			install.TagOption(tag),
 			install.PGUrlCertsDirOption(pgurlCertsDir),
@@ -474,7 +478,8 @@ environment variables to the cockroach process.
 			install.EnvOption(nodeEnv),
 			install.NumRacksOption(numRacks),
 		}
-		return roachprod.StartTenant(context.Background(), config.Logger, tenantCluster, hostCluster, startOpts, clusterSettingsOpts...)
+		return roachprod.StartServiceForVirtualCluster(context.Background(),
+			config.Logger, targetRoachprodCluster, storageCluster, startOpts, clusterSettingsOpts...)
 	}),
 }
 
@@ -807,7 +812,7 @@ var sqlCmd = &cobra.Command{
 	Long:  "Run `cockroach sql` on a remote cluster.\n",
 	Args:  cobra.MinimumNArgs(1),
 	Run: wrap(func(cmd *cobra.Command, args []string) error {
-		return roachprod.SQL(context.Background(), config.Logger, args[0], secure, tenantName, tenantInstance, args[1:])
+		return roachprod.SQL(context.Background(), config.Logger, args[0], secure, virtualClusterName, sqlInstance, args[1:])
 	}),
 }
 
@@ -819,10 +824,10 @@ var pgurlCmd = &cobra.Command{
 	Args: cobra.ExactArgs(1),
 	Run: wrap(func(cmd *cobra.Command, args []string) error {
 		urls, err := roachprod.PgURL(context.Background(), config.Logger, args[0], pgurlCertsDir, roachprod.PGURLOptions{
-			External:       external,
-			Secure:         secure,
-			TenantName:     tenantName,
-			TenantInstance: tenantInstance,
+			External:           external,
+			Secure:             secure,
+			VirtualClusterName: virtualClusterName,
+			SQLInstance:        sqlInstance,
 		})
 		if err != nil {
 			return err
@@ -867,7 +872,7 @@ var adminurlCmd = &cobra.Command{
 	Args: cobra.ExactArgs(1),
 	Run: wrap(func(cmd *cobra.Command, args []string) error {
 		urls, err := roachprod.AdminURL(
-			context.Background(), config.Logger, args[0], tenantName, tenantInstance, adminurlPath, adminurlIPs, adminurlOpen, secure,
+			context.Background(), config.Logger, args[0], virtualClusterName, sqlInstance, adminurlPath, adminurlIPs, adminurlOpen, secure,
 		)
 		if err != nil {
 			return err
@@ -1117,7 +1122,7 @@ func main() {
 		monitorCmd,
 		startCmd,
 		stopCmd,
-		startTenantCmd,
+		startInstanceAsSeparateProcessCmd,
 		initCmd,
 		runCmd,
 		signalCmd,

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -2273,9 +2273,9 @@ func (c *clusterImpl) pgURLErr(
 	ctx context.Context, l *logger.Logger, node option.NodeListOption, external bool, tenant string,
 ) ([]string, error) {
 	urls, err := roachprod.PgURL(ctx, l, c.MakeNodes(node), c.localCertsDir, roachprod.PGURLOptions{
-		External:   external,
-		Secure:     c.localCertsDir != "",
-		TenantName: tenant})
+		External:           external,
+		Secure:             c.localCertsDir != "",
+		VirtualClusterName: tenant})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -421,7 +421,7 @@ func (c *SyncedCluster) Signal(ctx context.Context, l *logger.Logger, sig int) e
 // cmdName and display specify the roachprod subcommand and a status message,
 // for output/logging. If wait is true, the command will wait for the processes
 // to exit, up to maxWait seconds.
-// TODO(herko): This command does not support tenants yet.
+// TODO(herko): This command does not support virtual clusters yet.
 func (c *SyncedCluster) kill(
 	ctx context.Context, l *logger.Logger, cmdName, display string, sig int, wait bool, maxWait int,
 ) error {
@@ -1992,7 +1992,7 @@ func (c *SyncedCluster) Put(
 // <user> allows retrieval of logs from a roachprod cluster being run by another
 // user and assumes that the current user used to create c has the ability to
 // sudo into <user>.
-// TODO(herko): This command does not support tenants yet.
+// TODO(herko): This command does not support virtual clusters yet.
 func (c *SyncedCluster) Logs(
 	l *logger.Logger,
 	src, dest, user, filter, programFilter string,
@@ -2346,7 +2346,7 @@ func (c *SyncedCluster) Get(
 
 // pgurls returns a map of PG URLs for the given nodes.
 func (c *SyncedCluster) pgurls(
-	ctx context.Context, l *logger.Logger, nodes Nodes, tenantName string, tenantInstance int,
+	ctx context.Context, l *logger.Logger, nodes Nodes, virtualClusterName string, sqlInstance int,
 ) (map[Node]string, error) {
 	hosts, err := c.pghosts(ctx, l, nodes)
 	if err != nil {
@@ -2354,15 +2354,15 @@ func (c *SyncedCluster) pgurls(
 	}
 	m := make(map[Node]string, len(hosts))
 	for node, host := range hosts {
-		desc, err := c.DiscoverService(ctx, node, tenantName, ServiceTypeSQL, tenantInstance)
+		desc, err := c.DiscoverService(ctx, node, virtualClusterName, ServiceTypeSQL, sqlInstance)
 		if err != nil {
 			return nil, err
 		}
-		sharedTenantName := ""
+		sharedClusterName := ""
 		if desc.ServiceMode == ServiceModeShared {
-			sharedTenantName = tenantName
+			sharedClusterName = virtualClusterName
 		}
-		m[node] = c.NodeURL(host, desc.Port, sharedTenantName)
+		m[node] = c.NodeURL(host, desc.Port, sharedClusterName)
 	}
 	return m, nil
 }

--- a/pkg/roachprod/install/cockroach.go
+++ b/pkg/roachprod/install/cockroach.go
@@ -122,12 +122,12 @@ type StartOpts struct {
 	StoreCount      int
 	EncryptedStores bool
 
-	// -- Options that apply only to StartTenantSQL target --
-	TenantName     string
-	TenantID       int
-	TenantInstance int
-	KVAddrs        string
-	KVCluster      *SyncedCluster
+	// -- Options that apply only to the StartServiceForVirtualCluster target --
+	VirtualClusterName string
+	VirtualClusterID   int
+	SQLInstance        int
+	KVAddrs            string
+	KVCluster          *SyncedCluster
 }
 
 // startSQLTimeout identifies the COCKROACH_CONNECT_TIMEOUT to use (in seconds)
@@ -140,19 +140,21 @@ type StartTarget int
 const (
 	// StartDefault starts a "full" (KV+SQL) node (the default).
 	StartDefault StartTarget = iota
-	// StartTenantSQL starts a tenant SQL-only process.
-	StartTenantSQL
-	// StartTenantProxy starts a tenant SQL proxy process.
-	StartTenantProxy
+	// StartServiceForVirtualCluster starts a SQL/HTTP-only server
+	// process for a virtual cluster.
+	StartServiceForVirtualCluster
+	// StartRoutingProxy starts the SQL proxy process to route
+	// connections to multiple virtual clusters.
+	StartRoutingProxy
 )
 
 const defaultInitTarget = Node(1)
 
 func (st StartTarget) String() string {
 	return [...]string{
-		StartDefault:     "default",
-		StartTenantSQL:   "tenant SQL",
-		StartTenantProxy: "tenant proxy",
+		StartDefault:                  "default",
+		StartServiceForVirtualCluster: "SQL/HTTP instance for virtual cluster",
+		StartRoutingProxy:             "SQL proxy for multiple tenants",
 	}[st]
 }
 
@@ -179,21 +181,22 @@ func (so StartOpts) GetJoinTargets() []Node {
 	return nodes
 }
 
-// maybeRegisterServices registers the SQL and Admin UI DNS services for the
-// cluster if no previous services for the tenant or host cluster are found. Any
-// ports specified in the startOpts are used for the services. If no ports are
-// specified, a search for open ports will be performed and selected for use.
+// maybeRegisterServices registers the SQL and Admin UI DNS services
+// for the cluster if no previous services for the virtual or storage
+// cluster are found. Any ports specified in the startOpts are used
+// for the services. If no ports are specified, a search for open
+// ports will be performed and selected for use.
 func (c *SyncedCluster) maybeRegisterServices(
 	ctx context.Context, l *logger.Logger, startOpts StartOpts,
 ) error {
-	serviceMap, err := c.MapServices(ctx, startOpts.TenantName, startOpts.TenantInstance)
+	serviceMap, err := c.MapServices(ctx, startOpts.VirtualClusterName, startOpts.SQLInstance)
 	if err != nil {
 		return err
 	}
-	tenantName := SystemTenantName
+	virtualClusterName := SystemInterfaceName
 	serviceMode := ServiceModeShared
-	if startOpts.Target == StartTenantSQL {
-		tenantName = startOpts.TenantName
+	if startOpts.Target == StartServiceForVirtualCluster {
+		virtualClusterName = startOpts.VirtualClusterName
 		serviceMode = ServiceModeExternal
 	}
 
@@ -204,22 +207,22 @@ func (c *SyncedCluster) maybeRegisterServices(
 		res := &RunResultDetails{Node: node}
 		if _, ok := serviceMap[node][ServiceTypeSQL]; !ok {
 			services = append(services, ServiceDesc{
-				TenantName:  tenantName,
-				ServiceType: ServiceTypeSQL,
-				ServiceMode: serviceMode,
-				Node:        node,
-				Port:        startOpts.SQLPort,
-				Instance:    startOpts.TenantInstance,
+				VirtualClusterName: virtualClusterName,
+				ServiceType:        ServiceTypeSQL,
+				ServiceMode:        serviceMode,
+				Node:               node,
+				Port:               startOpts.SQLPort,
+				Instance:           startOpts.SQLInstance,
 			})
 		}
 		if _, ok := serviceMap[node][ServiceTypeUI]; !ok {
 			services = append(services, ServiceDesc{
-				TenantName:  tenantName,
-				ServiceType: ServiceTypeUI,
-				ServiceMode: serviceMode,
-				Node:        node,
-				Port:        startOpts.AdminUIPort,
-				Instance:    startOpts.TenantInstance,
+				VirtualClusterName: virtualClusterName,
+				ServiceType:        ServiceTypeUI,
+				ServiceMode:        serviceMode,
+				Node:               node,
+				Port:               startOpts.AdminUIPort,
+				Instance:           startOpts.SQLInstance,
 			})
 		}
 		requiredPorts := 0
@@ -266,8 +269,8 @@ func (c *SyncedCluster) maybeRegisterServices(
 // `start-single-node` (this was written to provide a short hand to start a
 // single node cluster with a replication factor of one).
 func (c *SyncedCluster) Start(ctx context.Context, l *logger.Logger, startOpts StartOpts) error {
-	if startOpts.Target == StartTenantProxy {
-		return fmt.Errorf("start tenant proxy not implemented")
+	if startOpts.Target == StartRoutingProxy {
+		return fmt.Errorf("start SQL proxy not implemented")
 	}
 	// Local clusters do not support specifying ports. An error is returned if we
 	// detect that they were set.
@@ -292,8 +295,8 @@ func (c *SyncedCluster) Start(ctx context.Context, l *logger.Logger, startOpts S
 		if err := c.distributeCerts(ctx, l); err != nil {
 			return err
 		}
-	case StartTenantSQL:
-		if err := c.distributeTenantCerts(ctx, l, startOpts.KVCluster, startOpts.TenantID); err != nil {
+	case StartServiceForVirtualCluster:
+		if err := c.distributeTenantCerts(ctx, l, startOpts.KVCluster, startOpts.VirtualClusterID); err != nil {
 			return err
 		}
 	}
@@ -359,17 +362,20 @@ func (c *SyncedCluster) NodeDir(node Node, storeIndex int) string {
 }
 
 // LogDir returns the logs directory for the given node.
-func (c *SyncedCluster) LogDir(node Node, tenantName string, instance int) string {
-	dirName := "logs" + tenantDirSuffix(tenantName, instance)
+func (c *SyncedCluster) LogDir(node Node, virtualClusterName string, instance int) string {
+	dirName := "logs" + virtualClusterDirSuffix(virtualClusterName, instance)
 	if c.IsLocal() {
 		return filepath.Join(c.localVMDir(node), dirName)
 	}
 	return dirName
 }
 
-// TenantStoreDir returns the data directory for a given tenant.
-func (c *SyncedCluster) TenantStoreDir(node Node, tenantName string, instance int) string {
-	dataDir := fmt.Sprintf("data%s", tenantDirSuffix(tenantName, instance))
+// InstanceStoreDir returns the data directory for the given instance of
+// the given virtual cluster.
+func (c *SyncedCluster) InstanceStoreDir(
+	node Node, virtualClusterName string, instance int,
+) string {
+	dataDir := fmt.Sprintf("data%s", virtualClusterDirSuffix(virtualClusterName, instance))
 	if c.IsLocal() {
 		return filepath.Join(c.localVMDir(node), dataDir)
 	}
@@ -377,11 +383,12 @@ func (c *SyncedCluster) TenantStoreDir(node Node, tenantName string, instance in
 	return dataDir
 }
 
-// tenantDirSuffix returns the suffix to use for tenant-specific directories.
+// virtualClusterDirSuffix returns the suffix to use for directories specific
+// to one virtual cluster.
 // This suffix consists of the tenant name and instance number (if applicable).
-func tenantDirSuffix(tenantName string, instance int) string {
-	if tenantName != "" && tenantName != SystemTenantName {
-		return fmt.Sprintf("-%s-%d", tenantName, instance)
+func virtualClusterDirSuffix(virtualClusterName string, instance int) string {
+	if virtualClusterName != "" && virtualClusterName != SystemInterfaceName {
+		return fmt.Sprintf("-%s-%d", virtualClusterName, instance)
 	}
 	return ""
 }
@@ -396,8 +403,8 @@ func (c *SyncedCluster) CertsDir(node Node) string {
 
 // NodeURL constructs a postgres URL. If sharedTenantName is not empty, it will
 // be used as the virtual cluster name in the URL. This is used to connect to a
-// shared process hosting multiple tenants.
-func (c *SyncedCluster) NodeURL(host string, port int, sharedTenantName string) string {
+// shared process running services for multiple virtual clusters.
+func (c *SyncedCluster) NodeURL(host string, port int, virtualClusterName string) string {
 	var u url.URL
 	u.User = url.User("root")
 	u.Scheme = "postgres"
@@ -411,8 +418,8 @@ func (c *SyncedCluster) NodeURL(host string, port int, sharedTenantName string) 
 	} else {
 		v.Add("sslmode", "disable")
 	}
-	if sharedTenantName != "" {
-		v.Add("options", fmt.Sprintf("-ccluster=%s", sharedTenantName))
+	if virtualClusterName != "" {
+		v.Add("options", fmt.Sprintf("-ccluster=%s", virtualClusterName))
 	}
 	u.RawQuery = v.Encode()
 	return "'" + u.String() + "'"
@@ -420,7 +427,7 @@ func (c *SyncedCluster) NodeURL(host string, port int, sharedTenantName string) 
 
 // NodePort returns the system tenant's SQL port for the given node.
 func (c *SyncedCluster) NodePort(ctx context.Context, node Node) (int, error) {
-	desc, err := c.DiscoverService(ctx, node, SystemTenantName, ServiceTypeSQL, 0)
+	desc, err := c.DiscoverService(ctx, node, SystemInterfaceName, ServiceTypeSQL, 0)
 	if err != nil {
 		return 0, err
 	}
@@ -429,7 +436,7 @@ func (c *SyncedCluster) NodePort(ctx context.Context, node Node) (int, error) {
 
 // NodeUIPort returns the system tenant's AdminUI port for the given node.
 func (c *SyncedCluster) NodeUIPort(ctx context.Context, node Node) (int, error) {
-	desc, err := c.DiscoverService(ctx, node, SystemTenantName, ServiceTypeUI, 0)
+	desc, err := c.DiscoverService(ctx, node, SystemInterfaceName, ServiceTypeUI, 0)
 	if err != nil {
 		return 0, err
 	}
@@ -443,23 +450,23 @@ func (c *SyncedCluster) NodeUIPort(ctx context.Context, node Node) (int, error) 
 //
 // CAUTION: this function should not be used by roachtest writers. Use ExecSQL below.
 func (c *SyncedCluster) ExecOrInteractiveSQL(
-	ctx context.Context, l *logger.Logger, tenantName string, tenantInstance int, args []string,
+	ctx context.Context, l *logger.Logger, virtualClusterName string, sqlInstance int, args []string,
 ) error {
 	if len(c.Nodes) != 1 {
 		return fmt.Errorf("invalid number of nodes for interactive sql: %d", len(c.Nodes))
 	}
-	desc, err := c.DiscoverService(ctx, c.Nodes[0], tenantName, ServiceTypeSQL, tenantInstance)
+	desc, err := c.DiscoverService(ctx, c.Nodes[0], virtualClusterName, ServiceTypeSQL, sqlInstance)
 	if err != nil {
 		return err
 	}
-	if tenantName == "" {
-		tenantName = SystemTenantName
+	if virtualClusterName == "" {
+		virtualClusterName = SystemInterfaceName
 	}
-	sharedTenantName := ""
+	virtualCluster := ""
 	if desc.ServiceMode == ServiceModeShared {
-		sharedTenantName = tenantName
+		virtualCluster = virtualClusterName
 	}
-	url := c.NodeURL("localhost", desc.Port, sharedTenantName)
+	url := c.NodeURL("localhost", desc.Port, virtualCluster)
 	binary := cockroachNodeBinary(c, c.Nodes[0])
 	allArgs := []string{binary, "sql", "--url", url}
 	allArgs = append(allArgs, ssh.Escape(args))
@@ -472,19 +479,19 @@ func (c *SyncedCluster) ExecSQL(
 	ctx context.Context,
 	l *logger.Logger,
 	nodes Nodes,
-	tenantName string,
-	tenantInstance int,
+	virtualClusterName string,
+	sqlInstance int,
 	args []string,
 ) error {
 	display := fmt.Sprintf("%s: executing sql", c.Name)
 	results, _, err := c.ParallelE(ctx, l, nodes, func(ctx context.Context, node Node) (*RunResultDetails, error) {
-		desc, err := c.DiscoverService(ctx, node, tenantName, ServiceTypeSQL, tenantInstance)
+		desc, err := c.DiscoverService(ctx, node, virtualClusterName, ServiceTypeSQL, sqlInstance)
 		if err != nil {
 			return nil, err
 		}
 		sharedTenantName := ""
 		if desc.ServiceMode == ServiceModeShared {
-			sharedTenantName = tenantName
+			sharedTenantName = virtualClusterName
 		}
 		var cmd string
 		if c.IsLocal() {
@@ -550,7 +557,7 @@ func (c *SyncedCluster) generateStartCmd(
 	}
 
 	return execStartTemplate(startTemplateData{
-		LogDir: c.LogDir(node, startOpts.TenantName, startOpts.TenantInstance),
+		LogDir: c.LogDir(node, startOpts.VirtualClusterName, startOpts.SQLInstance),
 		KeyCmd: keyCmd,
 		EnvVars: append(append([]string{
 			fmt.Sprintf("ROACHPROD=%s", c.roachprodEnvValue(node)),
@@ -608,10 +615,10 @@ func (c *SyncedCluster) generateStartArgs(
 			args = []string{"start"}
 		}
 
-	case StartTenantSQL:
+	case StartServiceForVirtualCluster:
 		args = []string{"mt", "start-sql"}
 
-	case StartTenantProxy:
+	case StartRoutingProxy:
 		// args = []string{"mt", "start-proxy"}
 		panic("unimplemented")
 
@@ -627,7 +634,7 @@ func (c *SyncedCluster) generateStartArgs(
 		args = append(args, "--insecure")
 	}
 
-	logDir := c.LogDir(node, startOpts.TenantName, startOpts.TenantInstance)
+	logDir := c.LogDir(node, startOpts.VirtualClusterName, startOpts.SQLInstance)
 	idx1 := argExists(startOpts.ExtraArgs, "--log")
 	idx2 := argExists(startOpts.ExtraArgs, "--log-config-file")
 
@@ -643,28 +650,28 @@ func (c *SyncedCluster) generateStartArgs(
 		listenHost = "127.0.0.1"
 	}
 
-	tenantName := startOpts.TenantName
-	instance := startOpts.TenantInstance
+	virtualClusterName := startOpts.VirtualClusterName
+	instance := startOpts.SQLInstance
 	var sqlPort int
-	if startOpts.Target == StartTenantSQL {
-		desc, err := c.DiscoverService(ctx, node, tenantName, ServiceTypeSQL, instance)
+	if startOpts.Target == StartServiceForVirtualCluster {
+		desc, err := c.DiscoverService(ctx, node, virtualClusterName, ServiceTypeSQL, instance)
 		if err != nil {
 			return nil, err
 		}
 		sqlPort = desc.Port
 		args = append(args, fmt.Sprintf("--sql-addr=%s:%d", listenHost, sqlPort))
 	} else {
-		tenantName = SystemTenantName
-		// System tenant instance is always 0.
+		virtualClusterName = SystemInterfaceName
+		// System interface instance is always 0.
 		instance = 0
-		desc, err := c.DiscoverService(ctx, node, tenantName, ServiceTypeSQL, instance)
+		desc, err := c.DiscoverService(ctx, node, virtualClusterName, ServiceTypeSQL, instance)
 		if err != nil {
 			return nil, err
 		}
 		sqlPort = desc.Port
 		args = append(args, fmt.Sprintf("--listen-addr=%s:%d", listenHost, sqlPort))
 	}
-	desc, err := c.DiscoverService(ctx, node, tenantName, ServiceTypeUI, instance)
+	desc, err := c.DiscoverService(ctx, node, virtualClusterName, ServiceTypeUI, instance)
 	if err != nil {
 		return nil, err
 	}
@@ -687,7 +694,7 @@ func (c *SyncedCluster) generateStartArgs(
 		joinTargets := startOpts.GetJoinTargets()
 		addresses := make([]string, len(joinTargets))
 		for i, joinNode := range startOpts.GetJoinTargets() {
-			desc, err := c.DiscoverService(ctx, joinNode, SystemTenantName, ServiceTypeSQL, 0)
+			desc, err := c.DiscoverService(ctx, joinNode, SystemInterfaceName, ServiceTypeSQL, 0)
 			if err != nil {
 				return nil, err
 			}
@@ -695,16 +702,16 @@ func (c *SyncedCluster) generateStartArgs(
 		}
 		args = append(args, fmt.Sprintf("--join=%s", strings.Join(addresses, ",")))
 	}
-	if startOpts.Target == StartTenantSQL {
+	if startOpts.Target == StartServiceForVirtualCluster {
 		args = append(args, fmt.Sprintf("--kv-addrs=%s", startOpts.KVAddrs))
-		args = append(args, fmt.Sprintf("--tenant-id=%d", startOpts.TenantID))
+		args = append(args, fmt.Sprintf("--tenant-id=%d", startOpts.VirtualClusterID))
 	}
 
 	if startOpts.Target == StartDefault {
 		args = append(args, c.generateStartFlagsKV(node, startOpts)...)
 	}
 
-	if startOpts.Target == StartDefault || startOpts.Target == StartTenantSQL {
+	if startOpts.Target == StartDefault || startOpts.Target == StartServiceForVirtualCluster {
 		args = append(args, c.generateStartFlagsSQL(node, startOpts)...)
 	}
 
@@ -779,8 +786,8 @@ func (c *SyncedCluster) generateStartFlagsKV(node Node, startOpts StartOpts) []s
 func (c *SyncedCluster) generateStartFlagsSQL(node Node, startOpts StartOpts) []string {
 	var args []string
 	args = append(args, fmt.Sprintf("--max-sql-memory=%d%%", c.maybeScaleMem(25)))
-	if startOpts.Target == StartTenantSQL {
-		args = append(args, "--store", c.TenantStoreDir(node, startOpts.TenantName, startOpts.TenantInstance))
+	if startOpts.Target == StartServiceForVirtualCluster {
+		args = append(args, "--store", c.InstanceStoreDir(node, startOpts.VirtualClusterName, startOpts.SQLInstance))
 	}
 	return args
 }
@@ -866,7 +873,7 @@ func (c *SyncedCluster) generateClusterSettingCmd(
 	if err != nil {
 		return "", err
 	}
-	url := c.NodeURL("localhost", port, SystemTenantName /* tenantName */)
+	url := c.NodeURL("localhost", port, SystemInterfaceName /* virtualClusterName */)
 
 	clusterSettingsCmd += fmt.Sprintf(`
 		if ! test -e %s ; then
@@ -886,7 +893,7 @@ func (c *SyncedCluster) generateInitCmd(ctx context.Context, node Node) (string,
 	if err != nil {
 		return "", err
 	}
-	url := c.NodeURL("localhost", port, SystemTenantName /* tenantName */)
+	url := c.NodeURL("localhost", port, SystemInterfaceName /* virtualClusterName */)
 	binary := cockroachNodeBinary(c, node)
 	initCmd += fmt.Sprintf(`
 		if ! test -e %[1]s ; then
@@ -1012,7 +1019,7 @@ func (c *SyncedCluster) createFixedBackupSchedule(
 	if err != nil {
 		return err
 	}
-	url := c.NodeURL("localhost", port, SystemTenantName /* tenantName */)
+	url := c.NodeURL("localhost", port, SystemInterfaceName /* virtualClusterName */)
 	fullCmd := fmt.Sprintf(`COCKROACH_CONNECT_TIMEOUT=%d %s sql --url %s -e %q`,
 		startSQLTimeout, binary, url, createScheduleCmd)
 	// Instead of using `c.ExecSQL()`, use `c.runCmdOnSingleNode()`, which allows us to

--- a/pkg/roachprod/install/services_test.go
+++ b/pkg/roachprod/install/services_test.go
@@ -89,8 +89,8 @@ func TestStringToIntegers(t *testing.T) {
 func TestServiceNameComponents(t *testing.T) {
 	z := local.NewDNSProvider(t.TempDir(), "z1")
 	dnsName := serviceDNSName(z, "tenant-100", ServiceTypeSQL, "test-cluster")
-	tenantName, serviceType, err := serviceNameComponents(dnsName)
+	virtualClusterName, serviceType, err := serviceNameComponents(dnsName)
 	require.NoError(t, err)
-	require.Equal(t, "tenant-100", tenantName)
+	require.Equal(t, "tenant-100", virtualClusterName)
 	require.Equal(t, ServiceTypeSQL, serviceType)
 }

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -660,7 +660,7 @@ func DefaultStartOpts() install.StartOpts {
 		NumFilesLimit:      config.DefaultNumFilesLimit,
 		SkipInit:           false,
 		StoreCount:         1,
-		TenantID:           2,
+		VirtualClusterID:   2,
 		ScheduleBackups:    false,
 		ScheduleBackupArgs: "",
 		InitTarget:         1,
@@ -890,10 +890,10 @@ func Get(ctx context.Context, l *logger.Logger, clusterName, src, dest string) e
 }
 
 type PGURLOptions struct {
-	Secure         bool
-	External       bool
-	TenantName     string
-	TenantInstance int
+	Secure             bool
+	External           bool
+	VirtualClusterName string
+	SQLInstance        int
 }
 
 // PgURL generates pgurls for the nodes in a cluster.
@@ -925,14 +925,14 @@ func PgURL(
 
 	var urls []string
 	for i, ip := range ips {
-		desc, err := c.DiscoverService(ctx, nodes[i], opts.TenantName, install.ServiceTypeSQL, opts.TenantInstance)
+		desc, err := c.DiscoverService(ctx, nodes[i], opts.VirtualClusterName, install.ServiceTypeSQL, opts.SQLInstance)
 		if err != nil {
 			return nil, err
 		}
 		if ip == "" {
 			return nil, errors.Errorf("empty ip: %v", ips)
 		}
-		urls = append(urls, c.NodeURL(ip, desc.Port, opts.TenantName))
+		urls = append(urls, c.NodeURL(ip, desc.Port, opts.VirtualClusterName))
 	}
 	if len(urls) != len(nodes) {
 		return nil, errors.Errorf("have nodes %v, but urls %v from ips %v", nodes, urls, ips)


### PR DESCRIPTION
Backport 1/1 commits from #111113.

/cc @cockroachdb/release

---

Fixes #111103.
Epic: CRDB-29380

We want to distinguish the concepts for "tenant", "virtual cluster", "SQL/HTTP instance" through the team. For this it is useful when the tools and their source code also reflect these concepts.

This commit achieves that.

Release note: None
Release justification: Test only change

