### PR TITLE
streamingccl: clean up uses of cross_cluster_replication.enabled

### DIFF
--- a/pkg/ccl/streamingccl/replicationtestutils/replication_helpers.go
+++ b/pkg/ccl/streamingccl/replicationtestutils/replication_helpers.go
@@ -223,7 +223,7 @@ func NewReplicationHelper(
 	sqlDB.ExecMultiple(t,
 		// Required for replication stremas to work.
 		`SET CLUSTER SETTING kv.rangefeed.enabled = true`,
-		`SET CLUSTER SETTING cross_cluster_replication.enabled = true`,
+		`SET CLUSTER SETTING physical_replication.enabled = true`,
 
 		// Speeds up the tests a bit.
 		`SET CLUSTER SETTING kv.rangefeed.closed_timestamp_refresh_interval = '200ms'`,

--- a/pkg/ccl/streamingccl/replicationtestutils/testutils.go
+++ b/pkg/ccl/streamingccl/replicationtestutils/testutils.go
@@ -151,7 +151,7 @@ func (c *TenantStreamingClusters) init() {
 		c.Args.DestInitFunc(c.T, c.DestSysSQL)
 	}
 	// Enable stream replication on dest by default.
-	c.DestSysSQL.Exec(c.T, `SET CLUSTER SETTING cross_cluster_replication.enabled = true;`)
+	c.DestSysSQL.Exec(c.T, `SET CLUSTER SETTING physical_replication.enabled = true;`)
 }
 
 // StartDestTenant starts the destination tenant and returns a cleanup

--- a/pkg/ccl/streamingccl/streamingest/replication_random_client_test.go
+++ b/pkg/ccl/streamingccl/streamingest/replication_random_client_test.go
@@ -220,9 +220,9 @@ func TestStreamIngestionJobWithRandomClient(t *testing.T) {
 
 	// Attempt to run the ingestion job without enabling the experimental setting.
 	_, err = conn.Exec(query)
-	require.True(t, testutils.IsError(err, "cross cluster replication is disabled"))
+	require.True(t, testutils.IsError(err, "physical replication is disabled"))
 
-	_, err = conn.Exec(`SET CLUSTER SETTING cross_cluster_replication.enabled = true;`)
+	_, err = conn.Exec(`SET CLUSTER SETTING physical_replication.enabled = true;`)
 	require.NoError(t, err)
 
 	_, err = conn.Exec(query)

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_job_test.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_job_test.go
@@ -64,7 +64,7 @@ func TestTenantStreamingCreationErrors(t *testing.T) {
 	SrcSysSQL.Exec(t, `SET CLUSTER SETTING kv.rangefeed.enabled = true`)
 
 	DestSysSQL := sqlutils.MakeSQLRunner(destDB)
-	DestSysSQL.Exec(t, `SET CLUSTER SETTING cross_cluster_replication.enabled = true;`)
+	DestSysSQL.Exec(t, `SET CLUSTER SETTING physical_replication.enabled = true;`)
 
 	// Sink to read data from.
 	srcPgURL, cleanupSink := sqlutils.PGUrl(t, srcServer.AdvSQLAddr(), t.Name(), url.User(username.RootUser))

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_planning.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_planning.go
@@ -93,16 +93,7 @@ func ingestionPlanHook(
 	}
 
 	if !streamingccl.CrossClusterReplicationEnabled.Get(&p.ExecCfg().Settings.SV) {
-		return nil, nil, nil, false, errors.WithTelemetry(
-			pgerror.WithCandidateCode(
-				errors.WithHint(
-					errors.Newf("cross cluster replication is disabled"),
-					"You can enable cross cluster replication by running `SET CLUSTER SETTING cross_cluster_replication.enabled = true`.",
-				),
-				pgcode.ExperimentalFeature,
-			),
-			"cross_cluster_replication.enabled",
-		)
+		return nil, nil, nil, false, physicalReplicationDisabledErr
 	}
 
 	if !p.ExecCfg().Codec.ForSystemTenant() {

--- a/pkg/ccl/streamingccl/streamproducer/replication_stream_test.go
+++ b/pkg/ccl/streamingccl/streamproducer/replication_stream_test.go
@@ -188,7 +188,7 @@ func startReplication(
 	conn, err := pgx.ConnectConfig(queryCtx, pgxConfig)
 	require.NoError(t, err)
 
-	rows, err := conn.Query(queryCtx, `SET CLUSTER SETTING cross_cluster_replication.enabled = true;`)
+	rows, err := conn.Query(queryCtx, `SET CLUSTER SETTING physical_replication.enabled = true;`)
 	require.NoError(t, err)
 	rows.Close()
 

--- a/pkg/configprofiles/profiles.go
+++ b/pkg/configprofiles/profiles.go
@@ -154,7 +154,7 @@ func enableReplication(baseTasks []autoconfigpb.Task) []autoconfigpb.Task {
 		makeTask("enable rangefeeds and replication",
 			/* nonTxnSQL */ []string{
 				"SET CLUSTER SETTING kv.rangefeed.enabled = true",
-				"SET CLUSTER SETTING cross_cluster_replication.enabled = true",
+				"SET CLUSTER SETTING physical_replication.enabled = true",
 			},
 			nil, /* txnSQL */
 		),


### PR DESCRIPTION
This cleans up uses of cross_cluster_replication.enabled in test code and in error messages.

I've left the references in roachtest for now so that people don't get confused if they are using a roachtest binary that is mismatched from their cockroach binary.

Also, there are still references in the UI code since I believe these refer to the InternalKey.

Epic: none

Release note: None