### PR TITLE
sql: create reset_insights_tables builtin

### DIFF
--- a/pkg/clusterversion/cockroach_versions.go
+++ b/pkg/clusterversion/cockroach_versions.go
@@ -511,7 +511,7 @@ const (
 	V23_2_MVCCStatisticsTable
 
 	// V23_2_AddSystemExecInsightsTable is the version at which Cockroach creates
-	// stmnt_exec_insights and txn_exec_insights system tables.
+	// {statement|transaction}_execution_insights system tables.
 	V23_2_AddSystemExecInsightsTable
 
 	// *************************************************

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -2478,6 +2478,7 @@ var builtinOidsArray = []string{
 	2507: `text(refcursor: refcursor) -> string`,
 	2508: `varchar(refcursor: refcursor) -> varchar`,
 	2509: `crdb_internal.unsafe_revert_tenant_to_timestamp(tenant_name: string, ts: decimal) -> decimal`,
+	2510: `crdb_internal.reset_insights_tables() -> bool`,
 }
 
 var builtinOidsBySignature map[string]oid.Oid

--- a/pkg/sql/sem/eval/deps.go
+++ b/pkg/sql/sem/eval/deps.go
@@ -695,6 +695,7 @@ type GossipOperator interface {
 type SQLStatsController interface {
 	ResetClusterSQLStats(ctx context.Context) error
 	ResetActivityTables(ctx context.Context) error
+	ResetInsightsTables(ctx context.Context) error
 	CreateSQLStatsCompactionSchedule(ctx context.Context) error
 }
 

--- a/pkg/sql/sqlstats/persistedsqlstats/controller_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/controller_test.go
@@ -256,6 +256,148 @@ func TestActivityTablesReset(t *testing.T) {
 	require.Equal(t, 0 /* expected */, count)
 }
 
+func TestInsightsTablesReset(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	sqlDB := sqlutils.MakeSQLRunner(db)
+	defer s.Stopper().Stop(context.Background())
+
+	// Give the query runner privilege to insert into the insights tables.
+	sqlDB.Exec(t, "INSERT INTO system.users VALUES ('node', NULL, true, 3)")
+	sqlDB.Exec(t, "GRANT node TO root")
+
+	// Insert into system.statement_execution_insights table
+	sqlDB.Exec(t, `
+		INSERT INTO system.public.statement_execution_insights (
+		                                                        session_id,
+		                                                        transaction_id,
+		                                                        transaction_fingerprint_id,
+		                                                        statement_id,
+		                                                        statement_fingerprint_id,
+		                                                        problem,
+		                                                        causes,
+		                                                        query,
+		                                                        status,
+		                                                        start_time,
+		                                                        end_time,
+		                                                        full_scan,
+		                                                        user_name,
+		                                                        app_name,
+		                                                        user_priority,
+		                                                        database_name,
+		                                                        plan_gist,
+		                                                        retries,
+		                                                        last_retry_reason,
+		                                                        execution_node_ids,
+		                                                        index_recommendations,
+		                                                        implicit_txn,
+		                                                        cpu_sql_nanos,
+		                                                        error_code,
+		                                                        contention_time,
+		                                                        contention_info,
+		                                                        details
+		                                                        )
+		VALUES (
+		        '178b8f4d507072200000000000000001',
+		        '14a07bbc-dfdb-41df-9231-b6235943847d',
+		        '\xd98ea7ce7040ab94',
+		        '178b8f50ab40d8680000000000000001',
+		        '\x125167e869920859',
+		        1,
+		        '{}',
+		        'SELECT a.balance, b.balance FROM insights_workload_table_0 AS a LEFT JOIN insights_workload_table_1 AS b ON a.shared_key = b.shared_key WHERE a.balance < _',
+		        1,
+		        '2023-10-06 15:47:41',
+		        '2023-10-06 15:47:42',
+		        't',
+		        'root',
+		        'insights_tables_reset',
+		        'normal',
+		        'insights',
+		        'AgHmAQIACgAAAAHkAQIACgAAAAMJAgICAAAFBAYE',
+		        0,
+		        null,
+		        '{}',
+		        '{"creation : CREATE INDEX ON insights.public.insights_workload_table_0 (balance) STORING (shared_key);"}',
+		        't',
+		        0,
+		        'XXUUU',
+		        null,
+		        null,
+		        '{}'
+		)
+	`)
+	//Insert into system.transaction_execution_insights table
+	sqlDB.Exec(t, `
+			INSERT INTO system.public.transaction_execution_insights (
+			                                                        session_id,
+			                                                        transaction_id,
+			                                                        transaction_fingerprint_id,
+			                                                        stmt_execution_ids,
+			                                                        problems,
+			                                                        causes,
+			                                                        query_summary,
+			                                                        status,
+			                                                        start_time,
+			                                                        end_time,
+			                                                        user_name,
+			                                                        app_name,
+			                                                        user_priority,
+			                                                        retries,
+			                                                        last_retry_reason,
+			                                                        implicit_txn,
+			                                                        cpu_sql_nanos,
+			                                                        last_error_code,
+			                                                        contention_time,
+			                                                        contention_info,
+			                                                        details
+	
+	)
+			VALUES (
+			        '178b8f4d507072200000000000000001',
+			        '14a07bbc-dfdb-41df-9231-b6235943847d',
+			        '\xd98ea7ce7040ab94',
+			        '{"178b8f50ab40d8680000000000000001"}',
+			        '{1}',
+			        '{}',
+			        'SELECT a.balance, b.balance FROM insights_workload_table_0 AS a LEFT JOIN insights_workload_table_1 AS b ON a.shared_key = b.shared_key WHERE a.balance < _',
+			        1,
+			        '2023-10-06 15:47:41',
+			        '2023-10-06 15:47:42',
+			        'root',
+			        'insights_tables_reset',
+			        'normal',
+			        0,
+			        null,
+			        't',
+			        0,
+			        'XXUUU',
+			        null,
+			        null,
+			        '{}'
+			)
+		`)
+
+	// Check that system.{statement|transaction}_execution_insights tables both have 1 row.
+	var count int
+	sqlDB.QueryRow(t, "SELECT count(*) FROM system.statement_execution_insights").Scan(&count)
+	require.Equal(t, 1 /* expected */, count)
+
+	sqlDB.QueryRow(t, "SELECT count(*) FROM system.transaction_execution_insights").Scan(&count)
+	require.Equal(t, 1 /* expected */, count)
+
+	// Flush the tables.
+	sqlDB.QueryRow(t, "SELECT crdb_internal.reset_insights_tables()")
+
+	sqlDB.QueryRow(t, "SELECT count(*) FROM system.statement_execution_insights").Scan(&count)
+	require.Equal(t, 0 /* expected */, count)
+
+	sqlDB.QueryRow(t, "SELECT count(*) FROM system.transaction_execution_insights").Scan(&count)
+	require.Equal(t, 0 /* expected */, count)
+}
+
 func TestStmtStatsEnable(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)


### PR DESCRIPTION
Creates the builtin `crdb_internal.reset_insights_tables()` that reset all data from the tables:
- `system.statement_execution_insights`
- `system.transaction_execution_insights`

Fixes #110549

Release note (sql change): New builtin `crdb_internal.reset_insights_tables()` that resets the data from `system.statement_execution_insights` and `system.transaction_execution_insights`.