### PR TITLE
roachtest: prevent panic on invalid machine type

### DIFF
--- a/pkg/cmd/roachtest/cluster_test.go
+++ b/pkg/cmd/roachtest/cluster_test.go
@@ -320,15 +320,21 @@ func TestAWSMachineTypeNew(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("%d/%s/%t/%s", tc.cpus, tc.mem, tc.localSSD, tc.arch), func(t *testing.T) {
-			machineType, selectedArch := spec.SelectAWSMachineTypeNew(tc.cpus, tc.mem, tc.localSSD, tc.arch)
+			machineType, selectedArch, _ := spec.SelectAWSMachineTypeNew(tc.cpus, tc.mem, tc.localSSD, tc.arch)
 
 			require.Equal(t, tc.expectedMachineType, machineType)
 			require.Equal(t, tc.expectedArch, selectedArch)
 		})
 	}
 	// spec.Low is not supported.
-	require.Panics(t, func() { spec.SelectAWSMachineTypeNew(4, spec.Low, false, vm.ArchAMD64) })
-	require.Panics(t, func() { spec.SelectAWSMachineTypeNew(16, spec.Low, false, vm.ArchARM64) })
+	_, _, err := spec.SelectAWSMachineTypeNew(4, spec.Low, false, vm.ArchAMD64)
+	require.Error(t, err)
+
+	_, _, err2 := spec.SelectAWSMachineTypeNew(16, spec.Low, false, vm.ArchAMD64)
+	require.Error(t, err2)
+
+	_, err3 := spec.SelectAzureMachineType(4, spec.High)
+	require.Error(t, err3)
 }
 
 // TODO(srosenberg): restore the change in https://github.com/cockroachdb/cockroach/pull/111140 after 23.2 branch cut.

--- a/pkg/cmd/roachtest/spec/cluster_spec.go
+++ b/pkg/cmd/roachtest/spec/cluster_spec.go
@@ -289,13 +289,18 @@ func (s *ClusterSpec) RoachprodOpts(
 		if machineType == "" {
 			// If no machine type was specified, choose one
 			// based on the cloud and CPU count.
+			var err error
 			switch s.Cloud {
 			case AWS:
-				machineType, selectedArch = SelectAWSMachineType(s.CPUs, s.Mem, s.PreferLocalSSD && s.VolumeSize == 0, arch)
+				machineType, selectedArch, err = SelectAWSMachineType(s.CPUs, s.Mem, s.PreferLocalSSD && s.VolumeSize == 0, arch)
 			case GCE:
 				machineType, selectedArch = SelectGCEMachineType(s.CPUs, s.Mem, arch)
 			case Azure:
-				machineType = SelectAzureMachineType(s.CPUs, s.Mem)
+				machineType, err = SelectAzureMachineType(s.CPUs, s.Mem)
+			}
+
+			if err != nil {
+				return vm.CreateOpts{}, nil, err
 			}
 			if selectedArch != "" && selectedArch != arch {
 				// TODO(srosenberg): we need a better way to monitor the rate of this mismatch, i.e.,

--- a/pkg/cmd/roachtest/tests/restore.go
+++ b/pkg/cmd/roachtest/tests/restore.go
@@ -546,7 +546,10 @@ func (hw hardwareSpecs) makeClusterSpecs(r registry.Registry, backupCloud string
 		// https://github.com/cockroachdb/cockroach/issues/98783.
 		//
 		// TODO(srosenberg): Remove this workaround when 98783 is addressed.
-		s.AWS.MachineType, _ = spec.SelectAWSMachineType(s.CPUs, s.Mem, s.PreferLocalSSD && s.VolumeSize == 0, vm.ArchAMD64)
+		// TODO(miral): This now returns an error instead of panicking, so even though
+		// we haven't panicked here before, we should handle the error. Moot if this is
+		// removed as per TODO above.
+		s.AWS.MachineType, _, _ = spec.SelectAWSMachineType(s.CPUs, s.Mem, s.PreferLocalSSD && s.VolumeSize == 0, vm.ArchAMD64)
 		s.AWS.MachineType = strings.Replace(s.AWS.MachineType, "d.", ".", 1)
 		s.Arch = vm.ArchAMD64
 	}


### PR DESCRIPTION
When running on Azure or AWS, roachtest will panic when encountering a invalid memory/cpu config. This change returns an error instead, now resulting in a cluster creation failure for the test (preferred).

An example test which will cause this is `tpccbench/nodes=9/cpu=4/multi-region`, which has `HighMem: true`.

There may need to be future work in roachtest to support more custom Azure options, like there is for AWS/GCE.

Epic: CC-25185

Release note: None