### PR TITLE
licenseccl: add optional Usage to license strings

### DIFF
--- a/pkg/ccl/utilccl/license_check.go
+++ b/pkg/ccl/utilccl/license_check.go
@@ -252,6 +252,7 @@ func getLicense(st *cluster.Settings) (*licenseccl.License, error) {
 	return license, nil
 }
 
+// GetLicenseType returns the license type.
 func GetLicenseType(st *cluster.Settings) (string, error) {
 	license, err := getLicense(st)
 	if err != nil {
@@ -260,6 +261,17 @@ func GetLicenseType(st *cluster.Settings) (string, error) {
 		return "None", nil
 	}
 	return license.Type.String(), nil
+}
+
+// GetLicenseUsage returns the license usage.
+func GetLicenseUsage(st *cluster.Settings) (string, error) {
+	license, err := getLicense(st)
+	if err != nil {
+		return "", err
+	} else if license == nil {
+		return "", nil
+	}
+	return license.Usage.String(), nil
 }
 
 // decode attempts to read a base64 encoded License.

--- a/pkg/ccl/utilccl/licenseccl/license.go
+++ b/pkg/ccl/utilccl/licenseccl/license.go
@@ -47,3 +47,18 @@ func Decode(s string) (*License, error) {
 	}
 	return &lic, nil
 }
+
+func (u License_Usage) String() string {
+	switch u {
+	case Unspecified:
+		return ""
+	case Production:
+		return "production"
+	case PreProduction:
+		return "pre-production"
+	case Development:
+		return "development"
+	default:
+		return "other"
+	}
+}

--- a/pkg/ccl/utilccl/licenseccl/license.proto
+++ b/pkg/ccl/utilccl/licenseccl/license.proto
@@ -25,4 +25,16 @@ message License {
     Type type = 3;
 
     string organization_name = 4;
+
+    enum Usage {
+      option (gogoproto.goproto_enum_prefix) = false;
+      option (gogoproto.goproto_enum_stringer) = false;
+
+      Unspecified = 0;
+      Production = 1;
+      PreProduction = 2;
+      Development = 3;
+    }
+
+    Usage usage = 5;
 }


### PR DESCRIPTION
Release note: none.
Epic: none.