### PR TITLE
roachtest: pass artifacts-literal flag to local fips roachtests

### DIFF
--- a/build/teamcity/cockroach/ci/tests/local_roachtest_fips_impl.sh
+++ b/build/teamcity/cockroach/ci/tests/local_roachtest_fips_impl.sh
@@ -30,4 +30,5 @@ $BAZEL_BIN/pkg/cmd/roachtest/roachtest_/roachtest run acceptance kv/splits cdc/b
   --cockroach "$BAZEL_BIN/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short" \
   --workload "$BAZEL_BIN/pkg/cmd/workload/workload_/workload" \
   --artifacts /artifacts \
+  --artifacts-literal="${LITERAL_ARTIFACTS_DIR:-}" \
   --teamcity


### PR DESCRIPTION
In #108536, local roachtests were passed the --artifacts-literal flag so that artifacts could be immediately published after a test failure. However, this flag was mistakenly not passed to FIPS builds, causing artifacts to still not be published immediately for those builds. This change now passes that flag.

Epic: None
Release note: None