### PR TITLE
workload: check for undefined object errors for mixed-version testing

### DIFF
--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -1473,8 +1473,10 @@ func (og *operationGenerator) createTable(ctx context.Context, tx pgx.Tx) (*opSt
 		{code: pgcode.FeatureNotSupported, condition: hasUnsupportedTSQuery},
 		{code: pgcode.Syntax, condition: pgLSNNotSupported},
 		{code: pgcode.FeatureNotSupported, condition: pgLSNNotSupported},
+		{code: pgcode.UndefinedObject, condition: pgLSNNotSupported},
 		{code: pgcode.Syntax, condition: refCursorNotSupported},
 		{code: pgcode.FeatureNotSupported, condition: refCursorNotSupported},
+		{code: pgcode.UndefinedObject, condition: refCursorNotSupported},
 		{code: pgcode.FeatureNotSupported, condition: hasUnsupportedIdxQueries},
 		{code: pgcode.InvalidTableDefinition, condition: hasUnsupportedIdxQueries},
 	})


### PR DESCRIPTION
The schema-change workload generator ignores some errors that are expected to happen in a mixed-version state. It alreadly checks for `Syntax` and `FeatureNotSupported` errors for the `REFCURSOR` data type, but it is also possible to see `ObjectUndefined` errors. This patch adds a check for that to stop flakes.

Fixes #111844

Release note: None