### PR TITLE
copy: fix slice out of bounds error in vectorized copy encoder

### DIFF
--- a/pkg/sql/colenc/encode.go
+++ b/pkg/sql/colenc/encode.go
@@ -667,8 +667,10 @@ func (b *BatchEncoder) initFamily(familyIndex, familyID int) {
 		// keys up to end of PK prefix and then appending family id.
 		keyBuf := make([]byte, b.count*b.keyBufSize)
 		for row := 0; row < b.count; row++ {
-			// Elided partial index keys will be nil.
-			if b.keys[row] == nil {
+			// Elided partial index keys will be nil but since the putter can and
+			// will sort kys we need to check savedPrefixes.
+			if b.savedPrefixes[row] == nil {
+				kys[row] = nil
 				continue
 			}
 			offset := row * b.keyBufSize

--- a/pkg/sql/copy/testdata/copy_from
+++ b/pkg/sql/copy/testdata/copy_from
@@ -734,3 +734,28 @@ COPY thash FROM STDIN WITH CSV
 1,2,3
 ----
 1
+
+exec-ddl
+CREATE TABLE copy_bug (
+      id INT8 NOT NULL,
+      status STRING NOT NULL,
+      claim_instance_id INT8 NULL,
+      CONSTRAINT "primary" PRIMARY KEY (id ASC),
+      INDEX jobs_run_stats_idx (status ASC) STORING (claim_instance_id) WHERE status IN ('running':::STRING),
+      FAMILY fam_0_id_status (id, status),
+      FAMILY claim (claim_instance_id)
+)
+----
+
+copy-from-kvtrace
+COPY copy_bug FROM STDIN WITH CSV HEADER NULL 'NULL' DELIMITER E'\t'
+id	status	claim_instance_id
+1	running	3
+2	succeed	1
+----
+CPut /Table/<>/1/1/0 -> /TUPLE/2:2:Bytes/running
+CPut /Table/<>/1/1/1/1 -> /INT/3
+CPut /Table/<>/1/2/0 -> /TUPLE/2:2:Bytes/succeed
+CPut /Table/<>/1/2/1/1 -> /INT/1
+InitPut /Table/<>/2/"running"/1/0 -> /BYTES/
+InitPut /Table/<>/2/"running"/1/1/1 -> /TUPLE/3:3:Int/3


### PR DESCRIPTION
This is related to the fix for #103220 which didn't fix everything with
secondary indexes with a partial index predicate and multiple families.
When setting up the key prefixes for the new family we would use the
potentially mutated keys slice instead of the savedPrefixes slice in
order to skip the rows that were partial index elided.  This meant for
the second column family the wrong row would be elided and we would try
to build the prefix in a nil slice.

Found by using COPY to import system.jobs tables into a mock jobs table
for testing customer issue, dogfood is tasty.

Skipping release note since this hasn't been seen in the wild (we should
get a sentry report if anyone hit it).

Fixes: #111850
Release note: None
Epic: None
