### PR TITLE
mixedversion: LowestBinaryVersion works on every hook

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/BUILD.bazel
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/BUILD.bazel
@@ -33,6 +33,7 @@ go_library(
 go_test(
     name = "mixedversion_test",
     srcs = [
+        "helper_test.go",
         "mixedversion_test.go",
         "planner_test.go",
         "runner_test.go",

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/helper_test.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/helper_test.go
@@ -1,0 +1,132 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package mixedversion
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/clusterupgrade"
+	"github.com/cockroachdb/cockroach/pkg/util/version"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLowestBinaryVersion(t *testing.T) {
+	currentVersion := version.MustParse("v48.2.3")
+
+	testCases := []struct {
+		name        string
+		testContext *Context
+		crdbNodes   option.NodeListOption
+		expected    *version.Version
+	}{
+		{
+			name: "all nodes in the 'from' version, predecessor", // before an upgrade or downgrade
+			testContext: &Context{
+				FromVersionNodes: option.NodeListOption{1, 2, 3},
+				FromVersion:      "22.2.8",
+				ToVersionNodes:   option.NodeListOption{},
+				ToVersion:        clusterupgrade.MainVersion,
+			},
+			crdbNodes: option.NodeListOption{1, 2, 3},
+			expected:  version.MustParse("v22.2.8"),
+		},
+		{
+			name: "all nodes in the 'from' version, current", // before an upgrade or downgrade
+			testContext: &Context{
+				FromVersionNodes: option.NodeListOption{1, 2, 3},
+				FromVersion:      clusterupgrade.MainVersion,
+				ToVersionNodes:   option.NodeListOption{},
+				ToVersion:        "22.2.8",
+			},
+			crdbNodes: option.NodeListOption{1, 2, 3},
+			expected:  currentVersion,
+		},
+		{
+			name: "all nodes in the 'to' version, predecessor", // after an upgrade or downgrade
+			testContext: &Context{
+				FromVersionNodes: option.NodeListOption{},
+				FromVersion:      clusterupgrade.MainVersion,
+				ToVersionNodes:   option.NodeListOption{1, 2, 3},
+				ToVersion:        "22.2.8",
+			},
+			crdbNodes: option.NodeListOption{1, 2, 3},
+			expected:  version.MustParse("v22.2.8"),
+		},
+		{
+			name: "all nodes in the 'to' version, current", // after an upgrade or downgrade
+			testContext: &Context{
+				FromVersionNodes: option.NodeListOption{},
+				FromVersion:      "22.2.8",
+				ToVersionNodes:   option.NodeListOption{1, 2, 3},
+				ToVersion:        clusterupgrade.MainVersion,
+			},
+			crdbNodes: option.NodeListOption{1, 2, 3},
+			expected:  currentVersion,
+		},
+		{
+			name: "mixed-binary state, 'from' version is lowest, both non-current",
+			testContext: &Context{
+				FromVersionNodes: option.NodeListOption{1, 2},
+				FromVersion:      "22.2.8",
+				ToVersionNodes:   option.NodeListOption{3},
+				ToVersion:        "23.1.8",
+			},
+			crdbNodes: option.NodeListOption{1, 2, 3},
+			expected:  version.MustParse("v22.2.8"),
+		},
+		{
+			name: "mixed-binary state, 'from' version is lowest, 'to' is current",
+			testContext: &Context{
+				FromVersionNodes: option.NodeListOption{1, 2},
+				FromVersion:      "22.2.8",
+				ToVersionNodes:   option.NodeListOption{3},
+				ToVersion:        clusterupgrade.MainVersion,
+			},
+			crdbNodes: option.NodeListOption{1, 2, 3},
+			expected:  version.MustParse("v22.2.8"),
+		},
+		{
+			name: "mixed-binary state, 'to' version is lowest, both non-current",
+			testContext: &Context{
+				FromVersionNodes: option.NodeListOption{1, 2},
+				FromVersion:      "23.1.8",
+				ToVersionNodes:   option.NodeListOption{3},
+				ToVersion:        "22.2.0",
+			},
+			crdbNodes: option.NodeListOption{1, 2, 3},
+			expected:  version.MustParse("v22.2.0"),
+		},
+		{
+			name: "mixed-binary state, 'to' version is lowest, 'from' is current",
+			testContext: &Context{
+				FromVersionNodes: option.NodeListOption{1, 2},
+				FromVersion:      clusterupgrade.MainVersion,
+				ToVersionNodes:   option.NodeListOption{3},
+				ToVersion:        "22.2.0",
+			},
+			crdbNodes: option.NodeListOption{1, 2, 3},
+			expected:  version.MustParse("v22.2.0"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			runner := testTestRunner()
+			runner.crdbNodes = tc.crdbNodes
+			runner.currentVersion = currentVersion
+
+			h := runner.newHelper(ctx, nilLogger)
+			h.testContext = tc.testContext
+			require.Equal(t, tc.expected, h.LowestBinaryVersion())
+		})
+	}
+}

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion.go
@@ -548,7 +548,7 @@ func (t *Test) Run() {
 
 func (t *Test) run(plan *TestPlan) error {
 	return newTestRunner(
-		t.ctx, t.cancel, plan, t.logger, t.cluster, t.crdbNodes, t.seed,
+		t.ctx, t.cancel, plan, t.logger, t.cluster, t.crdbNodes, t.buildVersion(), t.seed,
 	).run()
 }
 

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/runner.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/runner.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/cockroach/pkg/util/version"
 )
 
 type (
@@ -96,13 +97,14 @@ type (
 	}
 
 	testRunner struct {
-		ctx       context.Context
-		cancel    context.CancelFunc
-		plan      *TestPlan
-		cluster   cluster.Cluster
-		crdbNodes option.NodeListOption
-		seed      int64
-		logger    *logger.Logger
+		ctx            context.Context
+		cancel         context.CancelFunc
+		plan           *TestPlan
+		cluster        cluster.Cluster
+		crdbNodes      option.NodeListOption
+		currentVersion *version.Version
+		seed           int64
+		logger         *logger.Logger
 
 		binaryVersions  atomic.Value
 		clusterVersions atomic.Value
@@ -129,18 +131,20 @@ func newTestRunner(
 	l *logger.Logger,
 	c cluster.Cluster,
 	crdbNodes option.NodeListOption,
+	currentVersion *version.Version,
 	randomSeed int64,
 ) *testRunner {
 	return &testRunner{
-		ctx:        ctx,
-		cancel:     cancel,
-		plan:       plan,
-		logger:     l,
-		cluster:    c,
-		crdbNodes:  crdbNodes,
-		background: newBackgroundRunner(ctx, l),
-		monitor:    newCRDBMonitor(ctx, c, crdbNodes),
-		seed:       randomSeed,
+		ctx:            ctx,
+		cancel:         cancel,
+		plan:           plan,
+		logger:         l,
+		cluster:        c,
+		crdbNodes:      crdbNodes,
+		currentVersion: currentVersion,
+		background:     newBackgroundRunner(ctx, l),
+		monitor:        newCRDBMonitor(ctx, c, crdbNodes),
+		seed:           randomSeed,
 	}
 }
 

--- a/pkg/cmd/roachtest/tests/mixed_version_backup.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_backup.go
@@ -526,9 +526,7 @@ func (dbb *databaseBackup) TargetTables() []string {
 	return tableNamesWithDB(dbb.db, dbb.tables)
 }
 
-func newClusterBackup(
-	rng *rand.Rand, dbs []string, tables [][]string, lowest *version.Version,
-) *clusterBackup {
+func newClusterBackup(rng *rand.Rand, dbs []string, tables [][]string) *clusterBackup {
 	dbBackups := make([]*databaseBackup, 0, len(dbs))
 	for j, db := range dbs {
 		dbBackups = append(dbBackups, newDatabaseBackup(rng, []string{db}, [][]string{tables[j]}))
@@ -1025,7 +1023,7 @@ func (mvb *mixedVersionBackup) newBackupType(rng *rand.Rand, h *mixedversion.Hel
 	possibleTypes := []backupType{
 		newTableBackup(rng, mvb.dbs, mvb.tables),
 		newDatabaseBackup(rng, mvb.dbs, mvb.tables),
-		newClusterBackup(rng, mvb.dbs, mvb.tables, h.LowestBinaryVersion()),
+		newClusterBackup(rng, mvb.dbs, mvb.tables),
 	}
 
 	return possibleTypes[rng.Intn(len(possibleTypes))]


### PR DESCRIPTION
The `LowestBinaryVersion()` helper function was implemented with the goal of supporting `InMixedVersion` hooks. Specifically, the previous implementation would return the wrong result if called in the `AfterUpgradeHook`; in that case, all nodes are running the new, upgraded binary, but the function would still return the version we upgraded from.

This commit updates the implementation to check for the number of nodes running in each version. If all nodes are running the same version, that version is returned instead. This should make `LowestBinaryVersion()` safe to use in all hooks supported by `mixedversion` to determine the lowest released binary running in any node at a point in time. Note that this does *not* mean a certain cluster-version gated feature is available. It just means that the binary is past a certain version. For things like determining whether a cluster setting is available, this check is sufficient (and arguably preferred).

This commit also adds a `ParseVersion` helper to make it convenient for callers to obtain a parsed version object from the mixedversion context, e.g., `h.ParseVersion(h.Context().FromVersion)`.

Epic: none

Release note: None