### PR TITLE
ui: fix transaction contention details query where clause

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/contentionApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/contentionApi.ts
@@ -137,7 +137,7 @@ function getContentionWhereClause(filters?: ContentionFilters): string {
     if (whereClause !== defaultWhereClause) {
       whereClause += " and ";
     }
-    whereClause = whereClause + ` waiting_txn_id >= '${filters.waitingTxnID}' `;
+    whereClause = whereClause + ` waiting_txn_id = '${filters.waitingTxnID}' `;
   }
 
   if (filters?.start) {


### PR DESCRIPTION
Change a `>=` to `=` in a where clause creation for txn details. The query where clause creation contained a bug where when filtering for a particular `waiting_txn_id`, we specify `>=` the id rather than strictly equals. This can lead to surfacing contention events for not just the txn id specified.

Epic: none

Release note (bug fix): In txn insight details, we will only surface contention details for the current txn and no others. Previously it was possible to see the contention details of other txns due to a bug.