### PR TITLE
ui: swap strict null check to `==`

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
@@ -771,7 +771,7 @@ export class StatementsPage extends React.Component<
             }
           />
           {this.props.statementsResponse.inFlight &&
-            getValidErrorsList(this.props.statementsResponse.error) === null &&
+            getValidErrorsList(this.props.statementsResponse.error) == null &&
             longLoadingMessage}
           <ActivateStatementDiagnosticsModal
             ref={this.activateDiagnosticsRef}

--- a/pkg/ui/workspaces/cluster-ui/src/util/format.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/format.ts
@@ -408,7 +408,7 @@ const breakLinesKeywords: BreakLineReplacement = {
 const LINE_BREAK_LIMIT = 100;
 
 export function FormatQuery(query: string): string {
-  if (query === null) {
+  if (query == null) {
     return "";
   }
   Object.keys(breakLinesKeywords).forEach(key => {


### PR DESCRIPTION
This check was erronneously swapped to a strict null check while improving some eslint rules. We should check for null and undefined here.

Epic: none

Release note: None