### PR TITLE
ui: extract txn details api into its own file

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/contentionApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/contentionApi.ts
@@ -10,16 +10,31 @@
 
 import {
   executeInternalSql,
+  formatApiResult,
+  INTERNAL_SQL_API_APP,
   LARGE_RESULT_SIZE,
   LONG_TIMEOUT,
+  sqlApiErrorMessage,
   SqlApiResponse,
   SqlExecutionRequest,
+  SqlExecutionResponse,
   sqlResultsAreEmpty,
-  formatApiResult,
 } from "./sqlApi";
-import { ContentionDetails } from "src/insights";
+import {
+  ContentionDetails,
+  InsightExecEnum,
+  InsightNameEnum,
+  TxnContentionInsightDetails,
+} from "src/insights";
 import moment from "moment-timezone";
-import { getLogger } from "../util";
+import { FixFingerprintHexValue, getLogger } from "../util";
+import { TxnInsightDetailsRequest } from "./txnInsightDetailsApi";
+import { makeInsightsSqlRequest } from "./txnInsightsUtils";
+import {
+  FingerprintStmtsResponseColumns,
+  TxnStmtFingerprintsResponseColumns,
+  TxnWithStmtFingerprints,
+} from "./txnInsightsApi";
 
 export type ContentionFilters = {
   waitingTxnID?: string;
@@ -172,12 +187,216 @@ function contentionDetailsQuery(filters?: ContentionFilters) {
                     encode(waiting_stmt_fingerprint_id, 'hex') AS waiting_stmt_fingerprint_id,
                     contention_duration,
                     contending_pretty_key AS key,
-  database_name,
-  schema_name,
-  table_name,
-  index_name
+                    database_name,
+                    schema_name,
+                    table_name,
+                    index_name
     FROM
-      crdb_internal.transaction_contention_events AS tce
+      crdb_internal.transaction_contention_events
       ${whereClause}
   `;
+}
+
+type PartialTxnContentionDetails = Omit<
+  TxnContentionInsightDetails,
+  "application" | "queries"
+>;
+
+function formatTxnContentionDetailsResponse(
+  response: ContentionDetails[],
+): PartialTxnContentionDetails {
+  if (!response || response.length === 9) {
+    // No data.
+    return;
+  }
+
+  const row = response[0];
+  return {
+    transactionExecutionID: row.waitingTxnID,
+    transactionFingerprintID: FixFingerprintHexValue(
+      row.waitingTxnFingerprintID,
+    ),
+    blockingContentionDetails: response,
+    insightName: InsightNameEnum.highContention,
+    execType: InsightExecEnum.TRANSACTION,
+  };
+}
+
+function buildTxnContentionInsightDetails(
+  partialTxnContentionDetails: PartialTxnContentionDetails,
+  txnsWithStmtFingerprints: TxnWithStmtFingerprints[],
+  stmtFingerprintToQuery: StmtFingerprintToQueryRecord,
+): TxnContentionInsightDetails {
+  if (!partialTxnContentionDetails && !txnsWithStmtFingerprints.length) {
+    return null;
+  }
+
+  partialTxnContentionDetails.blockingContentionDetails.forEach(blockedRow => {
+    const currBlockedFingerprintStmts = txnsWithStmtFingerprints.find(
+      txn =>
+        txn.transactionFingerprintID === blockedRow.blockingTxnFingerprintID,
+    );
+
+    if (!currBlockedFingerprintStmts) {
+      return;
+    }
+
+    blockedRow.blockingTxnQuery = currBlockedFingerprintStmts.queryIDs.map(
+      id =>
+        stmtFingerprintToQuery.get(id) ??
+        `Query unavailable for statement fingerprint ${id}`,
+    );
+  });
+
+  const waitingTxn = txnsWithStmtFingerprints.find(
+    txn =>
+      txn.transactionFingerprintID ===
+      partialTxnContentionDetails.transactionFingerprintID,
+  );
+
+  return {
+    ...partialTxnContentionDetails,
+    application: waitingTxn?.application,
+  };
+}
+
+type StmtFingerprintToQueryRecord = Map<
+  string, // Key = Stmt fingerprint ID
+  string // Value = query string
+>;
+
+function createStmtFingerprintToQueryMap(
+  response: SqlExecutionResponse<FingerprintStmtsResponseColumns>,
+): StmtFingerprintToQueryRecord {
+  const idToQuery: Map<string, string> = new Map();
+  if (!response || sqlResultsAreEmpty(response)) {
+    // No statement fingerprint results.
+    return idToQuery;
+  }
+  response.execution.txn_results[0].rows.forEach(row => {
+    idToQuery.set(
+      FixFingerprintHexValue(row.statement_fingerprint_id),
+      row.query,
+    );
+  });
+
+  return idToQuery;
+}
+
+// Query to select all statement queries for each requested statement
+// fingerprint.
+const fingerprintStmtsQuery = (stmtFingerprintIDs: string[]): string => `
+SELECT
+  DISTINCT ON (fingerprint_id) encode(fingerprint_id, 'hex') AS statement_fingerprint_id,
+  (metadata ->> 'query') AS query
+FROM crdb_internal.statement_statistics_persisted
+WHERE encode(fingerprint_id, 'hex') =
+      ANY ARRAY[ ${stmtFingerprintIDs.map(id => `'${id}'`).join(",")} ]`;
+
+// txnStmtFingerprintsQuery selects all statement fingerprints for each
+// requested transaction fingerprint.
+const txnStmtFingerprintsQuery = (txnFingerprintIDs: string[]) => `
+SELECT
+  DISTINCT ON (fingerprint_id) encode(fingerprint_id, 'hex') AS transaction_fingerprint_id,
+  app_name,
+  ARRAY( SELECT jsonb_array_elements_text(metadata -> 'stmtFingerprintIDs' )) AS query_ids
+FROM crdb_internal.transaction_statistics_persisted
+WHERE app_name != '${INTERNAL_SQL_API_APP}'
+  AND encode(fingerprint_id, 'hex') = 
+      ANY ARRAY[ ${txnFingerprintIDs.map(id => `'${id}'`).join(",")} ]`;
+
+function formatTxnFingerprintsResults(
+  response: SqlExecutionResponse<TxnStmtFingerprintsResponseColumns>,
+): TxnWithStmtFingerprints[] {
+  if (sqlResultsAreEmpty(response)) {
+    return [];
+  }
+
+  return response.execution.txn_results[0].rows.map(row => ({
+    transactionFingerprintID: FixFingerprintHexValue(
+      row.transaction_fingerprint_id,
+    ),
+    queryIDs: row.query_ids.map(id => FixFingerprintHexValue(id)),
+    application: row.app_name,
+  }));
+}
+
+export async function getTxnInsightsContentionDetailsApi(
+  req: Pick<TxnInsightDetailsRequest, "txnExecutionID">,
+): Promise<TxnContentionInsightDetails> {
+  // Note that any errors encountered fetching these results are caught
+  // earlier in the call stack.
+  //
+  // There are 3 api requests/queries in this process.
+  // 1. Get contention insight for the requested transaction.
+  // 2. Get the stmt fingerprints for ALL transactions involved in the contention.
+  // 3. Get the query strings for ALL statements involved in the transaction.
+
+  // Get contention results for requested transaction.
+
+  const contentionResponse = await getContentionDetailsApi({
+    waitingTxnID: req.txnExecutionID,
+  });
+  const contentionResults = contentionResponse.results;
+
+  if (contentionResults.length === 0) {
+    return null;
+  }
+
+  const contentionDetails =
+    formatTxnContentionDetailsResponse(contentionResults);
+
+  // Collect all blocking txn fingerprints involved.
+  const txnFingerprintIDs: string[] = [];
+  contentionDetails.blockingContentionDetails.forEach(x =>
+    txnFingerprintIDs.push(x.blockingTxnFingerprintID),
+  );
+
+  // Request all blocking stmt fingerprint ids involved.
+  const getStmtFingerprintsResponse =
+    await executeInternalSql<TxnStmtFingerprintsResponseColumns>(
+      makeInsightsSqlRequest([txnStmtFingerprintsQuery(txnFingerprintIDs)]),
+    );
+  if (getStmtFingerprintsResponse.error) {
+    throw new Error(
+      `Error while retrieving statements information: ${sqlApiErrorMessage(
+        getStmtFingerprintsResponse.error.message,
+      )}`,
+    );
+  }
+
+  const txnsWithStmtFingerprints = formatTxnFingerprintsResults(
+    getStmtFingerprintsResponse,
+  );
+
+  const stmtFingerprintIDs = new Set<string>();
+  txnsWithStmtFingerprints.forEach(txnFingerprint =>
+    txnFingerprint.queryIDs.forEach(id => stmtFingerprintIDs.add(id)),
+  );
+
+  // Request query string from stmt fingerprint ids.
+  let stmtQueriesResponse: SqlExecutionResponse<FingerprintStmtsResponseColumns> | null =
+    null;
+
+  if (stmtFingerprintIDs.size) {
+    stmtQueriesResponse =
+      await executeInternalSql<FingerprintStmtsResponseColumns>(
+        makeInsightsSqlRequest([
+          fingerprintStmtsQuery(Array.from(stmtFingerprintIDs)),
+        ]),
+      );
+    if (stmtQueriesResponse.error) {
+      throw new Error(
+        `Error while retrieving statements information: ${sqlApiErrorMessage(
+          stmtQueriesResponse.error.message,
+        )}`,
+      );
+    }
+  }
+
+  return buildTxnContentionInsightDetails(
+    contentionDetails,
+    txnsWithStmtFingerprints,
+    createStmtFingerprintToQueryMap(stmtQueriesResponse),
+  );
 }

--- a/pkg/ui/workspaces/cluster-ui/src/api/index.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/index.ts
@@ -27,3 +27,4 @@ export * from "./databaseDetailsApi";
 export * from "./tableDetailsApi";
 export * from "./types";
 export * from "./jobProfilerApi";
+export * from "./txnInsightDetailsApi";

--- a/pkg/ui/workspaces/cluster-ui/src/api/txnInsightDetailsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/txnInsightDetailsApi.ts
@@ -1,0 +1,158 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import moment from "moment-timezone";
+import {
+  executeInternalSql,
+  isMaxSizeError,
+  sqlApiErrorMessage,
+  SqlApiResponse,
+} from "./sqlApi";
+import { InsightNameEnum, TxnInsightDetails } from "../insights";
+import {
+  formatStmtInsights,
+  stmtInsightsByTxnExecutionQuery,
+  StmtInsightsResponseRow,
+} from "./stmtInsightsApi";
+import {
+  formatTxnInsightsRow,
+  createTxnInsightsQuery,
+  TxnInsightsResponseRow,
+} from "./txnInsightsApi";
+import { makeInsightsSqlRequest } from "./txnInsightsUtils";
+import { getTxnInsightsContentionDetailsApi } from "./contentionApi";
+
+export type TxnInsightDetailsRequest = {
+  txnExecutionID: string;
+  excludeStmts?: boolean;
+  excludeTxn?: boolean;
+  excludeContention?: boolean;
+  mergeResultWith?: TxnInsightDetails;
+  start?: moment.Moment;
+  end?: moment.Moment;
+};
+
+export type TxnInsightDetailsReqErrs = {
+  txnDetailsErr: Error | null;
+  contentionErr: Error | null;
+  statementsErr: Error | null;
+};
+
+export type TxnInsightDetailsResponse = {
+  txnExecutionID: string;
+  result: TxnInsightDetails;
+  errors: TxnInsightDetailsReqErrs;
+};
+
+export async function getTxnInsightDetailsApi(
+  req: TxnInsightDetailsRequest,
+): Promise<SqlApiResponse<TxnInsightDetailsResponse>> {
+  // All queries in this request read from virtual tables, which is an
+  // expensive operation. To reduce the number of RPC fanouts, we have the
+  // caller specify which parts of the txn details we should return, since
+  // some parts may be available in the cache or are unnecessary to fetch
+  // (e.g. when there is no high contention to report).
+  //
+  // Note the way we construct the object below is important. We spread the
+  // existing object fields into a new object in order to ensure a new
+  // reference is returned so that components will be notified that there
+  // was a change. However, we want the internal objects (e.g. txnDetails)
+  // should only change when they are re-fetched so that components don't update
+  // unnecessarily.
+  const txnInsightDetails: TxnInsightDetails = { ...req.mergeResultWith };
+  const errors: TxnInsightDetailsReqErrs = {
+    txnDetailsErr: null,
+    contentionErr: null,
+    statementsErr: null,
+  };
+
+  let maxSizeReached = false;
+  if (!req.excludeTxn) {
+    const request = makeInsightsSqlRequest([
+      createTxnInsightsQuery({
+        execID: req?.txnExecutionID,
+        start: req?.start,
+        end: req?.end,
+      }),
+    ]);
+
+    try {
+      const result = await executeInternalSql<TxnInsightsResponseRow>(request);
+      maxSizeReached = isMaxSizeError(result.error?.message);
+
+      if (result.error && !maxSizeReached) {
+        throw new Error(
+          `Error while retrieving insights information: ${sqlApiErrorMessage(
+            result.error.message,
+          )}`,
+        );
+      }
+
+      const txnDetailsRes = result.execution.txn_results[0];
+      if (txnDetailsRes.rows?.length) {
+        txnInsightDetails.txnDetails = formatTxnInsightsRow(
+          txnDetailsRes.rows[0],
+        );
+      }
+    } catch (e) {
+      errors.txnDetailsErr = e;
+    }
+  }
+
+  if (!req.excludeStmts) {
+    try {
+      const request = makeInsightsSqlRequest([
+        stmtInsightsByTxnExecutionQuery(req.txnExecutionID),
+      ]);
+
+      const result = await executeInternalSql<StmtInsightsResponseRow>(request);
+      const maxSizeStmtReached = isMaxSizeError(result.error?.message);
+
+      if (result.error && !maxSizeStmtReached) {
+        throw new Error(
+          `Error while retrieving insights information: ${sqlApiErrorMessage(
+            result.error.message,
+          )}`,
+        );
+      }
+      maxSizeReached = maxSizeReached || maxSizeStmtReached;
+
+      const stmts = result.execution.txn_results[0];
+      if (stmts.rows?.length) {
+        txnInsightDetails.statements = formatStmtInsights(stmts);
+      }
+    } catch (e) {
+      errors.statementsErr = e;
+    }
+  }
+
+  const highContention = txnInsightDetails.txnDetails?.insights?.some(
+    insight => insight.name === InsightNameEnum.highContention,
+  );
+
+  try {
+    if (!req.excludeContention && highContention) {
+      const contentionInfo = await getTxnInsightsContentionDetailsApi(req);
+      txnInsightDetails.blockingContentionDetails =
+        contentionInfo?.blockingContentionDetails;
+    }
+  } catch (e) {
+    errors.contentionErr = e;
+  }
+
+  return {
+    maxSizeReached: maxSizeReached,
+    results: {
+      txnExecutionID: req.txnExecutionID,
+      result: txnInsightDetails,
+      errors,
+    },
+  };
+}

--- a/pkg/ui/workspaces/cluster-ui/src/api/txnInsightsApi.spec.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/txnInsightsApi.spec.ts
@@ -9,7 +9,6 @@
 // licenses/APL.txt.
 
 import {
-  getTxnInsightsContentionDetailsApi,
   TxnStmtFingerprintsResponseColumns,
   FingerprintStmtsResponseColumns,
 } from "./txnInsightsApi";
@@ -20,7 +19,10 @@ import {
   InsightNameEnum,
   TxnContentionInsightDetails,
 } from "../insights";
-import { ContentionResponseColumns } from "./contentionApi";
+import {
+  ContentionResponseColumns,
+  getTxnInsightsContentionDetailsApi,
+} from "./contentionApi";
 import moment from "moment-timezone";
 
 function mockSqlResponse<T>(rows: T[]): SqlExecutionResponse<T> {

--- a/pkg/ui/workspaces/cluster-ui/src/api/txnInsightsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/txnInsightsApi.ts
@@ -11,49 +11,26 @@
 import {
   executeInternalSql,
   formatApiResult,
-  INTERNAL_SQL_API_APP,
-  isMaxSizeError,
-  LARGE_RESULT_SIZE,
-  LONG_TIMEOUT,
-  sqlApiErrorMessage,
   SqlApiResponse,
-  SqlExecutionRequest,
-  SqlExecutionResponse,
   sqlResultsAreEmpty,
 } from "./sqlApi";
 import {
-  ContentionDetails,
   getInsightsFromProblemsAndCauses,
   InsightExecEnum,
-  InsightNameEnum,
   TransactionStatus,
-  TxnContentionInsightDetails,
-  TxnInsightDetails,
   TxnInsightEvent,
 } from "src/insights";
 import moment from "moment-timezone";
-import { FixFingerprintHexValue } from "../util";
-import {
-  formatStmtInsights,
-  stmtInsightsByTxnExecutionQuery,
-  StmtInsightsResponseRow,
-} from "./stmtInsightsApi";
-import { INTERNAL_APP_NAME_PREFIX } from "src/util/constants";
-import { getContentionDetailsApi } from "./contentionApi";
+import { INTERNAL_APP_NAME_PREFIX } from "../util";
+import { makeInsightsSqlRequest } from "./txnInsightsUtils";
 
-export const TXN_QUERY_PREVIEW_MAX = 800;
-export const QUERY_MAX = 1500;
-export const TXN_INSIGHTS_TABLE_NAME =
-  "crdb_internal.cluster_txn_execution_insights";
+// Txn query string limit for previews in the overview page.
+const TXN_QUERY_PREVIEW_MAX = 800;
 
-const makeInsightsSqlRequest = (
-  queries: Array<string | null>,
-): SqlExecutionRequest => ({
-  statements: queries.filter(q => q).map(query => ({ sql: query })),
-  execute: true,
-  max_result_size: LARGE_RESULT_SIZE,
-  timeout: LONG_TIMEOUT,
-});
+// Query string limit for txn details.
+const QUERY_MAX = 1500;
+
+const TXN_INSIGHTS_TABLE_NAME = "crdb_internal.cluster_txn_execution_insights";
 
 export type TxnWithStmtFingerprints = {
   application: string; // TODO #108051: (xinhaoz) this field seems deprecated.
@@ -68,216 +45,12 @@ export type TxnStmtFingerprintsResponseColumns = {
   app_name: string;
 };
 
-// txnStmtFingerprintsQuery selects all statement fingerprints for each
-// requested transaction fingerprint.
-const txnStmtFingerprintsQuery = (txnFingerprintIDs: string[]) => `
-SELECT
-  DISTINCT ON (fingerprint_id) encode(fingerprint_id, 'hex') AS transaction_fingerprint_id,
-  app_name,
-  ARRAY( SELECT jsonb_array_elements_text(metadata -> 'stmtFingerprintIDs' )) AS query_ids
-FROM crdb_internal.transaction_statistics_persisted
-WHERE app_name != '${INTERNAL_SQL_API_APP}'
-  AND encode(fingerprint_id, 'hex') = 
-      ANY ARRAY[ ${txnFingerprintIDs.map(id => `'${id}'`).join(",")} ]`;
-
-function formatTxnFingerprintsResults(
-  response: SqlExecutionResponse<TxnStmtFingerprintsResponseColumns>,
-): TxnWithStmtFingerprints[] {
-  if (sqlResultsAreEmpty(response)) {
-    return [];
-  }
-
-  return response.execution.txn_results[0].rows.map(row => ({
-    transactionFingerprintID: FixFingerprintHexValue(
-      row.transaction_fingerprint_id,
-    ),
-    queryIDs: row.query_ids.map(id => FixFingerprintHexValue(id)),
-    application: row.app_name,
-  }));
-}
-
-type StmtFingerprintToQueryRecord = Map<
-  string, // Key = Stmt fingerprint ID
-  string // Value = query string
->;
-
 export type FingerprintStmtsResponseColumns = {
   statement_fingerprint_id: string;
   query: string;
 };
 
-// Query to select all statement queries for each requested statement
-// fingerprint.
-const fingerprintStmtsQuery = (stmtFingerprintIDs: string[]): string => `
-SELECT
-  DISTINCT ON (fingerprint_id) encode(fingerprint_id, 'hex') AS statement_fingerprint_id,
-  (metadata ->> 'query') AS query
-FROM crdb_internal.statement_statistics_persisted
-WHERE encode(fingerprint_id, 'hex') =
-      ANY ARRAY[ ${stmtFingerprintIDs.map(id => `'${id}'`).join(",")} ]`;
-
-function createStmtFingerprintToQueryMap(
-  response: SqlExecutionResponse<FingerprintStmtsResponseColumns>,
-): StmtFingerprintToQueryRecord {
-  const idToQuery: Map<string, string> = new Map();
-  if (!response || sqlResultsAreEmpty(response)) {
-    // No statement fingerprint results.
-    return idToQuery;
-  }
-  response.execution.txn_results[0].rows.forEach(row => {
-    idToQuery.set(
-      FixFingerprintHexValue(row.statement_fingerprint_id),
-      row.query,
-    );
-  });
-
-  return idToQuery;
-}
-
-type PartialTxnContentionDetails = Omit<
-  TxnContentionInsightDetails,
-  "application" | "queries"
->;
-
-function formatTxnContentionDetailsResponse(
-  response: ContentionDetails[],
-): PartialTxnContentionDetails {
-  if (!response || response.length === 9) {
-    // No data.
-    return;
-  }
-
-  const row = response[0];
-  return {
-    transactionExecutionID: row.waitingTxnID,
-    transactionFingerprintID: FixFingerprintHexValue(
-      row.waitingTxnFingerprintID,
-    ),
-    blockingContentionDetails: response,
-    insightName: InsightNameEnum.highContention,
-    execType: InsightExecEnum.TRANSACTION,
-  };
-}
-
-export async function getTxnInsightsContentionDetailsApi(
-  req: Pick<TxnInsightDetailsRequest, "txnExecutionID">,
-): Promise<TxnContentionInsightDetails> {
-  // Note that any errors encountered fetching these results are caught
-  // earlier in the call stack.
-  //
-  // There are 3 api requests/queries in this process.
-  // 1. Get contention insight for the requested transaction.
-  // 2. Get the stmt fingerprints for ALL transactions involved in the contention.
-  // 3. Get the query strings for ALL statements involved in the transaction.
-
-  // Get contention results for requested transaction.
-
-  const contentionResponse = await getContentionDetailsApi({
-    waitingTxnID: req.txnExecutionID,
-  });
-  const contentionResults = contentionResponse.results;
-
-  if (contentionResults.length === 0) {
-    return null;
-  }
-
-  const contentionDetails =
-    formatTxnContentionDetailsResponse(contentionResults);
-
-  // Collect all blocking txn fingerprints involved.
-  const txnFingerprintIDs: string[] = [];
-  contentionDetails.blockingContentionDetails.forEach(x =>
-    txnFingerprintIDs.push(x.blockingTxnFingerprintID),
-  );
-
-  // Request all blocking stmt fingerprint ids involved.
-  const getStmtFingerprintsResponse =
-    await executeInternalSql<TxnStmtFingerprintsResponseColumns>(
-      makeInsightsSqlRequest([txnStmtFingerprintsQuery(txnFingerprintIDs)]),
-    );
-  if (getStmtFingerprintsResponse.error) {
-    throw new Error(
-      `Error while retrieving statements information: ${sqlApiErrorMessage(
-        getStmtFingerprintsResponse.error.message,
-      )}`,
-    );
-  }
-
-  const txnsWithStmtFingerprints = formatTxnFingerprintsResults(
-    getStmtFingerprintsResponse,
-  );
-
-  const stmtFingerprintIDs = new Set<string>();
-  txnsWithStmtFingerprints.forEach(txnFingerprint =>
-    txnFingerprint.queryIDs.forEach(id => stmtFingerprintIDs.add(id)),
-  );
-
-  // Request query string from stmt fingerprint ids.
-  let stmtQueriesResponse: SqlExecutionResponse<FingerprintStmtsResponseColumns> | null =
-    null;
-
-  if (stmtFingerprintIDs.size) {
-    stmtQueriesResponse =
-      await executeInternalSql<FingerprintStmtsResponseColumns>(
-        makeInsightsSqlRequest([
-          fingerprintStmtsQuery(Array.from(stmtFingerprintIDs)),
-        ]),
-      );
-    if (stmtQueriesResponse.error) {
-      throw new Error(
-        `Error while retrieving statements information: ${sqlApiErrorMessage(
-          stmtQueriesResponse.error.message,
-        )}`,
-      );
-    }
-  }
-
-  return buildTxnContentionInsightDetails(
-    contentionDetails,
-    txnsWithStmtFingerprints,
-    createStmtFingerprintToQueryMap(stmtQueriesResponse),
-  );
-}
-
-function buildTxnContentionInsightDetails(
-  partialTxnContentionDetails: PartialTxnContentionDetails,
-  txnsWithStmtFingerprints: TxnWithStmtFingerprints[],
-  stmtFingerprintToQuery: StmtFingerprintToQueryRecord,
-): TxnContentionInsightDetails {
-  if (!partialTxnContentionDetails && !txnsWithStmtFingerprints.length) {
-    return null;
-  }
-
-  partialTxnContentionDetails.blockingContentionDetails.forEach(blockedRow => {
-    const currBlockedFingerprintStmts = txnsWithStmtFingerprints.find(
-      txn =>
-        txn.transactionFingerprintID === blockedRow.blockingTxnFingerprintID,
-    );
-
-    if (!currBlockedFingerprintStmts) {
-      return;
-    }
-
-    blockedRow.blockingTxnQuery = currBlockedFingerprintStmts.queryIDs.map(
-      id =>
-        stmtFingerprintToQuery.get(id) ??
-        `Query unavailable for statement fingerprint ${id}`,
-    );
-  });
-
-  const waitingTxn = txnsWithStmtFingerprints.find(
-    txn =>
-      txn.transactionFingerprintID ===
-      partialTxnContentionDetails.transactionFingerprintID,
-  );
-
-  return {
-    ...partialTxnContentionDetails,
-    application: waitingTxn?.application,
-  };
-}
-
-type TxnInsightsResponseRow = {
+export type TxnInsightsResponseRow = {
   session_id: string;
   txn_id: string;
   txn_fingerprint_id: string; // Hex string
@@ -311,7 +84,7 @@ type TxnQueryFilters = {
 
 // We only surface the most recently observed problem for a given
 // transaction.
-const createTxnInsightsQuery = (filters?: TxnQueryFilters) => {
+export const createTxnInsightsQuery = (filters?: TxnQueryFilters) => {
   const queryLimit = filters.execID ? QUERY_MAX : TXN_QUERY_PREVIEW_MAX;
 
   const txnColumns = `
@@ -376,7 +149,9 @@ SELECT ${txnColumns} FROM
 `;
 };
 
-function formatTxnInsightsRow(row: TxnInsightsResponseRow): TxnInsightEvent {
+export function formatTxnInsightsRow(
+  row: TxnInsightsResponseRow,
+): TxnInsightEvent {
   const startTime = moment.utc(row.start_time);
   const endTime = moment.utc(row.end_time);
   const insights = getInsightsFromProblemsAndCauses(
@@ -442,132 +217,4 @@ export async function getTxnInsightsApi(
     result.error,
     "retrieving insights information",
   );
-}
-
-export type TxnInsightDetailsRequest = {
-  txnExecutionID: string;
-  excludeStmts?: boolean;
-  excludeTxn?: boolean;
-  excludeContention?: boolean;
-  mergeResultWith?: TxnInsightDetails;
-  start?: moment.Moment;
-  end?: moment.Moment;
-};
-
-export type TxnInsightDetailsReqErrs = {
-  txnDetailsErr: Error | null;
-  contentionErr: Error | null;
-  statementsErr: Error | null;
-};
-
-export type TxnInsightDetailsResponse = {
-  txnExecutionID: string;
-  result: TxnInsightDetails;
-  errors: TxnInsightDetailsReqErrs;
-};
-
-export async function getTxnInsightDetailsApi(
-  req: TxnInsightDetailsRequest,
-): Promise<SqlApiResponse<TxnInsightDetailsResponse>> {
-  // All queries in this request read from virtual tables, which is an
-  // expensive operation. To reduce the number of RPC fanouts, we have the
-  // caller specify which parts of the txn details we should return, since
-  // some parts may be available in the cache or are unnecessary to fetch
-  // (e.g. when there is no high contention to report).
-  //
-  // Note the way we construct the object below is important. We spread the
-  // existing object fields into a new object in order to ensure a new
-  // reference is returned so that components will be notified that there
-  // was a change. However, we want the internal objects (e.g. txnDetails)
-  // should only change when they are re-fetched so that components don't update
-  // unnecessarily.
-  const txnInsightDetails: TxnInsightDetails = { ...req.mergeResultWith };
-  const errors: TxnInsightDetailsReqErrs = {
-    txnDetailsErr: null,
-    contentionErr: null,
-    statementsErr: null,
-  };
-
-  let maxSizeReached = false;
-  if (!req.excludeTxn) {
-    const request = makeInsightsSqlRequest([
-      createTxnInsightsQuery({
-        execID: req?.txnExecutionID,
-        start: req?.start,
-        end: req?.end,
-      }),
-    ]);
-
-    try {
-      const result = await executeInternalSql<TxnInsightsResponseRow>(request);
-      maxSizeReached = isMaxSizeError(result.error?.message);
-
-      if (result.error && !maxSizeReached) {
-        throw new Error(
-          `Error while retrieving insights information: ${sqlApiErrorMessage(
-            result.error.message,
-          )}`,
-        );
-      }
-
-      const txnDetailsRes = result.execution.txn_results[0];
-      if (txnDetailsRes.rows?.length) {
-        txnInsightDetails.txnDetails = formatTxnInsightsRow(
-          txnDetailsRes.rows[0],
-        );
-      }
-    } catch (e) {
-      errors.txnDetailsErr = e;
-    }
-  }
-
-  if (!req.excludeStmts) {
-    try {
-      const request = makeInsightsSqlRequest([
-        stmtInsightsByTxnExecutionQuery(req.txnExecutionID),
-      ]);
-
-      const result = await executeInternalSql<StmtInsightsResponseRow>(request);
-      const maxSizeStmtReached = isMaxSizeError(result.error?.message);
-
-      if (result.error && !maxSizeStmtReached) {
-        throw new Error(
-          `Error while retrieving insights information: ${sqlApiErrorMessage(
-            result.error.message,
-          )}`,
-        );
-      }
-      maxSizeReached = maxSizeReached || maxSizeStmtReached;
-
-      const stmts = result.execution.txn_results[0];
-      if (stmts.rows?.length) {
-        txnInsightDetails.statements = formatStmtInsights(stmts);
-      }
-    } catch (e) {
-      errors.statementsErr = e;
-    }
-  }
-
-  const highContention = txnInsightDetails.txnDetails?.insights?.some(
-    insight => insight.name === InsightNameEnum.highContention,
-  );
-
-  try {
-    if (!req.excludeContention && highContention) {
-      const contentionInfo = await getTxnInsightsContentionDetailsApi(req);
-      txnInsightDetails.blockingContentionDetails =
-        contentionInfo?.blockingContentionDetails;
-    }
-  } catch (e) {
-    errors.contentionErr = e;
-  }
-
-  return {
-    maxSizeReached: maxSizeReached,
-    results: {
-      txnExecutionID: req.txnExecutionID,
-      result: txnInsightDetails,
-      errors,
-    },
-  };
 }

--- a/pkg/ui/workspaces/cluster-ui/src/api/txnInsightsUtils.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/txnInsightsUtils.ts
@@ -1,0 +1,20 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { LARGE_RESULT_SIZE, LONG_TIMEOUT, SqlExecutionRequest } from "./sqlApi";
+
+export const makeInsightsSqlRequest = (
+  queries: Array<string | null>,
+): SqlExecutionRequest => ({
+  statements: queries.filter(q => q).map(query => ({ sql: query })),
+  execute: true,
+  max_result_size: LARGE_RESULT_SIZE,
+  timeout: LONG_TIMEOUT,
+});

--- a/pkg/ui/workspaces/cluster-ui/src/insights/types.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/types.ts
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-import { Moment } from "moment-timezone";
+import moment, { Moment } from "moment-timezone";
 import { Filters } from "../queryFilter";
 
 // This enum corresponds to the string enum for `problems` in `cluster_execution_insights`
@@ -85,6 +85,7 @@ export type ContentionDetails = {
   contentionTimeMs: number;
 };
 
+// The return type of getTxnInsightsContentionDetailsApi.
 export type TxnContentionInsightDetails = {
   transactionExecutionID: string;
   application: string;
@@ -101,7 +102,6 @@ export type TxnInsightDetails = {
   txnDetails?: TxnInsightEvent;
   blockingContentionDetails?: ContentionDetails[];
   statements?: StmtInsightEvent[];
-  execType?: InsightExecEnum;
 };
 
 // Shown on the stmt insights overview page.

--- a/pkg/ui/workspaces/cluster-ui/src/store/insightDetails/transactionInsightDetails/transactionInsightDetails.reducer.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/insightDetails/transactionInsightDetails/transactionInsightDetails.reducer.ts
@@ -12,12 +12,12 @@ import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { DOMAIN_NAME } from "src/store/utils";
 import moment, { Moment } from "moment-timezone";
 import { ErrorWithKey } from "src/api/statementsApi";
+import { TxnInsightDetails } from "src/insights";
+import { SqlApiResponse, TxnInsightDetailsReqErrs } from "src/api";
 import {
   TxnInsightDetailsRequest,
   TxnInsightDetailsResponse,
-} from "src/api/txnInsightsApi";
-import { TxnInsightDetails } from "src/insights";
-import { SqlApiResponse, TxnInsightDetailsReqErrs } from "src/api";
+} from "../../../api/txnInsightDetailsApi";
 
 export type TxnInsightDetailsState = {
   data: TxnInsightDetails | null;

--- a/pkg/ui/workspaces/cluster-ui/src/store/insightDetails/transactionInsightDetails/transactionInsightDetails.sagas.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/insightDetails/transactionInsightDetails/transactionInsightDetails.sagas.ts
@@ -11,13 +11,13 @@
 import { all, call, put, takeLatest, takeEvery } from "redux-saga/effects";
 
 import { actions } from "./transactionInsightDetails.reducer";
+import { PayloadAction } from "@reduxjs/toolkit";
+import { ErrorWithKey, SqlApiResponse } from "src/api";
 import {
   getTxnInsightDetailsApi,
   TxnInsightDetailsRequest,
   TxnInsightDetailsResponse,
-} from "src/api/txnInsightsApi";
-import { PayloadAction } from "@reduxjs/toolkit";
-import { ErrorWithKey, SqlApiResponse } from "src/api";
+} from "../../../api/txnInsightDetailsApi";
 
 export function* refreshTransactionInsightDetailsSaga(
   action: PayloadAction<TxnInsightDetailsRequest>,


### PR DESCRIPTION
This commit simply moves txn details functions out of `txnDetailsApi` and into its own file. No functional changes are made. New filesto organize shared functions:
- txnInsightsUtils.ts

This patch also moves contention related functions from `txnInsightsApi` to `contentionApi`.

Epic: none

Release note: None