### PR TITLE
release-23.1: kv: enable replay protection for ambiguous writes on commits

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -1166,7 +1166,7 @@ func (ds *DistSender) detectIntentMissingDueToIntentResolution(
 		// We weren't able to determine whether the intent missing error is
 		// due to intent resolution or not, so it is still ambiguous whether
 		// the commit succeeded.
-		return false, kvpb.NewAmbiguousResultErrorf("error=%s [intent missing]", pErr)
+		return false, kvpb.NewAmbiguousResultErrorf("error=%v [intent missing]", pErr)
 	}
 	resp := br.Responses[0].GetQueryTxn()
 	respTxn := &resp.QueriedTxn
@@ -1980,7 +1980,8 @@ func maybeSetResumeSpan(
 // the error that the last attempt to execute the request returned.
 func noMoreReplicasErr(ambiguousErr, lastAttemptErr error) error {
 	if ambiguousErr != nil {
-		return kvpb.NewAmbiguousResultErrorf("error=%s [exhausted]", ambiguousErr)
+		return kvpb.NewAmbiguousResultErrorf("error=%v [exhausted] (last error: %v)",
+			ambiguousErr, lastAttemptErr)
 	}
 
 	// TODO(bdarnell): The error from the last attempt is not necessarily the best
@@ -2158,6 +2159,28 @@ func (ds *DistSender) sendToReplicas(
 		ba = ba.ShallowCopy()
 		ba.Replica = curReplica
 		ba.RangeID = desc.RangeID
+
+		// When a sub-batch from a batch containing a commit experiences an
+		// ambiguous error, it is critical to ensure subsequent replay attempts
+		// do not permit changing the write timestamp, as the transaction may
+		// already have been considered implicitly committed.
+		ba.AmbiguousReplayProtection = ambiguousError != nil
+
+		// In the case that the batch has already seen an ambiguous error, in
+		// addition to enabling ambiguous replay protection, we also need to
+		// disable the ability for the server to forward the read timestamp, as
+		// the transaction may have been implicitly committed. If the intents for
+		// the implicitly committed transaction were already resolved, on a replay
+		// attempt encountering committed values above the read timestamp the
+		// server will attempt to handle what seems to be a write-write conflict by
+		// throwing a WriteTooOld, which could be refreshed away on the server if
+		// the read timestamp can be moved. Disabling this ability protects against
+		// refreshing away the error when retrying the ambiguous operation, instead
+		// returning to the DistSender so the ambiguous error can be propagated.
+		if ambiguousError != nil && ba.CanForwardReadTimestamp {
+			ba.CanForwardReadTimestamp = false
+		}
+
 		// Communicate to the server the information our cache has about the
 		// range. If it's stale, the serve will return an update.
 		ba.ClientRangeInfo = roachpb.ClientRangeInfo{
@@ -2183,10 +2206,13 @@ func (ds *DistSender) sendToReplicas(
 		ds.maybeIncrementErrCounters(br, err)
 
 		if err != nil {
+			log.VErrEventf(ctx, 2, "RPC error: %s", err)
+
 			if grpcutil.IsAuthError(err) {
 				// Authentication or authorization error. Propagate.
 				if ambiguousError != nil {
-					return nil, kvpb.NewAmbiguousResultErrorf("error=%s [propagate]", ambiguousError)
+					return nil, kvpb.NewAmbiguousResultErrorf("error=%v [propagate] (last error: %v)",
+						ambiguousError, err)
 				}
 				return nil, err
 			}
@@ -2208,10 +2234,6 @@ func (ds *DistSender) sendToReplicas(
 			// ambiguity.
 			// 2) SQL recognizes AmbiguousResultErrors and gives them a special code
 			// (StatementCompletionUnknown).
-			// TODO(andrei): The use of this code is inconsistent because a) the
-			// DistSender tries to only return the code for commits, but it'll happily
-			// forward along AmbiguousResultErrors coming from the replica and b) we
-			// probably should be returning that code for non-commit statements too.
 			//
 			// We retry requests in order to avoid returning errors (in particular,
 			// AmbiguousResultError). Retrying the batch will either:
@@ -2226,6 +2248,12 @@ func (ds *DistSender) sendToReplicas(
 			//    can't claim success (and even if we could claim success, we still
 			//    wouldn't have the complete result of the successful evaluation).
 			//
+			// Note that in case c), a request is not idempotent if the retry finds
+			// the request succeeded the first time around, but requires a change to
+			// the transaction's write timestamp. This is guarded against by setting
+			// the AmbiguousReplayProtection flag, so that the replay is aware the
+			// batch has seen an ambiguous error.
+			//
 			// Case a) is great - the retry made the request succeed. Case b) is also
 			// good; due to idempotency we managed to swallow a communication error.
 			// Case c) is not great - we'll end up returning an error even though the
@@ -2238,10 +2266,12 @@ func (ds *DistSender) sendToReplicas(
 			// evaluating twice, overwriting another unrelated write that fell
 			// in-between.
 			//
+			// NB: If this partial batch does not contain the EndTxn request but the
+			// batch contains a commit, the ambiguous error should be caught on
+			// retrying the writes, should it need to be propagated.
 			if withCommit && !grpcutil.RequestDidNotStart(err) {
 				ambiguousError = err
 			}
-			log.VErrEventf(ctx, 2, "RPC error: %s", err)
 
 			// If the error wasn't just a context cancellation and the down replica
 			// is cached as the lease holder, evict it. The only other eviction
@@ -2397,7 +2427,8 @@ func (ds *DistSender) sendToReplicas(
 				}
 			default:
 				if ambiguousError != nil {
-					return nil, kvpb.NewAmbiguousResultErrorf("error=%s [propagate]", ambiguousError)
+					return nil, kvpb.NewAmbiguousResultErrorf("error=%v [propagate] (last error: %v)",
+						ambiguousError, br.Error.GoError())
 				}
 
 				// The error received is likely not specific to this

--- a/pkg/kv/kvclient/kvcoord/dist_sender_ambiguous_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_ambiguous_test.go
@@ -1048,7 +1048,7 @@ func TestTransactionUnexpectedlyCommitted(t *testing.T) {
 			// 7. _->n1: PushTxn(txn2->txn1) -- Discovers txn1 in STAGING and starts
 			// recovery.
 			// 8. _->n1: RecoverTxn(txn1) -- Recovery should mark txn1 committed, but
-			// pauses before returning so that txn1's intents don't get cleaned up.
+			// intent resolution on txn1 needs to be paused until after txn1 finishes.
 			if req.ba.IsSingleRecoverTxnRequest() && cp == AfterSending {
 				close(recoverComplete)
 			}
@@ -1075,8 +1075,15 @@ func TestTransactionUnexpectedlyCommitted(t *testing.T) {
 			// 12. txn1->n1: EndTxn(commit) -- Recovery has already completed, so this
 			// request fails with "transaction unexpectedly committed".
 
-			// <allow (8) recovery to return and txn2 to continue>
-			if req.ba.IsSingleRecoverTxnRequest() && cp == AfterSending {
+			// <allow intent resolution after (8) recovery so txn2 can continue>
+			// If the intent on (b) were resolved and txn2 could grab the lock prior
+			// to txn1's retry of the Put(b), the retry will cause a PushTxn to txn2.
+			// Given that the recovery at (8) has already completed, a PushTxn
+			// request where the pusher is a committed transaction results in an
+			// "already committed" TransactionStatusError from the txnwait queue.
+			// While this still results in AmbiguousResultError from the DistSender,
+			// the reason will be distinct; as such we pause the intent resolution.
+			if riReq, ok := req.ba.GetArg(kvpb.ResolveIntent); ok && riReq.Header().Key.Equal(keyB) && cp == BeforeSending {
 				req.pauseUntil(t, txn1Done, cp)
 				t.Logf("%s - complete, resp={%s}", req.prefix, resp)
 			}

--- a/pkg/kv/kvpb/api.proto
+++ b/pkg/kv/kvpb/api.proto
@@ -2699,9 +2699,18 @@ message Header {
   // sender.
   repeated string profile_labels = 31 [(gogoproto.customname) = "ProfileLabels"];
 
+  // AmbiguousReplayProtection, if set, prevents a retried write operation
+  // from being considered an idempotent replay of a successful prior attempt
+  // (of the same operation) if the request's write timestamp is different from
+  // the prior attempt's. This protection is required when there has been an
+  // ambiguous write (i.e. RPC error) on a batch that contained a commit,
+  // as the transaction may have already been considered implicitly committed,
+  // and/or been explicitly committed by a RecoverTxn request. See #103817.
+  bool ambiguous_replay_protection = 32;
+
   reserved 7, 10, 12, 14, 20;
 
-  // Next ID: 32
+  // Next ID: 33
 }
 
 // BoundedStalenessHeader contains configuration values pertaining to bounded

--- a/pkg/kv/kvpb/batch.go
+++ b/pkg/kv/kvpb/batch.go
@@ -855,6 +855,9 @@ func (ba BatchRequest) SafeFormat(s redact.SafePrinter, _ rune) {
 	if ba.WaitPolicy != lock.WaitPolicy_Block {
 		s.Printf(", [wait-policy: %s]", ba.WaitPolicy)
 	}
+	if ba.AmbiguousReplayProtection {
+		s.Printf(", [protect-ambiguous-replay]")
+	}
 	if ba.CanForwardReadTimestamp {
 		s.Printf(", [can-forward-ts]")
 	}

--- a/pkg/kv/kvpb/string_test.go
+++ b/pkg/kv/kvpb/string_test.go
@@ -42,6 +42,7 @@ func TestBatchRequestString(t *testing.T) {
 	txn.ID = uuid.NamespaceDNS
 	ba.Txn = &txn
 	ba.WaitPolicy = lock.WaitPolicy_Error
+	ba.AmbiguousReplayProtection = true
 	ba.CanForwardReadTimestamp = true
 	ba.BoundedStaleness = &kvpb.BoundedStalenessHeader{
 		MinTimestampBound:       hlc.Timestamp{WallTime: 1},
@@ -58,7 +59,7 @@ func TestBatchRequestString(t *testing.T) {
 	ba.Requests = append(ba.Requests, ru)
 
 	{
-		exp := `Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min),... 76 skipped ..., Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), EndTxn(abort) [/Min], [txn: 6ba7b810], [wait-policy: Error], [can-forward-ts], [bounded-staleness, min_ts_bound: 0.000000001,0, min_ts_bound_strict, max_ts_bound: 0.000000002,0]`
+		exp := `Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min),... 76 skipped ..., Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), EndTxn(abort) [/Min], [txn: 6ba7b810], [wait-policy: Error], [protect-ambiguous-replay], [can-forward-ts], [bounded-staleness, min_ts_bound: 0.000000001,0, min_ts_bound_strict, max_ts_bound: 0.000000002,0]`
 		act := ba.String()
 		require.Equal(t, exp, act)
 	}

--- a/pkg/kv/kvserver/batcheval/cmd_conditional_put.go
+++ b/pkg/kv/kvserver/batcheval/cmd_conditional_put.go
@@ -57,9 +57,10 @@ func ConditionalPut(
 	handleMissing := storage.CPutMissingBehavior(args.AllowIfDoesNotExist)
 
 	opts := storage.MVCCWriteOptions{
-		Txn:            h.Txn,
-		LocalTimestamp: cArgs.Now,
-		Stats:          cArgs.Stats,
+		Txn:                            h.Txn,
+		LocalTimestamp:                 cArgs.Now,
+		Stats:                          cArgs.Stats,
+		ReplayWriteTimestampProtection: h.AmbiguousReplayProtection,
 	}
 
 	var err error

--- a/pkg/kv/kvserver/batcheval/cmd_delete.go
+++ b/pkg/kv/kvserver/batcheval/cmd_delete.go
@@ -32,9 +32,10 @@ func Delete(
 	reply := resp.(*kvpb.DeleteResponse)
 
 	opts := storage.MVCCWriteOptions{
-		Txn:            h.Txn,
-		LocalTimestamp: cArgs.Now,
-		Stats:          cArgs.Stats,
+		Txn:                            h.Txn,
+		LocalTimestamp:                 cArgs.Now,
+		Stats:                          cArgs.Stats,
+		ReplayWriteTimestampProtection: h.AmbiguousReplayProtection,
 	}
 
 	var err error

--- a/pkg/kv/kvserver/batcheval/cmd_delete_range.go
+++ b/pkg/kv/kvserver/batcheval/cmd_delete_range.go
@@ -218,6 +218,14 @@ func DeleteRange(
 	if !args.Inline {
 		timestamp = h.Timestamp
 	}
+
+	opts := storage.MVCCWriteOptions{
+		Txn:                            h.Txn,
+		LocalTimestamp:                 cArgs.Now,
+		Stats:                          cArgs.Stats,
+		ReplayWriteTimestampProtection: h.AmbiguousReplayProtection,
+	}
+
 	// NB: Even if args.ReturnKeys is false, we want to know which intents were
 	// written if we're evaluating the DeleteRange for a transaction so that we
 	// can update the Result's AcquiredLocks field.
@@ -225,8 +233,7 @@ func DeleteRange(
 	deleted, resumeSpan, num, err := storage.MVCCDeleteRange(
 		ctx, readWriter, args.Key, args.EndKey,
 		h.MaxSpanRequestKeys, timestamp,
-		storage.MVCCWriteOptions{Txn: h.Txn, LocalTimestamp: cArgs.Now, Stats: cArgs.Stats},
-		returnKeys)
+		opts, returnKeys)
 	if err == nil && args.ReturnKeys {
 		reply.Keys = deleted
 	}

--- a/pkg/kv/kvserver/batcheval/cmd_increment.go
+++ b/pkg/kv/kvserver/batcheval/cmd_increment.go
@@ -33,9 +33,10 @@ func Increment(
 	reply := resp.(*kvpb.IncrementResponse)
 
 	opts := storage.MVCCWriteOptions{
-		Txn:            h.Txn,
-		LocalTimestamp: cArgs.Now,
-		Stats:          cArgs.Stats,
+		Txn:                            h.Txn,
+		LocalTimestamp:                 cArgs.Now,
+		Stats:                          cArgs.Stats,
+		ReplayWriteTimestampProtection: h.AmbiguousReplayProtection,
 	}
 
 	newVal, err := storage.MVCCIncrement(

--- a/pkg/kv/kvserver/batcheval/cmd_init_put.go
+++ b/pkg/kv/kvserver/batcheval/cmd_init_put.go
@@ -37,9 +37,10 @@ func InitPut(
 	}
 
 	opts := storage.MVCCWriteOptions{
-		Txn:            h.Txn,
-		LocalTimestamp: cArgs.Now,
-		Stats:          cArgs.Stats,
+		Txn:                            h.Txn,
+		LocalTimestamp:                 cArgs.Now,
+		Stats:                          cArgs.Stats,
+		ReplayWriteTimestampProtection: h.AmbiguousReplayProtection,
 	}
 
 	var err error

--- a/pkg/kv/kvserver/batcheval/cmd_put.go
+++ b/pkg/kv/kvserver/batcheval/cmd_put.go
@@ -53,9 +53,10 @@ func Put(
 	}
 
 	opts := storage.MVCCWriteOptions{
-		Txn:            h.Txn,
-		LocalTimestamp: cArgs.Now,
-		Stats:          cArgs.Stats,
+		Txn:                            h.Txn,
+		LocalTimestamp:                 cArgs.Now,
+		Stats:                          cArgs.Stats,
+		ReplayWriteTimestampProtection: h.AmbiguousReplayProtection,
 	}
 
 	var err error

--- a/pkg/storage/mvcc_history_test.go
+++ b/pkg/storage/mvcc_history_test.go
@@ -87,15 +87,14 @@ var (
 // check_intent   k=<key> [none]
 // add_lock       t=<name> k=<key>
 //
-// cput           [t=<name>] [ts=<int>[,<int>]] [localTs=<int>[,<int>]] [resolve [status=<txnstatus>]] k=<key> v=<string> [raw] [cond=<string>]
-// del            [t=<name>] [ts=<int>[,<int>]] [localTs=<int>[,<int>]] [resolve [status=<txnstatus>]] k=<key>
-// del_range      [t=<name>] [ts=<int>[,<int>]] [localTs=<int>[,<int>]] [resolve [status=<txnstatus>]] k=<key> [end=<key>] [max=<max>] [returnKeys]
+// cput           [t=<name>] [ts=<int>[,<int>]] [localTs=<int>[,<int>]] [resolve [status=<txnstatus>]] [ambiguousReplay] k=<key> v=<string> [raw] [cond=<string>]
+// del            [t=<name>] [ts=<int>[,<int>]] [localTs=<int>[,<int>]] [resolve [status=<txnstatus>]] [ambiguousReplay] k=<key>
+// del_range      [t=<name>] [ts=<int>[,<int>]] [localTs=<int>[,<int>]] [resolve [status=<txnstatus>]] [ambiguousReplay] k=<key> [end=<key>] [max=<max>] [returnKeys]
 // del_range_ts   [ts=<int>[,<int>]] [localTs=<int>[,<int>]] k=<key> end=<key> [idempotent] [noCoveredStats]
 // del_range_pred [ts=<int>[,<int>]] [localTs=<int>[,<int>]] k=<key> end=<key> [startTime=<int>,max=<int>,maxBytes=<int>,rangeThreshold=<int>]
-// increment      [t=<name>] [ts=<int>[,<int>]] [localTs=<int>[,<int>]] [resolve [status=<txnstatus>]] k=<key> [inc=<val>]
-// initput        [t=<name>] [ts=<int>[,<int>]] [resolve [status=<txnstatus>]] k=<key> v=<string> [raw] [failOnTombstones]
-// merge          [t=<name>] [ts=<int>[,<int>]] [resolve [status=<txnstatus>]] k=<key> v=<string> [raw]
-// put            [t=<name>] [ts=<int>[,<int>]] [localTs=<int>[,<int>]] [resolve [status=<txnstatus>]] k=<key> v=<string> [raw]
+// increment      [t=<name>] [ts=<int>[,<int>]] [localTs=<int>[,<int>]] [resolve [status=<txnstatus>]] [ambiguousReplay] k=<key> [inc=<val>]
+// initput        [t=<name>] [ts=<int>[,<int>]] [resolve [status=<txnstatus>]] [ambiguousReplay] k=<key> v=<string> [raw] [failOnTombstones]
+// put            [t=<name>] [ts=<int>[,<int>]] [localTs=<int>[,<int>]] [resolve [status=<txnstatus>]] [ambiguousReplay] k=<key> v=<string> [raw]
 // put_rangekey   ts=<int>[,<int>] [localTs=<int>[,<int>]] k=<key> end=<key>
 // get            [t=<name>] [ts=<int>[,<int>]]                         [resolve [status=<txnstatus>]] k=<key> [inconsistent] [skipLocked] [tombstones] [failOnMoreRecent] [localUncertaintyLimit=<int>[,<int>]] [globalUncertaintyLimit=<int>[,<int>]] [maxKeys=<int>] [targetBytes=<int>] [allowEmpty]
 // scan           [t=<name>] [ts=<int>[,<int>]]                         [resolve [status=<txnstatus>]] k=<key> [end=<key>] [inconsistent] [skipLocked] [tombstones] [reverse] [failOnMoreRecent] [localUncertaintyLimit=<int>[,<int>]] [globalUncertaintyLimit=<int>[,<int>]] [max=<max>] [targetbytes=<target>] [wholeRows[=<int>]] [allowEmpty]
@@ -1088,9 +1087,10 @@ func cmdCPut(e *evalCtx) error {
 
 	return e.withWriter("cput", func(rw storage.ReadWriter) error {
 		opts := storage.MVCCWriteOptions{
-			Txn:            txn,
-			LocalTimestamp: localTs,
-			Stats:          e.ms,
+			Txn:                            txn,
+			LocalTimestamp:                 localTs,
+			Stats:                          e.ms,
+			ReplayWriteTimestampProtection: e.getAmbiguousReplay(),
 		}
 		if err := storage.MVCCConditionalPut(e.ctx, rw, key, ts, val, expVal, behavior, opts); err != nil {
 			return err
@@ -1114,9 +1114,10 @@ func cmdInitPut(e *evalCtx) error {
 
 	return e.withWriter("initput", func(rw storage.ReadWriter) error {
 		opts := storage.MVCCWriteOptions{
-			Txn:            txn,
-			LocalTimestamp: localTs,
-			Stats:          e.ms,
+			Txn:                            txn,
+			LocalTimestamp:                 localTs,
+			Stats:                          e.ms,
+			ReplayWriteTimestampProtection: e.getAmbiguousReplay(),
 		}
 		if err := storage.MVCCInitPut(e.ctx, rw, key, ts, val, failOnTombstones, opts); err != nil {
 			return err
@@ -1136,9 +1137,10 @@ func cmdDelete(e *evalCtx) error {
 	resolve, resolveStatus := e.getResolve()
 	return e.withWriter("del", func(rw storage.ReadWriter) error {
 		opts := storage.MVCCWriteOptions{
-			Txn:            txn,
-			LocalTimestamp: localTs,
-			Stats:          e.ms,
+			Txn:                            txn,
+			LocalTimestamp:                 localTs,
+			Stats:                          e.ms,
+			ReplayWriteTimestampProtection: e.getAmbiguousReplay(),
 		}
 		foundKey, err := storage.MVCCDelete(e.ctx, rw, key, ts, opts)
 		if err == nil || errors.HasType(err, &kvpb.WriteTooOldError{}) {
@@ -1170,9 +1172,10 @@ func cmdDeleteRange(e *evalCtx) error {
 	resolve, resolveStatus := e.getResolve()
 	return e.withWriter("del_range", func(rw storage.ReadWriter) error {
 		opts := storage.MVCCWriteOptions{
-			Txn:            txn,
-			LocalTimestamp: localTs,
-			Stats:          e.ms,
+			Txn:                            txn,
+			LocalTimestamp:                 localTs,
+			Stats:                          e.ms,
+			ReplayWriteTimestampProtection: e.getAmbiguousReplay(),
 		}
 		deleted, resumeSpan, num, err := storage.MVCCDeleteRange(
 			e.ctx, rw, key, endKey, int64(max), ts, opts, returnKeys)
@@ -1329,9 +1332,10 @@ func cmdIncrement(e *evalCtx) error {
 
 	return e.withWriter("increment", func(rw storage.ReadWriter) error {
 		opts := storage.MVCCWriteOptions{
-			Txn:            txn,
-			LocalTimestamp: localTs,
-			Stats:          e.ms,
+			Txn:                            txn,
+			LocalTimestamp:                 localTs,
+			Stats:                          e.ms,
+			ReplayWriteTimestampProtection: e.getAmbiguousReplay(),
 		}
 		curVal, err := storage.MVCCIncrement(e.ctx, rw, key, ts, opts, inc)
 		if err != nil {
@@ -1370,9 +1374,10 @@ func cmdPut(e *evalCtx) error {
 
 	return e.withWriter("put", func(rw storage.ReadWriter) error {
 		opts := storage.MVCCWriteOptions{
-			Txn:            txn,
-			LocalTimestamp: localTs,
-			Stats:          e.ms,
+			Txn:                            txn,
+			LocalTimestamp:                 localTs,
+			Stats:                          e.ms,
+			ReplayWriteTimestampProtection: e.getAmbiguousReplay(),
 		}
 		if err := storage.MVCCPut(e.ctx, rw, key, ts, val, opts); err != nil {
 			return err
@@ -2206,6 +2211,10 @@ func (e *evalCtx) getResolve() (bool, roachpb.TransactionStatus) {
 		return false, roachpb.PENDING
 	}
 	return true, e.getTxnStatus()
+}
+
+func (e *evalCtx) getAmbiguousReplay() bool {
+	return e.hasArg("ambiguousReplay")
 }
 
 func (e *evalCtx) getTs(txn *roachpb.Transaction) hlc.Timestamp {

--- a/pkg/storage/testdata/mvcc_histories/ambiguous_writes
+++ b/pkg/storage/testdata/mvcc_histories/ambiguous_writes
@@ -1,0 +1,404 @@
+# Ambiguous replay protection is only valid on transactional writes.
+
+run error
+del   k=a ambiguousReplay
+----
+>> at end:
+<no data>
+error: (*withstack.withStack:) cannot enable replay protection without a transaction
+
+# Idempotent replays should normally be allowed, even if they move the timestamp.
+
+run stats ok
+with t=A k=a
+  txn_begin ts=11
+  # Lay down an intent.
+  put v=first
+----
+>> put v=first t=A k=a
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+61 live_count=+1 live_bytes=+75 intent_count=+1 intent_bytes=+22 separated_intent_count=+1 intent_age=+89
+>> at end:
+txn: "A" meta={id=00000000 key="a" pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=11.000000000,0 wto=false gul=0,0
+meta: "a"/0,0 -> txn={id=00000000 key="a" pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0} ts=11.000000000,0 del=false klen=12 vlen=10 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "a"/11.000000000,0 -> /BYTES/first
+stats: key_count=1 key_bytes=14 val_count=1 val_bytes=61 live_count=1 live_bytes=75 intent_count=1 intent_bytes=22 separated_intent_count=1 intent_age=89
+
+run stats ok
+with t=A k=a
+  # Perform an idempotent replay, but at a higher ts.
+  txn_advance ts=12
+  put v=first
+----
+>> put v=first t=A k=a
+stats: no change
+>> at end:
+txn: "A" meta={id=00000000 key="a" pri=0.00000000 epo=0 ts=12.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=11.000000000,0 wto=false gul=0,0
+meta: "a"/0,0 -> txn={id=00000000 key="a" pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0} ts=11.000000000,0 del=false klen=12 vlen=10 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "a"/11.000000000,0 -> /BYTES/first
+stats: key_count=1 key_bytes=14 val_count=1 val_bytes=61 live_count=1 live_bytes=75 intent_count=1 intent_bytes=22 separated_intent_count=1 intent_age=89
+
+run ok
+with t=A k=a
+  resolve_intent
+  txn_remove
+----
+>> at end:
+data: "a"/12.000000000,0 -> {localTs=11.000000000,0}/BYTES/first
+
+# Ambiguous replay protection should allow initial writes.
+
+run stats ok
+with t=B k=k
+  txn_begin ts=0,1
+  initput k=k ts=0,1 v=k1 ambiguousReplay
+----
+>> initput k=k ts=0,1 v=k1 ambiguousReplay t=B k=k
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+50 live_count=+1 live_bytes=+64 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+100
+>> at end:
+txn: "B" meta={id=00000000 key="k" pri=0.00000000 epo=0 ts=0,1 min=0,0 seq=0} lock=true stat=PENDING rts=0,1 wto=false gul=0,0
+data: "a"/12.000000000,0 -> {localTs=11.000000000,0}/BYTES/first
+meta: "k"/0,0 -> txn={id=00000000 key="k" pri=0.00000000 epo=0 ts=0,1 min=0,0 seq=0} ts=0,1 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "k"/0,1 -> /BYTES/k1
+stats: key_count=2 key_bytes=28 val_count=2 val_bytes=73 live_count=2 live_bytes=101 intent_count=1 intent_bytes=19 separated_intent_count=1 intent_age=100
+
+run ok
+with t=B k=k
+  resolve_intent
+  txn_remove
+----
+>> at end:
+data: "a"/12.000000000,0 -> {localTs=11.000000000,0}/BYTES/first
+data: "k"/0,1 -> /BYTES/k1
+
+# Ambiguous replay protection should not affect identically evaluating cputs.
+
+run stats ok
+with t=C k=k
+  txn_begin ts=0,2
+  cput v=k2 cond=k1
+----
+>> cput v=k2 cond=k1 t=C k=k
+stats: key_bytes=+12 val_count=+1 val_bytes=+50 live_bytes=+43 gc_bytes_age=+1900 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+100
+>> at end:
+txn: "C" meta={id=00000000 key="k" pri=0.00000000 epo=0 ts=0,2 min=0,0 seq=0} lock=true stat=PENDING rts=0,2 wto=false gul=0,0
+data: "a"/12.000000000,0 -> {localTs=11.000000000,0}/BYTES/first
+meta: "k"/0,0 -> txn={id=00000000 key="k" pri=0.00000000 epo=0 ts=0,2 min=0,0 seq=0} ts=0,2 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "k"/0,2 -> /BYTES/k2
+data: "k"/0,1 -> /BYTES/k1
+stats: key_count=2 key_bytes=40 val_count=3 val_bytes=80 live_count=2 live_bytes=101 gc_bytes_age=1900 intent_count=1 intent_bytes=19 separated_intent_count=1 intent_age=100
+
+run stats ok
+with t=C k=k
+  cput v=k2 cond=k1 ambiguousReplay
+----
+>> cput v=k2 cond=k1 ambiguousReplay t=C k=k
+stats: no change
+>> at end:
+data: "a"/12.000000000,0 -> {localTs=11.000000000,0}/BYTES/first
+meta: "k"/0,0 -> txn={id=00000000 key="k" pri=0.00000000 epo=0 ts=0,2 min=0,0 seq=0} ts=0,2 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "k"/0,2 -> /BYTES/k2
+data: "k"/0,1 -> /BYTES/k1
+stats: key_count=2 key_bytes=40 val_count=3 val_bytes=80 live_count=2 live_bytes=101 gc_bytes_age=1900 intent_count=1 intent_bytes=19 separated_intent_count=1 intent_age=100
+
+run ok
+with t=C k=k
+  resolve_intent
+  txn_remove
+----
+>> at end:
+data: "a"/12.000000000,0 -> {localTs=11.000000000,0}/BYTES/first
+data: "k"/0,2 -> /BYTES/k2
+data: "k"/0,1 -> /BYTES/k1
+
+# Ambiguous replay protection should prevent a replay from evaluating at a higher timestamp.
+
+run stats ok
+with t=D k=k
+  txn_begin ts=3,0
+  put v=k3
+----
+>> put v=k3 t=D k=k
+stats: key_bytes=+12 val_count=+1 val_bytes=+58 live_bytes=+51 gc_bytes_age=+1843 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+97
+>> at end:
+txn: "D" meta={id=00000000 key="k" pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=3.000000000,0 wto=false gul=0,0
+data: "a"/12.000000000,0 -> {localTs=11.000000000,0}/BYTES/first
+meta: "k"/0,0 -> txn={id=00000000 key="k" pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} ts=3.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "k"/3.000000000,0 -> /BYTES/k3
+data: "k"/0,2 -> /BYTES/k2
+data: "k"/0,1 -> /BYTES/k1
+stats: key_count=2 key_bytes=52 val_count=4 val_bytes=95 live_count=2 live_bytes=109 gc_bytes_age=3743 intent_count=1 intent_bytes=19 separated_intent_count=1 intent_age=97
+
+run stats error
+with t=D k=k
+  txn_advance ts=3,1
+  put v=k3 ambiguousReplay
+----
+>> put v=k3 ambiguousReplay t=D k=k
+stats: no change
+>> at end:
+txn: "D" meta={id=00000000 key="k" pri=0.00000000 epo=0 ts=3.000000000,1 min=0,0 seq=0} lock=true stat=PENDING rts=3.000000000,0 wto=false gul=0,0
+data: "a"/12.000000000,0 -> {localTs=11.000000000,0}/BYTES/first
+meta: "k"/0,0 -> txn={id=00000000 key="k" pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} ts=3.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "k"/3.000000000,0 -> /BYTES/k3
+data: "k"/0,2 -> /BYTES/k2
+data: "k"/0,1 -> /BYTES/k1
+stats: key_count=2 key_bytes=52 val_count=4 val_bytes=95 live_count=2 live_bytes=109 gc_bytes_age=3743 intent_count=1 intent_bytes=19 separated_intent_count=1 intent_age=97
+error: (*withstack.withStack:) transaction 00000000-0000-0000-0000-000000000004 with sequence 0 prevented from changing write timestamp from 3.000000000,0 to 3.000000000,1 due to ambiguous replay protection
+
+run ok
+with t=D k=k
+  # Commit at the original timestamp (i.e. if committed by a recovery operation).
+  txn_advance ts=3,0
+  resolve_intent
+  txn_remove
+----
+>> at end:
+data: "a"/12.000000000,0 -> {localTs=11.000000000,0}/BYTES/first
+data: "k"/3.000000000,0 -> /BYTES/k3
+data: "k"/0,2 -> /BYTES/k2
+data: "k"/0,1 -> /BYTES/k1
+
+# Ambiguous replay protection still results in WriteTooOld errors after intent cleanup.
+
+run stats ok
+with t=E k=k
+  txn_begin ts=4,0
+  del resolve
+----
+>> del resolve t=E k=k
+del: "k": found key true
+stats: key_bytes=+12 val_count=+1 live_count=-1 live_bytes=-21 gc_bytes_age=+3168
+>> at end:
+txn: "E" meta={id=00000000 key="k" pri=0.00000000 epo=0 ts=4.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=4.000000000,0 wto=false gul=0,0
+data: "a"/12.000000000,0 -> {localTs=11.000000000,0}/BYTES/first
+data: "k"/4.000000000,0 -> /<empty>
+data: "k"/3.000000000,0 -> /BYTES/k3
+data: "k"/0,2 -> /BYTES/k2
+data: "k"/0,1 -> /BYTES/k1
+stats: key_count=2 key_bytes=64 val_count=5 val_bytes=44 live_count=1 live_bytes=37 gc_bytes_age=6911
+
+run stats error
+with t=E k=k
+  del ambiguousReplay
+----
+>> del ambiguousReplay t=E k=k
+del: "k": found key false
+stats: key_bytes=+12 val_count=+1 val_bytes=+53 gc_bytes_age=+6240 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+96
+>> at end:
+data: "a"/12.000000000,0 -> {localTs=11.000000000,0}/BYTES/first
+meta: "k"/0,0 -> txn={id=00000000 key="k" pri=0.00000000 epo=0 ts=4.000000000,1 min=0,0 seq=0} ts=4.000000000,1 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "k"/4.000000000,1 -> /<empty>
+data: "k"/4.000000000,0 -> /<empty>
+data: "k"/3.000000000,0 -> /BYTES/k3
+data: "k"/0,2 -> /BYTES/k2
+data: "k"/0,1 -> /BYTES/k1
+stats: key_count=2 key_bytes=76 val_count=6 val_bytes=97 live_count=1 live_bytes=37 gc_bytes_age=13151 intent_count=1 intent_bytes=12 separated_intent_count=1 intent_age=96
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k" at timestamp 4.000000000,0 too old; wrote at 4.000000000,1
+
+
+run ok
+with t=E k=k
+  resolve_intent status=ABORTED
+  txn_remove
+----
+>> at end:
+data: "a"/12.000000000,0 -> {localTs=11.000000000,0}/BYTES/first
+data: "k"/4.000000000,0 -> /<empty>
+data: "k"/3.000000000,0 -> /BYTES/k3
+data: "k"/0,2 -> /BYTES/k2
+data: "k"/0,1 -> /BYTES/k1
+
+# Ambiguous replay protects against timestamp change on point delete.
+
+run stats ok
+with t=F k=k
+  txn_begin ts=5,0
+  # Write an initial value at the first sequence number.
+  put v=k5
+----
+>> put v=k5 t=F k=k
+stats: key_bytes=+12 val_count=+1 val_bytes=+58 live_count=+1 live_bytes=+72 gc_bytes_age=-192 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+95
+>> at end:
+txn: "F" meta={id=00000000 key="k" pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=5.000000000,0 wto=false gul=0,0
+data: "a"/12.000000000,0 -> {localTs=11.000000000,0}/BYTES/first
+meta: "k"/0,0 -> txn={id=00000000 key="k" pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} ts=5.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "k"/5.000000000,0 -> /BYTES/k5
+data: "k"/4.000000000,0 -> /<empty>
+data: "k"/3.000000000,0 -> /BYTES/k3
+data: "k"/0,2 -> /BYTES/k2
+data: "k"/0,1 -> /BYTES/k1
+stats: key_count=2 key_bytes=76 val_count=6 val_bytes=102 live_count=2 live_bytes=109 gc_bytes_age=6719 intent_count=1 intent_bytes=19 separated_intent_count=1 intent_age=95
+
+run stats ok
+with t=F k=k
+  txn_step
+  # Let's assume we had an RPC error prior to the first successful operation.
+  del ambiguousReplay
+----
+>> del ambiguousReplay t=F k=k
+del: "k": found key true
+stats: val_bytes=+6 live_count=-1 live_bytes=-72 gc_bytes_age=+7410 intent_bytes=-7
+>> at end:
+txn: "F" meta={id=00000000 key="k" pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=5.000000000,0 wto=false gul=0,0
+data: "a"/12.000000000,0 -> {localTs=11.000000000,0}/BYTES/first
+meta: "k"/0,0 -> txn={id=00000000 key="k" pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=1} ts=5.000000000,0 del=true klen=12 vlen=0 ih={{0 /BYTES/k5}} mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "k"/5.000000000,0 -> /<empty>
+data: "k"/4.000000000,0 -> /<empty>
+data: "k"/3.000000000,0 -> /BYTES/k3
+data: "k"/0,2 -> /BYTES/k2
+data: "k"/0,1 -> /BYTES/k1
+stats: key_count=2 key_bytes=76 val_count=6 val_bytes=108 live_count=1 live_bytes=37 gc_bytes_age=14129 intent_count=1 intent_bytes=12 separated_intent_count=1 intent_age=95
+
+run stats ok
+with t=F k=k
+  txn_step n=-1
+  # A replay of a lower sequence number with the same timestamp should be allowed.
+  put v=k5 ambiguousReplay
+----
+>> put v=k5 ambiguousReplay t=F k=k
+stats: no change
+>> at end:
+txn: "F" meta={id=00000000 key="k" pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=5.000000000,0 wto=false gul=0,0
+data: "a"/12.000000000,0 -> {localTs=11.000000000,0}/BYTES/first
+meta: "k"/0,0 -> txn={id=00000000 key="k" pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=1} ts=5.000000000,0 del=true klen=12 vlen=0 ih={{0 /BYTES/k5}} mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "k"/5.000000000,0 -> /<empty>
+data: "k"/4.000000000,0 -> /<empty>
+data: "k"/3.000000000,0 -> /BYTES/k3
+data: "k"/0,2 -> /BYTES/k2
+data: "k"/0,1 -> /BYTES/k1
+stats: key_count=2 key_bytes=76 val_count=6 val_bytes=108 live_count=1 live_bytes=37 gc_bytes_age=14129 intent_count=1 intent_bytes=12 separated_intent_count=1 intent_age=95
+
+run stats error
+with t=F k=k
+  txn_step
+  txn_advance ts=5,1
+  del ambiguousReplay
+----
+>> del ambiguousReplay t=F k=k
+stats: no change
+>> at end:
+txn: "F" meta={id=00000000 key="k" pri=0.00000000 epo=0 ts=5.000000000,1 min=0,0 seq=1} lock=true stat=PENDING rts=5.000000000,0 wto=false gul=0,0
+data: "a"/12.000000000,0 -> {localTs=11.000000000,0}/BYTES/first
+meta: "k"/0,0 -> txn={id=00000000 key="k" pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=1} ts=5.000000000,0 del=true klen=12 vlen=0 ih={{0 /BYTES/k5}} mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "k"/5.000000000,0 -> /<empty>
+data: "k"/4.000000000,0 -> /<empty>
+data: "k"/3.000000000,0 -> /BYTES/k3
+data: "k"/0,2 -> /BYTES/k2
+data: "k"/0,1 -> /BYTES/k1
+stats: key_count=2 key_bytes=76 val_count=6 val_bytes=108 live_count=1 live_bytes=37 gc_bytes_age=14129 intent_count=1 intent_bytes=12 separated_intent_count=1 intent_age=95
+error: (*withstack.withStack:) transaction 00000000-0000-0000-0000-000000000006 with sequence 1 prevented from changing write timestamp from 5.000000000,0 to 5.000000000,1 due to ambiguous replay protection
+
+run ok
+with t=F k=k
+  resolve_intent status=ABORTED
+  txn_remove
+----
+>> at end:
+data: "a"/12.000000000,0 -> {localTs=11.000000000,0}/BYTES/first
+data: "k"/4.000000000,0 -> /<empty>
+data: "k"/3.000000000,0 -> /BYTES/k3
+data: "k"/0,2 -> /BYTES/k2
+data: "k"/0,1 -> /BYTES/k1
+
+# Ambiguous replay protection prevents timestamp change on transactional DeleteRange.
+
+run ok
+put k=k v=k6 ts=6,0
+----
+>> at end:
+data: "a"/12.000000000,0 -> {localTs=11.000000000,0}/BYTES/first
+data: "k"/6.000000000,0 -> /BYTES/k6
+data: "k"/4.000000000,0 -> /<empty>
+data: "k"/3.000000000,0 -> /BYTES/k3
+data: "k"/0,2 -> /BYTES/k2
+data: "k"/0,1 -> /BYTES/k1
+
+run stats ok
+with t=G k=k
+  txn_begin ts=12,1
+  del_range k=a end=z returnKeys
+----
+>> del_range k=a end=z returnKeys t=G k=k
+del_range: "a"-"z" -> deleted 2 key(s)
+del_range: returned "a"
+del_range: returned "k"
+stats: key_bytes=+24 val_count=+2 val_bytes=+106 live_count=-2 live_bytes=-58 gc_bytes_age=+16544 intent_count=+2 intent_bytes=+24 separated_intent_count=+2 intent_age=+176
+>> at end:
+txn: "G" meta={id=00000000 key="k" pri=0.00000000 epo=0 ts=12.000000000,1 min=0,0 seq=0} lock=true stat=PENDING rts=12.000000000,1 wto=false gul=0,0
+meta: "a"/0,0 -> txn={id=00000000 key="k" pri=0.00000000 epo=0 ts=12.000000000,1 min=0,0 seq=0} ts=12.000000000,1 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "a"/12.000000000,1 -> /<empty>
+data: "a"/12.000000000,0 -> {localTs=11.000000000,0}/BYTES/first
+meta: "k"/0,0 -> txn={id=00000000 key="k" pri=0.00000000 epo=0 ts=12.000000000,1 min=0,0 seq=0} ts=12.000000000,1 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "k"/12.000000000,1 -> /<empty>
+data: "k"/6.000000000,0 -> /BYTES/k6
+data: "k"/4.000000000,0 -> /<empty>
+data: "k"/3.000000000,0 -> /BYTES/k3
+data: "k"/0,2 -> /BYTES/k2
+data: "k"/0,1 -> /BYTES/k1
+stats: key_count=2 key_bytes=100 val_count=8 val_bytes=157 gc_bytes_age=23263 intent_count=2 intent_bytes=24 separated_intent_count=2 intent_age=176
+
+run stats ok
+with t=G k=k
+  # First attempt a standard idempotent replay at a higher timestamp.
+  txn_advance ts=12,2
+  del_range k=a end=z returnKeys
+----
+>> del_range k=a end=z returnKeys t=G k=k
+del_range: "a"-"z" -> deleted 2 key(s)
+del_range: returned "a"
+del_range: returned "k"
+stats: no change
+>> at end:
+txn: "G" meta={id=00000000 key="k" pri=0.00000000 epo=0 ts=12.000000000,2 min=0,0 seq=0} lock=true stat=PENDING rts=12.000000000,1 wto=false gul=0,0
+meta: "a"/0,0 -> txn={id=00000000 key="k" pri=0.00000000 epo=0 ts=12.000000000,1 min=0,0 seq=0} ts=12.000000000,1 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "a"/12.000000000,1 -> /<empty>
+data: "a"/12.000000000,0 -> {localTs=11.000000000,0}/BYTES/first
+meta: "k"/0,0 -> txn={id=00000000 key="k" pri=0.00000000 epo=0 ts=12.000000000,1 min=0,0 seq=0} ts=12.000000000,1 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "k"/12.000000000,1 -> /<empty>
+data: "k"/6.000000000,0 -> /BYTES/k6
+data: "k"/4.000000000,0 -> /<empty>
+data: "k"/3.000000000,0 -> /BYTES/k3
+data: "k"/0,2 -> /BYTES/k2
+data: "k"/0,1 -> /BYTES/k1
+stats: key_count=2 key_bytes=100 val_count=8 val_bytes=157 gc_bytes_age=23263 intent_count=2 intent_bytes=24 separated_intent_count=2 intent_age=176
+
+run stats error
+with t=G k=k
+  txn_advance ts=12,3
+  # However with ambiguous replay protection, a timestamp change should error.
+  del_range k=a end=z ambiguousReplay returnKeys
+----
+>> del_range k=a end=z ambiguousReplay returnKeys t=G k=k
+stats: no change
+>> at end:
+txn: "G" meta={id=00000000 key="k" pri=0.00000000 epo=0 ts=12.000000000,3 min=0,0 seq=0} lock=true stat=PENDING rts=12.000000000,1 wto=false gul=0,0
+meta: "a"/0,0 -> txn={id=00000000 key="k" pri=0.00000000 epo=0 ts=12.000000000,1 min=0,0 seq=0} ts=12.000000000,1 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "a"/12.000000000,1 -> /<empty>
+data: "a"/12.000000000,0 -> {localTs=11.000000000,0}/BYTES/first
+meta: "k"/0,0 -> txn={id=00000000 key="k" pri=0.00000000 epo=0 ts=12.000000000,1 min=0,0 seq=0} ts=12.000000000,1 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "k"/12.000000000,1 -> /<empty>
+data: "k"/6.000000000,0 -> /BYTES/k6
+data: "k"/4.000000000,0 -> /<empty>
+data: "k"/3.000000000,0 -> /BYTES/k3
+data: "k"/0,2 -> /BYTES/k2
+data: "k"/0,1 -> /BYTES/k1
+stats: key_count=2 key_bytes=100 val_count=8 val_bytes=157 gc_bytes_age=23263 intent_count=2 intent_bytes=24 separated_intent_count=2 intent_age=176
+error: (*withstack.withStack:) transaction 00000000-0000-0000-0000-000000000007 with sequence 0 prevented from changing write timestamp from 12.000000000,1 to 12.000000000,3 due to ambiguous replay protection
+
+run ok
+with t=G
+  # Commit at the last "correct" timestamp.
+  txn_advance ts=12,2
+  resolve_intent k=a
+  resolve_intent k=k
+  txn_remove
+----
+>> at end:
+data: "a"/12.000000000,2 -> {localTs=12.000000000,1}/<empty>
+data: "a"/12.000000000,0 -> {localTs=11.000000000,0}/BYTES/first
+data: "k"/12.000000000,2 -> {localTs=12.000000000,1}/<empty>
+data: "k"/6.000000000,0 -> /BYTES/k6
+data: "k"/4.000000000,0 -> /<empty>
+data: "k"/3.000000000,0 -> /BYTES/k3
+data: "k"/0,2 -> /BYTES/k2
+data: "k"/0,1 -> /BYTES/k1


### PR DESCRIPTION
Backport 1/1 commits from #107680.

/cc @cockroachdb/release

----

This change introduces `MVCCWriteOptions`, a structure for bundling parameters for `MVCCPut`, `MVCCDelete`, and their many variants, and refactors usages of these functions across the code base in order to move the existing function arguments into this structure. In addition to allowing the code to eliminate specifying default values in many callers, this enables the ability to pass new flags to write operations such as the replay protection needed to address #103817.

Part of: #103817

Release note: None

----

Backport 1/1 commits from #111090.

The `TestTransactionUnexpectedlyCommitted/recovery_after_transfer_lease` test, introduced to test https://github.com/cockroachdb/cockroach/pull/107658, has been flaky (particularly under deadlock builds) due to a race condition between a retry of a write and intent resolution. While both orderings in this test result in a correct `AmbiguousResultError` for the client, when intent resolution wins the race, the retried write will attempt to push away the current lockholder; since it is illegal for a committed transaction to perform a
push, this results in a different secondary error attached to the `AmbiguousResultError`. This change ensures a predefined ordering of these operations so that the secondary error is consistent across runs of the test.

Fixes: #110187

Release note: None

----

Depends on #111870, #111871

Release justification: Backporting fix for outstanding bug described in #103817.