### PR TITLE
row: improve memory accounting and memory usage of txnKVStreamer

### DIFF
--- a/pkg/sql/row/fetcher.go
+++ b/pkg/sql/row/fetcher.go
@@ -109,7 +109,18 @@ type KVBatchFetcherResponse struct {
 
 // KVBatchFetcher abstracts the logic of fetching KVs in batches.
 type KVBatchFetcher interface {
-	// SetupNextFetch prepares the fetch of the next set of spans.
+	// SetupNextFetch prepares the fetch of the next set of spans. Can be called
+	// multiple times.
+	//
+	// The fetcher takes ownership of the spans slice, will perform the memory
+	// accounting for it, and might modify it. The caller is only allowed to
+	// reuse the spans slice after all rows have been fetched (i.e. NextBatch()
+	// returned KVBatchFetcherResponse.MoreKVs=false) or the fetcher has been
+	// closed.
+	//
+	// The fetcher can also modify the spanIDs slice but will **not** perform
+	// memory accounting for it. If spanIDs is non-nil, then it must be of the
+	// same length as spans.
 	//
 	// spansCanOverlap indicates whether spans might be unordered and
 	// overlapping. If true, then spanIDs must be non-nil.

--- a/pkg/sql/row/kv_batch_fetcher.go
+++ b/pkg/sql/row/kv_batch_fetcher.go
@@ -529,6 +529,12 @@ func (f *txnKVFetcher) SetupNextFetch(
 
 // fetch retrieves spans from the kv layer.
 func (f *txnKVFetcher) fetch(ctx context.Context) error {
+	// Note that spansToRequests below might modify spans, so we need to log the
+	// spans before that.
+	if log.ExpensiveLogEnabled(ctx, 2) {
+		log.VEventf(ctx, 2, "Scan %s", f.spans)
+	}
+
 	ba := &kvpb.BatchRequest{}
 	ba.Header.WaitPolicy = f.lockWaitPolicy
 	ba.Header.LockTimeout = f.lockTimeout
@@ -551,10 +557,6 @@ func (f *txnKVFetcher) fetch(ctx context.Context) error {
 	ba.Requests = spansToRequests(
 		f.spans.Spans, f.scanFormat, f.reverse, f.lockStrength, f.lockDurability, f.reqsScratch,
 	)
-
-	if log.ExpensiveLogEnabled(ctx, 2) {
-		log.VEventf(ctx, 2, "Scan %s", f.spans)
-	}
 
 	monitoring := f.acc != nil
 
@@ -891,6 +893,10 @@ const requestUnionOverhead = int64(unsafe.Sizeof(kvpb.RequestUnion{}))
 //
 // The provided reqsScratch is reused if it has enough capacity for all spans,
 // if not, a new slice is allocated.
+//
+// NOTE: any span that results in a Scan or a ReverseScan request is nil-ed out.
+// This is because both callers of this method no longer need the original span
+// unless it resulted in a Get request.
 func spansToRequests(
 	spans roachpb.Spans,
 	scanFormat kvpb.ScanFormat,
@@ -939,6 +945,7 @@ func spansToRequests(
 			}
 			curScan := i - curGet
 			scans[curScan].req.SetSpan(spans[i])
+			spans[i] = roachpb.Span{}
 			scans[curScan].req.ScanFormat = scanFormat
 			scans[curScan].req.KeyLockingStrength = lockStrength
 			scans[curScan].req.KeyLockingDurability = lockDurability
@@ -964,6 +971,7 @@ func spansToRequests(
 			}
 			curScan := i - curGet
 			scans[curScan].req.SetSpan(spans[i])
+			spans[i] = roachpb.Span{}
 			scans[curScan].req.ScanFormat = scanFormat
 			scans[curScan].req.KeyLockingStrength = lockStrength
 			scans[curScan].req.KeyLockingDurability = lockDurability

--- a/pkg/sql/row/kv_batch_streamer.go
+++ b/pkg/sql/row/kv_batch_streamer.go
@@ -31,6 +31,10 @@ type txnKVStreamer struct {
 	lockStrength   lock.Strength
 	lockDurability lock.Durability
 
+	// spans contains the last set of spans provided in SetupNextFetch. The
+	// original span is only needed when handling Get responses, so each span is
+	// nil-ed out when it resulted in a Scan request (i.e. it had both Key and
+	// EndKey set).
 	spans       roachpb.Spans
 	spanIDs     []int
 	reqsScratch []kvpb.RequestUnion
@@ -106,12 +110,20 @@ func (f *txnKVStreamer) SetupNextFetch(
 	if err := f.streamer.Enqueue(ctx, reqs); err != nil {
 		return err
 	}
+	// For the spans slice we only need to account for the overhead of
+	// roachpb.Span objects. This is because spans that correspond to
+	// - Scan requests just got nil-ed out in `spansToRequests`,
+	// - Get requests have each key being shared directly (i.e. memory aliased)
+	//   with the Get requests, and the streamer will account for the latter.
+	//   Thus, in order to not double-count memory usage, we do no accounting
+	//   here.
+	spansMemUsage := roachpb.SpanOverhead * int64(cap(spans))
 	f.spans = spans
 	f.spanIDs = spanIDs
 	// Keep the reference to the requests slice in order to reuse in the future.
 	f.reqsScratch = reqs
 	reqsScratchMemUsage := requestUnionOverhead * int64(cap(f.reqsScratch))
-	return f.acc.ResizeTo(ctx, reqsScratchMemUsage)
+	return f.acc.ResizeTo(ctx, spansMemUsage+reqsScratchMemUsage)
 }
 
 func (f *txnKVStreamer) getSpanID(resultPosition int) int {
@@ -217,6 +229,7 @@ func (f *txnKVStreamer) reset(ctx context.Context) {
 func (f *txnKVStreamer) Close(ctx context.Context) {
 	f.reset(ctx)
 	f.streamer.Close(ctx)
+	f.acc.Clear(ctx)
 	// Preserve observability-related fields.
 	*f = txnKVStreamer{kvBatchFetcherHelper: f.kvBatchFetcherHelper}
 }


### PR DESCRIPTION
This commit improves how the `txnKVStreamer` handles the spans slice and
adds some missing memory accounting around that.

Both the `txnKVStreamer` and the `txnKVFetcher` need the spans in two
ways:
- in order to construct requests to be `Enqueue`d into the streamer
or put into the BatchRequest
- when handling Get response, in order to obtain the Key of the Get.

This setup allows us to derive the following: once a span results in
a Scan request, we no longer need it at all, so this commit makes it so
that in `spansToRequests` we nil out each span that resulted in a Scan
or a ReverseScan request. This should allow for faster GC of the keys
improving our memory usage.

This new behavior also makes it a lot easier to add missing memory
accounting for the spans slice in the `txnKVStreamer` (which it is
responsible for according to the contract of `SetupNextFetch`). For
Get requests we have memory aliasing in place (i.e. both the original
span and the Get request internally point to the same `[]byte` that
contains the key), and the streamer already accounts for the Get.Key
against its own budget; thus, we don't need to account for that. For
Scan requests we just nil-ed them out. This leaves us only with having
to account for the overhead of the spans slice itself.

(Note that if we didn't nil out the spans that resulted in Scan
requests, the story would be more difficult because Scan requests can be
split at range boundaries which would break the memory aliasing from the
original spans.)

Additionally, this commit adjusts a few comments to clarify the
contract and clears the memory account of `txnKVStreamer` in `Close`.

Epic: None

Release note: None