### PR TITLE
sql: clean up `sql/sem/tree/expr.go`

### DIFF
--- a/pkg/sql/sem/tree/expr.go
+++ b/pkg/sql/sem/tree/expr.go
@@ -800,19 +800,11 @@ func NewPlaceholder(name string) (*Placeholder, error) {
 
 // Format implements the NodeFormatter interface.
 func (node *Placeholder) Format(ctx *FmtCtx) {
-	if ctx.HasFlags(FmtHideConstants) {
-		if ctx.placeholderFormat != nil {
-			ctx.placeholderFormat(ctx, node)
-			return
-		}
-		ctx.Printf("$%d", node.Idx+1)
-	} else {
-		if ctx.placeholderFormat != nil {
-			ctx.placeholderFormat(ctx, node)
-			return
-		}
-		ctx.Printf("$%d", node.Idx+1)
+	if ctx.placeholderFormat != nil {
+		ctx.placeholderFormat(ctx, node)
+		return
 	}
+	ctx.Printf("$%d", node.Idx+1)
 }
 
 // ResolvedType implements the TypedExpr interface.


### PR DESCRIPTION
Closes #111779  by replacing the conditional with just the content of one of its branches.