### PR TITLE
sql: don't parallelize FK and unique checks containing locking

### DIFF
--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -2119,10 +2119,12 @@ func (dsp *DistSQLPlanner) PlanAndRunCascadesAndChecks(
 		return false
 	}
 
-	// We'll run the checks in parallel if the parallelization is enabled, we
-	// have multiple checks to run, and we're likely to have quota to do so.
+	// We'll run the checks in parallel if the parallelization is enabled, we have
+	// multiple checks to run, none of the checks have non-default locking, and
+	// we're likely to have quota to do so.
 	runParallelChecks := parallelizeChecks.Get(&dsp.st.SV) &&
 		len(plan.checkPlans) > 1 &&
+		!planner.curPlan.flags.IsSet(planFlagCheckContainsNonDefaultLocking) &&
 		dsp.parallelChecksSem.ApproximateQuota() > 0
 	if runParallelChecks {
 		// At the moment, we rely on not using the newer DistSQL spec factory to

--- a/pkg/sql/logictest/testdata/logic_test/fk_read_committed
+++ b/pkg/sql/logictest/testdata/logic_test/fk_read_committed
@@ -32,3 +32,40 @@ DELETE FROM cookies WHERE c = 1
 
 statement ok
 DELETE FROM jars WHERE j = 2
+
+# Test that we do not use parallel FK checks under RC (see #111888).
+subtest parallelFK
+
+statement ok
+CREATE TABLE a (a PRIMARY KEY) AS SELECT 1
+
+statement ok
+CREATE TABLE b (b PRIMARY KEY) AS SELECT 1
+
+statement ok
+CREATE TABLE c (c PRIMARY KEY) AS SELECT 1
+
+statement ok
+CREATE TABLE d (d PRIMARY KEY) AS SELECT 1
+
+statement ok
+CREATE TABLE e (e PRIMARY KEY) AS SELECT 1
+
+statement ok
+CREATE TABLE f (
+  a INT REFERENCES a (a),
+  b INT REFERENCES b (b),
+  c INT REFERENCES c (c),
+  d INT REFERENCES d (d),
+  e INT REFERENCES e (e),
+  f INT PRIMARY KEY
+)
+
+statement ok
+SET enable_insert_fast_path = off
+
+statement ok
+INSERT INTO f VALUES (1, 1, 1, 1, 1, 1)
+
+statement ok
+RESET enable_insert_fast_path

--- a/pkg/sql/opt/exec/execbuilder/builder.go
+++ b/pkg/sql/opt/exec/execbuilder/builder.go
@@ -145,6 +145,10 @@ type Builder struct {
 	// plan uses non-default key locking strength.
 	ContainsNonDefaultKeyLocking bool
 
+	// CheckContainsNonDefaultKeyLocking is set to true if at least one node in at
+	// least one check query plan uses non-default key locking strength.
+	CheckContainsNonDefaultKeyLocking bool
+
 	// MaxFullScanRows is the maximum number of rows scanned by a full scan, as
 	// estimated by the optimizer.
 	MaxFullScanRows float64

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -625,6 +625,10 @@ const (
 	// planFlagContainsNonDefaultLocking is set if the plan has a node with
 	// non-default key locking strength.
 	planFlagContainsNonDefaultLocking
+
+	// planFlagCheckContainsNonDefaultLocking is set if at least one check plan
+	// has a node with non-default key locking strength.
+	planFlagCheckContainsNonDefaultLocking
 )
 
 func (pf planFlags) IsSet(flag planFlags) bool {

--- a/pkg/sql/plan_opt.go
+++ b/pkg/sql/plan_opt.go
@@ -719,6 +719,9 @@ func (opc *optPlanningCtx) runExecBuilder(
 	if bld.ContainsNonDefaultKeyLocking {
 		planTop.flags.Set(planFlagContainsNonDefaultLocking)
 	}
+	if bld.CheckContainsNonDefaultKeyLocking {
+		planTop.flags.Set(planFlagCheckContainsNonDefaultLocking)
+	}
 	planTop.mem = mem
 	planTop.catalog = opc.catalog
 	return nil


### PR DESCRIPTION
Under read committed isolation, or when using a combination of `enable_implicit_fk_locking_for_serializable` and
`enable_shared_locking_for_serializable`, FK checks and unique checks acquire shared locks on the rows they check. These locks are not compatible with the LeafTxn used when parallelizing check queries. This commit disables parallelization of check queries containing locking.

Fixes: #111888

Release note: None