### PR TITLE
release-23.1: ui: do not show current time as a fall back for empty timestamps on Jobs pages

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/jobs/jobDetailsPage/jobDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/jobs/jobDetailsPage/jobDetails.tsx
@@ -131,7 +131,7 @@ export class JobDetails extends React.Component<JobDetailsProps> {
                 label="Creation Time"
                 value={
                   <Timestamp
-                    time={TimestampToMoment(job.created)}
+                    time={TimestampToMoment(job.created, null)}
                     format={DATE_WITH_SECONDS_AND_MILLISECONDS_FORMAT_24_TZ}
                   />
                 }
@@ -141,7 +141,7 @@ export class JobDetails extends React.Component<JobDetailsProps> {
                   label="Last Modified Time"
                   value={
                     <Timestamp
-                      time={TimestampToMoment(job.modified)}
+                      time={TimestampToMoment(job.modified, null)}
                       format={DATE_WITH_SECONDS_AND_MILLISECONDS_FORMAT_24_TZ}
                     />
                   }
@@ -152,7 +152,7 @@ export class JobDetails extends React.Component<JobDetailsProps> {
                   label="Completed Time"
                   value={
                     <Timestamp
-                      time={TimestampToMoment(job.finished)}
+                      time={TimestampToMoment(job.finished, null)}
                       format={DATE_WITH_SECONDS_AND_MILLISECONDS_FORMAT_24_TZ}
                     />
                   }
@@ -162,7 +162,7 @@ export class JobDetails extends React.Component<JobDetailsProps> {
                 label="Last Execution Time"
                 value={
                   <Timestamp
-                    time={TimestampToMoment(job.last_run)}
+                    time={TimestampToMoment(job.last_run, null)}
                     format={DATE_WITH_SECONDS_AND_MILLISECONDS_FORMAT_24_TZ}
                   />
                 }

--- a/pkg/ui/workspaces/cluster-ui/src/jobs/jobsPage/jobsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/jobs/jobsPage/jobsTable.tsx
@@ -172,7 +172,7 @@ export function makeJobsColumns(): ColumnDescriptor<Job>[] {
       ),
       cell: job => (
         <Timestamp
-          time={TimestampToMoment(job?.created)}
+          time={TimestampToMoment(job?.created, null)}
           format={DATE_WITH_SECONDS_AND_MILLISECONDS_FORMAT}
         />
       ),
@@ -194,7 +194,7 @@ export function makeJobsColumns(): ColumnDescriptor<Job>[] {
       ),
       cell: job => (
         <Timestamp
-          time={TimestampToMoment(job?.modified)}
+          time={TimestampToMoment(job?.modified, null)}
           format={DATE_WITH_SECONDS_AND_MILLISECONDS_FORMAT}
         />
       ),
@@ -220,7 +220,7 @@ export function makeJobsColumns(): ColumnDescriptor<Job>[] {
       ),
       cell: job => (
         <Timestamp
-          time={TimestampToMoment(job?.finished)}
+          time={TimestampToMoment(job?.finished, null)}
           format={DATE_WITH_SECONDS_AND_MILLISECONDS_FORMAT}
         />
       ),
@@ -242,7 +242,7 @@ export function makeJobsColumns(): ColumnDescriptor<Job>[] {
       ),
       cell: job => (
         <Timestamp
-          time={TimestampToMoment(job?.last_run)}
+          time={TimestampToMoment(job?.last_run, null)}
           format={DATE_WITH_SECONDS_AND_MILLISECONDS_FORMAT}
         />
       ),

--- a/pkg/ui/workspaces/cluster-ui/src/jobs/util/duration.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/jobs/util/duration.tsx
@@ -17,7 +17,7 @@ import { JOB_STATUS_SUCCEEDED, isRunning } from "./jobOptions";
 type Job = cockroach.server.serverpb.IJobResponse;
 
 export const formatDuration = (d: moment.Duration): string =>
-  [Math.floor(d.asHours()).toFixed(0), d.minutes(), d.seconds()]
+  [Number(Math.floor(d.asHours()).toFixed(0)), d.minutes(), d.seconds()]
     .map(c => (c < 10 ? ("0" + c).slice(-2) : c))
     .join(":");
 
@@ -36,17 +36,21 @@ export class Duration extends React.PureComponent<{
 
     if (isRunning(job.status)) {
       const fractionCompleted = job.fraction_completed;
-      if (fractionCompleted > 0) {
-        const duration = modifiedAt.diff(startedAt);
-        const remaining = duration / fractionCompleted - duration;
-        return (
-          <span className={className}>
-            {formatDuration(moment.duration(remaining)) + " remaining"}
-          </span>
-        );
+      if (!startedAt || !modifiedAt || fractionCompleted === 0) {
+        return null;
       }
-      return null;
-    } else if (job.status == JOB_STATUS_SUCCEEDED) {
+      const duration = modifiedAt.diff(startedAt);
+      const remaining = duration / fractionCompleted - duration;
+      return (
+        <span className={className}>
+          {formatDuration(moment.duration(remaining)) + " remaining"}
+        </span>
+      );
+    } else if (
+      job.status == JOB_STATUS_SUCCEEDED &&
+      !!startedAt &&
+      !!finishedAt
+    ) {
       return (
         <span className={className}>
           {"Duration: " +


### PR DESCRIPTION
Backport 1/1 commits from #110366.

/cc @cockroachdb/release

---

Previously, timestamps for running jobs showed
current time even if job is not finished because
`TimestampToMoment` function used current time as
a default value for Nulls.
With this change it is explicitly set to Null to
make sure that Job's time is not misinterpreted.

Resolves: https://github.com/cockroachdb/cockroach/issues/109204

Release note (ui change): Correctly display timestamps 
for creation, last modified, and completed time on Jobs table.

Release justification: low risk, high benefit changes to existing functionality

<img width="1587" alt="Screenshot 2023-09-11 at 22 10 13" src="https://github.com/cockroachdb/cockroach/assets/3106437/ec6d0b81-c728-4914-ad27-9bd48f4e24fe">

