### PR TITLE
types: give REFCURSOR its own type family

### DIFF
--- a/pkg/ccl/changefeedccl/avro.go
+++ b/pkg/ccl/changefeedccl/avro.go
@@ -338,6 +338,16 @@ func typeToAvroSchema(typ *types.T) (*avroSchemaField, error) {
 				return tree.ParseDPGLSN(x.(string))
 			},
 		)
+	case types.RefCursorFamily:
+		setNullable(
+			avroSchemaString,
+			func(d tree.Datum, _ interface{}) (interface{}, error) {
+				return string(tree.MustBeDString(d)), nil
+			},
+			func(x interface{}) (tree.Datum, error) {
+				return tree.NewDRefCursor(x.(string)), nil
+			},
+		)
 	case types.Box2DFamily:
 		setNullable(
 			avroSchemaString,

--- a/pkg/sql/catalog/colinfo/col_type_info.go
+++ b/pkg/sql/catalog/colinfo/col_type_info.go
@@ -78,14 +78,6 @@ func ValidateColumnDefType(ctx context.Context, version clusterversion.Handle, t
 				return pgerror.Newf(pgcode.Syntax, `invalid locale %s`, t.Locale())
 			}
 		}
-		if t.Oid() == oid.T_refcursor {
-			if !version.IsActive(ctx, clusterversion.V23_2) {
-				return pgerror.Newf(
-					pgcode.FeatureNotSupported,
-					"refcursor not supported until version 23.2",
-				)
-			}
-		}
 
 	case types.DecimalFamily:
 		switch {
@@ -137,6 +129,14 @@ func ValidateColumnDefType(ctx context.Context, version clusterversion.Handle, t
 			return pgerror.Newf(
 				pgcode.FeatureNotSupported,
 				"pg_lsn not supported until version 23.2",
+			)
+		}
+
+	case types.RefCursorFamily:
+		if !version.IsActive(ctx, clusterversion.V23_2) {
+			return pgerror.Newf(
+				pgcode.FeatureNotSupported,
+				"refcursor not supported until version 23.2",
 			)
 		}
 

--- a/pkg/sql/catalog/colinfo/column_type_properties.go
+++ b/pkg/sql/catalog/colinfo/column_type_properties.go
@@ -83,6 +83,7 @@ func CanHaveCompositeKeyEncoding(typ *types.T) bool {
 		types.EnumFamily,
 		types.Box2DFamily,
 		types.PGLSNFamily,
+		types.RefCursorFamily,
 		types.VoidFamily,
 		types.EncodedKeyFamily,
 		types.TSQueryFamily,

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -2010,6 +2010,7 @@ func checkResultType(typ *types.T) error {
 	case types.INetFamily:
 	case types.OidFamily:
 	case types.PGLSNFamily:
+	case types.RefCursorFamily:
 	case types.TupleFamily:
 	case types.EnumFamily:
 	case types.VoidFamily:

--- a/pkg/sql/importer/exportparquet.go
+++ b/pkg/sql/importer/exportparquet.go
@@ -329,6 +329,14 @@ func NewParquetColumn(typ *types.T, name string, nullable bool) (ParquetColumn, 
 		col.DecodeFn = func(x interface{}) (tree.Datum, error) {
 			return tree.ParseDPGLSN(string(x.([]byte)))
 		}
+	case types.RefCursorFamily:
+		populateLogicalStringCol(schemaEl)
+		col.encodeFn = func(d tree.Datum) (interface{}, error) {
+			return []byte(tree.MustBeDString(d)), nil
+		}
+		col.DecodeFn = func(x interface{}) (tree.Datum, error) {
+			return tree.NewDRefCursor(string(x.([]byte))), nil
+		}
 	case types.Box2DFamily:
 		populateLogicalStringCol(schemaEl)
 		col.encodeFn = func(d tree.Datum) (interface{}, error) {

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -1999,7 +1999,7 @@ oid     typname                typcategory  typispreferred  typisdefined  typdel
 1562    varbit                 V            false           true          ,         0         0        1563
 1563    _varbit                A            false           true          ,         0         1562     0
 1700    numeric                N            false           true          ,         0         0        1231
-1790    refcursor              S            false           true          ,         0         0        2201
+1790    refcursor              U            false           true          ,         0         0        2201
 2201    _refcursor             A            false           true          ,         0         1790     0
 2202    regprocedure           N            false           true          ,         0         0        2207
 2205    regclass               N            false           true          ,         0         0        2210
@@ -2344,8 +2344,8 @@ oid     typname                typndims  typcollation  typdefaultbin  typdefault
 1562    varbit                 0         0             NULL           NULL        NULL
 1563    _varbit                0         0             NULL           NULL        NULL
 1700    numeric                0         0             NULL           NULL        NULL
-1790    refcursor              0         3403232968    NULL           NULL        NULL
-2201    _refcursor             0         3403232968    NULL           NULL        NULL
+1790    refcursor              0         0             NULL           NULL        NULL
+2201    _refcursor             0         0             NULL           NULL        NULL
 2202    regprocedure           0         0             NULL           NULL        NULL
 2205    regclass               0         0             NULL           NULL        NULL
 2206    regtype                0         0             NULL           NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/plpgsql_cursor
+++ b/pkg/sql/logictest/testdata/logic_test/plpgsql_cursor
@@ -646,7 +646,7 @@ DELETE FROM xy WHERE x <> 1 AND x <> 3;
 # Testing unnamed cursors.
 statement ok
 DROP FUNCTION f();
-CREATE OR REPLACE FUNCTION f() RETURNS STRING AS $$
+CREATE OR REPLACE FUNCTION f() RETURNS REFCURSOR AS $$
   DECLARE
     curs REFCURSOR;
   BEGIN
@@ -770,7 +770,7 @@ SELECT name FROM pg_cursors;
 # Do not generate a new name if one was supplied.
 statement ok
 ABORT;
-CREATE OR REPLACE FUNCTION f() RETURNS STRING AS $$
+CREATE OR REPLACE FUNCTION f() RETURNS REFCURSOR AS $$
   DECLARE
     curs REFCURSOR := 'foo';
   BEGIN
@@ -797,7 +797,7 @@ foo
 # The unnamed portal counter shouldn't have incremented for the named cursor,
 # since no name was generated.
 statement ok
-CREATE OR REPLACE FUNCTION f_unnamed() RETURNS STRING AS $$
+CREATE OR REPLACE FUNCTION f_unnamed() RETURNS REFCURSOR AS $$
   DECLARE
     curs REFCURSOR;
   BEGIN
@@ -948,7 +948,7 @@ CREATE OR REPLACE FUNCTION f(n INT) RETURNS INT AS $$
   DECLARE
     curs CURSOR FOR SELECT 100;
   BEGIN
-    curs := 'foo' || n::STRING;
+    curs := ('foo' || n::STRING)::REFCURSOR;
     OPEN curs;
     RETURN 1 // n;
   EXCEPTION
@@ -1347,7 +1347,7 @@ statement ok
 ABORT;
 CREATE OR REPLACE FUNCTION f(n INT) RETURNS INT AS $$
   DECLARE
-    curs REFCURSOR := format('foo%s', n);
+    curs REFCURSOR := format('foo%s', n)::REFCURSOR;
     x INT;
   BEGIN
     OPEN curs FOR SELECT * FROM xy ORDER BY x;
@@ -1402,7 +1402,7 @@ SELECT f(10);
 statement ok
 CREATE OR REPLACE FUNCTION f(n INT) RETURNS INT AS $$
   DECLARE
-    curs REFCURSOR := format('foo%s', n);
+    curs REFCURSOR := format('foo%s', n)::REFCURSOR;
     x INT;
   BEGIN
     OPEN curs FOR SELECT * FROM xy ORDER BY x;

--- a/pkg/sql/logictest/testdata/logic_test/refcursor
+++ b/pkg/sql/logictest/testdata/logic_test/refcursor
@@ -52,34 +52,23 @@ SELECT * FROM xy;
 ----
 1  bar
 
-statement ok
-DROP TABLE IF EXISTS xy;
-CREATE TABLE xy (x INT, y INT);
-INSERT INTO xy VALUES (1, 2);
-INSERT INTO xy VALUES (3, 4);
-
 # Create a partial index that uses the REFCURSOR type.
 statement ok
-CREATE INDEX part ON xy (x) WHERE y::TEXT::REFCURSOR < '3';
+CREATE INDEX part ON xy (x) WHERE y::REFCURSOR::TEXT <= 'bar';
 
-query II
-SELECT * FROM xy@part WHERE y::TEXT::REFCURSOR < '3';
+query IT
+SELECT * FROM xy@part WHERE y::REFCURSOR::TEXT <= 'bar';
 ----
-1  2
-
-statement ok
-DROP TABLE IF EXISTS xy;
-CREATE TABLE xy (x INT, y INT);
-INSERT INTO xy VALUES (1, 2);
+1  bar
 
 # Add a check constraint that uses the REFCURSOR type.
 statement ok
-ALTER TABLE xy ADD CONSTRAINT bar CHECK (y::TEXT::REFCURSOR < 'baz');
+ALTER TABLE xy ADD CONSTRAINT bar CHECK (y::REFCURSOR::TEXT <= 'bar');
 
-query II
+query IT
 SELECT * FROM xy;
 ----
-1  2
+1  bar
 
 subtest type
 
@@ -211,11 +200,8 @@ SELECT f();
 
 subtest error
 
-# TODO(drewk): REFCURSOR should not support collation.
-query T
+statement error pgcode 42804 pq: incompatible type for COLLATE: refcursor
 SELECT 'foo'::REFCURSOR COLLATE en;
-----
-foo
 
 # REFCURSOR does not have a width.
 statement error pgcode 42601 syntax error

--- a/pkg/sql/logictest/testdata/logic_test/refcursor
+++ b/pkg/sql/logictest/testdata/logic_test/refcursor
@@ -28,7 +28,7 @@ statement ok
 ALTER TABLE xy ADD COLUMN curs REFCURSOR;
 
 statement ok
-INSERT INTO xy VALUES (1, 2, 'foo'::REFCURSOR);
+INSERT INTO xy VALUES (1, 2, 'foo');
 
 query IIT
 SELECT * FROM xy;
@@ -45,7 +45,7 @@ statement ok
 ALTER TABLE xy ALTER COLUMN y TYPE REFCURSOR;
 
 statement ok
-INSERT INTO xy VALUES (1, 'bar'::REFCURSOR);
+INSERT INTO xy VALUES (1, 'bar');
 
 query IT
 SELECT * FROM xy;
@@ -88,7 +88,7 @@ statement ok
 CREATE TYPE typ AS (x INT, y REFCURSOR);
 
 query T
-SELECT (100, 'bar'::REFCURSOR)::typ;
+SELECT (100, 'bar')::typ;
 ----
 (100,bar)
 
@@ -130,7 +130,7 @@ CREATE FUNCTION f(curs REFCURSOR) RETURNS INT AS $$
 $$ LANGUAGE SQL;
 
 query I
-SELECT f('foo'::REFCURSOR);
+SELECT f('foo');
 ----
 0
 
@@ -145,7 +145,7 @@ CREATE FUNCTION f(curs REFCURSOR) RETURNS INT AS $$
 $$ LANGUAGE PLpgSQL;
 
 query I
-SELECT f('foo'::REFCURSOR);
+SELECT f('foo');
 ----
 0
 

--- a/pkg/sql/logictest/testdata/logic_test/refcursor
+++ b/pkg/sql/logictest/testdata/logic_test/refcursor
@@ -391,4 +391,78 @@ NULL  a     NULL  NULL  NULL  NULL  NULL  NULL  NULL  NULL  NULL  NULL
 NULL  NULL  foo   NULL  NULL  NULL  NULL  NULL  NULL  NULL  NULL  NULL
 NULL  NULL  NULL  foo   NULL  NULL  NULL  NULL  NULL  NULL  NULL  NULL
 
+# REFCURSOR doesn't support any comparisons (with an exception mentioned below).
+subtest comparisons
+
+# TODO(drewk): The error code should be 42883.
+statement error pgcode 22023 pq: unsupported comparison operator
+SELECT 'foo'::REFCURSOR = 'foo'::REFCURSOR;
+
+statement error pgcode 22023 pq: unsupported comparison operator
+SELECT 'foo'::REFCURSOR = 'foo'::TEXT;
+
+statement error pgcode 22023 pq: unsupported comparison operator
+SELECT 'foo'::REFCURSOR = NULL;
+
+statement error pgcode 22023 pq: unsupported comparison operator
+SELECT 'foo'::REFCURSOR < 'foo'::REFCURSOR;
+
+statement error pgcode 22023 pq: unsupported comparison operator
+SELECT 'foo'::REFCURSOR < 'foo'::TEXT;
+
+statement error pgcode 22023 pq: unsupported comparison operator
+SELECT 'foo'::REFCURSOR < NULL;
+
+statement error pgcode 22023 pq: unsupported comparison operator
+SELECT 'foo'::REFCURSOR > 'foo'::REFCURSOR;
+
+statement error pgcode 22023 pq: unsupported comparison operator
+SELECT 'foo'::REFCURSOR > 'foo'::TEXT;
+
+statement error pgcode 22023 pq: unsupported comparison operator
+SELECT 'foo'::REFCURSOR > NULL;
+
+statement error pgcode 22023 pq: unsupported comparison operator
+SELECT 'foo'::REFCURSOR <= 'foo'::REFCURSOR;
+
+statement error pgcode 22023 pq: unsupported comparison operator
+SELECT 'foo'::REFCURSOR <= 'foo'::TEXT;
+
+statement error pgcode 22023 pq: unsupported comparison operator
+SELECT 'foo'::REFCURSOR <= NULL;
+
+statement error pgcode 22023 pq: unsupported comparison operator
+SELECT 'foo'::REFCURSOR >= 'foo'::REFCURSOR;
+
+statement error pgcode 22023 pq: unsupported comparison operator
+SELECT 'foo'::REFCURSOR >= 'foo'::TEXT;
+
+statement error pgcode 22023 pq: unsupported comparison operator
+SELECT 'foo'::REFCURSOR >= NULL;
+
+# TODO(drewk): Postgres allows this case.
+statement error pgcode 42883 pq: unsupported comparison operator
+SELECT 'foo'::REFCURSOR IS NULL;
+
+statement error pgcode 42883 pq: unsupported comparison operator
+SELECT 'foo'::REFCURSOR IS NOT NULL;
+
+statement error pgcode 22023 pq: unsupported comparison operator
+SELECT 'foo'::REFCURSOR IS DISTINCT FROM 'foo'::REFCURSOR;
+
+statement error pgcode 22023 pq: unsupported comparison operator
+SELECT 'foo'::REFCURSOR IS DISTINCT FROM 'foo'::TEXT;
+
+statement error pgcode 22023 pq: unsupported comparison operator
+SELECT 'foo'::REFCURSOR IS DISTINCT FROM NULL;
+
+statement error pgcode 22023 pq: unsupported comparison operator
+SELECT 'foo'::REFCURSOR IS NOT DISTINCT FROM 'foo'::REFCURSOR;
+
+statement error pgcode 22023 pq: unsupported comparison operator
+SELECT 'foo'::REFCURSOR IS NOT DISTINCT FROM 'foo'::TEXT;
+
+statement error pgcode 22023 pq: unsupported comparison operator
+SELECT 'foo'::REFCURSOR IS NOT DISTINCT FROM NULL;
+
 subtest end

--- a/pkg/sql/opt/optbuilder/plpgsql.go
+++ b/pkg/sql/opt/optbuilder/plpgsql.go
@@ -731,25 +731,13 @@ func (b *plpgsqlBuilder) buildCursorNameGen(nameCon *continuation, nameVar ast.V
 		memo.ScalarListExpr{b.ob.factory.ConstructVariable(source.(*scopeColumn).id)},
 		&memo.FunctionPrivate{
 			Name:       nameFnName,
-			Typ:        types.String,
+			Typ:        types.RefCursor,
 			Properties: props,
 			Overload:   &overloads[0],
 		},
 	)
-	// Build an expression that calls the builtin function if the name is unset.
-	scalar := b.ob.factory.ConstructCase(memo.TrueSingleton,
-		memo.ScalarListExpr{
-			b.ob.factory.ConstructWhen(
-				b.ob.factory.ConstructIs(
-					b.ob.factory.ConstructVariable(source.(*scopeColumn).id), memo.NullSingleton,
-				),
-				nameCall,
-			),
-		},
-		b.ob.factory.ConstructVariable(source.(*scopeColumn).id),
-	)
 	nameScope := nameCon.s.push()
-	b.ob.synthesizeColumn(nameScope, scopeColName(nameVar), types.String, nil /* expr */, scalar)
+	b.ob.synthesizeColumn(nameScope, scopeColName(nameVar), types.RefCursor, nil /* expr */, nameCall)
 	b.ob.constructProjectForScope(nameCon.s, nameScope)
 	return nameScope
 }

--- a/pkg/sql/opt/optbuilder/testdata/udf_plpgsql
+++ b/pkg/sql/opt/optbuilder/testdata/udf_plpgsql
@@ -4966,7 +4966,7 @@ project
                      │    │    │    ├── key: ()
                      │    │    │    └── tuple [type=tuple]
                      │    │    └── projections
-                     │    │         └── const: 'foo' [as=curs:1, type=string]
+                     │    │         └── const: 'foo' [as=curs:1, type=refcursor]
                      │    └── projections
                      │         └── udf: _gen_cursor_name_5 [as="_gen_cursor_name_5":11, type=int, outer=(1), volatile, udf]
                      │              ├── args
@@ -5262,7 +5262,7 @@ project
                      │    │    │    │    ├── key: ()
                      │    │    │    │    └── tuple [type=tuple]
                      │    │    │    └── projections
-                     │    │    │         └── const: 'foo' [as=curs:1, type=string]
+                     │    │    │         └── const: 'foo' [as=curs:1, type=refcursor]
                      │    │    └── projections
                      │    │         └── cast: INT8 [as=x:2, type=int, immutable]
                      │    │              └── null [type=unknown]

--- a/pkg/sql/opt/optbuilder/testdata/udf_plpgsql
+++ b/pkg/sql/opt/optbuilder/testdata/udf_plpgsql
@@ -4649,14 +4649,7 @@ project
                      │                        │    ├── values
                      │                        │    │    └── tuple
                      │                        │    └── projections
-                     │                        │         └── case [as=curs:6]
-                     │                        │              ├── true
-                     │                        │              ├── when
-                     │                        │              │    ├── is
-                     │                        │              │    │    ├── variable: curs:5
-                     │                        │              │    │    └── null
-                     │                        │              │    └── function: crdb_internal.plpgsql_gen_cursor_name
-                     │                        │              │         └── variable: curs:5
+                     │                        │         └── function: crdb_internal.plpgsql_gen_cursor_name [as=curs:6]
                      │                        │              └── variable: curs:5
                      │                        └── projections
                      │                             └── udf: _stmt_open_1 [as="_stmt_open_1":7]
@@ -4729,14 +4722,7 @@ project
                      │                        │    ├── values
                      │                        │    │    └── tuple
                      │                        │    └── projections
-                     │                        │         └── case [as=curs:13]
-                     │                        │              ├── true
-                     │                        │              ├── when
-                     │                        │              │    ├── is
-                     │                        │              │    │    ├── variable: curs:12
-                     │                        │              │    │    └── null
-                     │                        │              │    └── function: crdb_internal.plpgsql_gen_cursor_name
-                     │                        │              │         └── variable: curs:12
+                     │                        │         └── function: crdb_internal.plpgsql_gen_cursor_name [as=curs:13]
                      │                        │              └── variable: curs:12
                      │                        └── projections
                      │                             └── udf: _stmt_open_1 [as="_stmt_open_1":14]
@@ -4822,14 +4808,7 @@ project
                      │                        │    ├── values
                      │                        │    │    └── tuple
                      │                        │    └── projections
-                     │                        │         └── case [as=curs:32]
-                     │                        │              ├── true
-                     │                        │              ├── when
-                     │                        │              │    ├── is
-                     │                        │              │    │    ├── variable: curs:29
-                     │                        │              │    │    └── null
-                     │                        │              │    └── function: crdb_internal.plpgsql_gen_cursor_name
-                     │                        │              │         └── variable: curs:29
+                     │                        │         └── function: crdb_internal.plpgsql_gen_cursor_name [as=curs:32]
                      │                        │              └── variable: curs:29
                      │                        └── projections
                      │                             └── udf: _stmt_open_1 [as="_stmt_open_1":33]
@@ -4865,14 +4844,7 @@ project
                      │                                                                │    ├── values
                      │                                                                │    │    └── tuple
                      │                                                                │    └── projections
-                     │                                                                │         └── case [as=curs2:26]
-                     │                                                                │              ├── true
-                     │                                                                │              ├── when
-                     │                                                                │              │    ├── is
-                     │                                                                │              │    │    ├── variable: curs2:24
-                     │                                                                │              │    │    └── null
-                     │                                                                │              │    └── function: crdb_internal.plpgsql_gen_cursor_name
-                     │                                                                │              │         └── variable: curs2:24
+                     │                                                                │         └── function: crdb_internal.plpgsql_gen_cursor_name [as=curs2:26]
                      │                                                                │              └── variable: curs2:24
                      │                                                                └── projections
                      │                                                                     └── udf: _stmt_open_2 [as="_stmt_open_2":27]
@@ -4908,14 +4880,7 @@ project
                      │                                                                                                        │    ├── values
                      │                                                                                                        │    │    └── tuple
                      │                                                                                                        │    └── projections
-                     │                                                                                                        │         └── case [as=curs3:20]
-                     │                                                                                                        │              ├── true
-                     │                                                                                                        │              ├── when
-                     │                                                                                                        │              │    ├── is
-                     │                                                                                                        │              │    │    ├── variable: curs3:19
-                     │                                                                                                        │              │    │    └── null
-                     │                                                                                                        │              │    └── function: crdb_internal.plpgsql_gen_cursor_name
-                     │                                                                                                        │              │         └── variable: curs3:19
+                     │                                                                                                        │         └── function: crdb_internal.plpgsql_gen_cursor_name [as=curs3:20]
                      │                                                                                                        │              └── variable: curs3:19
                      │                                                                                                        └── projections
                      │                                                                                                             └── udf: _stmt_open_3 [as="_stmt_open_3":21]
@@ -5017,7 +4982,7 @@ project
                      │                        ├── key: ()
                      │                        ├── fd: ()-->(10)
                      │                        ├── project
-                     │                        │    ├── columns: curs:9(string)
+                     │                        │    ├── columns: curs:9(refcursor)
                      │                        │    ├── outer: (8)
                      │                        │    ├── cardinality: [1 - 1]
                      │                        │    ├── volatile
@@ -5031,19 +4996,12 @@ project
                      │                        │    │    ├── key: ()
                      │                        │    │    └── tuple [type=tuple]
                      │                        │    └── projections
-                     │                        │         └── case [as=curs:9, type=refcursor, outer=(8), volatile]
-                     │                        │              ├── true [type=bool]
-                     │                        │              ├── when [type=string]
-                     │                        │              │    ├── is [type=bool]
-                     │                        │              │    │    ├── variable: curs:8 [type=refcursor]
-                     │                        │              │    │    └── null [type=unknown]
-                     │                        │              │    └── function: crdb_internal.plpgsql_gen_cursor_name [type=string]
-                     │                        │              │         └── variable: curs:8 [type=refcursor]
+                     │                        │         └── function: crdb_internal.plpgsql_gen_cursor_name [as=curs:9, type=refcursor, outer=(8), volatile]
                      │                        │              └── variable: curs:8 [type=refcursor]
                      │                        └── projections
                      │                             └── udf: _stmt_open_1 [as="_stmt_open_1":10, type=int, outer=(9), volatile, udf]
                      │                                  ├── args
-                     │                                  │    └── variable: curs:9 [type=string]
+                     │                                  │    └── variable: curs:9 [type=refcursor]
                      │                                  ├── params: curs:2(refcursor)
                      │                                  └── body
                      │                                       ├── open-cursor
@@ -5169,14 +5127,7 @@ project
                      │              │                             │    ├── values
                      │              │                             │    │    └── tuple
                      │              │                             │    └── projections
-                     │              │                             │         └── case [as=curs:15]
-                     │              │                             │              ├── true
-                     │              │                             │              ├── when
-                     │              │                             │              │    ├── is
-                     │              │                             │              │    │    ├── variable: curs:14
-                     │              │                             │              │    │    └── null
-                     │              │                             │              │    └── function: crdb_internal.plpgsql_gen_cursor_name
-                     │              │                             │              │         └── variable: curs:14
+                     │              │                             │         └── function: crdb_internal.plpgsql_gen_cursor_name [as=curs:15]
                      │              │                             │              └── variable: curs:14
                      │              │                             └── projections
                      │              │                                  └── udf: _stmt_open_6 [as="_stmt_open_6":16]
@@ -5218,14 +5169,7 @@ project
                      │                                                 │    ├── values
                      │                                                 │    │    └── tuple
                      │                                                 │    └── projections
-                     │                                                 │         └── case [as=curs:7]
-                     │                                                 │              ├── true
-                     │                                                 │              ├── when
-                     │                                                 │              │    ├── is
-                     │                                                 │              │    │    ├── variable: curs:6
-                     │                                                 │              │    │    └── null
-                     │                                                 │              │    └── function: crdb_internal.plpgsql_gen_cursor_name
-                     │                                                 │              │         └── variable: curs:6
+                     │                                                 │         └── function: crdb_internal.plpgsql_gen_cursor_name [as=curs:7]
                      │                                                 │              └── variable: curs:6
                      │                                                 └── projections
                      │                                                      └── udf: _stmt_open_2 [as="_stmt_open_2":8]
@@ -5338,7 +5282,7 @@ project
                      │                        ├── key: ()
                      │                        ├── fd: ()-->(22)
                      │                        ├── project
-                     │                        │    ├── columns: curs:21(string)
+                     │                        │    ├── columns: curs:21(refcursor)
                      │                        │    ├── outer: (19)
                      │                        │    ├── cardinality: [1 - 1]
                      │                        │    ├── volatile
@@ -5352,19 +5296,12 @@ project
                      │                        │    │    ├── key: ()
                      │                        │    │    └── tuple [type=tuple]
                      │                        │    └── projections
-                     │                        │         └── case [as=curs:21, type=refcursor, outer=(19), volatile]
-                     │                        │              ├── true [type=bool]
-                     │                        │              ├── when [type=string]
-                     │                        │              │    ├── is [type=bool]
-                     │                        │              │    │    ├── variable: curs:19 [type=refcursor]
-                     │                        │              │    │    └── null [type=unknown]
-                     │                        │              │    └── function: crdb_internal.plpgsql_gen_cursor_name [type=string]
-                     │                        │              │         └── variable: curs:19 [type=refcursor]
+                     │                        │         └── function: crdb_internal.plpgsql_gen_cursor_name [as=curs:21, type=refcursor, outer=(19), volatile]
                      │                        │              └── variable: curs:19 [type=refcursor]
                      │                        └── projections
                      │                             └── udf: _stmt_open_1 [as="_stmt_open_1":22, type=int, outer=(20,21), volatile, udf]
                      │                                  ├── args
-                     │                                  │    ├── variable: curs:21 [type=string]
+                     │                                  │    ├── variable: curs:21 [type=refcursor]
                      │                                  │    └── variable: x:20 [type=int]
                      │                                  ├── params: curs:3(refcursor) x:4(int)
                      │                                  └── body
@@ -5507,14 +5444,7 @@ project
                      │                        │    ├── values
                      │                        │    │    └── tuple
                      │                        │    └── projections
-                     │                        │         └── case [as=curs:13]
-                     │                        │              ├── true
-                     │                        │              ├── when
-                     │                        │              │    ├── is
-                     │                        │              │    │    ├── variable: curs:12
-                     │                        │              │    │    └── null
-                     │                        │              │    └── function: crdb_internal.plpgsql_gen_cursor_name
-                     │                        │              │         └── variable: curs:12
+                     │                        │         └── function: crdb_internal.plpgsql_gen_cursor_name [as=curs:13]
                      │                        │              └── variable: curs:12
                      │                        └── projections
                      │                             └── udf: _stmt_open_1 [as="_stmt_open_1":14]

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -4539,6 +4539,7 @@ var datumToTypeCategory = map[types.Family]*tree.DString{
 	types.TupleFamily:       typCategoryPseudo,
 	types.OidFamily:         typCategoryNumeric,
 	types.PGLSNFamily:       typCategoryUserDefined,
+	types.RefCursorFamily:   typCategoryUserDefined,
 	types.UuidFamily:        typCategoryUserDefined,
 	types.INetFamily:        typCategoryNetworkAddr,
 	types.UnknownFamily:     typCategoryUnknown,

--- a/pkg/sql/pgwire/pgwirebase/encoding.go
+++ b/pkg/sql/pgwire/pgwirebase/encoding.go
@@ -815,9 +815,16 @@ func DecodeDatum(
 			return nil, err
 		}
 		return tree.NewDEnum(e), nil
+	case types.RefCursorFamily:
+		if err := validateStringBytes(b); err != nil {
+			return nil, err
+		}
+		// Note: we could use bs here if we were guaranteed all callers never
+		// mutated b.
+		return tree.NewDRefCursor(string(b)), nil
 	}
 	switch id {
-	case oid.T_text, oid.T_varchar, oid.T_refcursor, oid.T_unknown:
+	case oid.T_text, oid.T_varchar, oid.T_unknown:
 		if err := validateStringBytes(b); err != nil {
 			return nil, err
 		}

--- a/pkg/sql/randgen/datum.go
+++ b/pkg/sql/randgen/datum.go
@@ -128,6 +128,12 @@ func RandDatumWithNullChance(
 		return tree.NewDBox2D(*b)
 	case types.PGLSNFamily:
 		return tree.NewDPGLSN(lsn.LSN(rng.Uint64()))
+	case types.RefCursorFamily:
+		p := make([]byte, rng.Intn(10))
+		for i := range p {
+			p[i] = byte(1 + rng.Intn(127))
+		}
+		return tree.NewDRefCursor(string(p))
 	case types.GeographyFamily:
 		gm, err := typ.GeoMetadata()
 		if err != nil {
@@ -719,6 +725,14 @@ var (
 			tree.NewDPGLSN(math.MaxInt64 + 1),
 			tree.NewDPGLSN(math.MaxUint64),
 		},
+		types.RefCursorFamily: {
+			tree.NewDRefCursor(""),
+			tree.NewDRefCursor("X"),
+			tree.NewDRefCursor(`"`),
+			tree.NewDRefCursor(`'`),
+			tree.NewDRefCursor("\x00"),
+			tree.NewDRefCursor("\u2603"), // unicode snowman
+		},
 		types.JsonFamily: func() []tree.Datum {
 			var res []tree.Datum
 			for _, s := range []string{
@@ -887,6 +901,26 @@ var (
 		}(),
 		types.PGLSNFamily: {
 			tree.NewDPGLSN(0x1000),
+		},
+		types.RefCursorFamily: {
+			tree.NewDRefCursor("a"),
+			tree.NewDRefCursor("a\n"),
+			tree.NewDRefCursor("aa"),
+			tree.NewDRefCursor(`Aa`),
+			tree.NewDRefCursor(`aab`),
+			tree.NewDRefCursor(`aaaaaa`),
+			tree.NewDRefCursor("a "),
+			tree.NewDRefCursor(" a"),
+			tree.NewDRefCursor("	a"),
+			tree.NewDRefCursor("a	"),
+			tree.NewDRefCursor("a	"),
+			tree.NewDRefCursor("\u0001"),
+			tree.NewDRefCursor("\ufffd"),
+			tree.NewDRefCursor("\u00e1"),
+			tree.NewDRefCursor("À"),
+			tree.NewDRefCursor("à"),
+			tree.NewDRefCursor("àá"),
+			tree.NewDRefCursor("À1                à\n"),
 		},
 		types.IntervalFamily: func() []tree.Datum {
 			var res []tree.Datum

--- a/pkg/sql/rowenc/keyside/decode.go
+++ b/pkg/sql/rowenc/keyside/decode.go
@@ -82,6 +82,16 @@ func Decode(
 			rkey, i, err = encoding.DecodeUvarintDescending(key)
 		}
 		return a.NewDPGLSN(tree.DPGLSN{LSN: lsn.LSN(i)}), rkey, err
+	case types.RefCursorFamily:
+		var r string
+		if dir == encoding.Ascending {
+			// Perform a deep copy so that r would never reference the key's
+			// memory which might keep the BatchResponse alive.
+			rkey, r, err = encoding.DecodeUnsafeStringAscendingDeepCopy(key, nil)
+		} else {
+			rkey, r, err = encoding.DecodeUnsafeStringDescending(key, nil)
+		}
+		return a.NewDRefCursor(tree.DString(r)), rkey, err
 	case types.FloatFamily:
 		var f float64
 		if dir == encoding.Ascending {

--- a/pkg/sql/rowenc/valueside/array.go
+++ b/pkg/sql/rowenc/valueside/array.go
@@ -210,7 +210,8 @@ func DatumTypeToArrayElementEncodingType(t *types.T) (encoding.Type, error) {
 		return encoding.Geo, nil
 	case types.DecimalFamily:
 		return encoding.Decimal, nil
-	case types.BytesFamily, types.StringFamily, types.CollatedStringFamily, types.EnumFamily:
+	case types.BytesFamily, types.StringFamily, types.CollatedStringFamily,
+		types.EnumFamily, types.RefCursorFamily:
 		return encoding.Bytes, nil
 	case types.TimestampFamily, types.TimestampTZFamily:
 		return encoding.Time, nil

--- a/pkg/sql/rowenc/valueside/decode.go
+++ b/pkg/sql/rowenc/valueside/decode.go
@@ -122,6 +122,12 @@ func DecodeUntaggedDatum(
 			return nil, b, err
 		}
 		return a.NewDPGLSN(tree.DPGLSN{LSN: lsn.LSN(data)}), b, nil
+	case types.RefCursorFamily:
+		b, data, err := encoding.DecodeUntaggedBytesValue(buf)
+		if err != nil {
+			return nil, b, err
+		}
+		return a.NewDRefCursor(tree.DString(data)), b, nil
 	case types.Box2DFamily:
 		b, data, err := encoding.DecodeUntaggedBox2DValue(buf)
 		if err != nil {

--- a/pkg/sql/rowenc/valueside/legacy.go
+++ b/pkg/sql/rowenc/valueside/legacy.go
@@ -93,6 +93,11 @@ func MarshalLegacy(colType *types.T, val tree.Datum) (roachpb.Value, error) {
 			r.SetInt(int64(v.LSN))
 			return r, nil
 		}
+	case types.RefCursorFamily:
+		if v, ok := tree.AsDString(val); ok {
+			r.SetString(string(v))
+			return r, nil
+		}
 	case types.GeographyFamily:
 		if v, ok := val.(*tree.DGeography); ok {
 			err := r.SetGeo(v.SpatialObject())
@@ -249,6 +254,12 @@ func UnmarshalLegacy(a *tree.DatumAlloc, typ *types.T, value roachpb.Value) (tre
 			return nil, err
 		}
 		return a.NewDPGLSN(tree.DPGLSN{LSN: lsn.LSN(v)}), nil
+	case types.RefCursorFamily:
+		v, err := value.GetBytes()
+		if err != nil {
+			return nil, err
+		}
+		return a.NewDRefCursor(tree.DString(v)), nil
 	case types.FloatFamily:
 		v, err := value.GetFloat()
 		if err != nil {

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -8482,7 +8482,7 @@ specified store on the node it's run from. One of 'mvccGC', 'merge', 'split',
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				if args[0] == tree.DNull {
 					name := evalCtx.Planner.GenUniqueCursorName()
-					return tree.NewDString(string(name)), nil
+					return tree.NewDRefCursor(string(name)), nil
 				}
 				return args[0], nil
 			},

--- a/pkg/sql/sem/builtins/pgformat/format_test.go
+++ b/pkg/sql/sem/builtins/pgformat/format_test.go
@@ -61,8 +61,7 @@ func TestFormat(t *testing.T) {
 			}
 		}
 		if typ.Oid() == oid.T_refcursor {
-			// TODO(drewk): this case is temporarily skipped until we split REFCURSOR
-			// into its own family.
+			// REFCURSOR doesn't support comparison operators.
 			return true
 		}
 		return !randgen.IsLegalColumnType(typ)

--- a/pkg/sql/sem/eval/unsupported_types.go
+++ b/pkg/sql/sem/eval/unsupported_types.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
-	"github.com/lib/pq/oid"
 )
 
 type unsupportedTypeChecker struct {
@@ -36,9 +35,10 @@ var _ tree.UnsupportedTypeChecker = &unsupportedTypeChecker{}
 // CheckType implements the tree.UnsupportedTypeChecker interface.
 func (tc *unsupportedTypeChecker) CheckType(ctx context.Context, typ *types.T) error {
 	var errorTypeString string
-	if typ.Family() == types.PGLSNFamily {
+	switch typ.Family() {
+	case types.PGLSNFamily:
 		errorTypeString = "pg_lsn"
-	} else if typ.Oid() == oid.T_refcursor {
+	case types.RefCursorFamily:
 		errorTypeString = "refcursor"
 	}
 	if errorTypeString != "" && !tc.version.IsActive(ctx, clusterversion.V23_2) {

--- a/pkg/sql/sem/tree/constant.go
+++ b/pkg/sql/sem/tree/constant.go
@@ -544,6 +544,7 @@ var (
 		types.Jsonb,
 		types.PGLSN,
 		types.PGLSNArray,
+		types.RefCursor,
 		types.TSQuery,
 		types.TSVector,
 		types.VarBit,

--- a/pkg/sql/sem/tree/constant.go
+++ b/pkg/sql/sem/tree/constant.go
@@ -545,6 +545,7 @@ var (
 		types.PGLSN,
 		types.PGLSNArray,
 		types.RefCursor,
+		types.RefCursorArray,
 		types.TSQuery,
 		types.TSVector,
 		types.VarBit,

--- a/pkg/sql/sem/tree/constant_test.go
+++ b/pkg/sql/sem/tree/constant_test.go
@@ -347,7 +347,7 @@ func mustParseDPGLSN(t *testing.T, s string) tree.Datum {
 	return d
 }
 func mustParseDRefCursor(_ *testing.T, s string) tree.Datum {
-	return tree.NewDString(s)
+	return tree.NewDRefCursor(s)
 }
 func mustParseDINet(t *testing.T, s string) tree.Datum {
 	d, err := tree.ParseDIPAddrFromINetString(s)
@@ -421,6 +421,7 @@ var parseFuncs = map[*types.T]func(*testing.T, string) tree.Datum{
 	types.UUIDArray:        mustParseDArrayOfType(types.Uuid),
 	types.DateArray:        mustParseDArrayOfType(types.Date),
 	types.PGLSNArray:       mustParseDArrayOfType(types.PGLSN),
+	types.RefCursorArray:   mustParseDArrayOfType(types.RefCursor),
 	types.TimeArray:        mustParseDArrayOfType(types.Time),
 	types.TimeTZArray:      mustParseDArrayOfType(types.TimeTZ),
 	types.TimestampArray:   mustParseDArrayOfType(types.Timestamp),
@@ -553,6 +554,7 @@ func TestStringConstantResolveAvailableTypes(t *testing.T) {
 				types.TSVector,
 				types.TSQuery,
 				types.RefCursor,
+				types.RefCursorArray,
 			),
 		},
 		{
@@ -568,12 +570,13 @@ func TestStringConstantResolveAvailableTypes(t *testing.T) {
 				types.TSVector,
 				types.TSQuery,
 				types.RefCursor,
+				types.RefCursorArray,
 			),
 		},
 		{
 			c: tree.NewStrVal(`{a,b}`),
 			parseOptions: typeSet(types.String, types.Bytes, types.BytesArray, types.StringArray,
-				types.TSVector, types.TSQuery, types.RefCursor),
+				types.TSVector, types.TSQuery, types.RefCursor, types.RefCursorArray),
 		},
 		{
 			c:            tree.NewBytesStrVal(string([]byte{0xff, 0xfe, 0xfd})),
@@ -587,23 +590,23 @@ func TestStringConstantResolveAvailableTypes(t *testing.T) {
 		{
 			c: tree.NewStrVal(`{18e7b17e-4ead-4e27-bfd5-bb6d11261bb6, 18e7b17e-4ead-4e27-bfd5-bb6d11261bb7}`),
 			parseOptions: typeSet(types.String, types.Bytes, types.BytesArray, types.StringArray,
-				types.UUIDArray, types.TSVector, types.RefCursor),
+				types.UUIDArray, types.TSVector, types.RefCursor, types.RefCursorArray),
 		},
 		{
 			c: tree.NewStrVal("{true, false}"),
 			parseOptions: typeSet(types.String, types.Bytes, types.BytesArray, types.StringArray,
-				types.BoolArray, types.TSVector, types.RefCursor),
+				types.BoolArray, types.TSVector, types.RefCursor, types.RefCursorArray),
 		},
 		{
 			c: tree.NewStrVal("{2010-09-28, 2010-09-29}"),
 			parseOptions: typeSet(types.String, types.Bytes, types.BytesArray, types.StringArray,
 				types.DateArray, types.TimestampArray, types.TimestampTZArray, types.TSVector,
-				types.RefCursor),
+				types.RefCursor, types.RefCursorArray),
 		},
 		{
 			c: tree.NewStrVal("{1A/1,2/2A}"),
 			parseOptions: typeSet(types.String, types.PGLSNArray, types.Bytes, types.BytesArray,
-				types.StringArray, types.TSQuery, types.TSVector, types.RefCursor),
+				types.StringArray, types.TSQuery, types.TSVector, types.RefCursor, types.RefCursorArray),
 		},
 		{
 			c: tree.NewStrVal("{2010-09-28 12:00:00.1, 2010-09-29 12:00:00.1}"),
@@ -617,7 +620,8 @@ func TestStringConstantResolveAvailableTypes(t *testing.T) {
 				types.TimestampArray,
 				types.TimestampTZArray,
 				types.DateArray,
-				types.RefCursor),
+				types.RefCursor,
+				types.RefCursorArray),
 		},
 		{
 			c: tree.NewStrVal("{2006-07-08T00:00:00.000000123Z, 2006-07-10T00:00:00.000000123Z}"),
@@ -631,17 +635,18 @@ func TestStringConstantResolveAvailableTypes(t *testing.T) {
 				types.TimestampArray,
 				types.TimestampTZArray,
 				types.DateArray,
-				types.RefCursor),
+				types.RefCursor,
+				types.RefCursorArray),
 		},
 		{
 			c: tree.NewStrVal("{PT12H2M, -23:00:00}"),
 			parseOptions: typeSet(types.String, types.Bytes, types.BytesArray, types.StringArray,
-				types.IntervalArray, types.RefCursor),
+				types.IntervalArray, types.RefCursor, types.RefCursorArray),
 		},
 		{
 			c: tree.NewStrVal("{192.168.100.128, ::ffff:10.4.3.2}"),
 			parseOptions: typeSet(types.String, types.Bytes, types.BytesArray, types.StringArray,
-				types.INetArray, types.RefCursor),
+				types.INetArray, types.RefCursor, types.RefCursorArray),
 		},
 		{
 			c: tree.NewStrVal("{0101, 11}"),
@@ -657,6 +662,7 @@ func TestStringConstantResolveAvailableTypes(t *testing.T) {
 				types.VarBitArray,
 				types.TSVector,
 				types.RefCursor,
+				types.RefCursorArray,
 			),
 		},
 	}

--- a/pkg/sql/sem/tree/constant_test.go
+++ b/pkg/sql/sem/tree/constant_test.go
@@ -346,6 +346,9 @@ func mustParseDPGLSN(t *testing.T, s string) tree.Datum {
 	}
 	return d
 }
+func mustParseDRefCursor(_ *testing.T, s string) tree.Datum {
+	return tree.NewDString(s)
+}
 func mustParseDINet(t *testing.T, s string) tree.Datum {
 	d, err := tree.ParseDIPAddrFromINetString(s)
 	if err != nil {
@@ -406,6 +409,7 @@ var parseFuncs = map[*types.T]func(*testing.T, string) tree.Datum{
 	types.INet:             mustParseDINet,
 	types.VarBit:           mustParseDVarBit,
 	types.PGLSN:            mustParseDPGLSN,
+	types.RefCursor:        mustParseDRefCursor,
 	types.TSQuery:          mustParseDTSQuery,
 	types.TSVector:         mustParseDTSVector,
 	types.BytesArray:       mustParseDArrayOfType(types.Bytes),
@@ -424,7 +428,6 @@ var parseFuncs = map[*types.T]func(*testing.T, string) tree.Datum{
 	types.IntervalArray:    mustParseDArrayOfType(types.Interval),
 	types.INetArray:        mustParseDArrayOfType(types.INet),
 	types.VarBitArray:      mustParseDArrayOfType(types.VarBit),
-	types.PGLSNArray:       mustParseDArrayOfType(types.PGLSN),
 }
 
 func typeSet(tys ...*types.T) map[*types.T]struct{} {
@@ -449,27 +452,32 @@ func TestStringConstantResolveAvailableTypes(t *testing.T) {
 	}{
 		{
 			c:            tree.NewStrVal("abc 世界"),
-			parseOptions: typeSet(types.String, types.Bytes, types.TSVector),
+			parseOptions: typeSet(types.String, types.Bytes, types.TSVector, types.RefCursor),
 		},
 		{
-			c:            tree.NewStrVal("true"),
-			parseOptions: typeSet(types.String, types.Bytes, types.Bool, types.Jsonb, types.TSVector, types.TSQuery),
+			c: tree.NewStrVal("true"),
+			parseOptions: typeSet(types.String, types.Bytes, types.Bool, types.Jsonb, types.TSVector,
+				types.TSQuery, types.RefCursor),
 		},
 		{
-			c:            tree.NewStrVal("2010-09-28"),
-			parseOptions: typeSet(types.String, types.Bytes, types.Date, types.Timestamp, types.TimestampTZ, types.TSVector, types.TSQuery),
+			c: tree.NewStrVal("2010-09-28"),
+			parseOptions: typeSet(types.String, types.Bytes, types.Date, types.Timestamp,
+				types.TimestampTZ, types.TSVector, types.TSQuery, types.RefCursor),
 		},
 		{
-			c:            tree.NewStrVal("2010-09-28 12:00:00.1"),
-			parseOptions: typeSet(types.String, types.Bytes, types.Time, types.TimeTZ, types.Timestamp, types.TimestampTZ, types.Date),
+			c: tree.NewStrVal("2010-09-28 12:00:00.1"),
+			parseOptions: typeSet(types.String, types.Bytes, types.Time, types.TimeTZ, types.Timestamp,
+				types.TimestampTZ, types.Date, types.RefCursor),
 		},
 		{
-			c:            tree.NewStrVal("2006-07-08T00:00:00.000000123Z"),
-			parseOptions: typeSet(types.String, types.Bytes, types.Time, types.TimeTZ, types.Timestamp, types.TimestampTZ, types.Date),
+			c: tree.NewStrVal("2006-07-08T00:00:00.000000123Z"),
+			parseOptions: typeSet(types.String, types.Bytes, types.Time, types.TimeTZ, types.Timestamp,
+				types.TimestampTZ, types.Date, types.RefCursor),
 		},
 		{
-			c:            tree.NewStrVal("PT12H2M"),
-			parseOptions: typeSet(types.String, types.Bytes, types.Interval, types.TSVector, types.TSQuery),
+			c: tree.NewStrVal("PT12H2M"),
+			parseOptions: typeSet(types.String, types.Bytes, types.Interval, types.TSVector,
+				types.TSQuery, types.RefCursor),
 		},
 		{
 			c:            tree.NewBytesStrVal("abc 世界"),
@@ -492,16 +500,19 @@ func TestStringConstantResolveAvailableTypes(t *testing.T) {
 			parseOptions: typeSet(types.String, types.Bytes),
 		},
 		{
-			c:            tree.NewStrVal("box(0 0, 1 1)"),
-			parseOptions: typeSet(types.String, types.Bytes, types.Box2D, types.TSVector),
+			c: tree.NewStrVal("box(0 0, 1 1)"),
+			parseOptions: typeSet(types.String, types.Bytes, types.Box2D, types.TSVector,
+				types.RefCursor),
 		},
 		{
-			c:            tree.NewStrVal("POINT(-100.59 42.94)"),
-			parseOptions: typeSet(types.String, types.Bytes, types.Geography, types.Geometry, types.TSVector),
+			c: tree.NewStrVal("POINT(-100.59 42.94)"),
+			parseOptions: typeSet(types.String, types.Bytes, types.Geography, types.Geometry,
+				types.TSVector, types.RefCursor),
 		},
 		{
-			c:            tree.NewStrVal("192.168.100.128/25"),
-			parseOptions: typeSet(types.String, types.Bytes, types.INet, types.TSVector, types.TSQuery),
+			c: tree.NewStrVal("192.168.100.128/25"),
+			parseOptions: typeSet(types.String, types.Bytes, types.INet, types.TSVector, types.TSQuery,
+				types.RefCursor),
 		},
 		{
 			c: tree.NewStrVal("111000110101"),
@@ -516,15 +527,17 @@ func TestStringConstantResolveAvailableTypes(t *testing.T) {
 				types.Jsonb,
 				types.TSVector,
 				types.TSQuery,
+				types.RefCursor,
 			),
 		},
 		{
-			c:            tree.NewStrVal("A/1"),
-			parseOptions: typeSet(types.String, types.PGLSN, types.Bytes, types.TSQuery, types.TSVector),
+			c: tree.NewStrVal("A/1"),
+			parseOptions: typeSet(types.String, types.PGLSN, types.Bytes, types.TSQuery, types.TSVector,
+				types.RefCursor),
 		},
 		{
 			c:            tree.NewStrVal(`{"a": 1}`),
-			parseOptions: typeSet(types.String, types.Bytes, types.Jsonb),
+			parseOptions: typeSet(types.String, types.Bytes, types.Jsonb, types.RefCursor),
 		},
 		{
 			c: tree.NewStrVal(`{1,2}`),
@@ -539,6 +552,7 @@ func TestStringConstantResolveAvailableTypes(t *testing.T) {
 				types.IntervalArray,
 				types.TSVector,
 				types.TSQuery,
+				types.RefCursor,
 			),
 		},
 		{
@@ -553,37 +567,43 @@ func TestStringConstantResolveAvailableTypes(t *testing.T) {
 				types.IntervalArray,
 				types.TSVector,
 				types.TSQuery,
+				types.RefCursor,
 			),
 		},
 		{
-			c:            tree.NewStrVal(`{a,b}`),
-			parseOptions: typeSet(types.String, types.Bytes, types.BytesArray, types.StringArray, types.TSVector, types.TSQuery),
+			c: tree.NewStrVal(`{a,b}`),
+			parseOptions: typeSet(types.String, types.Bytes, types.BytesArray, types.StringArray,
+				types.TSVector, types.TSQuery, types.RefCursor),
 		},
 		{
 			c:            tree.NewBytesStrVal(string([]byte{0xff, 0xfe, 0xfd})),
 			parseOptions: typeSet(types.String, types.Bytes),
 		},
 		{
-			c:            tree.NewStrVal(`18e7b17e-4ead-4e27-bfd5-bb6d11261bb6`),
-			parseOptions: typeSet(types.String, types.Bytes, types.Uuid, types.TSVector, types.TSQuery),
+			c: tree.NewStrVal(`18e7b17e-4ead-4e27-bfd5-bb6d11261bb6`),
+			parseOptions: typeSet(types.String, types.Bytes, types.Uuid, types.TSVector, types.TSQuery,
+				types.RefCursor),
 		},
 		{
-			c:            tree.NewStrVal(`{18e7b17e-4ead-4e27-bfd5-bb6d11261bb6, 18e7b17e-4ead-4e27-bfd5-bb6d11261bb7}`),
-			parseOptions: typeSet(types.String, types.Bytes, types.BytesArray, types.StringArray, types.UUIDArray, types.TSVector),
+			c: tree.NewStrVal(`{18e7b17e-4ead-4e27-bfd5-bb6d11261bb6, 18e7b17e-4ead-4e27-bfd5-bb6d11261bb7}`),
+			parseOptions: typeSet(types.String, types.Bytes, types.BytesArray, types.StringArray,
+				types.UUIDArray, types.TSVector, types.RefCursor),
 		},
 		{
-			c:            tree.NewStrVal("{true, false}"),
-			parseOptions: typeSet(types.String, types.Bytes, types.BytesArray, types.StringArray, types.BoolArray, types.TSVector),
+			c: tree.NewStrVal("{true, false}"),
+			parseOptions: typeSet(types.String, types.Bytes, types.BytesArray, types.StringArray,
+				types.BoolArray, types.TSVector, types.RefCursor),
 		},
 		{
 			c: tree.NewStrVal("{2010-09-28, 2010-09-29}"),
-			parseOptions: typeSet(types.String, types.Bytes, types.BytesArray, types.StringArray, types.DateArray,
-				types.TimestampArray, types.TimestampTZArray, types.TSVector),
+			parseOptions: typeSet(types.String, types.Bytes, types.BytesArray, types.StringArray,
+				types.DateArray, types.TimestampArray, types.TimestampTZArray, types.TSVector,
+				types.RefCursor),
 		},
 		{
 			c: tree.NewStrVal("{1A/1,2/2A}"),
 			parseOptions: typeSet(types.String, types.PGLSNArray, types.Bytes, types.BytesArray,
-				types.StringArray, types.TSQuery, types.TSVector),
+				types.StringArray, types.TSQuery, types.TSVector, types.RefCursor),
 		},
 		{
 			c: tree.NewStrVal("{2010-09-28 12:00:00.1, 2010-09-29 12:00:00.1}"),
@@ -596,7 +616,8 @@ func TestStringConstantResolveAvailableTypes(t *testing.T) {
 				types.TimeTZArray,
 				types.TimestampArray,
 				types.TimestampTZArray,
-				types.DateArray),
+				types.DateArray,
+				types.RefCursor),
 		},
 		{
 			c: tree.NewStrVal("{2006-07-08T00:00:00.000000123Z, 2006-07-10T00:00:00.000000123Z}"),
@@ -609,15 +630,18 @@ func TestStringConstantResolveAvailableTypes(t *testing.T) {
 				types.TimeTZArray,
 				types.TimestampArray,
 				types.TimestampTZArray,
-				types.DateArray),
+				types.DateArray,
+				types.RefCursor),
 		},
 		{
-			c:            tree.NewStrVal("{PT12H2M, -23:00:00}"),
-			parseOptions: typeSet(types.String, types.Bytes, types.BytesArray, types.StringArray, types.IntervalArray),
+			c: tree.NewStrVal("{PT12H2M, -23:00:00}"),
+			parseOptions: typeSet(types.String, types.Bytes, types.BytesArray, types.StringArray,
+				types.IntervalArray, types.RefCursor),
 		},
 		{
-			c:            tree.NewStrVal("{192.168.100.128, ::ffff:10.4.3.2}"),
-			parseOptions: typeSet(types.String, types.Bytes, types.BytesArray, types.StringArray, types.INetArray),
+			c: tree.NewStrVal("{192.168.100.128, ::ffff:10.4.3.2}"),
+			parseOptions: typeSet(types.String, types.Bytes, types.BytesArray, types.StringArray,
+				types.INetArray, types.RefCursor),
 		},
 		{
 			c: tree.NewStrVal("{0101, 11}"),
@@ -632,6 +656,7 @@ func TestStringConstantResolveAvailableTypes(t *testing.T) {
 				types.IntervalArray,
 				types.VarBitArray,
 				types.TSVector,
+				types.RefCursor,
 			),
 		},
 	}

--- a/pkg/sql/sem/tree/datum_alloc.go
+++ b/pkg/sql/sem/tree/datum_alloc.go
@@ -157,6 +157,11 @@ func (a *DatumAlloc) NewDName(v DString) Datum {
 	return NewDNameFromDString(a.NewDString(v))
 }
 
+// NewDRefCursor allocates a DRefCursor.
+func (a *DatumAlloc) NewDRefCursor(v DString) Datum {
+	return NewDRefCursorFromDString(a.NewDString(v))
+}
+
 // NewDBytes allocates a DBytes.
 func (a *DatumAlloc) NewDBytes(v DBytes) *DBytes {
 	r := (*DBytes)(a.newString())

--- a/pkg/sql/sem/tree/parse_string.go
+++ b/pkg/sql/sem/tree/parse_string.go
@@ -69,6 +69,8 @@ func ParseAndRequireString(
 		d, err = ParseDIntervalWithTypeMetadata(intervalStyle(ctx), s, itm)
 	case types.PGLSNFamily:
 		d, err = ParseDPGLSN(s)
+	case types.RefCursorFamily:
+		d = NewDRefCursor(s)
 	case types.Box2DFamily:
 		d, err = ParseDBox2D(s)
 	case types.GeographyFamily:

--- a/pkg/sql/sem/tree/testutils.go
+++ b/pkg/sql/sem/tree/testutils.go
@@ -83,6 +83,8 @@ func SampleDatum(t *types.T) Datum {
 		return NewDOid(1009)
 	case types.PGLSNFamily:
 		return NewDPGLSN(0x1000000100)
+	case types.RefCursorFamily:
+		return NewDRefCursor("Wheezer")
 	case types.Box2DFamily:
 		b := geo.NewCartesianBoundingBox().AddPoint(1, 2).AddPoint(3, 4)
 		return NewDBox2D(*b)

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -941,6 +941,14 @@ func (expr *ComparisonExpr) TypeCheck(
 		return nil, err
 	}
 
+	// REFCURSOR does not support comparisons.
+	leftType, rightType := leftTyped.ResolvedType(), rightTyped.ResolvedType()
+	if leftType.Family() == types.RefCursorFamily || rightType.Family() == types.RefCursorFamily {
+		return nil, pgerror.Newf(pgcode.UndefinedFunction,
+			"unsupported comparison operator: <%s> %s <%s>", leftType, cmpOp, rightType,
+		)
+	}
+
 	if alwaysNull {
 		return DNull, nil
 	}
@@ -1463,6 +1471,12 @@ func (expr *IsNullExpr) TypeCheck(
 	if err != nil {
 		return nil, err
 	}
+	// REFCURSOR does not support comparisons.
+	if exprTyped.ResolvedType().Family() == types.RefCursorFamily {
+		return nil, pgerror.New(pgcode.UndefinedFunction,
+			"unsupported comparison operator: refcursor IS unknown",
+		)
+	}
 	expr.Expr = exprTyped
 	expr.typ = types.Bool
 	return expr, nil
@@ -1475,6 +1489,12 @@ func (expr *IsNotNullExpr) TypeCheck(
 	exprTyped, err := expr.Expr.TypeCheck(ctx, semaCtx, types.Any)
 	if err != nil {
 		return nil, err
+	}
+	// REFCURSOR does not support comparisons.
+	if exprTyped.ResolvedType().Family() == types.RefCursorFamily {
+		return nil, pgerror.New(pgcode.UndefinedFunction,
+			"unsupported comparison operator: refcursor IS NOT unknown",
+		)
 	}
 	expr.Expr = exprTyped
 	expr.typ = types.Bool

--- a/pkg/sql/types/oid.go
+++ b/pkg/sql/types/oid.go
@@ -174,6 +174,7 @@ var familyToOid = map[Family]oid.Oid{
 	CollatedStringFamily: oid.T_text,
 	OidFamily:            oid.T_oid,
 	PGLSNFamily:          oid.T_pg_lsn,
+	RefCursorFamily:      oid.T_refcursor,
 	UnknownFamily:        oid.T_unknown,
 	UuidFamily:           oid.T_uuid,
 	ArrayFamily:          oid.T_anyarray,

--- a/pkg/sql/types/types.proto
+++ b/pkg/sql/types/types.proto
@@ -396,6 +396,12 @@ enum Family {
     //   Oid      : T_pg_lsn
     PGLSNFamily = 30;
 
+    // RefCursorFamily is a type family for the refcursor type, which is the
+    // type representing PLpgSQL cursors.
+    //   Canonical: types.RefCursor
+    //   Oid      : T_refcursor
+    RefCursorFamily = 31;
+
     // AnyFamily is a special type family used during static analysis as a
     // wildcard type that matches any other type, including scalar, array, and
     // tuple types. Execution-time values should never have this type. As an

--- a/pkg/sql/types/types_test.go
+++ b/pkg/sql/types/types_test.go
@@ -364,6 +364,10 @@ func TestTypes(t *testing.T) {
 		{Oid, MakeScalar(OidFamily, oid.T_oid, 0, 0, emptyLocale)},
 		{RegClass, MakeScalar(OidFamily, oid.T_regclass, 0, 0, emptyLocale)},
 
+		{RefCursor, &T{InternalType: InternalType{
+			Family: RefCursorFamily, Oid: oid.T_refcursor, Locale: &emptyLocale}}},
+		{RefCursor, MakeScalar(RefCursorFamily, oid.T_refcursor, 0, 0, emptyLocale)},
+
 		// STRING
 		{MakeString(0), String},
 		{MakeString(0), &T{InternalType: InternalType{
@@ -392,10 +396,6 @@ func TestTypes(t *testing.T) {
 		{Name, &T{InternalType: InternalType{
 			Family: StringFamily, Oid: oid.T_name, Locale: &emptyLocale}}},
 		{Name, MakeScalar(StringFamily, oid.T_name, 0, 0, emptyLocale)},
-
-		{RefCursor, &T{InternalType: InternalType{
-			Family: StringFamily, Oid: oid.T_refcursor, Locale: &emptyLocale}}},
-		{RefCursor, MakeScalar(StringFamily, oid.T_refcursor, 0, 0, emptyLocale)},
 
 		// TIME
 		{Time, &T{InternalType: InternalType{
@@ -773,13 +773,15 @@ func TestMarshalCompat(t *testing.T) {
 		{Float, InternalType{Family: FloatFamily, Oid: oid.T_float8, Width: 64}},
 		{Float4, InternalType{Family: FloatFamily, Oid: oid.T_float4, Width: 32, VisibleType: visibleREAL}},
 
+		// REFCURSOR
+		{RefCursor, InternalType{Family: RefCursorFamily, Oid: oid.T_refcursor}},
+
 		// STRING
 		{MakeString(10), InternalType{Family: StringFamily, Oid: oid.T_text, Width: 10}},
 		{VarChar, InternalType{Family: StringFamily, Oid: oid.T_varchar, VisibleType: visibleVARCHAR}},
 		{MakeChar(10), InternalType{Family: StringFamily, Oid: oid.T_bpchar, Width: 10, VisibleType: visibleCHAR}},
 		{QChar, InternalType{Family: StringFamily, Oid: oid.T_char, Width: 1, VisibleType: visibleQCHAR}},
 		{Name, InternalType{Family: name, Oid: oid.T_name}},
-		{RefCursor, InternalType{Family: StringFamily, Oid: oid.T_refcursor}},
 	}
 
 	for _, tc := range testCases {
@@ -837,13 +839,15 @@ func TestUnmarshalCompat(t *testing.T) {
 		{InternalType{Family: IntFamily, Width: 20}, Int},
 		{InternalType{Family: IntFamily}, Int},
 
+		// REFCURSOR
+		{InternalType{Family: RefCursorFamily, Oid: oid.T_refcursor}, RefCursor},
+
 		// STRING
 		{InternalType{Family: StringFamily}, String},
 		{InternalType{Family: StringFamily, VisibleType: visibleVARCHAR}, VarChar},
 		{InternalType{Family: StringFamily, VisibleType: visibleVARCHAR, Width: 20}, MakeVarChar(20)},
 		{InternalType{Family: StringFamily, VisibleType: visibleCHAR}, typeBpChar},
 		{InternalType{Family: StringFamily, VisibleType: visibleQCHAR, Width: 1}, QChar},
-		{InternalType{Family: StringFamily, Oid: oid.T_refcursor}, RefCursor},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/util/parquet/decoders.go
+++ b/pkg/util/parquet/decoders.go
@@ -62,6 +62,12 @@ func (pglsnDecoder) decode(v int64) (tree.Datum, error) {
 	return tree.NewDPGLSN(lsn.LSN(v)), nil
 }
 
+type refcursorDecoder struct{}
+
+func (refcursorDecoder) decode(v parquet.ByteArray) (tree.Datum, error) {
+	return tree.NewDRefCursor(string(v)), nil
+}
+
 type int64Decoder struct{}
 
 func (int64Decoder) decode(v int64) (tree.Datum, error) {
@@ -288,6 +294,8 @@ func decoderFromFamilyAndType(typOid oid.Oid, family types.Family) (decoder, err
 		return box2DDecoder{}, nil
 	case types.PGLSNFamily:
 		return pglsnDecoder{}, nil
+	case types.RefCursorFamily:
+		return refcursorDecoder{}, nil
 	case types.GeographyFamily:
 		return geographyDecoder{}, nil
 	case types.GeometryFamily:
@@ -323,6 +331,7 @@ func init() {
 	var _, _ = int32Decoder{}.decode(0)
 	var _, _ = int64Decoder{}.decode(0)
 	var _, _ = pglsnDecoder{}.decode(0)
+	var _, _ = refcursorDecoder{}.decode(parquet.ByteArray{})
 	var _, _ = decimalDecoder{}.decode(parquet.ByteArray{})
 	var _, _ = timestampDecoder{}.decode(parquet.ByteArray{})
 	var _, _ = timestampTZDecoder{}.decode(parquet.ByteArray{})

--- a/pkg/util/parquet/schema.go
+++ b/pkg/util/parquet/schema.go
@@ -162,6 +162,15 @@ func makeColumn(colName string, typ *types.T, repetitions parquet.Repetition) (d
 		}
 		result.colWriter = scalarWriter(writePGLSN)
 		return result, nil
+	case types.RefCursorFamily:
+		result.node, err = schema.NewPrimitiveNodeLogical(colName,
+			repetitions, schema.StringLogicalType{}, parquet.Types.ByteArray,
+			defaultTypeLength, defaultSchemaFieldID)
+		if err != nil {
+			return datumColumn{}, err
+		}
+		result.colWriter = scalarWriter(writeString)
+		return result, nil
 	case types.DecimalFamily:
 		// According to PostgresSQL docs, scale or precision of 0 implies max
 		// precision and scale. This code assumes that CRDB matches this behavior.

--- a/pkg/util/parquet/testutils.go
+++ b/pkg/util/parquet/testutils.go
@@ -360,12 +360,13 @@ func decodeValuesIntoDatumsHelper(
 }
 
 func unwrapDatum(d tree.Datum) tree.Datum {
-	switch t := d.(type) {
-	case *tree.DOidWrapper:
-		return unwrapDatum(t.Wrapped)
-	default:
-		return d
+	if wrapper, ok := d.(*tree.DOidWrapper); ok {
+		// REFCURSOR is implemented using DOidWrapper.
+		if wrapper.Oid != oid.T_refcursor {
+			return unwrapDatum(wrapper.Wrapped)
+		}
 	}
+	return d
 }
 
 // ValidateDatum validates that the "contents" of the expected datum matches the

--- a/pkg/util/parquet/writer_test.go
+++ b/pkg/util/parquet/writer_test.go
@@ -493,6 +493,17 @@ func TestBasicDatums(t *testing.T) {
 				}, nil
 			},
 		},
+		{
+			name: "refcursor",
+			sch: &colSchema{
+				columnTypes: []*types.T{types.RefCursor, types.RefCursor, types.RefCursor},
+				columnNames: []string{"a", "b", "c"},
+			},
+			datums: func() ([][]tree.Datum, error) {
+				return [][]tree.Datum{
+					{tree.NewDRefCursor("a"), tree.NewDRefCursor(""), tree.DNull}}, nil
+			},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			datums, err := tc.datums()


### PR DESCRIPTION
#### plpgsql: prepare cursor name generation for REFCURSOR type family

This patch removes the case statement that checks whether a cursor
name is NULL before calling into `plpgsql_gen_cursor_name` because the
builtin already checks whether the argument is NULL, and `REFCURSOR`
will (correctly) not support comparisons after we add a new type family
for it. The return type for the call to `plpgsql_gen_cursor_name` is
also changed from `String` to `Refcursor`.

Informs #111560

Release note: None

#### tree: add REFCURSOR to the list of parsable string types

This patch adds the new `REFCURSOR` data type to the list of types that
a string constant can have. This will allow constant values to avoid
an explicit cast to `REFCURSOR` in cases when the context expects a
`REFCURSOR`, e.g. inserting into a `REFCURSOR` column or calling a
routine with a `REFCURSOR` parameter. Example:
```
CREATE FUNCTION f(curs REFCURSOR) RETURNS REFCURSOR AS $$
  SELECT curs;
$$ LANGUAGE SQL;

-- This cast was necessary before:
SELECT f('foo'::REFCURSOR);

-- Now this works:
SELECT f('foo');
```

Informs #111560

Release note: None

#### types: give REFCURSOR its own type family

Previously, REFCURSOR shared a type family with the string-like types.
However, since it can't be implicitly casted to and from string types in
all cases, it needs to have its own family (since types within a family
must be compatible). This patch adds the new `RefCursorFamily`, and
follows the example of the PG_LSN type in plumbing it throughout the
SQL layer.

Informs #111560

Release note: None

#### tree: disallow and test comparison operators for REFCURSOR

The `REFCURSOR` data type does not support comparisons apart from a
few edge cases like `'foo'::REFCURSOR IS NULL`. Example:
```
postgres=# SELECT 'foo'::REFCURSOR = 'foo'::REFCURSOR;
ERROR:  operator does not exist: refcursor = refcursor
```
The previous commit that added the `RefCursorFamily` type family already
effectively removed support for most comparisons; this commit also
prevents the `IS / IS DISTINCT FROM` variants from being used on a
`REFCURSOR` expression. Note that postgres supports a few cases with
`NULL` as mentioned above. However, this case seems unimportant, so I
leave it as a TODO for now.

This commit also adds tests for various comparisons involving `REFCURSOR`.

Informs #111560

Release note: None