### PR TITLE
mixedversion: replace LowestBinaryVersion with ClusterVersionAtLeast

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/BUILD.bazel
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/BUILD.bazel
@@ -33,6 +33,7 @@ go_library(
 go_test(
     name = "mixedversion_test",
     srcs = [
+        "helper_test.go",
         "mixedversion_test.go",
         "planner_test.go",
         "runner_test.go",
@@ -44,6 +45,7 @@ go_test(
         "//pkg/cmd/roachtest/option",
         "//pkg/cmd/roachtest/roachtestutil",
         "//pkg/cmd/roachtest/roachtestutil/clusterupgrade",
+        "//pkg/roachpb",
         "//pkg/roachprod/logger",
         "//pkg/roachprod/vm",
         "//pkg/util/version",

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/helper_test.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/helper_test.go
@@ -1,0 +1,93 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package mixedversion
+
+import (
+	"math/rand"
+	"sync/atomic"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClusterVersionAtLeast(t *testing.T) {
+	rng := rand.New(rand.NewSource(seed))
+
+	testCases := []struct {
+		name           string
+		currentVersion string
+		minVersion     string
+		expectedErr    string
+		expected       bool
+	}{
+		{
+			name:           "invalid minVersion",
+			currentVersion: "23.1",
+			minVersion:     "v23.1",
+			expectedErr:    `invalid version v23.1: strconv.ParseInt: parsing "v23": invalid syntax`,
+		},
+		{
+			name:           "cluster version is behind",
+			currentVersion: "22.2",
+			minVersion:     "23.1",
+			expected:       false,
+		},
+		{
+			name:           "cluster version is ahead",
+			currentVersion: "23.1",
+			minVersion:     "22.2",
+			expected:       true,
+		},
+		{
+			name:           "cluster version is equal to minVersion",
+			currentVersion: "23.1",
+			minVersion:     "23.1",
+			expected:       true,
+		},
+		{
+			name:           "cluster version is behind, internal version",
+			currentVersion: "22.1-82",
+			minVersion:     "23.1",
+			expected:       false,
+		},
+		{
+			name:           "cluster version is ahead, internal version",
+			currentVersion: "23.1-2",
+			minVersion:     "23.1",
+			expected:       true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			currentVersion, err := roachpb.ParseVersion(tc.currentVersion)
+			require.NoError(t, err)
+
+			var clusterVersions atomic.Value
+			clusterVersions.Store([]roachpb.Version{currentVersion})
+			runner := testTestRunner()
+			runner.clusterVersions = clusterVersions
+
+			h := runner.newHelper(ctx, nilLogger)
+			h.testContext = &Context{Finalizing: false} // do not attempt to query cluster version
+
+			supportedFeature, err := h.ClusterVersionAtLeast(rng, tc.minVersion)
+			if tc.expectedErr == "" {
+				require.NoError(t, err)
+				require.Equal(t, tc.expected, supportedFeature)
+			} else {
+				require.Error(t, err)
+				require.Equal(t, tc.expectedErr, err.Error())
+			}
+		})
+	}
+}


### PR DESCRIPTION
This removes the `LowestBinaryVersion` helper function and replaces it with a new `ClusterVersionAtLeast` function. This change shifts the focus from released binaries versions to cluster versions. At the end of the day, upgrade tests are much more concerned about cluster versions than binary versions, so orienting tests around that concept is both more intuitive and less error prone.

Epic: none

Release note: None