### PR TITLE
roachtest: remove direct references to cockroach.service from tests

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/BUILD.bazel
+++ b/pkg/cmd/roachtest/roachtestutil/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
         "disk_usage.go",
         "health_checker.go",
         "jaeger.go",
+        "utils.go",
         "validation_check.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil",

--- a/pkg/cmd/roachtest/roachtestutil/utils.go
+++ b/pkg/cmd/roachtest/roachtestutil/utils.go
@@ -1,0 +1,19 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package roachtestutil
+
+import "github.com/cockroachdb/cockroach/pkg/roachprod/install"
+
+// SystemInterfaceSystemdUnitName is a convenience function that
+// returns the systemd unit name for the system interface
+func SystemInterfaceSystemdUnitName() string {
+	return install.VirtualClusterLabel(install.SystemInterfaceName, 0)
+}

--- a/pkg/cmd/roachtest/tests/decommissionbench.go
+++ b/pkg/cmd/roachtest/tests/decommissionbench.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
@@ -940,8 +941,8 @@ func runSingleDecommission(
 		if err := h.c.RunE(
 			ctx, h.c.Node(target),
 			fmt.Sprintf("sudo bash -c 'echo \"259:0  %d\" > "+
-				"/sys/fs/cgroup/blkio/system.slice/cockroach.service/blkio.throttle.write_bps_device'",
-				100*(1<<20))); err != nil {
+				"/sys/fs/cgroup/blkio/system.slice/%s.service/blkio.throttle.write_bps_device'",
+				100*(1<<20), roachtestutil.SystemInterfaceSystemdUnitName())); err != nil {
 			return err
 		}
 		// Wait for some time after limiting write bandwidth in order to affect read amplification.

--- a/pkg/cmd/roachtest/tests/disk_full.go
+++ b/pkg/cmd/roachtest/tests/disk_full.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -117,9 +118,10 @@ func registerDiskFull(r registry.Registry) {
 					// propagated from roachprod, obscures the Cockroach
 					// exit code. There should still be a record of it
 					// in the systemd logs.
-					result, err := c.RunWithDetailsSingleNode(ctx, t.L(), c.Node(n),
-						`systemctl status cockroach.service | grep 'Main PID' | grep -oE '\((.+)\)'`,
-					)
+					result, err := c.RunWithDetailsSingleNode(ctx, t.L(), c.Node(n), fmt.Sprintf(
+						`systemctl status %s | grep 'Main PID' | grep -oE '\((.+)\)'`,
+						roachtestutil.SystemInterfaceSystemdUnitName(),
+					))
 					if err != nil {
 						t.Fatal(err)
 					}

--- a/pkg/cmd/roachtest/tests/disk_stall.go
+++ b/pkg/cmd/roachtest/tests/disk_stall.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
@@ -256,8 +257,8 @@ func getProcessExitMonotonic(
 func getProcessMonotonicTimestamp(
 	ctx context.Context, t test.Test, c cluster.Cluster, nodeID int, prop string,
 ) (time.Duration, bool) {
-	details, err := c.RunWithDetailsSingleNode(ctx, t.L(), c.Node(nodeID),
-		"systemctl show cockroach.service --property="+prop)
+	details, err := c.RunWithDetailsSingleNode(ctx, t.L(), c.Node(nodeID), fmt.Sprintf(
+		"systemctl show %s --property=%s", roachtestutil.SystemInterfaceSystemdUnitName(), prop))
 	require.NoError(t, err)
 	require.NoError(t, details.Err)
 	parts := strings.Split(details.Stdout, "=")


### PR DESCRIPTION
After #111064, we started naming the systemd unit for cockroach processes differently, since we now might have multiple cockroach processes in the same VM in the context of SQL server processes and cluster virtualization.

That change broke a few tests that directly referenced the `cockroach.service` unit. In this change, we create a util function that is reponsible for encapsulating that name and replace direct references to the systemd unit name with calls to this new function.

Fixes: #111902

Release note: None