### PR TITLE
mma: more normalization of constraints

### DIFF
--- a/pkg/kv/kvserver/allocator/mma/testdata/normalize_config
+++ b/pkg/kv/kvserver/allocator/mma/testdata/normalize_config
@@ -20,7 +20,8 @@ input:
 output:
  num-replicas=5 num-voters=3
  constraints:
-   :5
+   +region=a:3
+   :2
  voter-constraints:
    +region=a:3
 
@@ -114,7 +115,9 @@ output:
  constraints:
    +region=b:1
    +region=c:1
-   :3
+   +region=a,-zone=a1:1
+   +region=a,+zone=a1:1
+   :1
  voter-constraints:
    +region=a,+zone=a1:1
    +region=a,-zone=a1:1
@@ -144,7 +147,8 @@ output:
    +region=b:1
    +region=c:1
    +region=d:1
-   :2
+   +region=a,-zone=a1:1
+   +region=a,+zone=a1:1
  voter-constraints:
    +region=a,+zone=a1:1
    +region=a,-zone=a1:1
@@ -221,7 +225,8 @@ output:
    +region=c:1
    +region=d:1
    +region=e:1
-   :4
+   +region=f:2
+   :2
  voter-constraints:
    +region=f:2
    +region=e:1
@@ -263,7 +268,8 @@ output:
    +region=c:1
    +region=d:1
    +region=e:1
-   :4
+   +region=f:2
+   :2
  voter-constraints:
    +region=f:2
    +region=c:1
@@ -293,7 +299,9 @@ output:
  constraints:
    +region=b,+zone=b2:1
    +region=c,+zone=c2:1
-   :3
+   +region=a,-zone=a1:1
+   +region=b,+zone=b1:1
+   :1
  voter-constraints:
    +region=b,+zone=b1:1
    +region=a,-zone=a1:1
@@ -356,7 +364,7 @@ output:
    +region=b,+zone=b2:1
    +region=c,+zone=c2:1
    +region=d,+zone=d2:1
-   :1
+   +region=e:1
  voter-constraints:
    +region=e:1
    +region=c,+zone=c2:1
@@ -387,3 +395,62 @@ output:
    +region=a,+zone=a1:2
    +region=a,+zone=a2:2
    +region=a,+zone=a3:1
+
+# Config from #106559.
+normalize num-replicas=6 num-voters=5
+constraint num-replicas=1 +region=eu-west-1
+constraint num-replicas=1 +region=us-central-1
+constraint num-replicas=1 +region=us-east-1
+constraint num-replicas=1 +region=us-west-1
+voter-constraint num-replicas=2 +region=us-west-1
+voter-constraint num-replicas=2 +region=us-east-1
+----
+input:
+ num-replicas=6 num-voters=5
+ constraints:
+   +region=eu-west-1:1
+   +region=us-central-1:1
+   +region=us-east-1:1
+   +region=us-west-1:1
+ voter-constraints:
+   +region=us-west-1:2
+   +region=us-east-1:2
+output:
+ num-replicas=6 num-voters=5
+ constraints:
+   +region=eu-west-1:1
+   +region=us-central-1:1
+   +region=us-east-1:2
+   +region=us-west-1:2
+ voter-constraints:
+   +region=us-west-1:2
+   +region=us-east-1:2
+   +region=eu-west-1:1
+
+# Config from #122292. Note that the normalization over-specifies by adding a
+# voter constraint for +region=a:1. Based on the original configuration,
+# either +region=a:1 or +region=b:1 could be added, but we cannot express a
+# disjunction.
+normalize num-replicas=4 num-voters=3
+constraint num-replicas=1 +region=a
+constraint num-replicas=1 +region=b
+constraint num-replicas=1 +region=c
+voter-constraint num-replicas=2 +region=c
+----
+input:
+ num-replicas=4 num-voters=3
+ constraints:
+   +region=a:1
+   +region=b:1
+   +region=c:1
+ voter-constraints:
+   +region=c:2
+output:
+ num-replicas=4 num-voters=3
+ constraints:
+   +region=a:1
+   +region=b:1
+   +region=c:2
+ voter-constraints:
+   +region=c:2
+   +region=a:1

--- a/pkg/kv/kvserver/allocator/mma/testdata/range_analyzed_constraints
+++ b/pkg/kv/kvserver/allocator/mma/testdata/range_analyzed_constraints
@@ -11,7 +11,9 @@ voter-constraint num-replicas=1 +region=a -zone=a1
  constraints:
    +region=d,+zone=d2:1
    +region=c,+zone=c2:1
-   :3
+   +region=a,-zone=a1:1
+   +ssd,+region=b,+zone=b1:1
+   :1
  voter-constraints:
    +ssd,+region=b,+zone=b1:1
    +region=a,-zone=a1:1
@@ -32,8 +34,14 @@ constraints:
   +region=c,+zone=c2:1
     voters:
     non-voters:
-  :3
+  +region=a,-zone=a1:1
+    voters:
+    non-voters:
+  +ssd,+region=b,+zone=b1:1
     voters: 2
+    non-voters:
+  :1
+    voters:
     non-voters:
 voter-constraints:
   +ssd,+region=b,+zone=b1:1
@@ -64,8 +72,14 @@ constraints:
   +region=c,+zone=c2:1
     voters:
     non-voters:
-  :3
-    voters: 2 3
+  +region=a,-zone=a1:1
+    voters:
+    non-voters:
+  +ssd,+region=b,+zone=b1:1
+    voters: 2
+    non-voters:
+  :1
+    voters: 3
     non-voters:
 voter-constraints:
   +ssd,+region=b,+zone=b1:1
@@ -86,7 +100,7 @@ addingVoter
 	add: (+region=a,-zone=a1)
 voterToNonVoter
 addingNonVoter
-	add: (+region=d,+zone=d2) (+region=c,+zone=c2) ()
+	add: (+region=d,+zone=d2) (+region=c,+zone=c2) (+region=a,-zone=a1)
 roleSwap
 	err: expected enough voters and non-voters but have 2/3 voters and 0/2 non-voters
 toRemove
@@ -127,8 +141,14 @@ constraints:
   +region=c,+zone=c2:1
     voters:
     non-voters:
-  :3
-    voters: 2 3
+  +region=a,-zone=a1:1
+    voters:
+    non-voters:
+  +ssd,+region=b,+zone=b1:1
+    voters: 2
+    non-voters:
+  :1
+    voters: 3
     non-voters: 6
 voter-constraints:
   +ssd,+region=b,+zone=b1:1
@@ -201,8 +221,14 @@ constraints:
   +region=c,+zone=c2:1
     voters:
     non-voters:
-  :3
-    voters: 2 3 9 10
+  +region=a,-zone=a1:1
+    voters: 10
+    non-voters:
+  +ssd,+region=b,+zone=b1:1
+    voters: 2
+    non-voters:
+  :1
+    voters: 3 9
     non-voters: 6
 voter-constraints:
   +ssd,+region=b,+zone=b1:1
@@ -238,19 +264,19 @@ nonVoterUnsatisfied
 	remove: 5 8 6
 	add: (+region=c,+zone=c2)
 replaceVoterRebalance replace=2
-	err: expected only matched constraints but found under=1 match=0 over=2
+	err: expected only matched constraints but found under=1 match=2 over=2
 replaceVoterRebalance replace=3
-	err: expected only matched constraints but found under=1 match=0 over=2
+	err: expected only matched constraints but found under=1 match=2 over=2
 replaceVoterRebalance replace=9
-	err: expected only matched constraints but found under=1 match=0 over=2
+	err: expected only matched constraints but found under=1 match=2 over=2
 replaceVoterRebalance replace=10
-	err: expected only matched constraints but found under=1 match=0 over=2
+	err: expected only matched constraints but found under=1 match=2 over=2
 replaceNonVoterRebalance replace=5
-	err: expected only matched constraints but found under=1 match=0 over=2
+	err: expected only matched constraints but found under=1 match=2 over=2
 replaceNonVoterRebalance replace=6
-	err: expected only matched constraints but found under=1 match=0 over=2
+	err: expected only matched constraints but found under=1 match=2 over=2
 replaceNonVoterRebalance replace=8
-	err: expected only matched constraints but found under=1 match=0 over=2
+	err: expected only matched constraints but found under=1 match=2 over=2
 
 store store-id=11 attrs=flash locality-tiers=region=c,zone=c2 node-id=8
 ----
@@ -274,8 +300,14 @@ constraints:
   +region=c,+zone=c2:1
     voters:
     non-voters: 11
-  :3
-    voters: 2 10 3
+  +region=a,-zone=a1:1
+    voters: 10
+    non-voters:
+  +ssd,+region=b,+zone=b1:1
+    voters: 2
+    non-voters:
+  :1
+    voters: 3
     non-voters:
 voter-constraints:
   +ssd,+region=b,+zone=b1:1
@@ -333,9 +365,15 @@ constraints:
   +region=c,+zone=c2:1
     voters:
     non-voters: 11
-  :3
-    voters: 2 3
+  +region=a,-zone=a1:1
+    voters:
     non-voters: 10
+  +ssd,+region=b,+zone=b1:1
+    voters: 2
+    non-voters:
+  :1
+    voters: 3
+    non-voters:
 voter-constraints:
   +ssd,+region=b,+zone=b1:1
     voters: 2
@@ -396,9 +434,15 @@ constraints:
   +region=c,+zone=c2:1
     voters:
     non-voters: 11
-  :3
-    voters: 2 3
+  +region=a,-zone=a1:1
+    voters:
     non-voters: 10
+  +ssd,+region=b,+zone=b1:1
+    voters: 2
+    non-voters:
+  :1
+    voters: 3
+    non-voters:
 voter-constraints:
   +ssd,+region=b,+zone=b1:1
     voters: 2
@@ -458,8 +502,14 @@ constraints:
   +region=c,+zone=c2:1
     voters: 11
     non-voters:
-  :3
-    voters: 2 10 3
+  +region=a,-zone=a1:1
+    voters: 10
+    non-voters:
+  +ssd,+region=b,+zone=b1:1
+    voters: 2
+    non-voters:
+  :1
+    voters: 3
     non-voters:
 voter-constraints:
   +ssd,+region=b,+zone=b1:1

--- a/pkg/roachpb/span_config.proto
+++ b/pkg/roachpb/span_config.proto
@@ -175,6 +175,11 @@ message SpanConfig {
   //   themselves will not over-satisfy any ConstraintsConjunction in
   //   Constraints.
   //
+  // Additionally, we require that Constraints is not under-specified compared
+  // to VoterConstraints. That is, if there is a ConstraintsConjunction in
+  // VoterConstraints, there is a corresponding ConstraintsConjunction in
+  // Constraints that has NumReplicas at least that of VoterConstraints.
+  //
   // For existing clusters, these strictness requirements may not be met, so
   // internally the system tries to do a normalization to meet the strictness
   // requirement.


### PR DESCRIPTION
We now also do some normalization of constraints (in addition to voter constraints). This helps with a better choice of where to add a non-voter if the voter constraints are temporarily unsatisfiable. This was motivated by looking at the config in #106559 (though this is unrelated to the bug there).

Informs #103320

Epic: CRDB-25222

Release note: None