### PR TITLE
gcjob_test: use medium pool for RBE

### DIFF
--- a/pkg/sql/gcjob_test/BUILD.bazel
+++ b/pkg/sql/gcjob_test/BUILD.bazel
@@ -8,6 +8,7 @@ go_test(
         "main_test.go",
     ],
     args = ["-test.timeout=295s"],
+    exec_properties = {"Pool": "medium"},
     shard_count = 2,
     deps = [
         "//pkg/base",


### PR DESCRIPTION
Epic: CRDB-8308
Release note: None