### PR TITLE
kv: dequeue request from lock table wait-queues on scan error

### DIFF
--- a/pkg/kv/kvserver/concurrency/lock_table.go
+++ b/pkg/kv/kvserver/concurrency/lock_table.go
@@ -3785,6 +3785,9 @@ func (t *lockTableImpl) ScanAndEnqueue(req Request, guard lockTableGuard) (lockT
 
 	err := g.resumeScan(true /* notify */)
 	if err != nil {
+		// We're not returning the guard on this error path, so we need to
+		// release the guard in case it has already entered any wait-queues.
+		t.Dequeue(g)
 		return nil, kvpb.NewError(err)
 	}
 	if g.notRemovableLock != nil {

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/shared_locks
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/shared_locks
@@ -1137,10 +1137,7 @@ lock promotion from Shared to Exclusive is not allowed
 
 print
 ----
-num=2
- lock: "a"
-   queued locking requests:
-    active: false req: 58, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
+num=1
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
 

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/shared_locks
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/shared_locks
@@ -1071,6 +1071,79 @@ num=2
     active: true req: 53, strength: Shared, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 50
 
+# ------------------------------------------------------------------------------
+# Sub-test for lock promotion. When an initial call to ScanAndEnqueue returns an
+# error, the request is dequeued from any other wait-queues that it may have
+# entered.
+# ------------------------------------------------------------------------------
+
+clear
+----
+num=0
+
+new-request r=req56 txn=txn1 ts=10 spans=exclusive@a
+----
+
+scan r=req56
+----
+start-waiting: false
+
+acquire r=req56 k=a durability=u strength=exclusive
+----
+num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
+
+dequeue r=req56
+----
+num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
+
+new-request r=req57 txn=txn2 ts=10 spans=shared@b
+----
+
+scan r=req57
+----
+start-waiting: false
+
+acquire r=req57 k=b durability=u strength=shared
+----
+num=2
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
+ lock: "b"
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
+
+dequeue r=req57
+----
+num=2
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
+ lock: "b"
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
+
+# Mark txn1 as aborted so that the next two requests immediately acquire claims
+# on key "a" when scanning.
+pushed-txn-updated txn=txn1 status=aborted
+----
+
+new-request r=req58 txn=txn2 ts=10 spans=exclusive@a,c
+----
+
+scan r=req58
+----
+lock promotion from Shared to Exclusive is not allowed
+
+print
+----
+num=2
+ lock: "a"
+   queued locking requests:
+    active: false req: 58, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
+ lock: "b"
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
+
 # TODO(arul): (non-exhaustive list) of shared lock state transitions that aren't
 # currently supported (and we need to add support for):
 #


### PR DESCRIPTION
Informs #111352.
Informs #111530.
Informs #111564.
Informs #111893.

In 8205b437, we added a case to the lock table where a request's initial scan could throw an error. This was not being handled properly if the request had already entered any other lock wait-queues. In these cases, the request's entries in those wait-queues would be abandoned and the locks would get stuck. This commit fixes that issue by dequeuing the request from the lock table when throwing an error from ScanAndEnqueue.

This was one of the causes of the recent kvnemesis instability, but we believe that there is at least one other issue that is still causing timeouts.

Release note: None