### PR TITLE
Roachprod azure add machine

### DIFF
--- a/pkg/cmd/roachtest/cluster_test.go
+++ b/pkg/cmd/roachtest/cluster_test.go
@@ -332,9 +332,6 @@ func TestAWSMachineTypeNew(t *testing.T) {
 
 	_, _, err2 := spec.SelectAWSMachineTypeNew(16, spec.Low, false, vm.ArchAMD64)
 	require.Error(t, err2)
-
-	_, err3 := spec.SelectAzureMachineType(4, spec.High)
-	require.Error(t, err3)
 }
 
 // TODO(srosenberg): restore the change in https://github.com/cockroachdb/cockroach/pull/111140 after 23.2 branch cut.
@@ -427,6 +424,19 @@ func TestGCEMachineTypeNew(t *testing.T) {
 			require.Equal(t, tc.expectedArch, selectedArch)
 		})
 	}
+}
+
+func TestAzureMachineType(t *testing.T) {
+	m, err := spec.SelectAzureMachineType(8, spec.Auto, true)
+	require.NoError(t, err)
+	require.Equal(t, "Standard_D8_v3", m)
+
+	m, err2 := spec.SelectAzureMachineType(96, spec.Auto, false)
+	require.NoError(t, err2)
+	require.Equal(t, "Standard_D96s_v5", m)
+
+	_, err3 := spec.SelectAzureMachineType(4, spec.High, true)
+	require.Error(t, err3)
 }
 
 func TestCmdLogFileName(t *testing.T) {

--- a/pkg/cmd/roachtest/spec/cluster_spec.go
+++ b/pkg/cmd/roachtest/spec/cluster_spec.go
@@ -296,7 +296,7 @@ func (s *ClusterSpec) RoachprodOpts(
 			case GCE:
 				machineType, selectedArch = SelectGCEMachineType(s.CPUs, s.Mem, arch)
 			case Azure:
-				machineType, err = SelectAzureMachineType(s.CPUs, s.Mem)
+				machineType, err = SelectAzureMachineType(s.CPUs, s.Mem, s.PreferLocalSSD)
 			}
 
 			if err != nil {

--- a/pkg/cmd/roachtest/spec/machine_type.go
+++ b/pkg/cmd/roachtest/spec/machine_type.go
@@ -293,27 +293,32 @@ func SelectGCEMachineTypeNew(cpus int, mem MemPerCPU, arch vm.CPUArch) (string, 
 
 // SelectAzureMachineType selects a machine type given the desired number of CPUs and
 // memory per CPU ratio.
-func SelectAzureMachineType(cpus int, mem MemPerCPU) (string, error) {
+func SelectAzureMachineType(cpus int, mem MemPerCPU, ssd bool) (string, error) {
 	if mem != Auto && mem != Standard {
 		return "", errors.Newf("custom memory per CPU not implemented for Azure, memory ratio requested: %d", mem)
 	}
+	var premiumStorage string
+	// If not using Local SSD, the machine type must support premium/ultra storage.
+	if !ssd {
+		premiumStorage = "s"
+	}
 	switch {
 	case cpus <= 2:
-		return "Standard_D2_v3", nil
+		return fmt.Sprintf("Standard_D2%s_v3", premiumStorage), nil
 	case cpus <= 4:
-		return "Standard_D4_v3", nil
+		return fmt.Sprintf("Standard_D4%s_v3", premiumStorage), nil
 	case cpus <= 8:
-		return "Standard_D8_v3", nil
+		return fmt.Sprintf("Standard_D8%s_v3", premiumStorage), nil
 	case cpus <= 16:
-		return "Standard_D16_v3", nil
+		return fmt.Sprintf("Standard_D16%s_v3", premiumStorage), nil
 	case cpus <= 36:
-		return "Standard_D32_v3", nil
+		return fmt.Sprintf("Standard_D32%s_v3", premiumStorage), nil
 	case cpus <= 48:
-		return "Standard_D48_v3", nil
+		return fmt.Sprintf("Standard_D48%s_v3", premiumStorage), nil
 	case cpus <= 64:
-		return "Standard_D64_v3", nil
+		return fmt.Sprintf("Standard_D64%s_v3", premiumStorage), nil
 	case cpus <= 96:
-		return "Standard_D96_v5", nil
+		return fmt.Sprintf("Standard_D96%s_v5", premiumStorage), nil
 	default:
 		return "", errors.Newf("no azure machine type with %d cpus", cpus)
 	}

--- a/pkg/cmd/roachtest/spec/machine_type.go
+++ b/pkg/cmd/roachtest/spec/machine_type.go
@@ -312,6 +312,8 @@ func SelectAzureMachineType(cpus int, mem MemPerCPU) (string, error) {
 		return "Standard_D48_v3", nil
 	case cpus <= 64:
 		return "Standard_D64_v3", nil
+	case cpus <= 96:
+		return "Standard_D96_v5", nil
 	default:
 		return "", errors.Newf("no azure machine type with %d cpus", cpus)
 	}

--- a/pkg/cmd/roachtest/tests/asyncpg.go
+++ b/pkg/cmd/roachtest/tests/asyncpg.go
@@ -80,6 +80,12 @@ func registerAsyncpg(r registry.Registry) {
 		}
 
 		if err := repeatRunE(
+			ctx, t, c, node, "update apt-get", `sudo apt-get update`,
+		); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := repeatRunE(
 			ctx,
 			t,
 			c,

--- a/pkg/roachprod/vm/azure/flags.go
+++ b/pkg/roachprod/vm/azure/flags.go
@@ -31,9 +31,11 @@ type ProviderOpts struct {
 	DiskCaching     string
 }
 
+// These default locations support availability zones. At the time of
+// this comment, `westus` did not.
 var defaultLocations = []string{
 	"eastus",
-	"westus",
+	"westus2",
 	"westeurope",
 }
 


### PR DESCRIPTION
This PR makes several azure specific changes to roachtest and roachprod to support more roachtests.

- Add 96 cpu machine type
- Add `s` series machines for `premium/ultra` disks
- Firewall port configuration for more tests and refactor
- Set a default location from `west` to `west2` for AZ
- `apt-get update` for asyncpg

    
Epic: CC-25185
Release note: none
