### PR TITLE
kv: add conflicting txn_meta to error message

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
@@ -4657,6 +4657,7 @@ func TestRefreshFailureIncludesConflictingTxn(t *testing.T) {
 			} else {
 				require.NotNil(t, tErr.ConflictingTxn)
 				require.Equal(t, txn2.ID(), tErr.ConflictingTxn.ID)
+				require.Regexp(t, tErr.ConflictingTxn.String(), tErr)
 				require.Equal(t, int32(1), tErr.ConflictingTxn.CoordinatorNodeID)
 			}
 		})

--- a/pkg/kv/kvpb/errors.go
+++ b/pkg/kv/kvpb/errors.go
@@ -865,6 +865,9 @@ func (e *TransactionRetryError) SafeFormatError(p errors.Printer) (next error) {
 	} else if e.ExtraMsg != "" {
 		msg = redact.Sprintf(" - %s", e.ExtraMsg)
 	}
+	if e.ConflictingTxn != nil {
+		msg = redact.Sprintf(" %s - conflicting txn: meta={%s}", msg, e.ConflictingTxn.String())
+	}
 	p.Printf("TransactionRetryError: retry txn (%s%s)", redact.SafeString(TransactionRetryReason_name[int32(e.Reason)]), msg)
 	return nil
 }


### PR DESCRIPTION
This patch adds back the conflicting txn_meta to the error message printed out from a `TransactionRetryError` if available.

Fixes #110689.

Release note: None