### PR TITLE
roachtest: Add docs-infra-prs to files with docs dependencies

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -448,6 +448,20 @@
 /pkg/cmd/roachprod-microbench/ @cockroachdb/test-eng
 /pkg/cmd/roachprod-stress/   @cockroachdb/test-eng
 /pkg/cmd/roachtest/          @cockroachdb/test-eng
+/pkg/cmd/roachtest/tests/activerecord.go  @cockroachdb/test-eng @cockroachdb/docs-infra-prs
+/pkg/cmd/roachtest/tests/asyncpg.go       @cockroachdb/test-eng @cockroachdb/docs-infra-prs
+/pkg/cmd/roachtest/tests/django.go        @cockroachdb/test-eng @cockroachdb/docs-infra-prs
+/pkg/cmd/roachtest/tests/gopg.go	        @cockroachdb/test-eng @cockroachdb/docs-infra-prs
+/pkg/cmd/roachtest/tests/gorm.go	        @cockroachdb/test-eng @cockroachdb/docs-infra-prs
+/pkg/cmd/roachtest/tests/hibernate.go	    @cockroachdb/test-eng @cockroachdb/docs-infra-prs
+/pkg/cmd/roachtest/tests/knex.go	        @cockroachdb/test-eng @cockroachdb/docs-infra-prs
+/pkg/cmd/roachtest/tests/libpq.go	        @cockroachdb/test-eng @cockroachdb/docs-infra-prs
+/pkg/cmd/roachtest/tests/npgsql.go	      @cockroachdb/test-eng @cockroachdb/docs-infra-prs
+/pkg/cmd/roachtest/tests/pgjdbc.go	      @cockroachdb/test-eng @cockroachdb/docs-infra-prs
+/pkg/cmd/roachtest/tests/pgx.go	          @cockroachdb/test-eng @cockroachdb/docs-infra-prs
+/pkg/cmd/roachtest/tests/ruby_pg.go	      @cockroachdb/test-eng @cockroachdb/docs-infra-prs
+/pkg/cmd/roachtest/tests/sequelize.go	    @cockroachdb/test-eng @cockroachdb/docs-infra-prs
+/pkg/cmd/roachtest/tests/typeorm.go	      @cockroachdb/test-eng @cockroachdb/docs-infra-prs
 /pkg/cmd/label-merged-pr/    @cockroachdb/dev-inf
 # This isn't quite right, each file should ideally be owned
 # by a team (or at least most of them), namely the team that

--- a/pkg/cmd/roachtest/tests/activerecord.go
+++ b/pkg/cmd/roachtest/tests/activerecord.go
@@ -29,6 +29,9 @@ import (
 
 var activerecordResultRegex = regexp.MustCompile(`^(?P<test>[^\s]+#[^\s]+) = (?P<timing>\d+\.\d+ s) = (?P<result>.)$`)
 var railsReleaseTagRegex = regexp.MustCompile(`^v(?P<major>\d+)\.(?P<minor>\d+)\.(?P<point>\d+)\.?(?P<subpoint>\d*)$`)
+
+// WARNING: DO NOT MODIFY the name of the below constant/variable without approval from the docs team.
+// This is used by docs automation to produce a list of supported versions for ORM's.
 var supportedRailsVersion = "7.0.3"
 var activerecordAdapterVersion = "v7.0.2"
 

--- a/pkg/cmd/roachtest/tests/asyncpg.go
+++ b/pkg/cmd/roachtest/tests/asyncpg.go
@@ -30,6 +30,8 @@ PGPORT=26257 PGHOST=localhost PGUSER=root PGDATABASE=defaultdb python3 setup.py 
 
 var asyncpgReleaseTagRegex = regexp.MustCompile(`^(?P<major>v\d+)\.(?P<minor>\d+)\.(?P<point>\d+)$`)
 
+// WARNING: DO NOT MODIFY the name of the below constant/variable without approval from the docs team.
+// This is used by docs automation to produce a list of supported versions for ORM's.
 var asyncpgSupportedTag = "v0.24.0"
 
 func registerAsyncpg(r registry.Registry) {

--- a/pkg/cmd/roachtest/tests/django.go
+++ b/pkg/cmd/roachtest/tests/django.go
@@ -28,6 +28,8 @@ import (
 var djangoReleaseTagRegex = regexp.MustCompile(`^(?P<major>\d+)\.(?P<minor>\d+)(\.(?P<point>\d+))?$`)
 var djangoCockroachDBReleaseTagRegex = regexp.MustCompile(`^(?P<major>\d+)\.(?P<minor>\d+)$`)
 
+// WARNING: DO NOT MODIFY the name of the below constant/variable without approval from the docs team.
+// This is used by docs automation to produce a list of supported versions for ORM's.
 var djangoSupportedTag = "cockroach-4.1.x"
 var djangoCockroachDBSupportedTag = "4.1.*"
 

--- a/pkg/cmd/roachtest/tests/gopg.go
+++ b/pkg/cmd/roachtest/tests/gopg.go
@@ -30,6 +30,9 @@ import (
 
 // Currently, we're running a version like 'v9.0.1'.
 var gopgReleaseTagRegex = regexp.MustCompile(`^v(?P<major>\d+)(?:\.(?P<minor>\d+)(?:\.(?P<point>\d+))?)?$`)
+
+// WARNING: DO NOT MODIFY the name of the below constant/variable without approval from the docs team.
+// This is used by docs automation to produce a list of supported versions for ORM's.
 var gopgSupportedTag = "v10.9.0"
 
 // This test runs gopg full test suite against a single cockroach node.

--- a/pkg/cmd/roachtest/tests/gorm.go
+++ b/pkg/cmd/roachtest/tests/gorm.go
@@ -24,6 +24,9 @@ import (
 )
 
 var gormReleaseTag = regexp.MustCompile(`^v(?P<major>\d+)\.(?P<minor>\d+)\.(?P<point>\d+)$`)
+
+// WARNING: DO NOT MODIFY the name of the below constant/variable without approval from the docs team.
+// This is used by docs automation to produce a list of supported versions for ORM's.
 var gormSupportedTag = "v1.24.1"
 
 func registerGORM(r registry.Registry) {

--- a/pkg/cmd/roachtest/tests/hibernate.go
+++ b/pkg/cmd/roachtest/tests/hibernate.go
@@ -23,6 +23,9 @@ import (
 )
 
 var hibernateReleaseTagRegex = regexp.MustCompile(`^(?P<major>\d+)\.(?P<minor>\d+)\.(?P<point>\d+)$`)
+
+// WARNING: DO NOT MODIFY the name of the below constant/variable without approval from the docs team.
+// This is used by docs automation to produce a list of supported versions for ORM's.
 var supportedHibernateTag = "5.6.15"
 
 type hibernateOptions struct {

--- a/pkg/cmd/roachtest/tests/knex.go
+++ b/pkg/cmd/roachtest/tests/knex.go
@@ -22,6 +22,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// WARNING: DO NOT MODIFY the name of the below constant/variable without approval from the docs team.
+// This is used by docs automation to produce a list of supported versions for ORM's.
 const supportedKnexTag = "2.5.1"
 
 // This test runs one of knex's test suite against a single cockroach

--- a/pkg/cmd/roachtest/tests/libpq.go
+++ b/pkg/cmd/roachtest/tests/libpq.go
@@ -25,6 +25,9 @@ import (
 )
 
 var libPQReleaseTagRegex = regexp.MustCompile(`^v(?P<major>\d+)\.(?P<minor>\d+)\.(?P<point>\d+)$`)
+
+// WARNING: DO NOT MODIFY the name of the below constant/variable without approval from the docs team.
+// This is used by docs automation to produce a list of supported versions for ORM's.
 var libPQSupportedTag = "v1.10.5"
 
 func registerLibPQ(r registry.Registry) {

--- a/pkg/cmd/roachtest/tests/npgsql.go
+++ b/pkg/cmd/roachtest/tests/npgsql.go
@@ -25,6 +25,9 @@ import (
 )
 
 var npgsqlReleaseTagRegex = regexp.MustCompile(`^v(?P<major>\d+)\.(?P<minor>\d+)\.(?P<point>\d+)$`)
+
+// WARNING: DO NOT MODIFY the name of the below constant/variable without approval from the docs team.
+// This is used by docs automation to produce a list of supported versions for ORM's.
 var npgsqlSupportedTag = "v7.0.2"
 
 // This test runs npgsql's full test suite against a single cockroach node.

--- a/pkg/cmd/roachtest/tests/pgjdbc.go
+++ b/pkg/cmd/roachtest/tests/pgjdbc.go
@@ -23,6 +23,9 @@ import (
 )
 
 var pgjdbcReleaseTagRegex = regexp.MustCompile(`^REL(?P<major>\d+)\.(?P<minor>\d+)\.(?P<point>\d+)$`)
+
+// WARNING: DO NOT MODIFY the name of the below constant/variable without approval from the docs team.
+// This is used by docs automation to produce a list of supported versions for ORM's.
 var supportedPGJDBCTag = "REL42.3.3"
 
 // This test runs pgjdbc's full test suite against a single cockroach node.

--- a/pkg/cmd/roachtest/tests/pgx.go
+++ b/pkg/cmd/roachtest/tests/pgx.go
@@ -25,6 +25,9 @@ import (
 )
 
 var pgxReleaseTagRegex = regexp.MustCompile(`^v(?P<major>\d+)\.(?P<minor>\d+)\.(?P<point>\d+)$`)
+
+// WARNING: DO NOT MODIFY the name of the below constant/variable without approval from the docs team.
+// This is used by docs automation to produce a list of supported versions for ORM's.
 var supportedPGXTag = "v5.3.1"
 
 // This test runs pgx's full test suite against a single cockroach node.

--- a/pkg/cmd/roachtest/tests/ruby_pg.go
+++ b/pkg/cmd/roachtest/tests/ruby_pg.go
@@ -32,6 +32,9 @@ import (
 var rubyPGTestFailureRegex = regexp.MustCompile(`^rspec ./.*# .*`)
 var testFailureFilenameRegexp = regexp.MustCompile("^rspec .*.rb.*([0-9]|]) # ")
 var testSummaryRegexp = regexp.MustCompile("^([0-9]+) examples, [0-9]+ failures")
+
+// WARNING: DO NOT MODIFY the name of the below constant/variable without approval from the docs team.
+// This is used by docs automation to produce a list of supported versions for ORM's.
 var rubyPGVersion = "v1.3.5"
 
 // This test runs Ruby PG's full test suite against a single cockroach node.

--- a/pkg/cmd/roachtest/tests/sequelize.go
+++ b/pkg/cmd/roachtest/tests/sequelize.go
@@ -23,6 +23,9 @@ import (
 )
 
 var sequelizeCockroachDBReleaseTagRegex = regexp.MustCompile(`^v(?P<major>\d+)\.(?P<minor>\d+)\.(?P<point>\d+)$`)
+
+// WARNING: DO NOT MODIFY the name of the below constant/variable without approval from the docs team.
+// This is used by docs automation to produce a list of supported versions for ORM's.
 var supportedSequelizeCockroachDBRelease = "v6.0.5"
 
 // This test runs sequelize's full test suite against a single cockroach node.

--- a/pkg/cmd/roachtest/tests/typeorm.go
+++ b/pkg/cmd/roachtest/tests/typeorm.go
@@ -27,6 +27,8 @@ import (
 var typeORMReleaseTagRegex = regexp.MustCompile(`^(?P<major>\d+)\.(?P<minor>\d+)\.(?P<point>\d+)$`)
 
 // Use 0.3.18 from the upstream repo once it is released.
+// WARNING: DO NOT MODIFY the name of the below constant/variable without approval from the docs team.
+// This is used by docs automation to produce a list of supported versions for ORM's.
 const supportedTypeORMRelease = "remove-unsafe-crdb-setting"
 const typeORMRepo = "https://github.com/rafiss/typeorm.git"
 


### PR DESCRIPTION
Docs builds were breaking in quick succession, because a variable that once existed in a roachtest file was removed without notice. This PR adds docs-infra-prs as codeowners for the files that the docs team directly consumes within the docs repo and adds a comment on each line upon which the docs relies.

Fixes DOC-9017

Release note: None