### PR TITLE
build: update roachtest scripts to use --suite instead of tags

### DIFF
--- a/build/teamcity/cockroach/coverage/roachtest_nightly_gce_impl.sh
+++ b/build/teamcity/cockroach/coverage/roachtest_nightly_gce_impl.sh
@@ -19,10 +19,9 @@ echo "$GOOGLE_EPHEMERAL_CREDENTIALS" > creds.json
 gcloud auth activate-service-account --key-file=creds.json
 export ROACHPROD_USER=teamcity
 
-# See build/teamcity/util/roachtest_util.sh.
+# Values taken from build/teamcity/util/roachtest_util.sh.
 PARALLELISM=16
 CPUQUOTA=1024
-FILTER="tag:aws tag:default"
 
 build/teamcity-roachtest-invoke.sh \
   --metamorphic-encryption-probability=0.5 \
@@ -36,4 +35,5 @@ build/teamcity-roachtest-invoke.sh \
   --artifacts-literal="${LITERAL_ARTIFACTS_DIR:-}" \
   --slack-token="${SLACK_TOKEN:-}" \
   --go-cover \
-  ${TESTS:-} ${FILTER}
+  --suite nightly \
+  ${TESTS:-}

--- a/build/teamcity/cockroach/nightlies/pebble_nightly_write_throughput_impl.sh
+++ b/build/teamcity/cockroach/nightlies/pebble_nightly_write_throughput_impl.sh
@@ -25,7 +25,8 @@ timeout -s INT 12h bin/roachtest run \
   --parallelism 2 \
   --teamcity \
   --cpu-quota=384 \
-  pebble tag:pebble_nightly_write
+  --suite pebble_nightly_write \
+  pebble
 
 exit_status=$?
 

--- a/build/teamcity/cockroach/nightlies/pebble_nightly_ycsb_impl.sh
+++ b/build/teamcity/cockroach/nightlies/pebble_nightly_ycsb_impl.sh
@@ -24,7 +24,8 @@ timeout -s INT $((1000*60)) bin/roachtest run \
   --parallelism 3 \
   --teamcity \
   --cpu-quota=384 \
-  pebble tag:pebble_nightly_ycsb
+  --suite pebble_nightly_ycsb \
+  pebble
 
 exit_status=$?
 

--- a/build/teamcity/cockroach/nightlies/pebble_nightly_ycsb_race_impl.sh
+++ b/build/teamcity/cockroach/nightlies/pebble_nightly_ycsb_race_impl.sh
@@ -24,7 +24,8 @@ timeout -s INT $((1000*60)) bin/roachtest run \
   --parallelism 3 \
   --teamcity \
   --cpu-quota=384 \
-  pebble tag:pebble_nightly_ycsb_race
+  --suite pebble_nightly_ycsb_race \
+  pebble
 
 exit_status=$?
 

--- a/build/teamcity/cockroach/nightlies/roachtest_nightly_impl.sh
+++ b/build/teamcity/cockroach/nightlies/roachtest_nightly_impl.sh
@@ -30,4 +30,5 @@ build/teamcity-roachtest-invoke.sh \
   --artifacts=/artifacts \
   --artifacts-literal="${LITERAL_ARTIFACTS_DIR:-}" \
   --slack-token="${SLACK_TOKEN}" \
-  "${TESTS}" ${FILTER}
+  --suite nightly \
+  "${TESTS}"

--- a/build/teamcity/cockroach/nightlies/roachtest_weekly_aws_impl.sh
+++ b/build/teamcity/cockroach/nightlies/roachtest_weekly_aws_impl.sh
@@ -20,7 +20,7 @@ artifacts=/artifacts
 source $root/build/teamcity/util/roachtest_util.sh
 
 build/teamcity-roachtest-invoke.sh \
-  tag:aws-weekly \
+  --suite weekly \
   --cloud="${CLOUD}" \
   --cluster-id "${TC_BUILD_ID}" \
   --artifacts=/artifacts \

--- a/build/teamcity/cockroach/nightlies/roachtest_weekly_impl.sh
+++ b/build/teamcity/cockroach/nightlies/roachtest_weekly_impl.sh
@@ -32,7 +32,7 @@ source $root/build/teamcity/util/roachtest_util.sh
 # NB(3): If you make changes here, you should probably make the same change in
 # build/teamcity-weekly-roachtest.sh
 timeout -s INT $((7800*60)) build/teamcity-roachtest-invoke.sh \
-  tag:weekly \
+  --suite:weekly \
   --cluster-id "${TC_BUILD_ID}" \
   --zones "us-central1-b,us-west1-b,europe-west2-b" \
   --artifacts=/artifacts \

--- a/build/teamcity/internal/release/process/roachtest-release-qualification.sh
+++ b/build/teamcity/internal/release/process/roachtest-release-qualification.sh
@@ -55,7 +55,7 @@ EOF
 # by default. This reserves us-east1-b (the roachprod default zone) for use
 # by manually created clusters.
 timeout -s INT $((7800*60)) bin/roachtest run \
-  tag:release_qualification \
+  --suite release_qualification \
   --cluster-id "${TC_BUILD_ID}" \
   --zones "us-central1-b,us-west1-b,europe-west2-b" \
   --cockroach "$PWD/cockroach" \

--- a/build/teamcity/util/roachtest_util.sh
+++ b/build/teamcity/util/roachtest_util.sh
@@ -61,30 +61,3 @@ trap upload_stats EXIT
 PARALLELISM=16
 CPUQUOTA=1024
 TESTS="${TESTS-}"
-FILTER="${FILTER-}"
-case "${CLOUD}" in
-  gce)
-      # Confusing due to how we've handled tags in the past where it has been assumed that all tests should
-      # be run on GCE. Now with refactoring of how tags are handled, we need:
-      # - "default" to ensure we select tests that don't have any user specified tags (preserve old behavior)
-      # - "aws" to ensure we select tests that now no longer have "default" because they have the "aws" tag
-      # Ideally, refactor the tags themselves to be explicit about what cloud they are for and when they can run.
-      # https://github.com/cockroachdb/cockroach/issues/100605
-      FILTER="tag:aws tag:default tag:azure"
-    ;;
-  aws)
-    if [ -z "${FILTER}" ]; then
-      FILTER="tag:aws"
-    fi
-    ;;
-  azure)
-    if [ -z "${FILTER}" ]; then
-      # Soon to go away with Radu's tag changes.
-      FILTER="tag:azure"
-    fi
-    ;;
-  *)
-    echo "unknown cloud ${CLOUD}"
-    exit 1
-    ;;
-esac

--- a/pkg/cmd/roachtest/tests/fixtures.go
+++ b/pkg/cmd/roachtest/tests/fixtures.go
@@ -44,7 +44,8 @@ func registerFixtures(r registry.Registry) {
 	// this.
 	//
 	// Example invocation:
-	// FIXTURE_VERSION=v20.2.0-beta.1 roachtest --local run generate-fixtures --debug --cockroach ./cockroach tag:fixtures
+	//   FIXTURE_VERSION=v20.2.0-beta.1 roachtest --local run generate-fixtures \
+	//     --debug --cockroach ./cockroach --suite fixtures
 	runFixtures := func(
 		ctx context.Context,
 		t test.Test,


### PR DESCRIPTION
There is one more use (`tag:release_qualification`) inside the Release
Qualification script in TeamCity.

Note that we will not remove tag support until the new flags are
backported on all relevant branches, and even after that we will
provide some basic backward compatibility (e.g. convert a single tag
to a suite).

Epic: none
Release note: None