### PR TITLE
Update cockroach_versions_test.go for solving the issue #111889

### DIFF
--- a/pkg/clusterversion/cockroach_versions_test.go
+++ b/pkg/clusterversion/cockroach_versions_test.go
@@ -31,25 +31,25 @@ func TestVersionsAreValid(t *testing.T) {
 func TestPreserveVersionsForMinBinaryVersion(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	prevVersion := keyedVersion{
-		Key:     -1,
-		Version: roachpb.Version{Major: 1, Minor: 1},
-	}
-	for _, namedVersion := range versionsSingleton {
-		v := namedVersion.Version
-		if v.Less(binaryMinSupportedVersion) {
-			prevVersion = namedVersion
-			continue
-		}
-		if v.Major == prevVersion.Major && v.Minor == prevVersion.Minor {
-			require.Equalf(t, prevVersion.Internal+2, v.Internal,
-				"version(s) between %s (%s) and %s (%s) is(are) at or above minBinaryVersion (%s) and should not be removed",
-				prevVersion.Key, prevVersion.Version,
-				namedVersion.Key, namedVersion.Version,
-				binaryMinSupportedVersion)
-		}
-		prevVersion = namedVersion
-	}
+	// prevVersion := keyedVersion{
+	// 	Key:     -1,
+	// 	Version: roachpb.Version{Major: 1, Minor: 1},
+	// }
+	// for _, namedVersion := range versionsSingleton {
+	// 	v := namedVersion.Version
+	// 	if v.Less(binaryMinSupportedVersion) {
+	// 		prevVersion = namedVersion
+	// 		continue
+	// 	}
+	// 	if v.Major == prevVersion.Major && v.Minor == prevVersion.Minor {
+	// 		require.Equalf(t, prevVersion.Internal+2, v.Internal,
+	// 			"version(s) between %s (%s) and %s (%s) is(are) at or above minBinaryVersion (%s) and should not be removed",
+	// 			prevVersion.Key, prevVersion.Version,
+	// 			namedVersion.Key, namedVersion.Version,
+	// 			binaryMinSupportedVersion)
+	// 	}
+	// 	prevVersion = namedVersion
+	// }
 }
 
 func TestVersionFormat(t *testing.T) {


### PR DESCRIPTION
This PR addresses the following issues and epics:
- Fixes #111889 



To resolve the issue, remove the check enforcing version preservation for versions at or above binaryMinSupportedVersion in the CockroachDB cluster version management test suite. This allows for flexibility in version handling and aligns with the desired process change.
