### PR TITLE
sql: fix ALTER DEFAULT PRIVILEGES for procedures

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/procedure_privileges
+++ b/pkg/sql/logictest/testdata/logic_test/procedure_privileges
@@ -377,160 +377,218 @@ DROP USER test_user;
 
 subtest end
 
-# TODO(mgartner): Add ALTER DEFAULT PRIVILEGES tests. These tests have been
-# copied from udf_privileges as a starting place.
-# subtest default_privileges
-#
-# statement ok
-# CREATE USER test_user;
-# CREATE FUNCTION test_priv_p1() RETURNS INT LANGUAGE SQL AS $$ SELECT 1 $$;
-#
-# query TTTTTTTTTT colnames
-# SELECT * FROM information_schema.role_routine_grants
-# WHERE routine_name IN ('test_priv_p1', 'test_priv_p2', 'test_priv_p3')
-# ORDER BY grantee, routine_name;
-# ----
-#
-# query TTTTTTB colnames,rowsort
-# SHOW GRANTS ON FUNCTION test_priv_p1
-# ----
-#
-# # Add default privilege and make sure new function
-# statement ok
-# ALTER DEFAULT PRIVILEGES IN SCHEMA public, test_priv_sc1 GRANT EXECUTE ON FUNCTIONS TO test_user WITH GRANT OPTION;
-#
-# statement ok
-# CREATE FUNCTION test_priv_p2(int) RETURNS INT LANGUAGE SQL AS $$ SELECT 1 $$;
-# CREATE FUNCTION test_priv_sc1.test_priv_p3() RETURNS INT LANGUAGE SQL AS $$ SELECT 1 $$;
-#
-# query TTTTTTTTTT colnames
-# SELECT * FROM information_schema.role_routine_grants
-# WHERE routine_name IN ('test_priv_p1', 'test_priv_p2', 'test_priv_p3')
-# ORDER BY grantee, routine_name;
-# ----
-#
-# query TTTTTTB colnames,rowsort
-# SHOW GRANTS ON FUNCTION test_priv_p1, test_priv_p2, test_priv_p3
-# ----
-#
-# statement ok
-# DROP FUNCTION test_priv_p2;
-# DROP FUNCTION test_priv_sc1.test_priv_p3;
-#
-# query TTTTTTTTTT colnames
-# SELECT * FROM information_schema.role_routine_grants
-# WHERE routine_name IN ('test_priv_p1', 'test_priv_p2', 'test_priv_p3')
-# ORDER BY grantee, routine_name;
-# ----
-#
-# query TTTTTTB colnames,rowsort
-# SHOW GRANTS ON FUNCTION test_priv_p1
-# ----
-# database_name  schema_name  function_id  function_signature  grantee  privilege_type  is_grantable
-# test           public       100110       test_priv_p1()      admin    ALL             true
-# test           public       100110       test_priv_p1()      public   EXECUTE         false
-# test           public       100110       test_priv_p1()      root     ALL             true
-#
-# statement ok
-# ALTER DEFAULT PRIVILEGES IN SCHEMA public, test_priv_sc1 REVOKE EXECUTE ON FUNCTIONS FROM test_user;
-#
-# statement ok
-# CREATE FUNCTION test_priv_p2(int) RETURNS INT LANGUAGE SQL AS $$ SELECT 1 $$;
-# CREATE FUNCTION test_priv_sc1.test_priv_p3() RETURNS INT LANGUAGE SQL AS $$ SELECT 1 $$;
-#
-# query TTTTTTTTTT colnames
-# SELECT * FROM information_schema.role_routine_grants
-# WHERE routine_name IN ('test_priv_p1', 'test_priv_p2', 'test_priv_p3')
-# ORDER BY grantee, routine_name;
-# ----
-#
-# query TTTTTTB colnames,rowsort
-# SHOW GRANTS ON FUNCTION test_priv_p1, test_priv_p2, test_priv_p3
-# ----
-#
-# # Make sure has_function_privilege works.
-# query B
-# SELECT has_function_privilege('test_priv_p2(INT)', 'EXECUTE')
-# ----
-# true
-#
-# query B
-# SELECT has_function_privilege('test_priv_p2(INT)', 'EXECUTE WITH GRANT OPTION')
-# ----
-# true
-#
-# query B
-# SELECT has_function_privilege('test_priv_p2(INT)', 'EXECUTE, EXECUTE WITH GRANT OPTION')
-# ----
-# true
-#
-# user testuser
-#
-# query B
-# SELECT has_function_privilege('test_priv_p2(INT)', 'EXECUTE')
-# ----
-# true
-#
-# query B
-# SELECT has_function_privilege('test_priv_p2(INT)', 'EXECUTE WITH GRANT OPTION')
-# ----
-# false
-#
-# query B
-# SELECT has_function_privilege('test_priv_p2(INT)', 'EXECUTE, EXECUTE WITH GRANT OPTION')
-# ----
-# true
-#
-# user root
-#
-# statement ok
-# GRANT EXECUTE ON FUNCTION test_priv_p1(), test_priv_p2(int), test_priv_sc1.test_priv_p3 TO testuser WITH GRANT OPTION;
-#
-# user testuser
-#
-# query B retry
-# SELECT has_function_privilege('test_priv_p2(INT)', 'EXECUTE')
-# ----
-# true
-#
-# query B
-# SELECT has_function_privilege('test_priv_p2(INT)', 'EXECUTE WITH GRANT OPTION')
-# ----
-# true
-#
-# query B
-# SELECT has_function_privilege('test_priv_p2(INT)', 'EXECUTE, EXECUTE WITH GRANT OPTION')
-# ----
-# true
-#
-# user root
-#
-# statement ok
-# REVOKE GRANT OPTION FOR EXECUTE ON FUNCTION test_priv_p1(), test_priv_p2(int), test_priv_sc1.test_priv_p3 FROM testuser;
-#
-# user testuser
-#
-# query B retry
-# SELECT has_function_privilege('test_priv_p2(INT)', 'EXECUTE WITH GRANT OPTION')
-# ----
-# false
-#
-# query B
-# SELECT has_function_privilege('test_priv_p2(INT)', 'EXECUTE')
-# ----
-# true
-#
-# query B
-# SELECT has_function_privilege('test_priv_p2(INT)', 'EXECUTE, EXECUTE WITH GRANT OPTION')
-# ----
-# true
-#
-# user root
-#
-# statement ok
-# SET search_path = public;
-#
-# subtest end
+subtest default_privileges
+
+statement ok
+CREATE USER test_user;
+CREATE PROCEDURE test_priv_p1() LANGUAGE SQL AS $$ SELECT 1 $$;
+
+query TTTTTTTTTT colnames
+SELECT * FROM information_schema.role_routine_grants
+WHERE routine_name IN ('test_priv_p1', 'test_priv_p2', 'test_priv_p3')
+ORDER BY grantee, routine_name;
+----
+grantor  grantee  specific_catalog  specific_schema  specific_name        routine_catalog  routine_schema  routine_name  privilege_type  is_grantable
+NULL     admin    test              public           test_priv_p1_100110  test             public          test_priv_p1  ALL             YES
+NULL     public   test              public           test_priv_p1_100110  test             public          test_priv_p1  EXECUTE         NO
+NULL     root     test              public           test_priv_p1_100110  test             public          test_priv_p1  ALL             YES
+
+query TTTTTTB colnames,rowsort
+SHOW GRANTS ON PROCEDURE test_priv_p1
+----
+database_name  schema_name  routine_id  routine_signature  grantee  privilege_type  is_grantable
+test           public       100110      test_priv_p1()     admin    ALL             true
+test           public       100110      test_priv_p1()     public   EXECUTE         false
+test           public       100110      test_priv_p1()     root     ALL             true
+
+# Add default privilege and make sure it apples only to newly created
+# procedures.
+# NOTE: We use GRANT EXECUTE ON FUNCTIONS here because GRANT EXECUTE ON
+# PROCEDURES is not supported. "FUNCTIONS" applies to procedures too. This
+# matches Postgres behavior.
+statement ok
+ALTER DEFAULT PRIVILEGES IN SCHEMA public, test_priv_sc1 GRANT EXECUTE ON FUNCTIONS TO test_user WITH GRANT OPTION;
+
+statement ok
+CREATE PROCEDURE test_priv_p2(int) LANGUAGE SQL AS $$ SELECT 1 $$;
+CREATE PROCEDURE test_priv_sc1.test_priv_p3() LANGUAGE SQL AS $$ SELECT 1 $$;
+
+query TTTTTTTTTT colnames
+SELECT * FROM information_schema.role_routine_grants
+WHERE routine_name IN ('test_priv_p1', 'test_priv_p2', 'test_priv_p3')
+ORDER BY grantee, routine_name;
+----
+grantor  grantee    specific_catalog  specific_schema  specific_name        routine_catalog  routine_schema  routine_name  privilege_type  is_grantable
+NULL     admin      test              public           test_priv_p1_100110  test             public          test_priv_p1  ALL             YES
+NULL     admin      test              public           test_priv_p2_100111  test             public          test_priv_p2  ALL             YES
+NULL     admin      test              test_priv_sc1    test_priv_p3_100112  test             test_priv_sc1   test_priv_p3  ALL             YES
+NULL     public     test              public           test_priv_p1_100110  test             public          test_priv_p1  EXECUTE         NO
+NULL     public     test              public           test_priv_p2_100111  test             public          test_priv_p2  EXECUTE         NO
+NULL     public     test              test_priv_sc1    test_priv_p3_100112  test             test_priv_sc1   test_priv_p3  EXECUTE         NO
+NULL     root       test              public           test_priv_p1_100110  test             public          test_priv_p1  ALL             YES
+NULL     root       test              public           test_priv_p2_100111  test             public          test_priv_p2  ALL             YES
+NULL     root       test              test_priv_sc1    test_priv_p3_100112  test             test_priv_sc1   test_priv_p3  ALL             YES
+NULL     test_user  test              public           test_priv_p2_100111  test             public          test_priv_p2  EXECUTE         YES
+NULL     test_user  test              test_priv_sc1    test_priv_p3_100112  test             test_priv_sc1   test_priv_p3  EXECUTE         YES
+
+query TTTTTTB colnames,rowsort
+SHOW GRANTS ON PROCEDURE test_priv_p1, test_priv_p2, test_priv_p3
+----
+database_name  schema_name    routine_id  routine_signature   grantee    privilege_type  is_grantable
+test           public         100110      test_priv_p1()      admin      ALL             true
+test           public         100110      test_priv_p1()      public     EXECUTE         false
+test           public         100110      test_priv_p1()      root       ALL             true
+test           public         100111      test_priv_p2(int8)  admin      ALL             true
+test           public         100111      test_priv_p2(int8)  public     EXECUTE         false
+test           public         100111      test_priv_p2(int8)  root       ALL             true
+test           public         100111      test_priv_p2(int8)  test_user  EXECUTE         true
+test           test_priv_sc1  100112      test_priv_p3()      admin      ALL             true
+test           test_priv_sc1  100112      test_priv_p3()      public     EXECUTE         false
+test           test_priv_sc1  100112      test_priv_p3()      root       ALL             true
+test           test_priv_sc1  100112      test_priv_p3()      test_user  EXECUTE         true
+
+statement ok
+DROP PROCEDURE test_priv_p2;
+DROP PROCEDURE test_priv_sc1.test_priv_p3;
+
+query TTTTTTTTTT colnames
+SELECT * FROM information_schema.role_routine_grants
+WHERE routine_name IN ('test_priv_p1', 'test_priv_p2', 'test_priv_p3')
+ORDER BY grantee, routine_name;
+----
+grantor  grantee  specific_catalog  specific_schema  specific_name        routine_catalog  routine_schema  routine_name  privilege_type  is_grantable
+NULL     admin    test              public           test_priv_p1_100110  test             public          test_priv_p1  ALL             YES
+NULL     public   test              public           test_priv_p1_100110  test             public          test_priv_p1  EXECUTE         NO
+NULL     root     test              public           test_priv_p1_100110  test             public          test_priv_p1  ALL             YES
+
+query TTTTTTB colnames,rowsort
+SHOW GRANTS ON PROCEDURE test_priv_p1
+----
+database_name  schema_name  routine_id  routine_signature  grantee  privilege_type  is_grantable
+test           public       100110      test_priv_p1()     admin    ALL             true
+test           public       100110      test_priv_p1()     public   EXECUTE         false
+test           public       100110      test_priv_p1()     root     ALL             true
+
+statement ok
+ALTER DEFAULT PRIVILEGES IN SCHEMA public, test_priv_sc1 REVOKE EXECUTE ON FUNCTIONS FROM test_user;
+
+statement ok
+CREATE PROCEDURE test_priv_p2(int) LANGUAGE SQL AS $$ SELECT 1 $$;
+CREATE PROCEDURE test_priv_sc1.test_priv_p3() LANGUAGE SQL AS $$ SELECT 1 $$;
+
+query TTTTTTTTTT colnames
+SELECT * FROM information_schema.role_routine_grants
+WHERE routine_name IN ('test_priv_p1', 'test_priv_p2', 'test_priv_p3')
+ORDER BY grantee, routine_name;
+----
+grantor  grantee  specific_catalog  specific_schema  specific_name        routine_catalog  routine_schema  routine_name  privilege_type  is_grantable
+NULL     admin    test              public           test_priv_p1_100110  test             public          test_priv_p1  ALL             YES
+NULL     admin    test              public           test_priv_p2_100113  test             public          test_priv_p2  ALL             YES
+NULL     admin    test              test_priv_sc1    test_priv_p3_100114  test             test_priv_sc1   test_priv_p3  ALL             YES
+NULL     public   test              public           test_priv_p1_100110  test             public          test_priv_p1  EXECUTE         NO
+NULL     public   test              public           test_priv_p2_100113  test             public          test_priv_p2  EXECUTE         NO
+NULL     public   test              test_priv_sc1    test_priv_p3_100114  test             test_priv_sc1   test_priv_p3  EXECUTE         NO
+NULL     root     test              public           test_priv_p1_100110  test             public          test_priv_p1  ALL             YES
+NULL     root     test              public           test_priv_p2_100113  test             public          test_priv_p2  ALL             YES
+NULL     root     test              test_priv_sc1    test_priv_p3_100114  test             test_priv_sc1   test_priv_p3  ALL             YES
+
+query TTTTTTB colnames,rowsort
+SHOW GRANTS ON PROCEDURE test_priv_p1, test_priv_p2, test_priv_p3
+----
+database_name  schema_name    routine_id  routine_signature   grantee  privilege_type  is_grantable
+test           public         100110      test_priv_p1()      admin    ALL             true
+test           public         100110      test_priv_p1()      public   EXECUTE         false
+test           public         100110      test_priv_p1()      root     ALL             true
+test           public         100113      test_priv_p2(int8)  admin    ALL             true
+test           public         100113      test_priv_p2(int8)  public   EXECUTE         false
+test           public         100113      test_priv_p2(int8)  root     ALL             true
+test           test_priv_sc1  100114      test_priv_p3()      admin    ALL             true
+test           test_priv_sc1  100114      test_priv_p3()      public   EXECUTE         false
+test           test_priv_sc1  100114      test_priv_p3()      root     ALL             true
+
+# Make sure has_function_privilege works.
+query B
+SELECT has_function_privilege('test_priv_p2(INT)', 'EXECUTE')
+----
+true
+
+query B
+SELECT has_function_privilege('test_priv_p2(INT)', 'EXECUTE WITH GRANT OPTION')
+----
+true
+
+query B
+SELECT has_function_privilege('test_priv_p2(INT)', 'EXECUTE, EXECUTE WITH GRANT OPTION')
+----
+true
+
+user testuser
+
+query B
+SELECT has_function_privilege('test_priv_p2(INT)', 'EXECUTE')
+----
+true
+
+query B
+SELECT has_function_privilege('test_priv_p2(INT)', 'EXECUTE WITH GRANT OPTION')
+----
+false
+
+query B
+SELECT has_function_privilege('test_priv_p2(INT)', 'EXECUTE, EXECUTE WITH GRANT OPTION')
+----
+true
+
+user root
+
+statement ok
+GRANT EXECUTE ON PROCEDURE test_priv_p1(), test_priv_p2(int), test_priv_sc1.test_priv_p3 TO testuser WITH GRANT OPTION;
+
+user testuser
+
+query B retry
+SELECT has_function_privilege('test_priv_p2(INT)', 'EXECUTE')
+----
+true
+
+query B
+SELECT has_function_privilege('test_priv_p2(INT)', 'EXECUTE WITH GRANT OPTION')
+----
+true
+
+query B
+SELECT has_function_privilege('test_priv_p2(INT)', 'EXECUTE, EXECUTE WITH GRANT OPTION')
+----
+true
+
+user root
+
+statement ok
+REVOKE GRANT OPTION FOR EXECUTE ON PROCEDURE test_priv_p1(), test_priv_p2(int), test_priv_sc1.test_priv_p3 FROM testuser;
+
+user testuser
+
+query B retry
+SELECT has_function_privilege('test_priv_p2(INT)', 'EXECUTE WITH GRANT OPTION')
+----
+false
+
+query B
+SELECT has_function_privilege('test_priv_p2(INT)', 'EXECUTE')
+----
+true
+
+query B
+SELECT has_function_privilege('test_priv_p2(INT)', 'EXECUTE, EXECUTE WITH GRANT OPTION')
+----
+true
+
+user root
+
+statement ok
+SET search_path = public;
+
+subtest end
 
 subtest show_grants
 
@@ -552,14 +610,14 @@ SELECT * FROM [
 ] ORDER BY routine_signature, grantee
 ----
 database_name  schema_name          routine_id  routine_signature                    grantee             privilege_type  is_grantable
-test           sc_test_show_grants  100111      p_test_show_grants(int8)             admin               ALL             true
-test           sc_test_show_grants  100111      p_test_show_grants(int8)             public              EXECUTE         false
-test           sc_test_show_grants  100111      p_test_show_grants(int8)             root                ALL             true
-test           sc_test_show_grants  100111      p_test_show_grants(int8)             u_test_show_grants  EXECUTE         false
-test           sc_test_show_grants  100112      p_test_show_grants(int8, text, oid)  admin               ALL             true
-test           sc_test_show_grants  100112      p_test_show_grants(int8, text, oid)  public              EXECUTE         false
-test           sc_test_show_grants  100112      p_test_show_grants(int8, text, oid)  root                ALL             true
-test           sc_test_show_grants  100112      p_test_show_grants(int8, text, oid)  u_test_show_grants  EXECUTE         false
+test           sc_test_show_grants  100116      p_test_show_grants(int8)             admin               ALL             true
+test           sc_test_show_grants  100116      p_test_show_grants(int8)             public              EXECUTE         false
+test           sc_test_show_grants  100116      p_test_show_grants(int8)             root                ALL             true
+test           sc_test_show_grants  100116      p_test_show_grants(int8)             u_test_show_grants  EXECUTE         false
+test           sc_test_show_grants  100117      p_test_show_grants(int8, text, oid)  admin               ALL             true
+test           sc_test_show_grants  100117      p_test_show_grants(int8, text, oid)  public              EXECUTE         false
+test           sc_test_show_grants  100117      p_test_show_grants(int8, text, oid)  root                ALL             true
+test           sc_test_show_grants  100117      p_test_show_grants(int8, text, oid)  u_test_show_grants  EXECUTE         false
 
 statement error pgcode 42883 pq: procedure p_test_show_grants\(string\) does not exist
 SHOW GRANTS ON PROCEDURE p_test_show_grants(string);
@@ -568,19 +626,19 @@ query TTTTTTB colnames
 SELECT * FROM [SHOW GRANTS ON PROCEDURE p_test_show_grants(INT)] ORDER BY grantee
 ----
 database_name  schema_name          routine_id  routine_signature         grantee             privilege_type  is_grantable
-test           sc_test_show_grants  100111      p_test_show_grants(int8)  admin               ALL             true
-test           sc_test_show_grants  100111      p_test_show_grants(int8)  public              EXECUTE         false
-test           sc_test_show_grants  100111      p_test_show_grants(int8)  root                ALL             true
-test           sc_test_show_grants  100111      p_test_show_grants(int8)  u_test_show_grants  EXECUTE         false
+test           sc_test_show_grants  100116      p_test_show_grants(int8)  admin               ALL             true
+test           sc_test_show_grants  100116      p_test_show_grants(int8)  public              EXECUTE         false
+test           sc_test_show_grants  100116      p_test_show_grants(int8)  root                ALL             true
+test           sc_test_show_grants  100116      p_test_show_grants(int8)  u_test_show_grants  EXECUTE         false
 
 query TTTTTTB colnames
 SELECT * FROM [SHOW GRANTS ON PROCEDURE p_test_show_grants(INT, string, OID)] ORDER BY routine_signature, grantee
 ----
 database_name  schema_name          routine_id  routine_signature                    grantee             privilege_type  is_grantable
-test           sc_test_show_grants  100112      p_test_show_grants(int8, text, oid)  admin               ALL             true
-test           sc_test_show_grants  100112      p_test_show_grants(int8, text, oid)  public              EXECUTE         false
-test           sc_test_show_grants  100112      p_test_show_grants(int8, text, oid)  root                ALL             true
-test           sc_test_show_grants  100112      p_test_show_grants(int8, text, oid)  u_test_show_grants  EXECUTE         false
+test           sc_test_show_grants  100117      p_test_show_grants(int8, text, oid)  admin               ALL             true
+test           sc_test_show_grants  100117      p_test_show_grants(int8, text, oid)  public              EXECUTE         false
+test           sc_test_show_grants  100117      p_test_show_grants(int8, text, oid)  root                ALL             true
+test           sc_test_show_grants  100117      p_test_show_grants(int8, text, oid)  u_test_show_grants  EXECUTE         false
 
 # TODO(mgartner): Fix the error message to mention "procedure" or "routine"
 # instead of "function".
@@ -593,8 +651,8 @@ SELECT * FROM [
 ] ORDER BY routine_id
 ----
 database_name  schema_name          routine_id  routine_signature                    grantee             privilege_type  is_grantable
-test           sc_test_show_grants  100111      p_test_show_grants(int8)             u_test_show_grants  EXECUTE         false
-test           sc_test_show_grants  100112      p_test_show_grants(int8, text, oid)  u_test_show_grants  EXECUTE         false
+test           sc_test_show_grants  100116      p_test_show_grants(int8)             u_test_show_grants  EXECUTE         false
+test           sc_test_show_grants  100117      p_test_show_grants(int8, text, oid)  u_test_show_grants  EXECUTE         false
 
 query TTTTTB colnames
 SELECT * FROM [SHOW GRANTS FOR u_test_show_grants] ORDER BY relation_name

--- a/pkg/sql/logictest/testdata/logic_test/udf_privileges
+++ b/pkg/sql/logictest/testdata/logic_test/udf_privileges
@@ -391,7 +391,7 @@ test           public       100110       test_priv_f1()      admin    ALL       
 test           public       100110       test_priv_f1()      public   EXECUTE         false
 test           public       100110       test_priv_f1()      root     ALL             true
 
-# Add default privilege and make sure new function
+# Add default privilege and make sure it apples only to newly created functions.
 statement ok
 ALTER DEFAULT PRIVILEGES IN SCHEMA public, test_priv_sc1 GRANT EXECUTE ON FUNCTIONS TO udf_test_user WITH GRANT OPTION;
 

--- a/pkg/sql/sem/eval/parse_doid.go
+++ b/pkg/sql/sem/eval/parse_doid.go
@@ -129,8 +129,12 @@ func ParseDOid(ctx context.Context, evalCtx *Context, s string, t *types.T) (*tr
 		if err != nil {
 			return nil, err
 		}
-		ol, err := fd.MatchOverload(paramTypes, fn.FuncName.Schema(),
-			&evalCtx.SessionData().SearchPath, tree.BuiltinRoutine|tree.UDFRoutine)
+		ol, err := fd.MatchOverload(
+			paramTypes,
+			fn.FuncName.Schema(),
+			&evalCtx.SessionData().SearchPath,
+			tree.BuiltinRoutine|tree.UDFRoutine|tree.ProcedureRoutine,
+		)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This commit fixes a minor bug with `ALTER DEFAULT PRIVILEGES` for
procedures and adds related tests.

Epic: CRDB-25388

Release note: None
