### PR TITLE
changefeedccl: support attributes in pubsub sink

### DIFF
--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -198,6 +198,7 @@ go_test(
         "show_changefeed_jobs_test.go",
         "sink_cloudstorage_test.go",
         "sink_kafka_connection_test.go",
+        "sink_pubsub_v2_test.go",
         "sink_test.go",
         "sink_webhook_test.go",
         "testfeed_test.go",

--- a/pkg/ccl/changefeedccl/cdctest/testfeed.go
+++ b/pkg/ccl/changefeedccl/cdctest/testfeed.go
@@ -35,6 +35,9 @@ type TestFeedMessage struct {
 	Topic, Partition string
 	Key, Value       []byte
 	Resolved         []byte
+
+	// RawMessage is the sink-specific message type.
+	RawMessage interface{}
 }
 
 func (m TestFeedMessage) String() string {

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -7807,7 +7807,7 @@ func (s *memoryHoggingSink) EmitRow(
 	ctx context.Context,
 	topic TopicDescriptor,
 	key, value []byte,
-	updated, mvcc hlc.Timestamp,
+	rowMeta RowMeta,
 	alloc kvevent.Alloc,
 ) error {
 	s.mu.Lock()
@@ -7856,7 +7856,7 @@ func (s *countEmittedRowsSink) EmitRow(
 	ctx context.Context,
 	topic TopicDescriptor,
 	key, value []byte,
-	updated, mvcc hlc.Timestamp,
+	rowMeta RowMeta,
 	alloc kvevent.Alloc,
 ) error {
 	alloc.Release(ctx)

--- a/pkg/ccl/changefeedccl/event_processing.go
+++ b/pkg/ccl/changefeedccl/event_processing.go
@@ -454,7 +454,8 @@ func (c *kvEventToRowConsumer) encodeAndEmit(
 	alloc.AdjustBytesToTarget(ctx, int64(len(keyCopy)+len(valueCopy)))
 
 	if err := c.sink.EmitRow(
-		ctx, topic, keyCopy, valueCopy, schemaTS, updatedRow.MvccTimestamp, alloc,
+		ctx, topic, keyCopy, valueCopy,
+		RowMeta{updated: schemaTS, mvcc: updatedRow.MvccTimestamp, tableName: updatedRow.TableName}, alloc,
 	); err != nil {
 		return err
 	}

--- a/pkg/ccl/changefeedccl/parquet_sink_cloudstorage.go
+++ b/pkg/ccl/changefeedccl/parquet_sink_cloudstorage.go
@@ -109,7 +109,7 @@ func (parquetSink *parquetCloudStorageSink) EmitRow(
 	ctx context.Context,
 	topic TopicDescriptor,
 	key, value []byte,
-	updated, mvcc hlc.Timestamp,
+	rowMeta RowMeta,
 	alloc kvevent.Alloc,
 ) error {
 	return errors.AssertionFailedf("EmitRow unimplemented by the parquet cloud storage sink")

--- a/pkg/ccl/changefeedccl/sink_cloudstorage.go
+++ b/pkg/ccl/changefeedccl/sink_cloudstorage.go
@@ -548,7 +548,7 @@ func (s *cloudStorageSink) EmitRow(
 	ctx context.Context,
 	topic TopicDescriptor,
 	key, value []byte,
-	updated, mvcc hlc.Timestamp,
+	rowMeta RowMeta,
 	alloc kvevent.Alloc,
 ) (retErr error) {
 	if s.files == nil {
@@ -573,7 +573,7 @@ func (s *cloudStorageSink) EmitRow(
 	}()
 
 	s.metrics.recordMessageSize(int64(len(key) + len(value)))
-	file, err := s.getOrCreateFile(topic, mvcc)
+	file, err := s.getOrCreateFile(topic, rowMeta.mvcc)
 	if err != nil {
 		return err
 	}

--- a/pkg/ccl/changefeedccl/sink_cloudstorage_test.go
+++ b/pkg/ccl/changefeedccl/sink_cloudstorage_test.go
@@ -219,7 +219,7 @@ func TestCloudStorageSink(t *testing.T) {
 		defer func() { require.NoError(t, s.Close()) }()
 		s.(*cloudStorageSink).sinkID = 7 // Force a deterministic sinkID.
 
-		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`v1`), ts(1), ts(1), zeroAlloc))
+		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`v1`), RowMeta{updated: ts(1), mvcc: ts(1)}, zeroAlloc))
 		require.NoError(t, s.Flush(ctx))
 
 		require.Equal(t, []string{
@@ -279,9 +279,9 @@ func TestCloudStorageSink(t *testing.T) {
 				// the ordering among these two files is non deterministic as either of them could
 				// be flushed first (and thus be assigned fileID 0).
 				var pool testAllocPool
-				require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`v1`), ts(1), ts(1), pool.alloc()))
-				require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`v2`), ts(1), ts(1), pool.alloc()))
-				require.NoError(t, s.EmitRow(ctx, t2, noKey, []byte(`w1`), ts(3), ts(3), pool.alloc()))
+				require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`v1`), RowMeta{updated: ts(1), mvcc: ts(1)}, pool.alloc()))
+				require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`v2`), RowMeta{updated: ts(1), mvcc: ts(1)}, pool.alloc()))
+				require.NoError(t, s.EmitRow(ctx, t2, noKey, []byte(`w1`), RowMeta{updated: ts(3), mvcc: ts(3)}, pool.alloc()))
 				require.NoError(t, s.Flush(ctx))
 				require.EqualValues(t, 0, pool.used())
 				expected := []string{
@@ -299,7 +299,7 @@ func TestCloudStorageSink(t *testing.T) {
 				require.Equal(t, expected, actual)
 
 				// Without a flush, nothing new shows up.
-				require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`v3`), ts(3), ts(3), zeroAlloc))
+				require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`v3`), RowMeta{updated: ts(3), mvcc: ts(1)}, zeroAlloc))
 				actual = slurpDir(t)
 				sort.Strings(actual)
 				require.Equal(t, expected, actual)
@@ -318,9 +318,9 @@ func TestCloudStorageSink(t *testing.T) {
 				// after the rows emitted above.
 				require.True(t, forwardFrontier(sf, testSpan, 4))
 				require.NoError(t, s.Flush(ctx))
-				require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`v4`), ts(4), ts(4), zeroAlloc))
+				require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`v4`), RowMeta{updated: ts(4), mvcc: ts(4)}, zeroAlloc))
 				t1.Version = 2
-				require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`v5`), ts(5), ts(5), zeroAlloc))
+				require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`v5`), RowMeta{updated: ts(5), mvcc: ts(5)}, zeroAlloc))
 				require.NoError(t, s.Flush(ctx))
 				expected = []string{
 					"v4\n",
@@ -364,8 +364,8 @@ func TestCloudStorageSink(t *testing.T) {
 		// Each node writes some data at the same timestamp. When this data is
 		// written out, the files have different names and don't conflict because
 		// the sinks have different job session IDs.
-		require.NoError(t, s1.EmitRow(ctx, t1, noKey, []byte(`v1`), ts(1), ts(1), zeroAlloc))
-		require.NoError(t, s2.EmitRow(ctx, t1, noKey, []byte(`w1`), ts(1), ts(1), zeroAlloc))
+		require.NoError(t, s1.EmitRow(ctx, t1, noKey, []byte(`v1`), RowMeta{updated: ts(1), mvcc: ts(1)}, zeroAlloc))
+		require.NoError(t, s2.EmitRow(ctx, t1, noKey, []byte(`w1`), RowMeta{updated: ts(1), mvcc: ts(1)}, zeroAlloc))
 		require.NoError(t, s1.Flush(ctx))
 		require.NoError(t, s2.Flush(ctx))
 		require.Equal(t, []string{
@@ -399,8 +399,8 @@ func TestCloudStorageSink(t *testing.T) {
 		s1R.(*cloudStorageSink).jobSessionID = "a"
 		s2R.(*cloudStorageSink).jobSessionID = "b"
 		// Each resends the data it did before.
-		require.NoError(t, s1R.EmitRow(ctx, t1, noKey, []byte(`v1`), ts(1), ts(1), zeroAlloc))
-		require.NoError(t, s2R.EmitRow(ctx, t1, noKey, []byte(`w1`), ts(1), ts(1), zeroAlloc))
+		require.NoError(t, s1R.EmitRow(ctx, t1, noKey, []byte(`v1`), RowMeta{updated: ts(1), mvcc: ts(1)}, zeroAlloc))
+		require.NoError(t, s2R.EmitRow(ctx, t1, noKey, []byte(`w1`), RowMeta{updated: ts(1), mvcc: ts(1)}, zeroAlloc))
 		require.NoError(t, s1R.Flush(ctx))
 		require.NoError(t, s2R.Flush(ctx))
 		// s1 data ends up being overwritten, s2 data ends up duplicated.
@@ -442,17 +442,17 @@ func TestCloudStorageSink(t *testing.T) {
 		s2.(*cloudStorageSink).jobSessionID = "b" // Force deterministic job session ID.
 
 		// Good job writes
-		require.NoError(t, s1.EmitRow(ctx, t1, noKey, []byte(`v1`), ts(1), ts(1), zeroAlloc))
-		require.NoError(t, s1.EmitRow(ctx, t1, noKey, []byte(`v2`), ts(2), ts(2), zeroAlloc))
+		require.NoError(t, s1.EmitRow(ctx, t1, noKey, []byte(`v1`), RowMeta{updated: ts(1), mvcc: ts(1)}, zeroAlloc))
+		require.NoError(t, s1.EmitRow(ctx, t1, noKey, []byte(`v2`), RowMeta{updated: ts(2), mvcc: ts(2)}, zeroAlloc))
 		require.NoError(t, s1.Flush(ctx))
 
 		// Zombie job writes partial duplicate data
-		require.NoError(t, s2.EmitRow(ctx, t1, noKey, []byte(`v1`), ts(1), ts(1), zeroAlloc))
+		require.NoError(t, s2.EmitRow(ctx, t1, noKey, []byte(`v1`), RowMeta{updated: ts(1), mvcc: ts(1)}, zeroAlloc))
 		require.NoError(t, s2.Flush(ctx))
 
 		// Good job continues. There are duplicates in the data but nothing was
 		// lost.
-		require.NoError(t, s1.EmitRow(ctx, t1, noKey, []byte(`v3`), ts(3), ts(3), zeroAlloc))
+		require.NoError(t, s1.EmitRow(ctx, t1, noKey, []byte(`v3`), RowMeta{updated: ts(3), mvcc: ts(3)}, zeroAlloc))
 		require.NoError(t, s1.Flush(ctx))
 		require.Equal(t, []string{
 			"v1\nv2\n",
@@ -482,7 +482,7 @@ func TestCloudStorageSink(t *testing.T) {
 		// Writing more than the max file size chunks the file up and flushes it
 		// out as necessary.
 		for i := int64(1); i <= 5; i++ {
-			require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(fmt.Sprintf(`v%d`, i)), ts(i), ts(i), zeroAlloc))
+			require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(fmt.Sprintf(`v%d`, i)), RowMeta{updated: ts(i), mvcc: ts(i)}, zeroAlloc))
 		}
 		require.NoError(t, waitAsyncFlush(s))
 		require.Equal(t, []string{
@@ -505,7 +505,7 @@ func TestCloudStorageSink(t *testing.T) {
 		// Some more data is written. Some of it flushed out because of the max
 		// file size.
 		for i := int64(6); i < 10; i++ {
-			require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(fmt.Sprintf(`v%d`, i)), ts(i), ts(i), zeroAlloc))
+			require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(fmt.Sprintf(`v%d`, i)), RowMeta{updated: ts(i), mvcc: ts(i)}, zeroAlloc))
 		}
 		require.NoError(t, waitAsyncFlush(s))
 		require.Equal(t, []string{
@@ -629,7 +629,7 @@ func TestCloudStorageSink(t *testing.T) {
 						require.NoError(t, err)
 						require.NoError(t, s.Flush(ctx))
 
-						require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(fmt.Sprintf(`v%d`, i)), hlcTime, hlcTime, zeroAlloc))
+						require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(fmt.Sprintf(`v%d`, i)), RowMeta{updated: hlcTime, mvcc: hlcTime}, zeroAlloc))
 					}
 
 					require.NoError(t, s.Flush(ctx)) // Flush the last file
@@ -655,8 +655,8 @@ func TestCloudStorageSink(t *testing.T) {
 
 		// Simulate initial scan, which emits data at a timestamp, then an equal
 		// resolved timestamp.
-		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`is1`), ts(1), ts(1), zeroAlloc))
-		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`is2`), ts(1), ts(1), zeroAlloc))
+		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`is1`), RowMeta{updated: ts(1), mvcc: ts(1)}, zeroAlloc))
+		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`is2`), RowMeta{updated: ts(1), mvcc: ts(1)}, zeroAlloc))
 		require.NoError(t, s.Flush(ctx))
 		require.NoError(t, s.EmitResolvedTimestamp(ctx, e, ts(1)))
 
@@ -666,13 +666,13 @@ func TestCloudStorageSink(t *testing.T) {
 		// be after the resolved timestamp emitted above.
 		require.True(t, forwardFrontier(sf, testSpan, 2))
 		require.NoError(t, s.Flush(ctx))
-		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`e2`), ts(2), ts(2), zeroAlloc))
-		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`e3prev`), ts(3).Prev(), ts(3).Prev(), zeroAlloc))
-		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`e3`), ts(3), ts(3), zeroAlloc))
+		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`e2`), RowMeta{updated: ts(2), mvcc: ts(2)}, zeroAlloc))
+		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`e3prev`), RowMeta{updated: ts(3).Prev(), mvcc: ts(3).Prev()}, zeroAlloc))
+		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`e3`), RowMeta{updated: ts(13), mvcc: ts(3)}, zeroAlloc))
 		require.True(t, forwardFrontier(sf, testSpan, 3))
 		require.NoError(t, s.Flush(ctx))
 		require.NoError(t, s.EmitResolvedTimestamp(ctx, e, ts(3)))
-		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`e3next`), ts(3).Next(), ts(3).Next(), zeroAlloc))
+		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`e3next`), RowMeta{updated: ts(3).Next(), mvcc: ts(3).Next()}, zeroAlloc))
 		require.NoError(t, s.Flush(ctx))
 		require.NoError(t, s.EmitResolvedTimestamp(ctx, e, ts(4)))
 
@@ -687,7 +687,7 @@ func TestCloudStorageSink(t *testing.T) {
 
 		// Test that files with timestamp lower than the least resolved timestamp
 		// as of file creation time are ignored.
-		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`noemit`), ts(1).Next(), ts(1).Next(), zeroAlloc))
+		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`noemit`), RowMeta{updated: ts(1).Next(), mvcc: ts(1).Next()}, zeroAlloc))
 		require.Equal(t, []string{
 			"is1\nis2\n",
 			`{"resolved":"1.0000000000"}`,
@@ -711,13 +711,13 @@ func TestCloudStorageSink(t *testing.T) {
 		require.NoError(t, err)
 		defer func() { require.NoError(t, s.Close()) }()
 
-		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`v1`), ts(1), ts(1), zeroAlloc))
+		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`v1`), RowMeta{updated: ts(1), mvcc: ts(1)}, zeroAlloc))
 		t1.Version = 1
-		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`v3`), ts(1), ts(1), zeroAlloc))
+		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`v3`), RowMeta{updated: ts(1), mvcc: ts(1)}, zeroAlloc))
 		// Make the first file exceed its file size threshold. This should trigger a flush
 		// for the first file but not the second one.
 		t1.Version = 0
-		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`trigger-flush-v1`), ts(1), ts(1), zeroAlloc))
+		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`trigger-flush-v1`), RowMeta{updated: ts(1), mvcc: ts(1)}, zeroAlloc))
 		require.NoError(t, waitAsyncFlush(s))
 		require.Equal(t, []string{
 			"v1\ntrigger-flush-v1\n",
@@ -725,9 +725,9 @@ func TestCloudStorageSink(t *testing.T) {
 
 		// Now make the file with the newer schema exceed its file size threshold and ensure
 		// that the file with the older schema is flushed (and ordered) before.
-		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`v2`), ts(1), ts(1), zeroAlloc))
+		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`v2`), RowMeta{updated: ts(1), mvcc: ts(1)}, zeroAlloc))
 		t1.Version = 1
-		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`trigger-flush-v3`), ts(1), ts(1), zeroAlloc))
+		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`trigger-flush-v3`), RowMeta{updated: ts(1), mvcc: ts(1)}, zeroAlloc))
 		require.NoError(t, waitAsyncFlush(s))
 		require.Equal(t, []string{
 			"v1\ntrigger-flush-v1\n",
@@ -736,9 +736,9 @@ func TestCloudStorageSink(t *testing.T) {
 		}, slurpDir(t))
 
 		// Calling `Flush()` on the sink should emit files in the order of their schema IDs.
-		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`w1`), ts(1), ts(1), zeroAlloc))
+		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`w1`), RowMeta{updated: ts(1), mvcc: ts(1)}, zeroAlloc))
 		t1.Version = 0
-		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`x1`), ts(1), ts(1), zeroAlloc))
+		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`x1`), RowMeta{updated: ts(1), mvcc: ts(1)}, zeroAlloc))
 		require.NoError(t, s.Flush(ctx))
 		require.Equal(t, []string{
 			"v1\ntrigger-flush-v1\n",
@@ -775,7 +775,7 @@ func TestCloudStorageSink(t *testing.T) {
 				// Write few megs worth of data.
 				for n := 0; n < 20; n++ {
 					eventTS := ts(int64(n + 1))
-					require.NoError(t, s.EmitRow(ctx, topic, noKey, data, eventTS, eventTS, zeroAlloc))
+					require.NoError(t, s.EmitRow(ctx, topic, noKey, data, RowMeta{updated: eventTS, mvcc: eventTS}, zeroAlloc))
 				}
 
 				// Close the sink.  That's it -- we rely on leaktest detector to determine
@@ -821,7 +821,7 @@ func TestCloudStorageSink(t *testing.T) {
 					// Write few megs worth of data.
 					for n := 0; n < 20; n++ {
 						eventTS := ts(int64(n + 1))
-						require.NoError(t, s.EmitRow(ctx, topic, noKey, data, eventTS, eventTS, zeroAlloc))
+						require.NoError(t, s.EmitRow(ctx, topic, noKey, data, RowMeta{updated: eventTS, mvcc: eventTS}, zeroAlloc))
 					}
 					cancledCtx, cancel := context.WithCancel(ctx)
 					cancel()
@@ -829,7 +829,7 @@ func TestCloudStorageSink(t *testing.T) {
 					// Write 1 more piece of data.  We want to make sure that when error happens
 					// (context cancellation in this case) that any resources used by compression
 					// codec are released (this is checked by leaktest).
-					require.Equal(t, context.Canceled, s.EmitRow(cancledCtx, topic, noKey, data, ts(1), ts(1), zeroAlloc))
+					require.Equal(t, context.Canceled, s.EmitRow(cancledCtx, topic, noKey, data, RowMeta{updated: ts(1), mvcc: ts(1)}, zeroAlloc))
 				}()
 			})
 		}

--- a/pkg/ccl/changefeedccl/sink_kafka.go
+++ b/pkg/ccl/changefeedccl/sink_kafka.go
@@ -347,7 +347,7 @@ func (s *kafkaSink) EmitRow(
 	ctx context.Context,
 	topicDescr TopicDescriptor,
 	key, value []byte,
-	updated, mvcc hlc.Timestamp,
+	rowMeta RowMeta,
 	alloc kvevent.Alloc,
 ) error {
 	topic, err := s.topics.Name(topicDescr)
@@ -359,7 +359,7 @@ func (s *kafkaSink) EmitRow(
 		Topic:    topic,
 		Key:      sarama.ByteEncoder(key),
 		Value:    sarama.ByteEncoder(value),
-		Metadata: messageMetadata{alloc: alloc, mvcc: mvcc, updateMetrics: s.metrics.recordOneMessage()},
+		Metadata: messageMetadata{alloc: alloc, mvcc: rowMeta.mvcc, updateMetrics: s.metrics.recordOneMessage()},
 	}
 	s.stats.startMessage(int64(msg.Key.Length() + msg.Value.Length()))
 	return s.emitMessage(ctx, msg)

--- a/pkg/ccl/changefeedccl/sink_kafka_connection_test.go
+++ b/pkg/ccl/changefeedccl/sink_kafka_connection_test.go
@@ -51,7 +51,11 @@ func (e *externalConnectionKafkaSink) Close() error {
 
 // EmitRow implements the Sink interface.
 func (e *externalConnectionKafkaSink) EmitRow(
-	_ context.Context, _ TopicDescriptor, _, _ []byte, _, _ hlc.Timestamp, _ kvevent.Alloc,
+	ctx context.Context,
+	topic TopicDescriptor,
+	key, value []byte,
+	rowMeta RowMeta,
+	alloc kvevent.Alloc,
 ) error {
 	return nil
 }

--- a/pkg/ccl/changefeedccl/sink_pubsub.go
+++ b/pkg/ccl/changefeedccl/sink_pubsub.go
@@ -196,8 +196,7 @@ func (p *deprecatedPubsubSink) EmitRow(
 	ctx context.Context,
 	topic TopicDescriptor,
 	key, value []byte,
-	updated hlc.Timestamp,
-	mvcc hlc.Timestamp,
+	rowMeta RowMeta,
 	alloc kvevent.Alloc,
 ) error {
 	p.metrics.recordMessageSize(int64(len(key) + len(value)))
@@ -207,7 +206,7 @@ func (p *deprecatedPubsubSink) EmitRow(
 		return err
 	}
 	m := pubsubMessage{
-		alloc: alloc, isFlush: false, mvcc: mvcc, message: payload{
+		alloc: alloc, isFlush: false, mvcc: rowMeta.mvcc, message: payload{
 			Key:   key,
 			Value: value,
 			Topic: topicName,

--- a/pkg/ccl/changefeedccl/sink_pubsub_v2_test.go
+++ b/pkg/ccl/changefeedccl/sink_pubsub_v2_test.go
@@ -1,0 +1,65 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package changefeedccl
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigAttributes(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	for _, tc := range []struct {
+		name               string
+		attributes         string
+		expectedAttributes pubsubAttributes
+		err                string
+	}{
+		{
+			name:               "no attributes",
+			expectedAttributes: pubsubAttributes(nil),
+		},
+		{
+			name:       "mixed attributes",
+			attributes: `{"attributes": {"foo": "bar", "bar":"foo", "table": "TABLE_NAME"}}`,
+			expectedAttributes: map[string]string{
+				"foo":   "bar",
+				"bar":   "foo",
+				"table": "TABLE_NAME",
+			},
+		},
+		{
+			name:       "malformed attributes",
+			attributes: `{"attributes":{foo: "TABLE_NAME", "bar":"TABLE_NAME}}`,
+			err:        "could not marshall",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// Test that the config parses correctly.
+			cfg, err := unmarshalPubSubConfig(changefeedbase.SinkSpecificJSONConfig(tc.attributes))
+			if tc.err != "" {
+				require.Errorf(t, err, tc.err)
+				return
+			} else {
+				require.NoError(t, err)
+			}
+			require.True(t, reflect.DeepEqual(cfg.Attributes, tc.expectedAttributes), fmt.Sprintf("%#v=%#v",
+				cfg.Attributes, tc.expectedAttributes))
+		})
+	}
+
+}

--- a/pkg/ccl/changefeedccl/sink_sql.go
+++ b/pkg/ccl/changefeedccl/sink_sql.go
@@ -126,11 +126,11 @@ func (s *sqlSink) EmitRow(
 	ctx context.Context,
 	topicDescr TopicDescriptor,
 	key, value []byte,
-	updated, mvcc hlc.Timestamp,
+	rowMeta RowMeta,
 	alloc kvevent.Alloc,
 ) error {
 	defer alloc.Release(ctx)
-	defer s.metrics.recordOneMessage()(mvcc, len(key)+len(value), sinkDoesNotCompress)
+	defer s.metrics.recordOneMessage()(rowMeta.mvcc, len(key)+len(value), sinkDoesNotCompress)
 
 	topic, err := s.topicNamer.Name(topicDescr)
 	if err != nil {

--- a/pkg/ccl/changefeedccl/sink_webhook.go
+++ b/pkg/ccl/changefeedccl/sink_webhook.go
@@ -632,7 +632,7 @@ func (s *deprecatedWebhookSink) EmitRow(
 	ctx context.Context,
 	topic TopicDescriptor,
 	key, value []byte,
-	updated, mvcc hlc.Timestamp,
+	rowMeta RowMeta,
 	alloc kvevent.Alloc,
 ) error {
 	select {
@@ -651,7 +651,7 @@ func (s *deprecatedWebhookSink) EmitRow(
 			val:      value,
 			alloc:    alloc,
 			emitTime: timeutil.Now(),
-			mvcc:     mvcc,
+			mvcc:     rowMeta.mvcc,
 		}}:
 		s.metrics.recordMessageSize(int64(len(key) + len(value)))
 	}

--- a/pkg/ccl/changefeedccl/sink_webhook_test.go
+++ b/pkg/ccl/changefeedccl/sink_webhook_test.go
@@ -103,8 +103,8 @@ func testSendAndReceiveRows(t *testing.T, sinkSrc Sink, sinkDest *cdctest.MockWe
 
 	// test an insert row entry
 	var pool testAllocPool
-	require.NoError(t, sinkSrc.EmitRow(ctx, nil, []byte("[1001]"), []byte("{\"after\":{\"col1\":\"val1\",\"rowid\":1000},\"key\":[1001],\"topic:\":\"foo\"}"), zeroTS, zeroTS, pool.alloc()))
-	require.NoError(t, sinkSrc.EmitRow(ctx, nil, []byte("[1001]"), []byte("{\"after\":{\"col1\":\"val1\",\"rowid\":1002},\"key\":[1001],\"topic:\":\"foo\"}"), zeroTS, zeroTS, pool.alloc()))
+	require.NoError(t, sinkSrc.EmitRow(ctx, nil, []byte("[1001]"), []byte("{\"after\":{\"col1\":\"val1\",\"rowid\":1000},\"key\":[1001],\"topic:\":\"foo\"}"), RowMeta{}, pool.alloc()))
+	require.NoError(t, sinkSrc.EmitRow(ctx, nil, []byte("[1001]"), []byte("{\"after\":{\"col1\":\"val1\",\"rowid\":1002},\"key\":[1001],\"topic:\":\"foo\"}"), RowMeta{}, pool.alloc()))
 	require.NoError(t, sinkSrc.Flush(ctx))
 	testutils.SucceedsSoon(t, func() error {
 		remaining := pool.used()
@@ -120,7 +120,7 @@ func testSendAndReceiveRows(t *testing.T, sinkSrc Sink, sinkDest *cdctest.MockWe
 		"{\"payload\":[{\"after\":{\"col1\":\"val1\",\"rowid\":1002},\"key\":[1001],\"topic:\":\"foo\"}],\"length\":1}")
 
 	// test a delete row entry
-	require.NoError(t, sinkSrc.EmitRow(ctx, nil, []byte("[1002]"), []byte("{\"after\":null,\"key\":[1002],\"topic:\":\"foo\"}"), zeroTS, zeroTS, pool.alloc()))
+	require.NoError(t, sinkSrc.EmitRow(ctx, nil, []byte("[1002]"), []byte("{\"after\":null,\"key\":[1002],\"topic:\":\"foo\"}"), RowMeta{}, pool.alloc()))
 	require.NoError(t, sinkSrc.Flush(ctx))
 
 	require.Equal(t,
@@ -177,7 +177,7 @@ func TestWebhookSink(t *testing.T) {
 		require.NoError(t, err)
 
 		// now sink's client accepts no custom certs, should reject the server's cert and fail
-		require.NoError(t, sinkSrcNoCert.EmitRow(context.Background(), nil, []byte("[1001]"), []byte("{\"after\":{\"col1\":\"val1\",\"rowid\":1000},\"key\":[1001],\"topic:\":\"foo\"}"), zeroTS, zeroTS, zeroAlloc))
+		require.NoError(t, sinkSrcNoCert.EmitRow(context.Background(), nil, []byte("[1001]"), []byte("{\"after\":{\"col1\":\"val1\",\"rowid\":1000},\"key\":[1001],\"topic:\":\"foo\"}"), RowMeta{}, zeroAlloc))
 
 		require.Regexp(t, "x509", sinkSrcNoCert.Flush(context.Background()))
 
@@ -192,7 +192,7 @@ func TestWebhookSink(t *testing.T) {
 
 		// sink should throw an error if server is unreachable
 		sinkDest.Close()
-		require.NoError(t, sinkSrc.EmitRow(context.Background(), nil, []byte("[1001]"), []byte("{\"after\":{\"col1\":\"val1\",\"rowid\":1000},\"key\":[1001],\"topic:\":\"foo\"}"), zeroTS, zeroTS, zeroAlloc))
+		require.NoError(t, sinkSrc.EmitRow(context.Background(), nil, []byte("[1001]"), []byte("{\"after\":{\"col1\":\"val1\",\"rowid\":1000},\"key\":[1001],\"topic:\":\"foo\"}"), RowMeta{}, zeroAlloc))
 
 		err = sinkSrc.Flush(context.Background())
 		require.Error(t, err)
@@ -206,7 +206,7 @@ func TestWebhookSink(t *testing.T) {
 		require.NoError(t, err)
 
 		// sink's client should not accept the endpoint's use of HTTP (expects HTTPS)
-		require.NoError(t, sinkSrcWrongProtocol.EmitRow(context.Background(), nil, []byte("[1001]"), []byte("{\"after\":{\"col1\":\"val1\",\"rowid\":1000},\"key\":[1001],\"topic:\":\"foo\"}"), zeroTS, zeroTS, zeroAlloc))
+		require.NoError(t, sinkSrcWrongProtocol.EmitRow(context.Background(), nil, []byte("[1001]"), []byte("{\"after\":{\"col1\":\"val1\",\"rowid\":1000},\"key\":[1001],\"topic:\":\"foo\"}"), RowMeta{}, zeroAlloc))
 
 		require.EqualError(t, sinkSrcWrongProtocol.Flush(context.Background()),
 			fmt.Sprintf(`Post "%s": http: server gave HTTP response to HTTPS client`, fmt.Sprintf("https://%s", strings.TrimPrefix(sinkDestHTTP.URL(),
@@ -305,7 +305,7 @@ func TestWebhookSinkWithAuthOptions(t *testing.T) {
 		delete(details.Opts, changefeedbase.OptWebhookAuthHeader)
 		sinkSrcNoCreds, err := setupWebhookSinkWithDetails(context.Background(), details, parallelism, timeutil.DefaultTimeSource{})
 		require.NoError(t, err)
-		require.NoError(t, sinkSrcNoCreds.EmitRow(context.Background(), nil, []byte("[1001]"), []byte("{\"after\":{\"col1\":\"val1\",\"rowid\":1000},\"key\":[1001],\"topic:\":\"foo\"}"), zeroTS, zeroTS, zeroAlloc))
+		require.NoError(t, sinkSrcNoCreds.EmitRow(context.Background(), nil, []byte("[1001]"), []byte("{\"after\":{\"col1\":\"val1\",\"rowid\":1000},\"key\":[1001],\"topic:\":\"foo\"}"), RowMeta{}, zeroAlloc))
 
 		require.EqualError(t, sinkSrcNoCreds.Flush(context.Background()), "401 Unauthorized: ")
 
@@ -316,7 +316,7 @@ func TestWebhookSinkWithAuthOptions(t *testing.T) {
 		sinkSrcWrongCreds, err := setupWebhookSinkWithDetails(context.Background(), details, parallelism, timeutil.DefaultTimeSource{})
 		require.NoError(t, err)
 
-		require.NoError(t, sinkSrcWrongCreds.EmitRow(context.Background(), nil, []byte("[1001]"), []byte("{\"after\":{\"col1\":\"val1\",\"rowid\":1000},\"key\":[1001],\"topic:\":\"foo\"}"), zeroTS, zeroTS, zeroAlloc))
+		require.NoError(t, sinkSrcWrongCreds.EmitRow(context.Background(), nil, []byte("[1001]"), []byte("{\"after\":{\"col1\":\"val1\",\"rowid\":1000},\"key\":[1001],\"topic:\":\"foo\"}"), RowMeta{}, zeroAlloc))
 
 		require.EqualError(t, sinkSrcWrongCreds.Flush(context.Background()), "401 Unauthorized: ")
 
@@ -403,7 +403,7 @@ func TestWebhookSinkConfig(t *testing.T) {
 		sinkSrc, err := setupWebhookSinkWithDetails(context.Background(), details, parallelism, timeutil.DefaultTimeSource{})
 		require.NoError(t, err)
 
-		require.NoError(t, sinkSrc.EmitRow(context.Background(), nil, []byte("[1001]"), []byte("{\"after\":{\"col1\":\"val1\",\"rowid\":1000},\"key\":[1001],\"topic:\":\"foo\"}"), zeroTS, zeroTS, zeroAlloc))
+		require.NoError(t, sinkSrc.EmitRow(context.Background(), nil, []byte("[1001]"), []byte("{\"after\":{\"col1\":\"val1\",\"rowid\":1000},\"key\":[1001],\"topic:\":\"foo\"}"), RowMeta{}, zeroAlloc))
 
 		require.EqualError(t, sinkSrc.Flush(context.Background()), "500 Internal Server Error: ")
 
@@ -445,7 +445,7 @@ func TestWebhookSinkConfig(t *testing.T) {
 		sinkSrc, err := setupWebhookSinkWithDetails(context.Background(), details, parallelism, timeutil.DefaultTimeSource{})
 		require.NoError(t, err)
 
-		require.NoError(t, sinkSrc.EmitRow(context.Background(), nil, []byte("[1001]"), []byte("{\"after\":{\"col1\":\"val1\",\"rowid\":1000},\"key\":[1001],\"topic:\":\"foo\"}"), zeroTS, zeroTS, pool.alloc()))
+		require.NoError(t, sinkSrc.EmitRow(context.Background(), nil, []byte("[1001]"), []byte("{\"after\":{\"col1\":\"val1\",\"rowid\":1000},\"key\":[1001],\"topic:\":\"foo\"}"), RowMeta{}, pool.alloc()))
 
 		require.EqualError(t, sinkSrc.Flush(context.Background()), "500 Internal Server Error: ")
 
@@ -487,11 +487,11 @@ func TestWebhookSinkConfig(t *testing.T) {
 		sinkSrc, err := setupWebhookSinkWithDetails(context.Background(), details, parallelism, mt)
 		require.NoError(t, err)
 
-		require.NoError(t, sinkSrc.EmitRow(context.Background(), nil, []byte("[1001]"), []byte("{\"after\":{\"col1\":\"val1\",\"rowid\":1000},\"key\":[1001],\"topic:\":\"foo\"}"), zeroTS, zeroTS, pool.alloc()))
-		require.NoError(t, sinkSrc.EmitRow(context.Background(), nil, []byte("[1001]"), []byte("{\"after\":{\"col1\":\"val1\",\"rowid\":1001},\"key\":[1001],\"topic:\":\"foo\"}"), zeroTS, zeroTS, pool.alloc()))
-		require.NoError(t, sinkSrc.EmitRow(context.Background(), nil, []byte("[1001]"), []byte("{\"after\":{\"col1\":\"val1\",\"rowid\":1002},\"key\":[1001],\"topic:\":\"foo\"}"), zeroTS, zeroTS, pool.alloc()))
-		require.NoError(t, sinkSrc.EmitRow(context.Background(), nil, []byte("[1001]"), []byte("{\"after\":{\"col1\":\"val1\",\"rowid\":1003},\"key\":[1001],\"topic:\":\"foo\"}"), zeroTS, zeroTS, pool.alloc()))
-		require.NoError(t, sinkSrc.EmitRow(context.Background(), nil, []byte("[1001]"), []byte("{\"after\":{\"col1\":\"val1\",\"rowid\":1004},\"key\":[1001],\"topic:\":\"foo\"}"), zeroTS, zeroTS, pool.alloc()))
+		require.NoError(t, sinkSrc.EmitRow(context.Background(), nil, []byte("[1001]"), []byte("{\"after\":{\"col1\":\"val1\",\"rowid\":1000},\"key\":[1001],\"topic:\":\"foo\"}"), RowMeta{}, pool.alloc()))
+		require.NoError(t, sinkSrc.EmitRow(context.Background(), nil, []byte("[1001]"), []byte("{\"after\":{\"col1\":\"val1\",\"rowid\":1001},\"key\":[1001],\"topic:\":\"foo\"}"), RowMeta{}, pool.alloc()))
+		require.NoError(t, sinkSrc.EmitRow(context.Background(), nil, []byte("[1001]"), []byte("{\"after\":{\"col1\":\"val1\",\"rowid\":1002},\"key\":[1001],\"topic:\":\"foo\"}"), RowMeta{}, pool.alloc()))
+		require.NoError(t, sinkSrc.EmitRow(context.Background(), nil, []byte("[1001]"), []byte("{\"after\":{\"col1\":\"val1\",\"rowid\":1003},\"key\":[1001],\"topic:\":\"foo\"}"), RowMeta{}, pool.alloc()))
+		require.NoError(t, sinkSrc.EmitRow(context.Background(), nil, []byte("[1001]"), []byte("{\"after\":{\"col1\":\"val1\",\"rowid\":1004},\"key\":[1001],\"topic:\":\"foo\"}"), RowMeta{}, pool.alloc()))
 
 		require.NoError(t, sinkSrc.Flush(context.Background()))
 		require.Equal(t, sinkDest.Pop(), "{\"payload\":[{\"after\":{\"col1\":\"val1\",\"rowid\":1000},\"key\":[1001],\"topic:\":\"foo\"},"+
@@ -514,8 +514,8 @@ func TestWebhookSinkConfig(t *testing.T) {
 		require.Equal(t, sinkDest.Latest(), "")
 
 		// messages without a full batch should not send
-		require.NoError(t, sinkSrc.EmitRow(context.Background(), nil, []byte("[1001]"), []byte("{\"after\":{\"col1\":\"val1\",\"rowid\":1000},\"key\":[1001],\"topic:\":\"foo\"}"), zeroTS, zeroTS, pool.alloc()))
-		require.NoError(t, sinkSrc.EmitRow(context.Background(), nil, []byte("[1001]"), []byte("{\"after\":{\"col1\":\"val1\",\"rowid\":1001},\"key\":[1001],\"topic:\":\"foo\"}"), zeroTS, zeroTS, pool.alloc()))
+		require.NoError(t, sinkSrc.EmitRow(context.Background(), nil, []byte("[1001]"), []byte("{\"after\":{\"col1\":\"val1\",\"rowid\":1000},\"key\":[1001],\"topic:\":\"foo\"}"), RowMeta{}, pool.alloc()))
+		require.NoError(t, sinkSrc.EmitRow(context.Background(), nil, []byte("[1001]"), []byte("{\"after\":{\"col1\":\"val1\",\"rowid\":1001},\"key\":[1001],\"topic:\":\"foo\"}"), RowMeta{}, pool.alloc()))
 		require.Equal(t, sinkDest.Latest(), "")
 
 		require.NoError(t, sinkSrc.Close())
@@ -550,11 +550,11 @@ func TestWebhookSinkConfig(t *testing.T) {
 		sinkSrc, err := setupWebhookSinkWithDetails(context.Background(), details, parallelism, timeutil.DefaultTimeSource{})
 		require.NoError(t, err)
 
-		require.NoError(t, sinkSrc.EmitRow(context.Background(), nil, []byte("[1001]"), []byte("{\"after\":{\"col1\":\"val1\",\"rowid\":1000},\"key\":[1001],\"topic:\":\"foo\"}"), zeroTS, zeroTS, pool.alloc()))
-		require.NoError(t, sinkSrc.EmitRow(context.Background(), nil, []byte("[1001]"), []byte("{\"after\":{\"col1\":\"val1\",\"rowid\":1001},\"key\":[1001],\"topic:\":\"foo\"}"), zeroTS, zeroTS, pool.alloc()))
-		require.NoError(t, sinkSrc.EmitRow(context.Background(), nil, []byte("[1001]"), []byte("{\"after\":{\"col1\":\"val1\",\"rowid\":1002},\"key\":[1001],\"topic:\":\"foo\"}"), zeroTS, zeroTS, pool.alloc()))
-		require.NoError(t, sinkSrc.EmitRow(context.Background(), nil, []byte("[1001]"), []byte("{\"after\":{\"col1\":\"val1\",\"rowid\":1003},\"key\":[1001],\"topic:\":\"foo\"}"), zeroTS, zeroTS, pool.alloc()))
-		require.NoError(t, sinkSrc.EmitRow(context.Background(), nil, []byte("[1001]"), []byte("{\"after\":{\"col1\":\"val1\",\"rowid\":1004},\"key\":[1001],\"topic:\":\"foo\"}"), zeroTS, zeroTS, pool.alloc()))
+		require.NoError(t, sinkSrc.EmitRow(context.Background(), nil, []byte("[1001]"), []byte("{\"after\":{\"col1\":\"val1\",\"rowid\":1000},\"key\":[1001],\"topic:\":\"foo\"}"), RowMeta{}, pool.alloc()))
+		require.NoError(t, sinkSrc.EmitRow(context.Background(), nil, []byte("[1001]"), []byte("{\"after\":{\"col1\":\"val1\",\"rowid\":1001},\"key\":[1001],\"topic:\":\"foo\"}"), RowMeta{}, pool.alloc()))
+		require.NoError(t, sinkSrc.EmitRow(context.Background(), nil, []byte("[1001]"), []byte("{\"after\":{\"col1\":\"val1\",\"rowid\":1002},\"key\":[1001],\"topic:\":\"foo\"}"), RowMeta{}, pool.alloc()))
+		require.NoError(t, sinkSrc.EmitRow(context.Background(), nil, []byte("[1001]"), []byte("{\"after\":{\"col1\":\"val1\",\"rowid\":1003},\"key\":[1001],\"topic:\":\"foo\"}"), RowMeta{}, pool.alloc()))
+		require.NoError(t, sinkSrc.EmitRow(context.Background(), nil, []byte("[1001]"), []byte("{\"after\":{\"col1\":\"val1\",\"rowid\":1004},\"key\":[1001],\"topic:\":\"foo\"}"), RowMeta{}, pool.alloc()))
 
 		require.NoError(t, sinkSrc.Flush(context.Background()))
 		require.Equal(t, sinkDest.Pop(), "{\"payload\":[{\"after\":{\"col1\":\"val1\",\"rowid\":1000},\"key\":[1001],\"topic:\":\"foo\"},"+
@@ -564,8 +564,8 @@ func TestWebhookSinkConfig(t *testing.T) {
 			"{\"after\":{\"col1\":\"val1\",\"rowid\":1004},\"key\":[1001],\"topic:\":\"foo\"}],\"length\":5}")
 
 		// messages without a full batch should not send
-		require.NoError(t, sinkSrc.EmitRow(context.Background(), nil, []byte("[1001]"), []byte("{\"after\":{\"col1\":\"val1\",\"rowid\":1000},\"key\":[1001],\"topic:\":\"foo\"}"), zeroTS, zeroTS, pool.alloc()))
-		require.NoError(t, sinkSrc.EmitRow(context.Background(), nil, []byte("[1001]"), []byte("{\"after\":{\"col1\":\"val1\",\"rowid\":1001},\"key\":[1001],\"topic:\":\"foo\"}"), zeroTS, zeroTS, pool.alloc()))
+		require.NoError(t, sinkSrc.EmitRow(context.Background(), nil, []byte("[1001]"), []byte("{\"after\":{\"col1\":\"val1\",\"rowid\":1000},\"key\":[1001],\"topic:\":\"foo\"}"), RowMeta{}, pool.alloc()))
+		require.NoError(t, sinkSrc.EmitRow(context.Background(), nil, []byte("[1001]"), []byte("{\"after\":{\"col1\":\"val1\",\"rowid\":1001},\"key\":[1001],\"topic:\":\"foo\"}"), RowMeta{}, pool.alloc()))
 		require.Equal(t, sinkDest.Latest(), "")
 
 		require.NoError(t, sinkSrc.Close())
@@ -610,8 +610,8 @@ func TestWebhookSinkConfig(t *testing.T) {
 		}
 
 		// send incomplete batch
-		require.NoError(t, sinkSrc.EmitRow(context.Background(), nil, []byte("[1001]"), []byte("{\"after\":{\"col1\":\"val1\",\"rowid\":1000},\"key\":[1001],\"topic:\":\"foo\"}"), zeroTS, zeroTS, pool.alloc()))
-		require.NoError(t, sinkSrc.EmitRow(context.Background(), nil, []byte("[1001]"), []byte("{\"after\":{\"col1\":\"val1\",\"rowid\":1001},\"key\":[1001],\"topic:\":\"foo\"}"), zeroTS, zeroTS, pool.alloc()))
+		require.NoError(t, sinkSrc.EmitRow(context.Background(), nil, []byte("[1001]"), []byte("{\"after\":{\"col1\":\"val1\",\"rowid\":1000},\"key\":[1001],\"topic:\":\"foo\"}"), RowMeta{}, pool.alloc()))
+		require.NoError(t, sinkSrc.EmitRow(context.Background(), nil, []byte("[1001]"), []byte("{\"after\":{\"col1\":\"val1\",\"rowid\":1001},\"key\":[1001],\"topic:\":\"foo\"}"), RowMeta{}, pool.alloc()))
 
 		// no messages at first
 		require.Equal(t, sinkDest.Latest(), "")
@@ -678,7 +678,7 @@ func TestWebhookSinkShutsDownOnError(t *testing.T) {
 		sinkSrc, err := setupWebhookSinkWithDetails(ctx, details, parallelism, timeutil.DefaultTimeSource{})
 		require.NoError(t, err)
 
-		require.NoError(t, sinkSrc.EmitRow(ctx, nil, []byte("[1001]"), []byte("{\"after\":{\"col1\":\"val1\",\"rowid\":1000},\"key\":[1001],\"topic:\":\"foo\"}"), zeroTS, zeroTS, zeroAlloc))
+		require.NoError(t, sinkSrc.EmitRow(ctx, nil, []byte("[1001]"), []byte("{\"after\":{\"col1\":\"val1\",\"rowid\":1000},\"key\":[1001],\"topic:\":\"foo\"}"), RowMeta{}, zeroAlloc))
 		// error should be propagated immediately in the next call
 		require.EqualError(t, sinkSrc.Flush(ctx), "500 Internal Server Error: ")
 

--- a/pkg/ccl/changefeedccl/sink_webhook_v2.go
+++ b/pkg/ccl/changefeedccl/sink_webhook_v2.go
@@ -329,7 +329,7 @@ func (jb *webhookJSONBuffer) Close() (SinkPayload, error) {
 }
 
 // MakeBatchBuffer implements the SinkClient interface
-func (sc *webhookSinkClient) MakeBatchBuffer(topic string) BatchBuffer {
+func (sc *webhookSinkClient) MakeBatchBuffer(_ BatchBufferMeta) BatchBuffer {
 	if sc.format == changefeedbase.OptFormatCSV {
 		return &webhookCSVBuffer{sc: sc}
 	} else {

--- a/pkg/ccl/changefeedccl/testfeed_test.go
+++ b/pkg/ccl/changefeedccl/testfeed_test.go
@@ -2215,7 +2215,9 @@ func (f *webhookFeed) Close() error {
 
 type mockPubsubMessage struct {
 	data string
-	// NB: the topic may be empty.
+	// attributes are only populated for the non-deprecated pubsub sink.
+	attributes map[string]string
+	// topic is only populated for the non-deprecated pubsub sink.
 	topic string
 }
 
@@ -2321,7 +2323,7 @@ func (ps *fakePubsubServer) React(req interface{}) (handled bool, ret interface{
 		ps.mu.Lock()
 		defer ps.mu.Unlock()
 		for _, msg := range publishReq.Messages {
-			ps.mu.buffer = append(ps.mu.buffer, mockPubsubMessage{data: string(msg.Data), topic: publishReq.Topic})
+			ps.mu.buffer = append(ps.mu.buffer, mockPubsubMessage{data: string(msg.Data), topic: publishReq.Topic, attributes: msg.Attributes})
 		}
 		if ps.mu.notify != nil {
 			notifyCh := ps.mu.notify
@@ -2495,6 +2497,39 @@ func extractJSONMessagePubsub(wrapped []byte) (value []byte, key []byte, topic s
 	return
 }
 
+func (p *pubsubFeed) NextRaw(includeResolved bool) (*mockPubsubMessage, error) {
+	for {
+		msg := p.mockServer.Pop()
+		if msg == nil {
+			msg = p.deprecatedClient.buffer.pop()
+		}
+		if msg != nil {
+			details, err := p.Details()
+			if err != nil {
+				return nil, err
+			}
+			switch v := changefeedbase.FormatType(details.Opts[changefeedbase.OptFormat]); v {
+			case ``, changefeedbase.OptFormatJSON:
+				isResolved, err := isResolvedTimestamp([]byte(msg.data))
+				if err != nil {
+					return nil, err
+				}
+				if !(isResolved && !includeResolved) {
+					return msg, nil
+				}
+			case changefeedbase.OptFormatCSV:
+				return msg, nil
+			default:
+				return nil, errors.Errorf(`unknown %s: %s`, changefeedbase.OptFormat, v)
+			}
+		}
+
+		if err := p.waitForMessage(); err != nil {
+			return nil, err
+		}
+	}
+}
+
 // Next implements TestFeed
 func (p *pubsubFeed) Next() (*cdctest.TestFeedMessage, error) {
 	for {
@@ -2541,24 +2576,28 @@ func (p *pubsubFeed) Next() (*cdctest.TestFeedMessage, error) {
 			return m, nil
 		}
 
-		if err := timeutil.RunWithTimeout(
-			context.Background(), timeoutOp("pubsub.Next", p.jobID), timeout(),
-			func(ctx context.Context) error {
-				select {
-				case <-ctx.Done():
-					return ctx.Err()
-				case <-p.ss.eventReady():
-					return nil
-				case <-p.mockServer.NotifyMessage():
-					return nil
-				case <-p.shutdown:
-					return p.terminalJobError()
-				}
-			},
-		); err != nil {
+		if err := p.waitForMessage(); err != nil {
 			return nil, err
 		}
 	}
+}
+
+func (p *pubsubFeed) waitForMessage() error {
+	return timeutil.RunWithTimeout(
+		context.Background(), timeoutOp("pubsub.Next", p.jobID), timeout(),
+		func(ctx context.Context) error {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-p.ss.eventReady():
+				return nil
+			case <-p.mockServer.NotifyMessage():
+				return nil
+			case <-p.shutdown:
+				return p.terminalJobError()
+			}
+		},
+	)
 }
 
 // Close implements TestFeed


### PR DESCRIPTION
### changefeedccl: refactor EmitRow to take row metadata struct

This change updates the `EmitRow` method on the `EventSink` interface
to take a metadata struct instead of an mvcc timestamp and update timestamp.
This struct contains the mvcc and update timestamps such as before but
now also includes the table name corresponding to the row.

Release note: None
Epic: None

---

### support attributes in pubsub sink

This change adds support for pubsub attributes. Attributes
are essentially a `map[string]string` that is passed long with
each message.

These attributes can be specified via a new field in the `pubsub_sink_config` like so:
```
CREATE CHANGEFEED FOR ... WITH pubsub_sink_config='{"attributes": {"table": "TABLE_NAME", "foo": "bar"}}'
```

Keys and values can be arbitrary strings. Certain values are special, for
example `TABLE_NAME`. Specifying that value will result it in being
replaced with the table name corresponding to the row.

Version gates are not required. The `attributes` field should be ignored by nodes running
a version prior to this change. Those nodes will simply not emit attributes. A node running
this change will emit attributes and be able to resolve the `TABLE_NAME` given the previous
commit.

Release note (enterprise change): Pubsub attributes are now supported by changefeeds.
To add attributes to messages in a pubsub changefeed, add the "attributes" key to the existing
`pubsub_sink_config` changefeed option. For example:
```
CREATE CHANGEFEED FOR ... WITH pubsub_sink_config='{"attributes": {"table": "TABLE_NAME", "foo": "bar"}}'
```
The map of attributes will attached to each pubsub message sent from CockroachDB.
Certain attributes are special. Passing the "TABLE_NAME" value will result in the value
being replaced by the name of the table which the row was written to. Table names
will be lowercase.