### PR TITLE
pgcryptocipherccl: improve performance of parseCipherMethod

### DIFF
--- a/pkg/ccl/pgcryptoccl/pgcryptocipherccl/cipher_method.go
+++ b/pkg/ccl/pgcryptoccl/pgcryptocipherccl/cipher_method.go
@@ -43,9 +43,9 @@ type cipherMethod struct {
 	padding   cipherPadding
 }
 
-func parseCipherMethod(s string) (cipherMethod, error) {
-	cipherMethodRE := regexp.MustCompile("^(?P<algorithm>[[:alpha:]]+)(?:-(?P<mode>[[:alpha:]]+))?(?:/pad:(?P<padding>[[:alpha:]]+))?$")
+var cipherMethodRE = regexp.MustCompile("^(?P<algorithm>[[:alpha:]]+)(?:-(?P<mode>[[:alpha:]]+))?(?:/pad:(?P<padding>[[:alpha:]]+))?$")
 
+func parseCipherMethod(s string) (cipherMethod, error) {
 	submatches := cipherMethodRE.FindStringSubmatch(s)
 	if submatches == nil {
 		return cipherMethod{}, pgerror.Newf(pgcode.InvalidParameterValue, `cipher method has wrong format: "%s"`, s)


### PR DESCRIPTION
This patch vastly improves the performance of `parseCipherMethod` by
compiling the regex used once at the package level instead of within
the function body.

This improvement also greatly improves the performance of `Encrypt`
and `Decrypt` as a flamegraph revealed that the majority of the CPU
time during execution was being spent in `parseCipherMethod`.

Benchmark results:
```
name                        old time/op  new time/op  delta
Encrypt/AES-128-10          5.57µs ± 0%  0.70µs ± 0%  -87.41%  (p=1.000 n=1+1)
Encrypt/AES-128_with_IV-10  5.83µs ± 0%  0.76µs ± 0%  -87.02%  (p=1.000 n=1+1)
Encrypt/AES-192-10          5.97µs ± 0%  0.86µs ± 0%  -85.55%  (p=1.000 n=1+1)
Encrypt/AES-192_with_IV-10  5.91µs ± 0%  0.86µs ± 0%  -85.53%  (p=1.000 n=1+1)
Encrypt/AES-256-10          6.06µs ± 0%  1.07µs ± 0%  -82.30%  (p=1.000 n=1+1)
Encrypt/AES-256_with_IV-10  6.07µs ± 0%  1.16µs ± 0%  -80.87%  (p=1.000 n=1+1)
Decrypt/AES-128-10          0.00ns ± 0%  0.00ns ± 0%  -75.38%  (p=1.000 n=1+1)
Decrypt/AES-128_with_IV-10  0.00ns ± 0%  0.00ns ± 0%  -84.12%  (p=1.000 n=1+1)
Decrypt/AES-192-10          0.00ns ± 0%  0.00ns ± 0%  -73.94%  (p=1.000 n=1+1)
Decrypt/AES-192_with_IV-10  0.00ns ± 0%  0.00ns ± 0%  -83.13%  (p=1.000 n=1+1)
Decrypt/AES-256-10          0.00ns ± 0%  0.00ns ± 0%  -63.64%  (p=1.000 n=1+1)
Decrypt/AES-256_with_IV-10  0.00ns ± 0%  0.00ns ± 0%  -70.77%  (p=1.000 n=1+1)
```

Epic: CRDB-10655

Release note: None