### PR TITLE
release-23.1: roachtest: require perf. tests to opt in via TestSpec.Benchmark

### DIFF
--- a/pkg/cmd/roachtest/tests/admission_control_elastic_backup.go
+++ b/pkg/cmd/roachtest/tests/admission_control_elastic_backup.go
@@ -37,11 +37,12 @@ import (
 // in roachperf.
 func registerElasticControlForBackups(r registry.Registry) {
 	r.Add(registry.TestSpec{
-		Name:    "admission-control/elastic-backup",
-		Owner:   registry.OwnerAdmissionControl,
-		Tags:    registry.Tags(`weekly`),
-		Cluster: r.MakeClusterSpec(4, spec.CPU(8)),
-		Leases:  registry.MetamorphicLeases,
+		Name:      "admission-control/elastic-backup",
+		Owner:     registry.OwnerAdmissionControl,
+		Benchmark: true,
+		Tags:      registry.Tags(`weekly`),
+		Cluster:   r.MakeClusterSpec(4, spec.CPU(8)),
+		Leases:    registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			if c.Spec().NodeCount < 4 {
 				t.Fatalf("expected at least 4 nodes, found %d", c.Spec().NodeCount)

--- a/pkg/cmd/roachtest/tests/admission_control_elastic_cdc.go
+++ b/pkg/cmd/roachtest/tests/admission_control_elastic_cdc.go
@@ -32,6 +32,7 @@ func registerElasticControlForCDC(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:            "admission-control/elastic-cdc",
 		Owner:           registry.OwnerAdmissionControl,
+		Benchmark:       true,
 		Tags:            registry.Tags(`weekly`),
 		Cluster:         r.MakeClusterSpec(4, spec.CPU(8)),
 		RequiresLicense: true,

--- a/pkg/cmd/roachtest/tests/admission_control_index_overload.go
+++ b/pkg/cmd/roachtest/tests/admission_control_index_overload.go
@@ -33,11 +33,12 @@ import (
 // queries, but the intent is to measure the impact of the index creation.
 func registerIndexOverload(r registry.Registry) {
 	r.Add(registry.TestSpec{
-		Name:    "admission-control/index-overload",
-		Owner:   registry.OwnerAdmissionControl,
-		Tags:    registry.Tags("weekly"),
-		Cluster: r.MakeClusterSpec(4, spec.CPU(8)),
-		Leases:  registry.MetamorphicLeases,
+		Name:      "admission-control/index-overload",
+		Owner:     registry.OwnerAdmissionControl,
+		Benchmark: true,
+		Tags:      registry.Tags("weekly"),
+		Cluster:   r.MakeClusterSpec(4, spec.CPU(8)),
+		Leases:    registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			crdbNodes := c.Spec().NodeCount - 1
 			workloadNode := c.Spec().NodeCount

--- a/pkg/cmd/roachtest/tests/admission_control_multi_store_overload.go
+++ b/pkg/cmd/roachtest/tests/admission_control_multi_store_overload.go
@@ -92,11 +92,12 @@ func registerMultiStoreOverload(r registry.Registry) {
 	}
 
 	r.Add(registry.TestSpec{
-		Name:    "admission-control/multi-store-with-overload",
-		Owner:   registry.OwnerAdmissionControl,
-		Tags:    registry.Tags(`weekly`),
-		Cluster: r.MakeClusterSpec(2, spec.CPU(8), spec.SSD(2)),
-		Leases:  registry.MetamorphicLeases,
+		Name:      "admission-control/multi-store-with-overload",
+		Owner:     registry.OwnerAdmissionControl,
+		Benchmark: true,
+		Tags:      registry.Tags(`weekly`),
+		Cluster:   r.MakeClusterSpec(2, spec.CPU(8), spec.SSD(2)),
+		Leases:    registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runKV(ctx, t, c)
 		},

--- a/pkg/cmd/roachtest/tests/admission_control_multitenant_fairness.go
+++ b/pkg/cmd/roachtest/tests/admission_control_multitenant_fairness.go
@@ -90,6 +90,7 @@ func registerMultiTenantFairness(r registry.Registry) {
 			Name:              fmt.Sprintf("admission-control/multitenant-fairness/%s", s.name),
 			Cluster:           r.MakeClusterSpec(5),
 			Owner:             registry.OwnerAdmissionControl,
+			Benchmark:         true,
 			Leases:            registry.MetamorphicLeases,
 			NonReleaseBlocker: false,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {

--- a/pkg/cmd/roachtest/tests/admission_control_snapshot_overload.go
+++ b/pkg/cmd/roachtest/tests/admission_control_snapshot_overload.go
@@ -39,11 +39,12 @@ import (
 // make it shorter.
 func registerSnapshotOverload(r registry.Registry) {
 	r.Add(registry.TestSpec{
-		Name:    "admission-control/snapshot-overload",
-		Owner:   registry.OwnerAdmissionControl,
-		Tags:    registry.Tags(`weekly`),
-		Cluster: r.MakeClusterSpec(4, spec.CPU(8)),
-		Leases:  registry.MetamorphicLeases,
+		Name:      "admission-control/snapshot-overload",
+		Owner:     registry.OwnerAdmissionControl,
+		Benchmark: true,
+		Tags:      registry.Tags(`weekly`),
+		Cluster:   r.MakeClusterSpec(4, spec.CPU(8)),
+		Leases:    registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			if c.Spec().NodeCount < 4 {
 				t.Fatalf("expected at least 4 nodes, found %d", c.Spec().NodeCount)

--- a/pkg/cmd/roachtest/tests/admission_control_tpcc_overload.go
+++ b/pkg/cmd/roachtest/tests/admission_control_tpcc_overload.go
@@ -164,6 +164,7 @@ func registerTPCCOverload(r registry.Registry) {
 		r.Add(registry.TestSpec{
 			Name:              name,
 			Owner:             registry.OwnerAdmissionControl,
+			Benchmark:         true,
 			Tags:              registry.Tags(`weekly`),
 			Cluster:           r.MakeClusterSpec(s.Nodes+1, spec.CPU(s.CPUs)),
 			Run:               s.run,
@@ -182,8 +183,9 @@ func registerTPCCOverload(r registry.Registry) {
 // CRDB nodes will eventually OOM around 3-4 hours through the ramp period.
 func registerTPCCSevereOverload(r registry.Registry) {
 	r.Add(registry.TestSpec{
-		Name:  "admission-control/tpcc-severe-overload",
-		Owner: registry.OwnerAdmissionControl,
+		Name:      "admission-control/tpcc-severe-overload",
+		Owner:     registry.OwnerAdmissionControl,
+		Benchmark: true,
 		// TODO(abaptist): This test will require a lot of admission control work
 		// to pass. Just putting it here to make easy to run at any time.
 		Skip:    "#89142",

--- a/pkg/cmd/roachtest/tests/cluster_to_cluster.go
+++ b/pkg/cmd/roachtest/tests/cluster_to_cluster.go
@@ -296,6 +296,9 @@ type replicationSpec struct {
 	// name specifies the name of the roachtest
 	name string
 
+	// whether this is a performance test
+	benchmark bool
+
 	// srcodes is the number of nodes on the source cluster.
 	srcNodes int
 
@@ -746,6 +749,7 @@ func c2cRegisterWrapper(
 	r.Add(registry.TestSpec{
 		Name:            sp.name,
 		Owner:           registry.OwnerDisasterRecovery,
+		Benchmark:       sp.benchmark,
 		Cluster:         r.MakeClusterSpec(sp.dstNodes+sp.srcNodes+1, clusterOps...),
 		Leases:          registry.MetamorphicLeases,
 		Timeout:         sp.timeout,
@@ -784,11 +788,12 @@ func runAcceptanceClusterReplication(ctx context.Context, t test.Test, c cluster
 func registerClusterToCluster(r registry.Registry) {
 	for _, sp := range []replicationSpec{
 		{
-			name:     "c2c/tpcc/warehouses=500/duration=10/cutover=5",
-			srcNodes: 4,
-			dstNodes: 4,
-			cpus:     8,
-			pdSize:   1000,
+			name:      "c2c/tpcc/warehouses=500/duration=10/cutover=5",
+			benchmark: true,
+			srcNodes:  4,
+			dstNodes:  4,
+			cpus:      8,
+			pdSize:    1000,
 			// 500 warehouses adds 30 GB to source
 			//
 			// TODO(msbutler): increase default test to 1000 warehouses once fingerprinting
@@ -799,11 +804,12 @@ func registerClusterToCluster(r registry.Registry) {
 			cutover:            5 * time.Minute,
 		},
 		{
-			name:     "c2c/tpcc/warehouses=1000/duration=60/cutover=30",
-			srcNodes: 4,
-			dstNodes: 4,
-			cpus:     8,
-			pdSize:   1000,
+			name:      "c2c/tpcc/warehouses=1000/duration=60/cutover=30",
+			benchmark: true,
+			srcNodes:  4,
+			dstNodes:  4,
+			cpus:      8,
+			pdSize:    1000,
 			// 500 warehouses adds 30 GB to source
 			//
 			// TODO(msbutler): increase default test to 1000 warehouses once fingerprinting
@@ -815,6 +821,7 @@ func registerClusterToCluster(r registry.Registry) {
 		},
 		{
 			name:               "c2c/kv0",
+			benchmark:          true,
 			srcNodes:           3,
 			dstNodes:           3,
 			cpus:               8,

--- a/pkg/cmd/roachtest/tests/multitenant_tpch.go
+++ b/pkg/cmd/roachtest/tests/multitenant_tpch.go
@@ -118,19 +118,21 @@ func runMultiTenantTPCH(
 
 func registerMultiTenantTPCH(r registry.Registry) {
 	r.Add(registry.TestSpec{
-		Name:    "multitenant/tpch",
-		Owner:   registry.OwnerSQLQueries,
-		Cluster: r.MakeClusterSpec(1 /* nodeCount */),
-		Leases:  registry.MetamorphicLeases,
+		Name:      "multitenant/tpch",
+		Owner:     registry.OwnerSQLQueries,
+		Benchmark: true,
+		Cluster:   r.MakeClusterSpec(1 /* nodeCount */),
+		Leases:    registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runMultiTenantTPCH(ctx, t, c, false /* enableDirectScans */)
 		},
 	})
 	r.Add(registry.TestSpec{
-		Name:    "multitenant/tpch_direct_scans",
-		Owner:   registry.OwnerSQLQueries,
-		Cluster: r.MakeClusterSpec(1 /* nodeCount */),
-		Leases:  registry.MetamorphicLeases,
+		Name:      "multitenant/tpch_direct_scans",
+		Owner:     registry.OwnerSQLQueries,
+		Benchmark: true,
+		Cluster:   r.MakeClusterSpec(1 /* nodeCount */),
+		Leases:    registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runMultiTenantTPCH(ctx, t, c, true /* enableDirectScans */)
 		},

--- a/pkg/cmd/roachtest/tests/pebble_write_throughput.go
+++ b/pkg/cmd/roachtest/tests/pebble_write_throughput.go
@@ -32,12 +32,13 @@ func registerPebbleWriteThroughput(r registry.Registry) {
 	// Register the Pebble write benchmark. We only run the 1024 variant for now.
 	size := 1024
 	r.Add(registry.TestSpec{
-		Name:    fmt.Sprintf("pebble/write/size=%d", size),
-		Owner:   registry.OwnerStorage,
-		Timeout: 10 * time.Hour,
-		Cluster: r.MakeClusterSpec(5, spec.CPU(16), spec.SSD(16), spec.RAID0(true)),
-		Leases:  registry.MetamorphicLeases,
-		Tags:    registry.Tags("pebble_nightly_write"),
+		Name:      fmt.Sprintf("pebble/write/size=%d", size),
+		Owner:     registry.OwnerStorage,
+		Benchmark: true,
+		Timeout:   10 * time.Hour,
+		Cluster:   r.MakeClusterSpec(5, spec.CPU(16), spec.SSD(16), spec.RAID0(true)),
+		Leases:    registry.MetamorphicLeases,
+		Tags:      registry.Tags("pebble_nightly_write"),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runPebbleWriteBenchmark(ctx, t, c, size, pebble)
 		},

--- a/pkg/cmd/roachtest/tests/pebble_ycsb.go
+++ b/pkg/cmd/roachtest/tests/pebble_ycsb.go
@@ -51,11 +51,12 @@ func registerPebbleYCSB(r registry.Registry) {
 
 			d := dur
 			r.Add(registry.TestSpec{
-				Name:    name,
-				Owner:   registry.OwnerStorage,
-				Timeout: 12 * time.Hour,
-				Cluster: r.MakeClusterSpec(5, spec.CPU(16)),
-				Tags:    registry.Tags(tag),
+				Name:      name,
+				Owner:     registry.OwnerStorage,
+				Benchmark: true,
+				Timeout:   12 * time.Hour,
+				Cluster:   r.MakeClusterSpec(5, spec.CPU(16)),
+				Tags:      registry.Tags(tag),
 				Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 					runPebbleYCSB(ctx, t, c, size, pebble, d, nil, true /* artifacts */)
 				},
@@ -65,12 +66,13 @@ func registerPebbleYCSB(r registry.Registry) {
 
 	// Add the race build.
 	r.Add(registry.TestSpec{
-		Name:    "pebble/ycsb/A/race/duration=30",
-		Owner:   registry.OwnerStorage,
-		Timeout: 12 * time.Hour,
-		Cluster: r.MakeClusterSpec(5, spec.CPU(16)),
-		Leases:  registry.MetamorphicLeases,
-		Tags:    registry.Tags("pebble_nightly_ycsb_race"),
+		Name:      "pebble/ycsb/A/race/duration=30",
+		Owner:     registry.OwnerStorage,
+		Benchmark: true,
+		Timeout:   12 * time.Hour,
+		Cluster:   r.MakeClusterSpec(5, spec.CPU(16)),
+		Leases:    registry.MetamorphicLeases,
+		Tags:      registry.Tags("pebble_nightly_ycsb_race"),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runPebbleYCSB(ctx, t, c, 64, pebble, 30, []string{"A"}, false /* artifacts */)
 		},

--- a/pkg/cmd/roachtest/tests/tpcdsvec.go
+++ b/pkg/cmd/roachtest/tests/tpcdsvec.go
@@ -186,9 +186,10 @@ WITH unsafe_restore_incompatible_version;
 	}
 
 	r.Add(registry.TestSpec{
-		Name:    "tpcdsvec",
-		Owner:   registry.OwnerSQLQueries,
-		Cluster: r.MakeClusterSpec(3),
+		Name:      "tpcdsvec",
+		Owner:     registry.OwnerSQLQueries,
+		Benchmark: true,
+		Cluster:   r.MakeClusterSpec(3),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			if c.Spec().Cloud != spec.GCE {
 				t.Skip("uses gs://cockroach-fixtures; see https://github.com/cockroachdb/cockroach/issues/105968")

--- a/pkg/cmd/roachtest/tests/tpchvec.go
+++ b/pkg/cmd/roachtest/tests/tpchvec.go
@@ -598,9 +598,10 @@ const tpchVecNodeCount = 3
 
 func registerTPCHVec(r registry.Registry) {
 	r.Add(registry.TestSpec{
-		Name:    "tpchvec/perf",
-		Owner:   registry.OwnerSQLQueries,
-		Cluster: r.MakeClusterSpec(tpchVecNodeCount),
+		Name:      "tpchvec/perf",
+		Owner:     registry.OwnerSQLQueries,
+		Benchmark: true,
+		Cluster:   r.MakeClusterSpec(tpchVecNodeCount),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runTPCHVec(ctx, t, c, newTpchVecPerfTest(
 				"sql.defaults.vectorize", /* settingName */
@@ -629,9 +630,10 @@ func registerTPCHVec(r registry.Registry) {
 	})
 
 	r.Add(registry.TestSpec{
-		Name:    "tpchvec/streamer",
-		Owner:   registry.OwnerSQLQueries,
-		Cluster: r.MakeClusterSpec(tpchVecNodeCount),
+		Name:      "tpchvec/streamer",
+		Owner:     registry.OwnerSQLQueries,
+		Benchmark: true,
+		Cluster:   r.MakeClusterSpec(tpchVecNodeCount),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runTPCHVec(ctx, t, c, newTpchVecPerfTest(
 				"sql.distsql.use_streamer.enabled", /* settingName */


### PR DESCRIPTION
Backport 1/1 commits from #104176.

/cc @cockroachdb/release

Release justification: test only change, causing merge conflicts with later backport

---

Previously, roachtests which benchmark performance (cf. correctness) were indistinguishable from correctness tests. That is, a performance test is like any other test with the exception of _optionally_ writing stats.json under 'Test.PerfArtifactsDir'; these artifacts are automatically exported to a gcs bucket, used in conjunction with the roachperf dashboard.

Having no direct way to distinguish a performance test from a correctness test has several challenges. E.g., performance tests may require a specific machine type or architecture; background workloads like incremental backup may cause a performance regression; new metamorphic configurations like arm64 and fips may require a "bake-in" time before performance tests can be enabled. In future, the test runner may make specialized decisions (e.g., don't reuse a cluster) when executing a performance test. Thus, we need a (standard) mechanism to enumerate all performance tests. Given their specific requirements, the test author must explicitly opt in, by setting TestSpec.Benchmark to 'true'.

This PR applies the above change retroactively, i.e., setting 'TestSpec.Benchmark' for all _known_ performance tests, including those which _assert_ on performance instead of exporting stats.json.
It also fixes `roachtest list --bench` and `roachtest bench`, which were out-of-date, albeit not actively used.

Epic: none
Release note: None
