### PR TITLE
constraint: perform cancel checking when combining constraints

### DIFF
--- a/pkg/sql/opt/constraint/BUILD.bazel
+++ b/pkg/sql/opt/constraint/BUILD.bazel
@@ -51,5 +51,8 @@ go_test(
         "//pkg/util/intsets",
         "//pkg/util/leaktest",
         "//pkg/util/randutil",
+        "//pkg/util/timeutil",
+        "@com_github_cockroachdb_errors//:errors",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/sql/opt/idxconstraint/index_constraints.go
+++ b/pkg/sql/opt/idxconstraint/index_constraints.go
@@ -845,11 +845,11 @@ func (c *indexConstraintCtx) makeSpansForAnd(
 			}
 			ofsC.IntersectWith(c.evalCtx, &exprConstraint)
 		}
-		out.Combine(c.evalCtx, &ofsC)
+		out.Combine(c.evalCtx, &ofsC, c.checkCancellation)
 		numIterations++
 		// In case we can't exit this loop, allow the cancel checker to cancel
 		// this query.
-		if (numIterations % 16) == 0 {
+		if (numIterations % constraint.CancelCheckInterval) == 0 {
 			c.checkCancellation()
 		}
 	}


### PR DESCRIPTION
Previously, the combining of constraint spans when one constraint is a
suffix of the other could take a long time and cause the
`statement_timeout` session setting to not be honored when each
constraint has hundreds or thousands of spans.

The issue is that `constraint.Combine` has double nested loops to
consider every combination of one span from one constraint with one span
of the other constraint. The building of possibly millions of spans
may take excessive CPU time and allocate excessive amounts of memory.

The fix is to maintain a counter in `constraint.Combine` and call the
query cancel check function every 16 iterations. The cancel check
function itself will check for query timeout every 1024 iterations, so
effectively every 16K iterations `constraint.Combine` will perform
cancel checking and abort the query if the timeout has been reached.

Epic: none
Fixes: #111862

Release note (bug fix): This patch fixes an issue where the optimizer
fails to honor the `statement_timeout` session setting when generating
constrained index scans for queries with large IN lists or `= ANY`
predicates on multiple index key columns, which may lead to an out
of memory condition on the node.