### PR TITLE
sql: change type for RU estimates from integer to floating-point

### DIFF
--- a/pkg/ccl/multitenantccl/tenantcostclient/query_ru_estimate_test.go
+++ b/pkg/ccl/multitenantccl/tenantcostclient/query_ru_estimate_test.go
@@ -138,11 +138,11 @@ func TestEstimateQueryRUConsumption(t *testing.T) {
 	}
 
 	var err error
-	var tenantEstimatedRUs int
+	var tenantEstimatedRUs float64
 	for _, tc := range testCases {
 		for i := 0; i < tc.count; i++ {
 			output := tdb.QueryStr(t, "EXPLAIN ANALYZE "+tc.sql)
-			var estimatedRU int
+			var estimatedRU float64
 			for _, row := range output {
 				if len(row) != 1 {
 					t.Fatalf("expected one column")
@@ -152,7 +152,7 @@ func TestEstimateQueryRUConsumption(t *testing.T) {
 					substr := strings.Split(val, " ")
 					require.Equalf(t, 4, len(substr), "expected RU consumption message to have four words")
 					ruCountStr := strings.Replace(strings.TrimSpace(substr[3]), ",", "", -1)
-					estimatedRU, err = strconv.Atoi(ruCountStr)
+					estimatedRU, err = strconv.ParseFloat(ruCountStr, 64)
 					require.NoError(t, err, "failed to retrieve estimated RUs")
 					break
 				}

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -1968,8 +1968,8 @@ func populateQueryLevelStats(
 			if costController := cfg.DistSQLSrv.TenantCostController; costController != nil {
 				if costCfg := costController.GetCostConfig(); costCfg != nil {
 					networkEgressRUEstimate := costCfg.PGWireEgressCost(topLevelStats.networkEgressEstimate)
-					ih.queryLevelStatsWithErr.Stats.RUEstimate += int64(networkEgressRUEstimate)
-					ih.queryLevelStatsWithErr.Stats.RUEstimate += int64(cpuStats.EndCollection(ctx))
+					ih.queryLevelStatsWithErr.Stats.RUEstimate += float64(networkEgressRUEstimate)
+					ih.queryLevelStatsWithErr.Stats.RUEstimate += cpuStats.EndCollection(ctx)
 				}
 			}
 		}

--- a/pkg/sql/execstats/traceanalyzer.go
+++ b/pkg/sql/execstats/traceanalyzer.go
@@ -126,7 +126,7 @@ type NodeLevelStats struct {
 	MvccRangeKeySkippedPointsGroupedByNode          map[base.SQLInstanceID]int64
 	NetworkMessagesGroupedByNode                    map[base.SQLInstanceID]int64
 	ContentionTimeGroupedByNode                     map[base.SQLInstanceID]time.Duration
-	RUEstimateGroupedByNode                         map[base.SQLInstanceID]int64
+	RUEstimateGroupedByNode                         map[base.SQLInstanceID]float64
 	CPUTimeGroupedByNode                            map[base.SQLInstanceID]time.Duration
 }
 
@@ -158,7 +158,7 @@ type QueryLevelStats struct {
 	NetworkMessages                    int64
 	ContentionTime                     time.Duration
 	ContentionEvents                   []kvpb.ContentionEvent
-	RUEstimate                         int64
+	RUEstimate                         float64
 	CPUTime                            time.Duration
 	SqlInstanceIds                     map[base.SQLInstanceID]struct{}
 	Regions                            []string
@@ -310,7 +310,7 @@ func (a *TraceAnalyzer) ProcessStats() error {
 		MvccRangeKeySkippedPointsGroupedByNode:          make(map[base.SQLInstanceID]int64),
 		NetworkMessagesGroupedByNode:                    make(map[base.SQLInstanceID]int64),
 		ContentionTimeGroupedByNode:                     make(map[base.SQLInstanceID]time.Duration),
-		RUEstimateGroupedByNode:                         make(map[base.SQLInstanceID]int64),
+		RUEstimateGroupedByNode:                         make(map[base.SQLInstanceID]float64),
 		CPUTimeGroupedByNode:                            make(map[base.SQLInstanceID]time.Duration),
 	}
 	var errs error
@@ -340,7 +340,7 @@ func (a *TraceAnalyzer) ProcessStats() error {
 		a.nodeLevelStats.MvccRangeKeyContainedPointsGroupedByNode[instanceID] += int64(stats.KV.RangeKeyContainedPoints.Value())
 		a.nodeLevelStats.MvccRangeKeySkippedPointsGroupedByNode[instanceID] += int64(stats.KV.RangeKeySkippedPoints.Value())
 		a.nodeLevelStats.ContentionTimeGroupedByNode[instanceID] += stats.KV.ContentionTime.Value()
-		a.nodeLevelStats.RUEstimateGroupedByNode[instanceID] += int64(stats.Exec.ConsumedRU.Value())
+		a.nodeLevelStats.RUEstimateGroupedByNode[instanceID] += float64(stats.Exec.ConsumedRU.Value())
 		a.nodeLevelStats.CPUTimeGroupedByNode[instanceID] += stats.Exec.CPUTime.Value()
 	}
 
@@ -395,7 +395,7 @@ func (a *TraceAnalyzer) ProcessStats() error {
 				}
 			}
 			if v.FlowStats.ConsumedRU.HasValue() {
-				a.nodeLevelStats.RUEstimateGroupedByNode[instanceID] += int64(v.FlowStats.ConsumedRU.Value())
+				a.nodeLevelStats.RUEstimateGroupedByNode[instanceID] += float64(v.FlowStats.ConsumedRU.Value())
 			}
 		}
 	}

--- a/pkg/sql/opt/exec/explain/output.go
+++ b/pkg/sql/opt/exec/explain/output.go
@@ -390,11 +390,11 @@ func (ob *OutputBuilder) AddCPUTime(cpuTime time.Duration) {
 
 // AddRUEstimate adds a top-level field for the estimated number of RUs consumed
 // by the query.
-func (ob *OutputBuilder) AddRUEstimate(ru int64) {
+func (ob *OutputBuilder) AddRUEstimate(ru float64) {
 	ob.AddFlakyTopLevelField(
 		DeflakeVolatile,
 		"estimated RUs consumed",
-		string(humanizeutil.Count(uint64(ru))),
+		string(humanizeutil.Countf(ru)),
 	)
 }
 

--- a/pkg/util/humanizeutil/count.go
+++ b/pkg/util/humanizeutil/count.go
@@ -20,3 +20,7 @@ import (
 func Count(val uint64) redact.SafeString {
 	return redact.SafeString(humanize.Comma(int64(val)))
 }
+
+func Countf(val float64) redact.SafeString {
+	return redact.SafeString(humanize.Commaf(val))
+}


### PR DESCRIPTION
This patch changes the display for RU estimates shown in `EXPLAIN ANALYZE` from
integer to float. This will prevent small estimates from being rounded to zero, which
makes the estimate less confusing for cheap queries.

Fixes #100617

Release note(sql change): Currently, RUs are showing integer number.
RUs have the potensial to be floating number, however they are now rounded.
From now on, RUs are showing floating number, so they are not rounded.