### PR TITLE
sql/logictest: fix UDF execute privileges mixed version test

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/mixed_version_udf_execute_privileges
+++ b/pkg/sql/logictest/testdata/logic_test/mixed_version_udf_execute_privileges
@@ -74,9 +74,27 @@ true
 query B retry
 SELECT crdb_internal.is_at_least_version('23.1-26')
 ----
-false
+true
 
-# Makes sure the user still has the ability to execute f.
+query TTTTTTB colnames
+SELECT * FROM [SHOW GRANTS ON FUNCTION f] ORDER BY grantee
+----
+database_name  schema_name  routine_id  routine_signature  grantee  privilege_type  is_grantable
+test           public       100106      f()                admin    ALL             true
+test           public       100106      f()                public   EXECUTE         false
+test           public       100106      f()                root     ALL             true
+
+user testuser1 nodeidx=1
+
+# Makes sure the user can execute f on node 1.
+query I
+SELECT f()
+----
+1
+
+user testuser1 nodeidx=2
+
+# Makes sure the user can execute f on node 2.
 query I
 SELECT f()
 ----


### PR DESCRIPTION
The tests for UDF execute privileges in mixed version clusters was
not waiting for the upgrade to fully succeed at the end of the test like
it was intended to (likely due to a `--rewrite` of a `retry` test that
was missed). This has been fixed.

Epic: None

Release note: None
