### PR TITLE
server: use tenant capability watcher in orchestrator

### DIFF
--- a/pkg/server/drain.go
+++ b/pkg/server/drain.go
@@ -336,7 +336,7 @@ func (s *drainServer) drainInner(
 		// We are on a KV node, with a server controller.
 		//
 		// First tell the controller to stop starting new servers.
-		s.serverCtl.draining.Set(true)
+		s.serverCtl.SetDraining()
 
 		// Then shut down tenant servers orchestrated from
 		// this node.

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1221,6 +1221,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterf
 		&systemServerWrapper{server: lateBoundServer},
 		systemTenantNameContainer,
 		pgPreServer.SendRoutingError,
+		tenantCapabilitiesWatcher,
 	)
 	drain.serverCtl = sc
 


### PR DESCRIPTION
This changes over from polling to using the capability watcher to observe virtual cluster service mode changes.

On the surface, it may seem like this make us less responsive since our poll interval was 1 seconds and by default we will only see an update every 3 seconds from the watcher.

However, when we were using the polling approach, what was likely to happen is that the server would fail to start up until the tenant watcher caught up anyway, since the tenant server does a service-mode check using the capability watcher.

Fixes #107827.
Epic: CRDB-26691

Release note: None