### PR TITLE
sql: disallow identifiers after numeric constants

### DIFF
--- a/pkg/sql/parser/scanner_test.go
+++ b/pkg/sql/parser/scanner_test.go
@@ -356,6 +356,9 @@ func TestScanError(t *testing.T) {
 		{`$0`, "placeholder index must be between 1 and 65536"},
 		{`$9223372036854775809`, "placeholder index must be between 1 and 65536"},
 		{`B'123'`, `"2" is not a valid binary digit`},
+		{`123foo`, "trailing junk after numeric literal at or near \"123f\""},
+		{`1.23foo`, "trailing junk after numeric literal at or near \"1.23f\""},
+		{`0x0afoo`, "trailing junk after numeric literal at or near \"0x0afo\""},
 	}
 	for _, d := range testData {
 		s := makeSQLScanner(d.sql)

--- a/pkg/sql/scanner/scan.go
+++ b/pkg/sql/scanner/scan.go
@@ -720,6 +720,13 @@ func (s *Scanner) scanNumber(lval ScanSymType, ch int) {
 		break
 	}
 
+	// Disallow identifier after numerical constants e.g. "124foo".
+	if lexbase.IsIdentStart(s.peek()) {
+		lval.SetID(lexbase.ERROR)
+		lval.SetStr(fmt.Sprintf("trailing junk after numeric literal at or near %q", s.in[start:s.pos+1]))
+		return
+	}
+
 	lval.SetStr(s.in[start:s.pos])
 	if hasDecimal || hasExponent {
 		lval.SetID(lexbase.FCONST)


### PR DESCRIPTION
Release note (sql change): Match Postgres 15 behavior and disallow
identifiers after numeric constants not separated by whitespace.

Fixes #111037