### PR TITLE
server: set pprof label on shared-process tenants

### DIFF
--- a/pkg/server/server_controller_channel_orchestrator.go
+++ b/pkg/server/server_controller_channel_orchestrator.go
@@ -12,6 +12,7 @@ package server
 
 import (
 	"context"
+	"runtime/pprof"
 	"sync"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -325,6 +326,14 @@ func (o *channelOrchestrator) startControlledServer(
 		// RunAsyncTask, because this stopper will be assigned its own
 		// different tracer.
 		ctx := tenantCtx
+
+		// Set the pprof label to more easily identify
+		// goroutines related to this virtual cluster. The
+		// calls here are exactly what pprof.Do does.
+		defer pprof.SetGoroutineLabels(ctx)
+		ctx = pprof.WithLabels(ctx, pprof.Labels("cluster", string(tenantName)))
+		pprof.SetGoroutineLabels(ctx)
+
 		// We want a context that gets cancelled when the server is
 		// shutting down, for the possible few cases in
 		// newServerInternal/preStart/acceptClients which are not looking at the


### PR DESCRIPTION
In shared-process mode, for any given component of SQL server, we will have multiple copies running (one for each running tenant). When reading stacks it might be useful to be able to identify which tenant they are related to.

Epic: CRDB-27982

Release note: None