### PR TITLE
cli: remove redundant hex_ columns in debug.zip output

### DIFF
--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -711,8 +711,8 @@ The default value for --schema is 'cockroach.sql.sqlbase.Descriptor'.
 For example:
 
 $ cat debug/system.descriptor.txt | cockroach debug decode-proto
-id	descriptor	hex_descriptor
-1	\022!\012\006system\020\001\032\025\012\011\012\005admin\0200\012\010\012\004root\0200	{"database": {"id": 1, "modificationTime": {}, "name": "system", "privileges": {"users": [{"privileges": 48, "user": "admin"}, {"privileges": 48, "user": "root"}]}}}
+id	descriptor
+1	{"database": {"id": 1, "modificationTime": {}, "name": "system", "privileges": {"users": [{"privileges": 48, "user": "admin"}, {"privileges": 48, "user": "root"}]}}}
 ...
 
 decode-proto can be used to decode protos as captured by Chrome Dev

--- a/pkg/cli/zip_table_registry.go
+++ b/pkg/cli/zip_table_registry.go
@@ -399,9 +399,7 @@ var zipInternalTablesPerCluster = DebugZipTableRegistry{
 	"crdb_internal.system_jobs": {
 		// `payload` column may contain customer info, such as URI params
 		// containing access keys, encryption salts, etc.
-		customQueryUnredacted: `SELECT *, 
-			to_hex(payload) AS hex_payload, 
-			to_hex(progress) AS hex_progress 
+		customQueryUnredacted: `SELECT *
 			FROM crdb_internal.system_jobs`,
 		customQueryRedacted: `SELECT 
 			"id",
@@ -414,9 +412,7 @@ var zipInternalTablesPerCluster = DebugZipTableRegistry{
 			"claim_session_id",
 			"claim_instance_id",
 			"num_runs",
-			"last_run", 
-			'<redacted>' AS "hex_payload", 
-			to_hex(progress) AS "hex_progress"
+			"last_run"
 			FROM crdb_internal.system_jobs`,
 	},
 	"crdb_internal.kv_system_privileges": {
@@ -1005,13 +1001,11 @@ var zipSystemTables = DebugZipTableRegistry{
 	"system.descriptor": {
 		customQueryUnredacted: `SELECT
 				id,
-				descriptor,
-				to_hex(descriptor) AS hex_descriptor
+				descriptor
 			FROM system.descriptor`,
 		customQueryRedacted: `SELECT
 				id,
-				crdb_internal.redact_descriptor(descriptor) AS descriptor,
-				to_hex(crdb_internal.redact_descriptor(descriptor)) AS hex_descriptor
+				crdb_internal.redact_descriptor(descriptor) AS descriptor
 			FROM system.descriptor`,
 	},
 	"system.eventlog": {
@@ -1036,9 +1030,7 @@ var zipSystemTables = DebugZipTableRegistry{
 	"system.jobs": {
 		// NB: `payload` column may contain customer info, such as URI params
 		// containing access keys, encryption salts, etc.
-		customQueryUnredacted: `SELECT *, 
-			to_hex(payload) AS hex_payload, 
-			to_hex(progress) AS hex_progress 
+		customQueryUnredacted: `SELECT * 
 			FROM system.jobs`,
 		customQueryRedacted: `SELECT id,
 			status,
@@ -1050,16 +1042,13 @@ var zipSystemTables = DebugZipTableRegistry{
 			claim_session_id,
 			claim_instance_id,
 			num_runs,
-			last_run,
-			'<redacted>' AS hex_payload,
-			to_hex(progress) AS hex_progress
+			last_run
 			FROM system.jobs`,
 	},
 	"system.job_info": {
 		// `value` column may contain customer info, such as URI params
 		// containing access keys, encryption salts, etc.
-		customQueryUnredacted: `SELECT *,
-			to_hex(value) AS hex_value
+		customQueryUnredacted: `SELECT *
 			FROM system.job_info`,
 		customQueryRedacted: `SELECT job_id,
 			info_key,
@@ -1214,16 +1203,15 @@ var zipSystemTables = DebugZipTableRegistry{
 		},
 	},
 	"system.settings": {
-		customQueryUnredacted: `SELECT *, to_hex(value) as hex_value FROM system.settings`,
+		customQueryUnredacted: `SELECT * FROM system.settings`,
 		customQueryRedacted: `SELECT * FROM (
-    		SELECT *, to_hex(value) as hex_value
+    		SELECT *
     		FROM system.settings
 			WHERE "valueType" <> 's'
     	) UNION (
 			SELECT name, '<redacted>' as value,
 			"lastUpdated",
-			"valueType",
-			to_hex('redacted') as hex_value
+			"valueType"
 			FROM system.settings
 			WHERE "valueType"  = 's'
     	)`,

--- a/pkg/cli/zip_test.go
+++ b/pkg/cli/zip_test.go
@@ -750,7 +750,7 @@ func TestToHex(t *testing.T) {
 	// hex fields are always in the end of the row and they don't contain spaces.
 	hexFiles := map[string][]hexField{
 		"debug/system.descriptor.txt": {
-			{idx: 2, msg: &descpb.Descriptor{}},
+			{idx: 1, msg: &descpb.Descriptor{}},
 		},
 	}
 
@@ -785,7 +785,8 @@ func TestToHex(t *testing.T) {
 			if i < 0 {
 				i = len(fields) + i
 			}
-			bts, err := enc_hex.DecodeString(fields[i])
+			// [2:] to skip \x
+			bts, err := enc_hex.DecodeString(fields[i][2:])
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
In cockroachdb/cockroach#80398 we fixed the CLI to respect bytea_output
session variable and properly output BYTES columns in \xDEADBEEF format.
Now we don't need the extra hex_ columns. This makes debug.zips smaller
and quicker to create (jobs payloads can get big and so can descriptors
for large tables).

In order not to break cockroach debug decode-proto extend it to look
for and remove the \x prefix when attempting to decode hex.

Fixes: #112032
Epic: none
Release note (cli change): debug zip's no longer include redundant hex_
columns for system table BYTES columns.
