### PR TITLE
kvflowcontroller: clean up log message

### DIFF
--- a/pkg/kv/kvserver/kvflowcontrol/kvflowcontroller/kvflowcontroller_metrics.go
+++ b/pkg/kv/kvserver/kvflowcontrol/kvflowcontroller/kvflowcontroller_metrics.go
@@ -264,14 +264,14 @@ func newMetrics(c *Controller) *metrics {
 						}
 						if streamStatsCount <= streamStatsCountCap {
 							var b strings.Builder
-							fmt.Fprintf(&b, "stream %s was blocked: durations: ", stream.String())
+							fmt.Fprintf(&b, "stream %s was blocked: durations:", stream.String())
 							if regularStats.noTokenDuration > 0 {
-								fmt.Fprintf(&b, "regular %s", regularStats.noTokenDuration.String())
+								fmt.Fprintf(&b, " regular %s", regularStats.noTokenDuration.String())
 							}
 							if elasticStats.noTokenDuration > 0 {
-								fmt.Fprintf(&b, "elastic %s", elasticStats.noTokenDuration.String())
+								fmt.Fprintf(&b, " elastic %s", elasticStats.noTokenDuration.String())
 							}
-							fmt.Fprintf(&b, "tokens deducted: regular %s elastic %s",
+							fmt.Fprintf(&b, " tokens deducted: regular %s elastic %s",
 								humanize.Bytes(uint64(regularStats.tokensDeducted)),
 								humanize.Bytes(uint64(elasticStats.tokensDeducted)))
 							log.Infof(context.Background(), "%s", redact.SafeString(b.String()))


### PR DESCRIPTION
I recently opened a log and saw a lot of these message. The missing spaces makes them a little hard to read.

```
I231008 13:50:07.259185 463
kv/kvserver/kvflowcontrol/kvflowcontroller/kvflowcontroller_metrics.go:277
[-] 874 stream t1/s3 was blocked: durations: elastic
1.234898023stokens deducted: regular 0 B elastic 108 MB
```

Epic: none

Release note: None