### PR TITLE
kvserver,storage: logging and tracing of export requests

### DIFF
--- a/pkg/kv/kvpb/api.proto
+++ b/pkg/kv/kvpb/api.proto
@@ -3592,7 +3592,9 @@ message ScanStats {
   // NumGets, NumScans, and NumReverseScans tracks the number of Gets, Scans,
   // and ReverseScans, respectively, that were actually evaluated as part of the
   // BatchResponse. These don't include requests that were not evaluated due to
-  // reaching the BatchResponse's limits or an error.
+  // reaching the BatchResponse's limits or an error. NumScans also tracks the
+  // number of ExportRequests evaluated (including ones that resulted in an
+  // error).
   uint64 num_gets = 17;
   uint64 num_scans = 18;
   uint64 num_reverse_scans = 19;

--- a/pkg/kv/kvserver/batcheval/cmd_export.go
+++ b/pkg/kv/kvserver/batcheval/cmd_export.go
@@ -190,6 +190,7 @@ func evalExport(
 			MaxSize:            maxSize,
 			MaxLockConflicts:   maxLockConflicts,
 			StopMidKey:         args.SplitMidKey,
+			ScanStats:          cArgs.ScanStats,
 		}
 		var summary kvpb.BulkOpSummary
 		var resumeInfo storage.ExportRequestResumeInfo

--- a/pkg/kv/kvserver/batcheval/declare.go
+++ b/pkg/kv/kvserver/batcheval/declare.go
@@ -210,8 +210,8 @@ type CommandArgs struct {
 	Now     hlc.ClockTimestamp
 	// *Stats should be mutated to reflect any writes made by the command.
 	Stats *enginepb.MVCCStats
-	// ScanStats should be mutated to reflect Get and Scan/ReverseScan reads
-	// made by the command.
+	// ScanStats should be mutated to reflect Get, Scan, ReverseScan,
+	// ExportRequest reads made by the command.
 	ScanStats             *kvpb.ScanStats
 	Concurrency           *concurrency.Guard
 	Uncertainty           uncertainty.Interval

--- a/pkg/storage/intent_interleaving_iter.go
+++ b/pkg/storage/intent_interleaving_iter.go
@@ -1339,13 +1339,7 @@ func (i *intentInterleavingIter) FindSplitKey(
 func (i *intentInterleavingIter) Stats() IteratorStats {
 	stats := i.iter.Stats()
 	intentStats := i.intentIter.Stats()
-	for i := pebble.IteratorStatsKind(0); i < pebble.NumStatsKind; i++ {
-		stats.Stats.ForwardSeekCount[i] += intentStats.Stats.ForwardSeekCount[i]
-		stats.Stats.ReverseSeekCount[i] += intentStats.Stats.ReverseSeekCount[i]
-		stats.Stats.ForwardStepCount[i] += intentStats.Stats.ForwardStepCount[i]
-		stats.Stats.ReverseStepCount[i] += intentStats.Stats.ReverseStepCount[i]
-	}
-	stats.Stats.InternalStats.Merge(intentStats.Stats.InternalStats)
+	stats.Stats.Merge(intentStats.Stats)
 	return stats
 }
 

--- a/pkg/storage/mvcc_incremental_iterator.go
+++ b/pkg/storage/mvcc_incremental_iterator.go
@@ -785,6 +785,16 @@ func (i *MVCCIncrementalIterator) TryGetIntentError() error {
 	}
 }
 
+// Stats returns statistics about the iterator.
+func (i *MVCCIncrementalIterator) Stats() IteratorStats {
+	stats := i.iter.Stats()
+	if i.timeBoundIter != nil {
+		tbStats := i.timeBoundIter.Stats()
+		stats.Stats.Merge(tbStats.Stats)
+	}
+	return stats
+}
+
 // assertInvariants asserts iterator invariants. The iterator must be valid.
 func (i *MVCCIncrementalIterator) assertInvariants() error {
 	// Check general SimpleMVCCIterator API invariants.


### PR DESCRIPTION
- batcheval.CommandArgs.ScanStats are now populated for ExportRequest, so if tracing is enabled, they will be recorded in a trace span. This does not change whether tracing is possible for such internally originating export requests.

- When the export request evaluation exceeds the deadlne, and --vmodule=mvcc=1, the scan stats are logged. This can be used to diagnose chronic failures.

Relates to https://github.com/cockroachlabs/support/issues/2554

Epic: none

Release note: None