### PR TITLE
sql/sem/tree: fix `ALTER FUNCTION` formatting

### DIFF
--- a/pkg/sql/parser/testdata/alter_function
+++ b/pkg/sql/parser/testdata/alter_function
@@ -37,7 +37,7 @@ ALTER FUNCTION f(int) RENAME TO g
 ALTER FUNCTION f(IN INT8) RENAME TO g -- normalized!
 ALTER FUNCTION f(IN INT8) RENAME TO g -- fully parenthesized
 ALTER FUNCTION f(IN INT8) RENAME TO g -- literals removed
-ALTER FUNCTION _(IN INT8) RENAME TO g -- identifiers removed
+ALTER FUNCTION _(IN INT8) RENAME TO _ -- identifiers removed
 
 parse
 ALTER FUNCTION f(int) OWNER TO CURRENT_USER
@@ -53,7 +53,7 @@ ALTER FUNCTION f(int) SET SCHEMA test_sc
 ALTER FUNCTION f(IN INT8) SET SCHEMA test_sc -- normalized!
 ALTER FUNCTION f(IN INT8) SET SCHEMA test_sc -- fully parenthesized
 ALTER FUNCTION f(IN INT8) SET SCHEMA test_sc -- literals removed
-ALTER FUNCTION _(IN INT8) SET SCHEMA test_sc -- identifiers removed
+ALTER FUNCTION _(IN INT8) SET SCHEMA _ -- identifiers removed
 
 parse
 ALTER FUNCTION f(int) DEPENDS ON EXTENSION postgis

--- a/pkg/sql/parser/testdata/alter_procedure
+++ b/pkg/sql/parser/testdata/alter_procedure
@@ -4,7 +4,7 @@ ALTER PROCEDURE p(int) RENAME TO g
 ALTER PROCEDURE p(IN INT8) RENAME TO g -- normalized!
 ALTER PROCEDURE p(IN INT8) RENAME TO g -- fully parenthesized
 ALTER PROCEDURE p(IN INT8) RENAME TO g -- literals removed
-ALTER PROCEDURE _(IN INT8) RENAME TO g -- identifiers removed
+ALTER PROCEDURE _(IN INT8) RENAME TO _ -- identifiers removed
 
 parse
 ALTER PROCEDURE p(int) OWNER TO CURRENT_USER
@@ -20,7 +20,7 @@ ALTER PROCEDURE p(int) SET SCHEMA test_sc
 ALTER PROCEDURE p(IN INT8) SET SCHEMA test_sc -- normalized!
 ALTER PROCEDURE p(IN INT8) SET SCHEMA test_sc -- fully parenthesized
 ALTER PROCEDURE p(IN INT8) SET SCHEMA test_sc -- literals removed
-ALTER PROCEDURE _(IN INT8) SET SCHEMA test_sc -- identifiers removed
+ALTER PROCEDURE _(IN INT8) SET SCHEMA _ -- identifiers removed
 
 error
 ALTER PROCEDURE p()

--- a/pkg/sql/sem/tree/create_routine.go
+++ b/pkg/sql/sem/tree/create_routine.go
@@ -501,7 +501,7 @@ func (node *AlterRoutineRename) Format(ctx *FmtCtx) {
 	}
 	ctx.FormatNode(&node.Function)
 	ctx.WriteString(" RENAME TO ")
-	ctx.WriteString(string(node.NewName))
+	ctx.FormatNode(&node.NewName)
 }
 
 // AlterRoutineSetSchema represents a ALTER FUNCTION...SET SCHEMA or
@@ -521,7 +521,7 @@ func (node *AlterRoutineSetSchema) Format(ctx *FmtCtx) {
 	}
 	ctx.FormatNode(&node.Function)
 	ctx.WriteString(" SET SCHEMA ")
-	ctx.WriteString(string(node.NewSchemaName))
+	ctx.FormatNode(&node.NewSchemaName)
 }
 
 // AlterRoutineSetOwner represents the ALTER FUNCTION...OWNER TO or


### PR DESCRIPTION
This commit fixes a minor bug in the formatting of
`ALTER FUNCTION .. RENAME TO` and `ALTER FUNCTION .. SET SCHEMA`
statements that prevented identifiers from being anonymized.

Epic: None

Release note: None
