### PR TITLE
server: remove --secondary-tenant-port-offset

### DIFF
--- a/pkg/base/addr_validation.go
+++ b/pkg/base/addr_validation.go
@@ -83,11 +83,6 @@ func (cfg *Config) ValidateAddrs(ctx context.Context) error {
 	}
 	cfg.HTTPAddr = net.JoinHostPort(httpHost, httpPort)
 
-	// Validate secondary tenant port configuration.
-	if cfg.SecondaryTenantPortOffset > 0 && cfg.ApplicationInternalRPCPortMin > 0 {
-		return errors.Newf("cannot specify both %s and %s", cliflags.ApplicationInternalRPCPortRange.Name, cliflags.SecondaryTenantPortOffset.Name)
-	}
-
 	return nil
 }
 

--- a/pkg/base/config.go
+++ b/pkg/base/config.go
@@ -413,15 +413,6 @@ type Config struct {
 	// RPCHearbeatTimeout is the timeout for Ping requests.
 	RPCHeartbeatTimeout time.Duration
 
-	// SecondaryTenantPortOffset is the increment to add to the various
-	// addresses to generate the network configuration for the in-memory
-	// secondary tenant. If set to zero (the default), ports are
-	// auto-allocated randomly.
-	// TODO(knz): Remove this mechanism altogether in favor of a single
-	// network listener with protocol routing.
-	// See: https://github.com/cockroachdb/cockroach/issues/84585
-	SecondaryTenantPortOffset int
-
 	// ApplicationInternalRPCPortMin/PortMax define the range of TCP ports
 	// used to start the internal RPC service for application-level
 	// servers. This service is used for node-to-node RPC traffic and to
@@ -501,7 +492,6 @@ func (cfg *Config) InitDefaults() {
 	cfg.DisableClusterNameVerification = false
 	cfg.ClockDevicePath = ""
 	cfg.AcceptSQLWithoutTLS = false
-	cfg.SecondaryTenantPortOffset = 0
 	cfg.ApplicationInternalRPCPortMin = 0
 	cfg.ApplicationInternalRPCPortMax = 0
 }

--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -144,11 +144,6 @@ accept requests.`,
 
 	// TODO(knz): Remove this once https://github.com/cockroachdb/cockroach/issues/84604
 	// is addressed.
-	SecondaryTenantPortOffset = FlagInfo{
-		Name:        "secondary-tenant-port-offset",
-		Description: "TCP port number offset to use for the secondary in-memory tenant.",
-	}
-
 	ApplicationInternalRPCPortRange = FlagInfo{
 		Name: "internal-rpc-port-range",
 		Description: `

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -540,11 +540,8 @@ func init() {
 			cliflagcfg.BoolFlag(f, &startBackground, cliflags.Background)
 		}
 
-		// TODO(knz): Remove these port configuration mechanisms once we implement
+		// TODO(knz): Remove this port configuration mechanism once we implement
 		// a shared listener. See: https://github.com/cockroachdb/cockroach/issues/84585
-		cliflagcfg.IntFlag(f, &baseCfg.SecondaryTenantPortOffset, cliflags.SecondaryTenantPortOffset)
-		_ = f.MarkHidden(cliflags.SecondaryTenantPortOffset.Name)
-
 		cliflagcfg.VarFlag(f, addr.NewPortRangeSetter(&baseCfg.ApplicationInternalRPCPortMin, &baseCfg.ApplicationInternalRPCPortMax), cliflags.ApplicationInternalRPCPortRange)
 		_ = f.MarkHidden(cliflags.ApplicationInternalRPCPortRange.Name)
 	}

--- a/pkg/server/server_controller_new_server.go
+++ b/pkg/server/server_controller_new_server.go
@@ -252,10 +252,8 @@ func makeSharedProcessTenantServerConfig(
 	//
 	// TODO(knz): use a single network interface for all tenant servers.
 	// See: https://github.com/cockroachdb/cockroach/issues/92524
-	baseCfg.RPCListenerFactory, err = ListenerFactoryForConfig(&kvServerCfg.BaseConfig, portStartHint)
-	if err != nil {
-		return BaseConfig{}, SQLConfig{}, err
-	}
+	baseCfg.RPCListenerFactory = ListenerFactoryForConfig(&kvServerCfg.BaseConfig, portStartHint)
+
 	// We reset the port of the KV Addr configuration to 0. If we
 	// don't have a customized listener factory, this will force
 	// the operating system to choose a port by default.


### PR DESCRIPTION
The new internal-rpc-port-range provides the user to specify a known
range of ports to use for internal RPC listeners. The port offset
setting was attempting to provide predictability but without a clear
upper bound.

While we could leave this configuration option in place, it only
becomes harder to remove if we continue to have it in place in 23.2.

First two commits from #111798

Epic: CRDB-26691

Release note (cluster virtualization): This removes the hidden
--secondary-tenant-port-offset option. Users who were previously using
this option should use --internal-rpc-port-range instead.