### PR TITLE
bulk: disable as-we-fill scatters for PCR

### DIFF
--- a/pkg/kv/bulk/sst_batcher.go
+++ b/pkg/kv/bulk/sst_batcher.go
@@ -259,12 +259,19 @@ func MakeStreamSSTBatcher(
 		ingestAll: true,
 		mem:       mem,
 		limiter:   sendLimiter,
-		// We use NormalPri since anything lower than normal
-		// priority is assumed to be able to handle reduced
-		// throughput. We are OK witht his for now since the
-		// consuming cluster of a replication stream does not
-		// have a latency sensitive workload running against
-		// it.
+		// disableScatters is set to true to disable scattering as-we-fill. The
+		// replication job already pre-splits and pre-scatters its target ranges to
+		// distribute the ingestion load.
+		//
+		// If the batcher knows that it is about to overfill a range, it always
+		// makes sense to split it before adding to it, rather than overfill it. It
+		// does not however make sense to scatter that range as the RHS maybe
+		// non-empty.
+		disableScatters: true,
+		// We use NormalPri since anything lower than normal priority is assumed to
+		// be able to handle reduced throughput. We are OK with his for now since
+		// the consuming cluster of a replication stream does not have a latency
+		// sensitive workload running against it.
 		priority: admissionpb.NormalPri,
 	}
 	b.mu.lastFlush = timeutil.Now()


### PR DESCRIPTION
In #111952 we saw log lines indicating that the SST batcher was attempting to scatter ranges that were bigger than our "max scatter size". This is likely because of the out-of-order nature of PCR's ingestion which means that the batcher is not guaranteed to have an empty RHS when it splits a soon-to-be overfull range.

This change disable the as-we-fill scatters for PCR similar to how we disable them for restore. This is okay since the process already pre-splits and scatters the ranges into which the processors will ingest data.

Informs: #111952
Release note: None