### PR TITLE
streamingccl: disallow revert of system tenant

### DIFF
--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_manager_test.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_manager_test.go
@@ -54,6 +54,11 @@ func TestRevertTenantToTimestamp(t *testing.T) {
 		require.ErrorContains(t, err, "does not exist")
 		require.Error(t, err)
 	})
+	t.Run("errors if tenant is the system tenant", func(t *testing.T) {
+		_, err := systemDB.Exec("SELECT crdb_internal.unsafe_revert_tenant_to_timestamp('system', cluster_logical_timestamp())")
+		require.ErrorContains(t, err, "cannot revert the system tenant")
+		require.Error(t, err)
+	})
 	t.Run("requires the MANAGETENANT permission", func(t *testing.T) {
 		systemSQL.Exec(t, "CREATE ROLE otheruser LOGIN")
 		systemSQL.Exec(t, "SET role=otheruser")


### PR DESCRIPTION
This seems like a bad idea to allow. It was already technically disallowed because we do a service mode check and it is not possible to modify the service mode of the system tenant without manually modifying the system table.

But, this still gives a better error message.

Epic: none

Release note: none