### PR TITLE
sql: loosen CommandResultErrBase.SetError contract

### DIFF
--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -1004,8 +1004,12 @@ func (r *DistSQLReceiver) setStatus(s execinfra.ConsumerStatus) {
 // rowResultWriter is a subset of CommandResult to be used with the
 // DistSQLReceiver. It's implemented by RowResultWriter.
 type rowResultWriter interface {
-	// AddRow writes a result row.
+	// AddRow writes a result row. The returned error is a "communication error"
+	// which should result in closing the connection.
+	//
 	// Note that the caller owns the row slice and might reuse it.
+	//
+	// If an error has been previously set, this method is a noop.
 	AddRow(ctx context.Context, row tree.Datums) error
 	SetRowsAffected(ctx context.Context, n int)
 	SetError(error)
@@ -1015,6 +1019,10 @@ type rowResultWriter interface {
 // batchResultWriter is a subset of CommandResult to be used with the
 // DistSQLReceiver when the consumer can operate on columnar batches directly.
 type batchResultWriter interface {
+	// AddBatch writes a result batch. The returned error is a "communication
+	// error" which should result in closing the connection.
+	//
+	// If an error has been previously set, this method is a noop.
 	AddBatch(context.Context, coldata.Batch) error
 }
 

--- a/pkg/sql/pgwire/command_result.go
+++ b/pkg/sql/pgwire/command_result.go
@@ -62,6 +62,10 @@ type commandResult struct {
 		paramStatusUpdates []paramStatusUpdate
 	}
 
+	// err, if set, is a "regular" query error (i.e. it's not a "communication"
+	// error that would trigger closing the connection). It is set via
+	// SetError() and is not communicated immediately to the client since it can
+	// be updated later.
 	err error
 	// errExpected, if set, enforces that an error had been set when Close is
 	// called.
@@ -216,29 +220,28 @@ func (r *commandResult) SetError(err error) {
 	r.err = err
 }
 
-// beforeAdd should be called before rows are buffered.
-func (r *commandResult) beforeAdd() error {
-	r.assertNotReleased()
-	if r.err != nil {
-		panic(errors.NewAssertionErrorWithWrappedErrf(r.err, "can't call AddRow after having set error"))
-	}
-	r.conn.writerState.fi.registerCmd(r.pos)
-	if err := r.conn.GetErr(); err != nil {
-		return err
-	}
-	if r.err != nil {
-		panic("can't send row after error")
-	}
-	return nil
-}
-
 // JobIdColIdx is based on jobs.BulkJobExecutionResultHeader and
 // jobs.DetachedJobExecutionResultHeader.
 var JobIdColIdx int
 
 // AddRow is part of the sql.RestrictedCommandResult interface.
 func (r *commandResult) AddRow(ctx context.Context, row tree.Datums) error {
-	if err := r.beforeAdd(); err != nil {
+	r.assertNotReleased()
+	// TODO(yuzefovich): there is a possibility of a race on r.err between the
+	// main goroutine calling AddRow and the remote flows canceller goroutine
+	// calling DistSQLReceiver.SetError since the former doesn't happen under
+	// the mutex.
+	if r.err != nil {
+		// Since an error was already set, this is a noop.
+		//
+		// Note that we don't return r.err from this function because it's not a
+		// "communication" error (if it were, then it would've been encountered
+		// on a previous AddRow call, and this AddRow call wouldn't have
+		// happened).
+		return nil
+	}
+	r.conn.writerState.fi.registerCmd(r.pos)
+	if err := r.conn.GetErr(); err != nil {
 		return err
 	}
 	switch r.cmdCompleteTag {
@@ -252,7 +255,22 @@ func (r *commandResult) AddRow(ctx context.Context, row tree.Datums) error {
 
 // AddBatch is part of the sql.RestrictedCommandResult interface.
 func (r *commandResult) AddBatch(ctx context.Context, batch coldata.Batch) error {
-	if err := r.beforeAdd(); err != nil {
+	r.assertNotReleased()
+	// TODO(yuzefovich): there is a possibility of a race on r.err between the
+	// main goroutine calling AddBatch and the remote flows canceller goroutine
+	// calling DistSQLReceiver.SetError since the former doesn't happen under
+	// the mutex.
+	if r.err != nil {
+		// Since an error was already set, this is a noop.
+		//
+		// Note that we don't return r.err from this function because it's not a
+		// "communication" error (if it were, then it would've been encountered
+		// on a previous AddBatch call, and this AddBatch call wouldn't have
+		// happened).
+		return nil
+	}
+	r.conn.writerState.fi.registerCmd(r.pos)
+	if err := r.conn.GetErr(); err != nil {
 		return err
 	}
 	switch r.cmdCompleteTag {
@@ -371,7 +389,12 @@ func (r *commandResult) SendCopyOut(
 
 // SendCopyData is part of the sql.CopyOutResult interface.
 func (r *commandResult) SendCopyData(ctx context.Context, copyData []byte, isHeader bool) error {
-	if err := r.beforeAdd(); err != nil {
+	r.assertNotReleased()
+	if r.err != nil {
+		return r.err
+	}
+	r.conn.writerState.fi.registerCmd(r.pos)
+	if err := r.conn.GetErr(); err != nil {
 		return err
 	}
 	if err := r.conn.bufferCopyData(copyData, r); err != nil {


### PR DESCRIPTION
Previously, `CommandResultErrBase.SetError` contract required that only `SetError`, `Discard`, and `Err` could be called once `SetError` is called. This was asserted in `AddRow` and `AddBatch` which panicked after `SetError`.

However, as of 0c1095e31cf93ea7f177f8bf1750ebab188e02d7 (which we added in 23.1 time frame) this contract could be violated. In particular, it is now possible for the following race between the main `DistSQLReceiver` goroutine and the remote flows canceller goroutine to occur:
- the main goroutine enters `DistSQLReceiver.Push` and is pre-emptied somewhere in the middle of the method, after having checked the consumer status but before calling `AddRow`
- the concurrent canceller goroutine sets the error on `rowResultWriter`
- the main goroutine wakes up and calls `AddRow`, but there is already an error, so we panic.

This commit fixes this problem by loosening the contract of `SetError` to allow any calls to other methods while making most of them noops.

It is a bug fix, but there is no release note because we haven't seen this panic in the wild.

Fixes: #111995.

Release note: None