### PR TITLE
sql: run insert fast-path FK checks in parallel with uniqueness checks

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_insert_fast_path
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_insert_fast_path
@@ -186,3 +186,18 @@ INTO
   hash_sharded_rbr_computed (region_id, my_uuid, my_uuid2, another_id, row_ts)
 VALUES
   ('ap1234', gen_random_uuid(), gen_random_uuid(), 1, TIMESTAMP '2016-01-25 10:10:10.555555')
+
+statement ok
+INSERT INTO users (crdb_region, id, id2, username)
+VALUES ('ap-southeast-2', '5ebfedee-0dcf-41e6-a315-5fa0b51b9992', 9, 'Craig Roacher')
+
+statement ok
+SET tracing = on,kv,results; INSERT INTO user_settings2 (id2, user_id, value)
+VALUES (9, '5ebfedee-0dcf-41e6-a315-5fa0b51b9992', 'foo'); SET tracing = off
+
+# The FK and uniqueness checks should be bundled in a single batch of scans.
+query T rowsort
+SELECT message FROM [SHOW KV TRACE FOR SESSION]
+WHERE message LIKE '%batch%' AND message LIKE '%Scan%'
+----
+r67: sending batch 4 Scan to (n1,s1):1

--- a/pkg/sql/opt/bench/BUILD.bazel
+++ b/pkg/sql/opt/bench/BUILD.bazel
@@ -14,6 +14,7 @@ go_test(
     srcs = [
         "bench_test.go",
         "fk_test.go",
+        "uniq_test.go",
     ],
     args = ["-test.timeout=295s"],
     embed = [":bench"],

--- a/pkg/sql/opt/bench/uniq_test.go
+++ b/pkg/sql/opt/bench/uniq_test.go
@@ -1,0 +1,69 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package bench
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+)
+
+func runUniqBench(
+	b *testing.B,
+	setup func(b *testing.B, r *sqlutils.SQLRunner),
+	run func(b *testing.B, r *sqlutils.SQLRunner),
+) {
+	configs := []struct {
+		name           string
+		insertFastPath bool
+	}{
+		{name: "NoFastPath", insertFastPath: false},
+		{name: "FastPath", insertFastPath: true},
+	}
+
+	for _, cfg := range configs {
+		b.Run(cfg.name, func(b *testing.B) {
+			s, db, _ := serverutils.StartServer(b, base.TestServerArgs{})
+			defer s.Stopper().Stop(context.Background())
+			r := sqlutils.MakeSQLRunner(db)
+			// Don't let auto stats interfere with the test. Stock stats are
+			// sufficient to get the right plans (i.e. lookup join).
+			r.Exec(b, "SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false")
+			r.Exec(b, "SET experimental_enable_unique_without_index_constraints = true")
+			r.Exec(b, fmt.Sprintf("SET enable_insert_fast_path = %v", cfg.insertFastPath))
+			setup(b, r)
+			b.ResetTimer()
+			run(b, r)
+		})
+	}
+}
+
+func BenchmarkUniqInsert(b *testing.B) {
+	defer log.Scope(b).Close(b)
+
+	const numRows = 1000
+	setup := func(b *testing.B, r *sqlutils.SQLRunner) {
+		r.Exec(b, "CREATE TABLE t1 (k int, p int, INDEX (k), UNIQUE WITHOUT INDEX (k))")
+	}
+
+	b.Run("SingleRow", func(b *testing.B) {
+		runUniqBench(b, setup, func(b *testing.B, r *sqlutils.SQLRunner) {
+			for i := 0; i < b.N; i++ {
+				r.Exec(b, fmt.Sprintf("INSERT INTO t1 VALUES (%d, %d)", i, i%numRows))
+			}
+		})
+	})
+}


### PR DESCRIPTION

This commit combines the foreign key checks of insert fast-path with the
uniqueness checks into a single batch so that they may be processed in
parallel for reduced latency.

Epic: CRDB-26290
Informs: #58047

Release note: None

----
bench: insert fast path single row unique check benchmark

This commit adds a small benchmark for single-row insert fast path with
a UNIQUE WITHOUT INDEX constraint.

```
BenchmarkUniqInsert/SingleRow
BenchmarkUniqInsert/SingleRow/NoFastPath
BenchmarkUniqInsert/SingleRow/NoFastPath-10                 1623            634627 ns/op
BenchmarkUniqInsert/SingleRow/FastPath
BenchmarkUniqInsert/SingleRow/FastPath-10                   3058            399215 ns/op
```

Epic: CRDB-26290
Informs: #58047

Release note: None