### PR TITLE
roachtest/cdc: fix race in latency verifier in initial_scan='only' tests

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -654,9 +654,6 @@ func (ca *changeAggregator) Next() (rowenc.EncDatumRow, *execinfrapb.ProducerMet
 				// If the poller errored first, that's the
 				// interesting one, so overwrite `err`.
 				if kvFeedErr := ca.checkKVFeedErr(); kvFeedErr != nil {
-					if log.V(1) {
-						log.Infof(ca.Ctx(), "overwriting error %s", err)
-					}
 					err = kvFeedErr
 				}
 			}
@@ -1389,9 +1386,6 @@ func (cf *changeFrontier) forwardFrontier(resolved jobspb.ResolvedSpan) error {
 		return err
 	}
 
-	if log.V(1) {
-		log.Infof(cf.Ctx(), "forwarding frontier. changed: %t, resolved: %s", frontierChanged, resolved)
-	}
 	cf.maybeLogBehindSpan(frontierChanged)
 
 	// If frontier changed, we emit resolved timestamp.
@@ -1478,21 +1472,12 @@ func (cf *changeFrontier) maybeCheckpointJob(
 		checkpoint.Spans, checkpoint.Timestamp = cf.frontier.getCheckpointSpans(maxBytes)
 	}
 
-	if log.V(1) {
-		log.Infof(cf.Ctx(), "maybe checkpointing job. updateCheckpoint: %t, updateHighWater: %t",
-			updateCheckpoint, updateHighWater)
-	}
-
 	if updateCheckpoint || updateHighWater {
 		if cf.knobs.ShouldCheckpointToJobRecord != nil && !cf.knobs.ShouldCheckpointToJobRecord(cf.frontier.Frontier()) {
 			return false, nil
 		}
 		checkpointStart := timeutil.Now()
 		updated, err := cf.checkpointJobProgress(cf.frontier.Frontier(), checkpoint)
-		if log.V(1) {
-			log.Infof(cf.Ctx(), "checkpointed job progress: updated: %t, highwater: %s, err: %v",
-				updated, cf.frontier.Frontier(), err)
-		}
 		if err != nil {
 			return false, err
 		}

--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -1088,11 +1088,6 @@ func registerCDC(r registry.Registry) {
 		CompatibleClouds: registry.AllExceptAWS,
 		Suites:           registry.Suites(registry.Nightly),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-			vmoduleLevel = 1
-			defer func() {
-				vmoduleLevel = 0
-			}()
-
 			ct := newCDCTester(ctx, t, c)
 			defer ct.Close()
 

--- a/pkg/cmd/roachtest/tests/cdc_bench.go
+++ b/pkg/cmd/roachtest/tests/cdc_bench.go
@@ -166,8 +166,6 @@ func formatSI(num int64) string {
 	return fmt.Sprintf("%d%s", int64(numSI), suffix)
 }
 
-var vmoduleLevel = 0
-
 // makeCDCBenchOptions creates common cluster options for CDC benchmarks.
 func makeCDCBenchOptions() (option.StartOpts, install.ClusterSettings) {
 	opts := option.DefaultStartOpts()
@@ -222,10 +220,6 @@ func makeCDCBenchOptions() (option.StartOpts, install.ClusterSettings) {
 	// due to elevated goroutine scheduling latency.
 	// Current default is 4s which should be sufficient.
 	// settings.Env = append(settings.Env, "COCKROACH_NETWORK_TIMEOUT=6s")
-
-	if vmoduleLevel > 0 {
-		opts.RoachprodOpts.ExtraArgs = []string{"--vmodule=changefeed_processors=2"}
-	}
 
 	return opts, settings
 }

--- a/pkg/cmd/roachtest/tests/cluster_to_cluster.go
+++ b/pkg/cmd/roachtest/tests/cluster_to_cluster.go
@@ -930,7 +930,7 @@ func (rd *replicationDriver) main(ctx context.Context) {
 
 	latencyMonitor := rd.newMonitor(ctx)
 	latencyMonitor.Go(func(ctx context.Context) error {
-		return lv.pollLatency(ctx, rd.setup.dst.db, ingestionJobID, time.Second, workloadDoneCh)
+		return lv.pollLatencyUntilJobSucceeds(ctx, rd.setup.dst.db, ingestionJobID, time.Second, workloadDoneCh)
 	})
 	defer latencyMonitor.Wait()
 

--- a/pkg/cmd/roachtest/tests/latency_verifier.go
+++ b/pkg/cmd/roachtest/tests/latency_verifier.go
@@ -148,7 +148,9 @@ func (lv *latencyVerifier) noteHighwater(highwaterTime time.Time) {
 	}
 }
 
-func (lv *latencyVerifier) pollLatency(
+// pollLatencyUntilJobSucceeds polls the changefeed latency until it is
+// signalled to stop or the job completes.
+func (lv *latencyVerifier) pollLatencyUntilJobSucceeds(
 	ctx context.Context, db *gosql.DB, jobID int, interval time.Duration, stopper chan struct{},
 ) error {
 	for {
@@ -171,6 +173,8 @@ func (lv *latencyVerifier) pollLatency(
 		status := info.GetStatus()
 		if status == "succeeded" {
 			lv.noteHighwater(info.GetFinishedTime())
+			lv.logger.Printf("latency poller shutting down due to changefeed completion")
+			return nil
 		} else if status == "running" {
 			lv.noteHighwater(info.GetHighWater())
 		} else {


### PR DESCRIPTION
Before this change, it was possible for the test to finish before
the latency verifier sees the final highwater of a changefeed.
The latency verifier needs to see the final highwater in initial_scan='only'
tests to pass verification. This change makes sure that the initial_scan='only'
tests wait for the verifier to finish before tearing down the test.

Release note: None
Epic: None
Closes: https://github.com/cockroachdb/cockroach/issues/111495