### PR TITLE
pkg/util: Allow callers of Filter to control allocation behaviors

### DIFF
--- a/pkg/util/BUILD.bazel
+++ b/pkg/util/BUILD.bazel
@@ -38,7 +38,6 @@ go_library(
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_redact//:redact",
         "@org_golang_x_exp//constraints",
-        "@org_golang_x_exp//slices",
     ],
 )
 


### PR DESCRIPTION
#### c23736c3c218e384a95e9a8d2eaaa24c9b0f8e95 pkg/util: Allow callers of Filter to control allocation behaviors

Previously, `Filter` would always allocate a new slice the same size as
the input collection. This can be undesirable in performance sensitive
code, as opposed to performance _critical_ code where a helper would be
avoided entirely.

This commit updates `Filter` to instead accept the output slice as a 3rd
parameter. Filter's documentation has been updated with examples and
falls back to the original behavior if `nil` is passed in directly.

Epic: None
Release note: None