### PR TITLE
sql: allow refcursor comparison with NULL values

### DIFF
--- a/docs/generated/sql/operators.md
+++ b/docs/generated/sql/operators.md
@@ -447,6 +447,7 @@
 <tr><td>oid <code>IS NOT DISTINCT FROM</code> <a href="int.html">int</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td>oid <code>IS NOT DISTINCT FROM</code> oid</td><td><a href="bool.html">bool</a></td></tr>
 <tr><td>pg_lsn <code>IS NOT DISTINCT FROM</code> pg_lsn</td><td><a href="bool.html">bool</a></td></tr>
+<tr><td>refcursor <code>IS NOT DISTINCT FROM</code> unknown</td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="string.html">string</a> <code>IS NOT DISTINCT FROM</code> <a href="string.html">string</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="string.html">string[]</a> <code>IS NOT DISTINCT FROM</code> <a href="string.html">string[]</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="time.html">time</a> <code>IS NOT DISTINCT FROM</code> <a href="time.html">time</a></td><td><a href="bool.html">bool</a></td></tr>

--- a/pkg/sql/logictest/testdata/logic_test/refcursor
+++ b/pkg/sql/logictest/testdata/logic_test/refcursor
@@ -440,13 +440,6 @@ SELECT 'foo'::REFCURSOR >= 'foo'::TEXT;
 statement error pgcode 22023 pq: unsupported comparison operator
 SELECT 'foo'::REFCURSOR >= NULL;
 
-# TODO(drewk): Postgres allows this case.
-statement error pgcode 42883 pq: unsupported comparison operator
-SELECT 'foo'::REFCURSOR IS NULL;
-
-statement error pgcode 42883 pq: unsupported comparison operator
-SELECT 'foo'::REFCURSOR IS NOT NULL;
-
 statement error pgcode 22023 pq: unsupported comparison operator
 SELECT 'foo'::REFCURSOR IS DISTINCT FROM 'foo'::REFCURSOR;
 
@@ -454,15 +447,110 @@ statement error pgcode 22023 pq: unsupported comparison operator
 SELECT 'foo'::REFCURSOR IS DISTINCT FROM 'foo'::TEXT;
 
 statement error pgcode 22023 pq: unsupported comparison operator
-SELECT 'foo'::REFCURSOR IS DISTINCT FROM NULL;
-
-statement error pgcode 22023 pq: unsupported comparison operator
 SELECT 'foo'::REFCURSOR IS NOT DISTINCT FROM 'foo'::REFCURSOR;
 
 statement error pgcode 22023 pq: unsupported comparison operator
 SELECT 'foo'::REFCURSOR IS NOT DISTINCT FROM 'foo'::TEXT;
 
-statement error pgcode 22023 pq: unsupported comparison operator
+# Regression test for #112010 - REFCURSOR should allow IS NULL and
+# IS NOT NULL comparisons.
+subtest is_null
+
+query B
+SELECT 'foo'::REFCURSOR IS NULL;
+----
+false
+
+query B
+SELECT 'foo'::REFCURSOR IS NOT NULL;
+----
+true
+
+query B
+SELECT 'foo'::REFCURSOR IS DISTINCT FROM NULL;
+----
+true
+
+query B
 SELECT 'foo'::REFCURSOR IS NOT DISTINCT FROM NULL;
+----
+false
+
+# REFCURSOR columns are allowed.
+query B rowsort
+SELECT l IS NULL FROM implicit_types;
+----
+true
+true
+true
+true
+true
+
+query B rowsort
+SELECT l IS NOT NULL FROM implicit_types;
+----
+false
+false
+false
+false
+false
+
+query B rowsort
+SELECT l IS DISTINCT FROM NULL FROM implicit_types;
+----
+false
+false
+false
+false
+false
+
+query B rowsort
+SELECT l IS NOT DISTINCT FROM NULL FROM implicit_types;
+----
+true
+true
+true
+true
+true
+
+# Comparison with column is not allowed.
+statement error pgcode 22023 pq: unsupported comparison operator
+SELECT 'foo'::REFCURSOR IS DISTINCT FROM l FROM implicit_types;
+
+statement error pgcode 22023 pq: unsupported comparison operator
+SELECT 'foo'::REFCURSOR IS NOT DISTINCT FROM l FROM implicit_types;
+
+# Comparison with typed NULL is not allowed.
+statement error pgcode 22023 pq: unsupported comparison operator
+SELECT 'foo'::REFCURSOR IS DISTINCT FROM (NULL::REFCURSOR);
+
+statement error pgcode 22023 pq: unsupported comparison operator
+SELECT 'foo'::REFCURSOR IS NOT DISTINCT FROM (NULL::REFCURSOR);
+
+# Comparison with CASE expression is not allowed.
+statement error pgcode 22023 pq: unsupported comparison operator
+SELECT 'foo'::REFCURSOR IS DISTINCT FROM (CASE WHEN true THEN NULL ELSE 1 END);
+
+statement error pgcode 22023 pq: unsupported comparison operator
+SELECT 'foo'::REFCURSOR IS NOT DISTINCT FROM (CASE WHEN true THEN NULL ELSE 1 END);
+
+# The CASE operator is folded into an untyped NULL, so it's allowed.
+# TODO(drewk): Postgres doesn't allow this case.
+query B
+SELECT 'foo'::REFCURSOR IS DISTINCT FROM (CASE WHEN true THEN NULL ELSE NULL END);
+----
+true
+
+query B
+SELECT 'foo'::REFCURSOR IS NOT DISTINCT FROM (CASE WHEN true THEN NULL ELSE NULL END);
+----
+false
+
+# The CASE operator is folded into a typed NULL, so it's not allowed.
+statement error pgcode 22023 pq: unsupported comparison operator
+SELECT 'foo'::REFCURSOR IS DISTINCT FROM (CASE WHEN true THEN NULL ELSE NULL::REFCURSOR END);
+
+statement error pgcode 22023 pq: unsupported comparison operator
+SELECT 'foo'::REFCURSOR IS NOT DISTINCT FROM (CASE WHEN true THEN NULL ELSE NULL::REFCURSOR END);
 
 subtest end

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -1775,6 +1775,10 @@ var CmpOps = cmpOpFixups(map[treecmp.ComparisonOperatorSymbol]*CmpOpOverloads{
 		makeIsFn(types.Void, types.Unknown, volatility.Leakproof),
 		makeIsFn(types.Unknown, types.Void, volatility.Leakproof),
 
+		// REFCURSOR cannot be compared with itself, but as a special case, it can
+		// be compared with NULL using IS NOT DISTINCT FROM.
+		makeIsFn(types.RefCursor, types.Unknown, volatility.Leakproof),
+
 		// Tuple comparison.
 		{
 			LeftType:          types.AnyTuple,

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -941,14 +941,6 @@ func (expr *ComparisonExpr) TypeCheck(
 		return nil, err
 	}
 
-	// REFCURSOR does not support comparisons.
-	leftType, rightType := leftTyped.ResolvedType(), rightTyped.ResolvedType()
-	if leftType.Family() == types.RefCursorFamily || rightType.Family() == types.RefCursorFamily {
-		return nil, pgerror.Newf(pgcode.UndefinedFunction,
-			"unsupported comparison operator: <%s> %s <%s>", leftType, cmpOp, rightType,
-		)
-	}
-
 	if alwaysNull {
 		return DNull, nil
 	}
@@ -1471,12 +1463,6 @@ func (expr *IsNullExpr) TypeCheck(
 	if err != nil {
 		return nil, err
 	}
-	// REFCURSOR does not support comparisons.
-	if exprTyped.ResolvedType().Family() == types.RefCursorFamily {
-		return nil, pgerror.New(pgcode.UndefinedFunction,
-			"unsupported comparison operator: refcursor IS unknown",
-		)
-	}
 	expr.Expr = exprTyped
 	expr.typ = types.Bool
 	return expr, nil
@@ -1489,12 +1475,6 @@ func (expr *IsNotNullExpr) TypeCheck(
 	exprTyped, err := expr.Expr.TypeCheck(ctx, semaCtx, types.Any)
 	if err != nil {
 		return nil, err
-	}
-	// REFCURSOR does not support comparisons.
-	if exprTyped.ResolvedType().Family() == types.RefCursorFamily {
-		return nil, pgerror.New(pgcode.UndefinedFunction,
-			"unsupported comparison operator: refcursor IS NOT unknown",
-		)
 	}
 	expr.Expr = exprTyped
 	expr.typ = types.Bool


### PR DESCRIPTION
Most comparisons are disallowed for the REFCURSOR data type. For example, the following is not allowed in postgres:
```
SELECT 'foo'::REFCURSOR = 'bar'::REFCURSOR;
```
However, postgres does allow using `IS [NOT] DISTINCT FROM NULL` and `IS [NOT] NULL` with a refcursor-typed expression os the left operand. There are a few places where CRDB internally expects this comparison to be valid as well, so disallowing these comparisons has caused test failures.

This patch removes the refcursor-specific check for invalid comparisons during type checking, and relies on execution-time checks as is done for other comparisons. This means that `IsNull` and `IsNotNull` expressions can now be executed. In addition, the `IS DISTINCT FROM NULL` comparison is now supported only for the case of type `REFCURSOR` as the left operand, and `UNKNOWN` (NULL) as the right operand.

Fixes #112010
Fixes #112011

Release note: None