### PR TITLE
sql: fix sql activity cache for large cardinatlity

### DIFF
--- a/pkg/server/combined_statement_stats.go
+++ b/pkg/server/combined_statement_stats.go
@@ -168,7 +168,6 @@ func getCombinedStatementStats(
 			req,
 			transactions,
 			testingKnobs,
-			activityHasAllData,
 			tableSuffix)
 	} else {
 		statements, err = collectCombinedStatements(
@@ -672,11 +671,10 @@ func collectCombinedStatements(
 	tableSuffix string,
 ) ([]serverpb.StatementsResponse_CollectedStatementStatistics, error) {
 	aostClause := testingKnobs.GetAOSTClause()
-	const expectedNumDatums = 11
+	const expectedNumDatums = 10
 	const queryFormat = `
 SELECT 
     fingerprint_id,
-    txn_fingerprints,
     app_name,
     aggregated_ts,
     COALESCE(CAST(metadata -> 'distSQLCount' AS INT), 0)  AS distSQLCount,
@@ -688,7 +686,6 @@ SELECT
     FROM json_array_elements_text(metadata->'db') AS elem) AS databases,
     statistics
 FROM (SELECT fingerprint_id,
-             array_agg(distinct transaction_fingerprint_id)             AS txn_fingerprints,
              app_name,
              max(aggregated_ts)                                         AS aggregated_ts,
              crdb_internal.merge_stats_metadata(array_agg(metadata))    AS metadata,
@@ -713,7 +710,6 @@ FROM (SELECT fingerprint_id,
 			`
 SELECT 
     fingerprint_id,
-    txn_fingerprints,
     app_name,
     aggregated_ts,
     COALESCE(CAST(metadata -> 'distSQLCount' AS INT), 0)  AS distSQLCount,
@@ -725,7 +721,6 @@ SELECT
     FROM json_array_elements_text(metadata->'db') AS elem) AS databases,
     statistics
 FROM (SELECT fingerprint_id,
-             array_agg(distinct transaction_fingerprint_id)                    AS txn_fingerprints,
              app_name,
              max(aggregated_ts)                                                AS aggregated_ts,
              crdb_internal.merge_aggregated_stmt_metadata(array_agg(metadata)) AS metadata,
@@ -802,25 +797,15 @@ FROM (SELECT fingerprint_id,
 			return nil, srverrors.ServerError(ctx, err)
 		}
 
-		var txnFingerprintID uint64
-		txnFingerprintDatums := tree.MustBeDArray(row[1])
-		txnFingerprintIDs := make([]appstatspb.TransactionFingerprintID, 0, txnFingerprintDatums.Array.Len())
-		for _, idDatum := range txnFingerprintDatums.Array {
-			if txnFingerprintID, err = sqlstatsutil.DatumToUint64(idDatum); err != nil {
-				return nil, srverrors.ServerError(ctx, err)
-			}
-			txnFingerprintIDs = append(txnFingerprintIDs, appstatspb.TransactionFingerprintID(txnFingerprintID))
-		}
+		app := string(tree.MustBeDString(row[1]))
 
-		app := string(tree.MustBeDString(row[2]))
-
-		aggregatedTs := tree.MustBeDTimestampTZ(row[3]).Time
-		distSQLCount := int64(*row[4].(*tree.DInt))
-		fullScanCount := int64(*row[5].(*tree.DInt))
-		failedCount := int64(*row[6].(*tree.DInt))
-		query := string(tree.MustBeDString(row[7]))
-		querySummary := string(tree.MustBeDString(row[8]))
-		databases := string(tree.MustBeDString(row[9]))
+		aggregatedTs := tree.MustBeDTimestampTZ(row[2]).Time
+		distSQLCount := int64(*row[3].(*tree.DInt))
+		fullScanCount := int64(*row[4].(*tree.DInt))
+		failedCount := int64(*row[5].(*tree.DInt))
+		query := string(tree.MustBeDString(row[6]))
+		querySummary := string(tree.MustBeDString(row[7]))
+		databases := string(tree.MustBeDString(row[8]))
 
 		metadata := appstatspb.CollectedStatementStatistics{
 			Key: appstatspb.StatementStatisticsKey{
@@ -835,7 +820,7 @@ FROM (SELECT fingerprint_id,
 		}
 
 		var stats appstatspb.StatementStatistics
-		statsJSON := tree.MustBeDJSON(row[10]).JSON
+		statsJSON := tree.MustBeDJSON(row[9]).JSON
 		if err = sqlstatsutil.DecodeStmtStatsStatisticsJSON(statsJSON, &stats); err != nil {
 			return nil, srverrors.ServerError(ctx, err)
 		}
@@ -847,7 +832,7 @@ FROM (SELECT fingerprint_id,
 			},
 			ID:                appstatspb.StmtFingerprintID(statementFingerprintID),
 			Stats:             stats,
-			TxnFingerprintIDs: txnFingerprintIDs,
+			TxnFingerprintIDs: []appstatspb.TransactionFingerprintID{appstatspb.InvalidTransactionFingerprintID},
 		}
 
 		statements = append(statements, stmt)
@@ -1026,13 +1011,15 @@ FROM (SELECT app_name,
 	return transactions, nil
 }
 
+// This does not use the activity tables because the statement information is
+// aggregated to remove the transaction fingerprint id to keep the size of the
+// statement_activity manageable when transaction have over 1k+ statement ids.
 func collectStmtsForTxns(
 	ctx context.Context,
 	ie *sql.InternalExecutor,
 	req *serverpb.CombinedStatementsStatsRequest,
 	transactions []serverpb.StatementsResponse_ExtendedCollectedTransactionStatistics,
 	testingKnobs *sqlstats.TestingKnobs,
-	activityTableHasAllData bool,
 	tableSuffix string,
 ) ([]serverpb.StatementsResponse_CollectedStatementStatistics, error) {
 
@@ -1055,44 +1042,15 @@ GROUP BY
 	var it isql.Rows
 	var err error
 
-	if activityTableHasAllData {
-		it, err = ie.QueryIteratorEx(ctx, "console-combined-stmts-activity-for-txn", nil,
-			sessiondata.NodeUserSessionDataOverride, fmt.Sprintf(`
-SELECT fingerprint_id,
-       transaction_fingerprint_id,
-       crdb_internal.merge_aggregated_stmt_metadata(array_agg(metadata))   AS metadata,
-       crdb_internal.merge_statement_stats(array_agg(statistics)) AS statistics,
-       app_name
-FROM crdb_internal.statement_activity %s
-GROUP BY
-    fingerprint_id,
-    transaction_fingerprint_id,
-    app_name`, whereClause),
-			args...)
-		if err != nil {
-			return nil, srverrors.ServerError(ctx, err)
-		}
-	}
+	query := fmt.Sprintf(
+		queryFormat,
+		crdbInternalStmtStatsPersisted+tableSuffix,
+		whereClause)
+	it, err = ie.QueryIteratorEx(ctx, "console-combined-stmts-persisted-for-txn", nil,
+		sessiondata.NodeUserSessionDataOverride, query, args...)
 
-	// If there are no results from the activity table, retrieve the data from the persisted table.
-	var query string
-	if it == nil || !it.HasResults() {
-		if it != nil {
-			err = closeIterator(it, err)
-			if err != nil {
-				return nil, srverrors.ServerError(ctx, err)
-			}
-		}
-		query = fmt.Sprintf(
-			queryFormat,
-			crdbInternalStmtStatsPersisted+tableSuffix,
-			whereClause)
-		it, err = ie.QueryIteratorEx(ctx, "console-combined-stmts-persisted-for-txn", nil,
-			sessiondata.NodeUserSessionDataOverride, query, args...)
-
-		if err != nil {
-			return nil, srverrors.ServerError(ctx, err)
-		}
+	if err != nil {
+		return nil, srverrors.ServerError(ctx, err)
 	}
 
 	// If there are no results from the persisted table, retrieve the data from the combined view

--- a/pkg/sql/appstatspb/app_stats.go
+++ b/pkg/sql/appstatspb/app_stats.go
@@ -188,26 +188,30 @@ func (s *StatementStatistics) Add(other *StatementStatistics) {
 	s.Nodes = util.CombineUnique(s.Nodes, other.Nodes)
 	s.Regions = util.CombineUnique(s.Regions, other.Regions)
 	s.PlanGists = util.CombineUnique(s.PlanGists, other.PlanGists)
-	s.IndexRecommendations = other.IndexRecommendations
 	s.Indexes = util.CombineUnique(s.Indexes, other.Indexes)
-
 	s.ExecStats.Add(other.ExecStats)
 	s.LatencyInfo.Add(other.LatencyInfo)
-
-	if other.SensitiveInfo.LastErr != "" {
-		s.SensitiveInfo.LastErr = other.SensitiveInfo.LastErr
-	}
-
-	if other.LastErrorCode != "" {
-		s.LastErrorCode = other.LastErrorCode
-	}
 
 	if s.SensitiveInfo.MostRecentPlanTimestamp.Before(other.SensitiveInfo.MostRecentPlanTimestamp) {
 		s.SensitiveInfo = other.SensitiveInfo
 	}
 
+	// Use the LastExecTimestamp to decide which object has the last error
+	// and index recommendations.
 	if s.LastExecTimestamp.Before(other.LastExecTimestamp) {
 		s.LastExecTimestamp = other.LastExecTimestamp
+
+		if len(other.IndexRecommendations) > 0 {
+			s.IndexRecommendations = other.IndexRecommendations
+		}
+
+		if other.SensitiveInfo.LastErr != "" {
+			s.SensitiveInfo.LastErr = other.SensitiveInfo.LastErr
+		}
+
+		if other.LastErrorCode != "" {
+			s.LastErrorCode = other.LastErrorCode
+		}
 	}
 
 	s.Count += other.Count

--- a/pkg/sql/opt/exec/execbuilder/testdata/observability
+++ b/pkg/sql/opt/exec/execbuilder/testdata/observability
@@ -18,40 +18,174 @@ SELECT * FROM crdb_internal.transaction_activity
 statement ok
 SELECT * FROM crdb_internal.statement_activity
 
+# Pretend we have max number of rows in the transaction activity table
+statement ok
+ALTER TABLE system.transaction_activity INJECT STATISTICS '[
+  {
+    "columns": ["aggregated_ts"],
+    "created_at": "2023-01-01 1:00:00.00000+00:00",
+    "row_count": 200000,
+    "distinct_count": 72
+  },
+  {
+    "columns": ["aggregated_ts","fingerprint_id"],
+    "created_at": "2023-01-01 1:00:00.00000+00:00",
+    "row_count": 200000,
+    "distinct_count": 200000
+  },
+  {
+    "columns": ["aggregated_ts","fingerprint_id","app_name"],
+    "created_at": "2023-01-01 1:00:00.00000+00:00",
+    "row_count": 200000,
+    "distinct_count": 200000
+  }
+]'
+
+# Pretend we have max number of rows in the statement activity table
+statement ok
+ALTER TABLE system.statement_activity INJECT STATISTICS '[
+  {
+    "columns": ["aggregated_ts"],
+    "created_at": "2023-01-01 1:00:00.00000+00:00",
+    "row_count": 200000,
+    "distinct_count": 72
+  },
+  {
+    "columns": ["aggregated_ts","fingerprint_id"],
+    "created_at": "2023-01-01 1:00:00.00000+00:00",
+    "row_count": 200000,
+    "distinct_count": 200000
+  },
+  {
+    "columns": ["aggregated_ts","fingerprint_id","transaction_fingerprint_id"],
+    "created_at": "2023-01-01 1:00:00.00000+00:00",
+    "row_count": 200000,
+    "distinct_count": 200000
+  },
+  {
+    "columns": ["aggregated_ts","fingerprint_id","transaction_fingerprint_id","plan_hash"],
+    "created_at": "2023-01-01 1:00:00.00000+00:00",
+    "row_count": 200000,
+    "distinct_count": 200000
+  },
+  {
+    "columns": ["aggregated_ts","fingerprint_id","transaction_fingerprint_id","plan_hash","app_name"],
+    "created_at": "2023-01-01 1:00:00.00000+00:00",
+    "row_count": 200000,
+    "distinct_count": 200000
+  }
+]'
+
+# Pretend we have max number of rows in the transaction_statistics table
+statement ok
+ALTER TABLE system.transaction_statistics INJECT STATISTICS '[
+  {
+    "columns": ["aggregated_ts"],
+    "created_at": "2023-01-01 1:00:00.00000+00:00",
+    "row_count": 1000000,
+    "distinct_count": 12
+  },
+  {
+    "columns": ["aggregated_ts","fingerprint_id","app_name","node_id","crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8"],
+    "created_at": "2023-01-01 1:00:00.00000+00:00",
+    "row_count": 1000000,
+    "distinct_count": 1000000
+  },
+  {
+    "columns": ["aggregated_ts","fingerprint_id","app_name","crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8"],
+    "created_at": "2023-01-01 1:00:00.00000+00:00",
+    "row_count": 1000000,
+    "distinct_count": 1000000
+  },
+  {
+    "columns": ["aggregated_ts","fingerprint_id","crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8"],
+    "created_at": "2023-01-01 1:00:00.00000+00:00",
+    "row_count": 1000000,
+    "distinct_count": 1000000
+  },
+  {
+    "columns": ["aggregated_ts","crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8"],
+    "created_at": "2023-01-01 1:00:00.00000+00:00",
+    "row_count": 1000000,
+    "distinct_count": 30000
+  }
+]'
+
+# Pretend we have max number of rows in the statement_statistics table
+statement ok
+ALTER TABLE system.statement_statistics INJECT STATISTICS '[
+  {
+    "columns": ["aggregated_ts"],
+    "created_at": "2023-01-01 1:00:00.00000+00:00",
+    "row_count": 1000000,
+    "distinct_count": 12
+  },
+  {
+    "columns": ["aggregated_ts","fingerprint_id","transaction_fingerprint_id","plan_hash","app_name","node_id","crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8"],
+    "created_at": "2023-01-01 1:00:00.00000+00:00",
+    "row_count": 1000000,
+    "distinct_count": 1000000
+  },
+  {
+    "columns": ["aggregated_ts","fingerprint_id","transaction_fingerprint_id","plan_hash","crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8"],
+    "created_at": "2023-01-01 1:00:00.00000+00:00",
+    "row_count": 1000000,
+    "distinct_count": 1000000
+  },
+  {
+    "columns": ["aggregated_ts","fingerprint_id","transaction_fingerprint_id","crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8"],
+    "created_at": "2023-01-01 1:00:00.00000+00:00",
+    "row_count": 1000000,
+    "distinct_count": 1000000
+  },
+  {
+    "columns": ["aggregated_ts","fingerprint_id","crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8"],
+    "created_at": "2023-01-01 1:00:00.00000+00:00",
+    "row_count": 1000000,
+    "distinct_count": 1000000
+  },
+  {
+    "columns": ["crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8"],
+    "created_at": "2023-01-01 1:00:00.00000+00:00",
+    "row_count": 1000000,
+    "distinct_count": 1000000
+  }
+]'
+
 # Upsert all transaction_activity
 query T retry
-EXPLAIN (VERBOSE) UPSERT INTO system.public.transaction_activity
-                  (aggregated_ts, fingerprint_id, app_name, agg_interval, metadata,
-                   statistics, query, execution_count, execution_total_seconds,
-                   execution_total_cluster_seconds, contention_time_avg_seconds,
-                   cpu_sql_avg_nanos, service_latency_avg_seconds, service_latency_p99_seconds)
-                      (SELECT aggregated_ts,
-                              fingerprint_id,
-                              app_name,
-                              agg_interval,
-                              metadata,
-                              statistics,
-                              '' AS query,
-                              (statistics->'execution_statistics'->>'cnt')::int,
-                              ((statistics->'execution_statistics'->>'cnt')::float)*((statistics->'statistics'->'svcLat'->>'mean')::float),
-                              100 AS execution_total_cluster_seconds,
-                              COALESCE((statistics->'execution_statistics'->'contentionTime'->>'mean')::float,0),
-                              COALESCE((statistics->'execution_statistics'->'cpu_sql_nanos'->>'mean')::float,0),
-                              (statistics->'statistics'->'svcLat'->>'mean')::float,
-                              COALESCE((statistics->'statistics'->'latencyInfo'->>'p99')::float, 0)
-                       FROM (SELECT
-                                    max(aggregated_ts) AS aggregated_ts,
-                                    app_name,
-                                    fingerprint_id,
-                                    agg_interval,
-                                    merge_stats_metadata(metadata)      AS metadata,
-                                    merge_transaction_stats(statistics) AS statistics
-                             FROM system.public.transaction_statistics
-                             WHERE aggregated_ts = '2023-04-10 16:00:00.000000 +00:00'
-                               and app_name not like '$ internal%'
-                             GROUP BY app_name,
-                                      fingerprint_id,
-                                      agg_interval));
+EXPLAIN (VERBOSE)
+UPSERT INTO system.public.transaction_activity
+(aggregated_ts, fingerprint_id, app_name, agg_interval, metadata,
+ statistics, query, execution_count, execution_total_seconds,
+ execution_total_cluster_seconds, contention_time_avg_seconds,
+ cpu_sql_avg_nanos, service_latency_avg_seconds, service_latency_p99_seconds)
+    (SELECT max_aggregated_ts,
+            fingerprint_id,
+            app_name,
+            max_agg_interval,
+            metadata,
+            statistics,
+            '' AS query,
+            (statistics->'statistics'->>'cnt')::int,
+            ((statistics->'statistics'->>'cnt')::float)*((statistics->'statistics'->'svcLat'->>'mean')::float),
+            100 AS execution_total_cluster_seconds,
+            COALESCE((statistics->'execution_statistics'->'contentionTime'->>'mean')::float,0),
+            COALESCE((statistics->'execution_statistics'->'cpuSQLNanos'->>'mean')::float,0),
+            (statistics->'statistics'->'svcLat'->>'mean')::float,
+            0 as service_latency_p99_seconds
+     FROM (SELECT
+                  max(aggregated_ts) AS max_aggregated_ts,
+                  app_name,
+                  fingerprint_id,
+                  max(agg_interval) as max_agg_interval,
+                  max(metadata) as metadata,
+                  merge_transaction_stats(statistics) AS statistics
+           FROM system.public.transaction_statistics
+           WHERE aggregated_ts = '2023-04-10 16:00:00.000000 +00:00'
+             and app_name not like '$ internal%'
+           GROUP BY app_name,
+                    fingerprint_id));
 ----
 distribution: local
 vectorized: true
@@ -64,106 +198,95 @@ vectorized: true
 │ arbiter indexes: primary
 │
 └── • project
-    │ columns: (max, fingerprint_id, app_name, agg_interval, merge_stats_metadata, merge_transaction_stats, query, int8, "?column?", execution_total_cluster_seconds, "coalesce", "coalesce", float8, "coalesce", aggregated_ts, fingerprint_id, app_name, agg_interval, metadata, statistics, query, execution_count, execution_total_seconds, execution_total_cluster_seconds, contention_time_avg_seconds, cpu_sql_avg_nanos, service_latency_avg_seconds, service_latency_p99_seconds, agg_interval, merge_stats_metadata, merge_transaction_stats, query, int8, "?column?", execution_total_cluster_seconds, "coalesce", "coalesce", float8, "coalesce", aggregated_ts)
+    │ columns: (max, fingerprint_id, app_name, max, max, merge_transaction_stats, query, int8, "?column?", execution_total_cluster_seconds, "coalesce", "coalesce", float8, service_latency_p99_seconds, aggregated_ts, fingerprint_id, app_name, agg_interval, metadata, statistics, query, execution_count, execution_total_seconds, execution_total_cluster_seconds, contention_time_avg_seconds, cpu_sql_avg_nanos, service_latency_avg_seconds, service_latency_p99_seconds, max, max, merge_transaction_stats, query, int8, "?column?", execution_total_cluster_seconds, "coalesce", "coalesce", float8, service_latency_p99_seconds, aggregated_ts)
     │
     └── • lookup join (left outer)
-        │ columns: (query, int8, "?column?", execution_total_cluster_seconds, "coalesce", "coalesce", float8, "coalesce", fingerprint_id, app_name, agg_interval, max, merge_stats_metadata, merge_transaction_stats, aggregated_ts, fingerprint_id, app_name, agg_interval, metadata, statistics, query, execution_count, execution_total_seconds, execution_total_cluster_seconds, contention_time_avg_seconds, cpu_sql_avg_nanos, service_latency_avg_seconds, service_latency_p99_seconds)
-        │ estimated row count: 3 (missing stats)
+        │ columns: (query, int8, "?column?", execution_total_cluster_seconds, "coalesce", "coalesce", float8, service_latency_p99_seconds, fingerprint_id, app_name, max, max, max, merge_transaction_stats, aggregated_ts, fingerprint_id, app_name, agg_interval, metadata, statistics, query, execution_count, execution_total_seconds, execution_total_cluster_seconds, contention_time_avg_seconds, cpu_sql_avg_nanos, service_latency_avg_seconds, service_latency_p99_seconds)
+        │ estimated row count: 27,778
         │ table: transaction_activity@primary
         │ equality: (max, fingerprint_id, app_name) = (aggregated_ts,fingerprint_id,app_name)
         │ equality cols are key
         │
-        └── • distinct
-            │ columns: (query, int8, "?column?", execution_total_cluster_seconds, "coalesce", "coalesce", float8, "coalesce", fingerprint_id, app_name, agg_interval, max, merge_stats_metadata, merge_transaction_stats)
-            │ estimated row count: 3 (missing stats)
-            │ distinct on: fingerprint_id, app_name, max
-            │ nulls are distinct
-            │ error on duplicate
+        └── • render
+            │ columns: (query, int8, "?column?", execution_total_cluster_seconds, "coalesce", "coalesce", float8, service_latency_p99_seconds, fingerprint_id, app_name, max, max, max, merge_transaction_stats)
+            │ render query: ''
+            │ render int8: ((merge_transaction_stats->'statistics')->>'cnt')::INT8
+            │ render ?column?: ((merge_transaction_stats->'statistics')->>'cnt')::FLOAT8 * (((merge_transaction_stats->'statistics')->'svcLat')->>'mean')::FLOAT8
+            │ render execution_total_cluster_seconds: 100.0
+            │ render coalesce: COALESCE((((merge_transaction_stats->'execution_statistics')->'contentionTime')->>'mean')::FLOAT8, 0.0)
+            │ render coalesce: COALESCE((((merge_transaction_stats->'execution_statistics')->'cpuSQLNanos')->>'mean')::FLOAT8, 0.0)
+            │ render float8: (((merge_transaction_stats->'statistics')->'svcLat')->>'mean')::FLOAT8
+            │ render service_latency_p99_seconds: 0.0
+            │ render fingerprint_id: fingerprint_id
+            │ render app_name: app_name
+            │ render max: max
+            │ render max: max
+            │ render max: max
+            │ render merge_transaction_stats: merge_transaction_stats
             │
-            └── • render
-                │ columns: (query, int8, "?column?", execution_total_cluster_seconds, "coalesce", "coalesce", float8, "coalesce", fingerprint_id, app_name, agg_interval, max, merge_stats_metadata, merge_transaction_stats)
-                │ render query: ''
-                │ render int8: ((merge_transaction_stats->'execution_statistics')->>'cnt')::INT8
-                │ render ?column?: ((merge_transaction_stats->'execution_statistics')->>'cnt')::FLOAT8 * (((merge_transaction_stats->'statistics')->'svcLat')->>'mean')::FLOAT8
-                │ render execution_total_cluster_seconds: 100.0
-                │ render coalesce: COALESCE((((merge_transaction_stats->'execution_statistics')->'contentionTime')->>'mean')::FLOAT8, 0.0)
-                │ render coalesce: COALESCE((((merge_transaction_stats->'execution_statistics')->'cpu_sql_nanos')->>'mean')::FLOAT8, 0.0)
-                │ render float8: (((merge_transaction_stats->'statistics')->'svcLat')->>'mean')::FLOAT8
-                │ render coalesce: COALESCE((((merge_transaction_stats->'statistics')->'latencyInfo')->>'p99')::FLOAT8, 0.0)
-                │ render fingerprint_id: fingerprint_id
-                │ render app_name: app_name
-                │ render agg_interval: agg_interval
-                │ render max: max
-                │ render merge_stats_metadata: merge_stats_metadata
-                │ render merge_transaction_stats: merge_transaction_stats
+            └── • group (hash)
+                │ columns: (fingerprint_id, app_name, max, max, max, merge_transaction_stats)
+                │ estimated row count: 27,778
+                │ aggregate 0: max(aggregated_ts)
+                │ aggregate 1: max(agg_interval)
+                │ aggregate 2: max(metadata)
+                │ aggregate 3: merge_transaction_stats(statistics)
+                │ group by: fingerprint_id, app_name
                 │
-                └── • group (hash)
-                    │ columns: (fingerprint_id, app_name, agg_interval, max, merge_stats_metadata, merge_transaction_stats)
-                    │ estimated row count: 3 (missing stats)
-                    │ aggregate 0: max(aggregated_ts)
-                    │ aggregate 1: merge_stats_metadata(metadata)
-                    │ aggregate 2: merge_transaction_stats(statistics)
-                    │ group by: fingerprint_id, app_name, agg_interval
+                └── • filter
+                    │ columns: (aggregated_ts, fingerprint_id, app_name, agg_interval, metadata, statistics)
+                    │ estimated row count: 27,778
+                    │ filter: app_name NOT LIKE '$ internal%'
                     │
-                    └── • index join
-                        │ columns: (aggregated_ts, fingerprint_id, app_name, agg_interval, metadata, statistics)
-                        │ estimated row count: 3 (missing stats)
-                        │ table: transaction_statistics@primary
-                        │ key columns: crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, aggregated_ts, fingerprint_id, app_name, node_id
-                        │
-                        └── • scan
-                              columns: (aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8)
-                              estimated row count: 3 (missing stats)
-                              table: transaction_statistics@execution_count_idx (partial index)
-                              spans: /2023-04-10T16:00:00Z-/2023-04-10T16:00:00.000000001Z
+                    └── • scan
+                          columns: (aggregated_ts, fingerprint_id, app_name, agg_interval, metadata, statistics)
+                          estimated row count: 83,333 (8.3% of the table; stats collected <hidden> ago)
+                          table: transaction_statistics@primary
+                          spans: /0/2023-04-10T16:00:00Z-/0/2023-04-10T16:00:00.000000001Z /1/2023-04-10T16:00:00Z-/1/2023-04-10T16:00:00.000000001Z /2/2023-04-10T16:00:00Z-/2/2023-04-10T16:00:00.000000001Z /3/2023-04-10T16:00:00Z-/3/2023-04-10T16:00:00.000000001Z /4/2023-04-10T16:00:00Z-/4/2023-04-10T16:00:00.000000001Z /5/2023-04-10T16:00:00Z-/5/2023-04-10T16:00:00.000000001Z /6/2023-04-10T16:00:00Z-/6/2023-04-10T16:00:00.000000001Z /7/2023-04-10T16:00:00Z-/7/2023-04-10T16:00:00.000000001Z
+
 
 # Upsert all statement_activity
 query T retry
-EXPLAIN (VERBOSE) UPSERT
-                  INTO system.public.statement_activity (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name,
-                                                         agg_interval, metadata, statistics, plan, index_recommendations, execution_count,
-                                                         execution_total_seconds, execution_total_cluster_seconds,
-                                                         contention_time_avg_seconds,
-                                                         cpu_sql_avg_nanos,
-                                                         service_latency_avg_seconds, service_latency_p99_seconds)
-                      (SELECT aggregated_ts,
-                              fingerprint_id,
-                              transaction_fingerprint_id,
-                              plan_hash,
-                              app_name,
-                              agg_interval,
-                              metadata,
-                              statistics,
-                              plan,
-                              index_recommendations,
-                              (statistics -> 'execution_statistics' ->> 'cnt')::int,
-                              ((statistics -> 'execution_statistics' ->> 'cnt')::float) *
-                              ((statistics -> 'statistics' -> 'svcLat' ->> 'mean')::float),
-                              100 AS execution_total_cluster_seconds,
-                              COALESCE((statistics -> 'execution_statistics' -> 'contentionTime' ->> 'mean')::float, 0),
-                              COALESCE((statistics -> 'execution_statistics' -> 'cpu_sql_nanos' ->> 'mean')::float, 0),
-                              (statistics -> 'statistics' -> 'svcLat' ->> 'mean')::float,
-                              COALESCE((statistics -> 'statistics' -> 'latencyInfo' ->> 'p99')::float, 0)
-                       FROM (SELECT max(aggregated_ts)                                           AS aggregated_ts,
-                                    fingerprint_id,
-                                    transaction_fingerprint_id,
-                                    plan_hash,
-                                    app_name,
-                                    agg_interval,
-                                    merge_stats_metadata(metadata)      AS metadata,
-                                    merge_statement_stats(statistics) AS statistics,
-                                    plan,
-                                    index_recommendations
-                             FROM system.public.statement_statistics
-                             WHERE aggregated_ts = '2023-04-10 16:00:00.000000 +00:00'
-                               and app_name not like '$ internal%'
-                             GROUP BY app_name,
-                                      fingerprint_id,
-                                      transaction_fingerprint_id,
-                                      plan_hash,
-                                      agg_interval,
-                                      plan,
-                                      index_recommendations));
+EXPLAIN (VERBOSE)
+      UPSERT
+INTO system.public.statement_activity (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name,
+                                       agg_interval, metadata, statistics, plan, index_recommendations, execution_count,
+                                       execution_total_seconds, execution_total_cluster_seconds,
+                                       contention_time_avg_seconds,
+                                       cpu_sql_avg_nanos,
+                                       service_latency_avg_seconds, service_latency_p99_seconds)
+    (SELECT aggregated_ts,
+            fingerprint_id,
+            '0x0000000000000000'::bytes,
+            plan_hash,
+            app_name,
+            max_agg_interval,
+            merged_metadata,
+            merged_stats,
+            max_plan,
+             (select COALESCE(array_agg(o.rec::string), (array[]::string[])) FROM jsonb_array_elements_text(merged_stats -> 'index_recommendations') o(rec)) as idx_rec,
+            (merged_stats -> 'statistics' ->> 'cnt')::int,
+            ((merged_stats -> 'statistics' ->> 'cnt')::float) *
+            ((merged_stats -> 'statistics' -> 'svcLat' ->> 'mean')::float),
+            100 AS execution_total_cluster_seconds,
+            COALESCE((merged_stats -> 'execution_statistics' -> 'contentionTime' ->> 'mean')::float, 0),
+            COALESCE((merged_stats -> 'execution_statistics' -> 'cpuSQLNanos' ->> 'mean')::float, 0),
+            (merged_stats -> 'statistics' -> 'svcLat' ->> 'mean')::float,
+            COALESCE((merged_stats -> 'statistics' -> 'latencyInfo' ->> 'p99')::float, 0)
+     FROM (SELECT max(aggregated_ts)                                           AS aggregated_ts,
+                  fingerprint_id,
+                  plan_hash,
+                  app_name,
+                  max(agg_interval) as max_agg_interval,
+                  merge_stats_metadata(metadata)    AS merged_metadata,
+                  merge_statement_stats(statistics) AS merged_stats,
+                  max(plan) AS max_plan
+           FROM system.public.statement_statistics
+           WHERE aggregated_ts = '2023-04-10 16:00:00.000000 +00:00'
+             and app_name not like '$ internal%'
+           GROUP BY app_name,
+                    fingerprint_id,
+                    plan_hash));
 ----
 distribution: local
 vectorized: true
@@ -176,551 +299,253 @@ vectorized: true
 │ arbiter indexes: primary
 │
 └── • project
-    │ columns: (max, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, agg_interval, merge_stats_metadata, merge_statement_stats, plan, index_recommendations, int8, "?column?", execution_total_cluster_seconds, "coalesce", "coalesce", float8, "coalesce", aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, agg_interval, metadata, statistics, plan, index_recommendations, execution_count, execution_total_seconds, execution_total_cluster_seconds, contention_time_avg_seconds, cpu_sql_avg_nanos, service_latency_avg_seconds, service_latency_p99_seconds, agg_interval, merge_stats_metadata, merge_statement_stats, plan, index_recommendations, int8, "?column?", execution_total_cluster_seconds, "coalesce", "coalesce", float8, "coalesce", aggregated_ts)
+    │ columns: (max, fingerprint_id, bytea, plan_hash, app_name, max, merge_stats_metadata, merge_statement_stats, max, idx_rec, int8, "?column?", execution_total_cluster_seconds, "coalesce", "coalesce", float8, "coalesce", aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, agg_interval, metadata, statistics, plan, index_recommendations, execution_count, execution_total_seconds, execution_total_cluster_seconds, contention_time_avg_seconds, cpu_sql_avg_nanos, service_latency_avg_seconds, service_latency_p99_seconds, max, merge_stats_metadata, merge_statement_stats, max, idx_rec, int8, "?column?", execution_total_cluster_seconds, "coalesce", "coalesce", float8, "coalesce", aggregated_ts)
     │
-    └── • lookup join (left outer)
-        │ columns: (int8, "?column?", execution_total_cluster_seconds, "coalesce", "coalesce", float8, "coalesce", fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, agg_interval, plan, index_recommendations, max, merge_stats_metadata, merge_statement_stats, aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, agg_interval, metadata, statistics, plan, index_recommendations, execution_count, execution_total_seconds, execution_total_cluster_seconds, contention_time_avg_seconds, cpu_sql_avg_nanos, service_latency_avg_seconds, service_latency_p99_seconds)
-        │ estimated row count: 3 (missing stats)
-        │ table: statement_activity@primary
-        │ equality: (max, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name) = (aggregated_ts,fingerprint_id,transaction_fingerprint_id,plan_hash,app_name)
-        │ equality cols are key
+    └── • project
+        │ columns: (fingerprint_id, plan_hash, app_name, max, max, merge_stats_metadata, merge_statement_stats, max, bytea, idx_rec, int8, "?column?", execution_total_cluster_seconds, "coalesce", "coalesce", float8, "coalesce", aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, agg_interval, metadata, statistics, plan, index_recommendations, execution_count, execution_total_seconds, execution_total_cluster_seconds, contention_time_avg_seconds, cpu_sql_avg_nanos, service_latency_avg_seconds, service_latency_p99_seconds)
         │
-        └── • distinct
-            │ columns: (int8, "?column?", execution_total_cluster_seconds, "coalesce", "coalesce", float8, "coalesce", fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, agg_interval, plan, index_recommendations, max, merge_stats_metadata, merge_statement_stats)
-            │ estimated row count: 3 (missing stats)
-            │ distinct on: fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, max
-            │ nulls are distinct
-            │ error on duplicate
+        └── • lookup join (left outer)
+            │ columns: ("lookup_join_const_col_@63", bytea, idx_rec, int8, "?column?", execution_total_cluster_seconds, "coalesce", "coalesce", float8, "coalesce", fingerprint_id, plan_hash, app_name, max, max, merge_stats_metadata, merge_statement_stats, max, aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, agg_interval, metadata, statistics, plan, index_recommendations, execution_count, execution_total_seconds, execution_total_cluster_seconds, contention_time_avg_seconds, cpu_sql_avg_nanos, service_latency_avg_seconds, service_latency_p99_seconds)
+            │ estimated row count: 27,778
+            │ table: statement_activity@primary
+            │ equality: (max, fingerprint_id, lookup_join_const_col_@63, plan_hash, app_name) = (aggregated_ts,fingerprint_id,transaction_fingerprint_id,plan_hash,app_name)
+            │ equality cols are key
             │
             └── • render
-                │ columns: (int8, "?column?", execution_total_cluster_seconds, "coalesce", "coalesce", float8, "coalesce", fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, agg_interval, plan, index_recommendations, max, merge_stats_metadata, merge_statement_stats)
-                │ render int8: ((merge_statement_stats->'execution_statistics')->>'cnt')::INT8
-                │ render ?column?: ((merge_statement_stats->'execution_statistics')->>'cnt')::FLOAT8 * (((merge_statement_stats->'statistics')->'svcLat')->>'mean')::FLOAT8
+                │ columns: ("lookup_join_const_col_@63", bytea, idx_rec, int8, "?column?", execution_total_cluster_seconds, "coalesce", "coalesce", float8, "coalesce", fingerprint_id, plan_hash, app_name, max, max, merge_stats_metadata, merge_statement_stats, max)
+                │ render lookup_join_const_col_@63: '\x307830303030303030303030303030303030'
+                │ render bytea: '\x307830303030303030303030303030303030'
+                │ render idx_rec: COALESCE(CASE WHEN any_not_null IS NOT NULL THEN array_agg ELSE CAST(NULL AS STRING[]) END, ARRAY[])
+                │ render int8: ((any_not_null->'statistics')->>'cnt')::INT8
+                │ render ?column?: ((any_not_null->'statistics')->>'cnt')::FLOAT8 * (((any_not_null->'statistics')->'svcLat')->>'mean')::FLOAT8
                 │ render execution_total_cluster_seconds: 100.0
-                │ render coalesce: COALESCE((((merge_statement_stats->'execution_statistics')->'contentionTime')->>'mean')::FLOAT8, 0.0)
-                │ render coalesce: COALESCE((((merge_statement_stats->'execution_statistics')->'cpu_sql_nanos')->>'mean')::FLOAT8, 0.0)
-                │ render float8: (((merge_statement_stats->'statistics')->'svcLat')->>'mean')::FLOAT8
-                │ render coalesce: COALESCE((((merge_statement_stats->'statistics')->'latencyInfo')->>'p99')::FLOAT8, 0.0)
+                │ render coalesce: COALESCE((((any_not_null->'execution_statistics')->'contentionTime')->>'mean')::FLOAT8, 0.0)
+                │ render coalesce: COALESCE((((any_not_null->'execution_statistics')->'cpuSQLNanos')->>'mean')::FLOAT8, 0.0)
+                │ render float8: (((any_not_null->'statistics')->'svcLat')->>'mean')::FLOAT8
+                │ render coalesce: COALESCE((((any_not_null->'statistics')->'latencyInfo')->>'p99')::FLOAT8, 0.0)
                 │ render fingerprint_id: fingerprint_id
-                │ render transaction_fingerprint_id: transaction_fingerprint_id
                 │ render plan_hash: plan_hash
                 │ render app_name: app_name
-                │ render agg_interval: agg_interval
-                │ render plan: plan
-                │ render index_recommendations: index_recommendations
-                │ render max: max
-                │ render merge_stats_metadata: merge_stats_metadata
-                │ render merge_statement_stats: merge_statement_stats
+                │ render max: any_not_null
+                │ render max: any_not_null
+                │ render merge_stats_metadata: any_not_null
+                │ render merge_statement_stats: any_not_null
+                │ render max: any_not_null
                 │
                 └── • group (hash)
-                    │ columns: (fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, agg_interval, plan, index_recommendations, max, merge_stats_metadata, merge_statement_stats)
-                    │ estimated row count: 3 (missing stats)
-                    │ aggregate 0: max(aggregated_ts)
-                    │ aggregate 1: merge_stats_metadata(metadata)
-                    │ aggregate 2: merge_statement_stats(statistics)
-                    │ group by: fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, agg_interval, plan, index_recommendations
+                    │ columns: (fingerprint_id, plan_hash, app_name, array_agg, any_not_null, any_not_null, any_not_null, any_not_null, any_not_null, any_not_null)
+                    │ estimated row count: 27,778
+                    │ aggregate 0: array_agg(value)
+                    │ aggregate 1: any_not_null(max)
+                    │ aggregate 2: any_not_null(max)
+                    │ aggregate 3: any_not_null(merge_stats_metadata)
+                    │ aggregate 4: any_not_null(merge_statement_stats)
+                    │ aggregate 5: any_not_null(max)
+                    │ aggregate 6: any_not_null(canary)
+                    │ group by: fingerprint_id, plan_hash, app_name
                     │
-                    └── • index join
-                        │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, agg_interval, metadata, statistics, plan, index_recommendations)
-                        │ estimated row count: 3 (missing stats)
-                        │ table: statement_statistics@primary
-                        │ key columns: crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id
+                    └── • apply join (left outer)
+                        │ columns: (fingerprint_id, plan_hash, app_name, max, max, merge_stats_metadata, merge_statement_stats, max, value, canary)
+                        │ estimated row count: 277,778
                         │
-                        └── • scan
-                              columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8)
-                              estimated row count: 3 (missing stats)
-                              table: statement_statistics@execution_count_idx (partial index)
-                              spans: /2023-04-10T16:00:00Z-/2023-04-10T16:00:00.000000001Z
+                        └── • group (hash)
+                            │ columns: (fingerprint_id, plan_hash, app_name, max, max, merge_stats_metadata, merge_statement_stats, max)
+                            │ estimated row count: 27,778
+                            │ aggregate 0: max(aggregated_ts)
+                            │ aggregate 1: max(agg_interval)
+                            │ aggregate 2: merge_stats_metadata(metadata)
+                            │ aggregate 3: merge_statement_stats(statistics)
+                            │ aggregate 4: max(plan)
+                            │ group by: fingerprint_id, plan_hash, app_name
+                            │
+                            └── • union all
+                                │ columns: (aggregated_ts, fingerprint_id, plan_hash, app_name, agg_interval, metadata, statistics, plan)
+                                │ estimated row count: 2
+                                │
+                                ├── • union all
+                                │   │ columns: (aggregated_ts, fingerprint_id, plan_hash, app_name, agg_interval, metadata, statistics, plan)
+                                │   │ estimated row count: 1
+                                │   │
+                                │   ├── • union all
+                                │   │   │ columns: (aggregated_ts, fingerprint_id, plan_hash, app_name, agg_interval, metadata, statistics, plan)
+                                │   │   │ estimated row count: 1
+                                │   │   │
+                                │   │   ├── • filter
+                                │   │   │   │ columns: (aggregated_ts, fingerprint_id, plan_hash, app_name, agg_interval, metadata, statistics, plan)
+                                │   │   │   │ estimated row count: 0
+                                │   │   │   │ filter: app_name NOT LIKE '$ internal%'
+                                │   │   │   │
+                                │   │   │   └── • scan
+                                │   │   │         columns: (aggregated_ts, fingerprint_id, plan_hash, app_name, agg_interval, metadata, statistics, plan)
+                                │   │   │         estimated row count: 1 (<0.01% of the table; stats collected <hidden> ago)
+                                │   │   │         table: statement_statistics@primary
+                                │   │   │         spans: /0/2023-04-10T16:00:00Z-/0/2023-04-10T16:00:00.000000001Z
+                                │   │   │
+                                │   │   └── • filter
+                                │   │       │ columns: (aggregated_ts, fingerprint_id, plan_hash, app_name, agg_interval, metadata, statistics, plan)
+                                │   │       │ estimated row count: 0
+                                │   │       │ filter: app_name NOT LIKE '$ internal%'
+                                │   │       │
+                                │   │       └── • scan
+                                │   │             columns: (aggregated_ts, fingerprint_id, plan_hash, app_name, agg_interval, metadata, statistics, plan)
+                                │   │             estimated row count: 1 (<0.01% of the table; stats collected <hidden> ago)
+                                │   │             table: statement_statistics@primary
+                                │   │             spans: /1/2023-04-10T16:00:00Z-/1/2023-04-10T16:00:00.000000001Z
+                                │   │
+                                │   └── • union all
+                                │       │ columns: (aggregated_ts, fingerprint_id, plan_hash, app_name, agg_interval, metadata, statistics, plan)
+                                │       │ estimated row count: 1
+                                │       │
+                                │       ├── • filter
+                                │       │   │ columns: (aggregated_ts, fingerprint_id, plan_hash, app_name, agg_interval, metadata, statistics, plan)
+                                │       │   │ estimated row count: 0
+                                │       │   │ filter: app_name NOT LIKE '$ internal%'
+                                │       │   │
+                                │       │   └── • scan
+                                │       │         columns: (aggregated_ts, fingerprint_id, plan_hash, app_name, agg_interval, metadata, statistics, plan)
+                                │       │         estimated row count: 1 (<0.01% of the table; stats collected <hidden> ago)
+                                │       │         table: statement_statistics@primary
+                                │       │         spans: /2/2023-04-10T16:00:00Z-/2/2023-04-10T16:00:00.000000001Z
+                                │       │
+                                │       └── • filter
+                                │           │ columns: (aggregated_ts, fingerprint_id, plan_hash, app_name, agg_interval, metadata, statistics, plan)
+                                │           │ estimated row count: 0
+                                │           │ filter: app_name NOT LIKE '$ internal%'
+                                │           │
+                                │           └── • scan
+                                │                 columns: (aggregated_ts, fingerprint_id, plan_hash, app_name, agg_interval, metadata, statistics, plan)
+                                │                 estimated row count: 1 (<0.01% of the table; stats collected <hidden> ago)
+                                │                 table: statement_statistics@primary
+                                │                 spans: /3/2023-04-10T16:00:00Z-/3/2023-04-10T16:00:00.000000001Z
+                                │
+                                └── • union all
+                                    │ columns: (aggregated_ts, fingerprint_id, plan_hash, app_name, agg_interval, metadata, statistics, plan)
+                                    │ estimated row count: 1
+                                    │
+                                    ├── • union all
+                                    │   │ columns: (aggregated_ts, fingerprint_id, plan_hash, app_name, agg_interval, metadata, statistics, plan)
+                                    │   │ estimated row count: 1
+                                    │   │
+                                    │   ├── • filter
+                                    │   │   │ columns: (aggregated_ts, fingerprint_id, plan_hash, app_name, agg_interval, metadata, statistics, plan)
+                                    │   │   │ estimated row count: 0
+                                    │   │   │ filter: app_name NOT LIKE '$ internal%'
+                                    │   │   │
+                                    │   │   └── • scan
+                                    │   │         columns: (aggregated_ts, fingerprint_id, plan_hash, app_name, agg_interval, metadata, statistics, plan)
+                                    │   │         estimated row count: 1 (<0.01% of the table; stats collected <hidden> ago)
+                                    │   │         table: statement_statistics@primary
+                                    │   │         spans: /4/2023-04-10T16:00:00Z-/4/2023-04-10T16:00:00.000000001Z
+                                    │   │
+                                    │   └── • filter
+                                    │       │ columns: (aggregated_ts, fingerprint_id, plan_hash, app_name, agg_interval, metadata, statistics, plan)
+                                    │       │ estimated row count: 0
+                                    │       │ filter: app_name NOT LIKE '$ internal%'
+                                    │       │
+                                    │       └── • scan
+                                    │             columns: (aggregated_ts, fingerprint_id, plan_hash, app_name, agg_interval, metadata, statistics, plan)
+                                    │             estimated row count: 1 (<0.01% of the table; stats collected <hidden> ago)
+                                    │             table: statement_statistics@primary
+                                    │             spans: /5/2023-04-10T16:00:00Z-/5/2023-04-10T16:00:00.000000001Z
+                                    │
+                                    └── • union all
+                                        │ columns: (aggregated_ts, fingerprint_id, plan_hash, app_name, agg_interval, metadata, statistics, plan)
+                                        │ estimated row count: 1
+                                        │
+                                        ├── • filter
+                                        │   │ columns: (aggregated_ts, fingerprint_id, plan_hash, app_name, agg_interval, metadata, statistics, plan)
+                                        │   │ estimated row count: 0
+                                        │   │ filter: app_name NOT LIKE '$ internal%'
+                                        │   │
+                                        │   └── • scan
+                                        │         columns: (aggregated_ts, fingerprint_id, plan_hash, app_name, agg_interval, metadata, statistics, plan)
+                                        │         estimated row count: 1 (<0.01% of the table; stats collected <hidden> ago)
+                                        │         table: statement_statistics@primary
+                                        │         spans: /6/2023-04-10T16:00:00Z-/6/2023-04-10T16:00:00.000000001Z
+                                        │
+                                        └── • filter
+                                            │ columns: (aggregated_ts, fingerprint_id, plan_hash, app_name, agg_interval, metadata, statistics, plan)
+                                            │ estimated row count: 0
+                                            │ filter: app_name NOT LIKE '$ internal%'
+                                            │
+                                            └── • scan
+                                                  columns: (aggregated_ts, fingerprint_id, plan_hash, app_name, agg_interval, metadata, statistics, plan)
+                                                  estimated row count: 1 (<0.01% of the table; stats collected <hidden> ago)
+                                                  table: statement_statistics@primary
+                                                  spans: /7/2023-04-10T16:00:00Z-/7/2023-04-10T16:00:00.000000001Z
+
 
 # Upsert top 500 statement_activity including all statements in the top 500 transactions
 query T retry
-EXPLAIN (VERBOSE) UPSERT
-                  INTO system.public.statement_activity
-                  (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name,
-                   agg_interval, metadata, statistics, plan, index_recommendations, execution_count,
-                   execution_total_seconds, execution_total_cluster_seconds,
-                   contention_time_avg_seconds,
-                   cpu_sql_avg_nanos,
-                   service_latency_avg_seconds, service_latency_p99_seconds)
-                      (SELECT aggregated_ts,
-                              fingerprint_id,
-                              transaction_fingerprint_id,
-                              plan_hash,
-                              app_name,
-                              agg_interval,
-                              metadata,
-                              statistics,
-                              plan,
-                              index_recommendations,
-                              (statistics -> 'execution_statistics' ->> 'cnt')::int,
-                              ((statistics -> 'execution_statistics' ->> 'cnt')::float) *
-                              ((statistics -> 'statistics' -> 'svcLat' ->> 'mean')::float),
-                              100 AS execution_total_cluster_seconds,
-                              COALESCE((statistics -> 'execution_statistics' -> 'contentionTime' ->> 'mean')::float, 0),
-                              COALESCE((statistics -> 'execution_statistics' -> 'cpu_sql_nanos' ->> 'mean')::float, 0),
-                              (statistics -> 'statistics' -> 'svcLat' ->> 'mean')::float,
-                              COALESCE((statistics -> 'statistics' -> 'latencyInfo' ->> 'p99')::float, 0)
-                       FROM (SELECT max(ss.aggregated_ts)                                           AS aggregated_ts,
-                                    ss.fingerprint_id,
-                                    ss.transaction_fingerprint_id,
-                                    ss.plan_hash,
-                                    ss.app_name,
-                                    ss.agg_interval,
-                                    merge_stats_metadata(ss.metadata)    AS metadata,
-                                    merge_statement_stats(ss.statistics) AS statistics,
-                                    ss.plan,
-                                    ss.index_recommendations
-                             FROM system.public.statement_statistics ss
-                             inner join (SELECT fingerprint_id, app_name
-                                                      FROM (SELECT fingerprint_id, app_name,
-                                                                   row_number()
-                                                                   OVER (ORDER BY (statistics -> 'execution_statistics' ->> 'cnt')::int desc)      AS ePos,
-                                                                   row_number()
-                                                                   OVER (ORDER BY (statistics -> 'statistics' -> 'svcLat' ->> 'mean')::float desc) AS sPos,
-                                                                   row_number() OVER (ORDER BY
-                                                                           ((statistics -> 'execution_statistics' ->> 'cnt')::float) *
-                                                                           ((statistics -> 'statistics' -> 'svcLat' ->> 'mean')::float) desc)      AS tPos,
-                                                                   row_number() OVER (ORDER BY COALESCE(
-                                                                           (statistics -> 'execution_statistics' -> 'contentionTime' ->> 'mean')::float,
-                                                                           0) desc)                                                                AS cPos,
-                                                                   row_number() OVER (ORDER BY COALESCE(
-                                                                           (statistics -> 'execution_statistics' -> 'cpu_sql_nanos' ->> 'mean')::float,
-                                                                           0) desc)                                                                AS uPos,
-                                                                   row_number() OVER (ORDER BY COALESCE(
-                                                                           (statistics -> 'statistics' -> 'latencyInfo' ->> 'p99')::float,
-                                                                           0) desc)                                                                AS lPos
-                                                            FROM (SELECT fingerprint_id,
-                                                                         app_name,
-                                                                         merge_statement_stats(statistics) AS statistics
-                                                                  FROM system.public.statement_statistics
-                                                                  WHERE aggregated_ts = '2023-04-10 16:00:00.000000 +00:00' and
-                                                                        app_name not like '$ internal%'
-                                                                  GROUP BY app_name,
-                                                                           fingerprint_id))
-                                                      WHERE ePos < 500
-                                                         or sPos < 500
-                                                         or tPos < 500
-                                                         or cPos < 500
-                                                         or uPos < 500
-                                                         or lPos < 500) agg on agg.app_name = ss.app_name and agg.fingerprint_id = ss.fingerprint_id
-                             WHERE aggregated_ts = '2023-04-10 16:00:00.000000 +00:00'
-                             GROUP BY ss.app_name,
-                                      ss.fingerprint_id,
-                                      ss.transaction_fingerprint_id,
-                                      ss.plan_hash,
-                                      ss.agg_interval,
-                                      ss.plan,
-                                      ss.index_recommendations));
-----
-distribution: local
-vectorized: true
-·
-• upsert
-│ columns: ()
-│ estimated row count: 0 (missing stats)
-│ into: statement_activity(aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, agg_interval, metadata, statistics, plan, index_recommendations, execution_count, execution_total_seconds, execution_total_cluster_seconds, contention_time_avg_seconds, cpu_sql_avg_nanos, service_latency_avg_seconds, service_latency_p99_seconds)
-│ auto commit
-│ arbiter indexes: primary
-│
-└── • project
-    │ columns: (max, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, agg_interval, merge_stats_metadata, merge_statement_stats, plan, index_recommendations, int8, "?column?", execution_total_cluster_seconds, "coalesce", "coalesce", float8, "coalesce", aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, agg_interval, metadata, statistics, plan, index_recommendations, execution_count, execution_total_seconds, execution_total_cluster_seconds, contention_time_avg_seconds, cpu_sql_avg_nanos, service_latency_avg_seconds, service_latency_p99_seconds, agg_interval, merge_stats_metadata, merge_statement_stats, plan, index_recommendations, int8, "?column?", execution_total_cluster_seconds, "coalesce", "coalesce", float8, "coalesce", aggregated_ts)
-    │
-    └── • lookup join (left outer)
-        │ columns: (int8, "?column?", execution_total_cluster_seconds, "coalesce", "coalesce", float8, "coalesce", fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, agg_interval, plan, index_recommendations, max, merge_stats_metadata, merge_statement_stats, aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, agg_interval, metadata, statistics, plan, index_recommendations, execution_count, execution_total_seconds, execution_total_cluster_seconds, contention_time_avg_seconds, cpu_sql_avg_nanos, service_latency_avg_seconds, service_latency_p99_seconds)
-        │ estimated row count: 0 (missing stats)
-        │ table: statement_activity@primary
-        │ equality: (max, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name) = (aggregated_ts,fingerprint_id,transaction_fingerprint_id,plan_hash,app_name)
-        │ equality cols are key
-        │
-        └── • distinct
-            │ columns: (int8, "?column?", execution_total_cluster_seconds, "coalesce", "coalesce", float8, "coalesce", fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, agg_interval, plan, index_recommendations, max, merge_stats_metadata, merge_statement_stats)
-            │ estimated row count: 0 (missing stats)
-            │ distinct on: fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, max
-            │ nulls are distinct
-            │ error on duplicate
-            │
-            └── • render
-                │ columns: (int8, "?column?", execution_total_cluster_seconds, "coalesce", "coalesce", float8, "coalesce", fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, agg_interval, plan, index_recommendations, max, merge_stats_metadata, merge_statement_stats)
-                │ render int8: ((merge_statement_stats->'execution_statistics')->>'cnt')::INT8
-                │ render ?column?: ((merge_statement_stats->'execution_statistics')->>'cnt')::FLOAT8 * (((merge_statement_stats->'statistics')->'svcLat')->>'mean')::FLOAT8
-                │ render execution_total_cluster_seconds: 100.0
-                │ render coalesce: COALESCE((((merge_statement_stats->'execution_statistics')->'contentionTime')->>'mean')::FLOAT8, 0.0)
-                │ render coalesce: COALESCE((((merge_statement_stats->'execution_statistics')->'cpu_sql_nanos')->>'mean')::FLOAT8, 0.0)
-                │ render float8: (((merge_statement_stats->'statistics')->'svcLat')->>'mean')::FLOAT8
-                │ render coalesce: COALESCE((((merge_statement_stats->'statistics')->'latencyInfo')->>'p99')::FLOAT8, 0.0)
-                │ render fingerprint_id: fingerprint_id
-                │ render transaction_fingerprint_id: transaction_fingerprint_id
-                │ render plan_hash: plan_hash
-                │ render app_name: app_name
-                │ render agg_interval: agg_interval
-                │ render plan: plan
-                │ render index_recommendations: index_recommendations
-                │ render max: max
-                │ render merge_stats_metadata: merge_stats_metadata
-                │ render merge_statement_stats: merge_statement_stats
-                │
-                └── • group (hash)
-                    │ columns: (fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, agg_interval, plan, index_recommendations, max, merge_stats_metadata, merge_statement_stats)
-                    │ estimated row count: 0 (missing stats)
-                    │ aggregate 0: max(aggregated_ts)
-                    │ aggregate 1: merge_stats_metadata(metadata)
-                    │ aggregate 2: merge_statement_stats(statistics)
-                    │ group by: fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, agg_interval, plan, index_recommendations
-                    │
-                    └── • project
-                        │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, agg_interval, metadata, statistics, plan, index_recommendations)
-                        │
-                        └── • hash join (inner)
-                            │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, agg_interval, metadata, statistics, plan, index_recommendations, fingerprint_id, app_name, row_number, row_number, row_number, row_number, row_number, row_number_1_orderby_1_1, row_number_2_orderby_1_1, row_number_3_orderby_1_1, row_number_4_orderby_1_1, row_number_5_orderby_1_1, row_number_6_orderby_1_1, row_number)
-                            │ estimated row count: 0 (missing stats)
-                            │ equality: (app_name, fingerprint_id) = (app_name, fingerprint_id)
-                            │ right cols are key
-                            │
-                            ├── • scan
-                            │     columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, agg_interval, metadata, statistics, plan, index_recommendations)
-                            │     estimated row count: 10 (missing stats)
-                            │     table: statement_statistics@primary
-                            │     spans: /0/2023-04-10T16:00:00Z-/0/2023-04-10T16:00:00.000000001Z /1/2023-04-10T16:00:00Z-/1/2023-04-10T16:00:00.000000001Z /2/2023-04-10T16:00:00Z-/2/2023-04-10T16:00:00.000000001Z /3/2023-04-10T16:00:00Z-/3/2023-04-10T16:00:00.000000001Z /4/2023-04-10T16:00:00Z-/4/2023-04-10T16:00:00.000000001Z /5/2023-04-10T16:00:00Z-/5/2023-04-10T16:00:00.000000001Z /6/2023-04-10T16:00:00Z-/6/2023-04-10T16:00:00.000000001Z /7/2023-04-10T16:00:00Z-/7/2023-04-10T16:00:00.000000001Z
-                            │
-                            └── • filter
-                                │ columns: (fingerprint_id, app_name, row_number, row_number, row_number, row_number, row_number, row_number_1_orderby_1_1, row_number_2_orderby_1_1, row_number_3_orderby_1_1, row_number_4_orderby_1_1, row_number_5_orderby_1_1, row_number_6_orderby_1_1, row_number)
-                                │ estimated row count: 3 (missing stats)
-                                │ filter: (((((row_number < 500) OR (row_number < 500)) OR (row_number < 500)) OR (row_number < 500)) OR (row_number < 500)) OR (row_number < 500)
-                                │
-                                └── • window
-                                    │ columns: (fingerprint_id, app_name, row_number, row_number, row_number, row_number, row_number, row_number_1_orderby_1_1, row_number_2_orderby_1_1, row_number_3_orderby_1_1, row_number_4_orderby_1_1, row_number_5_orderby_1_1, row_number_6_orderby_1_1, row_number)
-                                    │ estimated row count: 3 (missing stats)
-                                    │ window 0: row_number() OVER (ORDER BY row_number_6_orderby_1_1 DESC RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
-                                    │
-                                    └── • window
-                                        │ columns: (fingerprint_id, app_name, row_number, row_number, row_number, row_number, row_number, row_number_1_orderby_1_1, row_number_2_orderby_1_1, row_number_3_orderby_1_1, row_number_4_orderby_1_1, row_number_5_orderby_1_1, row_number_6_orderby_1_1)
-                                        │ estimated row count: 3 (missing stats)
-                                        │ window 0: row_number() OVER (ORDER BY row_number_5_orderby_1_1 DESC RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
-                                        │
-                                        └── • window
-                                            │ columns: (fingerprint_id, app_name, row_number, row_number, row_number, row_number, row_number_1_orderby_1_1, row_number_2_orderby_1_1, row_number_3_orderby_1_1, row_number_4_orderby_1_1, row_number_5_orderby_1_1, row_number_6_orderby_1_1)
-                                            │ estimated row count: 3 (missing stats)
-                                            │ window 0: row_number() OVER (ORDER BY row_number_4_orderby_1_1 DESC RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
-                                            │
-                                            └── • window
-                                                │ columns: (fingerprint_id, app_name, row_number, row_number, row_number, row_number_1_orderby_1_1, row_number_2_orderby_1_1, row_number_3_orderby_1_1, row_number_4_orderby_1_1, row_number_5_orderby_1_1, row_number_6_orderby_1_1)
-                                                │ estimated row count: 3 (missing stats)
-                                                │ window 0: row_number() OVER (ORDER BY row_number_3_orderby_1_1 DESC RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
-                                                │
-                                                └── • window
-                                                    │ columns: (fingerprint_id, app_name, row_number, row_number, row_number_1_orderby_1_1, row_number_2_orderby_1_1, row_number_3_orderby_1_1, row_number_4_orderby_1_1, row_number_5_orderby_1_1, row_number_6_orderby_1_1)
-                                                    │ estimated row count: 3 (missing stats)
-                                                    │ window 0: row_number() OVER (ORDER BY row_number_2_orderby_1_1 DESC RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
-                                                    │
-                                                    └── • window
-                                                        │ columns: (fingerprint_id, app_name, row_number, row_number_1_orderby_1_1, row_number_2_orderby_1_1, row_number_3_orderby_1_1, row_number_4_orderby_1_1, row_number_5_orderby_1_1, row_number_6_orderby_1_1)
-                                                        │ estimated row count: 3 (missing stats)
-                                                        │ window 0: row_number() OVER (ORDER BY row_number_1_orderby_1_1 DESC RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
-                                                        │
-                                                        └── • render
-                                                            │ columns: (fingerprint_id, app_name, row_number_1_orderby_1_1, row_number_2_orderby_1_1, row_number_3_orderby_1_1, row_number_4_orderby_1_1, row_number_5_orderby_1_1, row_number_6_orderby_1_1)
-                                                            │ render row_number_1_orderby_1_1: ((merge_statement_stats->'execution_statistics')->>'cnt')::INT8
-                                                            │ render row_number_2_orderby_1_1: (((merge_statement_stats->'statistics')->'svcLat')->>'mean')::FLOAT8
-                                                            │ render row_number_3_orderby_1_1: ((merge_statement_stats->'execution_statistics')->>'cnt')::FLOAT8 * (((merge_statement_stats->'statistics')->'svcLat')->>'mean')::FLOAT8
-                                                            │ render row_number_4_orderby_1_1: COALESCE((((merge_statement_stats->'execution_statistics')->'contentionTime')->>'mean')::FLOAT8, 0.0)
-                                                            │ render row_number_5_orderby_1_1: COALESCE((((merge_statement_stats->'execution_statistics')->'cpu_sql_nanos')->>'mean')::FLOAT8, 0.0)
-                                                            │ render row_number_6_orderby_1_1: COALESCE((((merge_statement_stats->'statistics')->'latencyInfo')->>'p99')::FLOAT8, 0.0)
-                                                            │ render fingerprint_id: fingerprint_id
-                                                            │ render app_name: app_name
-                                                            │
-                                                            └── • group (hash)
-                                                                │ columns: (fingerprint_id, app_name, merge_statement_stats)
-                                                                │ estimated row count: 3 (missing stats)
-                                                                │ aggregate 0: merge_statement_stats(statistics)
-                                                                │ group by: fingerprint_id, app_name
-                                                                │
-                                                                └── • project
-                                                                    │ columns: (fingerprint_id, app_name, statistics)
-                                                                    │
-                                                                    └── • index join
-                                                                        │ columns: (aggregated_ts, fingerprint_id, app_name, statistics)
-                                                                        │ estimated row count: 3 (missing stats)
-                                                                        │ table: statement_statistics@primary
-                                                                        │ key columns: crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id
-                                                                        │
-                                                                        └── • scan
-                                                                              columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8)
-                                                                              estimated row count: 3 (missing stats)
-                                                                              table: statement_statistics@execution_count_idx (partial index)
-                                                                              spans: /2023-04-10T16:00:00Z-/2023-04-10T16:00:00.000000001Z
-
-# Upsert top 500 transactions
-query T retry
-EXPLAIN (VERBOSE) UPSERT
-                  INTO system.public.transaction_activity
-                  (aggregated_ts, fingerprint_id, app_name, agg_interval, metadata,
-                   statistics, query, execution_count, execution_total_seconds,
-                   execution_total_cluster_seconds, contention_time_avg_seconds,
-                   cpu_sql_avg_nanos, service_latency_avg_seconds, service_latency_p99_seconds)
-                      (SELECT aggregated_ts,
-                              fingerprint_id,
-                              app_name,
-                              agg_interval,
-                              metadata,
-                              statistics,
-                              ''  AS query,
-                              (statistics -> 'execution_statistics' ->> 'cnt')::int,
-                              ((statistics -> 'execution_statistics' ->> 'cnt')::float) *
-                              ((statistics -> 'statistics' -> 'svcLat' ->> 'mean')::float),
-                              100 AS execution_total_cluster_seconds,
-                              COALESCE((statistics -> 'execution_statistics' -> 'contentionTime' ->> 'mean')::float, 0),
-                              COALESCE((statistics -> 'execution_statistics' -> 'cpu_sql_nanos' ->> 'mean')::float, 0),
-                              (statistics -> 'statistics' -> 'svcLat' ->> 'mean')::float,
-                              COALESCE((statistics -> 'statistics' -> 'latencyInfo' ->> 'p99')::float, 0)
-                       FROM (SELECT max(ts.aggregated_ts)                                        AS aggregated_ts,
-                                    ts.app_name,
-                                    ts.fingerprint_id,
-                                    ts.agg_interval,
-                                    merge_stats_metadata(ts.metadata) AS metadata,
-                                    merge_transaction_stats(statistics) AS statistics
-                             FROM system.public.transaction_statistics ts
-                                      inner join (SELECT fingerprint_id, app_name, agg_interval
-                                                  FROM (SELECT fingerprint_id, app_name, agg_interval,
-                                                               row_number()
-                                                               OVER (ORDER BY (statistics -> 'execution_statistics' ->> 'cnt')::int desc)        AS ePos,
-                                                               row_number()
-                                                               OVER (ORDER BY (statistics -> 'statistics' -> 'svcLat' ->> 'mean')::float desc)   AS sPos,
-                                                               row_number()
-                                                               OVER (ORDER BY ((statistics -> 'execution_statistics' ->> 'cnt')::float) *
-                                                                              ((statistics -> 'statistics' -> 'svcLat' ->> 'mean')::float) desc) AS tPos,
-                                                               row_number() OVER (ORDER BY COALESCE(
-                                                                       (statistics -> 'execution_statistics' -> 'contentionTime' ->> 'mean')::float,
-                                                                       0) desc)                                                                  AS cPos,
-                                                               row_number() OVER (ORDER BY COALESCE(
-                                                                       (statistics -> 'execution_statistics' -> 'cpu_sql_nanos' ->> 'mean')::float,
-                                                                       0) desc)                                                                  AS uPos,
-                                                               row_number() OVER (ORDER BY COALESCE(
-                                                                       (statistics -> 'statistics' -> 'latencyInfo' ->> 'p99')::float,
-                                                                       0) desc)                                                                  AS lPos
-                                                        FROM (SELECT fingerprint_id, app_name, agg_interval,
-                                                                     merge_transaction_stats(statistics) AS statistics
-                                                              FROM system.public.transaction_statistics
-                                                              WHERE aggregated_ts = '2023-04-10 16:00:00.000000 +00:00' and
-                                                                    app_name not like '$ internal%'
-                                                              GROUP BY app_name,
-                                                                       fingerprint_id,
-                  																										agg_interval))
-                                                  WHERE ePos < 500
-                                                     or sPos < 500
-                                                     or tPos < 500
-                                                     or cPos < 500
-                                                     or uPos < 500
-                                                     or lPos < 500) agg
-                                                 on agg.app_name = ts.app_name and agg.fingerprint_id = ts.fingerprint_id and
-                                                    agg.agg_interval = ts.agg_interval
-                             GROUP BY ts.app_name,
-                                      ts.fingerprint_id,
-                                      ts.agg_interval));
-----
-distribution: local
-vectorized: true
-·
-• upsert
-│ columns: ()
-│ estimated row count: 0 (missing stats)
-│ into: transaction_activity(aggregated_ts, fingerprint_id, app_name, agg_interval, metadata, statistics, query, execution_count, execution_total_seconds, execution_total_cluster_seconds, contention_time_avg_seconds, cpu_sql_avg_nanos, service_latency_avg_seconds, service_latency_p99_seconds)
-│ auto commit
-│ arbiter indexes: primary
-│
-└── • project
-    │ columns: (max, fingerprint_id, app_name, agg_interval, merge_stats_metadata, merge_transaction_stats, query, int8, "?column?", execution_total_cluster_seconds, "coalesce", "coalesce", float8, "coalesce", aggregated_ts, fingerprint_id, app_name, agg_interval, metadata, statistics, query, execution_count, execution_total_seconds, execution_total_cluster_seconds, contention_time_avg_seconds, cpu_sql_avg_nanos, service_latency_avg_seconds, service_latency_p99_seconds, agg_interval, merge_stats_metadata, merge_transaction_stats, query, int8, "?column?", execution_total_cluster_seconds, "coalesce", "coalesce", float8, "coalesce", aggregated_ts)
-    │
-    └── • lookup join (left outer)
-        │ columns: (query, int8, "?column?", execution_total_cluster_seconds, "coalesce", "coalesce", float8, "coalesce", fingerprint_id, app_name, agg_interval, max, merge_stats_metadata, merge_transaction_stats, aggregated_ts, fingerprint_id, app_name, agg_interval, metadata, statistics, query, execution_count, execution_total_seconds, execution_total_cluster_seconds, contention_time_avg_seconds, cpu_sql_avg_nanos, service_latency_avg_seconds, service_latency_p99_seconds)
-        │ estimated row count: 0 (missing stats)
-        │ table: transaction_activity@primary
-        │ equality: (max, fingerprint_id, app_name) = (aggregated_ts,fingerprint_id,app_name)
-        │ equality cols are key
-        │
-        └── • distinct
-            │ columns: (query, int8, "?column?", execution_total_cluster_seconds, "coalesce", "coalesce", float8, "coalesce", fingerprint_id, app_name, agg_interval, max, merge_stats_metadata, merge_transaction_stats)
-            │ estimated row count: 0 (missing stats)
-            │ distinct on: fingerprint_id, app_name, max
-            │ nulls are distinct
-            │ error on duplicate
-            │
-            └── • render
-                │ columns: (query, int8, "?column?", execution_total_cluster_seconds, "coalesce", "coalesce", float8, "coalesce", fingerprint_id, app_name, agg_interval, max, merge_stats_metadata, merge_transaction_stats)
-                │ render query: ''
-                │ render int8: ((merge_transaction_stats->'execution_statistics')->>'cnt')::INT8
-                │ render ?column?: ((merge_transaction_stats->'execution_statistics')->>'cnt')::FLOAT8 * (((merge_transaction_stats->'statistics')->'svcLat')->>'mean')::FLOAT8
-                │ render execution_total_cluster_seconds: 100.0
-                │ render coalesce: COALESCE((((merge_transaction_stats->'execution_statistics')->'contentionTime')->>'mean')::FLOAT8, 0.0)
-                │ render coalesce: COALESCE((((merge_transaction_stats->'execution_statistics')->'cpu_sql_nanos')->>'mean')::FLOAT8, 0.0)
-                │ render float8: (((merge_transaction_stats->'statistics')->'svcLat')->>'mean')::FLOAT8
-                │ render coalesce: COALESCE((((merge_transaction_stats->'statistics')->'latencyInfo')->>'p99')::FLOAT8, 0.0)
-                │ render fingerprint_id: fingerprint_id
-                │ render app_name: app_name
-                │ render agg_interval: agg_interval
-                │ render max: max
-                │ render merge_stats_metadata: merge_stats_metadata
-                │ render merge_transaction_stats: merge_transaction_stats
-                │
-                └── • group (hash)
-                    │ columns: (fingerprint_id, app_name, agg_interval, max, merge_stats_metadata, merge_transaction_stats)
-                    │ estimated row count: 0 (missing stats)
-                    │ aggregate 0: max(aggregated_ts)
-                    │ aggregate 1: merge_stats_metadata(metadata)
-                    │ aggregate 2: merge_transaction_stats(statistics)
-                    │ group by: fingerprint_id, app_name, agg_interval
-                    │
-                    └── • project
-                        │ columns: (aggregated_ts, fingerprint_id, app_name, agg_interval, metadata, statistics)
-                        │
-                        └── • project
-                            │ columns: (aggregated_ts, fingerprint_id, app_name, agg_interval, metadata, statistics, fingerprint_id, app_name, agg_interval, row_number, row_number, row_number, row_number, row_number, row_number, row_number_1_orderby_1_1, row_number_2_orderby_1_1, row_number_3_orderby_1_1, row_number_4_orderby_1_1, row_number_5_orderby_1_1, row_number_6_orderby_1_1)
-                            │
-                            └── • lookup join (inner)
-                                │ columns: (fingerprint_id, app_name, agg_interval, row_number, row_number, row_number, row_number, row_number, row_number_1_orderby_1_1, row_number_2_orderby_1_1, row_number_3_orderby_1_1, row_number_4_orderby_1_1, row_number_5_orderby_1_1, row_number_6_orderby_1_1, row_number, aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, agg_interval, metadata, statistics)
-                                │ estimated row count: 0 (missing stats)
-                                │ table: transaction_statistics@primary
-                                │ equality: (crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, aggregated_ts, fingerprint_id, app_name, node_id) = (crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8,aggregated_ts,fingerprint_id,app_name,node_id)
-                                │ equality cols are key
-                                │ pred: agg_interval = agg_interval
-                                │
-                                └── • lookup join (inner)
-                                    │ columns: (fingerprint_id, app_name, agg_interval, row_number, row_number, row_number, row_number, row_number, row_number_1_orderby_1_1, row_number_2_orderby_1_1, row_number_3_orderby_1_1, row_number_4_orderby_1_1, row_number_5_orderby_1_1, row_number_6_orderby_1_1, row_number, aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8)
-                                    │ estimated row count: 0 (missing stats)
-                                    │ table: transaction_statistics@fingerprint_stats_idx
-                                    │ lookup condition: (fingerprint_id = fingerprint_id) AND (crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8 IN (0, 1, 2, 3, 4, 5, 6, 7))
-                                    │ pred: app_name = app_name
-                                    │
-                                    └── • filter
-                                        │ columns: (fingerprint_id, app_name, agg_interval, row_number, row_number, row_number, row_number, row_number, row_number_1_orderby_1_1, row_number_2_orderby_1_1, row_number_3_orderby_1_1, row_number_4_orderby_1_1, row_number_5_orderby_1_1, row_number_6_orderby_1_1, row_number)
-                                        │ estimated row count: 3 (missing stats)
-                                        │ filter: (((((row_number < 500) OR (row_number < 500)) OR (row_number < 500)) OR (row_number < 500)) OR (row_number < 500)) OR (row_number < 500)
-                                        │
-                                        └── • window
-                                            │ columns: (fingerprint_id, app_name, agg_interval, row_number, row_number, row_number, row_number, row_number, row_number_1_orderby_1_1, row_number_2_orderby_1_1, row_number_3_orderby_1_1, row_number_4_orderby_1_1, row_number_5_orderby_1_1, row_number_6_orderby_1_1, row_number)
-                                            │ estimated row count: 3 (missing stats)
-                                            │ window 0: row_number() OVER (ORDER BY row_number_6_orderby_1_1 DESC RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
-                                            │
-                                            └── • window
-                                                │ columns: (fingerprint_id, app_name, agg_interval, row_number, row_number, row_number, row_number, row_number, row_number_1_orderby_1_1, row_number_2_orderby_1_1, row_number_3_orderby_1_1, row_number_4_orderby_1_1, row_number_5_orderby_1_1, row_number_6_orderby_1_1)
-                                                │ estimated row count: 3 (missing stats)
-                                                │ window 0: row_number() OVER (ORDER BY row_number_5_orderby_1_1 DESC RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
-                                                │
-                                                └── • window
-                                                    │ columns: (fingerprint_id, app_name, agg_interval, row_number, row_number, row_number, row_number, row_number_1_orderby_1_1, row_number_2_orderby_1_1, row_number_3_orderby_1_1, row_number_4_orderby_1_1, row_number_5_orderby_1_1, row_number_6_orderby_1_1)
-                                                    │ estimated row count: 3 (missing stats)
-                                                    │ window 0: row_number() OVER (ORDER BY row_number_4_orderby_1_1 DESC RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
-                                                    │
-                                                    └── • window
-                                                        │ columns: (fingerprint_id, app_name, agg_interval, row_number, row_number, row_number, row_number_1_orderby_1_1, row_number_2_orderby_1_1, row_number_3_orderby_1_1, row_number_4_orderby_1_1, row_number_5_orderby_1_1, row_number_6_orderby_1_1)
-                                                        │ estimated row count: 3 (missing stats)
-                                                        │ window 0: row_number() OVER (ORDER BY row_number_3_orderby_1_1 DESC RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
-                                                        │
-                                                        └── • window
-                                                            │ columns: (fingerprint_id, app_name, agg_interval, row_number, row_number, row_number_1_orderby_1_1, row_number_2_orderby_1_1, row_number_3_orderby_1_1, row_number_4_orderby_1_1, row_number_5_orderby_1_1, row_number_6_orderby_1_1)
-                                                            │ estimated row count: 3 (missing stats)
-                                                            │ window 0: row_number() OVER (ORDER BY row_number_2_orderby_1_1 DESC RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
-                                                            │
-                                                            └── • window
-                                                                │ columns: (fingerprint_id, app_name, agg_interval, row_number, row_number_1_orderby_1_1, row_number_2_orderby_1_1, row_number_3_orderby_1_1, row_number_4_orderby_1_1, row_number_5_orderby_1_1, row_number_6_orderby_1_1)
-                                                                │ estimated row count: 3 (missing stats)
-                                                                │ window 0: row_number() OVER (ORDER BY row_number_1_orderby_1_1 DESC RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
-                                                                │
-                                                                └── • render
-                                                                    │ columns: (fingerprint_id, app_name, agg_interval, row_number_1_orderby_1_1, row_number_2_orderby_1_1, row_number_3_orderby_1_1, row_number_4_orderby_1_1, row_number_5_orderby_1_1, row_number_6_orderby_1_1)
-                                                                    │ render row_number_1_orderby_1_1: ((merge_transaction_stats->'execution_statistics')->>'cnt')::INT8
-                                                                    │ render row_number_2_orderby_1_1: (((merge_transaction_stats->'statistics')->'svcLat')->>'mean')::FLOAT8
-                                                                    │ render row_number_3_orderby_1_1: ((merge_transaction_stats->'execution_statistics')->>'cnt')::FLOAT8 * (((merge_transaction_stats->'statistics')->'svcLat')->>'mean')::FLOAT8
-                                                                    │ render row_number_4_orderby_1_1: COALESCE((((merge_transaction_stats->'execution_statistics')->'contentionTime')->>'mean')::FLOAT8, 0.0)
-                                                                    │ render row_number_5_orderby_1_1: COALESCE((((merge_transaction_stats->'execution_statistics')->'cpu_sql_nanos')->>'mean')::FLOAT8, 0.0)
-                                                                    │ render row_number_6_orderby_1_1: COALESCE((((merge_transaction_stats->'statistics')->'latencyInfo')->>'p99')::FLOAT8, 0.0)
-                                                                    │ render fingerprint_id: fingerprint_id
-                                                                    │ render app_name: app_name
-                                                                    │ render agg_interval: agg_interval
-                                                                    │
-                                                                    └── • group (hash)
-                                                                        │ columns: (fingerprint_id, app_name, agg_interval, merge_transaction_stats)
-                                                                        │ estimated row count: 3 (missing stats)
-                                                                        │ aggregate 0: merge_transaction_stats(statistics)
-                                                                        │ group by: fingerprint_id, app_name, agg_interval
-                                                                        │
-                                                                        └── • project
-                                                                            │ columns: (fingerprint_id, app_name, agg_interval, statistics)
-                                                                            │
-                                                                            └── • index join
-                                                                                │ columns: (aggregated_ts, fingerprint_id, app_name, agg_interval, statistics)
-                                                                                │ estimated row count: 3 (missing stats)
-                                                                                │ table: transaction_statistics@primary
-                                                                                │ key columns: crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, aggregated_ts, fingerprint_id, app_name, node_id
-                                                                                │
-                                                                                └── • scan
-                                                                                      columns: (aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8)
-                                                                                      estimated row count: 3 (missing stats)
-                                                                                      table: transaction_statistics@execution_count_idx (partial index)
-                                                                                      spans: /2023-04-10T16:00:00Z-/2023-04-10T16:00:00.000000001Z
-
-# Upsert top 500 transactions
-query T retry
 EXPLAIN (VERBOSE)
-WITH missed_stmt_ids_from_txn_activity AS (SELECT ta.fingerprint_id, ta.app_name
-                                     FROM (SELECT ta_sub.aggregated_ts,
-                                                  decode(jsonb_array_elements_text(ta_sub.metadata -> 'stmtFingerprintIDs'), 'hex')::bytes AS fingerprint_id,
-                                                  ta_sub.fingerprint_id                                                     AS transaction_fingerprint_id,
-                                                  ta_sub.app_name
-                                           FROM system.transaction_activity ta_sub WHERE ta_sub.aggregated_ts = '2023-04-10 16:00:00.000000 +00:00') ta
-                                        	 LEFT OUTER JOIN (select fingerprint_id,
-                                                                      app_name,
-                                                                      aggregated_ts
-                                                               FROM system.statement_activity WHERE aggregated_ts = '2023-04-10 16:00:00.000000 +00:00') sa
-                                                              ON sa.fingerprint_id = ta.fingerprint_id AND
-                                                                 sa.app_name = ta.app_name AND
-                                                                 ta.aggregated_ts = sa.aggregated_ts
-                                     WHERE sa.fingerprint_id is null
-																		 GROUP BY ta.fingerprint_id, ta.app_name)
+WITH agg_stmt_stats AS (SELECT aggregated_ts,
+                               fingerprint_id,
+                               app_name,
+                               merge_statement_stats(statistics) AS merged_stats
+                        FROM system.public.statement_statistics
+                        WHERE aggregated_ts = '2023-04-10 16:00:00.000000 +00:00'
+                          and app_name not like '$ internal%'
+                        GROUP BY aggregated_ts,
+                                 app_name,
+                                 fingerprint_id),
+     limit_stmt_stats AS (SELECT aggregated_ts,
+                                 fingerprint_id,
+                                 app_name
+                          FROM (SELECT aggregated_ts,
+                                       fingerprint_id,
+                                       app_name,
+                                       merged_stats,
+                                       row_number() OVER (ORDER BY (merged_stats -> 'statistics' ->> 'cnt')::int desc)                AS ePos,
+                                       row_number() OVER (ORDER BY (merged_stats -> 'statistics' -> 'svcLat' ->> 'mean')::float desc) AS sPos,
+                                       row_number() OVER (ORDER BY
+                                               ((merged_stats -> 'statistics' ->> 'cnt')::float) *
+                                               ((merged_stats -> 'statistics' -> 'svcLat' ->> 'mean')::float) desc)      AS tPos,
+                                       row_number() OVER (ORDER BY COALESCE((merged_stats -> 'execution_statistics' -> 'contentionTime' ->> 'mean')::float, 0) desc) AS cPos,
+                                       row_number() OVER (ORDER BY COALESCE((merged_stats -> 'execution_statistics' -> 'cpuSQLNanos' ->> 'mean')::float, 0) desc) AS uPos,
+                                       row_number() OVER (ORDER BY COALESCE((merged_stats -> 'statistics' -> 'latencyInfo' ->> 'p99')::float, 0) desc) AS lPos
+                                FROM agg_stmt_stats)
+                          WHERE ePos < 500
+                             or sPos < 500
+                             or tPos < 500
+                             or (cPos < 500 AND ((merged_stats -> 'execution_statistics' -> 'contentionTime' ->> 'mean')::float > 0))
+                             or (uPos < 500 AND  ((merged_stats -> 'execution_statistics' -> 'cpuSQLNanos' ->> 'mean')::float > 0))
+                             or (lPos < 500 AND ((merged_stats -> 'statistics' -> 'latencyInfo' ->> 'p99')::float > 0)))
 UPSERT INTO system.public.statement_activity
 (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name,
  agg_interval, metadata, statistics, plan, index_recommendations, execution_count,
  execution_total_seconds, execution_total_cluster_seconds,
  contention_time_avg_seconds,
  cpu_sql_avg_nanos,
- service_latency_avg_seconds, service_latency_p99_seconds)
-(SELECT aggregated_ts,
-    fingerprint_id,
-    transaction_fingerprint_id,
-    plan_hash,
-    app_name,
-    agg_interval,
-    metadata,
-    statistics,
-    plan,
-    index_recommendations,
-    (statistics -> 'execution_statistics' ->> 'cnt')::int,
-    ((statistics -> 'execution_statistics' ->> 'cnt')::float) *
-    ((statistics -> 'statistics' -> 'svcLat' ->> 'mean')::float),
-    100 AS execution_total_cluster_seconds,
-    COALESCE ((statistics -> 'execution_statistics' -> 'contentionTime' ->> 'mean')::float, 0),
-    COALESCE ((statistics -> 'execution_statistics' -> 'cpu_sql_nanos' ->> 'mean')::float, 0),
-    (statistics -> 'statistics' -> 'svcLat' ->> 'mean')::float,
-    COALESCE ((statistics -> 'statistics' -> 'latencyInfo' ->> 'p99')::float, 0)
-FROM (SELECT max(ss.aggregated_ts) AS aggregated_ts,
-    ss.fingerprint_id,
-    ss.transaction_fingerprint_id,
-    ss.plan_hash,
-    ss.app_name,
-    ss.agg_interval,
-    merge_stats_metadata(ss.metadata) AS metadata,
-    merge_statement_stats(ss.statistics) AS statistics,
-    ss.plan,
-    ss.index_recommendations
-    FROM system.public.statement_statistics ss
-    INNER JOIN missed_stmt_ids_from_txn_activity ON missed_stmt_ids_from_txn_activity.app_name = ss.app_name AND missed_stmt_ids_from_txn_activity.fingerprint_id = ss.fingerprint_id
-    WHERE aggregated_ts = '2023-04-10 16:00:00.000000 +00:00'
-		GROUP BY ss.app_name,
-		 ss.fingerprint_id,
-		 ss.transaction_fingerprint_id,
-		 ss.plan_hash,
-		 ss.agg_interval,
-		 ss.plan,
-		 ss.index_recommendations));
+ service_latency_avg_seconds, service_latency_p99_seconds)(
+SELECT aggregated_ts,
+       fingerprint_id,
+       '0x0000000000000000'::bytes as txn_fingerprint_id,
+       plan_hash,
+       app_name,
+       max_agg_interval,
+       metadata,
+       merged_stats,
+       max_plan,
+       (select COALESCE(array_agg(o.rec::string), (array[]::string[])) FROM jsonb_array_elements_text(merged_stats -> 'index_recommendations') o(rec)) as idx_rec,
+       (merged_stats -> 'statistics' ->> 'cnt')::int,
+       ((merged_stats -> 'statistics' ->> 'cnt')::float) *
+       ((merged_stats -> 'statistics' -> 'svcLat' ->> 'mean')::float),
+       100 AS execution_total_cluster_seconds,
+       COALESCE((merged_stats -> 'execution_statistics' -> 'contentionTime' ->> 'mean')::float, 0),
+       COALESCE((merged_stats -> 'execution_statistics' -> 'cpuSQLNanos' ->> 'mean')::float, 0),
+       (merged_stats -> 'statistics' -> 'svcLat' ->> 'mean')::float,
+       COALESCE((merged_stats -> 'statistics' -> 'latencyInfo' ->> 'p99')::float, 0)
+FROM (SELECT ss.aggregated_ts AS aggregated_ts,
+             ss.fingerprint_id,
+             ss.plan_hash,
+             ss.app_name,
+             max(ss.agg_interval) AS max_agg_interval,
+             max(ss.plan) AS max_plan,
+             merge_stats_metadata(ss.metadata) AS metadata,
+             merge_statement_stats(ss.statistics) AS merged_stats
+      FROM system.statement_statistics ss
+      inner join limit_stmt_stats using (aggregated_ts, fingerprint_id, app_name)
+      group by aggregated_ts, fingerprint_id, plan_hash, app_name));
 ----
 distribution: local
 vectorized: true
@@ -733,109 +558,461 @@ vectorized: true
 │ arbiter indexes: primary
 │
 └── • project
-    │ columns: (max, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, agg_interval, merge_stats_metadata, merge_statement_stats, plan, index_recommendations, int8, "?column?", execution_total_cluster_seconds, "coalesce", "coalesce", float8, "coalesce", aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, agg_interval, metadata, statistics, plan, index_recommendations, execution_count, execution_total_seconds, execution_total_cluster_seconds, contention_time_avg_seconds, cpu_sql_avg_nanos, service_latency_avg_seconds, service_latency_p99_seconds, agg_interval, merge_stats_metadata, merge_statement_stats, plan, index_recommendations, int8, "?column?", execution_total_cluster_seconds, "coalesce", "coalesce", float8, "coalesce", aggregated_ts)
+    │ columns: (aggregated_ts, fingerprint_id, txn_fingerprint_id, plan_hash, app_name, max, merge_stats_metadata, merge_statement_stats, max, idx_rec, int8, "?column?", execution_total_cluster_seconds, "coalesce", "coalesce", float8, "coalesce", aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, agg_interval, metadata, statistics, plan, index_recommendations, execution_count, execution_total_seconds, execution_total_cluster_seconds, contention_time_avg_seconds, cpu_sql_avg_nanos, service_latency_avg_seconds, service_latency_p99_seconds, max, merge_stats_metadata, merge_statement_stats, max, idx_rec, int8, "?column?", execution_total_cluster_seconds, "coalesce", "coalesce", float8, "coalesce", aggregated_ts)
     │
-    └── • lookup join (left outer)
-        │ columns: (int8, "?column?", execution_total_cluster_seconds, "coalesce", "coalesce", float8, "coalesce", fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, agg_interval, plan, index_recommendations, max, merge_stats_metadata, merge_statement_stats, aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, agg_interval, metadata, statistics, plan, index_recommendations, execution_count, execution_total_seconds, execution_total_cluster_seconds, contention_time_avg_seconds, cpu_sql_avg_nanos, service_latency_avg_seconds, service_latency_p99_seconds)
-        │ estimated row count: 7 (missing stats)
-        │ table: statement_activity@primary
-        │ equality: (max, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name) = (aggregated_ts,fingerprint_id,transaction_fingerprint_id,plan_hash,app_name)
-        │ equality cols are key
+    └── • project
+        │ columns: (aggregated_ts, fingerprint_id, plan_hash, app_name, max, max, merge_stats_metadata, merge_statement_stats, txn_fingerprint_id, idx_rec, int8, "?column?", execution_total_cluster_seconds, "coalesce", "coalesce", float8, "coalesce", aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, agg_interval, metadata, statistics, plan, index_recommendations, execution_count, execution_total_seconds, execution_total_cluster_seconds, contention_time_avg_seconds, cpu_sql_avg_nanos, service_latency_avg_seconds, service_latency_p99_seconds)
         │
-        └── • distinct
-            │ columns: (int8, "?column?", execution_total_cluster_seconds, "coalesce", "coalesce", float8, "coalesce", fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, agg_interval, plan, index_recommendations, max, merge_stats_metadata, merge_statement_stats)
-            │ estimated row count: 7 (missing stats)
-            │ distinct on: fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, max
-            │ nulls are distinct
-            │ error on duplicate
+        └── • lookup join (left outer)
+            │ columns: ("lookup_join_const_col_@104", txn_fingerprint_id, idx_rec, int8, "?column?", execution_total_cluster_seconds, "coalesce", "coalesce", float8, "coalesce", aggregated_ts, fingerprint_id, plan_hash, app_name, max, max, merge_stats_metadata, merge_statement_stats, aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, agg_interval, metadata, statistics, plan, index_recommendations, execution_count, execution_total_seconds, execution_total_cluster_seconds, contention_time_avg_seconds, cpu_sql_avg_nanos, service_latency_avg_seconds, service_latency_p99_seconds)
+            │ estimated row count: 3
+            │ table: statement_activity@primary
+            │ equality: (aggregated_ts, fingerprint_id, lookup_join_const_col_@104, plan_hash, app_name) = (aggregated_ts,fingerprint_id,transaction_fingerprint_id,plan_hash,app_name)
+            │ equality cols are key
             │
             └── • render
-                │ columns: (int8, "?column?", execution_total_cluster_seconds, "coalesce", "coalesce", float8, "coalesce", fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, agg_interval, plan, index_recommendations, max, merge_stats_metadata, merge_statement_stats)
-                │ render int8: ((merge_statement_stats->'execution_statistics')->>'cnt')::INT8
-                │ render ?column?: ((merge_statement_stats->'execution_statistics')->>'cnt')::FLOAT8 * (((merge_statement_stats->'statistics')->'svcLat')->>'mean')::FLOAT8
+                │ columns: ("lookup_join_const_col_@104", txn_fingerprint_id, idx_rec, int8, "?column?", execution_total_cluster_seconds, "coalesce", "coalesce", float8, "coalesce", aggregated_ts, fingerprint_id, plan_hash, app_name, max, max, merge_stats_metadata, merge_statement_stats)
+                │ render lookup_join_const_col_@104: '\x307830303030303030303030303030303030'
+                │ render txn_fingerprint_id: '\x307830303030303030303030303030303030'
+                │ render idx_rec: COALESCE(CASE WHEN any_not_null IS NOT NULL THEN array_agg ELSE CAST(NULL AS STRING[]) END, ARRAY[])
+                │ render int8: ((any_not_null->'statistics')->>'cnt')::INT8
+                │ render ?column?: ((any_not_null->'statistics')->>'cnt')::FLOAT8 * (((any_not_null->'statistics')->'svcLat')->>'mean')::FLOAT8
                 │ render execution_total_cluster_seconds: 100.0
-                │ render coalesce: COALESCE((((merge_statement_stats->'execution_statistics')->'contentionTime')->>'mean')::FLOAT8, 0.0)
-                │ render coalesce: COALESCE((((merge_statement_stats->'execution_statistics')->'cpu_sql_nanos')->>'mean')::FLOAT8, 0.0)
-                │ render float8: (((merge_statement_stats->'statistics')->'svcLat')->>'mean')::FLOAT8
-                │ render coalesce: COALESCE((((merge_statement_stats->'statistics')->'latencyInfo')->>'p99')::FLOAT8, 0.0)
+                │ render coalesce: COALESCE((((any_not_null->'execution_statistics')->'contentionTime')->>'mean')::FLOAT8, 0.0)
+                │ render coalesce: COALESCE((((any_not_null->'execution_statistics')->'cpuSQLNanos')->>'mean')::FLOAT8, 0.0)
+                │ render float8: (((any_not_null->'statistics')->'svcLat')->>'mean')::FLOAT8
+                │ render coalesce: COALESCE((((any_not_null->'statistics')->'latencyInfo')->>'p99')::FLOAT8, 0.0)
+                │ render aggregated_ts: any_not_null
                 │ render fingerprint_id: fingerprint_id
-                │ render transaction_fingerprint_id: transaction_fingerprint_id
                 │ render plan_hash: plan_hash
                 │ render app_name: app_name
-                │ render agg_interval: agg_interval
-                │ render plan: plan
-                │ render index_recommendations: index_recommendations
-                │ render max: max
-                │ render merge_stats_metadata: merge_stats_metadata
-                │ render merge_statement_stats: merge_statement_stats
+                │ render max: any_not_null
+                │ render max: any_not_null
+                │ render merge_stats_metadata: any_not_null
+                │ render merge_statement_stats: any_not_null
                 │
                 └── • group (hash)
-                    │ columns: (fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, agg_interval, plan, index_recommendations, max, merge_stats_metadata, merge_statement_stats)
-                    │ estimated row count: 7 (missing stats)
-                    │ aggregate 0: max(aggregated_ts)
-                    │ aggregate 1: merge_stats_metadata(metadata)
-                    │ aggregate 2: merge_statement_stats(statistics)
-                    │ group by: fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, agg_interval, plan, index_recommendations
+                    │ columns: (fingerprint_id, plan_hash, app_name, array_agg, any_not_null, any_not_null, any_not_null, any_not_null, any_not_null, any_not_null)
+                    │ estimated row count: 3
+                    │ aggregate 0: array_agg(value)
+                    │ aggregate 1: any_not_null(any_not_null)
+                    │ aggregate 2: any_not_null(max)
+                    │ aggregate 3: any_not_null(max)
+                    │ aggregate 4: any_not_null(merge_stats_metadata)
+                    │ aggregate 5: any_not_null(merge_statement_stats)
+                    │ aggregate 6: any_not_null(canary)
+                    │ group by: fingerprint_id, plan_hash, app_name
                     │
-                    └── • project
-                        │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, agg_interval, metadata, statistics, plan, index_recommendations)
+                    └── • apply join (left outer)
+                        │ columns: (fingerprint_id, plan_hash, app_name, max, max, merge_stats_metadata, merge_statement_stats, any_not_null, value, canary)
+                        │ estimated row count: 25
                         │
-                        └── • hash join (inner)
-                            │ columns: (fingerprint_id, app_name, aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, agg_interval, metadata, statistics, plan, index_recommendations)
-                            │ estimated row count: 7 (missing stats)
-                            │ equality: (app_name, fingerprint_id) = (app_name, fingerprint_id)
-                            │ left cols are key
+                        └── • group (hash)
+                            │ columns: (fingerprint_id, plan_hash, app_name, max, max, merge_stats_metadata, merge_statement_stats, any_not_null)
+                            │ estimated row count: 3
+                            │ aggregate 0: max(agg_interval)
+                            │ aggregate 1: max(plan)
+                            │ aggregate 2: merge_stats_metadata(metadata)
+                            │ aggregate 3: merge_statement_stats(statistics)
+                            │ aggregate 4: any_not_null(aggregated_ts)
+                            │ group by: fingerprint_id, plan_hash, app_name
                             │
-                            ├── • render
-                            │   │ columns: (fingerprint_id, app_name)
-                            │   │ render fingerprint_id: fingerprint_id
-                            │   │ render app_name: app_name
-                            │   │
-                            │   └── • distinct
-                            │       │ columns: (app_name, fingerprint_id)
-                            │       │ estimated row count: 64 (missing stats)
-                            │       │ distinct on: app_name, fingerprint_id
-                            │       │
-                            │       └── • project
-                            │           │ columns: (app_name, fingerprint_id)
-                            │           │
-                            │           └── • filter
-                            │               │ columns: (fingerprint_id, aggregated_ts, app_name, aggregated_ts, fingerprint_id, app_name)
-                            │               │ estimated row count: 89 (missing stats)
-                            │               │ filter: fingerprint_id IS NULL
-                            │               │
-                            │               └── • hash join (left outer)
-                            │                   │ columns: (fingerprint_id, aggregated_ts, app_name, aggregated_ts, fingerprint_id, app_name)
-                            │                   │ estimated row count: 100 (missing stats)
-                            │                   │ equality: (fingerprint_id, app_name, aggregated_ts) = (fingerprint_id, app_name, aggregated_ts)
-                            │                   │
-                            │                   ├── • render
-                            │                   │   │ columns: (fingerprint_id, aggregated_ts, app_name)
-                            │                   │   │ render fingerprint_id: decode(jsonb_array_elements_text, 'hex')
-                            │                   │   │ render aggregated_ts: aggregated_ts
-                            │                   │   │ render app_name: app_name
-                            │                   │   │
-                            │                   │   └── • project set
-                            │                   │       │ columns: (aggregated_ts, app_name, metadata, jsonb_array_elements_text)
-                            │                   │       │ estimated row count: 100 (missing stats)
-                            │                   │       │ render 0: jsonb_array_elements_text(metadata->'stmtFingerprintIDs')
-                            │                   │       │
-                            │                   │       └── • scan
-                            │                   │             columns: (aggregated_ts, app_name, metadata)
-                            │                   │             estimated row count: 10 (missing stats)
-                            │                   │             table: transaction_activity@primary
-                            │                   │             spans: /2023-04-10T16:00:00Z-/2023-04-10T16:00:00.000000001Z
-                            │                   │
-                            │                   └── • scan
-                            │                         columns: (aggregated_ts, fingerprint_id, app_name)
-                            │                         estimated row count: 10 (missing stats)
-                            │                         table: statement_activity@execution_count_idx
-                            │                         spans: /2023-04-10T16:00:00Z-/2023-04-10T16:00:00.000000001Z
+                            └── • project
+                                │ columns: (aggregated_ts, fingerprint_id, plan_hash, app_name, agg_interval, metadata, statistics, plan)
+                                │
+                                └── • project
+                                    │ columns: (aggregated_ts, fingerprint_id, plan_hash, app_name, agg_interval, metadata, statistics, plan, aggregated_ts, fingerprint_id, app_name)
+                                    │
+                                    └── • lookup join (inner)
+                                        │ columns: (aggregated_ts, fingerprint_id, app_name, aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, agg_interval, metadata, statistics, plan)
+                                        │ estimated row count: 3
+                                        │ table: statement_statistics@primary
+                                        │ equality: (crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id) = (crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8,aggregated_ts,fingerprint_id,transaction_fingerprint_id,plan_hash,app_name,node_id)
+                                        │ equality cols are key
+                                        │
+                                        └── • lookup join (inner)
+                                            │ columns: (aggregated_ts, fingerprint_id, app_name, aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8)
+                                            │ estimated row count: 3
+                                            │ table: statement_statistics@fingerprint_stats_idx
+                                            │ equality: (fingerprint_id) = (fingerprint_id)
+                                            │ pred: (aggregated_ts = aggregated_ts) AND (app_name = app_name)
+                                            │
+                                            └── • render
+                                                │ columns: (aggregated_ts, fingerprint_id, app_name)
+                                                │ render aggregated_ts: aggregated_ts
+                                                │ render fingerprint_id: fingerprint_id
+                                                │ render app_name: app_name
+                                                │
+                                                └── • filter
+                                                    │ columns: (aggregated_ts, fingerprint_id, app_name, merged_stats, row_number, row_number, row_number, row_number, row_number, row_number_1_orderby_1_1, row_number_2_orderby_1_1, row_number_3_orderby_1_1, row_number_4_orderby_1_1, row_number_5_orderby_1_1, row_number_6_orderby_1_1, row_number)
+                                                    │ estimated row count: 25,339
+                                                    │ filter: (((((row_number < 500) OR (row_number < 500)) OR (row_number < 500)) OR ((row_number < 500) AND ((((merged_stats->'execution_statistics')->'contentionTime')->>'mean')::FLOAT8 > 0.0))) OR ((row_number < 500) AND ((((merged_stats->'execution_statistics')->'cpuSQLNanos')->>'mean')::FLOAT8 > 0.0))) OR ((row_number < 500) AND ((((merged_stats->'statistics')->'latencyInfo')->>'p99')::FLOAT8 > 0.0))
+                                                    │
+                                                    └── • window
+                                                        │ columns: (aggregated_ts, fingerprint_id, app_name, merged_stats, row_number, row_number, row_number, row_number, row_number, row_number_1_orderby_1_1, row_number_2_orderby_1_1, row_number_3_orderby_1_1, row_number_4_orderby_1_1, row_number_5_orderby_1_1, row_number_6_orderby_1_1, row_number)
+                                                        │ estimated row count: 27,778
+                                                        │ window 0: row_number() OVER (ORDER BY row_number_6_orderby_1_1 DESC RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
+                                                        │
+                                                        └── • window
+                                                            │ columns: (aggregated_ts, fingerprint_id, app_name, merged_stats, row_number, row_number, row_number, row_number, row_number, row_number_1_orderby_1_1, row_number_2_orderby_1_1, row_number_3_orderby_1_1, row_number_4_orderby_1_1, row_number_5_orderby_1_1, row_number_6_orderby_1_1)
+                                                            │ estimated row count: 27,778
+                                                            │ window 0: row_number() OVER (ORDER BY row_number_5_orderby_1_1 DESC RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
+                                                            │
+                                                            └── • window
+                                                                │ columns: (aggregated_ts, fingerprint_id, app_name, merged_stats, row_number, row_number, row_number, row_number, row_number_1_orderby_1_1, row_number_2_orderby_1_1, row_number_3_orderby_1_1, row_number_4_orderby_1_1, row_number_5_orderby_1_1, row_number_6_orderby_1_1)
+                                                                │ estimated row count: 27,778
+                                                                │ window 0: row_number() OVER (ORDER BY row_number_4_orderby_1_1 DESC RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
+                                                                │
+                                                                └── • window
+                                                                    │ columns: (aggregated_ts, fingerprint_id, app_name, merged_stats, row_number, row_number, row_number, row_number_1_orderby_1_1, row_number_2_orderby_1_1, row_number_3_orderby_1_1, row_number_4_orderby_1_1, row_number_5_orderby_1_1, row_number_6_orderby_1_1)
+                                                                    │ estimated row count: 27,778
+                                                                    │ window 0: row_number() OVER (ORDER BY row_number_3_orderby_1_1 DESC RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
+                                                                    │
+                                                                    └── • window
+                                                                        │ columns: (aggregated_ts, fingerprint_id, app_name, merged_stats, row_number, row_number, row_number_1_orderby_1_1, row_number_2_orderby_1_1, row_number_3_orderby_1_1, row_number_4_orderby_1_1, row_number_5_orderby_1_1, row_number_6_orderby_1_1)
+                                                                        │ estimated row count: 27,778
+                                                                        │ window 0: row_number() OVER (ORDER BY row_number_2_orderby_1_1 DESC RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
+                                                                        │
+                                                                        └── • window
+                                                                            │ columns: (aggregated_ts, fingerprint_id, app_name, merged_stats, row_number, row_number_1_orderby_1_1, row_number_2_orderby_1_1, row_number_3_orderby_1_1, row_number_4_orderby_1_1, row_number_5_orderby_1_1, row_number_6_orderby_1_1)
+                                                                            │ estimated row count: 27,778
+                                                                            │ window 0: row_number() OVER (ORDER BY row_number_1_orderby_1_1 DESC RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
+                                                                            │
+                                                                            └── • render
+                                                                                │ columns: (aggregated_ts, fingerprint_id, app_name, merged_stats, row_number_1_orderby_1_1, row_number_2_orderby_1_1, row_number_3_orderby_1_1, row_number_4_orderby_1_1, row_number_5_orderby_1_1, row_number_6_orderby_1_1)
+                                                                                │ render row_number_1_orderby_1_1: ((merged_stats->'statistics')->>'cnt')::INT8
+                                                                                │ render row_number_2_orderby_1_1: (((merged_stats->'statistics')->'svcLat')->>'mean')::FLOAT8
+                                                                                │ render row_number_3_orderby_1_1: ((merged_stats->'statistics')->>'cnt')::FLOAT8 * (((merged_stats->'statistics')->'svcLat')->>'mean')::FLOAT8
+                                                                                │ render row_number_4_orderby_1_1: COALESCE((((merged_stats->'execution_statistics')->'contentionTime')->>'mean')::FLOAT8, 0.0)
+                                                                                │ render row_number_5_orderby_1_1: COALESCE((((merged_stats->'execution_statistics')->'cpuSQLNanos')->>'mean')::FLOAT8, 0.0)
+                                                                                │ render row_number_6_orderby_1_1: COALESCE((((merged_stats->'statistics')->'latencyInfo')->>'p99')::FLOAT8, 0.0)
+                                                                                │ render aggregated_ts: aggregated_ts
+                                                                                │ render fingerprint_id: fingerprint_id
+                                                                                │ render app_name: app_name
+                                                                                │ render merged_stats: merged_stats
+                                                                                │
+                                                                                └── • render
+                                                                                    │ columns: (aggregated_ts, fingerprint_id, app_name, merged_stats)
+                                                                                    │ render aggregated_ts: any_not_null
+                                                                                    │ render fingerprint_id: fingerprint_id
+                                                                                    │ render app_name: app_name
+                                                                                    │ render merged_stats: merge_statement_stats
+                                                                                    │
+                                                                                    └── • group (hash)
+                                                                                        │ columns: (fingerprint_id, app_name, merge_statement_stats, any_not_null)
+                                                                                        │ estimated row count: 27,778
+                                                                                        │ aggregate 0: merge_statement_stats(statistics)
+                                                                                        │ aggregate 1: any_not_null(aggregated_ts)
+                                                                                        │ group by: fingerprint_id, app_name
+                                                                                        │
+                                                                                        └── • union all
+                                                                                            │ columns: (aggregated_ts, fingerprint_id, app_name, statistics)
+                                                                                            │ estimated row count: 2
+                                                                                            │
+                                                                                            ├── • union all
+                                                                                            │   │ columns: (aggregated_ts, fingerprint_id, app_name, statistics)
+                                                                                            │   │ estimated row count: 1
+                                                                                            │   │
+                                                                                            │   ├── • union all
+                                                                                            │   │   │ columns: (aggregated_ts, fingerprint_id, app_name, statistics)
+                                                                                            │   │   │ estimated row count: 1
+                                                                                            │   │   │
+                                                                                            │   │   ├── • filter
+                                                                                            │   │   │   │ columns: (aggregated_ts, fingerprint_id, app_name, statistics)
+                                                                                            │   │   │   │ estimated row count: 0
+                                                                                            │   │   │   │ filter: app_name NOT LIKE '$ internal%'
+                                                                                            │   │   │   │
+                                                                                            │   │   │   └── • scan
+                                                                                            │   │   │         columns: (aggregated_ts, fingerprint_id, app_name, statistics)
+                                                                                            │   │   │         estimated row count: 1 (<0.01% of the table; stats collected <hidden> ago)
+                                                                                            │   │   │         table: statement_statistics@primary
+                                                                                            │   │   │         spans: /0/2023-04-10T16:00:00Z-/0/2023-04-10T16:00:00.000000001Z
+                                                                                            │   │   │
+                                                                                            │   │   └── • filter
+                                                                                            │   │       │ columns: (aggregated_ts, fingerprint_id, app_name, statistics)
+                                                                                            │   │       │ estimated row count: 0
+                                                                                            │   │       │ filter: app_name NOT LIKE '$ internal%'
+                                                                                            │   │       │
+                                                                                            │   │       └── • scan
+                                                                                            │   │             columns: (aggregated_ts, fingerprint_id, app_name, statistics)
+                                                                                            │   │             estimated row count: 1 (<0.01% of the table; stats collected <hidden> ago)
+                                                                                            │   │             table: statement_statistics@primary
+                                                                                            │   │             spans: /1/2023-04-10T16:00:00Z-/1/2023-04-10T16:00:00.000000001Z
+                                                                                            │   │
+                                                                                            │   └── • union all
+                                                                                            │       │ columns: (aggregated_ts, fingerprint_id, app_name, statistics)
+                                                                                            │       │ estimated row count: 1
+                                                                                            │       │
+                                                                                            │       ├── • filter
+                                                                                            │       │   │ columns: (aggregated_ts, fingerprint_id, app_name, statistics)
+                                                                                            │       │   │ estimated row count: 0
+                                                                                            │       │   │ filter: app_name NOT LIKE '$ internal%'
+                                                                                            │       │   │
+                                                                                            │       │   └── • scan
+                                                                                            │       │         columns: (aggregated_ts, fingerprint_id, app_name, statistics)
+                                                                                            │       │         estimated row count: 1 (<0.01% of the table; stats collected <hidden> ago)
+                                                                                            │       │         table: statement_statistics@primary
+                                                                                            │       │         spans: /2/2023-04-10T16:00:00Z-/2/2023-04-10T16:00:00.000000001Z
+                                                                                            │       │
+                                                                                            │       └── • filter
+                                                                                            │           │ columns: (aggregated_ts, fingerprint_id, app_name, statistics)
+                                                                                            │           │ estimated row count: 0
+                                                                                            │           │ filter: app_name NOT LIKE '$ internal%'
+                                                                                            │           │
+                                                                                            │           └── • scan
+                                                                                            │                 columns: (aggregated_ts, fingerprint_id, app_name, statistics)
+                                                                                            │                 estimated row count: 1 (<0.01% of the table; stats collected <hidden> ago)
+                                                                                            │                 table: statement_statistics@primary
+                                                                                            │                 spans: /3/2023-04-10T16:00:00Z-/3/2023-04-10T16:00:00.000000001Z
+                                                                                            │
+                                                                                            └── • union all
+                                                                                                │ columns: (aggregated_ts, fingerprint_id, app_name, statistics)
+                                                                                                │ estimated row count: 1
+                                                                                                │
+                                                                                                ├── • union all
+                                                                                                │   │ columns: (aggregated_ts, fingerprint_id, app_name, statistics)
+                                                                                                │   │ estimated row count: 1
+                                                                                                │   │
+                                                                                                │   ├── • filter
+                                                                                                │   │   │ columns: (aggregated_ts, fingerprint_id, app_name, statistics)
+                                                                                                │   │   │ estimated row count: 0
+                                                                                                │   │   │ filter: app_name NOT LIKE '$ internal%'
+                                                                                                │   │   │
+                                                                                                │   │   └── • scan
+                                                                                                │   │         columns: (aggregated_ts, fingerprint_id, app_name, statistics)
+                                                                                                │   │         estimated row count: 1 (<0.01% of the table; stats collected <hidden> ago)
+                                                                                                │   │         table: statement_statistics@primary
+                                                                                                │   │         spans: /4/2023-04-10T16:00:00Z-/4/2023-04-10T16:00:00.000000001Z
+                                                                                                │   │
+                                                                                                │   └── • filter
+                                                                                                │       │ columns: (aggregated_ts, fingerprint_id, app_name, statistics)
+                                                                                                │       │ estimated row count: 0
+                                                                                                │       │ filter: app_name NOT LIKE '$ internal%'
+                                                                                                │       │
+                                                                                                │       └── • scan
+                                                                                                │             columns: (aggregated_ts, fingerprint_id, app_name, statistics)
+                                                                                                │             estimated row count: 1 (<0.01% of the table; stats collected <hidden> ago)
+                                                                                                │             table: statement_statistics@primary
+                                                                                                │             spans: /5/2023-04-10T16:00:00Z-/5/2023-04-10T16:00:00.000000001Z
+                                                                                                │
+                                                                                                └── • union all
+                                                                                                    │ columns: (aggregated_ts, fingerprint_id, app_name, statistics)
+                                                                                                    │ estimated row count: 1
+                                                                                                    │
+                                                                                                    ├── • filter
+                                                                                                    │   │ columns: (aggregated_ts, fingerprint_id, app_name, statistics)
+                                                                                                    │   │ estimated row count: 0
+                                                                                                    │   │ filter: app_name NOT LIKE '$ internal%'
+                                                                                                    │   │
+                                                                                                    │   └── • scan
+                                                                                                    │         columns: (aggregated_ts, fingerprint_id, app_name, statistics)
+                                                                                                    │         estimated row count: 1 (<0.01% of the table; stats collected <hidden> ago)
+                                                                                                    │         table: statement_statistics@primary
+                                                                                                    │         spans: /6/2023-04-10T16:00:00Z-/6/2023-04-10T16:00:00.000000001Z
+                                                                                                    │
+                                                                                                    └── • filter
+                                                                                                        │ columns: (aggregated_ts, fingerprint_id, app_name, statistics)
+                                                                                                        │ estimated row count: 0
+                                                                                                        │ filter: app_name NOT LIKE '$ internal%'
+                                                                                                        │
+                                                                                                        └── • scan
+                                                                                                              columns: (aggregated_ts, fingerprint_id, app_name, statistics)
+                                                                                                              estimated row count: 1 (<0.01% of the table; stats collected <hidden> ago)
+                                                                                                              table: statement_statistics@primary
+                                                                                                              spans: /7/2023-04-10T16:00:00Z-/7/2023-04-10T16:00:00.000000001Z
+
+# Upsert top 500 transactions
+query T retry
+EXPLAIN (VERBOSE)
+UPSERT INTO system.public.transaction_activity
+(aggregated_ts, fingerprint_id, app_name, agg_interval, metadata,
+ statistics, query, execution_count, execution_total_seconds,
+ execution_total_cluster_seconds, contention_time_avg_seconds,
+ cpu_sql_avg_nanos, service_latency_avg_seconds, service_latency_p99_seconds)
+    (SELECT aggregated_ts,
+            fingerprint_id,
+            app_name,
+            agg_interval,
+            metadata,
+            merge_stats,
+            ''  AS query,
+              (merge_stats -> 'statistics' ->> 'cnt')::int,
+            ((merge_stats -> 'statistics' ->> 'cnt')::float) *
+            ((merge_stats -> 'statistics' -> 'svcLat' ->> 'mean')::float),
+            142 AS execution_total_cluster_seconds,
+            COALESCE ((merge_stats -> 'execution_statistics' -> 'contentionTime' ->> 'mean')::float, 0),
+            COALESCE ((merge_stats -> 'execution_statistics' -> 'cpuSQLNanos' ->> 'mean')::float, 0),
+            (merge_stats -> 'statistics' -> 'svcLat' ->> 'mean')::float,
+            0
+     FROM (SELECT ts.aggregated_ts                                       AS aggregated_ts,
+                  ts.app_name,
+                  ts.fingerprint_id,
+                  max(ts.agg_interval) as agg_interval,
+                  max(ts.metadata) AS metadata,
+                  crdb_internal.merge_transaction_stats(array_agg(statistics)) AS merge_stats
+           FROM system.public.transaction_statistics ts
+                    inner join (SELECT fingerprint_id, app_name
+                                FROM (SELECT fingerprint_id, app_name,
+                                           contentionTime, cpuTime,
+                                            row_number() OVER (ORDER BY (merge_stats -> 'statistics' ->> 'cnt')::int desc) AS ePos,
+                                            row_number() OVER (ORDER BY (merge_stats -> 'statistics' -> 'svcLat' ->> 'mean')::float desc) AS sPos,
+                                            row_number() OVER (ORDER BY ((merge_stats -> 'statistics' ->> 'cnt')::float) *
+                                                ((merge_stats -> 'statistics' -> 'svcLat' ->> 'mean')::float) desc) AS tPos,
+                                            row_number() OVER (ORDER BY COALESCE((merge_stats -> 'execution_statistics' -> 'contentionTime' ->> 'mean')::float, 0) desc) AS cPos,
+                                            row_number() OVER (ORDER BY COALESCE((merge_stats -> 'execution_statistics' -> 'cpuSQLNanos' ->> 'mean')::float, 0) desc) AS uPos
+                                      FROM (SELECT fingerprint_id, app_name, merge_stats,
+                                            (merge_stats -> 'execution_statistics' -> 'contentionTime' ->> 'mean')::float as contentionTime,
+                                            (merge_stats -> 'execution_statistics' -> 'cpuSQLNanos' ->> 'mean')::float as cpuTime
+                                            FROM (SELECT fingerprint_id, app_name,
+                                                   crdb_internal.merge_transaction_stats(array_agg(statistics)) AS merge_stats
+                                            FROM system.public.transaction_statistics
+                                            WHERE aggregated_ts = '2023-09-27 14:00:00.000000 +00:00' and
+                                                  app_name not like '$ internal%'
+                                            GROUP BY app_name,
+                                                     fingerprint_id  )))
+                                WHERE ePos < 500
+                                   or sPos < 500
+                                   or tPos < 500
+                                   or (cPos < 500 )
+                         or (uPos < 500 )) agg
+                               on agg.app_name = ts.app_name and agg.fingerprint_id = ts.fingerprint_id
+           WHERE aggregated_ts = '2023-09-27 14:00:00.000000 +00:00'
+           GROUP BY ts.aggregated_ts,
+                    ts.app_name,
+                    ts.fingerprint_id));
+----
+distribution: local
+            vectorized: true
+            ·
+            • upsert
+            │ columns: ()
+            │ estimated row count: 0 (missing stats)
+            │ into: transaction_activity(aggregated_ts, fingerprint_id, app_name, agg_interval, metadata, statistics, query, execution_count, execution_total_seconds, execution_total_cluster_seconds, contention_time_avg_seconds, cpu_sql_avg_nanos, service_latency_avg_seconds, service_latency_p99_seconds)
+            │ auto commit
+            │ arbiter indexes: primary
+            │
+            └── • project
+                │ columns: (aggregated_ts, fingerprint_id, app_name, max, max, merge_stats, query, int8, "?column?", execution_total_cluster_seconds, "coalesce", "coalesce", float8, "?column?", aggregated_ts, fingerprint_id, app_name, agg_interval, metadata, statistics, query, execution_count, execution_total_seconds, execution_total_cluster_seconds, contention_time_avg_seconds, cpu_sql_avg_nanos, service_latency_avg_seconds, service_latency_p99_seconds, max, max, merge_stats, query, int8, "?column?", execution_total_cluster_seconds, "coalesce", "coalesce", float8, "?column?", aggregated_ts)
+                │
+                └── • lookup join (left outer)
+                    │ columns: (query, int8, "?column?", execution_total_cluster_seconds, "coalesce", "coalesce", float8, "?column?", aggregated_ts, fingerprint_id, app_name, max, max, merge_stats, aggregated_ts, fingerprint_id, app_name, agg_interval, metadata, statistics, query, execution_count, execution_total_seconds, execution_total_cluster_seconds, contention_time_avg_seconds, cpu_sql_avg_nanos, service_latency_avg_seconds, service_latency_p99_seconds)
+                    │ estimated row count: 1
+                    │ table: transaction_activity@primary
+                    │ equality: (aggregated_ts, fingerprint_id, app_name) = (aggregated_ts,fingerprint_id,app_name)
+                    │ equality cols are key
+                    │
+                    └── • render
+                        │ columns: (query, int8, "?column?", execution_total_cluster_seconds, "coalesce", "coalesce", float8, "?column?", aggregated_ts, fingerprint_id, app_name, max, max, merge_stats)
+                        │ render query: ''
+                        │ render int8: ((merge_stats->'statistics')->>'cnt')::INT8
+                        │ render ?column?: ((merge_stats->'statistics')->>'cnt')::FLOAT8 * (((merge_stats->'statistics')->'svcLat')->>'mean')::FLOAT8
+                        │ render execution_total_cluster_seconds: 142.0
+                        │ render coalesce: COALESCE((((merge_stats->'execution_statistics')->'contentionTime')->>'mean')::FLOAT8, 0.0)
+                        │ render coalesce: COALESCE((((merge_stats->'execution_statistics')->'cpuSQLNanos')->>'mean')::FLOAT8, 0.0)
+                        │ render float8: (((merge_stats->'statistics')->'svcLat')->>'mean')::FLOAT8
+                        │ render ?column?: 0.0
+                        │ render aggregated_ts: aggregated_ts
+                        │ render fingerprint_id: fingerprint_id
+                        │ render app_name: app_name
+                        │ render max: max
+                        │ render max: max
+                        │ render merge_stats: merge_stats
+                        │
+                        └── • render
+                            │ columns: (merge_stats, aggregated_ts, fingerprint_id, app_name, max, max)
+                            │ render merge_stats: crdb_internal.merge_transaction_stats(array_agg)
+                            │ render aggregated_ts: any_not_null
+                            │ render fingerprint_id: fingerprint_id
+                            │ render app_name: app_name
+                            │ render max: max
+                            │ render max: max
                             │
-                            └── • scan
-                                  columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, agg_interval, metadata, statistics, plan, index_recommendations)
-                                  estimated row count: 10 (missing stats)
-                                  table: statement_statistics@primary
-                                  spans: /0/2023-04-10T16:00:00Z-/0/2023-04-10T16:00:00.000000001Z /1/2023-04-10T16:00:00Z-/1/2023-04-10T16:00:00.000000001Z /2/2023-04-10T16:00:00Z-/2/2023-04-10T16:00:00.000000001Z /3/2023-04-10T16:00:00Z-/3/2023-04-10T16:00:00.000000001Z /4/2023-04-10T16:00:00Z-/4/2023-04-10T16:00:00.000000001Z /5/2023-04-10T16:00:00Z-/5/2023-04-10T16:00:00.000000001Z /6/2023-04-10T16:00:00Z-/6/2023-04-10T16:00:00.000000001Z /7/2023-04-10T16:00:00Z-/7/2023-04-10T16:00:00.000000001Z
-
-
+                            └── • group (hash)
+                                │ columns: (fingerprint_id, app_name, max, max, array_agg, any_not_null)
+                                │ estimated row count: 1
+                                │ aggregate 0: max(agg_interval)
+                                │ aggregate 1: max(metadata)
+                                │ aggregate 2: array_agg(statistics)
+                                │ aggregate 3: any_not_null(aggregated_ts)
+                                │ group by: fingerprint_id, app_name
+                                │
+                                └── • project
+                                    │ columns: (aggregated_ts, fingerprint_id, app_name, agg_interval, metadata, statistics)
+                                    │
+                                    └── • hash join (inner)
+                                        │ columns: (aggregated_ts, fingerprint_id, app_name, agg_interval, metadata, statistics, fingerprint_id, app_name, row_number, row_number, row_number, row_number, row_number_1_orderby_1_1, row_number_2_orderby_1_1, row_number_3_orderby_1_1, row_number_4_orderby_1_1, row_number_5_orderby_1_1, row_number)
+                                        │ estimated row count: 1
+                                        │ equality: (app_name, fingerprint_id) = (app_name, fingerprint_id)
+                                        │ right cols are key
+                                        │
+                                        ├── • scan
+                                        │     columns: (aggregated_ts, fingerprint_id, app_name, agg_interval, metadata, statistics)
+                                        │     estimated row count: 83,333 (8.3% of the table; stats collected <hidden> ago)
+                                        │     table: transaction_statistics@primary
+                                        │     spans: /0/2023-09-27T14:00:00Z-/0/2023-09-27T14:00:00.000000001Z /1/2023-09-27T14:00:00Z-/1/2023-09-27T14:00:00.000000001Z /2/2023-09-27T14:00:00Z-/2/2023-09-27T14:00:00.000000001Z /3/2023-09-27T14:00:00Z-/3/2023-09-27T14:00:00.000000001Z /4/2023-09-27T14:00:00Z-/4/2023-09-27T14:00:00.000000001Z /5/2023-09-27T14:00:00Z-/5/2023-09-27T14:00:00.000000001Z /6/2023-09-27T14:00:00Z-/6/2023-09-27T14:00:00.000000001Z /7/2023-09-27T14:00:00Z-/7/2023-09-27T14:00:00.000000001Z
+                                        │
+                                        └── • filter
+                                            │ columns: (fingerprint_id, app_name, row_number, row_number, row_number, row_number, row_number_1_orderby_1_1, row_number_2_orderby_1_1, row_number_3_orderby_1_1, row_number_4_orderby_1_1, row_number_5_orderby_1_1, row_number)
+                                            │ estimated row count: 24,120
+                                            │ filter: ((((row_number < 500) OR (row_number < 500)) OR (row_number < 500)) OR (row_number < 500)) OR (row_number < 500)
+                                            │
+                                            └── • window
+                                                │ columns: (fingerprint_id, app_name, row_number, row_number, row_number, row_number, row_number_1_orderby_1_1, row_number_2_orderby_1_1, row_number_3_orderby_1_1, row_number_4_orderby_1_1, row_number_5_orderby_1_1, row_number)
+                                                │ estimated row count: 27,778
+                                                │ window 0: row_number() OVER (ORDER BY row_number_5_orderby_1_1 DESC RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
+                                                │
+                                                └── • window
+                                                    │ columns: (fingerprint_id, app_name, row_number, row_number, row_number, row_number, row_number_1_orderby_1_1, row_number_2_orderby_1_1, row_number_3_orderby_1_1, row_number_4_orderby_1_1, row_number_5_orderby_1_1)
+                                                    │ estimated row count: 27,778
+                                                    │ window 0: row_number() OVER (ORDER BY row_number_4_orderby_1_1 DESC RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
+                                                    │
+                                                    └── • window
+                                                        │ columns: (fingerprint_id, app_name, row_number, row_number, row_number, row_number_1_orderby_1_1, row_number_2_orderby_1_1, row_number_3_orderby_1_1, row_number_4_orderby_1_1, row_number_5_orderby_1_1)
+                                                        │ estimated row count: 27,778
+                                                        │ window 0: row_number() OVER (ORDER BY row_number_3_orderby_1_1 DESC RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
+                                                        │
+                                                        └── • window
+                                                            │ columns: (fingerprint_id, app_name, row_number, row_number, row_number_1_orderby_1_1, row_number_2_orderby_1_1, row_number_3_orderby_1_1, row_number_4_orderby_1_1, row_number_5_orderby_1_1)
+                                                            │ estimated row count: 27,778
+                                                            │ window 0: row_number() OVER (ORDER BY row_number_2_orderby_1_1 DESC RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
+                                                            │
+                                                            └── • window
+                                                                │ columns: (fingerprint_id, app_name, row_number, row_number_1_orderby_1_1, row_number_2_orderby_1_1, row_number_3_orderby_1_1, row_number_4_orderby_1_1, row_number_5_orderby_1_1)
+                                                                │ estimated row count: 27,778
+                                                                │ window 0: row_number() OVER (ORDER BY row_number_1_orderby_1_1 DESC RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
+                                                                │
+                                                                └── • render
+                                                                    │ columns: (fingerprint_id, app_name, row_number_1_orderby_1_1, row_number_2_orderby_1_1, row_number_3_orderby_1_1, row_number_4_orderby_1_1, row_number_5_orderby_1_1)
+                                                                    │ render row_number_1_orderby_1_1: ((merge_stats->'statistics')->>'cnt')::INT8
+                                                                    │ render row_number_2_orderby_1_1: (((merge_stats->'statistics')->'svcLat')->>'mean')::FLOAT8
+                                                                    │ render row_number_3_orderby_1_1: ((merge_stats->'statistics')->>'cnt')::FLOAT8 * (((merge_stats->'statistics')->'svcLat')->>'mean')::FLOAT8
+                                                                    │ render row_number_4_orderby_1_1: COALESCE((((merge_stats->'execution_statistics')->'contentionTime')->>'mean')::FLOAT8, 0.0)
+                                                                    │ render row_number_5_orderby_1_1: COALESCE((((merge_stats->'execution_statistics')->'cpuSQLNanos')->>'mean')::FLOAT8, 0.0)
+                                                                    │ render fingerprint_id: fingerprint_id
+                                                                    │ render app_name: app_name
+                                                                    │
+                                                                    └── • render
+                                                                        │ columns: (merge_stats, fingerprint_id, app_name)
+                                                                        │ render merge_stats: crdb_internal.merge_transaction_stats(array_agg)
+                                                                        │ render fingerprint_id: fingerprint_id
+                                                                        │ render app_name: app_name
+                                                                        │
+                                                                        └── • group (hash)
+                                                                            │ columns: (fingerprint_id, app_name, array_agg)
+                                                                            │ estimated row count: 27,778
+                                                                            │ aggregate 0: array_agg(statistics)
+                                                                            │ group by: fingerprint_id, app_name
+                                                                            │
+                                                                            └── • project
+                                                                                │ columns: (fingerprint_id, app_name, statistics)
+                                                                                │
+                                                                                └── • filter
+                                                                                    │ columns: (aggregated_ts, fingerprint_id, app_name, statistics)
+                                                                                    │ estimated row count: 27,778
+                                                                                    │ filter: app_name NOT LIKE '$ internal%'
+                                                                                    │
+                                                                                    └── • scan
+                                                                                          columns: (aggregated_ts, fingerprint_id, app_name, statistics)
+                                                                                          estimated row count: 83,333 (8.3% of the table; stats collected <hidden> ago)
+                                                                                          table: transaction_statistics@primary
+                                                                                          spans: /0/2023-09-27T14:00:00Z-/0/2023-09-27T14:00:00.000000001Z /1/2023-09-27T14:00:00Z-/1/2023-09-27T14:00:00.000000001Z /2/2023-09-27T14:00:00Z-/2/2023-09-27T14:00:00.000000001Z /3/2023-09-27T14:00:00Z-/3/2023-09-27T14:00:00.000000001Z /4/2023-09-27T14:00:00Z-/4/2023-09-27T14:00:00.000000001Z /5/2023-09-27T14:00:00Z-/5/2023-09-27T14:00:00.000000001Z /6/2023-09-27T14:00:00Z-/6/2023-09-27T14:00:00.000000001Z /7/2023-09-27T14:00:00Z-/7/2023-09-27T14:00:00.000000001Z

--- a/pkg/sql/sql_activity_update_job.go
+++ b/pkg/sql/sql_activity_update_job.go
@@ -242,33 +242,32 @@ func (u *sqlActivityUpdater) transferAllStats(
  statistics, query, execution_count, execution_total_seconds,
  execution_total_cluster_seconds, contention_time_avg_seconds, 
  cpu_sql_avg_nanos, service_latency_avg_seconds, service_latency_p99_seconds)
-    (SELECT aggregated_ts,
+    (SELECT max_aggregated_ts,
             fingerprint_id,
             app_name,
-            agg_interval,
+            max_agg_interval,
             metadata,
             statistics,
             '' AS query,
-            (statistics->'execution_statistics'->>'cnt')::int,
-            ((statistics->'execution_statistics'->>'cnt')::float)*((statistics->'statistics'->'svcLat'->>'mean')::float),
+            (statistics->'statistics'->>'cnt')::int,
+            ((statistics->'statistics'->>'cnt')::float)*((statistics->'statistics'->'svcLat'->>'mean')::float),
             $1 AS execution_total_cluster_seconds,
             COALESCE((statistics->'execution_statistics'->'contentionTime'->>'mean')::float,0),
-            COALESCE((statistics->'execution_statistics'->'cpu_sql_nanos'->>'mean')::float,0),
+            COALESCE((statistics->'execution_statistics'->'cpuSQLNanos'->>'mean')::float,0),
             (statistics->'statistics'->'svcLat'->>'mean')::float,
-            COALESCE((statistics->'statistics'->'latencyInfo'->>'p99')::float, 0)
+            0 as service_latency_p99_seconds
      FROM (SELECT
-                  max(aggregated_ts) AS aggregated_ts,
+                  max(aggregated_ts) AS max_aggregated_ts,
                   app_name,
                   fingerprint_id,
-                  agg_interval,
+                  max(agg_interval) as max_agg_interval,
                   max(metadata) as metadata,
-                  crdb_internal.merge_transaction_stats(array_agg(statistics)) AS statistics
+                  merge_transaction_stats(statistics) AS statistics
            FROM system.public.transaction_statistics
            WHERE aggregated_ts = $2
              and app_name not like '$ internal%'
            GROUP BY app_name,
-                    fingerprint_id,
-                    agg_interval));
+                    fingerprint_id));
 `,
 		totalEstimatedTxnClusterExecSeconds,
 		aggTs,
@@ -293,42 +292,36 @@ INTO system.public.statement_activity (aggregated_ts, fingerprint_id, transactio
                                        service_latency_avg_seconds, service_latency_p99_seconds)
     (SELECT aggregated_ts,
             fingerprint_id,
-            transaction_fingerprint_id,
+            '0x0000000000000000'::bytes,
             plan_hash,
             app_name,
-            agg_interval,
-            metadata,
-            statistics,
-            plan,
-            index_recommendations,
-            (statistics -> 'execution_statistics' ->> 'cnt')::int,
-            ((statistics -> 'execution_statistics' ->> 'cnt')::float) *
-            ((statistics -> 'statistics' -> 'svcLat' ->> 'mean')::float),
+            max_agg_interval,
+            merged_metadata,
+            merged_stats,
+            max_plan,
+             (select COALESCE(array_agg(o.rec::string), (array[]::string[])) FROM jsonb_array_elements_text(merged_stats -> 'index_recommendations') o(rec)) as idx_rec,
+            (merged_stats -> 'statistics' ->> 'cnt')::int,
+            ((merged_stats -> 'statistics' ->> 'cnt')::float) *
+            ((merged_stats -> 'statistics' -> 'svcLat' ->> 'mean')::float),
             $1 AS execution_total_cluster_seconds,
-            COALESCE((statistics -> 'execution_statistics' -> 'contentionTime' ->> 'mean')::float, 0),
-            COALESCE((statistics -> 'execution_statistics' -> 'cpu_sql_nanos' ->> 'mean')::float, 0),
-            (statistics -> 'statistics' -> 'svcLat' ->> 'mean')::float,
-            COALESCE((statistics -> 'statistics' -> 'latencyInfo' ->> 'p99')::float, 0)
+            COALESCE((merged_stats -> 'execution_statistics' -> 'contentionTime' ->> 'mean')::float, 0),
+            COALESCE((merged_stats -> 'execution_statistics' -> 'cpuSQLNanos' ->> 'mean')::float, 0),
+            (merged_stats -> 'statistics' -> 'svcLat' ->> 'mean')::float,
+            COALESCE((merged_stats -> 'statistics' -> 'latencyInfo' ->> 'p99')::float, 0)
      FROM (SELECT max(aggregated_ts)                                           AS aggregated_ts,
                   fingerprint_id,
-                  transaction_fingerprint_id,
                   plan_hash,
                   app_name,
-                  agg_interval,
-                  crdb_internal.merge_stats_metadata(array_agg(metadata))    AS metadata,
-                  crdb_internal.merge_statement_stats(array_agg(statistics)) AS statistics,
-                  plan,
-                  index_recommendations
+                  max(agg_interval) as max_agg_interval,
+                  merge_stats_metadata(metadata)    AS merged_metadata,
+                  merge_statement_stats(statistics) AS merged_stats,
+                  max(plan) AS max_plan
            FROM system.public.statement_statistics
            WHERE aggregated_ts = $2
              and app_name not like '$ internal%'
            GROUP BY app_name,
                     fingerprint_id,
-                    transaction_fingerprint_id,
-                    plan_hash,
-                    agg_interval,
-                    plan,
-                    index_recommendations));
+                    plan_hash));
 `,
 		totalEstimatedStmtClusterExecSeconds,
 		aggTs,
@@ -371,8 +364,8 @@ func (u *sqlActivityUpdater) transferTopStats(
 
 		// Select the top 500 (controlled by sql.stats.activity.top.max) for
 		// each of execution_count, total execution time, service_latency,cpu_sql_nanos,
-		// contention_time, p99_latency and insert into transaction_activity table.
-		// Up to 3000 rows (sql.stats.activity.top.max * 6) may be added to
+		// contention_time and insert into transaction_activity table.
+		// Up to 3000 rows (sql.stats.activity.top.max * 5) may be added to
 		// transaction_activity.
 		// Any change should update cockroach/pkg/sql/opt/exec/execbuilder/testdata/observability
 		_, err = txn.ExecEx(ctx,
@@ -380,8 +373,7 @@ func (u *sqlActivityUpdater) transferTopStats(
 			txn.KV(), /* txn */
 			sessiondata.NodeUserSessionDataOverride,
 			`
-UPSERT
-INTO system.public.transaction_activity
+UPSERT INTO system.public.transaction_activity
 (aggregated_ts, fingerprint_id, app_name, agg_interval, metadata,
  statistics, query, execution_count, execution_total_seconds,
  execution_total_cluster_seconds, contention_time_avg_seconds,
@@ -391,60 +383,52 @@ INTO system.public.transaction_activity
             app_name,
             agg_interval,
             metadata,
-            statistics,
+            merge_stats,
             ''  AS query,
-            (statistics -> 'execution_statistics' ->> 'cnt')::int,
-            ((statistics -> 'execution_statistics' ->> 'cnt')::float) *
-            ((statistics -> 'statistics' -> 'svcLat' ->> 'mean')::float),
+            	(merge_stats -> 'statistics' ->> 'cnt')::int,
+            ((merge_stats -> 'statistics' ->> 'cnt')::float) *
+            ((merge_stats -> 'statistics' -> 'svcLat' ->> 'mean')::float),
             $1 AS execution_total_cluster_seconds,
-            COALESCE((statistics -> 'execution_statistics' -> 'contentionTime' ->> 'mean')::float, 0),
-            COALESCE((statistics -> 'execution_statistics' -> 'cpu_sql_nanos' ->> 'mean')::float, 0),
-            (statistics -> 'statistics' -> 'svcLat' ->> 'mean')::float,
-            COALESCE((statistics -> 'statistics' -> 'latencyInfo' ->> 'p99')::float, 0)
-     FROM (SELECT max(ts.aggregated_ts)                                        AS aggregated_ts,
+            COALESCE ((merge_stats -> 'execution_statistics' -> 'contentionTime' ->> 'mean')::float, 0),
+            COALESCE ((merge_stats -> 'execution_statistics' -> 'cpuSQLNanos' ->> 'mean')::float, 0),
+            (merge_stats -> 'statistics' -> 'svcLat' ->> 'mean')::float,
+            0 as service_latency_p99_seconds
+     FROM (SELECT ts.aggregated_ts                                       AS aggregated_ts,
                   ts.app_name,
                   ts.fingerprint_id,
-                  ts.agg_interval,
+                  max(ts.agg_interval) as agg_interval,
                   max(ts.metadata) AS metadata,
-                  crdb_internal.merge_transaction_stats(array_agg(statistics)) AS statistics
+                  crdb_internal.merge_transaction_stats(array_agg(statistics)) AS merge_stats
            FROM system.public.transaction_statistics ts
-                    inner join (SELECT fingerprint_id, app_name, agg_interval
-                                FROM (SELECT fingerprint_id, app_name, agg_interval,
-                                             row_number()
-                                             OVER (ORDER BY (statistics -> 'execution_statistics' ->> 'cnt')::int desc)        AS ePos,
-                                             row_number()
-                                             OVER (ORDER BY (statistics -> 'statistics' -> 'svcLat' ->> 'mean')::float desc)   AS sPos,
-                                             row_number()
-                                             OVER (ORDER BY ((statistics -> 'execution_statistics' ->> 'cnt')::float) *
-                                                            ((statistics -> 'statistics' -> 'svcLat' ->> 'mean')::float) desc) AS tPos,
-                                             row_number() OVER (ORDER BY COALESCE(
-                                                     (statistics -> 'execution_statistics' -> 'contentionTime' ->> 'mean')::float,
-                                                     0) desc)                                                                  AS cPos,
-                                             row_number() OVER (ORDER BY COALESCE(
-                                                     (statistics -> 'execution_statistics' -> 'cpu_sql_nanos' ->> 'mean')::float,
-                                                     0) desc)                                                                  AS uPos,
-                                             row_number() OVER (ORDER BY COALESCE(
-                                                     (statistics -> 'statistics' -> 'latencyInfo' ->> 'p99')::float,
-                                                     0) desc)                                                                  AS lPos
-                                      FROM (SELECT fingerprint_id, app_name, agg_interval,
-                                                   crdb_internal.merge_transaction_stats(array_agg(statistics)) AS statistics
+                    inner join (SELECT fingerprint_id, app_name
+                                FROM (SELECT fingerprint_id, app_name,
+                                           contentionTime, cpuTime,
+                                            row_number() OVER (ORDER BY (merge_stats -> 'statistics' ->> 'cnt')::int desc) AS ePos,
+                                            row_number() OVER (ORDER BY (merge_stats -> 'statistics' -> 'svcLat' ->> 'mean')::float desc) AS sPos,
+                                            row_number() OVER (ORDER BY ((merge_stats -> 'statistics' ->> 'cnt')::float) *
+                                                ((merge_stats -> 'statistics' -> 'svcLat' ->> 'mean')::float) desc) AS tPos,
+                                            row_number() OVER (ORDER BY COALESCE((merge_stats -> 'execution_statistics' -> 'contentionTime' ->> 'mean')::float, 0) desc) AS cPos,
+                                            row_number() OVER (ORDER BY COALESCE((merge_stats -> 'execution_statistics' -> 'cpuSQLNanos' ->> 'mean')::float, 0) desc) AS uPos
+                                      FROM (SELECT fingerprint_id, app_name, merge_stats,
+                                            (merge_stats -> 'execution_statistics' -> 'contentionTime' ->> 'mean')::float as contentionTime,
+                                            (merge_stats -> 'execution_statistics' -> 'cpuSQLNanos' ->> 'mean')::float as cpuTime
+                                            FROM (SELECT fingerprint_id, app_name,
+                                                   crdb_internal.merge_transaction_stats(array_agg(statistics)) AS merge_stats
                                             FROM system.public.transaction_statistics
                                             WHERE aggregated_ts = $2 and
                                                   app_name not like '$ internal%'
                                             GROUP BY app_name,
-                                                     fingerprint_id,
-																										agg_interval))
+                                                     fingerprint_id	)))
                                 WHERE ePos < $3
                                    or sPos < $3
                                    or tPos < $3
-                                   or cPos < $3
-                                   or uPos < $3
-                                   or lPos < $3) agg
-                               on agg.app_name = ts.app_name and agg.fingerprint_id = ts.fingerprint_id and
-                                  agg.agg_interval = ts.agg_interval
-           GROUP BY ts.app_name,
-                    ts.fingerprint_id,
-                    ts.agg_interval));
+                                   or (cPos < $3 AND contentionTime > 0)
+                                   or (uPos < $3 AND cpuTime > 0)) agg
+                               on agg.app_name = ts.app_name and agg.fingerprint_id = ts.fingerprint_id
+           WHERE aggregated_ts = $2
+           GROUP BY ts.aggregated_ts,
+                    ts.app_name,
+                    ts.fingerprint_id));;
 `,
 			totalEstimatedTxnClusterExecSeconds,
 			aggTs,
@@ -487,83 +471,74 @@ INTO system.public.transaction_activity
 			txn.KV(), /* txn */
 			sessiondata.NodeUserSessionDataOverride,
 			`
-UPSERT
-INTO system.public.statement_activity
+WITH agg_stmt_stats AS (SELECT aggregated_ts,
+                               fingerprint_id,
+                               app_name,
+                               merge_statement_stats(statistics) AS merged_stats
+                        FROM system.public.statement_statistics
+                        WHERE aggregated_ts = $2
+                          and app_name not like '$ internal%'
+                        GROUP BY aggregated_ts,
+                                 app_name,
+                                 fingerprint_id),
+     limit_stmt_stats AS (SELECT aggregated_ts,
+                                 fingerprint_id,
+                                 app_name
+                          FROM (SELECT aggregated_ts,
+                                       fingerprint_id,
+                                       app_name,
+                                       merged_stats,
+                                       row_number() OVER (ORDER BY (merged_stats -> 'statistics' ->> 'cnt')::int desc)                AS ePos,
+                                       row_number() OVER (ORDER BY (merged_stats -> 'statistics' -> 'svcLat' ->> 'mean')::float desc) AS sPos,
+                                       row_number() OVER (ORDER BY
+                                               ((merged_stats -> 'statistics' ->> 'cnt')::float) *
+                                               ((merged_stats -> 'statistics' -> 'svcLat' ->> 'mean')::float) desc)      AS tPos,
+                                       row_number() OVER (ORDER BY COALESCE((merged_stats -> 'execution_statistics' -> 'contentionTime' ->> 'mean')::float, 0) desc) AS cPos,
+                                       row_number() OVER (ORDER BY COALESCE((merged_stats -> 'execution_statistics' -> 'cpuSQLNanos' ->> 'mean')::float, 0) desc) AS uPos,
+                                       row_number() OVER (ORDER BY COALESCE((merged_stats -> 'statistics' -> 'latencyInfo' ->> 'p99')::float, 0) desc) AS lPos
+                                FROM agg_stmt_stats)
+                          WHERE ePos < $3
+                             or sPos < $3
+                             or tPos < $3
+														 or (cPos < $3 AND ((merged_stats -> 'execution_statistics' -> 'contentionTime' ->> 'mean')::float > 0))
+														 or (uPos < $3 AND  ((merged_stats -> 'execution_statistics' -> 'cpuSQLNanos' ->> 'mean')::float > 0))
+														 or (lPos < $3 AND ((merged_stats -> 'statistics' -> 'latencyInfo' ->> 'p99')::float > 0)))
+UPSERT INTO system.public.statement_activity
 (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name,
  agg_interval, metadata, statistics, plan, index_recommendations, execution_count,
  execution_total_seconds, execution_total_cluster_seconds,
  contention_time_avg_seconds,
  cpu_sql_avg_nanos,
- service_latency_avg_seconds, service_latency_p99_seconds)
-    (SELECT aggregated_ts,
-            fingerprint_id,
-            transaction_fingerprint_id,
-            plan_hash,
-            app_name,
-            agg_interval,
-            metadata,
-            statistics,
-            plan,
-            index_recommendations,
-            (statistics -> 'execution_statistics' ->> 'cnt')::int,
-            ((statistics -> 'execution_statistics' ->> 'cnt')::float) *
-            ((statistics -> 'statistics' -> 'svcLat' ->> 'mean')::float),
-            $1 AS execution_total_cluster_seconds,
-            COALESCE((statistics -> 'execution_statistics' -> 'contentionTime' ->> 'mean')::float, 0),
-            COALESCE((statistics -> 'execution_statistics' -> 'cpu_sql_nanos' ->> 'mean')::float, 0),
-            (statistics -> 'statistics' -> 'svcLat' ->> 'mean')::float,
-            COALESCE((statistics -> 'statistics' -> 'latencyInfo' ->> 'p99')::float, 0)
-     FROM (SELECT max(ss.aggregated_ts)                                           AS aggregated_ts,
-                  ss.fingerprint_id,
-                  ss.transaction_fingerprint_id,
-                  ss.plan_hash,
-                  ss.app_name,
-                  ss.agg_interval,
-                  crdb_internal.merge_stats_metadata(array_agg(ss.metadata))    AS metadata,
-                  crdb_internal.merge_statement_stats(array_agg(ss.statistics)) AS statistics,
-                  ss.plan,
-                  ss.index_recommendations
-           FROM system.public.statement_statistics ss
-           inner join (SELECT fingerprint_id, app_name
-                                    FROM (SELECT fingerprint_id, app_name,
-                                                 row_number()
-                                                 OVER (ORDER BY (statistics -> 'execution_statistics' ->> 'cnt')::int desc)      AS ePos,
-                                                 row_number()
-                                                 OVER (ORDER BY (statistics -> 'statistics' -> 'svcLat' ->> 'mean')::float desc) AS sPos,
-                                                 row_number() OVER (ORDER BY
-                                                         ((statistics -> 'execution_statistics' ->> 'cnt')::float) *
-                                                         ((statistics -> 'statistics' -> 'svcLat' ->> 'mean')::float) desc)      AS tPos,
-                                                 row_number() OVER (ORDER BY COALESCE(
-                                                         (statistics -> 'execution_statistics' -> 'contentionTime' ->> 'mean')::float,
-                                                         0) desc)                                                                AS cPos,
-                                                 row_number() OVER (ORDER BY COALESCE(
-                                                         (statistics -> 'execution_statistics' -> 'cpu_sql_nanos' ->> 'mean')::float,
-                                                         0) desc)                                                                AS uPos,
-                                                 row_number() OVER (ORDER BY COALESCE(
-                                                         (statistics -> 'statistics' -> 'latencyInfo' ->> 'p99')::float,
-                                                         0) desc)                                                                AS lPos
-                                          FROM (SELECT fingerprint_id,
-                                                       app_name,
-                                                       crdb_internal.merge_statement_stats(array_agg(statistics)) AS statistics
-                                                FROM system.public.statement_statistics
-                                                WHERE aggregated_ts = $2 and
-                                                      app_name not like '$ internal%'
-                                                GROUP BY app_name,
-                                                         fingerprint_id))
-                                    WHERE ePos < $3
-                                       or sPos < $3
-                                       or tPos < $3
-                                       or cPos < $3
-                                       or uPos < $3
-                                       or lPos < $3) agg on agg.app_name = ss.app_name and agg.fingerprint_id = ss.fingerprint_id
-           WHERE aggregated_ts = $2
-           GROUP BY ss.app_name,
-                    ss.fingerprint_id,
-                    ss.transaction_fingerprint_id,
-                    ss.plan_hash,
-                    ss.agg_interval,
-                    ss.plan,
-                    ss.index_recommendations));
+ service_latency_avg_seconds, service_latency_p99_seconds)(
+SELECT aggregated_ts,
+       fingerprint_id,
+       '0x0000000000000000'::bytes,
+       plan_hash,
+       app_name,
+       max_agg_interval,
+       metadata,
+       merged_stats,
+       max_plan,
+			 (select COALESCE(array_agg(o.rec::string), (array[]::string[])) FROM jsonb_array_elements_text(merged_stats -> 'index_recommendations') o(rec)) as idx_rec,
+       (merged_stats -> 'statistics' ->> 'cnt')::int,
+       ((merged_stats -> 'statistics' ->> 'cnt')::float) *
+       ((merged_stats -> 'statistics' -> 'svcLat' ->> 'mean')::float),
+       $1 AS execution_total_cluster_seconds,
+       COALESCE((merged_stats -> 'execution_statistics' -> 'contentionTime' ->> 'mean')::float, 0),
+       COALESCE((merged_stats -> 'execution_statistics' -> 'cpuSQLNanos' ->> 'mean')::float, 0),
+       (merged_stats -> 'statistics' -> 'svcLat' ->> 'mean')::float,
+       COALESCE((merged_stats -> 'statistics' -> 'latencyInfo' ->> 'p99')::float, 0)
+FROM (SELECT ss.aggregated_ts AS aggregated_ts,
+             ss.fingerprint_id,
+             ss.plan_hash,
+             ss.app_name,
+             max(ss.agg_interval) AS max_agg_interval,
+             max(ss.plan) AS max_plan,
+						 merge_stats_metadata(ss.metadata) AS metadata,
+    				 merge_statement_stats(ss.statistics) AS merged_stats
+      FROM system.statement_statistics ss
+		  inner join limit_stmt_stats using (aggregated_ts, fingerprint_id, app_name)
+      group by aggregated_ts, fingerprint_id, plan_hash, app_name));
 `,
 			totalEstimatedStmtClusterExecSeconds,
 			aggTs,
@@ -573,89 +548,7 @@ INTO system.public.statement_activity
 		return err
 	})
 
-	if errTxn != nil {
-		return errTxn
-	}
-
-	// Ensure that if the transaction is in the transaction_activity table that
-	// all the stmts for that transaction are in the statement_activity table.
-	// This is necessary for the UI on the transaction details page to show
-	// the necessary information.
-	// The previous statement update only includes the top 500 by the top columns.
-	// This might not include all the statements that are in the transaction
-	// activity table. This query figure out if any statement fingerprint ids
-	// listed in the transaction activity table are missing from the
-	// statement_activity table and adds them if necessary.
-	// Any change should update cockroach/pkg/sql/opt/exec/execbuilder/testdata/observability
-	_, err := u.db.Executor().ExecEx(ctx,
-		"activity-flush-check-all-txn-stmts-captured",
-		nil, /* txn */
-		sessiondata.NodeUserSessionDataOverride,
-		`WITH missed_stmt_ids_from_txn_activity AS (SELECT ta.fingerprint_id, ta.app_name
-                                     FROM (SELECT ta_sub.aggregated_ts,
-                                                  decode(jsonb_array_elements_text(ta_sub.metadata -> 'stmtFingerprintIDs'), 'hex')::bytes AS fingerprint_id,
-                                                  ta_sub.fingerprint_id                                                     AS transaction_fingerprint_id,
-                                                  ta_sub.app_name
-                                           FROM system.transaction_activity ta_sub WHERE ta_sub.aggregated_ts = $2) ta
-                                        	 LEFT OUTER JOIN (select fingerprint_id,
-                                                                      app_name,
-                                                                      aggregated_ts
-                                                               FROM system.statement_activity WHERE aggregated_ts = $2) sa
-                                                              ON sa.fingerprint_id = ta.fingerprint_id AND
-                                                                 sa.app_name = ta.app_name AND
-                                                                 ta.aggregated_ts = sa.aggregated_ts
-                                     WHERE sa.fingerprint_id is null
-																		 GROUP BY ta.fingerprint_id, ta.app_name)
-UPSERT INTO system.public.statement_activity
-(aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name,
- agg_interval, metadata, statistics, plan, index_recommendations, execution_count,
- execution_total_seconds, execution_total_cluster_seconds,
- contention_time_avg_seconds,
- cpu_sql_avg_nanos,
- service_latency_avg_seconds, service_latency_p99_seconds)
-(SELECT aggregated_ts,
-    fingerprint_id,
-    transaction_fingerprint_id,
-    plan_hash,
-    app_name,
-    agg_interval,
-    metadata,
-    statistics,
-    plan,
-    index_recommendations,
-    (statistics -> 'execution_statistics' ->> 'cnt')::int,
-    ((statistics -> 'execution_statistics' ->> 'cnt')::float) *
-    ((statistics -> 'statistics' -> 'svcLat' ->> 'mean')::float),
-    $1 AS execution_total_cluster_seconds,
-    COALESCE ((statistics -> 'execution_statistics' -> 'contentionTime' ->> 'mean')::float, 0),
-    COALESCE ((statistics -> 'execution_statistics' -> 'cpu_sql_nanos' ->> 'mean')::float, 0),
-    (statistics -> 'statistics' -> 'svcLat' ->> 'mean')::float,
-    COALESCE ((statistics -> 'statistics' -> 'latencyInfo' ->> 'p99')::float, 0)
-FROM (SELECT max(ss.aggregated_ts) AS aggregated_ts,
-    ss.fingerprint_id,
-    ss.transaction_fingerprint_id,
-    ss.plan_hash,
-    ss.app_name,
-    ss.agg_interval,
-    crdb_internal.merge_stats_metadata(array_agg(ss.metadata)) AS metadata,
-    crdb_internal.merge_statement_stats(array_agg(ss.statistics)) AS statistics,
-    ss.plan,
-    ss.index_recommendations
-    FROM system.public.statement_statistics ss
-    INNER JOIN missed_stmt_ids_from_txn_activity ON missed_stmt_ids_from_txn_activity.app_name = ss.app_name AND missed_stmt_ids_from_txn_activity.fingerprint_id = ss.fingerprint_id
-    WHERE aggregated_ts = $2
-		GROUP BY ss.app_name,
-		 ss.fingerprint_id,
-		 ss.transaction_fingerprint_id,
-		 ss.plan_hash,
-		 ss.agg_interval,
-		 ss.plan,
-		 ss.index_recommendations));
-`,
-		totalEstimatedStmtClusterExecSeconds,
-		aggTs)
-
-	return err
+	return errTxn
 }
 
 // getAostRowCountAndTotalClusterExecSeconds is used to get the row counts of

--- a/pkg/sql/sql_activity_update_job_test.go
+++ b/pkg/sql/sql_activity_update_job_test.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -24,7 +25,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/appstatspb"
-	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/persistedsqlstats"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil"
@@ -67,6 +67,7 @@ func TestSqlActivityUpdateJob(t *testing.T) {
 			}}})
 	defer srv.Stopper().Stop(context.Background())
 	defer sqlDB.Close()
+	ts := srv.ApplicationLayer()
 
 	db := sqlutils.MakeSQLRunner(sqlDB)
 
@@ -84,41 +85,21 @@ func TestSqlActivityUpdateJob(t *testing.T) {
 	row.Scan(&count)
 	require.Equal(t, 0, count, "jobs: expect:0, actual:%d", count)
 
-	row = db.QueryRow(t, "SELECT count_rows() FROM system.public.transaction_statistics")
-	row.Scan(&count)
-	require.Equal(t, 0, count, "system.transaction_statistics: expect:0, actual:%d", count)
+	verifyActivityTablesAreEmpty(t, db)
 
-	row = db.QueryRow(t, "SELECT count_rows() FROM system.public.statement_statistics")
-	row.Scan(&count)
-	require.Equal(t, 0, count, "system.statement_statistics: expect:0, actual:%d", count)
-
-	row = db.QueryRow(t, "SELECT count_rows() FROM crdb_internal.transaction_activity")
-	row.Scan(&count)
-	require.Equal(t, 0, count, "crdb_internal.transaction_activity: expect:0, actual:%d", count)
-
-	row = db.QueryRow(t, "SELECT count_rows() FROM crdb_internal.statement_activity")
-	row.Scan(&count)
-	require.Equal(t, 0, count, "crdb_internal.statement_activity: expect:0, actual:%d", count)
-
-	execCfg := srv.ExecutorConfig().(ExecutorConfig)
+	execCfg := ts.ExecutorConfig().(ExecutorConfig)
 	st := cluster.MakeTestingClusterSettings()
 	updater := newSqlActivityUpdater(st, execCfg.InternalDB, sqlStatsKnobs)
 
 	require.NoError(t, updater.TransferStatsToActivity(ctx))
 
-	row = db.QueryRow(t, "SELECT count_rows() FROM system.public.transaction_activity")
-	row.Scan(&count)
-	require.Equal(t, 0, count, "system.transaction_activity: expect:0, actual:%d", count)
-
-	row = db.QueryRow(t, "SELECT count_rows() FROM system.public.statement_activity")
-	row.Scan(&count)
-	require.Equal(t, 0, count, "system.statement_activity: expect:0, actual:%d", count)
+	verifyActivityTablesAreEmpty(t, db)
 
 	appName := "TestSqlActivityUpdateJob"
 	db.Exec(t, "SET SESSION application_name=$1", appName)
 	db.Exec(t, "SELECT 1;")
 
-	srv.SQLServer().(*Server).GetSQLStatsProvider().(*persistedsqlstats.PersistedSQLStats).Flush(ctx)
+	ts.SQLServer().(*Server).GetSQLStatsProvider().(*persistedsqlstats.PersistedSQLStats).Flush(ctx)
 
 	db.Exec(t, "SET SESSION application_name=$1", "randomIgnore")
 
@@ -127,40 +108,12 @@ func TestSqlActivityUpdateJob(t *testing.T) {
 	// being a few rows.
 	require.NoError(t, updater.TransferStatsToActivity(ctx))
 
-	row = db.QueryRow(t, "SELECT count_rows() FROM system.public.transaction_activity WHERE app_name = $1", appName)
-	row.Scan(&count)
-	require.Equal(t, count, 1, "system.transaction_activity after transfer: expect:1, actual:%d", count)
-
-	row = db.QueryRow(t, "SELECT count_rows() FROM system.public.statement_activity WHERE app_name = $1", appName)
-	row.Scan(&count)
-	require.Equal(t, count, 1, "system.statement_activity after transfer: expect:1, actual:%d", count)
-
-	row = db.QueryRow(t, "SELECT count_rows() FROM crdb_internal.transaction_activity WHERE app_name = $1", appName)
-	row.Scan(&count)
-	require.Equal(t, count, 1, "crdb_internal.transaction_activity after transfer: expect:1, actual:%d", count)
-
-	row = db.QueryRow(t, "SELECT count_rows() FROM crdb_internal.statement_activity WHERE app_name = $1", appName)
-	row.Scan(&count)
-	require.Equal(t, count, 1, "crdb_internal.statement_activity after transfer: expect:1, actual:%d", count)
+	verifyActivityTableContentHelper(t, db, appName)
 
 	// Reset the stats and verify all sql stats tables are empty.
 	db.Exec(t, "SELECT crdb_internal.reset_sql_stats()")
 
-	row = db.QueryRow(t, "SELECT count_rows() FROM system.public.transaction_activity")
-	row.Scan(&count)
-	require.Zero(t, count, "system.transaction_activity after transfer: expect:0, actual:%d", count)
-
-	row = db.QueryRow(t, "SELECT count_rows() FROM system.public.statement_activity")
-	row.Scan(&count)
-	require.Zero(t, count, "system.statement_activity after transfer: expect:0, actual:%d", count)
-
-	row = db.QueryRow(t, "SELECT count_rows() FROM crdb_internal.transaction_activity")
-	row.Scan(&count)
-	require.Zero(t, count, "crdb_internal.transaction_activity after transfer: expect:0, actual:%d", count)
-
-	row = db.QueryRow(t, "SELECT count_rows() FROM crdb_internal.statement_activity")
-	row.Scan(&count)
-	require.Zero(t, count, "crdb_internal.statement_activity after transfer: expect:0, actual:%d", count)
+	verifyActivityTablesAreEmpty(t, db)
 }
 
 // TestMergeFunctionLogic verifies the merge functions used in the
@@ -312,7 +265,9 @@ func TestSqlActivityUpdateTopLimitJob(t *testing.T) {
 	db.Exec(t, "DELETE FROM system.public.transaction_statistics")
 	db.Exec(t, "DELETE FROM system.public.statement_statistics")
 
-	internalDb := ts.InternalDB().(isql.DB)
+	verifyActivityTablesAreEmpty(t, db)
+
+	execCfg := ts.ExecutorConfig().(ExecutorConfig)
 	st := cluster.MakeTestingClusterSettings()
 	su := st.MakeUpdater()
 	const topLimit = 3
@@ -322,7 +277,7 @@ func TestSqlActivityUpdateTopLimitJob(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	updater := newSqlActivityUpdater(st, internalDb, sqlStatsKnobs)
+	updater := newSqlActivityUpdater(st, execCfg.InternalDB, sqlStatsKnobs)
 
 	db.Exec(t, "SET tracing = true;")
 
@@ -360,6 +315,14 @@ func TestSqlActivityUpdateTopLimitJob(t *testing.T) {
 		ts.SQLServer().(*Server).GetSQLStatsProvider().(*persistedsqlstats.PersistedSQLStats).Flush(ctx)
 		db.Exec(t, "set cluster setting sql.stats.flush.enabled  = false;")
 
+		// Run the updater to add rows to the activity tables.
+		// This will use the transfer all scenarios with there only
+		// being a few rows.
+		err = updater.TransferStatsToActivity(ctx)
+		require.NoError(t, err)
+
+		verifyTopActivityTableContentHelper(t, db, 500)
+
 		// The max number of queries is number of top columns * max number of
 		// queries per a column (6*3=18 for this test, 6*500=3000 default). Most of
 		// the top queries are the same in this test so instead of getting 18 it's
@@ -372,7 +335,7 @@ func TestSqlActivityUpdateTopLimitJob(t *testing.T) {
 		for j := 0; j < topLimit; j++ {
 			updateStatsCount++
 			db.Exec(t, `UPDATE system.public.statement_statistics
-			SET statistics =  jsonb_set(jsonb_set(statistics, '{execution_statistics, cnt}', to_jsonb($1::INT)),
+			SET statistics =  jsonb_set(jsonb_set(statistics, '{statistics, cnt}', to_jsonb($1::INT)),
 			    '{statistics, svcLat, mean}', to_jsonb($2::FLOAT))
 			    WHERE app_name = $3;`, 10000+updateStatsCount, 0.0000001, getAppName(updateStatsCount))
 		}
@@ -381,7 +344,7 @@ func TestSqlActivityUpdateTopLimitJob(t *testing.T) {
 		for j := 0; j < topLimit; j++ {
 			updateStatsCount++
 			db.Exec(t, `UPDATE system.public.statement_statistics
-			SET statistics =  jsonb_set(jsonb_set(statistics, '{execution_statistics, cnt}', to_jsonb($1::INT)),
+			SET statistics =  jsonb_set(jsonb_set(statistics, '{statistics, cnt}', to_jsonb($1::INT)),
 			    '{statistics, svcLat, mean}', to_jsonb($2::FLOAT))
 			    WHERE app_name = $3;`, 1, 1000+updateStatsCount, getAppName(updateStatsCount))
 		}
@@ -391,7 +354,7 @@ func TestSqlActivityUpdateTopLimitJob(t *testing.T) {
 		for j := 0; j < topLimit; j++ {
 			updateStatsCount++
 			db.Exec(t, `UPDATE system.public.statement_statistics
-			SET statistics =  jsonb_set(jsonb_set(statistics, '{execution_statistics, cnt}', to_jsonb($1::INT)),
+			SET statistics =  jsonb_set(jsonb_set(statistics, '{statistics, cnt}', to_jsonb($1::INT)),
 			    '{statistics, svcLat, mean}', to_jsonb($2::FLOAT))
 			    WHERE app_name = $3;`, 500+updateStatsCount, 500+updateStatsCount, getAppName(updateStatsCount))
 		}
@@ -409,9 +372,12 @@ func TestSqlActivityUpdateTopLimitJob(t *testing.T) {
 
 		// Update the transaction stats
 		db.Exec(t, `UPDATE system.public.transaction_statistics
-			SET statistics =  jsonb_set(jsonb_set(statistics, '{execution_statistics, cnt}', to_jsonb($1::INT)),
+			SET statistics =  jsonb_set(jsonb_set(statistics, '{statistics, cnt}', to_jsonb($1::INT)),
 			    '{statistics, svcLat, mean}', to_jsonb($2::FLOAT))
 			    WHERE app_name = $3;`, 10000, 1, "topTransaction")
+
+		// Help check for primary key conflicts
+		duplicateRowHelper(t, db, getAppName(0))
 
 		// Run the updater to add rows to the activity tables.
 		// This will use the transfer all scenarios with there only
@@ -424,8 +390,8 @@ func TestSqlActivityUpdateTopLimitJob(t *testing.T) {
 		// Hit query endpoint.
 		urlPath := fmt.Sprintf("combinedstmts?start=%d", stubTime.Unix())
 		require.NoError(t, srvtestutils.GetStatusJSONProtoWithAdminOption(srv, urlPath, &httpStmtsResp, false))
-		require.Equal(t, httpStmtsResp.StmtsSourceTable, "crdb_internal.statement_activity")
-		require.Equal(t, httpStmtsResp.TxnsSourceTable, "crdb_internal.transaction_activity")
+		require.Equal(t, "crdb_internal.statement_activity", httpStmtsResp.StmtsSourceTable)
+		require.Equal(t, "crdb_internal.transaction_activity", httpStmtsResp.TxnsSourceTable)
 
 		maxRows := topLimit * 6 // Number of top columns to select from.
 		row := db.QueryRow(t,
@@ -462,7 +428,7 @@ func TestSqlActivityUpdateTopLimitJob(t *testing.T) {
 			row = db.QueryRow(t, `SELECT count_rows() FROM system.public.statement_activity 
                     WHERE encode(fingerprint_id, 'hex') = $1`, stmtToFind)
 			row.Scan(&count)
-			require.Equal(t, 1, count, "missing fingerprint from statement_activity:%s", stmtToFind)
+			require.Zero(t, count, "statement fingerprint should not be in statement_activity:%s", stmtToFind)
 
 		}
 
@@ -591,8 +557,9 @@ func TestTransactionActivityMetadata(t *testing.T) {
 	})
 	defer s.Stopper().Stop(context.Background())
 	defer sqlDB.Close()
+	ts := s.ApplicationLayer()
 
-	execCfg := s.ExecutorConfig().(ExecutorConfig)
+	execCfg := ts.ExecutorConfig().(ExecutorConfig)
 	st := cluster.MakeTestingClusterSettings()
 	updater := newSqlActivityUpdater(st, execCfg.InternalDB, sqlStatsKnobs)
 
@@ -604,7 +571,7 @@ func TestTransactionActivityMetadata(t *testing.T) {
 
 	// Flush and transfer stats.
 	var metadataJSON string
-	s.SQLServer().(*Server).GetSQLStatsProvider().(*persistedsqlstats.PersistedSQLStats).Flush(ctx)
+	ts.SQLServer().(*Server).GetSQLStatsProvider().(*persistedsqlstats.PersistedSQLStats).Flush(ctx)
 
 	// Ensure that the metadata column contains the populated 'stmtFingerprintIDs' field.
 	var metadata struct {
@@ -621,7 +588,7 @@ func TestTransactionActivityMetadata(t *testing.T) {
 	db.Exec(t, "SELECT 1")
 
 	// Flush and transfer top stats.
-	s.SQLServer().(*Server).GetSQLStatsProvider().(*persistedsqlstats.PersistedSQLStats).Flush(ctx)
+	ts.SQLServer().(*Server).GetSQLStatsProvider().(*persistedsqlstats.PersistedSQLStats).Flush(ctx)
 	require.NoError(t, updater.transferTopStats(ctx, stubTime, 100, 100, 100))
 
 	// Ensure that the metadata column contains the populated 'stmtFingerprintIDs' field.
@@ -657,8 +624,9 @@ func TestActivityStatusCombineAPI(t *testing.T) {
 	})
 	defer s.Stopper().Stop(context.Background())
 	defer sqlDB.Close()
+	ts := s.ApplicationLayer()
 
-	execCfg := s.ExecutorConfig().(ExecutorConfig)
+	execCfg := ts.ExecutorConfig().(ExecutorConfig)
 	st := cluster.MakeTestingClusterSettings()
 	updater := newSqlActivityUpdater(st, execCfg.InternalDB, sqlStatsKnobs)
 
@@ -675,7 +643,7 @@ func TestActivityStatusCombineAPI(t *testing.T) {
 
 	// Flush and transfer stats.
 	var metadataJSON string
-	s.SQLServer().(*Server).GetSQLStatsProvider().(*persistedsqlstats.PersistedSQLStats).Flush(ctx)
+	ts.SQLServer().(*Server).GetSQLStatsProvider().(*persistedsqlstats.PersistedSQLStats).Flush(ctx)
 
 	// Ensure that the metadata column contains the populated 'stmtFingerprintIDs' field.
 	var metadata struct {
@@ -763,6 +731,172 @@ func TestActivityStatusCombineAPI(t *testing.T) {
 	require.NotEmpty(t, resp.Statements)
 	require.Greater(t, resp.StmtsTotalRuntimeSecs, float32(0))
 	require.Greater(t, resp.TxnsTotalRuntimeSecs, float32(0))
+}
+
+// duplicateRowHelper duplicates a single row in each statistics table, but slightly
+// changes non-primary key fields to make sure it doesn't cause a conflict that
+// breaks upsert because multiple rows have same primary key.
+func duplicateRowHelper(t *testing.T, db *sqlutils.SQLRunner, appName string) {
+	// primary key for activity table: aggregated_ts, fingerprint_id, app_name
+	db.Exec(t, `INSERT INTO system.transaction_statistics (aggregated_ts, fingerprint_id, app_name, node_id, agg_interval, metadata, statistics)
+			 (SELECT aggregated_ts, fingerprint_id, app_name, 42, '00:00:01'::INTERVAL, metadata,  statistics FROM system.transaction_statistics where app_name = $1 limit 1)
+		`, appName)
+
+	// primary key for activity table: aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name
+	db.Exec(t, `INSERT INTO system.statement_statistics (aggregated_ts, fingerprint_id, transaction_fingerprint_id, app_name, node_id, agg_interval, plan_hash, metadata, statistics)
+			 (SELECT aggregated_ts, fingerprint_id, transaction_fingerprint_id, app_name, 42, '00:00:01'::INTERVAL, plan_hash, metadata, jsonb_set(statistics, '{index_recommendations}', to_jsonb('["creation : dummy value"]'))  FROM system.statement_statistics where app_name = $1 limit 1)
+		`, appName)
+}
+
+func verifyActivityTablesAreEmpty(t *testing.T, db *sqlutils.SQLRunner) {
+	var count int
+	row := db.QueryRow(t, "SELECT count_rows() FROM system.public.transaction_activity")
+	row.Scan(&count)
+	require.Zero(t, count, "system.transaction_activity after transfer: expect:0, actual:%d", count)
+
+	row = db.QueryRow(t, "SELECT count_rows() FROM system.public.statement_activity")
+	row.Scan(&count)
+	require.Zero(t, count, "system.statement_activity after transfer: expect:0, actual:%d", count)
+
+	row = db.QueryRow(t, "SELECT count_rows() FROM crdb_internal.transaction_activity")
+	row.Scan(&count)
+	require.Zero(t, count, "crdb_internal.transaction_activity after transfer: expect:0, actual:%d", count)
+
+	row = db.QueryRow(t, "SELECT count_rows() FROM crdb_internal.statement_activity")
+	row.Scan(&count)
+	require.Zero(t, count, "crdb_internal.statement_activity after transfer: expect:0, actual:%d", count)
+}
+
+func verifyActivityTableContentHelper(t *testing.T, db *sqlutils.SQLRunner, appName string) {
+	txnTables := []string{"system.public.transaction_activity", "crdb_internal.transaction_activity"}
+	for _, table := range txnTables {
+		query := fmt.Sprintf(`SELECT count_rows() 
+		FROM system.public.transaction_statistics ts
+		INNER JOIN	(SELECT * FROM %s) ta using (fingerprint_id, app_name)
+		WHERE app_name = $1 AND
+			ta.execution_count = ts.execution_count AND
+			ta.execution_total_seconds = ts.total_estimated_execution_time AND
+			ta.contention_time_avg_seconds  = ts.contention_time AND
+			ta.cpu_sql_avg_nanos = ts.cpu_sql_nanos AND      
+			ta.service_latency_avg_seconds = ts.service_latency AND
+			ta.statistics = ts.statistics AND
+			ta.metadata = ts.metadata`, table)
+		row := db.QueryRow(t, query, appName)
+		var count int
+		row.Scan(&count)
+		require.Equal(t, 1, count, "%s after transfer: expect:1, actual:%d, query: %s", table, count, query)
+	}
+
+	stmtTables := []string{"system.public.statement_activity", "crdb_internal.statement_activity"}
+	for _, table := range stmtTables {
+		query := fmt.Sprintf(`SELECT count_rows() 
+		FROM system.public.statement_statistics ss
+		INNER JOIN	(SELECT * FROM %s) sa using (fingerprint_id, app_name)
+		WHERE app_name = $1 AND
+			sa.execution_count = ss.execution_count AND
+			sa.execution_total_seconds = ss.total_estimated_execution_time AND
+			sa.contention_time_avg_seconds  = ss.contention_time AND
+			sa.cpu_sql_avg_nanos = ss.cpu_sql_nanos AND      
+			sa.service_latency_avg_seconds = ss.service_latency AND
+			sa.service_latency_p99_seconds = ss.p99_latency AND
+			sa.statistics = ss.statistics`, table)
+		row := db.QueryRow(t, query, appName)
+		var count int
+		row.Scan(&count)
+		require.Equal(t, 1, count, "%s after transfer: expect:1, actual:%d, query: %s", table, count, query)
+
+		// Metadata objects are changed because it's an aggregate.
+		query = fmt.Sprintf(`SELECT count_rows() 
+		FROM (select fingerprint_id, app_name, crdb_internal.merge_stats_metadata(array_agg(metadata)) AS metadata FROM system.public.statement_statistics GROUP BY fingerprint_id, app_name) ss
+		INNER JOIN	(SELECT * FROM %s) sa using (fingerprint_id, app_name)
+		WHERE app_name = $1 AND
+		      sa.metadata = ss.metadata`, table)
+		row = db.QueryRow(t, query, appName)
+		row.Scan(&count)
+		require.Equal(t, 1, count, "%s after transfer metadata: expect:1, actual:%d, query: %s", table, count, query)
+	}
+}
+
+func verifyTopActivityTableContentHelper(t *testing.T, db *sqlutils.SQLRunner, limitCnt int) {
+	txnTables := []string{"system.public.transaction_activity", "crdb_internal.transaction_activity"}
+	for _, table := range txnTables {
+		topColumnNames := []string{" (statistics->'statistics'->>'cnt')::int ",
+			" ((statistics->'statistics'->>'cnt')::float)*((statistics->'statistics'->'svcLat'->>'mean')::float) ",
+			" COALESCE((statistics->'execution_statistics'->'contentionTime'->>'mean')::float,0) ",
+			" COALESCE((statistics->'execution_statistics'->'cpuSQLNanos'->>'mean')::float,0) ",
+			" (statistics->'statistics'->'svcLat'->>'mean')::float "}
+		for _, column := range topColumnNames {
+			query := fmt.Sprintf(`SELECT count_rows()
+		FROM 
+		    (select * from (select 
+		                        aggregated_ts,
+		                        fingerprint_id,
+		                        app_name,
+		                        max(metadata) AS max_metadata,
+		                        crdb_internal.merge_transaction_stats(array_agg(statistics)) as statistics
+					from system.public.transaction_statistics 
+						where app_name not like '$ internal%%' 
+						group by aggregated_ts, fingerprint_id, app_name)
+				order by %s limit %d) ts
+		LEFT JOIN	(SELECT * FROM %s ) ta using (aggregated_ts, fingerprint_id, app_name)
+		WHERE ta.fingerprint_id != ts.fingerprint_id OR
+			ta.statistics != ts.statistics`, column, limitCnt, table)
+			row := db.QueryRow(t, query)
+
+			var count int
+			row.Scan(&count)
+			require.Zero(t, count, "%s after transfer: expect:0, actual:%d, query: %s", table, count, query)
+
+			if strings.Contains(column, "'statistics'") {
+				query = fmt.Sprintf(`SELECT sum(%s :: float) FROM  %s`, column, table)
+				row = db.QueryRow(t, query)
+				var totalColumnValue float64
+				row.Scan(&totalColumnValue)
+				require.Greater(t, totalColumnValue, float64(0), "%s after transfer: expect:1, actual:%d, query: %s", table, totalColumnValue, query)
+			}
+		}
+	}
+
+	stmtTables := []string{"system.public.statement_activity", "crdb_internal.statement_activity"}
+	for _, table := range stmtTables {
+		topColumnNames := []string{" (statistics->'statistics'->>'cnt')::int ",
+			" ((statistics->'statistics'->>'cnt')::float)*((statistics->'statistics'->'svcLat'->>'mean')::float) ",
+			" COALESCE((statistics->'execution_statistics'->'contentionTime'->>'mean')::float,0) ",
+			" COALESCE((statistics->'execution_statistics'->'cpuSQLNanos'->>'mean')::float,0) ",
+			" (statistics->'statistics'->'svcLat'->>'mean')::float ",
+			"COALESCE((statistics -> 'statistics' -> 'latencyInfo' ->> 'p99')::float, 0)"}
+		for _, column := range topColumnNames {
+			query := fmt.Sprintf(`SELECT count_rows()
+		FROM 
+		    (select * from (select 
+		                        aggregated_ts,
+		                        fingerprint_id,
+		                        app_name,
+		                        crdb_internal.merge_stats_metadata(array_agg(metadata))    AS merged_metadata,
+		                        crdb_internal.merge_statement_stats(array_agg(statistics)) as statistics
+					from system.public.statement_statistics 
+						where app_name not like '$ internal%%' 
+						group by aggregated_ts, fingerprint_id, app_name)
+				order by %s limit %d) ts
+		LEFT JOIN	(SELECT * FROM %s ) ta using (aggregated_ts, fingerprint_id, app_name)
+		WHERE ta.fingerprint_id != ts.fingerprint_id OR
+			ta.statistics != ts.statistics OR
+		  ta.metadata != ts.merged_metadata `, column, limitCnt, table)
+			row := db.QueryRow(t, query)
+
+			var count int
+			row.Scan(&count)
+			require.Zero(t, count, "%s after transfer: expect:0, actual:%d, query: %s", table, count, query)
+
+			if strings.Contains(column, "'statistics'") && !strings.Contains(column, "'p99'") {
+				query = fmt.Sprintf(`SELECT sum(%s :: float) FROM  %s`, column, table)
+				row = db.QueryRow(t, query)
+				var totalColumnValue float64
+				row.Scan(&totalColumnValue)
+				require.Greater(t, totalColumnValue, float64(0), "%s after transfer: expect:1, actual:%d, query: %s", table, totalColumnValue, query)
+			}
+		}
+	}
 }
 
 func getTxnAppNameCnt(resp serverpb.StatementsResponse, appName string) int {


### PR DESCRIPTION
tldr: fix activity update job failing from conflict, caching to much info when their is high cardinatlity in the stats, and fix cache to store the correct top stats.

1. Fix activity update failure from upserting same row multiple times. This was caused by 2 nodes having the same statement, but one only executed it 2 or 3 time and the other node executed it enough to generate an index recommendation. The different index recommendation caused duplicate rows based on primary key to be inserted. It now uses index recommendation from the merged stats which uses the last executed time to chose which one to use.
2. Customers can have transactions that have over 1k unique statement fingerprint ids. This makes it unreasonable to cache all of the statement information for all the top transactions. This commit removes the logic to cache all the statement information for the top transactions which could cause the table to grow to over 100k for a single hour. This requires the call to go the statistics table to get all the necessary statement information for the txn details.
3. The activity cache logic was not correctly selecting the top CPU json column. It was using the computed index column name instead of the json field name. The values shown on the UI were correct because the endpoint still aggregated several columns using the aggregated stats rather than the separate column.
4. The activity cache logic was using the execution count instead of the statistics count to select the top queries. In most cases this still generates the correct top queries, and the UI uses the aggregated stats which showed the correct value.

Fixes: #111780

Release note (sql change): Fix the SQL activity update job to avoid conflicts on update, reduces the amount of data cached to just what the overview page requires, and fix the correctess of the top queries.