### PR TITLE
opt: move locking durability check back to optbuilder

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -2934,19 +2934,6 @@ func (b *Builder) buildLocking(locking opt.Locking) (opt.Locking, error) {
 				return opt.Locking{}, nil // early return; do not set b.ContainsNonDefaultKeyLocking
 			}
 		}
-		// Check if we can actually use guaranteed-durable locking here.
-		if locking.Durability == tree.LockDurabilityGuaranteed {
-			// Guaranteed-durable locking didn't exist prior to v23.2.
-			if !b.evalCtx.Settings.Version.IsActive(b.ctx, clusterversion.V23_2) ||
-				// Under serializable isolation we only use guaranteed-durable locks if
-				// enable_durable_locking_for_serializable is set. (Serializable
-				// isolation does not require locking for correctness, so by default we
-				// use best-effort locks for better performance.)
-				(b.evalCtx.TxnIsoLevel == isolation.Serializable &&
-					!b.evalCtx.SessionData().DurableLockingForSerializable) {
-				locking.Durability = tree.LockDurabilityBestEffort
-			}
-		}
 		b.ContainsNonDefaultKeyLocking = true
 	}
 	return locking, nil

--- a/pkg/sql/opt/memo/testdata/logprops/join
+++ b/pkg/sql/opt/memo/testdata/logprops/join
@@ -1955,7 +1955,7 @@ inner-join (hash)
  ├── interesting orderings: (+1) (+7) (-9,+10,+7)
  ├── scan fk
  │    ├── columns: k:1(int!null) v:2(int) r1:3(int!null) r2:4(int)
- │    ├── locking: for-update,skip-locked,durability-guaranteed
+ │    ├── locking: for-update,skip-locked
  │    ├── volatile
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-4)
@@ -1963,7 +1963,7 @@ inner-join (hash)
  │    └── interesting orderings: (+1)
  ├── scan xysd
  │    ├── columns: x:7(int!null) y:8(int) s:9(string) d:10(decimal!null)
- │    ├── locking: for-update,skip-locked,durability-guaranteed
+ │    ├── locking: for-update,skip-locked
  │    ├── volatile
  │    ├── key: (7)
  │    ├── fd: (7)-->(8-10), (9,10)~~>(7,8)
@@ -1994,7 +1994,7 @@ inner-join (hash)
  │    └── unfiltered-cols: (1-6)
  ├── scan xysd
  │    ├── columns: x:7(int!null) y:8(int) s:9(string) d:10(decimal!null)
- │    ├── locking: for-share,skip-locked,durability-guaranteed
+ │    ├── locking: for-share,skip-locked
  │    ├── volatile
  │    ├── key: (7)
  │    ├── fd: (7)-->(8-10), (9,10)~~>(7,8)
@@ -2019,7 +2019,7 @@ inner-join (hash)
  ├── interesting orderings: (+1) (+7) (-9,+10,+7)
  ├── scan fk
  │    ├── columns: k:1(int!null) v:2(int) r1:3(int!null) r2:4(int)
- │    ├── locking: for-update,skip-locked,durability-guaranteed
+ │    ├── locking: for-update,skip-locked
  │    ├── volatile
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-4)

--- a/pkg/sql/opt/memo/testdata/logprops/scan
+++ b/pkg/sql/opt/memo/testdata/logprops/scan
@@ -285,7 +285,7 @@ project
  ├── interesting orderings: (+1) (-3,+4,+1)
  └── scan a
       ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null) crdb_internal_mvcc_timestamp:5(decimal) tableoid:6(oid)
-      ├── locking: for-update,durability-guaranteed
+      ├── locking: for-update
       ├── volatile
       ├── key: (1)
       ├── fd: (1)-->(2-6), (3,4)~~>(1,2,5,6)

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -14,6 +14,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/isolation"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
@@ -700,19 +702,25 @@ func (b *Builder) buildScan(
 	}
 	if locking.isSet() {
 		private.Locking = locking.get()
-		// Under weaker isolation levels we use fully-durable locks for SELECT FOR
-		// UPDATE statements, SELECT FOR SHARE statements, and constraint checks
-		// (e.g. FK checks), regardless of locking strength and wait policy. Unlike
-		// mutation statements, SELECT FOR UPDATE statements do not lay down
-		// intents, so we cannot rely on the durability of intents to guarantee
-		// exclusion until commit as we do for mutation statements. And unlike
-		// serializable isolation, weaker isolation levels do not perform read
-		// refreshing, so we cannot rely on read refreshing to guarantee exclusion.
-		//
-		// We set guaranteed durability here and then remove it in execbuilder if
-		// necessary, to allow for preparing and execution of statements in
-		// different isolation levels.
-		private.Locking.Durability = tree.LockDurabilityGuaranteed
+		if b.evalCtx.Settings.Version.IsActive(b.ctx, clusterversion.V23_2) &&
+			(b.evalCtx.TxnIsoLevel != isolation.Serializable ||
+				b.evalCtx.SessionData().DurableLockingForSerializable) {
+			// Under weaker isolation levels we use fully-durable locks for SELECT FOR
+			// UPDATE statements, SELECT FOR SHARE statements, and constraint checks
+			// (e.g. FK checks), regardless of locking strength and wait policy.
+			// Unlike mutation statements, SELECT FOR UPDATE statements do not lay
+			// down intents, so we cannot rely on the durability of intents to
+			// guarantee exclusion until commit as we do for mutation statements. And
+			// unlike serializable isolation, weaker isolation levels do not perform
+			// read refreshing, so we cannot rely on read refreshing to guarantee
+			// exclusion.
+			//
+			// Under serializable isolation we only use fully-durable locks if
+			// enable_durable_locking_for_serializable is set. (Serializable isolation
+			// does not require locking for correctness, so by default we use
+			// best-effort locks for better performance.)
+			private.Locking.Durability = tree.LockDurabilityGuaranteed
+		}
 		if private.Locking.WaitPolicy == tree.LockWaitSkipLocked && tab.FamilyCount() > 1 {
 			// TODO(rytaft): We may be able to support this if enough columns are
 			// pruned that only a single family is scanned.

--- a/pkg/sql/opt/optbuilder/testdata/fk-checks-insert
+++ b/pkg/sql/opt/optbuilder/testdata/fk-checks-insert
@@ -710,6 +710,6 @@ insert child
                 ├── scan parent
                 │    ├── columns: parent.p:8!null
                 │    ├── flags: disabled not visible index feature
-                │    └── locking: for-share,durability-guaranteed
+                │    └── locking: for-share
                 └── filters
                      └── p:7 = parent.p:8

--- a/pkg/sql/opt/optbuilder/testdata/fk-checks-update
+++ b/pkg/sql/opt/optbuilder/testdata/fk-checks-update
@@ -600,7 +600,7 @@ update child
       │         ├── scan parent
       │         │    ├── columns: parent.p:13!null
       │         │    ├── flags: disabled not visible index feature
-      │         │    └── locking: for-share,durability-guaranteed
+      │         │    └── locking: for-share
       │         └── filters
       │              └── p:11 = parent.p:13
       ├── f-k-checks-item: grandchild(c) -> child(c)
@@ -670,7 +670,7 @@ update self
                 ├── scan self
                 │    ├── columns: x:11!null
                 │    ├── flags: disabled not visible index feature
-                │    └── locking: for-share,durability-guaranteed
+                │    └── locking: for-share
                 └── filters
                      └── y:10 = x:11
 

--- a/pkg/sql/opt/optbuilder/testdata/select_for_update
+++ b/pkg/sql/opt/optbuilder/testdata/select_for_update
@@ -25,7 +25,7 @@ project
  ├── columns: a:1!null b:2
  └── scan t
       ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
-      └── locking: for-update,durability-guaranteed
+      └── locking: for-update
 
 build
 SELECT * FROM t FOR NO KEY UPDATE
@@ -34,7 +34,7 @@ project
  ├── columns: a:1!null b:2
  └── scan t
       ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
-      └── locking: for-no-key-update,durability-guaranteed
+      └── locking: for-no-key-update
 
 build
 SELECT * FROM t FOR SHARE
@@ -43,7 +43,7 @@ project
  ├── columns: a:1!null b:2
  └── scan t
       ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
-      └── locking: for-share,durability-guaranteed
+      └── locking: for-share
 
 build
 SELECT * FROM t FOR KEY SHARE
@@ -52,7 +52,7 @@ project
  ├── columns: a:1!null b:2
  └── scan t
       ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
-      └── locking: for-key-share,durability-guaranteed
+      └── locking: for-key-share
 
 build
 SELECT * FROM t FOR KEY SHARE FOR SHARE
@@ -61,7 +61,7 @@ project
  ├── columns: a:1!null b:2
  └── scan t
       ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
-      └── locking: for-share,durability-guaranteed
+      └── locking: for-share
 
 build
 SELECT * FROM t FOR KEY SHARE FOR SHARE FOR NO KEY UPDATE
@@ -70,7 +70,7 @@ project
  ├── columns: a:1!null b:2
  └── scan t
       ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
-      └── locking: for-no-key-update,durability-guaranteed
+      └── locking: for-no-key-update
 
 build
 SELECT * FROM t FOR KEY SHARE FOR SHARE FOR NO KEY UPDATE FOR UPDATE
@@ -79,7 +79,7 @@ project
  ├── columns: a:1!null b:2
  └── scan t
       ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
-      └── locking: for-update,durability-guaranteed
+      └── locking: for-update
 
 build
 SELECT * FROM t FOR UPDATE OF t
@@ -88,7 +88,7 @@ project
  ├── columns: a:1!null b:2
  └── scan t
       ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
-      └── locking: for-update,durability-guaranteed
+      └── locking: for-update
 
 build
 SELECT * FROM t FOR UPDATE OF t2
@@ -102,7 +102,7 @@ project
  ├── columns: "?column?":5!null
  ├── scan t
  │    ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
- │    └── locking: for-update,durability-guaranteed
+ │    └── locking: for-update
  └── projections
       └── 1 [as="?column?":5]
 
@@ -117,7 +117,7 @@ project
  ├── columns: a:1!null b:2
  └── scan t [as=t2]
       ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
-      └── locking: for-update,durability-guaranteed
+      └── locking: for-update
 
 build
 SELECT * FROM t AS t2 FOR UPDATE OF t
@@ -131,7 +131,7 @@ project
  ├── columns: a:1!null b:2
  └── scan t [as=t2]
       ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
-      └── locking: for-update,durability-guaranteed
+      └── locking: for-update
 
 # ------------------------------------------------------------------------------
 # Tests with numeric table references.
@@ -145,7 +145,7 @@ project
  ├── columns: a:1!null b:2
  └── scan t
       ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
-      └── locking: for-update,durability-guaranteed
+      └── locking: for-update
 
 build
 SELECT * FROM [53 AS t] FOR UPDATE OF t
@@ -154,7 +154,7 @@ project
  ├── columns: a:1!null b:2
  └── scan t
       ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
-      └── locking: for-update,durability-guaranteed
+      └── locking: for-update
 
 build
 SELECT * FROM [53 AS t] FOR UPDATE OF t2
@@ -172,7 +172,7 @@ project
  ├── columns: a:1!null
  └── scan t [as=t2]
       ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
-      └── locking: for-update,durability-guaranteed
+      └── locking: for-update
 
 build
 SELECT * FROM v FOR UPDATE OF v
@@ -181,7 +181,7 @@ project
  ├── columns: a:1!null
  └── scan t [as=t2]
       ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
-      └── locking: for-update,durability-guaranteed
+      └── locking: for-update
 
 build
 SELECT * FROM v FOR UPDATE OF v2
@@ -209,7 +209,7 @@ project
  ├── columns: a:1!null
  └── scan t [as=t2]
       ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
-      └── locking: for-update,durability-guaranteed
+      └── locking: for-update
 
 build
 SELECT * FROM v AS v2 FOR UPDATE OF v
@@ -223,7 +223,7 @@ project
  ├── columns: a:1!null
  └── scan t [as=t2]
       ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
-      └── locking: for-update,durability-guaranteed
+      └── locking: for-update
 
 # ------------------------------------------------------------------------------
 # Tests with subqueries.
@@ -240,7 +240,7 @@ project
  ├── columns: a:1!null
  └── scan t
       ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
-      └── locking: for-update,durability-guaranteed
+      └── locking: for-update
 
 build
 SELECT * FROM (SELECT a FROM t FOR UPDATE)
@@ -249,7 +249,7 @@ project
  ├── columns: a:1!null
  └── scan t
       ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
-      └── locking: for-update,durability-guaranteed
+      └── locking: for-update
 
 build
 SELECT * FROM (SELECT a FROM t FOR NO KEY UPDATE) FOR KEY SHARE
@@ -258,7 +258,7 @@ project
  ├── columns: a:1!null
  └── scan t
       ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
-      └── locking: for-no-key-update,durability-guaranteed
+      └── locking: for-no-key-update
 
 build
 SELECT * FROM (SELECT a FROM t FOR KEY SHARE) FOR NO KEY UPDATE
@@ -267,7 +267,7 @@ project
  ├── columns: a:1!null
  └── scan t
       ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
-      └── locking: for-no-key-update,durability-guaranteed
+      └── locking: for-no-key-update
 
 build
 SELECT * FROM (SELECT a FROM t) FOR UPDATE OF t
@@ -281,7 +281,7 @@ project
  ├── columns: a:1!null
  └── scan t
       ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
-      └── locking: for-update,durability-guaranteed
+      └── locking: for-update
 
 build
 SELECT * FROM (SELECT a FROM t) AS r FOR UPDATE
@@ -290,7 +290,7 @@ project
  ├── columns: a:1!null
  └── scan t
       ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
-      └── locking: for-update,durability-guaranteed
+      └── locking: for-update
 
 build
 SELECT * FROM (SELECT a FROM t FOR UPDATE) AS r
@@ -299,7 +299,7 @@ project
  ├── columns: a:1!null
  └── scan t
       ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
-      └── locking: for-update,durability-guaranteed
+      └── locking: for-update
 
 build
 SELECT * FROM (SELECT a FROM t) AS r FOR UPDATE OF t
@@ -313,7 +313,7 @@ project
  ├── columns: a:1!null
  └── scan t
       ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
-      └── locking: for-update,durability-guaranteed
+      └── locking: for-update
 
 build
 SELECT (SELECT a FROM t) FOR UPDATE
@@ -346,7 +346,7 @@ project
                      ├── columns: t.a:1!null
                      └── scan t
                           ├── columns: t.a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
-                          └── locking: for-update,durability-guaranteed
+                          └── locking: for-update
 
 build
 SELECT (SELECT a FROM t) FOR UPDATE OF t
@@ -368,7 +368,7 @@ project
                      ├── columns: t.a:1!null
                      └── scan t
                           ├── columns: t.a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
-                          └── locking: for-update,durability-guaranteed
+                          └── locking: for-update
 
 build
 SELECT (SELECT a FROM t) AS r FOR UPDATE
@@ -401,7 +401,7 @@ project
                      ├── columns: a:1!null
                      └── scan t
                           ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
-                          └── locking: for-update,durability-guaranteed
+                          └── locking: for-update
 
 build
 SELECT (SELECT a FROM t) AS r FOR UPDATE OF t
@@ -423,7 +423,7 @@ project
                      ├── columns: a:1!null
                      └── scan t
                           ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
-                          └── locking: for-update,durability-guaranteed
+                          └── locking: for-update
 
 build
 SELECT * FROM t WHERE a IN (SELECT a FROM t) FOR UPDATE
@@ -434,7 +434,7 @@ project
       ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
       ├── scan t
       │    ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
-      │    └── locking: for-update,durability-guaranteed
+      │    └── locking: for-update
       └── filters
            └── any: eq
                 ├── project
@@ -458,7 +458,7 @@ project
                 │    ├── columns: a:5!null
                 │    └── scan t
                 │         ├── columns: a:5!null b:6 crdb_internal_mvcc_timestamp:7 tableoid:8
-                │         └── locking: for-update,durability-guaranteed
+                │         └── locking: for-update
                 └── a:1
 
 build
@@ -470,7 +470,7 @@ project
       ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
       ├── scan t
       │    ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
-      │    └── locking: for-update,durability-guaranteed
+      │    └── locking: for-update
       └── filters
            └── any: eq
                 ├── project
@@ -494,7 +494,7 @@ project
                 │    ├── columns: a:5!null
                 │    └── scan t
                 │         ├── columns: a:5!null b:6 crdb_internal_mvcc_timestamp:7 tableoid:8
-                │         └── locking: for-update,durability-guaranteed
+                │         └── locking: for-update
                 └── a:1
 
 build
@@ -506,7 +506,7 @@ project
       ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
       ├── scan t
       │    ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
-      │    └── locking: for-update,durability-guaranteed
+      │    └── locking: for-update
       └── filters
            └── any: eq
                 ├── project
@@ -530,7 +530,7 @@ project
                 │    ├── columns: b:6
                 │    └── scan t
                 │         ├── columns: a:5!null b:6 crdb_internal_mvcc_timestamp:7 tableoid:8
-                │         └── locking: for-update,durability-guaranteed
+                │         └── locking: for-update
                 └── a:1
 
 build
@@ -542,7 +542,7 @@ project
       ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
       ├── scan t
       │    ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
-      │    └── locking: for-update,durability-guaranteed
+      │    └── locking: for-update
       └── filters
            └── any: eq
                 ├── project
@@ -566,7 +566,7 @@ project
                 │    ├── columns: b:6
                 │    └── scan t
                 │         ├── columns: a:5!null b:6 crdb_internal_mvcc_timestamp:7 tableoid:8
-                │         └── locking: for-update,durability-guaranteed
+                │         └── locking: for-update
                 └── a:1
 
 # ------------------------------------------------------------------------------
@@ -614,7 +614,7 @@ with &1
  │    ├── columns: t.a:1!null
  │    └── scan t
  │         ├── columns: t.a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
- │         └── locking: for-update,durability-guaranteed
+ │         └── locking: for-update
  └── with-scan &1
       ├── columns: a:5!null
       └── mapping:
@@ -629,7 +629,7 @@ with &1 (cte)
  │    ├── columns: t.a:1!null
  │    └── scan t
  │         ├── columns: t.a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
- │         └── locking: for-update,durability-guaranteed
+ │         └── locking: for-update
  └── with-scan &1 (cte)
       ├── columns: a:5!null
       └── mapping:
@@ -648,10 +648,10 @@ project
       ├── columns: t.a:1!null b:2 t.crdb_internal_mvcc_timestamp:3 t.tableoid:4 u.a:5!null c:6 u.crdb_internal_mvcc_timestamp:7 u.tableoid:8
       ├── scan t
       │    ├── columns: t.a:1!null b:2 t.crdb_internal_mvcc_timestamp:3 t.tableoid:4
-      │    └── locking: for-update,durability-guaranteed
+      │    └── locking: for-update
       ├── scan u
       │    ├── columns: u.a:5!null c:6 u.crdb_internal_mvcc_timestamp:7 u.tableoid:8
-      │    └── locking: for-update,durability-guaranteed
+      │    └── locking: for-update
       └── filters
            └── t.a:1 = u.a:5
 
@@ -664,7 +664,7 @@ project
       ├── columns: t.a:1!null b:2 t.crdb_internal_mvcc_timestamp:3 t.tableoid:4 u.a:5!null c:6 u.crdb_internal_mvcc_timestamp:7 u.tableoid:8
       ├── scan t
       │    ├── columns: t.a:1!null b:2 t.crdb_internal_mvcc_timestamp:3 t.tableoid:4
-      │    └── locking: for-update,durability-guaranteed
+      │    └── locking: for-update
       ├── scan u
       │    └── columns: u.a:5!null c:6 u.crdb_internal_mvcc_timestamp:7 u.tableoid:8
       └── filters
@@ -681,7 +681,7 @@ project
       │    └── columns: t.a:1!null b:2 t.crdb_internal_mvcc_timestamp:3 t.tableoid:4
       ├── scan u
       │    ├── columns: u.a:5!null c:6 u.crdb_internal_mvcc_timestamp:7 u.tableoid:8
-      │    └── locking: for-update,durability-guaranteed
+      │    └── locking: for-update
       └── filters
            └── t.a:1 = u.a:5
 
@@ -694,10 +694,10 @@ project
       ├── columns: t.a:1!null b:2 t.crdb_internal_mvcc_timestamp:3 t.tableoid:4 u.a:5!null c:6 u.crdb_internal_mvcc_timestamp:7 u.tableoid:8
       ├── scan t
       │    ├── columns: t.a:1!null b:2 t.crdb_internal_mvcc_timestamp:3 t.tableoid:4
-      │    └── locking: for-update,durability-guaranteed
+      │    └── locking: for-update
       ├── scan u
       │    ├── columns: u.a:5!null c:6 u.crdb_internal_mvcc_timestamp:7 u.tableoid:8
-      │    └── locking: for-update,durability-guaranteed
+      │    └── locking: for-update
       └── filters
            └── t.a:1 = u.a:5
 
@@ -710,10 +710,10 @@ project
       ├── columns: t.a:1!null b:2 t.crdb_internal_mvcc_timestamp:3 t.tableoid:4 u.a:5!null c:6 u.crdb_internal_mvcc_timestamp:7 u.tableoid:8
       ├── scan t
       │    ├── columns: t.a:1!null b:2 t.crdb_internal_mvcc_timestamp:3 t.tableoid:4
-      │    └── locking: for-update,durability-guaranteed
+      │    └── locking: for-update
       ├── scan u
       │    ├── columns: u.a:5!null c:6 u.crdb_internal_mvcc_timestamp:7 u.tableoid:8
-      │    └── locking: for-share,durability-guaranteed
+      │    └── locking: for-share
       └── filters
            └── t.a:1 = u.a:5
 
@@ -731,10 +731,10 @@ project
       ├── columns: t2.a:1!null b:2 t2.crdb_internal_mvcc_timestamp:3 t2.tableoid:4 u2.a:5!null c:6 u2.crdb_internal_mvcc_timestamp:7 u2.tableoid:8
       ├── scan t [as=t2]
       │    ├── columns: t2.a:1!null b:2 t2.crdb_internal_mvcc_timestamp:3 t2.tableoid:4
-      │    └── locking: for-update,durability-guaranteed
+      │    └── locking: for-update
       ├── scan u [as=u2]
       │    ├── columns: u2.a:5!null c:6 u2.crdb_internal_mvcc_timestamp:7 u2.tableoid:8
-      │    └── locking: for-share,durability-guaranteed
+      │    └── locking: for-share
       └── filters
            └── t2.a:1 = u2.a:5
 
@@ -747,10 +747,10 @@ project
       ├── columns: t.a:1!null b:2 t.crdb_internal_mvcc_timestamp:3 t.tableoid:4 u.a:5!null c:6 u.crdb_internal_mvcc_timestamp:7 u.tableoid:8
       ├── scan t
       │    ├── columns: t.a:1!null b:2 t.crdb_internal_mvcc_timestamp:3 t.tableoid:4
-      │    └── locking: for-update,durability-guaranteed
+      │    └── locking: for-update
       ├── scan u
       │    ├── columns: u.a:5!null c:6 u.crdb_internal_mvcc_timestamp:7 u.tableoid:8
-      │    └── locking: for-update,durability-guaranteed
+      │    └── locking: for-update
       └── filters
            └── t.a:1 = u.a:5
 
@@ -763,10 +763,10 @@ project
       ├── columns: t.a:1!null b:2 t.crdb_internal_mvcc_timestamp:3 t.tableoid:4 u.a:5!null c:6 u.crdb_internal_mvcc_timestamp:7 u.tableoid:8
       ├── scan t
       │    ├── columns: t.a:1!null b:2 t.crdb_internal_mvcc_timestamp:3 t.tableoid:4
-      │    └── locking: for-no-key-update,durability-guaranteed
+      │    └── locking: for-no-key-update
       ├── scan u
       │    ├── columns: u.a:5!null c:6 u.crdb_internal_mvcc_timestamp:7 u.tableoid:8
-      │    └── locking: for-key-share,durability-guaranteed
+      │    └── locking: for-key-share
       └── filters
            └── t.a:1 = u.a:5
 
@@ -779,10 +779,10 @@ project
       ├── columns: t.a:1!null b:2 t.crdb_internal_mvcc_timestamp:3 t.tableoid:4 u.a:5!null c:6 u.crdb_internal_mvcc_timestamp:7 u.tableoid:8
       ├── scan t
       │    ├── columns: t.a:1!null b:2 t.crdb_internal_mvcc_timestamp:3 t.tableoid:4
-      │    └── locking: for-no-key-update,durability-guaranteed
+      │    └── locking: for-no-key-update
       ├── scan u
       │    ├── columns: u.a:5!null c:6 u.crdb_internal_mvcc_timestamp:7 u.tableoid:8
-      │    └── locking: for-update,durability-guaranteed
+      │    └── locking: for-update
       └── filters
            └── t.a:1 = u.a:5
 
@@ -799,10 +799,10 @@ project
       ├── columns: t2.a:1!null b:2 t2.crdb_internal_mvcc_timestamp:3 t2.tableoid:4 u2.a:5!null c:6 u2.crdb_internal_mvcc_timestamp:7 u2.tableoid:8
       ├── scan t [as=t2]
       │    ├── columns: t2.a:1!null b:2 t2.crdb_internal_mvcc_timestamp:3 t2.tableoid:4
-      │    └── locking: for-update,durability-guaranteed
+      │    └── locking: for-update
       ├── scan u [as=u2]
       │    ├── columns: u2.a:5!null c:6 u2.crdb_internal_mvcc_timestamp:7 u2.tableoid:8
-      │    └── locking: for-update,durability-guaranteed
+      │    └── locking: for-update
       └── filters
            └── t2.a:1 = u2.a:5
 
@@ -830,7 +830,7 @@ project
       ├── columns: t2.a:1!null b:2 t2.crdb_internal_mvcc_timestamp:3 t2.tableoid:4 u2.a:5!null c:6 u2.crdb_internal_mvcc_timestamp:7 u2.tableoid:8
       ├── scan t [as=t2]
       │    ├── columns: t2.a:1!null b:2 t2.crdb_internal_mvcc_timestamp:3 t2.tableoid:4
-      │    └── locking: for-update,durability-guaranteed
+      │    └── locking: for-update
       ├── scan u [as=u2]
       │    └── columns: u2.a:5!null c:6 u2.crdb_internal_mvcc_timestamp:7 u2.tableoid:8
       └── filters
@@ -847,7 +847,7 @@ project
       │    └── columns: t2.a:1!null b:2 t2.crdb_internal_mvcc_timestamp:3 t2.tableoid:4
       ├── scan u [as=u2]
       │    ├── columns: u2.a:5!null c:6 u2.crdb_internal_mvcc_timestamp:7 u2.tableoid:8
-      │    └── locking: for-update,durability-guaranteed
+      │    └── locking: for-update
       └── filters
            └── t2.a:1 = u2.a:5
 
@@ -860,10 +860,10 @@ project
       ├── columns: t2.a:1!null b:2 t2.crdb_internal_mvcc_timestamp:3 t2.tableoid:4 u2.a:5!null c:6 u2.crdb_internal_mvcc_timestamp:7 u2.tableoid:8
       ├── scan t [as=t2]
       │    ├── columns: t2.a:1!null b:2 t2.crdb_internal_mvcc_timestamp:3 t2.tableoid:4
-      │    └── locking: for-update,durability-guaranteed
+      │    └── locking: for-update
       ├── scan u [as=u2]
       │    ├── columns: u2.a:5!null c:6 u2.crdb_internal_mvcc_timestamp:7 u2.tableoid:8
-      │    └── locking: for-update,durability-guaranteed
+      │    └── locking: for-update
       └── filters
            └── t2.a:1 = u2.a:5
 
@@ -881,10 +881,10 @@ project
       ├── columns: t.a:1!null b:2 t.crdb_internal_mvcc_timestamp:3 t.tableoid:4 u2.a:5!null c:6 u2.crdb_internal_mvcc_timestamp:7 u2.tableoid:8
       ├── scan t
       │    ├── columns: t.a:1!null b:2 t.crdb_internal_mvcc_timestamp:3 t.tableoid:4
-      │    └── locking: for-update,durability-guaranteed
+      │    └── locking: for-update
       ├── scan u [as=u2]
       │    ├── columns: u2.a:5!null c:6 u2.crdb_internal_mvcc_timestamp:7 u2.tableoid:8
-      │    └── locking: for-update,durability-guaranteed
+      │    └── locking: for-update
       └── filters
            └── t.a:1 = u2.a:5
 
@@ -912,10 +912,10 @@ project
       ├── columns: t.a:1!null b:2 t.crdb_internal_mvcc_timestamp:3 t.tableoid:4 u2.a:5!null c:6 u2.crdb_internal_mvcc_timestamp:7 u2.tableoid:8
       ├── scan t
       │    ├── columns: t.a:1!null b:2 t.crdb_internal_mvcc_timestamp:3 t.tableoid:4
-      │    └── locking: for-update,durability-guaranteed
+      │    └── locking: for-update
       ├── scan u [as=u2]
       │    ├── columns: u2.a:5!null c:6 u2.crdb_internal_mvcc_timestamp:7 u2.tableoid:8
-      │    └── locking: for-update,durability-guaranteed
+      │    └── locking: for-update
       └── filters
            └── t.a:1 = u2.a:5
 
@@ -932,10 +932,10 @@ project
       ├── columns: t.a:1!null b:2 t.crdb_internal_mvcc_timestamp:3 t.tableoid:4 u.a:5!null c:6 u.crdb_internal_mvcc_timestamp:7 u.tableoid:8
       ├── scan t
       │    ├── columns: t.a:1!null b:2 t.crdb_internal_mvcc_timestamp:3 t.tableoid:4
-      │    └── locking: for-update,durability-guaranteed
+      │    └── locking: for-update
       ├── scan u
       │    ├── columns: u.a:5!null c:6 u.crdb_internal_mvcc_timestamp:7 u.tableoid:8
-      │    └── locking: for-update,durability-guaranteed
+      │    └── locking: for-update
       └── filters (true)
 
 build
@@ -947,7 +947,7 @@ project
       ├── columns: t.a:1!null b:2 t.crdb_internal_mvcc_timestamp:3 t.tableoid:4 u.a:5!null c:6 u.crdb_internal_mvcc_timestamp:7 u.tableoid:8
       ├── scan t
       │    ├── columns: t.a:1!null b:2 t.crdb_internal_mvcc_timestamp:3 t.tableoid:4
-      │    └── locking: for-update,durability-guaranteed
+      │    └── locking: for-update
       ├── scan u
       │    └── columns: u.a:5!null c:6 u.crdb_internal_mvcc_timestamp:7 u.tableoid:8
       └── filters (true)
@@ -961,10 +961,10 @@ project
       ├── columns: t.a:1!null b:2 t.crdb_internal_mvcc_timestamp:3 t.tableoid:4 u.a:5!null c:6 u.crdb_internal_mvcc_timestamp:7 u.tableoid:8
       ├── scan t
       │    ├── columns: t.a:1!null b:2 t.crdb_internal_mvcc_timestamp:3 t.tableoid:4
-      │    └── locking: for-share,durability-guaranteed
+      │    └── locking: for-share
       ├── scan u
       │    ├── columns: u.a:5!null c:6 u.crdb_internal_mvcc_timestamp:7 u.tableoid:8
-      │    └── locking: for-update,durability-guaranteed
+      │    └── locking: for-update
       └── filters (true)
 
 build
@@ -976,12 +976,12 @@ project
       ├── columns: t.a:1!null b:2 t.crdb_internal_mvcc_timestamp:3 t.tableoid:4 u.a:5!null c:6
       ├── scan t
       │    ├── columns: t.a:1!null b:2 t.crdb_internal_mvcc_timestamp:3 t.tableoid:4
-      │    └── locking: for-update,durability-guaranteed
+      │    └── locking: for-update
       ├── project
       │    ├── columns: u.a:5!null c:6
       │    └── scan u
       │         ├── columns: u.a:5!null c:6 u.crdb_internal_mvcc_timestamp:7 u.tableoid:8
-      │         └── locking: for-update,durability-guaranteed
+      │         └── locking: for-update
       └── filters (true)
 
 build
@@ -1002,7 +1002,7 @@ project
       │    ├── columns: u.a:5!null c:6
       │    └── scan u
       │         ├── columns: u.a:5!null c:6 u.crdb_internal_mvcc_timestamp:7 u.tableoid:8
-      │         └── locking: for-update,durability-guaranteed
+      │         └── locking: for-update
       └── filters (true)
 
 # ------------------------------------------------------------------------------
@@ -1027,7 +1027,7 @@ project
       ├── columns: a:1!null b:2!null c:3 crdb_internal_mvcc_timestamp:4 tableoid:5
       ├── scan indexed
       │    ├── columns: a:1!null b:2 c:3 crdb_internal_mvcc_timestamp:4 tableoid:5
-      │    └── locking: for-update,durability-guaranteed
+      │    └── locking: for-update
       └── filters
            └── b:2 = 2
 
@@ -1040,7 +1040,7 @@ project
       ├── columns: a:1!null b:2!null c:3 crdb_internal_mvcc_timestamp:4 tableoid:5
       ├── scan indexed
       │    ├── columns: a:1!null b:2 c:3 crdb_internal_mvcc_timestamp:4 tableoid:5
-      │    └── locking: for-update,durability-guaranteed
+      │    └── locking: for-update
       └── filters
            └── (b:2 >= 2) AND (b:2 <= 10)
 
@@ -1059,10 +1059,10 @@ project
       │    ├── columns: t.a:1!null b:2!null t.crdb_internal_mvcc_timestamp:3 t.tableoid:4 u.a:5!null c:6 u.crdb_internal_mvcc_timestamp:7 u.tableoid:8
       │    ├── scan t
       │    │    ├── columns: t.a:1!null b:2 t.crdb_internal_mvcc_timestamp:3 t.tableoid:4
-      │    │    └── locking: for-update,durability-guaranteed
+      │    │    └── locking: for-update
       │    ├── scan u
       │    │    ├── columns: u.a:5!null c:6 u.crdb_internal_mvcc_timestamp:7 u.tableoid:8
-      │    │    └── locking: for-update,durability-guaranteed
+      │    │    └── locking: for-update
       │    └── filters
       │         └── b:2 = u.a:5
       └── filters
@@ -1079,10 +1079,10 @@ project
       │    ├── columns: t.a:1!null b:2!null t.crdb_internal_mvcc_timestamp:3 t.tableoid:4 u.a:5!null c:6 u.crdb_internal_mvcc_timestamp:7 u.tableoid:8
       │    ├── scan t
       │    │    ├── columns: t.a:1!null b:2 t.crdb_internal_mvcc_timestamp:3 t.tableoid:4
-      │    │    └── locking: for-update,durability-guaranteed
+      │    │    └── locking: for-update
       │    ├── scan u
       │    │    ├── columns: u.a:5!null c:6 u.crdb_internal_mvcc_timestamp:7 u.tableoid:8
-      │    │    └── locking: for-update,durability-guaranteed
+      │    │    └── locking: for-update
       │    └── filters
       │         └── b:2 = u.a:5
       └── filters
@@ -1099,10 +1099,10 @@ project
       │    ├── columns: t.a:1!null t.b:2!null t.crdb_internal_mvcc_timestamp:3 t.tableoid:4 indexed.a:5!null indexed.b:6!null c:7 indexed.crdb_internal_mvcc_timestamp:8 indexed.tableoid:9
       │    ├── scan t
       │    │    ├── columns: t.a:1!null t.b:2 t.crdb_internal_mvcc_timestamp:3 t.tableoid:4
-      │    │    └── locking: for-update,durability-guaranteed
+      │    │    └── locking: for-update
       │    ├── scan indexed
       │    │    ├── columns: indexed.a:5!null indexed.b:6 c:7 indexed.crdb_internal_mvcc_timestamp:8 indexed.tableoid:9
-      │    │    └── locking: for-update,durability-guaranteed
+      │    │    └── locking: for-update
       │    └── filters
       │         └── t.b:2 = indexed.b:6
       └── filters
@@ -1130,7 +1130,7 @@ project
       ├── columns: a:1!null b:2!null c:3 crdb_internal_mvcc_timestamp:4 tableoid:5
       ├── scan inverted
       │    ├── columns: a:1!null b:2 c:3 crdb_internal_mvcc_timestamp:4 tableoid:5
-      │    └── locking: for-update,durability-guaranteed
+      │    └── locking: for-update
       └── filters
            └── b:2 @> ARRAY[1,2]
 
@@ -1143,7 +1143,7 @@ project
       ├── columns: a:1!null b:2 c:3 crdb_internal_mvcc_timestamp:4 tableoid:5
       ├── scan inverted
       │    ├── columns: a:1!null b:2 c:3 crdb_internal_mvcc_timestamp:4 tableoid:5
-      │    └── locking: for-update,durability-guaranteed
+      │    └── locking: for-update
       └── filters
            └── b:2 <@ ARRAY[1,2]
 
@@ -1159,10 +1159,10 @@ project
       │    ├── scan inverted [as=i1]
       │    │    ├── columns: i1.a:1!null i1.b:2 i1.c:3 i1.crdb_internal_mvcc_timestamp:4 i1.tableoid:5
       │    │    ├── flags: force-index=b_inv
-      │    │    └── locking: for-update,durability-guaranteed
+      │    │    └── locking: for-update
       │    ├── scan inverted [as=i2]
       │    │    ├── columns: i2.a:7!null i2.b:8 i2.c:9 i2.crdb_internal_mvcc_timestamp:10 i2.tableoid:11
-      │    │    └── locking: for-update,durability-guaranteed
+      │    │    └── locking: for-update
       │    └── filters (true)
       └── filters
            └── i1.b:2 @> i2.b:8
@@ -1192,7 +1192,7 @@ project
       ├── columns: a:1!null b:2!null c:3!null d:4 crdb_internal_mvcc_timestamp:5 tableoid:6
       ├── scan zigzag
       │    ├── columns: a:1!null b:2 c:3 d:4 crdb_internal_mvcc_timestamp:5 tableoid:6
-      │    └── locking: for-update,durability-guaranteed
+      │    └── locking: for-update
       └── filters
            └── (b:2 = 5) AND (c:3 = 6.0)
 
@@ -1205,7 +1205,7 @@ project
       ├── columns: a:1!null b:2 c:3 d:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
       ├── scan zigzag
       │    ├── columns: a:1!null b:2 c:3 d:4 crdb_internal_mvcc_timestamp:5 tableoid:6
-      │    └── locking: for-update,durability-guaranteed
+      │    └── locking: for-update
       └── filters
            └── d:4 @> '{"a": {"b": "c"}, "f": "g"}'
 
@@ -1229,7 +1229,7 @@ project
  ├── columns: a:1!null b:2
  └── scan t
       ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
-      └── locking: for-update,nowait,durability-guaranteed
+      └── locking: for-update,nowait
 
 build
 SELECT * FROM t FOR NO KEY UPDATE NOWAIT
@@ -1238,7 +1238,7 @@ project
  ├── columns: a:1!null b:2
  └── scan t
       ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
-      └── locking: for-no-key-update,nowait,durability-guaranteed
+      └── locking: for-no-key-update,nowait
 
 build
 SELECT * FROM t FOR SHARE NOWAIT
@@ -1247,7 +1247,7 @@ project
  ├── columns: a:1!null b:2
  └── scan t
       ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
-      └── locking: for-share,nowait,durability-guaranteed
+      └── locking: for-share,nowait
 
 build
 SELECT * FROM t FOR KEY SHARE NOWAIT
@@ -1256,7 +1256,7 @@ project
  ├── columns: a:1!null b:2
  └── scan t
       ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
-      └── locking: for-key-share,nowait,durability-guaranteed
+      └── locking: for-key-share,nowait
 
 build
 SELECT * FROM t FOR KEY SHARE FOR SHARE NOWAIT
@@ -1265,7 +1265,7 @@ project
  ├── columns: a:1!null b:2
  └── scan t
       ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
-      └── locking: for-share,nowait,durability-guaranteed
+      └── locking: for-share,nowait
 
 build
 SELECT * FROM t FOR KEY SHARE FOR SHARE NOWAIT FOR NO KEY UPDATE
@@ -1274,7 +1274,7 @@ project
  ├── columns: a:1!null b:2
  └── scan t
       ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
-      └── locking: for-no-key-update,nowait,durability-guaranteed
+      └── locking: for-no-key-update,nowait
 
 build
 SELECT * FROM t FOR KEY SHARE FOR SHARE NOWAIT FOR NO KEY UPDATE FOR UPDATE NOWAIT
@@ -1283,7 +1283,7 @@ project
  ├── columns: a:1!null b:2
  └── scan t
       ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
-      └── locking: for-update,nowait,durability-guaranteed
+      └── locking: for-update,nowait
 
 build
 SELECT * FROM t FOR UPDATE OF t NOWAIT
@@ -1292,7 +1292,7 @@ project
  ├── columns: a:1!null b:2
  └── scan t
       ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
-      └── locking: for-update,nowait,durability-guaranteed
+      └── locking: for-update,nowait
 
 build
 SELECT * FROM t FOR UPDATE OF t2 NOWAIT
@@ -1306,7 +1306,7 @@ project
  ├── columns: "?column?":5!null
  ├── scan t
  │    ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
- │    └── locking: for-update,nowait,durability-guaranteed
+ │    └── locking: for-update,nowait
  └── projections
       └── 1 [as="?column?":5]
 
@@ -1321,7 +1321,7 @@ project
  ├── columns: a:1!null b:2
  └── scan t
       ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
-      └── locking: for-update,skip-locked,durability-guaranteed
+      └── locking: for-update,skip-locked
 
 build
 SELECT * FROM t FOR NO KEY UPDATE SKIP LOCKED
@@ -1330,7 +1330,7 @@ project
  ├── columns: a:1!null b:2
  └── scan t
       ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
-      └── locking: for-no-key-update,skip-locked,durability-guaranteed
+      └── locking: for-no-key-update,skip-locked
 
 build
 SELECT * FROM t FOR SHARE SKIP LOCKED
@@ -1339,7 +1339,7 @@ project
  ├── columns: a:1!null b:2
  └── scan t
       ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
-      └── locking: for-share,skip-locked,durability-guaranteed
+      └── locking: for-share,skip-locked
 
 build
 SELECT * FROM t FOR KEY SHARE SKIP LOCKED
@@ -1348,7 +1348,7 @@ project
  ├── columns: a:1!null b:2
  └── scan t
       ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
-      └── locking: for-key-share,skip-locked,durability-guaranteed
+      └── locking: for-key-share,skip-locked
 
 build
 SELECT * FROM t FOR KEY SHARE FOR SHARE SKIP LOCKED
@@ -1357,7 +1357,7 @@ project
  ├── columns: a:1!null b:2
  └── scan t
       ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
-      └── locking: for-share,skip-locked,durability-guaranteed
+      └── locking: for-share,skip-locked
 
 build
 SELECT * FROM t FOR KEY SHARE FOR SHARE SKIP LOCKED FOR NO KEY UPDATE
@@ -1366,7 +1366,7 @@ project
  ├── columns: a:1!null b:2
  └── scan t
       ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
-      └── locking: for-no-key-update,skip-locked,durability-guaranteed
+      └── locking: for-no-key-update,skip-locked
 
 build
 SELECT * FROM t FOR KEY SHARE FOR SHARE SKIP LOCKED FOR NO KEY UPDATE FOR UPDATE SKIP LOCKED
@@ -1375,7 +1375,7 @@ project
  ├── columns: a:1!null b:2
  └── scan t
       ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
-      └── locking: for-update,skip-locked,durability-guaranteed
+      └── locking: for-update,skip-locked
 
 build
 SELECT * FROM t FOR UPDATE OF t SKIP LOCKED
@@ -1384,7 +1384,7 @@ project
  ├── columns: a:1!null b:2
  └── scan t
       ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
-      └── locking: for-update,skip-locked,durability-guaranteed
+      └── locking: for-update,skip-locked
 
 build
 SELECT * FROM t FOR UPDATE OF t2 SKIP LOCKED
@@ -1398,7 +1398,7 @@ project
  ├── columns: "?column?":5!null
  ├── scan t
  │    ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
- │    └── locking: for-update,skip-locked,durability-guaranteed
+ │    └── locking: for-update,skip-locked
  └── projections
       └── 1 [as="?column?":5]
 

--- a/pkg/sql/opt/xform/testdata/external/tpce
+++ b/pkg/sql/opt/xform/testdata/external/tpce
@@ -3529,7 +3529,7 @@ project
  │    │    ├── scan trade
  │    │    │    ├── columns: t_id:1!null t_tt_id:4!null t_is_cash:5!null t_s_symb:6!null t_qty:7!null t_ca_id:9!null trade.t_chrg:12!null t_lifo:15!null
  │    │    │    ├── constraint: /1: [/0 - /0]
- │    │    │    ├── locking: for-update,durability-guaranteed
+ │    │    │    ├── locking: for-update
  │    │    │    ├── cardinality: [0 - 1]
  │    │    │    ├── volatile
  │    │    │    ├── key: ()
@@ -3586,7 +3586,7 @@ project
  │    │    ├── scan trade
  │    │    │    ├── columns: t_id:1!null t_tt_id:4!null t_is_cash:5!null t_s_symb:6!null t_qty:7!null t_ca_id:9!null trade.t_chrg:12!null t_lifo:15!null
  │    │    │    ├── constraint: /1: [/0 - /0]
- │    │    │    ├── locking: for-update,durability-guaranteed
+ │    │    │    ├── locking: for-update
  │    │    │    ├── cardinality: [0 - 1]
  │    │    │    ├── volatile
  │    │    │    ├── key: ()

--- a/pkg/sql/opt/xform/testdata/external/tpce-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpce-no-stats
@@ -3559,7 +3559,7 @@ project
  │    │    ├── scan trade
  │    │    │    ├── columns: t_id:1!null t_tt_id:4!null t_is_cash:5!null t_s_symb:6!null t_qty:7!null t_ca_id:9!null trade.t_chrg:12!null t_lifo:15!null
  │    │    │    ├── constraint: /1: [/0 - /0]
- │    │    │    ├── locking: for-update,durability-guaranteed
+ │    │    │    ├── locking: for-update
  │    │    │    ├── cardinality: [0 - 1]
  │    │    │    ├── volatile
  │    │    │    ├── key: ()
@@ -3616,7 +3616,7 @@ project
  │    │    ├── scan trade
  │    │    │    ├── columns: t_id:1!null t_tt_id:4!null t_is_cash:5!null t_s_symb:6!null t_qty:7!null t_ca_id:9!null trade.t_chrg:12!null t_lifo:15!null
  │    │    │    ├── constraint: /1: [/0 - /0]
- │    │    │    ├── locking: for-update,durability-guaranteed
+ │    │    │    ├── locking: for-update
  │    │    │    ├── cardinality: [0 - 1]
  │    │    │    ├── volatile
  │    │    │    ├── key: ()

--- a/pkg/sql/opt/xform/testdata/placeholder-fast-path/scan
+++ b/pkg/sql/opt/xform/testdata/placeholder-fast-path/scan
@@ -41,7 +41,7 @@ SELECT * FROM kv WHERE k = $1 FOR UPDATE
 ----
 placeholder-scan kv
  ├── columns: k:1!null v:2
- ├── locking: for-update,durability-guaranteed
+ ├── locking: for-update
  ├── cardinality: [0 - 1]
  ├── volatile, has-placeholder
  ├── stats: [rows=1, distinct(1)=1, null(1)=0]

--- a/pkg/sql/opt/xform/testdata/rules/limit
+++ b/pkg/sql/opt/xform/testdata/rules/limit
@@ -255,7 +255,7 @@ SELECT * FROM a LIMIT 1 FOR UPDATE
 scan a
  ├── columns: k:1!null i:2 f:3 s:4 j:5
  ├── limit: 1
- ├── locking: for-update,durability-guaranteed
+ ├── locking: for-update
  ├── volatile
  ├── key: ()
  └── fd: ()-->(1-5)
@@ -268,7 +268,7 @@ scan a@s_idx
  ├── columns: s:4!null
  ├── constraint: /4/1: [/'foo' - /'foo']
  ├── limit: 1
- ├── locking: for-update,durability-guaranteed
+ ├── locking: for-update
  ├── volatile
  ├── key: ()
  └── fd: ()-->(4)
@@ -352,7 +352,7 @@ limit
  ├── ordering: +2 opt(1) [actual: +2]
  ├── index-join kuv
  │    ├── columns: k:1!null u:2 v:3
- │    ├── locking: for-update,skip-locked,durability-guaranteed
+ │    ├── locking: for-update,skip-locked
  │    ├── volatile
  │    ├── fd: ()-->(1)
  │    ├── ordering: +2 opt(1) [actual: +2]
@@ -360,7 +360,7 @@ limit
  │    └── scan kuv@kuv_k_u_idx
  │         ├── columns: k:1!null u:2 rowid:4!null
  │         ├── constraint: /1/2/4: [/1 - /1]
- │         ├── locking: for-update,skip-locked,durability-guaranteed
+ │         ├── locking: for-update,skip-locked
  │         ├── volatile
  │         ├── key: (4)
  │         ├── fd: ()-->(1), (4)-->(2)
@@ -884,7 +884,7 @@ top-k
  ├── ordering: +2
  └── scan kuv
       ├── columns: k:1 u:2 v:3
-      ├── locking: for-update,durability-guaranteed
+      ├── locking: for-update
       └── volatile
 
 # -------------------------

--- a/pkg/sql/opt/xform/testdata/rules/scan
+++ b/pkg/sql/opt/xform/testdata/rules/scan
@@ -369,7 +369,7 @@ SELECT s, i, f FROM a ORDER BY s FOR UPDATE
 ----
 scan a@s_idx
  ├── columns: s:4 i:2 f:3
- ├── locking: for-update,durability-guaranteed
+ ├── locking: for-update
  ├── volatile
  └── ordering: +4
 

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -1145,7 +1145,7 @@ SELECT k FROM a WHERE k = 1 FOR UPDATE
 scan a
  ├── columns: k:1!null
  ├── constraint: /1: [/1 - /1]
- ├── locking: for-update,durability-guaranteed
+ ├── locking: for-update
  ├── cardinality: [0 - 1]
  ├── volatile
  ├── key: ()
@@ -1156,7 +1156,7 @@ SELECT * FROM b WHERE v >= 1 AND v <= 10 FOR UPDATE
 ----
 index-join b
  ├── columns: k:1!null u:2 v:3!null j:4
- ├── locking: for-update,durability-guaranteed
+ ├── locking: for-update
  ├── cardinality: [0 - 10]
  ├── volatile
  ├── key: (1)
@@ -1164,7 +1164,7 @@ index-join b
  └── scan b@v
       ├── columns: k:1!null v:3!null
       ├── constraint: /3: [/1 - /10]
-      ├── locking: for-update,durability-guaranteed
+      ├── locking: for-update
       ├── cardinality: [0 - 10]
       ├── volatile
       ├── key: (1)
@@ -1181,7 +1181,7 @@ select
  ├── fd: (1)-->(2-4), (3)-->(1,2,4)
  ├── index-join b
  │    ├── columns: k:1!null u:2 v:3 j:4
- │    ├── locking: for-update,durability-guaranteed
+ │    ├── locking: for-update
  │    ├── cardinality: [0 - 10]
  │    ├── volatile
  │    ├── key: (1)
@@ -1189,7 +1189,7 @@ select
  │    └── scan b@v
  │         ├── columns: k:1!null v:3!null
  │         ├── constraint: /3: [/1 - /10]
- │         ├── locking: for-update,durability-guaranteed
+ │         ├── locking: for-update
  │         ├── cardinality: [0 - 10]
  │         ├── volatile
  │         ├── key: (1)
@@ -5219,7 +5219,7 @@ project
       ├── columns: k:1!null
       ├── inverted constraint: /7/1
       │    └── spans: ["7a\x00\x01\x12b\x00\x01", "7a\x00\x01\x12b\x00\x01"]
-      ├── locking: for-update,durability-guaranteed
+      ├── locking: for-update
       ├── volatile
       └── key: (1)
 
@@ -9127,8 +9127,8 @@ inner-join (zigzag pqr@q pqr@r)
  ├── eq columns: [1] = [1]
  ├── left fixed columns: [2] = [1]
  ├── right fixed columns: [3] = [2]
- ├── left locking: for-update,durability-guaranteed
- ├── right locking: for-update,durability-guaranteed
+ ├── left locking: for-update
+ ├── right locking: for-update
  ├── volatile
  ├── fd: ()-->(2,3)
  └── filters
@@ -9605,7 +9605,7 @@ inner-join (lookup b)
  ├── columns: k:1!null u:2 v:3 j:4!null
  ├── key columns: [1] = [1]
  ├── lookup columns are key
- ├── locking: for-update,durability-guaranteed
+ ├── locking: for-update
  ├── volatile
  ├── key: (1)
  ├── fd: (1)-->(2-4), (3)~~>(1,2,4)
@@ -9614,8 +9614,8 @@ inner-join (lookup b)
  │    ├── eq columns: [1] = [1]
  │    ├── left fixed columns: [9] = ['\x376100012a0200']
  │    ├── right fixed columns: [9] = ['\x376300012a0400']
- │    ├── left locking: for-update,durability-guaranteed
- │    ├── right locking: for-update,durability-guaranteed
+ │    ├── left locking: for-update
+ │    ├── right locking: for-update
  │    └── filters (true)
  └── filters (true)
 

--- a/pkg/sql/opt/xform/testdata/rules/select_for_update
+++ b/pkg/sql/opt/xform/testdata/rules/select_for_update
@@ -24,14 +24,14 @@ SELECT * FROM indexed WHERE b = 2 FOR UPDATE
 ----
 index-join indexed
  ├── columns: a:1!null b:2!null c:3
- ├── locking: for-update,durability-guaranteed
+ ├── locking: for-update
  ├── volatile
  ├── key: (1)
  ├── fd: ()-->(2), (1)-->(3)
  └── scan indexed@b_idx
       ├── columns: a:1!null b:2!null
       ├── constraint: /2/1: [/2 - /2]
-      ├── locking: for-update,durability-guaranteed
+      ├── locking: for-update
       ├── volatile
       ├── key: (1)
       └── fd: ()-->(2)
@@ -41,14 +41,14 @@ SELECT * FROM indexed WHERE b BETWEEN 2 AND 10 FOR UPDATE
 ----
 index-join indexed
  ├── columns: a:1!null b:2!null c:3
- ├── locking: for-update,durability-guaranteed
+ ├── locking: for-update
  ├── volatile
  ├── key: (1)
  ├── fd: (1)-->(2,3)
  └── scan indexed@b_idx
       ├── columns: a:1!null b:2!null
       ├── constraint: /2/1: [/2 - /10]
-      ├── locking: for-update,durability-guaranteed
+      ├── locking: for-update
       ├── volatile
       ├── key: (1)
       └── fd: (1)-->(2)
@@ -70,7 +70,7 @@ project
       ├── columns: t.a:1!null b:2!null u.a:5!null c:6
       ├── key columns: [2] = [5]
       ├── lookup columns are key
-      ├── locking: for-update,durability-guaranteed
+      ├── locking: for-update
       ├── cardinality: [0 - 1]
       ├── volatile
       ├── key: ()
@@ -78,7 +78,7 @@ project
       ├── scan t
       │    ├── columns: t.a:1!null b:2
       │    ├── constraint: /1: [/2 - /2]
-      │    ├── locking: for-update,durability-guaranteed
+      │    ├── locking: for-update
       │    ├── cardinality: [0 - 1]
       │    ├── volatile
       │    ├── key: ()
@@ -96,7 +96,7 @@ project
       ├── columns: t.a:1!null b:2!null u.a:5!null c:6
       ├── key columns: [2] = [5]
       ├── lookup columns are key
-      ├── locking: for-update,durability-guaranteed
+      ├── locking: for-update
       ├── cardinality: [0 - 9]
       ├── volatile
       ├── key: (1)
@@ -104,7 +104,7 @@ project
       ├── scan t
       │    ├── columns: t.a:1!null b:2
       │    ├── constraint: /1: [/2 - /10]
-      │    ├── locking: for-update,durability-guaranteed
+      │    ├── locking: for-update
       │    ├── cardinality: [0 - 9]
       │    ├── volatile
       │    ├── key: (1)
@@ -118,21 +118,21 @@ inner-join (lookup indexed)
  ├── columns: a:1!null b:2!null a:5!null b:6!null c:7
  ├── key columns: [5] = [5]
  ├── lookup columns are key
- ├── locking: for-update,durability-guaranteed
+ ├── locking: for-update
  ├── volatile
  ├── key: (5)
  ├── fd: ()-->(1,2,6), (5)-->(7), (2)==(6), (6)==(2)
  ├── inner-join (lookup indexed@b_idx)
  │    ├── columns: t.a:1!null t.b:2!null indexed.a:5!null indexed.b:6!null
  │    ├── key columns: [2] = [6]
- │    ├── locking: for-update,durability-guaranteed
+ │    ├── locking: for-update
  │    ├── volatile
  │    ├── key: (5)
  │    ├── fd: ()-->(1,2,6), (2)==(6), (6)==(2)
  │    ├── scan t
  │    │    ├── columns: t.a:1!null t.b:2
  │    │    ├── constraint: /1: [/2 - /2]
- │    │    ├── locking: for-update,durability-guaranteed
+ │    │    ├── locking: for-update
  │    │    ├── cardinality: [0 - 1]
  │    │    ├── volatile
  │    │    ├── key: ()
@@ -160,7 +160,7 @@ inner-join (lookup inverted)
  ├── columns: a:1!null b:2!null c:3
  ├── key columns: [1] = [1]
  ├── lookup columns are key
- ├── locking: for-update,durability-guaranteed
+ ├── locking: for-update
  ├── volatile
  ├── key: (1)
  ├── fd: (1)-->(2,3)
@@ -169,8 +169,8 @@ inner-join (lookup inverted)
  │    ├── eq columns: [1] = [1]
  │    ├── left fixed columns: [6] = ['\x89']
  │    ├── right fixed columns: [6] = ['\x8a']
- │    ├── left locking: for-update,durability-guaranteed
- │    ├── right locking: for-update,durability-guaranteed
+ │    ├── left locking: for-update
+ │    ├── right locking: for-update
  │    └── filters (true)
  └── filters (true)
 
@@ -184,7 +184,7 @@ select
  ├── fd: (1)-->(2,3)
  ├── index-join inverted
  │    ├── columns: a:1!null b:2 c:3
- │    ├── locking: for-update,durability-guaranteed
+ │    ├── locking: for-update
  │    ├── volatile
  │    ├── key: (1)
  │    ├── fd: (1)-->(2,3)
@@ -203,7 +203,7 @@ select
  │              │    └── spans
  │              │         ├── ["C", "C"]
  │              │         └── ["\x89", "\x8b")
- │              ├── locking: for-update,durability-guaranteed
+ │              ├── locking: for-update
  │              ├── volatile
  │              ├── key: (1)
  │              └── fd: (1)-->(6)
@@ -217,7 +217,7 @@ inner-join (lookup inverted [as=i1])
  ├── columns: a:1!null b:2 c:3 a:7!null b:8 c:9
  ├── key columns: [19] = [1]
  ├── lookup columns are key
- ├── locking: for-update,durability-guaranteed
+ ├── locking: for-update
  ├── volatile
  ├── key: (1,7)
  ├── fd: (1)-->(2,3), (7)-->(8,9)
@@ -225,13 +225,13 @@ inner-join (lookup inverted [as=i1])
  │    ├── columns: i2.a:7!null i2.b:8 i2.c:9 i1.a:19!null
  │    ├── inverted-expr
  │    │    └── i1.b:20 @> i2.b:8
- │    ├── locking: for-update,durability-guaranteed
+ │    ├── locking: for-update
  │    ├── volatile
  │    ├── key: (7,19)
  │    ├── fd: (7)-->(8,9)
  │    ├── scan inverted [as=i2]
  │    │    ├── columns: i2.a:7!null i2.b:8 i2.c:9
- │    │    ├── locking: for-update,durability-guaranteed
+ │    │    ├── locking: for-update
  │    │    ├── volatile
  │    │    ├── key: (7)
  │    │    └── fd: (7)-->(8,9)
@@ -263,8 +263,8 @@ inner-join (zigzag zigzag@b_idx zigzag@c_idx)
  ├── eq columns: [1] = [1]
  ├── left fixed columns: [2] = [5]
  ├── right fixed columns: [3] = [6.0]
- ├── left locking: for-update,durability-guaranteed
- ├── right locking: for-update,durability-guaranteed
+ ├── left locking: for-update
+ ├── right locking: for-update
  ├── volatile
  ├── key: (1)
  ├── fd: ()-->(2,3)
@@ -279,7 +279,7 @@ inner-join (lookup zigzag)
  ├── columns: a:1!null b:2 c:3 d:4!null
  ├── key columns: [1] = [1]
  ├── lookup columns are key
- ├── locking: for-update,durability-guaranteed
+ ├── locking: for-update
  ├── volatile
  ├── key: (1)
  ├── fd: (1)-->(2-4)
@@ -288,7 +288,7 @@ inner-join (lookup zigzag)
  │    ├── eq columns: [1] = [1]
  │    ├── left fixed columns: [7] = ['\x3761000262000112630001']
  │    ├── right fixed columns: [7] = ['\x3766000112670001']
- │    ├── left locking: for-update,durability-guaranteed
- │    ├── right locking: for-update,durability-guaranteed
+ │    ├── left locking: for-update
+ │    ├── right locking: for-update
  │    └── filters (true)
  └── filters (true)


### PR DESCRIPTION
In #110945 I moved the locking durability check from optbuilder to execbuilder to allow a memo prepared under serializable isolation to execute under read committed isolation. As it turns out, however, memo staleness prevents this. Move the durability check back to optbuilder.

We have to keep the shared locking check in execbuilder to correctly throw errors if shared locking is used in a read-only transaction.

Informs: #100194

Release note: None