### PR TITLE
util/encoding: fix typo in TestKeyEncodeDecodeBitArrayRand

### DIFF
--- a/pkg/util/encoding/encoding_test.go
+++ b/pkg/util/encoding/encoding_test.go
@@ -962,8 +962,8 @@ func TestKeyEncodeDecodeBitArrayRand(t *testing.T) {
 				buf = EncodeBitArrayAscending(nil, test)
 				remainder, x, err = DecodeBitArrayAscending(buf)
 			} else {
-				buf = EncodeBitArrayAscending(nil, test)
-				remainder, x, err = DecodeBitArrayAscending(buf)
+				buf = EncodeBitArrayDescending(nil, test)
+				remainder, x, err = DecodeBitArrayDescending(buf)
 			}
 			if err != nil {
 				t.Fatalf("%+v", err)


### PR DESCRIPTION
In the test for `Descending` direction we were incorrectly using "asc" encoding/decoding function.

Fixes: #111898.

Authored-by: chavacava <salvadorcavadini+github@gmail.com>

Release note: None