### PR TITLE
protectedts: do not update pts meta table in 24.1

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -6410,6 +6410,10 @@ func TestProtectedTimestampsFailDueToLimits(t *testing.T) {
 	defer dirCleanupFn()
 	params := base.TestClusterArgs{}
 	params.ServerArgs.ExternalIODir = dir
+	params.ServerArgs.Knobs.ProtectedTS = &protectedts.TestingKnobs{
+		// The meta table is used to track limits.
+		UseMetaTable: true,
+	}
 	tc := testcluster.StartTestCluster(t, 1, params)
 	defer tc.Stopper().Stop(ctx)
 	db := tc.ServerConn(0)
@@ -6428,7 +6432,10 @@ func TestProtectedTimestampsFailDueToLimits(t *testing.T) {
 		params := base.TestClusterArgs{}
 		params.ServerArgs.ExternalIODir = dir
 		params.ServerArgs.Knobs.ProtectedTS = &protectedts.TestingKnobs{
-			DisableProtectedTimestampForMultiTenant: true}
+			DisableProtectedTimestampForMultiTenant: true,
+			// The meta table is used to track limits.
+			UseMetaTable: true,
+		}
 		// Test fails within a tenant. Tracked with #76378.
 		params.ServerArgs.DefaultTestTenant = base.TODOTestTenantDisabled
 		tc := testcluster.StartTestCluster(t, 1, params)

--- a/pkg/ccl/backupccl/schedule_pts_chaining_test.go
+++ b/pkg/ccl/backupccl/schedule_pts_chaining_test.go
@@ -274,7 +274,7 @@ INSERT INTO t values (1), (10), (100);
 		runSchedule(t, fullSchedule)
 
 		var numRows int
-		th.sqlDB.QueryRow(t, `SELECT num_records FROM system.protected_ts_meta`).Scan(&numRows)
+		th.sqlDB.QueryRow(t, `SELECT count(*) FROM system.protected_ts_records`).Scan(&numRows)
 		require.Zero(t, numRows)
 	})
 
@@ -383,7 +383,7 @@ INSERT INTO t values (1), (10), (100);
 	// Ensure that the pts record on the incremental schedule has been released
 	// by the DROP.
 	var numRows int
-	th.sqlDB.QueryRow(t, `SELECT num_records FROM system.protected_ts_meta`).Scan(&numRows)
+	th.sqlDB.QueryRow(t, `SELECT count(*) FROM system.protected_ts_records`).Scan(&numRows)
 	require.Zero(t, numRows)
 
 	// Also ensure that the full schedule doesn't have DependentID set anymore.

--- a/pkg/kv/kvserver/client_replica_test.go
+++ b/pkg/kv/kvserver/client_replica_test.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/rangefeed/rangefeedcache"
@@ -4075,7 +4076,8 @@ func TestStrictGCEnforcement(t *testing.T) {
 		syncutil.Mutex
 		blockOnTimestampUpdate func()
 	}
-	tc := testcluster.StartTestCluster(t, 3, base.TestClusterArgs{
+
+	args := base.TestClusterArgs{
 		ReplicationMode: base.ReplicationManual,
 		ServerArgs: base.TestServerArgs{
 			Knobs: base.TestingKnobs{
@@ -4092,7 +4094,21 @@ func TestStrictGCEnforcement(t *testing.T) {
 				},
 			},
 		},
-	})
+	}
+
+	// TODO(#119243): remove this test in 24.2
+	// One subtest is a regression test for old-style PTS records.
+	// Randomly set an old cluster version to test this functionality.
+	testCache := false
+	if rand.Intn(2) == 0 {
+		testCache = true
+		args.ServerArgs.Knobs.Server = &server.TestingKnobs{
+			DisableAutomaticVersionUpgrade: make(chan struct{}),
+			BinaryVersionOverride:          (clusterversion.V24_1_MigrateOldStylePTSRecords - 1).Version(),
+		}
+	}
+
+	tc := testcluster.StartTestCluster(t, 3, args)
 	defer tc.Stopper().Stop(ctx)
 
 	sqlDB := sqlutils.MakeSQLRunner(tc.ServerConn(0))
@@ -4309,6 +4325,7 @@ func TestStrictGCEnforcement(t *testing.T) {
 		_, err := txn.Scan(ctx, descriptorTable, descriptorTable.PrefixEnd(), 1)
 		require.NoError(t, err)
 	})
+
 	// This is a regression test for a bug where the implied GCThreshold computed
 	// when evaluating whether a batch request is below the replicas' GCThreshold,
 	// was not taking the `readAt` of the cached PTS state into consideration.
@@ -4318,6 +4335,9 @@ func TestStrictGCEnforcement(t *testing.T) {
 	// erroneously reject requests even though their request time was above the
 	// "correct" GCThreshold.
 	t.Run("implied gcthreshold respects cached readAt", func(t *testing.T) {
+		if !testCache {
+			return
+		}
 		s := tc.Server(0)
 
 		// Block the KVSubscriber rangefeed from progressing.

--- a/pkg/kv/kvserver/protectedts/ptcache/cache.go
+++ b/pkg/kv/kvserver/protectedts/ptcache/cache.go
@@ -30,6 +30,7 @@ import (
 )
 
 // Cache implements protectedts.Cache.
+// TODO(#119243): delete this in 24.2
 type Cache struct {
 	db       isql.DB
 	storage  protectedts.Manager

--- a/pkg/kv/kvserver/protectedts/ptcache/cache_test.go
+++ b/pkg/kv/kvserver/protectedts/ptcache/cache_test.go
@@ -86,6 +86,7 @@ func TestCacheBasic(t *testing.T) {
 			Knobs: base.TestingKnobs{
 				ProtectedTS: &protectedts.TestingKnobs{
 					DisableProtectedTimestampForMultiTenant: true,
+					UseMetaTable:                            true,
 				},
 			},
 		})
@@ -95,6 +96,7 @@ func TestCacheBasic(t *testing.T) {
 	insqlDB := s.InternalDB().(isql.DB)
 	m := ptstorage.New(s.ClusterSettings(), &protectedts.TestingKnobs{
 		DisableProtectedTimestampForMultiTenant: true,
+		UseMetaTable:                            true,
 	})
 	p := withDatabase(m, insqlDB)
 
@@ -157,6 +159,7 @@ func TestRefresh(t *testing.T) {
 	st := &scanTracker{}
 	ptsKnobs := &protectedts.TestingKnobs{
 		DisableProtectedTimestampForMultiTenant: true,
+		UseMetaTable:                            true,
 	}
 	srv := serverutils.StartServerOnly(t,
 		base.TestServerArgs{
@@ -302,6 +305,7 @@ func TestStart(t *testing.T) {
 				Knobs: base.TestingKnobs{
 					ProtectedTS: &protectedts.TestingKnobs{
 						DisableProtectedTimestampForMultiTenant: true,
+						UseMetaTable:                            true,
 					},
 				},
 			})
@@ -351,6 +355,7 @@ func TestQueryRecord(t *testing.T) {
 	db := s.InternalDB().(isql.DB)
 	storage := ptstorage.New(s.ClusterSettings(), &protectedts.TestingKnobs{
 		DisableProtectedTimestampForMultiTenant: true,
+		UseMetaTable:                            true,
 	})
 	p := withDatabase(storage, db)
 	// Set the poll interval to be very long.
@@ -415,6 +420,7 @@ func TestIterate(t *testing.T) {
 	db := s.InternalDB().(isql.DB)
 	m := ptstorage.New(s.ClusterSettings(), &protectedts.TestingKnobs{
 		DisableProtectedTimestampForMultiTenant: true,
+		UseMetaTable:                            true,
 	})
 	p := withDatabase(m, db)
 
@@ -485,6 +491,7 @@ func TestGetProtectionTimestamps(t *testing.T) {
 			Knobs: base.TestingKnobs{
 				ProtectedTS: &protectedts.TestingKnobs{
 					DisableProtectedTimestampForMultiTenant: true,
+					UseMetaTable:                            true,
 				},
 			},
 		})
@@ -565,6 +572,7 @@ func TestGetProtectionTimestamps(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			storage := ptstorage.New(s.ClusterSettings(), &protectedts.TestingKnobs{
 				DisableProtectedTimestampForMultiTenant: true,
+				UseMetaTable:                            true,
 			})
 			p := withDatabase(storage, s.InternalDB().(isql.DB))
 			c := ptcache.New(ptcache.Config{
@@ -595,6 +603,7 @@ func TestSettingChangedLeadsToFetch(t *testing.T) {
 	db := s.InternalDB().(isql.DB)
 	m := ptstorage.New(s.ClusterSettings(), &protectedts.TestingKnobs{
 		DisableProtectedTimestampForMultiTenant: true,
+		UseMetaTable:                            true,
 	})
 
 	// Set the poll interval to be very long.

--- a/pkg/kv/kvserver/protectedts/ptpb/protectedts.proto
+++ b/pkg/kv/kvserver/protectedts/ptpb/protectedts.proto
@@ -71,18 +71,18 @@ enum ProtectionMode {
 message Metadata {
 
    // Version is incremented whenever a Record is created or removed.
-   uint64 version = 1;
+   uint64 version = 1 [deprecated=true];
 
    // NumRecords is the number of records which exist in the subsystem.
-   uint64 num_records = 2;
+   uint64 num_records = 2 [deprecated=true];
 
    // NumSpans is the number of spans currently being protected by the
    // protectedts subsystem.
-   uint64 num_spans = 3;
+   uint64 num_spans = 3 [deprecated=true];
 
    // TotalBytes is the number of bytes currently in use by records
    // to store their spans and metadata.
-   uint64 total_bytes = 4;
+   uint64 total_bytes = 4 [deprecated=true];
 }
 
 // Record corresponds to a protected timestamp.

--- a/pkg/kv/kvserver/protectedts/ptreconcile/reconciler_test.go
+++ b/pkg/kv/kvserver/protectedts/ptreconcile/reconciler_test.go
@@ -44,7 +44,8 @@ func TestReconciler(t *testing.T) {
 
 		srv := serverutils.StartServerOnly(t, base.TestServerArgs{
 			Knobs: base.TestingKnobs{
-				ProtectedTS: &protectedts.TestingKnobs{DisableProtectedTimestampForMultiTenant: withDeprecatedSpans},
+				ProtectedTS: &protectedts.TestingKnobs{DisableProtectedTimestampForMultiTenant: withDeprecatedSpans,
+					UseMetaTable: withDeprecatedSpans},
 			},
 		})
 		defer srv.Stopper().Stop(ctx)

--- a/pkg/kv/kvserver/protectedts/ptstorage/BUILD.bazel
+++ b/pkg/kv/kvserver/protectedts/ptstorage/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/kv/kvserver/protectedts/ptstorage",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/clusterversion",
         "//pkg/kv/kvserver/protectedts",
         "//pkg/kv/kvserver/protectedts/ptpb",
         "//pkg/settings/cluster",
@@ -62,6 +63,7 @@ go_test(
         "//pkg/sql/sessiondata",
         "//pkg/testutils",
         "//pkg/testutils/serverutils",
+        "//pkg/testutils/skip",
         "//pkg/testutils/testcluster",
         "//pkg/util/hlc",
         "//pkg/util/leaktest",

--- a/pkg/kv/kvserver/protectedts/ptstorage/storage.go
+++ b/pkg/kv/kvserver/protectedts/ptstorage/storage.go
@@ -14,6 +14,7 @@ package ptstorage
 import (
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/protectedts"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/protectedts/ptpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -87,16 +88,30 @@ func (p *storage) Protect(ctx context.Context, r *ptpb.Record) error {
 	if err != nil { // how can this possibly fail?
 		return errors.Wrap(err, "failed to marshal spans")
 	}
-	it, err := p.txn.QueryIteratorEx(ctx, "protectedts-protect", p.txn.KV(),
-		sessiondata.NodeUserSessionDataOverride,
-		protectQuery,
-		s.maxSpans, s.maxBytes, len(r.DeprecatedSpans),
+
+	updateMeta := usePTSMetaTable(ctx, p.settings, p.knobs)
+	query := protectInsertRecordCTE
+	args := []interface{}{
 		r.ID, r.Timestamp.AsOfSystemTime(),
 		r.MetaType, meta,
-		len(r.DeprecatedSpans), encodedTarget, encodedTarget)
+		len(r.DeprecatedSpans), encodedTarget, encodedTarget}
+
+	if updateMeta {
+		query = protectQuery
+		args = []interface{}{s.maxSpans, s.maxBytes, len(r.DeprecatedSpans),
+			r.ID, r.Timestamp.AsOfSystemTime(),
+			r.MetaType, meta,
+			len(r.DeprecatedSpans), encodedTarget, encodedTarget}
+	}
+
+	it, err := p.txn.QueryIteratorEx(ctx, "protectedts-protect", p.txn.KV(),
+		sessiondata.NodeUserSessionDataOverride,
+		query,
+		args...)
 	if err != nil {
 		return errors.Wrapf(err, "failed to write record %v", r.ID)
 	}
+
 	ok, err := it.Next(ctx)
 	if err != nil {
 		return errors.Wrapf(err, "failed to write record %v", r.ID)
@@ -104,18 +119,24 @@ func (p *storage) Protect(ctx context.Context, r *ptpb.Record) error {
 	if !ok {
 		return errors.Newf("failed to write record %v", r.ID)
 	}
+
+	defer func() {
+		if err := it.Close(); err != nil {
+			log.Infof(ctx, "encountered %v when writing record %v", err, r.ID)
+		}
+	}()
+
 	row := it.Cur()
-	if err := it.Close(); err != nil {
-		log.Infof(ctx, "encountered %v when writing record %v", err, r.ID)
-	}
 	if failed := *row[0].(*tree.DBool); failed {
-		curBytes := int64(*row[1].(*tree.DInt))
-		recordBytes := int64(len(encodedTarget) + len(r.Meta) + len(r.MetaType))
-		if s.maxBytes > 0 && curBytes+recordBytes > s.maxBytes {
-			return errors.WithHint(
-				errors.Errorf("protectedts: limit exceeded: %d+%d > %d bytes", curBytes, recordBytes,
-					s.maxBytes),
-				"SET CLUSTER SETTING kv.protectedts.max_bytes to a higher value")
+		if updateMeta {
+			curBytes := int64(*row[1].(*tree.DInt))
+			recordBytes := int64(len(encodedTarget) + len(r.Meta) + len(r.MetaType))
+			if s.maxBytes > 0 && curBytes+recordBytes > s.maxBytes {
+				return errors.WithHint(
+					errors.Errorf("protectedts: limit exceeded: %d+%d > %d bytes", curBytes, recordBytes,
+						s.maxBytes),
+					"SET CLUSTER SETTING kv.protectedts.max_bytes to a higher value")
+			}
 		}
 		return protectedts.ErrExists
 	}
@@ -157,9 +178,13 @@ func (p storage) MarkVerified(ctx context.Context, id uuid.UUID) error {
 }
 
 func (p storage) Release(ctx context.Context, id uuid.UUID) error {
+	query := releaseQueryWithMeta
+	if !usePTSMetaTable(ctx, p.settings, p.knobs) {
+		query = releaseQuery
+	}
 	numRows, err := p.txn.ExecEx(ctx, "protectedts-Release", p.txn.KV(),
 		sessiondata.NodeUserSessionDataOverride,
-		releaseQuery, id.GetBytesMut())
+		query, id.GetBytesMut())
 	if err != nil {
 		return errors.Wrapf(err, "failed to release record %v", id)
 	}
@@ -228,9 +253,13 @@ func (p *storage) getRecords(ctx context.Context) ([]ptpb.Record, error) {
 }
 
 func (p storage) UpdateTimestamp(ctx context.Context, id uuid.UUID, timestamp hlc.Timestamp) error {
+	query := updateTimestampQuery
+	if !usePTSMetaTable(ctx, p.settings, p.knobs) {
+		query = updateTimestampUpsertRecordCTE
+	}
 	row, err := p.txn.QueryRowEx(ctx, "protectedts-update", p.txn.KV(),
 		sessiondata.NodeUserSessionDataOverride,
-		updateTimestampQuery, id.GetBytesMut(), timestamp.AsOfSystemTime())
+		query, id.GetBytesMut(), timestamp.AsOfSystemTime())
 	if err != nil {
 		return errors.Wrapf(err, "failed to update record %v", id)
 	}
@@ -259,6 +288,12 @@ func useDeprecatedProtectedTSStorage(
 
 func writeDeprecatedPTSRecord(knobs *protectedts.TestingKnobs, r *ptpb.Record) bool {
 	return knobs != nil && knobs.WriteDeprecatedPTSRecords && r.DeprecatedSpans != nil && len(r.DeprecatedSpans) > 0
+}
+
+func usePTSMetaTable(
+	ctx context.Context, st *cluster.Settings, knobs *protectedts.TestingKnobs,
+) bool {
+	return knobs.UseMetaTable || !st.Version.IsActive(ctx, clusterversion.V24_1)
 }
 
 // New creates a new Storage.

--- a/pkg/kv/kvserver/protectedts/settings.go
+++ b/pkg/kv/kvserver/protectedts/settings.go
@@ -24,7 +24,8 @@ import (
 var MaxBytes = settings.RegisterIntSetting(
 	settings.ApplicationLevel,
 	"kv.protectedts.max_bytes",
-	"if non-zero the limit of the number of bytes of spans and metadata which can be protected",
+	"if non-zero, this limits the number of bytes used by protected timestamp records in the protected timestamps"+
+		" system table. this will be a noop in 24.1 onwards and deprecated in the future",
 	1<<20, // 1 MiB
 	settings.NonNegativeInt,
 	settings.WithVisibility(settings.Reserved),

--- a/pkg/kv/kvserver/protectedts/testing_knobs.go
+++ b/pkg/kv/kvserver/protectedts/testing_knobs.go
@@ -25,6 +25,10 @@ type TestingKnobs struct {
 	// WriteDeprecatedPTSRecords When set to true, deprecated protected timestamp
 	// records will be written, only if deprecated spans are supplied.
 	WriteDeprecatedPTSRecords bool
+
+	// UseMetaTable	forces PTS management to update the meta table whenever
+	// any record is updated.
+	UseMetaTable bool
 }
 
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -811,7 +811,8 @@ func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterf
 		fn := cfg.TestingKnobs.SpanConfig.(*spanconfig.TestingKnobs).ProtectedTSReaderOverrideFn
 		protectedTSReader = fn(clock)
 	} else {
-		protectedTSReader = spanconfigptsreader.NewAdapter(protectedtsProvider.(*ptprovider.Provider).Cache, spanConfig.subscriber)
+		protectedTSReader = spanconfigptsreader.NewAdapter(protectedtsProvider.(*ptprovider.Provider).Cache,
+			spanConfig.subscriber, cfg.Settings)
 	}
 
 	rangeLogWriter := rangelog.NewWriter(

--- a/pkg/spanconfig/spanconfigptsreader/BUILD.bazel
+++ b/pkg/spanconfig/spanconfigptsreader/BUILD.bazel
@@ -6,9 +6,11 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/spanconfig/spanconfigptsreader",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/clusterversion",
         "//pkg/keys",
         "//pkg/kv/kvserver/protectedts",
         "//pkg/roachpb",
+        "//pkg/settings/cluster",
         "//pkg/spanconfig",
         "//pkg/testutils",
         "//pkg/util/hlc",
@@ -26,9 +28,11 @@ go_test(
         "//conditions:default": {"test.Pool": "default"},
     }),
     deps = [
+        "//pkg/clusterversion",
         "//pkg/keys",
         "//pkg/kv/kvserver/protectedts",
         "//pkg/roachpb",
+        "//pkg/settings/cluster",
         "//pkg/spanconfig",
         "//pkg/util/hlc",
         "//pkg/util/leaktest",

--- a/pkg/spanconfig/spanconfigptsreader/adapter_test.go
+++ b/pkg/spanconfig/spanconfigptsreader/adapter_test.go
@@ -15,9 +15,11 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/protectedts"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -45,57 +47,115 @@ func TestAdapter(t *testing.T) {
 	mc := &manualCache{}
 	ms := &manualSubscriber{}
 
-	adapter := NewAdapter(mc, ms)
-	ctx := context.Background()
+	// TODO(#119243): delete the cache in v24.2
+	t.Run("with pts cache", func(t *testing.T) {
+		version := clusterversion.V23_2.Version()
+		adapter := NewAdapter(mc, ms, cluster.MakeTestingClusterSettingsWithVersions(version, version, true))
+		ctx := context.Background()
 
-	// Setup with an empty subscriber and cache; ensure no records are returned
-	// and the freshness timestamp is the minimum of the two.
-	mc.asOf = ts(10)
-	ms.updatedTS = ts(14)
-	timestamps, asOf, err := adapter.GetProtectionTimestamps(ctx, keys.EverythingSpan)
-	require.NoError(t, err)
-	require.Empty(t, timestamps)
-	require.Equal(t, ts(10), asOf)
+		// Setup with an empty subscriber and cache; ensure no records are returned
+		// and the freshness timestamp is the minimum of the two.
+		mc.asOf = ts(10)
+		ms.updatedTS = ts(14)
+		timestamps, asOf, err := adapter.GetProtectionTimestamps(ctx, keys.EverythingSpan)
+		require.NoError(t, err)
+		require.Empty(t, timestamps)
+		require.Equal(t, ts(10), asOf)
 
-	// Forward the freshness of the cache past the subscriber's.
-	mc.asOf = ts(18)
-	timestamps, asOf, err = adapter.GetProtectionTimestamps(ctx, keys.EverythingSpan)
-	require.NoError(t, err)
-	require.Empty(t, timestamps)
-	require.Equal(t, ts(14), asOf)
+		// Forward the freshness of the cache past the subscriber's.
+		mc.asOf = ts(18)
+		timestamps, asOf, err = adapter.GetProtectionTimestamps(ctx, keys.EverythingSpan)
+		require.NoError(t, err)
+		require.Empty(t, timestamps)
+		require.Equal(t, ts(14), asOf)
 
-	// Add some records to the cache; ensure they're returned.
-	mc.protectedTimestamps = append(mc.protectedTimestamps, ts(6), ts(10))
-	mc.asOf = ts(20)
+		// Add some records to the cache; ensure they're returned.
+		mc.protectedTimestamps = append(mc.protectedTimestamps, ts(6), ts(10))
+		mc.asOf = ts(20)
 
-	timestamps, asOf, err = adapter.GetProtectionTimestamps(ctx, keys.EverythingSpan)
-	require.NoError(t, err)
-	require.Equal(t, ts(14), asOf)
-	validateProtectedTimestamps([]hlc.Timestamp{ts(6), ts(10)}, timestamps)
+		timestamps, asOf, err = adapter.GetProtectionTimestamps(ctx, keys.EverythingSpan)
+		require.NoError(t, err)
+		require.Equal(t, ts(14), asOf)
+		validateProtectedTimestamps([]hlc.Timestamp{ts(6), ts(10)}, timestamps)
 
-	// Add some records to the subscriber, ensure they're returned as well.
-	ms.protectedTimestamps = append(ms.protectedTimestamps, ts(7), ts(12))
-	ms.updatedTS = ts(19)
-	timestamps, asOf, err = adapter.GetProtectionTimestamps(ctx, keys.EverythingSpan)
-	require.NoError(t, err)
-	require.Equal(t, ts(19), asOf)
-	validateProtectedTimestamps([]hlc.Timestamp{ts(6), ts(7), ts(10), ts(12)}, timestamps)
+		// Add some records to the subscriber, ensure they're returned as well.
+		ms.protectedTimestamps = append(ms.protectedTimestamps, ts(7), ts(12))
+		ms.updatedTS = ts(19)
+		timestamps, asOf, err = adapter.GetProtectionTimestamps(ctx, keys.EverythingSpan)
+		require.NoError(t, err)
+		require.Equal(t, ts(19), asOf)
+		validateProtectedTimestamps([]hlc.Timestamp{ts(6), ts(7), ts(10), ts(12)}, timestamps)
 
-	// Clear out records from the cache, bump its freshness.
-	mc.protectedTimestamps = nil
-	mc.asOf = ts(22)
-	timestamps, asOf, err = adapter.GetProtectionTimestamps(ctx, keys.EverythingSpan)
-	require.NoError(t, err)
-	require.Equal(t, ts(19), asOf)
-	validateProtectedTimestamps([]hlc.Timestamp{ts(7), ts(12)}, timestamps)
+		// Clear out records from the cache, bump its freshness.
+		mc.protectedTimestamps = nil
+		mc.asOf = ts(22)
+		timestamps, asOf, err = adapter.GetProtectionTimestamps(ctx, keys.EverythingSpan)
+		require.NoError(t, err)
+		require.Equal(t, ts(19), asOf)
+		validateProtectedTimestamps([]hlc.Timestamp{ts(7), ts(12)}, timestamps)
 
-	// Clear out records from the subscriber, bump its freshness.
-	ms.protectedTimestamps = nil
-	ms.updatedTS = ts(25)
-	timestamps, asOf, err = adapter.GetProtectionTimestamps(ctx, keys.EverythingSpan)
-	require.NoError(t, err)
-	require.Equal(t, ts(22), asOf)
-	require.Empty(t, timestamps)
+		// Clear out records from the subscriber, bump its freshness.
+		ms.protectedTimestamps = nil
+		ms.updatedTS = ts(25)
+		timestamps, asOf, err = adapter.GetProtectionTimestamps(ctx, keys.EverythingSpan)
+		require.NoError(t, err)
+		require.Equal(t, ts(22), asOf)
+		require.Empty(t, timestamps)
+	})
+
+	t.Run("without pts cache", func(t *testing.T) {
+		version := clusterversion.Latest.Version()
+		adapter := NewAdapter(mc, ms, cluster.MakeTestingClusterSettingsWithVersions(version, version, true))
+		ctx := context.Background()
+
+		// Even though the cache has lower freshness, ignore it.
+		mc.asOf = ts(10)
+		ms.updatedTS = ts(14)
+		timestamps, asOf, err := adapter.GetProtectionTimestamps(ctx, keys.EverythingSpan)
+		require.NoError(t, err)
+		require.Empty(t, timestamps)
+		require.Equal(t, ts(14), asOf)
+
+		// Forward the freshness of the cache past the subscriber's. The freshness should be the same.
+		mc.asOf = ts(18)
+		timestamps, asOf, err = adapter.GetProtectionTimestamps(ctx, keys.EverythingSpan)
+		require.NoError(t, err)
+		require.Empty(t, timestamps)
+		require.Equal(t, ts(14), asOf)
+
+		// Add some records to the cache; ensure they aren't returned.
+		mc.protectedTimestamps = append(mc.protectedTimestamps, ts(6), ts(10))
+		mc.asOf = ts(20)
+		timestamps, asOf, err = adapter.GetProtectionTimestamps(ctx, keys.EverythingSpan)
+		require.NoError(t, err)
+		require.Equal(t, ts(14), asOf)
+		require.Empty(t, timestamps)
+
+		// Add some records to the subscriber, ensure they're returned only.
+		// The freshness of the adapter is the freshness of the subscriber.
+		ms.protectedTimestamps = append(ms.protectedTimestamps, ts(7), ts(12))
+		ms.updatedTS = ts(21)
+		timestamps, asOf, err = adapter.GetProtectionTimestamps(ctx, keys.EverythingSpan)
+		require.NoError(t, err)
+		require.Equal(t, ts(21), asOf)
+		validateProtectedTimestamps([]hlc.Timestamp{ts(7), ts(12)}, timestamps)
+
+		// Clear out records from the cache, bump its freshness.
+		mc.protectedTimestamps = nil
+		mc.asOf = ts(22)
+		timestamps, asOf, err = adapter.GetProtectionTimestamps(ctx, keys.EverythingSpan)
+		require.NoError(t, err)
+		require.Equal(t, ts(21), asOf)
+		validateProtectedTimestamps([]hlc.Timestamp{ts(7), ts(12)}, timestamps)
+
+		// Clear out records from the subscriber, bump its freshness.
+		ms.protectedTimestamps = nil
+		ms.updatedTS = ts(25)
+		timestamps, asOf, err = adapter.GetProtectionTimestamps(ctx, keys.EverythingSpan)
+		require.NoError(t, err)
+		require.Equal(t, ts(25), asOf)
+		require.Empty(t, timestamps)
+	})
 }
 
 type manualSubscriber struct {

--- a/pkg/sql/sessionprotectedts/session_protected_ts_test.go
+++ b/pkg/sql/sessionprotectedts/session_protected_ts_test.go
@@ -92,7 +92,7 @@ func TestSessionProtectedTimestampReconciler(t *testing.T) {
 
 	state, err := pts.GetState(ctx)
 	require.NoError(t, err)
-	require.Equal(t, uint64(2), state.NumRecords)
+	require.Equal(t, 2, len(state.Records))
 
 	t.Run("reconcile", func(t *testing.T) {
 		ptreconcile.ReconcileInterval.Override(ctx, &settings.SV, time.Millisecond)


### PR DESCRIPTION
Note that after https://github.com/cockroachdb/cockroach/pull/118772 is merged, all "old-style" protected timestamps will be migrated to the
"new-style", meaning that the PTS cache and PTS meta table will not be required to read PTS
records.

The metadata above refers to metadata in the `system.protected_ts_meta` table. This table had a single
row which tracked metadata for all PTS records (ex. the total size of all the records, the number of records,
and `version`). The `version` was a monotonically increasing integer used to mark every change to the
`system.protected_ts_records` table, such as adding or removing records.

This change bifurcates the PTS storage system to have two 'modes': with and without metadata. PTS
storage with metadata was the norm before 24.1. For 24.1 onwards, we want to maintain PTS records
without metadata. The reason which the metadata updates are being removed is because of contention
on the  `system.protected_ts_meta` table when multiple jobs attempt to update it.

These two modes are necessary to ensure things work in a mixed version state. If a new node updates
a PTS record without metadata, a replica on an old node might not see it and the replica might perform gc.
For this reason, nodes should always update metadata until all nodes are on 24.1 and are able to read
all PTS records.

Removing this metadata has 2 main implications:
(a) Removing the size tracking effectively deprecates `kv.protectedts.max_bytes`.
This setting used to limit the total bytes used by the `system.protected_ts_records`. Because
PTS records used to protect a list of spans, the size of records was a concern. Now, they protect
descriptor ids, so they are much smaller - there is no need to limit the size of the table.

(b) Removing the `version` increments will stop the PTS cache from refreshing
This is okay because PTS updates will be picked up from span configs. As of https://github.com/cockroachdb/cockroach/pull/118772, no jobs will
use the old-style PTS records in 24.1. Also as of $118772, there will be no readers/consumers of the PTS cache.

This change also deprecates the metadata fields in protobufs and in the PTS storage API.

```
message Metadata {
   uint64 version = 1 [deprecated=true];
   uint64 num_records = 2 [deprecated=true];
   uint64 num_spans = 3 [deprecated=true];
   uint64 total_bytes = 4 [deprecated=true];
}
```

This change does not:
- remove the pts cache
- remove the pts meta table
- remove deprecated PTS creation (ie. `DisableProtectedTimestampForMultiTenant` testing knob which could have been removed in 22.2)
These can be removed in future commits as a part of the cleanup.

Informs: https://github.com/cockroachdb/cockroach/issues/82888

Release note: None