### PR TITLE
tenantcapabilitieswatcher: make the watcher react faster

### DIFF
--- a/pkg/multitenant/tenantcapabilities/tenantcapabilitieswatcher/decoder.go
+++ b/pkg/multitenant/tenantcapabilities/tenantcapabilitieswatcher/decoder.go
@@ -14,7 +14,6 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/rangefeed/rangefeedbuffer"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/multitenant/mtinfo"
 	"github.com/cockroachdb/cockroach/pkg/multitenant/tenantcapabilities"
@@ -26,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc/valueside"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log/logcrash"
 	"github.com/cockroachdb/errors"
 )
@@ -96,7 +96,7 @@ func (d *decoder) decode(
 
 func (d *decoder) translateEvent(
 	ctx context.Context, ev *kvpb.RangeFeedValue,
-) rangefeedbuffer.Event {
+) (hasEvent bool, ts hlc.Timestamp, event tenantcapabilities.Update) {
 	deleted := !ev.Value.IsPresent()
 	var value roachpb.Value
 	// The event corresponds to a deletion. The capabilities being deleted must
@@ -105,7 +105,7 @@ func (d *decoder) translateEvent(
 		// There's nothing for us to do if this event corresponds to a deletion
 		// tombstone being removed (GC).
 		if !ev.PrevValue.IsPresent() {
-			return nil
+			return false, ts, event
 		}
 
 		value = ev.PrevValue
@@ -122,15 +122,12 @@ func (d *decoder) translateEvent(
 		// This should never happen: the rangefeed should only ever deliver valid SQL rows.
 		err = errors.NewAssertionErrorWithWrappedErrf(err, "failed to decode row %v", ev.Key)
 		logcrash.ReportOrPanic(ctx, &d.st.SV, "%w", err)
-		return nil
+		return false, ts, event
 	}
 
-	return &bufferEvent{
-		update: tenantcapabilities.Update{
-			Entry:   entry,
-			Deleted: deleted,
-		},
-		ts: ev.Value.Timestamp,
+	return true, ev.Value.Timestamp, tenantcapabilities.Update{
+		Entry:   entry,
+		Deleted: deleted,
 	}
 }
 

--- a/pkg/multitenant/tenantcapabilities/tenantcapabilitieswatcher/decoder_test.go
+++ b/pkg/multitenant/tenantcapabilities/tenantcapabilitieswatcher/decoder_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/stretchr/testify/require"
 )
@@ -32,6 +33,7 @@ import (
 // TenantCapabilities stored in the system.tenants table.
 func TestDecodeCapabilities(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
 	ts, db, kvDB := serverutils.StartServer(t, base.TestServerArgs{

--- a/pkg/multitenant/tenantcapabilities/tenantcapabilitieswatcher/testdata/basic
+++ b/pkg/multitenant/tenantcapabilities/tenantcapabilitieswatcher/testdata/basic
@@ -17,7 +17,6 @@ ok
 
 updates
 ----
-Incremental Update
 update: ten=10 name=foo state=add service=shared cap={can_admin_unsplit:true}
 update: ten=11 name=bar state=ready service=none cap={default}
 
@@ -32,7 +31,6 @@ ok
 
 updates
 ----
-Incremental Update
 update: ten=11 name= state=add service=none cap={can_admin_unsplit:true}
 
 get-capabilities ten=11
@@ -45,7 +43,6 @@ ok
 
 updates
 ----
-Incremental Update
 delete: ten=10
 
 get-capabilities ten=10
@@ -72,7 +69,6 @@ ok
 
 updates
 ----
-Incremental Update
 update: ten=15 name=bli state=add service=external cap={can_admin_unsplit:true}
 
 # Ensure only the last update is applied, even when there are multiple updates
@@ -91,7 +87,6 @@ ok
 
 updates
 ----
-Incremental Update
 delete: ten=11
 
 get-capabilities ten=11
@@ -117,7 +112,6 @@ ok
 
 updates
 ----
-Incremental Update
 update: ten=15 name=blax state=ready service=none cap={default}
 
 flush-state

--- a/pkg/multitenant/tenantcapabilities/tenantcapabilitieswatcher/testdata/initial_scan
+++ b/pkg/multitenant/tenantcapabilities/tenantcapabilitieswatcher/testdata/initial_scan
@@ -37,7 +37,6 @@ ok
 
 updates
 ----
-Complete Update
 update: ten=11 name=bar state=add service=external cap={default}
 update: ten=15 name=woo state=add service=none cap={can_admin_unsplit:true}
 

--- a/pkg/multitenant/tenantcapabilities/tenantcapabilitieswatcher/testdata/rangefeed_errors
+++ b/pkg/multitenant/tenantcapabilities/tenantcapabilitieswatcher/testdata/rangefeed_errors
@@ -24,7 +24,6 @@ ok
 
 updates
 ----
-Incremental Update
 update: ten=10 name=foo state=add service=shared cap={can_admin_unsplit:true}
 update: ten=11 name=bar state=add service=none cap={default}
 update: ten=12 name=baz state=ready service=none cap={default}
@@ -81,13 +80,15 @@ ok
 # it is able to restart.
 updates
 ----
-Complete Update
 update: ten=11 name=bar state=add service=none cap={default}
 update: ten=12 name=bli state=add service=none cap={can_admin_unsplit:true}
 update: ten=50 name=blax state=add service=none cap={default}
 
+# The previous entry for ten=10 remains, because we keep the map
+# across rangefeed restarts.
 flush-state
 ----
+ten=10 name=foo state=add service=shared cap={can_admin_unsplit:true}
 ten=11 name=bar state=add service=none cap={default}
 ten=12 name=bli state=add service=none cap={can_admin_unsplit:true}
 ten=50 name=blax state=add service=none cap={default}
@@ -102,4 +103,4 @@ ten=12 name=bli state=add service=none cap={can_admin_unsplit:true}
 
 get-capabilities ten=10
 ----
-not-found
+ten=10 name=foo state=add service=shared cap={can_admin_unsplit:true}

--- a/pkg/multitenant/tenantcapabilities/tenantcapabilitieswatcher/testingknobs.go
+++ b/pkg/multitenant/tenantcapabilities/tenantcapabilitieswatcher/testingknobs.go
@@ -12,7 +12,6 @@ package tenantcapabilitieswatcher
 
 import (
 	"github.com/cockroachdb/cockroach/pkg/base"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/rangefeed/rangefeedcache"
 	"github.com/cockroachdb/cockroach/pkg/multitenant/tenantcapabilities"
 )
 
@@ -24,9 +23,7 @@ type TestingKnobs struct {
 
 	// WatcherUpdatesInterceptor, if set, is called each time the Watcher
 	// receives a set of updates.
-	WatcherUpdatesInterceptor func(
-		updateType rangefeedcache.UpdateType, updates []tenantcapabilities.Update,
-	)
+	WatcherUpdatesInterceptor func(update tenantcapabilities.Update)
 }
 
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.

--- a/pkg/multitenant/tenantcapabilities/tenantcapabilitieswatcher/watcher.go
+++ b/pkg/multitenant/tenantcapabilities/tenantcapabilitieswatcher/watcher.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/rangefeed"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/rangefeed/rangefeedbuffer"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/rangefeed/rangefeedcache"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/multitenant/tenantcapabilities"
 	"github.com/cockroachdb/cockroach/pkg/multitenant/tenantcapabilities/tenantcapabilitiespb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -45,6 +46,9 @@ type Watcher struct {
 
 	mu struct {
 		syncutil.RWMutex
+
+		// lastUpdate is the timestamp of the last update.
+		lastUpdate map[roachpb.TenantID]hlc.Timestamp
 
 		store  map[roachpb.TenantID]*watcherEntry
 		byName map[roachpb.TenantName]roachpb.TenantID
@@ -107,6 +111,7 @@ func New(
 		knobs:            watcherKnobs,
 	}
 	w.initialScan.ch = make(chan struct{})
+	w.mu.lastUpdate = make(map[roachpb.TenantID]hlc.Timestamp)
 	w.mu.store = make(map[roachpb.TenantID]*watcherEntry)
 	w.mu.byName = make(map[roachpb.TenantName]roachpb.TenantID)
 	w.mu.anyChangeCh = make(chan struct{})
@@ -231,8 +236,8 @@ func (w *Watcher) startRangeFeed(ctx context.Context) error {
 		int(w.bufferMemLimit/tenantInfoEntrySize), /* bufferSize */
 		[]roachpb.Span{tenantsTableSpan},
 		true, /* withPrevValue */
-		w.decoder.translateEvent,
-		w.handleUpdate,
+		w.handleIncrementalUpdate,
+		w.handleRangefeedCacheEvent,
 		rfcTestingKnobs,
 	)
 	if err := rangefeedcache.Start(ctx, w.stopper, rfc, w.onError); err != nil {
@@ -275,113 +280,77 @@ func (w *Watcher) onError(err error) {
 	}
 }
 
-func (w *Watcher) handleUpdate(ctx context.Context, u rangefeedcache.Update) {
-	var updates []tenantcapabilities.Update
-	for _, ev := range u.Events {
-		update := ev.(*bufferEvent).update
-		updates = append(updates, update)
-	}
-
-	if fn := w.knobs.WatcherUpdatesInterceptor; fn != nil {
-		fn(u.Type, updates)
-	}
-
+func (w *Watcher) handleRangefeedCacheEvent(ctx context.Context, u rangefeedcache.Update) {
 	switch u.Type {
 	case rangefeedcache.CompleteUpdate:
 		log.Info(ctx, "received results of a full table scan for tenant capabilities")
-		w.handleCompleteUpdate(ctx, updates)
 		if !w.initialScan.done {
 			w.initialScan.done = true
 			close(w.initialScan.ch)
 		}
 	case rangefeedcache.IncrementalUpdate:
-		w.handleIncrementalUpdate(ctx, updates)
 	default:
 		err := errors.AssertionFailedf("unknown update type: %v", u.Type)
 		logcrash.ReportOrPanic(ctx, &w.st.SV, "%w", err)
 	}
-
-	if len(updates) > 0 {
-		w.closeAnyChangeCh()
-	}
-}
-
-func (w *Watcher) closeAnyChangeCh() {
-	w.mu.Lock()
-	defer w.mu.Unlock()
-	close(w.mu.anyChangeCh)
-	w.mu.anyChangeCh = make(chan struct{})
-}
-
-func (w *Watcher) handleCompleteUpdate(ctx context.Context, updates []tenantcapabilities.Update) {
-	// Populate a fresh store with the supplied updates.
-	// A Complete update indicates that the initial table scan is complete. This
-	// happens when the rangefeed is first established, or if it's restarted for
-	// some reason. Either way, we want to throw away any accumulated state so
-	// far, and reconstruct it using the result of the scan.
-	freshStore := make(map[roachpb.TenantID]*watcherEntry)
-	byName := make(map[roachpb.TenantName]roachpb.TenantID)
-	for i := range updates {
-		up := &updates[i]
-		if log.V(2) {
-			log.Infof(ctx, "adding initial tenant entry to cache: %+v", up.Entry)
-		}
-		freshStore[up.TenantID] = &watcherEntry{
-			Entry:    &up.Entry,
-			changeCh: make(chan struct{}),
-		}
-		if up.Entry.Name != "" {
-			byName[up.Entry.Name] = up.TenantID
-		}
-	}
-
-	w.mu.Lock()
-	defer w.mu.Unlock()
-
-	// Notify any previous watchers that the state has changed.
-	for _, entry := range w.mu.store {
-		close(entry.changeCh)
-	}
-
-	w.mu.store = freshStore
-	w.mu.byName = byName
 }
 
 func (w *Watcher) handleIncrementalUpdate(
-	ctx context.Context, updates []tenantcapabilities.Update,
-) {
+	ctx context.Context, ev *kvpb.RangeFeedValue,
+) rangefeedbuffer.Event {
+	hasEvent, ts, update := w.decoder.translateEvent(ctx, ev)
+	if !hasEvent {
+		return nil
+	}
+
+	if fn := w.knobs.WatcherUpdatesInterceptor; fn != nil {
+		fn(update)
+	}
+
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
-	for i := range updates {
-		update := &updates[i]
-		tid := update.TenantID
-		if entry := w.mu.store[tid]; entry != nil {
-			// Notify previous watchers, if any, that the entry is getting updated.
-			close(entry.changeCh)
-		}
+	tid := update.TenantID
 
-		if update.Deleted {
-			if log.V(2) {
-				log.Infof(ctx, "removing tenant entry from cache: %+v", update.Entry)
-			}
-			if entry := w.mu.store[tid]; entry != nil {
-				delete(w.mu.byName, entry.Name)
-			}
-			delete(w.mu.store, tid)
-		} else {
-			if log.V(2) {
-				log.Infof(ctx, "adding tenant entry to cache: %+v", update.Entry)
-			}
-			w.mu.store[update.TenantID] = &watcherEntry{
-				Entry:    &update.Entry,
-				changeCh: make(chan struct{}),
-			}
-			if update.Entry.Name != "" {
-				w.mu.byName[update.Entry.Name] = update.TenantID
-			}
+	if prevTs, ok := w.mu.lastUpdate[tid]; ok && ts.Less(prevTs) {
+		// Skip updates which have an earlier timestamp to avoid
+		// regressing on the contents of an entry.
+		return nil
+	}
+	w.mu.lastUpdate[tid] = ts
+
+	if entry := w.mu.store[tid]; entry != nil {
+		// Notify previous watchers, if any, that the entry is getting updated.
+		close(entry.changeCh)
+	}
+
+	// Notify previous watchers of the all-tenants accessor, if any,
+	// that some entry is getting updated.
+	close(w.mu.anyChangeCh)
+	w.mu.anyChangeCh = make(chan struct{})
+
+	if update.Deleted {
+		if log.V(2) {
+			log.Infof(ctx, "removing tenant entry from cache: %+v", update.Entry)
+		}
+		if entry := w.mu.store[tid]; entry != nil {
+			delete(w.mu.byName, entry.Name)
+		}
+		delete(w.mu.store, tid)
+	} else {
+		if log.V(2) {
+			log.Infof(ctx, "adding tenant entry to cache: %+v", update.Entry)
+		}
+		w.mu.store[update.TenantID] = &watcherEntry{
+			Entry:    &update.Entry,
+			changeCh: make(chan struct{}),
+		}
+		if update.Entry.Name != "" {
+			w.mu.byName[update.Entry.Name] = update.TenantID
 		}
 	}
+
+	return nil
 }
 
 func (w *Watcher) TestingRestart() {
@@ -410,14 +379,3 @@ func (w *Watcher) TestingFlushCapabilitiesState() (entries []tenantcapabilities.
 	})
 	return entries
 }
-
-type bufferEvent struct {
-	update tenantcapabilities.Update
-	ts     hlc.Timestamp
-}
-
-func (e *bufferEvent) Timestamp() hlc.Timestamp {
-	return e.ts
-}
-
-var _ rangefeedbuffer.Event = &bufferEvent{}

--- a/pkg/multitenant/tenantcapabilities/tenantcapabilitieswatcher/watcher_test.go
+++ b/pkg/multitenant/tenantcapabilities/tenantcapabilitieswatcher/watcher_test.go
@@ -85,7 +85,11 @@ func TestDataDriven(t *testing.T) {
 
 		tdb := sqlutils.MakeSQLRunner(db)
 		tdb.Exec(t, `SET CLUSTER SETTING kv.rangefeed.enabled = true`)
-		tdb.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.target_duration = '100ms'`)
+		// Make test faster.
+		// TODO(knz): Remove this after #111753 is merged.
+		tdb.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.target_duration = '10ms'`)
+		tdb.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.side_transport_interval = '10ms'`)
+		tdb.Exec(t, `SET CLUSTER SETTING kv.rangefeed.closed_timestamp_refresh_interval = '10ms'`)
 
 		const dummyTableName = "dummy_system_tenants"
 		tdb.Exec(t, fmt.Sprintf("CREATE TABLE %s (LIKE system.tenants INCLUDING ALL)", dummyTableName))


### PR DESCRIPTION
Needed for #111637. 
Epic: CRDB-26691.

Prior to this patch, the tenant info watcher would only react to
changes to `system.tenants` upon rangefeed cache flushes, which could
be (in default config) up to 3 seconds after the change is committed.

This commit accelerates the behavior by processing updates as soon as
the change is observed in the rangefeed.

This new behavior is similar to the way that cluster settings changes
are effected immediately in the settings watcher (pkg/settingswatcher).
