### PR TITLE
optbuilder: move finishBuildLastStmt to routine.go

### DIFF
--- a/pkg/sql/opt/optbuilder/routine.go
+++ b/pkg/sql/opt/optbuilder/routine.go
@@ -13,14 +13,17 @@ package optbuilder
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser/statements"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	plpgsql "github.com/cockroachdb/cockroach/pkg/sql/plpgsql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/cast"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/plpgsqltree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/errors"
@@ -323,4 +326,99 @@ func (b *Builder) buildRoutine(
 		},
 	)
 	return routine, rtyp, isMultiColDataSource
+}
+
+// finishBuildLastStmt manages the columns returned by the last statement of a
+// UDF. Depending on the context and return type of the UDF, this may mean
+// expanding a tuple into multiple columns, or combining multiple columns into
+// a tuple.
+func (b *Builder) finishBuildLastStmt(
+	stmtScope *scope, bodyScope *scope, isSetReturning bool, f *tree.FuncExpr,
+) (expr memo.RelExpr, physProps *physical.Required, isMultiColDataSource bool) {
+	expr, physProps = stmtScope.expr, stmtScope.makePhysicalProps()
+	rtyp := f.ResolvedType()
+
+	// Add a LIMIT 1 to the last statement if the UDF is not
+	// set-returning. This is valid because any other rows after the
+	// first can simply be ignored. The limit could be beneficial
+	// because it could allow additional optimization.
+	if !isSetReturning {
+		b.buildLimit(&tree.Limit{Count: tree.NewDInt(1)}, b.allocScope(), stmtScope)
+		expr = stmtScope.expr
+		// The limit expression will maintain the desired ordering, if any,
+		// so the physical props ordering can be cleared. The presentation
+		// must remain.
+		physProps.Ordering = props.OrderingChoice{}
+	}
+
+	// Only a single column can be returned from a UDF, unless it is used as a
+	// data source. Data sources may output multiple columns, and if the
+	// statement body produces a tuple it needs to be expanded into columns.
+	// When not used as a data source, combine statements producing multiple
+	// columns into a tuple. If the last statement is already returning a
+	// tuple and the function has a record return type, then we do not need to
+	// wrap the output in another tuple.
+	cols := physProps.Presentation
+	isSingleTupleResult := len(stmtScope.cols) == 1 &&
+		stmtScope.cols[0].typ.Family() == types.TupleFamily
+	if b.insideDataSource && rtyp.Family() == types.TupleFamily {
+		// When the UDF is used as a data source and expects to output a tuple
+		// type, its output needs to be a row of columns instead of the usual
+		// tuple. If the last statement output a tuple, we need to expand the
+		// tuple into individual columns.
+		isMultiColDataSource = true
+		if isSingleTupleResult {
+			stmtScope = bodyScope.push()
+			elems := make([]scopeColumn, len(rtyp.TupleContents()))
+			for i := range rtyp.TupleContents() {
+				e := b.factory.ConstructColumnAccess(b.factory.ConstructVariable(cols[0].ID), memo.TupleOrdinal(i))
+				col := b.synthesizeColumn(stmtScope, scopeColName(""), rtyp.TupleContents()[i], nil, e)
+				elems[i] = *col
+			}
+			expr = b.constructProject(expr, elems)
+			physProps = stmtScope.makePhysicalProps()
+		}
+	} else if len(cols) > 1 || (types.IsRecordType(rtyp) && !isSingleTupleResult) {
+		// Only a single column can be returned from a UDF, unless it is used as a
+		// data source (see comment above). If there are multiple columns, combine
+		// them into a tuple. If the last statement is already returning a tuple
+		// and the function has a record return type, then do not wrap the
+		// output in another tuple.
+		elems := make(memo.ScalarListExpr, len(cols))
+		for i := range cols {
+			elems[i] = b.factory.ConstructVariable(cols[i].ID)
+		}
+		tup := b.factory.ConstructTuple(elems, rtyp)
+		stmtScope = bodyScope.push()
+		col := b.synthesizeColumn(stmtScope, scopeColName(""), rtyp, nil /* expr */, tup)
+		expr = b.constructProject(expr, []scopeColumn{*col})
+		physProps = stmtScope.makePhysicalProps()
+	}
+
+	// We must preserve the presentation of columns as physical
+	// properties to prevent the optimizer from pruning the output
+	// column. If necessary, we add an assignment cast to the result
+	// column so that its type matches the function return type. Record return
+	// types do not need an assignment cast, since at this point the return
+	// column is already a tuple.
+	cols = physProps.Presentation
+	if len(cols) > 0 {
+		returnCol := physProps.Presentation[0].ID
+		returnColMeta := b.factory.Metadata().ColumnMeta(returnCol)
+		if !types.IsRecordType(rtyp) && !isMultiColDataSource && !returnColMeta.Type.Identical(rtyp) {
+			if !cast.ValidCast(returnColMeta.Type, rtyp, cast.ContextAssignment) {
+				panic(sqlerrors.NewInvalidAssignmentCastError(
+					returnColMeta.Type, rtyp, returnColMeta.Alias))
+			}
+			cast := b.factory.ConstructAssignmentCast(
+				b.factory.ConstructVariable(physProps.Presentation[0].ID),
+				rtyp,
+			)
+			stmtScope = bodyScope.push()
+			col := b.synthesizeColumn(stmtScope, scopeColName(""), rtyp, nil /* expr */, cast)
+			expr = b.constructProject(expr, []scopeColumn{*col})
+			physProps = stmtScope.makePhysicalProps()
+		}
+	}
+	return expr, physProps, isMultiColDataSource
 }

--- a/pkg/sql/opt/optbuilder/scalar.go
+++ b/pkg/sql/opt/optbuilder/scalar.go
@@ -21,13 +21,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/norm"
-	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
-	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/cast"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree/treebin"
@@ -610,101 +607,6 @@ func (b *Builder) buildFunction(
 	}
 
 	return b.finishBuildScalar(f, out, inScope, outScope, outCol)
-}
-
-// finishBuildLastStmt manages the columns returned by the last statement of a
-// UDF. Depending on the context and return type of the UDF, this may mean
-// expanding a tuple into multiple columns, or combining multiple columns into
-// a tuple.
-func (b *Builder) finishBuildLastStmt(
-	stmtScope *scope, bodyScope *scope, isSetReturning bool, f *tree.FuncExpr,
-) (expr memo.RelExpr, physProps *physical.Required, isMultiColDataSource bool) {
-	expr, physProps = stmtScope.expr, stmtScope.makePhysicalProps()
-	rtyp := f.ResolvedType()
-
-	// Add a LIMIT 1 to the last statement if the UDF is not
-	// set-returning. This is valid because any other rows after the
-	// first can simply be ignored. The limit could be beneficial
-	// because it could allow additional optimization.
-	if !isSetReturning {
-		b.buildLimit(&tree.Limit{Count: tree.NewDInt(1)}, b.allocScope(), stmtScope)
-		expr = stmtScope.expr
-		// The limit expression will maintain the desired ordering, if any,
-		// so the physical props ordering can be cleared. The presentation
-		// must remain.
-		physProps.Ordering = props.OrderingChoice{}
-	}
-
-	// Only a single column can be returned from a UDF, unless it is used as a
-	// data source. Data sources may output multiple columns, and if the
-	// statement body produces a tuple it needs to be expanded into columns.
-	// When not used as a data source, combine statements producing multiple
-	// columns into a tuple. If the last statement is already returning a
-	// tuple and the function has a record return type, then we do not need to
-	// wrap the output in another tuple.
-	cols := physProps.Presentation
-	isSingleTupleResult := len(stmtScope.cols) == 1 &&
-		stmtScope.cols[0].typ.Family() == types.TupleFamily
-	if b.insideDataSource && rtyp.Family() == types.TupleFamily {
-		// When the UDF is used as a data source and expects to output a tuple
-		// type, its output needs to be a row of columns instead of the usual
-		// tuple. If the last statement output a tuple, we need to expand the
-		// tuple into individual columns.
-		isMultiColDataSource = true
-		if isSingleTupleResult {
-			stmtScope = bodyScope.push()
-			elems := make([]scopeColumn, len(rtyp.TupleContents()))
-			for i := range rtyp.TupleContents() {
-				e := b.factory.ConstructColumnAccess(b.factory.ConstructVariable(cols[0].ID), memo.TupleOrdinal(i))
-				col := b.synthesizeColumn(stmtScope, scopeColName(""), rtyp.TupleContents()[i], nil, e)
-				elems[i] = *col
-			}
-			expr = b.constructProject(expr, elems)
-			physProps = stmtScope.makePhysicalProps()
-		}
-	} else if len(cols) > 1 || (types.IsRecordType(rtyp) && !isSingleTupleResult) {
-		// Only a single column can be returned from a UDF, unless it is used as a
-		// data source (see comment above). If there are multiple columns, combine
-		// them into a tuple. If the last statement is already returning a tuple
-		// and the function has a record return type, then do not wrap the
-		// output in another tuple.
-		elems := make(memo.ScalarListExpr, len(cols))
-		for i := range cols {
-			elems[i] = b.factory.ConstructVariable(cols[i].ID)
-		}
-		tup := b.factory.ConstructTuple(elems, rtyp)
-		stmtScope = bodyScope.push()
-		col := b.synthesizeColumn(stmtScope, scopeColName(""), rtyp, nil /* expr */, tup)
-		expr = b.constructProject(expr, []scopeColumn{*col})
-		physProps = stmtScope.makePhysicalProps()
-	}
-
-	// We must preserve the presentation of columns as physical
-	// properties to prevent the optimizer from pruning the output
-	// column. If necessary, we add an assignment cast to the result
-	// column so that its type matches the function return type. Record return
-	// types do not need an assignment cast, since at this point the return
-	// column is already a tuple.
-	cols = physProps.Presentation
-	if len(cols) > 0 {
-		returnCol := physProps.Presentation[0].ID
-		returnColMeta := b.factory.Metadata().ColumnMeta(returnCol)
-		if !types.IsRecordType(rtyp) && !isMultiColDataSource && !returnColMeta.Type.Identical(rtyp) {
-			if !cast.ValidCast(returnColMeta.Type, rtyp, cast.ContextAssignment) {
-				panic(sqlerrors.NewInvalidAssignmentCastError(
-					returnColMeta.Type, rtyp, returnColMeta.Alias))
-			}
-			cast := b.factory.ConstructAssignmentCast(
-				b.factory.ConstructVariable(physProps.Presentation[0].ID),
-				rtyp,
-			)
-			stmtScope = bodyScope.push()
-			col := b.synthesizeColumn(stmtScope, scopeColName(""), rtyp, nil /* expr */, cast)
-			expr = b.constructProject(expr, []scopeColumn{*col})
-			physProps = stmtScope.makePhysicalProps()
-		}
-	}
-	return expr, physProps, isMultiColDataSource
 }
 
 // buildRangeCond builds a RANGE clause as a simpler expression. Examples:


### PR DESCRIPTION
When routine-related optbuilder logic was moved to a new file,
`routine.go`, the `finishBuildLastStmt` function was missed. This commit
corrects that mistake.

Epic: CRDB-25388

Release note: None
