### PR TITLE
ctxutil: better compatibility with go 1.21

### DIFF
--- a/pkg/util/ctxutil/BUILD.bazel
+++ b/pkg/util/ctxutil/BUILD.bazel
@@ -7,7 +7,7 @@ go_library(
         "canceler_1_20.go",
         "context.go",
         "doc.go",
-        "link_1_21_bazel.go",
+        "link_1_21.go",
         "link_pre_1_21.go",
         "link_shared.go",
     ],
@@ -16,7 +16,6 @@ go_library(
     deps = [
         "//pkg/util/buildutil",
         "//pkg/util/log",
-        "@com_github_cockroachdb_errors//:errors",
     ],
 )
 

--- a/pkg/util/ctxutil/link_1_21.go
+++ b/pkg/util/ctxutil/link_1_21.go
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-//go:build go1.21 && !bazel
+//go:build go1.21
 
 package ctxutil
 
@@ -16,6 +16,8 @@ import "context"
 
 // Linkage definition for go1.21 or higher built outside ./dev toolchain --
 // that is, a toolchain that did not apply cockroach runtime patches.
+
+// TODO(knz): Remove this during #112089.
 
 // context_propagateCancel propagates cancellation from parent to child.
 // Since this code was built outside ./dev (i.e. "!bazel" tag defined),
@@ -27,7 +29,12 @@ func context_propagateCancel(parent context.Context, child canceler) {
 		panic("unexpected non-cancelable context")
 	}
 	go func() {
-		<-done
+		select {
+		case <-child.Done():
+			// Avoid leaking the goroutine.
+			return
+		case <-done:
+		}
 		child.(*whenDone).notify()
 	}()
 }

--- a/pkg/util/ctxutil/link_1_21_bazel.go
+++ b/pkg/util/ctxutil/link_1_21_bazel.go
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-//go:build go1.21 && bazel
+//go:build go1.21 && neverbuild
 
 package ctxutil
 
@@ -21,6 +21,8 @@ import (
 
 // Linkage definition for go1.21 or higher built with ./dev toolchain --
 // that is, a toolchain that applies cockroach runtime patches.
+
+// TODO(knz): Remove this during #112089.
 
 // Gross hack to access internal context function.  Sometimes, go makes things
 // SO much more difficult than it needs to.


### PR DESCRIPTION
Informs https://github.com/cockroachdb/cockroach/issues/112088.
Needed for https://github.com/cockroachdb/cockroach/pull/111928.

This is a temporary fallback until we make #112089 work well.

Release note: None