### PR TITLE
server: add tests for combined stmts api source tables

### DIFF
--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -2139,6 +2139,7 @@ GO_TARGETS = [
     "//pkg/sql/sqlstats/insights/integration:integration_test",
     "//pkg/sql/sqlstats/insights:insights",
     "//pkg/sql/sqlstats/insights:insights_test",
+    "//pkg/sql/sqlstats/persistedsqlstats/sqlstatstestutil:sqlstatstestutil",
     "//pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil:sqlstatsutil",
     "//pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil:sqlstatsutil_test",
     "//pkg/sql/sqlstats/persistedsqlstats:persistedsqlstats",

--- a/pkg/server/application_api/BUILD.bazel
+++ b/pkg/server/application_api/BUILD.bazel
@@ -67,6 +67,7 @@ go_test(
         "//pkg/sql/sessiondata",
         "//pkg/sql/sqlstats",
         "//pkg/sql/sqlstats/persistedsqlstats",
+        "//pkg/sql/sqlstats/persistedsqlstats/sqlstatstestutil",
         "//pkg/testutils",
         "//pkg/testutils/diagutils",
         "//pkg/testutils/serverutils",

--- a/pkg/server/combined_statement_stats.go
+++ b/pkg/server/combined_statement_stats.go
@@ -36,12 +36,12 @@ import (
 
 const (
 	// Table sources.
-	crdbInternalStmtStatsCombined  = "crdb_internal.statement_statistics"
-	crdbInternalStmtStatsPersisted = "crdb_internal.statement_statistics_persisted"
-	crdbInternalStmtStatsCached    = "crdb_internal.statement_activity"
-	crdbInternalTxnStatsCombined   = "crdb_internal.transaction_statistics"
-	crdbInternalTxnStatsPersisted  = "crdb_internal.transaction_statistics_persisted"
-	crdbInternalTxnStatsCached     = "crdb_internal.transaction_activity"
+	CrdbInternalStmtStatsCombined  = "crdb_internal.statement_statistics"
+	CrdbInternalStmtStatsPersisted = "crdb_internal.statement_statistics_persisted"
+	CrdbInternalStmtStatsCached    = "crdb_internal.statement_activity"
+	CrdbInternalTxnStatsCombined   = "crdb_internal.transaction_statistics"
+	CrdbInternalTxnStatsPersisted  = "crdb_internal.transaction_statistics_persisted"
+	CrdbInternalTxnStatsCached     = "crdb_internal.transaction_activity"
 
 	// Sorts
 	sortSvcLatDesc         = `(statistics -> 'statistics' -> 'svcLat' ->> 'mean')::FLOAT DESC`
@@ -429,7 +429,7 @@ FROM %s %s`, table, whereClause)
 	// we will swap to using one source table for all stmts returned in a request.
 	stmtsRuntime = 0
 	if activityTableHasAllData && (req.FetchMode == nil || req.FetchMode.StatsType == serverpb.CombinedStatementsStatsRequest_StmtStatsOnly) {
-		stmtSourceTable = crdbInternalStmtStatsCached
+		stmtSourceTable = CrdbInternalStmtStatsCached
 		stmtsRuntime, err = getRuntime(stmtSourceTable, createActivityTableQuery)
 		if err != nil {
 			return 0, 0, nil, stmtSourceTable, "", err
@@ -441,7 +441,7 @@ FROM %s %s`, table, whereClause)
 	}
 	// If there are no results from the activity table, retrieve the data from the persisted table.
 	if stmtsRuntime == 0 {
-		stmtSourceTable = crdbInternalStmtStatsPersisted + tableSuffix
+		stmtSourceTable = CrdbInternalStmtStatsPersisted + tableSuffix
 		stmtsRuntime, err = getRuntime(stmtSourceTable, createStatsTableQuery)
 		if err != nil {
 			return 0, 0, nil, stmtSourceTable, "", err
@@ -454,7 +454,7 @@ FROM %s %s`, table, whereClause)
 	// If there are no results from the persisted table, retrieve the data from the combined view
 	// with data in-memory.
 	if stmtsRuntime == 0 {
-		stmtSourceTable = crdbInternalStmtStatsCombined
+		stmtSourceTable = CrdbInternalStmtStatsCombined
 		stmtsRuntime, err = getRuntime(stmtSourceTable, createStatsTableQuery)
 		if err != nil {
 			return 0, 0, nil, stmtSourceTable, "", err
@@ -468,7 +468,7 @@ FROM %s %s`, table, whereClause)
 	txnsRuntime = 0
 	if req.FetchMode == nil || req.FetchMode.StatsType != serverpb.CombinedStatementsStatsRequest_StmtStatsOnly {
 		if activityTableHasAllData {
-			txnSourceTable = crdbInternalTxnStatsCached
+			txnSourceTable = CrdbInternalTxnStatsCached
 			txnsRuntime, err = getRuntime(txnSourceTable, createActivityTableQuery)
 			if err != nil {
 				return 0, 0, nil, stmtSourceTable, txnSourceTable, err
@@ -476,7 +476,7 @@ FROM %s %s`, table, whereClause)
 		}
 		// If there are no results from the activity table, retrieve the data from the persisted table.
 		if txnsRuntime == 0 {
-			txnSourceTable = crdbInternalTxnStatsPersisted + tableSuffix
+			txnSourceTable = CrdbInternalTxnStatsPersisted + tableSuffix
 			txnsRuntime, err = getRuntime(txnSourceTable, createStatsTableQuery)
 			if err != nil {
 				return 0, 0, nil, stmtSourceTable, txnSourceTable, err
@@ -485,7 +485,7 @@ FROM %s %s`, table, whereClause)
 		// If there are no results from the persisted table, retrieve the data from the combined view
 		// with data in-memory.
 		if txnsRuntime == 0 {
-			txnSourceTable = crdbInternalTxnStatsCombined
+			txnSourceTable = CrdbInternalTxnStatsCombined
 			txnsRuntime, err = getRuntime(txnSourceTable, createStatsTableQuery)
 			if err != nil {
 				return 0, 0, nil, stmtSourceTable, txnSourceTable, err
@@ -735,7 +735,7 @@ FROM (SELECT fingerprint_id,
           fingerprint_id,
           app_name) %s
 %s`,
-			crdbInternalStmtStatsCached,
+			CrdbInternalStmtStatsCached,
 			"combined-stmts-activity-by-interval",
 			whereClause,
 			args,
@@ -755,7 +755,7 @@ FROM (SELECT fingerprint_id,
 			ctx,
 			ie,
 			queryFormat,
-			crdbInternalStmtStatsPersisted+tableSuffix,
+			CrdbInternalStmtStatsPersisted+tableSuffix,
 			"combined-stmts-persisted-by-interval",
 			whereClause,
 			args,
@@ -774,7 +774,7 @@ FROM (SELECT fingerprint_id,
 			ctx,
 			ie,
 			queryFormat,
-			crdbInternalStmtStatsCombined,
+			CrdbInternalStmtStatsCombined,
 			"combined-stmts-with-memory-by-interval",
 			whereClause,
 			args,
@@ -911,7 +911,7 @@ FROM (SELECT app_name,
 			ctx,
 			ie,
 			queryFormat,
-			crdbInternalTxnStatsCached,
+			CrdbInternalTxnStatsCached,
 			"combined-txns-activity-by-interval",
 			whereClause,
 			args,
@@ -935,7 +935,7 @@ FROM (SELECT app_name,
 			ctx,
 			ie,
 			queryFormat,
-			crdbInternalTxnStatsPersisted+tableSuffix,
+			CrdbInternalTxnStatsPersisted+tableSuffix,
 			"combined-txns-persisted-by-interval",
 			whereClause,
 			args,
@@ -954,7 +954,7 @@ FROM (SELECT app_name,
 			ctx,
 			ie,
 			queryFormat,
-			crdbInternalTxnStatsCombined,
+			CrdbInternalTxnStatsCombined,
 			"combined-txns-with-memory-by-interval",
 			whereClause,
 			args,
@@ -1049,7 +1049,7 @@ GROUP BY
 
 	query := fmt.Sprintf(
 		queryFormat,
-		crdbInternalStmtStatsPersisted+tableSuffix,
+		CrdbInternalStmtStatsPersisted+tableSuffix,
 		whereClause)
 	it, err = ie.QueryIteratorEx(ctx, "console-combined-stmts-persisted-for-txn", nil,
 		sessiondata.NodeUserSessionDataOverride, query, args...)
@@ -1065,7 +1065,7 @@ GROUP BY
 		if err != nil {
 			return nil, srverrors.ServerError(ctx, err)
 		}
-		query = fmt.Sprintf(queryFormat, crdbInternalStmtStatsCombined, whereClause)
+		query = fmt.Sprintf(queryFormat, CrdbInternalStmtStatsCombined, whereClause)
 
 		it, err = ie.QueryIteratorEx(ctx, "console-combined-stmts-with-memory-for-txn", nil,
 			sessiondata.NodeUserSessionDataOverride, query, args...)

--- a/pkg/server/statement_details.go
+++ b/pkg/server/statement_details.go
@@ -254,7 +254,7 @@ LIMIT 1`, whereClause), args...)
 			sessiondata.NodeUserSessionDataOverride,
 			fmt.Sprintf(
 				queryFormat,
-				crdbInternalStmtStatsPersisted+tableSuffix,
+				CrdbInternalStmtStatsPersisted+tableSuffix,
 				whereClause), args...)
 		if err != nil {
 			return statement, srverrors.ServerError(ctx, err)
@@ -266,7 +266,7 @@ LIMIT 1`, whereClause), args...)
 	if row.Len() == 0 {
 		row, err = ie.QueryRowEx(ctx, "combined-stmts-details-total-with-memory", nil,
 			sessiondata.NodeUserSessionDataOverride,
-			fmt.Sprintf(queryFormat, crdbInternalStmtStatsCombined, whereClause), args...)
+			fmt.Sprintf(queryFormat, CrdbInternalStmtStatsCombined, whereClause), args...)
 		if err != nil {
 			return statement, srverrors.ServerError(ctx, err)
 		}
@@ -368,7 +368,7 @@ LIMIT $%d`, whereClause, len(args)),
 		}
 		query = fmt.Sprintf(
 			queryFormat,
-			crdbInternalStmtStatsPersisted+tableSuffix,
+			CrdbInternalStmtStatsPersisted+tableSuffix,
 			whereClause,
 			len(args))
 
@@ -384,7 +384,7 @@ LIMIT $%d`, whereClause, len(args)),
 	// with data in-memory.
 	if !it.HasResults() {
 		err = closeIterator(it, err)
-		query = fmt.Sprintf(queryFormat, crdbInternalStmtStatsCombined, whereClause, len(args))
+		query = fmt.Sprintf(queryFormat, CrdbInternalStmtStatsCombined, whereClause, len(args))
 		it, err = ie.QueryIteratorEx(ctx, "console-combined-stmts-details-by-aggregated-timestamp-with-memory", nil,
 			sessiondata.NodeUserSessionDataOverride, query, args...)
 		if err != nil {
@@ -580,7 +580,7 @@ LIMIT $%d`, whereClause, len(args)), args...)
 	// with data in-memory.
 	if !it.HasResults() {
 		err = closeIterator(it, err)
-		query = fmt.Sprintf(queryFormat, crdbInternalStmtStatsCombined, whereClause, len(args))
+		query = fmt.Sprintf(queryFormat, CrdbInternalStmtStatsCombined, whereClause, len(args))
 		it, iterErr = ie.QueryIteratorEx(ctx, "console-combined-stmts-details-by-plan-hash-with-memory", nil,
 			sessiondata.NodeUserSessionDataOverride, query, args...)
 		if iterErr != nil {

--- a/pkg/sql/sqlstats/persistedsqlstats/sqlstatstestutil/BUILD.bazel
+++ b/pkg/sql/sqlstats/persistedsqlstats/sqlstatstestutil/BUILD.bazel
@@ -6,7 +6,11 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/sqlstats/persistedsqlstats/sqlstatstestutil",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/base",
+        "//pkg/sql",
         "//pkg/sql/appstatspb",
+        "//pkg/sql/sem/tree",
+        "//pkg/sql/sessiondata",
         "//pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil",
     ],
 )

--- a/pkg/sql/sqlstats/persistedsqlstats/sqlstatstestutil/BUILD.bazel
+++ b/pkg/sql/sqlstats/persistedsqlstats/sqlstatstestutil/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "sqlstatstestutil",
+    srcs = ["testutils.go"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/sql/sqlstats/persistedsqlstats/sqlstatstestutil",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/sql/appstatspb",
+        "//pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil",
+    ],
+)

--- a/pkg/sql/sqlstats/persistedsqlstats/sqlstatstestutil/testutils.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/sqlstatstestutil/testutils.go
@@ -11,10 +11,16 @@
 package sqlstatstestutil
 
 import (
+	"context"
 	"reflect"
 	"testing"
+	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/appstatspb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil"
 )
 
@@ -27,4 +33,240 @@ func GetRandomizedCollectedStatementStatisticsForTest(
 	sqlstatsutil.FillObject(t, reflect.ValueOf(&result), &data)
 
 	return result
+}
+
+// GetRandomizedCollectedTransactionStatisticsForTest returns a
+// appstatspb.CollectedTransactionStatistics with its fields randomly filled.
+func GetRandomizedCollectedTransactionStatisticsForTest(
+	t *testing.T,
+) (result appstatspb.CollectedTransactionStatistics) {
+	data := sqlstatsutil.GenRandomData()
+	sqlstatsutil.FillObject(t, reflect.ValueOf(&result), &data)
+
+	return result
+}
+
+func InsertMockedIntoSystemStmtStats(
+	ctx context.Context,
+	ie *sql.InternalExecutor,
+	stmtStats *appstatspb.CollectedStatementStatistics,
+	nodeID base.SQLInstanceID,
+	aggInterval *time.Duration,
+) error {
+	if stmtStats == nil {
+		return nil
+	}
+
+	aggIntervalVal := time.Hour
+	if aggInterval != nil {
+		aggIntervalVal = *aggInterval
+	}
+
+	stmtFingerprint := sqlstatsutil.EncodeUint64ToBytes(uint64(stmtStats.ID))
+	txnFingerprint := sqlstatsutil.EncodeUint64ToBytes(uint64(stmtStats.Key.TransactionFingerprintID))
+	planHash := sqlstatsutil.EncodeUint64ToBytes(stmtStats.Key.PlanHash)
+
+	metadataJSON, err := sqlstatsutil.BuildStmtMetadataJSON(stmtStats)
+	if err != nil {
+		return err
+	}
+
+	statisticsJSON, err := sqlstatsutil.BuildStmtStatisticsJSON(&stmtStats.Stats)
+	if err != nil {
+		return err
+	}
+	statistics := tree.NewDJSON(statisticsJSON)
+
+	plan := tree.NewDJSON(sqlstatsutil.ExplainTreePlanNodeToJSON(&stmtStats.Stats.SensitiveInfo.MostRecentPlanDescription))
+
+	metadata := tree.NewDJSON(metadataJSON)
+
+	_, err = ie.ExecEx(ctx, "insert-mock-stmt-stats", nil, sessiondata.NodeUserSessionDataOverride,
+		`UPSERT INTO system.statement_statistics
+VALUES ($1 ,$2, $3, $4, $5, $6, $7, $8, $9, $10)`,
+		stmtStats.AggregatedTs, // aggregated_ts
+		stmtFingerprint,        // fingerprint_id
+		txnFingerprint,         // transaction_fingerprint_id
+		planHash,               // plan_hash
+		stmtStats.Key.App,      // app_name
+		nodeID,                 // node_id
+		aggIntervalVal,         // agg_interval
+		metadata,               // metadata
+		statistics,             // statistics
+		plan,                   // plan
+	)
+
+	return err
+}
+
+func InsertMockedIntoSystemTxnStats(
+	ctx context.Context,
+	ie *sql.InternalExecutor,
+	stats *appstatspb.CollectedTransactionStatistics,
+	nodeID base.SQLInstanceID,
+	aggInterval *time.Duration,
+) error {
+	if stats == nil {
+		return nil
+	}
+
+	aggIntervalVal := time.Hour
+	if aggInterval != nil {
+		aggIntervalVal = *aggInterval
+	}
+
+	txnFingerprint := sqlstatsutil.EncodeUint64ToBytes(uint64(stats.TransactionFingerprintID))
+
+	statisticsJSON, err := sqlstatsutil.BuildTxnStatisticsJSON(stats)
+	if err != nil {
+		return err
+	}
+	statistics := tree.NewDJSON(statisticsJSON)
+
+	metadataJSON, err := sqlstatsutil.BuildTxnMetadataJSON(stats)
+	if err != nil {
+		return err
+	}
+	metadata := tree.NewDJSON(metadataJSON)
+	aggregatedTs := stats.AggregatedTs
+
+	_, err = ie.ExecEx(ctx, "insert-mock-txn-stats", nil, sessiondata.NodeUserSessionDataOverride,
+		` UPSERT INTO system.transaction_statistics
+VALUES ($1 ,$2, $3, $4, $5, $6, $7)`,
+		aggregatedTs,   // aggregated_ts
+		txnFingerprint, // fingerprint_id
+		stats.App,      // app_name
+		nodeID,         // node_id
+		aggIntervalVal, // agg_interval
+		metadata,       // metadata
+		statistics,     // statistics
+	)
+
+	return err
+}
+
+func InsertMockedIntoSystemStmtActivity(
+	ctx context.Context,
+	ie *sql.InternalExecutor,
+	stmtStats *appstatspb.CollectedStatementStatistics,
+	aggInterval *time.Duration,
+) error {
+	if stmtStats == nil {
+		return nil
+	}
+
+	aggIntervalVal := time.Hour
+	if aggInterval != nil {
+		aggIntervalVal = *aggInterval
+	}
+
+	stmtFingerprint := sqlstatsutil.EncodeUint64ToBytes(uint64(stmtStats.ID))
+	txnFingerprint := sqlstatsutil.EncodeUint64ToBytes(uint64(stmtStats.Key.TransactionFingerprintID))
+	planHash := sqlstatsutil.EncodeUint64ToBytes(stmtStats.Key.PlanHash)
+
+	statisticsJSON, err := sqlstatsutil.BuildStmtStatisticsJSON(&stmtStats.Stats)
+	if err != nil {
+		return err
+	}
+	statistics := tree.NewDJSON(statisticsJSON)
+
+	plan := tree.NewDJSON(sqlstatsutil.ExplainTreePlanNodeToJSON(&stmtStats.Stats.SensitiveInfo.MostRecentPlanDescription))
+
+	metadataJSON, err := sqlstatsutil.BuildStmtDetailsMetadataJSON(
+		&appstatspb.AggregatedStatementMetadata{
+			Query:          stmtStats.Key.Query,
+			FormattedQuery: "",
+			QuerySummary:   "",
+			StmtType:       "",
+			AppNames:       []string{stmtStats.Key.App},
+			Databases:      []string{stmtStats.Key.Database},
+			ImplicitTxn:    false,
+			DistSQLCount:   0,
+			FailedCount:    0,
+			FullScanCount:  0,
+			VecCount:       0,
+			TotalCount:     0,
+		})
+	if err != nil {
+		return err
+	}
+	metadata := tree.NewDJSON(metadataJSON)
+
+	_, err = ie.ExecEx(ctx, "insert-mock-stmt-activity", nil, sessiondata.NodeUserSessionDataOverride,
+		`UPSERT INTO system.statement_activity
+VALUES ($1 ,$2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)`,
+		stmtStats.AggregatedTs, // aggregated_ts
+		stmtFingerprint,        // fingerprint_id
+		txnFingerprint,         // transaction_fingerprint_id
+		planHash,               // plan_hash
+		stmtStats.Key.App,      // app_name
+		aggIntervalVal,         // agg_interval
+		metadata,               // metadata
+		statistics,             // statistics
+		plan,                   // plan
+		// TODO allow these values to be mocked. No need for them right now.
+		[]string{}, // index_recommendations
+		1,          // execution_count
+		1,          // execution_total_seconds
+		1,          // execution_total_cluster_seconds
+		1,          // contention_time_avg_seconds
+		1,          // cpu_sql_avg_nanos
+		1,          //  service_latency_avg_seconds
+		1,          // service_latency_p99_seconds
+	)
+
+	return err
+}
+
+func InsertMockedIntoSystemTxnActivity(
+	ctx context.Context,
+	ie *sql.InternalExecutor,
+	stats *appstatspb.CollectedTransactionStatistics,
+	aggInterval *time.Duration,
+) error {
+	if stats == nil {
+		return nil
+	}
+
+	aggIntervalVal := time.Hour
+	if aggInterval != nil {
+		aggIntervalVal = *aggInterval
+	}
+
+	txnFingerprint := sqlstatsutil.EncodeUint64ToBytes(uint64(stats.TransactionFingerprintID))
+
+	statisticsJSON, err := sqlstatsutil.BuildTxnStatisticsJSON(stats)
+	if err != nil {
+		return err
+	}
+	statistics := tree.NewDJSON(statisticsJSON)
+
+	metadataJSON, err := sqlstatsutil.BuildTxnMetadataJSON(stats)
+	if err != nil {
+		return err
+	}
+	metadata := tree.NewDJSON(metadataJSON)
+	aggregatedTs := stats.AggregatedTs
+
+	_, err = ie.ExecEx(ctx, "insert-mock-txn-activity", nil, sessiondata.NodeUserSessionDataOverride,
+		` UPSERT INTO system.transaction_activity
+VALUES ($1 ,$2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)`,
+		aggregatedTs,   // aggregated_ts
+		txnFingerprint, // fingerprint_id
+		stats.App,      // app_name
+		aggIntervalVal, // agg_interval
+		metadata,       // metadata
+		statistics,     // statistics
+		// TODO (xinhaoz) allow mocking of these fields. Not necessary at the moment.
+		"", // query
+		1,  // execution_count
+		1,  // execution_total_seconds
+		1,  // execution_total_cluster_seconds
+		1,  // contention_time_avg_seconds
+		1,  // cpu_sql_avg_nanos
+		1,  // service_latency_avg_seconds
+		1,  // service_latency_p99_seconds
+	)
+
+	return err
 }

--- a/pkg/sql/sqlstats/persistedsqlstats/sqlstatstestutil/testutils.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/sqlstatstestutil/testutils.go
@@ -1,0 +1,30 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sqlstatstestutil
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/appstatspb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil"
+)
+
+// GetRandomizedCollectedStatementStatisticsForTest returns a
+// appstatspb.CollectedStatementStatistics with its fields randomly filled.
+func GetRandomizedCollectedStatementStatisticsForTest(
+	t *testing.T,
+) (result appstatspb.CollectedStatementStatistics) {
+	data := sqlstatsutil.GenRandomData()
+	sqlstatsutil.FillObject(t, reflect.ValueOf(&result), &data)
+
+	return result
+}

--- a/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_encoding_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_encoding_test.go
@@ -36,7 +36,7 @@ func TestSQLStatsJsonEncoding(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	t.Run("statement_statistics", func(t *testing.T) {
-		data := genRandomData()
+		data := GenRandomData()
 		input := appstatspb.CollectedStatementStatistics{}
 
 		expectedMetadataStrTemplate := `
@@ -200,7 +200,7 @@ func TestSQLStatsJsonEncoding(t *testing.T) {
 
 		expectedMetadataStr := fillTemplate(t, expectedMetadataStrTemplate, data)
 		expectedStatisticsStr := fillTemplate(t, expectedStatisticsStrTemplate, data)
-		fillObject(t, reflect.ValueOf(&input), &data)
+		FillObject(t, reflect.ValueOf(&input), &data)
 
 		actualMetadataJSON, err := BuildStmtMetadataJSON(&input)
 		require.NoError(t, err)
@@ -228,7 +228,7 @@ func TestSQLStatsJsonEncoding(t *testing.T) {
 	// new parameter, so this test is to confirm that all other parameters will be set and
 	// the new one will be empty, without breaking the decoding process.
 	t.Run("statement_statistics with new parameter", func(t *testing.T) {
-		data := genRandomData()
+		data := GenRandomData()
 		expectedStatistics := appstatspb.CollectedStatementStatistics{}
 
 		expectedMetadataStrTemplate := `
@@ -385,7 +385,7 @@ func TestSQLStatsJsonEncoding(t *testing.T) {
 
 		fillTemplate(t, expectedMetadataStrTemplate, data)
 		fillTemplate(t, expectedStatisticsStrTemplate, data)
-		fillObject(t, reflect.ValueOf(&expectedStatistics), &data)
+		FillObject(t, reflect.ValueOf(&expectedStatistics), &data)
 
 		actualMetadataJSON, err := BuildStmtMetadataJSON(&expectedStatistics)
 		require.NoError(t, err)
@@ -412,7 +412,7 @@ func TestSQLStatsJsonEncoding(t *testing.T) {
 	})
 
 	t.Run("transaction_statistics", func(t *testing.T) {
-		data := genRandomData()
+		data := GenRandomData()
 
 		input := appstatspb.CollectedTransactionStatistics{
 			StatementFingerprintIDs: []appstatspb.StmtFingerprintID{
@@ -552,7 +552,7 @@ func TestSQLStatsJsonEncoding(t *testing.T) {
 }
 		 `
 		expectedStatisticsStr := fillTemplate(t, expectedStatisticsStrTemplate, data)
-		fillObject(t, reflect.ValueOf(&input), &data)
+		FillObject(t, reflect.ValueOf(&input), &data)
 
 		actualMetadataJSON, err := BuildTxnMetadataJSON(&input)
 		require.NoError(t, err)
@@ -574,7 +574,7 @@ func TestSQLStatsJsonEncoding(t *testing.T) {
 	})
 
 	t.Run("statement aggregated metadata", func(t *testing.T) {
-		data := genRandomData()
+		data := GenRandomData()
 
 		input := appstatspb.AggregatedStatementMetadata{}
 
@@ -596,7 +596,7 @@ func TestSQLStatsJsonEncoding(t *testing.T) {
 }
 		 `
 		expectedAggregatedMetadataStr := fillTemplate(t, expectedAggregatedMetadataStrTemplate, data)
-		fillObject(t, reflect.ValueOf(&input), &data)
+		FillObject(t, reflect.ValueOf(&input), &data)
 
 		actualMetadataJSON, err := BuildStmtDetailsMetadataJSON(&input)
 		require.NoError(t, err)

--- a/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/testutils.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/testutils.go
@@ -20,21 +20,9 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/sql/appstatspb"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/stretchr/testify/require"
 )
-
-// GetRandomizedCollectedStatementStatisticsForTest returns a
-// appstatspb.CollectedStatementStatistics with its fields randomly filled.
-func GetRandomizedCollectedStatementStatisticsForTest(
-	t *testing.T,
-) (result appstatspb.CollectedStatementStatistics) {
-	data := genRandomData()
-	fillObject(t, reflect.ValueOf(&result), &data)
-
-	return result
-}
 
 type randomData struct {
 	Bool        bool
@@ -48,7 +36,7 @@ type randomData struct {
 
 var alphabet = []rune("abcdefghijklmkopqrstuvwxyz")
 
-func genRandomData() randomData {
+func GenRandomData() randomData {
 	r := randomData{}
 	r.Bool = rand.Float64() > 0.5
 
@@ -134,7 +122,7 @@ var fieldBlacklist = map[string]struct{}{
 	"AggregationInterval":     {},
 }
 
-func fillObject(t *testing.T, val reflect.Value, data *randomData) {
+func FillObject(t *testing.T, val reflect.Value, data *randomData) {
 	// Do not set the fields that are not being encoded as json.
 	if val.Kind() != reflect.Ptr {
 		t.Fatal("not a pointer type")
@@ -179,7 +167,7 @@ func fillObject(t *testing.T, val reflect.Value, data *randomData) {
 					continue
 				}
 
-				fillObject(t, fieldAddr, data)
+				FillObject(t, fieldAddr, data)
 			}
 		}
 	default:

--- a/pkg/sql/sqlstats/sslocal/BUILD.bazel
+++ b/pkg/sql/sqlstats/sslocal/BUILD.bazel
@@ -60,7 +60,7 @@ go_test(
         "//pkg/sql/sqlstats",
         "//pkg/sql/sqlstats/insights",
         "//pkg/sql/sqlstats/persistedsqlstats",
-        "//pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil",
+        "//pkg/sql/sqlstats/persistedsqlstats/sqlstatstestutil",
         "//pkg/testutils",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/sqlutils",

--- a/pkg/sql/sqlstats/sslocal/sql_stats_test.go
+++ b/pkg/sql/sqlstats/sslocal/sql_stats_test.go
@@ -35,7 +35,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/insights"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/persistedsqlstats"
-	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/persistedsqlstats/sqlstatstestutil"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/sslocal"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -62,7 +62,7 @@ func TestStmtStatsBulkIngestWithRandomMetadata(t *testing.T) {
 
 	for i := 0; i < 50; i++ {
 		var stats serverpb.StatementsResponse_CollectedStatementStatistics
-		randomData := sqlstatsutil.GetRandomizedCollectedStatementStatisticsForTest(t)
+		randomData := sqlstatstestutil.GetRandomizedCollectedStatementStatisticsForTest(t)
 		stats.Key.KeyData = randomData.Key
 		testData = append(testData, stats)
 	}


### PR DESCRIPTION
This patch creates the sqlstatstestutils pkg in
sqlstats/persistedsqlstats.  It moves the function
`GetRandomizedCollectedStatementStatisticsForTest` which was
previously in sqlstatsutil. This pkg is introduced in
preparation for adding more testing utilities to mock sql
stats tables without creating cyclic dependencies with
sqlstatsutil.

Epic: none

Release note: None

### 2: [server: add tests for combined stmts api](https://github.com/cockroachdb/cockroach/commit/1bf95c1d6dd1a680b9944a730020eee26c5bf580)

Add testing to verify that the combined stmts api uses the
correct source tables given different table states.

Epic: none