### PR TITLE
roachprod: azure refresh cli credential

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -82,6 +82,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.1.0
 	github.com/Azure/azure-sdk-for-go/sdk/keyvault/azkeys v0.9.0
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v0.6.1
+	github.com/Azure/go-autorest/autorest/adal v0.9.15
 	github.com/BurntSushi/toml v1.2.1
 	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/MichaelTJones/walk v0.0.0-20161122175330-4748e29d5718
@@ -241,7 +242,6 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/keyvault/internal v0.7.0 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
 	github.com/Azure/go-autorest v14.2.0+incompatible // indirect
-	github.com/Azure/go-autorest/autorest/adal v0.9.15 // indirect
 	github.com/Azure/go-autorest/autorest/date v0.3.0 // indirect
 	github.com/Azure/go-autorest/autorest/validation v0.3.1 // indirect
 	github.com/Azure/go-autorest/logger v0.2.1 // indirect

--- a/pkg/roachprod/vm/azure/BUILD.bazel
+++ b/pkg/roachprod/vm/azure/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
         "@com_github_azure_azure_sdk_for_go//profiles/latest/resources/mgmt/subscriptions",
         "@com_github_azure_azure_sdk_for_go//services/compute/mgmt/2019-07-01/compute",
         "@com_github_azure_go_autorest_autorest//:autorest",
+        "@com_github_azure_go_autorest_autorest_adal//:adal",
         "@com_github_azure_go_autorest_autorest_azure_auth//:auth",
         "@com_github_azure_go_autorest_autorest_to//:to",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/roachprod/vm/azure/auth.go
+++ b/pkg/roachprod/vm/azure/auth.go
@@ -13,8 +13,10 @@ package azure
 import (
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/adal"
 	"github.com/Azure/go-autorest/autorest/azure/auth"
 	"github.com/cockroachdb/errors"
 )
@@ -31,30 +33,62 @@ var hasEnvAuth = os.Getenv("AZURE_TENANT_ID") != "" &&
 // to install the Azure CLI.
 //
 // The Authorizer is memoized in the Provider.
-func (p *Provider) getAuthorizer() (ret autorest.Authorizer, err error) {
+func (p *Provider) getAuthorizer() (autorest.Authorizer, error) {
+	var authorizer autorest.Authorizer
 	p.mu.Lock()
-	ret = p.mu.authorizer
+	authorizer = p.mu.authorizer
 	p.mu.Unlock()
-	if ret != nil {
-		return
-	}
 
+	if authorizer != nil {
+		// Return the memoized authorizer if isn't soon to or already expired.
+		shouldRefresh, err := shouldRefreshAuth(authorizer)
+		if err != nil {
+			return nil, err
+		}
+
+		if !shouldRefresh {
+			return authorizer, nil
+		}
+	}
 	// Use the environment or azure CLI to bootstrap our authentication.
 	// https://docs.microsoft.com/en-us/go/azure/azure-sdk-go-authorization
+	var err error
 	if hasEnvAuth {
-		ret, err = auth.NewAuthorizerFromEnvironment()
+		authorizer, err = auth.NewAuthorizerFromEnvironment()
 	} else {
-		ret, err = auth.NewAuthorizerFromCLI()
+		authorizer, err = auth.NewAuthorizerFromCLI()
 	}
 
-	if err == nil {
-		p.mu.Lock()
-		p.mu.authorizer = ret
-		p.mu.Unlock()
-	} else {
-		err = errors.Wrap(err, "could not get Azure auth token")
+	if err != nil {
+		return nil, errors.Wrap(err, "could not get Azure auth token")
 	}
-	return
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.mu.authorizer = authorizer
+
+	return authorizer, err
+}
+
+// shouldRefreshAuth conservatively returns true if the current token is set to expire within 5 minutes.
+// CLI based tokens can have a variable length expiry of 5 - 60 minutes.
+// https://learn.microsoft.com/en-us/cli/azure/account?view=azure-cli-latest#az-account-get-access-token()
+func shouldRefreshAuth(authorizer autorest.Authorizer) (bool, error) {
+	// Environment based auth does not expire.
+	if hasEnvAuth {
+		return false, nil
+	}
+	bearerAuthorizer, ok := authorizer.(*autorest.BearerAuthorizer)
+	if !ok || bearerAuthorizer == nil {
+		return false, errors.New("failed to cast authorizer to *autorest.BearerAuthorizer")
+	}
+
+	token, ok := bearerAuthorizer.TokenProvider().(*adal.Token)
+	if !ok || token == nil {
+		return false, errors.New("failed to cast adal.OAuthTokenProvider to *adal.Token")
+	}
+
+	return token.WillExpireIn(5 * time.Minute), nil
 }
 
 // getAuthToken extracts the JWT token from the active Authorizer.


### PR DESCRIPTION
When using roachprod with azure and authenticating via the CLI, the access token can expire from after anywhere between 5 minutes and 1 hour, eventually resulting in multiple failures when running long lived or multiple roachtests.

This change ensures that for each API call, when using CLI authentication, the token has at least 5 minutes remaining, otherwise it will be refreshed.

Epic: CC-25185
Release note: none
Fixes: #77614
Fixes: #111843