### PR TITLE
kvserver,sql: speed up EventuallyFileOnlySnapshot acquisition in tests

### DIFF
--- a/pkg/kv/kvserver/consistency_queue_test.go
+++ b/pkg/kv/kvserver/consistency_queue_test.go
@@ -438,6 +438,14 @@ func TestCheckConsistencyInconsistent(t *testing.T) {
 func TestConsistencyQueueRecomputeStats(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	// This test relies on repeated sequential storage.EventuallyFileOnlySnapshot
+	// acquisitions. Reduce the max wait time for each acquisition to speed up
+	// this test.
+	origEFOSWait := storage.MaxEFOSWait
+	storage.MaxEFOSWait = 30 * time.Millisecond
+	defer func() {
+		storage.MaxEFOSWait = origEFOSWait
+	}()
 	testutils.RunTrueAndFalse(t, "hadEstimates", testConsistencyQueueRecomputeStatsImpl)
 }
 

--- a/pkg/sql/logictest/BUILD.bazel
+++ b/pkg/sql/logictest/BUILD.bazel
@@ -76,6 +76,7 @@ go_library(
         "//pkg/sql/sessiondatapb",
         "//pkg/sql/sqlstats",
         "//pkg/sql/stats",
+        "//pkg/storage",
         "//pkg/testutils",
         "//pkg/testutils/floatcmp",
         "//pkg/testutils/physicalplanutils",

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -65,7 +65,7 @@ var maxSyncDurationDefault = envutil.EnvOrDefaultDuration("COCKROACH_ENGINE_MAX_
 
 // Default maximum wait time before an EventuallyFileOnlySnapshot transitions
 // to a file-only snapshot.
-var maxEfosWait = envutil.EnvOrDefaultDuration("COCKROACH_EFOS_MAX_WAIT", 3*time.Second)
+var MaxEFOSWait = envutil.EnvOrDefaultDuration("COCKROACH_EFOS_MAX_WAIT", 3*time.Second)
 
 // MaxSyncDuration is the threshold above which an observed engine sync duration
 // triggers either a warning or a fatal error.
@@ -2947,7 +2947,7 @@ func (p *pebbleEFOS) MVCCIterate(
 
 // WaitForFileOnly implements the EventuallyFileOnlyReader interface.
 func (p *pebbleEFOS) WaitForFileOnly(ctx context.Context) error {
-	return p.efos.WaitForFileOnlySnapshot(ctx, maxEfosWait)
+	return p.efos.WaitForFileOnlySnapshot(ctx, MaxEFOSWait)
 }
 
 // NewMVCCIterator implements the Reader interface.


### PR DESCRIPTION
Previously, we were sticking to the default WaitForFileOnly() wait time in all tests when EventuallyFileOnlySnapshots were enabled, even if some tests relied on a bunch of repeat EFOS acquisitions to succeed. If no writes are happening at the same time, and EFOS are being grabbed one-after-the-other as is commonplace in some queues like the consistency queue, test runtime would really blow up if we were waiting 3s for each queue entry to be processed.

This change reduces the wait time for EFOS WaitForFileOnly() to 30ms down from the current 3s, in some tests to speed them up.

Fixes #111959.

Epic: none

Release note: None