### PR TITLE
sql/catalog: clarify error in getDescriptorByName

### DIFF
--- a/pkg/sql/catalog/descs/descriptor.go
+++ b/pkg/sql/catalog/descs/descriptor.go
@@ -423,7 +423,13 @@ func getDescriptorByName(
 			return nil, err
 		}
 		// In all other cases, having an ID should imply having a descriptor.
-		return nil, errors.WithAssertionFailure(err)
+		return nil, errors.Wrapf(
+			err,
+			"resolved %s to %d but found no descriptor with id %d",
+			name,
+			id,
+			id,
+		)
 	}
 	return nil, err
 }


### PR DESCRIPTION
**sql/catalog: clarify assertion error in getDescriptorByName**
Previously, `getDescriptorByName` could mark an error as an assertion
error if a name could be resolved but the resolved ID did not exist.

The resulting error message was quite terse and difficult to track down
the origin of. Being marked as an assertion failure would indicate that
this error should not be handled. However, many tests begin to fail if
the underlying error types are erased and only and error message is
returned.

This commit upgrades the error message to more clearly indicate what
happened and allow future debuggers to track it down more easily. The
assertion failure marker has also been removed as this error can be
recovered in some cases.

Epic: none
Informs: https://github.com/cockroachdb/cockroach/issues/109678
Release note: None
