### PR TITLE
sql: simplify and fix error handling from remote flows watcher

### DIFF
--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -625,7 +625,12 @@ func (dsp *DistSQLPlanner) setupFlows(
 					}
 					// First, we update the DistSQL receiver with the error to
 					// be returned to the client eventually.
-					recv.SetError(res.err)
+					//
+					// In order to not protect DistSQLReceiver.status with a
+					// mutex, we do not update the status here and, instead,
+					// rely on the DistSQLReceiver detecting the error the next
+					// time an object is pushed into it.
+					recv.setErrorWithoutStatusUpdate(res.err, true /* willDeferStatusUpdate */)
 					// Now explicitly cancel the local flow.
 					flow.Cancel()
 				}()
@@ -920,9 +925,11 @@ type DistSQLReceiver struct {
 		row   rowResultWriter
 		batch batchResultWriter
 	}
-	// status is execinfra.ConsumerStatus of the receiver. It should not be
-	// accessed directly - use getStatus() and setStatus() helpers instead.
-	status atomic.Uint32
+	// updateStatus, if true, indicates that a concurrent goroutine has set an
+	// error on the rowResultWriter without updating status, so the main
+	// goroutine needs to update the status.
+	updateStatus atomic.Bool
+	status       execinfra.ConsumerStatus
 
 	stmtType tree.StatementReturnType
 
@@ -991,14 +998,6 @@ type DistSQLReceiver struct {
 		// Possibly updated arguments are returned.
 		pushCallback func(rowenc.EncDatumRow, coldata.Batch, *execinfrapb.ProducerMetadata) (rowenc.EncDatumRow, coldata.Batch, *execinfrapb.ProducerMetadata)
 	}
-}
-
-func (r *DistSQLReceiver) getStatus() execinfra.ConsumerStatus {
-	return execinfra.ConsumerStatus(r.status.Load())
-}
-
-func (r *DistSQLReceiver) setStatus(s execinfra.ConsumerStatus) {
-	r.status.Store(uint32(s))
 }
 
 // rowResultWriter is a subset of CommandResult to be used with the
@@ -1238,7 +1237,8 @@ func MakeDistSQLReceiver(
 // fashion - locally.
 func (r *DistSQLReceiver) resetForLocalRerun(stats topLevelQueryStats) {
 	r.resultWriterMu.row.SetError(nil)
-	r.setStatus(execinfra.NeedMoreRows)
+	r.updateStatus.Store(false)
+	r.status = execinfra.NeedMoreRows
 	r.dataPushed = false
 	r.closed = false
 	r.stats = stats
@@ -1276,12 +1276,13 @@ func (r *DistSQLReceiver) getError() error {
 	return r.resultWriterMu.row.Err()
 }
 
-// SetError provides a convenient way for a client to pass in an error, thus
-// pretending that a query execution error happened. The error is passed along
-// to the resultWriter.
+// setErrorWithoutStatusUpdate sets the error in the rowResultWriter but does
+// **not** update the status of the DistSQLReceiver. willDeferStatusUpdate
+// indicates whether the main goroutine should update the status the next time
+// it pushes something into the DistSQLReceiver.
 //
-// The status of DistSQLReceiver is updated accordingly.
-func (r *DistSQLReceiver) SetError(err error) {
+// NOTE: consider using SetError() instead.
+func (r *DistSQLReceiver) setErrorWithoutStatusUpdate(err error, willDeferStatusUpdate bool) {
 	r.resultWriterMu.Lock()
 	defer r.resultWriterMu.Unlock()
 	// Check if the error we just received should take precedence over a
@@ -1306,16 +1307,47 @@ func (r *DistSQLReceiver) SetError(err error) {
 			}
 		}
 		r.resultWriterMu.row.SetError(err)
+		r.updateStatus.Store(willDeferStatusUpdate)
 	}
+}
+
+// updateStatusAfterError updates the status of the DistSQLReceiver after it
+// has received an error.
+func (r *DistSQLReceiver) updateStatusAfterError(err error) {
 	// If we encountered an error, we will transition to draining unless we were
 	// canceled.
 	if r.ctx.Err() != nil {
 		log.VEventf(r.ctx, 1, "encountered error (transitioning to shutting down): %v", r.ctx.Err())
-		r.setStatus(execinfra.ConsumerClosed)
+		r.status = execinfra.ConsumerClosed
 	} else {
 		log.VEventf(r.ctx, 1, "encountered error (transitioning to draining): %v", err)
-		r.setStatus(execinfra.DrainRequested)
+		r.status = execinfra.DrainRequested
 	}
+}
+
+// SetError provides a convenient way for a client to pass in an error, thus
+// pretending that a query execution error happened. The error is passed along
+// to the resultWriter.
+//
+// The status of DistSQLReceiver is updated accordingly.
+func (r *DistSQLReceiver) SetError(err error) {
+	r.setErrorWithoutStatusUpdate(err, false /* willDeferStatusUpdate */)
+	r.updateStatusAfterError(err)
+}
+
+// checkConcurrentError sets the status if an error has been set by another
+// goroutine that did not also update the status.
+func (r *DistSQLReceiver) checkConcurrentError() {
+	if r.status != execinfra.NeedMoreRows || !r.updateStatus.Load() {
+		// If the status already is not NeedMoreRows, then it doesn't matter if
+		// there was a concurrent error set.
+		return
+	}
+	previousErr := r.getError()
+	if previousErr == nil {
+		previousErr = errors.AssertionFailedf("unexpectedly updateStatus is set but there is no error")
+	}
+	r.updateStatusAfterError(previousErr)
 }
 
 // pushMeta takes in non-empty metadata object and pushes it to the result
@@ -1362,7 +1394,7 @@ func (r *DistSQLReceiver) pushMeta(meta *execinfrapb.ProducerMetadata) execinfra
 	}
 	// Release the meta object. It is unsafe for use after this call.
 	meta.Release()
-	return r.getStatus()
+	return r.status
 }
 
 // handleCommErr handles the communication error (the one returned when
@@ -1373,12 +1405,12 @@ func (r *DistSQLReceiver) handleCommErr(commErr error) {
 	// client (that's why we don't set the error on the resultWriter).
 	if errors.Is(commErr, ErrLimitedResultClosed) {
 		log.VEvent(r.ctx, 1, "encountered ErrLimitedResultClosed (transitioning to draining)")
-		r.setStatus(execinfra.DrainRequested)
+		r.status = execinfra.DrainRequested
 	} else if errors.Is(commErr, errIEResultChannelClosed) {
 		log.VEvent(r.ctx, 1, "encountered errIEResultChannelClosed (transitioning to draining)")
-		r.setStatus(execinfra.DrainRequested)
+		r.status = execinfra.DrainRequested
 	} else if errors.Is(commErr, ErrPortalLimitHasBeenReached) {
-		r.setStatus(execinfra.SwitchToAnotherPortal)
+		r.status = execinfra.SwitchToAnotherPortal
 	} else {
 		// Set the error on the resultWriter to notify the consumer about
 		// it. Most clients don't care to differentiate between
@@ -1407,17 +1439,18 @@ func (r *DistSQLReceiver) handleCommErr(commErr error) {
 func (r *DistSQLReceiver) Push(
 	row rowenc.EncDatumRow, meta *execinfrapb.ProducerMetadata,
 ) execinfra.ConsumerStatus {
+	r.checkConcurrentError()
 	if r.testingKnobs.pushCallback != nil {
 		row, _, meta = r.testingKnobs.pushCallback(row, nil /* batch */, meta)
 	}
 	if meta != nil {
 		return r.pushMeta(meta)
 	}
-	if r.ctx.Err() != nil && r.getStatus() != execinfra.ConsumerClosed {
+	if r.ctx.Err() != nil && r.status != execinfra.ConsumerClosed {
 		r.SetError(r.ctx.Err())
 	}
-	if status := r.getStatus(); status != execinfra.NeedMoreRows {
-		return status
+	if r.status != execinfra.NeedMoreRows {
+		return r.status
 	}
 
 	if r.stmtType != tree.Rows {
@@ -1426,7 +1459,7 @@ func (r *DistSQLReceiver) Push(
 		// ensuring that the last stage in the pipeline will return a single-column
 		// row with the row count in it, so just grab that and exit.
 		r.resultWriterMu.row.SetRowsAffected(r.ctx, n)
-		return r.getStatus()
+		return r.status
 	}
 
 	ensureDecodedRow := func() error {
@@ -1446,11 +1479,11 @@ func (r *DistSQLReceiver) Push(
 	if r.isTenantExplainAnalyze {
 		if err := ensureDecodedRow(); err != nil {
 			r.SetError(err)
-			return r.getStatus()
+			return r.status
 		}
 		if len(r.row) != len(r.outputTypes) {
 			r.SetError(errors.Errorf("expected number of columns and output types to be the same"))
-			return r.getStatus()
+			return r.status
 		}
 		if r.egressCounter == nil {
 			r.egressCounter = NewTenantNetworkEgressCounter()
@@ -1460,7 +1493,7 @@ func (r *DistSQLReceiver) Push(
 
 	if r.discardRows {
 		// Discard rows.
-		return r.getStatus()
+		return r.status
 	}
 
 	if r.existsMode {
@@ -1468,11 +1501,11 @@ func (r *DistSQLReceiver) Push(
 		// row is pushed or not, so the contents do not matter.
 		r.row = []tree.Datum{}
 		log.VEvent(r.ctx, 2, `a row is pushed in "exists" mode, so transition to draining`)
-		r.setStatus(execinfra.DrainRequested)
+		r.status = execinfra.DrainRequested
 	} else {
 		if err := ensureDecodedRow(); err != nil {
 			r.SetError(err)
-			return r.getStatus()
+			return r.status
 		}
 	}
 	r.tracing.TraceExecRowsResult(r.ctx, r.row)
@@ -1480,29 +1513,30 @@ func (r *DistSQLReceiver) Push(
 		r.handleCommErr(commErr)
 	}
 	r.dataPushed = true
-	return r.getStatus()
+	return r.status
 }
 
 // PushBatch is part of the execinfra.BatchReceiver interface.
 func (r *DistSQLReceiver) PushBatch(
 	batch coldata.Batch, meta *execinfrapb.ProducerMetadata,
 ) execinfra.ConsumerStatus {
+	r.checkConcurrentError()
 	if r.testingKnobs.pushCallback != nil {
 		_, batch, meta = r.testingKnobs.pushCallback(nil /* row */, batch, meta)
 	}
 	if meta != nil {
 		return r.pushMeta(meta)
 	}
-	if r.ctx.Err() != nil && r.getStatus() != execinfra.ConsumerClosed {
+	if r.ctx.Err() != nil && r.status != execinfra.ConsumerClosed {
 		r.SetError(r.ctx.Err())
 	}
-	if status := r.getStatus(); status != execinfra.NeedMoreRows {
-		return status
+	if r.status != execinfra.NeedMoreRows {
+		return r.status
 	}
 
 	if batch.Length() == 0 {
 		// Nothing to do on the zero-length batch.
-		return r.getStatus()
+		return r.status
 	}
 
 	if r.stmtType != tree.Rows {
@@ -1510,7 +1544,7 @@ func (r *DistSQLReceiver) PushBatch(
 		// ensuring that the last stage in the pipeline will return a single-column
 		// row with the row count in it, so just grab that and exit.
 		r.resultWriterMu.row.SetRowsAffected(r.ctx, int(batch.ColVec(0).Int64()[0]))
-		return r.getStatus()
+		return r.status
 	}
 
 	if r.isTenantExplainAnalyze {
@@ -1522,7 +1556,7 @@ func (r *DistSQLReceiver) PushBatch(
 
 	if r.discardRows {
 		// Discard rows.
-		return r.getStatus()
+		return r.status
 	}
 
 	if r.existsMode {
@@ -1535,7 +1569,7 @@ func (r *DistSQLReceiver) PushBatch(
 		r.handleCommErr(commErr)
 	}
 	r.dataPushed = true
-	return r.getStatus()
+	return r.status
 }
 
 var (


### PR DESCRIPTION
This commit refactors the way the "remote flows setup watcher" goroutine
communicates an error encountered during `SetupFlowRequest` RPCs
evaluation when they were issued concurrently (i.e. via the DistSQL
workers). This results in code simplification as well as bug fix of
a pretty rare crash that could occur due to a race condition.

As a reminder, during 23.1 cycle in https://github.com/cockroachdb/cockroach/commit/0c1095e31cf93ea7f177f8bf1750ebab188e02d7
we refactored the code for setting up all flows of the distributed plan
so that the gateway flow didn't wait for `SetupFlowRequest` RPCs to come
back from the remote nodes. This required introduction a new "remote
flows setup watcher" goroutine whose only job was to see whether all
RPCs succeed, and if not, to send the error to the main gateway flow
goroutine as well as to cancel that flow. We implemented the
communication of that error by storing it directly into
`rowResultWriter` and introduced mutex protection for synchornization
between two goroutines.

However, that mutex protection was insufficient which could lead to
a crash or a race when reading the error. In particular, the following
could now occur:
1. the main goroutine calls `AddRow` or `AddBatch` concurrently with the
watcher goroutine setting the error. The contract of
`RestrictedCommandResult` is such that most calls after `SetError` are
disallowed, and `AddRow/AddBatch` actually panic in case `err` is set.
This has been observed in a unit test where an error is injected.
2. `AddRow/AddBatch` read `err` field without mutex protection which the
watcher goroutine might be writing into it (under mutex).

These situations are now fixed by making so that only the main goroutine
can set the error on `rowResultWriter`, and we introduce a buffered
channel for the watcher goroutine to send the error on (the error is
picked up on the next call to `Push` or `PushBatch`). This significantly
simplies the code too.

The benchmarks show very minor differences (looks like noise) and are
available [here](https://gist.github.com/yuzefovich/6b4b10d77b2d802ddbcc870eda5f9158).

There is no release note since we haven't seen the bug in the wild, and
it should be quite rare to occur.

Fixes: #111995.

Release note: None