### PR TITLE
sql: disable indexes with a REFCURSOR column

### DIFF
--- a/pkg/sql/catalog/colinfo/col_type_info.go
+++ b/pkg/sql/catalog/colinfo/col_type_info.go
@@ -150,7 +150,7 @@ func ValidateColumnDefType(ctx context.Context, version clusterversion.Handle, t
 
 // ColumnTypeIsIndexable returns whether the type t is valid as an indexed column.
 func ColumnTypeIsIndexable(t *types.T) bool {
-	if t.IsAmbiguous() || t.Family() == types.TupleFamily {
+	if t.IsAmbiguous() || t.Family() == types.TupleFamily || t.Family() == types.RefCursorFamily {
 		return false
 	}
 	// Some inverted index types also have a key encoding, but we don't

--- a/pkg/sql/logictest/testdata/logic_test/refcursor
+++ b/pkg/sql/logictest/testdata/logic_test/refcursor
@@ -553,4 +553,54 @@ SELECT 'foo'::REFCURSOR IS DISTINCT FROM (CASE WHEN true THEN NULL ELSE NULL::RE
 statement error pgcode 22023 pq: unsupported comparison operator
 SELECT 'foo'::REFCURSOR IS NOT DISTINCT FROM (CASE WHEN true THEN NULL ELSE NULL::REFCURSOR END);
 
+# Regression test for #112099 - REFCURSOR is not valid as an index column.
+subtest refcursor_index
+
+statement ok
+CREATE TABLE t112099_no_index (x INT NOT NULL, y TEXT NOT NULL, r REFCURSOR NOT NULL);
+
+# REFCURSOR is not allowed in a primary key.
+statement error pgcode 0A000 pq: unimplemented: column r is of type refcursor and thus is not indexable
+CREATE TABLE t112099 (r REFCURSOR PRIMARY KEY);
+
+statement error pgcode 0A000 pq: unimplemented: column r is of type refcursor and thus is not indexable
+CREATE TABLE t112099 (x INT, y TEXT, r REFCURSOR, PRIMARY KEY (x, r, y));
+
+statement error pgcode 0A000 pq: unimplemented: column r is of type refcursor and thus is not indexable
+ALTER TABLE t112099_no_index ADD PRIMARY KEY (r);
+
+statement error pgcode 0A000 pq: unimplemented: column r is of type refcursor and thus is not indexable
+ALTER TABLE t112099_no_index ADD PRIMARY KEY (x, r, y);
+
+# REFCURSOR is not allowed in a secondary index.
+statement error pgcode 0A000 pq: unimplemented: column r is of type refcursor and thus is not indexable
+CREATE TABLE t112099 (r REFCURSOR, INDEX (r));
+
+statement error pgcode 0A000 pq: unimplemented: column r is of type refcursor and thus is not indexable
+CREATE TABLE t112099 (x INT, y TEXT, r REFCURSOR, INDEX (x, r, y));
+
+statement error pgcode 0A000 pq: unimplemented: column r is of type refcursor and thus is not indexable
+CREATE INDEX ON t112099_no_index (r);
+
+statement error pgcode 0A000 pq: unimplemented: column r is of type refcursor and thus is not indexable
+CREATE INDEX ON t112099_no_index (x, r, y);
+
+# REFCURSOR is allowed as a STORING column.
+statement ok
+CREATE TABLE t112099 (x INT, r REFCURSOR, INDEX (x) STORING (r));
+DROP TABLE t112099;
+
+statement ok
+CREATE TABLE t112099 (x INT, y TEXT, r REFCURSOR, INDEX (x) STORING (y, r));
+DROP TABLE t112099;
+
+statement ok
+CREATE INDEX ON t112099_no_index (x) STORING (r);
+
+statement ok
+CREATE INDEX ON t112099_no_index (x) STORING (y, r);
+
+statement ok
+DROP TABLE t112099_no_index;
+
 subtest end


### PR DESCRIPTION
When validating certain constraints for an indexed column, we internally expect that it should be possible to check if the column is equal to another column. This is not allowed for `REFCURSOR`, which disallows most comparisons. Postgres doesn't allow `REFCURSOR` to be used as an index column, either. This commit disables usage of `REFCURSOR` index columns. It is still allowed to use a `REFCURSOR` table column, as well as to include one in the `STORING` clause of an index. This feature hasn't made it into a public release yet, so there is no release note.

Fixes #112099
Fixes #112211
Fixes #112212

Release note: None