### PR TITLE
serverutils: TestURL query parameters with path

### DIFF
--- a/pkg/ccl/serverccl/server_sql_test.go
+++ b/pkg/ccl/serverccl/server_sql_test.go
@@ -244,8 +244,7 @@ func TestTenantProcessDebugging(t *testing.T) {
 		require.NoError(t, err)
 		defer httpClient.CloseIdleConnections()
 
-		url := s.AdminURL().URL
-		url.Path = url.Path + "/debug/pprof/goroutine"
+		url := s.AdminURL().WithPath("/debug/pprof/goroutine")
 		q := url.Query()
 		q.Add("debug", "2")
 		url.RawQuery = q.Encode()
@@ -265,8 +264,7 @@ func TestTenantProcessDebugging(t *testing.T) {
 		require.NoError(t, err)
 		defer httpClient.CloseIdleConnections()
 
-		url := tenant.AdminURL().URL
-		url.Path = url.Path + "/debug/pprof/"
+		url := tenant.AdminURL().WithPath("/debug/pprof/")
 		q := url.Query()
 		q.Add("debug", "2")
 		url.RawQuery = q.Encode()
@@ -307,8 +305,7 @@ func TestTenantProcessDebugging(t *testing.T) {
 		require.NoError(t, err)
 		defer httpClient.CloseIdleConnections()
 
-		url := tenant.AdminURL().URL
-		url.Path = url.Path + "/debug/vmodule"
+		url := tenant.AdminURL().WithPath("/debug/vmodule")
 		q := url.Query()
 		q.Add("duration", "-1s")
 		q.Add("vmodule", "exec_log=3")

--- a/pkg/ccl/streamingccl/streamingest/replication_execution_details_test.go
+++ b/pkg/ccl/streamingccl/streamingest/replication_execution_details_test.go
@@ -231,7 +231,7 @@ func listExecutionDetails(
 	client, err := s.GetAdminHTTPClient()
 	require.NoError(t, err)
 
-	url := s.AdminURL().String() + fmt.Sprintf("/_status/list_job_profiler_execution_details/%d", jobID)
+	url := s.AdminURL().WithPath(fmt.Sprintf("/_status/list_job_profiler_execution_details/%d", jobID)).String()
 	req, err := http.NewRequest("GET", url, nil)
 	require.NoError(t, err)
 
@@ -261,7 +261,7 @@ func checkExecutionDetails(
 		return nil, err
 	}
 
-	url := s.AdminURL().String() + fmt.Sprintf("/_status/job_profiler_execution_details/%d?%s", jobID, filename)
+	url := s.AdminURL().WithPath(fmt.Sprintf("/_status/job_profiler_execution_details/%d?%s", jobID, filename)).String()
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, err

--- a/pkg/server/api_v2_ranges_test.go
+++ b/pkg/server/api_v2_ranges_test.go
@@ -101,7 +101,9 @@ func TestNodeRangesV2(t *testing.T) {
 
 	// Take the first range ID, and call the ranges/ endpoint with it.
 	rangeID := nodeRangesResp.Ranges[0].Desc.RangeID
-	req, err = http.NewRequest("GET", fmt.Sprintf("%s%sranges/%d/", ts.AdminURL(), apiconstants.APIV2Path, rangeID), nil)
+	req, err = http.NewRequest(
+		"GET", ts.AdminURL().WithPath(fmt.Sprintf("%sranges/%d/", apiconstants.APIV2Path, rangeID)).String(), nil,
+	)
 	require.NoError(t, err)
 	resp, err = client.Do(req)
 	require.NoError(t, err)

--- a/pkg/server/application_api/schema_inspection_test.go
+++ b/pkg/server/application_api/schema_inspection_test.go
@@ -530,7 +530,7 @@ func TestAdminAPITableStats(t *testing.T) {
 		}
 	}
 
-	url := server0.AdminURL().String() + "/_admin/v1/databases/test test/tables/foo foo/stats"
+	url := server0.AdminURL().WithPath("/_admin/v1/databases/test test/tables/foo foo/stats").String()
 	var tsResponse serverpb.TableStatsResponse
 
 	// The new SQL table may not yet have split into its own range. Wait for

--- a/pkg/server/debug/debug_test.go
+++ b/pkg/server/debug/debug_test.go
@@ -27,8 +27,8 @@ import (
 )
 
 // debugURL returns the root debug URL.
-func debugURL(s serverutils.ApplicationLayerInterface) string {
-	return s.AdminURL().WithPath(debug.Endpoint).String()
+func debugURL(s serverutils.ApplicationLayerInterface, path string) string {
+	return s.AdminURL().WithPath(debug.Endpoint).WithPath(path).String()
 }
 
 // TestAdminDebugExpVar verifies that cmdline and memstats variables are
@@ -41,7 +41,7 @@ func TestAdminDebugExpVar(t *testing.T) {
 
 	ts := s.ApplicationLayer()
 
-	jI, err := srvtestutils.GetJSON(ts, debugURL(ts)+"vars")
+	jI, err := srvtestutils.GetJSON(ts, debugURL(ts, "vars"))
 	if err != nil {
 		t.Fatalf("failed to fetch JSON: %v", err)
 	}
@@ -64,7 +64,7 @@ func TestAdminDebugMetrics(t *testing.T) {
 
 	ts := s.ApplicationLayer()
 
-	jI, err := srvtestutils.GetJSON(ts, debugURL(ts)+"metrics")
+	jI, err := srvtestutils.GetJSON(ts, debugURL(ts, "metrics"))
 	if err != nil {
 		t.Fatalf("failed to fetch JSON: %v", err)
 	}
@@ -87,7 +87,7 @@ func TestAdminDebugPprof(t *testing.T) {
 
 	ts := s.ApplicationLayer()
 
-	body, err := srvtestutils.GetText(ts, debugURL(ts)+"pprof/block?debug=1")
+	body, err := srvtestutils.GetText(ts, debugURL(ts, "pprof/block?debug=1"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -114,7 +114,7 @@ func TestAdminDebugTrace(t *testing.T) {
 	}
 
 	for _, c := range tc {
-		body, err := srvtestutils.GetText(ts, debugURL(ts)+c.segment)
+		body, err := srvtestutils.GetText(ts, debugURL(ts, c.segment))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -132,7 +132,7 @@ func TestAdminDebugAuth(t *testing.T) {
 	defer s.Stopper().Stop(context.Background())
 	ts := s.ApplicationLayer()
 
-	url := debugURL(ts)
+	url := debugURL(ts, "")
 
 	// Unauthenticated.
 	client, err := ts.GetUnauthenticatedHTTPClient()
@@ -186,8 +186,8 @@ func TestAdminDebugRedirect(t *testing.T) {
 	defer s.Stopper().Stop(context.Background())
 	ts := s.ApplicationLayer()
 
-	expURL := debugURL(ts)
-	origURL := expURL + "incorrect"
+	expURL := debugURL(ts, "/")
+	origURL := debugURL(ts, "/incorrect")
 
 	// Must be admin to access debug endpoints
 	client, err := ts.GetAdminHTTPClient()

--- a/pkg/server/testserver_http.go
+++ b/pkg/server/testserver_http.go
@@ -111,7 +111,7 @@ func (ts *httpTestServer) GetAuthenticatedHTTPClient(
 	return httpClient, err
 }
 
-// GetAuthenticatedHTTPClient implements the TestServerInterface.
+// GetAuthSession implements the TestServerInterface.
 func (ts *httpTestServer) GetAuthSession(isAdmin bool) (*serverpb.SessionCookie, error) {
 	authUser := apiconstants.TestingUserName()
 	if !isAdmin {

--- a/pkg/sql/jobs_profiler_execution_details_test.go
+++ b/pkg/sql/jobs_profiler_execution_details_test.go
@@ -424,7 +424,7 @@ func listExecutionDetails(
 	client, err := s.GetAdminHTTPClient()
 	require.NoError(t, err)
 
-	url := s.AdminURL().String() + fmt.Sprintf("/_status/list_job_profiler_execution_details/%d", jobID)
+	url := s.AdminURL().WithPath(fmt.Sprintf("/_status/list_job_profiler_execution_details/%d", jobID)).String()
 	req, err := http.NewRequest("GET", url, nil)
 	require.NoError(t, err)
 
@@ -454,7 +454,7 @@ func checkExecutionDetails(
 		return nil, err
 	}
 
-	url := s.AdminURL().String() + fmt.Sprintf("/_status/job_profiler_execution_details/%d?%s", jobID, filename)
+	url := s.AdminURL().WithPath(fmt.Sprintf("/_status/job_profiler_execution_details/%d?%s", jobID, filename)).String()
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, err

--- a/pkg/testutils/serverutils/BUILD.bazel
+++ b/pkg/testutils/serverutils/BUILD.bazel
@@ -138,6 +138,7 @@ go_test(
     srcs = [
         "conditional_wrap_internal_test.go",
         "conditional_wrap_test.go",
+        "test_url_test.go",
     ],
     args = ["-test.timeout=295s"],
     embed = [":serverutils"],

--- a/pkg/testutils/serverutils/test_server_shim.go
+++ b/pkg/testutils/serverutils/test_server_shim.go
@@ -360,8 +360,8 @@ func GetJSONProtoWithAdminOption(
 	if err != nil {
 		return err
 	}
-	u := ts.AdminURL().String()
-	fullURL := u + path
+	u := ts.AdminURL()
+	fullURL := u.WithPath(path).String()
 	log.Infof(context.Background(), "test retrieving protobuf over HTTP: %s", fullURL)
 	return httputil.GetJSON(httpClient, fullURL, response)
 }
@@ -380,8 +380,8 @@ func GetJSONProtoWithAdminAndTimeoutOption(
 		return err
 	}
 	httpClient.Timeout += additionalTimeout
-	u := ts.AdminURL().String()
-	fullURL := u + path
+	u := ts.AdminURL()
+	fullURL := u.WithPath(path).String()
 	log.Infof(context.Background(), "test retrieving protobuf over HTTP: %s", fullURL)
 	log.Infof(context.Background(), "set HTTP client timeout to: %s", httpClient.Timeout)
 	return httputil.GetJSON(httpClient, fullURL, response)

--- a/pkg/testutils/serverutils/test_tenant_shim.go
+++ b/pkg/testutils/serverutils/test_tenant_shim.go
@@ -47,16 +47,24 @@ func NewTestURL(path string) TestURL {
 	return TestURL{u}
 }
 
-// WithPath is a helper that allows the user of the `TestURL` to easily
-// append paths to use for testing. Please be aware that your path will
-// automatically be escaped for you, but if it includes any invalid hex
-// escapes (eg: `%s`) it will fail silently and you'll get back a blank
-// URL.
+// WithPath is a helper that allows the user of the `TestURL` to easily append
+// paths to use for testing. Any queries in the given path will be added to the
+// returned URL. Please be aware that your path will automatically be escaped
+// for you, but if it includes any invalid hex escapes (eg: `%s`) it will fail
+// silently, and you'll get back a blank URL.
 func (t *TestURL) WithPath(path string) *TestURL {
-	newPath, err := url.JoinPath(t.Path, path)
+	parsedPath, err := url.Parse(path)
 	if err != nil {
 		panic(err)
 	}
-	t.Path = newPath
+	// Append the path to the existing path (The paths used here do not contain any
+	// query parameters). To prevent double escaping, we use the `JoinPath` method.
+	t.URL = t.JoinPath(parsedPath.EscapedPath())
+	// Append the query parameters to the existing query parameters.
+	query := t.Query()
+	for k, v := range parsedPath.Query() {
+		query[k] = v
+	}
+	t.RawQuery = query.Encode()
 	return t
 }

--- a/pkg/testutils/serverutils/test_url_test.go
+++ b/pkg/testutils/serverutils/test_url_test.go
@@ -1,0 +1,74 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+//
+// This file provides generic interfaces that allow tests to set up test tenants
+// without importing the server package (avoiding circular dependencies). This
+
+package serverutils
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithPath(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	testCases := []struct {
+		name        string
+		testURL     TestURL
+		withPath    string
+		expectedStr string
+	}{
+		{
+			name:        "append",
+			testURL:     NewTestURL("http://localhost:8080"),
+			withPath:    "/test",
+			expectedStr: "http://localhost:8080/test",
+		},
+		{
+			name:        "query on base url",
+			testURL:     NewTestURL("http://localhost:8080/operation?cluster=1"),
+			withPath:    "/test",
+			expectedStr: "http://localhost:8080/operation/test?cluster=1",
+		},
+		{
+			name:        "append path with query",
+			testURL:     NewTestURL("http://localhost:8080"),
+			withPath:    "/test?foo=bar",
+			expectedStr: "http://localhost:8080/test?foo=bar",
+		},
+		{
+			name:        "combine paths with queries",
+			testURL:     NewTestURL("http://localhost:8080?cluster=1"),
+			withPath:    "/test?foo=bar&arg=1",
+			expectedStr: "http://localhost:8080/test?arg=1&cluster=1&foo=bar",
+		},
+		{
+			name:        "escaped characters before",
+			testURL:     NewTestURL("http://localhost:8080/hello%20world?cluster=1"),
+			withPath:    "/test%20test?foo=bar",
+			expectedStr: "http://localhost:8080/hello%20world/test%20test?cluster=1&foo=bar",
+		},
+		{
+			name:        "escaped characters after",
+			testURL:     NewTestURL("http://localhost:8080/hello world?cluster=1"),
+			withPath:    "/test test?foo=bar",
+			expectedStr: "http://localhost:8080/hello%20world/test%20test?cluster=1&foo=bar",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actualURL := tc.testURL.WithPath(tc.withPath)
+			require.Equal(t, tc.expectedStr, actualURL.String())
+		})
+	}
+}


### PR DESCRIPTION
Previously the `WithPath` method for `TestURL` supported adding a path, but it does not carry over any query parameters in that path to the returned path. In the event of shared processes the paths that go through this method usually will contain a query parameter on the base path `TestURL` which contains the cluster, and the path to be appended could also contain query parameters.

For ease of use, if the path that is to be appended contains query parameters those parameters are transferred to the final return path. We also ensure that escaping remains intact as it currently works.

See also: #111134
Epic: CRDB-31933

Release note: None