### PR TITLE
cli: add job traces for traceable jobs to the debug zip

### DIFF
--- a/pkg/cli/BUILD.bazel
+++ b/pkg/cli/BUILD.bazel
@@ -359,6 +359,7 @@ go_test(
     deps = [
         "//pkg/base",
         "//pkg/build",
+        "//pkg/ccl/backupccl",
         "//pkg/cli/clicfg",
         "//pkg/cli/clienturl",
         "//pkg/cli/clierror",
@@ -374,6 +375,7 @@ go_test(
         "//pkg/gossip",
         "//pkg/jobs",
         "//pkg/jobs/jobspb",
+        "//pkg/jobs/jobstest",
         "//pkg/keys",
         "//pkg/kv",
         "//pkg/kv/kvclient/kvtenant",
@@ -402,6 +404,7 @@ go_test(
         "//pkg/storage",
         "//pkg/testutils",
         "//pkg/testutils/datapathutils",
+        "//pkg/testutils/jobutils",
         "//pkg/testutils/listenerutil",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/skip",

--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -1690,6 +1690,15 @@ require any additional stop-the-world operations to be collected.
 `,
 	}
 
+	ZipIncludeRunningJobTraces = FlagInfo{
+		Name: "include-running-job-traces",
+		Description: `
+Include information about each running, traceable job in jobs/*/*/trace.zip
+files. This involves collecting cluster-wide traces for each running job in the
+cluster.
+`,
+	}
+
 	ZipCPUProfileDuration = FlagInfo{
 		Name: "cpu-profile-duration",
 		Description: `

--- a/pkg/cli/clisqlcfg/context.go
+++ b/pkg/cli/clisqlcfg/context.go
@@ -184,7 +184,7 @@ func (c *Context) MakeConn(url string) (clisqlclient.Conn, error) {
 	// By default, all connections will use the underlying driver to infer
 	// result types. This should be set back to false for any use case where the
 	// results are only shown for textual display.
-	conn.SetAlwaysInferResultTypes(true)
+	_ = conn.SetAlwaysInferResultTypes(true)
 
 	return conn, nil
 }
@@ -198,7 +198,7 @@ func (c *Context) Run(ctx context.Context, conn clisqlclient.Conn) error {
 	// Anything using a SQL shell (e.g. `cockroach sql` or `demo`), only needs
 	// to show results in text format, so the underlying driver doesn't need to
 	// infer types.
-	conn.SetAlwaysInferResultTypes(false)
+	_ = conn.SetAlwaysInferResultTypes(false)
 
 	// Open the connection to make sure everything is OK before running any
 	// statements. Performs authentication.

--- a/pkg/cli/clisqlclient/api.go
+++ b/pkg/cli/clisqlclient/api.go
@@ -70,8 +70,9 @@ type Conn interface {
 
 	// SetAlwaysInferResultTypes configures the alwaysInferResultTypes flag, which
 	// determines if the client should use the underlying driver to infer result
-	// types.
-	SetAlwaysInferResultTypes(b bool)
+	// types. It returns a method that can be used to reset the configuration to
+	// its previous value.
+	SetAlwaysInferResultTypes(b bool) func()
 
 	// GetServerMetadata returns details about the CockroachDB node
 	// this connection is connected to.

--- a/pkg/cli/clisqlclient/conn.go
+++ b/pkg/cli/clisqlclient/conn.go
@@ -164,8 +164,12 @@ func (c *sqlConn) SetMissingPassword(missing bool) {
 }
 
 // SetAlwaysInferResultTypes implements the Conn interface.
-func (c *sqlConn) SetAlwaysInferResultTypes(b bool) {
+func (c *sqlConn) SetAlwaysInferResultTypes(b bool) func() {
+	oldVal := c.alwaysInferResultTypes
 	c.alwaysInferResultTypes = b
+	return func() {
+		c.alwaysInferResultTypes = oldVal
+	}
 }
 
 // EnsureConn (re-)establishes the connection to the server.

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -363,6 +363,10 @@ type zipContext struct {
 	// latency.
 	includeStacks bool
 
+	// includeRunningJobTraces includes the active traces of each running
+	// Traceable job in individual jobs/*/ranges/trace.zip files.
+	includeRunningJobTraces bool
+
 	// The log/heap/etc files to include.
 	files fileSelection
 }
@@ -381,6 +385,9 @@ func setZipContextDefaults() {
 	// Goroutine stack dumps require a "stop the world" operation on the server side,
 	// which impacts performance and SQL service latency.
 	zipCtx.includeStacks = true
+	// Job traces for running Traceable jobs involves fetching cluster wide traces
+	// for each job.
+	zipCtx.includeRunningJobTraces = false
 	zipCtx.cpuProfDuration = 5 * time.Second
 	zipCtx.concurrency = 15
 

--- a/pkg/cli/debug_job_trace_test.go
+++ b/pkg/cli/debug_job_trace_test.go
@@ -77,6 +77,7 @@ func (r *traceSpanResumer) CollectProfile(_ context.Context, _ interface{}) erro
 func TestDebugJobTrace(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	defer jobs.ResetConstructors()()
 
 	ctx := context.Background()
 	argsFn := func(args *base.TestServerArgs) {

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -702,6 +702,7 @@ func init() {
 		cliflagcfg.IntFlag(f, &zipCtx.concurrency, cliflags.ZipConcurrency)
 		cliflagcfg.BoolFlag(f, &zipCtx.includeRangeInfo, cliflags.ZipIncludeRangeInfo)
 		cliflagcfg.BoolFlag(f, &zipCtx.includeStacks, cliflags.ZipIncludeGoroutineStacks)
+		cliflagcfg.BoolFlag(f, &zipCtx.includeRunningJobTraces, cliflags.ZipIncludeRunningJobTraces)
 	}
 	// List-files + Zip commands.
 	for _, cmd := range []*cobra.Command{debugZipCmd, debugListFilesCmd} {

--- a/pkg/cli/testdata/zip/partial1
+++ b/pkg/cli/testdata/zip/partial1
@@ -263,3 +263,4 @@ debug zip --concurrency=1 --cpu-profile-duration=0s /dev/null
 [cluster] pprof summary script... writing binary output: debug/pprof-summary.sh... done
 [cluster] hot range summary script... writing binary output: debug/hot-ranges.sh... done
 [cluster] tenant hot range summary script... writing binary output: debug/hot-ranges-tenant.sh... done
+[cluster] NOTE: Omitted traces of running jobs from this debug zip bundle. Use the --include-running-job-traces flag to enable the fetching of this data.

--- a/pkg/cli/testdata/zip/partial1_excluded
+++ b/pkg/cli/testdata/zip/partial1_excluded
@@ -166,3 +166,4 @@ debug zip /dev/null --concurrency=1 --exclude-nodes=2 --cpu-profile-duration=0
 [cluster] pprof summary script... writing binary output: debug/pprof-summary.sh... done
 [cluster] hot range summary script... writing binary output: debug/hot-ranges.sh... done
 [cluster] tenant hot range summary script... writing binary output: debug/hot-ranges-tenant.sh... done
+[cluster] NOTE: Omitted traces of running jobs from this debug zip bundle. Use the --include-running-job-traces flag to enable the fetching of this data.

--- a/pkg/cli/testdata/zip/partial2
+++ b/pkg/cli/testdata/zip/partial2
@@ -165,3 +165,4 @@ debug zip --concurrency=1 --cpu-profile-duration=0 /dev/null
 [cluster] pprof summary script... writing binary output: debug/pprof-summary.sh... done
 [cluster] hot range summary script... writing binary output: debug/hot-ranges.sh... done
 [cluster] tenant hot range summary script... writing binary output: debug/hot-ranges-tenant.sh... done
+[cluster] NOTE: Omitted traces of running jobs from this debug zip bundle. Use the --include-running-job-traces flag to enable the fetching of this data.

--- a/pkg/cli/testdata/zip/testzip
+++ b/pkg/cli/testdata/zip/testzip
@@ -126,3 +126,4 @@ debug zip --concurrency=1 --cpu-profile-duration=1s /dev/null
 [cluster] pprof summary script... writing binary output: debug/pprof-summary.sh... done
 [cluster] hot range summary script... writing binary output: debug/hot-ranges.sh... done
 [cluster] tenant hot range summary script... writing binary output: debug/hot-ranges-tenant.sh... done
+[cluster] NOTE: Omitted traces of running jobs from this debug zip bundle. Use the --include-running-job-traces flag to enable the fetching of this data.

--- a/pkg/cli/testdata/zip/testzip_concurrent
+++ b/pkg/cli/testdata/zip/testzip_concurrent
@@ -1,5 +1,6 @@
 zip
 ----
+[cluster] NOTE: Omitted traces of running jobs from this debug zip bundle. Use the --include-running-job-traces flag to enable the fetching of this data.
 [cluster] creating output file /dev/null...
 [cluster] creating output file /dev/null: done
 [cluster] discovering virtual clusters...

--- a/pkg/cli/testdata/zip/testzip_exclude_goroutine_stacks
+++ b/pkg/cli/testdata/zip/testzip_exclude_goroutine_stacks
@@ -125,4 +125,5 @@ debug zip --concurrency=1 --cpu-profile-duration=1s --include-goroutine-stacks=f
 [cluster] pprof summary script... writing binary output: debug/pprof-summary.sh... done
 [cluster] hot range summary script... writing binary output: debug/hot-ranges.sh... done
 [cluster] tenant hot range summary script... writing binary output: debug/hot-ranges-tenant.sh... done
+[cluster] NOTE: Omitted traces of running jobs from this debug zip bundle. Use the --include-running-job-traces flag to enable the fetching of this data.
 [cluster] NOTE: Omitted node-level goroutine stack dumps from this debug zip bundle. Use the --include-goroutine-stacks flag to enable the fetching of this data.

--- a/pkg/cli/testdata/zip/testzip_external_process_virtualization
+++ b/pkg/cli/testdata/zip/testzip_external_process_virtualization
@@ -161,3 +161,4 @@ debug zip --concurrency=1 --cpu-profile-duration=1s /dev/null
 [cluster] pprof summary script... writing binary output: debug/pprof-summary.sh... done
 [cluster] hot range summary script... writing binary output: debug/hot-ranges.sh... done
 [cluster] tenant hot range summary script... writing binary output: debug/hot-ranges-tenant.sh... done
+[cluster] NOTE: Omitted traces of running jobs from this debug zip bundle. Use the --include-running-job-traces flag to enable the fetching of this data.

--- a/pkg/cli/testdata/zip/testzip_include_goroutine_stacks
+++ b/pkg/cli/testdata/zip/testzip_include_goroutine_stacks
@@ -126,3 +126,4 @@ debug zip --concurrency=1 --cpu-profile-duration=1s /dev/null
 [cluster] pprof summary script... writing binary output: debug/pprof-summary.sh... done
 [cluster] hot range summary script... writing binary output: debug/hot-ranges.sh... done
 [cluster] tenant hot range summary script... writing binary output: debug/hot-ranges-tenant.sh... done
+[cluster] NOTE: Omitted traces of running jobs from this debug zip bundle. Use the --include-running-job-traces flag to enable the fetching of this data.

--- a/pkg/cli/testdata/zip/testzip_include_range_info
+++ b/pkg/cli/testdata/zip/testzip_include_range_info
@@ -126,3 +126,4 @@ debug zip --concurrency=1 --cpu-profile-duration=1s --include-range-info /dev/nu
 [cluster] pprof summary script... writing binary output: debug/pprof-summary.sh... done
 [cluster] hot range summary script... writing binary output: debug/hot-ranges.sh... done
 [cluster] tenant hot range summary script... writing binary output: debug/hot-ranges-tenant.sh... done
+[cluster] NOTE: Omitted traces of running jobs from this debug zip bundle. Use the --include-running-job-traces flag to enable the fetching of this data.

--- a/pkg/cli/testdata/zip/testzip_shared_process_virtualization
+++ b/pkg/cli/testdata/zip/testzip_shared_process_virtualization
@@ -286,3 +286,4 @@ debug zip --concurrency=1 --cpu-profile-duration=1s /dev/null
 [cluster] pprof summary script... writing binary output: debug/cluster/test-tenant/pprof-summary.sh... done
 [cluster] hot range summary script... writing binary output: debug/cluster/test-tenant/hot-ranges.sh... done
 [cluster] tenant hot range summary script... writing binary output: debug/cluster/test-tenant/hot-ranges-tenant.sh... done
+[cluster] NOTE: Omitted traces of running jobs from this debug zip bundle. Use the --include-running-job-traces flag to enable the fetching of this data.

--- a/pkg/cli/testdata/zip/testzip_shared_process_virtualization_with_default_tenant
+++ b/pkg/cli/testdata/zip/testzip_shared_process_virtualization_with_default_tenant
@@ -286,3 +286,4 @@ debug zip --concurrency=1 --cpu-profile-duration=1s /dev/null
 [cluster] pprof summary script... writing binary output: debug/cluster/test-tenant/pprof-summary.sh... done
 [cluster] hot range summary script... writing binary output: debug/cluster/test-tenant/hot-ranges.sh... done
 [cluster] tenant hot range summary script... writing binary output: debug/cluster/test-tenant/hot-ranges-tenant.sh... done
+[cluster] NOTE: Omitted traces of running jobs from this debug zip bundle. Use the --include-running-job-traces flag to enable the fetching of this data.

--- a/pkg/cli/zip_cluster_wide.go
+++ b/pkg/cli/zip_cluster_wide.go
@@ -188,5 +188,12 @@ func (zc *debugZipContext) collectClusterData(
 		}
 	}
 
+	if zipCtx.includeRunningJobTraces {
+		zc.clusterPrinter.info("collecting the inflight traces for jobs")
+		if err := zc.dumpTraceableJobTraces(); err != nil {
+			return &serverpb.NodesListResponse{}, nil, err
+		}
+	}
+
 	return nodesList, livenessByNodeID, nil
 }

--- a/pkg/jobs/BUILD.bazel
+++ b/pkg/jobs/BUILD.bazel
@@ -41,7 +41,6 @@ go_library(
         "//pkg/scheduledjobs",
         "//pkg/security/username",
         "//pkg/server/telemetry",
-        "//pkg/server/tracedumper",
         "//pkg/settings",
         "//pkg/settings/cluster",
         "//pkg/sql/catalog",

--- a/pkg/jobs/delegate_control_test.go
+++ b/pkg/jobs/delegate_control_test.go
@@ -159,7 +159,7 @@ func TestJobsControlForSchedules(t *testing.T) {
 	// As such, the job does not undergo usual job state transitions
 	// (e.g. pause-request -> paused).
 	RegisterConstructor(jobspb.TypeImport, func(job *Job, _ *cluster.Settings) Resumer {
-		return FakeResumer{
+		return jobstest.FakeResumer{
 			OnResume: func(_ context.Context) error {
 				<-blockResume
 				return nil
@@ -273,7 +273,7 @@ func TestFilterJobsControlForSchedules(t *testing.T) {
 
 	// Our resume never completes any jobs, until this test completes.
 	RegisterConstructor(jobspb.TypeImport, func(job *Job, _ *cluster.Settings) Resumer {
-		return FakeResumer{
+		return jobstest.FakeResumer{
 			OnResume: func(_ context.Context) error {
 				<-blockResume
 				return nil
@@ -406,7 +406,7 @@ func TestJobControlByType(t *testing.T) {
 	// Make the jobs of each type controllable.
 	for _, jobType := range allJobTypes {
 		RegisterConstructor(jobType, func(job *Job, _ *cluster.Settings) Resumer {
-			return FakeResumer{
+			return jobstest.FakeResumer{
 				OnResume: func(ctx context.Context) error {
 					<-ctx.Done()
 					return nil

--- a/pkg/jobs/jobstest/BUILD.bazel
+++ b/pkg/jobs/jobstest/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "jobstest",
     srcs = [
         "logutils.go",
+        "resumer.go",
         "utils.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/jobs/jobstest",
@@ -13,6 +14,7 @@ go_library(
         "//pkg/jobs/jobspb",
         "//pkg/scheduledjobs",
         "//pkg/sql/catalog/systemschema",
+        "//pkg/sql/isql",
         "//pkg/sql/sem/tree",
         "//pkg/testutils",
         "//pkg/util/log",

--- a/pkg/jobs/jobstest/resumer.go
+++ b/pkg/jobs/jobstest/resumer.go
@@ -1,0 +1,67 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package jobstest
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/sql/isql"
+)
+
+// FakeResumer calls optional callbacks during the job lifecycle.
+type FakeResumer struct {
+	OnResume      func(context.Context) error
+	FailOrCancel  func(context.Context) error
+	Success       func() error
+	PauseRequest  func(ctx context.Context, planHookState interface{}, txn isql.Txn, progress *jobspb.Progress) error
+	TraceRealSpan bool
+}
+
+func (d FakeResumer) ForceRealSpan() bool {
+	return d.TraceRealSpan
+}
+
+func (d FakeResumer) DumpTraceAfterRun() bool {
+	return true
+}
+
+func (d FakeResumer) Resume(ctx context.Context, _ interface{}) error {
+	if d.OnResume != nil {
+		if err := d.OnResume(ctx); err != nil {
+			return err
+		}
+	}
+	if d.Success != nil {
+		return d.Success()
+	}
+	return nil
+}
+
+func (d FakeResumer) OnFailOrCancel(ctx context.Context, _ interface{}, _ error) error {
+	if d.FailOrCancel != nil {
+		return d.FailOrCancel(ctx)
+	}
+	return nil
+}
+
+func (d FakeResumer) CollectProfile(_ context.Context, _ interface{}) error {
+	return nil
+}
+
+func (d FakeResumer) OnPauseRequest(
+	ctx context.Context, execCtx interface{}, txn isql.Txn, details *jobspb.Progress,
+) error {
+	if d.PauseRequest == nil {
+		return nil
+	}
+	return d.PauseRequest(ctx, execCtx, txn, details)
+}

--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -26,7 +26,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
-	"github.com/cockroachdb/cockroach/pkg/server/tracedumper"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
@@ -107,7 +106,6 @@ type Registry struct {
 	settings  *cluster.Settings
 	execCtx   jobExecCtxMaker
 	metrics   Metrics
-	td        *tracedumper.TraceDumper
 	knobs     TestingKnobs
 
 	// adoptionChan is used to nudge the registry to resume claimed jobs and
@@ -226,7 +224,6 @@ func MakeRegistry(
 	histogramWindowInterval time.Duration,
 	execCtxFn jobExecCtxMaker,
 	preventAdoptionFile string,
-	td *tracedumper.TraceDumper,
 	knobs *TestingKnobs,
 ) *Registry {
 	r := &Registry{
@@ -241,7 +238,6 @@ func MakeRegistry(
 		execCtx:                 execCtxFn,
 		preventAdoptionFile:     preventAdoptionFile,
 		preventAdoptionLogEvery: log.Every(time.Minute),
-		td:                      td,
 		// Use a non-zero buffer to allow queueing of notifications.
 		// The writing method will use a default case to avoid blocking
 		// if a notification is already queued.

--- a/pkg/jobs/registry_external_test.go
+++ b/pkg/jobs/registry_external_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobstest"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -364,7 +365,7 @@ func TestGCDurationControl(t *testing.T) {
 	}
 
 	jobs.RegisterConstructor(jobspb.TypeImport, func(_ *jobs.Job, cs *cluster.Settings) jobs.Resumer {
-		return jobs.FakeResumer{}
+		return jobstest.FakeResumer{}
 	}, jobs.UsesTenantCostControl)
 	s, sqlDB, _ := serverutils.StartServer(t, args)
 	defer s.Stopper().Stop(ctx)
@@ -443,7 +444,7 @@ func TestErrorsPopulatedOnRetry(t *testing.T) {
 				return ctx.Err()
 			}
 		}
-		return jobs.FakeResumer{
+		return jobstest.FakeResumer{
 			OnResume:     execFn,
 			FailOrCancel: execFn,
 		}

--- a/pkg/jobs/registry_test.go
+++ b/pkg/jobs/registry_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobstest"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/keyvisualizer"
 	"github.com/cockroachdb/cockroach/pkg/kv"
@@ -344,7 +345,7 @@ func TestCreateJobWritesToJobInfo(t *testing.T) {
 	r := s.JobRegistry().(*Registry)
 
 	RegisterConstructor(jobspb.TypeImport, func(job *Job, cs *cluster.Settings) Resumer {
-		return FakeResumer{
+		return jobstest.FakeResumer{
 			OnResume: func(ctx context.Context) error {
 				return nil
 			},
@@ -531,7 +532,7 @@ func TestBatchJobsCreation(t *testing.T) {
 				r := s.JobRegistry().(*Registry)
 
 				RegisterConstructor(jobspb.TypeImport, func(job *Job, cs *cluster.Settings) Resumer {
-					return FakeResumer{
+					return jobstest.FakeResumer{
 						OnResume: func(ctx context.Context) error {
 							return nil
 						},
@@ -728,7 +729,7 @@ func TestRetriesWithExponentialBackoff(t *testing.T) {
 		bti.adopted = bti.registry.metrics.AdoptIterations
 		bti.resumed = bti.registry.metrics.ResumedJobs
 		RegisterConstructor(jobspb.TypeImport, func(job *Job, cs *cluster.Settings) Resumer {
-			return FakeResumer{
+			return jobstest.FakeResumer{
 				OnResume: func(ctx context.Context) error {
 					if bti.done.Load().(bool) {
 						return nil
@@ -1040,7 +1041,7 @@ func TestExponentialBackoffSettings(t *testing.T) {
 			tdb = sqlutils.MakeSQLRunner(sdb)
 			// Create and run a dummy job.
 			RegisterConstructor(jobspb.TypeImport, func(_ *Job, cs *cluster.Settings) Resumer {
-				return FakeResumer{}
+				return jobstest.FakeResumer{}
 			}, UsesTenantCostControl)
 			registry := s.JobRegistry().(*Registry)
 			id := registry.MakeJobID()
@@ -1179,7 +1180,7 @@ func TestRunWithoutLoop(t *testing.T) {
 				atomic.AddInt64(counter, 1)
 			}
 		}
-		return FakeResumer{
+		return jobstest.FakeResumer{
 			OnResume: func(ctx context.Context) error {
 				maybeIncrementCounter(&successDone, &ran)
 				if shouldFail {
@@ -1259,7 +1260,7 @@ func TestJobIdleness(t *testing.T) {
 	resumeErrChan := make(chan error)
 	defer close(resumeErrChan)
 	RegisterConstructor(jobspb.TypeImport, func(_ *Job, cs *cluster.Settings) Resumer {
-		return FakeResumer{
+		return jobstest.FakeResumer{
 			OnResume: func(ctx context.Context) error {
 				resumeStartChan <- struct{}{}
 				return <-resumeErrChan
@@ -1485,7 +1486,7 @@ func TestGetClaimedResumerFromRegistry(t *testing.T) {
 	defer close(resumeErrChan)
 	var counter int
 	RegisterConstructor(jobspb.TypeImport, func(_ *Job, cs *cluster.Settings) Resumer {
-		return FakeResumer{
+		return jobstest.FakeResumer{
 			OnResume: func(ctx context.Context) error {
 				resumeStartChan <- struct{}{}
 				return <-resumeErrChan

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -201,7 +201,6 @@ go_library(
         "//pkg/server/systemconfigwatcher",
         "//pkg/server/telemetry",
         "//pkg/server/tenantsettingswatcher",
-        "//pkg/server/tracedumper",
         "//pkg/settings",
         "//pkg/settings/cluster",
         "//pkg/spanconfig",

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -63,7 +63,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server/settingswatcher"
 	"github.com/cockroachdb/cockroach/pkg/server/status"
 	"github.com/cockroachdb/cockroach/pkg/server/systemconfigwatcher"
-	"github.com/cockroachdb/cockroach/pkg/server/tracedumper"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/spanconfig"
@@ -646,7 +645,6 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 			jobsKnobs = cfg.TestingKnobs.JobsTestingKnobs.(*jobs.TestingKnobs)
 		}
 
-		td := tracedumper.NewTraceDumper(ctx, cfg.InflightTraceDirName, cfg.Settings)
 		*jobRegistry = *jobs.MakeRegistry(
 			ctx,
 			cfg.AmbientCtx,
@@ -663,7 +661,6 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 				return sql.MakeJobExecContext(ctx, opName, user, &sql.MemoryMetrics{}, execCfg)
 			},
 			jobAdoptionStopFile,
-			td,
 			jobsKnobs,
 		)
 	}

--- a/pkg/server/tracedumper/BUILD.bazel
+++ b/pkg/server/tracedumper/BUILD.bazel
@@ -10,11 +10,8 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/server/dumpstore",
-        "//pkg/settings",
-        "//pkg/settings/cluster",
         "//pkg/sql/isql",
         "//pkg/util/log",
-        "//pkg/util/timeutil",
         "//pkg/util/tracing/zipper",
         "@com_github_cockroachdb_errors//:errors",
     ],

--- a/pkg/server/tracedumper/tracedumper.go
+++ b/pkg/server/tracedumper/tracedumper.go
@@ -18,11 +18,8 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/server/dumpstore"
-	"github.com/cockroachdb/cockroach/pkg/settings"
-	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing/zipper"
 	"github.com/cockroachdb/errors"
 )
@@ -30,17 +27,6 @@ import (
 const (
 	jobTraceDumpPrefix = "job_trace_dump"
 	timeFormat         = "2006-01-02T15_04_05.000"
-)
-
-var (
-	totalDumpSizeLimit = settings.RegisterByteSizeSetting(
-		settings.ApplicationLevel,
-		"server.job_trace.total_dump_size_limit",
-		"total size of job trace dumps to be kept. "+
-			"Dumps are GC'ed in the order of creation time. The latest dump is "+
-			"always kept even if its size exceeds the limit.",
-		500<<20, // 500MiB
-	)
 )
 
 // TraceDumper can be used to dump a zip file containing cluster wide inflight
@@ -105,21 +91,4 @@ func (t *TraceDumper) Dump(ctx context.Context, name string, traceID int64, ie i
 	if err != nil {
 		log.Errorf(ctx, "failed to dump trace %v", err)
 	}
-}
-
-// NewTraceDumper returns a TraceDumper.
-//
-// dir is the directory in which dumps are stored.
-func NewTraceDumper(ctx context.Context, dir string, st *cluster.Settings) *TraceDumper {
-	if dir == "" {
-		return nil
-	}
-
-	log.Infof(ctx, "writing job trace dumps to %s", log.SafeManaged(dir))
-
-	td := &TraceDumper{
-		currentTime: timeutil.Now,
-		store:       dumpstore.NewStore(dir, totalDumpSizeLimit, st),
-	}
-	return td
 }

--- a/pkg/sql/copy/copy_test.go
+++ b/pkg/sql/copy/copy_test.go
@@ -339,7 +339,7 @@ func TestCopyFromTransaction(t *testing.T) {
 				tconn := sqlConnCtx.MakeSQLConn(io.Discard, io.Discard, url.String())
 				tc.testf(tconn, func(tconn clisqlclient.Conn) {
 					// Without this everything comes back as strings
-					tconn.SetAlwaysInferResultTypes(true)
+					_ = tconn.SetAlwaysInferResultTypes(true)
 					// Put each test in its own db so they can be parallelized.
 					err := tconn.Exec(ctx, fmt.Sprintf("CREATE DATABASE %s; USE %s", tc.name, tc.name))
 					require.NoError(t, err)


### PR DESCRIPTION
This change teaches the debug zip to collect the traces for traceable jobs (backup, restore, import, pcr) that are in a running or reverting state at the time the zip is collected. These traces are dumped in a
`/jobs/<jobID>/<timestamp>/trace.zip` file and rely on the existing `tracing/zippr` that is used by
`cockroach debug job-trace` to collect the required information.

Informs: #111886
Release note (cli change): `cockroach debug zip` will now collect the inflight traces of traceable jobs such as backup, restore, import, c2c and dump them in a `jobs/` subdirectory in the zip.