### PR TITLE
sctest: Skip `CREATE TEMP TABLE` and correctly handle `CREATE FUNCTION` with tagged quote

### DIFF
--- a/pkg/sql/schemachanger/schemachanger_test.go
+++ b/pkg/sql/schemachanger/schemachanger_test.go
@@ -883,6 +883,9 @@ func TestCompareLegacyAndDeclarative(t *testing.T) {
 			"ALTER TABLE t6 ALTER PRIMARY KEY USING COLUMNS (j), DROP COLUMN i; -- ditto",
 			"ALTER TABLE t6 ALTER PRIMARY KEY USING COLUMNS (j), DROP COLUMN k; -- ditto",
 			"ALTER TABLE t6 ADD COLUMN p INT DEFAULT 30, DROP COLUMN p; -- ditto",
+			"SET experimental_enable_temp_tables = true;",
+			"CREATE TEMPORARY TABLE t7 (i INT);  -- expect to skip this line",
+			"CREATE TEMP TABLE t7 (i INT);  -- ditto",
 		},
 	}
 

--- a/pkg/sql/schemachanger/schemachanger_test.go
+++ b/pkg/sql/schemachanger/schemachanger_test.go
@@ -840,8 +840,11 @@ func TestCompareLegacyAndDeclarative(t *testing.T) {
 			"ALTER TABLE t1 DROP COLUMN xyz; -- expect a rejected (sql_safe_updates = true) warning",
 			"ALTER TABLE t1 DROP COLUMN xyz; -- expect a UndefinedColumn error",
 			"ALTER TABLE txyz ADD COLUMN i INT DEFAULT 30; -- expect a UndefinedTable error",
-			"SELECT (*) FROM t1; -- expect to be skipped because of the syntax error",
+			"SELECT (*) FROM t1; -- expect a Syntax error",
 			"FROM t1 SELECT *; -- ditto",
+			"sdfsd  -- ditto",
+			"CREATE VIEW v AS (SELECT (*,1) FROM t);  -- ditto",
+			"CREATE MATERIALIZED VIEW v AS (xlsd);  -- ditto",
 
 			// Statements with TCL commands or empty content.
 			"",

--- a/pkg/sql/schemachanger/schemachanger_test.go
+++ b/pkg/sql/schemachanger/schemachanger_test.go
@@ -845,6 +845,8 @@ func TestCompareLegacyAndDeclarative(t *testing.T) {
 			"sdfsd  -- ditto",
 			"CREATE VIEW v AS (SELECT (*,1) FROM t);  -- ditto",
 			"CREATE MATERIALIZED VIEW v AS (xlsd);  -- ditto",
+			"CREATE FUNCTION f1() RETURNS INT LANGUAGE SQL AS $$ SELECT $$vsd $$;  -- ditto",
+			"CREATE FUNCTION f1() RETURNS INT LANGUAGE SQL AS $funcTag$ SELECT $$vsd $funcTag$;  -- ditto",
 
 			// Statements with TCL commands or empty content.
 			"",

--- a/pkg/sql/schemachanger/sctest/comparator.go
+++ b/pkg/sql/schemachanger/sctest/comparator.go
@@ -155,7 +155,7 @@ func modifyBlacklistedStmt(
 	if modify {
 		t.Logf("Comparator testing framework modifies line %q to %q", line, parsedLine.String())
 	}
-	return parsedLine.String()
+	return parsedLine.StringWithFlags(tree.FmtSimple | tree.FmtTagDollarQuotes)
 }
 
 // modifySetDeclarativeSchemaChangerMode skips stmts that attempt to alter


### PR DESCRIPTION
This PR makes a few small improvement on the comparator testing framework, one in each commit. Each the commit message for details:
1. Skip `CREATE TEMP TABLE` statement
2. Unkip statements with syntax error
3. Correctly handle UDFs with *tagged* quote.

Informs #111978
Epic: None
Release note: None