### PR TITLE
release-22.2: sql: fix TestSQLStatsCompactor test flake

### DIFF
--- a/pkg/sql/sqlstats/persistedsqlstats/compaction_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/compaction_test.go
@@ -155,6 +155,9 @@ func TestSQLStatsCompactor(t *testing.T) {
 			// Test creates a new compactor and calls it directly.
 			sqlConn.Exec(t, "SET CLUSTER SETTING sql.stats.cleanup.recurrence = '@yearly';")
 
+			// Disable auto split by load as it affects the number of wide scans.
+			sqlConn.Exec(t, "SET CLUSTER SETTING kv.range_split.by_load_enabled = false")
+
 			_, err := internalExecutor.ExecEx(
 				ctx,
 				"truncate-stmt-stats",


### PR DESCRIPTION
Backport 1/1 commits from https://github.com/cockroachdb/cockroach/pull/107870 on behalf of @koorosh.

cc @cockroachdb/release 

---

Disables load based splitting during TestSQLStatsCompactor. This is a continuation of #107870 and #108060.

Resolves #111849
Epic: none
Release note: None

-----
Release justification: test fix