### PR TITLE
sql: make SHOW CREATE FUNCTION work with PLpgSQL

### DIFF
--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -459,6 +459,7 @@ go_library(
         "//pkg/sql/pgwire/pgwirecancel",
         "//pkg/sql/physicalplan",
         "//pkg/sql/physicalplan/replicaoracle",
+        "//pkg/sql/plpgsql/parser:plpgparser",
         "//pkg/sql/privilege",
         "//pkg/sql/protoreflect",
         "//pkg/sql/querycache",

--- a/pkg/sql/logictest/testdata/logic_test/show_create
+++ b/pkg/sql/logictest/testdata/logic_test/show_create
@@ -292,3 +292,43 @@ r2  CREATE PROCEDURE sc.r2(IN s STRING)
       AS $$
       SELECT 1;
     $$
+
+# Regression test for #112134 - correctly parse and display PLpgSQL.
+skipif config local-mixed-23.1
+statement ok
+CREATE FUNCTION f112134() RETURNS INT AS $$
+  DECLARE
+    x INT := 0;
+    i INT := 0;
+  BEGIN
+    WHILE i < 3 LOOP
+      x := x + i;
+      i := i + 1;
+    END LOOP;
+    RETURN x;
+  END
+$$ LANGUAGE PLpgSQL;
+
+# TODO(112136): Fix the formatting.
+skipif config local-mixed-23.1
+query TT
+SHOW CREATE FUNCTION f112134;
+----
+f112134  CREATE FUNCTION sc.f112134()
+           RETURNS INT8
+           VOLATILE
+           NOT LEAKPROOF
+           CALLED ON NULL INPUT
+           LANGUAGE plpgsql
+           AS $$
+           DECLARE
+           x INT8 := 0;
+           i INT8 := 0;
+           BEGIN
+           WHILE i < 3 LOOP
+           x := x + i;
+           i := i + 1;
+           END LOOP;
+           RETURN x;
+           END
+         $$


### PR DESCRIPTION
This patch extends the `SHOW CREATE FUNCTION` to check the function language, and call into the correct parser (SQL vs PLpgSQL) in order to format the function body. Since PLpgSQL is not yet in a public release, there is no release note.

Fixes #112134

Release note: None