### PR TITLE
roachtest: fix reused cluster wipe failure handling

### DIFF
--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -572,6 +572,11 @@ func (r *testRunner) runWorker(
 				// N.B. we do not count reuse attempt error toward clusterCreateErr.
 				// Let's attempt to create a fresh cluster.
 				testToRun.canReuseCluster = false
+				// We need an allocation quota to start a new cluster; steal it from the
+				// old cluster before we destroy it (we know the cluster configurations
+				// will be identical).
+				testToRun.alloc = c.destroyState.alloc
+				c.destroyState.alloc = nil
 			}
 		}
 


### PR DESCRIPTION
In a recent refactoring I broke the error case of failing to Wipe a
cluster that was determined to be reusable - `testToRun.alloc` was nil
which makes `newCluster` error out. Restore the old quota-stealing
code to fix this.

Epic: none
Release note: None