### PR TITLE
parser: fix round-tripping of `NOT INDEX IN ()`

### DIFF
--- a/pkg/sql/lexbase/encode.go
+++ b/pkg/sql/lexbase/encode.go
@@ -57,7 +57,7 @@ const (
 // contains special characters, or the identifier is a reserved SQL
 // keyword.
 func EncodeRestrictedSQLIdent(buf *bytes.Buffer, s string, flags EncodeFlags) {
-	if flags.HasFlags(EncBareIdentifiers) || (!isReservedKeyword(s) && IsBareIdentifier(s)) {
+	if flags.HasFlags(EncBareIdentifiers) || (!IsReservedOrLookaheadKeyword(s) && IsBareIdentifier(s)) {
 		buf.WriteString(s)
 		return
 	}

--- a/pkg/sql/lexbase/predicates.go
+++ b/pkg/sql/lexbase/predicates.go
@@ -66,10 +66,16 @@ func init() {
 	}
 }
 
-// isReservedKeyword returns true if the keyword is reserved, or needs
-// one extra token of lookahead.
-func isReservedKeyword(s string) bool {
+// IsReservedOrLookaheadKeyword returns true if the keyword is reserved, or
+// needs one extra token of lookahead.
+func IsReservedOrLookaheadKeyword(s string) bool {
 	_, ok := reservedOrLookaheadKeywords[s]
+	return ok
+}
+
+// IsReservedKeyword returns true if the keyword is reserved.
+func IsReservedKeyword(s string) bool {
+	_, ok := reservedKeywords[s]
 	return ok
 }
 

--- a/pkg/sql/parser/testdata/reserved_keywords
+++ b/pkg/sql/parser/testdata/reserved_keywords
@@ -119,3 +119,13 @@ SET a = index
 SET a = (index) -- fully parenthesized
 SET a = index -- literals removed
 SET a = _ -- identifiers removed
+
+# Test that "of" is allowed as an index name. "of" is not a reserved keyword,
+# but it is a lookahead keyword.
+parse
+CREATE TABLE t (a INT, INDEX of (a))
+----
+CREATE TABLE t (a INT8, INDEX "of" (a)) -- normalized!
+CREATE TABLE t (a INT8, INDEX "of" (a)) -- fully parenthesized
+CREATE TABLE t (a INT8, INDEX "of" (a)) -- literals removed
+CREATE TABLE _ (_ INT8, INDEX _ (_)) -- identifiers removed

--- a/pkg/sql/parser/testdata/select_exprs
+++ b/pkg/sql/parser/testdata/select_exprs
@@ -1451,6 +1451,20 @@ SELECT (ANNOTATE_TYPE((1), STRING)) -- fully parenthesized
 SELECT ANNOTATE_TYPE(_, STRING) -- literals removed
 SELECT ANNOTATE_TYPE(1, STRING) -- identifiers removed
 
+
+# Regression test for https://github.com/cockroachdb/cockroach/issues/111326.
+# `NOT index IN ()` previously would not round trip, since when it gets
+# formatted as `NOT (INDEX IN ())` the parser's special lookahead rules used to
+# incorrectly change the "index" identifier into the special
+# INDEX_BEFORE_NAME_THEN_PAREN token.
+parse
+SELECT NOT index IN ( ) FROM t
+----
+SELECT NOT (index IN ()) FROM t -- normalized!
+SELECT (NOT (((index) IN (())))) FROM t -- fully parenthesized
+SELECT NOT (index IN ()) FROM t -- literals removed
+SELECT NOT (_ IN ()) FROM _ -- identifiers removed
+
 parse
 SELECT (1 + 2).*
 ----


### PR DESCRIPTION
The parser's special lookahead rules were incorrectly changing the "index" identifier into the special
INDEX_BEFORE_NAME_THEN_PAREN token.

This is fixed by checking if the token after the "index" token is a reserved keyword.

fixes https://github.com/cockroachdb/cockroach/issues/111326
Release note (bug fix): Fixed a bug where statements with an expression of the form `NOT INDEX IN ()` could not get formatted correctly.