### PR TITLE
Revert "roachtest: bump span stats limit for `failover`"

### DIFF
--- a/pkg/cmd/roachtest/tests/failover.go
+++ b/pkg/cmd/roachtest/tests/failover.go
@@ -212,9 +212,6 @@ func runFailoverChaos(ctx context.Context, t test.Test, c cluster.Cluster, readO
 	settings := install.MakeClusterSettings()
 	settings.Env = append(settings.Env, "COCKROACH_ENABLE_UNSAFE_TEST_BUILTINS=true")
 	settings.Env = append(settings.Env, "COCKROACH_SCAN_MAX_IDLE_TIME=100ms") // speed up replication
-	// TODO(erikgrinaker): temporary workaround for
-	// https://github.com/cockroachdb/cockroach/issues/105274
-	settings.ClusterSettings["server.span_stats.span_batch_limit"] = "4096"
 
 	m := c.NewMonitor(ctx, c.Range(1, 9))
 
@@ -397,9 +394,6 @@ func runFailoverPartialLeaseGateway(ctx context.Context, t test.Test, c cluster.
 	opts.RoachprodOpts.ScheduleBackups = false
 	settings := install.MakeClusterSettings()
 	settings.Env = append(settings.Env, "COCKROACH_SCAN_MAX_IDLE_TIME=100ms") // speed up replication
-	// TODO(erikgrinaker): temporary workaround for
-	// https://github.com/cockroachdb/cockroach/issues/105274
-	settings.ClusterSettings["server.span_stats.span_batch_limit"] = "4096"
 
 	m := c.NewMonitor(ctx, c.Range(1, 7))
 
@@ -535,9 +529,6 @@ func runFailoverPartialLeaseLeader(ctx context.Context, t test.Test, c cluster.C
 	opts := option.DefaultStartOpts()
 	opts.RoachprodOpts.ScheduleBackups = false
 	settings := install.MakeClusterSettings()
-	// TODO(erikgrinaker): temporary workaround for
-	// https://github.com/cockroachdb/cockroach/issues/105274
-	settings.ClusterSettings["server.span_stats.span_batch_limit"] = "4096"
 
 	m := c.NewMonitor(ctx, c.Range(1, 6))
 
@@ -678,9 +669,6 @@ func runFailoverPartialLeaseLiveness(ctx context.Context, t test.Test, c cluster
 	opts.RoachprodOpts.ScheduleBackups = false
 	settings := install.MakeClusterSettings()
 	settings.Env = append(settings.Env, "COCKROACH_SCAN_MAX_IDLE_TIME=100ms") // speed up replication
-	// TODO(erikgrinaker): temporary workaround for
-	// https://github.com/cockroachdb/cockroach/issues/105274
-	settings.ClusterSettings["server.span_stats.span_batch_limit"] = "4096"
 
 	m := c.NewMonitor(ctx, c.Range(1, 7))
 
@@ -800,9 +788,6 @@ func runFailoverNonSystem(
 	settings := install.MakeClusterSettings()
 	settings.Env = append(settings.Env, "COCKROACH_ENABLE_UNSAFE_TEST_BUILTINS=true")
 	settings.Env = append(settings.Env, "COCKROACH_SCAN_MAX_IDLE_TIME=100ms") // speed up replication
-	// TODO(erikgrinaker): temporary workaround for
-	// https://github.com/cockroachdb/cockroach/issues/105274
-	settings.ClusterSettings["server.span_stats.span_batch_limit"] = "4096"
 
 	m := c.NewMonitor(ctx, c.Range(1, 6))
 
@@ -913,9 +898,6 @@ func runFailoverLiveness(
 	settings := install.MakeClusterSettings()
 	settings.Env = append(settings.Env, "COCKROACH_ENABLE_UNSAFE_TEST_BUILTINS=true")
 	settings.Env = append(settings.Env, "COCKROACH_SCAN_MAX_IDLE_TIME=100ms") // speed up replication
-	// TODO(erikgrinaker): temporary workaround for
-	// https://github.com/cockroachdb/cockroach/issues/105274
-	settings.ClusterSettings["server.span_stats.span_batch_limit"] = "4096"
 
 	m := c.NewMonitor(ctx, c.Range(1, 4))
 
@@ -1032,9 +1014,6 @@ func runFailoverSystemNonLiveness(
 	settings := install.MakeClusterSettings()
 	settings.Env = append(settings.Env, "COCKROACH_ENABLE_UNSAFE_TEST_BUILTINS=true")
 	settings.Env = append(settings.Env, "COCKROACH_SCAN_MAX_IDLE_TIME=100ms") // speed up replication
-	// TODO(erikgrinaker): temporary workaround for
-	// https://github.com/cockroachdb/cockroach/issues/105274
-	settings.ClusterSettings["server.span_stats.span_batch_limit"] = "4096"
 
 	m := c.NewMonitor(ctx, c.Range(1, 6))
 


### PR DESCRIPTION
This reverts commit b051b1400976becef3eedfa552051299fef3d296.