### PR TITLE
streamingccl: fix test flake

### DIFF
--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_job_test.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_job_test.go
@@ -132,45 +132,6 @@ func TestTenantStreamingFailback(t *testing.T) {
 		return conn
 	}
 
-	// ALTER VIRTUAL CLUSTER STOP SERVICE does not block until the
-	// service is stopped. But, we need to wait until the
-	// SQLServer is stopped to ensure that nothing is writing to
-	// the relevant keyspace.
-	waitUntilStopped := func(t *testing.T, srv serverutils.ApplicationLayerInterface, tenantName string) {
-		// TODO(ssd): We may want to do something like this,
-		// but this query is driven first from the
-		// system.tenants table and doesn't strictly represent
-		// the in-memory state of the tenant controller.
-		//
-		// client := srv.GetAdminClient(t)
-		// testutils.SucceedsSoon(t, func() error {
-		// 	resp, err := client.ListTenants(ctx, &serverpb.ListTenantsRequest{})
-		// 	if err != nil {
-		// 		return err
-		// 	}
-		// 	for _, tenant := range resp.Tenants {
-		// 		if tenant.TenantName == tenantName {
-		// 			t.Logf("tenant %q is still running", tenantName)
-		// 			return errors.Newf("tenant %q still running")
-		// 		}
-		// 	}
-		// 	t.Logf("tenant %q is not running", tenantName)
-		// 	return nil
-		// })
-		testutils.SucceedsSoon(t, func() error {
-			db, err := srv.SQLConnE(serverutils.DBName(fmt.Sprintf("cluster:%s", tenantName)))
-			if err != nil {
-				return err
-			}
-			if err := db.Ping(); err == nil {
-				t.Logf("tenant %q is still accepting connections", tenantName)
-				return errors.Newf("tenant %q still accepting connections")
-			}
-			t.Logf("tenant %q is not accepting connections", tenantName)
-			return nil
-		})
-	}
-
 	sqlA := sqlutils.MakeSQLRunner(aDB)
 	sqlB := sqlutils.MakeSQLRunner(bDB)
 
@@ -287,7 +248,7 @@ func TestTenantStreamingFailback(t *testing.T) {
 	//   Fingerprint f and g as of ts1
 	//   Fingerprint f and g as of ts2
 	sqlA.Exec(t, "ALTER VIRTUAL CLUSTER f STOP SERVICE")
-	waitUntilStopped(t, serverA.SystemLayer(), "f")
+	waitUntilTenantServerStopped(t, serverA.SystemLayer(), "f")
 	t.Logf("starting replication g->f")
 	sqlA.Exec(t, fmt.Sprintf("SELECT crdb_internal.unsafe_revert_tenant_to_timestamp('f', %s)", ts1))
 	sqlA.Exec(t, fmt.Sprintf("CREATE VIRTUAL CLUSTER f FROM REPLICATION OF g ON $1 WITH RESUME TIMESTAMP = '%s'", ts1), serverBURL.String())
@@ -317,7 +278,7 @@ func TestTenantStreamingFailback(t *testing.T) {
 	sqlA.Exec(t, "ALTER VIRTUAL CLUSTER f START SERVICE SHARED")
 
 	sqlB.Exec(t, "ALTER VIRTUAL CLUSTER g STOP SERVICE")
-	waitUntilStopped(t, serverB.SystemLayer(), "g")
+	waitUntilTenantServerStopped(t, serverB.SystemLayer(), "g")
 	t.Logf("starting replication f->g")
 	sqlB.Exec(t, fmt.Sprintf("SELECT crdb_internal.unsafe_revert_tenant_to_timestamp('g', %s)", ts3))
 	sqlB.Exec(t, fmt.Sprintf("CREATE VIRTUAL CLUSTER g FROM REPLICATION OF f ON $1 WITH RESUME TIMESTAMP = '%s'", ts3), serverAURL.String())
@@ -745,4 +706,45 @@ func TestCutoverCheckpointing(t *testing.T) {
 	// the empty remainingSpans are encoded as
 	// roachpb.Spans{roachpb.Span{Key:/Min, EndKey:/Min}.
 	require.Equal(t, getCutoverRemainingSpans().String(), roachpb.Spans{}.String())
+}
+
+// ALTER VIRTUAL CLUSTER STOP SERVICE does not block until the service
+// is stopped. But, we need to wait until the SQLServer is stopped to
+// ensure that nothing is writing to the relevant keyspace.
+func waitUntilTenantServerStopped(
+	t *testing.T, srv serverutils.ApplicationLayerInterface, tenantName string,
+) {
+	t.Helper()
+	// TODO(ssd): We may want to do something like this,
+	// but this query is driven first from the
+	// system.tenants table and doesn't strictly represent
+	// the in-memory state of the tenant controller.
+	//
+	// client := srv.GetAdminClient(t)
+	// testutils.SucceedsSoon(t, func() error {
+	// 	resp, err := client.ListTenants(ctx, &serverpb.ListTenantsRequest{})
+	// 	if err != nil {
+	// 		return err
+	// 	}
+	// 	for _, tenant := range resp.Tenants {
+	// 		if tenant.TenantName == tenantName {
+	// 			t.Logf("tenant %q is still running", tenantName)
+	// 			return errors.Newf("tenant %q still running")
+	// 		}
+	// 	}
+	// 	t.Logf("tenant %q is not running", tenantName)
+	// 	return nil
+	// })
+	testutils.SucceedsSoon(t, func() error {
+		db, err := srv.SQLConnE(serverutils.DBName(fmt.Sprintf("cluster:%s", tenantName)))
+		if err != nil {
+			return err
+		}
+		if err := db.Ping(); err == nil {
+			t.Logf("tenant %q is still accepting connections", tenantName)
+			return errors.Newf("tenant %q still accepting connections")
+		}
+		t.Logf("tenant %q is not accepting connections", tenantName)
+		return nil
+	})
 }

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_manager_test.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_manager_test.go
@@ -115,6 +115,8 @@ func TestRevertTenantToTimestamp(t *testing.T) {
 		tenantSQL.CheckQueryResults(t, "SELECT max(k) FROM test.revert1", [][]string{{"1100"}})
 
 		systemSQL.Exec(t, "ALTER VIRTUAL CLUSTER target STOP SERVICE")
+		waitUntilTenantServerStopped(t, srv.SystemLayer(), "target")
+
 		systemSQL.Exec(t, fmt.Sprintf("SELECT crdb_internal.unsafe_revert_tenant_to_timestamp('target', %s)", ts))
 		systemSQL.Exec(t, "ALTER VIRTUAL CLUSTER target START SERVICE SHARED")
 


### PR DESCRIPTION
Currently, tenant servers are slow to shut down after a STOP SERVICE. This can cause flakes because (1) it is unsafe to revert a tenant that is still writing and (2) the test assumes it can connect anew after bringing the tenant back online, but the tenant might still be draining.

Epic: none

Release note: None