### PR TITLE
roachtest: prototype for metamorphic settings during upgrade tests

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/BUILD.bazel
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
     deps = [
         "//pkg/cmd/roachtest/cluster",
         "//pkg/cmd/roachtest/option",
+        "//pkg/cmd/roachtest/registry",
         "//pkg/cmd/roachtest/roachtestutil",
         "//pkg/cmd/roachtest/roachtestutil/clusterupgrade",
         "//pkg/cmd/roachtest/test",


### PR DESCRIPTION
This patch prototypes support for metamorphic cluster settings in upgrade tests.

The motivation is to metamorphically vary cluster settings that are not supported on all version (in particular, the initial version being upgraded from). Instead, the cluster setting is only modified once the cluster has been upgraded to a version that supports it.

Touches #103304.
Epic: none
Release note: None