### PR TITLE
opt: fix bug in ReplaceMinWithLimit and ReplaceMaxWithLimit rules

### DIFF
--- a/pkg/sql/opt/xform/groupby_funcs.go
+++ b/pkg/sql/opt/xform/groupby_funcs.go
@@ -153,13 +153,17 @@ func (c *CustomFuncs) TwoOrMoreMinOrMax(aggs memo.AggregationsExpr) bool {
 // input expression is expected to return zero or one rows, and the aggregate
 // functions are expected to always pass through their values in that case.
 func (c *CustomFuncs) MakeProjectFromPassthroughAggs(
-	grp memo.RelExpr, required *physical.Required, input memo.RelExpr, aggs memo.AggregationsExpr,
+	grp memo.RelExpr,
+	required *physical.Required,
+	input memo.RelExpr,
+	aggs memo.AggregationsExpr,
+	groupingCols opt.ColSet,
 ) {
 	if !input.Relational().Cardinality.IsZeroOrOne() {
 		panic(errors.AssertionFailedf("input expression cannot have more than one row: %v", input))
 	}
 
-	var passthrough opt.ColSet
+	passthrough := groupingCols.Copy()
 	projections := make(memo.ProjectionsExpr, 0, len(aggs))
 	for i := range aggs {
 		// If aggregate remaps the column ID, need to synthesize projection item;

--- a/pkg/sql/opt/xform/rules/groupby.opt
+++ b/pkg/sql/opt/xform/rules/groupby.opt
@@ -99,7 +99,10 @@
         (OtherAggsAreConst $aggregations $item)
     $groupingPrivate:* &
         (IsCanonicalGroupBy $groupingPrivate) &
-        (ColsAreConst (GroupingCols $groupingPrivate) $input)
+        (ColsAreConst
+            $groupingCols:(GroupingCols $groupingPrivate)
+            $input
+        )
 )
 =>
 (MakeProjectFromPassthroughAggs
@@ -109,6 +112,7 @@
         (MakeOrderingChoiceFromColumn Min $col)
     )
     $aggregations
+    $groupingCols
 )
 
 # ReplaceMaxWithLimit is analogous to the ReplaceMinWithLimit rule, except that
@@ -127,7 +131,10 @@
         (OtherAggsAreConst $aggregations $item)
     $groupingPrivate:* &
         (IsCanonicalGroupBy $groupingPrivate) &
-        (ColsAreConst (GroupingCols $groupingPrivate) $input)
+        (ColsAreConst
+            $groupingCols:(GroupingCols $groupingPrivate)
+            $input
+        )
 )
 =>
 (MakeProjectFromPassthroughAggs
@@ -137,6 +144,7 @@
         (MakeOrderingChoiceFromColumn Max $col)
     )
     $aggregations
+    $groupingCols
 )
 
 # GenerateStreamingGroupBy creates variants of a GroupBy, DistinctOn,

--- a/pkg/sql/opt/xform/testdata/rules/groupby
+++ b/pkg/sql/opt/xform/testdata/rules/groupby
@@ -723,6 +723,55 @@ project
  └── projections
       └── w:4 [as=max:7, outer=(4)]
 
+# Basic min case with ReduceGroupingCols disabled. By disabling this
+# normalization rule, the constant column w is left in the grouping columns
+# instead of being moved to a constant aggregate. This ensures that
+# ReplaceMinWithLimit handles constant grouping columns correctly.
+opt disable=ReduceGroupingCols expect=ReplaceMinWithLimit
+SELECT min(k) FROM kuvw WHERE w = 5 GROUP BY w
+----
+project
+ ├── columns: min:7!null
+ ├── cardinality: [0 - 1]
+ ├── key: ()
+ ├── fd: ()-->(7)
+ └── project
+      ├── columns: min:7!null w:4!null
+      ├── cardinality: [0 - 1]
+      ├── key: ()
+      ├── fd: ()-->(4,7)
+      ├── scan kuvw@w
+      │    ├── columns: k:1!null w:4!null
+      │    ├── constraint: /4/1: [/5 - /5]
+      │    ├── limit: 1
+      │    ├── key: ()
+      │    └── fd: ()-->(1,4)
+      └── projections
+           └── k:1 [as=min:7, outer=(1)]
+
+# Basic max case with ReduceGroupingCols disabled.
+opt disable=ReduceGroupingCols expect=ReplaceMaxWithLimit
+SELECT max(w) FROM kuvw WHERE v = 5 GROUP BY v
+----
+project
+ ├── columns: max:7
+ ├── cardinality: [0 - 1]
+ ├── key: ()
+ ├── fd: ()-->(7)
+ └── project
+      ├── columns: max:7 v:3!null
+      ├── cardinality: [0 - 1]
+      ├── key: ()
+      ├── fd: ()-->(3,7)
+      ├── scan kuvw@vw,rev
+      │    ├── columns: v:3!null w:4
+      │    ├── constraint: /3/4/1: [/5 - /5]
+      │    ├── limit: 1(rev)
+      │    ├── key: ()
+      │    └── fd: ()-->(3,4)
+      └── projections
+           └── w:4 [as=max:7, outer=(4)]
+
 # Add const_agg function, as well as min function.
 opt expect=ReplaceMinWithLimit
 SELECT v + 1, min(w), v FROM kuvw WHERE v = 5 AND w IS NOT NULL GROUP BY v
@@ -1075,6 +1124,83 @@ group-by (streaming)
  └── aggregations
       └── min [as=min:7, outer=(4)]
            └── w:4
+
+exec-ddl
+CREATE TABLE t112131 (
+    a INT PRIMARY KEY,
+    b INT NOT NULL
+)
+----
+
+# Regression test for #112131. ReplaceMinWithLimit should project constant
+# grouping columns.
+opt expect=ReplaceMinWithLimit
+SELECT a, min(b) FROM t112131
+WHERE a IN (
+    SELECT min(b) FROM t112131
+)
+GROUP BY a
+----
+project
+ ├── columns: a:1!null min:10!null
+ ├── cardinality: [0 - 1]
+ ├── key: (1)
+ ├── fd: (1)-->(10)
+ ├── inner-join (lookup t112131)
+ │    ├── columns: a:1!null b:2!null min:9!null
+ │    ├── key columns: [9] = [1]
+ │    ├── lookup columns are key
+ │    ├── cardinality: [0 - 1]
+ │    ├── key: ()
+ │    ├── fd: ()-->(1,2,9), (9)==(1), (1)==(9)
+ │    ├── scalar-group-by
+ │    │    ├── columns: min:9
+ │    │    ├── cardinality: [1 - 1]
+ │    │    ├── key: ()
+ │    │    ├── fd: ()-->(9)
+ │    │    ├── scan t112131
+ │    │    │    └── columns: b:6!null
+ │    │    └── aggregations
+ │    │         └── min [as=min:9, outer=(6)]
+ │    │              └── b:6
+ │    └── filters (true)
+ └── projections
+      └── b:2 [as=min:10, outer=(2)]
+
+# Regression test for #112131. ReplaceMaxWithLimit should project constant
+# grouping columns.
+opt expect=ReplaceMaxWithLimit
+SELECT a, max(b) FROM t112131
+WHERE a IN (
+    SELECT max(b) FROM t112131
+)
+GROUP BY a
+----
+project
+ ├── columns: a:1!null max:10!null
+ ├── cardinality: [0 - 1]
+ ├── key: (1)
+ ├── fd: (1)-->(10)
+ ├── inner-join (lookup t112131)
+ │    ├── columns: a:1!null b:2!null max:9!null
+ │    ├── key columns: [9] = [1]
+ │    ├── lookup columns are key
+ │    ├── cardinality: [0 - 1]
+ │    ├── key: ()
+ │    ├── fd: ()-->(1,2,9), (9)==(1), (1)==(9)
+ │    ├── scalar-group-by
+ │    │    ├── columns: max:9
+ │    │    ├── cardinality: [1 - 1]
+ │    │    ├── key: ()
+ │    │    ├── fd: ()-->(9)
+ │    │    ├── scan t112131
+ │    │    │    └── columns: b:6!null
+ │    │    └── aggregations
+ │    │         └── max [as=max:9, outer=(6)]
+ │    │              └── b:6
+ │    └── filters (true)
+ └── projections
+      └── b:2 [as=max:10, outer=(2)]
 
 # --------------------------------------------------
 # ReplaceScalarMinMaxWithScalarSubqueries


### PR DESCRIPTION
This commit fixes a bug in `ReplaceMinWithLimit` and
`ReplaceMaxWithLimit` that causes internal errors during query planning.
The bug occurs when these rules match a GroupBy expression with constant
grouping columns. Those columns are not included as passthrough columns
of the resulting Project, so the Project's output columns do not match
the output columns of the original GroupBy.

This bug is rare because constant grouping columns are usually converted
to constant aggregation expressions via the `ReduceGroupingCols`
normalization rule. As the regression tests show, there are cases where
constant grouping columns are not reduced to constant aggregations,
causing an internal error if the best plan includes the incorrect
Project expression.

As far as I can tell, this bug has existed since the
rules were created in the first release of the cost-based optimizer.
However, I have only been able to reproduce the bug in v21.2.0 and
later. I assume that some statistics or costing changes in that version
made it more likely that the invalid plan would be selected.

Fixes #112131

Release note (bug fix): A bug has been fixed that caused internal errors
during query optimization in rare cases. The bug has been present since
version 2.1.11, but it is more likely to occur in version 21.2.0 and
later, though it is still rare. The bug only presents when a query
contains `min` and `max` aggregate functions.
