### PR TITLE
roachtest/sqlsmith: include setup statement when it errors

### DIFF
--- a/pkg/cmd/roachtest/tests/sqlsmith.go
+++ b/pkg/cmd/roachtest/tests/sqlsmith.go
@@ -123,7 +123,7 @@ WITH into_db = 'defaultdb', unsafe_restore_incompatible_version;
 		t.L().Printf("setup:\n%s", strings.Join(setup, "\n"))
 		for _, stmt := range setup {
 			if _, err := conn.Exec(stmt); err != nil {
-				t.Fatal(err)
+				t.Fatalf("error: %s\nstatement: %s", err.Error(), stmt)
 			} else {
 				logStmt(stmt)
 			}


### PR DESCRIPTION
This commit updates the error message when a setup statement of sqlsmith
fails. The statement itself is not included in the error message. This
will aid in tracking down the bug in sqlsmith that causes it to create
invalid setup statements.

Informs #112003

Release note: None
