### PR TITLE
roachtest: bump workload duration in c2c/initialscan/kv0

### DIFF
--- a/pkg/cmd/roachtest/tests/cluster_to_cluster.go
+++ b/pkg/cmd/roachtest/tests/cluster_to_cluster.go
@@ -1133,7 +1133,7 @@ func registerClusterToCluster(r registry.Registry) {
 			// Write ~50GB total (~12.5GB per node).
 			workload:           replicateKV{readPercent: 0, initRows: 50000000, maxBlockBytes: 2048},
 			timeout:            1 * time.Hour,
-			additionalDuration: 1 * time.Minute,
+			additionalDuration: 5 * time.Minute,
 			cutover:            0,
 			clouds:             registry.AllExceptAWS,
 			suites:             registry.Suites("nightly"),


### PR DESCRIPTION
This is expected to reduce the chances of the test not achieving the target latency by giving it more than a minute to complete its catchup scan and thereby update its replicated time.

Informs: #111952
Release note: None