### PR TITLE
release-23.2: scripts: update bump-pebble script

### DIFF
--- a/scripts/bump-pebble.sh
+++ b/scripts/bump-pebble.sh
@@ -17,11 +17,8 @@ echoerr() { printf "%s\n" "$*" >&2; }
 pushd() { builtin pushd "$@" > /dev/null; }
 popd() { builtin popd "$@" > /dev/null; }
 
-# NOTE: After a new release has been cut, update this to the appropriate
-# Cockroach branch name (i.e. release-22.2, etc.), and corresponding Pebble
-# branch name (e.g. crl-release-21.2, etc.).
-BRANCH=master
-PEBBLE_BRANCH=master
+BRANCH=release-23.2
+PEBBLE_BRANCH=crl-release-23.2
 
 # The script can only be run from a specific branch.
 if [ "$(git rev-parse --abbrev-ref HEAD)" != "$BRANCH" ]; then


### PR DESCRIPTION
Update the bump-pebble script to use the correct release branches.

Release justification: internal script change

Epic: none
Release note: None