### PR TITLE
roachtest: fix deadlock in `getTestToRun`

### DIFF
--- a/pkg/cmd/roachtest/work_pool.go
+++ b/pkg/cmd/roachtest/work_pool.go
@@ -93,11 +93,19 @@ func (p *workPool) getTestToRun(
 	if c != nil {
 		ttr := p.selectTestForCluster(ctx, c.spec, cr)
 		if !ttr.noWork {
-			// We found a test that can take advantage of this cluster.
+			// We found a test that can reuse this cluster.
 			return ttr, nil
 		}
+		// We failed to find a test that can reuse this cluster. A fresh cluster will need to be allocated.
+		// The existing cluster will be destroyed _before_ a fresh one is created.
+		// N.B. we must release the allocation quota before invoking 'selectTest' below, otherwise a deadlock may occur.
+		qp.Release(ttr.alloc)
+		// N.B. we transferred the allocation quota from the existing cluster in order to try to allocate a fresh one, so
+		// when the cluster is destroyed, don't release it again.
+		c.destroyState.alloc = nil
+		ttr.alloc = nil
 	}
-
+	// invariant: testToRunRes.noWork || !testToRunRes.canReuseCluster
 	return p.selectTest(ctx, qp)
 }
 


### PR DESCRIPTION
In [1], we refactored test_runner to clean up cluster reuse logic. The refactoring produced a regression in `getTestToRun` which results in a deadlock. In case a cluster cannot be reused, its allocation quota must be released before attempting to allocate a fresh cluster.

[1] https://github.com/cockroachdb/cockroach/pull/111861

Epic: none

Release note: None