### PR TITLE
roachtest: fix rust-postgres test so it uses disk storage

### DIFF
--- a/pkg/cmd/roachtest/tests/rust_postgres.go
+++ b/pkg/cmd/roachtest/tests/rust_postgres.go
@@ -33,7 +33,10 @@ func registerRustPostgres(r registry.Registry) {
 		t.Status("setting up cockroach")
 		c.Put(ctx, t.Cockroach(), "./cockroach", c.All())
 
-		c.Start(ctx, t.L(), option.DefaultStartOptsInMemory(), install.MakeClusterSettings(), c.All())
+		// Most other ORM tests use an in-memory cluster. However, for this test, we
+		// need to restart the cluster with a different port, so we need disk
+		// storage.
+		c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), c.All())
 		db := c.Conn(ctx, t.L(), 1)
 		_, err := db.Exec("create user postgres with createdb createlogin createrole cancelquery")
 		if err != nil {


### PR DESCRIPTION
In d7e63b9dcf367959cccd2bf6b8bd53b388b395eb this test was changed to use in-memory storage. However, that doesn't work because the cluster gets restarted in this test.

In-memory storage was just an optimization, and this test only takes a minute, so it's OK to use disk storage here.

fixes https://github.com/cockroachdb/cockroach/issues/111826
fixes https://github.com/cockroachdb/cockroach/issues/112171
Release note: None