### PR TITLE
sql: fix type-checking of call statements

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/procedure
+++ b/pkg/sql/logictest/testdata/logic_test/procedure
@@ -286,3 +286,31 @@ statement ok
 DROP PROCEDURE rfp
 
 subtest end
+
+subtest regression_111021
+
+statement ok
+CREATE PROCEDURE p111021(i INT) LANGUAGE SQL AS 'SELECT i'
+
+# Subqueries are not allowed in arguments to procedures.
+statement error pgcode 0A000 p111021\(\): subqueries are not allowed in CALL argument
+CALL p111021((SELECT 1));
+
+# Subqueries nested within other expressions are not allowed in arguments to
+# procedures.
+statement error pgcode 0A000 p111021\(\): subqueries are not allowed in CALL argument
+CALL p111021(CASE WHEN false THEN 1 ELSE (SELECT 1) END);
+
+# The ALL prefix is allowed as an argument to a procedure, but has no effect.
+statement ok
+CALL p(ALL NULL);
+
+# The ALL prefix is allowed as an argument to a procedure, but has no effect.
+statement ok
+CALL p(ALL 1);
+
+# Calling a built-in function with ALL should not cause an internal error.
+statement error pgcode 42809 family\(val: inet\) is not a procedure
+CALL family(ALL NULL);
+
+subtest end

--- a/pkg/sql/opt/optbuilder/routine.go
+++ b/pkg/sql/opt/optbuilder/routine.go
@@ -94,7 +94,8 @@ func (b *Builder) buildProcedure(c *tree.Call, inScope *scope) *scope {
 	outScope := inScope.push()
 
 	// Type-check the procedure.
-	defer b.semaCtx.Properties.Ancestors.PopTo(b.semaCtx.Properties.Ancestors)
+	defer b.semaCtx.Properties.Restore(b.semaCtx.Properties)
+	b.semaCtx.Properties.Require("CALL argument", tree.RejectSubqueries)
 	b.semaCtx.Properties.Ancestors.Push(tree.CallAncestor)
 	typedExpr, err := tree.TypeCheck(b.ctx, c.Proc, b.semaCtx, types.Any)
 	if err != nil {


### PR DESCRIPTION
This commit fixes a few related bugs with the type-checking of `CALL`
statements. See the test cases for examples.

Fixes #111021

There is no release note because procedures have not yet been included
in any major release.

Release note: None
