### PR TITLE
storage: pebble version cleanup

### DIFF
--- a/pkg/ccl/backupccl/datadriven_test.go
+++ b/pkg/ccl/backupccl/datadriven_test.go
@@ -81,10 +81,8 @@ var localityCfgs = map[string]roachpb.Locality{
 }
 
 var clusterVersionKeys = map[string]clusterversion.Key{
-	"23_1_Start":          clusterversion.TODO_Delete_V23_1Start,
-	"23_1_MVCCTombstones": clusterversion.TODO_Delete_V23_1_MVCCRangeTombstonesUnconditionallyEnabled,
-	"23_2_Start":          clusterversion.V23_2Start,
-	"23_2":                clusterversion.V23_2,
+	"23_2_Start": clusterversion.V23_2Start,
+	"23_2":       clusterversion.V23_2,
 }
 
 type sqlDBKey struct {

--- a/pkg/clusterversion/cockroach_versions.go
+++ b/pkg/clusterversion/cockroach_versions.go
@@ -242,30 +242,6 @@ const (
 	// inverted index on table system.statement_statistics.
 	TODO_Delete_V23_1_AlterSystemStatementStatisticsAddIndexesUsage
 
-	// TODO_Delete_V23_1EnsurePebbleFormatSSTableValueBlocks upgrades the Pebble
-	// format major version to FormatSSTableValueBlocks, which supports writing
-	// sstables in a new format containing value blocks
-	// (sstable.TableFormatPebblev3).
-	//
-	// Only a Pebble version that has upgraded to FormatSSTableValueBlocks can
-	// read sstables with format sstable.TableFormatPebblev3 -- i.e., it is
-	// insufficient for the Pebble code to be recent enough. Hence, this is the
-	// first step of a two-part migration, and we cannot do this in a single
-	// step. With a single step migration, consider a cluster with nodes N1 and
-	// N2: once both are on TODO_Delete_V23_1EnsurePebbleFormatSSTableValueBlocks,
-	// N1 is notified of the change and upgrades the format major version in
-	// Pebble and starts constructing sstables (say for range snapshot ingestion)
-	// in this new format. This sstable could be sent to N2 before N2 has been
-	// notified about TODO_Delete_V23_1EnsurePebbleFormatSSTableValueBlocks, which
-	// will cause the sstable ingestion to fail.
-	TODO_Delete_V23_1EnsurePebbleFormatSSTableValueBlocks
-
-	// TODO_Delete_V23_1EnablePebbleFormatSSTableValueBlocks is the second step of
-	// the two-part migration. When this starts we are sure that all Pebble
-	// instances in the cluster have already upgraded to format major version
-	// FormatSSTableValueBlocks.
-	TODO_Delete_V23_1EnablePebbleFormatSSTableValueBlocks
-
 	// TODO_Delete_V23_1AlterSystemSQLInstancesAddSQLAddr adds a sql_addr column
 	// to the system.sql_instances table.
 	TODO_Delete_V23_1AlterSystemSQLInstancesAddSQLAddr
@@ -333,15 +309,6 @@ const (
 	// been backfilled.
 	TODO_Delete_V23_1DatabaseRoleSettingsRoleIDColumnBackfilled
 
-	// TODO_Delete_V23_1_MVCCRangeTombstonesUnconditionallyEnabled is a version
-	// gate after which Cockroach will always write MVCC Range Tombstones,
-	// regardless of the value of the storage.mvcc.range_tombstones.enabled
-	// cluster setting. Prior to this version, it was possible for a cluster to be
-	// writing MVCC Range Tombstones, but only if the cluster had been opted in
-	// manually, under a specific set of circumstances (i.e. appropriate 22.2.x
-	// version, Cockroach Cloud cluster, etc.).
-	TODO_Delete_V23_1_MVCCRangeTombstonesUnconditionallyEnabled
-
 	// TODO_Delete_V23_1TenantCapabilities is the version where tenant
 	// capabilities can be set.
 	TODO_Delete_V23_1TenantCapabilities
@@ -349,10 +316,6 @@ const (
 	// TODO_Delete_V23_1DeprecateClusterVersionKey is the version where we no
 	// longer write cluster version keys to engines.
 	TODO_Delete_V23_1DeprecateClusterVersionKey
-
-	// TODO_Delete_V23_1SetPebbleCreatorID is a version gate after which we set
-	// the Creator ID on Pebble stores that have shared storage configured.
-	TODO_Delete_V23_1SetPebbleCreatorID
 
 	// TODO_Delete_V23_1_SystemRbrDualWrite indicates regional by row compatible
 	// system tables should write to the old and new indexes. See
@@ -655,14 +618,6 @@ var rawVersionsSingleton = keyedVersions{
 		Version: roachpb.Version{Major: 22, Minor: 2, Internal: 22},
 	},
 	{
-		Key:     TODO_Delete_V23_1EnsurePebbleFormatSSTableValueBlocks,
-		Version: roachpb.Version{Major: 22, Minor: 2, Internal: 24},
-	},
-	{
-		Key:     TODO_Delete_V23_1EnablePebbleFormatSSTableValueBlocks,
-		Version: roachpb.Version{Major: 22, Minor: 2, Internal: 26},
-	},
-	{
 		Key:     TODO_Delete_V23_1AlterSystemSQLInstancesAddSQLAddr,
 		Version: roachpb.Version{Major: 22, Minor: 2, Internal: 28},
 	},
@@ -723,20 +678,12 @@ var rawVersionsSingleton = keyedVersions{
 		Version: roachpb.Version{Major: 22, Minor: 2, Internal: 56},
 	},
 	{
-		Key:     TODO_Delete_V23_1_MVCCRangeTombstonesUnconditionallyEnabled,
-		Version: roachpb.Version{Major: 22, Minor: 2, Internal: 58},
-	},
-	{
 		Key:     TODO_Delete_V23_1TenantCapabilities,
 		Version: roachpb.Version{Major: 22, Minor: 2, Internal: 60},
 	},
 	{
 		Key:     TODO_Delete_V23_1DeprecateClusterVersionKey,
 		Version: roachpb.Version{Major: 22, Minor: 2, Internal: 62},
-	},
-	{
-		Key:     TODO_Delete_V23_1SetPebbleCreatorID,
-		Version: roachpb.Version{Major: 22, Minor: 2, Internal: 64},
 	},
 	{
 		Key:     TODO_Delete_V23_1_SystemRbrDualWrite,
@@ -973,6 +920,7 @@ var V23_2 = versionsSingleton[len(versionsSingleton)-1].Key
 
 const (
 	BinaryMinSupportedVersionKey = V23_1
+	PreviousReleaseVersionKey    = V23_1
 )
 
 // TODO(irfansharif): clusterversion.binary{,MinimumSupported}Version

--- a/pkg/settings/registry.go
+++ b/pkg/settings/registry.go
@@ -227,6 +227,9 @@ var retiredSettings = map[InternalKey]struct{}{
 	"changefeed.lagging_ranges_polling_rate":                   {},
 	"trace.jaeger.agent":                                       {},
 	"bulkio.restore.use_simple_import_spans":                   {},
+
+	// removed as of 24.1
+	"storage.mvcc.range_tombstones.enabled": {},
 }
 
 // sqlDefaultSettings is the list of "grandfathered" existing sql.defaults

--- a/pkg/sql/gcjob/gcjobnotifier/BUILD.bazel
+++ b/pkg/sql/gcjob/gcjobnotifier/BUILD.bazel
@@ -12,7 +12,6 @@ go_library(
         "//pkg/keys",
         "//pkg/roachpb",
         "//pkg/settings/cluster",
-        "//pkg/storage",
         "//pkg/util/log/logcrash",
         "//pkg/util/stop",
         "//pkg/util/syncutil",

--- a/pkg/sql/gcjob/gcjobnotifier/notifier.go
+++ b/pkg/sql/gcjob/gcjobnotifier/notifier.go
@@ -23,7 +23,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
-	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util/log/logcrash"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
@@ -155,20 +154,11 @@ func (n *Notifier) run(_ context.Context) {
 			versionSettingChanged <- struct{}{}
 		}
 	})
-	tombstonesEnableChanges := make(chan struct{}, 1)
-	storage.MVCCRangeTombstonesEnabledInMixedClusters.SetOnChange(&n.settings.SV, func(ctx context.Context) {
-		select {
-		case tombstonesEnableChanges <- struct{}{}:
-		default:
-		}
-	})
 	for {
 		select {
 		case <-n.stopper.ShouldQuiesce():
 			return
 		case <-versionSettingChanged:
-			n.notify()
-		case <-tombstonesEnableChanges:
 			n.notify()
 		case <-systemConfigUpdateCh:
 			n.maybeNotify()

--- a/pkg/sql/gcjob_test/BUILD.bazel
+++ b/pkg/sql/gcjob_test/BUILD.bazel
@@ -34,7 +34,6 @@ go_test(
         "//pkg/sql/gcjob",
         "//pkg/sql/isql",
         "//pkg/sql/sem/catid",
-        "//pkg/storage",
         "//pkg/testutils",
         "//pkg/testutils/jobutils",
         "//pkg/testutils/serverutils",

--- a/pkg/sql/gcjob_test/gc_job_test.go
+++ b/pkg/sql/gcjob_test/gc_job_test.go
@@ -39,7 +39,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/gcjob"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catid"
-	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/jobutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -285,7 +284,6 @@ func TestGCJobRetry(t *testing.T) {
 	failed.Store(false)
 	cs := cluster.MakeTestingClusterSettings()
 	gcjob.EmptySpanPollInterval.Override(ctx, &cs.SV, 100*time.Millisecond)
-	storage.MVCCRangeTombstonesEnabledInMixedClusters.Override(ctx, &cs.SV, true)
 	params := base.TestServerArgs{Settings: cs}
 	params.Knobs.JobsTestingKnobs = jobs.NewTestingKnobsWithShortIntervals()
 	params.Knobs.Store = &kvserver.StoreTestingKnobs{

--- a/pkg/sql/importer/BUILD.bazel
+++ b/pkg/sql/importer/BUILD.bazel
@@ -227,7 +227,6 @@ go_test(
         "//pkg/sql/stats",
         "//pkg/sql/tests",
         "//pkg/sql/types",
-        "//pkg/storage",
         "//pkg/testutils",
         "//pkg/testutils/datapathutils",
         "//pkg/testutils/jobutils",

--- a/pkg/sql/importer/import_stmt_test.go
+++ b/pkg/sql/importer/import_stmt_test.go
@@ -66,7 +66,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/stats"
 	"github.com/cockroachdb/cockroach/pkg/sql/tests"
-	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/datapathutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/jobutils"
@@ -6389,7 +6388,6 @@ func TestImportPgDumpSchemas(t *testing.T) {
 	baseDir := datapathutils.TestDataPath(t, "pgdump")
 	mkArgs := func() base.TestServerArgs {
 		s := cluster.MakeTestingClusterSettings()
-		storage.MVCCRangeTombstonesEnabledInMixedClusters.Override(ctx, &s.SV, true)
 		return base.TestServerArgs{
 			Settings:      s,
 			ExternalIODir: baseDir,

--- a/pkg/sql/tests/BUILD.bazel
+++ b/pkg/sql/tests/BUILD.bazel
@@ -80,7 +80,6 @@ go_test(
         "//pkg/ccl",
         "//pkg/cloud",
         "//pkg/cloud/impl:cloudimpl",
-        "//pkg/clusterversion",
         "//pkg/config/zonepb",
         "//pkg/internal/rsg",
         "//pkg/internal/sqlsmith",

--- a/pkg/sql/tests/kv_test.go
+++ b/pkg/sql/tests/kv_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
-	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	kv2 "github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -67,11 +66,6 @@ func newKVNative(b *testing.B) kvInterface {
 
 func newKVNativeAndEngine(tb testing.TB, valueBlocks bool) (*kvNative, storage.Engine) {
 	st := cluster.MakeTestingClusterSettings()
-	version := st.Version.ActiveVersionOrEmpty(context.Background())
-	if version.Less(clusterversion.ByKey(
-		clusterversion.TODO_Delete_V23_1EnablePebbleFormatSSTableValueBlocks)) {
-		tb.Fatalf("cluster version is too old %s", version.String())
-	}
 	storage.ValueBlocksEnabled.Override(context.Background(), &st.SV, valueBlocks)
 	s, _, db := serverutils.StartServer(tb, base.TestServerArgs{Settings: st})
 	engines := s.Engines()

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -22,7 +22,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvnemesis/kvnemesisutil"
@@ -76,35 +75,12 @@ var minWALSyncInterval = settings.RegisterDurationSetting(
 	settings.NonNegativeDurationWithMaximum(1*time.Second),
 )
 
-// MVCCRangeTombstonesEnabledInMixedClusters enables writing of MVCC range
-// tombstones. Currently, this is used for schema GC and import cancellation
-// rollbacks.
-//
-// Note that any executing jobs may not pick up this change, so these need to be
-// waited out before being certain that the setting has taken effect.
-//
-// If disabled after being enabled, this will prevent new range tombstones from
-// being written, but already written tombstones will remain until GCed. The
-// above note on jobs also applies in this case.
-//
-// If the version of the cluster is at or beyond the version
-// TODO_Delete_V23_1_MVCCRangeTombstonesUnconditionallyEnabled, the feature is
-// unconditionally enabled.
-var MVCCRangeTombstonesEnabledInMixedClusters = settings.RegisterBoolSetting(
-	settings.SystemVisible,
-	"storage.mvcc.range_tombstones.enabled",
-	"controls the use of MVCC range tombstones in mixed version clusters; range tombstones are always on in finalized 23.1 clusters",
-	false)
-
 // CanUseMVCCRangeTombstones returns true if the caller can begin writing MVCC
-// range tombstones, by setting DeleteRangeRequest.UseRangeTombstone. It
-// requires the storage.mvcc.range_tombstones.enabled cluster setting to be
-// enabled, OR the cluster version is at or beyond the
-// TODO_Delete_V23_1_MVCCRangeTombstonesUnconditionallyEnabled version (i.e. in 23.1, the
-// feature is unconditionally enabled).
+// range tombstones, by setting DeleteRangeRequest.UseRangeTombstone.
 func CanUseMVCCRangeTombstones(ctx context.Context, st *cluster.Settings) bool {
-	return st.Version.IsActive(ctx, clusterversion.TODO_Delete_V23_1_MVCCRangeTombstonesUnconditionallyEnabled) ||
-		MVCCRangeTombstonesEnabledInMixedClusters.Get(&st.SV)
+	// All compatible Cockroach cluster versions support MVCC range tombstones
+	// now.
+	return true
 }
 
 // MaxConflictsPerLockConflictError sets maximum number of locks returned in

--- a/pkg/storage/sst_writer.go
+++ b/pkg/storage/sst_writer.go
@@ -69,8 +69,7 @@ func MakeIngestionWriterOptions(ctx context.Context, cs *cluster.Settings) sstab
 	// table features available. Upgrade to an appropriate version only if the
 	// cluster supports it.
 	format := sstable.TableFormatPebblev2
-	if cs.Version.IsActive(ctx, clusterversion.TODO_Delete_V23_1EnablePebbleFormatSSTableValueBlocks) &&
-		ValueBlocksEnabled.Get(&cs.SV) {
+	if ValueBlocksEnabled.Get(&cs.SV) {
 		format = sstable.TableFormatPebblev3
 	}
 	if cs.Version.IsActive(ctx, clusterversion.V23_2_EnablePebbleFormatVirtualSSTables) && ValueBlocksEnabled.Get(&cs.SV) {


### PR DESCRIPTION
This change cleans up the code that maps cluster versions to pebble
formats and allows the benchmark code to use the same logic.

We also remove all deprecated version gates in storage.

Epic: none
Release note: None