### PR TITLE
server: avoid missing service mode changes 

### DIFF
--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_job_test.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_job_test.go
@@ -740,6 +740,7 @@ func waitUntilTenantServerStopped(
 		if err != nil {
 			return err
 		}
+		defer func() { _ = db.Close() }()
 		if err := db.Ping(); err == nil {
 			t.Logf("tenant %q is still accepting connections", tenantName)
 			return errors.Newf("tenant %q still accepting connections")

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_job_test.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_job_test.go
@@ -132,45 +132,6 @@ func TestTenantStreamingFailback(t *testing.T) {
 		return conn
 	}
 
-	// ALTER VIRTUAL CLUSTER STOP SERVICE does not block until the
-	// service is stopped. But, we need to wait until the
-	// SQLServer is stopped to ensure that nothing is writing to
-	// the relevant keyspace.
-	waitUntilStopped := func(t *testing.T, srv serverutils.ApplicationLayerInterface, tenantName string) {
-		// TODO(ssd): We may want to do something like this,
-		// but this query is driven first from the
-		// system.tenants table and doesn't strictly represent
-		// the in-memory state of the tenant controller.
-		//
-		// client := srv.GetAdminClient(t)
-		// testutils.SucceedsSoon(t, func() error {
-		// 	resp, err := client.ListTenants(ctx, &serverpb.ListTenantsRequest{})
-		// 	if err != nil {
-		// 		return err
-		// 	}
-		// 	for _, tenant := range resp.Tenants {
-		// 		if tenant.TenantName == tenantName {
-		// 			t.Logf("tenant %q is still running", tenantName)
-		// 			return errors.Newf("tenant %q still running")
-		// 		}
-		// 	}
-		// 	t.Logf("tenant %q is not running", tenantName)
-		// 	return nil
-		// })
-		testutils.SucceedsSoon(t, func() error {
-			db, err := srv.SQLConnE(serverutils.DBName(fmt.Sprintf("cluster:%s", tenantName)))
-			if err != nil {
-				return err
-			}
-			if err := db.Ping(); err == nil {
-				t.Logf("tenant %q is still accepting connections", tenantName)
-				return errors.Newf("tenant %q still accepting connections")
-			}
-			t.Logf("tenant %q is not accepting connections", tenantName)
-			return nil
-		})
-	}
-
 	sqlA := sqlutils.MakeSQLRunner(aDB)
 	sqlB := sqlutils.MakeSQLRunner(bDB)
 
@@ -287,7 +248,7 @@ func TestTenantStreamingFailback(t *testing.T) {
 	//   Fingerprint f and g as of ts1
 	//   Fingerprint f and g as of ts2
 	sqlA.Exec(t, "ALTER VIRTUAL CLUSTER f STOP SERVICE")
-	waitUntilStopped(t, serverA.SystemLayer(), "f")
+	waitUntilTenantServerStopped(t, serverA.SystemLayer(), "f")
 	t.Logf("starting replication g->f")
 	sqlA.Exec(t, fmt.Sprintf("SELECT crdb_internal.unsafe_revert_tenant_to_timestamp('f', %s)", ts1))
 	sqlA.Exec(t, fmt.Sprintf("CREATE VIRTUAL CLUSTER f FROM REPLICATION OF g ON $1 WITH RESUME TIMESTAMP = '%s'", ts1), serverBURL.String())
@@ -317,7 +278,7 @@ func TestTenantStreamingFailback(t *testing.T) {
 	sqlA.Exec(t, "ALTER VIRTUAL CLUSTER f START SERVICE SHARED")
 
 	sqlB.Exec(t, "ALTER VIRTUAL CLUSTER g STOP SERVICE")
-	waitUntilStopped(t, serverB.SystemLayer(), "g")
+	waitUntilTenantServerStopped(t, serverB.SystemLayer(), "g")
 	t.Logf("starting replication f->g")
 	sqlB.Exec(t, fmt.Sprintf("SELECT crdb_internal.unsafe_revert_tenant_to_timestamp('g', %s)", ts3))
 	sqlB.Exec(t, fmt.Sprintf("CREATE VIRTUAL CLUSTER g FROM REPLICATION OF f ON $1 WITH RESUME TIMESTAMP = '%s'", ts3), serverAURL.String())
@@ -745,4 +706,45 @@ func TestCutoverCheckpointing(t *testing.T) {
 	// the empty remainingSpans are encoded as
 	// roachpb.Spans{roachpb.Span{Key:/Min, EndKey:/Min}.
 	require.Equal(t, getCutoverRemainingSpans().String(), roachpb.Spans{}.String())
+}
+
+// ALTER VIRTUAL CLUSTER STOP SERVICE does not block until the service
+// is stopped. But, we need to wait until the SQLServer is stopped to
+// ensure that nothing is writing to the relevant keyspace.
+func waitUntilTenantServerStopped(
+	t *testing.T, srv serverutils.ApplicationLayerInterface, tenantName string,
+) {
+	t.Helper()
+	// TODO(ssd): We may want to do something like this,
+	// but this query is driven first from the
+	// system.tenants table and doesn't strictly represent
+	// the in-memory state of the tenant controller.
+	//
+	// client := srv.GetAdminClient(t)
+	// testutils.SucceedsSoon(t, func() error {
+	// 	resp, err := client.ListTenants(ctx, &serverpb.ListTenantsRequest{})
+	// 	if err != nil {
+	// 		return err
+	// 	}
+	// 	for _, tenant := range resp.Tenants {
+	// 		if tenant.TenantName == tenantName {
+	// 			t.Logf("tenant %q is still running", tenantName)
+	// 			return errors.Newf("tenant %q still running")
+	// 		}
+	// 	}
+	// 	t.Logf("tenant %q is not running", tenantName)
+	// 	return nil
+	// })
+	testutils.SucceedsSoon(t, func() error {
+		db, err := srv.SQLConnE(serverutils.DBName(fmt.Sprintf("cluster:%s", tenantName)))
+		if err != nil {
+			return err
+		}
+		if err := db.Ping(); err == nil {
+			t.Logf("tenant %q is still accepting connections", tenantName)
+			return errors.Newf("tenant %q still accepting connections")
+		}
+		t.Logf("tenant %q is not accepting connections", tenantName)
+		return nil
+	})
 }

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_manager_test.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_manager_test.go
@@ -115,6 +115,8 @@ func TestRevertTenantToTimestamp(t *testing.T) {
 		tenantSQL.CheckQueryResults(t, "SELECT max(k) FROM test.revert1", [][]string{{"1100"}})
 
 		systemSQL.Exec(t, "ALTER VIRTUAL CLUSTER target STOP SERVICE")
+		waitUntilTenantServerStopped(t, srv.SystemLayer(), "target")
+
 		systemSQL.Exec(t, fmt.Sprintf("SELECT crdb_internal.unsafe_revert_tenant_to_timestamp('target', %s)", ts))
 		systemSQL.Exec(t, "ALTER VIRTUAL CLUSTER target START SERVICE SHARED")
 


### PR DESCRIPTION
In https://github.com/cockroachdb/cockroach/pull/112001 we introduced a bug and an unintended behaviour change.

The bug is that if we receive a notification of a state change from
none to shared when the server is still shutting down, that state
change will be ignored. Namely, the following can happen:

1. ALTER VIRTUAL CLUSTER a STOP SERVICE
2. Watcher gets notification of shutdown and notifies virtual
   cluster's SQL server.
3. Tenant 1 starts shutdown but does not fully complete it
4. ALTER VIRTUAL CLUSTER a START SERVICE SHARED
5. Watcher notifies the server orchestrator; but, since the SQL server has
   not finished stopping from the previous stop request, it appears as if
   it is already started.
6. Tenant 1 finishes shutdown.
7. Server orchestrator never again tries to start the virtual cluster.

The newly added test reveals this under stress.

The behaviour change is that previously if a SQL server for a virtual
cluster failed to start up, it would previously be restarted.

Here, we fix both of these by re-introducing a periodic polling of the
service state.  Unlike the previous polling, we poll the watcher state
so we are not generating a SQL query every second.

Further, since we are now calling the tenantcapabailities watcher
GetAllTenants method every second in addition to on every update, I've
moved where we allocate the list of all tenants to our handle update
call.

An alternative here would be to revert https://github.com/cockroachdb/cockroach/pull/112001 completely.  I think
there are still advantage to using the watcher: not generating a SQL
query on every node once per second and after the integration of

Fixes https://github.com/cockroachdb/cockroach/issues/112077

Release note: None