### PR TITLE
server: add type safety to iterateNodes and pagination 

### DIFF
--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -3246,8 +3246,8 @@ func (s *systemAdminServer) EnqueueRange(
 	}
 
 	if err := timeutil.RunWithTimeout(ctx, "enqueue range", time.Minute, func(ctx context.Context) error {
-		return s.server.status.iterateNodes(
-			ctx, fmt.Sprintf("enqueue r%d in queue %s", req.RangeID, req.Queue),
+		return iterateNodes(
+			ctx, s.serverIterator, s.server.stopper, fmt.Sprintf("enqueue r%d in queue %s", req.RangeID, req.Queue),
 			noTimeout,
 			dialFn, nodeFn, responseFn, errorFn,
 		)

--- a/pkg/server/api_v2_ranges.go
+++ b/pkg/server/api_v2_ranges.go
@@ -241,10 +241,13 @@ func (a *apiV2Server) listRange(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	if err := a.status.iterateNodes(
+	if err := iterateNodes(
 		ctx,
+		a.status.serverIterator,
+		a.status.stopper,
 		fmt.Sprintf("details about range %d", rangeID),
 		noTimeout,
+		a.status.dialNode,
 		nodeFn,
 		responseFn, errorFn,
 	); err != nil {

--- a/pkg/server/index_usage_stats.go
+++ b/pkg/server/index_usage_stats.go
@@ -74,13 +74,7 @@ func (s *statusServer) IndexUsageStatistics(
 		return statusClient.IndexUsageStatistics(ctx, localReq)
 	}
 
-	dialFn := func(ctx context.Context, nodeID roachpb.NodeID) (interface{}, error) {
-		client, err := s.dialNode(ctx, nodeID)
-		return client, err
-	}
-
-	fetchIndexUsageStats := func(ctx context.Context, client interface{}, _ roachpb.NodeID) (interface{}, error) {
-		statusClient := client.(serverpb.StatusClient)
+	fetchIndexUsageStats := func(ctx context.Context, statusClient serverpb.StatusClient, _ roachpb.NodeID) (interface{}, error) {
 		return statusClient.IndexUsageStatistics(ctx, localReq)
 	}
 
@@ -101,7 +95,7 @@ func (s *statusServer) IndexUsageStatistics(
 	if err := s.iterateNodes(ctx,
 		"requesting index usage stats",
 		noTimeout,
-		dialFn, fetchIndexUsageStats, aggFn, errFn); err != nil {
+		fetchIndexUsageStats, aggFn, errFn); err != nil {
 		return nil, err
 	}
 
@@ -176,13 +170,7 @@ func (s *statusServer) ResetIndexUsageStats(
 		return statusClient.ResetIndexUsageStats(ctx, localReq)
 	}
 
-	dialFn := func(ctx context.Context, nodeID roachpb.NodeID) (interface{}, error) {
-		client, err := s.dialNode(ctx, nodeID)
-		return client, err
-	}
-
-	resetIndexUsageStats := func(ctx context.Context, client interface{}, _ roachpb.NodeID) (interface{}, error) {
-		statusClient := client.(serverpb.StatusClient)
+	resetIndexUsageStats := func(ctx context.Context, statusClient serverpb.StatusClient, _ roachpb.NodeID) (interface{}, error) {
 		return statusClient.ResetIndexUsageStats(ctx, localReq)
 	}
 
@@ -198,7 +186,7 @@ func (s *statusServer) ResetIndexUsageStats(
 	if err := s.iterateNodes(ctx,
 		"Resetting index usage stats",
 		noTimeout,
-		dialFn, resetIndexUsageStats, aggFn, errFn); err != nil {
+		resetIndexUsageStats, aggFn, errFn); err != nil {
 		return nil, err
 	}
 

--- a/pkg/server/index_usage_stats.go
+++ b/pkg/server/index_usage_stats.go
@@ -92,9 +92,11 @@ func (s *statusServer) IndexUsageStatistics(
 	// It's unfortunate that we cannot use paginatedIterateNodes here because we
 	// need to aggregate all stats before returning. Returning a partial result
 	// yields an incorrect result.
-	if err := s.iterateNodes(ctx,
+	if err := iterateNodes(ctx,
+		s.serverIterator, s.stopper,
 		"requesting index usage stats",
 		noTimeout,
+		s.dialNode,
 		fetchIndexUsageStats, aggFn, errFn); err != nil {
 		return nil, err
 	}
@@ -183,9 +185,11 @@ func (s *statusServer) ResetIndexUsageStats(
 		combinedError = errors.CombineErrors(combinedError, nodeFnError)
 	}
 
-	if err := s.iterateNodes(ctx,
+	if err := iterateNodes(ctx,
+		s.serverIterator, s.stopper,
 		"Resetting index usage stats",
 		noTimeout,
+		s.dialNode,
 		resetIndexUsageStats, aggFn, errFn); err != nil {
 		return nil, err
 	}

--- a/pkg/server/key_visualizer_server.go
+++ b/pkg/server/key_visualizer_server.go
@@ -109,7 +109,9 @@ func (s *KeyVisualizerServer) getSamplesFromFanOut(
 			nodeID, err)
 	}
 
-	err := s.status.iterateNodes(ctx,
+	err := iterateNodes(ctx,
+		s.status.serverIterator,
+		s.status.stopper,
 		"iterating nodes for key visualizer samples",
 		noTimeout,
 		dialFn,

--- a/pkg/server/pagination.go
+++ b/pkg/server/pagination.go
@@ -40,26 +40,25 @@ import (
 // in cases where input has been exhausted, helps when it's being returned
 // back to the client as a `json:omitempty` field, as the JSON mashal code will
 // simply ignore the field if it's a zero value.
-func simplePaginate(input interface{}, limit, offset int) (result interface{}, next int) {
-	val := reflect.ValueOf(input)
-	if limit <= 0 || val.Kind() != reflect.Slice {
+func simplePaginate[T any](input []T, limit, offset int) (result []T, next int) {
+	if limit <= 0 {
 		return input, 0
 	} else if offset < 0 {
 		offset = 0
 	}
 	startIdx := offset
 	endIdx := offset + limit
-	if startIdx > val.Len() {
-		startIdx = val.Len()
+	if startIdx > len(input) {
+		startIdx = len(input)
 	}
-	if endIdx > val.Len() {
-		endIdx = val.Len()
+	if endIdx > len(input) {
+		endIdx = len(input)
 	}
 	next = endIdx
-	if endIdx == val.Len() {
+	if endIdx == len(input) {
 		next = 0
 	}
-	return val.Slice(startIdx, endIdx).Interface(), next
+	return input[startIdx:endIdx], next
 }
 
 // paginationState represents the current state of pagination through the result

--- a/pkg/server/pagination.go
+++ b/pkg/server/pagination.go
@@ -17,7 +17,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"reflect"
 	"sort"
 	"strconv"
 	"strings"
@@ -266,11 +265,9 @@ func (p *paginationState) MarshalText() (text []byte, err error) {
 
 // paginatedNodeResponse stores the response from one node in a paginated fan-out
 // request. For use with rpcNodePaginator.
-type paginatedNodeResponse struct {
+type paginatedNodeResponse[T any] struct {
 	nodeID   roachpb.NodeID
-	response interface{}
-	value    reflect.Value
-	len      int
+	response []T
 	err      error
 }
 
@@ -292,17 +289,17 @@ type paginatedNodeResponse struct {
 // Nodes already queried on past calls from the same user (according to
 // pagState) are not ignored. The goroutine that calls processResponses handles
 // slice truncation and response ordering.
-type rpcNodePaginator[Client any] struct {
+type rpcNodePaginator[Client, Result any] struct {
 	limit        int
 	numNodes     int
 	errorCtx     string
 	pagState     paginationState
-	responseChan chan paginatedNodeResponse
+	responseChan chan paginatedNodeResponse[Result]
 	nodeStatuses map[serverID]livenesspb.NodeLivenessStatus
 
 	dialFn     func(ctx context.Context, id roachpb.NodeID) (client Client, err error)
-	nodeFn     func(ctx context.Context, client Client, nodeID roachpb.NodeID) (res interface{}, err error)
-	responseFn func(nodeID roachpb.NodeID, resp interface{})
+	nodeFn     func(ctx context.Context, client Client, nodeID roachpb.NodeID) ([]Result, error)
+	responseFn func(nodeID roachpb.NodeID, res []Result)
 	errorFn    func(nodeID roachpb.NodeID, nodeFnError error)
 
 	mu struct {
@@ -318,9 +315,9 @@ type rpcNodePaginator[Client any] struct {
 	done int32
 }
 
-func (r *rpcNodePaginator[Client]) init() {
+func (r *rpcNodePaginator[Client, Result]) init() {
 	r.mu.turnCond.L = &r.mu
-	r.responseChan = make(chan paginatedNodeResponse, r.numNodes)
+	r.responseChan = make(chan paginatedNodeResponse[Result], r.numNodes)
 }
 
 const noTimeout time.Duration = 0
@@ -328,7 +325,7 @@ const noTimeout time.Duration = 0
 // queryNode queries the given node, and sends the responses back through responseChan
 // in order of idx (i.e. when all nodes with a lower idx have already sent theirs).
 // Safe for concurrent use.
-func (r *rpcNodePaginator[Client]) queryNode(
+func (r *rpcNodePaginator[Client, Result]) queryNode(
 	ctx context.Context, nodeID roachpb.NodeID, idx int, timeout time.Duration,
 ) {
 	if atomic.LoadInt32(&r.done) != 0 {
@@ -336,7 +333,7 @@ func (r *rpcNodePaginator[Client]) queryNode(
 		return
 	}
 	var client Client
-	addNodeResp := func(resp paginatedNodeResponse) {
+	addNodeResp := func(resp paginatedNodeResponse[Result]) {
 		r.mu.Lock()
 		defer r.mu.Unlock()
 
@@ -355,14 +352,14 @@ func (r *rpcNodePaginator[Client]) queryNode(
 			return
 		}
 		r.responseChan <- resp
-		r.mu.currentLen += resp.len
+		r.mu.currentLen += len(resp.response)
 		if nodeID == r.pagState.inProgress {
 			// We're resuming partway through a node's response. Subtract away the
 			// count of values already sent in previous calls (i.e. inProgressIndex).
-			if resp.len > r.pagState.inProgressIndex {
+			if len(resp.response) > r.pagState.inProgressIndex {
 				r.mu.currentLen -= r.pagState.inProgressIndex
 			} else {
-				r.mu.currentLen -= resp.len
+				r.mu.currentLen -= len(resp.response)
 			}
 		}
 		if r.mu.currentLen >= r.limit {
@@ -379,11 +376,11 @@ func (r *rpcNodePaginator[Client]) queryNode(
 	}); err != nil {
 		err = errors.Wrapf(err, "failed to dial into node %d (%s)",
 			nodeID, r.nodeStatuses[serverID(nodeID)])
-		addNodeResp(paginatedNodeResponse{nodeID: nodeID, err: err})
+		addNodeResp(paginatedNodeResponse[Result]{nodeID: nodeID, err: err})
 		return
 	}
 
-	var res interface{}
+	var res []Result
 	var err error
 	if timeout == noTimeout {
 		res, err = r.nodeFn(ctx, client, nodeID)
@@ -399,20 +396,14 @@ func (r *rpcNodePaginator[Client]) queryNode(
 		err = errors.Wrapf(err, "error requesting %s from node %d (%s)",
 			r.errorCtx, nodeID, r.nodeStatuses[serverID(nodeID)])
 	}
-	length := 0
-	value := reflect.ValueOf(res)
-	if res != nil && !value.IsNil() {
-		length = 1
-		if value.Kind() == reflect.Slice {
-			length = value.Len()
-		}
-	}
-	addNodeResp(paginatedNodeResponse{nodeID: nodeID, response: res, len: length, value: value, err: err})
+	addNodeResp(paginatedNodeResponse[Result]{nodeID: nodeID, response: res, err: err})
 }
 
 // processResponses processes the responses returned into responseChan. Must only
 // be called once.
-func (r *rpcNodePaginator[Client]) processResponses(ctx context.Context) (next paginationState, err error) {
+func (r *rpcNodePaginator[Client, Result]) processResponses(
+	ctx context.Context,
+) (next paginationState, err error) {
 	// Copy r.pagState, as concurrent invocations of queryNode expect it to not
 	// change.
 	next = r.pagState
@@ -424,20 +415,13 @@ func (r *rpcNodePaginator[Client]) processResponses(ctx context.Context) (next p
 			if res.err != nil {
 				r.errorFn(res.nodeID, res.err)
 			} else {
-				start, end, newLimit, err2 := next.paginate(limit, res.nodeID, res.len)
+				start, end, newLimit, err2 := next.paginate(limit, res.nodeID, len(res.response))
 				if err2 != nil {
 					r.errorFn(res.nodeID, err2)
 					// Break out of select, resume loop.
 					break
 				}
-				var response interface{}
-				if res.value.Kind() == reflect.Slice {
-					response = res.value.Slice(start, end).Interface()
-				} else if end > start {
-					// res.len must be 1 if res.value.Kind is not Slice.
-					response = res.value.Interface()
-				}
-				r.responseFn(res.nodeID, response)
+				r.responseFn(res.nodeID, res.response[start:end])
 				limit = newLimit
 			}
 			if !ok {

--- a/pkg/server/pagination_test.go
+++ b/pkg/server/pagination_test.go
@@ -57,7 +57,7 @@ func TestSimplePaginate(t *testing.T) {
 	datadriven.RunTest(t, datapathutils.TestDataPath(t, "simple_paginate"), func(t *testing.T, d *datadriven.TestData) string {
 		switch d.Cmd {
 		case "paginate":
-			var input interface{}
+			var input []int
 			if len(d.CmdArgs) != 2 {
 				return "expected 2 args: paginate <limit> <offset>"
 			}

--- a/pkg/server/span_stats_server.go
+++ b/pkg/server/span_stats_server.go
@@ -132,8 +132,10 @@ func (s *systemStatusServer) spanStatsFanOut(
 	}
 
 	timeout := roachpb.SpanStatsNodeTimeout.Get(&s.st.SV)
-	if err := s.statusServer.iterateNodes(
+	if err := iterateNodes(
 		ctx,
+		s.serverIterator,
+		s.stopper,
 		"iterating nodes for span stats",
 		timeout,
 		smartDial,

--- a/pkg/server/sql_stats.go
+++ b/pkg/server/sql_stats.go
@@ -66,13 +66,7 @@ func (s *statusServer) ResetSQLStats(
 		return status.ResetSQLStats(ctx, localReq)
 	}
 
-	dialFn := func(ctx context.Context, nodeID roachpb.NodeID) (interface{}, error) {
-		client, err := s.dialNode(ctx, nodeID)
-		return client, err
-	}
-
-	resetSQLStats := func(ctx context.Context, client interface{}, _ roachpb.NodeID) (interface{}, error) {
-		status := client.(serverpb.StatusClient)
+	resetSQLStats := func(ctx context.Context, status serverpb.StatusClient, _ roachpb.NodeID) (interface{}, error) {
 		return status.ResetSQLStats(ctx, localReq)
 	}
 
@@ -80,7 +74,6 @@ func (s *statusServer) ResetSQLStats(
 
 	if err := s.iterateNodes(ctx, "reset SQL statistics",
 		noTimeout,
-		dialFn,
 		resetSQLStats,
 		func(nodeID roachpb.NodeID, resp interface{}) {
 			// Nothing to do here.

--- a/pkg/server/sql_stats.go
+++ b/pkg/server/sql_stats.go
@@ -72,8 +72,9 @@ func (s *statusServer) ResetSQLStats(
 
 	var fanoutError error
 
-	if err := s.iterateNodes(ctx, "reset SQL statistics",
+	if err := iterateNodes(ctx, s.serverIterator, s.stopper, "reset SQL statistics",
 		noTimeout,
+		s.dialNode,
 		resetSQLStats,
 		func(nodeID roachpb.NodeID, resp interface{}) {
 			// Nothing to do here.

--- a/pkg/server/statements.go
+++ b/pkg/server/statements.go
@@ -79,8 +79,9 @@ func (s *statusServer) Statements(
 		return status.Statements(ctx, localReq)
 	}
 
-	if err := s.iterateNodes(ctx, "statement statistics",
+	if err := iterateNodes(ctx, s.serverIterator, s.stopper, "statement statistics",
 		noTimeout,
+		s.dialNode,
 		nodeStatement,
 		func(nodeID roachpb.NodeID, resp interface{}) {
 			statementsResp := resp.(*serverpb.StatementsResponse)

--- a/pkg/server/statements.go
+++ b/pkg/server/statements.go
@@ -75,18 +75,12 @@ func (s *statusServer) Statements(
 		return status.Statements(ctx, localReq)
 	}
 
-	dialFn := func(ctx context.Context, nodeID roachpb.NodeID) (interface{}, error) {
-		client, err := s.dialNode(ctx, nodeID)
-		return client, err
-	}
-	nodeStatement := func(ctx context.Context, client interface{}, _ roachpb.NodeID) (interface{}, error) {
-		status := client.(serverpb.StatusClient)
+	nodeStatement := func(ctx context.Context, status serverpb.StatusClient, _ roachpb.NodeID) (interface{}, error) {
 		return status.Statements(ctx, localReq)
 	}
 
 	if err := s.iterateNodes(ctx, "statement statistics",
 		noTimeout,
-		dialFn,
 		nodeStatement,
 		func(nodeID roachpb.NodeID, resp interface{}) {
 			statementsResp := resp.(*serverpb.StatementsResponse)

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -2967,12 +2967,11 @@ func (s *statusServer) Range(
 		RangeIDs: []roachpb.RangeID{roachpb.RangeID(req.RangeId)},
 	}
 
-	nodeFn := func(ctx context.Context, status serverpb.StatusClient, _ roachpb.NodeID) (interface{}, error) {
+	nodeFn := func(ctx context.Context, status serverpb.StatusClient, _ roachpb.NodeID) (*serverpb.RangesResponse, error) {
 		return status.Ranges(ctx, rangesRequest)
 	}
 	nowNanos := timeutil.Now().UnixNano()
-	responseFn := func(nodeID roachpb.NodeID, resp interface{}) {
-		rangesResp := resp.(*serverpb.RangesResponse)
+	responseFn := func(nodeID roachpb.NodeID, rangesResp *serverpb.RangesResponse) {
 		// Age the MVCCStats to a consistent current timestamp. An age that is
 		// not up to date is less useful.
 		for i := range rangesResp.Ranges {

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -1619,7 +1619,7 @@ func (s *statusServer) fetchProfileFromAllNodes(
 	senderServerVersion := resp.Desc.ServerVersion
 
 	opName := fmt.Sprintf("fetch cluster-wide %s profile", req.Type)
-	nodeFn := func(ctx context.Context, statusClient serverpb.StatusClient, nodeID roachpb.NodeID) (interface{}, error) {
+	nodeFn := func(ctx context.Context, statusClient serverpb.StatusClient, nodeID roachpb.NodeID) (*profData, error) {
 		var pd *profData
 		err := timeutil.RunWithTimeout(ctx, opName, 1*time.Minute, func(ctx context.Context) error {
 			resp, err := statusClient.Profile(ctx, &serverpb.ProfileRequest{
@@ -1638,8 +1638,7 @@ func (s *statusServer) fetchProfileFromAllNodes(
 		})
 		return pd, err
 	}
-	responseFn := func(nodeID roachpb.NodeID, resp interface{}) {
-		profResp := resp.(*profData)
+	responseFn := func(nodeID roachpb.NodeID, profResp *profData) {
 		response.profDataByNodeID[nodeID] = profResp
 	}
 	errorFn := func(nodeID roachpb.NodeID, err error) {

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -3551,19 +3551,18 @@ func (s *statusServer) ListExecutionInsights(
 
 	var response serverpb.ListExecutionInsightsResponse
 
-	nodeFn := func(ctx context.Context, statusClient serverpb.StatusClient, nodeID roachpb.NodeID) (interface{}, error) {
+	nodeFn := func(ctx context.Context, statusClient serverpb.StatusClient, nodeID roachpb.NodeID) (*serverpb.ListExecutionInsightsResponse, error) {
 		resp, err := statusClient.ListExecutionInsights(ctx, &localRequest)
 		if err != nil {
 			return nil, err
 		}
 		return resp, nil
 	}
-	responseFn := func(nodeID roachpb.NodeID, nodeResponse interface{}) {
-		if nodeResponse == nil {
+	responseFn := func(nodeID roachpb.NodeID, resp *serverpb.ListExecutionInsightsResponse) {
+		if resp == nil {
 			return
 		}
-		insightsResponse := nodeResponse.(*serverpb.ListExecutionInsightsResponse)
-		response.Insights = append(response.Insights, insightsResponse.Insights...)
+		response.Insights = append(response.Insights, resp.Insights...)
 	}
 	errorFn := func(nodeID roachpb.NodeID, err error) {
 		response.Errors = append(response.Errors, errors.EncodeError(ctx, err))

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -3905,7 +3905,7 @@ func (s *statusServer) TransactionContentionEvents(
 		return statusClient.TransactionContentionEvents(ctx, req)
 	}
 
-	rpcCallFn := func(ctx context.Context, statusClient serverpb.StatusClient, _ roachpb.NodeID) (interface{}, error) {
+	rpcCallFn := func(ctx context.Context, statusClient serverpb.StatusClient, _ roachpb.NodeID) (*serverpb.TransactionContentionEventsResponse, error) {
 		return statusClient.TransactionContentionEvents(ctx, &serverpb.TransactionContentionEventsRequest{
 			NodeID: "local",
 		})
@@ -3919,9 +3919,8 @@ func (s *statusServer) TransactionContentionEvents(
 		noTimeout,
 		s.dialNode,
 		rpcCallFn,
-		func(nodeID roachpb.NodeID, nodeResp interface{}) {
-			txnContentionEvents := nodeResp.(*serverpb.TransactionContentionEventsResponse)
-			resp.Events = append(resp.Events, txnContentionEvents.Events...)
+		func(nodeID roachpb.NodeID, nodeResp *serverpb.TransactionContentionEventsResponse) {
+			resp.Events = append(resp.Events, nodeResp.Events...)
 		},
 		func(nodeID roachpb.NodeID, nodeFnError error) {
 		},

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -2628,11 +2628,10 @@ func (s *systemStatusServer) HotRanges(
 
 	// Hot ranges from all nodes.
 	remoteRequest := serverpb.HotRangesRequest{NodeID: "local"}
-	nodeFn := func(ctx context.Context, status serverpb.StatusClient, _ roachpb.NodeID) (interface{}, error) {
+	nodeFn := func(ctx context.Context, status serverpb.StatusClient, _ roachpb.NodeID) (*serverpb.HotRangesResponse, error) {
 		return status.HotRanges(ctx, &remoteRequest)
 	}
-	responseFn := func(nodeID roachpb.NodeID, resp interface{}) {
-		hotRangesResp := resp.(*serverpb.HotRangesResponse)
+	responseFn := func(nodeID roachpb.NodeID, hotRangesResp *serverpb.HotRangesResponse) {
 		response.HotRangesByNodeID[nodeID] = hotRangesResp.HotRangesByNodeID[nodeID]
 	}
 	errorFn := func(nodeID roachpb.NodeID, err error) {

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -3445,7 +3445,7 @@ func (s *statusServer) ListContentionEvents(
 	}
 
 	var response serverpb.ListContentionEventsResponse
-	nodeFn := func(ctx context.Context, statusClient serverpb.StatusClient, _ roachpb.NodeID) (interface{}, error) {
+	nodeFn := func(ctx context.Context, statusClient serverpb.StatusClient, _ roachpb.NodeID) (*serverpb.ListContentionEventsResponse, error) {
 		resp, err := statusClient.ListLocalContentionEvents(ctx, req)
 		if err != nil {
 			return nil, err
@@ -3455,11 +3455,11 @@ func (s *statusServer) ListContentionEvents(
 		}
 		return resp, nil
 	}
-	responseFn := func(_ roachpb.NodeID, nodeResp interface{}) {
-		if nodeResp == nil {
+	responseFn := func(_ roachpb.NodeID, resp *serverpb.ListContentionEventsResponse) {
+		if resp == nil {
 			return
 		}
-		events := nodeResp.(*serverpb.ListContentionEventsResponse).Events
+		events := resp.Events
 		response.Events = contention.MergeSerializedRegistries(response.Events, events)
 	}
 	errorFn := func(nodeID roachpb.NodeID, err error) {

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -2049,11 +2049,10 @@ func (s *systemStatusServer) NetworkConnectivity(
 
 	// No NodeID parameter specified, so fan-out to all nodes and collect results.
 	remoteRequest := serverpb.NetworkConnectivityRequest{NodeID: "local"}
-	nodeFn := func(ctx context.Context, statusClient serverpb.StatusClient, _ roachpb.NodeID) (interface{}, error) {
+	nodeFn := func(ctx context.Context, statusClient serverpb.StatusClient, _ roachpb.NodeID) (*serverpb.NetworkConnectivityResponse, error) {
 		return statusClient.NetworkConnectivity(ctx, &remoteRequest)
 	}
-	responseFn := func(nodeID roachpb.NodeID, resp interface{}) {
-		r := resp.(*serverpb.NetworkConnectivityResponse)
+	responseFn := func(nodeID roachpb.NodeID, r *serverpb.NetworkConnectivityResponse) {
 		response.Connections[nodeID] = r.Connections[nodeID]
 	}
 	errorFn := func(nodeID roachpb.NodeID, err error) {

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -3490,7 +3490,7 @@ func (s *statusServer) ListDistSQLFlows(
 	}
 
 	var response serverpb.ListDistSQLFlowsResponse
-	nodeFn := func(ctx context.Context, statusClient serverpb.StatusClient, _ roachpb.NodeID) (interface{}, error) {
+	nodeFn := func(ctx context.Context, statusClient serverpb.StatusClient, _ roachpb.NodeID) (*serverpb.ListDistSQLFlowsResponse, error) {
 		resp, err := statusClient.ListLocalDistSQLFlows(ctx, request)
 		if err != nil {
 			return nil, err
@@ -3500,12 +3500,11 @@ func (s *statusServer) ListDistSQLFlows(
 		}
 		return resp, nil
 	}
-	responseFn := func(_ roachpb.NodeID, nodeResp interface{}) {
+	responseFn := func(_ roachpb.NodeID, nodeResp *serverpb.ListDistSQLFlowsResponse) {
 		if nodeResp == nil {
 			return
 		}
-		flows := nodeResp.(*serverpb.ListDistSQLFlowsResponse).Flows
-		response.Flows = mergeDistSQLRemoteFlows(response.Flows, flows)
+		response.Flows = mergeDistSQLRemoteFlows(response.Flows, nodeResp.Flows)
 	}
 	errorFn := func(nodeID roachpb.NodeID, err error) {
 		errResponse := serverpb.ListActivityError{NodeID: nodeID, Message: err.Error()}

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -1864,9 +1864,7 @@ func getNodeStatuses(
 
 	var rows []kv.KeyValue
 	if len(b.Results[0].Rows) > 0 {
-		var rowsInterface interface{}
-		rowsInterface, next = simplePaginate(b.Results[0].Rows, limit, offset)
-		rows = rowsInterface.([]kv.KeyValue)
+		rows, next = simplePaginate(b.Results[0].Rows, limit, offset)
 	}
 
 	statuses = make([]statuspb.NodeStatus, len(rows))
@@ -2248,12 +2246,11 @@ func (s *systemStatusServer) rangesHelper(
 			return nil, 0, err
 		}
 		resp, err := status.Ranges(ctx, req)
+		var next int
 		if resp != nil && len(resp.Ranges) > 0 {
-			resultInterface, next := simplePaginate(resp.Ranges, limit, offset)
-			resp.Ranges = resultInterface.([]serverpb.RangeInfo)
-			return resp, next, err
+			resp.Ranges, next = simplePaginate(resp.Ranges, limit, offset)
 		}
-		return resp, 0, err
+		return resp, next, err
 	}
 
 	output := serverpb.RangesResponse{
@@ -2422,9 +2419,7 @@ func (s *systemStatusServer) rangesHelper(
 	}
 	var next int
 	if limit > 0 {
-		var outputInterface interface{}
-		outputInterface, next = simplePaginate(output.Ranges, limit, offset)
-		output.Ranges = outputInterface.([]serverpb.RangeInfo)
+		output.Ranges, next = simplePaginate(output.Ranges, limit, offset)
 	}
 	return &output, next, nil
 }

--- a/pkg/server/testdata/simple_paginate
+++ b/pkg/server/testdata/simple_paginate
@@ -48,10 +48,3 @@ paginate 5 -1
 ----
 result=[1 2 3 4 5]
 next=5
-
-# Non-slice input always returns a nil output
-
-paginate 5 5
-----
-result=<nil>
-next=0


### PR DESCRIPTION
See individual commits. I tried to break this down into tiny commits where I could, to make those little ones where it is just adding a type and removing a casts easier to review.

The switch from method to func is required as methods cannot take type parameters.

Release note: none.
Epic: none.