### PR TITLE
release-23.1: kv/kvclient: introduce txn.GetReadSeqNum

### DIFF
--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
@@ -1342,6 +1342,13 @@ func (tc *TxnCoordSender) Step(ctx context.Context) error {
 	return tc.interceptorAlloc.txnSeqNumAllocator.stepLocked(ctx)
 }
 
+// GetReadSeqNum is part of the TxnSender interface.
+func (tc *TxnCoordSender) GetReadSeqNum() enginepb.TxnSeq {
+	tc.mu.Lock()
+	defer tc.mu.Unlock()
+	return tc.interceptorAlloc.txnSeqNumAllocator.readSeq
+}
+
 // SetReadSeqNum is part of the TxnSender interface.
 func (tc *TxnCoordSender) SetReadSeqNum(seq enginepb.TxnSeq) error {
 	tc.mu.Lock()

--- a/pkg/kv/mock_transactional_sender.go
+++ b/pkg/kv/mock_transactional_sender.go
@@ -199,6 +199,9 @@ func (m *MockTransactionalSender) Step(_ context.Context) error {
 	return nil
 }
 
+// GetReadSeqNum is part of the TxnSender interface.
+func (m *MockTransactionalSender) GetReadSeqNum() enginepb.TxnSeq { return 0 }
+
 // SetReadSeqNum is part of the TxnSender interface.
 func (m *MockTransactionalSender) SetReadSeqNum(_ enginepb.TxnSeq) error { return nil }
 

--- a/pkg/kv/sender.go
+++ b/pkg/kv/sender.go
@@ -281,6 +281,9 @@ type TxnSender interface {
 	// The method is idempotent.
 	Step(context.Context) error
 
+	// GetReadSeqNum gets the read sequence point for the current transaction.
+	GetReadSeqNum() enginepb.TxnSeq
+
 	// SetReadSeqNum sets the read sequence point for the current transaction.
 	SetReadSeqNum(seq enginepb.TxnSeq) error
 

--- a/pkg/kv/txn.go
+++ b/pkg/kv/txn.go
@@ -1500,6 +1500,13 @@ func (txn *Txn) Step(ctx context.Context) error {
 	return txn.mu.sender.Step(ctx)
 }
 
+// GetReadSeqNum gets the read sequence number for this transaction.
+func (txn *Txn) GetReadSeqNum() enginepb.TxnSeq {
+	txn.mu.Lock()
+	defer txn.mu.Unlock()
+	return txn.mu.sender.GetReadSeqNum()
+}
+
 // SetReadSeqNum sets the read sequence number for this transaction.
 func (txn *Txn) SetReadSeqNum(seq enginepb.TxnSeq) error {
 	txn.mu.Lock()

--- a/pkg/sql/routine.go
+++ b/pkg/sql/routine.go
@@ -139,7 +139,7 @@ func (g *routineGenerator) Start(ctx context.Context, txn *kv.Txn) (err error) {
 	// invoking statement are visible to the routine.
 	if g.expr.EnableStepping {
 		prevSteppingMode := txn.ConfigureStepping(ctx, kv.SteppingEnabled)
-		prevSeqNum := txn.GetLeafTxnInputState(ctx).ReadSeqNum
+		prevSeqNum := txn.GetReadSeqNum()
 		defer func() {
 			// If the routine errored, the transaction should be aborted, so
 			// there is no need to reconfigure stepping or revert to the

--- a/pkg/sql/sql_cursor.go
+++ b/pkg/sql/sql_cursor.go
@@ -102,10 +102,9 @@ func (p *planner) DeclareCursor(ctx context.Context, s *tree.DeclareCursor) (pla
 			if err != nil {
 				return nil, errors.Wrap(err, "failed to DECLARE CURSOR")
 			}
-			inputState := p.txn.GetLeafTxnInputState(ctx)
 			cursor := &sqlCursor{
 				Rows:       rows,
-				readSeqNum: inputState.ReadSeqNum,
+				readSeqNum: p.txn.GetReadSeqNum(),
 				txn:        p.txn,
 				statement:  statement,
 				created:    timeutil.Now(),
@@ -173,12 +172,11 @@ type fetchNode struct {
 }
 
 func (f *fetchNode) startExec(params runParams) error {
-	state := f.cursor.txn.GetLeafTxnInputState(params.ctx)
 	// We need to make sure that we're reading at the same read sequence number
 	// that we had when we created the cursor, to preserve the "sensitivity"
 	// semantics of cursors, which demand that data written after the cursor
 	// was declared is not visible to the cursor.
-	f.origTxnSeqNum = state.ReadSeqNum
+	f.origTxnSeqNum = f.cursor.txn.GetReadSeqNum()
 	return f.cursor.txn.SetReadSeqNum(f.cursor.readSeqNum)
 }
 


### PR DESCRIPTION
Backport of 1 of 2 commits from #99378.

Fixes #112188.

This commit introduces a new `txn.GetReadSeqNum` method.

It then uses this method to avoid unnecessarily heavyweight calls into GetLeafTxnInputState. It turns out that this removes all production calls into `GetLeafTxnInputState`. We'll do something with that in a future commit.

Epic: None
Release note: None

Release justification: bug fix.