### PR TITLE
roachtest: maybe init tpcc with column families in backup-restore tests

### DIFF
--- a/pkg/cmd/roachtest/tests/backup_restore_roundtrip.go
+++ b/pkg/cmd/roachtest/tests/backup_restore_roundtrip.go
@@ -168,7 +168,7 @@ func startBackgroundWorkloads(
 	// for the cluster used in this test without overloading it,
 	// which can make the backups take much longer to finish.
 	const numWarehouses = 100
-	tpccInit, tpccRun := tpccWorkloadCmd(numWarehouses, roachNodes)
+	tpccInit, tpccRun := tpccWorkloadCmd(testRNG, numWarehouses, roachNodes)
 	bankInit, bankRun := bankWorkloadCmd(testRNG, roachNodes)
 
 	err := c.RunE(ctx, workloadNode, bankInit.String())

--- a/pkg/cmd/roachtest/tests/mixed_version_backup.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_backup.go
@@ -2373,7 +2373,7 @@ func registerBackupMixedVersion(r registry.Registry) {
 			// which can make the backups take much longer to finish.
 			const numWarehouses = 100
 			bankInit, bankRun := bankWorkloadCmd(testRNG, roachNodes)
-			tpccInit, tpccRun := tpccWorkloadCmd(numWarehouses, roachNodes)
+			tpccInit, tpccRun := tpccWorkloadCmd(testRNG, numWarehouses, roachNodes)
 
 			mvt.OnStartup("set short job interval", backupTest.setShortJobIntervals)
 			mvt.OnStartup("take backup in previous version", backupTest.maybeTakePreviousVersionBackup)
@@ -2406,9 +2406,10 @@ func registerBackupMixedVersion(r registry.Registry) {
 }
 
 func tpccWorkloadCmd(
-	numWarehouses int, roachNodes option.NodeListOption,
+	testRNG *rand.Rand, numWarehouses int, roachNodes option.NodeListOption,
 ) (init *roachtestutil.Command, run *roachtestutil.Command) {
 	init = roachtestutil.NewCommand("./cockroach workload init tpcc").
+		MaybeOption(testRNG.Intn(2) == 0, "families").
 		Arg("{pgurl%s}", roachNodes).
 		Flag("warehouses", numWarehouses)
 	run = roachtestutil.NewCommand("./cockroach workload run tpcc").


### PR DESCRIPTION
This patch inits the tpcc workload with column families 50% of the time in the backup-mixed-version and backup-restore/roundtrip tests.

This patch is the first step to recreating a roachtest workload that can reproduce #109483.

Release note: None

Epic: none