### PR TITLE
release-23.2: sql: fix minor bugs and add tests for procedures

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/drop_function
+++ b/pkg/sql/logictest/testdata/logic_test/drop_function
@@ -70,8 +70,20 @@ COMMIT;
 statement ok
 ROLLBACK;
 
+statement error pgcode 42883 procedure f_test_drop\(\) does not exist
+DROP PROCEDURE f_test_drop
+
 statement ok
-DROP FUNCTION f_test_drop();
+DROP PROCEDURE IF EXISTS f_test_drop
+
+statement error pgcode 42809 f_test_drop\(\) is not a procedure
+DROP PROCEDURE f_test_drop()
+
+statement error pgcode 42809 f_test_drop\(\) is not a procedure
+DROP PROCEDURE IF EXISTS f_test_drop()
+
+statement ok
+DROP FUNCTION f_test_drop()
 
 query T
 SELECT create_statement FROM [SHOW CREATE FUNCTION public.f_test_drop];

--- a/pkg/sql/logictest/testdata/logic_test/drop_procedure
+++ b/pkg/sql/logictest/testdata/logic_test/drop_procedure
@@ -60,8 +60,20 @@ COMMIT;
 statement ok
 ROLLBACK
 
+statement error pgcode 42883 function p_test_drop\(\) does not exist
+DROP FUNCTION p_test_drop
+
 statement ok
-DROP PROCEDURE p_test_drop()
+DROP FUNCTION IF EXISTS p_test_drop
+
+statement error pgcode 42809 p_test_drop\(\) is not a function
+DROP FUNCTION p_test_drop()
+
+statement error pgcode 42809 p_test_drop\(\) is not a function
+DROP FUNCTION IF EXISTS p_test_drop()
+
+statement ok
+DROP PROCEDURE IF EXISTS p_test_drop()
 
 # TODO(mgartner): This error message could be improved.
 statement error pgcode 42883 unknown signature: p_test_drop\(\)

--- a/pkg/sql/logictest/testdata/logic_test/procedure
+++ b/pkg/sql/logictest/testdata/logic_test/procedure
@@ -196,3 +196,67 @@ DROP PROCEDURE insert_into_anon_args(STRING, INT);
 DROP TABLE anon_args;
 
 subtest end
+
+subtest replace
+
+statement ok
+CREATE TABLE replace(k INT PRIMARY KEY, v STRING)
+
+statement ok
+CREATE PROCEDURE insert_into_replace(k_new INT, v_new STRING) LANGUAGE SQL AS $$
+  INSERT INTO replace(k, v) VALUES (k_new, v_new)
+$$
+
+statement ok
+CALL insert_into_replace(1, 'a')
+
+statement error pgcode 42809 cannot change routine kind\nDETAIL: "insert_into_replace" is a procedure
+CREATE OR REPLACE FUNCTION insert_into_replace(k_new INT, v_new STRING) RETURNS VOID LANGUAGE SQL AS ''
+
+statement ok
+CREATE OR REPLACE PROCEDURE insert_into_replace(k_new INT, v_new STRING) LANGUAGE SQL AS $$
+  INSERT INTO replace(k, v) VALUES (k_new+100, v_new)
+$$
+
+statement ok
+CALL insert_into_replace(1, 'a')
+
+query IT rowsort
+SELECT * FROM replace
+----
+1    a
+101  a
+
+# The procedure should not be replaced if the signature is different.
+statement ok
+CREATE OR REPLACE PROCEDURE insert_into_replace(k_new INT) LANGUAGE SQL AS $$
+  INSERT INTO replace(k, v) VALUES (k_new, 'overload')
+$$
+
+# The procedure should not be replaced if the name is different.
+statement ok
+CREATE OR REPLACE PROCEDURE insert_into_replace_v2(k_new INT, v_new STRING) LANGUAGE SQL AS $$
+  INSERT INTO replace(k, v) VALUES (k_new, v_new||'_v2')
+$$
+
+statement ok
+CALL insert_into_replace(2, 'b');
+CALL insert_into_replace(3);
+CALL insert_into_replace_v2(4, 'b');
+
+query IT rowsort
+SELECT * FROM replace
+----
+1    a
+101  a
+102  b
+3    overload
+4    b_v2
+
+statement ok
+DROP PROCEDURE insert_into_replace(INT, STRING);
+DROP PROCEDURE insert_into_replace(INT);
+DROP PROCEDURE insert_into_replace_v2;
+DROP TABLE replace;
+
+subtest end

--- a/pkg/sql/logictest/testdata/logic_test/procedure
+++ b/pkg/sql/logictest/testdata/logic_test/procedure
@@ -157,3 +157,42 @@ CREATE FUNCTION t_update(a STRING, b STRING) RETURNS SETOF INT LANGUAGE SQL AS '
 # has been resolved to a specific overload.
 statement error ambiguous function class on t_update
 CALL t_update(1, 0)
+
+subtest anonymous_args
+
+statement ok
+CREATE TABLE anon_args(k INT PRIMARY KEY, v STRING)
+
+statement ok
+CREATE PROCEDURE insert_into_anon_args(INT, STRING) LANGUAGE SQL AS $$
+  INSERT INTO anon_args(k, v) VALUES ($1, $2)
+$$
+
+statement ok
+CALL insert_into_anon_args(1, 'a')
+
+query IT
+SELECT * FROM anon_args
+----
+1  a
+
+statement ok
+CREATE PROCEDURE insert_into_anon_args(STRING, INT) LANGUAGE SQL AS $$
+  INSERT INTO anon_args(k, v) VALUES ($2, $1)
+$$
+
+statement ok
+CALL insert_into_anon_args('b', 2)
+
+query IT rowsort
+SELECT * FROM anon_args
+----
+1  a
+2  b
+
+statement ok
+DROP PROCEDURE insert_into_anon_args(INT, STRING);
+DROP PROCEDURE insert_into_anon_args(STRING, INT);
+DROP TABLE anon_args;
+
+subtest end

--- a/pkg/sql/logictest/testdata/logic_test/procedure
+++ b/pkg/sql/logictest/testdata/logic_test/procedure
@@ -76,13 +76,6 @@ CREATE FUNCTION foo(i INT) RETURNS VOID LANGUAGE SQL AS ''
 statement error pgcode 42883 unknown signature: public.foo\(\) \(desired <int>\)
 CALL p(foo())
 
-skipif config local-legacy-schema-changer
-skipif config local-mixed-22.2-23.1
-statement error pgcode 42723 function "p" already exists with same argument types
-CREATE FUNCTION p() RETURNS VOID LANGUAGE SQL AS ''
-
-onlyif config local-legacy-schema-changer
-onlyif config local-mixed-22.2-23.1
 statement error pgcode 42723 function "p" already exists with same argument types
 CREATE FUNCTION p() RETURNS VOID LANGUAGE SQL AS ''
 
@@ -258,5 +251,38 @@ DROP PROCEDURE insert_into_replace(INT, STRING);
 DROP PROCEDURE insert_into_replace(INT);
 DROP PROCEDURE insert_into_replace_v2;
 DROP TABLE replace;
+
+subtest end
+
+subtest replace_func_with_proc
+
+statement ok
+CREATE PROCEDURE rfp(i INT) LANGUAGE SQL AS 'SELECT 0'
+
+statement error pgcode 42809 rfp\(i: int\) is a procedure\nHINT: To call a procedure, use CALL.
+SELECT rfp(1)
+
+statement ok
+DROP PROCEDURE rfp
+
+statement ok
+CREATE FUNCTION rfp(i INT) RETURNS INT LANGUAGE SQL AS 'SELECT 100+i'
+
+query I
+SELECT rfp(1)
+----
+101
+
+statement ok
+DROP FUNCTION rfp;
+CREATE PROCEDURE rfp(i INT) LANGUAGE SQL AS 'SELECT 0'
+
+# There error should be the same as the error above before the function was
+# created.
+statement error pgcode 42809 rfp\(i: int\) is a procedure\nHINT: To call a procedure, use CALL.
+SELECT rfp(1)
+
+statement ok
+DROP PROCEDURE rfp
 
 subtest end

--- a/pkg/sql/logictest/testdata/logic_test/procedure_privileges
+++ b/pkg/sql/logictest/testdata/logic_test/procedure_privileges
@@ -86,8 +86,8 @@ public         test_priv_p1    ·
 public         test_priv_p2    int8
 test_priv_sc1  test_priv_p3    ·
 
-statement error pgcode 42883 function test_priv_p1\(\) does not exist
-GRANT EXECUTE ON FUNCTION test_priv_p1() TO test_user WITH GRANT OPTION;
+statement error pgcode 42809 test_priv_p1\(\) is not a function
+GRANT EXECUTE ON FUNCTION test_priv_p1() TO test_user WITH GRANT OPTION
 
 statement ok
 GRANT EXECUTE ON PROCEDURE test_priv_p1(), test_priv_p2(int), test_priv_sc1.test_priv_p3 TO test_user WITH GRANT OPTION;
@@ -131,8 +131,8 @@ test           test_priv_sc1  100109      test_priv_p3()      test_user  EXECUTE
 statement error pgcode 2BP01 pq: cannot drop role/user test_user: grants still exist on.*
 DROP USER test_user;
 
-statement error pgcode 42883 function test_priv_p1\(\) does not exist
-REVOKE GRANT OPTION FOR EXECUTE ON FUNCTION test_priv_p1() FROM test_user;
+statement error pgcode 42809 test_priv_p1\(\) is not a function
+REVOKE GRANT OPTION FOR EXECUTE ON FUNCTION test_priv_p1() FROM test_user
 
 statement ok
 REVOKE GRANT OPTION FOR EXECUTE ON PROCEDURE test_priv_p1(), test_priv_p2(int), test_priv_sc1.test_priv_p3 FROM test_user;

--- a/pkg/sql/logictest/testdata/logic_test/udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf
@@ -239,6 +239,10 @@ CREATE FUNCTION f_test_cor(a INT, b INT) RETURNS INT IMMUTABLE LEAKPROOF STRICT 
 statement error pgcode 42723 pq: function "f_test_cor" already exists with same argument types
 CREATE FUNCTION f_test_cor(a INT, b INT) RETURNS INT IMMUTABLE LANGUAGE SQL AS $$ SELECT 1 $$;
 
+skipif config local-mixed-22.2-23.1
+statement error pgcode 42809 cannot change routine kind\nDETAIL: "f_test_cor" is a function
+CREATE OR REPLACE PROCEDURE f_test_cor(a INT, b INT) LANGUAGE SQL AS $$ SELECT 2 $$;
+
 statement ok
 CREATE OR REPLACE FUNCTION f_test_cor_not_exist(a INT, b INT) RETURNS INT IMMUTABLE LANGUAGE SQL AS $$ SELECT 1 $$;
 

--- a/pkg/sql/logictest/testdata/logic_test/udf_privileges
+++ b/pkg/sql/logictest/testdata/logic_test/udf_privileges
@@ -81,9 +81,7 @@ public         test_priv_f1   int8              ·                    func      
 public         test_priv_f2   int8              int8                 func           volatile
 test_priv_sc1  test_priv_f3   int8              ·                    func           volatile
 
-# TODO(mgartner): This error message should ideally mention that test_priv_f1 is
-# not a procedure.
-statement error pgcode 42883 procedure test_priv_f1\(\) does not exist
+statement error pgcode 42809 test_priv_f1\(\) is not a procedure
 GRANT EXECUTE ON PROCEDURE test_priv_f1() TO udf_test_user WITH GRANT OPTION
 
 statement ok
@@ -167,9 +165,7 @@ test           test_priv_sc1  100109       test_priv_f3()      public         EX
 test           test_priv_sc1  100109       test_priv_f3()      root           ALL             true
 test           test_priv_sc1  100109       test_priv_f3()      udf_test_user  EXECUTE         false
 
-# TODO(mgartner): This error message should ideally mention that test_priv_f1 is
-# not a procedure.
-statement error pgcode 42883 procedure test_priv_f1\(\) does not exist
+statement error pgcode 42809 test_priv_f1\(\) is not a procedure
 REVOKE EXECUTE ON PROCEDURE test_priv_f1() FROM udf_test_user
 
 statement ok

--- a/pkg/sql/sem/tree/function_definition_test.go
+++ b/pkg/sql/sem/tree/function_definition_test.go
@@ -120,8 +120,11 @@ func TestMatchOverload(t *testing.T) {
 				},
 			},
 			{
-				Schema:   "sc1",
-				Overload: &tree.Overload{Oid: 6, Type: tree.ProcedureRoutine, Types: tree.ParamTypes{tree.ParamType{Typ: types.Int}}},
+				Schema: "sc1",
+				Overload: &tree.Overload{Oid: 6, Type: tree.ProcedureRoutine,
+					Types: tree.ParamTypes{
+						tree.ParamType{Typ: types.Bool}},
+				},
 			},
 		},
 	}
@@ -144,7 +147,7 @@ func TestMatchOverload(t *testing.T) {
 		},
 		{
 			testName:    "match a procedure",
-			argTypes:    nil,
+			argTypes:    []*types.T{types.Bool},
 			path:        []string{"sc1", "sc2"},
 			routineType: tree.ProcedureRoutine,
 			expectedOid: 6,


### PR DESCRIPTION
Backport 3/3 commits from #112067.

/cc @cockroachdb/release

---

#### sql: add tests for procedures with anonymous arguments

Release note: None

Epic: CRDB-25388

#### sql: fix `CREATE OR REPLACE PROCEDURE` and add tests

This commit fixes a minor bug with `CREATE OR REPLACE PROCEDURE` that
allowed it to replace functions. The bug also allowed
`CREATE OR REPLACE FUNCTION` to replace procedures. Tests for
`CREATE OR REPLACE PROCEDURE` have also been added.

Release note: None

#### sql: fix routine-related error messages

This commit fixes some minor bugs with the error message of
routine-related statements.

Release note: None

---

Release justification: Minor bug fixes for new features that missed
the branch cut.

