### PR TITLE
release-23.2: demo: disable multitenancy by default

### DIFF
--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -655,7 +655,7 @@ func setDemoContextDefaults() {
 	demoCtx.SQLPort, _ = strconv.Atoi(base.DefaultPort)
 	demoCtx.HTTPPort, _ = strconv.Atoi(base.DefaultHTTPPort)
 	demoCtx.WorkloadMaxQPS = 25
-	demoCtx.Multitenant = true
+	demoCtx.Multitenant = false
 	demoCtx.DisableServerController = false
 	demoCtx.DefaultEnableRangefeeds = true
 	demoCtx.AutoConfigProvider = acprovider.NoTaskProvider{}


### PR DESCRIPTION
Backport 1/1 commits from #112305.

/cc @cockroachdb/release

---

In every release since 22.2 we've enabled multitenancy by default on the master branch for cockroach demo. This has resulted in much more robust user testing, and has uncovered several bugs. We're still however, not at the point where our multi-tenant UX completely matches our single-tenant UX. As a result, before we ship 23.2 we're going to disable multitenancy by default for demo.

Epic: none

Release note: None
Release justification: Reverting functional regression.
