### PR TITLE
logictest,kvserver,scbuild: Revert "use long-running pool for tests"

### DIFF
--- a/pkg/cmd/generate-bazel-extra/main.go
+++ b/pkg/cmd/generate-bazel-extra/main.go
@@ -288,20 +288,7 @@ func generateTestsTimeouts() {
 	}
 	for size, defaultTimeout := range testSizeToDefaultTimeout {
 		if size == "enormous" {
-			enormousTargets := targets[size]
-			var largePoolTargets, longRunningPoolTargets []string
-			for _, target := range enormousTargets {
-				if strings.Contains(target, "pkg/sql/logictest/tests/local:local_test") ||
-					strings.Contains(target, "pkg/sql/logictest/tests/local-legacy-schema-changer:local-legacy-schema-changer_test") ||
-					strings.Contains(target, "pkg/sql/logictest/tests/fakedist-disk:fakedist-disk_test") ||
-					strings.Contains(target, "pkg/kv/kvserver:kvserver_test") {
-					longRunningPoolTargets = append(longRunningPoolTargets, target)
-				} else {
-					largePoolTargets = append(largePoolTargets, target)
-				}
-			}
-			runBuildozer(append([]string{`dict_set exec_properties Pool:large`}, largePoolTargets...))
-			runBuildozer(append([]string{`dict_set exec_properties Pool:long_running`}, longRunningPoolTargets...))
+			runBuildozer(append([]string{`dict_set exec_properties Pool:large`}, targets[size]...))
 			// Exclude really enormous targets since they have a custom timeout that
 			// exceeds the default 1h.
 			targets[size] = excludeReallyEnormousTargets(targets[size])

--- a/pkg/cmd/generate-logictest/main.go
+++ b/pkg/cmd/generate-logictest/main.go
@@ -33,7 +33,6 @@ type testFileTemplateConfig struct {
 	Ccl                           bool
 	ForceProductionValues         bool
 	Package, TestRuleName, RelDir string
-	Pool                          string
 	ConfigIdx                     int
 	TestCount                     int
 	NumCPU                        int
@@ -173,12 +172,6 @@ func (t *testdir) dump() error {
 		tplCfg.TestRuleName = strings.ReplaceAll(cfg.Name, ".", "_")
 		tplCfg.Package = strings.ReplaceAll(strings.ReplaceAll(cfg.Name, "-", "_"), ".", "")
 		tplCfg.RelDir = t.relPathToParent
-		tplCfg.Pool = "large"
-		if strings.Contains(t.dir, "pkg/sql/logictest/tests") &&
-			(cfg.Name == "local" || cfg.Name == "local-legacy-schema-changer" ||
-				cfg.Name == "fakedist-disk") {
-			tplCfg.Pool = "long_running"
-		}
 		tplCfg.TestCount = testCount
 		tplCfg.CockroachGoTestserverTest = cfg.UseCockroachGoTestserver
 		// The NumCPU calculation is a guess pulled out of thin air to

--- a/pkg/cmd/generate-logictest/templates.go
+++ b/pkg/cmd/generate-logictest/templates.go
@@ -275,7 +275,7 @@ go_test(
         "//pkg/sql/logictest:testdata",  # keep{{ end }}{{ if .ExecBuildLogicTest }}
         "//pkg/sql/opt/exec/execbuilder:testdata",  # keep{{ end }}
     ],
-    exec_properties = {"Pool": "{{ .Pool }}"},
+    exec_properties = {"Pool": "large"},
     shard_count = {{ if gt .TestCount 48 }}48{{ else }}{{ .TestCount }}{{end}},
     tags = [{{ if .Ccl }}
         "ccl_test",{{ end }}

--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -361,7 +361,7 @@ go_test(
     }),
     data = glob(["testdata/**"]),
     embed = [":kvserver"],
-    exec_properties = {"Pool": "long_running"},
+    exec_properties = {"Pool": "large"},
     shard_count = 48,
     tags = ["cpu:2"],
     deps = [

--- a/pkg/sql/logictest/tests/fakedist-disk/BUILD.bazel
+++ b/pkg/sql/logictest/tests/fakedist-disk/BUILD.bazel
@@ -12,7 +12,7 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/sql/logictest:testdata",  # keep
     ],
-    exec_properties = {"Pool": "long_running"},
+    exec_properties = {"Pool": "large"},
     shard_count = 48,
     tags = [
         "cpu:2",

--- a/pkg/sql/logictest/tests/local-legacy-schema-changer/BUILD.bazel
+++ b/pkg/sql/logictest/tests/local-legacy-schema-changer/BUILD.bazel
@@ -12,7 +12,7 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/sql/logictest:testdata",  # keep
     ],
-    exec_properties = {"Pool": "long_running"},
+    exec_properties = {"Pool": "large"},
     shard_count = 48,
     tags = [
         "cpu:1",

--- a/pkg/sql/logictest/tests/local/BUILD.bazel
+++ b/pkg/sql/logictest/tests/local/BUILD.bazel
@@ -12,7 +12,7 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/sql/logictest:testdata",  # keep
     ],
-    exec_properties = {"Pool": "long_running"},
+    exec_properties = {"Pool": "large"},
     shard_count = 48,
     tags = [
         "cpu:1",

--- a/pkg/sql/schemachanger/scbuild/BUILD.bazel
+++ b/pkg/sql/schemachanger/scbuild/BUILD.bazel
@@ -69,7 +69,6 @@ go_test(
     ],
     args = ["-test.timeout=895s"],
     data = glob(["testdata/**"]),
-    exec_properties = {"Pool": "long_running"},
     deps = [
         ":scbuild",
         "//pkg/base",


### PR DESCRIPTION
This reverts commit 5c0c06a1678f3a833d3540849d4f68488a4b4dcf.

Epic: CRDB-8308
Release note: None