### PR TITLE
logictest: upgrade all nodes in some mixed version tests

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/mixed_version_procedure
+++ b/pkg/sql/logictest/testdata/logic_test/mixed_version_procedure
@@ -37,6 +37,8 @@ upgrade 1
 
 upgrade 2
 
+upgrade 3
+
 # Makes sure the upgrade job has finished, and the cluster version gate is
 # passed.
 query B retry

--- a/pkg/sql/logictest/testdata/logic_test/mixed_version_udf_execute_privileges
+++ b/pkg/sql/logictest/testdata/logic_test/mixed_version_udf_execute_privileges
@@ -52,6 +52,8 @@ upgrade 1
 
 upgrade 2
 
+upgrade 3
+
 # Verify that all nodes are now running 23.2 binaries.
 
 query B nodeidx=0

--- a/pkg/sql/logictest/testdata/logic_test/mixed_version_udf_mutations
+++ b/pkg/sql/logictest/testdata/logic_test/mixed_version_udf_mutations
@@ -87,6 +87,8 @@ upgrade 1
 
 upgrade 2
 
+upgrade 3
+
 query B retry
 SELECT crdb_internal.is_at_least_version('23.1-38')
 ----


### PR DESCRIPTION
`cockroach-go-testserver-upgrade-to-master` config uses 3 nodes, yet we previously only upgraded two of them although we wanted to "upgrade all nodes". This is now fixed.

Fixes: #112206.
Fixes: #112249.

Release note: None