### PR TITLE
roachtest: reduce concurrency from 1000 to 500 in tpch_concurrency

### DIFF
--- a/pkg/cmd/roachtest/tests/tpch_concurrency.go
+++ b/pkg/cmd/roachtest/tests/tpch_concurrency.go
@@ -161,11 +161,11 @@ func registerTPCHConcurrency(r registry.Registry) {
 		disableStreamer bool,
 	) {
 		setupCluster(ctx, t, c, disableStreamer)
-		// Run at concurrency 1000. We often can push this a bit higher, but
-		// then the iterations also get longer. 1000 concurrently running
-		// analytical queries on the 3 node cluster that doesn't crash is much
-		// more than we expect our users to run.
-		const concurrency = 1000
+		// Run at concurrency 500. We often can push this higher, but then the
+		// iterations also get longer. 500 concurrently running analytical
+		// queries on the 3 node cluster that doesn't crash is much more than we
+		// expect our users to run.
+		const concurrency = 500
 		// Each iteration can take on the order of 3 hours, so we choose the
 		// iteration count such that it'd be definitely completed with 18 hour
 		// timeout.


### PR DESCRIPTION
This commit lowers the concurrency we use in `tpch_concurrency` test from 1000 to 500 in order to reduce somewhat flaky failures. This is still far larger than what we expect users to have, and this load still gives us coverage to make sure we don't regress on OOM stability front.

Fixes: #112178.

Release note: None