### PR TITLE
roachtest: guard against nil log file reference

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -2201,7 +2201,11 @@ func (c *clusterImpl) RunE(ctx context.Context, nodes option.NodeListOption, arg
 		}
 
 		l.Printf("> result: %s", err)
-		createFailedFile(l.File.Name())
+		var logFileName string
+		if l.File != nil {
+			logFileName = l.File.Name()
+		}
+		createFailedFile(logFileName)
 		return errors.Wrapf(err, "full command output in %s.log", logFile)
 	}
 	l.Printf("> result: <ok>")
@@ -2248,7 +2252,10 @@ func (c *clusterImpl) RunWithDetails(
 	l.Printf("> %s", cmd)
 	results, err := roachprod.RunWithDetails(ctx, l, c.MakeNodes(nodes), "" /* SSHOptions */, "" /* processTag */, c.IsSecure(), args)
 
-	logFileFull := l.File.Name()
+	var logFileFull string
+	if l.File != nil {
+		logFileFull = l.File.Name()
+	}
 	if err != nil {
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			l.Printf("(note: incoming context was canceled: %s)", err)


### PR DESCRIPTION
These checks prevent panics in the roachtes test runner, which could jeopardize an entire test run; if the checks fail, we might not create ".failed" files for commands that fail.

Example panic:

https://teamcity.cockroachdb.com/viewLog.html?tab=buildLog&logTab=tree&filter=debug&expand=all&buildId=12162051&_focus=7888

Epic: none

Release note: None