### PR TITLE
release-23.2: mint 23.2 version

### DIFF
--- a/docs/generated/settings/settings-for-tenants.txt
+++ b/docs/generated/settings/settings-for-tenants.txt
@@ -323,4 +323,4 @@ trace.snapshot.rate	duration	0s	if non-zero, interval at which background trace 
 trace.span_registry.enabled	boolean	true	if set, ongoing traces can be seen at https://<ui>/#/debug/tracez	application
 trace.zipkin.collector	string		the address of a Zipkin instance to receive traces, as <host>:<port>. If no port is specified, 9411 will be used.	application
 ui.display_timezone	enumeration	etc/utc	the timezone used to format timestamps in the ui [etc/utc = 0, america/new_york = 1]	application
-version	version	23.1-32	set the active cluster version in the format '<major>.<minor>'	application
+version	version	23.2	set the active cluster version in the format '<major>.<minor>'	application

--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -275,6 +275,6 @@
 <tr><td><div id="setting-trace-span-registry-enabled" class="anchored"><code>trace.span_registry.enabled</code></div></td><td>boolean</td><td><code>true</code></td><td>if set, ongoing traces can be seen at https://&lt;ui&gt;/#/debug/tracez</td><td>Serverless/Dedicated/Self-Hosted</td></tr>
 <tr><td><div id="setting-trace-zipkin-collector" class="anchored"><code>trace.zipkin.collector</code></div></td><td>string</td><td><code></code></td><td>the address of a Zipkin instance to receive traces, as &lt;host&gt;:&lt;port&gt;. If no port is specified, 9411 will be used.</td><td>Serverless/Dedicated/Self-Hosted</td></tr>
 <tr><td><div id="setting-ui-display-timezone" class="anchored"><code>ui.display_timezone</code></div></td><td>enumeration</td><td><code>etc/utc</code></td><td>the timezone used to format timestamps in the ui [etc/utc = 0, america/new_york = 1]</td><td>Serverless/Dedicated/Self-Hosted</td></tr>
-<tr><td><div id="setting-version" class="anchored"><code>version</code></div></td><td>version</td><td><code>23.1-32</code></td><td>set the active cluster version in the format &#39;&lt;major&gt;.&lt;minor&gt;&#39;</td><td>Serverless/Dedicated/Self-Hosted</td></tr>
+<tr><td><div id="setting-version" class="anchored"><code>version</code></div></td><td>version</td><td><code>23.2</code></td><td>set the active cluster version in the format &#39;&lt;major&gt;.&lt;minor&gt;&#39;</td><td>Serverless/Dedicated/Self-Hosted</td></tr>
 </tbody>
 </table>

--- a/pkg/ccl/logictestccl/testdata/logic_test/crdb_internal_tenant
+++ b/pkg/ccl/logictestccl/testdata/logic_test/crdb_internal_tenant
@@ -400,7 +400,7 @@ select crdb_internal.get_vmodule()
 query T
 select regexp_replace(regexp_replace(crdb_internal.node_executable_version()::string, '(-\d+)?$', ''), '10000', '');
 ----
-23.1
+23.2
 
 query ITTT colnames,rowsort
 select node_id, component, field, regexp_replace(regexp_replace(value, '^\d+$', '<port>'), e':\\d+', ':<port>') as value from crdb_internal.node_runtime_info
@@ -490,7 +490,7 @@ select * from crdb_internal.gossip_alerts
 query T
 select regexp_replace(regexp_replace(crdb_internal.node_executable_version()::string, '(-\d+)?$', ''), '10000', '');
 ----
-23.1
+23.2
 
 user root
 

--- a/pkg/cli/declarative_print_rules_test.go
+++ b/pkg/cli/declarative_print_rules_test.go
@@ -32,7 +32,8 @@ func TestDeclarativeRules(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		version := clusterversion.TestingBinaryVersion
+		// Get the previous version.
+		version := clusterversion.VCurrent_Start
 		versionString := strings.Split(version.String(), "-")[0]
 		opOut, err := c.RunWithCapture(fmt.Sprintf("debug declarative-print-rules %s op", versionString))
 		if err != nil {
@@ -49,7 +50,7 @@ func TestDeclarativeRules(t *testing.T) {
 			// for testing purposes. This can change from build to build, and
 			// need changes for every version bump.
 			return strings.Replace(invalidOut,
-				" "+clusterversion.ByKey(clusterversion.V23_2).String()+"\n",
+				" "+clusterversion.ByKey(clusterversion.BinaryVersionKey).String()+"\n",
 				" latest\n",
 				-1)
 		})

--- a/pkg/clusterversion/cockroach_versions.go
+++ b/pkg/clusterversion/cockroach_versions.go
@@ -505,6 +505,9 @@ const (
 	// {statement|transaction}_execution_insights system tables.
 	V23_2_AddSystemExecInsightsTable
 
+	// V23_2 is CockroachDB v23.2. It's used for all v23.2.x patch releases.
+	V23_2
+
 	// *************************************************
 	// Step (1) Add new versions here.
 	// Do not add new versions to a patch release.
@@ -847,6 +850,10 @@ var rawVersionsSingleton = keyedVersions{
 		Key:     V23_2_AddSystemExecInsightsTable,
 		Version: roachpb.Version{Major: 23, Minor: 1, Internal: 32},
 	},
+	{
+		Key:     V23_2,
+		Version: roachpb.Version{Major: 23, Minor: 2, Internal: 0},
+	},
 
 	// *************************************************
 	// Step (2): Add new versions here.
@@ -868,7 +875,7 @@ const (
 	// finalVersion should be set on a release branch to the minted final cluster
 	// version key, e.g. to V22_2 on the release-22.2 branch once it is minted.
 	// Setting it has the effect of ensuring no versions are subsequently added.
-	finalVersion = invalidVersionKey
+	finalVersion = V23_2
 )
 
 var allowUpgradeToDev = envutil.EnvOrDefaultBool("COCKROACH_UPGRADE_TO_DEV_VERSION", false)
@@ -914,14 +921,6 @@ var versionsSingleton = func() keyedVersions {
 	}
 	return rawVersionsSingleton
 }()
-
-// V23_2 is a placeholder that will eventually be replaced by the actual 23.2
-// version Key, but in the meantime it points to the latest Key. The placeholder
-// is defined so that it can be referenced in code that simply wants to check if
-// a cluster is running 23.2 and has completed all associated migrations; most
-// version gates can use this instead of defining their own version key if all
-// simply need to check is that the cluster has upgraded to 23.2.
-var V23_2 = versionsSingleton[len(versionsSingleton)-1].Key
 
 const (
 	BinaryMinSupportedVersionKey = V23_1

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -640,7 +640,7 @@ select crdb_internal.get_vmodule()
 query T
 select regexp_replace(crdb_internal.node_executable_version()::string, '(-\d+)?$', '');
 ----
-23.1
+23.2
 
 query ITTT colnames,rowsort
 select node_id, component, field, regexp_replace(regexp_replace(value, '^\d+$', '<port>'), e':\\d+', ':<port>') as value from crdb_internal.node_runtime_info
@@ -794,7 +794,7 @@ SELECT * FROM crdb_internal.check_consistency(true, b'\x02', b'\x04')
 query T
 select regexp_replace(crdb_internal.node_executable_version()::string, '(-\d+)?$', '');
 ----
-23.1
+23.2
 
 user root
 

--- a/pkg/sql/logictest/testdata/logic_test/mixed_version_can_login
+++ b/pkg/sql/logictest/testdata/logic_test/mixed_version_can_login
@@ -9,10 +9,10 @@ upgrade 0
 
 upgrade 1
 
-query B nodeidx=0
-SELECT crdb_internal.node_executable_version() SIMILAR TO '23.1-%'
+query T nodeidx=0
+SELECT crdb_internal.node_executable_version()
 ----
-true
+23.2
 
 query T nodeidx=2
 SELECT crdb_internal.node_executable_version()
@@ -22,18 +22,18 @@ SELECT crdb_internal.node_executable_version()
 # Verify that a non-root user can login on the upgraded node.
 user testuser nodeidx=0
 
-query B
-SELECT crdb_internal.node_executable_version() SIMILAR TO '23.1-%'
+query T
+SELECT crdb_internal.node_executable_version()
 ----
-true
+23.2
 
 # Verify that a root user can login on the upgraded node.
 user root nodeidx=1
 
-query B
-SELECT crdb_internal.node_executable_version() SIMILAR TO '23.1-%'
+query T
+SELECT crdb_internal.node_executable_version()
 ----
-true
+23.2
 
 # Verify that a non-root user can login on the non-upgraded node.
 user testuser nodeidx=2
@@ -53,7 +53,7 @@ SELECT crdb_internal.node_executable_version()
 
 upgrade 2
 
-query B
-SELECT crdb_internal.node_executable_version() SIMILAR TO '23.1-%'
+query T
+SELECT crdb_internal.node_executable_version()
 ----
-true
+23.2

--- a/pkg/sql/logictest/testdata/logic_test/mixed_version_role_members_user_ids
+++ b/pkg/sql/logictest/testdata/logic_test/mixed_version_role_members_user_ids
@@ -46,10 +46,10 @@ upgrade 1
 
 # Test that there are no problems creating role memberships on a mixed-version cluster.
 
-query B nodeidx=1
-SELECT crdb_internal.node_executable_version() SIMILAR TO '23.1-%'
+query T nodeidx=1
+SELECT crdb_internal.node_executable_version()
 ----
-true
+23.2
 
 user root nodeidx=1
 
@@ -87,19 +87,19 @@ upgrade 0
 
 upgrade 2
 
-# Verify that all nodes are now running 23.1 binaries.
+# Verify that all nodes are now running 23.2 binaries.
 
-query B nodeidx=0
-SELECT crdb_internal.node_executable_version() SIMILAR TO '23.1-%'
+query T nodeidx=0
+SELECT crdb_internal.node_executable_version()
 ----
-true
+23.2
 
-query B nodeidx=1
-SELECT crdb_internal.node_executable_version() SIMILAR TO '23.1-%'
+query T nodeidx=1
+SELECT crdb_internal.node_executable_version()
 ----
-true
+23.2
 
-query B nodeidx=2
-SELECT crdb_internal.node_executable_version() SIMILAR TO '23.1-%'
+query T nodeidx=2
+SELECT crdb_internal.node_executable_version()
 ----
-true
+23.2

--- a/pkg/sql/logictest/testdata/logic_test/mixed_version_udf_execute_privileges
+++ b/pkg/sql/logictest/testdata/logic_test/mixed_version_udf_execute_privileges
@@ -54,20 +54,20 @@ upgrade 2
 
 # Verify that all nodes are now running 23.2 binaries.
 
-query B nodeidx=0
-SELECT crdb_internal.node_executable_version() SIMILAR TO '23.1-%'
+query T nodeidx=0
+SELECT crdb_internal.node_executable_version()
 ----
-true
+23.2
 
-query B nodeidx=1
-SELECT crdb_internal.node_executable_version() SIMILAR TO '23.1-%'
+query T nodeidx=1
+SELECT crdb_internal.node_executable_version()
 ----
-true
+23.2
 
-query B nodeidx=2
-SELECT crdb_internal.node_executable_version() SIMILAR TO '23.1-%'
+query T nodeidx=2
+SELECT crdb_internal.node_executable_version()
 ----
-true
+23.2
 
 # Makes sure the upgrade job has finished, and the cluster version gate is
 # passed.


### PR DESCRIPTION
Set the final 23.2 cluster version.

Release justification: necessary versioning step for every release.
Epic: none
Release note: None