### PR TITLE
tenantcostclient: add limit support to token bucket

### DIFF
--- a/pkg/ccl/multitenantccl/tenantcostclient/limiter.go
+++ b/pkg/ccl/multitenantccl/tenantcostclient/limiter.go
@@ -141,6 +141,11 @@ type limiterReconfigureArgs struct {
 	// NewRate is the new token fill rate for the bucket.
 	NewRate tenantcostmodel.RU
 
+	// MaxTokens is the maximum number of tokens that can be present in the
+	// bucket. Tokens beyond this limit are discarded. If MaxTokens = 0, then
+	// no limit is enforced.
+	MaxTokens tenantcostmodel.RU
+
 	// NotifyThreshold is the AvailableRU level below which a low RU notification
 	// will be sent.
 	NotifyThreshold tenantcostmodel.RU
@@ -159,6 +164,7 @@ func (l *limiter) Reconfigure(now time.Time, cfg limiterReconfigureArgs) {
 		l.qp.tb.Reconfigure(now, tokenBucketReconfigureArgs{
 			NewTokens: cfg.NewTokens,
 			NewRate:   cfg.NewRate,
+			MaxTokens: cfg.MaxTokens,
 		})
 		l.maybeNotifyLocked(now)
 

--- a/pkg/ccl/multitenantccl/tenantcostclient/limiter_test.go
+++ b/pkg/ccl/multitenantccl/tenantcostclient/limiter_test.go
@@ -163,4 +163,13 @@ func TestLimiterNotify(t *testing.T) {
 	}
 	checkNotification()
 	check("0.00 RU filling @ 0.00 RU/s")
+
+	// Ensure that MaxTokens is enforced.
+	args = limiterReconfigureArgs{
+		NewTokens: 100,
+		MaxTokens: 50,
+	}
+	lim.Reconfigure(ts.Now(), args)
+	checkNoNotification()
+	check("50.00 RU filling @ 0.00 RU/s")
 }


### PR DESCRIPTION
Add support for limit enforcement in the token bucket. This will limit the maximum number of tokens in the bucket to a configured value. Tokens beyond that limit are discarded.

This work will be used in an upcoming PR to strengthen support for request unit rate limiting.

Release note: None