### PR TITLE
bootstrap: fix and clean up bootstrapping at older versions

### DIFF
--- a/pkg/ccl/backupccl/datadriven_test.go
+++ b/pkg/ccl/backupccl/datadriven_test.go
@@ -179,7 +179,6 @@ func (d *datadrivenTestState) addCluster(t *testing.T, cfg clusterCfg) error {
 		params.ServerArgs.Knobs.Server = &server.TestingKnobs{
 			BinaryVersionOverride:          clusterversion.ByKey(beforeKey),
 			DisableAutomaticVersionUpgrade: make(chan struct{}),
-			BootstrapVersionKeyOverride:    clusterversion.BinaryMinSupportedVersionKey,
 		}
 	}
 

--- a/pkg/ccl/kvccl/kvtenantccl/upgradeccl/tenant_upgrade_test.go
+++ b/pkg/ccl/kvccl/kvtenantccl/upgradeccl/tenant_upgrade_test.go
@@ -63,7 +63,6 @@ func TestTenantAutoUpgradeRespectsAutoUpgradeEnabledSetting(t *testing.T) {
 			Server: &server.TestingKnobs{
 				DisableAutomaticVersionUpgrade: make(chan struct{}),
 				BinaryVersionOverride:          clusterversion.ByKey(v0),
-				BootstrapVersionKeyOverride:    v0,
 			},
 			SQLEvalContext: &eval.TestingKnobs{
 				// When the host binary version is not equal to its cluster version, tenant logical version is set
@@ -95,9 +94,8 @@ func TestTenantAutoUpgradeRespectsAutoUpgradeEnabledSetting(t *testing.T) {
 			TenantName: roachpb.TenantName(name),
 			Knobs: base.TestingKnobs{
 				Server: &server.TestingKnobs{
-					TenantAutoUpgradeInfo:       upgradeInfoCh,
-					BootstrapVersionKeyOverride: v0,
-					BinaryVersionOverride:       clusterversion.ByKey(v0),
+					TenantAutoUpgradeInfo: upgradeInfoCh,
+					BinaryVersionOverride: clusterversion.ByKey(v0),
 				},
 			},
 		}
@@ -166,7 +164,6 @@ func TestTenantAutoUpgrade(t *testing.T) {
 			Server: &server.TestingKnobs{
 				DisableAutomaticVersionUpgrade: make(chan struct{}),
 				BinaryVersionOverride:          clusterversion.ByKey(v0),
-				BootstrapVersionKeyOverride:    v0,
 			},
 			SQLEvalContext: &eval.TestingKnobs{
 				// When the host binary version is not equal to its cluster version, tenant logical version is set
@@ -201,7 +198,6 @@ func TestTenantAutoUpgrade(t *testing.T) {
 				Server: &server.TestingKnobs{
 					TenantAutoUpgradeInfo:                          upgradeInfoCh,
 					AllowTenantAutoUpgradeOnInternalVersionChanges: true,
-					BootstrapVersionKeyOverride:                    v0,
 					BinaryVersionOverride:                          clusterversion.ByKey(v0),
 				},
 			},

--- a/pkg/ccl/schemachangerccl/schemachanger_ccl_test.go
+++ b/pkg/ccl/schemachangerccl/schemachanger_ccl_test.go
@@ -47,7 +47,6 @@ func (f MultiRegionTestClusterFactory) WithSchemaChangerKnobs(
 // WithMixedVersion implements the sctest.TestServerFactory interface.
 func (f MultiRegionTestClusterFactory) WithMixedVersion() sctest.TestServerFactory {
 	f.server = &server.TestingKnobs{
-		BootstrapVersionKeyOverride:    sctest.OldVersionKey,
 		BinaryVersionOverride:          clusterversion.ByKey(sctest.OldVersionKey),
 		DisableAutomaticVersionUpgrade: make(chan struct{}),
 	}

--- a/pkg/ccl/serverccl/server_startup_guardrails_test.go
+++ b/pkg/ccl/serverccl/server_startup_guardrails_test.go
@@ -98,7 +98,6 @@ func TestServerStartupGuardrails(t *testing.T) {
 				Knobs: base.TestingKnobs{
 					Server: &server.TestingKnobs{
 						BinaryVersionOverride:          test.storageBinaryVersion,
-						BootstrapVersionKeyOverride:    logicalVersionKey,
 						DisableAutomaticVersionUpgrade: make(chan struct{}),
 					},
 					SQLEvalContext: &eval.TestingKnobs{

--- a/pkg/kv/kvserver/client_migration_test.go
+++ b/pkg/kv/kvserver/client_migration_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/batcheval"
@@ -29,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/upgrade/upgradebase"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -241,7 +243,7 @@ func TestMigrateWaitsForApplication(t *testing.T) {
 	blockApplicationCh := make(chan struct{})
 
 	// We're going to be migrating from startV to endV.
-	startV := roachpb.Version{Major: 1000041}
+	startV := clusterversion.ByKey(clusterversion.BinaryVersionKey)
 	endV := roachpb.Version{Major: 1000042}
 
 	ctx := context.Background()
@@ -253,6 +255,16 @@ func TestMigrateWaitsForApplication(t *testing.T) {
 				Server: &server.TestingKnobs{
 					BinaryVersionOverride:          startV,
 					DisableAutomaticVersionUpgrade: make(chan struct{}),
+				},
+				UpgradeManager: &upgradebase.TestingKnobs{
+					ListBetweenOverride: func(from, to roachpb.Version) []roachpb.Version {
+						res := clusterversion.ListBetween(from, to)
+						// Pretend endV is a valid version.
+						if from.Less(endV) && to.AtLeast(endV) {
+							res = append(res, endV)
+						}
+						return res
+					},
 				},
 				Store: &kvserver.StoreTestingKnobs{
 					TestingApplyCalledTwiceFilter: func(args kvserverbase.ApplyFilterArgs) (int, *kvpb.Error) {
@@ -281,7 +293,7 @@ func TestMigrateWaitsForApplication(t *testing.T) {
 
 		repl := store.LookupReplica(roachpb.RKey(k))
 		require.NotNil(t, repl)
-		require.Equal(t, repl.Version(), startV)
+		require.Equal(t, startV, repl.Version())
 	}
 
 	desc := tc.LookupRangeOrFatal(t, k)

--- a/pkg/server/init.go
+++ b/pkg/server/init.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/bootstrap"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/grpcutil"
@@ -351,7 +352,7 @@ func (s *initServer) Bootstrap(
 		return nil, s.mu.rejectErr
 	}
 
-	state, err := s.tryBootstrap(ctx)
+	state, err := bootstrapCluster(ctx, s.inspectedDiskState.uninitializedEngines, s.config)
 	if err != nil {
 		log.Errorf(ctx, "bootstrap: %v", err)
 		s.mu.rejectErr = errInternalBootstrapError
@@ -519,26 +520,6 @@ func (s *initServer) attemptJoinTo(
 	return resp, nil
 }
 
-func (s *initServer) tryBootstrap(ctx context.Context) (*initState, error) {
-	// We expect all the stores to be empty at this point, except for
-	// the store cluster version key. Assert so.
-	//
-	// TODO(jackson): Eventually we should be able to avoid opening the
-	// engines altogether until here, but that requires us to move the
-	// store cluster version key outside of the storage engine.
-	if err := assertEnginesEmpty(s.inspectedDiskState.uninitializedEngines); err != nil {
-		return nil, err
-	}
-
-	// We use our binary version to bootstrap the cluster.
-	cv := clusterversion.ClusterVersion{Version: s.config.binaryVersion}
-	if err := kvstorage.WriteClusterVersionToEngines(ctx, s.inspectedDiskState.uninitializedEngines, cv); err != nil {
-		return nil, err
-	}
-
-	return bootstrapCluster(ctx, s.inspectedDiskState.uninitializedEngines, s.config)
-}
-
 // DiskClusterVersion returns the cluster version synthesized from disk. This
 // is always non-zero since it falls back to the BinaryMinSupportedVersion.
 func (s *initServer) DiskClusterVersion() clusterversion.ClusterVersion {
@@ -657,19 +638,27 @@ func newInitServerConfig(
 	binaryVersion := cfg.Settings.Version.BinaryVersion()
 	binaryMinSupportedVersion := cfg.Settings.Version.BinaryMinSupportedVersion()
 	if knobs := cfg.TestingKnobs.Server; knobs != nil {
-		// If BinaryVersionOverride is set, and our `binaryMinSupportedVersion` is
-		// at its default value, we must bootstrap the cluster at
-		// `binaryMinSupportedVersion`. This cluster will then run the necessary
-		// upgrades until `BinaryVersionOverride` before being ready to use in the
-		// test.
-		//
-		// Refer to the header comment on BinaryVersionOverride for more details.
-		if ov := knobs.(*TestingKnobs).BinaryVersionOverride; ov != (roachpb.Version{}) {
-			if binaryMinSupportedVersion.Equal(clusterversion.ByKey(clusterversion.BinaryMinSupportedVersionKey)) {
-				binaryVersion = clusterversion.ByKey(clusterversion.BinaryMinSupportedVersionKey)
-			} else {
-				binaryVersion = ov
+		if overrideVersion := knobs.(*TestingKnobs).BinaryVersionOverride; overrideVersion != (roachpb.Version{}) {
+			// We are customizing the cluster version. We can only bootstrap a fresh
+			// cluster at specific versions (specifically, the current version and
+			// previously released versions down to the minimum supported).
+			// We choose the closest version that's not newer than the target version.;
+			// later on, we will upgrade to `BinaryVersionOverride` (this happens
+			// separately when we Activate the server).
+			var bootstrapVersion roachpb.Version
+			for _, v := range bootstrap.VersionsWithInitialValues() {
+				if !overrideVersion.Less(clusterversion.ByKey(v)) {
+					bootstrapVersion = clusterversion.ByKey(v)
+					break
+				}
 			}
+			if bootstrapVersion == (roachpb.Version{}) {
+				// As a special case, we tolerate initializing clusters at versions
+				// older than the min supported for some specific tests (we will just
+				// use the minimum supported version for the initial values).
+				bootstrapVersion = overrideVersion
+			}
+			binaryVersion = bootstrapVersion
 		}
 	}
 	if binaryVersion.Less(binaryMinSupportedVersion) {
@@ -742,7 +731,7 @@ func inspectEngines(
 		initializedEngines = append(initializedEngines, eng)
 	}
 	clusterVersion, err := kvstorage.SynthesizeClusterVersionFromEngines(
-		ctx, initializedEngines, binaryVersion, binaryMinSupportedVersion,
+		ctx, engines, binaryVersion, binaryMinSupportedVersion,
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/server/node_test.go
+++ b/pkg/server/node_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvstorage"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server/status"
 	"github.com/cockroachdb/cockroach/pkg/server/status/statuspb"
@@ -68,7 +67,6 @@ func TestBootstrapCluster(t *testing.T) {
 	ctx := context.Background()
 	e := storage.NewDefaultInMemForTesting()
 	defer e.Close()
-	require.NoError(t, kvstorage.WriteClusterVersion(ctx, e, clusterversion.TestingClusterVersion))
 
 	initCfg := initServerCfg{
 		binaryMinSupportedVersion: clusterversion.TestingBinaryMinSupportedVersion,
@@ -253,8 +251,6 @@ func TestCorruptedClusterID(t *testing.T) {
 	defer e.Close()
 
 	cv := clusterversion.TestingClusterVersion
-	require.NoError(t, kvstorage.WriteClusterVersion(ctx, e, cv))
-
 	initCfg := initServerCfg{
 		binaryMinSupportedVersion: clusterversion.TestingBinaryMinSupportedVersion,
 		binaryVersion:             clusterversion.TestingBinaryVersion,

--- a/pkg/server/testing_knobs.go
+++ b/pkg/server/testing_knobs.go
@@ -16,7 +16,6 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/blobs"
-	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
@@ -76,10 +75,6 @@ type TestingKnobs struct {
 	// been started, `SET CLUSTER SETTING version = BinaryVersionOverride` will be
 	// run to step through the upgrades until the specified override.
 	//
-	// TODO(adityamaru): We should force tests that set BinaryVersionOverride to
-	// also set BootstrapVersionKeyOverride so as to specify what image they would
-	// like the cluster bootstrapped at before upgrading to BinaryVersionOverride.
-	//
 	// Case 2:
 	// ------
 	// If the test has overridden the
@@ -130,10 +125,6 @@ type TestingKnobs struct {
 	// StubTimeNow allows tests to override the timeutil.Now() function used
 	// in the jobs endpoint to calculate earliest_retained_time.
 	StubTimeNow func() time.Time
-
-	// We use clusterversion.Key rather than a roachpb.Version because it will be used
-	// to get initial values to use during bootstrap.
-	BootstrapVersionKeyOverride clusterversion.Key
 
 	// RequireGracefulDrain, if set, causes a shutdown to fail with a log.Fatal
 	// if the server is not gracefully drained prior to its stopper shutting down.

--- a/pkg/sql/catalog/bootstrap/initial_values.go
+++ b/pkg/sql/catalog/bootstrap/initial_values.go
@@ -34,9 +34,9 @@ type InitialValuesOpts struct {
 	Codec                   keys.SQLCodec
 }
 
-// GenerateInitialValues generates the initial values with which to bootstrap
-// a new cluster. This generates the values assuming a cluster version equal to
-// to the latest binary, unless explicitly overridden.
+// GenerateInitialValues generates the initial values with which to bootstrap a
+// new cluster. This generates the values assuming a cluster version equal to
+// the latest binary, unless explicitly overridden.
 func (opts InitialValuesOpts) GenerateInitialValues() ([]roachpb.KeyValue, []roachpb.RKey, error) {
 	versionKey := clusterversion.BinaryVersionKey
 	if opts.OverrideKey != 0 {
@@ -47,6 +47,20 @@ func (opts InitialValuesOpts) GenerateInitialValues() ([]roachpb.KeyValue, []roa
 		return nil, nil, errors.Newf("unsupported version %q", versionKey)
 	}
 	return f(opts)
+}
+
+// VersionsWithInitialValues returns all the versions which can be used for
+// InitialValuesOpts.OverrideKey, in descending order; the first one is always
+// the current version.
+func VersionsWithInitialValues() []clusterversion.Key {
+	res := make([]clusterversion.Key, 0, len(initialValuesFactoryByKey))
+	for k := range initialValuesFactoryByKey {
+		res = append(res, k)
+	}
+	sort.Slice(res, func(i, j int) bool {
+		return res[i] > res[j]
+	})
+	return res
 }
 
 type initialValuesFactoryFn = func(opts InitialValuesOpts) (

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -1463,7 +1463,6 @@ func (t *logicTest) newCluster(
 		if params.ServerArgs.Knobs.Server == nil {
 			params.ServerArgs.Knobs.Server = &server.TestingKnobs{}
 		}
-		params.ServerArgs.Knobs.Server.(*server.TestingKnobs).BootstrapVersionKeyOverride = cfg.BootstrapVersion
 		params.ServerArgs.Knobs.Server.(*server.TestingKnobs).BinaryVersionOverride = clusterversion.ByKey(cfg.BootstrapVersion)
 	}
 	if cfg.DisableUpgrade {

--- a/pkg/sql/schemachanger/sctest/test_server_factory.go
+++ b/pkg/sql/schemachanger/sctest/test_server_factory.go
@@ -69,7 +69,6 @@ func (f SingleNodeTestClusterFactory) WithSchemaChangerKnobs(
 // WithMixedVersion implements the TestServerFactory interface.
 func (f SingleNodeTestClusterFactory) WithMixedVersion() TestServerFactory {
 	f.server = &server.TestingKnobs{
-		BootstrapVersionKeyOverride:    OldVersionKey,
 		BinaryVersionOverride:          clusterversion.ByKey(OldVersionKey),
 		DisableAutomaticVersionUpgrade: make(chan struct{}),
 	}

--- a/pkg/upgrade/upgrademanager/BUILD.bazel
+++ b/pkg/upgrade/upgrademanager/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
         "//pkg/upgrade/upgradecluster",
         "//pkg/upgrade/upgradejob:upgrade_job",
         "//pkg/upgrade/upgrades",
+        "//pkg/util/buildutil",
         "//pkg/util/log",
         "//pkg/util/startup",
         "//pkg/util/stop",

--- a/pkg/upgrade/upgrademanager/manager.go
+++ b/pkg/upgrade/upgrademanager/manager.go
@@ -39,6 +39,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/upgrade/upgradecluster"
 	"github.com/cockroachdb/cockroach/pkg/upgrade/upgradejob"
 	"github.com/cockroachdb/cockroach/pkg/upgrade/upgrades"
+	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/startup"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
@@ -396,6 +397,11 @@ func (m *Manager) Migrate(
 	clusterVersions := m.listBetween(from.Version, to.Version)
 	log.Infof(ctx, "migrating cluster from %s to %s (stepping through %s)", from, to, clusterVersions)
 	if len(clusterVersions) == 0 {
+		if buildutil.CrdbTestBuild && from.Version != to.Version {
+			// This suggests a test is using bogus versions and didn't set up
+			// ListBetweenOverride properly.
+			panic(errors.AssertionFailedf("no valid versions in (%s, %s]", from.Version, to.Version))
+		}
 		return nil
 	}
 

--- a/pkg/upgrade/upgrademanager/manager_external_test.go
+++ b/pkg/upgrade/upgrademanager/manager_external_test.go
@@ -80,7 +80,6 @@ func TestAlreadyRunningJobsAreHandledProperly(t *testing.T) {
 			Knobs: base.TestingKnobs{
 				JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
 				Server: &server.TestingKnobs{
-					BootstrapVersionKeyOverride:    clusterversion.BinaryMinSupportedVersionKey,
 					BinaryVersionOverride:          clusterversion.ByKey(startCV),
 					DisableAutomaticVersionUpgrade: make(chan struct{}),
 				},
@@ -381,7 +380,6 @@ func TestMigrateUpdatesReplicaVersion(t *testing.T) {
 
 			Knobs: base.TestingKnobs{
 				Server: &server.TestingKnobs{
-					BootstrapVersionKeyOverride:    clusterversion.BinaryMinSupportedVersionKey,
 					BinaryVersionOverride:          startCV,
 					DisableAutomaticVersionUpgrade: make(chan struct{}),
 				},
@@ -574,7 +572,6 @@ func TestPauseMigration(t *testing.T) {
 				JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
 				Server: &server.TestingKnobs{
 					BinaryVersionOverride:          clusterversion.ByKey(startCV),
-					BootstrapVersionKeyOverride:    clusterversion.BinaryMinSupportedVersionKey,
 					DisableAutomaticVersionUpgrade: make(chan struct{}),
 				},
 				UpgradeManager: &upgradebase.TestingKnobs{
@@ -860,7 +857,6 @@ func TestMigrationFailure(t *testing.T) {
 		TestingKnobs: base.TestingKnobs{
 			Server: &server.TestingKnobs{
 				DisableAutomaticVersionUpgrade: make(chan struct{}),
-				BootstrapVersionKeyOverride:    startVersionKey,
 				BinaryVersionOverride:          startVersion,
 			},
 			UpgradeManager: &upgradebase.TestingKnobs{

--- a/pkg/upgrade/upgrades/mvcc_statistics_migration_test.go
+++ b/pkg/upgrade/upgrades/mvcc_statistics_migration_test.go
@@ -35,7 +35,6 @@ func TestMVCCStatisticsMigration(t *testing.T) {
 				Server: &server.TestingKnobs{
 					DisableAutomaticVersionUpgrade: make(chan struct{}),
 					BinaryVersionOverride:          clusterversion.ByKey(clusterversion.BinaryMinSupportedVersionKey),
-					BootstrapVersionKeyOverride:    clusterversion.BinaryMinSupportedVersionKey,
 				},
 			},
 		},

--- a/pkg/upgrade/upgrades/schema_changes_external_test.go
+++ b/pkg/upgrade/upgrades/schema_changes_external_test.go
@@ -341,7 +341,6 @@ func testMigrationWithFailures(
 						Server: &server.TestingKnobs{
 							DisableAutomaticVersionUpgrade: make(chan struct{}),
 							BinaryVersionOverride:          startCV,
-							BootstrapVersionKeyOverride:    startKey,
 						},
 						JobsTestingKnobs: jobsKnobs,
 						SQLExecutor: &sql.ExecutorTestingKnobs{

--- a/pkg/upgrade/upgrades/system_exec_insights_test.go
+++ b/pkg/upgrade/upgrades/system_exec_insights_test.go
@@ -35,7 +35,6 @@ func TestExecSystemInsights(t *testing.T) {
 				Server: &server.TestingKnobs{
 					DisableAutomaticVersionUpgrade: make(chan struct{}),
 					BinaryVersionOverride:          clusterversion.ByKey(clusterversion.BinaryMinSupportedVersionKey),
-					BootstrapVersionKeyOverride:    clusterversion.BinaryMinSupportedVersionKey,
 				},
 			},
 		},


### PR DESCRIPTION
Note: this PR is only for the top commit, the rest is #112456.

----

This commit fixes the logic around bootstrapping clusters at earlier
versions. Currently there is some special casing around the minimum
supported version which makes that work, but other backwards
compatible versions don't work correctly.  Specifically, after bumping
the version to 24.1, a `local-mixed-23.2` config for logic tests does
not work.

The core problem is that we are initializing the stores with a version
and then populating the initial system values at another version.

I am reasonably confident this was the root cause for #104994, where
we tried adding a 23.1 config while the min supported version was
22.2.

This fix makes the logic clearer and simpler. We can only bootstrap
the cluster at specific versions (the current version, and compatible
released versions). When the bootstrap version is overridden, we find
the latest version that we can initialize the cluster and use that for
both the stores and the initial values. Then we can upgrade to the
desired version from there.

This simplifies the tests: we no longer need
`BootstrapVersionKeyOverride` (which was confusing, given that we also
have `BinaryVersionOverride`).

Epic: none
Release note: None

