### PR TITLE
testcluster: disallow sharing of Settings

### DIFF
--- a/pkg/base/test_server_args.go
+++ b/pkg/base/test_server_args.go
@@ -31,12 +31,21 @@ import (
 // testutils/serverutils (test code) and server.TestServer (non-test code).
 //
 // The zero value is suitable for most tests.
+//
+// Note: when starting a multi-node test cluster, TestServerArgs are copied for
+// each node. If any fields are added which are not safe to share (like
+// Settings), a check that the field is unset should be added in
+// testcluster.NewTestCluster (when the cluster has more than 1 node).
 type TestServerArgs struct {
 	// Knobs for the test server.
 	Knobs TestingKnobs
 
-	*cluster.Settings
-	RaftConfig
+	RaftConfig RaftConfig
+
+	// Settings object for the server.
+	// Note: this field cannot be used for TestClusterArgs.ServerArgs when there
+	// are multiple nodes.
+	Settings *cluster.Settings
 
 	// PartOfCluster must be set if the TestServer is joining others in a cluster.
 	// If not set (and hence the server is the only one in the cluster), the

--- a/pkg/kv/kvclient/kvcoord/dist_sender_ambiguous_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_ambiguous_test.go
@@ -344,19 +344,18 @@ func TestTransactionUnexpectedlyCommitted(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	st := cluster.MakeTestingClusterSettings()
+	makeSettings := func() *cluster.Settings {
+		st := cluster.MakeTestingClusterSettings()
 
-	// Disable closed timestamps for control over when transaction gets bumped.
-	closedts.TargetDuration.Override(ctx, &st.SV, 1*time.Hour)
+		// Disable closed timestamps for control over when transaction gets bumped.
+		closedts.TargetDuration.Override(ctx, &st.SV, 1*time.Hour)
+		return st
+	}
 
 	tc := testcluster.StartTestCluster(t, 3, base.TestClusterArgs{
-		ServerArgs: base.TestServerArgs{
-			Settings: st,
-			Insecure: true,
-		},
 		ServerArgsPerNode: map[int]base.TestServerArgs{
 			0: {
-				Settings: st,
+				Settings: makeSettings(),
 				Insecure: true,
 				Knobs: base.TestingKnobs{
 					KVClient: &kvcoord.ClientTestingKnobs{
@@ -370,6 +369,14 @@ func TestTransactionUnexpectedlyCommitted(t *testing.T) {
 						},
 					},
 				},
+			},
+			1: {
+				Settings: makeSettings(),
+				Insecure: true,
+			},
+			2: {
+				Settings: makeSettings(),
+				Insecure: true,
 			},
 		},
 	})

--- a/pkg/kv/kvserver/gossip_test.go
+++ b/pkg/kv/kvserver/gossip_test.go
@@ -160,8 +160,8 @@ func TestGossipHandlesReplacedNode(t *testing.T) {
 			MaxBackoff:     50 * time.Millisecond,
 		},
 	}
-	serverArgs.RaftTickInterval = 50 * time.Millisecond
-	serverArgs.RaftElectionTimeoutTicks = 10
+	serverArgs.RaftConfig.RaftTickInterval = 50 * time.Millisecond
+	serverArgs.RaftConfig.RaftElectionTimeoutTicks = 10
 
 	tc := testcluster.StartTestCluster(t, 3,
 		base.TestClusterArgs{

--- a/pkg/sql/catalog/lease/lease_internal_test.go
+++ b/pkg/sql/catalog/lease/lease_internal_test.go
@@ -992,7 +992,7 @@ func TestLeaseAcquireAndReleaseConcurrently(t *testing.T) {
 			// monotonically increasing expiration. This prevents two leases
 			// from having the same expiration due to randomness, as the
 			// leases are checked for having a different expiration.
-			LeaseJitterFraction.Override(ctx, &serverArgs.SV, 0)
+			LeaseJitterFraction.Override(ctx, &serverArgs.Settings.SV, 0)
 
 			srv, sqlDB, _ := serverutils.StartServer(t, serverArgs)
 			defer srv.Stopper().Stop(context.Background())

--- a/pkg/sql/catalog/lease/lease_test.go
+++ b/pkg/sql/catalog/lease/lease_test.go
@@ -386,7 +386,7 @@ func TestLeaseManagerReacquire(testingT *testing.T) {
 	params.ServerArgs.Settings = cluster.MakeTestingClusterSettings()
 	// Set the lease duration such that the next lease acquisition will
 	// require the lease to be reacquired.
-	lease.LeaseDuration.Override(ctx, &params.ServerArgs.SV, 0)
+	lease.LeaseDuration.Override(ctx, &params.ServerArgs.Settings.SV, 0)
 
 	removalTracker := lease.NewLeaseRemovalTracker()
 	params.ServerArgs.Knobs = base.TestingKnobs{
@@ -1265,11 +1265,11 @@ func TestLeaseRenewedAutomatically(testingT *testing.T) {
 	params.ServerArgs.Settings = cluster.MakeTestingClusterSettings()
 	// The lease jitter is set to ensure newer leases have higher
 	// expiration timestamps.
-	lease.LeaseJitterFraction.Override(ctx, &params.ServerArgs.SV, 0)
+	lease.LeaseJitterFraction.Override(ctx, &params.ServerArgs.Settings.SV, 0)
 	// The renewal timeout is set to be the duration, so background
 	// renewal should begin immediately after accessing a lease.
-	lease.LeaseRenewalDuration.Override(ctx, &params.ServerArgs.SV,
-		lease.LeaseDuration.Get(&params.ServerArgs.SV))
+	lease.LeaseRenewalDuration.Override(ctx, &params.ServerArgs.Settings.SV,
+		lease.LeaseDuration.Get(&params.ServerArgs.Settings.SV))
 
 	t := newLeaseTest(testingT, params)
 	defer t.cleanup()
@@ -1865,12 +1865,12 @@ func TestLeaseRenewedPeriodically(testingT *testing.T) {
 
 	// The lease jitter is set to ensure newer leases have higher
 	// expiration timestamps.
-	lease.LeaseJitterFraction.Override(ctx, &params.ServerArgs.SV, 0)
+	lease.LeaseJitterFraction.Override(ctx, &params.ServerArgs.Settings.SV, 0)
 	// Lease duration to something small.
-	lease.LeaseDuration.Override(ctx, &params.ServerArgs.SV, 50*time.Millisecond)
+	lease.LeaseDuration.Override(ctx, &params.ServerArgs.Settings.SV, 50*time.Millisecond)
 	// Renewal timeout to 0 saying that the lease will get renewed only
 	// after the lease expires when a request requests the descriptor.
-	lease.LeaseRenewalDuration.Override(ctx, &params.ServerArgs.SV, 0)
+	lease.LeaseRenewalDuration.Override(ctx, &params.ServerArgs.Settings.SV, 0)
 
 	t := newLeaseTest(testingT, params)
 	defer t.cleanup()
@@ -2960,7 +2960,7 @@ func TestLeaseTxnDeadlineExtension(t *testing.T) {
 	params.Settings = cluster.MakeTestingClusterSettings()
 	// Set the lease duration such that the next lease acquisition will
 	// require the lease to be reacquired.
-	lease.LeaseDuration.Override(ctx, &params.SV, 0)
+	lease.LeaseDuration.Override(ctx, &params.Settings.SV, 0)
 	params.Knobs.Store = &kvserver.StoreTestingKnobs{
 		TestingRequestFilter: func(ctx context.Context, req *kvpb.BatchRequest) *kvpb.Error {
 			filterMu.Lock()
@@ -3147,7 +3147,7 @@ func TestLeaseBulkInsertWithImplicitTxn(t *testing.T) {
 	params.ServerArgs.Settings = cluster.MakeTestingClusterSettings()
 	// Set the lease duration such that the next lease acquisition will
 	// require the lease to be reacquired.
-	lease.LeaseDuration.Override(ctx, &params.ServerArgs.SV, 0)
+	lease.LeaseDuration.Override(ctx, &params.ServerArgs.Settings.SV, 0)
 	var leaseManager *lease.Manager
 	leaseTableID := uint64(0)
 	params.ServerArgs.Knobs.SQLExecutor = &sql.ExecutorTestingKnobs{
@@ -3411,7 +3411,7 @@ func TestDescriptorRemovedFromCacheWhenLeaseRenewalForThisDescriptorFails(t *tes
 
 	// Set lease duration to something small so that the periodical lease refresh is kicked off often where the testing
 	// knob will be invoked, and eventually the logic to remove unfound descriptor from cache will be triggered.
-	lease.LeaseDuration.Override(ctx, &params.SV, time.Second)
+	lease.LeaseDuration.Override(ctx, &params.Settings.SV, time.Second)
 
 	srv, sqlDB, kvDB := serverutils.StartServer(t, params)
 	defer srv.Stopper().Stop(ctx)

--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -247,6 +247,10 @@ func NewTestCluster(
 		t.Fatal("invalid cluster size: ", nodes)
 	}
 
+	if nodes > 1 && clusterArgs.ServerArgs.Settings != nil {
+		t.Fatalf("multiple test servers cannot share the same Settings object")
+	}
+
 	if err := checkServerArgsForCluster(
 		clusterArgs.ServerArgs, clusterArgs.ReplicationMode, disallowJoinAddr,
 	); err != nil {


### PR DESCRIPTION
If a test sets `TestClusterArgs.ServerArgs.Settings`, the `Settings`
object will be shared between all nodes. This can lead to very hard to
root-cause failures, especially around version changes (including
during node initialization).

As part of this change, we also correct the unnecessary embedding of
`*Settings` and `RaftSettings` into this struct.

Fixes: #112395
Release note: None