### PR TITLE
roachtest: change JRE version installed for hibernate test

### DIFF
--- a/pkg/cmd/roachtest/tests/hibernate.go
+++ b/pkg/cmd/roachtest/tests/hibernate.go
@@ -131,7 +131,7 @@ func registerHibernate(r registry.Registry, opt hibernateOptions) {
 			c,
 			node,
 			"install dependencies",
-			`sudo apt-get -qq install default-jre openjdk-8-jdk-headless gradle`,
+			`sudo apt-get -qq install openjdk-8-jre-headless openjdk-8-jdk-headless gradle`,
 		); err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
This patch changes the JRE version that is installed for the `hibernate`
roachtest to be `openjdk-8-jre-headless` instead of `default-jre`.
The `settings.gradle` file for the version of hibernate we are using
specifies that the maximum supported version is 15. It is suspected
that `default-jre` on the nightly build is installing version 17.

Informs #111335
Informs #111332
Informs #111167

Release note: None