### PR TITLE
release-23.2: demo: disable multitenancy by default

### DIFF
--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -655,7 +655,7 @@ func setDemoContextDefaults() {
 	demoCtx.SQLPort, _ = strconv.Atoi(base.DefaultPort)
 	demoCtx.HTTPPort, _ = strconv.Atoi(base.DefaultHTTPPort)
 	demoCtx.WorkloadMaxQPS = 25
-	demoCtx.Multitenant = true
+	demoCtx.Multitenant = false
 	demoCtx.DisableServerController = false
 	demoCtx.DefaultEnableRangefeeds = true
 	demoCtx.AutoConfigProvider = acprovider.NoTaskProvider{}

--- a/pkg/cli/interactive_tests/test_demo.tcl
+++ b/pkg/cli/interactive_tests/test_demo.tcl
@@ -41,10 +41,10 @@ send_eof
 eexpect eof
 end_test
 
-start_test "Check that demo insecure, env var, says hello properly"
+start_test "Check that demo insecure, env var, says hello properly, multitenant"
 # With env var.
 set ::env(COCKROACH_INSECURE) "true"
-spawn $argv demo --no-line-editor --no-example-database --log-dir=logs
+spawn $argv demo --no-line-editor --no-example-database --log-dir=logs --multitenant=true
 eexpect "Welcome"
 eexpect "defaultdb>"
 end_test
@@ -98,12 +98,33 @@ send_eof
 eexpect eof
 
 end_test
-
-start_test "Check that demo secure says hello properly"
+start_test "Check that demo secure says hello properly, singletenant"
 
 # With env var.
 set ::env(COCKROACH_INSECURE) "false"
-spawn $argv demo --no-line-editor --no-example-database --log-dir=logs
+spawn $argv demo --no-line-editor --no-example-database --log-dir=logs --multitenant=false
+eexpect "Welcome"
+
+eexpect "(webui)"
+eexpect "http://127.0.0.1:8080/demologin"
+eexpect "(sql)"
+eexpect "postgresql://demo:"
+eexpect "sslmode=require"
+eexpect "Username: \"demo\", password"
+eexpect "Directory with certificate files"
+
+eexpect "defaultdb>"
+
+send_eof
+eexpect eof
+
+end_test
+
+start_test "Check that demo secure says hello properly, multitenant"
+
+# With env var.
+set ::env(COCKROACH_INSECURE) "false"
+spawn $argv demo --no-line-editor --no-example-database --log-dir=logs --multitenant=true
 eexpect "Welcome"
 
 eexpect "(webui)"
@@ -266,7 +287,7 @@ eexpect "defaultdb>"
 send_eof
 eexpect eof
 
-spawn $argv demo --no-line-editor --no-example-database --nodes 3 --sql-port 23000 --log-dir=logs
+spawn $argv demo --no-line-editor --no-example-database --nodes 3 --sql-port 23000 --log-dir=logs --multitenant=true
 eexpect "Welcome"
 eexpect "defaultdb>"
 

--- a/pkg/cli/interactive_tests/test_demo_partitioning.tcl
+++ b/pkg/cli/interactive_tests/test_demo_partitioning.tcl
@@ -130,7 +130,7 @@ eexpect $prompt
 end_test
 
 start_test "Expect an error if geo-partitioning is requested with multitenant mode"
-send "$argv demo --no-line-editor --geo-partitioned-replicas --log-dir=logs \r"
+send "$argv demo --multitenant=true --no-line-editor --geo-partitioned-replicas --log-dir=logs \r"
 # expect a failure
 eexpect "operation is disabled within a virtual cluster"
 eexpect $prompt


### PR DESCRIPTION
Backport 1/1 commits from #112305.

/cc @cockroachdb/release

---

In every release since 22.2 we've enabled multitenancy by default on the master branch for cockroach demo. This has resulted in much more robust user testing, and has uncovered several bugs. We're still however, not at the point where our multi-tenant UX completely matches our single-tenant UX. As a result, before we ship 23.2 we're going to disable multitenancy by default for demo.

Epic: none

Release note: None
Release justification: Reverting functional regression.
