### PR TITLE
roachtest/cdc: prevent deadlock in cdc roachtest

### DIFF
--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -522,9 +522,7 @@ func (ct *cdcTester) runFeedLatencyVerifier(
 
 	finished := make(chan struct{})
 	ct.mon.Go(func(ctx context.Context) error {
-		defer func() {
-			finished <- struct{}{}
-		}()
+		defer close(finished)
 		err := verifier.pollLatencyUntilJobSucceeds(ctx, ct.DB(), cj.jobID, time.Second, ct.doneCh)
 		if err != nil {
 			return err


### PR DESCRIPTION
In https://github.com/cockroachdb/cockroach/issues/12064, a new channel was added to fix a race during test
termination. In a recent failure (https://github.com/cockroachdb/cockroach/issues/112374), a timeout occurred.

Looking at the code, deadlock can occur because the new channel is
unbuffered and has no receiver when the function caller ignores the
return value.

This change updates termination to be signaled by closing the channel
instead of sending onteh channel so deadlock does not occur.

Release note: None
Closes: https://github.com/cockroachdb/cockroach/issues/112374
Epic: None