### PR TITLE
schema: skip flaky TestAlterTableDMLInjection tests

### DIFF
--- a/pkg/sql/schemachanger/dml_injection_test.go
+++ b/pkg/sql/schemachanger/dml_injection_test.go
@@ -303,6 +303,7 @@ func TestAlterTableDMLInjection(t *testing.T) {
 		{
 			desc:         "create index",
 			schemaChange: "CREATE INDEX idx ON tbl (val)",
+			skipIssue:    112421,
 		},
 		{
 			desc:         "drop index",
@@ -361,6 +362,7 @@ func TestAlterTableDMLInjection(t *testing.T) {
 			desc:         "drop partial index",
 			setup:        []string{"CREATE INDEX idx ON tbl (val) WHERE val > 1"},
 			schemaChange: "DROP INDEX idx",
+			skipIssue:    112417,
 		},
 		{
 			desc: "drop column with partial index",
@@ -400,6 +402,7 @@ func TestAlterTableDMLInjection(t *testing.T) {
 				"CREATE MATERIALIZED VIEW mv AS SELECT * FROM tbl@idx",
 			},
 			schemaChange: "DROP INDEX idx CASCADE",
+			skipIssue:    112418,
 		},
 	}
 


### PR DESCRIPTION
Fixes #111881
Informs #112417
Informs #112418
Informs #112421

This change skips flaky schema changer DML injection tests.

Release note: None