### PR TITLE
sql: fix formatting of create virtual cluster options

### DIFF
--- a/pkg/sql/parser/testdata/create_virtual_cluster
+++ b/pkg/sql/parser/testdata/create_virtual_cluster
@@ -103,6 +103,14 @@ CREATE VIRTUAL CLUSTER "destination-hyphen" FROM REPLICATION OF "source-hyphen" 
 CREATE VIRTUAL CLUSTER _ FROM REPLICATION OF _ ON 'pgurl' WITH RESUME TIMESTAMP = '132412341234.000000' -- identifiers removed
 
 parse
+CREATE VIRTUAL CLUSTER "destination-hyphen" FROM REPLICATION OF "source-hyphen" ON 'pgurl' WITH RESUME TIMESTAMP = '132412341234.000000', RETENTION = '36h'
+----
+CREATE VIRTUAL CLUSTER "destination-hyphen" FROM REPLICATION OF "source-hyphen" ON 'pgurl' WITH RETENTION = '36h', RESUME TIMESTAMP = '132412341234.000000' -- normalized!
+CREATE VIRTUAL CLUSTER ("destination-hyphen") FROM REPLICATION OF ("source-hyphen") ON ('pgurl') WITH RETENTION = ('36h'), RESUME TIMESTAMP = ('132412341234.000000') -- fully parenthesized
+CREATE VIRTUAL CLUSTER "destination-hyphen" FROM REPLICATION OF "source-hyphen" ON '_' WITH RETENTION = '_', RESUME TIMESTAMP = '_' -- literals removed
+CREATE VIRTUAL CLUSTER _ FROM REPLICATION OF _ ON 'pgurl' WITH RETENTION = '36h', RESUME TIMESTAMP = '132412341234.000000' -- identifiers removed
+
+parse
 CREATE VIRTUAL CLUSTER "destination-hyphen" FROM REPLICATION OF "source-hyphen" ON 'pgurl' WITH OPTIONS (RETENTION = '36h')
 ----
 CREATE VIRTUAL CLUSTER "destination-hyphen" FROM REPLICATION OF "source-hyphen" ON 'pgurl' WITH RETENTION = '36h' -- normalized!

--- a/pkg/sql/sem/tree/create.go
+++ b/pkg/sql/sem/tree/create.go
@@ -2274,7 +2274,15 @@ func (node *CreateTenantFromReplication) Format(ctx *FmtCtx) {
 
 // Format implements the NodeFormatter interface
 func (o *TenantReplicationOptions) Format(ctx *FmtCtx) {
+	var addSep bool
+	maybeAddSep := func() {
+		if addSep {
+			ctx.WriteString(", ")
+		}
+		addSep = true
+	}
 	if o.Retention != nil {
+		maybeAddSep()
 		ctx.WriteString("RETENTION = ")
 		_, canOmitParentheses := o.Retention.(alreadyDelimitedAsSyntacticDExpr)
 		if !canOmitParentheses {
@@ -2286,6 +2294,7 @@ func (o *TenantReplicationOptions) Format(ctx *FmtCtx) {
 		}
 	}
 	if o.ResumeTimestamp != nil {
+		maybeAddSep()
 		ctx.WriteString("RESUME TIMESTAMP = ")
 		_, canOmitParentheses := o.ResumeTimestamp.(alreadyDelimitedAsSyntacticDExpr)
 		if !canOmitParentheses {


### PR DESCRIPTION
Previously, we did not correctly render the option list when more than one option was present.

Fixes #112214

Release note: None