### PR TITLE
roachtest: mark ruby-pg and npgsql flaky tests

### DIFF
--- a/pkg/cmd/roachtest/tests/npgsql_blocklist.go
+++ b/pkg/cmd/roachtest/tests/npgsql_blocklist.go
@@ -717,6 +717,7 @@ var npgsqlIgnoreList = blocklist{
 	`Npgsql.Tests.CommandTests(Multiplexing).Cursor_move_RecordsAffected `:                            "flaky",
 	`Npgsql.Tests.CommandTests(Multiplexing).QueryNonQuery`:                                           "flaky",
 	`Npgsql.Tests.CommandTests(Multiplexing).SingleNonQuery`:                                          "flaky",
+	`Npgsql.Tests.CommandTests(Multiplexing).SingleQuery`:                                             "flaky",
 	`Npgsql.Tests.CommandTests(Multiplexing).Statement_mapped_output_parameters(Default)`:             "flaky",
 	`Npgsql.Tests.CommandTests(Multiplexing).Use_across_connection_change(NotPrepared)`:               "flaky",
 	`Npgsql.Tests.CommandTests(NonMultiplexing).Cached_command_clears_parameters_placeholder_type`:    "flaky",

--- a/pkg/cmd/roachtest/tests/ruby_pg_blocklist.go
+++ b/pkg/cmd/roachtest/tests/ruby_pg_blocklist.go
@@ -200,5 +200,6 @@ var rubyPGBlocklist = blocklist{
 }
 
 var rubyPGIgnorelist = blocklist{
-	`running with sync_* methods PG::Connection consume_input should raise ConnectionBad for a closed connection`: "unknown",
+	`PG::Connection OS thread support Connection.new shouldn't block a second thread`:                             "flaky",
+	`running with sync_* methods PG::Connection consume_input should raise ConnectionBad for a closed connection`: "flaky",
 }


### PR DESCRIPTION
These two tests flake and are not easy to reproduce.

fixes https://github.com/cockroachdb/cockroach/issues/112407
fixes https://github.com/cockroachdb/cockroach/issues/112316
Release note: None