### PR TITLE
bootstrap: fix buglet in test

### DIFF
--- a/pkg/sql/catalog/bootstrap/bootstrap_test.go
+++ b/pkg/sql/catalog/bootstrap/bootstrap_test.go
@@ -45,7 +45,7 @@ func TestSupportedReleases(t *testing.T) {
 	latest := clusterversion.ByKey(clusterversion.BinaryVersionKey)
 	var incumbent roachpb.Version
 	for _, v := range clusterversion.ListBetween(earliest, latest) {
-		if v.Major != incumbent.Major && v.Minor != incumbent.Minor {
+		if v.Major != incumbent.Major || v.Minor != incumbent.Minor {
 			incumbent = roachpb.Version{
 				Major: v.Major,
 				Minor: v.Minor,


### PR DESCRIPTION
This fixes a bug in `TestSupportedReleases`, which causes a failure if we bump the version to 24.1.

Epic: none
Release note: None