### PR TITLE
clusterversion: rename permanent version key

### DIFF
--- a/pkg/clusterversion/cockroach_versions.go
+++ b/pkg/clusterversion/cockroach_versions.go
@@ -505,10 +505,10 @@ const (
 	// V23_2_PebbleFormatVirtualSSTables above.
 	V23_2_EnablePebbleFormatVirtualSSTables
 
-	// V23_2_MVCCStatisticsTable adds the system.mvcc_statistics
+	// Permanent_V23_2_MVCCStatisticsTable adds the system.mvcc_statistics
 	// table and update job. The table is used to serve fast reads of historical
 	// mvcc data from observability surfaces.
-	V23_2_MVCCStatisticsTable
+	Permanent_V23_2_MVCCStatisticsTable
 
 	// V23_2_AddSystemExecInsightsTable is the version at which Cockroach creates
 	// {statement|transaction}_execution_insights system tables.
@@ -867,7 +867,7 @@ var rawVersionsSingleton = keyedVersions{
 		Version: roachpb.Version{Major: 23, Minor: 1, Internal: 28},
 	},
 	{
-		Key:     V23_2_MVCCStatisticsTable,
+		Key:     Permanent_V23_2_MVCCStatisticsTable,
 		Version: roachpb.Version{Major: 23, Minor: 1, Internal: 30},
 	},
 	{

--- a/pkg/upgrade/upgrades/mvcc_statistics_migration_test.go
+++ b/pkg/upgrade/upgrades/mvcc_statistics_migration_test.go
@@ -55,7 +55,7 @@ func TestMVCCStatisticsMigration(t *testing.T) {
 	upgrades.Upgrade(
 		t,
 		sqlDB,
-		clusterversion.V23_2_MVCCStatisticsTable,
+		clusterversion.Permanent_V23_2_MVCCStatisticsTable,
 		nil,
 		false,
 	)

--- a/pkg/upgrade/upgrades/upgrades.go
+++ b/pkg/upgrade/upgrades/upgrades.go
@@ -323,7 +323,7 @@ var upgrades = []upgradebase.Upgrade{
 	),
 	upgrade.NewPermanentTenantUpgrade(
 		"create system.mvcc_statistics table and job",
-		toCV(clusterversion.V23_2_MVCCStatisticsTable),
+		toCV(clusterversion.Permanent_V23_2_MVCCStatisticsTable),
 		createMVCCStatisticsTableAndJobMigration,
 		"create system.mvcc_statistics table and job",
 	),


### PR DESCRIPTION
`V23_2_MVCCStatisticsTable` is associated with a permanent upgrade.
Renaming the key to indicate that (it is important so that it doesn't
get removed later).

Epic: none
Release note: None