### PR TITLE
sctest: Fix bug where post-execution checks happens even in open txn

### DIFF
--- a/pkg/sql/schemachanger/schemachanger_test.go
+++ b/pkg/sql/schemachanger/schemachanger_test.go
@@ -821,6 +821,10 @@ func TestCompareLegacyAndDeclarative(t *testing.T) {
 		stmts: []string{
 			// Statements expected to succeed.
 			"SET sql_safe_updates = false;",
+			"CREATE DATABASE testdb1; SET DATABASE = testdb1",
+			"CREATE TABLE testdb1.t1 (i INT PRIMARY KEY); CREATE TABLE testdb1.t2 (i INT PRIMARY KEY REFERENCES testdb1.t1(i));",
+			"DROP DATABASE testdb1 CASCADE  -- current db is dropped; expect no post-execution checks",
+			"USE defaultdb",
 			"CREATE TABLE t2 (i INT PRIMARY KEY, j INT NOT NULL);",
 			"CREATE TABLE t1 (i INT PRIMARY KEY, j INT REFERENCES t2(i));",
 			"INSERT INTO t2 SELECT k, k+1 FROM generate_series(1,1000) AS tmp(k);",

--- a/pkg/sql/schemachanger/schemachanger_test.go
+++ b/pkg/sql/schemachanger/schemachanger_test.go
@@ -868,6 +868,8 @@ func TestCompareLegacyAndDeclarative(t *testing.T) {
 			"ALTER TABLE t3 DROP CONSTRAINT t3_pkey;",
 			"DELETE FROM t3 WHERE i = 1;  -- expect to result in an error",
 			"ROLLBACK;",
+			"BEGIN; ALTER TABLE t3 ADD COLUMN j INT CREATE FAMILY;",
+			"ROLLBACK;",
 			"BEGIN; SAVEPOINT cockroach_restart;",
 			"RELEASE SAVEPOINT cockroach_restart;  -- move txn into DONE state",
 			"SELECT 1;  -- expect to be ignored",

--- a/pkg/sql/schemachanger/sctest/comparator.go
+++ b/pkg/sql/schemachanger/sctest/comparator.go
@@ -71,16 +71,14 @@ func CompareLegacyAndDeclarative(t *testing.T, ss StmtLineReader) {
 
 	for ss.HasNextLine() {
 		line := ss.NextLine()
-
 		syntaxError := hasSyntaxError(line)
-		inTxn := isInATransaction(ctx, t, legacyConn)
 
 		// Pre-execution: modify `line` so that executing it produces the same
 		// state. This step is to account for the known behavior difference between
 		// the two schema changers.
 		// Only run when not in a transaction (otherwise certain DDL combo can make
 		// sql queries issued during modification break; see commit message).
-		if !inTxn && !syntaxError {
+		if !isInATransaction(ctx, t, legacyConn) && !syntaxError {
 			line = modifyBlacklistedStmt(ctx, t, line, legacyConn)
 		}
 
@@ -98,7 +96,7 @@ func CompareLegacyAndDeclarative(t *testing.T, ss StmtLineReader) {
 		// Post-execution: Check metadata level identity between two clusters.
 		// Only run when not in a transaction (because legacy schema changer will be
 		// used in both clusters).
-		if !inTxn && !syntaxError {
+		if !isInATransaction(ctx, t, legacyConn) && !syntaxError {
 			if containsStmtOfType(t, line, tree.TypeDDL) {
 				metaDataIdentityCheck(ctx, t, legacyConn, declarativeConn, linesExecutedSoFar)
 			}


### PR DESCRIPTION
This PR fixes three flaws in the comparator testing framework. See each commit for details:
1. ensure we don't perform post-execution identity checks if in a txn
2. skip `schema_repair` entry in the nightly comparator test from logic tests
3. skip post-execution identity checks if current database has just been dropped.

Informs #111978
Release note: None