### PR TITLE
roachtest: _actually_ fix deadlock in `getTestToRun`

### DIFF
--- a/pkg/cmd/roachtest/work_pool.go
+++ b/pkg/cmd/roachtest/work_pool.go
@@ -99,11 +99,12 @@ func (p *workPool) getTestToRun(
 		// We failed to find a test that can reuse this cluster. A fresh cluster will need to be allocated.
 		// The existing cluster will be destroyed _before_ a fresh one is created.
 		// N.B. we must release the allocation quota before invoking 'selectTest' below, otherwise a deadlock may occur.
-		qp.Release(ttr.alloc)
-		// N.B. we transferred the allocation quota from the existing cluster in order to try to allocate a fresh one, so
-		// when the cluster is destroyed, don't release it again.
-		c.destroyState.alloc = nil
-		ttr.alloc = nil
+		if c.destroyState.alloc != nil {
+			qp.Release(c.destroyState.alloc)
+			// N.B. we transferred the allocation quota from the existing cluster in order to try to allocate a fresh one, so
+			// when the cluster is destroyed, don't release it again.
+			c.destroyState.alloc = nil
+		}
 	}
 	// invariant: testToRunRes.noWork || !testToRunRes.canReuseCluster
 	return p.selectTest(ctx, qp)


### PR DESCRIPTION
In [1], we attempted to fix a potential deadlock in getTestToRun. The change was effectively no-op due to the wrong, actual argument passed to `Release`.

[1] https://github.com/cockroachdb/cockroach/pull/112250

Epic: none

Release note: None