### PR TITLE
build: move tests from medium to large pool

### DIFF
--- a/pkg/bench/rttanalysis/BUILD.bazel
+++ b/pkg/bench/rttanalysis/BUILD.bazel
@@ -54,7 +54,7 @@ go_test(
     args = ["-test.timeout=895s"],
     data = glob(["testdata/**"]),
     embed = [":rttanalysis"],
-    exec_properties = {"Pool": "medium"},
+    exec_properties = {"Pool": "large"},
     shard_count = 16,
     deps = [
         "//pkg/base",

--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/BUILD.bazel
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/BUILD.bazel
@@ -8,7 +8,7 @@ go_test(
     ],
     args = ["-test.timeout=295s"],
     data = glob(["testdata/**"]),
-    exec_properties = {"Pool": "medium"},
+    exec_properties = {"Pool": "large"},
     tags = ["ccl_test"],
     deps = [
         "//pkg/base",

--- a/pkg/ccl/sqlproxyccl/BUILD.bazel
+++ b/pkg/ccl/sqlproxyccl/BUILD.bazel
@@ -77,7 +77,7 @@ go_test(
     args = ["-test.timeout=895s"],
     data = glob(["testdata/**"]),
     embed = [":sqlproxyccl"],
-    exec_properties = {"Pool": "medium"},
+    exec_properties = {"Pool": "large"},
     shard_count = 8,
     tags = ["ccl_test"],
     deps = [

--- a/pkg/sql/catalog/lease/BUILD.bazel
+++ b/pkg/sql/catalog/lease/BUILD.bazel
@@ -75,7 +75,7 @@ go_test(
     ],
     args = ["-test.timeout=895s"],
     embed = [":lease"],
-    exec_properties = {"Pool": "medium"},
+    exec_properties = {"Pool": "large"},
     shard_count = 4,
     deps = [
         "//pkg/base",

--- a/pkg/sql/gcjob_test/BUILD.bazel
+++ b/pkg/sql/gcjob_test/BUILD.bazel
@@ -8,7 +8,7 @@ go_test(
         "main_test.go",
     ],
     args = ["-test.timeout=295s"],
-    exec_properties = {"Pool": "medium"},
+    exec_properties = {"Pool": "large"},
     shard_count = 2,
     deps = [
         "//pkg/base",

--- a/pkg/sql/logictest/BUILD.bazel
+++ b/pkg/sql/logictest/BUILD.bazel
@@ -110,7 +110,7 @@ go_test(
     args = ["-test.timeout=295s"],
     data = [":testdata"],
     embed = [":logictest"],
-    exec_properties = {"Pool": "medium"},
+    exec_properties = {"Pool": "large"},
     deps = [
         "//pkg/base",
         "//pkg/config/zonepb",

--- a/pkg/sql/ttl/ttljob/BUILD.bazel
+++ b/pkg/sql/ttl/ttljob/BUILD.bazel
@@ -64,7 +64,7 @@ go_test(
         "ttljob_test.go",
     ],
     args = ["-test.timeout=895s"],
-    exec_properties = {"Pool": "medium"},
+    exec_properties = {"Pool": "large"},
     shard_count = 4,
     deps = [
         ":ttljob",

--- a/pkg/storage/BUILD.bazel
+++ b/pkg/storage/BUILD.bazel
@@ -143,7 +143,7 @@ go_test(
     args = ["-test.timeout=295s"],
     data = glob(["testdata/**"]),
     embed = [":storage"],
-    exec_properties = {"Pool": "medium"},
+    exec_properties = {"Pool": "large"},
     shard_count = 2,
     deps = [
         "//pkg/base",


### PR DESCRIPTION
We'll decommission the medium pool, so these want to be large instead.

Epic: CRDB-8308
Release note: None