### PR TITLE
kvserver: deflake large unsplittable range test

### DIFF
--- a/pkg/kv/kvserver/replicate_queue_test.go
+++ b/pkg/kv/kvserver/replicate_queue_test.go
@@ -1811,6 +1811,21 @@ func TestLargeUnsplittableRangeReplicate(t *testing.T) {
 	toggleReplicationQueues(tc, true /* active */)
 	toggleSplitQueues(tc, true /* active */)
 
+	// Check that the two ranges exist for table t.
+	testutils.SucceedsSoon(t, func() error {
+		r := db.QueryRow(
+			"SELECT count(*) FROM [SHOW RANGES FROM TABLE t]")
+		var count int
+		if err := r.Scan(&count); err != nil {
+			return err
+		}
+		if count != 2 {
+			return fmt.Errorf(
+				"splits not created, expected %d ranges, found %d", 2, count)
+		}
+		return nil
+	})
+
 	// We're going to create a large row, but now large enough that write
 	// back-pressuring kicks in and refuses it.
 	var sb strings.Builder


### PR DESCRIPTION
`TestLargeUnsplittableRangeReplicate` creates two ranges, one which is
above the max range size and asserts that they both can be successfully
up-replicated (3->5). The test has occasionally failed when both splits
were not created.

Wait for the two ranges to exist when querying the test table, before
up-replicating.

Fixes: https://github.com/cockroachdb/cockroach/issues/111960
Fixes: https://github.com/cockroachdb/cockroach/issues/112207
Release note: None