### PR TITLE
testcluster: clone Settings for each server

### DIFF
--- a/pkg/base/test_server_args.go
+++ b/pkg/base/test_server_args.go
@@ -35,8 +35,8 @@ type TestServerArgs struct {
 	// Knobs for the test server.
 	Knobs TestingKnobs
 
-	*cluster.Settings
-	RaftConfig
+	Settings   *cluster.Settings
+	RaftConfig RaftConfig
 
 	// PartOfCluster must be set if the TestServer is joining others in a cluster.
 	// If not set (and hence the server is the only one in the cluster), the

--- a/pkg/base/test_server_args.go
+++ b/pkg/base/test_server_args.go
@@ -35,7 +35,13 @@ type TestServerArgs struct {
 	// Knobs for the test server.
 	Knobs TestingKnobs
 
-	Settings   *cluster.Settings
+	// Settings for the server.
+	//
+	// When TestServerArgs is used for a multi-node test cluster, the Settings
+	// object is cloned for each node (see cluster.TestingCloneClusterSettings).
+	// To effect a change in a node's settings, ClusterSettings() should be used.
+	Settings *cluster.Settings
+
 	RaftConfig RaftConfig
 
 	// PartOfCluster must be set if the TestServer is joining others in a cluster.

--- a/pkg/kv/kvserver/client_lease_test.go
+++ b/pkg/kv/kvserver/client_lease_test.go
@@ -45,7 +45,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
-	raft "go.etcd.io/raft/v3"
+	"go.etcd.io/raft/v3"
 	"go.etcd.io/raft/v3/tracker"
 )
 
@@ -1609,8 +1609,10 @@ func TestLeaseRequestBumpsEpoch(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, roachpb.LeaseEpoch, prevLease.Type())
 
-		// Non-cooperatively move the lease to n2.
-		kvserver.ExpirationLeasesOnly.Override(ctx, &st.SV, expLease)
+		for _, s := range tc.Servers {
+			// Non-cooperatively move the lease to n2.
+			kvserver.ExpirationLeasesOnly.Override(ctx, &s.ClusterSettings().SV, expLease)
+		}
 		t1 := tc.Target(1)
 		newLease, err := tc.MoveRangeLeaseNonCooperatively(ctx, desc, t1, manual)
 		require.NoError(t, err)

--- a/pkg/kv/kvserver/gossip_test.go
+++ b/pkg/kv/kvserver/gossip_test.go
@@ -160,8 +160,8 @@ func TestGossipHandlesReplacedNode(t *testing.T) {
 			MaxBackoff:     50 * time.Millisecond,
 		},
 	}
-	serverArgs.RaftTickInterval = 50 * time.Millisecond
-	serverArgs.RaftElectionTimeoutTicks = 10
+	serverArgs.RaftConfig.RaftTickInterval = 50 * time.Millisecond
+	serverArgs.RaftConfig.RaftElectionTimeoutTicks = 10
 
 	tc := testcluster.StartTestCluster(t, 3,
 		base.TestClusterArgs{

--- a/pkg/settings/cluster/cluster_settings.go
+++ b/pkg/settings/cluster/cluster_settings.go
@@ -174,3 +174,17 @@ func MakeTestingClusterSettingsWithVersions(
 	}
 	return s
 }
+
+// TestingCloneClusterSettings makes a clone of the Settings object. This is to
+// be used for settings objects that are passed as initial parameters for test
+// clusters; the given Settings object should not be in use by any server.
+func TestingCloneClusterSettings(st *Settings) *Settings {
+	result := &Settings{
+		ExternalIODir: st.ExternalIODir,
+	}
+	result.Version = clusterversion.MakeVersionHandleWithOverride(
+		&result.SV, st.Version.BinaryVersion(), st.Version.BinaryMinSupportedVersion(),
+	)
+	result.SV.TestingCopyForServer(&st.SV, result.Version)
+	return result
+}

--- a/pkg/settings/values.go
+++ b/pkg/settings/values.go
@@ -282,3 +282,26 @@ func (sv *Values) TestingCopyForVirtualCluster(input *Values) {
 		sv.setDefaultOverride(slot, v)
 	}
 }
+
+// TestingCopyForServer makes a copy of the input Values in the target Values
+// for use when initializing a server in a test cluster. This is meant to
+// propagate initial values and overrides.
+func (sv *Values) TestingCopyForServer(input *Values, newOpaque interface{}) {
+	sv.opaque = newOpaque
+	for slot := slotIdx(0); slot < slotIdx(len(registry)); slot++ {
+		// Copy the value.
+		sv.container.intVals[slot] = input.container.intVals[slot]
+		if v := input.container.genericVals[slot].Load(); v != nil {
+			sv.container.genericVals[slot].Store(v)
+		}
+
+		// Copy the default.
+		input.defaultOverridesMu.Lock()
+		v, hasVal := input.defaultOverridesMu.defaultOverrides[slot]
+		input.defaultOverridesMu.Unlock()
+		if !hasVal {
+			continue
+		}
+		sv.setDefaultOverride(slot, v)
+	}
+}

--- a/pkg/sql/catalog/lease/lease_internal_test.go
+++ b/pkg/sql/catalog/lease/lease_internal_test.go
@@ -992,7 +992,7 @@ func TestLeaseAcquireAndReleaseConcurrently(t *testing.T) {
 			// monotonically increasing expiration. This prevents two leases
 			// from having the same expiration due to randomness, as the
 			// leases are checked for having a different expiration.
-			LeaseJitterFraction.Override(ctx, &serverArgs.SV, 0)
+			LeaseJitterFraction.Override(ctx, &serverArgs.Settings.SV, 0)
 
 			srv, sqlDB, _ := serverutils.StartServer(t, serverArgs)
 			defer srv.Stopper().Stop(context.Background())

--- a/pkg/sql/catalog/lease/lease_test.go
+++ b/pkg/sql/catalog/lease/lease_test.go
@@ -386,7 +386,7 @@ func TestLeaseManagerReacquire(testingT *testing.T) {
 	params.ServerArgs.Settings = cluster.MakeTestingClusterSettings()
 	// Set the lease duration such that the next lease acquisition will
 	// require the lease to be reacquired.
-	lease.LeaseDuration.Override(ctx, &params.ServerArgs.SV, 0)
+	lease.LeaseDuration.Override(ctx, &params.ServerArgs.Settings.SV, 0)
 
 	removalTracker := lease.NewLeaseRemovalTracker()
 	params.ServerArgs.Knobs = base.TestingKnobs{
@@ -1265,11 +1265,11 @@ func TestLeaseRenewedAutomatically(testingT *testing.T) {
 	params.ServerArgs.Settings = cluster.MakeTestingClusterSettings()
 	// The lease jitter is set to ensure newer leases have higher
 	// expiration timestamps.
-	lease.LeaseJitterFraction.Override(ctx, &params.ServerArgs.SV, 0)
+	lease.LeaseJitterFraction.Override(ctx, &params.ServerArgs.Settings.SV, 0)
 	// The renewal timeout is set to be the duration, so background
 	// renewal should begin immediately after accessing a lease.
-	lease.LeaseRenewalDuration.Override(ctx, &params.ServerArgs.SV,
-		lease.LeaseDuration.Get(&params.ServerArgs.SV))
+	lease.LeaseRenewalDuration.Override(ctx, &params.ServerArgs.Settings.SV,
+		lease.LeaseDuration.Get(&params.ServerArgs.Settings.SV))
 
 	t := newLeaseTest(testingT, params)
 	defer t.cleanup()
@@ -1865,12 +1865,12 @@ func TestLeaseRenewedPeriodically(testingT *testing.T) {
 
 	// The lease jitter is set to ensure newer leases have higher
 	// expiration timestamps.
-	lease.LeaseJitterFraction.Override(ctx, &params.ServerArgs.SV, 0)
+	lease.LeaseJitterFraction.Override(ctx, &params.ServerArgs.Settings.SV, 0)
 	// Lease duration to something small.
-	lease.LeaseDuration.Override(ctx, &params.ServerArgs.SV, 50*time.Millisecond)
+	lease.LeaseDuration.Override(ctx, &params.ServerArgs.Settings.SV, 50*time.Millisecond)
 	// Renewal timeout to 0 saying that the lease will get renewed only
 	// after the lease expires when a request requests the descriptor.
-	lease.LeaseRenewalDuration.Override(ctx, &params.ServerArgs.SV, 0)
+	lease.LeaseRenewalDuration.Override(ctx, &params.ServerArgs.Settings.SV, 0)
 
 	t := newLeaseTest(testingT, params)
 	defer t.cleanup()
@@ -2960,7 +2960,7 @@ func TestLeaseTxnDeadlineExtension(t *testing.T) {
 	params.Settings = cluster.MakeTestingClusterSettings()
 	// Set the lease duration such that the next lease acquisition will
 	// require the lease to be reacquired.
-	lease.LeaseDuration.Override(ctx, &params.SV, 0)
+	lease.LeaseDuration.Override(ctx, &params.Settings.SV, 0)
 	params.Knobs.Store = &kvserver.StoreTestingKnobs{
 		TestingRequestFilter: func(ctx context.Context, req *kvpb.BatchRequest) *kvpb.Error {
 			filterMu.Lock()
@@ -3147,7 +3147,7 @@ func TestLeaseBulkInsertWithImplicitTxn(t *testing.T) {
 	params.ServerArgs.Settings = cluster.MakeTestingClusterSettings()
 	// Set the lease duration such that the next lease acquisition will
 	// require the lease to be reacquired.
-	lease.LeaseDuration.Override(ctx, &params.ServerArgs.SV, 0)
+	lease.LeaseDuration.Override(ctx, &params.ServerArgs.Settings.SV, 0)
 	var leaseManager *lease.Manager
 	leaseTableID := uint64(0)
 	params.ServerArgs.Knobs.SQLExecutor = &sql.ExecutorTestingKnobs{
@@ -3411,7 +3411,7 @@ func TestDescriptorRemovedFromCacheWhenLeaseRenewalForThisDescriptorFails(t *tes
 
 	// Set lease duration to something small so that the periodical lease refresh is kicked off often where the testing
 	// knob will be invoked, and eventually the logic to remove unfound descriptor from cache will be triggered.
-	lease.LeaseDuration.Override(ctx, &params.SV, time.Second)
+	lease.LeaseDuration.Override(ctx, &params.Settings.SV, time.Second)
 
 	srv, sqlDB, kvDB := serverutils.StartServer(t, params)
 	defer srv.Stopper().Stop(ctx)

--- a/pkg/testutils/testcluster/BUILD.bazel
+++ b/pkg/testutils/testcluster/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//pkg/rpc/nodedialer",
         "//pkg/server",
         "//pkg/server/serverpb",
+        "//pkg/settings/cluster",
         "//pkg/spanconfig",
         "//pkg/sql/catalog",
         "//pkg/sql/isql",

--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/rpc/nodedialer"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
@@ -302,6 +303,12 @@ func NewTestCluster(
 			serverArgs = perNodeServerArgs
 		} else {
 			serverArgs = tc.clusterArgs.ServerArgs
+		}
+
+		// We cannot allow multiple nodes to share a Settings object, so we make a
+		// clone for each one.
+		if serverArgs.Settings != nil && nodes > 1 {
+			serverArgs.Settings = cluster.TestingCloneClusterSettings(serverArgs.Settings)
 		}
 
 		// If a reusable listener registry is provided, create reusable listeners


### PR DESCRIPTION
#### testserver: unembed Settings, RaftConfig

There is no reason these should be embedded.
Epic: none
Release note: None

#### testcluster: clone Settings for each server

Currently there are many tests where multi-node test clusters share
the same `*Settings` object. This is problematic - on one hand, it can
make some test failures very hard to debug, and on the other hand, we
are missing out on testing more realistic scenarios where nodes in a
cluster don't magically have their settings in sync.

This change adds some test-only code to clone the Settings object.

Fixes #112395
Release note: None