### PR TITLE
release-23.2: Revert "Revert "kvstreamer: resolve a deadlock in an edge case""

### DIFF
--- a/pkg/kv/kvclient/kvstreamer/streamer.go
+++ b/pkg/kv/kvclient/kvstreamer/streamer.go
@@ -750,10 +750,7 @@ func (s *Streamer) GetResults(ctx context.Context) ([]Result, error) {
 			return results, err
 		}
 		log.VEvent(ctx, 2, "waiting in GetResults")
-		s.results.wait()
-		// Check whether the Streamer has been canceled or closed while we were
-		// waiting for the results.
-		if err = ctx.Err(); err != nil {
+		if err = s.results.wait(ctx); err != nil {
 			s.results.setError(err)
 			return nil, err
 		}


### PR DESCRIPTION
This reverts commit 655588aa2c373f1dc807080a71e8ef836af55982.

Addresses: #108884.

Epic: None

Release note: None

Release justification: bug fix.