### PR TITLE
upgrademanager: run each upgrade twice in test-only builds

### DIFF
--- a/pkg/upgrade/upgrademanager/BUILD.bazel
+++ b/pkg/upgrade/upgrademanager/BUILD.bazel
@@ -30,6 +30,7 @@ go_library(
         "//pkg/upgrade/upgrades",
         "//pkg/util/buildutil",
         "//pkg/util/log",
+        "//pkg/util/randutil",
         "//pkg/util/startup",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_logtags//:logtags",


### PR DESCRIPTION
This would prevent issues like the one fixed in #112470 from slipping in.

Epic: None

Release note: None