### PR TITLE
packer: upgrade Go to 1.21.3 on TeamCity agents

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -111,7 +111,6 @@ Please copy this checklist (based on [Basic Process](#basic-process)) into the r
 back to this document and perform these steps:
 
 * [ ] Adjust the Pebble tests to run in new version.
-* [ ] Adjust version in the TeamCity agent image ([setup script](./packer/teamcity-agent.sh))
 * [ ] Update `build/teamcity/internal/release/build-and-publish-patched-go/impl.sh` with the new version and adjust SHA256 sums as necessary.
 * [ ] Adjust `GO_VERSION` and `GO_FIPS_COMMIT` for the FIPS Go toolchain ([source](./teamcity/internal/release/build-and-publish-patched-go/impl-fips.sh)).
 * [ ] Run the `Internal / Cockroach / Build / Toolchains / Publish Patched Go for Mac` build configuration in TeamCity with your latest version of the script above. Note the job depends on another job `Build and Publish Patched Go`. That job prints out the SHA256 of all tarballs, which you will need to copy-paste into `WORKSPACE` (see below). `Publish Patched Go for Mac` is an extra step that publishes the *signed* `go` binaries for macOS. That job also prints out the SHA256 of the Mac tarballs in particular.
@@ -122,7 +121,6 @@ back to this document and perform these steps:
 * [ ] Bump the go version in `go.mod`.
 * [ ] Bump the default installed version of Go in `bootstrap-debian.sh` ([source](./bootstrap/bootstrap-debian.sh)).
 * [ ] Replace other mentions of the older version of go (grep for `golang:<old_version>` and `go<old_version>`).
-* [ ] Ask the Developer Infrastructure team to deploy new TeamCity agent images according to [packer/README.md](./packer/README.md)
 
 You can test the new builder image in TeamCity by using the custom parameters
 UI (the "..." icon next to the "Run" button) to verify the image before

--- a/build/packer/teamcity-agent.sh
+++ b/build/packer/teamcity-agent.sh
@@ -76,10 +76,12 @@ EOF
 tar --strip-components=1 -C /usr -xzf /tmp/cmake.tar.gz
 rm -f /tmp/cmake.tar.gz
 
+# NB: The Go version should match up to the version required by managed-service.
+# CRDB builds use Bazel and therefore have no dependency on the globally-installed Go CLI.
 if [[ $ARCH = x86_64 ]]; then
-    curl -fsSL https://dl.google.com/go/go1.20.10.linux-amd64.tar.gz > /tmp/go.tgz
+    curl -fsSL https://dl.google.com/go/go1.21.3.linux-amd64.tar.gz > /tmp/go.tgz
     sha256sum -c - <<EOF
-80d34f1fd74e382d86c2d6102e0e60d4318461a7c2f457ec1efc4042752d4248  /tmp/go.tgz
+1241381b2843fae5a9707eec1f8fb2ef94d827990582c7c7c32f5bdfbfd420c8  /tmp/go.tgz
 EOF
     tar -C /usr/local -zxf /tmp/go.tgz && rm /tmp/go.tgz
     # Explicitly symlink the pinned version to /usr/bin.


### PR DESCRIPTION
This PR upgrades the Go version installed on the x86_64 TeamCity agents to to 1.21.3. This version is not used by the CRDB builds or tests. The primary consumer of it is Cockroach Cloud CI.

Epic: none
Release note: None