### PR TITLE
licenses: update CCT

### DIFF
--- a/licenses/CCL.txt
+++ b/licenses/CCL.txt
@@ -1,420 +1,383 @@
 CockroachDB Community License Agreement
 
-  Please read this CockroachDB Community License Agreement (the "Agreement")
-  carefully before using CockroachDB (as defined below), which is offered by
-  Cockroach Labs, Inc. or its affiliated Legal Entities ("Cockroach Labs").
+Please read this CockroachDB Community License Agreement (the "Agreement")
+carefully before using CockroachDB (as defined below), which is offered by
+Cockroach Labs, Inc. or its affiliated Legal Entities ("Cockroach Labs").
 
-  By downloading CockroachDB or using it in any manner, You agree that You have
-  read and agree to be bound by the terms of this Agreement.  If You are
-  accessing CockroachDB on behalf of a Legal Entity, You represent and warrant
-  that You have the authority to agree to these terms on its behalf and the
-  right to bind that Legal Entity to this Agreement.  Use of CockroachDB is
-  expressly conditioned upon Your assent to all the terms of this Agreement, to
-  the exclusion of all other terms.
+By downloading CockroachDB or using it in any manner, You agree that You have
+read and agree to be bound by the terms of this Agreement. If You are accessing
+CockroachDB on behalf of a Legal Entity, You represent and warrant that You have
+the authority to agree to these terms on its behalf and the right to bind that
+Legal Entity to this Agreement. Use of CockroachDB is expressly conditioned upon
+Your assent to all the terms of this Agreement, to the exclusion of all other
+terms.
 
-  1. Definitions.  In addition to other terms defined elsewhere in this
-     Agreement, the terms below have the following meanings.
+1. Definitions. In addition to other terms defined elsewhere in this Agreement,
+the terms below have the following meanings.
 
-    (a) "CockroachDB" shall mean the SQL database software provided by Cockroach
-        Labs, including both CockroachDB Core and CockroachDB Enterprise
-        editions, as defined below.
+(a) "CockroachDB" shall mean the SQL database software provided by Cockroach
+Labs, including both CockroachDB Core and CockroachDB Self-hosted, as defined
+below.
 
-    (b) "CockroachDB Core" shall mean the version of
-        CockroachDB, available free of charge at
+(b) "CockroachDB Core" shall mean the version of CockroachDB, available free of
+charge at https://github.com/cockroachdb/cockroach
 
-            https://github.com/cockroachdb/cockroach
+(c) "CockroachDB Self-hosted (f/k/a "CockroachDB Enterprise Edition")" shall
+mean the additional features made available by Cockroach Labs, the use of which
+is subject to additional terms set out below.
 
-    (c) "CockroachDB Enterprise Edition" shall mean the additional features made
-        available by Cockroach Labs, the use of which is subject to additional
-        terms set out below.
+(d) "Contribution" shall mean any work of authorship, including the original
+version of the Work and any modifications or additions to that Work or
+Derivative Works thereof, that is intentionally submitted Cockroach Labs for
+inclusion in the Work by the copyright owner or by an individual or Legal Entity
+authorized to submit on behalf of the copyright owner. For the purposes of this
+definition, "submitted" means any form of electronic, verbal, or written
+communication sent to Cockroach Labs or its representatives, including but not
+limited to communication on electronic mailing lists, source code control
+systems, and issue tracking systems that are managed by, or on behalf of,
+Cockroach Labs for the purpose of discussing and improving the Work, but
+excluding communication that is conspicuously marked or otherwise designated in
+writing by the copyright owner as "Not a Contribution."
 
-    (d) "Contribution" shall mean any work of authorship, including the original
-        version of the Work and any modifications or additions to that Work or
-        Derivative Works thereof, that is intentionally submitted Cockroach Labs
-        for inclusion in the Work by the copyright owner or by an individual or
-        Legal Entity authorized to submit on behalf of the copyright owner.  For
-        the purposes of this definition, "submitted" means any form of
-        electronic, verbal, or written communication sent to Cockroach Labs or
-        its representatives, including but not limited to communication on
-        electronic mailing lists, source code control systems, and issue
-        tracking systems that are managed by, or on behalf of, Cockroach Labs
-        for the purpose of discussing and improving the Work, but excluding
-        communication that is conspicuously marked or otherwise designated in
-        writing by the copyright owner as "Not a Contribution."
+(e) "Contributor" shall mean any copyright owner or individual or Legal Entity
+authorized by the copyright owner, other than Cockroach Labs, from whom
+Cockroach Labs receives a Contribution that Cockroach Labs subsequently
+incorporates within the Work.
 
-    (e) "Contributor" shall mean any copyright owner or individual or Legal
-        Entity authorized by the copyright owner, other than Cockroach Labs,
-        from whom Cockroach Labs receives a Contribution that Cockroach Labs
-        subsequently incorporates within the Work.
+(f) "Derivative Works" shall mean any work, whether in Source or Object form,
+that is based on (or derived from) the Work, such as a translation, abridgement,
+condensation, or any other recasting, transformation, or adaptation for which
+the editorial revisions, annotations, elaborations, or other modifications
+represent, as a whole, an original work of authorship. For the purposes of this
+License, Derivative Works shall not include works that remain separable from, or
+merely link (or bind by name) to the interfaces of, the Work and Derivative
+Works thereof.
 
-    (f) "Derivative Works" shall mean any work, whether in Source or Object
-        form, that is based on (or derived from) the Work, such as a
-        translation, abridgement, condensation, or any other recasting,
-        transformation, or adaptation for which the editorial revisions,
-        annotations, elaborations, or other modifications represent, as a whole,
-        an original work of authorship. For the purposes of this License,
-        Derivative Works shall not include works that remain separable from, or
-        merely link (or bind by name) to the interfaces of, the Work and
-        Derivative Works thereof.
+(g) "Legal Entity" shall mean the union of the acting entity and all other
+entities that control, are controlled by, or are under common control with that
+entity. For the purposes of this definition, "control" means (i) the power,
+direct or indirect, to cause the direction or management of such entity, whether
+by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of
+the outstanding shares, or (iii) beneficial ownership of such entity.
 
-    (g) "Legal Entity" shall mean the union of the acting entity and all other
-        entities that control, are controlled by, or are under common control
-        with that entity.  For the purposes of this definition, "control" means
-        (i) the power, direct or indirect, to cause the direction or management
-        of such entity, whether by contract or otherwise, or (ii) ownership of
-        fifty percent (50%) or more of the outstanding shares, or (iii)
-        beneficial ownership of such entity.
+(h) "License" shall mean the terms and conditions for use, reproduction, and
+distribution of a Work as defined by this Agreement.
 
-    (h) "License" shall mean the terms and conditions for use, reproduction, and
-        distribution of a Work as defined by this Agreement.
+(i) "Licensor" shall mean Cockroach Labs or a Contributor, as applicable.
 
-    (i) "Licensor" shall mean Cockroach Labs or a Contributor, as applicable.
+(j) "Object" form shall mean any form resulting from mechanical transformation
+or translation of a Source form, including but not limited to compiled object
+code, generated documentation, and conversions to other media types.
 
-    (j) "Object" form shall mean any form resulting from mechanical
-        transformation or translation of a Source form, including but not
-        limited to compiled object code, generated documentation, and
-        conversions to other media types.
+(k) "Source" form shall mean the preferred form for making modifications,
+including but not limited to software source code, documentation source, and
+configuration files.
 
-    (k) "Source" form shall mean the preferred form for making modifications,
-        including but not limited to software source code, documentation source,
-        and configuration files.
+(l) "Third Party Works" shall mean Works, including Contributions, and other
+technology owned by a person or Legal Entity other than Cockroach Labs, as
+indicated by a copyright notice that is included in or attached to such Works or
+technology.
 
-    (l) "Third Party Works" shall mean Works, including Contributions, and other
-        technology owned by a person or Legal Entity other than Cockroach Labs,
-        as indicated by a copyright notice that is included in or attached to
-        such Works or technology.
+(m) "Work" shall mean the work of authorship, whether in Source or Object form,
+made available under a License, as indicated by a copyright notice that is
+included in or attached to the work.
 
-    (m) "Work" shall mean the work of authorship, whether in Source or Object
-        form, made available under a License, as indicated by a copyright notice
-        that is included in or attached to the work.
+(n) "You" (or "Your") shall mean an individual or Legal Entity exercising
+permissions granted by this License.
 
-    (n) "You" (or "Your") shall mean an individual or Legal Entity exercising
-        permissions granted by this License.
+2. Licenses.
 
-  2. Licenses.
+(a) License to CockroachDB Core. The License for the applicable version of
+CockroachDB Core can be found on the Cockroach DB Licensing FAQs page and in the
+applicable license file at the CockroachDB GitHub. CockroachDB Core is a
+no-cost, entry-level license and as such, contains the following disclaimers:
+NOTWITHSTANDING ANYTHING TO THE CONTRARY HEREIN, COCKROACHDB CORE IS PROVIDED
+"AS IS" AND "AS AVAILABLE", AND ALL EXPRESS OR IMPLIED WARRANTIES ARE EXCLUDED
+AND DISCLAIMED, INCLUDING WITHOUT LIMITATION THE IMPLIED WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND ANY
+WARRANTIES ARISING BY STATUTE OR OTHERWISE IN LAW OR FROM COURSE OF DEALING,
+COURSE OF PERFORMANCE, OR USE IN TRADE. For clarity, the terms of this
+Agreement, other than the relevant definitions in Section 1 and this Section
+2(a) do not apply to CockroachDB Core.
 
-    (a) License to CockroachDB Core.  The License for the applicable version of CockroachDB
-        Core can be found on the CockroachDB Licensing FAQs page and in the applicable
-        license file at the CockroachDB GitHub.  CockroachDB Core is a no-cost, entry-level
-        license and as such, contains the following disclaimers: NOTWITHSTANDING
-        ANYTHING TO THE CONTRARY HEREIN, COCKROACHDB CORE IS
-        PROVIDED "AS IS" AND "AS AVAILABLE", AND ALL EXPRESS OR IMPLIED
-        WARRANTIES ARE EXCLUDED AND DISCLAIMED, INCLUDING WITHOUT LIMITATION THE
-        IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE,
-        NON-INFRINGEMENT, AND ANY WARRANTIES ARISING BY STATUTE OR OTHERWISE IN
-        LAW OR FROM COURSE OF DEALING, COURSE OF PERFORMANCE, OR USE IN TRADE.
-        For clarity, the terms of this Agreement, other than the relevant
-        definitions in Section 1 and this Section 2(a) do not apply to
-        CockroachDB Core.
+(b) License to CockroachDB Self-hosted.
 
-    (b) License to CockroachDB Enterprise Edition.
+(i) Grant of Copyright License: Subject to the terms of this Agreement, Licensor
+hereby grants to You a worldwide, non-exclusive, non-transferable limited
+license to reproduce, prepare Enterprise Derivative Works (as defined below) of,
+publicly display, publicly perform, sublicense, and distribute CockroachDB
+Self-hosted for Your business purposes, for so long as You are not in violation
+of this Section 2(b) and are current on all payments required by Section 4
+below.
 
-      i   Grant of Copyright License: Subject to the terms of this Agreement,
-          Licensor hereby grants to You a worldwide, non-exclusive,
-          non-transferable limited license to reproduce, prepare Enterprise
-          Derivative Works (as defined below) of, publicly display, publicly
-          perform, sublicense, and distribute CockroachDB Enterprise Edition
-          for Your business purposes, for so long as You are not in violation
-          of this Section 2(b) and are current on all payments required by
-          Section 4 below.
+(ii) Grant of Patent License: Subject to the terms of this Agreement, Licensor
+hereby grants to You a worldwide, non-exclusive, non-transferable limited patent
+license to make, have made, use, offer to sell, sell, import, and otherwise
+transfer CockroachDB Self-hosted, where such license applies only to those
+patent claims licensable by Licensor that are necessarily infringed by their
+Contribution(s) alone or by combination of their Contribution(s) with the Work
+to which such Contribution(s) was submitted. If You institute patent litigation
+against any entity (including a cross-claim or counterclaim in a lawsuit)
+alleging that the Work or a Contribution incorporated within the Work
+constitutes direct or contributory patent infringement, then any patent licenses
+granted to You under this License for that Work shall terminate as of the date
+such litigation is filed.
 
-      ii  Grant of Patent License: Subject to the terms of this Agreement,
-          Licensor hereby grants to You a worldwide, non-exclusive,
-          non-transferable limited patent license to make, have made, use,
-          offer to sell, sell, import, and otherwise transfer CockroachDB
-          Enterprise Edition, where such license applies only to those patent
-          claims licensable by Licensor that are necessarily infringed by
-          their Contribution(s) alone or by combination of their
-          Contribution(s) with the Work to which such Contribution(s) was
-          submitted.  If You institute patent litigation against any entity
-          (including a cross-claim or counterclaim in a lawsuit) alleging that
-          the Work or a Contribution incorporated within the Work constitutes
-          direct or contributory patent infringement, then any patent licenses
-          granted to You under this License for that Work shall terminate as
-          of the date such litigation is filed.
+(iii) License to Third Party Works: From time to time Cockroach Labs may use, or
+provide You access to, Third Party Works in connection with CockroachDB
+Self-hosted. You acknowledge and agree that in addition to this Agreement, Your
+use of Third Party Works is subject to all other terms and conditions set forth
+in the License provided with or contained in such Third Party Works. Some Third
+Party Works may be licensed to You solely for use with CockroachDB Self-hosted
+under the terms of a third party License, or as otherwise notified by Cockroach
+Labs, and not under the terms of this Agreement. You agree that the owners and
+third party licensors of Third Party Works are intended third party
+beneficiaries to this Agreement.
 
-      iii License to Third Party Works: From time to time Cockroach Labs may
-          use, or provide You access to, Third Party Works in connection with
-          CockroachDB Enterprise Edition. You acknowledge and agree that in
-          addition to this Agreement, Your use of Third Party Works is subject
-          to all other terms and conditions set forth in the License provided
-          with or contained in such Third Party Works. Some Third Party Works
-          may be licensed to You solely for use with CockroachDB Enterprise
-          Edition under the terms of a third party License, or as otherwise
-          notified by Cockroach Labs, and not under the terms of this
-          Agreement. You agree that the owners and third party licensors of
-          Third Party Works are intended third party beneficiaries to this
-          Agreement.
+3. Support. From time to time, in its sole discretion, Cockroach Labs may offer
+professional services or support for CockroachDB, which may now or in the future
+be subject to additional fees.
 
-  3. Support.  From time to time, in its sole discretion, Cockroach Labs may
-     offer professional services or support for CockroachDB, which may now or in
-     the future be subject to additional fees.
+4. Fees for CockroachDB Self-hosted or CockroachDB Support.
 
-  4. Fees for CockroachDB Enterprise Edition or CockroachDB Support.
+(a) Fees. The License to CockroachDB Self-hosted is conditioned upon Your
+entering into a signed written agreement with Cockroach Labs for its use (a
+"Paid Enterprise License") and timely paying Cockroach Labs for such Paid
+Enterprise License; provided that features of CockroachDB Self-hosted that are
+not designated as "Enterprise features" at
+https://www.cockroachlabs.com/docs/stable/enterprise-licensing and do not
+require a license key (e.g. the feature does not require the use of the
+‘enterprise.license’ cluster setting, and the software has not been modified to
+remove such a requirement) may be used for free under the terms of the Agreement
+without a Paid Enterprise License. Any professional services or support for
+CockroachDB may also be subject to Your payment of fees, which will be specified
+by Cockroach Labs when you sign up to receive such professional services or
+support. Cockroach Labs reserves the right to change the fees at any time with
+prior written notice; for recurring fees, any such adjustments will take effect
+as of the next pay period.
 
-    (a) Fees. The License to CockroachDB Enterprise Edition is conditioned
-        upon Your entering into a signed written agreement with Cockroach Labs
-        for its use (a “Paid Enterprise License”) and timely paying Cockroach
-        Labs for such Paid Enterprise License; provided that features of
-        CockroachDB Enterprise Edition that are not designated as “Enterprise
-        features” at
+(b) Overdue Payments and Taxes. Overdue payments are subject to a service charge
+equal to the lesser of 1.5% per month or the maximum legal interest rate allowed
+by law, and You shall pay all Cockroach Labs’ reasonable costs of collection,
+including court costs and attorneys’ fees. Fees are stated and payable in U.S.
+dollars and are exclusive of all sales, use, value added and similar taxes,
+duties, withholdings and other governmental assessments (but excluding taxes
+based on Cockroach Labs’ income) that may be levied on the transactions
+contemplated by this Agreement in any jurisdiction, all of which are Your
+responsibility unless you have provided Cockroach Labs with a valid tax-exempt
+certificate.
 
-            https://www.cockroachlabs.com/docs/stable/enterprise-licensing.html
+(c) Record-keeping and Audit. If fees for CockroachDB Self-hosted are based on
+the number of cores or servers running on CockroachDB Self-hosted or another
+use-based unit of measurement, You must maintain complete and accurate records
+with respect Your use of CockroachDB Self-hosted and will provide such records
+to Cockroach Labs for inspection or audit upon Cockroach Labs’ reasonable
+request. If an inspection or audit uncovers additional usage by You for which
+fees are owed under this Agreement, then You shall pay for such additional usage
+at Cockroach Labs’ then-current rates.
 
-        and do not require a license key (e.g. the feature does not require
-        the use of the ‘enterprise.license’ cluster setting, and the software
-        has not been modified to remove such a requirement) may be used for
-        free under the terms of the Agreement without a Paid Enterprise
-        License. Any professional services or support for CockroachDB may also
-        be subject to Your payment of fees, which will be specified by
-        Cockroach Labs when you sign up to receive such professional services
-        or support. Cockroach Labs reserves the right to change the fees at
-        any time with prior written notice; for recurring fees, any such
-        adjustments will take effect as of the next pay period.
+5. Trial License. If You have signed up for a trial or evaluation of CockroachDB
+Self-hosted, Your License to CockroachDB Self-hosted is granted without charge
+for the trial or evaluation period specified when You signed up, or if no term
+was specified, for thirty (30) calendar days, provided that Your License is
+granted solely for purposes of Your internal evaluation of CockroachDB
+Self-hosted during the trial or evaluation period (a "Trial License"). You may
+not use CockroachDB Self-hosted under a Trial License more than once in any
+twelve (12) month period. Cockroach Labs may revoke a Trial License at any time
+and for any reason. Sections 3, 4, 9 and 11 of this Agreement do not apply to
+Trial Licenses.
 
-    (b) Overdue Payments and Taxes. Overdue payments are subject to a service
-        charge equal to the lesser of 1.5% per month or the maximum legal
-        interest rate allowed by law, and You shall pay all Cockroach Labs’
-        reasonable costs of collection, including court costs and attorneys’
-        fees.  Fees are stated and payable in U.S. dollars and are exclusive of
-        all sales, use, value added and similar taxes, duties, withholdings and
-        other governmental assessments (but excluding taxes based on Cockroach
-        Labs’ income) that may be levied on the transactions contemplated by
-        this Agreement in any jurisdiction, all of which are Your responsibility
-        unless you have provided Cockroach Labs with a valid tax-exempt
-        certificate.
+6. Redistribution. You may reproduce and distribute copies of the Work or
+Derivative Works thereof in any medium, with or without modifications, and in
+Source or Object form, provided that You meet the following conditions:
 
-    (c) Record-keeping and Audit.  If fees for CockroachDB Enterprise Edition
-        are based on the number of cores or servers running on CockroachDB
-        Enterprise Edition or another use-based unit of measurement, You must
-        maintain complete and accurate records with respect to Your use of
-        CockroachDB Enterprise Edition and will provide such records to
-        Cockroach Labs for inspection or audit upon Cockroach Labs’ reasonable
-        request.  If an inspection or audit uncovers additional usage by You for
-        which fees are owed under this Agreement, then You shall pay for such
-        additional usage at Cockroach Labs’ then-current rates.
+(a) You must give any other recipients of the Work or Derivative Works a copy of
+this License; and
 
-  5. Trial License.  If You have signed up for a trial or evaluation of
-     CockroachDB Enterprise Edition, Your License to CockroachDB Enterprise
-     Edition is granted without charge for the trial or evaluation period
-     specified when You signed up, or if no term was specified, for thirty (30)
-     calendar days, provided that Your License is granted solely for purposes of
-     Your internal evaluation of CockroachDB Enterprise Edition during the trial
-     or evaluation period (a "Trial License").  You may not use CockroachDB
-     Enterprise Edition under a Trial License more than once in any twelve (12)
-     month period.  Cockroach Labs may revoke a Trial License at any time and
-     for any reason.  Sections 3, 4, 9 and 11 of this Agreement do not apply to
-     Trial Licenses.
+(b) You must cause any modified files to carry prominent notices stating that
+You changed the files; and
 
-  6. Redistribution.  You may reproduce and distribute copies of the Work or
-     Derivative Works thereof in any medium, with or without modifications, and
-     in Source or Object form, provided that You meet the following conditions:
+(c) You must retain, in the Source form of any Derivative Works that You
+distribute, all copyright, patent, trademark, and attribution notices from the
+Source form of the Work, excluding those notices that do not pertain to any part
+of the Derivative Works; and
 
-    (a) You must give any other recipients of the Work or Derivative Works a
-        copy of this License; and
+(d) If the Work includes a "NOTICE" text file as part of its distribution, then
+any Derivative Works that You distribute must include a readable copy of the
+attribution notices contained within such NOTICE file, excluding those notices
+that do not pertain to any part of the Derivative Works, in at least one of the
+following places: within a NOTICE text file distributed as part of the
+Derivative Works; within the Source form or documentation, if provided along
+with the Derivative Works; or, within a display generated by the Derivative
+Works, if and wherever such third-party notices normally appear. The contents of
+the NOTICE file are for informational purposes only and do not modify the
+License. You may add Your own attribution notices within Derivative Works that
+You distribute, alongside or as an addendum to the NOTICE text from the Work,
+provided that such additional attribution notices cannot be construed as
+modifying the License.
 
-    (b) You must cause any modified files to carry prominent notices stating
-        that You changed the files; and
+You may add Your own copyright statement to Your modifications and may provide
+additional or different license terms and conditions for use, reproduction, or
+distribution of Your modifications, or for any such Derivative Works as a whole,
+provided Your use, reproduction, and distribution of the Work otherwise complies
+with the conditions stated in this License.
 
-    (c) You must retain, in the Source form of any Derivative Works that You
-        distribute, all copyright, patent, trademark, and attribution notices
-        from the Source form of the Work, excluding those notices that do not
-        pertain to any part of the Derivative Works; and
+(e) Enterprise Derivative Works: Derivative Works of CockroachDB Self-hosted
+("Enterprise Derivative Works") may be made, reproduced and distributed in any
+medium, with or without modifications, in Source or Object form, provided that
+each Enterprise Derivative Work will be considered to include a License to
+CockroachDB Self-hosted and thus will be subject to the payment of fees to
+Cockroach Labs by any user of the Enterprise Derivative Work.
 
-    (d) If the Work includes a "NOTICE" text file as part of its distribution,
-        then any Derivative Works that You distribute must include a readable
-        copy of the attribution notices contained within such NOTICE file,
-        excluding those notices that do not pertain to any part of the
-        Derivative Works, in at least one of the following places: within a
-        NOTICE text file distributed as part of the Derivative Works; within the
-        Source form or documentation, if provided along with the Derivative
-        Works; or, within a display generated by the Derivative Works, if and
-        wherever such third-party notices normally appear.  The contents of the
-        NOTICE file are for informational purposes only and do not modify the
-        License.  You may add Your own attribution notices within Derivative
-        Works that You distribute, alongside or as an addendum to the NOTICE
-        text from the Work, provided that such additional attribution notices
-        cannot be construed as modifying the License.
+7. Submission of Contributions. Unless You explicitly state otherwise, any
+Contribution intentionally submitted for inclusion in CockroachDB by You to
+Cockroach Labs shall be under the terms and conditions of
+https://cla-assistant.io/cockroachdb/cockroach (which is based off of the Apache
+License), without any additional terms or conditions, payments of royalties or
+otherwise to Your benefit. Notwithstanding the above, nothing herein shall
+supersede or modify the terms of any separate license agreement You may have
+executed with Cockroach Labs regarding such Contributions.
 
-        You may add Your own copyright statement to Your modifications and may
-        provide additional or different license terms and conditions for use,
-        reproduction, or distribution of Your modifications, or for any such
-        Derivative Works as a whole, provided Your use, reproduction, and
-        distribution of the Work otherwise complies with the conditions stated
-        in this License.
+8. Trademarks. This License does not grant permission to use the trade names,
+trademarks, service marks, or product names of Licensor, except as required for
+reasonable and customary use in describing the origin of the Work and
+reproducing the content of the NOTICE file.
 
-    (e) Enterprise Derivative Works: Derivative Works of CockroachDB Enterprise
-        Edition ("Enterprise Derivative Works") may be made, reproduced and
-        distributed in any medium, with or without modifications, in Source or
-        Object form, provided that each Enterprise Derivative Work will be
-        considered to include a License to CockroachDB Enterprise Edition and
-        thus will be subject to the payment of fees to Cockroach Labs by any
-        user of the Enterprise Derivative Work.
+9. Limited Warranty.
 
-  7. Submission of Contributions. Unless You explicitly state otherwise, any
-     Contribution intentionally submitted for inclusion in CockroachDB by You to
-     Cockroach Labs shall be under the terms and conditions of
+(a) Warranties. Cockroach Labs warrants to You that: (i) CockroachDB Self-hosted
+will materially perform in accordance with the applicable documentation for
+ninety (90) days after initial delivery to You; and (ii) any professional
+services performed by Cockroach Labs under this Agreement will be performed in a
+workmanlike manner, in accordance with general industry standards.
 
-         https://cla-assistant.io/cockroachdb/cockroach
+(b) Exclusions. Cockroach Labs’ warranties in this Section 9 do not extend to
+problems that result from: (i) Your failure to implement updates issued by
+Cockroach Labs during the warranty period; (ii) any alterations or additions
+(including Enterprise Derivative Works and Contributions) to CockroachDB not
+performed by or at the direction of Cockroach Labs; (iii) failures that are not
+reproducible by Cockroach Labs; (iv) operation of CockroachDB Self-hosted in
+violation of this Agreement or not in accordance with its documentation; (v)
+failures caused by software, hardware or products not licensed or provided by
+Cockroach Labs hereunder; or (vi) Third Party Works.
 
-     (which is based off of the Apache License), without any additional terms or
-     conditions, payments of royalties or otherwise to Your benefit.
-     Notwithstanding the above, nothing herein shall supersede or modify the
-     terms of any separate license agreement You may have executed with
-     Cockroach Labs regarding such Contributions.
+(c) Remedies. In the event of a breach of a warranty under this Section 9,
+Cockroach Labs will, at its discretion and cost, either repair, replace or
+re-perform the applicable Works or services or refund a portion of fees
+previously paid to Cockroach Labs that are associated with the defective Works
+or services. This is Your exclusive remedy, and Cockroach Labs’ sole liability,
+arising in connection with the limited warranties herein.
 
-  8. Trademarks.  This License does not grant permission to use the trade names,
-     trademarks, service marks, or product names of Licensor, except as required
-     for reasonable and customary use in describing the origin of the Work and
-     reproducing the content of the NOTICE file.
+10. Disclaimer of Warranty. Except as set out in Section 9, unless required by
+applicable law, Licensor provides the Work (and each Contributor provides its
+Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied, arising out of course of dealing, course of
+performance, or usage in trade, including, without limitation, any warranties or
+conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, CORRECTNESS,
+RELIABILITY, or FITNESS FOR A PARTICULAR PURPOSE, all of which are hereby
+disclaimed. You are solely responsible for determining the appropriateness of
+using or redistributing Works and assume any risks associated with Your exercise
+of permissions under the applicable License for such Works.
 
-  9. Limited Warranty.
+11. Limited Indemnity.
 
-    (a) Warranties.  Cockroach Labs warrants to You that: (i) CockroachDB
-        Enterprise Edition will materially perform in accordance with the
-        applicable documentation for ninety (90) days after initial delivery to
-        You; and (ii) any professional services performed by Cockroach Labs
-        under this Agreement will be performed in a workmanlike manner, in
-        accordance with general industry standards.
+(a) Indemnity. Cockroach Labs will defend, indemnify and hold You harmless
+against any third party claims, liabilities or expenses incurred (including
+reasonable attorneys’ fees), as well as amounts finally awarded in a settlement
+or a non-appealable judgement by a court ("Losses"), to the extent arising from
+any claim or allegation by a third party that CockroachDB Self-hosted infringes
+or misappropriates a valid United States patent, copyright or trade secret right
+of a third party; provided that You give Cockroach Labs: (i) prompt written
+notice of any such claim or allegation; (ii) sole control of the defense and
+settlement thereof; and (iii) reasonable cooperation and assistance in such
+defense or settlement. If any Work within CockroachDB Self-hosted becomes or, in
+Cockroach Labs’ opinion, is likely to become, the subject of an injunction,
+Cockroach Labs may, at its option, (A) procure for You the right to continue
+using such Work, (B) replace or modify such Work so that it becomes
+non-infringing without substantially compromising its functionality, or, if (A)
+and (B) are not commercially practicable, then (C) terminate Your license to the
+allegedly infringing Work and refund to You a prorated portion of the prepaid
+and unearned fees for such infringing Work. The foregoing states the entire
+liability of Cockroach Labs with respect to infringement of patents, copyrights,
+trade secrets or other intellectual property rights.
 
-    (b) Exclusions.  Cockroach Labs’ warranties in this Section 9 do not extend
-        to problems that result from: (i) Your failure to implement updates
-        issued by Cockroach Labs during the warranty period; (ii) any
-        alterations or additions (including Enterprise Derivative Works and
-        Contributions) to CockroachDB not performed by or at the direction of
-        Cockroach Labs; (iii) failures that are not reproducible by Cockroach
-        Labs; (iv) operation of CockroachDB Enterprise Edition in violation of
-        this Agreement or not in accordance with its documentation; (v) failures
-        caused by software, hardware or products not licensed or provided by
-        Cockroach Labs hereunder; or (vi) Third Party Works.
+(b) Exclusions. The foregoing obligations shall not apply to: (i) Works modified
+by any party other than Cockroach Labs (including Enterprise Derivative Works
+and Contributions), if the alleged infringement relates to such modification,
+(ii) Works combined or bundled with any products, processes or materials not
+provided by Cockroach Labs where the alleged infringement relates to such
+combination, (iii) use of a version of CockroachDB Self-hosted other than the
+version that was current at the time of such use, as long as a non-infringing
+version had been released, (iv) any Works created to Your specifications, (v)
+infringement or misappropriation of any proprietary right in which You have an
+interest, or (vi) Third Party Works. You will defend, indemnify and hold
+Cockroach Labs harmless against any Losses arising from any such claim or
+allegation, subject to conditions reciprocal to those in Section 11(a).
 
-    (c) Remedies.  In the event of a breach of a warranty under this Section 9,
-        Cockroach Labs will, at its discretion and cost, either repair, replace
-        or re-perform the applicable Works or services or refund a portion of
-        fees previously paid to Cockroach Labs that are associated with the
-        defective Works or services. This is Your exclusive remedy, and
-        Cockroach Labs’ sole liability, arising in connection with the limited
-        warranties herein.
+12. Limitation of Liability. In no event and under no legal or equitable theory,
+whether in tort (including negligence), contract, or otherwise, unless required
+by applicable law (such as deliberate and grossly negligent acts), and
+notwithstanding anything in this Agreement to the contrary, shall Licensor or
+any Contributor be liable to You for (i) any amounts in excess, in the
+aggregate, of the fees paid by You to Cockroach Labs under this Agreement in the
+twelve (12) months preceding the date the first cause of liability arose), or
+(ii) any indirect, special, incidental, punitive, exemplary, reliance, or
+consequential damages of any character arising as a result of this Agreement or
+out of the use or inability to use the Work (including but not limited to
+damages for loss of goodwill, profits, data or data use, work stoppage, computer
+failure or malfunction, cost of procurement of substitute goods, technology or
+services, or any and all other commercial damages or losses), even if such
+Licensor or Contributor has been advised of the possibility of such damages.
+THESE LIMITATIONS SHALL APPLY NOTWITHSTANDING THE FAILURE OF THE ESSENTIAL
+PURPOSE OF ANY LIMITED REMEDY.
 
-  10. Disclaimer of Warranty.  Except as set out in Section 9, unless required
-      by applicable law, Licensor provides the Work (and each Contributor
-      provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR
-      CONDITIONS OF ANY KIND, either express or implied, arising out of course
-      of dealing, course of performance, or usage in trade, including, without
-      limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT,
-      MERCHANTABILITY, CORRECTNESS, RELIABILITY, or FITNESS FOR A PARTICULAR
-      PURPOSE, all of which are hereby disclaimed.  You are solely responsible
-      for determining the appropriateness of using or redistributing Works and
-      assume any risks associated with Your exercise of permissions under the
-      applicable License for such Works.
+13. Accepting Warranty or Additional Liability. While redistributing Works or
+Derivative Works thereof, and without limiting your obligations under Section 6,
+You may choose to offer, and charge a fee for, acceptance of support, warranty,
+indemnity, or other liability obligations and/or rights consistent with this
+License. However, in accepting such obligations, You may act only on Your own
+behalf and on Your sole responsibility, not on behalf of any other Contributor,
+and only if You agree to indemnify, defend, and hold Cockroach Labs and each
+other Contributor harmless for any liability incurred by, or claims asserted
+against, such Contributor by reason of your accepting any such warranty or
+additional liability.
 
-  11. Limited Indemnity.
+14. General.
 
-    (a) Indemnity.  Cockroach Labs will defend, indemnify and hold You harmless
-        against any third party claims, liabilities or expenses incurred
-        (including reasonable attorneys’ fees), as well as amounts finally
-        awarded in a settlement or a non-appealable judgement by a court
-        ("Losses"), to the extent arising from any claim or allegation by a
-        third party that CockroachDB Enterprise Edition infringes or
-        misappropriates a valid United States patent, copyright or trade secret
-        right of a third party; provided that You give Cockroach Labs: (i)
-        prompt written notice of any such claim or allegation; (ii) sole control
-        of the defense and settlement thereof; and (iii) reasonable cooperation
-        and assistance in such defense or settlement.  If any Work within
-        CockroachDB Enterprise Edition becomes or, in Cockroach Labs’ opinion,
-        is likely to become, the subject of an injunction, Cockroach Labs may,
-        at its option, (A) procure for You the right to continue using such
-        Work, (B) replace or modify such Work so that it becomes non-infringing
-        without substantially compromising its functionality, or, if (A) and (B)
-        are not commercially practicable, then (C) terminate Your license to the
-        allegedly infringing Work and refund to You a prorated portion of the
-        prepaid and unearned fees for such infringing Work.  The foregoing
-        states the entire liability of Cockroach Labs with respect to
-        infringement of patents, copyrights, trade secrets or other intellectual
-        property rights.
+(a) Relationship of Parties. You and Cockroach Labs are independent contractors,
+and nothing herein shall be deemed to constitute either party as the agent or
+representative of the other or both parties as joint venturers or partners for
+any purpose.
 
-    (b) Exclusions.  The foregoing obligations shall not apply to: (i) Works
-        modified by any party other than Cockroach Labs (including Enterprise
-        Derivative Works and Contributions), if the alleged infringement relates
-        to such modification, (ii) Works combined or bundled with any products,
-        processes or materials not provided by Cockroach Labs where the alleged
-        infringement relates to such combination, (iii) use of a version of
-        CockroachDB Enterprise Edition other than the version that was current
-        at the time of such use, as long as a non-infringing version had been
-        released, (iv) any Works created to Your specifications, (v)
-        infringement or misappropriation of any proprietary right in which You
-        have an interest, or (vi) Third Party Works.  You will defend, indemnify
-        and hold Cockroach Labs harmless against any Losses arising from any
-        such claim or allegation, subject to conditions reciprocal to those in
-        Section 11(a).
+(b) Export Control. You shall comply with the U.S. Foreign Corrupt Practices Act
+and all applicable export laws, restrictions and regulations of the U.S.
+Department of Commerce, and any other applicable U.S. and foreign authority.
 
-  12. Limitation of Liability.  In no event and under no legal or equitable
-      theory, whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts), and notwithstanding anything in this Agreement to the
-      contrary, shall Licensor or any Contributor be liable to You for (i) any
-      amounts in excess, in the aggregate, of the fees paid by You to Cockroach
-      Labs under this Agreement in the twelve (12) months preceding the date the
-      first cause of liability arose), or (ii) any indirect, special,
-      incidental, punitive, exemplary, reliance, or consequential damages of any
-      character arising as a result of this Agreement or out of the use or
-      inability to use the Work (including but not limited to damages for loss
-      of goodwill, profits, data or data use, work stoppage, computer failure or
-      malfunction, cost of procurement of substitute goods, technology or
-      services, or any and all other commercial damages or losses), even if such
-      Licensor or Contributor has been advised of the possibility of such
-      damages. THESE LIMITATIONS SHALL APPLY NOTWITHSTANDING THE FAILURE OF THE
-      ESSENTIAL PURPOSE OF ANY LIMITED REMEDY.
+(c) Assignment. This Agreement and the rights and obligations herein may not be
+assigned or transferred, in whole or in part, by You without the prior written
+consent of Cockroach Labs. Any assignment in violation of this provision is
+void. This Agreement shall be binding upon, and inure to the benefit of, the
+successors and permitted assigns of the parties.
 
-  13. Accepting Warranty or Additional Liability.  While redistributing Works or
-      Derivative Works thereof, and without limiting your obligations under
-      Section 6, You may choose to offer, and charge a fee for, acceptance of
-      support, warranty, indemnity, or other liability obligations and/or rights
-      consistent with this License.  However, in accepting such obligations, You
-      may act only on Your own behalf and on Your sole responsibility, not on
-      behalf of any other Contributor, and only if You agree to indemnify,
-      defend, and hold Cockroach Labs and each other Contributor harmless for
-      any liability incurred by, or claims asserted against, such Contributor by
-      reason of your accepting any such warranty or additional liability.
+(d) Governing Law. This Agreement shall be governed by and construed under the
+laws of the State of New York and the United States without regard to conflicts
+of laws provisions thereof, and without regard to the Uniform Computer
+Information Transactions Act.
 
-  14. General.
+(e) Attorneys’ Fees. In any action or proceeding to enforce rights under this
+Agreement, the prevailing party shall be entitled to recover its costs, expenses
+and attorneys’ fees.
 
-    (a) Relationship of Parties.  You and Cockroach Labs are independent
-        contractors, and nothing herein shall be deemed to constitute either
-        party as the agent or representative of the other or both parties as
-        joint venturers or partners for any purpose.
+(f) Severability. If any provision of this Agreement is held to be invalid,
+illegal or unenforceable in any respect, that provision shall be limited or
+eliminated to the minimum extent necessary so that this Agreement otherwise
+remains in full force and effect and enforceable.
 
-    (b) Export Control.  You shall comply with the U.S. Foreign Corrupt
-        Practices Act and all applicable export laws, restrictions and
-        regulations of the U.S. Department of Commerce, and any other applicable
-        U.S. and foreign authority.
-
-    (c) Assignment.  This Agreement and the rights and obligations herein may
-        not be assigned or transferred, in whole or in part, by You without the
-        prior written consent of Cockroach Labs.  Any assignment in violation of
-        this provision is void.  This Agreement shall be binding upon, and inure
-        to the benefit of, the successors and permitted assigns of the parties.
-
-    (d) Governing Law.  This Agreement shall be governed by and construed under
-        the laws of the State of New York and the United States without regard
-        to conflicts of laws provisions thereof, and without regard to the
-        Uniform Computer Information Transactions Act.
-
-    (e) Attorneys’ Fees.  In any action or proceeding to enforce rights under
-        this Agreement, the prevailing party shall be entitled to recover its
-        costs, expenses and attorneys’ fees.
-
-    (f) Severability.  If any provision of this Agreement is held to be invalid,
-        illegal or unenforceable in any respect, that provision shall be limited
-        or eliminated to the minimum extent necessary so that this Agreement
-        otherwise remains in full force and effect and enforceable.
-
-    (g) Entire Agreement; Waivers; Modification.  This Agreement constitutes the
-        entire agreement between the parties relating to the subject matter
-        hereof and supersedes all proposals, understandings, or discussions,
-        whether written or oral, relating to the subject matter of this
-        Agreement and all past dealing or industry custom. The failure of either
-        party to enforce its rights under this Agreement at any time for any
-        period shall not be construed as a waiver of such rights. No changes,
-        modifications or waivers to this Agreement will be effective unless in
-        writing and signed by both parties.
+(g) Entire Agreement; Waivers; Modification. This Agreement constitutes the
+entire agreement between the parties relating to the subject matter hereof and
+supersedes all proposals, understandings, or discussions, whether written or
+oral, relating to the subject matter of this Agreement and all past dealing or
+industry custom. The failure of either party to enforce its rights under this
+Agreement at any time for any period shall not be construed as a waiver of such
+rights. No changes, modifications or waivers to this Agreement will be effective
+unless in writing and signed by both parties.


### PR DESCRIPTION
Update /licenses/CCT.txt to reflect latest license at https://www.cockroachlabs.com/cockroachdb-community-license/

Epic: REL-531
Release note (general change): Update CCT license.