### PR TITLE
logictest: unskip stressrace config for logic tests

### DIFF
--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -4060,8 +4060,6 @@ func RunLogicTest(
 	// Note: there is special code in teamcity-trigger/main.go to run this package
 	// with less concurrency in the nightly stress runs. If you see problems
 	// please make adjustments there.
-	// As of 6/4/2019, the logic tests never complete under race.
-	skip.UnderRace(t, "logic tests and race detector don't mix: #37993")
 
 	// This test relies on repeated sequential storage.EventuallyFileOnlySnapshot
 	// acquisitions. Reduce the max wait time for each acquisition to speed up


### PR DESCRIPTION
It seems like this was skipped long time ago without proper investigation. Running just one test file manually uncovered a couple of races, so let's re-enable this.

Epic: None

Release note: None