### PR TITLE
upgrade: Increase timeout for TestTenantAutoUpgrade under stress

### DIFF
--- a/pkg/ccl/kvccl/kvtenantccl/upgradeccl/tenant_upgrade_test.go
+++ b/pkg/ccl/kvccl/kvtenantccl/upgradeccl/tenant_upgrade_test.go
@@ -233,7 +233,7 @@ func TestTenantAutoUpgrade(t *testing.T) {
 		UpgradeTo roachpb.Version
 	}
 	succeedsSoon := 20 * time.Second
-	if util.RaceEnabled {
+	if util.RaceEnabled || skip.Stress() {
 		succeedsSoon = 60 * time.Second
 	}
 	// Wait for auto upgrade status to be received by the testing knob.


### PR DESCRIPTION
Test times out under stress. With updated timeout it now passes on a local repro.

Fixes: #112158

Release note: None