### PR TITLE
roachtest: add WITH unsafe_restore_incompatible_version

### DIFF
--- a/pkg/cmd/roachtest/tests/restore.go
+++ b/pkg/cmd/roachtest/tests/restore.go
@@ -897,7 +897,7 @@ func (rd *restoreDriver) run(ctx context.Context, target string) error {
 	if err != nil {
 		return errors.Wrapf(err, "failed to connect to node 1; running restore")
 	}
-	_, err = conn.ExecContext(ctx, rd.restoreCmd(target, ""))
+	_, err = conn.ExecContext(ctx, rd.restoreCmd(target, "WITH unsafe_restore_incompatible_version"))
 	return err
 }
 
@@ -909,7 +909,7 @@ func (rd *restoreDriver) runDetached(
 		return 0, errors.Wrapf(err, "failed to connect to node %d; running restore detached", node)
 	}
 	if _, err = db.ExecContext(ctx, rd.restoreCmd(target,
-		"WITH DETACHED")); err != nil {
+		"WITH DETACHED, unsafe_restore_incompatible_version")); err != nil {
 		return 0, err
 	}
 	var jobID jobspb.JobID


### PR DESCRIPTION
This is a test only change to allow  a restore roachtest to run on fixtures outside their compatability windows. This is a stop gap as we upgrade the fixtures to a compatable version.

Fixes: #112522
Fixes: #112521
Fixes: #112520
Fixes: #112519
Fixes: #112518
Fixes: #112522
Fixes: #112522

Release note: None