### PR TITLE
release-23.1: changefeedccl: check changefeed status in TestAlterChangefeedAddTargetsDuringSchemaChangeError

### DIFF
--- a/pkg/ccl/changefeedccl/alter_changefeed_test.go
+++ b/pkg/ccl/changefeedccl/alter_changefeed_test.go
@@ -1253,6 +1253,14 @@ func TestAlterChangefeedAddTargetsDuringSchemaChangeError(t *testing.T) {
 			if atomic.LoadInt32(&foundCheckpoint) != 0 {
 				return nil
 			}
+			if err := jobFeed.FetchTerminalJobErr(); err != nil {
+				t.Fatal(err)
+			}
+			runningStatus, err := jobFeed.FetchRunningStatus()
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Logf("changefeed running status: %s", runningStatus)
 			return errors.New("waiting for checkpoint")
 		})
 


### PR DESCRIPTION
Merging into release-23.1

---

### changefeedccl: check changefeed status in TestAlterChangefeedAddTargetsDuringSchemaChangeError

In the latest failure of `TestAlterChangefeedAddTargetsDuringSchemaChangeError` in #111390, we stop logging resolved message after 1 second. This indicates that changefeeds and/or rangefeeds stop running during the test.

This change adds polling and logging for the changefeed's status while we wait for an initial checkpoint. Hopefully, this makes the root cause for test failure apparent.

Release note: None
Informs: #111390
Epic: None

Release justification: Test only change.