### PR TITLE
streamingccl: unskip TestStreamingRegionalConstraint

### DIFF
--- a/pkg/ccl/streamingccl/streamingest/replication_stream_e2e_test.go
+++ b/pkg/ccl/streamingccl/streamingest/replication_stream_e2e_test.go
@@ -1169,8 +1169,8 @@ func TestLoadProducerAndIngestionProgress(t *testing.T) {
 func TestStreamingRegionalConstraint(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	skip.WithIssue(t, 111541)
 	skip.UnderStressRace(t, "takes too long under stress race")
+	skip.UnderStress(t, "the allocator machinery stuggles with cpu contention, which can cause the test to timeout")
 
 	ctx := context.Background()
 	regions := []string{"mars", "venus", "mercury"}


### PR DESCRIPTION
This patch unskips TestStreamingRegionalConstraint under a non-stress build.

Fixes #111541

Release note: none