### PR TITLE
roachtest: halve backup-restore/round-trip runtime

### DIFF
--- a/pkg/cmd/roachtest/tests/backup_restore_roundtrip.go
+++ b/pkg/cmd/roachtest/tests/backup_restore_roundtrip.go
@@ -30,6 +30,8 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
+const numFullBackups = 5
+
 func registerBackupRestoreRoundTrip(r registry.Registry) {
 	// backup-restore/round-trip tests that a round trip of creating a backup and
 	// restoring the created backup create the same objects.
@@ -76,11 +78,6 @@ func backupRestoreRoundTrip(ctx context.Context, t test.Test, c cluster.Cluster)
 			return err
 		}
 
-		stopBackgroundCommands, err := runBackgroundWorkload()
-		if err != nil {
-			return err
-		}
-
 		tables, err := testUtils.loadTablesForDBs(ctx, t.L(), testRNG, dbs...)
 		if err != nil {
 			return err
@@ -98,7 +95,12 @@ func backupRestoreRoundTrip(ctx context.Context, t test.Test, c cluster.Cluster)
 			return err
 		}
 
-		for i := 0; i < 10; i++ {
+		stopBackgroundCommands, err := runBackgroundWorkload()
+		if err != nil {
+			return err
+		}
+
+		for i := 0; i < numFullBackups; i++ {
 			allNodes := labeledNodes{Nodes: roachNodes, Version: clusterupgrade.MainVersion}
 			bspec := backupSpec{
 				PauseProbability: pauseProbability,


### PR DESCRIPTION
This patch reduces the number of full backups taken from 10 to 5, halving the run time of this test. I made this change because I don't think the extra 5 full backups adds significantly more coverage. Further, I'd like to add a new variant for this test with small ranges (#112120), and the lowered runtime will be less painful on the roachtest nightly runtime and pocketbook.

This patch also moves the workload to start after all cluster settings have been set.

Informs #112120

Release note: none