### PR TITLE
sql: fix db/schema in information_schema.referential_constraints

### DIFF
--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -960,12 +960,22 @@ https://www.postgresql.org/docs/9.5/infoschema-referential-constraints.html`,
 				if err != nil {
 					return err
 				}
+				// Note: Cross DB references are deprecated, but this should be
+				// a cached look up when they don't exist.
+				refDB, err := p.Descriptors().ByID(p.Txn()).Get().Database(ctx, refTable.GetParentID())
+				if err != nil {
+					return err
+				}
+				refSchema, err := p.Descriptors().ByID(p.Txn()).Get().Schema(ctx, refTable.GetParentSchemaID())
+				if err != nil {
+					return err
+				}
 				if err := addRow(
 					dbNameStr,                                // constraint_catalog
 					scNameStr,                                // constraint_schema
 					tree.NewDString(fk.GetName()),            // constraint_name
-					dbNameStr,                                // unique_constraint_catalog
-					scNameStr,                                // unique_constraint_schema
+					tree.NewDString(refDB.GetName()),         // unique_constraint_catalog
+					tree.NewDString(refSchema.GetName()),     // unique_constraint_schema
 					tree.NewDString(refConstraint.GetName()), // unique_constraint_name
 					matchType,                                // match_option
 					dStringForFKAction(fk.OnUpdate()),        // update_rule

--- a/pkg/sql/logictest/testdata/logic_test/fk
+++ b/pkg/sql/logictest/testdata/logic_test/fk
@@ -3880,6 +3880,14 @@ select * from "".crdb_internal.cross_db_references ORDER BY object_name
 db2  public  child   db1  public  parent  table foreign key reference
 db2  public  child2  db1  public  parent  table foreign key reference
 
+# Ensure later tests only operate on the test database to avoid
+# confusion.
+statement ok
+USE test;
+
+statement ok
+SET CLUSTER SETTING sql.cross_db_fks.enabled = FALSE
+
 
 # Test that foreign keys cannot reference columns that are indexed by a partial
 # unique index or a partial unique constraint. Partial unique indexes and
@@ -4166,3 +4174,15 @@ create table t104546_fk_src (a int primary key, b int);
 
 statement error pgcode 42703 column "b" does not exist
 alter table t104546 add constraint con foreign key (b) references t104546_fk_src(b);
+
+statement ok
+create schema sc1;
+create schema sc2;
+create table sc1.parent (p int primary key);
+create table sc2.child(p int primary key, r int REFERENCES sc1.parent (p));
+
+query TTTTTT rowsort
+SELECT constraint_catalog, constraint_schema, constraint_name, unique_constraint_catalog, unique_constraint_schema, unique_constraint_name
+FROM  information_schema.referential_constraints WHERE unique_constraint_schema='sc1';
+----
+test  sc2  child_r_fkey  test  sc1  parent_pkey


### PR DESCRIPTION
Previously, the unique constraint schema / database columns were not properly resolved and instead used the names from the parent table. This was incorrect because constraint references can be across schema or databases (deprecated). This patch, adds logic to resolve the database/schema name for the unqiue constraints instead of using the same ones as the parent table.

Fixes: #111419

Release note (bug fix): The unique_constraint_catalog and unique_constraint_schema columns in
information_schema.referential_constraints could be incorrect for cross schema / cross DB references.