### PR TITLE
*: add jobspb.ScheduleID to distinguish ids

### DIFF
--- a/pkg/ccl/backupccl/backup_job.go
+++ b/pkg/ccl/backupccl/backup_job.go
@@ -1165,7 +1165,7 @@ func getScheduledBackupExecutionArgsFromSchedule(
 	ctx context.Context,
 	env scheduledjobs.JobSchedulerEnv,
 	storage jobs.ScheduledJobStorage,
-	scheduleID int64,
+	scheduleID jobspb.ScheduleID,
 ) (*jobs.ScheduledJob, *backuppb.ScheduledBackupExecutionArgs, error) {
 	// Load the schedule that has spawned this job.
 	sj, err := storage.Load(ctx, env, scheduleID)
@@ -1203,7 +1203,7 @@ func planSchedulePTSChaining(
 	}
 
 	_, args, err := getScheduledBackupExecutionArgsFromSchedule(
-		ctx, env, jobs.ScheduledJobTxn(txn), createdBy.ID,
+		ctx, env, jobs.ScheduledJobTxn(txn), createdBy.ScheduleID(),
 	)
 	if err != nil {
 		return err
@@ -2028,7 +2028,7 @@ func (b *backupResumer) maybeNotifyScheduledJobCompletion(
 			return nil
 		}
 
-		scheduleID := int64(tree.MustBeDInt(datums[0]))
+		scheduleID := jobspb.ScheduleID(tree.MustBeDInt(datums[0]))
 		if err := jobs.NotifyJobTermination(ctx, txn, env, b.job.ID(), jobStatus, b.job.Details(), scheduleID); err != nil {
 			return errors.Wrapf(err,
 				"failed to notify schedule %d of completion of job %d", scheduleID, b.job.ID())

--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -658,8 +658,8 @@ func backupPlanHook(
 			ExecutionLocality:               executionLocality,
 			UpdatesClusterMonitoringMetrics: updatesClusterMonitoringMetrics,
 		}
-		if backupStmt.CreatedByInfo != nil && backupStmt.CreatedByInfo.Name == jobs.CreatedByScheduledJobs {
-			initialDetails.ScheduleID = backupStmt.CreatedByInfo.ID
+		if backupStmt.CreatedByInfo != nil {
+			initialDetails.ScheduleID = backupStmt.CreatedByInfo.ScheduleID()
 		}
 
 		// For backups of specific targets, those targets were resolved with this

--- a/pkg/ccl/backupccl/backuppb/BUILD.bazel
+++ b/pkg/ccl/backupccl/backuppb/BUILD.bazel
@@ -46,6 +46,7 @@ go_library(
     deps = [
         "//pkg/cloud",
         "//pkg/jobs",
+        "//pkg/jobs/jobspb",
         "//pkg/multitenant/mtinfopb",
         "//pkg/sql/parser",
         "//pkg/sql/protoreflect",

--- a/pkg/ccl/backupccl/backuppb/backup.go
+++ b/pkg/ccl/backupccl/backuppb/backup.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/cloud"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
+	_ "github.com/cockroachdb/cockroach/pkg/jobs/jobspb" // required for backup.proto
 	"github.com/cockroachdb/cockroach/pkg/multitenant/mtinfopb"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/protoreflect"

--- a/pkg/ccl/backupccl/backuppb/backup.proto
+++ b/pkg/ccl/backupccl/backuppb/backup.proto
@@ -173,14 +173,14 @@ message ScheduledBackupExecutionArgs {
   }
   BackupType backup_type = 1;
   string backup_statement = 2;
-  int64 unpause_on_success = 3;
+  int64 unpause_on_success = 3 [(gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/jobs/jobspb.ScheduleID"];
   bool updates_last_backup_metric = 4;
   // If the schedule is one of the two  that were created when setting up a
   // full+incremental schedule backup, then DependentScheduleID will be set to
   // the schedule ID of the other "dependent" schedule.
   // i.e. the full schedule will have the inc schedules ID and vice versa.
   // A value of 0 indicates that there is no dependent schedule.
-  int64 dependent_schedule_id = 6 [(gogoproto.customname) = "DependentScheduleID"];
+  int64 dependent_schedule_id = 6 [(gogoproto.customname) = "DependentScheduleID", (gogoproto.casttype)="github.com/cockroachdb/cockroach/pkg/jobs/jobspb.ScheduleID"];
 
   // ChainProtectedTimestampRecords indicates that chaining of protected
   // timestamp records is enabled for this schedule. The chaining scheme works

--- a/pkg/ccl/backupccl/create_scheduled_backup.go
+++ b/pkg/ccl/backupccl/create_scheduled_backup.go
@@ -317,7 +317,7 @@ func doCreateBackupSchedules(
 		return err
 	}
 
-	unpauseOnSuccessID := jobs.InvalidScheduleID
+	unpauseOnSuccessID := jobspb.InvalidScheduleID
 
 	var chainProtectedTimestampRecords bool
 	// If needed, create an incremental schedule.
@@ -425,7 +425,7 @@ func setDependentSchedule(
 	storage jobs.ScheduledJobStorage,
 	scheduleExecutionArgs *backuppb.ScheduledBackupExecutionArgs,
 	schedule *jobs.ScheduledJob,
-	dependentID int64,
+	dependentID jobspb.ScheduleID,
 ) error {
 	scheduleExecutionArgs.DependentScheduleID = dependentID
 	any, err := pbtypes.MarshalAny(scheduleExecutionArgs)
@@ -480,7 +480,7 @@ func makeBackupSchedule(
 	label string,
 	recurrence *schedulebase.ScheduleRecurrence,
 	details jobspb.ScheduleDetails,
-	unpauseOnSuccess int64,
+	unpauseOnSuccess jobspb.ScheduleID,
 	updateLastMetricOnSuccess bool,
 	backupNode *tree.Backup,
 	chainProtectedTimestampRecords bool,

--- a/pkg/ccl/backupccl/schedule_exec.go
+++ b/pkg/ccl/backupccl/schedule_exec.go
@@ -366,7 +366,7 @@ func (e *scheduledBackupExecutor) backupSucceeded(
 		e.metrics.RpoMetric.Update(details.(jobspb.BackupDetails).EndTime.GoTime().Unix())
 	}
 
-	if args.UnpauseOnSuccess == jobs.InvalidScheduleID {
+	if args.UnpauseOnSuccess == jobspb.InvalidScheduleID {
 		return nil
 	}
 
@@ -390,7 +390,7 @@ func (e *scheduledBackupExecutor) backupSucceeded(
 	}
 
 	// Clear UnpauseOnSuccess; caller updates schedule.
-	args.UnpauseOnSuccess = jobs.InvalidScheduleID
+	args.UnpauseOnSuccess = jobspb.InvalidScheduleID
 	any, err := pbtypes.MarshalAny(args)
 	if err != nil {
 		return errors.Wrap(err, "marshaling args")
@@ -424,7 +424,7 @@ func extractBackupStatement(sj *jobs.ScheduledJob) (*annotatedBackupStatement, e
 			Backup: backupStmt,
 			CreatedByInfo: &jobs.CreatedByInfo{
 				Name: jobs.CreatedByScheduledJobs,
-				ID:   sj.ScheduleID(),
+				ID:   int64(sj.ScheduleID()),
 			},
 		}, nil
 	}

--- a/pkg/ccl/backupccl/schedule_pts_chaining.go
+++ b/pkg/ccl/backupccl/schedule_pts_chaining.go
@@ -116,7 +116,7 @@ func maybeUpdateSchedulePTSRecord(
 		}
 
 		schedules := jobs.ScheduledJobTxn(txn)
-		scheduleID := int64(tree.MustBeDInt(datums[0]))
+		scheduleID := jobspb.ScheduleID(tree.MustBeDInt(datums[0]))
 		sj, args, err := getScheduledBackupExecutionArgsFromSchedule(
 			ctx, env, schedules, scheduleID,
 		)
@@ -179,7 +179,7 @@ func manageFullBackupPTSChaining(
 	env scheduledjobs.JobSchedulerEnv,
 	backupDetails jobspb.BackupDetails,
 	fullScheduleArgs *backuppb.ScheduledBackupExecutionArgs,
-	scheduleID int64,
+	scheduleID jobspb.ScheduleID,
 ) error {
 	// Let's resolve the dependent incremental schedule as the first step. If the
 	// schedule has been dropped then we can avoid doing unnecessary work.
@@ -269,7 +269,7 @@ func manageIncrementalBackupPTSChaining(
 	pts protectedts.Storage,
 	ptsRecordID *uuid.UUID,
 	tsToProtect hlc.Timestamp,
-	scheduleID int64,
+	scheduleID jobspb.ScheduleID,
 ) error {
 	if ptsRecordID == nil {
 		return errors.AssertionFailedf("unexpected nil pts record id on incremental schedule %d", scheduleID)
@@ -312,11 +312,11 @@ func protectTimestampRecordForSchedule(
 	targetToProtect *ptpb.Target,
 	deprecatedSpansToProtect roachpb.Spans,
 	tsToProtect hlc.Timestamp,
-	scheduleID int64,
+	scheduleID jobspb.ScheduleID,
 ) (uuid.UUID, error) {
 	protectedtsID := uuid.MakeV4()
 	return protectedtsID, pts.Protect(ctx, jobsprotectedts.MakeRecord(
-		protectedtsID, scheduleID, tsToProtect, deprecatedSpansToProtect,
+		protectedtsID, int64(scheduleID), tsToProtect, deprecatedSpansToProtect,
 		jobsprotectedts.Schedules, targetToProtect,
 	))
 }

--- a/pkg/ccl/backupccl/schedule_pts_chaining_test.go
+++ b/pkg/ccl/backupccl/schedule_pts_chaining_test.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/jobs"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobsprotectedts"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/protectedts"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/protectedts/ptpb"
@@ -37,7 +38,7 @@ import (
 // Returns schedule IDs for full and incremental schedules, plus a cleanup function.
 func (th *testHelper) createSchedules(
 	t *testing.T, backupStmt string, opts ...string,
-) (int64, int64, func()) {
+) (jobspb.ScheduleID, jobspb.ScheduleID, func()) {
 	backupOpts := ""
 	if len(opts) > 0 {
 		backupOpts = fmt.Sprintf(" WITH %s", strings.Join(opts, ", "))
@@ -80,7 +81,7 @@ func checkPTSRecord(
 		require.NoError(t, err)
 		return nil
 	}))
-	encodedScheduleID := []byte(strconv.FormatInt(schedule.ScheduleID(), 10))
+	encodedScheduleID := []byte(strconv.FormatInt(int64(schedule.ScheduleID()), 10))
 	require.Equal(t, encodedScheduleID, ptsRecord.Meta)
 	require.Equal(t, jobsprotectedts.GetMetaType(jobsprotectedts.Schedules), ptsRecord.MetaType)
 	require.Equal(t, timestamp, ptsRecord.Timestamp)

--- a/pkg/ccl/changefeedccl/scheduled_changefeed.go
+++ b/pkg/ccl/changefeedccl/scheduled_changefeed.go
@@ -218,7 +218,7 @@ func extractChangefeedStatement(sj *jobs.ScheduledJob) (*annotatedChangefeedStat
 			CreateChangefeed: stmt,
 			CreatedByInfo: &jobs.CreatedByInfo{
 				Name: jobs.CreatedByScheduledJobs,
-				ID:   sj.ScheduleID(),
+				ID:   int64(sj.ScheduleID()),
 			},
 		}, nil
 	}
@@ -393,7 +393,7 @@ func makeChangefeedSchedule(
 func dryRunCreateChangefeed(
 	ctx context.Context,
 	p sql.PlanHookState,
-	scheduleID int64,
+	scheduleID jobspb.ScheduleID,
 	createChangefeedNode *tree.CreateChangefeed,
 ) error {
 	sp, err := p.ExtendedEvalContext().Txn.CreateSavepoint(ctx)
@@ -406,7 +406,7 @@ func dryRunCreateChangefeed(
 			CreateChangefeed: createChangefeedNode,
 			CreatedByInfo: &jobs.CreatedByInfo{
 				Name: jobs.CreatedByScheduledJobs,
-				ID:   scheduleID,
+				ID:   int64(scheduleID),
 			},
 		}
 		changefeedFn, err := planCreateChangefeed(ctx, p, annotated)

--- a/pkg/ccl/changefeedccl/scheduled_changefeed_test.go
+++ b/pkg/ccl/changefeedccl/scheduled_changefeed_test.go
@@ -58,7 +58,7 @@ type testHelper struct {
 	sqlDB            *sqlutils.SQLRunner
 	server           serverutils.TestServerInterface
 	executeSchedules func() error
-	createdSchedules []int64
+	createdSchedules []jobspb.ScheduleID
 }
 
 func newTestHelper(t *testing.T) (*testHelper, func()) {
@@ -101,14 +101,16 @@ func (h *testHelper) clearSchedules(t *testing.T) {
 	sep := ""
 	for _, id := range h.createdSchedules {
 		sb.WriteString(sep)
-		sb.WriteString(strconv.FormatInt(id, 10))
+		sb.WriteString(strconv.FormatInt(int64(id), 10))
 		sep = ", "
 	}
 	h.sqlDB.Exec(t, fmt.Sprintf("DELETE FROM %s WHERE schedule_id IN (%s)",
 		h.env.ScheduledJobsTableName(), sb.String()))
 }
 
-func (h *testHelper) waitForSuccessfulScheduledJob(t *testing.T, scheduleID int64) int64 {
+func (h *testHelper) waitForSuccessfulScheduledJob(
+	t *testing.T, scheduleID jobspb.ScheduleID,
+) int64 {
 	query := "SELECT id FROM " + h.env.SystemJobsTableName() +
 		" WHERE status=$1 AND created_by_type=$2 AND created_by_id=$3"
 	var jobID int64

--- a/pkg/ccl/jobsccl/jobsprotectedtsccl/jobs_protected_ts_test.go
+++ b/pkg/ccl/jobsccl/jobsprotectedtsccl/jobs_protected_ts_test.go
@@ -234,7 +234,7 @@ func testSchedulesProtectedTimestamp(
 			require.NoError(t, schedules.Create(ctx, sj))
 			deprecatedSpansToProtect := roachpb.Spans{{Key: keys.MinKey, EndKey: keys.MaxKey}}
 			targetToProtect := ptpb.MakeClusterTarget()
-			rec = jobsprotectedts.MakeRecord(uuid.MakeV4(), sj.ScheduleID(), ts,
+			rec = jobsprotectedts.MakeRecord(uuid.MakeV4(), int64(sj.ScheduleID()), ts,
 				deprecatedSpansToProtect, jobsprotectedts.Schedules, targetToProtect)
 			return ptp.WithTxn(txn).Protect(ctx, rec)
 		}))

--- a/pkg/jobs/delegate_control_test.go
+++ b/pkg/jobs/delegate_control_test.go
@@ -58,7 +58,7 @@ func TestScheduleControl(t *testing.T) {
 	var recurringNever string
 
 	schedules := ScheduledJobDB(th.cfg.DB)
-	makeSchedule := func(name string, cron string) int64 {
+	makeSchedule := func(name string, cron string) jobspb.ScheduleID {
 		schedule := th.newScheduledJob(t, name, "sql")
 		if cron != "" {
 			require.NoError(t, schedule.SetSchedule(cron))
@@ -116,7 +116,7 @@ func TestScheduleControl(t *testing.T) {
 	})
 
 	t.Run("pause-resume-and-drop-many-schedules", func(t *testing.T) {
-		var scheduleIDs []int64
+		var scheduleIDs []jobspb.ScheduleID
 		for i := 0; i < 10; i++ {
 			scheduleIDs = append(
 				scheduleIDs,

--- a/pkg/jobs/job_scheduler.go
+++ b/pkg/jobs/job_scheduler.go
@@ -103,7 +103,10 @@ func (s scheduledJobStorageTxn) loadCandidateScheduleForExecution(
 
 // lookupNumRunningJobs returns the number of running jobs for the specified schedule.
 func lookupNumRunningJobs(
-	ctx context.Context, scheduleID int64, env scheduledjobs.JobSchedulerEnv, txn isql.Txn,
+	ctx context.Context,
+	scheduleID jobspb.ScheduleID,
+	env scheduledjobs.JobSchedulerEnv,
+	txn isql.Txn,
 ) (int64, error) {
 	lookupStmt := fmt.Sprintf(
 		"SELECT count(*) FROM %s WHERE created_by_type = '%s' AND created_by_id = %d AND status IN %s",

--- a/pkg/jobs/job_scheduler_test.go
+++ b/pkg/jobs/job_scheduler_test.go
@@ -236,7 +236,7 @@ func TestJobSchedulerDaemonGetWaitPeriod(t *testing.T) {
 }
 
 type recordScheduleExecutor struct {
-	executed []int64
+	executed []jobspb.ScheduleID
 }
 
 func (n *recordScheduleExecutor) ExecuteJob(
@@ -338,7 +338,7 @@ func TestJobSchedulerCanBeDisabledWhileSleeping(t *testing.T) {
 
 // We expect the first 2 jobs to be executed.
 type expectedRun struct {
-	id      int64
+	id      jobspb.ScheduleID
 	nextRun interface{} // Interface to support nullable nextRun
 }
 
@@ -377,7 +377,7 @@ func TestJobSchedulerDaemonProcessesJobs(t *testing.T) {
 	// Create few, one-off schedules.
 	const numJobs = 5
 	scheduleRunTime := h.env.Now().Add(time.Hour)
-	var scheduleIDs []int64
+	var scheduleIDs []jobspb.ScheduleID
 	schedules := ScheduledJobDB(h.cfg.DB)
 	for i := 0; i < numJobs; i++ {
 		schedule := h.newScheduledJob(t, "test_job", "SELECT 42")
@@ -421,7 +421,7 @@ func TestJobSchedulerDaemonHonorsMaxJobsLimit(t *testing.T) {
 	// Create few, one-off schedules.
 	const numJobs = 5
 	scheduleRunTime := h.env.Now().Add(time.Hour)
-	var scheduleIDs []int64
+	var scheduleIDs []jobspb.ScheduleID
 	schedules := ScheduledJobDB(h.cfg.DB)
 	for i := 0; i < numJobs; i++ {
 		schedule := h.newScheduledJob(t, "test_job", "SELECT 42")

--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -71,6 +71,16 @@ type CreatedByInfo struct {
 	ID   int64
 }
 
+// ScheduleID return ID as a [jobspb.ScheduleID] iff Name is
+// [CreatedByScheduledJobs]. Otherwise it returns [jobspb.InvalidScheduleID],
+// the zero value.
+func (i *CreatedByInfo) ScheduleID() jobspb.ScheduleID {
+	if i.Name == CreatedByScheduledJobs {
+		return jobspb.ScheduleID(i.ID)
+	}
+	return jobspb.InvalidScheduleID
+}
+
 // Record bundles together the user-managed fields in jobspb.Payload.
 type Record struct {
 	JobID         jobspb.JobID

--- a/pkg/jobs/jobspb/BUILD.bazel
+++ b/pkg/jobs/jobspb/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     name = "jobspb",
     srcs = [
         "jobs.go",
+        "schedule.go",
         "wrap.go",
     ],
     embed = [":jobspb_go_proto"],

--- a/pkg/jobs/jobspb/jobs.go
+++ b/pkg/jobs/jobspb/jobs.go
@@ -10,7 +10,16 @@
 
 package jobspb
 
-import "github.com/cockroachdb/cockroach/pkg/util/tracing/tracingpb"
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing/tracingpb"
+)
+
+// JobID is the ID of a job.
+type JobID = catpb.JobID
+
+// InvalidJobID is the zero value for JobID corresponding to no job.
+const InvalidJobID = catpb.InvalidJobID
 
 // ToText implements the ProtobinExecutionDetailFile interface.
 func (t *TraceData) ToText() []byte {

--- a/pkg/jobs/jobspb/jobs.proto
+++ b/pkg/jobs/jobspb/jobs.proto
@@ -289,7 +289,7 @@ message BackupDetails {
   // to its path.
   string collection_URI = 8 [(gogoproto.customname) = "CollectionURI"];
 
-  int64 schedule_id = 12 [(gogoproto.customname) = "ScheduleID"];
+  int64 schedule_id = 12 [(gogoproto.customname) = "ScheduleID", (gogoproto.casttype) = "ScheduleID"];
 
   // SchedulePTSChainingRecord is used by scheduled backups to chain protected
   // timestamp records. For more details about the chaining scheme refer to the

--- a/pkg/jobs/jobspb/schedule.go
+++ b/pkg/jobs/jobspb/schedule.go
@@ -1,0 +1,19 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package jobspb
+
+import "github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
+
+// ScheduleID is the ID of a job schedule.
+type ScheduleID = catpb.ScheduleID
+
+// InvalidScheduleID is a constant indicating the schedule ID is not valid.
+const InvalidScheduleID = catpb.InvalidScheduleID

--- a/pkg/jobs/jobspb/wrap.go
+++ b/pkg/jobs/jobspb/wrap.go
@@ -16,18 +16,11 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/protoreflect"
 	"github.com/cockroachdb/errors"
 	"github.com/gogo/protobuf/jsonpb"
 )
-
-// JobID is the ID of a job.
-type JobID = catpb.JobID
-
-// InvalidJobID is the zero value for JobID corresponding to no job.
-const InvalidJobID = catpb.InvalidJobID
 
 // Details is a marker interface for job details proto structs.
 type Details interface{}

--- a/pkg/jobs/jobsprotectedts/jobs_protected_ts.go
+++ b/pkg/jobs/jobsprotectedts/jobs_protected_ts.go
@@ -76,7 +76,7 @@ func MakeStatusFunc(jr *jobs.Registry, metaType MetaType) ptreconcile.StatusFunc
 				return false, err
 			}
 			_, err = jobs.ScheduledJobTxn(txn).
-				Load(ctx, scheduledjobs.ProdJobSchedulerEnv, scheduleID)
+				Load(ctx, scheduledjobs.ProdJobSchedulerEnv, jobspb.ScheduleID(scheduleID))
 			if jobs.HasScheduledJobNotFoundError(err) {
 				return true, nil
 			}

--- a/pkg/jobs/metricspoller/job_statistics.go
+++ b/pkg/jobs/metricspoller/job_statistics.go
@@ -121,7 +121,7 @@ func manageProtectedTimestamps(ctx context.Context, execCtx sql.JobExecContext) 
 					return err
 				}
 			case jobsprotectedts.GetMetaType(jobsprotectedts.Schedules):
-				if err := processSchedulePTSRecord(ctx, id, rec, schedulePtsStats, txn); err != nil {
+				if err := processSchedulePTSRecord(ctx, jobspb.ScheduleID(id), rec, schedulePtsStats, txn); err != nil {
 					return err
 				}
 			default:
@@ -213,7 +213,7 @@ func updateJobPTSMetrics(
 
 func processSchedulePTSRecord(
 	ctx context.Context,
-	scheduleID int64,
+	scheduleID jobspb.ScheduleID,
 	rec ptpb.Record,
 	ptsStats map[string]*schedulePTSStat,
 	txn isql.Txn,

--- a/pkg/jobs/scheduled_job_executor.go
+++ b/pkg/jobs/scheduled_job_executor.go
@@ -180,7 +180,7 @@ func NotifyJobTermination(
 	jobID jobspb.JobID,
 	jobStatus Status,
 	jobDetails jobspb.Details,
-	scheduleID int64,
+	scheduleID jobspb.ScheduleID,
 ) error {
 	if env == nil {
 		env = scheduledjobs.ProdJobSchedulerEnv

--- a/pkg/jobs/testutils_test.go
+++ b/pkg/jobs/testutils_test.go
@@ -134,7 +134,7 @@ func (h *testHelper) newScheduledJobForExecutor(
 }
 
 // loadSchedule loads  all columns for the specified scheduled job.
-func (h *testHelper) loadSchedule(t *testing.T, id int64) *ScheduledJob {
+func (h *testHelper) loadSchedule(t *testing.T, id jobspb.ScheduleID) *ScheduledJob {
 	j := NewScheduledJob(h.env)
 	row, cols, err := h.cfg.DB.Executor().QueryRowExWithCols(
 		context.Background(), "sched-load", nil,
@@ -168,7 +168,7 @@ func registerScopedScheduledJobExecutor(name string, ex ScheduledJobExecutor) fu
 // addFakeJob adds a fake job associated with the specified scheduleID.
 // Returns the id of the newly created job.
 func addFakeJob(
-	t *testing.T, h *testHelper, scheduleID int64, status Status, txn isql.Txn,
+	t *testing.T, h *testHelper, scheduleID jobspb.ScheduleID, status Status, txn isql.Txn,
 ) jobspb.JobID {
 	payload := []byte("fake payload")
 	datums, err := txn.QueryRowEx(context.Background(), "fake-job", txn.KV(),

--- a/pkg/sql/catalog/catpb/catalog.proto
+++ b/pkg/sql/catalog/catpb/catalog.proto
@@ -179,8 +179,8 @@ message RowLevelTTL {
   optional int64 delete_batch_size = 3 [(gogoproto.nullable)=false];
   // DeletionCron signifies how often the TTL deletion job runs in a cron format.
   optional string deletion_cron = 4 [(gogoproto.nullable)=false];
-  // ScheduleID is the ID of the row-level TTL job schedules.
-  optional int64 schedule_id = 5 [(gogoproto.customname)="ScheduleID",(gogoproto.nullable)=false];
+  // ScheduleID is the ID of the row-level TTL job schedule.
+  optional int64 schedule_id = 5 [(gogoproto.customname)="ScheduleID",(gogoproto.nullable)=false, (gogoproto.casttype)="ScheduleID"];
   // RangeConcurrency is based on the number of spans and is no longer configurable.
   reserved 6;
   // DeleteRateLimit is the maximum amount of rows to delete per second.

--- a/pkg/sql/catalog/catpb/job_id.go
+++ b/pkg/sql/catalog/catpb/job_id.go
@@ -27,3 +27,19 @@ func (j JobID) SafeValue() {}
 func (j JobID) String() string {
 	return strconv.Itoa(int(j))
 }
+
+// ScheduleID is the ID of a job schedule. It is defined here and imported in
+// jobspb for the same reasons as JobID. Additionally, it's helpful to keep the
+// two type definitions close together.
+type ScheduleID int64
+
+// InvalidScheduleID is a constant indicating the schedule ID is not valid.
+const InvalidScheduleID ScheduleID = 0
+
+// SafeValue implements the redact.SafeValue interface.
+func (s ScheduleID) SafeValue() {}
+
+// String implements the fmt.Stringer interface.
+func (s ScheduleID) String() string {
+	return strconv.Itoa(int(s))
+}

--- a/pkg/sql/catalog/schematelemetry/scheduled_job_executor.go
+++ b/pkg/sql/catalog/schematelemetry/scheduled_job_executor.go
@@ -74,7 +74,7 @@ func (s schemaTelemetryExecutor) ExecuteJob(
 	p, cleanup := cfg.PlanHookMaker(ctx, "invoke-schema-telemetry", txn.KV(), username.NodeUserName())
 	defer cleanup()
 	jr := p.(sql.PlanHookState).ExecCfg().JobRegistry
-	r := schematelemetrycontroller.CreateSchemaTelemetryJobRecord(jobs.CreatedByScheduledJobs, sj.ScheduleID())
+	r := schematelemetrycontroller.CreateSchemaTelemetryJobRecord(jobs.CreatedByScheduledJobs, int64(sj.ScheduleID()))
 	_, err = jr.CreateAdoptableJobWithTxn(ctx, r, jr.MakeJobID(), txn)
 	return err
 }

--- a/pkg/sql/catalog/schematelemetry/schematelemetrycontroller/controller.go
+++ b/pkg/sql/catalog/schematelemetry/schematelemetrycontroller/controller.go
@@ -257,7 +257,9 @@ func CreateSchemaTelemetrySchedule(
 
 // GetSchemaTelemetryScheduleID returns the ID of the schema telemetry schedule
 // if it exists, 0 if it does not exist yet.
-func GetSchemaTelemetryScheduleID(ctx context.Context, txn isql.Txn) (id int64, _ error) {
+func GetSchemaTelemetryScheduleID(
+	ctx context.Context, txn isql.Txn,
+) (id jobspb.ScheduleID, _ error) {
 	row, err := txn.QueryRowEx(
 		ctx,
 		"check-existing-schema-telemetry-schedule",
@@ -277,5 +279,5 @@ func GetSchemaTelemetryScheduleID(ctx context.Context, txn isql.Txn) (id int64, 
 	if !ok {
 		return 0, errors.AssertionFailedf("unexpectedly received non-integer value %v", row[0])
 	}
-	return int64(v), nil
+	return jobspb.ScheduleID(v), nil
 }

--- a/pkg/sql/control_schedules.go
+++ b/pkg/sql/control_schedules.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/jobs"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/scheduledjobs"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
@@ -94,7 +95,7 @@ func loadSchedule(params runParams, scheduleID tree.Datum) (*jobs.ScheduledJob, 
 
 // DeleteSchedule deletes specified schedule.
 func DeleteSchedule(
-	ctx context.Context, execCfg *ExecutorConfig, txn isql.Txn, scheduleID int64,
+	ctx context.Context, execCfg *ExecutorConfig, txn isql.Txn, scheduleID jobspb.ScheduleID,
 ) error {
 	env := JobSchedulerEnv(execCfg.JobsKnobs())
 	_, err := txn.ExecEx(

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -1619,7 +1619,7 @@ func decodeMetaFieldsForSchedules(
 	decodedMeta = tree.NewDJSON(decodedMetaJSON)
 
 	schedEnv := scheduledjobs.ProdJobSchedulerEnv
-	sched, err := jobs.ScheduledJobTxn(p.InternalSQLTxn()).Load(ctx, schedEnv, schedID)
+	sched, err := jobs.ScheduledJobTxn(p.InternalSQLTxn()).Load(ctx, schedEnv, jobspb.ScheduleID(schedID))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/sql/crdb_internal_test.go
+++ b/pkg/sql/crdb_internal_test.go
@@ -1802,7 +1802,7 @@ func TestVirtualPTSTable(t *testing.T) {
 
 		rec := jobsprotectedts.MakeRecord(
 			uuid.MakeV4(),
-			sj.ScheduleID(),
+			int64(sj.ScheduleID()),
 			tc.Server(0).Clock().Now(),
 			[]roachpb.Span{},
 			jobsprotectedts.Schedules,

--- a/pkg/sql/descmetadata/BUILD.bazel
+++ b/pkg/sql/descmetadata/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/descmetadata",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/jobs/jobspb",
         "//pkg/keys",
         "//pkg/settings",
         "//pkg/sql/catalog/descpb",

--- a/pkg/sql/descmetadata/metadata_updater.go
+++ b/pkg/sql/descmetadata/metadata_updater.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
@@ -85,7 +86,7 @@ func (mu metadataUpdater) DeleteDatabaseRoleSettings(ctx context.Context, dbID d
 }
 
 // DeleteSchedule implement scexec.DescriptorMetadataUpdater.
-func (mu metadataUpdater) DeleteSchedule(ctx context.Context, scheduleID int64) error {
+func (mu metadataUpdater) DeleteSchedule(ctx context.Context, scheduleID jobspb.ScheduleID) error {
 	_, err := mu.txn.ExecEx(
 		ctx,
 		"delete-schedule",

--- a/pkg/sql/schemachanger/scdeps/sctestdeps/test_deps.go
+++ b/pkg/sql/schemachanger/scdeps/sctestdeps/test_deps.go
@@ -1180,7 +1180,7 @@ func (s *TestState) DeleteDatabaseRoleSettings(_ context.Context, dbID descpb.ID
 }
 
 // DeleteSchedule implements scexec.DescriptorMetadataUpdater
-func (s *TestState) DeleteSchedule(ctx context.Context, id int64) error {
+func (s *TestState) DeleteSchedule(ctx context.Context, id jobspb.ScheduleID) error {
 	s.LogSideEffectf("delete job schedule #%d", id)
 	return nil
 }

--- a/pkg/sql/schemachanger/scexec/dependencies.go
+++ b/pkg/sql/schemachanger/scexec/dependencies.go
@@ -348,7 +348,7 @@ type DescriptorMetadataUpdater interface {
 	DeleteDatabaseRoleSettings(ctx context.Context, dbID descpb.ID) error
 
 	// DeleteSchedule deletes the given schedule.
-	DeleteSchedule(ctx context.Context, id int64) error
+	DeleteSchedule(ctx context.Context, id jobspb.ScheduleID) error
 
 	// UpdateTTLScheduleLabel updates the schedule_name for the TTL Scheduled Job
 	// of the given table.

--- a/pkg/sql/schemachanger/scexec/exec_deferred_mutation.go
+++ b/pkg/sql/schemachanger/scexec/exec_deferred_mutation.go
@@ -30,7 +30,7 @@ type deferredState struct {
 	databaseRoleSettingsToDelete []databaseRoleSettingToDelete
 	schemaChangerJob             *jobs.Record
 	schemaChangerJobUpdates      map[jobspb.JobID]schemaChangerJobUpdate
-	scheduleIDsToDelete          []int64
+	scheduleIDsToDelete          []jobspb.ScheduleID
 	statsToRefresh               catalog.DescriptorIDSet
 	indexesToSplitAndScatter     []indexesToSplitAndScatter
 	gcJobs
@@ -71,7 +71,7 @@ func (s *deferredState) AddIndexForMaybeSplitAndScatter(
 		})
 }
 
-func (s *deferredState) DeleteSchedule(scheduleID int64) {
+func (s *deferredState) DeleteSchedule(scheduleID jobspb.ScheduleID) {
 	s.scheduleIDsToDelete = append(s.scheduleIDsToDelete, scheduleID)
 }
 

--- a/pkg/sql/schemachanger/scexec/executor_external_test.go
+++ b/pkg/sql/schemachanger/scexec/executor_external_test.go
@@ -519,7 +519,7 @@ func (noopMetadataUpdater) DeleteDatabaseRoleSettings(ctx context.Context, dbID 
 }
 
 // DeleteScheduleID implements scexec.DescriptorMetadataUpdater.
-func (noopMetadataUpdater) DeleteSchedule(ctx context.Context, scheduleID int64) error {
+func (noopMetadataUpdater) DeleteSchedule(ctx context.Context, scheduleID jobspb.ScheduleID) error {
 	return nil
 }
 

--- a/pkg/sql/schemachanger/scexec/scmutationexec/dependencies.go
+++ b/pkg/sql/schemachanger/scexec/scmutationexec/dependencies.go
@@ -121,7 +121,7 @@ type DeferredMutationStateUpdater interface {
 	) error
 
 	// DeleteSchedule deletes a scheduled job.
-	DeleteSchedule(scheduleID int64)
+	DeleteSchedule(scheduleID jobspb.ScheduleID)
 
 	// RefreshStats refresh stats for a given descriptor.
 	RefreshStats(id descpb.ID)

--- a/pkg/sql/schemachanger/scop/deferred_mutation.go
+++ b/pkg/sql/schemachanger/scop/deferred_mutation.go
@@ -81,7 +81,7 @@ type RemoveDatabaseRoleSettings struct {
 // DeleteSchedule is used to delete a schedule ID from the database.
 type DeleteSchedule struct {
 	deferredMutationOp
-	ScheduleID int64
+	ScheduleID jobspb.ScheduleID
 }
 
 // RefreshStats is used to queue a table for stats refresh.

--- a/pkg/sql/sqlstats/persistedsqlstats/scheduled_job_monitor.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/scheduled_job_monitor.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/jobs"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/scheduledjobs"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
@@ -146,7 +147,7 @@ func (j *jobMonitor) getSchedule(
 		return nil, errScheduleNotFound
 	}
 
-	scheduledJobID := int64(tree.MustBeDInt(row[0]))
+	scheduledJobID := jobspb.ScheduleID(tree.MustBeDInt(row[0]))
 
 	sj, err = jobs.ScheduledJobTxn(txn).Load(ctx, scheduledjobs.ProdJobSchedulerEnv, scheduledJobID)
 	if err != nil {

--- a/pkg/sql/sqlstats/persistedsqlstats/scheduled_sql_stats_compaction_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/scheduled_sql_stats_compaction_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobstest"
 	"github.com/cockroachdb/cockroach/pkg/scheduledjobs"
 	"github.com/cockroachdb/cockroach/pkg/sql"
@@ -108,12 +109,12 @@ func verifySQLStatsCompactionScheduleCreatedOnStartup(t *testing.T, helper *test
 }
 
 func getSQLStatsCompactionSchedule(t *testing.T, helper *testHelper) *jobs.ScheduledJob {
-	var jobID int64
+	var scheduleID jobspb.ScheduleID
 	helper.sqlDB.
 		QueryRow(t, `SELECT schedule_id FROM system.scheduled_jobs WHERE schedule_name = 'sql-stats-compaction'`).
-		Scan(&jobID)
+		Scan(&scheduleID)
 	schedules := jobs.ScheduledJobDB(helper.server.InternalDB().(isql.DB))
-	sj, err := schedules.Load(context.Background(), helper.env, jobID)
+	sj, err := schedules.Load(context.Background(), helper.env, scheduleID)
 	require.NoError(t, err)
 	require.NotNil(t, sj)
 	return sj

--- a/pkg/sql/ttl/ttlschedule/ttlschedule.go
+++ b/pkg/sql/ttl/ttlschedule/ttlschedule.go
@@ -152,7 +152,7 @@ func (s rowLevelTTLExecutor) ExecuteJob(
 	if _, err := createRowLevelTTLJob(
 		ctx,
 		&jobs.CreatedByInfo{
-			ID:   sj.ScheduleID(),
+			ID:   int64(sj.ScheduleID()),
 			Name: jobs.CreatedByScheduledJobs,
 		},
 		txn,

--- a/pkg/testutils/lint/passes/redactcheck/redactcheck.go
+++ b/pkg/testutils/lint/passes/redactcheck/redactcheck.go
@@ -130,7 +130,8 @@ func runAnalyzer(pass *analysis.Pass) (interface{}, error) {
 						"ConnectionClass": {},
 					},
 					"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb": {
-						"JobID": {},
+						"JobID":      {},
+						"ScheduleID": {},
 					},
 					"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb": {
 						"ConstraintValidity":           {},


### PR DESCRIPTION
#### aeec29996e7199575d7585a7851756d2331a81d2 *: add jobspb.ScheduleID to distinguish ids

Previously, the IDs of job schedules we're just `int64s`. This was
identified as one of the causes of a recent bug where a schedule ID was
misinterpreted as a job ID.

This commit adds a wrapper type, `ScheduleID`, to clarify values which
correspond to the IDs of a job schedule vs the id of a job itself.

Fixes: #110909
Release note: None