### PR TITLE
roachtest: introduce structured version objects

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/clusterupgrade/BUILD.bazel
+++ b/pkg/cmd/roachtest/roachtestutil/clusterupgrade/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/clusterupgrade",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/build",
         "//pkg/cmd/roachtest/cluster",
         "//pkg/cmd/roachtest/option",
         "//pkg/cmd/roachtest/test",

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion_test.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion_test.go
@@ -16,8 +16,8 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/clusterupgrade"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
-	"github.com/cockroachdb/cockroach/pkg/util/version"
 	"github.com/stretchr/testify/require"
 )
 
@@ -103,14 +103,14 @@ func Test_choosePreviousReleases(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			mvt := newTest()
 			mvt._arch = &tc.arch
-			mvt.predecessorFunc = func(_ *rand.Rand, _ *version.Version, _ int) ([]string, error) {
-				return tc.predecessorHistory, tc.predecessorErr
+			mvt.predecessorFunc = func(_ *rand.Rand, _ *clusterupgrade.Version, _ int) ([]*clusterupgrade.Version, error) {
+				return parseVersions(tc.predecessorHistory), tc.predecessorErr
 			}
 
 			releases, err := mvt.choosePreviousReleases()
 			if tc.expectedErr == "" {
 				require.NoError(t, err)
-				require.Equal(t, tc.expectedReleases, releases)
+				require.Equal(t, parseVersions(tc.expectedReleases), releases)
 			} else {
 				require.Error(t, err)
 				require.Equal(t, tc.expectedErr, err.Error())

--- a/pkg/cmd/roachtest/tests/admission_control_database_drop.go
+++ b/pkg/cmd/roachtest/tests/admission_control_database_drop.go
@@ -68,7 +68,9 @@ func registerDatabaseDrop(r registry.Registry) {
 				if err != nil {
 					t.Fatal(err)
 				}
-				path, err := clusterupgrade.UploadVersion(ctx, t, t.L(), c, c.All(), pred)
+				path, err := clusterupgrade.UploadVersion(
+					ctx, t, t.L(), c, c.All(), clusterupgrade.MustParseVersion(pred),
+				)
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/pkg/cmd/roachtest/tests/admission_control_index_backfill.go
+++ b/pkg/cmd/roachtest/tests/admission_control_index_backfill.go
@@ -80,7 +80,9 @@ func registerIndexBackfill(r registry.Registry) {
 							t.Fatal(err)
 						}
 
-						path, err := clusterupgrade.UploadVersion(ctx, t, t.L(), c, c.All(), pred)
+						path, err := clusterupgrade.UploadVersion(
+							ctx, t, t.L(), c, c.All(), clusterupgrade.MustParseVersion(pred),
+						)
 						if err != nil {
 							t.Fatal(err)
 						}

--- a/pkg/cmd/roachtest/tests/backup_fixtures.go
+++ b/pkg/cmd/roachtest/tests/backup_fixtures.go
@@ -13,7 +13,6 @@ package tests
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
@@ -133,9 +132,8 @@ func (bd *backupDriver) prepareCluster(ctx context.Context) {
 		// For now, only run the test on the cloud provider that also stores the backup.
 		bd.t.Skip(fmt.Sprintf("test configured to run on %s", bd.sp.backup.cloud))
 	}
-	version := strings.Replace(bd.sp.backup.version, "v", "", 1)
 	binaryPath, err := clusterupgrade.UploadVersion(ctx, bd.t, bd.t.L(), bd.c,
-		bd.sp.hardware.getCRDBNodes(), version)
+		bd.sp.hardware.getCRDBNodes(), clusterupgrade.MustParseVersion(bd.sp.backup.version))
 	require.NoError(bd.t, err)
 
 	require.NoError(bd.t, clusterupgrade.StartWithSettings(ctx, bd.t.L(), bd.c,

--- a/pkg/cmd/roachtest/tests/backup_restore_roundtrip.go
+++ b/pkg/cmd/roachtest/tests/backup_restore_roundtrip.go
@@ -60,7 +60,7 @@ func backupRestoreRoundTrip(ctx context.Context, t test.Test, c cluster.Cluster)
 	t.L().Printf("random seed: %d", seed)
 
 	// Upload binaries and start cluster.
-	uploadVersion(ctx, t, c, c.All(), clusterupgrade.MainVersion)
+	uploadVersion(ctx, t, c, c.All(), clusterupgrade.CurrentVersion())
 
 	c.Start(ctx, t.L(), option.DefaultStartOptsNoBackups(), install.MakeClusterSettings(install.SecureOption(true)), roachNodes)
 	m := c.NewMonitor(ctx, roachNodes)
@@ -101,7 +101,7 @@ func backupRestoreRoundTrip(ctx context.Context, t test.Test, c cluster.Cluster)
 		}
 
 		for i := 0; i < numFullBackups; i++ {
-			allNodes := labeledNodes{Nodes: roachNodes, Version: clusterupgrade.MainVersion}
+			allNodes := labeledNodes{Nodes: roachNodes, Version: clusterupgrade.CurrentVersion().String()}
 			bspec := backupSpec{
 				PauseProbability: pauseProbability,
 				Plan:             allNodes,
@@ -125,7 +125,7 @@ func backupRestoreRoundTrip(ctx context.Context, t test.Test, c cluster.Cluster)
 					m.ExpectDeaths(int32(n))
 				}
 
-				if err := testUtils.resetCluster(ctx, t.L(), clusterupgrade.MainVersion, expectDeathsFn); err != nil {
+				if err := testUtils.resetCluster(ctx, t.L(), clusterupgrade.CurrentVersion(), expectDeathsFn); err != nil {
 					return err
 				}
 			}

--- a/pkg/cmd/roachtest/tests/decommission_self.go
+++ b/pkg/cmd/roachtest/tests/decommission_self.go
@@ -24,9 +24,9 @@ import (
 func runDecommissionSelf(ctx context.Context, t test.Test, c cluster.Cluster) {
 	allNodes := c.All()
 	u := newVersionUpgradeTest(c,
-		uploadVersionStep(allNodes, clusterupgrade.MainVersion),
-		startVersion(allNodes, clusterupgrade.MainVersion),
-		fullyDecommissionStep(2, 2, clusterupgrade.MainVersion),
+		uploadVersionStep(allNodes, clusterupgrade.CurrentVersion()),
+		startVersion(allNodes, clusterupgrade.CurrentVersion()),
+		fullyDecommissionStep(2, 2, clusterupgrade.CurrentVersion()),
 		func(ctx context.Context, t test.Test, u *versionUpgradeTest) {
 			// Stop n2 and exclude it from post-test consistency checks,
 			// as this node can't contact cluster any more and operations

--- a/pkg/cmd/roachtest/tests/follower_reads.go
+++ b/pkg/cmd/roachtest/tests/follower_reads.go
@@ -897,7 +897,9 @@ func runFollowerReadsMixedVersionSingleRegionTest(
 
 	// Start the cluster at the old version.
 	settings := install.MakeClusterSettings()
-	settings.Binary = uploadVersion(ctx, t, c, c.All(), predecessorVersion)
+	settings.Binary = uploadVersion(
+		ctx, t, c, c.All(), clusterupgrade.MustParseVersion(predecessorVersion),
+	)
 	startOpts := option.DefaultStartOpts()
 	c.Start(ctx, t.L(), startOpts, settings, c.All())
 	topology := topologySpec{multiRegion: false}
@@ -907,7 +909,7 @@ func runFollowerReadsMixedVersionSingleRegionTest(
 	randNode := 1 + rand.Intn(c.Spec().NodeCount)
 	t.L().Printf("upgrading n%d to current version", randNode)
 	nodeToUpgrade := c.Node(randNode)
-	upgradeNodes(ctx, t, c, nodeToUpgrade, startOpts, clusterupgrade.MainVersion)
+	upgradeNodes(ctx, t, c, nodeToUpgrade, startOpts, clusterupgrade.CurrentVersion())
 	runFollowerReadsTest(ctx, t, c, topologySpec{multiRegion: false}, exactStaleness, data)
 
 	// Upgrade the remaining nodes to the new version and run the test.
@@ -919,6 +921,6 @@ func runFollowerReadsMixedVersionSingleRegionTest(
 		remainingNodes = remainingNodes.Merge(c.Node(i + 1))
 	}
 	t.L().Printf("upgrading nodes %s to current version", remainingNodes)
-	upgradeNodes(ctx, t, c, remainingNodes, startOpts, clusterupgrade.MainVersion)
+	upgradeNodes(ctx, t, c, remainingNodes, startOpts, clusterupgrade.CurrentVersion())
 	runFollowerReadsTest(ctx, t, c, topologySpec{multiRegion: false}, exactStaleness, data)
 }

--- a/pkg/cmd/roachtest/tests/import.go
+++ b/pkg/cmd/roachtest/tests/import.go
@@ -353,20 +353,21 @@ func successfulImportStep(warehouses, nodeID int) versionStep {
 }
 
 func runImportMixedVersion(
-	ctx context.Context, t test.Test, c cluster.Cluster, warehouses int, predecessorVersion string,
+	ctx context.Context, t test.Test, c cluster.Cluster, warehouses int, predVersion string,
 ) {
 	roachNodes := c.All()
 
 	t.Status("starting csv servers")
 
+	predecessorVersion := clusterupgrade.MustParseVersion(predVersion)
 	u := newVersionUpgradeTest(c,
 		uploadAndStartFromCheckpointFixture(roachNodes, predecessorVersion),
 		waitForUpgradeStep(roachNodes),
 		preventAutoUpgradeStep(1),
 
 		// Upgrade some of the nodes.
-		binaryUpgradeStep(c.Node(1), clusterupgrade.MainVersion),
-		binaryUpgradeStep(c.Node(2), clusterupgrade.MainVersion),
+		binaryUpgradeStep(c.Node(1), clusterupgrade.CurrentVersion()),
+		binaryUpgradeStep(c.Node(2), clusterupgrade.CurrentVersion()),
 
 		successfulImportStep(warehouses, 1 /* nodeID */),
 	)

--- a/pkg/cmd/roachtest/tests/mixed_version_decl_schemachange_compat.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_decl_schemachange_compat.go
@@ -20,10 +20,10 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/clusterupgrade"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/testutils/release"
-	"github.com/cockroachdb/cockroach/pkg/util/version"
 )
 
 func registerDeclSchemaChangeCompatMixedVersions(r registry.Registry) {
@@ -37,7 +37,7 @@ func registerDeclSchemaChangeCompatMixedVersions(r registry.Registry) {
 			if c.Cloud() != spec.GCE && !c.IsLocal() {
 				t.Skip("uses gs://cockroach-corpus; see https://github.com/cockroachdb/cockroach/issues/105968")
 			}
-			runDeclSchemaChangeCompatMixedVersions(ctx, t, c, t.BuildVersion())
+			runDeclSchemaChangeCompatMixedVersions(ctx, t, c)
 		},
 	})
 }
@@ -129,25 +129,42 @@ func validateCorpusFile(
 //  3. Elements from the current version are backwards compatible with the same
 //     version (specifically focused on master during development before
 //     a version bump).
-func runDeclSchemaChangeCompatMixedVersions(
-	ctx context.Context, t test.Test, c cluster.Cluster, buildVersion *version.Version,
-) {
-	versionRegex := regexp.MustCompile(`(\d+\.\d+)`)
-	predecessorVersion, err := release.LatestPredecessor(buildVersion)
+func runDeclSchemaChangeCompatMixedVersions(ctx context.Context, t test.Test, c cluster.Cluster) {
+	currentVersion := clusterupgrade.CurrentVersion()
+	predecessorVersionStr, err := release.LatestPredecessor(currentVersion.Version)
 	if err != nil {
 		t.Fatal(err)
 	}
+	predecessorVersion := clusterupgrade.MustParseVersion(predecessorVersionStr)
+
+	releaseSeries := func(v *clusterupgrade.Version) string {
+		return fmt.Sprintf("%d.%d", v.Major(), v.Minor())
+	}
+
 	// Test definitions which indicates which version of the corpus to fetch,
 	// and the binary to validate against.
 	compatTests := []struct {
 		testName               string
-		binaryVersion          string
+		binaryVersion          *clusterupgrade.Version
 		corpusVersion          string
 		alternateCorpusVersion string
 	}{
-		{"backwards compatibility", predecessorVersion, fmt.Sprintf("mixed-release-%d.%d", buildVersion.Major(), buildVersion.Minor()), "mixed-master"},
-		{"forwards compatibility", "", fmt.Sprintf("release-%s", versionRegex.FindStringSubmatch(predecessorVersion)[0]), ""},
-		{"same version", "", fmt.Sprintf("release-%s", versionRegex.FindStringSubmatch(buildVersion.String())[0]), "master"},
+		{
+			testName:               "backwards compatibility",
+			binaryVersion:          predecessorVersion,
+			corpusVersion:          fmt.Sprintf("mixed-release-%s", releaseSeries(currentVersion)),
+			alternateCorpusVersion: "mixed-master",
+		},
+		{
+			testName:      "forwards compatibility",
+			binaryVersion: currentVersion,
+			corpusVersion: fmt.Sprintf("release-%s", releaseSeries(predecessorVersion)),
+		},
+		{
+			testName:      "same version",
+			binaryVersion: currentVersion,
+			corpusVersion: fmt.Sprintf("release-%s", releaseSeries(currentVersion)),
+		},
 	}
 	for _, testInfo := range compatTests {
 		binaryName := uploadVersion(ctx, t, c, c.All(), testInfo.binaryVersion)

--- a/pkg/cmd/roachtest/tests/mixed_version_job_compatibility_in_declarative_schema_changer.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_job_compatibility_in_declarative_schema_changer.go
@@ -136,6 +136,7 @@ func registerDeclarativeSchemaChangerJobCompatibilityInMixedVersion(r registry.R
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			predV, err := release.LatestPredecessor(t.BuildVersion())
 			require.NoError(t, err)
+			predecessorVersion := clusterupgrade.MustParseVersion(predV)
 
 			allNodes := c.All()
 			upgradedNodes := c.Nodes(1, 2)
@@ -143,14 +144,14 @@ func registerDeclarativeSchemaChangerJobCompatibilityInMixedVersion(r registry.R
 
 			u := newVersionUpgradeTest(c,
 				// System setup.
-				uploadAndStartFromCheckpointFixture(allNodes, predV),
+				uploadAndStartFromCheckpointFixture(allNodes, predecessorVersion),
 				waitForUpgradeStep(allNodes),
 				preventAutoUpgradeStep(1),
 				setShortJobIntervalsStep(1),
 				setShortGCTTLInSystemZoneConfig(c),
 
 				// Upgrade some nodes.
-				binaryUpgradeStep(upgradedNodes, clusterupgrade.MainVersion),
+				binaryUpgradeStep(upgradedNodes, clusterupgrade.CurrentVersion()),
 
 				// Job backward compatibility test:
 				//   - upgraded nodes: plan schema change and create schema changer jobs

--- a/pkg/cmd/roachtest/tests/mixed_version_schemachange.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_schemachange.go
@@ -90,10 +90,11 @@ func runSchemaChangeMixedVersions(
 	concurrency int,
 	buildVersion *version.Version,
 ) {
-	predecessorVersion, err := release.LatestPredecessor(buildVersion)
+	predecessorVersionStr, err := release.LatestPredecessor(buildVersion)
 	if err != nil {
 		t.Fatal(err)
 	}
+	predecessorVersion := clusterupgrade.MustParseVersion(predecessorVersionStr)
 
 	schemaChangeStep := runSchemaChangeWorkloadStep(c.All().RandNode()[0], maxOps, concurrency)
 	schemaChangeValidationStep := runSchemaChangeDoctorValidate()
@@ -120,16 +121,16 @@ func runSchemaChangeMixedVersions(
 		// Roll the nodes into the new version one by one, while repeatedly running
 		// schema changes. We use an empty string for the version below, which means
 		// use the main ./cockroach binary (i.e. the one being tested in this run).
-		binaryUpgradeStep(c.Node(3), clusterupgrade.MainVersion),
+		binaryUpgradeStep(c.Node(3), clusterupgrade.CurrentVersion()),
 		schemaChangeStep,
 		schemaChangeValidationStep,
-		binaryUpgradeStep(c.Node(2), clusterupgrade.MainVersion),
+		binaryUpgradeStep(c.Node(2), clusterupgrade.CurrentVersion()),
 		schemaChangeStep,
 		schemaChangeValidationStep,
-		binaryUpgradeStep(c.Node(1), clusterupgrade.MainVersion),
+		binaryUpgradeStep(c.Node(1), clusterupgrade.CurrentVersion()),
 		schemaChangeStep,
 		schemaChangeValidationStep,
-		binaryUpgradeStep(c.Node(4), clusterupgrade.MainVersion),
+		binaryUpgradeStep(c.Node(4), clusterupgrade.CurrentVersion()),
 		schemaChangeStep,
 		schemaChangeValidationStep,
 
@@ -149,16 +150,16 @@ func runSchemaChangeMixedVersions(
 		schemaChangeValidationStep,
 
 		// Roll nodes forward and finalize upgrade.
-		binaryUpgradeStep(c.Node(4), clusterupgrade.MainVersion),
+		binaryUpgradeStep(c.Node(4), clusterupgrade.CurrentVersion()),
 		schemaChangeStep,
 		schemaChangeValidationStep,
-		binaryUpgradeStep(c.Node(3), clusterupgrade.MainVersion),
+		binaryUpgradeStep(c.Node(3), clusterupgrade.CurrentVersion()),
 		schemaChangeStep,
 		schemaChangeValidationStep,
-		binaryUpgradeStep(c.Node(1), clusterupgrade.MainVersion),
+		binaryUpgradeStep(c.Node(1), clusterupgrade.CurrentVersion()),
 		schemaChangeStep,
 		schemaChangeValidationStep,
-		binaryUpgradeStep(c.Node(2), clusterupgrade.MainVersion),
+		binaryUpgradeStep(c.Node(2), clusterupgrade.CurrentVersion()),
 		schemaChangeStep,
 		schemaChangeValidationStep,
 

--- a/pkg/cmd/roachtest/tests/rebalance_load.go
+++ b/pkg/cmd/roachtest/tests/rebalance_load.go
@@ -96,8 +96,9 @@ func registerRebalanceLoad(r registry.Registry) {
 			"--vmodule=store_rebalancer=5,allocator=5,allocator_scorer=5,replicate_queue=5")
 		settings := install.MakeClusterSettings()
 		if mixedVersion {
-			predecessorVersion, err := release.LatestPredecessor(t.BuildVersion())
+			predecessorVersionStr, err := release.LatestPredecessor(t.BuildVersion())
 			require.NoError(t, err)
+			predecessorVersion := clusterupgrade.MustParseVersion(predecessorVersionStr)
 			settings.Binary = uploadVersion(ctx, t, c, c.All(), predecessorVersion)
 			// Upgrade some (or all) of the first N-1 CRDB nodes. We ignore the last
 			// CRDB node (to leave at least one node on the older version), and the
@@ -106,7 +107,7 @@ func registerRebalanceLoad(r registry.Registry) {
 			t.L().Printf("upgrading %d nodes to the current cockroach binary", lastNodeToUpgrade)
 			nodesToUpgrade := c.Range(1, lastNodeToUpgrade)
 			c.Start(ctx, t.L(), startOpts, settings, roachNodes)
-			upgradeNodes(ctx, t, c, nodesToUpgrade, startOpts, clusterupgrade.MainVersion)
+			upgradeNodes(ctx, t, c, nodesToUpgrade, startOpts, clusterupgrade.CurrentVersion())
 		} else {
 			c.Put(ctx, t.Cockroach(), "./cockroach", roachNodes)
 			c.Start(ctx, t.L(), startOpts, settings, roachNodes)

--- a/pkg/cmd/roachtest/tests/secondary_indexes.go
+++ b/pkg/cmd/roachtest/tests/secondary_indexes.go
@@ -25,7 +25,7 @@ import (
 // and modifies it in a mixed version setting. It aims to test the changes made
 // to index encodings done to allow secondary indexes to respect column families.
 func runIndexUpgrade(
-	ctx context.Context, t test.Test, c cluster.Cluster, predecessorVersion string,
+	ctx context.Context, t test.Test, c cluster.Cluster, predecessorVersionStr string,
 ) {
 	firstExpected := [][]int{
 		{2, 3, 4},
@@ -42,6 +42,7 @@ func runIndexUpgrade(
 	}
 
 	roachNodes := c.All()
+	predecessorVersion := clusterupgrade.MustParseVersion(predecessorVersionStr)
 	u := newVersionUpgradeTest(c,
 		uploadAndStart(roachNodes, predecessorVersion),
 		waitForUpgradeStep(roachNodes),
@@ -50,7 +51,7 @@ func runIndexUpgrade(
 		createDataStep(),
 
 		// Upgrade one of the nodes.
-		binaryUpgradeStep(c.Node(1), clusterupgrade.MainVersion),
+		binaryUpgradeStep(c.Node(1), clusterupgrade.CurrentVersion()),
 
 		// Modify index data from that node.
 		modifyData(1,
@@ -64,8 +65,8 @@ func runIndexUpgrade(
 		verifyTableData(3, firstExpected),
 
 		// Upgrade the rest of the cluster.
-		binaryUpgradeStep(c.Node(2), clusterupgrade.MainVersion),
-		binaryUpgradeStep(c.Node(3), clusterupgrade.MainVersion),
+		binaryUpgradeStep(c.Node(2), clusterupgrade.CurrentVersion()),
+		binaryUpgradeStep(c.Node(3), clusterupgrade.CurrentVersion()),
 
 		// Finalize the upgrade.
 		allowAutoUpgradeStep(1),


### PR DESCRIPTION
This introduces a `clusterupgrade.Version` struct that is a thin wrapper around `version.Version` representing released cockroach binaries. Previously, these versions would be passed across functions as strings, with a special sentinel value (the empty string) corresponding to the current build.

In this commit, we change the utility functions in the `clusterupgrade` package to take the new `Version` struct instead of a string; a number of tests are changed mechanically to adhere to this API change.

Epic: none

Release note: None