### PR TITLE
logictest: fix a flake in mixed version logic test with procedures

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/mixed_version_procedure
+++ b/pkg/sql/logictest/testdata/logic_test/mixed_version_procedure
@@ -40,7 +40,7 @@ upgrade 2
 # Makes sure the upgrade job has finished, and the cluster version gate is
 # passed.
 query B retry
-SELECT crdb_internal.is_at_least_version('23.1-32')
+SELECT crdb_internal.is_at_least_version('23.1-34')
 ----
 true
 


### PR DESCRIPTION
This commit _hopefully_ fixes a failure in `mixed_version_procedure` logic test where we were waiting for the incorrect internal version: `V23_2_Procedures` is 23.1-34 and not 23.1-32. I haven't been able to repro the original failure, but this change shouldn't have any negative impact.

Fixes: #112000.
Fixes: #112206.

Release note: None