### PR TITLE
sql: fix stmt bundle for local retries

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -2257,19 +2257,8 @@ func (ex *connExecutor) execWithDistSQLEngine(
 		err = planner.resumeFlowForPausablePortal(recv)
 	} else {
 		evalCtx := planner.ExtendedEvalContext()
-		planCtx := ex.server.cfg.DistSQLPlanner.NewPlanningCtx(ctx, evalCtx, planner,
-			planner.txn, distribute)
-		planCtx.stmtType = recv.stmtType
-		// Skip the diagram generation since on this "main" query path we can get it
-		// via the statement bundle.
-		planCtx.skipDistSQLDiagramGeneration = true
-		if ex.server.cfg.TestingKnobs.TestingSaveFlows != nil {
-			planCtx.saveFlows = ex.server.cfg.TestingKnobs.TestingSaveFlows(planner.stmt.SQL)
-		} else if planner.instrumentation.ShouldSaveFlows() {
-			planCtx.saveFlows = getDefaultSaveFlowsFunc(ctx, planner, planComponentTypeMainQuery)
-		}
-		planCtx.associateNodeWithComponents = planner.instrumentation.getAssociateNodeWithComponentsFn()
-		planCtx.collectExecStats = planner.instrumentation.ShouldCollectExecStats()
+		planCtx := ex.server.cfg.DistSQLPlanner.NewPlanningCtx(ctx, evalCtx, planner, planner.txn, distribute)
+		planCtx.setUpForMainQuery(ctx, planner, recv)
 
 		var evalCtxFactory func(usedConcurrently bool) *extendedEvalContext
 		if len(planner.curPlan.subqueryPlans) != 0 ||

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -2266,7 +2266,7 @@ func (ex *connExecutor) execWithDistSQLEngine(
 		if ex.server.cfg.TestingKnobs.TestingSaveFlows != nil {
 			planCtx.saveFlows = ex.server.cfg.TestingKnobs.TestingSaveFlows(planner.stmt.SQL)
 		} else if planner.instrumentation.ShouldSaveFlows() {
-			planCtx.saveFlows = planCtx.getDefaultSaveFlowsFunc(ctx, planner, planComponentTypeMainQuery)
+			planCtx.saveFlows = getDefaultSaveFlowsFunc(ctx, planner, planComponentTypeMainQuery)
 		}
 		planCtx.associateNodeWithComponents = planner.instrumentation.getAssociateNodeWithComponentsFn()
 		planCtx.collectExecStats = planner.instrumentation.ShouldCollectExecStats()

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -1984,6 +1984,7 @@ func (dsp *DistSQLPlanner) PlanAndRun(
 		localPlanCtx := dsp.NewPlanningCtx(
 			ctx, evalCtx, planCtx.planner, evalCtx.Txn, DistributionTypeNone,
 		)
+		localPlanCtx.setUpForMainQuery(ctx, planCtx.planner, recv)
 		localPhysPlan, localPhysPlanCleanup, err := dsp.createPhysPlan(ctx, localPlanCtx, plan)
 		defer localPhysPlanCleanup()
 		if err != nil {

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1594,7 +1594,7 @@ type ExecutorTestingKnobs struct {
 	// query (i.e. no subqueries). The physical plan is only safe for use for the
 	// lifetime of this function. Note that returning a nil function is
 	// unsupported and will lead to a panic.
-	TestingSaveFlows func(stmt string) func(map[base.SQLInstanceID]*execinfrapb.FlowSpec, execopnode.OpChains, bool) error
+	TestingSaveFlows func(stmt string) func(map[base.SQLInstanceID]*execinfrapb.FlowSpec, execopnode.OpChains, []execinfra.LocalProcessor, bool) error
 
 	// DeterministicExplain, if set, will result in overriding fields in EXPLAIN
 	// and EXPLAIN ANALYZE that can vary between runs (like elapsed times).

--- a/pkg/sql/execstats/traceanalyzer_test.go
+++ b/pkg/sql/execstats/traceanalyzer_test.go
@@ -60,11 +60,13 @@ func TestTraceAnalyzer(t *testing.T) {
 			UseDatabase: "test",
 			Knobs: base.TestingKnobs{
 				SQLExecutor: &sql.ExecutorTestingKnobs{
-					TestingSaveFlows: func(stmt string) func(map[base.SQLInstanceID]*execinfrapb.FlowSpec, execopnode.OpChains, bool) error {
+					TestingSaveFlows: func(stmt string) func(map[base.SQLInstanceID]*execinfrapb.FlowSpec, execopnode.OpChains, []execinfra.LocalProcessor, bool) error {
 						if stmt != testStmt {
-							return func(map[base.SQLInstanceID]*execinfrapb.FlowSpec, execopnode.OpChains, bool) error { return nil }
+							return func(map[base.SQLInstanceID]*execinfrapb.FlowSpec, execopnode.OpChains, []execinfra.LocalProcessor, bool) error {
+								return nil
+							}
 						}
-						return func(flows map[base.SQLInstanceID]*execinfrapb.FlowSpec, _ execopnode.OpChains, _ bool) error {
+						return func(flows map[base.SQLInstanceID]*execinfrapb.FlowSpec, _ execopnode.OpChains, _ []execinfra.LocalProcessor, _ bool) error {
 							flowsMetadata := execstats.NewFlowsMetadata(flows)
 							analyzer := execstats.NewTraceAnalyzer(flowsMetadata)
 							analyzerChan <- analyzer

--- a/pkg/sql/explain_vec.go
+++ b/pkg/sql/explain_vec.go
@@ -62,7 +62,7 @@ func (n *explainVecNode) startExec(params runParams) error {
 
 	finalizePlanWithRowCount(params.ctx, planCtx, physPlan, n.plan.mainRowCount)
 	flows := physPlan.GenerateFlowSpecs()
-	flowCtx, cleanup := newFlowCtxForExplainPurposes(params.ctx, planCtx, params.p)
+	flowCtx, cleanup := newFlowCtxForExplainPurposes(params.ctx, params.p)
 	defer cleanup()
 
 	// We want to get the vectorized plan which would be executed with the
@@ -91,7 +91,7 @@ func (n *explainVecNode) startExec(params runParams) error {
 }
 
 func newFlowCtxForExplainPurposes(
-	ctx context.Context, planCtx *PlanningCtx, p *planner,
+	ctx context.Context, p *planner,
 ) (_ *execinfra.FlowCtx, cleanup func()) {
 	monitor := mon.NewMonitor(
 		"explain", /* name */
@@ -107,8 +107,8 @@ func newFlowCtxForExplainPurposes(
 		monitor.Stop(ctx)
 	}
 	return &execinfra.FlowCtx{
-		NodeID:  planCtx.EvalContext().NodeID,
-		EvalCtx: planCtx.EvalContext(),
+		NodeID:  p.EvalContext().NodeID,
+		EvalCtx: p.EvalContext(),
 		Mon:     monitor,
 		Txn:     p.txn,
 		Cfg: &execinfra.ServerConfig{


### PR DESCRIPTION
**sql: simplify saveFlows machinery**

This commit makes `getDefaultSaveFlowsFunc` function be receiver-less to
simplify the code a bit. The main idea is to use the planner to access
a few fields that were previously supplied by the `PlanningCtx`. This
will make it a bit easier the change in the following commit.

Release note: None

**sql: fix stmt bundle for local retries**

This commit fixes a few things about the local `PlanningCtx` that we use
when retry-as-local mechanism kicks in. In particular, previuosly we
forgot to set a few observability related fields which would make it so
that stmt bundles were incomplete, and this is now fixed.

A few points worth calling out:
- both the original distributed and retried local plans will be included
in `distsql.html` and `EXPLAIN (VEC)` formats
- the trace will include both too
- each `planNode` in `plan.txt` will have aggregation of execution stats
from both runs. This is a bit unfortunate but is not easy to fix.
`distsql.html` diagrams will have the precise information for each run
though
- in `plan.txt` we will have `distribution: full`, and the execution
time will include both runs.

Fixes: #112564.

Release note: None