### PR TITLE
release-22.2: roachtest: fix teamCityEscape to handle '\r' and unicode

### DIFF
--- a/pkg/cmd/roachtest/BUILD.bazel
+++ b/pkg/cmd/roachtest/BUILD.bazel
@@ -72,6 +72,7 @@ go_test(
         "cluster_test.go",
         "github_test.go",
         "main_test.go",
+        "test_impl_test.go",
         "test_registry_test.go",
         "test_test.go",
     ],

--- a/pkg/cmd/roachtest/main.go
+++ b/pkg/cmd/roachtest/main.go
@@ -623,7 +623,7 @@ func testsToRun(r testRegistryImpl, filter *registry.TestFilter) []registry.Test
 		} else {
 			if teamCity {
 				fmt.Fprintf(os.Stdout, "##teamcity[testIgnored name='%s' message='%s']\n",
-					s.Name, teamCityEscape(s.Skip))
+					s.Name, TeamCityEscape(s.Skip))
 			}
 			fmt.Fprintf(os.Stdout, "--- SKIP: %s (%s)\n\t%s\n", s.Name, "0.00s", s.Skip)
 		}

--- a/pkg/cmd/roachtest/test_impl.go
+++ b/pkg/cmd/roachtest/test_impl.go
@@ -451,18 +451,34 @@ func (t *testImpl) IsBuildVersion(minVersion string) bool {
 	return t.BuildVersion().AtLeast(vers)
 }
 
-// teamCityEscape escapes a string for use as <value> in a key='<value>' attribute
+// TeamCityEscape escapes a string for use as <value> in a key='<value>' attribute
 // in TeamCity build output marker.
-// Documentation here: https://confluence.jetbrains.com/display/TCD10/Build+Script+Interaction+with+TeamCity#BuildScriptInteractionwithTeamCity-Escapedvalues
-func teamCityEscape(s string) string {
-	r := strings.NewReplacer(
-		"\n", "|n",
-		"'", "|'",
-		"|", "||",
-		"[", "|[",
-		"]", "|]",
-	)
-	return r.Replace(s)
+// See https://www.jetbrains.com/help/teamcity/2023.05/service-messages.html#Escaped+Values
+func TeamCityEscape(s string) string {
+	var sb strings.Builder
+
+	for _, runeValue := range s {
+		switch runeValue {
+		case '\n':
+			sb.WriteString("|n")
+		case '\r':
+			sb.WriteString("|r")
+		case '|':
+			sb.WriteString("||")
+		case '[':
+			sb.WriteString("|[")
+		case ']':
+			sb.WriteString("|]")
+		default:
+			if runeValue > 127 {
+				// escape unicode
+				sb.WriteString(fmt.Sprintf("|0x%04x", runeValue))
+			} else {
+				sb.WriteRune(runeValue)
+			}
+		}
+	}
+	return sb.String()
 }
 
 func teamCityNameEscape(name string) string {

--- a/pkg/cmd/roachtest/test_impl_test.go
+++ b/pkg/cmd/roachtest/test_impl_test.go
@@ -1,0 +1,37 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTeamCityEscape(t *testing.T) {
+	require.Equal(t, "|n", TeamCityEscape("\n"))
+	require.Equal(t, "|r", TeamCityEscape("\r"))
+	require.Equal(t, "||", TeamCityEscape("|"))
+	require.Equal(t, "|[", TeamCityEscape("["))
+	require.Equal(t, "|]", TeamCityEscape("]"))
+
+	require.Equal(t, "identity", TeamCityEscape("identity"))
+	require.Equal(t, "aaa|nbbb", TeamCityEscape("aaa\nbbb"))
+	require.Equal(t, "aaa|nbbb||", TeamCityEscape("aaa\nbbb|"))
+	require.Equal(t, "||||", TeamCityEscape("||"))
+	require.Equal(t, "Connection to 104.196.113.229 port 22: Broken pipe|r|nlost connection: exit status 1",
+		TeamCityEscape("Connection to 104.196.113.229 port 22: Broken pipe\r\nlost connection: exit status 1"))
+
+	//Unicode
+	require.Equal(t, "|0x00bf", TeamCityEscape("\u00bf"))
+	require.Equal(t, "|0x00bfaaa", TeamCityEscape("\u00bfaaa"))
+	require.Equal(t, "bb|0x00bfaaa", TeamCityEscape("bb\u00bfaaa"))
+}

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -919,7 +919,7 @@ func (r *testRunner) runTest(
 
 			if teamCity {
 				shout(ctx, l, stdout, "##teamcity[testFailed name='%s' details='%s' flowId='%s']",
-					t.Name(), teamCityEscape(output), runID)
+					t.Name(), TeamCityEscape(output), runID)
 			}
 
 			shout(ctx, l, stdout, "--- FAIL: %s (%s)\n%s", runID, durationStr, output)


### PR DESCRIPTION
Backport 1/1 commits from #112507.

/cc @cockroachdb/release

---

`teamCityEscape` is used in conjunction with TeamCity's service messages to report the status of a roachtest. Recently, we found a regression wherein the test was reported to have succeeded while in reality it failed,

```
10:13:26 test_runner.go:985: [w2] ##teamcity[testFailed name='allocbench/nodes=7/cpu=8/kv/r=50/ops=skew' details='(cluster.go:1830).Put: cluster.PutE: put /go/src/github.com/cockroachdb/cockroach/bin/cockroach.linux-amd64 failed: error persisted after 2 attempts: ~ scp -r -C -o StrictHostKeyChecking=no -o ConnectTimeout=10 -i /home/roach/.ssh/id_rsa -i /home/roach/.ssh/google_compute_engine /go/src/github.com/cockroachdb/cockroach/bin/cockroach.linux-amd64 ubuntu@104.196.113.229:./cockroach|nclient_loop: ssh_packet_write_poll: Connection to 104.196.113.229 port 22: Broken pipe^M|nlost connection: exit status 1|ntest artifacts and logs in: /artifacts/allocbench/nodes=7/cpu=8/kv/r=50/ops=skew/run_1' flowId='allocbench/nodes=7/cpu=8/kv/r=50/ops=skew']
```

The above service message did not properly escape '\r' (i.e., ^M) after `Broken pipe`. Thus, the service message was deemed ill-formed by TeamCity. In the absense of a well-formed `testFailed name=...` service message, test was reported successful.

This PR updates the missing escape logic as per [1] and adds a unit test.

[1] https://www.jetbrains.com/help/teamcity/service-messages.html#Escaped+Values

Epic: none

Release note: None
Release justification: test-only change
