### PR TITLE
workload/schemachange: add query helpers

### DIFF
--- a/pkg/workload/schemachange/BUILD.bazel
+++ b/pkg/workload/schemachange/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "error_screening.go",
         "operation_generator.go",
         "optype.go",
+        "query_util.go",
         "schemachange.go",
         "type_resolver.go",
         "watch_dog.go",

--- a/pkg/workload/schemachange/error_screening.go
+++ b/pkg/workload/schemachange/error_screening.go
@@ -79,36 +79,13 @@ func (og *operationGenerator) tableHasRows(
 func (og *operationGenerator) scanInt(
 	ctx context.Context, tx pgx.Tx, query string, args ...interface{},
 ) (i int, err error) {
-	err = tx.QueryRow(ctx, query, args...).Scan(&i)
-	if err == nil {
-		og.LogQueryResults(
-			query,
-			i,
-			args...,
-		)
-	}
-	return i, errors.Wrapf(err, "scanBool: %q %q", query, args)
+	return Scan[int](ctx, og, tx, query, args...)
 }
 
 func (og *operationGenerator) scanBool(
 	ctx context.Context, tx pgx.Tx, query string, args ...interface{},
 ) (b bool, err error) {
-	err = tx.QueryRow(ctx, query, args...).Scan(&b)
-	if err == nil {
-		og.LogQueryResults(
-			query,
-			b,
-			args...,
-		)
-	}
-	return b, errors.Wrapf(err, "scanBool: %q %q", query, args)
-}
-
-func scanString(
-	ctx context.Context, tx pgx.Tx, query string, args ...interface{},
-) (s string, err error) {
-	err = tx.QueryRow(ctx, query, args...).Scan(&s)
-	return s, errors.Wrapf(err, "scanString: %q %q", query, args)
+	return Scan[bool](ctx, og, tx, query, args...)
 }
 
 func (og *operationGenerator) schemaExists(
@@ -1582,10 +1559,7 @@ func (og *operationGenerator) getRegionColumn(
 			tableName.String())
 	}
 
-	regionCol, err := scanString(
-		ctx,
-		tx,
-		`
+	regionCol, err := Scan[string](ctx, og, tx, `
 WITH
 	descriptors
 		AS (

--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -96,10 +96,10 @@ type OpGenLogMessage struct {
 
 // LogQueryResults logs a string query result.
 func (og *operationGenerator) LogQueryResults(
-	queryName string, result interface{}, queryArgs ...interface{},
+	sql string, result interface{}, queryArgs ...interface{},
 ) {
-	formattedQuery := queryName
-	parsedQuery, err := parser.Parse(queryName)
+	formattedQuery := sql
+	parsedQuery, err := parser.Parse(sql)
 	if err == nil {
 		formattedQuery = parsedQuery.String()
 	}
@@ -491,10 +491,7 @@ func (og *operationGenerator) getDatabaseRegionNames(
 }
 
 func (og *operationGenerator) getDatabase(ctx context.Context, tx pgx.Tx) (string, error) {
-	var database string
-	err := tx.QueryRow(ctx, "SHOW DATABASE").Scan(&database)
-	og.LogQueryResults("SHOW DATABASE", database)
-	return database, err
+	return Scan[string](ctx, og, tx, `SHOW DATABASE`)
 }
 
 type getRegionsResult struct {

--- a/pkg/workload/schemachange/query_util.go
+++ b/pkg/workload/schemachange/query_util.go
@@ -1,0 +1,112 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+package schemachange
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/cockroachdb/errors"
+	"github.com/jackc/pgx/v5"
+)
+
+type CTE struct {
+	As    string
+	Query string
+}
+
+// With is a helper for building queries utilizing Common Table Expressions
+// (CTEs). Managing reusable and composable SQL queries in Golang is quite
+// difficult without building out a full expression engine. The denormalized
+// nature of the descriptor table, however, necessitates some degree of
+// reusability. Our solution is to provide many CTE expression as constants and
+// allow them to be composed with With.
+// Usage:
+//
+//	With([]CTE{
+//		{"descriptors", descJSONQuery},
+//		{"table_descs", `SELECT id, descriptor->'table' FROM descriptors WHERE descriptor ? 'table'`},
+//	}, `SELECT * FROM descriptors WHERE EXISTS(table_descs)`)
+func With(ctes []CTE, query string) string {
+	var b strings.Builder
+	_, _ = b.WriteString("WITH ")
+	for i, cte := range ctes {
+		if i > 0 {
+			_, _ = b.WriteString(",\n")
+		}
+		_, _ = fmt.Fprintf(&b, "%q AS (%s)", cte.As, cte.Query)
+	}
+	_, _ = b.WriteRune('\n')
+	_, _ = b.WriteString(query)
+	return b.String()
+}
+
+// Scan is a convenience wrapper around [CollectOne] that uses [pgx.RowTo] as
+// fn.
+func Scan[T any](
+	ctx context.Context, og *operationGenerator, tx pgx.Tx, query string, args ...any,
+) (result T, err error) {
+	return CollectOne[T](ctx, og, tx, pgx.RowTo[T], query, args...)
+}
+
+// CollectOne is a convenience wrapper around [pgx.CollectOneRow] that logs the
+// query and results via [LogQueryResults]. Usage:
+//
+//	CollectOne(ctx, og, tx, pgx.RowTo[string], `SELECT $1`, "bar")
+func CollectOne[T any](
+	ctx context.Context,
+	og *operationGenerator,
+	tx pgx.Tx,
+	fn pgx.RowToFunc[T],
+	query string,
+	args ...any,
+) (T, error) {
+	rows, err := tx.Query(ctx, query, args...)
+	if err != nil {
+		var zero T
+		return zero, errors.Wrapf(err, "CollectOne: Query: %q %q", query, args)
+	}
+
+	result, err := pgx.CollectOneRow[T](rows, fn)
+	if err != nil {
+		var zero T
+		return zero, errors.Wrapf(err, "CollectOne: CollectOneRow: %q %q", query, args)
+	}
+
+	og.LogQueryResults(query, result, args...)
+	return result, nil
+}
+
+// Collect is a convenience wrapper around [pgx.CollectRows] that logs the
+// query and results via [LogQueryResults]. Usage:
+//
+//	Collect(ctx, og, tx, pgx.RowTo[int], `SELECT * FROM gen_sequence(0, 100)`)
+func Collect[T any](
+	ctx context.Context,
+	og *operationGenerator,
+	tx pgx.Tx,
+	fn pgx.RowToFunc[T],
+	query string,
+	args ...any,
+) (result []T, err error) {
+	rows, err := tx.Query(ctx, query, args...)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Collect: Query: %q %q", query, args)
+	}
+
+	results, err := pgx.CollectRows(rows, fn)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Collect: CollectRows: %q %q", query, args)
+	}
+
+	og.LogQueryResults(query, results, args...)
+	return results, nil
+}


### PR DESCRIPTION
Previously, SQL queries in the schemachange workload we're all handwritten and inconsistently logged. This increased the cognitive overhead of adding new operations, the likelihood of typos, difficulty of debugging. This commit adds a handful of query helper functions that utilize pgx's generic helpers but add on logging via `LogQueryResults`.

Epic: CRDB-14461
Release note: None