### PR TITLE
workload/schemachange: add Generate helper

### DIFF
--- a/pkg/workload/schemachange/BUILD.bazel
+++ b/pkg/workload/schemachange/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 load("//build:STRINGER.bzl", "stringer")
 
 go_library(
@@ -7,6 +7,7 @@ go_library(
         "deck.go",
         "error_code_set.go",
         "error_screening.go",
+        "generate.go",
         "operation_generator.go",
         "optype.go",
         "schemachange.go",
@@ -30,6 +31,7 @@ go_library(
         "//pkg/sql/sem/catconstants",
         "//pkg/sql/sem/tree",
         "//pkg/sql/types",
+        "//pkg/util",
         "//pkg/util/encoding",
         "//pkg/util/randutil",
         "//pkg/util/syncutil",
@@ -42,6 +44,7 @@ go_library(
         "@com_github_jackc_pgx_v5//pgxpool",
         "@com_github_lib_pq//oid",
         "@com_github_spf13_pflag//:pflag",
+        "@org_golang_x_exp//slices",
     ],
 )
 
@@ -49,4 +52,16 @@ stringer(
     name = "gen-optype-stringer",
     src = "optype.go",
     typ = "opType",
+)
+
+go_test(
+    name = "schemachange_test",
+    srcs = ["generate_test.go"],
+    args = ["-test.timeout=295s"],
+    embed = [":schemachange"],
+    deps = [
+        "//pkg/sql/pgwire/pgcode",
+        "//pkg/sql/sem/tree",
+        "@com_github_stretchr_testify//require",
+    ],
 )

--- a/pkg/workload/schemachange/error_code_set.go
+++ b/pkg/workload/schemachange/error_code_set.go
@@ -30,6 +30,11 @@ func (set errorCodeSet) merge(otherSet errorCodeSet) {
 }
 
 func (set errorCodeSet) add(code pgcode.Code) {
+	// For ergonomics, we allow the success code to be added to errorCodeSet. As
+	// it does not indicate an error, it won't actually be added.
+	if code == pgcode.SuccessfulCompletion {
+		return
+	}
 	set[code] = struct{}{}
 }
 

--- a/pkg/workload/schemachange/generate.go
+++ b/pkg/workload/schemachange/generate.go
@@ -1,0 +1,220 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package schemachange
+
+import (
+	"fmt"
+	"math/rand"
+	"reflect"
+	"strings"
+	"text/template"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/errors"
+	"golang.org/x/exp/slices"
+)
+
+// ErrCaseNotPossible is a sentinel indicating that an elected case could not
+// occur. For example, picking any element from an empty slice.
+var ErrCaseNotPossible = errors.New("case not possible")
+
+// PickOne returns a random element from options. If options is empty, it
+// returns ErrCaseNotPossible.
+func PickOne[T any](rng *rand.Rand, options []T) (T, error) {
+	if len(options) < 1 {
+		var zero T
+		return zero, errors.WithStack(ErrCaseNotPossible)
+	}
+	return options[rng.Intn(len(options))], nil
+}
+
+// PickAtLeast returns [`atLeast`, `len(options)`] elements from options in a
+// random order. It returns ErrCaseNotPossible, if options does not contain
+// `atLeast` elements. It panics if `atLeast` is less than zero.
+func PickAtLeast[T any](rng *rand.Rand, atLeast int, options []T) ([]T, error) {
+	if atLeast > len(options) {
+		return nil, errors.WithStack(ErrCaseNotPossible)
+	}
+	return PickBetween(rng, atLeast, len(options), options)
+}
+
+// PickBetween returns [`atLeast`, `atMost`] elements from options. It panics
+// if `atLeast` or `atMost` is less than zero. It returns ErrCaseNotPossible,
+// if options does not contain `atLeast` elements,
+func PickBetween[T any](rng *rand.Rand, atLeast, atMost int, options []T) ([]T, error) {
+	if atLeast < 0 || atMost < 0 || atLeast > atMost {
+		panic(errors.AssertionFailedf(
+			"bad arguments to PickBetween: [%d, %d]", atLeast, atMost,
+		))
+	}
+
+	if len(options) < atLeast {
+		return nil, errors.WithStack(ErrCaseNotPossible)
+	}
+
+	if atMost > len(options) {
+		atMost = len(options)
+	}
+
+	cloned := slices.Clone(options)
+
+	rng.Shuffle(len(cloned), func(i, j int) {
+		cloned[i], cloned[j] = cloned[j], cloned[i]
+	})
+
+	length := atLeast + rng.Intn(atMost-atLeast+1)
+	return options[:length], nil
+}
+
+// Values is a helper for formatting a list of SQL values within a
+// [GenerationCase]. It delegates to [tree.AsString] and joins the resultant
+// strings with commas.
+// Example Template Usage: `INSERT INTO table VALUES ({HelperThatReturnsValues})
+type Values []tree.NodeFormatter
+
+func AsValues[T tree.NodeFormatter](vals []T, err error) (Values, error) {
+	return util.Map(vals, func(v T) tree.NodeFormatter {
+		return v
+	}), err
+}
+
+// String implements fmt.Stringer.
+func (v Values) String() string {
+	var b strings.Builder
+	for i, nf := range v {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		b.WriteString(tree.AsString(nf))
+	}
+	return b.String()
+}
+
+// GenerationCase is an "interesting" form of a specific [tree.Statement] and
+// the [pgcode.Code] it is expected to return.
+type GenerationCase struct {
+	// Code is the expected [pgcode.Code] of this case. Successful cases should
+	// use [pgcode.SuccessfulCompletion]
+	Code pgcode.Code
+	// Template is a text/template using `{` and `}` as delimiters that should be
+	// parsable as SQL when executed.
+	// Example: `CREATE TABLE {TableName} ({Columns})`
+	Template string
+}
+
+// Generate is a helper to produce a psuedo-random case for a given
+// [tree.Statement]. Functions may return ErrCaseNotPossible to indicate that
+// they can't return an appropriate value. Closures may be used to track state
+// of generation. For example, a "Table" function make set a local variable so
+// that a "Columns" function knows which table to select columns from rather
+// than buffering all possible columns into memory.
+// Usage:
+//
+//	Generate[*tree.AlterType](og.params.rng, og.produceError(), []GenerationCase{
+//		{pgcode.SuccessfulCompletion, `ALTER TYPE {Type} ADD VALUE {Value}`},
+//		{pgcode.FileAlreadyExists, `ALTER TYPE "NeverExists" ADD VALUE "Irrelevant"`},
+//	}, template.FuncMap{
+//		"Type": func() *tree.Name {
+//			// Types that implement tree.NodeFormatter should be used to properly escape values.
+//			return PickOne(og.params.rng, existingTypes)
+//		},
+//		"Value": func() string {
+//			return "foo"
+//		},
+//	})
+func Generate[T tree.Statement](
+	rng *rand.Rand, produceError bool, cases []GenerationCase, funcs template.FuncMap,
+) (T, pgcode.Code, error) {
+	var zero T
+	name := reflect.TypeOf(zero).Name()
+
+	tpl := template.New(name).Delims("{", "}").Funcs(funcs)
+
+	type nameme struct {
+		Code         pgcode.Code
+		TemplateName string
+	}
+
+	// TODO(chrisseto): Consider caching the compiled templates.
+	var compiledCases []nameme
+	for i, gc := range cases {
+		tplName := fmt.Sprintf("Case %d - %s", i, gc.Code.String())
+
+		// If produceError is true, exclude successful cases from our selection.
+		if gc.Code == pgcode.SuccessfulCompletion && produceError {
+			continue
+		}
+
+		caseTpl := tpl.New(tplName)
+		if _, err := caseTpl.Parse(gc.Template); err != nil {
+			return zero, pgcode.Code{}, errors.NewAssertionErrorWithWrappedErrf(err, "failed to parse %q", tplName)
+		}
+
+		compiledCases = append(compiledCases, nameme{
+			Code:         gc.Code,
+			TemplateName: tplName,
+		})
+	}
+
+	// Randomize which case we'll select.
+	rng.Shuffle(len(compiledCases), func(i, j int) {
+		compiledCases[i], compiledCases[j] = compiledCases[j], compiledCases[i]
+	})
+
+	// Prioritize cases that will succeed but pushing them to the front of our
+	// slice. If no successful case is possible, we'll fallback to error cases.
+	slices.SortStableFunc(compiledCases, func(a, b nameme) bool {
+		aIsSuccess := a.Code == pgcode.SuccessfulCompletion
+		bIsSuccess := b.Code == pgcode.SuccessfulCompletion
+
+		return aIsSuccess && !bIsSuccess
+	})
+
+	// TODO(chrisseto): Prioritize cases that have not been previously run to
+	// ensure the widest coverage possible.
+	for _, c := range compiledCases {
+		var raw strings.Builder
+		if err := tpl.ExecuteTemplate(&raw, c.TemplateName, nil); err != nil {
+			// If a case isn't possible, continue iterating until we find a valid
+			// case.
+			if errors.Is(err, ErrCaseNotPossible) {
+				continue
+			}
+			return zero, pgcode.Code{}, errors.WithStack(err)
+		}
+
+		// NB: Parsing the template result as SQL ensures that we catch any
+		// template errors and distinguish them from workload errors. It also
+		// allows us to normalize the outputs so users don't have to worry about
+		// whitespace and/or captialization.
+		stmts, err := parser.Parse(raw.String())
+		if err != nil {
+			return zero, pgcode.Code{}, errors.AssertionFailedf(
+				"syntax error; could not parse %T: %q",
+				zero, raw.String(),
+			)
+		}
+
+		if asT, ok := stmts[0].AST.(T); ok {
+			return asT, c.Code, nil
+		}
+
+		return zero, pgcode.Code{}, errors.AssertionFailedf(
+			"expected to parse %T; got %T: %q",
+			zero, stmts[0].AST, raw.String(),
+		)
+	}
+
+	return zero, pgcode.Code{}, errors.Wrapf(ErrCaseNotPossible, "generating any case for %T", zero)
+}

--- a/pkg/workload/schemachange/generate_test.go
+++ b/pkg/workload/schemachange/generate_test.go
@@ -1,0 +1,165 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package schemachange
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPickOne(t *testing.T) {
+	r := rand.New(rand.NewSource(0))
+
+	v, err := PickOne(r, []int{0, 1, 2, 3, 4})
+	require.NoError(t, err)
+	require.Equal(t, 4, v)
+
+	_, err = PickOne(r, ([]int)(nil))
+	require.ErrorIs(t, err, ErrCaseNotPossible)
+}
+
+func TestPickAtLeast(t *testing.T) {
+	r := rand.New(rand.NewSource(0))
+
+	require.Panics(t, func() {
+		PickAtLeast(r, -1, []int{})
+	})
+
+	out, err := PickAtLeast(r, 0, []int{})
+	require.NoError(t, err)
+	require.Equal(t, []int{}, out)
+
+	_, err = PickAtLeast(r, 1, []int{})
+	require.ErrorIs(t, err, ErrCaseNotPossible)
+
+	out, err = PickAtLeast(r, 3, []int{1, 1, 1})
+	require.NoError(t, err)
+	require.Equal(t, []int{1, 1, 1}, out)
+}
+
+func TestPickBetween(t *testing.T) {
+	r := rand.New(rand.NewSource(0))
+
+	require.Panics(t, func() {
+		PickBetween(r, -1, -1, []int{})
+	})
+
+	require.Panics(t, func() {
+		PickBetween(r, 3, 1, []int{})
+	})
+
+	out, err := PickBetween(r, 0, 2, []int{})
+	require.NoError(t, err)
+	require.Equal(t, []int{}, out)
+
+	_, err = PickBetween(r, 1, 2, []int{})
+	require.ErrorIs(t, err, ErrCaseNotPossible)
+
+	out, err = PickBetween(r, 2, 2, []int{1, 1, 1, 1, 1})
+	require.NoError(t, err)
+	require.Equal(t, []int{1, 1}, out)
+}
+
+func TestValues(t *testing.T) {
+	require.Equal(t, `false, 'some value', "DATA base"."SCHE ma"."TA ble"`, Values{
+		tree.MakeDBool(false),
+		tree.NewDString("some value"),
+		tree.NewTableNameWithSchema("DATA base", "SCHE ma", "TA ble"),
+	}.String())
+}
+
+func TestGenerate(t *testing.T) {
+	r := rand.New(rand.NewSource(0))
+	funcs := map[string]any{
+		"Database": func() *tree.Name {
+			db := tree.Name("MyDatabase")
+			return &db
+		},
+		"ReturnErrCaseNotPossible": func() (tree.Name, error) {
+			return "", ErrCaseNotPossible
+		},
+	}
+
+	t.Run("Successful", func(t *testing.T) {
+		// Successful cases will be prioritized when they are possible and
+		// produceError is false.
+		code, stmt, err := Generate[*tree.RenameDatabase](r, false, []GenerationCase{
+			{pgcode.SuccessfulCompletion, `{ReturnErrCaseNotPossible}`},
+			{pgcode.SuccessfulCompletion, `ALTER DATABASE {Database} RENAME TO NewName`},
+		}, funcs)
+		require.NoError(t, err)
+		require.Equal(t, pgcode.SuccessfulCompletion, code)
+		require.Equal(t, &tree.RenameDatabase{
+			Name:    "MyDatabase",
+			NewName: "newname",
+		}, stmt)
+	})
+
+	t.Run("SyntaxError", func(t *testing.T) {
+		_, _, err := Generate[*tree.RenameDatabase](r, false, []GenerationCase{
+			{pgcode.SuccessfulCompletion, `ALTER DATABASE {Database}`},
+		}, funcs)
+		require.EqualError(t, err, `syntax error; could not parse *tree.RenameDatabase: "ALTER DATABASE \"MyDatabase\""`)
+	})
+
+	t.Run("WrongType", func(t *testing.T) {
+		_, _, err := Generate[*tree.RenameDatabase](r, false, []GenerationCase{
+			{pgcode.SuccessfulCompletion, `ALTER TABLE foo RENAME TO bar`},
+		}, funcs)
+		require.EqualError(t, err, `expected to parse *tree.RenameDatabase; got *tree.RenameTable: "ALTER TABLE foo RENAME TO bar"`)
+	})
+
+	t.Run("NoCasesPossible", func(t *testing.T) {
+		_, _, err := Generate[*tree.RenameDatabase](r, false, nil, funcs)
+		require.ErrorIs(t, err, ErrCaseNotPossible)
+
+		_, _, err = Generate[*tree.RenameDatabase](r, false, []GenerationCase{
+			{pgcode.SuccessfulCompletion, `{ReturnErrCaseNotPossible}`},
+		}, funcs)
+		require.ErrorIs(t, err, ErrCaseNotPossible)
+
+		// Cases will be tried until we either exhaust all cases or we find a valid
+		// case.
+		_, _, err = Generate[*tree.RenameDatabase](r, false, []GenerationCase{
+			{pgcode.SuccessfulCompletion, `{ReturnErrCaseNotPossible}`},
+			{pgcode.SuccessfulCompletion, `{ReturnErrCaseNotPossible}`},
+			{pgcode.SuccessfulCompletion, `{ReturnErrCaseNotPossible}`},
+			{pgcode.SuccessfulCompletion, `ALTER DATABASE foo RENAME TO bar`},
+		}, funcs)
+		require.NoError(t, err)
+	})
+
+	t.Run("ProduceError", func(t *testing.T) {
+		// If the only cases provided are successes and produceError is true, we'll
+		// error out with case not possible.
+		_, _, err := Generate[*tree.RenameDatabase](r, true, []GenerationCase{
+			{pgcode.SuccessfulCompletion, `ALTER DATABASE {Database} RENAME TO NewName`},
+			{pgcode.SuccessfulCompletion, `ALTER DATABASE {Database} RENAME TO NewName`},
+			{pgcode.SuccessfulCompletion, `ALTER DATABASE {Database} RENAME TO NewName`},
+		}, funcs)
+		require.ErrorIs(t, err, ErrCaseNotPossible)
+
+		// Assert that only error cases will be selected if produceError is true.
+		for i := 0; i < 100; i++ {
+			_, _, err := Generate[*tree.RenameDatabase](r, true, []GenerationCase{
+				{pgcode.SuccessfulCompletion, `ALTER DATABASE {Database} RENAME TO NewName`},
+				{pgcode.SuccessfulCompletion, `ALTER DATABASE {Database} RENAME TO NewName`},
+				{pgcode.SuccessfulCompletion, `ALTER DATABASE {Database} RENAME TO NewName`},
+				{pgcode.ReservedName, `ALTER DATABASE {Database} RENAME TO SomeReservedName`},
+			}, funcs)
+			require.NoError(t, err)
+		}
+	})
+}

--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -2674,6 +2674,24 @@ func makeOpStmt(queryType opStmtType) *opStmt {
 	}
 }
 
+// opStmtFromTree constructs an operation from the provide tree.Statement.
+func newOpStmt(stmt tree.Statement, codes codesWithConditions) *opStmt {
+	queryType := OpStmtDDL
+	if stmt.StatementType() != tree.TypeDDL {
+		queryType = OpStmtDML
+	}
+
+	expectedErrors := makeExpectedErrorSet()
+	expectedErrors.addAll(codes)
+
+	return &opStmt{
+		sql:                 tree.Serialize(stmt),
+		queryType:           queryType,
+		expectedExecErrors:  expectedErrors,
+		potentialExecErrors: makeExpectedErrorSet(),
+	}
+}
+
 // ErrorState wraps schemachange workload errors to have state information for
 // the purpose of dumping in our JSON log.
 type ErrorState struct {


### PR DESCRIPTION
Previously, workload/schemachange operation generators were bespoke implements per DDL. This added a high degree of effort towards adding new DDL. Maintaining or debugging previously added DDLs could also be quite difficult.

One of the primary difficulties was calling out the various forms a DDL could take and then randomly opting for one. This was due to having a mixture of valid and invalid cases and, at times, impossible cases.

This commit implements a text/template based helper `Generate` for aiding the development and maintenance of operation generators.

Epic: CRDB-19168
Release note: None