### PR TITLE
sql: builtint for jsonb array to string array conversion

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -337,6 +337,8 @@
 </span></td><td>Immutable</td></tr>
 <tr><td><a name="cardinality"></a><code>cardinality(input: anyelement[]) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Calculates the number of elements contained in <code>input</code></p>
 </span></td><td>Immutable</td></tr>
+<tr><td><a name="jsonb_array_to_string_array"></a><code>jsonb_array_to_string_array(input: jsonb) &rarr; <a href="string.html">string</a>[]</code></td><td><span class="funcdesc"><p>Convert a JSONB array into a string array.</p>
+</span></td><td>Immutable</td></tr>
 <tr><td><a name="string_to_array"></a><code>string_to_array(str: <a href="string.html">string</a>, delimiter: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a>[]</code></td><td><span class="funcdesc"><p>Split a string into components on a delimiter.</p>
 </span></td><td>Immutable</td></tr>
 <tr><td><a name="string_to_array"></a><code>string_to_array(str: <a href="string.html">string</a>, delimiter: <a href="string.html">string</a>, null: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a>[]</code></td><td><span class="funcdesc"><p>Split a string into components on a delimiter with a specified string to consider NULL.</p>

--- a/pkg/sql/logictest/testdata/logic_test/array
+++ b/pkg/sql/logictest/testdata/logic_test/array
@@ -1191,6 +1191,30 @@ SELECT string_to_array('foofoofoofoo', 'foo', 'foo')
 ----
 {"","","","",""}
 
+# jsonb_array_to_string_array function
+
+statement ok
+CREATE TABLE str_arr(j JSONB)
+
+statement ok
+INSERT INTO str_arr
+VALUES
+    ('{"a": ["foo", "bar", "z"]}'),
+    ('{"a": ["1", "2", "3"]}'),
+    ('{"a": []}'),
+    ('{"b": "not-array"}')
+
+query T
+SELECT jsonb_array_to_string_array(j -> 'a') FROM str_arr ORDER BY j ASC
+----
+{}
+{1,2,3}
+{foo,bar,z}
+{}
+
+query error input argument must be JSON array type
+SELECT jsonb_array_to_string_array(j -> 'b') FROM str_arr ORDER BY j ASC
+
 # Regression test for #23429.
 
 statement ok

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -2485,6 +2485,7 @@ var builtinOidsArray = []string{
 	2514: `crdb_internal.start_replication_stream(tenant_name: string, spec: bytes) -> bytes`,
 	2515: `crdb_internal.privilege_name(internal_key: string) -> string`,
 	2516: `crdb_internal.privilege_name(internal_key: string[]) -> string[]`,
+	2517: `jsonb_array_to_string_array(input: jsonb) -> string[]`,
 }
 
 var builtinOidsBySignature map[string]oid.Oid


### PR DESCRIPTION
This commit introduces the function
`jsonb_array_to_string_array` that converts a JSONB array to a string array format.

Epic: none

Release note (sql change): New builtin that converts JSONB array to string array.