### PR TITLE
backupccl: retire bulkio.restore.remove_regions.enabled

### DIFF
--- a/pkg/settings/registry.go
+++ b/pkg/settings/registry.go
@@ -227,6 +227,7 @@ var retiredSettings = map[InternalKey]struct{}{
 	"changefeed.lagging_ranges_polling_rate":                   {},
 	"trace.jaeger.agent":                                       {},
 	"bulkio.restore.use_simple_import_spans":                   {},
+	"bulkio.restore.remove_regions.enabled":                    {},
 
 	// removed as of 24.1
 	"storage.mvcc.range_tombstones.enabled": {},


### PR DESCRIPTION
This patch adds cluster setting bulkio.restore.remove_regions.enabled to the retiredSettings map. The cluster setting was added to 23.1 with the following context: #111863.

Epic: none
Fixes: #112199

Release note: None