### PR TITLE
jobs: handle retryable errors waiting for jobs

### DIFF
--- a/pkg/jobs/BUILD.bazel
+++ b/pkg/jobs/BUILD.bazel
@@ -140,6 +140,7 @@ go_test(
         "//pkg/sql/catalog/colinfo",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/desctestutils",
+        "//pkg/sql/catalog/lease",
         "//pkg/sql/catalog/tabledesc",
         "//pkg/sql/isql",
         "//pkg/sql/sem/tree",

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -1783,7 +1783,7 @@ func (ief *InternalDB) txn(
 			}
 
 			return commitTxnFn(ctx)
-		}); descs.IsTwoVersionInvariantViolationError(err) {
+		}); errIsRetriable(err) {
 			continue
 		} else {
 			if err == nil {


### PR DESCRIPTION
Previously, when waiting for jobs if the internal executor hit any retryable errors, we would incorrectly bubble these errors up. This would intermittently be seen in leasing tests, which intentionally disable renewals, increasing the likelihood of transaction retry errors. To address this, this patch will modify waitForJobs to handle retryable errors gracefully.

Fixes: #112392
fixes #110642
fixes #111166
fixes https://github.com/cockroachdb/cockroach/issues/112696
fixes https://github.com/cockroachdb/cockroach/issues/112180
fixes https://github.com/cockroachdb/cockroach/issues/112377

Release note: None