### PR TITLE
scplan: Remove extra rule in `rule/release_23_1` directory

### DIFF
--- a/pkg/cli/testdata/declarative-rules/deprules
+++ b/pkg/cli/testdata/declarative-rules/deprules
@@ -293,114 +293,6 @@ deprules
     - descriptorIsNotBeingDropped-23.1($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
-- name: Constraint should be hidden before name
-  from: constraint-name-Node
-  kind: Precedence
-  to: constraint-Node
-  query:
-    - $constraint-name[Type] = '*scpb.ConstraintWithoutIndexName'
-    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
-    - joinOnConstraintID($constraint-name, $constraint, $table-id, $constraint-id)
-    - toAbsent($constraint-name-Target, $constraint-Target)
-    - $constraint-name-Node[CurrentStatus] = ABSENT
-    - $constraint-Node[CurrentStatus] = ABSENT
-    - joinTargetNode($constraint-name, $constraint-name-Target, $constraint-name-Node)
-    - joinTargetNode($constraint, $constraint-Target, $constraint-Node)
-- name: Constraint should be hidden before name
-  from: constraint-name-Node
-  kind: Precedence
-  to: constraint-Node
-  query:
-    - $constraint-name[Type] = '*scpb.ConstraintWithoutIndexName'
-    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
-    - joinOnConstraintID($constraint-name, $constraint, $table-id, $constraint-id)
-    - transient($constraint-name-Target, $constraint-Target)
-    - $constraint-name-Node[CurrentStatus] = TRANSIENT_ABSENT
-    - $constraint-Node[CurrentStatus] = TRANSIENT_ABSENT
-    - joinTargetNode($constraint-name, $constraint-name-Target, $constraint-name-Node)
-    - joinTargetNode($constraint, $constraint-Target, $constraint-Node)
-- name: Constraint should be hidden before name
-  from: constraint-name-Node
-  kind: Precedence
-  to: constraint-Node
-  query:
-    - $constraint-name[Type] = '*scpb.ConstraintWithoutIndexName'
-    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
-    - joinOnConstraintID($constraint-name, $constraint, $table-id, $constraint-id)
-    - $constraint-name-Target[TargetStatus] = TRANSIENT_ABSENT
-    - $constraint-name-Node[CurrentStatus] = TRANSIENT_ABSENT
-    - $constraint-Target[TargetStatus] = ABSENT
-    - $constraint-Node[CurrentStatus] = ABSENT
-    - joinTargetNode($constraint-name, $constraint-name-Target, $constraint-name-Node)
-    - joinTargetNode($constraint, $constraint-Target, $constraint-Node)
-- name: Constraint should be hidden before name
-  from: constraint-name-Node
-  kind: Precedence
-  to: constraint-Node
-  query:
-    - $constraint-name[Type] = '*scpb.ConstraintWithoutIndexName'
-    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
-    - joinOnConstraintID($constraint-name, $constraint, $table-id, $constraint-id)
-    - $constraint-name-Target[TargetStatus] = ABSENT
-    - $constraint-name-Node[CurrentStatus] = ABSENT
-    - $constraint-Target[TargetStatus] = TRANSIENT_ABSENT
-    - $constraint-Node[CurrentStatus] = TRANSIENT_ABSENT
-    - joinTargetNode($constraint-name, $constraint-name-Target, $constraint-name-Node)
-    - joinTargetNode($constraint, $constraint-Target, $constraint-Node)
-- name: Constraint should be hidden before name
-  from: constraint-Node
-  kind: Precedence
-  to: constraint-name-Node
-  query:
-    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
-    - $constraint-name[Type] = '*scpb.ConstraintWithoutIndexName'
-    - joinOnConstraintID($constraint, $constraint-name, $table-id, $constraint-id)
-    - toAbsent($constraint-Target, $constraint-name-Target)
-    - $constraint-Node[CurrentStatus] = VALIDATED
-    - $constraint-name-Node[CurrentStatus] = ABSENT
-    - joinTargetNode($constraint, $constraint-Target, $constraint-Node)
-    - joinTargetNode($constraint-name, $constraint-name-Target, $constraint-name-Node)
-- name: Constraint should be hidden before name
-  from: constraint-Node
-  kind: Precedence
-  to: constraint-name-Node
-  query:
-    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
-    - $constraint-name[Type] = '*scpb.ConstraintWithoutIndexName'
-    - joinOnConstraintID($constraint, $constraint-name, $table-id, $constraint-id)
-    - transient($constraint-Target, $constraint-name-Target)
-    - $constraint-Node[CurrentStatus] = TRANSIENT_VALIDATED
-    - $constraint-name-Node[CurrentStatus] = TRANSIENT_ABSENT
-    - joinTargetNode($constraint, $constraint-Target, $constraint-Node)
-    - joinTargetNode($constraint-name, $constraint-name-Target, $constraint-name-Node)
-- name: Constraint should be hidden before name
-  from: constraint-Node
-  kind: Precedence
-  to: constraint-name-Node
-  query:
-    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
-    - $constraint-name[Type] = '*scpb.ConstraintWithoutIndexName'
-    - joinOnConstraintID($constraint, $constraint-name, $table-id, $constraint-id)
-    - $constraint-Target[TargetStatus] = TRANSIENT_ABSENT
-    - $constraint-Node[CurrentStatus] = TRANSIENT_VALIDATED
-    - $constraint-name-Target[TargetStatus] = ABSENT
-    - $constraint-name-Node[CurrentStatus] = ABSENT
-    - joinTargetNode($constraint, $constraint-Target, $constraint-Node)
-    - joinTargetNode($constraint-name, $constraint-name-Target, $constraint-name-Node)
-- name: Constraint should be hidden before name
-  from: constraint-Node
-  kind: Precedence
-  to: constraint-name-Node
-  query:
-    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
-    - $constraint-name[Type] = '*scpb.ConstraintWithoutIndexName'
-    - joinOnConstraintID($constraint, $constraint-name, $table-id, $constraint-id)
-    - $constraint-Target[TargetStatus] = ABSENT
-    - $constraint-Node[CurrentStatus] = VALIDATED
-    - $constraint-name-Target[TargetStatus] = TRANSIENT_ABSENT
-    - $constraint-name-Node[CurrentStatus] = TRANSIENT_ABSENT
-    - joinTargetNode($constraint, $constraint-Target, $constraint-Node)
-    - joinTargetNode($constraint-name, $constraint-name-Target, $constraint-name-Node)
 - name: DEFAULT or ON UPDATE existence precedes writes to column
   from: expr-Node
   kind: Precedence
@@ -1900,7 +1792,7 @@ deprules
   kind: SameStagePrecedence
   to: complex-constraint-Node
   query:
-    - $dependent[Type] = '*scpb.ConstraintComment'
+    - $dependent[Type] IN ['*scpb.ConstraintComment', '*scpb.ConstraintWithoutIndexName']
     - $complex-constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.UniqueWithoutIndexConstraint']
     - joinOnConstraintID($dependent, $complex-constraint, $table-id, $constraint-id)
     - ToPublicOrTransient($dependent-Target, $complex-constraint-Target)
@@ -1914,7 +1806,7 @@ deprules
   to: dependent-Node
   query:
     - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.UniqueWithoutIndexConstraint']
-    - $dependent[Type] = '*scpb.ConstraintComment'
+    - $dependent[Type] IN ['*scpb.ConstraintComment', '*scpb.ConstraintWithoutIndexName']
     - joinOnConstraintID($constraint, $dependent, $table-id, $constraint-id)
     - toAbsent($constraint-Target, $dependent-Target)
     - $constraint-Node[CurrentStatus] = VALIDATED
@@ -1927,7 +1819,7 @@ deprules
   to: dependent-Node
   query:
     - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.UniqueWithoutIndexConstraint']
-    - $dependent[Type] = '*scpb.ConstraintComment'
+    - $dependent[Type] IN ['*scpb.ConstraintComment', '*scpb.ConstraintWithoutIndexName']
     - joinOnConstraintID($constraint, $dependent, $table-id, $constraint-id)
     - transient($constraint-Target, $dependent-Target)
     - $constraint-Node[CurrentStatus] = TRANSIENT_VALIDATED
@@ -1940,7 +1832,7 @@ deprules
   to: dependent-Node
   query:
     - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.UniqueWithoutIndexConstraint']
-    - $dependent[Type] = '*scpb.ConstraintComment'
+    - $dependent[Type] IN ['*scpb.ConstraintComment', '*scpb.ConstraintWithoutIndexName']
     - joinOnConstraintID($constraint, $dependent, $table-id, $constraint-id)
     - $constraint-Target[TargetStatus] = TRANSIENT_ABSENT
     - $constraint-Node[CurrentStatus] = TRANSIENT_VALIDATED
@@ -1954,7 +1846,7 @@ deprules
   to: dependent-Node
   query:
     - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.UniqueWithoutIndexConstraint']
-    - $dependent[Type] = '*scpb.ConstraintComment'
+    - $dependent[Type] IN ['*scpb.ConstraintComment', '*scpb.ConstraintWithoutIndexName']
     - joinOnConstraintID($constraint, $dependent, $table-id, $constraint-id)
     - $constraint-Target[TargetStatus] = ABSENT
     - $constraint-Node[CurrentStatus] = VALIDATED
@@ -2168,7 +2060,7 @@ deprules
   kind: Precedence
   to: constraint-Node
   query:
-    - $dependents[Type] = '*scpb.ConstraintComment'
+    - $dependents[Type] IN ['*scpb.ConstraintComment', '*scpb.ConstraintWithoutIndexName']
     - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.UniqueWithoutIndexConstraint']
     - joinOnConstraintID($dependents, $constraint, $table-id, $constraint-id)
     - toAbsent($dependents-Target, $constraint-Target)
@@ -2181,7 +2073,7 @@ deprules
   kind: Precedence
   to: constraint-Node
   query:
-    - $dependents[Type] = '*scpb.ConstraintComment'
+    - $dependents[Type] IN ['*scpb.ConstraintComment', '*scpb.ConstraintWithoutIndexName']
     - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.UniqueWithoutIndexConstraint']
     - joinOnConstraintID($dependents, $constraint, $table-id, $constraint-id)
     - transient($dependents-Target, $constraint-Target)
@@ -2194,7 +2086,7 @@ deprules
   kind: Precedence
   to: constraint-Node
   query:
-    - $dependents[Type] = '*scpb.ConstraintComment'
+    - $dependents[Type] IN ['*scpb.ConstraintComment', '*scpb.ConstraintWithoutIndexName']
     - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.UniqueWithoutIndexConstraint']
     - joinOnConstraintID($dependents, $constraint, $table-id, $constraint-id)
     - $dependents-Target[TargetStatus] = TRANSIENT_ABSENT
@@ -2208,7 +2100,7 @@ deprules
   kind: Precedence
   to: constraint-Node
   query:
-    - $dependents[Type] = '*scpb.ConstraintComment'
+    - $dependents[Type] IN ['*scpb.ConstraintComment', '*scpb.ConstraintWithoutIndexName']
     - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.UniqueWithoutIndexConstraint']
     - joinOnConstraintID($dependents, $constraint, $table-id, $constraint-id)
     - $dependents-Target[TargetStatus] = ABSENT
@@ -2276,7 +2168,7 @@ deprules
   kind: SameStagePrecedence
   to: constraint-Node
   query:
-    - $dependents[Type] = '*scpb.ConstraintComment'
+    - $dependents[Type] IN ['*scpb.ConstraintComment', '*scpb.ConstraintWithoutIndexName']
     - $constraint[Type] IN ['*scpb.CheckConstraintUnvalidated', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
     - joinOnConstraintID($dependents, $constraint, $table-id, $constraint-id)
     - toAbsent($dependents-Target, $constraint-Target)
@@ -2289,7 +2181,7 @@ deprules
   kind: SameStagePrecedence
   to: constraint-Node
   query:
-    - $dependents[Type] = '*scpb.ConstraintComment'
+    - $dependents[Type] IN ['*scpb.ConstraintComment', '*scpb.ConstraintWithoutIndexName']
     - $constraint[Type] IN ['*scpb.CheckConstraintUnvalidated', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
     - joinOnConstraintID($dependents, $constraint, $table-id, $constraint-id)
     - transient($dependents-Target, $constraint-Target)
@@ -2302,7 +2194,7 @@ deprules
   kind: SameStagePrecedence
   to: constraint-Node
   query:
-    - $dependents[Type] = '*scpb.ConstraintComment'
+    - $dependents[Type] IN ['*scpb.ConstraintComment', '*scpb.ConstraintWithoutIndexName']
     - $constraint[Type] IN ['*scpb.CheckConstraintUnvalidated', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
     - joinOnConstraintID($dependents, $constraint, $table-id, $constraint-id)
     - $dependents-Target[TargetStatus] = TRANSIENT_ABSENT
@@ -2316,7 +2208,7 @@ deprules
   kind: SameStagePrecedence
   to: constraint-Node
   query:
-    - $dependents[Type] = '*scpb.ConstraintComment'
+    - $dependents[Type] IN ['*scpb.ConstraintComment', '*scpb.ConstraintWithoutIndexName']
     - $constraint[Type] IN ['*scpb.CheckConstraintUnvalidated', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
     - joinOnConstraintID($dependents, $constraint, $table-id, $constraint-id)
     - $dependents-Target[TargetStatus] = ABSENT
@@ -3400,19 +3292,6 @@ deprules
     - $dependent-Node[CurrentStatus] = PUBLIC
     - joinTargetNode($simple-constraint, $simple-constraint-Target, $simple-constraint-Node)
     - joinTargetNode($dependent, $dependent-Target, $dependent-Node)
-- name: simple constraint visible before name
-  from: simple-constraint-Node
-  kind: Precedence
-  to: constraint-name-Node
-  query:
-    - $simple-constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
-    - $constraint-name[Type] = '*scpb.ConstraintWithoutIndexName'
-    - joinOnConstraintID($simple-constraint, $constraint-name, $table-id, $constraint-id)
-    - ToPublicOrTransient($simple-constraint-Target, $constraint-name-Target)
-    - $simple-constraint-Node[CurrentStatus] = WRITE_ONLY
-    - $constraint-name-Node[CurrentStatus] = PUBLIC
-    - joinTargetNode($simple-constraint, $simple-constraint-Target, $simple-constraint-Node)
-    - joinTargetNode($constraint-name, $constraint-name-Target, $constraint-name-Node)
 - name: swapped primary index public before column
   from: index-Node
   kind: Precedence

--- a/pkg/sql/schemachanger/scplan/internal/rules/release_23_1/dep_add_constraint.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/release_23_1/dep_add_constraint.go
@@ -26,7 +26,7 @@ func init() {
 		"dependent", "complex-constraint",
 		func(from, to NodeVars) rel.Clauses {
 			return rel.Clauses{
-				from.TypeFilter(rulesVersionKey, isConstraintDependent, Not(isConstraintWithIndexName)),
+				from.TypeFilter(rulesVersionKey, isConstraintDependent),
 				to.TypeFilter(rulesVersionKey, isNonIndexBackedConstraint, isSubjectTo2VersionInvariant),
 				JoinOnConstraintID(from, to, "table-id", "constraint-id"),
 				StatusesToPublicOrTransient(from, scpb.Status_PUBLIC, to, scpb.Status_PUBLIC),
@@ -44,22 +44,6 @@ func init() {
 				to.TypeFilter(rulesVersionKey, isConstraintDependent),
 				JoinOnConstraintID(from, to, "table-id", "constraint-id"),
 				StatusesToPublicOrTransient(from, scpb.Status_PUBLIC, to, scpb.Status_PUBLIC),
-			}
-		},
-	)
-
-	// Constraint name should be assigned right before it becomes visible, otherwise
-	// we won't have the correct message inside errors.
-	registerDepRule(
-		"simple constraint visible before name",
-		scgraph.Precedence,
-		"simple-constraint", "constraint-name",
-		func(from, to NodeVars) rel.Clauses {
-			return rel.Clauses{
-				from.TypeFilter(rulesVersionKey, isNonIndexBackedConstraint),
-				to.TypeFilter(rulesVersionKey, isConstraintWithIndexName),
-				JoinOnConstraintID(from, to, "table-id", "constraint-id"),
-				StatusesToPublicOrTransient(from, scpb.Status_WRITE_ONLY, to, scpb.Status_PUBLIC),
 			}
 		},
 	)

--- a/pkg/sql/schemachanger/scplan/internal/rules/release_23_1/dep_drop_constraint.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/release_23_1/dep_drop_constraint.go
@@ -29,7 +29,7 @@ func init() {
 		func(from, to NodeVars) rel.Clauses {
 			return rel.Clauses{
 				from.TypeFilter(rulesVersionKey, isNonIndexBackedConstraint, isSubjectTo2VersionInvariant),
-				to.TypeFilter(rulesVersionKey, isConstraintDependent, Not(isConstraintWithIndexName)),
+				to.TypeFilter(rulesVersionKey, isConstraintDependent),
 				JoinOnConstraintID(from, to, "table-id", "constraint-id"),
 			}
 		},
@@ -42,7 +42,7 @@ func init() {
 		scpb.Status_ABSENT, scpb.Status_ABSENT,
 		func(from, to NodeVars) rel.Clauses {
 			return rel.Clauses{
-				from.TypeFilter(rulesVersionKey, isConstraintDependent, Not(isConstraintWithIndexName)),
+				from.TypeFilter(rulesVersionKey, isConstraintDependent),
 				to.TypeFilter(rulesVersionKey, isNonIndexBackedConstraint, isSubjectTo2VersionInvariant),
 				JoinOnConstraintID(from, to, "table-id", "constraint-id"),
 			}
@@ -61,39 +61,8 @@ func init() {
 		scpb.Status_ABSENT, scpb.Status_ABSENT,
 		func(from, to NodeVars) rel.Clauses {
 			return rel.Clauses{
-				from.TypeFilter(rulesVersionKey, isConstraintDependent, Not(isConstraintWithIndexName)),
+				from.TypeFilter(rulesVersionKey, isConstraintDependent),
 				to.TypeFilter(rulesVersionKey, isNonIndexBackedConstraint, Not(isSubjectTo2VersionInvariant)),
-				JoinOnConstraintID(from, to, "table-id", "constraint-id"),
-			}
-		},
-	)
-
-	// Constraint name should be cleared right before the constraint is no
-	// longer visible.
-	registerDepRuleForDrop(
-		"Constraint should be hidden before name",
-		scgraph.Precedence,
-		"constraint-name", "constraint",
-		scpb.Status_ABSENT, scpb.Status_ABSENT,
-		func(from, to NodeVars) rel.Clauses {
-			return rel.Clauses{
-				from.Type((*scpb.ConstraintWithoutIndexName)(nil)),
-				to.TypeFilter(rulesVersionKey, isNonIndexBackedConstraint),
-				JoinOnConstraintID(from, to, "table-id", "constraint-id"),
-			}
-		},
-	)
-	// Constraint should be validated before the constraint name is attempted
-	// to be cleaned.
-	registerDepRuleForDrop(
-		"Constraint should be hidden before name",
-		scgraph.Precedence,
-		"constraint", "constraint-name",
-		scpb.Status_VALIDATED, scpb.Status_ABSENT,
-		func(from, to NodeVars) rel.Clauses {
-			return rel.Clauses{
-				from.TypeFilter(rulesVersionKey, isNonIndexBackedConstraint),
-				to.Type((*scpb.ConstraintWithoutIndexName)(nil)),
 				JoinOnConstraintID(from, to, "table-id", "constraint-id"),
 			}
 		},

--- a/pkg/sql/schemachanger/scplan/internal/rules/release_23_1/helpers.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/release_23_1/helpers.go
@@ -264,14 +264,6 @@ func isConstraintDependent(e scpb.Element) bool {
 	return false
 }
 
-func isConstraintWithIndexName(e scpb.Element) bool {
-	switch e.(type) {
-	case *scpb.ConstraintWithoutIndexName:
-		return true
-	}
-	return false
-}
-
 func isData(e scpb.Element) bool {
 	switch e.(type) {
 	case *scpb.DatabaseData:

--- a/pkg/sql/schemachanger/scplan/internal/rules/release_23_1/testdata/deprules
+++ b/pkg/sql/schemachanger/scplan/internal/rules/release_23_1/testdata/deprules
@@ -290,114 +290,6 @@ deprules
     - descriptorIsNotBeingDropped-23.1($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
-- name: Constraint should be hidden before name
-  from: constraint-name-Node
-  kind: Precedence
-  to: constraint-Node
-  query:
-    - $constraint-name[Type] = '*scpb.ConstraintWithoutIndexName'
-    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
-    - joinOnConstraintID($constraint-name, $constraint, $table-id, $constraint-id)
-    - toAbsent($constraint-name-Target, $constraint-Target)
-    - $constraint-name-Node[CurrentStatus] = ABSENT
-    - $constraint-Node[CurrentStatus] = ABSENT
-    - joinTargetNode($constraint-name, $constraint-name-Target, $constraint-name-Node)
-    - joinTargetNode($constraint, $constraint-Target, $constraint-Node)
-- name: Constraint should be hidden before name
-  from: constraint-name-Node
-  kind: Precedence
-  to: constraint-Node
-  query:
-    - $constraint-name[Type] = '*scpb.ConstraintWithoutIndexName'
-    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
-    - joinOnConstraintID($constraint-name, $constraint, $table-id, $constraint-id)
-    - transient($constraint-name-Target, $constraint-Target)
-    - $constraint-name-Node[CurrentStatus] = TRANSIENT_ABSENT
-    - $constraint-Node[CurrentStatus] = TRANSIENT_ABSENT
-    - joinTargetNode($constraint-name, $constraint-name-Target, $constraint-name-Node)
-    - joinTargetNode($constraint, $constraint-Target, $constraint-Node)
-- name: Constraint should be hidden before name
-  from: constraint-name-Node
-  kind: Precedence
-  to: constraint-Node
-  query:
-    - $constraint-name[Type] = '*scpb.ConstraintWithoutIndexName'
-    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
-    - joinOnConstraintID($constraint-name, $constraint, $table-id, $constraint-id)
-    - $constraint-name-Target[TargetStatus] = TRANSIENT_ABSENT
-    - $constraint-name-Node[CurrentStatus] = TRANSIENT_ABSENT
-    - $constraint-Target[TargetStatus] = ABSENT
-    - $constraint-Node[CurrentStatus] = ABSENT
-    - joinTargetNode($constraint-name, $constraint-name-Target, $constraint-name-Node)
-    - joinTargetNode($constraint, $constraint-Target, $constraint-Node)
-- name: Constraint should be hidden before name
-  from: constraint-name-Node
-  kind: Precedence
-  to: constraint-Node
-  query:
-    - $constraint-name[Type] = '*scpb.ConstraintWithoutIndexName'
-    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
-    - joinOnConstraintID($constraint-name, $constraint, $table-id, $constraint-id)
-    - $constraint-name-Target[TargetStatus] = ABSENT
-    - $constraint-name-Node[CurrentStatus] = ABSENT
-    - $constraint-Target[TargetStatus] = TRANSIENT_ABSENT
-    - $constraint-Node[CurrentStatus] = TRANSIENT_ABSENT
-    - joinTargetNode($constraint-name, $constraint-name-Target, $constraint-name-Node)
-    - joinTargetNode($constraint, $constraint-Target, $constraint-Node)
-- name: Constraint should be hidden before name
-  from: constraint-Node
-  kind: Precedence
-  to: constraint-name-Node
-  query:
-    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
-    - $constraint-name[Type] = '*scpb.ConstraintWithoutIndexName'
-    - joinOnConstraintID($constraint, $constraint-name, $table-id, $constraint-id)
-    - toAbsent($constraint-Target, $constraint-name-Target)
-    - $constraint-Node[CurrentStatus] = VALIDATED
-    - $constraint-name-Node[CurrentStatus] = ABSENT
-    - joinTargetNode($constraint, $constraint-Target, $constraint-Node)
-    - joinTargetNode($constraint-name, $constraint-name-Target, $constraint-name-Node)
-- name: Constraint should be hidden before name
-  from: constraint-Node
-  kind: Precedence
-  to: constraint-name-Node
-  query:
-    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
-    - $constraint-name[Type] = '*scpb.ConstraintWithoutIndexName'
-    - joinOnConstraintID($constraint, $constraint-name, $table-id, $constraint-id)
-    - transient($constraint-Target, $constraint-name-Target)
-    - $constraint-Node[CurrentStatus] = TRANSIENT_VALIDATED
-    - $constraint-name-Node[CurrentStatus] = TRANSIENT_ABSENT
-    - joinTargetNode($constraint, $constraint-Target, $constraint-Node)
-    - joinTargetNode($constraint-name, $constraint-name-Target, $constraint-name-Node)
-- name: Constraint should be hidden before name
-  from: constraint-Node
-  kind: Precedence
-  to: constraint-name-Node
-  query:
-    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
-    - $constraint-name[Type] = '*scpb.ConstraintWithoutIndexName'
-    - joinOnConstraintID($constraint, $constraint-name, $table-id, $constraint-id)
-    - $constraint-Target[TargetStatus] = TRANSIENT_ABSENT
-    - $constraint-Node[CurrentStatus] = TRANSIENT_VALIDATED
-    - $constraint-name-Target[TargetStatus] = ABSENT
-    - $constraint-name-Node[CurrentStatus] = ABSENT
-    - joinTargetNode($constraint, $constraint-Target, $constraint-Node)
-    - joinTargetNode($constraint-name, $constraint-name-Target, $constraint-name-Node)
-- name: Constraint should be hidden before name
-  from: constraint-Node
-  kind: Precedence
-  to: constraint-name-Node
-  query:
-    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
-    - $constraint-name[Type] = '*scpb.ConstraintWithoutIndexName'
-    - joinOnConstraintID($constraint, $constraint-name, $table-id, $constraint-id)
-    - $constraint-Target[TargetStatus] = ABSENT
-    - $constraint-Node[CurrentStatus] = VALIDATED
-    - $constraint-name-Target[TargetStatus] = TRANSIENT_ABSENT
-    - $constraint-name-Node[CurrentStatus] = TRANSIENT_ABSENT
-    - joinTargetNode($constraint, $constraint-Target, $constraint-Node)
-    - joinTargetNode($constraint-name, $constraint-name-Target, $constraint-name-Node)
 - name: DEFAULT or ON UPDATE existence precedes writes to column
   from: expr-Node
   kind: Precedence
@@ -1897,7 +1789,7 @@ deprules
   kind: SameStagePrecedence
   to: complex-constraint-Node
   query:
-    - $dependent[Type] = '*scpb.ConstraintComment'
+    - $dependent[Type] IN ['*scpb.ConstraintComment', '*scpb.ConstraintWithoutIndexName']
     - $complex-constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.UniqueWithoutIndexConstraint']
     - joinOnConstraintID($dependent, $complex-constraint, $table-id, $constraint-id)
     - ToPublicOrTransient($dependent-Target, $complex-constraint-Target)
@@ -1911,7 +1803,7 @@ deprules
   to: dependent-Node
   query:
     - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.UniqueWithoutIndexConstraint']
-    - $dependent[Type] = '*scpb.ConstraintComment'
+    - $dependent[Type] IN ['*scpb.ConstraintComment', '*scpb.ConstraintWithoutIndexName']
     - joinOnConstraintID($constraint, $dependent, $table-id, $constraint-id)
     - toAbsent($constraint-Target, $dependent-Target)
     - $constraint-Node[CurrentStatus] = VALIDATED
@@ -1924,7 +1816,7 @@ deprules
   to: dependent-Node
   query:
     - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.UniqueWithoutIndexConstraint']
-    - $dependent[Type] = '*scpb.ConstraintComment'
+    - $dependent[Type] IN ['*scpb.ConstraintComment', '*scpb.ConstraintWithoutIndexName']
     - joinOnConstraintID($constraint, $dependent, $table-id, $constraint-id)
     - transient($constraint-Target, $dependent-Target)
     - $constraint-Node[CurrentStatus] = TRANSIENT_VALIDATED
@@ -1937,7 +1829,7 @@ deprules
   to: dependent-Node
   query:
     - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.UniqueWithoutIndexConstraint']
-    - $dependent[Type] = '*scpb.ConstraintComment'
+    - $dependent[Type] IN ['*scpb.ConstraintComment', '*scpb.ConstraintWithoutIndexName']
     - joinOnConstraintID($constraint, $dependent, $table-id, $constraint-id)
     - $constraint-Target[TargetStatus] = TRANSIENT_ABSENT
     - $constraint-Node[CurrentStatus] = TRANSIENT_VALIDATED
@@ -1951,7 +1843,7 @@ deprules
   to: dependent-Node
   query:
     - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.UniqueWithoutIndexConstraint']
-    - $dependent[Type] = '*scpb.ConstraintComment'
+    - $dependent[Type] IN ['*scpb.ConstraintComment', '*scpb.ConstraintWithoutIndexName']
     - joinOnConstraintID($constraint, $dependent, $table-id, $constraint-id)
     - $constraint-Target[TargetStatus] = ABSENT
     - $constraint-Node[CurrentStatus] = VALIDATED
@@ -2165,7 +2057,7 @@ deprules
   kind: Precedence
   to: constraint-Node
   query:
-    - $dependents[Type] = '*scpb.ConstraintComment'
+    - $dependents[Type] IN ['*scpb.ConstraintComment', '*scpb.ConstraintWithoutIndexName']
     - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.UniqueWithoutIndexConstraint']
     - joinOnConstraintID($dependents, $constraint, $table-id, $constraint-id)
     - toAbsent($dependents-Target, $constraint-Target)
@@ -2178,7 +2070,7 @@ deprules
   kind: Precedence
   to: constraint-Node
   query:
-    - $dependents[Type] = '*scpb.ConstraintComment'
+    - $dependents[Type] IN ['*scpb.ConstraintComment', '*scpb.ConstraintWithoutIndexName']
     - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.UniqueWithoutIndexConstraint']
     - joinOnConstraintID($dependents, $constraint, $table-id, $constraint-id)
     - transient($dependents-Target, $constraint-Target)
@@ -2191,7 +2083,7 @@ deprules
   kind: Precedence
   to: constraint-Node
   query:
-    - $dependents[Type] = '*scpb.ConstraintComment'
+    - $dependents[Type] IN ['*scpb.ConstraintComment', '*scpb.ConstraintWithoutIndexName']
     - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.UniqueWithoutIndexConstraint']
     - joinOnConstraintID($dependents, $constraint, $table-id, $constraint-id)
     - $dependents-Target[TargetStatus] = TRANSIENT_ABSENT
@@ -2205,7 +2097,7 @@ deprules
   kind: Precedence
   to: constraint-Node
   query:
-    - $dependents[Type] = '*scpb.ConstraintComment'
+    - $dependents[Type] IN ['*scpb.ConstraintComment', '*scpb.ConstraintWithoutIndexName']
     - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.UniqueWithoutIndexConstraint']
     - joinOnConstraintID($dependents, $constraint, $table-id, $constraint-id)
     - $dependents-Target[TargetStatus] = ABSENT
@@ -2273,7 +2165,7 @@ deprules
   kind: SameStagePrecedence
   to: constraint-Node
   query:
-    - $dependents[Type] = '*scpb.ConstraintComment'
+    - $dependents[Type] IN ['*scpb.ConstraintComment', '*scpb.ConstraintWithoutIndexName']
     - $constraint[Type] IN ['*scpb.CheckConstraintUnvalidated', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
     - joinOnConstraintID($dependents, $constraint, $table-id, $constraint-id)
     - toAbsent($dependents-Target, $constraint-Target)
@@ -2286,7 +2178,7 @@ deprules
   kind: SameStagePrecedence
   to: constraint-Node
   query:
-    - $dependents[Type] = '*scpb.ConstraintComment'
+    - $dependents[Type] IN ['*scpb.ConstraintComment', '*scpb.ConstraintWithoutIndexName']
     - $constraint[Type] IN ['*scpb.CheckConstraintUnvalidated', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
     - joinOnConstraintID($dependents, $constraint, $table-id, $constraint-id)
     - transient($dependents-Target, $constraint-Target)
@@ -2299,7 +2191,7 @@ deprules
   kind: SameStagePrecedence
   to: constraint-Node
   query:
-    - $dependents[Type] = '*scpb.ConstraintComment'
+    - $dependents[Type] IN ['*scpb.ConstraintComment', '*scpb.ConstraintWithoutIndexName']
     - $constraint[Type] IN ['*scpb.CheckConstraintUnvalidated', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
     - joinOnConstraintID($dependents, $constraint, $table-id, $constraint-id)
     - $dependents-Target[TargetStatus] = TRANSIENT_ABSENT
@@ -2313,7 +2205,7 @@ deprules
   kind: SameStagePrecedence
   to: constraint-Node
   query:
-    - $dependents[Type] = '*scpb.ConstraintComment'
+    - $dependents[Type] IN ['*scpb.ConstraintComment', '*scpb.ConstraintWithoutIndexName']
     - $constraint[Type] IN ['*scpb.CheckConstraintUnvalidated', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
     - joinOnConstraintID($dependents, $constraint, $table-id, $constraint-id)
     - $dependents-Target[TargetStatus] = ABSENT
@@ -3397,19 +3289,6 @@ deprules
     - $dependent-Node[CurrentStatus] = PUBLIC
     - joinTargetNode($simple-constraint, $simple-constraint-Target, $simple-constraint-Node)
     - joinTargetNode($dependent, $dependent-Target, $dependent-Node)
-- name: simple constraint visible before name
-  from: simple-constraint-Node
-  kind: Precedence
-  to: constraint-name-Node
-  query:
-    - $simple-constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
-    - $constraint-name[Type] = '*scpb.ConstraintWithoutIndexName'
-    - joinOnConstraintID($simple-constraint, $constraint-name, $table-id, $constraint-id)
-    - ToPublicOrTransient($simple-constraint-Target, $constraint-name-Target)
-    - $simple-constraint-Node[CurrentStatus] = WRITE_ONLY
-    - $constraint-name-Node[CurrentStatus] = PUBLIC
-    - joinTargetNode($simple-constraint, $simple-constraint-Target, $simple-constraint-Node)
-    - joinTargetNode($constraint-name, $constraint-name-Target, $constraint-name-Node)
 - name: swapped primary index public before column
   from: index-Node
   kind: Precedence
@@ -3772,114 +3651,6 @@ deprules
     - descriptorIsNotBeingDropped-23.1($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
-- name: Constraint should be hidden before name
-  from: constraint-name-Node
-  kind: Precedence
-  to: constraint-Node
-  query:
-    - $constraint-name[Type] = '*scpb.ConstraintWithoutIndexName'
-    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
-    - joinOnConstraintID($constraint-name, $constraint, $table-id, $constraint-id)
-    - toAbsent($constraint-name-Target, $constraint-Target)
-    - $constraint-name-Node[CurrentStatus] = ABSENT
-    - $constraint-Node[CurrentStatus] = ABSENT
-    - joinTargetNode($constraint-name, $constraint-name-Target, $constraint-name-Node)
-    - joinTargetNode($constraint, $constraint-Target, $constraint-Node)
-- name: Constraint should be hidden before name
-  from: constraint-name-Node
-  kind: Precedence
-  to: constraint-Node
-  query:
-    - $constraint-name[Type] = '*scpb.ConstraintWithoutIndexName'
-    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
-    - joinOnConstraintID($constraint-name, $constraint, $table-id, $constraint-id)
-    - transient($constraint-name-Target, $constraint-Target)
-    - $constraint-name-Node[CurrentStatus] = TRANSIENT_ABSENT
-    - $constraint-Node[CurrentStatus] = TRANSIENT_ABSENT
-    - joinTargetNode($constraint-name, $constraint-name-Target, $constraint-name-Node)
-    - joinTargetNode($constraint, $constraint-Target, $constraint-Node)
-- name: Constraint should be hidden before name
-  from: constraint-name-Node
-  kind: Precedence
-  to: constraint-Node
-  query:
-    - $constraint-name[Type] = '*scpb.ConstraintWithoutIndexName'
-    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
-    - joinOnConstraintID($constraint-name, $constraint, $table-id, $constraint-id)
-    - $constraint-name-Target[TargetStatus] = TRANSIENT_ABSENT
-    - $constraint-name-Node[CurrentStatus] = TRANSIENT_ABSENT
-    - $constraint-Target[TargetStatus] = ABSENT
-    - $constraint-Node[CurrentStatus] = ABSENT
-    - joinTargetNode($constraint-name, $constraint-name-Target, $constraint-name-Node)
-    - joinTargetNode($constraint, $constraint-Target, $constraint-Node)
-- name: Constraint should be hidden before name
-  from: constraint-name-Node
-  kind: Precedence
-  to: constraint-Node
-  query:
-    - $constraint-name[Type] = '*scpb.ConstraintWithoutIndexName'
-    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
-    - joinOnConstraintID($constraint-name, $constraint, $table-id, $constraint-id)
-    - $constraint-name-Target[TargetStatus] = ABSENT
-    - $constraint-name-Node[CurrentStatus] = ABSENT
-    - $constraint-Target[TargetStatus] = TRANSIENT_ABSENT
-    - $constraint-Node[CurrentStatus] = TRANSIENT_ABSENT
-    - joinTargetNode($constraint-name, $constraint-name-Target, $constraint-name-Node)
-    - joinTargetNode($constraint, $constraint-Target, $constraint-Node)
-- name: Constraint should be hidden before name
-  from: constraint-Node
-  kind: Precedence
-  to: constraint-name-Node
-  query:
-    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
-    - $constraint-name[Type] = '*scpb.ConstraintWithoutIndexName'
-    - joinOnConstraintID($constraint, $constraint-name, $table-id, $constraint-id)
-    - toAbsent($constraint-Target, $constraint-name-Target)
-    - $constraint-Node[CurrentStatus] = VALIDATED
-    - $constraint-name-Node[CurrentStatus] = ABSENT
-    - joinTargetNode($constraint, $constraint-Target, $constraint-Node)
-    - joinTargetNode($constraint-name, $constraint-name-Target, $constraint-name-Node)
-- name: Constraint should be hidden before name
-  from: constraint-Node
-  kind: Precedence
-  to: constraint-name-Node
-  query:
-    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
-    - $constraint-name[Type] = '*scpb.ConstraintWithoutIndexName'
-    - joinOnConstraintID($constraint, $constraint-name, $table-id, $constraint-id)
-    - transient($constraint-Target, $constraint-name-Target)
-    - $constraint-Node[CurrentStatus] = TRANSIENT_VALIDATED
-    - $constraint-name-Node[CurrentStatus] = TRANSIENT_ABSENT
-    - joinTargetNode($constraint, $constraint-Target, $constraint-Node)
-    - joinTargetNode($constraint-name, $constraint-name-Target, $constraint-name-Node)
-- name: Constraint should be hidden before name
-  from: constraint-Node
-  kind: Precedence
-  to: constraint-name-Node
-  query:
-    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
-    - $constraint-name[Type] = '*scpb.ConstraintWithoutIndexName'
-    - joinOnConstraintID($constraint, $constraint-name, $table-id, $constraint-id)
-    - $constraint-Target[TargetStatus] = TRANSIENT_ABSENT
-    - $constraint-Node[CurrentStatus] = TRANSIENT_VALIDATED
-    - $constraint-name-Target[TargetStatus] = ABSENT
-    - $constraint-name-Node[CurrentStatus] = ABSENT
-    - joinTargetNode($constraint, $constraint-Target, $constraint-Node)
-    - joinTargetNode($constraint-name, $constraint-name-Target, $constraint-name-Node)
-- name: Constraint should be hidden before name
-  from: constraint-Node
-  kind: Precedence
-  to: constraint-name-Node
-  query:
-    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
-    - $constraint-name[Type] = '*scpb.ConstraintWithoutIndexName'
-    - joinOnConstraintID($constraint, $constraint-name, $table-id, $constraint-id)
-    - $constraint-Target[TargetStatus] = ABSENT
-    - $constraint-Node[CurrentStatus] = VALIDATED
-    - $constraint-name-Target[TargetStatus] = TRANSIENT_ABSENT
-    - $constraint-name-Node[CurrentStatus] = TRANSIENT_ABSENT
-    - joinTargetNode($constraint, $constraint-Target, $constraint-Node)
-    - joinTargetNode($constraint-name, $constraint-name-Target, $constraint-name-Node)
 - name: DEFAULT or ON UPDATE existence precedes writes to column
   from: expr-Node
   kind: Precedence
@@ -5379,7 +5150,7 @@ deprules
   kind: SameStagePrecedence
   to: complex-constraint-Node
   query:
-    - $dependent[Type] = '*scpb.ConstraintComment'
+    - $dependent[Type] IN ['*scpb.ConstraintComment', '*scpb.ConstraintWithoutIndexName']
     - $complex-constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.UniqueWithoutIndexConstraint']
     - joinOnConstraintID($dependent, $complex-constraint, $table-id, $constraint-id)
     - ToPublicOrTransient($dependent-Target, $complex-constraint-Target)
@@ -5393,7 +5164,7 @@ deprules
   to: dependent-Node
   query:
     - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.UniqueWithoutIndexConstraint']
-    - $dependent[Type] = '*scpb.ConstraintComment'
+    - $dependent[Type] IN ['*scpb.ConstraintComment', '*scpb.ConstraintWithoutIndexName']
     - joinOnConstraintID($constraint, $dependent, $table-id, $constraint-id)
     - toAbsent($constraint-Target, $dependent-Target)
     - $constraint-Node[CurrentStatus] = VALIDATED
@@ -5406,7 +5177,7 @@ deprules
   to: dependent-Node
   query:
     - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.UniqueWithoutIndexConstraint']
-    - $dependent[Type] = '*scpb.ConstraintComment'
+    - $dependent[Type] IN ['*scpb.ConstraintComment', '*scpb.ConstraintWithoutIndexName']
     - joinOnConstraintID($constraint, $dependent, $table-id, $constraint-id)
     - transient($constraint-Target, $dependent-Target)
     - $constraint-Node[CurrentStatus] = TRANSIENT_VALIDATED
@@ -5419,7 +5190,7 @@ deprules
   to: dependent-Node
   query:
     - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.UniqueWithoutIndexConstraint']
-    - $dependent[Type] = '*scpb.ConstraintComment'
+    - $dependent[Type] IN ['*scpb.ConstraintComment', '*scpb.ConstraintWithoutIndexName']
     - joinOnConstraintID($constraint, $dependent, $table-id, $constraint-id)
     - $constraint-Target[TargetStatus] = TRANSIENT_ABSENT
     - $constraint-Node[CurrentStatus] = TRANSIENT_VALIDATED
@@ -5433,7 +5204,7 @@ deprules
   to: dependent-Node
   query:
     - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.UniqueWithoutIndexConstraint']
-    - $dependent[Type] = '*scpb.ConstraintComment'
+    - $dependent[Type] IN ['*scpb.ConstraintComment', '*scpb.ConstraintWithoutIndexName']
     - joinOnConstraintID($constraint, $dependent, $table-id, $constraint-id)
     - $constraint-Target[TargetStatus] = ABSENT
     - $constraint-Node[CurrentStatus] = VALIDATED
@@ -5647,7 +5418,7 @@ deprules
   kind: Precedence
   to: constraint-Node
   query:
-    - $dependents[Type] = '*scpb.ConstraintComment'
+    - $dependents[Type] IN ['*scpb.ConstraintComment', '*scpb.ConstraintWithoutIndexName']
     - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.UniqueWithoutIndexConstraint']
     - joinOnConstraintID($dependents, $constraint, $table-id, $constraint-id)
     - toAbsent($dependents-Target, $constraint-Target)
@@ -5660,7 +5431,7 @@ deprules
   kind: Precedence
   to: constraint-Node
   query:
-    - $dependents[Type] = '*scpb.ConstraintComment'
+    - $dependents[Type] IN ['*scpb.ConstraintComment', '*scpb.ConstraintWithoutIndexName']
     - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.UniqueWithoutIndexConstraint']
     - joinOnConstraintID($dependents, $constraint, $table-id, $constraint-id)
     - transient($dependents-Target, $constraint-Target)
@@ -5673,7 +5444,7 @@ deprules
   kind: Precedence
   to: constraint-Node
   query:
-    - $dependents[Type] = '*scpb.ConstraintComment'
+    - $dependents[Type] IN ['*scpb.ConstraintComment', '*scpb.ConstraintWithoutIndexName']
     - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.UniqueWithoutIndexConstraint']
     - joinOnConstraintID($dependents, $constraint, $table-id, $constraint-id)
     - $dependents-Target[TargetStatus] = TRANSIENT_ABSENT
@@ -5687,7 +5458,7 @@ deprules
   kind: Precedence
   to: constraint-Node
   query:
-    - $dependents[Type] = '*scpb.ConstraintComment'
+    - $dependents[Type] IN ['*scpb.ConstraintComment', '*scpb.ConstraintWithoutIndexName']
     - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.UniqueWithoutIndexConstraint']
     - joinOnConstraintID($dependents, $constraint, $table-id, $constraint-id)
     - $dependents-Target[TargetStatus] = ABSENT
@@ -5755,7 +5526,7 @@ deprules
   kind: SameStagePrecedence
   to: constraint-Node
   query:
-    - $dependents[Type] = '*scpb.ConstraintComment'
+    - $dependents[Type] IN ['*scpb.ConstraintComment', '*scpb.ConstraintWithoutIndexName']
     - $constraint[Type] IN ['*scpb.CheckConstraintUnvalidated', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
     - joinOnConstraintID($dependents, $constraint, $table-id, $constraint-id)
     - toAbsent($dependents-Target, $constraint-Target)
@@ -5768,7 +5539,7 @@ deprules
   kind: SameStagePrecedence
   to: constraint-Node
   query:
-    - $dependents[Type] = '*scpb.ConstraintComment'
+    - $dependents[Type] IN ['*scpb.ConstraintComment', '*scpb.ConstraintWithoutIndexName']
     - $constraint[Type] IN ['*scpb.CheckConstraintUnvalidated', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
     - joinOnConstraintID($dependents, $constraint, $table-id, $constraint-id)
     - transient($dependents-Target, $constraint-Target)
@@ -5781,7 +5552,7 @@ deprules
   kind: SameStagePrecedence
   to: constraint-Node
   query:
-    - $dependents[Type] = '*scpb.ConstraintComment'
+    - $dependents[Type] IN ['*scpb.ConstraintComment', '*scpb.ConstraintWithoutIndexName']
     - $constraint[Type] IN ['*scpb.CheckConstraintUnvalidated', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
     - joinOnConstraintID($dependents, $constraint, $table-id, $constraint-id)
     - $dependents-Target[TargetStatus] = TRANSIENT_ABSENT
@@ -5795,7 +5566,7 @@ deprules
   kind: SameStagePrecedence
   to: constraint-Node
   query:
-    - $dependents[Type] = '*scpb.ConstraintComment'
+    - $dependents[Type] IN ['*scpb.ConstraintComment', '*scpb.ConstraintWithoutIndexName']
     - $constraint[Type] IN ['*scpb.CheckConstraintUnvalidated', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
     - joinOnConstraintID($dependents, $constraint, $table-id, $constraint-id)
     - $dependents-Target[TargetStatus] = ABSENT
@@ -6879,19 +6650,6 @@ deprules
     - $dependent-Node[CurrentStatus] = PUBLIC
     - joinTargetNode($simple-constraint, $simple-constraint-Target, $simple-constraint-Node)
     - joinTargetNode($dependent, $dependent-Target, $dependent-Node)
-- name: simple constraint visible before name
-  from: simple-constraint-Node
-  kind: Precedence
-  to: constraint-name-Node
-  query:
-    - $simple-constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
-    - $constraint-name[Type] = '*scpb.ConstraintWithoutIndexName'
-    - joinOnConstraintID($simple-constraint, $constraint-name, $table-id, $constraint-id)
-    - ToPublicOrTransient($simple-constraint-Target, $constraint-name-Target)
-    - $simple-constraint-Node[CurrentStatus] = WRITE_ONLY
-    - $constraint-name-Node[CurrentStatus] = PUBLIC
-    - joinTargetNode($simple-constraint, $simple-constraint-Target, $simple-constraint-Node)
-    - joinTargetNode($constraint-name, $constraint-name-Target, $constraint-name-Node)
 - name: swapped primary index public before column
   from: index-Node
   kind: Precedence


### PR DESCRIPTION
We removed a few rule changes present in `rule/release_23_1` directory on master but not present in `rule/current` on `release-23.1` branch. It should have been excluded but was mistakenly added in PR #103349.

Informs #112376
Release note: None