### PR TITLE
acceptance: use single-node cluster and disable metamorphic constants

### DIFF
--- a/pkg/acceptance/util_docker.go
+++ b/pkg/acceptance/util_docker.go
@@ -208,6 +208,9 @@ var cmdBase = []string{
 	"/usr/bin/env",
 	"COCKROACH_SKIP_UPDATE_CHECK=1",
 	"COCKROACH_CRASH_REPORTS=",
+	// Disable metamorphic testing for acceptance tests, since they are
+	// end-to-end tests and metamorphic constants can make them too slow.
+	"COCKROACH_INTERNAL_DISABLE_METAMORPHIC_TESTING=true",
 	"/bin/bash",
 	"-c",
 }


### PR DESCRIPTION
When possible, the acceptance tests will now use the start-single-node command. This avoids unnecessary attempts to perform replication in many tests.

Also, disable metamorphic constants, which can slow end-to-end tests down.

fixes https://github.com/cockroachdb/cockroach/issues/112605
Release note: None