### PR TITLE
release-23.1: roachtest: add support for collecting Go coverage

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -684,6 +684,9 @@ type clusterImpl struct {
 
 	// clusterSettings are additional cluster settings set on cluster startup.
 	clusterSettings map[string]string
+	// goCoverDir is the directory for Go coverage data (if coverage is enabled).
+	// BAZEL_COVER_DIR will be set to this value when starting a node.
+	goCoverDir string
 
 	os   string     // OS of the cluster
 	arch vm.CPUArch // CPU architecture of the cluster
@@ -1946,6 +1949,10 @@ func (c *clusterImpl) StartE(
 		// This makes all roachtest use the new SHOW RANGES behavior,
 		// regardless of cluster settings.
 		settings.Env = append(settings.Env, "COCKROACH_FORCE_DEPRECATED_SHOW_RANGE_BEHAVIOR=false")
+	}
+
+	if c.goCoverDir != "" {
+		settings.Env = append(settings.Env, fmt.Sprintf("BAZEL_COVER_DIR=%s", c.goCoverDir))
 	}
 
 	clusterSettingsOpts := []install.ClusterSettingOption{

--- a/pkg/cmd/roachtest/cluster_test.go
+++ b/pkg/cmd/roachtest/cluster_test.go
@@ -118,6 +118,11 @@ func (t testWrapper) PerfArtifactsDir() string {
 	return ""
 }
 
+// GoCoverArtifactsDir is part of the test.Test interface.
+func (t testWrapper) GoCoverArtifactsDir() string {
+	return ""
+}
+
 // logger is part of the testI interface.
 func (t testWrapper) L() *logger.Logger {
 	return t.l

--- a/pkg/cmd/roachtest/run.go
+++ b/pkg/cmd/roachtest/run.go
@@ -58,6 +58,7 @@ var (
 	debugAlways            bool
 	runSkipped             bool
 	skipInit               bool
+	goCoverEnabled         bool
 	clusterID              string
 	count                  int
 	versionsBinaryOverride map[string]string
@@ -119,6 +120,8 @@ func addRunBenchCommonFlags(cmd *cobra.Command) {
 		&runSkipped, "run-skipped", runSkipped, "run skipped tests")
 	cmd.Flags().BoolVar(
 		&skipInit, "skip-init", false, "skip initialization step (imports, table creation, etc.) for tests that support it, useful when re-using clusters with --wipe=false")
+	cmd.Flags().BoolVar(
+		&goCoverEnabled, "go-cover", false, "enable collection of go coverage profiles (requires instrumented cockroach binary)")
 	cmd.Flags().IntVarP(
 		&parallelism, "parallelism", "p", 10, "number of tests to run in parallel")
 	cmd.Flags().StringVar(
@@ -274,6 +277,7 @@ func runTests(register func(registry.Registry), args []string, benchOnly bool) e
 		testOpts{
 			versionsBinaryOverride: versionsBinaryOverride,
 			skipInit:               skipInit,
+			goCoverEnabled:         goCoverEnabled,
 		},
 		lopt, nil /* clusterAllocator */)
 

--- a/pkg/cmd/roachtest/test/test_interface.go
+++ b/pkg/cmd/roachtest/test/test_interface.go
@@ -49,11 +49,20 @@ type Test interface {
 	Fatal(args ...interface{})
 	Fatalf(format string, args ...interface{})
 	Failed() bool
+
 	ArtifactsDir() string
+
 	// PerfArtifactsDir is the directory on cluster nodes in which perf artifacts
 	// reside. Upon success this directory is copied into test's ArtifactsDir from
 	// each node in the cluster.
 	PerfArtifactsDir() string
+
+	// GoCoverArtifactsDir is the directory on cluster nodes in which coverage
+	// profiles are dumped (or "" if go coverage is not enabled). At the end of
+	// this test, this directory is copied into the test's ArtifactsDir from each
+	// node in the cluster.
+	GoCoverArtifactsDir() string
+
 	L() *logger.Logger
 	Progress(float64)
 	Status(args ...interface{})

--- a/pkg/cmd/roachtest/test_impl.go
+++ b/pkg/cmd/roachtest/test_impl.go
@@ -29,9 +29,14 @@ import (
 )
 
 // perfArtifactsDir is the directory on cluster nodes in which perf artifacts
-// reside. Upon success this directory is copied into test artifactsDir from
+// reside. Upon success this directory is copied into the test's ArtifactsDir() from
 // each node in the cluster.
 const perfArtifactsDir = "perf"
+
+// goCoverArtifactsDir the directory on cluster nodes in which go coverage
+// profiles are dumped. At the end of a test this directory is copied into the
+// test's ArtifactsDir() from each node in the cluster.
+const goCoverArtifactsDir = "gocover"
 
 type testStatus struct {
 	msg      string
@@ -111,6 +116,9 @@ type testImpl struct {
 	// Version strings look like "20.1.4".
 	versionsBinaryOverride map[string]string
 	skipInit               bool
+	// If true, go coverage is enabled and the BAZEL_COVER_DIR env var will be set
+	// when starting nodes.
+	goCoverEnabled bool
 }
 
 func newFailure(squashedErr error, errs []error) failure {
@@ -428,6 +436,13 @@ func (t *testImpl) ArtifactsDir() string {
 
 func (t *testImpl) PerfArtifactsDir() string {
 	return perfArtifactsDir
+}
+
+func (t *testImpl) GoCoverArtifactsDir() string {
+	if t.goCoverEnabled {
+		return goCoverArtifactsDir
+	}
+	return ""
 }
 
 // IsBuildVersion returns true if the build version is greater than or equal to

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -212,6 +212,7 @@ func (c clustersOpt) validate() error {
 type testOpts struct {
 	versionsBinaryOverride map[string]string
 	skipInit               bool
+	goCoverEnabled         bool
 }
 
 // Run runs tests.
@@ -612,8 +613,8 @@ func (r *testRunner) runWorker(
 				if err := c.WipeE(ctx, l, false /* preserveCerts */); err != nil {
 					return err
 				}
-				if err := c.RunE(ctx, c.All(), "rm -rf "+perfArtifactsDir); err != nil {
-					return errors.Wrapf(err, "failed to remove perf artifacts dir")
+				if err := c.RunE(ctx, c.All(), fmt.Sprintf("rm -rf %s %s", perfArtifactsDir, goCoverArtifactsDir)); err != nil {
+					return errors.Wrapf(err, "failed to remove perf/gocover artifacts dirs")
 				}
 				if c.localCertsDir != "" {
 					if err := os.RemoveAll(c.localCertsDir); err != nil {
@@ -715,8 +716,8 @@ func (r *testRunner) runWorker(
 		escapedTestName := teamCityNameEscape(testToRun.spec.Name)
 		runSuffix := "run_" + strconv.Itoa(testToRun.runNum)
 
-		artifactsDir := filepath.Join(filepath.Join(artifactsRootDir, escapedTestName), runSuffix)
-		logPath := filepath.Join(artifactsDir, "test.log")
+		testArtifactsDir := filepath.Join(filepath.Join(artifactsRootDir, escapedTestName), runSuffix)
+		logPath := filepath.Join(testArtifactsDir, "test.log")
 
 		// Map artifacts/TestFoo/run_?/** => TestFoo/run_?/**, i.e. collect the artifacts
 		// for this test exactly as they are laid out on disk (when the time
@@ -737,12 +738,13 @@ func (r *testRunner) runWorker(
 			cockroachShort:         cockroachEA[arch],
 			deprecatedWorkload:     workload[arch],
 			buildVersion:           binaryVersion,
-			artifactsDir:           artifactsDir,
+			artifactsDir:           testArtifactsDir,
 			artifactsSpec:          artifactsSpec,
 			l:                      testL,
 			versionsBinaryOverride: topt.versionsBinaryOverride,
 			skipInit:               topt.skipInit,
 			debug:                  debugMode.IsDebug(),
+			goCoverEnabled:         topt.goCoverEnabled,
 		}
 		github := newGithubIssues(r.config.disableIssue, c, vmCreateOpts)
 
@@ -822,6 +824,8 @@ func (r *testRunner) runWorker(
 					t.Fatalf("unknown lease type %s", testSpec.Leases)
 				}
 
+				c.goCoverDir = t.GoCoverArtifactsDir()
+
 				wStatus.SetCluster(c)
 				wStatus.SetTest(t, testToRun)
 				wStatus.SetStatus("running test")
@@ -875,7 +879,7 @@ func (r *testRunner) runWorker(
 		} else {
 			// Upon success fetch the perf artifacts from the remote hosts.
 			if t.spec.Benchmark {
-				getPerfArtifacts(ctx, l, c, t)
+				getPerfArtifacts(ctx, c, t)
 			}
 			if debugMode == DebugKeepAlways {
 				c.Save(ctx, "cluster saved since --debug-always set", l)
@@ -885,45 +889,68 @@ func (r *testRunner) runWorker(
 	}
 }
 
-// getPerfArtifacts retrieves the perf artifacts for the test.
-// If there's an error, oh well, don't do anything rash like fail a test
-// which already passed.
-func getPerfArtifacts(ctx context.Context, l *logger.Logger, c *clusterImpl, t test.Test) {
-	g := ctxgroup.WithContext(ctx)
-	fetchNode := func(node int) func(context.Context) error {
-		return func(ctx context.Context) error {
-			testCmd := `'PERF_ARTIFACTS="` + perfArtifactsDir + `"
-if [[ -d "${PERF_ARTIFACTS}" ]]; then
+// getArtifacts retrieves artifacts (like perf or go cover) produced by a
+// successful test.
+//
+// Any errors are logged but otherwise don't cause a test failure.
+func getArtifacts(
+	ctx context.Context,
+	c *clusterImpl,
+	t test.Test,
+	srcDirOnNode string,
+	dstDirFn func(nodeIdx int) string,
+) {
+	fetchNode := func(ctx context.Context, node int) error {
+		testCmd := `'ARTIFACTS_DIR="` + srcDirOnNode + `"
+if [[ -d "${ARTIFACTS_DIR}" ]]; then
     echo true
-elif [[ -e "${PERF_ARTIFACTS}" ]]; then
-    ls -la "${PERF_ARTIFACTS}"
+elif [[ -e "${ARTIFACTS_DIR}" ]]; then
+    ls -la "${ARTIFACTS_DIR}"
     exit 1
 else
     echo false
 fi'`
-			result, err := c.RunWithDetailsSingleNode(ctx, t.L(), c.Node(node), "bash", "-c", testCmd)
-			if err != nil {
-				return errors.Wrapf(err, "failed to check for perf artifacts")
-			}
-			out := strings.TrimSpace(result.Stdout)
-			switch out {
-			case "true":
-				dst := fmt.Sprintf("%s/%d.%s", t.ArtifactsDir(), node, perfArtifactsDir)
-				return c.Get(ctx, l, perfArtifactsDir, dst, c.Node(node))
-			case "false":
-				l.PrintfCtx(ctx, "no perf artifacts exist on node %v", c.Node(node))
-				return nil
-			default:
-				return errors.Errorf("unexpected output when checking for perf artifacts: %s", out)
-			}
+		result, err := c.RunWithDetailsSingleNode(ctx, t.L(), c.Node(node), "bash", "-c", testCmd)
+		if err != nil {
+			return errors.Wrapf(err, "failed to check for artifacts in %q", srcDirOnNode)
+		}
+		out := strings.TrimSpace(result.Stdout)
+		switch out {
+		case "true":
+			return c.Get(ctx, t.L(), srcDirOnNode, dstDirFn(node), c.Node(node))
+		case "false":
+			t.L().PrintfCtx(ctx, "no artifacts exist in %q on node %v", srcDirOnNode, c.Node(node))
+			return nil
+		default:
+			return errors.Errorf("unexpected output when checking for artifacts in %q: %s", srcDirOnNode, out)
 		}
 	}
+	g := ctxgroup.WithContext(ctx)
 	for _, i := range c.All() {
-		g.GoCtx(fetchNode(i))
+		node := i
+		g.GoCtx(func(ctx context.Context) error {
+			return fetchNode(ctx, node)
+		})
 	}
 	if err := g.Wait(); err != nil {
-		l.PrintfCtx(ctx, "failed to get perf artifacts: %v", err)
+		t.L().PrintfCtx(ctx, "failed to get artifacts from %q: %v", srcDirOnNode, err)
 	}
+}
+
+// getPerfArtifacts retrieves the perf artifacts for the test.
+func getPerfArtifacts(ctx context.Context, c *clusterImpl, t test.Test) {
+	dstDirFn := func(nodeIdx int) string {
+		return fmt.Sprintf("%s/%d.%s", t.ArtifactsDir(), nodeIdx, perfArtifactsDir)
+	}
+	getArtifacts(ctx, c, t, t.PerfArtifactsDir(), dstDirFn)
+}
+
+// getGoCoverArtifacts retrieves the go coverage artifacts for the test.
+func getGoCoverArtifacts(ctx context.Context, c *clusterImpl, t test.Test) {
+	dstDirFn := func(nodeIdx int) string {
+		return fmt.Sprintf("%s/%d.%s", t.ArtifactsDir(), nodeIdx, goCoverArtifactsDir)
+	}
+	getArtifacts(ctx, c, t, t.GoCoverArtifactsDir(), dstDirFn)
 }
 
 // An error is returned if the test is still running (on another goroutine) when
@@ -1029,12 +1056,11 @@ func (r *testRunner) runTest(
 		}
 
 		if teamCity {
-
 			// Zip the artifacts. This improves the TeamCity UX where we can navigate
 			// through zip files just fine, but we can't download subtrees of the
 			// artifacts storage. By zipping we get this capability as we can just
 			// download the zip file for the failing test instead.
-			if err := zipArtifacts(t.ArtifactsDir()); err != nil {
+			if err := zipArtifacts(t); err != nil {
 				l.Printf("unable to zip artifacts: %s", err)
 			}
 
@@ -1285,28 +1311,49 @@ func (r *testRunner) postTestAssertions(
 func (r *testRunner) teardownTest(
 	ctx context.Context, t *testImpl, c *clusterImpl, timedOut bool,
 ) error {
-	var err error
 	if timedOut || t.Failed() {
-		err = r.collectArtifacts(ctx, t, c, timedOut, time.Hour)
+		err := r.collectArtifacts(ctx, t, c, timedOut, time.Hour)
 		if err != nil {
 			t.L().Printf("error collecting artifacts: %v", err)
 		}
-	}
 
-	if timedOut {
-		// Shut down the cluster. We only do this on timeout to help the test terminate;
-		// for regular failures, if the --debug flag is used, we want the cluster to stay
-		// around so someone can poke at it.
-		_ = c.StopE(ctx, t.L(), option.DefaultStopOpts(), c.All())
+		if timedOut {
+			// Shut down the cluster. We only do this on timeout to help the test terminate;
+			// for regular failures, if the --debug flag is used, we want the cluster to stay
+			// around so someone can poke at it.
+			_ = c.StopE(ctx, t.L(), option.DefaultStopOpts(), c.All())
 
-		// We previously added a timeout failure without cancellation, so we cancel here.
-		if t.mu.cancel != nil {
-			t.mu.cancel()
+			// We previously added a timeout failure without cancellation, so we cancel here.
+			if t.mu.cancel != nil {
+				t.mu.cancel()
+			}
+			t.L().Printf("test timed out; check __stacks.log and CRDB logs for goroutine dumps")
 		}
-		t.L().Printf("test timed out; check __stacks.log and CRDB logs for goroutine dumps")
+		return err
 	}
 
-	return err
+	// Test was successful. If we are collecting code coverage, copy the files now.
+	if t.goCoverEnabled {
+		// Go cover data is dumped when the cockroach process exits; send SIGUSR1 to
+		// make it exit immediately.
+		//
+		// TODO(radu): many tests stop the nodes with the default options (SIGKILL)
+		// during the test, which means some coverage data will be lost. Consider
+		// updating the default options.
+		t.L().Printf("Stopping all nodes to obtain go cover artifacts")
+		stopOpts := option.DefaultStopOpts()
+		stopOpts.RoachprodOpts.Sig = 10 // SIGUSR1
+		stopOpts.RoachprodOpts.Wait = true
+		stopOpts.RoachprodOpts.MaxWait = 10
+		if err := c.StopE(ctx, t.L(), stopOpts, c.All()); err != nil {
+			t.L().PrintfCtx(ctx, "error stopping cluster: %v", err)
+		}
+
+		t.L().Printf("Retrieving go cover artifacts")
+		getGoCoverArtifacts(ctx, c, t)
+	}
+
+	return nil
 }
 
 func (r *testRunner) collectArtifacts(
@@ -1684,8 +1731,26 @@ func (we *workerErrors) Err() error {
 
 // zipArtifacts moves everything inside the artifacts dir except any zip files
 // (like debug.zip) into an artifacts.zip file.
-func zipArtifacts(artifactsDir string) error {
-	list, err := filterDirEntries(artifactsDir, func(entry os.DirEntry) bool {
+//
+// If Go coverage artifacts are present, they are moved inside a separate
+// gocover.zip file.
+func zipArtifacts(t *testImpl) error {
+	if t.goCoverEnabled {
+		// First, look for any go coverage artifacts.
+		if goCoverList, err := filterDirEntries(t.ArtifactsDir(), func(entry os.DirEntry) bool {
+			return entry.IsDir() && strings.HasSuffix(entry.Name(), "."+goCoverArtifactsDir)
+		}); err != nil {
+			return err
+		} else if len(goCoverList) > 0 {
+			// Found artifacts; move them to an archive. Note that this archive will be
+			// filtered out below.
+			if err := moveToZipArchive("gocover.zip", t.ArtifactsDir(), goCoverList...); err != nil {
+				return err
+			}
+		}
+	}
+
+	list, err := filterDirEntries(t.ArtifactsDir(), func(entry os.DirEntry) bool {
 		if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".zip") {
 			// Skip any zip files.
 			return false
@@ -1695,5 +1760,5 @@ func zipArtifacts(artifactsDir string) error {
 	if err != nil {
 		return err
 	}
-	return moveToZipArchive("artifacts.zip", artifactsDir, list...)
+	return moveToZipArchive("artifacts.zip", t.ArtifactsDir(), list...)
 }

--- a/pkg/roachprod/install/scripts/start.sh
+++ b/pkg/roachprod/install/scripts/start.sh
@@ -45,6 +45,10 @@ if [[ -n "${LOCAL}" || "${1-}" == "run" ]]; then
   fi
   # NB: ENV_VARS is never empty.
   export "${ENV_VARS[@]}"
+  # If we are collecting code coverage, make sure the directory exists.
+  if [ -n "${BAZEL_COVER_DIR:-}" ]; then
+    mkdir -p "${BAZEL_COVER_DIR}"
+  fi
   CODE=0
   "${BINARY}" "${ARGS[@]}" >> "${LOG_DIR}/cockroach.stdout.log" 2>> "${LOG_DIR}/cockroach.stderr.log" || CODE="$?"
   if [[ -z "${LOCAL}" || "${CODE}" -ne 0 ]]; then

--- a/pkg/roachprod/install/testdata/start/start.txt
+++ b/pkg/roachprod/install/testdata/start/start.txt
@@ -49,6 +49,10 @@ if [[ -n "${LOCAL}" || "${1-}" == "run" ]]; then
   fi
   # NB: ENV_VARS is never empty.
   export "${ENV_VARS[@]}"
+  # If we are collecting code coverage, make sure the directory exists.
+  if [ -n "${BAZEL_COVER_DIR:-}" ]; then
+    mkdir -p "${BAZEL_COVER_DIR}"
+  fi
   CODE=0
   "${BINARY}" "${ARGS[@]}" >> "${LOG_DIR}/cockroach.stdout.log" 2>> "${LOG_DIR}/cockroach.stderr.log" || CODE="$?"
   if [[ -z "${LOCAL}" || "${CODE}" -ne 0 ]]; then


### PR DESCRIPTION
Backport 1/1 commits from #110434.

/cc @cockroachdb/release

Release justification: test-only fix, keeping roachtest in sync as much as possible

---

PR #110280 added instrumentation to the cockroach binary. When built in this mode, cockroach dumps coverage counters to the directory specified in `BAZEL_COVER_DIR` env var. Note that this is similar to Go's recent support for binary instrumentation
(https://go.dev/testing/coverage/); we will eventually switch to using that when Bazel supports building in that mode.

This commit adds a `--go-cover` flag to `roachtest`. When this flag is set, the `BAZEL_COVER_DIR` env var is set and after the test completes we copy the contents to the artifacts (similar to the `perf` artifacts).

Epic: none
Release note: None
