### PR TITLE
release-23.1: logictest: disable metamorphic testing for mixed version test

### DIFF
--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -1263,10 +1263,14 @@ func (t *logicTest) newTestServerCluster(bootstrapBinaryPath string, upgradeBina
 		testserver.PollListenURLTimeoutOpt(120),
 	}
 	if strings.Contains(upgradeBinaryPath, "cockroach-short") {
-		// If we're using a cockroach-short binary, that means it was locally
-		// built, so we need to opt-in to development upgrades.
 		opts = append(opts, testserver.EnvVarOpt([]string{
-			"COCKROACH_UPGRADE_TO_DEV_VERSION=true",
+			// If we're using a cockroach-short binary, that means it was
+			// locally built, so we need to opt-out of version offsetting to
+			// better simulate a real upgrade path.
+			"COCKROACH_TESTING_FORCE_RELEASE_BRANCH=true",
+			// The build is made during testing, so it has metamorphic constants.
+			// We disable them here so that the test is more stable.
+			"COCKROACH_INTERNAL_DISABLE_METAMORPHIC_TESTING=true",
 		}))
 	}
 


### PR DESCRIPTION
Backport 1/1 commits from #112624.

/cc @cockroachdb/release

Release justification: test only change

---

We've seen that these tests can get quite slow sometimes. One theory is that this is caused by metamorphic test settings, so this PR disables them so we can determine if it helps with test stability.

informs https://github.com/cockroachdb/cockroach/issues/112621
Release note: None
