### PR TITLE
release-23.1: sqlstats: fix schema name for TestInsightsIntegrationForContention

### DIFF
--- a/pkg/sql/sqlstats/insights/integration/insights_test.go
+++ b/pkg/sql/sqlstats/insights/integration/insights_test.go
@@ -572,7 +572,7 @@ func TestInsightsIntegrationForContention(t *testing.T) {
 		query,
 		COALESCE(insight.contention, 0::INTERVAL)::FLOAT,
 		COALESCE(sum(txn_contention.contention_duration), 0::INTERVAL)::FLOAT AS durationMs,
-		txn_contention.schema_name,
+		COALESCE(txn_contention.schema_name, ''::STRING)::STRING AS schema_name,
 		txn_contention.database_name,
 		txn_contention.table_name,
 		txn_contention.index_name,


### PR DESCRIPTION
Backport 1/1 commits from #112128.

/cc @cockroachdb/release

Resolves #112468

---

Fix TestInsightsIntegrationForContention, by adding COALESCE on possible NULL schema name.

Fix #111883

Release note: None

Release justification: test-only change to fix a flake
