### PR TITLE
opt: fix inverted index constrained scans for equality filters

### DIFF
--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -8198,6 +8198,77 @@ select
  └── filters
       └── val:3 > st_maxdistance(geom:1, '010100000000000000000000000000000000000000') [outer=(1,3), immutable, constraints=(/3: (/NULL - ])]
 
+# Regression test for #111963. Do not plan inverted index scans on columns that
+# are not filtered in the query.
+exec-ddl
+CREATE TABLE t111963 (
+  j1 JSON,
+  j2 JSON
+)
+----
+
+exec-ddl
+CREATE INVERTED INDEX idx111963 ON t111963 (j1)
+----
+
+opt expect-not=GenerateInvertedIndexScans
+SELECT * FROM t111963 WHERE j2 = '1'
+----
+select
+ ├── columns: j1:1 j2:2!null
+ ├── immutable
+ ├── fd: ()-->(2)
+ ├── scan t111963
+ │    └── columns: j1:1 j2:2
+ └── filters
+      └── j2:2 = '1' [outer=(2), immutable, constraints=(/2: [/'1' - /'1']; tight), fd=()-->(2)]
+
+opt expect-not=GenerateInvertedIndexScans
+SELECT * FROM t111963 WHERE j2 IN ('1', '10', '100')
+----
+select
+ ├── columns: j1:1 j2:2!null
+ ├── scan t111963
+ │    └── columns: j1:1 j2:2
+ └── filters
+      └── j2:2 IN ('1', '10', '100') [outer=(2), constraints=(/2: [/'1' - /'1'] [/'10' - /'10'] [/'100' - /'100']; tight)]
+
+exec-ddl
+DROP INDEX idx111963
+----
+
+exec-ddl
+CREATE INVERTED INDEX idx111963 ON t111963 ((j1->'foo'))
+----
+
+opt expect-not=GenerateInvertedIndexScans
+SELECT * FROM t111963 WHERE j1 = '1'
+----
+select
+ ├── columns: j1:1!null j2:2
+ ├── immutable
+ ├── fd: ()-->(1)
+ ├── scan t111963
+ │    ├── columns: j1:1 j2:2
+ │    └── computed column expressions
+ │         └── crdb_internal_idx_expr:7
+ │              └── j1:1->'foo'
+ └── filters
+      └── j1:1 = '1' [outer=(1), immutable, constraints=(/1: [/'1' - /'1']; tight), fd=()-->(1)]
+
+opt expect-not=GenerateInvertedIndexScans
+SELECT * FROM t111963 WHERE j1 IN ('1', '10', '100')
+----
+select
+ ├── columns: j1:1!null j2:2
+ ├── scan t111963
+ │    ├── columns: j1:1 j2:2
+ │    └── computed column expressions
+ │         └── crdb_internal_idx_expr:7
+ │              └── j1:1->'foo'
+ └── filters
+      └── j1:1 IN ('1', '10', '100') [outer=(1), constraints=(/1: [/'1' - /'1'] [/'10' - /'10'] [/'100' - /'100']; tight)]
+
 # --------------------------------------------------
 # GenerateZigzagJoins
 # --------------------------------------------------


### PR DESCRIPTION
#### opt: fix inverted index constrained scans for equality filters

This commit fixes a bug introduced in #101178 that allows the optimizer
to generated inverted index scans on columns that are not filtered by
the query. For example, an inverted index over the column `j1` could be
scanned for a filter involving a different column, like `j2 = '5'`. The
bug is caused by a simple omission of code that must check that the
column in the filter is an indexed column.

Fixes #111963

There is no release note because this bug is not present in any
releases.

Release note: None

#### randgen: generate single-column indexes more often

This commit makes `randgen` more likely to generate single-column
indexes. It is motivated by the bug #111963, which surprisingly lived on
the master branch for sixth months without being detected. It's not
entirely clear why TLP or other randomized tests did not catch the bug,
which has such a simple reproduction.

One theory is that indexes tend to be multi-column and constrained scans
on multi-column inverted indexes are not commonly planned for randomly
generated queries because the set of requirements to generate the scan
are very specific: the query must hold each prefix column constant, e.g.
`a=1 AND b=2 AND j='5'::JSON`. The likelihood of randomly generating
such an expression may be so low that the bug was not caught.

By making 10% of indexes single-column, this bug may have been more
likely to be caught because only the inverted index column needs to be
constrained by an equality filter.

Release note: None
