### PR TITLE
server: fix timeouts in multi-store tests

### DIFF
--- a/pkg/server/init.go
+++ b/pkg/server/init.go
@@ -731,7 +731,7 @@ func inspectEngines(
 		initializedEngines = append(initializedEngines, eng)
 	}
 	clusterVersion, err := kvstorage.SynthesizeClusterVersionFromEngines(
-		ctx, engines, binaryVersion, binaryMinSupportedVersion,
+		ctx, initializedEngines, binaryVersion, binaryMinSupportedVersion,
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
I don't yet have the complete story here, but in #112385 we changed this from looking just at initialized engines to all engines.

In the case of multi-node, multi-engine tests, this occasionally results in the test timing out with liveness problems.

What appears to happen is that in the cases where we fail, nodes have their second and third stores at a lower cluster version resulting in the initial state of both the second and third nodes having a lower cluster version. Additional stores for non-bootstrap node are initialized asyncronously during start up.

There may be a better fix here, but I need to become better acquainted with the code before making more serious changes here.

Fixes #112658
Fixes #112676

Release note: None