### PR TITLE
release: verify SHA before publishing

### DIFF
--- a/build/teamcity/internal/cockroach/release/publish/publish-staged-cockroach-release.sh
+++ b/build/teamcity/internal/cockroach/release/publish/publish-staged-cockroach-release.sh
@@ -56,6 +56,12 @@ fi
 
 tc_end_block "Variable Setup"
 
+tc_start_block "Verify binaries SHA"
+# Make sure that the linux/amd64 source docker image is built using the same version and SHA. 
+# This is a quick check and it assumes that the docker image was built correctly and based on the tarball binaries.
+docker_login_gcr "$gcr_staged_repository" "$gcr_staged_credentials"
+verify_docker_image "${gcr_staged_repository}:${version}" "linux/amd64" "$BUILD_VCS_NUMBER" "$version" false
+tc_end_block "Verify binaries SHA"
 
 tc_start_block "Check remote tag and tag"
 if [[ -z "${DRY_RUN}" ]]; then
@@ -76,7 +82,6 @@ tc_start_block "Setup dockerhub credentials"
 configure_docker_creds
 docker_login
 tc_end_block "Setup dockerhub credentials"
-
 
 tc_start_block "Copy binaries"
 export google_credentials="$gcs_credentials"


### PR DESCRIPTION
Previously, we published the release binaries and docker images without making sure their SHA matches the current SHA in CI. In cases when we select a different SHA, but forget to rebuild the binaries, this caused a verification failure at the very end, after the binaries are published.

This PR adds a quick check to verify that the source docker image version and SHA matches the expected values. The check is limited to a single platform, but can be extended to a full verification in the future.

Fixes: RE-466
Release note: None
Release justification: release automation changes