### PR TITLE
streamclient: bump test size

### DIFF
--- a/pkg/ccl/streamingccl/streamclient/BUILD.bazel
+++ b/pkg/ccl/streamingccl/streamclient/BUILD.bazel
@@ -45,14 +45,14 @@ go_library(
 
 go_test(
     name = "streamclient_test",
-    size = "small",
+    size = "medium",
     srcs = [
         "client_test.go",
         "main_test.go",
         "partitioned_stream_client_test.go",
         "span_config_stream_client_test.go",
     ],
-    args = ["-test.timeout=55s"],
+    args = ["-test.timeout=295s"],
     embed = [":streamclient"],
     tags = [
         "ccl_test",


### PR DESCRIPTION
This is routinely timing out in the EngFlow continuous test. Maybe when it's working on remote execution it will be quicker and we can bump this back down to `small`.

Epic: CRDB-8308
Release note: None