### PR TITLE
sql: disallow invocation of procedures outside of CALL

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/procedure
+++ b/pkg/sql/logictest/testdata/logic_test/procedure
@@ -163,6 +163,25 @@ SELECT * FROM t
 1  11
 
 statement ok
+CREATE FUNCTION one() RETURNS INT LANGUAGE SQL AS 'SELECT 1'
+
+statement ok
+CALL t_update(one(), 12)
+
+query II
+SELECT * FROM t
+----
+1  12
+
+statement ok
+CALL t_update(one(), one()+12)
+
+query II
+SELECT * FROM t
+----
+1  13
+
+statement ok
 CREATE FUNCTION t_update() RETURNS INT LANGUAGE SQL AS 'SELECT 1'
 
 # The procedure t_update and the function t_update can be disambiguated via the

--- a/pkg/sql/logictest/testdata/logic_test/procedure
+++ b/pkg/sql/logictest/testdata/logic_test/procedure
@@ -46,6 +46,39 @@ SELECT currval('s')
 statement error pgcode 42809 p\(\) is a procedure\nHINT: To call a procedure, use CALL.
 SELECT p()
 
+statement error pgcode 42809 p\(\) is a procedure\nHINT: To call a procedure, use CALL.
+CALL p(p())
+
+statement error pgcode 42809 p\(\) is a procedure\nHINT: To call a procedure, use CALL.
+SELECT * FROM (VALUES (1), (2), (3)) LIMIT p()
+
+statement error pgcode 42809 p\(\) is a procedure\nHINT: To call a procedure, use CALL.
+SELECT * FROM (VALUES (1), (2), (3)) ORDER BY p()
+
+statement error pgcode 42809 p\(\) is a procedure\nHINT: To call a procedure, use CALL.
+SELECT * FROM (VALUES (1), (2), (3)) v(i) WHERE i = p()
+
+statement error pgcode 42809 p\(\) is a procedure\nHINT: To call a procedure, use CALL.
+SELECT * FROM (VALUES (1), (2), (3)) v(i) GROUP BY i HAVING i > p()
+
+statement error pgcode 42809 p\(\) is a procedure\nHINT: To call a procedure, use CALL.
+SELECT * FROM (VALUES (1), (2)) v(i) JOIN (VALUES (2), (3)) w(j) ON i = p()
+
+statement error pgcode 42809 p\(\) is a procedure\nHINT: To call a procedure, use CALL.
+SELECT * FROM generate_series(1, p())
+
+statement error pgcode 42809 p\(\) is a procedure\nHINT: To call a procedure, use CALL.
+SELECT * FROM generate_series(1, p())
+
+statement error pgcode 42809 p\(\) is a procedure\nHINT: To call a procedure, use CALL.
+SELECT abs(p())
+
+statement error pgcode 42809 p\(\) is a procedure\nHINT: To call a procedure, use CALL.
+SELECT nth_value(1, p()) OVER () FROM (VALUES (1), (2))
+
+statement error pgcode 42809 p\(\) is a procedure\nHINT: To call a procedure, use CALL.
+SELECT nth_value(1, i) OVER (ORDER BY p()) FROM (VALUES (1), (2)) v(i)
+
 statement ok
 CREATE OR REPLACE PROCEDURE p() LANGUAGE SQL AS ''
 
@@ -84,6 +117,27 @@ statement error pgcode 0A000 unimplemented: CALL usage inside a function definit
 CREATE OR REPLACE PROCEDURE p2() LANGUAGE SQL AS $$
   CALL p();
 $$
+
+statement error pgcode 42883 unknown function: p\(\)
+CREATE FUNCTION err(i INT) RETURNS VOID LANGUAGE SQL AS 'SELECT p()'
+
+statement error pgcode 0A000 unimplemented: CALL usage inside a function definition
+CREATE FUNCTION err(i INT) RETURNS VOID LANGUAGE SQL AS 'CALL p()'
+
+statement error pgcode 42809 p\(\) is a procedure\nHINT: To call a procedure, use CALL.
+CREATE TABLE err (i INT DEFAULT p())
+
+statement error pgcode 42809 p\(\) is a procedure\nHINT: To call a procedure, use CALL.
+CREATE TABLE err (i INT AS (p()) STORED)
+
+statement error pgcode 42809 p\(\) is a procedure\nHINT: To call a procedure, use CALL.
+CREATE TABLE err (i INT, INDEX (p()))
+
+statement error pgcode 42809 p\(\) is a procedure\nHINT: To call a procedure, use CALL.
+CREATE TABLE err (a INT, b INT, INDEX (a, (b + p())))
+
+statement error pgcode 42809 p\(\) is a procedure\nHINT: To call a procedure, use CALL.
+CREATE TABLE err (a INT, INDEX (a) WHERE p() = 1)
 
 statement ok
 CREATE TABLE t (

--- a/pkg/sql/opt/optbuilder/groupby.go
+++ b/pkg/sql/opt/optbuilder/groupby.go
@@ -459,7 +459,8 @@ func (b *Builder) analyzeHaving(having *tree.Where, fromScope *scope) tree.Typed
 	// in case we are recursively called within a subquery context.
 	defer b.semaCtx.Properties.Restore(b.semaCtx.Properties)
 	b.semaCtx.Properties.Require(
-		exprKindHaving.String(), tree.RejectWindowApplications|tree.RejectGenerators,
+		exprKindHaving.String(),
+		tree.RejectWindowApplications|tree.RejectGenerators|tree.RejectProcedures,
 	)
 	fromScope.context = exprKindHaving
 	return fromScope.resolveAndRequireType(having.Expr, types.Bool)

--- a/pkg/sql/opt/optbuilder/join.go
+++ b/pkg/sql/opt/optbuilder/join.go
@@ -117,7 +117,8 @@ func (b *Builder) buildJoin(
 		if on, ok := cond.(*tree.OnJoinCond); ok {
 			// Do not allow special functions in the ON clause.
 			b.semaCtx.Properties.Require(
-				exprKindOn.String(), tree.RejectGenerators|tree.RejectWindowApplications,
+				exprKindOn.String(),
+				tree.RejectGenerators|tree.RejectWindowApplications|tree.RejectProcedures,
 			)
 			outScope.context = exprKindOn
 			filter := b.buildScalar(

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -1332,7 +1332,7 @@ func (b *Builder) buildWhere(where *tree.Where, inScope *scope) {
 		where.Expr,
 		types.Bool,
 		exprKindWhere,
-		tree.RejectGenerators|tree.RejectWindowApplications,
+		tree.RejectGenerators|tree.RejectWindowApplications|tree.RejectProcedures,
 		inScope,
 	)
 

--- a/pkg/sql/opt/optbuilder/srfs.go
+++ b/pkg/sql/opt/optbuilder/srfs.go
@@ -89,7 +89,8 @@ func (b *Builder) buildZip(exprs tree.Exprs, inScope *scope) (outScope *scope) {
 	// context.
 	defer b.semaCtx.Properties.Restore(b.semaCtx.Properties)
 	b.semaCtx.Properties.Require(exprKindFrom.String(),
-		tree.RejectAggregates|tree.RejectWindowApplications|tree.RejectNestedGenerators)
+		tree.RejectAggregates|tree.RejectWindowApplications|
+			tree.RejectNestedGenerators|tree.RejectProcedures)
 	inScope.context = exprKindFrom
 
 	// Build each of the provided expressions.


### PR DESCRIPTION
#### sql: disallow invocation of procedures outside of CALL

This commit adds some missing checks to ensure that procedures cannot be
invoked in any context besides as the root expression in `CALL`
statements.

Epic: CRDB-25388

Release note: None

#### sql: add tests with function invocation in procedure argument

This commit adds a couple of tests that show that functions can be used
in procedure argument expressions.

Release note: None
