### PR TITLE
sql/schemachanger: fix TableData element migration crash

### DIFF
--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_add_column.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_add_column.go
@@ -711,7 +711,7 @@ func addSecondaryIndexTargetsForAddColumn(
 		tempIndexColumns = append(tempIndexColumns, c)
 	})
 	for _, c := range tempIndexColumns {
-		b.Add(c)
+		b.AddTransient(c)
 	}
 	b.AddTransient(temp)
 	b.AddTransient(&scpb.IndexData{TableID: temp.TableID, IndexID: temp.IndexID})

--- a/pkg/sql/schemachanger/scplan/testdata/alter_table_add_column
+++ b/pkg/sql/schemachanger/scplan/testdata/alter_table_add_column
@@ -2275,8 +2275,8 @@ PostCommitPhase stage 8 of 15 with 15 MutationType ops
     [[SecondaryIndex:{DescID: 109, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 4, RecreateSourceIndexID: 0}, PUBLIC], ABSENT] -> BACKFILL_ONLY
     [[IndexData:{DescID: 109, IndexID: 2}, PUBLIC], ABSENT] -> PUBLIC
     [[IndexName:{DescID: 109, Name: baz_g_key, IndexID: 2}, PUBLIC], ABSENT] -> PUBLIC
-    [[IndexColumn:{DescID: 109, ColumnID: 2, IndexID: 3}, PUBLIC], ABSENT] -> PUBLIC
-    [[IndexColumn:{DescID: 109, ColumnID: 1, IndexID: 3}, PUBLIC], ABSENT] -> PUBLIC
+    [[IndexColumn:{DescID: 109, ColumnID: 2, IndexID: 3}, TRANSIENT_ABSENT], ABSENT] -> PUBLIC
+    [[IndexColumn:{DescID: 109, ColumnID: 1, IndexID: 3}, TRANSIENT_ABSENT], ABSENT] -> PUBLIC
     [[TemporaryIndex:{DescID: 109, IndexID: 3, ConstraintID: 3, SourceIndexID: 4}, TRANSIENT_ABSENT], ABSENT] -> DELETE_ONLY
   ops:
     *scop.MakePublicPrimaryIndexWriteOnly
@@ -2414,7 +2414,7 @@ PostCommitPhase stage 15 of 15 with 1 ValidationType op
     *scop.ValidateIndex
       IndexID: 2
       TableID: 109
-PostCommitNonRevertiblePhase stage 1 of 2 with 12 MutationType ops
+PostCommitNonRevertiblePhase stage 1 of 2 with 14 MutationType ops
   transitions:
     [[IndexColumn:{DescID: 109, ColumnID: 1, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
     [[PrimaryIndex:{DescID: 109, IndexID: 1, ConstraintID: 1}, ABSENT], VALIDATED] -> DELETE_ONLY
@@ -2423,6 +2423,8 @@ PostCommitNonRevertiblePhase stage 1 of 2 with 12 MutationType ops
     [[IndexColumn:{DescID: 109, ColumnID: 1, IndexID: 5}, TRANSIENT_ABSENT], PUBLIC] -> TRANSIENT_ABSENT
     [[IndexColumn:{DescID: 109, ColumnID: 2, IndexID: 5}, TRANSIENT_ABSENT], PUBLIC] -> TRANSIENT_ABSENT
     [[SecondaryIndex:{DescID: 109, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 4, RecreateSourceIndexID: 0}, PUBLIC], VALIDATED] -> PUBLIC
+    [[IndexColumn:{DescID: 109, ColumnID: 2, IndexID: 3}, TRANSIENT_ABSENT], PUBLIC] -> TRANSIENT_ABSENT
+    [[IndexColumn:{DescID: 109, ColumnID: 1, IndexID: 3}, TRANSIENT_ABSENT], PUBLIC] -> TRANSIENT_ABSENT
     [[TemporaryIndex:{DescID: 109, IndexID: 3, ConstraintID: 3, SourceIndexID: 4}, TRANSIENT_ABSENT], TRANSIENT_DELETE_ONLY] -> TRANSIENT_ABSENT
   ops:
     *scop.MakeWriteOnlyColumnPublic
@@ -2443,6 +2445,15 @@ PostCommitNonRevertiblePhase stage 1 of 2 with 12 MutationType ops
       IndexID: 2
       TableID: 109
     *scop.RefreshStats
+      TableID: 109
+    *scop.RemoveColumnFromIndex
+      ColumnID: 2
+      IndexID: 3
+      TableID: 109
+    *scop.RemoveColumnFromIndex
+      ColumnID: 1
+      IndexID: 3
+      Kind: 1
       TableID: 109
     *scop.MakeIndexAbsent
       IndexID: 3
@@ -2591,6 +2602,14 @@ ALTER TABLE defaultdb.baz ADD g INT UNIQUE DEFAULT 1
   to:   [SecondaryIndex:{DescID: 109, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 4, RecreateSourceIndexID: 0}, PUBLIC]
   kind: Precedence
   rule: index dependents exist before index becomes public
+- from: [IndexColumn:{DescID: 109, ColumnID: 1, IndexID: 3}, PUBLIC]
+  to:   [TemporaryIndex:{DescID: 109, IndexID: 3, ConstraintID: 3, SourceIndexID: 4}, WRITE_ONLY]
+  kind: Precedence
+  rule: index-column added to index before temp index receives writes
+- from: [IndexColumn:{DescID: 109, ColumnID: 1, IndexID: 3}, TRANSIENT_ABSENT]
+  to:   [TemporaryIndex:{DescID: 109, IndexID: 3, ConstraintID: 3, SourceIndexID: 4}, TRANSIENT_ABSENT]
+  kind: Precedence
+  rule: dependents removed before index
 - from: [IndexColumn:{DescID: 109, ColumnID: 1, IndexID: 4}, PUBLIC]
   to:   [PrimaryIndex:{DescID: 109, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}, BACKFILLED]
   kind: Precedence
@@ -2623,6 +2642,14 @@ ALTER TABLE defaultdb.baz ADD g INT UNIQUE DEFAULT 1
   to:   [Column:{DescID: 109, ColumnID: 2}, PUBLIC]
   kind: Precedence
   rule: column dependents exist before column becomes public
+- from: [IndexColumn:{DescID: 109, ColumnID: 2, IndexID: 3}, PUBLIC]
+  to:   [TemporaryIndex:{DescID: 109, IndexID: 3, ConstraintID: 3, SourceIndexID: 4}, WRITE_ONLY]
+  kind: Precedence
+  rule: index-column added to index before temp index receives writes
+- from: [IndexColumn:{DescID: 109, ColumnID: 2, IndexID: 3}, TRANSIENT_ABSENT]
+  to:   [TemporaryIndex:{DescID: 109, IndexID: 3, ConstraintID: 3, SourceIndexID: 4}, TRANSIENT_ABSENT]
+  kind: Precedence
+  rule: dependents removed before index
 - from: [IndexColumn:{DescID: 109, ColumnID: 2, IndexID: 4}, PUBLIC]
   to:   [Column:{DescID: 109, ColumnID: 2}, PUBLIC]
   kind: Precedence
@@ -2839,6 +2866,14 @@ ALTER TABLE defaultdb.baz ADD g INT UNIQUE DEFAULT 1
   to:   [IndexData:{DescID: 109, IndexID: 3}, TRANSIENT_DROPPED]
   kind: Precedence
   rule: index removed before garbage collection
+- from: [TemporaryIndex:{DescID: 109, IndexID: 3, ConstraintID: 3, SourceIndexID: 4}, TRANSIENT_DELETE_ONLY]
+  to:   [IndexColumn:{DescID: 109, ColumnID: 1, IndexID: 3}, TRANSIENT_ABSENT]
+  kind: Precedence
+  rule: index drop mutation visible before cleaning up index columns
+- from: [TemporaryIndex:{DescID: 109, IndexID: 3, ConstraintID: 3, SourceIndexID: 4}, TRANSIENT_DELETE_ONLY]
+  to:   [IndexColumn:{DescID: 109, ColumnID: 2, IndexID: 3}, TRANSIENT_ABSENT]
+  kind: Precedence
+  rule: index drop mutation visible before cleaning up index columns
 - from: [TemporaryIndex:{DescID: 109, IndexID: 3, ConstraintID: 3, SourceIndexID: 4}, TRANSIENT_DELETE_ONLY]
   to:   [SecondaryIndex:{DescID: 109, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 4, RecreateSourceIndexID: 0}, WRITE_ONLY]
   kind: Precedence

--- a/pkg/sql/schemachanger/sctest/backup.go
+++ b/pkg/sql/schemachanger/sctest/backup.go
@@ -71,7 +71,6 @@ func BackupSuccessMixedVersion(t *testing.T, path string, factory TestServerFact
 	// These tests are only marginally more useful than BackupSuccess
 	// and at least as expensive to run.
 	skip.UnderShort(t)
-	skip.WithIssue(t, 112208)
 
 	factory = factory.WithMixedVersion()
 	cumulativeTestForEachPostCommitStage(t, path, factory, func(t *testing.T, cs CumulativeTestCaseSpec) {
@@ -88,7 +87,6 @@ func BackupRollbacksMixedVersion(t *testing.T, path string, factory TestServerFa
 	// These tests are only marginally more useful than BackupSuccess
 	// and at least as expensive to run.
 	skip.UnderShort(t)
-	skip.WithIssue(t, 112208)
 
 	factory = factory.WithMixedVersion()
 	cumulativeTestForEachPostCommitStage(t, path, factory, func(t *testing.T, cs CumulativeTestCaseSpec) {

--- a/pkg/sql/schemachanger/sctest/framework.go
+++ b/pkg/sql/schemachanger/sctest/framework.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/cockroach-go/v2/crdb"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
@@ -884,7 +885,7 @@ func executeSchemaChangeTxn(
 			return nil
 		})
 	}()
-	testutils.SucceedsSoon(t, func() error {
+	testutils.SucceedsWithin(t, func() error {
 		select {
 		case e := <-c:
 			err = e
@@ -892,7 +893,8 @@ func executeSchemaChangeTxn(
 		default:
 			return errors.Newf("waiting for statements to execute: %v", spec.Stmts)
 		}
-	})
+	},
+		time.Minute*2)
 	return err
 }
 

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_default_unique/add_column_default_unique.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_default_unique/add_column_default_unique.explain
@@ -130,17 +130,17 @@ Schema change plan for ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN �
  │    │    └── 1 Validation operation
  │    │         └── ValidateIndex {"IndexID":4,"TableID":106}
  │    ├── Stage 8 of 15 in PostCommitPhase
- │    │    ├── 9 elements transitioning toward PUBLIC
+ │    │    ├── 7 elements transitioning toward PUBLIC
  │    │    │    ├── VALIDATED → PUBLIC        PrimaryIndex:{DescID: 106 (tbl), IndexID: 4 (tbl_pkey+), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1 (tbl_pkey-)}
  │    │    │    ├── ABSENT    → PUBLIC        IndexName:{DescID: 106 (tbl), Name: "tbl_pkey", IndexID: 4 (tbl_pkey+)}
  │    │    │    ├── ABSENT    → PUBLIC        IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (j+), IndexID: 2 (tbl_j_key+)}
  │    │    │    ├── ABSENT    → PUBLIC        IndexColumn:{DescID: 106 (tbl), ColumnID: 1 (i), IndexID: 2 (tbl_j_key+)}
  │    │    │    ├── ABSENT    → BACKFILL_ONLY SecondaryIndex:{DescID: 106 (tbl), IndexID: 2 (tbl_j_key+), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 4 (tbl_pkey+), RecreateSourceIndexID: 0}
  │    │    │    ├── ABSENT    → PUBLIC        IndexData:{DescID: 106 (tbl), IndexID: 2 (tbl_j_key+)}
- │    │    │    ├── ABSENT    → PUBLIC        IndexName:{DescID: 106 (tbl), Name: "tbl_j_key", IndexID: 2 (tbl_j_key+)}
+ │    │    │    └── ABSENT    → PUBLIC        IndexName:{DescID: 106 (tbl), Name: "tbl_j_key", IndexID: 2 (tbl_j_key+)}
+ │    │    ├── 3 elements transitioning toward TRANSIENT_ABSENT
  │    │    │    ├── ABSENT    → PUBLIC        IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (j+), IndexID: 3}
- │    │    │    └── ABSENT    → PUBLIC        IndexColumn:{DescID: 106 (tbl), ColumnID: 1 (i), IndexID: 3}
- │    │    ├── 1 element transitioning toward TRANSIENT_ABSENT
+ │    │    │    ├── ABSENT    → PUBLIC        IndexColumn:{DescID: 106 (tbl), ColumnID: 1 (i), IndexID: 3}
  │    │    │    └── ABSENT    → DELETE_ONLY   TemporaryIndex:{DescID: 106 (tbl), IndexID: 3, ConstraintID: 3, SourceIndexID: 4 (tbl_pkey+)}
  │    │    ├── 2 elements transitioning toward ABSENT
  │    │    │    ├── PUBLIC    → VALIDATED     PrimaryIndex:{DescID: 106 (tbl), IndexID: 1 (tbl_pkey-), ConstraintID: 1}
@@ -213,21 +213,25 @@ Schema change plan for ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN �
       │    ├── 2 elements transitioning toward PUBLIC
       │    │    ├── WRITE_ONLY            → PUBLIC           Column:{DescID: 106 (tbl), ColumnID: 2 (j+)}
       │    │    └── VALIDATED             → PUBLIC           SecondaryIndex:{DescID: 106 (tbl), IndexID: 2 (tbl_j_key+), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 4 (tbl_pkey+), RecreateSourceIndexID: 0}
-      │    ├── 4 elements transitioning toward TRANSIENT_ABSENT
+      │    ├── 6 elements transitioning toward TRANSIENT_ABSENT
       │    │    ├── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 106 (tbl), IndexID: 5, ConstraintID: 5, SourceIndexID: 1 (tbl_pkey-)}
       │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 106 (tbl), ColumnID: 1 (i), IndexID: 5}
       │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (j+), IndexID: 5}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (j+), IndexID: 3}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 106 (tbl), ColumnID: 1 (i), IndexID: 3}
       │    │    └── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 106 (tbl), IndexID: 3, ConstraintID: 3, SourceIndexID: 4 (tbl_pkey+)}
       │    ├── 2 elements transitioning toward ABSENT
       │    │    ├── PUBLIC                → ABSENT           IndexColumn:{DescID: 106 (tbl), ColumnID: 1 (i), IndexID: 1 (tbl_pkey-)}
       │    │    └── VALIDATED             → DELETE_ONLY      PrimaryIndex:{DescID: 106 (tbl), IndexID: 1 (tbl_pkey-), ConstraintID: 1}
-      │    └── 12 Mutation operations
+      │    └── 14 Mutation operations
       │         ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":106}
       │         ├── RefreshStats {"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Kind":2,"TableID":106}
       │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":106}
       │         ├── RefreshStats {"TableID":106}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"TableID":106}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"Kind":1,"TableID":106}
       │         ├── MakeIndexAbsent {"IndexID":3,"TableID":106}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":1,"TableID":106}
       │         ├── MakeIndexAbsent {"IndexID":5,"TableID":106}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_default_unique/add_column_default_unique.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_default_unique/add_column_default_unique.side_effects
@@ -591,7 +591,7 @@ begin transaction #17
 validate forward indexes [2] in table #106
 commit transaction #17
 begin transaction #18
-## PostCommitNonRevertiblePhase stage 1 of 2 with 12 MutationType ops
+## PostCommitNonRevertiblePhase stage 1 of 2 with 14 MutationType ops
 upsert descriptor #106
   ...
          oid: 20


### PR DESCRIPTION
Previously, the migration to inject TableData elements when migrating the schema changer state did not correctly populate metadata.  When attempting to execute any schema change after this change, the missing metadata could cause the execution to fail. To address this, this patch populates the metadata for the added TableData elements. Additionally, it updates the code to populate the statement metadata to ensure they are indexable by ID since, during backup, unrelated statements will get cleaned up. With these changes we can re-enable the mixed version backup/restore tests again.

Fixes: #112208

Release note: None