### PR TITLE
parquet: unwrap datums better

### DIFF
--- a/pkg/sql/importer/exportparquet_test.go
+++ b/pkg/sql/importer/exportparquet_test.go
@@ -141,7 +141,8 @@ func validateDatum(t *testing.T, expected tree.Datum, actual tree.Datum, typ *ty
 		eArr := expected.(*tree.DArray)
 		aArr := actual.(*tree.DArray)
 		for i := 0; i < eArr.Len(); i++ {
-			validateDatum(t, tree.UnwrapDOidWrapper(eArr.Array[i]), aArr.Array[i], typ.ArrayContents())
+			validateDatum(t, tree.UnwrapDOidWrapper(eArr.Array[i]),
+				tree.UnwrapDOidWrapper(aArr.Array[i]), typ.ArrayContents())
 		}
 	case types.DateFamily:
 		// pgDate.orig property doesn't matter and can cause the test to fail

--- a/pkg/util/parquet/testutils.go
+++ b/pkg/util/parquet/testutils.go
@@ -360,13 +360,12 @@ func decodeValuesIntoDatumsHelper(
 }
 
 func unwrapDatum(d tree.Datum) tree.Datum {
-	if wrapper, ok := d.(*tree.DOidWrapper); ok {
-		// REFCURSOR is implemented using DOidWrapper.
-		if wrapper.Oid != oid.T_refcursor {
-			return unwrapDatum(wrapper.Wrapped)
-		}
+	switch t := d.(type) {
+	case *tree.DOidWrapper:
+		return unwrapDatum(t.Wrapped)
+	default:
+		return d
 	}
-	return d
 }
 
 // ValidateDatum validates that the "contents" of the expected datum matches the
@@ -383,6 +382,7 @@ func ValidateDatum(t *testing.T, expected tree.Datum, actual tree.Datum) {
 	// we should unwrap them. We unwrap at this stage as opposed to when
 	// generating datums to test that the writer can handle wrapped datums.
 	expected = unwrapDatum(expected)
+	actual = unwrapDatum(actual)
 
 	switch expected.ResolvedType().Family() {
 	case types.JsonFamily:


### PR DESCRIPTION
Previously, we did not unwrap datums read from parquet files before
comparing. Now, we do. Before https://github.com/cockroachdb/cockroach/pull/111906, we didn't need to, but now we
do because that patch added a new decoder which may return an
OID-wrapped datum.

We do not need to preserve OID wrappers etc when reading parquet
files in tests because we do not store that information in the parquet
files. Testing that OID wrappers match before and after is unecessary.

Additionally, we used to skip unwrapping `REFCURSOR` datums before
comparing. For the same reason as above, we can just unwrap them.

This change also fixes the `validateDatum` function in exporter
tests. It previously did not unwrap array contents. Now it does.

Release note: None
Epic: None
Closes: https://github.com/cockroachdb/cockroach/issues/112561