### PR TITLE
kvflowcontroller: set wait duration to 0 when there is no wait

### DIFF
--- a/pkg/kv/kvserver/kvflowcontrol/kvflowcontroller/kvflowcontroller.go
+++ b/pkg/kv/kvserver/kvflowcontrol/kvflowcontroller/kvflowcontroller.go
@@ -170,7 +170,15 @@ func (c *Controller) Admit(
 		b := c.getBucket(connection.Stream())
 		waitEndState, waited = b.wait(ctx, class, connection.Disconnected())
 	}
-	waitDuration := c.clock.PhysicalTime().Sub(tstart)
+	var waitDuration time.Duration
+	if waited {
+		waitDuration = c.clock.PhysicalTime().Sub(tstart)
+	}
+	// Else, did not wait (common case), so waitDuration stays 0.
+	// Unconditionally computing the waitDuration as the elapsed time pollutes
+	// the wait duration metrics with CPU scheduling artifacts, causing
+	// confusion.
+
 	if waitEndState == waitSuccess {
 		const formatStr = "admitted request (pri=%s stream=%s wait-duration=%s mode=%s)"
 		if waited {


### PR DESCRIPTION
The current unconditional computation of elapsed duration causes the wait duration metric to be occasionally positive which causes confusion when doing diagnosis. This is especially confusing for regular traffic waits, which are not subject to replication flow control by default, or when the CPU is heavily utilized and context switches can cause larger elapsed time.

Epic: none

Release note: None