### PR TITLE
upgrades: assert descriptor repair has correct set of targets

### DIFF
--- a/pkg/sql/catalog/post_deserialization_changes.go
+++ b/pkg/sql/catalog/post_deserialization_changes.go
@@ -31,6 +31,11 @@ func (c *PostDeserializationChanges) Add(change PostDeserializationChangeType) {
 	c.s.Add(int(change))
 }
 
+// Len returns length of the set of changes.
+func (c PostDeserializationChanges) Len() int {
+	return c.s.Len()
+}
+
 // ForEach calls f for every change in the set of changes.
 func (c PostDeserializationChanges) ForEach(f func(change PostDeserializationChangeType)) {
 	c.s.ForEach(func(i int) { f(PostDeserializationChangeType(i)) })

--- a/pkg/upgrade/upgrades/grant_execute_to_public.go
+++ b/pkg/upgrade/upgrades/grant_execute_to_public.go
@@ -80,6 +80,9 @@ func grantExecuteToPublicOnAllFunctions(
 			}
 			kvBatch := txn.KV().NewBatch()
 			for _, desc := range descs {
+				if desc.GetPrivileges().CheckPrivilege(username.PublicRoleName(), privilege.EXECUTE) {
+					continue
+				}
 				desc.GetPrivileges().Grant(
 					username.PublicRoleName(),
 					privilege.List{privilege.EXECUTE},


### PR DESCRIPTION
This patch adds a test to assert that during automated repair of
corrupt descriptors, we do not try to repair a descriptor that
is not corrupted. 

This includes an addition to the previous check for post-deserialization changes that we had for the upgrade logic. We found that during the automatic repair, the descriptor already gets updated in place during the unsafe_upsert_descriptor (in WriteDescToBatch) process and that the previous check was a bit redundant. Thus, the check benefits from being a bit stricter - short-circuiting when the only post-deserialization change is SetModTimeToMVCCTimestamp (not having to update descriptors if they have already been updated).

While testing, it was discovered that function descriptors (regardless of corruption/repair) had their descriptor version increased due to `grantExecuteToPublicOnAllFunctions` being called on each function during a cluster upgrade; however, we noticed that the functions we were testing already had execute privileges for `public`. Thus, a check was added in said logic that ensures functions in this situation (where public already has execute priv. for the func) do not try to grant execute again.

Epic: none
Fixes: #110906

Release note: None