### PR TITLE
roachprod: remove `WaitDelay` call in `localSession`

### DIFF
--- a/pkg/roachprod/install/session.go
+++ b/pkg/roachprod/install/session.go
@@ -18,7 +18,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"sync"
-	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/roachprod/config"
 	rperrors "github.com/cockroachdb/cockroach/pkg/roachprod/errors"
@@ -246,7 +245,6 @@ type localSession struct {
 func newLocalSession(cmd string) *localSession {
 	ctx, cancel := context.WithCancel(context.Background())
 	fullCmd := exec.CommandContext(ctx, "/bin/bash", "-c", cmd)
-	fullCmd.WaitDelay = time.Second
 	return &localSession{fullCmd, cancel}
 }
 


### PR DESCRIPTION
This call was added during work on #111064 as an attempt to fix issues during development. It should not be needed for correctness. It also makes backporting that work to 23.1 not possible, since the `WaitDelay` API was introduced in Go 1.20.

Epic: none

Release note: None