### PR TITLE
release-23.1: sql: simplify and fix error handling from remote flows watcher

### DIFF
--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -450,7 +450,7 @@ func (dsp *DistSQLPlanner) setupFlows(
 	// First, set up the flow on this node.
 	setupReq.Flow = *flows[thisNodeID]
 	var batchReceiver execinfra.BatchReceiver
-	if recv.resultWriterMu.batch != nil {
+	if recv.batchWriter != nil {
 		// Use the DistSQLReceiver as an execinfra.BatchReceiver only if the
 		// former has the corresponding writer set.
 		batchReceiver = recv
@@ -580,6 +580,8 @@ func (dsp *DistSQLPlanner) setupFlows(
 	// since flow.Cleanup() is the last thing before DistSQLPlanner.Run returns
 	// at which point the rowResultWriter is no longer protected by the mutex of
 	// the DistSQLReceiver.
+	// TODO(yuzefovich): think through this comment - we no longer have mutex
+	// protection in place, so perhaps this can be simplified.
 	cleanupCalledMu := struct {
 		syncutil.Mutex
 		called bool
@@ -613,14 +615,10 @@ func (dsp *DistSQLPlanner) setupFlows(
 						// so there is nothing to do.
 						return
 					}
-					// First, we update the DistSQL receiver with the error to
-					// be returned to the client eventually.
-					//
-					// In order to not protect DistSQLReceiver.status with a
-					// mutex, we do not update the status here and, instead,
-					// rely on the DistSQLReceiver detecting the error the next
-					// time an object is pushed into it.
-					recv.setErrorWithoutStatusUpdate(res.err, true /* willDeferStatusUpdate */)
+					// First, we send the error to the DistSQL receiver to be
+					// returned to the client eventually (which will happen on
+					// the next Push or PushBatch call).
+					recv.concurrentErrorCh <- res.err
 					// Now explicitly cancel the local flow.
 					flow.Cancel()
 				}()
@@ -831,9 +829,11 @@ func (dsp *DistSQLPlanner) Run(
 		// We ended up planning everything locally, regardless of whether we
 		// intended to distribute or not.
 		localState.IsLocal = true
+		// Concurrent errors are only possible during the distributed execution.
+		recv.skipConcurrentErrorCheck = true
 	} else {
 		defer func() {
-			if recv.getError() != nil {
+			if recv.resultWriter.Err() != nil {
 				// The execution of this query encountered some error, so we
 				// will eagerly cancel all flows running on the remote nodes
 				// because they are now dead.
@@ -912,21 +912,25 @@ func (dsp *DistSQLPlanner) Run(
 type DistSQLReceiver struct {
 	ctx context.Context
 
-	resultWriterMu struct {
-		// Mutex only protects SetError() and Err() methods of the
-		// rowResultWriter.
-		syncutil.Mutex
-		// These two interfaces refer to the same object, but batch might be
-		// unset (row is always set). These are used to send the results to.
-		row   rowResultWriter
-		batch batchResultWriter
-	}
-	// updateStatus, if true, indicates that a concurrent goroutine has set an
-	// error on the rowResultWriter without updating status, so the main
-	// goroutine needs to update the status.
-	updateStatus atomic.Bool
-	status       execinfra.ConsumerStatus
+	// These two interfaces refer to the same object, but batchWriter might be
+	// unset (resultWriter is always set). These are used to send the results
+	// to.
+	resultWriter rowResultWriter
+	batchWriter  batchResultWriter
 
+	// concurrentErrorCh is a buffered channel that allows for concurrent
+	// goroutines to tell the main execution goroutine that there is an error.
+	// The main goroutine will read from this channel on the next call to Push
+	// or PushBatch.
+	//
+	// This channel is needed since rowResultWriter is not thread-safe and will
+	// only be sent on during distributed plan execution.
+	concurrentErrorCh chan error
+	// skipConcurrentErrorCheck is set when concurrent errors aren't possible,
+	// so there is no need to poll concurrentErrorCh.
+	skipConcurrentErrorCheck bool
+
+	status   execinfra.ConsumerStatus
 	stmtType tree.StatementReturnType
 
 	// outputTypes are the types of the result columns produced by the plan.
@@ -1211,15 +1215,18 @@ func MakeDistSQLReceiver(
 	}
 	*r = DistSQLReceiver{
 		ctx:          consumeCtx,
-		cleanup:      cleanup,
-		rangeCache:   rangeCache,
-		txn:          txn,
-		clockUpdater: clockUpdater,
-		stmtType:     stmtType,
-		tracing:      tracing,
+		resultWriter: resultWriter,
+		batchWriter:  batchWriter,
+		// At the time of writing, there is only one concurrent goroutine that
+		// might send at most one error.
+		concurrentErrorCh: make(chan error, 1),
+		cleanup:           cleanup,
+		rangeCache:        rangeCache,
+		txn:               txn,
+		clockUpdater:      clockUpdater,
+		stmtType:          stmtType,
+		tracing:           tracing,
 	}
-	r.resultWriterMu.row = resultWriter
-	r.resultWriterMu.batch = batchWriter
 	return r
 }
 
@@ -1235,36 +1242,27 @@ func (r *DistSQLReceiver) Release() {
 func (r *DistSQLReceiver) clone() *DistSQLReceiver {
 	ret := receiverSyncPool.Get().(*DistSQLReceiver)
 	*ret = DistSQLReceiver{
-		ctx:          r.ctx,
-		cleanup:      func() {},
-		rangeCache:   r.rangeCache,
-		txn:          r.txn,
-		clockUpdater: r.clockUpdater,
-		stmtType:     tree.Rows,
-		tracing:      r.tracing,
+		ctx:               r.ctx,
+		concurrentErrorCh: make(chan error, 1),
+		cleanup:           func() {},
+		rangeCache:        r.rangeCache,
+		txn:               r.txn,
+		clockUpdater:      r.clockUpdater,
+		stmtType:          tree.Rows,
+		tracing:           r.tracing,
 	}
 	return ret
 }
 
-// getError returns the error stored in the rowResultWriter (if any).
-func (r *DistSQLReceiver) getError() error {
-	r.resultWriterMu.Lock()
-	defer r.resultWriterMu.Unlock()
-	return r.resultWriterMu.row.Err()
-}
-
-// setErrorWithoutStatusUpdate sets the error in the rowResultWriter but does
-// **not** update the status of the DistSQLReceiver. willDeferStatusUpdate
-// indicates whether the main goroutine should update the status the next time
-// it pushes something into the DistSQLReceiver.
+// SetError passes the given error to the resultWriter and updates the status of
+// the DistSQLReceiver accordingly.
 //
-// NOTE: consider using SetError() instead.
-func (r *DistSQLReceiver) setErrorWithoutStatusUpdate(err error, willDeferStatusUpdate bool) {
-	r.resultWriterMu.Lock()
-	defer r.resultWriterMu.Unlock()
+// Note that this method is **not** concurrency safe and needs to be called only
+// from the main execution goroutine.
+func (r *DistSQLReceiver) SetError(err error) {
 	// Check if the error we just received should take precedence over a
 	// previous error (if any).
-	if kvpb.ErrPriority(err) > kvpb.ErrPriority(r.resultWriterMu.row.Err()) {
+	if kvpb.ErrPriority(err) > kvpb.ErrPriority(r.resultWriter.Err()) {
 		if r.txn != nil {
 			if retryErr := (*kvpb.UnhandledRetryableError)(nil); errors.As(err, &retryErr) {
 				// Update the txn in response to remote errors. In the
@@ -1283,54 +1281,39 @@ func (r *DistSQLReceiver) setErrorWithoutStatusUpdate(err error, willDeferStatus
 				}
 			}
 		}
-		r.resultWriterMu.row.SetError(err)
-		r.updateStatus.Store(willDeferStatusUpdate)
+		r.resultWriter.SetError(err)
+		// If we encountered an error, we will transition to draining unless we
+		// were canceled.
+		if r.ctx.Err() != nil {
+			log.VEventf(r.ctx, 1, "encountered error (transitioning to shutting down): %v", r.ctx.Err())
+			r.status = execinfra.ConsumerClosed
+		} else {
+			log.VEventf(r.ctx, 1, "encountered error (transitioning to draining): %v", err)
+			r.status = execinfra.DrainRequested
+		}
 	}
 }
 
-// updateStatusAfterError updates the status of the DistSQLReceiver after it
-// has received an error.
-func (r *DistSQLReceiver) updateStatusAfterError(err error) {
-	// If we encountered an error, we will transition to draining unless we were
-	// canceled.
-	if r.ctx.Err() != nil {
-		log.VEventf(r.ctx, 1, "encountered error (transitioning to shutting down): %v", r.ctx.Err())
-		r.status = execinfra.ConsumerClosed
-	} else {
-		log.VEventf(r.ctx, 1, "encountered error (transitioning to draining): %v", err)
-		r.status = execinfra.DrainRequested
-	}
-}
-
-// SetError provides a convenient way for a client to pass in an error, thus
-// pretending that a query execution error happened. The error is passed along
-// to the resultWriter.
-//
-// The status of DistSQLReceiver is updated accordingly.
-func (r *DistSQLReceiver) SetError(err error) {
-	r.setErrorWithoutStatusUpdate(err, false /* willDeferStatusUpdate */)
-	r.updateStatusAfterError(err)
-}
-
-// checkConcurrentError sets the status if an error has been set by another
-// goroutine that did not also update the status.
+// checkConcurrentError checks whether a concurrent goroutine encountered an
+// error that should trigger the shutdown of the execution pipeline. The status
+// of the DistSQLReceiver is updated accordingly.
 func (r *DistSQLReceiver) checkConcurrentError() {
-	if r.status != execinfra.NeedMoreRows || !r.updateStatus.Load() {
+	if r.skipConcurrentErrorCheck || r.status != execinfra.NeedMoreRows {
 		// If the status already is not NeedMoreRows, then it doesn't matter if
 		// there was a concurrent error set.
 		return
 	}
-	previousErr := r.getError()
-	if previousErr == nil {
-		previousErr = errors.AssertionFailedf("unexpectedly updateStatus is set but there is no error")
+	select {
+	case err := <-r.concurrentErrorCh:
+		r.SetError(err)
+	default:
 	}
-	r.updateStatusAfterError(previousErr)
 }
 
 // pushMeta takes in non-empty metadata object and pushes it to the result
 // writer. Possibly updated status is returned.
 func (r *DistSQLReceiver) pushMeta(meta *execinfrapb.ProducerMetadata) execinfra.ConsumerStatus {
-	if metaWriter, ok := r.resultWriterMu.row.(MetadataResultWriter); ok {
+	if metaWriter, ok := r.resultWriter.(MetadataResultWriter); ok {
 		metaWriter.AddMeta(r.ctx, meta)
 	}
 	if meta.LeafTxnFinalState != nil {
@@ -1432,7 +1415,7 @@ func (r *DistSQLReceiver) Push(
 		// We only need the row count. planNodeToRowSource is set up to handle
 		// ensuring that the last stage in the pipeline will return a single-column
 		// row with the row count in it, so just grab that and exit.
-		r.resultWriterMu.row.SetRowsAffected(r.ctx, n)
+		r.resultWriter.SetRowsAffected(r.ctx, n)
 		return r.status
 	}
 
@@ -1483,7 +1466,7 @@ func (r *DistSQLReceiver) Push(
 		}
 	}
 	r.tracing.TraceExecRowsResult(r.ctx, r.row)
-	if commErr := r.resultWriterMu.row.AddRow(r.ctx, r.row); commErr != nil {
+	if commErr := r.resultWriter.AddRow(r.ctx, r.row); commErr != nil {
 		r.handleCommErr(commErr)
 	}
 	return r.status
@@ -1516,7 +1499,7 @@ func (r *DistSQLReceiver) PushBatch(
 		// We only need the row count. planNodeToRowSource is set up to handle
 		// ensuring that the last stage in the pipeline will return a single-column
 		// row with the row count in it, so just grab that and exit.
-		r.resultWriterMu.row.SetRowsAffected(r.ctx, int(batch.ColVec(0).Int64()[0]))
+		r.resultWriter.SetRowsAffected(r.ctx, int(batch.ColVec(0).Int64()[0]))
 		return r.status
 	}
 
@@ -1538,7 +1521,7 @@ func (r *DistSQLReceiver) PushBatch(
 		panic("unsupported exists mode for PushBatch")
 	}
 	r.tracing.TraceExecBatchResult(r.ctx, batch)
-	if commErr := r.resultWriterMu.batch.AddBatch(r.ctx, batch); commErr != nil {
+	if commErr := r.batchWriter.AddBatch(r.ctx, batch); commErr != nil {
 		r.handleCommErr(commErr)
 	}
 	return r.status
@@ -1664,7 +1647,7 @@ func (dsp *DistSQLPlanner) PlanAndRunAll(
 		}
 	}
 
-	if recv.commErr != nil || recv.getError() != nil {
+	if recv.commErr != nil || recv.resultWriter.Err() != nil {
 		return recv.commErr
 	}
 
@@ -1781,7 +1764,7 @@ func (dsp *DistSQLPlanner) planAndRunSubquery(
 
 	// TODO(yuzefovich): consider implementing batch receiving result writer.
 	subqueryRowReceiver := NewRowResultWriter(&rows)
-	subqueryRecv.resultWriterMu.row = subqueryRowReceiver
+	subqueryRecv.resultWriter = subqueryRowReceiver
 	subqueryPlans[planIdx].started = true
 	finishedSetupFn, cleanup := getFinishedSetupFn(planner)
 	defer cleanup()
@@ -2157,12 +2140,12 @@ func (dsp *DistSQLPlanner) planAndRunPostquery(
 	defer postqueryRecv.Release()
 	defer addTopLevelQueryStats(&postqueryRecv.stats)
 	postqueryResultWriter := &errOnlyResultWriter{}
-	postqueryRecv.resultWriterMu.row = postqueryResultWriter
-	postqueryRecv.resultWriterMu.batch = postqueryResultWriter
+	postqueryRecv.resultWriter = postqueryResultWriter
+	postqueryRecv.batchWriter = postqueryResultWriter
 	finishedSetupFn, cleanup := getFinishedSetupFn(planner)
 	defer cleanup()
 	dsp.Run(ctx, postqueryPlanCtx, planner.txn, postqueryPhysPlan, postqueryRecv, evalCtx, finishedSetupFn)
-	return postqueryRecv.getError()
+	return postqueryRecv.resultWriter.Err()
 }
 
 // planAndRunChecksInParallel executes all checkPlans in parallel. The function


### PR DESCRIPTION
Backport 1/2 commits from #112117.

/cc @cockroachdb/release

---

This commit refactors the way the "remote flows setup watcher" goroutine
communicates an error encountered during `SetupFlowRequest` RPCs
evaluation when they were issued concurrently (i.e. via the DistSQL
workers). This results in code simplification as well as bug fix of
a pretty rare crash that could occur due to a race condition.

As a reminder, during 23.1 cycle in https://github.com/cockroachdb/cockroach/commit/0c1095e31cf93ea7f177f8bf1750ebab188e02d7
we refactored the code for setting up all flows of the distributed plan
so that the gateway flow didn't wait for `SetupFlowRequest` RPCs to come
back from the remote nodes. This required introduction a new "remote
flows setup watcher" goroutine whose only job was to see whether all
RPCs succeed, and if not, to send the error to the main gateway flow
goroutine as well as to cancel that flow. We implemented the
communication of that error by storing it directly into
`rowResultWriter` and introduced mutex protection for synchornization
between two goroutines.

However, that mutex protection was insufficient which could lead to
a crash or a race when reading the error. In particular, the following
could now occur:
1. the main goroutine calls `AddRow` or `AddBatch` concurrently with the
watcher goroutine setting the error. The contract of
`RestrictedCommandResult` is such that most calls after `SetError` are
disallowed, and `AddRow/AddBatch` actually panic in case `err` is set.
This has been observed in a unit test where an error is injected.
2. `AddRow/AddBatch` read `err` field without mutex protection which the
watcher goroutine might be writing into it (under mutex).

These situations are now fixed by making so that only the main goroutine
can set the error on `rowResultWriter`, and we introduce a buffered
channel for the watcher goroutine to send the error on (the error is
picked up on the next call to `Push` or `PushBatch`). This significantly
simplies the code too.

The benchmarks show very minor differences (looks like noise) and are
available [here](https://gist.github.com/yuzefovich/6b4b10d77b2d802ddbcc870eda5f9158).

There is no release note since we haven't seen the bug in the wild, and
it should be quite rare to occur.

Fixes: #111995.

Release note: None

Release justification: bug fix.