### PR TITLE
sql: make tests error if a leaf txn is not created when expected

### DIFF
--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -896,6 +896,10 @@ func (dsp *DistSQLPlanner) Run(
 			"unexpected concurrency for a flow that was forced to be planned locally"))
 		return
 	}
+	if buildutil.CrdbTestBuild && txn != nil && localState.MustUseLeafTxn() && flow.GetFlowCtx().Txn.Type() != kv.LeafTxn {
+		recv.SetError(errors.AssertionFailedf("unexpected root txn used when leaf txn expected"))
+		return
+	}
 
 	noWait := planCtx.getPortalPauseInfo() != nil
 	flow.Run(ctx, noWait)


### PR DESCRIPTION
This adds a test-only error if a leaf transaction is expected to be used by a plan but a root transaction is used instead.

Epic: none
Informs: #111097

Release note: None