### PR TITLE
opt: fix invalid st_union optimizations

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial
@@ -6176,3 +6176,46 @@ WHERE
 null
 empty 1
 empty 2
+
+# Regression test for #111556. st_union produces different results depending on
+# the number of duplicate values, so it should not ignore duplicate values. This
+# test ensures that the optimizer does not eliminate joins and change the number
+# of input values to an st_union aggregate.
+subtest regression_111556
+
+# Create a table for input and a table for results of the st_union aggregate.
+statement ok
+CREATE TABLE t111556_in (g GEOMETRY NOT NULL);
+CREATE TABLE t111556_res (g GEOMETRY);
+
+# Insert two identical values in the input table
+statement ok
+INSERT INTO t111556_in(g)
+SELECT '0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000'
+FROM generate_series(1, 2)
+
+# Perform an st_union aggregate and insert the results into the table.
+statement ok
+INSERT INTO t111556_res
+SELECT st_union(t2.g) FROM t111556_in t1 JOIN t111556_in t2 ON t1.g = t2.g
+
+# Turn off all optimizations.
+statement ok
+SET testing_optimizer_disable_rule_probability = 1.0
+
+# Perform the same st_union aggregate and insert the results into the table.
+statement ok
+INSERT INTO t111556_res
+SELECT st_union(t2.g) FROM t111556_in t1 JOIN t111556_in t2 ON t1.g = t2.g
+
+# Count the number of distinct values in the results table. It should be 1
+# because the INSERTS above should insert the same value.
+query I
+SELECT count(DISTINCT g) FROM t111556_res
+----
+1
+
+statement ok
+SET testing_optimizer_disable_rule_probability = 0
+
+subtest end

--- a/pkg/sql/opt/operator.go
+++ b/pkg/sql/opt/operator.go
@@ -456,13 +456,13 @@ func AggregatesCanMerge(inner, outer Operator) bool {
 func AggregateIgnoresDuplicates(op Operator) bool {
 	switch op {
 	case AnyNotNullAggOp, BitAndAggOp, BitOrAggOp, BoolAndOp, BoolOrOp,
-		ConstAggOp, ConstNotNullAggOp, FirstAggOp, MaxOp, MinOp, STExtentOp, STUnionOp:
+		ConstAggOp, ConstNotNullAggOp, FirstAggOp, MaxOp, MinOp, STExtentOp:
 		return true
 
 	case ArrayAggOp, ArrayCatAggOp, AvgOp, ConcatAggOp, CountOp, CorrOp, CountRowsOp,
 		SumIntOp, SumOp, SqrDiffOp, VarianceOp, StdDevOp, XorAggOp, JsonAggOp, JsonbAggOp,
 		StringAggOp, PercentileDiscOp, PercentileContOp, StdDevPopOp, STMakeLineOp,
-		VarPopOp, JsonObjectAggOp, JsonbObjectAggOp, STCollectOp, CovarPopOp,
+		VarPopOp, JsonObjectAggOp, JsonbObjectAggOp, STCollectOp, STUnionOp, CovarPopOp,
 		CovarSampOp, RegressionAvgXOp, RegressionAvgYOp, RegressionInterceptOp,
 		RegressionR2Op, RegressionSlopeOp, RegressionSXXOp, RegressionSXYOp,
 		RegressionSYYOp, RegressionCountOp, MergeStatsMetadataOp, MergeStatementStatsOp,


### PR DESCRIPTION
The `st_union` aggregate function was incorrectly thought to ignore
duplicate values. That is, given any number of duplicate input values,
it was assumed to produce the same result. This is not the case in both
Postgres with Postgis and CRDB (see #111556).

This incorrect assumption caused the optimizer to perform invalid
optimizations and produce query plans that return incorrect results.
This commit fixes the bug by marking `st_union` as a
non-duplicate-ignoring aggregate.

Fixes #111556

Release note (bug fix): Queries with the `st_union` aggregate function
could produce incorrect results in some cases due to the query optimizer
performing invalid optimizations. This bug has been present since the
`st_union` function was introduced in version 20.2.0.
