### PR TITLE
concurrency: correctly handle lock updates that decrease its strength

### DIFF
--- a/pkg/kv/kvserver/concurrency/lock/locking.go
+++ b/pkg/kv/kvserver/concurrency/lock/locking.go
@@ -80,7 +80,7 @@ func init() {
 // Conflict rules are as described in the compatibility matrix in locking.pb.go.
 func Conflicts(m1, m2 Mode, sv *settings.Values) bool {
 	if m1.Empty() || m2.Empty() {
-		panic("cannot check conflict for uninitialized locks")
+		return false // no conflict with empty lock modes
 	}
 	if m1.Strength > m2.Strength {
 		// Conflict rules are symmetric, so reduce the number of cases we need to
@@ -125,6 +125,15 @@ func Conflicts(m1, m2 Mode, sv *settings.Values) bool {
 // Empty returns true if m is an empty (uninitialized) lock Mode.
 func (m *Mode) Empty() bool {
 	return m.Strength == None && m.Timestamp.IsEmpty()
+}
+
+// Weaker returns true if the receiver conflicts with fewer requests than the
+// Mode supplied.
+func (m Mode) Weaker(o Mode) bool {
+	if m.Strength == o.Strength {
+		return !m.Timestamp.Less(o.Timestamp) // lower timestamp conflicts with more requests
+	}
+	return m.Strength < o.Strength
 }
 
 // MakeModeNone constructs a Mode with strength None.

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/shared_locks
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/shared_locks
@@ -13,6 +13,15 @@ new-txn name=txn4 ts=10,1 epoch=0
 new-txn name=txn5 ts=10,1 epoch=0
 ----
 
+new-txn name=txn6 ts=10,1 epoch=0
+----
+
+new-txn name=txn7 ts=11,1 epoch=0 iso=read-committed
+----
+
+new-txn name=txn8 ts=10,1 epoch=0
+----
+
 # -----------------------------------------------------------------------------
 # Ensure releasing the first of multiple shared lock holders results in correct
 # pushes.
@@ -180,3 +189,191 @@ on-txn-updated txn=txn3 status=committed
 finish req=req5
 ----
 [-] finish req5: finishing request
+
+# ------------------------------------------------------------------------------
+# Ensure that when an intent is pushed out of the way by a non-locking read, but
+# there is still a shared lock on the key, the non-locking read is able to
+# proceed. Serves as a regression test for the bug identified in
+# https://github.com/cockroachdb/cockroach/issues/112608; prior to the fix, the
+# non-locking read could end up waiting indefinitely.
+# ------------------------------------------------------------------------------
+
+new-request name=req6 txn=txn6 ts=10,1
+  put key=a value=v
+----
+
+sequence req=req6
+----
+[6] sequence req6: sequencing request
+[6] sequence req6: acquiring latches
+[6] sequence req6: scanning lock table for conflicting locks
+[6] sequence req6: sequencing complete, returned guard
+
+on-lock-acquired req=req6 key=a dur=r str=intent
+----
+[-] acquire lock: txn 00000006 @ ‹a›
+
+finish req=req6
+----
+[-] finish req6: finishing request
+
+new-request name=req7 txn=txn6 ts=10,1
+  get key=a str=shared
+----
+
+sequence req=req7
+----
+[7] sequence req7: sequencing request
+[7] sequence req7: acquiring latches
+[7] sequence req7: scanning lock table for conflicting locks
+[7] sequence req7: sequencing complete, returned guard
+
+on-lock-acquired req=req7 key=a dur=u str=shared
+----
+[-] acquire lock: txn 00000006 @ ‹a›
+
+finish req=req7
+----
+[-] finish req7: finishing request
+
+debug-lock-table
+----
+num=1
+ lock: "a"
+  holder: txn: 00000006-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
+
+# Note that txn7 is read-committed, so it can push the timestamp of intents as
+# if it was high priority.
+new-request name=req8 txn=txn7 ts=10,1
+  get key=a
+----
+
+sequence req=req8
+----
+[8] sequence req8: sequencing request
+[8] sequence req8: acquiring latches
+[8] sequence req8: scanning lock table for conflicting locks
+[8] sequence req8: sequencing complete, returned guard
+
+handle-lock-conflict-error req=req8 lease-seq=1
+  lock txn=txn6 key=a
+----
+[9] handle lock conflict error req8: handled conflicting locks on ‹"a"›, released latches
+
+debug-lock-table
+----
+num=1
+ lock: "a"
+  holder: txn: 00000006-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent], unrepl [(str: Shared seq: 0)]
+
+sequence req=req8
+----
+[10] sequence req8: re-sequencing request
+[10] sequence req8: acquiring latches
+[10] sequence req8: scanning lock table for conflicting locks
+[10] sequence req8: waiting in lock wait-queues
+[10] sequence req8: lock wait-queue event: wait for (distinguished) txn 00000006 holding lock @ key ‹"a"› (queuedLockingRequests: 0, queuedReaders: 1)
+[10] sequence req8: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = true, wait policy error = false
+[10] sequence req8: pushing timestamp of txn 00000006 above 11.000000000,1
+[10] sequence req8: pusher pushed pushee to 11.000000000,2
+[10] sequence req8: resolving intent ‹"a"› for txn 00000006 with PENDING status and clock observation {1 123.000000000,5}
+[10] sequence req8: lock wait-queue event: done waiting
+[10] sequence req8: conflicted with ‹00000006-0000-0000-0000-000000000000› on ‹"a"› for 0.000s
+[10] sequence req8: acquiring latches
+[10] sequence req8: scanning lock table for conflicting locks
+[10] sequence req8: sequencing complete, returned guard
+
+finish req=req8
+----
+[-] finish req8: finishing request
+
+# ------------------------------------------------------------------------------
+# Similar test to the one above, except this time there's both a non-locking
+# read and shared locking request waiting on the intent. When the non-locking
+# read pushes the intent out of its way, the shared locking request should also
+# be allowed to proceed (as we stop tracking the intent in the lock table).
+# However, the shared locking request should re-discover the intent.
+# ------------------------------------------------------------------------------
+
+new-request name=req9 txn=txn8 ts=10,1
+  get key=a str=shared
+----
+
+sequence req=req9
+----
+[11] sequence req9: sequencing request
+[11] sequence req9: acquiring latches
+[11] sequence req9: scanning lock table for conflicting locks
+[11] sequence req9: sequencing complete, returned guard
+
+handle-lock-conflict-error req=req9 lease-seq=1
+  lock txn=txn6 key=a
+----
+[12] handle lock conflict error req9: handled conflicting locks on ‹"a"›, released latches
+
+debug-lock-table
+----
+num=1
+ lock: "a"
+  holder: txn: 00000006-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent], unrepl [(str: Shared seq: 0)]
+   queued locking requests:
+    active: false req: 9, strength: Shared, txn: 00000008-0000-0000-0000-000000000000
+
+sequence req=req9
+----
+[13] sequence req9: re-sequencing request
+[13] sequence req9: acquiring latches
+[13] sequence req9: scanning lock table for conflicting locks
+[13] sequence req9: waiting in lock wait-queues
+[13] sequence req9: lock wait-queue event: wait for (distinguished) txn 00000006 holding lock @ key ‹"a"› (queuedLockingRequests: 1, queuedReaders: 0)
+[13] sequence req9: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
+[13] sequence req9: pushing txn 00000006 to abort
+[13] sequence req9: blocked on select in concurrency_test.(*cluster).PushTransaction
+
+debug-lock-table
+----
+num=1
+ lock: "a"
+  holder: txn: 00000006-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent], unrepl [(str: Shared seq: 0)]
+   queued locking requests:
+    active: true req: 9, strength: Shared, txn: 00000008-0000-0000-0000-000000000000
+   distinguished req: 9
+
+# Note that txn7 is read-committed, so it can push the timestamp of intents as
+# if it was high priority.
+new-request name=req10 txn=txn7 ts=10,1
+  get key=a
+----
+
+sequence req=req10
+----
+[13] sequence req9: lock wait-queue event: done waiting
+[13] sequence req9: conflicted with ‹00000006-0000-0000-0000-000000000000› on ‹"a"› for 0.000s
+[13] sequence req9: acquiring latches
+[13] sequence req9: scanning lock table for conflicting locks
+[13] sequence req9: sequencing complete, returned guard
+[14] sequence req10: sequencing request
+[14] sequence req10: acquiring latches
+[14] sequence req10: scanning lock table for conflicting locks
+[14] sequence req10: waiting in lock wait-queues
+[14] sequence req10: lock wait-queue event: wait for txn 00000006 holding lock @ key ‹"a"› (queuedLockingRequests: 1, queuedReaders: 1)
+[14] sequence req10: pushing after 0s for: liveness detection = false, deadlock detection = true, timeout enforcement = false, priority enforcement = true, wait policy error = false
+[14] sequence req10: pushing timestamp of txn 00000006 above 11.000000000,1
+[14] sequence req10: resolving intent ‹"a"› for txn 00000006 with PENDING status and clock observation {1 123.000000000,8}
+[14] sequence req10: lock wait-queue event: done waiting
+[14] sequence req10: conflicted with ‹00000006-0000-0000-0000-000000000000› on ‹"a"› for 0.000s
+[14] sequence req10: acquiring latches
+[14] sequence req10: scanning lock table for conflicting locks
+[14] sequence req10: sequencing complete, returned guard
+
+debug-lock-table
+----
+num=1
+ lock: "a"
+  holder: txn: 00000006-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
+   queued locking requests:
+    active: false req: 9, strength: Shared, txn: 00000008-0000-0000-0000-000000000000
+
+finish req=req10
+----
+[-] finish req10: finishing request

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/shared_locks
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/shared_locks
@@ -1141,6 +1141,111 @@ num=1
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
 
+# ------------------------------------------------------------------------------
+# Tests where both a shared lock and (replicated) intent exist on a key, and the
+# intent is forgotten because of a lock update. In such cases, compatible
+# waiting requests should be allowed to proceed. They might re-discover the
+# intent, but that's okay -- we don't want requests waiting in the lock table if
+# the lock that was blocking them isn't being tracked.
+# ------------------------------------------------------------------------------
+
+clear
+----
+num=0
+
+new-request r=req59 txn=txn1 ts=10 spans=shared@a
+----
+
+scan r=req59
+----
+start-waiting: false
+
+acquire r=req59 k=a durability=u strength=shared
+----
+num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
+
+new-request r=req60 txn=txn2 ts=10 spans=shared@a
+----
+
+scan r=req60
+----
+start-waiting: false
+
+add-discovered k=a durability=r strength=intent txn=txn1 r=req60
+----
+num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Intent], unrepl [(str: Shared seq: 0)]
+   queued locking requests:
+    active: false req: 60, strength: Shared, txn: 00000000-0000-0000-0000-000000000002
+
+scan r=req60
+----
+start-waiting: true
+
+new-request r=req61 txn=txn3 ts=10 spans=shared@a
+----
+
+scan r=req61
+----
+start-waiting: true
+
+new-request r=req62 txn=none ts=10 spans=shared@a
+----
+
+scan r=req62
+----
+start-waiting: true
+
+new-request r=req63 txn=txn4 ts=10 spans=exclusive@a
+----
+
+scan r=req63
+----
+start-waiting: true
+
+new-request r=req64 txn=txn5 ts=10 spans=none@a
+----
+
+scan r=req64
+----
+start-waiting: true
+
+new-request r=req65 txn=txn5 ts=10 spans=none@a
+----
+
+scan r=req65
+----
+start-waiting: true
+
+print
+----
+num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Intent], unrepl [(str: Shared seq: 0)]
+   waiting readers:
+    req: 65, txn: 00000000-0000-0000-0000-000000000005
+    req: 64, txn: 00000000-0000-0000-0000-000000000005
+   queued locking requests:
+    active: true req: 60, strength: Shared, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 61, strength: Shared, txn: 00000000-0000-0000-0000-000000000003
+    active: true req: 62, strength: Shared, txn: none
+    active: true req: 63, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000004
+   distinguished req: 60
+
+update txn=txn1 ts=11,0 epoch=0 span=a
+----
+num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
+   queued locking requests:
+    active: false req: 60, strength: Shared, txn: 00000000-0000-0000-0000-000000000002
+    active: false req: 61, strength: Shared, txn: 00000000-0000-0000-0000-000000000003
+    active: true req: 63, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000004
+   distinguished req: 63
+
 # TODO(arul): (non-exhaustive list) of shared lock state transitions that aren't
 # currently supported (and we need to add support for):
 #

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/update
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/update
@@ -386,6 +386,12 @@ new-lock-table maxlocks=10000
 new-txn txn=txn1 ts=10 epoch=1 seq=1
 ----
 
+new-txn txn=txn2 ts=12,1 epoch=0
+----
+
+new-txn txn=txn3 ts=14,1 epoch=0
+----
+
 new-request r=req1 txn=txn1 ts=10 spans=exclusive@a
 ----
 
@@ -489,3 +495,69 @@ num=1
 update txn=txn1 ts=10 epoch=1 span=a ignored-seqs=1
 ----
 num=0
+
+# ------------------------------------------------------------------------------
+# Tests where both an exclusive lock and a (replicated) intent exists on a key,
+# and the intent is forgotten because of a lock update, we correctly let some
+# waiting requests through.
+# ------------------------------------------------------------------------------
+
+clear
+----
+num=0
+
+new-request r=req5 txn=txn1 ts=10 spans=exclusive@a
+----
+
+scan r=req5
+----
+start-waiting: false
+
+acquire r=req5 k=a durability=u strength=exclusive
+----
+num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 10)]
+
+new-request r=req6 txn=txn2 ts=10 spans=none@a
+----
+
+scan r=req6
+----
+start-waiting: true
+
+add-discovered k=a durability=r strength=intent txn=txn1 r=req6
+----
+num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, iso: Serializable, ts: 10.000000000,0, info: repl [Intent], unrepl [(str: Exclusive seq: 10)]
+   waiting readers:
+    req: 2, txn: 00000000-0000-0000-0000-000000000002
+   distinguished req: 2
+
+new-request r=req7 txn=txn3 ts=10 spans=shared@a
+----
+
+scan r=req7
+----
+start-waiting: true
+
+print
+----
+num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, iso: Serializable, ts: 10.000000000,0, info: repl [Intent], unrepl [(str: Exclusive seq: 10)]
+   waiting readers:
+    req: 2, txn: 00000000-0000-0000-0000-000000000002
+   queued locking requests:
+    active: true req: 3, strength: Shared, txn: 00000000-0000-0000-0000-000000000003
+   distinguished req: 2
+
+update txn=txn1 ts=11,0 epoch=0 span=a
+----
+num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, iso: Serializable, ts: 11.000000000,0, info: unrepl [(str: Exclusive seq: 10)]
+   queued locking requests:
+    active: true req: 3, strength: Shared, txn: 00000000-0000-0000-0000-000000000003
+   distinguished req: 3


### PR DESCRIPTION
When a lock is updated on behalf of a non-finalized transaction, the lock table simply forgets any replicated lock information it was previously tracking. Now, if a lock is held with both replicated and unreplicated durability, and the replicated lock's strength is stronger than the unreplicated lock's strength, forgetting the replicated lock means there may be requests waiting on a key that no longer conflict with what's being tracked in memory[*]. In such cases, requests that no longer conflict with the in-memory tracking should no longer wait on this key -- they should be allowed to proceed with their scan. It's not guaranteed that they no longer conflict with the lock -- they might rediscover the replicated lock again and start waiting. However, if they no longer conflict with the lock, blocking them indefinitely can lead to deadlocks.

[*] Concretely, consider the following construction:
- key a: [txn 1, (repl intent ts@10), (unrepl shared)]
  - wait-queue readers: [none ts@12], [none ts@15]
  - wait-queue locking requests: [shared], [shared], [exclusive] [shared] In this case, updating the intent's timestamp to ts@14 (and forgetting it) should allow both the non-locking readers and first two shared locking requests to become compatible with what's being tracked in memory for this key.

Fixes #112608

Release note: None