### PR TITLE
storage: change iterator creation methods to accept context.Context

### DIFF
--- a/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
+++ b/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
@@ -224,7 +224,7 @@ CREATE TABLE data2.foo (a int);
 		store := tcRestore.GetFirstStoreFromServer(t, 0)
 		startKey := keys.SystemSQLCodec.TablePrefix(uint32(id))
 		endKey := startKey.PrefixEnd()
-		it, err := store.TODOEngine().NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{
+		it, err := store.TODOEngine().NewMVCCIterator(context.Background(), storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{
 			UpperBound: endKey,
 		})
 		require.NoError(t, err)

--- a/pkg/ccl/backupccl/restore_data_processor_test.go
+++ b/pkg/ccl/backupccl/restore_data_processor_test.go
@@ -117,7 +117,7 @@ func slurpSSTablesLatestKey(
 	}
 
 	var kvs []storage.MVCCKeyValue
-	it, err := batch.NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{UpperBound: roachpb.KeyMax})
+	it, err := batch.NewMVCCIterator(context.Background(), storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{UpperBound: roachpb.KeyMax})
 	require.NoError(t, err)
 	defer it.Close()
 	for it.SeekGE(start); ; it.NextKey() {

--- a/pkg/ccl/storageccl/engineccl/bench_test.go
+++ b/pkg/ccl/storageccl/engineccl/bench_test.go
@@ -181,12 +181,12 @@ func BenchmarkTimeBoundIterate(b *testing.B) {
 		b.Run(fmt.Sprintf("LoadFactor=%.2f", loadFactor), func(b *testing.B) {
 			b.Run("NormalIterator", func(b *testing.B) {
 				runIterate(b, loadFactor, func(e storage.Engine, _, _ hlc.Timestamp) (storage.MVCCIterator, error) {
-					return e.NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{UpperBound: roachpb.KeyMax})
+					return e.NewMVCCIterator(context.Background(), storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{UpperBound: roachpb.KeyMax})
 				})
 			})
 			b.Run("TimeBoundIterator", func(b *testing.B) {
 				runIterate(b, loadFactor, func(e storage.Engine, startTime, endTime hlc.Timestamp) (storage.MVCCIterator, error) {
-					return e.NewMVCCIterator(storage.MVCCKeyIterKind, storage.IterOptions{
+					return e.NewMVCCIterator(context.Background(), storage.MVCCKeyIterKind, storage.IterOptions{
 						MinTimestamp: startTime,
 						MaxTimestamp: endTime,
 						UpperBound:   roachpb.KeyMax,

--- a/pkg/ccl/streamingccl/streamingest/replication_random_client_test.go
+++ b/pkg/ccl/streamingccl/streamingest/replication_random_client_test.go
@@ -300,7 +300,7 @@ func assertExactlyEqualKVs(
 ) hlc.Timestamp {
 	// Iterate over the store.
 	store := tc.GetFirstStoreFromServer(t, 0)
-	it, err := store.TODOEngine().NewMVCCIterator(storage.MVCCKeyIterKind, storage.IterOptions{
+	it, err := store.TODOEngine().NewMVCCIterator(context.Background(), storage.MVCCKeyIterKind, storage.IterOptions{
 		LowerBound: tenantSpan.Key,
 		UpperBound: tenantSpan.EndKey,
 	})

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor_test.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor_test.go
@@ -585,7 +585,7 @@ func assertEqualKVs(
 	// Iterate over the store.
 	store, err := srv.StorageLayer().GetStores().(*kvserver.Stores).GetStore(srv.GetFirstStoreID())
 	require.NoError(t, err)
-	it, err := store.TODOEngine().NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{
+	it, err := store.TODOEngine().NewMVCCIterator(context.Background(), storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{
 		LowerBound: targetSpan.Key,
 		UpperBound: targetSpan.EndKey,
 	})

--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -364,13 +364,14 @@ func runDebugKeys(cmd *cobra.Command, args []string) error {
 		splitScan = true
 		endKey = keys.LocalMax
 	}
-	if err := db.MVCCIterate(debugCtx.startKey.Key, endKey, storage.MVCCKeyAndIntentsIterKind,
+	if err := db.MVCCIterate(
+		cmd.Context(), debugCtx.startKey.Key, endKey, storage.MVCCKeyAndIntentsIterKind,
 		storage.IterKeyTypePointsAndRanges, iterFunc); err != nil {
 		return err
 	}
 	if splitScan {
-		if err := db.MVCCIterate(keys.LocalMax, debugCtx.endKey.Key, storage.MVCCKeyAndIntentsIterKind,
-			storage.IterKeyTypePointsAndRanges, iterFunc); err != nil {
+		if err := db.MVCCIterate(cmd.Context(), keys.LocalMax, debugCtx.endKey.Key,
+			storage.MVCCKeyAndIntentsIterKind, storage.IterKeyTypePointsAndRanges, iterFunc); err != nil {
 			return err
 		}
 	}
@@ -469,7 +470,7 @@ func runDebugRangeData(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	desc, err := loadRangeDescriptor(db, rangeID)
+	desc, err := loadRangeDescriptor(cmd.Context(), db, rangeID)
 	if err != nil {
 		return err
 	}
@@ -478,7 +479,8 @@ func runDebugRangeData(cmd *cobra.Command, args []string) error {
 	defer snapshot.Close()
 
 	var results int
-	return rditer.IterateReplicaKeySpans(&desc, snapshot, debugCtx.replicated, rditer.ReplicatedSpansAll,
+	return rditer.IterateReplicaKeySpans(cmd.Context(), &desc, snapshot, debugCtx.replicated,
+		rditer.ReplicatedSpansAll,
 		func(iter storage.EngineIterator, _ roachpb.Span, keyType storage.IterKeyType) error {
 			for ok := true; ok && err == nil; ok, err = iter.NextEngineKey() {
 				switch keyType {
@@ -526,7 +528,7 @@ Prints all range descriptors in a store with a history of changes.
 }
 
 func loadRangeDescriptor(
-	db storage.Engine, rangeID roachpb.RangeID,
+	ctx context.Context, db storage.Engine, rangeID roachpb.RangeID,
 ) (roachpb.RangeDescriptor, error) {
 	var desc roachpb.RangeDescriptor
 	handleKV := func(kv storage.MVCCKeyValue, _ storage.MVCCRangeKeyStack) error {
@@ -563,8 +565,8 @@ func loadRangeDescriptor(
 	end := keys.LocalRangeMax
 
 	// NB: Range descriptor keys can have intents.
-	if err := db.MVCCIterate(start, end, storage.MVCCKeyAndIntentsIterKind,
-		storage.IterKeyTypePointsOnly, handleKV); err != nil {
+	if err := db.MVCCIterate(
+		ctx, start, end, storage.MVCCKeyAndIntentsIterKind, storage.IterKeyTypePointsOnly, handleKV); err != nil {
 		return roachpb.RangeDescriptor{}, err
 	}
 	if desc.RangeID == rangeID {
@@ -586,8 +588,8 @@ func runDebugRangeDescriptors(cmd *cobra.Command, args []string) error {
 	end := keys.LocalRangeMax
 
 	// NB: Range descriptor keys can have intents.
-	return db.MVCCIterate(start, end, storage.MVCCKeyAndIntentsIterKind, storage.IterKeyTypePointsOnly,
-		func(kv storage.MVCCKeyValue, _ storage.MVCCRangeKeyStack) error {
+	return db.MVCCIterate(cmd.Context(), start, end, storage.MVCCKeyAndIntentsIterKind,
+		storage.IterKeyTypePointsOnly, func(kv storage.MVCCKeyValue, _ storage.MVCCRangeKeyStack) error {
 			if kvserver.IsRangeDescriptorKey(kv.Key) != nil {
 				return nil
 			}
@@ -763,8 +765,8 @@ func runDebugRaftLog(cmd *cobra.Command, args []string) error {
 		string(storage.EncodeMVCCKey(storage.MakeMVCCMetadataKey(end))))
 
 	// NB: raft log does not have intents.
-	return db.MVCCIterate(start, end, storage.MVCCKeyIterKind, storage.IterKeyTypePointsOnly,
-		func(kv storage.MVCCKeyValue, _ storage.MVCCRangeKeyStack) error {
+	return db.MVCCIterate(cmd.Context(), start, end, storage.MVCCKeyIterKind,
+		storage.IterKeyTypePointsOnly, func(kv storage.MVCCKeyValue, _ storage.MVCCRangeKeyStack) error {
 			kvserver.PrintMVCCKeyValue(kv)
 			return nil
 		})
@@ -1278,7 +1280,7 @@ func runDebugIntentCount(cmd *cobra.Command, args []string) error {
 		}
 	})
 
-	iter, err := db.NewEngineIterator(storage.IterOptions{
+	iter, err := db.NewEngineIterator(ctx, storage.IterOptions{
 		LowerBound: keys.LockTableSingleKeyStart,
 		UpperBound: keys.LockTableSingleKeyEnd,
 	})

--- a/pkg/cli/debug_check_store.go
+++ b/pkg/cli/debug_check_store.go
@@ -130,7 +130,7 @@ func worker(ctx context.Context, in checkInput) checkResult {
 		res.err = err
 		return res
 	}
-	ms, err := rditer.ComputeStatsForRange(desc, eng, claimedMS.LastUpdateNanos)
+	ms, err := rditer.ComputeStatsForRange(ctx, desc, eng, claimedMS.LastUpdateNanos)
 	if err != nil {
 		res.err = err
 		return res

--- a/pkg/cli/debug_synctest.go
+++ b/pkg/cli/debug_synctest.go
@@ -149,7 +149,7 @@ func runSyncer(
 	}
 
 	fmt.Fprintf(stderr, "verifying existing sequence numbers...")
-	err = db.MVCCIterate(roachpb.KeyMin, roachpb.KeyMax, storage.MVCCKeyAndIntentsIterKind,
+	err = db.MVCCIterate(ctx, roachpb.KeyMin, roachpb.KeyMax, storage.MVCCKeyAndIntentsIterKind,
 		storage.IterKeyTypePointsOnly, check)
 	if err != nil {
 		return 0, err

--- a/pkg/kv/kvserver/batcheval/cmd_add_sstable.go
+++ b/pkg/kv/kvserver/batcheval/cmd_add_sstable.go
@@ -408,12 +408,12 @@ func EvalAddSSTable(
 	// needs to know what data is there, it must issue its own real Scan.
 	if args.ReturnFollowingLikelyNonEmptySpanStart {
 		existingIter, err := spanset.DisableReaderAssertions(readWriter).NewMVCCIterator(
+			ctx,
 			storage.MVCCKeyIterKind, // don't care if it is committed or not, just that it isn't empty.
 			storage.IterOptions{
 				KeyTypes:   storage.IterKeyTypePointsAndRanges,
 				UpperBound: reply.RangeSpan.EndKey,
-			},
-		)
+			})
 		if err != nil {
 			return result.Result{}, errors.Wrap(err, "error when creating iterator for non-empty span")
 		}

--- a/pkg/kv/kvserver/batcheval/cmd_add_sstable_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_add_sstable_test.go
@@ -1986,7 +1986,7 @@ func TestAddSSTableSSTTimestampToRequestTimestampRespectsClosedTS(t *testing.T) 
 	require.True(t, closedTS.LessEq(writeTS), "timestamp %s below closed timestamp %s", result.Timestamp, closedTS)
 
 	// Check that the value was in fact written at the write timestamp.
-	kvs, err := storage.Scan(store.TODOEngine(), roachpb.Key("key"), roachpb.Key("key").Next(), 0)
+	kvs, err := storage.Scan(context.Background(), store.TODOEngine(), roachpb.Key("key"), roachpb.Key("key").Next(), 0)
 	require.NoError(t, err)
 	require.Len(t, kvs, 1)
 	require.Equal(t, storage.MVCCKey{Key: roachpb.Key("key"), Timestamp: writeTS}, kvs[0].Key)

--- a/pkg/kv/kvserver/batcheval/cmd_clear_range.go
+++ b/pkg/kv/kvserver/batcheval/cmd_clear_range.go
@@ -155,7 +155,7 @@ func ClearRange(
 	// range key span, since we expect range keys to be rare.
 	const pointKeyThreshold, rangeKeyThreshold = 2, 2
 	if err := storage.ClearRangeWithHeuristic(
-		readWriter, readWriter, from, to, pointKeyThreshold, rangeKeyThreshold,
+		ctx, readWriter, readWriter, from, to, pointKeyThreshold, rangeKeyThreshold,
 	); err != nil {
 		return result.Result{}, err
 	}
@@ -192,7 +192,7 @@ func computeStatsDelta(
 	// If we can't use the fast stats path, or race test is enabled, compute stats
 	// across the key span to be cleared.
 	if !entireRange || util.RaceEnabled {
-		computed, err := storage.ComputeStats(readWriter, from, to, delta.LastUpdateNanos)
+		computed, err := storage.ComputeStats(ctx, readWriter, from, to, delta.LastUpdateNanos)
 		if err != nil {
 			return enginepb.MVCCStats{}, err
 		}
@@ -217,7 +217,7 @@ func computeStatsDelta(
 		if !entireRange {
 			leftPeekBound, rightPeekBound := rangeTombstonePeekBounds(
 				from, to, desc.StartKey.AsRawKey(), desc.EndKey.AsRawKey())
-			rkIter, err := readWriter.NewMVCCIterator(storage.MVCCKeyIterKind, storage.IterOptions{
+			rkIter, err := readWriter.NewMVCCIterator(ctx, storage.MVCCKeyIterKind, storage.IterOptions{
 				KeyTypes:   storage.IterKeyTypeRangesOnly,
 				LowerBound: leftPeekBound,
 				UpperBound: rightPeekBound,

--- a/pkg/kv/kvserver/batcheval/cmd_clear_range_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_clear_range_test.go
@@ -207,7 +207,7 @@ func TestCmdClearRange(t *testing.T) {
 				require.Equal(t, tc.expClearIter, batch.clearIterCount == 1)
 
 				// Ensure that the data is gone.
-				iter, err := eng.NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{
+				iter, err := eng.NewMVCCIterator(context.Background(), storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{
 					KeyTypes:   storage.IterKeyTypePointsAndRanges,
 					LowerBound: startKey,
 					UpperBound: endKey,

--- a/pkg/kv/kvserver/batcheval/cmd_delete_range_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_delete_range_test.go
@@ -309,7 +309,7 @@ func TestDeleteRangeTombstone(t *testing.T) {
 // operated on. The command should not have written an actual rangekey!
 func checkPredicateDeleteRange(t *testing.T, engine storage.Reader, rKeyInfo storage.MVCCRangeKey) {
 
-	iter, err := engine.NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{
+	iter, err := engine.NewMVCCIterator(context.Background(), storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{
 		KeyTypes:   storage.IterKeyTypePointsAndRanges,
 		LowerBound: rKeyInfo.StartKey,
 		UpperBound: rKeyInfo.EndKey,
@@ -349,7 +349,7 @@ func checkDeleteRangeTombstone(
 	written bool,
 	now hlc.ClockTimestamp,
 ) {
-	iter, err := engine.NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{
+	iter, err := engine.NewMVCCIterator(context.Background(), storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{
 		KeyTypes:   storage.IterKeyTypeRangesOnly,
 		LowerBound: rangeKey.StartKey,
 		UpperBound: rangeKey.EndKey,
@@ -409,7 +409,7 @@ func computeStats(
 	if len(to) == 0 {
 		to = keys.MaxKey
 	}
-	ms, err := storage.ComputeStats(reader, from, to, nowNanos)
+	ms, err := storage.ComputeStats(context.Background(), reader, from, to, nowNanos)
 	require.NoError(t, err)
 	return ms
 }

--- a/pkg/kv/kvserver/batcheval/cmd_end_transaction_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_end_transaction_test.go
@@ -1470,7 +1470,7 @@ func TestComputeSplitRangeKeyStatsDelta(t *testing.T) {
 
 			tc.expect.LastUpdateNanos = nowNanos
 
-			msDelta, err := computeSplitRangeKeyStatsDelta(engine, lhsDesc, rhsDesc)
+			msDelta, err := computeSplitRangeKeyStatsDelta(context.Background(), engine, lhsDesc, rhsDesc)
 			require.NoError(t, err)
 			msDelta.AgeTo(nowNanos)
 			require.Equal(t, tc.expect, msDelta)

--- a/pkg/kv/kvserver/batcheval/cmd_export_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_export_test.go
@@ -542,7 +542,7 @@ func exportUsingGoIterator(
 		return nil, nil
 	}
 
-	iter, err := storage.NewMVCCIncrementalIterator(reader, storage.MVCCIncrementalIterOptions{
+	iter, err := storage.NewMVCCIncrementalIterator(ctx, reader, storage.MVCCIncrementalIterOptions{
 		EndKey:    endKey,
 		StartTime: startTime,
 		EndTime:   endTime,

--- a/pkg/kv/kvserver/batcheval/cmd_query_intent.go
+++ b/pkg/kv/kvserver/batcheval/cmd_query_intent.go
@@ -75,7 +75,7 @@ func QueryIntent(
 	}
 
 	// Read from the lock table to see if an intent exists.
-	intent, err := storage.GetIntent(reader, args.Key)
+	intent, err := storage.GetIntent(ctx, reader, args.Key)
 	if err != nil {
 		return result.Result{}, err
 	}

--- a/pkg/kv/kvserver/batcheval/cmd_query_resolved_timestamp.go
+++ b/pkg/kv/kvserver/batcheval/cmd_query_resolved_timestamp.go
@@ -74,7 +74,7 @@ func QueryResolvedTimestamp(
 	intentCleanupAge := QueryResolvedTimestampIntentCleanupAge.Get(&st.SV)
 	intentCleanupThresh := cArgs.EvalCtx.Clock().Now().Add(-intentCleanupAge.Nanoseconds(), 0)
 	minIntentTS, encounteredIntents, err := computeMinIntentTimestamp(
-		reader, args.Span(), maxEncounteredIntents, maxEncounteredIntentKeyBytes, intentCleanupThresh,
+		ctx, reader, args.Span(), maxEncounteredIntents, maxEncounteredIntentKeyBytes, intentCleanupThresh,
 	)
 	if err != nil {
 		return result.Result{}, errors.Wrapf(err, "computing minimum intent timestamp")
@@ -96,6 +96,7 @@ func QueryResolvedTimestamp(
 // minimum timestamp of any intent. While doing so, it also collects and returns
 // up to maxEncounteredIntents intents that are older than intentCleanupThresh.
 func computeMinIntentTimestamp(
+	ctx context.Context,
 	reader storage.Reader,
 	span roachpb.Span,
 	maxEncounteredIntents int64,
@@ -110,7 +111,7 @@ func computeMinIntentTimestamp(
 		// Ignore Exclusive and Shared locks. We only care about intents.
 		MatchMinStr: lock.Intent,
 	}
-	iter, err := storage.NewLockTableIterator(reader, opts)
+	iter, err := storage.NewLockTableIterator(ctx, reader, opts)
 	if err != nil {
 		return hlc.Timestamp{}, nil, err
 	}

--- a/pkg/kv/kvserver/batcheval/cmd_recompute_stats.go
+++ b/pkg/kv/kvserver/batcheval/cmd_recompute_stats.go
@@ -75,7 +75,7 @@ func RecomputeStats(
 
 	args = nil // avoid accidental use below
 
-	actualMS, err := rditer.ComputeStatsForRange(desc, reader, cArgs.Header.Timestamp.WallTime)
+	actualMS, err := rditer.ComputeStatsForRange(ctx, desc, reader, cArgs.Header.Timestamp.WallTime)
 	if err != nil {
 		return result.Result{}, err
 	}

--- a/pkg/kv/kvserver/batcheval/cmd_refresh_range.go
+++ b/pkg/kv/kvserver/batcheval/cmd_refresh_range.go
@@ -81,7 +81,7 @@ func refreshRange(
 	// Construct an incremental iterator with the desired time bounds. Incremental
 	// iterators will emit MVCC tombstones by default and will emit intents when
 	// configured to do so (see IntentPolicy).
-	iter, err := storage.NewMVCCIncrementalIterator(reader, storage.MVCCIncrementalIterOptions{
+	iter, err := storage.NewMVCCIncrementalIterator(ctx, reader, storage.MVCCIncrementalIterOptions{
 		KeyTypes:     storage.IterKeyTypePointsAndRanges,
 		StartKey:     span.Key,
 		EndKey:       span.EndKey,

--- a/pkg/kv/kvserver/batcheval/cmd_subsume.go
+++ b/pkg/kv/kvserver/batcheval/cmd_subsume.go
@@ -148,7 +148,7 @@ func Subsume(
 	// rather than introducing additional synchronization complexity.
 	ridPrefix := keys.MakeRangeIDReplicatedPrefix(desc.RangeID)
 	reply.RangeIDLocalMVCCStats, err = storage.ComputeStats(
-		readWriter, ridPrefix, ridPrefix.PrefixEnd(), 0 /* nowNanos */)
+		ctx, readWriter, ridPrefix, ridPrefix.PrefixEnd(), 0 /* nowNanos */)
 	if err != nil {
 		return result.Result{}, err
 	}

--- a/pkg/kv/kvserver/batcheval/cmd_truncate_log.go
+++ b/pkg/kv/kvserver/batcheval/cmd_truncate_log.go
@@ -121,7 +121,7 @@ func TruncateLog(
 	// are not tracked in the raft log delta. The delta will be adjusted below
 	// raft.
 	// We can pass zero as nowNanos because we're only interested in SysBytes.
-	ms, err := storage.ComputeStats(readWriter, start, end, 0 /* nowNanos */)
+	ms, err := storage.ComputeStats(ctx, readWriter, start, end, 0 /* nowNanos */)
 	if err != nil {
 		return result.Result{}, errors.Wrap(err, "while computing stats of Raft log freed by truncation")
 	}

--- a/pkg/kv/kvserver/batcheval/intent_test.go
+++ b/pkg/kv/kvserver/batcheval/intent_test.go
@@ -36,12 +36,12 @@ type instrumentedEngine struct {
 }
 
 func (ie *instrumentedEngine) NewMVCCIterator(
-	iterKind storage.MVCCIterKind, opts storage.IterOptions,
+	ctx context.Context, iterKind storage.MVCCIterKind, opts storage.IterOptions,
 ) (storage.MVCCIterator, error) {
 	if ie.onNewIterator != nil {
 		ie.onNewIterator(opts)
 	}
-	return ie.Engine.NewMVCCIterator(iterKind, opts)
+	return ie.Engine.NewMVCCIterator(ctx, iterKind, opts)
 }
 
 // TestCollectIntentsUsesSameIterator tests that all uses of CollectIntents

--- a/pkg/kv/kvserver/client_raft_test.go
+++ b/pkg/kv/kvserver/client_raft_test.go
@@ -5887,7 +5887,7 @@ func TestRaftSnapshotsWithMVCCRangeKeysEverywhere(t *testing.T) {
 			for _, span := range rditer.MakeReplicatedKeySpans(&desc) {
 				prefix := append(span.Key.Clone(), ':')
 
-				iter, err := e.NewEngineIterator(storage.IterOptions{
+				iter, err := e.NewEngineIterator(context.Background(), storage.IterOptions{
 					KeyTypes:   storage.IterKeyTypeRangesOnly,
 					LowerBound: span.Key,
 					UpperBound: span.EndKey,

--- a/pkg/kv/kvserver/client_replica_test.go
+++ b/pkg/kv/kvserver/client_replica_test.go
@@ -2727,7 +2727,7 @@ func TestClearRange(t *testing.T) {
 		t.Helper()
 		start := prefix
 		end := prefix.PrefixEnd()
-		kvs, err := storage.Scan(store.TODOEngine(), start, end, 0 /* maxRows */)
+		kvs, err := storage.Scan(context.Background(), store.TODOEngine(), start, end, 0)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/kv/kvserver/client_split_test.go
+++ b/pkg/kv/kvserver/client_split_test.go
@@ -386,7 +386,7 @@ func TestStoreRangeSplitIntents(t *testing.T) {
 	// Verify the transaction record is gone.
 	start := storage.MakeMVCCMetadataKey(keys.MakeRangeKeyPrefix(roachpb.RKeyMin))
 	end := storage.MakeMVCCMetadataKey(keys.MakeRangeKeyPrefix(roachpb.RKeyMax))
-	iter, err := store.TODOEngine().NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{UpperBound: end.Key})
+	iter, err := store.TODOEngine().NewMVCCIterator(context.Background(), storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{UpperBound: end.Key})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/kv/kvserver/client_test.go
+++ b/pkg/kv/kvserver/client_test.go
@@ -188,7 +188,7 @@ func assertRecomputedStats(
 ) {
 	t.Helper()
 
-	ms, err := rditer.ComputeStatsForRange(desc, r, nowNanos)
+	ms, err := rditer.ComputeStatsForRange(context.Background(), desc, r, nowNanos)
 	require.NoError(t, err)
 
 	// When used with a real wall clock these will not be the same, since it

--- a/pkg/kv/kvserver/gc/data_distribution_test.go
+++ b/pkg/kv/kvserver/gc/data_distribution_test.go
@@ -94,7 +94,7 @@ func (ds dataDistribution) setupTest(
 	require.NoError(t, eng.Flush())
 	snap := eng.NewSnapshot()
 	defer snap.Close()
-	ms, err := rditer.ComputeStatsForRange(&desc, snap, maxTs.WallTime)
+	ms, err := rditer.ComputeStatsForRange(ctx, &desc, snap, maxTs.WallTime)
 	require.NoError(t, err)
 	return ms
 }

--- a/pkg/kv/kvserver/gc/gc_iterator_test.go
+++ b/pkg/kv/kvserver/gc/gc_iterator_test.go
@@ -11,6 +11,7 @@
 package gc
 
 import (
+	"context"
 	"math/rand"
 	"testing"
 	"time"
@@ -163,7 +164,7 @@ func TestGCIterator(t *testing.T) {
 			ds.setupTest(t, eng, desc)
 			snap := eng.NewSnapshot()
 			defer snap.Close()
-			mvccIt, err := snap.NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{
+			mvccIt, err := snap.NewMVCCIterator(context.Background(), storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{
 				LowerBound: desc.StartKey.AsRawKey(),
 				UpperBound: desc.EndKey.AsRawKey(),
 				KeyTypes:   storage.IterKeyTypePointsAndRanges,

--- a/pkg/kv/kvserver/gc/gc_old_test.go
+++ b/pkg/kv/kvserver/gc/gc_old_test.go
@@ -51,7 +51,7 @@ func runGCOld(
 	cleanupTxnIntentsAsyncFn CleanupTxnIntentsAsyncFunc,
 ) (Info, error) {
 
-	iter := rditer.NewReplicaMVCCDataIterator(desc, snap, rditer.ReplicaDataIteratorOptions{
+	iter := rditer.NewReplicaMVCCDataIterator(ctx, desc, snap, rditer.ReplicaDataIteratorOptions{
 		Reverse:  false,
 		IterKind: storage.MVCCKeyAndIntentsIterKind,
 		KeyTypes: storage.IterKeyTypePointsOnly,

--- a/pkg/kv/kvserver/gc/gc_random_test.go
+++ b/pkg/kv/kvserver/gc/gc_random_test.go
@@ -436,24 +436,22 @@ func assertLiveData(
 		GCTTL:     gcTTL,
 		Threshold: gcThreshold,
 	}
-	pointIt, err := before.NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind,
-		storage.IterOptions{
-			LowerBound: desc.StartKey.AsRawKey(),
-			UpperBound: desc.EndKey.AsRawKey(),
-			KeyTypes:   storage.IterKeyTypePointsAndRanges,
-		})
+	pointIt, err := before.NewMVCCIterator(context.Background(), storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{
+		LowerBound: desc.StartKey.AsRawKey(),
+		UpperBound: desc.EndKey.AsRawKey(),
+		KeyTypes:   storage.IterKeyTypePointsAndRanges,
+	})
 	require.NoError(t, err)
 	defer pointIt.Close()
 	pointIt.SeekGE(storage.MVCCKey{Key: desc.StartKey.AsRawKey()})
 	pointExpectationsGenerator := getExpectationsGenerator(t, pointIt, gcThreshold, intentThreshold,
 		&expInfo)
 
-	rangeIt, err := before.NewMVCCIterator(storage.MVCCKeyIterKind,
-		storage.IterOptions{
-			LowerBound: desc.StartKey.AsRawKey(),
-			UpperBound: desc.EndKey.AsRawKey(),
-			KeyTypes:   storage.IterKeyTypeRangesOnly,
-		})
+	rangeIt, err := before.NewMVCCIterator(context.Background(), storage.MVCCKeyIterKind, storage.IterOptions{
+		LowerBound: desc.StartKey.AsRawKey(),
+		UpperBound: desc.EndKey.AsRawKey(),
+		KeyTypes:   storage.IterKeyTypeRangesOnly,
+	})
 	require.NoError(t, err)
 	defer rangeIt.Close()
 	rangeIt.SeekGE(storage.MVCCKey{Key: desc.StartKey.AsRawKey()})
@@ -462,7 +460,7 @@ func assertLiveData(
 
 	// Loop over engine data after applying GCer requests and compare with
 	// expected point keys.
-	itAfter, err := after.NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{
+	itAfter, err := after.NewMVCCIterator(context.Background(), storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{
 		LowerBound: desc.StartKey.AsRawKey(),
 		UpperBound: desc.EndKey.AsRawKey(),
 		KeyTypes:   storage.IterKeyTypePointsOnly,
@@ -500,7 +498,7 @@ func assertLiveData(
 		}
 	}
 
-	rangeItAfter, err := after.NewMVCCIterator(storage.MVCCKeyIterKind, storage.IterOptions{
+	rangeItAfter, err := after.NewMVCCIterator(context.Background(), storage.MVCCKeyIterKind, storage.IterOptions{
 		LowerBound:           desc.StartKey.AsRawKey(),
 		UpperBound:           desc.EndKey.AsRawKey(),
 		KeyTypes:             storage.IterKeyTypeRangesOnly,
@@ -676,7 +674,7 @@ func getExpectationsGenerator(
 func getKeyHistory(t *testing.T, r storage.Reader, key roachpb.Key) string {
 	var result []string
 
-	it, err := r.NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{
+	it, err := r.NewMVCCIterator(context.Background(), storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{
 		LowerBound:           key,
 		UpperBound:           key.Next(),
 		KeyTypes:             storage.IterKeyTypePointsAndRanges,

--- a/pkg/kv/kvserver/gc/gc_test.go
+++ b/pkg/kv/kvserver/gc/gc_test.go
@@ -1173,7 +1173,7 @@ func requireEqualReaders(
 ) {
 	// First compare only points. We assert points and ranges separately for
 	// simplicity.
-	itExp, err := exected.NewMVCCIterator(storage.MVCCKeyIterKind, storage.IterOptions{
+	itExp, err := exected.NewMVCCIterator(context.Background(), storage.MVCCKeyIterKind, storage.IterOptions{
 		LowerBound:           desc.StartKey.AsRawKey(),
 		UpperBound:           desc.EndKey.AsRawKey(),
 		KeyTypes:             storage.IterKeyTypePointsOnly,
@@ -1183,7 +1183,7 @@ func requireEqualReaders(
 	defer itExp.Close()
 	itExp.SeekGE(storage.MVCCKey{Key: desc.StartKey.AsRawKey()})
 
-	itActual, err := actual.NewMVCCIterator(storage.MVCCKeyIterKind, storage.IterOptions{
+	itActual, err := actual.NewMVCCIterator(context.Background(), storage.MVCCKeyIterKind, storage.IterOptions{
 		LowerBound:           desc.StartKey.AsRawKey(),
 		UpperBound:           desc.EndKey.AsRawKey(),
 		KeyTypes:             storage.IterKeyTypePointsOnly,
@@ -1223,7 +1223,7 @@ func requireEqualReaders(
 	}
 
 	// Compare only ranges.
-	itExpRanges, err := exected.NewMVCCIterator(storage.MVCCKeyIterKind, storage.IterOptions{
+	itExpRanges, err := exected.NewMVCCIterator(context.Background(), storage.MVCCKeyIterKind, storage.IterOptions{
 		LowerBound:           desc.StartKey.AsRawKey(),
 		UpperBound:           desc.EndKey.AsRawKey(),
 		KeyTypes:             storage.IterKeyTypeRangesOnly,
@@ -1233,7 +1233,7 @@ func requireEqualReaders(
 	defer itExpRanges.Close()
 	itExpRanges.SeekGE(storage.MVCCKey{Key: desc.StartKey.AsRawKey()})
 
-	itActualRanges, err := actual.NewMVCCIterator(storage.MVCCKeyIterKind, storage.IterOptions{
+	itActualRanges, err := actual.NewMVCCIterator(context.Background(), storage.MVCCKeyIterKind, storage.IterOptions{
 		LowerBound:           desc.StartKey.AsRawKey(),
 		UpperBound:           desc.EndKey.AsRawKey(),
 		KeyTypes:             storage.IterKeyTypeRangesOnly,
@@ -1465,7 +1465,7 @@ func (d tableData) liveDistribution() dataDistribution {
 func engineData(t *testing.T, r storage.Reader, desc roachpb.RangeDescriptor) []tableCell {
 	var result []tableCell
 
-	rangeIt, err := r.NewMVCCIterator(storage.MVCCKeyIterKind, storage.IterOptions{
+	rangeIt, err := r.NewMVCCIterator(context.Background(), storage.MVCCKeyIterKind, storage.IterOptions{
 		LowerBound:           desc.StartKey.AsRawKey(),
 		UpperBound:           desc.EndKey.AsRawKey(),
 		KeyTypes:             storage.IterKeyTypeRangesOnly,
@@ -1541,7 +1541,7 @@ func engineData(t *testing.T, r storage.Reader, desc roachpb.RangeDescriptor) []
 	}
 	result = append(result, makeRangeCells(partialRangeKeys)...)
 
-	it, err := r.NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{
+	it, err := r.NewMVCCIterator(context.Background(), storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{
 		LowerBound:           desc.StartKey.AsRawKey(),
 		UpperBound:           desc.EndKey.AsRawKey(),
 		KeyTypes:             storage.IterKeyTypePointsOnly,

--- a/pkg/kv/kvserver/helpers_test.go
+++ b/pkg/kv/kvserver/helpers_test.go
@@ -88,7 +88,7 @@ func (s *Store) ComputeMVCCStats(reader storage.Reader) (enginepb.MVCCStats, err
 	now := s.Clock().PhysicalNow()
 	newStoreReplicaVisitor(s).Visit(func(r *Replica) bool {
 		var stats enginepb.MVCCStats
-		stats, err = rditer.ComputeStatsForRange(r.Desc(), reader, now)
+		stats, err = rditer.ComputeStatsForRange(context.Background(), r.Desc(), reader, now)
 		if err != nil {
 			return false
 		}

--- a/pkg/kv/kvserver/kvstorage/destroy.go
+++ b/pkg/kv/kvserver/kvstorage/destroy.go
@@ -71,7 +71,11 @@ type ClearRangeDataOptions struct {
 // "CRDB Range" and "storage.ClearRange" context in the setting of this method could
 // be confusing.
 func ClearRangeData(
-	rangeID roachpb.RangeID, reader storage.Reader, writer storage.Writer, opts ClearRangeDataOptions,
+	ctx context.Context,
+	rangeID roachpb.RangeID,
+	reader storage.Reader,
+	writer storage.Writer,
+	opts ClearRangeDataOptions,
 ) error {
 	keySpans := rditer.Select(rangeID, rditer.SelectOpts{
 		ReplicatedBySpan:      opts.ClearReplicatedBySpan,
@@ -86,7 +90,7 @@ func ClearRangeData(
 
 	for _, keySpan := range keySpans {
 		if err := storage.ClearRangeWithHeuristic(
-			reader, writer, keySpan.Key, keySpan.EndKey, pointKeyThreshold, rangeKeyThreshold,
+			ctx, reader, writer, keySpan.Key, keySpan.EndKey, pointKeyThreshold, rangeKeyThreshold,
 		); err != nil {
 			return err
 		}
@@ -117,7 +121,7 @@ func DestroyReplica(
 	if diskReplicaID.ReplicaID >= nextReplicaID {
 		return errors.AssertionFailedf("replica r%d/%d must not survive its own tombstone", rangeID, diskReplicaID)
 	}
-	if err := ClearRangeData(rangeID, reader, writer, opts); err != nil {
+	if err := ClearRangeData(ctx, rangeID, reader, writer, opts); err != nil {
 		return err
 	}
 

--- a/pkg/kv/kvserver/kvstorage/init.go
+++ b/pkg/kv/kvserver/kvstorage/init.go
@@ -101,7 +101,7 @@ func checkCanInitializeEngine(ctx context.Context, eng storage.Engine) error {
 	//
 	// We use an EngineIterator to ensure that there are no keys that cannot be
 	// parsed as MVCCKeys (e.g. lock table keys) in the engine.
-	iter, err := eng.NewEngineIterator(storage.IterOptions{
+	iter, err := eng.NewEngineIterator(ctx, storage.IterOptions{
 		KeyTypes:   storage.IterKeyTypePointsAndRanges,
 		UpperBound: roachpb.KeyMax,
 	})
@@ -166,7 +166,7 @@ func IterateIDPrefixKeys(
 ) error {
 	rangeID := roachpb.RangeID(1)
 	// NB: Range-ID local keys have no versions and no intents.
-	iter, err := reader.NewMVCCIterator(storage.MVCCKeyIterKind, storage.IterOptions{
+	iter, err := reader.NewMVCCIterator(ctx, storage.MVCCKeyIterKind, storage.IterOptions{
 		UpperBound: keys.LocalRangeIDPrefix.PrefixEnd().AsRawKey(),
 	})
 	if err != nil {

--- a/pkg/kv/kvserver/logstore/logstore.go
+++ b/pkg/kv/kvserver/logstore/logstore.go
@@ -446,7 +446,7 @@ func LoadTerm(
 	reader := eng.NewReadOnly(storage.StandardDurability)
 	defer reader.Close()
 
-	if err := raftlog.Visit(reader, rangeID, index, index+1, func(ent raftpb.Entry) error {
+	if err := raftlog.Visit(ctx, reader, rangeID, index, index+1, func(ent raftpb.Entry) error {
 		if found {
 			return errors.Errorf("found more than one entry in [%d,%d)", index, index+1)
 		}
@@ -578,7 +578,7 @@ func LoadEntries(
 
 	reader := eng.NewReadOnly(storage.StandardDurability)
 	defer reader.Close()
-	if err := raftlog.Visit(reader, rangeID, expectedIndex, hi, scanFunc); err != nil {
+	if err := raftlog.Visit(ctx, reader, rangeID, expectedIndex, hi, scanFunc); err != nil {
 		return nil, 0, 0, err
 	}
 	eCache.Add(rangeID, ents, false /* truncate */)

--- a/pkg/kv/kvserver/logstore/stateloader.go
+++ b/pkg/kv/kvserver/logstore/stateloader.go
@@ -57,7 +57,8 @@ func (sl StateLoader) LoadLastIndex(
 ) (kvpb.RaftIndex, error) {
 	prefix := sl.RaftLogPrefix()
 	// NB: raft log has no intents.
-	iter, err := reader.NewMVCCIterator(storage.MVCCKeyIterKind, storage.IterOptions{LowerBound: prefix})
+	iter, err := reader.NewMVCCIterator(
+		ctx, storage.MVCCKeyIterKind, storage.IterOptions{LowerBound: prefix})
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/kv/kvserver/loqrecovery/collect.go
+++ b/pkg/kv/kvserver/loqrecovery/collect.go
@@ -179,8 +179,8 @@ func visitStoreReplicas(
 		// at potentially uncommitted entries as we have no way to determine their
 		// outcome, and they will become committed as soon as the replica is
 		// designated as a survivor.
-		rangeUpdates, err := GetDescriptorChangesFromRaftLog(desc.RangeID,
-			rstate.RaftAppliedIndex+1, math.MaxInt64, reader)
+		rangeUpdates, err := GetDescriptorChangesFromRaftLog(
+			ctx, desc.RangeID, rstate.RaftAppliedIndex+1, math.MaxInt64, reader)
 		if err != nil {
 			return err
 		}
@@ -209,10 +209,10 @@ func visitStoreReplicas(
 // lo (inclusive) and hi (exclusive) and searches for changes to range
 // descriptors, as identified by presence of a commit trigger.
 func GetDescriptorChangesFromRaftLog(
-	rangeID roachpb.RangeID, lo, hi kvpb.RaftIndex, reader storage.Reader,
+	ctx context.Context, rangeID roachpb.RangeID, lo, hi kvpb.RaftIndex, reader storage.Reader,
 ) ([]loqrecoverypb.DescriptorChangeInfo, error) {
 	var changes []loqrecoverypb.DescriptorChangeInfo
-	if err := raftlog.Visit(reader, rangeID, lo, hi, func(ent raftpb.Entry) error {
+	if err := raftlog.Visit(ctx, reader, rangeID, lo, hi, func(ent raftpb.Entry) error {
 		e, err := raftlog.NewEntry(ent)
 		if err != nil {
 			return err

--- a/pkg/kv/kvserver/loqrecovery/collect_raft_log_test.go
+++ b/pkg/kv/kvserver/loqrecovery/collect_raft_log_test.go
@@ -75,7 +75,8 @@ func TestFindUpdateDescriptor(t *testing.T) {
 			return srk
 		},
 		func(t *testing.T, ctx context.Context, reader storage.Reader) {
-			seq, err := loqrecovery.GetDescriptorChangesFromRaftLog(testRangeID, 0, math.MaxInt64, reader)
+			seq, err := loqrecovery.GetDescriptorChangesFromRaftLog(
+				ctx, testRangeID, 0, math.MaxInt64, reader)
 			require.NoError(t, err, "failed to read raft log data")
 
 			requireContainsDescriptor(t, loqrecoverypb.DescriptorChangeInfo{
@@ -125,7 +126,8 @@ func TestFindUpdateRaft(t *testing.T) {
 			return srk
 		},
 		func(t *testing.T, ctx context.Context, reader storage.Reader) {
-			seq, err := loqrecovery.GetDescriptorChangesFromRaftLog(sRD.RangeID, 0, math.MaxInt64, reader)
+			seq, err := loqrecovery.GetDescriptorChangesFromRaftLog(
+				ctx, sRD.RangeID, 0, math.MaxInt64, reader)
 			require.NoError(t, err, "failed to read raft log data")
 			requireContainsDescriptor(t, loqrecoverypb.DescriptorChangeInfo{
 				ChangeType: loqrecoverypb.DescriptorChangeType_ReplicaChange,

--- a/pkg/kv/kvserver/loqrecovery/record.go
+++ b/pkg/kv/kvserver/loqrecovery/record.go
@@ -75,11 +75,10 @@ func RegisterOfflineRecoveryEvents(
 	successCount := 0
 	var processingErrors error
 
-	iter, err := readWriter.NewMVCCIterator(
-		storage.MVCCKeyIterKind, storage.IterOptions{
-			LowerBound: keys.LocalStoreUnsafeReplicaRecoveryKeyMin,
-			UpperBound: keys.LocalStoreUnsafeReplicaRecoveryKeyMax,
-		})
+	iter, err := readWriter.NewMVCCIterator(ctx, storage.MVCCKeyIterKind, storage.IterOptions{
+		LowerBound: keys.LocalStoreUnsafeReplicaRecoveryKeyMin,
+		UpperBound: keys.LocalStoreUnsafeReplicaRecoveryKeyMax,
+	})
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/kv/kvserver/raft_log_truncator_test.go
+++ b/pkg/kv/kvserver/raft_log_truncator_test.go
@@ -202,7 +202,7 @@ func (r *replicaTruncatorTest) printEngine(t *testing.T, eng storage.Engine) {
 	require.NoError(t, err)
 	fmt.Fprintf(r.buf, "truncated index: %d\n", truncState.Index)
 	prefix := r.stateLoader.RaftLogPrefix()
-	iter, err := eng.NewMVCCIterator(storage.MVCCKeyIterKind, storage.IterOptions{
+	iter, err := eng.NewMVCCIterator(context.Background(), storage.MVCCKeyIterKind, storage.IterOptions{
 		UpperBound: r.stateLoader.RaftLogKey(math.MaxUint64),
 	})
 	if err != nil {

--- a/pkg/kv/kvserver/raftlog/iter_test.go
+++ b/pkg/kv/kvserver/raftlog/iter_test.go
@@ -12,6 +12,7 @@
 package raftlog
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"strings"
@@ -154,7 +155,7 @@ func TestIteratorEmptyLog(t *testing.T) {
 
 	eng := storage.NewDefaultInMemForTesting()
 	for _, hi := range []kvpb.RaftIndex{0, 1} {
-		it, err := NewIterator(rangeID, eng, IterOptions{Hi: hi})
+		it, err := NewIterator(context.Background(), rangeID, eng, IterOptions{Hi: hi})
 		require.NoError(t, err)
 		ok, err := it.SeekGE(0)
 		it.Close()
@@ -250,7 +251,7 @@ func TestIterator(t *testing.T) {
 						hi = 0
 					}
 					t.Run(fmt.Sprintf("lo=%s,hi=%s", indToName(lo), indToName(hi)), func(t *testing.T) {
-						it, err := NewIterator(rangeID, eng, IterOptions{Hi: hi})
+						it, err := NewIterator(context.Background(), rangeID, eng, IterOptions{Hi: hi})
 						require.NoError(t, err)
 						sl, err := consumeIter(it, lo)
 						it.Close()

--- a/pkg/kv/kvserver/rangefeed/catchup_scan.go
+++ b/pkg/kv/kvserver/rangefeed/catchup_scan.go
@@ -77,13 +77,14 @@ type CatchUpIterator struct {
 // NB: startTime is exclusive, i.e. the first possible event will be emitted at
 // Timestamp.Next().
 func NewCatchUpIterator(
+	ctx context.Context,
 	reader storage.Reader,
 	span roachpb.Span,
 	startTime hlc.Timestamp,
 	closer func(),
 	pacer *admission.Pacer,
 ) (*CatchUpIterator, error) {
-	iter, err := storage.NewMVCCIncrementalIterator(reader,
+	iter, err := storage.NewMVCCIncrementalIterator(ctx, reader,
 		storage.MVCCIncrementalIterOptions{
 			KeyTypes:  storage.IterKeyTypePointsAndRanges,
 			StartKey:  span.Key,

--- a/pkg/kv/kvserver/rangefeed/catchup_scan_bench_test.go
+++ b/pkg/kv/kvserver/rangefeed/catchup_scan_bench_test.go
@@ -50,7 +50,7 @@ func runCatchUpBenchmark(b *testing.B, emk engineMaker, opts benchOptions) (numE
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		func() {
-			iter, err := rangefeed.NewCatchUpIterator(eng, span, opts.ts, nil, nil)
+			iter, err := rangefeed.NewCatchUpIterator(ctx, eng, span, opts.ts, nil, nil)
 			if err != nil {
 				b.Fatal(err)
 			}

--- a/pkg/kv/kvserver/rangefeed/catchup_scan_test.go
+++ b/pkg/kv/kvserver/rangefeed/catchup_scan_test.go
@@ -113,7 +113,7 @@ func TestCatchupScan(t *testing.T) {
 	}
 	testutils.RunTrueAndFalse(t, "withDiff", func(t *testing.T, withDiff bool) {
 		span := roachpb.Span{Key: testKey1, EndKey: roachpb.KeyMax}
-		iter, err := NewCatchUpIterator(eng, span, ts1, nil, nil)
+		iter, err := NewCatchUpIterator(ctx, eng, span, ts1, nil, nil)
 		require.NoError(t, err)
 		defer iter.Close()
 		var events []kvpb.RangeFeedValue
@@ -157,7 +157,7 @@ func TestCatchupScanInlineError(t *testing.T) {
 
 	// Run a catchup scan across the span and watch it error.
 	span := roachpb.Span{Key: keys.LocalMax, EndKey: keys.MaxKey}
-	iter, err := NewCatchUpIterator(eng, span, hlc.Timestamp{}, nil, nil)
+	iter, err := NewCatchUpIterator(ctx, eng, span, hlc.Timestamp{}, nil, nil)
 	require.NoError(t, err)
 	defer iter.Close()
 
@@ -198,7 +198,7 @@ func TestCatchupScanSeesOldIntent(t *testing.T) {
 
 	// Run a catchup scan across the span and watch it succeed.
 	span := roachpb.Span{Key: keys.LocalMax, EndKey: keys.MaxKey}
-	iter, err := NewCatchUpIterator(eng, span, tsCutoff, nil, nil)
+	iter, err := NewCatchUpIterator(ctx, eng, span, tsCutoff, nil, nil)
 	require.NoError(t, err)
 	defer iter.Close()
 

--- a/pkg/kv/kvserver/rangefeed/processor_test.go
+++ b/pkg/kv/kvserver/rangefeed/processor_test.go
@@ -326,7 +326,7 @@ func makeIntentScanner(data []storeOp, span roachpb.RSpan) (*blockingScanner, fu
 	if err != nil {
 		return nil, nil, err
 	}
-	scanner, err := NewSeparatedIntentScanner(engine, span)
+	scanner, err := NewSeparatedIntentScanner(context.Background(), engine, span)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/kv/kvserver/rangefeed/task.go
+++ b/pkg/kv/kvserver/rangefeed/task.go
@@ -102,10 +102,12 @@ type SeparatedIntentScanner struct {
 
 // NewSeparatedIntentScanner returns an IntentScanner appropriate for
 // use when the separated intents migration has completed.
-func NewSeparatedIntentScanner(reader storage.Reader, span roachpb.RSpan) (IntentScanner, error) {
+func NewSeparatedIntentScanner(
+	ctx context.Context, reader storage.Reader, span roachpb.RSpan,
+) (IntentScanner, error) {
 	lowerBound, _ := keys.LockTableSingleKey(span.Key.AsRawKey(), nil)
 	upperBound, _ := keys.LockTableSingleKey(span.EndKey.AsRawKey(), nil)
-	iter, err := storage.NewLockTableIterator(reader, storage.LockTableIteratorOptions{
+	iter, err := storage.NewLockTableIterator(ctx, reader, storage.LockTableIteratorOptions{
 		LowerBound: lowerBound,
 		UpperBound: upperBound,
 		// Ignore Shared and Exclusive locks. We only care about intents.

--- a/pkg/kv/kvserver/rangefeed/task_test.go
+++ b/pkg/kv/kvserver/rangefeed/task_test.go
@@ -326,7 +326,7 @@ func TestInitResolvedTSScan(t *testing.T) {
 		eventC: make(chan *event, 100),
 	}
 
-	scanner, err := NewSeparatedIntentScanner(engine, span)
+	scanner, err := NewSeparatedIntentScanner(ctx, engine, span)
 	require.NoError(t, err, "failed to create scanner")
 	initScan := newInitResolvedTSScan(p.Span, &p, scanner)
 	initScan.Run(ctx)

--- a/pkg/kv/kvserver/rditer/replica_data_iter_test.go
+++ b/pkg/kv/kvserver/rditer/replica_data_iter_test.go
@@ -162,7 +162,8 @@ func verifyIterateReplicaKeySpans(
 		"pretty",
 	})
 
-	require.NoError(t, IterateReplicaKeySpans(desc, readWriter, replicatedOnly, replicatedSpansFilter,
+	require.NoError(t, IterateReplicaKeySpans(context.Background(), desc, readWriter, replicatedOnly,
+		replicatedSpansFilter,
 		func(iter storage.EngineIterator, span roachpb.Span, keyType storage.IterKeyType) error {
 			var err error
 			for ok := true; ok && err == nil; ok, err = iter.NextEngineKey() {
@@ -355,7 +356,7 @@ func TestIterateMVCCReplicaKeySpansSpansSet(t *testing.T) {
 		var rangeStart roachpb.Key
 		var actualKeys []storage.MVCCKey
 		var actualRanges []storage.MVCCRangeKey
-		err := IterateMVCCReplicaKeySpans(&desc, readWriter, IterateOptions{
+		err := IterateMVCCReplicaKeySpans(context.Background(), &desc, readWriter, IterateOptions{
 			CombineRangesAndPoints: false,
 			Reverse:                reverse,
 		}, func(iter storage.MVCCIterator, span roachpb.Span, keyType storage.IterKeyType) error {
@@ -468,7 +469,8 @@ func TestReplicaDataIteratorGlobalRangeKey(t *testing.T) {
 				}
 
 				var actualSpans []roachpb.Span
-				require.NoError(t, IterateReplicaKeySpans(&desc, snapshot, replicatedOnly, ReplicatedSpansAll,
+				require.NoError(t, IterateReplicaKeySpans(
+					context.Background(), &desc, snapshot, replicatedOnly, ReplicatedSpansAll,
 					func(iter storage.EngineIterator, span roachpb.Span, keyType storage.IterKeyType) error {
 						// We should never see any point keys.
 						require.Equal(t, storage.IterKeyTypeRangesOnly, keyType)
@@ -575,7 +577,8 @@ func benchReplicaEngineDataIterator(b *testing.B, numRanges, numKeysPerRange, va
 
 	for i := 0; i < b.N; i++ {
 		for _, desc := range descs {
-			err := IterateReplicaKeySpans(&desc, snapshot, false /* replicatedOnly */, ReplicatedSpansAll,
+			err := IterateReplicaKeySpans(
+				context.Background(), &desc, snapshot, false /* replicatedOnly */, ReplicatedSpansAll,
 				func(iter storage.EngineIterator, _ roachpb.Span, _ storage.IterKeyType) error {
 					var err error
 					for ok := true; ok && err == nil; ok, err = iter.NextEngineKey() {
@@ -692,7 +695,7 @@ func TestIterateMVCCReplicaKeySpans(t *testing.T) {
 				t.Run("sequential", func(t *testing.T) {
 					var actualSpans []roachpb.Span
 					var actualPoints []roachpb.Key
-					require.NoError(t, IterateMVCCReplicaKeySpans(&d.desc, snapshot,
+					require.NoError(t, IterateMVCCReplicaKeySpans(context.Background(), &d.desc, snapshot,
 						IterateOptions{CombineRangesAndPoints: false, Reverse: reverse},
 						func(iter storage.MVCCIterator, span roachpb.Span, keyType storage.IterKeyType) error {
 							if keyType == storage.IterKeyTypePointsOnly {
@@ -734,7 +737,8 @@ func TestIterateMVCCReplicaKeySpans(t *testing.T) {
 				t.Run("combined", func(t *testing.T) {
 					var actualSpans []roachpb.Span
 					var actualPoints []roachpb.Key
-					require.NoError(t, IterateMVCCReplicaKeySpans(&d.desc, snapshot, IterateOptions{CombineRangesAndPoints: true, Reverse: reverse},
+					require.NoError(t, IterateMVCCReplicaKeySpans(
+						context.Background(), &d.desc, snapshot, IterateOptions{CombineRangesAndPoints: true, Reverse: reverse},
 						func(iter storage.MVCCIterator, span roachpb.Span, keyType storage.IterKeyType) error {
 							actualSpans = append(actualSpans, span.Clone())
 							_, r := iter.HasPointAndRange()

--- a/pkg/kv/kvserver/rditer/stats.go
+++ b/pkg/kv/kvserver/rditer/stats.go
@@ -11,6 +11,8 @@
 package rditer
 
 import (
+	"context"
+
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
@@ -19,14 +21,16 @@ import (
 // ComputeStatsForRange computes the stats for a given range by iterating over
 // all key spans for the given range that should be accounted for in its stats.
 func ComputeStatsForRange(
-	d *roachpb.RangeDescriptor, reader storage.Reader, nowNanos int64,
+	ctx context.Context, d *roachpb.RangeDescriptor, reader storage.Reader, nowNanos int64,
 ) (enginepb.MVCCStats, error) {
-	return ComputeStatsForRangeWithVisitors(d, reader, nowNanos, storage.ComputeStatsVisitors{})
+	return ComputeStatsForRangeWithVisitors(
+		ctx, d, reader, nowNanos, storage.ComputeStatsVisitors{})
 }
 
 // ComputeStatsForRangeWithVisitors is like ComputeStatsForRange but also
 // calls the given callbacks for every key.
 func ComputeStatsForRangeWithVisitors(
+	ctx context.Context,
 	d *roachpb.RangeDescriptor,
 	reader storage.Reader,
 	nowNanos int64,
@@ -34,7 +38,8 @@ func ComputeStatsForRangeWithVisitors(
 ) (enginepb.MVCCStats, error) {
 	var ms enginepb.MVCCStats
 	for _, keySpan := range MakeReplicatedKeySpans(d) {
-		msDelta, err := storage.ComputeStatsWithVisitors(reader, keySpan.Key, keySpan.EndKey, nowNanos, visitors)
+		msDelta, err := storage.ComputeStatsWithVisitors(
+			ctx, reader, keySpan.Key, keySpan.EndKey, nowNanos, visitors)
 		if err != nil {
 			return enginepb.MVCCStats{}, err
 		}

--- a/pkg/kv/kvserver/replica_consistency.go
+++ b/pkg/kv/kvserver/replica_consistency.go
@@ -642,7 +642,8 @@ func CalcReplicaDigest(
 	// all of the replicated key space.
 	var result ReplicaDigest
 	if !statsOnly {
-		ms, err := rditer.ComputeStatsForRangeWithVisitors(&desc, snap, 0 /* nowNanos */, visitors)
+		ms, err := rditer.ComputeStatsForRangeWithVisitors(
+			ctx, &desc, snap, 0 /* nowNanos */, visitors)
 		// Consume the remaining quota borrowed in the visitors. Do it even on
 		// iteration error, but prioritize returning the latter if it occurs.
 		if wErr := limiter.WaitN(ctx, batchSize); wErr != nil && err == nil {

--- a/pkg/kv/kvserver/replica_learner_test.go
+++ b/pkg/kv/kvserver/replica_learner_test.go
@@ -2232,7 +2232,8 @@ func getExpectedSnapshotSizeBytes(
 	b := originStore.TODOEngine().NewWriteBatch()
 	defer b.Close()
 
-	err = rditer.IterateReplicaKeySpans(snap.State.Desc, snap.EngineSnap, true /* replicatedOnly */, rditer.ReplicatedSpansAll,
+	err = rditer.IterateReplicaKeySpans(
+		ctx, snap.State.Desc, snap.EngineSnap, true /* replicatedOnly */, rditer.ReplicatedSpansAll,
 		func(iter storage.EngineIterator, _ roachpb.Span, keyType storage.IterKeyType) error {
 			var err error
 			for ok := true; ok && err == nil; ok, err = iter.NextEngineKey() {

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -2625,7 +2625,7 @@ func ComputeRaftLogSize(
 ) (int64, error) {
 	prefix := keys.RaftLogPrefix(rangeID)
 	prefixEnd := prefix.PrefixEnd()
-	ms, err := storage.ComputeStats(reader, prefix, prefixEnd, 0 /* nowNanos */)
+	ms, err := storage.ComputeStats(ctx, reader, prefix, prefixEnd, 0 /* nowNanos */)
 	if err != nil {
 		return 0, err
 	}
@@ -2712,7 +2712,8 @@ func (r *Replica) printRaftTail(
 	end := keys.RaftLogPrefix(r.RangeID).PrefixEnd()
 
 	// NB: raft log does not have intents.
-	it, err := r.store.TODOEngine().NewEngineIterator(storage.IterOptions{LowerBound: start, UpperBound: end})
+	it, err := r.store.TODOEngine().NewEngineIterator(
+		ctx, storage.IterOptions{LowerBound: start, UpperBound: end})
 	if err != nil {
 		return "", err
 	}

--- a/pkg/kv/kvserver/replica_raftstorage.go
+++ b/pkg/kv/kvserver/replica_raftstorage.go
@@ -974,6 +974,7 @@ func clearSubsumedReplicaDiskData(
 			)
 			defer subsumedReplSST.Close()
 			if err := storage.ClearRangeWithHeuristic(
+				ctx,
 				reader,
 				&subsumedReplSST,
 				keySpans[i].EndKey,

--- a/pkg/kv/kvserver/replica_rangefeed.go
+++ b/pkg/kv/kvserver/replica_rangefeed.go
@@ -273,7 +273,8 @@ func (r *Replica) RangeFeed(
 	// Register the stream with a catch-up iterator.
 	var catchUpIter *rangefeed.CatchUpIterator
 	if usingCatchUpIter {
-		catchUpIter, err = rangefeed.NewCatchUpIterator(r.store.TODOEngine(), rSpan.AsRawSpanWithNoLocals(),
+		catchUpIter, err = rangefeed.NewCatchUpIterator(
+			ctx, r.store.TODOEngine(), rSpan.AsRawSpanWithNoLocals(),
 			args.Timestamp, iterSemRelease, pacer)
 		if err != nil {
 			r.raftMu.Unlock()
@@ -466,7 +467,7 @@ func (r *Replica) registerWithRangefeedRaftMuLocked(
 		// waiting for the Register call below to return.
 		r.raftMu.AssertHeld()
 
-		scanner, err := rangefeed.NewSeparatedIntentScanner(r.store.TODOEngine(), desc.RSpan())
+		scanner, err := rangefeed.NewSeparatedIntentScanner(ctx, r.store.TODOEngine(), desc.RSpan())
 		if err != nil {
 			done.Set(err)
 			return nil
@@ -676,7 +677,8 @@ func (r *Replica) handleLogicalOpLogRaftMuLocked(
 			if vhf == nil {
 				continue
 			}
-			valBytes, err := storage.MVCCLookupRangeKeyValue(reader, t.StartKey, t.EndKey, t.Timestamp)
+			valBytes, err := storage.MVCCLookupRangeKeyValue(
+				ctx, reader, t.StartKey, t.EndKey, t.Timestamp)
 			if err != nil {
 				panic(err)
 			}

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -1842,7 +1842,7 @@ func TestOptimizePuts(t *testing.T) {
 		// change when it is passed to optimizePuts.
 		oldRequests := batch.Requests
 		var err error
-		batch.Requests, err = optimizePuts(tc.engine, batch.Requests, false)
+		batch.Requests, err = optimizePuts(ctx, tc.engine, batch.Requests, false)
 		require.NoError(t, err)
 		if !reflect.DeepEqual(goldenRequests, oldRequests) {
 			t.Fatalf("%d: optimizePuts mutated the original request slice: %s",
@@ -3133,7 +3133,7 @@ func TestReplicaTSCacheForwardsIntentTS(t *testing.T) {
 				if _, pErr := tc.SendWrappedWith(kvpb.Header{Txn: txnOld}, &pArgs); pErr != nil {
 					t.Fatal(pErr)
 				}
-				iter, err := tc.engine.NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{Prefix: true})
+				iter, err := tc.engine.NewMVCCIterator(context.Background(), storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{Prefix: true})
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -7202,7 +7202,8 @@ func TestReplicaDestroy(t *testing.T) {
 	expectedKeys := []roachpb.Key{keys.RangeTombstoneKey(tc.repl.RangeID)}
 	actualKeys := []roachpb.Key{}
 
-	require.NoError(t, rditer.IterateReplicaKeySpans(tc.repl.Desc(), engSnapshot, false /* replicatedOnly */, rditer.ReplicatedSpansAll,
+	require.NoError(t, rditer.IterateReplicaKeySpans(
+		ctx, tc.repl.Desc(), engSnapshot, false /* replicatedOnly */, rditer.ReplicatedSpansAll,
 		func(iter storage.EngineIterator, _ roachpb.Span, keyType storage.IterKeyType) error {
 			require.Equal(t, storage.IterKeyTypePointsOnly, keyType)
 			var err error

--- a/pkg/kv/kvserver/spanset/batch.go
+++ b/pkg/kv/kvserver/spanset/batch.go
@@ -464,6 +464,7 @@ func (s spanSetReader) Closed() bool {
 }
 
 func (s spanSetReader) MVCCIterate(
+	ctx context.Context,
 	start, end roachpb.Key,
 	iterKind storage.MVCCIterKind,
 	keyTypes storage.IterKeyType,
@@ -478,13 +479,13 @@ func (s spanSetReader) MVCCIterate(
 			return err
 		}
 	}
-	return s.r.MVCCIterate(start, end, iterKind, keyTypes, f)
+	return s.r.MVCCIterate(ctx, start, end, iterKind, keyTypes, f)
 }
 
 func (s spanSetReader) NewMVCCIterator(
-	iterKind storage.MVCCIterKind, opts storage.IterOptions,
+	ctx context.Context, iterKind storage.MVCCIterKind, opts storage.IterOptions,
 ) (storage.MVCCIterator, error) {
-	mvccIter, err := s.r.NewMVCCIterator(iterKind, opts)
+	mvccIter, err := s.r.NewMVCCIterator(ctx, iterKind, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -494,8 +495,10 @@ func (s spanSetReader) NewMVCCIterator(
 	return NewIteratorAt(mvccIter, s.spans, s.ts), nil
 }
 
-func (s spanSetReader) NewEngineIterator(opts storage.IterOptions) (storage.EngineIterator, error) {
-	engineIter, err := s.r.NewEngineIterator(opts)
+func (s spanSetReader) NewEngineIterator(
+	ctx context.Context, opts storage.IterOptions,
+) (storage.EngineIterator, error) {
+	engineIter, err := s.r.NewEngineIterator(ctx, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kv/kvserver/spanset/batch_test.go
+++ b/pkg/kv/kvserver/spanset/batch_test.go
@@ -11,6 +11,7 @@
 package spanset_test
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -79,8 +80,8 @@ func TestReadWriterDeclareLockTable(t *testing.T) {
 					defer b.Close()
 					rw := fn(ss, b)
 
-					require.NoError(t, rw.MVCCIterate(ltStartKey, ltEndKey, storage.MVCCKeyIterKind, storage.IterKeyTypePointsOnly, nil))
-					require.Error(t, rw.MVCCIterate(ltEndKey, ltEndKey.Next(), storage.MVCCKeyIterKind, storage.IterKeyTypePointsOnly, nil))
+					require.NoError(t, rw.MVCCIterate(context.Background(), ltStartKey, ltEndKey, storage.MVCCKeyIterKind, storage.IterKeyTypePointsOnly, nil))
+					require.Error(t, rw.MVCCIterate(context.Background(), ltEndKey, ltEndKey.Next(), storage.MVCCKeyIterKind, storage.IterKeyTypePointsOnly, nil))
 
 					err := rw.PutUnversioned(ltStartKey, []byte("value"))
 					if str == lock.None {

--- a/pkg/kv/kvserver/store_init.go
+++ b/pkg/kv/kvserver/store_init.go
@@ -216,7 +216,7 @@ func WriteInitialClusterData(
 			ctx, batch, *desc, firstReplicaID, initialReplicaVersion); err != nil {
 			return err
 		}
-		computedStats, err := rditer.ComputeStatsForRange(desc, batch, now.WallTime)
+		computedStats, err := rditer.ComputeStatsForRange(ctx, desc, batch, now.WallTime)
 		if err != nil {
 			return err
 		}

--- a/pkg/kv/kvserver/store_snapshot.go
+++ b/pkg/kv/kvserver/store_snapshot.go
@@ -829,7 +829,7 @@ func (kvSS *kvBatchSnapshotStrategy) Send(
 		}
 		return err
 	}
-	err := rditer.IterateReplicaKeySpans(snap.State.Desc, snap.EngineSnap, true, /* replicatedOnly */
+	err := rditer.IterateReplicaKeySpans(ctx, snap.State.Desc, snap.EngineSnap, true, /* replicatedOnly */
 		replicatedFilter, iterateRKSpansVisitor)
 	if err != nil {
 		return 0, err
@@ -908,7 +908,7 @@ func (kvSS *kvBatchSnapshotStrategy) Send(
 		})
 		if err != nil && errors.Is(err, pebble.ErrInvalidSkipSharedIteration) {
 			transitionFromSharedToRegularReplicate = true
-			err = rditer.IterateReplicaKeySpans(snap.State.Desc, snap.EngineSnap, true, /* replicatedOnly */
+			err = rditer.IterateReplicaKeySpans(ctx, snap.State.Desc, snap.EngineSnap, true, /* replicatedOnly */
 				rditer.ReplicatedSpansUserOnly, iterateRKSpansVisitor)
 		}
 		if err != nil {

--- a/pkg/kv/kvserver/store_split.go
+++ b/pkg/kv/kvserver/store_split.go
@@ -94,7 +94,7 @@ func splitPreApply(
 				log.Fatalf(ctx, "failed to load hard state for removed rhs: %v", err)
 			}
 		}
-		if err := kvstorage.ClearRangeData(split.RightDesc.RangeID, readWriter, readWriter, kvstorage.ClearRangeDataOptions{
+		if err := kvstorage.ClearRangeData(ctx, split.RightDesc.RangeID, readWriter, readWriter, kvstorage.ClearRangeDataOptions{
 			// We know there isn't anything in these two replicated spans below in the
 			// right-hand side (before the current batch), so setting these options
 			// will in effect only clear the writes to the RHS replicated state we have

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -521,7 +521,7 @@ func TestStoreInitAndBootstrap(t *testing.T) {
 		memMS := repl.GetMVCCStats()
 		// Stats should agree with a recomputation.
 		now := store.Clock().Now()
-		diskMS, err := rditer.ComputeStatsForRange(repl.Desc(), store.TODOEngine(), now.WallTime)
+		diskMS, err := rditer.ComputeStatsForRange(ctx, repl.Desc(), store.TODOEngine(), now.WallTime)
 		require.NoError(t, err)
 		memMS.AgeTo(diskMS.LastUpdateNanos)
 		require.Equal(t, memMS, diskMS)

--- a/pkg/server/init.go
+++ b/pkg/server/init.go
@@ -566,9 +566,11 @@ func (s *initServer) initializeFirstStoreAfterJoin(
 func assertEnginesEmpty(engines []storage.Engine) error {
 	storeClusterVersionKey := keys.DeprecatedStoreClusterVersionKey()
 
+	// TODO(sumeer): plumb a context if necessary.
+	ctx := context.Background()
 	for _, engine := range engines {
 		err := func() error {
-			iter, err := engine.NewEngineIterator(storage.IterOptions{
+			iter, err := engine.NewEngineIterator(ctx, storage.IterOptions{
 				KeyTypes:   storage.IterKeyTypePointsAndRanges,
 				UpperBound: roachpb.KeyMax,
 			})

--- a/pkg/server/settings_cache.go
+++ b/pkg/server/settings_cache.go
@@ -124,14 +124,11 @@ func storeCachedSettingsKVs(ctx context.Context, eng storage.Engine, kvs []roach
 }
 
 // loadCachedSettingsKVs loads locally stored cached settings.
-func loadCachedSettingsKVs(_ context.Context, eng storage.Engine) ([]roachpb.KeyValue, error) {
+func loadCachedSettingsKVs(ctx context.Context, eng storage.Engine) ([]roachpb.KeyValue, error) {
 	var settingsKVs []roachpb.KeyValue
-	if err := eng.MVCCIterate(
-		keys.LocalStoreCachedSettingsKeyMin,
-		keys.LocalStoreCachedSettingsKeyMax,
-		storage.MVCCKeyAndIntentsIterKind,
-		storage.IterKeyTypePointsOnly,
-		func(kv storage.MVCCKeyValue, _ storage.MVCCRangeKeyStack) error {
+	if err := eng.MVCCIterate(ctx, keys.LocalStoreCachedSettingsKeyMin,
+		keys.LocalStoreCachedSettingsKeyMax, storage.MVCCKeyAndIntentsIterKind,
+		storage.IterKeyTypePointsOnly, func(kv storage.MVCCKeyValue, _ storage.MVCCRangeKeyStack) error {
 			settingKey, err := keys.DecodeStoreCachedSettingsKey(kv.Key.Key)
 			if err != nil {
 				return err
@@ -145,8 +142,7 @@ func loadCachedSettingsKVs(_ context.Context, eng storage.Engine) ([]roachpb.Key
 				Value: roachpb.Value{RawBytes: meta.RawBytes},
 			})
 			return nil
-		},
-	); err != nil {
+		}); err != nil {
 		return nil, err
 	}
 	return settingsKVs, nil

--- a/pkg/server/span_stats_server.go
+++ b/pkg/server/span_stats_server.go
@@ -226,6 +226,7 @@ func (s *systemStatusServer) statsForSpan(
 			}
 			err = s.stores.VisitStores(func(s *kvserver.Store) error {
 				stats, err := storage.ComputeStats(
+					ctx,
 					s.TODOEngine(),
 					scanStart.AsRawKey(),
 					scanEnd.AsRawKey(),

--- a/pkg/sql/row/fetcher_mvcc_test.go
+++ b/pkg/sql/row/fetcher_mvcc_test.go
@@ -44,7 +44,7 @@ func slurpUserDataKVs(t testing.TB, e storage.Engine, codec keys.SQLCodec) []roa
 	var kvs []roachpb.KeyValue
 	testutils.SucceedsSoon(t, func() error {
 		kvs = nil
-		it, err := e.NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{UpperBound: codec.TenantEndKey()})
+		it, err := e.NewMVCCIterator(context.Background(), storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{UpperBound: codec.TenantEndKey()})
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/sql/tests/data.go
+++ b/pkg/sql/tests/data.go
@@ -68,6 +68,7 @@ func CheckKeyCountIncludingTombstonedE(
 
 	keyCount := 0
 	it, err := engines[0].NewMVCCIterator(
+		context.Background(),
 		storage.MVCCKeyIterKind,
 		storage.IterOptions{
 			LowerBound: tableSpan.Key,

--- a/pkg/storage/col_mvcc.go
+++ b/pkg/storage/col_mvcc.go
@@ -402,7 +402,7 @@ func MVCCScanToCols(
 	st *cluster.Settings,
 ) (MVCCScanResult, error) {
 	iter, err := newMVCCIterator(
-		reader, timestamp, !opts.Tombstones, opts.DontInterleaveIntents, IterOptions{
+		ctx, reader, timestamp, !opts.Tombstones, opts.DontInterleaveIntents, IterOptions{
 			KeyTypes:   IterKeyTypePointsAndRanges,
 			LowerBound: key,
 			UpperBound: endKey,

--- a/pkg/storage/intent_interleaving_iter_test.go
+++ b/pkg/storage/intent_interleaving_iter_test.go
@@ -12,6 +12,7 @@ package storage
 
 import (
 	"bytes"
+	"context"
 	"flag"
 	"fmt"
 	"math/rand"
@@ -347,7 +348,7 @@ func TestIntentInterleavingIter(t *testing.T) {
 				if d.HasArg("prefix") {
 					d.ScanArgs(t, "prefix", &opts.Prefix)
 				}
-				iiter, err := newIntentInterleavingIterator(eng, opts)
+				iiter, err := newIntentInterleavingIterator(context.Background(), eng, opts)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -416,10 +417,12 @@ func TestIntentInterleavingIterBoundaries(t *testing.T) {
 
 	eng := createTestPebbleEngine()
 	defer eng.Close()
+	ctx := context.Background()
+
 	// Boundary cases for constrainedToLocal.
 	func() {
 		opts := IterOptions{LowerBound: keys.MinKey}
-		iiiter, err := newIntentInterleavingIterator(eng, opts)
+		iiiter, err := newIntentInterleavingIterator(ctx, eng, opts)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -430,7 +433,7 @@ func TestIntentInterleavingIterBoundaries(t *testing.T) {
 	}()
 	func() {
 		opts := IterOptions{UpperBound: keys.LocalMax}
-		iiiter, err := newIntentInterleavingIterator(eng, opts)
+		iiiter, err := newIntentInterleavingIterator(ctx, eng, opts)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -440,7 +443,7 @@ func TestIntentInterleavingIterBoundaries(t *testing.T) {
 	}()
 	require.Panics(t, func() {
 		opts := IterOptions{UpperBound: keys.LocalMax}
-		iiiter, err := newIntentInterleavingIterator(eng, opts)
+		iiiter, err := newIntentInterleavingIterator(ctx, eng, opts)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -451,7 +454,7 @@ func TestIntentInterleavingIterBoundaries(t *testing.T) {
 	// Boundary cases for constrainedToGlobal.
 	func() {
 		opts := IterOptions{LowerBound: keys.LocalMax}
-		iiiter, err := newIntentInterleavingIterator(eng, opts)
+		iiiter, err := newIntentInterleavingIterator(ctx, eng, opts)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -461,7 +464,7 @@ func TestIntentInterleavingIterBoundaries(t *testing.T) {
 	}()
 	func() {
 		opts := IterOptions{LowerBound: keys.LocalMax}
-		iiiter, err := newIntentInterleavingIterator(eng, opts)
+		iiiter, err := newIntentInterleavingIterator(ctx, eng, opts)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -473,7 +476,7 @@ func TestIntentInterleavingIterBoundaries(t *testing.T) {
 	// Panics for using a local key that is above the lock table.
 	require.Panics(t, func() {
 		opts := IterOptions{UpperBound: keys.LocalMax}
-		iiiter, err := newIntentInterleavingIterator(eng, opts)
+		iiiter, err := newIntentInterleavingIterator(ctx, eng, opts)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -484,7 +487,7 @@ func TestIntentInterleavingIterBoundaries(t *testing.T) {
 	})
 	require.Panics(t, func() {
 		opts := IterOptions{UpperBound: keys.LocalMax}
-		iiiter, err := newIntentInterleavingIterator(eng, opts)
+		iiiter, err := newIntentInterleavingIterator(ctx, eng, opts)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -497,7 +500,7 @@ func TestIntentInterleavingIterBoundaries(t *testing.T) {
 	// specified.
 	func() {
 		opts := IterOptions{Prefix: true, LowerBound: keys.LocalMax}
-		iiiter, err := newIntentInterleavingIterator(eng, opts)
+		iiiter, err := newIntentInterleavingIterator(ctx, eng, opts)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -507,7 +510,7 @@ func TestIntentInterleavingIterBoundaries(t *testing.T) {
 	}()
 	// Prefix iteration with no bounds.
 	func() {
-		iiiter, err := newIntentInterleavingIterator(eng, IterOptions{Prefix: true})
+		iiiter, err := newIntentInterleavingIterator(ctx, eng, IterOptions{Prefix: true})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -722,6 +725,7 @@ func doOps(t *testing.T, ops []string, eng Engine, interleave bool, out *strings
 			iter = nil
 		}
 	}
+	ctx := context.Background()
 	defer closeIter()
 	var d datadriven.TestData
 	var err error
@@ -740,9 +744,9 @@ func doOps(t *testing.T, ops []string, eng Engine, interleave bool, out *strings
 			}
 			var err error
 			if interleave {
-				iter, err = newIntentInterleavingIterator(eng, opts)
+				iter, err = newIntentInterleavingIterator(ctx, eng, opts)
 			} else {
-				iter, err = eng.NewMVCCIterator(MVCCKeyIterKind, opts)
+				iter, err = eng.NewMVCCIterator(ctx, MVCCKeyIterKind, opts)
 			}
 			require.NoError(t, err)
 			lowerStr := "nil"
@@ -919,7 +923,7 @@ func BenchmarkIntentInterleavingIterNext(b *testing.B) {
 		b.Run(state.benchPrefix,
 			func(b *testing.B) {
 				opts := IterOptions{LowerBound: state.keyPrefix, UpperBound: state.keyPrefix.PrefixEnd()}
-				iter, err := newIntentInterleavingIterator(state.eng, opts)
+				iter, err := newIntentInterleavingIterator(context.Background(), state.eng, opts)
 				if err != nil {
 					b.Fatal(err)
 				}
@@ -956,7 +960,7 @@ func BenchmarkIntentInterleavingIterPrev(b *testing.B) {
 			func(b *testing.B) {
 				endKey := MVCCKey{Key: state.keyPrefix.PrefixEnd()}
 				opts := IterOptions{LowerBound: state.keyPrefix, UpperBound: endKey.Key}
-				iter, err := newIntentInterleavingIterator(state.eng, opts)
+				iter, err := newIntentInterleavingIterator(context.Background(), state.eng, opts)
 				if err != nil {
 					b.Fatal(err)
 				}
@@ -997,7 +1001,7 @@ func BenchmarkIntentInterleavingSeekGEAndIter(b *testing.B) {
 					}
 					endKey := state.keyPrefix.PrefixEnd()
 					opts := IterOptions{LowerBound: state.keyPrefix, UpperBound: endKey}
-					iter, err := newIntentInterleavingIterator(state.eng, opts)
+					iter, err := newIntentInterleavingIterator(context.Background(), state.eng, opts)
 					if err != nil {
 						b.Fatal(err)
 					}

--- a/pkg/storage/lock_table_iterator.go
+++ b/pkg/storage/lock_table_iterator.go
@@ -12,6 +12,7 @@ package storage
 
 import (
 	"bytes"
+	"context"
 	"sync"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
@@ -122,12 +123,12 @@ var lockTableIteratorPool = sync.Pool{
 
 // NewLockTableIterator creates a new LockTableIterator.
 func NewLockTableIterator(
-	reader Reader, opts LockTableIteratorOptions,
+	ctx context.Context, reader Reader, opts LockTableIteratorOptions,
 ) (*LockTableIterator, error) {
 	if err := opts.validate(); err != nil {
 		return nil, err
 	}
-	iter, err := reader.NewEngineIterator(opts.toIterOptions())
+	iter, err := reader.NewEngineIterator(ctx, opts.toIterOptions())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storage/lock_table_iterator_test.go
+++ b/pkg/storage/lock_table_iterator_test.go
@@ -12,6 +12,7 @@ package storage
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"math/rand"
 	"reflect"
@@ -266,7 +267,7 @@ func TestLockTableIterator(t *testing.T) {
 				if d.HasArg("match-min-str") {
 					opts.MatchMinStr = scanLockStrength(t, d, "match-min-str")
 				}
-				iter, err := NewLockTableIterator(eng, opts)
+				iter, err := NewLockTableIterator(context.Background(), eng, opts)
 				if err != nil {
 					return fmt.Sprintf("error constructing new iter: %s", err)
 				}
@@ -630,7 +631,7 @@ func TestLockTableIteratorEquivalence(t *testing.T) {
 		}
 
 		// Then use a LockTableIterator with an appropriate filter config.
-		iter, err := NewLockTableIterator(eng, LockTableIteratorOptions{
+		iter, err := NewLockTableIterator(context.Background(), eng, LockTableIteratorOptions{
 			Prefix:      prefix,
 			UpperBound:  keys.LockTableSingleKeyEnd,
 			MatchTxnID:  f.matchTxnID.toUUID(),
@@ -662,7 +663,7 @@ func TestLockTableIteratorEquivalence(t *testing.T) {
 		}
 
 		// Then use a raw engine iterator.
-		iter, err := eng.NewEngineIterator(IterOptions{
+		iter, err := eng.NewEngineIterator(context.Background(), IterOptions{
 			Prefix:     prefix,
 			UpperBound: keys.LockTableSingleKeyEnd,
 		})

--- a/pkg/storage/lock_table_key_scanner.go
+++ b/pkg/storage/lock_table_key_scanner.go
@@ -11,6 +11,7 @@
 package storage
 
 import (
+	"context"
 	"sync"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
@@ -120,7 +121,11 @@ var lockTableKeyScannerPool = sync.Pool{
 // should accumulate before returning an error. If maxConflicts is zero, the
 // scanner will accumulate all conflicting locks.
 func newLockTableKeyScanner(
-	reader Reader, txn *roachpb.Transaction, str lock.Strength, maxConflicts int64,
+	ctx context.Context,
+	reader Reader,
+	txn *roachpb.Transaction,
+	str lock.Strength,
+	maxConflicts int64,
 ) (*lockTableKeyScanner, error) {
 	var txnID uuid.UUID
 	if txn != nil {
@@ -130,7 +135,7 @@ func newLockTableKeyScanner(
 	if err != nil {
 		return nil, err
 	}
-	iter, err := NewLockTableIterator(reader, LockTableIteratorOptions{
+	iter, err := NewLockTableIterator(ctx, reader, LockTableIteratorOptions{
 		Prefix:      true,
 		MatchTxnID:  txnID,
 		MatchMinStr: minConflictStr,

--- a/pkg/storage/metamorphic/operations.go
+++ b/pkg/storage/metamorphic/operations.go
@@ -608,7 +608,7 @@ type iterOpenOp struct {
 
 func (i iterOpenOp) run(ctx context.Context) string {
 	rw := i.m.getReadWriter(i.rw)
-	iter, err := rw.NewMVCCIterator(storage.MVCCKeyIterKind, storage.IterOptions{
+	iter, err := rw.NewMVCCIterator(ctx, storage.MVCCKeyIterKind, storage.IterOptions{
 		Prefix:     false,
 		LowerBound: i.key,
 		UpperBound: i.endKey.Next(),

--- a/pkg/storage/mvcc_incremental_iterator.go
+++ b/pkg/storage/mvcc_incremental_iterator.go
@@ -11,6 +11,7 @@
 package storage
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
@@ -175,7 +176,7 @@ type MVCCIncrementalIterOptions struct {
 // specified reader and options. The timestamp hint range should not be more
 // restrictive than the start and end time range.
 func NewMVCCIncrementalIterator(
-	reader Reader, opts MVCCIncrementalIterOptions,
+	ctx context.Context, reader Reader, opts MVCCIncrementalIterOptions,
 ) (*MVCCIncrementalIterator, error) {
 	// Default to MaxTimestamp for EndTime, since the code assumes it is set.
 	if opts.EndTime.IsEmpty() {
@@ -196,7 +197,7 @@ func NewMVCCIncrementalIterator(
 	if useTBI {
 		// An iterator without the timestamp hints is created to ensure that the
 		// iterator visits every required version of every key that has changed.
-		iter, err = reader.NewMVCCIterator(MVCCKeyAndIntentsIterKind, IterOptions{
+		iter, err = reader.NewMVCCIterator(ctx, MVCCKeyAndIntentsIterKind, IterOptions{
 			KeyTypes:             opts.KeyTypes,
 			LowerBound:           opts.StartKey,
 			UpperBound:           opts.EndKey,
@@ -214,7 +215,7 @@ func NewMVCCIncrementalIterator(
 		if tbiRangeKeyMasking.LessEq(opts.StartTime) && opts.KeyTypes == IterKeyTypePointsAndRanges {
 			tbiRangeKeyMasking = opts.StartTime.Next()
 		}
-		timeBoundIter, err = reader.NewMVCCIterator(MVCCKeyIterKind, IterOptions{
+		timeBoundIter, err = reader.NewMVCCIterator(ctx, MVCCKeyIterKind, IterOptions{
 			KeyTypes:   opts.KeyTypes,
 			LowerBound: opts.StartKey,
 			UpperBound: opts.EndKey,
@@ -229,7 +230,7 @@ func NewMVCCIncrementalIterator(
 			return nil, err
 		}
 	} else {
-		iter, err = reader.NewMVCCIterator(MVCCKeyAndIntentsIterKind, IterOptions{
+		iter, err = reader.NewMVCCIterator(ctx, MVCCKeyAndIntentsIterKind, IterOptions{
 			KeyTypes:             opts.KeyTypes,
 			LowerBound:           opts.StartKey,
 			UpperBound:           opts.EndKey,

--- a/pkg/storage/mvcc_incremental_iterator_test.go
+++ b/pkg/storage/mvcc_incremental_iterator_test.go
@@ -102,7 +102,7 @@ func assertExpectErr(
 	revisions bool,
 	expectedIntent roachpb.Intent,
 ) {
-	iter, err := NewMVCCIncrementalIterator(e, MVCCIncrementalIterOptions{
+	iter, err := NewMVCCIncrementalIterator(context.Background(), e, MVCCIncrementalIterOptions{
 		EndKey:    endKey,
 		StartTime: startTime,
 		EndTime:   endTime,
@@ -142,7 +142,7 @@ func assertExpectErrs(
 	revisions bool,
 	expectedIntents []roachpb.Intent,
 ) {
-	iter, err := NewMVCCIncrementalIterator(e, MVCCIncrementalIterOptions{
+	iter, err := NewMVCCIncrementalIterator(context.Background(), e, MVCCIncrementalIterOptions{
 		EndKey:       endKey,
 		StartTime:    startTime,
 		EndTime:      endTime,
@@ -285,7 +285,7 @@ func ignoreTimeExpectErr(
 	errString string,
 	nextKey bool,
 ) {
-	iter, err := NewMVCCIncrementalIterator(e, MVCCIncrementalIterOptions{
+	iter, err := NewMVCCIncrementalIterator(context.Background(), e, MVCCIncrementalIterOptions{
 		EndKey:    endKey,
 		StartTime: startTime,
 		EndTime:   endTime,
@@ -319,7 +319,7 @@ func assertIgnoreTimeIteratedKVs(
 	expected []MVCCKeyValue,
 	nextKey bool,
 ) {
-	iter, err := NewMVCCIncrementalIterator(e, MVCCIncrementalIterOptions{
+	iter, err := NewMVCCIncrementalIterator(context.Background(), e, MVCCIncrementalIterOptions{
 		EndKey:    endKey,
 		StartTime: startTime,
 		EndTime:   endTime,
@@ -371,7 +371,7 @@ func assertIteratedKVs(
 	revisions bool,
 	expected []MVCCKeyValue,
 ) {
-	iter, err := NewMVCCIncrementalIterator(e, MVCCIncrementalIterOptions{
+	iter, err := NewMVCCIncrementalIterator(context.Background(), e, MVCCIncrementalIterOptions{
 		EndKey:       endKey,
 		StartTime:    startTime,
 		EndTime:      endTime,
@@ -743,7 +743,7 @@ func TestMVCCIncrementalIteratorInlinePolicy(t *testing.T) {
 		}
 	}
 	t.Run("returns error if inline value is found", func(t *testing.T) {
-		iter, err := NewMVCCIncrementalIterator(e, MVCCIncrementalIterOptions{
+		iter, err := NewMVCCIncrementalIterator(context.Background(), e, MVCCIncrementalIterOptions{
 			EndKey:    keyMax,
 			StartTime: tsMin,
 			EndTime:   tsMax,
@@ -756,7 +756,7 @@ func TestMVCCIncrementalIteratorInlinePolicy(t *testing.T) {
 	})
 	t.Run("returns error on NextIgnoringTime if inline value is found",
 		func(t *testing.T) {
-			iter, err := NewMVCCIncrementalIterator(e, MVCCIncrementalIterOptions{
+			iter, err := NewMVCCIncrementalIterator(context.Background(), e, MVCCIncrementalIterOptions{
 				EndKey:    keyMax,
 				StartTime: tsMin,
 				EndTime:   tsMax,
@@ -818,7 +818,7 @@ func TestMVCCIncrementalIteratorIntentPolicy(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Run("PolicyError returns error if an intent is in the time range", func(t *testing.T) {
-		iter, err := NewMVCCIncrementalIterator(e, MVCCIncrementalIterOptions{
+		iter, err := NewMVCCIncrementalIterator(context.Background(), e, MVCCIncrementalIterOptions{
 			EndKey:       keyMax,
 			StartTime:    tsMin,
 			EndTime:      tsMax,
@@ -846,7 +846,7 @@ func TestMVCCIncrementalIteratorIntentPolicy(t *testing.T) {
 		}
 	})
 	t.Run("PolicyError ignores intents outside of time range", func(t *testing.T) {
-		iter, err := NewMVCCIncrementalIterator(e, MVCCIncrementalIterOptions{
+		iter, err := NewMVCCIncrementalIterator(context.Background(), e, MVCCIncrementalIterOptions{
 			EndKey:       keyMax,
 			StartTime:    ts2,
 			EndTime:      tsMax,
@@ -862,7 +862,7 @@ func TestMVCCIncrementalIteratorIntentPolicy(t *testing.T) {
 		assert.False(t, valid)
 	})
 	t.Run("PolicyEmit returns inline values to caller", func(t *testing.T) {
-		iter, err := NewMVCCIncrementalIterator(e, MVCCIncrementalIterOptions{
+		iter, err := NewMVCCIncrementalIterator(context.Background(), e, MVCCIncrementalIterOptions{
 			EndKey:       keyMax,
 			StartTime:    tsMin,
 			EndTime:      tsMax,
@@ -886,7 +886,7 @@ func TestMVCCIncrementalIteratorIntentPolicy(t *testing.T) {
 		testIterWithNextFunc(iter.NextIgnoringTime)
 	})
 	t.Run("PolicyEmit ignores intents outside of time range", func(t *testing.T) {
-		iter, err := NewMVCCIncrementalIterator(e, MVCCIncrementalIterOptions{
+		iter, err := NewMVCCIncrementalIterator(context.Background(), e, MVCCIncrementalIterOptions{
 			EndKey:       keyMax,
 			StartTime:    ts2,
 			EndTime:      tsMax,
@@ -1109,7 +1109,7 @@ func slurpKVsInTimeRange(
 	reader Reader, prefix roachpb.Key, startTime, endTime hlc.Timestamp,
 ) ([]MVCCKeyValue, error) {
 	endKey := prefix.PrefixEnd()
-	iter, err := NewMVCCIncrementalIterator(reader, MVCCIncrementalIterOptions{
+	iter, err := NewMVCCIncrementalIterator(context.Background(), reader, MVCCIncrementalIterOptions{
 		EndKey:    endKey,
 		StartTime: startTime,
 		EndTime:   endTime,
@@ -1403,7 +1403,7 @@ func TestMVCCIncrementalIteratorIntentStraddlesSStables(t *testing.T) {
 	{
 		// Iterate over the entries in the first DB, ingesting them into SSTables
 		// in the second DB.
-		it, err := db1.NewEngineIterator(IterOptions{UpperBound: keys.MaxKey})
+		it, err := db1.NewEngineIterator(context.Background(), IterOptions{UpperBound: keys.MaxKey})
 		require.NoError(t, err)
 		defer it.Close()
 		valid, err := it.SeekEngineKeyGE(EngineKey{Key: keys.LocalRangeLockTablePrefix})
@@ -1417,7 +1417,7 @@ func TestMVCCIncrementalIteratorIntentStraddlesSStables(t *testing.T) {
 		// 2]. Note that incremental iterators are exclusive on the start time and
 		// inclusive on the end time. The expectation is that we'll see a write
 		// intent error.
-		it, err := NewMVCCIncrementalIterator(db2, MVCCIncrementalIterOptions{
+		it, err := NewMVCCIncrementalIterator(context.Background(), db2, MVCCIncrementalIterOptions{
 			EndKey:    keys.MaxKey,
 			StartTime: hlc.Timestamp{WallTime: 1},
 			EndTime:   hlc.Timestamp{WallTime: 2},
@@ -1504,7 +1504,7 @@ func collectMatchingWithMVCCIterator(
 	t *testing.T, eng Engine, start, end hlc.Timestamp,
 ) []MVCCKeyValue {
 	var expectedKVs []MVCCKeyValue
-	iter, err := eng.NewMVCCIterator(MVCCKeyAndIntentsIterKind, IterOptions{UpperBound: roachpb.KeyMax})
+	iter, err := eng.NewMVCCIterator(context.Background(), MVCCKeyAndIntentsIterKind, IterOptions{UpperBound: roachpb.KeyMax})
 	require.NoError(t, err)
 	defer iter.Close()
 	iter.SeekGE(MVCCKey{Key: localMax})
@@ -1538,7 +1538,7 @@ func runIncrementalBenchmark(b *testing.B, ts hlc.Timestamp, opts mvccBenchData)
 		// Pull all of the sstables into the cache.  This
 		// probably defeats a lot of the benefits of the
 		// time-based optimization.
-		_, err := ComputeStats(eng, keys.LocalMax, roachpb.KeyMax, 0)
+		_, err := ComputeStats(context.Background(), eng, keys.LocalMax, roachpb.KeyMax, 0)
 		if err != nil {
 			b.Fatalf("stats failed: %s", err)
 		}
@@ -1548,7 +1548,7 @@ func runIncrementalBenchmark(b *testing.B, ts hlc.Timestamp, opts mvccBenchData)
 	endKey := roachpb.Key(encoding.EncodeUvarintAscending([]byte("key-"), uint64(opts.numKeys)))
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		it, err := NewMVCCIncrementalIterator(eng, MVCCIncrementalIterOptions{
+		it, err := NewMVCCIncrementalIterator(context.Background(), eng, MVCCIncrementalIterOptions{
 			EndKey:    endKey,
 			StartTime: ts,
 			EndTime:   hlc.MaxTimestamp,
@@ -1658,7 +1658,7 @@ func BenchmarkMVCCIncrementalIteratorForOldData(b *testing.B) {
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				func() {
-					it, err := NewMVCCIncrementalIterator(eng, MVCCIncrementalIterOptions{
+					it, err := NewMVCCIncrementalIterator(context.Background(), eng, MVCCIncrementalIterOptions{
 						EndKey:    endKey,
 						StartTime: hlc.Timestamp{},
 						EndTime:   hlc.Timestamp{WallTime: baseTimestamp},

--- a/pkg/storage/mvcc_stats_test.go
+++ b/pkg/storage/mvcc_stats_test.go
@@ -70,7 +70,8 @@ func assertEqImpl(
 		}
 		// NOTE: we use ComputeStats for the lock table stats because it is not
 		// supported by ComputeStatsForIter.
-		compLockMS, err := ComputeStats(rw, lockKeyMin, lockKeyMax, ms.LastUpdateNanos)
+		compLockMS, err := ComputeStats(
+			context.Background(), rw, lockKeyMin, lockKeyMax, ms.LastUpdateNanos)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1479,13 +1480,13 @@ var mvccStatsTests = []struct {
 	{
 		name: "ComputeStats",
 		fn: func(r Reader, start, end roachpb.Key, nowNanos int64) (enginepb.MVCCStats, error) {
-			return ComputeStats(r, start, end, nowNanos)
+			return ComputeStats(context.Background(), r, start, end, nowNanos)
 		},
 	},
 	{
 		name: "ComputeStatsForIter",
 		fn: func(r Reader, start, end roachpb.Key, nowNanos int64) (enginepb.MVCCStats, error) {
-			iter, err := r.NewMVCCIterator(MVCCKeyAndIntentsIterKind, IterOptions{
+			iter, err := r.NewMVCCIterator(context.Background(), MVCCKeyAndIntentsIterKind, IterOptions{
 				KeyTypes:   IterKeyTypePointsAndRanges,
 				LowerBound: start,
 				UpperBound: end,

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -1513,6 +1513,7 @@ func (p *Pebble) Closed() bool {
 
 // MVCCIterate implements the Engine interface.
 func (p *Pebble) MVCCIterate(
+	ctx context.Context,
 	start, end roachpb.Key,
 	iterKind MVCCIterKind,
 	keyTypes IterKeyType,
@@ -1521,19 +1522,21 @@ func (p *Pebble) MVCCIterate(
 	if iterKind == MVCCKeyAndIntentsIterKind {
 		r := wrapReader(p)
 		// Doing defer r.Free() does not inline.
-		err := iterateOnReader(r, start, end, iterKind, keyTypes, f)
+		err := iterateOnReader(ctx, r, start, end, iterKind, keyTypes, f)
 		r.Free()
 		return err
 	}
-	return iterateOnReader(p, start, end, iterKind, keyTypes, f)
+	return iterateOnReader(ctx, p, start, end, iterKind, keyTypes, f)
 }
 
 // NewMVCCIterator implements the Engine interface.
-func (p *Pebble) NewMVCCIterator(iterKind MVCCIterKind, opts IterOptions) (MVCCIterator, error) {
+func (p *Pebble) NewMVCCIterator(
+	ctx context.Context, iterKind MVCCIterKind, opts IterOptions,
+) (MVCCIterator, error) {
 	if iterKind == MVCCKeyAndIntentsIterKind {
 		r := wrapReader(p)
 		// Doing defer r.Free() does not inline.
-		iter, err := r.NewMVCCIterator(iterKind, opts)
+		iter, err := r.NewMVCCIterator(ctx, iterKind, opts)
 		r.Free()
 		if err != nil {
 			return nil, err
@@ -1541,7 +1544,7 @@ func (p *Pebble) NewMVCCIterator(iterKind MVCCIterKind, opts IterOptions) (MVCCI
 		return maybeWrapInUnsafeIter(iter), nil
 	}
 
-	iter, err := newPebbleIterator(p.db, opts, StandardDurability, p)
+	iter, err := newPebbleIterator(ctx, p.db, opts, StandardDurability, p)
 	if err != nil {
 		return nil, err
 	}
@@ -1549,8 +1552,8 @@ func (p *Pebble) NewMVCCIterator(iterKind MVCCIterKind, opts IterOptions) (MVCCI
 }
 
 // NewEngineIterator implements the Engine interface.
-func (p *Pebble) NewEngineIterator(opts IterOptions) (EngineIterator, error) {
-	return newPebbleIterator(p.db, opts, StandardDurability, p)
+func (p *Pebble) NewEngineIterator(ctx context.Context, opts IterOptions) (EngineIterator, error) {
+	return newPebbleIterator(ctx, p.db, opts, StandardDurability, p)
 }
 
 // ScanInternal implements the Engine interface.
@@ -2586,6 +2589,7 @@ func (p *pebbleReadOnly) Closed() bool {
 }
 
 func (p *pebbleReadOnly) MVCCIterate(
+	ctx context.Context,
 	start, end roachpb.Key,
 	iterKind MVCCIterKind,
 	keyTypes IterKeyType,
@@ -2597,16 +2601,16 @@ func (p *pebbleReadOnly) MVCCIterate(
 	if iterKind == MVCCKeyAndIntentsIterKind {
 		r := wrapReader(p)
 		// Doing defer r.Free() does not inline.
-		err := iterateOnReader(r, start, end, iterKind, keyTypes, f)
+		err := iterateOnReader(ctx, r, start, end, iterKind, keyTypes, f)
 		r.Free()
 		return err
 	}
-	return iterateOnReader(p, start, end, iterKind, keyTypes, f)
+	return iterateOnReader(ctx, p, start, end, iterKind, keyTypes, f)
 }
 
 // NewMVCCIterator implements the Engine interface.
 func (p *pebbleReadOnly) NewMVCCIterator(
-	iterKind MVCCIterKind, opts IterOptions,
+	ctx context.Context, iterKind MVCCIterKind, opts IterOptions,
 ) (MVCCIterator, error) {
 	if p.closed {
 		panic("using a closed pebbleReadOnly")
@@ -2615,7 +2619,7 @@ func (p *pebbleReadOnly) NewMVCCIterator(
 	if iterKind == MVCCKeyAndIntentsIterKind {
 		r := wrapReader(p)
 		// Doing defer r.Free() does not inline.
-		iter, err := r.NewMVCCIterator(iterKind, opts)
+		iter, err := r.NewMVCCIterator(ctx, iterKind, opts)
 		r.Free()
 		if err != nil {
 			return nil, err
@@ -2628,7 +2632,7 @@ func (p *pebbleReadOnly) NewMVCCIterator(
 		iter = &p.prefixIter
 	}
 	if iter.inuse {
-		return newPebbleIteratorByCloning(CloneContext{
+		return newPebbleIteratorByCloning(ctx, CloneContext{
 			rawIter: p.iter,
 			engine:  p.parent,
 		}, opts, p.durability), nil
@@ -2637,7 +2641,8 @@ func (p *pebbleReadOnly) NewMVCCIterator(
 	if iter.iter != nil {
 		iter.setOptions(opts, p.durability)
 	} else {
-		if err := iter.initReuseOrCreate(p.parent.db, p.iter, p.iterUsed, opts, p.durability, p.parent); err != nil {
+		if err := iter.initReuseOrCreate(
+			ctx, p.parent.db, p.iter, p.iterUsed, opts, p.durability, p.parent); err != nil {
 			return nil, err
 		}
 		if p.iter == nil {
@@ -2653,7 +2658,9 @@ func (p *pebbleReadOnly) NewMVCCIterator(
 }
 
 // NewEngineIterator implements the Engine interface.
-func (p *pebbleReadOnly) NewEngineIterator(opts IterOptions) (EngineIterator, error) {
+func (p *pebbleReadOnly) NewEngineIterator(
+	ctx context.Context, opts IterOptions,
+) (EngineIterator, error) {
 	if p.closed {
 		panic("using a closed pebbleReadOnly")
 	}
@@ -2663,7 +2670,7 @@ func (p *pebbleReadOnly) NewEngineIterator(opts IterOptions) (EngineIterator, er
 		iter = &p.prefixEngineIter
 	}
 	if iter.inuse {
-		return newPebbleIteratorByCloning(CloneContext{
+		return newPebbleIteratorByCloning(ctx, CloneContext{
 			rawIter: p.iter,
 			engine:  p.parent,
 		}, opts, p.durability), nil
@@ -2672,7 +2679,8 @@ func (p *pebbleReadOnly) NewEngineIterator(opts IterOptions) (EngineIterator, er
 	if iter.iter != nil {
 		iter.setOptions(opts, p.durability)
 	} else {
-		err := iter.initReuseOrCreate(p.parent.db, p.iter, p.iterUsed, opts, p.durability, p.parent)
+		err := iter.initReuseOrCreate(
+			ctx, p.parent.db, p.iter, p.iterUsed, opts, p.durability, p.parent)
 		if err != nil {
 			return nil, err
 		}
@@ -2844,6 +2852,7 @@ func (p *pebbleSnapshot) Closed() bool {
 
 // MVCCIterate implements the Reader interface.
 func (p *pebbleSnapshot) MVCCIterate(
+	ctx context.Context,
 	start, end roachpb.Key,
 	iterKind MVCCIterKind,
 	keyTypes IterKeyType,
@@ -2852,21 +2861,21 @@ func (p *pebbleSnapshot) MVCCIterate(
 	if iterKind == MVCCKeyAndIntentsIterKind {
 		r := wrapReader(p)
 		// Doing defer r.Free() does not inline.
-		err := iterateOnReader(r, start, end, iterKind, keyTypes, f)
+		err := iterateOnReader(ctx, r, start, end, iterKind, keyTypes, f)
 		r.Free()
 		return err
 	}
-	return iterateOnReader(p, start, end, iterKind, keyTypes, f)
+	return iterateOnReader(ctx, p, start, end, iterKind, keyTypes, f)
 }
 
 // NewMVCCIterator implements the Reader interface.
 func (p *pebbleSnapshot) NewMVCCIterator(
-	iterKind MVCCIterKind, opts IterOptions,
+	ctx context.Context, iterKind MVCCIterKind, opts IterOptions,
 ) (MVCCIterator, error) {
 	if iterKind == MVCCKeyAndIntentsIterKind {
 		r := wrapReader(p)
 		// Doing defer r.Free() does not inline.
-		iter, err := r.NewMVCCIterator(iterKind, opts)
+		iter, err := r.NewMVCCIterator(ctx, iterKind, opts)
 		r.Free()
 		if err != nil {
 			return nil, err
@@ -2874,7 +2883,7 @@ func (p *pebbleSnapshot) NewMVCCIterator(
 		return maybeWrapInUnsafeIter(iter), nil
 	}
 
-	iter, err := newPebbleIterator(p.snapshot, opts, StandardDurability, p.parent)
+	iter, err := newPebbleIterator(ctx, p.snapshot, opts, StandardDurability, p.parent)
 	if err != nil {
 		return nil, err
 	}
@@ -2882,8 +2891,10 @@ func (p *pebbleSnapshot) NewMVCCIterator(
 }
 
 // NewEngineIterator implements the Reader interface.
-func (p pebbleSnapshot) NewEngineIterator(opts IterOptions) (EngineIterator, error) {
-	return newPebbleIterator(p.snapshot, opts, StandardDurability, p.parent)
+func (p pebbleSnapshot) NewEngineIterator(
+	ctx context.Context, opts IterOptions,
+) (EngineIterator, error) {
+	return newPebbleIterator(ctx, p.snapshot, opts, StandardDurability, p.parent)
 }
 
 // ConsistentIterators implements the Reader interface.
@@ -2935,6 +2946,7 @@ func (p *pebbleEFOS) Closed() bool {
 
 // MVCCIterate implements the Reader interface.
 func (p *pebbleEFOS) MVCCIterate(
+	ctx context.Context,
 	start, end roachpb.Key,
 	iterKind MVCCIterKind,
 	keyTypes IterKeyType,
@@ -2943,11 +2955,11 @@ func (p *pebbleEFOS) MVCCIterate(
 	if iterKind == MVCCKeyAndIntentsIterKind {
 		r := wrapReader(p)
 		// Doing defer r.Free() does not inline.
-		err := iterateOnReader(r, start, end, iterKind, keyTypes, f)
+		err := iterateOnReader(ctx, r, start, end, iterKind, keyTypes, f)
 		r.Free()
 		return err
 	}
-	return iterateOnReader(p, start, end, iterKind, keyTypes, f)
+	return iterateOnReader(ctx, p, start, end, iterKind, keyTypes, f)
 }
 
 // WaitForFileOnly implements the EventuallyFileOnlyReader interface.
@@ -2957,7 +2969,7 @@ func (p *pebbleEFOS) WaitForFileOnly(ctx context.Context) error {
 
 // NewMVCCIterator implements the Reader interface.
 func (p *pebbleEFOS) NewMVCCIterator(
-	iterKind MVCCIterKind, opts IterOptions,
+	ctx context.Context, iterKind MVCCIterKind, opts IterOptions,
 ) (MVCCIterator, error) {
 	// Check if the bounds fall within the EFOS' keyRanges. We can only do this
 	// check for non-prefix iterators as prefix iterators often don't specify
@@ -2981,7 +2993,7 @@ func (p *pebbleEFOS) NewMVCCIterator(
 	if iterKind == MVCCKeyAndIntentsIterKind {
 		r := wrapReader(p)
 		// Doing defer r.Free() does not inline.
-		iter, err := r.NewMVCCIterator(iterKind, opts)
+		iter, err := r.NewMVCCIterator(ctx, iterKind, opts)
 		r.Free()
 		if err != nil {
 			return nil, err
@@ -2989,7 +3001,7 @@ func (p *pebbleEFOS) NewMVCCIterator(
 		return maybeWrapInUnsafeIter(iter), nil
 	}
 
-	iter, err := newPebbleIterator(p.efos, opts, StandardDurability, p.parent)
+	iter, err := newPebbleIterator(ctx, p.efos, opts, StandardDurability, p.parent)
 	if err != nil {
 		return nil, err
 	}
@@ -2997,8 +3009,10 @@ func (p *pebbleEFOS) NewMVCCIterator(
 }
 
 // NewEngineIterator implements the Reader interface.
-func (p *pebbleEFOS) NewEngineIterator(opts IterOptions) (EngineIterator, error) {
-	return newPebbleIterator(p.efos, opts, StandardDurability, p.parent)
+func (p *pebbleEFOS) NewEngineIterator(
+	ctx context.Context, opts IterOptions,
+) (EngineIterator, error) {
+	return newPebbleIterator(ctx, p.efos, opts, StandardDurability, p.parent)
 }
 
 // ConsistentIterators implements the Reader interface.

--- a/pkg/storage/pebble_iterator_test.go
+++ b/pkg/storage/pebble_iterator_test.go
@@ -78,7 +78,7 @@ func TestPebbleIterator_Corruption(t *testing.T) {
 		LowerBound: []byte("a"),
 		UpperBound: []byte("z"),
 	}
-	iter, err := newPebbleIterator(p.db, iterOpts, StandardDurability, p)
+	iter, err := newPebbleIterator(context.Background(), p.db, iterOpts, StandardDurability, p)
 	require.NoError(t, err)
 
 	// Seeking into the table catches the corruption.

--- a/pkg/storage/pebble_mvcc_scanner_test.go
+++ b/pkg/storage/pebble_mvcc_scanner_test.go
@@ -83,8 +83,7 @@ func TestMVCCScanWithManyVersionsAndSeparatedIntents(t *testing.T) {
 
 	reader := eng.NewReadOnly(StandardDurability)
 	defer reader.Close()
-	iter, err := reader.NewMVCCIterator(
-		MVCCKeyAndIntentsIterKind, IterOptions{LowerBound: keys[0], UpperBound: roachpb.Key("d")})
+	iter, err := reader.NewMVCCIterator(context.Background(), MVCCKeyAndIntentsIterKind, IterOptions{LowerBound: keys[0], UpperBound: roachpb.Key("d")})
 	require.NoError(t, err)
 	defer iter.Close()
 
@@ -152,8 +151,7 @@ func TestMVCCScanWithLargeKeyValue(t *testing.T) {
 
 	reader := eng.NewReadOnly(StandardDurability)
 	defer reader.Close()
-	iter, err := reader.NewMVCCIterator(
-		MVCCKeyAndIntentsIterKind, IterOptions{LowerBound: keys[0], UpperBound: roachpb.Key("e")})
+	iter, err := reader.NewMVCCIterator(context.Background(), MVCCKeyAndIntentsIterKind, IterOptions{LowerBound: keys[0], UpperBound: roachpb.Key("e")})
 	require.NoError(t, err)
 	defer iter.Close()
 
@@ -232,8 +230,7 @@ func TestMVCCScanWithMemoryAccounting(t *testing.T) {
 	}()
 
 	// iterator that can span over all the written keys.
-	iter, err := eng.NewMVCCIterator(MVCCKeyAndIntentsIterKind,
-		IterOptions{LowerBound: makeKey(nil, 0), UpperBound: makeKey(nil, 11)})
+	iter, err := eng.NewMVCCIterator(context.Background(), MVCCKeyAndIntentsIterKind, IterOptions{LowerBound: makeKey(nil, 0), UpperBound: makeKey(nil, 11)})
 	require.NoError(t, err)
 	defer iter.Close()
 

--- a/pkg/storage/pebble_test.go
+++ b/pkg/storage/pebble_test.go
@@ -100,7 +100,7 @@ func TestPebbleIterReuse(t *testing.T) {
 		}
 	}
 
-	iter1, err := batch.NewMVCCIterator(MVCCKeyAndIntentsIterKind, IterOptions{LowerBound: []byte{40}, UpperBound: []byte{50}})
+	iter1, err := batch.NewMVCCIterator(context.Background(), MVCCKeyAndIntentsIterKind, IterOptions{LowerBound: []byte{40}, UpperBound: []byte{50}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -132,7 +132,7 @@ func TestPebbleIterReuse(t *testing.T) {
 	// is lower than the previous iterator's lower bound. This should still result
 	// in the right amount of keys being returned; the lower bound from the
 	// previous iterator should get zeroed.
-	iter2, err := batch.NewMVCCIterator(MVCCKeyAndIntentsIterKind, IterOptions{UpperBound: []byte{10}})
+	iter2, err := batch.NewMVCCIterator(context.Background(), MVCCKeyAndIntentsIterKind, IterOptions{UpperBound: []byte{10}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -320,13 +320,13 @@ func TestPebbleIterConsistency(t *testing.T) {
 	// Since an iterator is created on pebbleReadOnly, pebbleBatch before
 	// writing a newer version of "a", the newer version will not be visible to
 	// iterators that are created later.
-	iter, err := roEngine.NewMVCCIterator(MVCCKeyIterKind, IterOptions{UpperBound: []byte("a")})
+	iter, err := roEngine.NewMVCCIterator(context.Background(), MVCCKeyIterKind, IterOptions{UpperBound: []byte("a")})
 	require.NoError(t, err)
 	iter.Close()
-	batchIter, err := batch.NewMVCCIterator(MVCCKeyIterKind, IterOptions{UpperBound: []byte("a")})
+	batchIter, err := batch.NewMVCCIterator(context.Background(), MVCCKeyIterKind, IterOptions{UpperBound: []byte("a")})
 	require.NoError(t, err)
 	batchIter.Close()
-	engIter, err := eng.NewMVCCIterator(MVCCKeyIterKind, IterOptions{UpperBound: []byte("a")})
+	engIter, err := eng.NewMVCCIterator(context.Background(), MVCCKeyIterKind, IterOptions{UpperBound: []byte("a")})
 	require.NoError(t, err)
 	engIter.Close()
 	// Pin the state for iterators.
@@ -370,23 +370,23 @@ func TestPebbleIterConsistency(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	checkMVCCIter(roEngine.NewMVCCIterator(MVCCKeyIterKind, IterOptions{UpperBound: []byte("b")}))
-	checkMVCCIter(roEngine.NewMVCCIterator(MVCCKeyIterKind, IterOptions{Prefix: true}))
-	checkMVCCIter(batch.NewMVCCIterator(MVCCKeyIterKind, IterOptions{UpperBound: []byte("b")}))
-	checkMVCCIter(batch.NewMVCCIterator(MVCCKeyIterKind, IterOptions{Prefix: true}))
-	checkMVCCIter(roEngine2.NewMVCCIterator(MVCCKeyIterKind, IterOptions{UpperBound: []byte("b")}))
-	checkMVCCIter(roEngine2.NewMVCCIterator(MVCCKeyIterKind, IterOptions{Prefix: true}))
-	checkMVCCIter(batch2.NewMVCCIterator(MVCCKeyIterKind, IterOptions{UpperBound: []byte("b")}))
-	checkMVCCIter(batch2.NewMVCCIterator(MVCCKeyIterKind, IterOptions{Prefix: true}))
+	checkMVCCIter(roEngine.NewMVCCIterator(context.Background(), MVCCKeyIterKind, IterOptions{UpperBound: []byte("b")}))
+	checkMVCCIter(roEngine.NewMVCCIterator(context.Background(), MVCCKeyIterKind, IterOptions{Prefix: true}))
+	checkMVCCIter(batch.NewMVCCIterator(context.Background(), MVCCKeyIterKind, IterOptions{UpperBound: []byte("b")}))
+	checkMVCCIter(batch.NewMVCCIterator(context.Background(), MVCCKeyIterKind, IterOptions{Prefix: true}))
+	checkMVCCIter(roEngine2.NewMVCCIterator(context.Background(), MVCCKeyIterKind, IterOptions{UpperBound: []byte("b")}))
+	checkMVCCIter(roEngine2.NewMVCCIterator(context.Background(), MVCCKeyIterKind, IterOptions{Prefix: true}))
+	checkMVCCIter(batch2.NewMVCCIterator(context.Background(), MVCCKeyIterKind, IterOptions{UpperBound: []byte("b")}))
+	checkMVCCIter(batch2.NewMVCCIterator(context.Background(), MVCCKeyIterKind, IterOptions{Prefix: true}))
 
-	checkEngineIter(roEngine.NewEngineIterator(IterOptions{UpperBound: []byte("b")}))
-	checkEngineIter(roEngine.NewEngineIterator(IterOptions{Prefix: true}))
-	checkEngineIter(batch.NewEngineIterator(IterOptions{UpperBound: []byte("b")}))
-	checkEngineIter(batch.NewEngineIterator(IterOptions{Prefix: true}))
-	checkEngineIter(roEngine2.NewEngineIterator(IterOptions{UpperBound: []byte("b")}))
-	checkEngineIter(roEngine2.NewEngineIterator(IterOptions{Prefix: true}))
-	checkEngineIter(batch2.NewEngineIterator(IterOptions{UpperBound: []byte("b")}))
-	checkEngineIter(batch2.NewEngineIterator(IterOptions{Prefix: true}))
+	checkEngineIter(roEngine.NewEngineIterator(context.Background(), IterOptions{UpperBound: []byte("b")}))
+	checkEngineIter(roEngine.NewEngineIterator(context.Background(), IterOptions{Prefix: true}))
+	checkEngineIter(batch.NewEngineIterator(context.Background(), IterOptions{UpperBound: []byte("b")}))
+	checkEngineIter(batch.NewEngineIterator(context.Background(), IterOptions{Prefix: true}))
+	checkEngineIter(roEngine2.NewEngineIterator(context.Background(), IterOptions{UpperBound: []byte("b")}))
+	checkEngineIter(roEngine2.NewEngineIterator(context.Background(), IterOptions{Prefix: true}))
+	checkEngineIter(batch2.NewEngineIterator(context.Background(), IterOptions{UpperBound: []byte("b")}))
+	checkEngineIter(batch2.NewEngineIterator(context.Background(), IterOptions{Prefix: true}))
 
 	checkIterSeesBothValues := func(iter MVCCIterator, err error) {
 		require.NoError(t, err)
@@ -404,7 +404,7 @@ func TestPebbleIterConsistency(t *testing.T) {
 		require.Equal(t, 2, count)
 	}
 	// The eng iterator will see both values.
-	checkIterSeesBothValues(eng.NewMVCCIterator(MVCCKeyIterKind, IterOptions{UpperBound: []byte("b")}))
+	checkIterSeesBothValues(eng.NewMVCCIterator(context.Background(), MVCCKeyIterKind, IterOptions{UpperBound: []byte("b")}))
 	// The indexed batches will see 2 values since the second one is written to the batch.
 	require.NoError(t, batch.PutMVCC(
 		MVCCKey{Key: []byte("a"), Timestamp: ts2},
@@ -414,8 +414,8 @@ func TestPebbleIterConsistency(t *testing.T) {
 		MVCCKey{Key: []byte("a"), Timestamp: ts2},
 		MVCCValue{Value: roachpb.MakeValueFromString("a2")},
 	))
-	checkIterSeesBothValues(batch.NewMVCCIterator(MVCCKeyIterKind, IterOptions{UpperBound: []byte("b")}))
-	checkIterSeesBothValues(batch2.NewMVCCIterator(MVCCKeyIterKind, IterOptions{UpperBound: []byte("b")}))
+	checkIterSeesBothValues(batch.NewMVCCIterator(context.Background(), MVCCKeyIterKind, IterOptions{UpperBound: []byte("b")}))
+	checkIterSeesBothValues(batch2.NewMVCCIterator(context.Background(), MVCCKeyIterKind, IterOptions{UpperBound: []byte("b")}))
 }
 
 func BenchmarkMVCCKeyCompare(b *testing.B) {
@@ -757,7 +757,7 @@ func TestPebbleMVCCTimeIntervalCollectorAndFilter(t *testing.T) {
 						}
 						expect = append(expect, kv)
 					}
-					iter, err := eng.NewMVCCIterator(MVCCKeyIterKind, IterOptions{
+					iter, err := eng.NewMVCCIterator(context.Background(), MVCCKeyIterKind, IterOptions{
 						KeyTypes:     keyType,
 						UpperBound:   keys.MaxKey,
 						MinTimestamp: tc.minTimestamp,
@@ -870,7 +870,7 @@ func TestPebbleMVCCTimeIntervalWithClears(t *testing.T) {
 						}
 						expect = append(expect, kv)
 					}
-					iter, err := eng.NewMVCCIterator(MVCCKeyIterKind, IterOptions{
+					iter, err := eng.NewMVCCIterator(context.Background(), MVCCKeyIterKind, IterOptions{
 						KeyTypes:     keyType,
 						UpperBound:   keys.MaxKey,
 						MinTimestamp: tc.minTimestamp,
@@ -952,7 +952,7 @@ func TestPebbleMVCCTimeIntervalWithRangeClears(t *testing.T) {
 						}
 						expect = append(expect, kv)
 					}
-					iter, err := eng.NewMVCCIterator(MVCCKeyIterKind, IterOptions{
+					iter, err := eng.NewMVCCIterator(context.Background(), MVCCKeyIterKind, IterOptions{
 						KeyTypes:     keyType,
 						UpperBound:   keys.MaxKey,
 						MinTimestamp: tc.minTimestamp,
@@ -1023,7 +1023,7 @@ func TestPebbleTablePropertyFilter(t *testing.T) {
 	}
 	for name, tc := range testcases {
 		t.Run(name, func(t *testing.T) {
-			iter, err := eng.NewMVCCIterator(MVCCKeyIterKind, IterOptions{
+			iter, err := eng.NewMVCCIterator(context.Background(), MVCCKeyIterKind, IterOptions{
 				UpperBound:   keys.MaxKey,
 				MinTimestamp: hlc.Timestamp{WallTime: tc.minTimestamp},
 				MaxTimestamp: hlc.Timestamp{WallTime: tc.maxTimestamp},
@@ -1084,7 +1084,7 @@ func TestPebbleFlushCallbackAndDurabilityRequirement(t *testing.T) {
 	// Returns the value found or nil.
 	checkGetAndIter := func(reader Reader) []byte {
 		v := mvccGetRaw(t, reader, k)
-		iter, err := reader.NewMVCCIterator(MVCCKeyIterKind, IterOptions{UpperBound: k.Key.Next()})
+		iter, err := reader.NewMVCCIterator(context.Background(), MVCCKeyIterKind, IterOptions{UpperBound: k.Key.Next()})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1179,11 +1179,11 @@ func TestPebbleReaderMultipleIterators(t *testing.T) {
 	for name, r := range testcases {
 		t.Run(name, func(t *testing.T) {
 			// Make sure we can create two iterators of the same type.
-			i1, err := r.NewMVCCIterator(MVCCKeyIterKind, IterOptions{LowerBound: a1.Key, UpperBound: keys.MaxKey})
+			i1, err := r.NewMVCCIterator(context.Background(), MVCCKeyIterKind, IterOptions{LowerBound: a1.Key, UpperBound: keys.MaxKey})
 			if err != nil {
 				t.Fatal(err)
 			}
-			i2, err := r.NewMVCCIterator(MVCCKeyIterKind, IterOptions{LowerBound: b1.Key, UpperBound: keys.MaxKey})
+			i2, err := r.NewMVCCIterator(context.Background(), MVCCKeyIterKind, IterOptions{LowerBound: b1.Key, UpperBound: keys.MaxKey})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1210,12 +1210,12 @@ func TestPebbleReaderMultipleIterators(t *testing.T) {
 			i2.Close()
 
 			// Quick check for engine iterators too.
-			e1, err := r.NewEngineIterator(IterOptions{UpperBound: keys.MaxKey})
+			e1, err := r.NewEngineIterator(context.Background(), IterOptions{UpperBound: keys.MaxKey})
 			if err != nil {
 				t.Fatal(err)
 			}
 			defer e1.Close()
-			e2, err := r.NewEngineIterator(IterOptions{UpperBound: keys.MaxKey})
+			e2, err := r.NewEngineIterator(context.Background(), IterOptions{UpperBound: keys.MaxKey})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1487,7 +1487,7 @@ func TestConvertFilesToBatchAndCommit(t *testing.T) {
 		}))
 	require.NoError(t, engs[ingestEngine].IngestLocalFiles(ctx, []string{fileName1, fileName2}))
 	outputState := func(eng Engine) []string {
-		it, err := eng.NewEngineIterator(IterOptions{
+		it, err := eng.NewEngineIterator(context.Background(), IterOptions{
 			UpperBound: roachpb.KeyMax,
 			KeyTypes:   IterKeyTypePointsAndRanges,
 		})

--- a/pkg/storage/pebbleiter/crdb_test_on.go
+++ b/pkg/storage/pebbleiter/crdb_test_on.go
@@ -14,6 +14,7 @@
 package pebbleiter
 
 import (
+	"context"
 	"math/rand"
 	"time"
 
@@ -87,6 +88,16 @@ func (b *rangeKeyBuf) mangle() {
 
 func (i *assertionIter) Clone(cloneOpts pebble.CloneOptions) (Iterator, error) {
 	iter, err := i.Iterator.Clone(cloneOpts)
+	if err != nil {
+		return nil, err
+	}
+	return MaybeWrap(iter), nil
+}
+
+func (i *assertionIter) CloneWithContext(
+	ctx context.Context, cloneOpts pebble.CloneOptions,
+) (Iterator, error) {
+	iter, err := i.Iterator.CloneWithContext(ctx, cloneOpts)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storage/read_as_of_iterator_test.go
+++ b/pkg/storage/read_as_of_iterator_test.go
@@ -86,7 +86,7 @@ func TestReadAsOfIterator(t *testing.T) {
 			batch := pebble.NewBatch()
 			defer batch.Close()
 			populateBatch(t, batch, test.input)
-			iter, err := batch.NewMVCCIterator(MVCCKeyAndIntentsIterKind, IterOptions{UpperBound: roachpb.KeyMax})
+			iter, err := batch.NewMVCCIterator(context.Background(), MVCCKeyAndIntentsIterKind, IterOptions{UpperBound: roachpb.KeyMax})
 			require.NoError(t, err)
 			defer iter.Close()
 
@@ -160,7 +160,7 @@ func TestReadAsOfIteratorSeek(t *testing.T) {
 			batch := pebble.NewBatch()
 			defer batch.Close()
 			populateBatch(t, batch, test.input)
-			iter, err := batch.NewMVCCIterator(MVCCKeyAndIntentsIterKind, IterOptions{UpperBound: roachpb.KeyMax})
+			iter, err := batch.NewMVCCIterator(context.Background(), MVCCKeyAndIntentsIterKind, IterOptions{UpperBound: roachpb.KeyMax})
 			require.NoError(t, err)
 			defer iter.Close()
 

--- a/pkg/storage/sst.go
+++ b/pkg/storage/sst.go
@@ -153,7 +153,7 @@ func CheckSSTConflicts(
 		// first, where there are no keys in the reader between the sstable's start
 		// and end keys. We use a non-prefix iterator for this search, and reopen a
 		// prefix one if there are engine keys in the span.
-		nonPrefixIter, err := reader.NewMVCCIterator(MVCCKeyAndIntentsIterKind, IterOptions{
+		nonPrefixIter, err := reader.NewMVCCIterator(ctx, MVCCKeyAndIntentsIterKind, IterOptions{
 			KeyTypes:   IterKeyTypePointsAndRanges,
 			UpperBound: end.Key,
 		})
@@ -193,7 +193,7 @@ func CheckSSTConflicts(
 	}
 	rkIter.Close()
 
-	rkIter, err = reader.NewMVCCIterator(MVCCKeyIterKind, IterOptions{
+	rkIter, err = reader.NewMVCCIterator(ctx, MVCCKeyIterKind, IterOptions{
 		UpperBound: rightPeekBound,
 		KeyTypes:   IterKeyTypeRangesOnly,
 	})
@@ -233,7 +233,7 @@ func CheckSSTConflicts(
 		// https://github.com/cockroachdb/cockroach/issues/92254
 		statsDiff.ContainsEstimates += 2
 	}
-	extIter, err := reader.NewMVCCIterator(MVCCKeyAndIntentsIterKind, IterOptions{
+	extIter, err := reader.NewMVCCIterator(ctx, MVCCKeyAndIntentsIterKind, IterOptions{
 		KeyTypes:             IterKeyTypePointsAndRanges,
 		LowerBound:           leftPeekBound,
 		UpperBound:           rightPeekBound,

--- a/pkg/testutils/storageutils/mvcc.go
+++ b/pkg/testutils/storageutils/mvcc.go
@@ -11,6 +11,7 @@
 package storageutils
 
 import (
+	"context"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/storage"
@@ -27,7 +28,8 @@ func MVCCGetRaw(t *testing.T, r storage.Reader, key storage.MVCCKey) []byte {
 // MVCCGetRawWithError is like MVCCGetRaw, but returns an error rather than
 // failing the test.
 func MVCCGetRawWithError(t *testing.T, r storage.Reader, key storage.MVCCKey) ([]byte, error) {
-	iter, err := r.NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{Prefix: true})
+	iter, err := r.NewMVCCIterator(
+		context.Background(), storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{Prefix: true})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/testutils/storageutils/scan.go
+++ b/pkg/testutils/storageutils/scan.go
@@ -11,6 +11,7 @@
 package storageutils
 
 import (
+	"context"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
@@ -87,11 +88,12 @@ func ScanIter(t *testing.T, iter storage.SimpleMVCCIterator) KVs {
 func ScanKeySpan(t *testing.T, r storage.Reader, start, end roachpb.Key) KVs {
 	t.Helper()
 
-	iter, err := r.NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{
-		KeyTypes:   storage.IterKeyTypePointsAndRanges,
-		LowerBound: start,
-		UpperBound: end,
-	})
+	iter, err := r.NewMVCCIterator(
+		context.Background(), storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{
+			KeyTypes:   storage.IterKeyTypePointsAndRanges,
+			LowerBound: start,
+			UpperBound: end,
+		})
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/testutils/storageutils/stats.go
+++ b/pkg/testutils/storageutils/stats.go
@@ -11,6 +11,7 @@
 package storageutils
 
 import (
+	"context"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
@@ -24,7 +25,8 @@ import (
 func EngineStats(t *testing.T, engine storage.Reader, nowNanos int64) *enginepb.MVCCStats {
 	t.Helper()
 
-	stats, err := storage.ComputeStats(engine, keys.LocalMax, keys.MaxKey, nowNanos)
+	stats, err := storage.ComputeStats(
+		context.Background(), engine, keys.LocalMax, keys.MaxKey, nowNanos)
 	require.NoError(t, err)
 	return &stats
 }

--- a/pkg/ts/maintenance.go
+++ b/pkg/ts/maintenance.go
@@ -54,7 +54,7 @@ func (tsdb *DB) MaintainTimeSeries(
 	budgetBytes int64,
 	now hlc.Timestamp,
 ) error {
-	series, err := tsdb.findTimeSeries(reader, start, end, now)
+	series, err := tsdb.findTimeSeries(ctx, reader, start, end, now)
 	if err != nil {
 		return err
 	}

--- a/pkg/ts/pruning.go
+++ b/pkg/ts/pruning.go
@@ -41,7 +41,7 @@ type timeSeriesResolutionInfo struct {
 // intended to be called by a storage queue which can inspect the local data for
 // a single range without the need for expensive network calls.
 func (tsdb *DB) findTimeSeries(
-	reader storage.Reader, startKey, endKey roachpb.RKey, now hlc.Timestamp,
+	ctx context.Context, reader storage.Reader, startKey, endKey roachpb.RKey, now hlc.Timestamp,
 ) ([]timeSeriesResolutionInfo, error) {
 	var results []timeSeriesResolutionInfo
 
@@ -64,7 +64,8 @@ func (tsdb *DB) findTimeSeries(
 	thresholds := tsdb.computeThresholds(now.WallTime)
 
 	// NB: timeseries don't have intents.
-	iter, err := reader.NewMVCCIterator(storage.MVCCKeyIterKind, storage.IterOptions{UpperBound: endKey.AsRawKey()})
+	iter, err := reader.NewMVCCIterator(
+		ctx, storage.MVCCKeyIterKind, storage.IterOptions{UpperBound: endKey.AsRawKey()})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ts/pruning_test.go
+++ b/pkg/ts/pruning_test.go
@@ -11,6 +11,7 @@
 package ts
 
 import (
+	"context"
 	"reflect"
 	"testing"
 	"time"
@@ -276,7 +277,8 @@ func TestFindTimeSeries(t *testing.T) {
 		},
 	} {
 		snap := e.NewSnapshot()
-		actual, err := tm.DB.findTimeSeries(snap, tcase.start, tcase.end, tcase.timestamp)
+		actual, err := tm.DB.findTimeSeries(
+			context.Background(), snap, tcase.start, tcase.end, tcase.timestamp)
 		snap.Close()
 		if err != nil {
 			t.Fatalf("case %d: unexpected error %q", i, err)


### PR DESCRIPTION
This is needed for the existing tracing facility in Pebble. And in the future, contexts specifying the source of the work will be used to collect Pebble stats by source, so we can understand the source responsible for block cache misses etc. which can lead to high disk bandwidth and high IOPS.

Epic: none

Release note: None