### PR TITLE
streamingccl: reduce scan interval for testing

### DIFF
--- a/pkg/ccl/streamingccl/replicationtestutils/testutils.go
+++ b/pkg/ccl/streamingccl/replicationtestutils/testutils.go
@@ -357,6 +357,7 @@ func startC2CTestCluster(
 		for i, locality := range regions {
 			param := serverArgs
 			param.Locality = makeLocality(locality)
+			param.ScanMaxIdleTime = 10 * time.Millisecond
 			serverArgsPerNode[i] = param
 		}
 		params.ServerArgsPerNode = serverArgsPerNode

--- a/pkg/ccl/streamingccl/streamingest/replication_stream_e2e_test.go
+++ b/pkg/ccl/streamingccl/streamingest/replication_stream_e2e_test.go
@@ -1170,7 +1170,6 @@ func TestStreamingRegionalConstraint(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	skip.UnderStressRace(t, "takes too long under stress race")
-	skip.UnderStress(t, "the allocator machinery stuggles with cpu contention, which can cause the test to timeout")
 
 	ctx := context.Background()
 	regions := []string{"mars", "venus", "mercury"}
@@ -1204,7 +1203,8 @@ func TestStreamingRegionalConstraint(t *testing.T) {
 				for _, desc := range descriptors {
 					for _, replica := range desc.InternalReplicas {
 						if replica.NodeID != marsNodeID {
-							return errors.Newf("found table data located on another node %d", replica.NodeID)
+							return errors.Newf("found table data located on another node %d, desc %v",
+								replica.NodeID, desc)
 						}
 					}
 				}


### PR DESCRIPTION
Reduce the replica scanner min interval from 1s, to 10ms for test
clusters. This speeds up tests which rely on replica changes either on
the source, or host cluster.

```
dev test pkg/ccl/streamingccl/streamingest \
  -f TestStreamingRegionalConstraint -v --stress
...
Stats over 1000 runs: max = 51.9s, min = 21.6s, avg = 38.3s, dev = 4.6s
```

Resolves: https://github.com/cockroachdb/cockroach/issues/112541
Release note: None