### PR TITLE
release-23.2: roachtest: bump previous version in multitenant-upgrade

### DIFF
--- a/pkg/cmd/roachtest/tests/multitenant_upgrade.go
+++ b/pkg/cmd/roachtest/tests/multitenant_upgrade.go
@@ -14,7 +14,6 @@ import (
 	"context"
 	gosql "database/sql"
 	"fmt"
-	"strconv"
 	"strings"
 	"time"
 
@@ -85,25 +84,10 @@ func runMultiTenantUpgrade(
 	currentBinaryMinSupportedVersion, ok := versionToMinSupportedVersion[curBinaryMajorAndMinorVersion]
 	require.True(t, ok, "current binary '%s' not found in 'versionToMinSupportedVersion' map", curBinaryMajorAndMinorVersion)
 
-	getPredecessorVersion := func() *clusterupgrade.Version {
-		predecessor, err := release.LatestPredecessor(v)
-		require.NoError(t, err)
+	predecessorV, err := release.LatestPredecessor(v)
+	require.NoError(t, err)
+	predecessor := clusterupgrade.MustParseVersion(predecessorV)
 
-		// Hard-code the pre-decessor release to 23.1.4 if 23.1.9 is not out yet because
-		// the test is in-compatible with 23.1.{5,6,7,8} due to an erroneous PR merged on the 23.1 branch.
-		// See https://github.com/cockroachdb/cockroach/pull/108202 for more context.
-		parsedPredecessor := strings.Split(predecessor, ".")
-		major := parsedPredecessor[0]
-		minor := parsedPredecessor[1]
-		patch, err := strconv.Atoi(parsedPredecessor[2])
-		require.NoError(t, err)
-		if major == "23" && minor == "1" && patch < 9 {
-			predecessor = "23.1.4"
-		}
-		return clusterupgrade.MustParseVersion(predecessor)
-	}
-
-	predecessor := getPredecessorVersion()
 	currentBinary := uploadVersion(ctx, t, c, c.All(), clusterupgrade.CurrentVersion())
 	predecessorBinary := uploadVersion(ctx, t, c, c.All(), predecessor)
 

--- a/pkg/cmd/roachtest/tests/multitenant_upgrade.go
+++ b/pkg/cmd/roachtest/tests/multitenant_upgrade.go
@@ -78,7 +78,7 @@ func runMultiTenantUpgrade(
 ) {
 	// Update this map with every new release.
 	versionToMinSupportedVersion := map[string]string{
-		"23.2": "22.2",
+		"23.2": "23.1",
 	}
 	curBinaryMajorAndMinorVersion := getMajorAndMinorVersionOnly(v)
 	currentBinaryMinSupportedVersion, ok := versionToMinSupportedVersion[curBinaryMajorAndMinorVersion]


### PR DESCRIPTION
Backport 2/2 commits from #112668.

/cc @cockroachdb/release

---

We bumped the min supported version to 23.1 recently, and we forgot to
adjust the multitenant-upgrade test accordingly.

Fixes: #111999.
Fixes: #112379.

Release note: None

Release justification: test-only change.