### PR TITLE
bazel: small fixes/improvements when running under EngFlow

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -124,6 +124,8 @@ build:engflowbase --grpc_keepalive_time=30s
 build:engflowbase --experimental_remote_cache_compression=true
 build:engflowbase --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
 build:engflowbase --extra_execution_platforms=//build/toolchains:cross_linux
+build:engflowbase --remote_upload_local_results=false
+build:engflowbase --remote_download_minimal
 test:engflowbase --test_env=REMOTE_EXEC=1
 build:engflow --config=engflowbase
 build:engflow --remote_cache=grpcs://tanzanite.cluster.engflow.com

--- a/build/teamcity/cockroach/nightlies/stress_engflow.sh
+++ b/build/teamcity/cockroach/nightlies/stress_engflow.sh
@@ -8,8 +8,7 @@ mkdir -p artifacts
 # and after this build step.
 ENGFLOW_FLAGS="--config engflow --config cibase --config crosslinux \
 --jobs 400 --tls_client_certificate=/home/agent/engflow/engflow.crt \
---tls_client_key=/home/agent/engflow/engflow.key \
---remote_upload_local_results=false"
+--tls_client_key=/home/agent/engflow/engflow.key"
 INVOCATION_ID=$(uuidgen)
 
 status=0


### PR DESCRIPTION
Set `--remote_download_minimal` to improve performance. Also make sure `--remote_upload_local_results=false` is always set and mark the stress script as executable.

Epic: CRDB-8308
Release note: None