### PR TITLE
roachprod: automatically create admin user for secure clusters

### DIFF
--- a/pkg/cmd/roachprod/flags.go
+++ b/pkg/cmd/roachprod/flags.go
@@ -357,7 +357,7 @@ Default is "RECURRING '*/15 * * * *' FULL BACKUP '@hourly' WITH SCHEDULE OPTIONS
 		cmd.Flags().StringVarP(&config.Binary,
 			"binary", "b", config.Binary, "the remote cockroach binary to use")
 	}
-	for _, cmd := range []*cobra.Command{startCmd, startInstanceCmd, sqlCmd, pgurlCmd, adminurlCmd, runCmd} {
+	for _, cmd := range []*cobra.Command{startCmd, startInstanceCmd, stopInstanceCmd, sqlCmd, pgurlCmd, adminurlCmd, runCmd} {
 		cmd.Flags().BoolVar(&secure,
 			"secure", false, "use a secure cluster")
 	}

--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -620,7 +620,7 @@ non-terminating signal (e.g. SIGHUP), unless you also configure --max-wait.
 			SQLInstance:        sqlInstance,
 		}
 		clusterName := args[0]
-		return roachprod.StopServiceForVirtualCluster(context.Background(), config.Logger, clusterName, stopOpts)
+		return roachprod.StopServiceForVirtualCluster(context.Background(), config.Logger, clusterName, secure, stopOpts)
 	}),
 }
 

--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -463,6 +463,10 @@ func (c *SyncedCluster) Stop(
 			"-e", fmt.Sprintf("ALTER TENANT '%s' STOP SERVICE", virtualClusterName),
 		})
 		if err != nil || res[0].Err != nil {
+			if len(res) > 0 {
+				return errors.CombineErrors(err, res[0].Err)
+			}
+
 			return err
 		}
 	}

--- a/pkg/roachprod/install/cockroach.go
+++ b/pkg/roachprod/install/cockroach.go
@@ -963,8 +963,13 @@ func (c *SyncedCluster) createAdminUserForSecureCluster(
 	}
 
 	const username = "roach"
-	// N.B.: we cannot reuse username and password combinations across
-	// the system interface and virtual clusters due to #109691.
+	// N.B.: although using the same username/password combination would
+	// be easier to remember, if we do it for the system interface and
+	// virtual clusters we would be unable to log-in to the virtual
+	// cluster console due to #109691.
+	//
+	// TODO(renato): use the same combination once we're able to select
+	// the virtual cluster we are connecting to in the console.
 	var password = startOpts.VirtualClusterName
 	if startOpts.VirtualClusterName == "" {
 		password = SystemInterfaceName

--- a/pkg/roachprod/install/cockroach.go
+++ b/pkg/roachprod/install/cockroach.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachprod/ssh"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm/gce"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
@@ -146,10 +147,6 @@ func (s *StartOpts) IsVirtualCluster() bool {
 	return s.Target == StartSharedProcessForVirtualCluster || s.Target == StartServiceForVirtualCluster
 }
 
-// startSQLTimeout identifies the COCKROACH_CONNECT_TIMEOUT to use (in seconds)
-// for sql cmds within syncedCluster.Start().
-const startSQLTimeout = 1200
-
 // StartTarget identifies what flavor of cockroach we are starting.
 type StartTarget int
 
@@ -165,9 +162,17 @@ const (
 	// StartRoutingProxy starts the SQL proxy process to route
 	// connections to multiple virtual clusters.
 	StartRoutingProxy
-)
 
-const defaultInitTarget = Node(1)
+	// startSQLTimeout identifies the COCKROACH_CONNECT_TIMEOUT to use (in seconds)
+	// for sql cmds within syncedCluster.Start().
+	startSQLTimeout = 1200
+	// NoSQLTimeout indicates that a `cockroach sql` call is expected to
+	// succeed immediately (i.e., the server is known to be accepting
+	// requests at the time the call is made).
+	NoSQLTimeout = 0
+
+	defaultInitTarget = Node(1)
+)
 
 func (st StartTarget) String() string {
 	return [...]string{
@@ -387,7 +392,7 @@ func (c *SyncedCluster) Start(ctx context.Context, l *logger.Logger, startOpts S
 		res, err := c.startNode(ctx, l, node, startOpts)
 		if err != nil || res.Err != nil {
 			// If err is non-nil, then this will not be retried, but if res.Err is non-nil, it will be.
-			return res, err
+			return res, errors.CombineErrors(err, res.Err)
 		}
 
 		// We reserve a few special operations (bootstrapping, and setting
@@ -403,12 +408,22 @@ func (c *SyncedCluster) Start(ctx context.Context, l *logger.Logger, startOpts S
 		// `--start-single-node` flag will handle all of this for us.
 		shouldInit := startOpts.Target == StartDefault && !c.useStartSingleNode()
 		if shouldInit {
-			if res, err := c.initializeCluster(ctx, l, node); err != nil || res.Err != nil {
+			if initRes, err := c.initializeCluster(ctx, l, node); err != nil || initRes.Err != nil {
 				// If err is non-nil, then this will not be retried, but if res.Err is non-nil, it will be.
-				return res, err
+				return initRes, errors.CombineErrors(err, res.Err)
 			}
 		}
-		return c.setClusterSettings(ctx, l, node, startOpts.VirtualClusterName)
+
+		if startOpts.GetInitTarget() == node {
+			res, err = c.createAdminUserForSecureCluster(ctx, l, startOpts)
+			if err != nil || res.Err != nil {
+				return res, errors.CombineErrors(err, res.Err)
+			}
+
+			return c.setClusterSettings(ctx, l, node, startOpts.VirtualClusterName)
+		}
+
+		return res, err
 	}, WithConcurrency(parallelism)); err != nil {
 		return err
 	}
@@ -935,6 +950,62 @@ func (c *SyncedCluster) initializeCluster(
 		}
 	}
 	return res, err
+}
+
+// createAdminUserForSecureCluster creates a `roach` user with admin
+// privileges. The password used matches the virtual cluster name
+// ('system' for the storage cluster).
+func (c *SyncedCluster) createAdminUserForSecureCluster(
+	ctx context.Context, l *logger.Logger, startOpts StartOpts,
+) (*RunResultDetails, error) {
+	if !c.Secure {
+		return &RunResultDetails{}, nil
+	}
+
+	const username = "roach"
+	// N.B.: we cannot reuse username and password combinations across
+	// the system interface and virtual clusters due to #109691.
+	var password = startOpts.VirtualClusterName
+	if startOpts.VirtualClusterName == "" {
+		password = SystemInterfaceName
+	}
+
+	stmts := strings.Join([]string{
+		fmt.Sprintf("CREATE USER IF NOT EXISTS %s WITH LOGIN PASSWORD '%s'", username, password),
+		fmt.Sprintf("GRANT ADMIN TO %s", username),
+	}, "; ")
+
+	var result *RunResultDetails
+	// We retry a few times here because cockroach process might not be
+	// ready to serve connections at this point. We also can't use
+	// `COCKROACH_CONNECT_TIMEOUT` in this case because that would not
+	// work for shared-process virtual clusters.
+	retryOpts := retry.Options{MaxRetries: 20}
+	if err := retryOpts.Do(ctx, func(ctx context.Context) error {
+		results, err := c.ExecSQL(
+			ctx, l, c.Nodes[:1], startOpts.VirtualClusterName, startOpts.SQLInstance, []string{
+				"-e", stmts,
+			})
+
+		if err != nil || results[0].Err != nil {
+			err := errors.CombineErrors(err, results[0].Err)
+			l.Printf("error (retrying): %v, output: %s", err, results[0].CombinedOut)
+			return err
+		}
+
+		result = results[0]
+		return nil
+	}); err != nil {
+		return &RunResultDetails{}, fmt.Errorf("failed to create default admin user: %w", err)
+	}
+
+	var virtualClusterInfo string
+	if startOpts.VirtualClusterName != "" && startOpts.VirtualClusterName != SystemInterfaceName {
+		virtualClusterInfo = fmt.Sprintf(" for virtual cluster %s", startOpts.VirtualClusterName)
+	}
+
+	l.Printf("log into DB console%s with user=%s password=%s", virtualClusterInfo, username, password)
+	return result, nil
 }
 
 func (c *SyncedCluster) setClusterSettings(

--- a/pkg/roachprod/multitenant.go
+++ b/pkg/roachprod/multitenant.go
@@ -74,9 +74,9 @@ func StartServiceForVirtualCluster(
 
 // StopServiceForVirtualCluster stops SQL instance processes on the virtualCluster given.
 func StopServiceForVirtualCluster(
-	ctx context.Context, l *logger.Logger, clusterName string, stopOpts StopOpts,
+	ctx context.Context, l *logger.Logger, clusterName string, secure bool, stopOpts StopOpts,
 ) error {
-	c, err := newCluster(l, clusterName)
+	c, err := newCluster(l, clusterName, install.SecureOption(secure))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This commit adds a default admin user to clusters created with roachprod; this applies both to the system interface, as well as virtual clusters (shared or separate process).

This is mostly done for convenience, so that roachprod users can have easy access to the dbconsole. It is also helpful while running roachtests.

Epic: none

Release note: None