### PR TITLE
log: fix stacktrace test goroutine counts

### DIFF
--- a/pkg/util/log/clog_test.go
+++ b/pkg/util/log/clog_test.go
@@ -586,17 +586,23 @@ func TestFatalStacktraceStderr(t *testing.T) {
 			if !strings.Contains(cont, "clog_test") {
 				t.Fatalf("stack trace does not contain file name: %s", cont)
 			}
+
+			// NB: the string "!goroutine" is used here in order to match the
+			// goroutine headers in the formatted output. The stacktrace
+			// itself can sometimes contain the string `goroutine` if one
+			// goroutine is spawned from another due to
+			// https://github.com/golang/go/commit/51225f6fc648ba3e833f3493700c2996a816bdaa
 			switch traceback {
 			case tracebackNone:
-				if strings.Count(cont, "goroutine ") > 0 {
+				if strings.Count(cont, "!goroutine ") > 0 {
 					t.Fatalf("unexpected stack trace:\n%s", cont)
 				}
 			case tracebackSingle:
-				if strings.Count(cont, "goroutine ") != 1 {
+				if strings.Count(cont, "!goroutine ") != 1 {
 					t.Fatalf("stack trace contains too many goroutines: %s", cont)
 				}
 			case tracebackAll:
-				if strings.Count(cont, "goroutine ") < 2 {
+				if strings.Count(cont, "!goroutine ") < 2 {
 					t.Fatalf("stack trace contains less than two goroutines: %s", cont)
 				}
 			}


### PR DESCRIPTION
Previously, we would use the count of the string `goroutine ` as a proxy for the number of goroutines in the stacktrace. This stopped working in go 1.21 due to this change:
https://github.com/golang/go/commit/51225f6fc648ba3e833f3493700c2996a816bdaa

We should consider using a stacktrace parser in the future.

Supports #112088

Epic: None
Release note: None