### PR TITLE
release-23.1: roachprod: virtual cluster support work

### DIFF
--- a/pkg/cmd/roachprod/flags.go
+++ b/pkg/cmd/roachprod/flags.go
@@ -49,7 +49,6 @@ var (
 	secure                = false
 	virtualClusterName    string
 	sqlInstance           int
-	virtualClusterID      int
 	extraSSHOptions       = ""
 	nodeEnv               []string
 	tag                   string
@@ -212,8 +211,6 @@ Default is "RECURRING '*/15 * * * *' FULL BACKUP '@hourly' WITH SCHEDULE OPTIONS
 
 	startInstanceCmd.Flags().StringVarP(&storageCluster, "storage-cluster", "S", "", "storage cluster")
 	_ = startInstanceCmd.MarkFlagRequired("storage-cluster")
-	startInstanceCmd.Flags().IntVarP(&startOpts.VirtualClusterID,
-		"cluster-id", "i", startOpts.VirtualClusterID, "internal ID for the virtual cluster")
 	startInstanceCmd.Flags().IntVar(&startOpts.SQLInstance,
 		"sql-instance", 0, "specific SQL/HTTP instance to connect to (this is a roachprod abstraction for separate-process deployments distinct from the internal instance ID)")
 	startInstanceCmd.Flags().StringVar(&externalProcessNodes, "external-cluster", externalProcessNodes, "start service in external mode, as a separate process in the given nodes")
@@ -224,9 +221,6 @@ Default is "RECURRING '*/15 * * * *' FULL BACKUP '@hourly' WITH SCHEDULE OPTIONS
 		stopProcessesCmd.Flags().BoolVar(&waitFlag, "wait", waitFlag, "wait for processes to exit")
 		stopProcessesCmd.Flags().IntVar(&maxWait, "max-wait", maxWait, "approx number of seconds to wait for processes to exit")
 	}
-
-	stopInstanceCmd.Flags().IntVarP(&virtualClusterID, "cluster-id", "t", virtualClusterID, "internal ID for the virtual cluster")
-	stopInstanceCmd.Flags().IntVar(&sqlInstance, "sql-instance", 0, "specific SQL/HTTP instance to stop")
 
 	syncCmd.Flags().BoolVar(&listOpts.IncludeVolumes, "include-volumes", false, "Include volumes when syncing")
 
@@ -355,7 +349,7 @@ Default is "RECURRING '*/15 * * * *' FULL BACKUP '@hourly' WITH SCHEDULE OPTIONS
 		cmd.Flags().BoolVar(&secure,
 			"secure", false, "use a secure cluster")
 	}
-	for _, cmd := range []*cobra.Command{pgurlCmd, sqlCmd, adminurlCmd} {
+	for _, cmd := range []*cobra.Command{pgurlCmd, sqlCmd, adminurlCmd, stopInstanceCmd} {
 		cmd.Flags().StringVar(&virtualClusterName,
 			"cluster", "", "specific virtual cluster to connect to")
 		cmd.Flags().IntVar(&sqlInstance,

--- a/pkg/cmd/roachprod/flags.go
+++ b/pkg/cmd/roachprod/flags.go
@@ -325,7 +325,7 @@ Default is "RECURRING '*/15 * * * *' FULL BACKUP '@hourly' WITH SCHEDULE OPTIONS
 	}
 
 	for _, cmd := range []*cobra.Command{
-		startCmd, statusCmd, stopCmd, runCmd,
+		startCmd, startInstanceAsSeparateProcessCmd, statusCmd, stopCmd, runCmd,
 	} {
 		cmd.Flags().StringVar(&tag, "tag", "", "the process tag")
 	}

--- a/pkg/cmd/roachprod/flags.go
+++ b/pkg/cmd/roachprod/flags.go
@@ -219,14 +219,14 @@ Default is "RECURRING '*/15 * * * *' FULL BACKUP '@hourly' WITH SCHEDULE OPTIONS
 	startInstanceCmd.Flags().StringVar(&externalProcessNodes, "external-cluster", externalProcessNodes, "start service in external mode, as a separate process in the given nodes")
 
 	// Flags for processes that stop (kill) processes.
-	for _, stopProcessesCmd := range []*cobra.Command{stopCmd, stopInstanceAsSeparateProcessCmd} {
+	for _, stopProcessesCmd := range []*cobra.Command{stopCmd, stopInstanceCmd} {
 		stopProcessesCmd.Flags().IntVar(&sig, "sig", sig, "signal to pass to kill")
 		stopProcessesCmd.Flags().BoolVar(&waitFlag, "wait", waitFlag, "wait for processes to exit")
 		stopProcessesCmd.Flags().IntVar(&maxWait, "max-wait", maxWait, "approx number of seconds to wait for processes to exit")
 	}
 
-	stopInstanceAsSeparateProcessCmd.Flags().IntVarP(&virtualClusterID, "cluster-id", "t", virtualClusterID, "internal ID for the virtual cluster")
-	stopInstanceAsSeparateProcessCmd.Flags().IntVar(&sqlInstance, "sql-instance", 0, "specific SQL/HTTP instance to stop")
+	stopInstanceCmd.Flags().IntVarP(&virtualClusterID, "cluster-id", "t", virtualClusterID, "internal ID for the virtual cluster")
+	stopInstanceCmd.Flags().IntVar(&sqlInstance, "sql-instance", 0, "specific SQL/HTTP instance to stop")
 
 	syncCmd.Flags().BoolVar(&listOpts.IncludeVolumes, "include-volumes", false, "Include volumes when syncing")
 

--- a/pkg/cmd/roachprod/flags.go
+++ b/pkg/cmd/roachprod/flags.go
@@ -81,6 +81,9 @@ var (
 
 	// storageCluster is used for cluster virtualization and multi-tenant functionality.
 	storageCluster string
+	// externalProcessNodes indicates the cluster/nodes where external
+	// process SQL instances should be deployed.
+	externalProcessNodes string
 )
 
 func initFlags() {
@@ -207,13 +210,13 @@ func initFlags() {
 		`Recurrence and scheduled backup options specification.
 Default is "RECURRING '*/15 * * * *' FULL BACKUP '@hourly' WITH SCHEDULE OPTIONS first_run = 'now'"`)
 
-	startInstanceAsSeparateProcessCmd.Flags().StringVarP(&storageCluster,
-		"storage-cluster", "S", "", "storage cluster")
-	_ = startInstanceAsSeparateProcessCmd.MarkFlagRequired("storage-cluster")
-	startInstanceAsSeparateProcessCmd.Flags().IntVarP(&startOpts.VirtualClusterID,
+	startInstanceCmd.Flags().StringVarP(&storageCluster, "storage-cluster", "S", "", "storage cluster")
+	_ = startInstanceCmd.MarkFlagRequired("storage-cluster")
+	startInstanceCmd.Flags().IntVarP(&startOpts.VirtualClusterID,
 		"cluster-id", "i", startOpts.VirtualClusterID, "internal ID for the virtual cluster")
-	startInstanceAsSeparateProcessCmd.Flags().IntVar(&startOpts.SQLInstance,
-		"sql-instance", 0, "specific SQL/HTTP instance to connect to (this is a roachprod abstraction distinct from the internal instance ID)")
+	startInstanceCmd.Flags().IntVar(&startOpts.SQLInstance,
+		"sql-instance", 0, "specific SQL/HTTP instance to connect to (this is a roachprod abstraction for separate-process deployments distinct from the internal instance ID)")
+	startInstanceCmd.Flags().StringVar(&externalProcessNodes, "external-cluster", externalProcessNodes, "start service in external mode, as a separate process in the given nodes")
 
 	// Flags for processes that stop (kill) processes.
 	for _, stopProcessesCmd := range []*cobra.Command{stopCmd, stopInstanceAsSeparateProcessCmd} {
@@ -324,7 +327,7 @@ Default is "RECURRING '*/15 * * * *' FULL BACKUP '@hourly' WITH SCHEDULE OPTIONS
 			&ssh.InsecureIgnoreHostKey, "insecure-ignore-host-key", true, "don't check ssh host keys")
 	}
 
-	for _, cmd := range []*cobra.Command{startCmd, startInstanceAsSeparateProcessCmd} {
+	for _, cmd := range []*cobra.Command{startCmd, startInstanceCmd} {
 		cmd.Flags().BoolVar(&startOpts.Sequential,
 			"sequential", startOpts.Sequential, "start nodes sequentially so node IDs match hostnames")
 		cmd.Flags().Int64Var(&startOpts.NumFilesLimit, "num-files-limit", startOpts.NumFilesLimit,
@@ -332,7 +335,7 @@ Default is "RECURRING '*/15 * * * *' FULL BACKUP '@hourly' WITH SCHEDULE OPTIONS
 	}
 
 	for _, cmd := range []*cobra.Command{
-		startCmd, startInstanceAsSeparateProcessCmd, statusCmd, stopCmd, runCmd,
+		startCmd, startInstanceCmd, statusCmd, stopCmd, runCmd,
 	} {
 		cmd.Flags().StringVar(&tag, "tag", "", "the process tag")
 	}
@@ -348,7 +351,7 @@ Default is "RECURRING '*/15 * * * *' FULL BACKUP '@hourly' WITH SCHEDULE OPTIONS
 		cmd.Flags().StringVarP(&config.Binary,
 			"binary", "b", config.Binary, "the remote cockroach binary to use")
 	}
-	for _, cmd := range []*cobra.Command{startCmd, startInstanceAsSeparateProcessCmd, sqlCmd, pgurlCmd, adminurlCmd, runCmd} {
+	for _, cmd := range []*cobra.Command{startCmd, startInstanceCmd, sqlCmd, pgurlCmd, adminurlCmd, runCmd} {
 		cmd.Flags().BoolVar(&secure,
 			"secure", false, "use a secure cluster")
 	}

--- a/pkg/cmd/roachprod/flags.go
+++ b/pkg/cmd/roachprod/flags.go
@@ -49,6 +49,7 @@ var (
 	secure                = false
 	virtualClusterName    string
 	sqlInstance           int
+	virtualClusterID      int
 	extraSSHOptions       = ""
 	nodeEnv               []string
 	tag                   string
@@ -214,9 +215,15 @@ Default is "RECURRING '*/15 * * * *' FULL BACKUP '@hourly' WITH SCHEDULE OPTIONS
 	startInstanceAsSeparateProcessCmd.Flags().IntVar(&startOpts.SQLInstance,
 		"sql-instance", 0, "specific SQL/HTTP instance to connect to (this is a roachprod abstraction distinct from the internal instance ID)")
 
-	stopCmd.Flags().IntVar(&sig, "sig", sig, "signal to pass to kill")
-	stopCmd.Flags().BoolVar(&waitFlag, "wait", waitFlag, "wait for processes to exit")
-	stopCmd.Flags().IntVar(&maxWait, "max-wait", maxWait, "approx number of seconds to wait for processes to exit")
+	// Flags for processes that stop (kill) processes.
+	for _, stopProcessesCmd := range []*cobra.Command{stopCmd, stopInstanceAsSeparateProcessCmd} {
+		stopProcessesCmd.Flags().IntVar(&sig, "sig", sig, "signal to pass to kill")
+		stopProcessesCmd.Flags().BoolVar(&waitFlag, "wait", waitFlag, "wait for processes to exit")
+		stopProcessesCmd.Flags().IntVar(&maxWait, "max-wait", maxWait, "approx number of seconds to wait for processes to exit")
+	}
+
+	stopInstanceAsSeparateProcessCmd.Flags().IntVarP(&virtualClusterID, "cluster-id", "t", virtualClusterID, "internal ID for the virtual cluster")
+	stopInstanceAsSeparateProcessCmd.Flags().IntVar(&sqlInstance, "sql-instance", 0, "specific SQL/HTTP instance to stop")
 
 	syncCmd.Flags().BoolVar(&listOpts.IncludeVolumes, "include-volumes", false, "Include volumes when syncing")
 

--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -478,6 +478,15 @@ environment variables to the cockroach process.
 			install.EnvOption(nodeEnv),
 			install.NumRacksOption(numRacks),
 		}
+
+		// Always pick a random available port when starting virtual
+		// clusters. We do not expose the functionality of choosing a
+		// specific port, so this is fine.
+		//
+		// TODO(renato): remove this once #111052 is addressed.
+		startOpts.SQLPort = 0
+		startOpts.AdminUIPort = 0
+
 		return roachprod.StartServiceForVirtualCluster(context.Background(),
 			config.Logger, targetRoachprodCluster, storageCluster, startOpts, clusterSettingsOpts...)
 	}),

--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -421,6 +421,7 @@ shutdown cockroach. The --wait flag causes stop to loop waiting for all
 processes with the right ROACHPROD environment variable to exit. Note that stop
 will wait forever if you specify --wait with a non-terminating signal (e.g.
 SIGHUP), unless you also configure --max-wait.
+
 --wait defaults to true for signal 9 (SIGKILL) and false for all other signals.
 ` + tagHelp + `
 `,
@@ -479,6 +480,43 @@ environment variables to the cockroach process.
 		}
 		return roachprod.StartServiceForVirtualCluster(context.Background(),
 			config.Logger, targetRoachprodCluster, storageCluster, startOpts, clusterSettingsOpts...)
+	}),
+}
+
+var stopInstanceAsSeparateProcessCmd = &cobra.Command{
+	Use:   "stop-sql <virtual-cluster> --tenant-id <id> --sql-instance <instance> [--sig] [--wait]",
+	Short: "stop sql instances on a cluster",
+	Long: `Stop sql instances on a cluster.
+
+Stop roachprod created sql instances running on the nodes in a cluster. Every
+process started by roachprod is tagged with a ROACHPROD environment variable
+which is used by "stop-sql" to locate the processes and terminate them. By default,
+processes are killed with signal 9 (SIGKILL) giving them no chance for a graceful
+exit.
+
+The --sig flag will pass a signal to kill to allow us finer control over how we
+shutdown processes. The --wait flag causes stop to loop waiting for all
+processes with the right ROACHPROD environment variable to exit. Note that stop
+will wait forever if you specify --wait with a non-terminating signal (e.g.
+SIGHUP), unless you also configure --max-wait.
+
+--wait defaults to true for signal 9 (SIGKILL) and false for all other signals.
+`,
+	Args: cobra.ExactArgs(1),
+	Run: wrap(func(cmd *cobra.Command, args []string) error {
+		wait := waitFlag
+		if sig == 9 /* SIGKILL */ && !cmd.Flags().Changed("wait") {
+			wait = true
+		}
+		stopOpts := roachprod.StopOpts{
+			Wait:             wait,
+			MaxWait:          maxWait,
+			Sig:              sig,
+			VirtualClusterID: virtualClusterID,
+			SQLInstance:      sqlInstance,
+		}
+		virtualCluster := args[0]
+		return roachprod.StopServiceForVirtualCluster(context.Background(), config.Logger, virtualCluster, stopOpts)
 	}),
 }
 
@@ -589,7 +627,7 @@ of nodes, outputting a line whenever a change is detected:
 var signalCmd = &cobra.Command{
 	Use:   "signal <cluster> <signal>",
 	Short: "send signal to cluster",
-	Long:  "Send a POSIX signal to the nodes in a cluster, specified by its integer code.",
+	Long:  "Send a POSIX signal, specified by its integer code, to every process started via roachprod in a cluster.",
 	Args:  cobra.ExactArgs(2),
 	Run: wrap(func(cmd *cobra.Command, args []string) error {
 		sig, err := strconv.ParseInt(args[1], 10, 8)
@@ -1122,6 +1160,7 @@ func main() {
 		startCmd,
 		stopCmd,
 		startInstanceAsSeparateProcessCmd,
+		stopInstanceAsSeparateProcessCmd,
 		initCmd,
 		runCmd,
 		signalCmd,

--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -436,10 +436,8 @@ SIGHUP), unless you also configure --max-wait.
 	}),
 }
 
-// TODO(herko/renato): maybe also support adding SQL instances to a
-// shared-process node.
-var startInstanceAsSeparateProcessCmd = &cobra.Command{
-	Use:   "start-sql <virtual-cluster-nodes> --storage-cluster <storage-cluster>",
+var startInstanceCmd = &cobra.Command{
+	Use:   "start-sql --storage-cluster <storage-cluster> [--external-cluster <virtual-cluster-nodes]",
 	Short: "start the SQL/HTTP service for a virtual cluster as a separate process",
 	Long: `Start SQL/HTTP instances for a virtual cluster as separate processes.
 
@@ -451,25 +449,30 @@ node, the --sql-instance flag must be passed to differentiate them.
 
 The --cluster-id flag can be used to specify the tenant ID; it defaults to 2.
 
+The instance is started in shared process (in memory) mode by
+default. To start an external process instance, pass the
+--external-cluster flag indicating where the SQL server processes
+should be started.
+
 The --secure flag can be used to start nodes in secure mode (i.e. using
 certs). When specified, there is a one time initialization for the cluster to
 create and distribute the certs. Note that running some modes in secure mode
 and others in insecure mode is not a supported Cockroach configuration.
 
-As a debugging aid, the --sequential flag starts the nodes sequentially so node
-IDs match hostnames. Otherwise nodes are started in parallel.
+As a debugging aid, the --sequential flag starts the services
+sequentially; otherwise services are started in parallel.
 
-The --binary flag specifies the remote binary to run. It is up to the roachprod
-user to ensure this binary exists, usually via "roachprod put". Note that no
-cockroach software is installed by default on a newly created cluster.
+The --binary flag specifies the remote binary to run, if starting
+external services. It is up to the roachprod user to ensure this
+binary exists, usually via "roachprod put". Note that no cockroach
+software is installed by default on a newly created cluster.
 
 The --args and --env flags can be used to pass arbitrary command line flags and
 environment variables to the cockroach process.
 ` + tagHelp + `
 `,
-	Args: cobra.ExactArgs(1),
+	Args: cobra.NoArgs,
 	Run: wrap(func(cmd *cobra.Command, args []string) error {
-		targetRoachprodCluster := args[0]
 		clusterSettingsOpts := []install.ClusterSettingOption{
 			install.TagOption(tag),
 			install.PGUrlCertsDirOption(pgurlCertsDir),
@@ -481,14 +484,21 @@ environment variables to the cockroach process.
 
 		// Always pick a random available port when starting virtual
 		// clusters. We do not expose the functionality of choosing a
-		// specific port, so this is fine.
+		// specific port for separate-process deployments; for
+		// shared-process, the port will always be based on the system
+		// tenant service.
 		//
 		// TODO(renato): remove this once #111052 is addressed.
 		startOpts.SQLPort = 0
 		startOpts.AdminUIPort = 0
 
+		startOpts.Target = install.StartSharedProcessForVirtualCluster
+		if externalProcessNodes != "" {
+			startOpts.Target = install.StartServiceForVirtualCluster
+		}
+
 		return roachprod.StartServiceForVirtualCluster(context.Background(),
-			config.Logger, targetRoachprodCluster, storageCluster, startOpts, clusterSettingsOpts...)
+			config.Logger, externalProcessNodes, storageCluster, startOpts, clusterSettingsOpts...)
 	}),
 }
 
@@ -1168,7 +1178,7 @@ func main() {
 		monitorCmd,
 		startCmd,
 		stopCmd,
-		startInstanceAsSeparateProcessCmd,
+		startInstanceCmd,
 		stopInstanceAsSeparateProcessCmd,
 		initCmd,
 		runCmd,

--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -439,7 +439,7 @@ SIGHUP), unless you also configure --max-wait.
 // TODO(herko/renato): maybe also support adding SQL instances to a
 // shared-process node.
 var startInstanceAsSeparateProcessCmd = &cobra.Command{
-	Use:   "start-sql <virtual-cluster> --storage-cluster <storage-cluster>",
+	Use:   "start-sql <virtual-cluster-nodes> --storage-cluster <storage-cluster>",
 	Short: "start the SQL/HTTP service for a virtual cluster as a separate process",
 	Long: `Start SQL/HTTP instances for a virtual cluster as separate processes.
 
@@ -449,7 +449,7 @@ will create the virtual cluster on the storage cluster if it does not
 exist already.  If creating multiple virtual clusters on the same
 node, the --sql-instance flag must be passed to differentiate them.
 
-The --tenant-id flag can be used to specify the tenant ID; it defaults to 2.
+The --cluster-id flag can be used to specify the tenant ID; it defaults to 2.
 
 The --secure flag can be used to start nodes in secure mode (i.e. using
 certs). When specified, there is a one time initialization for the cluster to

--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -502,22 +502,19 @@ environment variables to the cockroach process.
 	}),
 }
 
-var stopInstanceAsSeparateProcessCmd = &cobra.Command{
-	Use:   "stop-sql <virtual-cluster> --tenant-id <id> --sql-instance <instance> [--sig] [--wait]",
+var stopInstanceCmd = &cobra.Command{
+	Use:   "stop-sql <cluster> --cluster-id <id> --sql-instance <instance> [--sig] [--wait]",
 	Short: "stop sql instances on a cluster",
 	Long: `Stop sql instances on a cluster.
 
-Stop roachprod created sql instances running on the nodes in a cluster. Every
-process started by roachprod is tagged with a ROACHPROD environment variable
-which is used by "stop-sql" to locate the processes and terminate them. By default,
-processes are killed with signal 9 (SIGKILL) giving them no chance for a graceful
-exit.
+Stop roachprod created virtual clusters (shared or separate process). By default,
+separate processes are killed with signal 9 (SIGKILL) giving them no chance for a
+graceful exit.
 
 The --sig flag will pass a signal to kill to allow us finer control over how we
 shutdown processes. The --wait flag causes stop to loop waiting for all
-processes with the right ROACHPROD environment variable to exit. Note that stop
-will wait forever if you specify --wait with a non-terminating signal (e.g.
-SIGHUP), unless you also configure --max-wait.
+processes to exit. Note that stop will wait forever if you specify --wait with a
+non-terminating signal (e.g. SIGHUP), unless you also configure --max-wait.
 
 --wait defaults to true for signal 9 (SIGKILL) and false for all other signals.
 `,
@@ -534,8 +531,8 @@ SIGHUP), unless you also configure --max-wait.
 			VirtualClusterID: virtualClusterID,
 			SQLInstance:      sqlInstance,
 		}
-		virtualCluster := args[0]
-		return roachprod.StopServiceForVirtualCluster(context.Background(), config.Logger, virtualCluster, stopOpts)
+		clusterName := args[0]
+		return roachprod.StopServiceForVirtualCluster(context.Background(), config.Logger, clusterName, stopOpts)
 	}),
 }
 
@@ -1179,7 +1176,7 @@ func main() {
 		startCmd,
 		stopCmd,
 		startInstanceCmd,
-		stopInstanceAsSeparateProcessCmd,
+		stopInstanceCmd,
 		initCmd,
 		runCmd,
 		signalCmd,

--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -445,9 +445,8 @@ var startInstanceAsSeparateProcessCmd = &cobra.Command{
 The --storage-cluster flag must be used to specify a storage cluster
 (with optional node selector) which is already running. The command
 will create the virtual cluster on the storage cluster if it does not
-exist already. The storage cluster and virtual cluster can use the
-same underlying roachprod VM cluster, as long as different subsets of
-nodes are selected.
+exist already.  If creating multiple virtual clusters on the same
+node, the --sql-instance flag must be passed to differentiate them.
 
 The --tenant-id flag can be used to specify the tenant ID; it defaults to 2.
 

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -1397,17 +1397,22 @@ func (c *clusterImpl) assertNoDeadNode(ctx context.Context, t test.Test) error {
 		return err
 	}
 
-	deadNodes := 0
+	deadProcesses := 0
 	for info := range eventsCh {
 		t.L().Printf("%s", info)
 
-		if _, isDeath := info.Event.(install.MonitorNodeDead); isDeath {
-			deadNodes++
+		if _, isDeath := info.Event.(install.MonitorProcessDead); isDeath {
+			deadProcesses++
 		}
 	}
 
-	if deadNodes > 0 {
-		return errors.Newf("%d dead node(s) detected", deadNodes)
+	var plural string
+	if deadProcesses > 1 {
+		plural = "es"
+	}
+
+	if deadProcesses > 0 {
+		return errors.Newf("%d dead cockroach process%s detected", deadProcesses, plural)
 	}
 	return nil
 }

--- a/pkg/cmd/roachtest/monitor.go
+++ b/pkg/cmd/roachtest/monitor.go
@@ -168,7 +168,7 @@ func (m *monitorImpl) startNodeMonitor() {
 			}
 
 			for info := range eventsCh {
-				_, isDeath := info.Event.(install.MonitorNodeDead)
+				_, isDeath := info.Event.(install.MonitorProcessDead)
 				isExpectedDeath := isDeath && atomic.AddInt32(&m.expDeaths, -1) >= 0
 				var expectedDeathStr string
 				if isExpectedDeath {

--- a/pkg/cmd/roachtest/roachtestutil/BUILD.bazel
+++ b/pkg/cmd/roachtest/roachtestutil/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
         "disk_usage.go",
         "health_checker.go",
         "jaeger.go",
+        "utils.go",
         "validation_check.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil",

--- a/pkg/cmd/roachtest/roachtestutil/clusterupgrade/BUILD.bazel
+++ b/pkg/cmd/roachtest/roachtestutil/clusterupgrade/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/clusterupgrade",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/build",
         "//pkg/cmd/roachtest/cluster",
         "//pkg/cmd/roachtest/option",
         "//pkg/cmd/roachtest/test",

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion_test.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion_test.go
@@ -16,8 +16,8 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/clusterupgrade"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
-	"github.com/cockroachdb/cockroach/pkg/util/version"
 	"github.com/stretchr/testify/require"
 )
 
@@ -103,14 +103,14 @@ func Test_choosePreviousReleases(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			mvt := newTest()
 			mvt._arch = &tc.arch
-			mvt.predecessorFunc = func(_ *rand.Rand, _ *version.Version, _ int) ([]string, error) {
-				return tc.predecessorHistory, tc.predecessorErr
+			mvt.predecessorFunc = func(_ *rand.Rand, _ *clusterupgrade.Version, _ int) ([]*clusterupgrade.Version, error) {
+				return parseVersions(tc.predecessorHistory), tc.predecessorErr
 			}
 
 			releases, err := mvt.choosePreviousReleases()
 			if tc.expectedErr == "" {
 				require.NoError(t, err)
-				require.Equal(t, tc.expectedReleases, releases)
+				require.Equal(t, parseVersions(tc.expectedReleases), releases)
 			} else {
 				require.Error(t, err)
 				require.Equal(t, tc.expectedErr, err.Error())

--- a/pkg/cmd/roachtest/roachtestutil/utils.go
+++ b/pkg/cmd/roachtest/roachtestutil/utils.go
@@ -1,0 +1,19 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package roachtestutil
+
+import "github.com/cockroachdb/cockroach/pkg/roachprod/install"
+
+// SystemInterfaceSystemdUnitName is a convenience function that
+// returns the systemd unit name for the system interface
+func SystemInterfaceSystemdUnitName() string {
+	return install.VirtualClusterLabel(install.SystemInterfaceName, 0)
+}

--- a/pkg/cmd/roachtest/tests/backup_restore_roundtrip.go
+++ b/pkg/cmd/roachtest/tests/backup_restore_roundtrip.go
@@ -60,7 +60,7 @@ func backupRestoreRoundTrip(ctx context.Context, t test.Test, c cluster.Cluster)
 	t.L().Printf("random seed: %d", seed)
 
 	// Upload binaries and start cluster.
-	uploadVersion(ctx, t, c, c.All(), clusterupgrade.MainVersion)
+	uploadVersion(ctx, t, c, c.All(), clusterupgrade.CurrentVersion())
 
 	c.Start(ctx, t.L(), option.DefaultStartOptsNoBackups(), install.MakeClusterSettings(install.SecureOption(true)), roachNodes)
 	m := c.NewMonitor(ctx, roachNodes)
@@ -101,7 +101,7 @@ func backupRestoreRoundTrip(ctx context.Context, t test.Test, c cluster.Cluster)
 		}
 
 		for i := 0; i < numFullBackups; i++ {
-			allNodes := labeledNodes{Nodes: roachNodes, Version: clusterupgrade.MainVersion}
+			allNodes := labeledNodes{Nodes: roachNodes, Version: clusterupgrade.CurrentVersion().String()}
 			bspec := backupSpec{
 				PauseProbability: pauseProbability,
 				Plan:             allNodes,
@@ -125,7 +125,7 @@ func backupRestoreRoundTrip(ctx context.Context, t test.Test, c cluster.Cluster)
 					m.ExpectDeaths(int32(n))
 				}
 
-				if err := testUtils.resetCluster(ctx, t.L(), clusterupgrade.MainVersion, expectDeathsFn); err != nil {
+				if err := testUtils.resetCluster(ctx, t.L(), clusterupgrade.CurrentVersion(), expectDeathsFn); err != nil {
 					return err
 				}
 			}

--- a/pkg/cmd/roachtest/tests/decommission_self.go
+++ b/pkg/cmd/roachtest/tests/decommission_self.go
@@ -24,9 +24,9 @@ import (
 func runDecommissionSelf(ctx context.Context, t test.Test, c cluster.Cluster) {
 	allNodes := c.All()
 	u := newVersionUpgradeTest(c,
-		uploadVersionStep(allNodes, clusterupgrade.MainVersion),
-		startVersion(allNodes, clusterupgrade.MainVersion),
-		fullyDecommissionStep(2, 2, clusterupgrade.MainVersion),
+		uploadVersionStep(allNodes, clusterupgrade.CurrentVersion()),
+		startVersion(allNodes, clusterupgrade.CurrentVersion()),
+		fullyDecommissionStep(2, 2, clusterupgrade.CurrentVersion()),
 		func(ctx context.Context, t test.Test, u *versionUpgradeTest) {
 			// Stop n2 and exclude it from post-test consistency checks,
 			// as this node can't contact cluster any more and operations

--- a/pkg/cmd/roachtest/tests/decommissionbench.go
+++ b/pkg/cmd/roachtest/tests/decommissionbench.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
@@ -942,8 +943,8 @@ func runSingleDecommission(
 		if err := h.c.RunE(
 			ctx, h.c.Node(target),
 			fmt.Sprintf("sudo bash -c 'echo \"259:0  %d\" > "+
-				"/sys/fs/cgroup/blkio/system.slice/cockroach.service/blkio.throttle.write_bps_device'",
-				100*(1<<20))); err != nil {
+				"/sys/fs/cgroup/blkio/system.slice/%s.service/blkio.throttle.write_bps_device'",
+				100*(1<<20), roachtestutil.SystemInterfaceSystemdUnitName())); err != nil {
 			return err
 		}
 		// Wait for some time after limiting write bandwidth in order to affect read amplification.

--- a/pkg/cmd/roachtest/tests/disk_full.go
+++ b/pkg/cmd/roachtest/tests/disk_full.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -117,9 +118,10 @@ func registerDiskFull(r registry.Registry) {
 					// propagated from roachprod, obscures the Cockroach
 					// exit code. There should still be a record of it
 					// in the systemd logs.
-					result, err := c.RunWithDetailsSingleNode(ctx, t.L(), c.Node(n),
-						`systemctl status cockroach.service | grep 'Main PID' | grep -oE '\((.+)\)'`,
-					)
+					result, err := c.RunWithDetailsSingleNode(ctx, t.L(), c.Node(n), fmt.Sprintf(
+						`systemctl status %s | grep 'Main PID' | grep -oE '\((.+)\)'`,
+						roachtestutil.SystemInterfaceSystemdUnitName(),
+					))
 					if err != nil {
 						t.Fatal(err)
 					}

--- a/pkg/cmd/roachtest/tests/disk_stall.go
+++ b/pkg/cmd/roachtest/tests/disk_stall.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
@@ -252,8 +253,8 @@ func getProcessExitMonotonic(
 func getProcessMonotonicTimestamp(
 	ctx context.Context, t test.Test, c cluster.Cluster, nodeID int, prop string,
 ) (time.Duration, bool) {
-	details, err := c.RunWithDetailsSingleNode(ctx, t.L(), c.Node(nodeID),
-		"systemctl show cockroach.service --property="+prop)
+	details, err := c.RunWithDetailsSingleNode(ctx, t.L(), c.Node(nodeID), fmt.Sprintf(
+		"systemctl show %s --property=%s", roachtestutil.SystemInterfaceSystemdUnitName(), prop))
 	require.NoError(t, err)
 	require.NoError(t, details.Err)
 	parts := strings.Split(details.Stdout, "=")

--- a/pkg/cmd/roachtest/tests/follower_reads.go
+++ b/pkg/cmd/roachtest/tests/follower_reads.go
@@ -895,7 +895,9 @@ func runFollowerReadsMixedVersionSingleRegionTest(
 
 	// Start the cluster at the old version.
 	settings := install.MakeClusterSettings()
-	settings.Binary = uploadVersion(ctx, t, c, c.All(), predecessorVersion)
+	settings.Binary = uploadVersion(
+		ctx, t, c, c.All(), clusterupgrade.MustParseVersion(predecessorVersion),
+	)
 	startOpts := option.DefaultStartOpts()
 	c.Start(ctx, t.L(), startOpts, settings, c.All())
 	topology := topologySpec{multiRegion: false}
@@ -905,7 +907,7 @@ func runFollowerReadsMixedVersionSingleRegionTest(
 	randNode := 1 + rand.Intn(c.Spec().NodeCount)
 	t.L().Printf("upgrading n%d to current version", randNode)
 	nodeToUpgrade := c.Node(randNode)
-	upgradeNodes(ctx, t, c, nodeToUpgrade, startOpts, clusterupgrade.MainVersion)
+	upgradeNodes(ctx, t, c, nodeToUpgrade, startOpts, clusterupgrade.CurrentVersion())
 	runFollowerReadsTest(ctx, t, c, topologySpec{multiRegion: false}, exactStaleness, data)
 
 	// Upgrade the remaining nodes to the new version and run the test.
@@ -917,6 +919,6 @@ func runFollowerReadsMixedVersionSingleRegionTest(
 		remainingNodes = remainingNodes.Merge(c.Node(i + 1))
 	}
 	t.L().Printf("upgrading nodes %s to current version", remainingNodes)
-	upgradeNodes(ctx, t, c, remainingNodes, startOpts, clusterupgrade.MainVersion)
+	upgradeNodes(ctx, t, c, remainingNodes, startOpts, clusterupgrade.CurrentVersion())
 	runFollowerReadsTest(ctx, t, c, topologySpec{multiRegion: false}, exactStaleness, data)
 }

--- a/pkg/cmd/roachtest/tests/import.go
+++ b/pkg/cmd/roachtest/tests/import.go
@@ -352,20 +352,21 @@ func successfulImportStep(warehouses, nodeID int) versionStep {
 }
 
 func runImportMixedVersion(
-	ctx context.Context, t test.Test, c cluster.Cluster, warehouses int, predecessorVersion string,
+	ctx context.Context, t test.Test, c cluster.Cluster, warehouses int, predVersion string,
 ) {
 	roachNodes := c.All()
 
 	t.Status("starting csv servers")
 
+	predecessorVersion := clusterupgrade.MustParseVersion(predVersion)
 	u := newVersionUpgradeTest(c,
 		uploadAndStartFromCheckpointFixture(roachNodes, predecessorVersion),
 		waitForUpgradeStep(roachNodes),
 		preventAutoUpgradeStep(1),
 
 		// Upgrade some of the nodes.
-		binaryUpgradeStep(c.Node(1), clusterupgrade.MainVersion),
-		binaryUpgradeStep(c.Node(2), clusterupgrade.MainVersion),
+		binaryUpgradeStep(c.Node(1), clusterupgrade.CurrentVersion()),
+		binaryUpgradeStep(c.Node(2), clusterupgrade.CurrentVersion()),
 
 		successfulImportStep(warehouses, 1 /* nodeID */),
 	)

--- a/pkg/cmd/roachtest/tests/mixed_version_decl_schemachange_compat.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_decl_schemachange_compat.go
@@ -20,10 +20,10 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/clusterupgrade"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/testutils/release"
-	"github.com/cockroachdb/cockroach/pkg/util/version"
 )
 
 func registerDeclSchemaChangeCompatMixedVersions(r registry.Registry) {
@@ -37,7 +37,7 @@ func registerDeclSchemaChangeCompatMixedVersions(r registry.Registry) {
 			if c.Spec().Cloud != spec.GCE {
 				t.Skip("uses gs://cockroach-corpus; see https://github.com/cockroachdb/cockroach/issues/105968")
 			}
-			runDeclSchemaChangeCompatMixedVersions(ctx, t, c, t.BuildVersion())
+			runDeclSchemaChangeCompatMixedVersions(ctx, t, c)
 		},
 	})
 }
@@ -129,25 +129,42 @@ func validateCorpusFile(
 //  3. Elements from the current version are backwards compatible with the same
 //     version (specifically focused on master during development before
 //     a version bump).
-func runDeclSchemaChangeCompatMixedVersions(
-	ctx context.Context, t test.Test, c cluster.Cluster, buildVersion *version.Version,
-) {
-	versionRegex := regexp.MustCompile(`(\d+\.\d+)`)
-	predecessorVersion, err := release.LatestPredecessor(buildVersion)
+func runDeclSchemaChangeCompatMixedVersions(ctx context.Context, t test.Test, c cluster.Cluster) {
+	currentVersion := clusterupgrade.CurrentVersion()
+	predecessorVersionStr, err := release.LatestPredecessor(currentVersion.Version)
 	if err != nil {
 		t.Fatal(err)
 	}
+	predecessorVersion := clusterupgrade.MustParseVersion(predecessorVersionStr)
+
+	releaseSeries := func(v *clusterupgrade.Version) string {
+		return fmt.Sprintf("%d.%d", v.Major(), v.Minor())
+	}
+
 	// Test definitions which indicates which version of the corpus to fetch,
 	// and the binary to validate against.
 	compatTests := []struct {
 		testName               string
-		binaryVersion          string
+		binaryVersion          *clusterupgrade.Version
 		corpusVersion          string
 		alternateCorpusVersion string
 	}{
-		{"backwards compatibility", predecessorVersion, fmt.Sprintf("mixed-release-%d.%d", buildVersion.Major(), buildVersion.Minor()), "mixed-master"},
-		{"forwards compatibility", "", fmt.Sprintf("release-%s", versionRegex.FindStringSubmatch(predecessorVersion)[0]), ""},
-		{"same version", "", fmt.Sprintf("release-%s", versionRegex.FindStringSubmatch(buildVersion.String())[0]), "master"},
+		{
+			testName:               "backwards compatibility",
+			binaryVersion:          predecessorVersion,
+			corpusVersion:          fmt.Sprintf("mixed-release-%s", releaseSeries(currentVersion)),
+			alternateCorpusVersion: "mixed-master",
+		},
+		{
+			testName:      "forwards compatibility",
+			binaryVersion: currentVersion,
+			corpusVersion: fmt.Sprintf("release-%s", releaseSeries(predecessorVersion)),
+		},
+		{
+			testName:      "same version",
+			binaryVersion: currentVersion,
+			corpusVersion: fmt.Sprintf("release-%s", releaseSeries(currentVersion)),
+		},
 	}
 	for _, testInfo := range compatTests {
 		binaryName := uploadVersion(ctx, t, c, c.All(), testInfo.binaryVersion)

--- a/pkg/cmd/roachtest/tests/mixed_version_decommission.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_decommission.go
@@ -34,10 +34,11 @@ import (
 func runDecommissionMixedVersions(
 	ctx context.Context, t test.Test, c cluster.Cluster, buildVersion *version.Version,
 ) {
-	predecessorVersion, err := release.LatestPredecessor(buildVersion)
+	predecessorVersionStr, err := release.LatestPredecessor(buildVersion)
 	if err != nil {
 		t.Fatal(err)
 	}
+	predecessorVersion := clusterupgrade.MustParseVersion(predecessorVersionStr)
 
 	h := newDecommTestHelper(t, c)
 
@@ -53,7 +54,7 @@ func runDecommissionMixedVersions(
 		// We upload both binaries to each node, to be able to vary the binary
 		// used when issuing `cockroach node` subcommands.
 		uploadVersionStep(allNodes, predecessorVersion),
-		uploadVersionStep(allNodes, clusterupgrade.MainVersion),
+		uploadVersionStep(allNodes, clusterupgrade.CurrentVersion()),
 
 		startVersion(allNodes, predecessorVersion),
 		waitForUpgradeStep(allNodes),
@@ -62,9 +63,9 @@ func runDecommissionMixedVersions(
 
 		preloadDataStep(pinnedUpgrade),
 
-		// We upgrade a pinnedUpgrade and one other random node of the cluster to v20.2.
-		binaryUpgradeStep(c.Node(pinnedUpgrade), clusterupgrade.MainVersion),
-		binaryUpgradeStep(c.Node(h.getRandNodeOtherThan(pinnedUpgrade)), clusterupgrade.MainVersion),
+		// We upgrade a pinned node and one other random node of the cluster to the current version.
+		binaryUpgradeStep(c.Node(pinnedUpgrade), clusterupgrade.CurrentVersion()),
+		binaryUpgradeStep(c.Node(h.getRandNodeOtherThan(pinnedUpgrade)), clusterupgrade.CurrentVersion()),
 		checkAllMembership(pinnedUpgrade, "active"),
 
 		// After upgrading, which restarts the nodes, ensure that nodes are not
@@ -88,7 +89,7 @@ func runDecommissionMixedVersions(
 		binaryUpgradeStep(allNodes, predecessorVersion),
 
 		// Roll all nodes forward, and finalize upgrade.
-		binaryUpgradeStep(allNodes, clusterupgrade.MainVersion),
+		binaryUpgradeStep(allNodes, clusterupgrade.CurrentVersion()),
 		allowAutoUpgradeStep(1),
 		waitForUpgradeStep(allNodes),
 
@@ -104,20 +105,13 @@ func runDecommissionMixedVersions(
 		// to communicate with the cluster (i.e. most commands against it will fail).
 		// This is also why we're making sure to avoid decommissioning pinnedUpgrade
 		// itself, as we use it to check the membership after.
-		fullyDecommissionStep(h.getRandNodeOtherThan(pinnedUpgrade), h.getRandNode(), ""),
+		fullyDecommissionStep(
+			h.getRandNodeOtherThan(pinnedUpgrade), h.getRandNode(), clusterupgrade.CurrentVersion(),
+		),
 		checkOneMembership(pinnedUpgrade, "decommissioned"),
 	)
 
 	u.run(ctx, t)
-}
-
-// cockroachBinaryPath is a shorthand to retrieve the path for a cockroach
-// binary of a given version.
-func cockroachBinaryPath(version string) string {
-	if version == "" {
-		return "./cockroach"
-	}
-	return fmt.Sprintf("./v%s/cockroach", version)
 }
 
 // suspectLivenessSettingsStep sets the duration a node is considered "suspect"
@@ -151,10 +145,10 @@ func preloadDataStep(target int) versionStep {
 // partialDecommissionStep runs `cockroach node decommission --wait=none` from a
 // given node, targeting another. It uses the specified binary version to run
 // the command.
-func partialDecommissionStep(target, from int, binaryVersion string) versionStep {
+func partialDecommissionStep(target, from int, binaryVersion *clusterupgrade.Version) versionStep {
 	return func(ctx context.Context, t test.Test, u *versionUpgradeTest) {
 		c := u.c
-		c.Run(ctx, c.Node(from), cockroachBinaryPath(binaryVersion), "node", "decommission",
+		c.Run(ctx, c.Node(from), clusterupgrade.BinaryPathForVersion(t, binaryVersion), "node", "decommission",
 			"--wait=none", "--insecure", strconv.Itoa(target), "--port", fmt.Sprintf("{pgport:%d}", from))
 	}
 }
@@ -162,20 +156,20 @@ func partialDecommissionStep(target, from int, binaryVersion string) versionStep
 // recommissionAllStep runs `cockroach node recommission` from a given node,
 // targeting all nodes in the cluster. It uses the specified binary version to
 // run the command.
-func recommissionAllStep(from int, binaryVersion string) versionStep {
+func recommissionAllStep(from int, binaryVersion *clusterupgrade.Version) versionStep {
 	return func(ctx context.Context, t test.Test, u *versionUpgradeTest) {
 		c := u.c
-		c.Run(ctx, c.Node(from), cockroachBinaryPath(binaryVersion), "node", "recommission",
+		c.Run(ctx, c.Node(from), clusterupgrade.BinaryPathForVersion(t, binaryVersion), "node", "recommission",
 			"--insecure", c.All().NodeIDsString(), "--port", fmt.Sprintf("{pgport:%d}", from))
 	}
 }
 
 // fullyDecommissionStep is like partialDecommissionStep, except it uses
 // `--wait=all`.
-func fullyDecommissionStep(target, from int, binaryVersion string) versionStep {
+func fullyDecommissionStep(target, from int, binaryVersion *clusterupgrade.Version) versionStep {
 	return func(ctx context.Context, t test.Test, u *versionUpgradeTest) {
 		c := u.c
-		c.Run(ctx, c.Node(from), cockroachBinaryPath(binaryVersion), "node", "decommission",
+		c.Run(ctx, c.Node(from), clusterupgrade.BinaryPathForVersion(t, binaryVersion), "node", "decommission",
 			"--wait=all", "--insecure", strconv.Itoa(target), "--port", fmt.Sprintf("{pgport:%d}", from))
 
 		// If we are decommissioning a target node from the same node, the drain
@@ -325,7 +319,7 @@ func checkAllMembership(from int, membership string) versionStep {
 
 // uploadVersionStep uploads the specified cockroach binary version on the specified
 // nodes.
-func uploadVersionStep(nodes option.NodeListOption, version string) versionStep {
+func uploadVersionStep(nodes option.NodeListOption, version *clusterupgrade.Version) versionStep {
 	return func(ctx context.Context, t test.Test, u *versionUpgradeTest) {
 		// Put the binary.
 		uploadVersion(ctx, t, u.c, nodes, version)
@@ -334,9 +328,11 @@ func uploadVersionStep(nodes option.NodeListOption, version string) versionStep 
 
 // startVersion starts the specified cockroach binary version on the specified
 // nodes.
-func startVersion(nodes option.NodeListOption, version string) versionStep {
+func startVersion(nodes option.NodeListOption, version *clusterupgrade.Version) versionStep {
 	return func(ctx context.Context, t test.Test, u *versionUpgradeTest) {
-		settings := install.MakeClusterSettings(install.BinaryOption(cockroachBinaryPath(version)))
+		settings := install.MakeClusterSettings(install.BinaryOption(
+			clusterupgrade.BinaryPathForVersion(t, version),
+		))
 		startOpts := option.DefaultStartOpts()
 		u.c.Start(ctx, t.L(), startOpts, settings, nodes)
 	}

--- a/pkg/cmd/roachtest/tests/mixed_version_job_compatibility_in_declarative_schema_changer.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_job_compatibility_in_declarative_schema_changer.go
@@ -136,6 +136,7 @@ func registerDeclarativeSchemaChangerJobCompatibilityInMixedVersion(r registry.R
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			predV, err := release.LatestPredecessor(t.BuildVersion())
 			require.NoError(t, err)
+			predecessorVersion := clusterupgrade.MustParseVersion(predV)
 
 			allNodes := c.All()
 			upgradedNodes := c.Nodes(1, 2)
@@ -143,14 +144,14 @@ func registerDeclarativeSchemaChangerJobCompatibilityInMixedVersion(r registry.R
 
 			u := newVersionUpgradeTest(c,
 				// System setup.
-				uploadAndStartFromCheckpointFixture(allNodes, predV),
+				uploadAndStartFromCheckpointFixture(allNodes, predecessorVersion),
 				waitForUpgradeStep(allNodes),
 				preventAutoUpgradeStep(1),
 				setShortJobIntervalsStep(1),
 				setShortGCTTLInSystemZoneConfig(c),
 
 				// Upgrade some nodes.
-				binaryUpgradeStep(upgradedNodes, clusterupgrade.MainVersion),
+				binaryUpgradeStep(upgradedNodes, clusterupgrade.CurrentVersion()),
 
 				// Job backward compatibility test:
 				//   - upgraded nodes: plan schema change and create schema changer jobs

--- a/pkg/cmd/roachtest/tests/mixed_version_jobs.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_jobs.go
@@ -228,12 +228,13 @@ FROM [SHOW JOBS] WHERE status = $1 OR status = $2`,
 }
 
 func runJobsMixedVersions(
-	ctx context.Context, t test.Test, c cluster.Cluster, warehouses int, predecessorVersion string,
+	ctx context.Context, t test.Test, c cluster.Cluster, warehouses int, predecessorVersionStr string,
 ) {
 	roachNodes := c.All()
 	backgroundTPCC := backgroundJobsTestTPCCImport(t, warehouses)
 	resumeAllJobsAndWaitStep := makeResumeAllJobsAndWaitStep(10 * time.Second)
 	c.Put(ctx, t.DeprecatedWorkload(), "./workload", c.Node(1))
+	predecessorVersion := clusterupgrade.MustParseVersion(predecessorVersionStr)
 
 	u := newVersionUpgradeTest(c,
 		uploadAndStartFromCheckpointFixture(roachNodes, predecessorVersion),
@@ -247,22 +248,22 @@ func runJobsMixedVersions(
 
 		// Roll the nodes into the new version one by one, while repeatedly pausing
 		// and resuming all jobs.
-		binaryUpgradeStep(c.Node(3), clusterupgrade.MainVersion),
+		binaryUpgradeStep(c.Node(3), clusterupgrade.CurrentVersion()),
 		resumeAllJobsAndWaitStep,
 		checkForFailedJobsStep,
 		pauseAllJobsStep(),
 
-		binaryUpgradeStep(c.Node(2), clusterupgrade.MainVersion),
+		binaryUpgradeStep(c.Node(2), clusterupgrade.CurrentVersion()),
 		resumeAllJobsAndWaitStep,
 		checkForFailedJobsStep,
 		pauseAllJobsStep(),
 
-		binaryUpgradeStep(c.Node(1), clusterupgrade.MainVersion),
+		binaryUpgradeStep(c.Node(1), clusterupgrade.CurrentVersion()),
 		resumeAllJobsAndWaitStep,
 		checkForFailedJobsStep,
 		pauseAllJobsStep(),
 
-		binaryUpgradeStep(c.Node(4), clusterupgrade.MainVersion),
+		binaryUpgradeStep(c.Node(4), clusterupgrade.CurrentVersion()),
 		resumeAllJobsAndWaitStep,
 		checkForFailedJobsStep,
 		pauseAllJobsStep(),
@@ -290,22 +291,22 @@ func runJobsMixedVersions(
 		pauseAllJobsStep(),
 
 		// Roll nodes forward and finalize upgrade.
-		binaryUpgradeStep(c.Node(4), clusterupgrade.MainVersion),
+		binaryUpgradeStep(c.Node(4), clusterupgrade.CurrentVersion()),
 		resumeAllJobsAndWaitStep,
 		checkForFailedJobsStep,
 		pauseAllJobsStep(),
 
-		binaryUpgradeStep(c.Node(3), clusterupgrade.MainVersion),
+		binaryUpgradeStep(c.Node(3), clusterupgrade.CurrentVersion()),
 		resumeAllJobsAndWaitStep,
 		checkForFailedJobsStep,
 		pauseAllJobsStep(),
 
-		binaryUpgradeStep(c.Node(1), clusterupgrade.MainVersion),
+		binaryUpgradeStep(c.Node(1), clusterupgrade.CurrentVersion()),
 		resumeAllJobsAndWaitStep,
 		checkForFailedJobsStep,
 		pauseAllJobsStep(),
 
-		binaryUpgradeStep(c.Node(2), clusterupgrade.MainVersion),
+		binaryUpgradeStep(c.Node(2), clusterupgrade.CurrentVersion()),
 		resumeAllJobsAndWaitStep,
 		checkForFailedJobsStep,
 		pauseAllJobsStep(),

--- a/pkg/cmd/roachtest/tests/mixed_version_schemachange.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_schemachange.go
@@ -90,10 +90,11 @@ func runSchemaChangeMixedVersions(
 	concurrency int,
 	buildVersion *version.Version,
 ) {
-	predecessorVersion, err := release.LatestPredecessor(buildVersion)
+	predecessorVersionStr, err := release.LatestPredecessor(buildVersion)
 	if err != nil {
 		t.Fatal(err)
 	}
+	predecessorVersion := clusterupgrade.MustParseVersion(predecessorVersionStr)
 
 	schemaChangeStep := runSchemaChangeWorkloadStep(c.All().RandNode()[0], maxOps, concurrency)
 	schemaChangeValidationStep := runSchemaChangeDoctorValidate()
@@ -120,16 +121,16 @@ func runSchemaChangeMixedVersions(
 		// Roll the nodes into the new version one by one, while repeatedly running
 		// schema changes. We use an empty string for the version below, which means
 		// use the main ./cockroach binary (i.e. the one being tested in this run).
-		binaryUpgradeStep(c.Node(3), clusterupgrade.MainVersion),
+		binaryUpgradeStep(c.Node(3), clusterupgrade.CurrentVersion()),
 		schemaChangeStep,
 		schemaChangeValidationStep,
-		binaryUpgradeStep(c.Node(2), clusterupgrade.MainVersion),
+		binaryUpgradeStep(c.Node(2), clusterupgrade.CurrentVersion()),
 		schemaChangeStep,
 		schemaChangeValidationStep,
-		binaryUpgradeStep(c.Node(1), clusterupgrade.MainVersion),
+		binaryUpgradeStep(c.Node(1), clusterupgrade.CurrentVersion()),
 		schemaChangeStep,
 		schemaChangeValidationStep,
-		binaryUpgradeStep(c.Node(4), clusterupgrade.MainVersion),
+		binaryUpgradeStep(c.Node(4), clusterupgrade.CurrentVersion()),
 		schemaChangeStep,
 		schemaChangeValidationStep,
 
@@ -149,16 +150,16 @@ func runSchemaChangeMixedVersions(
 		schemaChangeValidationStep,
 
 		// Roll nodes forward and finalize upgrade.
-		binaryUpgradeStep(c.Node(4), clusterupgrade.MainVersion),
+		binaryUpgradeStep(c.Node(4), clusterupgrade.CurrentVersion()),
 		schemaChangeStep,
 		schemaChangeValidationStep,
-		binaryUpgradeStep(c.Node(3), clusterupgrade.MainVersion),
+		binaryUpgradeStep(c.Node(3), clusterupgrade.CurrentVersion()),
 		schemaChangeStep,
 		schemaChangeValidationStep,
-		binaryUpgradeStep(c.Node(1), clusterupgrade.MainVersion),
+		binaryUpgradeStep(c.Node(1), clusterupgrade.CurrentVersion()),
 		schemaChangeStep,
 		schemaChangeValidationStep,
-		binaryUpgradeStep(c.Node(2), clusterupgrade.MainVersion),
+		binaryUpgradeStep(c.Node(2), clusterupgrade.CurrentVersion()),
 		schemaChangeStep,
 		schemaChangeValidationStep,
 

--- a/pkg/cmd/roachtest/tests/multitenant_upgrade.go
+++ b/pkg/cmd/roachtest/tests/multitenant_upgrade.go
@@ -77,8 +77,8 @@ func runMultiTenantUpgrade(
 	predecessor, err := release.LatestPredecessor(v)
 	require.NoError(t, err)
 
-	currentBinary := uploadVersion(ctx, t, c, c.All(), clusterupgrade.MainVersion)
-	predecessorBinary := uploadVersion(ctx, t, c, c.All(), predecessor)
+	currentBinary := uploadVersion(ctx, t, c, c.All(), clusterupgrade.CurrentVersion())
+	predecessorBinary := uploadVersion(ctx, t, c, c.All(), clusterupgrade.MustParseVersion(predecessor))
 
 	kvNodes := c.Node(1)
 

--- a/pkg/cmd/roachtest/tests/rebalance_load.go
+++ b/pkg/cmd/roachtest/tests/rebalance_load.go
@@ -96,8 +96,9 @@ func registerRebalanceLoad(r registry.Registry) {
 			"--vmodule=store_rebalancer=5,allocator=5,allocator_scorer=5,replicate_queue=5")
 		settings := install.MakeClusterSettings()
 		if mixedVersion {
-			predecessorVersion, err := release.LatestPredecessor(t.BuildVersion())
+			predecessorVersionStr, err := release.LatestPredecessor(t.BuildVersion())
 			require.NoError(t, err)
+			predecessorVersion := clusterupgrade.MustParseVersion(predecessorVersionStr)
 			settings.Binary = uploadVersion(ctx, t, c, c.All(), predecessorVersion)
 			// Upgrade some (or all) of the first N-1 CRDB nodes. We ignore the last
 			// CRDB node (to leave at least one node on the older version), and the
@@ -106,7 +107,7 @@ func registerRebalanceLoad(r registry.Registry) {
 			t.L().Printf("upgrading %d nodes to the current cockroach binary", lastNodeToUpgrade)
 			nodesToUpgrade := c.Range(1, lastNodeToUpgrade)
 			c.Start(ctx, t.L(), startOpts, settings, roachNodes)
-			upgradeNodes(ctx, t, c, nodesToUpgrade, startOpts, clusterupgrade.MainVersion)
+			upgradeNodes(ctx, t, c, nodesToUpgrade, startOpts, clusterupgrade.CurrentVersion())
 		} else {
 			c.Put(ctx, t.Cockroach(), "./cockroach", roachNodes)
 			c.Start(ctx, t.L(), startOpts, settings, roachNodes)

--- a/pkg/cmd/roachtest/tests/secondary_indexes.go
+++ b/pkg/cmd/roachtest/tests/secondary_indexes.go
@@ -25,7 +25,7 @@ import (
 // and modifies it in a mixed version setting. It aims to test the changes made
 // to index encodings done to allow secondary indexes to respect column families.
 func runIndexUpgrade(
-	ctx context.Context, t test.Test, c cluster.Cluster, predecessorVersion string,
+	ctx context.Context, t test.Test, c cluster.Cluster, predecessorVersionStr string,
 ) {
 	firstExpected := [][]int{
 		{2, 3, 4},
@@ -42,6 +42,7 @@ func runIndexUpgrade(
 	}
 
 	roachNodes := c.All()
+	predecessorVersion := clusterupgrade.MustParseVersion(predecessorVersionStr)
 	u := newVersionUpgradeTest(c,
 		uploadAndStart(roachNodes, predecessorVersion),
 		waitForUpgradeStep(roachNodes),
@@ -50,7 +51,7 @@ func runIndexUpgrade(
 		createDataStep(),
 
 		// Upgrade one of the nodes.
-		binaryUpgradeStep(c.Node(1), clusterupgrade.MainVersion),
+		binaryUpgradeStep(c.Node(1), clusterupgrade.CurrentVersion()),
 
 		// Modify index data from that node.
 		modifyData(1,
@@ -64,8 +65,8 @@ func runIndexUpgrade(
 		verifyTableData(3, firstExpected),
 
 		// Upgrade the rest of the cluster.
-		binaryUpgradeStep(c.Node(2), clusterupgrade.MainVersion),
-		binaryUpgradeStep(c.Node(3), clusterupgrade.MainVersion),
+		binaryUpgradeStep(c.Node(2), clusterupgrade.CurrentVersion()),
+		binaryUpgradeStep(c.Node(3), clusterupgrade.CurrentVersion()),
 
 		// Finalize the upgrade.
 		allowAutoUpgradeStep(1),

--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/clusterupgrade"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
@@ -387,7 +388,6 @@ func runTPCCMixedHeadroom(
 	}
 
 	randomCRDBNode := func() int { return crdbNodes.RandNode()[0] }
-	const mainBinary = ""
 
 	// NB: this results in ~100GB of (actual) disk usage per node once things
 	// have settled down, and ~7.5k ranges. The import takes ~40 minutes.
@@ -406,7 +406,11 @@ func runTPCCMixedHeadroom(
 	}
 	sep := " -> "
 	t.L().Printf("testing upgrade: %s%scurrent", strings.Join(history, sep), sep)
-	history = append(history, mainBinary)
+	releases := make([]*clusterupgrade.Version, 0, len(history))
+	for _, v := range history {
+		releases = append(releases, clusterupgrade.MustParseVersion(v))
+	}
+	releases = append(releases, clusterupgrade.CurrentVersion())
 
 	waitForWorkloadToRampUp := sleepStep(rampDuration(c.IsLocal()))
 	logStep := func(format string, args ...interface{}) versionStep {
@@ -415,12 +419,12 @@ func runTPCCMixedHeadroom(
 		}
 	}
 
-	oldestVersion := history[0]
+	oldestVersion := releases[0]
 	setupSteps := []versionStep{
 		logStep("starting from fixture at version %s", oldestVersion),
 		uploadAndStartFromCheckpointFixture(crdbNodes, oldestVersion),
-		waitForUpgradeStep(crdbNodes),               // let oldest version settle (gossip etc)
-		uploadVersionStep(workloadNode, mainBinary), // for tpccBackgroundStepper's workload
+		waitForUpgradeStep(crdbNodes),                                    // let oldest version settle (gossip etc)
+		uploadVersionStep(workloadNode, clusterupgrade.CurrentVersion()), // for tpccBackgroundStepper's workload
 
 		// Load TPCC dataset, don't run TPCC yet. We do this while in the
 		// version we are starting with to load some data and hopefully
@@ -435,17 +439,15 @@ func runTPCCMixedHeadroom(
 
 	// upgradeToVersionSteps returns the list of steps to be performed
 	// when upgrading to the given version.
-	upgradeToVersionSteps := func(crdbVersion string) []versionStep {
+	upgradeToVersionSteps := func(crdbVersion *clusterupgrade.Version) []versionStep {
 		duration := 10 * time.Minute
-		versionString := crdbVersion
-		if crdbVersion == mainBinary {
+		if crdbVersion.IsCurrent() {
 			duration = 100 * time.Minute
-			versionString = "current"
 		}
 		tpccWorkload := tpccBackgroundStepper(duration)
 
 		return []versionStep{
-			logStep("upgrading to version %q", versionString),
+			logStep("upgrading to version %q", crdbVersion.String()),
 			preventAutoUpgradeStep(randomCRDBNode()),
 			// Upload and restart cluster into the new
 			// binary (stays at previous cluster version).
@@ -476,7 +478,7 @@ func runTPCCMixedHeadroom(
 	// Test steps consist of the setup steps + the upgrade steps for
 	// each upgrade being carried out here.
 	testSteps := append([]versionStep{}, setupSteps...)
-	for _, nextVersion := range history[1:] {
+	for _, nextVersion := range releases[1:] {
 		testSteps = append(testSteps, upgradeToVersionSteps(nextVersion)...)
 	}
 

--- a/pkg/roachprod/install/BUILD.bazel
+++ b/pkg/roachprod/install/BUILD.bazel
@@ -50,6 +50,7 @@ go_test(
     name = "install_test",
     srcs = [
         "cluster_synced_test.go",
+        "cockroach_test.go",
         "services_test.go",
         "staging_test.go",
         "start_template_test.go",

--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -22,6 +22,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -414,7 +415,16 @@ func (c *SyncedCluster) Stop(
 	maxWait int,
 	virtualClusterLabel string,
 ) error {
-	display := fmt.Sprintf("%s: stopping", c.Name)
+	var virtualClusterDisplay string
+	if virtualClusterLabel != "" {
+		virtualClusterName, sqlInstance, err := VirtualClusterInfoFromLabel(virtualClusterLabel)
+		if err != nil {
+			return err
+		}
+
+		virtualClusterDisplay = fmt.Sprintf(" virtual cluster %q, instance %d", virtualClusterName, sqlInstance)
+	}
+	display := fmt.Sprintf("%s: stopping%s", c.Name, virtualClusterDisplay)
 	if wait {
 		display += " and waiting"
 	}
@@ -583,18 +593,26 @@ fi
 	return statuses, nil
 }
 
-// MonitorNodeSkipped represents a node whose status was not checked.
-type MonitorNodeSkipped struct{}
-
-// MonitorNodeRunning represents the cockroach process running on a
-// node.
-type MonitorNodeRunning struct {
-	PID string
+// MonitorProcessSkipped represents a cockroach process whose status
+// was not checked.
+type MonitorProcessSkipped struct {
+	VirtualClusterName string
+	SQLInstance        int
 }
 
-// MonitorNodeDead represents the cockroach process dying on a node.
-type MonitorNodeDead struct {
-	ExitCode string
+// MonitorProcessRunning represents the cockroach process running on a
+// node.
+type MonitorProcessRunning struct {
+	VirtualClusterName string
+	SQLInstance        int
+	PID                string
+}
+
+// MonitorProcessDead represents the cockroach process dying on a node.
+type MonitorProcessDead struct {
+	VirtualClusterName string
+	SQLInstance        int
+	ExitCode           string
 }
 
 type MonitorError struct {
@@ -606,24 +624,36 @@ type NodeMonitorInfo struct {
 	// The index of the node (in a SyncedCluster) at which the message originated.
 	Node Node
 	// Event describes what happened to the node; it is one of
-	// MonitorNodeSkipped (no store directory was found);
-	// MonitorNodeRunning, sent when cockroach is running on a node;
-	// MonitorNodeDead, when the cockroach process stops running on a
-	// node; or MonitorError, typically indicate networking issues
-	// or nodes that have (physically) shut down.
+	// MonitorProcessSkipped (no store directory was found);
+	// MonitorProcessRunning, sent when cockroach is running on a node;
+	// MonitorProcessDead, when the cockroach process stops running on a
+	// node; or MonitorError, typically indicate networking issues or
+	// nodes that have (physically) shut down.
 	Event interface{}
 }
 
 func (nmi NodeMonitorInfo) String() string {
 	var status string
 
+	virtualClusterDesc := func(name string, instance int) string {
+		if name == SystemInterfaceName {
+			return "system interface"
+		}
+
+		return fmt.Sprintf("virtual cluster %q, instance %d", name, instance)
+	}
+
 	switch event := nmi.Event.(type) {
-	case MonitorNodeRunning:
-		status = fmt.Sprintf("cockroach process is running (PID: %s)", event.PID)
-	case MonitorNodeSkipped:
-		status = "node skipped"
-	case MonitorNodeDead:
-		status = fmt.Sprintf("cockroach process died (exit code %s)", event.ExitCode)
+	case MonitorProcessRunning:
+		status = fmt.Sprintf("cockroach process for %s is running (PID: %s)",
+			virtualClusterDesc(event.VirtualClusterName, event.SQLInstance), event.PID,
+		)
+	case MonitorProcessSkipped:
+		status = fmt.Sprintf("%s was skipped", virtualClusterDesc(event.VirtualClusterName, event.SQLInstance))
+	case MonitorProcessDead:
+		status = fmt.Sprintf("cockroach process for %s died (exit code %s)",
+			virtualClusterDesc(event.VirtualClusterName, event.SQLInstance), event.ExitCode,
+		)
 	case MonitorError:
 		status = fmt.Sprintf("error: %s", event.Err.Error())
 	}
@@ -645,9 +675,14 @@ type MonitorOpts struct {
 // channel is subsequently closed; otherwise the process continues indefinitely
 // (emitting new information as the status of the cockroach process changes).
 //
-// If IgnoreEmptyNodes is true, nodes on which no CockroachDB data is found
-// (in {store-dir}) will not be probed and single event, MonitorNodeSkipped,
-// will be emitted for them.
+// If IgnoreEmptyNodes is true, tenants on which no CockroachDB data is found
+// (in {store-dir}) will not be probed and single event, MonitorTenantSkipped,
+// will be emitted for each tenant.
+//
+// Note that the monitor will only send events for tenants that exist
+// at the time this function is called. In other words, this function
+// will not emit events for tenants started *after* a call to
+// Monitor().
 func (c *SyncedCluster) Monitor(
 	l *logger.Logger, ctx context.Context, opts MonitorOpts,
 ) chan NodeMonitorInfo {
@@ -660,6 +695,13 @@ func (c *SyncedCluster) Monitor(
 	// that is listened to by the caller. Bails if the context is
 	// canceled.
 	sendEvent := func(info NodeMonitorInfo) {
+		// if the monitor's context is already canceled, do not attempt to
+		// send the error down the channel, as it is most likely *caused*
+		// by the cancelation itself.
+		if monitorCtx.Err() != nil {
+			return
+		}
+
 		select {
 		case ch <- info:
 			// We were able to send the info through the channel.
@@ -675,39 +717,87 @@ func (c *SyncedCluster) Monitor(
 		deadMsg    = "dead"
 	)
 
+	wg.Add(len(nodes))
 	for i := range nodes {
-		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
-
 			node := nodes[i]
-			port, err := c.NodePort(ctx, node)
-			if err != nil {
-				err := errors.Wrap(err, "failed to get node port")
+
+			// We first find out all cockroach processes that are currently
+			// running in this node.
+			cockroachProcessesCmd := fmt.Sprintf(`ps axeww -o command | `+
+				`grep -E '%s' | `+ // processes started by roachprod
+				`grep -E -o 'ROACHPROD_VIRTUAL_CLUSTER=[^ ]*' | `+ // ROACHPROD_VIRTUAL_CLUSTER indicates this is a cockroach process
+				`cut -d= -f2`, // grab the virtual cluster label
+				c.roachprodEnvRegex(node),
+			)
+
+			result, err := c.runCmdOnSingleNode(
+				ctx, l, node, cockroachProcessesCmd, defaultCmdOpts("list-processes"),
+			)
+			if err := errors.CombineErrors(err, result.Err); err != nil {
+				err := errors.Wrap(err, "failed to list cockroach processes")
 				sendEvent(NodeMonitorInfo{Node: node, Event: MonitorError{err}})
 				return
 			}
-			// On each monitored node, we loop looking for a cockroach process.
+
+			type virtualClusterInfo struct {
+				Name     string
+				Instance int
+			}
+
+			// Make the collection of virtual clusters a set to handle the
+			// unlikely but possible case that, in `local` runs, we'll find
+			// two processes associated with the same virtual cluster
+			// label. This can happen if we invoke the command above while the
+			// parent cockroach process already created the child,
+			// background process, but has not terminated yet.
+			vcs := map[virtualClusterInfo]struct{}{}
+			vcLines := strings.TrimSuffix(result.CombinedOut, "\n")
+			if vcLines == "" {
+				err := errors.New("no cockroach processes running")
+				sendEvent(NodeMonitorInfo{Node: node, Event: MonitorError{err}})
+				return
+			}
+			for _, label := range strings.Split(vcLines, "\n") {
+				name, instance, err := VirtualClusterInfoFromLabel(label)
+				if err != nil {
+					sendEvent(NodeMonitorInfo{Node: node, Event: MonitorError{err}})
+					return
+				}
+				vcs[virtualClusterInfo{name, instance}] = struct{}{}
+			}
+
 			data := struct {
 				OneShot     bool
+				Node        Node
 				IgnoreEmpty bool
 				Store       string
-				Port        int
 				Local       bool
 				Separator   string
 				SkippedMsg  string
 				RunningMsg  string
 				DeadMsg     string
+				Processes   []virtualClusterInfo
 			}{
 				OneShot:     opts.OneShot,
+				Node:        node,
 				IgnoreEmpty: opts.IgnoreEmptyNodes,
 				Store:       c.NodeDir(node, 1 /* storeIndex */),
-				Port:        port,
 				Local:       c.IsLocal(),
 				Separator:   separator,
 				SkippedMsg:  skippedMsg,
 				RunningMsg:  runningMsg,
 				DeadMsg:     deadMsg,
+				Processes:   maps.Keys(vcs),
+			}
+
+			storeFor := func(name string, instance int) string {
+				return c.InstanceStoreDir(node, name, instance)
+			}
+
+			localPIDFile := func(name string, instance int) string {
+				return filepath.Join(c.LogDir(node, name, instance), "cockroach.pid")
 			}
 
 			// NB.: we parse the output of every line this script
@@ -715,62 +805,86 @@ func (c *SyncedCluster) Monitor(
 			// down below in order to produce structured results to the
 			// caller.
 			snippet := `
-{{ if .IgnoreEmpty }}
-if ! ls {{.Store}}/marker.* 1> /dev/null 2>&1; then
-  echo "{{.SkippedMsg}}"
-  exit 0
-fi
-{{- end}}
-# Init with -1 so that when cockroach is initially dead, we print
-# a dead event for it.
-lastpid=-1
-while :; do
-{{ if .Local }}
-  pid=$(lsof -i :{{.Port}} -sTCP:LISTEN | awk '!/COMMAND/ {print $2}')
-	pid=${pid:-0} # default to 0
-	status="unknown"
-{{- else }}
-  # When CRDB is not running, this is zero.
-	pid=$(systemctl show cockroach --property MainPID --value)
-	status=$(systemctl show cockroach --property ExecMainStatus --value)
-{{- end }}
-  if [[ "${lastpid}" == -1 && "${pid}" != 0 ]]; then
-    # On the first iteration through the loop, if the process is running,
-    # don't register a PID change (which would trigger an erroneous dead
-    # event).
-    lastpid=0
+dead_parent() {
+  ! ps -p "$1" >/dev/null || ps -o ucomm -p "$1" | grep -q defunct
+}
+{{ range .Processes }}
+monitor_process_{{$.Node}}_{{.Name}}_{{.Instance}}() {
+  {{ if $.IgnoreEmpty }}
+  if ! ls {{storeFor .Name .Instance}}/marker.* 1> /dev/null 2>&1; then
+    echo "{{.Name}}{{$.Separator}}{{.Instance}}{{$.Separator}}{{$.SkippedMsg}}"
+    return 0
   fi
-  # Output a dead event whenever the PID changes from a nonzero value to
-  # any other value. In particular, we emit a dead event when the node stops
-  # (lastpid is nonzero, pid is zero), but not when the process then starts
-  # again (lastpid is zero, pid is nonzero).
-  if [ "${pid}" != "${lastpid}" ]; then
-    if [ "${lastpid}" != 0 ]; then
-      if [ "${pid}" != 0 ]; then
-        # If the PID changed but neither is zero, then the status refers to
-        # the new incarnation. We lost the actual exit status of the old PID.
-        status="unknown"
+  {{- end}}
+  # Init with -1 so that when cockroach is initially dead, we print
+  # a dead event for it.
+  lastpid=-1
+  while :; do
+    # if parent process terminated, quit as well.
+    if dead_parent "$1"; then
+      return 0
+    fi
+    {{ if $.Local }}
+    pidFile=$(cat "{{pidFile .Name .Instance}}")
+    # Make sure the process is still running
+    pid=$(test -n "${pidFile}" && ps -p "${pidFile}" >/dev/null && echo "${pidFile}")
+    pid=${pid:-0} # default to 0
+    status="unknown"
+    {{- else }}
+    # When CRDB is not running, this is zero.
+    pid=$(systemctl show "{{virtualClusterLabel .Name .Instance}}" --property MainPID --value)
+    status=$(systemctl show "{{virtualClusterLabel .Name .Instance}}" --property ExecMainStatus --value)
+    {{- end }}
+    if [[ "${lastpid}" == -1 && "${pid}" != 0 ]]; then
+      # On the first iteration through the loop, if the process is running,
+      # don't register a PID change (which would trigger an erroneous dead
+      # event).
+      lastpid=0
+    fi
+    # Output a dead event whenever the PID changes from a nonzero value to
+    # any other value. In particular, we emit a dead event when the node stops
+    # (lastpid is nonzero, pid is zero), but not when the process then starts
+    # again (lastpid is zero, pid is nonzero).
+    if [ "${pid}" != "${lastpid}" ]; then
+      if [ "${lastpid}" != 0 ]; then
+        if [ "${pid}" != 0 ]; then
+          # If the PID changed but neither is zero, then the status refers to
+          # the new incarnation. We lost the actual exit status of the old PID.
+          status="unknown"
+        fi
+    	  echo "{{.Name}}{{$.Separator}}{{.Instance}}{{$.Separator}}{{$.DeadMsg}}{{$.Separator}}${status}"
       fi
-    	echo "{{.DeadMsg}}{{.Separator}}${status}"
+  	  if [ "${pid}" != 0 ]; then
+  		  echo "{{.Name}}{{$.Separator}}{{.Instance}}{{$.Separator}}{{$.RunningMsg}}{{$.Separator}}${pid}"
+      fi
+      lastpid=${pid}
     fi
-		if [ "${pid}" != 0 ]; then
-			echo "{{.RunningMsg}}{{.Separator}}${pid}"
+    {{ if $.OneShot }}
+      return 0
+    {{- end }}
+    sleep 1
+    if [ "${pid}" != 0 ]; then
+      while kill -0 "${pid}" && ! dead_parent "$1"; do
+        sleep 1
+      done
     fi
-    lastpid=${pid}
-  fi
-{{ if .OneShot }}
-  exit 0
-{{- end }}
-  sleep 1
-  if [ "${pid}" != 0 ]; then
-    while kill -0 "${pid}"; do
-      sleep 1
-    done
-  fi
-done
+  done
+}
+{{ end }}
+
+# monitor every cockroach process in parallel.
+{{ range .Processes }}
+monitor_process_{{$.Node}}_{{.Name}}_{{.Instance}} $$ &
+{{ end }}
+
+wait
 `
 
-			t := template.Must(template.New("script").Parse(snippet))
+			t := template.Must(template.New("script").Funcs(template.FuncMap{
+				"storeFor":            storeFor,
+				"pidFile":             localPIDFile,
+				"virtualClusterLabel": VirtualClusterLabel,
+			}).Parse(snippet))
 			var buf bytes.Buffer
 			if err := t.Execute(&buf, data); err != nil {
 				err := errors.Wrap(err, "failed to execute template")
@@ -786,7 +900,6 @@ done
 			if err != nil {
 				err := errors.Wrap(err, "failed to read stdout pipe")
 				sendEvent(NodeMonitorInfo{Node: node, Event: MonitorError{err}})
-				wg.Done()
 				return
 			}
 			// Request a PTY so that the script will receive a SIGPIPE when the
@@ -810,20 +923,46 @@ done
 					if err != nil {
 						err := errors.Wrap(err, "error reading from session")
 						sendEvent(NodeMonitorInfo{Node: node, Event: MonitorError{err}})
+						return
 					}
 
 					parts := strings.Split(string(line), separator)
-					switch parts[0] {
+					ensureNumParts := func(n int) {
+						if len(parts) < n {
+							panic(fmt.Errorf("invalid output from monitor: %q", line))
+						}
+					}
+					// Every event is expected to have at least 3 parts. If
+					// that's not the case, panic explicitly below. Otherwise,
+					// we'd get a slice out of bounds error and the error
+					// message would not include the actual problematic line,
+					// which would make understanding the failure more
+					// difficult.
+					ensureNumParts(3) // name, instance, event
+
+					// Virtual cluster name and instance are the first fields of
+					// every event type.
+					name, instanceStr := parts[0], parts[1]
+					instance, _ := strconv.Atoi(instanceStr)
+					switch parts[2] {
 					case skippedMsg:
-						sendEvent(NodeMonitorInfo{Node: node, Event: MonitorNodeSkipped{}})
+						sendEvent(NodeMonitorInfo{Node: node, Event: MonitorProcessSkipped{
+							VirtualClusterName: name, SQLInstance: instance,
+						}})
 					case runningMsg:
-						pid := parts[1]
-						sendEvent(NodeMonitorInfo{Node: node, Event: MonitorNodeRunning{pid}})
+						ensureNumParts(4)
+						pid := parts[3]
+						sendEvent(NodeMonitorInfo{Node: node, Event: MonitorProcessRunning{
+							VirtualClusterName: name, SQLInstance: instance, PID: pid,
+						}})
 					case deadMsg:
-						exitCode := parts[1]
-						sendEvent(NodeMonitorInfo{Node: node, Event: MonitorNodeDead{exitCode}})
+						ensureNumParts(4)
+						exitCode := parts[3]
+						sendEvent(NodeMonitorInfo{Node: node, Event: MonitorProcessDead{
+							VirtualClusterName: name, SQLInstance: instance, ExitCode: exitCode,
+						}})
 					default:
-						err := fmt.Errorf("internal error: unrecognized output from monitor: %s", line)
+						err := fmt.Errorf("internal error: unrecognized output from monitor: %q", line)
 						sendEvent(NodeMonitorInfo{Node: node, Event: MonitorError{err}})
 					}
 				}
@@ -835,8 +974,8 @@ done
 				return
 			}
 
-			// Watch for context cancellation, which can happen either if
-			// the test fails, or if the monitor loop exits.
+			// Watch for context cancellation, which can happen if the test
+			// fails, or if the monitor loop exits.
 			go func() {
 				<-monitorCtx.Done()
 				sess.Close()

--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -2877,7 +2877,7 @@ func (c *SyncedCluster) Init(ctx context.Context, l *logger.Logger, node Node) e
 		return errors.WithDetail(errors.CombineErrors(err, res.Err), "install.Init() failed: unable to initialize cluster.")
 	}
 
-	if res, err := c.setClusterSettings(ctx, l, node); err != nil || (res != nil && res.Err != nil) {
+	if res, err := c.setClusterSettings(ctx, l, node, ""); err != nil || (res != nil && res.Err != nil) {
 		return errors.WithDetail(errors.CombineErrors(err, res.Err), "install.Init() failed: unable to set cluster settings.")
 	}
 

--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -2522,11 +2522,7 @@ func (c *SyncedCluster) pgurls(
 		if err != nil {
 			return nil, err
 		}
-		sharedClusterName := ""
-		if desc.ServiceMode == ServiceModeShared {
-			sharedClusterName = virtualClusterName
-		}
-		m[node] = c.NodeURL(host, desc.Port, sharedClusterName)
+		m[node] = c.NodeURL(host, desc.Port, virtualClusterName, desc.ServiceMode)
 	}
 	return m, nil
 }

--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -1687,7 +1687,7 @@ tar cvf %[3]s certs
 // DistributeTenantCerts will generate and distribute certificates to all of the
 // nodes, using the host cluster to generate tenant certificates.
 func (c *SyncedCluster) DistributeTenantCerts(
-	ctx context.Context, l *logger.Logger, hostCluster *SyncedCluster, tenantID int,
+	ctx context.Context, l *logger.Logger, hostCluster *SyncedCluster, virtualClusterID int,
 ) error {
 	if hostCluster.checkForTenantCertificates(ctx, l) {
 		return nil
@@ -1702,7 +1702,7 @@ func (c *SyncedCluster) DistributeTenantCerts(
 		return err
 	}
 
-	if err := hostCluster.createTenantCertBundle(ctx, l, tenantCertsTarName, tenantID, nodeNames); err != nil {
+	if err := hostCluster.createTenantCertBundle(ctx, l, tenantCertsTarName, virtualClusterID, nodeNames); err != nil {
 		return err
 	}
 
@@ -1721,7 +1721,11 @@ func (c *SyncedCluster) DistributeTenantCerts(
 // This function assumes it is running on a host cluster node that already has
 // had the main cert bundle created.
 func (c *SyncedCluster) createTenantCertBundle(
-	ctx context.Context, l *logger.Logger, bundleName string, tenantID int, nodeNames []string,
+	ctx context.Context,
+	l *logger.Logger,
+	bundleName string,
+	virtualClusterID int,
+	nodeNames []string,
 ) error {
 	display := fmt.Sprintf("%s: initializing tenant certs", c.Name)
 	return c.Parallel(ctx, l, c.Nodes[0:1], func(ctx context.Context, node Node) (*RunResultDetails, error) {
@@ -1751,7 +1755,7 @@ fi
 `,
 			cockroachNodeBinary(c, node),
 			strings.Join(nodeNames, " "),
-			tenantID,
+			virtualClusterID,
 			bundleName,
 		)
 

--- a/pkg/roachprod/install/cockroach.go
+++ b/pkg/roachprod/install/cockroach.go
@@ -13,6 +13,7 @@ package install
 import (
 	"context"
 	_ "embed" // required for go:embed
+	"encoding/json"
 	"fmt"
 	"net/url"
 	"os"
@@ -353,13 +354,20 @@ func (c *SyncedCluster) Start(ctx context.Context, l *logger.Logger, startOpts S
 	}
 
 	if startOpts.IsVirtualCluster() {
-		if err := c.createVirtualClusterMetadata(ctx, l, startOpts); err != nil {
+		startOpts.VirtualClusterID, err = c.upsertVirtualClusterMetadata(ctx, l, startOpts)
+		if err != nil {
 			return err
 		}
-	}
 
-	if err := c.distributeTenantCerts(ctx, l, startOpts.KVCluster, startOpts.VirtualClusterID); err != nil {
-		return err
+		l.Printf("virtual cluster ID: %d", startOpts.VirtualClusterID)
+
+		if err := c.distributeTenantCerts(ctx, l, startOpts.KVCluster, startOpts.VirtualClusterID); err != nil {
+			return err
+		}
+	} else {
+		if err := c.distributeCerts(ctx, l); err != nil {
+			return err
+		}
 	}
 
 	nodes := c.TargetNodes()
@@ -1072,15 +1080,16 @@ func (c *SyncedCluster) distributeCerts(ctx context.Context, l *logger.Logger) e
 	return nil
 }
 
-// createVirtualClusterMetadata creates the virtual cluster, if
-// necessary. We only need to run the statements in this function
-// against a single connection to the storage cluster.
-func (c *SyncedCluster) createVirtualClusterMetadata(
+// upsertVirtualClusterMetadata creates the virtual cluster metadata,
+// if necessary, and marks the service as started internally. We only
+// need to run the statements in this function against a single
+// connection to the storage cluster.
+func (c *SyncedCluster) upsertVirtualClusterMetadata(
 	ctx context.Context, l *logger.Logger, startOpts StartOpts,
-) error {
+) (int, error) {
 	runSQL := func(stmt string) (string, error) {
 		results, err := startOpts.KVCluster.ExecSQL(ctx, l, startOpts.KVCluster.Nodes[:1], "", 0, []string{
-			"--format", "raw", "-e", stmt,
+			"--format", "json", "-e", stmt,
 		})
 		if err != nil {
 			return "", err
@@ -1092,42 +1101,75 @@ func (c *SyncedCluster) createVirtualClusterMetadata(
 		return results[0].CombinedOut, nil
 	}
 
-	tenantExistsQuery := fmt.Sprintf(
-		"SELECT 1 FROM system.tenants WHERE name = '%s'", startOpts.VirtualClusterName,
-	)
+	virtualClusterIDByName := func(name string) (int, error) {
+		type tenantRow struct {
+			ID string `json:"id"`
+		}
 
-	existsOut, err := runSQL(tenantExistsQuery)
+		query := fmt.Sprintf(
+			"SELECT id FROM system.tenants WHERE name = '%s'", startOpts.VirtualClusterName,
+		)
+
+		existsOut, err := runSQL(query)
+		if err != nil {
+			return -1, err
+		}
+
+		var tenants []tenantRow
+		if err := json.Unmarshal([]byte(existsOut), &tenants); err != nil {
+			return -1, fmt.Errorf("failed to unmarshal system.tenants output: %w", err)
+		}
+
+		if len(tenants) == 0 {
+			return -1, nil
+		}
+
+		n, err := strconv.Atoi(tenants[0].ID)
+		if err != nil {
+			return -1, fmt.Errorf("failed to parse virtual cluster ID: %w", err)
+		}
+
+		return n, nil
+	}
+
+	virtualClusterID, err := virtualClusterIDByName(startOpts.VirtualClusterName)
 	if err != nil {
-		return err
+		return -1, err
 	}
 
-	// Check if virtual cluster already exists, in which case there is
-	// nothing to do.
-	if !strings.Contains(existsOut, "0 rows") {
-		return nil
-	}
-
-	l.Printf("Creating virtual cluster metadata")
+	l.Printf("Starting virtual cluster")
 	serviceMode := "SHARED"
 	if startOpts.Target == StartServiceForVirtualCluster {
 		serviceMode = "EXTERNAL"
 	}
 
-	createTenantStmts := []string{
-		fmt.Sprintf("CREATE TENANT '%s'", startOpts.VirtualClusterName),
-		fmt.Sprintf("ALTER TENANT '%s' START SERVICE %s", startOpts.VirtualClusterName, serviceMode),
+	var virtualClusterStmts []string
+	if virtualClusterID <= 0 {
+		// If the virtual cluster metadata does not exist yet, create it.
+		virtualClusterStmts = append(virtualClusterStmts,
+			fmt.Sprintf("CREATE TENANT '%s'", startOpts.VirtualClusterName),
+		)
 	}
 
-	_, err = runSQL(strings.Join(createTenantStmts, "; "))
-	return err
+	virtualClusterStmts = append(virtualClusterStmts, fmt.Sprintf(
+		"ALTER TENANT '%s' START SERVICE %s",
+		startOpts.VirtualClusterName, serviceMode),
+	)
+
+	_, err = runSQL(strings.Join(virtualClusterStmts, "; "))
+	if err != nil {
+		return -1, err
+	}
+
+	return virtualClusterIDByName(startOpts.VirtualClusterName)
 }
 
 // distributeCerts distributes certs if it's a secure cluster.
 func (c *SyncedCluster) distributeTenantCerts(
-	ctx context.Context, l *logger.Logger, storageCluster *SyncedCluster, tenantID int,
+	ctx context.Context, l *logger.Logger, storageCluster *SyncedCluster, virtualClusterID int,
 ) error {
 	if c.Secure {
-		return c.DistributeTenantCerts(ctx, l, storageCluster, tenantID)
+		return c.DistributeTenantCerts(ctx, l, storageCluster, virtualClusterID)
 	}
 	return nil
 }

--- a/pkg/roachprod/install/cockroach.go
+++ b/pkg/roachprod/install/cockroach.go
@@ -564,23 +564,36 @@ func (c *SyncedCluster) generateStartCmd(
 			"GOTRACEBACK=crash",
 			"COCKROACH_SKIP_ENABLING_DIAGNOSTIC_REPORTING=1",
 		}, c.Env...), getEnvVars()...),
-		Binary:        cockroachNodeBinary(c, node),
-		Args:          args,
-		MemoryMax:     config.MemoryMax,
-		NumFilesLimit: startOpts.NumFilesLimit,
-		Local:         c.IsLocal(),
+		Binary:              cockroachNodeBinary(c, node),
+		Args:                args,
+		MemoryMax:           config.MemoryMax,
+		NumFilesLimit:       startOpts.NumFilesLimit,
+		VirtualClusterLabel: VirtualClusterLabel(startOpts.VirtualClusterName, startOpts.SQLInstance),
+		Local:               c.IsLocal(),
 	})
 }
 
 type startTemplateData struct {
-	Local         bool
-	LogDir        string
-	Binary        string
-	KeyCmd        string
-	MemoryMax     string
-	NumFilesLimit int64
-	Args          []string
-	EnvVars       []string
+	Local               bool
+	LogDir              string
+	Binary              string
+	KeyCmd              string
+	MemoryMax           string
+	NumFilesLimit       int64
+	VirtualClusterLabel string
+	Args                []string
+	EnvVars             []string
+}
+
+// VirtualClusterLabel is the value used to "label" virtual cluster
+// (cockroach) processes running locally or in a VM. This is used by
+// roachprod to monitor identify such processes and monitor them.
+func VirtualClusterLabel(virtualClusterName string, sqlInstance int) string {
+	if virtualClusterName == "" || virtualClusterName == SystemInterfaceName {
+		return "cockroach-system"
+	}
+
+	return fmt.Sprintf("cockroach-%s_%d", virtualClusterName, sqlInstance)
 }
 
 func execStartTemplate(data startTemplateData) (string, error) {

--- a/pkg/roachprod/install/cockroach.go
+++ b/pkg/roachprod/install/cockroach.go
@@ -297,6 +297,10 @@ func (c *SyncedCluster) Start(ctx context.Context, l *logger.Logger, startOpts S
 			return err
 		}
 	case StartServiceForVirtualCluster:
+		if err := c.createTenantMetadata(ctx, l, startOpts.VirtualClusterName, startOpts.KVCluster); err != nil {
+			return err
+		}
+
 		if err := c.distributeTenantCerts(ctx, l, startOpts.KVCluster, startOpts.VirtualClusterID); err != nil {
 			return err
 		}
@@ -1006,12 +1010,54 @@ func (c *SyncedCluster) distributeCerts(ctx context.Context, l *logger.Logger) e
 	return nil
 }
 
+// createTenantMetadata creates the virtual cluster, if necessary. We
+// only need to run the statements in this function against a single
+// connection to the storage cluster.
+func (c *SyncedCluster) createTenantMetadata(
+	ctx context.Context, l *logger.Logger, virtualClusterName string, storageCluster *SyncedCluster,
+) error {
+	runSQL := func(stmt string) (string, error) {
+		results, err := storageCluster.ExecSQL(ctx, l, storageCluster.Nodes[:1], "", 0, []string{
+			"--format", "raw", "-e", stmt,
+		})
+		if err != nil {
+			return "", err
+		}
+
+		return results[0].CombinedOut, nil
+	}
+
+	tenantExistsQuery := fmt.Sprintf(
+		"SELECT 1 FROM system.tenants WHERE name = '%s'", virtualClusterName,
+	)
+
+	existsOut, err := runSQL(tenantExistsQuery)
+	if err != nil {
+		return err
+	}
+
+	// Check if virtual cluster already exists, in which case there is
+	// nothing to do.
+	if !strings.Contains(existsOut, "0 rows") {
+		return nil
+	}
+
+	l.Printf("Creating tenant metadata")
+	createTenantStmts := []string{
+		fmt.Sprintf("CREATE TENANT '%s'", virtualClusterName),
+		fmt.Sprintf("ALTER TENANT '%s' START SERVICE EXTERNAL", virtualClusterName),
+	}
+
+	_, err = runSQL(strings.Join(createTenantStmts, "; "))
+	return err
+}
+
 // distributeCerts distributes certs if it's a secure cluster.
 func (c *SyncedCluster) distributeTenantCerts(
-	ctx context.Context, l *logger.Logger, hostCluster *SyncedCluster, tenantID int,
+	ctx context.Context, l *logger.Logger, storageCluster *SyncedCluster, tenantID int,
 ) error {
 	if c.Secure {
-		return c.DistributeTenantCerts(ctx, l, hostCluster, tenantID)
+		return c.DistributeTenantCerts(ctx, l, storageCluster, tenantID)
 	}
 	return nil
 }

--- a/pkg/roachprod/install/cockroach.go
+++ b/pkg/roachprod/install/cockroach.go
@@ -409,7 +409,9 @@ func (c *SyncedCluster) CertsDir(node Node) string {
 // NodeURL constructs a postgres URL. If sharedTenantName is not empty, it will
 // be used as the virtual cluster name in the URL. This is used to connect to a
 // shared process running services for multiple virtual clusters.
-func (c *SyncedCluster) NodeURL(host string, port int, virtualClusterName string) string {
+func (c *SyncedCluster) NodeURL(
+	host string, port int, virtualClusterName string, serviceMode ServiceMode,
+) string {
 	var u url.URL
 	u.User = url.User("root")
 	u.Scheme = "postgres"
@@ -423,7 +425,7 @@ func (c *SyncedCluster) NodeURL(host string, port int, virtualClusterName string
 	} else {
 		v.Add("sslmode", "disable")
 	}
-	if virtualClusterName != "" {
+	if serviceMode == ServiceModeShared && virtualClusterName != "" {
 		v.Add("options", fmt.Sprintf("-ccluster=%s", virtualClusterName))
 	}
 	u.RawQuery = v.Encode()
@@ -467,11 +469,7 @@ func (c *SyncedCluster) ExecOrInteractiveSQL(
 	if virtualClusterName == "" {
 		virtualClusterName = SystemInterfaceName
 	}
-	virtualCluster := ""
-	if desc.ServiceMode == ServiceModeShared {
-		virtualCluster = virtualClusterName
-	}
-	url := c.NodeURL("localhost", desc.Port, virtualCluster)
+	url := c.NodeURL("localhost", desc.Port, virtualClusterName, desc.ServiceMode)
 	binary := cockroachNodeBinary(c, c.Nodes[0])
 	allArgs := []string{binary, "sql", "--url", url}
 	allArgs = append(allArgs, ssh.Escape(args))
@@ -495,16 +493,12 @@ func (c *SyncedCluster) ExecSQL(
 		if err != nil {
 			return nil, err
 		}
-		sharedTenantName := ""
-		if desc.ServiceMode == ServiceModeShared {
-			sharedTenantName = virtualClusterName
-		}
 		var cmd string
 		if c.IsLocal() {
 			cmd = fmt.Sprintf(`cd %s ; `, c.localVMDir(node))
 		}
 		cmd += cockroachNodeBinary(c, node) + " sql --url " +
-			c.NodeURL("localhost", desc.Port, sharedTenantName) + " " +
+			c.NodeURL("localhost", desc.Port, virtualClusterName, desc.ServiceMode) + " " +
 			ssh.Escape(args)
 
 		return c.runCmdOnSingleNode(ctx, l, node, cmd, defaultCmdOpts("run-sql"))
@@ -922,7 +916,7 @@ func (c *SyncedCluster) generateClusterSettingCmd(
 	if err != nil {
 		return "", err
 	}
-	url := c.NodeURL("localhost", port, SystemInterfaceName /* virtualClusterName */)
+	url := c.NodeURL("localhost", port, SystemInterfaceName /* virtualClusterName */, ServiceModeShared)
 
 	clusterSettingsCmd += fmt.Sprintf(`
 		if ! test -e %s ; then
@@ -942,7 +936,7 @@ func (c *SyncedCluster) generateInitCmd(ctx context.Context, node Node) (string,
 	if err != nil {
 		return "", err
 	}
-	url := c.NodeURL("localhost", port, SystemInterfaceName /* virtualClusterName */)
+	url := c.NodeURL("localhost", port, SystemInterfaceName /* virtualClusterName */, ServiceModeShared)
 	binary := cockroachNodeBinary(c, node)
 	initCmd += fmt.Sprintf(`
 		if ! test -e %[1]s ; then
@@ -1110,7 +1104,7 @@ func (c *SyncedCluster) createFixedBackupSchedule(
 	if err != nil {
 		return err
 	}
-	url := c.NodeURL("localhost", port, SystemInterfaceName /* virtualClusterName */)
+	url := c.NodeURL("localhost", port, SystemInterfaceName /* virtualClusterName */, ServiceModeShared)
 	fullCmd := fmt.Sprintf(`COCKROACH_CONNECT_TIMEOUT=%d %s sql --url %s -e %q`,
 		startSQLTimeout, binary, url, createScheduleCmd)
 	// Instead of using `c.ExecSQL()`, use `c.runCmdOnSingleNode()`, which allows us to

--- a/pkg/roachprod/install/cockroach_test.go
+++ b/pkg/roachprod/install/cockroach_test.go
@@ -1,0 +1,67 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package install
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestVirtualClusterLabel(t *testing.T) {
+	testCases := []struct {
+		name               string
+		virtualClusterName string
+		sqlInstance        int
+		expectedLabel      string
+	}{
+		{
+			name:               "empty virtual cluster name",
+			virtualClusterName: "",
+			expectedLabel:      "cockroach-system",
+		},
+		{
+			name:               "system interface name",
+			virtualClusterName: "system",
+			expectedLabel:      "cockroach-system",
+		},
+		{
+			name:               "simple virtual cluster name",
+			virtualClusterName: "a",
+			sqlInstance:        1,
+			expectedLabel:      "cockroach-a_1",
+		},
+		{
+			name:               "virtual cluster name with hyphens",
+			virtualClusterName: "virtual-cluster-a-1",
+			sqlInstance:        1,
+			expectedLabel:      "cockroach-virtual-cluster-a-1_1",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			label := VirtualClusterLabel(tc.virtualClusterName, tc.sqlInstance)
+			require.Equal(t, tc.expectedLabel, label)
+
+			nameFromLabel, instanceFromLabel, err := VirtualClusterInfoFromLabel(label)
+			require.NoError(t, err)
+
+			expectedVirtualClusterName := tc.virtualClusterName
+			if tc.virtualClusterName == "" {
+				expectedVirtualClusterName = "system"
+			}
+			require.Equal(t, expectedVirtualClusterName, nameFromLabel)
+
+			require.Equal(t, tc.sqlInstance, instanceFromLabel)
+		})
+	}
+}

--- a/pkg/roachprod/install/scripts/start.sh
+++ b/pkg/roachprod/install/scripts/start.sh
@@ -20,6 +20,7 @@ BINARY=#{shesc .Binary#}
 KEY_CMD=#{.KeyCmd#}
 MEMORY_MAX=#{.MemoryMax#}
 NUM_FILES_LIMIT=#{.NumFilesLimit#}
+VIRTUAL_CLUSTER_LABEL=#{.VirtualClusterLabel#}
 ARGS=(
 #{range .Args -#}
 #{shesc .#}
@@ -50,7 +51,7 @@ if [[ -n "${LOCAL}" || "${1-}" == "run" ]]; then
     mkdir -p "${BAZEL_COVER_DIR}"
   fi
   CODE=0
-  "${BINARY}" "${ARGS[@]}" >> "${LOG_DIR}/cockroach.stdout.log" 2>> "${LOG_DIR}/cockroach.stderr.log" || CODE="$?"
+  ROACHPROD_VIRTUAL_CLUSTER="${VIRTUAL_CLUSTER_LABEL}" "${BINARY}" "${ARGS[@]}" >> "${LOG_DIR}/cockroach.stdout.log" 2>> "${LOG_DIR}/cockroach.stderr.log" || CODE="$?"
   if [[ -z "${LOCAL}" || "${CODE}" -ne 0 ]]; then
     echo "cockroach exited with code ${CODE}: $(date)" | tee -a "${LOG_DIR}"/{roachprod,cockroach.{exit,std{out,err}}}.log
   fi
@@ -73,18 +74,18 @@ sudo systemctl reset-failed cockroach 2>/dev/null || true
 # The first time we run, install a small script that shows some helpful
 # information when we ssh in.
 if [ ! -e "${HOME}/.profile-cockroach" ]; then
-  cat > "${HOME}/.profile-cockroach" <<'EOQ'
+  cat > "${HOME}/.profile-${VIRTUAL_CLUSTER_LABEL}" <<'EOQ'
 echo ""
-if systemctl is-active -q cockroach; then
-  echo "cockroach is running; see: systemctl status cockroach"
-elif systemctl is-failed -q cockroach; then
-  echo "cockroach stopped; see: systemctl status cockroach"
+if systemctl is-active -q ${VIRTUAL_CLUSTER_LABEL}; then
+  echo "${VIRTUAL_CLUSTER_LABEL} is running; see: systemctl status ${VIRTUAL_CLUSTER_LABEL}"
+elif systemctl is-failed -q ${VIRTUAL_CLUSTER_LABEL}; then
+  echo "${VIRTUAL_CLUSTER_LABEL} stopped; see: systemctl status ${VIRTUAL_CLUSTER_LABEL}"
 else
-  echo "cockroach not started"
+  echo "${VIRTUAL_CLUSTER_LABEL} not started"
 fi
 echo ""
 EOQ
-  echo ". ${HOME}/.profile-cockroach" >> "${HOME}/.profile"
+  echo ". ${HOME}/.profile-${VIRTUAL_CLUSTER_LABEL}" >> "${HOME}/.profile"
 fi
 
 # We run this script (with arg "run") as a service unit. We do not use --user
@@ -93,7 +94,7 @@ fi
 # The "notify" service type means that systemd-run waits until cockroach
 # notifies systemd that it is ready; NotifyAccess=all is needed because this
 # notification doesn't come from the main PID (which is bash).
-sudo systemd-run --unit cockroach \
+sudo systemd-run --unit "${VIRTUAL_CLUSTER_LABEL}" \
   --same-dir --uid "$(id -u)" --gid "$(id -g)" \
   --service-type=notify -p NotifyAccess=all \
   -p "MemoryMax=${MEMORY_MAX}" \

--- a/pkg/roachprod/install/session.go
+++ b/pkg/roachprod/install/session.go
@@ -18,6 +18,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"sync"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/roachprod/config"
 	rperrors "github.com/cockroachdb/cockroach/pkg/roachprod/errors"
@@ -214,7 +215,15 @@ func (s *remoteSession) StderrPipe() (io.Reader, error) {
 }
 
 func (s *remoteSession) RequestPty() error {
-	s.Cmd.Args = append(s.Cmd.Args, "-t")
+	if len(s.Cmd.Args) == 0 {
+		return fmt.Errorf("unexpected remote command: expected arguments, none found")
+	}
+
+	// Add the `-t` option after `ssh user@host`, otherwise, "-t" could
+	// confuse the underlying shell used when executing complex commands
+	// using `ssh`, leading to cryptic errors like: `bash: line 70:
+	// syntax error near -t`.
+	s.Cmd.Args = append(s.Cmd.Args[:1], append([]string{"-t"}, s.Cmd.Args[1:]...)...)
 	return nil
 }
 
@@ -237,6 +246,7 @@ type localSession struct {
 func newLocalSession(cmd string) *localSession {
 	ctx, cancel := context.WithCancel(context.Background())
 	fullCmd := exec.CommandContext(ctx, "/bin/bash", "-c", cmd)
+	fullCmd.WaitDelay = time.Second
 	return &localSession{fullCmd, cancel}
 }
 

--- a/pkg/roachprod/install/session.go
+++ b/pkg/roachprod/install/session.go
@@ -18,7 +18,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"sync"
-	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/roachprod/config"
 	rperrors "github.com/cockroachdb/cockroach/pkg/roachprod/errors"
@@ -246,7 +245,6 @@ type localSession struct {
 func newLocalSession(cmd string) *localSession {
 	ctx, cancel := context.WithCancel(context.Background())
 	fullCmd := exec.CommandContext(ctx, "/bin/bash", "-c", cmd)
-	fullCmd.WaitDelay = time.Second
 	return &localSession{fullCmd, cancel}
 }
 

--- a/pkg/roachprod/install/start_template_test.go
+++ b/pkg/roachprod/install/start_template_test.go
@@ -23,11 +23,12 @@ func TestExecStartTemplate(t *testing.T) {
 		LogDir: "./path with spaces/logs/$THIS_DOES_NOT_EVER_GET_EXPANDED",
 		KeyCmd: `echo foo && \
 echo bar $HOME`,
-		EnvVars:   []string{"ROACHPROD=1/tigtag", "COCKROACH=foo", "ROCKCOACH=17%"},
-		Binary:    "./cockroach",
-		Args:      []string{`start`, `--log`, `file-defaults: {dir: '/path with spaces/logs', exit-on-error: false}`},
-		MemoryMax: "81%",
-		Local:     true,
+		EnvVars:             []string{"ROACHPROD=1/tigtag", "COCKROACH=foo", "ROCKCOACH=17%"},
+		Binary:              "./cockroach",
+		Args:                []string{`start`, `--log`, `file-defaults: {dir: '/path with spaces/logs', exit-on-error: false}`},
+		MemoryMax:           "81%",
+		VirtualClusterLabel: "cockroach-system",
+		Local:               true,
 	}
 	datadriven.Walk(t, datapathutils.TestDataPath(t, "start"), func(t *testing.T, path string) {
 		datadriven.RunTest(t, path, func(t *testing.T, td *datadriven.TestData) string {

--- a/pkg/roachprod/install/testdata/start/start.txt
+++ b/pkg/roachprod/install/testdata/start/start.txt
@@ -24,6 +24,7 @@ KEY_CMD=echo foo && \
 echo bar $HOME
 MEMORY_MAX=81%
 NUM_FILES_LIMIT=0
+VIRTUAL_CLUSTER_LABEL=cockroach-system
 ARGS=(
 start
 --log
@@ -54,7 +55,7 @@ if [[ -n "${LOCAL}" || "${1-}" == "run" ]]; then
     mkdir -p "${BAZEL_COVER_DIR}"
   fi
   CODE=0
-  "${BINARY}" "${ARGS[@]}" >> "${LOG_DIR}/cockroach.stdout.log" 2>> "${LOG_DIR}/cockroach.stderr.log" || CODE="$?"
+  ROACHPROD_VIRTUAL_CLUSTER="${VIRTUAL_CLUSTER_LABEL}" "${BINARY}" "${ARGS[@]}" >> "${LOG_DIR}/cockroach.stdout.log" 2>> "${LOG_DIR}/cockroach.stderr.log" || CODE="$?"
   if [[ -z "${LOCAL}" || "${CODE}" -ne 0 ]]; then
     echo "cockroach exited with code ${CODE}: $(date)" | tee -a "${LOG_DIR}"/{roachprod,cockroach.{exit,std{out,err}}}.log
   fi
@@ -77,18 +78,18 @@ sudo systemctl reset-failed cockroach 2>/dev/null || true
 # The first time we run, install a small script that shows some helpful
 # information when we ssh in.
 if [ ! -e "${HOME}/.profile-cockroach" ]; then
-  cat > "${HOME}/.profile-cockroach" <<'EOQ'
+  cat > "${HOME}/.profile-${VIRTUAL_CLUSTER_LABEL}" <<'EOQ'
 echo ""
-if systemctl is-active -q cockroach; then
-  echo "cockroach is running; see: systemctl status cockroach"
-elif systemctl is-failed -q cockroach; then
-  echo "cockroach stopped; see: systemctl status cockroach"
+if systemctl is-active -q ${VIRTUAL_CLUSTER_LABEL}; then
+  echo "${VIRTUAL_CLUSTER_LABEL} is running; see: systemctl status ${VIRTUAL_CLUSTER_LABEL}"
+elif systemctl is-failed -q ${VIRTUAL_CLUSTER_LABEL}; then
+  echo "${VIRTUAL_CLUSTER_LABEL} stopped; see: systemctl status ${VIRTUAL_CLUSTER_LABEL}"
 else
-  echo "cockroach not started"
+  echo "${VIRTUAL_CLUSTER_LABEL} not started"
 fi
 echo ""
 EOQ
-  echo ". ${HOME}/.profile-cockroach" >> "${HOME}/.profile"
+  echo ". ${HOME}/.profile-${VIRTUAL_CLUSTER_LABEL}" >> "${HOME}/.profile"
 fi
 
 # We run this script (with arg "run") as a service unit. We do not use --user
@@ -97,7 +98,7 @@ fi
 # The "notify" service type means that systemd-run waits until cockroach
 # notifies systemd that it is ready; NotifyAccess=all is needed because this
 # notification doesn't come from the main PID (which is bash).
-sudo systemd-run --unit cockroach \
+sudo systemd-run --unit "${VIRTUAL_CLUSTER_LABEL}" \
   --same-dir --uid "$(id -u)" --gid "$(id -g)" \
   --service-type=notify -p NotifyAccess=all \
   -p "MemoryMax=${MEMORY_MAX}" \

--- a/pkg/roachprod/install/testdata/start/start.txt
+++ b/pkg/roachprod/install/testdata/start/start.txt
@@ -39,7 +39,11 @@ ROCKCOACH=17%
 # End of templated code.
 
 if [[ -n "${LOCAL}" ]]; then
-  ARGS+=("--background")
+  # Write to an empty pid file. This is referenced by the roachprod
+  # monitor to find the PID of cockroach processes running locally.
+  PID_FILE="${LOG_DIR}/cockroach.pid"
+  rm -f "${PID_FILE}"
+  ARGS+=("--background" "--pid-file" "${PID_FILE}")
 fi
 
 if [[ -n "${LOCAL}" || "${1-}" == "run" ]]; then
@@ -65,20 +69,20 @@ fi
 # Set up systemd unit and start it, which will recursively
 # invoke this script but hit the above conditional.
 
-if systemctl is-active -q cockroach; then
-  echo "cockroach service already active"
-  echo "To get more information: systemctl status cockroach"
+if systemctl is-active -q "${VIRTUAL_CLUSTER_LABEL}"; then
+  echo "${VIRTUAL_CLUSTER_LABEL} service already active"
+  echo "To get more information: systemctl status ${VIRTUAL_CLUSTER_LABEL}"
   exit 1
 fi
 
 # If cockroach failed, the service still exists; we need to clean it up before
 # we can start it again.
-sudo systemctl reset-failed cockroach 2>/dev/null || true
+sudo systemctl reset-failed "${VIRTUAL_CLUSTER_LABEL}" 2>/dev/null || true
 
 # The first time we run, install a small script that shows some helpful
 # information when we ssh in.
 if [ ! -e "${HOME}/.profile-cockroach" ]; then
-  cat > "${HOME}/.profile-${VIRTUAL_CLUSTER_LABEL}" <<'EOQ'
+  cat > "${HOME}/.profile-${VIRTUAL_CLUSTER_LABEL}" <<EOQ
 echo ""
 if systemctl is-active -q ${VIRTUAL_CLUSTER_LABEL}; then
   echo "${VIRTUAL_CLUSTER_LABEL} is running; see: systemctl status ${VIRTUAL_CLUSTER_LABEL}"

--- a/pkg/roachprod/multitenant.go
+++ b/pkg/roachprod/multitenant.go
@@ -33,12 +33,12 @@ import (
 func StartServiceForVirtualCluster(
 	ctx context.Context,
 	l *logger.Logger,
-	tenantCluster string,
+	virtualCluster string,
 	storageCluster string,
 	startOpts install.StartOpts,
 	clusterSettingsOpts ...install.ClusterSettingOption,
 ) error {
-	tc, err := newCluster(l, tenantCluster, clusterSettingsOpts...)
+	tc, err := newCluster(l, virtualCluster, clusterSettingsOpts...)
 	if err != nil {
 		return err
 	}
@@ -53,8 +53,7 @@ func StartServiceForVirtualCluster(
 	if startOpts.VirtualClusterID < 2 {
 		return errors.Errorf("invalid tenant ID %d (must be 2 or higher)", startOpts.VirtualClusterID)
 	}
-	// TODO(herko): Allow users to pass in a virtual cluster name.
-	startOpts.VirtualClusterName = fmt.Sprintf("tenant-%d", startOpts.VirtualClusterID)
+	startOpts.VirtualClusterName = defaultVirtualClusterName(startOpts.VirtualClusterID)
 
 	// Create virtual cluster, if necessary. We only need to run this
 	// SQL against a single connection to the storage cluster.
@@ -78,6 +77,28 @@ func StartServiceForVirtualCluster(
 	startOpts.KVAddrs = strings.Join(kvAddrs, ",")
 	startOpts.KVCluster = hc
 	return tc.Start(ctx, l, startOpts)
+}
+
+// StopServiceForVirtualCluster stops SQL instance processes on the virtualCluster given.
+func StopServiceForVirtualCluster(
+	ctx context.Context, l *logger.Logger, virtualCluster string, stopOpts StopOpts,
+) error {
+	tc, err := newCluster(l, virtualCluster)
+	if err != nil {
+		return err
+	}
+
+	stopOpts.VirtualClusterName = defaultVirtualClusterName(stopOpts.VirtualClusterID)
+	vc := install.VirtualClusterLabel(stopOpts.VirtualClusterName, stopOpts.SQLInstance)
+	return tc.Stop(ctx, l, stopOpts.Sig, stopOpts.Wait, stopOpts.MaxWait, vc)
+}
+
+// defaultVirtualClusterName returns the virtual cluster name used for
+// the virtual cluster with ID given.
+//
+// TODO(herko): Allow users to pass in a virtual cluster name.
+func defaultVirtualClusterName(virtualClusterID int) string {
+	return fmt.Sprintf("virtual-cluster-%d", virtualClusterID)
 }
 
 // createVirtualClusterIfNotExistsQuery is used to initialize the

--- a/pkg/roachprod/multitenant.go
+++ b/pkg/roachprod/multitenant.go
@@ -80,16 +80,16 @@ func StartServiceForVirtualCluster(
 
 // StopServiceForVirtualCluster stops SQL instance processes on the virtualCluster given.
 func StopServiceForVirtualCluster(
-	ctx context.Context, l *logger.Logger, virtualCluster string, stopOpts StopOpts,
+	ctx context.Context, l *logger.Logger, clusterName string, stopOpts StopOpts,
 ) error {
-	tc, err := newCluster(l, virtualCluster)
+	c, err := newCluster(l, clusterName)
 	if err != nil {
 		return err
 	}
 
 	stopOpts.VirtualClusterName = defaultVirtualClusterName(stopOpts.VirtualClusterID)
-	vc := install.VirtualClusterLabel(stopOpts.VirtualClusterName, stopOpts.SQLInstance)
-	return tc.Stop(ctx, l, stopOpts.Sig, stopOpts.Wait, stopOpts.MaxWait, vc)
+	label := install.VirtualClusterLabel(stopOpts.VirtualClusterName, stopOpts.SQLInstance)
+	return c.Stop(ctx, l, stopOpts.Sig, stopOpts.Wait, stopOpts.MaxWait, label)
 }
 
 // defaultVirtualClusterName returns the virtual cluster name used for

--- a/pkg/roachprod/multitenant.go
+++ b/pkg/roachprod/multitenant.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
-	"github.com/cockroachdb/errors"
 )
 
 // StartServiceForVirtualCluster starts SQL/HTTP instances for a
@@ -67,11 +66,6 @@ func StartServiceForVirtualCluster(
 		startCluster = ec
 	}
 
-	if startOpts.VirtualClusterID < 2 {
-		return errors.Errorf("invalid virtual cluster ID %d (must be 2 or higher)", startOpts.VirtualClusterID)
-	}
-	startOpts.VirtualClusterName = defaultVirtualClusterName(startOpts.VirtualClusterID)
-
 	if startOpts.Target == install.StartServiceForVirtualCluster {
 		l.Printf("Starting SQL/HTTP instances for the virtual cluster")
 	}
@@ -87,15 +81,6 @@ func StopServiceForVirtualCluster(
 		return err
 	}
 
-	stopOpts.VirtualClusterName = defaultVirtualClusterName(stopOpts.VirtualClusterID)
 	label := install.VirtualClusterLabel(stopOpts.VirtualClusterName, stopOpts.SQLInstance)
 	return c.Stop(ctx, l, stopOpts.Sig, stopOpts.Wait, stopOpts.MaxWait, label)
-}
-
-// defaultVirtualClusterName returns the virtual cluster name used for
-// the virtual cluster with ID given.
-//
-// TODO(herko): Allow users to pass in a virtual cluster name.
-func defaultVirtualClusterName(virtualClusterID int) string {
-	return fmt.Sprintf("virtual-cluster-%d", virtualClusterID)
 }

--- a/pkg/roachprod/multitenant.go
+++ b/pkg/roachprod/multitenant.go
@@ -58,7 +58,7 @@ func StartServiceForVirtualCluster(
 	// Create virtual cluster, if necessary. We only need to run this
 	// SQL against a single connection to the storage cluster.
 	l.Printf("Creating tenant metadata")
-	if err := hc.ExecSQL(ctx, l, hc.Nodes[:1], "", 0, []string{
+	if _, err := hc.ExecSQL(ctx, l, hc.Nodes[:1], "", 0, []string{
 		`-e`,
 		fmt.Sprintf(createVirtualClusterIfNotExistsQuery, startOpts.VirtualClusterID),
 	}); err != nil {

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -708,6 +708,11 @@ type StopOpts struct {
 	// If MaxWait is set, roachprod waits that approximate number of seconds
 	// until the PID disappears.
 	MaxWait int
+
+	// Options that only apply to StopServiceForVirtualCluster
+	VirtualClusterID   int
+	VirtualClusterName string
+	SQLInstance        int
 }
 
 // DefaultStopOpts returns StopOpts populated with the default values used by Stop.
@@ -729,7 +734,7 @@ func Stop(ctx context.Context, l *logger.Logger, clusterName string, opts StopOp
 	if err != nil {
 		return err
 	}
-	return c.Stop(ctx, l, opts.Sig, opts.Wait, opts.MaxWait)
+	return c.Stop(ctx, l, opts.Sig, opts.Wait, opts.MaxWait, "")
 }
 
 // Signal sends a signal to nodes in the cluster.

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -430,7 +430,15 @@ func SQL(
 	if len(c.Nodes) == 1 {
 		return c.ExecOrInteractiveSQL(ctx, l, tenantName, tenantInstance, cmdArray)
 	}
-	return c.ExecSQL(ctx, l, c.Nodes, tenantName, tenantInstance, cmdArray)
+	results, err := c.ExecSQL(ctx, l, c.Nodes, tenantName, tenantInstance, cmdArray)
+	if err != nil {
+		return err
+	}
+
+	for _, r := range results {
+		l.Printf("node %d:\n%s", r.Node, r.CombinedOut)
+	}
+	return nil
 }
 
 // IP gets the ip addresses of the nodes in a cluster.

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -947,7 +947,7 @@ func PgURL(
 		if ip == "" {
 			return nil, errors.Errorf("empty ip: %v", ips)
 		}
-		urls = append(urls, c.NodeURL(ip, desc.Port, opts.VirtualClusterName))
+		urls = append(urls, c.NodeURL(ip, desc.Port, opts.VirtualClusterName, desc.ServiceMode))
 	}
 	if len(urls) != len(nodes) {
 		return nil, errors.Errorf("have nodes %v, but urls %v from ips %v", nodes, urls, ips)

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -664,8 +664,10 @@ func DefaultStartOpts() install.StartOpts {
 		ScheduleBackups:    false,
 		ScheduleBackupArgs: "",
 		InitTarget:         1,
-		SQLPort:            config.DefaultSQLPort,
-		AdminUIPort:        config.DefaultAdminUIPort,
+		// TODO(renato): change the defaults below to `0` (i.e., pick a
+		// random available port) once #111052 is addressed.
+		SQLPort:     config.DefaultSQLPort,
+		AdminUIPort: config.DefaultAdminUIPort,
 	}
 }
 


### PR DESCRIPTION
Backport:
  * 3/3 commits from "roachprod: add virtual cluster support to the monitor" (#111064)
  * 1/1 commits form "roachtest: remove direct references to cockroach.service from tests" (#111915)
  * 6/6 commits from "roachprod: support managing shared process virtual clusters" (#111533)
  * 1/1 commits from "roachtest: introduce structured version objects" (#112568)
  * 1/1 commits from "roachprod: remove `WaitDelay` call in `localSession`" (#112714)

Please see individual PRs for details.

/cc @cockroachdb/release

Release justification: test-only changes.