### PR TITLE
sql: unskip TestTelemetry/sql-stats

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -55,7 +55,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scerrors"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scrun"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/asof"
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/catconstants"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
@@ -733,11 +732,7 @@ func (s *Server) getScrubbedStmtStats(
 		}
 
 		stat.Key.Query = scrubbedQueryStr
-
-		// Possibly scrub the app name.
-		if !strings.HasPrefix(stat.Key.App, catconstants.ReportableAppNamePrefix) {
-			stat.Key.App = HashForReporting(salt, stat.Key.App)
-		}
+		stat.Key.App = MaybeHashAppName(stat.Key.App, salt)
 
 		// Quantize the counts to avoid leaking information that way.
 		quantizeCounts(&stat.Stats)

--- a/pkg/sql/sqltestutils/BUILD.bazel
+++ b/pkg/sql/sqltestutils/BUILD.bazel
@@ -32,7 +32,6 @@ go_library(
         "//pkg/testutils",
         "//pkg/testutils/diagutils",
         "//pkg/testutils/serverutils",
-        "//pkg/testutils/skip",
         "//pkg/testutils/sqlutils",
         "//pkg/util",
         "//pkg/util/cloudinfo",

--- a/pkg/sql/sqltestutils/telemetry.go
+++ b/pkg/sql/sqltestutils/telemetry.go
@@ -32,7 +32,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/diagutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
-	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/cloudinfo"
 	"github.com/cockroachdb/cockroach/pkg/util/treeprinter"
@@ -90,10 +89,6 @@ func TelemetryTest(t *testing.T, serverArgs []base.TestServerArgs, testTenant bo
 		var test telemetryTest
 		test.Start(t, serverArgs)
 		defer test.Close()
-
-		if path == "testdata/telemetry/sql-stats" {
-			skip.WithIssue(t, 107593)
-		}
 
 		// Run test against physical CRDB cluster.
 		t.Run("server", func(t *testing.T) {

--- a/pkg/sql/sqltestutils/telemetry.go
+++ b/pkg/sql/sqltestutils/telemetry.go
@@ -366,7 +366,9 @@ func formatSQLStats(stats []appstatspb.CollectedStatementStatistics) string {
 	for i := range stats {
 		s := &stats[i]
 
-		if strings.HasPrefix(s.Key.App, catconstants.InternalAppNamePrefix) {
+		if strings.HasPrefix(s.Key.App,
+			catconstants.InternalAppNamePrefix) || strings.HasPrefix(s.Key.App,
+			catconstants.DelegatedAppNamePrefix) {
 			// Let's ignore all internal queries for this test.
 			continue
 		}

--- a/pkg/sql/testdata/telemetry/sql-stats
+++ b/pkg/sql/testdata/telemetry/sql-stats
@@ -23,7 +23,7 @@ error: pq: failed to satisfy CHECK constraint (a > 1:::INT8)
 sql-stats
  └── $ some app
       ├── [nodist] CREATE TABLE _ (_ INT8, CONSTRAINT _ CHECK (_ > _))
-      └── [failed,nodist] INSERT INTO _ SELECT unnest(ARRAY[_, _, __more1_10__])
+      └── [failed,nodist] INSERT INTO _ SELECT _(ARRAY[_, _, __more1_10__])
 
 # Verify statements are correctly separated by app.
 sql-stats
@@ -37,14 +37,11 @@ CREATE TABLE baz.t (x INT, y INT);
 INSERT INTO baz.t VALUES (1, 1), (2, 2);
 ----
 sql-stats
- ├── $ some app
- │    ├── [nodist] CREATE TABLE _ (_ INT8, _ INT8)
- │    └── [nodist] SET application_name = '_'
- ├── $ some other app
- │    ├── [nodist] CREATE DATABASE _
- │    ├── [nodist] CREATE TABLE _ (_ INT8, _ INT8)
- │    └── [nodist] SET application_name = '_'
  └── b16e4363
       ├── [nodist] CREATE DATABASE _
+      ├── [nodist] CREATE DATABASE _
       ├── [nodist] CREATE TABLE _ (_ INT8, _ INT8)
-      └── [nodist] INSERT INTO _ VALUES (_, _), (__more1_10__)
+      ├── [nodist] CREATE TABLE _ (_ INT8, _ INT8)
+      ├── [nodist] CREATE TABLE _ (_ INT8, _ INT8)
+      ├── [nodist] INSERT INTO _ VALUES (_, _), (__more1_10__)
+      └── [nodist] SET application_name = '_'


### PR DESCRIPTION
sql: add delegated names to app name scrubbing

This commit adds delegated names to getScrubbedStmtStats,
which will now scrub app names in statement statistics
that execute internal queries on behalf of an external
app name.

Epic: None
Release note: None

----

sql: unskip TestTelemetry/sql-stats

This commit unskips the TestTelemetry/sql-stats test,
and updates the testdata for the test.

Resolves: #107593
Follow up issue: https://github.com/cockroachdb/cockroach/issues/111942.

Epic: None
Release note: None