### PR TITLE
process-bep-file: de-dupe tests before posting to GitHub

### DIFF
--- a/pkg/cmd/bazci/githubpost/BUILD.bazel
+++ b/pkg/cmd/bazci/githubpost/BUILD.bazel
@@ -25,6 +25,7 @@ go_test(
     ],
     embed = [":githubpost"],
     deps = [
+        "//pkg/build/util",
         "//pkg/cmd/internal/issues",
         "//pkg/testutils/datapathutils",
         "@com_github_stretchr_testify//assert",

--- a/pkg/cmd/bazci/process-bep-file/BUILD.bazel
+++ b/pkg/cmd/bazci/process-bep-file/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//pkg/build",
         "//pkg/build/bazel/bes",
+        "//pkg/build/util",
         "//pkg/cmd/bazci/githubpost",
         "//pkg/cmd/internal/issues",
         "@com_github_golang_protobuf//proto:go_default_library",


### PR DESCRIPTION
Keep track of failed tests we've already seen and don't attempt posting to GitHub if we've already seen that test fail. The previous version of this code should resolve some issues we are seeing with overloading the GitHub API by attempting to post to GH less.

Epic: CRDB-8308
Release note: None