### PR TITLE
release-23.1: acceptance: use single-node cluster and disable metamorphic constants

### DIFF
--- a/pkg/acceptance/adapter_test.go
+++ b/pkg/acceptance/adapter_test.go
@@ -44,8 +44,12 @@ func TestDockerCSharp(t *testing.T) {
 	defer s.Close(t)
 
 	ctx := context.Background()
-	testDockerSuccess(ctx, t, "csharp", []string{"sh", "-c", "cd /mnt/data/csharp && dotnet run"})
-	testDockerFail(ctx, t, "csharp", []string{"sh", "-c", "cd /mnt/data/csharp && dotnet notacommand"})
+	t.Run("Success", func(t *testing.T) {
+		testDockerSuccess(ctx, t, "csharp", []string{"sh", "-c", "cd /mnt/data/csharp && dotnet run"})
+	})
+	t.Run("Fail", func(t *testing.T) {
+		testDockerFail(ctx, t, "csharp", []string{"sh", "-c", "cd /mnt/data/csharp && dotnet notacommand"})
+	})
 }
 
 func TestDockerJava(t *testing.T) {
@@ -53,8 +57,12 @@ func TestDockerJava(t *testing.T) {
 	defer s.Close(t)
 
 	ctx := context.Background()
-	testDockerSuccess(ctx, t, "java", []string{"sh", "-c", "cd /mnt/data/java && mvn -o test"})
-	testDockerFail(ctx, t, "java", []string{"sh", "-c", "cd /mnt/data/java && mvn -o foobar"})
+	t.Run("Success", func(t *testing.T) {
+		testDockerSuccess(ctx, t, "java", []string{"sh", "-c", "cd /mnt/data/java && mvn -o test"})
+	})
+	t.Run("Fail", func(t *testing.T) {
+		testDockerFail(ctx, t, "java", []string{"sh", "-c", "cd /mnt/data/java && mvn -o foobar"})
+	})
 }
 
 func TestDockerElixir(t *testing.T) {
@@ -64,8 +72,12 @@ func TestDockerElixir(t *testing.T) {
 	defer s.Close(t)
 
 	ctx := context.Background()
-	testDockerSuccess(ctx, t, "elixir", []string{"sh", "-c", "cd /mnt/data/elixir/test_crdb && mix local.hex --force && mix deps.get && psql -c 'CREATE DATABASE IF NOT EXISTS testdb' && mix test"})
-	testDockerFail(ctx, t, "elixir", []string{"sh", "-c", "cd /mnt/data/elixir/test_crdb && mix local.hex --force && mix deps.get && mix thisshouldfail"})
+	t.Run("Success", func(t *testing.T) {
+		testDockerSuccess(ctx, t, "elixir", []string{"sh", "-c", "cd /mnt/data/elixir/test_crdb && mix local.hex --force && mix deps.get && psql -c 'CREATE DATABASE IF NOT EXISTS testdb' && mix test"})
+	})
+	t.Run("Fail", func(t *testing.T) {
+		testDockerFail(ctx, t, "elixir", []string{"sh", "-c", "cd /mnt/data/elixir/test_crdb && mix local.hex --force && mix deps.get && mix thisshouldfail"})
+	})
 }
 
 func TestDockerNodeJS(t *testing.T) {
@@ -83,7 +95,9 @@ func TestDockerNodeJS(t *testing.T) {
 	`
 
 	ctx := context.Background()
-	testDockerSuccess(ctx, t, "node.js", []string{"/bin/sh", "-c", strings.Replace(nodeJS, "%v", "", 1)})
+	t.Run("Success", func(t *testing.T) {
+		testDockerSuccess(ctx, t, "node.js", []string{"/bin/sh", "-c", strings.Replace(nodeJS, "%v", "", 1)})
+	})
 	testDockerFail(ctx, t, "node.js", []string{"/bin/sh", "-c", strings.Replace(nodeJS, "%v", "fail", 1)})
 }
 
@@ -92,8 +106,12 @@ func TestDockerPHP(t *testing.T) {
 	defer s.Close(t)
 
 	ctx := context.Background()
-	testDockerSuccess(ctx, t, "php", []string{"sh", "-c", "cd /mnt/data/php && php test.php 3"})
-	testDockerFail(ctx, t, "php", []string{"sh", "-c", "cd /mnt/data/php && php test.php 1"})
+	t.Run("Success", func(t *testing.T) {
+		testDockerSuccess(ctx, t, "php", []string{"sh", "-c", "cd /mnt/data/php && php test.php 3"})
+	})
+	t.Run("Fail", func(t *testing.T) {
+		testDockerFail(ctx, t, "php", []string{"sh", "-c", "cd /mnt/data/php && php test.php 1"})
+	})
 }
 
 func TestDockerPSQL(t *testing.T) {
@@ -101,7 +119,9 @@ func TestDockerPSQL(t *testing.T) {
 	defer s.Close(t)
 
 	ctx := context.Background()
-	testDockerSuccess(ctx, t, "psql", []string{"/mnt/data/psql/test-psql.sh"})
+	t.Run("Success", func(t *testing.T) {
+		testDockerSuccess(ctx, t, "psql", []string{"/mnt/data/psql/test-psql.sh"})
+	})
 }
 
 func TestDockerPython(t *testing.T) {
@@ -109,8 +129,12 @@ func TestDockerPython(t *testing.T) {
 	defer s.Close(t)
 
 	ctx := context.Background()
-	testDockerSuccess(ctx, t, "python", []string{"sh", "-c", "cd /mnt/data/python && python test.py 3"})
-	testDockerFail(ctx, t, "python", []string{"sh", "-c", "cd /mnt/data/python && python test.py 2"})
+	t.Run("Success", func(t *testing.T) {
+		testDockerSuccess(ctx, t, "python", []string{"sh", "-c", "cd /mnt/data/python && python test.py 3"})
+	})
+	t.Run("Fail", func(t *testing.T) {
+		testDockerFail(ctx, t, "python", []string{"sh", "-c", "cd /mnt/data/python && python test.py 2"})
+	})
 }
 
 func TestDockerRuby(t *testing.T) {
@@ -118,6 +142,10 @@ func TestDockerRuby(t *testing.T) {
 	defer s.Close(t)
 
 	ctx := context.Background()
-	testDockerSuccess(ctx, t, "ruby", []string{"sh", "-c", "cd /mnt/data/ruby && ruby test.rb 3"})
-	testDockerFail(ctx, t, "ruby", []string{"sh", "-c", "cd /mnt/data/ruby && ruby test.rb 1"})
+	t.Run("Success", func(t *testing.T) {
+		testDockerSuccess(ctx, t, "ruby", []string{"sh", "-c", "cd /mnt/data/ruby && ruby test.rb 3"})
+	})
+	t.Run("Fail", func(t *testing.T) {
+		testDockerFail(ctx, t, "ruby", []string{"sh", "-c", "cd /mnt/data/ruby && ruby test.rb 1"})
+	})
 }

--- a/pkg/acceptance/cluster/dockercluster.go
+++ b/pkg/acceptance/cluster/dockercluster.go
@@ -458,9 +458,13 @@ func (l *DockerCluster) createNodeCerts() {
 
 // startNode starts a Docker container to run testNode. It may be called in
 // parallel to start many nodes at once, and thus should remain threadsafe.
-func (l *DockerCluster) startNode(ctx context.Context, node *testNode) {
+func (l *DockerCluster) startNode(ctx context.Context, node *testNode, singleNode bool) {
+	startCmd := "start"
+	if singleNode {
+		startCmd = "start-single-node"
+	}
 	cmd := []string{
-		"start",
+		startCmd,
 		"--certs-dir=/certs/",
 		"--listen-addr=" + node.nodeStr,
 		"--vmodule=*=1",
@@ -480,8 +484,10 @@ func (l *DockerCluster) startNode(ctx context.Context, node *testNode) {
 		cmd = append(cmd, fmt.Sprintf("--store=%s", storeSpec))
 	}
 	// Append --join flag for all nodes.
-	firstNodeAddr := l.Nodes[0].nodeStr
-	cmd = append(cmd, "--join="+net.JoinHostPort(firstNodeAddr, base.DefaultPort))
+	if !singleNode {
+		firstNodeAddr := l.Nodes[0].nodeStr
+		cmd = append(cmd, "--join="+net.JoinHostPort(firstNodeAddr, base.DefaultPort))
+	}
 
 	dockerLogDir := "/logs/" + node.nodeStr
 	localLogDir := filepath.Join(l.volumesDir, "logs", node.nodeStr)
@@ -496,6 +502,9 @@ func (l *DockerCluster) startNode(ctx context.Context, node *testNode) {
 		// Needed for backward-compat on crdb_internal.ranges{_no_leases}.
 		// Remove in v23.2.
 		"COCKROACH_FORCE_DEPRECATED_SHOW_RANGE_BEHAVIOR=false",
+		// Disable metamorphic testing for acceptance tests, since they are
+		// end-to-end tests and metamorphic constants can make them too slow.
+		"COCKROACH_INTERNAL_DISABLE_METAMORPHIC_TESTING=true",
 	}
 	l.createRoach(ctx, node, l.vols, env, cmd...)
 	maybePanic(node.Start(ctx))
@@ -653,15 +662,16 @@ func (l *DockerCluster) Start(ctx context.Context) {
 	go l.monitor(ctx, l.monitorDone)
 	var wg sync.WaitGroup
 	wg.Add(len(l.Nodes))
+	singleNode := len(l.Nodes) == 1
 	for _, node := range l.Nodes {
 		go func(node *testNode) {
 			defer wg.Done()
-			l.startNode(ctx, node)
+			l.startNode(ctx, node, singleNode)
 		}(node)
 	}
 	wg.Wait()
 
-	if l.config.InitMode == INIT_COMMAND && len(l.Nodes) > 0 {
+	if l.config.InitMode == INIT_COMMAND && len(l.Nodes) > 1 {
 		l.RunInitCommand(ctx, 0)
 	}
 }

--- a/pkg/acceptance/util_cluster.go
+++ b/pkg/acceptance/util_cluster.go
@@ -91,9 +91,9 @@ func StartCluster(ctx context.Context, t *testing.T, cfg cluster.TestConfig) (c 
 			wantedReplicas = numNodes
 		}
 
-		// Looks silly, but we actually start zero-node clusters in the
-		// reference tests.
-		if wantedReplicas > 0 {
+		// We actually start zero-node clusters in the reference tests. For one-node
+		// clusters, no replication is possible, so we can also skip this step.
+		if wantedReplicas > 1 {
 			log.Infof(ctx, "waiting for first range to have %d replicas", wantedReplicas)
 
 			testutils.SucceedsSoon(t, func() error {


### PR DESCRIPTION
Backport 1/1 commits from #112633.

/cc @cockroachdb/release

Release justification: test only change

---

When possible, the acceptance tests will now use the start-single-node command. This avoids unnecessary attempts to perform replication in many tests.

Also, disable metamorphic constants, which can slow end-to-end tests down.

fixes https://github.com/cockroachdb/cockroach/issues/112605
Release note: None
