### PR TITLE
serverutils: probabilistic shared process virtual cluster

### DIFF
--- a/pkg/base/BUILD.bazel
+++ b/pkg/base/BUILD.bazel
@@ -56,11 +56,12 @@ go_test(
         "main_test.go",
         "node_id_test.go",
         "store_spec_test.go",
+        "test_server_args_test.go",
     ],
     args = ["-test.timeout=55s"],
     data = glob(["testdata/**"]),
+    embed = [":base"],
     deps = [
-        ":base",
         "//pkg/roachpb",
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",

--- a/pkg/base/test_server_args.go
+++ b/pkg/base/test_server_args.go
@@ -240,12 +240,13 @@ type DefaultTestTenantOptions struct {
 	label    string
 }
 
-type testBehavior int8
+type testBehavior int16
 
 const (
-	ttProb testBehavior = iota
-	ttEnabled
+	ttEnabled testBehavior = 1 << iota
 	ttDisabled
+	ttSharedProcess
+	ttExternalProcess
 )
 
 var (
@@ -253,12 +254,12 @@ var (
 	// cluster on a probabilistic basis. It will also prevent the
 	// starting of additional virtual clusters by raising an error if it
 	// is attempted. This is the default behavior.
-	TestTenantProbabilisticOnly = DefaultTestTenantOptions{testBehavior: ttProb, allowAdditionalTenants: false}
+	TestTenantProbabilisticOnly = DefaultTestTenantOptions{allowAdditionalTenants: false}
 
 	// TestTenantProbabilistic starts the test under a virtual
 	// cluster on a probabilistic basis. It allows the starting of
 	// additional virtual clusters.
-	TestTenantProbabilistic = DefaultTestTenantOptions{testBehavior: ttProb, allowAdditionalTenants: true}
+	TestTenantProbabilistic = DefaultTestTenantOptions{allowAdditionalTenants: true}
 
 	// TestTenantAlwaysEnabled will always redirect the test workload to
 	// a virtual cluster. This is useful for quickly verifying that a
@@ -268,6 +269,24 @@ var (
 	// unless there is a good reason to do so. We want the common case
 	// to use TestTenantProbabilistic or TestTenantProbabilisticOnly.
 	TestTenantAlwaysEnabled = DefaultTestTenantOptions{testBehavior: ttEnabled, allowAdditionalTenants: true}
+
+	// ExternalTestTenantAlwaysEnabled will always redirect the test workload to
+	// an external process virtual cluster. This is useful for quickly verifying that a
+	// test works under cluster virtualization.
+	//
+	// Note: this value should not be used for checked in test code
+	// unless there is a good reason to do so. We want the common case
+	// to use TestTenantProbabilistic or TestTenantProbabilisticOnly.
+	ExternalTestTenantAlwaysEnabled = DefaultTestTenantOptions{testBehavior: ttEnabled | ttExternalProcess, allowAdditionalTenants: true}
+
+	// SharedTestTenantAlwaysEnabled will always redirect the test workload to
+	// a shared process virtual cluster. This is useful for quickly verifying that a
+	// test works under cluster virtualization.
+	//
+	// Note: this value should not be used for checked in test code
+	// unless there is a good reason to do so. We want the common case
+	// to use TestTenantProbabilistic or TestTenantProbabilisticOnly.
+	SharedTestTenantAlwaysEnabled = DefaultTestTenantOptions{testBehavior: ttEnabled | ttSharedProcess, allowAdditionalTenants: true}
 
 	// TODOTestTenantDisabled should not be used anymore. Use the
 	// other values instead.
@@ -308,16 +327,39 @@ func (do DefaultTestTenantOptions) AllowAdditionalTenants() bool {
 }
 
 func (do DefaultTestTenantOptions) TestTenantAlwaysEnabled() bool {
-	return do.testBehavior == ttEnabled
+	return do.testBehavior&ttEnabled != 0
 }
 
 func (do DefaultTestTenantOptions) TestTenantAlwaysDisabled() bool {
-	return do.testBehavior == ttDisabled
+	return do.testBehavior&ttDisabled != 0
+}
+
+func (do DefaultTestTenantOptions) TestTenantNoDecisionMade() bool {
+	// Exactly one of ttEnabled or ttDisabled must be set.
+	if (do.testBehavior&ttEnabled != 0) == (do.testBehavior&ttDisabled != 0) {
+		return true
+	}
+	if do.testBehavior&ttEnabled != 0 {
+		// If ttEnabled is set, then exactly one of ttSharedProcess or
+		// ttExternalProcess must be set.
+		if (do.testBehavior&ttExternalProcess != 0) == (do.testBehavior&ttSharedProcess != 0) {
+			return true
+		}
+	}
+	return false
+}
+
+func (do DefaultTestTenantOptions) SharedProcessMode() bool {
+	return do.testBehavior&ttSharedProcess != 0
+}
+
+func (do DefaultTestTenantOptions) ExternalProcessMode() bool {
+	return do.testBehavior&ttExternalProcess != 0
 }
 
 // WarnImplicitInterfaces indicates whether to warn when the test code
 // uses ApplicationLayerInterface or StorageLayerInterface
-// implicitely.
+// implicitly.
 func (do DefaultTestTenantOptions) WarnImplicitInterfaces() bool {
 	return !do.noWarnImplicitInterfaces
 }
@@ -343,7 +385,7 @@ func TestDoesNotWorkWithSecondaryTenantsButWeDontKnowWhyYet(
 
 // TestIsForStuffThatShouldWorkWithSecondaryTenantsButDoesntYet can be
 // used to disable virtualization because the test exercises a feature
-// known not to work with virtualization enabled yet but we wish it to
+// known not to work with virtualization enabled yet, but we wish it to
 // eventually.
 //
 // It should link to a github issue with label C-bug
@@ -359,16 +401,82 @@ func TestIsForStuffThatShouldWorkWithSecondaryTenantsButDoesntYet(
 	}
 }
 
+// TestDoesNotWorkWithSharedProcessModeButWeDontKnowWhyYet can be used to
+// disable selecting a shared process test virtual cluster probabilistically
+// because the test doesn't appear to be compatible with it, and we don't
+// understand it yet.
+//
+// The `baseOptions` are adjusted to restrict the default test virtual cluster
+// process mode selection to an external process virtual cluster only. Using
+// this function with `baseOptions` that explicitly disable a test virtual
+// cluster, or opt specifically for a shared process test virtual cluster does
+// not make sense and will cause a panic.
+//
+// It should link to a github issue with label C-test-failure.
+func TestDoesNotWorkWithSharedProcessModeButWeDontKnowWhyYet(
+	baseOptions DefaultTestTenantOptions, issueNumber int,
+) DefaultTestTenantOptions {
+	if baseOptions.testBehavior&ttDisabled != 0 {
+		panic("test behavior cannot be disabled, please refer to one of the other options to disable secondary virtual clusters with a reason")
+	}
+	if baseOptions.testBehavior&ttSharedProcess != 0 {
+		panic("test behavior cannot be set to a shared process.")
+	}
+	return DefaultTestTenantOptions{
+		testBehavior:           baseOptions.testBehavior | ttExternalProcess,
+		allowAdditionalTenants: baseOptions.allowAdditionalTenants,
+		issueNum:               issueNumber,
+		label:                  "C-test-failure",
+	}
+}
+
+// TestIsForStuffThatShouldWorkWithSharedProcessModeButDoesntYet can be used to
+// disable selecting a shared process test virtual cluster probabilistically
+// because the test exercises a feature known not to work with a shared process
+// virtual cluster, but we wish it to eventually.
+//
+// The `baseOptions` are adjusted to restrict the default test virtual cluster
+// process mode selection to an external process virtual cluster only. Using
+// this function with `baseOptions` that explicitly disable a test virtual
+// cluster, or opt specifically for a shared process test virtual cluster does
+// not make sense and will cause a panic.
+//
+// It should link to a github issue with label C-bug and the issue should be
+// linked to an epic under INI-213 or INI-214.
+func TestIsForStuffThatShouldWorkWithSharedProcessModeButDoesntYet(
+	baseOptions DefaultTestTenantOptions, issueNumber int,
+) DefaultTestTenantOptions {
+	if baseOptions.testBehavior&ttDisabled != 0 {
+		panic("test behavior cannot be disabled, please refer to one of the other options to disable secondary virtual clusters with a reason")
+	}
+	if baseOptions.testBehavior&ttSharedProcess != 0 {
+		panic("test behavior cannot be set to a shared process.")
+	}
+	return DefaultTestTenantOptions{
+		testBehavior:           baseOptions.testBehavior | ttExternalProcess,
+		allowAdditionalTenants: baseOptions.allowAdditionalTenants,
+		issueNum:               issueNumber,
+		label:                  "C-bug",
+	}
+}
+
 // InternalNonDefaultDecision builds a sentinel value used inside a
 // mechanism in serverutils. Should not be used by tests directly.
 func InternalNonDefaultDecision(
-	baseArg DefaultTestTenantOptions, enable bool,
+	baseArg DefaultTestTenantOptions, enable bool, shared bool,
 ) DefaultTestTenantOptions {
-	mode := ttDisabled
+	var tb testBehavior
 	if enable {
-		mode = ttEnabled
+		tb |= ttEnabled
+		if shared {
+			tb |= ttSharedProcess
+		} else {
+			tb |= ttExternalProcess
+		}
+	} else {
+		tb |= ttDisabled
 	}
-	baseArg.testBehavior = mode
+	baseArg.testBehavior = tb
 	return baseArg
 }
 

--- a/pkg/base/test_server_args.go
+++ b/pkg/base/test_server_args.go
@@ -558,6 +558,9 @@ type TestSharedProcessTenantArgs struct {
 	// automatically open a connection to the server. That's equivalent to running
 	// SET DATABASE=foo, which works even if the database doesn't (yet) exist.
 	UseDatabase string
+
+	// Skip check for tenant existence when running the test.
+	SkipTenantCheck bool
 }
 
 // TestTenantArgs are the arguments to TestServer.StartTenant.

--- a/pkg/base/test_server_args_test.go
+++ b/pkg/base/test_server_args_test.go
@@ -1,0 +1,46 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package base
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultTestTenantOptionsBehavior(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	testCases := []struct {
+		name               string
+		tb                 testBehavior
+		expectedNoDecision bool
+	}{
+		// Decision missing enabled or disabled flag
+		{name: "no decision made", tb: 0, expectedNoDecision: true},
+		// Decision missing process mode
+		{name: "no decision on tenant process mode", tb: ttEnabled, expectedNoDecision: true},
+		// Decision made to not run test tenant
+		{name: "decision to not run test tenant", tb: ttDisabled, expectedNoDecision: false},
+		// Decision made to run test tenant as an external process
+		{name: "decision to run external test tenant", tb: ttEnabled | ttExternalProcess, expectedNoDecision: false},
+		// Decision made to run test tenant as a shared process
+		{name: "decision to run shared test tenant", tb: ttEnabled | ttSharedProcess, expectedNoDecision: false},
+		// Decision missing enabled or disabled flag with additional erroneous flag
+		{name: "no decision made with erroneous flag", tb: ttExternalProcess, expectedNoDecision: true},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			d := DefaultTestTenantOptions{testBehavior: tc.tb}
+			require.Equal(t, tc.expectedNoDecision, d.TestTenantNoDecisionMade())
+		})
+	}
+}

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -7427,8 +7427,9 @@ func TestClientDisconnect(t *testing.T) {
 			// Make credentials for the new connection.
 			sqlDB.Exec(t, `CREATE USER testuser`)
 			sqlDB.Exec(t, `GRANT admin TO testuser`)
-			pgURL, cleanup := sqlutils.PGUrl(t, tc.ApplicationLayer(0).AdvSQLAddr(),
-				"TestClientDisconnect-testuser", url.User("testuser"))
+			pgURL, cleanup := tc.ApplicationLayer(0).PGUrl(t,
+				serverutils.CertsDirPrefix("TestClientDisconnect-testuser"), serverutils.User("testuser"),
+			)
 			defer cleanup()
 
 			// Kick off the job on a new connection which we're going to close.

--- a/pkg/ccl/backupccl/datadriven_test.go
+++ b/pkg/ccl/backupccl/datadriven_test.go
@@ -240,8 +240,10 @@ func (d *datadrivenTestState) getSQLDB(t *testing.T, name string, user string) *
 	if db, ok := d.sqlDBs[key]; ok {
 		return db
 	}
-	addr := d.firstNode[name].ApplicationLayer().AdvSQLAddr()
-	pgURL, cleanup := sqlutils.PGUrl(t, addr, "TestBackupRestoreDataDriven", url.User(user))
+	s := d.firstNode[name].ApplicationLayer()
+	pgURL, cleanup := s.PGUrl(
+		t, serverutils.CertsDirPrefix("TestBackupRestoreDataDriven"), serverutils.User(user),
+	)
 	d.cleanupFns = append(d.cleanupFns, cleanup)
 
 	base, err := pq.NewConnector(pgURL.String())

--- a/pkg/ccl/changefeedccl/sink_test.go
+++ b/pkg/ccl/changefeedccl/sink_test.go
@@ -11,7 +11,6 @@ package changefeedccl
 import (
 	"context"
 	"fmt"
-	"net/url"
 	"strconv"
 	"strings"
 	"sync"
@@ -480,7 +479,7 @@ func TestSQLSink(t *testing.T) {
 	sqlDB := sqlutils.MakeSQLRunner(sqlDBRaw)
 	sqlDB.Exec(t, `CREATE DATABASE d`)
 
-	pgURL, cleanup := sqlutils.PGUrl(t, s.ApplicationLayer().AdvSQLAddr(), t.Name(), url.User(username.RootUser))
+	pgURL, cleanup := s.PGUrl(t, serverutils.CertsDirPrefix(t.Name()), serverutils.User(username.RootUser))
 	defer cleanup()
 	pgURL.Path = `d`
 

--- a/pkg/ccl/importerccl/ccl_test.go
+++ b/pkg/ccl/importerccl/ccl_test.go
@@ -388,7 +388,7 @@ func TestExportInsideTenant(t *testing.T) {
 	defer cleanupDir()
 
 	srv := serverutils.StartServerOnly(t, base.TestServerArgs{
-		DefaultTestTenant: base.TestTenantProbabilistic,
+		DefaultTestTenant: base.TestControlsTenantsExplicitly,
 		ExternalIODir:     dir,
 	})
 	defer srv.Stopper().Stop(context.Background())

--- a/pkg/ccl/serverccl/server_sql_test.go
+++ b/pkg/ccl/serverccl/server_sql_test.go
@@ -185,7 +185,9 @@ func TestTenantHTTP(t *testing.T) {
 	s := serverutils.StartServerOnly(t, base.TestServerArgs{
 		// This test is specific to secondary tenants; no need to run it
 		// using the system tenant.
-		DefaultTestTenant: base.TestTenantAlwaysEnabled,
+		DefaultTestTenant: base.TestIsForStuffThatShouldWorkWithSharedProcessModeButDoesntYet(
+			base.TestTenantAlwaysEnabled, 113187,
+		),
 	})
 	defer s.Stopper().Stop(ctx)
 

--- a/pkg/ccl/spanconfigccl/spanconfiglimiterccl/drop_table_test.go
+++ b/pkg/ccl/spanconfigccl/spanconfiglimiterccl/drop_table_test.go
@@ -35,7 +35,7 @@ func TestDropTableLowersSpanCount(t *testing.T) {
 
 	ctx := context.Background()
 	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{ServerArgs: base.TestServerArgs{
-		DefaultTestTenant: base.TestTenantProbabilistic,
+		DefaultTestTenant: base.TestControlsTenantsExplicitly,
 	}})
 
 	defer tc.Stopper().Stop(ctx)

--- a/pkg/ccl/spanconfigccl/spanconfiglimiterccl/testdata/indexes
+++ b/pkg/ccl/spanconfigccl/spanconfiglimiterccl/testdata/indexes
@@ -1,56 +1,56 @@
 # Ensure that system.span_count is maintained appropriately when creating and
 # dropping secondary indexes, and then dropping the table entirely.
 
-initialize tenant=10
+initialize tenant=11
 ----
 
-query-sql tenant=10
+query-sql tenant=11
 SELECT count(*) FROM system.span_count;
 ----
 0
 
-exec-sql tenant=10
+exec-sql tenant=11
 CREATE DATABASE db;
 CREATE TABLE db.t(i INT PRIMARY KEY, j INT);
 ----
 
-query-sql tenant=10
+query-sql tenant=11
 SELECT span_count FROM system.span_count;
 ----
 3
 
-exec-sql tenant=10
+exec-sql tenant=11
 CREATE INDEX idx2 ON db.t (j);
 ----
 
-query-sql tenant=10
+query-sql tenant=11
 SELECT span_count FROM system.span_count;
 ----
 5
 
-exec-sql tenant=10
+exec-sql tenant=11
 DROP INDEX db.t@idx2;
 ----
 
-query-sql tenant=10
+query-sql tenant=11
 SELECT span_count FROM system.span_count;
 ----
 3
 
-exec-sql tenant=10
+exec-sql tenant=11
 CREATE INDEX idx4 ON db.t (j);
 ----
 
-query-sql tenant=10
+query-sql tenant=11
 SELECT span_count FROM system.span_count;
 ----
 5
 
-exec-sql tenant=10
+exec-sql tenant=11
 DROP TABLE db.t;
 ----
 
-query-sql tenant=10
+query-sql tenant=11
 SELECT span_count FROM system.span_count;
 ----
 0

--- a/pkg/ccl/spanconfigccl/spanconfiglimiterccl/testdata/limit
+++ b/pkg/ccl/spanconfigccl/spanconfiglimiterccl/testdata/limit
@@ -1,15 +1,15 @@
 # Ensure that we respect tenant span config limits, rejecting schema change
 # operations that take us past it.
 
-initialize tenant=10
+initialize tenant=11
 ----
 
-exec-sql tenant=10
+exec-sql tenant=11
 CREATE DATABASE db;
 CREATE TABLE db.t1(i INT PRIMARY KEY);
 ----
 
-query-sql tenant=10
+query-sql tenant=11
 SELECT span_count FROM system.span_count;
 ----
 3
@@ -17,35 +17,35 @@ SELECT span_count FROM system.span_count;
 override limit=3
 ----
 
-exec-sql tenant=10
+exec-sql tenant=11
 CREATE TABLE db.t2(i INT PRIMARY KEY);
 ----
 err: pq: exceeded limit for number of table spans
 
-query-sql tenant=10
+query-sql tenant=11
 SELECT span_count FROM system.span_count;
 ----
 3
 
-query-sql tenant=10
+query-sql tenant=11
 SELECT table_name FROM [SHOW TABLES FROM db];
 ----
 t1
 
-exec-sql tenant=10
+exec-sql tenant=11
 DROP TABLE db.t1;
 ----
 
-exec-sql tenant=10
+exec-sql tenant=11
 CREATE TABLE db.t2(i INT PRIMARY KEY);
 ----
 
-query-sql tenant=10
+query-sql tenant=11
 SELECT span_count FROM system.span_count;
 ----
 3
 
-query-sql tenant=10
+query-sql tenant=11
 SELECT table_name FROM [SHOW TABLES FROM db];
 ----
 t2

--- a/pkg/ccl/spanconfigccl/spanconfiglimiterccl/testdata/partitioning
+++ b/pkg/ccl/spanconfigccl/spanconfiglimiterccl/testdata/partitioning
@@ -2,10 +2,10 @@
 # changes operations that would take us past it. Repartitioning old partitions,
 # or dropping them entirely, should return quota back for subsequent use.
 
-initialize tenant=10
+initialize tenant=11
 ----
 
-exec-sql tenant=10
+exec-sql tenant=11
 CREATE DATABASE db;
 CREATE TABLE db.list_partitions(i INT PRIMARY KEY, j INT, k INT);
 CREATE INDEX idx_i ON db.list_partitions (i);
@@ -17,7 +17,7 @@ ALTER INDEX db.list_partitions@idx_i PARTITION BY LIST (i) (
 );
 ----
 
-query-sql tenant=10
+query-sql tenant=11
 SELECT span_count FROM system.span_count;
 ----
 15
@@ -25,7 +25,7 @@ SELECT span_count FROM system.span_count;
 override limit=15
 ----
 
-exec-sql tenant=10
+exec-sql tenant=11
 ALTER INDEX db.list_partitions@idx_j PARTITION BY LIST (j) (
   PARTITION one_and_five    VALUES IN (1, 5),
   PARTITION everything_else VALUES IN (DEFAULT)
@@ -35,32 +35,32 @@ err: pq: exceeded limit for number of table spans
 
 # Drop partitioning spans, expect to see span_count reduce accordingly.
 #
-exec-sql tenant=10
+exec-sql tenant=11
 ALTER INDEX db.list_partitions@idx_i PARTITION BY NOTHING
 ----
 
-query-sql tenant=10
+query-sql tenant=11
 SELECT span_count FROM system.span_count;
 ----
 9
 
 # Re-attempt the secondary index partition, should succeed.
 #
-exec-sql tenant=10
+exec-sql tenant=11
 ALTER INDEX db.list_partitions@idx_j PARTITION BY LIST (j) (
   PARTITION one_and_five    VALUES IN (1, 5),
   PARTITION everything_else VALUES IN (DEFAULT)
 );
 ----
 
-query-sql tenant=10
+query-sql tenant=11
 SELECT span_count FROM system.span_count;
 ----
 15
 
 # We could also claw back quota by dropping a partitioned index entirely.
 #
-exec-sql tenant=10
+exec-sql tenant=11
 ALTER INDEX db.list_partitions@idx_k PARTITION BY LIST (k) (
   PARTITION one_and_five    VALUES IN (1, 5),
   PARTITION everything_else VALUES IN (DEFAULT)
@@ -68,16 +68,16 @@ ALTER INDEX db.list_partitions@idx_k PARTITION BY LIST (k) (
 ----
 err: pq: exceeded limit for number of table spans
 
-exec-sql tenant=10
+exec-sql tenant=11
 DROP INDEX db.list_partitions@idx_j;
 ----
 
-query-sql tenant=10
+query-sql tenant=11
 SELECT span_count FROM system.span_count;
 ----
 7
 
-exec-sql tenant=10
+exec-sql tenant=11
 ALTER INDEX db.list_partitions@idx_k PARTITION BY LIST (k) (
   PARTITION one_and_five    VALUES IN (1, 5),
   PARTITION everything_else VALUES IN (DEFAULT)

--- a/pkg/ccl/spanconfigccl/spanconfiglimiterccl/testdata/tables
+++ b/pkg/ccl/spanconfigccl/spanconfiglimiterccl/testdata/tables
@@ -1,55 +1,55 @@
 # Ensure that system.span_count is maintained appropriately when creating and
 # dropping tables.
 
-initialize tenant=10
+initialize tenant=11
 ----
 
-query-sql tenant=10
+query-sql tenant=11
 SELECT count(*) FROM system.span_count;
 ----
 0
 
-exec-sql tenant=10
+exec-sql tenant=11
 CREATE DATABASE db;
 CREATE TABLE db.t1(i INT PRIMARY KEY);
 ----
 
-query-sql tenant=10
+query-sql tenant=11
 SELECT span_count FROM system.span_count;
 ----
 3
 
-exec-sql tenant=10
+exec-sql tenant=11
 CREATE TABLE db.t2(i INT PRIMARY KEY);
 CREATE TABLE db.t3(i INT PRIMARY KEY);
 CREATE TABLE db.t4(i INT PRIMARY KEY);
 CREATE TABLE db.t5(i INT PRIMARY KEY);
 ----
 
-query-sql tenant=10
+query-sql tenant=11
 SELECT span_count FROM system.span_count;
 ----
 15
 
-exec-sql tenant=10
+exec-sql tenant=11
 DROP TABLE db.t1;
 ----
 
-exec-sql tenant=10
+exec-sql tenant=11
 DROP TABLE db.t2;
 DROP TABLE db.t3;
 ----
 
-query-sql tenant=10
+query-sql tenant=11
 SELECT span_count FROM system.span_count;
 ----
 6
 
-exec-sql tenant=10
+exec-sql tenant=11
 DROP DATABASE db CASCADE;
 ----
 
-query-sql tenant=10
+query-sql tenant=11
 SELECT span_count FROM system.span_count;
 ----
 0

--- a/pkg/ccl/sqlproxyccl/proxy_handler_test.go
+++ b/pkg/ccl/sqlproxyccl/proxy_handler_test.go
@@ -135,7 +135,11 @@ func TestProxyProtocol(t *testing.T) {
 	te := newTester()
 	defer te.Close()
 
-	sql, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	sql, db, _ := serverutils.StartServer(t, base.TestServerArgs{
+		DefaultTestTenant: base.TestIsForStuffThatShouldWorkWithSharedProcessModeButDoesntYet(
+			base.TestTenantProbabilistic, 112867,
+		),
+	})
 
 	ts := sql.ApplicationLayer()
 	ts.PGPreServer().(*pgwire.PreServeConnHandler).TestingSetTrustClientProvidedRemoteAddr(true)
@@ -244,7 +248,11 @@ func TestPrivateEndpointsACL(t *testing.T) {
 	te := newTester()
 	defer te.Close()
 
-	sql, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	sql, db, _ := serverutils.StartServer(t, base.TestServerArgs{
+		DefaultTestTenant: base.TestIsForStuffThatShouldWorkWithSharedProcessModeButDoesntYet(
+			base.TestTenantProbabilistic, 112867,
+		),
+	})
 	defer sql.Stopper().Stop(ctx)
 
 	ts := sql.ApplicationLayer()
@@ -412,7 +420,11 @@ func TestAllowedCIDRRangesACL(t *testing.T) {
 	te := newTester()
 	defer te.Close()
 
-	sql, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	sql, db, _ := serverutils.StartServer(t, base.TestServerArgs{
+		DefaultTestTenant: base.TestIsForStuffThatShouldWorkWithSharedProcessModeButDoesntYet(
+			base.TestTenantProbabilistic, 112867,
+		),
+	})
 	defer sql.Stopper().Stop(ctx)
 
 	ts := sql.ApplicationLayer()
@@ -676,7 +688,11 @@ func TestProxyAgainstSecureCRDB(t *testing.T) {
 	te := newTester()
 	defer te.Close()
 
-	sql, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	sql, db, _ := serverutils.StartServer(t, base.TestServerArgs{
+		DefaultTestTenant: base.TestIsForStuffThatShouldWorkWithSharedProcessModeButDoesntYet(
+			base.TestTenantProbabilisticOnly, 112867,
+		),
+	})
 	defer sql.Stopper().Stop(ctx)
 
 	ts := sql.ApplicationLayer()
@@ -873,7 +889,11 @@ func TestProxyTLSClose(t *testing.T) {
 	te := newTester()
 	defer te.Close()
 
-	sql, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	sql, db, _ := serverutils.StartServer(t, base.TestServerArgs{
+		DefaultTestTenant: base.TestIsForStuffThatShouldWorkWithSharedProcessModeButDoesntYet(
+			base.TestTenantProbabilistic, 112867,
+		),
+	})
 	defer sql.Stopper().Stop(ctx)
 
 	ts := sql.ApplicationLayer()
@@ -924,7 +944,11 @@ func TestProxyModifyRequestParams(t *testing.T) {
 	te := newTester()
 	defer te.Close()
 
-	sql, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	sql, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{
+		DefaultTestTenant: base.TestIsForStuffThatShouldWorkWithSharedProcessModeButDoesntYet(
+			base.TestTenantProbabilistic, 112867,
+		),
+	})
 	defer sql.Stopper().Stop(ctx)
 
 	ts := sql.ApplicationLayer()
@@ -982,7 +1006,11 @@ func TestInsecureProxy(t *testing.T) {
 	te := newTester()
 	defer te.Close()
 
-	sql, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	sql, db, _ := serverutils.StartServer(t, base.TestServerArgs{
+		DefaultTestTenant: base.TestIsForStuffThatShouldWorkWithSharedProcessModeButDoesntYet(
+			base.TestTenantProbabilistic, 112867,
+		),
+	})
 	defer sql.Stopper().Stop(ctx)
 
 	ts := sql.ApplicationLayer()
@@ -1165,7 +1193,11 @@ func TestDenylistUpdate(t *testing.T) {
 	_, err = denyList.Write(bytes)
 	require.NoError(t, err)
 
-	sql, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	sql, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{
+		DefaultTestTenant: base.TestIsForStuffThatShouldWorkWithSharedProcessModeButDoesntYet(
+			base.TestTenantProbabilistic, 112867,
+		),
+	})
 	defer sql.Stopper().Stop(ctx)
 
 	ts := sql.ApplicationLayer()

--- a/pkg/ccl/testccl/authccl/BUILD.bazel
+++ b/pkg/ccl/testccl/authccl/BUILD.bazel
@@ -23,7 +23,6 @@ go_test(
         "//pkg/testutils/datapathutils",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/skip",
-        "//pkg/testutils/sqlutils",
         "//pkg/testutils/testcluster",
         "//pkg/util/leaktest",
         "//pkg/util/log",

--- a/pkg/ccl/testccl/authccl/auth_test.go
+++ b/pkg/ccl/testccl/authccl/auth_test.go
@@ -33,7 +33,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/datapathutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
-	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/log/channel"
@@ -284,9 +283,10 @@ func jwtRunTest(t *testing.T, insecure bool) {
 
 					// We want the certs to be present in the filesystem for this test.
 					// However, certs are only generated for users "root" and "testuser" specifically.
-					sqlURL, cleanupFn := sqlutils.PGUrlWithOptionalClientCerts(
-						t, s.AdvSQLAddr(), t.Name(), url.User(user),
-						forceCerts || user == username.RootUser || user == username.TestUser /* withClientCerts */)
+					sqlURL, cleanupFn := s.PGUrl(
+						t, serverutils.CertsDirPrefix(t.Name()), serverutils.User(user),
+						serverutils.ClientCerts(forceCerts || user == username.RootUser || user == username.TestUser),
+					)
 					defer cleanupFn()
 
 					var host, port string
@@ -417,8 +417,8 @@ func TestClientAddrOverride(t *testing.T) {
 	defer s.Stopper().Stop(ctx)
 	ts := s.ApplicationLayer()
 
-	pgURL, cleanupFunc := sqlutils.PGUrl(
-		t, ts.AdvSQLAddr(), "testClientAddrOverride" /* prefix */, url.User(username.TestUser),
+	pgURL, cleanupFunc := ts.PGUrl(
+		t, serverutils.CertsDirPrefix("testClientAddrOverride"), serverutils.User(username.TestUser),
 	)
 	defer cleanupFunc()
 

--- a/pkg/ccl/testccl/authccl/auth_test.go
+++ b/pkg/ccl/testccl/authccl/auth_test.go
@@ -181,6 +181,9 @@ func jwtRunTest(t *testing.T, insecure bool) {
 
 		srv, conn, _ := serverutils.StartServer(t,
 			base.TestServerArgs{
+				DefaultTestTenant: base.TestDoesNotWorkWithSharedProcessModeButWeDontKnowWhyYet(
+					base.TestTenantProbabilistic, 112949,
+				),
 				Insecure:   insecure,
 				SocketFile: maybeSocketFile,
 			})
@@ -412,7 +415,11 @@ func TestClientAddrOverride(t *testing.T) {
 	defer sc.Close(t)
 
 	// Start a server.
-	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{
+		DefaultTestTenant: base.TestIsForStuffThatShouldWorkWithSharedProcessModeButDoesntYet(
+			base.TestTenantProbabilistic, 112867,
+		),
+	})
 	ctx := context.Background()
 	defer s.Stopper().Stop(ctx)
 	ts := s.ApplicationLayer()

--- a/pkg/ccl/testccl/sqlccl/tenant_gc_test.go
+++ b/pkg/ccl/testccl/sqlccl/tenant_gc_test.go
@@ -49,7 +49,7 @@ func TestGCTenantRemovesSpanConfigs(t *testing.T) {
 
 	ctx := context.Background()
 	ts := serverutils.StartServerOnly(t, base.TestServerArgs{
-		DefaultTestTenant: base.TestTenantProbabilistic,
+		DefaultTestTenant: base.TestControlsTenantsExplicitly,
 		Knobs: base.TestingKnobs{
 			SpanConfig: &spanconfig.TestingKnobs{
 				// Disable the system tenant's reconciliation process so that we can

--- a/pkg/cli/gen.go
+++ b/pkg/cli/gen.go
@@ -331,7 +331,7 @@ Output the list of metrics typical for a node.
 		// test servers too.
 		sArgs := base.TestServerArgs{
 			Insecure:          true,
-			DefaultTestTenant: base.TestTenantAlwaysEnabled,
+			DefaultTestTenant: base.ExternalTestTenantAlwaysEnabled,
 		}
 		s, err := server.TestServerFactory.New(sArgs)
 		if err != nil {

--- a/pkg/cli/interactive_tests/test_demo_partitioning.tcl
+++ b/pkg/cli/interactive_tests/test_demo_partitioning.tcl
@@ -129,13 +129,6 @@ eexpect "ERROR: use of partitions requires an enterprise license"
 eexpect $prompt
 end_test
 
-start_test "Expect an error if geo-partitioning is requested with multitenant mode"
-send "$argv demo --no-line-editor --geo-partitioned-replicas --log-dir=logs \r"
-# expect a failure
-eexpect "operation is disabled within a virtual cluster"
-eexpect $prompt
-end_test
-
 start_test "Expect an error if geo-partitioning is requested and license acquisition is disabled"
 # set the proper environment variable
 send "$argv demo --no-line-editor --geo-partitioned-replicas --disable-demo-license --log-dir=logs \r"

--- a/pkg/cli/zip_test.go
+++ b/pkg/cli/zip_test.go
@@ -920,13 +920,13 @@ func TestZipJobTrace(t *testing.T) {
 		jobutils.WaitForJobToRun(t, runner, jobID)
 		return jobID
 	}
+	sqlURL, cleanupFn := s.ApplicationLayer().PGUrl(t, serverutils.User(username.RootUser))
+	defer cleanupFn()
 
-	sqlURL := url.URL{
-		Scheme:   "postgres",
-		User:     url.User(username.RootUser),
-		Host:     s.AdvSQLAddr(),
-		RawQuery: "sslmode=disable",
-	}
+	options := url.Values{}
+	options.Add("sslmode", "disable")
+	sqlURL.RawQuery = options.Encode()
+
 	sqlConn := sqlConnCtx.MakeSQLConn(io.Discard, io.Discard, sqlURL.String())
 	defer func() {
 		if err := sqlConn.Close(); err != nil {

--- a/pkg/cli/zip_test.go
+++ b/pkg/cli/zip_test.go
@@ -885,6 +885,9 @@ func TestZipJobTrace(t *testing.T) {
 	defer jobs.ResetConstructors()()
 
 	s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{
+		DefaultTestTenant: base.TestDoesNotWorkWithSharedProcessModeButWeDontKnowWhyYet(
+			base.TestTenantProbabilistic, 112950,
+		),
 		Insecure: true,
 		Knobs: base.TestingKnobs{
 			JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),

--- a/pkg/server/application_api/metrics_test.go
+++ b/pkg/server/application_api/metrics_test.go
@@ -90,7 +90,9 @@ func TestStatusVarsTxnMetrics(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	srv := serverutils.StartServerOnly(t, base.TestServerArgs{
-		DefaultTestTenant: base.TestTenantAlwaysEnabled,
+		DefaultTestTenant: base.TestIsForStuffThatShouldWorkWithSharedProcessModeButDoesntYet(
+			base.TestTenantAlwaysEnabled, 112953,
+		),
 	})
 	defer srv.Stopper().Stop(context.Background())
 
@@ -133,6 +135,8 @@ func TestStatusVarsTxnMetrics(t *testing.T) {
 	t.Run("tenant", func(t *testing.T) {
 		s := srv.ApplicationLayer()
 		// TODO(knz): why is the tenant label missing here?
+		// TODO(herko): it is present when running in shared process mode. Hence why
+		// the test is now forced to run only in external process mode.
 		testFn(s, `tenant=""`)
 	})
 }

--- a/pkg/server/application_api/sessions_test.go
+++ b/pkg/server/application_api/sessions_test.go
@@ -15,7 +15,6 @@ import (
 	gosql "database/sql"
 	"encoding/hex"
 	"fmt"
-	"net/url"
 	"sort"
 	"strings"
 	"sync"
@@ -340,14 +339,9 @@ func TestListClosedSessions(t *testing.T) {
 	}
 
 	getUserConn := func(t *testing.T, username string, server serverutils.ApplicationLayerInterface) *gosql.DB {
-		pgURL := url.URL{
-			Scheme: "postgres",
-			User:   url.UserPassword(username, "hunter2"),
-			Host:   server.AdvSQLAddr(),
-		}
-		db, err := gosql.Open("postgres", pgURL.String())
-		require.NoError(t, err)
-		return db
+		return server.SQLConn(
+			t, serverutils.UserPassword(username, "hunter2"), serverutils.ClientCerts(false),
+		)
 	}
 
 	// Create a test user.

--- a/pkg/server/application_api/sql_stats_test.go
+++ b/pkg/server/application_api/sql_stats_test.go
@@ -12,10 +12,8 @@ package application_api_test
 
 import (
 	"context"
-	gosql "database/sql"
 	"encoding/json"
 	"fmt"
-	"net/url"
 	"reflect"
 	"sort"
 	"strings"
@@ -68,9 +66,6 @@ func TestStatusAPICombinedTransactions(t *testing.T) {
 	defer testCluster.Stopper().Stop(ctx)
 
 	thirdServer := testCluster.Server(2)
-	pgURL, cleanupGoDB := sqlutils.PGUrl(
-		t, thirdServer.AdvSQLAddr(), "CreateConnections" /* prefix */, url.User(username.RootUser))
-	defer cleanupGoDB()
 	firstServerProto := testCluster.Server(0)
 
 	type testCase struct {
@@ -117,10 +112,11 @@ func TestStatusAPICombinedTransactions(t *testing.T) {
 
 		// Create a brand new connection for each app, so that we don't pollute
 		// transaction stats collection with `SET application_name` queries.
-		sqlDB, err := gosql.Open("postgres", pgURL.String())
+		sqlDB, err := thirdServer.ApplicationLayer().SQLConnE()
 		if err != nil {
 			t.Fatal(err)
 		}
+
 		if _, err := sqlDB.Exec(fmt.Sprintf(`SET application_name = "%s"`, appName)); err != nil {
 			t.Fatal(err)
 		}
@@ -203,9 +199,6 @@ func TestStatusAPITransactions(t *testing.T) {
 	defer testCluster.Stopper().Stop(ctx)
 
 	thirdServer := testCluster.Server(2)
-	pgURL, cleanupGoDB := sqlutils.PGUrl(
-		t, thirdServer.AdvSQLAddr(), "CreateConnections" /* prefix */, url.User(username.RootUser))
-	defer cleanupGoDB()
 	firstServerProto := testCluster.Server(0)
 
 	type testCase struct {
@@ -250,9 +243,9 @@ func TestStatusAPITransactions(t *testing.T) {
 		appName := fmt.Sprintf("app%d", i)
 		appNameToTestCase[appName] = tc
 
-		// Create a brand new connection for each app, so that we don't pollute
+		// Create a brand-new connection for each app, so that we don't pollute
 		// transaction stats collection with `SET application_name` queries.
-		sqlDB, err := gosql.Open("postgres", pgURL.String())
+		sqlDB, err := thirdServer.ApplicationLayer().SQLConnE()
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/server/debug/debug_test.go
+++ b/pkg/server/debug/debug_test.go
@@ -36,7 +36,11 @@ func debugURL(s serverutils.ApplicationLayerInterface, path string) string {
 func TestAdminDebugExpVar(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{
+		DefaultTestTenant: base.TestIsForStuffThatShouldWorkWithSharedProcessModeButDoesntYet(
+			base.TestTenantProbabilistic, 113187,
+		),
+	})
 	defer s.Stopper().Stop(context.Background())
 
 	ts := s.ApplicationLayer()
@@ -59,7 +63,11 @@ func TestAdminDebugExpVar(t *testing.T) {
 func TestAdminDebugMetrics(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{
+		DefaultTestTenant: base.TestIsForStuffThatShouldWorkWithSharedProcessModeButDoesntYet(
+			base.TestTenantProbabilistic, 113187,
+		),
+	})
 	defer s.Stopper().Stop(context.Background())
 
 	ts := s.ApplicationLayer()
@@ -82,7 +90,11 @@ func TestAdminDebugMetrics(t *testing.T) {
 func TestAdminDebugPprof(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{
+		DefaultTestTenant: base.TestIsForStuffThatShouldWorkWithSharedProcessModeButDoesntYet(
+			base.TestTenantProbabilistic, 113187,
+		),
+	})
 	defer s.Stopper().Stop(context.Background())
 
 	ts := s.ApplicationLayer()
@@ -101,7 +113,11 @@ func TestAdminDebugPprof(t *testing.T) {
 func TestAdminDebugTrace(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{
+		DefaultTestTenant: base.TestIsForStuffThatShouldWorkWithSharedProcessModeButDoesntYet(
+			base.TestTenantProbabilistic, 113187,
+		),
+	})
 	defer s.Stopper().Stop(context.Background())
 
 	ts := s.ApplicationLayer()

--- a/pkg/server/debug/debug_test.go
+++ b/pkg/server/debug/debug_test.go
@@ -182,7 +182,11 @@ func TestAdminDebugAuth(t *testing.T) {
 func TestAdminDebugRedirect(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{
+		DefaultTestTenant: base.TestIsForStuffThatShouldWorkWithSharedProcessModeButDoesntYet(
+			base.TestTenantProbabilistic, 112955,
+		),
+	})
 	defer s.Stopper().Stop(context.Background())
 	ts := s.ApplicationLayer()
 

--- a/pkg/server/storage_api/files_test.go
+++ b/pkg/server/storage_api/files_test.go
@@ -38,6 +38,9 @@ func TestStatusGetFiles(t *testing.T) {
 	storeSpec := base.StoreSpec{Path: tempDir}
 
 	srv := serverutils.StartServerOnly(t, base.TestServerArgs{
+		DefaultTestTenant: base.TestDoesNotWorkWithSharedProcessModeButWeDontKnowWhyYet(
+			base.TestTenantProbabilistic, 112956,
+		),
 		StoreSpecs: []base.StoreSpec{
 			storeSpec,
 		},

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -675,10 +675,7 @@ func (ts *testServer) startSharedProcessDefaultTestTenant(
 
 // maybeStartDefaultTestTenant might start a test tenant. This can then be used
 // for multi-tenant testing, where the default SQL connection will be made to
-// this tenant instead of to the system tenant. Note that we will
-// currently only attempt to start a test tenant if we're running in an
-// enterprise enabled build. This is due to licensing restrictions on the MT
-// capabilities.
+// this tenant instead of to the system tenant.
 func (ts *testServer) maybeStartDefaultTestTenant(ctx context.Context) error {
 	if ts.params.DefaultTestTenant.TestTenantNoDecisionMade() {
 		return errors.WithHint(

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -596,30 +596,9 @@ func (ts *testServer) TestTenant() serverutils.ApplicationLayerInterface {
 	return ts.testTenants[0]
 }
 
-// maybeStartDefaultTestTenant might start a test tenant. This can then be used
-// for multi-tenant testing, where the default SQL connection will be made to
-// this tenant instead of to the system tenant. Note that we will
-// currently only attempt to start a test tenant if we're running in an
-// enterprise enabled build. This is due to licensing restrictions on the MT
-// capabilities.
-func (ts *testServer) maybeStartDefaultTestTenant(ctx context.Context) error {
-	if !(ts.params.DefaultTestTenant.TestTenantAlwaysDisabled() ||
-		ts.params.DefaultTestTenant.TestTenantAlwaysEnabled()) {
-		return errors.WithHint(
-			errors.AssertionFailedf("programming error: no decision taken about the default test tenant"),
-			"Maybe add the missing call to serverutils.ShouldStartDefaultTestTenant()?")
-	}
-
-	// If the flag has been set to disable the default test tenant, don't start
-	// it here.
-	if ts.params.DefaultTestTenant.TestTenantAlwaysDisabled() {
-		return nil
-	}
-
-	if ts.params.DisableSQLServer {
-		return serverutils.PreventDisableSQLForTenantError()
-	}
-
+func (ts *testServer) startDefaultTestTenant(
+	ctx context.Context,
+) (serverutils.ApplicationLayerInterface, error) {
 	tenantSettings := cluster.MakeTestingClusterSettings()
 	if st := ts.params.Settings; st != nil {
 		// Copy overrides and other test-specific configuration,
@@ -664,6 +643,59 @@ func (ts *testServer) maybeStartDefaultTestTenant(ctx context.Context) error {
 	if ts.params.Knobs.Server != nil {
 		params.TestingKnobs.Server.(*TestingKnobs).DiagnosticsTestingKnobs = ts.params.Knobs.Server.(*TestingKnobs).DiagnosticsTestingKnobs
 	}
+	return ts.StartTenant(ctx, params)
+}
+
+func (ts *testServer) startSharedProcessDefaultTestTenant(
+	ctx context.Context,
+) (serverutils.ApplicationLayerInterface, error) {
+	params := base.TestSharedProcessTenantArgs{
+		TenantName:  "test-tenant",
+		TenantID:    serverutils.TestTenantID(),
+		Knobs:       ts.params.Knobs,
+		UseDatabase: ts.params.UseDatabase,
+	}
+	// See comment above on separate process tenant regarding the testing knobs.
+	params.Knobs.Server = &TestingKnobs{}
+	if ts.params.Knobs.Server != nil {
+		params.Knobs.Server.(*TestingKnobs).DiagnosticsTestingKnobs = ts.params.Knobs.Server.(*TestingKnobs).DiagnosticsTestingKnobs
+	}
+
+	tenant, _, err := ts.StartSharedProcessTenant(ctx, params)
+	if err != nil {
+		return nil, err
+	}
+
+	if err = ts.grantDefaultSharedProcessCapabilities(ctx, params.TenantID); err != nil {
+		return nil, err
+	}
+
+	return tenant, err
+}
+
+// maybeStartDefaultTestTenant might start a test tenant. This can then be used
+// for multi-tenant testing, where the default SQL connection will be made to
+// this tenant instead of to the system tenant. Note that we will
+// currently only attempt to start a test tenant if we're running in an
+// enterprise enabled build. This is due to licensing restrictions on the MT
+// capabilities.
+func (ts *testServer) maybeStartDefaultTestTenant(ctx context.Context) error {
+	if ts.params.DefaultTestTenant.TestTenantNoDecisionMade() {
+		return errors.WithHint(
+			errors.AssertionFailedf(
+				"programming error: no decision taken about starting the default test tenant or which mode to use",
+			), "Maybe add the missing call to serverutils.ShouldStartDefaultTestTenant()?")
+	}
+
+	// If the flag has been set to disable the default test tenant, don't start
+	// it here.
+	if ts.params.DefaultTestTenant.TestTenantAlwaysDisabled() {
+		return nil
+	}
+
+	if ts.params.DisableSQLServer {
+		return serverutils.PreventDisableSQLForTenantError()
+	}
 
 	// Temporarily disable the error that is returned if a tenant should not be started manually,
 	// so that we can start the default test tenant internally here.
@@ -677,7 +709,17 @@ func (ts *testServer) maybeStartDefaultTestTenant(ctx context.Context) error {
 		}
 	}()
 
-	tenant, err := ts.StartTenant(ctx, params)
+	var startTenantFn func(context.Context) (serverutils.ApplicationLayerInterface, error)
+	switch {
+	case ts.params.DefaultTestTenant.ExternalProcessMode():
+		startTenantFn = ts.startDefaultTestTenant
+	case ts.params.DefaultTestTenant.SharedProcessMode():
+		startTenantFn = ts.startSharedProcessDefaultTestTenant
+	default:
+		return errors.AssertionFailedf("invalid default test tenant mode %v", ts.params.DefaultTestTenant)
+	}
+
+	tenant, err := startTenantFn(ctx)
 	if err != nil {
 		return err
 	}
@@ -694,6 +736,43 @@ func (ts *testServer) maybeStartDefaultTestTenant(ctx context.Context) error {
 		// test tenants, in which case, you should evaluate what to do about
 		// returning a default SQL address in AdvSQLAddr().
 		return errors.AssertionFailedf("invalid number of test SQL servers %d", len(ts.testTenants))
+	}
+	return nil
+}
+
+func (ts *testServer) grantDefaultSharedProcessCapabilities(
+	ctx context.Context, tenID roachpb.TenantID,
+) error {
+	ie := ts.InternalExecutor().(*sql.InternalExecutor)
+	for _, setting := range []settings.Setting{
+		sql.SecondaryTenantScatterEnabled,
+		sql.SecondaryTenantSplitAtEnabled,
+		sql.SecondaryTenantZoneConfigsEnabled,
+		sql.SecondaryTenantsMultiRegionAbstractionsEnabled,
+	} {
+		_, err := ie.Exec(ctx, "testserver-alter-tenant-cap", nil,
+			fmt.Sprintf("ALTER VIRTUAL CLUSTER [$1] SET CLUSTER SETTING %s = true", setting.Name()), tenID.ToUint64())
+		if err != nil {
+			return err
+		}
+	}
+	execSQL := func(opName, stmt string, qargs ...interface{}) error {
+		_, err := ie.ExecEx(ctx, opName, nil /* txn */, sessiondata.NodeUserSessionDataOverride, stmt, qargs...)
+		return err
+	}
+	err := execSQL("set-tenant-capability",
+		`ALTER TENANT [$1] GRANT CAPABILITY can_debug_process=true,can_use_nodelocal_storage=true,can_admin_split=true`,
+		tenID.ToUint64(),
+	)
+	if err != nil {
+		return err
+	}
+	if err := ts.WaitForTenantCapabilities(ctx, tenID, map[tenantcapabilities.ID]string{
+		tenantcapabilities.CanDebugProcess:        "true",
+		tenantcapabilities.CanUseNodelocalStorage: "true",
+		tenantcapabilities.CanAdminSplit:          "true",
+	}, ""); err != nil {
+		return err
 	}
 	return nil
 }
@@ -1203,7 +1282,12 @@ func (ts *testServer) StartSharedProcessTenant(
 	if err := args.TenantName.IsValid(); err != nil {
 		return nil, nil, err
 	}
-
+	// Helper function to execute SQL statements.
+	ie := ts.InternalExecutor().(*sql.InternalExecutor)
+	execSQL := func(opName, stmt string, qargs ...interface{}) error {
+		_, err := ie.ExecEx(ctx, opName, nil /* txn */, sessiondata.NodeUserSessionDataOverride, stmt, qargs...)
+		return err
+	}
 	// Save the args for use if the server needs to be created.
 	func() {
 		ts.topLevelServer.serverController.mu.Lock()
@@ -1211,7 +1295,7 @@ func (ts *testServer) StartSharedProcessTenant(
 		ts.topLevelServer.serverController.mu.testArgs[args.TenantName] = args
 	}()
 
-	tenantRow, err := ts.InternalExecutor().(*sql.InternalExecutor).QueryRow(
+	tenantRow, err := ie.QueryRow(
 		ctx, "testserver-check-tenant-active", nil, /* txn */
 		"SELECT id FROM system.tenants WHERE name=$1 AND active=true",
 		args.TenantName,
@@ -1235,13 +1319,8 @@ func (ts *testServer) StartSharedProcessTenant(
 		// The tenant doesn't exist; let's create it.
 		if args.TenantID.IsSet() {
 			// Create with name and ID.
-			_, err := ts.InternalExecutor().(*sql.InternalExecutor).ExecEx(
-				ctx,
-				"create-tenant",
-				nil, /* txn */
-				sessiondata.NodeUserSessionDataOverride,
-				"SELECT crdb_internal.create_tenant($1,$2)",
-				args.TenantID.ToUint64(), args.TenantName,
+			err := execSQL(
+				"create-tenant", "SELECT crdb_internal.create_tenant($1,$2)", args.TenantID.ToUint64(), args.TenantName,
 			)
 			if err != nil {
 				return nil, nil, err
@@ -1249,7 +1328,7 @@ func (ts *testServer) StartSharedProcessTenant(
 			tenantID = args.TenantID
 		} else {
 			// Create with name alone; allocate an ID automatically.
-			row, err := ts.InternalExecutor().(*sql.InternalExecutor).QueryRowEx(
+			row, err := ie.QueryRowEx(
 				ctx,
 				"create-tenant",
 				nil, /* txn */
@@ -1266,11 +1345,8 @@ func (ts *testServer) StartSharedProcessTenant(
 	}
 
 	// Also mark it for shared-process execution.
-	_, err = ts.InternalExecutor().(*sql.InternalExecutor).ExecEx(
-		ctx,
+	err = execSQL(
 		"start-tenant-shared-service",
-		nil, /* txn */
-		sessiondata.NodeUserSessionDataOverride,
 		"ALTER TENANT $1 START SERVICE SHARED",
 		args.TenantName,
 	)

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -759,10 +759,10 @@ func (ts *testServer) grantDefaultTenantCapabilities(
 		}
 	}
 
-	// Waiting for capabilities can time To avoid paying this cost in all
+	// Waiting for capabilities can take time. To avoid paying this cost in all
 	// cases, we only set the nodelocal storage capability if the caller has
-	// configured an ExternalIODir since nodelocal storage only works with
-	// that configured.
+	// configured an ExternalIODir since nodelocal storage only works with that
+	// configured.
 	shouldGrantNodelocalCap := ts.params.ExternalIODir != ""
 	canGrantNodelocalCap := ts.ClusterSettings().Version.IsActive(ctx, clusterversion.TODO_Delete_V23_1TenantCapabilities)
 	if canGrantNodelocalCap && shouldGrantNodelocalCap {

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -666,10 +666,6 @@ func (ts *testServer) startSharedProcessDefaultTestTenant(
 		return nil, err
 	}
 
-	if err = ts.grantDefaultSharedProcessCapabilities(ctx, params.TenantID); err != nil {
-		return nil, err
-	}
-
 	return tenant, err
 }
 
@@ -737,8 +733,8 @@ func (ts *testServer) maybeStartDefaultTestTenant(ctx context.Context) error {
 	return nil
 }
 
-func (ts *testServer) grantDefaultSharedProcessCapabilities(
-	ctx context.Context, tenID roachpb.TenantID,
+func (ts *testServer) grantDefaultTenantCapabilities(
+	ctx context.Context, tenantID roachpb.TenantID, skipTenantCheck bool,
 ) error {
 	ie := ts.InternalExecutor().(*sql.InternalExecutor)
 	for _, setting := range []settings.Setting{
@@ -747,29 +743,44 @@ func (ts *testServer) grantDefaultSharedProcessCapabilities(
 		sql.SecondaryTenantZoneConfigsEnabled,
 		sql.SecondaryTenantsMultiRegionAbstractionsEnabled,
 	} {
+		// Update the override for this setting. We need to do this
+		// instead of calling .Override() on the setting directly: certain
+		// tests expect to be able to change the value afterwards using
+		// another ALTER VC SET CLUSTER SETTING statement, which is not
+		// possible with regular overrides.
 		_, err := ie.Exec(ctx, "testserver-alter-tenant-cap", nil,
-			fmt.Sprintf("ALTER VIRTUAL CLUSTER [$1] SET CLUSTER SETTING %s = true", setting.Name()), tenID.ToUint64())
+			fmt.Sprintf("ALTER VIRTUAL CLUSTER [$1] SET CLUSTER SETTING %s = true", setting.Name()), tenantID.ToUint64())
 		if err != nil {
-			return err
+			if skipTenantCheck {
+				log.Infof(ctx, "ignoring error changing setting because SkipTenantCheck is true: %v", err)
+			} else {
+				return err
+			}
 		}
 	}
-	execSQL := func(opName, stmt string, qargs ...interface{}) error {
-		_, err := ie.ExecEx(ctx, opName, nil /* txn */, sessiondata.NodeUserSessionDataOverride, stmt, qargs...)
-		return err
-	}
-	err := execSQL("set-tenant-capability",
-		`ALTER TENANT [$1] GRANT CAPABILITY can_debug_process=true,can_use_nodelocal_storage=true,can_admin_split=true`,
-		tenID.ToUint64(),
-	)
-	if err != nil {
-		return err
-	}
-	if err := ts.WaitForTenantCapabilities(ctx, tenID, map[tenantcapabilities.ID]string{
-		tenantcapabilities.CanDebugProcess:        "true",
-		tenantcapabilities.CanUseNodelocalStorage: "true",
-		tenantcapabilities.CanAdminSplit:          "true",
-	}, ""); err != nil {
-		return err
+
+	// Waiting for capabilities can time To avoid paying this cost in all
+	// cases, we only set the nodelocal storage capability if the caller has
+	// configured an ExternalIODir since nodelocal storage only works with
+	// that configured.
+	shouldGrantNodelocalCap := ts.params.ExternalIODir != ""
+	canGrantNodelocalCap := ts.ClusterSettings().Version.IsActive(ctx, clusterversion.TODO_Delete_V23_1TenantCapabilities)
+	if canGrantNodelocalCap && shouldGrantNodelocalCap {
+		_, err := ie.Exec(ctx, "testserver-alter-tenant-cap", nil,
+			"ALTER TENANT [$1] GRANT CAPABILITY can_use_nodelocal_storage", tenantID.ToUint64())
+		if err != nil {
+			if skipTenantCheck {
+				log.Infof(ctx, "ignoring error granting capability because SkipTenantCheck is true: %v", err)
+			} else {
+				return err
+			}
+		} else {
+			if err := ts.WaitForTenantCapabilities(ctx, tenantID, map[tenantcapabilities.ID]string{
+				tenantcapabilities.CanUseNodelocalStorage: "true",
+			}, ""); err != nil {
+				return err
+			}
+		}
 	}
 	return nil
 }
@@ -1381,6 +1392,10 @@ func (ts *testServer) StartSharedProcessTenant(
 		drain:          sqlServerWrapper.drainServer,
 	}
 
+	if err = ts.grantDefaultTenantCapabilities(ctx, tenantID, args.SkipTenantCheck); err != nil {
+		return nil, nil, err
+	}
+
 	sqlDB, err := ts.SQLConnE(serverutils.DBName("cluster:" + string(args.TenantName) + "/" + args.UseDatabase))
 	if err != nil {
 		return nil, nil, err
@@ -1674,53 +1689,9 @@ func (ts *testServer) StartTenant(
 	baseCfg.HeapProfileDirName = ts.Cfg.BaseConfig.HeapProfileDirName
 	baseCfg.GoroutineDumpDirName = ts.Cfg.BaseConfig.GoroutineDumpDirName
 
-	for _, setting := range []settings.Setting{
-		sql.SecondaryTenantScatterEnabled,
-		sql.SecondaryTenantSplitAtEnabled,
-		sql.SecondaryTenantZoneConfigsEnabled,
-		sql.SecondaryTenantsMultiRegionAbstractionsEnabled,
-	} {
-		// Update the override for this setting. We need to do this
-		// instead of calling .Override() on the setting directly: certain
-		// tests expect to be able to change the value afterwards using
-		// another ALTER VC SET CLUSTER SETTING statement, which is not
-		// possible with regular overrides.
-		_, err := ie.Exec(ctx, "testserver-alter-tenant-cap", nil,
-			fmt.Sprintf("ALTER VIRTUAL CLUSTER [$1] SET CLUSTER SETTING %s = true", setting.Name()), params.TenantID.ToUint64())
-		if err != nil {
-			if params.SkipTenantCheck {
-				log.Infof(ctx, "ignoring error changing setting because SkipTenantCheck is true: %v", err)
-			} else {
-				return nil, err
-			}
-		}
-	}
-
-	// Waiting for capabilities can time To avoid paying this cost in all
-	// cases, we only set the nodelocal storage capability if the caller has
-	// configured an ExternalIODir since nodelocal storage only works with
-	// that configured.
-	//
-	// TODO(ssd): We do not set this capability in
-	// StartSharedProcessTenant.
-	shouldGrantNodelocalCap := ts.params.ExternalIODir != ""
-	canGrantNodelocalCap := ts.ClusterSettings().Version.IsActive(ctx, clusterversion.TODO_Delete_V23_1TenantCapabilities)
-	if canGrantNodelocalCap && shouldGrantNodelocalCap {
-		_, err := ie.Exec(ctx, "testserver-alter-tenant-cap", nil,
-			"ALTER TENANT [$1] GRANT CAPABILITY can_use_nodelocal_storage", params.TenantID.ToUint64())
-		if err != nil {
-			if params.SkipTenantCheck {
-				log.Infof(ctx, "ignoring error granting capability because SkipTenantCheck is true: %v", err)
-			} else {
-				return nil, err
-			}
-		} else {
-			if err := ts.WaitForTenantCapabilities(ctx, params.TenantID, map[tenantcapabilities.ID]string{
-				tenantcapabilities.CanUseNodelocalStorage: "true",
-			}, ""); err != nil {
-				return nil, err
-			}
-		}
+	// Grant the tenant the default capabilities.
+	if err := ts.grantDefaultTenantCapabilities(ctx, params.TenantID, params.SkipTenantCheck); err != nil {
+		return nil, err
 	}
 
 	// For now, we don't support split RPC/SQL ports for secondary tenants

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -499,6 +500,35 @@ func (ts *testServer) SQLConnE(opts ...serverutils.SQLConnOption) (*gosql.DB, er
 		ts.cfg.SQLAdvertiseAddr,
 		ts.cfg.Insecure,
 		options.ClientCerts,
+		options.CertsDirPrefix,
+	)
+}
+
+// PGUrl is part of the serverutils.ApplicationLayerInterface.
+func (ts *testServer) PGUrl(
+	test serverutils.TestFataler, opts ...serverutils.SQLConnOption,
+) (url.URL, func()) {
+	u, cleanupFn, err := ts.PGUrlE(opts...)
+	if err != nil {
+		test.Fatal(err)
+	}
+	return u, cleanupFn
+}
+
+// PGUrlE is part of the serverutils.ApplicationLayerInterface.
+func (ts *testServer) PGUrlE(opts ...serverutils.SQLConnOption) (url.URL, func(), error) {
+	options := serverutils.DefaultSQLConnOptions()
+	for _, opt := range opts {
+		opt(options)
+	}
+	return pgURL(
+		options.DBName,
+		options.User,
+		catconstants.SystemTenantName,
+		ts.cfg.SQLAdvertiseAddr,
+		ts.cfg.Insecure,
+		options.ClientCerts,
+		options.CertsDirPrefix,
 	)
 }
 
@@ -850,6 +880,41 @@ func (t *testTenant) SQLConnE(opts ...serverutils.SQLConnOption) (*gosql.DB, err
 		t.Cfg.SQLAdvertiseAddr,
 		t.Cfg.Insecure,
 		options.ClientCerts,
+		options.CertsDirPrefix,
+	)
+}
+
+// PGUrl is part of the serverutils.ApplicationLayerInterface.
+func (t *testTenant) PGUrl(
+	test serverutils.TestFataler, opts ...serverutils.SQLConnOption,
+) (url.URL, func()) {
+	u, cleanupFn, err := t.PGUrlE(opts...)
+	if err != nil {
+		test.Fatal(err)
+	}
+	return u, cleanupFn
+}
+
+// PGUrlE is part of the serverutils.ApplicationLayerInterface.
+func (t *testTenant) PGUrlE(opts ...serverutils.SQLConnOption) (url.URL, func(), error) {
+	options := serverutils.DefaultSQLConnOptions()
+	for _, opt := range opts {
+		opt(options)
+	}
+	tenantName := t.t.tenantName
+	if !t.Cfg.DisableSQLListener {
+		// This tenant server has its own SQL listener. It will not accept
+		// a "cluster" connection parameter.
+		tenantName = ""
+	}
+	return pgURL(
+		options.DBName,
+		options.User,
+		tenantName,
+		t.Cfg.SQLAdvertiseAddr,
+		t.Cfg.Insecure,
+		options.ClientCerts,
+		options.CertsDirPrefix,
 	)
 }
 

--- a/pkg/sql/catalog/lease/lease_test.go
+++ b/pkg/sql/catalog/lease/lease_test.go
@@ -383,6 +383,9 @@ func TestLeaseManagerReacquire(testingT *testing.T) {
 
 	ctx := context.Background()
 	var params base.TestClusterArgs
+	params.ServerArgs.DefaultTestTenant = base.TestDoesNotWorkWithSharedProcessModeButWeDontKnowWhyYet(
+		base.TestTenantProbabilistic, 112957,
+	)
 	params.ServerArgs.Settings = cluster.MakeTestingClusterSettings()
 	// Set the lease duration such that the next lease acquisition will
 	// require the lease to be reacquired.
@@ -1240,6 +1243,9 @@ func TestLeaseRenewedAutomatically(testingT *testing.T) {
 	var testAcquiredCount int32
 	var testAcquisitionBlockCount int32
 	var params base.TestClusterArgs
+	params.ServerArgs.DefaultTestTenant = base.TestDoesNotWorkWithSharedProcessModeButWeDontKnowWhyYet(
+		base.TestTenantProbabilistic, 112957,
+	)
 	params.ServerArgs.Knobs = base.TestingKnobs{
 		SQLLeaseManager: &lease.ManagerTestingKnobs{
 			LeaseStoreTestingKnobs: lease.StorageTestingKnobs{
@@ -1829,6 +1835,9 @@ func TestLeaseRenewedPeriodically(testingT *testing.T) {
 	var expected catalog.DescriptorIDSet
 
 	var params base.TestClusterArgs
+	params.ServerArgs.DefaultTestTenant = base.TestDoesNotWorkWithSharedProcessModeButWeDontKnowWhyYet(
+		base.TestTenantProbabilistic, 112957,
+	)
 	params.ServerArgs.Knobs = base.TestingKnobs{
 		SQLLeaseManager: &lease.ManagerTestingKnobs{
 			LeaseStoreTestingKnobs: lease.StorageTestingKnobs{
@@ -2338,6 +2347,9 @@ func TestRangefeedUpdatesHandledProperlyInTheFaceOfRaces(t *testing.T) {
 	blockLeaseAcquisitionOfInterestingTable := make(chan chan struct{})
 	unblockAll := make(chan struct{})
 	args := base.TestServerArgs{}
+	args.DefaultTestTenant = base.TestDoesNotWorkWithSharedProcessModeButWeDontKnowWhyYet(
+		base.TestTenantProbabilistic, 112957,
+	)
 	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{
 		ServerArgs: args,
 	})
@@ -2957,6 +2969,9 @@ func TestLeaseTxnDeadlineExtension(t *testing.T) {
 	var txnID string
 
 	var params base.TestServerArgs
+	params.DefaultTestTenant = base.TestDoesNotWorkWithSharedProcessModeButWeDontKnowWhyYet(
+		base.TestTenantProbabilistic, 112957,
+	)
 	params.Settings = cluster.MakeTestingClusterSettings()
 	// Set the lease duration such that the next lease acquisition will
 	// require the lease to be reacquired.

--- a/pkg/sql/conn_executor_test.go
+++ b/pkg/sql/conn_executor_test.go
@@ -1194,7 +1194,7 @@ func TestTransactionDeadline(t *testing.T) {
 		},
 	}
 	s := serverutils.StartServerOnly(t, base.TestServerArgs{
-		DefaultTestTenant: base.TestTenantAlwaysEnabled,
+		DefaultTestTenant: base.TestControlsTenantsExplicitly,
 		Knobs:             knobs,
 	})
 	defer s.Stopper().Stop(ctx)

--- a/pkg/sql/copy/copy_in_test.go
+++ b/pkg/sql/copy/copy_in_test.go
@@ -309,8 +309,9 @@ func TestCopyFromBinary(t *testing.T) {
 	defer srv.Stopper().Stop(ctx)
 	s := srv.ApplicationLayer()
 
-	pgURL, cleanupGoDB := sqlutils.PGUrl(
-		t, s.AdvSQLAddr(), "StartServer" /* prefix */, url.User(username.RootUser))
+	pgURL, cleanupGoDB := s.PGUrl(
+		t, serverutils.CertsDirPrefix("StartServer"), serverutils.User(username.RootUser),
+	)
 	defer cleanupGoDB()
 	conn, err := pgx.Connect(ctx, pgURL.String())
 	if err != nil {
@@ -520,8 +521,9 @@ func TestCopyFromRetries(t *testing.T) {
 			ctx := context.Background()
 
 			// Use pgx instead of lib/pq as pgx doesn't require copy to be in a txn.
-			pgURL, cleanupGoDB := sqlutils.PGUrl(
-				t, s.AdvSQLAddr(), "StartServer" /* prefix */, url.User(username.RootUser))
+			pgURL, cleanupGoDB := s.PGUrl(
+				t, serverutils.CertsDirPrefix("StartServer"), serverutils.User(username.RootUser),
+			)
 			defer cleanupGoDB()
 			pgxConn, err := pgx.Connect(ctx, pgURL.String())
 			require.NoError(t, err)
@@ -678,9 +680,11 @@ func TestCopyInReleasesLeases(t *testing.T) {
 	tdb.Exec(t, `CREATE USER foo WITH PASSWORD 'testabc'`)
 	tdb.Exec(t, `GRANT admin TO foo`)
 
-	userURL, cleanupFn := sqlutils.PGUrlWithOptionalClientCerts(t,
-		s.AdvSQLAddr(), t.Name(), url.UserPassword("foo", "testabc"),
-		false /* withClientCerts */)
+	userURL, cleanupFn := s.PGUrl(t,
+		serverutils.CertsDirPrefix(t.Name()),
+		serverutils.UserPassword("foo", "testabc"),
+		serverutils.ClientCerts(false),
+	)
 	defer cleanupFn()
 	conn, err := sqltestutils.PGXConn(t, userURL)
 	require.NoError(t, err)

--- a/pkg/sql/copy/copy_out_test.go
+++ b/pkg/sql/copy/copy_out_test.go
@@ -14,7 +14,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"net/url"
 	"strings"
 	"testing"
 
@@ -52,10 +51,9 @@ func TestCopyOutTransaction(t *testing.T) {
 	`)
 	require.NoError(t, err)
 
-	pgURL, cleanupGoDB, err := sqlutils.PGUrlE(
-		s.AdvSQLAddr(),
-		"StartServer", /* prefix */
-		url.User(username.RootUser),
+	pgURL, cleanupGoDB, err := s.PGUrlE(
+		serverutils.CertsDirPrefix("StartServer"),
+		serverutils.User(username.RootUser),
 	)
 	require.NoError(t, err)
 	s.AppStopper().AddCloser(stop.CloserFn(func() { cleanupGoDB() }))
@@ -120,10 +118,9 @@ func TestCopyOutRandom(t *testing.T) {
 
 	// Use pgx for this next bit as it allows selecting rows by raw values.
 	// Furthermore, it handles CopyTo!
-	pgURL, cleanupGoDB, err := sqlutils.PGUrlE(
-		s.AdvSQLAddr(),
-		"StartServer", /* prefix */
-		url.User(username.RootUser),
+	pgURL, cleanupGoDB, err := s.PGUrlE(
+		serverutils.CertsDirPrefix("StartServer"),
+		serverutils.User(username.RootUser),
 	)
 	require.NoError(t, err)
 	s.AppStopper().AddCloser(stop.CloserFn(func() { cleanupGoDB() }))

--- a/pkg/sql/copy/copy_test.go
+++ b/pkg/sql/copy/copy_test.go
@@ -693,7 +693,7 @@ func TestLargeCopy(t *testing.T) {
 	defer srv.Stopper().Stop(ctx)
 	s := srv.ApplicationLayer()
 
-	url, cleanup := sqlutils.PGUrl(t, s.AdvSQLAddr(), "copytest", url.User(username.RootUser))
+	url, cleanup := s.PGUrl(t, serverutils.CertsDirPrefix("copytest"), serverutils.User(username.RootUser))
 	defer cleanup()
 	var sqlConnCtx clisqlclient.Context
 	conn := sqlConnCtx.MakeSQLConn(io.Discard, io.Discard, url.String())

--- a/pkg/sql/importer/import_stmt_test.go
+++ b/pkg/sql/importer/import_stmt_test.go
@@ -1693,11 +1693,10 @@ func TestImportRowLimit(t *testing.T) {
 	sqlDB := sqlutils.MakeSQLRunner(conn)
 
 	// Also create a pgx connection so we can check notices.
-	pgURL, cleanup := sqlutils.PGUrl(
+	pgURL, cleanup := tc.ApplicationLayer(0).PGUrl(
 		t,
-		tc.ApplicationLayer(0).AdvSQLAddr(),
-		"TestImportRowLimit",
-		url.User(username.RootUser),
+		serverutils.CertsDirPrefix("TestImportRowLimit"),
+		serverutils.User(username.RootUser),
 	)
 	defer cleanup()
 	config, err := pgx.ParseConfig(pgURL.String())
@@ -6785,8 +6784,9 @@ func TestImportClientDisconnect(t *testing.T) {
 	// Make credentials for the new connection.
 	runner.Exec(t, `CREATE USER testuser`)
 	runner.Exec(t, `GRANT admin TO testuser`)
-	pgURL, cleanup := sqlutils.PGUrl(t, tc.ApplicationLayer(0).AdvSQLAddr(),
-		"TestImportClientDisconnect-testuser", url.User("testuser"))
+	pgURL, cleanup := tc.ApplicationLayer(0).PGUrl(t,
+		serverutils.CertsDirPrefix("TestImportClientDisconnect-testuser"), serverutils.User("testuser"),
+	)
 	defer cleanup()
 	runner.Exec(t, "CREATE TABLE foo (k INT PRIMARY KEY, v STRING)")
 

--- a/pkg/sql/pgrepl/connect_test.go
+++ b/pkg/sql/pgrepl/connect_test.go
@@ -13,7 +13,6 @@ package pgrepl_test
 import (
 	"context"
 	"fmt"
-	"net/url"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -91,11 +90,12 @@ func TestReplicationConnect(t *testing.T) {
 				sqlDB.Exec(t, `GRANT ADMIN TO testuser`)
 			}
 
-			u := url.User(username.TestUser)
+			u := username.TestUser
 			if tc.useRoot {
-				u = url.User(username.RootUser)
+				u = username.RootUser
 			}
-			pgURL, cleanup := sqlutils.PGUrl(t, s.AdvSQLAddr(), "pgrepl_conn_test", u)
+
+			pgURL, cleanup := s.PGUrl(t, serverutils.CertsDirPrefix("pgrepl_conn_test"), serverutils.User(u))
 			defer cleanup()
 
 			cfg, err := pgx.ParseConfig(pgURL.String())

--- a/pkg/sql/pgrepl/extended_protocol_test.go
+++ b/pkg/sql/pgrepl/extended_protocol_test.go
@@ -12,7 +12,6 @@ package pgrepl
 
 import (
 	"context"
-	"net/url"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -40,7 +39,9 @@ func TestExtendedProtocolDisabled(t *testing.T) {
 	sqlDB := sqlutils.MakeSQLRunner(db)
 	sqlDB.Exec(t, `CREATE USER testuser LOGIN REPLICATION`)
 
-	pgURL, cleanup := sqlutils.PGUrl(t, s.AdvSQLAddr(), "pgrepl_extended_protocol_test", url.User(username.TestUser))
+	pgURL, cleanup := s.PGUrl(
+		t, serverutils.CertsDirPrefix("pgrepl_extended_protocol_test"), serverutils.User(username.TestUser),
+	)
 	defer cleanup()
 
 	cfg, err := pgconn.ParseConfig(pgURL.String())

--- a/pkg/sql/pgwire/auth_test.go
+++ b/pkg/sql/pgwire/auth_test.go
@@ -633,7 +633,11 @@ func TestClientAddrOverride(t *testing.T) {
 	defer sc.Close(t)
 
 	// Start a server.
-	srv, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	srv, db, _ := serverutils.StartServer(t, base.TestServerArgs{
+		DefaultTestTenant: base.TestIsForStuffThatShouldWorkWithSharedProcessModeButDoesntYet(
+			base.TestTenantProbabilistic, 112867,
+		),
+	})
 	ctx := context.Background()
 	defer srv.Stopper().Stop(ctx)
 
@@ -803,6 +807,12 @@ func TestSSLSessionVar(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Set the system layer to accept SQL without TLS in the event of a shared
+	// process virtual cluster.
+	srv.SystemLayer().SetAcceptSQLWithoutTLS(true)
+
+	// TODO(herko): What effect should this have on a shared process virtual
+	// cluster? See: https://github.com/cockroachdb/cockroach/issues/112961
 	s.SetAcceptSQLWithoutTLS(true)
 
 	pgURLWithCerts, cleanupFuncCerts := s.PGUrl(t,

--- a/pkg/sql/pgwire/auth_test.go
+++ b/pkg/sql/pgwire/auth_test.go
@@ -639,9 +639,7 @@ func TestClientAddrOverride(t *testing.T) {
 
 	s := srv.ApplicationLayer()
 
-	pgURL, cleanupFunc := sqlutils.PGUrl(
-		t, s.AdvSQLAddr(), "testClientAddrOverride" /* prefix */, url.User(username.TestUser),
-	)
+	pgURL, cleanupFunc := s.PGUrl(t, serverutils.CertsDirPrefix("testClientAddrOverride"), serverutils.User(username.TestUser))
 	defer cleanupFunc()
 
 	// Ensure the test user exists.
@@ -807,15 +805,20 @@ func TestSSLSessionVar(t *testing.T) {
 
 	s.SetAcceptSQLWithoutTLS(true)
 
-	pgURLWithCerts, cleanupFuncCerts := sqlutils.PGUrlWithOptionalClientCerts(
-		t, s.AdvSQLAddr(), "TestSSLSessionVarCerts" /* prefix */, url.User(username.TestUser), true,
+	pgURLWithCerts, cleanupFuncCerts := s.PGUrl(t,
+		serverutils.CertsDirPrefix("TestSSLSessionVarCerts"),
+		serverutils.User(username.TestUser),
+		serverutils.ClientCerts(true),
 	)
 	defer cleanupFuncCerts()
 
-	pgURLWithoutCerts, cleanupFuncWithoutCerts := sqlutils.PGUrlWithOptionalClientCerts(
-		t, s.AdvSQLAddr(), "TestSSLSessionVarNoCerts" /* prefix */, url.UserPassword(username.TestUser, "abc"), false,
+	pgURLWithoutCerts, cleanupFuncWithoutCerts := s.PGUrl(t,
+		serverutils.CertsDirPrefix("TestSSLSessionVarNoCerts"),
+		serverutils.UserPassword(username.TestUser, "abc"),
+		serverutils.ClientCerts(false),
 	)
 	defer cleanupFuncWithoutCerts()
+
 	q := pgURLWithoutCerts.Query()
 	q.Set("sslmode", "disable")
 	pgURLWithoutCerts.RawQuery = q.Encode()

--- a/pkg/sql/pgwire/conn_test.go
+++ b/pkg/sql/pgwire/conn_test.go
@@ -1717,13 +1717,20 @@ func TestParseSearchPathInConnectionString(t *testing.T) {
 		},
 	}
 
-	srv := serverutils.StartServerOnly(t, base.TestServerArgs{})
+	srv := serverutils.StartServerOnly(t, base.TestServerArgs{
+		DefaultTestTenant: base.TestIsForStuffThatShouldWorkWithSharedProcessModeButDoesntYet(
+			base.TestTenantProbabilistic, 112959,
+		),
+	})
 	ctx := context.Background()
 	defer srv.Stopper().Stop(ctx)
 	s := srv.ApplicationLayer()
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
+			// TODO(herko): This test manipulates the query string directly and needs
+			// to be updated to support a cluster option in order to support shared
+			// process virtual clusters.
 			pgURL, cleanupFunc := sqlutils.PGUrl(
 				t, s.AdvSQLAddr(), "TestParseSearchPathInConnectionString" /* prefix */, url.User(username.RootUser),
 			)
@@ -1748,7 +1755,11 @@ func TestParseSearchPathInConnectionString(t *testing.T) {
 func TestSetSessionArguments(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	srv := serverutils.StartServerOnly(t, base.TestServerArgs{})
+	srv := serverutils.StartServerOnly(t, base.TestServerArgs{
+		DefaultTestTenant: base.TestIsForStuffThatShouldWorkWithSharedProcessModeButDoesntYet(
+			base.TestTenantProbabilistic, 112959,
+		),
+	})
 	ctx := context.Background()
 	defer srv.Stopper().Stop(ctx)
 	s := srv.ApplicationLayer()
@@ -1756,6 +1767,9 @@ func TestSetSessionArguments(t *testing.T) {
 	_, err := s.SQLConn(t, serverutils.DBName("defaultdb")).Exec(`SET CLUSTER SETTING sql.txn.read_committed_syntax.enabled = true`)
 	require.NoError(t, err)
 
+	// TODO(herko): This test manipulates the query string directly and needs to
+	// be updated to support a cluster option in order to support shared process
+	// virtual clusters.
 	pgURL, cleanupFunc := sqlutils.PGUrl(
 		t, s.AdvSQLAddr(), "testConnClose" /* prefix */, url.User(username.RootUser),
 	)

--- a/pkg/sql/pgwire/pgtest_test.go
+++ b/pkg/sql/pgwire/pgtest_test.go
@@ -38,6 +38,9 @@ func TestPGTest(t *testing.T) {
 		newServer := func() (addr, user string, cleanup func()) {
 			ctx := context.Background()
 			s, db, _ := serverutils.StartServer(t, base.TestServerArgs{
+				DefaultTestTenant: base.TestIsForStuffThatShouldWorkWithSharedProcessModeButDoesntYet(
+					base.TestTenantProbabilistic, 112960,
+				),
 				Insecure: true,
 			})
 			cleanup = func() {

--- a/pkg/sql/sessioninit/BUILD.bazel
+++ b/pkg/sql/sessioninit/BUILD.bazel
@@ -44,7 +44,6 @@ go_test(
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/descs",
         "//pkg/testutils/serverutils",
-        "//pkg/testutils/sqlutils",
         "//pkg/testutils/testcluster",
         "//pkg/util/leaktest",
         "//pkg/util/log",

--- a/pkg/sql/sessioninit/cache_test.go
+++ b/pkg/sql/sessioninit/cache_test.go
@@ -13,7 +13,6 @@ package sessioninit_test
 import (
 	"context"
 	gosql "database/sql"
-	"net/url"
 	"sync"
 	"testing"
 
@@ -24,7 +23,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessioninit"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
-	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/stretchr/testify/require"
@@ -39,8 +37,8 @@ func TestCacheInvalidation(t *testing.T) {
 	defer srv.Stopper().Stop(ctx)
 	s := srv.ApplicationLayer()
 
-	pgURL, cleanupFunc := sqlutils.PGUrl(
-		t, s.AdvSQLAddr(), "TestCacheInvalidation" /* prefix */, url.UserPassword("testuser", "abc"),
+	pgURL, cleanupFunc := s.PGUrl(
+		t, serverutils.CertsDirPrefix("TestCacheInvalidation"), serverutils.UserPassword("testuser", "abc"),
 	)
 	defer cleanupFunc()
 

--- a/pkg/sql/tests/allow_role_memberships_to_change_during_transaction_test.go
+++ b/pkg/sql/tests/allow_role_memberships_to_change_during_transaction_test.go
@@ -13,7 +13,6 @@ package tests
 import (
 	"context"
 	gosql "database/sql"
-	"net/url"
 	"testing"
 	"time"
 
@@ -39,19 +38,10 @@ func TestAllowRoleMembershipsToChangeDuringTransaction(t *testing.T) {
 	defer s.Stopper().Stop(ctx)
 
 	openUser := func(username, dbName string) (_ *gosql.DB, cleanup func()) {
-		pgURL, testuserCleanupFunc := sqlutils.PGUrlWithOptionalClientCerts(
-			t, s.ApplicationLayer().AdvSQLAddr(), username,
-			url.UserPassword(username, username),
-			false, /* withClientCerts */
-		)
-		pgURL.Path = dbName
-		db, err := gosql.Open("postgres", pgURL.String())
-		if err != nil {
-			t.Fatal(err)
-		}
+		db := s.ApplicationLayer().
+			SQLConn(t, serverutils.UserPassword(username, username), serverutils.DBName(dbName), serverutils.ClientCerts(false))
 		return db, func() {
 			require.NoError(t, db.Close())
-			testuserCleanupFunc()
 		}
 	}
 

--- a/pkg/sql/tests/autocommit_extended_protocol_test.go
+++ b/pkg/sql/tests/autocommit_extended_protocol_test.go
@@ -13,7 +13,6 @@ package tests
 import (
 	"context"
 	"errors"
-	"net/url"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -22,7 +21,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
-	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
@@ -90,7 +88,7 @@ func TestInsertFastPathDisableDDLExtendedProtocol(t *testing.T) {
 	require.NoError(t, err)
 
 	// Use pgx so that we can introspect error codes returned from cockroach.
-	pgURL, cleanup := sqlutils.PGUrl(t, s.ApplicationLayer().AdvSQLAddr(), "", url.User("root"))
+	pgURL, cleanup := s.PGUrl(t)
 	defer cleanup()
 	conf, err := pgx.ParseConfig(pgURL.String())
 	require.NoError(t, err)

--- a/pkg/sql/tests/show_commit_timestamp_test.go
+++ b/pkg/sql/tests/show_commit_timestamp_test.go
@@ -15,7 +15,6 @@ import (
 	gosql "database/sql"
 	"fmt"
 	"math/big"
-	"net/url"
 	"testing"
 
 	"github.com/cockroachdb/cockroach-go/v2/crdb"
@@ -78,7 +77,7 @@ CREATE TABLE foo (i INT PRIMARY KEY)`)
 
 	testutils.RunTrueAndFalse(t, "pgx batch; simple", func(t *testing.T, simple bool) {
 		resetTable(t)
-		pgURL, cleanup := sqlutils.PGUrl(t, s.ApplicationLayer().AdvSQLAddr(), "", url.User("root"))
+		pgURL, cleanup := s.PGUrl(t)
 		defer cleanup()
 		conf, err := pgx.ParseConfig(pgURL.String())
 		require.NoError(t, err)
@@ -130,7 +129,7 @@ CREATE TABLE foo (i INT PRIMARY KEY)`)
 	})
 	testutils.RunTrueAndFalse(t, "pgx with crdb; simple", func(t *testing.T, simple bool) {
 		resetTable(t)
-		pgURL, cleanup := sqlutils.PGUrl(t, s.ApplicationLayer().AdvSQLAddr(), "", url.User("root"))
+		pgURL, cleanup := s.PGUrl(t)
 		defer cleanup()
 		conf, err := pgx.ParseConfig(pgURL.String())
 		require.NoError(t, err)

--- a/pkg/sql/tests/show_commit_timestamp_test.go
+++ b/pkg/sql/tests/show_commit_timestamp_test.go
@@ -77,7 +77,7 @@ CREATE TABLE foo (i INT PRIMARY KEY)`)
 
 	testutils.RunTrueAndFalse(t, "pgx batch; simple", func(t *testing.T, simple bool) {
 		resetTable(t)
-		pgURL, cleanup := s.PGUrl(t)
+		pgURL, cleanup := s.ApplicationLayer().PGUrl(t)
 		defer cleanup()
 		conf, err := pgx.ParseConfig(pgURL.String())
 		require.NoError(t, err)
@@ -129,7 +129,7 @@ CREATE TABLE foo (i INT PRIMARY KEY)`)
 	})
 	testutils.RunTrueAndFalse(t, "pgx with crdb; simple", func(t *testing.T, simple bool) {
 		resetTable(t)
-		pgURL, cleanup := s.PGUrl(t)
+		pgURL, cleanup := s.ApplicationLayer().PGUrl(t)
 		defer cleanup()
 		conf, err := pgx.ParseConfig(pgURL.String())
 		require.NoError(t, err)

--- a/pkg/testutils/serverutils/BUILD.bazel
+++ b/pkg/testutils/serverutils/BUILD.bazel
@@ -45,6 +45,7 @@ go_library(
         "//pkg/util/httputil",
         "//pkg/util/log",
         "//pkg/util/protoutil",
+        "//pkg/util/randutil",
         "//pkg/util/stop",
         "//pkg/util/tracing",
         "//pkg/util/uuid",

--- a/pkg/testutils/serverutils/api.go
+++ b/pkg/testutils/serverutils/api.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	gosql "database/sql"
 	"net/http"
+	"net/url"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/config"
@@ -184,6 +185,15 @@ type ApplicationLayerInterface interface {
 	// SQLConnE is like SQLConn, but it allows the test to check the error.
 	SQLConnE(opts ...SQLConnOption) (*gosql.DB, error)
 
+	// PGUrl returns a postgres connection URL for the server's SQL interface
+	// similar to the URL that SQLConn uses to open a SQL connection. The SQLConn
+	// method should be preferred and this method only should be used when the
+	// test needs to open a connection with special options, or in a specific way.
+	PGUrl(t TestFataler, opts ...SQLConnOption) (url.URL, func())
+
+	// PGUrlE is like PGUrl, but it allows the test to check the error.
+	PGUrlE(opts ...SQLConnOption) (url.URL, func(), error)
+
 	// DB returns a handle to the cluster's KV interface.
 	DB() *kv.DB
 
@@ -209,7 +219,7 @@ type ApplicationLayerInterface interface {
 	// HTTPAuthServer returns the authserver.Server as an interface{}.
 	HTTPAuthServer() interface{}
 
-	// HTTPserver returns the server.httpServer as an interface{}.
+	// HTTPServer returns the server.httpServer as an interface{}.
 	HTTPServer() interface{}
 
 	// SQLLoopbackListener returns the *netutil.LoopbackListener as an interface{}.

--- a/pkg/testutils/serverutils/options.go
+++ b/pkg/testutils/serverutils/options.go
@@ -18,9 +18,10 @@ import (
 
 // SQLConnOptions contains options for opening a SQL connection.
 type SQLConnOptions struct {
-	DBName      string
-	User        *url.Userinfo
-	ClientCerts bool
+	DBName         string
+	User           *url.Userinfo
+	ClientCerts    bool
+	CertsDirPrefix string
 }
 
 // SQLConnOption is an option for opening a SQL connection.
@@ -29,9 +30,10 @@ type SQLConnOption func(result *SQLConnOptions)
 // DefaultSQLConnOptions returns the default options for opening a SQL connection.
 func DefaultSQLConnOptions() *SQLConnOptions {
 	return &SQLConnOptions{
-		DBName:      "",
-		User:        url.User(username.RootUser),
-		ClientCerts: true,
+		DBName:         "",
+		User:           url.User(username.RootUser),
+		ClientCerts:    true,
+		CertsDirPrefix: "openTestSQLConn",
 	}
 }
 
@@ -64,5 +66,13 @@ func UserPassword(username, password string) SQLConnOption {
 func ClientCerts(clientCerts bool) SQLConnOption {
 	return func(result *SQLConnOptions) {
 		result.ClientCerts = clientCerts
+	}
+}
+
+// CertsDirPrefix sets the prefix for the directory where the client certificates
+// are stored.
+func CertsDirPrefix(certsDirPrefix string) SQLConnOption {
+	return func(result *SQLConnOptions) {
+		result.CertsDirPrefix = certsDirPrefix
 	}
 }

--- a/pkg/testutils/serverutils/test_server_shim.go
+++ b/pkg/testutils/serverutils/test_server_shim.go
@@ -37,6 +37,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/httputil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/errors"
 )
@@ -95,6 +96,8 @@ func ShouldStartDefaultTestTenant(
 	}
 
 	// Determine if the default test tenant should be run as a shared process.
+	// TODO(herko): We should add an environment variable override for this.
+	// See also: https://github.com/cockroachdb/cockroach/issues/113294
 	var shared bool
 	switch {
 	case baseArg.SharedProcessMode():
@@ -102,7 +105,9 @@ func ShouldStartDefaultTestTenant(
 	case baseArg.ExternalProcessMode():
 		shared = false
 	default:
-		shared = util.ConstantWithMetamorphicTestBoolWithoutLogging("test-tenant-shared-process", false)
+		// If no explicit process mode was selected, then randomly select one.
+		rng, _ := randutil.NewTestRand()
+		shared = rng.Intn(2) == 0
 	}
 
 	// Explicit case for enabling the default test tenant, but with a

--- a/pkg/util/tracing/tracer_external_test.go
+++ b/pkg/util/tracing/tracer_external_test.go
@@ -105,7 +105,9 @@ func TestTraceForTenantWithLocalKVServer(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
 
-	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{
+		DefaultTestTenant: base.TestControlsTenantsExplicitly,
+	})
 	defer s.Stopper().Stop(ctx)
 
 	server.RedactServerTracesForSecondaryTenants.Override(ctx, &s.SystemLayer().ClusterSettings().SV, false)


### PR DESCRIPTION
This PR contain several commits that ultimately enables the probabilistic selection of a shared process test virtual cluster that tests run against, iff the test also probabilistically decided to run with a test tenant. Previously only an external process virtual cluster would be available as an option when deciding to run with a test virtual cluster.

Additionally some API changes have been made to serverutils to encourage the use of the test interface layers when working with a test server or cluster. Tests that use other utility methods to connect or create connection URLs may not be aware of a test virtual cluster and lack required information when interacting with the cluster resulting in flakiness and failures.

Finally this change also disables selecting a shared process virtual cluster instead of an external process virtual cluster for tests which fail with a shared process virtual cluster. An issue has been created to track these tests: https://github.com/cockroachdb/cockroach/issues/112857
Issues linked to this issue will contain more detail relating to the failure. And the issue has been referenced in the code itself when disabling a shared process virtual cluster for a specific test.

Resolves: #111134
