### PR TITLE
c2c: deflake a few e2e tests

### DIFF
--- a/pkg/ccl/streamingccl/streamingest/alter_replication_job_test.go
+++ b/pkg/ccl/streamingccl/streamingest/alter_replication_job_test.go
@@ -114,7 +114,7 @@ func TestAlterTenantPauseResume(t *testing.T) {
 	cutoverOutput := replicationtestutils.DecimalTimeToHLC(t, cutoverStr)
 	require.Equal(t, cutoverTime, cutoverOutput.GoTime())
 	jobutils.WaitForJobToSucceed(c.T, c.DestSysSQL, jobspb.JobID(ingestionJobID))
-	cleanupTenant := c.StartDestTenant(ctx, nil)
+	cleanupTenant := c.StartDestTenant(ctx, nil, 0)
 	defer func() {
 		require.NoError(t, cleanupTenant())
 	}()

--- a/pkg/ccl/streamingccl/streamingest/datadriven_test.go
+++ b/pkg/ccl/streamingccl/streamingest/datadriven_test.go
@@ -155,7 +155,7 @@ func TestDataDriven(t *testing.T) {
 					jobspb.JobID(ds.ingestionJobID))
 			case "start-replicated-tenant":
 				testingKnobs := replicationtestutils.DefaultAppTenantTestingKnobs()
-				cleanupTenant := ds.replicationClusters.StartDestTenant(ctx, &testingKnobs)
+				cleanupTenant := ds.replicationClusters.StartDestTenant(ctx, &testingKnobs, 0)
 				ds.cleanupFns = append(ds.cleanupFns, cleanupTenant)
 			case "let":
 				if len(d.CmdArgs) == 0 {


### PR DESCRIPTION
This patch changes the TestTenantStreamingMultipleNodes and
TestTenantStreamingUnavailable tests to run on a single single host cluster,
instead of two, which should reduce cpu contention and flakes.

Informs https://github.com/cockroachdb/cockroach/issues/112748
Fixes https://github.com/cockroachdb/cockroach/issues/112783
Fixes https://github.com/cockroachdb/cockroach/issues/109185

Release note: none