### PR TITLE
storage: fix data race in MVCCPredicateDeleteRange

### DIFF
--- a/pkg/kv/kvserver/replica_rangefeed.go
+++ b/pkg/kv/kvserver/replica_rangefeed.go
@@ -714,7 +714,7 @@ func (r *Replica) handleLogicalOpLogRaftMuLocked(
 		}
 		if err != nil {
 			r.disconnectRangefeedWithErr(p, kvpb.NewErrorf(
-				"error consuming %T for key %v @ ts %v: %v", op, key, ts, err,
+				"error consuming %T for key %s @ ts %v: %v", op.GetValue(), roachpb.Key(key), ts, err,
 			))
 			return
 		}

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -3595,7 +3595,7 @@ func MVCCPredicateDeleteRange(
 
 	var runStart, runEnd roachpb.Key
 
-	buf := make([]roachpb.Key, rangeTombstoneThreshold)
+	buf := make([]roachpb.Key, 0, rangeTombstoneThreshold)
 
 	if ms == nil {
 		return nil, errors.AssertionFailedf(
@@ -3723,8 +3723,11 @@ func MVCCPredicateDeleteRange(
 			batchByteSize += runByteSize
 			batchSize += runSize
 		}
+
 		runSize = 0
 		runStart = roachpb.Key{}
+		runEnd = roachpb.Key{}
+		buf = buf[:0]
 		return nil
 	}
 
@@ -3815,10 +3818,11 @@ func MVCCPredicateDeleteRange(
 			if runSize < rangeTombstoneThreshold {
 				// Only buffer keys if there's a possibility of issuing point tombstones.
 				//
-				// To avoid unecessary memory allocation, overwrite the previous key at
-				// buffer's current position. No data corruption occurs because the
-				// buffer is flushed up to runSize.
-				buf[runSize] = append(buf[runSize][:0], runEnd...)
+				// TODO(ssd): It would be nice to avoid unnecessary allocations
+				// here. We copy the end key because when mvccInternalPut publishes
+				// the logical operation related to the delete, it currenty assumes
+				// that the key will not be subsequently modified.
+				buf = append(buf, runEnd.Clone())
 			}
 
 			runSize++

--- a/pkg/storage/mvcc_history_test.go
+++ b/pkg/storage/mvcc_history_test.go
@@ -71,7 +71,7 @@ var (
 //
 // The input files use the following DSL:
 //
-// run            [ok|trace|stats|error]
+// run            [ok|trace|stats|error|log-ops]
 //
 // txn_begin      t=<name> [ts=<int>[,<int>]] [globalUncertaintyLimit=<int>[,<int>]]
 // txn_remove     t=<name>
@@ -471,11 +471,13 @@ func TestMVCCHistories(t *testing.T) {
 				// Options:
 				// - trace: emit intermediate results after each operation.
 				// - stats: emit MVCC statistics for each operation and at the end.
+				// - log-ops: emit any MVCC Logical operations at the end.
 				// - error: expect an error to occur. The specific error type/ message
 				//   to expect is spelled out in the expected output.
 				//
 				trace := e.hasArg("trace")
 				stats := e.hasArg("stats")
+				logOps := e.hasArg("log-ops")
 				expectError := e.hasArg("error")
 
 				// buf will accumulate the actual output, which the
@@ -484,6 +486,9 @@ func TestMVCCHistories(t *testing.T) {
 				var buf redact.StringBuilder
 				e.results.buf = &buf
 				e.results.traceClearKey = trace
+
+				e.logOps = logOps
+				e.opLog = nil
 
 				// We reset the stats such that they accumulate for all commands
 				// in a single test.
@@ -548,6 +553,21 @@ func TestMVCCHistories(t *testing.T) {
 							} else {
 								buf.Printf("error reading locks: (%T:) %v\n", err, err)
 							}
+						}
+					}
+					if logOps {
+						prettyPrintOp := func(op enginepb.MVCCLogicalOp) string {
+							switch t := op.GetValue().(type) {
+							case *enginepb.MVCCWriteValueOp:
+								return fmt.Sprintf("write_value: key=%s, ts=%s", roachpb.Key(t.Key), t.Timestamp)
+							case *enginepb.MVCCDeleteRangeOp:
+								return fmt.Sprintf("delete_range: startKey=%s endKey=%s ts=%s", roachpb.Key(t.StartKey), roachpb.Key(t.EndKey), t.Timestamp)
+							default:
+								return fmt.Sprintf("%T", t)
+							}
+						}
+						for _, op := range e.opLog {
+							buf.Printf("logical op: %s\n", prettyPrintOp(op))
 						}
 					}
 				}
@@ -2378,6 +2398,9 @@ type evalCtx struct {
 	sstWriter         *storage.SSTWriter
 	sstFile           *storage.MemObject
 	ssts              [][]byte
+
+	logOps bool
+	opLog  []enginepb.MVCCLogicalOp
 }
 
 func newEvalCtx(ctx context.Context, engine storage.Engine) *evalCtx {
@@ -2532,10 +2555,29 @@ func (e *evalCtx) withReader(fn func(storage.Reader) error) error {
 	return fn(r)
 }
 
+type opLoggerWriter struct {
+	storage.ReadWriter
+
+	// TODO(ssd): I reused OpLoggerBatch here to avoid having two
+	// implementations of the operation handling. We can't use
+	// OpLoggerBatch directly because we don't always have a
+	// batch. We could modify OpLoggerBatch so it was usable in
+	// any case without a wrapper, but I didn't want to add
+	// conditionals or indirection into the production path just
+	// for testing.
+	logger *storage.OpLoggerBatch
+}
+
+func (ol *opLoggerWriter) LogLogicalOp(
+	op storage.MVCCLogicalOpType, details storage.MVCCLogicalOpDetails,
+) {
+	ol.logger.LogLogicalOpOnly(op, details)
+}
+
 // withWriter calls the given closure with a writer. The writer is
 // metamorphically chosen to be a batch, which will be committed and closed when
 // done.
-func (e *evalCtx) withWriter(cmd string, fn func(_ storage.ReadWriter) error) error {
+func (e *evalCtx) withWriter(cmd string, fn func(storage.ReadWriter) error) error {
 	var rw storage.ReadWriter
 	rw = e.engine
 	var batch storage.Batch
@@ -2544,7 +2586,17 @@ func (e *evalCtx) withWriter(cmd string, fn func(_ storage.ReadWriter) error) er
 		defer batch.Close()
 		rw = batch
 	}
+
+	opLogger := &storage.OpLoggerBatch{}
+	if e.logOps {
+		rw = &opLoggerWriter{
+			ReadWriter: rw,
+			logger:     opLogger,
+		}
+	}
+
 	rw = e.tryWrapForClearKeyPrinting(rw)
+
 	err := fn(rw)
 	if e.hasArg("batched") {
 		batchStatus := "non-empty"
@@ -2561,6 +2613,9 @@ func (e *evalCtx) withWriter(cmd string, fn func(_ storage.ReadWriter) error) er
 				return err
 			}
 		}
+	}
+	if e.logOps {
+		e.opLog = append(e.opLog, opLogger.LogicalOps()...)
 	}
 	return err
 }

--- a/pkg/storage/mvcc_logical_ops.go
+++ b/pkg/storage/mvcc_logical_ops.go
@@ -84,11 +84,11 @@ var _ Batch = &OpLoggerBatch{}
 
 // LogLogicalOp implements the Writer interface.
 func (ol *OpLoggerBatch) LogLogicalOp(op MVCCLogicalOpType, details MVCCLogicalOpDetails) {
-	ol.logLogicalOp(op, details)
+	ol.LogLogicalOpOnly(op, details)
 	ol.Batch.LogLogicalOp(op, details)
 }
 
-func (ol *OpLoggerBatch) logLogicalOp(op MVCCLogicalOpType, details MVCCLogicalOpDetails) {
+func (ol *OpLoggerBatch) LogLogicalOpOnly(op MVCCLogicalOpType, details MVCCLogicalOpDetails) {
 	if keys.IsLocal(details.Key) {
 		// Ignore mvcc operations on local keys.
 		if bytes.HasPrefix(details.Key, keys.LocalRangeLockTablePrefix) {

--- a/pkg/storage/testdata/mvcc_histories/delete_range_predicate
+++ b/pkg/storage/testdata/mvcc_histories/delete_range_predicate
@@ -47,7 +47,7 @@ meta: "i"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0
 data: "i"/7.000000000,0 -> /BYTES/i7
 
 # Writing next to or above point keys and tombstones should work.
-run stats ok
+run stats ok log-ops
 del_range_pred k=a end=i ts=5 startTime=3 rangeThreshold=2
 ----
 >> del_range_pred k=a end=i ts=5 startTime=3 rangeThreshold=2
@@ -68,6 +68,8 @@ data: "g"/2.000000000,0 -> /BYTES/g2
 data: "h"/4.000000000,0 -> /BYTES/h4
 meta: "i"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "i"/7.000000000,0 -> /BYTES/i7
+logical op: write_value: key="d", ts=5.000000000,0
+logical op: delete_range: startKey="f" endKey="h\x00" ts=5.000000000,0
 stats: key_count=8 key_bytes=160 val_count=12 val_bytes=111 range_key_count=2 range_key_bytes=27 range_val_count=2 live_count=3 live_bytes=111 gc_bytes_age=17863 intent_count=1 intent_bytes=19 lock_count=1 lock_age=93
 
 # Error on intent, no tombstones should be written. We try both the
@@ -228,7 +230,7 @@ stats: key_count=11 key_bytes=202 val_count=15 val_bytes=132 range_key_count=2 r
 
 # try the same call as above, except with startTime set to 1
 # check that delrange properly continues the run over a range tombstone
-run stats ok
+run stats ok log-ops
 del_range_pred k=j end=r ts=5 startTime=1 rangeThreshold=2
 ----
 >> del_range_pred k=j end=r ts=5 startTime=1 rangeThreshold=2
@@ -254,6 +256,7 @@ meta: "i"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0
 data: "i"/7.000000000,0 -> /BYTES/i7
 data: "j"/2.000000000,0 -> /BYTES/j2
 data: "q"/2.000000000,0 -> /BYTES/q2
+logical op: delete_range: startKey="j" endKey="q\x00" ts=5.000000000,0
 stats: key_count=11 key_bytes=202 val_count=15 val_bytes=132 range_key_count=4 range_key_bytes=63 range_val_count=5 live_count=4 live_bytes=132 gc_bytes_age=25269 intent_count=1 intent_bytes=19 lock_count=1 lock_age=93
 
 # check that we flush with a range tombstone, if maxBytes is exceeded

--- a/pkg/storage/testdata/mvcc_histories/delete_range_predicate_complex
+++ b/pkg/storage/testdata/mvcc_histories/delete_range_predicate_complex
@@ -117,7 +117,7 @@ data: "p"/6.000000000,0 -> /BYTES/p6
 stats: key_count=11 key_bytes=226 val_count=17 val_bytes=98 range_key_count=8 range_key_bytes=158 range_val_count=14 live_count=5 live_bytes=105 gc_bytes_age=36216
 
 # Delete the entire span, using both point and range tombstones.
-run stats ok
+run stats ok log-ops
 del_range_pred k=a end=z ts=10 startTime=0 rangeThreshold=10
 ----
 >> del_range_pred k=a end=z ts=10 startTime=0 rangeThreshold=10
@@ -153,6 +153,11 @@ data: "k"/10.000000000,0 -> /<empty>
 data: "k"/2.000000000,0 -> /BYTES/k2
 data: "p"/10.000000000,0 -> /<empty>
 data: "p"/6.000000000,0 -> /BYTES/p6
+logical op: write_value: key="f", ts=10.000000000,0
+logical op: write_value: key="h", ts=10.000000000,0
+logical op: write_value: key="i", ts=10.000000000,0
+logical op: write_value: key="k", ts=10.000000000,0
+logical op: write_value: key="p", ts=10.000000000,0
 stats: key_count=11 key_bytes=286 val_count=22 val_bytes=98 range_key_count=8 range_key_bytes=158 range_val_count=14 gc_bytes_age=51066
 
 run stats ok
@@ -255,6 +260,80 @@ data: "j"/2.000000000,0 -> /BYTES/j2
 data: "k"/2.000000000,0 -> /BYTES/k2
 data: "p"/6.000000000,0 -> /BYTES/p6
 stats: key_count=11 key_bytes=226 val_count=17 val_bytes=98 range_key_count=8 range_key_bytes=158 range_val_count=14 live_count=5 live_bytes=105 gc_bytes_age=36216
+
+run stats ok log-ops
+del_range_pred k=a end=z ts=7 startTime=3 rangeThreshold=1
+----
+>> del_range_pred k=a end=z ts=7 startTime=3 rangeThreshold=1
+stats: range_key_count=+4 range_key_bytes=+84 range_val_count=+7 live_count=-3 live_bytes=-63 gc_bytes_age=+13865
+>> at end:
+rangekey: {a-b}/[1.000000000,0=/<empty>]
+rangekey: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: f{-\x00}/[7.000000000,0=/<empty> 5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+rangekey: {f\x00-h}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+rangekey: {h-i}/[1.000000000,0=/<empty>]
+rangekey: i{-\x00}/[7.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {i\x00-k}/[1.000000000,0=/<empty>]
+rangekey: {l-n}/[5.000000000,0=/<empty>]
+rangekey: {n-o}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+rangekey: p{-\x00}/[7.000000000,0=/<empty>]
+data: "a"/4.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "b"/4.000000000,0 -> /<empty>
+data: "d"/4.000000000,0 -> /BYTES/d4
+data: "d"/2.000000000,0 -> /BYTES/d2
+data: "e"/3.000000000,0 -> /BYTES/e3
+data: "f"/6.000000000,0 -> /BYTES/f6
+data: "f"/4.000000000,0 -> /BYTES/f4
+data: "f"/2.000000000,0 -> /BYTES/f2
+data: "g"/4.000000000,0 -> /BYTES/g4
+data: "g"/2.000000000,0 -> /BYTES/g2
+data: "h"/3.000000000,0 -> /BYTES/h3
+data: "i"/5.000000000,0 -> /BYTES/i5
+data: "j"/6.000000000,0 -> /<empty>
+data: "j"/2.000000000,0 -> /BYTES/j2
+data: "k"/2.000000000,0 -> /BYTES/k2
+data: "p"/6.000000000,0 -> /BYTES/p6
+logical op: delete_range: startKey="f" endKey="f\x00" ts=7.000000000,0
+logical op: delete_range: startKey="i" endKey="i\x00" ts=7.000000000,0
+logical op: delete_range: startKey="p" endKey="p\x00" ts=7.000000000,0
+stats: key_count=11 key_bytes=226 val_count=17 val_bytes=98 range_key_count=12 range_key_bytes=242 range_val_count=21 live_count=2 live_bytes=42 gc_bytes_age=50081
+
+run stats ok
+clear_time_range k=a end=z ts=10 targetTs=6
+----
+>> clear_time_range k=a end=z ts=10 targetTs=6
+stats: range_key_count=-4 range_key_bytes=-84 range_val_count=-7 live_count=+3 live_bytes=+63 gc_bytes_age=-13865
+>> at end:
+rangekey: {a-b}/[1.000000000,0=/<empty>]
+rangekey: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {f-h}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+rangekey: {h-k}/[1.000000000,0=/<empty>]
+rangekey: {l-n}/[5.000000000,0=/<empty>]
+rangekey: {n-o}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+data: "a"/4.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "b"/4.000000000,0 -> /<empty>
+data: "d"/4.000000000,0 -> /BYTES/d4
+data: "d"/2.000000000,0 -> /BYTES/d2
+data: "e"/3.000000000,0 -> /BYTES/e3
+data: "f"/6.000000000,0 -> /BYTES/f6
+data: "f"/4.000000000,0 -> /BYTES/f4
+data: "f"/2.000000000,0 -> /BYTES/f2
+data: "g"/4.000000000,0 -> /BYTES/g4
+data: "g"/2.000000000,0 -> /BYTES/g2
+data: "h"/3.000000000,0 -> /BYTES/h3
+data: "i"/5.000000000,0 -> /BYTES/i5
+data: "j"/6.000000000,0 -> /<empty>
+data: "j"/2.000000000,0 -> /BYTES/j2
+data: "k"/2.000000000,0 -> /BYTES/k2
+data: "p"/6.000000000,0 -> /BYTES/p6
+stats: key_count=11 key_bytes=226 val_count=17 val_bytes=98 range_key_count=8 range_key_bytes=158 range_val_count=14 live_count=5 live_bytes=105 gc_bytes_age=36216
+
 
 # Range tombstone deletion of times (5-10].
 run stats ok


### PR DESCRIPTION
This fixes two bugs in MVCCPredicateDeleteRange that would result in incorrect logical operations being published to rangefeeds.

When publishing a logical operation, the caller indicates whether the buffers provide for the Key and EndKey of the operation are safe for concurrent use by setting a `Safe` boolean field in the published operation.

MVCCPredicateDeleteRange calls either MVCCDeleteRangeUsingTombstone or mvccPutInternal, both of which publish logical opts with Safe set to true.

Unfortunatelely, the code in MVCCPredicateDeleteRange _did_ invalidate the keys passed to these functions.

As a result, it was possible for rangefeeds to observe:

1. Range keys with incorrect bounds,
2. Missed pointed deletions events,
3. Unnecessarily duplicated point deletions, and
4. Point deletions that never occurred (but were part of range deletions).

Additionally, since we expect to be able to read the values for a logical operation back out of storage, rangefeeds may also encounter errors as they failed to read back the value for an erroneous events.

Fixes #112733

Epic: none

Release note(bug fix): Fix a bug that would result in incorrect physical replication results for users of the private preview physical replication feature.