### PR TITLE
kv: tolerate new goroutine wait reasons in TestConcurrencyManagerBasic

### DIFF
--- a/pkg/kv/kvserver/concurrency/concurrency_manager_test.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager_test.go
@@ -1317,6 +1317,7 @@ var goroutineStalledStates = map[string]bool{
 	"waiting":   true,
 	"dead":      false,
 	"copystack": false,
+	"preempted": false,
 	"???":       false, // catch-all in runtime.goroutineheader
 
 	// runtime.goroutineheader may override these G statuses with a waitReason.
@@ -1344,13 +1345,22 @@ var goroutineStalledStates = map[string]bool{
 	// runtime itself. No request-level synchronization points use mutexes to
 	// wait for state transitions by other requests, so it is safe to ignore
 	// this state and wait for it to exit.
-	"semacquire":             false,
-	"sleep":                  false,
-	"sync.Cond.Wait":         true,
-	"timer goroutine (idle)": false,
+	"semacquire":     false,
+	"sleep":          false,
+	"sync.Cond.Wait": true,
+	// Similar to "semaquire" above, we mark the following three mutex states as
+	// non-stalled, assuming that they are transient states.
+	"sync.Mutex.Lock":        false,
+	"sync.RWMutex.RLock":     false,
+	"sync.RWMutex.Lock":      false,
 	"trace reader (blocked)": false,
 	"wait for GC cycle":      false,
 	"GC worker (idle)":       false,
+	"GC worker (active)":     false,
+	// "preempted" is already included above as part of gStatusStrings.
+	"debug call":          false,
+	"GC mark termination": false,
+	"stopping the world":  false,
 }
 
 // goroutineStatus returns a stack trace for each goroutine whose stack frame

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -565,6 +565,8 @@ func TestLint(t *testing.T) {
 			":!util/syncutil/mutex_sync.go",
 			":!util/syncutil/mutex_sync_race.go",
 			":!testutils/lint/passes/deferunlockcheck/testdata/src/github.com/cockroachdb/cockroach/pkg/util/syncutil/mutex_sync.go",
+			// Exception needed for goroutineStalledStates.
+			":!kv/kvserver/concurrency/concurrency_manager_test.go",
 		)
 		if err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
Fixes #112257.

When we upgraded to Go 1.20, we picked up https://github.com/golang/go/commit/a2c396ce00df96f66246aab7a63f3ce5b7ad8753. This broke the goroutine stall monitor in `TestConcurrencyManagerBasic`, because the new goroutine states were not handled.

This commit fixes this by updating the `goroutineStalledStates` map. While here, we pick up a few other states that were added in the past few years but never caused issues. Like we saw in #112257, had those states ever been hit, the test would have failed.

Release note: None