### PR TITLE
release-23.2: sql: fix incorrectly stripping during fingerprinting

### DIFF
--- a/pkg/sql/show_fingerprints.go
+++ b/pkg/sql/show_fingerprints.go
@@ -197,8 +197,8 @@ func (n *showFingerprintsNode) nextTenant(params runParams) (bool, error) {
 	fingerprint, err := params.p.FingerprintSpan(params.ctx,
 		keys.MakeTenantSpan(tid),
 		hlc.Timestamp{},
-		false,
-		true)
+		false, /* allRevisions */
+		false /* stripped */)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
This change is a fix for an oversight that is in the `SHOW EXPERIMENTAL_FINGERPRINT` command that stripped away the index prefix and the timestamp before fingerprinting the keyspace. This was not intended to be set to true as we would like to default to fingerprinting the keys with their index prefixes and timestamps.

Epic: none
Release note: None
Release justification: low risk change to EXPERIMENTAL SQL syntax to fix an oversight. This oversight could result in a less complete fingerprint than we are capable of generating.