### PR TITLE
release-23.1: acceptance: skip TestDockerCLI/test_demo_multitenant

### DIFF
--- a/pkg/cli/interactive_tests/test_demo_multitenant.tcl.disabled
+++ b/pkg/cli/interactive_tests/test_demo_multitenant.tcl.disabled
@@ -2,7 +2,7 @@
 
 # This test is skipped -- its filename lets it hide from the selector in
 # TestDockerCLI. Unskip it by renaming after fixing
-# https://github.com/cockroachdb/cockroach/issues/96239.
+# https://github.com/cockroachdb/cockroach/issues/112745.
 
 source [file join [file dirname $argv0] common.tcl]
 


### PR DESCRIPTION
This test is flaky, failing to close engines before reopening them.

Epic: none
Informs #112745.
Informs #110855.
Release note: none.
Release justification: test-only changes