### PR TITLE
acceptance: fix flake in TestDockerCLI_test_exec_log

### DIFF
--- a/pkg/cli/interactive_tests/test_exec_log.tcl
+++ b/pkg/cli/interactive_tests/test_exec_log.tcl
@@ -104,16 +104,19 @@ send "SELECT 111;\r"
 eexpect 111
 eexpect root@
 
-flush_and_sync_logs $logfile "SELECT ..*111..*"
-
+# The regex here is finicky... CI can't handle matching against redaction marker literals, but .* is too broad
+# to match against and leads to false matches. Therefore, this regex matches against a literal `"SELECT `, followed
+# by a single character of any type to capture the opening and closing redaction markers `.\\{1\\}`, and then the
+# closing quotation mark. Similar concepts are used for the following grep assertions.
+flush_and_sync_logs $logfile "\"SELECT .\\{1\\}111.\\{1\\}\""
 
 # Two separate single-stmt txns.
-system "n=`grep 'SELECT ..*550..* +' $logfile | sed -e 's/.*TxnCounter.:\\(\[0-9\]*\\).*/\\1/g' | uniq | wc -l`; if test \$n -ne 2; then echo unexpected \$n; exit 1; fi"
+system "n=`grep '\"SELECT .\\{1\\}550.\\{1\\} +' $logfile | sed -e 's/.*TxnCounter.:\\(\[0-9\]*\\).*/\\1/g' | uniq | wc -l`; if test \$n -ne 2; then echo unexpected \$n; exit 1; fi"
 # Same txns.
-system "n=`grep 'SELECT ..*660..* +' $logfile | sed -e 's/.*TxnCounter.:\\(\[0-9\]*\\).*/\\1/g' | uniq | wc -l`; if test \$n -ne 1; then echo unexpected \$n; exit 1; fi"
-system "n=`grep 'SELECT ..*770..* +' $logfile | sed -e 's/.*TxnCounter.:\\(\[0-9\]*\\).*/\\1/g' | uniq | wc -l`; if test \$n -ne 1; then echo unexpected \$n; exit 1; fi"
-system "n=`grep 'SELECT ..*880..* +' $logfile | sed -e 's/.*TxnCounter.:\\(\[0-9\]*\\).*/\\1/g' | uniq | wc -l`; if test \$n -ne 1; then echo unexpected \$n; exit 1; fi"
-system "n=`grep 'SELECT ..*990..* +' $logfile | sed -e 's/.*TxnCounter.:\\(\[0-9\]*\\).*/\\1/g' | uniq | wc -l`; if test \$n -ne 1; then echo unexpected \$n; exit 1; fi"
+system "n=`grep '\"SELECT .\\{1\\}660.\\{1\\} +' $logfile | sed -e 's/.*TxnCounter.:\\(\[0-9\]*\\).*/\\1/g' | uniq | wc -l`; if test \$n -ne 1; then echo unexpected \$n; exit 1; fi"
+system "n=`grep '\"SELECT .\\{1\\}770.\\{1\\} +' $logfile | sed -e 's/.*TxnCounter.:\\(\[0-9\]*\\).*/\\1/g' | uniq | wc -l`; if test \$n -ne 1; then echo unexpected \$n; exit 1; fi"
+system "n=`grep '\"SELECT .\\{1\\}880.\\{1\\} +' $logfile | sed -e 's/.*TxnCounter.:\\(\[0-9\]*\\).*/\\1/g' | uniq | wc -l`; if test \$n -ne 1; then echo unexpected \$n; exit 1; fi"
+system "n=`grep '\"SELECT .\\{1\\}990.\\{1\\} +' $logfile | sed -e 's/.*TxnCounter.:\\(\[0-9\]*\\).*/\\1/g' | uniq | wc -l`; if test \$n -ne 1; then echo unexpected \$n; exit 1; fi"
 
 end_test
 


### PR DESCRIPTION
TestDockerCLI_test_exec_log tests for the existence of query exec logs to ensure that each statement is logged when the `sql.log.all_statements.enabled` cluster setting is enabled.

The test triggers a flush of logs first, to ensure the presence of the exec log statements in the log file before it makes assertions via grep. When the log is flushed, we wait until a specific log line appears, signaling the flush has completed, before making the assertions.

The text we were grep'ing for was unfortunately matching against text other than the query we were originally looking for (`SELECT 111`), which was causing flakes.

The fix is to make the grep regex more specific. This patch updates the regex used to determine the flush has completed, along with all the following grep regular expressions used to make additional assertions.

Fixes #112243

Release note: none