### PR TITLE
bazel: for RBE builds, download top-level outputs by default

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -125,7 +125,7 @@ build:engflowbase --experimental_remote_cache_compression=true
 build:engflowbase --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
 build:engflowbase --extra_execution_platforms=//build/toolchains:cross_linux
 build:engflowbase --remote_upload_local_results=false
-build:engflowbase --remote_download_minimal
+build:engflowbase --remote_download_toplevel
 test:engflowbase --test_env=REMOTE_EXEC=1
 build:engflow --config=engflowbase
 build:engflow --remote_cache=grpcs://tanzanite.cluster.engflow.com

--- a/build/teamcity/cockroach/nightlies/stress_engflow.sh
+++ b/build/teamcity/cockroach/nightlies/stress_engflow.sh
@@ -12,8 +12,8 @@ ENGFLOW_FLAGS="--config engflow --config cibase --config crosslinux \
 INVOCATION_ID=$(uuidgen)
 
 status=0
-bazel test //pkg:all_tests $ENGFLOW_FLAGS --runs_per_test 30 \
-      --verbose_failures --build_event_binary_file=artifacts/eventstream \
+bazel test //pkg:all_tests $ENGFLOW_FLAGS --remote_download_minimal \
+      --runs_per_test 30 --verbose_failures --build_event_binary_file=artifacts/eventstream \
       --profile=artifacts/profile.json.gz --invocation_id=$INVOCATION_ID \
     || status=$?
 


### PR DESCRIPTION
This can be set back to `--remote_download_minimal` if useful for certain builds.

Epic: CRDB-8308
Release note: None