### PR TITLE
packer: install `zip` on build agents

### DIFF
--- a/build/packer/teamcity-agent.sh
+++ b/build/packer/teamcity-agent.sh
@@ -55,7 +55,8 @@ apt-get install --yes \
   python2 \
   python3 \
   sudo \
-  unzip
+  unzip \
+  zip
 
 # Enable support for executing binaries of all architectures via qemu emulation
 # (necessary for building arm64 Docker images)


### PR DESCRIPTION
This is useful for capturing build artifacts on `no-remote-exec` tests.

Epic: CRDB-8308
Release note: None