### PR TITLE
kvserver: alter show range query for unsplittable range test 

### DIFF
--- a/pkg/kv/kvserver/replicate_queue_test.go
+++ b/pkg/kv/kvserver/replicate_queue_test.go
@@ -1877,7 +1877,7 @@ func TestLargeUnsplittableRangeReplicate(t *testing.T) {
 	testutils.SucceedsSoon(t, func() error {
 		forceProcess()
 		r := db.QueryRow(
-			"SELECT replicas FROM [SHOW RANGES FROM TABLE t] WHERE start_key LIKE '%TableMin%'")
+			"SELECT replicas FROM [SHOW RANGES FROM TABLE t] WHERE start_key NOT LIKE '%/2'")
 		var repl string
 		if err := r.Scan(&repl); err != nil {
 			return err


### PR DESCRIPTION
`TestLargeUnsplittableRangeReplicate` would fail when the SQL query to
show the table's replicas returned no results for the unsplittable range
being tested. The query to find the unsplittable range filtered on
`start_key LIKE '%TableMin%'`.

Update the show ranges query to specify the opposite of the smaller row
query, so that it is guaranteed to return the other range containing the
test table data, regardless of the `start_key`.

Resolves: https://github.com/cockroachdb/cockroach/issues/112774
Release note: None