### PR TITLE
roachtest: admission-control/intent-resolution assert on 20 sublevels

### DIFF
--- a/pkg/cmd/roachtest/tests/admission_control_intent_resolution.go
+++ b/pkg/cmd/roachtest/tests/admission_control_intent_resolution.go
@@ -124,10 +124,7 @@ func registerIntentResolutionOverload(r registry.Registry) {
 				}
 				// Loop for up to 20 minutes. Intents take ~10min to resolve, and
 				// we're padding by another 10min.
-				//
-				// TODO(sumeer): change subLevelThreshold to 20 after intent
-				// resolution is subject to admission control.
-				const subLevelThreshold = 100
+				const subLevelThreshold = 20
 				numErrors := 0
 				numSuccesses := 0
 				latestIntentCount := math.MaxInt


### PR DESCRIPTION
This patch addresses a lingering TODO to start asserting on 20 sublevels since https://github.com/cockroachdb/cockroach/pull/109932 has been merged.

Release note: None