### PR TITLE
sql: fix for crash with null elements on jsonb_array_to_string_array

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -337,7 +337,7 @@
 </span></td><td>Immutable</td></tr>
 <tr><td><a name="cardinality"></a><code>cardinality(input: anyelement[]) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Calculates the number of elements contained in <code>input</code></p>
 </span></td><td>Immutable</td></tr>
-<tr><td><a name="jsonb_array_to_string_array"></a><code>jsonb_array_to_string_array(input: jsonb) &rarr; <a href="string.html">string</a>[]</code></td><td><span class="funcdesc"><p>Convert a JSONB array into a string array.</p>
+<tr><td><a name="jsonb_array_to_string_array"></a><code>jsonb_array_to_string_array(input: jsonb) &rarr; <a href="string.html">string</a>[]</code></td><td><span class="funcdesc"><p>Convert a JSONB array into a string array, removing ‘null’ elements.</p>
 </span></td><td>Immutable</td></tr>
 <tr><td><a name="string_to_array"></a><code>string_to_array(str: <a href="string.html">string</a>, delimiter: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a>[]</code></td><td><span class="funcdesc"><p>Split a string into components on a delimiter.</p>
 </span></td><td>Immutable</td></tr>

--- a/pkg/sql/logictest/testdata/logic_test/array
+++ b/pkg/sql/logictest/testdata/logic_test/array
@@ -1215,6 +1215,26 @@ SELECT jsonb_array_to_string_array(j -> 'a') FROM str_arr ORDER BY j ASC
 query error input argument must be JSON array type
 SELECT jsonb_array_to_string_array(j -> 'b') FROM str_arr ORDER BY j ASC
 
+query T
+SELECT jsonb_array_to_string_array('[1, 2, 3]':::JSONB)
+----
+{1,2,3}
+
+query T
+SELECT jsonb_array_to_string_array('[true, false, false, true]':::JSONB)
+----
+{true,false,false,true}
+
+query T
+SELECT jsonb_array_to_string_array('[null]':::JSONB)
+----
+{}
+
+query T
+SELECT jsonb_array_to_string_array('["foo", null]':::JSONB)
+----
+{foo}
+
 # Regression test for #23429.
 
 statement ok

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -3566,14 +3566,16 @@ value if you rely on the HLC for accuracy.`,
 					if err != nil {
 						return nil, err
 					}
-					err = strArray.Append(tree.NewDString(*str))
-					if err != nil {
-						return nil, err
+					if str != nil {
+						err = strArray.Append(tree.NewDString(*str))
+						if err != nil {
+							return nil, err
+						}
 					}
 				}
 				return strArray, nil
 			},
-			Info:              "Convert a JSONB array into a string array.",
+			Info:              "Convert a JSONB array into a string array, removing 'null' elements.",
 			Volatility:        volatility.Immutable,
 			CalledOnNullInput: true,
 		}),


### PR DESCRIPTION
Fixes #112829

The builtin `jsonb_array_to_string_array` was crashing, when it had `null` elements. This commit handles this case, removing them from the final array.

Release note: None