### PR TITLE
builtins: return expected error for null arguments to PLpgSQL builtins

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/plpgsql_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/plpgsql_builtins
@@ -627,3 +627,30 @@ DECLARE foo CURSOR FOR SELECT * FROM xy ORDER BY x DESC;
 
 statement error pgcode 22023 pq: invalid fetch/move direction: 10
 SELECT crdb_internal.plpgsql_fetch('foo', 10, 0, (NULL::INT, NULL::INT));
+
+statement ok
+ABORT;
+
+# Regression test for 112895. The plpgsql_close and plpgsql_fetch builtin
+# functions should return an expected error for NULL arguments.
+subtest null_error
+
+statement error pgcode 22004 pq: FETCH statement option cannot be null
+SELECT crdb_internal.plpgsql_fetch(NULL, 0, 1, (NULL::INT, NULL::INT));
+
+statement error pgcode 22004 pq: FETCH statement option cannot be null
+SELECT crdb_internal.plpgsql_fetch('foo', NULL, 1, (NULL::INT, NULL::INT));
+
+statement error pgcode 22004 pq: FETCH statement option cannot be null
+SELECT crdb_internal.plpgsql_fetch('foo', 0, NULL, (NULL::INT, NULL::INT));
+
+statement error pgcode 22004 pq: FETCH statement option cannot be null
+SELECT crdb_internal.plpgsql_fetch('foo', 0, 1, NULL);
+
+statement error pgcode 22004 pq: FETCH statement option cannot be null
+SELECT crdb_internal.plpgsql_fetch(NULL, NULL, NULL, NULL);
+
+statement error pgcode 22004 pq: cursor name for CLOSE statement cannot be null
+SELECT crdb_internal.plpgsql_close(NULL);
+
+subtest end

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -8553,7 +8553,9 @@ specified store on the node it's run from. One of 'mvccGC', 'merge', 'split',
 			ReturnType: tree.FixedReturnType(types.Int),
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				if args[0] == tree.DNull {
-					return nil, errors.AssertionFailedf("expected non-null argument for plpgsql_close")
+					return nil, pgerror.New(
+						pgcode.NullValueNotAllowed, "cursor name for CLOSE statement cannot be null",
+					)
 				}
 				return tree.DNull, evalCtx.Planner.PLpgSQLCloseCursor(tree.Name(tree.MustBeDString(args[0])))
 			},
@@ -8575,6 +8577,13 @@ specified store on the node it's run from. One of 'mvccGC', 'merge', 'split',
 			},
 			ReturnType: tree.IdentityReturnType(3),
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				for i := range args {
+					if args[i] == tree.DNull {
+						return nil, pgerror.New(
+							pgcode.NullValueNotAllowed, "FETCH statement option cannot be null",
+						)
+					}
+				}
 				cursorName := tree.MustBeDString(args[0])
 				cursorDir := tree.MustBeDInt(args[1])
 				cursorCount := tree.MustBeDInt(args[2])


### PR DESCRIPTION
This patch adds checks for NULL arguments to the `crdb_internal.plpgsql_close` and `crdb_internal.plpgsql_fetch` builtin functions so that they will now return an expected error, rather than an assertion failure.

Fixes #112895

Release note: None