### PR TITLE
stats: harden stats collection code a bit

### DIFF
--- a/pkg/sql/rowenc/encoded_datum.go
+++ b/pkg/sql/rowenc/encoded_datum.go
@@ -422,7 +422,8 @@ type EncDatumRow []EncDatum
 
 func (r EncDatumRow) stringToBuf(types []*types.T, a *tree.DatumAlloc, b *bytes.Buffer) {
 	if len(types) != len(r) {
-		panic(errors.AssertionFailedf("mismatched types (%v) and row (%v)", types, r))
+		b.WriteString(fmt.Sprintf("mismatched types (%v) and row (%v)", types, r))
+		return
 	}
 	b.WriteString("[")
 	for i := range r {

--- a/pkg/sql/rowexec/sampler.go
+++ b/pkg/sql/rowexec/sampler.go
@@ -514,6 +514,9 @@ func (s *sketchInfo) addRow(
 	var useFastPath bool
 	if len(s.spec.Columns) == 1 {
 		col = s.spec.Columns[0]
+		if row[col].IsUnset() {
+			return errors.AssertionFailedf("unset datum: col=%d row=%s", col, row.String(typs))
+		}
 		isNull := row[col].IsNull()
 		useFastPath = typs[col].Family() == types.IntFamily && !isNull
 	}
@@ -557,7 +560,12 @@ func (s *sketchInfo) addRow(
 		if err != nil {
 			return err
 		}
-		isNull = isNull && row[col].IsNull()
+		if isNull {
+			if row[col].IsUnset() {
+				return errors.AssertionFailedf("unset datum: col=%d row=%s", col, row.String(typs))
+			}
+			isNull = row[col].IsNull()
+		}
 		s.size += int64(row[col].DiskSize())
 	}
 	if isNull {

--- a/pkg/sql/stats/row_sampling.go
+++ b/pkg/sql/stats/row_sampling.go
@@ -226,13 +226,13 @@ func (sr *SampleReservoir) GetNonNullDatums(
 		}
 		values = make(tree.Datums, 0, len(sr.samples))
 		for _, sample := range sr.samples {
-			ed := &sample.Row[colIdx]
-			if ed.Datum == nil {
+			d := sample.Row[colIdx].Datum
+			if d == nil {
 				values = nil
 				return errors.AssertionFailedf("value in column %d not decoded", colIdx)
 			}
-			if !ed.IsNull() {
-				values = append(values, ed.Datum)
+			if d != tree.DNull {
+				values = append(values, d)
 			}
 		}
 		return nil


### PR DESCRIPTION
This commit audits `EncDatum.IsNull` calls in the stats collection code to prevent the process crash in case `EncDatum` is in "unset" state (`IsNull` panics in such a scenario). We've seen this issue once in a customer environment, but it's unclear how we got there, still we don't want the process crash. In two places we will now return an assertion failed error with some information about the row and in a third place we don't actually need to call `IsNull`. There is no regression test since we don't know how this panic can occur. If a cluster is affected, then stats collection will always be retrying, but I hope that the "corrupted" row info will help in understanding the root cause.

Addresses: https://github.com/cockroachlabs/support/issues/2650.
Touches: #112072.
Epic: None

Release note: None