### PR TITLE
streamingccl: use correct bounds for range key SSTs

### DIFF
--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor.go
@@ -920,7 +920,9 @@ func (r *rangeKeyBatcher) flush(ctx context.Context, toFlush mvccRangeKeyValues)
 	sstToFlush := &rangeKeySST{
 		data:  sstFile.Bytes(),
 		start: start,
-		end:   end.Next(),
+		// NB: End is set from the range key EndKey, which is
+		// already exclusive.
+		end: end,
 	}
 
 	work := []*rangeKeySST{sstToFlush}
@@ -956,7 +958,16 @@ func (r *rangeKeyBatcher) flush(ctx context.Context, toFlush mvccRangeKeyValues)
 				if err != nil {
 					return err
 				}
-				work = append([]*rangeKeySST{left, right}, work...)
+
+				if left != nil && right != nil {
+					work = append([]*rangeKeySST{left, right}, work...)
+				} else if left != nil {
+					log.Warningf(ctx, "RHS of split point %s was unexpectedly empty", split)
+					work = append([]*rangeKeySST{left}, work...)
+				} else if right != nil {
+					log.Warningf(ctx, "LHS of split point %s was unexpectedly empty", split)
+					work = append([]*rangeKeySST{right}, work...)
+				}
 			} else {
 				return err
 			}
@@ -985,6 +996,17 @@ func (r *rangeKeyBatcher) flush(ctx context.Context, toFlush mvccRangeKeyValues)
 func splitRangeKeySSTAtKey(
 	ctx context.Context, st *cluster.Settings, start, end, splitKey roachpb.Key, data []byte,
 ) (*rangeKeySST, *rangeKeySST, error) {
+	// Special case: The split key less than the start key.
+	if splitKey.Compare(start) < 0 {
+		return nil, &rangeKeySST{start: start, end: end, data: data}, nil
+	}
+
+	// Special case: The split key is greater or equal to the
+	// exclusive end key.
+	if end.Compare(splitKey) <= 0 {
+		return &rangeKeySST{start: start, end: end, data: data}, nil, nil
+	}
+
 	var (
 		// left and right are our output SSTs.
 		// Data less than the split key is written into left.
@@ -1024,6 +1046,10 @@ func splitRangeKeySSTAtKey(
 		if err := writer.Finish(); err != nil {
 			return err
 		}
+		if first == nil || last == nil {
+			return errors.AssertionFailedf("likely prorgramming error: invalid SST bounds on RHS [%v, %v)", first, last)
+		}
+
 		leftRet = &rangeKeySST{start: first, end: last, data: left.Data()}
 		writer = rightWriter
 		last = nil
@@ -1118,11 +1144,19 @@ func splitRangeKeySSTAtKey(
 		iter.Next()
 	}
 
+	if !reachedSplit {
+		return nil, nil, errors.AssertionFailedf("likely programming error: split point %s not found in SST", splitKey)
+	}
+
 	if err := writer.Finish(); err != nil {
 		return nil, nil, err
 	}
-	rightRet = &rangeKeySST{start: first, end: last, data: right.Data()}
 
+	if first == nil || last == nil {
+		return nil, nil, errors.AssertionFailedf("likely prorgramming error: invalid SST bounds on RHS [%v, %v)", first, last)
+	}
+
+	rightRet = &rangeKeySST{start: first, end: last, data: right.Data()}
 	return leftRet, rightRet, nil
 }
 


### PR DESCRIPTION
Previously, we were erroneously calling Next() on the end key of our SST even though the end key already represented an exclusive bounds.

This Next() meant that the bounds of our SSTs were slightly incorrect. In most cases, this was harmless, but in the case of a range boundary that aligned directly with the _actual_ bounds of the SST, it could result in us attempting to split an SST into 2 with the RHS ending up empty.

Here, we fix that and also make our SST splitting a bit more robust to bad input. It now errors if the LHS or RHS ends up empty despite a split key inside the given bounds. It also handles split keys outside of the bounds. Neither of these things should happen unless our contract with other parts of the system changes.

Fixes #112846

Release note (bug fix): Fix a bug that could prevent phyiscal replication from advancing in the face of some range deletion operations.