### PR TITLE
roachtest: properly escape `'` in TeamCity service messages

### DIFF
--- a/pkg/cmd/roachtest/test_impl.go
+++ b/pkg/cmd/roachtest/test_impl.go
@@ -487,6 +487,8 @@ func TeamCityEscape(s string) string {
 			sb.WriteString("|[")
 		case ']':
 			sb.WriteString("|]")
+		case '\'':
+			sb.WriteString("|'")
 		default:
 			if runeValue > 127 {
 				// escape unicode

--- a/pkg/cmd/roachtest/test_impl_test.go
+++ b/pkg/cmd/roachtest/test_impl_test.go
@@ -30,7 +30,12 @@ func TestTeamCityEscape(t *testing.T) {
 	require.Equal(t, "Connection to 104.196.113.229 port 22: Broken pipe|r|nlost connection: exit status 1",
 		TeamCityEscape("Connection to 104.196.113.229 port 22: Broken pipe\r\nlost connection: exit status 1"))
 
-	//Unicode
+	require.Equal(t,
+		"Messages:   	current binary |'24.1|' not found in |'versionToMinSupportedVersion|'",
+		TeamCityEscape("Messages:   	current binary '24.1' not found in 'versionToMinSupportedVersion'"),
+	)
+
+	// Unicode
 	require.Equal(t, "|0x00bf", TeamCityEscape("\u00bf"))
 	require.Equal(t, "|0x00bfaaa", TeamCityEscape("\u00bfaaa"))
 	require.Equal(t, "bb|0x00bfaaa", TeamCityEscape("bb\u00bfaaa"))


### PR DESCRIPTION
This commit adds proper escaping for the `'` character in TeamCity service messages emitted by roachtest. Previously, if a test failed with an error message that included `'`, the service message would fail to be parsed by TeamCity, and the test failure would go unnoticed.

`multitenant-upgrade` has been failing for the last couple of nights silently for this reason. This commit includes a test case with the error that is currently produced by that test.

Epic: none

Release note: None