### PR TITLE
release-23.1: sql: drop index can be incorrectly blocked for a TA

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/drop_index
+++ b/pkg/sql/logictest/testdata/logic_test/drop_index
@@ -479,6 +479,109 @@ statement ok
 CREATE TABLE t_with_idx_data_loss (n INT8 PRIMARY KEY, j INT8);
 CREATE INDEX ON t_with_idx_data_loss(n) STORING (j);
 
+# Prior versions of Cockroach allowed creating indexes storing
+# the PK columns. We can't do this on later versions so use surgery
+# to get that state.
+statement ok
+CREATE INDEX t_with_safe_idx_112858 ON t_with_idx_data_loss(j)
+
+# Modify the index descriptor to make the PK columns as storing.
+statement ok
+WITH
+	to_json
+		AS (
+			SELECT
+				id,
+				crdb_internal.pb_to_json(
+					'cockroach.sql.sqlbase.Descriptor',
+					descriptor,
+					false
+				)
+					AS d
+			FROM
+				system.descriptor
+			WHERE
+				id IN ('t_with_idx_data_loss'::regclass::oid::int,)
+		),
+	modified
+		AS (
+			SELECT
+				id,
+				json_set(
+					json_set(
+					  json_set(
+              json_set(
+                 json_remove_path(
+                    json_remove_path(
+                      d,
+                      ARRAY[
+                        'table',
+                        'indexes',
+                        '1',
+                        'keySuffixColumnNames'
+                      ]
+                    ),
+                    ARRAY[
+                      'table',
+                      'indexes',
+                      '1',
+                      'keySuffixColumnIds'
+                    ]
+                 ),
+                 ARRAY[
+                      'table',
+                      'indexes',
+                      '1',
+                      'storeColumnIds'
+                    ],
+                    '[1]'
+               ),
+               ARRAY[
+                     'table',
+                     'indexes',
+                     '1',
+                     'storeColumnNames'
+                   ],
+                   '["n"]'
+						),
+						ARRAY['table', 'version'],
+						(
+							(d->'table'->>'version')::INT8
+							+ 1
+						)::STRING::JSONB
+					),
+					ARRAY['table', 'modificationTime'],
+					json_build_object(
+						'wallTime',
+						(
+							(
+								extract('epoch', now())
+								* 1000000
+							)::INT8
+							* 1000
+						)::STRING
+					)
+				)
+					AS d
+			FROM
+				to_json
+		)
+SELECT
+	crdb_internal.unsafe_upsert_descriptor(
+		id,
+		crdb_internal.json_to_pb(
+			'cockroach.sql.sqlbase.Descriptor',
+			d
+		),
+		false
+	)
+FROM
+	modified;
+
+# DROP INDEX with storing columns being key columns will be allowed.
+statement ok
+DROP INDEX t_with_idx_data_loss@t_with_safe_idx_112858;
+
 # Corrupt the primary index to stop storing j, so the only source is storing
 # is a secondary index.
 statement ok
@@ -553,7 +656,7 @@ SELECT
 FROM
 	modified;
 
-# Drop INDEX will be blocked
+# DROP INDEX will be blocked
 statement error pq: index t_with_idx_data_loss_n_idx cannot be safely dropped, since doing so will lose data in certain columns
 DROP INDEX t_with_idx_data_loss@t_with_idx_data_loss_n_idx;
 


### PR DESCRIPTION
Previously, we added a warning during DROP INDEX to prevent dropping secondary indexes that could lead to data loss because of a technical advisory (a99561). Unfortunately, this logic in the legacy schema changer was inaccurate since older releases allowed primary key columns as stored columns. To address this, this patch will add the primary key columns into the set of stored columns when validating if the stored columns for a secondary index are stored somewhere.

Note: The declarative schema changer handled this case correctly because of its more straightforward logic.

Fixes: #112858

Release note (bug fix): A warning for technical advisory 99561 could
incorrectly surface when dropping secondary indexes that store primary
key columns.

Release justification: This change fixes a low-risk bug that prevents users from being unable to drop secondary indexes where the stored columns overlap with the PK columns of a table. The change overall is low risk and fixes incorrect detection for a TA scenario.