### PR TITLE
release-23.1: testutils: advance 22.2 to 22.2.15

### DIFF
--- a/pkg/testutils/release/cockroach_releases.yaml
+++ b/pkg/testutils/release/cockroach_releases.yaml
@@ -8,7 +8,7 @@
   - 22.1.19
   predecessor: "21.2"
 "22.2":
-  latest: 22.2.14
+  latest: 22.2.15
   withdrawn:
   - 22.2.4
   - 22.2.8


### PR DESCRIPTION
Release note: None
Epic: None
Release Justification: release-process test-infra-only change