### PR TITLE
tenantcostserver: update token bucket debt algorithm

### DIFF
--- a/pkg/ccl/multitenantccl/tenantcostserver/tenanttokenbucket/BUILD.bazel
+++ b/pkg/ccl/multitenantccl/tenantcostserver/tenanttokenbucket/BUILD.bazel
@@ -21,6 +21,7 @@ go_test(
     tags = ["ccl_test"],
     deps = [
         "//pkg/kv/kvpb",
+        "//pkg/roachpb",
         "//pkg/testutils/datapathutils",
         "//pkg/util/leaktest",
         "@com_github_cockroachdb_datadriven//:datadriven",

--- a/pkg/ccl/multitenantccl/tenantcostserver/tenanttokenbucket/tenant_token_bucket.go
+++ b/pkg/ccl/multitenantccl/tenantcostserver/tenanttokenbucket/tenant_token_bucket.go
@@ -21,10 +21,20 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
+// movingAvgFactor is the weight applied to a new "sample" of the current number
+// of RUs in the bucket (with one sample per Request call).
+const movingAvgFactor = 0.25
+
+// debtLimitMultiple is a multiple of the default debt limit (number of tokens
+// refilled in target period). This is used to allow grants that temporarily
+// exceed the default debt limit in the case where multiple tenant instances are
+// competing and RUCurrentAvg has not yet stabilized at a level that provides
+// the right grant size to each of them.
+const debtLimitMultiple = 1.5
+
 // State of the distributed token bucket.
 type State struct {
 	// RUBurstLimit is the burst limit in RUs.
-	// TODO(radu): this is ignored for now.
 	RUBurstLimit float64
 
 	// RURefillRate is the refill rate in RUs/second.
@@ -33,9 +43,13 @@ type State struct {
 	// RUCurrent is the available (burst) RUs.
 	RUCurrent float64
 
-	// CurrentShareSum is the sum of the last reported share value for
-	// each active SQL pod for the tenant.
-	CurrentShareSum float64
+	// RUCurrentAvg is the average number of (burst) RUs in the bucket when
+	// requests arrive. This is used to smooth out the size of trickle grants
+	// made to competing tenant instances.
+	// NOTE: This field is serialized as the current_share_sum column in the
+	// system.tenant_usage table. That column is unused and reusing it avoids
+	// a system table schema change.
+	RUCurrentAvg float64
 }
 
 // fallbackRateTimeFrame is a time frame used to calculate a fallback rate.
@@ -52,6 +66,7 @@ func (s *State) Update(since time.Duration) {
 	if since > 0 {
 		s.RUCurrent += s.RURefillRate * since.Seconds()
 	}
+	s.clampToLimit()
 }
 
 // Request processes a request for more tokens and updates the State
@@ -61,17 +76,27 @@ func (s *State) Request(
 ) kvpb.TokenBucketResponse {
 	var res kvpb.TokenBucketResponse
 
+	// Compute the exponential moving average (EMA) of the number of RUs in the
+	// bucket when Request is called.
+	s.RUCurrentAvg = movingAvgFactor*s.RUCurrent + (1-movingAvgFactor)*s.RUCurrentAvg
+
 	// Calculate the fallback rate.
 	res.FallbackRate = s.RURefillRate
 	if s.RUCurrent > 0 {
 		res.FallbackRate += s.RUCurrent / fallbackRateTimeFrame.Seconds()
 	}
 	if log.V(1) {
-		log.Infof(ctx, "token bucket request (tenant=%d requested=%g current=%g)", req.TenantID, req.RequestedRU, s.RUCurrent)
+		log.Infof(ctx, "token bucket request (tenant=%d requested=%g current=%g, avg=%g)",
+			req.TenantID, req.RequestedRU, s.RUCurrent, s.RUCurrentAvg)
 	}
 
 	needed := req.RequestedRU
+	if needed > s.RUCurrent && s.RURefillRate == 0 {
+		// No way to refill tokens, so don't allow taking on debt.
+		needed = s.RUCurrent
+	}
 	if needed <= 0 {
+		// Grant zero tokens.
 		return res
 	}
 
@@ -84,46 +109,62 @@ func (s *State) Request(
 		return res
 	}
 
-	var grantedTokens float64
+	var granted float64
 
+	// There are not enough tokens in the bucket, so take on debt and return a
+	// trickle grant that needs to be consumed over the target request period.
 	if s.RUCurrent > 0 {
-		grantedTokens = s.RUCurrent
+		// Consume remaining available tokens.
+		granted = s.RUCurrent
 		needed -= s.RUCurrent
 	}
 
-	availableRate := s.RURefillRate
+	// The trickle grant algorithm tries to ensure that the rate of token grants
+	// does not exceed the token bucket refill rate. This is challenging when
+	// there are multiple tenant instances requesting tokens at constantly
+	// shifting intervals and rates. The solution is to ensure a *statistical*
+	// guarantee rather than a *hard* guarantee. Over time, the *average* rate of
+	// token consumption should not exceed the token bucket refill rate, even if
+	// at any given time, it may temporarily exceed it.
+	//
+	// The way this is accomplished is quite simple. We track the average number
+	// of request units that are present in the bucket when Request is called
+	// (RUCurrentAvg). This is typically a negative number, as the bucket will be
+	// in debt when trickle grants are made. The grant increases the average debt
+	// to the maximum allowed level - the number of tokens that would refill the
+	// bucket during the target request period.
+	//
+	// As an example, say that RUCurrentAvg starts at 0 and the refill rate is
+	// 1000 RU/s. Tenant instance #1 requests 1000 RU/s with a target request
+	// period of 10 seconds. It is granted the entire 1000 RU/s rate with a 10-
+	// second trickle. Four seconds later, instance #2 also requests 1000 RU/s.
+	// The bucket has -6000 RUs available, and RUCurrentAvg is updated to the
+	// EMA of -6000 * 0.2 = -1200. Instance #2 is therefore granted 880 RU/s.
+	// This temporarily exceeds the token bucket refill rate. However, over time
+	// the EMA will converge towards -5000 and each instance will get 500 RU/s.
+	refill := req.TargetRequestPeriod.Seconds() * s.RURefillRate
+	available := refill
+
+	if debtAvg := -s.RUCurrentAvg; debtAvg > 0 {
+		// Clamp available RUs to average.
+		available -= debtAvg
+	}
+
 	if debt := -s.RUCurrent; debt > 0 {
-		// We pre-distribute tokens over the next TargetRefillPeriod; any debt over
-		// that is a systematic error we need to account for.
-		debt -= req.TargetRequestPeriod.Seconds() * s.RURefillRate
-		if debt > 0 {
-			// Say that we want to pay the debt over the next RefillPeriod (but use at
-			// most 95% of the rate for the debt).
-			// TODO(radu): make this configurable?
-			debtRate := debt / req.TargetRequestPeriod.Seconds()
-			availableRate -= debtRate
-			availableRate = math.Max(availableRate, 0.05*s.RURefillRate)
-		}
+		// Don't allow debt to exceed max limit.
+		available = math.Min(available, refill*debtLimitMultiple-debt)
 	}
-	// TODO(radu): support multiple instances by giving out only a share of the rate.
-	// Without this, all instances will get roughly equal rates even if they have
-	// different levels of load (in addition, we are heavily relying on the debt
-	// mechanism above).
-	allowedRate := availableRate
-	duration := time.Duration(float64(time.Second) * (needed / allowedRate))
-	if duration <= req.TargetRequestPeriod {
-		grantedTokens += needed
-	} else {
-		// We don't want to plan ahead for more than the target period; give out
-		// fewer tokens.
-		duration = req.TargetRequestPeriod
-		grantedTokens += allowedRate * duration.Seconds()
-	}
-	s.RUCurrent -= grantedTokens
-	res.GrantedRU = grantedTokens
-	res.TrickleDuration = duration
+
+	needed = math.Min(needed, math.Max(available, 0))
+
+	// Compute the grant and adjust the current RU balance.
+	granted += needed
+	s.RUCurrent -= granted
+	res.GrantedRU = granted
+	res.TrickleDuration = req.TargetRequestPeriod
 	if log.V(1) {
-		log.Infof(ctx, "request granted over time (tenant=%d granted=%g trickle=%s)", req.TenantID, res.GrantedRU, res.TrickleDuration)
+		log.Infof(ctx, "request granted over time (tenant=%d granted=%g trickle=%s)",
+			req.TenantID, res.GrantedRU, res.TrickleDuration)
 	}
 	return res
 }
@@ -133,10 +174,11 @@ func (s *State) Request(
 // Arguments:
 //
 //   - availableRU is the amount of Request Units that the tenant can consume at
-//     will. Also known as "burst RUs".
+//     will. Also known as "burst RUs". If this is -1 (or any negative number),
+//     the bucket's available tokens are not updated.
 //
 //   - refillRate is the amount of Request Units per second that the tenant
-//     receives.
+//     receives. If this is 0, the bucket does not refill on its own.
 //
 //   - maxBurstRU is the maximum amount of Request Units that can be accumulated
 //     from the refill rate, or 0 if there is no limit.
@@ -166,11 +208,21 @@ func (s *State) Reconfigure(
 ) {
 	// TODO(radu): adjust available RUs according to asOf and asOfConsumedUnits
 	// and add tests.
-	s.RUCurrent = availableRU
+	if availableRU >= 0 {
+		s.RUCurrent = availableRU
+	}
 	s.RURefillRate = refillRate
 	s.RUBurstLimit = maxBurstRU
+	s.clampToLimit()
 	log.Infof(
 		ctx, "token bucket for tenant %s reconfigured: available=%g refill-rate=%g burst-limit=%g",
 		tenantID.String(), s.RUCurrent, s.RURefillRate, s.RUBurstLimit,
 	)
+}
+
+// clampToLimit limits current RUs in the bucket to the burst limit.
+func (s *State) clampToLimit() {
+	if s.RUBurstLimit > 0 && s.RUCurrent > s.RUBurstLimit {
+		s.RUCurrent = s.RUBurstLimit
+	}
 }

--- a/pkg/ccl/multitenantccl/tenantcostserver/tenanttokenbucket/testdata/fallback
+++ b/pkg/ccl/multitenantccl/tenantcostserver/tenanttokenbucket/testdata/fallback
@@ -1,25 +1,36 @@
 # Tests for the fallback rate.
 
-init
+reconfigure
+limit: 1000
 rate: 1000
-initial: 0
+current: 0
 ----
+Burst Limit: 1000
+Refill Rate: 1000
 Current RUs: 0
+Average RUs: 0
 
 # Fallback rate should be just the base rate 1000.
 request
 ru: 10
 ----
 Granted: 10 RU
-Trickle duration: 10ms
+Trickle duration: 10s
 Fallback rate: 1000 RU/s
+Burst Limit: 1000
+Refill Rate: 1000
 Current RUs: -10
+Average RUs: 0
 
-init
+reconfigure
+limit: 5000000
 rate: 500
-initial: 3600000
+current: 3600000
 ----
+Burst Limit: 5000000
+Refill Rate: 500
 Current RUs: 3600000
+Average RUs: 0
 
 # Fallback rate should be the base rate 500 plus 1000.
 request
@@ -28,4 +39,7 @@ ru: 10
 Granted: 10 RU
 Trickle duration: 0s
 Fallback rate: 1500 RU/s
+Burst Limit: 5000000
+Refill Rate: 500
 Current RUs: 3599990
+Average RUs: 900000

--- a/pkg/ccl/multitenantccl/tenantcostserver/tenanttokenbucket/testdata/reconfigure
+++ b/pkg/ccl/multitenantccl/tenantcostserver/tenanttokenbucket/testdata/reconfigure
@@ -1,0 +1,103 @@
+# Try to reconfigure with limit = 50 and current > limit.
+reconfigure
+limit: 50
+rate: 100
+current: 100
+----
+Burst Limit: 50
+Refill Rate: 100
+Current RUs: 50
+Average RUs: 0
+
+# Ensure that update respects the limit.
+update
+10s
+----
+Burst Limit: 50
+Refill Rate: 100
+Current RUs: 50
+Average RUs: 0
+
+# Request tokens and go into debt.
+request
+ru: 100
+----
+Granted: 100 RU
+Trickle duration: 10s
+Fallback rate: 100.0138889 RU/s
+Burst Limit: 50
+Refill Rate: 100
+Current RUs: -50
+Average RUs: 12.5
+
+request
+ru: 100
+----
+Granted: 100 RU
+Trickle duration: 10s
+Fallback rate: 100 RU/s
+Burst Limit: 50
+Refill Rate: 100
+Current RUs: -150
+Average RUs: -3.125
+
+# Update limit, but don't update current RUs.
+reconfigure
+limit: 100
+rate: 100
+current: -1
+----
+Burst Limit: 100
+Refill Rate: 100
+Current RUs: -150
+Average RUs: -3.125
+
+# Ensure that update respects the burst limit.
+update
+10s
+----
+Burst Limit: 100
+Refill Rate: 100
+Current RUs: 100
+Average RUs: -3.125
+
+# No token refill, set current.
+reconfigure
+limit: 5000000
+rate: 0
+current: 5000000
+----
+Burst Limit: 5000000
+Refill Rate: 0
+Current RUs: 5000000
+Average RUs: -3.125
+
+request
+ru: 1000000
+----
+Granted: 1000000 RU
+Trickle duration: 0s
+Fallback rate: 1388.888889 RU/s
+Burst Limit: 5000000
+Refill Rate: 0
+Current RUs: 4000000
+Average RUs: 1249997.656
+
+# Limit of 0 = unlimited.
+reconfigure
+limit: 0
+rate: 1000000
+current: -1
+----
+Burst Limit: 0
+Refill Rate: 1000000
+Current RUs: 4000000
+Average RUs: 1249997.656
+
+update
+10s
+----
+Burst Limit: 0
+Refill Rate: 1000000
+Current RUs: 14000000
+Average RUs: 1249997.656

--- a/pkg/ccl/multitenantccl/tenantcostserver/tenanttokenbucket/testdata/request
+++ b/pkg/ccl/multitenantccl/tenantcostserver/tenanttokenbucket/testdata/request
@@ -1,8 +1,12 @@
-init
+reconfigure
+limit: 1000
 rate: 100
-initial: 1000
+current: 1000
 ----
+Burst Limit: 1000
+Refill Rate: 100
 Current RUs: 1000
+Average RUs: 0
 
 request
 ru: 10
@@ -10,7 +14,10 @@ ru: 10
 Granted: 10 RU
 Trickle duration: 0s
 Fallback rate: 100.2777778 RU/s
+Burst Limit: 1000
+Refill Rate: 100
 Current RUs: 990
+Average RUs: 250
 
 request
 ru: 890
@@ -18,17 +25,22 @@ ru: 890
 Granted: 890 RU
 Trickle duration: 0s
 Fallback rate: 100.275 RU/s
+Burst Limit: 1000
+Refill Rate: 100
 Current RUs: 100
+Average RUs: 435
 
-# We have 100 available, and it will take 1s for another 100 to become
-# available.
+# Go into debt.
 request
 ru: 200
 ----
 Granted: 200 RU
-Trickle duration: 1s
+Trickle duration: 10s
 Fallback rate: 100.0277778 RU/s
+Burst Limit: 1000
+Refill Rate: 100
 Current RUs: -100
+Average RUs: 351.25
 
 # Request a very large value. We only grant what we get over the next request
 # period (10s by default).
@@ -38,47 +50,115 @@ ru: 10000
 Granted: 1000 RU
 Trickle duration: 10s
 Fallback rate: 100 RU/s
+Burst Limit: 1000
+Refill Rate: 100
 Current RUs: -1100
+Average RUs: 238.4375
 
-# If we keep requesting, we will enter into debt and less will be granted.
+# Try to request enough that we hit max debt levels. Note that we're temporarily
+# giving out more than the configured rate while Average RUs stabilizes.
 request
 ru: 1000
 ----
-Granted: 900 RU
+Granted: 400 RU
 Trickle duration: 10s
 Fallback rate: 100 RU/s
-Current RUs: -2000
+Burst Limit: 1000
+Refill Rate: 100
+Current RUs: -1500
+Average RUs: -96.171875
 
-request
-ru: 1000
-----
-Granted: 50 RU
-Trickle duration: 10s
-Fallback rate: 100 RU/s
-Current RUs: -2050
-
+# Fast-forward 10 seconds.
 update
 10s
 ----
-Current RUs: -1050
+Burst Limit: 1000
+Refill Rate: 100
+Current RUs: -500
+Average RUs: -96.171875
+
+# Make a request that is limited by average RUs.
+request
+ru: 1000
+----
+Granted: 802.8710938 RU
+Trickle duration: 10s
+Fallback rate: 100 RU/s
+Burst Limit: 1000
+Refill Rate: 100
+Current RUs: -1302.871094
+Average RUs: -197.1289062
+
+# Make another request that should be granted.
+request
+ru: 100
+----
+Granted: 100 RU
+Trickle duration: 10s
+Fallback rate: 100 RU/s
+Burst Limit: 1000
+Refill Rate: 100
+Current RUs: -1402.871094
+Average RUs: -473.5644531
+
+# Fast-forward 10 seconds.
+update
+10s
+----
+Burst Limit: 1000
+Refill Rate: 100
+Current RUs: -402.8710938
+Average RUs: -473.5644531
 
 request
 ru: 100
 ----
 Granted: 100 RU
-Trickle duration: 1.052631578s
+Trickle duration: 10s
 Fallback rate: 100 RU/s
-Current RUs: -1150
+Burst Limit: 1000
+Refill Rate: 100
+Current RUs: -502.8710938
+Average RUs: -455.8911133
 
 update
 10s
 ----
-Current RUs: -150
+Burst Limit: 1000
+Refill Rate: 100
+Current RUs: 497.1289062
+Average RUs: -455.8911133
 
+request
+ru: 500
+----
+Granted: 500 RU
+Trickle duration: 10s
+Fallback rate: 100.1380914 RU/s
+Burst Limit: 1000
+Refill Rate: 100
+Current RUs: -2.87109375
+Average RUs: -217.6361084
+
+# No token refill, don't update current RUs.
+reconfigure
+limit: 1000
+rate: 0
+current: -1
+----
+Burst Limit: 1000
+Refill Rate: 0
+Current RUs: -2.87109375
+Average RUs: -217.6361084
+
+# Try to request tokens, expect 0 grant.
 request
 ru: 100
 ----
-Granted: 100 RU
-Trickle duration: 1s
-Fallback rate: 100 RU/s
-Current RUs: -250
+Granted: 0 RU
+Trickle duration: 0s
+Fallback rate: 0 RU/s
+Burst Limit: 1000
+Refill Rate: 0
+Current RUs: -2.87109375
+Average RUs: -163.9448547

--- a/pkg/ccl/multitenantccl/tenantcostserver/tenanttokenbucket/testdata/update
+++ b/pkg/ccl/multitenantccl/tenantcostserver/tenanttokenbucket/testdata/update
@@ -1,40 +1,66 @@
-init
+reconfigure
+limit: 1000000000
 rate: 1000
 ----
+Burst Limit: 1000000000
+Refill Rate: 1000
 Current RUs: 0
+Average RUs: 0
 
 update
 1s
 ----
+Burst Limit: 1000000000
+Refill Rate: 1000
 Current RUs: 1000
+Average RUs: 0
 
 update
 0s
 ----
+Burst Limit: 1000000000
+Refill Rate: 1000
 Current RUs: 1000
+Average RUs: 0
 
 update
 -5s
 ----
+Burst Limit: 1000000000
+Refill Rate: 1000
 Current RUs: 1000
+Average RUs: 0
 
 update
 10s
 ----
+Burst Limit: 1000000000
+Refill Rate: 1000
 Current RUs: 11000
+Average RUs: 0
 
 update
 72h
 ----
+Burst Limit: 1000000000
+Refill Rate: 1000
 Current RUs: 259211000
+Average RUs: 0
 
-init
-initial: 1234
+reconfigure
+limit: 10000
 rate: 10
+current: 1234
 ----
+Burst Limit: 10000
+Refill Rate: 10
 Current RUs: 1234
+Average RUs: 0
 
 update
 10s
 ----
+Burst Limit: 10000
+Refill Rate: 10
 Current RUs: 1334
+Average RUs: 0

--- a/pkg/ccl/multitenantccl/tenantcostserver/testdata/cleanup
+++ b/pkg/ccl/multitenantccl/tenantcostserver/testdata/cleanup
@@ -21,7 +21,7 @@ instance_id: 9
 
 inspect tenant=5
 ----
-Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10000000  current-share-sum=0
+Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10000000  ru-current-avg=6835937.5
 Consumption: ru=0 kvru=0  reads=0 in 0 batches (0 bytes)  writes=0 in 0 batches (0 bytes)  pod-cpu-usage: 0 secs  pgwire-egress=0 bytes  external-egress=0 bytes  external-ingress=0 bytes
 Last update: 00:00:00.000
 First active instance: 3
@@ -47,7 +47,7 @@ instance_id: 3
 
 inspect tenant=13
 ----
-Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10000000  current-share-sum=0
+Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10000000  ru-current-avg=5781250
 Consumption: ru=0 kvru=0  reads=0 in 0 batches (0 bytes)  writes=0 in 0 batches (0 bytes)  pod-cpu-usage: 0 secs  pgwire-egress=0 bytes  external-egress=0 bytes  external-ingress=0 bytes
 Last update: 00:00:00.000
 First active instance: 2
@@ -73,7 +73,7 @@ next_live_instance_id: 9
 
 wait-inspect tenant=5
 ----
-Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10030000  current-share-sum=0
+Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10030000  ru-current-avg=7634453.125
 Consumption: ru=0 kvru=0  reads=0 in 0 batches (0 bytes)  writes=0 in 0 batches (0 bytes)  pod-cpu-usage: 0 secs  pgwire-egress=0 bytes  external-egress=0 bytes  external-ingress=0 bytes
 Last update: 00:05:00.000
 First active instance: 3
@@ -94,7 +94,7 @@ next_live_instance_id: 3
 
 wait-inspect tenant=5
 ----
-Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10060000  current-share-sum=0
+Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10060000  ru-current-avg=8240839.84375
 Consumption: ru=0 kvru=0  reads=0 in 0 batches (0 bytes)  writes=0 in 0 batches (0 bytes)  pod-cpu-usage: 0 secs  pgwire-egress=0 bytes  external-egress=0 bytes  external-ingress=0 bytes
 Last update: 00:10:00.000
 First active instance: 3
@@ -115,7 +115,7 @@ next_live_instance_id: 5
 
 wait-inspect tenant=5
 ----
-Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10090000  current-share-sum=0
+Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10090000  ru-current-avg=8703129.88281
 Consumption: ru=0 kvru=0  reads=0 in 0 batches (0 bytes)  writes=0 in 0 batches (0 bytes)  pod-cpu-usage: 0 secs  pgwire-egress=0 bytes  external-egress=0 bytes  external-ingress=0 bytes
 Last update: 00:15:00.000
 First active instance: 5
@@ -123,7 +123,7 @@ First active instance: 5
 
 inspect tenant=13
 ----
-Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10000000  current-share-sum=0
+Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10000000  ru-current-avg=5781250
 Consumption: ru=0 kvru=0  reads=0 in 0 batches (0 bytes)  writes=0 in 0 batches (0 bytes)  pod-cpu-usage: 0 secs  pgwire-egress=0 bytes  external-egress=0 bytes  external-ingress=0 bytes
 Last update: 00:00:00.000
 First active instance: 2

--- a/pkg/ccl/multitenantccl/tenantcostserver/testdata/configure
+++ b/pkg/ccl/multitenantccl/tenantcostserver/testdata/configure
@@ -17,7 +17,7 @@ max_burst_ru: 5000
 
 inspect tenant=5
 ----
-Bucket state: ru-burst-limit=5000  ru-refill-rate=100  ru-current=1000  current-share-sum=0
+Bucket state: ru-burst-limit=5000  ru-refill-rate=100  ru-current=1000  ru-current-avg=0
 Consumption: ru=0 kvru=0  reads=0 in 0 batches (0 bytes)  writes=0 in 0 batches (0 bytes)  pod-cpu-usage: 0 secs  pgwire-egress=0 bytes  external-egress=0 bytes  external-ingress=0 bytes
 Last update: 00:00:00.000
 First active instance: 0
@@ -39,7 +39,7 @@ consumption:
 
 inspect tenant=5
 ----
-Bucket state: ru-burst-limit=5000  ru-refill-rate=100  ru-current=1000  current-share-sum=0
+Bucket state: ru-burst-limit=5000  ru-refill-rate=100  ru-current=1000  ru-current-avg=250
 Consumption: ru=10 kvru=10  reads=20 in 2 batches (30 bytes)  writes=40 in 2 batches (50 bytes)  pod-cpu-usage: 60 secs  pgwire-egress=70 bytes  external-egress=0 bytes  external-ingress=0 bytes
 Last update: 00:00:00.000
 First active instance: 1
@@ -57,7 +57,7 @@ refill_rate: 100
 
 inspect tenant=5
 ----
-Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=2000  current-share-sum=0
+Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=2000  ru-current-avg=250
 Consumption: ru=10 kvru=10  reads=20 in 2 batches (30 bytes)  writes=40 in 2 batches (50 bytes)  pod-cpu-usage: 60 secs  pgwire-egress=70 bytes  external-egress=0 bytes  external-ingress=0 bytes
 Last update: 00:01:00.000
 First active instance: 1

--- a/pkg/ccl/multitenantccl/tenantcostserver/testdata/instances
+++ b/pkg/ccl/multitenantccl/tenantcostserver/testdata/instances
@@ -17,7 +17,7 @@ instance_id: 10
 
 inspect tenant=5
 ----
-Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10000000  current-share-sum=0
+Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10000000  ru-current-avg=2500000
 Consumption: ru=0 kvru=0  reads=0 in 0 batches (0 bytes)  writes=0 in 0 batches (0 bytes)  pod-cpu-usage: 0 secs  pgwire-egress=0 bytes  external-egress=0 bytes  external-ingress=0 bytes
 Last update: 00:00:00.000
 First active instance: 10
@@ -29,7 +29,7 @@ instance_id: 10
 
 inspect tenant=5
 ----
-Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10000000  current-share-sum=0
+Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10000000  ru-current-avg=4375000
 Consumption: ru=0 kvru=0  reads=0 in 0 batches (0 bytes)  writes=0 in 0 batches (0 bytes)  pod-cpu-usage: 0 secs  pgwire-egress=0 bytes  external-egress=0 bytes  external-ingress=0 bytes
 Last update: 00:00:00.000
 First active instance: 10
@@ -41,7 +41,7 @@ instance_id: 20
 
 inspect tenant=5
 ----
-Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10000000  current-share-sum=0
+Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10000000  ru-current-avg=5781250
 Consumption: ru=0 kvru=0  reads=0 in 0 batches (0 bytes)  writes=0 in 0 batches (0 bytes)  pod-cpu-usage: 0 secs  pgwire-egress=0 bytes  external-egress=0 bytes  external-ingress=0 bytes
 Last update: 00:00:00.000
 First active instance: 10
@@ -54,7 +54,7 @@ instance_id: 15
 
 inspect tenant=5
 ----
-Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10000000  current-share-sum=0
+Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10000000  ru-current-avg=6835937.5
 Consumption: ru=0 kvru=0  reads=0 in 0 batches (0 bytes)  writes=0 in 0 batches (0 bytes)  pod-cpu-usage: 0 secs  pgwire-egress=0 bytes  external-egress=0 bytes  external-ingress=0 bytes
 Last update: 00:00:00.000
 First active instance: 10
@@ -68,7 +68,7 @@ instance_id: 1
 
 inspect tenant=5
 ----
-Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10000000  current-share-sum=0
+Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10000000  ru-current-avg=7626953.125
 Consumption: ru=0 kvru=0  reads=0 in 0 batches (0 bytes)  writes=0 in 0 batches (0 bytes)  pod-cpu-usage: 0 secs  pgwire-egress=0 bytes  external-egress=0 bytes  external-ingress=0 bytes
 Last update: 00:00:00.000
 First active instance: 1

--- a/pkg/ccl/multitenantccl/tenantcostserver/testdata/metrics
+++ b/pkg/ccl/multitenantccl/tenantcostserver/testdata/metrics
@@ -68,7 +68,7 @@ consumption:
 
 inspect tenant=5
 ----
-Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10000000  current-share-sum=0
+Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10000000  ru-current-avg=5781250
 Consumption: ru=1110 kvru=888  reads=2220 in 222 batches (3330 bytes)  writes=4440 in 333 batches (5550 bytes)  pod-cpu-usage: 6660 secs  pgwire-egress=7770 bytes  external-egress=0 bytes  external-ingress=0 bytes
 Last update: 00:00:00.000
 First active instance: 1

--- a/pkg/ccl/multitenantccl/tenantcostserver/testdata/requests
+++ b/pkg/ccl/multitenantccl/tenantcostserver/testdata/requests
@@ -16,11 +16,11 @@ token-bucket-request tenant=5
 instance_id: 1
 ru: 10
 ----
-10 RUs granted over 100ms. Fallback rate: 100 RU/s
+10 RUs granted over 10s. Fallback rate: 100 RU/s
 
 inspect tenant=5
 ----
-Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=-10  current-share-sum=0
+Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=-10  ru-current-avg=1875000
 Consumption: ru=0 kvru=0  reads=0 in 0 batches (0 bytes)  writes=0 in 0 batches (0 bytes)  pod-cpu-usage: 0 secs  pgwire-egress=0 bytes  external-egress=0 bytes  external-ingress=0 bytes
 Last update: 00:00:00.000
 First active instance: 1
@@ -39,7 +39,7 @@ ru: 500
 
 inspect tenant=5
 ----
-Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=490  current-share-sum=0
+Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=490  ru-current-avg=1406497.5
 Consumption: ru=0 kvru=0  reads=0 in 0 batches (0 bytes)  writes=0 in 0 batches (0 bytes)  pod-cpu-usage: 0 secs  pgwire-egress=0 bytes  external-egress=0 bytes  external-ingress=0 bytes
 Last update: 00:00:10.000
 First active instance: 1
@@ -70,7 +70,7 @@ ru: 10
 # Last update time for the tenant is unchanged. The per-instance time does get updated.
 inspect tenant=5
 ----
-Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=230  current-share-sum=0
+Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=230  ru-current-avg=791306.71875
 Consumption: ru=0 kvru=0  reads=0 in 0 batches (0 bytes)  writes=0 in 0 batches (0 bytes)  pod-cpu-usage: 0 secs  pgwire-egress=0 bytes  external-egress=0 bytes  external-ingress=0 bytes
 Last update: 00:00:10.000
 First active instance: 1
@@ -89,7 +89,7 @@ instance_id: 1
 # The current RU amount stays the same.
 inspect tenant=5
 ----
-Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=230  current-share-sum=0
+Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=230  ru-current-avg=593537.539062
 Consumption: ru=0 kvru=0  reads=0 in 0 batches (0 bytes)  writes=0 in 0 batches (0 bytes)  pod-cpu-usage: 0 secs  pgwire-egress=0 bytes  external-egress=0 bytes  external-ingress=0 bytes
 Last update: 00:00:10.000
 First active instance: 1
@@ -108,7 +108,7 @@ instance_id: 1
 # RU refilling resumed.
 inspect tenant=5
 ----
-Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=330  current-share-sum=0
+Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=330  ru-current-avg=445235.654297
 Consumption: ru=0 kvru=0  reads=0 in 0 batches (0 bytes)  writes=0 in 0 batches (0 bytes)  pod-cpu-usage: 0 secs  pgwire-egress=0 bytes  external-egress=0 bytes  external-ingress=0 bytes
 Last update: 00:00:11.000
 First active instance: 1

--- a/pkg/ccl/multitenantccl/tenantcostserver/testdata/seqnum
+++ b/pkg/ccl/multitenantccl/tenantcostserver/testdata/seqnum
@@ -20,7 +20,7 @@ consumption:
 
 inspect tenant=5
 ----
-Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10000000  current-share-sum=0
+Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10000000  ru-current-avg=2500000
 Consumption: ru=10 kvru=10  reads=20 in 1 batches (30 bytes)  writes=40 in 3 batches (50 bytes)  pod-cpu-usage: 60 secs  pgwire-egress=70 bytes  external-egress=0 bytes  external-ingress=0 bytes
 Last update: 00:00:00.000
 First active instance: 1
@@ -46,7 +46,7 @@ consumption:
 
 inspect tenant=5
 ----
-Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10000000  current-share-sum=0
+Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10000000  ru-current-avg=4375000
 Consumption: ru=20 kvru=20  reads=40 in 2 batches (60 bytes)  writes=80 in 6 batches (100 bytes)  pod-cpu-usage: 120 secs  pgwire-egress=140 bytes  external-egress=0 bytes  external-ingress=0 bytes
 Last update: 00:00:00.000
 First active instance: 1
@@ -72,7 +72,7 @@ consumption:
 
 inspect tenant=5
 ----
-Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10000000  current-share-sum=0
+Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10000000  ru-current-avg=5781250
 Consumption: ru=20 kvru=20  reads=40 in 2 batches (60 bytes)  writes=80 in 6 batches (100 bytes)  pod-cpu-usage: 120 secs  pgwire-egress=140 bytes  external-egress=0 bytes  external-ingress=0 bytes
 Last update: 00:00:00.000
 First active instance: 1
@@ -97,7 +97,7 @@ consumption:
 
 inspect tenant=5
 ----
-Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10000000  current-share-sum=0
+Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10000000  ru-current-avg=6835937.5
 Consumption: ru=20 kvru=20  reads=40 in 2 batches (60 bytes)  writes=80 in 6 batches (100 bytes)  pod-cpu-usage: 120 secs  pgwire-egress=140 bytes  external-egress=0 bytes  external-ingress=0 bytes
 Last update: 00:00:00.000
 First active instance: 1
@@ -123,7 +123,7 @@ consumption:
 
 inspect tenant=5
 ----
-Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10000000  current-share-sum=0
+Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10000000  ru-current-avg=7626953.125
 Consumption: ru=30 kvru=40  reads=60 in 3 batches (90 bytes)  writes=120 in 9 batches (150 bytes)  pod-cpu-usage: 180 secs  pgwire-egress=210 bytes  external-egress=0 bytes  external-ingress=0 bytes
 Last update: 00:00:00.000
 First active instance: 1
@@ -149,7 +149,7 @@ consumption:
 
 inspect tenant=5
 ----
-Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10000000  current-share-sum=0
+Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10000000  ru-current-avg=8220214.84375
 Consumption: ru=40 kvru=70  reads=80 in 4 batches (120 bytes)  writes=160 in 12 batches (200 bytes)  pod-cpu-usage: 240 secs  pgwire-egress=280 bytes  external-egress=0 bytes  external-ingress=0 bytes
 Last update: 00:00:00.000
 First active instance: 1

--- a/pkg/ccl/multitenantccl/tenantcostserver/token_bucket.go
+++ b/pkg/ccl/multitenantccl/tenantcostserver/token_bucket.go
@@ -103,7 +103,6 @@ func (s *instance) TokenBucketRequest(
 			instance.Seq = in.SeqNum
 		}
 
-		// TODO(radu): update shares.
 		*result = tenant.Bucket.Request(ctx, in)
 
 		instance.LastUpdate.Time = now


### PR DESCRIPTION
Previously, the token bucket's debt algorithm was greedy, always granting as many tokens as available on a first-come-first-served basis. This resulted in inequitable treatment of competing tenant instances, with some instances being starved while others got more than their share. Depending on the timing of calls, the balance could rapidly shift, with big swings in the relative RU rates of tenant instances.

This PR updates the algorithm to track the average debt in the bucket. Grants to requesting tenant instances are limited to the difference between the limit of tokens in the bucket and the average debt. This means that requests that come in when there are many tokens available will not greedily take all the tokens; instead they'll get a portion that corresponds to the average number of tokens that are available at any given time.

The new algorithm incrementally moves towards "fairness" across tenant instances, even in the presence of shifting workloads or tenant instances joining/leaving.

Epic: CC-25942

Release note: None