### PR TITLE
roachtest: disable tpch checks for the import-cancellation test

### DIFF
--- a/pkg/cmd/roachtest/tests/import_cancellation.go
+++ b/pkg/cmd/roachtest/tests/import_cancellation.go
@@ -147,7 +147,7 @@ func runImportCancellation(ctx context.Context, t test.Test, c cluster.Cluster) 
 		maxOps := 2 * tpch.NumQueries
 		const maxLatency = 500 * time.Second
 		cmd := fmt.Sprintf(
-			"./workload run tpch --db=csv --concurrency=1 --max-ops=%d {pgurl%s} --enable-checks=true "+
+			"./workload run tpch --db=csv --concurrency=1 --max-ops=%d {pgurl%s} "+
 				"--histograms="+t.PerfArtifactsDir()+"/stats.json --histograms-max-latency=%s",
 			maxOps, c.All(), maxLatency.String())
 		if err := c.RunE(ctx, c.Node(1), cmd); err != nil {


### PR DESCRIPTION
We recently added checking for the results of running TPCH queries to the import-cancellation roachtest. However, the test uses a dataset with scale-factor=100, while the expected results for the checks used scale-factor-1. This was causing test failures, so this patch removes the query result checks.

Fixes #112826

Release note: None