### PR TITLE
server: skip decommission self under deadlock

### DIFF
--- a/pkg/server/storage_api/decommission_test.go
+++ b/pkg/server/storage_api/decommission_test.go
@@ -657,6 +657,7 @@ func TestDecommissionSelf(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	skip.UnderRace(t) // can't handle 7-node clusters
+	skip.UnderDeadlockWithIssue(t, 112918)
 
 	// Set up test cluster.
 	ctx := context.Background()


### PR DESCRIPTION
Skip `TestDecommissionSelf` under deadlock.

The underlying bug is tracked in https://github.com/cockroachdb/cockroach/issues/112918. The bug has only reproduced
under test scenarios with a deadlock build introducing slowness and is
relatively harmless, affecting status reporting and the CLI.

Resolves: https://github.com/cockroachdb/cockroach/issues/109883
Resolves: https://github.com/cockroachdb/cockroach/issues/111989
Release note: None