### PR TITLE
release-23.2: clusterversion: remove redundant version gates introduced in 23.2

### DIFF
--- a/docs/generated/settings/settings-for-tenants.txt
+++ b/docs/generated/settings/settings-for-tenants.txt
@@ -319,4 +319,4 @@ trace.snapshot.rate	duration	0s	if non-zero, interval at which background trace 
 trace.span_registry.enabled	boolean	true	if set, ongoing traces can be seen at https://<ui>/#/debug/tracez	application
 trace.zipkin.collector	string		the address of a Zipkin instance to receive traces, as <host>:<port>. If no port is specified, 9411 will be used.	application
 ui.display_timezone	enumeration	etc/utc	the timezone used to format timestamps in the ui [etc/utc = 0, america/new_york = 1]	application
-version	version	1000023.1-38	set the active cluster version in the format '<major>.<minor>'	application
+version	version	1000023.1-32	set the active cluster version in the format '<major>.<minor>'	application

--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -271,6 +271,6 @@
 <tr><td><div id="setting-trace-span-registry-enabled" class="anchored"><code>trace.span_registry.enabled</code></div></td><td>boolean</td><td><code>true</code></td><td>if set, ongoing traces can be seen at https://&lt;ui&gt;/#/debug/tracez</td><td>Serverless/Dedicated/Self-Hosted</td></tr>
 <tr><td><div id="setting-trace-zipkin-collector" class="anchored"><code>trace.zipkin.collector</code></div></td><td>string</td><td><code></code></td><td>the address of a Zipkin instance to receive traces, as &lt;host&gt;:&lt;port&gt;. If no port is specified, 9411 will be used.</td><td>Serverless/Dedicated/Self-Hosted</td></tr>
 <tr><td><div id="setting-ui-display-timezone" class="anchored"><code>ui.display_timezone</code></div></td><td>enumeration</td><td><code>etc/utc</code></td><td>the timezone used to format timestamps in the ui [etc/utc = 0, america/new_york = 1]</td><td>Serverless/Dedicated/Self-Hosted</td></tr>
-<tr><td><div id="setting-version" class="anchored"><code>version</code></div></td><td>version</td><td><code>1000023.1-38</code></td><td>set the active cluster version in the format &#39;&lt;major&gt;.&lt;minor&gt;&#39;</td><td>Serverless/Dedicated/Self-Hosted</td></tr>
+<tr><td><div id="setting-version" class="anchored"><code>version</code></div></td><td>version</td><td><code>1000023.1-32</code></td><td>set the active cluster version in the format &#39;&lt;major&gt;.&lt;minor&gt;&#39;</td><td>Serverless/Dedicated/Self-Hosted</td></tr>
 </tbody>
 </table>

--- a/pkg/clusterversion/cockroach_versions.go
+++ b/pkg/clusterversion/cockroach_versions.go
@@ -447,14 +447,6 @@ const (
 	// the process of upgrading from previous supported releases to 23.2.
 	V23_2Start
 
-	// V23_2TTLAllowDescPK is the version where TTL tables can have descending
-	// primary keys.
-	V23_2TTLAllowDescPK
-
-	// V23_2_PartiallyVisibleIndexes is the version where partially visible
-	// indexes are enabled.
-	V23_2_PartiallyVisibleIndexes
-
 	// V23_2_EnableRangeCoalescingForSystemTenant enables range coalescing for
 	// the system tenant.
 	V23_2_EnableRangeCoalescingForSystemTenant
@@ -513,16 +505,6 @@ const (
 	// V23_2_AddSystemExecInsightsTable is the version at which Cockroach creates
 	// {statement|transaction}_execution_insights system tables.
 	V23_2_AddSystemExecInsightsTable
-
-	// V23_2_Procedures is the version where procedures are enabled.
-	V23_2_Procedures
-
-	// V23_2_PLpgSQL is the version at which Cockroach supports routines using
-	// PLpgSQL language.
-	V23_2_PLpgSQL
-
-	// V23_2_UDFMutations is the version where UDFs with mutations are enabled.
-	V23_2_UDFMutations
 
 	// *************************************************
 	// Step (1) Add new versions here.
@@ -815,14 +797,6 @@ var rawVersionsSingleton = keyedVersions{
 		Version: roachpb.Version{Major: 23, Minor: 1, Internal: 2},
 	},
 	{
-		Key:     V23_2TTLAllowDescPK,
-		Version: roachpb.Version{Major: 23, Minor: 1, Internal: 4},
-	},
-	{
-		Key:     V23_2_PartiallyVisibleIndexes,
-		Version: roachpb.Version{Major: 23, Minor: 1, Internal: 6},
-	},
-	{
 		Key:     V23_2_EnableRangeCoalescingForSystemTenant,
 		Version: roachpb.Version{Major: 23, Minor: 1, Internal: 8},
 	},
@@ -873,18 +847,6 @@ var rawVersionsSingleton = keyedVersions{
 	{
 		Key:     V23_2_AddSystemExecInsightsTable,
 		Version: roachpb.Version{Major: 23, Minor: 1, Internal: 32},
-	},
-	{
-		Key:     V23_2_Procedures,
-		Version: roachpb.Version{Major: 23, Minor: 1, Internal: 34},
-	},
-	{
-		Key:     V23_2_PLpgSQL,
-		Version: roachpb.Version{Major: 23, Minor: 1, Internal: 36},
-	},
-	{
-		Key:     V23_2_UDFMutations,
-		Version: roachpb.Version{Major: 23, Minor: 1, Internal: 38},
 	},
 
 	// *************************************************

--- a/pkg/clusterversion/cockroach_versions_test.go
+++ b/pkg/clusterversion/cockroach_versions_test.go
@@ -41,8 +41,18 @@ func TestPreserveVersionsForMinBinaryVersion(t *testing.T) {
 			prevVersion = namedVersion
 			continue
 		}
+		expectedDiff := int32(2)
+		if prevVersion.Key == V23_2Start {
+			// In 23.2 cycle V23_2TTLAllowDescPK and
+			// V23_2_PartiallyVisibleIndexes were introduced but then later
+			// removed (since they were redundant), so we exempt them from not
+			// being deleted. (There were more versions introduced and then
+			// removed, but they were at the tail of 23.2 versions, so they
+			// don't require a similar exemption.)
+			expectedDiff = 6
+		}
 		if v.Major == prevVersion.Major && v.Minor == prevVersion.Minor {
-			require.Equalf(t, prevVersion.Internal+2, v.Internal,
+			require.Equalf(t, prevVersion.Internal+expectedDiff, v.Internal,
 				"version(s) between %s (%s) and %s (%s) is(are) at or above minBinaryVersion (%s) and should not be removed",
 				prevVersion.Key, prevVersion.Version,
 				namedVersion.Key, namedVersion.Version,

--- a/pkg/sql/alter_index_visible.go
+++ b/pkg/sql/alter_index_visible.go
@@ -87,7 +87,7 @@ func (n *alterIndexVisibleNode) startExec(params runParams) error {
 	}
 
 	activeVersion := params.ExecCfg().Settings.Version.ActiveVersion(params.ctx)
-	if !activeVersion.IsActive(clusterversion.V23_2_PartiallyVisibleIndexes) &&
+	if !activeVersion.IsActive(clusterversion.V23_2) &&
 		n.n.Invisibility.Value > 0.0 && n.n.Invisibility.Value < 1.0 {
 		return unimplemented.New("partially visible indexes", "partially visible indexes are not yet supported")
 	}

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -296,7 +296,7 @@ func (n *alterTableNode) startExec(params runParams) error {
 				}
 
 				activeVersion := params.ExecCfg().Settings.Version.ActiveVersion(params.ctx)
-				if !activeVersion.IsActive(clusterversion.V23_2_PartiallyVisibleIndexes) &&
+				if !activeVersion.IsActive(clusterversion.V23_2) &&
 					d.Invisibility.Value > 0.0 && d.Invisibility.Value < 1.0 {
 					return unimplemented.New("partially visible indexes", "partially visible indexes are not yet supported")
 				}

--- a/pkg/sql/catalog/tabledesc/validate.go
+++ b/pkg/sql/catalog/tabledesc/validate.go
@@ -977,7 +977,7 @@ func (desc *wrapper) ValidateSelf(vea catalog.ValidationErrorAccumulator) {
 	// ValidateRowLevelTTL is also used before the table descriptor is fully
 	// initialized to validate the storage parameters.
 	vea.Report(ValidateTTLExpirationExpr(desc))
-	vea.Report(ValidateTTLExpirationColumn(desc, vea.IsActive(clusterversion.V23_2TTLAllowDescPK)))
+	vea.Report(ValidateTTLExpirationColumn(desc, vea.IsActive(clusterversion.V23_2)))
 
 	// Validate that there are no column with both a foreign key ON UPDATE and an
 	// ON UPDATE expression. This check is made to ensure that we know which ON

--- a/pkg/sql/create_index.go
+++ b/pkg/sql/create_index.go
@@ -199,7 +199,7 @@ func makeIndexDescriptor(
 		return nil, err
 	}
 
-	if !activeVersion.IsActive(clusterversion.V23_2_PartiallyVisibleIndexes) &&
+	if !activeVersion.IsActive(clusterversion.V23_2) &&
 		n.Invisibility.Value > 0.0 && n.Invisibility.Value < 1.0 {
 		return nil, unimplemented.New("partially visible indexes", "partially visible indexes are not yet supported")
 	}

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -1829,7 +1829,7 @@ func NewTableDesc(
 			if err := checkIndexColumns(&desc, d.Columns, d.Storing, d.Inverted, version); err != nil {
 				return nil, err
 			}
-			if !version.IsActive(clusterversion.V23_2_PartiallyVisibleIndexes) &&
+			if !version.IsActive(clusterversion.V23_2) &&
 				d.Invisibility.Value > 0.0 && d.Invisibility.Value < 1.0 {
 				return nil, unimplemented.New("partially visible indexes", "partially visible indexes are not yet supported")
 			}
@@ -1948,7 +1948,7 @@ func NewTableDesc(
 			if err := checkIndexColumns(&desc, d.Columns, d.Storing, d.Inverted, version); err != nil {
 				return nil, err
 			}
-			if !version.IsActive(clusterversion.V23_2_PartiallyVisibleIndexes) &&
+			if !version.IsActive(clusterversion.V23_2) &&
 				d.Invisibility.Value > 0.0 && d.Invisibility.Value < 1.0 {
 				return nil, unimplemented.New("partially visible indexes", "partially visible indexes are not yet supported")
 			}

--- a/pkg/sql/logictest/testdata/logic_test/mixed_version_procedure
+++ b/pkg/sql/logictest/testdata/logic_test/mixed_version_procedure
@@ -40,7 +40,7 @@ upgrade 2
 # Makes sure the upgrade job has finished, and the cluster version gate is
 # passed.
 query B retry
-SELECT crdb_internal.is_at_least_version('23.1-34')
+SELECT crdb_internal.is_at_least_version('23.1-32')
 ----
 true
 

--- a/pkg/sql/logictest/testdata/logic_test/mixed_version_udf_mutations
+++ b/pkg/sql/logictest/testdata/logic_test/mixed_version_udf_mutations
@@ -88,7 +88,7 @@ upgrade 1
 upgrade 2
 
 query B retry
-SELECT crdb_internal.is_at_least_version('23.1-38')
+SELECT crdb_internal.is_at_least_version('23.1-32')
 ----
 true
 

--- a/pkg/sql/opt/optbuilder/builder.go
+++ b/pkg/sql/opt/optbuilder/builder.go
@@ -328,7 +328,7 @@ func (b *Builder) buildStmt(
 		case *tree.Select, tree.SelectStatement:
 		case *tree.Insert, *tree.Update, *tree.Delete:
 			activeVersion := b.evalCtx.Settings.Version.ActiveVersion(b.ctx)
-			if !activeVersion.IsActive(clusterversion.V23_2_UDFMutations) {
+			if !activeVersion.IsActive(clusterversion.V23_2) {
 				panic(unimplemented.Newf("user-defined functions", "%s usage inside a function definition is not supported until version 23.2", stmt.StatementTag()))
 			}
 		default:

--- a/pkg/sql/opt/optbuilder/create_function.go
+++ b/pkg/sql/opt/optbuilder/create_function.go
@@ -41,7 +41,7 @@ func (b *Builder) buildCreateFunction(cf *tree.CreateRoutine, inScope *scope) (o
 	}
 
 	activeVersion := b.evalCtx.Settings.Version.ActiveVersion(b.ctx)
-	if cf.IsProcedure && !activeVersion.IsActive(clusterversion.V23_2_Procedures) {
+	if cf.IsProcedure && !activeVersion.IsActive(clusterversion.V23_2) {
 		panic(unimplemented.New("procedures", "procedures are not yet supported"))
 	}
 
@@ -124,7 +124,7 @@ func (b *Builder) buildCreateFunction(cf *tree.CreateRoutine, inScope *scope) (o
 	if !languageFound {
 		panic(pgerror.New(pgcode.InvalidFunctionDefinition, "no language specified"))
 	}
-	if language == tree.RoutineLangPLpgSQL && !activeVersion.IsActive(clusterversion.V23_2_PLpgSQL) {
+	if language == tree.RoutineLangPLpgSQL && !activeVersion.IsActive(clusterversion.V23_2) {
 		panic(unimplemented.New("PLpgSQL", "PLpgSQL is not supported until version 23.2"))
 	}
 

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_primary_key.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_primary_key.go
@@ -450,7 +450,7 @@ func fallBackIfDescColInRowLevelTTLTables(b BuildCtx, tableID catid.DescID, t al
 
 	// It's a row-level-ttl table. Ensure it has no non-descending
 	// key columns, and there is no inbound/outbound foreign keys.
-	if !b.ClusterSettings().Version.IsActive(b, clusterversion.V23_2TTLAllowDescPK) {
+	if !b.ClusterSettings().Version.IsActive(b, clusterversion.V23_2) {
 		for _, col := range t.Columns {
 			if indexColumnDirection(col.Direction) != catenumpb.IndexColumn_ASC {
 				panic(scerrors.NotImplementedErrorf(t.n, "non-ascending ordering on PRIMARY KEYs are not supported"))

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_index.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_index.go
@@ -85,7 +85,7 @@ func CreateIndex(b BuildCtx, n *tree.CreateIndex) {
 		}
 	}
 	activeVersion := b.EvalCtx().Settings.Version.ActiveVersion(context.TODO())
-	if !activeVersion.IsActive(clusterversion.V23_2_PartiallyVisibleIndexes) &&
+	if !activeVersion.IsActive(clusterversion.V23_2) &&
 		n.Invisibility.Value > 0.0 && n.Invisibility.Value < 1.0 {
 		panic(unimplemented.New("partially visible indexes", "partially visible indexes are not yet supported"))
 	}

--- a/pkg/upgrade/upgrades/upgrades.go
+++ b/pkg/upgrade/upgrades/upgrades.go
@@ -298,12 +298,6 @@ var upgrades = []upgradebase.Upgrade{
 	),
 	firstUpgradeTowardsV23_2,
 	upgrade.NewTenantUpgrade(
-		"enable partially visible indexes",
-		toCV(clusterversion.V23_2_PartiallyVisibleIndexes),
-		upgrade.NoPrecondition,
-		NoTenantUpgradeFunc,
-	),
-	upgrade.NewTenantUpgrade(
 		"update system.statement_diagnostics_requests to support plan gist matching",
 		toCV(clusterversion.V23_2_StmtDiagForPlanGist),
 		upgrade.NoPrecondition,

--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -1047,7 +1047,7 @@ func (og *operationGenerator) createIndex(ctx context.Context, tx pgx.Tx) (*opSt
 	if notvisible := og.randIntn(20) == 0; notvisible {
 		invisibility.Value = 1.0
 		partiallyVisibleIndexNotSupported, err := isClusterVersionLessThan(
-			ctx, tx, clusterversion.ByKey(clusterversion.V23_2_PartiallyVisibleIndexes),
+			ctx, tx, clusterversion.ByKey(clusterversion.V23_2),
 		)
 		if err != nil {
 			return nil, err
@@ -1324,7 +1324,7 @@ func (og *operationGenerator) createTable(ctx context.Context, tx pgx.Tx) (*opSt
 	}
 
 	partiallyVisibleIndexNotSupported, err := isClusterVersionLessThan(
-		ctx, tx, clusterversion.ByKey(clusterversion.V23_2_PartiallyVisibleIndexes),
+		ctx, tx, clusterversion.ByKey(clusterversion.V23_2),
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Backport 1/1 commits from #112873.

/cc @cockroachdb/release

---

This commit removes multiple versions introduced in 23.2 cycle that
don't require an upgrade by replacing them with `V23_2`. The
following gates are removed:
- `V23_2TTLAllowDescPK`
- `V23_2_PartiallyVisibleIndexes`
- `V23_2_Procedures`
- `V23_2_PLpgSQL`
- `V23_2_UDFMutations`.

Epic: None

Release note: None

Release justification: low-risk cleanup.