### PR TITLE
docker: switch to using ubi9/ubi-minimal

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -30,7 +30,7 @@ executable.
 ### Deployment
 
 The deploy image is a downsized image containing a minimal environment for
-running CockroachDB. It is based on RedHat's `ubi8/ubi-minimal` image and
+running CockroachDB. It is based on RedHat's `ubi9/ubi-minimal` image and
 contains only the main CockroachDB binary, libgeos libraries, and licenses. To
 fetch this image, run `docker pull cockroachdb/cockroach` in the usual fashion.
 

--- a/build/deploy/Dockerfile
+++ b/build/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.access.redhat.com/ubi9/ubi-minimal
 ARG fips_enabled
 
 # For deployment, we need the following additionally installed:

--- a/build/packer/teamcity-agent.sh
+++ b/build/packer/teamcity-agent.sh
@@ -63,8 +63,8 @@ apt-get install --yes \
 apt-get install --yes qemu binfmt-support qemu-user-static
 
 # Verify that both of the platforms we support Docker for can be built.
-docker run --attach=stdout --attach=stderr --platform=linux/amd64 --rm --pull=always registry.access.redhat.com/ubi8/ubi-minimal uname -p
-docker run --attach=stdout --attach=stderr --platform=linux/arm64 --rm --pull=always registry.access.redhat.com/ubi8/ubi-minimal uname -p
+docker run --attach=stdout --attach=stderr --platform=linux/amd64 --rm --pull=always registry.access.redhat.com/ubi9/ubi-minimal uname -p
+docker run --attach=stdout --attach=stderr --platform=linux/arm64 --rm --pull=always registry.access.redhat.com/ubi9/ubi-minimal uname -p
 
 case $ARCH in
     x86_64) WHICH=x86_64; SHASUM=97bf730372f9900b2dfb9206fccbcf92f5c7f3b502148b832e77451aa0f9e0e6 ;;

--- a/build/teamcity/internal/release/build-and-publish-patched-go.sh
+++ b/build/teamcity/internal/release/build-and-publish-patched-go.sh
@@ -20,9 +20,8 @@ docker run --rm -i ${tty-} -v $this_dir/build-and-publish-patched-go:/bootstrap 
 tc_end_block "Build Go toolchains"
 
 tc_start_block "Build FIPS Go toolchains (linux/amd64)"
-# UBI 8 image with Go toolchain installed. The same image Red Hat uses for their CI.
-# TODO: consider switching to UBI 9
-UBI_DOCKER_IMAGE=registry.access.redhat.com/ubi8/go-toolset:1.18
+# UBI 9 image with Go toolchain installed. The same image Red Hat uses for their CI.
+UBI_DOCKER_IMAGE=registry.access.redhat.com/ubi9/go-toolset:1.18
 # FIPS Go toolchain version has a 'fips' suffix, so there should be no name collision
 docker run --rm -i ${tty-} -v "$this_dir/build-and-publish-patched-go:/bootstrap" \
   -v "${toplevel}"/artifacts:/artifacts \


### PR DESCRIPTION
Before this change, cockroach docker images were based on the ubi8/ubi-minimal image.

Now, cockroach images are based on the ubi9/ubi-minimal image.

Fixes: #112670

Release note (general change): The cockroach docker image is now based on Red Hat's ubi9/ubi-minimal image (instead of ubi8/ubi-minimal).