### PR TITLE
release-23.2: c2c: deflake a few e2e tests

### DIFF
--- a/pkg/ccl/streamingccl/replicationtestutils/testutils.go
+++ b/pkg/ccl/streamingccl/replicationtestutils/testutils.go
@@ -166,11 +166,11 @@ func (c *TenantStreamingClusters) init(ctx context.Context) {
 // will not yet be active. If the caller passes withTestingKnobs, the
 // destination tenant starts up via a testServer.StartSharedProcessTenant().
 func (c *TenantStreamingClusters) StartDestTenant(
-	ctx context.Context, withTestingKnobs *base.TestingKnobs,
+	ctx context.Context, withTestingKnobs *base.TestingKnobs, server int,
 ) func() error {
 	if withTestingKnobs != nil {
 		var err error
-		_, c.DestTenantConn, err = c.DestCluster.Server(0).StartSharedProcessTenant(ctx, base.TestSharedProcessTenantArgs{
+		_, c.DestTenantConn, err = c.DestCluster.Server(server).StartSharedProcessTenant(ctx, base.TestSharedProcessTenantArgs{
 			TenantID:    c.Args.DestTenantID,
 			TenantName:  c.Args.DestTenantName,
 			Knobs:       *withTestingKnobs,
@@ -179,7 +179,7 @@ func (c *TenantStreamingClusters) StartDestTenant(
 		require.NoError(c.T, err)
 	} else {
 		c.DestSysSQL.Exec(c.T, `ALTER TENANT $1 START SERVICE SHARED`, c.Args.DestTenantName)
-		c.DestTenantConn = c.DestCluster.Server(0).SystemLayer().SQLConn(c.T, "cluster:"+string(c.Args.DestTenantName)+"/defaultdb")
+		c.DestTenantConn = c.DestCluster.Server(server).SystemLayer().SQLConn(c.T, "cluster:"+string(c.Args.DestTenantName)+"/defaultdb")
 	}
 
 	c.DestTenantSQL = sqlutils.MakeSQLRunner(c.DestTenantConn)
@@ -189,7 +189,7 @@ func (c *TenantStreamingClusters) StartDestTenant(
 	// TODO (msbutler): consider granting the new tenant some capabilities.
 	c.DestSysSQL.Exec(c.T, `ALTER TENANT $1 SET CLUSTER SETTING sql.virtual_cluster.feature_access.zone_configs.enabled=true`, c.Args.DestTenantName)
 	c.DestSysSQL.Exec(c.T, `ALTER TENANT $1 GRANT CAPABILITY can_use_nodelocal_storage`, c.Args.DestTenantName)
-	require.NoError(c.T, c.DestCluster.Server(0).WaitForTenantCapabilities(ctx, c.Args.DestTenantID, map[tenantcapabilities.ID]string{
+	require.NoError(c.T, c.DestCluster.Server(server).WaitForTenantCapabilities(ctx, c.Args.DestTenantID, map[tenantcapabilities.ID]string{
 		tenantcapabilities.CanUseNodelocalStorage: "true",
 	}, ""))
 	return func() error {

--- a/pkg/ccl/streamingccl/streamingest/alter_replication_job_test.go
+++ b/pkg/ccl/streamingccl/streamingest/alter_replication_job_test.go
@@ -114,7 +114,7 @@ func TestAlterTenantPauseResume(t *testing.T) {
 	cutoverOutput := replicationtestutils.DecimalTimeToHLC(t, cutoverStr)
 	require.Equal(t, cutoverTime, cutoverOutput.GoTime())
 	jobutils.WaitForJobToSucceed(c.T, c.DestSysSQL, jobspb.JobID(ingestionJobID))
-	cleanupTenant := c.StartDestTenant(ctx, nil)
+	cleanupTenant := c.StartDestTenant(ctx, nil, 0)
 	defer func() {
 		require.NoError(t, cleanupTenant())
 	}()

--- a/pkg/ccl/streamingccl/streamingest/datadriven_test.go
+++ b/pkg/ccl/streamingccl/streamingest/datadriven_test.go
@@ -155,7 +155,7 @@ func TestDataDriven(t *testing.T) {
 					jobspb.JobID(ds.ingestionJobID))
 			case "start-replicated-tenant":
 				testingKnobs := replicationtestutils.DefaultAppTenantTestingKnobs()
-				cleanupTenant := ds.replicationClusters.StartDestTenant(ctx, &testingKnobs)
+				cleanupTenant := ds.replicationClusters.StartDestTenant(ctx, &testingKnobs, 0)
 				ds.cleanupFns = append(ds.cleanupFns, cleanupTenant)
 			case "let":
 				if len(d.CmdArgs) == 0 {


### PR DESCRIPTION
Manual backport of #112827

---

This patch changes the TestTenantStreamingMultipleNodes and TestTenantStreamingUnavailable tests to run on a single single host cluster, instead of two, which should reduce cpu contention and flakes.

Informs #112748

Release note: none

Release justification: test only change