### PR TITLE
c2c: set autoreplan threshold to 0.1

### DIFF
--- a/pkg/ccl/streamingccl/settings.go
+++ b/pkg/ccl/streamingccl/settings.go
@@ -85,7 +85,7 @@ var ReplanThreshold = settings.RegisterFloatSetting(
 	"stream_replication.replan_flow_threshold",
 	"fraction of nodes in the producer or consumer job that would need to change to refresh the"+
 		" physical execution plan. If set to 0, the physical plan will not automatically refresh.",
-	0,
+	0.1,
 	settings.NonNegativeFloatWithMaximum(1),
 	settings.WithName("physical_replication.consumer.replan_flow_threshold"),
 )


### PR DESCRIPTION
This patch turns on auto replanning by default. If the replanner detects that more than 10% of participating nodes are different in a proposed plan, c2c will replan.  We decided to turn on auto replanning by default after realizing it can help if c2c gets behind, such as during #112737.

Epic: none

Release note: none