### PR TITLE
kv: support Del and DelRange in GetResult

### DIFF
--- a/pkg/kv/batch.go
+++ b/pkg/kv/batch.go
@@ -1166,6 +1166,10 @@ func (b *Batch) bulkRequest(
 }
 
 // GetResult retrieves the Result and Result row KeyValue for a particular index.
+//
+// WARNING: introduce new usages of this function with care. See discussion in
+// https://github.com/cockroachdb/cockroach/pull/112937.
+// TODO(yuzefovich): look into removing this confusing function.
 func (b *Batch) GetResult(idx int) (*Result, KeyValue, error) {
 	origIdx := idx
 	for i := range b.Results {
@@ -1173,6 +1177,8 @@ func (b *Batch) GetResult(idx int) (*Result, KeyValue, error) {
 		if idx < r.calls {
 			if idx < len(r.Rows) {
 				return r, r.Rows[idx], nil
+			} else if idx < len(r.Keys) {
+				return r, KeyValue{Key: r.Keys[idx]}, nil
 			} else {
 				return r, KeyValue{}, nil
 			}

--- a/pkg/kv/db.go
+++ b/pkg/kv/db.go
@@ -131,7 +131,7 @@ type Result struct {
 	// Rows contains the key/value pairs for the operation. The number of rows
 	// returned varies by operation. For Get, Put, CPut, and Inc the number
 	// of rows returned is the number of keys operated on. For Scan the number of
-	// rows returned is the number or rows matching the scan capped by the
+	// rows returned is the number of rows matching the scan capped by the
 	// maxRows parameter and other options. For Del and DelRange Rows is nil.
 	Rows []KeyValue
 

--- a/pkg/kv/db_test.go
+++ b/pkg/kv/db_test.go
@@ -1157,7 +1157,7 @@ func TestBulkBatchAPI(t *testing.T) {
 	testF(func(b *kv.Batch) { b.CPutValuesEmpty(&byteSliceBulkSource[roachpb.Value]{kys, values}) })
 }
 
-func TestGetResults(t *testing.T) {
+func TestGetResult(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	s, db := setup(t)
@@ -1171,6 +1171,8 @@ func TestGetResults(t *testing.T) {
 	b := txn.NewBatch()
 	b.PutBytes(&byteSliceBulkSource[[]byte]{kys1, vals})
 	b.PutBytes(&byteSliceBulkSource[[]byte]{kys2, vals})
+	keyToDel := roachpb.Key("b")
+	b.Del(keyToDel)
 	err := txn.CommitInBatch(ctx, b)
 	require.NoError(t, err)
 	for i := 0; i < len(kys1)+len(kys2); i++ {
@@ -1179,12 +1181,17 @@ func TestGetResults(t *testing.T) {
 		require.Equal(t, row, b.Results[i/3].Rows[i%3])
 		require.NoError(t, err)
 	}
+	// test Del request (it uses Result.Keys rather than Result.Rows)
+	_, kv, err := b.GetResult(len(kys1) + len(kys2))
+	require.NoError(t, err)
+	require.Equal(t, keyToDel, kv.Key)
+	require.Nil(t, kv.Value)
 	// test EndTxn result
-	_, _, err = b.GetResult(len(kys1) + len(kys2))
+	_, _, err = b.GetResult(len(kys1) + len(kys2) + 1)
 	require.NoError(t, err)
 
 	// test out of bounds
-	_, _, err = b.GetResult(len(kys1) + len(kys2) + 1)
+	_, _, err = b.GetResult(len(kys1) + len(kys2) + 2)
 	require.Error(t, err)
 }
 


### PR DESCRIPTION
Previously, we only looked at `Result.Rows` in `Batch.GetResult`, but `Del` and `DelRange` requests put their "rows" into `Keys`, so this commit expands `GetResult` to support this. I found this while working on another issue, and although I don't think this omission was problematic, it seems nicer to complete the function (if only to prevent possible confusion in the future).

I did look into removing this confusing function altogether, but there were some issues and I forgot all the context. For now, I added a warning to use the function with care and left a TODO to remove it.

Epic: None

Release note: None