### PR TITLE
plpgsql: correctly parse UPSERT statements

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/udf_plpgsql
+++ b/pkg/sql/logictest/testdata/logic_test/udf_plpgsql
@@ -2320,4 +2320,59 @@ $$ LANGUAGE PLpgSQL;
 statement error pgcode 22004 pq: null_value_not_allowed
 SELECT f();
 
+# Regression test for #112940 - UPSERT INTO should be allowed.
+subtest upsert_into
+
+statement ok
+BEGIN;
+
+query II rowsort
+SELECT * FROM xy;
+----
+1  2
+3  4
+
+statement ok
+DROP FUNCTION f();
+CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$
+  BEGIN
+    UPSERT INTO xy VALUES (100, 200);
+    RETURN 0;
+  END
+$$ LANGUAGE PLpgSQL;
+SELECT f();
+
+query II rowsort
+SELECT * FROM xy;
+----
+1    2
+3    4
+100  200
+
+statement ok
+CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$
+  DECLARE
+    a INT;
+  BEGIN
+    UPSERT INTO xy VALUES (300, 400) RETURNING y, x INTO a;
+    RETURN a;
+  END
+$$ LANGUAGE PLpgSQL;
+
+query I
+SELECT f();
+----
+400
+
+query II rowsort
+SELECT * FROM xy;
+----
+1    2
+3    4
+100  200
+300  400
+
+statement ok
+ABORT;
+
 subtest end

--- a/pkg/sql/plpgsql/parser/lexer.go
+++ b/pkg/sql/plpgsql/parser/lexer.go
@@ -144,8 +144,10 @@ func (l *lexer) MakeExecSqlStmt() (*plpgsqltree.Execute, error) {
 		prevTok := tok
 		tok = l.tokens[pos]
 		if tok.id == INTO {
-			if prevTok.id == INSERT || prevTok.id == MERGE || firstTok.id == IMPORT {
-				// INSERT INTO, MERGE INTO, and IMPORT ... INTO are not INTO-targets.
+			if prevTok.id == INSERT || prevTok.id == UPSERT ||
+				prevTok.id == MERGE || firstTok.id == IMPORT {
+				// INSERT INTO, UPSERT INTO, MERGE INTO, and IMPORT ... INTO are not
+				// INTO-targets.
 				continue
 			}
 			if haveInto {

--- a/pkg/sql/plpgsql/parser/plpgsql.y
+++ b/pkg/sql/plpgsql/parser/plpgsql.y
@@ -294,6 +294,7 @@ func (u *plpgsqlSymUnion) sqlStatement() tree.Statement {
 %token <str>  THEN
 %token <str>  TO
 %token <str>  TYPE
+%token <str>  UPSERT
 %token <str>  USE_COLUMN
 %token <str>  USE_VARIABLE
 %token <str>  USING
@@ -1279,6 +1280,7 @@ stmt_execsql: stmt_execsql_start
 stmt_execsql_start:
   IMPORT
 | INSERT
+| UPSERT
 | MERGE
 | IDENT
 ;
@@ -1601,6 +1603,7 @@ unreserved_keyword:
 | TABLE
 | TABLE_NAME
 | TYPE
+| UPSERT
 | USE_COLUMN
 | USE_VARIABLE
 | VARIABLE_CONFLICT

--- a/pkg/sql/plpgsql/parser/testdata/stmt_exec_sql
+++ b/pkg/sql/plpgsql/parser/testdata/stmt_exec_sql
@@ -155,3 +155,34 @@ BEGIN
 END
 ----
 at or near "EOF": syntax error: mismatched parentheses
+
+# Regression test for #112940 - UPSERT INTO should be allowed.
+parse
+DECLARE
+BEGIN
+  UPSERT INTO t1 VALUES (1,2) RETURNING x INTO y;
+END
+----
+DECLARE
+BEGIN
+UPSERT INTO t1 VALUES (1, 2) RETURNING x INTO y;
+END
+
+parse
+DECLARE
+BEGIN
+  UPSERT INTO t1 VALUES (1,2) RETURNING x INTO STRICT y;
+END
+----
+DECLARE
+BEGIN
+UPSERT INTO t1 VALUES (1, 2) RETURNING x INTO STRICT y;
+END
+
+parse
+DECLARE
+BEGIN
+  UPSERT INTO t1 VALUES (1,2) INTO y;
+END
+----
+at or near ";": syntax error: INTO used with a command that cannot return data


### PR DESCRIPTION
PLpgSQL has a special `INTO` clause that allows assigning the output of a SQL statement to a set of PLpgSQL variables. This complicates parsing of some SQL statements within a PLpgSQL block, since an `INTO` token may be a PLpgSQL `INTO`, or it may be part of a SQL statement like `INSERT INTO` or `IMPORT INTO`. These cases are handled specially, since there are relatively few of them.

Previously, we forgot to add this special handling for the case of `UPSERT INTO`, prevented execution of `UPSERT` statements within a PLpgSQL routine. This patch adds `UPSERT` to the list of special cases.

Fixes #112940

Release note: None