### PR TITLE
kvserver: gate writing the new sticky GCHint

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_delete_range.go
+++ b/pkg/kv/kvserver/batcheval/cmd_delete_range.go
@@ -21,10 +21,20 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/lockspanset"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/spanset"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/errors"
+)
+
+// enableStickyGCHint controls whether the sticky GCHint is enabled.
+var enableStickyGCHint = settings.RegisterBoolSetting(
+	settings.SystemOnly,
+	"kv.gc.sticky_hint.enabled",
+	"enable writing sticky GC hints which expedite garbage collection after schema changes"+
+		" (ignored and assumed 'true' in 23.2)",
+	false,
 )
 
 func init() {
@@ -135,8 +145,11 @@ func DeleteRange(
 				return err
 			}
 
-			// Add the timestamp to GCHint to guarantee that GC eventually clears it.
-			updated := hint.ScheduleGCFor(h.Timestamp)
+			updated := false
+			if enableStickyGCHint.Get(&cArgs.EvalCtx.ClusterSettings().SV) {
+				// Add the timestamp to GCHint to guarantee that GC eventually clears it.
+				updated = hint.ScheduleGCFor(h.Timestamp)
+			}
 			// If the range tombstone covers the whole Range key span, update the
 			// corresponding timestamp in GCHint to enable ClearRange optimization.
 			if args.Key.Equal(desc.StartKey.AsRawKey()) && args.EndKey.Equal(desc.EndKey.AsRawKey()) {

--- a/pkg/kv/kvserver/batcheval/cmd_delete_range.go
+++ b/pkg/kv/kvserver/batcheval/cmd_delete_range.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/batcheval/result"
@@ -146,7 +147,10 @@ func DeleteRange(
 			}
 
 			updated := false
-			if enableStickyGCHint.Get(&cArgs.EvalCtx.ClusterSettings().SV) {
+			// TODO(pavelkalinnikov): deprecate the cluster setting and call
+			// ScheduleGCFor unconditionally when min supported version is 23.2.
+			if cArgs.EvalCtx.ClusterSettings().Version.IsActive(ctx, clusterversion.V23_2) ||
+				enableStickyGCHint.Get(&cArgs.EvalCtx.ClusterSettings().SV) {
 				// Add the timestamp to GCHint to guarantee that GC eventually clears it.
 				updated = hint.ScheduleGCFor(h.Timestamp)
 			}

--- a/pkg/kv/kvserver/batcheval/cmd_delete_range.go
+++ b/pkg/kv/kvserver/batcheval/cmd_delete_range.go
@@ -147,7 +147,7 @@ func DeleteRange(
 				return nil
 			}
 
-			if updated, err := sl.SetGCHint(ctx, readWriter, cArgs.Stats, hint); err != nil || !updated {
+			if err := sl.SetGCHint(ctx, readWriter, cArgs.Stats, hint); err != nil {
 				return err
 			}
 			res.Replicated.State = &kvserverpb.ReplicaState{

--- a/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
+++ b/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
@@ -1355,14 +1355,11 @@ func mergeTrigger(
 			return result.Result{}, err
 		}
 		if lhsHint.Merge(rhsHint, rec.GetMVCCStats().HasNoUserData(), merge.RightMVCCStats.HasNoUserData()) {
-			updated, err := lhsLoader.SetGCHint(ctx, batch, ms, lhsHint)
-			if err != nil {
+			if err := lhsLoader.SetGCHint(ctx, batch, ms, lhsHint); err != nil {
 				return result.Result{}, err
 			}
-			if updated {
-				pd.Replicated.State = &kvserverpb.ReplicaState{
-					GCHint: lhsHint,
-				}
+			pd.Replicated.State = &kvserverpb.ReplicaState{
+				GCHint: lhsHint,
 			}
 		}
 	}

--- a/pkg/kv/kvserver/batcheval/cmd_gc.go
+++ b/pkg/kv/kvserver/batcheval/cmd_gc.go
@@ -285,7 +285,7 @@ func GC(
 				res.Replicated.State = &kvserverpb.ReplicaState{}
 			}
 			res.Replicated.State.GCHint = hint
-			if _, err := sl.SetGCHint(ctx, readWriter, cArgs.Stats, hint); err != nil {
+			if err := sl.SetGCHint(ctx, readWriter, cArgs.Stats, hint); err != nil {
 				return result.Result{}, err
 			}
 		}

--- a/pkg/kv/kvserver/stateloader/stateloader.go
+++ b/pkg/kv/kvserver/stateloader/stateloader.go
@@ -124,7 +124,7 @@ func (rsl StateLoader) Save(
 	if err := rsl.SetGCThreshold(ctx, readWriter, ms, state.GCThreshold); err != nil {
 		return enginepb.MVCCStats{}, err
 	}
-	if _, err := rsl.SetGCHint(ctx, readWriter, ms, state.GCHint); err != nil {
+	if err := rsl.SetGCHint(ctx, readWriter, ms, state.GCHint); err != nil {
 		return enginepb.MVCCStats{}, err
 	}
 	// TODO(sep-raft-log): SetRaftTruncatedState will be in a separate batch when
@@ -327,15 +327,12 @@ func (rsl StateLoader) LoadGCHint(
 // SetGCHint writes the GC hint.
 func (rsl StateLoader) SetGCHint(
 	ctx context.Context, readWriter storage.ReadWriter, ms *enginepb.MVCCStats, hint *roachpb.GCHint,
-) (updated bool, _ error) {
+) error {
 	if hint == nil {
-		return false, errors.New("cannot persist nil GCHint")
+		return errors.New("cannot persist nil GCHint")
 	}
-	if err := storage.MVCCPutProto(ctx, readWriter, rsl.RangeGCHintKey(),
-		hlc.Timestamp{}, hint, storage.MVCCWriteOptions{Stats: ms}); err != nil {
-		return false, err
-	}
-	return true, nil
+	return storage.MVCCPutProto(ctx, readWriter, rsl.RangeGCHintKey(),
+		hlc.Timestamp{}, hint, storage.MVCCWriteOptions{Stats: ms})
 }
 
 // LoadVersion loads the replica version.


### PR DESCRIPTION
This PR makes the new behaviour of `GCHint` introduced in #110078 conditional on a default-off cluster setting in 23.1, and enabled in 23.2 by a version gate.

Since it is late to enable this behaviour in 23.1 (risk of backwards incompatibility), hide it behind a default-off cluster setting. In 23.2, it will be enabled by default, and the cluster setting will be deprecated.

The new `GCHint` behaviour is likely backwards compatible, but we are hiding it behind a setting for extra safety.

The safest moment to enable this cluster setting is when there is some confidence that the cluster binaries will not rollback to previous patch versions of 23.1. The risk exists only in mixed-version state in which some 23.1 binaries don't know the new `GCHint` fields, and some do.

Epic: none

Release note (ops change): introduce a default-off cluster setting `kv.gc.sticky_hint.enabled` which helps expediting garbage collection after range deletions, such as when a SQL table or index is dropped.

Release note (general change): set the default behaviour for `kv.gc.sticky_hint.enabled` cluster setting to enabled since 23.2. The setting is deprecated in 23.2 going forward.