### PR TITLE
upgrade: Tune upgradeinterlockccl TTL for stress

### DIFF
--- a/pkg/sql/sqlliveness/slstorage/slstorage.go
+++ b/pkg/sql/sqlliveness/slstorage/slstorage.go
@@ -540,7 +540,7 @@ func (s *Storage) Insert(
 		s.metrics.WriteFailures.Inc(1)
 		return errors.Wrapf(err, "could not insert session %s", sid)
 	}
-	log.Infof(ctx, "inserted sqlliveness session %s", sid)
+	log.Infof(ctx, "inserted sqlliveness session %s with expiry %s", sid, expiration)
 	s.metrics.WriteSuccesses.Inc(1)
 	return nil
 }


### PR DESCRIPTION
The upgradeinterlockccl tests tune the TTL and heartbeat settings to ensure that failed SQL instances are cleaned up aggressively (since the tests cause SQL server failures and then wait for them to be resolved). When machines get stressed, we see instances where given SQL instances can't heartbeat fast enough to preserve their session, and the TTL job cleans the up unexpectedly. This causes the tests to fail in unpredictable ways.

This commit extends the current TTL and attempts to heartbeat more frequently, so that the heartbeat will hopefully occur before the TTL expiry is reached. On my local machine, where I could reproduce this problem fairly easily, the new settings allow the test to succeed under stress.

Release note: None

Release justification: Test-only fix

Fixes: #112813