### PR TITLE
sqlstats: fix TestInsightsIntegration

### DIFF
--- a/pkg/sql/sqlstats/insights/integration/insights_test.go
+++ b/pkg/sql/sqlstats/insights/integration/insights_test.go
@@ -55,6 +55,7 @@ func TestInsightsIntegration(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	const appName = "TestInsightsIntegration"
+	const appNameToIgnore = "TestInsightsIntegrationIgnore"
 
 	// Start the cluster. (One node is sufficient; the outliers system is currently in-memory only.)
 	ctx := context.Background()
@@ -68,7 +69,7 @@ func TestInsightsIntegration(t *testing.T) {
 	latencyThreshold := 250 * time.Millisecond
 	insights.LatencyThreshold.Override(ctx, &settings.SV, latencyThreshold)
 
-	_, err := conn.ExecContext(ctx, "SET SESSION application_name=$1", appName)
+	_, err := conn.ExecContext(ctx, "SET SESSION application_name=$1", appNameToIgnore)
 	require.NoError(t, err)
 
 	// See no recorded insights.
@@ -81,8 +82,16 @@ func TestInsightsIntegration(t *testing.T) {
 	require.Equal(t, 0, count, "expect:0, actual:%d, queries:%s", count, queryText)
 
 	queryDelayInSeconds := latencyThreshold.Seconds()
+	_, err = conn.ExecContext(ctx, "SET SESSION application_name=$1", appName)
+	require.NoError(t, err)
+
 	// Execute a "long-running" statement, running longer than our latencyThreshold.
+	// Use a specific app name just for this query, and ignore the other statements, since
+	// the select used to check the values can end up or not as part of the Insights view.
 	_, err = conn.ExecContext(ctx, "SELECT pg_sleep($1)", queryDelayInSeconds)
+	require.NoError(t, err)
+
+	_, err = conn.ExecContext(ctx, "SET SESSION application_name=$1", appNameToIgnore)
 	require.NoError(t, err)
 
 	// Eventually see one recorded insight.


### PR DESCRIPTION
Fix #112875

This test was using the same app name for the query being tested, but also for the select being done by the test itself, which meant that is the select took longer, it could also be added to the Insights list.
This commit updates the test, so that the query that we want to check is the only using that specific app name, and the select being done for the test check itself won't matter.

Release note: None