### PR TITLE
sql: make `jsonb_array_to_string_array` return NULL elements

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -337,7 +337,7 @@
 </span></td><td>Immutable</td></tr>
 <tr><td><a name="cardinality"></a><code>cardinality(input: anyelement[]) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Calculates the number of elements contained in <code>input</code></p>
 </span></td><td>Immutable</td></tr>
-<tr><td><a name="jsonb_array_to_string_array"></a><code>jsonb_array_to_string_array(input: jsonb) &rarr; <a href="string.html">string</a>[]</code></td><td><span class="funcdesc"><p>Convert a JSONB array into a string array, removing ‘null’ elements.</p>
+<tr><td><a name="jsonb_array_to_string_array"></a><code>jsonb_array_to_string_array(input: jsonb) &rarr; <a href="string.html">string</a>[]</code></td><td><span class="funcdesc"><p>Convert a JSONB array into a string array.</p>
 </span></td><td>Immutable</td></tr>
 <tr><td><a name="string_to_array"></a><code>string_to_array(str: <a href="string.html">string</a>, delimiter: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a>[]</code></td><td><span class="funcdesc"><p>Split a string into components on a delimiter.</p>
 </span></td><td>Immutable</td></tr>

--- a/pkg/sql/logictest/testdata/logic_test/array
+++ b/pkg/sql/logictest/testdata/logic_test/array
@@ -1228,12 +1228,12 @@ SELECT jsonb_array_to_string_array('[true, false, false, true]':::JSONB)
 query T
 SELECT jsonb_array_to_string_array('[null]':::JSONB)
 ----
-{}
+{NULL}
 
 query T
-SELECT jsonb_array_to_string_array('["foo", null]':::JSONB)
+SELECT jsonb_array_to_string_array('[1, "abc", true, ["a", "b"], {"b": "foo"}, null]':::JSONB)
 ----
-{foo}
+{1,abc,true,"[\"a\", \"b\"]","{\"b\": \"foo\"}",NULL}
 
 # Regression test for #23429.
 

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -3571,11 +3571,16 @@ value if you rely on the HLC for accuracy.`,
 						if err != nil {
 							return nil, err
 						}
+					} else {
+						err = strArray.Append(tree.DNull)
+						if err != nil {
+							return nil, err
+						}
 					}
 				}
 				return strArray, nil
 			},
-			Info:              "Convert a JSONB array into a string array, removing 'null' elements.",
+			Info:              "Convert a JSONB array into a string array.",
 			Volatility:        volatility.Immutable,
 			CalledOnNullInput: true,
 		}),


### PR DESCRIPTION
This commit makes the builtin `jsonb_array_to_string_array` return NULL elements, which were previously being removed. It also adds more testing for different types of elements on the array.

Followup from https://github.com/cockroachdb/cockroach/pull/112865#pullrequestreview-1695142250

Epic: none

Release note (sql change): The newly added builting jsonb_array_to_string_array no longer removes NULL objects and includes them into the resulting array.