### PR TITLE
scexec: remember to set `invertedIndexKinds` field for `AddIndexColumn` op

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/trigram_indexes
+++ b/pkg/sql/logictest/testdata/logic_test/trigram_indexes
@@ -311,3 +311,27 @@ query T
 SELECT t FROM t89609@idx WHERE t::STRING % 'aab';
 ----
 aaaaaa
+
+subtest end
+
+# Regression test for issue #112713
+subtest 112713
+
+statement ok
+CREATE TABLE t_112713 (i INT PRIMARY KEY, t STRING, FAMILY (i, t));
+
+statement ok
+CREATE INVERTED INDEX ON t_112713 (t gin_trgm_ops);
+
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE t_112713];
+----
+CREATE TABLE public.t_112713 (
+    i INT8 NOT NULL,
+    t STRING NULL,
+    CONSTRAINT t_112713_pkey PRIMARY KEY (i ASC),
+    INVERTED INDEX t_112713_t_idx (t gin_trgm_ops),
+    FAMILY fam_0_i_t (i, t)
+)
+
+subtest end

--- a/pkg/sql/schemachanger/scexec/scmutationexec/index.go
+++ b/pkg/sql/schemachanger/scexec/scmutationexec/index.go
@@ -411,6 +411,10 @@ func (i *immediateVisitor) AddColumnToIndex(ctx context.Context, op scop.AddColu
 			return colOrdMap.GetDefault(cids[i]) < colOrdMap.GetDefault(cids[j])
 		})
 	}
+	// If this is an inverted column, note that.
+	if indexDesc.Type == descpb.IndexDescriptor_INVERTED && op.ColumnID == indexDesc.InvertedColumnID() {
+		indexDesc.InvertedColumnKinds = append(indexDesc.InvertedColumnKinds, op.InvertedKind)
+	}
 	return nil
 }
 

--- a/pkg/sql/schemachanger/schemachanger_test.go
+++ b/pkg/sql/schemachanger/schemachanger_test.go
@@ -838,6 +838,8 @@ func TestCompareLegacyAndDeclarative(t *testing.T) {
 			"DROP TABLE IF EXISTS t1, t2;",
 			"CREATE TABLE t1 (rowid INT NOT NULL);",
 			"ALTER TABLE t1 ALTER PRIMARY KEY USING COLUMNS (rowid); -- special case where column name `rowid` is used",
+			"CREATE TABLE t8 (i INT PRIMARY KEY, j STRING);",
+			"CREATE INVERTED INDEX ON t8 (j gin_trgm_ops);",
 
 			// Statements expected to fail.
 			"CREATE TABLE t1 (); -- expect a DuplicateRelation error",

--- a/pkg/sql/schemachanger/scplan/internal/opgen/opgen_index_column.go
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/opgen_index_column.go
@@ -21,12 +21,13 @@ func init() {
 			scpb.Status_ABSENT,
 			to(scpb.Status_PUBLIC, emit(func(column *scpb.IndexColumn) *scop.AddColumnToIndex {
 				return &scop.AddColumnToIndex{
-					TableID:   column.TableID,
-					ColumnID:  column.ColumnID,
-					IndexID:   column.IndexID,
-					Kind:      column.Kind,
-					Direction: column.Direction,
-					Ordinal:   column.OrdinalInKind,
+					TableID:      column.TableID,
+					ColumnID:     column.ColumnID,
+					IndexID:      column.IndexID,
+					Kind:         column.Kind,
+					Direction:    column.Direction,
+					Ordinal:      column.OrdinalInKind,
+					InvertedKind: column.InvertedKind,
 				}
 			})),
 		),

--- a/pkg/sql/schemachanger/scplan/testdata/create_index
+++ b/pkg/sql/schemachanger/scplan/testdata/create_index
@@ -478,6 +478,7 @@ StatementPhase stage 1 of 1 with 7 MutationType ops
     *scop.AddColumnToIndex
       ColumnID: 2
       IndexID: 2
+      InvertedKind: 1
       Ordinal: 1
       TableID: 104
     *scop.SetIndexName
@@ -500,6 +501,7 @@ StatementPhase stage 1 of 1 with 7 MutationType ops
     *scop.AddColumnToIndex
       ColumnID: 2
       IndexID: 3
+      InvertedKind: 1
       Ordinal: 1
       TableID: 104
 PreCommitPhase stage 1 of 2 with 1 MutationType op
@@ -545,6 +547,7 @@ PreCommitPhase stage 2 of 2 with 11 MutationType ops
     *scop.AddColumnToIndex
       ColumnID: 2
       IndexID: 2
+      InvertedKind: 1
       Ordinal: 1
       TableID: 104
     *scop.SetIndexName
@@ -570,6 +573,7 @@ PreCommitPhase stage 2 of 2 with 11 MutationType ops
     *scop.AddColumnToIndex
       ColumnID: 2
       IndexID: 3
+      InvertedKind: 1
       Ordinal: 1
       TableID: 104
     *scop.SetJobStateOnDescriptor


### PR DESCRIPTION
Previously, when we executed an `AddIndexColumn` operation, we forgot to set the field `invertedIndexKinds` in the index descriptor if the column is an inverted column. This commit fixes that.

Fixes #112713
Release note (bug fix): Fixed a bug where if we create a trigram index and later display it via SHOW CREATE TABLE, the opclass for this trigram index is not shown.