### PR TITLE
scripts/gceworker: increase default disk size to 250GB

### DIFF
--- a/scripts/gceworker.sh
+++ b/scripts/gceworker.sh
@@ -45,7 +45,7 @@ case "${cmd}" in
            --maintenance-policy "MIGRATE" \
            --image-project "ubuntu-os-cloud" \
            --image-family "ubuntu-2004-lts" \
-           --boot-disk-size "100" \
+           --boot-disk-size "250" \
            --boot-disk-type "pd-ssd" \
            --boot-disk-device-name "${NAME}" \
            --scopes "cloud-platform" \


### PR DESCRIPTION
The full test suite requires more than 100GB to compile and run on a GCE
worker, so this commit increases the default disk size from 100GB to
250GB.

Epic: None

Release note: None
