### PR TITLE
tests: Fix a bug in `schemachange/mixed-versions-compat` where corpus is not found

### DIFF
--- a/pkg/cmd/roachtest/tests/mixed_version_decl_schemachange_compat.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_decl_schemachange_compat.go
@@ -161,9 +161,10 @@ func runDeclSchemaChangeCompatMixedVersions(ctx context.Context, t test.Test, c 
 			corpusVersion: fmt.Sprintf("release-%s", releaseSeries(predecessorVersion)),
 		},
 		{
-			testName:      "same version",
-			binaryVersion: currentVersion,
-			corpusVersion: fmt.Sprintf("release-%s", releaseSeries(currentVersion)),
+			testName:               "same version",
+			binaryVersion:          currentVersion,
+			corpusVersion:          fmt.Sprintf("release-%s", releaseSeries(currentVersion)),
+			alternateCorpusVersion: "master",
 		},
 	}
 	for _, testInfo := range compatTests {


### PR DESCRIPTION
A recent change (#112568) incorrectly deleted some code in this
roachtest resulting in its failing ever since. The issue is that the
test attempts to fetch the corpus collected from the "latest" binary, which
was previously set to `release-24.1` *or* `master`. That recent change
deleted `master` so that the test fails bc the corpus entry for
`release-24.1` does not exist (instead, we should use the corpus entry
for `master` in this case).

Fixes #112376
Release note: None