### PR TITLE
kvserver: setup ranges in large unsplittable replicate test

### DIFF
--- a/pkg/kv/kvserver/replicate_queue_test.go
+++ b/pkg/kv/kvserver/replicate_queue_test.go
@@ -1811,21 +1811,6 @@ func TestLargeUnsplittableRangeReplicate(t *testing.T) {
 	toggleReplicationQueues(tc, true /* active */)
 	toggleSplitQueues(tc, true /* active */)
 
-	// Check that the two ranges exist for table t.
-	testutils.SucceedsSoon(t, func() error {
-		r := db.QueryRow(
-			"SELECT count(*) FROM [SHOW RANGES FROM TABLE t]")
-		var count int
-		if err := r.Scan(&count); err != nil {
-			return err
-		}
-		if count != 2 {
-			return fmt.Errorf(
-				"splits not created, expected %d ranges, found %d", 2, count)
-		}
-		return nil
-	})
-
 	// We're going to create a large row, but now large enough that write
 	// back-pressuring kicks in and refuses it.
 	var sb strings.Builder


### PR DESCRIPTION
`TestLargeUnsplittableRangeReplicate` would fail when the SQL query to
show the table's replicas returned no results for the unsplittable range
being tested. No results would be returned when the table split was
delayed.

Update the test to insert a split at the first row, as well as the
existing split at the second row. This avoids the first range starting
with 5 replicas and the test's reliance on timely span config splits.

The previous deflake attempt is reverted.

Resolves: https://github.com/cockroachdb/cockroach/issues/112774
Release note: None