### PR TITLE
kvclient: draining not started SQL

### DIFF
--- a/pkg/server/drain.go
+++ b/pkg/server/drain.go
@@ -462,11 +462,13 @@ func (s *drainServer) drainClients(
 	if err != nil {
 		return err
 	}
-
-	instanceID := s.sqlServer.sqlIDContainer.SQLInstanceID()
-	err = s.sqlServer.sqlInstanceStorage.ReleaseInstance(ctx, session, instanceID)
-	if err != nil {
-		return err
+	// If we started a sql session on this node.
+	if session != "" {
+		instanceID := s.sqlServer.sqlIDContainer.SQLInstanceID()
+		err = s.sqlServer.sqlInstanceStorage.ReleaseInstance(ctx, session, instanceID)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Mark the node as fully drained.

--- a/pkg/sql/sqlliveness/slinstance/slinstance.go
+++ b/pkg/sql/sqlliveness/slinstance/slinstance.go
@@ -457,7 +457,7 @@ func (l *Instance) Release(ctx context.Context) (sqlliveness.SessionID, error) {
 	}()
 
 	if session == nil {
-		return sqlliveness.SessionID(""), errors.New("no session to release")
+		return "", nil
 	}
 
 	if err := l.storage.Delete(ctx, session.ID()); err != nil {


### PR DESCRIPTION
Previously a drain would assume the SQL instance had been started on a node prior to draining. This would result in a failure if the node attempting to drain had never started SQL.

Epic: none

Release note: None