### PR TITLE
pkg/cli: update the delayed tenant id watcher to be more robust

### DIFF
--- a/pkg/cli/cliflags/flags_mt.go
+++ b/pkg/cli/cliflags/flags_mt.go
@@ -20,11 +20,10 @@ var (
 
 	TenantIDFile = FlagInfo{
 		Name: "tenant-id-file",
-		Description: `Allows sourcing the tenant id from a file. The tenant id will
-be expected to be by itself on the first line of the file. The file has to exist
-on startup but may be empty or have partial id without ending newline. In this 
-case the tenant server will block and wait for the tenant id to be fully written 
-to the file.`,
+		Description: `Allows sourcing the tenant id from a file. The tenant id
+will be expected to be by itself on the first line of the file. If the file does
+not exist, or if the tenant id is incomplete, the tenant server will block, and
+wait for the tenant id to be fully written to the file (with a newline character).`,
 	}
 
 	KVAddrs = FlagInfo{

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -500,8 +500,8 @@ func runStartInternal(
 	// Check the --tenant-id-file flag.
 	if fl := cliflagcfg.FlagSetForCmd(cmd).Lookup(cliflags.TenantIDFile.Name); fl != nil && fl.Changed {
 		fileName := fl.Value.String()
-		serverCfg.DelayedSetTenantID = func() (roachpb.TenantID, error) {
-			return tenantIDFromFile(fileName, nil, nil)
+		serverCfg.DelayedSetTenantID = func(ctx context.Context) (roachpb.TenantID, error) {
+			return tenantIDFromFile(ctx, fileName, nil, nil, nil)
 		}
 	}
 

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -497,7 +497,7 @@ type SQLConfig struct {
 	TenantID roachpb.TenantID
 
 	// If set, will to be called at server startup to obtain the tenant id.
-	DelayedSetTenantID func() (roachpb.TenantID, error)
+	DelayedSetTenantID func(context.Context) (roachpb.TenantID, error)
 
 	// TempStorageConfig is used to configure temp storage, which stores
 	// ephemeral data when processing large queries.

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -289,7 +289,7 @@ func newTenantServer(
 	// case, DelayedSetTenantID will be set and should be used to populate
 	// TenantID in the config. We call it here as we need a valid TenantID below.
 	if sqlCfg.DelayedSetTenantID != nil {
-		cfgTenantID, err := sqlCfg.DelayedSetTenantID()
+		cfgTenantID, err := sqlCfg.DelayedSetTenantID(ctx)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/server/tenant_delayed_id_set_test.go
+++ b/pkg/server/tenant_delayed_id_set_test.go
@@ -64,7 +64,7 @@ func TestStartTenantWithDelayedID(t *testing.T) {
 	listenerReady.Add(1)
 
 	var timeTenantIDSet time.Time
-	sqlCfg.DelayedSetTenantID = func() (roachpb.TenantID, error) {
+	sqlCfg.DelayedSetTenantID = func(ctx context.Context) (roachpb.TenantID, error) {
 		// Unblock the connect code bellow, so it can try to connect.
 		listenerReady.Done()
 		// Wait until getting a go ahead with setting the tenant id.


### PR DESCRIPTION
Follow up to https://github.com/cockroachdb/cockroach/pull/110082.

Previously, the fsnotify watcher was set up to point at the tenant ID file.

This caused several issues:
1. The file has to exist before starting the watcher (i.e. during process
   startup), or else the watcher will fail to start. Callers would have to
   create an empty file manually to address this.
2. We cannot perform atomic writes on the tenant ID file. The moment we run
   a unix rename(2) operation, the watcher would break. This also means that
   the existing fsnotify watcher only supports normal write calls.

This commit updates the delayed tenant ID watcher to be more robust by
establishing the watch on the directory instead of the file itself, which
should address the two main issues noted above. If the file does not exist,
the watcher proceeds to wait for a creation event for it. Note that the
existing tenant ID file format remains (i.e. the file has to include the
tenant ID on the first line, followed by a newline character. Anything after
the newline character will be discarded.)

No release note as this is only used by CockroachDB Cloud internally.

Epic: [CC-8504](https://cockroachlabs.atlassian.net/browse/CC-8504)

Release note: None