### PR TITLE
clusterversion: benchmark and rm Unmarshal allocs

### DIFF
--- a/pkg/clusterversion/setting.go
+++ b/pkg/clusterversion/setting.go
@@ -137,7 +137,7 @@ func (cv *clusterVersionSetting) activeVersionOrEmpty(
 		return ClusterVersion{}
 	}
 	var curVer ClusterVersion
-	if err := protoutil.Unmarshal(encoded.([]byte), &curVer); err != nil {
+	if err := curVer.Unmarshal(encoded.([]byte)); err != nil {
 		log.Fatalf(ctx, "%v", err)
 	}
 	return curVer

--- a/pkg/clusterversion/setting.go
+++ b/pkg/clusterversion/setting.go
@@ -154,7 +154,7 @@ func (cv *clusterVersionSetting) isActive(
 // Decode is part of the VersionSettingImpl interface.
 func (cv *clusterVersionSetting) Decode(val []byte) (settings.ClusterVersionImpl, error) {
 	var clusterVersion ClusterVersion
-	if err := protoutil.Unmarshal(val, &clusterVersion); err != nil {
+	if err := clusterVersion.Unmarshal(val); err != nil {
 		return nil, err
 	}
 	return clusterVersion, nil
@@ -165,7 +165,7 @@ func (cv *clusterVersionSetting) ValidateVersionUpgrade(
 	_ context.Context, sv *settings.Values, curRawProto, newRawProto []byte,
 ) error {
 	var newCV ClusterVersion
-	if err := protoutil.Unmarshal(newRawProto, &newCV); err != nil {
+	if err := newCV.Unmarshal(newRawProto); err != nil {
 		return err
 	}
 
@@ -174,7 +174,7 @@ func (cv *clusterVersionSetting) ValidateVersionUpgrade(
 	}
 
 	var oldCV ClusterVersion
-	if err := protoutil.Unmarshal(curRawProto, &oldCV); err != nil {
+	if err := oldCV.Unmarshal(curRawProto); err != nil {
 		return err
 	}
 
@@ -210,7 +210,7 @@ func (cv *clusterVersionSetting) ValidateBinaryVersions(
 	}()
 
 	var ver ClusterVersion
-	if err := protoutil.Unmarshal(rawProto, &ver); err != nil {
+	if err := ver.Unmarshal(rawProto); err != nil {
 		return err
 	}
 	return cv.validateBinaryVersions(ver.Version, sv)

--- a/pkg/clusterversion/setting.go
+++ b/pkg/clusterversion/setting.go
@@ -137,6 +137,9 @@ func (cv *clusterVersionSetting) activeVersionOrEmpty(
 		return ClusterVersion{}
 	}
 	var curVer ClusterVersion
+	// NB: our linter requires using protoutil.Unmarshal here, but it causes an
+	// unnecessary allocation. This and other uses in this file are exceptions.
+	// TODO(pavelkalinnikov): don't parse proto on each time reading this setting.
 	if err := curVer.Unmarshal(encoded.([]byte)); err != nil {
 		log.Fatalf(ctx, "%v", err)
 	}

--- a/pkg/clusterversion/setting_test.go
+++ b/pkg/clusterversion/setting_test.go
@@ -60,3 +60,13 @@ func TestMakeMetricsAndRegisterOnVersionChangeCallback(t *testing.T) {
 		return nil
 	})
 }
+
+func BenchmarkClusterVersionSettingIsActive(b *testing.B) {
+	s := cluster.MakeTestingClusterSettingsWithVersions(clusterversion.TestingBinaryVersion, clusterversion.TestingBinaryMinSupportedVersion, true)
+	ctx := context.Background()
+	active := true
+	for i := 0; i < b.N; i++ {
+		active = s.Version.IsActive(ctx, clusterversion.VCurrent_Start) && active
+	}
+	require.True(b, active)
+}

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -1271,6 +1271,7 @@ func TestLint(t *testing.T) {
 			"--",
 			"*.go",
 			":!*.pb.go",
+			":!clusterversion/setting.go",
 			":!util/protoutil/marshal.go",
 			":!util/protoutil/marshaler.go",
 			":!util/encoding/encoding.go",


### PR DESCRIPTION
Currently, each `IsActive` does a memory allocation:

```
==================== Test output for //pkg/clusterversion:clusterversion_test:
goos: darwin
goarch: arm64
BenchmarkClusterVersionSettingIsActive
BenchmarkClusterVersionSettingIsActive-10       28778041                42.03 ns/op           16 B/op          1 allocs/op
PASS
```

Since the cluster version check is in many hot paths, we should eliminate this allocation.

After:

```
==================== Test output for //pkg/clusterversion:clusterversion_test:
goos: darwin
goarch: arm64
BenchmarkClusterVersionSettingIsActive
BenchmarkClusterVersionSettingIsActive-10       45417914                26.43 ns/op            0 B/op          0 allocs/op
PASS
```

Touches #111561
Epic: none
Release note: none