### PR TITLE
storage: expose new compaction concurrency env var

### DIFF
--- a/pkg/storage/BUILD.bazel
+++ b/pkg/storage/BUILD.bazel
@@ -173,6 +173,7 @@ go_test(
         "//pkg/util",
         "//pkg/util/admission",
         "//pkg/util/encoding",
+        "//pkg/util/envutil",
         "//pkg/util/hlc",
         "//pkg/util/iterutil",
         "//pkg/util/leaktest",

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -93,16 +93,47 @@ var MaxConflictsPerLockConflictError = settings.RegisterIntSetting(
 	settings.WithName("storage.mvcc.max_conflicts_per_lock_conflict_error"),
 )
 
-var rocksdbConcurrency = envutil.EnvOrDefaultInt(
-	"COCKROACH_ROCKSDB_CONCURRENCY", func() int {
-		// Use up to min(numCPU, 4) threads for background RocksDB compactions per
-		// store.
-		const max = 4
-		if n := runtime.GOMAXPROCS(0); n <= max {
-			return n
-		}
-		return max
-	}())
+// getMaxConcurrentCompactions wraps the maxConcurrentCompactions env var in a
+// func that may be installed on Options.MaxConcurrentCompactions. It also
+// imposes a floor on the max, so that an engine is always created with at least
+// 1 slot for a compactions.
+//
+// NB: This function inspects the environment every time it's called. This is
+// okay, because Engine construction in NewPebble will invoke it and store the
+// value on the Engine itself.
+func getMaxConcurrentCompactions() int {
+	n := envutil.EnvOrDefaultInt(
+		"COCKROACH_CONCURRENT_COMPACTIONS", func() int {
+			// The old COCKROACH_ROCKSDB_CONCURRENCY environment variable was never
+			// documented, but customers were told about it and use today in
+			// production. We don't want to break them, so if the new env var
+			// is unset but COCKROACH_ROCKSDB_CONCURRENCY is set, use the old env
+			// var's value. This old env var has a wart in that it's expressed as a
+			// number of concurrency slots to make available to both flushes and
+			// compactions (a vestige of the corresponding RocksDB option's
+			// mechanics). We need to adjust it to be in terms of just compaction
+			// concurrency by subtracting the flushing routine's dedicated slot.
+			//
+			// TODO(jackson): Should envutil expose its `getEnv` internal func for
+			// cases like this where we actually want to know whether it's present
+			// or not; not just fallback to a default?
+			if oldV := envutil.EnvOrDefaultInt("COCKROACH_ROCKSDB_CONCURRENCY", 0); oldV > 0 {
+				return oldV - 1
+			}
+
+			// By default use up to min(numCPU-1, 3) threads for background
+			// compactions per store (reserving the final process for flushes).
+			const max = 3
+			if n := runtime.GOMAXPROCS(0); n-1 < max {
+				return n - 1
+			}
+			return max
+		}())
+	if n < 1 {
+		return 1
+	}
+	return n
+}
 
 // l0SubLevelCompactionConcurrency is the sub-level threshold at which to
 // allow an increase in compaction concurrency. The maximum is still

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -600,23 +600,18 @@ const MinimumSupportedFormatVersion = pebble.FormatPrePebblev1Marked
 
 // DefaultPebbleOptions returns the default pebble options.
 func DefaultPebbleOptions() *pebble.Options {
-	// In RocksDB, the concurrency setting corresponds to both flushes and
-	// compactions. In Pebble, there is always a slot for a flush, and
-	// compactions are counted separately.
-	maxConcurrentCompactions := rocksdbConcurrency - 1
-	if maxConcurrentCompactions < 1 {
-		maxConcurrentCompactions = 1
-	}
-
 	opts := &pebble.Options{
 		Comparer: EngineComparer,
 		FS:       vfs.Default,
 		// A value of 2 triggers a compaction when there is 1 sub-level.
-		L0CompactionThreshold:       2,
-		L0StopWritesThreshold:       1000,
-		LBaseMaxBytes:               64 << 20, // 64 MB
-		Levels:                      make([]pebble.LevelOptions, 7),
-		MaxConcurrentCompactions:    func() int { return maxConcurrentCompactions },
+		L0CompactionThreshold: 2,
+		L0StopWritesThreshold: 1000,
+		LBaseMaxBytes:         64 << 20, // 64 MB
+		Levels:                make([]pebble.LevelOptions, 7),
+		// NB: Options.MaxConcurrentCompactions may be overidden in NewPebble to
+		// allow overriding the max at runtime through
+		// Engine.SetCompactionConcurrency.
+		MaxConcurrentCompactions:    getMaxConcurrentCompactions,
 		MemTableSize:                64 << 20, // 64 MB
 		MemTableStopWritesThreshold: 4,
 		Merger:                      MVCCMerger,
@@ -1335,12 +1330,12 @@ func (p *Pebble) writePreventStartupFile(ctx context.Context, corruptionError er
 
 	preventStartupMsg := fmt.Sprintf(`ATTENTION:
 
-  this node is terminating because of sstable corruption. 
-	Corruption may be a consequence of a hardware error. 
+  this node is terminating because of sstable corruption.
+	Corruption may be a consequence of a hardware error.
 
-	Error: %s 
+	Error: %s
 
-  A file preventing this node from restarting was placed at: 
+  A file preventing this node from restarting was placed at:
   %s`, corruptionError.Error(), path)
 
 	if err := fs.WriteFile(p.unencryptedFS, path, []byte(preventStartupMsg)); err != nil {

--- a/pkg/util/envutil/env.go
+++ b/pkg/util/envutil/env.go
@@ -452,3 +452,23 @@ func TestSetEnv(t TB, name string, value string) func() {
 		ClearEnvCache()
 	}
 }
+
+// TestUnsetEnv unsets an environment variable and the cleanup function
+// resets it to the original value.
+func TestUnsetEnv(t TB, name string) func() {
+	t.Helper()
+	ClearEnvCache()
+	before, exists := os.LookupEnv(name)
+	if !exists {
+		return func() {}
+	}
+	if err := os.Unsetenv(name); err != nil {
+		t.Fatal(err)
+	}
+	return func() {
+		if err := os.Setenv(name, before); err != nil {
+			t.Fatal(err)
+		}
+		ClearEnvCache()
+	}
+}


### PR DESCRIPTION
Add a new COCKROACH_COMPACTION_CONCURRENCY environment variable to control the
maximum number of concurrent compactions that a single store will schedule.
This environment variable will supersede the old COCKROACH_ROCKSDB_CONCURRENCY
environment variable which was undocumented and was unfortunately named.

Epic: none
Release note (ops change): Introduced a new documented environment variable
that allows an operator to configure the compaction concurrency.