### PR TITLE
changefeedccl: use stable sort in parquet test

### DIFF
--- a/pkg/ccl/changefeedccl/parquet_test.go
+++ b/pkg/ccl/changefeedccl/parquet_test.go
@@ -214,13 +214,14 @@ func TestParquetRows(t *testing.T) {
 			// NB: Rangefeeds have per-key ordering, so the rows in the parquet
 			// file may not match the order we insert them. To accommodate for
 			// this, sort the expected and actual datums by the primary key.
-			slices.SortFunc(datums, func(a []tree.Datum, b []tree.Datum) bool {
+			slices.SortStableFunc(datums, func(a []tree.Datum, b []tree.Datum) bool {
 				return a[0].Compare(&eval.Context{}, b[0]) == -1
 			})
-			slices.SortFunc(readDatums, func(a []tree.Datum, b []tree.Datum) bool {
+			slices.SortStableFunc(readDatums, func(a []tree.Datum, b []tree.Datum) bool {
 				return a[0].Compare(&eval.Context{}, b[0]) == -1
 			})
 			for r := 0; r < numRows; r++ {
+				t.Logf("comparing row expected: %s to actual: %s\n", datums[r], readDatums[r])
 				for c := 0; c < numCols; c++ {
 					parquet.ValidateDatum(t, datums[r][c], readDatums[r][c])
 				}


### PR DESCRIPTION
Previously, this test failed in https://github.com/cockroachdb/cockroach/issues/113031 because events were out of order
for the row with id 3. Because rangefeeds don't have a total ordering but
instead have per-key ordering, we sort rows by key for the expected
output and actual output. Previously, we used a non-stable sort for this.
This means the the operations for a given row may be sorted out of order.
This change updates the sorting to be stable and also adds logging to make debugging easier.

Closes: #113031
Release note: None
Epic: None