### PR TITLE
roachtest: add min support version for 24.1 in multitenant-upgrade

### DIFF
--- a/pkg/cmd/roachtest/tests/multitenant_upgrade.go
+++ b/pkg/cmd/roachtest/tests/multitenant_upgrade.go
@@ -79,6 +79,7 @@ func runMultiTenantUpgrade(
 	// Update this map with every new release.
 	versionToMinSupportedVersion := map[string]string{
 		"23.2": "23.1",
+		"24.1": "23.1",
 	}
 	curBinaryMajorAndMinorVersion := getMajorAndMinorVersionOnly(v)
 	currentBinaryMinSupportedVersion, ok := versionToMinSupportedVersion[curBinaryMajorAndMinorVersion]


### PR DESCRIPTION
Fixes: #112776.

Release note: None