### PR TITLE
build: pass -y to microdnf install

### DIFF
--- a/build/deploy/Dockerfile
+++ b/build/deploy/Dockerfile
@@ -17,7 +17,7 @@ RUN microdnf update -y \
 RUN if [ "$fips_enabled" == "1" ]; then \
     microdnf install -y openssl && \
     rpm -qa | sort > /before.txt && \
-    microdnf install crypto-policies-scripts && \
+    microdnf install -y crypto-policies-scripts && \
     fips-mode-setup --enable --no-bootcfg && \
     rpm -qa | sort > /after.txt && \
     microdnf remove -y $(comm -13 /before.txt /after.txt) && \


### PR DESCRIPTION
Previously, one of the `microdnf install` didn't pass `-y` what cause to build hangs.

This PR adds the missing parameter.

Epic: none
Release note: None