### PR TITLE
release-23.1: kvstreamer: mark one setting as ApplicationLevel

### DIFF
--- a/pkg/kv/kvclient/kvstreamer/avg_response_estimator.go
+++ b/pkg/kv/kvclient/kvstreamer/avg_response_estimator.go
@@ -39,7 +39,7 @@ const (
 // streamerAvgResponseSizeMultiple determines the multiple used when calculating
 // the average response size.
 var streamerAvgResponseSizeMultiple = settings.RegisterFloatSetting(
-	settings.TenantReadOnly,
+	settings.TenantWritable,
 	"sql.distsql.streamer.avg_response_size_multiple",
 	"determines the multiple used when calculating the average response size by the streamer component",
 	defaultAvgResponseSizeMultiple,


### PR DESCRIPTION
Backport 1/1 commits from #113014.

/cc @cockroachdb/release

---

There is no reason for `sql.distsql.streamer.avg_response_size_multiple` to be "system-visible" - I think I simply mislabeled it originally.

Epic: None

Release note: None

Release justification: low-risk setting class fix.