### PR TITLE
sql/catalog: fix SHOW CREATE for columns with collated strings

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/collatedstring
+++ b/pkg/sql/logictest/testdata/logic_test/collatedstring
@@ -363,8 +363,8 @@ SHOW CREATE TABLE quoted_coll
 quoted_coll  CREATE TABLE public.quoted_coll (
                a STRING COLLATE en NULL,
                b STRING COLLATE en_US NULL,
-               c STRING COLLATE en_US NULL DEFAULT 'c':::STRING COLLATE en_US,
-               d STRING COLLATE en_u_ks_level1 NULL DEFAULT 'd':::STRING COLLATE en_u_ks_level1,
+               c STRING COLLATE en_US NULL DEFAULT ('c':::STRING COLLATE en_US),
+               d STRING COLLATE en_u_ks_level1 NULL DEFAULT ('d':::STRING COLLATE en_u_ks_level1),
                e STRING COLLATE en_US NULL AS (a COLLATE en_US) STORED,
                rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
                CONSTRAINT quoted_coll_pkey PRIMARY KEY (rowid ASC)

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -1580,8 +1580,15 @@ func (expr *ParenExpr) TypeCheck(
 	if err != nil {
 		return nil, err
 	}
-	// Parentheses are semantically unimportant and can be removed/replaced
-	// with its nested expression in our plan. This makes type checking cleaner.
+	// Parentheses are semantically unimportant and in most cases can be
+	// removed/replaced with its nested expression in our plan. This makes type
+	// checking cleaner. Collated string expressions need the parentheses to
+	// parse correctly in some cases.
+	if _, ok := exprTyped.(*CollateExpr); ok {
+		expr.Expr = exprTyped
+		expr.typ = exprTyped.ResolvedType()
+		return expr, nil
+	}
 	return exprTyped, nil
 }
 

--- a/pkg/sql/show_create_all_tables_builtin_test.go
+++ b/pkg/sql/show_create_all_tables_builtin_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
 )
 
 // Use the output from crdb_internal.show_create_all_tables() to recreate the
@@ -36,22 +37,33 @@ func TestRecreateTables(t *testing.T) {
 	sqlRunner.Exec(t, `USE test;`)
 	sqlRunner.Exec(t, `CREATE TABLE foo(x INT primary key);`)
 	sqlRunner.Exec(t, `CREATE TABLE bar(x INT, y INT, z STRING, FAMILY f1(x, y, z))`)
+	sqlRunner.Exec(t, `
+		CREATE TABLE tab (
+			a STRING COLLATE en,
+			b STRING COLLATE en_US,
+			c STRING COLLATE en_US DEFAULT ('c' COLLATE en_US),
+			d STRING COLLATE en_u_ks_level1 DEFAULT ('d'::STRING COLLATE en_u_ks_level1),
+			e STRING COLLATE en_US AS (a COLLATE en_US) STORED,
+			f STRING COLLATE en_US ON UPDATE ('f' COLLATE en_US))`)
 
-	row := sqlRunner.QueryRow(t, "SELECT crdb_internal.show_create_all_tables('test')")
-	var recreateTablesStmt string
-	row.Scan(&recreateTablesStmt)
+	var recreateTablesStmts []string
+	for _, r := range sqlRunner.QueryStr(t, "SELECT crdb_internal.show_create_all_tables('test')") {
+		recreateTablesStmts = append(recreateTablesStmts, r[0])
+	}
 
 	// Use the recreateTablesStmt to recreate the tables, perform another
 	// show_create_all_tables and compare that the output is the same.
 	sqlRunner.Exec(t, `DROP DATABASE test;`)
 	sqlRunner.Exec(t, `CREATE DATABASE test;`)
-	sqlRunner.Exec(t, recreateTablesStmt)
 
-	row = sqlRunner.QueryRow(t, "SELECT crdb_internal.show_create_all_tables('test')")
-	var recreateTablesStmt2 string
-	row.Scan(&recreateTablesStmt2)
-
-	if recreateTablesStmt != recreateTablesStmt2 {
-		t.Fatalf("got: %s\nexpected: %s", recreateTablesStmt2, recreateTablesStmt)
+	for _, stmt := range recreateTablesStmts {
+		sqlRunner.Exec(t, stmt)
 	}
+
+	var recreateTablesStmts2 []string
+	for _, r := range sqlRunner.QueryStr(t, "SELECT crdb_internal.show_create_all_tables('test')") {
+		recreateTablesStmts2 = append(recreateTablesStmts2, r[0])
+	}
+
+	require.ElementsMatch(t, recreateTablesStmts, recreateTablesStmts2)
 }


### PR DESCRIPTION
This commit also fixes a test bug that prevented an existing test from verifying that all the tables in the test would round-trip with SHOW CREATE.

fixes https://github.com/cockroachdb/cockroach/issues/112157

Release note (bug fix): The result of SHOW CREATE for a table that has a collated string column with a default expression was incorrect, since the statement was not parseable. This is now fixed.