### PR TITLE
sql, obs: add exporter to PersistedSQLStats

### DIFF
--- a/pkg/obsservice/obslib/ingest/grpc_ingest_test.go
+++ b/pkg/obsservice/obslib/ingest/grpc_ingest_test.go
@@ -93,7 +93,7 @@ type reqBuilder struct {
 
 type scopeLogs struct {
 	eventType string
-	logs      []v1.LogRecord
+	logs      []*v1.LogRecord
 }
 
 func newReqBuilder(resource *otel_res_pb.Resource) *reqBuilder {
@@ -119,13 +119,13 @@ func (r *reqBuilder) withLogEvent(eventType string, data string) *reqBuilder {
 	if sl == nil {
 		sl = &scopeLogs{
 			eventType: eventType,
-			logs:      make([]v1.LogRecord, 0),
+			logs:      make([]*v1.LogRecord, 0),
 		}
 		r.scopeLogs = append(r.scopeLogs, sl)
 	}
 	timestamp := r.lastTimestamp + 10000000
 	r.lastTimestamp = timestamp
-	sl.logs = append(sl.logs, v1.LogRecord{
+	sl.logs = append(sl.logs, &v1.LogRecord{
 		TimeUnixNano: uint64(timestamp),
 		Body:         &v12.AnyValue{Value: &v12.AnyValue_StringValue{StringValue: data}},
 		Attributes: []*v12.KeyValue{{
@@ -138,7 +138,7 @@ func (r *reqBuilder) withLogEvent(eventType string, data string) *reqBuilder {
 
 func (r *reqBuilder) build() *logspb.ExportLogsServiceRequest {
 	for _, sl := range r.scopeLogs {
-		r.req.ResourceLogs[0].ScopeLogs = append(r.req.ResourceLogs[0].ScopeLogs, v1.ScopeLogs{
+		r.req.ResourceLogs[0].ScopeLogs = append(r.req.ResourceLogs[0].ScopeLogs, &v1.ScopeLogs{
 			Scope: &v12.InstrumentationScope{
 				Name:    sl.eventType,
 				Version: "1.0",

--- a/pkg/obsservice/obslib/ingest/testdata/grpc_ingest
+++ b/pkg/obsservice/obslib/ingest/testdata/grpc_ingest
@@ -22,7 +22,7 @@ type2,mundo
         Attributes:             nil,
         DroppedAttributesCount: 0x0,
     },
-    LogRecord: v1.LogRecord{
+    LogRecord: &v1.LogRecord{
         TimeUnixNano:         0x176c33b203521680,
         ObservedTimeUnixNano: 0x176c33bffb00d800,
         SeverityNumber:       0,
@@ -62,7 +62,7 @@ type2,mundo
         Attributes:             nil,
         DroppedAttributesCount: 0x0,
     },
-    LogRecord: v1.LogRecord{
+    LogRecord: &v1.LogRecord{
         TimeUnixNano:         0x176c33b204834380,
         ObservedTimeUnixNano: 0x176c33bffb00d800,
         SeverityNumber:       0,
@@ -102,7 +102,7 @@ type2,mundo
         Attributes:             nil,
         DroppedAttributesCount: 0x0,
     },
-    LogRecord: v1.LogRecord{
+    LogRecord: &v1.LogRecord{
         TimeUnixNano:         0x176c33b203eaad00,
         ObservedTimeUnixNano: 0x176c33bffb00d800,
         SeverityNumber:       0,
@@ -142,7 +142,7 @@ type2,mundo
         Attributes:             nil,
         DroppedAttributesCount: 0x0,
     },
-    LogRecord: v1.LogRecord{
+    LogRecord: &v1.LogRecord{
         TimeUnixNano:         0x176c33b2051bda00,
         ObservedTimeUnixNano: 0x176c33bffb00d800,
         SeverityNumber:       0,

--- a/pkg/obsservice/obslib/transform/log_record_to_event.go
+++ b/pkg/obsservice/obslib/transform/log_record_to_event.go
@@ -27,7 +27,7 @@ func LogRecordToEvent(
 	ingestTime time.Time,
 	resource *resourcev1.Resource,
 	scope *commonv1.InstrumentationScope,
-	logRecord logsv1.LogRecord,
+	logRecord *logsv1.LogRecord,
 ) *obspb.Event {
 	logRecord.ObservedTimeUnixNano = uint64(ingestTime.UnixNano())
 	return &obspb.Event{

--- a/pkg/obsservice/obspb/obsservice.proto
+++ b/pkg/obsservice/obspb/obsservice.proto
@@ -34,5 +34,5 @@ message Event {
   opentelemetry.proto.common.v1.InstrumentationScope scope = 2;
 
   // The LogRecord containing the specific event information.
-  opentelemetry.proto.logs.v1.LogRecord log_record = 3 [(gogoproto.nullable) = false ];
+  opentelemetry.proto.logs.v1.LogRecord log_record = 3;
 }

--- a/pkg/obsservice/obspb/opentelemetry-proto/logs/v1/logs.proto
+++ b/pkg/obsservice/obspb/opentelemetry-proto/logs/v1/logs.proto
@@ -55,7 +55,7 @@ message ResourceLogs {
   opentelemetry.proto.resource.v1.Resource resource = 1;
 
   // A list of ScopeLogs that originate from a resource.
-  repeated ScopeLogs scope_logs = 2 [(gogoproto.nullable) = false ];
+  repeated ScopeLogs scope_logs = 2;
 
   // This schema_url applies to the data in the "resource" field. It does not apply
   // to the data in the "scope_logs" field which have their own schema_url field.
@@ -70,7 +70,7 @@ message ScopeLogs {
   opentelemetry.proto.common.v1.InstrumentationScope scope = 1;
 
   // A list of log records.
-  repeated LogRecord log_records = 2 [(gogoproto.nullable) = false ];
+  repeated LogRecord log_records = 2;
 
   // This schema_url applies to all logs in the "logs" field.
   string schema_url = 3;

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -1145,6 +1145,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 		sqlMemMetrics,
 		rootSQLMemoryMonitor,
 		cfg.HistogramWindowInterval(),
+		cfg.eventsExporter,
 		execCfg,
 	)
 

--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -777,6 +777,7 @@ go_test(
         "//pkg/kv/kvserver/protectedts/ptpb",
         "//pkg/kv/kvserver/protectedts/ptstorage",
         "//pkg/multitenant/tenantcapabilities",
+        "//pkg/obs",
         "//pkg/roachpb",
         "//pkg/rpc",
         "//pkg/rpc/nodedialer",

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/isolation"
 	"github.com/cockroachdb/cockroach/pkg/multitenant"
 	"github.com/cockroachdb/cockroach/pkg/multitenant/multitenantcpu"
+	"github.com/cockroachdb/cockroach/pkg/obs"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
@@ -408,7 +409,9 @@ type ServerMetrics struct {
 
 // NewServer creates a new Server. Start() needs to be called before the Server
 // is used.
-func NewServer(cfg *ExecutorConfig, pool *mon.BytesMonitor) *Server {
+func NewServer(
+	cfg *ExecutorConfig, pool *mon.BytesMonitor, eventsExporter obs.EventsExporterInterface,
+) *Server {
 	metrics := makeMetrics(false /* internal */)
 	serverMetrics := makeServerMetrics(cfg)
 	insightsProvider := insights.New(cfg.Settings, serverMetrics.InsightsMetrics)
@@ -477,7 +480,7 @@ func NewServer(cfg *ExecutorConfig, pool *mon.BytesMonitor) *Server {
 		FlushCounter:   serverMetrics.StatsMetrics.SQLStatsFlushStarted,
 		FailureCounter: serverMetrics.StatsMetrics.SQLStatsFlushFailure,
 		FlushDuration:  serverMetrics.StatsMetrics.SQLStatsFlushDuration,
-	}, memSQLStats)
+	}, memSQLStats, eventsExporter)
 
 	s.sqlStats = persistedSQLStats
 	s.sqlStatsController = persistedSQLStats.GetController(cfg.SQLStatusServer)

--- a/pkg/sql/conn_executor_internal_test.go
+++ b/pkg/sql/conn_executor_internal_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/obs"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -348,7 +349,7 @@ func startConnExecutor(
 		CollectionFactory:       collectionFactory,
 	}
 
-	s := NewServer(cfg, pool)
+	s := NewServer(cfg, pool, obs.NoopEventsExporter{})
 	buf := NewStmtBuf()
 	syncResults := make(chan []*streamingCommandResult, 1)
 	resultChannel := newAsyncIEResultChannel()

--- a/pkg/sql/event_log.go
+++ b/pkg/sql/event_log.go
@@ -670,7 +670,7 @@ func asyncWriteToOtelAndSystemEventsTable(
 }
 
 func sendEventsToObsService(
-	ctx context.Context, execCfg *ExecutorConfig, events []otel_logs_pb.LogRecord,
+	ctx context.Context, execCfg *ExecutorConfig, events []*otel_logs_pb.LogRecord,
 ) {
 	for i := range events {
 		execCfg.EventsExporter.SendEvent(ctx, obspb.EventlogEvent, events[i])
@@ -679,7 +679,7 @@ func sendEventsToObsService(
 
 func prepareEventWrite(
 	ctx context.Context, execCfg *ExecutorConfig, entries []logpb.EventPayload,
-) (query string, args []interface{}, events []otel_logs_pb.LogRecord) {
+) (query string, args []interface{}, events []*otel_logs_pb.LogRecord) {
 	reportingID := execCfg.NodeInfo.NodeID.SQLInstanceID()
 	const colsPerEvent = 4
 	// Note: we insert the value zero as targetID because sadly this
@@ -692,7 +692,7 @@ INSERT INTO system.eventlog (
 VALUES($1, $2, $3, $4, 0)`
 	args = make([]interface{}, 0, len(entries)*colsPerEvent)
 
-	events = make([]otel_logs_pb.LogRecord, len(entries))
+	events = make([]*otel_logs_pb.LogRecord, len(entries))
 	sp := tracing.SpanFromContext(ctx)
 	var traceID [16]byte
 	var spanID [8]byte
@@ -724,7 +724,7 @@ VALUES($1, $2, $3, $4, 0)`
 			string(infoBytes),
 		)
 
-		events[i] = otel_logs_pb.LogRecord{
+		events[i] = &otel_logs_pb.LogRecord{
 			TimeUnixNano: uint64(nowNanos),
 			Body:         &v1.AnyValue{Value: &v1.AnyValue_StringValue{StringValue: args[len(args)-1].(string)}},
 			Attributes: []*v1.KeyValue{{

--- a/pkg/sql/pgwire/BUILD.bazel
+++ b/pkg/sql/pgwire/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
         "//pkg/clusterversion",
         "//pkg/col/coldata",
         "//pkg/jobs",
+        "//pkg/obs",
         "//pkg/roachpb",
         "//pkg/security",
         "//pkg/security/password",

--- a/pkg/sql/pgwire/fuzz.go
+++ b/pkg/sql/pgwire/fuzz.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/obs"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -34,6 +35,7 @@ func FuzzServeConn(data []byte) int {
 		sql.MemoryMetrics{},
 		&mon.BytesMonitor{},
 		time.Minute,
+		obs.NoopEventsExporter{},
 		&sql.ExecutorConfig{
 			Settings: &cluster.Settings{},
 		},

--- a/pkg/sql/pgwire/server.go
+++ b/pkg/sql/pgwire/server.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/obs"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/settings"
@@ -315,6 +316,7 @@ func MakeServer(
 	sqlMemMetrics sql.MemoryMetrics,
 	parentMemoryMonitor *mon.BytesMonitor,
 	histogramWindow time.Duration,
+	eventsExporter obs.EventsExporterInterface,
 	executorConfig *sql.ExecutorConfig,
 ) *Server {
 	ctx := ambientCtx.AnnotateCtx(context.Background())
@@ -337,7 +339,7 @@ func MakeServer(
 		nil, /* maxHist */
 		0, noteworthySQLMemoryUsageBytes, st)
 	server.sqlMemoryPool.StartNoReserved(ctx, parentMemoryMonitor)
-	server.SQLServer = sql.NewServer(executorConfig, server.sqlMemoryPool)
+	server.SQLServer = sql.NewServer(executorConfig, server.sqlMemoryPool, eventsExporter)
 
 	server.tenantSpecificConnMonitor = mon.NewMonitor("conn",
 		mon.MemoryResource,

--- a/pkg/sql/sqlstats/persistedsqlstats/BUILD.bazel
+++ b/pkg/sql/sqlstats/persistedsqlstats/BUILD.bazel
@@ -26,6 +26,7 @@ go_library(
         "//pkg/clusterversion",
         "//pkg/jobs",
         "//pkg/jobs/jobspb",
+        "//pkg/obs",
         "//pkg/scheduledjobs",
         "//pkg/security/username",
         "//pkg/server/serverpb",

--- a/pkg/sql/sqlstats/persistedsqlstats/provider.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/provider.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
+	"github.com/cockroachdb/cockroach/pkg/obs"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
@@ -90,17 +91,22 @@ type PersistedSQLStats struct {
 
 	// The last time the size was checked before doing a flush.
 	lastSizeCheck time.Time
+
+	eventsExporter obs.EventsExporterInterface
 }
 
 var _ sqlstats.Provider = &PersistedSQLStats{}
 
 // New returns a new instance of the PersistedSQLStats.
-func New(cfg *Config, memSQLStats *sslocal.SQLStats) *PersistedSQLStats {
+func New(
+	cfg *Config, memSQLStats *sslocal.SQLStats, eventsExporter obs.EventsExporterInterface,
+) *PersistedSQLStats {
 	p := &PersistedSQLStats{
 		SQLStats:             memSQLStats,
 		cfg:                  cfg,
 		memoryPressureSignal: make(chan struct{}),
 		drain:                make(chan struct{}),
+		eventsExporter:       eventsExporter,
 	}
 
 	p.jobMonitor = jobMonitor{


### PR DESCRIPTION
Commits originally created on #111875

Epic: None

**Commit 1:**
sql: plumb obs.EventsExporter to PersistedSQLStats
If we're going to export statement statistics to external
o11y systems, the system responsible for aggregating this
data within CRDB needs access to an obs.EventsExporter
implementation.

This patch plumbs one through to the PersistedSQLStats
instance used by the SQL Server. This enables us
to send events to external systems from within
the PersistedSQLStats system.

Release note: none

---

**Commit 2:**
obs: change EventsExporterInterface, protos to use pointers
Previously, the otlp LogRecord proto messages, as well as the
EventsExporterInterface, were using value slices and parameters instead
of pointers.

As the size of the objects that we pass to the EventsExporter grows,
passing arguments by value becomes an issue. Originally, I figured that
perhaps this decision was made for compatbility reasons with the OTLP
proto library. However, looking at the OTLP protos, that doesn't seem to
be the case (e.g. no nullable gogoproto flags are used). See:
https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/logs/v1/logs.proto

This patch changes the protos and interfaces to use pointers where
appropriate.

Release note: none

