### PR TITLE
storage: add MVCCDeleteRangeWithPredicate benchmark

### DIFF
--- a/pkg/storage/bench_data_test.go
+++ b/pkg/storage/bench_data_test.go
@@ -293,6 +293,7 @@ func (d mvccBenchData) Build(ctx context.Context, b *testing.B, eng Engine) erro
 			cf = (cf + 1) % uint32(d.numColumnFamilies)
 		} else {
 			keySlice[i] = roachpb.Key(encoding.EncodeUvarintAscending([]byte("key-"), uint64(i)))
+
 		}
 		keyVersions := rng.Intn(d.numVersions) + 1
 		for j := 0; j < keyVersions; j++ {
@@ -396,5 +397,122 @@ func (d mvccBenchData) Build(ctx context.Context, b *testing.B, eng Engine) erro
 		return err
 	}
 
+	return nil
+}
+
+// mvccImportedData defines an mvcc data generator that simulates the keys created
+// by multiple import runs. The generator rotates through the `layers` and
+// generates a run of ascending keys until the keyCount is reached. Like
+// sequential imports, no layer will have a key that overlaps with another
+// layer. A given run length is chosen uniformly over the interval
+// [0,streakBound). As an example, for 2 imports and streakBound of 5, and a key
+// count of 9, we could generate the following data:
+//
+// t10 (import 2):      x x x x   x x
+// t5 (import 1) :  x x         x
+//
+//	  -------------------------
+//	key  1 2 3 4 5 6 7 8 9
+//
+// A larger streakBound creates longer runs of keys, which are more likely to
+// get rolled back using a delete range tombstone.
+type mvccImportedData struct {
+	streakBound int
+	keyCount    int
+	layers      int
+	valueBytes  int
+}
+
+var _ initialState = mvccImportedData{}
+
+func (i mvccImportedData) Key() []string {
+	key := []string{
+		"mvcc",
+		fmt.Sprintf("fmtver_%d", previousReleaseFormatMajorVersion),
+		fmt.Sprintf("streak_%d", i.streakBound),
+		fmt.Sprintf("keys_%d", i.keyCount),
+		fmt.Sprintf("valueBytes_%d", i.valueBytes),
+		fmt.Sprintf("layers_%d", i.layers),
+	}
+	return key
+}
+func (i mvccImportedData) ConfigOptions() []ConfigOption { return nil }
+func (i mvccImportedData) Base() initialState            { return nil }
+func (i mvccImportedData) Build(ctx context.Context, b *testing.B, eng Engine) error {
+	// The creation of the database is time consuming, especially for larger
+	// numbers of versions. The database is persisted between runs and stored in
+	// a directory with the path elements returned by Key().
+
+	// Generate the same data every time.
+	rng := rand.New(rand.NewSource(1449168817))
+	keysByLayer := i.genLayers(b, rng)
+	for layer := 0; layer < i.layers; layer++ {
+		batch := eng.NewBatch()
+		if err := i.writeLayer(ctx, eng, batch, rng, keysByLayer[layer], layer); err != nil {
+			return err
+		}
+		if err := batch.Commit(false /* sync */); err != nil {
+			return err
+		}
+		batch.Close()
+	}
+	return nil
+}
+
+func (i mvccImportedData) genLayers(b *testing.B, rng *rand.Rand) [][]roachpb.Key {
+	keys := make([][]roachpb.Key, i.layers)
+	for layer := 0; layer < i.layers; layer++ {
+		keys[layer] = make([]roachpb.Key, 0, i.keyCount)
+	}
+	keyID := 0
+	remaining := i.keyCount
+	streakCount := 0
+	for remaining > 0 {
+		currentLayer := streakCount % i.layers
+		streak := rng.Intn(i.streakBound)
+		if streak > remaining {
+			streak = remaining
+		}
+		b.Logf("%d streak; layer %d: adding %d keys %d-%d\n", i.streakBound, currentLayer, streak, keyID, keyID+streak)
+		for s := 0; s < streak; s++ {
+			keys[currentLayer] = append(keys[currentLayer], roachpb.Key(encoding.EncodeUvarintAscending(nil, uint64(keyID))))
+			keyID++
+			remaining--
+		}
+		streakCount++
+	}
+	return keys
+}
+
+func (i mvccImportedData) writeLayer(
+	ctx context.Context, eng Engine, batch Batch, rng *rand.Rand, keys []roachpb.Key, layer int,
+) error {
+	for idx, key := range keys {
+		// TODO (msbulter): share common code with mvccBenchData
+		//
+		// Output the keys in ~20 batches. If we used a single batch to output all
+		// of the keys pebble would create a single sstable. We want multiple
+		// sstables in order to exercise filtering of which sstables are examined
+		// during iterator seeking. We fix the number of batches we output so that
+		// optimizations which change the data size result in the same number of
+		// sstables.
+		if scaled := len(keys) / 20; idx > 0 && (idx%scaled) == 0 {
+			log.Infof(ctx, "committing (%d/~%d)", idx/scaled, 20)
+			if err := batch.Commit(false /* sync */); err != nil {
+				return err
+			}
+			batch.Close()
+			batch = eng.NewBatch()
+			if err := eng.Flush(); err != nil {
+				return err
+			}
+		}
+		ts := hlc.Timestamp{WallTime: int64((layer + 1) * 5)}
+		value := roachpb.MakeValueFromBytes(randutil.RandBytes(rng, i.valueBytes))
+		value.InitChecksum(key)
+		if err := MVCCPut(ctx, batch, key, ts, value, MVCCWriteOptions{}); err != nil {
+			return err
+		}
+	}
 	return nil
 }

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -3830,6 +3830,7 @@ func MVCCPredicateDeleteRange(
 			// current key we're about to delete.
 			iter.NextKeyIgnoringTime()
 		} else {
+
 			// This key does not match. Flush the run of matching keys,
 			// to prevent issuing tombstones on keys that do not match the predicates.
 			if err := flushDeleteKeys(); err != nil {


### PR DESCRIPTION
This patch adds a benchmark for predicate based delete range. Specifically, the benchmark generates data that simulates 2 sequential imports, under a variety of configs, and benchmarks the roll back of data from the second import.

The main parameter that determines predicate based delete range performance is how interspersed the data is between imports. If the data is very interspersed, predicate based delete range must delete the newer data with point tombsones instead of range tombstones. To that end, we benchmark predicate based delete range over import workloads with varying levels of interspersion.

In the results below, a larger streakBound leads to less interspersed data:

```
BenchmarkMVCCDeleteRangeWithPredicate_Pebble/streakBound=10/rangeKeyThreshold=64-24         	       1	1402779743 ns/op	   0.32 MB/s
BenchmarkMVCCDeleteRangeWithPredicate_Pebble/streakBound=100/rangeKeyThreshold=64-24        	       2	 618831724 ns/op	   0.72 MB/s
BenchmarkMVCCDeleteRangeWithPredicate_Pebble/streakBound=200/rangeKeyThreshold=64-24        	       5	 206304070 ns/op	   2.17 MB/s
BenchmarkMVCCDeleteRangeWithPredicate_Pebble/streakBound=500/rangeKeyThreshold=64-24        	      48	  21952393 ns/op	  20.41 MB/s
```

Informs #112733

Release note: None