### PR TITLE
nightlies: add stress-engflow scripts for deadlock nightly, race-enabled

### DIFF
--- a/build/teamcity/cockroach/nightlies/stress_engflow_deadlock.sh
+++ b/build/teamcity/cockroach/nightlies/stress_engflow_deadlock.sh
@@ -2,6 +2,8 @@
 
 set -euo pipefail
 
+export EXTRA_TEST_ARGS="--define gotags=bazel,gss,deadlock"
+
 THIS_DIR=$(cd "$(dirname "$0")" && pwd)
 
 $THIS_DIR/stress_engflow_impl.sh

--- a/build/teamcity/cockroach/nightlies/stress_engflow_impl.sh
+++ b/build/teamcity/cockroach/nightlies/stress_engflow_impl.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+mkdir -p artifacts
+
+# NB: The certs are set up and cleaned up in unconditional build steps before
+# and after this build step.
+ENGFLOW_FLAGS="--config engflow --config cibase --config crosslinux \
+--jobs 400 --tls_client_certificate=/home/agent/engflow/engflow.crt \
+--tls_client_key=/home/agent/engflow/engflow.key"
+INVOCATION_ID=$(uuidgen)
+
+status=0
+bazel test //pkg:all_tests $ENGFLOW_FLAGS --remote_download_minimal \
+      --runs_per_test ${RUNS_PER_TEST=30} --verbose_failures --build_event_binary_file=artifacts/eventstream \
+      --profile=artifacts/profile.json.gz --invocation_id=$INVOCATION_ID \
+      ${EXTRA_TEST_ARGS:+$EXTRA_TEST_ARGS} \
+    || status=$?
+
+# Upload results to GitHub.
+bazel build //pkg/cmd/bazci/process-bep-file $ENGFLOW_FLAGS
+_bazel/bin/pkg/cmd/bazci/process-bep-file/process-bep-file_/process-bep-file \
+    -branch $TC_BUILD_BRANCH -eventsfile artifacts/eventstream \
+    -invocation $INVOCATION_ID -cert /home/agent/engflow/engflow.crt \
+    -key /home/agent/engflow/engflow.key
+
+exit $status

--- a/build/teamcity/cockroach/nightlies/stress_engflow_race.sh
+++ b/build/teamcity/cockroach/nightlies/stress_engflow_race.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+export RUNS_PER_TEST=5
+export EXTRA_TEST_ARGS="--@io_bazel_rules_go//go/config:race --test_env=GORACE=halt_on_error=1"
+
+THIS_DIR=$(cd "$(dirname "$0")" && pwd)
+
+$THIS_DIR/stress_engflow_impl.sh


### PR DESCRIPTION
The `teamcity-trigger` stress trigger starts three kinds of stress jobs: normal, `race`-enabled, and `deadlock`-enabled. We already have the one script for normal nightlies, just add corresponding nightlies for `race` and `deadlock`.

Epic: CRDB-8308
Release note: None