### PR TITLE
kv/kvnemesis: disable guaranteed durability skip locked reqs in batches

### DIFF
--- a/pkg/kv/kvnemesis/applier.go
+++ b/pkg/kv/kvnemesis/applier.go
@@ -452,6 +452,9 @@ func applyBatchOp(
 	for i := range o.Ops {
 		switch subO := o.Ops[i].GetValue().(type) {
 		case *GetOperation:
+			if subO.SkipLocked {
+				panic(errors.AssertionFailedf(`SkipLocked cannot be used in batches`))
+			}
 			dur := kvpb.BestEffort
 			if subO.GuaranteedDurability {
 				dur = kvpb.GuaranteedDurability
@@ -467,6 +470,9 @@ func applyBatchOp(
 			b.Put(subO.Key, subO.Value())
 			setLastReqSeq(b, subO.Seq)
 		case *ScanOperation:
+			if subO.SkipLocked {
+				panic(errors.AssertionFailedf(`SkipLocked cannot be used in batches`))
+			}
 			dur := kvpb.BestEffort
 			if subO.GuaranteedDurability {
 				dur = kvpb.GuaranteedDurability

--- a/pkg/kv/kvnemesis/generator.go
+++ b/pkg/kv/kvnemesis/generator.go
@@ -460,18 +460,32 @@ func NewDefaultConfig() GeneratorConfig {
 	// avoid mixing skip locked and non-skip locked requests, we disable these ops
 	// in the batchOpConfig.
 	// TODO(nvanbenschoten): support multi-operation SkipLocked batches.
-	config.Ops.Batch.Ops.GetMissingSkipLocked = 0
-	config.Ops.Batch.Ops.GetMissingForUpdateSkipLocked = 0
-	config.Ops.Batch.Ops.GetMissingForShareSkipLocked = 0
-	config.Ops.Batch.Ops.GetExistingSkipLocked = 0
-	config.Ops.Batch.Ops.GetExistingForUpdateSkipLocked = 0
-	config.Ops.Batch.Ops.GetExistingForShareSkipLocked = 0
-	config.Ops.Batch.Ops.ScanSkipLocked = 0
-	config.Ops.Batch.Ops.ScanForUpdateSkipLocked = 0
-	config.Ops.Batch.Ops.ScanForShareSkipLocked = 0
-	config.Ops.Batch.Ops.ReverseScanSkipLocked = 0
-	config.Ops.Batch.Ops.ReverseScanForUpdateSkipLocked = 0
-	config.Ops.Batch.Ops.ReverseScanForShareSkipLocked = 0
+	for _, batchOps := range []*ClientOperationConfig{
+		&config.Ops.Batch.Ops,
+		&config.Ops.ClosureTxn.TxnBatchOps.Ops,
+		&config.Ops.ClosureTxn.CommitBatchOps,
+	} {
+		batchOps.GetMissingSkipLocked = 0
+		batchOps.GetMissingForUpdateSkipLocked = 0
+		batchOps.GetMissingForUpdateSkipLockedGuaranteedDurability = 0
+		batchOps.GetMissingForShareSkipLocked = 0
+		batchOps.GetMissingForShareSkipLockedGuaranteedDurability = 0
+		batchOps.GetExistingSkipLocked = 0
+		batchOps.GetExistingForUpdateSkipLocked = 0
+		batchOps.GetExistingForUpdateSkipLockedGuaranteedDurability = 0
+		batchOps.GetExistingForShareSkipLocked = 0
+		batchOps.GetExistingForShareSkipLockedGuaranteedDurability = 0
+		batchOps.ScanSkipLocked = 0
+		batchOps.ScanForUpdateSkipLocked = 0
+		batchOps.ScanForUpdateSkipLockedGuaranteedDurability = 0
+		batchOps.ScanForShareSkipLocked = 0
+		batchOps.ScanForShareSkipLockedGuaranteedDurability = 0
+		batchOps.ReverseScanSkipLocked = 0
+		batchOps.ReverseScanForUpdateSkipLocked = 0
+		batchOps.ReverseScanForUpdateSkipLockedGuaranteedDurability = 0
+		batchOps.ReverseScanForShareSkipLocked = 0
+		batchOps.ReverseScanForShareSkipLockedGuaranteedDurability = 0
+	}
 	// AddSSTable cannot be used in transactions, nor in batches.
 	config.Ops.Batch.Ops.AddSSTable = 0
 	config.Ops.ClosureTxn.CommitBatchOps.AddSSTable = 0


### PR DESCRIPTION
Like other skip locked requests in batch operations, these aren't supported. This wasn't causing any issues, but I noticed it while reading code.

The commit also adds assertions to prevent this mistake in the future.

Epic: None
Release note: None