### PR TITLE
sql: log non-internal errors for explain-redaction test

### DIFF
--- a/pkg/sql/tests/explain_test_util.go
+++ b/pkg/sql/tests/explain_test_util.go
@@ -95,6 +95,10 @@ func GenerateAndCheckRedactedExplainsForPII(
 									msg := err.Error()
 									if strings.Contains(msg, "internal error") {
 										t.Error(err)
+									} else if !strings.Contains(msg, "syntax error") {
+										// Skip logging syntax errors, since they're expected to be
+										// common and uninteresting.
+										t.Logf("encountered non-internal error: %s\n", err)
 									}
 									continue
 								}


### PR DESCRIPTION
This patch adds logging to `TestExplainRedact` and `TestExplainRedactDDL` in the case of non-internal errors, which were previously silently skipped. This should add visibility into the "leaked goroutine" test flakes that have been appearing in these tests.

Informs #112868

Release note: None