### PR TITLE
build: add `Info.BinaryName`

### DIFF
--- a/pkg/build/info.go
+++ b/pkg/build/info.go
@@ -34,6 +34,7 @@ var (
 	utcTime          string // Build time in UTC (year/month/day hour:min:sec)
 	rev              string // SHA-1 of this build (git rev-parse)
 	buildTagOverride string
+	binaryName       string // Name of the binary that was built, e.g., cockroach, roachtest, roachprod.
 	cgoCompiler      = cgoVersion()
 	cgoTargetTriple  string
 	platform         = fmt.Sprintf("%s %s", runtime.GOOS, runtime.GOARCH)
@@ -130,6 +131,7 @@ func (b Info) Long() string {
 	fmt.Fprintf(tw, "C Compiler:       %s\n", b.CgoCompiler)
 	fmt.Fprintf(tw, "Build Commit ID:  %s\n", b.Revision)
 	fmt.Fprintf(tw, "Build Type:       %s\n", b.Type)
+	fmt.Fprintf(tw, "Binary Name:			%s\n", b.BinaryName)
 	fmt.Fprintf(tw, "Enabled Assertions: %t", b.EnabledAssertions) // No final newline: cobra prints one for us.
 	_ = tw.Flush()
 	return buf.String()
@@ -159,6 +161,7 @@ func GetInfo() Info {
 	if ch == "" {
 		ch = "unknown"
 	}
+
 	return Info{
 		GoVersion:         runtime.Version(),
 		Tag:               binaryVersion,
@@ -171,6 +174,7 @@ func GetInfo() Info {
 		Type:              typ,
 		Channel:           ch,
 		EnvChannel:        envChannel,
+		BinaryName:        binaryName,
 		EnabledAssertions: enabledAssertions,
 	}
 }

--- a/pkg/build/info.proto
+++ b/pkg/build/info.proto
@@ -42,6 +42,8 @@ message Info {
   optional string env_channel = 11 [(gogoproto.nullable) = false];
   // enabled_assertions returns the value of 'CrdbTestBuild' (true iff compiled with 'crdb_test' tag)
   optional bool enabled_assertions = 12 [(gogoproto.nullable) = false];
+  // binary_anme returns the name of the binary, e.g., cockroach, roachtest, roachprod.
+  optional string binary_name = 13 [(gogoproto.nullable) = false];
 
   // dependencies exists to allow tests that run against old clusters
   // to unmarshal JSON containing this field. The tag is unimportant,

--- a/pkg/cmd/cockroach-oss/BUILD.bazel
+++ b/pkg/cmd/cockroach-oss/BUILD.bazel
@@ -6,6 +6,9 @@ go_library(
     srcs = ["main.go"],
     importpath = "github.com/cockroachdb/cockroach/pkg/cmd/cockroach-oss",
     visibility = ["//visibility:private"],
+    x_defs = {
+        "github.com/cockroachdb/cockroach/pkg/build.binaryName": "cockroach-oss",
+    },
     deps = [
         "//pkg/cli",
         "//pkg/ui/distoss",

--- a/pkg/cmd/cockroach-short/BUILD.bazel
+++ b/pkg/cmd/cockroach-short/BUILD.bazel
@@ -5,6 +5,9 @@ go_library(
     srcs = ["main.go"],
     importpath = "github.com/cockroachdb/cockroach/pkg/cmd/cockroach-short",
     visibility = ["//visibility:private"],
+    x_defs = {
+        "github.com/cockroachdb/cockroach/pkg/build.binaryName": "cockroach-short",
+    },
     deps = [
         "//pkg/ccl",
         "//pkg/cli",

--- a/pkg/cmd/cockroach-sql/BUILD.bazel
+++ b/pkg/cmd/cockroach-sql/BUILD.bazel
@@ -5,6 +5,9 @@ go_library(
     srcs = ["main.go"],
     importpath = "github.com/cockroachdb/cockroach/pkg/cmd/cockroach-sql",
     visibility = ["//visibility:private"],
+    x_defs = {
+        "github.com/cockroachdb/cockroach/pkg/build.binaryName": "cockroach-sql",
+    },
     deps = [
         "//pkg/build",
         "//pkg/cli/clicfg",

--- a/pkg/cmd/cockroach/BUILD.bazel
+++ b/pkg/cmd/cockroach/BUILD.bazel
@@ -6,6 +6,9 @@ go_library(
     srcs = ["main.go"],
     importpath = "github.com/cockroachdb/cockroach/pkg/cmd/cockroach",
     visibility = ["//visibility:private"],
+    x_defs = {
+        "github.com/cockroachdb/cockroach/pkg/build.binaryName": "cockroach",
+    },
     deps = [
         "//pkg/ccl",
         "//pkg/ccl/cliccl",

--- a/pkg/cmd/roachprod/BUILD.bazel
+++ b/pkg/cmd/roachprod/BUILD.bazel
@@ -9,6 +9,9 @@ go_library(
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/cmd/roachprod",
     visibility = ["//visibility:private"],
+    x_defs = {
+        "github.com/cockroachdb/cockroach/pkg/build.binaryName": "roachprod",
+    },
     deps = [
         "//pkg/build",
         "//pkg/cmd/roachprod/grafana",

--- a/pkg/cmd/roachtest/BUILD.bazel
+++ b/pkg/cmd/roachtest/BUILD.bazel
@@ -19,6 +19,9 @@ go_library(
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/cmd/roachtest",
     visibility = ["//visibility:private"],
+    x_defs = {
+        "github.com/cockroachdb/cockroach/pkg/build.binaryName": "roachtest",
+    },
     deps = [
         "//pkg/build",
         "//pkg/cmd/internal/issues",

--- a/pkg/util/BUILD.bazel
+++ b/pkg/util/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/util",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/build",
         "//pkg/build/bazel",
         "//pkg/util/buildutil",
         "//pkg/util/envutil",

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -14,7 +14,9 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
+	"strings"
 
+	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/build/bazel"
 	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
@@ -96,6 +98,10 @@ const DisableMetamorphicEnvVar = "COCKROACH_INTERNAL_DISABLE_METAMORPHIC_TESTING
 // initialization of the test module and its dependencies.
 func metamorphicEligible() bool {
 	if !buildutil.CrdbTestBuild {
+		return false
+	}
+	// Bail out if we are running a non-test binary which also happens to be non-cockroach, e.g., roachprod, roachtest.
+	if !bazel.InBazelTest() && !strings.Contains(build.GetInfo().BinaryName, "cockroach") {
 		return false
 	}
 


### PR DESCRIPTION
We now link the name attribute of the go_binary, as it appears in the corresponding BUILD.bazel. The primary motivation for this change is to exclude non-cockroach binaries (i.e., roachtest and roachprod) from the initialization of the metamorphic constants.

Note, to fully support interop between a roachtest runner, (executing the roachtest binary), and a node, executing the cockroach binary compiled with assertions (i.e., crdb_test), the roachtest binary must also be compiled with assertions to establish the same serialization on the wire. E.g., KVNemesisSeq is used on the wire only under crdb_test builds. The corresponding (sequence) Container type is conditional on the binary being compiled under crdb_test. (See pkg/kv/kvpb/api.proto) Thus, a request serialized from the roachtest runner is compatible with the cockroach binary iff both binaries are built under crdb_test.

Epic: none

Release note: None