### PR TITLE
streamingccl: skip TestTenantStreamingFailback under stressrace

### DIFF
--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_job_test.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_job_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/jobutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
@@ -100,6 +101,8 @@ func TestTenantStreamingFailback(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
+
+	skip.UnderStressRace(t, "test takes ~5 minutes under stressrace")
 
 	serverA, aDB, _ := serverutils.StartServer(t, base.TestServerArgs{
 		DefaultTestTenant: base.TestControlsTenantsExplicitly,


### PR DESCRIPTION
TestTenantStreamingFailback typically passes under stressrace, but can take nearly 5 minutes. The overall timeout for our test suite is 7.5 minutes which doesn't leave much time for the rest of the tests in the package.

Fixes #113092

Epic: none

Release note: None