### PR TITLE
kv: assert transaction finalization after re-issued EndTxn

### DIFF
--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_committer.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_committer.go
@@ -465,6 +465,10 @@ func (tc *txnCommitter) retryTxnCommitAfterFailedParallelCommit(
 	if err := br.Combine(ctx, brSuffix, []int{etIdx}, ba); err != nil {
 		return nil, kvpb.NewError(err)
 	}
+	if br.Txn == nil || !br.Txn.Status.IsFinalized() {
+		return nil, kvpb.NewError(errors.AssertionFailedf(
+			"txn status not finalized after successful retried EndTxn: %v", br.Txn))
+	}
 	return br, nil
 }
 

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_span_refresher.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_span_refresher.go
@@ -420,6 +420,10 @@ func (sr *txnSpanRefresher) splitEndTxnAndRetrySend(
 	if err := br.Combine(ctx, brSuffix, []int{etIdx}, ba); err != nil {
 		return nil, kvpb.NewError(err)
 	}
+	if br.Txn == nil || !br.Txn.Status.IsFinalized() {
+		return nil, kvpb.NewError(errors.AssertionFailedf(
+			"txn status not finalized after successful retried EndTxn: %v", br.Txn))
+	}
 	return br, nil
 }
 


### PR DESCRIPTION
Informs #111962.
Informs #111967.

This commit updates the two places where EndTxn requests are re-issued in the TxnCoordSender (one in the txnCommitter, one in the txnSpanRefresher) to ensure that after the retry succeeds and the response is stitched back together, the transaction is finalized.

I have no reason to believe that these assertions will fail.

Release note: None