### PR TITLE
allocator/plan: add `AllowVoterRemovalWhenNotLeader` testing knob

### DIFF
--- a/pkg/kv/kvserver/allocator/allocatorimpl/allocator.go
+++ b/pkg/kv/kvserver/allocator/allocatorimpl/allocator.go
@@ -2938,6 +2938,18 @@ func FilterUnremovableReplicas(
 	brandNewReplicaID roachpb.ReplicaID,
 ) []roachpb.ReplicaDescriptor {
 	upToDateReplicas := FilterBehindReplicas(ctx, raftStatus, replicas)
+	return FilterUnremovableReplicasWithoutRaftStatus(
+		ctx, replicas, upToDateReplicas, brandNewReplicaID)
+}
+
+// FilterUnremovableReplicasWithoutRaftStatus is like FilterUnremovableReplicas,
+// but takes an upToDateReplicas slice to avoid the Raft status dependency.
+func FilterUnremovableReplicasWithoutRaftStatus(
+	ctx context.Context,
+	replicas []roachpb.ReplicaDescriptor,
+	upToDateReplicas []roachpb.ReplicaDescriptor,
+	brandNewReplicaID roachpb.ReplicaID,
+) []roachpb.ReplicaDescriptor {
 	oldQuorum := computeQuorum(len(replicas))
 	if len(upToDateReplicas) < oldQuorum {
 		// The number of up-to-date replicas is less than the old quorum. No

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -1339,6 +1339,7 @@ func (sc *StoreConfig) SetDefaults(numStores int) {
 			sc.TestingKnobs.AllocatorKnobs = &allocator.TestingKnobs{}
 		}
 		sc.TestingKnobs.AllocatorKnobs.AllowLeaseTransfersToReplicasNeedingSnapshots = true
+		sc.TestingKnobs.ReplicaPlannerKnobs.AllowVoterRemovalWhenNotLeader = true // downreplication
 	}
 	if raftDisableQuiescence {
 		sc.TestingKnobs.DisableQuiescence = true


### PR DESCRIPTION
I'll verify with 5 manual runs, but given https://github.com/cockroachdb/cockroach/issues/113059#issuecomment-1781099051 that isn't really saying much. Let's run it through the nightlies.

---

Deflakes `failover/partial/lease-leader`.

Touches #113059.
Epic: none
Release note: None