### PR TITLE
sql/logictest: skip unreliable mixed version tests

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/mixed_version_procedure
+++ b/pkg/sql/logictest/testdata/logic_test/mixed_version_procedure
@@ -33,17 +33,19 @@ CREATE PROCEDURE p() LANGUAGE SQL AS 'SELECT 1'
 
 # Upgrade all nodes.
 
-upgrade 1
-
-upgrade 2
-
-# Makes sure the upgrade job has finished, and the cluster version gate is
-# passed.
-query B retry
-SELECT crdb_internal.is_at_least_version('23.2')
-----
-true
-
-# Creating a procedure should now be possible.
-statement ok
-CREATE PROCEDURE p() LANGUAGE SQL AS 'SELECT 1'
+# TODO(#112621): Unskip these tests. It is currently skipped because the cluster
+# does not reliably complete the upgrade in CI.
+# upgrade 1
+#
+# upgrade 2
+#
+# # Makes sure the upgrade job has finished, and the cluster version gate is
+# # passed.
+# query B retry
+# SELECT crdb_internal.is_at_least_version('23.2')
+# ----
+# true
+#
+# # Creating a procedure should now be possible.
+# statement ok
+# CREATE PROCEDURE p() LANGUAGE SQL AS 'SELECT 1'

--- a/pkg/sql/logictest/testdata/logic_test/mixed_version_udf_execute_privileges
+++ b/pkg/sql/logictest/testdata/logic_test/mixed_version_udf_execute_privileges
@@ -71,31 +71,33 @@ true
 
 # Makes sure the upgrade job has finished, and the cluster version gate is
 # passed.
-query B retry
-SELECT crdb_internal.is_at_least_version('23.2')
-----
-true
-
-query TTTTTTB colnames
-SELECT * FROM [SHOW GRANTS ON FUNCTION f] ORDER BY grantee
-----
-database_name  schema_name  routine_id  routine_signature  grantee  privilege_type  is_grantable
-test           public       100106      f()                admin    ALL             true
-test           public       100106      f()                public   EXECUTE         false
-test           public       100106      f()                root     ALL             true
-
-user testuser1 nodeidx=1
-
-# Makes sure the user can execute f on node 1.
-query I
-SELECT f()
-----
-1
-
-user testuser1 nodeidx=2
-
-# Makes sure the user can execute f on node 2.
-query I
-SELECT f()
-----
-1
+# TODO(#112621): Unskip these tests. It is currently skipped because the cluster
+# does not reliably complete the upgrade in CI.
+# query B retry
+# SELECT crdb_internal.is_at_least_version('23.2')
+# ----
+# true
+#
+# query TTTTTTB colnames
+# SELECT * FROM [SHOW GRANTS ON FUNCTION f] ORDER BY grantee
+# ----
+# database_name  schema_name  routine_id  routine_signature  grantee  privilege_type  is_grantable
+# test           public       100106      f()                admin    ALL             true
+# test           public       100106      f()                public   EXECUTE         false
+# test           public       100106      f()                root     ALL             true
+#
+# user testuser1 nodeidx=1
+#
+# # Makes sure the user can execute f on node 1.
+# query I
+# SELECT f()
+# ----
+# 1
+#
+# user testuser1 nodeidx=2
+#
+# # Makes sure the user can execute f on node 2.
+# query I
+# SELECT f()
+# ----
+# 1

--- a/pkg/sql/logictest/testdata/logic_test/mixed_version_udf_mutations
+++ b/pkg/sql/logictest/testdata/logic_test/mixed_version_udf_mutations
@@ -83,26 +83,28 @@ $$ LANGUAGE SQL;
 # Upgrade all nodes and test that creating UDFs with mutations succeeds.
 # ----------------------------------------------------------------------
 
-upgrade 1
-
-upgrade 2
-
-query B retry
-SELECT crdb_internal.is_at_least_version('23.2')
-----
-true
-
-statement ok
-CREATE FUNCTION f_insert() RETURNS VOID AS $$
-  INSERT INTO t VALUES (1,1);
-$$ LANGUAGE SQL;
-
-statement ok
-CREATE FUNCTION f_delete() RETURNS VOID AS $$
-  DELETE FROM t WHERE a = 1;
-$$ LANGUAGE SQL;
-
-statement ok
-CREATE FUNCTION f_update() RETURNS VOID AS $$
-  UPDATE t SET b = 1 WHERE a = 1;
-$$ LANGUAGE SQL;
+# TODO(#112621): Unskip these tests. It is currently skipped because the cluster
+# does not reliably complete the upgrade in CI.
+# upgrade 1
+#
+# upgrade 2
+#
+# query B retry
+# SELECT crdb_internal.is_at_least_version('23.2')
+# ----
+# true
+#
+# statement ok
+# CREATE FUNCTION f_insert() RETURNS VOID AS $$
+#   INSERT INTO t VALUES (1,1);
+# $$ LANGUAGE SQL;
+#
+# statement ok
+# CREATE FUNCTION f_delete() RETURNS VOID AS $$
+#   DELETE FROM t WHERE a = 1;
+# $$ LANGUAGE SQL;
+#
+# statement ok
+# CREATE FUNCTION f_update() RETURNS VOID AS $$
+#   UPDATE t SET b = 1 WHERE a = 1;
+# $$ LANGUAGE SQL;


### PR DESCRIPTION
Clusters do not reliably complete upgrades in mixed version tests in CI.
This commit skips test cases that rely on completing the upgrade to
avoid flakes.

Informs #112621
