### PR TITLE
release-23.1: kvserver: add metrics for raft (re-)proposals

### DIFF
--- a/pkg/kv/kvserver/metrics.go
+++ b/pkg/kv/kvserver/metrics.go
@@ -1076,9 +1076,38 @@ histogram.
 		Measurement: "Processing Time",
 		Unit:        metric.Unit_NANOSECONDS,
 	}
+	metaRaftCommandsProposed = metric.Metadata{
+		Name: "raft.commands.proposed",
+		Help: `Number of Raft commands proposed.
+
+The number of proposals and all kinds of reproposals made by leaseholders. This
+metric approximates the number of commands submitted through Raft.`,
+		Measurement: "Commands",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaRaftCommandsReproposed = metric.Metadata{
+		Name: "raft.commands.reproposed.unchanged",
+		Help: `Number of Raft commands re-proposed without modification.
+
+The number of Raft commands that leaseholders re-proposed without modification.
+Such re-proposals happen for commands that are not committed/applied within a
+timeout, and have a high chance of being dropped.`,
+		Measurement: "Commands",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaRaftCommandsReproposedLAI = metric.Metadata{
+		Name: "raft.commands.reproposed.new-lai",
+		Help: `Number of Raft commands re-proposed with a newer LAI.
+
+The number of Raft commands that leaseholders re-proposed with a modified LAI.
+Such re-proposals happen for commands that are committed to Raft out of intended
+order, and hence can not be applied as is.`,
+		Measurement: "Commands",
+		Unit:        metric.Unit_COUNT,
+	}
 	metaRaftCommandsApplied = metric.Metadata{
 		Name: "raft.commandsapplied",
-		Help: `Count of Raft commands applied.
+		Help: `Number of Raft commands applied.
 
 This measurement is taken on the Raft apply loops of all Replicas (leaders and
 followers alike), meaning that it does not measure the number of Raft commands
@@ -2192,6 +2221,9 @@ type StoreMetrics struct {
 	RaftQuotaPoolPercentUsed  metric.IHistogram
 	RaftWorkingDurationNanos  *metric.Counter
 	RaftTickingDurationNanos  *metric.Counter
+	RaftCommandsProposed      *metric.Counter
+	RaftCommandsReproposed    *metric.Counter
+	RaftCommandsReproposedLAI *metric.Counter
 	RaftCommandsApplied       *metric.Counter
 	RaftLogCommitLatency      metric.IHistogram
 	RaftCommandCommitLatency  metric.IHistogram
@@ -2782,9 +2814,12 @@ func newStoreMetrics(histogramWindow time.Duration) *StoreMetrics {
 			SigFigs:  1,
 			Buckets:  metric.Percent100Buckets,
 		}),
-		RaftWorkingDurationNanos: metric.NewCounter(metaRaftWorkingDurationNanos),
-		RaftTickingDurationNanos: metric.NewCounter(metaRaftTickingDurationNanos),
-		RaftCommandsApplied:      metric.NewCounter(metaRaftCommandsApplied),
+		RaftWorkingDurationNanos:  metric.NewCounter(metaRaftWorkingDurationNanos),
+		RaftTickingDurationNanos:  metric.NewCounter(metaRaftTickingDurationNanos),
+		RaftCommandsProposed:      metric.NewCounter(metaRaftCommandsProposed),
+		RaftCommandsReproposed:    metric.NewCounter(metaRaftCommandsReproposed),
+		RaftCommandsReproposedLAI: metric.NewCounter(metaRaftCommandsReproposedLAI),
+		RaftCommandsApplied:       metric.NewCounter(metaRaftCommandsApplied),
 		RaftLogCommitLatency: metric.NewHistogram(metric.HistogramOptions{
 			Mode:     metric.HistogramModePreferHdrLatency,
 			Metadata: metaRaftLogCommitLatency,

--- a/pkg/kv/kvserver/replica_application_result.go
+++ b/pkg/kv/kvserver/replica_application_result.go
@@ -286,6 +286,7 @@ func (r *Replica) tryReproposeWithNewLeaseIndex(
 	if pErr != nil {
 		return pErr
 	}
+	r.store.metrics.RaftCommandsReproposedLAI.Inc(1)
 	log.VEventf(ctx, 2, "reproposed command %x", cmd.ID)
 	return nil
 }

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -509,6 +509,7 @@ func (r *Replica) propose(
 	if err != nil {
 		return kvpb.NewError(err)
 	}
+	r.store.metrics.RaftCommandsProposed.Inc(1)
 	return nil
 }
 
@@ -1453,7 +1454,9 @@ func (r *Replica) refreshProposalsLocked(
 			p.finishApplication(ctx, proposalResult{
 				Err: kvpb.NewError(kvpb.NewAmbiguousResultError(err)),
 			})
+			continue
 		}
+		r.store.metrics.RaftCommandsReproposed.Inc(1)
 	}
 }
 

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -1994,6 +1994,23 @@ var charts = []sectionDescription{
 		},
 	},
 	{
+		Organization: [][]string{{ReplicationLayer, "Raft", "Proposals"}},
+		Charts: []chartDescription{
+			{
+				Title:   "Commands Proposed",
+				Metrics: []string{"raft.commands.proposed"},
+			},
+			{
+				Title:   "Commands Reproposed (unchanged)",
+				Metrics: []string{"raft.commands.reproposed.unchanged"},
+			},
+			{
+				Title:   "Commands Reproposed (new LAI)",
+				Metrics: []string{"raft.commands.reproposed.new-lai"},
+			},
+		},
+	},
+	{
 		Organization: [][]string{{ReplicationLayer, "Raft", "Queues"}},
 		Charts: []chartDescription{
 			{


### PR DESCRIPTION
Backport 1/1 commits from #111272.

/cc @cockroachdb/release

---

This commit adds new metrics:

- `raft.commands.proposed`: commands proposed to Raft by leaseholders
- `raft.commands.reproposed.unchanged`: commads retried/reproposed to Raft because they take too long to apply (so they might be dropped)
- `raft.commands.reproposed.new-lai`: commands retried/reproposed to Raft because they were committed to Raft out of order (failed the LAI or closed timestamp check)

The `proposed` metric includes both `reproposed` metrics.

Resolves #105199
Epic: none
Release note (ops change): added metrics for raft proposals and reproposals

Release justification: observability improvement for support escalations