### PR TITLE
execbuilder: de-flake a logic test

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/lookup_join_limit
+++ b/pkg/sql/opt/exec/execbuilder/testdata/lookup_join_limit
@@ -4,7 +4,7 @@
 # rows eagerly in the presence of limit hints.
 
 statement ok
-CREATE TABLE a (x INT PRIMARY KEY, y INT, z INT, INDEX (y));
+CREATE TABLE a (x INT PRIMARY KEY, y INT, z INT, INDEX (y), FAMILY (x, y, z));
 CREATE TABLE b (x INT PRIMARY KEY);
 INSERT INTO a VALUES (1, 1, 1), (2, 1, 1), (3, 2, 2), (4, 2, 2);
 INSERT INTO b VALUES (1), (2), (3), (4);


### PR DESCRIPTION
We recently made a change to use the InOrder mode of the streamer in more cases. In particular, when we have at least 3 column families and we might end up with "family-specific" spans in the lookup and index joins, we'll now use the InOrder mode. That mode needs disk-backed results buffer which can show up as `estimated max sql temp disk usage` line in EXPLAIN ANALYZE output. This made one opt logic test a bit flaky due to randomization of column families, so this commit adjusts a single table with 3 columns to have a single column family to guarantee deterministic output.

Fixes: #113112.

Release note: None