### PR TITLE
admission: use ambient context in debug message

### DIFF
--- a/pkg/util/admission/work_queue.go
+++ b/pkg/util/admission/work_queue.go
@@ -799,7 +799,8 @@ func (q *WorkQueue) Admit(ctx context.Context, info WorkInfo) (enabled bool, err
 		q.metrics.incErrored(info.Priority)
 		q.metrics.recordFinishWait(info.Priority, waitDur)
 		deadline, _ := ctx.Deadline()
-		log.Eventf(ctx, "deadline expired, waited in %s queue for %v",
+		// Don't use the cancelled context.
+		log.Eventf(q.ambientCtx, "deadline expired, waited in %s queue for %v",
 			workKindString(q.workKind), waitDur)
 		return true,
 			errors.Newf("work %s deadline expired while waiting: deadline: %v, start: %v, dur: %v",


### PR DESCRIPTION
The test in https://github.com/cockroachdb/cockroach/issues/113126 fails because the work queue uses a cancelled context to log a message. This change updates the call to use the ambient context which is not cancelled and exists for this purpose.

Release note: None
Epic: None
Closes: https://github.com/cockroachdb/cockroach/issues/113126