### PR TITLE
admission: add tracing for admission work queue

### DIFF
--- a/pkg/util/admission/BUILD.bazel
+++ b/pkg/util/admission/BUILD.bazel
@@ -38,6 +38,7 @@ go_library(
         "//pkg/util/schedulerlatency",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
+        "//pkg/util/tracing",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_logtags//:logtags",
         "@com_github_cockroachdb_pebble//:pebble",

--- a/pkg/util/admission/admissionpb/BUILD.bazel
+++ b/pkg/util/admission/admissionpb/BUILD.bazel
@@ -21,10 +21,15 @@ go_library(
 
 proto_library(
     name = "admissionpb_proto",
-    srcs = ["io_threshold.proto"],
+    srcs = [
+        "admission_stats.proto",
+        "io_threshold.proto",
+    ],
     strip_import_prefix = "/pkg",
     visibility = ["//visibility:public"],
-    deps = ["@com_github_gogo_protobuf//gogoproto:gogo_proto"],
+    deps = [
+        "@com_github_gogo_protobuf//gogoproto:gogo_proto",
+    ],
 )
 
 go_proto_library(
@@ -33,7 +38,9 @@ go_proto_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb",
     proto = ":admissionpb_proto",
     visibility = ["//visibility:public"],
-    deps = ["@com_github_gogo_protobuf//gogoproto"],
+    deps = [
+        "@com_github_gogo_protobuf//gogoproto",
+    ],
 )
 
 go_test(

--- a/pkg/util/admission/admissionpb/admission_stats.proto
+++ b/pkg/util/admission/admissionpb/admission_stats.proto
@@ -1,0 +1,26 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+syntax = "proto3";
+package cockroach.util.admission.admissionpb;
+option go_package = "github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb";
+
+import "gogoproto/gogo.proto";
+
+// AdmissionWorkQueueStats is recorded for work items waiting in the admission
+// work queue.
+message AdmissionWorkQueueStats {
+  // Duration spent waiting.
+  int64 wait_duration_nanos = 1 [(gogoproto.casttype) = "time.Duration"];
+  // String representation of admission work kind.
+  string work_kind = 2;
+  // Set to true if deadline was exceeded.
+  bool deadline_exceeded = 3;
+}


### PR DESCRIPTION
This patch adds some stats about the admission work queue to a tracing span if available as a structured event. This will allow us to know how long work items spend in the queue when debugging increased latency.

Fixes #112126

Release note: None