### PR TITLE
teamcity-trigger: don't pass `--jobs` parameter

### DIFF
--- a/pkg/cmd/teamcity-trigger/main.go
+++ b/pkg/cmd/teamcity-trigger/main.go
@@ -173,9 +173,9 @@ func runTC(queueBuild func(string, map[string]string)) {
 		// Run non-race build.
 		bazelFlags, ok := opts["env.EXTRA_BAZEL_FLAGS"]
 		if ok {
-			opts["env.EXTRA_BAZEL_FLAGS"] = fmt.Sprintf("%s --test_sharding_strategy=disabled --jobs %d", bazelFlags, parallelism)
+			opts["env.EXTRA_BAZEL_FLAGS"] = fmt.Sprintf("%s --test_sharding_strategy=disabled", bazelFlags)
 		} else {
-			opts["env.EXTRA_BAZEL_FLAGS"] = fmt.Sprintf("--test_sharding_strategy=disabled --jobs %d", parallelism)
+			opts["env.EXTRA_BAZEL_FLAGS"] = "--test_sharding_strategy=disabled"
 		}
 
 		opts["env.STRESSFLAGS"] = fmt.Sprintf("-maxruns %d -maxtime %s -maxfails %d -p %d",


### PR DESCRIPTION
This doesn't affect correctness but was probably slowing builds down somewhat.

A thing to note is that we were passing `-p 4` to `stress` as well as `--jobs 4`. Luckily we only run the test once and disable sharding, otherwise concurrency would explode to 16. However the presence of the flag is confusing in addition to probably slowing down builds.

Epic: none
Release note: None