### PR TITLE
roachtest: port `change-replicas/mixed-version` to `mixedversion`

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/helper.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/helper.go
@@ -36,6 +36,15 @@ func (h *Helper) RandomDB(prng *rand.Rand, nodes option.NodeListOption) (int, *g
 	return node, h.Connect(node)
 }
 
+// Query performs `db.QueryContext` on a randomly picked database node. The
+// query and the node picked are logged in the logs of the step that calls this
+// function.
+func (h *Helper) Query(rng *rand.Rand, query string, args ...interface{}) (*gosql.Rows, error) {
+	node, db := h.RandomDB(rng, h.runner.crdbNodes)
+	h.stepLogger.Printf("running SQL statement:\n%s\nArgs: %v\nNode: %d", query, args, node)
+	return db.QueryContext(h.ctx, query, args...)
+}
+
 // QueryRow performs `db.QueryRowContext` on a randomly picked
 // database node. The query and the node picked are logged in the logs
 // of the step that calls this function.

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion.go
@@ -247,6 +247,7 @@ type (
 		minUpgrades            int
 		maxUpgrades            int
 		predecessorFunc        predecessorFunc
+		settings               []install.ClusterSettingOption
 	}
 
 	CustomOption func(*testOptions)
@@ -344,6 +345,14 @@ func NumUpgrades(n int) CustomOption {
 	return func(opts *testOptions) {
 		opts.minUpgrades = n
 		opts.maxUpgrades = n
+	}
+}
+
+// ClusterSettingOption adds a cluster setting option, in addition to the
+// default set of options.
+func ClusterSettingOption(opt ...install.ClusterSettingOption) CustomOption {
+	return func(opts *testOptions) {
+		opts.settings = append(opts.settings, opt...)
 	}
 }
 
@@ -684,6 +693,7 @@ type startStep struct {
 	rt        test.Test
 	version   *clusterupgrade.Version
 	crdbNodes option.NodeListOption
+	settings  []install.ClusterSettingOption
 }
 
 func (s startStep) ID() int                { return s.id }
@@ -704,7 +714,7 @@ func (s startStep) Run(ctx context.Context, l *logger.Logger, c cluster.Cluster,
 	startOpts := option.DefaultStartOptsNoBackups()
 	startOpts.RoachprodOpts.Sequential = false
 	clusterSettings := append(
-		append([]install.ClusterSettingOption{}, defaultClusterSettings...),
+		append([]install.ClusterSettingOption{}, s.settings...),
 		install.BinaryOption(binaryPath),
 	)
 	return clusterupgrade.StartWithSettings(ctx, l, c, s.crdbNodes, startOpts, clusterSettings...)
@@ -773,10 +783,11 @@ func (s preserveDowngradeOptionStep) Run(
 // then the new binary will be uploaded and the `cockroach` process
 // will restart using the new binary.
 type restartWithNewBinaryStep struct {
-	id      int
-	version *clusterupgrade.Version
-	rt      test.Test
-	node    int
+	id       int
+	version  *clusterupgrade.Version
+	rt       test.Test
+	node     int
+	settings []install.ClusterSettingOption
 }
 
 func (s restartWithNewBinaryStep) ID() int                { return s.id }
@@ -803,7 +814,7 @@ func (s restartWithNewBinaryStep) Run(
 		// scheduled backup if necessary.
 		option.DefaultStartOptsNoBackups(),
 		s.version,
-		defaultClusterSettings...,
+		s.settings...,
 	)
 }
 


### PR DESCRIPTION
**roachtestutil/mixedversion: add `ClusterSettingOption`**

This allows e.g. passing envvars to clusters.

**roachtest: port `change-replicas/mixed-version` to `mixedversion`**

Resolves #110532.
Epic: none
Release note: None
