### PR TITLE
c2c: only persist physical specs after initial plan

### DIFF
--- a/pkg/ccl/streamingccl/streamingest/replication_execution_details.go
+++ b/pkg/ccl/streamingccl/streamingest/replication_execution_details.go
@@ -185,5 +185,8 @@ func persistStreamIngestionPartitionSpecs(
 		}
 		return jobs.WriteChunkedFileToJobInfo(ctx, replicationPartitionInfoFilename, specBytes, txn, ingestionJobID)
 	})
+	if knobs := execCfg.StreamingTestingKnobs; knobs != nil && knobs.AfterPersistingPartitionSpecs != nil {
+		knobs.AfterPersistingPartitionSpecs()
+	}
 	return err
 }

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1790,6 +1790,8 @@ type StreamingTestingKnobs struct {
 	AfterReplicationFlowPlan func(map[base.SQLInstanceID]*execinfrapb.StreamIngestionDataSpec,
 		*execinfrapb.StreamIngestionFrontierSpec)
 
+	AfterPersistingPartitionSpecs func()
+
 	// OverrideRevertRangeBatchSize allows overriding the `MaxSpanRequestKeys`
 	// used when sending a RevertRange request.
 	OverrideRevertRangeBatchSize int64


### PR DESCRIPTION
This patch fixes a bug where the distSQL replanner, which generates physical plan candidates, would persist the candidate plan to the job info table, even though the plan would not get executed. This patch tweaks the planning logic to only persist the initialPlan which is the only plan that gets executed. Note that if the replanner discovers a candidate plan it prefers, it will shutdown the distSQL flow and choose a new initialPlan.

Fixes #113223

Release note: None