### PR TITLE
kv,server,roachpb: avoid error overhead for x-locality comparison

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -2656,12 +2656,12 @@ func (ds *DistSender) getLocalityComparison(
 		return roachpb.LocalityComparisonType_UNDEFINED
 	}
 
-	comparisonResult, regionErr, zoneErr := gatewayNodeDesc.Locality.CompareWithLocality(destinationNodeDesc.Locality)
-	if regionErr != nil {
-		log.VInfof(ctx, 5, "unable to determine if the given nodes are cross region %v", regionErr)
+	comparisonResult, regionValid, zoneValid := gatewayNodeDesc.Locality.CompareWithLocality(destinationNodeDesc.Locality)
+	if !regionValid {
+		log.VInfof(ctx, 5, "unable to determine if the given nodes are cross region")
 	}
-	if zoneErr != nil {
-		log.VInfof(ctx, 5, "unable to determine if the given nodes are cross zone %v", zoneErr)
+	if !zoneValid {
+		log.VInfof(ctx, 5, "unable to determine if the given nodes are cross zone")
 	}
 	return comparisonResult
 }

--- a/pkg/kv/kvserver/store_snapshot.go
+++ b/pkg/kv/kvserver/store_snapshot.go
@@ -1272,12 +1272,12 @@ func (s *Store) getLocalityComparison(
 ) roachpb.LocalityComparisonType {
 	firstLocality := s.cfg.StorePool.GetNodeLocality(fromNodeID)
 	secLocality := s.cfg.StorePool.GetNodeLocality(toNodeID)
-	comparisonResult, regionErr, zoneErr := firstLocality.CompareWithLocality(secLocality)
-	if regionErr != nil {
-		log.VEventf(ctx, 5, "unable to determine if the given nodes are cross region %v", regionErr)
+	comparisonResult, regionValid, zoneValid := firstLocality.CompareWithLocality(secLocality)
+	if !regionValid {
+		log.VEventf(ctx, 5, "unable to determine if the given nodes are cross region")
 	}
-	if zoneErr != nil {
-		log.VEventf(ctx, 5, "unable to determine if the given nodes are cross zone %v", zoneErr)
+	if !zoneValid {
+		log.VEventf(ctx, 5, "unable to determine if the given nodes are cross zone")
 	}
 	return comparisonResult
 }

--- a/pkg/roachpb/metadata.go
+++ b/pkg/roachpb/metadata.go
@@ -698,7 +698,7 @@ func (l Locality) getFirstRegionFirstZone() (
 // iteration.
 func (l Locality) CompareWithLocality(
 	other Locality,
-) (_ LocalityComparisonType, regionErr error, zoneErr error) {
+) (_ LocalityComparisonType, regionValid bool, zoneValid bool) {
 	firstRegionValue, hasRegion, firstZoneKey, firstZone, hasZone := l.getFirstRegionFirstZone()
 	firstRegionValueOther, hasRegionOther, firstZoneKeyOther, firstZoneOther, hasZoneOther := other.getFirstRegionFirstZone()
 
@@ -707,21 +707,23 @@ func (l Locality) CompareWithLocality(
 
 	if !hasRegion || !hasRegionOther {
 		isCrossRegion = false
-		regionErr = errors.Errorf("localities must have a valid region tier key for cross-region comparison")
+	} else {
+		regionValid = true
 	}
 
 	if (!hasZone || !hasZoneOther) || (firstZoneKey != firstZoneKeyOther) {
 		isCrossZone = false
-		zoneErr = errors.Errorf("localities must have a valid zone tier key for cross-zone comparison")
+	} else {
+		zoneValid = true
 	}
 
 	if isCrossRegion {
-		return LocalityComparisonType_CROSS_REGION, regionErr, zoneErr
+		return LocalityComparisonType_CROSS_REGION, regionValid, zoneValid
 	} else {
 		if isCrossZone {
-			return LocalityComparisonType_SAME_REGION_CROSS_ZONE, regionErr, zoneErr
+			return LocalityComparisonType_SAME_REGION_CROSS_ZONE, regionValid, zoneValid
 		} else {
-			return LocalityComparisonType_SAME_REGION_SAME_ZONE, regionErr, zoneErr
+			return LocalityComparisonType_SAME_REGION_SAME_ZONE, regionValid, zoneValid
 		}
 	}
 }

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -1401,12 +1401,12 @@ func (n *Node) getLocalityComparison(
 		return roachpb.LocalityComparisonType_UNDEFINED
 	}
 
-	comparisonResult, regionErr, zoneErr := n.Descriptor.Locality.CompareWithLocality(gatewayNodeDesc.Locality)
-	if regionErr != nil {
-		log.VInfof(ctx, 5, "unable to determine if the given nodes are cross region %v", regionErr)
+	comparisonResult, regionValid, zoneValid := n.Descriptor.Locality.CompareWithLocality(gatewayNodeDesc.Locality)
+	if !regionValid {
+		log.VInfof(ctx, 5, "unable to determine if the given nodes are cross region")
 	}
-	if zoneErr != nil {
-		log.VInfof(ctx, 5, "unable to determine if the given nodes are cross zone %v", zoneErr)
+	if !zoneValid {
+		log.VInfof(ctx, 5, "unable to determine if the given nodes are cross zone")
 	}
 
 	return comparisonResult


### PR DESCRIPTION
Cross locality traffic instrumentation  was added to raft, snapshots and batch requests to quantify the amount of cross region/zone traffic. Errors would be returned from `CompareWithLocality` when the region, or zone locality flags were set in an unsupported manner according to our documentation. These error allocations added overhead (cpu/mem) when hit.

Alter `CompareWithLocality` to return booleans in place of an error to reduce overhead.

Resolves: #111148
Resolves: #111142
Informs: #111561
Release note: None