### PR TITLE
build: fix test name and visibility in schema change test script

### DIFF
--- a/build/teamcity/cockroach/nightlies/schema_changer_comparator_nightly_impl.sh
+++ b/build/teamcity/cockroach/nightlies/schema_changer_comparator_nightly_impl.sh
@@ -14,7 +14,7 @@ BAZEL_BIN=$(bazel info bazel-bin --config=ci)
 # Run schema changer comparator test.
 $BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci test -- --config=ci \
   //pkg/sql/schemachanger:schemachanger_test \
-  --test_filter='^TestComparatorFromLogicTests' \
+  --test_filter='^TestSchemaChangeComparator' \
   --test_env=GO_TEST_WRAP_TESTV=1 \
   --test_env=GO_TEST_WRAP=1 \
   --test_env=COCKROACH_SCHEMA_CHANGE_COMPARATOR_SKIP=false \

--- a/pkg/sql/schemachanger/BUILD.bazel
+++ b/pkg/sql/schemachanger/BUILD.bazel
@@ -24,6 +24,7 @@ go_test(
     name = "schemachanger_test",
     size = "enormous",
     srcs = [
+        "comparator_generated_test.go",  # keep
         "comparator_test.go",
         "dml_injection_test.go",
         "main_test.go",
@@ -34,7 +35,9 @@ go_test(
         "//build/toolchains:use_ci_timeouts": ["-test.timeout=895s"],
         "//conditions:default": ["-test.timeout=3595s"],
     }),
-    data = glob(["testdata/**"]),
+    data = glob(["testdata/**"]) + [
+        "//pkg/sql/logictest:testdata",
+    ],
     exec_properties = {"Pool": "large"},
     shard_count = 16,
     deps = [

--- a/pkg/sql/schemachanger/comparator_generated_test.go
+++ b/pkg/sql/schemachanger/comparator_generated_test.go
@@ -16,2604 +16,2170 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
 func TestSchemaChangeComparator_aggregate(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/aggregate"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_alias_types(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/alias_types"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_alter_column_type(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/alter_column_type"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_alter_database_convert_to_schema(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/alter_database_convert_to_schema"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_alter_database_owner(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/alter_database_owner"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_alter_default_privileges_for_all_roles(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/alter_default_privileges_for_all_roles"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_alter_default_privileges_for_schema(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/alter_default_privileges_for_schema"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_alter_default_privileges_for_sequence(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/alter_default_privileges_for_sequence"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_alter_default_privileges_for_table(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/alter_default_privileges_for_table"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_alter_default_privileges_for_type(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/alter_default_privileges_for_type"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_alter_default_privileges_in_schema(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/alter_default_privileges_in_schema"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_alter_default_privileges_with_grant_option(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/alter_default_privileges_with_grant_option"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_alter_primary_key(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/alter_primary_key"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_alter_role(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/alter_role"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_alter_role_set(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/alter_role_set"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_alter_schema_owner(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/alter_schema_owner"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_alter_sequence(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/alter_sequence"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_alter_sequence_owner(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/alter_sequence_owner"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_alter_table(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/alter_table"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_alter_table_owner(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/alter_table_owner"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_alter_type(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/alter_type"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_alter_type_owner(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/alter_type_owner"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_alter_view_owner(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/alter_view_owner"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_and_or(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/and_or"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_apply_join(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/apply_join"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_array(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/array"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_as_of(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/as_of"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_asyncpg(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/asyncpg"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_auto_span_config_reconciliation_job(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/auto_span_config_reconciliation_job"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_bit(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/bit"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_builtin_function(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/builtin_function"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_builtin_function_notenant(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/builtin_function_notenant"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_bytes(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/bytes"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_cascade(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/cascade"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_case_sensitive_names(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/case_sensitive_names"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_cast(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/cast"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_ccl(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/ccl"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_check_constraints(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/check_constraints"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_cluster_locks(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/cluster_locks"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_cluster_settings(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/cluster_settings"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_collatedstring(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/collatedstring"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_collatedstring_constraint(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/collatedstring_constraint"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_collatedstring_index1(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/collatedstring_index1"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_collatedstring_index2(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/collatedstring_index2"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_collatedstring_normalization(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/collatedstring_normalization"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_collatedstring_nullinindex(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/collatedstring_nullinindex"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_collatedstring_uniqueindex1(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/collatedstring_uniqueindex1"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_collatedstring_uniqueindex2(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/collatedstring_uniqueindex2"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_column_families(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/column_families"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_comment_on(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/comment_on"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_composite_types(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/composite_types"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_computed(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/computed"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_conditional(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/conditional"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_connect_privilege(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/connect_privilege"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_contention_event(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/contention_event"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_crdb_internal(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/crdb_internal"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_crdb_internal_catalog(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/crdb_internal_catalog"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_crdb_internal_default_privileges(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/crdb_internal_default_privileges"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_create_as(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/create_as"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_create_as_non_metamorphic(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/create_as_non_metamorphic"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_create_index(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/create_index"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_create_statements(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/create_statements"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_create_table(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/create_table"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_cross_join(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/cross_join"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_cursor(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/cursor"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_custom_escape_character(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/custom_escape_character"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_dangerous_statements(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/dangerous_statements"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_database(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/database"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_datetime(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/datetime"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_decimal(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/decimal"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_default(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/default"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_delete(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/delete"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_delete_batch(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/delete_batch"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_dependencies(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/dependencies"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_discard(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/discard"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_disjunction_in_join(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/disjunction_in_join"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_dist_vectorize(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/dist_vectorize"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_distinct(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/distinct"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_distinct_on(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/distinct_on"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_distsql_agg(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/distsql_agg"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_distsql_automatic_stats(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/distsql_automatic_stats"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_distsql_builtin(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/distsql_builtin"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_distsql_crdb_internal(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/distsql_crdb_internal"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_distsql_datetime(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/distsql_datetime"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_distsql_distinct_on(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/distsql_distinct_on"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_distsql_enum(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/distsql_enum"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_distsql_event_log(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/distsql_event_log"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_distsql_expr(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/distsql_expr"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_distsql_join(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/distsql_join"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_distsql_numtables(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/distsql_numtables"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_distsql_srfs(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/distsql_srfs"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_distsql_stats(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/distsql_stats"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_distsql_subquery(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/distsql_subquery"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_distsql_tenant(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/distsql_tenant"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_distsql_tenant_locality(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/distsql_tenant_locality"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_distsql_union(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/distsql_union"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_drop_database(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/drop_database"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_drop_function(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/drop_function"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_drop_index(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/drop_index"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_drop_owned_by(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/drop_owned_by"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_drop_procedure(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/drop_procedure"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_drop_role_with_default_privileges(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/drop_role_with_default_privileges"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_drop_role_with_default_privileges_in_schema(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/drop_role_with_default_privileges_in_schema"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_drop_schema(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/drop_schema"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_drop_sequence(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/drop_sequence"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_drop_table(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/drop_table"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_drop_temp(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/drop_temp"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_drop_type(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/drop_type"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_drop_user(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/drop_user"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_drop_view(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/drop_view"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_edge(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/edge"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_enums(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/enums"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_errors(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/errors"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_event_log(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/event_log"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_event_log_legacy(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/event_log_legacy"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_exclude_data_from_backup(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/exclude_data_from_backup"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_experimental_distsql_planning(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/experimental_distsql_planning"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_experimental_distsql_planning_5node(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/experimental_distsql_planning_5node"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_explain(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/explain"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_explain_analyze(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/explain_analyze"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_export(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/export"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_expression_index(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/expression_index"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_external_connection_privileges(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/external_connection_privileges"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_family(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/family"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_feature_counts(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/feature_counts"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_fk(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/fk"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_fk_read_committed(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/fk_read_committed"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_float(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/float"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_format(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/format"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_function_lookup(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/function_lookup"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_fuzzystrmatch(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/fuzzystrmatch"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_gc_job_mixed(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/gc_job_mixed"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_gen_test_objects(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/gen_test_objects"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_generator_probe_ranges(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/generator_probe_ranges"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_geospatial(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/geospatial"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_geospatial_bbox(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/geospatial_bbox"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_geospatial_index(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/geospatial_index"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_geospatial_meta(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/geospatial_meta"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_geospatial_regression(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/geospatial_regression"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_geospatial_zm(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/geospatial_zm"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_grant_database(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/grant_database"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_grant_in_txn(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/grant_in_txn"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_grant_inherited(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/grant_inherited"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_grant_on_all_sequences_in_schema(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/grant_on_all_sequences_in_schema"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_grant_on_all_tables_in_schema(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/grant_on_all_tables_in_schema"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_grant_revoke_with_grant_option(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/grant_revoke_with_grant_option"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_grant_role(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/grant_role"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_grant_schema(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/grant_schema"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_grant_sequence(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/grant_sequence"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_grant_table(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/grant_table"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_grant_type(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/grant_type"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_group_join(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/group_join"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_guardrails(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/guardrails"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_hash_join(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/hash_join"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_hash_join_dist(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/hash_join_dist"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_hash_sharded_index(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/hash_sharded_index"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_hash_sharded_index_read_committed(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/hash_sharded_index_read_committed"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_hidden_columns(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/hidden_columns"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_impure(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/impure"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_index_join(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/index_join"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_inet(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/inet"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_inflight_trace_spans(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/inflight_trace_spans"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_information_schema(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/information_schema"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_inner_join(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/inner-join"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_insert(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/insert"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_int_size(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/int_size"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_internal_executor(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/internal_executor"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_interval(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/interval"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_inv_stats(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/inv_stats"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_inverted_filter_geospatial(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/inverted_filter_geospatial"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_inverted_filter_geospatial_dist(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/inverted_filter_geospatial_dist"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_inverted_filter_json_array(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/inverted_filter_json_array"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_inverted_index(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/inverted_index"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_inverted_index_geospatial(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/inverted_index_geospatial"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_inverted_index_multi_column(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/inverted_index_multi_column"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_inverted_join_geospatial(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/inverted_join_geospatial"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_inverted_join_geospatial_bbox(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/inverted_join_geospatial_bbox"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_inverted_join_geospatial_dist(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/inverted_join_geospatial_dist"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_inverted_join_json_array(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/inverted_join_json_array"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_inverted_join_multi_column(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/inverted_join_multi_column"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_jobs(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/jobs"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_join(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/join"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_json(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/json"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_json_builtins(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/json_builtins"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_json_index(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/json_index"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_json_index_local_mixed(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/json_index_local_mixed"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_kv_builtin_functions(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/kv_builtin_functions"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_kv_builtin_functions_local(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/kv_builtin_functions_local"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_kv_builtin_functions_tenant(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/kv_builtin_functions_tenant"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_limit(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/limit"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_locality(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/locality"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_lock_timeout(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/lock_timeout"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_lookup_join(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/lookup_join"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_lookup_join_local(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/lookup_join_local"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_lookup_join_spans(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/lookup_join_spans"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_manual_retry(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/manual_retry"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_materialized_view(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/materialized_view"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_merge_join(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/merge_join"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_merge_join_dist(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/merge_join_dist"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_mixed_version_bootstrap_tenant(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/mixed_version_bootstrap_tenant"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_mixed_version_can_login(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/mixed_version_can_login"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_mixed_version_database_role_settings_role_id(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/mixed_version_database_role_settings_role_id"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_mixed_version_external_connections_owner_id(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/mixed_version_external_connections_owner_id"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_mixed_version_insights_queries(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/mixed_version_insights_queries"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_mixed_version_partially_visible_index(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/mixed_version_partially_visible_index"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_mixed_version_plpgsql(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/mixed_version_plpgsql"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_mixed_version_procedure(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/mixed_version_procedure"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_mixed_version_refcursor(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/mixed_version_refcursor"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_mixed_version_role_members_user_ids(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/mixed_version_role_members_user_ids"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_mixed_version_schedule_details(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/mixed_version_schedule_details"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_mixed_version_system_privileges_user_id(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/mixed_version_system_privileges_user_id"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_mixed_version_udf_execute_privileges(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/mixed_version_udf_execute_privileges"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_mixed_version_udf_mutations(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/mixed_version_udf_mutations"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_mixed_version_upgrade_repair_descriptors(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/mixed_version_upgrade_repair_descriptors"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_multi_region(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/multi_region"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_multi_statement(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/multi_statement"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_multiregion_invalid_locality(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/multiregion_invalid_locality"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_name_escapes(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/name_escapes"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_namespace(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/namespace"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_new_schema_changer(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/new_schema_changer"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_no_primary_key(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/no_primary_key"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_notice(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/notice"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_numeric_references(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/numeric_references"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_on_update(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/on_update"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_operator(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/operator"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_optimizer_timeout(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/optimizer_timeout"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_order_by(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/order_by"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_ordinal_references(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/ordinal_references"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_ordinality(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/ordinality"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_orms(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/orms"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_overflow(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/overflow"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_overlaps(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/overlaps"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_owner(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/owner"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_parallel_stmts_compat(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/parallel_stmts_compat"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_partial_index(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/partial_index"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_partial_txn_commit(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/partial_txn_commit"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_partitioning(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/partitioning"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_pg_builtins(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/pg_builtins"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_pg_catalog(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/pg_catalog"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_pg_catalog_pg_default_acl(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/pg_catalog_pg_default_acl"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_pg_catalog_pg_default_acl_with_grant_option(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/pg_catalog_pg_default_acl_with_grant_option"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_pg_extension(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/pg_extension"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_pg_lsn(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/pg_lsn"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_pg_lsn_mixed(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/pg_lsn_mixed"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_pgcrypto_builtins(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/pgcrypto_builtins"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_pgoidtype(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/pgoidtype"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_plpgsql_builtins(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/plpgsql_builtins"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_plpgsql_cursor(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/plpgsql_cursor"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_poison_after_push(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/poison_after_push"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_postgres_jsonb(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/postgres_jsonb"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_postgresjoin(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/postgresjoin"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_prepare(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/prepare"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_privilege_builtins(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/privilege_builtins"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_privileges_comments(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/privileges_comments"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_privileges_table(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/privileges_table"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_procedure(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/procedure"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_procedure_plpgsql(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/procedure_plpgsql"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_procedure_privileges(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/procedure_privileges"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_procedure_schema_change(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/procedure_schema_change"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_propagate_input_ordering(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/propagate_input_ordering"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_rand_ident(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/rand_ident"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_ranges(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/ranges"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_read_committed(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/read_committed"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_reassign_owned_by(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/reassign_owned_by"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_record(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/record"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_redact_descriptor(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/redact_descriptor"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_refcursor(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/refcursor"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_rename_atomic(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/rename_atomic"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_rename_column(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/rename_column"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_rename_constraint(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/rename_constraint"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_rename_database(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/rename_database"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_rename_index(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/rename_index"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_rename_sequence(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/rename_sequence"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_rename_table(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/rename_table"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_rename_view(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/rename_view"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_reset(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/reset"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_retry(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/retry"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_returning(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/returning"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_role(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/role"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_routine_schema_change(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/routine_schema_change"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_row_level_ttl(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/row_level_ttl"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_rows_from(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/rows_from"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_run_control(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/run_control"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_save_table(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/save_table"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_savepoints(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/savepoints"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_scale(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/scale"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_scatter(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/scatter"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_schema(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/schema"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_schema_change_feature_flags(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/schema_change_feature_flags"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_schema_change_in_txn(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/schema_change_in_txn"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_schema_change_retry(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/schema_change_retry"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_schema_locked(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/schema_locked"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_schema_repair(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/schema_repair"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_scrub(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/scrub"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_secondary_index_column_families(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/secondary_index_column_families"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_select(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/select"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_select_for_share(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/select_for_share"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_select_for_update(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/select_for_update"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_select_for_update_read_committed(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/select_for_update_read_committed"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_select_index(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/select_index"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_select_index_flags(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/select_index_flags"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_select_search_path(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/select_search_path"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_select_table_alias(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/select_table_alias"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_sequences(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/sequences"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_sequences_distsql(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/sequences_distsql"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_sequences_regclass(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/sequences_regclass"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_serial(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/serial"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_serializable_eager_restart(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/serializable_eager_restart"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_set(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/set"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_set_local(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/set_local"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_set_role(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/set_role"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_set_schema(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/set_schema"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_set_time_zone(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/set_time_zone"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_shift(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/shift"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_show_commit_timestamp(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/show_commit_timestamp"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_show_completions(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/show_completions"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_show_create(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/show_create"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_show_create_all_schemas(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/show_create_all_schemas"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_show_create_all_tables(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/show_create_all_tables"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_show_create_all_tables_builtin(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/show_create_all_tables_builtin"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_show_create_all_types(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/show_create_all_types"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_show_create_redact(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/show_create_redact"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_show_default_privileges(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/show_default_privileges"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_show_fingerprints(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/show_fingerprints"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_show_grants_on_virtual_table(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/show_grants_on_virtual_table"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_show_grants_synthetic(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/show_grants_synthetic"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_show_indexes(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/show_indexes"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_show_ranges(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/show_ranges"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_show_source(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/show_source"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_show_tables(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/show_tables"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_show_tenant_fingerprints(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/show_tenant_fingerprints"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_show_transfer_state(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/show_transfer_state"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_show_var(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/show_var"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_skip_on_retry(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/skip_on_retry"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_span_builtins(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/span_builtins"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_split_at(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/split_at"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_sql_keys(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/sql_keys"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_sqllite(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/sqllite"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_sqlsmith(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/sqlsmith"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_srfs(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/srfs"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_statement_source(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/statement_source"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_statement_statistics(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/statement_statistics"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_statement_statistics_errors(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/statement_statistics_errors"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_statement_statistics_errors_redacted(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/statement_statistics_errors_redacted"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_stats(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/stats"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_storing(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/storing"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_strict_ddl_atomicity(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/strict_ddl_atomicity"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_suboperators(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/suboperators"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_subquery(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/subquery"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_subquery_correlated(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/subquery_correlated"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_synthetic_privileges(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/synthetic_privileges"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_system(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/system"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_system_columns(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/system_columns"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_system_namespace(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/system_namespace"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_table(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/table"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_target_names(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/target_names"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_temp_table(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/temp_table"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_temp_table_txn(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/temp_table_txn"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_tenant(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/tenant"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_tenant_builtins(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/tenant_builtins"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_tenant_from_tenant(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/tenant_from_tenant"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_tenant_from_tenant_hint(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/tenant_from_tenant_hint"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_tenant_slow_repro(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/tenant_slow_repro"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_tenant_span_stats(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/tenant_span_stats"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_time(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/time"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_timestamp(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/timestamp"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_timetz(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/timetz"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_trigram_builtins(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/trigram_builtins"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_trigram_indexes(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/trigram_indexes"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_truncate(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/truncate"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_truncate_with_concurrent_mutation(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/truncate_with_concurrent_mutation"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_tsvector(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/tsvector"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_tuple(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/tuple"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_tuple_local(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/tuple_local"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_txn(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/txn"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_txn_as_of(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/txn_as_of"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_txn_retry(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/txn_retry"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_txn_stats(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/txn_stats"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_type_privileges(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/type_privileges"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_typing(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/typing"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_udf(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/udf"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_udf_delete(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/udf_delete"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_udf_fk(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/udf_fk"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_udf_in_column_defaults(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/udf_in_column_defaults"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_udf_in_constraints(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/udf_in_constraints"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_udf_insert(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/udf_insert"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_udf_observability(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/udf_observability"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_udf_oid_ref(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/udf_oid_ref"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_udf_options(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/udf_options"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_udf_plpgsql(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/udf_plpgsql"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_udf_prepare(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/udf_prepare"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_udf_privileges(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/udf_privileges"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_udf_privileges_mutations(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/udf_privileges_mutations"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_udf_record(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/udf_record"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_udf_regressions(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/udf_regressions"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_udf_schema_change(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/udf_schema_change"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_udf_setof(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/udf_setof"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_udf_star(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/udf_star"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_udf_subquery(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/udf_subquery"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_udf_unsupported(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/udf_unsupported"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_udf_update(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/udf_update"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_udf_upsert(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/udf_upsert"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_udf_volatility_check(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/udf_volatility_check"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_union(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/union"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_unique(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/unique"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_unique_read_committed(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/unique_read_committed"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_update(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/update"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_update_from(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/update_from"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_upsert(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/upsert"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_upsert_non_metamorphic(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/upsert_non_metamorphic"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_user(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/user"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_uuid(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/uuid"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_values(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/values"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_vectorize(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/vectorize"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_vectorize_agg(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/vectorize_agg"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_vectorize_local(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/vectorize_local"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_vectorize_overloads(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/vectorize_overloads"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_vectorize_shutdown(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/vectorize_shutdown"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_vectorize_types(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/vectorize_types"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_vectorize_unsupported(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/vectorize_unsupported"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_vectorize_window(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/vectorize_window"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_views(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/views"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_virtual_columns(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/virtual_columns"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_virtual_table_privileges(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/virtual_table_privileges"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_void(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/void"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_where(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/where"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_window(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/window"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_with(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/with"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_workload_indexrecs(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/workload_indexrecs"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_zero(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/zero"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_zigzag_join(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/zigzag_join"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_zone_config(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/zone_config"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_zone_config_system_tenant(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/zone_config_system_tenant"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }

--- a/pkg/sql/schemachanger/comparator_test.go
+++ b/pkg/sql/schemachanger/comparator_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/sctest"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
-	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/stretchr/testify/require"
 )
@@ -44,9 +43,7 @@ func (ss *staticSQLStmtLineProvider) NextLine() string {
 }
 
 func runSchemaChangeComparatorTest(t *testing.T, logicTestFile string) {
-	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-
 	var path string
 	if bazel.BuiltWithBazel() {
 		var err error

--- a/pkg/sql/schemachanger/sctest/sccomparatortestgen/main.go
+++ b/pkg/sql/schemachanger/sctest/sccomparatortestgen/main.go
@@ -87,14 +87,12 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
 {{ range $index, $file := $.Files -}}
 
 func TestSchemaChangeComparator_{{ basename $file }}(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	var logicTestFile = "{{ $file }}"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }


### PR DESCRIPTION
The previous commit (3d36139e5fb) forgot to update the name of the test
in the script when it was renamed, and also forgot to update the bazel
visibility rules.
Epic: None
Release note: None