### PR TITLE
rttanalysis: adjust expectations for drop_3_roles

### DIFF
--- a/pkg/bench/rttanalysis/testdata/benchmark_expectations
+++ b/pkg/bench/rttanalysis/testdata/benchmark_expectations
@@ -41,7 +41,7 @@ exp,benchmark
 18,DropDatabase/drop_database_3_tables
 27,DropRole/drop_1_role
 36,DropRole/drop_2_roles
-45,DropRole/drop_3_roles
+43-46,DropRole/drop_3_roles
 15,DropSequence/drop_1_sequence
 17,DropSequence/drop_2_sequences
 19,DropSequence/drop_3_sequences


### PR DESCRIPTION
Sometimes this test performs fewer round-trips. Lower is better, so we can adjust the expectation to allow a wider range.

fixes https://github.com/cockroachdb/cockroach/issues/113137
Release note: None