### PR TITLE
release-23.1: roachtest: update hibernate test to use 6.3.1

### DIFF
--- a/pkg/cmd/roachtest/tests/hibernate.go
+++ b/pkg/cmd/roachtest/tests/hibernate.go
@@ -23,7 +23,10 @@ import (
 )
 
 var hibernateReleaseTagRegex = regexp.MustCompile(`^(?P<major>\d+)\.(?P<minor>\d+)\.(?P<point>\d+)$`)
-var supportedHibernateTag = "5.6.15"
+
+// WARNING: DO NOT MODIFY the name of the below constant/variable without approval from the docs team.
+// This is used by docs automation to produce a list of supported versions for ORM's.
+var supportedHibernateTag = "6.3.1"
 
 type hibernateOptions struct {
 	testName string
@@ -39,7 +42,7 @@ var (
 		testName: "hibernate",
 		testDir:  "hibernate-core",
 		buildCmd: `cd /mnt/data1/hibernate/hibernate-core/ && ./../gradlew test -Pdb=cockroachdb ` +
-			`--tests org.hibernate.jdbc.util.BasicFormatterTest.*`,
+			`--tests org.hibernate.orm.test.jdbc.util.BasicFormatterTest.*`,
 		testCmd: "cd /mnt/data1/hibernate/hibernate-core/ && ./../gradlew test -Pdb=cockroachdb",
 		listWithName: listWithName{
 			blocklistName:  "hibernateBlockList",
@@ -52,10 +55,10 @@ var (
 	hibernateSpatialOpts = hibernateOptions{
 		testName: "hibernate-spatial",
 		testDir:  "hibernate-spatial",
-		buildCmd: `cd /mnt/data1/hibernate/hibernate-spatial/ && ./../gradlew test -Pdb=cockroachdb_spatial ` +
+		buildCmd: `cd /mnt/data1/hibernate/hibernate-spatial/ && ./../gradlew test -Pdb=cockroachdb ` +
 			`--tests org.hibernate.spatial.dialect.postgis.*`,
 		testCmd: `cd /mnt/data1/hibernate/hibernate-spatial && ` +
-			`HIBERNATE_CONNECTION_LEAK_DETECTION=true ./../gradlew test -Pdb=cockroachdb_spatial`,
+			`HIBERNATE_CONNECTION_LEAK_DETECTION=true ./../gradlew test -Pdb=cockroachdb`,
 		listWithName: listWithName{
 			blocklistName:  "hibernateSpatialBlockList",
 			blocklist:      hibernateSpatialBlockList,
@@ -121,14 +124,13 @@ func registerHibernate(r registry.Registry, opt hibernateOptions) {
 			t.Fatal(err)
 		}
 
-		// TODO(rafi): use openjdk-11-jdk-headless once we are off of Ubuntu 16.
 		if err := repeatRunE(
 			ctx,
 			t,
 			c,
 			node,
 			"install dependencies",
-			`sudo apt-get -qq install default-jre openjdk-8-jdk-headless gradle`,
+			`sudo apt-get -qq install openjdk-11-jre-headless openjdk-11-jdk-headless`,
 		); err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/cmd/roachtest/tests/hibernate_blocklist.go
+++ b/pkg/cmd/roachtest/tests/hibernate_blocklist.go
@@ -15,24 +15,7 @@ package tests
 // in the test log.
 var hibernateSpatialBlockList = blocklist{}
 
-var hibernateBlockList = blocklist{
-	"org.hibernate.jpa.test.graphs.FetchGraphTest.testCollectionEntityGraph":                                                "unknown",
-	"org.hibernate.jpa.test.packaging.PackagedEntityManagerTest.testConfiguration":                                          "unknown",
-	"org.hibernate.jpa.test.packaging.PackagedEntityManagerTest.testDefaultPar":                                             "unknown",
-	"org.hibernate.jpa.test.packaging.PackagedEntityManagerTest.testDefaultParForPersistence_1_0":                           "unknown",
-	"org.hibernate.jpa.test.packaging.PackagedEntityManagerTest.testExcludeHbmPar":                                          "unknown",
-	"org.hibernate.jpa.test.packaging.PackagedEntityManagerTest.testExplodedPar":                                            "unknown",
-	"org.hibernate.jpa.test.packaging.PackagedEntityManagerTest.testExtendedEntityManager":                                  "unknown",
-	"org.hibernate.jpa.test.packaging.PackagedEntityManagerTest.testExternalJar":                                            "unknown",
-	"org.hibernate.jpa.test.packaging.PackagedEntityManagerTest.testListeners":                                              "unknown",
-	"org.hibernate.jpa.test.packaging.PackagedEntityManagerTest.testListenersDefaultPar":                                    "unknown",
-	"org.hibernate.jpa.test.packaging.PackagedEntityManagerTest.testORMFileOnMainAndExplicitJars":                           "unknown",
-	"org.hibernate.jpa.test.packaging.PackagedEntityManagerTest.testRelativeJarReferences":                                  "unknown",
-	"org.hibernate.jpa.test.packaging.PackagedEntityManagerTest.testSpacePar":                                               "unknown",
-	"org.hibernate.jpa.test.packaging.ScannerTest.testCustomScanner":                                                        "unknown",
-	"org.hibernate.test.bytecode.enhancement.lazy.proxy.inlinedirtychecking.DirtyCheckPrivateUnMappedCollectionTest.testIt": "unknown",
-	"org.hibernate.test.hql.BulkManipulationTest.testUpdateWithSubquery":                                                    "unknown",
-}
+var hibernateBlockList = blocklist{}
 
 var hibernateSpatialIgnoreList = blocklist{
 	"org.hibernate.serialization.SessionFactorySerializationTest.testUnNamedSessionFactorySerialization": "flaky",

--- a/pkg/cmd/roachtest/tests/java_helpers.go
+++ b/pkg/cmd/roachtest/tests/java_helpers.go
@@ -191,13 +191,15 @@ func parseAndSummarizeJavaORMTestsResults(
 	}
 	for i, file := range files {
 		t.L().Printf("Parsing %d of %d: %s\n", i+1, len(files), file)
+		// NB: It is necessary to single quote the file name to prevent
+		// unintentional variable interpolation if the name contains $'s.
 		result, err := repeatRunWithDetailsSingleNode(
 			ctx,
 			c,
 			t,
 			node,
 			fmt.Sprintf("fetching results file %s", file),
-			fmt.Sprintf("cat %s", file),
+			fmt.Sprintf("cat '%s'", file),
 		)
 		if err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
Backport 1/1 commits from #113114.

/cc @cockroachdb/release

---

Fixes: #111402

Release note: None

---

Release justification: test-only change
