### PR TITLE
release-22.2: roachtest: update hibernate test to use 6.3.1

### DIFF
--- a/pkg/cmd/roachtest/tests/hibernate.go
+++ b/pkg/cmd/roachtest/tests/hibernate.go
@@ -23,7 +23,10 @@ import (
 )
 
 var hibernateReleaseTagRegex = regexp.MustCompile(`^(?P<major>\d+)\.(?P<minor>\d+)\.(?P<point>\d+)$`)
-var supportedHibernateTag = "5.6.15"
+
+// WARNING: DO NOT MODIFY the name of the below constant/variable without approval from the docs team.
+// This is used by docs automation to produce a list of supported versions for ORM's.
+var supportedHibernateTag = "6.3.1"
 
 type hibernateOptions struct {
 	testName string
@@ -39,7 +42,7 @@ var (
 		testName: "hibernate",
 		testDir:  "hibernate-core",
 		buildCmd: `cd /mnt/data1/hibernate/hibernate-core/ && ./../gradlew test -Pdb=cockroachdb ` +
-			`--tests org.hibernate.jdbc.util.BasicFormatterTest.*`,
+			`--tests org.hibernate.orm.test.jdbc.util.BasicFormatterTest.*`,
 		testCmd:     "cd /mnt/data1/hibernate/hibernate-core/ && ./../gradlew test -Pdb=cockroachdb",
 		blocklists:  hibernateBlocklists,
 		dbSetupFunc: nil,
@@ -47,10 +50,10 @@ var (
 	hibernateSpatialOpts = hibernateOptions{
 		testName: "hibernate-spatial",
 		testDir:  "hibernate-spatial",
-		buildCmd: `cd /mnt/data1/hibernate/hibernate-spatial/ && ./../gradlew test -Pdb=cockroachdb_spatial ` +
+		buildCmd: `cd /mnt/data1/hibernate/hibernate-spatial/ && ./../gradlew test -Pdb=cockroachdb ` +
 			`--tests org.hibernate.spatial.dialect.postgis.*`,
 		testCmd: `cd /mnt/data1/hibernate/hibernate-spatial && ` +
-			`HIBERNATE_CONNECTION_LEAK_DETECTION=true ./../gradlew test -Pdb=cockroachdb_spatial`,
+			`HIBERNATE_CONNECTION_LEAK_DETECTION=true ./../gradlew test -Pdb=cockroachdb`,
 		blocklists: hibernateSpatialBlocklists,
 		dbSetupFunc: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			db := c.Conn(ctx, t.L(), 1)
@@ -111,14 +114,13 @@ func registerHibernate(r registry.Registry, opt hibernateOptions) {
 			t.Fatal(err)
 		}
 
-		// TODO(rafi): use openjdk-11-jdk-headless once we are off of Ubuntu 16.
 		if err := repeatRunE(
 			ctx,
 			t,
 			c,
 			node,
 			"install dependencies",
-			`sudo apt-get -qq install default-jre openjdk-8-jdk-headless gradle`,
+			`sudo apt-get -qq install openjdk-11-jre-headless openjdk-11-jdk-headless`,
 		); err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/cmd/roachtest/tests/hibernate_blocklist.go
+++ b/pkg/cmd/roachtest/tests/hibernate_blocklist.go
@@ -36,7 +36,7 @@ var hibernateSpatialBlockList21_2 = blocklist{}
 
 var hibernateSpatialBlockList21_1 = blocklist{}
 
-var hibernateBlockList22_2 = hibernateBlockList22_1
+var hibernateBlockList22_2 = blocklist{}
 
 var hibernateBlockList22_1 = blocklist{
 	"org.hibernate.jpa.test.graphs.FetchGraphTest.testCollectionEntityGraph":                                                "unknown",

--- a/pkg/cmd/roachtest/tests/java_helpers.go
+++ b/pkg/cmd/roachtest/tests/java_helpers.go
@@ -202,13 +202,15 @@ func parseAndSummarizeJavaORMTestsResults(
 	}
 	for i, file := range files {
 		t.L().Printf("Parsing %d of %d: %s\n", i+1, len(files), file)
+		// NB: It is necessary to single quote the file name to prevent
+		// unintentional variable interpolation if the name contains $'s.
 		result, err := repeatRunWithDetailsSingleNode(
 			ctx,
 			c,
 			t,
 			node,
 			fmt.Sprintf("fetching results file %s", file),
-			fmt.Sprintf("cat %s", file),
+			fmt.Sprintf("cat '%s'", file),
 		)
 		if err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
Backport 1/1 commits from #113114.

/cc @cockroachdb/release

---

Fixes: #111402

Release note: None

---

Release justification: test-only change
