### PR TITLE
kvserver: fix flaky work queue tests

### DIFF
--- a/pkg/build/info.go
+++ b/pkg/build/info.go
@@ -34,6 +34,7 @@ var (
 	utcTime          string // Build time in UTC (year/month/day hour:min:sec)
 	rev              string // SHA-1 of this build (git rev-parse)
 	buildTagOverride string
+	binaryName       string // Name of the binary that was built, e.g., cockroach, roachtest, roachprod.
 	cgoCompiler      = cgoVersion()
 	cgoTargetTriple  string
 	platform         = fmt.Sprintf("%s %s", runtime.GOOS, runtime.GOARCH)
@@ -130,6 +131,7 @@ func (b Info) Long() string {
 	fmt.Fprintf(tw, "C Compiler:       %s\n", b.CgoCompiler)
 	fmt.Fprintf(tw, "Build Commit ID:  %s\n", b.Revision)
 	fmt.Fprintf(tw, "Build Type:       %s\n", b.Type)
+	fmt.Fprintf(tw, "Binary Name:			%s\n", b.BinaryName)
 	fmt.Fprintf(tw, "Enabled Assertions: %t", b.EnabledAssertions) // No final newline: cobra prints one for us.
 	_ = tw.Flush()
 	return buf.String()
@@ -159,6 +161,7 @@ func GetInfo() Info {
 	if ch == "" {
 		ch = "unknown"
 	}
+
 	return Info{
 		GoVersion:         runtime.Version(),
 		Tag:               binaryVersion,
@@ -171,6 +174,7 @@ func GetInfo() Info {
 		Type:              typ,
 		Channel:           ch,
 		EnvChannel:        envChannel,
+		BinaryName:        binaryName,
 		EnabledAssertions: enabledAssertions,
 	}
 }

--- a/pkg/build/info.proto
+++ b/pkg/build/info.proto
@@ -42,6 +42,8 @@ message Info {
   optional string env_channel = 11 [(gogoproto.nullable) = false];
   // enabled_assertions returns the value of 'CrdbTestBuild' (true iff compiled with 'crdb_test' tag)
   optional bool enabled_assertions = 12 [(gogoproto.nullable) = false];
+  // binary_anme returns the name of the binary, e.g., cockroach, roachtest, roachprod.
+  optional string binary_name = 13 [(gogoproto.nullable) = false];
 
   // dependencies exists to allow tests that run against old clusters
   // to unmarshal JSON containing this field. The tag is unimportant,

--- a/pkg/cmd/cockroach-oss/BUILD.bazel
+++ b/pkg/cmd/cockroach-oss/BUILD.bazel
@@ -6,6 +6,9 @@ go_library(
     srcs = ["main.go"],
     importpath = "github.com/cockroachdb/cockroach/pkg/cmd/cockroach-oss",
     visibility = ["//visibility:private"],
+    x_defs = {
+        "github.com/cockroachdb/cockroach/pkg/build.binaryName": "cockroach-oss",
+    },
     deps = [
         "//pkg/cli",
         "//pkg/ui/distoss",

--- a/pkg/cmd/cockroach-short/BUILD.bazel
+++ b/pkg/cmd/cockroach-short/BUILD.bazel
@@ -5,6 +5,9 @@ go_library(
     srcs = ["main.go"],
     importpath = "github.com/cockroachdb/cockroach/pkg/cmd/cockroach-short",
     visibility = ["//visibility:private"],
+    x_defs = {
+        "github.com/cockroachdb/cockroach/pkg/build.binaryName": "cockroach-short",
+    },
     deps = [
         "//pkg/ccl",
         "//pkg/cli",

--- a/pkg/cmd/cockroach-sql/BUILD.bazel
+++ b/pkg/cmd/cockroach-sql/BUILD.bazel
@@ -5,6 +5,9 @@ go_library(
     srcs = ["main.go"],
     importpath = "github.com/cockroachdb/cockroach/pkg/cmd/cockroach-sql",
     visibility = ["//visibility:private"],
+    x_defs = {
+        "github.com/cockroachdb/cockroach/pkg/build.binaryName": "cockroach-sql",
+    },
     deps = [
         "//pkg/build",
         "//pkg/cli/clicfg",

--- a/pkg/cmd/cockroach/BUILD.bazel
+++ b/pkg/cmd/cockroach/BUILD.bazel
@@ -6,6 +6,9 @@ go_library(
     srcs = ["main.go"],
     importpath = "github.com/cockroachdb/cockroach/pkg/cmd/cockroach",
     visibility = ["//visibility:private"],
+    x_defs = {
+        "github.com/cockroachdb/cockroach/pkg/build.binaryName": "cockroach",
+    },
     deps = [
         "//pkg/ccl",
         "//pkg/ccl/cliccl",

--- a/pkg/cmd/roachprod/BUILD.bazel
+++ b/pkg/cmd/roachprod/BUILD.bazel
@@ -9,6 +9,9 @@ go_library(
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/cmd/roachprod",
     visibility = ["//visibility:private"],
+    x_defs = {
+        "github.com/cockroachdb/cockroach/pkg/build.binaryName": "roachprod",
+    },
     deps = [
         "//pkg/build",
         "//pkg/cmd/roachprod/grafana",

--- a/pkg/cmd/roachtest/BUILD.bazel
+++ b/pkg/cmd/roachtest/BUILD.bazel
@@ -19,6 +19,9 @@ go_library(
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/cmd/roachtest",
     visibility = ["//visibility:private"],
+    x_defs = {
+        "github.com/cockroachdb/cockroach/pkg/build.binaryName": "roachtest",
+    },
     deps = [
         "//pkg/build",
         "//pkg/cmd/internal/issues",

--- a/pkg/kv/kvserver/consistency_queue.go
+++ b/pkg/kv/kvserver/consistency_queue.go
@@ -103,7 +103,7 @@ func newConsistencyQueue(store *Store) *consistencyQueue {
 			pending:              store.metrics.ConsistencyQueuePending,
 			processingNanos:      store.metrics.ConsistencyQueueProcessingNanos,
 			processTimeoutFunc:   makeRateLimitedTimeoutFunc(consistencyCheckRate),
-			disabledConfig:       kvserverbase.ConsistencyQueueEnabled,
+			enabledConfig:        kvserverbase.ConsistencyQueueEnabled,
 		},
 	)
 	return q

--- a/pkg/kv/kvserver/merge_queue.go
+++ b/pkg/kv/kvserver/merge_queue.go
@@ -124,7 +124,7 @@ func newMergeQueue(store *Store, db *kv.DB) *mergeQueue {
 			pending:              store.metrics.MergeQueuePending,
 			processingNanos:      store.metrics.MergeQueueProcessingNanos,
 			purgatory:            store.metrics.MergeQueuePurgatory,
-			disabledConfig:       kvserverbase.MergeQueueEnabled,
+			enabledConfig:        kvserverbase.MergeQueueEnabled,
 		},
 	)
 	return mq

--- a/pkg/kv/kvserver/mvcc_gc_queue.go
+++ b/pkg/kv/kvserver/mvcc_gc_queue.go
@@ -209,7 +209,7 @@ func newMVCCGCQueue(store *Store) *mvccGCQueue {
 			storeFailures:   store.metrics.StoreFailures,
 			pending:         store.metrics.MVCCGCQueuePending,
 			processingNanos: store.metrics.MVCCGCQueueProcessingNanos,
-			disabledConfig:  kvserverbase.MVCCGCQueueEnabled,
+			enabledConfig:   kvserverbase.MVCCGCQueueEnabled,
 		},
 	)
 	return mgcq

--- a/pkg/kv/kvserver/queue.go
+++ b/pkg/kv/kvserver/queue.go
@@ -344,9 +344,9 @@ type queueConfig struct {
 	processingNanos *metric.Counter
 	// purgatory is a gauge measuring current replica count in purgatory.
 	purgatory *metric.Gauge
-	// disabledConfig is a reference to the cluster setting that controls enabling
+	// enabledConfig is a reference to the cluster setting that controls enabling
 	// and disabling queues.
-	disabledConfig *settings.BoolSetting
+	enabledConfig *settings.BoolSetting
 }
 
 // baseQueue is the base implementation of the replicaQueue interface. Queue
@@ -493,9 +493,9 @@ func newBaseQueue(name string, impl queueImpl, store *Store, cfg queueConfig) *b
 		},
 	}
 	bq.mu.replicas = map[roachpb.RangeID]*replicaItem{}
-	bq.SetDisabled(!cfg.disabledConfig.Get(&store.cfg.Settings.SV))
-	cfg.disabledConfig.SetOnChange(&store.cfg.Settings.SV, func(ctx context.Context) {
-		bq.SetDisabled(!cfg.disabledConfig.Get(&store.cfg.Settings.SV))
+	bq.SetDisabled(!cfg.enabledConfig.Get(&store.cfg.Settings.SV))
+	cfg.enabledConfig.SetOnChange(&store.cfg.Settings.SV, func(ctx context.Context) {
+		bq.SetDisabled(!cfg.enabledConfig.Get(&store.cfg.Settings.SV))
 	})
 
 	return &bq

--- a/pkg/kv/kvserver/raft_log_queue.go
+++ b/pkg/kv/kvserver/raft_log_queue.go
@@ -183,7 +183,7 @@ func newRaftLogQueue(store *Store, db *kv.DB) *raftLogQueue {
 			storeFailures:        store.metrics.StoreFailures,
 			pending:              store.metrics.RaftLogQueuePending,
 			processingNanos:      store.metrics.RaftLogQueueProcessingNanos,
-			disabledConfig:       kvserverbase.RaftLogQueueEnabled,
+			enabledConfig:        kvserverbase.RaftLogQueueEnabled,
 		},
 	)
 	return rlq

--- a/pkg/kv/kvserver/raft_snapshot_queue.go
+++ b/pkg/kv/kvserver/raft_snapshot_queue.go
@@ -59,7 +59,7 @@ func newRaftSnapshotQueue(store *Store) *raftSnapshotQueue {
 			storeFailures:        store.metrics.StoreFailures,
 			pending:              store.metrics.RaftSnapshotQueuePending,
 			processingNanos:      store.metrics.RaftSnapshotQueueProcessingNanos,
-			disabledConfig:       kvserverbase.RaftSnapshotQueueEnabled,
+			enabledConfig:        kvserverbase.RaftSnapshotQueueEnabled,
 		},
 	)
 	return rq

--- a/pkg/kv/kvserver/replica_gc_queue.go
+++ b/pkg/kv/kvserver/replica_gc_queue.go
@@ -108,7 +108,7 @@ func newReplicaGCQueue(store *Store, db *kv.DB) *replicaGCQueue {
 			storeFailures:            store.metrics.StoreFailures,
 			pending:                  store.metrics.ReplicaGCQueuePending,
 			processingNanos:          store.metrics.ReplicaGCQueueProcessingNanos,
-			disabledConfig:           kvserverbase.ReplicaGCQueueEnabled,
+			enabledConfig:            kvserverbase.ReplicaGCQueueEnabled,
 		},
 	)
 	return rgcq

--- a/pkg/kv/kvserver/replicate_queue.go
+++ b/pkg/kv/kvserver/replicate_queue.go
@@ -590,7 +590,7 @@ func newReplicateQueue(store *Store, allocator allocatorimpl.Allocator) *replica
 			pending:            store.metrics.ReplicateQueuePending,
 			processingNanos:    store.metrics.ReplicateQueueProcessingNanos,
 			purgatory:          store.metrics.ReplicateQueuePurgatory,
-			disabledConfig:     kvserverbase.ReplicateQueueEnabled,
+			enabledConfig:      kvserverbase.ReplicateQueueEnabled,
 		},
 	)
 	updateFn := func() {

--- a/pkg/kv/kvserver/split_queue.go
+++ b/pkg/kv/kvserver/split_queue.go
@@ -127,7 +127,7 @@ func newSplitQueue(store *Store, db *kv.DB) *splitQueue {
 			pending:              store.metrics.SplitQueuePending,
 			processingNanos:      store.metrics.SplitQueueProcessingNanos,
 			purgatory:            store.metrics.SplitQueuePurgatory,
-			disabledConfig:       kvserverbase.SplitQueueEnabled,
+			enabledConfig:        kvserverbase.SplitQueueEnabled,
 		},
 	)
 	return sq

--- a/pkg/kv/kvserver/ts_maintenance_queue.go
+++ b/pkg/kv/kvserver/ts_maintenance_queue.go
@@ -120,7 +120,7 @@ func newTimeSeriesMaintenanceQueue(
 			storeFailures:        store.metrics.StoreFailures,
 			pending:              store.metrics.TimeSeriesMaintenanceQueuePending,
 			processingNanos:      store.metrics.TimeSeriesMaintenanceQueueProcessingNanos,
-			disabledConfig:       kvserverbase.TimeSeriesMaintenanceQueueEnabled,
+			enabledConfig:        kvserverbase.TimeSeriesMaintenanceQueueEnabled,
 		},
 	)
 

--- a/pkg/util/BUILD.bazel
+++ b/pkg/util/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/util",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/build",
         "//pkg/build/bazel",
         "//pkg/util/buildutil",
         "//pkg/util/envutil",

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -14,7 +14,9 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
+	"strings"
 
+	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/build/bazel"
 	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
@@ -96,6 +98,10 @@ const DisableMetamorphicEnvVar = "COCKROACH_INTERNAL_DISABLE_METAMORPHIC_TESTING
 // initialization of the test module and its dependencies.
 func metamorphicEligible() bool {
 	if !buildutil.CrdbTestBuild {
+		return false
+	}
+	// Bail out if we are running a non-test binary which also happens to be non-cockroach, e.g., roachprod, roachtest.
+	if !bazel.InBazelTest() && !strings.Contains(build.GetInfo().BinaryName, "cockroach") {
 		return false
 	}
 


### PR DESCRIPTION
In [1], new cluster settings have been added, e.g.,
`kv.replica_gc_queue.enabled`, `kv.raft_log_queue.enabled`,
to selectively disable work queues per store, at runtime.

The new unit tests use a dummy `BoolSetting` which aliases
slot 0 of the global cluster setting `registry`. Thus, its
value corresponds to whichever cluster setting is registered
first during `init()`. Before the change in [2], the first
registered cluster setting is `bulkio.backup.merge_file_buffer_size`,
one with a non-zero value in slot 0.
After the change, it is `keyvisualizer.enabled`, one with a
zero value in slot 0. Subsequently, a number of the unit tests
failed because `baseQueue.mu.disabled` is now true instead
of previously, false.

The change in this PR fixes the bug by registering a fresh dummy
`BoolSetting`. We also rename `disabledConfig` to match the polarity
used in conjunction with `bq.SetDisabled`.

[1] https://github.com/cockroachdb/cockroach/pull/104170
[2] https://github.com/cockroachdb/cockroach/pull/113113

Epic: none

Release note: None