### PR TITLE
release-23.1: store: add `AllowVoterRemovalWhenNotLeader` testing knob

### DIFF
--- a/pkg/kv/kvserver/allocator/allocatorimpl/allocator.go
+++ b/pkg/kv/kvserver/allocator/allocatorimpl/allocator.go
@@ -2920,6 +2920,18 @@ func FilterUnremovableReplicas(
 	brandNewReplicaID roachpb.ReplicaID,
 ) []roachpb.ReplicaDescriptor {
 	upToDateReplicas := FilterBehindReplicas(ctx, raftStatus, replicas)
+	return FilterUnremovableReplicasWithoutRaftStatus(
+		ctx, replicas, upToDateReplicas, brandNewReplicaID)
+}
+
+// FilterUnremovableReplicasWithoutRaftStatus is like FilterUnremovableReplicas,
+// but takes an upToDateReplicas slice to avoid the Raft status dependency.
+func FilterUnremovableReplicasWithoutRaftStatus(
+	ctx context.Context,
+	replicas []roachpb.ReplicaDescriptor,
+	upToDateReplicas []roachpb.ReplicaDescriptor,
+	brandNewReplicaID roachpb.ReplicaID,
+) []roachpb.ReplicaDescriptor {
 	oldQuorum := computeQuorum(len(replicas))
 	if len(upToDateReplicas) < oldQuorum {
 		// The number of up-to-date replicas is less than the old quorum. No

--- a/pkg/kv/kvserver/replicate_queue.go
+++ b/pkg/kv/kvserver/replicate_queue.go
@@ -1415,6 +1415,12 @@ func (rq *replicateQueue) findRemoveVoter(
 		}
 		raftStatus := repl.RaftStatus()
 		if raftStatus == nil || raftStatus.RaftState != raft.StateLeader {
+			// If requested, assume all replicas are up-to-date.
+			if rq.store.TestingKnobs().AllowVoterRemovalWhenNotLeader {
+				candidates = allocatorimpl.FilterUnremovableReplicasWithoutRaftStatus(
+					ctx, existingVoters, existingVoters, lastReplAdded)
+				break
+			}
 			// If we've lost raft leadership, we're unlikely to regain it so give up immediately.
 			return roachpb.ReplicationTarget{}, "", &benignError{errors.Errorf("not raft leader while range needs removal")}
 		}

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -1219,6 +1219,7 @@ func (sc *StoreConfig) SetDefaults(numStores int) {
 			sc.TestingKnobs.AllocatorKnobs = &allocator.TestingKnobs{}
 		}
 		sc.TestingKnobs.AllocatorKnobs.AllowLeaseTransfersToReplicasNeedingSnapshots = true
+		sc.TestingKnobs.AllowVoterRemovalWhenNotLeader = true // downreplication
 	}
 }
 

--- a/pkg/kv/kvserver/testing_knobs.go
+++ b/pkg/kv/kvserver/testing_knobs.go
@@ -151,6 +151,9 @@ type StoreTestingKnobs struct {
 	// DisableReplicaRebalancing disables rebalancing of replicas but otherwise
 	// leaves the replicate queue operational.
 	DisableReplicaRebalancing bool
+	// AllowVoterRemovalWhenNotLeader allows the replicate queue to remove
+	// voters when this replica is not the leader.
+	AllowVoterRemovalWhenNotLeader bool
 	// DisableLoadBasedSplitting turns off LBS so no splits happen because of load.
 	DisableLoadBasedSplitting bool
 	// LoadBasedSplittingOverrideKey returns a key which should be used for load


### PR DESCRIPTION
Backport 1/1 commits from #113141.

/cc @cockroachdb/release

---

Deflakes `failover/partial/lease-leader`.

Touches #113059.
Epic: none
Release note: None
