### PR TITLE
rangefeed: add `kv.rangefeed.push_txns.enabled`

### DIFF
--- a/pkg/kv/kvserver/rangefeed/BUILD.bazel
+++ b/pkg/kv/kvserver/rangefeed/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
         "//pkg/kv/kvserver/concurrency/lock",
         "//pkg/roachpb",
         "//pkg/settings",
+        "//pkg/settings/cluster",
         "//pkg/storage",
         "//pkg/storage/enginepb",
         "//pkg/util/admission",

--- a/pkg/kv/kvserver/replica_rangefeed.go
+++ b/pkg/kv/kvserver/replica_rangefeed.go
@@ -445,6 +445,7 @@ func (r *Replica) registerWithRangefeedRaftMuLocked(
 		AmbientContext:   r.AmbientContext,
 		Clock:            r.Clock(),
 		Stopper:          r.store.stopper,
+		Settings:         r.store.ClusterSettings(),
 		RangeID:          r.RangeID,
 		Span:             desc.RSpan(),
 		TxnPusher:        &tp,

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -2450,6 +2450,9 @@ func (s *Store) startRangefeedTxnPushNotifier(ctx context.Context) {
 		for {
 			select {
 			case <-ticker.C:
+				if !rangefeed.PushTxnsEnabled.Get(&s.ClusterSettings().SV) {
+					continue
+				}
 				batch := makeSchedulerBatch()
 				s.rangefeedScheduler.EnqueueBatch(batch, rangefeed.PushTxnQueued)
 				batch.Close()


### PR DESCRIPTION
This patch adds `kv.rangefeed.push_txns.enabled`, which can be used to disable rangefeed txn pushes, e.g. if they cause excessive contention. The cluster setting is meant to be used temporarily, since disabling txn pushes can cause the rangefeed resolved timestamp to fall arbitrarily far behind.

Resolves #113262.
Epic: none
Release note: None