### PR TITLE
workload/schemachange: implement ALTER TABLE ALTER PRIMARY KEY

### DIFF
--- a/pkg/workload/schemachange/BUILD.bazel
+++ b/pkg/workload/schemachange/BUILD.bazel
@@ -32,6 +32,7 @@ go_library(
         "//pkg/sql/sem/catconstants",
         "//pkg/sql/sem/tree",
         "//pkg/sql/types",
+        "//pkg/util",
         "//pkg/util/encoding",
         "//pkg/util/randutil",
         "//pkg/util/syncutil",

--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -19,6 +19,7 @@ import (
 	"strconv"
 	"strings"
 	"sync/atomic"
+	"text/template"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
@@ -33,6 +34,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catconstants"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
@@ -2439,6 +2441,130 @@ func (og *operationGenerator) setColumnType(ctx context.Context, tx pgx.Tx) (*op
 	stmt.sql = fmt.Sprintf(`%s ALTER TABLE %s ALTER COLUMN "%s" SET DATA TYPE %s`,
 		setSessionVariableString, tableName, columnForTypeChange.name, newTypeName.SQLString())
 	return stmt, nil
+}
+
+func (og *operationGenerator) alterTableAlterPrimaryKey(
+	ctx context.Context, tx pgx.Tx,
+) (*opStmt, error) {
+	type Column struct {
+		Name     tree.Name
+		Nullable bool
+		Unique   bool
+	}
+
+	rowToTableName := func(row pgx.CollectableRow) (*tree.UnresolvedName, error) {
+		var schema string
+		var name string
+		if err := row.Scan(&schema, &name); err != nil {
+			return nil, err
+		}
+		return tree.NewUnresolvedName(schema, name), nil
+	}
+
+	columnsFrom := func(table tree.NodeFormatter) ([]Column, error) {
+		query := With([]CTE{
+			{"stats", fmt.Sprintf(`SELECT * FROM [SHOW STATISTICS FOR TABLE %v]`, table)},
+			{"unique_columns", `SELECT column_names[1] AS name FROM stats WHERE row_count = distinct_count AND array_length(column_names, 1) = 1`},
+		}, fmt.Sprintf(`SELECT column_name, is_nullable, EXISTS(SELECT * FROM unique_columns WHERE name = column_name) FROM [SHOW COLUMNS FROM %v] WHERE NOT is_hidden`, table))
+
+		return Collect(ctx, og, tx, pgx.RowToStructByPos[Column], query)
+	}
+
+	ctes := []CTE{
+		{"tables", `SELECT * FROM [SHOW TABLES] WHERE type = 'table'`},
+		{"descriptors", descJSONQuery},
+		{"tables_undergoing_schema_changes", `SELECT id FROM descriptors WHERE descriptor ? 'table' AND json_array_length(descriptor->'table'->'mutations') > 0`},
+	}
+
+	tablesUndergoingSchemaChangesQuery := With(ctes, `SELECT schema_name, table_name FROM tables WHERE NOT EXISTS(SELECT * FROM tables_undergoing_schema_changes WHERE id = (schema_name || '.' || table_name)::regclass::oid)`)
+	tablesNotUndergoingSchemaChangesQuery := With(ctes, `SELECT schema_name, table_name FROM tables WHERE EXISTS(SELECT * FROM tables_undergoing_schema_changes WHERE id = (schema_name || '.' || table_name)::regclass::oid)`)
+
+	var table *tree.UnresolvedName
+	stmt, code, err := Generate[*tree.AlterTable](og.params.rng, og.produceError(), []GenerationCase{
+		// IF EXISTS should noop if the table doesn't exist.
+		{pgcode.SuccessfulCompletion, `ALTER TABLE IF EXISTS "NonExistentTable" ALTER PRIMARY KEY USING COLUMNS ("IrrelevantColumn")`},
+		// Targeting a table that doesn't exist should error out.
+		{pgcode.UndefinedTable, `ALTER TABLE "NonExistentTable" ALTER PRIMARY KEY USING COLUMNS ("IrrelevantColumn")`},
+		// Targeting a column that doesn't exist should error out.
+		{pgcode.InvalidSchemaDefinition, `ALTER TABLE {TableNotUnderGoingSchemaChange} ALTER PRIMARY KEY USING COLUMNS ("NonExistentColumn")`},
+		// NonUniqueColumns can't be used as PKs.
+		{pgcode.UniqueViolation, `ALTER TABLE {TableNotUnderGoingSchemaChange} ALTER PRIMARY KEY USING COLUMNS ({NonUniqueColumns})`},
+		// NullableColumns can't be used as PKs.
+		{pgcode.InvalidSchemaDefinition, `ALTER TABLE {TableNotUnderGoingSchemaChange} ALTER PRIMARY KEY USING COLUMNS ({NullableColumns})`},
+		// Tables undergoing a schema change may not have their PK changed.
+		// TODO(chrisseto): This case doesn't cause errors as expected.
+		// {pgcode.Code{}, `ALTER TABLE {TableUnderGoingSchemaChange} ALTER PRIMARY KEY USING COLUMNS ({UniqueNotNullableColumns})`},
+		// Successful cases.
+		{pgcode.SuccessfulCompletion, `ALTER TABLE {TableNotUnderGoingSchemaChange} ALTER PRIMARY KEY USING COLUMNS ({UniqueNotNullableColumns})`},
+		{pgcode.SuccessfulCompletion, `ALTER TABLE {TableNotUnderGoingSchemaChange} ALTER PRIMARY KEY USING COLUMNS ({UniqueNotNullableColumns}) USING HASH`},
+		// TODO(chrisseto): Add support for hash parameters and storage parameters.
+	}, template.FuncMap{
+		"TableNotUnderGoingSchemaChange": func() (*tree.UnresolvedName, error) {
+			tables, err := Collect(ctx, og, tx, rowToTableName, tablesNotUndergoingSchemaChangesQuery)
+			if err != nil {
+				return nil, err
+			}
+			table, err = PickOne(og.params.rng, tables)
+			return table, err
+		},
+		"TableUnderGoingSchemaChange": func() (*tree.UnresolvedName, error) {
+			tables, err := Collect(ctx, og, tx, rowToTableName, tablesUndergoingSchemaChangesQuery)
+			if err != nil {
+				return nil, err
+			}
+			table, err = PickOne(og.params.rng, tables)
+			return table, err
+		},
+		"NullableColumns": func() (Values, error) {
+			columns, err := columnsFrom(table)
+			if err != nil {
+				return nil, err
+			}
+
+			names := util.Map(util.Filter(columns, func(c Column) bool {
+				return c.Nullable
+			}), func(c Column) *tree.Name {
+				return &c.Name
+			})
+
+			return AsValues(PickAtLeast(og.params.rng, 1, names))
+		},
+		"NonUniqueColumns": func() (Values, error) {
+			columns, err := columnsFrom(table)
+			if err != nil {
+				return nil, err
+			}
+
+			names := util.Map(util.Filter(columns, func(c Column) bool {
+				return !c.Nullable && !c.Unique
+			}), func(c Column) *tree.Name {
+				return &c.Name
+			})
+
+			return AsValues(PickAtLeast(og.params.rng, 1, names))
+		},
+		"UniqueNotNullableColumns": func() (Values, error) {
+			columns, err := columnsFrom(table)
+			if err != nil {
+				return nil, err
+			}
+
+			names := util.Map(util.Filter(columns, func(c Column) bool {
+				return !c.Nullable && c.Unique
+			}), func(c Column) *tree.Name {
+				return &c.Name
+			})
+
+			return AsValues(PickAtLeast(og.params.rng, 1, names))
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return newOpStmt(stmt, codesWithConditions{
+		{code, true},
+	}), nil
 }
 
 func (og *operationGenerator) survive(ctx context.Context, tx pgx.Tx) (*opStmt, error) {

--- a/pkg/workload/schemachange/optype.go
+++ b/pkg/workload/schemachange/optype.go
@@ -94,10 +94,11 @@ const (
 	alterTableAddConstraintForeignKey // ALTER TABLE <table> ADD CONSTRAINT <constraint> FOREIGN KEY (<column>) REFERENCES <table> (<column>)
 	alterTableAddConstraintUnique     // ALTER TABLE <table> ADD CONSTRAINT <constraint> UNIQUE (<column>)
 	alterTableAlterColumnType         // ALTER TABLE <table> ALTER [COLUMN] <column> [SET DATA] TYPE <type>
+	alterTableAlterPrimaryKey         // ALTER TABLE <table> ALTER PRIMARY KEY USING COLUMNS (<columns>)
 	alterTableDropColumn              // ALTER TABLE <table> DROP COLUMN <column>
+	alterTableDropColumnDefault       // ALTER TABLE <table> ALTER [COLUMN] <column> DROP DEFAULT
 	alterTableDropConstraint          // ALTER TABLE <table> DROP CONSTRAINT <constraint>
 	alterTableDropNotNull             // ALTER TABLE <table> ALTER [COLUMN] <column> DROP NOT NULL
-	alterTableDropColumnDefault       // ALTER TABLE <table> ALTER [COLUMN] <column> DROP DEFAULT
 	alterTableDropStored              // ALTER TABLE <table> ALTER [COLUMN] <column> DROP STORED
 	alterTableLocality                // ALTER TABLE <table> LOCALITY <locality>
 	alterTableRenameColumn            // ALTER TABLE <table> RENAME [COLUMN] <column> TO <column>
@@ -151,7 +152,6 @@ const (
 	// alterSchemaOwner
 	// alterSchemaRename
 	// alterSequence
-	// alterTableAlterPrimaryKey
 	// alterTableInjectStats
 	// alterTableOwner
 	// alterTablePartitionByTable
@@ -216,6 +216,7 @@ var opFuncs = []func(*operationGenerator, context.Context, pgx.Tx) (*opStmt, err
 	alterTableAddConstraintForeignKey: (*operationGenerator).addForeignKeyConstraint,
 	alterTableAddConstraintUnique:     (*operationGenerator).addUniqueConstraint,
 	alterTableAlterColumnType:         (*operationGenerator).setColumnType,
+	alterTableAlterPrimaryKey:         (*operationGenerator).alterTableAlterPrimaryKey,
 	alterTableDropColumn:              (*operationGenerator).dropColumn,
 	alterTableDropColumnDefault:       (*operationGenerator).dropColumnDefault,
 	alterTableDropConstraint:          (*operationGenerator).dropConstraint,
@@ -282,6 +283,7 @@ var opWeights = []int{
 	renameView:                        1,
 	alterTableSetColumnDefault:        1,
 	alterTableSetColumnNotNull:        1,
+	alterTableAlterPrimaryKey:         1,
 	alterTableAlterColumnType:         0, // Disabled and tracked with #66662.
 	alterDatabaseSurvivalGoal:         0, // Disabled and tracked with #83831
 }

--- a/pkg/workload/schemachange/optype_string.go
+++ b/pkg/workload/schemachange/optype_string.go
@@ -23,28 +23,29 @@ func _() {
 	_ = x[alterTableAddConstraintForeignKey-12]
 	_ = x[alterTableAddConstraintUnique-13]
 	_ = x[alterTableAlterColumnType-14]
-	_ = x[alterTableDropColumn-15]
-	_ = x[alterTableDropConstraint-16]
-	_ = x[alterTableDropNotNull-17]
-	_ = x[alterTableDropColumnDefault-18]
-	_ = x[alterTableDropStored-19]
-	_ = x[alterTableLocality-20]
-	_ = x[alterTableRenameColumn-21]
-	_ = x[alterTableSetColumnDefault-22]
-	_ = x[alterTableSetColumnNotNull-23]
-	_ = x[alterTypeDropValue-24]
-	_ = x[createTypeEnum-25]
-	_ = x[createIndex-26]
-	_ = x[createSchema-27]
-	_ = x[createSequence-28]
-	_ = x[createTable-29]
-	_ = x[createTableAs-30]
-	_ = x[createView-31]
-	_ = x[dropIndex-32]
-	_ = x[dropSchema-33]
-	_ = x[dropSequence-34]
-	_ = x[dropTable-35]
-	_ = x[dropView-36]
+	_ = x[alterTableAlterPrimaryKey-15]
+	_ = x[alterTableDropColumn-16]
+	_ = x[alterTableDropColumnDefault-17]
+	_ = x[alterTableDropConstraint-18]
+	_ = x[alterTableDropNotNull-19]
+	_ = x[alterTableDropStored-20]
+	_ = x[alterTableLocality-21]
+	_ = x[alterTableRenameColumn-22]
+	_ = x[alterTableSetColumnDefault-23]
+	_ = x[alterTableSetColumnNotNull-24]
+	_ = x[alterTypeDropValue-25]
+	_ = x[createTypeEnum-26]
+	_ = x[createIndex-27]
+	_ = x[createSchema-28]
+	_ = x[createSequence-29]
+	_ = x[createTable-30]
+	_ = x[createTableAs-31]
+	_ = x[createView-32]
+	_ = x[dropIndex-33]
+	_ = x[dropSchema-34]
+	_ = x[dropSequence-35]
+	_ = x[dropTable-36]
+	_ = x[dropView-37]
 }
 
 func (i opType) String() string {
@@ -79,14 +80,16 @@ func (i opType) String() string {
 		return "alterTableAddConstraintUnique"
 	case alterTableAlterColumnType:
 		return "alterTableAlterColumnType"
+	case alterTableAlterPrimaryKey:
+		return "alterTableAlterPrimaryKey"
 	case alterTableDropColumn:
 		return "alterTableDropColumn"
+	case alterTableDropColumnDefault:
+		return "alterTableDropColumnDefault"
 	case alterTableDropConstraint:
 		return "alterTableDropConstraint"
 	case alterTableDropNotNull:
 		return "alterTableDropNotNull"
-	case alterTableDropColumnDefault:
-		return "alterTableDropColumnDefault"
 	case alterTableDropStored:
 		return "alterTableDropStored"
 	case alterTableLocality:

--- a/pkg/workload/schemachange/query_util.go
+++ b/pkg/workload/schemachange/query_util.go
@@ -18,6 +18,10 @@ import (
 	"github.com/jackc/pgx/v5"
 )
 
+const (
+	descJSONQuery = `SELECT id, crdb_internal.pb_to_json('desc', descriptor) AS descriptor FROM system.descriptor`
+)
+
 type CTE struct {
 	As    string
 	Query string


### PR DESCRIPTION
#### 193b04f487b68b3f36d0aa62d72df12e5aa115c5 workload/schemachange: implement ALTER TABLE ALTER PRIMARY KEY

This commit adds support for the `ALTER TABLE ... ALTER PRIMARY KEY` DDL
to the random schema change workload.

Epic: CRDB-19168
Informs: #59595

Release note: None