### PR TITLE
kvserver: deflake test base requeue

### DIFF
--- a/pkg/kv/kvserver/queue_test.go
+++ b/pkg/kv/kvserver/queue_test.go
@@ -65,7 +65,7 @@ func (tq *testQueueImpl) shouldQueue(
 func (tq *testQueueImpl) process(
 	_ context.Context, _ *Replica, _ spanconfig.StoreReader,
 ) (bool, error) {
-	atomic.AddInt32(&tq.processed, 1)
+	defer atomic.AddInt32(&tq.processed, 1)
 	if tq.err != nil {
 		return false, tq.err
 	}


### PR DESCRIPTION
It was possible for there to be concurrent r/w to the testing `err` value in `TestBaseQueueRequeue` if the succeeds soon loop exited quickly enough.

Defer the atomic `processed` increment, so that it blocks the succeeds soon loop from exiting before reading the test `err`.

Fixes: #113045
Release note: None