### PR TITLE
authors: add wenyihu work email to authors

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -473,7 +473,7 @@ Vy Ton <vyton92@gmail.com> <vy@cockroachlabs.com>
 Wade Waldron <wade@cockroachlabs.com>
 wenyong-h <weyo.huang@gmail.com>
 Will Haack <will.haack@appboy.com> <will@cockroachlabs.com>
-Wenyi Hu <wenyihu3@gmail.com> <wenyihu6@gmail.com> <wenyi.hu@cockroachlabs.com>
+Wenyi Hu <wenyihu6@gmail.com> <wenyi.hu@cockroachlabs.com> <wenyi@cockroachlabs.com>
 Xiang Gu <xiang@cockroachlabs.com>
 Xiang Li <xiangli.cs@gmail.com>
 Xin Hao Zhang <xzhang@cockroachlabs.com> <xinhao.zhang98@gmail.com>


### PR DESCRIPTION
This patch adds my new work email to authors. 

Release note: None
Epic: None