### PR TITLE
Revert "admission: use ambient context in debug message"

### DIFF
--- a/pkg/util/admission/work_queue.go
+++ b/pkg/util/admission/work_queue.go
@@ -799,8 +799,7 @@ func (q *WorkQueue) Admit(ctx context.Context, info WorkInfo) (enabled bool, err
 		q.metrics.incErrored(info.Priority)
 		q.metrics.recordFinishWait(info.Priority, waitDur)
 		deadline, _ := ctx.Deadline()
-		// Don't use the cancelled context.
-		log.Eventf(q.ambientCtx, "deadline expired, waited in %s queue for %v",
+		log.Eventf(ctx, "deadline expired, waited in %s queue for %v",
 			workKindString(q.workKind), waitDur)
 		return true,
 			errors.Newf("work %s deadline expired while waiting: deadline: %v, start: %v, dur: %v",


### PR DESCRIPTION
This reverts commit 88f280c3b908a2534db8ecd07ec65c3363895424.

Reverting this commit since it was found to be an incorrect change and requires more investigation before merging.

Additional context:
https://github.com/cockroachdb/cockroach/pull/113167#pullrequestreview-1702408626.

Informs: https://github.com/cockroachdb/cockroach/issues/113126

Release note: None