### PR TITLE
roachtest: avoid using single quotes in ORM test

### DIFF
--- a/pkg/cmd/roachtest/tests/java_helpers.go
+++ b/pkg/cmd/roachtest/tests/java_helpers.go
@@ -191,15 +191,17 @@ func parseAndSummarizeJavaORMTestsResults(
 	}
 	for i, file := range files {
 		t.L().Printf("Parsing %d of %d: %s\n", i+1, len(files), file)
-		// NB: It is necessary to single quote the file name to prevent
-		// unintentional variable interpolation if the name contains $'s.
+		// NB: It is necessary to escape `$` in case the name contains them so they
+		// aren't treated as environment variables. We avoid using single quotes
+		// because we still want `~` to be expanded to the home directory.
+		file = strings.ReplaceAll(file, "$", "\\$")
 		result, err := repeatRunWithDetailsSingleNode(
 			ctx,
 			c,
 			t,
 			node,
 			fmt.Sprintf("fetching results file %s", file),
-			fmt.Sprintf("cat '%s'", file),
+			fmt.Sprintf("cat %s", file),
 		)
 		if err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
A recent change used single quotes in a command, which prevents ~ from
being expanded in path names. Now the $ characters are escaped, which
prevents them from being handled as environment variables, but
still allows ~ to be expanded.

fixes https://github.com/cockroachdb/cockroach/issues/113255
fixes https://github.com/cockroachdb/cockroach/issues/113263
fixes https://github.com/cockroachdb/cockroach/issues/113499
fixes https://github.com/cockroachdb/cockroach/issues/113497
fixes https://github.com/cockroachdb/cockroach/issues/113391
fixes https://github.com/cockroachdb/cockroach/issues/113390
fixes https://github.com/cockroachdb/cockroach/issues/113389
fixes https://github.com/cockroachdb/cockroach/issues/113383
Release note: None