### PR TITLE
bazel: add `rules_oci` support

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -533,6 +533,39 @@ rules_pkg_dependencies()
 # end rules_pkg dependencies #
 ##############################
 
+################################
+# begin rules_oci dependencies #
+################################
+
+http_archive(
+    name = "rules_oci",
+    sha256 = "21a7d14f6ddfcb8ca7c5fc9ffa667c937ce4622c7d2b3e17aea1ffbc90c96bed",
+    strip_prefix = "rules_oci-1.4.0",
+    url = "https://storage.googleapis.com/public-bazel-artifacts/bazel/rules_oci-v1.4.0.tar.gz",
+)
+
+# bazel_skylib handled above.
+# aspect_bazel_lib handled above.
+
+load("@rules_oci//oci:dependencies.bzl", "rules_oci_dependencies")
+
+rules_oci_dependencies()
+
+# TODO: This will pull from an upstream location: specifically it will download
+# `crane` from https://github.com/google/go-containerregistry/... Before this is
+# used in CI or anything production-ready, this should be mirrored. rules_oci
+# doesn't support this mirroring yet so we'd have to submit a patch.
+load("@rules_oci//oci:repositories.bzl", "LATEST_CRANE_VERSION", "oci_register_toolchains")
+
+oci_register_toolchains(
+    name = "oci",
+    crane_version = LATEST_CRANE_VERSION,
+)
+
+##############################
+# end rules_oci dependencies #
+##############################
+
 register_toolchains(
     "//build/toolchains:cross_x86_64_linux_toolchain",
     "//build/toolchains:cross_x86_64_linux_arm_toolchain",

--- a/build/bazelutil/distdir_files.bzl
+++ b/build/bazelutil/distdir_files.bzl
@@ -1168,6 +1168,7 @@ DISTDIR_FILES = {
     "https://storage.googleapis.com/public-bazel-artifacts/bazel/platforms-0.0.4.tar.gz": "079945598e4b6cc075846f7fd6a9d0857c33a7afc0de868c2ccb96405225135d",
     "https://storage.googleapis.com/public-bazel-artifacts/bazel/rules_java-981f06c3d2bd10225e85209904090eb7b5fb26bd.tar.gz": "f5a3e477e579231fca27bf202bb0e8fbe4fc6339d63b38ccb87c2760b533d1c3",
     "https://storage.googleapis.com/public-bazel-artifacts/bazel/rules_license-0.0.1.tar.gz": "4865059254da674e3d18ab242e21c17f7e3e8c6b1f1421fffa4c5070f82e98b5",
+    "https://storage.googleapis.com/public-bazel-artifacts/bazel/rules_oci-v1.4.0.tar.gz": "21a7d14f6ddfcb8ca7c5fc9ffa667c937ce4622c7d2b3e17aea1ffbc90c96bed",
     "https://storage.googleapis.com/public-bazel-artifacts/bazel/rules_pkg-0.7.0.tar.gz": "8a298e832762eda1830597d64fe7db58178aa84cd5926d76d5b744d6558941c2",
     "https://storage.googleapis.com/public-bazel-artifacts/bazel/rules_proto-b0cc14be5da05168b01db282fe93bdf17aa2b9f4.tar.gz": "88b0a90433866b44bb4450d4c30bc5738b8c4f9c9ba14e9661deb123f56a833d",
     "https://storage.googleapis.com/public-bazel-artifacts/bazel/rules_python-0.1.0.tar.gz": "b6d46438523a3ec0f3cead544190ee13223a52f6a6765a29eae7b7cc24cc83a0",


### PR DESCRIPTION
We would use `rules_docker` but it's deprecated.

Epic: CRDB-17171
Release note: None