### PR TITLE
release-23.1: sql: add SpanPartitionState to understand partitioning behavior

### DIFF
--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -1046,6 +1046,77 @@ func identityMapInPlace(slice []int) []int {
 	return slice
 }
 
+// SpanPartitionReason is the reason why a span was assigned to a particular
+// node or SQL Instance ID.
+type SpanPartitionReason int32
+
+const (
+	// SpanPartitionReason_UNSPECIFIED is reported when the reason is unspecified.
+	SpanPartitionReason_UNSPECIFIED SpanPartitionReason = 0
+	// SpanPartitionReason_GATEWAY_TARGET_UNHEALTHY is reported when the target
+	// node is unhealthy and so we default to the gateway node.
+	SpanPartitionReason_GATEWAY_TARGET_UNHEALTHY SpanPartitionReason = 1
+	// SpanPartitionReason_GATEWAY_NO_HEALTHY_INSTANCES is reported when there are
+	// no healthy instances and so we default to the gateway node.
+	SpanPartitionReason_GATEWAY_NO_HEALTHY_INSTANCES SpanPartitionReason = 2
+	// SpanPartitionReason_GATEWAY_ON_ERROR is reported when there is an error and
+	// so we default to the gateway node.
+	SpanPartitionReason_GATEWAY_ON_ERROR SpanPartitionReason = 3
+	// SpanPartitionReason_TARGET_HEALTHY is reported when the target node is
+	// healthy.
+	SpanPartitionReason_TARGET_HEALTHY SpanPartitionReason = 4
+	// SpanPartitionReason_CLOSEST_LOCALITY_MATCH is reported when we picked an
+	// instance with the closest match to the provided locality filter.
+	SpanPartitionReason_CLOSEST_LOCALITY_MATCH SpanPartitionReason = 5
+	// SpanPartitionReason_GATEWAY_NO_LOCALITY_MATCH is reported when there is no
+	// match to the provided locality filter and so we default to the gateway.
+	SpanPartitionReason_GATEWAY_NO_LOCALITY_MATCH SpanPartitionReason = 6
+	// SpanPartitionReason_LOCALITY_AWARE_RANDOM is reported when there is no
+	// match to the provided locality filter and the gateway is not eligible. In
+	// this case we pick a random available instance.
+	SpanPartitionReason_LOCALITY_AWARE_RANDOM SpanPartitionReason = 7
+	// SpanPartitionReason_ROUND_ROBIN is reported when there is no locality info
+	// on any of the instances and so we default to a naive round-robin strategy.
+	SpanPartitionReason_ROUND_ROBIN SpanPartitionReason = 8
+
+	// SpanPartitionReason_GOSSIP_GATEWAY_TARGET_UNHEALTHY is reported when the
+	// target node retrieved via gossip is deemed unhealthy. In this case we
+	// default to the gateway node.
+	SpanPartitionReason_GOSSIP_GATEWAY_TARGET_UNHEALTHY SpanPartitionReason = 9
+	// SpanPartitionReason_GOSSIP_TARGET_HEALTHY is reported when the
+	// target node retrieved via gossip is deemed healthy.
+	SpanPartitionReason_GOSSIP_TARGET_HEALTHY SpanPartitionReason = 10
+)
+
+func (r SpanPartitionReason) String() string {
+	switch r {
+	case SpanPartitionReason_UNSPECIFIED:
+		return "unspecified"
+	case SpanPartitionReason_GATEWAY_TARGET_UNHEALTHY:
+		return "gateway-target-unhealthy"
+	case SpanPartitionReason_GATEWAY_NO_HEALTHY_INSTANCES:
+		return "gateway-no-healthy-instances"
+	case SpanPartitionReason_GATEWAY_ON_ERROR:
+		return "gateway-on-error"
+	case SpanPartitionReason_TARGET_HEALTHY:
+		return "target-healthy"
+	case SpanPartitionReason_CLOSEST_LOCALITY_MATCH:
+		return "closest-locality-match"
+	case SpanPartitionReason_GATEWAY_NO_LOCALITY_MATCH:
+		return "gateway-no-locality-match"
+	case SpanPartitionReason_LOCALITY_AWARE_RANDOM:
+		return "locality-aware-random"
+	case SpanPartitionReason_ROUND_ROBIN:
+		return "round-robin"
+	case SpanPartitionReason_GOSSIP_GATEWAY_TARGET_UNHEALTHY:
+		return "gossip-gateway-target-unhealthy"
+	case SpanPartitionReason_GOSSIP_TARGET_HEALTHY:
+		return "gossip-target-healthy"
+	default:
+		return "unknown"
+	}
+}
+
 // SpanPartition associates a subset of spans with a specific SQL instance,
 // chosen to have the most efficient access to those spans. In the single-tenant
 // case, the instance is the one running on the same node as the leaseholder for
@@ -1208,7 +1279,7 @@ func (dsp *DistSQLPlanner) partitionSpan(
 	span roachpb.Span,
 	partitions []SpanPartition,
 	nodeMap map[base.SQLInstanceID]int,
-	getSQLInstanceIDForKVNodeID func(roachpb.NodeID) base.SQLInstanceID,
+	getSQLInstanceIDForKVNodeID func(roachpb.NodeID) (base.SQLInstanceID, SpanPartitionReason),
 	ignoreMisplannedRanges *bool,
 ) (_ []SpanPartition, lastPartitionIdx int, _ error) {
 	it := planCtx.spanIter
@@ -1250,7 +1321,7 @@ func (dsp *DistSQLPlanner) partitionSpan(
 			)
 		}
 
-		sqlInstanceID := getSQLInstanceIDForKVNodeID(replDesc.NodeID)
+		sqlInstanceID, reason := getSQLInstanceIDForKVNodeID(replDesc.NodeID)
 		partitionIdx, inNodeMap := nodeMap[sqlInstanceID]
 		if !inNodeMap {
 			partitionIdx = len(partitions)
@@ -1266,6 +1337,10 @@ func (dsp *DistSQLPlanner) partitionSpan(
 			// Thus, we include the span into partition.Spans without trying to
 			// merge it with the last span.
 			partition.Spans = append(partition.Spans, span)
+			if log.ExpensiveLogEnabled(ctx, 2) {
+				log.VEventf(ctx, 2, "partition span: %s, instance ID: %d, reason: %s",
+					span, sqlInstanceID, reason)
+			}
 			break
 		}
 
@@ -1275,14 +1350,17 @@ func (dsp *DistSQLPlanner) partitionSpan(
 			endKey = rSpan.EndKey
 		}
 
+		partitionedSpan := roachpb.Span{Key: lastKey.AsRawKey(), EndKey: endKey.AsRawKey()}
+		if log.ExpensiveLogEnabled(ctx, 2) {
+			log.VEventf(ctx, 2, "partition span: %s, instance ID: %d, reason: %s",
+				partitionedSpan.String(), sqlInstanceID, reason.String())
+		}
+
 		if lastSQLInstanceID == sqlInstanceID {
 			// Two consecutive ranges on the same node, merge the spans.
 			partition.Spans[len(partition.Spans)-1].EndKey = endKey.AsRawKey()
 		} else {
-			partition.Spans = append(partition.Spans, roachpb.Span{
-				Key:    lastKey.AsRawKey(),
-				EndKey: endKey.AsRawKey(),
-			})
+			partition.Spans = append(partition.Spans, partitionedSpan)
 		}
 
 		if !endKey.Less(rSpan.EndKey) {
@@ -1302,8 +1380,8 @@ func (dsp *DistSQLPlanner) deprecatedPartitionSpansSystem(
 	ctx context.Context, planCtx *PlanningCtx, spans roachpb.Spans,
 ) (partitions []SpanPartition, ignoreMisplannedRanges bool, _ error) {
 	nodeMap := make(map[base.SQLInstanceID]int)
-	resolver := func(nodeID roachpb.NodeID) base.SQLInstanceID {
-		return dsp.healthySQLInstanceIDForKVNodeIDSystem(ctx, planCtx, nodeID)
+	resolver := func(nodeID roachpb.NodeID) (base.SQLInstanceID, SpanPartitionReason) {
+		return dsp.deprecatedHealthySQLInstanceIDForKVNodeIDSystem(ctx, planCtx, nodeID)
 	}
 	for _, span := range spans {
 		var err error
@@ -1363,28 +1441,30 @@ func (dsp *DistSQLPlanner) partitionSpans(
 	return partitions, ignoreMisplannedRanges, nil
 }
 
-// healthySQLInstanceIDForKVNodeIDSystem returns the SQL instance that
-// should handle the range with the given node ID when planning is
-// done on behalf of the system tenant. It ensures that the chosen SQL
-// instance is healthy and of the compatible DistSQL version.
-func (dsp *DistSQLPlanner) healthySQLInstanceIDForKVNodeIDSystem(
+// deprecatedHealthySQLInstanceIDForKVNodeIDSystem returns the SQL instance that
+// should handle the range with the given node ID when planning is done on
+// behalf of the system tenant. It ensures that the chosen SQL instance is
+// healthy and of the compatible DistSQL version.
+func (dsp *DistSQLPlanner) deprecatedHealthySQLInstanceIDForKVNodeIDSystem(
 	ctx context.Context, planCtx *PlanningCtx, nodeID roachpb.NodeID,
-) base.SQLInstanceID {
+) (base.SQLInstanceID, SpanPartitionReason) {
 	sqlInstanceID := base.SQLInstanceID(nodeID)
 	status := dsp.checkInstanceHealthAndVersionSystem(ctx, planCtx, sqlInstanceID)
 	// If the node is unhealthy or its DistSQL version is incompatible, use the
 	// gateway to process this span instead of the unhealthy host. An empty
 	// address indicates an unhealthy host.
+	reason := SpanPartitionReason_GOSSIP_TARGET_HEALTHY
 	if status != NodeOK {
-		log.Eventf(ctx, "not planning on node %d: %s", sqlInstanceID, status)
+		log.VEventf(ctx, 2, "not planning on node %d: %s", sqlInstanceID, status)
 		sqlInstanceID = dsp.gatewaySQLInstanceID
+		reason = SpanPartitionReason_GOSSIP_GATEWAY_TARGET_UNHEALTHY
 	}
-	return sqlInstanceID
+	return sqlInstanceID, reason
 }
 
-// healthySQLInstanceIDForKVNodeHostedInstanceResolver returns the SQL instance ID for
-// an instance that is hosted in the process of a KV node. Currently SQL
-// instances run in KV node processes have IDs fixed to be equal to the KV
+// healthySQLInstanceIDForKVNodeHostedInstanceResolver returns the SQL instance
+// ID for an instance that is hosted in the process of a KV node. Currently SQL
+// instances that run in KV node processes have IDs fixed to be equal to the KV
 // nodes' IDs, and all of the SQL instances for a given tenant are _either_ run
 // in this mixed mode or standalone, meaning if this server is in mixed mode, we
 // can safely assume every other server is as well, and thus has IDs matching
@@ -1392,14 +1472,16 @@ func (dsp *DistSQLPlanner) healthySQLInstanceIDForKVNodeIDSystem(
 //
 // If the given node is not healthy, the gateway node is returned.
 func (dsp *DistSQLPlanner) healthySQLInstanceIDForKVNodeHostedInstanceResolver(
-	ctx context.Context, planCtx *PlanningCtx,
-) func(nodeID roachpb.NodeID) base.SQLInstanceID {
+	ctx context.Context,
+) func(nodeID roachpb.NodeID) (base.SQLInstanceID, SpanPartitionReason) {
 	allHealthy, err := dsp.sqlAddressResolver.GetAllInstances(ctx)
 	if err != nil {
 		log.Warningf(ctx, "could not get all instances: %v", err)
-		return func(nodeID roachpb.NodeID) base.SQLInstanceID {
-			return dsp.gatewaySQLInstanceID
-		}
+		return dsp.alwaysUseGatewayWithReason(SpanPartitionReason_GATEWAY_ON_ERROR)
+	}
+
+	if log.ExpensiveLogEnabled(ctx, 2) {
+		log.VEventf(ctx, 2, "healthy SQL instances available for distributed planning: %v", allHealthy)
 	}
 
 	healthyNodes := make(map[base.SQLInstanceID]struct{}, len(allHealthy))
@@ -1407,13 +1489,21 @@ func (dsp *DistSQLPlanner) healthySQLInstanceIDForKVNodeHostedInstanceResolver(
 		healthyNodes[n.InstanceID] = struct{}{}
 	}
 
-	return func(nodeID roachpb.NodeID) base.SQLInstanceID {
+	return func(nodeID roachpb.NodeID) (base.SQLInstanceID, SpanPartitionReason) {
 		sqlInstance := base.SQLInstanceID(nodeID)
 		if _, ok := healthyNodes[sqlInstance]; ok {
-			return sqlInstance
+			return sqlInstance, SpanPartitionReason_TARGET_HEALTHY
 		}
 		log.Warningf(ctx, "not planning on node %d", sqlInstance)
-		return dsp.gatewaySQLInstanceID
+		return dsp.gatewaySQLInstanceID, SpanPartitionReason_GATEWAY_TARGET_UNHEALTHY
+	}
+}
+
+func (dsp *DistSQLPlanner) alwaysUseGatewayWithReason(
+	reason SpanPartitionReason,
+) func(nodeID roachpb.NodeID) (base.SQLInstanceID, SpanPartitionReason) {
+	return func(nodeID roachpb.NodeID) (base.SQLInstanceID, SpanPartitionReason) {
+		return dsp.gatewaySQLInstanceID, reason
 	}
 }
 
@@ -1426,13 +1516,17 @@ func (dsp *DistSQLPlanner) healthySQLInstanceIDForKVNodeHostedInstanceResolver(
 // information leading to random assignments then no instance list is returned.
 func (dsp *DistSQLPlanner) makeInstanceResolver(
 	ctx context.Context, planCtx *PlanningCtx,
-) (func(roachpb.NodeID) base.SQLInstanceID, []sqlinstance.InstanceInfo, error) {
+) (
+	func(roachpb.NodeID) (base.SQLInstanceID, SpanPartitionReason),
+	[]sqlinstance.InstanceInfo,
+	error,
+) {
 	_, mixedProcessMode := dsp.distSQLSrv.NodeID.OptionalNodeID()
 	locFilter := planCtx.localityFilter
 
-	var mixedProcessSameNodeResolver func(nodeID roachpb.NodeID) base.SQLInstanceID
+	var mixedProcessSameNodeResolver func(nodeID roachpb.NodeID) (base.SQLInstanceID, SpanPartitionReason)
 	if mixedProcessMode {
-		mixedProcessSameNodeResolver = dsp.healthySQLInstanceIDForKVNodeHostedInstanceResolver(ctx, planCtx)
+		mixedProcessSameNodeResolver = dsp.healthySQLInstanceIDForKVNodeHostedInstanceResolver(ctx)
 	}
 
 	if mixedProcessMode && locFilter.Empty() {
@@ -1479,15 +1573,19 @@ func (dsp *DistSQLPlanner) makeInstanceResolver(
 		gatewayIsEligible = true
 	}
 
+	if log.ExpensiveLogEnabled(ctx, 2) {
+		log.VEventf(ctx, 2, "healthy SQL instances available for distributed planning: %v", instances)
+	}
+
 	// If we were able to determine the locality information for at least some
 	// instances, use the locality-aware resolver.
 	if instancesHaveLocality {
-		resolver := func(nodeID roachpb.NodeID) base.SQLInstanceID {
+		resolver := func(nodeID roachpb.NodeID) (base.SQLInstanceID, SpanPartitionReason) {
 			// Lookup the node localities to compare to the instance localities.
 			nodeDesc, err := dsp.nodeDescs.GetNodeDescriptor(nodeID)
 			if err != nil {
 				log.Eventf(ctx, "unable to get node descriptor for KV node %s", nodeID)
-				return dsp.gatewaySQLInstanceID
+				return dsp.gatewaySQLInstanceID, SpanPartitionReason_GATEWAY_ON_ERROR
 			}
 
 			// If we're in mixed-mode, check if the picked node already matches the
@@ -1505,16 +1603,16 @@ func (dsp *DistSQLPlanner) makeInstanceResolver(
 
 			// TODO(dt): Pre-compute / cache this result, e.g. in the instance reader.
 			if closest := closestInstances(instances, nodeDesc.Locality); len(closest) > 0 {
-				return closest[rng.Intn(len(closest))]
+				return closest[rng.Intn(len(closest))], SpanPartitionReason_CLOSEST_LOCALITY_MATCH
 			}
 
 			// No instances had any locality tiers in common with the node locality so
 			// just return the gateway if it is eligible. If it isn't, just pick a
 			// random instance from the eligible instances.
 			if gatewayIsEligible {
-				return dsp.gatewaySQLInstanceID
+				return dsp.gatewaySQLInstanceID, SpanPartitionReason_GATEWAY_NO_LOCALITY_MATCH
 			}
-			return instances[rng.Intn(len(instances))].InstanceID
+			return instances[rng.Intn(len(instances))].InstanceID, SpanPartitionReason_LOCALITY_AWARE_RANDOM
 		}
 		return resolver, instances, nil
 	}
@@ -1527,10 +1625,10 @@ func (dsp *DistSQLPlanner) makeInstanceResolver(
 		instances[i], instances[j] = instances[j], instances[i]
 	})
 	var i int
-	resolver := func(roachpb.NodeID) base.SQLInstanceID {
+	resolver := func(roachpb.NodeID) (base.SQLInstanceID, SpanPartitionReason) {
 		id := instances[i%len(instances)].InstanceID
 		i++
-		return id
+		return id, SpanPartitionReason_ROUND_ROBIN
 	}
 	return resolver, nil, nil
 }
@@ -1636,13 +1734,15 @@ func (dsp *DistSQLPlanner) getInstanceIDForScan(
 	}
 
 	if dsp.useGossipPlanning(ctx, planCtx) && planCtx.localityFilter.Empty() {
-		return dsp.healthySQLInstanceIDForKVNodeIDSystem(ctx, planCtx, replDesc.NodeID), nil
+		sqlInstanceID, _ := dsp.deprecatedHealthySQLInstanceIDForKVNodeIDSystem(ctx, planCtx, replDesc.NodeID)
+		return sqlInstanceID, nil
 	}
 	resolver, _, err := dsp.makeInstanceResolver(ctx, planCtx)
 	if err != nil {
 		return 0, err
 	}
-	return resolver(replDesc.NodeID), nil
+	sqlInstanceID, _ := resolver(replDesc.NodeID)
+	return sqlInstanceID, nil
 }
 
 func (dsp *DistSQLPlanner) useGossipPlanning(ctx context.Context, planCtx *PlanningCtx) bool {

--- a/pkg/sql/distsql_physical_planner_test.go
+++ b/pkg/sql/distsql_physical_planner_test.go
@@ -56,6 +56,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
@@ -672,7 +673,8 @@ func TestPartitionSpans(t *testing.T) {
 		locFilter string
 
 		// expected result: a map of node to list of spans.
-		partitions map[int][][2]string
+		partitions      map[int][][2]string
+		partitionStates []string
 	}{
 		{
 			ranges:      []testSpanResolverRange{{"A", 1}, {"B", 2}, {"C", 1}, {"D", 3}},
@@ -684,6 +686,13 @@ func TestPartitionSpans(t *testing.T) {
 				1: {{"A1", "B"}, {"C", "C1"}},
 				2: {{"B", "C"}},
 				3: {{"D1", "X"}},
+			},
+
+			partitionStates: []string{
+				"partition span: {A1-B}, instance ID: 1, reason: gossip-target-healthy",
+				"partition span: {B-C}, instance ID: 2, reason: gossip-target-healthy",
+				"partition span: C{-1}, instance ID: 1, reason: gossip-target-healthy",
+				"partition span: {D1-X}, instance ID: 3, reason: gossip-target-healthy",
 			},
 		},
 
@@ -699,6 +708,13 @@ func TestPartitionSpans(t *testing.T) {
 				2: {{"B", "C"}},
 				3: {{"D1", "X"}},
 			},
+
+			partitionStates: []string{
+				"partition span: {A1-B}, instance ID: 1, reason: gossip-target-healthy",
+				"partition span: {B-C}, instance ID: 2, reason: gossip-target-healthy",
+				"partition span: C{-1}, instance ID: 1, reason: gossip-target-healthy",
+				"partition span: {D1-X}, instance ID: 3, reason: gossip-target-healthy",
+			},
 		},
 
 		{
@@ -711,6 +727,13 @@ func TestPartitionSpans(t *testing.T) {
 			partitions: map[int][][2]string{
 				1: {{"A1", "C1"}},
 				3: {{"D1", "X"}},
+			},
+
+			partitionStates: []string{
+				"partition span: {A1-B}, instance ID: 1, reason: gossip-target-healthy",
+				"partition span: {B-C}, instance ID: 1, reason: gossip-gateway-target-unhealthy",
+				"partition span: C{-1}, instance ID: 1, reason: gossip-target-healthy",
+				"partition span: {D1-X}, instance ID: 3, reason: gossip-target-healthy",
 			},
 		},
 
@@ -725,6 +748,13 @@ func TestPartitionSpans(t *testing.T) {
 				1: {{"A1", "B"}, {"C", "C1"}, {"D1", "X"}},
 				2: {{"B", "C"}},
 			},
+
+			partitionStates: []string{
+				"partition span: {A1-B}, instance ID: 1, reason: gossip-target-healthy",
+				"partition span: {B-C}, instance ID: 2, reason: gossip-target-healthy",
+				"partition span: C{-1}, instance ID: 1, reason: gossip-target-healthy",
+				"partition span: {D1-X}, instance ID: 1, reason: gossip-gateway-target-unhealthy",
+			},
 		},
 
 		{
@@ -737,6 +767,13 @@ func TestPartitionSpans(t *testing.T) {
 			partitions: map[int][][2]string{
 				2: {{"A1", "C1"}},
 				3: {{"D1", "X"}},
+			},
+
+			partitionStates: []string{
+				"partition span: {A1-B}, instance ID: 2, reason: gossip-gateway-target-unhealthy",
+				"partition span: {B-C}, instance ID: 2, reason: gossip-target-healthy",
+				"partition span: C{-1}, instance ID: 2, reason: gossip-gateway-target-unhealthy",
+				"partition span: {D1-X}, instance ID: 3, reason: gossip-target-healthy",
 			},
 		},
 
@@ -751,6 +788,13 @@ func TestPartitionSpans(t *testing.T) {
 				2: {{"B", "C"}},
 				3: {{"A1", "B"}, {"C", "C1"}, {"D1", "X"}},
 			},
+
+			partitionStates: []string{
+				"partition span: {A1-B}, instance ID: 3, reason: gossip-gateway-target-unhealthy",
+				"partition span: {B-C}, instance ID: 2, reason: gossip-target-healthy",
+				"partition span: C{-1}, instance ID: 3, reason: gossip-gateway-target-unhealthy",
+				"partition span: {D1-X}, instance ID: 3, reason: gossip-target-healthy",
+			},
 		},
 
 		// Test point lookups in isolation.
@@ -763,6 +807,12 @@ func TestPartitionSpans(t *testing.T) {
 			partitions: map[int][][2]string{
 				1: {{"A2", ""}, {"A1", ""}},
 				2: {{"B1", ""}},
+			},
+
+			partitionStates: []string{
+				"partition span: A2, instance ID: 1, reason: gossip-target-healthy",
+				"partition span: A1, instance ID: 1, reason: gossip-target-healthy",
+				"partition span: B1, instance ID: 2, reason: gossip-target-healthy",
 			},
 		},
 
@@ -777,6 +827,19 @@ func TestPartitionSpans(t *testing.T) {
 				1: {{"A1", ""}, {"A1", "A2"}, {"A2", ""}, {"A2", "C"}, {"B1", ""}, {"A3", "B3"}, {"B2", ""}},
 				2: {{"C", "C2"}},
 			},
+
+			partitionStates: []string{
+				"partition span: A1, instance ID: 1, reason: gossip-target-healthy",
+				"partition span: A{1-2}, instance ID: 1, reason: gossip-target-healthy",
+				"partition span: A2, instance ID: 1, reason: gossip-target-healthy",
+				"partition span: {A2-B}, instance ID: 1, reason: gossip-target-healthy",
+				"partition span: {B-C}, instance ID: 1, reason: gossip-target-healthy",
+				"partition span: C{-2}, instance ID: 2, reason: gossip-target-healthy",
+				"partition span: B1, instance ID: 1, reason: gossip-target-healthy",
+				"partition span: {A3-B}, instance ID: 1, reason: gossip-target-healthy",
+				"partition span: B{-3}, instance ID: 1, reason: gossip-target-healthy",
+				"partition span: B2, instance ID: 1, reason: gossip-target-healthy",
+			},
 		},
 
 		// A single span touching multiple ranges but on the same node results
@@ -790,8 +853,18 @@ func TestPartitionSpans(t *testing.T) {
 			partitions: map[int][][2]string{
 				1: {{"A", "B"}},
 			},
+
+			partitionStates: []string{
+				"partition span: A{-1}, instance ID: 1, reason: gossip-target-healthy",
+				"partition span: {A1-B}, instance ID: 1, reason: gossip-target-healthy",
+			},
 		},
 		// Test some locality-filtered planning too.
+		//
+		// Since this test is run on a system tenant but there is a locality filter,
+		// the spans are resolved in a mixed process mode. As a result, the
+		// partition states include a mix of locality and target reasons, which is
+		// expected.
 		{
 			ranges:      []testSpanResolverRange{{"A", 1}, {"B", 2}, {"C", 1}, {"D", 3}},
 			gatewayNode: 1,
@@ -801,6 +874,13 @@ func TestPartitionSpans(t *testing.T) {
 			partitions: map[int][][2]string{
 				1: {{"A1", "B"}, {"C", "C1"}, {"D1", "X"}},
 				2: {{"B", "C"}},
+			},
+
+			partitionStates: []string{
+				"partition span: {A1-B}, instance ID: 1, reason: target-healthy",
+				"partition span: {B-C}, instance ID: 2, reason: target-healthy",
+				"partition span: C{-1}, instance ID: 1, reason: target-healthy",
+				"partition span: {D1-X}, instance ID: 1, reason: gateway-no-locality-match",
 			},
 		},
 		{
@@ -813,6 +893,13 @@ func TestPartitionSpans(t *testing.T) {
 				2: {{"A1", "C1"}},
 				4: {{"D1", "X"}},
 			},
+
+			partitionStates: []string{
+				"partition span: {A1-B}, instance ID: 2, reason: closest-locality-match",
+				"partition span: {B-C}, instance ID: 2, reason: target-healthy",
+				"partition span: C{-1}, instance ID: 2, reason: closest-locality-match",
+				"partition span: {D1-X}, instance ID: 4, reason: closest-locality-match",
+			},
 		},
 		{
 			ranges:      []testSpanResolverRange{{"A", 1}, {"B", 2}, {"C", 1}, {"D", 3}},
@@ -822,6 +909,13 @@ func TestPartitionSpans(t *testing.T) {
 			locFilter: "x=3",
 			partitions: map[int][][2]string{
 				7: {{"A1", "C1"}, {"D1", "X"}},
+			},
+
+			partitionStates: []string{
+				"partition span: {A1-B}, instance ID: 7, reason: gateway-no-locality-match",
+				"partition span: {B-C}, instance ID: 7, reason: gateway-no-locality-match",
+				"partition span: C{-1}, instance ID: 7, reason: gateway-no-locality-match",
+				"partition span: {D1-X}, instance ID: 7, reason: gateway-no-locality-match",
 			},
 		},
 		{
@@ -833,14 +927,22 @@ func TestPartitionSpans(t *testing.T) {
 			partitions: map[int][][2]string{
 				7: {{"A1", "C1"}, {"D1", "X"}},
 			},
+
+			partitionStates: []string{
+				"partition span: {A1-B}, instance ID: 7, reason: locality-aware-random",
+				"partition span: {B-C}, instance ID: 7, reason: locality-aware-random",
+				"partition span: C{-1}, instance ID: 7, reason: locality-aware-random",
+				"partition span: {D1-X}, instance ID: 7, reason: locality-aware-random",
+			},
 		},
 	}
 
 	// We need a mock Gossip to contain addresses for the nodes. Otherwise the
 	// DistSQLPlanner will not plan flows on them.
-	testStopper := stop.NewStopper()
-	defer testStopper.Stop(context.Background())
-	mockGossip := gossip.NewTest(roachpb.NodeID(1), testStopper, metric.NewRegistry(), zonepb.DefaultZoneConfigRef())
+	ctx := context.Background()
+	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(ctx)
+	mockGossip := gossip.NewTest(roachpb.NodeID(1), s.Stopper(), metric.NewRegistry(), zonepb.DefaultZoneConfigRef())
 	var nodeDescs []*roachpb.NodeDescriptor
 	mockInstances := make(mockAddressResolver)
 	for i := 1; i <= 10; i++ {
@@ -872,6 +974,9 @@ func TestPartitionSpans(t *testing.T) {
 
 	for testIdx, tc := range testCases {
 		t.Run(strconv.Itoa(testIdx), func(t *testing.T) {
+			ctx := context.Background()
+			ctx, getRecAndFinish := tracing.ContextWithRecordingSpan(ctx, s.Tracer(), "PartitionSpans")
+
 			stopper := stop.NewStopper()
 			defer stopper.Stop(context.Background())
 
@@ -911,7 +1016,6 @@ func TestPartitionSpans(t *testing.T) {
 				nodeDescs:          mockGossip,
 			}
 
-			ctx := context.Background()
 			var locFilter roachpb.Locality
 			if tc.locFilter != "" {
 				require.NoError(t, locFilter.Set(tc.locFilter))
@@ -939,6 +1043,12 @@ func TestPartitionSpans(t *testing.T) {
 					spans = append(spans, [2]string{string(s.Key), string(s.EndKey)})
 				}
 				resMap[int(p.SQLInstanceID)] = spans
+			}
+
+			recording := getRecAndFinish()
+			t.Logf("recording is %s", recording)
+			for _, expectedMsg := range tc.partitionStates {
+				require.NotEqual(t, -1, tracing.FindMsgInRecording(recording, expectedMsg))
 			}
 
 			if !reflect.DeepEqual(resMap, tc.partitions) {


### PR DESCRIPTION
Backport 1/1 commits from #112938.

/cc @cockroachdb/release

---

Previously, there was no obseravbility into why our resolver
picked a particular instance for a given span. This made
debugging features such as backups/restores with execution
locality harder as we do not know why all replicas were
picked on a given node instead of being distributed to another
node. This will also benefit distributed SQL queries where
its important to understand what replicas are being picked.

This change adds a `SpanPartitionState` that covers all the
"interesting" decisions made by the resolver. This state can
be attributed to each span partition. Currently, this is logged
if vmodule>=2 or if verbose tracing is enabled. In the future
we may integrate it with the jobs profile infrastructure to
be dumped to disk on demand.

Informs: #113044
Release note: None

Release justification: low risk change to add critical observability into why spans are assigned to nodes during distributed execution
