### PR TITLE
upgrademanager: defer retrieval of cluster ID

### DIFF
--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -1264,7 +1264,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 		knobs, _ := cfg.TestingKnobs.UpgradeManager.(*upgradebase.TestingKnobs)
 		upgradeMgr = upgrademanager.NewManager(
 			systemDeps, leaseMgr, cfg.circularInternalExecutor, jobRegistry, codec,
-			cfg.Settings, clusterIDForSQL.Get(), knobs,
+			cfg.Settings, clusterIDForSQL, knobs,
 		)
 		execCfg.UpgradeJobDeps = upgradeMgr
 		execCfg.VersionUpgradeHook = upgradeMgr.Migrate

--- a/pkg/upgrade/upgrademanager/BUILD.bazel
+++ b/pkg/upgrade/upgrademanager/BUILD.bazel
@@ -32,7 +32,6 @@ go_library(
         "//pkg/util/log",
         "//pkg/util/startup",
         "//pkg/util/stop",
-        "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_logtags//:logtags",
         "@com_github_cockroachdb_redact//:redact",


### PR DESCRIPTION
Previously, the upgrade manager's constructor took the cluster ID
directly.

However, the cluster ID may not be initialised at the point of
constructing the manager. This isn't typically a problem because in
most cases, the only upgrade that _require_ the cluster ID doesn't
actually take the cluster ID from the manager. Rather, it gets the
cluster ID from the execution context of the migration job on
resumption.

But, tests such as TestRetriesWithExponentialBackoff set the
DontUseJobs testing hook. In this case, the migration manager runs the
upgrades directly, passing its own copy of the cluster ID, which is
unitialized.

To fix this, we pass the cluster ID container rather than the cluster
ID so that we can defer retrieving it until we actually run the
migrations, at which point it should be set.

Informs #112763

Release note: none