### PR TITLE
roachtestutil/mixedversion: start nodes sequentially

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion.go
@@ -702,7 +702,6 @@ func (s startStep) Run(ctx context.Context, l *logger.Logger, c cluster.Cluster,
 	}
 
 	startOpts := option.DefaultStartOptsNoBackups()
-	startOpts.RoachprodOpts.Sequential = false
 	clusterSettings := append(
 		append([]install.ClusterSettingOption{}, defaultClusterSettings...),
 		install.BinaryOption(binaryPath),


### PR DESCRIPTION
`Sequential: false` will start nodes concurrently. During cluster bootstrapping, this will assign random node IDs depending on the order in which they join the cluster. These random node IDs will not match the `node` attribute nor the directory name given to the process -- for example, a node allocated n2 may be stored on `~/local/3` with attribute `node3`, which can both violate test assertions (e.g. zone configurations referencing the `node` attribute) and make failures much harder to debug.

This patch instead starts nodes sequentially, such that they're allocated correct node IDs.

Resolves #113384.
Touches #113222.
Epic: none
Release note: None