### PR TITLE
jobs: potentially fix flake in TestRetriesWithExponentialBackoff

### DIFF
--- a/pkg/jobs/registry_test.go
+++ b/pkg/jobs/registry_test.go
@@ -789,15 +789,17 @@ func TestRetriesWithExponentialBackoff(t *testing.T) {
 			require.GreaterOrEqual(t, maxDelay, delay, "delay exceeds the max")
 			// Advance the clock such that it is before the next expected retry time.
 			bti.clock.AdvanceTo(lastRun.Add(delay - unitTime))
-			// This allows adopt-loops to run for a few times, which ensures that
-			// adopt-loops do not resume jobs without correctly following the job
-			// schedules.
-			waitUntilCount(t, bti.adopted, bti.adopted.Count()+2)
 			if bti.expectImmediateRetry && i > 0 {
-				// Validate that the job did not wait to resume on retry.
+				// Validate that the job does not wait to resume on retry.
+				waitUntilCount(t, bti.resumed, expectedResumed+1)
 				require.Equal(t, expectedResumed+1, bti.resumed.Count(), "unexpected number of jobs resumed in retry %d", i)
 			} else {
 				// Validate that the job is not resumed yet.
+
+				// This allows adopt-loops to run for a few times, which ensures that
+				// adopt-loops do not resume jobs without correctly following the job
+				// schedules.
+				waitUntilCount(t, bti.adopted, bti.adopted.Count()+2)
 				require.Equal(t, expectedResumed, bti.resumed.Count(), "unexpected number of jobs resumed in retry %d", i)
 			}
 			// Advance the clock by delta from the expected time of next retry.

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -1264,7 +1264,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 		knobs, _ := cfg.TestingKnobs.UpgradeManager.(*upgradebase.TestingKnobs)
 		upgradeMgr = upgrademanager.NewManager(
 			systemDeps, leaseMgr, cfg.circularInternalExecutor, jobRegistry, codec,
-			cfg.Settings, clusterIDForSQL.Get(), knobs,
+			cfg.Settings, clusterIDForSQL, knobs,
 		)
 		execCfg.UpgradeJobDeps = upgradeMgr
 		execCfg.VersionUpgradeHook = upgradeMgr.Migrate

--- a/pkg/upgrade/upgrademanager/BUILD.bazel
+++ b/pkg/upgrade/upgrademanager/BUILD.bazel
@@ -32,7 +32,6 @@ go_library(
         "//pkg/util/log",
         "//pkg/util/startup",
         "//pkg/util/stop",
-        "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_logtags//:logtags",
         "@com_github_cockroachdb_redact//:redact",


### PR DESCRIPTION
This potentially fixes an error we've seen when attempting to stress
this test. Namely, we occasionally see:

```
=== RUN   TestRetriesWithExponentialBackoff/pause_running
    registry_test.go:796:
        	Error Trace:	github.com/cockroachdb/cockroach/pkg/jobs/registry_test.go:796
        	                github.com/cockroachdb/cockroach/pkg/jobs/registry_test.go:873
        	Error:      	Not equal:
        	            	expected: 41
        	            	actual  : 40
        	Test:       	TestRetriesWithExponentialBackoff/pause_running
        	Messages:   	unexpected number of jobs resumed in
                retry 40
```

What I _think_ is happening here is that the adopt loop is able to
run twice before the paused job actually exits its Resumer. So,
waiting for the adopt loop to run twice isn't actually enough to
guarantee we've tried to resume the job already.

In this change, I wait on the resumed metric to advance which should
only advance once we've actually decided to call the resumer.

Locally, this failure mode is _very_ rare, so it is hard for me to say
whether this fixes the problem completely.

Informs https://github.com/cockroachdb/cockroach/issues/112763

Release note: None