### PR TITLE
roachtest: skip restore/tpce/32TB/inc-count=400/gce/nodes=15/cpus=16

### DIFF
--- a/pkg/cmd/roachtest/tests/restore.go
+++ b/pkg/cmd/roachtest/tests/restore.go
@@ -420,6 +420,7 @@ func registerRestore(r registry.Registry) {
 				`SET CLUSTER SETTING backup.restore_span.target_size = '0'`,
 			},
 			restoreUptoIncremental: 400,
+			skip:                   "a recent gcp pricing policy makes this test very expensive. unskip after #111371 is addressed",
 		},
 		{
 			// A teeny weeny 15GB restore that could be used to bisect scale agnostic perf regressions.
@@ -453,6 +454,7 @@ func registerRestore(r registry.Registry) {
 			CompatibleClouds:  sp.clouds,
 			Suites:            sp.suites,
 			Tags:              sp.tags,
+			Skip:              sp.skip,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 
 				rd := makeRestoreDriver(t, c, sp)
@@ -825,6 +827,9 @@ type restoreSpecs struct {
 
 	testName   string
 	setUpStmts []string
+
+	// skip, if non-empty, skips the test with the given reason.
+	skip string
 }
 
 func (sp *restoreSpecs) initTestName() {


### PR DESCRIPTION
This weekly test is very costly (leads to cross region egress) and is already
run on aws. We can reconsider unskipping it after https://github.com/cockroachdb/cockroach/issues/111371 is addressed.

Epic: none

Release note: none