### PR TITLE
bincheck: bind 127.0.0.1

### DIFF
--- a/build/release/bincheck/bincheck
+++ b/build/release/bincheck/bincheck
@@ -32,7 +32,7 @@ echo "Generating encryption key:"
 echo ""
 
 # Start node with encryption enabled.
-"$cockroach" start-single-node --insecure --listening-url-file="$urlfile" --enterprise-encryption=path=cockroach-data,key=aes-128.key,old-key=plain --pid-file="$pidfile" &
+"$cockroach" start-single-node --listen-addr 127.0.0.1:26257 --insecure --listening-url-file="$urlfile" --enterprise-encryption=path=cockroach-data,key=aes-128.key,old-key=plain --pid-file="$pidfile" &
 
 trap "kill -9 $! || true" EXIT
 for i in {0..8}


### PR DESCRIPTION
Previously, bincheck started a single node database instance without specifying the address/port it listens on. In this case the server code tried to resolve the hostname and use it. See
https://github.com/cockroachdb/cockroach/blob/d498a59cc2afc9778af6f7e0120206ab1ee56bc2/pkg/base/addr_validation.go#L128 for the details.

At some point this method stopped working on MacOS GitHub workers. There is an upstream issue open: https://github.com/actions/runner-images/issues/8649

This PR explicitly sets the `--listen-addr` parameter to skip the problematic code.

Epic: none
Release note: None