### PR TITLE
roachtest: remove cloud from registry and ClusterSpec

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -620,10 +620,11 @@ type nodeSelector interface {
 
 // It is safe for concurrent use by multiple goroutines.
 type clusterImpl struct {
-	name string
-	tag  string
-	spec spec.ClusterSpec
-	t    test.Test
+	name  string
+	tag   string
+	cloud string
+	spec  spec.ClusterSpec
+	t     test.Test
 	// r is the registry tracking this cluster. Destroying the cluster will
 	// unregister it.
 	r *clusterRegistry
@@ -862,7 +863,9 @@ func (f *clusterFactory) newCluster(
 
 	providerOptsContainer := vm.CreateProviderOptionsContainer()
 
+	cloud := roachtestflags.Cloud
 	params := spec.RoachprodClusterConfig{
+		Cloud:                  cloud,
 		UseIOBarrierOnLocalSSD: cfg.useIOBarrier,
 		PreferredArch:          cfg.arch,
 	}
@@ -876,8 +879,8 @@ func (f *clusterFactory) newCluster(
 	if err != nil {
 		return nil, nil, err
 	}
-	if cfg.spec.Cloud != spec.Local {
-		providerOptsContainer.SetProviderOpts(cfg.spec.Cloud, providerOpts)
+	if cloud != spec.Local {
+		providerOptsContainer.SetProviderOpts(cloud, providerOpts)
 	}
 
 	if cfg.spec.UbuntuVersion.IsOverridden() {
@@ -916,6 +919,7 @@ func (f *clusterFactory) newCluster(
 		}
 
 		c := &clusterImpl{
+			cloud:      cloud,
 			name:       genName,
 			spec:       cfg.spec,
 			expiration: cfg.spec.Expiration(),
@@ -2584,7 +2588,7 @@ func (c *clusterImpl) MakeNodes(opts ...option.Option) string {
 }
 
 func (c *clusterImpl) Cloud() string {
-	return c.spec.Cloud
+	return c.cloud
 }
 
 func (c *clusterImpl) IsLocal() bool {
@@ -2666,7 +2670,7 @@ func archForTest(ctx context.Context, l *logger.Logger, testSpec registry.TestSp
 		return testSpec.Cluster.Arch
 	}
 
-	if testSpec.Benchmark && testSpec.Cluster.Cloud != spec.Local {
+	if testSpec.Benchmark && roachtestflags.Cloud != spec.Local {
 		// TODO(srosenberg): enable after https://github.com/cockroachdb/cockroach/issues/104213
 		arch := vm.ArchAMD64
 		l.PrintfCtx(ctx, "Disabling arch randomization for benchmark; arch=%q, %s", arch, testSpec.Name)

--- a/pkg/cmd/roachtest/cluster_test.go
+++ b/pkg/cmd/roachtest/cluster_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func TestClusterNodes(t *testing.T) {
-	c := &clusterImpl{spec: spec.MakeClusterSpec(spec.GCE, 10)}
+	c := &clusterImpl{spec: spec.MakeClusterSpec(10)}
 	opts := func(opts ...option.Option) []option.Option {
 		return opts
 	}

--- a/pkg/cmd/roachtest/github.go
+++ b/pkg/cmd/roachtest/github.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/internal/issues"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestflags"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/tests"
@@ -207,7 +208,7 @@ func (g *githubIssues) createPostRequest(
 	artifacts := fmt.Sprintf("/%s", testName)
 
 	clusterParams := map[string]string{
-		roachtestPrefix("cloud"):            spec.Cluster.Cloud,
+		roachtestPrefix("cloud"):            roachtestflags.Cloud,
 		roachtestPrefix("cpu"):              fmt.Sprintf("%d", spec.Cluster.CPUs),
 		roachtestPrefix("ssd"):              fmt.Sprintf("%d", spec.Cluster.SSDs),
 		roachtestPrefix("metamorphicBuild"): fmt.Sprintf("%t", metamorphicBuild),
@@ -248,7 +249,7 @@ func (g *githubIssues) createPostRequest(
 		Artifacts:            artifacts,
 		ExtraLabels:          labels,
 		ExtraParams:          clusterParams,
-		HelpCommand:          generateHelpCommand(testName, issueClusterName, spec.Cluster.Cloud, start, end),
+		HelpCommand:          generateHelpCommand(testName, issueClusterName, roachtestflags.Cloud, start, end),
 	}, nil
 }
 

--- a/pkg/cmd/roachtest/github_test.go
+++ b/pkg/cmd/roachtest/github_test.go
@@ -83,7 +83,7 @@ func TestShouldPost(t *testing.T) {
 		{false, 1, "token", "master", true, ""},
 	}
 
-	reg := makeTestRegistry(spec.GCE)
+	reg := makeTestRegistry()
 	for _, c := range testCases {
 		t.Setenv("GITHUB_API_TOKEN", c.envGithubAPIToken)
 		t.Setenv("TC_BUILD_BRANCH", c.envTcBuildBranch)
@@ -198,7 +198,7 @@ func TestCreatePostRequest(t *testing.T) {
 		},
 	}
 
-	reg := makeTestRegistry(spec.GCE)
+	reg := makeTestRegistry()
 	for idx, c := range testCases {
 		t.Run(fmt.Sprintf("%d", idx+1), func(t *testing.T) {
 			clusterSpec := reg.MakeClusterSpec(1, spec.Arch(c.arch))

--- a/pkg/cmd/roachtest/main.go
+++ b/pkg/cmd/roachtest/main.go
@@ -96,7 +96,7 @@ Examples:
    roachtest list --suite weekly --owner kv
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			r := makeTestRegistry(roachtestflags.Cloud)
+			r := makeTestRegistry()
 			tests.RegisterTests(&r)
 
 			filter, err := makeTestFilter(args)

--- a/pkg/cmd/roachtest/main_test.go
+++ b/pkg/cmd/roachtest/main_test.go
@@ -30,7 +30,7 @@ func init() {
 }
 
 func makeRegistry(names ...string) testRegistryImpl {
-	r := makeTestRegistry(spec.GCE)
+	r := makeTestRegistry()
 	dummyRun := func(context.Context, test.Test, cluster.Cluster) {}
 
 	for _, name := range names {
@@ -38,7 +38,7 @@ func makeRegistry(names ...string) testRegistryImpl {
 			Name:             name,
 			Owner:            OwnerUnitTest,
 			Run:              dummyRun,
-			Cluster:          spec.MakeClusterSpec(spec.GCE, 0),
+			Cluster:          spec.MakeClusterSpec(0),
 			CompatibleClouds: registry.AllExceptAWS,
 			Suites:           registry.Suites(registry.Nightly),
 		})

--- a/pkg/cmd/roachtest/registry/registry_interface.go
+++ b/pkg/cmd/roachtest/registry/registry_interface.go
@@ -21,5 +21,4 @@ type Registry interface {
 	MakeClusterSpec(nodeCount int, opts ...spec.Option) spec.ClusterSpec
 	Add(TestSpec)
 	PromFactory() promauto.Factory
-	Cloud() string
 }

--- a/pkg/cmd/roachtest/run.go
+++ b/pkg/cmd/roachtest/run.go
@@ -43,7 +43,7 @@ import (
 func runTests(register func(registry.Registry), filter *registry.TestFilter) error {
 	//lint:ignore SA1019 deprecated
 	rand.Seed(roachtestflags.GlobalSeed)
-	r := makeTestRegistry(roachtestflags.Cloud)
+	r := makeTestRegistry()
 
 	// actual registering of tests
 	// TODO: don't register if we can't run on the specified registry cloud

--- a/pkg/cmd/roachtest/spec/option.go
+++ b/pkg/cmd/roachtest/spec/option.go
@@ -19,13 +19,6 @@ import (
 // Option for MakeClusterSpec.
 type Option func(spec *ClusterSpec)
 
-// Cloud controls what cloud is used to create the cluster.
-func Cloud(s string) Option {
-	return func(spec *ClusterSpec) {
-		spec.Cloud = s
-	}
-}
-
 // Arch requests a specific CPU architecture.
 //
 // Note that it is not guaranteed that this architecture will be used (e.g. if

--- a/pkg/cmd/roachtest/test_registry.go
+++ b/pkg/cmd/roachtest/test_registry.go
@@ -26,7 +26,6 @@ import (
 
 type testRegistryImpl struct {
 	m                map[string]*registry.TestSpec
-	cloud            string
 	snapshotPrefixes map[string]struct{}
 
 	promRegistry *prometheus.Registry
@@ -35,9 +34,8 @@ type testRegistryImpl struct {
 var _ registry.Registry = (*testRegistryImpl)(nil)
 
 // makeTestRegistry constructs a testRegistryImpl and configures it with opts.
-func makeTestRegistry(cloud string) testRegistryImpl {
+func makeTestRegistry() testRegistryImpl {
 	return testRegistryImpl{
-		cloud:            cloud,
 		m:                make(map[string]*registry.TestSpec),
 		snapshotPrefixes: make(map[string]struct{}),
 		promRegistry:     prometheus.NewRegistry(),
@@ -71,7 +69,7 @@ func (r *testRegistryImpl) Add(spec registry.TestSpec) {
 // MakeClusterSpec makes a cluster spec. It should be used over `spec.MakeClusterSpec`
 // because this method also adds options baked into the registry.
 func (r *testRegistryImpl) MakeClusterSpec(nodeCount int, opts ...spec.Option) spec.ClusterSpec {
-	return spec.MakeClusterSpec(r.cloud, nodeCount, opts...)
+	return spec.MakeClusterSpec(nodeCount, opts...)
 }
 
 const testNameRE = "^[a-zA-Z0-9-_=/,]+$"
@@ -140,8 +138,4 @@ func (r testRegistryImpl) AllTests() []registry.TestSpec {
 		return tests[i].Name < tests[j].Name
 	})
 	return tests
-}
-
-func (r testRegistryImpl) Cloud() string {
-	return r.cloud
 }

--- a/pkg/cmd/roachtest/test_registry_test.go
+++ b/pkg/cmd/roachtest/test_registry_test.go
@@ -21,8 +21,7 @@ import (
 )
 
 func TestMakeTestRegistry(t *testing.T) {
-	r := makeTestRegistry(spec.AWS)
-	require.Equal(t, spec.AWS, r.cloud)
+	r := makeTestRegistry()
 
 	s := r.MakeClusterSpec(100, spec.Geo(), spec.CPU(12),
 		spec.PreferLocalSSD())
@@ -52,7 +51,7 @@ func TestMakeTestRegistry(t *testing.T) {
 // TestPrometheusMetricParser tests that the registry.PromSub()
 // helper properly converts a string into a metric name that Prometheus can read.
 func TestPrometheusMetricParser(t *testing.T) {
-	r := makeTestRegistry(spec.AWS)
+	r := makeTestRegistry()
 	f := r.PromFactory()
 
 	rawName := "restore/nodes=4/duration"

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -955,7 +955,7 @@ func (r *testRunner) runTest(
 
 	s := t.Spec().(*registry.TestSpec)
 
-	grafanaAvailable := s.Cluster.Cloud == spec.GCE
+	grafanaAvailable := roachtestflags.Cloud == spec.GCE
 	if err := c.addLabels(map[string]string{VmLabelTestName: testRunID}); err != nil {
 		shout(ctx, l, stdout, "failed to add label to cluster [%s] - %s", c.Name(), err)
 		grafanaAvailable = false

--- a/pkg/cmd/roachtest/test_test.go
+++ b/pkg/cmd/roachtest/test_test.go
@@ -44,7 +44,7 @@ const defaultParallelism = 10
 
 func mkReg(t *testing.T) testRegistryImpl {
 	t.Helper()
-	return makeTestRegistry(spec.GCE)
+	return makeTestRegistry()
 }
 
 func nilLogger() *logger.Logger {
@@ -319,7 +319,7 @@ func TestRunnerTestTimeout(t *testing.T) {
 		Name:             `timeout`,
 		Owner:            OwnerUnitTest,
 		Timeout:          10 * time.Millisecond,
-		Cluster:          spec.MakeClusterSpec(spec.GCE, 0),
+		Cluster:          spec.MakeClusterSpec(0),
 		CompatibleClouds: registry.AllExceptAWS,
 		Suites:           registry.Suites(registry.Nightly),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
@@ -356,7 +356,7 @@ func TestRegistryPrepareSpec(t *testing.T) {
 				Name:             "a",
 				Owner:            OwnerUnitTest,
 				Run:              dummyRun,
-				Cluster:          spec.MakeClusterSpec(spec.GCE, 0),
+				Cluster:          spec.MakeClusterSpec(0),
 				CompatibleClouds: registry.AllExceptAWS,
 				Suites:           registry.Suites(registry.Nightly),
 			},
@@ -368,7 +368,7 @@ func TestRegistryPrepareSpec(t *testing.T) {
 				Name:             "illegal *[]",
 				Owner:            OwnerUnitTest,
 				Run:              dummyRun,
-				Cluster:          spec.MakeClusterSpec(spec.GCE, 0),
+				Cluster:          spec.MakeClusterSpec(0),
 				CompatibleClouds: registry.AllExceptAWS,
 				Suites:           registry.Suites(registry.Nightly),
 			},
@@ -378,7 +378,7 @@ func TestRegistryPrepareSpec(t *testing.T) {
 	}
 	for _, c := range testCases {
 		t.Run("", func(t *testing.T) {
-			r := makeTestRegistry(spec.GCE)
+			r := makeTestRegistry()
 			err := r.prepareSpec(&c.spec)
 			if !testutils.IsError(err, c.expectedErr) {
 				t.Fatalf("expected %q, but found %q", c.expectedErr, err.Error())
@@ -405,7 +405,7 @@ func runExitCodeTest(t *testing.T, injectedError error) error {
 	r.Add(registry.TestSpec{
 		Name:             "boom",
 		Owner:            OwnerUnitTest,
-		Cluster:          spec.MakeClusterSpec(spec.GCE, 0),
+		Cluster:          spec.MakeClusterSpec(0),
 		CompatibleClouds: registry.AllExceptAWS,
 		Suites:           registry.Suites(registry.Nightly),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {

--- a/pkg/cmd/roachtest/tests/admission_control_database_drop.go
+++ b/pkg/cmd/roachtest/tests/admission_control_database_drop.go
@@ -32,7 +32,6 @@ func registerDatabaseDrop(r registry.Registry) {
 		10, /* nodeCount */
 		spec.CPU(8),
 		spec.VolumeSize(500),
-		spec.Cloud(spec.GCE),
 		spec.GCEMinCPUPlatform("Intel Ice Lake"),
 		spec.GCEVolumeType("pd-ssd"),
 		spec.GCEMachineType("n2-standard-8"),

--- a/pkg/cmd/roachtest/tests/admission_control_index_backfill.go
+++ b/pkg/cmd/roachtest/tests/admission_control_index_backfill.go
@@ -33,7 +33,6 @@ func registerIndexBackfill(r registry.Registry) {
 		10, /* nodeCount */
 		spec.CPU(8),
 		spec.VolumeSize(500),
-		spec.Cloud(spec.GCE),
 		spec.GCEMinCPUPlatform("Intel Ice Lake"),
 		spec.GCEVolumeType("pd-ssd"),
 		spec.GCEMachineType("n2-standard-8"),

--- a/pkg/cmd/roachtest/tests/backup_restore_roundtrip.go
+++ b/pkg/cmd/roachtest/tests/backup_restore_roundtrip.go
@@ -73,7 +73,7 @@ func registerBackupRestoreRoundTrip(r registry.Registry) {
 			Cluster:           r.MakeClusterSpec(4),
 			EncryptionSupport: registry.EncryptionMetamorphic,
 			RequiresLicense:   true,
-			CompatibleClouds:  registry.AllExceptAWS,
+			CompatibleClouds:  registry.OnlyGCE,
 			Suites:            registry.Suites(registry.Nightly),
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				backupRestoreRoundTrip(ctx, t, c, sp.metamorphicRangeSize)
@@ -87,7 +87,7 @@ func registerBackupRestoreRoundTrip(r registry.Registry) {
 func backupRestoreRoundTrip(
 	ctx context.Context, t test.Test, c cluster.Cluster, metamorphicRangeSize bool,
 ) {
-	if c.Spec().Cloud != spec.GCE {
+	if c.Cloud() != spec.GCE {
 		t.Skip("uses gs://cockroachdb-backup-testing; see https://github.com/cockroachdb/cockroach/issues/105968")
 	}
 	pauseProbability := 0.2

--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -1016,14 +1016,6 @@ func runCDCKafkaAuth(ctx context.Context, t test.Test, c cluster.Cluster) {
 	}
 }
 
-func skipLocalUnderArm64(cloud string) string {
-	if cloud == spec.Local && runtime.GOARCH == "arm64" {
-		// N.B. we also have to skip locally since amd64 emulation may not be available everywhere.
-		return "Skip under ARM64."
-	}
-	return ""
-}
-
 func registerCDC(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:             "cdc/initial-scan-only",
@@ -1446,13 +1438,18 @@ func registerCDC(r registry.Registry) {
 		Owner:     `cdc`,
 		Benchmark: true,
 		// Only Kafka 3 supports Arm64, but the broker setup for Oauth used only works with Kafka 2
-		Skip:             skipLocalUnderArm64(r.Cloud()),
 		Cluster:          r.MakeClusterSpec(4, spec.Arch(vm.ArchAMD64)),
 		Leases:           registry.MetamorphicLeases,
 		CompatibleClouds: registry.AllExceptAWS,
 		Suites:           registry.Suites(registry.Nightly),
 		RequiresLicense:  true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			if c.Cloud() == spec.Local && runtime.GOARCH == "arm64" {
+				// N.B. We have to skip locally since amd64 emulation may not be available everywhere.
+				t.L().PrintfCtx(ctx, "Skipping test under ARM64")
+				return
+			}
+
 			ct := newCDCTester(ctx, t, c)
 			defer ct.Close()
 

--- a/pkg/cmd/roachtest/tests/prune_dangling_snapshots_and_disks.go
+++ b/pkg/cmd/roachtest/tests/prune_dangling_snapshots_and_disks.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
-	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
@@ -28,14 +27,13 @@ import (
 func registerPruneDanglingSnapshotsAndDisks(r registry.Registry) {
 	clusterSpec := r.MakeClusterSpec(
 		1, /* nodeCount */
-		spec.Cloud(spec.GCE),
 	)
 
 	r.Add(registry.TestSpec{
 		Name:             "prune-dangling",
 		Owner:            registry.OwnerTestEng,
 		Cluster:          clusterSpec,
-		CompatibleClouds: registry.AllExceptAWS,
+		CompatibleClouds: registry.OnlyGCE,
 		Suites:           registry.Suites(registry.Nightly),
 		RequiresLicense:  true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {

--- a/pkg/cmd/roachtest/tests/tpcc_test.go
+++ b/pkg/cmd/roachtest/tests/tpcc_test.go
@@ -26,16 +26,16 @@ func TestTPCCSupportedWarehouses(t *testing.T) {
 		buildVersion *version.Version
 		expected     int
 	}{
-		{"gce", spec.MakeClusterSpec(spec.GCE, 4, spec.CPU(16)), version.MustParse(`v2.1.0`), 1300},
-		{"gce", spec.MakeClusterSpec(spec.GCE, 4, spec.CPU(16)), version.MustParse(`v19.1.0-rc.1`), 1250},
-		{"gce", spec.MakeClusterSpec(spec.GCE, 4, spec.CPU(16)), version.MustParse(`v19.1.0`), 1250},
+		{"gce", spec.MakeClusterSpec(4, spec.CPU(16)), version.MustParse(`v2.1.0`), 1300},
+		{"gce", spec.MakeClusterSpec(4, spec.CPU(16)), version.MustParse(`v19.1.0-rc.1`), 1250},
+		{"gce", spec.MakeClusterSpec(4, spec.CPU(16)), version.MustParse(`v19.1.0`), 1250},
 
-		{"aws", spec.MakeClusterSpec(spec.GCE, 4, spec.CPU(16)), version.MustParse(`v19.1.0-rc.1`), 2100},
-		{"aws", spec.MakeClusterSpec(spec.GCE, 4, spec.CPU(16)), version.MustParse(`v19.1.0`), 2100},
+		{"aws", spec.MakeClusterSpec(4, spec.CPU(16)), version.MustParse(`v19.1.0-rc.1`), 2100},
+		{"aws", spec.MakeClusterSpec(4, spec.CPU(16)), version.MustParse(`v19.1.0`), 2100},
 
-		{"nope", spec.MakeClusterSpec(spec.GCE, 4, spec.CPU(16)), version.MustParse(`v2.1.0`), expectPanic},
-		{"gce", spec.MakeClusterSpec(spec.GCE, 5, spec.CPU(160)), version.MustParse(`v2.1.0`), expectPanic},
-		{"gce", spec.MakeClusterSpec(spec.GCE, 4, spec.CPU(16)), version.MustParse(`v1.0.0`), expectPanic},
+		{"nope", spec.MakeClusterSpec(4, spec.CPU(16)), version.MustParse(`v2.1.0`), expectPanic},
+		{"gce", spec.MakeClusterSpec(5, spec.CPU(160)), version.MustParse(`v2.1.0`), expectPanic},
+		{"gce", spec.MakeClusterSpec(4, spec.CPU(16)), version.MustParse(`v1.0.0`), expectPanic},
 	}
 	for _, test := range tests {
 		t.Run("", func(t *testing.T) {


### PR DESCRIPTION
This change is the last step in removing runtime state from the test
registry and the cluster spec. The cloud is no longer accessible at
test registration time.

Fixes #104029
Release note: None