### PR TITLE
workloadccl: disable multi-tenant config in TestImportFixture

### DIFF
--- a/pkg/ccl/workloadccl/fixture_test.go
+++ b/pkg/ccl/workloadccl/fixture_test.go
@@ -182,7 +182,12 @@ func TestImportFixture(t *testing.T) {
 	stats.DefaultRefreshInterval = time.Millisecond
 	stats.DefaultAsOfTime = 10 * time.Millisecond
 
-	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{
+		// Occasionally, for some reason auto stats aren't collected within the
+		// retry window after the import is finished in multi-tenant setup, so
+		// for now we disable this config.
+		DefaultTestTenant: base.TestIsForStuffThatShouldWorkWithSecondaryTenantsButDoesntYet(110708),
+	})
 	defer s.Stopper().Stop(ctx)
 	sqlDB := sqlutils.MakeSQLRunner(db)
 


### PR DESCRIPTION
This test regularly fails under stress in multi-tenant setup even with the retry loop waiting for auto stats to be collected after the import succeeds. In order to avoid unnecessary noise, this commit disables multi-tenant config.

Informs: #110708.
Epic: None.

Release note: None