### PR TITLE
tenantcostclient: add blocked requests metric

### DIFF
--- a/pkg/ccl/multitenantccl/tenantcostclient/BUILD.bazel
+++ b/pkg/ccl/multitenantccl/tenantcostclient/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "tenantcostclient",
     srcs = [
         "limiter.go",
+        "metrics.go",
         "tenant_side.go",
         "test_utils.go",
         "token_bucket.go",
@@ -23,6 +24,7 @@ go_library(
         "//pkg/sql/execinfra",
         "//pkg/sql/sqlliveness",
         "//pkg/util/log",
+        "//pkg/util/metric",
         "//pkg/util/quotapool",
         "//pkg/util/stop",
         "//pkg/util/syncutil",
@@ -93,6 +95,7 @@ go_test(
         "//pkg/util/ioctx",
         "//pkg/util/leaktest",
         "//pkg/util/log",
+        "//pkg/util/metric",
         "//pkg/util/protoutil",
         "//pkg/util/randutil",
         "//pkg/util/stop",

--- a/pkg/ccl/multitenantccl/tenantcostclient/metrics.go
+++ b/pkg/ccl/multitenantccl/tenantcostclient/metrics.go
@@ -1,0 +1,30 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package tenantcostclient
+
+import "github.com/cockroachdb/cockroach/pkg/util/metric"
+
+var (
+	metaCurrentBlocked = metric.Metadata{
+		Name:        "tenant.cost_client.blocked_requests",
+		Help:        "Number of requests currently blocked by the rate limiter",
+		Measurement: "Requests",
+		Unit:        metric.Unit_COUNT,
+	}
+)
+
+// metrics manage the metrics used by the tenant cost client.
+type metrics struct {
+	CurrentBlocked *metric.Gauge
+}
+
+// Init initializes the tenant cost client metrics.
+func (m *metrics) Init() {
+	m.CurrentBlocked = metric.NewGauge(metaCurrentBlocked)
+}

--- a/pkg/ccl/multitenantccl/tenantcostclient/tenant_side.go
+++ b/pkg/ccl/multitenantccl/tenantcostclient/tenant_side.go
@@ -166,7 +166,12 @@ func newTenantSideCostController(
 		responseChan:    make(chan *kvpb.TokenBucketResponse, 1),
 		lowRUNotifyChan: make(chan struct{}, 1),
 	}
-	c.limiter.Init(timeSource, c.lowRUNotifyChan)
+
+	// Initialize metrics.
+	c.metrics.Init()
+
+	// Start with filled burst buffer.
+	c.limiter.Init(&c.metrics, timeSource, c.lowRUNotifyChan)
 	c.limiter.Reconfigure(timeSource.Now(), limiterReconfigureArgs{
 		NewTokens: initialRUs,
 		NewRate:   initialRate,
@@ -238,6 +243,7 @@ func init() {
 }
 
 type tenantSideCostController struct {
+	metrics              metrics
 	timeSource           timeutil.TimeSource
 	testInstr            TestInstrumentation
 	settings             *cluster.Settings


### PR DESCRIPTION
Add metric that tracks the number of requests that are blocked waiting for more request units to become available. This metric will enable us to detect when a customer workload is being throttled due to insufficient provisioned capacity.

Epic: CC-25942

Release note: None