### PR TITLE
backup: tolerate no value for updates_cluster_last_backup_time_metric in ALTER

### DIFF
--- a/pkg/ccl/backupccl/alter_backup_schedule.go
+++ b/pkg/ccl/backupccl/alter_backup_schedule.go
@@ -312,9 +312,15 @@ func processScheduleOptions(
 					"only users with the admin role are allowed to change %s", optUpdatesLastBackupMetric)
 			}
 
-			updatesLastBackupMetric, err := strconv.ParseBool(v)
-			if err != nil {
-				return errors.Wrapf(err, "unexpected value for %s: %s", k, v)
+			// If the option is specified it generally means to set it, unless it has
+			// a value and that value parses as false.
+			updatesLastBackupMetric := true
+			if v != "" {
+				var err error
+				updatesLastBackupMetric, err = strconv.ParseBool(v)
+				if err != nil {
+					return errors.Wrapf(err, "unexpected value for %s: %s", k, v)
+				}
 			}
 			s.fullArgs.UpdatesLastBackupMetric = updatesLastBackupMetric
 			if s.incArgs == nil {

--- a/pkg/ccl/backupccl/testdata/backup-restore/alter-schedule/schedule-options
+++ b/pkg/ccl/backupccl/testdata/backup-restore/alter-schedule/schedule-options
@@ -91,6 +91,7 @@ alter backup schedule $fullID set schedule option updates_cluster_last_backup_ti
 alter backup schedule $fullID set schedule option updates_cluster_last_backup_time_metric = 'TRUE';
 alter backup schedule $fullID set schedule option updates_cluster_last_backup_time_metric = 'False';
 alter backup schedule $fullID set schedule option updates_cluster_last_backup_time_metric = 't';
+alter backup schedule $fullID set schedule option updates_cluster_last_backup_time_metric;
 ----
 
 exec-sql expect-error-regex=(unexpected value)


### PR DESCRIPTION
Release note (bug fix): ALTER BACKUP SCHEDULE can be used to set updates_cluster_last_backup_time_metric without providing an explicit value, matching the behavior of the option when specified during CREATE SCHEDULE.

Epic: none.