### PR TITLE
importer: deflake import stmt test

### DIFF
--- a/pkg/sql/importer/import_stmt_test.go
+++ b/pkg/sql/importer/import_stmt_test.go
@@ -4649,7 +4649,9 @@ func TestImportDefaultNextVal(t *testing.T) {
 					if util.RaceEnabled {
 						expectedVal = test.seqToNumNextval[seqName].expectedImportChunkAllocsUnderRace
 					}
-					require.Equal(t, expectedVal, seqVal)
+					// The seqVal may have advanced further due to retries, so it may be
+					// greater than the expectedVal.
+					require.LessOrEqual(t, expectedVal, seqVal)
 				}
 			})
 		}


### PR DESCRIPTION
Due to retries, the test sequence may be more advanced than expected. This PR modifies the test assertion to check that at least the expected sequence value has been reached.

Epic: None
Fixes: #112552

Release note: None