### PR TITLE
rttanalysis: add a benchmark for asyncpg query to load types

### DIFF
--- a/pkg/bench/rttanalysis/testdata/benchmark_expectations
+++ b/pkg/bench/rttanalysis/testdata/benchmark_expectations
@@ -62,6 +62,7 @@ exp,benchmark
 16,GrantRole/grant_1_role
 21,GrantRole/grant_2_roles
 4,ORMQueries/activerecord_type_introspection_query
+1,ORMQueries/asyncpg_types
 1,ORMQueries/column_descriptions_json_agg
 5,ORMQueries/django_column_introspection_1_table
 5,ORMQueries/django_column_introspection_4_tables


### PR DESCRIPTION
This benchmark shows that a query made by asyncpg only performs one KV roundtrip, but still takes multiple seconds to complete because of a suboptimal query plan. It's likely that WITH RECURSIVE is part of the problem.

informs  #113292

Release note: None