### PR TITLE
docker: fix env variable

### DIFF
--- a/build/deploy/cockroach.sh
+++ b/build/deploy/cockroach.sh
@@ -298,7 +298,8 @@ _main() {
 set_env_var "COCKROACH_ARGS"
 
 if [[ -n "$COCKROACH_ARGS" ]]; then
-  _main "$COCKROACH_ARGS"
-else
-  _main "$@"
+  # override positional parameters
+  IFS=' ' eval set -- "$COCKROACH_ARGS"
 fi
+
+_main "$@"


### PR DESCRIPTION
The current approach passes in COCKROACH_ARGS as is which does not work when environment variables has more than one parameters as docker passes them as a single string. This commit overrides the parameters with proper splitting.

Release note: None