### PR TITLE
release-23.1: rangefeed: add `kv.rangefeed.push_txns.enabled`

### DIFF
--- a/pkg/kv/kvserver/rangefeed/BUILD.bazel
+++ b/pkg/kv/kvserver/rangefeed/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//pkg/kv/kvpb",
         "//pkg/roachpb",
         "//pkg/settings",
+        "//pkg/settings/cluster",
         "//pkg/storage",
         "//pkg/storage/enginepb",
         "//pkg/util/admission",

--- a/pkg/kv/kvserver/rangefeed/processor.go
+++ b/pkg/kv/kvserver/rangefeed/processor.go
@@ -18,6 +18,8 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/future"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -39,6 +41,17 @@ const (
 	defaultCheckStreamsInterval = 1 * time.Second
 )
 
+var (
+	// PushTxnsEnabled can be used to disable rangefeed txn pushes, typically to
+	// temporarily alleviate contention.
+	PushTxnsEnabled = settings.RegisterBoolSetting(
+		settings.SystemOnly,
+		"kv.rangefeed.push_txns.enabled",
+		"periodically push txn write timestamps to advance rangefeed resolved timestamps",
+		true,
+	)
+)
+
 // newErrBufferCapacityExceeded creates an error that is returned to subscribers
 // if the rangefeed processor is not able to keep up with the flow of incoming
 // events and is forced to drop events in order to not block.
@@ -51,9 +64,10 @@ func newErrBufferCapacityExceeded() *kvpb.Error {
 // Config encompasses the configuration required to create a Processor.
 type Config struct {
 	log.AmbientContext
-	Clock   *hlc.Clock
-	RangeID roachpb.RangeID
-	Span    roachpb.RSpan
+	Clock    *hlc.Clock
+	Settings *cluster.Settings
+	RangeID  roachpb.RangeID
+	Span     roachpb.RSpan
 
 	TxnPusher TxnPusher
 	// PushTxnsInterval specifies the interval at which a Processor will push
@@ -358,9 +372,9 @@ func (p *Processor) run(
 
 		// Check whether any unresolved intents need a push.
 		case <-txnPushTickerC:
-			// Don't perform transaction push attempts until the resolved
-			// timestamp has been initialized.
-			if !p.rts.IsInit() {
+			// Don't perform transaction push attempts if disabled or until the
+			// resolved timestamp has been initialized.
+			if !PushTxnsEnabled.Get(&p.Settings.SV) || !p.rts.IsInit() {
 				continue
 			}
 

--- a/pkg/kv/kvserver/rangefeed/processor.go
+++ b/pkg/kv/kvserver/rangefeed/processor.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/future"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -29,19 +30,21 @@ import (
 )
 
 const (
-	// defaultPushTxnsInterval is the default interval at which a Processor will
-	// push all transactions in the unresolvedIntentQueue that are above the age
-	// specified by PushTxnsAge.
-	defaultPushTxnsInterval = 250 * time.Millisecond
-	// defaultPushTxnsAge is the default age at which a Processor will begin to
-	// consider a transaction old enough to push.
-	defaultPushTxnsAge = 10 * time.Second
 	// defaultCheckStreamsInterval is the default interval at which a Processor
 	// will check all streams to make sure they have not been canceled.
 	defaultCheckStreamsInterval = 1 * time.Second
 )
 
 var (
+	// defaultPushTxnsInterval is the default interval at which a Processor will
+	// push all transactions in the unresolvedIntentQueue that are above the age
+	// specified by PushTxnsAge.
+	defaultPushTxnsInterval = envutil.EnvOrDefaultDuration(
+		"COCKROACH_RANGEFEED_PUSH_TXNS_INTERVAL", 250*time.Millisecond)
+	// defaultPushTxnsAge is the default age at which a Processor will begin to
+	// consider a transaction old enough to push.
+	defaultPushTxnsAge = envutil.EnvOrDefaultDuration(
+		"COCKROACH_RANGEFEED_PUSH_TXNS_AGE", 10*time.Second)
 	// PushTxnsEnabled can be used to disable rangefeed txn pushes, typically to
 	// temporarily alleviate contention.
 	PushTxnsEnabled = settings.RegisterBoolSetting(

--- a/pkg/kv/kvserver/rangefeed/processor_test.go
+++ b/pkg/kv/kvserver/rangefeed/processor_test.go
@@ -70,6 +70,10 @@ func writeIntentOpWithDetails(
 	})
 }
 
+func writeIntentOpFromMeta(txn enginepb.TxnMeta) enginepb.MVCCLogicalOp {
+	return writeIntentOpWithDetails(txn.ID, txn.Key, txn.MinTimestamp, txn.WriteTimestamp)
+}
+
 func writeIntentOpWithKey(txnID uuid.UUID, key []byte, ts hlc.Timestamp) enginepb.MVCCLogicalOp {
 	return writeIntentOpWithDetails(txnID, key, ts /* minTS */, ts)
 }
@@ -140,7 +144,7 @@ func rangeFeedCheckpoint(span roachpb.Span, ts hlc.Timestamp) *kvpb.RangeFeedEve
 const testProcessorEventCCap = 16
 
 func newTestProcessorWithTxnPusher(
-	t *testing.T, rtsIter storage.SimpleMVCCIterator, txnPusher TxnPusher,
+	t *testing.T, rtsIter storage.SimpleMVCCIterator, txnPusher TxnPusher, st *cluster.Settings,
 ) (*Processor, *stop.Stopper) {
 	t.Helper()
 	stopper := stop.NewStopper()
@@ -150,8 +154,12 @@ func newTestProcessorWithTxnPusher(
 		pushTxnInterval = 10 * time.Millisecond
 		pushTxnAge = 50 * time.Millisecond
 	}
+	if st == nil {
+		st = cluster.MakeTestingClusterSettings()
+	}
 	p := NewProcessor(Config{
 		AmbientContext:       log.MakeTestingAmbientCtxWithNewTracer(),
+		Settings:             st,
 		Clock:                hlc.NewClockForTesting(nil),
 		Span:                 roachpb.RSpan{Key: roachpb.RKey("a"), EndKey: roachpb.RKey("z")},
 		TxnPusher:            txnPusher,
@@ -176,7 +184,7 @@ func newTestProcessor(
 	t *testing.T, rtsIter storage.SimpleMVCCIterator,
 ) (*Processor, *stop.Stopper) {
 	t.Helper()
-	return newTestProcessorWithTxnPusher(t, rtsIter, nil /* pusher */)
+	return newTestProcessorWithTxnPusher(t, rtsIter, nil /* pusher */, nil /* settings */)
 }
 
 func waitErrorFuture(f *future.ErrorFuture) error {
@@ -563,6 +571,7 @@ func TestProcessorMemoryBudgetExceeded(t *testing.T) {
 	var pushTxnInterval, pushTxnAge time.Duration = 0, 0 // disable
 	p := NewProcessor(Config{
 		AmbientContext:       log.MakeTestingAmbientCtxWithNewTracer(),
+		Settings:             cluster.MakeTestingClusterSettings(),
 		Clock:                hlc.NewClockForTesting(nil),
 		Span:                 roachpb.RSpan{Key: roachpb.RKey("a"), EndKey: roachpb.RKey("z")},
 		PushTxnsInterval:     pushTxnInterval,
@@ -632,6 +641,7 @@ func TestProcessorMemoryBudgetReleased(t *testing.T) {
 	var pushTxnInterval, pushTxnAge time.Duration = 0, 0 // disable
 	p := NewProcessor(Config{
 		AmbientContext:       log.MakeTestingAmbientCtxWithNewTracer(),
+		Settings:             cluster.MakeTestingClusterSettings(),
 		Clock:                hlc.NewClockForTesting(nil),
 		Span:                 roachpb.RSpan{Key: roachpb.RKey("a"), EndKey: roachpb.RKey("z")},
 		PushTxnsInterval:     pushTxnInterval,
@@ -879,14 +889,11 @@ func TestProcessorTxnPushAttempt(t *testing.T) {
 		return nil
 	})
 
-	p, stopper := newTestProcessorWithTxnPusher(t, nil /* rtsIter */, &tp)
+	p, stopper := newTestProcessorWithTxnPusher(t, nil /* rtsIter */, &tp, nil /* settings */)
 	ctx := context.Background()
 	defer stopper.Stop(ctx)
 
 	// Add a few intents and move the closed timestamp forward.
-	writeIntentOpFromMeta := func(txn enginepb.TxnMeta) enginepb.MVCCLogicalOp {
-		return writeIntentOpWithDetails(txn.ID, txn.Key, txn.MinTimestamp, txn.WriteTimestamp)
-	}
 	p.ConsumeLogicalOps(ctx,
 		writeIntentOpFromMeta(txn1Meta),
 		writeIntentOpFromMeta(txn2Meta),
@@ -955,6 +962,56 @@ func TestProcessorTxnPushAttempt(t *testing.T) {
 
 	// Release push attempt to avoid deadlock.
 	resumePushAttemptsC <- struct{}{}
+}
+
+// TestProcessorTxnPushDisabled tests that processors don't attempt txn pushes
+// when disabled.
+func TestProcessorTxnPushDisabled(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	const pushInterval = 10 * time.Millisecond
+
+	// Set up a txn to write intents.
+	ts := hlc.Timestamp{WallTime: 10}
+	txnID := uuid.MakeV4()
+	txnMeta := enginepb.TxnMeta{
+		ID:             txnID,
+		Key:            keyA,
+		WriteTimestamp: ts,
+		MinTimestamp:   ts,
+	}
+
+	// Disable txn pushes.
+	ctx := context.Background()
+	st := cluster.MakeTestingClusterSettings()
+	PushTxnsEnabled.Override(ctx, &st.SV, false)
+
+	// Set up a txn pusher and processor that errors on any pushes.
+	var tp testTxnPusher
+	tp.mockPushTxns(func(txns []enginepb.TxnMeta, ts hlc.Timestamp) ([]*roachpb.Transaction, error) {
+		err := errors.Errorf("unexpected txn push for txns=%v ts=%s", txns, ts)
+		t.Errorf("%v", err)
+		return nil, err
+	})
+
+	p, stopper := newTestProcessorWithTxnPusher(t, nil /* rtsIter */, &tp, st)
+	defer stopper.Stop(ctx)
+
+	// Move the resolved ts forward to just before the txn timestamp.
+	rts := ts.Add(-1, 0)
+	require.True(t, p.ForwardClosedTS(ctx, rts))
+	p.syncEventC()
+	require.Equal(t, rts, p.rts.Get())
+
+	// Add a few intents and move the closed timestamp forward.
+	p.ConsumeLogicalOps(ctx, writeIntentOpFromMeta(txnMeta))
+	p.ForwardClosedTS(ctx, ts)
+	p.syncEventC()
+	require.Equal(t, rts, p.rts.Get())
+
+	// Wait for 10x the push txns interval, to make sure pushes are disabled.
+	// Waiting for something to not happen is a bit smelly, but gets the job done.
+	time.Sleep(10 * pushInterval)
 }
 
 // TestProcessorConcurrentStop tests that all methods in Processor's API
@@ -1122,6 +1179,7 @@ func TestBudgetReleaseOnProcessorStop(t *testing.T) {
 	var pushTxnInterval, pushTxnAge time.Duration = 0, 0 // disable
 	p := NewProcessor(Config{
 		AmbientContext:       log.MakeTestingAmbientCtxWithNewTracer(),
+		Settings:             cluster.MakeTestingClusterSettings(),
 		Clock:                hlc.NewClockForTesting(nil),
 		Span:                 roachpb.RSpan{Key: roachpb.RKey("a"), EndKey: roachpb.RKey("z")},
 		PushTxnsInterval:     pushTxnInterval,
@@ -1213,6 +1271,7 @@ func TestBudgetReleaseOnLastStreamError(t *testing.T) {
 	var pushTxnInterval, pushTxnAge time.Duration = 0, 0 // disable
 	p := NewProcessor(Config{
 		AmbientContext:       log.MakeTestingAmbientCtxWithNewTracer(),
+		Settings:             cluster.MakeTestingClusterSettings(),
 		Clock:                hlc.NewClockForTesting(nil),
 		Span:                 roachpb.RSpan{Key: roachpb.RKey("a"), EndKey: roachpb.RKey("z")},
 		PushTxnsInterval:     pushTxnInterval,
@@ -1293,6 +1352,7 @@ func TestBudgetReleaseOnOneStreamError(t *testing.T) {
 	var pushTxnInterval, pushTxnAge time.Duration = 0, 0 // disable
 	p := NewProcessor(Config{
 		AmbientContext:       log.MakeTestingAmbientCtxWithNewTracer(),
+		Settings:             cluster.MakeTestingClusterSettings(),
 		Clock:                hlc.NewClockForTesting(nil),
 		Span:                 roachpb.RSpan{Key: roachpb.RKey("a"), EndKey: roachpb.RKey("z")},
 		PushTxnsInterval:     pushTxnInterval,

--- a/pkg/kv/kvserver/replica_rangefeed.go
+++ b/pkg/kv/kvserver/replica_rangefeed.go
@@ -373,6 +373,7 @@ func (r *Replica) registerWithRangefeedRaftMuLocked(
 	cfg := rangefeed.Config{
 		AmbientContext:   r.AmbientContext,
 		Clock:            r.Clock(),
+		Settings:         r.store.ClusterSettings(),
 		RangeID:          r.RangeID,
 		Span:             desc.RSpan(),
 		TxnPusher:        &tp,


### PR DESCRIPTION
Backport 1/1 commits from #113281.
Backport part of #110332.

Release justification: this would have been useful to mitigate a recent outage.

/cc @cockroachdb/release

---

This patch adds `kv.rangefeed.push_txns.enabled`, which can be used to disable rangefeed txn pushes, e.g. if they cause excessive contention. The cluster setting is meant to be used temporarily, since disabling txn pushes can cause the rangefeed resolved timestamp to fall arbitrarily far behind.

Resolves #113262.
Epic: none
Release note: None
