### PR TITLE
release-22.2: rangefeed: add `kv.rangefeed.push_txns.enabled`

### DIFF
--- a/pkg/kv/kvserver/rangefeed/BUILD.bazel
+++ b/pkg/kv/kvserver/rangefeed/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//pkg/keys",
         "//pkg/roachpb",
         "//pkg/settings",
+        "//pkg/settings/cluster",
         "//pkg/storage",
         "//pkg/storage/enginepb",
         "//pkg/util/admission",

--- a/pkg/kv/kvserver/rangefeed/processor.go
+++ b/pkg/kv/kvserver/rangefeed/processor.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
@@ -27,19 +28,21 @@ import (
 )
 
 const (
-	// defaultPushTxnsInterval is the default interval at which a Processor will
-	// push all transactions in the unresolvedIntentQueue that are above the age
-	// specified by PushTxnsAge.
-	defaultPushTxnsInterval = 250 * time.Millisecond
-	// defaultPushTxnsAge is the default age at which a Processor will begin to
-	// consider a transaction old enough to push.
-	defaultPushTxnsAge = 10 * time.Second
 	// defaultCheckStreamsInterval is the default interval at which a Processor
 	// will check all streams to make sure they have not been canceled.
 	defaultCheckStreamsInterval = 1 * time.Second
 )
 
 var (
+	// defaultPushTxnsInterval is the default interval at which a Processor will
+	// push all transactions in the unresolvedIntentQueue that are above the age
+	// specified by PushTxnsAge.
+	defaultPushTxnsInterval = envutil.EnvOrDefaultDuration(
+		"COCKROACH_RANGEFEED_PUSH_TXNS_INTERVAL", 250*time.Millisecond)
+	// defaultPushTxnsAge is the default age at which a Processor will begin to
+	// consider a transaction old enough to push.
+	defaultPushTxnsAge = envutil.EnvOrDefaultDuration(
+		"COCKROACH_RANGEFEED_PUSH_TXNS_AGE", 10*time.Second)
 	// PushTxnsEnabled can be used to disable rangefeed txn pushes, typically to
 	// temporarily alleviate contention.
 	PushTxnsEnabled = settings.RegisterBoolSetting(

--- a/pkg/kv/kvserver/replica_rangefeed.go
+++ b/pkg/kv/kvserver/replica_rangefeed.go
@@ -374,6 +374,7 @@ func (r *Replica) registerWithRangefeedRaftMuLocked(
 	cfg := rangefeed.Config{
 		AmbientContext:   r.AmbientContext,
 		Clock:            r.Clock(),
+		Settings:         r.store.ClusterSettings(),
 		RangeID:          r.RangeID,
 		Span:             desc.RSpan(),
 		TxnPusher:        &tp,


### PR DESCRIPTION
Backport 1/1 commits from #113281.
Backport part of #110332.

Release justification: this would have been useful to mitigate a recent outage.

/cc @cockroachdb/release

---

This patch adds `kv.rangefeed.push_txns.enabled`, which can be used to disable rangefeed txn pushes, e.g. if they cause excessive contention. The cluster setting is meant to be used temporarily, since disabling txn pushes can cause the rangefeed resolved timestamp to fall arbitrarily far behind.

Resolves #113262.
Epic: none
Release note: None