### PR TITLE
roachtest: use SIGUSR1 instead of SIGKILL in coverage mode

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -2104,6 +2104,15 @@ func (c *clusterImpl) StopE(
 	if c.spec.NodeCount == 0 {
 		return nil // unit tests
 	}
+	if c.goCoverDir != "" {
+		// Never kill processes if we're trying to collect coverage; use SIGUSR1
+		// which dumps coverage data and exits.
+		if stopOpts.RoachprodOpts.Sig == 9 {
+			stopOpts.RoachprodOpts.Sig = 10 // SIGUSR1
+			stopOpts.RoachprodOpts.Wait = true
+			stopOpts.RoachprodOpts.MaxWait = 10
+		}
+	}
 	c.setStatusForClusterOpt("stopping", stopOpts.RoachtestOpts.Worker, nodes...)
 	defer c.clearStatusForClusterOpt(stopOpts.RoachtestOpts.Worker)
 	return errors.Wrap(roachprod.Stop(ctx, l, c.MakeNodes(nodes...), stopOpts.RoachprodOpts), "cluster.StopE")

--- a/pkg/cmd/roachtest/option/options.go
+++ b/pkg/cmd/roachtest/option/options.go
@@ -58,6 +58,8 @@ func DefaultStartSingleNodeOpts() StartOpts {
 
 // StopOpts is a type that combines the stop options needed by roachprod and roachtest.
 type StopOpts struct {
+	// TODO(radu): we should use a higher-level abstraction instead of
+	// roachprod.StopOpts so we don't have to pass around signal values etc.
 	RoachprodOpts roachprod.StopOpts
 	RoachtestOpts struct {
 		Worker bool

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -1276,18 +1276,8 @@ func (r *testRunner) teardownTest(
 
 	// Test was successful. If we are collecting code coverage, copy the files now.
 	if t.goCoverEnabled {
-		// Go cover data is dumped when the cockroach process exits; send SIGUSR1 to
-		// make it exit immediately.
-		//
-		// TODO(radu): many tests stop the nodes with the default options (SIGKILL)
-		// during the test, which means some coverage data will be lost. Consider
-		// updating the default options.
 		t.L().Printf("Stopping all nodes to obtain go cover artifacts")
-		stopOpts := option.DefaultStopOpts()
-		stopOpts.RoachprodOpts.Sig = 10 // SIGUSR1
-		stopOpts.RoachprodOpts.Wait = true
-		stopOpts.RoachprodOpts.MaxWait = 10
-		if err := c.StopE(ctx, t.L(), stopOpts, c.All()); err != nil {
+		if err := c.StopE(ctx, t.L(), option.DefaultStopOpts(), c.All()); err != nil {
 			t.L().PrintfCtx(ctx, "error stopping cluster: %v", err)
 		}
 


### PR DESCRIPTION
Epic: none
Release note: None