### PR TITLE
release-23.2: serverutils: use options for SQL connections

### DIFF
--- a/pkg/ccl/auditloggingccl/audit_logging_test.go
+++ b/pkg/ccl/auditloggingccl/audit_logging_test.go
@@ -119,7 +119,7 @@ func TestSingleRoleAuditLogging(t *testing.T) {
 	rootRunner := sqlutils.MakeSQLRunner(sqlDB)
 	defer s.Stopper().Stop(context.Background())
 
-	testUserDb := s.ApplicationLayer().SQLConnForUser(t, username.TestUser, "")
+	testUserDb := s.ApplicationLayer().SQLConn(t, serverutils.User(username.TestUser))
 	testRunner := sqlutils.MakeSQLRunner(testUserDb)
 
 	// Dummy table/user used by tests.
@@ -261,7 +261,7 @@ func TestMultiRoleAuditLogging(t *testing.T) {
 	defer s.Stopper().Stop(context.Background())
 	rootRunner := sqlutils.MakeSQLRunner(sqlDB)
 
-	testUserDb := s.ApplicationLayer().SQLConnForUser(t, username.TestUser, "")
+	testUserDb := s.ApplicationLayer().SQLConn(t, serverutils.User(username.TestUser))
 	testRunner := sqlutils.MakeSQLRunner(testUserDb)
 
 	// Dummy table/user used by tests.
@@ -376,7 +376,7 @@ func TestReducedAuditConfig(t *testing.T) {
 		return nil
 	})
 
-	testUserDb := s.ApplicationLayer().SQLConnForUser(t, username.TestUser, "")
+	testUserDb := s.ApplicationLayer().SQLConn(t, serverutils.User(username.TestUser))
 	testRunner := sqlutils.MakeSQLRunner(testUserDb)
 
 	// Set a cluster configuration.
@@ -432,7 +432,7 @@ func TestReducedAuditConfig(t *testing.T) {
 	}
 
 	// Open 2nd connection for the test user.
-	testUserDb2 := s.ApplicationLayer().SQLConnForUser(t, username.TestUser, "")
+	testUserDb2 := s.ApplicationLayer().SQLConn(t, serverutils.User(username.TestUser))
 	testRunner2 := sqlutils.MakeSQLRunner(testUserDb2)
 
 	// Run a query on the new connection. The new connection will cause the reduced audit config to be re-computed.

--- a/pkg/ccl/backupccl/alter_backup_schedule_test.go
+++ b/pkg/ccl/backupccl/alter_backup_schedule_test.go
@@ -78,7 +78,7 @@ func newAlterSchedulesTestHelper(t *testing.T) (*alterSchedulesTestHelper, func(
 	th.sqlDB = sqlutils.MakeSQLRunner(db)
 	th.server = s
 	th.sqlDB.Exec(t, `SET CLUSTER SETTING bulkio.backup.merge_file_buffer_size = '1MiB'`)
-	sysDB := sqlutils.MakeSQLRunner(s.SystemLayer().SQLConn(t, ""))
+	sysDB := sqlutils.MakeSQLRunner(s.SystemLayer().SQLConn(t))
 	sysDB.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.target_duration = '100ms'`) // speeds up test
 
 	return th, func() {

--- a/pkg/ccl/backupccl/backup_tenant_test.go
+++ b/pkg/ccl/backupccl/backup_tenant_test.go
@@ -83,7 +83,7 @@ func TestBackupSharedProcessTenantNodeDown(t *testing.T) {
 	for i := 1; i < multiNode; i++ {
 		testutils.SucceedsSoon(t, func() error {
 			t.Logf("waiting for server %d", i)
-			db, err := tc.Server(i).SystemLayer().SQLConnE("cluster:test/defaultdb")
+			db, err := tc.Server(i).SystemLayer().SQLConnE(serverutils.DBName("cluster:test/defaultdb"))
 			if err != nil {
 				return err
 			}

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -1018,7 +1018,7 @@ func backupAndRestore(
 ) {
 	conn := tc.Conns[0]
 	sqlDB := sqlutils.MakeSQLRunner(conn)
-	storageConn := tc.SystemLayer(0).SQLConn(t, "")
+	storageConn := tc.SystemLayer(0).SQLConn(t)
 	storageSQLDB := sqlutils.MakeSQLRunner(storageConn)
 	storageSQLDB.Exec(t, "SET DATABASE=defaultdb")
 	{
@@ -3396,7 +3396,7 @@ func TestBackupJobFailsInRestoredTenant(t *testing.T) {
 			JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals()},
 	})
 	require.NoError(t, err)
-	t10Sql := sqlutils.MakeSQLRunner(t10.SQLConn(t, ""))
+	t10Sql := sqlutils.MakeSQLRunner(t10.SQLConn(t))
 	potentialPausePoints := []string{
 		"backup.after.write_first_checkpoint",
 		"backup.after.details_has_checkpoint",
@@ -3418,7 +3418,7 @@ func TestBackupJobFailsInRestoredTenant(t *testing.T) {
 			JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals()},
 	})
 	require.NoError(t, err)
-	t20Sql := sqlutils.MakeSQLRunner(t20.SQLConn(t, ""))
+	t20Sql := sqlutils.MakeSQLRunner(t20.SQLConn(t))
 	t20Sql.Exec(t, `RESUME JOB $1`, backupJobID)
 	jobutils.WaitForJobToFail(t, t20Sql, jobspb.JobID(backupJobID))
 }

--- a/pkg/ccl/backupccl/create_scheduled_backup_test.go
+++ b/pkg/ccl/backupccl/create_scheduled_backup_test.go
@@ -985,7 +985,7 @@ func TestCreateBackupScheduleRequiresAdminRole(t *testing.T) {
 	defer cleanup()
 
 	th.sqlDB.Exec(t, `CREATE USER testuser`)
-	testuser := th.server.ApplicationLayer().SQLConnForUser(t, "testuser", "")
+	testuser := th.server.ApplicationLayer().SQLConn(t, serverutils.User("testuser"))
 
 	_, err := testuser.Exec("CREATE SCHEDULE FOR BACKUP INTO 'somewhere' RECURRING '@daily'")
 	require.Error(t, err)

--- a/pkg/ccl/backupccl/show_test.go
+++ b/pkg/ccl/backupccl/show_test.go
@@ -673,7 +673,7 @@ func TestShowBackupPrivileges(t *testing.T) {
 	sqlDB.Exec(t, `CREATE USER testuser`)
 	sqlDB.Exec(t, `CREATE TABLE privs (a INT)`)
 
-	testuser := srv.ApplicationLayer().SQLConnForUser(t, "testuser", "")
+	testuser := srv.ApplicationLayer().SQLConn(t, serverutils.User("testuser"))
 
 	// Make an initial backup.
 	const full = localFoo + "/full"

--- a/pkg/ccl/backupccl/tenant_backup_nemesis_test.go
+++ b/pkg/ccl/backupccl/tenant_backup_nemesis_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util"
@@ -78,7 +79,7 @@ func TestTenantBackupWithCanceledImport(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	tenant10Conn := tenant10.SQLConn(t, "defaultdb")
+	tenant10Conn := tenant10.SQLConn(t, serverutils.DBName("defaultdb"))
 	tenant10DB := sqlutils.MakeSQLRunner(tenant10Conn)
 
 	tenant10DB.Exec(t, "CREATE DATABASE bank")
@@ -106,7 +107,7 @@ func TestTenantBackupWithCanceledImport(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	tenant11Conn := tenant11.SQLConn(t, "bank")
+	tenant11Conn := tenant11.SQLConn(t, serverutils.DBName("bank"))
 	tenant11DB := sqlutils.MakeSQLRunner(tenant11Conn)
 	countQuery := fmt.Sprintf(`SELECT count(1) FROM bank."%s"`, tableName)
 	assertEqualQueries(t, tenant10DB, tenant11DB, countQuery)
@@ -150,7 +151,7 @@ func TestTenantBackupNemesis(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	tenant10Conn := tenant10.SQLConn(t, "defaultdb")
+	tenant10Conn := tenant10.SQLConn(t, serverutils.DBName("defaultdb"))
 	_, err = tenant10Conn.Exec("CREATE DATABASE bank")
 	require.NoError(t, err)
 	_, err = tenant10Conn.Exec("USE bank")
@@ -250,7 +251,7 @@ func TestTenantBackupNemesis(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	tenant11Conn := tenant11.SQLConn(t, "bank")
+	tenant11Conn := tenant11.SQLConn(t, serverutils.DBName("bank"))
 
 	tenant10SQLDB := sqlutils.MakeSQLRunner(tenant10Conn)
 	tenant11SQLDB := sqlutils.MakeSQLRunner(tenant11Conn)

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -3594,7 +3594,7 @@ func TestChangefeedFailOnTableOffline(t *testing.T) {
 
 	cdcTestNamedWithSystem(t, "import fails changefeed", func(t *testing.T, s TestServerWithSystem, f cdctest.TestFeedFactory) {
 		sqlDB := sqlutils.MakeSQLRunner(s.DB)
-		sysDB := sqlutils.MakeSQLRunner(s.SystemServer.SQLConn(t, ""))
+		sysDB := sqlutils.MakeSQLRunner(s.SystemServer.SQLConn(t))
 		sysDB.Exec(t, "SET CLUSTER SETTING kv.closed_timestamp.target_duration = '50ms'")
 		sqlDB.Exec(t, `CREATE TABLE for_import (a INT PRIMARY KEY, b INT)`)
 		defer sqlDB.Exec(t, `DROP TABLE for_import`)
@@ -3759,7 +3759,7 @@ func TestChangefeedWorksOnRBRChange(t *testing.T) {
 
 	testFnJSON := func(t *testing.T, s TestServerWithSystem, f cdctest.TestFeedFactory) {
 		sqlDB := sqlutils.MakeSQLRunner(s.DB)
-		sysDB := sqlutils.MakeSQLRunner(s.SystemServer.SQLConn(t, ""))
+		sysDB := sqlutils.MakeSQLRunner(s.SystemServer.SQLConn(t))
 		sysDB.Exec(t, "SET CLUSTER SETTING kv.closed_timestamp.target_duration = '50ms'")
 		t.Run("regional by row change works", func(t *testing.T) {
 			sqlDB.Exec(t, `CREATE TABLE rbr (a INT PRIMARY KEY, b INT)`)
@@ -3904,7 +3904,7 @@ func TestChangefeedStopOnSchemaChange(t *testing.T) {
 	}
 	testFn := func(t *testing.T, s TestServerWithSystem, f cdctest.TestFeedFactory) {
 		sqlDB := sqlutils.MakeSQLRunner(s.DB)
-		sysDB := sqlutils.MakeSQLRunner(s.SystemServer.SQLConn(t, ""))
+		sysDB := sqlutils.MakeSQLRunner(s.SystemServer.SQLConn(t))
 		// Shorten the intervals so this test doesn't take so long. We need to wait
 		// for timestamps to get resolved.
 		sysDB.Exec(t, "SET CLUSTER SETTING changefeed.experimental_poll_interval = '200ms'")
@@ -4035,7 +4035,7 @@ func TestChangefeedNoBackfill(t *testing.T) {
 	skip.UnderShort(t)
 	testFn := func(t *testing.T, s TestServerWithSystem, f cdctest.TestFeedFactory) {
 		sqlDB := sqlutils.MakeSQLRunner(s.DB)
-		sysDB := sqlutils.MakeSQLRunner(s.SystemServer.SQLConn(t, ""))
+		sysDB := sqlutils.MakeSQLRunner(s.SystemServer.SQLConn(t))
 
 		usingLegacySchemaChanger := maybeDisableDeclarativeSchemaChangesForTest(t, sqlDB)
 
@@ -4361,7 +4361,7 @@ func TestChangefeedMonitoring(t *testing.T) {
 
 	testFn := func(t *testing.T, s TestServerWithSystem, f cdctest.TestFeedFactory) {
 		sqlDB := sqlutils.MakeSQLRunner(s.DB)
-		sysDB := sqlutils.MakeSQLRunner(s.SystemServer.SQLConn(t, ""))
+		sysDB := sqlutils.MakeSQLRunner(s.SystemServer.SQLConn(t))
 		sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY)`)
 		sqlDB.Exec(t, `INSERT INTO foo VALUES (1)`)
 

--- a/pkg/ccl/changefeedccl/protected_timestamps_test.go
+++ b/pkg/ccl/changefeedccl/protected_timestamps_test.go
@@ -56,7 +56,7 @@ func TestChangefeedUpdateProtectedTimestamp(t *testing.T) {
 			context.Background(), &s.Server.ClusterSettings().SV, ptsInterval)
 
 		sqlDB := sqlutils.MakeSQLRunner(s.DB)
-		sysDB := sqlutils.MakeSQLRunner(s.SystemServer.SQLConn(t, ""))
+		sysDB := sqlutils.MakeSQLRunner(s.SystemServer.SQLConn(t))
 		sysDB.Exec(t, "SET CLUSTER SETTING kv.protectedts.poll_interval = '10ms'")
 		sysDB.Exec(t, "SET CLUSTER SETTING kv.closed_timestamp.target_duration = '100ms'") // speeds up the test
 		sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY)`)
@@ -233,7 +233,7 @@ func TestChangefeedProtectedTimestamps(t *testing.T) {
 
 	testFn := func(t *testing.T, s TestServerWithSystem, f cdctest.TestFeedFactory) {
 		sqlDB := sqlutils.MakeSQLRunner(s.DB)
-		sysDB := sqlutils.MakeSQLRunner(s.SystemServer.SQLConn(t, ""))
+		sysDB := sqlutils.MakeSQLRunner(s.SystemServer.SQLConn(t))
 		sysDB.Exec(t, `SET CLUSTER SETTING kv.protectedts.poll_interval = '10ms'`)
 		sysDB.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.target_duration = '100ms'`)
 		sqlDB.Exec(t, `ALTER RANGE default CONFIGURE ZONE USING gc.ttlseconds = 100`)
@@ -402,7 +402,7 @@ func TestChangefeedCanceledWhenPTSIsOld(t *testing.T) {
 
 	testFn := func(t *testing.T, s TestServerWithSystem, f cdctest.TestFeedFactory) {
 		sqlDB := sqlutils.MakeSQLRunner(s.DB)
-		sysDB := sqlutils.MakeSQLRunner(s.SystemServer.SQLConn(t, ""))
+		sysDB := sqlutils.MakeSQLRunner(s.SystemServer.SQLConn(t))
 		sysDB.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.target_duration = '100ms'`)
 		sqlDB.Exec(t, `SET CLUSTER SETTING jobs.metrics.interval.poll = '100ms'`) // speed up metrics poller
 		// Create the data table; it will only contain a

--- a/pkg/ccl/cloudccl/cloudprivilege/privileges_test.go
+++ b/pkg/ccl/cloudccl/cloudprivilege/privileges_test.go
@@ -42,7 +42,7 @@ func TestURIRequiresAdminOrPrivilege(t *testing.T) {
 	rootDB := sqlutils.MakeSQLRunner(conn)
 
 	rootDB.Exec(t, `CREATE USER testuser`)
-	testuser := tc.ApplicationLayer(0).SQLConnForUser(t, username.TestUser, "")
+	testuser := tc.ApplicationLayer(0).SQLConn(t, serverutils.User(username.TestUser))
 	rootDB.Exec(t, `CREATE TABLE foo (id INT)`)
 
 	// Grant SELECT so that EXPORT fails when checking URI privileges.

--- a/pkg/ccl/kvccl/kvfollowerreadsccl/followerreads_test.go
+++ b/pkg/ccl/kvccl/kvfollowerreadsccl/followerreads_test.go
@@ -1024,7 +1024,7 @@ func TestSecondaryTenantFollowerReadsRouting(t *testing.T) {
 						Locality:     localities[i],
 						TestingKnobs: knobs,
 					})
-					dbs[i] = tenants[i].SQLConn(t, "")
+					dbs[i] = tenants[i].SQLConn(t)
 				}
 				require.NoError(t, err)
 			}

--- a/pkg/ccl/kvccl/kvtenantccl/upgradeccl/tenant_upgrade_test.go
+++ b/pkg/ccl/kvccl/kvtenantccl/upgradeccl/tenant_upgrade_test.go
@@ -74,7 +74,7 @@ func TestTenantAutoUpgradeRespectsAutoUpgradeEnabledSetting(t *testing.T) {
 		},
 	})
 	defer ts.Stopper().Stop(ctx)
-	sysDB := sqlutils.MakeSQLRunner(ts.SQLConn(t, ""))
+	sysDB := sqlutils.MakeSQLRunner(ts.SQLConn(t, serverutils.DBName("")))
 
 	expectedInitialTenantVersion := clusterversion.ByKey(v0)
 
@@ -177,7 +177,7 @@ func TestTenantAutoUpgrade(t *testing.T) {
 		},
 	})
 	defer ts.Stopper().Stop(ctx)
-	sysDB := sqlutils.MakeSQLRunner(ts.SQLConn(t, ""))
+	sysDB := sqlutils.MakeSQLRunner(ts.SQLConn(t, serverutils.DBName("")))
 
 	expectedInitialTenantVersion := clusterversion.ByKey(v0)
 	expectedFinalTenantVersion := clusterversion.TestingBinaryVersion
@@ -293,7 +293,7 @@ func TestTenantUpgrade(t *testing.T) {
 		},
 	})
 	defer ts.Stopper().Stop(ctx)
-	sysDB := sqlutils.MakeSQLRunner(ts.SQLConn(t, ""))
+	sysDB := sqlutils.MakeSQLRunner(ts.SQLConn(t))
 
 	expectedInitialTenantVersion, _, _ := v0v1v2()
 	startAndConnectToTenant := func(t *testing.T, id uint64) (tenant serverutils.ApplicationLayerInterface, tenantDB *gosql.DB) {
@@ -318,7 +318,7 @@ func TestTenantUpgrade(t *testing.T) {
 		}
 		tenant, err := ts.TenantController().StartTenant(ctx, tenantArgs)
 		require.NoError(t, err)
-		return tenant, tenant.SQLConn(t, "")
+		return tenant, tenant.SQLConn(t)
 	}
 
 	t.Run("upgrade tenant", func(t *testing.T) {
@@ -357,7 +357,7 @@ func TestTenantUpgrade(t *testing.T) {
 			TenantID: roachpb.MustMakeTenantID(initialTenantID),
 		})
 		require.NoError(t, err)
-		conn = tenantServer.SQLConn(t, "")
+		conn = tenantServer.SQLConn(t)
 		db = sqlutils.MakeSQLRunner(conn)
 
 		t.Log("ensure that the version is still at v2")
@@ -381,7 +381,7 @@ func TestTenantUpgrade(t *testing.T) {
 			TenantID: roachpb.MustMakeTenantID(postUpgradeTenantID),
 		})
 		require.NoError(t, err)
-		conn = tenant.SQLConn(t, "")
+		conn = tenant.SQLConn(t)
 
 		t.Log("verify it still is at v2")
 		sqlutils.MakeSQLRunner(conn).CheckQueryResults(t,
@@ -443,7 +443,7 @@ func TestTenantUpgradeFailure(t *testing.T) {
 		},
 	})
 	defer ts.Stopper().Stop(ctx)
-	sysDB := sqlutils.MakeSQLRunner(ts.SQLConn(t, ""))
+	sysDB := sqlutils.MakeSQLRunner(ts.SQLConn(t))
 
 	// Channel for stopping a tenant.
 	tenantStopperChannel := make(chan struct{})
@@ -522,7 +522,7 @@ func TestTenantUpgradeFailure(t *testing.T) {
 		}
 		tenant, err := ts.TenantController().StartTenant(ctx, tenantArgs)
 		require.NoError(t, err)
-		tenantDB := tenant.SQLConn(t, "")
+		tenantDB := tenant.SQLConn(t)
 		return tenant, tenantDB
 	}
 

--- a/pkg/ccl/kvccl/kvtenantccl/upgradeinterlockccl/local_test_util_test.go
+++ b/pkg/ccl/kvccl/kvtenantccl/upgradeinterlockccl/local_test_util_test.go
@@ -170,7 +170,7 @@ func runTest(t *testing.T, variant sharedtestutil.TestVariant, test sharedtestut
 		}
 		tenant, err := tc.Server(0).TenantController().StartTenant(ctx, tenantArgs)
 		require.NoError(t, err)
-		return tenant.SQLConn(t, ""), func() { tenant.AppStopper().Stop(ctx) }
+		return tenant.SQLConn(t), func() { tenant.AppStopper().Stop(ctx) }
 	}
 
 	logf("creating an initial tenant server")
@@ -307,7 +307,7 @@ func runTest(t *testing.T, variant sharedtestutil.TestVariant, test sharedtestut
 		otherServerStopper.Stop(ctx)
 	} else if otherServerStartError == nil {
 		defer otherServer.AppStopper().Stop(ctx)
-		otherTenant := otherServer.SQLConn(t, "")
+		otherTenant := otherServer.SQLConn(t)
 		otherTenantRunner = sqlutils.MakeSQLRunner(otherTenant)
 		numTenantsStr = "2"
 	}

--- a/pkg/ccl/multitenantccl/tenantcapabilitiesccl/capabilities_test.go
+++ b/pkg/ccl/multitenantccl/tenantcapabilitiesccl/capabilities_test.go
@@ -91,7 +91,7 @@ func TestDataDriven(t *testing.T) {
 		testTenantInterface, err := tc.Server(0).TenantController().StartTenant(ctx, tenantArgs)
 		require.NoError(t, err)
 
-		tenantSQLDB := testTenantInterface.SQLConn(t, "")
+		tenantSQLDB := testTenantInterface.SQLConn(t)
 
 		lastUpdateTS := tc.Server(0).Clock().Now() // ensure watcher isn't starting out empty
 		datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {

--- a/pkg/ccl/serverccl/server_controller_test.go
+++ b/pkg/ccl/serverccl/server_controller_test.go
@@ -102,7 +102,7 @@ ALTER TENANT application START SERVICE SHARED`)
 				continue
 			}
 
-			db, err := tc.Server(i).SystemLayer().SQLConnE("cluster:application")
+			db, err := tc.Server(i).SystemLayer().SQLConnE(serverutils.DBName("cluster:application"))
 			if err != nil {
 				return err
 			}
@@ -166,7 +166,7 @@ func TestServerControllerHTTP(t *testing.T) {
 	t.Logf("connecting to the test tenant")
 
 	// Get a SQL connection to the test tenant.
-	db2, err := s.SystemLayer().SQLConnE("cluster:hello/defaultdb")
+	db2, err := s.SystemLayer().SQLConnE(serverutils.DBName("cluster:hello/defaultdb"))
 	// Expect no error yet: the connection is opened lazily; an
 	// error here means the parameters were incorrect.
 	require.NoError(t, err)
@@ -414,7 +414,7 @@ func TestServerControllerMultiNodeTenantStartup(t *testing.T) {
 	sqlAddr := tc.Server(serverIdx).AdvSQLAddr()
 	t.Logf("attempting to use tenant server on node %d (%s)", serverIdx, sqlAddr)
 	testutils.SucceedsSoon(t, func() error {
-		tenantDB, err := tc.Server(serverIdx).SystemLayer().SQLConnE("cluster:hello")
+		tenantDB, err := tc.Server(serverIdx).SystemLayer().SQLConnE(serverutils.DBName("cluster:hello"))
 		if err != nil {
 			t.Logf("error connecting to tenant server (will retry): %v", err)
 			return err
@@ -462,7 +462,7 @@ func TestServerStartStop(t *testing.T) {
 
 	// Check the liveness.
 	testutils.SucceedsSoon(t, func() error {
-		db2, err := s.SystemLayer().SQLConnE("cluster:hello/defaultdb")
+		db2, err := s.SystemLayer().SQLConnE(serverutils.DBName("cluster:hello/defaultdb"))
 		// Expect no error yet: the connection is opened lazily; an
 		// error here means the parameters were incorrect.
 		require.NoError(t, err)
@@ -486,7 +486,7 @@ func TestServerStartStop(t *testing.T) {
 
 	// Verify that the service is indeed stopped.
 	testutils.SucceedsSoon(t, func() error {
-		db2, err := s.SystemLayer().SQLConnE("cluster:hello/defaultdb")
+		db2, err := s.SystemLayer().SQLConnE(serverutils.DBName("cluster:hello/defaultdb"))
 		// Expect no error yet: the connection is opened lazily; an
 		// error here means the parameters were incorrect.
 		require.NoError(t, err)

--- a/pkg/ccl/serverccl/shared_process_tenant_test.go
+++ b/pkg/ccl/serverccl/shared_process_tenant_test.go
@@ -43,7 +43,7 @@ func TestSharedProcessTenantNoSpanLimit(t *testing.T) {
 	var tenantDB *gosql.DB
 	testutils.SucceedsSoon(t, func() error {
 		var err error
-		tenantDB, err = tc.Server(0).SystemLayer().SQLConnE("cluster:hello")
+		tenantDB, err = tc.Server(0).SystemLayer().SQLConnE(serverutils.DBName("cluster:hello"))
 		if err != nil {
 			return err
 		}

--- a/pkg/ccl/serverccl/statusccl/tenant_status_test.go
+++ b/pkg/ccl/serverccl/statusccl/tenant_status_test.go
@@ -447,7 +447,7 @@ func TestTenantCannotSeeNonTenantStats(t *testing.T) {
 		{stmt: `SELECT * FROM posts_nt`},
 	}
 
-	sqlDB = systemLayer.SQLConn(t, "")
+	sqlDB = systemLayer.SQLConn(t)
 
 	for _, stmt := range testCaseNonTenant {
 		_, err = sqlDB.Exec(stmt.stmt)

--- a/pkg/ccl/spanconfigccl/spanconfiglimiterccl/datadriven_test.go
+++ b/pkg/ccl/spanconfigccl/spanconfiglimiterccl/datadriven_test.go
@@ -81,7 +81,7 @@ func TestDataDriven(t *testing.T) {
 		})
 		defer tc.Stopper().Stop(ctx)
 		{
-			sysDB := sqlutils.MakeSQLRunner(tc.SystemLayer(0).SQLConn(t, ""))
+			sysDB := sqlutils.MakeSQLRunner(tc.SystemLayer(0).SQLConn(t))
 			sysDB.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.target_duration = '20ms'`)
 		}
 

--- a/pkg/ccl/spanconfigccl/spanconfiglimiterccl/drop_table_test.go
+++ b/pkg/ccl/spanconfigccl/spanconfiglimiterccl/drop_table_test.go
@@ -56,7 +56,7 @@ func TestDropTableLowersSpanCount(t *testing.T) {
 	zoneConfig.GC.TTLSeconds = 1
 	config.TestingSetupZoneConfigHook(tc.Stopper())
 
-	tenantSQLDB := tenant.SQLConn(t, "")
+	tenantSQLDB := tenant.SQLConn(t)
 	tenantDB := sqlutils.MakeSQLRunner(tenantSQLDB)
 
 	tenantDB.Exec(t, `CREATE TABLE t(k INT PRIMARY KEY)`)

--- a/pkg/ccl/spanconfigccl/spanconfigsqlwatcherccl/sqlwatcher_test.go
+++ b/pkg/ccl/spanconfigccl/spanconfigsqlwatcherccl/sqlwatcher_test.go
@@ -300,7 +300,7 @@ func TestSQLWatcherMultiple(t *testing.T) {
 	defer tc.Stopper().Stop(ctx)
 	ts := tc.Server(0 /* idx */)
 	tdb := sqlutils.MakeSQLRunner(tc.ServerConn(0 /* idx */))
-	sdb := sqlutils.MakeSQLRunner(tc.SystemLayer(0).SQLConn(t, ""))
+	sdb := sqlutils.MakeSQLRunner(tc.SystemLayer(0).SQLConn(t))
 	sdb.Exec(t, `SET CLUSTER SETTING kv.rangefeed.enabled = true`)
 	sdb.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.target_duration = '100ms'`)
 

--- a/pkg/ccl/streamingccl/replicationtestutils/testutils.go
+++ b/pkg/ccl/streamingccl/replicationtestutils/testutils.go
@@ -179,7 +179,7 @@ func (c *TenantStreamingClusters) StartDestTenant(
 		require.NoError(c.T, err)
 	} else {
 		c.DestSysSQL.Exec(c.T, `ALTER TENANT $1 START SERVICE SHARED`, c.Args.DestTenantName)
-		c.DestTenantConn = c.DestCluster.Server(0).SystemLayer().SQLConn(c.T, "cluster:"+string(c.Args.DestTenantName)+"/defaultdb")
+		c.DestTenantConn = c.DestCluster.Server(0).SystemLayer().SQLConn(c.T, serverutils.DBName("cluster:"+string(c.Args.DestTenantName)+"/defaultdb"))
 	}
 
 	c.DestTenantSQL = sqlutils.MakeSQLRunner(c.DestTenantConn)

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_job_test.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_job_test.go
@@ -122,7 +122,7 @@ func TestTenantStreamingFailback(t *testing.T) {
 	newTenantConn := func(t *testing.T, srv serverutils.ApplicationLayerInterface, tenantName string) *gosql.DB {
 		var conn *gosql.DB
 		testutils.SucceedsSoon(t, func() error {
-			db, err := srv.SQLConnE(fmt.Sprintf("cluster:%s", tenantName))
+			db, err := srv.SQLConnE(serverutils.DBName(fmt.Sprintf("cluster:%s", tenantName)))
 			if err != nil {
 				return err
 			}
@@ -739,7 +739,7 @@ func waitUntilTenantServerStopped(
 	// 	return nil
 	// })
 	testutils.SucceedsSoon(t, func() error {
-		db, err := srv.SQLConnE(fmt.Sprintf("cluster:%s", tenantName))
+		db, err := srv.SQLConnE(serverutils.DBName(fmt.Sprintf("cluster:%s", tenantName)))
 		if err != nil {
 			return err
 		}

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_manager_test.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_manager_test.go
@@ -88,7 +88,7 @@ func TestRevertTenantToTimestamp(t *testing.T) {
 	newConn := func(t *testing.T) *gosql.DB {
 		var conn *gosql.DB
 		testutils.SucceedsSoon(t, func() error {
-			db, err := srv.SystemLayer().SQLConnE("cluster:target")
+			db, err := srv.SystemLayer().SQLConnE(serverutils.DBName("cluster:target"))
 			if err != nil {
 				return err
 			}
@@ -236,7 +236,7 @@ func TestRevertTenantToTimestampPTS(t *testing.T) {
 	newConn := func(t *testing.T) *gosql.DB {
 		var conn *gosql.DB
 		testutils.SucceedsSoon(t, func() error {
-			db, err := srv.SystemLayer().SQLConnE("cluster:target")
+			db, err := srv.SystemLayer().SQLConnE(serverutils.DBName("cluster:target"))
 			if err != nil {
 				return err
 			}

--- a/pkg/ccl/testccl/sqlccl/session_revival_test.go
+++ b/pkg/ccl/testccl/sqlccl/session_revival_test.go
@@ -53,7 +53,7 @@ func TestAuthenticateWithSessionRevivalToken(t *testing.T) {
 
 	var token string
 	t.Run("generate token", func(t *testing.T) {
-		conn := tenant.SQLConnForUser(t, username.TestUser, "")
+		conn := tenant.SQLConn(t, serverutils.User(username.TestUser))
 		err := conn.QueryRowContext(ctx, "SELECT encode(crdb_internal.create_session_revival_token(), 'base64')").Scan(&token)
 		require.NoError(t, err)
 	})

--- a/pkg/ccl/testccl/sqlccl/show_transfer_state_test.go
+++ b/pkg/ccl/testccl/sqlccl/show_transfer_state_test.go
@@ -52,7 +52,7 @@ func TestShowTransferState(t *testing.T) {
 	_, err = tenantDB.Exec("GRANT SELECT ON tab TO testuser")
 	require.NoError(t, err)
 
-	testUserConn := tenant.SQLConnForUser(t, username.TestUser, "")
+	testUserConn := tenant.SQLConn(t, serverutils.User(username.TestUser))
 
 	t.Run("without_transfer_key", func(t *testing.T) {
 		conn := testUserConn

--- a/pkg/ccl/testccl/sqlstatsccl/sql_stats_test.go
+++ b/pkg/ccl/testccl/sqlstatsccl/sql_stats_test.go
@@ -173,7 +173,7 @@ func TestSQLStatsRegions(t *testing.T) {
 						require.NoError(t, err)
 						lhID, err := strconv.Atoi(row[1])
 						require.NoError(t, err)
-						systemSqlDb := host.SystemLayer(lhID-1).SQLConn(t, tc.dbName)
+						systemSqlDb := host.SystemLayer(lhID-1).SQLConn(t, serverutils.DBName(tc.dbName))
 						// ignore errors of enqueued splits to make sure it doesn't affect test execution.
 						_, _ = systemSqlDb.Exec(`SELECT crdb_internal.kv_enqueue_replica($1, 'split', true)`, rangeID)
 					}

--- a/pkg/cli/clisqlshell/describe_test.go
+++ b/pkg/cli/clisqlshell/describe_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/cli"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/datadriven"
 )
@@ -38,7 +39,7 @@ func TestDescribe(t *testing.T) {
 	c := cli.NewCLITest(cli.TestCLIParams{T: t})
 	defer c.Cleanup()
 
-	db := c.Server.SQLConn(t, "defaultdb")
+	db := c.Server.SQLConn(t, serverutils.DBName("defaultdb"))
 
 	var commonArgs []string
 

--- a/pkg/cmd/reduce/reduce/reducesql/reducesql_test.go
+++ b/pkg/cmd/reduce/reduce/reducesql/reducesql_test.go
@@ -47,7 +47,7 @@ func isInterestingSQL(t *testing.T, contains string) reduce.InterestingFn {
 		serv := serverutils.StartServerOnly(t, args)
 		defer serv.Stopper().Stop(ctx)
 
-		db := serv.ApplicationLayer().SQLConn(t, "")
+		db := serv.ApplicationLayer().SQLConn(t)
 
 		_, err := db.Exec(f)
 		if err == nil {

--- a/pkg/configprofiles/datadriven_test.go
+++ b/pkg/configprofiles/datadriven_test.go
@@ -72,7 +72,7 @@ func TestDataDriven(t *testing.T) {
 				// We need to force the connection to the system tenant,
 				// because at least one of the config profiles changes the
 				// default tenant.
-				sysTenantDB := s.SystemLayer().SQLConn(t, "defaultdb")
+				sysTenantDB := s.SystemLayer().SQLConn(t, serverutils.DBName("defaultdb"))
 				db = sqlutils.MakeSQLRunner(sysTenantDB)
 				res.WriteString("server started\n")
 
@@ -113,7 +113,7 @@ AND   status = 'succeeded'`).Scan(&numTasksCompleted)
 					t.Fatalf("%s: must use profile before sql", d.Pos)
 				}
 				testutils.SucceedsSoon(t, func() error {
-					goDB := s.SystemLayer().SQLConn(t, "cluster:"+d.Input+"/defaultdb")
+					goDB := s.SystemLayer().SQLConn(t, serverutils.DBName("cluster:"+d.Input+"/defaultdb"))
 					return goDB.Ping()
 				})
 				return "ok"

--- a/pkg/kv/kvserver/gc/gc_int_test.go
+++ b/pkg/kv/kvserver/gc/gc_int_test.go
@@ -103,7 +103,7 @@ func TestEndToEndGC(t *testing.T) {
 				defer s.Stopper().Stop(ctx)
 
 				statusServer := s.SystemLayer().StatusServer().(serverpb.StatusServer)
-				systemSqlDb := s.SystemLayer().SQLConn(t, "system")
+				systemSqlDb := s.SystemLayer().SQLConn(t, serverutils.DBName("system"))
 
 				execOrFatal := func(t *testing.T, db *gosql.DB, stmt string, args ...interface{}) {
 					t.Helper()

--- a/pkg/kv/kvserver/replica_rangefeed_test.go
+++ b/pkg/kv/kvserver/replica_rangefeed_test.go
@@ -518,7 +518,7 @@ func TestScheduledProcessorKillSwitch(t *testing.T) {
 	require.NoError(t, ts.Start(ctx), "start server")
 	defer ts.Stopper().Stop(ctx)
 
-	db := ts.SystemLayer().SQLConn(t, "")
+	db := ts.SystemLayer().SQLConn(t)
 	_, err = db.Exec("set cluster setting kv.rangefeed.enabled = t")
 	require.NoError(t, err, "can't enable rangefeeds")
 	_, err = db.Exec("set cluster setting kv.rangefeed.scheduler.enabled = t")

--- a/pkg/server/application_api/contention_test.go
+++ b/pkg/server/application_api/contention_test.go
@@ -49,8 +49,8 @@ func TestStatusAPIContentionEvents(t *testing.T) {
 	s0 := testCluster.Server(0).ApplicationLayer()
 	s1 := testCluster.Server(1).ApplicationLayer()
 	s2 := testCluster.Server(2).ApplicationLayer()
-	server1Conn := sqlutils.MakeSQLRunner(s0.SQLConn(t, ""))
-	server2Conn := sqlutils.MakeSQLRunner(s1.SQLConn(t, ""))
+	server1Conn := sqlutils.MakeSQLRunner(s0.SQLConn(t))
+	server2Conn := sqlutils.MakeSQLRunner(s1.SQLConn(t))
 
 	contentionCountBefore := s1.SQLServer().(*sql.Server).Metrics.EngineMetrics.SQLContendedTxns.Count()
 
@@ -157,7 +157,7 @@ func TestTransactionContentionEvents(t *testing.T) {
 		sqlutils.ToRowFn(sqlutils.RowIdxFn),
 	)
 
-	conn2 := s.SQLConn(t, "")
+	conn2 := s.SQLConn(t)
 	defer func() {
 		require.NoError(t, conn2.Close())
 	}()

--- a/pkg/server/application_api/metrics_test.go
+++ b/pkg/server/application_api/metrics_test.go
@@ -95,7 +95,7 @@ func TestStatusVarsTxnMetrics(t *testing.T) {
 	defer srv.Stopper().Stop(context.Background())
 
 	testFn := func(s serverutils.ApplicationLayerInterface, expectedLabel string) {
-		db := s.SQLConn(t, "")
+		db := s.SQLConn(t)
 
 		if _, err := db.Exec("BEGIN;" +
 			"SAVEPOINT cockroach_restart;" +

--- a/pkg/server/application_api/schema_inspection_test.go
+++ b/pkg/server/application_api/schema_inspection_test.go
@@ -294,7 +294,7 @@ func TestAdminAPITableDetails(t *testing.T) {
 				fmt.Sprintf("GRANT SELECT,UPDATE,DELETE ON %s.%s TO app", escDBName, tblName),
 				fmt.Sprintf("CREATE STATISTICS test_stats FROM %s.%s", escDBName, tblName),
 			}
-			db := ts.SQLConn(t, tc.dbName)
+			db := ts.SQLConn(t, serverutils.DBName(tc.dbName))
 			for _, q := range setupQueries {
 				t.Logf("executing: %v", q)
 				if _, err := db.Exec(q); err != nil {
@@ -428,7 +428,7 @@ func TestAdminAPIDatabaseDetails(t *testing.T) {
 	tc := testcluster.StartTestCluster(t, numServers, base.TestClusterArgs{})
 	defer tc.Stopper().Stop(context.Background())
 
-	db := tc.ApplicationLayer(0).SQLConn(t, "")
+	db := tc.ApplicationLayer(0).SQLConn(t)
 
 	_, err := db.Exec("CREATE DATABASE test")
 	require.NoError(t, err)
@@ -497,7 +497,7 @@ func TestAdminAPITableStats(t *testing.T) {
 	server0 := tc.Server(0).ApplicationLayer()
 
 	// Create clients (SQL, HTTP) connected to server 0.
-	db := server0.SQLConn(t, "")
+	db := server0.SQLConn(t)
 
 	client, err := server0.GetAdminHTTPClient()
 	if err != nil {

--- a/pkg/server/application_api/sessions_test.go
+++ b/pkg/server/application_api/sessions_test.go
@@ -243,7 +243,7 @@ func TestStatusCancelSessionGatewayMetadataPropagation(t *testing.T) {
 	s1 := testCluster.Server(1).ApplicationLayer()
 
 	// Start a SQL session as admin on node 1.
-	sql0 := sqlutils.MakeSQLRunner(s0.SQLConn(t, ""))
+	sql0 := sqlutils.MakeSQLRunner(s0.SQLConn(t))
 	results := sql0.QueryStr(t, "SELECT session_id FROM [SHOW SESSIONS] LIMIT 1")
 	sessionID, err := hex.DecodeString(results[0][0])
 	require.NoError(t, err)
@@ -267,7 +267,7 @@ func TestStatusAPIListSessions(t *testing.T) {
 	defer testCluster.Stopper().Stop(ctx)
 
 	s0 := testCluster.Server(0).ApplicationLayer()
-	serverSQL := sqlutils.MakeSQLRunner(s0.SQLConn(t, ""))
+	serverSQL := sqlutils.MakeSQLRunner(s0.SQLConn(t))
 
 	appName := "test_sessions_api"
 	serverSQL.Exec(t, fmt.Sprintf(`SET application_name = "%s"`, appName))

--- a/pkg/server/application_api/stats_test.go
+++ b/pkg/server/application_api/stats_test.go
@@ -311,7 +311,7 @@ func TestClusterResetSQLStats(t *testing.T) {
 			gateway := testCluster.Server(1 /* idx */).ApplicationLayer()
 			status := gateway.StatusServer().(serverpb.SQLStatusServer)
 
-			sqlDB := gateway.SQLConn(t, "")
+			sqlDB := gateway.SQLConn(t)
 
 			populateStats(t, sqlDB)
 			if flushed {

--- a/pkg/server/application_api/storage_inspection_test.go
+++ b/pkg/server/application_api/storage_inspection_test.go
@@ -211,7 +211,7 @@ func TestAdminAPIDataDistribution(t *testing.T) {
 	{
 		// TODO(irfansharif): The data-distribution page and underyling APIs don't
 		// know how to deal with coalesced ranges. See #97942.
-		sysDB := sqlutils.MakeSQLRunner(tc.Server(0).SystemLayer().SQLConn(t, ""))
+		sysDB := sqlutils.MakeSQLRunner(tc.Server(0).SystemLayer().SQLConn(t))
 		sysDB.Exec(t, `SET CLUSTER SETTING spanconfig.range_coalescing.system.enabled = false`)
 		sysDB.Exec(t, `SET CLUSTER SETTING spanconfig.range_coalescing.application.enabled = false`)
 		// Make sure extra secondary tenants don't cause the endpoint to error.

--- a/pkg/server/authserver/authentication_test.go
+++ b/pkg/server/authserver/authentication_test.go
@@ -101,7 +101,7 @@ func TestSSLEnforcement(t *testing.T) {
 
 	if srv.TenantController().StartedDefaultTestTenant() {
 		// Enable access to the nodes endpoint for the test tenant.
-		_, err := srv.SystemLayer().SQLConn(t, "").Exec(
+		_, err := srv.SystemLayer().SQLConn(t).Exec(
 			`ALTER TENANT [$1] GRANT CAPABILITY can_view_node_info=true`, serverutils.TestTenantID().ToUint64())
 		require.NoError(t, err)
 

--- a/pkg/server/index_usage_stats_test.go
+++ b/pkg/server/index_usage_stats_test.go
@@ -80,7 +80,7 @@ func TestStatusAPIIndexUsage(t *testing.T) {
 		LastRead:       timeutil.Now(),
 	}
 
-	firstServerSQLConn := firstServer.SQLConn(t, "")
+	firstServerSQLConn := firstServer.SQLConn(t)
 
 	// Create table on the first node.
 	_, err := firstServerSQLConn.Exec("CREATE TABLE t (k INT PRIMARY KEY, a INT, b INT, c INT, INDEX(a), INDEX(b))")
@@ -124,7 +124,7 @@ func TestStatusAPIIndexUsage(t *testing.T) {
 	secondServer := testCluster.Server(1 /* idx */)
 	secondLocalStatsReader := secondServer.SQLServer().(*sql.Server).GetLocalIndexStatistics()
 
-	secondServerSQLConn := secondServer.SQLConn(t, "")
+	secondServerSQLConn := secondServer.SQLConn(t)
 
 	// Records a non-full scan over t_a_idx.
 	_, err = secondServerSQLConn.Exec("SELECT k, a FROM t WHERE a = 0")
@@ -146,7 +146,7 @@ func TestStatusAPIIndexUsage(t *testing.T) {
 	fourthServer := testCluster.Server(3 /* idx */)
 	fourthLocalStatsReader := fourthServer.SQLServer().(*sql.Server).GetLocalIndexStatistics()
 
-	fourthServerSQLConn := fourthServer.SQLConn(t, "")
+	fourthServerSQLConn := fourthServer.SQLConn(t)
 
 	// Test that total_reads / last_read was not populated by an explicit CREATE INDEX query.
 	_, err = fourthServerSQLConn.Exec("CREATE TABLE test(num INT PRIMARY KEY, letter CHAR)")

--- a/pkg/server/job_profiler_test.go
+++ b/pkg/server/job_profiler_test.go
@@ -106,7 +106,7 @@ func TestJobExecutionDetailsRouting(t *testing.T) {
 	defer tc.Stopper().Stop(ctx)
 
 	s := tc.Server(1)
-	sqlDB := s.SQLConn(t, "n1")
+	sqlDB := s.SQLConn(t, serverutils.DBName("n1"))
 	defer sqlDB.Close()
 
 	_, err := sqlDB.Exec(`CREATE TABLE defaultdb.t (id INT)`)

--- a/pkg/server/server_controller_test.go
+++ b/pkg/server/server_controller_test.go
@@ -94,7 +94,7 @@ func TestServerControllerStopStart(t *testing.T) {
 	sqlRunner.Exec(t, "SET CLUSTER SETTING kv.rangefeed.closed_timestamp_refresh_interval ='100ms'")
 
 	tryConnect := func() error {
-		conn, err := s.SystemLayer().SQLConnE("cluster:hello")
+		conn, err := s.SystemLayer().SQLConnE(serverutils.DBName("cluster:hello"))
 		if err != nil {
 			return err
 		}
@@ -135,7 +135,7 @@ func TestSQLErrorUponInvalidTenant(t *testing.T) {
 	})
 	defer s.Stopper().Stop(ctx)
 
-	db, err := s.SystemLayer().SQLConnE("cluster:nonexistent")
+	db, err := s.SystemLayer().SQLConnE(serverutils.DBName("cluster:nonexistent"))
 	// Expect no error yet: the connection is opened lazily; an
 	// error here means the parameters were incorrect.
 	require.NoError(t, err)
@@ -218,7 +218,7 @@ func TestServerSQLConn(t *testing.T) {
 				Exec(ctx, "create-table", nil, "CREATE TABLE defaultdb."+tc.tbName+" (i INT)")
 			require.NoError(t, err)
 
-			conn := tc.sqlInterface.SQLConn(t, "defaultdb")
+			conn := tc.sqlInterface.SQLConn(t, serverutils.DBName("defaultdb"))
 			var unused int
 			assert.NoError(t, conn.QueryRowContext(ctx, "SELECT count(*) FROM "+tc.tbName).Scan(&unused))
 		})

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1013,7 +1013,7 @@ func TestSQLDecommissioned(t *testing.T) {
 		require.True(t, ok, "expected gRPC status error, got %T: %s", err, err)
 		require.Equal(t, codes.PermissionDenied, s.Code())
 
-		sqlClient := decomSrv.SQLConn(t, "")
+		sqlClient := decomSrv.SQLConn(t)
 
 		var result int
 		err = sqlClient.QueryRow("SELECT 1").Scan(&result)

--- a/pkg/server/settingswatcher/settings_watcher_external_test.go
+++ b/pkg/server/settingswatcher/settings_watcher_external_test.go
@@ -644,7 +644,7 @@ func TestNotifyCalledUponReadOnlySettingChanges(t *testing.T) {
 	})
 	defer s.Stopper().Stop(ctx)
 
-	sysDB := sqlutils.MakeSQLRunner(s.SystemLayer().SQLConn(t, ""))
+	sysDB := sqlutils.MakeSQLRunner(s.SystemLayer().SQLConn(t))
 
 	ts := s.ApplicationLayer()
 	st := ts.ClusterSettings()

--- a/pkg/server/span_stats_test.go
+++ b/pkg/server/span_stats_test.go
@@ -307,7 +307,7 @@ func TestSpanStatsFanOutFaultTolerance(t *testing.T) {
 			tc := testcluster.StartTestCluster(t, numNodes, base.TestClusterArgs{ServerArgs: serverArgs})
 			defer tc.Stopper().Stop(ctx)
 
-			sqlDB := tc.Server(0).SQLConn(t, "defaultdb")
+			sqlDB := tc.Server(0).SQLConn(t, serverutils.DBName("defaultdb"))
 			_, err := sqlDB.Exec("SET CLUSTER SETTING server.span_stats.node.timeout = '3s'")
 			require.NoError(t, err)
 

--- a/pkg/server/storage_api/health_test.go
+++ b/pkg/server/storage_api/health_test.go
@@ -114,7 +114,7 @@ func TestLivenessAPI(t *testing.T) {
 	// The liveness endpoint needs a special tenant capability.
 	if tc.Server(0).TenantController().StartedDefaultTestTenant() {
 		// Enable access to the nodes endpoint for the test tenant.
-		_, err := tc.SystemLayer(0).SQLConn(t, "").Exec(
+		_, err := tc.SystemLayer(0).SQLConn(t).Exec(
 			`ALTER TENANT [$1] GRANT CAPABILITY can_view_node_info=true`, serverutils.TestTenantID().ToUint64())
 		require.NoError(t, err)
 

--- a/pkg/server/storage_api/nodes_test.go
+++ b/pkg/server/storage_api/nodes_test.go
@@ -95,7 +95,7 @@ func TestNodeStatusResponse(t *testing.T) {
 
 	if srv.TenantController().StartedDefaultTestTenant() {
 		// Enable access to the nodes endpoint for the test tenant.
-		_, err := srv.SystemLayer().SQLConn(t, "").Exec(
+		_, err := srv.SystemLayer().SQLConn(t).Exec(
 			`ALTER TENANT [$1] GRANT CAPABILITY can_view_node_info=true`, serverutils.TestTenantID().ToUint64())
 		require.NoError(t, err)
 
@@ -212,7 +212,7 @@ func TestNodesGRPCResponse(t *testing.T) {
 
 	if srv.TenantController().StartedDefaultTestTenant() {
 		// Enable access to the nodes endpoint for the test tenant.
-		_, err := srv.SystemLayer().SQLConn(t, "").Exec(
+		_, err := srv.SystemLayer().SQLConn(t).Exec(
 			`ALTER TENANT [$1] GRANT CAPABILITY can_view_node_info=true`, serverutils.TestTenantID().ToUint64())
 		require.NoError(t, err)
 

--- a/pkg/server/testserver_sqlconn.go
+++ b/pkg/server/testserver_sqlconn.go
@@ -45,7 +45,8 @@ const useLoopbackListener = false
 // openTestSQLConn is a test helper that supports the SQLConn* methods
 // of serverutils.ApplicationLayerInterface.
 func openTestSQLConn(
-	userName, dbName string,
+	dbName string,
+	user *url.Userinfo,
 	tenantName roachpb.TenantName,
 	stopper *stop.Stopper,
 	// When useLoopbackListener is set, only this is used:
@@ -53,6 +54,7 @@ func openTestSQLConn(
 	// When useLoopbackListener is not set, this is used:
 	sqlAddr string,
 	insecure bool,
+	clientCerts bool,
 ) (*gosql.DB, error) {
 	cleanupFn := func() {}
 	var goDB *gosql.DB
@@ -68,7 +70,7 @@ func openTestSQLConn(
 	if useLoopbackListener {
 		pgurl := url.URL{
 			Scheme:   "postgres",
-			User:     url.User(userName),
+			User:     user,
 			Host:     "unused",
 			Path:     dbName,
 			RawQuery: opts.Encode(),
@@ -83,7 +85,7 @@ func openTestSQLConn(
 	} else /* useLoopbackListener == false */ {
 		var pgURL url.URL
 		var err error
-		pgURL, cleanupFn, err = sqlutils.PGUrlE(sqlAddr, "openTestSQLConn", url.User(userName))
+		pgURL, cleanupFn, err = sqlutils.PGUrlWithOptionalClientCertsE(sqlAddr, "openTestSQLConn", user, clientCerts)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/settings/integration_tests/propagation_test.go
+++ b/pkg/settings/integration_tests/propagation_test.go
@@ -88,7 +88,7 @@ func runSettingDefaultPropagationTest(
 	})
 	defer s.Stopper().Stop(ctx)
 
-	sysDB := sqlutils.MakeSQLRunner(s.SystemLayer().SQLConn(t, ""))
+	sysDB := sqlutils.MakeSQLRunner(s.SystemLayer().SQLConn(t))
 	sysDB.Exec(t, "SELECT crdb_internal.create_tenant($1, 'test')", serverutils.TestTenantID().ToUint64())
 	// Speed up the tests.
 	sysDB.Exec(t, "SET CLUSTER SETTING kv.closed_timestamp.target_duration = '10ms'")

--- a/pkg/spanconfig/spanconfigtestutils/spanconfigtestcluster/cluster.go
+++ b/pkg/spanconfig/spanconfigtestutils/spanconfigtestcluster/cluster.go
@@ -48,7 +48,7 @@ func NewHandle(
 		tc:      tc,
 		ts:      make(map[roachpb.TenantID]*Tenant),
 		scKnobs: scKnobs,
-		sysDB:   sqlutils.MakeSQLRunner(tc.Server(0).SystemLayer().SQLConn(t, "")),
+		sysDB:   sqlutils.MakeSQLRunner(tc.Server(0).SystemLayer().SQLConn(t)),
 	}
 }
 
@@ -79,7 +79,7 @@ func (h *Handle) InitializeTenant(ctx context.Context, tenID roachpb.TenantID) *
 		tenantState.ApplicationLayerInterface, err = testServer.TenantController().StartTenant(ctx, tenantArgs)
 		require.NoError(h.t, err)
 
-		tenantSQLDB := tenantState.SQLConn(h.t, "")
+		tenantSQLDB := tenantState.SQLConn(h.t)
 
 		tenantState.db = sqlutils.MakeSQLRunner(tenantSQLDB)
 		tenantState.cleanup = func() {}

--- a/pkg/sql/admin_audit_log_test.go
+++ b/pkg/sql/admin_audit_log_test.go
@@ -104,7 +104,7 @@ func TestAdminAuditLogRegularUser(t *testing.T) {
 
 	db.Exec(t, `CREATE USER testuser`)
 
-	testuser := s.ApplicationLayer().SQLConnForUser(t, "testuser", "")
+	testuser := s.ApplicationLayer().SQLConn(t, serverutils.User("testuser"))
 
 	if _, err := testuser.Exec(`SELECT 1`); err != nil {
 		t.Fatal(err)
@@ -221,7 +221,7 @@ func TestAdminAuditLogMultipleTransactions(t *testing.T) {
 
 	db.Exec(t, `CREATE USER testuser`)
 
-	testuser := s.ApplicationLayer().SQLConnForUser(t, "testuser", "")
+	testuser := s.ApplicationLayer().SQLConn(t, serverutils.User("testuser"))
 
 	db.Exec(t, `GRANT admin TO testuser`)
 

--- a/pkg/sql/backfill_protected_timestamp_test.go
+++ b/pkg/sql/backfill_protected_timestamp_test.go
@@ -75,7 +75,7 @@ func TestValidationWithProtectedTS(t *testing.T) {
 	protectedts.PollInterval.Override(ctx, &tenantSettings.SV, time.Millisecond)
 	r := sqlutils.MakeSQLRunner(db)
 
-	systemSqlDb := s.SystemLayer().SQLConn(t, "system")
+	systemSqlDb := s.SystemLayer().SQLConn(t, serverutils.DBName("system"))
 	rSys := sqlutils.MakeSQLRunner(systemSqlDb)
 
 	// Refreshes the in-memory protected timestamp state to asOf.

--- a/pkg/sql/builtin_mem_usage_test.go
+++ b/pkg/sql/builtin_mem_usage_test.go
@@ -95,7 +95,7 @@ CREATE TABLE d.t (a STRING)
 	for _, statement := range statements {
 		errCh := make(chan error)
 		go func(statement string) {
-			dbConn, err := s.ApplicationLayer().SQLConnE("")
+			dbConn, err := s.ApplicationLayer().SQLConnE()
 			if err != nil {
 				errCh <- err
 				return

--- a/pkg/sql/catalog/internal/catkv/catalog_reader_test.go
+++ b/pkg/sql/catalog/internal/catkv/catalog_reader_test.go
@@ -71,7 +71,7 @@ func TestDataDriven(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			s := tc.layer
 
-			sqlDB := s.SQLConn(t, "")
+			sqlDB := s.SQLConn(t)
 			tdb := sqlutils.MakeSQLRunner(sqlDB)
 			execCfg := s.ExecutorConfig().(sql.ExecutorConfig)
 			v := execCfg.Settings.Version.ActiveVersion(ctx)

--- a/pkg/sql/catalog/lease/kv_writer_test.go
+++ b/pkg/sql/catalog/lease/kv_writer_test.go
@@ -62,7 +62,7 @@ func TestKVWriterMatchesIEWriter(t *testing.T) {
 	s := srv.ApplicationLayer()
 
 	// Otherwise, we wouldn't get complete SSTs in our export under stress.
-	sqlutils.MakeSQLRunner(srv.SystemLayer().SQLConn(t, "")).Exec(
+	sqlutils.MakeSQLRunner(srv.SystemLayer().SQLConn(t)).Exec(
 		t, "SET CLUSTER SETTING admission.elastic_cpu.enabled = false",
 	)
 

--- a/pkg/sql/colflow/draining_test.go
+++ b/pkg/sql/colflow/draining_test.go
@@ -65,7 +65,7 @@ func TestDrainingAfterRemoteError(t *testing.T) {
 	defer tc.Stopper().Stop(ctx)
 
 	if srv := tc.Server(0); srv.TenantController().StartedDefaultTestTenant() {
-		systemSqlDB := srv.SystemLayer().SQLConn(t, "system")
+		systemSqlDB := srv.SystemLayer().SQLConn(t, serverutils.DBName("system"))
 		_, err := systemSqlDB.Exec(`ALTER TENANT [$1] GRANT CAPABILITY can_admin_relocate_range=true`, serverutils.TestTenantID().ToUint64())
 		require.NoError(t, err)
 		serverutils.WaitForTenantCapabilities(t, srv, serverutils.TestTenantID(), map[tenantcapabilities.ID]string{

--- a/pkg/sql/conn_executor_savepoints_test.go
+++ b/pkg/sql/conn_executor_savepoints_test.go
@@ -64,7 +64,7 @@ func TestSavepoints(t *testing.T) {
 					var ok bool
 					sqlConn, ok = sqlConns[connName]
 					if !ok {
-						sqlConn = s.ApplicationLayer().SQLConn(t, params.UseDatabase)
+						sqlConn = s.ApplicationLayer().SQLConn(t, serverutils.DBName(params.UseDatabase))
 						sqlConns[connName] = sqlConn
 					}
 				}

--- a/pkg/sql/conn_executor_test.go
+++ b/pkg/sql/conn_executor_test.go
@@ -1274,7 +1274,7 @@ CREATE TABLE t1.test (k INT PRIMARY KEY, v TEXT);
 		// the session expiry should be ignored.
 		// Open a DB connection on the server and not the tenant to test that the session
 		// expiry is ignored outside of the multi-tenant environment.
-		dbConn := s.SystemLayer().SQLConn(t, "")
+		dbConn := s.SystemLayer().SQLConn(t)
 		defer dbConn.Close()
 		// Set up a dummy database and table to write into for the test.
 		if _, err := dbConn.Exec(`CREATE DATABASE t1;
@@ -1644,7 +1644,7 @@ func TestTrackOnlyUserOpenTransactionsAndActiveStatements(t *testing.T) {
 	params := base.TestServerArgs{}
 	s, sqlDB, _ := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(ctx)
-	dbConn := s.ApplicationLayer().SQLConn(t, "")
+	dbConn := s.ApplicationLayer().SQLConn(t)
 	defer dbConn.Close()
 
 	waitChannel := make(chan struct{})
@@ -1827,7 +1827,7 @@ func TestSessionTotalActiveTime(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	rawSQL := s.SQLConnForUser(t, username.TestUser, "")
+	rawSQL := s.SQLConn(t, serverutils.User(username.TestUser))
 
 	getSessionWithTestUser := func() *serverpb.Session {
 		sessions := s.SQLServer().(*sql.Server).GetExecutorConfig().SessionRegistry.SerializeAll()

--- a/pkg/sql/copy_test.go
+++ b/pkg/sql/copy_test.go
@@ -69,7 +69,7 @@ func TestCopyLogging(t *testing.T) {
 
 			// We have to start a new connection every time to exercise all possible paths.
 			t.Run("success during COPY FROM", func(t *testing.T) {
-				db := s.SQLConn(t, "")
+				db := s.SQLConn(t)
 				txn, err := db.Begin()
 				require.NoError(t, err)
 				{
@@ -101,7 +101,7 @@ func TestCopyLogging(t *testing.T) {
 			})
 
 			t.Run("error in statement", func(t *testing.T) {
-				db := s.SQLConn(t, "")
+				db := s.SQLConn(t)
 				txn, err := db.Begin()
 				require.NoError(t, err)
 				{
@@ -113,7 +113,7 @@ func TestCopyLogging(t *testing.T) {
 			})
 
 			t.Run("error during COPY FROM", func(t *testing.T) {
-				db := s.SQLConn(t, "")
+				db := s.SQLConn(t)
 				txn, err := db.Begin()
 				require.NoError(t, err)
 				{
@@ -129,7 +129,7 @@ func TestCopyLogging(t *testing.T) {
 			})
 
 			t.Run("error in statement during COPY FROM", func(t *testing.T) {
-				db := s.SQLConn(t, "")
+				db := s.SQLConn(t)
 				txn, err := db.Begin()
 				require.NoError(t, err)
 				{
@@ -141,7 +141,7 @@ func TestCopyLogging(t *testing.T) {
 			})
 
 			t.Run("error during insert phase of COPY FROM", func(t *testing.T) {
-				db := s.SQLConn(t, "")
+				db := s.SQLConn(t)
 				txn, err := db.Begin()
 				require.NoError(t, err)
 				{
@@ -170,7 +170,7 @@ func TestCopyLogging(t *testing.T) {
 			})
 
 			t.Run("error during copy during COPY FROM", func(t *testing.T) {
-				db := s.SQLConn(t, "")
+				db := s.SQLConn(t)
 				txn, err := db.Begin()
 				require.NoError(t, err)
 				{

--- a/pkg/sql/crdb_internal_test.go
+++ b/pkg/sql/crdb_internal_test.go
@@ -1292,7 +1292,7 @@ func TestExecutionInsights(t *testing.T) {
 				}()
 
 				// Connect to the cluster as the test user.
-				tdb := s.SQLConnForUser(t, "testuser", "")
+				tdb := s.SQLConn(t, serverutils.User("testuser"))
 
 				// Try to read the virtual table, and see that we can or cannot as expected.
 				rows, err := tdb.Query(fmt.Sprintf("SELECT count(*) FROM crdb_internal.%s", table))

--- a/pkg/sql/create_stats_test.go
+++ b/pkg/sql/create_stats_test.go
@@ -73,7 +73,7 @@ SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false;
 		defer wg.Done()
 
 		// Open a separate connection to the database.
-		db2 := s.SQLConn(t, "")
+		db2 := s.SQLConn(t)
 
 		_, err := db2.Exec("USE test")
 		if err != nil {

--- a/pkg/sql/distsql_physical_planner_test.go
+++ b/pkg/sql/distsql_physical_planner_test.go
@@ -77,7 +77,7 @@ func TestPlanningDuringSplitsAndMerges(t *testing.T) {
 	s := tc.Server(0)
 	ts := s.ApplicationLayer()
 	cdb := ts.DB()
-	db := ts.SQLConn(t, "test")
+	db := ts.SQLConn(t, serverutils.DBName("test"))
 
 	sqlutils.CreateTable(
 		t, db, "t", "x INT PRIMARY KEY, xsquared INT",
@@ -144,7 +144,7 @@ func TestPlanningDuringSplitsAndMerges(t *testing.T) {
 			defer wg.Done()
 
 			// Create a gosql.DB for this worker.
-			goDB := ts.SQLConn(t, "test")
+			goDB := ts.SQLConn(t, serverutils.DBName("test"))
 
 			// Limit to 1 connection because we set a session variable.
 			goDB.SetMaxOpenConns(1)

--- a/pkg/sql/execstats/traceanalyzer_test.go
+++ b/pkg/sql/execstats/traceanalyzer_test.go
@@ -84,14 +84,14 @@ func TestTraceAnalyzer(t *testing.T) {
 	const gatewayNode = 0
 	srv, s := tc.Server(gatewayNode), tc.ApplicationLayer(gatewayNode)
 	if srv.TenantController().StartedDefaultTestTenant() {
-		systemSqlDB := srv.SystemLayer().SQLConn(t, "system")
+		systemSqlDB := srv.SystemLayer().SQLConn(t, serverutils.DBName("system"))
 		_, err := systemSqlDB.Exec(`ALTER TENANT [$1] GRANT CAPABILITY can_admin_relocate_range=true`, serverutils.TestTenantID().ToUint64())
 		require.NoError(t, err)
 		serverutils.WaitForTenantCapabilities(t, srv, serverutils.TestTenantID(), map[tenantcapabilities.ID]string{
 			tenantcapabilities.CanAdminRelocateRange: "true",
 		}, "")
 	}
-	db := s.SQLConn(t, "")
+	db := s.SQLConn(t)
 	sqlDB := sqlutils.MakeSQLRunner(db)
 
 	sqlutils.CreateTable(

--- a/pkg/sql/flowinfra/cluster_test.go
+++ b/pkg/sql/flowinfra/cluster_test.go
@@ -270,7 +270,7 @@ func TestClusterFlow(t *testing.T) {
 	for i := 0; i < numNodes; i++ {
 		s := tc.Server(i).ApplicationLayer()
 		servers[i] = s
-		conns[i] = s.SQLConn(t, "")
+		conns[i] = s.SQLConn(t)
 		conn := s.RPCClientConn(t, username.RootUserName())
 		clients[i] = execinfrapb.NewDistSQLClient(conn)
 	}
@@ -597,7 +597,7 @@ func TestEvalCtxTxnOnRemoteNodes(t *testing.T) {
 	defer tc.Stopper().Stop(ctx)
 
 	if srv := tc.Server(0); srv.TenantController().StartedDefaultTestTenant() {
-		systemSqlDB := srv.SystemLayer().SQLConn(t, "system")
+		systemSqlDB := srv.SystemLayer().SQLConn(t, serverutils.DBName("system"))
 		_, err := systemSqlDB.Exec(`ALTER TENANT [$1] GRANT CAPABILITY can_admin_relocate_range=true`, serverutils.TestTenantID().ToUint64())
 		require.NoError(t, err)
 		serverutils.WaitForTenantCapabilities(t, srv, serverutils.TestTenantID(), map[tenantcapabilities.ID]string{

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -1569,7 +1569,7 @@ func (t *logicTest) newCluster(
 
 		// Open a connection to a tenant to set any cluster settings specified
 		// by the test config.
-		db := t.tenantApps[0].SQLConn(t.rootT, "")
+		db := t.tenantApps[0].SQLConn(t.rootT)
 		connsForClusterSettingChanges = append(connsForClusterSettingChanges, db)
 
 		// Increase tenant rate limits for faster tests.
@@ -1591,7 +1591,7 @@ func (t *logicTest) newCluster(
 	// behavior.
 	if cfg.UseSecondaryTenant == logictestbase.Always || t.cluster.StartedDefaultTestTenant() {
 		tenantID := serverutils.TestTenantID()
-		conn := t.cluster.SystemLayer(0).SQLConn(t.rootT, "")
+		conn := t.cluster.SystemLayer(0).SQLConn(t.rootT)
 
 		clusterSettings := toa.clusterSettings
 		if len(clusterSettings) > 0 {
@@ -1793,7 +1793,7 @@ func (t *logicTest) waitForSystemVisibleClusterSettingToTakeEffectOrFatal(
 	// Wait until all tenant servers are aware of the setting override.
 	dbs := make([]*gosql.DB, len(t.tenantApps))
 	for i := range dbs {
-		dbs[i] = t.tenantApps[i].SQLConn(t.rootT, "")
+		dbs[i] = t.tenantApps[i].SQLConn(t.rootT)
 	}
 	testutils.SucceedsSoon(t.rootT, func() error {
 		for i := 0; i < len(t.tenantApps); i++ {

--- a/pkg/sql/logictest/parallel_test.go
+++ b/pkg/sql/logictest/parallel_test.go
@@ -88,7 +88,7 @@ func (t *parallelTest) processTestFile(path string, nodeIdx int, db *gosql.DB, c
 
 func (t *parallelTest) getClient(nodeIdx, clientIdx int) *gosql.DB {
 	for len(t.clients[nodeIdx]) <= clientIdx {
-		db := t.cluster.ApplicationLayer(nodeIdx).SQLConn(t, "")
+		db := t.cluster.ApplicationLayer(nodeIdx).SQLConn(t)
 		sqlutils.MakeSQLRunner(db).Exec(t, "SET DATABASE = test")
 		t.clients[nodeIdx] = append(t.clients[nodeIdx], db)
 	}
@@ -186,7 +186,7 @@ func (t *parallelTest) setup(ctx context.Context, spec *parTestSpec) {
 
 	t.clients = make([][]*gosql.DB, spec.ClusterSize)
 	for i := range t.clients {
-		t.clients[i] = append(t.clients[i], t.cluster.ApplicationLayer(i).SQLConn(t, ""))
+		t.clients[i] = append(t.clients[i], t.cluster.ApplicationLayer(i).SQLConn(t))
 	}
 	r0 := sqlutils.MakeSQLRunner(t.clients[0][0])
 
@@ -208,7 +208,7 @@ func (t *parallelTest) setup(ctx context.Context, spec *parTestSpec) {
 	// Disable the circuit breakers on this cluster because they can lead to
 	// rare test flakes since the machine is likely to be overloaded when
 	// running TestParallel.
-	sqlutils.MakeSQLRunner(t.cluster.Server(0).SystemLayer().SQLConn(t, "")).Exec(
+	sqlutils.MakeSQLRunner(t.cluster.Server(0).SystemLayer().SQLConn(t)).Exec(
 		t, `SET CLUSTER SETTING kv.replica_circuit_breaker.slow_replication_threshold = '0s'`,
 	)
 

--- a/pkg/sql/multitenant_admin_function_test.go
+++ b/pkg/sql/multitenant_admin_function_test.go
@@ -252,7 +252,7 @@ func (tc testCase) runTest(
 
 	testServer := testCluster.Server(0)
 
-	systemDB := testServer.SystemLayer().SQLConn(t, "")
+	systemDB := testServer.SystemLayer().SQLConn(t)
 
 	createSecondaryDB := func(
 		tenantID roachpb.TenantID,

--- a/pkg/sql/opt/exec/explain/output_test.go
+++ b/pkg/sql/opt/exec/explain/output_test.go
@@ -186,7 +186,7 @@ func TestCPUTimeEndToEnd(t *testing.T) {
 	defer tc.Stopper().Stop(ctx)
 
 	if srv := tc.Server(0); srv.TenantController().StartedDefaultTestTenant() {
-		systemSqlDB := srv.SystemLayer().SQLConn(t, "system")
+		systemSqlDB := srv.SystemLayer().SQLConn(t, serverutils.DBName("system"))
 		_, err := systemSqlDB.Exec(`ALTER TENANT [$1] GRANT CAPABILITY can_admin_relocate_range=true`, serverutils.TestTenantID().ToUint64())
 		require.NoError(t, err)
 		serverutils.WaitForTenantCapabilities(t, srv, serverutils.TestTenantID(), map[tenantcapabilities.ID]string{

--- a/pkg/sql/pgwire/conn_test.go
+++ b/pkg/sql/pgwire/conn_test.go
@@ -1755,7 +1755,7 @@ func TestSetSessionArguments(t *testing.T) {
 	defer srv.Stopper().Stop(ctx)
 	s := srv.ApplicationLayer()
 
-	_, err := s.SQLConn(t, "defaultdb").Exec(`SET CLUSTER SETTING sql.txn.read_committed_syntax.enabled = true`)
+	_, err := s.SQLConn(t, serverutils.DBName("defaultdb")).Exec(`SET CLUSTER SETTING sql.txn.read_committed_syntax.enabled = true`)
 	require.NoError(t, err)
 
 	pgURL, cleanupFunc := sqlutils.PGUrl(

--- a/pkg/sql/pgwire/pgwire_test.go
+++ b/pkg/sql/pgwire/pgwire_test.go
@@ -1305,7 +1305,7 @@ func TestPGPrepareNameQual(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	db2 := s.ApplicationLayer().SQLConn(t, "testing")
+	db2 := s.ApplicationLayer().SQLConn(t, serverutils.DBName("testing"))
 
 	statements := []string{
 		`CREATE TABLE IF NOT EXISTS f (v INT)`,

--- a/pkg/sql/physicalplan/fake_span_resolver_test.go
+++ b/pkg/sql/physicalplan/fake_span_resolver_test.go
@@ -39,7 +39,7 @@ func TestFakeSpanResolver(t *testing.T) {
 	ts := tc.ApplicationLayer(0)
 
 	sqlutils.CreateTable(
-		t, ts.SQLConn(t, ""), "t",
+		t, ts.SQLConn(t), "t",
 		"k INT PRIMARY KEY, v INT",
 		100,
 		func(row int) []tree.Datum {

--- a/pkg/sql/physicalplan/span_resolver_test.go
+++ b/pkg/sql/physicalplan/span_resolver_test.go
@@ -51,7 +51,7 @@ func TestSpanResolverUsesCaches(t *testing.T) {
 	defer tc.Stopper().Stop(ctx)
 
 	rowRanges, _ := setupRanges(
-		tc.ApplicationLayer(0).SQLConn(t, "t"),
+		tc.ApplicationLayer(0).SQLConn(t, serverutils.DBName("t")),
 		tc.ApplicationLayer(0),
 		tc.StorageLayer(0),
 		t)
@@ -139,7 +139,7 @@ func TestSpanResolverUsesCaches(t *testing.T) {
 	// with the default test tenant (#108763).
 	numExpectedRows := len(rowRanges)
 	var numRows int
-	err = s3.SQLConn(t, "t").QueryRow(`SELECT count(1) FROM test`).Scan(&numRows)
+	err = s3.SQLConn(t, serverutils.DBName("t")).QueryRow(`SELECT count(1) FROM test`).Scan(&numRows)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/run_control_test.go
+++ b/pkg/sql/run_control_test.go
@@ -934,7 +934,7 @@ func TestTenantStatementTimeoutAdmissionQueueCancellation(t *testing.T) {
 	require.Equal(t, tableID, int(id))
 
 	makeTenantConn := func() *sqlutils.SQLRunner {
-		return sqlutils.MakeSQLRunner(tt.SQLConn(t, ""))
+		return sqlutils.MakeSQLRunner(tt.SQLConn(t))
 	}
 
 	blockers := make([]*sqlutils.SQLRunner, numBlockers)

--- a/pkg/sql/sessionprotectedts/session_protected_ts_test.go
+++ b/pkg/sql/sessionprotectedts/session_protected_ts_test.go
@@ -46,7 +46,7 @@ func createSessionAndProtect(
 	t.Helper()
 
 	// Start the first SQL session that will lay down a PTS record.
-	targetDB := s0.SQLConn(t, "defaultdb")
+	targetDB := s0.SQLConn(t, serverutils.DBName("defaultdb"))
 	targetRunner := sqlutils.MakeSQLRunner(targetDB)
 	targetRunner.Exec(t, `SELECT 1`)
 
@@ -70,7 +70,7 @@ func TestSessionProtectedTimestampReconciler(t *testing.T) {
 	defer testCluster.Stopper().Stop(ctx)
 	s0 := testCluster.Server(0).ApplicationLayer()
 
-	sqlDB := sqlutils.MakeSQLRunner(s0.SQLConn(t, "defaultdb"))
+	sqlDB := sqlutils.MakeSQLRunner(s0.SQLConn(t, serverutils.DBName("defaultdb")))
 
 	insqlDB := s0.InternalDB().(isql.DB)
 	ptp := s0.ExecutorConfig().(sql.ExecutorConfig).ProtectedTimestampProvider

--- a/pkg/sql/sqlstats/insights/integration/insights_test.go
+++ b/pkg/sql/sqlstats/insights/integration/insights_test.go
@@ -216,7 +216,7 @@ func TestFailedInsights(t *testing.T) {
 	args := base.TestClusterArgs{ServerArgs: base.TestServerArgs{Settings: settings}}
 	tc := testcluster.StartTestCluster(t, 1, args)
 	defer tc.Stopper().Stop(ctx)
-	rootConn := sqlutils.MakeSQLRunner(tc.ApplicationLayer(0).SQLConn(t, ""))
+	rootConn := sqlutils.MakeSQLRunner(tc.ApplicationLayer(0).SQLConn(t))
 
 	// Enable detection by setting a latencyThreshold > 0.
 	latencyThreshold := 100 * time.Millisecond
@@ -227,9 +227,9 @@ func TestFailedInsights(t *testing.T) {
 
 	testutils.RunTrueAndFalse(t, "with_redaction", func(t *testing.T, testRedacted bool) {
 		rootConn.Exec(t, `select crdb_internal.reset_sql_stats()`)
-		conn := tc.ApplicationLayer(0).SQLConn(t, "")
+		conn := tc.ApplicationLayer(0).SQLConn(t)
 		if testRedacted {
-			conn = tc.ApplicationLayer(0).SQLConnForUser(t, "testuser", "")
+			conn = tc.ApplicationLayer(0).SQLConn(t, serverutils.User("testuser"))
 		}
 
 		_, err := conn.Exec("SET SESSION application_name=$1", appName)
@@ -442,8 +442,8 @@ func TestTransactionInsightsFailOnCommit(t *testing.T) {
 
 	connDefault := sqlutils.MakeSQLRunner(db)
 	// Connections specifically to run our conflicting txns.
-	conn1 := sqlutils.MakeSQLRunner(srv.ApplicationLayer().SQLConn(t, ""))
-	conn2 := sqlutils.MakeSQLRunner(srv.ApplicationLayer().SQLConn(t, ""))
+	conn1 := sqlutils.MakeSQLRunner(srv.ApplicationLayer().SQLConn(t))
+	conn2 := sqlutils.MakeSQLRunner(srv.ApplicationLayer().SQLConn(t))
 
 	connDefault.Exec(t, "SET CLUSTER SETTING sql.contention.event_store.resolution_interval = '100ms'")
 

--- a/pkg/sql/sqlstats/persistedsqlstats/controller_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/controller_test.go
@@ -41,8 +41,8 @@ func TestPersistedSQLStatsReset(t *testing.T) {
 
 	// Open two connections so that we can run statements without messing up
 	// the SQL stats.
-	testConn := server.SQLConn(t, "")
-	observerConn := cluster.Server(1).ApplicationLayer().SQLConn(t, "")
+	testConn := server.SQLConn(t)
+	observerConn := cluster.Server(1).ApplicationLayer().SQLConn(t)
 
 	sqlDB := sqlutils.MakeSQLRunner(testConn)
 	observer := sqlutils.MakeSQLRunner(observerConn)

--- a/pkg/sql/sqlstats/persistedsqlstats/flush_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/flush_test.go
@@ -91,10 +91,10 @@ func TestSQLStatsFlush(t *testing.T) {
 	firstServer := testCluster.Server(0 /* idx */).ApplicationLayer()
 	secondServer := testCluster.Server(1 /* idx */).ApplicationLayer()
 
-	pgFirstSQLConn := firstServer.SQLConn(t, "")
+	pgFirstSQLConn := firstServer.SQLConn(t)
 	firstSQLConn := sqlutils.MakeSQLRunner(pgFirstSQLConn)
 
-	pgSecondSQLConn := secondServer.SQLConn(t, "")
+	pgSecondSQLConn := secondServer.SQLConn(t)
 	secondSQLConn := sqlutils.MakeSQLRunner(pgSecondSQLConn)
 
 	firstServerSQLStats := firstServer.SQLServer().(*sql.Server).GetSQLStatsProvider().(*persistedsqlstats.PersistedSQLStats)
@@ -394,7 +394,7 @@ func TestInMemoryStatsDiscard(t *testing.T) {
 	defer srv.Stopper().Stop(ctx)
 	s := srv.ApplicationLayer()
 
-	observer := s.SQLConn(t, "")
+	observer := s.SQLConn(t)
 
 	sqlConn := sqlutils.MakeSQLRunner(conn)
 	sqlConn.Exec(t,

--- a/pkg/sql/sqlstats/persistedsqlstats/reader_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/reader_test.go
@@ -142,7 +142,7 @@ func insertData(
 	t *testing.T, testCluster serverutils.TestClusterInterface,
 ) (*sqlutils.SQLRunner, *persistedsqlstats.PersistedSQLStats, map[string]int64) {
 	server1 := testCluster.Server(0 /* idx */)
-	sqlConn := sqlutils.MakeSQLRunner(server1.SQLConn(t, ""))
+	sqlConn := sqlutils.MakeSQLRunner(server1.SQLConn(t))
 	sqlStats := server1.SQLServer().(*sql.Server).GetSQLStatsProvider().(*persistedsqlstats.PersistedSQLStats)
 
 	sqlConn.Exec(t, `SET application_name = 'TestPersistedSQLStatsRead'`)

--- a/pkg/sql/sqlstats/sslocal/sql_stats_test.go
+++ b/pkg/sql/sqlstats/sslocal/sql_stats_test.go
@@ -317,7 +317,7 @@ func TestNodeLocalInMemoryViewDoesNotReturnPersistedStats(t *testing.T) {
 
 	// Open two connections so that we can run statements without messing up
 	// the SQL stats.
-	testConn := server.SQLConn(t, "")
+	testConn := server.SQLConn(t)
 	sqlDB := sqlutils.MakeSQLRunner(testConn)
 	sqlDB.Exec(t, "SET application_name = 'app1'")
 	sqlDB.Exec(t, "SELECT 1 WHERE true")
@@ -1275,7 +1275,7 @@ func TestSQLStatsIdleLatencies(t *testing.T) {
 			// Note that we're not using pgx here because it *always* prepares
 			// statements, and we want to test our client latency measurements
 			// both with and without prepared statements.
-			opsDB := s.SQLConn(t, "")
+			opsDB := s.SQLConn(t)
 
 			// Set a unique application name for our session, so we can find our
 			// stats easily.

--- a/pkg/sql/stats/create_stats_job_test.go
+++ b/pkg/sql/stats/create_stats_job_test.go
@@ -70,7 +70,7 @@ func TestCreateStatsControlJob(t *testing.T) {
 	ctx := context.Background()
 	tc := testcluster.StartTestCluster(t, nodes, params)
 	defer tc.Stopper().Stop(ctx)
-	sqlDB := sqlutils.MakeSQLRunner(tc.ApplicationLayer(0).SQLConn(t, ""))
+	sqlDB := sqlutils.MakeSQLRunner(tc.ApplicationLayer(0).SQLConn(t))
 	sqlDB.Exec(t, `CREATE DATABASE d`)
 	sqlDB.Exec(t, `CREATE TABLE d.t (x INT PRIMARY KEY)`)
 	var tID descpb.ID
@@ -205,7 +205,7 @@ func TestAtMostOneRunningCreateStats(t *testing.T) {
 	const nodes = 1
 	tc := testcluster.StartTestCluster(t, nodes, params)
 	defer tc.Stopper().Stop(ctx)
-	conn := tc.ApplicationLayer(0).SQLConn(t, "")
+	conn := tc.ApplicationLayer(0).SQLConn(t)
 	sqlDB := sqlutils.MakeSQLRunner(conn)
 
 	sqlDB.Exec(t, `CREATE DATABASE d`)
@@ -299,7 +299,7 @@ func TestDeleteFailedJob(t *testing.T) {
 	serverArgs := base.TestServerArgs{Knobs: base.TestingKnobs{JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals()}}
 	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{ServerArgs: serverArgs})
 	defer tc.Stopper().Stop(ctx)
-	conn := tc.ApplicationLayer(0).SQLConn(t, "")
+	conn := tc.ApplicationLayer(0).SQLConn(t)
 	sqlDB := sqlutils.MakeSQLRunner(conn)
 
 	sqlDB.Exec(t, `SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false`)
@@ -374,7 +374,7 @@ func TestCreateStatsProgress(t *testing.T) {
 	tc := testcluster.StartTestCluster(t, nodes, params)
 	defer tc.Stopper().Stop(ctx)
 	s := tc.ApplicationLayer(0)
-	conn := s.SQLConn(t, "")
+	conn := s.SQLConn(t)
 	sqlDB := sqlutils.MakeSQLRunner(conn)
 
 	sqlDB.Exec(t, `SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false`)
@@ -513,7 +513,7 @@ func TestCreateStatsAsOfTime(t *testing.T) {
 	ctx := context.Background()
 	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{})
 	defer tc.Stopper().Stop(ctx)
-	sqlDB := sqlutils.MakeSQLRunner(tc.ApplicationLayer(0).SQLConn(t, ""))
+	sqlDB := sqlutils.MakeSQLRunner(tc.ApplicationLayer(0).SQLConn(t))
 	sqlDB.Exec(t, `CREATE DATABASE d`)
 	sqlDB.Exec(t, `CREATE TABLE d.t (x INT PRIMARY KEY)`)
 

--- a/pkg/sql/stats/delete_stats_test.go
+++ b/pkg/sql/stats/delete_stats_test.go
@@ -682,7 +682,7 @@ func TestStatsAreDeletedForDroppedTables(t *testing.T) {
 	runner := sqlutils.MakeSQLRunner(sqlDB)
 
 	// Poll for MVCC GC more frequently.
-	systemDB := sqlutils.MakeSQLRunner(s.SystemLayer().SQLConn(t, ""))
+	systemDB := sqlutils.MakeSQLRunner(s.SystemLayer().SQLConn(t))
 	systemDB.Exec(t, "SET CLUSTER SETTING sql.gc_job.wait_for_gc.interval = '1s';")
 
 	// Disable auto stats so that it doesn't interfere.

--- a/pkg/sql/stats/stats_cache_test.go
+++ b/pkg/sql/stats/stats_cache_test.go
@@ -446,7 +446,7 @@ func TestCacheAutoRefresh(t *testing.T) {
 	)
 	require.NoError(t, sc.Start(ctx, s.Codec(), s.RangeFeedFactory().(*rangefeed.Factory)))
 
-	sr0 := sqlutils.MakeSQLRunner(s.SQLConn(t, ""))
+	sr0 := sqlutils.MakeSQLRunner(s.SQLConn(t))
 	sr0.Exec(t, "SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false")
 	sr0.Exec(t, "CREATE DATABASE test")
 	sr0.Exec(t, "CREATE TABLE test.t (k INT PRIMARY KEY, v INT)")
@@ -468,14 +468,14 @@ func TestCacheAutoRefresh(t *testing.T) {
 	if err := expectNStats(0); err != nil {
 		t.Fatal(err)
 	}
-	sr1 := sqlutils.MakeSQLRunner(tc.ApplicationLayer(1).SQLConn(t, ""))
+	sr1 := sqlutils.MakeSQLRunner(tc.ApplicationLayer(1).SQLConn(t))
 	sr1.Exec(t, "CREATE STATISTICS k ON k FROM test.t")
 
 	testutils.SucceedsSoon(t, func() error {
 		return expectNStats(1)
 	})
 
-	sr2 := sqlutils.MakeSQLRunner(tc.ApplicationLayer(2).SQLConn(t, ""))
+	sr2 := sqlutils.MakeSQLRunner(tc.ApplicationLayer(2).SQLConn(t))
 	sr2.Exec(t, "CREATE STATISTICS v ON v FROM test.t")
 
 	testutils.SucceedsSoon(t, func() error {

--- a/pkg/sql/stmtdiagnostics/statement_diagnostics_test.go
+++ b/pkg/sql/stmtdiagnostics/statement_diagnostics_test.go
@@ -543,8 +543,8 @@ func TestDiagnosticsRequestDifferentNode(t *testing.T) {
 	ctx := context.Background()
 	defer tc.Stopper().Stop(ctx)
 	s0 := tc.ApplicationLayer(0)
-	db0 := s0.SQLConn(t, "")
-	db1 := tc.ApplicationLayer(1).SQLConn(t, "")
+	db0 := s0.SQLConn(t)
+	db1 := tc.ApplicationLayer(1).SQLConn(t)
 	_, err := db0.Exec("CREATE TABLE test (x int PRIMARY KEY)")
 	require.NoError(t, err)
 

--- a/pkg/sql/tests/impure_builtin_test.go
+++ b/pkg/sql/tests/impure_builtin_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -31,7 +32,7 @@ func TestClusterID(t *testing.T) {
 	expected := tc.ApplicationLayer(0).RPCContext().LogicalClusterID.Get()
 
 	for i := 0; i < 3; i++ {
-		conn := tc.ApplicationLayer(i).SQLConn(t, "system")
+		conn := tc.ApplicationLayer(i).SQLConn(t, serverutils.DBName("system"))
 		db := sqlutils.MakeSQLRunner(conn)
 		var clusterID uuid.UUID
 		db.QueryRow(t, "SELECT crdb_internal.cluster_id()").Scan(&clusterID)

--- a/pkg/sql/tests/set_cluster_setting_interlock_test.go
+++ b/pkg/sql/tests/set_cluster_setting_interlock_test.go
@@ -46,7 +46,7 @@ func TestSetUnsafeClusterSettingInterlock(t *testing.T) {
 	defer s.Stopper().Stop(ctx)
 	ts := s.ApplicationLayer()
 
-	firstSession := ts.SQLConn(t, "")
+	firstSession := ts.SQLConn(t)
 
 	// RESET on unsafe settings never get an error.
 	_, err := firstSession.Exec(fmt.Sprintf("RESET CLUSTER SETTING %s", unsafeSettingName))
@@ -75,7 +75,7 @@ func TestSetUnsafeClusterSettingInterlock(t *testing.T) {
 	_, err = firstSession.Exec(fmt.Sprintf("SET CLUSTER SETTING %s = true", unsafeSettingName))
 	require.NoError(t, err)
 
-	otherSession := ts.SQLConn(t, "")
+	otherSession := ts.SQLConn(t)
 
 	// The first key produced in each session is different from other sessions.
 	_, err = otherSession.Exec(fmt.Sprintf("SET CLUSTER SETTING %s = true", unsafeSettingName))

--- a/pkg/sql/tests/split_test.go
+++ b/pkg/sql/tests/split_test.go
@@ -36,7 +36,7 @@ func TestSplitOnTableBoundaries(t *testing.T) {
 
 	// speeds up test
 	{
-		sysDB := sqlutils.MakeSQLRunner(s.SystemLayer().SQLConn(t, ""))
+		sysDB := sqlutils.MakeSQLRunner(s.SystemLayer().SQLConn(t))
 		sysDB.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.target_duration = '100ms'`)
 	}
 

--- a/pkg/sql/tests/table_split_test.go
+++ b/pkg/sql/tests/table_split_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -31,7 +32,7 @@ func TestSplitAtTableBoundary(t *testing.T) {
 	defer tc.Stopper().Stop(context.Background())
 	s := tc.ApplicationLayer(0)
 
-	runner := sqlutils.MakeSQLRunner(s.SQLConn(t, "system"))
+	runner := sqlutils.MakeSQLRunner(s.SQLConn(t, serverutils.DBName("system")))
 	runner.Exec(t, `CREATE DATABASE test`)
 	runner.Exec(t, `CREATE TABLE test.t (k SERIAL PRIMARY KEY, v INT)`)
 

--- a/pkg/sql/tests/truncate_test.go
+++ b/pkg/sql/tests/truncate_test.go
@@ -398,7 +398,7 @@ func TestTruncatePreservesSplitPoints(t *testing.T) {
 			defer tc.Stopper().Stop(ctx)
 			s := tc.ApplicationLayer(0)
 			tenantSettings := s.ClusterSettings()
-			conn := s.SQLConn(t, "defaultdb")
+			conn := s.SQLConn(t, serverutils.DBName("defaultdb"))
 
 			{
 				// This test asserts on KV-internal effects (i.e. range splits
@@ -406,7 +406,7 @@ func TestTruncatePreservesSplitPoints(t *testing.T) {
 				// installed splits. To ensure it works with the span configs
 				// infrastructure quickly enough, we set a low closed timestamp
 				// target duration.
-				sysDB := sqlutils.MakeSQLRunner(tc.SystemLayer(0).SQLConn(t, ""))
+				sysDB := sqlutils.MakeSQLRunner(tc.SystemLayer(0).SQLConn(t))
 				sysDB.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.target_duration = '100ms'`)
 			}
 

--- a/pkg/sql/ttl/ttljob/ttljob_test.go
+++ b/pkg/sql/ttl/ttljob/ttljob_test.go
@@ -121,7 +121,7 @@ func newRowLevelTTLTestJobTestHelper(
 		th.sqlDB = sqlutils.MakeSQLRunner(db)
 		th.server = tenantServer
 	} else {
-		db := ts.SystemLayer().SQLConn(t, "")
+		db := ts.SystemLayer().SQLConn(t)
 		th.sqlDB = sqlutils.MakeSQLRunner(db)
 		th.server = ts
 	}

--- a/pkg/testutils/serverutils/BUILD.bazel
+++ b/pkg/testutils/serverutils/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "api.go",
         "conditional_wrap.go",
+        "options.go",
         "test_cluster_shim.go",
         "test_cluster_utils.go",
         "test_server_shim.go",

--- a/pkg/testutils/serverutils/api.go
+++ b/pkg/testutils/serverutils/api.go
@@ -174,26 +174,15 @@ type ApplicationLayerInterface interface {
 	// The concrete type is *nodedialer.Dialer.
 	NodeDialer() interface{}
 
-	// SQLConn returns a handle to the server's SQL interface, opened
-	// with the 'root' user.
+	// SQLConn returns a handle to the server's SQL interface, opened with the
+	// 'root' user if no user option is passed. If no database name option is
+	// passed, DefaultDatabaseName is used.
 	// The connection is closed automatically when the server is stopped.
 	// Beware that each call returns a separate, new connection object.
-	//
-	// For the second argument use catalogkeys.DefaultDatabaseName or
-	// catconstants.SystemDatabaseName when in doubt. An empty
-	// string results in DefaultDatabaseName being used.
-	SQLConn(t TestFataler, dbName string) *gosql.DB
+	SQLConn(t TestFataler, opts ...SQLConnOption) *gosql.DB
 
-	// SQLConnE is like SQLConn but it allows the test to check the error.
-	SQLConnE(dbName string) (*gosql.DB, error)
-
-	// SQLConnForUser is like SQLConn but allows the test to specify a
-	// username.
-	SQLConnForUser(t TestFataler, userName, dbName string) *gosql.DB
-
-	// SQLConnForUserE is like SQLConnForUser but it allows the test to
-	// check the error.
-	SQLConnForUserE(userName, dbName string) (*gosql.DB, error)
+	// SQLConnE is like SQLConn, but it allows the test to check the error.
+	SQLConnE(opts ...SQLConnOption) (*gosql.DB, error)
 
 	// DB returns a handle to the cluster's KV interface.
 	DB() *kv.DB

--- a/pkg/testutils/serverutils/options.go
+++ b/pkg/testutils/serverutils/options.go
@@ -1,0 +1,68 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package serverutils
+
+import (
+	"net/url"
+
+	"github.com/cockroachdb/cockroach/pkg/security/username"
+)
+
+// SQLConnOptions contains options for opening a SQL connection.
+type SQLConnOptions struct {
+	DBName      string
+	User        *url.Userinfo
+	ClientCerts bool
+}
+
+// SQLConnOption is an option for opening a SQL connection.
+type SQLConnOption func(result *SQLConnOptions)
+
+// DefaultSQLConnOptions returns the default options for opening a SQL connection.
+func DefaultSQLConnOptions() *SQLConnOptions {
+	return &SQLConnOptions{
+		DBName:      "",
+		User:        url.User(username.RootUser),
+		ClientCerts: true,
+	}
+}
+
+// DBName sets the database name to use when connecting to the server.
+// Use catalogkeys.DefaultDatabaseName or catconstants.SystemDatabaseName when
+// in doubt. An empty string results in DefaultDatabaseName being used.
+func DBName(dbName string) SQLConnOption {
+	return func(result *SQLConnOptions) {
+		result.DBName = dbName
+	}
+}
+
+// User sets the username to use when connecting to the server.
+func User(username string) SQLConnOption {
+	return func(result *SQLConnOptions) {
+		result.User = url.User(username)
+	}
+}
+
+// UserPassword sets the username and password to use when connecting to the
+// server.
+func UserPassword(username, password string) SQLConnOption {
+	return func(result *SQLConnOptions) {
+		result.User = url.UserPassword(username, password)
+	}
+}
+
+// ClientCerts set whether the client certificates are loaded on-disk and in the
+// connection URL.
+func ClientCerts(clientCerts bool) SQLConnOption {
+	return func(result *SQLConnOptions) {
+		result.ClientCerts = clientCerts
+	}
+}

--- a/pkg/testutils/serverutils/test_server_shim.go
+++ b/pkg/testutils/serverutils/test_server_shim.go
@@ -231,7 +231,7 @@ func StartServer(
 	t TestFataler, params base.TestServerArgs,
 ) (TestServerInterface, *gosql.DB, *kv.DB) {
 	s := StartServerOnly(t, params)
-	goDB := s.ApplicationLayer().SQLConn(t, params.UseDatabase)
+	goDB := s.ApplicationLayer().SQLConn(t, DBName(params.UseDatabase))
 	kvDB := s.ApplicationLayer().DB()
 	return s, goDB, kvDB
 }
@@ -310,7 +310,7 @@ func StartTenant(
 		t.Fatalf("%+v", err)
 	}
 
-	goDB := tenant.SQLConn(t, params.UseDatabase)
+	goDB := tenant.SQLConn(t, DBName(params.UseDatabase))
 	return tenant, goDB
 }
 

--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -478,7 +478,7 @@ func (tc *TestCluster) Start(t serverutils.TestFataler) {
 			tc.Stopper().Stop(ctx)
 			t.Fatal(err)
 		}
-		dbConn, err := s.ApplicationLayer().SQLConnE(tc.serverArgs[idx].UseDatabase)
+		dbConn, err := s.ApplicationLayer().SQLConnE(serverutils.DBName(tc.serverArgs[idx].UseDatabase))
 		if err != nil {
 			tc.Stopper().Stop(ctx)
 			t.Fatal(err)
@@ -623,7 +623,7 @@ func (tc *TestCluster) startServer(idx int, serverArgs base.TestServerArgs) erro
 		return err
 	}
 
-	dbConn, err := server.ApplicationLayer().SQLConnE(serverArgs.UseDatabase)
+	dbConn, err := server.ApplicationLayer().SQLConnE(serverutils.DBName(serverArgs.UseDatabase))
 	if err != nil {
 		return err
 	}
@@ -1757,7 +1757,7 @@ func (tc *TestCluster) RestartServerWithInspect(
 			return err
 		}
 
-		dbConn, err := s.ApplicationLayer().SQLConnE(serverArgs.UseDatabase)
+		dbConn, err := s.ApplicationLayer().SQLConnE(serverutils.DBName(serverArgs.UseDatabase))
 		if err != nil {
 			return err
 		}

--- a/pkg/ts/server_test.go
+++ b/pkg/ts/server_test.go
@@ -310,7 +310,7 @@ func TestServerQueryTenant(t *testing.T) {
 	})
 	defer s.Stopper().Stop(context.Background())
 
-	systemDB := s.SystemLayer().SQLConn(t, "")
+	systemDB := s.SystemLayer().SQLConn(t)
 
 	// Populate data directly.
 	tsdb := s.TsDB().(*ts.DB)

--- a/pkg/upgrade/upgrademanager/manager_external_test.go
+++ b/pkg/upgrade/upgrademanager/manager_external_test.go
@@ -357,7 +357,7 @@ FROM system.job_info WHERE job_id = $1 AND info_key = 'legacy_payload')`, jobID)
 			Settings: settingsForUpgrade(),
 		})
 		require.NoError(t, err)
-		tenantSQLDB := tenant.SQLConn(t, "")
+		tenantSQLDB := tenant.SQLConn(t)
 		runTestForDB(t, tenantSQLDB)
 	})
 }

--- a/pkg/util/startup/startup_test.go
+++ b/pkg/util/startup/startup_test.go
@@ -179,7 +179,7 @@ func runCircuitBreakerTestForKey(
 	require.NoError(t, tc.WaitFor5NodeReplication(), "failed to succeed 5x replication")
 
 	tc.ToggleReplicateQueues(false)
-	c := tc.Server(0).SystemLayer().SQLConn(t, "")
+	c := tc.Server(0).SystemLayer().SQLConn(t)
 	_, err := c.ExecContext(ctx, "set cluster setting kv.allocator.load_based_rebalancing='off'")
 	require.NoError(t, err, "failed to disable load rebalancer")
 	_, err = c.ExecContext(ctx,

--- a/pkg/util/tracing/collector/collector_test.go
+++ b/pkg/util/tracing/collector/collector_test.go
@@ -233,7 +233,7 @@ func TestClusterInflightTraces(t *testing.T) {
 			}
 			systemDBs := make([]*gosql.DB, len(tc.Servers))
 			for i, s := range tc.Servers {
-				systemDBs[i] = s.SQLConn(t, "")
+				systemDBs[i] = s.SQLConn(t)
 			}
 
 			type testCase struct {
@@ -282,7 +282,7 @@ func TestClusterInflightTraces(t *testing.T) {
 					tenant, err := tc.Servers[i].TenantController().StartTenant(ctx, base.TestTenantArgs{TenantID: tenantID})
 					require.NoError(t, err)
 					tenants[i] = tenant
-					dbs[i] = tenant.SQLConn(t, "")
+					dbs[i] = tenant.SQLConn(t)
 				}
 				testCases = []testCase{
 					{


### PR DESCRIPTION
Backport 1/1 commits from #112086.

/cc @cockroachdb/release

---

Previously `ApplicationLayerInterface` contained multiple `SQLConn` method variants for passing connection parameters. Various tests throughout the code use `SQLConn` or `PGUrl` to connect, but the latter does not take into account virtual clusters unless informed.

This PR is meant to enable `SQLConn` to become a standard replacement for `PGUrl` in order to leverage the probabilistic nature of the tests which select between running a second virtual cluster or not.

Numerous tests still use `PGUrl` and pass user, password, or cert details. These tests will soon be updated to start using `SQLConn` and hence should have the same functionality available. This enables the test to not have to deal with querying its probabilistic mode to determine if it should pass a virtual cluster name to `PGUrl`. The `ApplicationLayerInterface` already handles this logic and tests should leverage this.

See also: #111134
Epic: CRDB-31933

Release note: None

Release justification: Test only change.
