### PR TITLE
release-23.1: roachtest: mark new npgsql tests as flaky

### DIFF
--- a/pkg/cmd/roachtest/tests/npgsql_blocklist.go
+++ b/pkg/cmd/roachtest/tests/npgsql_blocklist.go
@@ -64,6 +64,7 @@ var npgsqlBlocklist = blocklist{
 	`Npgsql.Tests.CommandTests(Multiplexing).Multiple_statements_with_dependencies`:                                                               "unknown",
 	`Npgsql.Tests.CommandTests(Multiplexing).Non_standards_conforming_strings`:                                                                    "unknown",
 	`Npgsql.Tests.CommandTests(Multiplexing).Positional_parameters_are_not_supported_with_legacy_batching`:                                        "unknown",
+	`Npgsql.Tests.CommandTests(Multiplexing).Reuse_command_with_different_parameter_placeholder_types`:                                            "flaky",
 	`Npgsql.Tests.CommandTests(NonMultiplexing).Cursor_statement`:                                                                                 "unknown",
 	`Npgsql.Tests.CommandTests(NonMultiplexing).ExecuteNonQuery_Throws_PostgresException(False)`:                                                  "unknown",
 	`Npgsql.Tests.CommandTests(NonMultiplexing).ExecuteNonQuery_Throws_PostgresException(True)`:                                                   "unknown",
@@ -723,9 +724,12 @@ var npgsqlBlocklist = blocklist{
 var npgsqlIgnoreList = blocklist{
 	`Npgsql.Tests.CommandTests(Multiplexing).Cursor_move_RecordsAffected `:                                 "flaky",
 	`Npgsql.Tests.CommandTests(Multiplexing).QueryNonQuery`:                                                "flaky",
+	`Npgsql.Tests.CommandTests(Multiplexing).Same_command_different_param_instances`:                       "flaky",
+	`Npgsql.Tests.CommandTests(Multiplexing).Same_command_different_param_values`:                          "flaky",
 	`Npgsql.Tests.CommandTests(Multiplexing).SingleNonQuery`:                                               "flaky",
 	`Npgsql.Tests.CommandTests(Multiplexing).SingleQuery`:                                                  "flaky",
 	`Npgsql.Tests.CommandTests(Multiplexing).Statement_mapped_output_parameters(Default)`:                  "flaky",
+	`Npgsql.Tests.CommandTests(Multiplexing).TableDirect`:                                                  "flaky",
 	`Npgsql.Tests.CommandTests(Multiplexing).Use_across_connection_change(NotPrepared)`:                    "flaky",
 	`Npgsql.Tests.CommandTests(NonMultiplexing).Cached_command_clears_parameters_placeholder_type`:         "flaky",
 	`Npgsql.Tests.CommandTests(NonMultiplexing).CloseConnection_with_exception`:                            "flaky",
@@ -781,4 +785,6 @@ var npgsqlIgnoreList = blocklist{
 	`Npgsql.Tests.TaskTimeoutAndCancellationTest.DelayedFaultedTaskCancellation("TimeoutOnly")`:            "flaky",
 	`Npgsql.Tests.TransactionTests(Multiplexing).Failed_transaction_on_close_with_custom_timeout`:          "flaky",
 	`Npgsql.Tests.TransactionTests(NonMultiplexing).CommitAsync(Prepared)`:                                 "flaky",
+	`Npgsql.Tests.TransactionTests(NonMultiplexing).Rollback(Prepared)`:                                    "flaky",
+	`Npgsql.Tests.TransactionTests(NonMultiplexing).RollbackAsync(NotPrepared)`:                            "flaky",
 }


### PR DESCRIPTION
Backport 1/1 commits from #113542.

/cc @cockroachdb/release

Release justification: test only change

---

These tests started flaking due to #108414. We will mark them as flaky and investigate later.

fixes https://github.com/cockroachdb/cockroach/issues/112686

Release note: None
