### PR TITLE
sql: disable shared process tenant for TestTraceAnalyzer

### DIFF
--- a/pkg/sql/execstats/traceanalyzer_test.go
+++ b/pkg/sql/execstats/traceanalyzer_test.go
@@ -57,6 +57,9 @@ func TestTraceAnalyzer(t *testing.T) {
 	tc := serverutils.StartCluster(t, numNodes, base.TestClusterArgs{
 		ReplicationMode: base.ReplicationManual,
 		ServerArgs: base.TestServerArgs{
+			DefaultTestTenant: base.TestDoesNotWorkWithSharedProcessModeButWeDontKnowWhyYet(
+				base.TestTenantProbabilistic, 113598,
+			),
 			UseDatabase: "test",
 			Knobs: base.TestingKnobs{
 				SQLExecutor: &sql.ExecutorTestingKnobs{


### PR DESCRIPTION
This test is flaky when running with a shared process test virtual cluster.

Informs: #113591
Informs: #113598

Epic: None