### PR TITLE
release-23.1: roachtest: port import/mixed-versions to the new framework

### DIFF
--- a/pkg/cmd/roachtest/tests/BUILD.bazel
+++ b/pkg/cmd/roachtest/tests/BUILD.bazel
@@ -95,6 +95,7 @@ go_library(
         "mixed_version_change_replicas.go",
         "mixed_version_decl_schemachange_compat.go",
         "mixed_version_decommission.go",
+        "mixed_version_import.go",
         "mixed_version_job_compatibility_in_declarative_schema_changer.go",
         "mixed_version_jobs.go",
         "mixed_version_schemachange.go",

--- a/pkg/cmd/roachtest/tests/import.go
+++ b/pkg/cmd/roachtest/tests/import.go
@@ -22,12 +22,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil"
-	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/clusterupgrade"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
-	"github.com/cockroachdb/cockroach/pkg/testutils/release"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/errors"
@@ -343,56 +341,6 @@ func registerImportTPCH(r registry.Registry) {
 			},
 		})
 	}
-}
-
-func successfulImportStep(warehouses, nodeID int) versionStep {
-	return func(ctx context.Context, t test.Test, u *versionUpgradeTest) {
-		u.c.Run(ctx, u.c.Node(nodeID), tpccImportCmd(warehouses))
-	}
-}
-
-func runImportMixedVersion(
-	ctx context.Context, t test.Test, c cluster.Cluster, warehouses int, predVersion string,
-) {
-	roachNodes := c.All()
-
-	t.Status("starting csv servers")
-
-	predecessorVersion := clusterupgrade.MustParseVersion(predVersion)
-	u := newVersionUpgradeTest(c,
-		uploadAndStartFromCheckpointFixture(roachNodes, predecessorVersion),
-		waitForUpgradeStep(roachNodes),
-		preventAutoUpgradeStep(1),
-
-		// Upgrade some of the nodes.
-		binaryUpgradeStep(c.Node(1), clusterupgrade.CurrentVersion()),
-		binaryUpgradeStep(c.Node(2), clusterupgrade.CurrentVersion()),
-
-		successfulImportStep(warehouses, 1 /* nodeID */),
-	)
-	u.run(ctx, t)
-}
-
-func registerImportMixedVersion(r registry.Registry) {
-	r.Add(registry.TestSpec{
-		Name:  "import/mixed-versions",
-		Owner: registry.OwnerSQLQueries,
-		// Mixed-version support was added in 21.1.
-		Cluster:          r.MakeClusterSpec(4),
-		CompatibleClouds: registry.AllExceptAWS,
-		Suites:           registry.Suites(registry.Nightly),
-		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-			predV, err := release.LatestPredecessor(t.BuildVersion())
-			if err != nil {
-				t.Fatal(err)
-			}
-			warehouses := 100
-			if c.IsLocal() {
-				warehouses = 10
-			}
-			runImportMixedVersion(ctx, t, c, warehouses, predV)
-		},
-	})
 }
 
 func registerImportDecommissioned(r registry.Registry) {

--- a/pkg/cmd/roachtest/tests/mixed_version_import.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_import.go
@@ -1,0 +1,58 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package tests
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/mixedversion"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
+)
+
+func registerImportMixedVersions(r registry.Registry) {
+	r.Add(registry.TestSpec{
+		Name:             "import/mixed-versions",
+		Owner:            registry.OwnerSQLQueries,
+		Cluster:          r.MakeClusterSpec(4),
+		CompatibleClouds: registry.AllExceptAWS,
+		Suites:           registry.Suites(registry.Nightly),
+		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			warehouses := 100
+			if c.IsLocal() {
+				warehouses = 10
+			}
+			runImportMixedVersions(ctx, t, c, warehouses)
+		},
+	})
+}
+
+func runImportMixedVersions(ctx context.Context, t test.Test, c cluster.Cluster, warehouses int) {
+	// NB: We rely on the testing framework to choose a random predecessor to
+	// upgrade from.
+	mvt := mixedversion.NewTest(ctx, t, t.L(), c, c.All())
+	runImport := func(ctx context.Context, l *logger.Logger, r *rand.Rand, h *mixedversion.Helper) error {
+		if err := h.Exec(r, "DROP DATABASE IF EXISTS tpcc CASCADE;"); err != nil {
+			return err
+		}
+		node := h.RandomNode(r, c.All())
+		cmd := tpccImportCmdWithCockroachBinary(test.DefaultCockroachPath, warehouses) + fmt.Sprintf(" {pgurl%s}", c.Node(node))
+		l.Printf("executing %q on node %d", cmd, node)
+		return c.RunE(ctx, c.Node(node), cmd)
+	}
+	mvt.InMixedVersion("import", runImport)
+	mvt.AfterUpgradeFinalized("import", runImport)
+	mvt.Run()
+}

--- a/pkg/cmd/roachtest/tests/registry.go
+++ b/pkg/cmd/roachtest/tests/registry.go
@@ -61,7 +61,7 @@ func RegisterTests(r registry.Registry) {
 	registerHotSpotSplits(r)
 	registerImportCancellation(r)
 	registerImportDecommissioned(r)
-	registerImportMixedVersion(r)
+	registerImportMixedVersions(r)
 	registerImportNodeShutdown(r)
 	registerImportTPCC(r)
 	registerImportTPCH(r)


### PR DESCRIPTION
Backport of #113546.

There are some minor differences:
- we no longer install fixtures (which weren't used anyway)
- we'll probably run the IMPORT multiple times throughout the test run.

Epic: None

Release note: None

Release justification: test-only change.