### PR TITLE
sql/schemachanger: prevent concurrent type desc changes

### DIFF
--- a/pkg/sql/catalog/typedesc/type_desc.go
+++ b/pkg/sql/catalog/typedesc/type_desc.go
@@ -866,6 +866,13 @@ func (desc *immutable) HasConcurrentSchemaChanges() bool {
 		desc.DeclarativeSchemaChangerState.JobID != catpb.InvalidJobID {
 		return true
 	}
+	// Check if any enum members are transitioning, which should
+	// block declarative jobs.
+	for _, member := range desc.EnumMembers {
+		if member.Direction != descpb.TypeDescriptor_EnumMember_NONE {
+			return true
+		}
+	}
 	// TODO(fqazi): In the future we may not have concurrent declarative schema
 	// changes without a job ID. So, we should scan the elements involved for
 	// types.


### PR DESCRIPTION
Previously, the declarative schema changer only waited for legacy schema changer mutations/jobs on relations and did not correctly account for type schema changes.  As a result, it was possible to drop a type concurrently while a schema change was trying to mutate a type, which could lead to type change jobs hanging. To address this, this patch causes declarative schema changes to wait for type modifications.

Fixes: #112390, #111540

Release note (bug fix): ALTER TYPE could get stuck if DROP TYPE
 was executed concurrently.