### PR TITLE
liveness: create the Cache externally to liveness

### DIFF
--- a/pkg/kv/kvserver/liveness/cache.go
+++ b/pkg/kv/kvserver/liveness/cache.go
@@ -18,6 +18,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness/livenesspb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/rpc"
+	"github.com/cockroachdb/cockroach/pkg/rpc/nodedialer"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
@@ -37,7 +40,7 @@ type Gossip interface {
 var livenessRegex = gossip.MakePrefixPattern(gossip.KeyNodeLivenessPrefix)
 var storeRegex = gossip.MakePrefixPattern(gossip.KeyStoreDescPrefix)
 
-// cache stores updates to both Liveness records and the store descriptor map.
+// Cache stores updates to both Liveness records and the store descriptor map.
 // It doesn't store the entire StoreDescriptor, only the time when it is
 // updated. The StoreDescriptor is sent directly from nodes so doesn't require
 // the liveness leaseholder to be available.
@@ -46,11 +49,12 @@ var storeRegex = gossip.MakePrefixPattern(gossip.KeyStoreDescPrefix)
 // checking liveness on the liveness record, then the isLive method should
 // change to take this into account. Only epoch leases will use the liveness
 // timestamp directly.
-type cache struct {
-	gossip                Gossip
-	clock                 *hlc.Clock
-	notifyLivenessChanged func(old, new livenesspb.Liveness)
-	mu                    struct {
+type Cache struct {
+	gossip     Gossip
+	clock      *hlc.Clock
+	nodeDialer *nodedialer.Dialer
+	st         *cluster.Settings
+	mu         struct {
 		syncutil.RWMutex
 		// lastNodeUpdate stores timestamps of StoreDescriptor updates in Gossip.
 		// This is tracking based on NodeID, so any store that is updated on this
@@ -58,47 +62,57 @@ type cache struct {
 		// "1 stalled store" on a node from a liveness perspective.
 		lastNodeUpdate map[roachpb.NodeID]UpdateInfo
 		// nodes stores liveness records read from Gossip
-		nodes map[roachpb.NodeID]Record
+		nodes                 map[roachpb.NodeID]Record
+		notifyLivenessChanged func(old, new livenesspb.Liveness)
 	}
 }
 
-func newCache(
-	g Gossip, clock *hlc.Clock, cbFn func(livenesspb.Liveness, livenesspb.Liveness),
-) *cache {
-	c := cache{}
-	c.gossip = g
-	c.clock = clock
+// NewCache creates a liveness cache. The cache will receive updates from Gossip
+// or from direct updates to liveness made through this node.
+func NewCache(
+	g Gossip, clock *hlc.Clock, st *cluster.Settings, nodeDialer *nodedialer.Dialer,
+) *Cache {
+	c := Cache{
+		gossip:     g,
+		clock:      clock,
+		nodeDialer: nodeDialer,
+		st:         st,
+	}
 	c.mu.nodes = make(map[roachpb.NodeID]Record)
 	c.mu.lastNodeUpdate = make(map[roachpb.NodeID]UpdateInfo)
 
-	c.notifyLivenessChanged = cbFn
+	// Listen for gossip updates to both liveness and store descriptors.
+	// Liveness updates are only published by the liveness leaseholder, but
+	// store updates are published directly by the node. Different parts of the
+	// system have different criteria for what they consider alive.
+	c.gossip.RegisterCallback(livenessRegex, c.livenessGossipUpdate)
 
-	// Gossip is nil in some tests.
-	if c.gossip != nil {
-		// NB: we should consider moving this registration to .Start() once we
-		// have ensured that nobody uses the server's KV client (kv.DB) before
-		// nl.Start() is invoked. At the time of writing this invariant does
-		// not hold (which is a problem, since the node itself won't be live
-		// at this point, and requests routed to it will hang).
-		c.gossip.RegisterCallback(livenessRegex, c.livenessGossipUpdate)
+	// Enable redundant callbacks for the store keys because we use these
+	// callbacks as a clock to determine when a store was last updated even if
+	// it hasn't otherwise changed.
+	c.gossip.RegisterCallback(storeRegex, c.storeGossipUpdate, gossip.Redundant)
 
-		// Enable redundant callbacks for the store keys because we use these
-		// callbacks as a clock to determine when a store was last updated even if it
-		// hasn't otherwise changed.
-		c.gossip.RegisterCallback(storeRegex, c.storeGossipUpdate, gossip.Redundant)
-	}
 	return &c
+}
+
+// setLivenessChangedFn sets the liveness function after the Cache has been
+// created. This prevents a circular dependency between the Cache and the
+// NodeLiveness objects.
+func (c *Cache) setLivenessChangedFn(cbFn func(old, new livenesspb.Liveness)) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.mu.notifyLivenessChanged = cbFn
 }
 
 // selfID returns the ID for this node according to Gossip. This will be 0
 // until the node has joined the cluster.
-func (c *cache) selfID() roachpb.NodeID {
+func (c *Cache) selfID() roachpb.NodeID {
 	return c.gossip.GetNodeID()
 }
 
 // livenessGossipUpdate is the gossip callback used to keep the
 // in-memory liveness info up to date.
-func (c *cache) livenessGossipUpdate(_ string, content roachpb.Value) {
+func (c *Cache) livenessGossipUpdate(_ string, content roachpb.Value) {
 	ctx := context.TODO()
 	var liveness livenesspb.Liveness
 	if err := content.GetProto(&liveness); err != nil {
@@ -110,7 +124,7 @@ func (c *cache) livenessGossipUpdate(_ string, content roachpb.Value) {
 }
 
 // storeGossipUpdate is the Gossip callback used to keep the nodeDescMap up to date.
-func (c *cache) storeGossipUpdate(_ string, content roachpb.Value) {
+func (c *Cache) storeGossipUpdate(_ string, content roachpb.Value) {
 	ctx := context.TODO()
 	var storeDesc roachpb.StoreDescriptor
 	if err := content.GetProto(&storeDesc); err != nil {
@@ -134,7 +148,7 @@ func (c *cache) storeGossipUpdate(_ string, content roachpb.Value) {
 
 // maybeUpdate replaces the liveness (if it appears newer) and invokes the
 // registered callbacks if the node became live in the process.
-func (c *cache) maybeUpdate(ctx context.Context, newLivenessRec Record) {
+func (c *Cache) maybeUpdate(ctx context.Context, newLivenessRec Record) {
 	if newLivenessRec.Liveness == (livenesspb.Liveness{}) {
 		log.Fatal(ctx, "invalid new liveness record; found to be empty")
 	}
@@ -157,10 +171,11 @@ func (c *cache) maybeUpdate(ctx context.Context, newLivenessRec Record) {
 	if shouldReplace {
 		c.mu.nodes[newLivenessRec.NodeID] = newLivenessRec
 	}
+	notifyFn := c.mu.notifyLivenessChanged
 	c.mu.Unlock()
 
 	if shouldReplace {
-		c.notifyLivenessChanged(oldLivenessRec.Liveness, newLivenessRec.Liveness)
+		notifyFn(oldLivenessRec.Liveness, newLivenessRec.Liveness)
 	}
 }
 
@@ -192,18 +207,18 @@ func livenessChanged(old, new Record) bool {
 		(oldL.Equal(newL) && !bytes.Equal(old.raw, new.raw))
 }
 
-// Self returns the raw, encoded value that the database has for this liveness
+// self returns the raw, encoded value that the database has for this liveness
 // record in addition to the decoded liveness proto.
-func (c *cache) Self() (_ Record, ok bool) {
-	return c.GetLiveness(c.selfID())
+func (c *Cache) self() (_ Record, ok bool) {
+	return c.getLiveness(c.selfID())
 }
 
-// GetLiveness returns the liveness record for the specified nodeID. If the
+// getLiveness returns the liveness record for the specified nodeID. If the
 // liveness record is not found (due to gossip propagation delays or due to the
 // node not existing), we surface that to the caller. The record returned also
 // includes the raw, encoded value that the database has for this liveness
 // record in addition to the decoded liveness proto.
-func (c *cache) GetLiveness(nodeID roachpb.NodeID) (_ Record, ok bool) {
+func (c *Cache) getLiveness(nodeID roachpb.NodeID) (_ Record, ok bool) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	if l, ok := c.mu.nodes[nodeID]; ok {
@@ -212,10 +227,45 @@ func (c *cache) GetLiveness(nodeID roachpb.NodeID) (_ Record, ok bool) {
 	return Record{}, false
 }
 
-// GetIsLiveMap returns a map of nodeID to boolean liveness status of
+// GetNodeVitality returns the vitality record for the specified nodeID. If the
+// vitality record is not found (due to gossip propagation delays or due to the
+// node not existing), we surface that to the caller by returning a record where
+// NodeVitality.IsValid return false.
+func (c *Cache) GetNodeVitality(nodeID roachpb.NodeID) livenesspb.NodeVitality {
+	if l, ok := c.getLiveness(nodeID); ok {
+		return c.convertToNodeVitality(l.Liveness)
+	}
+	// If we don't have a liveness record, we can't create a full NodeVitality.
+	// This is a little unfortunate as we may have a NodeDescriptor.
+	return livenesspb.NodeVitality{}
+}
+
+// convertToNodeVitality is used if you already have a Liveness record received
+// externally.
+func (c *Cache) convertToNodeVitality(l livenesspb.Liveness) livenesspb.NodeVitality {
+	// The store is considered dead if it hasn't been updated via gossip
+	// within the liveness threshold. Note that LastUpdatedTime is set
+	// when the store detail is created and will have a non-zero value
+	// even before the first gossip arrives for a store.
+
+	// NB: nodeDialer is nil in some tests.
+	connected := c.nodeDialer == nil || c.nodeDialer.ConnHealth(l.NodeID, rpc.SystemClass) == nil
+	lastDescUpdate := c.lastDescriptorUpdate(l.NodeID)
+
+	return l.CreateNodeVitality(
+		c.clock.Now(),
+		lastDescUpdate.lastUpdateTime,
+		lastDescUpdate.lastUnavailableTime,
+		connected,
+		TimeUntilNodeDead.Get(&c.st.SV),
+		TimeAfterNodeSuspect.Get(&c.st.SV),
+	)
+}
+
+// getIsLiveMap returns a map of nodeID to boolean liveness status of
 // each node. This excludes nodes that were removed completely (dead +
 // decommissioned)
-func (c *cache) GetIsLiveMap() livenesspb.IsLiveMap {
+func (c *Cache) getIsLiveMap() livenesspb.IsLiveMap {
 	lMap := livenesspb.IsLiveMap{}
 	c.mu.RLock()
 	defer c.mu.RUnlock()
@@ -235,10 +285,10 @@ func (c *cache) GetIsLiveMap() livenesspb.IsLiveMap {
 }
 
 // getAllLivenessEntries returns a copy of all the entries currently in the
-// liveness cache. Most places should avoid calling this method and instead just
+// liveness Cache. Most places should avoid calling this method and instead just
 // get the entry they need. In a few places in the code it is more efficient to
 // get the entries once and keep the map in memory for later iteration.
-func (c *cache) getAllLivenessEntries() []livenesspb.Liveness {
+func (c *Cache) getAllLivenessEntries() []livenesspb.Liveness {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	cpy := make([]livenesspb.Liveness, 0, len(c.mu.nodes))
@@ -248,22 +298,40 @@ func (c *cache) getAllLivenessEntries() []livenesspb.Liveness {
 	return cpy
 }
 
-// LastDescriptorUpdate returns when this node last had an update.
-func (c *cache) LastDescriptorUpdate(nodeID roachpb.NodeID) (UpdateInfo, bool) {
+// ScanNodeVitalityFromCache returns a map of nodeID to boolean liveness status
+// of each node from the cache. This excludes nodes that were decommissioned.
+// Decommissioned nodes are kept in the KV store and the cache forever, but are
+// typically not referenced in normal usage. The method ScanNodeVitalityFromKV
+// does return decommissioned nodes.
+func (c *Cache) ScanNodeVitalityFromCache() livenesspb.NodeVitalityMap {
+	entries := c.getAllLivenessEntries()
+	statusMap := make(map[roachpb.NodeID]livenesspb.NodeVitality, len(entries))
+	for _, l := range entries {
+		if l.Membership.Decommissioned() {
+			// This is a node that was completely removed. Skip over it.
+			continue
+		}
+		statusMap[l.NodeID] = c.convertToNodeVitality(l)
+	}
+	return statusMap
+}
+
+// lastDescriptorUpdate returns when this node last had an update.
+func (c *Cache) lastDescriptorUpdate(nodeID roachpb.NodeID) UpdateInfo {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	if l, ok := c.mu.lastNodeUpdate[nodeID]; ok {
-		return l, true
+		return l
 	}
 	// If there is no timestamp, use the "0" timestamp.
-	return UpdateInfo{}, false
+	return UpdateInfo{}
 }
 
-// CheckForStaleEntries checks if any of the cached node updates have not been
+// checkForStaleEntries checks if any of the cached node updates have not been
 // updated for longer than the interval. If they become stale, they remain stale
 // for the suspect interval to prevent flapping nodes from impacting system
 // stability.
-func (c *cache) CheckForStaleEntries(interval time.Duration) {
+func (c *Cache) checkForStaleEntries(interval time.Duration) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	now := c.clock.Now()

--- a/pkg/kv/kvserver/liveness/liveness.go
+++ b/pkg/kv/kvserver/liveness/liveness.go
@@ -22,11 +22,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness/livenesspb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/rpc"
-	"github.com/cockroachdb/cockroach/pkg/rpc/nodedialer"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/settings"
-	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	diskStorage "github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
 	"github.com/cockroachdb/cockroach/pkg/util/grpcutil"
@@ -251,10 +248,9 @@ type NodeLiveness struct {
 	clock             *hlc.Clock
 	storage           Storage
 	livenessThreshold time.Duration
-	cache             *cache
+	cache             *Cache
 	renewalDuration   time.Duration
 	selfSem           chan struct{}
-	st                *cluster.Settings
 	otherSem          chan struct{}
 	// heartbeatPaused contains an atomically-swapped number representing a bool
 	// (1 or 0). heartbeatToken is a channel containing a token which is taken
@@ -264,7 +260,6 @@ type NodeLiveness struct {
 	metrics               Metrics
 	onNodeDecommissioned  func(id roachpb.NodeID) // noop if nil
 	onNodeDecommissioning func(id roachpb.NodeID) // noop if nil
-	nodeDialer            *nodedialer.Dialer
 	engineSyncs           *singleflight.Group
 
 	// onIsLiveMu holds callback registered by stores.
@@ -305,8 +300,6 @@ type Record struct {
 type NodeLivenessOptions struct {
 	AmbientCtx              log.AmbientContext
 	Stopper                 *stop.Stopper
-	Settings                *cluster.Settings
-	Gossip                  Gossip
 	Clock                   *hlc.Clock
 	Storage                 Storage
 	LivenessThreshold       time.Duration
@@ -322,7 +315,7 @@ type NodeLivenessOptions struct {
 	OnNodeDecommissioning func(id roachpb.NodeID)
 	Engines               []diskStorage.Engine
 	OnSelfHeartbeat       HeartbeatCallback
-	NodeDialer            *nodedialer.Dialer
+	Cache                 *Cache
 }
 
 // NewNodeLiveness returns a new instance of NodeLiveness configured
@@ -336,7 +329,6 @@ func NewNodeLiveness(opts NodeLivenessOptions) *NodeLiveness {
 		livenessThreshold:     opts.LivenessThreshold,
 		renewalDuration:       opts.RenewalDuration,
 		selfSem:               make(chan struct{}, 1),
-		st:                    opts.Settings,
 		otherSem:              make(chan struct{}, 1),
 		heartbeatToken:        make(chan struct{}, 1),
 		onNodeDecommissioned:  opts.OnNodeDecommissioned,
@@ -344,7 +336,7 @@ func NewNodeLiveness(opts NodeLivenessOptions) *NodeLiveness {
 		engineSyncs:           singleflight.NewGroup("engine sync", "engine"),
 		engines:               opts.Engines,
 		onSelfHeartbeat:       opts.OnSelfHeartbeat,
-		nodeDialer:            opts.NodeDialer,
+		cache:                 opts.Cache,
 	}
 	nl.metrics = Metrics{
 		LiveNodes:          metric.NewFunctionalGauge(metaLiveNodes, nl.numLiveNodes),
@@ -359,7 +351,7 @@ func NewNodeLiveness(opts NodeLivenessOptions) *NodeLiveness {
 			BucketConfig: metric.IOLatencyBuckets,
 		}),
 	}
-	nl.cache = newCache(opts.Gossip, opts.Clock, nl.cacheUpdated)
+	nl.cache.setLivenessChangedFn(nl.cacheUpdated)
 	nl.heartbeatToken <- struct{}{}
 
 	return nl
@@ -388,7 +380,7 @@ func (nl *NodeLiveness) SetDraining(
 	retryOpts := base.DefaultRetryOptions()
 	retryOpts.Closer = nl.stopper.ShouldQuiesce()
 	for r := retry.StartWithCtx(ctx, retryOpts); r.Next(); {
-		oldLivenessRec, ok := nl.cache.Self()
+		oldLivenessRec, ok := nl.cache.self()
 		if !ok {
 			// There was a cache miss, let's now fetch the record from KV
 			// directly.
@@ -645,7 +637,7 @@ func (nl *NodeLiveness) Start(ctx context.Context) {
 			// have left before our liveness entry expires.
 			if err := timeutil.RunWithTimeout(ctx, "node liveness heartbeat", nl.renewalDuration,
 				func(ctx context.Context) error {
-					nl.cache.CheckForStaleEntries(gossip.StoreTTL)
+					nl.cache.checkForStaleEntries(gossip.StoreTTL)
 					// Retry heartbeat in the event the conditional put fails.
 					for r := retry.StartWithCtx(ctx, retryOpts); r.Next(); {
 						oldLiveness, ok := nl.Self()
@@ -884,7 +876,7 @@ func (nl *NodeLiveness) heartbeatInternal(
 // liveness record successfully, nor received a gossip message containing
 // a former liveness update on restart.
 func (nl *NodeLiveness) Self() (_ livenesspb.Liveness, ok bool) {
-	rec, ok := nl.cache.Self()
+	rec, ok := nl.cache.self()
 	if !ok {
 		return livenesspb.Liveness{}, false
 	}
@@ -896,7 +888,7 @@ func (nl *NodeLiveness) Self() (_ livenesspb.Liveness, ok bool) {
 // decommissioning).
 // TODO(baptist): Remove.
 func (nl *NodeLiveness) GetIsLiveMap() livenesspb.IsLiveMap {
-	return nl.cache.GetIsLiveMap()
+	return nl.cache.getIsLiveMap()
 }
 
 // ScanNodeVitalityFromCache returns a map of nodeID to boolean liveness status
@@ -905,16 +897,7 @@ func (nl *NodeLiveness) GetIsLiveMap() livenesspb.IsLiveMap {
 // typically not referenced in normal usage. The method ScanNodeVitalityFromKV
 // does return decommissioned nodes.
 func (nl *NodeLiveness) ScanNodeVitalityFromCache() livenesspb.NodeVitalityMap {
-	entries := nl.cache.getAllLivenessEntries()
-	statusMap := make(map[roachpb.NodeID]livenesspb.NodeVitality, len(entries))
-	for _, l := range entries {
-		if l.Membership.Decommissioned() {
-			// This is a node that was completely removed. Skip over it.
-			continue
-		}
-		statusMap[l.NodeID] = nl.convertToNodeVitality(l)
-	}
-	return statusMap
+	return nl.cache.ScanNodeVitalityFromCache()
 }
 
 // ScanNodeVitalityFromKV returns the status for all the nodes from KV including
@@ -932,33 +915,11 @@ func (nl *NodeLiveness) ScanNodeVitalityFromKV(
 
 	statusMap := make(map[roachpb.NodeID]livenesspb.NodeVitality, len(records))
 	for _, liveness := range records {
-		vitality := nl.convertToNodeVitality(liveness.Liveness)
+		vitality := nl.cache.convertToNodeVitality(liveness.Liveness)
 		nl.cache.maybeUpdate(ctx, liveness)
 		statusMap[liveness.NodeID] = vitality
 	}
 	return statusMap, nil
-}
-
-// convertToNodeVitality is used if you already have a Liveness record received
-// externally.
-func (nl *NodeLiveness) convertToNodeVitality(l livenesspb.Liveness) livenesspb.NodeVitality {
-	// The store is considered dead if it hasn't been updated via gossip
-	// within the liveness threshold. Note that LastUpdatedTime is set
-	// when the store detail is created and will have a non-zero value
-	// even before the first gossip arrives for a store.
-
-	// NB: nodeDialer is nil in some tests.
-	connected := nl.nodeDialer == nil || nl.nodeDialer.ConnHealth(l.NodeID, rpc.SystemClass) == nil
-	lastDescUpdate, _ := nl.cache.LastDescriptorUpdate(l.NodeID)
-
-	return l.CreateNodeVitality(
-		nl.clock.Now(),
-		lastDescUpdate.lastUpdateTime,
-		lastDescUpdate.lastUnavailableTime,
-		connected,
-		TimeUntilNodeDead.Get(&nl.st.SV),
-		TimeAfterNodeSuspect.Get(&nl.st.SV),
-	)
 }
 
 // GetNodeVitalityFromCache returns the current status of the node. This method
@@ -969,13 +930,7 @@ func (nl *NodeLiveness) convertToNodeVitality(l livenesspb.Liveness) livenesspb.
 // may no longer be accurate in the future. See livenesspb.NodeVitality for
 // using this method.
 func (nl *NodeLiveness) GetNodeVitalityFromCache(nodeID roachpb.NodeID) livenesspb.NodeVitality {
-	l, ok := nl.cache.GetLiveness(nodeID)
-	if !ok {
-		// If we don't have a liveness record, we can't create a full NodeVitality.
-		// This is a little unfortunate as we may have a NodeDescriptor.
-		return livenesspb.NodeVitality{}
-	}
-	return nl.convertToNodeVitality(l.Liveness)
+	return nl.cache.GetNodeVitality(nodeID)
 }
 
 // GetLiveness returns the liveness record for the specified nodeID. If the
@@ -985,7 +940,7 @@ func (nl *NodeLiveness) GetNodeVitalityFromCache(nodeID roachpb.NodeID) liveness
 // record in addition to the decoded liveness proto.
 // TODO(baptist): Remove.
 func (nl *NodeLiveness) GetLiveness(nodeID roachpb.NodeID) (_ Record, ok bool) {
-	return nl.cache.GetLiveness(nodeID)
+	return nl.cache.getLiveness(nodeID)
 }
 
 // getLivenessRecordFromKV fetches the liveness record from KV for a given node,
@@ -1170,7 +1125,7 @@ func (nl *NodeLiveness) updateLivenessAttempt(
 	// If the caller is not manually providing the previous value in
 	// update.oldRaw. we need to read it from our cache.
 	if update.oldRaw == nil {
-		l, ok := nl.cache.GetLiveness(update.newLiveness.NodeID)
+		l, ok := nl.cache.getLiveness(update.newLiveness.NodeID)
 		if !ok {
 			// TODO(baptist): We only expect callers to supply us with node IDs
 			// they learnt through existing liveness records, which implies we

--- a/pkg/kv/kvserver/replica_range_lease_test.go
+++ b/pkg/kv/kvserver/replica_range_lease_test.go
@@ -123,10 +123,16 @@ func TestReplicaLeaseStatus(t *testing.T) {
 			wantErr: "node liveness info for n1 is stale"},
 	} {
 		t.Run("", func(t *testing.T) {
+			cache :=
+				liveness.NewCache(
+					gossip.NewTest(roachpb.NodeID(1), stopper, metric.NewRegistry()),
+					clock,
+					cluster.MakeTestingClusterSettings(),
+					nil,
+				)
 			l := liveness.NewNodeLiveness(liveness.NodeLivenessOptions{
-				Clock:    clock,
-				Gossip:   gossip.NewTest(roachpb.NodeID(1), stopper, metric.NewRegistry()),
-				Settings: cluster.MakeTestingClusterSettings(),
+				Clock: clock,
+				Cache: cache,
 			})
 			r := Replica{store: &Store{
 				Ident: &roachpb.StoreIdent{StoreID: 1, NodeID: 1},

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -1085,15 +1085,21 @@ func TestReplicaLeaseCounters(t *testing.T) {
 	var tc testContext
 	cfg := TestStoreConfig(nil)
 	nlActive, nlRenewal := cfg.NodeLivenessDurations()
+	cache := liveness.NewCache(
+		gossip.NewTest(roachpb.NodeID(1), stopper, metric.NewRegistry()),
+		cfg.Clock,
+		cfg.Settings,
+		cfg.NodeDialer,
+	)
+
 	cfg.NodeLiveness = liveness.NewNodeLiveness(liveness.NodeLivenessOptions{
 		AmbientCtx:        log.AmbientContext{},
 		Stopper:           stopper,
-		Settings:          cfg.Settings,
 		Clock:             cfg.Clock,
+		Cache:             cache,
 		LivenessThreshold: nlActive,
 		RenewalDuration:   nlRenewal,
 		Engines:           []storage.Engine{},
-		NodeDialer:        cfg.NodeDialer,
 	})
 	tc.StartWithStoreConfig(ctx, t, stopper, cfg)
 

--- a/pkg/testutils/localtestcluster/local_test_cluster.go
+++ b/pkg/testutils/localtestcluster/local_test_cluster.go
@@ -199,13 +199,11 @@ func (ltc *LocalTestCluster) Start(t testing.TB, initFactory InitFactoryFn) {
 		Stopper:                 ltc.stopper,
 		Clock:                   cfg.Clock,
 		Storage:                 liveness.NewKVStorage(cfg.DB),
-		Gossip:                  cfg.Gossip,
+		Cache:                   liveness.NewCache(cfg.Gossip, cfg.Clock, cfg.Settings, cfg.NodeDialer),
 		LivenessThreshold:       active,
 		RenewalDuration:         renewal,
-		Settings:                cfg.Settings,
 		HistogramWindowInterval: cfg.HistogramWindowInterval,
 		Engines:                 []storage.Engine{ltc.Eng},
-		NodeDialer:              cfg.NodeDialer,
 	})
 	liveness.TimeUntilNodeDead.Override(ctx, &cfg.Settings.SV, liveness.TestTimeUntilNodeDead)
 	nodeCountFn := func() int {


### PR DESCRIPTION
This commit creates the liveness cache earlier in the process of NodeLiveness construction. Creating the liveness cache before the rest of NodeLiveness
removes the eircular dependency between DistSender which requires the liveness cache and NodeLiveness.storage which requires DistSender to read and write Liveness records.

Epic: none

Release note: None