### PR TITLE
server: wait for active configuration profiles during startup

### DIFF
--- a/pkg/server/autoconfig/acprovider/provider.go
+++ b/pkg/server/autoconfig/acprovider/provider.go
@@ -26,8 +26,9 @@ type Provider interface {
 	// initial event immediately.
 	EnvUpdate() <-chan struct{}
 
-	// ActiveEnvironments returns the IDs of environments that have
-	// tasks available for execution.
+	// ActiveEnvironments returns the IDs of environments that
+	// have tasks available for execution. A nil or empty array is
+	// returned when there are no more tasks to run.
 	ActiveEnvironments() []autoconfigpb.EnvironmentID
 
 	// Peek will block waiting for the first task the provider believes

--- a/pkg/server/testing_knobs.go
+++ b/pkg/server/testing_knobs.go
@@ -172,6 +172,11 @@ type TestingKnobs struct {
 	// // TODO(ahmad/healthy-pod): Remove this once `v23.2` is cut and update `TestTenantAutoUpgrade`
 	// to reflect the changes.
 	AllowTenantAutoUpgradeOnInternalVersionChanges bool
+
+	// If non-nil, AutoConfigProfileStartupWaitTime is used when
+	// waiting for any active configuration environments to
+	// complete their tasks.
+	AutoConfigProfileStartupWaitTime *time.Duration
 }
 
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.


### PR DESCRIPTION
Before, we did not wait for these configuration profiles at startup. This produces confusing behaviour where the behaviour of the cluster changes substantially a few moments after startup.

For instance the replication-source configuration profile runs

  SET CLUSTER SETTING server.controller.default_target_cluster = 'application'

If this is delayed until after we start accepting connections, then for a few moments new connections will go to the system tenant and then afterwards they will go to the application tenant.

Here, we narrow the window of confusion by waiting for the configuration profiles to be complete during the preStart sequence in SQL.

Note that this doesn't solve startup coordination. There are still at least two problems:

1. Async server startup still means the user may get an error for a few moments after startup until the server is started.

2. Async settings propagation still means that the default_target_cluster setting can still be delayed.

Informs #111637

Release note: None