### PR TITLE
roachtest: fix js install command (gpg)

### DIFF
--- a/pkg/cmd/roachtest/tests/knex.go
+++ b/pkg/cmd/roachtest/tests/knex.go
@@ -59,30 +59,39 @@ func registerKnex(r registry.Registry) {
 		)
 		require.NoError(t, err)
 
-		err = repeatRunE(
-			ctx,
-			t,
-			c,
-			node,
-			"add nodesource key and deb repository",
-			`
+		// In case we are running into a state where machines are being reused, we first check to see if we
+		// can use npm to reduce the potential of trying to add another nodesource key
+		// (preventing gpg: dearmoring failed: File exists) errors.
+		err = c.RunE(
+			ctx, node, `sudo npm i -g npm`,
+		)
+
+		if err != nil {
+			err = repeatRunE(
+				ctx,
+				t,
+				c,
+				node,
+				"add nodesource key and deb repository",
+				`
 sudo apt-get update && \
 sudo apt-get install -y ca-certificates curl gnupg && \
 sudo mkdir -p /etc/apt/keyrings && \
-curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
+curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --batch --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
 echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list`,
-		)
-		require.NoError(t, err)
+			)
+			require.NoError(t, err)
 
-		err = repeatRunE(
-			ctx, t, c, node, "install nodejs and npm", `sudo apt-get update && sudo apt-get -qq install nodejs`,
-		)
-		require.NoError(t, err)
+			err = repeatRunE(
+				ctx, t, c, node, "install nodejs and npm", `sudo apt-get update && sudo apt-get -qq install nodejs`,
+			)
+			require.NoError(t, err)
 
-		err = repeatRunE(
-			ctx, t, c, node, "update npm", `sudo npm i -g npm`,
-		)
-		require.NoError(t, err)
+			err = repeatRunE(
+				ctx, t, c, node, "update npm", `sudo npm i -g npm`,
+			)
+			require.NoError(t, err)
+		}
 
 		err = repeatRunE(
 			ctx, t, c, node, "install mocha", `sudo npm i -g mocha`,

--- a/pkg/cmd/roachtest/tests/nodejs_postgres.go
+++ b/pkg/cmd/roachtest/tests/nodejs_postgres.go
@@ -67,30 +67,39 @@ func registerNodeJSPostgres(r registry.Registry) {
 		err = alterZoneConfigAndClusterSettings(ctx, t, version, c, node[0])
 		require.NoError(t, err)
 
-		err = repeatRunE(
-			ctx,
-			t,
-			c,
-			node,
-			"add nodesource key and deb repository",
-			`
+		// In case we are running into a state where machines are being reused, we first check to see if we
+		// can use npm to reduce the potential of trying to add another nodesource key
+		// (preventing gpg: dearmoring failed: File exists) errors.
+		err = c.RunE(
+			ctx, node, `sudo npm i -g npm`,
+		)
+
+		if err != nil {
+			err = repeatRunE(
+				ctx,
+				t,
+				c,
+				node,
+				"add nodesource key and deb repository",
+				`
 sudo apt-get update && \
 sudo apt-get install -y ca-certificates curl gnupg && \
 sudo mkdir -p /etc/apt/keyrings && \
-curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
+curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --batch --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
 echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list`,
-		)
-		require.NoError(t, err)
+			)
+			require.NoError(t, err)
 
-		err = repeatRunE(
-			ctx, t, c, node, "install nodejs and npm", `sudo apt-get update && sudo apt-get -qq install nodejs`,
-		)
-		require.NoError(t, err)
+			err = repeatRunE(
+				ctx, t, c, node, "install nodejs and npm", `sudo apt-get update && sudo apt-get -qq install nodejs`,
+			)
+			require.NoError(t, err)
 
-		err = repeatRunE(
-			ctx, t, c, node, "update npm", `sudo npm i -g npm`,
-		)
-		require.NoError(t, err)
+			err = repeatRunE(
+				ctx, t, c, node, "update npm", `sudo npm i -g npm`,
+			)
+			require.NoError(t, err)
+		}
 
 		err = repeatRunE(
 			ctx, t, c, node, "install yarn", `sudo npm i -g yarn`,

--- a/pkg/cmd/roachtest/tests/sequelize.go
+++ b/pkg/cmd/roachtest/tests/sequelize.go
@@ -93,32 +93,39 @@ func registerSequelize(r registry.Registry) {
 			t.Fatal(err)
 		}
 
-		if err := repeatRunE(
-			ctx,
-			t,
-			c,
-			node,
-			"add nodesource key and deb repository",
-			`
+		// In case we are running into a state where machines are being reused, we first check to see if we
+		// can use npm to reduce the potential of trying to add another nodesource key
+		// (preventing gpg: dearmoring failed: File exists) errors.
+		if err := c.RunE(
+			ctx, node, `sudo npm i -g npm`,
+		); err != nil {
+			if err := repeatRunE(
+				ctx,
+				t,
+				c,
+				node,
+				"add nodesource key and deb repository",
+				`
 sudo apt-get update && \
 sudo apt-get install -y ca-certificates curl gnupg && \
 sudo mkdir -p /etc/apt/keyrings && \
-curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
+curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --batch --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
 echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list`,
-		); err != nil {
-			t.Fatal(err)
-		}
+			); err != nil {
+				t.Fatal(err)
+			}
 
-		if err := repeatRunE(
-			ctx, t, c, node, "install nodejs and npm", `sudo apt-get update && sudo apt-get -qq install nodejs`,
-		); err != nil {
-			t.Fatal(err)
-		}
+			if err := repeatRunE(
+				ctx, t, c, node, "install nodejs and npm", `sudo apt-get update && sudo apt-get -qq install nodejs`,
+			); err != nil {
+				t.Fatal(err)
+			}
 
-		if err := repeatRunE(
-			ctx, t, c, node, "update npm", `sudo npm i -g npm`,
-		); err != nil {
-			t.Fatal(err)
+			if err := repeatRunE(
+				ctx, t, c, node, "update npm", `sudo npm i -g npm`,
+			); err != nil {
+				t.Fatal(err)
+			}
 		}
 
 		if err := repeatRunE(

--- a/pkg/cmd/roachtest/tests/typeorm.go
+++ b/pkg/cmd/roachtest/tests/typeorm.go
@@ -89,32 +89,39 @@ func registerTypeORM(r registry.Registry) {
 			t.Fatal(err)
 		}
 
-		if err := repeatRunE(
-			ctx,
-			t,
-			c,
-			node,
-			"add nodesource key and deb repository",
-			`
+		// In case we are running into a state where machines are being reused, we first check to see if we
+		// can use npm to reduce the potential of trying to add another nodesource key
+		// (preventing gpg: dearmoring failed: File exists) errors.
+		if err := c.RunE(
+			ctx, node, `sudo npm i -g npm`,
+		); err != nil {
+			if err := repeatRunE(
+				ctx,
+				t,
+				c,
+				node,
+				"add nodesource key and deb repository",
+				`
 sudo apt-get update && \
 sudo apt-get install -y ca-certificates curl gnupg && \
 sudo mkdir -p /etc/apt/keyrings && \
-curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
+curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --batch --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
 echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list`,
-		); err != nil {
-			t.Fatal(err)
-		}
+			); err != nil {
+				t.Fatal(err)
+			}
 
-		if err := repeatRunE(
-			ctx, t, c, node, "install nodejs and npm", `sudo apt-get update && sudo apt-get -qq install nodejs`,
-		); err != nil {
-			t.Fatal(err)
-		}
+			if err := repeatRunE(
+				ctx, t, c, node, "install nodejs and npm", `sudo apt-get update && sudo apt-get -qq install nodejs`,
+			); err != nil {
+				t.Fatal(err)
+			}
 
-		if err := repeatRunE(
-			ctx, t, c, node, "update npm", `sudo npm i -g npm`,
-		); err != nil {
-			t.Fatal(err)
+			if err := repeatRunE(
+				ctx, t, c, node, "update npm", `sudo npm i -g npm`,
+			); err != nil {
+				t.Fatal(err)
+			}
 		}
 
 		if err := repeatRunE(


### PR DESCRIPTION
We are seeing a `gpg: cannot open '/dev/tty': No such device or address` error from the new installation method we followed. Resolution seems to be https://github.com/nodejs/docker-node/issues/922.

In case we are running into an issue with machines being reused, we
first check to see if we can install nodejs and npm before we add
a nodesource key and deb repository (to prevent gpg: dearmoring failed:
File exists) issues.

(Copied from a reply to the bug report in the issue linked above)
> For any script use you should anyway use --batch which disables the use
of the tty as a side-effect.

Fixes: #113673
Fixes: #113662
Fixes: #113659
Fixes: #113675
Fixes: #113677
Fixes: #113762

Release note: None