### PR TITLE
roachtest: fix qps parse in kvrestart test

### DIFF
--- a/pkg/cmd/roachtest/tests/kv.go
+++ b/pkg/cmd/roachtest/tests/kv.go
@@ -924,13 +924,13 @@ func measureQPS(
 			db := db
 			go func() {
 				defer wg.Done()
-				var v uint64
+				var v float64
 				if err := db.QueryRowContext(
 					ctx, `SELECT value FROM crdb_internal.node_metrics WHERE name = 'sql.insert.count'`,
 				).Scan(&v); err != nil {
 					t.Fatal(err)
 				}
-				atomic.AddUint64(&value, v)
+				atomic.AddUint64(&value, uint64(v))
 			}()
 		}
 		wg.Wait()


### PR DESCRIPTION
The `kv/restart/nodes=12` test could fail when failing to parse the QPS metric value into a uint64. Parse as a float64, then later convert.

Epic: none
Release note: None