### PR TITLE
server: option to wait for default_target_cluster on connect

### DIFF
--- a/pkg/multitenant/tenant_config.go
+++ b/pkg/multitenant/tenant_config.go
@@ -43,22 +43,12 @@ var VerifyTenantService = settings.RegisterBoolSetting(
 	settings.WithName(DefaultClusterSelectSettingName+".check_service.enabled"),
 )
 
-// WaitForClusterStart, if enabled, instructs the tenant controller to
-// wait up to WaitForClusterStartTimeout for the defuault virtual
-// cluster to have an active SQL server.
-var WaitForClusterStart = settings.RegisterBoolSetting(
-	settings.SystemOnly,
-	"server.controller.mux_virtual_cluster_wait.enabled",
-	"wait up to server.controller_mux_virtual_cluster_wait.timeout for the default virtual cluster to become available for SQL connections",
-	false,
-)
-
-// WaitForClusterStartTimeout is the amoutn of time the the tenant
+// WaitForClusterStartTimeout is the amount of time the tenant
 // controller will wait for the default virtual cluster to have an
-// active SQL server, if WaitForClusterStart is true.
+// active SQL server.
 var WaitForClusterStartTimeout = settings.RegisterDurationSetting(
 	settings.SystemOnly,
 	"server.controller.mux_virtual_cluster_wait.timeout",
-	"amount of time to wait for a default virtual cluster to become available when serving SQL connections",
+	"amount of time to wait for a default virtual cluster to become available when serving SQL connections (0 to disable)",
 	10*time.Second,
 )

--- a/pkg/multitenant/tenant_config.go
+++ b/pkg/multitenant/tenant_config.go
@@ -11,6 +11,8 @@
 package multitenant
 
 import (
+	"time"
+
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catconstants"
 )
@@ -39,4 +41,24 @@ var VerifyTenantService = settings.RegisterBoolSetting(
 	"verify that the service mode is coherently set with the value of "+DefaultClusterSelectSettingName,
 	true,
 	settings.WithName(DefaultClusterSelectSettingName+".check_service.enabled"),
+)
+
+// WaitForClusterStart, if enabled, instructs the tenant controller to
+// wait up to WaitForClusterStartTimeout for the defuault virtual
+// cluster to have an active SQL server.
+var WaitForClusterStart = settings.RegisterBoolSetting(
+	settings.SystemOnly,
+	"server.controller.mux_virtual_cluster_wait.enabled",
+	"wait up to server.controller_mux_virtual_cluster_wait.timeout for the default virtual cluster to become available for SQL connections",
+	false,
+)
+
+// WaitForClusterStartTimeout is the amoutn of time the the tenant
+// controller will wait for the default virtual cluster to have an
+// active SQL server, if WaitForClusterStart is true.
+var WaitForClusterStartTimeout = settings.RegisterDurationSetting(
+	settings.SystemOnly,
+	"server.controller.mux_virtual_cluster_wait.timeout",
+	"amount of time to wait for a default virtual cluster to become available when serving SQL connections",
+	10*time.Second,
 )

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -331,6 +331,7 @@ go_library(
         "//pkg/util/stop",
         "//pkg/util/strutil",
         "//pkg/util/syncutil",
+        "//pkg/util/syncutil/singleflight",
         "//pkg/util/sysutil",
         "//pkg/util/timeutil",
         "//pkg/util/timeutil/ptp",

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -4046,7 +4046,7 @@ func (s *systemAdminServer) ListTenants(
 
 	tenantList := make([]*serverpb.Tenant, 0, len(tenantNames))
 	for _, tenantName := range tenantNames {
-		server, err := s.server.serverController.getServer(ctx, tenantName)
+		server, _, err := s.server.serverController.getServer(ctx, tenantName)
 		if err != nil {
 			if errors.Is(err, errNoTenantServerRunning) {
 				// The service for this tenant is not started yet. This is not

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1235,7 +1235,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterf
 		// https://github.com/cockroachdb/cockroach/issues/84585 is
 		// implemented.
 		func(ctx context.Context, name roachpb.TenantName) error {
-			d, err := sc.getServer(ctx, name)
+			d, _, err := sc.getServer(ctx, name)
 			if err != nil {
 				return err
 			}

--- a/pkg/server/server_controller.go
+++ b/pkg/server/server_controller.go
@@ -105,6 +105,10 @@ type serverController struct {
 		// nextServerIdx is the index to provide to the next call to
 		// newServerFn.
 		nextServerIdx int
+
+		// newServerCh is closed anytime a server is added to
+		// the servers list.
+		newServerCh chan struct{}
 	}
 }
 
@@ -138,6 +142,7 @@ func newServerController(
 		catconstants.SystemTenantName: c.orchestrator.makeServerStateForSystemTenant(systemTenantNameContainer, systemServer),
 	}
 	c.mu.testArgs = make(map[roachpb.TenantName]base.TestSharedProcessTenantArgs)
+	c.mu.newServerCh = make(chan struct{})
 	parentStopper.AddCloser(c)
 	return c
 }

--- a/pkg/server/server_controller.go
+++ b/pkg/server/server_controller.go
@@ -91,7 +91,7 @@ type serverController struct {
 	watcher *tenantcapabilitieswatcher.Watcher
 
 	mu struct {
-		syncutil.Mutex
+		syncutil.RWMutex
 
 		// servers maps tenant names to the server for that tenant.
 		//

--- a/pkg/server/server_controller_accessors.go
+++ b/pkg/server/server_controller_accessors.go
@@ -18,18 +18,26 @@ import (
 )
 
 // getServer retrieves a reference to the current server for the given
-// tenant name.
+// tenant name. The returned channel is closed if a new tenant is
+// added to the running tenants or if the requested tenant becomes
+// available. It can be used by the caller to wait for the server to
+// become available.
 func (c *serverController) getServer(
 	ctx context.Context, tenantName roachpb.TenantName,
-) (onDemandServer, error) {
+) (onDemandServer, <-chan struct{}, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if e, ok := c.mu.servers[tenantName]; ok {
 		if so, isReady := e.getServer(); isReady {
-			return so.(onDemandServer), nil
+			return so.(onDemandServer), c.mu.newServerCh, nil
+		} else {
+			// If we have a server but it isn't ready yet,
+			// return the startedOrStopped entry for the
+			// channel for the caller to poll on.
+			return nil, e.startedOrStopped(), errors.Mark(errors.Newf("server for tenant %q not ready", tenantName), errNoTenantServerRunning)
 		}
 	}
-	return nil, errors.Mark(errors.Newf("no server for tenant %q", tenantName), errNoTenantServerRunning)
+	return nil, c.mu.newServerCh, errors.Mark(errors.Newf("no server for tenant %q", tenantName), errNoTenantServerRunning)
 }
 
 type noTenantServerRunning struct{}

--- a/pkg/server/server_controller_accessors.go
+++ b/pkg/server/server_controller_accessors.go
@@ -25,8 +25,8 @@ import (
 func (c *serverController) getServer(
 	ctx context.Context, tenantName roachpb.TenantName,
 ) (onDemandServer, <-chan struct{}, error) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
+	c.mu.RLock()
+	defer c.mu.RUnlock()
 	if e, ok := c.mu.servers[tenantName]; ok {
 		if so, isReady := e.getServer(); isReady {
 			return so.(onDemandServer), c.mu.newServerCh, nil
@@ -49,8 +49,8 @@ var errNoTenantServerRunning error = noTenantServerRunning{}
 // getServers retrieves all the currently instantiated and running
 // in-memory servers.
 func (c *serverController) getServers() (res []onDemandServer) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
+	c.mu.RLock()
+	defer c.mu.RUnlock()
 	for _, e := range c.mu.servers {
 		so, isReady := e.getServer()
 		if !isReady {
@@ -65,8 +65,8 @@ func (c *serverController) getServers() (res []onDemandServer) {
 // already have a tenant server running.
 func (c *serverController) getCurrentTenantNames() []roachpb.TenantName {
 	var serverNames []roachpb.TenantName
-	c.mu.Lock()
-	defer c.mu.Unlock()
+	c.mu.RLock()
+	defer c.mu.RUnlock()
 	for name, e := range c.mu.servers {
 		if _, isReady := e.getServer(); !isReady {
 			continue

--- a/pkg/server/server_controller_http.go
+++ b/pkg/server/server_controller_http.go
@@ -81,7 +81,7 @@ func (c *serverController) httpMux(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	tenantName := getTenantNameFromHTTPRequest(c.st, r)
-	s, err := c.getServer(ctx, tenantName)
+	s, _, err := c.getServer(ctx, tenantName)
 	if err != nil {
 		log.Warningf(ctx, "unable to find server for tenant %q: %v", tenantName, err)
 		// Clear session and tenant cookies since it appears they reference invalid state.
@@ -105,7 +105,7 @@ func (c *serverController) httpMux(w http.ResponseWriter, r *http.Request) {
 		// get into a state where they cannot load DB Console assets at all due to invalid
 		// cookies.
 		defaultTenantName := roachpb.TenantName(multitenant.DefaultTenantSelect.Get(&c.st.SV))
-		s, err = c.getServer(ctx, defaultTenantName)
+		s, _, err = c.getServer(ctx, defaultTenantName)
 		if err != nil {
 			log.Warningf(ctx, "unable to find server for default tenant %q: %v", defaultTenantName, err)
 			w.WriteHeader(http.StatusInternalServerError)
@@ -169,7 +169,7 @@ func (c *serverController) attemptLoginToAllTenants() http.Handler {
 		redirectLocation := "/" // default to home page
 		collectedErrors := make([]string, len(tenantNames))
 		for i, name := range tenantNames {
-			server, err := c.getServer(ctx, name)
+			server, _, err := c.getServer(ctx, name)
 			if err != nil {
 				if errors.Is(err, errNoTenantServerRunning) {
 					// Server has stopped after the call to
@@ -301,7 +301,7 @@ func (c *serverController) attemptLogoutFromAllTenants() http.Handler {
 			return
 		}
 		for _, name := range tenantNames {
-			server, err := c.getServer(ctx, name)
+			server, _, err := c.getServer(ctx, name)
 			if err != nil {
 				if errors.Is(err, errNoTenantServerRunning) {
 					// Server has stopped after the call to

--- a/pkg/server/server_controller_orchestration.go
+++ b/pkg/server/server_controller_orchestration.go
@@ -176,7 +176,10 @@ func (c *serverController) createServerEntryLocked(
 	if err != nil {
 		return nil, err
 	}
+
 	c.mu.servers[tenantName] = entry
+	close(c.mu.newServerCh)
+	c.mu.newServerCh = make(chan struct{})
 	return entry, nil
 }
 

--- a/pkg/server/server_controller_orchestration.go
+++ b/pkg/server/server_controller_orchestration.go
@@ -310,8 +310,8 @@ func (c *serverController) drain(ctx context.Context) (stillRunning int) {
 }
 
 func (c *serverController) getAllEntries() (res map[roachpb.TenantName]serverState) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
+	c.mu.RLock()
+	defer c.mu.RUnlock()
 	res = make(map[roachpb.TenantName]serverState, len(c.mu.servers))
 	for name, e := range c.mu.servers {
 		res[name] = e

--- a/pkg/server/server_controller_sql.go
+++ b/pkg/server/server_controller_sql.go
@@ -110,7 +110,7 @@ func (c *serverController) shouldWaitForTenantServer(name roachpb.TenantName) bo
 		return false
 	}
 
-	return multitenant.WaitForClusterStart.Get(&c.st.SV)
+	return multitenant.WaitForClusterStartTimeout.Get(&c.st.SV) > 0
 }
 
 func (c *serverController) waitForTenantServer(

--- a/pkg/server/server_controller_test.go
+++ b/pkg/server/server_controller_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
@@ -138,7 +139,9 @@ func TestServerControllerWaitForDefaultCluster(t *testing.T) {
 	defer s.Stopper().Stop(ctx)
 
 	sqlRunner := sqlutils.MakeSQLRunner(db)
-	sqlRunner.Exec(t, "SET CLUSTER SETTING server.controller.mux_virtual_cluster_wait.enabled = true")
+	if util.RaceEnabled {
+		sqlRunner.Exec(t, "SET CLUSTER SETTING server.controller.mux_virtual_cluster_wait.timeout = '1m'")
+	}
 
 	tryConnect := func() error {
 		conn, err := s.SystemLayer().SQLConnE(serverutils.DBName("cluster:hello"))

--- a/pkg/server/server_controller_test.go
+++ b/pkg/server/server_controller_test.go
@@ -43,20 +43,20 @@ func TestServerController(t *testing.T) {
 	sc := s.TenantController().ServerController().(*serverController)
 	ts := s.SystemLayer().(*testServer)
 
-	d, err := sc.getServer(ctx, "system")
+	d, _, err := sc.getServer(ctx, "system")
 	require.NoError(t, err)
 	if d.(*systemServerWrapper).server != ts.topLevelServer {
 		t.Fatal("expected wrapped system server")
 	}
 
-	d, err = sc.getServer(ctx, "somename")
+	d, _, err = sc.getServer(ctx, "somename")
 	require.Nil(t, d)
 	require.Error(t, err, `no tenant found with name "somename"`)
 
 	_, err = db.Exec("CREATE TENANT hello; ALTER TENANT hello START SERVICE SHARED")
 	require.NoError(t, err)
 
-	_, err = sc.getServer(ctx, "hello")
+	_, _, err = sc.getServer(ctx, "hello")
 	// TODO(knz): We're not really expecting an error here.
 	// The actual error seen will exist as long as in-memory
 	// servers use the standard KV connector.


### PR DESCRIPTION
Virtual cluster startup is asynchronous. As a result, it can be hard to
orchestrate bringing a virtual cluster up since the client needs to
retry until the cluster is available.

This makes it a little easier by optionally allowing connections to
the default_target_cluster to be held until the cluster is online.

As a result, a user who does:

    ALTER VIRTUAL CLUSTER app START SERVICE SHARED
    SET CLUSTER SETTING server.controller.default_target_cluster = 'app'

Should be able to immediately connect to the same node without having
to handle retries while the virtual cluster starts up.

Note that we can extend this to wait for _any_
tenant. The restriction on only waiting on the default_target_cluster
is that we need to thread a little state into the server controller in
order to avoid pitfalls such as holding a lot of connections open for
longer than needed for a tenant that will never become available
because it doesn't exist.

In a future PR, we will set this option by default in the replication-source and replication-target
configuration profiles.

Built on #113666

Informs https://github.com/cockroachdb/cockroach/issues/111637

Release note: None