### PR TITLE
tree: make SET TRANSACTION a walkable statement

### DIFF
--- a/pkg/sql/pgwire/testdata/pgtest/set_transaction
+++ b/pkg/sql/pgwire/testdata/pgtest/set_transaction
@@ -1,0 +1,39 @@
+# This test relies on a CoockroachDB-specific feature, so everything
+# is marked as crdb_only.
+
+only crdb
+----
+
+send
+Query {"String": "BEGIN"}
+----
+
+until
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"BEGIN"}
+{"Type":"ReadyForQuery","TxStatus":"T"}
+
+send
+Parse {"Query": "SET TRANSACTION AS OF SYSTEM TIME $1::timestamp"}
+Bind {"Parameters": [{"text":"2019-01-01 00:00:00"}]}
+Execute
+Sync
+Query {"String": "SELECT now()"}
+Query {"String": "COMMIT"}
+----
+
+until ignore=RowDescription
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"CommandComplete","CommandTag":"SET TRANSACTION"}
+{"Type":"ReadyForQuery","TxStatus":"T"}
+{"Type":"DataRow","Values":[{"text":"2019-01-01 00:00:00+00"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 1"}
+{"Type":"ReadyForQuery","TxStatus":"T"}
+{"Type":"CommandComplete","CommandTag":"COMMIT"}
+{"Type":"ReadyForQuery","TxStatus":"I"}

--- a/pkg/sql/sem/tree/set.go
+++ b/pkg/sql/sem/tree/set.go
@@ -103,6 +103,25 @@ func (node *SetTransaction) Format(ctx *FmtCtx) {
 	ctx.FormatNode(&node.Modes)
 }
 
+// copyNode makes a copy of this Statement.
+func (stmt *SetTransaction) copyNode() *SetTransaction {
+	stmtCopy := *stmt
+	return &stmtCopy
+}
+
+// walkStmt is part of the walkableStmt interface.
+func (stmt *SetTransaction) walkStmt(v Visitor) Statement {
+	ret := stmt
+	if stmt.Modes.AsOf.Expr != nil {
+		e, changed := WalkExpr(v, stmt.Modes.AsOf.Expr)
+		if changed {
+			ret = stmt.copyNode()
+			ret.Modes.AsOf.Expr = e
+		}
+	}
+	return ret
+}
+
 // SetSessionAuthorizationDefault represents a SET SESSION AUTHORIZATION DEFAULT
 // statement. This can be extended (and renamed) if we ever support names in the
 // last position.

--- a/pkg/sql/sem/tree/walk.go
+++ b/pkg/sql/sem/tree/walk.go
@@ -2039,6 +2039,7 @@ var _ walkableStmt = &Restore{}
 var _ walkableStmt = &SelectClause{}
 var _ walkableStmt = &Select{}
 var _ walkableStmt = &SetClusterSetting{}
+var _ walkableStmt = &SetTransaction{}
 var _ walkableStmt = &SetVar{}
 var _ walkableStmt = &ShowFingerprints{}
 var _ walkableStmt = &ShowTenantClusterSetting{}


### PR DESCRIPTION
SET TRANSACTION is now a walkable statement. This fixes a bug where
placeholders in a SET TRANSACTION statement were not resolved correctly.

The statement must be walkable for the placeholderAnnotationVisitor to
work correctly -- it is an AST visitor that relies on walkStmt to
discover all placeholders in a statement.

https://github.com/cockroachdb/cockroach/blob/536ff945690b7e99015e4d318b0a6f6ca50a0424/pkg/sql/sem/tree/type_check.go#L3324-L3341

Epic: None
Release note (bug fix): Placeholder arguments can now be used in SET TRANSACTION statements.