### PR TITLE
workload: don't add errored writes or span queries to histogram

### DIFF
--- a/pkg/workload/kv/kv.go
+++ b/pkg/workload/kv/kv.go
@@ -643,6 +643,9 @@ func (o *kvOp) run(ctx context.Context) (retErr error) {
 		} else {
 			_, err = o.spanStmt.Exec(ctx)
 		}
+		if err != nil {
+			return err
+		}
 		elapsed := timeutil.Since(start)
 		o.hists.Get(`span`).Record(elapsed)
 		return err
@@ -699,6 +702,9 @@ func (o *kvOp) run(ctx context.Context) (retErr error) {
 		}
 	} else {
 		_, err = o.writeStmt.Exec(ctx, writeArgs...)
+	}
+	if err != nil {
+		return err
 	}
 	elapsed := timeutil.Since(start)
 	o.hists.Get(`write`).Record(elapsed)


### PR DESCRIPTION
Previously, errored read queries in the kv workload would not count towards the histogram and would not affect tracked metrics like ops/sec, however write statements that returned errors were counted. This change eliminates this inconsistency by having both reads and writes not update the histogram in case of error. Span queries were also erroneously counted previously, so that's fixed now too.

Epic: none

Release note: None