### PR TITLE
version skipping WIP

### DIFF
--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cli/clisqlexec"
 	"github.com/cockroachdb/cockroach/pkg/cli/clisqlshell"
 	"github.com/cockroachdb/cockroach/pkg/cli/democluster"
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security/clientsecopts"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
@@ -33,6 +34,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/ts"
+	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log/logconfig"
 	"github.com/cockroachdb/cockroach/pkg/util/log/logcrash"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -90,18 +92,32 @@ func clearFlagChanges(cmd *cobra.Command) {
 //
 // See below for defaults.
 var serverCfg = func() server.Config {
-	st := cluster.MakeClusterSettings()
-	logcrash.SetGlobalSettings(&st.SV)
-
+	st := makeClusterSettings()
 	return server.MakeConfig(context.Background(), st)
 }()
+
+func makeClusterSettings() *cluster.Settings {
+	// Even though the code supports upgrading from multiple previous releases,
+	// skipping versions is experimental; by default, we only allow upgrading from
+	// the previous release.
+	//
+	// Version skipping can be enabled by setting COCKROACH_ALLOW_VERSION_SKIPPING=1.
+	var minSupported clusterversion.Key
+	if envutil.EnvOrDefaultBool("COCKROACH_ALLOW_VERSION_SKIPPING", false) {
+		minSupported = clusterversion.MinSupported
+	} else {
+		minSupported = clusterversion.PreviousRelease
+	}
+	st := cluster.MakeClusterSettingsWithVersions(clusterversion.Latest.Version(), minSupported.Version())
+	logcrash.SetGlobalSettings(&st.SV)
+	return st
+}
 
 // setServerContextDefaults set the default values in serverCfg.  This
 // function is called by initCLIDefaults() and thus re-called in every
 // test that exercises command-line parsing.
 func setServerContextDefaults() {
-	st := cluster.MakeClusterSettings()
-	logcrash.SetGlobalSettings(&st.SV)
+	st := makeClusterSettings()
 	serverCfg.SetDefaults(context.Background(), st)
 
 	serverCfg.TenantKVAddrs = []string{"127.0.0.1:26257"}

--- a/pkg/clusterversion/clusterversion.go
+++ b/pkg/clusterversion/clusterversion.go
@@ -167,19 +167,12 @@ type handleImpl struct {
 
 var _ Handle = (*handleImpl)(nil)
 
-// MakeVersionHandle returns a Handle that has its latest and minimum supported
-// versions initialized to this binary's build and its minimum supported
-// versions respectively.
-func MakeVersionHandle(sv *settings.Values) Handle {
-	return MakeVersionHandleWithOverride(sv, Latest.Version(), MinSupported.Version())
-}
-
-// MakeVersionHandleWithOverride returns a Handle that has its
-// binary and minimum supported versions initialized to the provided versions.
+// MakeVersionHandle returns a Handle that has its binary and minimum supported
+// versions initialized to the provided versions.
 //
 // It's typically used in tests that want to override the default binary and
 // minimum supported versions.
-func MakeVersionHandleWithOverride(
+func MakeVersionHandle(
 	sv *settings.Values, latestVersion, minSupportedVersion roachpb.Version,
 ) Handle {
 	return newHandleImpl(version, sv, latestVersion, minSupportedVersion)

--- a/pkg/server/profiler/BUILD.bazel
+++ b/pkg/server/profiler/BUILD.bazel
@@ -43,7 +43,6 @@ go_test(
     args = ["-test.timeout=55s"],
     embed = [":profiler"],
     deps = [
-        "//pkg/clusterversion",
         "//pkg/server/dumpstore",
         "//pkg/settings/cluster",
         "//pkg/util/timeutil",

--- a/pkg/server/profiler/activequeryprofiler_test.go
+++ b/pkg/server/profiler/activequeryprofiler_test.go
@@ -15,7 +15,6 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/server/dumpstore"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/stretchr/testify/require"
@@ -89,11 +88,8 @@ func TestNewActiveQueryProfiler(t *testing.T) {
 func TestShouldDump(t *testing.T) {
 	ctx := context.Background()
 	createSettingFn := func(settingEnabled bool) *cluster.Settings {
-		s := &cluster.Settings{}
-		sv := &s.SV
-		s.Version = clusterversion.MakeVersionHandle(sv)
-		sv.Init(ctx, s.Version)
-		ActiveQueryDumpsEnabled.Override(ctx, sv, settingEnabled)
+		s := cluster.MakeClusterSettings()
+		ActiveQueryDumpsEnabled.Override(ctx, &s.SV, settingEnabled)
 		return s
 	}
 

--- a/pkg/server/profiler/cpuprofile_test.go
+++ b/pkg/server/profiler/cpuprofile_test.go
@@ -15,7 +15,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/server/dumpstore"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -25,10 +24,8 @@ import (
 func TestCPUProfiler(t *testing.T) {
 	ctx := context.Background()
 	dumpStore := dumpstore.NewStore(t.TempDir(), nil, nil)
-	s := &cluster.Settings{}
+	s := cluster.MakeClusterSettings()
 	sv := &s.SV
-	s.Version = clusterversion.MakeVersionHandle(sv)
-	sv.Init(ctx, s.Version)
 	cpuProfileInterval.Override(ctx, sv, time.Hour)
 	cpuUsageCombined.Override(ctx, sv, 80)
 	pastTime := time.Date(2023, 1, 1, 1, 1, 1, 1, time.UTC)


### PR DESCRIPTION
#### clusterversion: cockroach versions cleanup

This commit cleans up the code and constants in
`cockroach_versions.go`:
 - we separate out the "dev offset" code and improve the
   documentation;
 - we replace the key-to-version slice with a table (array). This
   makes the declaration much cleaner and makes the lookup easier.
 - we replace `ByKey()` with a method, to make the call site less
   messy; e.g. `clusterversion.ByKey(clusterversion.V23_2)` becomes
   `clusterversion.V23_2.Version()`;
 - we deprecate `BinaryMinSupportedVersionKey` in favor of `MinSupported`;
 - we deprecate `BinaryVersionKey` in favor of `Latest`;
 - we remove `roachpb.Version` "constants" in favor of using the
   `Version()` method.

Informs: #112629
Release note: None

#### WIP