### PR TITLE
metamorphic: add MVCC{CheckFor,}AcquireLock operations

### DIFF
--- a/pkg/storage/metamorphic/BUILD.bazel
+++ b/pkg/storage/metamorphic/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "//pkg/base",
         "//pkg/keys",
         "//pkg/kv/kvpb",
+        "//pkg/kv/kvserver/concurrency/lock",
         "//pkg/roachpb",
         "//pkg/settings/cluster",
         "//pkg/storage",


### PR DESCRIPTION
This change adds two new operations to the MVCC metamorphic testing package that were added in #110323. We check for determinism in the storage package by adding these operations to the metamorphic tests as well.

Fixes #109650.

Epic: none

Release note: None