### PR TITLE
opt: remove interface-to-interface assertion

### DIFF
--- a/pkg/sql/opt/xform/physical_props.go
+++ b/pkg/sql/opt/xform/physical_props.go
@@ -59,7 +59,7 @@ func BuildChildPhysicalProps(
 
 	// ScalarExprs don't support required physical properties; don't build
 	// physical properties for them.
-	if _, ok := parent.Child(nth).(opt.ScalarExpr); ok {
+	if opt.IsScalarOp(parent.Child(nth)) {
 		return mem.InternPhysicalProps(&childProps)
 	}
 


### PR DESCRIPTION
This commit removes a type assertion from `opt.Expr` to
`opt.ScalarExpr`, which is fairly expensive. Instead, the cheaper
`opt.IsScalarOp` function is used.

Epic: None

Release note: None
