### PR TITLE
sql/schemachanger: apply admission control to merge phase of backfill

### DIFF
--- a/pkg/sql/backfill/mvcc_index_merger.go
+++ b/pkg/sql/backfill/mvcc_index_merger.go
@@ -386,7 +386,8 @@ func (ibm *IndexBackfillMerger) merge(
 			}
 		}
 		return nil
-	})
+	},
+		isql.WithPriority(admissionpb.BulkNormalPri))
 
 	return err
 }


### PR DESCRIPTION
Previously, when merging indexes as a part of our MVCC-compliant protocol, we did not properly flag the writes with the correct priority. As a result, on certain workloads, creating a secondary index could tank performance. To address this, this patch will set the priority for the writes during the merge phase of the backfill protocol.

Fixes: #113705

Release note (performance): Address performance regression that can
happen when the declarative schema changer is being used to create an
index with a concurrent workload.