### PR TITLE
roachprod: never start cockroach processes concurrently

### DIFF
--- a/pkg/cmd/roachprod/flags.go
+++ b/pkg/cmd/roachprod/flags.go
@@ -334,8 +334,6 @@ Default is "RECURRING '*/15 * * * *' FULL BACKUP '@hourly' WITH SCHEDULE OPTIONS
 	}
 
 	for _, cmd := range []*cobra.Command{startCmd, startInstanceCmd} {
-		cmd.Flags().BoolVar(&startOpts.Sequential,
-			"sequential", startOpts.Sequential, "start nodes sequentially so node IDs match hostnames")
 		cmd.Flags().Int64Var(&startOpts.NumFilesLimit, "num-files-limit", startOpts.NumFilesLimit,
 			"limit the number of files that can be created by the cockroach process")
 	}

--- a/pkg/cmd/roachtest/roachtestutil/clusterupgrade/clusterupgrade.go
+++ b/pkg/cmd/roachtest/roachtestutil/clusterupgrade/clusterupgrade.go
@@ -268,6 +268,10 @@ func RestartNodesWithNewBinary(
 		if err != nil {
 			return err
 		}
+		// Never run init steps when restarting -- these should already
+		// have happened by the time the cluster was first bootstrapped
+		// and trying to run them again just adds noise to the logs.
+		startOpts.RoachprodOpts.SkipInit = true
 		if err := StartWithSettings(
 			ctx, l, c, c.Node(node), startOpts, append(settings, install.BinaryOption(binary))...,
 		); err != nil {

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion.go
@@ -702,7 +702,6 @@ func (s startStep) Run(ctx context.Context, l *logger.Logger, c cluster.Cluster,
 	}
 
 	startOpts := option.DefaultStartOptsNoBackups()
-	startOpts.RoachprodOpts.Sequential = false
 	clusterSettings := append(
 		append([]install.ClusterSettingOption{}, defaultClusterSettings...),
 		install.BinaryOption(binaryPath),

--- a/pkg/cmd/roachtest/tests/admission_control_database_drop.go
+++ b/pkg/cmd/roachtest/tests/admission_control_database_drop.go
@@ -199,7 +199,6 @@ func registerDatabaseDrop(r registry.Registry) {
 				start: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 					c.Put(ctx, t.Cockroach(), "./cockroach", c.All())
 					startOpts := option.DefaultStartOptsNoBackups()
-					startOpts.RoachprodOpts.Sequential = false // the cluster's already bootstrapped
 					settings := install.MakeClusterSettings(install.NumRacksOption(crdbNodes))
 					if err := c.StartE(ctx, t.L(), startOpts, settings, c.Range(1, crdbNodes)); err != nil {
 						t.Fatal(err)

--- a/pkg/cmd/roachtest/tests/admission_control_index_backfill.go
+++ b/pkg/cmd/roachtest/tests/admission_control_index_backfill.go
@@ -153,7 +153,6 @@ func registerIndexBackfill(r registry.Registry) {
 				start: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 					c.Put(ctx, t.Cockroach(), "./cockroach", c.All())
 					startOpts := option.DefaultStartOptsNoBackups()
-					startOpts.RoachprodOpts.Sequential = false // the cluster's already bootstrapped
 					settings := install.MakeClusterSettings(install.NumRacksOption(crdbNodes))
 					if err := c.StartE(ctx, t.L(), startOpts, settings, c.Range(1, crdbNodes)); err != nil {
 						t.Fatal(err)

--- a/pkg/cmd/roachtest/tests/versionupgrade.go
+++ b/pkg/cmd/roachtest/tests/versionupgrade.go
@@ -275,8 +275,6 @@ func uploadAndStartFromCheckpointFixture(
 		}
 		binary := uploadVersion(ctx, t, u.c, nodes, v)
 		startOpts := option.DefaultStartOpts()
-		// NB: can't start sequentially since cluster already bootstrapped.
-		startOpts.RoachprodOpts.Sequential = false
 		if err := clusterupgrade.StartWithSettings(
 			ctx, t.L(), u.c, nodes, startOpts, install.BinaryOption(binary),
 		); err != nil {
@@ -289,8 +287,6 @@ func uploadAndStart(nodes option.NodeListOption, v *clusterupgrade.Version) vers
 	return func(ctx context.Context, t test.Test, u *versionUpgradeTest) {
 		binary := uploadVersion(ctx, t, u.c, nodes, v)
 		startOpts := option.DefaultStartOpts()
-		// NB: can't start sequentially since cluster already bootstrapped.
-		startOpts.RoachprodOpts.Sequential = false
 		if err := clusterupgrade.StartWithSettings(
 			ctx, t.L(), u.c, nodes, startOpts, install.BinaryOption(binary),
 		); err != nil {

--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -2972,8 +2972,8 @@ func (c *SyncedCluster) Init(ctx context.Context, l *logger.Logger, node Node) e
 		return errors.WithDetail(errors.CombineErrors(err, res.Err), "install.Init() failed: unable to initialize cluster.")
 	}
 
-	if res, err := c.setClusterSettings(ctx, l, node, ""); err != nil || (res != nil && res.Err != nil) {
-		return errors.WithDetail(errors.CombineErrors(err, res.Err), "install.Init() failed: unable to set cluster settings.")
+	if err := c.setClusterSettings(ctx, l, node, ""); err != nil {
+		return errors.WithDetail(err, "install.Init() failed: unable to set cluster settings.")
 	}
 
 	return nil

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -666,7 +666,6 @@ func Extend(l *logger.Logger, clusterName string, lifetime time.Duration) error 
 // DefaultStartOpts returns a StartOpts populated with default values.
 func DefaultStartOpts() install.StartOpts {
 	return install.StartOpts{
-		Sequential:         true,
 		EncryptedStores:    false,
 		NumFilesLimit:      config.DefaultNumFilesLimit,
 		SkipInit:           false,


### PR DESCRIPTION
This changes startup logic to always start cockroach processes sequentially: this ensures that node IDs match hostnames. Previously, we were starting nodes concurrently for upgrade tests because initialization tasks performed by roachprod required quorum.

Fixes: #113384.

Release note: None