### PR TITLE
kvstreamer: adjust recently added tracing

### DIFF
--- a/pkg/kv/kvclient/kvstreamer/results_buffer.go
+++ b/pkg/kv/kvclient/kvstreamer/results_buffer.go
@@ -98,7 +98,7 @@ type resultsBuffer interface {
 	//
 	// It is assumed that the budget's mutex is already being held.
 	//
-	// doneAddingLocked returns the naumber of results that have been added but
+	// doneAddingLocked returns the number of results that have been added but
 	// not yet returned to the client, and whether the client goroutine was woken.
 	doneAddingLocked(context.Context) (int, bool)
 


### PR DESCRIPTION
This commit makes some minor adjustments to the recently added tracing in the streamer:
- `singleRangeBatch.String()` now has a more sane behavior when it contains many requests (previously, we would truncate the requests but would keep everything else, now we include the full information only about the first 5 and the last 5 "sub-requests")
- that method also no longer includes `r.reqsKeys` because this field is redundant with `r.reqs` and is likely to be empty anyway
- the "exit" message in `GetResults` now specifies the number of results and the error if present
- redundant "incomplete Get" and "incomplete Scan" messages are removed (they add very little additional information - the number of incomplete Gets is already printed elsewhere, plus the KV layer already specifies whether each Get / Scan request resulted in a "resume span" meaning it was incomplete).

Epic: None

Release note: None