### PR TITLE
roachtest: remove stale comment in multitenant_distsql

### DIFF
--- a/pkg/cmd/roachtest/tests/multitenant_distsql.go
+++ b/pkg/cmd/roachtest/tests/multitenant_distsql.go
@@ -59,8 +59,6 @@ func runMultiTenantDistSQL(
 	bundle bool,
 	timeoutMillis int,
 ) {
-	// This test fails when runtime assertions are enabled.
-	// See: https://github.com/cockroachdb/cockroach/issues/113170
 	c.Put(ctx, t.Cockroach(), "./cockroach")
 	// This test sets a smaller default range size than the default due to
 	// performance and resource limitations. We set the minimum range max bytes to


### PR DESCRIPTION
The referenced issue has already been addressed.

Epic: None

Release note: None