### PR TITLE
server, cli: make debug zip tolerate corrupted log entries

### DIFF
--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -3267,6 +3267,7 @@ Support status: [reserved](#support-status)
 | Field | Type | Label | Description | Support status |
 | ----- | ---- | ----- | ----------- | -------------- |
 | entries | [cockroach.util.log.Entry](#cockroach.server.serverpb.LogEntriesResponse-cockroach.util.log.Entry) | repeated |  | [reserved](#support-status) |
+| parse_errors | [string](#cockroach.server.serverpb.LogEntriesResponse-string) | repeated | parse_errors contains list of errors that occurred during retrieving individual log entries that don't prevent to return at least partial response. | [reserved](#support-status) |
 
 
 
@@ -3317,6 +3318,7 @@ Support status: [reserved](#support-status)
 | Field | Type | Label | Description | Support status |
 | ----- | ---- | ----- | ----------- | -------------- |
 | entries | [cockroach.util.log.Entry](#cockroach.server.serverpb.LogEntriesResponse-cockroach.util.log.Entry) | repeated |  | [reserved](#support-status) |
+| parse_errors | [string](#cockroach.server.serverpb.LogEntriesResponse-string) | repeated | parse_errors contains list of errors that occurred during retrieving individual log entries that don't prevent to return at least partial response. | [reserved](#support-status) |
 
 
 

--- a/pkg/cli/zip_per_node.go
+++ b/pkg/cli/zip_per_node.go
@@ -16,6 +16,7 @@ import (
 	"net/url"
 	"os"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -471,6 +472,17 @@ func (zc *debugZipContext) collectPerNodeData(
 				}); requestErr != nil {
 				if err := zc.z.createError(sf, name, requestErr); err != nil {
 					return err
+				}
+				// Log out the list of errors that occurred during log entries request.
+				if len(entries.ParseErrors) > 0 {
+					sf.shout("%d parsing errors occurred:", len(entries.ParseErrors))
+					for _, err := range entries.ParseErrors {
+						sf.shout("%s", err)
+					}
+					parseErr := fmt.Errorf("%d errors occurred:\n%s", len(entries.ParseErrors), strings.Join(entries.ParseErrors, "\n"))
+					if err := zc.z.createError(sf, name, parseErr); err != nil {
+						return err
+					}
 				}
 				continue
 			}

--- a/pkg/server/serverpb/status.proto
+++ b/pkg/server/serverpb/status.proto
@@ -668,6 +668,9 @@ message LogsRequest {
 message LogEntriesResponse {
   repeated cockroach.util.log.Entry entries = 1
       [ (gogoproto.nullable) = false ];
+  // parse_errors contains list of errors that occurred during retrieving individual log entries
+  // that don't prevent to return at least partial response.
+  repeated string parse_errors = 2;
 }
 
 message LogFilesListRequest {

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -1315,6 +1315,12 @@ func (s *statusServer) LogFile(
 			if err == io.EOF {
 				break
 			}
+			if errors.Is(err, log.ErrMalformedLogEntry) {
+				resp.ParseErrors = append(resp.ParseErrors, err.Error())
+				// Proceed decoding next entry, as we want to retrieve as much logs
+				// as possible.
+				continue
+			}
 			return nil, srverrors.ServerError(ctx, err)
 		}
 		if tenantIDFilter != "" && entry.TenantID != tenantIDFilter {

--- a/pkg/util/log/format_crdb_v2_test.go
+++ b/pkg/util/log/format_crdb_v2_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log/severity"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/datadriven"
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
 	"github.com/kr/pretty"
 )
@@ -265,6 +266,9 @@ func TestCrdbV2Decode(t *testing.T) {
 					if err := d.Decode(&e); err != nil {
 						if err == io.EOF {
 							break
+						}
+						if errors.Is(err, ErrMalformedLogEntry) {
+							continue
 						}
 						td.Fatalf(t, "error while decoding: %v", err)
 					}

--- a/pkg/util/log/format_json.go
+++ b/pkg/util/log/format_json.go
@@ -14,6 +14,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"sort"
 	"strconv"
 	"strings"
@@ -523,10 +524,10 @@ type jsonCommon struct {
 type JSONEntry struct {
 	jsonCommon
 
-	//Channel         Channel  `json:"channel,omitempty"`
+	// Channel         Channel  `json:"channel,omitempty"`
 	ChannelNumeric int64  `json:"channel_numeric,omitempty"`
 	Timestamp      string `json:"timestamp,omitempty"`
-	//Severity        Severity `json:"severity,omitempty"`
+	// Severity        Severity `json:"severity,omitempty"`
 	SeverityNumeric int64  `json:"severity_numeric,omitempty"`
 	Goroutine       int64  `json:"goroutine,omitempty"`
 	File            string `json:"file,omitempty"`
@@ -545,10 +546,10 @@ type JSONEntry struct {
 type JSONCompactEntry struct {
 	jsonCommon
 
-	//Channel         Channel  `json:"C,omitempty"`
+	// Channel         Channel  `json:"C,omitempty"`
 	ChannelNumeric int64  `json:"c,omitempty"`
 	Timestamp      string `json:"t,omitempty"`
-	//Severity        Severity `json:"sev,omitempty"`
+	// Severity        Severity `json:"sev,omitempty"`
 	SeverityNumeric int64  `json:"s,omitempty"`
 	Goroutine       int64  `json:"g,omitempty"`
 	File            string `json:"f,omitempty"`
@@ -652,12 +653,19 @@ func (e *JSONCompactEntry) toEntry(entry *JSONEntry) {
 }
 
 // Decode decodes the next log entry into the provided protobuf message.
-func (d *entryDecoderJSON) Decode(entry *logpb.Entry) error {
+func (d *entryDecoderJSON) Decode(entry *logpb.Entry) (err error) {
+	defer func() {
+		// Wrap all errors except EOF as a malformed entries to make it easier to
+		// handle this type of error later on.
+		if err != nil && err != io.EOF {
+			err = errors.CombineErrors(ErrMalformedLogEntry, err)
+		}
+	}()
 	var rp *redactablePackage
 	var e JSONEntry
 	if d.compact {
 		var compact JSONCompactEntry
-		err := d.decoder.Decode(&compact)
+		err = d.decoder.Decode(&compact)
 		if err != nil {
 			return err
 		}
@@ -668,7 +676,7 @@ func (d *entryDecoderJSON) Decode(entry *logpb.Entry) error {
 			return err
 		}
 	}
-	rp, err := e.populate(entry, d)
+	rp, err = e.populate(entry, d)
 	if err != nil {
 		return err
 	}

--- a/pkg/util/log/format_json_test.go
+++ b/pkg/util/log/format_json_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log/severity"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/datadriven"
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
 	"github.com/kr/pretty"
 )
@@ -119,7 +120,7 @@ func TestJsonDecode(t *testing.T) {
 				for {
 					var e logpb.Entry
 					if err := d.Decode(&e); err != nil {
-						if err == io.EOF {
+						if err == io.EOF || errors.Is(err, ErrMalformedLogEntry) {
 							break
 						}
 						td.Fatalf(t, "error while decoding: %v", err)

--- a/pkg/util/log/log_decoder.go
+++ b/pkg/util/log/log_decoder.go
@@ -170,3 +170,5 @@ func getLogFormat(data []byte) (string, error) {
 	}
 	return "", errors.New("failed to extract log file format from the log")
 }
+
+var ErrMalformedLogEntry = errors.New("malformed log entry")

--- a/pkg/util/log/testdata/parse
+++ b/pkg/util/log/testdata/parse
@@ -274,3 +274,20 @@ logpb.Entry{Severity:1, Time:1610826557073282000, Goroutine:14, File:"server/nod
 
 
 subtest end
+
+subtest corrupted_log
+
+# Check that entries after corrupted line is parsed.
+log
+.
+I210116 17:49:17.073282-020000 14 server/node.go:464 ⋮ [-] 23  started with engine type ‹2›
+.
+.
+.
+I210116 19:49:17.073282 14 server/node.go:464 ⋮ [-] 23  last line
+----
+logpb.Entry{Severity:1, Time:1610826557073282000, Goroutine:14, File:"server/node.go", Line:464, Message:"started with engine type ‹2›", Tags:"", Counter:0x17, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
+logpb.Entry{Severity:1, Time:1610826557073282000, Goroutine:14, File:"server/node.go", Line:464, Message:"last line", Tags:"", Counter:0x17, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
+
+
+subtest end

--- a/pkg/util/log/testdata/parse_json
+++ b/pkg/util/log/testdata/parse_json
@@ -74,10 +74,17 @@ log format=json
 ----
 logpb.Entry{Severity:2, Time:1136214245654321000, Goroutine:11, File:"util/log/format_json_test.go", Line:123, Message:"‹hello world›", Tags:"‹long=2,noval,s1›", Counter:0x0, Redactable:true, Channel:1, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
 
+# Expected to receive only two records that were decoded before hitting corrupted lines. Decoding stops when first error
+# occurred and returns partial response.
 log format=json
 {"channel_numeric":2,"channel":"HEALTH","timestamp":"1136214245.654321000","version":"v999.0.0","severity_numeric":3,"severity":"ERROR","goroutine":11,"file":"util/log/format_json_test.go","line":123,"entry_counter":0,"redactable":1,"tags":{"noval":"","s":"‹1›","long":"‹2›"},"message":"hello ‹world›"}
+{"channel_numeric":3,"channel":"HEALTH","timestamp":"1136214245.654321000","version":"v999.0.0","severity_numeric":3,"severity":"ERROR","goroutine":11,"file":"util/log/format_json_test.go","line":123,"entry_counter":0,"redactable":1,"tags":{"noval":"","s":"‹1›","long":"‹2›"},"message":"hello ‹world›"}
+a
+b
+{"channel_numeric":4,"channel":"HEALTH","timestamp":"1136214245.654321000","version":"v999.0.0","severity_numeric":3,"severity":"ERROR","goroutine":11,"file":"util/log/format_json_test.go","line":123,"entry_counter":0,"redactable":1,"tags":{"noval":"","s":"‹1›","long":"‹2›"},"message":"hello ‹world›"}
 ----
 logpb.Entry{Severity:3, Time:1136214245654321000, Goroutine:11, File:"util/log/format_json_test.go", Line:123, Message:"hello ‹world›", Tags:"long=‹2›,noval,s‹1›", Counter:0x0, Redactable:true, Channel:2, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
+logpb.Entry{Severity:3, Time:1136214245654321000, Goroutine:11, File:"util/log/format_json_test.go", Line:123, Message:"hello ‹world›", Tags:"long=‹2›,noval,s‹1›", Counter:0x0, Redactable:true, Channel:3, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
 
 subtest end
 


### PR DESCRIPTION
This change changes the way log file decoder handles corrupted log strings. Before, decoder would panic, recover and propagate errors during parsing back to status server and then status server would stop decoding remaining records and returns error only. It doesn't allow to get at least some logs that might be important as well.

Now, decoder doesn't panic during failed string parsing and returns this error which is then added to Errors slice as part of the `LogEntriesResponse` and status server continues decoding remaining records.

Release note (bug fix): debug zip doesn't fail on corrupted log files.

Resolves: #80674