### PR TITLE
server: ensure TestStatusLocalLogs flushes logs

### DIFF
--- a/pkg/server/storage_api/logfiles_test.go
+++ b/pkg/server/storage_api/logfiles_test.go
@@ -80,6 +80,9 @@ func TestStatusLocalLogs(t *testing.T) {
 	time.Sleep(sleepBuffer)
 	timestampEWI := timeutil.Now().UnixNano()
 
+	// Ensure all log lines above are written to disk.
+	log.FlushFiles()
+
 	var wrapper serverpb.LogFilesListResponse
 	if err := srvtestutils.GetStatusJSONProto(ts, "logfiles/local", &wrapper); err != nil {
 		t.Fatal(err)
@@ -152,7 +155,7 @@ func TestStatusLocalLogs(t *testing.T) {
 		if testCase.StartTimestamp > 0 {
 			fmt.Fprintf(&url, "&start_time=%d", testCase.StartTimestamp)
 		}
-		if testCase.StartTimestamp > 0 {
+		if testCase.EndTimestamp > 0 {
 			fmt.Fprintf(&url, "&end_time=%d", testCase.EndTimestamp)
 		}
 		if len(testCase.Pattern) > 0 {


### PR DESCRIPTION
Previously, this test would not flush logs to disk before attempting to read, resulting in errors.

The test is otherwise resilient to additional logs making it into the response mixed with the specific ones we emit here.

Also contains a minor fix for a conditional that was using the wrong variable. This does not affect test outcomes.

Resolves: #112375

Epic: None

Release note: None