### PR TITLE
kvserver: deflake `TestReplicaCircuitBreaker_ExemptRequests`

### DIFF
--- a/pkg/kv/kvserver/helpers_test.go
+++ b/pkg/kv/kvserver/helpers_test.go
@@ -400,6 +400,12 @@ func (r *Replica) QuotaReleaseQueueLen() int {
 	return len(r.mu.quotaReleaseQueue)
 }
 
+func (r *Replica) NumPendingProposals() int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.numPendingProposalsRLocked()
+}
+
 func (r *Replica) IsFollowerActiveSince(
 	ctx context.Context, followerID roachpb.ReplicaID, threshold time.Duration,
 ) bool {


### PR DESCRIPTION
**kvserver: add `Replica.NumPendingProposals()` test helper**

**kvserver: deflake `TestReplicaCircuitBreaker_ExemptRequests`**

It was possible for a reproposal from a previous subtest to cause the circuit breaker to trip again when remove quorum. This would violate assertions that were expecting a different command to fail.

This patch waits for all pending proposals to complete before tripping the circuit breaker again.

Resolves #112073.
Epic: none
Release note: None
