### PR TITLE
util/log: allow bool fields to be emitted as false in json format

### DIFF
--- a/pkg/util/log/eventpb/eventpbgen/gen.go
+++ b/pkg/util/log/eventpb/eventpbgen/gen.go
@@ -595,7 +595,8 @@ func (m *{{.GoType}}) AppendJSONFields(printComma bool, b redact.RedactableBytes
    if m.{{.FieldName}} {
    {{- end }}
      if printComma { b = append(b, ',')}; printComma = true
-     b = append(b, "\"{{.FieldName}}\":true"...)
+     b = append(b, "\"{{.FieldName}}\":"...)
+     b = strconv.AppendBool(b, m.{{.FieldName}})
    {{ if not .AllowZeroValue -}}
    }
    {{- end }}

--- a/pkg/util/log/eventpb/json_encode_generated.go
+++ b/pkg/util/log/eventpb/json_encode_generated.go
@@ -281,7 +281,8 @@ func (m *AlterDefaultPrivileges) AppendJSONFields(printComma bool, b redact.Reda
 			b = append(b, ',')
 		}
 		printComma = true
-		b = append(b, "\"ForAllRoles\":true"...)
+		b = append(b, "\"ForAllRoles\":"...)
+		b = strconv.AppendBool(b, m.ForAllRoles)
 	}
 
 	if m.SchemaName != "" {
@@ -434,7 +435,8 @@ func (m *AlterIndexVisible) AppendJSONFields(printComma bool, b redact.Redactabl
 			b = append(b, ',')
 		}
 		printComma = true
-		b = append(b, "\"NotVisible\":true"...)
+		b = append(b, "\"NotVisible\":"...)
+		b = strconv.AppendBool(b, m.NotVisible)
 	}
 
 	if m.Invisibility != 0 {
@@ -788,7 +790,8 @@ func (m *CapturedIndexUsageStats) AppendJSONFields(printComma bool, b redact.Red
 			b = append(b, ',')
 		}
 		printComma = true
-		b = append(b, "\"IsUnique\":true"...)
+		b = append(b, "\"IsUnique\":"...)
+		b = strconv.AppendBool(b, m.IsUnique)
 	}
 
 	if m.IsInverted {
@@ -796,7 +799,8 @@ func (m *CapturedIndexUsageStats) AppendJSONFields(printComma bool, b redact.Red
 			b = append(b, ',')
 		}
 		printComma = true
-		b = append(b, "\"IsInverted\":true"...)
+		b = append(b, "\"IsInverted\":"...)
+		b = strconv.AppendBool(b, m.IsInverted)
 	}
 
 	if m.CreatedAt != "" {
@@ -832,7 +836,8 @@ func (m *CertsReload) AppendJSONFields(printComma bool, b redact.RedactableBytes
 			b = append(b, ',')
 		}
 		printComma = true
-		b = append(b, "\"Success\":true"...)
+		b = append(b, "\"Success\":"...)
+		b = strconv.AppendBool(b, m.Success)
 	}
 
 	if m.ErrorMessage != "" {
@@ -1007,7 +1012,8 @@ func (m *ChangefeedEmittedBytes) AppendJSONFields(printComma bool, b redact.Reda
 			b = append(b, ',')
 		}
 		printComma = true
-		b = append(b, "\"Closing\":true"...)
+		b = append(b, "\"Closing\":"...)
+		b = strconv.AppendBool(b, m.Closing)
 	}
 
 	return printComma, b
@@ -1228,7 +1234,8 @@ func (m *CommentOnColumn) AppendJSONFields(printComma bool, b redact.RedactableB
 			b = append(b, ',')
 		}
 		printComma = true
-		b = append(b, "\"NullComment\":true"...)
+		b = append(b, "\"NullComment\":"...)
+		b = strconv.AppendBool(b, m.NullComment)
 	}
 
 	return printComma, b
@@ -1282,7 +1289,8 @@ func (m *CommentOnConstraint) AppendJSONFields(printComma bool, b redact.Redacta
 			b = append(b, ',')
 		}
 		printComma = true
-		b = append(b, "\"NullComment\":true"...)
+		b = append(b, "\"NullComment\":"...)
+		b = strconv.AppendBool(b, m.NullComment)
 	}
 
 	return printComma, b
@@ -1324,7 +1332,8 @@ func (m *CommentOnDatabase) AppendJSONFields(printComma bool, b redact.Redactabl
 			b = append(b, ',')
 		}
 		printComma = true
-		b = append(b, "\"NullComment\":true"...)
+		b = append(b, "\"NullComment\":"...)
+		b = strconv.AppendBool(b, m.NullComment)
 	}
 
 	return printComma, b
@@ -1378,7 +1387,8 @@ func (m *CommentOnIndex) AppendJSONFields(printComma bool, b redact.RedactableBy
 			b = append(b, ',')
 		}
 		printComma = true
-		b = append(b, "\"NullComment\":true"...)
+		b = append(b, "\"NullComment\":"...)
+		b = strconv.AppendBool(b, m.NullComment)
 	}
 
 	return printComma, b
@@ -1420,7 +1430,8 @@ func (m *CommentOnSchema) AppendJSONFields(printComma bool, b redact.RedactableB
 			b = append(b, ',')
 		}
 		printComma = true
-		b = append(b, "\"NullComment\":true"...)
+		b = append(b, "\"NullComment\":"...)
+		b = strconv.AppendBool(b, m.NullComment)
 	}
 
 	return printComma, b
@@ -1462,7 +1473,8 @@ func (m *CommentOnTable) AppendJSONFields(printComma bool, b redact.RedactableBy
 			b = append(b, ',')
 		}
 		printComma = true
-		b = append(b, "\"NullComment\":true"...)
+		b = append(b, "\"NullComment\":"...)
+		b = strconv.AppendBool(b, m.NullComment)
 	}
 
 	return printComma, b
@@ -1933,7 +1945,8 @@ func (m *CommonSQLExecDetails) AppendJSONFields(printComma bool, b redact.Redact
 			b = append(b, ',')
 		}
 		printComma = true
-		b = append(b, "\"FullTableScan\":true"...)
+		b = append(b, "\"FullTableScan\":"...)
+		b = strconv.AppendBool(b, m.FullTableScan)
 	}
 
 	if m.FullIndexScan {
@@ -1941,7 +1954,8 @@ func (m *CommonSQLExecDetails) AppendJSONFields(printComma bool, b redact.Redact
 			b = append(b, ',')
 		}
 		printComma = true
-		b = append(b, "\"FullIndexScan\":true"...)
+		b = append(b, "\"FullIndexScan\":"...)
+		b = strconv.AppendBool(b, m.FullIndexScan)
 	}
 
 	if m.TxnCounter != 0 {
@@ -2272,7 +2286,8 @@ func (m *CreateChangefeed) AppendJSONFields(printComma bool, b redact.Redactable
 			b = append(b, ',')
 		}
 		printComma = true
-		b = append(b, "\"Transformation\":true"...)
+		b = append(b, "\"Transformation\":"...)
+		b = strconv.AppendBool(b, m.Transformation)
 	}
 
 	return printComma, b
@@ -2324,7 +2339,8 @@ func (m *CreateFunction) AppendJSONFields(printComma bool, b redact.RedactableBy
 			b = append(b, ',')
 		}
 		printComma = true
-		b = append(b, "\"IsReplace\":true"...)
+		b = append(b, "\"IsReplace\":"...)
+		b = strconv.AppendBool(b, m.IsReplace)
 	}
 
 	return printComma, b
@@ -3500,7 +3516,8 @@ func (m *RecoveryEvent) AppendJSONFields(printComma bool, b redact.RedactableByt
 			b = append(b, ',')
 		}
 		printComma = true
-		b = append(b, "\"IsMultiregionTarget\":true"...)
+		b = append(b, "\"IsMultiregionTarget\":"...)
+		b = strconv.AppendBool(b, m.IsMultiregionTarget)
 	}
 
 	if m.TargetCount != 0 {
@@ -3561,7 +3578,8 @@ func (m *RecoveryEvent) AppendJSONFields(printComma bool, b redact.RedactableByt
 			b = append(b, ',')
 		}
 		printComma = true
-		b = append(b, "\"IsLocalityAware\":true"...)
+		b = append(b, "\"IsLocalityAware\":"...)
+		b = strconv.AppendBool(b, m.IsLocalityAware)
 	}
 
 	if m.AsOfInterval != 0 {
@@ -3578,7 +3596,8 @@ func (m *RecoveryEvent) AppendJSONFields(printComma bool, b redact.RedactableByt
 			b = append(b, ',')
 		}
 		printComma = true
-		b = append(b, "\"WithRevisionHistory\":true"...)
+		b = append(b, "\"WithRevisionHistory\":"...)
+		b = strconv.AppendBool(b, m.WithRevisionHistory)
 	}
 
 	if m.HasEncryptionPassphrase {
@@ -3586,7 +3605,8 @@ func (m *RecoveryEvent) AppendJSONFields(printComma bool, b redact.RedactableByt
 			b = append(b, ',')
 		}
 		printComma = true
-		b = append(b, "\"HasEncryptionPassphrase\":true"...)
+		b = append(b, "\"HasEncryptionPassphrase\":"...)
+		b = strconv.AppendBool(b, m.HasEncryptionPassphrase)
 	}
 
 	if m.KMSType != "" {
@@ -3718,7 +3738,8 @@ func (m *RecoveryEvent) AppendJSONFields(printComma bool, b redact.RedactableByt
 			b = append(b, ',')
 		}
 		printComma = true
-		b = append(b, "\"IgnoreExistingBackup\":true"...)
+		b = append(b, "\"IgnoreExistingBackup\":"...)
+		b = strconv.AppendBool(b, m.IgnoreExistingBackup)
 	}
 
 	if m.ApplicationName != "" {
@@ -4289,7 +4310,8 @@ func (m *SampledQuery) AppendJSONFields(printComma bool, b redact.RedactableByte
 			b = append(b, ',')
 		}
 		printComma = true
-		b = append(b, "\"StatsAvailable\":true"...)
+		b = append(b, "\"StatsAvailable\":"...)
+		b = strconv.AppendBool(b, m.StatsAvailable)
 	}
 
 	if m.NanosSinceStatsCollected != 0 {
@@ -5134,7 +5156,8 @@ func (m *SetTenantClusterSetting) AppendJSONFields(printComma bool, b redact.Red
 			b = append(b, ',')
 		}
 		printComma = true
-		b = append(b, "\"AllTenants\":true"...)
+		b = append(b, "\"AllTenants\":"...)
+		b = strconv.AppendBool(b, m.AllTenants)
 	}
 
 	return printComma, b
@@ -5528,7 +5551,8 @@ func (m *TenantSharedServiceStart) AppendJSONFields(printComma bool, b redact.Re
 			b = append(b, ',')
 		}
 		printComma = true
-		b = append(b, "\"OK\":true"...)
+		b = append(b, "\"OK\":"...)
+		b = strconv.AppendBool(b, m.OK)
 	}
 
 	if m.ErrorText != "" {
@@ -5666,7 +5690,8 @@ func (m *UnsafeDeleteDescriptor) AppendJSONFields(printComma bool, b redact.Reda
 			b = append(b, ',')
 		}
 		printComma = true
-		b = append(b, "\"Force\":true"...)
+		b = append(b, "\"Force\":"...)
+		b = strconv.AppendBool(b, m.Force)
 	}
 
 	if m.ForceNotice != "" {
@@ -5726,7 +5751,8 @@ func (m *UnsafeDeleteNamespaceEntry) AppendJSONFields(printComma bool, b redact.
 			b = append(b, ',')
 		}
 		printComma = true
-		b = append(b, "\"Force\":true"...)
+		b = append(b, "\"Force\":"...)
+		b = strconv.AppendBool(b, m.Force)
 	}
 
 	if m.ForceNotice != "" {
@@ -5780,7 +5806,8 @@ func (m *UnsafeUpsertDescriptor) AppendJSONFields(printComma bool, b redact.Reda
 			b = append(b, ',')
 		}
 		printComma = true
-		b = append(b, "\"Force\":true"...)
+		b = append(b, "\"Force\":"...)
+		b = strconv.AppendBool(b, m.Force)
 	}
 
 	if m.ForceNotice != "" {
@@ -5849,7 +5876,8 @@ func (m *UnsafeUpsertNamespaceEntry) AppendJSONFields(printComma bool, b redact.
 			b = append(b, ',')
 		}
 		printComma = true
-		b = append(b, "\"Force\":true"...)
+		b = append(b, "\"Force\":"...)
+		b = strconv.AppendBool(b, m.Force)
 	}
 
 	if m.FailedValidation {
@@ -5857,7 +5885,8 @@ func (m *UnsafeUpsertNamespaceEntry) AppendJSONFields(printComma bool, b redact.
 			b = append(b, ',')
 		}
 		printComma = true
-		b = append(b, "\"FailedValidation\":true"...)
+		b = append(b, "\"FailedValidation\":"...)
+		b = strconv.AppendBool(b, m.FailedValidation)
 	}
 
 	if m.ValidationErrors != "" {


### PR DESCRIPTION
Previously with the json logging format, it was not possible to emit boolean fields that were false. Even if the boolean field is marked as 'includeempty', it will be emitted as `field: true` in the event. While always not including false boolean fields is more space efficient, with certain fields it's helpful to have the field emitted in all instances and explicitly state its 'false' value.

This patch makes it possible for `fieldName: false` to be emitted in the json logging format when the field is marked as `includeempty`.

Epic: none
Part of: #108284

Release note: None