### PR TITLE
admission: change the estimation logic for at-admission-tokens

### DIFF
--- a/pkg/util/admission/admission.go
+++ b/pkg/util/admission/admission.go
@@ -575,11 +575,27 @@ type storeAdmissionStats struct {
 		// will turn into when written to a flushed sstable.
 		writeBytes uint64
 	}
+	// aboveRaftStats is a subset of the top-level storeAdmissionStats that
+	// represents admission that happened above-raft for which we deducted
+	// tokens prior to proposal evaluation. Replication admission/flow control
+	// happens below-raft, so those stats are *not* here. Only above-raft
+	// request stats are used to estimate tokens to deduct prior to evaluation.
+	// Since large write requests (often ingested) use the below-raft admission
+	// path as part of replication admission control, not ignoring such requests
+	// inflates estimates and results in under-admission. See
+	// https://github.com/cockroachdb/cockroach/issues/113711.
+	aboveRaftStats struct {
+		workCount              uint64
+		writeAccountedBytes    uint64
+		ingestedAccountedBytes uint64
+	}
 	// aux represents additional information carried for informational purposes
 	// (e.g. for logging).
 	aux struct {
 		// These bypassed numbers are already included in the corresponding
-		// {workCount, writeAccountedBytes, ingestedAccountedBytes}.
+		// {workCount, writeAccountedBytes, ingestedAccountedBytes}. These are a
+		// subset of the below-raft stats (those that were not subject to
+		// replication admission control).
 		bypassedCount                  uint64
 		writeBypassedAccountedBytes    uint64
 		ingestedBypassedAccountedBytes uint64

--- a/pkg/util/admission/io_load_listener_test.go
+++ b/pkg/util/admission/io_load_listener_test.go
@@ -84,6 +84,15 @@ func TestIOLoadListener(t *testing.T) {
 				if d.HasArg("ingested-bytes") {
 					d.ScanArgs(t, "ingested-bytes", &req.stats.ingestedAccountedBytes)
 				}
+				belowRaft := false
+				if d.HasArg("below-raft") {
+					d.ScanArgs(t, "below-raft", &belowRaft)
+				}
+				if !belowRaft {
+					req.stats.aboveRaftStats.workCount = req.stats.workCount
+					req.stats.aboveRaftStats.writeAccountedBytes = req.stats.writeAccountedBytes
+					req.stats.aboveRaftStats.ingestedAccountedBytes = req.stats.ingestedAccountedBytes
+				}
 				return fmt.Sprintf("%+v", req.stats)
 
 			case "set-min-flush-util":

--- a/pkg/util/admission/store_token_estimation_test.go
+++ b/pkg/util/admission/store_token_estimation_test.go
@@ -70,6 +70,17 @@ func TestStorePerWorkTokenEstimator(t *testing.T) {
 					admissionStats.aux.writeBypassedAccountedBytes += uint64(bypassedWrite)
 					admissionStats.aux.ingestedBypassedAccountedBytes += uint64(bypassedIngested)
 				}
+				if d.HasArg("above-raft-count") {
+					var count, write, ingested uint64
+					d.ScanArgs(t, "above-raft-count", &count)
+					d.ScanArgs(t, "above-raft-write", &write)
+					if d.HasArg("above-raft-ingested") {
+						d.ScanArgs(t, "above-raft-ingested", &ingested)
+					}
+					admissionStats.aboveRaftStats.workCount += count
+					admissionStats.aboveRaftStats.writeAccountedBytes += write
+					admissionStats.aboveRaftStats.ingestedAccountedBytes += ingested
+				}
 				if d.HasArg("ignore-ingested-into-L0") {
 					var ignoreIngestedIntoL0 int
 					d.ScanArgs(t, "ignore-ingested-into-L0", &ignoreIngestedIntoL0)

--- a/pkg/util/admission/testdata/io_load_listener
+++ b/pkg/util/admission/testdata/io_load_listener
@@ -6,7 +6,7 @@ init
 
 prep-admission-stats admitted=0
 ----
-{workCount:0 writeAccountedBytes:0 ingestedAccountedBytes:0 statsToIgnore:{ingestStats:{Bytes:0 ApproxIngestedIntoL0Bytes:0 MemtableOverlappingFiles:0} writeBytes:0} aux:{bypassedCount:0 writeBypassedAccountedBytes:0 ingestedBypassedAccountedBytes:0}}
+{workCount:0 writeAccountedBytes:0 ingestedAccountedBytes:0 statsToIgnore:{ingestStats:{Bytes:0 ApproxIngestedIntoL0Bytes:0 MemtableOverlappingFiles:0} writeBytes:0} aboveRaftStats:{workCount:0 writeAccountedBytes:0 ingestedAccountedBytes:0} aux:{bypassedCount:0 writeBypassedAccountedBytes:0 ingestedBypassedAccountedBytes:0}}
 
 # Even though above the threshold, the first 60 ticks don't limit the tokens.
 set-state l0-bytes=10000 l0-added-write=1000 l0-files=21 l0-sublevels=21
@@ -76,7 +76,7 @@ tick: 59, setAvailableTokens: io-tokens=unlimited(elastic unlimited) elastic-dis
 
 prep-admission-stats admitted=10000 write-bytes=40000
 ----
-{workCount:10000 writeAccountedBytes:40000 ingestedAccountedBytes:0 statsToIgnore:{ingestStats:{Bytes:0 ApproxIngestedIntoL0Bytes:0 MemtableOverlappingFiles:0} writeBytes:0} aux:{bypassedCount:0 writeBypassedAccountedBytes:0 ingestedBypassedAccountedBytes:0}}
+{workCount:10000 writeAccountedBytes:40000 ingestedAccountedBytes:0 statsToIgnore:{ingestStats:{Bytes:0 ApproxIngestedIntoL0Bytes:0 MemtableOverlappingFiles:0} writeBytes:0} aboveRaftStats:{workCount:10000 writeAccountedBytes:40000 ingestedAccountedBytes:0} aux:{bypassedCount:0 writeBypassedAccountedBytes:0 ingestedBypassedAccountedBytes:0}}
 
 # Delta added is 100,000. The l0-bytes are the same, so compactions removed
 # 100,000 bytes. Smoothed removed by compactions is 50,000. Each admitted is
@@ -151,7 +151,7 @@ tick: 59, setAvailableTokens: io-tokens=208(elastic 0) elastic-disk-bw-tokens=un
 
 prep-admission-stats admitted=20000 write-bytes=80000
 ----
-{workCount:20000 writeAccountedBytes:80000 ingestedAccountedBytes:0 statsToIgnore:{ingestStats:{Bytes:0 ApproxIngestedIntoL0Bytes:0 MemtableOverlappingFiles:0} writeBytes:0} aux:{bypassedCount:0 writeBypassedAccountedBytes:0 ingestedBypassedAccountedBytes:0}}
+{workCount:20000 writeAccountedBytes:80000 ingestedAccountedBytes:0 statsToIgnore:{ingestStats:{Bytes:0 ApproxIngestedIntoL0Bytes:0 MemtableOverlappingFiles:0} writeBytes:0} aboveRaftStats:{workCount:20000 writeAccountedBytes:80000 ingestedAccountedBytes:0} aux:{bypassedCount:0 writeBypassedAccountedBytes:0 ingestedBypassedAccountedBytes:0}}
 
 # Same delta as previous but smoothing bumps up the tokens to 25,000.
 set-state l0-bytes=10000 l0-added-write=201000 l0-files=21 l0-sublevels=21
@@ -232,7 +232,7 @@ setAvailableTokens: io-tokens=365(elastic 1) elastic-disk-bw-tokens=unlimited ma
 
 prep-admission-stats admitted=30000 write-bytes=120000
 ----
-{workCount:30000 writeAccountedBytes:120000 ingestedAccountedBytes:0 statsToIgnore:{ingestStats:{Bytes:0 ApproxIngestedIntoL0Bytes:0 MemtableOverlappingFiles:0} writeBytes:0} aux:{bypassedCount:0 writeBypassedAccountedBytes:0 ingestedBypassedAccountedBytes:0}}
+{workCount:30000 writeAccountedBytes:120000 ingestedAccountedBytes:0 statsToIgnore:{ingestStats:{Bytes:0 ApproxIngestedIntoL0Bytes:0 MemtableOverlappingFiles:0} writeBytes:0} aboveRaftStats:{workCount:30000 writeAccountedBytes:120000 ingestedAccountedBytes:0} aux:{bypassedCount:0 writeBypassedAccountedBytes:0 ingestedBypassedAccountedBytes:0}}
 
 # l0-sublevels drops below threshold. We calculate the smoothed values, but
 # don't limit the tokens.
@@ -246,7 +246,7 @@ setAvailableTokens: io-tokens=1870(elastic 1055) elastic-disk-bw-tokens=unlimite
 
 prep-admission-stats admitted=40000 write-bytes=160000
 ----
-{workCount:40000 writeAccountedBytes:160000 ingestedAccountedBytes:0 statsToIgnore:{ingestStats:{Bytes:0 ApproxIngestedIntoL0Bytes:0 MemtableOverlappingFiles:0} writeBytes:0} aux:{bypassedCount:0 writeBypassedAccountedBytes:0 ingestedBypassedAccountedBytes:0}}
+{workCount:40000 writeAccountedBytes:160000 ingestedAccountedBytes:0 statsToIgnore:{ingestStats:{Bytes:0 ApproxIngestedIntoL0Bytes:0 MemtableOverlappingFiles:0} writeBytes:0} aboveRaftStats:{workCount:40000 writeAccountedBytes:160000 ingestedAccountedBytes:0} aux:{bypassedCount:0 writeBypassedAccountedBytes:0 ingestedBypassedAccountedBytes:0}}
 
 set-state l0-bytes=10000 l0-added-write=501000 l0-files=21 l0-sublevels=6 print-only-first-tick=true
 ----
@@ -258,7 +258,7 @@ setAvailableTokens: io-tokens=2201(elastic 1055) elastic-disk-bw-tokens=unlimite
 
 prep-admission-stats admitted=50000 write-bytes=200000
 ----
-{workCount:50000 writeAccountedBytes:200000 ingestedAccountedBytes:0 statsToIgnore:{ingestStats:{Bytes:0 ApproxIngestedIntoL0Bytes:0 MemtableOverlappingFiles:0} writeBytes:0} aux:{bypassedCount:0 writeBypassedAccountedBytes:0 ingestedBypassedAccountedBytes:0}}
+{workCount:50000 writeAccountedBytes:200000 ingestedAccountedBytes:0 statsToIgnore:{ingestStats:{Bytes:0 ApproxIngestedIntoL0Bytes:0 MemtableOverlappingFiles:0} writeBytes:0} aboveRaftStats:{workCount:50000 writeAccountedBytes:200000 ingestedAccountedBytes:0} aux:{bypassedCount:0 writeBypassedAccountedBytes:0 ingestedBypassedAccountedBytes:0}}
 
 set-state l0-bytes=10000 l0-added-write=501000 l0-files=21 l0-sublevels=3 print-only-first-tick=true
 ----
@@ -275,7 +275,7 @@ init
 
 prep-admission-stats admitted=0
 ----
-{workCount:0 writeAccountedBytes:0 ingestedAccountedBytes:0 statsToIgnore:{ingestStats:{Bytes:0 ApproxIngestedIntoL0Bytes:0 MemtableOverlappingFiles:0} writeBytes:0} aux:{bypassedCount:0 writeBypassedAccountedBytes:0 ingestedBypassedAccountedBytes:0}}
+{workCount:0 writeAccountedBytes:0 ingestedAccountedBytes:0 statsToIgnore:{ingestStats:{Bytes:0 ApproxIngestedIntoL0Bytes:0 MemtableOverlappingFiles:0} writeBytes:0} aboveRaftStats:{workCount:0 writeAccountedBytes:0 ingestedAccountedBytes:0} aux:{bypassedCount:0 writeBypassedAccountedBytes:0 ingestedBypassedAccountedBytes:0}}
 
 set-state l0-bytes=1000 l0-added-write=1000 l0-added-ingested=0 l0-files=21 l0-sublevels=21 print-only-first-tick=true
 ----
@@ -285,9 +285,9 @@ tick: 0, setAvailableTokens: io-tokens=unlimited(elastic unlimited) elastic-disk
 
 # L0 will see an addition of 200,000 bytes. 150,000 bytes were mentioned by
 # the admitted requests.
-prep-admission-stats admitted=10 write-bytes=130000 ingested-bytes=20000
+prep-admission-stats admitted=10 write-bytes=130000 ingested-bytes=20000 below-raft=true
 ----
-{workCount:10 writeAccountedBytes:130000 ingestedAccountedBytes:20000 statsToIgnore:{ingestStats:{Bytes:0 ApproxIngestedIntoL0Bytes:0 MemtableOverlappingFiles:0} writeBytes:0} aux:{bypassedCount:0 writeBypassedAccountedBytes:0 ingestedBypassedAccountedBytes:0}}
+{workCount:10 writeAccountedBytes:130000 ingestedAccountedBytes:20000 statsToIgnore:{ingestStats:{Bytes:0 ApproxIngestedIntoL0Bytes:0 MemtableOverlappingFiles:0} writeBytes:0} aboveRaftStats:{workCount:0 writeAccountedBytes:0 ingestedAccountedBytes:0} aux:{bypassedCount:0 writeBypassedAccountedBytes:0 ingestedBypassedAccountedBytes:0}}
 
 # The ingested model can be fit with a multiplier of ~1.5 for the interval,
 # but since the l0-ingest-lm model had a previous multiplier of 0.75 and the
@@ -296,9 +296,9 @@ prep-admission-stats admitted=10 write-bytes=130000 ingested-bytes=20000
 # of 1.12 and 1.25 respectively.
 set-state l0-bytes=1000 l0-added-write=171000 l0-added-ingested=30000 l0-files=21 l0-sublevels=21 print-only-first-tick=true
 ----
-compaction score 1.050[L0-overload] (21 ssts, 21 sub-levels), L0 growth 195 KiB (write 166 KiB (ignored 0 B) ingest 29 KiB (ignored 0 B)): requests 10 (0 bypassed) with 127 KiB acc-write (0 B bypassed) + 20 KiB acc-ingest (0 B bypassed) + write-model 1.31x+1 B (smoothed 1.53x+1 B) + ingested-model 1.50x+1 B (smoothed 1.12x+1 B) + at-admission-tokens 9.8 KiB, compacted 195 KiB [≈98 KiB], flushed 0 B [≈0 B]; admitting 24 KiB (rate 1.6 KiB/s) (elastic 1 B rate 0 B/s) due to L0 growth (used total: 0 B elastic 0 B); write stalls 0
-{ioLoadListenerState:{cumL0AddedBytes:201000 curL0Bytes:1000 cumWriteStallCount:0 cumFlushWriteThroughput:{Bytes:0 WorkDuration:0 IdleDuration:0} diskBW:{bytesRead:0 bytesWritten:0 incomingLSMBytes:201000} smoothedIntL0CompactedBytes:100000 smoothedCompactionByteTokens:25000 smoothedNumFlushTokens:0 flushUtilTargetFraction:1.5 totalNumByteTokens:25000 byteTokensAllocated:0 byteTokensUsed:0 byteTokensUsedByElasticWork:0 totalNumElasticByteTokens:1 elasticByteTokensAllocated:0 elasticDiskBWTokens:9223372036854775807 elasticDiskBWTokensAllocated:0} requestEstimates:{writeTokens:10000} l0WriteLM:{multiplier:1.5288076923076923 constant:1} l0IngestLM:{multiplier:1.125 constant:1} ingestLM:{multiplier:1.2497500000000001 constant:1} aux:{intL0AddedBytes:200000 intL0CompactedBytes:200000 intFlushTokens:0 intFlushUtilization:0 intWriteStalls:0 prevTokensUsed:0 prevTokensUsedByElasticWork:0 tokenKind:0 perWorkTokensAux:{intWorkCount:10 intL0WriteBytes:170000 intL0IngestedBytes:30000 intLSMIngestedBytes:30000 intL0WriteAccountedBytes:130000 intIngestedAccountedBytes:20000 intL0WriteLinearModel:{multiplier:1.3076153846153846 constant:1} intL0IngestedLinearModel:{multiplier:1.4995 constant:1} intIngestedLinearModel:{multiplier:1.4995 constant:1} intBypassedWorkCount:0 intL0WriteBypassedAccountedBytes:0 intIngestedBypassedAccountedBytes:0 intL0IgnoredWriteBytes:0 intL0IgnoredIngestedBytes:0} doLogFlush:true diskBW:{intervalDiskLoadInfo:{readBandwidth:0 writeBandwidth:0 provisionedBandwidth:0} intervalLSMInfo:{incomingBytes:200000 regularTokensUsed:0 elasticTokensUsed:0}}} ioThreshold:<nil>}
-store-request-estimates: writeTokens: 10000
+compaction score 1.050[L0-overload] (21 ssts, 21 sub-levels), L0 growth 195 KiB (write 166 KiB (ignored 0 B) ingest 29 KiB (ignored 0 B)): requests 10 (0 bypassed) with 127 KiB acc-write (0 B bypassed) + 20 KiB acc-ingest (0 B bypassed) + write-model 1.31x+1 B (smoothed 1.53x+1 B) + ingested-model 1.50x+1 B (smoothed 1.12x+1 B) + at-admission-tokens 1 B, compacted 195 KiB [≈98 KiB], flushed 0 B [≈0 B]; admitting 24 KiB (rate 1.6 KiB/s) (elastic 1 B rate 0 B/s) due to L0 growth (used total: 0 B elastic 0 B); write stalls 0
+{ioLoadListenerState:{cumL0AddedBytes:201000 curL0Bytes:1000 cumWriteStallCount:0 cumFlushWriteThroughput:{Bytes:0 WorkDuration:0 IdleDuration:0} diskBW:{bytesRead:0 bytesWritten:0 incomingLSMBytes:201000} smoothedIntL0CompactedBytes:100000 smoothedCompactionByteTokens:25000 smoothedNumFlushTokens:0 flushUtilTargetFraction:1.5 totalNumByteTokens:25000 byteTokensAllocated:0 byteTokensUsed:0 byteTokensUsedByElasticWork:0 totalNumElasticByteTokens:1 elasticByteTokensAllocated:0 elasticDiskBWTokens:9223372036854775807 elasticDiskBWTokensAllocated:0} requestEstimates:{writeTokens:1} l0WriteLM:{multiplier:1.5288076923076923 constant:1} l0IngestLM:{multiplier:1.125 constant:1} ingestLM:{multiplier:1.2497500000000001 constant:1} aux:{intL0AddedBytes:200000 intL0CompactedBytes:200000 intFlushTokens:0 intFlushUtilization:0 intWriteStalls:0 prevTokensUsed:0 prevTokensUsedByElasticWork:0 tokenKind:0 perWorkTokensAux:{intWorkCount:10 intL0WriteBytes:170000 intL0IngestedBytes:30000 intLSMIngestedBytes:30000 intL0WriteAccountedBytes:130000 intIngestedAccountedBytes:20000 intL0WriteLinearModel:{multiplier:1.3076153846153846 constant:1} intL0IngestedLinearModel:{multiplier:1.4995 constant:1} intIngestedLinearModel:{multiplier:1.4995 constant:1} intBypassedWorkCount:0 intL0WriteBypassedAccountedBytes:0 intIngestedBypassedAccountedBytes:0 intL0IgnoredWriteBytes:0 intL0IgnoredIngestedBytes:0} doLogFlush:true diskBW:{intervalDiskLoadInfo:{readBandwidth:0 writeBandwidth:0 provisionedBandwidth:0} intervalLSMInfo:{incomingBytes:200000 regularTokensUsed:0 elasticTokensUsed:0}}} ioThreshold:<nil>}
+store-request-estimates: writeTokens: 1
 tick: 0, setAdmittedDoneModelsLocked: l0-write-lm: 1.53x+1 l0-ingest-lm: 1.12x+1 ingest-lm: 1.25x+1
 setAvailableTokens: io-tokens=417(elastic 1) elastic-disk-bw-tokens=unlimited max-byte-tokens=417(elastic 1) max-disk-bw-tokens=unlimited lastTick=false
 
@@ -307,13 +307,13 @@ setAvailableTokens: io-tokens=417(elastic 1) elastic-disk-bw-tokens=unlimited ma
 # ingested model is decayed by a factor of 2.
 prep-admission-stats admitted=20 write-bytes=150000 ingested-bytes=20000
 ----
-{workCount:20 writeAccountedBytes:150000 ingestedAccountedBytes:20000 statsToIgnore:{ingestStats:{Bytes:0 ApproxIngestedIntoL0Bytes:0 MemtableOverlappingFiles:0} writeBytes:0} aux:{bypassedCount:0 writeBypassedAccountedBytes:0 ingestedBypassedAccountedBytes:0}}
+{workCount:20 writeAccountedBytes:150000 ingestedAccountedBytes:20000 statsToIgnore:{ingestStats:{Bytes:0 ApproxIngestedIntoL0Bytes:0 MemtableOverlappingFiles:0} writeBytes:0} aboveRaftStats:{workCount:20 writeAccountedBytes:150000 ingestedAccountedBytes:20000} aux:{bypassedCount:0 writeBypassedAccountedBytes:0 ingestedBypassedAccountedBytes:0}}
 
 set-state l0-bytes=1000 l0-added-write=191000 l0-added-ingested=30000 l0-files=21 l0-sublevels=21 print-only-first-tick=true
 ----
-compaction score 1.050[L0-overload] (21 ssts, 21 sub-levels), L0 growth 20 KiB (write 20 KiB (ignored 0 B) ingest 0 B (ignored 0 B)): requests 10 (0 bypassed) with 20 KiB acc-write (0 B bypassed) + 0 B acc-ingest (0 B bypassed) + write-model 1.00x+1 B (smoothed 1.26x+1 B) + ingested-model 0.00x+0 B (smoothed 1.12x+1 B) + at-admission-tokens 5.9 KiB, compacted 20 KiB [≈59 KiB], flushed 0 B [≈0 B]; admitting 27 KiB (rate 1.8 KiB/s) (elastic 1 B rate 0 B/s) due to L0 growth (used total: 0 B elastic 0 B); write stalls 0
-{ioLoadListenerState:{cumL0AddedBytes:221000 curL0Bytes:1000 cumWriteStallCount:0 cumFlushWriteThroughput:{Bytes:0 WorkDuration:0 IdleDuration:0} diskBW:{bytesRead:0 bytesWritten:0 incomingLSMBytes:221000} smoothedIntL0CompactedBytes:60000 smoothedCompactionByteTokens:27500 smoothedNumFlushTokens:0 flushUtilTargetFraction:1.5 totalNumByteTokens:27500 byteTokensAllocated:0 byteTokensUsed:0 byteTokensUsedByElasticWork:0 totalNumElasticByteTokens:1 elasticByteTokensAllocated:0 elasticDiskBWTokens:9223372036854775807 elasticDiskBWTokensAllocated:0} requestEstimates:{writeTokens:6000} l0WriteLM:{multiplier:1.2641538461538462 constant:1} l0IngestLM:{multiplier:1.125 constant:1} ingestLM:{multiplier:1.2497500000000001 constant:1} aux:{intL0AddedBytes:20000 intL0CompactedBytes:20000 intFlushTokens:0 intFlushUtilization:0 intWriteStalls:0 prevTokensUsed:0 prevTokensUsedByElasticWork:0 tokenKind:0 perWorkTokensAux:{intWorkCount:10 intL0WriteBytes:20000 intL0IngestedBytes:0 intLSMIngestedBytes:0 intL0WriteAccountedBytes:20000 intIngestedAccountedBytes:0 intL0WriteLinearModel:{multiplier:0.9995 constant:1} intL0IngestedLinearModel:{multiplier:0 constant:0} intIngestedLinearModel:{multiplier:0 constant:0} intBypassedWorkCount:0 intL0WriteBypassedAccountedBytes:0 intIngestedBypassedAccountedBytes:0 intL0IgnoredWriteBytes:0 intL0IgnoredIngestedBytes:0} doLogFlush:true diskBW:{intervalDiskLoadInfo:{readBandwidth:0 writeBandwidth:0 provisionedBandwidth:0} intervalLSMInfo:{incomingBytes:20000 regularTokensUsed:0 elasticTokensUsed:0}}} ioThreshold:<nil>}
-store-request-estimates: writeTokens: 6000
+compaction score 1.050[L0-overload] (21 ssts, 21 sub-levels), L0 growth 20 KiB (write 20 KiB (ignored 0 B) ingest 0 B (ignored 0 B)): requests 10 (0 bypassed) with 20 KiB acc-write (0 B bypassed) + 0 B acc-ingest (0 B bypassed) + write-model 1.00x+1 B (smoothed 1.26x+1 B) + ingested-model 0.00x+0 B (smoothed 1.12x+1 B) + at-admission-tokens 4.1 KiB, compacted 20 KiB [≈59 KiB], flushed 0 B [≈0 B]; admitting 27 KiB (rate 1.8 KiB/s) (elastic 1 B rate 0 B/s) due to L0 growth (used total: 0 B elastic 0 B); write stalls 0
+{ioLoadListenerState:{cumL0AddedBytes:221000 curL0Bytes:1000 cumWriteStallCount:0 cumFlushWriteThroughput:{Bytes:0 WorkDuration:0 IdleDuration:0} diskBW:{bytesRead:0 bytesWritten:0 incomingLSMBytes:221000} smoothedIntL0CompactedBytes:60000 smoothedCompactionByteTokens:27500 smoothedNumFlushTokens:0 flushUtilTargetFraction:1.5 totalNumByteTokens:27500 byteTokensAllocated:0 byteTokensUsed:0 byteTokensUsedByElasticWork:0 totalNumElasticByteTokens:1 elasticByteTokensAllocated:0 elasticDiskBWTokens:9223372036854775807 elasticDiskBWTokensAllocated:0} requestEstimates:{writeTokens:4195} l0WriteLM:{multiplier:1.2641538461538462 constant:1} l0IngestLM:{multiplier:1.125 constant:1} ingestLM:{multiplier:1.2497500000000001 constant:1} aux:{intL0AddedBytes:20000 intL0CompactedBytes:20000 intFlushTokens:0 intFlushUtilization:0 intWriteStalls:0 prevTokensUsed:0 prevTokensUsedByElasticWork:0 tokenKind:0 perWorkTokensAux:{intWorkCount:10 intL0WriteBytes:20000 intL0IngestedBytes:0 intLSMIngestedBytes:0 intL0WriteAccountedBytes:20000 intIngestedAccountedBytes:0 intL0WriteLinearModel:{multiplier:0.9995 constant:1} intL0IngestedLinearModel:{multiplier:0 constant:0} intIngestedLinearModel:{multiplier:0 constant:0} intBypassedWorkCount:0 intL0WriteBypassedAccountedBytes:0 intIngestedBypassedAccountedBytes:0 intL0IgnoredWriteBytes:0 intL0IgnoredIngestedBytes:0} doLogFlush:true diskBW:{intervalDiskLoadInfo:{readBandwidth:0 writeBandwidth:0 provisionedBandwidth:0} intervalLSMInfo:{incomingBytes:20000 regularTokensUsed:0 elasticTokensUsed:0}}} ioThreshold:<nil>}
+store-request-estimates: writeTokens: 4195
 tick: 0, setAdmittedDoneModelsLocked: l0-write-lm: 1.26x+1 l0-ingest-lm: 1.12x+1 ingest-lm: 1.25x+1
 setAvailableTokens: io-tokens=459(elastic 1) elastic-disk-bw-tokens=unlimited max-byte-tokens=459(elastic 1) max-disk-bw-tokens=unlimited lastTick=false
 
@@ -321,13 +321,13 @@ setAvailableTokens: io-tokens=459(elastic 1) elastic-disk-bw-tokens=unlimited ma
 # bytes to L0. We don't let unaccounted bytes become negative.
 prep-admission-stats admitted=30 write-bytes=250000 ingested-bytes=20000 ingested-into-l0=20000
 ----
-{workCount:30 writeAccountedBytes:250000 ingestedAccountedBytes:20000 statsToIgnore:{ingestStats:{Bytes:0 ApproxIngestedIntoL0Bytes:0 MemtableOverlappingFiles:0} writeBytes:0} aux:{bypassedCount:0 writeBypassedAccountedBytes:0 ingestedBypassedAccountedBytes:0}}
+{workCount:30 writeAccountedBytes:250000 ingestedAccountedBytes:20000 statsToIgnore:{ingestStats:{Bytes:0 ApproxIngestedIntoL0Bytes:0 MemtableOverlappingFiles:0} writeBytes:0} aboveRaftStats:{workCount:30 writeAccountedBytes:250000 ingestedAccountedBytes:20000} aux:{bypassedCount:0 writeBypassedAccountedBytes:0 ingestedBypassedAccountedBytes:0}}
 
 set-state l0-bytes=1000 l0-added-write=211000 l0-added-ingested=30000 l0-files=21 l0-sublevels=21 print-only-first-tick=true
 ----
-compaction score 1.050[L0-overload] (21 ssts, 21 sub-levels), L0 growth 20 KiB (write 20 KiB (ignored 0 B) ingest 0 B (ignored 0 B)): requests 10 (0 bypassed) with 98 KiB acc-write (0 B bypassed) + 0 B acc-ingest (0 B bypassed) + write-model 0.50x+1 B (smoothed 0.88x+1 B) + ingested-model 0.00x+0 B (smoothed 1.12x+1 B) + at-admission-tokens 3.9 KiB, compacted 20 KiB [≈39 KiB], flushed 0 B [≈0 B]; admitting 23 KiB (rate 1.5 KiB/s) (elastic 1 B rate 0 B/s) due to L0 growth (used total: 0 B elastic 0 B); write stalls 0
-{ioLoadListenerState:{cumL0AddedBytes:241000 curL0Bytes:1000 cumWriteStallCount:0 cumFlushWriteThroughput:{Bytes:0 WorkDuration:0 IdleDuration:0} diskBW:{bytesRead:0 bytesWritten:0 incomingLSMBytes:241000} smoothedIntL0CompactedBytes:40000 smoothedCompactionByteTokens:23750 smoothedNumFlushTokens:0 flushUtilTargetFraction:1.5 totalNumByteTokens:23750 byteTokensAllocated:0 byteTokensUsed:0 byteTokensUsedByElasticWork:0 totalNumElasticByteTokens:1 elasticByteTokensAllocated:0 elasticDiskBWTokens:9223372036854775807 elasticDiskBWTokensAllocated:0} requestEstimates:{writeTokens:4000} l0WriteLM:{multiplier:0.8820769230769231 constant:1} l0IngestLM:{multiplier:1.125 constant:1} ingestLM:{multiplier:1.2497500000000001 constant:1} aux:{intL0AddedBytes:20000 intL0CompactedBytes:20000 intFlushTokens:0 intFlushUtilization:0 intWriteStalls:0 prevTokensUsed:0 prevTokensUsedByElasticWork:0 tokenKind:0 perWorkTokensAux:{intWorkCount:10 intL0WriteBytes:20000 intL0IngestedBytes:0 intLSMIngestedBytes:0 intL0WriteAccountedBytes:100000 intIngestedAccountedBytes:0 intL0WriteLinearModel:{multiplier:0.5 constant:1} intL0IngestedLinearModel:{multiplier:0 constant:0} intIngestedLinearModel:{multiplier:0 constant:0} intBypassedWorkCount:0 intL0WriteBypassedAccountedBytes:0 intIngestedBypassedAccountedBytes:0 intL0IgnoredWriteBytes:0 intL0IgnoredIngestedBytes:0} doLogFlush:true diskBW:{intervalDiskLoadInfo:{readBandwidth:0 writeBandwidth:0 provisionedBandwidth:0} intervalLSMInfo:{incomingBytes:20000 regularTokensUsed:0 elasticTokensUsed:0}}} ioThreshold:<nil>}
-store-request-estimates: writeTokens: 4000
+compaction score 1.050[L0-overload] (21 ssts, 21 sub-levels), L0 growth 20 KiB (write 20 KiB (ignored 0 B) ingest 0 B (ignored 0 B)): requests 10 (0 bypassed) with 98 KiB acc-write (0 B bypassed) + 0 B acc-ingest (0 B bypassed) + write-model 0.50x+1 B (smoothed 0.88x+1 B) + ingested-model 0.00x+0 B (smoothed 1.12x+1 B) + at-admission-tokens 3.0 KiB, compacted 20 KiB [≈39 KiB], flushed 0 B [≈0 B]; admitting 23 KiB (rate 1.5 KiB/s) (elastic 1 B rate 0 B/s) due to L0 growth (used total: 0 B elastic 0 B); write stalls 0
+{ioLoadListenerState:{cumL0AddedBytes:241000 curL0Bytes:1000 cumWriteStallCount:0 cumFlushWriteThroughput:{Bytes:0 WorkDuration:0 IdleDuration:0} diskBW:{bytesRead:0 bytesWritten:0 incomingLSMBytes:241000} smoothedIntL0CompactedBytes:40000 smoothedCompactionByteTokens:23750 smoothedNumFlushTokens:0 flushUtilTargetFraction:1.5 totalNumByteTokens:23750 byteTokensAllocated:0 byteTokensUsed:0 byteTokensUsedByElasticWork:0 totalNumElasticByteTokens:1 elasticByteTokensAllocated:0 elasticDiskBWTokens:9223372036854775807 elasticDiskBWTokensAllocated:0} requestEstimates:{writeTokens:3097} l0WriteLM:{multiplier:0.8820769230769231 constant:1} l0IngestLM:{multiplier:1.125 constant:1} ingestLM:{multiplier:1.2497500000000001 constant:1} aux:{intL0AddedBytes:20000 intL0CompactedBytes:20000 intFlushTokens:0 intFlushUtilization:0 intWriteStalls:0 prevTokensUsed:0 prevTokensUsedByElasticWork:0 tokenKind:0 perWorkTokensAux:{intWorkCount:10 intL0WriteBytes:20000 intL0IngestedBytes:0 intLSMIngestedBytes:0 intL0WriteAccountedBytes:100000 intIngestedAccountedBytes:0 intL0WriteLinearModel:{multiplier:0.5 constant:1} intL0IngestedLinearModel:{multiplier:0 constant:0} intIngestedLinearModel:{multiplier:0 constant:0} intBypassedWorkCount:0 intL0WriteBypassedAccountedBytes:0 intIngestedBypassedAccountedBytes:0 intL0IgnoredWriteBytes:0 intL0IgnoredIngestedBytes:0} doLogFlush:true diskBW:{intervalDiskLoadInfo:{readBandwidth:0 writeBandwidth:0 provisionedBandwidth:0} intervalLSMInfo:{incomingBytes:20000 regularTokensUsed:0 elasticTokensUsed:0}}} ioThreshold:<nil>}
+store-request-estimates: writeTokens: 3097
 tick: 0, setAdmittedDoneModelsLocked: l0-write-lm: 0.88x+1 l0-ingest-lm: 1.12x+1 ingest-lm: 1.25x+1
 setAvailableTokens: io-tokens=396(elastic 1) elastic-disk-bw-tokens=unlimited max-byte-tokens=396(elastic 1) max-disk-bw-tokens=unlimited lastTick=false
 
@@ -337,7 +337,7 @@ init
 
 prep-admission-stats admitted=0
 ----
-{workCount:0 writeAccountedBytes:0 ingestedAccountedBytes:0 statsToIgnore:{ingestStats:{Bytes:0 ApproxIngestedIntoL0Bytes:0 MemtableOverlappingFiles:0} writeBytes:0} aux:{bypassedCount:0 writeBypassedAccountedBytes:0 ingestedBypassedAccountedBytes:0}}
+{workCount:0 writeAccountedBytes:0 ingestedAccountedBytes:0 statsToIgnore:{ingestStats:{Bytes:0 ApproxIngestedIntoL0Bytes:0 MemtableOverlappingFiles:0} writeBytes:0} aboveRaftStats:{workCount:0 writeAccountedBytes:0 ingestedAccountedBytes:0} aux:{bypassedCount:0 writeBypassedAccountedBytes:0 ingestedBypassedAccountedBytes:0}}
 
 set-state l0-bytes=10000 l0-added-write=1000 l0-files=1 l0-sublevels=1 print-only-first-tick=true
 ----
@@ -554,7 +554,7 @@ init
 
 prep-admission-stats admitted=0
 ----
-{workCount:0 writeAccountedBytes:0 ingestedAccountedBytes:0 statsToIgnore:{ingestStats:{Bytes:0 ApproxIngestedIntoL0Bytes:0 MemtableOverlappingFiles:0} writeBytes:0} aux:{bypassedCount:0 writeBypassedAccountedBytes:0 ingestedBypassedAccountedBytes:0}}
+{workCount:0 writeAccountedBytes:0 ingestedAccountedBytes:0 statsToIgnore:{ingestStats:{Bytes:0 ApproxIngestedIntoL0Bytes:0 MemtableOverlappingFiles:0} writeBytes:0} aboveRaftStats:{workCount:0 writeAccountedBytes:0 ingestedAccountedBytes:0} aux:{bypassedCount:0 writeBypassedAccountedBytes:0 ingestedBypassedAccountedBytes:0}}
 
 # Even though above the threshold, the first 60 ticks don't limit the tokens.
 set-state l0-bytes=10000 l0-added-write=1000 l0-files=21 l0-sublevels=21 print-only-first-tick=true loaded=true
@@ -565,7 +565,7 @@ tick: 0, setAvailableTokens: io-tokens=unlimited(elastic unlimited) elastic-disk
 
 prep-admission-stats admitted=10000 write-bytes=40000
 ----
-{workCount:10000 writeAccountedBytes:40000 ingestedAccountedBytes:0 statsToIgnore:{ingestStats:{Bytes:0 ApproxIngestedIntoL0Bytes:0 MemtableOverlappingFiles:0} writeBytes:0} aux:{bypassedCount:0 writeBypassedAccountedBytes:0 ingestedBypassedAccountedBytes:0}}
+{workCount:10000 writeAccountedBytes:40000 ingestedAccountedBytes:0 statsToIgnore:{ingestStats:{Bytes:0 ApproxIngestedIntoL0Bytes:0 MemtableOverlappingFiles:0} writeBytes:0} aboveRaftStats:{workCount:10000 writeAccountedBytes:40000 ingestedAccountedBytes:0} aux:{bypassedCount:0 writeBypassedAccountedBytes:0 ingestedBypassedAccountedBytes:0}}
 
 # Delta added is 100,000. The l0-bytes are the same, so compactions removed
 # 100,000 bytes. Smoothed removed by compactions is 50,000. Each admitted is
@@ -603,7 +603,7 @@ init
 
 prep-admission-stats admitted=0
 ----
-{workCount:0 writeAccountedBytes:0 ingestedAccountedBytes:0 statsToIgnore:{ingestStats:{Bytes:0 ApproxIngestedIntoL0Bytes:0 MemtableOverlappingFiles:0} writeBytes:0} aux:{bypassedCount:0 writeBypassedAccountedBytes:0 ingestedBypassedAccountedBytes:0}}
+{workCount:0 writeAccountedBytes:0 ingestedAccountedBytes:0 statsToIgnore:{ingestStats:{Bytes:0 ApproxIngestedIntoL0Bytes:0 MemtableOverlappingFiles:0} writeBytes:0} aboveRaftStats:{workCount:0 writeAccountedBytes:0 ingestedAccountedBytes:0} aux:{bypassedCount:0 writeBypassedAccountedBytes:0 ingestedBypassedAccountedBytes:0}}
 
 set-state l0-bytes=10000 l0-added-write=1000 l0-files=5 l0-sublevels=5 print-only-first-tick=true loaded=true
 ----
@@ -685,7 +685,7 @@ init
 
 prep-admission-stats admitted=0
 ----
-{workCount:0 writeAccountedBytes:0 ingestedAccountedBytes:0 statsToIgnore:{ingestStats:{Bytes:0 ApproxIngestedIntoL0Bytes:0 MemtableOverlappingFiles:0} writeBytes:0} aux:{bypassedCount:0 writeBypassedAccountedBytes:0 ingestedBypassedAccountedBytes:0}}
+{workCount:0 writeAccountedBytes:0 ingestedAccountedBytes:0 statsToIgnore:{ingestStats:{Bytes:0 ApproxIngestedIntoL0Bytes:0 MemtableOverlappingFiles:0} writeBytes:0} aboveRaftStats:{workCount:0 writeAccountedBytes:0 ingestedAccountedBytes:0} aux:{bypassedCount:0 writeBypassedAccountedBytes:0 ingestedBypassedAccountedBytes:0}}
 
 set-state l0-bytes=10000 l0-added-write=1000 l0-files=21 l0-sublevels=21 print-only-first-tick=true
 ----

--- a/pkg/util/admission/testdata/store_per_work_token_estimator
+++ b/pkg/util/admission/testdata/store_per_work_token_estimator
@@ -12,19 +12,21 @@ ingest-tokens: int: 0.00x+0 smoothed: 1.00x+1 per-work-accounted: 1
 
 # Writes account for ~1/2 of what is written, reflecting what can happen with
 # application to the state machine. No ingests.
-update flushed=1000 ingested=0 admitted=10 write-accounted=500 ingested-accounted=0
+update flushed=1000 ingested=0 admitted=10 write-accounted=500 ingested-accounted=0 above-raft-count=8 above-raft-write=40
 ----
 interval state: {intWorkCount:10 intL0WriteBytes:1000 intL0IngestedBytes:0 intLSMIngestedBytes:0 intL0WriteAccountedBytes:500 intIngestedAccountedBytes:0 intL0WriteLinearModel:{multiplier:1.98 constant:1} intL0IngestedLinearModel:{multiplier:0 constant:0} intIngestedLinearModel:{multiplier:0 constant:0} intBypassedWorkCount:0 intL0WriteBypassedAccountedBytes:0 intIngestedBypassedAccountedBytes:0 intL0IgnoredWriteBytes:0 intL0IgnoredIngestedBytes:0}
-at-admission-tokens: 50
+at-admission-tokens: 5
 L0-write-tokens: int: 1.98x+1 smoothed: 1.86x+1 per-work-accounted: 25
 L0-ingest-tokens: int: 0.00x+0 smoothed: 0.75x+1 per-work-accounted: 1
 ingest-tokens: int: 0.00x+0 smoothed: 1.00x+1 per-work-accounted: 1
 
-# Same as previous, except some of these are bypassed. Will not affect the model.
+# Same as previous, except some of these are bypassed. Will not affect the
+# model. Since there are no above-raft stats, at-admission-tokens is
+# unchanged.
 update flushed=1000 ingested=0 admitted=10 write-accounted=500 ingested-accounted=0 bypassed-count=4 bypassed-write=300 bypassed-ingested=0
 ----
 interval state: {intWorkCount:10 intL0WriteBytes:1000 intL0IngestedBytes:0 intLSMIngestedBytes:0 intL0WriteAccountedBytes:500 intIngestedAccountedBytes:0 intL0WriteLinearModel:{multiplier:1.98 constant:1} intL0IngestedLinearModel:{multiplier:0 constant:0} intIngestedLinearModel:{multiplier:0 constant:0} intBypassedWorkCount:4 intL0WriteBypassedAccountedBytes:300 intIngestedBypassedAccountedBytes:0 intL0IgnoredWriteBytes:0 intL0IgnoredIngestedBytes:0}
-at-admission-tokens: 75
+at-admission-tokens: 5
 L0-write-tokens: int: 1.98x+1 smoothed: 1.92x+1 per-work-accounted: 37
 L0-ingest-tokens: int: 0.00x+0 smoothed: 0.75x+1 per-work-accounted: 1
 ingest-tokens: int: 0.00x+0 smoothed: 1.00x+1 per-work-accounted: 1
@@ -39,10 +41,10 @@ ingest-tokens: int: 0.00x+0 smoothed: 1.00x+1 per-work-accounted: 1
 # model uses all the ingested bytes including other-levels-ingested, so the
 # observed bytes are 1000+9000=10000, and the accounted bytes are 4000, so the
 # max multiplier of 1.5 is used and the rest handled in the additive term.
-update flushed=1000 ingested=1000 other-levels-ingested=9000 admitted=10 write-accounted=500 ingested-accounted=4000 bypassed-count=2 bypassed-write=0 bypassed-ingested=2000
+update flushed=1000 ingested=1000 other-levels-ingested=9000 admitted=10 write-accounted=500 ingested-accounted=4000 bypassed-count=2 bypassed-write=0 bypassed-ingested=2000 above-raft-count=4 above-raft-write=100
 ----
 interval state: {intWorkCount:10 intL0WriteBytes:1000 intL0IngestedBytes:1000 intLSMIngestedBytes:10000 intL0WriteAccountedBytes:500 intIngestedAccountedBytes:4000 intL0WriteLinearModel:{multiplier:1.98 constant:1} intL0IngestedLinearModel:{multiplier:0.2475 constant:1} intIngestedLinearModel:{multiplier:1.5 constant:400} intBypassedWorkCount:2 intL0WriteBypassedAccountedBytes:0 intIngestedBypassedAccountedBytes:2000 intL0IgnoredWriteBytes:0 intL0IgnoredIngestedBytes:0}
-at-admission-tokens: 137
+at-admission-tokens: 19
 L0-write-tokens: int: 1.98x+1 smoothed: 1.95x+1 per-work-accounted: 43
 L0-ingest-tokens: int: 0.25x+1 smoothed: 0.50x+1 per-work-accounted: 200
 ingest-tokens: int: 1.50x+400 smoothed: 1.25x+200 per-work-accounted: 200
@@ -51,19 +53,20 @@ ingest-tokens: int: 1.50x+400 smoothed: 1.25x+200 per-work-accounted: 200
 # -- this updates the L0-ingest model since all these ingested bytes have gone
 # to levels lower than L0. For the ingest model, the observed bytes are 500,
 # and the accounted bytes are 500, hence the multiplier close to 1.0.
-update flushed=1000 ingested=0 other-levels-ingested=500 admitted=10 write-accounted=450 ingested-accounted=500
+update flushed=1000 ingested=0 other-levels-ingested=500 admitted=10 write-accounted=450 ingested-accounted=500 above-raft-count=2 above-raft-write=225 above-write-ingested=250
 ----
 interval state: {intWorkCount:10 intL0WriteBytes:1000 intL0IngestedBytes:0 intLSMIngestedBytes:500 intL0WriteAccountedBytes:450 intIngestedAccountedBytes:500 intL0WriteLinearModel:{multiplier:2.2 constant:1} intL0IngestedLinearModel:{multiplier:0.001 constant:1} intIngestedLinearModel:{multiplier:0.98 constant:1} intBypassedWorkCount:0 intL0WriteBypassedAccountedBytes:0 intIngestedBypassedAccountedBytes:0 intL0IgnoredWriteBytes:0 intL0IgnoredIngestedBytes:0}
-at-admission-tokens: 118
+at-admission-tokens: 120
 L0-write-tokens: int: 2.20x+1 smoothed: 2.08x+1 per-work-accounted: 44
 L0-ingest-tokens: int: 0.00x+1 smoothed: 0.25x+1 per-work-accounted: 125
 ingest-tokens: int: 0.98x+1 smoothed: 1.11x+100 per-work-accounted: 125
 
-# Large amount of ingestion. Bumps up at-admission-tokens.
-update flushed=1000 ingested=1000000 other-levels-ingested=2000000 admitted=10 write-accounted=450 ingested-accounted=2000000
+# Large amount of ingestion. Does not bump up at-admission-tokens to a very
+# large value since the ingestions do below-raft admission.
+update flushed=1000 ingested=1000000 other-levels-ingested=2000000 admitted=10 write-accounted=450 ingested-accounted=2000000 above-raft-count=10 above-raft-write=450
 ----
 interval state: {intWorkCount:10 intL0WriteBytes:1000 intL0IngestedBytes:1000000 intLSMIngestedBytes:3000000 intL0WriteAccountedBytes:450 intIngestedAccountedBytes:2000000 intL0WriteLinearModel:{multiplier:2.2 constant:1} intL0IngestedLinearModel:{multiplier:0.499995 constant:1} intIngestedLinearModel:{multiplier:1.499995 constant:1} intBypassedWorkCount:0 intL0WriteBypassedAccountedBytes:0 intIngestedBypassedAccountedBytes:0 intL0IgnoredWriteBytes:0 intL0IgnoredIngestedBytes:0}
-at-admission-tokens: 50109
+at-admission-tokens: 124
 L0-write-tokens: int: 2.20x+1 smoothed: 2.14x+1 per-work-accounted: 44
 L0-ingest-tokens: int: 0.50x+1 smoothed: 0.37x+1 per-work-accounted: 100062
 ingest-tokens: int: 1.50x+1 smoothed: 1.31x+50 per-work-accounted: 100062
@@ -74,7 +77,7 @@ ingest-tokens: int: 1.50x+1 smoothed: 1.31x+50 per-work-accounted: 100062
 update flushed=0 ingested=1000000 admitted=10 write-accounted=0 ingested-accounted=2000 ignore-ingested-into-L0=998000
 ----
 interval state: {intWorkCount:10 intL0WriteBytes:0 intL0IngestedBytes:1000000 intLSMIngestedBytes:1000000 intL0WriteAccountedBytes:0 intIngestedAccountedBytes:2000 intL0WriteLinearModel:{multiplier:0 constant:0} intL0IngestedLinearModel:{multiplier:0.995 constant:1} intIngestedLinearModel:{multiplier:0.995 constant:1} intBypassedWorkCount:0 intL0WriteBypassedAccountedBytes:0 intIngestedBypassedAccountedBytes:0 intL0IgnoredWriteBytes:0 intL0IgnoredIngestedBytes:998000}
-at-admission-tokens: 25154
+at-admission-tokens: 124
 L0-write-tokens: int: 0.00x+0 smoothed: 2.14x+1 per-work-accounted: 44
 L0-ingest-tokens: int: 0.99x+1 smoothed: 0.68x+1 per-work-accounted: 50131
 ingest-tokens: int: 0.99x+1 smoothed: 1.15x+25 per-work-accounted: 50131
@@ -83,17 +86,18 @@ ingest-tokens: int: 0.99x+1 smoothed: 1.15x+25 per-work-accounted: 50131
 update flushed=0 ingested=1000000 admitted=10 write-accounted=0 ingested-accounted=2000 ignore-ingested-into-L0=998000
 ----
 interval state: {intWorkCount:10 intL0WriteBytes:0 intL0IngestedBytes:1000000 intLSMIngestedBytes:1000000 intL0WriteAccountedBytes:0 intIngestedAccountedBytes:2000 intL0WriteLinearModel:{multiplier:0 constant:0} intL0IngestedLinearModel:{multiplier:0.995 constant:1} intIngestedLinearModel:{multiplier:0.995 constant:1} intBypassedWorkCount:0 intL0WriteBypassedAccountedBytes:0 intIngestedBypassedAccountedBytes:0 intL0IgnoredWriteBytes:0 intL0IgnoredIngestedBytes:998000}
-at-admission-tokens: 12677
+at-admission-tokens: 124
 L0-write-tokens: int: 0.00x+0 smoothed: 2.14x+1 per-work-accounted: 44
 L0-ingest-tokens: int: 0.99x+1 smoothed: 0.84x+1 per-work-accounted: 25165
 ingest-tokens: int: 0.99x+1 smoothed: 1.07x+13 per-work-accounted: 25165
 
 # Large number of bytes written into L0, but only 2000 are not to be ignored.
-# So we can fit a reasonable model.
-update flushed=1000000 ingested=0 admitted=10 write-accounted=1000 ingested-accounted=0 ignored-written=998000
+# So we can fit a reasonable model. The above-raft writes are small, so
+# at-admission-tokens shrinks.
+update flushed=1000000 ingested=0 admitted=10 write-accounted=1000 ingested-accounted=0 ignored-written=998000 above-raft-count=9 above-raft-write=20
 ----
 interval state: {intWorkCount:10 intL0WriteBytes:1000000 intL0IngestedBytes:0 intLSMIngestedBytes:0 intL0WriteAccountedBytes:1000 intIngestedAccountedBytes:0 intL0WriteLinearModel:{multiplier:1.99 constant:1} intL0IngestedLinearModel:{multiplier:0 constant:0} intIngestedLinearModel:{multiplier:0 constant:0} intBypassedWorkCount:0 intL0WriteBypassedAccountedBytes:0 intIngestedBypassedAccountedBytes:0 intL0IgnoredWriteBytes:998000 intL0IgnoredIngestedBytes:0}
-at-admission-tokens: 6438
+at-admission-tokens: 64
 L0-write-tokens: int: 1.99x+1 smoothed: 2.06x+1 per-work-accounted: 72
 L0-ingest-tokens: int: 0.00x+0 smoothed: 0.84x+1 per-work-accounted: 25165
 ingest-tokens: int: 0.00x+0 smoothed: 1.07x+6 per-work-accounted: 25165
@@ -102,7 +106,7 @@ ingest-tokens: int: 0.00x+0 smoothed: 1.07x+6 per-work-accounted: 25165
 update flushed=2000 ingested=0 admitted=10 write-accounted=1000 ingested-accounted=0 ignored-written=998000
 ----
 interval state: {intWorkCount:10 intL0WriteBytes:2000 intL0IngestedBytes:0 intLSMIngestedBytes:0 intL0WriteAccountedBytes:1000 intIngestedAccountedBytes:0 intL0WriteLinearModel:{multiplier:0 constant:0} intL0IngestedLinearModel:{multiplier:0 constant:0} intIngestedLinearModel:{multiplier:0 constant:0} intBypassedWorkCount:0 intL0WriteBypassedAccountedBytes:0 intIngestedBypassedAccountedBytes:0 intL0IgnoredWriteBytes:998000 intL0IgnoredIngestedBytes:0}
-at-admission-tokens: 6438
+at-admission-tokens: 64
 L0-write-tokens: int: 0.00x+0 smoothed: 2.06x+1 per-work-accounted: 72
 L0-ingest-tokens: int: 0.00x+0 smoothed: 0.84x+1 per-work-accounted: 25165
 ingest-tokens: int: 0.00x+0 smoothed: 1.07x+3 per-work-accounted: 25165

--- a/pkg/util/admission/testdata/store_work_queue
+++ b/pkg/util/admission/testdata/store_work_queue
@@ -5,7 +5,7 @@ print
 ----
 regular workqueue: closed epoch: 0 tenantHeap len: 0
 elastic workqueue: closed epoch: 0 tenantHeap len: 0
-stats:{workCount:0 writeAccountedBytes:0 ingestedAccountedBytes:0 statsToIgnore:{ingestStats:{Bytes:0 ApproxIngestedIntoL0Bytes:0 MemtableOverlappingFiles:0} writeBytes:0} aux:{bypassedCount:0 writeBypassedAccountedBytes:0 ingestedBypassedAccountedBytes:0}}
+stats:{workCount:0 writeAccountedBytes:0 ingestedAccountedBytes:0 statsToIgnore:{ingestStats:{Bytes:0 ApproxIngestedIntoL0Bytes:0 MemtableOverlappingFiles:0} writeBytes:0} aboveRaftStats:{workCount:0 writeAccountedBytes:0 ingestedAccountedBytes:0} aux:{bypassedCount:0 writeBypassedAccountedBytes:0 ingestedBypassedAccountedBytes:0}}
 estimates:{writeTokens:1}
 
 set-try-get-return-value v=true
@@ -25,7 +25,7 @@ set-store-request-estimates write-tokens=100
 regular workqueue: closed epoch: 0 tenantHeap len: 0
  tenant-id: 53 used: 1, w: 1, fifo: -128
 elastic workqueue: closed epoch: 0 tenantHeap len: 0
-stats:{workCount:1 writeAccountedBytes:0 ingestedAccountedBytes:0 statsToIgnore:{ingestStats:{Bytes:0 ApproxIngestedIntoL0Bytes:0 MemtableOverlappingFiles:0} writeBytes:0} aux:{bypassedCount:0 writeBypassedAccountedBytes:0 ingestedBypassedAccountedBytes:0}}
+stats:{workCount:1 writeAccountedBytes:0 ingestedAccountedBytes:0 statsToIgnore:{ingestStats:{Bytes:0 ApproxIngestedIntoL0Bytes:0 MemtableOverlappingFiles:0} writeBytes:0} aboveRaftStats:{workCount:1 writeAccountedBytes:0 ingestedAccountedBytes:0} aux:{bypassedCount:0 writeBypassedAccountedBytes:0 ingestedBypassedAccountedBytes:0}}
 estimates:{writeTokens:100}
 
 admit id=2 tenant=55 priority=0 create-time-millis=1 bypass=false
@@ -44,7 +44,7 @@ regular workqueue: closed epoch: 0 tenantHeap len: 0
  tenant-id: 53 used: 101, w: 1, fifo: -128
  tenant-id: 55 used: 100, w: 1, fifo: -128
 elastic workqueue: closed epoch: 0 tenantHeap len: 0
-stats:{workCount:1 writeAccountedBytes:0 ingestedAccountedBytes:0 statsToIgnore:{ingestStats:{Bytes:0 ApproxIngestedIntoL0Bytes:0 MemtableOverlappingFiles:0} writeBytes:0} aux:{bypassedCount:0 writeBypassedAccountedBytes:0 ingestedBypassedAccountedBytes:0}}
+stats:{workCount:1 writeAccountedBytes:0 ingestedAccountedBytes:0 statsToIgnore:{ingestStats:{Bytes:0 ApproxIngestedIntoL0Bytes:0 MemtableOverlappingFiles:0} writeBytes:0} aboveRaftStats:{workCount:1 writeAccountedBytes:0 ingestedAccountedBytes:0} aux:{bypassedCount:0 writeBypassedAccountedBytes:0 ingestedBypassedAccountedBytes:0}}
 estimates:{writeTokens:100}
 
 set-try-get-return-value v=false
@@ -65,7 +65,7 @@ regular workqueue: closed epoch: 0 tenantHeap len: 1 top tenant: 57
  tenant-id: 55 used: 600, w: 1, fifo: -128
  tenant-id: 57 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 0]
 elastic workqueue: closed epoch: 0 tenantHeap len: 0
-stats:{workCount:2 writeAccountedBytes:0 ingestedAccountedBytes:0 statsToIgnore:{ingestStats:{Bytes:0 ApproxIngestedIntoL0Bytes:0 MemtableOverlappingFiles:0} writeBytes:0} aux:{bypassedCount:0 writeBypassedAccountedBytes:0 ingestedBypassedAccountedBytes:0}}
+stats:{workCount:2 writeAccountedBytes:0 ingestedAccountedBytes:0 statsToIgnore:{ingestStats:{Bytes:0 ApproxIngestedIntoL0Bytes:0 MemtableOverlappingFiles:0} writeBytes:0} aboveRaftStats:{workCount:2 writeAccountedBytes:0 ingestedAccountedBytes:0} aux:{bypassedCount:0 writeBypassedAccountedBytes:0 ingestedBypassedAccountedBytes:0}}
 estimates:{writeTokens:100}
 
 granted
@@ -81,7 +81,7 @@ regular workqueue: closed epoch: 0 tenantHeap len: 0
  tenant-id: 55 used: 600, w: 1, fifo: -128
  tenant-id: 57 used: 100, w: 1, fifo: -128
 elastic workqueue: closed epoch: 0 tenantHeap len: 0
-stats:{workCount:2 writeAccountedBytes:0 ingestedAccountedBytes:0 statsToIgnore:{ingestStats:{Bytes:0 ApproxIngestedIntoL0Bytes:0 MemtableOverlappingFiles:0} writeBytes:0} aux:{bypassedCount:0 writeBypassedAccountedBytes:0 ingestedBypassedAccountedBytes:0}}
+stats:{workCount:2 writeAccountedBytes:0 ingestedAccountedBytes:0 statsToIgnore:{ingestStats:{Bytes:0 ApproxIngestedIntoL0Bytes:0 MemtableOverlappingFiles:0} writeBytes:0} aboveRaftStats:{workCount:2 writeAccountedBytes:0 ingestedAccountedBytes:0} aux:{bypassedCount:0 writeBypassedAccountedBytes:0 ingestedBypassedAccountedBytes:0}}
 estimates:{writeTokens:100}
 
 work-done id=3 ingested-bytes=1000000 additional-tokens=50000
@@ -95,7 +95,7 @@ regular workqueue: closed epoch: 0 tenantHeap len: 0
  tenant-id: 55 used: 600, w: 1, fifo: -128
  tenant-id: 57 used: 100, w: 1, fifo: -128
 elastic workqueue: closed epoch: 0 tenantHeap len: 0
-stats:{workCount:3 writeAccountedBytes:0 ingestedAccountedBytes:1000000 statsToIgnore:{ingestStats:{Bytes:0 ApproxIngestedIntoL0Bytes:0 MemtableOverlappingFiles:0} writeBytes:0} aux:{bypassedCount:0 writeBypassedAccountedBytes:0 ingestedBypassedAccountedBytes:0}}
+stats:{workCount:3 writeAccountedBytes:0 ingestedAccountedBytes:1000000 statsToIgnore:{ingestStats:{Bytes:0 ApproxIngestedIntoL0Bytes:0 MemtableOverlappingFiles:0} writeBytes:0} aboveRaftStats:{workCount:3 writeAccountedBytes:0 ingestedAccountedBytes:1000000} aux:{bypassedCount:0 writeBypassedAccountedBytes:0 ingestedBypassedAccountedBytes:0}}
 estimates:{writeTokens:100}
 
 set-store-request-estimates write-tokens=10000
@@ -105,7 +105,7 @@ regular workqueue: closed epoch: 0 tenantHeap len: 0
  tenant-id: 55 used: 600, w: 1, fifo: -128
  tenant-id: 57 used: 100, w: 1, fifo: -128
 elastic workqueue: closed epoch: 0 tenantHeap len: 0
-stats:{workCount:3 writeAccountedBytes:0 ingestedAccountedBytes:1000000 statsToIgnore:{ingestStats:{Bytes:0 ApproxIngestedIntoL0Bytes:0 MemtableOverlappingFiles:0} writeBytes:0} aux:{bypassedCount:0 writeBypassedAccountedBytes:0 ingestedBypassedAccountedBytes:0}}
+stats:{workCount:3 writeAccountedBytes:0 ingestedAccountedBytes:1000000 statsToIgnore:{ingestStats:{Bytes:0 ApproxIngestedIntoL0Bytes:0 MemtableOverlappingFiles:0} writeBytes:0} aboveRaftStats:{workCount:3 writeAccountedBytes:0 ingestedAccountedBytes:1000000} aux:{bypassedCount:0 writeBypassedAccountedBytes:0 ingestedBypassedAccountedBytes:0}}
 estimates:{writeTokens:10000}
 
 work-done id=4 write-bytes=2000 ingested-bytes=1000 additional-tokens=2000
@@ -119,7 +119,7 @@ regular workqueue: closed epoch: 0 tenantHeap len: 0
  tenant-id: 55 used: 600, w: 1, fifo: -128
  tenant-id: 57 used: 2100, w: 1, fifo: -128
 elastic workqueue: closed epoch: 0 tenantHeap len: 0
-stats:{workCount:4 writeAccountedBytes:2000 ingestedAccountedBytes:1001000 statsToIgnore:{ingestStats:{Bytes:0 ApproxIngestedIntoL0Bytes:0 MemtableOverlappingFiles:0} writeBytes:0} aux:{bypassedCount:0 writeBypassedAccountedBytes:0 ingestedBypassedAccountedBytes:0}}
+stats:{workCount:4 writeAccountedBytes:2000 ingestedAccountedBytes:1001000 statsToIgnore:{ingestStats:{Bytes:0 ApproxIngestedIntoL0Bytes:0 MemtableOverlappingFiles:0} writeBytes:0} aboveRaftStats:{workCount:4 writeAccountedBytes:2000 ingestedAccountedBytes:1001000} aux:{bypassedCount:0 writeBypassedAccountedBytes:0 ingestedBypassedAccountedBytes:0}}
 estimates:{writeTokens:10000}
 
 bypassed-work-done work-count=10 write-bytes=1000 ingested-bytes=1000000
@@ -133,7 +133,7 @@ regular workqueue: closed epoch: 0 tenantHeap len: 0
  tenant-id: 55 used: 600, w: 1, fifo: -128
  tenant-id: 57 used: 2100, w: 1, fifo: -128
 elastic workqueue: closed epoch: 0 tenantHeap len: 0
-stats:{workCount:14 writeAccountedBytes:3000 ingestedAccountedBytes:2001000 statsToIgnore:{ingestStats:{Bytes:0 ApproxIngestedIntoL0Bytes:0 MemtableOverlappingFiles:0} writeBytes:0} aux:{bypassedCount:10 writeBypassedAccountedBytes:1000 ingestedBypassedAccountedBytes:1000000}}
+stats:{workCount:14 writeAccountedBytes:3000 ingestedAccountedBytes:2001000 statsToIgnore:{ingestStats:{Bytes:0 ApproxIngestedIntoL0Bytes:0 MemtableOverlappingFiles:0} writeBytes:0} aboveRaftStats:{workCount:4 writeAccountedBytes:2000 ingestedAccountedBytes:1001000} aux:{bypassedCount:10 writeBypassedAccountedBytes:1000 ingestedBypassedAccountedBytes:1000000}}
 estimates:{writeTokens:10000}
 
 stats-to-ignore ingested-bytes=12000 ingested-into-L0-bytes=9000 write-bytes=1500
@@ -143,7 +143,7 @@ regular workqueue: closed epoch: 0 tenantHeap len: 0
  tenant-id: 55 used: 600, w: 1, fifo: -128
  tenant-id: 57 used: 2100, w: 1, fifo: -128
 elastic workqueue: closed epoch: 0 tenantHeap len: 0
-stats:{workCount:14 writeAccountedBytes:3000 ingestedAccountedBytes:2001000 statsToIgnore:{ingestStats:{Bytes:12000 ApproxIngestedIntoL0Bytes:9000 MemtableOverlappingFiles:0} writeBytes:1500} aux:{bypassedCount:10 writeBypassedAccountedBytes:1000 ingestedBypassedAccountedBytes:1000000}}
+stats:{workCount:14 writeAccountedBytes:3000 ingestedAccountedBytes:2001000 statsToIgnore:{ingestStats:{Bytes:12000 ApproxIngestedIntoL0Bytes:9000 MemtableOverlappingFiles:0} writeBytes:1500} aboveRaftStats:{workCount:4 writeAccountedBytes:2000 ingestedAccountedBytes:1001000} aux:{bypassedCount:10 writeBypassedAccountedBytes:1000 ingestedBypassedAccountedBytes:1000000}}
 estimates:{writeTokens:10000}
 
 # Elastic work.
@@ -171,7 +171,7 @@ regular workqueue: closed epoch: 0 tenantHeap len: 0
  tenant-id: 57 used: 2100, w: 1, fifo: -128
 elastic workqueue: closed epoch: 0 tenantHeap len: 0
  tenant-id: 53 used: 10000, w: 1, fifo: -128
-stats:{workCount:14 writeAccountedBytes:3000 ingestedAccountedBytes:2001000 statsToIgnore:{ingestStats:{Bytes:12000 ApproxIngestedIntoL0Bytes:9000 MemtableOverlappingFiles:0} writeBytes:1500} aux:{bypassedCount:10 writeBypassedAccountedBytes:1000 ingestedBypassedAccountedBytes:1000000}}
+stats:{workCount:14 writeAccountedBytes:3000 ingestedAccountedBytes:2001000 statsToIgnore:{ingestStats:{Bytes:12000 ApproxIngestedIntoL0Bytes:9000 MemtableOverlappingFiles:0} writeBytes:1500} aboveRaftStats:{workCount:4 writeAccountedBytes:2000 ingestedAccountedBytes:1001000} aux:{bypassedCount:10 writeBypassedAccountedBytes:1000 ingestedBypassedAccountedBytes:1000000}}
 estimates:{writeTokens:10000}
 
 set-try-get-return-value v=true elastic=true
@@ -191,7 +191,7 @@ regular workqueue: closed epoch: 0 tenantHeap len: 0
 elastic workqueue: closed epoch: 0 tenantHeap len: 0
  tenant-id: 53 used: 10000, w: 1, fifo: -128
  tenant-id: 54 used: 10000, w: 1, fifo: -128
-stats:{workCount:14 writeAccountedBytes:3000 ingestedAccountedBytes:2001000 statsToIgnore:{ingestStats:{Bytes:12000 ApproxIngestedIntoL0Bytes:9000 MemtableOverlappingFiles:0} writeBytes:1500} aux:{bypassedCount:10 writeBypassedAccountedBytes:1000 ingestedBypassedAccountedBytes:1000000}}
+stats:{workCount:14 writeAccountedBytes:3000 ingestedAccountedBytes:2001000 statsToIgnore:{ingestStats:{Bytes:12000 ApproxIngestedIntoL0Bytes:9000 MemtableOverlappingFiles:0} writeBytes:1500} aboveRaftStats:{workCount:4 writeAccountedBytes:2000 ingestedAccountedBytes:1001000} aux:{bypassedCount:10 writeBypassedAccountedBytes:1000 ingestedBypassedAccountedBytes:1000000}}
 estimates:{writeTokens:10000}
 
 work-done id=5 write-bytes=1000 additional-tokens=200
@@ -207,7 +207,7 @@ regular workqueue: closed epoch: 0 tenantHeap len: 0
 elastic workqueue: closed epoch: 0 tenantHeap len: 0
  tenant-id: 53 used: 10200, w: 1, fifo: -128
  tenant-id: 54 used: 10000, w: 1, fifo: -128
-stats:{workCount:15 writeAccountedBytes:4000 ingestedAccountedBytes:2001000 statsToIgnore:{ingestStats:{Bytes:12000 ApproxIngestedIntoL0Bytes:9000 MemtableOverlappingFiles:0} writeBytes:1500} aux:{bypassedCount:10 writeBypassedAccountedBytes:1000 ingestedBypassedAccountedBytes:1000000}}
+stats:{workCount:15 writeAccountedBytes:4000 ingestedAccountedBytes:2001000 statsToIgnore:{ingestStats:{Bytes:12000 ApproxIngestedIntoL0Bytes:9000 MemtableOverlappingFiles:0} writeBytes:1500} aboveRaftStats:{workCount:5 writeAccountedBytes:3000 ingestedAccountedBytes:1001000} aux:{bypassedCount:10 writeBypassedAccountedBytes:1000 ingestedBypassedAccountedBytes:1000000}}
 estimates:{writeTokens:10000}
 
 work-done id=6 ingested-bytes=500 additional-tokens=500
@@ -223,5 +223,5 @@ regular workqueue: closed epoch: 0 tenantHeap len: 0
 elastic workqueue: closed epoch: 0 tenantHeap len: 0
  tenant-id: 53 used: 10200, w: 1, fifo: -128
  tenant-id: 54 used: 10500, w: 1, fifo: -128
-stats:{workCount:16 writeAccountedBytes:4000 ingestedAccountedBytes:2001500 statsToIgnore:{ingestStats:{Bytes:12000 ApproxIngestedIntoL0Bytes:9000 MemtableOverlappingFiles:0} writeBytes:1500} aux:{bypassedCount:10 writeBypassedAccountedBytes:1000 ingestedBypassedAccountedBytes:1000000}}
+stats:{workCount:16 writeAccountedBytes:4000 ingestedAccountedBytes:2001500 statsToIgnore:{ingestStats:{Bytes:12000 ApproxIngestedIntoL0Bytes:9000 MemtableOverlappingFiles:0} writeBytes:1500} aboveRaftStats:{workCount:6 writeAccountedBytes:3000 ingestedAccountedBytes:1001500} aux:{bypassedCount:10 writeBypassedAccountedBytes:1000 ingestedBypassedAccountedBytes:1000000}}
 estimates:{writeTokens:10000}


### PR DESCRIPTION
The at-admission-tokens are used for writes that are not subject to replication admission control (which was all the writes prior to implementation of replication AC). Now, only regular work by default goes through this path, and elastic work is subject to replication AC. Elastic work includes large writes, like AddSSTable, that if counted towards the at-admission-tokens inflate the mean size that is deducted at admission time. For high throughput regular work, deducting a large amount of tokens at admission time can have a detrimental effect on throughput, in the presence of small latency perturbations in evaluation and replication (outside AC's control, such as scheduling delay), since the unused tokens are returned too late to avoid temporary token exhaustion (which causes unnecessary queueing).

We saw such regular writes token exhaustion in an internal experiment when running an index backill plus regular writes, even though the regular tokens should have been enough. This is reproducible in controlled kv0 experiments.

The issue is fixed by only including writes that are not subject to replication admission control (above-raft AC), in the logic for at-admission-tokens estimation.

Fixes https://github.com/cockroachdb/cockroach/issues/113711

Epic: none

Release note: None