### PR TITLE
sql/tests: use SFU with consistent lock ordering in Bank benchmark

### DIFF
--- a/pkg/sql/tests/bank_test.go
+++ b/pkg/sql/tests/bank_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/bench"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
 // maxTransfer is the maximum amount to transfer in one transaction.
@@ -72,6 +73,7 @@ UPDATE bench.bank
 }
 
 func BenchmarkBank(b *testing.B) {
+	defer log.Scope(b).Close(b)
 	bench.ForEachDB(b, func(b *testing.B, db *sqlutils.SQLRunner) {
 		for _, numAccounts := range []int{2, 4, 8, 32, 64} {
 			b.Run(fmt.Sprintf("numAccounts=%d", numAccounts), func(b *testing.B) {


### PR DESCRIPTION
Fixes #113513.

The bank benchmark is heavily contended and was not careful about lock ordering. This lead to thrashing and poor performance, which 83233220 made worse. Critically though, the workload was already thrashing and performing poorly before that change, so we don't consider this to be a concerning regression.

This commit resolves this and improves the benchmark by an order of magnitude by introducing SELECT FOR UPDATE locking with a consistent lock ordering. This eliminates the thrashing between transactions.

```
name                                                 old time/op    new time/op    delta
Bank/Cockroach/numAccounts=2-10                        2.91ms ±10%    0.31ms ±14%  -89.48%  (p=0.000 n=10+10)
Bank/Cockroach/numAccounts=4-10                        1.58ms ±10%    0.30ms ±10%  -80.71%  (p=0.000 n=10+9)
Bank/Cockroach/numAccounts=8-10                         745µs ±19%     219µs ±15%  -70.54%  (p=0.000 n=10+9)
Bank/Cockroach/numAccounts=32-10                        182µs ± 8%     148µs ± 7%  -18.60%  (p=0.000 n=10+9)
Bank/Cockroach/numAccounts=64-10                        144µs ± 9%     142µs ±15%     ~     (p=0.211 n=9+10)
Bank/SharedProcessTenantCockroach/numAccounts=2-10     3.36ms ±10%    0.33ms ±18%  -90.31%  (p=0.000 n=10+10)
Bank/SharedProcessTenantCockroach/numAccounts=4-10     1.64ms ±10%    0.33ms ±10%  -79.92%  (p=0.000 n=10+9)
Bank/SharedProcessTenantCockroach/numAccounts=8-10      704µs ±13%     247µs ±17%  -64.93%  (p=0.000 n=10+9)
Bank/SharedProcessTenantCockroach/numAccounts=32-10     191µs ± 4%     156µs ±12%  -18.62%  (p=0.000 n=9+9)
Bank/SharedProcessTenantCockroach/numAccounts=64-10     146µs ± 6%     149µs ±13%     ~     (p=0.604 n=10+9)
Bank/MultinodeCockroach/numAccounts=2-10               2.97ms ± 7%    0.61ms ±14%  -79.60%  (p=0.000 n=10+10)
Bank/MultinodeCockroach/numAccounts=4-10               1.77ms ± 7%    0.62ms ±12%  -65.26%  (p=0.000 n=10+9)
Bank/MultinodeCockroach/numAccounts=8-10                807µs ±11%     439µs ± 6%  -45.57%  (p=0.000 n=10+10)
Bank/MultinodeCockroach/numAccounts=32-10               330µs ± 3%     270µs ±12%  -18.08%  (p=0.000 n=9+10)
Bank/MultinodeCockroach/numAccounts=64-10               278µs ±11%     254µs ± 9%   -8.70%  (p=0.009 n=10+10)

name                                                 old alloc/op   new alloc/op   delta
Bank/Cockroach/numAccounts=2-10                        1.66MB ± 6%    0.19MB ± 2%  -88.52%  (p=0.000 n=10+10)
Bank/Cockroach/numAccounts=4-10                        1.04MB ± 6%    0.20MB ± 0%  -80.99%  (p=0.000 n=10+10)
Bank/Cockroach/numAccounts=8-10                         542kB ± 3%     192kB ± 1%  -64.62%  (p=0.000 n=9+10)
Bank/Cockroach/numAccounts=32-10                        207kB ± 1%     181kB ± 1%  -12.85%  (p=0.000 n=9+10)
Bank/Cockroach/numAccounts=64-10                        170kB ± 2%     176kB ± 1%   +3.48%  (p=0.000 n=9+10)
Bank/SharedProcessTenantCockroach/numAccounts=2-10     1.86MB ± 5%    0.21MB ± 0%  -88.65%  (p=0.000 n=10+10)
Bank/SharedProcessTenantCockroach/numAccounts=4-10     1.16MB ± 4%    0.22MB ± 1%  -81.02%  (p=0.000 n=10+9)
Bank/SharedProcessTenantCockroach/numAccounts=8-10      594kB ± 6%     222kB ± 7%  -62.55%  (p=0.000 n=10+10)
Bank/SharedProcessTenantCockroach/numAccounts=32-10     230kB ± 2%     197kB ± 1%  -14.15%  (p=0.000 n=10+10)
Bank/SharedProcessTenantCockroach/numAccounts=64-10     180kB ± 4%     193kB ± 2%   +7.10%  (p=0.000 n=10+9)
Bank/MultinodeCockroach/numAccounts=2-10               2.22MB ± 5%    0.28MB ± 1%  -87.47%  (p=0.000 n=10+10)
Bank/MultinodeCockroach/numAccounts=4-10               1.34MB ± 5%    0.32MB ± 1%  -76.18%  (p=0.000 n=10+9)
Bank/MultinodeCockroach/numAccounts=8-10                719kB ± 4%     313kB ± 2%  -56.44%  (p=0.000 n=10+10)
Bank/MultinodeCockroach/numAccounts=32-10               334kB ± 2%     275kB ± 0%  -17.63%  (p=0.000 n=10+9)
Bank/MultinodeCockroach/numAccounts=64-10               289kB ±10%     287kB ±10%     ~     (p=0.579 n=10+10)

name                                                 old allocs/op  new allocs/op  delta
Bank/Cockroach/numAccounts=2-10                         17.7k ± 6%      2.0k ± 4%  -88.84%  (p=0.000 n=10+10)
Bank/Cockroach/numAccounts=4-10                         11.0k ± 5%      2.1k ± 0%  -81.00%  (p=0.000 n=10+10)
Bank/Cockroach/numAccounts=8-10                         5.70k ± 3%     2.03k ± 0%  -64.35%  (p=0.000 n=9+9)
Bank/Cockroach/numAccounts=32-10                        2.10k ± 1%     1.88k ± 1%  -10.68%  (p=0.000 n=9+10)
Bank/Cockroach/numAccounts=64-10                        1.73k ± 8%     1.83k ± 0%   +5.98%  (p=0.001 n=10+10)
Bank/SharedProcessTenantCockroach/numAccounts=2-10      20.1k ± 4%      2.3k ± 0%  -88.49%  (p=0.000 n=10+10)
Bank/SharedProcessTenantCockroach/numAccounts=4-10      12.9k ± 2%      2.5k ± 0%  -80.82%  (p=0.000 n=9+8)
Bank/SharedProcessTenantCockroach/numAccounts=8-10      6.47k ± 6%     2.51k ±10%  -61.16%  (p=0.000 n=10+10)
Bank/SharedProcessTenantCockroach/numAccounts=32-10     2.44k ± 2%     2.14k ± 0%  -12.21%  (p=0.000 n=10+9)
Bank/SharedProcessTenantCockroach/numAccounts=64-10     1.82k ± 8%     2.06k ± 3%  +13.42%  (p=0.000 n=10+9)
Bank/MultinodeCockroach/numAccounts=2-10                24.0k ± 4%      2.9k ± 0%  -87.99%  (p=0.000 n=10+10)
Bank/MultinodeCockroach/numAccounts=4-10                14.4k ± 6%      3.4k ± 1%  -76.58%  (p=0.000 n=10+10)
Bank/MultinodeCockroach/numAccounts=8-10                7.55k ± 4%     3.31k ± 1%  -56.19%  (p=0.000 n=10+9)
Bank/MultinodeCockroach/numAccounts=32-10               3.32k ± 1%     2.86k ± 1%  -14.04%  (p=0.000 n=9+10)
Bank/MultinodeCockroach/numAccounts=64-10               2.83k ± 8%     2.96k ± 9%     ~     (p=0.447 n=9+10)
```

Interestingly, this would not be needed if implicit SFU worked with this UPDATE plan. Unfortunately, it is disabled by the `balance` check on the "from" account.

Release note: None