### PR TITLE
geo: various geospatial built-in fixes

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial
@@ -6244,4 +6244,16 @@ SELECT ST_Extent(ST_PointFromGeoHash(NULL::TEXT, 1::INT4)::GEOMETRY);
 ----
 NULL
 
+# X min > X max
+query T
+SELECT ST_AsEWKT(ST_MakeEnvelope(8.0::FLOAT8, 2.0::FLOAT8, 5.0::FLOAT8, 4.0::FLOAT8)::GEOMETRY);
+----
+POLYGON ((8 2, 8 4, 5 4, 5 2, 8 2))
+
+# Y min > Y max
+query T
+SELECT ST_AsEWKT(ST_MakeEnvelope(5.0::FLOAT8, 4.0::FLOAT8, 8.0::FLOAT8, 2.0::FLOAT8)::GEOMETRY);
+----
+POLYGON ((5 4, 5 2, 8 2, 8 4, 5 4))
+
 subtest end

--- a/pkg/sql/logictest/testdata/logic_test/geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial
@@ -6219,3 +6219,29 @@ statement ok
 SET testing_optimizer_disable_rule_probability = 0
 
 subtest end
+
+
+subtest regressions
+
+# Regression test for #111157
+query T
+SELECT ST_Extent(ST_GeomFromGeoHash('C'::TEXT, NULL::INT4)::GEOMETRY);
+----
+BOX(-135 45,-90 90)
+
+query T
+SELECT ST_Extent(ST_GeomFromGeoHash(NULL::TEXT, 1::INT4)::GEOMETRY);
+----
+NULL
+
+query T
+SELECT ST_Extent(ST_PointFromGeoHash('C'::TEXT, NULL::INT4)::GEOMETRY);
+----
+BOX(-112.5 67.5,-112.5 67.5)
+
+query T
+SELECT ST_Extent(ST_PointFromGeoHash(NULL::TEXT, 1::INT4)::GEOMETRY);
+----
+NULL
+
+subtest end

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -1127,11 +1127,18 @@ var geoBuiltins = map[string]builtinDefinition{
 				{Name: "geohash", Typ: types.String},
 				{Name: "precision", Typ: types.Int},
 			},
-			ReturnType: tree.FixedReturnType(types.Geometry),
+			CalledOnNullInput: true,
+			ReturnType:        tree.FixedReturnType(types.Geometry),
 			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
+				if args[0] == tree.DNull {
+					return tree.DNull, nil
+				}
 				g := tree.MustBeDString(args[0])
-				p := tree.MustBeDInt(args[1])
-				ret, err := geo.ParseGeometryPointFromGeoHash(string(g), int(p))
+				p := -1
+				if args[1] != tree.DNull {
+					p = int(tree.MustBeDInt(args[1]))
+				}
+				ret, err := geo.ParseGeometryPointFromGeoHash(string(g), p)
 				if err != nil {
 					return nil, err
 				}
@@ -1169,11 +1176,18 @@ var geoBuiltins = map[string]builtinDefinition{
 				{Name: "geohash", Typ: types.String},
 				{Name: "precision", Typ: types.Int},
 			},
-			ReturnType: tree.FixedReturnType(types.Geometry),
-			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			CalledOnNullInput: true,
+			ReturnType:        tree.FixedReturnType(types.Geometry),
+			Fn: func(ctx context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
+				if args[0] == tree.DNull {
+					return tree.DNull, nil
+				}
 				g := tree.MustBeDString(args[0])
-				p := tree.MustBeDInt(args[1])
-				bbox, err := geo.ParseCartesianBoundingBoxFromGeoHash(string(g), int(p))
+				p := -1
+				if args[1] != tree.DNull {
+					p = int(tree.MustBeDInt(args[1]))
+				}
+				bbox, err := geo.ParseCartesianBoundingBoxFromGeoHash(string(g), p)
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -7878,12 +7878,16 @@ func stEnvelopeFromArgs(args tree.Datums) (tree.Datum, error) {
 	if len(args) > 4 {
 		srid = int(tree.MustBeDInt(args[4]))
 	}
+	coords := []float64{
+		xmin, ymin,
+		xmin, ymax,
+		xmax, ymax,
+		xmax, ymin,
+		xmin, ymin,
+	}
 
 	extent, err := geo.MakeGeometryFromGeomT(
-		geom.NewBounds(geom.XY).
-			Set(xmin, ymin, xmax, ymax).
-			Polygon().
-			SetSRID(srid),
+		geom.NewPolygonFlat(geom.XY, coords, []int{len(coords)}).SetSRID(srid),
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
    geo: support null input for geohash builtins
    
    Allows and adds support for NULL inputs for the st_pointfromgeohash and
    st_geomfromgeohash built-ins.
    
    Epic: None
    Informs: #111157
    
    Release note (bug fix): Fixes null input handling for the geospatial
    built-ins st_pointfromgeohash and st_geomfromgeohash.
  

    geo: allow st_makeenvelope min/max bounds to be reversed
    
    Postgis allows xmin/ymin to be greater than xmax/ymax respectively in
    st_makeenvelope, but the geom library does not allow this when
    converting Bounds to Polygon. Instead, we build the polygon explicitly
    from the provided min/max coordinates.
    
    Epic: None
    Fixes: #111157
    
    Release note (bug fix): The geospatial st_makeenvelope built-in now
    correctly supports xmin or ymin to be greater than xmax or ymax,
    respectively.