### PR TITLE
release-23.1: sql/stats: don't use linear regression with NaN for stats forecasting

### DIFF
--- a/pkg/sql/stats/BUILD.bazel
+++ b/pkg/sql/stats/BUILD.bazel
@@ -54,7 +54,6 @@ go_library(
         "//pkg/util/hlc",
         "//pkg/util/intsets",
         "//pkg/util/log",
-        "//pkg/util/log/logcrash",
         "//pkg/util/mon",
         "//pkg/util/protoutil",
         "//pkg/util/stop",

--- a/pkg/sql/stats/simple_linear_regression_test.go
+++ b/pkg/sql/stats/simple_linear_regression_test.go
@@ -286,11 +286,7 @@ func TestQuantileSimpleLinearRegression(t *testing.T) {
 	for i, tc := range testCases {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			yn, r2 := quantileSimpleLinearRegression(tc.x, tc.y, tc.xn)
-			var err error
-			yn, err = yn.fixMalformed()
-			if err != nil {
-				t.Errorf("test case %d had an unexpected error: %s", i, err)
-			}
+			yn = yn.fixMalformed()
 			if !reflect.DeepEqual(yn, tc.yn) {
 				t.Errorf("test case %d incorrect yn %v expected %v", i, yn, tc.yn)
 			}


### PR DESCRIPTION
Backport 2/2 commits from #113712.

/cc @cockroachdb/release

---

This patch adds a method to the quantile function, `invalid`, which checks for `NaN` values within the function. These indicate a failure to derive a linear regression model for the observed histograms, and can lead to internal errors and panics if not caught. Stats forecasting now checks this method before attempting to use a quantile function to derive a histogram prediction.

Fixes #113645
Fixes #113680

Release note (bug fix): Fixed a bug that could cause internal errors or panics while attempting to forecast statistics on a numeric column.

Release justification: fix for internal error encountered by customer
