### PR TITLE
sql: add `crdb_internal.release_series` builtin

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/crdb_internal
+++ b/pkg/ccl/logictestccl/testdata/logic_test/crdb_internal
@@ -201,7 +201,7 @@ ALTER TENANT [5] GRANT CAPABILITY can_admin_split
 query ITT colnames,retry,rowsort
 SELECT * FROM crdb_internal.node_tenant_capabilities_cache WHERE capability_name = 'can_admin_split'
 ----
-tenant_id  capability_name    capability_value
+tenant_id  capability_name  capability_value
 1          can_admin_split  true
 5          can_admin_split  true
 

--- a/pkg/ccl/logictestccl/testdata/logic_test/crdb_internal_tenant
+++ b/pkg/ccl/logictestccl/testdata/logic_test/crdb_internal_tenant
@@ -398,9 +398,9 @@ select crdb_internal.get_vmodule()
 ·
 
 query T
-select regexp_replace(regexp_replace(crdb_internal.node_executable_version()::string, '(-\d+)?$', ''), '10000', '');
+SELECT crdb_internal.release_series(crdb_internal.node_executable_version())
 ----
-23.2
+24.1
 
 query ITTT colnames,rowsort
 select node_id, component, field, regexp_replace(regexp_replace(value, '^\d+$', '<port>'), e':\\d+', ':<port>') as value from crdb_internal.node_runtime_info
@@ -488,9 +488,9 @@ select * from crdb_internal.gossip_alerts
 
 # Anyone can see the executable version.
 query T
-select regexp_replace(regexp_replace(crdb_internal.node_executable_version()::string, '(-\d+)?$', ''), '10000', '');
+SELECT crdb_internal.release_series(crdb_internal.node_executable_version())
 ----
-23.2
+24.1
 
 user root
 

--- a/pkg/clusterversion/BUILD.bazel
+++ b/pkg/clusterversion/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/clusterversion",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/build",
         "//pkg/roachpb",
         "//pkg/settings",
         "//pkg/util/envutil",
@@ -39,6 +40,7 @@ go_test(
     args = ["-test.timeout=55s"],
     embed = [":clusterversion"],
     deps = [
+        "//pkg/build",
         "//pkg/roachpb",
         "//pkg/settings",
         "//pkg/settings/cluster",

--- a/pkg/clusterversion/dev_offset.go
+++ b/pkg/clusterversion/dev_offset.go
@@ -78,10 +78,18 @@ var devOffsetKeyStart = func() Key {
 // a dev branch.
 const DevOffset = 1_000_000
 
-// maybeDevOffset applies DevOffset to the major version, if appropriate.
-func maybeDevOffset(key Key, v roachpb.Version) roachpb.Version {
+// maybeApplyDevOffset applies DevOffset to the major version, if appropriate.
+func maybeApplyDevOffset(key Key, v roachpb.Version) roachpb.Version {
 	if key >= devOffsetKeyStart {
 		v.Major += DevOffset
+	}
+	return v
+}
+
+// removeDevOffset removes DevOffset from the given version, if it was applied.
+func removeDevOffset(v roachpb.Version) roachpb.Version {
+	if v.Major > DevOffset {
+		v.Major -= DevOffset
 	}
 	return v
 }

--- a/pkg/roachpb/version.go
+++ b/pkg/roachpb/version.go
@@ -66,8 +66,10 @@ func (v Version) SafeFormat(p redact.SafePrinter, _ rune) {
 	p.Printf("%d.%d-%d", v.Major, v.Minor, v.Internal)
 }
 
-// IsFinal returns true if this is a final version (as opposed to a
-// transitional internal version during upgrade).
+// IsFinal returns true if this is a final version (as opposed to a transitional
+// internal version during upgrade).
+//
+// A version is final iff Internal = 0.
 func (v Version) IsFinal() bool {
 	return v.Internal == 0
 }

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -638,9 +638,15 @@ select crdb_internal.get_vmodule()
 ·
 
 query T
-select regexp_replace(crdb_internal.node_executable_version()::string, '(-\d+)?$', '');
+SELECT crdb_internal.release_series(crdb_internal.node_executable_version())
 ----
-1000023.2
+24.1
+
+query error version '1.0' not supported
+SELECT crdb_internal.release_series('1.0')
+
+query error version '2000000.0' not supported
+SELECT crdb_internal.release_series('2000000.0')
 
 query ITTT colnames,rowsort
 select node_id, component, field, regexp_replace(regexp_replace(value, '^\d+$', '<port>'), e':\\d+', ':<port>') as value from crdb_internal.node_runtime_info
@@ -792,9 +798,9 @@ SELECT * FROM crdb_internal.check_consistency(true, b'\x02', b'\x04')
 
 # Anyone can see the executable version.
 query T
-select regexp_replace(crdb_internal.node_executable_version()::string, '(-\d+)?$', '');
+SELECT crdb_internal.release_series(crdb_internal.node_executable_version())
 ----
-1000023.2
+24.1
 
 user root
 

--- a/pkg/sql/logictest/testdata/logic_test/mixed_version_can_login
+++ b/pkg/sql/logictest/testdata/logic_test/mixed_version_can_login
@@ -9,10 +9,10 @@ upgrade 0
 
 upgrade 1
 
-query B nodeidx=0
-SELECT crdb_internal.node_executable_version() SIMILAR TO '23.2-%'
+query T nodeidx=0
+SELECT crdb_internal.release_series(crdb_internal.node_executable_version())
 ----
-true
+24.1
 
 query T nodeidx=2
 SELECT crdb_internal.node_executable_version()
@@ -22,18 +22,18 @@ SELECT crdb_internal.node_executable_version()
 # Verify that a non-root user can login on the upgraded node.
 user testuser nodeidx=0
 
-query B
-SELECT crdb_internal.node_executable_version() SIMILAR TO '23.2-%'
+query T
+SELECT crdb_internal.release_series(crdb_internal.node_executable_version())
 ----
-true
+24.1
 
 # Verify that a root user can login on the upgraded node.
 user root nodeidx=1
 
-query B
-SELECT crdb_internal.node_executable_version() SIMILAR TO '23.2-%'
+query T
+SELECT crdb_internal.release_series(crdb_internal.node_executable_version())
 ----
-true
+24.1
 
 # Verify that a non-root user can login on the non-upgraded node.
 user testuser nodeidx=2
@@ -53,7 +53,7 @@ SELECT crdb_internal.node_executable_version()
 
 upgrade 2
 
-query B
-SELECT crdb_internal.node_executable_version() SIMILAR TO '23.2-%'
+query T
+SELECT crdb_internal.release_series(crdb_internal.node_executable_version())
 ----
-true
+24.1

--- a/pkg/sql/logictest/testdata/logic_test/mixed_version_role_members_user_ids
+++ b/pkg/sql/logictest/testdata/logic_test/mixed_version_role_members_user_ids
@@ -46,10 +46,10 @@ upgrade 1
 
 # Test that there are no problems creating role memberships on a mixed-version cluster.
 
-query B nodeidx=1
-SELECT crdb_internal.node_executable_version() SIMILAR TO '23.2-%'
+query T nodeidx=1
+SELECT crdb_internal.release_series(crdb_internal.node_executable_version())
 ----
-true
+24.1
 
 user root nodeidx=1
 
@@ -89,17 +89,17 @@ upgrade 2
 
 # Verify that all nodes are now running 23.2 binaries.
 
-query B nodeidx=0
-SELECT crdb_internal.node_executable_version() SIMILAR TO '23.2-%'
+query T nodeidx=0
+SELECT crdb_internal.release_series(crdb_internal.node_executable_version())
 ----
-true
+24.1
 
-query B nodeidx=1
-SELECT crdb_internal.node_executable_version() SIMILAR TO '23.2-%'
+query T nodeidx=1
+SELECT crdb_internal.release_series(crdb_internal.node_executable_version())
 ----
-true
+24.1
 
-query B nodeidx=2
-SELECT crdb_internal.node_executable_version() SIMILAR TO '23.2-%'
+query T nodeidx=2
+SELECT crdb_internal.release_series(crdb_internal.node_executable_version())
 ----
-true
+24.1

--- a/pkg/sql/logictest/testdata/logic_test/mixed_version_udf_execute_privileges
+++ b/pkg/sql/logictest/testdata/logic_test/mixed_version_udf_execute_privileges
@@ -54,20 +54,20 @@ upgrade 2
 
 # Verify that all nodes are now running 24.1 binaries.
 
-query B nodeidx=0
-SELECT crdb_internal.node_executable_version() SIMILAR TO '23.2-%'
+query T nodeidx=0
+SELECT crdb_internal.release_series(crdb_internal.node_executable_version())
 ----
-true
+24.1
 
-query B nodeidx=1
-SELECT crdb_internal.node_executable_version() SIMILAR TO '23.2-%'
+query T nodeidx=1
+SELECT crdb_internal.release_series(crdb_internal.node_executable_version())
 ----
-true
+24.1
 
-query B nodeidx=2
-SELECT crdb_internal.node_executable_version() SIMILAR TO '23.2-%'
+query T nodeidx=2
+SELECT crdb_internal.release_series(crdb_internal.node_executable_version())
 ----
-true
+24.1
 
 # Makes sure the upgrade job has finished, and the cluster version gate is
 # passed.

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -2510,6 +2510,7 @@ var builtinOidsArray = []string{
 	2539: `pg_encoding_max_length(encoding: int) -> int`,
 	2540: `information_schema._pg_datetime_precision(typid: oid, typmod: int4) -> int`,
 	2541: `information_schema._pg_interval_type(typid: oid, typmod: int4) -> string`,
+	2542: `crdb_internal.release_series(version: string) -> string`,
 }
 
 var builtinOidsBySignature map[string]oid.Oid

--- a/pkg/upgrade/upgrades/builtins_test.go
+++ b/pkg/upgrade/upgrades/builtins_test.go
@@ -50,10 +50,14 @@ func TestIsAtLeastVersionBuiltin(t *testing.T) {
 	// Check that the builtin returns false when comparing against the new
 	// version because we are still on the bootstrap version.
 	sqlDB.CheckQueryResults(t, "SELECT crdb_internal.is_at_least_version('"+v+"')", [][]string{{"false"}})
+	sqlDB.CheckQueryResults(t, "SELECT crdb_internal.release_series(version) FROM [SHOW CLUSTER SETTING version]",
+		[][]string{{clusterversion.MinSupported.ReleaseSeries().String()}})
 
 	// Run the upgrade.
 	sqlDB.Exec(t, "SET CLUSTER SETTING version = $1", v)
 
 	// It should now return true.
 	sqlDB.CheckQueryResultsRetry(t, "SELECT crdb_internal.is_at_least_version('"+v+"')", [][]string{{"true"}})
+	sqlDB.CheckQueryResults(t, "SELECT crdb_internal.release_series(version) FROM [SHOW CLUSTER SETTING version]",
+		[][]string{{clusterversion.Latest.ReleaseSeries().String()}})
 }


### PR DESCRIPTION
This commit adds a built-in that resolves dev versions (e.g. 23.2-10)
to the corresponding release series (e.g. 24.1). This allows us to
clean up some tests and make them stable - they will no longer need to
be adjusted when minting a release.

Informs: #112629
Release note: None
