### PR TITLE
sql: fix error message for pg_trgm.similarity_threshold

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/trigram_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/trigram_builtins
@@ -141,3 +141,7 @@ query BBBB
 SELECT 'FOO' % 'foo', 'foobar' % 'foo', 'foobar' % 'barfoo', 'blorp' % 'z'
 ----
 true  false  false  false
+
+# Sanity check the error message.
+query error pq: 2.00 is out of range for similarity_threshold
+SET pg_trgm.similarity_threshold = 2.0

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -1284,7 +1284,7 @@ var varGen = map[string]sessionVar{
 			}
 			if f < 0 || f > 1 {
 				return pgerror.Newf(pgcode.InvalidParameterValue,
-					"%f is out of range for similarity_threshold")
+					"%.2f is out of range for similarity_threshold", f)
 			}
 			m.SetTrigramSimilarityThreshold(f)
 			return nil


### PR DESCRIPTION
Epic: None

Release note: None