### PR TITLE
multiregionccl,testutilsccl: deflake TestAlterTableLocalityRegionalByRowCorrectZoneConfigBeforeBackfill

### DIFF
--- a/pkg/ccl/testutilsccl/BUILD.bazel
+++ b/pkg/ccl/testutilsccl/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "//pkg/base",
         "//pkg/jobs",
         "//pkg/roachpb",
+        "//pkg/settings/cluster",
         "//pkg/sql",
         "//pkg/sql/execinfra",
         "//pkg/sql/sqltestutils",


### PR DESCRIPTION
This test could fail if run from a secondary tenant. It can be fixed by enabling a cluster setting.

fixes https://github.com/cockroachdb/cockroach/issues/113820
fixes https://github.com/cockroachdb/cockroach/issues/113853

Release note: None