### PR TITLE
build: add BranchReleaseSeries

### DIFF
--- a/pkg/build/info_test.go
+++ b/pkg/build/info_test.go
@@ -74,9 +74,10 @@ func TestComputeBinaryVersion(t *testing.T) {
 			defer func() { typ = oldBuildType }()
 
 			if tc.panicExpected {
-				require.Panics(t, func() { computeBinaryVersion(tc.versionTxt, tc.revision) })
+				require.Panics(t, func() { parseCockroachVersion(tc.versionTxt) })
 			} else {
-				actualVersion := computeBinaryVersion(tc.versionTxt, tc.revision)
+				v := parseCockroachVersion(tc.versionTxt)
+				actualVersion := computeBinaryVersion("" /* buildTagOverride */, v, tc.revision)
 				require.Equal(t, tc.expectedVersion, actualVersion)
 			}
 		})


### PR DESCRIPTION
This change adds `build.BranchReleaseSeries()` which returns the major and minor in `version.txt`. This will be used to know the current release series when the latest `clusterversion` is not finalized.

We also clean up the code a bit: we separate the variables that are overridden by Bazel, and we use a different variable for the testing override (to make things more clear).

Epic: none
Release note: None