### PR TITLE
workload/tpcc: support Read Committed isolation

### DIFF
--- a/pkg/sql/opt/bench/bench_test.go
+++ b/pkg/sql/opt/bench/bench_test.go
@@ -372,6 +372,7 @@ var queries = [...]benchQuery{
 			WHERE no_w_id = $1 AND no_d_id = $2
 			ORDER BY no_o_id ASC
 			LIMIT 1
+			FOR UPDATE
 		`,
 		args: []interface{}{10, 100},
 	},

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpcc
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpcc
@@ -146,12 +146,14 @@ SELECT s_quantity, s_ytd, s_order_cnt, s_remote_cnt, s_data, s_dist_05
 FROM stock
 WHERE (s_i_id, s_w_id) IN ((1000, 4), (900, 4), (1100, 4), (1500, 4), (1400, 4))
 ORDER BY s_i_id
+FOR UPDATE
 ----
 ----
 project
  ├── save-table-name: new_order_04_project_1
  ├── columns: s_quantity:3(int) s_ytd:14(int) s_order_cnt:15(int) s_remote_cnt:16(int) s_data:17(varchar) s_dist_05:8(char)  [hidden: s_i_id:1(int!null)]
  ├── cardinality: [0 - 5]
+ ├── volatile
  ├── stats: [rows=4.548552, distinct(1)=4.54855, null(1)=0, distinct(3)=4.43676, null(3)=0, distinct(8)=4.38572, null(8)=0, distinct(14)=0.989418, null(14)=0, distinct(15)=0.989418, null(15)=0, distinct(16)=0.989418, null(16)=0, distinct(17)=4.54833, null(17)=0]
  ├── key: (1)
  ├── fd: (1)-->(3,8,14-17)
@@ -165,7 +167,9 @@ project
       │    ├── [/4/1100 - /4/1100]
       │    ├── [/4/1400 - /4/1400]
       │    └── [/4/1500 - /4/1500]
+      ├── locking: for-update
       ├── cardinality: [0 - 5]
+      ├── volatile
       ├── stats: [rows=4.548552, distinct(1)=4.54855, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=4.43676, null(3)=0, distinct(8)=4.38572, null(8)=0, distinct(14)=0.989418, null(14)=0, distinct(15)=0.989418, null(15)=0, distinct(16)=0.989418, null(16)=0, distinct(17)=4.54833, null(17)=0, distinct(1,2)=4.54855, null(1,2)=0]
       │   histogram(1)=  0 0.966 0 0.966  0 0.966  0 0.82528 0 0.82528
       │                <--- 900 --- 1000 --- 1100 --- 1400 ---- 1500 -
@@ -489,12 +493,14 @@ FROM new_order
 WHERE no_w_id = 7 AND no_d_id = 6
 ORDER BY no_o_id ASC
 LIMIT 1
+FOR UPDATE
 ----
 ----
 project
  ├── save-table-name: delivery_01_project_1
  ├── columns: no_o_id:1(int!null)
  ├── cardinality: [0 - 1]
+ ├── volatile
  ├── stats: [rows=1, distinct(1)=0.999675, null(1)=0]
  ├── key: ()
  ├── fd: ()-->(1)
@@ -503,6 +509,8 @@ project
       ├── columns: no_o_id:1(int!null) no_d_id:2(int!null) no_w_id:3(int!null)
       ├── constraint: /3/2/1: [/7/6 - /7/6]
       ├── limit: 1
+      ├── locking: for-update
+      ├── volatile
       ├── stats: [rows=1, distinct(1)=0.999675, null(1)=0, distinct(2)=0.632308, null(2)=0, distinct(3)=0.632308, null(3)=0]
       ├── key: ()
       └── fd: ()-->(1-3)

--- a/pkg/sql/opt/xform/testdata/external/tpcc
+++ b/pkg/sql/opt/xform/testdata/external/tpcc
@@ -119,10 +119,12 @@ SELECT s_quantity, s_ytd, s_order_cnt, s_remote_cnt, s_data, s_dist_05
 FROM stock
 WHERE (s_i_id, s_w_id) IN ((1000, 4), (900, 4), (1100, 4), (1500, 4), (1400, 4))
 ORDER BY s_i_id
+FOR UPDATE
 ----
 project
  ├── columns: s_quantity:3 s_ytd:14 s_order_cnt:15 s_remote_cnt:16 s_data:17 s_dist_05:8  [hidden: s_i_id:1!null]
  ├── cardinality: [0 - 5]
+ ├── volatile
  ├── key: (1)
  ├── fd: (1)-->(3,8,14-17)
  ├── ordering: +1
@@ -134,7 +136,9 @@ project
       │    ├── [/4/1100 - /4/1100]
       │    ├── [/4/1400 - /4/1400]
       │    └── [/4/1500 - /4/1500]
+      ├── locking: for-update
       ├── cardinality: [0 - 5]
+      ├── volatile
       ├── key: (1)
       ├── fd: ()-->(2), (1)-->(3,8,14-17)
       └── ordering: +1 opt(2) [actual: +1]
@@ -801,16 +805,20 @@ FROM new_order
 WHERE no_w_id = 10 AND no_d_id = 100
 ORDER BY no_o_id ASC
 LIMIT 1
+FOR UPDATE
 ----
 project
  ├── columns: no_o_id:1!null
  ├── cardinality: [0 - 1]
+ ├── volatile
  ├── key: ()
  ├── fd: ()-->(1)
  └── scan new_order
       ├── columns: no_o_id:1!null no_d_id:2!null no_w_id:3!null
       ├── constraint: /3/2/1: [/10/100 - /10/100]
       ├── limit: 1
+      ├── locking: for-update
+      ├── volatile
       ├── key: ()
       └── fd: ()-->(1-3)
 

--- a/pkg/sql/opt/xform/testdata/external/tpcc-later-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpcc-later-stats
@@ -804,16 +804,20 @@ FROM new_order
 WHERE no_w_id = 10 AND no_d_id = 100
 ORDER BY no_o_id ASC
 LIMIT 1
+FOR UPDATE
 ----
 project
  ├── columns: no_o_id:1!null
  ├── cardinality: [0 - 1]
+ ├── volatile
  ├── key: ()
  ├── fd: ()-->(1)
  └── scan new_order
       ├── columns: no_o_id:1!null no_d_id:2!null no_w_id:3!null
       ├── constraint: /3/2/1: [/10/100 - /10/100]
       ├── limit: 1
+      ├── locking: for-update
+      ├── volatile
       ├── key: ()
       └── fd: ()-->(1-3)
 

--- a/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
@@ -116,10 +116,12 @@ SELECT s_quantity, s_ytd, s_order_cnt, s_remote_cnt, s_data, s_dist_05
 FROM stock
 WHERE (s_i_id, s_w_id) IN ((1000, 4), (900, 4), (1100, 4), (1500, 4), (1400, 4))
 ORDER BY s_i_id
+FOR UPDATE
 ----
 project
  ├── columns: s_quantity:3 s_ytd:14 s_order_cnt:15 s_remote_cnt:16 s_data:17 s_dist_05:8  [hidden: s_i_id:1!null]
  ├── cardinality: [0 - 5]
+ ├── volatile
  ├── key: (1)
  ├── fd: (1)-->(3,8,14-17)
  ├── ordering: +1
@@ -131,7 +133,9 @@ project
       │    ├── [/4/1100 - /4/1100]
       │    ├── [/4/1400 - /4/1400]
       │    └── [/4/1500 - /4/1500]
+      ├── locking: for-update
       ├── cardinality: [0 - 5]
+      ├── volatile
       ├── key: (1)
       ├── fd: ()-->(2), (1)-->(3,8,14-17)
       └── ordering: +1 opt(2) [actual: +1]
@@ -802,16 +806,20 @@ FROM new_order
 WHERE no_w_id = 10 AND no_d_id = 100
 ORDER BY no_o_id ASC
 LIMIT 1
+FOR UPDATE
 ----
 project
  ├── columns: no_o_id:1!null
  ├── cardinality: [0 - 1]
+ ├── volatile
  ├── key: ()
  ├── fd: ()-->(1)
  └── scan new_order
       ├── columns: no_o_id:1!null no_d_id:2!null no_w_id:3!null
       ├── constraint: /3/2/1: [/10/100 - /10/100]
       ├── limit: 1
+      ├── locking: for-update
+      ├── volatile
       ├── key: ()
       └── fd: ()-->(1-3)
 

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -736,7 +736,7 @@ func BenchmarkParse(b *testing.B) {
 		},
 		{
 			"tpcc-delivery",
-			`SELECT no_o_id FROM new_order WHERE no_w_id = $1 AND no_d_id = $2 ORDER BY no_o_id ASC LIMIT 1`,
+			`SELECT no_o_id FROM new_order WHERE no_w_id = $1 AND no_d_id = $2 ORDER BY no_o_id ASC LIMIT 1 FOR UPDATE`,
 		},
 		{
 			"account",

--- a/pkg/workload/tpcc/delivery.go
+++ b/pkg/workload/tpcc/delivery.go
@@ -63,7 +63,8 @@ func createDelivery(
 		FROM new_order
 		WHERE no_w_id = $1 AND no_d_id = $2
 		ORDER BY no_o_id ASC
-		LIMIT 1`,
+		LIMIT 1
+		FOR UPDATE`,
 	)
 
 	del.sumAmount = del.sr.Define(`

--- a/pkg/workload/tpcc/delivery.go
+++ b/pkg/workload/tpcc/delivery.go
@@ -87,7 +87,7 @@ func (del *delivery) run(ctx context.Context, wID int) (interface{}, error) {
 	olDeliveryD := timeutil.Now()
 
 	err := crdbpgx.ExecuteTx(
-		ctx, del.mcp.Get(), del.config.txOpts,
+		ctx, del.mcp.Get(), pgx.TxOptions{},
 		func(tx pgx.Tx) error {
 			// 2.7.4.2. For each district:
 			dIDoIDPairs := make(map[int]int)

--- a/pkg/workload/tpcc/new_order.go
+++ b/pkg/workload/tpcc/new_order.go
@@ -302,7 +302,8 @@ func (n *newOrder) run(ctx context.Context, wID int) (interface{}, error) {
 					SELECT s_quantity, s_ytd, s_order_cnt, s_remote_cnt, s_data, s_dist_%02[1]d
 					FROM stock
 					WHERE (s_i_id, s_w_id) IN (%[2]s)
-					ORDER BY s_i_id`,
+					ORDER BY s_i_id
+					FOR UPDATE`,
 					d.dID, strings.Join(stockIDs, ", "),
 				),
 			)

--- a/pkg/workload/tpcc/new_order.go
+++ b/pkg/workload/tpcc/new_order.go
@@ -212,7 +212,7 @@ func (n *newOrder) run(ctx context.Context, wID int) (interface{}, error) {
 	d.oEntryD = timeutil.Now()
 
 	err := crdbpgx.ExecuteTx(
-		ctx, n.mcp.Get(), n.config.txOpts,
+		ctx, n.mcp.Get(), pgx.TxOptions{},
 		func(tx pgx.Tx) error {
 			// Select the district tax rate and next available order number, bumping it.
 			var dNextOID int

--- a/pkg/workload/tpcc/order_status.go
+++ b/pkg/workload/tpcc/order_status.go
@@ -134,7 +134,7 @@ func (o *orderStatus) run(ctx context.Context, wID int) (interface{}, error) {
 	}
 
 	if err := crdbpgx.ExecuteTx(
-		ctx, o.mcp.Get(), o.config.txOpts,
+		ctx, o.mcp.Get(), pgx.TxOptions{},
 		func(tx pgx.Tx) error {
 			// 2.6.2.2 explains this entire transaction.
 

--- a/pkg/workload/tpcc/payment.go
+++ b/pkg/workload/tpcc/payment.go
@@ -190,7 +190,7 @@ func (p *payment) run(ctx context.Context, wID int) (interface{}, error) {
 	}
 
 	if err := crdbpgx.ExecuteTx(
-		ctx, p.mcp.Get(), p.config.txOpts,
+		ctx, p.mcp.Get(), pgx.TxOptions{},
 		func(tx pgx.Tx) error {
 			var wName, dName string
 			// Update warehouse with payment

--- a/pkg/workload/tpcc/stock_level.go
+++ b/pkg/workload/tpcc/stock_level.go
@@ -97,7 +97,7 @@ func (s *stockLevel) run(ctx context.Context, wID int) (interface{}, error) {
 	}
 
 	if err := crdbpgx.ExecuteTx(
-		ctx, s.mcp.Get(), s.config.txOpts,
+		ctx, s.mcp.Get(), pgx.TxOptions{},
 		func(tx pgx.Tx) error {
 			var dNextOID int
 			if err := s.selectDNextOID.QueryRowTx(

--- a/pkg/workload/tpcc/stock_level.go
+++ b/pkg/workload/tpcc/stock_level.go
@@ -68,19 +68,15 @@ func createStockLevel(
 
 	// Count the number of recently sold items that have a stock level below
 	// the threshold.
-	// TODO(radu): we use count(DISTINCT s_i_id) because DISTINCT inside
-	// aggregates was not supported by the optimizer. This can be cleaned up.
 	s.countRecentlySold = s.sr.Define(`
-		SELECT count(*) FROM (
-			SELECT DISTINCT s_i_id
-			FROM order_line
-			JOIN stock
-			ON s_i_id=ol_i_id AND s_w_id=ol_w_id
-			WHERE ol_w_id = $1
-				AND ol_d_id = $2
-				AND ol_o_id BETWEEN $3 - 20 AND $3 - 1
-				AND s_quantity < $4
-		)`,
+		SELECT count(DISTINCT s_i_id)
+		FROM order_line
+		JOIN stock
+		ON s_w_id = $1 AND s_i_id = ol_i_id
+		WHERE ol_w_id = $1
+		  AND ol_d_id = $2
+		  AND ol_o_id BETWEEN $3 - 20 AND $3 - 1
+		  AND s_quantity < $4`,
 	)
 
 	if err := s.sr.Init(ctx, "stock-level", mcp); err != nil {

--- a/pkg/workload/tpcc/tpcc.go
+++ b/pkg/workload/tpcc/tpcc.go
@@ -14,7 +14,6 @@ import (
 	"context"
 	gosql "database/sql"
 	"fmt"
-	"net/url"
 	"strconv"
 	"strings"
 	"sync"
@@ -43,8 +42,8 @@ type tpcc struct {
 	activeWarehouses int
 	nowString        []byte
 	numConns         int
-
-	idleConns int
+	idleConns        int
+	isoLevel         string
 
 	// Used in non-uniform random data generation. cLoad is the value of C at load
 	// time. cCustomerID is the value of C for the customer id generator. cItemID
@@ -87,10 +86,6 @@ type tpcc struct {
 	// violation of the TPC-C spec, so it should only be used for internal
 	// testing purposes.
 	localWarehouses bool
-
-	usePostgres  bool
-	serializable bool
-	txOpts       pgx.TxOptions
 
 	expensiveChecks bool
 
@@ -170,12 +165,12 @@ var tpccMeta = workload.Meta{
 			`zones`:                    {RuntimeOnly: true},
 			`active-warehouses`:        {RuntimeOnly: true},
 			`scatter`:                  {RuntimeOnly: true},
-			`serializable`:             {RuntimeOnly: true},
 			`split`:                    {RuntimeOnly: true},
 			`wait`:                     {RuntimeOnly: true},
 			`workers`:                  {RuntimeOnly: true},
 			`conns`:                    {RuntimeOnly: true},
 			`idle-conns`:               {RuntimeOnly: true},
+			`isolation-level`:          {RuntimeOnly: true},
 			`expensive-checks`:         {RuntimeOnly: true, CheckConsistencyOnly: true},
 			`local-warehouses`:         {RuntimeOnly: true},
 			`regions`:                  {RuntimeOnly: true},
@@ -203,6 +198,7 @@ var tpccMeta = workload.Meta{
 			numConnsPerWarehouse,
 		))
 		g.flags.IntVar(&g.idleConns, `idle-conns`, 0, `Number of idle connections. Defaults to 0`)
+		g.flags.StringVar(&g.isoLevel, `isolation-level`, ``, `Isolation level to run workload transactions under [serializable, snapshot, read_committed]. If unset, the workload will run with the default isolation level of the database.`)
 		g.flags.IntVar(&g.partitions, `partitions`, 1, `Partition tables`)
 		g.flags.IntVar(&g.clientPartitions, `client-partitions`, 0, `Make client behave as if the tables are partitioned, but does not actually partition underlying data. Requires --partition-affinity.`)
 		g.flags.IntSliceVar(&g.affinityPartitions, `partition-affinity`, nil, `Run load generator against specific partition (requires partitions). `+
@@ -214,7 +210,6 @@ var tpccMeta = workload.Meta{
 		g.flags.Var(&g.multiRegionCfg.survivalGoal, "survival-goal", "Survival goal to use for multi-region setups. Allowed values: [zone, region].")
 		g.flags.IntVar(&g.activeWarehouses, `active-warehouses`, 0, `Run the load generator against a specific number of warehouses. Defaults to --warehouses'`)
 		g.flags.BoolVar(&g.scatter, `scatter`, false, `Scatter ranges`)
-		g.flags.BoolVar(&g.serializable, `serializable`, false, `Force serializable mode`)
 		g.flags.BoolVar(&g.split, `split`, false, `Split tables`)
 		g.flags.BoolVar(&g.expensiveChecks, `expensive-checks`, false, `Run expensive checks`)
 		g.flags.BoolVar(&g.separateColumnFamilies, `families`, false, `Use separate column families for dynamic and static columns`)
@@ -342,10 +337,6 @@ func (w *tpcc) Hooks() workload.Hooks {
 			if w.waitFraction > 0 && w.workers != w.activeWarehouses*NumWorkersPerWarehouse {
 				return errors.Errorf(`--wait > 0 and --warehouses=%d requires --workers=%d`,
 					w.activeWarehouses, w.warehouses*NumWorkersPerWarehouse)
-			}
-
-			if w.serializable {
-				w.txOpts = pgx.TxOptions{IsoLevel: pgx.Serializable}
 			}
 
 			w.auditor = newAuditor(w.activeWarehouses)
@@ -755,12 +746,9 @@ func (w *tpcc) Ops(
 	if err != nil {
 		return workload.QueryLoad{}, err
 	}
-	parsedURL, err := url.Parse(urls[0])
-	if err != nil {
+	if err := workload.SetDefaultIsolationLevel(urls, w.isoLevel); err != nil {
 		return workload.QueryLoad{}, err
 	}
-
-	w.usePostgres = parsedURL.Port() == "5432"
 
 	// We can't use a single MultiConnPool because we want to implement partition
 	// affinity. Instead we have one MultiConnPool per server.


### PR DESCRIPTION
Closes #100176.

This PR consists of a series of commits which together add support for Read Committed isolation to the TPC-C workload and then use it to add new roachtest variants.

See individual commits, including an interesting change to explicit row-level locking in TPC-C transactions to avoid concurrency anomalies.

Release note: None