### PR TITLE
team: embed TEAMS.yaml

### DIFF
--- a/build/bazelutil/check.sh
+++ b/build/bazelutil/check.sh
@@ -44,6 +44,7 @@ pkg/util/log/channels.go://go:generate go run gen/main.go logpb/log.proto loggin
 pkg/util/log/channels.go://go:generate go run gen/main.go logpb/log.proto severity.go severity/severity_generated.go
 pkg/util/log/sinks.go://go:generate mockgen -package=log -destination=mocks_generated_test.go --mock_names=TestingLogSink=MockLogSink . TestingLogSink
 pkg/util/timeutil/zoneinfo.go://go:generate go run gen/main.go
+pkg/internal/team/team.go://go:generate cp ../../../TEAMS.yaml TEAMS.yaml
 "
 
 EXISTING_CRDB_TEST_BUILD_CONSTRAINTS="

--- a/pkg/gen/misc.bzl
+++ b/pkg/gen/misc.bzl
@@ -6,6 +6,7 @@ MISC_SRCS = [
     "//pkg/ccl/backupccl:restore_memory_monitoring_generated_test.go",
     "//pkg/ccl/backupccl:restore_mid_schema_change_generated_test.go",
     "//pkg/ccl/kvccl/kvtenantccl/upgradeinterlockccl:generated_test.go",
+    "//pkg/internal/team:TEAMS.yaml",
     "//pkg/kv/kvpb:batch_generated.go",
     "//pkg/kv/kvserver/concurrency:keylocks_interval_btree.go",
     "//pkg/kv/kvserver/concurrency:keylocks_interval_btree_test.go",

--- a/pkg/internal/team/.gitignore
+++ b/pkg/internal/team/.gitignore
@@ -1,0 +1,1 @@
+TEAMS.yaml

--- a/pkg/internal/team/BUILD.bazel
+++ b/pkg/internal/team/BUILD.bazel
@@ -3,13 +3,26 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "team",
     srcs = ["team.go"],
+    data = [
+        ":gen-teams-yaml",  # keep
+    ],
+    embedsrcs = ["TEAMS.yaml"],
     importpath = "github.com/cockroachdb/cockroach/pkg/internal/team",
     visibility = ["//pkg:__subpackages__"],
     deps = [
-        "//pkg/build/bazel",
-        "//pkg/internal/reporoot",
         "@com_github_cockroachdb_errors//:errors",
         "@in_gopkg_yaml_v2//:yaml_v2",
+    ],
+)
+
+genrule(
+    name = "gen-teams-yaml",
+    srcs = ["//:TEAMS.yaml"],
+    outs = ["TEAMS.yaml"],
+    cmd = "cat $(SRCS) > $@",
+    visibility = [
+        ":__pkg__",
+        "//pkg/gen:__pkg__",
     ],
 )
 
@@ -18,9 +31,6 @@ go_test(
     size = "small",
     srcs = ["team_test.go"],
     args = ["-test.timeout=55s"],
-    data = [
-        "//:TEAMS.yaml",
-    ],
     embed = [":team"],
     deps = ["@com_github_stretchr_testify//require"],
 )

--- a/pkg/internal/team/team.go
+++ b/pkg/internal/team/team.go
@@ -13,12 +13,10 @@
 package team
 
 import (
+	_ "embed"
 	"io"
-	"os"
-	"path/filepath"
+	"strings"
 
-	"github.com/cockroachdb/cockroach/pkg/build/bazel"
-	"github.com/cockroachdb/cockroach/pkg/internal/reporoot"
 	"github.com/cockroachdb/errors"
 	"gopkg.in/yaml.v2"
 )
@@ -83,28 +81,14 @@ func (m Map) GetAliasesForPurpose(alias Alias, purpose Purpose) ([]Alias, bool) 
 	return sl, true
 }
 
+//go:generate cp ../../../TEAMS.yaml TEAMS.yaml
+
+//go:embed TEAMS.yaml
+var teamsYaml string
+
 // DefaultLoadTeams loads teams from the repo root's TEAMS.yaml.
 func DefaultLoadTeams() (Map, error) {
-	var path string
-	if os.Getenv("BAZEL_TEST") != "" {
-		runfiles, err := bazel.RunfilesPath()
-		if err != nil {
-			return nil, err
-		}
-		path = filepath.Join(runfiles, "TEAMS.yaml")
-	} else {
-		root := reporoot.GetFor(".", "TEAMS.yaml")
-		if root == "" {
-			return nil, errors.New("TEAMS.yaml not found")
-		}
-		path = filepath.Join(root, "TEAMS.yaml")
-	}
-	f, err := os.Open(path)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = f.Close() }()
-	return LoadTeams(f)
+	return LoadTeams(strings.NewReader(teamsYaml))
 }
 
 // Purpose determines which alias to return for a given team via


### PR DESCRIPTION
The `internal/team` code looks for `TEAMS.yaml` in the repo. This
means that `roachtest` must be run in the tree (and if the branches
don't match, obscure errors could happen in principle).

This commit moves to embedding the data using `go:embed`. Because
`go:embed` doesn't allow embedding of files outside the package, we
also have to add a generation rule to copy the file.

Fixes: #111661
Release note: None