### PR TITLE
roachtest: remove 128 KiB bank payload load option from backup-restore/*

### DIFF
--- a/pkg/cmd/roachtest/tests/backup_restore_roundtrip.go
+++ b/pkg/cmd/roachtest/tests/backup_restore_roundtrip.go
@@ -211,8 +211,8 @@ func startBackgroundWorkloads(
 	// for the cluster used in this test without overloading it,
 	// which can make the backups take much longer to finish.
 	const numWarehouses = 100
-	tpccInit, tpccRun := tpccWorkloadCmd(testRNG, numWarehouses, roachNodes)
-	bankInit, bankRun := bankWorkloadCmd(testRNG, roachNodes)
+	tpccInit, tpccRun := tpccWorkloadCmd(l, testRNG, numWarehouses, roachNodes)
+	bankInit, bankRun := bankWorkloadCmd(l, testRNG, roachNodes)
 
 	err := c.RunE(ctx, workloadNode, bankInit.String())
 	if err != nil {


### PR DESCRIPTION
This patch removes the large bank payload option as it could exhaust hardware and trigger admission control behavior that would cause restore to time out.

Fixes #113657
Fixes #113558

Release note: none