### PR TITLE
streamingest: skip TestStreamingAutoReplan under stress race

### DIFF
--- a/pkg/ccl/streamingccl/streamingest/replication_stream_e2e_test.go
+++ b/pkg/ccl/streamingccl/streamingest/replication_stream_e2e_test.go
@@ -678,6 +678,8 @@ func TestStreamingAutoReplan(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	skip.UnderStressRace(t, "multi cluster/node config exhausts hardware")
+
 	ctx := context.Background()
 	args := replicationtestutils.DefaultTenantStreamingClustersArgs
 	args.MultitenantSingleClusterNumNodes = 1


### PR DESCRIPTION
Under stress-race, this test times out while waiting for full replication, likely because of resource exhaustion.

Fixes #113238

Release note: none