### PR TITLE
storage: use TableFormatPebblev4 even if storage.value_blocks.enabled…

### DIFF
--- a/pkg/kv/kvnemesis/testdata/TestOperationsFormat/4
+++ b/pkg/kv/kvnemesis/testdata/TestOperationsFormat/4
@@ -1,6 +1,6 @@
 echo
 ----
-···db0.AddSSTable(ctx, tk(1), tk(4), ... /* @s1 */) // 1114 bytes (as writes)
+···db0.AddSSTable(ctx, tk(1), tk(4), ... /* @s1 */) // 1144 bytes (as writes)
 ···// ^-- tk(1) -> sv(s1): /Table/100/"0000000000000001"/0.000000001,0 -> /BYTES/v1
 ···// ^-- tk(2) -> sv(s1): /Table/100/"0000000000000002"/0.000000001,0 -> /<empty>
 ···// ^-- [tk(3), tk(4)) -> sv(s1): /Table/100/"000000000000000{3"-4"} -> /<empty>

--- a/pkg/storage/sst_writer.go
+++ b/pkg/storage/sst_writer.go
@@ -72,7 +72,7 @@ func MakeIngestionWriterOptions(ctx context.Context, cs *cluster.Settings) sstab
 	if ValueBlocksEnabled.Get(&cs.SV) {
 		format = sstable.TableFormatPebblev3
 	}
-	if cs.Version.IsActive(ctx, clusterversion.V23_2_EnablePebbleFormatVirtualSSTables) && ValueBlocksEnabled.Get(&cs.SV) {
+	if cs.Version.IsActive(ctx, clusterversion.V23_2_EnablePebbleFormatVirtualSSTables) {
 		format = sstable.TableFormatPebblev4
 	}
 	opts := DefaultPebbleOptions().MakeWriterOptions(0, format)


### PR DESCRIPTION
… is false

Once the cluster is at V23_2_EnablePebbleFormatVirtualSSTables, we should always use TableFormatPebblev4. And this format is required for disaggregated storage foreign sstables.

Fixes https://github.com/cockroachdb/cockroach/issues/113732

Epic: none

Release note: None