### PR TITLE
release-23.2: *: disable shared process test virtual cluster on some tests

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -261,6 +261,9 @@ func TestBackupRestoreJobTagAndLabel(t *testing.T) {
 	tc, _, _, cleanupFn := backupRestoreTestSetupWithParams(t, numNodes, numAccounts, InitManualReplication,
 		base.TestClusterArgs{
 			ServerArgs: base.TestServerArgs{
+				DefaultTestTenant: base.TestDoesNotWorkWithSharedProcessModeButWeDontKnowWhyYet(
+					base.TestTenantProbabilistic, 113857, /* issueNumber */
+				),
 				Knobs: base.TestingKnobs{
 					DistSQL: &execinfra.TestingKnobs{
 						SetupFlowCb: func(ctx context.Context, _ base.SQLInstanceID, _ *execinfrapb.SetupFlowRequest) error {

--- a/pkg/server/application_api/stats_test.go
+++ b/pkg/server/application_api/stats_test.go
@@ -300,6 +300,9 @@ func TestClusterResetSQLStats(t *testing.T) {
 		t.Run(fmt.Sprintf("flushed=%t", flushed), func(t *testing.T) {
 			testCluster := serverutils.StartCluster(t, 3 /* numNodes */, base.TestClusterArgs{
 				ServerArgs: base.TestServerArgs{
+					DefaultTestTenant: base.TestDoesNotWorkWithSharedProcessModeButWeDontKnowWhyYet(
+						base.TestTenantProbabilistic, 113856, /* issueNumber */
+					),
 					Insecure: true,
 					Knobs: base.TestingKnobs{
 						SQLStatsKnobs: sqlstats.CreateTestingKnobs(),

--- a/pkg/sql/sqlstats/persistedsqlstats/datadriven_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/datadriven_test.go
@@ -75,6 +75,9 @@ func TestSQLStatsDataDriven(t *testing.T) {
 
 	ctx := context.Background()
 	var params base.TestServerArgs
+	params.DefaultTestTenant = base.TestDoesNotWorkWithSharedProcessModeButWeDontKnowWhyYet(
+		base.TestTenantProbabilistic, 113854, /* issueNumber */
+	)
 	knobs := sqlstats.CreateTestingKnobs()
 	knobs.StubTimeNow = stubTime.Now
 	knobs.OnStmtStatsFlushFinished = injector.invokePostStmtStatsFlushCallback

--- a/pkg/sql/sqlstats/persistedsqlstats/flush_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/flush_test.go
@@ -74,6 +74,9 @@ func TestSQLStatsFlush(t *testing.T) {
 
 	testCluster := serverutils.StartCluster(t, 3 /* numNodes */, base.TestClusterArgs{
 		ServerArgs: base.TestServerArgs{
+			DefaultTestTenant: base.TestDoesNotWorkWithSharedProcessModeButWeDontKnowWhyYet(
+				base.TestTenantProbabilistic, 113855, /* issueNumber */
+			),
 			Knobs: base.TestingKnobs{
 				SQLStatsKnobs: &sqlstats.TestingKnobs{
 					StubTimeNow: fakeTime.Now,


### PR DESCRIPTION
Backport 1/1 commits from #113860.

/cc @cockroachdb/release

---

A couple of tests are flaky or failing when running with a shared process test virtual cluster. These tests will need to be investigated further to determine the cause. For now the tests disable running with a shared process test virtual cluster and are linked to a corresponding issue.

Informs: #113857, #113853, #113856, #113854, #113855

Epic: None
Release Note: None

Release justification: Test only change