### PR TITLE
server: statement stats test ignores retry counts

### DIFF
--- a/pkg/server/application_api/sql_stats_test.go
+++ b/pkg/server/application_api/sql_stats_test.go
@@ -510,6 +510,7 @@ func TestStatusAPICombinedStatementsWithFullScans(t *testing.T) {
 	if skip.Stress() {
 		additionalTimeout = additionalTimeoutUnderStress
 	}
+	skip.UnderStressRace(t, "test is too slow to run under race")
 
 	// Aug 30 2021 19:50:00 GMT+0000
 	aggregatedTs := int64(1630353000)
@@ -637,7 +638,7 @@ func TestStatusAPICombinedStatementsWithFullScans(t *testing.T) {
 			respStatement, exists := actualResponseStatsMap[respQuery]
 			require.True(t, exists, "Expected statement '%s' not found in response: %v", respQuery, responseToJSON(resp))
 
-			actualCount := respStatement.Stats.Count
+			actualCount := respStatement.Stats.FirstAttemptCount
 			actualFullScan := respStatement.Key.KeyData.FullScan
 			actualDistSQL := respStatement.Key.KeyData.DistSQL
 			actualFailed := respStatement.Key.KeyData.Failed


### PR DESCRIPTION
Previously, the TestStatusAPICombinedStatementsWithFullScans test would check exec counts against the `Count` field of the `CollectedStatementStatistics` object. This count includes retries so queries that were retried would increase the count.

This change updates the test to check against `FirstAttemptCount` instead which should be more stable.

Epic: None
Resolves: #113273

Release note: None