### PR TITLE
release-23.1: kv: fix "unknown" error text in refresh error

### DIFF
--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_span_refresher.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_span_refresher.go
@@ -478,8 +478,8 @@ func newRetryErrorOnFailedPreemptiveRefresh(
 	msg := redact.StringBuilder{}
 	msg.SafeString("failed preemptive refresh")
 	if refreshErr != nil {
-		if refreshErr, ok := refreshErr.GetDetail().(*kvpb.RefreshFailedError); ok {
-			msg.Printf(" due to a conflict: %s on key %s", refreshErr.FailureReason(), refreshErr.Key)
+		if rfErr, ok := refreshErr.GetDetail().(*kvpb.RefreshFailedError); ok {
+			msg.Printf(" due to a conflict: %s on key %s", rfErr.FailureReason(), rfErr.Key)
 		} else {
 			msg.Printf(" - unknown error: %s", refreshErr)
 		}


### PR DESCRIPTION
Fixes #113496.

This helps us understand what's going on when we get this error. Otherwise, the refresh error is lost.

Release note: None

Release justification: low-risk improvement to error reporting.