### PR TITLE
pkg/workload: allow specifying a pgx.QueryTracer

### DIFF
--- a/pkg/workload/pgx_helpers.go
+++ b/pkg/workload/pgx_helpers.go
@@ -93,6 +93,10 @@ type MultiConnPoolCfg struct {
 
 	// Duration between refreshes of the DNS cache
 	DNSRefreshInterval time.Duration
+
+	// QueryTracer is an optional tracer to attach to the pgx connections from
+	// this pool. See [pgx.ConnConfig] for details.
+	QueryTracer pgx.QueryTracer
 }
 
 // NewMultiConnPoolCfgFromFlags constructs a new MultiConnPoolCfg object based
@@ -239,6 +243,9 @@ func NewMultiConnPool(
 				}
 				return true
 			}
+
+			// Attach the supplied tracer to the ConnConfig.
+			poolCfg.ConnConfig.Tracer = cfg.QueryTracer
 
 			connCfg := poolCfg.ConnConfig
 			if m.resolver != nil {


### PR DESCRIPTION
#### 849e1c5c1cf79e240d6dd9c6169a2102109f137a pkg/workload: allow specifying a pgx.QueryTracer

The majority of fields on a `pgx.ConnConfig` can be set or influenced
via the connection URL. An unfortunate exception to this case is the
`QueryTracer` field which allows external users to trace or log outgoing
queries.

This commit adds a `QueryTracer` field to `MultiConnPoolCfg` which will
allow workloads to instrument pgx connections with tracing and logging
to aid in debugging failures or understanding other behaviors of a
workload.

Epic: CRDB-19168
Release note: None