### PR TITLE
pkg/obsservice: script to build Docker image for prototype

### DIFF
--- a/pkg/obsservice/README.md
+++ b/pkg/obsservice/README.md
@@ -76,6 +76,48 @@ exporters:
   only proxied to CRDB nodes that present certificates signed by this CA. If not
   specified, the system's CA list is used.
 
+## Building & Pushing a Docker Image
+
+With a local docker instance running, you can build a docker image using the Dockerfile in `pkg/obsservice/cmd/obsservice`,
+which can then be pushed & hosted in GCR. Once in GCR, the image is available to be pulled by environments such
+as Kubernetes.
+
+To build an `obsservice` docker image locally, make use of the `build-docker.sh` script in
+`pkg/obsservice/cmd/obsservice`.
+
+```shell
+$ ./pkg/obsservice/cmd/obsservice/build-docker.sh
+```
+
+This should create a Docker image locally. You can check this locally.
+```shell
+ $ docker image ls | grep obsservice
+obsservice    latest    13c5d49056cc    12 seconds ago    156MB
+```
+
+You can run the image locally via Docker.
+```shell
+$ docker run --platform=linux/amd64 obsservice:latest
+I231113 22:25:02.716505 1 main/main.go:112  [-] 1  Listening for OTLP connections on localhost:4317.
+```
+
+You can use environment variables to control things like the OTLP listen address.
+```shell
+$ docker run -e OTLP_ADDR=localhost:7171 -e HTTP_ADDR=localhost:8082 --platform=linux/amd64 obsservice:latest
+I231113 22:25:02.716505 1 main/main.go:112  [-] 1  Listening for OTLP connections on localhost:7171.
+Listening for HTTP requests on http://localhost:8082.
+```
+
+With the image created, you can [push it to GCR](https://cockroachlabs.atlassian.net/wiki/spaces/OI/pages/3249472038/Pushing+an+Antenna+Docker+Image+to+GCR).
+
+NOTE: This script is not meant to last the test of time, but rather get a prototype up and running
+quickly. It is not meant for production use. The main problem with it is that it relies on 
+`./dev build --cross=linux` for cross compilation of the `obsservice`.
+`obsservice` makes use of CGO libraries, meaning it can't be cross-compiled without Docker. Therefore, the
+script uses `./dev build --cross=linux` to generate the cross-compiled artifact, copies the artifact into
+`pkg/obsservice/cmd/obsservice`, and then the Dockerfile targets that artifact file to generate the Docker
+image. It's probably not best practice to use `./dev build --cross` and then copy the artifact elsewhere.
+
 ## Functionality
 
 In the current fledgling state, the Obs Service does a couple of things:

--- a/pkg/obsservice/cmd/obsservice/.gitignore
+++ b/pkg/obsservice/cmd/obsservice/.gitignore
@@ -1,0 +1,2 @@
+# Copied obsservice artifacts. build-docker.sh should remove it, but this is just a safeguard.
+artifact_obsservice

--- a/pkg/obsservice/cmd/obsservice/Dockerfile
+++ b/pkg/obsservice/cmd/obsservice/Dockerfile
@@ -1,0 +1,13 @@
+# Generates a Docker image of the obsservice binary.
+# Use OTLP_ADDR and HTTP_ADDR env vars when running the image to control
+# the ports/addresses that are listened on for each. Defaults are used
+# otherwise (:4317 and :8081).
+#
+# You'll need to expose relevant ports when running the image.
+
+FROM --platform=linux/amd64 debian:stable-slim
+WORKDIR /bin
+ENV OTLP_ADDR=localhost:4317
+ENV HTTP_ADDR=localhost:8081
+COPY ./artifact_obsservice /bin/
+CMD /bin/artifact_obsservice --otlp-addr=$OTLP_ADDR --http-addr=$HTTP_ADDR

--- a/pkg/obsservice/cmd/obsservice/build-docker.sh
+++ b/pkg/obsservice/cmd/obsservice/build-docker.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+## This script is in support of a Dockerfile that we hacked together
+## in the interest of prototyping speed. The obsservice binary has
+## cgo dependencies, meaning we need to build within Docker when
+## cross compiling for linux. We decided to just use the `dev` build
+## system to cross compile into the $CRDB_ROOT/artifacts directory, and
+## then use that file as the basis for our Docker image. This might not
+## be the best approach, but it works for now.
+
+echo "Begin cross compiling obsservice binary..."
+
+echo "Running dev in $PWD to cross compile obsservice binary..."
+if [[ $(./dev build obsservice --cross=linux) ]]; then
+  echo "obsservice binary successfully cross compiled"
+else
+  echo "obsservice binary failed to cross compile. Exiting."
+  exit 1
+fi
+
+echo "Copying obsservice binary to pkg/obsservice/cmd/obsservice to make available to Dockerfile"
+echo "NOTE: This is a quick hack solution made for prototyping. It should not be used beyond that."
+
+cp artifacts/obsservice pkg/obsservice/cmd/obsservice/artifact_obsservice
+
+echo "Building obsservice docker image."
+
+cd pkg/obsservice/cmd/obsservice
+
+echo "(Now running in $PWD)"
+
+docker build -t obsservice .
+
+echo "Finalizing... Removing copied obsservice artifact. Check $ docker image ls to see image."
+rm artifact_obsservice
+
+


### PR DESCRIPTION
This patch adds a script to build a Docker image. The image is
wregistered locally, from which we're able to push to GCR (see
README).

This script is not meant to last the test of time, but rather get
a prototype up and running quickly. It is not meant for production
use. The main problem with it is that it isn't fully "bazel-ified"
because it relies on ./dev build --cross=linux for cross compilation
of the obsservice. obsservice makes use of CGO libraries, meaning it
can't be cross-compiled without Docker. Therefore, the script uses
./dev build --cross=linux to generate the cross-compiled artifact,
copies the artifact into pkg/obsservice/cmd/obsservice, and then
the bazel rule targets that artifact file to generate the Docker
image. Finally, it cleans up the copied artifact. Generally, Bazel
rules should target other Bazel rules, which is why this is less
than ideal. For prototyping, it gets the job done.

Release note: none

Epic: CC-25978