### PR TITLE
gossip: handle port reuse

### DIFF
--- a/pkg/kv/kvserver/replicate_queue_test.go
+++ b/pkg/kv/kvserver/replicate_queue_test.go
@@ -2154,7 +2154,7 @@ func TestReplicateQueueAcquiresInvalidLeases(t *testing.T) {
 	// Restart the servers to invalidate the leases.
 	for i := range tc.Servers {
 		tc.StopServer(i)
-		err = tc.RestartServerWithInspect(i, nil)
+		err = tc.RestartServer(i)
 		require.NoError(t, err)
 	}
 

--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -683,6 +683,8 @@ func (tc *TestCluster) WaitForNStores(t serverutils.TestFataler, n int, g *gossi
 			}
 			t.Fatal(err)
 		case <-time.After(testutils.DefaultSucceedsSoonDuration):
+			storesMu.Lock()
+			defer storesMu.Unlock()
 			t.Fatalf("timed out waiting for %d store descriptors: %v", n-seen, stores)
 		}
 	}
@@ -1699,9 +1701,19 @@ func (tc *TestCluster) RestartServerWithInspect(
 		return errors.Errorf("server %d must be stopped before attempting to restart", idx)
 	}
 	serverArgs := tc.serverArgs[idx]
+	return tc.RestartServerWithArgs(idx, serverArgs, inspect)
+}
 
+func (tc *TestCluster) RestartServerWithArgs(
+	idx int, serverArgs base.TestServerArgs, inspect func(s serverutils.TestServerInterface),
+) error {
 	if ln := tc.reusableListeners[idx]; ln != nil {
 		serverArgs.Listener = ln
+		if serverArgs.Knobs.Server == nil {
+			serverArgs.Knobs.Server = &server.TestingKnobs{}
+		}
+		serverArgs.Knobs.Server.ModuleTestingKnobs()
+		serverArgs.Knobs.Server.(*server.TestingKnobs).RPCListener = serverArgs.Listener
 	}
 
 	if serverArgs.Listener == nil {
@@ -1735,11 +1747,14 @@ func (tc *TestCluster) RestartServerWithInspect(
 		return err
 	}
 
-	for i, specs := range serverArgs.StoreSpecs {
-		if specs.InMemory && specs.StickyVFSID == "" {
-			return errors.Errorf("failed to restart Server %d, because a restart can only be used on a server with a sticky VFS", i)
+	/*
+		for i, specs := range serverArgs.StoreSpecs {
+			if specs.InMemory && specs.StickyVFSID == "" {
+				return errors.Errorf("failed to restart Server %d, because a restart can only be used on a server with a sticky VFS", i)
+			}
 		}
-	}
+
+	*/
 	s, err := serverutils.NewServer(serverArgs)
 	if err != nil {
 		return err


### PR DESCRIPTION
A previous attempt to fix this test detected port reuse, however, it would then still wait for the failed node to join the cluster and gossip. This couldn't happen if `AddAndStartServerE` returned an error. This change correctly exits the test if the node fails to start.

Informs: #74447
Fixes: #113046

Epic: none

Release note: None