### PR TITLE
workload/schemachange: instrument schemaChange

### DIFF
--- a/pkg/workload/schemachange/BUILD.bazel
+++ b/pkg/workload/schemachange/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "optype.go",
         "query_util.go",
         "schemachange.go",
+        "tracing.go",
         "type_resolver.go",
         "watch_dog.go",
         ":gen-optype-stringer",  # keep
@@ -45,6 +46,10 @@ go_library(
         "@com_github_jackc_pgx_v5//pgxpool",
         "@com_github_lib_pq//oid",
         "@com_github_spf13_pflag//:pflag",
+        "@io_opentelemetry_go_otel//attribute",
+        "@io_opentelemetry_go_otel//codes",
+        "@io_opentelemetry_go_otel_sdk//trace",
+        "@io_opentelemetry_go_otel_trace//:trace",
         "@org_golang_x_exp//slices",
     ],
 )

--- a/pkg/workload/schemachange/schemachange.go
+++ b/pkg/workload/schemachange/schemachange.go
@@ -35,6 +35,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/spf13/pflag"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 )
 
 // This workload executes batches of schema changes asynchronously. Each
@@ -150,7 +151,21 @@ func (s *schemaChange) Tables() []workload.Table {
 // Ops implements the workload.Opser interface.
 func (s *schemaChange) Ops(
 	ctx context.Context, urls []string, reg *histogram.Registry,
-) (workload.QueryLoad, error) {
+) (_ workload.QueryLoad, err error) {
+	// Initialize tracing ahead of everything else. The Ops function is used for
+	// managing the life cycle of this workload so we keep tracing localized to
+	// this function.
+	// NB: a noopSpanProcessor is provided here as there appears to be a bug in
+	// the OTeL SDK that causes Shutdown to error if no processors have been
+	// registered.
+	tracerProvider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(noopSpanProcessor{}))
+	tracer := tracerProvider.Tracer("schemachange")
+
+	// NB: The schemaChange.Ops span ends when this function returns, NOT when
+	// the workload is done.
+	ctx, span := tracer.Start(ctx, "schemaChange.Ops")
+	defer func() { EndSpan(span, err) }()
+
 	sqlDatabase, err := workload.SanitizeUrls(s, s.dbOverride, urls)
 	if err != nil {
 		return workload.QueryLoad{}, err
@@ -195,9 +210,19 @@ func (s *schemaChange) Ops(
 
 	ql := workload.QueryLoad{
 		SQLDatabase: sqlDatabase,
-		Close: func(ctx context.Context) error {
+		Close: func(_ context.Context) error {
+			// Create a new context for shutting down the tracer provider. The
+			// provided context may be cancelled depending on why the workload is
+			// shutting down and we always want to provide a period of time to flush
+			// traces.
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+
 			pool.Close()
-			return s.closeJSONLogFile()
+			closeErr := s.closeJSONLogFile()
+			shutdownErr := tracerProvider.Shutdown(ctx)
+
+			return errors.CombineErrors(closeErr, shutdownErr)
 		},
 	}
 

--- a/pkg/workload/schemachange/tracing.go
+++ b/pkg/workload/schemachange/tracing.go
@@ -1,0 +1,53 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package schemachange
+
+import (
+	"context"
+
+	"github.com/cockroachdb/errors"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// EndSpan is a helper for ending a span and annotating it with error
+// information, if relevant. Usage:
+//
+//	func mytracedfunc(ctx context.Context) (retErr err) {
+//		ctx, span := tracer.Start(ctx, "mytracedfunc")
+//		defer func() { EndSpan(span, retErr) }()
+//	}
+func EndSpan(span trace.Span, err error) {
+	if err == nil {
+		span.SetStatus(codes.Ok, "")
+	} else if errors.Is(err, context.Canceled) {
+		span.SetStatus(codes.Unset, "")
+		span.SetAttributes(
+			attribute.Bool("context.canceled", true),
+		)
+	} else {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+	}
+	span.End()
+}
+
+// noopSpanProcessor is an sdktrace.SpanProcessor that does nothing.
+type noopSpanProcessor struct{}
+
+var _ sdktrace.SpanProcessor = noopSpanProcessor{}
+
+func (noopSpanProcessor) ForceFlush(ctx context.Context) error                     { return nil }
+func (noopSpanProcessor) OnEnd(s sdktrace.ReadOnlySpan)                            {}
+func (noopSpanProcessor) OnStart(parent context.Context, s sdktrace.ReadWriteSpan) {}
+func (noopSpanProcessor) Shutdown(ctx context.Context) error                       { return nil }


### PR DESCRIPTION
#### 931750a9fc72972305e41001c314ce2ed087673b workload/schemachange: instrument schemaChange

`workload/schemachange` solely relies on a bespoke logging solution for
collecting and reporting debug information. While useful, logging alone
is limited in the usefulness of the information it can provide without
becoming overly noisy.

This commit begins the process of bolstering the existing logging
solution by adding OTeL instrument to the workload's entrypoint.

Future commits will add further instrumentation, logging integration,
and a file based exporter.

Epic: CRDB-19168
Release note: None