### PR TITLE
release: fix ubi9 openssl FIPS check

### DIFF
--- a/build/release/teamcity-support.sh
+++ b/build/release/teamcity-support.sh
@@ -96,9 +96,9 @@ verify_docker_image(){
       echo "ERROR: Go version '$go_version' does not contain 'fips'"
       error=1
     fi
-    openssl_version_output=$(docker run --platform="$docker_platform" "$img" shell -c "openssl version")
-    if [[ $openssl_version_output != *"FIPS"* ]]; then
-      echo "ERROR: openssl version '$openssl_version_output' does not contain 'FIPS'"
+    openssl_version_output=$(docker run --platform="$docker_platform" "$img" shell -c "openssl version -f")
+    if [[ $openssl_version_output != *"FIPS_VERSION"* ]]; then
+      echo "ERROR: openssl version '$openssl_version_output' does not contain 'FIPS_VERSION'"
       error=1
     fi
   fi

--- a/build/teamcity/internal/release/build-and-publish-patched-go/impl-fips.sh
+++ b/build/teamcity/internal/release/build-and-publish-patched-go/impl-fips.sh
@@ -11,7 +11,7 @@ GO_VERSION=1.21.3
 yum install git golang golang-bin openssl openssl-devel -y
 cat /etc/os-release
 go version
-openssl version
+openssl version -a
 git config --global user.name "golang-fips ci"
 git config --global user.email "<>"
 

--- a/build/teamcity/internal/release/process/publish-cockroach-release.sh
+++ b/build/teamcity/internal/release/process/publish-cockroach-release.sh
@@ -320,9 +320,9 @@ for img in "${images[@]}"; do
     echo "ERROR: Build tag from 'cockroach version --build-tag' mismatch, expected '$build_name', got '$build_tag_output'"
     error=1
   fi
-  openssl_version_output=$(docker run --platform="linux/amd64" "$img" shell -c "openssl version")
-  if [[ $openssl_version_output != *"FIPS"* ]]; then
-    echo "ERROR: openssl version '$openssl_version_outpu' does not contain 'FIPS'"
+  openssl_version_output=$(docker run --platform="linux/amd64" "$img" shell -c "openssl version -f")
+  if [[ $openssl_version_output != *"FIPS_VERSION"* ]]; then
+    echo "ERROR: openssl version '$openssl_version_outpu' does not contain 'FIPS_VERSION'"
     error=1
   fi
 done


### PR DESCRIPTION
Previously, we used the `openssl version` command to determine if the library supports FIPS or not. In UBI8 the output contained "FIPS", but in UBI9 this signature has been removed.

This PR uses `openssl version -f` to dump the compiler flags and searches for `FIPS_VERSION` instead.

Epic: none
Release note: None