### PR TITLE
workloadccl: deflake TestImportFixture

### DIFF
--- a/pkg/ccl/workloadccl/BUILD.bazel
+++ b/pkg/ccl/workloadccl/BUILD.bazel
@@ -44,6 +44,7 @@ go_test(
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",
         "//pkg/server",
+        "//pkg/settings/cluster",
         "//pkg/sql/stats",
         "//pkg/testutils",
         "//pkg/testutils/serverutils",


### PR DESCRIPTION
This commit deflakes `TestImportFixture` for good. It is achieved by disabling auto stats collection and only enabling it on the table being imported. This is needed in order to not "starve out" the auto stats job for the imported table since we only run a single auto stats job at a time, and previously auto stats on system tables could delay the "imported" stats run enough to exceed the "succeeds soon" duration.

Note that shared-process multi-tenancy is disabled because it appears that we don't propagate setting overrides that are set via `.Override` API into the shared-process tenant. Investigating that is tracked separately.

Fixes: #110708.

Release note: None