### PR TITLE
release-23.2: demo: Grant all capabilities to default tenant

### DIFF
--- a/pkg/cli/democluster/BUILD.bazel
+++ b/pkg/cli/democluster/BUILD.bazel
@@ -74,6 +74,7 @@ go_test(
         "//pkg/ccl/kvccl/kvtenantccl",
         "//pkg/cli/clisqlclient",
         "//pkg/cli/clisqlexec",
+        "//pkg/multitenant/tenantcapabilities",
         "//pkg/roachpb",
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",

--- a/pkg/cli/democluster/demo_cluster.go
+++ b/pkg/cli/democluster/demo_cluster.go
@@ -444,6 +444,12 @@ func (c *transientCluster) Start(ctx context.Context) (err error) {
 
 			ie := c.firstServer.InternalExecutor().(isql.Executor)
 
+			// Grant full capabilities.
+			_, err = ie.Exec(ctx, "tenant-grant-capabilities", nil, fmt.Sprintf("ALTER VIRTUAL CLUSTER %s GRANT ALL CAPABILITIES", demoTenantName))
+			if err != nil {
+				return err
+			}
+
 			if !c.demoCtx.DisableServerController {
 				// Select the default tenant.
 				// Choose the tenant to use when no tenant is specified on a


### PR DESCRIPTION
Backport 1/1 commits from #113756.

/cc @cockroachdb/release

---

Previously, the default tenant created by cockroach demo in multi-tenant mode did not have sufficient capabilities to run some operations. This manifested in issues like #107975.

This commit grants all capabilities to the default demo tenant so that it operates unfettered.

Fixes: #107975
Release note: None
Release justification: Low-risk fix to non-default behaviour
