### PR TITLE
kv: disable 1PC when weak isolation txns acquire replicated locks 

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
@@ -3055,7 +3055,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 			},
 			allIsoLevels: &expect{
 				expServerRefresh:  true,
-				expOnePhaseCommit: true,
+				expOnePhaseCommit: false,
 			},
 		},
 		{
@@ -3083,7 +3083,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 			},
 			allIsoLevels: &expect{
 				expServerRefresh:  true,
-				expOnePhaseCommit: true,
+				expOnePhaseCommit: false,
 			},
 		},
 		{
@@ -3118,7 +3118,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 			},
 		},
 		{
-			name: "write too old with (replicateed) exclusive locking read after prior read",
+			name: "write too old with (replicated) exclusive locking read after prior read",
 			afterTxnStart: func(ctx context.Context, db *kv.DB) error {
 				return db.Put(ctx, "a", "put")
 			},
@@ -3132,19 +3132,19 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 				isolation.Serializable: {
 					expClientRefreshSuccess:        true,
 					expClientAutoRetryAfterRefresh: true,
-					expOnePhaseCommit:              true,
+					expOnePhaseCommit:              false,
 				},
 				// Client-side refresh of prior reads after write-write conflict.
 				isolation.Snapshot: {
 					expClientRefreshSuccess:        true,
 					expClientAutoRetryAfterRefresh: true,
-					expOnePhaseCommit:              true,
+					expOnePhaseCommit:              false,
 				},
 				// Server-side refresh after write-write conflict. Prior reads performed
 				// in earlier batches (from earlier read snapshots) are not refreshed.
 				isolation.ReadCommitted: {
 					expServerRefresh:  true,
-					expOnePhaseCommit: true,
+					expOnePhaseCommit: false,
 				},
 			},
 		},
@@ -3194,19 +3194,19 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 				isolation.Serializable: {
 					expClientRefreshSuccess:        true,
 					expClientAutoRetryAfterRefresh: true,
-					expOnePhaseCommit:              true,
+					expOnePhaseCommit:              false,
 				},
 				// Client-side refresh of prior reads after write-write conflict.
 				isolation.Snapshot: {
 					expClientRefreshSuccess:        true,
 					expClientAutoRetryAfterRefresh: true,
-					expOnePhaseCommit:              true,
+					expOnePhaseCommit:              false,
 				},
 				// Server-side refresh after write-write conflict. Prior reads performed
 				// in earlier batches (from earlier read snapshots) are not refreshed.
 				isolation.ReadCommitted: {
 					expServerRefresh:  true,
-					expOnePhaseCommit: true,
+					expOnePhaseCommit: false,
 				},
 			},
 		},
@@ -3237,7 +3237,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 			allIsoLevels: &expect{
 				expClientRefreshSuccess:        true,
 				expClientAutoRetryAfterRefresh: true,
-				expOnePhaseCommit:              true,
+				expOnePhaseCommit:              false,
 			},
 		},
 		{
@@ -3267,7 +3267,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 			allIsoLevels: &expect{
 				expClientRefreshSuccess:        true,
 				expClientAutoRetryAfterRefresh: true,
-				expOnePhaseCommit:              true,
+				expOnePhaseCommit:              false,
 			},
 		},
 		{
@@ -3297,7 +3297,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 			allIsoLevels: &expect{
 				expClientRefreshSuccess:        true,
 				expClientAutoRetryAfterRefresh: true,
-				expOnePhaseCommit:              true,
+				expOnePhaseCommit:              false,
 			},
 		},
 		{
@@ -3327,7 +3327,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 			allIsoLevels: &expect{
 				expClientRefreshSuccess:        true,
 				expClientAutoRetryAfterRefresh: true,
-				expOnePhaseCommit:              true,
+				expOnePhaseCommit:              false,
 			},
 		},
 		{
@@ -3361,7 +3361,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 			allIsoLevels: &expect{
 				expClientRefreshSuccess:        true,
 				expClientAutoRetryAfterRefresh: true,
-				expOnePhaseCommit:              true,
+				expOnePhaseCommit:              false,
 			},
 		},
 		{
@@ -3395,7 +3395,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 			allIsoLevels: &expect{
 				expClientRefreshSuccess:        true,
 				expClientAutoRetryAfterRefresh: true,
-				expOnePhaseCommit:              true,
+				expOnePhaseCommit:              false,
 			},
 		},
 		{
@@ -3429,7 +3429,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 			allIsoLevels: &expect{
 				expClientRefreshSuccess:        true,
 				expClientAutoRetryAfterRefresh: true,
-				expOnePhaseCommit:              true,
+				expOnePhaseCommit:              false,
 			},
 		},
 		{

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_committer.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_committer.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/lock"
 	"github.com/cockroachdb/cockroach/pkg/multitenant"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
@@ -129,17 +130,19 @@ var parallelCommitsEnabled = settings.RegisterBoolSetting(
 // In all cases, the interceptor abstracts away the details of this from all
 // interceptors above it in the coordinator interceptor stack.
 type txnCommitter struct {
-	st      *cluster.Settings
-	stopper *stop.Stopper
-	wrapped lockedSender
-	metrics *TxnMetrics
-	mu      sync.Locker
+	st         *cluster.Settings
+	stopper    *stop.Stopper
+	wrapped    lockedSender
+	metrics    *TxnMetrics
+	mu         sync.Locker
+	disable1PC bool
 }
 
 // SendLocked implements the lockedSender interface.
 func (tc *txnCommitter) SendLocked(
 	ctx context.Context, ba *kvpb.BatchRequest,
 ) (*kvpb.BatchResponse, *kvpb.Error) {
+	tc.maybeDisable1PC(ba)
 	// If the batch does not include an EndTxn request, pass it through.
 	rArgs, hasET := ba.GetArg(kvpb.EndTxn)
 	if !hasET {
@@ -163,6 +166,7 @@ func (tc *txnCommitter) SendLocked(
 		return nil, kvpb.NewError(errors.AssertionFailedf("client must not assign Key to EndTxn"))
 	}
 	et.Key = ba.Txn.Key
+	et.Disable1PC = tc.disable1PC // disable the 1PC optimization, if necessary
 
 	// Determine whether the commit request can be run in parallel with the rest
 	// of the requests in the batch. If not, move the in-flight writes currently
@@ -274,6 +278,13 @@ func (tc *txnCommitter) validateEndTxnBatch(ba *kvpb.BatchRequest) error {
 	_, delRange := ba.GetArg(kvpb.DeleteRange)
 	if delRange && endTxn && !e.(*kvpb.EndTxnRequest).Require1PC {
 		return errors.Errorf("possible 1PC batch cannot contain EndTxn without setting Require1PC; see #37457")
+	}
+	// Check that the EndTxn request doesn't require a 1PC when we've previously
+	// determined 1PC should be disabled.
+	if e.(*kvpb.EndTxnRequest).Require1PC && tc.disable1PC {
+		return errors.AssertionFailedf(
+			"cannot require 1PC when for transactions that acquire replicated locks",
+		)
 	}
 	return nil
 }
@@ -542,6 +553,53 @@ func makeTxnCommitExplicitLocked(
 		return pErr.GoError()
 	}
 	return nil
+}
+
+// maybeDisable1PC checks if the supplied batch would require us to disable 1PC
+// when it's time to commit the transaction. A transaction that has acquired one
+// or more replicated locks is not allowed to commit using 1PC; everyone else,
+// if they're able to (determined on the server), is.
+//
+// Replicated locks must be held until and provide protection up till their
+// transaction's commit timestamp[1]. We ensure this by bumping the timestamp
+// cache to the transaction's commit timestamp for all locked keys when
+// resolving locks. Let's consider external and local replicated locks
+// separately:
+//
+// - External locks: 1PC transactions do not write a transaction record. This
+// means if any of its external locks are resolved by another transaction
+// they'll be resolved as if the transaction were aborted, thus not providing us
+// protection until the transaction's commit timestamp.
+// - Local locks: we have all the information to locally resolve replicated
+// locks and bump the timestamp cache correctly if we're only dealing with local
+// replicated locks. However, the mechanics of 1PC transactions prevent us from
+// hitting it in the common case, where we're acquiring a replicated lock and
+// writing to the same key. 1PC transactions work by stripping the batch of its
+// EndTxnRequest and running it as a non-transactional batch. This means that
+// without some elbow grease, 1PC is bound to fail when it discovers its own
+// replicated lock. For now, we disable 1PC on the client for local locks as
+// well -- this can be optimized in the future.
+// TODO(arul): file an issue about improving things for local locks.
+//
+// [1] This distinction is currently moot for serializable transactions, as they
+// refresh all their reads (locked and unlocked) before committing. Doing so
+// bumps the timestamp cache. However, one can imagine a world where
+// serializable transactions do not need to refresh keys they acquired
+// replicated locks on. In such a world, we would be relying on lock resolution
+// to bump the timestamp cache to the commit timestamp of the transaction.
+func (tc *txnCommitter) maybeDisable1PC(ba *kvpb.BatchRequest) {
+	if tc.disable1PC {
+		return // already disabled; early return
+	}
+	for _, req := range ba.Requests {
+		if readOnlyReq, ok := req.GetInner().(kvpb.LockingReadRequest); ok {
+			_, dur := readOnlyReq.KeyLocking()
+			if dur == lock.Replicated {
+				tc.disable1PC = true
+				return
+			}
+		}
+	}
 }
 
 // setWrapped implements the txnInterceptor interface.

--- a/pkg/kv/kvpb/api.proto
+++ b/pkg/kv/kvpb/api.proto
@@ -952,12 +952,16 @@ message EndTxnRequest {
   // reliably for these transactions - a TransactionStatusError might be
   // returned instead if 1PC execution fails.
   bool require_1pc = 6 [(gogoproto.customname) = "Require1PC"];
+  // Disables the transaction from attempting 1 phase commit. Cannot be used in
+  // conjunction with the Require1PC flag.
+  bool disable_1pc = 11 [(gogoproto.customname) = "Disable1PC"];
   // True to indicate that lock spans should be resolved with poison=true.
   // This is used when the transaction is being aborted independently of the
   // main thread of client operation, as in the case of an asynchronous abort
   // from the TxnCoordSender on a failed heartbeat. It should only be set to
   // true when commit=false.
   bool poison = 9;
+
   reserved 7, 8, 10;
 }
 


### PR DESCRIPTION
Replicated locks acquired by a transaction must provide protection up
till its commit timestamp. Serializable transactions do not permit
write skew, so the read refresh mechanism gives us this property.
However, for isolation levels that do permit write skew (read committed,
snapshot), we ensure this by bumping the timestamp cache over all locked
keys when resolving replicated locks.

It's worth considering external and local replicated locks separately for
1PC transactions:

- External locks: 1PC transactions do not write a transaction record.
This means if any of its external locks are resolved by another
transaction they'll be resolved as if the transaction were aborted,
thus not providing us protection until the transaction's commit
timestamp.
- Local locks: we have all the information to locally resolve replicated
locks and bump the timestamp cache correctly if we're only dealing with
local replicated locks. However, the mechanics of 1PC transactions
prevent us from hitting it in the common case, where we're acquiring a
replicated lock and writing to the same key. 1PC transactions work by
stripping the batch of its EndTxnRequest and running it as a
non-transactional batch. This means that without some elbow grease, 1PC
is bound to fail when it discovers its own replicated lock. For now,
we disable 1PC on the client for local locks as well -- this can
be optimized in the future.

Fixes: https://github.com/cockroachdb/cockroach/issues/113768

Release note: None