### PR TITLE
kvclient: optimize and clean up sorting computation

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_test.go
@@ -5417,11 +5417,12 @@ func TestDistSenderComputeNetworkCost(t *testing.T) {
 			ReplicaDescriptor: roachpb.ReplicaDescriptor{
 				ReplicaID: roachpb.ReplicaID(replicaID),
 			},
-			Tiers: []roachpb.Tier{
-				{Key: "az", Value: fmt.Sprintf("az%d", rand.Intn(10))},
-				{Key: "region", Value: region},
-				{Key: "dc", Value: fmt.Sprintf("dc%d", rand.Intn(10))},
-			},
+			Locality: roachpb.Locality{
+				Tiers: []roachpb.Tier{
+					{Key: "az", Value: fmt.Sprintf("az%d", rand.Intn(10))},
+					{Key: "region", Value: region},
+					{Key: "dc", Value: fmt.Sprintf("dc%d", rand.Intn(10))},
+				}},
 		}
 	}
 

--- a/pkg/kv/kvclient/kvcoord/replica_slice_test.go
+++ b/pkg/kv/kvclient/kvcoord/replica_slice_test.go
@@ -170,7 +170,7 @@ func locality(t *testing.T, locStrs []string) roachpb.Locality {
 func info(t *testing.T, nid roachpb.NodeID, sid roachpb.StoreID, locStrs []string) ReplicaInfo {
 	return ReplicaInfo{
 		ReplicaDescriptor: desc(nid, sid),
-		Tiers:             locality(t, locStrs).Tiers,
+		Locality:          locality(t, locStrs),
 	}
 }
 


### PR DESCRIPTION
Previously the locality distance and the latency function were computed multiple times for each node in the sort.Slice method. This change computes the values once when the ReplicaSlice is created and uses simple comparisions within the sorting loop.

Epic: none
Informs: #112351

Release note: None