### PR TITLE
log: add protobuf messages for telemetry txn events

### DIFF
--- a/docs/generated/eventlog.md
+++ b/docs/generated/eventlog.md
@@ -2879,6 +2879,29 @@ An event of type `hot_ranges_stats`
 | `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
 | `EventType` | The type of the event. | no |
 
+### `m_v_c_c_iterator_stats`
+
+Internal storage iteration statistics for a single execution.
+
+
+| Field | Description | Sensitive |
+|--|--|--|
+| `StepCount` | StepCount collects the number of times the iterator moved forward or backward over the DB's underlying storage keyspace. For details, see pkg/storage/engine.go and pkg/sql/opt/exec/factory.go. | no |
+| `StepCountInternal` | StepCountInternal collects the number of times the iterator moved forward or backward over LSM internal keys. For details, see pkg/storage/engine.go and pkg/sql/opt/exec/factory.go. | no |
+| `SeekCount` | SeekCount collects the number of times the iterator moved to a specific key/value pair in the DB's underlying storage keyspace. For details, see pkg/storage/engine.go and pkg/sql/opt/exec/factory.go. | no |
+| `SeekCountInternal` | SeekCountInternal collects the number of times the iterator moved to a specific LSM internal key. For details, see pkg/storage/engine.go and pkg/sql/opt/exec/factory.go. | no |
+| `BlockBytes` | BlockBytes collects the bytes in the loaded SSTable data blocks. For details, see pebble.InternalIteratorStats. | no |
+| `BlockBytesInCache` | BlockBytesInCache collects the subset of BlockBytes in the block cache. For details, see pebble.InternalIteratorStats. | no |
+| `KeyBytes` | KeyBytes collects the bytes in keys that were iterated over. For details, see pebble.InternalIteratorStats. | no |
+| `ValueBytes` | ValueBytes collects the bytes in values that were iterated over. For details, see pebble.InternalIteratorStats. | no |
+| `PointCount` | PointCount collects the count of point keys iterated over. For details, see pebble.InternalIteratorStats. | no |
+| `PointsCoveredByRangeTombstones` | PointsCoveredByRangeTombstones collects the count of point keys that were iterated over that were covered by range tombstones. For details, see pebble.InternalIteratorStats and https://github.com/cockroachdb/cockroach/blob/master/docs/tech-notes/mvcc-range-tombstones.md. | no |
+| `RangeKeyCount` | RangeKeyCount collects the count of range keys encountered during iteration. For details, see pebble.RangeKeyIteratorStats and https://github.com/cockroachdb/cockroach/blob/master/docs/tech-notes/mvcc-range-tombstones.md. | no |
+| `RangeKeyContainedPoints` | RangeKeyContainedPoints collects the count of point keys encountered within the bounds of a range key. For details, see pebble.RangeKeyIteratorStats and https://github.com/cockroachdb/cockroach/blob/master/docs/tech-notes/mvcc-range-tombstones.md. | no |
+| `RangeKeySkippedPoints` | RangeKeySkippedPoints collects the count of the subset of ContainedPoints point keys that were skipped during iteration due to range-key masking. For details, see pkg/storage/engine.go, pebble.RangeKeyIteratorStats, and https://github.com/cockroachdb/cockroach/blob/master/docs/tech-notes/mvcc-range-tombstones.md. | no |
+
+
+
 ### `recovery_event`
 
 An event of type `recovery_event` is an event that is logged on every invocation of BACKUP,
@@ -2923,6 +2946,27 @@ logged whenever a BACKUP and RESTORE job completes or fails.
 |--|--|--|
 | `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
 | `EventType` | The type of the event. | no |
+
+### `sampled_exec_stats`
+
+An event of type `sampled_exec_stats` contains execution statistics that apply to both statements
+and transactions. These stats as a whole are collected using a sampling approach.
+These exec stats are meant to contain the same fields as ExecStats in
+apps_stats.proto but are for a single execution rather than aggregated executions.
+Fields in this struct should be updated in sync with apps_stats.proto.
+
+
+| Field | Description | Sensitive |
+|--|--|--|
+| `NetworkBytes` | NetworkBytes collects the number of bytes sent over the network. | no |
+| `MaxMemUsage` | MaxMemUsage collects the maximum memory usage that occurred on a node. | no |
+| `ContentionTime` | ContentionTime collects the time in seconds statements in the transaction spent contending. | no |
+| `NetworkMessages` | NetworkMessages collects the number of messages that were sent over the network. | no |
+| `MaxDiskUsage` | MaxDiskUsage collects the maximum temporary disk usage that occurred. This is set in cases where a query had to spill to disk, e.g. when performing a large sort where not all of the tuples fit in memory. | no |
+| `CPUSQLNanos` | CPUSQLNanos collects the CPU time spent executing SQL operations in nanoseconds. Currently, it is only collected for statements without mutations that have a vectorized plan. | no |
+| `MVCCIteratorStats` | Internal storage iteration statistics. | yes |
+
+
 
 ### `sampled_query`
 
@@ -3029,6 +3073,46 @@ contains common SQL event/execution details.
 | `TxnCounter` | The sequence number of the SQL transaction inside its session. | no |
 | `BulkJobId` | The job id for bulk job (IMPORT/BACKUP/RESTORE). | no |
 | `StmtPosInTxn` | The statement's index in the transaction, starting at 1. | no |
+
+### `sampled_transaction`
+
+An event of type `sampled_transaction` is the event logged to telemetry at the end of transaction execution.
+
+
+| Field | Description | Sensitive |
+|--|--|--|
+| `User` | User is the user account that triggered the transaction. The special usernames `root` and `node` are not considered sensitive. | depends |
+| `ApplicationName` | ApplicationName is the application name for the session where the transaction was executed. This is included in the event to ease filtering of logging output by application. | no |
+| `TxnCounter` | TxnCounter is the sequence number of the SQL transaction inside its session. | no |
+| `SessionID` | SessionID is the ID of the session that initiated the transaction. | no |
+| `TransactionID` | TransactionID is the id of the transaction. | no |
+| `TransactionFingerprintID` | TransactionFingerprintID is the fingerprint ID of the transaction. This can be used to find the transaction in the console. | no |
+| `Committed` | Committed indicates if the transaction committed successfully. We want to include this value even if it is false. | no |
+| `ImplicitTxn` | ImplicitTxn indicates if the transaction was an implicit one. We want to include this value even if it is false. | no |
+| `StartTimeUnixNanos` | StartTimeUnixNanos is the time the transaction was started. Expressed as unix time in nanoseconds. | no |
+| `EndTimeUnixNanos` | EndTimeUnixNanos the time the transaction finished (either committed or aborted). Expressed as unix time in nanoseconds. | no |
+| `ServiceLatNanos` | ServiceLatNanos is the time to service the whole transaction, from start to end of execution. | no |
+| `SQLSTATE` | SQLSTATE is the SQLSTATE code for the error, if an error was encountered. Empty/omitted if no error. | no |
+| `ErrorText` | ErrorText is the text of the error if any. | partially |
+| `NumRetries` | NumRetries is the number of time when the txn was retried automatically by the server. | no |
+| `LastAutoRetryReason` | LastAutoRetryReason is a string containing the reason for the last automatic retry. | partially |
+| `StatementFingerprintIDs` | StatementFingerprintIDs is an array of statement fingerprint IDs belonging to this transaction. | yes |
+| `NumRows` | NumRows is the total number of rows returned across all statements. | no |
+| `RetryLatNanos` | RetryLatNanos is the amount of time spent retrying the transaction. | no |
+| `CommitLatNanos` | CommitLatNanos is the amount of time spent committing the transaction after all statement operations. | no |
+| `IdleLatNanos` | IdleLatNanos is the amount of time spent waiting for the client to send statements while the transaction is open. | no |
+| `BytesRead` | BytesRead is the number of bytes read from disk. | no |
+| `RowsRead` | RowsRead is the number of rows read from disk. | no |
+| `RowsWritten` | RowsWritten is the number of rows written to disk. | no |
+| `SampledExecStats` | SampledExecStats is a nested field containing execution statistics. This field will be omitted if the stats were not sampled. | yes |
+
+
+#### Common fields
+
+| Field | Description | Sensitive |
+|--|--|--|
+| `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
+| `EventType` | The type of the event. | no |
 
 ### `schema_descriptor`
 

--- a/pkg/sql/appstatspb/app_stats.proto
+++ b/pkg/sql/appstatspb/app_stats.proto
@@ -313,6 +313,9 @@ message TxnStats {
 // ExecStats contains execution statistics that apply to both statements
 // and transactions. These stats are currently collected using a sampling
 // approach.
+// When adding additional fields to this message, please make the corresponding
+// changes to 'SampledExecStats' in telemetry.proto to keep the two messages in sync
+// with respect to the information stored.
 message ExecStats {
   // Count keeps track of how many times execution stats were recorded. This is
   // not necessarily equal to the number of times a statement/transaction was

--- a/pkg/util/log/eventpb/BUILD.bazel
+++ b/pkg/util/log/eventpb/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/util/log/eventpb",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/sql/appstatspb",  # keep
         "//pkg/util/jsonbytes",  # keep
         "//pkg/util/log/logpb",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/util/log/eventpb/eventlog_channels_generated.go
+++ b/pkg/util/log/eventpb/eventlog_channels_generated.go
@@ -332,10 +332,19 @@ func (m *CreateChangefeed) LoggingChannel() logpb.Channel { return logpb.Channel
 func (m *HotRangesStats) LoggingChannel() logpb.Channel { return logpb.Channel_TELEMETRY }
 
 // LoggingChannel implements the EventPayload interface.
+func (m *MVCCIteratorStats) LoggingChannel() logpb.Channel { return logpb.Channel_TELEMETRY }
+
+// LoggingChannel implements the EventPayload interface.
 func (m *RecoveryEvent) LoggingChannel() logpb.Channel { return logpb.Channel_TELEMETRY }
 
 // LoggingChannel implements the EventPayload interface.
+func (m *SampledExecStats) LoggingChannel() logpb.Channel { return logpb.Channel_TELEMETRY }
+
+// LoggingChannel implements the EventPayload interface.
 func (m *SampledQuery) LoggingChannel() logpb.Channel { return logpb.Channel_TELEMETRY }
+
+// LoggingChannel implements the EventPayload interface.
+func (m *SampledTransaction) LoggingChannel() logpb.Channel { return logpb.Channel_TELEMETRY }
 
 // LoggingChannel implements the EventPayload interface.
 func (m *SchemaDescriptor) LoggingChannel() logpb.Channel { return logpb.Channel_TELEMETRY }

--- a/pkg/util/log/eventpb/eventpbgen/BUILD.bazel
+++ b/pkg/util/log/eventpb/eventpbgen/BUILD.bazel
@@ -15,12 +15,6 @@ go_library(
     ],
 )
 
-go_binary(
-    name = "eventpbgen",
-    embed = [":eventpbgen_lib"],
-    visibility = ["//visibility:public"],
-)
-
 # The code generator
 
 genrule(
@@ -37,4 +31,10 @@ genrule(
         ":__pkg__",
         "//pkg/gen:__pkg__",
     ],
+)
+
+go_binary(
+    name = "eventpbgen",
+    embed = [":eventpbgen_lib"],
+    visibility = ["//visibility:public"],
 )

--- a/pkg/util/log/eventpb/eventpbgen/gen.go
+++ b/pkg/util/log/eventpb/eventpbgen/gen.go
@@ -389,6 +389,12 @@ func readInput(
 				typ = "timestamp"
 			case "cockroach.sql.sqlbase.Descriptor":
 				typ = "protobuf"
+			case "MVCCIteratorStats":
+				fallthrough
+			case "SampledExecStats":
+				// This is necessary so that the fields in the
+				// message doesn't get inlined.
+				typ = "nestedMessage"
 			}
 
 			if otherMsg, ok := infos[typ]; ok {
@@ -660,6 +666,16 @@ func (m *{{.GoType}}) AppendJSONFields(printComma bool, b redact.RedactableBytes
      }
      b = append(b, ']')
    }
+   {{- else if eq .FieldType "array_of_uint64" -}}
+   if len(m.{{.FieldName}}) > 0 {
+     if printComma { b = append(b, ',')}; printComma = true
+     b = append(b, "\"{{.FieldName}}\":["...)
+     for i, v := range m.{{.FieldName}} {
+       if i > 0 { b = append(b, ',') }
+       b = strconv.AppendUint(b, uint64(v), 10)
+     }
+     b = append(b, ']')
+   }
    {{- else if .IsEnum }}
    {{ if not .AllowZeroValue -}}
    if m.{{.FieldName}} != 0 {
@@ -694,6 +710,14 @@ func (m *{{.GoType}}) AppendJSONFields(printComma bool, b redact.RedactableBytes
        b = append(b, "\"{{.FieldName}}\":"...)
        b = append(b, []byte(str)...)
      }
+   }
+   {{- else if eq .FieldType "nestedMessage"}}
+if m.{{.FieldName}} != nil {
+     if printComma { b = append(b, ',')}; printComma = true
+     b = append(b, "\"{{.FieldName}}\":"...)
+     b = append(b, '{')
+     printComma, b = m.{{.FieldName}}.AppendJSONFields(false, b)
+     b = append(b, '}')
    }
    {{- else}}
    {{ error  .FieldType }}

--- a/pkg/util/log/eventpb/json_encode_generated.go
+++ b/pkg/util/log/eventpb/json_encode_generated.go
@@ -3394,6 +3394,103 @@ func (m *LevelStats) AppendJSONFields(printComma bool, b redact.RedactableBytes)
 }
 
 // AppendJSONFields implements the EventPayload interface.
+func (m *MVCCIteratorStats) AppendJSONFields(printComma bool, b redact.RedactableBytes) (bool, redact.RedactableBytes) {
+
+	if printComma {
+		b = append(b, ',')
+	}
+	printComma = true
+	b = append(b, "\"StepCount\":"...)
+	b = strconv.AppendInt(b, int64(m.StepCount), 10)
+
+	if printComma {
+		b = append(b, ',')
+	}
+	printComma = true
+	b = append(b, "\"StepCountInternal\":"...)
+	b = strconv.AppendInt(b, int64(m.StepCountInternal), 10)
+
+	if printComma {
+		b = append(b, ',')
+	}
+	printComma = true
+	b = append(b, "\"SeekCount\":"...)
+	b = strconv.AppendInt(b, int64(m.SeekCount), 10)
+
+	if printComma {
+		b = append(b, ',')
+	}
+	printComma = true
+	b = append(b, "\"SeekCountInternal\":"...)
+	b = strconv.AppendInt(b, int64(m.SeekCountInternal), 10)
+
+	if printComma {
+		b = append(b, ',')
+	}
+	printComma = true
+	b = append(b, "\"BlockBytes\":"...)
+	b = strconv.AppendInt(b, int64(m.BlockBytes), 10)
+
+	if printComma {
+		b = append(b, ',')
+	}
+	printComma = true
+	b = append(b, "\"BlockBytesInCache\":"...)
+	b = strconv.AppendInt(b, int64(m.BlockBytesInCache), 10)
+
+	if printComma {
+		b = append(b, ',')
+	}
+	printComma = true
+	b = append(b, "\"KeyBytes\":"...)
+	b = strconv.AppendInt(b, int64(m.KeyBytes), 10)
+
+	if printComma {
+		b = append(b, ',')
+	}
+	printComma = true
+	b = append(b, "\"ValueBytes\":"...)
+	b = strconv.AppendInt(b, int64(m.ValueBytes), 10)
+
+	if printComma {
+		b = append(b, ',')
+	}
+	printComma = true
+	b = append(b, "\"PointCount\":"...)
+	b = strconv.AppendInt(b, int64(m.PointCount), 10)
+
+	if printComma {
+		b = append(b, ',')
+	}
+	printComma = true
+	b = append(b, "\"PointsCoveredByRangeTombstones\":"...)
+	b = strconv.AppendInt(b, int64(m.PointsCoveredByRangeTombstones), 10)
+
+	if printComma {
+		b = append(b, ',')
+	}
+	printComma = true
+	b = append(b, "\"RangeKeyCount\":"...)
+	b = strconv.AppendInt(b, int64(m.RangeKeyCount), 10)
+
+	if printComma {
+		b = append(b, ',')
+	}
+	printComma = true
+	b = append(b, "\"RangeKeyContainedPoints\":"...)
+	b = strconv.AppendInt(b, int64(m.RangeKeyContainedPoints), 10)
+
+	if printComma {
+		b = append(b, ',')
+	}
+	printComma = true
+	b = append(b, "\"RangeKeySkippedPoints\":"...)
+	b = strconv.AppendInt(b, int64(m.RangeKeySkippedPoints), 10)
+
+	return printComma, b
+}
+
+// AppendJSONFields implements the EventPayload interface.
 func (m *NodeDecommissioned) AppendJSONFields(printComma bool, b redact.RedactableBytes) (bool, redact.RedactableBytes) {
 
 	printComma, b = m.CommonEventDetails.AppendJSONFields(printComma, b)
@@ -4192,6 +4289,67 @@ func (m *RuntimeStats) AppendJSONFields(printComma bool, b redact.RedactableByte
 }
 
 // AppendJSONFields implements the EventPayload interface.
+func (m *SampledExecStats) AppendJSONFields(printComma bool, b redact.RedactableBytes) (bool, redact.RedactableBytes) {
+
+	if printComma {
+		b = append(b, ',')
+	}
+	printComma = true
+	b = append(b, "\"NetworkBytes\":"...)
+	b = strconv.AppendInt(b, int64(m.NetworkBytes), 10)
+
+	if printComma {
+		b = append(b, ',')
+	}
+	printComma = true
+	b = append(b, "\"MaxMemUsage\":"...)
+	b = strconv.AppendInt(b, int64(m.MaxMemUsage), 10)
+
+	if m.ContentionTime != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"ContentionTime\":"...)
+		b = strconv.AppendInt(b, int64(m.ContentionTime), 10)
+	}
+
+	if printComma {
+		b = append(b, ',')
+	}
+	printComma = true
+	b = append(b, "\"NetworkMessages\":"...)
+	b = strconv.AppendInt(b, int64(m.NetworkMessages), 10)
+
+	if printComma {
+		b = append(b, ',')
+	}
+	printComma = true
+	b = append(b, "\"MaxDiskUsage\":"...)
+	b = strconv.AppendInt(b, int64(m.MaxDiskUsage), 10)
+
+	if printComma {
+		b = append(b, ',')
+	}
+	printComma = true
+	b = append(b, "\"CPUSQLNanos\":"...)
+	b = strconv.AppendInt(b, int64(m.CPUSQLNanos), 10)
+
+	if m.MVCCIteratorStats != nil {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"MVCCIteratorStats\":"...)
+		b = append(b, '{')
+		printComma, b = m.MVCCIteratorStats.AppendJSONFields(false, b)
+		b = append(b, '}')
+	}
+
+	return printComma, b
+}
+
+// AppendJSONFields implements the EventPayload interface.
 func (m *SampledQuery) AppendJSONFields(printComma bool, b redact.RedactableBytes) (bool, redact.RedactableBytes) {
 
 	printComma, b = m.CommonEventDetails.AppendJSONFields(printComma, b)
@@ -4883,6 +5041,224 @@ func (m *SampledQuery) AppendJSONFields(printComma bool, b redact.RedactableByte
 			b = strconv.AppendInt(b, int64(v), 10)
 		}
 		b = append(b, ']')
+	}
+
+	return printComma, b
+}
+
+// AppendJSONFields implements the EventPayload interface.
+func (m *SampledTransaction) AppendJSONFields(printComma bool, b redact.RedactableBytes) (bool, redact.RedactableBytes) {
+
+	printComma, b = m.CommonEventDetails.AppendJSONFields(printComma, b)
+
+	if printComma {
+		b = append(b, ',')
+	}
+	printComma = true
+	b = append(b, "\"User\":\""...)
+
+	if safeRe1.MatchString(m.User) {
+		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.User)))))
+	} else {
+		b = append(b, redact.StartMarker()...)
+		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.User)))))
+		b = append(b, redact.EndMarker()...)
+	}
+	b = append(b, '"')
+
+	if printComma {
+		b = append(b, ',')
+	}
+	printComma = true
+	b = append(b, "\"ApplicationName\":\""...)
+	b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.ApplicationName)))
+	b = append(b, '"')
+
+	if m.TxnCounter != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"TxnCounter\":"...)
+		b = strconv.AppendUint(b, uint64(m.TxnCounter), 10)
+	}
+
+	if m.SessionID != "" {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"SessionID\":\""...)
+		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.SessionID)))
+		b = append(b, '"')
+	}
+
+	if printComma {
+		b = append(b, ',')
+	}
+	printComma = true
+	b = append(b, "\"TransactionID\":\""...)
+	b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.TransactionID)))
+	b = append(b, '"')
+
+	if m.TransactionFingerprintID != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"TransactionFingerprintID\":"...)
+		b = strconv.AppendUint(b, uint64(m.TransactionFingerprintID), 10)
+	}
+
+	if printComma {
+		b = append(b, ',')
+	}
+	printComma = true
+	b = append(b, "\"Committed\":"...)
+	b = strconv.AppendBool(b, m.Committed)
+
+	if printComma {
+		b = append(b, ',')
+	}
+	printComma = true
+	b = append(b, "\"ImplicitTxn\":"...)
+	b = strconv.AppendBool(b, m.ImplicitTxn)
+
+	if printComma {
+		b = append(b, ',')
+	}
+	printComma = true
+	b = append(b, "\"StartTimeUnixNanos\":"...)
+	b = strconv.AppendInt(b, int64(m.StartTimeUnixNanos), 10)
+
+	if printComma {
+		b = append(b, ',')
+	}
+	printComma = true
+	b = append(b, "\"EndTimeUnixNanos\":"...)
+	b = strconv.AppendInt(b, int64(m.EndTimeUnixNanos), 10)
+
+	if printComma {
+		b = append(b, ',')
+	}
+	printComma = true
+	b = append(b, "\"ServiceLatNanos\":"...)
+	b = strconv.AppendInt(b, int64(m.ServiceLatNanos), 10)
+
+	if m.SQLSTATE != "" {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"SQLSTATE\":\""...)
+		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.SQLSTATE)))
+		b = append(b, '"')
+	}
+
+	if m.ErrorText != "" {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"ErrorText\":\""...)
+		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.ErrorText)))
+		b = append(b, '"')
+	}
+
+	if m.NumRetries != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"NumRetries\":"...)
+		b = strconv.AppendInt(b, int64(m.NumRetries), 10)
+	}
+
+	if m.LastAutoRetryReason != "" {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"LastAutoRetryReason\":\""...)
+		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.LastAutoRetryReason)))
+		b = append(b, '"')
+	}
+
+	if len(m.StatementFingerprintIDs) > 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"StatementFingerprintIDs\":["...)
+		for i, v := range m.StatementFingerprintIDs {
+			if i > 0 {
+				b = append(b, ',')
+			}
+			b = strconv.AppendUint(b, uint64(v), 10)
+		}
+		b = append(b, ']')
+	}
+
+	if printComma {
+		b = append(b, ',')
+	}
+	printComma = true
+	b = append(b, "\"NumRows\":"...)
+	b = strconv.AppendInt(b, int64(m.NumRows), 10)
+
+	if m.RetryLatNanos != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"RetryLatNanos\":"...)
+		b = strconv.AppendInt(b, int64(m.RetryLatNanos), 10)
+	}
+
+	if printComma {
+		b = append(b, ',')
+	}
+	printComma = true
+	b = append(b, "\"CommitLatNanos\":"...)
+	b = strconv.AppendInt(b, int64(m.CommitLatNanos), 10)
+
+	if printComma {
+		b = append(b, ',')
+	}
+	printComma = true
+	b = append(b, "\"IdleLatNanos\":"...)
+	b = strconv.AppendInt(b, int64(m.IdleLatNanos), 10)
+
+	if printComma {
+		b = append(b, ',')
+	}
+	printComma = true
+	b = append(b, "\"BytesRead\":"...)
+	b = strconv.AppendInt(b, int64(m.BytesRead), 10)
+
+	if printComma {
+		b = append(b, ',')
+	}
+	printComma = true
+	b = append(b, "\"RowsRead\":"...)
+	b = strconv.AppendInt(b, int64(m.RowsRead), 10)
+
+	if printComma {
+		b = append(b, ',')
+	}
+	printComma = true
+	b = append(b, "\"RowsWritten\":"...)
+	b = strconv.AppendInt(b, int64(m.RowsWritten), 10)
+
+	if m.SampledExecStats != nil {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"SampledExecStats\":"...)
+		b = append(b, '{')
+		printComma, b = m.SampledExecStats.AppendJSONFields(false, b)
+		b = append(b, '}')
 	}
 
 	return printComma, b

--- a/pkg/util/log/eventpb/telemetry.proto
+++ b/pkg/util/log/eventpb/telemetry.proto
@@ -296,6 +296,189 @@ message SampledQuery {
   // Next available ID: 78.
 }
 
+// SampledExecStats contains execution statistics that apply to both statements
+// and transactions. These stats as a whole are collected using a sampling approach.
+// These exec stats are meant to contain the same fields as ExecStats in
+// apps_stats.proto but are for a single execution rather than aggregated executions.
+// Fields in this struct should be updated in sync with apps_stats.proto.
+message SampledExecStats {
+
+  // NetworkBytes collects the number of bytes sent over the network.
+  int64 network_bytes = 1 [(gogoproto.jsontag) = ",includeempty"];
+
+  // MaxMemUsage collects the maximum memory usage that occurred on a node.
+  int64 max_mem_usage = 2 [(gogoproto.jsontag) = ",includeempty"];
+
+  // ContentionTime collects the time in seconds statements in the transaction spent contending.
+  int64 contention_time = 3 [(gogoproto.jsontag) = ",omitempty"];
+
+  // NetworkMessages collects the number of messages that were sent over the
+  // network.
+  int64 network_messages = 4 [(gogoproto.jsontag) = ",includeempty"];
+
+  // MaxDiskUsage collects the maximum temporary disk usage that occurred. This
+  // is set in cases where a query had to spill to disk, e.g. when performing a
+  // large sort where not all of the tuples fit in memory.
+  int64 max_disk_usage = 5 [(gogoproto.jsontag) = ",includeempty"];
+
+  // CPUSQLNanos collects the CPU time spent executing SQL operations in
+  // nanoseconds. Currently, it is only collected for statements without
+  // mutations that have a vectorized plan.
+  int64 cpu_sql_nanos = 6 [(gogoproto.customname) = "CPUSQLNanos", (gogoproto.jsontag) = "CPUSQLNanos,includeempty"];
+
+  // Internal storage iteration statistics.
+  MVCCIteratorStats mvcc_iterator_stats = 7 [(gogoproto.customname) = "MVCCIteratorStats", (gogoproto.jsontag) = ",omitempty"];
+}
+
+// Internal storage iteration statistics for a single execution.
+message MVCCIteratorStats {
+  // StepCount collects the number of times the iterator moved forward or backward over the
+  // DB's underlying storage keyspace.
+  // For details, see pkg/storage/engine.go and pkg/sql/opt/exec/factory.go.
+  int64 step_count = 1 [(gogoproto.jsontag) = ",includeempty"];
+
+  // StepCountInternal collects the number of times the iterator moved forward or backward
+  // over LSM internal keys.
+  // For details, see pkg/storage/engine.go and pkg/sql/opt/exec/factory.go.
+  int64 step_count_internal = 2 [(gogoproto.jsontag) = ",includeempty"];
+
+  // SeekCount collects the number of times the iterator moved to a specific key/value pair
+  // in the DB's underlying storage keyspace.
+  // For details, see pkg/storage/engine.go and pkg/sql/opt/exec/factory.go.
+  int64 seek_count = 3 [(gogoproto.jsontag) = ",includeempty"];
+
+  // SeekCountInternal collects the number of times the iterator moved to a specific LSM
+  // internal key.
+  // For details, see pkg/storage/engine.go and pkg/sql/opt/exec/factory.go.
+  int64 seek_count_internal = 4 [(gogoproto.jsontag) = ",includeempty"];
+
+  // BlockBytes collects the bytes in the loaded SSTable data blocks.
+  // For details, see pebble.InternalIteratorStats.
+  int64 block_bytes = 5 [(gogoproto.jsontag) = ",includeempty"];
+
+  // BlockBytesInCache collects the subset of BlockBytes in the block cache.
+  // For details, see pebble.InternalIteratorStats.
+  int64 block_bytes_in_cache = 6 [(gogoproto.jsontag) = ",includeempty"];
+
+  // KeyBytes collects the bytes in keys that were iterated over.
+  // For details, see pebble.InternalIteratorStats.
+  int64 key_bytes = 7 [(gogoproto.jsontag) = ",includeempty"];
+
+  // ValueBytes collects the bytes in values that were iterated over.
+  // For details, see pebble.InternalIteratorStats.
+  int64 value_bytes = 8 [(gogoproto.jsontag) = ",includeempty"];
+
+  // PointCount collects the count of point keys iterated over.
+  // For details, see pebble.InternalIteratorStats.
+  int64 point_count = 9 [(gogoproto.jsontag) = ",includeempty"];
+
+  // PointsCoveredByRangeTombstones collects the count of point keys that were iterated over that
+  // were covered by range tombstones.
+  // For details, see pebble.InternalIteratorStats and
+  // https://github.com/cockroachdb/cockroach/blob/master/docs/tech-notes/mvcc-range-tombstones.md.
+  int64 points_covered_by_range_tombstones = 10 [(gogoproto.jsontag) = ",includeempty"];
+
+  // RangeKeyCount collects the count of range keys encountered during iteration.
+  // For details, see pebble.RangeKeyIteratorStats and
+  // https://github.com/cockroachdb/cockroach/blob/master/docs/tech-notes/mvcc-range-tombstones.md.
+  int64 range_key_count = 11 [(gogoproto.jsontag) = ",includeempty"];
+
+  // RangeKeyContainedPoints collects the count of point keys encountered within the bounds of
+  // a range key.
+  // For details, see pebble.RangeKeyIteratorStats and
+  // https://github.com/cockroachdb/cockroach/blob/master/docs/tech-notes/mvcc-range-tombstones.md.
+  int64 range_key_contained_points = 12 [(gogoproto.jsontag) = ",includeempty"];
+
+  // RangeKeySkippedPoints collects the count of the subset of ContainedPoints point keys that
+  // were skipped during iteration due to range-key masking.
+  // For details, see pkg/storage/engine.go, pebble.RangeKeyIteratorStats, and
+  // https://github.com/cockroachdb/cockroach/blob/master/docs/tech-notes/mvcc-range-tombstones.md.
+  int64 range_key_skipped_points = 13 [(gogoproto.jsontag) = ",includeempty"];
+}
+
+// SampledTransaction is the event logged to telemetry at the end of transaction execution.
+message SampledTransaction {
+  // Common contains common event details shared by all log events.
+  CommonEventDetails common = 1 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "", (gogoproto.embed) = true];
+
+  // User is the user account that triggered the transaction.
+  // The special usernames `root` and `node` are not considered sensitive.
+  string user = 2 [(gogoproto.jsontag) = ",includeempty", (gogoproto.moretags) = "redact:\"safeif:root|node\""];
+
+  // ApplicationName is the application name for the session where the transaction was executed.
+  // This is included in the event to ease filtering of logging output by application.
+  string application_name = 3 [(gogoproto.jsontag) = ",includeempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
+
+  // TxnCounter is the sequence number of the SQL transaction inside its session.
+  uint32 txn_counter = 4 [(gogoproto.jsontag) = ",omitempty"];
+
+  // SessionID is the ID of the session that initiated the transaction.
+  string session_id = 5 [(gogoproto.customname) = "SessionID", (gogoproto.jsontag) = ",includeemepty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
+
+  // TransactionID is the id of the transaction.
+  string transaction_id = 6 [(gogoproto.customname) = "TransactionID", (gogoproto.jsontag) = ',includeempty', (gogoproto.moretags) = "redact:\"nonsensitive\""];
+
+  // TransactionFingerprintID is the fingerprint ID of the transaction.
+  // This can be used to find the transaction in the console.
+  uint64 transaction_fingerprint_id = 7 [(gogoproto.customname) = "TransactionFingerprintID", (gogoproto.customtype) = "github.com/cockroachdb/cockroach/pkg/sql/appstatspb.TransactionFingerprintID", (gogoproto.nullable) = false, (gogoproto.jsontag) = 'TransactionFingerprintID,'];
+
+  // Committed indicates if the transaction committed successfully. We want to include this value even if it is false.
+  bool committed = 8 [(gogoproto.jsontag) = ",includeempty"];
+
+  // ImplicitTxn indicates if the transaction was an implicit one. We want to include this value even if it is false.
+  bool implicit_txn = 9 [(gogoproto.jsontag) = ",includeempty"];
+
+  // StartTimeUnixNanos is the time the transaction was started. Expressed as unix time in nanoseconds.
+  int64 start_time_unix_nanos = 10 [(gogoproto.jsontag) = ",includeempty"];
+
+  // EndTimeUnixNanos the time the transaction finished (either committed or aborted).
+  // Expressed as unix time in nanoseconds.
+  int64 end_time_unix_nanos = 11 [(gogoproto.jsontag) = ",includeempty"];
+
+  // ServiceLatNanos is the time to service the whole transaction, from start to end of execution.
+  int64 service_lat_nanos = 12 [(gogoproto.jsontag) = ",includeempty"];
+
+  // SQLSTATE is the SQLSTATE code for the error, if an error was encountered. Empty/omitted if no error.
+  string sqlstate = 13 [(gogoproto.customname) = "SQLSTATE", (gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
+
+  // ErrorText is the text of the error if any.
+  string error_text = 14 [(gogoproto.jsontag) = ",omitempty", (gogoproto.customtype) = "github.com/cockroachdb/redact.RedactableString", (gogoproto.nullable) = false, (gogoproto.moretags) = "redact:\"mixed\""];
+
+  // NumRetries is the number of time when the txn was retried automatically by the server.
+  int64 num_retries = 15 [(gogoproto.jsontag) = ",omitempty"];
+
+  // LastAutoRetryReason is a string containing the reason for the last automatic retry.
+  string last_auto_retry_reason = 16 [(gogoproto.customtype) = "github.com/cockroachdb/redact.RedactableString", (gogoproto.nullable) = false, (gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"mixed\""];
+
+  // StatementFingerprintIDs is an array of statement fingerprint IDs belonging to this transaction.
+  repeated uint64 statement_fingerprint_ids = 17 [(gogoproto.customname) = "StatementFingerprintIDs", (gogoproto.jsontag) = ',omitempty', (gogoproto.customtype) = "github.com/cockroachdb/cockroach/pkg/sql/appstatspb.StmtFingerprintID"];
+
+  // NumRows is the total number of rows returned across all statements.
+  int64 num_rows = 18 [(gogoproto.jsontag) = ",includeempty"];
+
+  // RetryLatNanos is the amount of time spent retrying the transaction.
+ int64 retry_lat_nanos  = 19 [(gogoproto.jsontag) = ",omitempty"];
+
+ // CommitLatNanos is the amount of time spent committing the transaction after all statement operations.
+ int64 commit_lat_nanos = 20 [(gogoproto.jsontag) = ",includeempty"];
+
+ // IdleLatNanos is the amount of time spent waiting for the client to send statements
+  // while the transaction is open.
+ int64 idle_lat_nanos = 21 [(gogoproto.jsontag) = ",includeempty"];
+
+ // BytesRead is the number of bytes read from disk.
+ int64 bytes_read = 22 [(gogoproto.jsontag) = ",includeempty"];
+
+ // RowsRead is the number of rows read from disk.
+ int64 rows_read = 23 [(gogoproto.jsontag) = ",includeempty"];
+
+ // RowsWritten is the number of rows written to disk.
+ int64 rows_written = 24 [(gogoproto.jsontag) = ",includeempty"];
+
+ // SampledExecStats is a nested field containing execution statistics.
+ // This field will be omitted if the stats were not sampled.
+ SampledExecStats sampled_exec_stats = 25 [(gogoproto.jsontag) = ",omitempty"];
+}
 
 // CapturedIndexUsageStats
 message CapturedIndexUsageStats {


### PR DESCRIPTION
This commit adds the  messages listed below to `telemetry.proto` in
preparation for sending transaction executions to the telemetry
channel. The transaction event that is eventually sent should  contain
all execution information currently being tracked for transaction
fingerprints.

- `SampledTransaction`: contains fields equivalent to the execution
information stored by `CollectedTransactionStatistics` from
app_stats.proto, but represents a single txn execution instead
of aggregated executions of a transaction fingerprint.
- `SampledExecStats`: used as a field in `SampledTransaction`, it
contains execution stats that are sampled. This event is the equivalent
to `ExecStats` from app_stats.proto but for a single execution.
- `MVCCIteratorStats`: used in `SampledExecStats` above, the equivalent of
MVCCIteratorStats from app_stats.proto but for a single execution.

In addition, in order to support the above fields a couple of additional
code templates have been added for generating json log encoding:
- array_of_uint64 type is now being handled for json logs
- `nestedMessage` has been added as a custom type in `gen.go`. Object field
types can be assigned to this type in order to generate them as nested
objects.

Part of: https://github.com/cockroachdb/cockroach/issues/108284

Release note: None