### PR TITLE
storage: call pebble.Iterator.SetContext when reusing the iterator

### DIFF
--- a/pkg/kv/kvserver/rangefeed/catchup_scan.go
+++ b/pkg/kv/kvserver/rangefeed/catchup_scan.go
@@ -135,6 +135,9 @@ type outputEventFn func(e *kvpb.RangeFeedEvent) error
 // For example, with MVCC range tombstones [a-f)@5 and [a-f)@3 overlapping point
 // keys a@6, a@4, and b@2, the emitted order is [a-f)@3,[a-f)@5,a@4,a@6,b@2 because
 // the start key "a" is ordered before all of the timestamped point keys.
+//
+// TODO(sumeer): ctx is not used for SeekGE and Next. Fix by adding a method
+// to SimpleMVCCIterator to replace the context.
 func (i *CatchUpIterator) CatchUpScan(
 	ctx context.Context, outputFn outputEventFn, withDiff bool,
 ) error {

--- a/pkg/kv/kvserver/replica_rangefeed.go
+++ b/pkg/kv/kvserver/replica_rangefeed.go
@@ -273,8 +273,10 @@ func (r *Replica) RangeFeed(
 	// Register the stream with a catch-up iterator.
 	var catchUpIter *rangefeed.CatchUpIterator
 	if usingCatchUpIter {
+		// Pass context.Background() since the context where the iter will be used
+		// is different.
 		catchUpIter, err = rangefeed.NewCatchUpIterator(
-			ctx, r.store.TODOEngine(), rSpan.AsRawSpanWithNoLocals(),
+			context.Background(), r.store.TODOEngine(), rSpan.AsRawSpanWithNoLocals(),
 			args.Timestamp, iterSemRelease, pacer)
 		if err != nil {
 			r.raftMu.Unlock()

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -2635,7 +2635,7 @@ func (p *pebbleReadOnly) NewMVCCIterator(
 	}
 
 	if iter.iter != nil {
-		iter.setOptions(opts, p.durability)
+		iter.setOptions(ctx, opts, p.durability)
 	} else {
 		if err := iter.initReuseOrCreate(
 			ctx, p.parent.db, p.iter, p.iterUsed, opts, p.durability, p.parent); err != nil {
@@ -2673,7 +2673,7 @@ func (p *pebbleReadOnly) NewEngineIterator(
 	}
 
 	if iter.iter != nil {
-		iter.setOptions(opts, p.durability)
+		iter.setOptions(ctx, opts, p.durability)
 	} else {
 		err := iter.initReuseOrCreate(
 			ctx, p.parent.db, p.iter, p.iterUsed, opts, p.durability, p.parent)

--- a/pkg/storage/pebble_batch.go
+++ b/pkg/storage/pebble_batch.go
@@ -208,7 +208,7 @@ func (p *pebbleBatch) NewMVCCIterator(
 	}
 
 	if iter.iter != nil {
-		iter.setOptions(opts, StandardDurability)
+		iter.setOptions(ctx, opts, StandardDurability)
 	} else {
 		if err := iter.initReuseOrCreate(
 			ctx, handle, p.iter, p.iterUsed, opts, StandardDurability, p.parent); err != nil {
@@ -249,7 +249,7 @@ func (p *pebbleBatch) NewEngineIterator(
 	}
 
 	if iter.iter != nil {
-		iter.setOptions(opts, StandardDurability)
+		iter.setOptions(ctx, opts, StandardDurability)
 	} else {
 		if err := iter.initReuseOrCreate(
 			ctx, handle, p.iter, p.iterUsed, opts, StandardDurability, p.parent); err != nil {

--- a/pkg/storage/pebble_iterator_test.go
+++ b/pkg/storage/pebble_iterator_test.go
@@ -165,7 +165,7 @@ func TestPebbleIterator_SkipPointIfOutsideTimeBounds(t *testing.T) {
 		max, err := hlc.ParseTimestamp(maxStr)
 		require.NoError(t, err)
 
-		iter.setOptions(IterOptions{
+		iter.setOptions(context.Background(), IterOptions{
 			LowerBound:   []byte{0x00}, // so setOptions doesn't complain
 			MinTimestamp: min,
 			MaxTimestamp: max,


### PR DESCRIPTION
Additionally, pass context.Background() when constructing CatchUpIterator since the iteration is done using a different context.

Fixes https://github.com/cockroachdb/cockroach/issues/113257 Fixes https://github.com/cockroachdb/cockroach/issues/113256

Epic: none

Release note: None