### PR TITLE
storage/metamorphic: use unused keys in MVCCAcquireLock

### DIFF
--- a/pkg/storage/metamorphic/operations.go
+++ b/pkg/storage/metamorphic/operations.go
@@ -1040,7 +1040,7 @@ var opGenerators = []opGenerator{
 		operands: []operandType{
 			operandReadWriter,
 			operandTransaction,
-			operandMVCCKey,
+			operandUnusedMVCCKey,
 			operandFloat,
 			operandFloat,
 		},


### PR DESCRIPTION
Previously, we were overwriting the txnGenerator's view of what transaction was writing to what key, by having MVCCAcquireLock work on all mvcc keys, not just unused ones. This would generate operations that would break expected usage of the MVCC API and result in non-determinism.

This change fixes it by having MVCCAcquireLock use keys that don't have conflicting transactions. Note that MVCCCheckForAcquireLock will continue to run on the whole keyspace as it doesn't need to track writes.

Fixes #113806.

Epic: none

Release note: None