### PR TITLE
workload/schemachange: export OTLP traces

### DIFF
--- a/pkg/workload/pgx_helpers.go
+++ b/pkg/workload/pgx_helpers.go
@@ -93,6 +93,10 @@ type MultiConnPoolCfg struct {
 
 	// Duration between refreshes of the DNS cache
 	DNSRefreshInterval time.Duration
+
+	// QueryTracer is an optional tracer to attach to the pgx connections from
+	// this pool. See [pgx.ConnConfig] for details.
+	QueryTracer pgx.QueryTracer
 }
 
 // NewMultiConnPoolCfgFromFlags constructs a new MultiConnPoolCfg object based
@@ -239,6 +243,9 @@ func NewMultiConnPool(
 				}
 				return true
 			}
+
+			// Attach the supplied tracer to the ConnConfig.
+			poolCfg.ConnConfig.Tracer = cfg.QueryTracer
 
 			connCfg := poolCfg.ConnConfig
 			if m.resolver != nil {

--- a/pkg/workload/schemachange/BUILD.bazel
+++ b/pkg/workload/schemachange/BUILD.bazel
@@ -32,6 +32,7 @@ go_library(
         "//pkg/sql/sem/catconstants",
         "//pkg/sql/sem/tree",
         "//pkg/sql/types",
+        "//pkg/util",
         "//pkg/util/encoding",
         "//pkg/util/randutil",
         "//pkg/util/syncutil",

--- a/pkg/workload/schemachange/BUILD.bazel
+++ b/pkg/workload/schemachange/BUILD.bazel
@@ -47,8 +47,12 @@ go_library(
         "@com_github_spf13_pflag//:pflag",
         "@io_opentelemetry_go_otel//attribute",
         "@io_opentelemetry_go_otel//codes",
+        "@io_opentelemetry_go_otel_exporters_otlp_otlptrace//:otlptrace",
         "@io_opentelemetry_go_otel_sdk//trace",
         "@io_opentelemetry_go_otel_trace//:trace",
+        "@io_opentelemetry_go_proto_otlp//collector/trace/v1:trace",
+        "@io_opentelemetry_go_proto_otlp//trace/v1:trace",
+        "@org_golang_google_protobuf//proto",
     ],
 )
 

--- a/pkg/workload/schemachange/BUILD.bazel
+++ b/pkg/workload/schemachange/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "optype.go",
         "query_util.go",
         "schemachange.go",
+        "tracing.go",
         "type_resolver.go",
         "watch_dog.go",
         ":gen-optype-stringer",  # keep
@@ -43,6 +44,10 @@ go_library(
         "@com_github_jackc_pgx_v5//pgxpool",
         "@com_github_lib_pq//oid",
         "@com_github_spf13_pflag//:pflag",
+        "@io_opentelemetry_go_otel//attribute",
+        "@io_opentelemetry_go_otel//codes",
+        "@io_opentelemetry_go_otel_sdk//trace",
+        "@io_opentelemetry_go_otel_trace//:trace",
     ],
 )
 

--- a/pkg/workload/schemachange/schemachange.go
+++ b/pkg/workload/schemachange/schemachange.go
@@ -147,15 +147,6 @@ func (s *schemaChange) Tables() []workload.Table {
 	return nil
 }
 
-// Hooks implements the workload.Hookser interface.
-func (s *schemaChange) Hooks() workload.Hooks {
-	return workload.Hooks{
-		PostRun: func(_ time.Duration) error {
-			return s.closeJSONLogFile()
-		},
-	}
-}
-
 // Ops implements the workload.Opser interface.
 func (s *schemaChange) Ops(
 	ctx context.Context, urls []string, reg *histogram.Registry,
@@ -199,7 +190,13 @@ func (s *schemaChange) Ops(
 	}
 	declarativeOps := newDeck(rng, declarativeOpWeights...)
 
-	ql := workload.QueryLoad{SQLDatabase: sqlDatabase}
+	ql := workload.QueryLoad{
+		SQLDatabase: sqlDatabase,
+		Close: func(ctx context.Context) error {
+			pool.Close()
+			return s.closeJSONLogFile()
+		},
+	}
 
 	var artifactsLog *atomicLog
 	if s.logFilePath != "" {
@@ -251,9 +248,6 @@ func (s *schemaChange) Ops(
 		s.workers = append(s.workers, w)
 
 		ql.WorkerFns = append(ql.WorkerFns, w.run)
-		ql.Close = func(ctx2 context.Context) {
-			pool.Close()
-		}
 	}
 	return ql, nil
 }

--- a/pkg/workload/schemachange/schemachange.go
+++ b/pkg/workload/schemachange/schemachange.go
@@ -35,6 +35,8 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/spf13/pflag"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // This workload executes batches of schema changes asynchronously. Each
@@ -150,7 +152,18 @@ func (s *schemaChange) Tables() []workload.Table {
 // Ops implements the workload.Opser interface.
 func (s *schemaChange) Ops(
 	ctx context.Context, urls []string, reg *histogram.Registry,
-) (workload.QueryLoad, error) {
+) (_ workload.QueryLoad, err error) {
+	// Initialize tracing ahead of everything else. The Ops function is used for
+	// managing the life cycle of this workload so we keep tracing localized to
+	// this function.
+	tracerProvider := sdktrace.NewTracerProvider()
+	tracer := tracerProvider.Tracer("schemachange")
+
+	// NB: The schemaChange.Ops span ends when this function returns, NOT when
+	// the workload is done.
+	ctx, span := tracer.Start(ctx, "schemaChange.Ops")
+	defer func() { EndSpan(span, err) }()
+
 	sqlDatabase, err := workload.SanitizeUrls(s, s.dbOverride, urls)
 	if err != nil {
 		return workload.QueryLoad{}, err
@@ -192,9 +205,19 @@ func (s *schemaChange) Ops(
 
 	ql := workload.QueryLoad{
 		SQLDatabase: sqlDatabase,
-		Close: func(ctx context.Context) error {
+		Close: func(_ context.Context) error {
+			// Create a new context for shutting down the tracer provider. The
+			// provided context may be cancelled depending on why the workload is
+			// shutting down and we always want to provide a period of time to flush
+			// traces.
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+
 			pool.Close()
-			return s.closeJSONLogFile()
+			closeErr := s.closeJSONLogFile()
+			shutdownErr := tracerProvider.Shutdown(ctx)
+
+			return errors.CombineErrors(closeErr, shutdownErr)
 		},
 	}
 

--- a/pkg/workload/schemachange/schemachange.go
+++ b/pkg/workload/schemachange/schemachange.go
@@ -180,6 +180,7 @@ func (s *schemaChange) Ops(
 	// checks for progress.
 	cfg.MaxConnLifetime = time.Hour
 	cfg.MaxConnIdleTime = time.Hour
+	cfg.QueryTracer = &PGXTracer{tracer: s.tracer}
 	pool, err := workload.NewMultiConnPool(ctx, cfg, urls...)
 	if err != nil {
 		return workload.QueryLoad{}, err

--- a/pkg/workload/schemachange/schemachange.go
+++ b/pkg/workload/schemachange/schemachange.go
@@ -35,8 +35,8 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/spf13/pflag"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	"go.opentelemetry.io/otel/trace"
 )
 
 // This workload executes batches of schema changes asynchronously. Each
@@ -89,6 +89,7 @@ type schemaChange struct {
 	fkChildInvalidPct               int
 	declarativeSchemaChangerPct     int
 	declarativeSchemaMaxStmtsPerTxn int
+	traceFilePath                   string
 }
 
 var schemaChangeMeta = workload.Meta{
@@ -114,6 +115,8 @@ var schemaChangeMeta = workload.Meta{
 			`Percentage of times that a sequence is owned by column upon creation.`)
 		s.flags.StringVar(&s.logFilePath, `txn-log`, "",
 			`If provided, transactions will be written to this file in JSON form`)
+		s.flags.StringVar(&s.traceFilePath, `trace-file`, "",
+			`The file to write OTeL traces to. Defaults to schemachange-workload.{timestamp}.otlp.tar.gz`)
 		s.flags.IntVar(&s.fkParentInvalidPct, `fk-parent-invalid-pct`, defaultFkParentInvalidPct,
 			`Percentage of times to choose an invalid parent column in a fk constraint.`)
 		s.flags.IntVar(&s.fkChildInvalidPct, `fk-child-invalid-pct`, defaultFkChildInvalidPct,
@@ -156,7 +159,11 @@ func (s *schemaChange) Ops(
 	// Initialize tracing ahead of everything else. The Ops function is used for
 	// managing the life cycle of this workload so we keep tracing localized to
 	// this function.
-	tracerProvider := sdktrace.NewTracerProvider()
+	traceProvider, err := s.initTraceProvider()
+	if err != nil {
+		return workload.QueryLoad{}, nil
+	}
+
 	tracer := tracerProvider.Tracer("schemachange")
 
 	// NB: The schemaChange.Ops span ends when this function returns, NOT when
@@ -797,6 +804,23 @@ func (l *atomicLog) printLn(message string) {
 	defer l.mu.Unlock()
 
 	_, _ = l.mu.log.Write(append([]byte(message), '\n'))
+}
+
+func (s *schemaChange) initTraceProvider() (*sdktrace.TraceProvider, error) {
+	path := s.traceFilePath
+	if path == "" {
+		// TODO(chrisseto): Before merge ensure this default output is to a
+		// location that is easily accessed from CI and when running locally.
+		path = fmt.Sprintf("schemachange-workload.%s.otlp.tar.gz", timeutil.Now().Format("20060102150405"))
+	}
+
+	// NB: otlptrace is usually used to connect to an HTTP or gRPC server, hence
+	// the context. OTLPFileClient writes to a file, so there's no use in adding a timeout to this context.
+	exporter, err := otlptrace.New(context.Background(), &OTLPFileClient{Path: path})
+	if err != nil {
+		return err
+	}
+	return sdktrace.NewTracerProvider(sdktrace.WithBatcher(exporter)), nil
 }
 
 // initJsonLogFile opens the file denoted by filePath and sets s.logFile on success.

--- a/pkg/workload/schemachange/tracing.go
+++ b/pkg/workload/schemachange/tracing.go
@@ -1,0 +1,47 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package schemachange
+
+import (
+	"context"
+
+	"github.com/cockroachdb/errors"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// EndSpan is a helper for ending a span and annotating it with error
+// information, if relevant. Usage:
+//
+//	func mytracedfunc(ctx context.Context) (retErr err) {
+//		ctx, span := tracer.Start(ctx, "mytracedfunc")
+//		defer func() { EndSpan(span, retErr) }()
+//	}
+func EndSpan(span trace.Span, err error) {
+	if err == nil {
+		span.SetStatus(codes.Ok, "")
+	} else {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+
+		// If the error is a context cancellation, add an attribute so we can
+		// ignore the "errors".
+		// TODO(chrisseto): Maybe we should just use codes.Unset and record a
+		// "cancellation" event?
+		if errors.Is(err, context.Canceled) {
+			span.SetAttributes(
+				attribute.Bool("context.canceled", true),
+			)
+		}
+	}
+	span.End()
+}

--- a/pkg/workload/schemachange/tracing.go
+++ b/pkg/workload/schemachange/tracing.go
@@ -12,8 +12,11 @@ package schemachange
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/errors"
+	"github.com/jackc/pgx/v5"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
@@ -44,4 +47,30 @@ func EndSpan(span trace.Span, err error) {
 		}
 	}
 	span.End()
+}
+
+type PGXTracer struct {
+	tracer trace.Tracer
+}
+
+func (l *PGXTracer) TraceQueryStart(ctx context.Context, conn *pgx.Conn, data pgx.TraceQueryStartData) context.Context {
+	stringifiedArgs := util.Map(data.Args, func(arg any) string {
+		return fmt.Sprintf("%#v", arg)
+	})
+
+	ctx, span := l.tracer.Start(ctx, "Query")
+	span.SetAttributes(
+		attribute.String("sql", data.SQL),
+		attribute.StringSlice("args", stringifiedArgs),
+	)
+
+	return ctx
+}
+
+func (*PGXTracer) TraceQueryEnd(ctx context.Context, conn *pgx.Conn, data pgx.TraceQueryEndData) {
+	span := trace.SpanFromContext(ctx)
+	span.SetAttributes(
+		attribute.String("command_tag", data.CommandTag.String()),
+	)
+	EndSpan(span, data.Err)
 }

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -389,11 +389,11 @@ type QueryLoad struct {
 	WorkerFns []func(context.Context) error
 
 	// Close, if set, is called before the process exits, giving workloads a
-	// chance to print some information.
+	// chance to print some information or perform cleanup.
 	// It's guaranteed that the ctx passed to WorkerFns (if they're still running)
 	// has been canceled by the time this is called (so an implementer can
 	// synchronize with the WorkerFns if need be).
-	Close func(context.Context)
+	Close func(context.Context) error
 
 	// ResultHist is the name of the NamedHistogram to use for the benchmark
 	// formatted results output at the end of `./workload run`. The empty string


### PR DESCRIPTION
### This PR is stacked on top of others!

Please consider reviewing those PRs first. This message will be removed once prerequisite PRs are merged and this one is rebased.

* 47df7be8906e0da6a25aa7259fc520a27d806bea is from #113896
* 4c312c91d5955cf1033e7923e295ba07d09ecea7 is from #113899
* 8f98cfd52fab487a1319f433cd247dd4375ac372 is from #113906
* ccb4f6285403f68393361c99ca1886f974fcad8a is from #113960

---

#### c9f6ae1bf4c8a213f92eedd635adc1c2e83214d3 workload/schemachange: export OTLP traces

Previous commits instrumented the schemachange workload with OTeL but
did not provide a way to access the output spans.

This commit implements a OTLP exporter to a bespoke tar.gz format. See
`OTLPFileClient` for more details about the format and why it was
chosen.

Epic: none
Release note (cli change): workload schemachange now writes a tar.gz
archive containing OTLP trace bundles for debugging purposes.