### PR TITLE
workload/schemachange: instrument PGX

### DIFF
--- a/pkg/workload/schemachange/schemachange.go
+++ b/pkg/workload/schemachange/schemachange.go
@@ -182,6 +182,7 @@ func (s *schemaChange) Ops(
 	// checks for progress.
 	cfg.MaxConnLifetime = time.Hour
 	cfg.MaxConnIdleTime = time.Hour
+	cfg.QueryTracer = &PGXTracer{tracer: tracer}
 	pool, err := workload.NewMultiConnPool(ctx, cfg, urls...)
 	if err != nil {
 		return workload.QueryLoad{}, err


### PR DESCRIPTION
#### f5df1cd143676d5fd64f2d44dda30e48d23c21f3 workload/schemachange: instrument PGX

This commit instruments the `MultiConnPool` used in the schemachange
workload with OTeL by implementing  `pgx.QueryTracer`.

Doing so ensures that all queries executed by the workload are logged to
spans. Future commits will instrument the workers and query helpers. The
combination of all these instrumentations will allow debuggers to easily
inspect all SQL queries emitted by the workload and isolate them to
individual workers and transactions.

Epic: CRDB-19168
Release note: None