### PR TITLE
release-23.1: roachprod: never start cockroach processes concurrently

### DIFF
--- a/pkg/cmd/roachprod/flags.go
+++ b/pkg/cmd/roachprod/flags.go
@@ -322,8 +322,6 @@ Default is "RECURRING '*/15 * * * *' FULL BACKUP '@hourly' WITH SCHEDULE OPTIONS
 	}
 
 	for _, cmd := range []*cobra.Command{startCmd, startInstanceCmd} {
-		cmd.Flags().BoolVar(&startOpts.Sequential,
-			"sequential", startOpts.Sequential, "start nodes sequentially so node IDs match hostnames")
 		cmd.Flags().Int64Var(&startOpts.NumFilesLimit, "num-files-limit", startOpts.NumFilesLimit,
 			"limit the number of files that can be created by the cockroach process")
 	}

--- a/pkg/cmd/roachtest/roachtestutil/clusterupgrade/clusterupgrade.go
+++ b/pkg/cmd/roachtest/roachtestutil/clusterupgrade/clusterupgrade.go
@@ -265,6 +265,10 @@ func RestartNodesWithNewBinary(
 		if err != nil {
 			return err
 		}
+		// Never run init steps when restarting -- these should already
+		// have happened by the time the cluster was first bootstrapped
+		// and trying to run them again just adds noise to the logs.
+		startOpts.RoachprodOpts.SkipInit = true
 		if err := StartWithSettings(
 			ctx, l, c, c.Node(node), startOpts, append(settings, install.BinaryOption(binary))...,
 		); err != nil {

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion.go
@@ -702,7 +702,6 @@ func (s startStep) Run(ctx context.Context, l *logger.Logger, c cluster.Cluster,
 	}
 
 	startOpts := option.DefaultStartOptsNoBackups()
-	startOpts.RoachprodOpts.Sequential = false
 	clusterSettings := append(
 		append([]install.ClusterSettingOption{}, defaultClusterSettings...),
 		install.BinaryOption(binaryPath),

--- a/pkg/cmd/roachtest/tests/versionupgrade.go
+++ b/pkg/cmd/roachtest/tests/versionupgrade.go
@@ -302,8 +302,6 @@ func uploadAndStartFromCheckpointFixture(
 		}
 		binary := uploadVersion(ctx, t, u.c, nodes, v)
 		startOpts := option.DefaultStartOpts()
-		// NB: can't start sequentially since cluster already bootstrapped.
-		startOpts.RoachprodOpts.Sequential = false
 		if err := clusterupgrade.StartWithSettings(
 			ctx, t.L(), u.c, nodes, startOpts, install.BinaryOption(binary),
 		); err != nil {
@@ -316,8 +314,6 @@ func uploadAndStart(nodes option.NodeListOption, v *clusterupgrade.Version) vers
 	return func(ctx context.Context, t test.Test, u *versionUpgradeTest) {
 		binary := uploadVersion(ctx, t, u.c, nodes, v)
 		startOpts := option.DefaultStartOpts()
-		// NB: can't start sequentially since cluster already bootstrapped.
-		startOpts.RoachprodOpts.Sequential = false
 		if err := clusterupgrade.StartWithSettings(
 			ctx, t.L(), u.c, nodes, startOpts, install.BinaryOption(binary),
 		); err != nil {

--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -2924,8 +2924,8 @@ func (c *SyncedCluster) Init(ctx context.Context, l *logger.Logger, node Node) e
 		return errors.WithDetail(errors.CombineErrors(err, res.Err), "install.Init() failed: unable to initialize cluster.")
 	}
 
-	if res, err := c.setClusterSettings(ctx, l, node, ""); err != nil || (res != nil && res.Err != nil) {
-		return errors.WithDetail(errors.CombineErrors(err, res.Err), "install.Init() failed: unable to set cluster settings.")
+	if err := c.setClusterSettings(ctx, l, node, ""); err != nil {
+		return errors.WithDetail(err, "install.Init() failed: unable to set cluster settings.")
 	}
 
 	return nil

--- a/pkg/roachprod/install/cockroach.go
+++ b/pkg/roachprod/install/cockroach.go
@@ -96,8 +96,7 @@ func argExists(args []string, target string) int {
 
 // StartOpts houses the options needed by Start().
 type StartOpts struct {
-	Target     StartTarget
-	Sequential bool
+	Target StartTarget
 	// ExtraArgs are extra arguments used when starting the node. Multiple
 	// arguments should be passed as separate items in the slice. For example:
 	//   Instead of: []string{"--flag foo bar"}
@@ -375,60 +374,49 @@ func (c *SyncedCluster) Start(ctx context.Context, l *logger.Logger, startOpts S
 		}
 	}
 
-	nodes := c.TargetNodes()
-	var parallelism = 0
-	if startOpts.Sequential {
-		parallelism = 1
-	}
-
 	l.Printf("%s: starting nodes", c.Name)
-
-	// SSH retries are disabled by passing nil RunRetryOpts
-	if err := c.Parallel(ctx, l, nodes, func(ctx context.Context, node Node) (*RunResultDetails, error) {
+	// For single node non-virtual clusters, `init` can be skipped
+	// because during the c.StartNode call above, the
+	// `--start-single-node` flag will handle all of this for us.
+	shouldInit := startOpts.Target == StartDefault && !c.useStartSingleNode() && !startOpts.SkipInit
+	for _, node := range c.Nodes {
 		// NB: if cockroach started successfully, we ignore the output as it is
 		// some harmless start messaging.
 		res, err := c.startNode(ctx, l, node, startOpts)
 		if err != nil || res.Err != nil {
 			// If err is non-nil, then this will not be retried, but if res.Err is non-nil, it will be.
-			return res, errors.CombineErrors(err, res.Err)
+			return errors.CombineErrors(err, res.Err)
 		}
-
 		// We reserve a few special operations (bootstrapping, and setting
 		// cluster settings) to the InitTarget.
 		if startOpts.Target == StartDefault {
 			if startOpts.GetInitTarget() != node || startOpts.SkipInit {
-				return res, nil
+				continue
 			}
 		}
-
-		// For single node non-virtual clusters, this can be skipped
-		// because during the c.StartNode call above, the
-		// `--start-single-node` flag will handle all of this for us.
-		shouldInit := startOpts.Target == StartDefault && !c.useStartSingleNode()
 		if shouldInit {
-			if initRes, err := c.initializeCluster(ctx, l, node); err != nil || initRes.Err != nil {
+			if res, err = c.initializeCluster(ctx, l, node); err != nil || res.Err != nil {
 				// If err is non-nil, then this will not be retried, but if res.Err is non-nil, it will be.
-				return initRes, errors.CombineErrors(err, res.Err)
+				return errors.CombineErrors(err, res.Err)
 			}
 		}
+	}
 
-		if startOpts.GetInitTarget() == node {
-			if err := c.waitForDefaultTargetCluster(ctx, l, startOpts); err != nil {
-				return res, errors.Wrap(err, "failed to wait for default target cluster")
-			}
-			c.createAdminUserForSecureCluster(ctx, l, startOpts)
-			return c.setClusterSettings(ctx, l, node, startOpts.VirtualClusterName)
+	if shouldInit {
+		if err := c.waitForDefaultTargetCluster(ctx, l, startOpts); err != nil {
+			return errors.Wrap(err, "failed to wait for default target cluster")
+		}
+		c.createAdminUserForSecureCluster(ctx, l, startOpts)
+		if err = c.setClusterSettings(ctx, l, startOpts.GetInitTarget(), startOpts.VirtualClusterName); err != nil {
+			return err
 		}
 
-		return res, err
-	}, WithConcurrency(parallelism)); err != nil {
-		return err
+		// Only after a successful cluster initialization should we attempt to schedule backups.
+		if startOpts.ScheduleBackups && shouldInit && config.CockroachDevLicense != "" {
+			return c.createFixedBackupSchedule(ctx, l, startOpts.ScheduleBackupArgs)
+		}
 	}
 
-	// Only after a successful cluster initialization should we attempt to schedule backups.
-	if startOpts.ScheduleBackups && !startOpts.SkipInit && config.CockroachDevLicense != "" {
-		return c.createFixedBackupSchedule(ctx, l, startOpts.ScheduleBackupArgs)
-	}
 	return nil
 }
 
@@ -1053,7 +1041,7 @@ func (c *SyncedCluster) createAdminUserForSecureCluster(
 	retryOpts := retry.Options{MaxRetries: 20}
 	if err := retryOpts.Do(ctx, func(ctx context.Context) error {
 		results, err := c.ExecSQL(
-			ctx, l, c.Nodes[:1], startOpts.VirtualClusterName, startOpts.SQLInstance, []string{
+			ctx, l, Nodes{startOpts.GetInitTarget()}, startOpts.VirtualClusterName, startOpts.SQLInstance, []string{
 				"-e", stmts,
 			})
 
@@ -1078,11 +1066,11 @@ func (c *SyncedCluster) createAdminUserForSecureCluster(
 
 func (c *SyncedCluster) setClusterSettings(
 	ctx context.Context, l *logger.Logger, node Node, virtualCluster string,
-) (*RunResultDetails, error) {
+) error {
 	l.Printf("%s: setting cluster settings", c.Name)
 	cmd, err := c.generateClusterSettingCmd(ctx, l, node, virtualCluster)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	res, err := c.runCmdOnSingleNode(ctx, l, node, cmd, defaultCmdOpts("set-cluster-settings"))
@@ -1092,7 +1080,12 @@ func (c *SyncedCluster) setClusterSettings(
 			l.Printf(out)
 		}
 	}
-	return res, err
+
+	if res != nil && res.Err != nil {
+		err = errors.CombineErrors(err, res.Err)
+	}
+
+	return err
 }
 
 func (c *SyncedCluster) generateClusterSettingCmd(

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -663,7 +663,6 @@ func Extend(l *logger.Logger, clusterName string, lifetime time.Duration) error 
 // DefaultStartOpts returns a StartOpts populated with default values.
 func DefaultStartOpts() install.StartOpts {
 	return install.StartOpts{
-		Sequential:         true,
 		EncryptedStores:    false,
 		NumFilesLimit:      config.DefaultNumFilesLimit,
 		SkipInit:           false,


### PR DESCRIPTION
Backport 2/2 commits from #113718.

Release justification: test-only change.

/cc @cockroachdb/release

---

This changes startup logic to always start cockroach processes sequentially: this ensures that node IDs match hostnames. Previously, we were starting nodes concurrently for upgrade tests because initialization tasks performed by roachprod required quorum.

Fixes: #113384.

Release note: None
