### PR TITLE
workload/schemachange: enable testing of declarative CREATE SCHEMA

### DIFF
--- a/pkg/workload/schemachange/optype.go
+++ b/pkg/workload/schemachange/optype.go
@@ -300,6 +300,7 @@ var opDeclarativeVersion = map[opType]clusterversion.Key{
 	alterTypeDropValue:                clusterversion.BinaryMinSupportedVersionKey,
 	createIndex:                       clusterversion.BinaryMinSupportedVersionKey,
 	createSequence:                    clusterversion.BinaryMinSupportedVersionKey,
+	createSchema:                      clusterversion.V23_2,
 	dropIndex:                         clusterversion.BinaryMinSupportedVersionKey,
 	dropSchema:                        clusterversion.BinaryMinSupportedVersionKey,
 	dropSequence:                      clusterversion.BinaryMinSupportedVersionKey,

--- a/pkg/workload/schemachange/schemachange.go
+++ b/pkg/workload/schemachange/schemachange.go
@@ -63,7 +63,7 @@ const (
 	defaultSequenceOwnedByPct              = 25
 	defaultFkParentInvalidPct              = 5
 	defaultFkChildInvalidPct               = 5
-	defaultDeclarativeSchemaChangerPct     = 25
+	defaultDeclarativeSchemaChangerPct     = 75
 	defaultDeclarativeSchemaMaxStmtsPerTxn = 1
 )
 
@@ -118,7 +118,7 @@ var schemaChangeMeta = workload.Meta{
 			`Percentage of times to choose an invalid child column in a fk constraint.`)
 		s.flags.IntVar(&s.declarativeSchemaChangerPct, `declarative-schema-changer-pct`,
 			defaultDeclarativeSchemaChangerPct,
-			`Percentage of the declarative schema changer is used.`)
+			`Percentage (between 0 and 100) of schema change statements handled by declarative schema changer, if supported.`)
 		s.flags.IntVar(&s.declarativeSchemaMaxStmtsPerTxn, `declarative-schema-changer-stmt-per-txn`,
 			defaultDeclarativeSchemaMaxStmtsPerTxn,
 			`Number of statements per-txn used by the declarative schema changer.`)
@@ -431,7 +431,7 @@ func (w *schemaChangeWorker) run(ctx context.Context) error {
 	if err != nil {
 		return errors.Wrap(err, "cannot get a connection")
 	}
-	useDeclarativeSchemaChanger := w.opGen.randIntn(100) > w.workload.declarativeSchemaChangerPct
+	useDeclarativeSchemaChanger := w.opGen.randIntn(100) < w.workload.declarativeSchemaChangerPct
 	if useDeclarativeSchemaChanger {
 		if _, err := conn.Exec(ctx, "SET use_declarative_schema_changer='unsafe_always';"); err != nil {
 			return err


### PR DESCRIPTION
This commit enables the schemachange workload to issue CREATE SCHEMA under the declarative schema changer.

Fixes #110473
Release note: None