### PR TITLE
kvclient: remove unused ReplicaSlice sort option

### DIFF
--- a/pkg/kv/kvclient/kvcoord/replica_slice.go
+++ b/pkg/kv/kvclient/kvcoord/replica_slice.go
@@ -44,23 +44,19 @@ const (
 	// replicas that are not LEARNERs, VOTER_OUTGOING, or
 	// VOTER_DEMOTING_{LEARNER/NON_VOTER}.
 	AllExtantReplicas
-	// AllReplicas prescribes that the ReplicaSlice should include all replicas.
-	AllReplicas
 )
 
 // NewReplicaSlice creates a ReplicaSlice from the replicas listed in the range
 // descriptor and using gossip to lookup node descriptors. Replicas on nodes
 // that are not gossiped are omitted from the result.
 //
-// Generally, learners are not returned, unless AllReplicas was passed in as a
-// filter, which in that case, everything will be returned. However, if a
-// non-nil leaseholder is passed in, it will be included in the result even if
-// the descriptor has it as a learner (we assert that the leaseholder is part
-// of the descriptor). The idea is that the descriptor might be stale and list
-// the leaseholder as a learner erroneously, and lease info is a strong signal
-// in that direction. Note that the returned ReplicaSlice might still not
-// include the leaseholder if info for the respective node is missing from the
-// NodeDescStore.
+// Generally, learners are not returned. However, if a non-nil leaseholder is
+// passed in, it will be included in the result even if the descriptor has it as
+// a learner (we assert that the leaseholder is part of the descriptor). The
+// idea is that the descriptor might be stale and list the leaseholder as a
+// learner erroneously, and lease info is a strong signal in that direction.
+// Note that the returned ReplicaSlice might still not include the leaseholder
+// if info for the respective node is missing from the NodeDescStore.
 //
 // If there's no info in gossip for any of the nodes in the descriptor, a
 // sendError is returned.
@@ -99,8 +95,6 @@ func NewReplicaSlice(
 		replicas = desc.Replicas().Filter(canReceiveLease).Descriptors()
 	case AllExtantReplicas:
 		replicas = desc.Replicas().VoterAndNonVoterDescriptors()
-	case AllReplicas:
-		replicas = desc.Replicas().Descriptors()
 	default:
 		log.Fatalf(ctx, "unknown ReplicaSliceFilter %v", filter)
 	}
@@ -250,15 +244,4 @@ func (rs ReplicaSlice) Descriptors() []roachpb.ReplicaDescriptor {
 		reps[i] = rs[i].ReplicaDescriptor
 	}
 	return reps
-}
-
-// LocalityValue returns the value of the locality tier associated with the
-// given key.
-func (ri *ReplicaInfo) LocalityValue(key string) string {
-	for _, tier := range ri.Tiers {
-		if tier.Key == key {
-			return tier.Value
-		}
-	}
-	return ""
 }

--- a/pkg/kv/kvclient/kvcoord/replica_slice_test.go
+++ b/pkg/kv/kvclient/kvcoord/replica_slice_test.go
@@ -83,9 +83,6 @@ func TestNewReplicaSlice(t *testing.T) {
 	rs, err := NewReplicaSlice(ctx, ns, rd, nil, OnlyPotentialLeaseholders)
 	require.NoError(t, err)
 	require.Equal(t, 3, rs.Len())
-	rs, err = NewReplicaSlice(ctx, ns, rd, nil, AllReplicas)
-	require.NoError(t, err)
-	require.Equal(t, 3, rs.Len())
 
 	// Check that learners are not included.
 	rd.InternalReplicas[2].Type = roachpb.LEARNER
@@ -95,9 +92,6 @@ func TestNewReplicaSlice(t *testing.T) {
 	rs, err = NewReplicaSlice(ctx, ns, rd, nil, AllExtantReplicas)
 	require.NoError(t, err)
 	require.Equal(t, 2, rs.Len())
-	rs, err = NewReplicaSlice(ctx, ns, rd, nil, AllReplicas)
-	require.NoError(t, err)
-	require.Equal(t, 3, rs.Len())
 
 	// Check that non-voters are included iff we ask for them to be.
 	rd.InternalReplicas[2].Type = roachpb.NON_VOTER
@@ -107,18 +101,11 @@ func TestNewReplicaSlice(t *testing.T) {
 	rs, err = NewReplicaSlice(ctx, ns, rd, nil, OnlyPotentialLeaseholders)
 	require.NoError(t, err)
 	require.Equal(t, 2, rs.Len())
-	rs, err = NewReplicaSlice(ctx, ns, rd, nil, AllReplicas)
-	require.NoError(t, err)
-	require.Equal(t, 3, rs.Len())
 
 	// Check that, if the leaseholder points to a learner, that learner is
 	// included.
-	rd.InternalReplicas[2].Type = roachpb.LEARNER
 	leaseholder := &roachpb.ReplicaDescriptor{NodeID: 3, StoreID: 3, ReplicaID: 3}
 	rs, err = NewReplicaSlice(ctx, ns, rd, leaseholder, OnlyPotentialLeaseholders)
-	require.NoError(t, err)
-	require.Equal(t, 3, rs.Len())
-	rs, err = NewReplicaSlice(ctx, ns, rd, leaseholder, AllReplicas)
 	require.NoError(t, err)
 	require.Equal(t, 3, rs.Len())
 }
@@ -282,14 +269,4 @@ func TestReplicaSliceOptimizeReplicaOrder(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestReplicaInfoLocalityValue(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-
-	ri := info(t, 1, 1, []string{"country=us", "region=west", "city=la"})
-	require.Equal(t, "", ri.LocalityValue("foo"))
-	require.Equal(t, "us", ri.LocalityValue("country"))
-	require.Equal(t, "west", ri.LocalityValue("region"))
-	require.Equal(t, "la", ri.LocalityValue("city"))
 }


### PR DESCRIPTION
`AllReplicas` was added as a replica filter as part of #95913 Its use was later removed. This PR reverts the creation of that option.

Epic: none

Release note: None