### PR TITLE
allocator: bump ranges by up to 1 per iter in full disk test

### DIFF
--- a/pkg/kv/kvserver/allocator/allocatorimpl/allocator_test.go
+++ b/pkg/kv/kvserver/allocator/allocatorimpl/allocator_test.go
@@ -8524,8 +8524,8 @@ func TestAllocatorFullDisks(t *testing.T) {
 				continue
 			}
 			ts := &testStores[j]
-			// Add [0,3) ranges to the node, simulating splits and data growth.
-			toAdd := alloc.randGen.Intn(3)
+			// Add [0,2) ranges to the node, simulating splits and data growth.
+			toAdd := alloc.randGen.Intn(2)
 			for k := 0; k < toAdd; k++ {
 				if rangesAdded < rangesToAdd {
 					ts.add(rangeSize, 0)


### PR DESCRIPTION
`TestAllocatorTestAllocatorFullDisks` adds ranges to stores incrementally over 100 generations, mocking rebalancing each generation. The test fails if a store ever reaches, or exceeds the disk capacity.

This test recently failed in #113822 during the add step of the generation loop. Add a maximum of 1 range each iteration, as opposed to the previous 2.

Resolves: #113822
Release note: None