### PR TITLE
roachtest: revert recent changes to tpch_concurrency

### DIFF
--- a/pkg/cmd/roachtest/tests/tpch_concurrency.go
+++ b/pkg/cmd/roachtest/tests/tpch_concurrency.go
@@ -33,8 +33,9 @@ func registerTPCHConcurrency(r registry.Registry) {
 		c cluster.Cluster,
 		disableStreamer bool,
 	) {
-		// We run this test without runtime assertions as it uses too much memory
-		// budget. Even increasing the max to 80% still flaked.
+		// We run this test without runtime assertions as it pushes the VMs way
+		// past the overload point, so it cannot withstand any metamorphic
+		// perturbations.
 		c.Put(ctx, t.StandardCockroach(), "./cockroach", c.Range(1, numNodes-1))
 		c.Put(ctx, t.DeprecatedWorkload(), "./workload", c.Node(numNodes))
 		c.Start(ctx, t.L(), option.DefaultStartOptsNoBackups(), install.MakeClusterSettings(), c.Range(1, numNodes-1))
@@ -56,7 +57,7 @@ func registerTPCHConcurrency(r registry.Registry) {
 
 	restartCluster := func(ctx context.Context, c cluster.Cluster, t test.Test) {
 		c.Stop(ctx, t.L(), option.DefaultStopOpts(), c.Range(1, numNodes-1))
-		c.Start(ctx, t.L(), maybeUseMemoryBudget(t, 35), install.MakeClusterSettings(), c.Range(1, numNodes-1))
+		c.Start(ctx, t.L(), option.DefaultStartOptsNoBackups(), install.MakeClusterSettings(), c.Range(1, numNodes-1))
 	}
 
 	// checkConcurrency returns an error if at least one node of the cluster


### PR DESCRIPTION
This commit reverts a couple of changes to `tpch_concurrency` that were recently added in 581e671f813102b521b6ac0eed480bbf4e23ee18. In particular, this test is extremely sensitive to startup parameters, so we need to use the default `--max-sql-memory` parameter.

Fixes: #113921.

Release note: None