### PR TITLE
engineccl: Add benchmark for ctr_stream encryption

### DIFF
--- a/pkg/ccl/storageccl/engineccl/BUILD.bazel
+++ b/pkg/ccl/storageccl/engineccl/BUILD.bazel
@@ -41,6 +41,7 @@ go_test(
     deps = [
         "//pkg/base",
         "//pkg/ccl/baseccl",
+        "//pkg/ccl/securityccl/fipsccl",
         "//pkg/ccl/storageccl/engineccl/enginepbccl",
         "//pkg/clusterversion",
         "//pkg/keys",

--- a/pkg/ccl/storageccl/engineccl/ctr_stream_test.go
+++ b/pkg/ccl/storageccl/engineccl/ctr_stream_test.go
@@ -11,10 +11,12 @@ package engineccl
 import (
 	"context"
 	"crypto/rand"
+	"encoding/binary"
 	"fmt"
 	"strings"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/ccl/securityccl/fipsccl"
 	"github.com/cockroachdb/cockroach/pkg/ccl/storageccl/engineccl/enginepbccl"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -171,5 +173,70 @@ func TestFileCipherStreamCreator(t *testing.T) {
 	fs5.Encrypt(5, data)
 	if diff := pretty.Diff(data, testData); diff != nil {
 		t.Fatalf("%s\n%s", strings.Join(diff, "\n"), data)
+	}
+}
+
+// Running non-fips mode:
+// ./dev bench pkg/ccl/storageccl/engineccl -f FileCipherStream --stream-output --ignore-cache
+// Running fips mode (be sure to look for fips=true in the output):
+// ./dev test-binaries --cross=crosslinuxfips pkg/ccl/storageccl/engineccl && mkdir -p fipsbin && tar xf bin/test_binaries.tar.gz -C fipsbin && docker run -v $PWD/fipsbin:/fipsbin -it redhat/ubi9 /fipsbin/pkg/ccl/storageccl/engineccl/bin/engineccl_test -test.run '^$' -test.bench FileCipherStream
+func BenchmarkFileCipherStream(b *testing.B) {
+	isFips := fipsccl.IsFIPSReady()
+	for _, keySize := range []int{128, 192, 256} {
+		for _, blockSize := range []int{16, 1024, 10240} {
+			b.Run(fmt.Sprintf("fips=%t/key=%d/block=%d/", isFips, keySize, blockSize), func(b *testing.B) {
+				keyBytes := make([]byte, keySize/8)
+				if _, err := rand.Read(keyBytes); err != nil {
+					panic(err)
+				}
+				var encType enginepbccl.EncryptionType
+				switch keySize {
+				case 128:
+					encType = enginepbccl.EncryptionType_AES128_CTR
+				case 192:
+					encType = enginepbccl.EncryptionType_AES192_CTR
+				case 256:
+					encType = enginepbccl.EncryptionType_AES256_CTR
+				default:
+					panic("unknown key size")
+				}
+				key := &enginepbccl.SecretKey{
+					Info: &enginepbccl.KeyInfo{
+						EncryptionType: encType,
+					},
+					Key: keyBytes,
+				}
+				nonce := make([]byte, ctrNonceSize)
+				if _, err := rand.Read(nonce); err != nil {
+					panic(err)
+				}
+				initCounterBytes := make([]byte, 4)
+				if _, err := rand.Read(initCounterBytes); err != nil {
+					panic(err)
+				}
+				// Endianness doesn't matter for converting this random number to an int.
+				initCounter := binary.LittleEndian.Uint32(initCounterBytes)
+				blockStream, err := newCTRBlockCipherStream(key, nonce, initCounter)
+				if err != nil {
+					panic(err)
+				}
+
+				stream := fileCipherStream{blockStream}
+
+				// Benchmarks are fun! We're just going to encrypt a bunch of zeros
+				// and re-encrypt over the previous output because that doesn't matter
+				// to the speed :)
+				//
+				// TODO(bdarnell): The offset argument to stream.Encrypt *does* matter,
+				// specifically whether the data is aligned to the CTR block size or not.
+				data := make([]byte, blockSize)
+				b.SetBytes(int64(blockSize))
+				b.ResetTimer()
+
+				for i := 0; i < b.N; i++ {
+					stream.Encrypt(0, data)
+				}
+			})
+		}
 	}
 }


### PR DESCRIPTION
Start measuring performance of this code in anticipation of improving it.

Epic: none

Release note: None