### PR TITLE
[wip] bootstrap: make system tables inherit constraints from system database

### DIFF
--- a/pkg/sql/catalog/bootstrap/metadata.go
+++ b/pkg/sql/catalog/bootstrap/metadata.go
@@ -538,16 +538,17 @@ func InitialZoneConfigKVs(
 	// .meta zone config entry with a shorter GC time.
 	metaRangeZoneConf.GC.TTLSeconds = 60 * 60 // 1h
 
-	// Some reporting tables have shorter GC times.
-	replicationConstraintStatsZoneConf := &zonepb.ZoneConfig{
-		GC: &zonepb.GCPolicy{TTLSeconds: int32(systemschema.ReplicationConstraintStatsTableTTL.Seconds())},
-	}
-	replicationStatsZoneConf := &zonepb.ZoneConfig{
-		GC: &zonepb.GCPolicy{TTLSeconds: int32(systemschema.ReplicationStatsTableTTL.Seconds())},
-	}
-	tenantUsageZoneConf := &zonepb.ZoneConfig{
-		GC: &zonepb.GCPolicy{TTLSeconds: int32(systemschema.TenantUsageTableTTL.Seconds())},
-	}
+	// Some reporting tables have shorter GC times. We must initialize them with
+	// NewZoneConfig so that they are configured to inherit constraints and
+	// lease preferences from the system database.
+	replicationConstraintStatsZoneConf := zonepb.NewZoneConfig()
+	replicationConstraintStatsZoneConf.GC = &zonepb.GCPolicy{TTLSeconds: int32(systemschema.ReplicationConstraintStatsTableTTL.Seconds())}
+
+	replicationStatsZoneConf := zonepb.NewZoneConfig()
+	replicationStatsZoneConf.GC = &zonepb.GCPolicy{TTLSeconds: int32(systemschema.ReplicationStatsTableTTL.Seconds())}
+
+	tenantUsageZoneConf := zonepb.NewZoneConfig()
+	tenantUsageZoneConf.GC = &zonepb.GCPolicy{TTLSeconds: int32(systemschema.TenantUsageTableTTL.Seconds())}
 
 	// Liveness zone config entry with a shorter GC time.
 	livenessZoneConf.GC.TTLSeconds = 10 * 60 // 10m


### PR DESCRIPTION
When these tables were added, there was onversight that led to them
never inheriting prefs/constraints from the database zone config.

still needs:
- tests to ensure _all_ system tables inherit from the system database.
- an upgrade step that applies this change to upgraded clusters.

fixes https://github.com/cockroachdb/cockroach/issues/113296

Release note: None