### PR TITLE
kvnemesis: bump reproposal probability

### DIFF
--- a/pkg/kv/kvnemesis/kvnemesis_test.go
+++ b/pkg/kv/kvnemesis/kvnemesis_test.go
@@ -306,6 +306,16 @@ func testKVNemesisImpl(t *testing.T, cfg kvnemesisTestCfg) {
 	logger := newTBridge(t)
 	env := &Env{SQLDBs: sqlDBs, Tracker: tr, L: logger}
 	failures, err := RunNemesis(ctx, rng, env, config, cfg.concurrency, cfg.numSteps, dbs...)
+
+	for i := 0; i < cfg.numNodes; i++ {
+		t.Logf("[%d] proposed: %d", i,
+			tc.GetFirstStoreFromServer(t, i).Metrics().RaftCommandsProposed.Count())
+		t.Logf("[%d] reproposed unchanged: %d", i,
+			tc.GetFirstStoreFromServer(t, i).Metrics().RaftCommandsReproposed.Count())
+		t.Logf("[%d] reproposed with new LAI: %d", i,
+			tc.GetFirstStoreFromServer(t, i).Metrics().RaftCommandsReproposedLAI.Count())
+	}
+
 	require.NoError(t, err, `%+v`, err)
 	require.Zero(t, len(failures), "kvnemesis detected failures") // they've been logged already
 }

--- a/pkg/kv/kvnemesis/kvnemesis_test.go
+++ b/pkg/kv/kvnemesis/kvnemesis_test.go
@@ -235,8 +235,8 @@ func TestKVNemesisSingleNode(t *testing.T) {
 		numSteps:                     defaultNumSteps,
 		concurrency:                  5,
 		seedOverride:                 0,
-		invalidLeaseAppliedIndexProb: 0.1,
-		injectReproposalErrorProb:    0.1,
+		invalidLeaseAppliedIndexProb: 0.2,
+		injectReproposalErrorProb:    0.2,
 	})
 }
 
@@ -263,8 +263,8 @@ func TestKVNemesisMultiNode(t *testing.T) {
 		numSteps:                     defaultNumSteps,
 		concurrency:                  5,
 		seedOverride:                 0,
-		invalidLeaseAppliedIndexProb: 0.1,
-		injectReproposalErrorProb:    0.1,
+		invalidLeaseAppliedIndexProb: 0.2,
+		injectReproposalErrorProb:    0.2,
 	})
 }
 


### PR DESCRIPTION
With 1000 `kvnemesis` steps:

Before:

```
=== RUN   TestKVNemesisSingleNode
    kvnemesis_test.go:315: [0] reproposed with new LAI: 19
=== RUN   TestKVNemesisSingleNode_ReproposalChaos
    kvnemesis_test.go:315: [0] reproposed with new LAI: 251
=== RUN   TestKVNemesisMultiNode
    kvnemesis_test.go:315: [0] reproposed with new LAI: 4
    kvnemesis_test.go:315: [1] reproposed with new LAI: 5
    kvnemesis_test.go:315: [2] reproposed with new LAI: 3
    kvnemesis_test.go:315: [3] reproposed with new LAI: 8
```

After:
```
=== RUN   TestKVNemesisSingleNode
    kvnemesis_test.go:315: [0] reproposed with new LAI: 36
=== RUN   TestKVNemesisSingleNode_ReproposalChaos
    kvnemesis_test.go:315: [0] reproposed with new LAI: 223
=== RUN   TestKVNemesisMultiNode
    kvnemesis_test.go:315: [0] reproposed with new LAI: 8
    kvnemesis_test.go:315: [1] reproposed with new LAI: 20
    kvnemesis_test.go:315: [2] reproposed with new LAI: 11
    kvnemesis_test.go:315: [3] reproposed with new LAI: 3
```

Touches #110551
Release note: none
Epic: none