### PR TITLE
release-23.2: kv: fix handling of non-txn'al locking requests and recompute wait queues when locking requests drop out

### DIFF
--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/shared_locks
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/shared_locks
@@ -1320,6 +1320,95 @@ num=1
     active: false req: 68, strength: Shared, txn: 00000000-0000-0000-0000-000000000003
     active: false req: 69, strength: Shared, txn: 00000000-0000-0000-0000-000000000004
 
+# ------------------------------------------------------------------------------
+# Regression test for
+# https://github.com/cockroachdb/cockroach/issues/113924#issuecomment-1799057694.
+# ------------------------------------------------------------------------------
+
+clear
+----
+num=0
+
+new-request r=req70 txn=txn1 ts=10 spans=intent@a
+----
+
+scan r=req70
+----
+start-waiting: false
+
+new-request r=req71 txn=none ts=10 spans=intent@a
+----
+
+scan r=req71
+----
+start-waiting: false
+
+add-discovered r=req71 txn=txn2 k=a durability=u strength=shared
+----
+num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, info: repl [Shared]
+   queued locking requests:
+    active: false req: 71, strength: Intent, txn: none
+
+scan r=req70
+----
+start-waiting: true
+
+new-request r=req72 txn=txn3 ts=10 spans=shared@a
+----
+
+scan r=req72
+----
+start-waiting: true
+
+new-request r=req73 txn=none ts=10 spans=shared@a
+----
+
+scan r=req73
+----
+start-waiting: true
+
+new-request r=req74 txn=none ts=10 spans=intent@a
+----
+
+scan r=req74
+----
+start-waiting: true
+
+print
+----
+num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, info: repl [Shared]
+   queued locking requests:
+    active: true req: 70, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 71, strength: Intent, txn: none
+    active: true req: 72, strength: Shared, txn: 00000000-0000-0000-0000-000000000003
+    active: true req: 73, strength: Shared, txn: none
+    active: true req: 74, strength: Intent, txn: none
+   distinguished req: 70
+
+release txn=txn2 span=a
+----
+num=1
+ lock: "a"
+   queued locking requests:
+    active: false req: 70, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 71, strength: Intent, txn: none
+    active: true req: 72, strength: Shared, txn: 00000000-0000-0000-0000-000000000003
+    active: true req: 73, strength: Shared, txn: none
+    active: true req: 74, strength: Intent, txn: none
+   distinguished req: 72
+
+dequeue r=req70
+----
+num=1
+ lock: "a"
+   queued locking requests:
+    active: false req: 72, strength: Shared, txn: 00000000-0000-0000-0000-000000000003
+    active: true req: 74, strength: Intent, txn: none
+   distinguished req: 74
 
 # TODO(arul): (non-exhaustive list) of shared lock state transitions that aren't
 # currently supported (and we need to add support for):

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/shared_locks
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/shared_locks
@@ -1246,6 +1246,81 @@ num=1
     active: true req: 63, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000004
    distinguished req: 63
 
+# ------------------------------------------------------------------------------
+# Test when a locking request drops out of a wait queue and makes other actively
+# waiting requests compatible as a result. They should be able to proceed.
+# Serves as a regression test for
+# https://github.com/cockroachdb/cockroach/issues/111144.
+# ------------------------------------------------------------------------------
+
+clear
+----
+num=0
+
+new-request r=req66 txn=txn1 ts=10 spans=shared@a
+----
+
+scan r=req66
+----
+start-waiting: false
+
+acquire r=req66 k=a durability=u strength=shared
+----
+num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
+
+new-request r=req67 txn=txn2 ts=10 spans=exclusive@a
+----
+
+scan r=req67
+----
+start-waiting: true
+
+new-request r=req68 txn=txn3 ts=10 spans=shared@a
+----
+
+scan r=req68
+----
+start-waiting: true
+
+new-request r=req69 txn=txn4 ts=10 spans=shared@a
+----
+
+scan r=req69
+----
+start-waiting: true
+
+print
+----
+num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
+   queued locking requests:
+    active: true req: 67, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 68, strength: Shared, txn: 00000000-0000-0000-0000-000000000003
+    active: true req: 69, strength: Shared, txn: 00000000-0000-0000-0000-000000000004
+   distinguished req: 67
+
+dequeue r=req67
+----
+num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
+   queued locking requests:
+    active: false req: 68, strength: Shared, txn: 00000000-0000-0000-0000-000000000003
+    active: false req: 69, strength: Shared, txn: 00000000-0000-0000-0000-000000000004
+
+print
+----
+num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
+   queued locking requests:
+    active: false req: 68, strength: Shared, txn: 00000000-0000-0000-0000-000000000003
+    active: false req: 69, strength: Shared, txn: 00000000-0000-0000-0000-000000000004
+
+
 # TODO(arul): (non-exhaustive list) of shared lock state transitions that aren't
 # currently supported (and we need to add support for):
 #


### PR DESCRIPTION
Backport:
  * 1/1 commits from "concurrency: recompute wait queues when locking requests drop out " (#113636)
  * 1/1 commits from "kv: fix handling of non-txn'al locking requests in recomputeWaitQueues" (#113987)

Please see individual PRs for details.

/cc @cockroachdb/release
