### PR TITLE
roachprod: fix initialization of 1-node clusters

### DIFF
--- a/pkg/roachprod/install/cockroach.go
+++ b/pkg/roachprod/install/cockroach.go
@@ -405,7 +405,7 @@ func (c *SyncedCluster) Start(ctx context.Context, l *logger.Logger, startOpts S
 		}
 	}
 
-	if shouldInit {
+	if !startOpts.SkipInit {
 		if err := c.waitForDefaultTargetCluster(ctx, l, startOpts); err != nil {
 			return errors.Wrap(err, "failed to wait for default target cluster")
 		}


### PR DESCRIPTION
In #113718, we changed how initialization is done in order to remove the concurrent start of cockroach process. In that change, we also unified the `shouldInit` variable that controls whether the cluster should be initialized with `cockroach init`. However, that particular change was a mistake: it conflated cluster initialization with whether "startup tasks" should run.

This commit fixes that issue by separating the two concepts; now one-node clusters should still skip `cockroach init`, but they will run startup tasks as usual.

Fixes: #114015.

Release note: None