### PR TITLE
release-23.2: roachtest: move schemachange/secondary-index-multi-version to new framework

### DIFF
--- a/pkg/cmd/roachtest/tests/versionupgrade.go
+++ b/pkg/cmd/roachtest/tests/versionupgrade.go
@@ -283,18 +283,6 @@ func uploadAndStartFromCheckpointFixture(
 	}
 }
 
-func uploadAndStart(nodes option.NodeListOption, v *clusterupgrade.Version) versionStep {
-	return func(ctx context.Context, t test.Test, u *versionUpgradeTest) {
-		binary := uploadVersion(ctx, t, u.c, nodes, v)
-		startOpts := option.DefaultStartOpts()
-		if err := clusterupgrade.StartWithSettings(
-			ctx, t.L(), u.c, nodes, startOpts, install.BinaryOption(binary),
-		); err != nil {
-			t.Fatal(err)
-		}
-	}
-}
-
 // binaryUpgradeStep rolling-restarts the given nodes into the new binary
 // version. Note that this does *not* wait for the cluster version to upgrade.
 // Use a waitForUpgradeStep() for that.


### PR DESCRIPTION
Backport 1/1 commits from #113696.

/cc @cockroachdb/release

Release justification: test only change

---

The new framework has better testing and is the only one being maintained now.

fixes https://github.com/cockroachdb/cockroach/issues/110534
Release note: None
