### PR TITLE
release-23.2: multiregionccl,testutilsccl: deflake TestAlterTableLocalityRegionalByRowCorrectZoneConfigBeforeBackfill

### DIFF
--- a/pkg/ccl/testutilsccl/BUILD.bazel
+++ b/pkg/ccl/testutilsccl/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "//pkg/base",
         "//pkg/jobs",
         "//pkg/roachpb",
+        "//pkg/settings/cluster",
         "//pkg/sql",
         "//pkg/sql/execinfra",
         "//pkg/sql/sqltestutils",

--- a/pkg/ccl/testutilsccl/alter_primary_key.go
+++ b/pkg/ccl/testutilsccl/alter_primary_key.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltestutils"
@@ -62,11 +63,20 @@ func AlterPrimaryKeyCorrectZoneConfigTest(
 		t.Run(tc.Desc, func(t *testing.T) {
 			var db *gosql.DB
 			var params base.TestServerArgs
+			params.Settings = cluster.MakeClusterSettings()
 			params.Locality.Tiers = []roachpb.Tier{
 				{Key: "region", Value: "ajstorm-1"},
 			}
 
 			runCheck := false
+
+			// This setting must be overridden so that secondary tenants can configure
+			// regions.
+			sql.SecondaryTenantsMultiRegionAbstractionsEnabled.Override(
+				ctx,
+				&params.Settings.SV,
+				true,
+			)
 			params.Knobs = base.TestingKnobs{
 				SQLSchemaChanger: &sql.SchemaChangerTestingKnobs{
 					BackfillChunkSize: chunkSize,


### PR DESCRIPTION
Backport 1/1 commits from #113826.

/cc @cockroachdb/release

Release justification: test only change

---

This test could fail if run from a secondary tenant. It can be fixed by enabling a cluster setting.

fixes https://github.com/cockroachdb/cockroach/issues/113820
fixes https://github.com/cockroachdb/cockroach/issues/113853

Release note: None
