### PR TITLE
sql/schemachanger: enhance coverage for drop index

### DIFF
--- a/pkg/ccl/schemachangerccl/backup_base_generated_test.go
+++ b/pkg/ccl/schemachangerccl/backup_base_generated_test.go
@@ -305,6 +305,13 @@ func TestBackupRollbacks_base_drop_index_vanilla_index(t *testing.T) {
 	sctest.BackupRollbacks(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestBackupRollbacks_base_drop_index_with_fks(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/drop_index_with_fks"
+	sctest.BackupRollbacks(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestBackupRollbacks_base_drop_index_with_materialized_view_dep(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -624,6 +631,13 @@ func TestBackupRollbacksMixedVersion_base_drop_index_vanilla_index(t *testing.T)
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/drop_index_vanilla_index"
+	sctest.BackupRollbacksMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestBackupRollbacksMixedVersion_base_drop_index_with_fks(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/drop_index_with_fks"
 	sctest.BackupRollbacksMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
@@ -949,6 +963,13 @@ func TestBackupSuccess_base_drop_index_vanilla_index(t *testing.T) {
 	sctest.BackupSuccess(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestBackupSuccess_base_drop_index_with_fks(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/drop_index_with_fks"
+	sctest.BackupSuccess(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestBackupSuccess_base_drop_index_with_materialized_view_dep(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -1268,6 +1289,13 @@ func TestBackupSuccessMixedVersion_base_drop_index_vanilla_index(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/drop_index_vanilla_index"
+	sctest.BackupSuccessMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestBackupSuccessMixedVersion_base_drop_index_with_fks(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/drop_index_with_fks"
 	sctest.BackupSuccessMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 

--- a/pkg/sql/schemachanger/dml_injection_test.go
+++ b/pkg/sql/schemachanger/dml_injection_test.go
@@ -336,6 +336,15 @@ func TestAlterTableDMLInjection(t *testing.T) {
 			skipIssue:    111619,
 		},
 		{
+			desc: "drop column with composite index + fk",
+			setup: []string{
+				"ALTER TABLE tbl ADD COLUMN i INT NOT NULL DEFAULT unique_rowid()",
+				"CREATE UNIQUE INDEX idx ON tbl (val, i)",
+				"CREATE TABLE tbl_ref (val int primary key, i int, CONSTRAINT \"j_k_fk\" FOREIGN KEY (val, i) REFERENCES tbl(val, i))",
+			},
+			schemaChange: "DROP INDEX tbl@idx CASCADE",
+		},
+		{
 			desc:         "create unique index",
 			schemaChange: "CREATE UNIQUE INDEX idx ON tbl (insert_phase_ordinal, operation_phase_ordinal, operation)",
 		},

--- a/pkg/sql/schemachanger/sctest_generated_test.go
+++ b/pkg/sql/schemachanger/sctest_generated_test.go
@@ -307,6 +307,13 @@ func TestEndToEndSideEffects_drop_index_vanilla_index(t *testing.T) {
 	sctest.EndToEndSideEffects(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestEndToEndSideEffects_drop_index_with_fks(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/drop_index_with_fks"
+	sctest.EndToEndSideEffects(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestEndToEndSideEffects_drop_index_with_materialized_view_dep(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -626,6 +633,13 @@ func TestExecuteWithDMLInjection_drop_index_vanilla_index(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/drop_index_vanilla_index"
+	sctest.ExecuteWithDMLInjection(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestExecuteWithDMLInjection_drop_index_with_fks(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/drop_index_with_fks"
 	sctest.ExecuteWithDMLInjection(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
@@ -951,6 +965,13 @@ func TestGenerateSchemaChangeCorpus_drop_index_vanilla_index(t *testing.T) {
 	sctest.GenerateSchemaChangeCorpus(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestGenerateSchemaChangeCorpus_drop_index_with_fks(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/drop_index_with_fks"
+	sctest.GenerateSchemaChangeCorpus(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestGenerateSchemaChangeCorpus_drop_index_with_materialized_view_dep(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -1270,6 +1291,13 @@ func TestPause_drop_index_vanilla_index(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/drop_index_vanilla_index"
+	sctest.Pause(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestPause_drop_index_with_fks(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/drop_index_with_fks"
 	sctest.Pause(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
@@ -1595,6 +1623,13 @@ func TestPauseMixedVersion_drop_index_vanilla_index(t *testing.T) {
 	sctest.PauseMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestPauseMixedVersion_drop_index_with_fks(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/drop_index_with_fks"
+	sctest.PauseMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestPauseMixedVersion_drop_index_with_materialized_view_dep(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -1914,6 +1949,13 @@ func TestRollback_drop_index_vanilla_index(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/drop_index_vanilla_index"
+	sctest.Rollback(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestRollback_drop_index_with_fks(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/drop_index_with_fks"
 	sctest.Rollback(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_index_with_fks/drop_index_with_fks.definition
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_index_with_fks/drop_index_with_fks.definition
@@ -1,0 +1,61 @@
+setup
+CREATE TABLE t (i INT PRIMARY KEY, j INT, m INT);
+CREATE TABLE k (i INT PRIMARY KEY, j INT, m INT);
+CREATE UNIQUE INDEX idx ON t(j, i) USING HASH;
+CREATE UNIQUE INDEX idx2 ON k(j, i);
+INSERT INTO t VALUES (-1, -1), (-2, -2), (-3, -3);
+INSERT INTO k VALUES (-1, -1), (-2, -2), (-3, -3);
+CREATE TABLE t_ref(i INT PRIMARY KEY,
+                   j INT,
+                   CONSTRAINT "j_t_fk" FOREIGN KEY (j, i) REFERENCES
+                          t(j, i),
+                   CONSTRAINT "j_k_fk" FOREIGN KEY (j, i) REFERENCES
+                                                    k(j, i)
+                   );
+----
+
+# Intentionally, only add $stageKey+[1,2] into t, and
+# $stageKey+[0,1] into k to detect when the FK is officially
+# disabled. Beofre the first stage we expect it to be enabled
+# here.
+stage-exec phase=PostCommitNonRevertiblePhase stage=:
+INSERT INTO t (i, j) VALUES($stageKey+1, $stageKey+1);
+INSERT INTO t (i, j) VALUES($stageKey + 2, $stageKey +2);
+INSERT INTO k (i, j) VALUES($stageKey, $stageKey);
+INSERT INTO k (i, j) VALUES($stageKey + 1, $stageKey +1);
+INSERT INTO t_ref(i, j) VALUES($stageKey + 1, $stageKey +1);
+----
+
+# Confirm the FK reference is enabled.
+stage-exec phase=PostCommitNonRevertiblePhase stage=1
+INSERT INTO t_ref (i, j) VALUES($stageKey, $stageKey);
+----
+pq: insert on table "t_ref" violates foreign key constraint .*
+
+# Confirm it was removed.
+stage-exec phase=PostCommitNonRevertiblePhase stage=2
+INSERT INTO t_ref (i, j) VALUES($stageKey, $stageKey);
+----
+
+
+
+# Each insert will be injected twice per stage for t and
+# k.
+stage-query phase=PostCommitNonRevertiblePhase stage=:
+SELECT count(*)=($successfulStageCount*2)+3 FROM t;
+SELECT count(*)=($successfulStageCount*2)+3 FROM k;
+SELECT count(*)=3 FROM t_ref;
+----
+true
+
+# For t_ref the first stage will only get a single insert.
+# The second stage can get two inserts, because the foreign
+# key ref is disabled.
+stage-query phase=PostCommitNonRevertiblePhase stage=2
+SELECT count(*)=3 FROM t_ref;
+---
+true
+
+test
+DROP INDEX idx CASCADE
+----

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_index_with_fks/drop_index_with_fks.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_index_with_fks/drop_index_with_fks.explain
@@ -1,0 +1,113 @@
+/* setup */
+CREATE TABLE t (i INT PRIMARY KEY, j INT, m INT);
+CREATE TABLE k (i INT PRIMARY KEY, j INT, m INT);
+CREATE UNIQUE INDEX idx ON t(j, i) USING HASH;
+CREATE UNIQUE INDEX idx2 ON k(j, i) USING HASH;
+INSERT INTO t VALUES (-1, -1), (-2, -2), (-3, -3);
+INSERT INTO k VALUES (-1, -1), (-2, -2), (-3, -3);
+CREATE TABLE t_ref(i INT PRIMARY KEY,
+                   j INT,
+                   CONSTRAINT "j_t_fk" FOREIGN KEY (j, i) REFERENCES
+                          t(j, i),
+                   CONSTRAINT "j_k_fk" FOREIGN KEY (j, i) REFERENCES
+                                                    k(j, i)
+                   );
+
+/* test */
+EXPLAIN (DDL) DROP INDEX idx CASCADE;
+----
+Schema change plan for DROP INDEX ‹defaultdb›.‹public›.‹t›@‹idx› CASCADE;
+ ├── StatementPhase
+ │    └── Stage 1 of 1 in StatementPhase
+ │         ├── 8 elements transitioning toward ABSENT
+ │         │    ├── PUBLIC → WRITE_ONLY Column:{DescID: 104 (t), ColumnID: 4 (crdb_internal_i_j_shard_16-)}
+ │         │    ├── PUBLIC → ABSENT     ColumnName:{DescID: 104 (t), Name: "crdb_internal_i_j_shard_16", ColumnID: 4 (crdb_internal_i_j_shard_16-)}
+ │         │    ├── PUBLIC → VALIDATED  ColumnNotNull:{DescID: 104 (t), ColumnID: 4 (crdb_internal_i_j_shard_16-), IndexID: 0}
+ │         │    ├── PUBLIC → VALIDATED  SecondaryIndex:{DescID: 104 (t), IndexID: 2 (idx-), ConstraintID: 3, RecreateSourceIndexID: 0}
+ │         │    ├── PUBLIC → VALIDATED  CheckConstraint:{DescID: 104 (t), IndexID: 0, ConstraintID: 2 (check_crdb_internal_i_j_shard_16-)}
+ │         │    ├── PUBLIC → ABSENT     ConstraintWithoutIndexName:{DescID: 104 (t), Name: "check_crdb_internal_i_j_shard_16", ConstraintID: 2 (check_crdb_internal_i_j_shard_16-)}
+ │         │    ├── PUBLIC → VALIDATED  ForeignKeyConstraint:{DescID: 106 (t_ref), IndexID: 0, ConstraintID: 2 (j_t_fk-), ReferencedDescID: 104 (t)}
+ │         │    └── PUBLIC → ABSENT     ConstraintWithoutIndexName:{DescID: 106 (t_ref), Name: "j_t_fk", ConstraintID: 2 (j_t_fk-)}
+ │         └── 8 Mutation operations
+ │              ├── MakePublicColumnNotNullValidated {"ColumnID":4,"TableID":104}
+ │              ├── MakePublicSecondaryIndexWriteOnly {"IndexID":2,"TableID":104}
+ │              ├── MakePublicCheckConstraintValidated {"ConstraintID":2,"TableID":104}
+ │              ├── SetConstraintName {"ConstraintID":2,"Name":"crdb_internal_co...","TableID":104}
+ │              ├── MakePublicForeignKeyConstraintValidated {"ConstraintID":2,"TableID":106}
+ │              ├── SetConstraintName {"ConstraintID":2,"Name":"crdb_internal_co...","TableID":106}
+ │              ├── MakePublicColumnWriteOnly {"ColumnID":4,"TableID":104}
+ │              └── SetColumnName {"ColumnID":4,"Name":"crdb_internal_co...","TableID":104}
+ ├── PreCommitPhase
+ │    ├── Stage 1 of 2 in PreCommitPhase
+ │    │    ├── 8 elements transitioning toward ABSENT
+ │    │    │    ├── WRITE_ONLY → PUBLIC Column:{DescID: 104 (t), ColumnID: 4 (crdb_internal_i_j_shard_16-)}
+ │    │    │    ├── ABSENT     → PUBLIC ColumnName:{DescID: 104 (t), Name: "crdb_internal_i_j_shard_16", ColumnID: 4 (crdb_internal_i_j_shard_16-)}
+ │    │    │    ├── VALIDATED  → PUBLIC ColumnNotNull:{DescID: 104 (t), ColumnID: 4 (crdb_internal_i_j_shard_16-), IndexID: 0}
+ │    │    │    ├── VALIDATED  → PUBLIC SecondaryIndex:{DescID: 104 (t), IndexID: 2 (idx-), ConstraintID: 3, RecreateSourceIndexID: 0}
+ │    │    │    ├── VALIDATED  → PUBLIC CheckConstraint:{DescID: 104 (t), IndexID: 0, ConstraintID: 2 (check_crdb_internal_i_j_shard_16-)}
+ │    │    │    ├── ABSENT     → PUBLIC ConstraintWithoutIndexName:{DescID: 104 (t), Name: "check_crdb_internal_i_j_shard_16", ConstraintID: 2 (check_crdb_internal_i_j_shard_16-)}
+ │    │    │    ├── VALIDATED  → PUBLIC ForeignKeyConstraint:{DescID: 106 (t_ref), IndexID: 0, ConstraintID: 2 (j_t_fk-), ReferencedDescID: 104 (t)}
+ │    │    │    └── ABSENT     → PUBLIC ConstraintWithoutIndexName:{DescID: 106 (t_ref), Name: "j_t_fk", ConstraintID: 2 (j_t_fk-)}
+ │    │    └── 1 Mutation operation
+ │    │         └── UndoAllInTxnImmediateMutationOpSideEffects
+ │    └── Stage 2 of 2 in PreCommitPhase
+ │         ├── 8 elements transitioning toward ABSENT
+ │         │    ├── PUBLIC → WRITE_ONLY Column:{DescID: 104 (t), ColumnID: 4 (crdb_internal_i_j_shard_16-)}
+ │         │    ├── PUBLIC → ABSENT     ColumnName:{DescID: 104 (t), Name: "crdb_internal_i_j_shard_16", ColumnID: 4 (crdb_internal_i_j_shard_16-)}
+ │         │    ├── PUBLIC → VALIDATED  ColumnNotNull:{DescID: 104 (t), ColumnID: 4 (crdb_internal_i_j_shard_16-), IndexID: 0}
+ │         │    ├── PUBLIC → VALIDATED  SecondaryIndex:{DescID: 104 (t), IndexID: 2 (idx-), ConstraintID: 3, RecreateSourceIndexID: 0}
+ │         │    ├── PUBLIC → VALIDATED  CheckConstraint:{DescID: 104 (t), IndexID: 0, ConstraintID: 2 (check_crdb_internal_i_j_shard_16-)}
+ │         │    ├── PUBLIC → ABSENT     ConstraintWithoutIndexName:{DescID: 104 (t), Name: "check_crdb_internal_i_j_shard_16", ConstraintID: 2 (check_crdb_internal_i_j_shard_16-)}
+ │         │    ├── PUBLIC → VALIDATED  ForeignKeyConstraint:{DescID: 106 (t_ref), IndexID: 0, ConstraintID: 2 (j_t_fk-), ReferencedDescID: 104 (t)}
+ │         │    └── PUBLIC → ABSENT     ConstraintWithoutIndexName:{DescID: 106 (t_ref), Name: "j_t_fk", ConstraintID: 2 (j_t_fk-)}
+ │         └── 11 Mutation operations
+ │              ├── MakePublicColumnNotNullValidated {"ColumnID":4,"TableID":104}
+ │              ├── MakePublicSecondaryIndexWriteOnly {"IndexID":2,"TableID":104}
+ │              ├── MakePublicCheckConstraintValidated {"ConstraintID":2,"TableID":104}
+ │              ├── SetConstraintName {"ConstraintID":2,"Name":"crdb_internal_co...","TableID":104}
+ │              ├── MakePublicForeignKeyConstraintValidated {"ConstraintID":2,"TableID":106}
+ │              ├── SetConstraintName {"ConstraintID":2,"Name":"crdb_internal_co...","TableID":106}
+ │              ├── MakePublicColumnWriteOnly {"ColumnID":4,"TableID":104}
+ │              ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_co...","TableID":104}
+ │              ├── SetJobStateOnDescriptor {"DescriptorID":104,"Initialize":true}
+ │              ├── SetJobStateOnDescriptor {"DescriptorID":106,"Initialize":true}
+ │              └── CreateSchemaChangerJob {"NonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 9 elements transitioning toward ABSENT
+      │    │    ├── WRITE_ONLY → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 4 (crdb_internal_i_j_shard_16-)}
+      │    │    ├── VALIDATED  → ABSENT      ColumnNotNull:{DescID: 104 (t), ColumnID: 4 (crdb_internal_i_j_shard_16-), IndexID: 0}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_i_j_shard_16-), IndexID: 2 (idx-)}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 2 (idx-)}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 2 (idx-)}
+      │    │    ├── VALIDATED  → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 2 (idx-), ConstraintID: 3, RecreateSourceIndexID: 0}
+      │    │    ├── PUBLIC     → ABSENT      IndexName:{DescID: 104 (t), Name: "idx", IndexID: 2 (idx-)}
+      │    │    ├── VALIDATED  → ABSENT      CheckConstraint:{DescID: 104 (t), IndexID: 0, ConstraintID: 2 (check_crdb_internal_i_j_shard_16-)}
+      │    │    └── VALIDATED  → ABSENT      ForeignKeyConstraint:{DescID: 106 (t_ref), IndexID: 0, ConstraintID: 2 (j_t_fk-), ReferencedDescID: 104 (t)}
+      │    └── 13 Mutation operations
+      │         ├── RemoveColumnNotNull {"ColumnID":4,"TableID":104}
+      │         ├── RemoveCheckConstraint {"ConstraintID":2,"TableID":104}
+      │         ├── RemoveForeignKeyBackReference {"OriginConstraintID":2,"OriginTableID":106,"ReferencedTableID":104}
+      │         ├── RemoveForeignKeyConstraint {"ConstraintID":2,"TableID":106}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":2,"TableID":104}
+      │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"Ordinal":2,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 4 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 4 (crdb_internal_i_j_shard_16-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 4 (crdb_internal_i_j_shard_16-)}
+           │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 2 (idx-), ConstraintID: 3, RecreateSourceIndexID: 0}
+           │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 2 (idx-)}
+           └── 6 Mutation operations
+                ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":2,"TableID":104}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":106}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_index_with_fks/drop_index_with_fks.explain_shape
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_index_with_fks/drop_index_with_fks.explain_shape
@@ -1,0 +1,20 @@
+/* setup */
+CREATE TABLE t (i INT PRIMARY KEY, j INT, m INT);
+CREATE TABLE k (i INT PRIMARY KEY, j INT, m INT);
+CREATE UNIQUE INDEX idx ON t(j, i) USING HASH;
+CREATE UNIQUE INDEX idx2 ON k(j, i) USING HASH;
+INSERT INTO t VALUES (-1, -1), (-2, -2), (-3, -3);
+INSERT INTO k VALUES (-1, -1), (-2, -2), (-3, -3);
+CREATE TABLE t_ref(i INT PRIMARY KEY,
+                   j INT,
+                   CONSTRAINT "j_t_fk" FOREIGN KEY (j, i) REFERENCES
+                          t(j, i),
+                   CONSTRAINT "j_k_fk" FOREIGN KEY (j, i) REFERENCES
+                                                    k(j, i)
+                   );
+
+/* test */
+EXPLAIN (DDL, SHAPE) DROP INDEX idx CASCADE;
+----
+Schema change plan for DROP INDEX ‹defaultdb›.‹public›.‹t›@‹idx› CASCADE;
+ └── execute 3 system table mutations transactions

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_index_with_fks/drop_index_with_fks.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_index_with_fks/drop_index_with_fks.side_effects
@@ -1,0 +1,809 @@
+/* setup */
+CREATE TABLE t (i INT PRIMARY KEY, j INT, m INT);
+CREATE TABLE k (i INT PRIMARY KEY, j INT, m INT);
+CREATE UNIQUE INDEX idx ON t(j, i) USING HASH;
+CREATE UNIQUE INDEX idx2 ON k(j, i) USING HASH;
+INSERT INTO t VALUES (-1, -1), (-2, -2), (-3, -3);
+INSERT INTO k VALUES (-1, -1), (-2, -2), (-3, -3);
+CREATE TABLE t_ref(i INT PRIMARY KEY,
+                   j INT,
+                   CONSTRAINT "j_t_fk" FOREIGN KEY (j, i) REFERENCES
+                          t(j, i),
+                   CONSTRAINT "j_k_fk" FOREIGN KEY (j, i) REFERENCES
+                                                    k(j, i)
+                   );
+----
+...
++object {100 101 t} -> 104
++object {100 101 k} -> 105
++object {100 101 t_ref} -> 106
+
+/* test */
+DROP INDEX idx CASCADE;
+----
+begin transaction #1
+# begin StatementPhase
+checking for feature: DROP INDEX
+getting all objects in schema: 101
+increment telemetry for sql.schema.drop_index
+write *eventpb.DropIndex to event log:
+  indexName: idx
+  mutationId: 1
+  sql:
+    descriptorId: 104
+    statement: DROP INDEX ‹defaultdb›.‹public›.‹t›@‹idx› CASCADE
+    tag: DROP INDEX
+    user: root
+  tableName: defaultdb.public.t
+## StatementPhase stage 1 of 1 with 8 MutationType ops
+upsert descriptor #104
+  ...
+       - 4
+       constraintId: 2
+  -    expr: '"crdb_internal_i_j_shard_16" IN (0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15)'
+  +    expr: crdb_internal_column_4_name_placeholder IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
+       fromHashShardedColumn: true
+  -    name: check_crdb_internal_i_j_shard_16
+  +    name: crdb_internal_constraint_2_name_placeholder
+  +    validity: Dropping
+  +  - columnIds:
+  +    - 4
+  +    expr: crdb_internal_column_4_name_placeholder IS NOT NULL
+  +    isNonNullConstraint: true
+  +    name: crdb_internal_i_j_shard_16_auto_not_null
+  +    validity: Dropping
+     columns:
+     - id: 1
+  ...
+         oid: 20
+         width: 64
+  -  - computeExpr: mod(fnv32(md5(crdb_internal.datums_to_bytes(i, j))), 16:::INT8)
+  -    hidden: true
+  -    id: 4
+  -    name: crdb_internal_i_j_shard_16
+  -    type:
+  -      family: IntFamily
+  -      oid: 20
+  -      width: 64
+  -    virtual: true
+     createAsOfTime:
+       wallTime: "1640995200000000000"
+  ...
+     inboundFks:
+     - constraintId: 2
+  -    name: j_t_fk
+  +    name: crdb_internal_constraint_2_name_placeholder
+       originColumnIds:
+       - 2
+  ...
+       - 1
+       referencedTableId: 104
+  -  indexes:
+  -  - constraintId: 3
+  -    createdAtNanos: "1640995200000000000"
+  -    createdExplicitly: true
+  -    foreignKey: {}
+  -    geoConfig: {}
+  -    id: 2
+  -    interleave: {}
+  -    keyColumnDirections:
+  -    - ASC
+  -    - ASC
+  -    - ASC
+  -    keyColumnIds:
+  -    - 4
+  -    - 2
+  -    - 1
+  -    keyColumnNames:
+  -    - crdb_internal_i_j_shard_16
+  -    - j
+  -    - i
+  -    name: idx
+  -    partitioning: {}
+  -    sharded:
+  -      columnNames:
+  -      - i
+  -      - j
+  -      isSharded: true
+  -      name: crdb_internal_i_j_shard_16
+  -      shardBuckets: 16
+  -    unique: true
+  -    version: 4
+  +    validity: Dropping
+  +  indexes: []
+     modificationTime: {}
+  +  mutations:
+  +  - constraint:
+  +      check:
+  +        columnIds:
+  +        - 4
+  +        expr: crdb_internal_column_4_name_placeholder IS NOT NULL
+  +        isNonNullConstraint: true
+  +        name: crdb_internal_i_j_shard_16_auto_not_null
+  +        validity: Dropping
+  +      constraintType: NOT_NULL
+  +      foreignKey: {}
+  +      name: crdb_internal_i_j_shard_16_auto_not_null
+  +      notNullColumn: 4
+  +      uniqueWithoutIndexConstraint: {}
+  +    direction: DROP
+  +    mutationId: 1
+  +    state: WRITE_ONLY
+  +  - direction: DROP
+  +    index:
+  +      constraintId: 3
+  +      createdAtNanos: "1640995200000000000"
+  +      createdExplicitly: true
+  +      foreignKey: {}
+  +      geoConfig: {}
+  +      id: 2
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      - ASC
+  +      - ASC
+  +      keyColumnIds:
+  +      - 4
+  +      - 2
+  +      - 1
+  +      keyColumnNames:
+  +      - crdb_internal_column_4_name_placeholder
+  +      - j
+  +      - i
+  +      name: idx
+  +      partitioning: {}
+  +      sharded:
+  +        columnNames:
+  +        - i
+  +        - j
+  +        isSharded: true
+  +        name: crdb_internal_i_j_shard_16
+  +        shardBuckets: 16
+  +      unique: true
+  +      version: 4
+  +    mutationId: 1
+  +    state: WRITE_ONLY
+  +  - constraint:
+  +      check:
+  +        columnIds:
+  +        - 4
+  +        constraintId: 2
+  +        expr: crdb_internal_column_4_name_placeholder IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
+  +        fromHashShardedColumn: true
+  +        name: check_crdb_internal_i_j_shard_16
+  +        validity: Dropping
+  +      foreignKey: {}
+  +      name: check_crdb_internal_i_j_shard_16
+  +      uniqueWithoutIndexConstraint: {}
+  +    direction: DROP
+  +    mutationId: 1
+  +    state: WRITE_ONLY
+  +  - column:
+  +      computeExpr: mod(fnv32(md5(crdb_internal.datums_to_bytes(i, j))), 16:::INT8)
+  +      hidden: true
+  +      id: 4
+  +      name: crdb_internal_column_4_name_placeholder
+  +      nullable: true
+  +      type:
+  +        family: IntFamily
+  +        oid: 20
+  +        width: 64
+  +      virtual: true
+  +    direction: DROP
+  +    mutationId: 1
+  +    state: WRITE_ONLY
+     name: t
+     nextColumnId: 5
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "8"
+  +  version: "9"
+upsert descriptor #106
+  ...
+     id: 106
+     modificationTime: {}
+  +  mutations:
+  +  - constraint:
+  +      check: {}
+  +      constraintType: FOREIGN_KEY
+  +      foreignKey:
+  +        constraintId: 2
+  +        name: crdb_internal_constraint_2_name_placeholder
+  +        originColumnIds:
+  +        - 2
+  +        - 1
+  +        originTableId: 106
+  +        referencedColumnIds:
+  +        - 2
+  +        - 1
+  +        referencedTableId: 104
+  +        validity: Dropping
+  +      name: j_t_fk
+  +      uniqueWithoutIndexConstraint: {}
+  +    direction: DROP
+  +    mutationId: 1
+  +    state: WRITE_ONLY
+     name: t_ref
+     nextColumnId: 3
+  ...
+     nextMutationId: 1
+     outboundFks:
+  -  - constraintId: 2
+  -    name: j_t_fk
+  -    originColumnIds:
+  -    - 2
+  -    - 1
+  -    originTableId: 106
+  -    referencedColumnIds:
+  -    - 2
+  -    - 1
+  -    referencedTableId: 104
+     - constraintId: 3
+       name: j_k_fk
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "2"
+  +  version: "3"
+# end StatementPhase
+# begin PreCommitPhase
+## PreCommitPhase stage 1 of 2 with 1 MutationType op
+undo all catalog changes within txn #1
+persist all catalog changes to storage
+## PreCommitPhase stage 2 of 2 with 11 MutationType ops
+upsert descriptor #104
+  ...
+       - 4
+       constraintId: 2
+  -    expr: '"crdb_internal_i_j_shard_16" IN (0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15)'
+  +    expr: crdb_internal_column_4_name_placeholder IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
+       fromHashShardedColumn: true
+  -    name: check_crdb_internal_i_j_shard_16
+  +    name: crdb_internal_constraint_2_name_placeholder
+  +    validity: Dropping
+  +  - columnIds:
+  +    - 4
+  +    expr: crdb_internal_column_4_name_placeholder IS NOT NULL
+  +    isNonNullConstraint: true
+  +    name: crdb_internal_i_j_shard_16_auto_not_null
+  +    validity: Dropping
+     columns:
+     - id: 1
+  ...
+         oid: 20
+         width: 64
+  -  - computeExpr: mod(fnv32(md5(crdb_internal.datums_to_bytes(i, j))), 16:::INT8)
+  -    hidden: true
+  -    id: 4
+  -    name: crdb_internal_i_j_shard_16
+  -    type:
+  -      family: IntFamily
+  -      oid: 20
+  -      width: 64
+  -    virtual: true
+     createAsOfTime:
+       wallTime: "1640995200000000000"
+  +  declarativeSchemaChangerState:
+  +    authorization:
+  +      userName: root
+  +    currentStatuses: <redacted>
+  +    jobId: "1"
+  +    nameMapping:
+  +      columns:
+  +        "1": i
+  +        "2": j
+  +        "3": m
+  +        "4294967294": tableoid
+  +        "4294967295": crdb_internal_mvcc_timestamp
+  +      families:
+  +        "0": primary
+  +      id: 104
+  +      indexes:
+  +        "1": t_pkey
+  +      name: t
+  +    relevantStatements:
+  +    - statement:
+  +        redactedStatement: DROP INDEX ‹defaultdb›.‹public›.‹t›@‹idx› CASCADE
+  +        statement: DROP INDEX idx CASCADE
+  +        statementTag: DROP INDEX
+  +    targetRanks: <redacted>
+  +    targets: <redacted>
+     families:
+     - columnIds:
+  ...
+     inboundFks:
+     - constraintId: 2
+  -    name: j_t_fk
+  +    name: crdb_internal_constraint_2_name_placeholder
+       originColumnIds:
+       - 2
+  ...
+       - 1
+       referencedTableId: 104
+  -  indexes:
+  -  - constraintId: 3
+  -    createdAtNanos: "1640995200000000000"
+  -    createdExplicitly: true
+  -    foreignKey: {}
+  -    geoConfig: {}
+  -    id: 2
+  -    interleave: {}
+  -    keyColumnDirections:
+  -    - ASC
+  -    - ASC
+  -    - ASC
+  -    keyColumnIds:
+  -    - 4
+  -    - 2
+  -    - 1
+  -    keyColumnNames:
+  -    - crdb_internal_i_j_shard_16
+  -    - j
+  -    - i
+  -    name: idx
+  -    partitioning: {}
+  -    sharded:
+  -      columnNames:
+  -      - i
+  -      - j
+  -      isSharded: true
+  -      name: crdb_internal_i_j_shard_16
+  -      shardBuckets: 16
+  -    unique: true
+  -    version: 4
+  +    validity: Dropping
+  +  indexes: []
+     modificationTime: {}
+  +  mutations:
+  +  - constraint:
+  +      check:
+  +        columnIds:
+  +        - 4
+  +        expr: crdb_internal_column_4_name_placeholder IS NOT NULL
+  +        isNonNullConstraint: true
+  +        name: crdb_internal_i_j_shard_16_auto_not_null
+  +        validity: Dropping
+  +      constraintType: NOT_NULL
+  +      foreignKey: {}
+  +      name: crdb_internal_i_j_shard_16_auto_not_null
+  +      notNullColumn: 4
+  +      uniqueWithoutIndexConstraint: {}
+  +    direction: DROP
+  +    mutationId: 1
+  +    state: WRITE_ONLY
+  +  - direction: DROP
+  +    index:
+  +      constraintId: 3
+  +      createdAtNanos: "1640995200000000000"
+  +      createdExplicitly: true
+  +      foreignKey: {}
+  +      geoConfig: {}
+  +      id: 2
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      - ASC
+  +      - ASC
+  +      keyColumnIds:
+  +      - 4
+  +      - 2
+  +      - 1
+  +      keyColumnNames:
+  +      - crdb_internal_column_4_name_placeholder
+  +      - j
+  +      - i
+  +      name: idx
+  +      partitioning: {}
+  +      sharded:
+  +        columnNames:
+  +        - i
+  +        - j
+  +        isSharded: true
+  +        name: crdb_internal_i_j_shard_16
+  +        shardBuckets: 16
+  +      unique: true
+  +      version: 4
+  +    mutationId: 1
+  +    state: WRITE_ONLY
+  +  - constraint:
+  +      check:
+  +        columnIds:
+  +        - 4
+  +        constraintId: 2
+  +        expr: crdb_internal_column_4_name_placeholder IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
+  +        fromHashShardedColumn: true
+  +        name: check_crdb_internal_i_j_shard_16
+  +        validity: Dropping
+  +      foreignKey: {}
+  +      name: check_crdb_internal_i_j_shard_16
+  +      uniqueWithoutIndexConstraint: {}
+  +    direction: DROP
+  +    mutationId: 1
+  +    state: WRITE_ONLY
+  +  - column:
+  +      computeExpr: mod(fnv32(md5(crdb_internal.datums_to_bytes(i, j))), 16:::INT8)
+  +      hidden: true
+  +      id: 4
+  +      name: crdb_internal_column_4_name_placeholder
+  +      nullable: true
+  +      type:
+  +        family: IntFamily
+  +        oid: 20
+  +        width: 64
+  +      virtual: true
+  +    direction: DROP
+  +    mutationId: 1
+  +    state: WRITE_ONLY
+     name: t
+     nextColumnId: 5
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "8"
+  +  version: "9"
+upsert descriptor #106
+  ...
+     createAsOfTime:
+       wallTime: "1640995200000000000"
+  +  declarativeSchemaChangerState:
+  +    authorization:
+  +      userName: root
+  +    currentStatuses: <redacted>
+  +    jobId: "1"
+  +    nameMapping:
+  +      columns:
+  +        "1": i
+  +        "2": j
+  +        "4294967294": tableoid
+  +        "4294967295": crdb_internal_mvcc_timestamp
+  +      constraints:
+  +        "3": j_k_fk
+  +      families:
+  +        "0": primary
+  +      id: 106
+  +      indexes:
+  +        "1": t_ref_pkey
+  +      name: t_ref
+  +    relevantStatements:
+  +    - statement:
+  +        redactedStatement: DROP INDEX ‹defaultdb›.‹public›.‹t›@‹idx› CASCADE
+  +        statement: DROP INDEX idx CASCADE
+  +        statementTag: DROP INDEX
+  +    targetRanks: <redacted>
+  +    targets: <redacted>
+     families:
+     - columnIds:
+  ...
+     id: 106
+     modificationTime: {}
+  +  mutations:
+  +  - constraint:
+  +      check: {}
+  +      constraintType: FOREIGN_KEY
+  +      foreignKey:
+  +        constraintId: 2
+  +        name: crdb_internal_constraint_2_name_placeholder
+  +        originColumnIds:
+  +        - 2
+  +        - 1
+  +        originTableId: 106
+  +        referencedColumnIds:
+  +        - 2
+  +        - 1
+  +        referencedTableId: 104
+  +        validity: Dropping
+  +      name: j_t_fk
+  +      uniqueWithoutIndexConstraint: {}
+  +    direction: DROP
+  +    mutationId: 1
+  +    state: WRITE_ONLY
+     name: t_ref
+     nextColumnId: 3
+  ...
+     nextMutationId: 1
+     outboundFks:
+  -  - constraintId: 2
+  -    name: j_t_fk
+  -    originColumnIds:
+  -    - 2
+  -    - 1
+  -    originTableId: 106
+  -    referencedColumnIds:
+  -    - 2
+  -    - 1
+  -    referencedTableId: 104
+     - constraintId: 3
+       name: j_k_fk
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "2"
+  +  version: "3"
+persist all catalog changes to storage
+create job #1 (non-cancelable: true): "DROP INDEX defaultdb.public.t@idx CASCADE"
+  descriptor IDs: [104 106]
+# end PreCommitPhase
+commit transaction #1
+notified job registry to adopt jobs: [1]
+# begin PostCommitPhase
+begin transaction #2
+commit transaction #2
+begin transaction #3
+## PostCommitNonRevertiblePhase stage 1 of 2 with 13 MutationType ops
+upsert descriptor #104
+   table:
+  -  checks:
+  -  - columnIds:
+  -    - 4
+  -    constraintId: 2
+  -    expr: crdb_internal_column_4_name_placeholder IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
+  -    fromHashShardedColumn: true
+  -    name: crdb_internal_constraint_2_name_placeholder
+  -    validity: Dropping
+  -  - columnIds:
+  -    - 4
+  -    expr: crdb_internal_column_4_name_placeholder IS NOT NULL
+  -    isNonNullConstraint: true
+  -    name: crdb_internal_i_j_shard_16_auto_not_null
+  -    validity: Dropping
+  +  checks: []
+     columns:
+     - id: 1
+  ...
+     formatVersion: 3
+     id: 104
+  -  inboundFks:
+  -  - constraintId: 2
+  -    name: crdb_internal_constraint_2_name_placeholder
+  -    originColumnIds:
+  -    - 2
+  -    - 1
+  -    originTableId: 106
+  -    referencedColumnIds:
+  -    - 2
+  -    - 1
+  -    referencedTableId: 104
+  -    validity: Dropping
+     indexes: []
+     modificationTime: {}
+     mutations:
+  -  - constraint:
+  -      check:
+  -        columnIds:
+  -        - 4
+  -        expr: crdb_internal_column_4_name_placeholder IS NOT NULL
+  -        isNonNullConstraint: true
+  -        name: crdb_internal_i_j_shard_16_auto_not_null
+  -        validity: Dropping
+  -      constraintType: NOT_NULL
+  -      foreignKey: {}
+  -      name: crdb_internal_i_j_shard_16_auto_not_null
+  -      notNullColumn: 4
+  -      uniqueWithoutIndexConstraint: {}
+  -    direction: DROP
+  -    mutationId: 1
+  -    state: WRITE_ONLY
+     - direction: DROP
+       index:
+  ...
+         - j
+         - i
+  -      name: idx
+  +      name: crdb_internal_index_2_name_placeholder
+         partitioning: {}
+         sharded:
+  ...
+         version: 4
+       mutationId: 1
+  -    state: WRITE_ONLY
+  -  - constraint:
+  -      check:
+  -        columnIds:
+  -        - 4
+  -        constraintId: 2
+  -        expr: crdb_internal_column_4_name_placeholder IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
+  -        fromHashShardedColumn: true
+  -        name: check_crdb_internal_i_j_shard_16
+  -        validity: Dropping
+  -      foreignKey: {}
+  -      name: check_crdb_internal_i_j_shard_16
+  -      uniqueWithoutIndexConstraint: {}
+  -    direction: DROP
+  -    mutationId: 1
+  -    state: WRITE_ONLY
+  +    state: DELETE_ONLY
+     - column:
+         computeExpr: mod(fnv32(md5(crdb_internal.datums_to_bytes(i, j))), 16:::INT8)
+  ...
+       direction: DROP
+       mutationId: 1
+  -    state: WRITE_ONLY
+  +    state: DELETE_ONLY
+     name: t
+     nextColumnId: 5
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "9"
+  +  version: "10"
+upsert descriptor #106
+  ...
+     id: 106
+     modificationTime: {}
+  -  mutations:
+  -  - constraint:
+  -      check: {}
+  -      constraintType: FOREIGN_KEY
+  -      foreignKey:
+  -        constraintId: 2
+  -        name: crdb_internal_constraint_2_name_placeholder
+  -        originColumnIds:
+  -        - 2
+  -        - 1
+  -        originTableId: 106
+  -        referencedColumnIds:
+  -        - 2
+  -        - 1
+  -        referencedTableId: 104
+  -        validity: Dropping
+  -      name: j_t_fk
+  -      uniqueWithoutIndexConstraint: {}
+  -    direction: DROP
+  -    mutationId: 1
+  -    state: WRITE_ONLY
+     name: t_ref
+     nextColumnId: 3
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "3"
+  +  version: "4"
+persist all catalog changes to storage
+update progress of schema change job #1: "PostCommitNonRevertiblePhase stage 2 of 2 with 3 MutationType ops pending"
+commit transaction #3
+begin transaction #4
+## PostCommitNonRevertiblePhase stage 2 of 2 with 6 MutationType ops
+upsert descriptor #104
+  ...
+     createAsOfTime:
+       wallTime: "1640995200000000000"
+  -  declarativeSchemaChangerState:
+  -    authorization:
+  -      userName: root
+  -    currentStatuses: <redacted>
+  -    jobId: "1"
+  -    nameMapping:
+  -      columns:
+  -        "1": i
+  -        "2": j
+  -        "3": m
+  -        "4294967294": tableoid
+  -        "4294967295": crdb_internal_mvcc_timestamp
+  -      families:
+  -        "0": primary
+  -      id: 104
+  -      indexes:
+  -        "1": t_pkey
+  -      name: t
+  -    relevantStatements:
+  -    - statement:
+  -        redactedStatement: DROP INDEX ‹defaultdb›.‹public›.‹t›@‹idx› CASCADE
+  -        statement: DROP INDEX idx CASCADE
+  -        statementTag: DROP INDEX
+  -    targetRanks: <redacted>
+  -    targets: <redacted>
+     families:
+     - columnIds:
+  ...
+     indexes: []
+     modificationTime: {}
+  -  mutations:
+  -  - direction: DROP
+  -    index:
+  -      constraintId: 3
+  -      createdAtNanos: "1640995200000000000"
+  -      createdExplicitly: true
+  -      foreignKey: {}
+  -      geoConfig: {}
+  -      id: 2
+  -      interleave: {}
+  -      keyColumnDirections:
+  -      - ASC
+  -      - ASC
+  -      - ASC
+  -      keyColumnIds:
+  -      - 4
+  -      - 2
+  -      - 1
+  -      keyColumnNames:
+  -      - crdb_internal_column_4_name_placeholder
+  -      - j
+  -      - i
+  -      name: crdb_internal_index_2_name_placeholder
+  -      partitioning: {}
+  -      sharded:
+  -        columnNames:
+  -        - i
+  -        - j
+  -        isSharded: true
+  -        name: crdb_internal_i_j_shard_16
+  -        shardBuckets: 16
+  -      unique: true
+  -      version: 4
+  -    mutationId: 1
+  -    state: DELETE_ONLY
+  -  - column:
+  -      computeExpr: mod(fnv32(md5(crdb_internal.datums_to_bytes(i, j))), 16:::INT8)
+  -      hidden: true
+  -      id: 4
+  -      name: crdb_internal_column_4_name_placeholder
+  -      nullable: true
+  -      type:
+  -        family: IntFamily
+  -        oid: 20
+  -        width: 64
+  -      virtual: true
+  -    direction: DROP
+  -    mutationId: 1
+  -    state: DELETE_ONLY
+  +  mutations: []
+     name: t
+     nextColumnId: 5
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "10"
+  +  version: "11"
+upsert descriptor #106
+  ...
+     createAsOfTime:
+       wallTime: "1640995200000000000"
+  -  declarativeSchemaChangerState:
+  -    authorization:
+  -      userName: root
+  -    currentStatuses: <redacted>
+  -    jobId: "1"
+  -    nameMapping:
+  -      columns:
+  -        "1": i
+  -        "2": j
+  -        "4294967294": tableoid
+  -        "4294967295": crdb_internal_mvcc_timestamp
+  -      constraints:
+  -        "3": j_k_fk
+  -      families:
+  -        "0": primary
+  -      id: 106
+  -      indexes:
+  -        "1": t_ref_pkey
+  -      name: t_ref
+  -    relevantStatements:
+  -    - statement:
+  -        redactedStatement: DROP INDEX ‹defaultdb›.‹public›.‹t›@‹idx› CASCADE
+  -        statement: DROP INDEX idx CASCADE
+  -        statementTag: DROP INDEX
+  -    targetRanks: <redacted>
+  -    targets: <redacted>
+     families:
+     - columnIds:
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "4"
+  +  version: "5"
+persist all catalog changes to storage
+create job #2 (non-cancelable: true): "GC for DROP INDEX defaultdb.public.t@idx CASCADE"
+  descriptor IDs: [104]
+update progress of schema change job #1: "all stages completed"
+set schema change job #1 to non-cancellable
+updated schema change job #1 descriptor IDs to []
+write *eventpb.FinishSchemaChange to event log:
+  sc:
+    descriptorId: 104
+write *eventpb.FinishSchemaChange to event log:
+  sc:
+    descriptorId: 106
+commit transaction #4
+notified job registry to adopt jobs: [2]
+# end PostCommitPhase


### PR DESCRIPTION
Previously, our DML injection testing for DROP index did not include any foreign key references or composite indexes. This patch adds extra coverage to include foreign key references with composite indexes in DML injection.

Fixes: #107733

Release note: None