### PR TITLE
cli: Enable cockroach debug tsdump to automatically create tsdump.yaml

### DIFF
--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -1543,6 +1543,7 @@ func init() {
 	f.Var(&debugTimeSeriesDumpOpts.to, "to", "newest timestamp to include (inclusive)")
 	f.StringVar(&debugTimeSeriesDumpOpts.clusterLabel, "cluster-label",
 		"", "prometheus label for cluster name")
+	f.StringVar(&debugTimeSeriesDumpOpts.yaml, "yaml", debugTimeSeriesDumpOpts.yaml, "full path to create the tsdump.yaml with storeID: nodeID mappings (raw format only). This file is required when loading the raw tsdump for troubleshooting.")
 
 	f = debugSendKVBatchCmd.Flags()
 	f.StringVar(&debugSendKVBatchContext.traceFormat, "trace", debugSendKVBatchContext.traceFormat,


### PR DESCRIPTION
Release note (cli change): cockroach debug tsdump creates tsdump.yaml

The changes provided by this PR will enable users when creating a tsdump in raw format, to automatically create a tsdump.yaml file containing the storeID: nodeID mappings. This file is required by Technical Support in order to be able to load tsdump raw files for troubleshooting purposes, so this feature will automate the process of creating such yaml file.

This change will expedite the TSEs ability to investigate issues requiring the tsdump, as it eliminates the
requirement for TSEs to also obtain the debug zip in order to create the tsdump.yaml file.

The tsdump.yaml is only created automatically if the flag `--format=raw` is used, if the user choses any other format the yaml file will not be created. The tsdump.yaml will be automatically created in `/tmp/tsump.yaml`.

In addition to using the `--format=raw` flag, an user can pass the `--yaml` flag, allowing the user to chose where to save the yaml file, instead of the default location (`/tmp`).

Usage:

```
cockroach debug tsdump --host <host>:<port> --format raw --yaml=/some_path/tsdump.yaml > /some_path/tsdump.gob
```

Authored by: Daniel Almeida

