### PR TITLE
workload/schemachange: enable inserts

### DIFF
--- a/pkg/sql/randgen/schema.go
+++ b/pkg/sql/randgen/schema.go
@@ -470,7 +470,7 @@ func GenerateRandInterestingTable(db *gosql.DB, dbName, tableName string) error 
 // randColumnTableDef produces a random ColumnTableDef for a non-computed
 // column, with a random type and nullability.
 func randColumnTableDef(rng *rand.Rand, tableIdx int, colSuffix string) *tree.ColumnTableDef {
-	g := randident.NewNameGenerator(&nameGenCfg, rng, fmt.Sprintf("col%d_", tableIdx))
+	g := randident.NewNameGenerator(&nameGenCfg, rng, fmt.Sprintf("col%d", tableIdx))
 	colName := g.GenerateOne(colSuffix)
 	columnDef := &tree.ColumnTableDef{
 		// We make a unique name for all columns by prefixing them with the table

--- a/pkg/workload/schemachange/error_screening.go
+++ b/pkg/workload/schemachange/error_screening.go
@@ -251,7 +251,7 @@ func (e *exprColumnCollector) VisitPre(expr tree.Expr) (recurse bool, newExpr tr
 }
 
 // valuesViolateUniqueConstraints determines if any unique constraints (including primary
-// constraints and constraint expressions) that  will be violated upon inserting
+// constraints and constraint expressions) that will be violated upon inserting
 // the specified rows into the specified table.
 func (og *operationGenerator) valuesViolateUniqueConstraints(
 	ctx context.Context,
@@ -262,50 +262,7 @@ func (og *operationGenerator) valuesViolateUniqueConstraints(
 	rows [][]string,
 ) (bool, codesWithConditions, error) {
 	var generatedCodes codesWithConditions
-	constraints, err := og.scanStringArrayRows(ctx, tx, `
-    WITH tab_json AS (
-                    SELECT crdb_internal.pb_to_json(
-                            'desc',
-                            descriptor
-                           )->'table' AS t
-                      FROM system.descriptor
-                     WHERE id = $1::REGCLASS
-                  ),
-         columns_json AS (
-                        SELECT json_array_elements(t->'columns') AS c FROM tab_json
-                      ),
-         columns AS (
-                    SELECT (c->>'id')::INT8 AS col_id,
-                           IF(
-                            (c->'inaccessible')::BOOL,
-                            c->>'computeExpr',
-                            c->>'name'
-                           ) AS expr
-                      FROM columns_json
-                 ),
-         indexes_json AS (
-                         SELECT json_array_elements(t->'indexes') AS idx
-                           FROM tab_json
-                         UNION ALL SELECT t->'primaryIndex' FROM tab_json
-                      ),
-         unique_indexes AS (
-                            SELECT idx->'name' AS name,
-                                   json_array_elements(
-                                    idx->'keyColumnIds'
-                                   )::STRING::INT8 AS col_id
-                              FROM indexes_json
-                             WHERE (idx->'unique')::BOOL
-                        ),
-         index_exprs AS (
-                        SELECT name, expr
-                          FROM unique_indexes AS idx
-                               INNER JOIN columns AS c ON idx.col_id = c.col_id
-                     )
-  SELECT ARRAY['(' || array_to_string(array_agg(expr), ', ') || ')'] AS final_expr
-    FROM index_exprs
-   WHERE expr != 'rowid'
-GROUP BY name;
-`, tableName.String())
+	constraints, err := getUniqueConstraintsForTable(ctx, tx, tableName.String())
 	if err != nil {
 		return false, nil, og.checkAndAdjustForUnknownSchemaErrors(err)
 	}
@@ -367,7 +324,7 @@ GROUP BY name;
 		}
 		// Next validate the uniqueness of both constraints and index expressions.
 		for constraintIdx, constraint := range constraints {
-			nonTupleConstraint := constraint[0]
+			nonTupleConstraint := constraint
 			if len(nonTupleConstraint) > 2 &&
 				nonTupleConstraint[0] == '(' &&
 				nonTupleConstraint[len(nonTupleConstraint)-1] == ')' {
@@ -380,12 +337,12 @@ GROUP BY name;
 
 			tupleSelectQuery := strings.Builder{}
 			tupleSelectQuery.WriteString("SELECT array[(")
-			tupleSelectQuery.WriteString(constraint[0])
+			tupleSelectQuery.WriteString(constraint)
 			tupleSelectQuery.WriteString(")::STRING] FROM (VALUES(")
 
 			query := strings.Builder{}
 			columns := strings.Builder{}
-			t, err := parser.ParseExpr(constraint[0])
+			t, err := parser.ParseExpr(constraint)
 			if err != nil {
 				return false, nil, err
 			}
@@ -394,10 +351,10 @@ GROUP BY name;
 			query.WriteString("SELECT COUNT (*) > 0 FROM (SELECT * FROM ")
 			query.WriteString(tableName.String())
 			query.WriteString(" WHERE ")
-			query.WriteString(constraint[0])
+			query.WriteString(constraint)
 			query.WriteString("= ( SELECT ")
 			query.WriteString(" ")
-			query.WriteString(constraint[0])
+			query.WriteString(constraint)
 			query.WriteString(" FROM (VALUES( ")
 			colIdx := 0
 			for col := range collector.columnsObserved {
@@ -579,9 +536,12 @@ func (og *operationGenerator) validateGeneratedExpressionsForInsert(
 	columns []string,
 	colInfos []column,
 	row []string,
-) (bool, codesWithConditions, codesWithConditions, error) {
-	var expectedErrors codesWithConditions
-	var potentialErrors codesWithConditions
+) (
+	isInvalidInsert bool,
+	expectedErrCodes codesWithConditions,
+	potentialErrCodes codesWithConditions,
+	err error,
+) {
 	// Put values to be inserted into a column name to value map to simplify lookups.
 	columnsToValues := map[string]string{}
 	for i := 0; i < len(columns); i++ {
@@ -665,17 +625,17 @@ func (og *operationGenerator) validateGeneratedExpressionsForInsert(
 			if !isValidGenerationError(pgErr.Code) {
 				return err
 			}
-			expectedErrors = expectedErrors.append(pgcode.MakeCode(pgErr.Code))
+			expectedErrCodes = expectedErrCodes.append(pgcode.MakeCode(pgErr.Code))
 		}
 		if isNull && !isNullable && !nullViolationAdded {
 			nullViolationAdded = true
-			expectedErrors = expectedErrors.append(pgcode.NotNullViolation)
+			expectedErrCodes = expectedErrCodes.append(pgcode.NotNullViolation)
 		}
 		// Re-run the another variant in case we have NULL values in arithmetic
 		// of expression, the evaluation order can differ depending on how variables
 		// get bound during the actual insert.
 		if err == nil && isNull {
-			if _, err := og.scanBool(ctx, evalTx, queryEvalOrderCheck.String()); err != nil {
+			if _, err = og.scanBool(ctx, evalTx, queryEvalOrderCheck.String()); err != nil {
 				var pgErr *pgconn.PgError
 				if !errors.As(err, &pgErr) {
 					rbkErr := evalTx.Rollback(ctx)
@@ -684,7 +644,7 @@ func (og *operationGenerator) validateGeneratedExpressionsForInsert(
 				// Note: Invalid errors are allowed, since this is a heuristic. We replaced
 				// random NULL values with zero.
 				if isValidGenerationError(pgErr.Code) {
-					potentialErrors = potentialErrors.append(pgcode.MakeCode(pgErr.Code))
+					potentialErrCodes = potentialErrCodes.append(pgcode.MakeCode(pgErr.Code))
 				}
 			}
 		}
@@ -703,70 +663,28 @@ func (og *operationGenerator) validateGeneratedExpressionsForInsert(
 		if !colInfo.generated {
 			continue
 		}
-		err := validateExpression(colInfo.generatedExpression, colInfo.typ.SQLString(), colInfo.nullable, false)
+		err = validateExpression(colInfo.generatedExpression, colInfo.typ.SQLString(), colInfo.nullable, false)
 		if err != nil {
 			return false, nil, nil, err
 		}
 	}
 	// Any bad generated expression means we don't have to bother with indexes next,
 	// since we expect the insert to fail earlier.
-	if expectedErrors == nil {
+	if expectedErrCodes == nil {
 		// Validate unique constraint expressions that are backed by indexes.
-		constraints, err := og.scanStringArrayRows(ctx, tx, `
-WITH tab_json AS (
-                    SELECT crdb_internal.pb_to_json(
-                            'desc',
-                            descriptor
-                           )->'table' AS t
-                      FROM system.descriptor
-                     WHERE id = $1::REGCLASS
-                  ),
-         columns_json AS (
-                        SELECT json_array_elements(t->'columns') AS c FROM tab_json
-                      ),
-         columns AS (
-                    SELECT (c->>'id')::INT8 AS col_id,
-                           IF(
-                            (c->'inaccessible')::BOOL,
-                            c->>'computeExpr',
-                            c->>'name'
-                           ) AS expr
-                      FROM columns_json
-                 ),
-         indexes_json AS (
-                         SELECT json_array_elements(t->'indexes') AS idx
-                           FROM tab_json
-                         UNION ALL SELECT t->'primaryIndex' FROM tab_json
-                      ),
-         unique_indexes AS (
-                            SELECT idx->'name' AS name,
-                                   json_array_elements(
-                                    idx->'keyColumnIds'
-                                   )::STRING::INT8 AS col_id
-                              FROM indexes_json
-                        ),
-         index_exprs AS (
-                        SELECT name, expr
-                          FROM unique_indexes AS idx
-                               INNER JOIN columns AS c ON idx.col_id = c.col_id
-                     )
-  SELECT ARRAY['(' || array_to_string(array_agg(expr), ', ') || ')'] AS final_expr
-    FROM index_exprs
-   WHERE expr != 'rowid'
-GROUP BY name;
-		`, tableName.String())
+		constraints, err := getUniqueConstraintsForTable(ctx, tx, tableName.String())
 		if err != nil {
 			return false, nil, nil, og.checkAndAdjustForUnknownSchemaErrors(err)
 		}
 
 		for _, constraint := range constraints {
-			err := validateExpression(constraint[0], "STRING", true, true)
+			err = validateExpression(constraint, "STRING", true, true)
 			if err != nil {
 				return false, nil, nil, err
 			}
 		}
 	}
-	return len(expectedErrors) > 0, expectedErrors, potentialErrors, nil
+	return len(expectedErrCodes) > 0, expectedErrCodes, potentialErrCodes, nil
 }
 
 // generateColumn generates values for columns that are generated.
@@ -1101,13 +1019,15 @@ SELECT count(*) FROM %s
 		return true, nil
 	}
 
-	numJoinRows, err := og.scanInt(ctx, tx, fmt.Sprintf(`
+	q := fmt.Sprintf(`
 	  SELECT count(*)
 	    FROM %s as t1
 		  LEFT JOIN %s as t2
 				     ON t1.%s = t2.%s
 			WHERE t2.%s IS NOT NULL
-`, childTable.String(), parentTable.String(), childColumn.name, parentColumn.name, parentColumn.name))
+`, childTable.String(), parentTable.String(), tree.NameString(childColumn.name), tree.NameString(parentColumn.name), tree.NameString(parentColumn.name))
+
+	numJoinRows, err := og.scanInt(ctx, tx, q)
 	if err != nil {
 		return false, err
 	}
@@ -1199,7 +1119,7 @@ func (og *operationGenerator) violatesFkConstraints(
 			}
 
 			violation, err := og.violatesFkConstraintsHelper(
-				ctx, tx, columnNameToIndexMap, parentTableSchema, parentTableName, parentColumnName, tableName.String(), childColumnName, parentAndChildAreSame, row, rows,
+				ctx, tx, columnNameToIndexMap, parentTableSchema, parentTableName, parentColumnName, childColumnName, tableName, parentAndChildAreSame, row, rows,
 			)
 			if err != nil {
 				return false, err
@@ -1219,7 +1139,8 @@ func (og *operationGenerator) violatesFkConstraintsHelper(
 	ctx context.Context,
 	tx pgx.Tx,
 	columnNameToIndexMap map[string]int,
-	parentTableSchema, parentTableName, parentColumn, childTableName, childColumn string,
+	parentTableSchema, parentTableName, parentColumn, childColumn string,
+	childTableName *tree.TableName,
 	parentAndChildAreSameTable bool,
 	row []string,
 	allRows [][]string,
@@ -1273,11 +1194,12 @@ func (og *operationGenerator) violatesFkConstraintsHelper(
 		checkSharedParentChildRows = fmt.Sprintf("false = ANY (ARRAY [%s]) AND",
 			strings.Join(parentAndChildSameQueryColumns, ","))
 	}
-	return og.scanBool(ctx, tx, fmt.Sprintf(`
+	q := fmt.Sprintf(`
 	    SELECT %s count(*) = 0 from %s.%s
 	    WHERE %s = (%s)
 	`,
-		checkSharedParentChildRows, parentTableSchema, parentTableName, parentColumn, childValue))
+		checkSharedParentChildRows, parentTableSchema, parentTableName, tree.NameString(parentColumn), childValue)
+	return og.scanBool(ctx, tx, q)
 }
 
 func (og *operationGenerator) columnIsInDroppingIndex(
@@ -1670,4 +1592,74 @@ func (og *operationGenerator) databaseHasTablesWithPartitioning(
 		fmt.Sprintf(`SELECT count(*)> 0 FROM %s.crdb_internal.partitions`,
 			database),
 	)
+}
+
+// getUniqueConstraintsForTable returns the set of expressions associated with unique indexes
+// in the specified tableName.
+func getUniqueConstraintsForTable(
+	ctx context.Context, tx pgx.Tx, tableName string,
+) (constraints []string, err error) {
+	q := `
+WITH tab_json AS (
+                    SELECT crdb_internal.pb_to_json(
+                            'desc',
+                            descriptor
+                           )->'table' AS t
+                      FROM system.descriptor
+                     WHERE id = $1::REGCLASS
+                  ),
+         columns_json AS (
+                        SELECT json_array_elements(t->'columns') AS c FROM tab_json
+                      ),
+         columns AS (
+                    SELECT (c->>'id')::INT8 AS col_id,
+                           IF(
+                            (c->'inaccessible')::BOOL,
+                            c->>'computeExpr',
+                            quote_ident(c->>'name')
+                           ) AS expr
+                      FROM columns_json
+                 ),
+         indexes_json AS (
+                         SELECT json_array_elements(t->'indexes') AS idx
+                           FROM tab_json
+                         UNION ALL SELECT t->'primaryIndex' FROM tab_json
+                      ),
+         unique_indexes AS (
+                            SELECT idx->'name' AS name,
+                                   json_array_elements(
+                                    idx->'keyColumnIds'
+                                   )::STRING::INT8 AS col_id
+                              FROM indexes_json
+															WHERE (idx->'unique')::BOOL
+                        ),
+         index_exprs AS (
+                        SELECT name, expr
+                          FROM unique_indexes AS idx
+                               INNER JOIN columns AS c ON idx.col_id = c.col_id
+                     )
+      SELECT '(' || array_to_string(array_agg(expr), ', ') || ')' AS final_expr                    
+      FROM index_exprs                                                                                       
+      WHERE expr != 'rowid'                                                                          
+      GROUP BY name; 
+		`
+	rows, err := tx.Query(ctx, q, tableName)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var constraint string
+		err = rows.Scan(&constraint)
+		if err != nil {
+			return nil, err
+		}
+		constraints = append(constraints, constraint)
+	}
+	if err = rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return constraints, nil
 }

--- a/pkg/workload/schemachange/generate.go
+++ b/pkg/workload/schemachange/generate.go
@@ -208,7 +208,7 @@ func Generate[T tree.Statement](
 		// NB: Parsing the template result as SQL ensures that we catch any
 		// template errors and distinguish them from workload errors. It also
 		// allows us to normalize the outputs so users don't have to worry about
-		// whitespace and/or captialization.
+		// whitespace and/or capitalization.
 		stmt, err := parser.ParseOne(raw.String())
 		if err != nil {
 			return zero, pgcode.Code{}, errors.AssertionFailedf(

--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -3332,7 +3332,7 @@ func (og *operationGenerator) randChildColumnForFkRelation(
 	query.WriteString(`
     SELECT table_schema, table_name, column_name, crdb_sql_type, is_nullable
       FROM information_schema.columns
-		 WHERE table_name ~ 'table[0-9]+' AND column_name <> 'rowid'
+		 WHERE table_name SIMILAR TO 'table_w[0-9]_+%' AND column_name <> 'rowid'
   `)
 	query.WriteString(fmt.Sprintf(`
 			AND crdb_sql_type = '%s'
@@ -3393,7 +3393,7 @@ func (og *operationGenerator) randParentColumnForFkRelation(
 		        SELECT contype, conkey, conrelid
 		          FROM pg_catalog.pg_constraint
 		       ) AS cons ON cons.conrelid = cols.tableid
-		 WHERE table_name ~ 'table[0-9]+'
+		 WHERE table_name SIMILAR TO 'table_w[0-9]_+%'
   `)
 	if unique {
 		subQuery.WriteString(`
@@ -3617,7 +3617,7 @@ func (og *operationGenerator) randTable(
 		q := fmt.Sprintf(`
 		  SELECT table_name
 		    FROM [SHOW TABLES]
-		   WHERE table_name ~ 'table[0-9]+'
+		   WHERE table_name SIMILAR TO 'table_w[0-9]_+%%'
 				 AND schema_name = '%s'
 		ORDER BY random()
 		   LIMIT 1;
@@ -3655,7 +3655,7 @@ func (og *operationGenerator) randTable(
 	const q = `
   SELECT schema_name, table_name
     FROM [SHOW TABLES]
-   WHERE table_name ~ 'table[0-9]+'
+   WHERE table_name SIMILAR TO 'table_w[0-9]_+%'
 ORDER BY random()
    LIMIT 1;
 `

--- a/pkg/workload/schemachange/optype.go
+++ b/pkg/workload/schemachange/optype.go
@@ -252,7 +252,7 @@ var opFuncs = []func(*operationGenerator, context.Context, pgx.Tx) (*opStmt, err
 
 var opWeights = []int{
 	// Non-DDL
-	insertRow:  0, // Disabled and tracked with #91863
+	insertRow:  10,
 	selectStmt: 10,
 	validate:   2, // validate twice more often
 

--- a/pkg/workload/schemachange/schemachange.go
+++ b/pkg/workload/schemachange/schemachange.go
@@ -201,7 +201,9 @@ func (s *schemaChange) Ops(
 		return workload.QueryLoad{}, err
 	}
 	stdoutLog := makeAtomicLog(os.Stdout)
-	_, seed := randutil.NewTestRand()
+	// Use NewPseudoRand here because we want to print out the global seed used by the workload.
+	// Using NewTestRand() here would only let us see the per-test seed that is derived from the global seed.
+	_, seed := randutil.NewPseudoRand()
 	stdoutLog.printLn(fmt.Sprintf("using random seed: %d", seed))
 	// A separate weighting is constructed of only schema changes supported by the
 	// declarative schema changer. This will be used to make a per-worker deck


### PR DESCRIPTION
### workload/schemachange: use a pseudo-rand rng

This patch replaces the rng we used for the
schemachange workload with a rand that can
be seeded from the `COCKROACH_RANDOM_SEED'
environment variable and properly printed
out for later use.

Epic: none

Release note: None

----

### workload/schemachange: fix existing table search

With the addition of workers specified in table names
to make our workload more deterministic, this patch
fixes the regex match we had when we look for existing
tables.

Epic: none

Release note: None

----

### workload/schemachange: enable inserts

This patch enables inserts inside of the randomized schema change workload.

Fixes: #91863
Epic: CRDB-19168

Release note: None