### PR TITLE
build: build `com_github_azure_azure_sdk_for_go` on `large` pool

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -632,6 +632,10 @@ def go_deps():
         name = "com_github_azure_azure_sdk_for_go",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/Azure/azure-sdk-for-go",
+        patch_args = ["-p1"],
+        patches = [
+            "@com_github_cockroachdb_cockroach//build/patches:com_github_azure_azure_sdk_for_go.patch",
+        ],
         sha256 = "7232ccaf96ab411dce27e8c61f4ec0e20835f60e192ffc7b56b7c3a308e29978",
         strip_prefix = "github.com/Azure/azure-sdk-for-go@v57.1.0+incompatible",
         urls = [

--- a/build/patches/com_github_azure_azure_sdk_for_go.patch
+++ b/build/patches/com_github_azure_azure_sdk_for_go.patch
@@ -1,0 +1,11 @@
+diff -urN a/services/network/mgmt/2021-03-01/network/BUILD.bazel b/services/network/mgmt/2021-03-01/network/BUILD.bazel
+--- a/services/network/mgmt/2021-03-01/network/BUILD.bazel
++++ b/services/network/mgmt/2021-03-01/network/BUILD.bazel
+@@ -116,6 +116,7 @@
+         "webapplicationfirewallpolicies.go",
+         "webcategories.go",
+     ],
++    exec_properties = { "Pool": "large" },
+     importpath = "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-03-01/network",
+     visibility = ["//visibility:public"],
+     deps = [


### PR DESCRIPTION
When building with `race`, this will OOM. Using the `large` pool grants it some extra memory.

Epic: CRDB-8308
Release note: None